### PR TITLE
reset repartition flag after map

### DIFF
--- a/ksql-engine/src/test/java/io/confluent/ksql/integration/JoinIntTest.java
+++ b/ksql-engine/src/test/java/io/confluent/ksql/integration/JoinIntTest.java
@@ -6,7 +6,6 @@ import io.confluent.ksql.serde.DataSource;
 import io.confluent.ksql.util.ItemDataProvider;
 import io.confluent.ksql.util.OrderDataProvider;
 import org.apache.kafka.clients.producer.RecordMetadata;
-import org.apache.kafka.common.serialization.Serde;
 import org.apache.kafka.common.serialization.StringDeserializer;
 import org.apache.kafka.connect.data.Schema;
 import org.apache.kafka.streams.StreamsConfig;
@@ -22,7 +21,6 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
 
-import static org.hamcrest.MatcherAssert.assertThat;
 
 @Category({IntegrationTest.class})
 public class JoinIntTest {
@@ -76,7 +74,7 @@ public class JoinIntTest {
 
     final String queryString = String.format(
             "CREATE STREAM %s AS SELECT ORDERID, ITEMID, ORDERUNITS, DESCRIPTION FROM orders LEFT JOIN items " +
-                    " on orders.ITEMID = item.ITEMID WHERE orders.ITEMID = 'ITEM_1' ;",
+                    " on orders.ITEMID = item.ID WHERE orders.ITEMID = 'ITEM_1' ;",
             testStreamName
     );
 

--- a/ksql-engine/src/test/java/io/confluent/ksql/planner/plan/JoinNodeTest.java
+++ b/ksql-engine/src/test/java/io/confluent/ksql/planner/plan/JoinNodeTest.java
@@ -84,11 +84,12 @@ public class JoinNodeTest {
   @Test
   public void shouldHaveLeftJoin() {
     final Topology topology = builder.build();
+    System.out.println(topology.describe());
     final TopologyDescription.Processor leftJoin
-        = (TopologyDescription.Processor) getNodeByName(topology, "KSTREAM-LEFTJOIN-0000000016");
+        = (TopologyDescription.Processor) getNodeByName(topology, "KSTREAM-LEFTJOIN-0000000013");
     final List<String> predecessors = leftJoin.predecessors().stream().map(TopologyDescription.Node::name).collect(Collectors.toList());
     assertThat(leftJoin.stores(), equalTo(Utils.mkSet("KSTREAM-REDUCE-STATE-STORE-0000000003")));
-    assertThat(predecessors, equalTo(Collections.singletonList("KSTREAM-SOURCE-0000000015")));
+    assertThat(predecessors, equalTo(Collections.singletonList("KSTREAM-SOURCE-0000000012")));
   }
 
   @Test


### PR DESCRIPTION
When creating the execution plan in `StructuredDataSourceNode` we do a `stream#map(..)` to add the key to the `GenericRow`. This causes the `repartitionRequired` flag to be set to true even though we haven't changed the key. In this case we don't want a repartition as it is unnecessary and also causes issues with the stream/table join, i.e., we end up with nulls when we shouldn't. 
As a temporary workaround, we use reflection to reset the `repartitionRequired` flag on the `KStream` so that joins and aggregations won't require an additional repartitioning. This can be removed once KIP-159 is in as part of AK 1.1