### PR TITLE
Assign query id only to the persistent queries (CSAS/CTAS). We don't …

### DIFF
--- a/ksql-engine/src/main/java/io/confluent/ksql/QueryEngine.java
+++ b/ksql-engine/src/main/java/io/confluent/ksql/QueryEngine.java
@@ -162,7 +162,7 @@ class QueryEngine {
         overriddenStreamsProperties,
         updateMetastore,
         ksqlEngine.getMetaStore(),
-        queryIdCounter.getAndIncrement());
+        queryIdCounter);
 
     physicalPlans.add(physicalPlanBuilder.buildPhysicalPlan(statementPlanPair));
   }

--- a/ksql-engine/src/main/java/io/confluent/ksql/physical/PhysicalPlanBuilder.java
+++ b/ksql-engine/src/main/java/io/confluent/ksql/physical/PhysicalPlanBuilder.java
@@ -47,6 +47,7 @@ import org.apache.kafka.streams.StreamsConfig;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.concurrent.ThreadLocalRandom;
+import java.util.concurrent.atomic.AtomicLong;
 
 public class PhysicalPlanBuilder {
 
@@ -59,7 +60,7 @@ public class PhysicalPlanBuilder {
   private final Map<String, Object> overriddenStreamsProperties;
   private final MetaStore metaStore;
   private final boolean updateMetastore;
-  private final long queryId;
+  private final AtomicLong queryIdCounter;
 
   public PhysicalPlanBuilder(final StreamsBuilder builder,
                              final KsqlConfig ksqlConfig,
@@ -70,7 +71,7 @@ public class PhysicalPlanBuilder {
                              final Map<String, Object> overriddenStreamsProperties,
                              final boolean updateMetastore,
                              final MetaStore metaStore,
-                             final long queryId) {
+                             final AtomicLong queryIdCounter) {
     this.builder = builder;
     this.ksqlConfig = ksqlConfig;
     this.kafkaTopicClient = kafkaTopicClient;
@@ -80,7 +81,7 @@ public class PhysicalPlanBuilder {
     this.overriddenStreamsProperties = overriddenStreamsProperties;
     this.metaStore = metaStore;
     this.updateMetastore = updateMetastore;
-    this.queryId = queryId;
+    this.queryIdCounter = queryIdCounter;
   }
 
   public QueryMetadata buildPhysicalPlan(final Pair<String, PlanNode> statementPlanPair) throws Exception {
@@ -159,6 +160,7 @@ public class PhysicalPlanBuilder {
                                                          final String persistanceQueryPrefix,
                                                          final String statement) {
 
+    long queryId = queryIdCounter.getAndIncrement();
     String applicationId = serviceId + persistanceQueryPrefix + queryId;
     if (addUniqueTimeSuffix) {
       applicationId = addTimeSuffix(applicationId);

--- a/ksql-engine/src/test/java/io/confluent/ksql/physical/PhysicalPlanBuilderTest.java
+++ b/ksql-engine/src/test/java/io/confluent/ksql/physical/PhysicalPlanBuilderTest.java
@@ -36,6 +36,7 @@ import org.junit.Test;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
+import java.util.concurrent.atomic.AtomicLong;
 
 import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.MatcherAssert.assertThat;
@@ -65,8 +66,7 @@ public class PhysicalPlanBuilderTest {
         false,
         Collections.emptyMap(),
         false,
-        metaStore,
-        1);
+        metaStore, new AtomicLong(1) );
     planBuilder = new LogicalPlanBuilder(metaStore);
   }
 


### PR DESCRIPTION
The query id counter was incremented for both persistent (CSAS/CTAS) queries and transient (SELEC) queries. We just need to do this for persistent queries.