### PR TITLE
KSQL-233-end-to-end-integration-tests

### DIFF
--- a/ksql-cli/src/main/java/io/confluent/ksql/util/CliUtils.java
+++ b/ksql-cli/src/main/java/io/confluent/ksql/util/CliUtils.java
@@ -130,7 +130,7 @@ public class CliUtils {
     }
   }
 
-  public static String getServerAddress(int portNumber) {
+  public static String getLocalServerAddress(int portNumber) {
     return String.format("http://localhost:%d", portNumber);
   }
 

--- a/ksql-cli/src/test/java/io/confluent/ksql/CliTest.java
+++ b/ksql-cli/src/test/java/io/confluent/ksql/CliTest.java
@@ -2,36 +2,65 @@ package io.confluent.ksql;
 
 import io.confluent.ksql.cli.LocalCli;
 import io.confluent.ksql.cli.console.OutputFormat;
+import io.confluent.ksql.physical.GenericRow;
 import io.confluent.ksql.rest.client.KsqlRestClient;
+import io.confluent.ksql.rest.server.KsqlRestApplication;
+import io.confluent.ksql.rest.server.KsqlRestConfig;
 import io.confluent.ksql.testutils.EmbeddedSingleNodeKafkaCluster;
+import io.confluent.ksql.util.CliUtils;
+import io.confluent.ksql.util.OrderDataProvider;
+import io.confluent.ksql.util.TestDataProvider;
+import io.confluent.ksql.util.TopicConsumer;
+import io.confluent.ksql.util.TopicProducer;
 import org.apache.kafka.clients.consumer.ConsumerConfig;
+import org.apache.kafka.common.serialization.StringDeserializer;
+import org.apache.kafka.connect.data.Schema;
+import org.apache.kafka.connect.data.SchemaBuilder;
 import org.junit.AfterClass;
+import org.junit.Assert;
 import org.junit.BeforeClass;
 import org.junit.ClassRule;
 import org.junit.Test;
 
+import java.util.Arrays;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 import java.util.Properties;
 
-public class CliTest {
+import static io.confluent.ksql.TestResult.*;
+import static io.confluent.ksql.util.KsqlConfig.*;
+import static io.confluent.ksql.util.KsqlTestUtil.assertExpectedResults;
+
+/**
+ * Most tests in CliTest are end-to-end integration tests, so it may expect a long running time.
+ */
+public class CliTest extends TestRunner {
 
   @ClassRule
   public static final EmbeddedSingleNodeKafkaCluster CLUSTER = new EmbeddedSingleNodeKafkaCluster();
 
+  private static final String COMMANDS_KSQL_TOPIC_NAME = KsqlRestApplication.COMMANDS_KSQL_TOPIC_NAME;
   private static final int PORT = 9098;
-  private static final String SERVER = "http://localhost:" + PORT;
+  private static final String LOCAL_REST_SERVER_ADDR = "http://localhost:" + PORT;
   private static final OutputFormat CLI_OUTPUT_FORMAT = OutputFormat.TABULAR;
 
   private static final long STREAMED_QUERY_ROW_LIMIT = 10000;
   private static final long STREAMED_QUERY_TIMEOUT_MS = 10000;
 
+  private static final TestResult.OrderedResult EMPTY_RESULT = build("");
+
   private static LocalCli localCli;
   private static TestTerminal terminal;
+  private static String commandTopicName;
+  private static TopicProducer topicProducer;
+  private static TopicConsumer topicConsumer;
+
+  private static OrderDataProvider orderDataProvider;
 
   @BeforeClass
   public static void setUp() throws Exception {
-    KsqlRestClient restClient = new KsqlRestClient(SERVER);
+    KsqlRestClient restClient = new KsqlRestClient(LOCAL_REST_SERVER_ADDR);
 
     // TODO: Fix Properties Setup in Local().getCli()
     // Local local =  new Local().getCli();
@@ -40,14 +69,52 @@ public class CliTest {
     // TODO: add remote cli test cases
     terminal = new TestTerminal(CLI_OUTPUT_FORMAT, restClient);
 
+    KsqlRestConfig restServerConfig = new KsqlRestConfig(defaultServerProperties());
+    commandTopicName = restServerConfig.getCommandTopic();
+
+    KsqlRestApplication restServer = KsqlRestApplication.buildApplication(restServerConfig, false);
+    restServer.start();
+
     localCli = new LocalCli(
-        defaultServerProperties(),
-        PORT,
         STREAMED_QUERY_ROW_LIMIT,
         STREAMED_QUERY_TIMEOUT_MS,
         restClient,
-        terminal
+        terminal,
+        restServer
     );
+
+    TestRunner.setup(localCli, terminal);
+
+    topicProducer = new TopicProducer(CLUSTER);
+    topicConsumer = new TopicConsumer(CLUSTER);
+
+    // Test list or show commands before any custom topics created.
+    testListOrShowCommands();
+
+    orderDataProvider = new OrderDataProvider();
+    restServer.getKsqlEngine().getKafkaTopicClient().createTopic(orderDataProvider.topicName(), 1, (short)1);
+    produceInputStream(orderDataProvider);
+  }
+
+  private static void produceInputStream(TestDataProvider dataProvider) throws Exception {
+    createKStream(dataProvider);
+    topicProducer.produceInputData(dataProvider);
+  }
+
+  private static void createKStream(TestDataProvider dataProvider) {
+    test(
+        String.format("CREATE STREAM %s %s WITH (value_format = 'json', kafka_topic = '%s' , key='%s')",
+            dataProvider.kstreamName(), dataProvider.ksqlSchemaString(), dataProvider.topicName(), dataProvider.key()),
+        build("Stream created")
+    );
+  }
+
+  private static void testListOrShowCommands() {
+    testListOrShow("topics", build(commandTopicName, true, 1, 1));
+    testListOrShow("registered topics", build(COMMANDS_KSQL_TOPIC_NAME, commandTopicName, "JSON"));
+    testListOrShow("streams", EMPTY_RESULT);
+    testListOrShow("tables", EMPTY_RESULT);
+    testListOrShow("queries", EMPTY_RESULT);
   }
 
   @AfterClass
@@ -65,11 +132,13 @@ public class CliTest {
   private static Map<String, Object> genDefaultConfigMap() {
     Map<String, Object> configMap = new HashMap<>();
     configMap.put(ConsumerConfig.BOOTSTRAP_SERVERS_CONFIG, CLUSTER.bootstrapServers());
+    configMap.put(KsqlRestConfig.LISTENERS_CONFIG, CliUtils.getLocalServerAddress(PORT));
     configMap.put("application.id", "KSQL");
     configMap.put("commit.interval.ms", 0);
     configMap.put("cache.max.bytes.buffering", 0);
     configMap.put("auto.offset.reset", "earliest");
     configMap.put("ksql.command.topic.suffix", "commands");
+
     return configMap;
   }
 
@@ -79,8 +148,188 @@ public class CliTest {
     return serverProperties;
   }
 
+  private static Map<String, Object> validStartUpConfigs() {
+    // TODO: these configs should be set with other configs on start-up, rather than setup later.
+    Map<String, Object> startConfigs = genDefaultConfigMap();
+    startConfigs.put("num.stream.threads", 4);
 
-  /* Only for coverage, not for validation */
+    startConfigs.put(SINK_NUMBER_OF_REPLICATIONS, 1);
+    startConfigs.put(SINK_NUMBER_OF_PARTITIONS, 4);
+    startConfigs.put(SINK_WINDOW_CHANGE_LOG_ADDITIONAL_RETENTION, 1000000);
+
+    startConfigs.put(KSQL_TRANSIENT_QUERY_NAME_PREFIX_CONFIG, KSQL_TRANSIENT_QUERY_NAME_PREFIX_DEFAULT);
+    startConfigs.put(KSQL_SERVICE_ID_CONFIG, KSQL_SERVICE_ID_DEFAULT);
+    startConfigs.put(KSQL_TABLE_STATESTORE_NAME_SUFFIX_CONFIG, KSQL_TABLE_STATESTORE_NAME_SUFFIX_DEFAULT);
+    startConfigs.put(KSQL_PERSISTENT_QUERY_NAME_PREFIX_CONFIG, KSQL_PERSISTENT_QUERY_NAME_PREFIX_DEFAULT);
+
+    return startConfigs;
+  }
+
+  private static void testCreateStreamAsSelect(String selectQuery, Schema resultSchema, Map<String, GenericRow> expectedResults) throws Exception {
+    if (!selectQuery.endsWith(";")) {
+      selectQuery += ";";
+    }
+    String resultKStreamName = "RESULT";
+    String resultTopicName = resultKStreamName;
+    final String queryString = "CREATE STREAM " + resultKStreamName + " AS " + selectQuery;
+
+    /* Start Stream Query */
+    test(queryString, build("Stream created and running"));
+
+    /* Assert Results */
+    Map<String, GenericRow> results = topicConsumer.readResults(resultTopicName, resultSchema, expectedResults.size(), new StringDeserializer());
+    Assert.assertEquals(expectedResults.size(), results.size());
+    assertExpectedResults(results, expectedResults);
+
+    /* Get first column of the first row in the result set to obtain the queryID */
+    String queryID = (String) ((List) run("list queries").data.toArray()[0]).get(0);
+
+    /* Clean Up */
+    run("terminate query " + queryID);
+    dropStream(resultKStreamName);
+  }
+
+  private static void dropStream(String name) {
+    test(
+        String.format("drop stream %s", name),
+        build("Source " + name + " was dropped")
+    );
+  }
+
+  @Test
+  public void testPropertySetUnset() {
+    test("set 'application.id' = 'Test_App'", EMPTY_RESULT);
+    test("set 'producer.batch.size' = '16384'", EMPTY_RESULT);
+    test("set 'max.request.size' = '1048576'", EMPTY_RESULT);
+    test("set 'consumer.max.poll.records' = '500'", EMPTY_RESULT);
+    test("set 'enable.auto.commit' = 'true'", EMPTY_RESULT);
+    test("set 'AVROSCHEMA' = 'schema'", EMPTY_RESULT);
+
+    test("unset 'application.id'", EMPTY_RESULT);
+    test("unset 'producer.batch.size'", EMPTY_RESULT);
+    test("unset 'max.request.size'", EMPTY_RESULT);
+    test("unset 'consumer.max.poll.records'", EMPTY_RESULT);
+    test("unset 'enable.auto.commit'", EMPTY_RESULT);
+    test("unset 'AVROSCHEMA'", EMPTY_RESULT);
+
+    testListOrShow("properties", build(validStartUpConfigs()), false);
+  }
+
+  @Test
+  public void testDescribe() {
+    test("describe topic " + COMMANDS_KSQL_TOPIC_NAME,
+        build(COMMANDS_KSQL_TOPIC_NAME, commandTopicName, "JSON"));
+  }
+
+  @Test
+  public void testSelectStar() throws Exception {
+    testCreateStreamAsSelect(
+        "SELECT * FROM " + orderDataProvider.kstreamName(),
+        orderDataProvider.schema(),
+        orderDataProvider.data()
+    );
+  }
+
+  @Test
+  public void testSelectProject() throws Exception {
+    Map<String, GenericRow> expectedResults = new HashMap<>();
+    expectedResults.put("1", new GenericRow(Arrays.asList("ITEM_1", 10.0, new
+        Double[]{100.0,
+        110.99,
+        90.0 })));
+    expectedResults.put("2", new GenericRow(Arrays.asList("ITEM_2", 20.0, new
+        Double[]{10.0,
+        10.99,
+        9.0 })));
+
+    expectedResults.put("3", new GenericRow(Arrays.asList("ITEM_3", 30.0, new
+        Double[]{10.0,
+        10.99,
+        91.0 })));
+
+    expectedResults.put("4", new GenericRow(Arrays.asList("ITEM_4", 40.0, new
+        Double[]{10.0,
+        140.99,
+        94.0 })));
+
+    expectedResults.put("5", new GenericRow(Arrays.asList("ITEM_5", 50.0, new
+        Double[]{160.0,
+        160.99,
+        98.0 })));
+
+    expectedResults.put("6", new GenericRow(Arrays.asList("ITEM_6", 60.0, new
+        Double[]{1000.0,
+        1100.99,
+        900.0 })));
+
+    expectedResults.put("7", new GenericRow(Arrays.asList("ITEM_7", 70.0, new
+        Double[]{1100.0,
+        1110.99,
+        190.0 })));
+
+    expectedResults.put("8", new GenericRow(Arrays.asList("ITEM_8", 80.0, new
+        Double[]{1100.0,
+        1110.99,
+        970.0 })));
+
+    Schema resultSchema = SchemaBuilder.struct()
+        .field("ITEMID", SchemaBuilder.STRING_SCHEMA)
+        .field("ORDERUNITS", SchemaBuilder.FLOAT64_SCHEMA)
+        .field("PRICEARRAY", SchemaBuilder.array(SchemaBuilder.FLOAT64_SCHEMA))
+        .build();
+
+    testCreateStreamAsSelect(
+        "SELECT ITEMID, ORDERUNITS, PRICEARRAY FROM " + orderDataProvider.kstreamName(),
+        resultSchema,
+        expectedResults
+    );
+  }
+
+  @Test
+  public void testSelectFilter() throws Exception {
+    Map<String, GenericRow> expectedResults = new HashMap<>();
+    Map<String, Double> mapField = new HashMap<>();
+    mapField.put("key1", 1.0);
+    mapField.put("key2", 2.0);
+    mapField.put("key3", 3.0);
+    expectedResults.put("8", new GenericRow(Arrays.asList(8, "ORDER_6",
+        "ITEM_8", 80.0, new
+            Double[]{1100.0,
+            1110.99,
+            970.0 },
+        mapField)));
+
+    testCreateStreamAsSelect(
+        "SELECT * FROM " + orderDataProvider.kstreamName() + " WHERE ORDERUNITS > 20 AND ITEMID = 'ITEM_8'",
+        orderDataProvider.schema(),
+        expectedResults
+        );
+  }
+
+  @Test
+  public void testSelectUDFs() throws Exception {
+    final String selectColumns =
+        "ITEMID, ORDERUNITS*10, PRICEARRAY[0]+10, KEYVALUEMAP['key1']*KEYVALUEMAP['key2']+10, PRICEARRAY[1]>1000";
+    final String whereClause = "ORDERUNITS > 20 AND ITEMID LIKE '%_8'";
+
+    final String queryString = String.format(
+        "SELECT %s FROM %s WHERE %s;",
+        selectColumns,
+        orderDataProvider.kstreamName(),
+        whereClause
+    );
+
+    Map<String, GenericRow> expectedResults = new HashMap<>();
+    expectedResults.put("8", new GenericRow(Arrays.asList("ITEM_8", 800.0, 1110.0, 12.0, true)));
+
+    // TODO: tests failed!
+    // testCreateStreamAsSelect(queryString, orderDataProvider.schema(), expectedResults);
+  }
+
+  // ===================================================================
+  // Below Tests are only used for coverage, not for results validation.
+  // ===================================================================
+
   @Test
   public void testRunInteractively() {
     localCli.runInteractively();

--- a/ksql-cli/src/test/java/io/confluent/ksql/CliTestFailedException.java
+++ b/ksql-cli/src/test/java/io/confluent/ksql/CliTestFailedException.java
@@ -1,0 +1,13 @@
+/**
+ * Copyright 2017 Confluent Inc.
+ **/
+
+package io.confluent.ksql;
+
+public class CliTestFailedException extends RuntimeException {
+
+  public CliTestFailedException(Throwable cause) {
+    super(cause);
+  }
+
+}

--- a/ksql-cli/src/test/java/io/confluent/ksql/TestResult.java
+++ b/ksql-cli/src/test/java/io/confluent/ksql/TestResult.java
@@ -1,0 +1,122 @@
+/**
+ * Copyright 2017 Confluent Inc.
+ **/
+
+package io.confluent.ksql;
+
+import io.confluent.ksql.physical.GenericRow;
+import io.confluent.ksql.util.StringUtil;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.TreeMap;
+
+public abstract class TestResult {
+
+  private static final String LINE_SEPARATOR = ", ";
+
+  Collection<List<String>> data;
+  private boolean sealed = false;
+
+  static class OrderedResult extends TestResult {
+    private OrderedResult() {
+      data = new ArrayList<>();
+    }
+
+    private OrderedResult(String singleRow) {
+      this();
+      if (singleRow.length() > 0) {
+        data.add(Arrays.asList(singleRow.split(LINE_SEPARATOR)));
+      }
+      seal();
+    }
+
+    @Override
+    public String toString() {
+      return data.toString();
+    }
+  }
+
+  static class UnorderedResult extends TestResult {
+    private UnorderedResult() {
+      data = new HashSet<>();
+    }
+
+    private UnorderedResult(Map<String, Object> map) {
+      this();
+      for (Map.Entry<String, Object> kv : map.entrySet()) {
+        data.add(Arrays.asList(kv.getKey(), String.valueOf(kv.getValue())));
+      }
+      seal();
+    }
+
+    @Override
+    public String toString() {
+      // for convenience, we show content ordered by first column (key) alphabetically
+      TreeMap<String, Object> map = new TreeMap<>();
+      for (List<String> entry: data) {
+        map.put(entry.get(0), entry);
+      }
+      return map.values().toString();
+    }
+  }
+
+  static UnorderedResult build(Map<String, Object> map) {
+    return new UnorderedResult(map);
+  }
+
+  static OrderedResult build(String singleRow) {
+    return new OrderedResult(singleRow);
+  }
+
+  static OrderedResult build(Object... cols) {
+    return new OrderedResult(StringUtil.join(", ", Arrays.asList(cols)));
+  }
+
+  static TestResult init(boolean requireOrder) {
+    return requireOrder ? new OrderedResult() : new UnorderedResult();
+  }
+
+  void addRow(GenericRow row) {
+    if (sealed) {
+      throw new RuntimeException("TestResult already sealed, cannot add more rows to it.");
+    }
+
+    List<String> newRow = new ArrayList<>();
+    for (Object column : row.getColumns()) {
+      newRow.add(String.valueOf(column));
+    }
+
+    data.add(newRow);
+  }
+
+  void addRows(List<List<String>> rows) {
+    if (sealed) {
+      throw new RuntimeException("TestResult already sealed, cannot add more rows to it.");
+    }
+
+    data.addAll(rows);
+  }
+
+  void seal() {
+    this.sealed = true;
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) return true;
+    if (o == null || getClass() != o.getClass()) return false;
+    TestResult that = (TestResult) o;
+    return Objects.equals(data, that.data);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(data);
+  }
+}

--- a/ksql-cli/src/test/java/io/confluent/ksql/TestRunner.java
+++ b/ksql-cli/src/test/java/io/confluent/ksql/TestRunner.java
@@ -1,0 +1,64 @@
+/**
+ * Copyright 2017 Confluent Inc.
+ **/
+
+package io.confluent.ksql;
+
+import io.confluent.ksql.cli.LocalCli;
+import org.junit.Assert;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.Objects;
+
+public abstract class TestRunner {
+
+  private static final Logger LOGGER = LoggerFactory.getLogger(TestRunner.class);
+
+  private static LocalCli localCli;
+  private static TestTerminal testTerminal;
+
+  public static void setup(LocalCli localCli, TestTerminal testTerminal) {
+    Objects.requireNonNull(localCli);
+    Objects.requireNonNull(testTerminal);
+    TestRunner.localCli = localCli;
+    TestRunner.testTerminal = testTerminal;
+  }
+
+  protected static void testListOrShow(String commandSuffix, TestResult.OrderedResult expectedResult) {
+    testListOrShow(commandSuffix, expectedResult, true);
+  }
+
+  protected static void testListOrShow(String commandSuffix, TestResult expectedResult, boolean requireOrder) {
+    test("list " + commandSuffix, expectedResult, requireOrder);
+    test("show " + commandSuffix, expectedResult, requireOrder);
+  }
+
+  protected static void test(String command, TestResult.OrderedResult expectedResult) {
+    test(command, expectedResult, true);
+  }
+
+  protected static void test(String command, TestResult expectedResult, boolean requireOrder) {
+    TestResult actual = run(command, requireOrder);
+    Assert.assertEquals(expectedResult, actual);
+  }
+
+  protected static TestResult run(String command, boolean requireOrder) throws CliTestFailedException {
+    try {
+      if (!command.endsWith(";")) {
+        command += ";";
+      }
+      System.out.println("[Run Command] " + command);
+      testTerminal.resetTestResult(requireOrder);
+      localCli.handleLine(command);
+      return testTerminal.getTestResult();
+    } catch (Exception e) {
+      throw new CliTestFailedException(e);
+    }
+  }
+
+  protected static TestResult run(String command) throws CliTestFailedException {
+    return run(command, false);
+  }
+
+}

--- a/ksql-cli/src/test/java/io/confluent/ksql/TestTerminal.java
+++ b/ksql-cli/src/test/java/io/confluent/ksql/TestTerminal.java
@@ -6,6 +6,7 @@ package io.confluent.ksql;
 
 import io.confluent.ksql.cli.console.Console;
 import io.confluent.ksql.cli.console.OutputFormat;
+import io.confluent.ksql.physical.GenericRow;
 
 import io.confluent.ksql.rest.client.KsqlRestClient;
 import org.jline.terminal.Terminal;
@@ -14,21 +15,43 @@ import org.jline.utils.InfoCmp;
 import java.io.IOException;
 import java.io.PrintWriter;
 import java.io.StringWriter;
+import java.util.List;
 
 public class TestTerminal extends Console {
 
   private final PrintWriter printWriter;
   private final StringWriter writer;
+  private TestResult output;
 
   public TestTerminal(OutputFormat outputFormat, KsqlRestClient restClient) {
     super(outputFormat, restClient);
 
     this.writer = new StringWriter();
     this.printWriter = new PrintWriter(writer);
+
+    resetTestResult(true);
+  }
+
+  public void resetTestResult(boolean requireOrder) {
+    output = TestResult.init(requireOrder);
+  }
+
+  public TestResult getTestResult() {
+    return output;
   }
 
   public String getOutputString() {
     return writer.toString();
+  }
+
+  @Override
+  public void addResult(GenericRow row) {
+    output.addRow(row);
+  }
+
+  @Override
+  public void addResult(List<String> columnHeaders, List<List<String>> rows) {
+    output.addRows(rows);
   }
 
   @Override

--- a/ksql-core/src/main/java/io/confluent/ksql/physical/GenericRow.java
+++ b/ksql-core/src/main/java/io/confluent/ksql/physical/GenericRow.java
@@ -4,17 +4,21 @@
 
 package io.confluent.ksql.physical;
 
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
+import java.util.Objects;
 
 public class GenericRow {
 
-  private List<Object> columns;
+  private final List<Object> columns;
 
   public GenericRow() {
+    columns = new ArrayList<>();
   }
 
   public GenericRow(List<Object> columns) {
+    Objects.requireNonNull(columns);
     this.columns = columns;
   }
 
@@ -43,25 +47,25 @@ public class GenericRow {
     return stringBuilder.toString();
   }
 
-  public boolean hasTheSameContent(Object other) {
-    if (!(other instanceof GenericRow)) {
-      return  false;
-    }
-    GenericRow otherGenericRow = (GenericRow) other;
-    if (columns.size() != otherGenericRow.columns.size()) {
-      return false;
-    }
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) return true;
+    if (o == null || getClass() != o.getClass()) return false;
+    GenericRow that = (GenericRow) o;
 
-    // For now string matching is used to compare the rows.
-    return this.toString().equals(otherGenericRow.toString());
+    if (columns.size() != that.columns.size()) return false;
+
+    // For now string matching is used to compare the rows as double comparision will cause issues
+    return this.toString().equals(that.toString());
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(columns);
   }
 
   public List<Object> getColumns() {
     return columns;
-  }
-
-  public void setColumns(List<Object> columns) {
-    this.columns = columns;
   }
 
 }

--- a/ksql-core/src/test/java/io/confluent/ksql/integtests/json/JsonFormatTest.java
+++ b/ksql-core/src/test/java/io/confluent/ksql/integtests/json/JsonFormatTest.java
@@ -1,10 +1,11 @@
 package io.confluent.ksql.integtests.json;
 
+import io.confluent.ksql.util.OrderDataProvider;
+import io.confluent.ksql.util.TopicConsumer;
+import io.confluent.ksql.util.TopicProducer;
 import io.confluent.ksql.KsqlEngine;
 import io.confluent.ksql.metastore.MetaStore;
 import io.confluent.ksql.physical.GenericRow;
-import io.confluent.ksql.serde.json.KsqlJsonDeserializer;
-import io.confluent.ksql.serde.json.KsqlJsonSerializer;
 import io.confluent.ksql.testutils.EmbeddedSingleNodeKafkaCluster;
 import io.confluent.ksql.util.KafkaTopicClient;
 import io.confluent.ksql.util.KafkaTopicClientImpl;
@@ -13,15 +14,9 @@ import io.confluent.ksql.util.PersistentQueryMetadata;
 import io.confluent.ksql.util.QueryMetadata;
 import io.confluent.ksql.util.SchemaUtil;
 import org.apache.kafka.clients.consumer.ConsumerConfig;
-import org.apache.kafka.clients.consumer.ConsumerRecord;
-import org.apache.kafka.clients.consumer.KafkaConsumer;
-import org.apache.kafka.clients.producer.KafkaProducer;
-import org.apache.kafka.clients.producer.ProducerConfig;
-import org.apache.kafka.clients.producer.ProducerRecord;
 import org.apache.kafka.clients.producer.RecordMetadata;
 import org.apache.kafka.common.serialization.Deserializer;
 import org.apache.kafka.common.serialization.StringDeserializer;
-import org.apache.kafka.common.serialization.StringSerializer;
 import org.apache.kafka.connect.data.Schema;
 import org.apache.kafka.connect.data.SchemaBuilder;
 import org.apache.kafka.streams.kstream.Windowed;
@@ -40,26 +35,23 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.Properties;
-import java.util.concurrent.ExecutionException;
-import java.util.concurrent.Future;
-import java.util.concurrent.TimeUnit;
-import java.util.concurrent.TimeoutException;
+
+import static io.confluent.ksql.util.KsqlTestUtil.assertExpectedResults;
+import static io.confluent.ksql.util.KsqlTestUtil.assertExpectedWindowedResults;
 
 public class JsonFormatTest {
 
-  MetaStore metaStore;
-  KsqlEngine ksqlEngine;
-  Map<String, GenericRow> inputData;
-  Map<String, RecordMetadata> inputRecordsMetadata;
-  Map<String, Object> configMap;
+  private MetaStore metaStore;
+  private KsqlEngine ksqlEngine;
+  private TopicProducer topicProducer;
+  private TopicConsumer topicConsumer;
+
+  private Map<String, GenericRow> inputData;
+  private Map<String, RecordMetadata> inputRecordsMetadata;
 
   @ClassRule
   public static final EmbeddedSingleNodeKafkaCluster CLUSTER = new EmbeddedSingleNodeKafkaCluster();
 
-  private static final long TEST_RECORD_FUTURE_TIMEOUT_MS = 5000;
-  private static final long RESULTS_POLL_MAX_TIME_MS = 30000;
-  private static final long RESULTS_EXTRA_POLL_TIME_MS = 250;
   private static final String inputTopic = "orders_topic";
   private static final String inputStream = "ORDERS";
   private static final String messageLogTopic = "log_topic";
@@ -70,18 +62,7 @@ public class JsonFormatTest {
   @Before
   public void before() throws Exception {
 
-    SchemaBuilder schemaBuilderOrders = SchemaBuilder.struct()
-        .field("ORDERTIME", SchemaBuilder.INT64_SCHEMA)
-        .field("ORDERID", SchemaBuilder.STRING_SCHEMA)
-        .field("ITEMID", SchemaBuilder.STRING_SCHEMA)
-        .field("ORDERUNITS", SchemaBuilder.FLOAT64_SCHEMA)
-        .field("PRICEARRAY", SchemaBuilder.array(SchemaBuilder.FLOAT64_SCHEMA))
-        .field("KEYVALUEMAP", SchemaBuilder.map(SchemaBuilder.STRING_SCHEMA, SchemaBuilder.FLOAT64_SCHEMA));
-
-    SchemaBuilder schemaBuilderMessage = SchemaBuilder.struct()
-        .field("MESSAGE", SchemaBuilder.STRING_SCHEMA);
-
-    configMap = new HashMap<>();
+    Map<String, Object> configMap = new HashMap<>();
     configMap.put(ConsumerConfig.BOOTSTRAP_SERVERS_CONFIG, CLUSTER.bootstrapServers());
     configMap.put("application.id", "KSQL");
     configMap.put("commit.interval.ms", 0);
@@ -91,29 +72,49 @@ public class JsonFormatTest {
     KsqlConfig ksqlConfig = new KsqlConfig(configMap);
     ksqlEngine = new KsqlEngine(ksqlConfig, new KafkaTopicClientImpl(ksqlConfig));
     metaStore = ksqlEngine.getMetaStore();
-    inputData = getInputData();
-    produceMessageData(schemaBuilderMessage.build());
+    topicProducer = new TopicProducer(CLUSTER);
+    topicConsumer = new TopicConsumer(CLUSTER);
 
+    createInitTopics();
+    produceInitData();
+    execInitCreateStreamQueries();
+
+  }
+
+  private void createInitTopics() {
     ksqlEngine.getKafkaTopicClient().createTopic(inputTopic, 1, (short)1);
     ksqlEngine.getKafkaTopicClient().createTopic(messageLogTopic, 1, (short)1);
+  }
 
+  private void produceInitData() throws Exception {
+    OrderDataProvider orderDataProvider = new OrderDataProvider();
+    inputData = orderDataProvider.data();
+    inputRecordsMetadata = topicProducer.produceInputData(inputTopic, orderDataProvider.data(), orderDataProvider.schema());
+
+    Schema messageSchema = SchemaBuilder.struct().field("MESSAGE", SchemaBuilder.STRING_SCHEMA).build();
+
+    GenericRow messageRow = new GenericRow(Arrays.asList
+        ("{\"log\":{\"@timestamp\":\"2017-05-30T16:44:22.175Z\",\"@version\":\"1\","
+            + "\"caasVersion\":\"0.0.2\",\"cloud\":\"aws\",\"clusterId\":\"cp99\",\"clusterName\":\"kafka\",\"cpComponentId\":\"kafka\",\"host\":\"kafka-1-wwl0p\",\"k8sId\":\"k8s13\",\"k8sName\":\"perf\",\"level\":\"ERROR\",\"logger\":\"kafka.server.ReplicaFetcherThread\",\"message\":\"Found invalid messages during fetch for partition [foo512,172] offset 0 error Record is corrupt (stored crc = 1321230880, computed crc = 1139143803)\",\"networkId\":\"vpc-d8c7a9bf\",\"region\":\"us-west-2\",\"serverId\":\"1\",\"skuId\":\"sku5\",\"source\":\"kafka\",\"tenantId\":\"t47\",\"tenantName\":\"perf-test\",\"thread\":\"ReplicaFetcherThread-0-2\",\"zone\":\"us-west-2a\"},\"stream\":\"stdout\",\"time\":2017}"));
+
+    Map<String, GenericRow> records = new HashMap<>();
+    records.put("1", messageRow);
+
+    topicProducer.produceInputData(messageLogTopic, records, messageSchema);
+  }
+
+  private void execInitCreateStreamQueries() throws Exception {
     String ordersStreamStr = String.format("CREATE STREAM %s (ORDERTIME bigint, ORDERID varchar, "
-                                           + "ITEMID varchar, ORDERUNITS double, PRICEARRAY array<double>, KEYVALUEMAP "
-                                           + "map<varchar, double>) WITH (value_format = 'json', "
-                                           + "kafka_topic='%s' , "
-                                           + "key='ordertime');", inputStream, inputTopic, inputTopic);
+        + "ITEMID varchar, ORDERUNITS double, PRICEARRAY array<double>, KEYVALUEMAP "
+        + "map<varchar, double>) WITH (value_format = 'json', "
+        + "kafka_topic='%s' , "
+        + "key='ordertime');", inputStream, inputTopic);
 
     String messageStreamStr = String.format("CREATE STREAM %s (message varchar) WITH (value_format = 'json', "
-                                            + "kafka_topic='%s');", messageLogStream,
-                                            messageLogTopic, messageLogTopic);
+        + "kafka_topic='%s');", messageLogStream, messageLogTopic);
 
     ksqlEngine.buildMultipleQueries(false, ordersStreamStr, Collections.emptyMap());
-
     ksqlEngine.buildMultipleQueries(false, messageStreamStr, Collections.emptyMap());
-
-    inputRecordsMetadata = produceInputData(inputData, schemaBuilderOrders.build());
-
-
   }
 
   @After
@@ -135,7 +136,7 @@ public class JsonFormatTest {
     Map<String, GenericRow> results = readNormalResults(streamName, resultSchema, inputData.size());
 
     Assert.assertEquals(inputData.size(), results.size());
-    Assert.assertTrue(assertExpectedResults(results, inputData));
+    assertExpectedResults(results, inputData);
 
     ksqlEngine.terminateQuery(queryMetadata.getId(), true);
   }
@@ -156,47 +157,47 @@ public class JsonFormatTest {
     Map<String, GenericRow> expectedResults = new HashMap<>();
     expectedResults.put("1", new GenericRow(Arrays.asList("ITEM_1", 10.0, new
         Double[]{100.0,
-                 110.99,
-                 90.0 })));
+        110.99,
+        90.0 })));
     expectedResults.put("2", new GenericRow(Arrays.asList("ITEM_2", 20.0, new
         Double[]{10.0,
-                 10.99,
-                 9.0 })));
+        10.99,
+        9.0 })));
 
     expectedResults.put("3", new GenericRow(Arrays.asList("ITEM_3", 30.0, new
         Double[]{10.0,
-                 10.99,
-                 91.0 })));
+        10.99,
+        91.0 })));
 
     expectedResults.put("4", new GenericRow(Arrays.asList("ITEM_4", 40.0, new
         Double[]{10.0,
-                 140.99,
-                 94.0 })));
+        140.99,
+        94.0 })));
 
     expectedResults.put("5", new GenericRow(Arrays.asList("ITEM_5", 50.0, new
         Double[]{160.0,
-                 160.99,
-                 98.0 })));
+        160.99,
+        98.0 })));
 
     expectedResults.put("6", new GenericRow(Arrays.asList("ITEM_6", 60.0, new
         Double[]{1000.0,
-                 1100.99,
-                 900.0 })));
+        1100.99,
+        900.0 })));
 
     expectedResults.put("7", new GenericRow(Arrays.asList("ITEM_7", 70.0, new
         Double[]{1100.0,
-                 1110.99,
-                 190.0 })));
+        1110.99,
+        190.0 })));
 
     expectedResults.put("8", new GenericRow(Arrays.asList("ITEM_8", 80.0, new
         Double[]{1100.0,
-                 1110.99,
-                 970.0 })));
+        1110.99,
+        970.0 })));
 
     Map<String, GenericRow> results = readNormalResults(streamName, resultSchema, expectedResults.size());
 
     Assert.assertEquals(expectedResults.size(), results.size());
