### PR TITLE
cli-file-logging

### DIFF
--- a/ksql-cli/src/main/java/io/confluent/ksql/cli/util/TimestampLogFileAppender.java
+++ b/ksql-cli/src/main/java/io/confluent/ksql/cli/util/TimestampLogFileAppender.java
@@ -1,0 +1,23 @@
+/**
+ * Copyright 2017 Confluent Inc.
+ **/
+
+package io.confluent.ksql.cli.util;
+
+import java.text.SimpleDateFormat;
+import java.util.Date;
+import org.apache.log4j.FileAppender;
+
+public class TimestampLogFileAppender extends FileAppender {
+
+  @Override
+  public void setFile(String fileName) {
+    if (fileName.contains("%timestamp")) {
+      Date d = new Date();
+      SimpleDateFormat format = new SimpleDateFormat("yyMMdd-HHmmss");
+      fileName = fileName.replaceAll("%timestamp", format.format(d));
+    }
+    super.setFile(fileName);
+  }
+
+}

--- a/ksql-cli/src/main/resources/log4j.properties
+++ b/ksql-cli/src/main/resources/log4j.properties
@@ -1,2 +1,11 @@
-# Don't want any logging output during a CLI REPL
-log4j.rootLogger=OFF
+# For the general syntax of property based configuration files see
+# the documentation of org.apache.log4j.PropertyConfigurator.
+
+log4j.rootLogger=WARN, default.file
+
+log4j.appender.default.file=io.confluent.ksql.cli.util.TimestampLogFileAppender
+log4j.appender.default.file.ImmediateFlush=true
+log4j.appender.default.file.append=false
+log4j.appender.default.file.file=/tmp/ksql-logs/cli-%timestamp.log
+log4j.appender.default.file.layout=org.apache.log4j.PatternLayout
+log4j.appender.default.file.layout.ConversionPattern=[%d] %p %m (%c:%L)%n


### PR DESCRIPTION
Add file logging to ksql-cli, now all log information generated if using KSQL through cli will be written to file named "/tmp/ksql-logs/cli-%timestamp.log", which facilitates debugging if something goes wrong. 