### PR TITLE
Added basic auth capabilities to KSQL Remote cli

### DIFF
--- a/ksql-cli/src/main/java/io/confluent/ksql/cli/commands/Remote.java
+++ b/ksql-cli/src/main/java/io/confluent/ksql/cli/commands/Remote.java
@@ -60,18 +60,20 @@ public class Remote extends AbstractCliCommands {
   String propertiesFile;
 
   private static final String USERNAME_OPTION = "--user";
+  private static final String USERNAME_SHORT_OPTION = "-u";
   private static final String PASSWORD_OPTION = "--password";
+  private static final String PASSWORD_SHORT_OPTION = "-p";
   @Option(
-          name = USERNAME_OPTION,
+          name = {USERNAME_OPTION, USERNAME_SHORT_OPTION},
           description = "If your KSQL server is configured for authentication, then provide your user name here. " +
-                  "The password must be specified separately with the " + PASSWORD_OPTION + " flag"
+                  "The password must be specified separately with the " + PASSWORD_SHORT_OPTION + "/" + PASSWORD_OPTION + " flag"
   )
   String userName;
 
   @Option(
-          name = PASSWORD_OPTION,
+          name = {PASSWORD_OPTION, PASSWORD_SHORT_OPTION},
           description = "If your KSQL server is configured for authentication, then provide your password here. " +
-                  "The username must be specified separately with the " + USERNAME_OPTION + " flag"
+                  "The username must be specified separately with the " + USERNAME_SHORT_OPTION + "/" + USERNAME_OPTION + " flag"
   )
   String password;
 

--- a/ksql-cli/src/main/java/io/confluent/ksql/cli/commands/Remote.java
+++ b/ksql-cli/src/main/java/io/confluent/ksql/cli/commands/Remote.java
@@ -21,6 +21,7 @@ import com.github.rvesse.airline.annotations.Option;
 import com.github.rvesse.airline.annotations.restrictions.Once;
 import com.github.rvesse.airline.annotations.restrictions.Required;
 
+import io.confluent.common.config.ConfigException;
 import org.apache.kafka.streams.StreamsConfig;
 
 import io.confluent.ksql.cli.Cli;
@@ -58,6 +59,22 @@ public class Remote extends AbstractCliCommands {
   )
   String propertiesFile;
 
+  private static final String USERNAME_OPTION = "--user";
+  private static final String PASSWORD_OPTION = "--password";
+  @Option(
+          name = USERNAME_OPTION,
+          description = "If your KSQL server is configured for authentication, then provide your user name here. " +
+                  "The password must be specified separately with the " + PASSWORD_OPTION + " flag"
+  )
+  String userName;
+
+  @Option(
+          name = PASSWORD_OPTION,
+          description = "If your KSQL server is configured for authentication, then provide your password here. " +
+                  "The username must be specified separately with the " + USERNAME_OPTION + " flag"
+  )
+  String password;
+
   @Override
   public Cli getCli() throws Exception {
     Map<String, Object> propertiesMap = new HashMap<>();
@@ -67,6 +84,16 @@ public class Remote extends AbstractCliCommands {
     }
 
     KsqlRestClient restClient = new KsqlRestClient(server, propertiesMap);
+    if ((userName == null && password != null) || (password == null && userName != null)) {
+      throw new ConfigException("You must specify both a username and a password. If you don't want to use an " +
+              "authenticated session, don't specify either of the " + USERNAME_OPTION + " or the " + PASSWORD_OPTION
+              + " flags on the command line");
+    }
+
+    if (userName != null) {
+      restClient.setupAuthenticationCredentials(userName, password);
+    }
+
     Console terminal = new JLineTerminal(parseOutputFormat(), restClient);
 
     versionCheckerAgent.start(KsqlModuleType.REMOTE_CLI, properties);

--- a/ksql-cli/src/test/java/io/confluent/ksql/cli/commands/RemoteTest.java
+++ b/ksql-cli/src/test/java/io/confluent/ksql/cli/commands/RemoteTest.java
@@ -1,0 +1,76 @@
+/**
+ * Copyright 2017 Confluent Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ **/
+
+package io.confluent.ksql.cli.commands;
+
+import io.confluent.common.config.ConfigException;
+import io.confluent.ksql.cli.Cli;
+import io.confluent.ksql.cli.RemoteCli;
+import io.confluent.ksql.version.metrics.VersionCheckerAgent;
+import org.easymock.EasyMock;
+import org.junit.Test;
+
+import static junit.framework.TestCase.assertNotNull;
+import static junit.framework.TestCase.fail;
+import static org.junit.Assert.assertTrue;
+
+public class RemoteTest {
+
+  @Test
+  public void shouldThrowConfigExceptionIfOnlyUsernameIsProvided() throws Exception {
+    Remote remoteCommand = new Remote();
+    remoteCommand.server = "http://foobar";
+    remoteCommand.userName = "someone";
+
+    try {
+      remoteCommand.getCli();
+      fail("should have thrown a ConfigException since only the username was specified");
+    } catch (ConfigException e) {
+      // good!
+    }
+  }
+
+  @Test
+  public void shouldThrowConfigExceptionIfOnlyPasswordIsProvided() throws Exception {
+    Remote remoteCommand = new Remote();
+    remoteCommand.server = "http://foobar";
+
+    remoteCommand.password = "hello";
+
+    try {
+      remoteCommand.getCli();
+      fail("should have thrown a ConfigException since only the password was specified");
+    } catch (ConfigException e) {
+      // good!
+    }
+  }
+
+  @Test
+  public void shouldReturnRemoteCliWhenBothUsernameAndPasswordAreProvided() throws Exception {
+    Remote remoteCommand = new Remote();
+    remoteCommand.server = "http://foobar";
+    remoteCommand.versionCheckerAgent = EasyMock.mock(VersionCheckerAgent.class);
+    remoteCommand.userName = "somebody";
+    remoteCommand.password = "password";
+    Cli cli = remoteCommand.getCli();
+    assertNotNull(cli);
+
+    assertTrue(cli instanceof RemoteCli);
+    RemoteCli remoteCli = (RemoteCli) cli;
+
+    assertTrue(remoteCli.hasUserCredentials());
+  }
+}

--- a/ksql-cli/src/test/java/io/confluent/ksql/rest/client/KsqlRestClientTest.java
+++ b/ksql-cli/src/test/java/io/confluent/ksql/rest/client/KsqlRestClientTest.java
@@ -1,0 +1,66 @@
+/**
+ * Copyright 2017 Confluent Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ **/
+
+package io.confluent.ksql.rest.client;
+
+import org.easymock.EasyMock;
+import org.junit.Test;
+
+import javax.ws.rs.client.Client;
+import javax.ws.rs.client.Invocation;
+import javax.ws.rs.client.WebTarget;
+import javax.ws.rs.core.MediaType;
+import javax.ws.rs.core.Response;
+
+import static org.junit.Assert.assertTrue;
+
+public class KsqlRestClientTest {
+
+  @Test
+  public void shouldRaiseAuthenticationExceptionOn401Response() {
+    String serverAddress = "http://foobar";
+    Client client = mockClientExpectingGetRequestAndReturningStatus(serverAddress, Response.Status.UNAUTHORIZED);
+    KsqlRestClient restClient = new KsqlRestClient(client, serverAddress);
+    RestResponse restResponse = restClient.makeRootRequest();
+    assertTrue(restResponse.isErroneous());
+  }
+
+  @Test
+  public void shouldReturnSuccessfulResponseWhenAuthenticationSucceeds() {
+    String serverAddress = "http://foobar";
+    Client client = mockClientExpectingGetRequestAndReturningStatus(serverAddress, Response.Status.OK);
+    KsqlRestClient restClient = new KsqlRestClient(client, serverAddress);
+    RestResponse restResponse = restClient.makeRootRequest();
+    assertTrue(restResponse.isSuccessful());
+  }
+
+  private Client mockClientExpectingGetRequestAndReturningStatus(String server, Response.Status status) {
+    Client client = EasyMock.createNiceMock(Client.class);
+
+    WebTarget target = EasyMock.createNiceMock(WebTarget.class);
+    EasyMock.expect(client.target(server)).andReturn(target);
+    EasyMock.expect(target.path("/")).andReturn(target);
+    Invocation.Builder builder = EasyMock.createNiceMock(Invocation.Builder.class);
+    EasyMock.expect(target.request(MediaType.APPLICATION_JSON_TYPE)).andReturn(builder);
+    Response response = EasyMock.createNiceMock(Response.class);
+    EasyMock.expect(builder.get()).andReturn(response);
+
+    EasyMock.expect(response.getStatus()).andReturn(status.getStatusCode());
+
+    EasyMock.replay(client, target, builder, response);
+    return client;
+  }
+}


### PR DESCRIPTION
This patch adds the ability for the remote CLI to do basic http authentication with the KSQL server. The server side simply needs to be configured to support basic auth -- the code is already there.

There are some improvements we _should_ make: 
1. Currently, the username _and_ password can only be specified by the `--user` and `--password` cli arguments in remote mode.  We should add the option for entering the password on the cli and hiding the characters typed for additional security. This may be a nontrivial amount of additional work with the current code base though.
2. The password thus entered is sent to the server on an unsecure connection in plain text. We should use SSL for the connection, but that requires broader changes.

I see this is a first step toward basic security and nothing more.