### PR TITLE
Allow statements rule to match with zero statements in grammar

### DIFF
--- a/ksql-core/src/main/antlr4/io/confluent/ksql/parser/SqlBase.g4
+++ b/ksql-core/src/main/antlr4/io/confluent/ksql/parser/SqlBase.g4
@@ -21,9 +21,8 @@ tokens {
 }
 
 statements
-    : singleStatement (singleStatement)* EOF
+    : (singleStatement)* EOF
     ;
-
 
 singleStatement
     : statement ';'

--- a/ksql-core/src/main/java/io/confluent/ksql/parser/tree/EmptyStatement.java
+++ b/ksql-core/src/main/java/io/confluent/ksql/parser/tree/EmptyStatement.java
@@ -1,0 +1,45 @@
+/**
+ * Copyright 2017 Confluent Inc.
+ **/
+
+package io.confluent.ksql.parser.tree;
+
+import java.util.Objects;
+import java.util.Optional;
+
+import static com.google.common.base.MoreObjects.toStringHelper;
+
+public class EmptyStatement extends Statement {
+
+  public EmptyStatement() {
+    this(Optional.empty());
+  }
+
+  public EmptyStatement(NodeLocation location) {
+    this(Optional.of(location));
+  }
+
+  private EmptyStatement(Optional<NodeLocation> location) {
+    super(location);
+  }
+
+  @Override
+  public <R, C> R accept(AstVisitor<R, C> visitor, C context) {
+    return null;
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(this);
+  }
+
+  @Override
+  public boolean equals(Object obj) {
+    return obj instanceof EmptyStatement;
+  }
+
+  @Override
+  public String toString() {
+    return toStringHelper(this).toString();
+  }
+}


### PR DESCRIPTION
Right now things break if commented-out or all-whitespace lines are sent to the parser; this small change allows lines like that to be accepted (and then ignored) silently.