-    Assert.assertTrue(assertExpectedResults(results, expectedResults));
+    assertExpectedResults(results, expectedResults);
 
     ksqlEngine.terminateQuery(queryMetadata.getId(), true);
   }
@@ -206,8 +207,8 @@ public class JsonFormatTest {
     final String streamName = "SelectProjectKeyTimestampStream".toUpperCase();
     final String queryString =
         String.format("CREATE STREAM %s AS SELECT ROWKEY AS RKEY, ROWTIME AS RTIME, ITEMID "
-                      + "FROM %s WHERE ORDERUNITS > 20 AND ITEMID = 'ITEM_8';", streamName,
-                      inputStream);
+                + "FROM %s WHERE ORDERUNITS > 20 AND ITEMID = 'ITEM_8';", streamName,
+            inputStream);
 
     PersistentQueryMetadata queryMetadata =
         (PersistentQueryMetadata) ksqlEngine.buildMultipleQueries(true, queryString, Collections.emptyMap()).get(0);
@@ -223,7 +224,7 @@ public class JsonFormatTest {
     Map<String, GenericRow> results = readNormalResults(streamName, resultSchema, expectedResults.size());
 
     Assert.assertEquals(expectedResults.size(), results.size());
-    Assert.assertTrue(assertExpectedResults(results, expectedResults));
+    assertExpectedResults(results, expectedResults);
 
     ksqlEngine.terminateQuery(queryMetadata.getId(), true);
   }
