### PR TITLE
Add metrics which report the number of running queries

### DIFF
--- a/ksql-common/src/main/java/io/confluent/ksql/metrics/ConsumerCollector.java
+++ b/ksql-common/src/main/java/io/confluent/ksql/metrics/ConsumerCollector.java
@@ -140,14 +140,9 @@ public class ConsumerCollector implements MetricCollector {
 
 
   @Override
-  public double currentMessageProductionRate() {
-    return 0;
-  }
-
-  @Override
   public double currentMessageConsumptionRate() {
     final List<TopicSensors.Stat> allStats = new ArrayList<>();
-    topicSensors.values().stream().forEach(record -> allStats.addAll(record.stats(false)));
+    topicSensors.values().forEach(record -> allStats.addAll(record.stats(false)));
 
     return allStats
         .stream()

--- a/ksql-common/src/main/java/io/confluent/ksql/metrics/ConsumerCollector.java
+++ b/ksql-common/src/main/java/io/confluent/ksql/metrics/ConsumerCollector.java
@@ -140,6 +140,23 @@ public class ConsumerCollector implements MetricCollector {
 
 
   @Override
+  public double currentMessageProductionRate() {
+    return 0;
+  }
+
+  @Override
+  public double currentMessageConsumptionRate() {
+    final List<TopicSensors.Stat> allStats = new ArrayList<>();
+    topicSensors.values().stream().forEach(record -> allStats.addAll(record.stats(false)));
+
+    return allStats
+        .stream()
+        .filter(stat -> stat.name().contains("events-per-sec"))
+        .mapToDouble(TopicSensors.Stat::getValue)
+        .sum();
+  }
+
+  @Override
   public String toString() {
     return getClass().getSimpleName() + " id:" + this.id + " " + topicSensors.keySet();
   }

--- a/ksql-common/src/main/java/io/confluent/ksql/metrics/MetricCollector.java
+++ b/ksql-common/src/main/java/io/confluent/ksql/metrics/MetricCollector.java
@@ -46,4 +46,14 @@ interface MetricCollector extends ConsumerInterceptor, ProducerInterceptor {
   Collection<TopicSensors.Stat> stats(String topic, boolean isError);
 
   void recordError(String topic);
+
+  /**
+   * Get the current message production across all topics tracked by this collector.
+   */
+  double currentMessageProductionRate();
+
+  /**
+   * Get the current message consumption rate across all topics tracked by this collector.
+   */
+  double currentMessageConsumptionRate();
 }

--- a/ksql-common/src/main/java/io/confluent/ksql/metrics/MetricCollector.java
+++ b/ksql-common/src/main/java/io/confluent/ksql/metrics/MetricCollector.java
@@ -50,10 +50,14 @@ interface MetricCollector extends ConsumerInterceptor, ProducerInterceptor {
   /**
    * Get the current message production across all topics tracked by this collector.
    */
-  double currentMessageProductionRate();
+  default double currentMessageProductionRate() {
+    return 0;
+  }
 
   /**
    * Get the current message consumption rate across all topics tracked by this collector.
    */
-  double currentMessageConsumptionRate();
+  default double currentMessageConsumptionRate() {
+    return 0;
+  }
 }

--- a/ksql-common/src/main/java/io/confluent/ksql/metrics/MetricCollectors.java
+++ b/ksql-common/src/main/java/io/confluent/ksql/metrics/MetricCollectors.java
@@ -92,6 +92,18 @@ public class MetricCollectors {
     return results.toString();
   }
 
+  public static double currentProductionRate() {
+    return collectorMap.values().stream()
+        .mapToDouble(MetricCollector::currentMessageProductionRate)
+        .sum();
+  }
+
+  public static double currentConsumptionRate() {
+    return collectorMap.values().stream()
+        .mapToDouble(MetricCollector::currentMessageConsumptionRate)
+        .sum();
+  }
+
   public static Metrics getMetrics() {
     return metrics;
   }

--- a/ksql-common/src/main/java/io/confluent/ksql/metrics/ProducerCollector.java
+++ b/ksql-common/src/main/java/io/confluent/ksql/metrics/ProducerCollector.java
@@ -129,14 +129,9 @@ public class ProducerCollector implements MetricCollector {
   }
 
   @Override
-  public double currentMessageConsumptionRate() {
-    return 0;
-  }
-
-  @Override
   public double currentMessageProductionRate() {
     final List<TopicSensors.Stat> allStats = new ArrayList<>();
-    topicSensors.values().stream().forEach(record -> allStats.addAll(record.stats(false)));
+    topicSensors.values().forEach(record -> allStats.addAll(record.stats(false)));
 
     return allStats
         .stream()

--- a/ksql-common/src/main/java/io/confluent/ksql/metrics/ProducerCollector.java
+++ b/ksql-common/src/main/java/io/confluent/ksql/metrics/ProducerCollector.java
@@ -129,6 +129,23 @@ public class ProducerCollector implements MetricCollector {
   }
 
   @Override
+  public double currentMessageConsumptionRate() {
+    return 0;
+  }
+
+  @Override
+  public double currentMessageProductionRate() {
+    final List<TopicSensors.Stat> allStats = new ArrayList<>();
+    topicSensors.values().stream().forEach(record -> allStats.addAll(record.stats(false)));
+
+    return allStats
+        .stream()
+        .filter(stat -> stat.name().contains("events-per-sec"))
+        .mapToDouble(TopicSensors.Stat::getValue)
+        .sum();
+  }
+
+  @Override
   public String toString() {
     return getClass().getSimpleName() + " " + this.id + " " + this.topicSensors.toString();
   }

--- a/ksql-common/src/test/java/io/confluent/ksql/metrics/MetricCollectorsTest.java
+++ b/ksql-common/src/test/java/io/confluent/ksql/metrics/MetricCollectorsTest.java
@@ -4,21 +4,32 @@ import com.google.common.collect.ImmutableMap;
 import org.apache.kafka.clients.consumer.ConsumerConfig;
 import org.apache.kafka.clients.consumer.ConsumerRecord;
 import org.apache.kafka.clients.consumer.ConsumerRecords;
+import org.apache.kafka.clients.producer.ProducerConfig;
+import org.apache.kafka.clients.producer.ProducerRecord;
 import org.apache.kafka.common.TopicPartition;
 import org.apache.kafka.common.record.TimestampType;
+import org.junit.After;
 import org.junit.Test;
 
+import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
 import static org.hamcrest.CoreMatchers.equalTo;
+import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertThat;
 import static org.junit.Assert.assertTrue;
 
 public class MetricCollectorsTest {
 
   private static final String TEST_TOPIC = "shared-topic";
+
+  @After
+  public void tearDown() {
+    MetricCollectors.getMetrics().close();
+  }
 
   @Test
   public void shouldAggregateStats() throws Exception {
@@ -30,7 +41,7 @@ public class MetricCollectorsTest {
   }
 
 
-    @Test
+  @Test
   public void shouldKeepWorkingWhenDuplicateTopicConsumerIsRemoved() throws Exception {
 
     ConsumerCollector collector1 = new ConsumerCollector();
@@ -61,6 +72,52 @@ public class MetricCollectorsTest {
     String statsForTopic2 =  MetricCollectors.getStatsFor(TEST_TOPIC, false);
 
     assertTrue("Missed stats, got:" + statsForTopic2, statsForTopic2.contains("total-events:         2"));
+  }
 
+
+  @Test
+  public void shouldAggregateStatsAcrossAllProducers() throws Exception {
+    ProducerCollector collector1 = new ProducerCollector();
+    collector1.configure(ImmutableMap.of(ProducerConfig.CLIENT_ID_CONFIG, "client1"));
+
+    ProducerCollector collector2 = new ProducerCollector();
+    collector2.configure(ImmutableMap.of(ProducerConfig.CLIENT_ID_CONFIG, "client2"));
+
+    for (int i = 0; i < 500; i++) {
+      collector1.onSend(new ProducerRecord<>(TEST_TOPIC, "key", Integer.toString(i)));
+      collector2.onSend(new ProducerRecord<>(TEST_TOPIC + "_" + i, "key",
+                                             Integer.toString(i * 100)));
+    }
+
+    // The Kafka metrics in MetricCollectors is configured so that sampled stats (like the Rate
+    // measurable stat) have a 100 samples, each with a duration of 1 second. In this test we
+    // record a 1000 events, but only in a single sample since they all belong to the same second.
+    // So 99 samples are empty. Hence the rate is computed as a tenth of what it should be. This
+    // won't be a problem for a longer running program.
+    assertEquals(10, Math.floor(MetricCollectors.currentProductionRate()), 0);
+  }
+
+
+  @Test
+  public void shouldAggregateStatsAcrossAllConsumers() throws Exception {
+    ConsumerCollector collector1 = new ConsumerCollector();
+    collector1.configure(ImmutableMap.of(ConsumerConfig.CLIENT_ID_CONFIG, "client1"));
+
+    ConsumerCollector collector2 = new ConsumerCollector();
+    collector2.configure(ImmutableMap.of(ConsumerConfig.CLIENT_ID_CONFIG, "client2"));
+    Map<TopicPartition, List<ConsumerRecord<Object, Object>>> records = new HashMap<>();
+    List<ConsumerRecord<Object, Object>> recordList = new ArrayList<>();
+    for (int i = 0; i < 500; i++) {
+      recordList.add(new ConsumerRecord<>(TEST_TOPIC, 1, 1,  1l, TimestampType
+          .CREATE_TIME,  1l, 10, 10, "key", "1234567890"));
+    }
+    records.put(new TopicPartition(TEST_TOPIC, 1), recordList);
+    ConsumerRecords<Object, Object> consumerRecords = new ConsumerRecords<>(records);
+    collector1.onConsume(consumerRecords);
+    collector2.onConsume(consumerRecords);
+
+    // Same as the above test, the kafka `Rate` measurable stat reports the rate as a tenth
+    // of what it should be because all the samples haven't been filled out yet.
+    assertEquals(10, Math.floor(MetricCollectors.currentConsumptionRate()), 0);
   }
 }

--- a/ksql-engine/src/main/java/io/confluent/ksql/KsqlContext.java
+++ b/ksql-engine/src/main/java/io/confluent/ksql/KsqlContext.java
@@ -109,7 +109,7 @@ public class KsqlContext {
   }
 
   public Set<QueryMetadata> getRunningQueries() {
-    return ksqlEngine.getLiveQueries();
+    return ksqlEngine.getLivePersistentQueries();
   }
 
   public void close() throws IOException {

--- a/ksql-engine/src/main/java/io/confluent/ksql/KsqlEngine.java
+++ b/ksql-engine/src/main/java/io/confluent/ksql/KsqlEngine.java
@@ -461,6 +461,10 @@ public class KsqlEngine implements Closeable, QueryTerminator {
     return true;
   }
 
+  public void removeTemporaryQuery(QueryMetadata queryMetadata) {
+    this.allLiveQueries.remove(queryMetadata);
+  }
+
   public DDLCommandResult executeDdlStatement(String sqlExpression, final DDLStatement statement,
                                               final Map<String, Object> streamsProperties) {
     return queryEngine.handleDdlStatement(sqlExpression, statement, streamsProperties);

--- a/ksql-engine/src/main/java/io/confluent/ksql/internal/KsqlEngineMetrics.java
+++ b/ksql-engine/src/main/java/io/confluent/ksql/internal/KsqlEngineMetrics.java
@@ -1,0 +1,105 @@
+/**
+ * Copyright 2017 Confluent Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ **/
+
+package io.confluent.ksql.internal;
+
+import org.apache.kafka.common.metrics.MeasurableStat;
+import org.apache.kafka.common.metrics.MetricConfig;
+import org.apache.kafka.common.metrics.Metrics;
+import org.apache.kafka.common.metrics.Sensor;
+import org.apache.kafka.common.metrics.stats.Value;
+
+import java.io.Closeable;
+
+import io.confluent.ksql.KsqlEngine;
+import io.confluent.ksql.metrics.MetricCollectors;
+
+public class KsqlEngineMetrics implements Closeable {
+  private final String metricGroupName;
+  private final Sensor numActiveQueries;
+  private final Sensor messagesIn;
+  private final Sensor messagesOut;
+
+  private final KsqlEngine ksqlEngine;
+
+  public KsqlEngineMetrics(String metricGroupPrefix, KsqlEngine ksqlEngine) {
+    Metrics metrics = MetricCollectors.getMetrics();
+
+    this.ksqlEngine = ksqlEngine;
+
+    this.metricGroupName = metricGroupPrefix + "-query-stats";
+    this.numActiveQueries = metrics.sensor(metricGroupName + "-active-queries");
+    numActiveQueries.add(
+        metrics.metricName("num-active-queries", this.metricGroupName,
+                           "The current number of active queries running in this engine"),
+        new MeasurableStat() {
+          @Override
+          public double measure(MetricConfig metricConfig, long l) {
+            return ksqlEngine.numberOfLiveQueries();
+          }
+
+          @Override
+          public void record(MetricConfig metricConfig, double v, long l) {
+            // We don't want to record anything, since the live queries anyway.
+          }
+        });
+
+    numActiveQueries.add(
+        metrics.metricName("num-persistent-queries", this.metricGroupName,
+                           "The current number of persistent queries running in this engine"),
+        new MeasurableStat() {
+          @Override
+          public double measure(MetricConfig metricConfig, long l) {
+            return ksqlEngine.numberOfPersistentQueries();
+          }
+
+          @Override
+          public void record(MetricConfig metricConfig, double v, long l) {
+            // No action for record since we can read the desired results directly.
+          }
+        }
+    );
+
+    this.messagesIn = metrics.sensor(metricGroupName + "-messages-consumed");
+    this.messagesIn.add(
+        metrics.metricName("messages-consumed-per-sec", this.metricGroupName,
+                           "The number of messages consumed per second across all queries"),
+        new Value());
+
+
+    this.messagesOut = metrics.sensor(metricGroupName + "-messages-produced");
+    this.messagesOut.add(
+        metrics.metricName("messages-produced-per-sec", this.metricGroupName,
+                           "The number of messages produced per second across all queries"),
+        new Value());
+  }
+
+  public void recordMessagesProduced(double value) {
+    this.messagesOut.record(value);
+  }
+
+  public void recordMessagesConsumed(double value) {
+    this.messagesIn.record(value);
+  }
+
+  @Override
+  public void close() {
+    Metrics metrics = MetricCollectors.getMetrics();
+    metrics.removeSensor(numActiveQueries.name());
+    metrics.removeSensor(messagesIn.name());
+    metrics.removeSensor(messagesOut.name());
+  }
+}

--- a/ksql-engine/src/main/java/io/confluent/ksql/util/QueryMetadata.java
+++ b/ksql-engine/src/main/java/io/confluent/ksql/util/QueryMetadata.java
@@ -86,6 +86,7 @@ public class QueryMetadata {
   }
 
   public void close() {
+
     kafkaStreams.close();
     if (kafkaStreams.state() == KafkaStreams.State.NOT_RUNNING) {
       kafkaStreams.cleanUp();

--- a/ksql-rest-app/src/main/java/io/confluent/ksql/rest/server/resources/streaming/QueryStreamWriter.java
+++ b/ksql-rest-app/src/main/java/io/confluent/ksql/rest/server/resources/streaming/QueryStreamWriter.java
@@ -44,6 +44,7 @@ class QueryStreamWriter implements StreamingOutput {
   private final long disconnectCheckInterval;
   private final ObjectMapper objectMapper;
   private Throwable streamsException;
+  private final KsqlEngine ksqlEngine;
 
 
   QueryStreamWriter(
@@ -66,6 +67,7 @@ class QueryStreamWriter implements StreamingOutput {
     this.queryMetadata = ((QueuedQueryMetadata) queryMetadata);
 
     this.queryMetadata.getKafkaStreams().setUncaughtExceptionHandler(new StreamsExceptionHandler());
+    this.ksqlEngine = ksqlEngine;
     queryMetadata.getKafkaStreams().start();
   }
 
@@ -106,6 +108,7 @@ class QueryStreamWriter implements StreamingOutput {
       out.flush();
 
     } finally {
+      ksqlEngine.removeTemporaryQuery(queryMetadata);
       queryMetadata.close();
     }
   }

--- a/ksql-rest-app/src/test/java/io/confluent/ksql/rest/server/resources/StreamedQueryResourceTest.java
+++ b/ksql-rest-app/src/test/java/io/confluent/ksql/rest/server/resources/StreamedQueryResourceTest.java
@@ -119,6 +119,8 @@ public class StreamedQueryResourceTest {
                                 );
     expect(mockKsqlEngine.buildMultipleQueries(queryString, requestStreamsProperties))
         .andReturn(Collections.singletonList(queuedQueryMetadata));
+    mockKsqlEngine.removeTemporaryQuery(queuedQueryMetadata);
+    expectLastCall();
 
     StatementParser mockStatementParser = mock(StatementParser.class);
     expect(mockStatementParser.parseSingleStatement(queryString)).andReturn(mock(Query.class));


### PR DESCRIPTION
This is a first in a series of PRs to add operability metrics to ksql. After this PR, I plan on adding metrics for reporting the relative activity of various queries, the aggregate error rate, and the total throughput across all streams in the system.

Note that there are concurrency issues when reading the `size` of the various structures which track the present queries. This may lead to incorrect readings some of the time, but won't violate the integrity of the system. I think this is preferable to adding excessive synchronization.