### PR TITLE
Print more informative error messages

### DIFF
--- a/ksql-cli/src/main/java/io/confluent/ksql/Ksql.java
+++ b/ksql-cli/src/main/java/io/confluent/ksql/Ksql.java
@@ -21,6 +21,7 @@ import com.github.rvesse.airline.parser.errors.ParseException;
 import io.confluent.ksql.cli.commands.Local;
 import io.confluent.ksql.cli.commands.Remote;
 import io.confluent.ksql.cli.commands.Standalone;
+import io.confluent.ksql.util.CommonUtils;
 
 import java.io.IOException;
 
@@ -48,7 +49,7 @@ public class Ksql {
       }
       System.err.println("See the help command for usage information");
     } catch (Exception e) {
-      System.err.println(e.getMessage());
+      System.err.println(CommonUtils.getErrorMessageWithCause(e));
     }
     if ((runnable != null) && !(runnable instanceof Standalone)) {
       System.exit(0);

--- a/ksql-cli/src/main/java/io/confluent/ksql/cli/Cli.java
+++ b/ksql-cli/src/main/java/io/confluent/ksql/cli/Cli.java
@@ -32,6 +32,7 @@ import io.confluent.ksql.rest.client.RestResponse;
 import io.confluent.ksql.rest.entity.KsqlEntityList;
 import io.confluent.ksql.rest.entity.PropertiesList;
 import io.confluent.ksql.cli.console.Console;
+import io.confluent.ksql.util.CommonUtils;
 import io.confluent.ksql.util.KsqlException;
 import io.confluent.ksql.util.Version;
 import org.apache.commons.lang3.exception.ExceptionUtils;
@@ -110,6 +111,10 @@ public class Cli implements Closeable, AutoCloseable {
         } else {
           terminal.writer().println(exception.getClass().getName());
           // TODO: Maybe ask the user if they'd like to see the stack trace here?
+        }
+        String causeMsg = CommonUtils.getErrorCauseMessage(exception);
+        if (causeMsg != "") {
+          terminal.writer().println(causeMsg);
         }
       }
       terminal.flush();

--- a/ksql-cli/src/main/java/io/confluent/ksql/cli/RemoteCli.java
+++ b/ksql-cli/src/main/java/io/confluent/ksql/cli/RemoteCli.java
@@ -20,6 +20,8 @@ import io.confluent.ksql.rest.client.KsqlRestClient;
 import io.confluent.ksql.cli.console.CliSpecificCommand;
 import io.confluent.ksql.cli.console.Console;
 import io.confluent.ksql.rest.client.RestResponse;
+import io.confluent.ksql.rest.client.exception.KsqlRestClientException;
+import io.confluent.ksql.util.CommonUtils;
 
 import javax.ws.rs.ProcessingException;
 import java.io.IOException;
@@ -83,8 +85,17 @@ public class RemoteCli extends Cli {
       }
     } catch (IllegalArgumentException exception) {
       writer.println("Server URL must begin with protocol (e.g., http:// or https://)");
-    } catch (ProcessingException exception) {
-      writer.println("Warning: remote server address may not be valid");
+    } catch (KsqlRestClientException exception) {
+      if (exception.getCause() instanceof ProcessingException) {
+        writer.println();
+        writer.println("**************** WARNING ******************");
+        writer.println("Remote server address may not be valid:");
+        writer.println(CommonUtils.getErrorMessageWithCause(exception));
+        writer.println("*******************************************");
+        writer.println();
+      } else {
+        throw exception;
+      }
     }
   }
 }

--- a/ksql-cli/src/main/java/io/confluent/ksql/cli/commands/AbstractCliCommands.java
+++ b/ksql-cli/src/main/java/io/confluent/ksql/cli/commands/AbstractCliCommands.java
@@ -84,6 +84,8 @@ public abstract class AbstractCliCommands implements Runnable {
       } else {
         cli.runInteractively();
       }
+    } catch (RuntimeException exception) {
+      throw exception;
     } catch (Exception exception) {
       throw new RuntimeException(exception);
     }

--- a/ksql-cli/src/main/java/io/confluent/ksql/util/CliUtils.java
+++ b/ksql-cli/src/main/java/io/confluent/ksql/util/CliUtils.java
@@ -26,7 +26,6 @@ import java.io.BufferedReader;
 import java.io.FileInputStream;
 import java.io.IOException;
 import java.io.InputStreamReader;
-import java.net.ConnectException;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
@@ -96,14 +95,6 @@ public class CliUtils {
       throw new KsqlException("Could not read the query file. Details: " + e.getMessage(), e);
     }
     return sb.toString();