@@ -234,13 +235,13 @@ public class JsonFormatTest {
     final String stream2Name = "TIMESTAMPSTREAM";
     final String query1String =
         String.format("CREATE STREAM %s WITH (timestamp='RTIME') AS SELECT ROWKEY AS RKEY, "
-                      + "ROWTIME+10000 AS "
-                      + "RTIME, ROWTIME+100 AS RT100, ORDERID, ITEMID "
-                      + "FROM %s WHERE ORDERUNITS > 20 AND ITEMID = 'ITEM_8'; "
-                      + "CREATE STREAM %s AS SELECT ROWKEY AS NEWRKEY, "
-                      + "ROWTIME AS NEWRTIME, RKEY, RTIME, RT100, ORDERID, ITEMID "
-                      + "FROM %s ;", stream1Name,
-                      inputStream, stream2Name, stream1Name);
+                + "ROWTIME+10000 AS "
+                + "RTIME, ROWTIME+100 AS RT100, ORDERID, ITEMID "
+                + "FROM %s WHERE ORDERUNITS > 20 AND ITEMID = 'ITEM_8'; "
+                + "CREATE STREAM %s AS SELECT ROWKEY AS NEWRKEY, "
+                + "ROWTIME AS NEWRTIME, RKEY, RTIME, RT100, ORDERID, ITEMID "
+                + "FROM %s ;", stream1Name,
+            inputStream, stream2Name, stream1Name);
 
     List<QueryMetadata> queryMetadataList = ksqlEngine.buildMultipleQueries(true, query1String, Collections.emptyMap());
 
