### PR TITLE
extract QueryAnalyzer from QueryEngine

### DIFF
--- a/ksql-engine/src/main/java/io/confluent/ksql/KsqlEngine.java
+++ b/ksql-engine/src/main/java/io/confluent/ksql/KsqlEngine.java
@@ -330,7 +330,7 @@ public class KsqlEngine implements Closeable {
 
     QuerySpecification newQuerySpecification = new QuerySpecification(
             querySpecification.getSelect(),
-            Optional.of(intoTable),
+            intoTable,
             querySpecification.getFrom(),
             querySpecification.getWindowExpression(),
             querySpecification.getWhere(),

--- a/ksql-engine/src/main/java/io/confluent/ksql/analyzer/Analysis.java
+++ b/ksql-engine/src/main/java/io/confluent/ksql/analyzer/Analysis.java
@@ -142,5 +142,9 @@ public class Analysis {
   public Pair<StructuredDataSource, String> getFromDataSource(int index) {
     return fromDataSources.get(index);
   }
+
+  void addDataSource(Pair<StructuredDataSource, String> fromDataSource) {
+    fromDataSources.add(fromDataSource);
+  }
 }
 

--- a/ksql-engine/src/main/java/io/confluent/ksql/analyzer/AnalysisContext.java
+++ b/ksql-engine/src/main/java/io/confluent/ksql/analyzer/AnalysisContext.java
@@ -38,6 +38,9 @@ public class AnalysisContext {
 
   private final ParentType parentType;
 
+  public AnalysisContext() {
+    this(null);
+  }
   public AnalysisContext(final ParentType parentType) {
     this.parentType = parentType;
   }

--- a/ksql-engine/src/main/java/io/confluent/ksql/analyzer/Analyzer.java
+++ b/ksql-engine/src/main/java/io/confluent/ksql/analyzer/Analyzer.java
@@ -77,10 +77,10 @@ public class Analyzer extends DefaultTraversalVisitor<Node, AnalysisContext> {
   protected Node visitQuerySpecification(final QuerySpecification node,
                                          final AnalysisContext context) {
 
-    process(node.getFrom().get(),
+    process(node.getFrom(),
             new AnalysisContext(AnalysisContext.ParentType.FROM));
 
-    process(node.getInto().get(), new AnalysisContext(
+    process(node.getInto(), new AnalysisContext(
         AnalysisContext.ParentType.INTO));
     if (!(analysis.getInto() instanceof KsqlStdOut)) {
       analyzeNonStdOutSink();
@@ -312,7 +312,7 @@ public class Analyzer extends DefaultTraversalVisitor<Node, AnalysisContext> {
         new Pair<>(
             structuredDataSource,
             node.getAlias());
-    analysis.getFromDataSources().add(fromDataSource);
+    analysis.addDataSource(fromDataSource);
     return node;
   }
 

--- a/ksql-engine/src/main/java/io/confluent/ksql/analyzer/QueryAnalyzer.java
+++ b/ksql-engine/src/main/java/io/confluent/ksql/analyzer/QueryAnalyzer.java
@@ -1,0 +1,114 @@
+/**
+ * Copyright 2017 Confluent Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ **/
+package io.confluent.ksql.analyzer;
+
+import io.confluent.ksql.function.FunctionRegistry;
+import io.confluent.ksql.metastore.MetaStore;
+import io.confluent.ksql.parser.tree.Expression;
+import io.confluent.ksql.parser.tree.ExpressionTreeRewriter;
+import io.confluent.ksql.parser.tree.Query;
+import io.confluent.ksql.parser.tree.QuerySpecification;
+import io.confluent.ksql.util.AggregateExpressionRewriter;
+import io.confluent.ksql.util.KsqlException;
+
+public class QueryAnalyzer {
+  private final MetaStore metaStore;
+  private final FunctionRegistry functionRegistry;
+
+  public QueryAnalyzer(final MetaStore metaStore, final FunctionRegistry functionRegistry) {
+    this.metaStore = metaStore;
+    this.functionRegistry = functionRegistry;
+  }
+
+  public Analysis analyize(final Query query) {
+    Analysis analysis = new Analysis();
+    Analyzer analyzer = new Analyzer(analysis, metaStore);
+    analyzer.process(query, new AnalysisContext());
+    return analysis;
+  }
+
+  public AggregateAnalysis analyizeAggregate(final Query query, final Analysis analysis) {
+    AggregateAnalysis aggregateAnalysis = new AggregateAnalysis();
+    AggregateAnalyzer aggregateAnalyzer = new
+        AggregateAnalyzer(aggregateAnalysis, analysis, functionRegistry);
+    AggregateExpressionRewriter aggregateExpressionRewriter =
+        new AggregateExpressionRewriter(functionRegistry);
+
+    processSelectExpressions(analysis,
+        aggregateAnalysis,
+        aggregateAnalyzer,
+        aggregateExpressionRewriter);
+
+    if (!aggregateAnalysis.getAggregateFunctionArguments().isEmpty() &&
+        analysis.getGroupByExpressions().isEmpty()) {
+      throw new KsqlException("Aggregate query needs GROUP BY clause. query:" + query);
+    }
+
+    // TODO: make sure only aggregates are in the expression. For now we assume this is the case.
+    if (analysis.getHavingExpression() != null) {
+      processHavingExpression(analysis,
+          aggregateAnalysis,
+          aggregateAnalyzer,
+          aggregateExpressionRewriter);
+    }
+
+    enforceAggregateRules(query, aggregateAnalysis);
+    return aggregateAnalysis;
+  }
+
+  private void processHavingExpression(final Analysis analysis,
+                                       final AggregateAnalysis aggregateAnalysis,
+                                       final AggregateAnalyzer aggregateAnalyzer,
+                                       final AggregateExpressionRewriter aggregateExpressionRewriter) {
+    aggregateAnalyzer.process(analysis.getHavingExpression(),
+        new AnalysisContext());
+    if (!aggregateAnalyzer.isHasAggregateFunction()) {
+      aggregateAnalysis.getNonAggResultColumns().add(analysis.getHavingExpression());
+    }
+    aggregateAnalysis
+        .setHavingExpression(ExpressionTreeRewriter.rewriteWith(aggregateExpressionRewriter,
+            analysis.getHavingExpression()));
+    aggregateAnalyzer.setHasAggregateFunction(false);
+  }
+
+  private void processSelectExpressions(final Analysis analysis,
+                                        final AggregateAnalysis aggregateAnalysis,
+                                        final AggregateAnalyzer aggregateAnalyzer,
+                                        final AggregateExpressionRewriter aggregateExpressionRewriter) {
+    for (Expression expression: analysis.getSelectExpressions()) {
+      aggregateAnalyzer
+          .process(expression, new AnalysisContext());
+      if (!aggregateAnalyzer.isHasAggregateFunction()) {
+        aggregateAnalysis.getNonAggResultColumns().add(expression);
+      }
+      aggregateAnalysis.getFinalSelectExpressions()
+          .add(ExpressionTreeRewriter.rewriteWith(aggregateExpressionRewriter, expression));
+      aggregateAnalyzer.setHasAggregateFunction(false);
+    }
+  }
+
+  private void enforceAggregateRules(final Query query, final AggregateAnalysis aggregateAnalysis) {
+    if (!((QuerySpecification) query.getQueryBody()).getGroupBy().isPresent()) {
+      return;
+    }
+    int numberOfNonAggProjections = aggregateAnalysis.getNonAggResultColumns().size();
+    int groupBySize = ((QuerySpecification) query.getQueryBody()).getGroupBy().get()
+        .getGroupingElements().size();
+    if (numberOfNonAggProjections != groupBySize) {
+      throw new KsqlException("Group by elements should match the SELECT expressions.");
+    }
+  }
+}

--- a/ksql-engine/src/main/java/io/confluent/ksql/planner/DefaultTraversalVisitor.java
+++ b/ksql-engine/src/main/java/io/confluent/ksql/planner/DefaultTraversalVisitor.java
@@ -320,9 +320,8 @@ public abstract class DefaultTraversalVisitor<R, C>
   @Override
   protected R visitQuerySpecification(QuerySpecification node, C context) {
     process(node.getSelect(), context);
-    if (node.getFrom().isPresent()) {
-      process(node.getFrom().get(), context);
-    }
+    process(node.getFrom(), context);
+
     if (node.getWhere().isPresent()) {
       process(node.getWhere().get(), context);
     }

--- a/ksql-engine/src/test/java/io/confluent/ksql/analyzer/QueryAnalyzerTest.java
+++ b/ksql-engine/src/test/java/io/confluent/ksql/analyzer/QueryAnalyzerTest.java
@@ -1,0 +1,137 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.confluent.ksql.analyzer;
+
+import org.junit.Test;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import io.confluent.ksql.function.FunctionRegistry;
+import io.confluent.ksql.metastore.KsqlStream;
+import io.confluent.ksql.metastore.MetaStore;
+import io.confluent.ksql.metastore.StructuredDataSource;
+import io.confluent.ksql.parser.KsqlParser;
+import io.confluent.ksql.parser.tree.ComparisonExpression;
+import io.confluent.ksql.parser.tree.DereferenceExpression;
+import io.confluent.ksql.parser.tree.Expression;
+import io.confluent.ksql.parser.tree.LongLiteral;
+import io.confluent.ksql.parser.tree.QualifiedName;
+import io.confluent.ksql.parser.tree.QualifiedNameReference;
+import io.confluent.ksql.parser.tree.Query;
+import io.confluent.ksql.parser.tree.Statement;
+import io.confluent.ksql.util.KsqlException;
+import io.confluent.ksql.util.MetaStoreFixture;
+import io.confluent.ksql.util.Pair;
+
+import static org.hamcrest.CoreMatchers.equalTo;
+import static org.hamcrest.CoreMatchers.instanceOf;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.Assert.fail;
+
+public class QueryAnalyzerTest {
+
+  private final MetaStore metaStore = MetaStoreFixture.getNewMetaStore();
+  private final KsqlParser ksqlParser = new KsqlParser();
+  private final QueryAnalyzer queryAnalyzer =  new QueryAnalyzer(metaStore, new FunctionRegistry());
+
+  @Test
+  public void shouldCreateAnalysisForSimpleQuery() {
+    final List<Statement> statements = ksqlParser.buildAst("select orderid from orders;", metaStore);
+    final Analysis analysis = queryAnalyzer.analyize((Query)statements.get(0));
+    final Pair<StructuredDataSource, String> fromDataSource = analysis.getFromDataSource(0);
+    assertThat(analysis.getSelectExpressions(), equalTo(
+        Collections.singletonList(new DereferenceExpression(
+            new QualifiedNameReference(QualifiedName.of("ORDERS")), "ORDERID"))));
+    assertThat(analysis.getFromDataSources().size(), equalTo(1));
+    assertThat(fromDataSource.left, instanceOf(KsqlStream.class));
+    assertThat(fromDataSource.right, equalTo("ORDERS"));
+  }
+
+  @Test
+  public void shouldAnalyseWindowedAggregate() {
+    final List<Statement> statements = ksqlParser.buildAst(
+        "select itemid, sum(orderunits) from orders window TUMBLING ( size 30 second) " +
+            "where orderunits > 5 group by itemid;",
+        metaStore);
+    final Query query = (Query) statements.get(0);
+    final Analysis analysis = queryAnalyzer.analyize(query);
+    final AggregateAnalysis aggregateAnalysis = queryAnalyzer.analyizeAggregate(query, analysis);
+    final DereferenceExpression itemId = new DereferenceExpression(new QualifiedNameReference(QualifiedName.of("ORDERS")), "ITEMID");
+    final DereferenceExpression orderUnits = new DereferenceExpression(new QualifiedNameReference(QualifiedName.of("ORDERS")), "ORDERUNITS");
+    final Map<String, Expression> expectedRequiredColumns = new HashMap<>();
+    expectedRequiredColumns.put("ORDERS.ITEMID", itemId);
+    expectedRequiredColumns.put("ORDERS.ORDERUNITS", orderUnits);
+    assertThat(aggregateAnalysis.getNonAggResultColumns(), equalTo(Collections.singletonList(itemId)));
+    assertThat(aggregateAnalysis.getFinalSelectExpressions(), equalTo(Arrays.asList(itemId, new QualifiedNameReference(QualifiedName.of("KSQL_AGG_VARIABLE_0")))));
+    assertThat(aggregateAnalysis.getAggregateFunctionArguments(), equalTo(Collections.singletonList(orderUnits)));
+    assertThat(aggregateAnalysis.getRequiredColumnsMap(), equalTo(expectedRequiredColumns));
+  }
+
+  @Test
+  public void shouldThrowExceptionIfAggregateAnalysisDoesntHaveGroupBy() {
+    final List<Statement> statements = ksqlParser.buildAst(
+        "select itemid, sum(orderunits) from orders window TUMBLING ( size 30 second) " +
+            "where orderunits > 5;",
+        metaStore);
+    final Query query = (Query) statements.get(0);
+    final Analysis analysis = queryAnalyzer.analyize(query);
+    try {
+      queryAnalyzer.analyizeAggregate(query, analysis);
+      fail("should have thrown KsqlException as aggregate query doesn't have a groupby clause");
+    } catch (KsqlException e) {
+      // ok
+    }
+
+  }
+
+  @Test
+  public void shouldThrowExceptionIfNonAggregateSelectsDontMatchGroupBySize() {
+    final List<Statement> statements = ksqlParser.buildAst(
+        "select itemid, orderid, sum(orderunits) from orders window TUMBLING ( size 30 second) " +
+            "where orderunits > 5 group by itemid;",
+        metaStore);
+    final Query query = (Query) statements.get(0);
+    final Analysis analysis = queryAnalyzer.analyize(query);
+    try {
+      queryAnalyzer.analyizeAggregate(query, analysis);
+      fail("should have thrown KsqlException as aggregate query doesn't have a groupby clause");
+    } catch (KsqlException e) {
+      // ok
+    }
+  }
+
+  @Test
+  public void shouldProcessHavingExpression() {
+    final List<Statement> statements = ksqlParser.buildAst(
+        "select itemid, sum(orderunits) from orders window TUMBLING ( size 30 second) " +
+            "where orderunits > 5 group by itemid having count(itemid) > 10;",
+        metaStore);
+    final Query query = (Query) statements.get(0);
+    final Analysis analysis = queryAnalyzer.analyize(query);
+    final AggregateAnalysis aggregateAnalysis = queryAnalyzer.analyizeAggregate(query, analysis);
+    final Expression havingExpression = aggregateAnalysis.getHavingExpression();
+    assertThat(havingExpression, equalTo(new ComparisonExpression(
+        ComparisonExpression.Type.GREATER_THAN,
+        new QualifiedNameReference(QualifiedName.of("KSQL_AGG_VARIABLE_1")),
+        new LongLiteral("10"))));
+  }
+}

--- a/ksql-parser/src/main/java/io/confluent/ksql/parser/AstBuilder.java
+++ b/ksql-parser/src/main/java/io/confluent/ksql/parser/AstBuilder.java
@@ -260,8 +260,8 @@ public class AstBuilder
     return new QuerySpecification(
         getLocation(context),
         select,
-        Optional.of(into),
-        Optional.of(from),
+        into,
+        from,
         visitIfPresent(context.windowExpression(), WindowExpression.class),
         visitIfPresent(context.where, Expression.class),
         visitIfPresent(context.groupBy(), GroupBy.class),

--- a/ksql-parser/src/main/java/io/confluent/ksql/parser/SqlFormatter.java
+++ b/ksql-parser/src/main/java/io/confluent/ksql/parser/SqlFormatter.java
@@ -162,11 +162,9 @@ public final class SqlFormatter {
     protected Void visitQuerySpecification(QuerySpecification node, Integer indent) {
       process(node.getSelect(), indent);
 
-      if (node.getFrom().isPresent()) {
-        append(indent, "FROM");
-        builder.append('\n');
-        append(indent, "  ");
-      }
+      append(indent, "FROM");
+      builder.append('\n');
+      append(indent, "  ");
 
       builder.append('\n');
 

--- a/ksql-parser/src/main/java/io/confluent/ksql/parser/rewrite/SqlFormatterQueryRewrite.java
+++ b/ksql-parser/src/main/java/io/confluent/ksql/parser/rewrite/SqlFormatterQueryRewrite.java
@@ -159,21 +159,16 @@ public final class SqlFormatterQueryRewrite {
     @Override
     protected Void visitQuerySpecification(QuerySpecification node, Integer indent) {
       process(node.getSelect(), indent);
+      append(indent, "INTO");
+      builder.append('\n');
+      append(indent, "  ");
+      process(node.getInto(), indent);
+      builder.append('\n');
 
-      if (node.getInto().isPresent()) {
-        append(indent, "INTO");
-        builder.append('\n');
-        append(indent, "  ");
-        process(node.getInto().get(), indent);
-        builder.append('\n');
-      }
-
-      if (node.getFrom().isPresent()) {
-        append(indent, "FROM");
-        builder.append('\n');
-        append(indent, "  ");
-        process(node.getFrom().get(), indent);
-      }
+      append(indent, "FROM");
+      builder.append('\n');
+      append(indent, "  ");
+      process(node.getFrom(), indent);
 
       builder.append('\n');
 

--- a/ksql-parser/src/main/java/io/confluent/ksql/parser/tree/DefaultTraversalVisitor.java
+++ b/ksql-parser/src/main/java/io/confluent/ksql/parser/tree/DefaultTraversalVisitor.java
@@ -261,9 +261,8 @@ public abstract class DefaultTraversalVisitor<R, C>
   @Override
   protected R visitQuerySpecification(QuerySpecification node, C context) {
     process(node.getSelect(), context);
-    if (node.getFrom().isPresent()) {
-      process(node.getFrom().get(), context);
-    }
+
+    process(node.getFrom(), context);
     if (node.getWhere().isPresent()) {
       process(node.getWhere().get(), context);
     }

--- a/ksql-parser/src/main/java/io/confluent/ksql/parser/tree/QuerySpecification.java
+++ b/ksql-parser/src/main/java/io/confluent/ksql/parser/tree/QuerySpecification.java
@@ -27,8 +27,8 @@ public class QuerySpecification
     extends QueryBody {
 
   private final Select select;
-  private final Optional<Relation> into;
-  private final Optional<Relation> from;
+  private final Relation into;
+  private final Relation from;
   private final Optional<WindowExpression> windowExpression;
   private final Optional<Expression> where;
   private final Optional<GroupBy> groupBy;
@@ -38,8 +38,8 @@ public class QuerySpecification
 
   public QuerySpecification(
       Select select,
-      Optional<Relation> into,
-      Optional<Relation> from,
+      Relation into,
+      Relation from,
       Optional<WindowExpression> windowExpression,
       Optional<Expression> where,
       Optional<GroupBy> groupBy,
@@ -53,8 +53,8 @@ public class QuerySpecification
   public QuerySpecification(
       NodeLocation location,
       Select select,
-      Optional<Relation> into,
-      Optional<Relation> from,
+      Relation into,
+      Relation from,
       Optional<WindowExpression> windowExpression,
       Optional<Expression> where,
       Optional<GroupBy> groupBy,
@@ -68,8 +68,8 @@ public class QuerySpecification
   private QuerySpecification(
       Optional<NodeLocation> location,
       Select select,
-      Optional<Relation> into,
-      Optional<Relation> from,
+      Relation into,
+      Relation from,
       Optional<WindowExpression> windowExpression,
       Optional<Expression> where,
       Optional<GroupBy> groupBy,
@@ -102,11 +102,11 @@ public class QuerySpecification
     return select;
   }
 
-  public Optional<Relation> getInto() {
+  public Relation getInto() {
     return into;
   }
 
-  public Optional<Relation> getFrom() {
+  public Relation getFrom() {
     return from;
   }
 

--- a/ksql-parser/src/main/java/io/confluent/ksql/parser/tree/Table.java
+++ b/ksql-parser/src/main/java/io/confluent/ksql/parser/tree/Table.java
@@ -16,6 +16,7 @@
 
 package io.confluent.ksql.parser.tree;
 
+import java.util.HashMap;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
@@ -24,7 +25,7 @@ public class Table
     extends QueryBody {
 
   public final boolean isStdOut;
-  Map<String, Expression> properties;
+  private final Map<String, Expression> properties  = new HashMap<>();
   private final QualifiedName name;
 
   public Table(QualifiedName name) {
@@ -63,7 +64,8 @@ public class Table
 
   public void setProperties(
       Map<String, Expression> properties) {
-    this.properties = properties;
+    this.properties.clear();
+    this.properties.putAll(properties);
   }
 
   @Override

--- a/ksql-rest-app/src/main/java/io/confluent/ksql/rest/server/computation/StatementExecutor.java
+++ b/ksql-rest-app/src/main/java/io/confluent/ksql/rest/server/computation/StatementExecutor.java
@@ -295,9 +295,9 @@ public class StatementExecutor {
   ) throws Exception {
     if (query.getQueryBody() instanceof QuerySpecification) {
       QuerySpecification querySpecification = (QuerySpecification) query.getQueryBody();
-      Optional<Relation> into = querySpecification.getInto();
-      if (into.isPresent() && into.get() instanceof Table) {
-        Table table = (Table) into.get();
+      Relation into = querySpecification.getInto();
+      if (into instanceof Table) {
+        Table table = (Table) into;
         if (ksqlEngine.getMetaStore().getSource(table.getName().getSuffix()) != null) {
           throw new Exception(String.format(
               "Sink specified in INTO clause already exists: %s",


### PR DESCRIPTION
Extract `QueryAnalyzer` from `QueryEngine`.
Removed redundant usages of `Optional` from `QuerySpecification`