### PR TITLE
remove checkstlye build plugin as it is provided by the parent pom

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -229,16 +229,6 @@
                         </descriptors>
                     </configuration>
                 </plugin>
-
-                <plugin>
-                    <groupId>org.apache.maven.plugins</groupId>
-                    <artifactId>maven-checkstyle-plugin</artifactId>
-                    <configuration>
-                        <failsOnError>true</failsOnError>
-                        <failOnViolation>true</failOnViolation>
-                    </configuration>
-                </plugin>
-
                 <plugin>
                     <groupId>net.alchim31.maven</groupId>
                     <artifactId>scala-maven-plugin</artifactId>


### PR DESCRIPTION
confluent-common provides the configuration for checkstyle, so we don't need to add it as a build plugin. We keep the separate config for the suppressions