@@ -255,18 +256,18 @@ public class JsonFormatTest {
 
     Map<String, GenericRow> expectedResults = new HashMap<>();
     expectedResults.put("8", new GenericRow(Arrays.asList("8", inputRecordsMetadata.get("8")
-                                                                   .timestamp() + 10000, "8", inputRecordsMetadata.get("8").timestamp() + 10000,
-                                                          inputRecordsMetadata.get("8").timestamp
-                                                              () + 100, "ORDER_6", "ITEM_8")));
+            .timestamp() + 10000, "8", inputRecordsMetadata.get("8").timestamp() + 10000,
+        inputRecordsMetadata.get("8").timestamp
+            () + 100, "ORDER_6", "ITEM_8")));
 
     Map<String, GenericRow> results1 = readNormalResults(stream1Name, resultSchema,
-                                                         expectedResults.size());
+        expectedResults.size());
 
     Map<String, GenericRow> results = readNormalResults(stream2Name, resultSchema,
-                                                        expectedResults.size());
+        expectedResults.size());
 
     Assert.assertEquals(expectedResults.size(), results.size());
-    Assert.assertTrue(assertExpectedResults(results, expectedResults));
+    assertExpectedResults(results, expectedResults);
 
     ksqlEngine.terminateQuery(query1Metadata.getId(), true);
     ksqlEngine.terminateQuery(query2Metadata.getId(), true);
