### PR TITLE
Don't run terminated queries at startup #482

### DIFF
--- a/ksql-rest-app/src/main/java/io/confluent/ksql/rest/server/computation/CommandRunner.java
+++ b/ksql-rest-app/src/main/java/io/confluent/ksql/rest/server/computation/CommandRunner.java
@@ -25,10 +25,7 @@ import org.slf4j.LoggerFactory;
 import java.io.Closeable;
 import java.io.PrintWriter;
 import java.io.StringWriter;
-import java.util.List;
 import java.util.concurrent.atomic.AtomicBoolean;
-
-import io.confluent.ksql.util.Pair;
 
 /**
  * Handles the logic of reading distributed commands, including pre-existing commands that were
@@ -98,8 +95,8 @@ public class CommandRunner implements Runnable, Closeable {
    * @throws Exception TODO: Refine this.
    */
   public void processPriorCommands() throws Exception {
-    List<Pair<CommandId, Command>> priorCommands = commandStore.getPriorCommands();
-    statementExecutor.handleStatements(priorCommands);
+    final RestoreCommands restoreCommands = commandStore.getRestoreCommands();
+    statementExecutor.handleRestoration(restoreCommands);
   }
 
   private void executeStatement(Command command, CommandId commandId) {

--- a/ksql-rest-app/src/main/java/io/confluent/ksql/rest/server/computation/RestoreCommands.java
+++ b/ksql-rest-app/src/main/java/io/confluent/ksql/rest/server/computation/RestoreCommands.java
@@ -32,6 +32,9 @@ class RestoreCommands {
   void addCommand(final CommandId key, final Command value) {
     if (key.getType() == CommandId.Type.TERMINATE) {
       allTerminatedQueries.put(new QueryId(key.getEntity()), key);
+      if (allCommandIds.contains(key)) {
+        allCommandIds.remove(key);
+      }
     } else if (!toRestore.containsKey(key)){
       toRestore.put(key, value);
     }

--- a/ksql-rest-app/src/main/java/io/confluent/ksql/rest/server/computation/RestoreCommands.java
+++ b/ksql-rest-app/src/main/java/io/confluent/ksql/rest/server/computation/RestoreCommands.java
@@ -1,0 +1,71 @@
+/**
+ * Copyright 2017 Confluent Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ **/
+package io.confluent.ksql.rest.server.computation;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+
+import io.confluent.ksql.query.QueryId;
+
+class RestoreCommands {
+  private final Map<CommandId, Command> toRestore = new LinkedHashMap<>();
+  private final Map<QueryId, CommandId> allTerminatedQueries = new HashMap<>();
+  private final List<CommandId> allCommandIds = new ArrayList<>();
+
+  void addCommand(final CommandId key, final Command value) {
+    if (key.getType() == CommandId.Type.TERMINATE) {
+      allTerminatedQueries.put(new QueryId(key.getEntity()), key);
+    } else if (!toRestore.containsKey(key)){
+      toRestore.put(key, value);
+    }
+    allCommandIds.add(key);
+  }
+
+  boolean remove(final CommandId commandId) {
+    if (toRestore.remove(commandId) != null) {
+      allCommandIds.remove(commandId);
+      return true;
+    }
+    return false;
+  }
+
+  interface ForEach {
+    void apply(final CommandId commandId,
+               final Command command,
+               final Map<QueryId, CommandId> terminatedQueries);
+  }
+
+  void forEach(final ForEach action) {
+    toRestore.forEach((commandId, command) -> {
+      final int commandIdIdx = allCommandIds.indexOf(commandId);
+      final Map<QueryId, CommandId> terminatedAfter = new HashMap<>();
+      allTerminatedQueries.entrySet().stream()
+          .filter(entry -> allCommandIds.indexOf(entry.getValue()) > commandIdIdx)
+          .forEach(queryIdCommandIdEntry ->
+              terminatedAfter.put(queryIdCommandIdEntry.getKey(), queryIdCommandIdEntry.getValue()));
+      action.apply(commandId, command, terminatedAfter);
+    });
+  }
+
+  // Visible for testing
+  Map<QueryId, CommandId> terminatedQueries() {
+    return Collections.unmodifiableMap(allTerminatedQueries);
+  }
+}

--- a/ksql-rest-app/src/test/java/io/confluent/ksql/rest/server/computation/CommandRunnerTest.java
+++ b/ksql-rest-app/src/test/java/io/confluent/ksql/rest/server/computation/CommandRunnerTest.java
@@ -69,11 +69,11 @@ public class CommandRunnerTest {
   @Test
   public void shouldFetchAndRunPriorCommandsFromCommandTopic() throws Exception {
     StatementExecutor statementExecutor = mock(StatementExecutor.class);
-    statementExecutor.handleStatements(anyObject());
+    statementExecutor.handleRestoration(anyObject());
     expectLastCall();
     replay(statementExecutor);
     CommandStore commandStore = mock(CommandStore.class);
-    expect(commandStore.getPriorCommands()).andReturn(Collections.emptyList());
+    expect(commandStore.getRestoreCommands()).andReturn(new RestoreCommands());
     replay(commandStore);
     CommandRunner commandRunner = new CommandRunner(statementExecutor, commandStore);
     commandRunner.processPriorCommands();

--- a/ksql-rest-app/src/test/java/io/confluent/ksql/rest/server/computation/RestoreCommandsTest.java
+++ b/ksql-rest-app/src/test/java/io/confluent/ksql/rest/server/computation/RestoreCommandsTest.java
@@ -1,0 +1,107 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.confluent.ksql.rest.server.computation;
+
+import org.junit.Test;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+
+import io.confluent.ksql.query.QueryId;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.core.IsEqual.equalTo;
+
+public class RestoreCommandsTest {
+
+  private final RestoreCommands restoreCommands = new RestoreCommands();
+  private final CommandId createId = new CommandId(CommandId.Type.TABLE, "foo", CommandId.Action.CREATE);
+  private final CommandId terminateId = new CommandId(CommandId.Type.TERMINATE,
+      "queryId",
+      CommandId.Action.EXECUTE);
+  private final Command createCommand = new Command("create table foo", Collections.emptyMap());
+  private final Command terminateCommand = new Command("terminate query 'queryId'", Collections.emptyMap());
+
+  @Test
+  public void shouldHaveMapContainingTerminatedQueriesThatWereIssuedAfterCreate() {
+    restoreCommands.addCommand(createId,
+        createCommand);
+    restoreCommands.addCommand(terminateId,
+        terminateCommand);
+
+    restoreCommands.forEach((commandId, command, terminatedQueries) -> {
+      assertThat(commandId, equalTo(createId));
+      assertThat(command, equalTo(createCommand));
+      assertThat(terminatedQueries, equalTo(Collections.singletonMap(new QueryId("queryId"),
+          terminateId)));
+    });
+  }
+
+  @Test
+  public void shouldNotHaveTerminatedQueryWhenDroppedAndRecreatedAfterTerminate() {
+    restoreCommands.addCommand(createId,
+        createCommand);
+    restoreCommands.addCommand(terminateId,
+        terminateCommand);
+    // drop
+    restoreCommands.remove(createId);
+    // recreate
+    restoreCommands.addCommand(createId, createCommand);
+    restoreCommands.forEach((commandId, command, terminatedQueries) -> {
+      assertThat(commandId, equalTo(createId));
+      assertThat(command, equalTo(createCommand));
+      assertThat(terminatedQueries, equalTo(Collections.emptyMap()));
+    });
+  }
+
+  @Test
+  public void shouldNotHaveTerminatedQueriesIssuedBeforeCreate() {
+    restoreCommands.addCommand(terminateId,
+        terminateCommand);
+    restoreCommands.addCommand(createId,
+        createCommand);
+
+    restoreCommands.forEach((commandId, command, terminatedQueries) -> {
+      assertThat(commandId, equalTo(createId));
+      assertThat(command, equalTo(createCommand));
+      assertThat(terminatedQueries, equalTo(Collections.emptyMap()));
+    });
+
+  }
+
+  @Test
+  public void shouldIterateCommandsInOrderTheyWereIssued() {
+    restoreCommands.addCommand(createId,
+        createCommand);
+    final CommandId createStreamOneId =
+        new CommandId(CommandId.Type.STREAM, "stream", CommandId.Action.CREATE);
+
+    restoreCommands.addCommand(createStreamOneId,
+        new Command("create stream one", Collections.emptyMap()));
+
+    final List<CommandId> results = new ArrayList<>();
+    restoreCommands.forEach((commandId, command, terminatedQueries) -> {
+      results.add(commandId);
+    });
+    assertThat(results, equalTo(Arrays.asList(createId, createStreamOneId)));
+  }
+
+
+}

--- a/ksql-rest-app/src/test/java/io/confluent/ksql/rest/server/computation/StatementExecutorTest.java
+++ b/ksql-rest-app/src/test/java/io/confluent/ksql/rest/server/computation/StatementExecutorTest.java
@@ -86,7 +86,7 @@ public class StatementExecutorTest extends EasyMockSupport {
   public void shouldNotRunNullStatementList() {
     StatementExecutor statementExecutor = getStatementExecutor();
     try{
-      statementExecutor.handleStatements(null);
+      statementExecutor.handleRestoration(null);
     } catch (Exception nex) {
       assertThat("Statement list should not be null.", nex instanceof NullPointerException);
     }
@@ -150,13 +150,15 @@ public class StatementExecutorTest extends EasyMockSupport {
     StatementExecutor statementExecutor = getStatementExecutor();
     TestUtils testUtils = new TestUtils();
     List<Pair<CommandId, Command>> priorCommands = testUtils.getAllPriorCommandRecords();
+    final RestoreCommands restoreCommands = new RestoreCommands();
+    priorCommands.forEach(pair -> restoreCommands.addCommand(pair.left, pair.right));
 
     CommandId topicCommandId =  new CommandId(CommandId.Type.TOPIC, "_CSASTopicGen", CommandId.Action.CREATE);
     CommandId csCommandId =  new CommandId(CommandId.Type.STREAM, "_CSASStreamGen", CommandId.Action.CREATE);
     CommandId csasCommandId =  new CommandId(CommandId.Type.STREAM, "_CSASGen", CommandId.Action.CREATE);
     CommandId ctasCommandId =  new CommandId(CommandId.Type.TABLE, "_CTASGen", CommandId.Action.CREATE);
 
-    statementExecutor.handleStatements(priorCommands);
+    statementExecutor.handleRestoration(restoreCommands);
 
     Map<CommandId, CommandStatus> statusStore = statementExecutor.getStatuses();
     Assert.assertNotNull(statusStore);


### PR DESCRIPTION
When reading the previous command from the command topic also collect the terminated queryIds such that any query that has been terminated will not be re-run. It will still have its data in the metastore so that any dependent queries can reference it #482