### PR TITLE
Stream Table join results in null data - fixed by resetting offset to EARLIEST

### DIFF
--- a/ksql-clickstream-demo/demo/clickstream-schema.sql
+++ b/ksql-clickstream-demo/demo/clickstream-schema.sql
@@ -1,6 +1,7 @@
 -- lets the windows accumulate more data
 set 'commit.interval.ms'='2000';
 set 'cache.max.bytes.buffering'='10000000';
+set 'auto.offset.reset'='earliest';
 
 
 -- 1. SOURCE of ClickStream


### PR DESCRIPTION
Stream Table join results in null data - fixed by resetting offset to EARLIEST