@@ -294,16 +295,16 @@ public class JsonFormatTest {
     mapField.put("key2", 2.0);
     mapField.put("key3", 3.0);
     expectedResults.put("8", new GenericRow(Arrays.asList(8, "ORDER_6",
-                                                          "ITEM_8", 80.0, new
-                                                              Double[]{1100.0,
-                                                                       1110.99,
-                                                                       970.0 },
-                                                          mapField)));
+        "ITEM_8", 80.0, new
+            Double[]{1100.0,
+            1110.99,
+            970.0 },
+        mapField)));
 
     Map<String, GenericRow> results = readNormalResults(streamName, resultSchema, expectedResults.size());
 
     Assert.assertEquals(expectedResults.size(), results.size());
-    Assert.assertTrue(assertExpectedResults(results, expectedResults));
+    assertExpectedResults(results, expectedResults);
 
     ksqlEngine.terminateQuery(queryMetadata.getId(), true);
   }
@@ -337,7 +338,7 @@ public class JsonFormatTest {
     Map<String, GenericRow> results = readNormalResults(streamName, resultSchema, expectedResults.size());
 
     Assert.assertEquals(expectedResults.size(), results.size());
-    Assert.assertTrue(assertExpectedResults(results, expectedResults));
+    assertExpectedResults(results, expectedResults);
 
     ksqlEngine.terminateQuery(queryMetadata.getId(), true);
   }
