### PR TITLE
don't execute dropped streams/tables, but update metastore

### DIFF
--- a/ksql-rest-app/src/main/java/io/confluent/ksql/rest/server/computation/CommandStore.java
+++ b/ksql-rest-app/src/main/java/io/confluent/ksql/rest/server/computation/CommandStore.java
@@ -127,17 +127,7 @@ public class CommandStore implements Closeable {
         while (!records.isEmpty()) {
             log.debug("Received {} records from poll", records.count());
             for (ConsumerRecord<CommandId, Command> record : records) {
-                final CommandId key = record.key();
-                if (key.getAction() != CommandId.Action.DROP) {
-                    restoreCommands.addCommand(record.key(), record.value());
-                } else if (key.getAction() == CommandId.Action.DROP){
-                    if(!restoreCommands.remove(new CommandId(key.getType(),
-                        key.getEntity(),
-                        CommandId.Action.CREATE))) {
-                        log.warn("drop command {} found without a corresponding create command for"
-                            + " {} {}", key, key.getType(), key.getAction());
-                    }
-                }
+                restoreCommands.addCommand(record.key(), record.value());
             }
             records = commandConsumer.poll(POLLING_TIMEOUT_FOR_COMMAND_TOPIC);
         }

--- a/ksql-rest-app/src/main/java/io/confluent/ksql/rest/server/computation/RestoreCommands.java
+++ b/ksql-rest-app/src/main/java/io/confluent/ksql/rest/server/computation/RestoreCommands.java
@@ -21,12 +21,17 @@ import java.util.HashMap;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
+import java.util.stream.Collectors;
 
 import io.confluent.ksql.query.QueryId;
+import io.confluent.ksql.util.Pair;
 
 class RestoreCommands {
-  private final Map<CommandId, Command> toRestore = new LinkedHashMap<>();
+
+  private final Map<Pair<Integer, CommandId>, Command> toRestore = new LinkedHashMap<>();
   private final Map<QueryId, CommandId> allTerminatedQueries = new HashMap<>();
+  private final Map<String, CommandId> dropped = new HashMap<>();
   private final List<CommandId> allCommandIds = new ArrayList<>();
 
   void addCommand(final CommandId key, final Command value) {
@@ -35,35 +40,37 @@ class RestoreCommands {
       if (allCommandIds.contains(key)) {
         allCommandIds.remove(key);
       }
-    } else if (!toRestore.containsKey(key)){
-      toRestore.put(key, value);
+    } else {
+      toRestore.put(new Pair<>(allCommandIds.size(), key), value);
+      if (key.getAction() == CommandId.Action.DROP) {
+        dropped.put(key.getEntity(), key);
+      }
     }
     allCommandIds.add(key);
   }
 
-  boolean remove(final CommandId commandId) {
-    if (toRestore.remove(commandId) != null) {
-      allCommandIds.remove(commandId);
-      return true;
-    }
-    return false;
-  }
 
   interface ForEach {
     void apply(final CommandId commandId,
                final Command command,
-               final Map<QueryId, CommandId> terminatedQueries);
+               final Map<QueryId, CommandId> terminatedQueries,
+               final boolean dropped);
   }
 
   void forEach(final ForEach action) {
-    toRestore.forEach((commandId, command) -> {
-      final int commandIdIdx = allCommandIds.indexOf(commandId);
+    toRestore.forEach((commandIdIndexPair, command) -> {
       final Map<QueryId, CommandId> terminatedAfter = new HashMap<>();
       allTerminatedQueries.entrySet().stream()
-          .filter(entry -> allCommandIds.indexOf(entry.getValue()) > commandIdIdx)
+          .filter(entry -> allCommandIds.indexOf(entry.getValue()) > commandIdIndexPair.left)
           .forEach(queryIdCommandIdEntry ->
               terminatedAfter.put(queryIdCommandIdEntry.getKey(), queryIdCommandIdEntry.getValue()));
-      action.apply(commandId, command, terminatedAfter);
+      final Set<String> droppedEntities = this.dropped.entrySet().stream()
+          .filter(entry -> allCommandIds.indexOf(entry.getValue()) > commandIdIndexPair.left)
+          .map(Map.Entry::getKey)
+          .collect(Collectors.toSet());
+      action.apply(commandIdIndexPair.right, command,
+          terminatedAfter,
+          droppedEntities.contains(commandIdIndexPair.right.getEntity()));
     });
   }
 

--- a/ksql-rest-app/src/main/java/io/confluent/ksql/rest/server/computation/StatementExecutor.java
+++ b/ksql-rest-app/src/main/java/io/confluent/ksql/rest/server/computation/StatementExecutor.java
@@ -73,13 +73,14 @@ public class StatementExecutor {
   }
 
   void handleRestoration(final RestoreCommands restoreCommands) throws Exception {
-    restoreCommands.forEach(((commandId, command, terminatedQueries) -> {
+    restoreCommands.forEach(((commandId, command, terminatedQueries, wasDropped) -> {
       log.info("Executing prior statement: '{}'", command);
       try {
         handleStatementWithTerminatedQueries(
             command,
             commandId,
-            terminatedQueries);
+            terminatedQueries,
+            wasDropped);
       } catch (Exception exception) {
         log.warn("Failed to execute statement due to exception", exception);
       }
@@ -96,7 +97,7 @@ public class StatementExecutor {
       Command command,
       CommandId commandId
   ) throws Exception {
-    handleStatementWithTerminatedQueries(command, commandId, null);
+    handleStatementWithTerminatedQueries(command, commandId, null, false);
   }
 
   /**
@@ -162,13 +163,14 @@ public class StatementExecutor {
    * @param commandId The ID to be used to track the status of the command
    * @param terminatedQueries An optional map from terminated query IDs to the commands that
    *                          requested their termination
+   * @param wasDropped was this table/stream subsequently dropped
    * @throws Exception TODO: Refine this.
    */
   private void handleStatementWithTerminatedQueries(
       Command command,
       CommandId commandId,
-      Map<QueryId, CommandId> terminatedQueries
-  ) throws Exception {
+      Map<QueryId, CommandId> terminatedQueries,
+      boolean wasDropped) throws Exception {
     try {
       String statementString = command.getStatement();
       statusStore.put(
@@ -180,7 +182,7 @@ public class StatementExecutor {
           commandId,
           new CommandStatus(CommandStatus.Status.EXECUTING, "Executing statement")
       );
-      executeStatement(statement, command, commandId, terminatedQueries);
+      executeStatement(statement, command, commandId, terminatedQueries, wasDropped);
     } catch (WakeupException exception) {
       throw exception;
     } catch (Exception exception) {
@@ -195,8 +197,8 @@ public class StatementExecutor {
       Statement statement,
       Command command,
       CommandId commandId,
-      Map<QueryId, CommandId> terminatedQueries
-  ) throws Exception {
+      Map<QueryId, CommandId> terminatedQueries,
+      boolean wasDropped) throws Exception {
     String statementStr = command.getStatement();
 
     DDLCommandResult result = null;
@@ -210,7 +212,8 @@ public class StatementExecutor {
           command,
           commandId,
           terminatedQueries,
-          statementStr);
+          statementStr,
+          wasDropped);
       if (successMessage == null) return;
     } else if (statement instanceof TerminateQuery) {
       terminateQuery((TerminateQuery) statement);
@@ -251,7 +254,8 @@ public class StatementExecutor {
                                       final Command command,
                                       final CommandId commandId,
                                       final Map<QueryId, CommandId> terminatedQueries,
-                                      final String statementStr) throws Exception {
+                                      final String statementStr,
+                                      final boolean wasDropped) throws Exception {
     QuerySpecification querySpecification =
         (QuerySpecification) statement.getQuery().getQueryBody();
     Query query = ksqlEngine.addInto(
@@ -261,7 +265,7 @@ public class StatementExecutor {
         statement.getProperties(),
         statement.getPartitionByColumn()
     );
-    if (startQuery(statementStr, query, commandId, terminatedQueries, command)) {
+    if (startQuery(statementStr, query, commandId, terminatedQueries, command, wasDropped)) {
       return statement instanceof CreateTableAsSelect
           ? "Table created and running"
           : "Stream created and running";
@@ -275,8 +279,8 @@ public class StatementExecutor {
       Query query,
       CommandId commandId,
       Map<QueryId, CommandId> terminatedQueries,
-      Command command
-  ) throws Exception {
+      Command command,
+      boolean wasDropped) throws Exception {
     if (query.getQueryBody() instanceof QuerySpecification) {
       QuerySpecification querySpecification = (QuerySpecification) query.getQueryBody();
       Relation into = querySpecification.getInto();
@@ -310,6 +314,9 @@ public class StatementExecutor {
             commandId,
             new CommandStatus(CommandStatus.Status.TERMINATED, "Query terminated")
         );
+        ksqlEngine.terminateQuery(queryId, false);
+        return false;
+      } else if (wasDropped){
         ksqlEngine.terminateQuery(queryId, false);
         return false;
       } else {


### PR DESCRIPTION
During startup when reading and executing the prior commands we need to update the metastore for tables/streams that are subsequently dropped so that dependent commands can also execute, i.e. if we have

create stream s1 as select ...
create stream s2 as select * from s1
terminate query 'csas_s1'
drop s1

when we restart we should still have s2 running
#531