### PR TITLE
Fix datagen docker components

### DIFF
--- a/docs/quickstart/docker-compose.yml
+++ b/docs/quickstart/docker-compose.yml
@@ -68,9 +68,9 @@ services:
                        cub sr-ready schema-registry 8081 20 && \
                        echo Waiting a few seconds for topic creation to finish... && \
                        sleep 2 && \
-                       java -jar /usr/share/java/ksql-examples/ksql-examples-4.0.0-SNAPSHOT-standalone.jar
+                       java -jar /usr/share/java/ksql-examples/ksql-examples-0.1-SNAPSHOT-standalone.jar
                        quickstart=pageviews format=delimited topic=pageviews bootstrap-server=kafka:29092 maxInterval=100 iterations=1000 && \
-                       java -jar /usr/share/java/ksql-examples/ksql-examples-4.0.0-SNAPSHOT-standalone.jar
+                       java -jar /usr/share/java/ksql-examples/ksql-examples-0.1-SNAPSHOT-standalone.jar
                        quickstart=pageviews format=delimited topic=pageviews bootstrap-server=kafka:29092 maxInterval=1000'"
     environment:
       KSQL_CONFIG_DIR: "/etc/ksql"
@@ -98,9 +98,9 @@ services:
                        cub sr-ready schema-registry 8081 20 && \
                        echo Waiting a few seconds for topic creation to finish... && \
                        sleep 2 && \
-                       java -jar /usr/share/java/ksql-examples/ksql-examples-4.0.0-SNAPSHOT-standalone.jar
+                       java -jar /usr/share/java/ksql-examples/ksql-examples-0.1-SNAPSHOT-standalone.jar
                        quickstart=users format=json topic=users bootstrap-server=kafka:29092 maxInterval=100 iterations=1000 && \
-                       java -jar /usr/share/java/ksql-examples/ksql-examples-4.0.0-SNAPSHOT-standalone.jar
+                       java -jar /usr/share/java/ksql-examples/ksql-examples-0.1-SNAPSHOT-standalone.jar
                        quickstart=users format=json topic=users bootstrap-server=kafka:29092 maxInterval=1000'"
     environment:
       KSQL_CONFIG_DIR: "/etc/ksql"


### PR DESCRIPTION
The datagen components used to crash write after they started because
there was no ksql-examples-4.0.0-SNAPSHOT-standalone.jar file.
The current version of the jar file is 0.1-SNAPSHOT which can be used
correctly launch the datagen components