### PR TITLE
KSQL-398: integration test covering quickstart scenarios

### DIFF
--- a/ksql-engine/src/main/java/io/confluent/ksql/KsqlContext.java
+++ b/ksql-engine/src/main/java/io/confluent/ksql/KsqlContext.java
@@ -112,10 +112,6 @@ public class KsqlContext {
     return ksqlEngine.getLiveQueries();
   }
 
-  public KsqlEngine getKsqlEngine() {
-    return ksqlEngine;
-  }
-
   public void close() throws IOException {
     ksqlEngine.close();
     topicClient.close();

--- a/ksql-engine/src/main/java/io/confluent/ksql/KsqlContext.java
+++ b/ksql-engine/src/main/java/io/confluent/ksql/KsqlContext.java
@@ -111,6 +111,10 @@ public class KsqlContext {
   public Set<QueryMetadata> getRunningQueries() {
     return ksqlEngine.getLiveQueries();
   }
+  
+  public KsqlEngine getKsqlEngine() {
+    return ksqlEngine;
+  }
 
   public void close() throws IOException {
     ksqlEngine.close();

--- a/ksql-engine/src/main/java/io/confluent/ksql/KsqlContext.java
+++ b/ksql-engine/src/main/java/io/confluent/ksql/KsqlContext.java
@@ -111,7 +111,7 @@ public class KsqlContext {
   public Set<QueryMetadata> getRunningQueries() {
     return ksqlEngine.getLiveQueries();
   }
-  
+
   public KsqlEngine getKsqlEngine() {
     return ksqlEngine;
   }

--- a/ksql-engine/src/main/java/io/confluent/ksql/analyzer/Analyzer.java
+++ b/ksql-engine/src/main/java/io/confluent/ksql/analyzer/Analyzer.java
@@ -321,7 +321,7 @@ public class Analyzer extends DefaultTraversalVisitor<Node, AnalysisContext> {
 
     StructuredDataSource into;
     if (node.isStdOut) {
-      into =
+        into =
           new KsqlStdOut(KsqlStdOut.KSQL_STDOUT_NAME, null, null,
                          null, StructuredDataSource.DataSourceType.KSTREAM);
 

--- a/ksql-engine/src/main/java/io/confluent/ksql/analyzer/Analyzer.java
+++ b/ksql-engine/src/main/java/io/confluent/ksql/analyzer/Analyzer.java
@@ -321,10 +321,8 @@ public class Analyzer extends DefaultTraversalVisitor<Node, AnalysisContext> {
 
     StructuredDataSource into;
     if (node.isStdOut) {
-        into =
-          new KsqlStdOut(KsqlStdOut.KSQL_STDOUT_NAME, null, null,
-                         null, StructuredDataSource.DataSourceType.KSTREAM);
-
+      into = new KsqlStdOut(KsqlStdOut.KSQL_STDOUT_NAME, null, null,
+              null, StructuredDataSource.DataSourceType.KSTREAM);
     } else if (context.getParentType() == AnalysisContext.ParentType.INTO) {
       into = analyzeNonStdOutTable(node);
     } else {

--- a/ksql-engine/src/main/java/io/confluent/ksql/util/KafkaTopicClientImpl.java
+++ b/ksql-engine/src/main/java/io/confluent/ksql/util/KafkaTopicClientImpl.java
@@ -53,10 +53,8 @@ public class KafkaTopicClientImpl implements KafkaTopicClient {
     init();
   }
 
-  @Override
-  public void createTopic(final String topic, final int numPartitions, final short
-      replicatonFactor) {
-    log.info("Creating topic '{}'", topic);
+
+  public void createTopic(final String topic, final int numPartitions, final short replicatonFactor) {
     if (isTopicExists(topic)) {
       Map<String, TopicDescription> topicDescriptions = describeTopics(Arrays.asList(topic));
       TopicDescription topicDescription = topicDescriptions.get(topic);
@@ -69,10 +67,13 @@ public class KafkaTopicClientImpl implements KafkaTopicClient {
         ));
       }
       // Topic with the partitons and replicas exists, reuse it!
+      log.debug("Did not create topic {} with {} partitions and replication-factor {} since it already exists", topic,
+              numPartitions, replicatonFactor);
       return;
     }
     NewTopic newTopic = new NewTopic(topic, numPartitions, replicatonFactor);
     try {
+      log.info("Creating topic '{}'", topic);
       adminClient.createTopics(Collections.singleton(newTopic)).all().get();
 
     } catch (InterruptedException | ExecutionException e) {
@@ -83,7 +84,7 @@ public class KafkaTopicClientImpl implements KafkaTopicClient {
 
   @Override
   public boolean isTopicExists(final String topic) {
-    log.debug("Checking for existence of topic '{}'", topic);
+    log.trace("Checking for existence of topic '{}'", topic);
     return listTopicNames().contains(topic);
   }
 

--- a/ksql-engine/src/main/java/io/confluent/ksql/util/KafkaTopicClientImpl.java
+++ b/ksql-engine/src/main/java/io/confluent/ksql/util/KafkaTopicClientImpl.java
@@ -53,7 +53,7 @@ public class KafkaTopicClientImpl implements KafkaTopicClient {
     init();
   }
 
-
+  @Override
   public void createTopic(final String topic, final int numPartitions, final short replicatonFactor) {
     if (isTopicExists(topic)) {
       Map<String, TopicDescription> topicDescriptions = describeTopics(Arrays.asList(topic));

--- a/ksql-engine/src/test/java/io/confluent/ksql/integration/EndToEndIntegrationTest.java
+++ b/ksql-engine/src/test/java/io/confluent/ksql/integration/EndToEndIntegrationTest.java
@@ -61,8 +61,8 @@ public class EndToEndIntegrationTest {
 
   private Map<String, RecordMetadata> pageViewTopicMessages;
 
-  private final String pageViewStream = "pageview_stream";
-  private final String userTable = "user_table";
+  private final String pageViewStream = "pageviews_original";
+  private final String userTable = "users_original";
 
   @Before
   public void before() throws Exception {
@@ -82,9 +82,9 @@ public class EndToEndIntegrationTest {
 
     pageViewDataProvider = new PageViewDataProvider();
     userDataProvider = new UserDataProvider();
-    pageViewTopicMessages = testHarness.publishTestData(pageViewTopic, pageViewDataProvider, System.currentTimeMillis());
     testHarness.publishTestData(usersTopic, userDataProvider, System.currentTimeMillis());
-
+    Thread.sleep(3000);
+    pageViewTopicMessages = testHarness.publishTestData(pageViewTopic, pageViewDataProvider, System.currentTimeMillis());
   }
 
   @After

--- a/ksql-engine/src/test/java/io/confluent/ksql/integration/EndToEndIntegrationTest.java
+++ b/ksql-engine/src/test/java/io/confluent/ksql/integration/EndToEndIntegrationTest.java
@@ -24,6 +24,7 @@ import io.confluent.ksql.util.QueuedQueryMetadata;
 import io.confluent.ksql.util.UserDataProvider;
 import org.apache.kafka.clients.consumer.ConsumerConfig;
 import org.apache.kafka.clients.producer.RecordMetadata;
+import org.apache.kafka.common.utils.Utils;
 import org.apache.kafka.streams.KeyValue;
 import org.apache.kafka.test.IntegrationTest;
 import org.junit.After;
@@ -120,7 +121,7 @@ public class EndToEndIntegrationTest {
     BlockingQueue<KeyValue<String, GenericRow>> rowQueue = queryMetadata.getRowQueue();
 
     Set<String> actualUsers = new HashSet<>();
-    Set<String> expectedUsers = new HashSet<>(Arrays.asList("USER_0", "USER_1", "USER_2", "USER_3", "USER_4"));
+    Set<String> expectedUsers = Utils.mkSet("USER_0", "USER_1", "USER_2", "USER_3", "USER_4");
     while (actualUsers.size() < 5) {
       KeyValue<String, GenericRow> nextRow = rowQueue.poll();
       if (nextRow != null) {

--- a/ksql-engine/src/test/java/io/confluent/ksql/integration/EndToEndIntegrationTest.java
+++ b/ksql-engine/src/test/java/io/confluent/ksql/integration/EndToEndIntegrationTest.java
@@ -19,6 +19,7 @@ import io.confluent.ksql.GenericRow;
 import io.confluent.ksql.KsqlContext;
 import io.confluent.ksql.KsqlEngine;
 import io.confluent.ksql.parser.tree.Except;
+import io.confluent.ksql.serde.DataSource;
 import io.confluent.ksql.util.KafkaTopicClient;
 import io.confluent.ksql.util.KafkaTopicClientImpl;
 import io.confluent.ksql.util.KsqlConfig;
@@ -78,7 +79,7 @@ public class EndToEndIntegrationTest {
 
   @Before
   public void before() throws Exception {
-    testHarness = new IntegrationTestHarness();
+    testHarness = new IntegrationTestHarness(DataSource.DataSourceSerDe.JSON.name());
     testHarness.start();
     Map<String, Object> streamsConfig = testHarness.ksqlConfig.getKsqlStreamConfigProps();
     streamsConfig.put(ConsumerConfig.AUTO_OFFSET_RESET_CONFIG, "earliest");

--- a/ksql-engine/src/test/java/io/confluent/ksql/integration/EndToEndIntegrationTest.java
+++ b/ksql-engine/src/test/java/io/confluent/ksql/integration/EndToEndIntegrationTest.java
@@ -1,0 +1,204 @@
+/**
+ * Copyright 2017 Confluent Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ **/
+package io.confluent.ksql.integration;
+
+import io.confluent.ksql.GenericRow;
+import io.confluent.ksql.KsqlContext;
+import io.confluent.ksql.util.PageViewDataProvider;
+import io.confluent.ksql.util.PersistentQueryMetadata;
+import io.confluent.ksql.util.QueryMetadata;
+import io.confluent.ksql.util.QueuedQueryMetadata;
+import io.confluent.ksql.util.UserDataProvider;
+import org.apache.kafka.clients.producer.RecordMetadata;
+import org.apache.kafka.streams.KeyValue;
+import org.apache.kafka.test.IntegrationTest;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.BlockingQueue;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+import static org.testng.Assert.assertNotNull;
+
+/**
+ * This test emulates the end to end flow in the quick start guide and ensures that the outputs at each stage
+ * are what we expect. This tests a broad set of KSQL functionality and is a good catch-all.
+ */
+@Category({IntegrationTest.class})
+public class EndToEndIntegrationTest {
+  private static final Logger log = LoggerFactory.getLogger(EndToEndIntegrationTest.class);
+  private IntegrationTestHarness testHarness;
+  private KsqlContext ksqlContext;
+
+  private PageViewDataProvider pageViewDataProvider;
+  private UserDataProvider userDataProvider;
+
+  private final String pageViewTopic = "pageviews";
+  private final String usersTopic = "users";
+
+  private Map<String, RecordMetadata> pageViewTopicMessages;
+
+  private final String pageViewStream = "pageview_stream";
+  private final String userTable = "user_table";
+
+  @Before
+  public void before() throws Exception {
+    testHarness = new IntegrationTestHarness();
+    testHarness.start();
+
+    ksqlContext = KsqlContext.create(testHarness.ksqlConfig.getKsqlStreamConfigProps());
+
+    testHarness.createTopic(pageViewTopic);
+    testHarness.createTopic(usersTopic);
+
+    ksqlContext.sql(String.format("CREATE STREAM %s (viewtime bigint, userid varchar, pageid varchar) " +
+            "WITH (kafka_topic='%s', value_format='JSON');", pageViewStream, pageViewTopic));
+
+    ksqlContext.sql(String.format("CREATE TABLE %s (registertime bigint, gender varchar, regionid varchar, " +
+            "userid varchar) WITH (kafka_topic='%s', value_format='JSON');", userTable, usersTopic));
+
+    pageViewDataProvider = new PageViewDataProvider();
+    userDataProvider = new UserDataProvider();
+    pageViewTopicMessages = testHarness.publishTestData(pageViewTopic, pageViewDataProvider, System.currentTimeMillis());
+    testHarness.publishTestData(usersTopic, userDataProvider, System.currentTimeMillis());
+
+  }
+
+  @After
+  public void after() throws Exception {
+    ksqlContext.close();
+    testHarness.stop();
+  }
+
+  @Test
+  public void testKSQLFromEndToEnd() throws Exception {
+    validateSelectStatementWithSpecificColumn();
+
+    validateSelectAllFromDerivedStream();
+
+  }
+
+  private void validateSelectStatementWithSpecificColumn() throws Exception {
+    String query = String.format("SELECT pageid from %s;", pageViewStream);
+    log.debug("Sending query: {}", query);
+
+    List<QueryMetadata> queries = ksqlContext.getKsqlEngine().buildMultipleQueries(false, query, Collections.emptyMap());
+
+    assertEquals(1, queries.size());
+    assertTrue(queries.get(0) instanceof QueuedQueryMetadata);
+
+    QueuedQueryMetadata queryMetadata = (QueuedQueryMetadata) queries.get(0);
+    queryMetadata.getKafkaStreams().start();
+
+    BlockingQueue<KeyValue<String, GenericRow>> rowQueue = queryMetadata.getRowQueue();
+
+    List<String> actualPages = new ArrayList<>();
+    List<String> expectedPages = Arrays.asList("PAGE_1", "PAGE_2", "PAGE_3", "PAGE_4", "PAGE_5", "PAGE_5", "PAGE_5");
+    while (actualPages.size() < expectedPages.size()) {
+      KeyValue<String, GenericRow> nextRow = rowQueue.poll();
+      if (nextRow != null) {
+        List<Object> columns = nextRow.value.getColumns();
+        assertEquals(1, columns.size());
+
+        String page = (String) columns.get(0);
+        actualPages.add(page);
+        log.debug("Pageview : {}", page);
+      }
+    }
+
+    assertEquals(expectedPages, actualPages);
+
+    queryMetadata.getKafkaStreams().close();
+
+  }
+
+  private void validateSelectAllFromDerivedStream() throws Exception {
+
+    String derivedStream = "pageviews_female";
+    createPageViewsFemaleStream(derivedStream);
+
+    String selectQuery = String.format("SELECT * from %s;", derivedStream);
+
+    List<QueryMetadata> queries = ksqlContext.getKsqlEngine().buildMultipleQueries(false, selectQuery, Collections.emptyMap());
+
+    assertEquals(1, queries.size());
+    assertTrue(queries.get(0) instanceof QueuedQueryMetadata);
+
+    QueuedQueryMetadata queryMetadata = (QueuedQueryMetadata) queries.get(0);
+    queryMetadata.getKafkaStreams().start();
+
+    List<KeyValue<String, GenericRow>> results = new ArrayList<>();
+    BlockingQueue<KeyValue<String, GenericRow>> rowQueue = queryMetadata.getRowQueue();
+
+    // From the mock data, we expect exactly 3 page views from female users.
+
+    List<String> expectedPages = Arrays.asList("PAGE_2", "PAGE_5", "PAGE_5");
+    List<String> expectedUsers = Arrays.asList("USER_2", "USER_0", "USER_2");
+    List<String> actualPages = new ArrayList<>();
+    List<String> actualUsers = new ArrayList<>();
+
+    while (results.size() < 3) {
+      KeyValue<String, GenericRow> nextRow = rowQueue.poll();
+      if (nextRow != null) {
+        results.add(nextRow);
+      }
+    }
+
+    for (KeyValue<String, GenericRow> result: results) {
+      List<Object> columns = result.value.getColumns();
+      assertEquals(5, columns.size());
+      String user = (String) columns.get(0);
+      actualUsers.add(user);
+
+      String page = (String) columns.get(2);
+      actualPages.add(page);
+      log.debug("user {} viewed page {}", user, page);
+    }
+
+    assertEquals(expectedPages, actualPages);
+    assertEquals(expectedUsers, actualUsers);
+  }
+
+  private PersistentQueryMetadata createPageViewsFemaleStream(String streamName) throws Exception {
+    String createStreamStatement = String.format("CREATE STREAM %s AS SELECT %s.userid AS userid, " +
+                    "pageid, regionid, gender FROM %s LEFT JOIN %s ON " +
+                    "%s.userid = %s.userid WHERE gender = 'FEMALE';", streamName,
+            userTable, pageViewStream, userTable, pageViewStream, userTable);
+
+    log.debug("Creating {} using: {}", streamName, createStreamStatement);
+
+    List<QueryMetadata> queries = ksqlContext.getKsqlEngine().buildMultipleQueries(false, createStreamStatement,
+            Collections.emptyMap());
+
+    assertEquals(1, queries.size());
+    assertTrue(queries.get(0) instanceof PersistentQueryMetadata);
+
+    PersistentQueryMetadata persistentQueryMetadata = (PersistentQueryMetadata) queries.get(0);
+    persistentQueryMetadata.getKafkaStreams().start();
+    return persistentQueryMetadata;
+
+  }
+}

--- a/ksql-engine/src/test/java/io/confluent/ksql/util/PageViewDataProvider.java
+++ b/ksql-engine/src/test/java/io/confluent/ksql/util/PageViewDataProvider.java
@@ -1,0 +1,65 @@
+/**
+ * Copyright 2017 Confluent Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ **/
+package io.confluent.ksql.util;
+
+import io.confluent.ksql.GenericRow;
+import org.apache.kafka.connect.data.Schema;
+import org.apache.kafka.connect.data.SchemaBuilder;
+
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.Map;
+
+public class PageViewDataProvider extends TestDataProvider {
+  private static final String namePrefix =
+      "PAGEVIEW";
+
+  private static final String ksqlSchemaString = "(VIEWTIME bigint, USERID varchar, PAGEID varchar)";
+
+
+  private static final String key = "PAGEID";
+
+  private static final Schema schema = SchemaBuilder.struct()
+      .field("VIEWTIME", SchemaBuilder.INT64_SCHEMA)
+      .field("USERID", SchemaBuilder.STRING_SCHEMA)
+      .field("PAGEID", SchemaBuilder.STRING_SCHEMA).build();
+
+  private static final Map<String, GenericRow> data = new PageViewDataProvider().buildData();
+
+  public PageViewDataProvider() {
+    super(namePrefix, ksqlSchemaString, key, schema, data);
+  }
+
+  private Map<String, GenericRow> buildData() {
+    Map<String, GenericRow> dataMap = new HashMap<>();
+
+    // Create page view records with:
+    // key = page_id
+    // value = (view time, user_id, page_id)
+    dataMap.put("1", new GenericRow(Arrays.asList(1, "USER_1", "PAGE_1")));
+    dataMap.put("2", new GenericRow(Arrays.asList(2, "USER_2", "PAGE_2")));
+    dataMap.put("3", new GenericRow(Arrays.asList(3, "USER_4", "PAGE_3")));
+    dataMap.put("4", new GenericRow(Arrays.asList(4, "USER_3", "PAGE_4")));
+    dataMap.put("5", new GenericRow(Arrays.asList(5, "USER_0", "PAGE_5")));
+
+    // Duplicate page views from different users.
+    dataMap.put("6", new GenericRow(Arrays.asList(6, "USER_2", "PAGE_5")));
+    dataMap.put("7", new GenericRow(Arrays.asList(7, "USER_3", "PAGE_5")));
+
+    return dataMap;
+  }
+
+}

--- a/ksql-engine/src/test/java/io/confluent/ksql/util/UserDataProvider.java
+++ b/ksql-engine/src/test/java/io/confluent/ksql/util/UserDataProvider.java
@@ -1,0 +1,60 @@
+/**
+ * Copyright 2017 Confluent Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ **/
+package io.confluent.ksql.util;
+
+import io.confluent.ksql.GenericRow;
+import org.apache.kafka.connect.data.Schema;
+import org.apache.kafka.connect.data.SchemaBuilder;
+
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.Map;
+
+public class UserDataProvider extends TestDataProvider {
+  private static final String namePrefix = "USER";
+
+  private static final String ksqlSchemaString = "(REGISTERTIME bigint, GENDER varchar, REGIONID varchar, USERID varchar)";
+
+  private static final String key = "USERID";
+
+  private static final Schema schema = SchemaBuilder.struct()
+          .field("REGISTERTIME", SchemaBuilder.INT64_SCHEMA)
+          .field("GENDER", SchemaBuilder.STRING_SCHEMA)
+          .field("REGIONID", SchemaBuilder.STRING_SCHEMA)
+          .field("USERID", SchemaBuilder.STRING_SCHEMA).build();
+
+  private static final Map<String, GenericRow> data = new UserDataProvider().buildData();
+
+  public UserDataProvider() {
+    super(namePrefix, ksqlSchemaString, key, schema, data);
+  }
+
+  private Map<String, GenericRow> buildData() {
+    Map<String, GenericRow> dataMap = new HashMap<>();
+    // create a records with:
+    // key == user_id
+    // value = (creation_time, gender, region, user_id)
+    dataMap.put("0", new GenericRow(Arrays.asList(0, "FEMALE", "REGION_0", "USER_0")));
+    dataMap.put("1", new GenericRow(Arrays.asList(1, "MALE", "REGION_1", "USER_1")));
+    dataMap.put("2", new GenericRow(Arrays.asList(2, "FEMALE", "REGION_1", "USER_2")));
+    dataMap.put("3", new GenericRow(Arrays.asList(3, "MALE", "REGION_0", "USER_3")));
+    dataMap.put("4", new GenericRow(Arrays.asList(4, "MALE", "REGION_4", "USER_4")));
+
+    return dataMap;
+  }
+
+
+}

--- a/ksql-engine/src/test/java/io/confluent/ksql/util/UserDataProvider.java
+++ b/ksql-engine/src/test/java/io/confluent/ksql/util/UserDataProvider.java
@@ -47,11 +47,11 @@ public class UserDataProvider extends TestDataProvider {
     // create a records with:
     // key == user_id
     // value = (creation_time, gender, region, user_id)
-    dataMap.put("0", new GenericRow(Arrays.asList(0, "FEMALE", "REGION_0", "USER_0")));
-    dataMap.put("1", new GenericRow(Arrays.asList(1, "MALE", "REGION_1", "USER_1")));
-    dataMap.put("2", new GenericRow(Arrays.asList(2, "FEMALE", "REGION_1", "USER_2")));
-    dataMap.put("3", new GenericRow(Arrays.asList(3, "MALE", "REGION_0", "USER_3")));
-    dataMap.put("4", new GenericRow(Arrays.asList(4, "MALE", "REGION_4", "USER_4")));
+    dataMap.put("USER_0", new GenericRow(Arrays.asList(0, "FEMALE", "REGION_0", "USER_0")));
+    dataMap.put("USER_1", new GenericRow(Arrays.asList(1, "MALE", "REGION_1", "USER_1")));
+    dataMap.put("USER_2", new GenericRow(Arrays.asList(2, "FEMALE", "REGION_1", "USER_2")));
+    dataMap.put("USER_3", new GenericRow(Arrays.asList(3, "MALE", "REGION_0", "USER_3")));
+    dataMap.put("USER_4", new GenericRow(Arrays.asList(4, "MALE", "REGION_4", "USER_4")));
 
     return dataMap;
   }

--- a/ksql-engine/src/test/resources/log4j.properties
+++ b/ksql-engine/src/test/resources/log4j.properties
@@ -1,0 +1,7 @@
+log4j.rootLogger=WARN,stdout
+
+log4j.logger.io.confluent.ksql=DEBUG
+log4j.logger.io.confluent.ksql.integration=DEBUG
+log4j.appender.stdout=org.apache.log4j.ConsoleAppender
+log4j.appender.stdout.layout=org.apache.log4j.PatternLayout
+log4j.appender.stdout.layout.ConversionPattern=[%d] %p %m (%c:%L)%n


### PR DESCRIPTION
This patch covers all the queries in the quickstart, including the 'plain' select statements.

I have noticed that the join between the pageviews stream and the users table sometimes results in 'null' values for the columns in the users table. @hjafarpour thinks that this is because the rocksdb store isn't ready when the join is executed, resulting in an empty user table and null values for the corresponding fields in the join.