### PR TITLE
[EXPERIMENTAL] ksql metrics reporter framework

### DIFF
--- a/ksql-cli/src/main/java/io/confluent/ksql/cli/StandaloneExecutor.java
+++ b/ksql-cli/src/main/java/io/confluent/ksql/cli/StandaloneExecutor.java
@@ -48,14 +48,14 @@ public class StandaloneExecutor {
   public void executeStatements(String queries) throws Exception {
     MetaStore tempMetaStore = ksqlEngine.getMetaStore().clone();
     List<Pair<String, Statement>> queryList = ksqlEngine.parseQueries(queries,
-                                                                      Collections.emptyMap(),
-                                                                      tempMetaStore);
+        Collections.emptyMap(),
+        tempMetaStore);
     List<QueryMetadata> queryMetadataList = ksqlEngine.planQueries(
         false, queryList, new HashMap<>(), tempMetaStore);
     for (QueryMetadata queryMetadata: queryMetadataList) {
       if (queryMetadata instanceof PersistentQueryMetadata) {
         PersistentQueryMetadata persistentQueryMetadata = (PersistentQueryMetadata) queryMetadata;
-        persistentQueryMetadata.getKafkaStreams().start();
+        persistentQueryMetadata.start();
       } else {
         System.err.println("Ignoring statemenst: " + queryMetadata.getStatementString());
         System.err.println("Only CREATE statements can run in KSQL embedded mode.");

--- a/ksql-core/src/main/java/io/confluent/ksql/KsqlContext.java
+++ b/ksql-core/src/main/java/io/confluent/ksql/KsqlContext.java
@@ -74,7 +74,7 @@ public class KsqlContext {
     for (QueryMetadata queryMetadata: queryMetadataList) {
       if (queryMetadata instanceof PersistentQueryMetadata) {
         PersistentQueryMetadata persistentQueryMetadata = (PersistentQueryMetadata) queryMetadata;
-        persistentQueryMetadata.getKafkaStreams().start();
+        persistentQueryMetadata.start();
         ksqlEngine.getPersistentQueries()
             .put(persistentQueryMetadata.getId(), persistentQueryMetadata);
       } else {
@@ -98,7 +98,7 @@ public class KsqlContext {
     }
     PersistentQueryMetadata persistentQueryMetadata = ksqlEngine
         .getPersistentQueries().get(queryId);
-    persistentQueryMetadata.getKafkaStreams().close();
+    persistentQueryMetadata.closeAndCleanUp();
     ksqlEngine.getPersistentQueries().remove(queryId);
   }
 

--- a/ksql-core/src/main/java/io/confluent/ksql/QueryEngine.java
+++ b/ksql-core/src/main/java/io/confluent/ksql/QueryEngine.java
@@ -259,9 +259,11 @@ public class QueryEngine {
           streams,
           ksqlBareOutputNode,
           schemaKStream.getExecutionPlan(""),
+          getNextQueryId(),
           queuedSchemaKStream.getQueue(),
           (sourceSchemaKstream instanceof SchemaKTable)?
-          DataSource.DataSourceType.KTABLE: DataSource.DataSourceType.KSTREAM
+          DataSource.DataSourceType.KTABLE: DataSource.DataSourceType.KSTREAM,
+          ksqlEngine.getKsqlMetrics()
       ));
 
     } else if (outputNode instanceof KsqlStructuredDataOutputNode) {
@@ -283,7 +285,8 @@ public class QueryEngine {
                                       streams, kafkaTopicOutputNode, schemaKStream
                                           .getExecutionPlan(""), queryId,
                                       (schemaKStream instanceof SchemaKTable)? DataSource
-                                          .DataSourceType.KTABLE: DataSource.DataSourceType.KSTREAM)
+                                          .DataSourceType.KTABLE: DataSource.DataSourceType.KSTREAM,
+                                      ksqlEngine.getKsqlMetrics())
       );
 
       MetaStore metaStore = ksqlEngine.getMetaStore();

--- a/ksql-core/src/main/java/io/confluent/ksql/metrics/KsqlMetrics.java
+++ b/ksql-core/src/main/java/io/confluent/ksql/metrics/KsqlMetrics.java
@@ -1,0 +1,44 @@
+/**
+ * Copyright 2017 Confluent Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ **/
+
+package io.confluent.ksql.metrics;
+
+import org.apache.kafka.common.metrics.JmxReporter;
+import org.apache.kafka.common.metrics.MetricsReporter;
+
+import java.util.ArrayList;
+import java.util.List;
+
+public class KsqlMetrics {
+  private static final String JMX_PREFIX = "ksql";
+  private final long serverId;
+  private final List<MetricsReporter> reporters;
+
+  public KsqlMetrics(long serverId) {
+    // TODO: make the reporter class configurable, e.g.
+    // config.getConfiguredInstances(ProducerConfig.METRIC_REPORTER_CLASSES_CONFIG, MetricsReporter.class);
+    List<MetricsReporter> reporters = new ArrayList<>();
+    reporters.add(new JmxReporter(JMX_PREFIX));
+
+    this.serverId = serverId;
+    this.reporters = reporters;
+  }
+
+  public QueryMetric addQueryMetric(String queryDescription) {
+    return new QueryMetric(queryDescription, serverId, reporters);
+  }
+
+}

--- a/ksql-core/src/main/java/io/confluent/ksql/metrics/QueryMetric.java
+++ b/ksql-core/src/main/java/io/confluent/ksql/metrics/QueryMetric.java
@@ -1,0 +1,64 @@
+/**
+ * Copyright 2017 Confluent Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ **/
+
+package io.confluent.ksql.metrics;
+
+import org.apache.kafka.common.MetricName;
+import org.apache.kafka.common.metrics.Measurable;
+import org.apache.kafka.common.metrics.MetricConfig;
+import org.apache.kafka.common.metrics.Metrics;
+import org.apache.kafka.common.metrics.MetricsReporter;
+import org.apache.kafka.common.metrics.Sensor;
+import org.apache.kafka.common.utils.Time;
+
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+
+public class QueryMetric {
+  private final Metrics metrics;
+  private static final Time time = Time.SYSTEM;
+
+  public QueryMetric(String queryDescription, long serverId, List<MetricsReporter> reporters) {
+    Map<String, String> metricTags = new LinkedHashMap<>();
+    metricTags.put("query-description", queryDescription);
+    metricTags.put("server-id", "Server-" + serverId);
+
+    MetricConfig metricConfig = new MetricConfig().tags(metricTags);
+    this.metrics = new Metrics(metricConfig, reporters, time);
+  }
+
+  public MetricName metricName(String name, String group, String description) {
+    return metrics.metricName(name, group, description);
+  }
+
+  public void addMeasurableMetric(MetricName metricName, Measurable measurable) {
+    metrics.addMetric(metricName, measurable);
+  }
+
+  public void removeMetric(MetricName metricName) {
+    metrics.removeMetric(metricName);
+  }
+
+  public void removeSensor(String sensorName) {
+    metrics.removeSensor(sensorName);
+  }
+
+  public Sensor getOrCreateSensor(String sensorName) {
+    return metrics.sensor(sensorName);
+  }
+
+}

--- a/ksql-core/src/main/java/io/confluent/ksql/util/PersistentQueryMetadata.java
+++ b/ksql-core/src/main/java/io/confluent/ksql/util/PersistentQueryMetadata.java
@@ -17,6 +17,7 @@
 package io.confluent.ksql.util;
 
 import io.confluent.ksql.metastore.DataSource;
+import io.confluent.ksql.metrics.KsqlMetrics;
 import io.confluent.ksql.planner.plan.OutputNode;
 import org.apache.kafka.streams.KafkaStreams;
 
@@ -29,8 +30,9 @@ public class PersistentQueryMetadata extends QueryMetadata {
 
   public PersistentQueryMetadata(String statementString, KafkaStreams kafkaStreams,
                                  OutputNode outputNode, String executionPlan, long id,
-                                 DataSource.DataSourceType dataSourceType) {
-    super(statementString, kafkaStreams, outputNode, executionPlan, dataSourceType);
+                                 DataSource.DataSourceType dataSourceType, KsqlMetrics ksqlMetrics) {
+    super(statementString, kafkaStreams, outputNode, executionPlan, dataSourceType, ksqlMetrics,
+        "PersistentQuery-" + id);
     this.id = id;
 
   }

--- a/ksql-core/src/main/java/io/confluent/ksql/util/QueuedQueryMetadata.java
+++ b/ksql-core/src/main/java/io/confluent/ksql/util/QueuedQueryMetadata.java
@@ -17,6 +17,7 @@
 package io.confluent.ksql.util;
 
 import io.confluent.ksql.metastore.DataSource;
+import io.confluent.ksql.metrics.KsqlMetrics;
 import io.confluent.ksql.physical.GenericRow;
 import io.confluent.ksql.planner.plan.OutputNode;
 import org.apache.kafka.streams.KafkaStreams;
@@ -28,17 +29,22 @@ import java.util.concurrent.SynchronousQueue;
 public class QueuedQueryMetadata extends QueryMetadata {
 
   private final SynchronousQueue<KeyValue<String, GenericRow>> rowQueue;
+  private final long id;
 
   public QueuedQueryMetadata(
       String statementString,
       KafkaStreams kafkaStreams,
       OutputNode outputNode,
       String executionPlan,
+      long id,
       SynchronousQueue<KeyValue<String, GenericRow>> rowQueue,
-      DataSource.DataSourceType dataSourceType
+      DataSource.DataSourceType dataSourceType,
+      KsqlMetrics ksqlMetrics
   ) {
-    super(statementString, kafkaStreams, outputNode, executionPlan, dataSourceType);
+    super(statementString, kafkaStreams, outputNode, executionPlan, dataSourceType, ksqlMetrics,
+        "QueuedQuery-" + id);
     this.rowQueue = rowQueue;
+    this.id = id;
   }
 
   public SynchronousQueue<KeyValue<String, GenericRow>> getRowQueue() {

--- a/ksql-core/src/test/java/io/confluent/ksql/integtests/json/JsonFormatTest.java
+++ b/ksql-core/src/test/java/io/confluent/ksql/integtests/json/JsonFormatTest.java
@@ -145,7 +145,7 @@ public class JsonFormatTest {
 
     PersistentQueryMetadata queryMetadata =
         (PersistentQueryMetadata) ksqlEngine.buildMultipleQueries(true, queryString, Collections.emptyMap()).get(0);
-    queryMetadata.getKafkaStreams().start();
+    queryMetadata.start();
 
     Schema resultSchema = SchemaUtil
         .removeImplicitRowTimeRowKeyFromSchema(metaStore.getSource(streamName).getSchema());
@@ -165,7 +165,7 @@ public class JsonFormatTest {
 
     PersistentQueryMetadata queryMetadata =
         (PersistentQueryMetadata) ksqlEngine.buildMultipleQueries(true, queryString, Collections.emptyMap()).get(0);
-    queryMetadata.getKafkaStreams().start();
+    queryMetadata.start();
 
     Schema resultSchema = SchemaUtil
         .removeImplicitRowTimeRowKeyFromSchema(metaStore.getSource(streamName).getSchema());
@@ -228,7 +228,7 @@ public class JsonFormatTest {
 
     PersistentQueryMetadata queryMetadata =
         (PersistentQueryMetadata) ksqlEngine.buildMultipleQueries(true, queryString, Collections.emptyMap()).get(0);
-    queryMetadata.getKafkaStreams().start();
+    queryMetadata.start();
 
     Schema resultSchema = SchemaUtil
         .removeImplicitRowTimeRowKeyFromSchema(metaStore.getSource(streamName).getSchema());
@@ -264,8 +264,8 @@ public class JsonFormatTest {
     PersistentQueryMetadata query1Metadata = (PersistentQueryMetadata) queryMetadataList.get(0);
     PersistentQueryMetadata query2Metadata = (PersistentQueryMetadata) queryMetadataList.get(1);
 
-    query1Metadata.getKafkaStreams().start();
-    query2Metadata.getKafkaStreams().start();
+    query1Metadata.start();
+    query2Metadata.start();
 
     Schema resultSchema = SchemaUtil
         .removeImplicitRowTimeRowKeyFromSchema(metaStore.getSource(stream2Name).getSchema());
@@ -300,7 +300,7 @@ public class JsonFormatTest {
 
     PersistentQueryMetadata queryMetadata =
         (PersistentQueryMetadata) ksqlEngine.buildMultipleQueries(true, queryString, Collections.emptyMap()).get(0);
-    queryMetadata.getKafkaStreams().start();
+    queryMetadata.start();
 
     Schema resultSchema = SchemaUtil
         .removeImplicitRowTimeRowKeyFromSchema(metaStore.getSource(streamName).getSchema());
@@ -343,7 +343,7 @@ public class JsonFormatTest {
 
     PersistentQueryMetadata queryMetadata =
         (PersistentQueryMetadata) ksqlEngine.buildMultipleQueries(true, queryString, Collections.emptyMap()).get(0);
-    queryMetadata.getKafkaStreams().start();
+    queryMetadata.start();
 
     Schema resultSchema = SchemaUtil
         .removeImplicitRowTimeRowKeyFromSchema(metaStore.getSource(streamName).getSchema());
@@ -379,7 +379,7 @@ public class JsonFormatTest {
 
     PersistentQueryMetadata queryMetadata =
         (PersistentQueryMetadata) ksqlEngine.buildMultipleQueries(true, queryString, Collections.emptyMap()).get(0);
-    queryMetadata.getKafkaStreams().start();
+    queryMetadata.start();
 
     Schema resultSchema = SchemaUtil
         .removeImplicitRowTimeRowKeyFromSchema(metaStore.getSource(streamName).getSchema());
@@ -414,7 +414,7 @@ public class JsonFormatTest {
 
     PersistentQueryMetadata queryMetadata =
         (PersistentQueryMetadata) ksqlEngine.buildMultipleQueries(true, queryString, Collections.emptyMap()).get(0);
-    queryMetadata.getKafkaStreams().start();
+    queryMetadata.start();
 
     Schema resultSchema = SchemaUtil
         .removeImplicitRowTimeRowKeyFromSchema(metaStore.getSource(streamName).getSchema());
@@ -448,7 +448,7 @@ public class JsonFormatTest {
 
     PersistentQueryMetadata queryMetadata =
         (PersistentQueryMetadata) ksqlEngine.buildMultipleQueries(true, queryString, Collections.emptyMap()).get(0);
-    queryMetadata.getKafkaStreams().start();
+    queryMetadata.start();
 
     Schema resultSchema = SchemaUtil
         .removeImplicitRowTimeRowKeyFromSchema(metaStore.getSource(streamName).getSchema());
@@ -470,8 +470,8 @@ public class JsonFormatTest {
 
     final String selectColumns =
         "(ORDERTIME+1500962514806) , TIMESTAMPTOSTRING(ORDERTIME+1500962514806, "
-        + "'yyyy-MM-dd HH:mm:ss.SSS'), "
-        + "STRINGTOTIMESTAMP"
+            + "'yyyy-MM-dd HH:mm:ss.SSS'), "
+            + "STRINGTOTIMESTAMP"
             + "(TIMESTAMPTOSTRING"
             + "(ORDERTIME+1500962514806, 'yyyy-MM-dd HH:mm:ss.SSS'), 'yyyy-MM-dd HH:mm:ss.SSS')";
     final String whereClause = "ORDERUNITS > 20 AND ITEMID LIKE '%_8'";
@@ -486,7 +486,7 @@ public class JsonFormatTest {
 
     PersistentQueryMetadata queryMetadata =
         (PersistentQueryMetadata) ksqlEngine.buildMultipleQueries(true, queryString, Collections.emptyMap()).get(0);
-    queryMetadata.getKafkaStreams().start();
+    queryMetadata.start();
 
     Schema resultSchema = SchemaUtil
         .removeImplicitRowTimeRowKeyFromSchema(metaStore.getSource(streamName).getSchema());
@@ -528,7 +528,7 @@ public class JsonFormatTest {
 
     PersistentQueryMetadata queryMetadata =
         (PersistentQueryMetadata) ksqlEngine.buildMultipleQueries(true, queryString, Collections.emptyMap()).get(0);
-    queryMetadata.getKafkaStreams().start();
+    queryMetadata.start();
     Schema resultSchema = SchemaUtil
         .removeImplicitRowTimeRowKeyFromSchema(ksqlEngine.getMetaStore().getSource(streamName).getSchema());
 
@@ -561,7 +561,7 @@ public class JsonFormatTest {
 
     PersistentQueryMetadata queryMetadata =
         (PersistentQueryMetadata) ksqlEngine.buildMultipleQueries(true, queryString, Collections.emptyMap()).get(0);
-    queryMetadata.getKafkaStreams().start();
+    queryMetadata.start();
 
     KafkaTopicClient kafkaTopicClient = ksqlEngine.getKafkaTopicClient();
 
@@ -588,7 +588,7 @@ public class JsonFormatTest {
 
     PersistentQueryMetadata queryMetadata =
         (PersistentQueryMetadata) ksqlEngine.buildMultipleQueries(true, queryString, Collections.emptyMap()).get(0);
-    queryMetadata.getKafkaStreams().start();
+    queryMetadata.start();
 
     Schema resultSchema = SchemaUtil
         .removeImplicitRowTimeRowKeyFromSchema(metaStore.getSource(streamName).getSchema());

--- a/ksql-rest-app/src/main/java/io/confluent/ksql/rest/server/computation/StatementExecutor.java
+++ b/ksql-rest-app/src/main/java/io/confluent/ksql/rest/server/computation/StatementExecutor.java
@@ -189,7 +189,7 @@ public class StatementExecutor {
 
   /**
    * Attempt to execute a single statement.
-//   * @param statementString The string containing the statement to be executed
+   //   * @param statementString The string containing the statement to be executed
    * @param command The string containing the statement to be executed
    * @param commandId The ID to be used to track the status of the command
    * @param terminatedQueries An optional map from terminated query IDs to the commands that
@@ -284,11 +284,11 @@ public class StatementExecutor {
         String queries =
             (String) command.getStreamsProperties().get(DdlConfig.SCHEMA_FILE_CONTENT_PROPERTY);
         List<QueryMetadata> queryMetadataList = ksqlEngine.buildMultipleQueries(false, queries,
-                                            command.getStreamsProperties());
+            command.getStreamsProperties());
         for (QueryMetadata queryMetadata : queryMetadataList) {
           if (queryMetadata instanceof PersistentQueryMetadata) {
             PersistentQueryMetadata persistentQueryMetadata = (PersistentQueryMetadata) queryMetadata;
-            persistentQueryMetadata.getKafkaStreams().start();
+            persistentQueryMetadata.start();
           }
         }
       } else {
@@ -348,7 +348,7 @@ public class StatementExecutor {
         ksqlEngine.terminateQuery(queryId, false);
         return false;
       } else {
-        persistentQueryMetadata.getKafkaStreams().start();
+        persistentQueryMetadata.start();
         return true;
       }
 

--- a/ksql-rest-app/src/main/java/io/confluent/ksql/rest/server/resources/streaming/QueryStreamWriter.java
+++ b/ksql-rest-app/src/main/java/io/confluent/ksql/rest/server/resources/streaming/QueryStreamWriter.java
@@ -62,9 +62,9 @@ class QueryStreamWriter implements StreamingOutput {
     this.queryMetadata = ((QueuedQueryMetadata) queryMetadata);
 
     this.streamsException = new AtomicReference<>(null);
-    this.queryMetadata.getKafkaStreams().setUncaughtExceptionHandler(new StreamsExceptionHandler());
+    this.queryMetadata.setUncaughtExceptionHandler(new StreamsExceptionHandler());
 
-    queryMetadata.getKafkaStreams().start();
+    this.queryMetadata.start();
   }
 
   @Override
@@ -128,8 +128,7 @@ class QueryStreamWriter implements StreamingOutput {
       }
 
     } finally {
-      queryMetadata.getKafkaStreams().close(100L, TimeUnit.MILLISECONDS);
-      queryMetadata.getKafkaStreams().cleanUp();
+      queryMetadata.closeAndCleanUp(100L, TimeUnit.MILLISECONDS);
     }
   }
 

--- a/ksql-rest-app/src/test/java/io/confluent/ksql/rest/server/resources/StreamedQueryResourceTest.java
+++ b/ksql-rest-app/src/test/java/io/confluent/ksql/rest/server/resources/StreamedQueryResourceTest.java
@@ -26,6 +26,7 @@ import io.confluent.ksql.rest.entity.KsqlRequest;
 import io.confluent.ksql.rest.entity.StreamedRow;
 import io.confluent.ksql.rest.server.StatementParser;
 import io.confluent.ksql.rest.server.resources.streaming.StreamedQueryResource;
+import io.confluent.ksql.metrics.KsqlMetrics;
 import io.confluent.ksql.util.QueuedQueryMetadata;
 import org.apache.kafka.connect.data.SchemaBuilder;
 import org.apache.kafka.streams.KafkaStreams;
@@ -102,8 +103,8 @@ public class StreamedQueryResourceTest {
         .andReturn(SchemaBuilder.struct().field("f1", SchemaBuilder.INT32_SCHEMA));
 
     final QueuedQueryMetadata queuedQueryMetadata =
-        new QueuedQueryMetadata(queryString, mockKafkaStreams, mockOutputNode, "",
-                                rowQueue, DataSource.DataSourceType.KSTREAM);
+        new QueuedQueryMetadata(queryString, mockKafkaStreams, mockOutputNode, "", 1L,
+            rowQueue, DataSource.DataSourceType.KSTREAM, new KsqlMetrics(1));
 
     final Map<String, Object> requestStreamsProperties = Collections.emptyMap();
 


### PR DESCRIPTION
Note: This PR starts the prototype of a metrics reporter framework in ksql. Currently we do not recommend to merge this PR as the details of a fully functional metrics reporter framework still needs more discussions.

Changes made in this PR:
1. Add "metrics" package: each KsqlEngine contains a KsqlMetrics instance and each query contains a QueryMetric instance.
2. Add initial tracking metrics (start-timestamp, running-seconds, executed-seconds) to QueryMetadata class.
3. Minor cleanups: call "closeAndCleanUp" when a query finishes as a single step. 

We utilize metric lib implemented in "org.apache.kafka.common.metrics" to add new metrics.
This framework does not limit specific ways to show metrics, but using JMX is easiest (and is already supported by lib).

Related Tickets: [KSQL-340](https://confluentinc.atlassian.net/browse/KSQL-340), [KSQL-341](https://confluentinc.atlassian.net/browse/KSQL-341), [KSQL-342](https://confluentinc.atlassian.net/browse/KSQL-342).