### PR TITLE
use mapValues instead of map in SchemaKStream.select

### DIFF
--- a/ksql-engine/src/main/java/io/confluent/ksql/structured/SchemaKStream.java
+++ b/ksql-engine/src/main/java/io/confluent/ksql/structured/SchemaKStream.java
@@ -108,17 +108,15 @@ public class SchemaKStream {
   }
 
   public SchemaKStream select(final Schema selectSchema) {
-
     final KStream<String, GenericRow>
         projectedKStream =
-        kstream.map((KeyValueMapper<String, GenericRow, KeyValue<String, GenericRow>>) (key, row) -> {
+        kstream.mapValues(row -> {
           List<Object> newColumns = new ArrayList<>();
           for (Field schemaField : selectSchema.fields()) {
             newColumns.add(
                 row.getColumns().get(SchemaUtil.getFieldIndexByName(schema, schemaField.name())));
           }
-          GenericRow newRow = new GenericRow(newColumns);
-          return new KeyValue<>(key, newRow);
+          return new GenericRow(newColumns);
         });
 
     return new SchemaKStream(selectSchema, projectedKStream, keyField, Collections.singletonList(this),


### PR DESCRIPTION
As we are not changing the key during select, there is no point in using `map`. Using `mapValues` will avoid a re-partitioning event if the resulting stream is joined.