### PR TITLE
Add bootstrap server option to sample

### DIFF
--- a/docs/quickstart/quickstart-non-docker.md
+++ b/docs/quickstart/quickstart-non-docker.md
@@ -60,7 +60,7 @@ connect is [UP]
 1.  Start KSQL. The `local` argument starts the KSQL engine locally.
 
     ```bash
-    $ ./bin/ksql-cli local
+    $ ./bin/ksql-cli local --bootstrap-server=localhost:9092
     ```
 
     After KSQL is started, your terminal should resemble this.


### PR DESCRIPTION
In my initial play, the console was stuck after entering the command `ksql-cli local` without any extra information provided. Eventually realized that the bootstrap-server can be updated by going through the code. 
