### PR TITLE
Change println() to println(), disable event expansion

### DIFF
--- a/kql-cli/src/main/java/io/confluent/kql/KQL.java
+++ b/kql-cli/src/main/java/io/confluent/kql/KQL.java
@@ -76,6 +76,7 @@ public class KQL {
           new AnsiStringsCompleter("select", "show queries",
                                    "terminate", "exit", "describe", "print", "list topics",
                                    "list streams", "create topic", "create stream", "create table"));
+      console.setExpandEvents(false); // Disable event expansion so things like '!=' are left alone by the console reader
       String line = null;
       while ((line = console.readLine()) != null) {
         if (line.length() == 0) {


### PR DESCRIPTION
Currently, queries like

`SELECT * FROM orders WHERE orderunits != 5`

will fail in CLI mode because JLine will attempt to expand the '!=' as an event. Disabling event expansion prevents this from happening and allows queries containing '!' to pass unchanged through the console reader to the parsing phase. The only downside I can think of is the loss of that shell-like functionality where you can use '!!' as a shortcut to represent the last command you entered and '!foo' to represent the last command you entered that started with 'foo'... probably not a huge deal, especially right now.

Also, small thing, but calls to println() with the empty string as an argument are redundant, as println() has a no-args version that does the exact same thing.