### PR TITLE
change replication factor check when creating topics

### DIFF
--- a/ksql-engine/src/main/java/io/confluent/ksql/util/KafkaTopicClientImpl.java
+++ b/ksql-engine/src/main/java/io/confluent/ksql/util/KafkaTopicClientImpl.java
@@ -59,7 +59,7 @@ public class KafkaTopicClientImpl implements KafkaTopicClient {
       Map<String, TopicDescription> topicDescriptions = describeTopics(Arrays.asList(topic));
       TopicDescription topicDescription = topicDescriptions.get(topic);
       if (topicDescription.partitions().size() != numPartitions ||
-          topicDescription.partitions().get(0).replicas().size() != replicatonFactor) {
+          topicDescription.partitions().get(0).replicas().size() < replicatonFactor) {
         throw new KafkaTopicException(String.format(
             "Topic '%s' does not conform to the requirements Partitions:%d v %d. Replication: %d v %d", topic,
                 topicDescription.partitions().size(), numPartitions,


### PR DESCRIPTION
When we are about to create a topic and it already exists we should accept a replication factor that is >= the replication factor in config