### PR TITLE
Improve exception handling in parser and response entity

### DIFF
--- a/ksql-core/src/main/java/io/confluent/ksql/exception/ParseFailedException.java
+++ b/ksql-core/src/main/java/io/confluent/ksql/exception/ParseFailedException.java
@@ -1,0 +1,17 @@
+/**
+ * Copyright 2017 Confluent Inc.
+ **/
+
+package io.confluent.ksql.exception;
+
+import io.confluent.ksql.util.KsqlException;
+
+public class ParseFailedException extends KsqlException {
+  public ParseFailedException(String message) {
+    super(message);
+  }
+
+  public ParseFailedException(String message, Throwable throwable) {
+    super(message, throwable);
+  }
+}

--- a/ksql-core/src/main/java/io/confluent/ksql/parser/KsqlParser.java
+++ b/ksql-core/src/main/java/io/confluent/ksql/parser/KsqlParser.java
@@ -4,11 +4,11 @@
 
 package io.confluent.ksql.parser;
 
+import io.confluent.ksql.exception.ParseFailedException;
 import io.confluent.ksql.metastore.MetaStore;
 import io.confluent.ksql.parser.tree.Node;
 import io.confluent.ksql.parser.tree.Statement;
 import io.confluent.ksql.util.DataSourceExtractor;
-import io.confluent.ksql.util.KsqlException;
 import io.confluent.ksql.util.Pair;
 import org.antlr.v4.runtime.ANTLRInputStream;
 import org.antlr.v4.runtime.BaseErrorListener;
@@ -46,9 +46,9 @@ public class KsqlParser {
         astNodes.add(statement);
       }
       return astNodes;
-    } catch (ParseCancellationException ex) {
+    } catch (Exception e) {
       // if we fail, parse with LL mode
-      throw new KsqlException(ex.getMessage());
+      throw new ParseFailedException(e.getMessage(), e);
     }
   }
 
@@ -58,7 +58,7 @@ public class KsqlParser {
       SqlBaseParser.StatementsContext statementsContext = (SqlBaseParser.StatementsContext) tree;
       return statementsContext.singleStatement();
     } catch (Exception e) {
-      throw new KsqlException(e.getMessage());
+      throw new ParseFailedException(e.getMessage(), e);
     }
   }
 

--- a/ksql-core/src/test/java/io/confluent/ksql/parser/KsqlParserTest.java
+++ b/ksql-core/src/test/java/io/confluent/ksql/parser/KsqlParserTest.java
@@ -2,6 +2,7 @@ package io.confluent.ksql.parser;
 
 
 import io.confluent.ksql.ddl.DdlConfig;
+import io.confluent.ksql.exception.ParseFailedException;
 import io.confluent.ksql.metastore.MetaStore;
 import io.confluent.ksql.parser.tree.AliasedRelation;
 import io.confluent.ksql.parser.tree.ComparisonExpression;
@@ -378,8 +379,8 @@ public class KsqlParserTest {
       String simpleQuery = "SELLECT col0, col2, col3 FROM test1 WHERE col0 > 100;";
       Statement statement = KSQL_PARSER.buildAst(simpleQuery, metaStore).get(0);
       Assert.fail();
-    } catch (ParsingException parsingException) {
-      String errorMessage = parsingException.getMessage();
+    } catch (ParseFailedException e) {
+      String errorMessage = e.getMessage();
       Assert.assertTrue(errorMessage.toLowerCase().contains(("line 1:1: mismatched input 'SELLECT'" + " expecting").toLowerCase()));
     }
   }

--- a/ksql-rest-app/src/main/java/io/confluent/ksql/rest/entity/ErrorMessage.java
+++ b/ksql-rest-app/src/main/java/io/confluent/ksql/rest/entity/ErrorMessage.java
@@ -47,6 +47,18 @@ public class ErrorMessage {
   }
 
   @Override
+  public String toString() {
+    StringBuilder sb = new StringBuilder();
+    sb.append(message);
+    sb.append("\n");
+    for (String line : stackTrace) {
+      sb.append(line);
+      sb.append("\n");
+    }
+    return sb.toString();
+  }
+
+  @Override
   public boolean equals(Object o) {
     if (this == o) {
       return true;

--- a/ksql-rest-app/src/main/java/io/confluent/ksql/rest/server/computation/StatementExecutor.java
+++ b/ksql-rest-app/src/main/java/io/confluent/ksql/rest/server/computation/StatementExecutor.java
@@ -6,6 +6,7 @@ package io.confluent.ksql.rest.server.computation;
 
 import io.confluent.ksql.KsqlEngine;
 import io.confluent.ksql.ddl.commands.*;
+import io.confluent.ksql.exception.ExceptionUtil;
 import io.confluent.ksql.metastore.DataSource;
 import io.confluent.ksql.parser.tree.CreateStream;
 import io.confluent.ksql.parser.tree.CreateStreamAsSelect;
@@ -229,11 +230,9 @@ public class StatementExecutor {
     } catch (WakeupException exception) {
       throw exception;
     } catch (Exception exception) {
-      StringWriter stringWriter = new StringWriter();
-      PrintWriter printWriter = new PrintWriter(stringWriter);
-      exception.printStackTrace(printWriter);
-      CommandStatus errorStatus =
-          new CommandStatus(CommandStatus.Status.ERROR, stringWriter.toString());
+      String stackTraceString = ExceptionUtil.stackTraceToString(exception);
+      log.error(stackTraceString);
+      CommandStatus errorStatus = new CommandStatus(CommandStatus.Status.ERROR, stackTraceString);
       statusStore.put(commandId, errorStatus);
       completeStatusFuture(commandId, errorStatus);
     }


### PR DESCRIPTION
1. Throw ParseFailedException if parsing is failed.
2. Fix issue on cli to correctly print Ksql Response if there is an error from the server.