@@ -349,7 +350,7 @@ public class JsonFormatTest {
 
     final String selectColumns =
         " CAST (ORDERUNITS AS INTEGER), CAST( PRICEARRAY[1]>1000 AS STRING), CAST (SUBSTRING"
-        + "(ITEMID, 5) AS DOUBLE), CAST(ORDERUNITS AS VARCHAR) ";
+            + "(ITEMID, 5) AS DOUBLE), CAST(ORDERUNITS AS VARCHAR) ";
     final String whereClause = "ORDERUNITS > 20 AND ITEMID LIKE '%_8'";
 
     final String queryString = String.format(
@@ -374,7 +375,7 @@ public class JsonFormatTest {
     Map<String, GenericRow> results = readNormalResults(streamName, resultSchema, expectedResults.size());
 
     Assert.assertEquals(expectedResults.size(), results.size());
-    Assert.assertTrue(assertExpectedResults(results, expectedResults));
+    assertExpectedResults(results, expectedResults);
 
     ksqlEngine.terminateQuery(queryMetadata.getId(), true);
   }
@@ -408,7 +409,7 @@ public class JsonFormatTest {
     Map<String, GenericRow> results = readNormalResults(streamName, resultSchema, expectedResults.size());
 
     Assert.assertEquals(expectedResults.size(), results.size());
-    Assert.assertTrue(assertExpectedResults(results, expectedResults));
+    assertExpectedResults(results, expectedResults);
 
     ksqlEngine.terminateQuery(queryMetadata.getId(), true);
   }
@@ -442,7 +443,7 @@ public class JsonFormatTest {
     Map<String, GenericRow> results = readNormalResults(streamName, resultSchema, expectedResults.size());
 
     Assert.assertEquals(expectedResults.size(), results.size());
-    Assert.assertTrue(assertExpectedResults(results, expectedResults));
+    assertExpectedResults(results, expectedResults);
 
     ksqlEngine.terminateQuery(queryMetadata.getId(), true);
   }
@@ -453,8 +454,8 @@ public class JsonFormatTest {
 
     final String selectColumns =
         "(ORDERTIME+1500962514806) , TIMESTAMPTOSTRING(ORDERTIME+1500962514806), STRINGTOTIMESTAMP"
-        + "(TIMESTAMPTOSTRING"
-        + "(ORDERTIME+1500962514806))";
+            + "(TIMESTAMPTOSTRING"
+            + "(ORDERTIME+1500962514806))";
     final String whereClause = "ORDERUNITS > 20 AND ITEMID LIKE '%_8'";
 
     final String queryString = String.format(
@@ -474,13 +475,13 @@ public class JsonFormatTest {
 
     Map<String, GenericRow> expectedResults = new HashMap<>();
     expectedResults.put("8", new GenericRow(Arrays.asList(1500962514814l,
-                                                          "2017-07-24 23:01:54.814",
-                                                          1500962514814l)));
+        "2017-07-24 23:01:54.814",
+        1500962514814l)));
 
     Map<String, GenericRow> results = readNormalResults(streamName, resultSchema, expectedResults.size());
 
     Assert.assertEquals(expectedResults.size(), results.size());
-    Assert.assertTrue(assertExpectedResults(results, expectedResults));
+    assertExpectedResults(results, expectedResults);
 
     ksqlEngine.terminateQuery(queryMetadata.getId(), true);
   }
@@ -488,7 +489,7 @@ public class JsonFormatTest {
   @Test
   public void testAggSelectStar() throws Exception {
 
-    Map<String, RecordMetadata> newRecordsMetadata = produceInputData(inputData, SchemaUtil
+    Map<String, RecordMetadata> newRecordsMetadata = topicProducer.produceInputData(inputTopic, inputData, SchemaUtil
         .removeImplicitRowTimeRowKeyFromSchema(ksqlEngine.getMetaStore().getSource(inputStream).getSchema()));
     final String streamName = "AGGTEST";
     final long windowSizeMilliseconds = 2000;
@@ -499,7 +500,7 @@ public class JsonFormatTest {
 
     final String queryString = String.format(
         "CREATE TABLE %s AS SELECT %s FROM %s WINDOW %s WHERE ORDERUNITS > 60 GROUP BY ITEMID "
-        + "HAVING %s;",
+            + "HAVING %s;",
         streamName,
         selectColumns,
         inputStream,
@@ -527,7 +528,7 @@ public class JsonFormatTest {
     Map<Windowed<String>, GenericRow> results = readWindowedResults(streamName, resultSchema, expectedResults.size());
 
     Assert.assertEquals(expectedResults.size(), results.size());
-    Assert.assertTrue(assertExpectedWindowedResults(results, expectedResults));
+    assertExpectedWindowedResults(results, expectedResults);
 
     ksqlEngine.terminateQuery(queryMetadata.getId(), true);
   }
@@ -537,8 +538,8 @@ public class JsonFormatTest {
     final String streamName = "SinkPropertiesStream".toUpperCase();
     final int resultPartitionCount = 3;
     final String queryString = String.format("CREATE STREAM %s WITH (PARTITIONS = %d) AS SELECT * "
-                                             + "FROM %s;",
-                                             streamName, resultPartitionCount, inputStream);
+            + "FROM %s;",
+        streamName, resultPartitionCount, inputStream);
 
     PersistentQueryMetadata queryMetadata =
         (PersistentQueryMetadata) ksqlEngine.buildMultipleQueries(true, queryString, Collections.emptyMap()).get(0);
@@ -563,9 +564,9 @@ public class JsonFormatTest {
 
     final String streamName = "JSONSTREAM";
     final String queryString = String.format("CREATE STREAM %s AS SELECT EXTRACTJSONFIELD"
-                                             + "(message, '$.log.cloud') "
-                                             + "FROM %s;",
-                                             streamName, messageLogStream);
+            + "(message, '$.log.cloud') "
+            + "FROM %s;",
+        streamName, messageLogStream);
 
     PersistentQueryMetadata queryMetadata =
         (PersistentQueryMetadata) ksqlEngine.buildMultipleQueries(true, queryString, Collections.emptyMap()).get(0);
@@ -580,64 +581,15 @@ public class JsonFormatTest {
     Map<String, GenericRow> results = readNormalResults(streamName, resultSchema, expectedResults.size());
 
     Assert.assertEquals(expectedResults.size(), results.size());
-    Assert.assertTrue(assertExpectedResults(results, expectedResults));
+    assertExpectedResults(results, expectedResults);
 
     ksqlEngine.terminateQuery(queryMetadata.getId(), true);
   }
 
   //*********************************************************//
 
-
-  private Map<String, RecordMetadata> produceInputData(Map<String, GenericRow> recordsToPublish, Schema schema)
-      throws InterruptedException, TimeoutException, ExecutionException {
-    Properties producerConfig = new Properties();
-    producerConfig.put(ProducerConfig.BOOTSTRAP_SERVERS_CONFIG, CLUSTER.bootstrapServers());
-    producerConfig.put(ProducerConfig.ACKS_CONFIG, "all");
-    producerConfig.put(ProducerConfig.RETRIES_CONFIG, 0);
-
-    KafkaProducer<String, GenericRow> producer =
-        new KafkaProducer<>(producerConfig, new StringSerializer(), new KsqlJsonSerializer(schema));
-
-    Map<String, RecordMetadata> result = new HashMap<>();
-    for (Map.Entry<String, GenericRow> recordEntry : recordsToPublish.entrySet()) {
-      String key = recordEntry.getKey();
-      ProducerRecord<String, GenericRow> producerRecord = new ProducerRecord<>(inputTopic, key, recordEntry.getValue());
-      Future<RecordMetadata> recordMetadataFuture = producer.send(producerRecord);
-      result.put(key, recordMetadataFuture.get(TEST_RECORD_FUTURE_TIMEOUT_MS, TimeUnit.MILLISECONDS));
-    }
-    producer.close();
-
-    return result;
-  }
-
-  private Map<String, RecordMetadata> produceMessageData(Schema schema)
-      throws InterruptedException, ExecutionException, TimeoutException {
-    Properties producerConfig = new Properties();
-    producerConfig.put(ProducerConfig.BOOTSTRAP_SERVERS_CONFIG, CLUSTER.bootstrapServers());
-    producerConfig.put(ProducerConfig.ACKS_CONFIG, "all");
-    producerConfig.put(ProducerConfig.RETRIES_CONFIG, 0);
-
-    KafkaProducer<String, GenericRow> producer =
-        new KafkaProducer<>(producerConfig, new StringSerializer(), new KsqlJsonSerializer(schema));
-
-    Map<String, RecordMetadata> result = new HashMap<>();
-
-    GenericRow messageRow = new GenericRow(Arrays.asList
-        ("{\"log\":{\"@timestamp\":\"2017-05-30T16:44:22.175Z\",\"@version\":\"1\","
-         + "\"caasVersion\":\"0.0.2\",\"cloud\":\"aws\",\"clusterId\":\"cp99\",\"clusterName\":\"kafka\",\"cpComponentId\":\"kafka\",\"host\":\"kafka-1-wwl0p\",\"k8sId\":\"k8s13\",\"k8sName\":\"perf\",\"level\":\"ERROR\",\"logger\":\"kafka.server.ReplicaFetcherThread\",\"message\":\"Found invalid messages during fetch for partition [foo512,172] offset 0 error Record is corrupt (stored crc = 1321230880, computed crc = 1139143803)\",\"networkId\":\"vpc-d8c7a9bf\",\"region\":\"us-west-2\",\"serverId\":\"1\",\"skuId\":\"sku5\",\"source\":\"kafka\",\"tenantId\":\"t47\",\"tenantName\":\"perf-test\",\"thread\":\"ReplicaFetcherThread-0-2\",\"zone\":\"us-west-2a\"},\"stream\":\"stdout\",\"time\":2017}"));
-
-    ProducerRecord<String, GenericRow> producerRecord = new ProducerRecord<>(messageLogTopic, "1",
-                                                                             messageRow);
-    Future<RecordMetadata> recordMetadataFuture = producer.send(producerRecord);
-    result.put("1", recordMetadataFuture.get(TEST_RECORD_FUTURE_TIMEOUT_MS, TimeUnit.MILLISECONDS));
-    producer.close();
-
-    return result;
-  }
-
-
   private Map<String, GenericRow> readNormalResults(String resultTopic, Schema resultSchema, int expectedNumMessages) {
-    return readResults(resultTopic, resultSchema, expectedNumMessages, new StringDeserializer());
+    return topicConsumer.readResults(resultTopic, resultSchema, expectedNumMessages, new StringDeserializer());
   }
 
   private Map<Windowed<String>, GenericRow> readWindowedResults(
@@ -646,147 +598,7 @@ public class JsonFormatTest {
       int expectedNumMessages
   ) {
     Deserializer<Windowed<String>> keyDeserializer = new WindowedDeserializer<>(new StringDeserializer());
-    return readResults(resultTopic, resultSchema, expectedNumMessages, keyDeserializer);
-  }
-
-  private <K>Map<K, GenericRow> readResults(
-      String resultTopic,
-      Schema resultSchema,
-      int expectedNumMessages,
-      Deserializer<K> keyDeserializer
-  ) {
-    Map<K, GenericRow> result = new HashMap<>();
-
-    Properties consumerConfig = new Properties();
-    consumerConfig.put(ConsumerConfig.BOOTSTRAP_SERVERS_CONFIG, CLUSTER.bootstrapServers());
-    consumerConfig.put(ConsumerConfig.GROUP_ID_CONFIG, "filter-integration-test-standard-consumer");
-    consumerConfig.put(ConsumerConfig.AUTO_OFFSET_RESET_CONFIG, "earliest");
-
-    try (KafkaConsumer<K, GenericRow> consumer =
-             new KafkaConsumer<>(consumerConfig, keyDeserializer, new KsqlJsonDeserializer(resultSchema))
-    ) {
-      consumer.subscribe(Collections.singleton(resultTopic));
-      long pollStart = System.currentTimeMillis();
-      long pollEnd = pollStart + RESULTS_POLL_MAX_TIME_MS;
-      while (System.currentTimeMillis() < pollEnd && continueConsuming(result.size(), expectedNumMessages)) {
-        for (ConsumerRecord<K, GenericRow> record : consumer.poll(Math.max(1, pollEnd - System.currentTimeMillis()))) {
-          if (record.value() != null) {
-            result.put(record.key(), record.value());
-          }
-        }
-      }
-
-      for (ConsumerRecord<K, GenericRow> record : consumer.poll(RESULTS_EXTRA_POLL_TIME_MS)) {
-        if (record.value() != null) {
-          result.put(record.key(), record.value());
-        }
-      }
-    }
-    return result;
-  }
-
-  private static boolean continueConsuming(int messagesConsumed, int maxMessages) {
-    return maxMessages < 0 || messagesConsumed < maxMessages;
-  }
-
-  private Map<String, GenericRow> getInputData() {
-
-    Map<String, Double> mapField = new HashMap<>();
-    mapField.put("key1", 1.0);
-    mapField.put("key2", 2.0);
-    mapField.put("key3", 3.0);
-
-    Map<String, GenericRow> dataMap = new HashMap<>();
-    dataMap.put("1", new GenericRow(Arrays.asList(1,
-                                                  "ORDER_1",
-                                                  "ITEM_1", 10.0, new
-                                                      Double[]{100.0,
-                                                               110.99,
-                                                               90.0 },
-                                                  mapField)));
-    dataMap.put("2", new GenericRow(Arrays.asList(2, "ORDER_2",
-                                                  "ITEM_2", 20.0, new
-                                                      Double[]{10.0,
-                                                               10.99,
-                                                               9.0 },
-                                                  mapField)));
-
-    dataMap.put("3", new GenericRow(Arrays.asList(3, "ORDER_3",
-                                                  "ITEM_3", 30.0, new
-                                                      Double[]{10.0,
-                                                               10.99,
-                                                               91.0 },
-                                                  mapField)));
-
-    dataMap.put("4", new GenericRow(Arrays.asList(4, "ORDER_4",
-                                                  "ITEM_4", 40.0, new
-                                                      Double[]{10.0,
-                                                               140.99,
-                                                               94.0 },
-                                                  mapField)));
-
-    dataMap.put("5", new GenericRow(Arrays.asList(5, "ORDER_5",
-                                                  "ITEM_5", 50.0, new
-                                                      Double[]{160.0,
-                                                               160.99,
-                                                               98.0 },
-                                                  mapField)));
-
-    dataMap.put("6", new GenericRow(Arrays.asList(6, "ORDER_6",
-                                                  "ITEM_6", 60.0, new
-                                                      Double[]{1000.0,
-                                                               1100.99,
-                                                               900.0 },
-                                                  mapField)));
-
-    dataMap.put("7", new GenericRow(Arrays.asList(7, "ORDER_6",
-                                                  "ITEM_7", 70.0, new
-                                                      Double[]{1100.0,
-                                                               1110.99,
-                                                               190.0 },
-                                                  mapField)));
-
-    dataMap.put("8", new GenericRow(Arrays.asList(8, "ORDER_6",
-                                                  "ITEM_8", 80.0, new
-                                                      Double[]{1100.0,
-                                                               1110.99,
-                                                               970.0 },
-                                                  mapField)));
-
-    return dataMap;
-  }
-
-  private boolean assertExpectedResults(Map<String, GenericRow> actualResult,
-                                        Map<String, GenericRow> expectedResult) {
-    if (actualResult.size() != expectedResult.size()) {
-      return false;
-    }
-    for (String k: expectedResult.keySet()) {
-      if (!actualResult.containsKey(k)) {
-        return false;
-      }
-      if (!expectedResult.get(k).hasTheSameContent(actualResult.get(k))) {
-        return false;
-      }
-    }
-    return true;
-  }
-
-  private boolean assertExpectedWindowedResults(Map<Windowed<String>, GenericRow> actualResult,
-                                                Map<Windowed<String>, GenericRow> expectedResult) {
-    Map<String, GenericRow> actualResultSimplified = new HashMap<>();
-    Map<String, GenericRow> expectedResultSimplified = new HashMap<>();
-    for (Windowed<String> k: expectedResult.keySet()) {
-      expectedResultSimplified.put(k.key(), expectedResult.get(k));
-    }
-
-    for (Windowed<String> k: actualResult.keySet()) {
-      if (actualResult.get(k) != null) {
-        actualResultSimplified.put(k.key(), actualResult.get(k));
-      }
-
-    }
-    return assertExpectedResults(actualResultSimplified, expectedResultSimplified);
+    return topicConsumer.readResults(resultTopic, resultSchema, expectedNumMessages, keyDeserializer);
   }
 
 }

--- a/ksql-core/src/test/java/io/confluent/ksql/util/KsqlTestUtil.java
+++ b/ksql-core/src/test/java/io/confluent/ksql/util/KsqlTestUtil.java
@@ -1,13 +1,18 @@
 package io.confluent.ksql.util;
 
-
 import io.confluent.ksql.metastore.KsqlStream;
 import io.confluent.ksql.metastore.KsqlTable;
 import io.confluent.ksql.metastore.KsqlTopic;
 import io.confluent.ksql.metastore.MetaStore;
 import io.confluent.ksql.metastore.MetaStoreImpl;
+import io.confluent.ksql.physical.GenericRow;
 import io.confluent.ksql.serde.json.KsqlJsonTopicSerDe;
 import org.apache.kafka.connect.data.SchemaBuilder;
+import org.apache.kafka.streams.kstream.Windowed;
+import org.junit.Assert;
+
+import java.util.HashMap;
+import java.util.Map;
 
 public class KsqlTestUtil {
 
@@ -70,4 +75,32 @@ public class KsqlTestUtil {
 
     return metaStore;
   }
+
+  public static void assertExpectedResults(Map<String, GenericRow> actualResult,
+                                        Map<String, GenericRow> expectedResult) {
+    Assert.assertEquals(actualResult.size(), expectedResult.size());
+
+    for (String k: expectedResult.keySet()) {
+      Assert.assertTrue(actualResult.containsKey(k));
+      Assert.assertEquals(expectedResult.get(k), actualResult.get(k));
+    }
+  }
+
+  public static void assertExpectedWindowedResults(Map<Windowed<String>, GenericRow> actualResult,
+                                                Map<Windowed<String>, GenericRow> expectedResult) {
+    Map<String, GenericRow> actualResultSimplified = new HashMap<>();
+    Map<String, GenericRow> expectedResultSimplified = new HashMap<>();
+    for (Windowed<String> k: expectedResult.keySet()) {
+      expectedResultSimplified.put(k.key(), expectedResult.get(k));
+    }
+
+    for (Windowed<String> k: actualResult.keySet()) {
+      if (actualResult.get(k) != null) {
+        actualResultSimplified.put(k.key(), actualResult.get(k));
+      }
+
+    }
+    assertExpectedResults(actualResultSimplified, expectedResultSimplified);
+  }
+
 }

--- a/ksql-core/src/test/java/io/confluent/ksql/util/OrderDataProvider.java
+++ b/ksql-core/src/test/java/io/confluent/ksql/util/OrderDataProvider.java
@@ -1,0 +1,106 @@
+/**
+ * Copyright 2017 Confluent Inc.
+ **/
+
+package io.confluent.ksql.util;
+
+import io.confluent.ksql.physical.GenericRow;
+import org.apache.kafka.connect.data.Schema;
+import org.apache.kafka.connect.data.SchemaBuilder;
+
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.Map;
+
+public class OrderDataProvider extends TestDataProvider {
+
+  private static final String namePrefix =
+      "ORDER";
+
+  private static final String ksqlSchemaString =
+      "(ORDERTIME bigint, ORDERID varchar, ITEMID varchar, ORDERUNITS double, PRICEARRAY array<double>, KEYVALUEMAP map<varchar, double>)";
+
+  private static final String key = "ORDERTIME";
+
+  private static final Schema schema = SchemaBuilder.struct()
+      .field("ORDERTIME", SchemaBuilder.INT64_SCHEMA)
+      .field("ORDERID", SchemaBuilder.STRING_SCHEMA)
+      .field("ITEMID", SchemaBuilder.STRING_SCHEMA)
+      .field("ORDERUNITS", SchemaBuilder.FLOAT64_SCHEMA)
+      .field("PRICEARRAY", SchemaBuilder.array(SchemaBuilder.FLOAT64_SCHEMA))
+      .field("KEYVALUEMAP", SchemaBuilder.map(SchemaBuilder.STRING_SCHEMA, SchemaBuilder.FLOAT64_SCHEMA)).build();
+
+  private static final Map<String, GenericRow> data = buildData();
+
+  public OrderDataProvider() {
+    super(namePrefix, ksqlSchemaString, key, schema, data);
+  }
+
+  private static Map<String, GenericRow> buildData() {
+
+    Map<String, Double> mapField = new HashMap<>();
+    mapField.put("key1", 1.0);
+    mapField.put("key2", 2.0);
+    mapField.put("key3", 3.0);
+
+    Map<String, GenericRow> dataMap = new HashMap<>();
+    dataMap.put("1", new GenericRow(Arrays.asList(1,
+        "ORDER_1",
+        "ITEM_1", 10.0, new
+            Double[]{100.0,
+            110.99,
+            90.0 },
+        mapField)));
+    dataMap.put("2", new GenericRow(Arrays.asList(2, "ORDER_2",
+        "ITEM_2", 20.0, new
+            Double[]{10.0,
+            10.99,
+            9.0 },
+        mapField)));
+
+    dataMap.put("3", new GenericRow(Arrays.asList(3, "ORDER_3",
+        "ITEM_3", 30.0, new
+            Double[]{10.0,
+            10.99,
+            91.0 },
+        mapField)));
+
+    dataMap.put("4", new GenericRow(Arrays.asList(4, "ORDER_4",
+        "ITEM_4", 40.0, new
+            Double[]{10.0,
+            140.99,
+            94.0 },
+        mapField)));
+
+    dataMap.put("5", new GenericRow(Arrays.asList(5, "ORDER_5",
+        "ITEM_5", 50.0, new
+            Double[]{160.0,
+            160.99,
+            98.0 },
+        mapField)));
+
+    dataMap.put("6", new GenericRow(Arrays.asList(6, "ORDER_6",
+        "ITEM_6", 60.0, new
+            Double[]{1000.0,
+            1100.99,
+            900.0 },
+        mapField)));
+
+    dataMap.put("7", new GenericRow(Arrays.asList(7, "ORDER_6",
+        "ITEM_7", 70.0, new
+            Double[]{1100.0,
+            1110.99,
+            190.0 },
+        mapField)));
+
+    dataMap.put("8", new GenericRow(Arrays.asList(8, "ORDER_6",
+        "ITEM_8", 80.0, new
+            Double[]{1100.0,
+            1110.99,
+            970.0 },
+        mapField)));
+
+    return dataMap;
+  }
+
+}

--- a/ksql-core/src/test/java/io/confluent/ksql/util/TestDataProvider.java
+++ b/ksql-core/src/test/java/io/confluent/ksql/util/TestDataProvider.java
@@ -1,0 +1,52 @@
+/**
+ * Copyright 2017 Confluent Inc.
+ **/
+
+package io.confluent.ksql.util;
+
+import io.confluent.ksql.physical.GenericRow;
+import org.apache.kafka.connect.data.Schema;
+
+import java.util.Map;
+
+public abstract class TestDataProvider {
+  final String topicName;
+  final String ksqlSchemaString;
+  final String key;
+  final Schema schema;
+  final Map<String, GenericRow> data;
+  final String kstreamName;
+
+  public TestDataProvider(String namePrefix, String ksqlSchemaString, String key, Schema schema, Map<String, GenericRow> data) {
+    this.topicName = namePrefix + "_TOPIC";
+    this.kstreamName =  namePrefix + "_KSTREAM";
+    this.ksqlSchemaString = ksqlSchemaString;
+    this.key = key;
+    this.schema = schema;
+    this.data = data;
+  }
+
+  public String topicName() {
+    return topicName;
+  }
+
+  public String ksqlSchemaString() {
+    return ksqlSchemaString;
+  }
+
+  public String key() {
+    return key;
+  }
+
+  public Schema schema() {
+    return schema;
+  }
+
+  public Map<String, GenericRow> data() {
+    return data;
+  }
+
+  public String kstreamName() {
+    return kstreamName;
+  }
+}

--- a/ksql-core/src/test/java/io/confluent/ksql/util/TopicConsumer.java
+++ b/ksql-core/src/test/java/io/confluent/ksql/util/TopicConsumer.java
@@ -1,0 +1,72 @@
+/**
+ * Copyright 2017 Confluent Inc.
+ **/
+
+package io.confluent.ksql.util;
+
+import io.confluent.ksql.physical.GenericRow;
+import io.confluent.ksql.serde.json.KsqlJsonDeserializer;
+import io.confluent.ksql.testutils.EmbeddedSingleNodeKafkaCluster;
+import org.apache.kafka.clients.consumer.ConsumerConfig;
+import org.apache.kafka.clients.consumer.ConsumerRecord;
+import org.apache.kafka.clients.consumer.KafkaConsumer;
+import org.apache.kafka.common.serialization.Deserializer;
+import org.apache.kafka.connect.data.Schema;
+
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Properties;
+
+public class TopicConsumer {
+
+  public static final long RESULTS_POLL_MAX_TIME_MS = 30000;
+  public static final long RESULTS_EXTRA_POLL_TIME_MS = 250;
+
+  private final EmbeddedSingleNodeKafkaCluster cluster;
+
+  public TopicConsumer(EmbeddedSingleNodeKafkaCluster cluster) {
+    this.cluster = cluster;
+  }
+
+  public <K> Map<K, GenericRow> readResults(
+      String topic,
+      Schema schema,
+      int expectedNumMessages,
+      Deserializer<K> keyDeserializer
+  ) {
+    Map<K, GenericRow> result = new HashMap<>();
+
+    Properties consumerConfig = new Properties();
+    consumerConfig.put(ConsumerConfig.BOOTSTRAP_SERVERS_CONFIG, cluster.bootstrapServers());
+    consumerConfig.put(ConsumerConfig.GROUP_ID_CONFIG, "filter-integration-test-standard-consumer");
+    consumerConfig.put(ConsumerConfig.AUTO_OFFSET_RESET_CONFIG, "earliest");
+
+    try (KafkaConsumer<K, GenericRow> consumer =
+             new KafkaConsumer<>(consumerConfig, keyDeserializer, new KsqlJsonDeserializer(schema))
+    ) {
+      consumer.subscribe(Collections.singleton(topic));
+      long pollStart = System.currentTimeMillis();
+      long pollEnd = pollStart + RESULTS_POLL_MAX_TIME_MS;
+      while (System.currentTimeMillis() < pollEnd && continueConsuming(result.size(), expectedNumMessages)) {
+        for (ConsumerRecord<K, GenericRow> record : consumer.poll(Math.max(1, pollEnd - System.currentTimeMillis()))) {
+          if (record.value() != null) {
+            result.put(record.key(), record.value());
+          }
+        }
+      }
+
+      for (ConsumerRecord<K, GenericRow> record : consumer.poll(RESULTS_EXTRA_POLL_TIME_MS)) {
+        if (record.value() != null) {
+          result.put(record.key(), record.value());
+        }
+      }
+    }
+    return result;
+  }
+
+  private static boolean continueConsuming(int messagesConsumed, int maxMessages) {
+    return maxMessages < 0 || messagesConsumed < maxMessages;
+  }
+
+}

--- a/ksql-core/src/test/java/io/confluent/ksql/util/TopicProducer.java
+++ b/ksql-core/src/test/java/io/confluent/ksql/util/TopicProducer.java
@@ -1,0 +1,76 @@
+/**
+ * Copyright 2017 Confluent Inc.
+ **/
+
+package io.confluent.ksql.util;
+
+import io.confluent.ksql.physical.GenericRow;
+import io.confluent.ksql.serde.json.KsqlJsonSerializer;
+import io.confluent.ksql.testutils.EmbeddedSingleNodeKafkaCluster;
+import org.apache.kafka.clients.producer.KafkaProducer;
+import org.apache.kafka.clients.producer.ProducerConfig;
+import org.apache.kafka.clients.producer.ProducerRecord;
+import org.apache.kafka.clients.producer.RecordMetadata;
+import org.apache.kafka.common.serialization.StringSerializer;
+import org.apache.kafka.connect.data.Schema;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Properties;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.Future;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
+
+public class TopicProducer {
+
+  public static final long TEST_RECORD_FUTURE_TIMEOUT_MS = 5000;
+
+  private final EmbeddedSingleNodeKafkaCluster cluster;
+  private final Properties producerConfig;
+
+  public TopicProducer(EmbeddedSingleNodeKafkaCluster cluster) {
+    this.cluster = cluster;
+
+    this.producerConfig = new Properties();
+    producerConfig.put(ProducerConfig.BOOTSTRAP_SERVERS_CONFIG, cluster.bootstrapServers());
+    producerConfig.put(ProducerConfig.ACKS_CONFIG, "all");
+    producerConfig.put(ProducerConfig.RETRIES_CONFIG, 0);
+  }
+
+  /**
+   * Topic topicName will be automatically created if it doesn't exist.
+   * @param topicName
+   * @param recordsToPublish
+   * @param schema
+   * @return
+   * @throws InterruptedException
+   * @throws TimeoutException
+   * @throws ExecutionException
+   */
+  public Map<String, RecordMetadata> produceInputData(String topicName, Map<String, GenericRow> recordsToPublish, Schema schema)
+      throws InterruptedException, TimeoutException, ExecutionException {
+
+    KafkaProducer<String, GenericRow> producer =
+        new KafkaProducer<>(producerConfig, new StringSerializer(), new KsqlJsonSerializer(schema));
+
+    Map<String, RecordMetadata> result = new HashMap<>();
+    for (Map.Entry<String, GenericRow> recordEntry : recordsToPublish.entrySet()) {
+      String key = recordEntry.getKey();
+      ProducerRecord<String, GenericRow> producerRecord = new ProducerRecord<>(topicName, key, recordEntry.getValue());
+      Future<RecordMetadata> recordMetadataFuture = producer.send(producerRecord);
+      result.put(key, recordMetadataFuture.get(TEST_RECORD_FUTURE_TIMEOUT_MS, TimeUnit.MILLISECONDS));
+    }
+    producer.close();
+
+    return result;
+  }
+
+  /**
+   * Produce input data to the topic named dataProvider.topicName()
+   */
+  public Map<String, RecordMetadata> produceInputData(TestDataProvider dataProvider) throws Exception {
+    return produceInputData(dataProvider.topicName(), dataProvider.data(), dataProvider.schema());
+  }
+
+}

--- a/ksql-rest-app/src/main/java/io/confluent/ksql/rest/server/KsqlRestApplication.java
+++ b/ksql-rest-app/src/main/java/io/confluent/ksql/rest/server/KsqlRestApplication.java
@@ -63,8 +63,8 @@ public class KsqlRestApplication extends Application<KsqlRestConfig> {
 
   private static final Logger log = LoggerFactory.getLogger(KsqlRestApplication.class);
 
-  private static final String COMMANDS_KSQL_TOPIC_NAME = "__KSQL_COMMANDS_TOPIC";
-  private static final String COMMANDS_STREAM_NAME = "KSQL_COMMANDS";
+  public static final String COMMANDS_KSQL_TOPIC_NAME = "__KSQL_COMMANDS_TOPIC";
+  public static final String COMMANDS_STREAM_NAME = "KSQL_COMMANDS";
 
   private final KsqlEngine ksqlEngine;
   private final CommandRunner commandRunner;
@@ -173,8 +173,9 @@ public class KsqlRestApplication extends Application<KsqlRestConfig> {
       return;
     }
 
-    Properties props = getProps(cliOptions.getPropertiesFile());
-    KsqlRestApplication app = buildApplication(props, cliOptions.getQuickstart());
+    KsqlRestConfig restConfig = new KsqlRestConfig(getProps(cliOptions.getPropertiesFile()));
+    KsqlRestApplication app = buildApplication(restConfig, cliOptions.getQuickstart());
+
     log.info("Starting server");
     app.start();
     log.info("Server up and running");
@@ -182,9 +183,8 @@ public class KsqlRestApplication extends Application<KsqlRestConfig> {
     log.info("Server shutting down");
   }
 
-  public static KsqlRestApplication buildApplication(Properties props, boolean quickstart)
+  public static KsqlRestApplication buildApplication(KsqlRestConfig restConfig, boolean quickstart)
       throws Exception {
-    KsqlRestConfig restConfig = new KsqlRestConfig(props);
 
     Map<String, Object> ksqlConfProperties = new HashMap<>();
     ksqlConfProperties.putAll(restConfig.getCommandConsumerProperties());

--- a/ksql-rest-app/src/test/java/io/confluent/ksql/rest/server/resources/StreamedQueryResourceTest.java
+++ b/ksql-rest-app/src/test/java/io/confluent/ksql/rest/server/resources/StreamedQueryResourceTest.java
@@ -35,7 +35,7 @@ import static org.easymock.EasyMock.expectLastCall;
 import static org.easymock.EasyMock.mock;
 import static org.easymock.EasyMock.replay;
 import static org.easymock.EasyMock.verify;
-import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.assertEquals;
 
 public class StreamedQueryResourceTest {
 
@@ -138,7 +138,7 @@ public class StreamedQueryResourceTest {
           expectedRow = writtenRows.poll();
         }
         GenericRow testRow = objectMapper.readValue(responseLine, StreamedRow.class).getRow();
-        assertTrue(expectedRow.hasTheSameContent(testRow));
+        assertEquals(expectedRow, testRow);
       }
     }
 


### PR DESCRIPTION
It is a large PR related to end-to-end-integration-tests. Following tasks are done in this PR:

1. Add end-to-end test utility classes, e.g. TestResult, TestRunner.
2. Refactor JsonFormatTest to extract its data setup methods to DataProvider classes. 
3. Minor refactoring on Cli and KsqlRestApplication classes, e.g. passing restServer as arg to localCli class, making rest app to accept rest config as arg.