-  }
-
-  public static String getErrorMessage(Throwable e) {
-    if (e instanceof ConnectException) {
-      return "Could not connect to the server.";
-    } else {
-      return e.getMessage();
-    }
   }
 
   public static PropertiesList propertiesListWithOverrides(PropertiesList propertiesList, Map<String, Object> localProperties) {

--- a/ksql-cli/src/test/java/io/confluent/ksql/util/CliUtilsTest.java
+++ b/ksql-cli/src/test/java/io/confluent/ksql/util/CliUtilsTest.java
@@ -30,18 +30,6 @@ import java.sql.SQLDataException;
  * @see CliUtils
  */
 public class CliUtilsTest {
-
-  @Test
-  public void testGetErrorMessage() {
-    Exception exception = new SQLDataException("http://localhost:1621", "", 422);
-
-    assertEquals("http://localhost:1621", CliUtils.getErrorMessage(exception));
-
-    exception = new ConnectException("asdf");
-
-    assertEquals("Could not connect to the server.", CliUtils.getErrorMessage(exception));
-  }
-
   @Test
   public void testReadQueryFileWithNonEmptyStringThrowsKsqlException() throws IOException {
     CliUtils cliUtils = new CliUtils();

--- a/ksql-common/src/main/java/io/confluent/ksql/util/CommonUtils.java
+++ b/ksql-common/src/main/java/io/confluent/ksql/util/CommonUtils.java
@@ -1,0 +1,49 @@
+/**
+ * Copyright 2017 Confluent Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ **/
+
+package io.confluent.ksql.util;
+
+import java.net.ConnectException;
+
+public class CommonUtils {
+  public static String getErrorMessageWithCause(Throwable e) {
+    String msg = getErrorMessage(e);
+    String causeMsg = getErrorCauseMessage(e);
+    // append the cause msg, if any
+    return causeMsg == "" ? msg : msg + "\r\n" + causeMsg;
+  }
+
+  public static String getErrorMessage(Throwable e) {
+    if (e instanceof ConnectException) {
+      return "Could not connect to the server.";
+    } else {
+      return e.getMessage();
+    }
+  }
+
+  public static String getErrorCauseMessage(Throwable e) {
+    String prefix = "Caused by: ";
+    String msg = "";
+    // walk down the cause stack and append error messages
+    e = e.getCause();
+    while (e != null) {
+      msg += prefix + getErrorMessage(e);
+      e = e.getCause();
+      prefix = "\r\n" + prefix;
+    }
+    return msg;
+  }
+}

--- a/ksql-common/src/test/java/io/confluent/ksql/util/CommonUtilsTest.java
+++ b/ksql-common/src/test/java/io/confluent/ksql/util/CommonUtilsTest.java
@@ -1,0 +1,80 @@
+/**
+ * Copyright 2017 Confluent Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ **/
+
+package io.confluent.ksql.util;
+
+import org.junit.Test;
+
+import java.net.ConnectException;
+import java.sql.SQLDataException;
+
+import static org.junit.Assert.assertEquals;
+
+public class CommonUtilsTest {
+  @Test
+  public void testGetErrorMessage() {
+    Exception exception = new SQLDataException("http://localhost:1621", "", 422);
+
+    assertEquals("http://localhost:1621", CommonUtils.getErrorMessage(exception));
+
+    exception = new ConnectException("asdf");
+
+    assertEquals("Could not connect to the server.", CommonUtils.getErrorMessage(exception));
+  }
+
+  class TestException extends Exception {
+    TestException (String msg) { super(msg); }
+    TestException (String msg, Throwable cause) { super(msg, cause); }
+  }
+
+  @Test
+  public void testGetErrorCauseMessage() {
+    // test the case where there is a single cause
+    Exception cause = new TestException("Cause");
+    Exception exception = new TestException("Exception", cause);
+
+    assertEquals("Caused by: Cause", CommonUtils.getErrorCauseMessage(exception));
+
+    // test the case where there are multiple causes
+    Exception l2Cause = new TestException("L2 Cause");
+    cause = new TestException("Cause", l2Cause);
+    exception = new TestException("Exception", cause);
+
+    assertEquals("Caused by: Cause\r\nCaused by: L2 Cause", CommonUtils.getErrorCauseMessage(exception));
+  }
+
+  @Test
+  public void testGetErrorCauseMessageNoCause() {
+    Exception exception = new TestException("Exception");
+
+    assertEquals("", CommonUtils.getErrorCauseMessage(exception));
+  }
+
+  @Test
+  public void testGetErrorMessageWithCause() {
+    Exception cause = new TestException("Cause");
+    Exception exception = new TestException("Exception", cause);
+
+    assertEquals("Exception\r\nCaused by: Cause", CommonUtils.getErrorMessageWithCause(exception));
+  }
+
+  @Test
+  public void testGetErrorMessageWithCauseNoCause() {
+    Exception exception = new TestException("Exception");
+
+    assertEquals("Exception", CommonUtils.getErrorMessageWithCause(exception));
+  }
+}

--- a/ksql-rest-app/src/main/java/io/confluent/ksql/rest/client/KsqlRestClient.java
+++ b/ksql-rest-app/src/main/java/io/confluent/ksql/rest/client/KsqlRestClient.java
@@ -17,6 +17,7 @@
 package io.confluent.ksql.rest.client;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import io.confluent.ksql.rest.client.exception.KsqlRestClientException;
 import io.confluent.ksql.rest.entity.CommandStatus;
 import io.confluent.ksql.rest.entity.CommandStatuses;
 import io.confluent.ksql.rest.entity.ErrorMessage;
@@ -169,16 +170,24 @@ public class KsqlRestClient implements Closeable, AutoCloseable {
   }
 
   private Response makePostRequest(String path, Object jsonEntity) {
-    return client.target(serverAddress)
-        .path(path)
-        .request(MediaType.APPLICATION_JSON_TYPE)
-        .post(Entity.json(jsonEntity));
+    try {
+      return client.target(serverAddress)
+              .path(path)
+              .request(MediaType.APPLICATION_JSON_TYPE)
+              .post(Entity.json(jsonEntity));
+    } catch (Exception exception) {
+      throw new KsqlRestClientException("Error issuing POST to KSQL server", exception);
+    }
   }
 
   private Response makeGetRequest(String path) {
-    return client.target(serverAddress).path(path)
-        .request(MediaType.APPLICATION_JSON_TYPE)
-        .get();
+    try {
+      return client.target(serverAddress).path(path)
+              .request(MediaType.APPLICATION_JSON_TYPE)
+              .get();
+    } catch (Exception exception) {
+      throw new KsqlRestClientException("Error issuing GET to KSQL server", exception);
+    }
   }
 
   public static class QueryStream implements Closeable, AutoCloseable, Iterator<StreamedRow> {

--- a/ksql-rest-app/src/main/java/io/confluent/ksql/rest/client/exception/KsqlRestClientException.java
+++ b/ksql-rest-app/src/main/java/io/confluent/ksql/rest/client/exception/KsqlRestClientException.java
@@ -1,0 +1,27 @@
+/**
+ * Copyright 2017 Confluent Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ **/
+
+package io.confluent.ksql.rest.client.exception;
+
+public class KsqlRestClientException extends RuntimeException {
+  public KsqlRestClientException(String message) {
+    super(message);
+  }
+
+  public KsqlRestClientException(String message, Throwable throwable) {
+    super(message, throwable);
+  }
+}

--- a/ksql-rest-app/src/main/java/io/confluent/ksql/rest/entity/ErrorMessage.java
+++ b/ksql-rest-app/src/main/java/io/confluent/ksql/rest/entity/ErrorMessage.java
@@ -20,6 +20,8 @@ import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonSubTypes;
 
+import io.confluent.ksql.util.CommonUtils;
+
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
@@ -42,8 +44,14 @@ public class ErrorMessage {
     this.stackTrace = stackTrace;
   }
 
+  private static String buildErrorMessage(Throwable exception) {
+    String msg = exception.getMessage() != null ? exception.getMessage() : " ServerError:" + exception.toString();
+    String causeMsg = CommonUtils.getErrorCauseMessage(exception);
+    return causeMsg == "" ? msg : msg + "\r\n" + causeMsg;
+  }
+
   public ErrorMessage(Throwable exception) {
-    this(exception.getMessage() != null ? exception.getMessage() : " ServerError:" + exception.toString(), getStackTraceStrings(exception));
+    this(buildErrorMessage(exception), getStackTraceStrings(exception));
   }
 
   public static List<String> getStackTraceStrings(Throwable exception) {


### PR DESCRIPTION
The goal here is to provide more useful error messaging
in the cli. This includes more informative messages for certain
errors, and leveraging exception causes to provide more info:

* Add a CommonUtils class for common utility methods. Currently,
  this includes methods for printing error messages that can
  include information about the errors/exceptions that caused
  the exception for which a message is being generated.

* Print a more visible warning if the ksql server cannot be
  contacted when the cli is started in remote mode.

* Wrap rest client errors in a new exception class
  KsqlRestClientException, and provide a more context-specific error
  message.