### PR TITLE
Add ability to specify the schema registry url to the CLI in local mode.

### DIFF
--- a/docs/quickstart/quickstart-docker.md
+++ b/docs/quickstart/quickstart-docker.md
@@ -41,7 +41,7 @@ Proceed to [starting KSQL](#start-ksql).
 1.  From the host machine, start KSQL CLI on the container.
 
     ```bash
-    $ docker-compose exec ksql-cli ksql-cli local --bootstrap-server kafka:29092
+    $ docker-compose exec ksql-cli ksql-cli local --bootstrap-server kafka:29092 --schema-registry-url schema-registry:8081
     ```
 
 2.  Return to the [main KSQL quick start](README.md#create-a-stream-and-table) to start querying the data in the Kafka cluster.

--- a/ksql-cli/src/main/java/io/confluent/ksql/cli/commands/Local.java
+++ b/ksql-cli/src/main/java/io/confluent/ksql/cli/commands/Local.java
@@ -55,6 +55,9 @@ public class Local extends AbstractCliCommands {
   private static final String COMMAND_TOPIC_SUFFIX_OPTION_NAME = "--command-topic-suffix";
   private static final String COMMAND_TOPIC_SUFFIX_OPTION_DEFAULT = "commands";
 
+  private static final String SCHEMA_REGISTRY_URL_OPTION_NAME = "--schema-registry-url";
+  private static final String SCHEMA_REGISTRY_URL_OPTION_DEFAULT = "http://localhost:8081";
+
   @Port(acceptablePorts = PortType.ANY)
   @Option(
       name = PORT_NUMBER_OPTION_NAME,
@@ -97,6 +100,14 @@ public class Local extends AbstractCliCommands {
           + "be overridden if also given via  flags)"
   )
   String propertiesFile;
+
+  @Option(
+      name = SCHEMA_REGISTRY_URL_OPTION_NAME,
+      description = "The url of the schema registry server to be used. It defaults to " +
+                    SCHEMA_REGISTRY_URL_OPTION_DEFAULT + ". Avro support requires a functioning "
+                    + "schema registry which the KSQL instance can connect to."
+  )
+  String schemaRegistryUrl;
 
   @Override
   public LocalCli getCli() throws Exception {
@@ -145,6 +156,7 @@ public class Local extends AbstractCliCommands {
         COMMAND_TOPIC_SUFFIX_OPTION_DEFAULT
     );
     properties.put(StreamsConfig.APPLICATION_ID_CONFIG, KsqlConfig.KSQL_SERVICE_ID_DEFAULT);
+    properties.put(KsqlConfig.SCHEMA_REGISTRY_URL_PROPERTY, SCHEMA_REGISTRY_URL_OPTION_DEFAULT);
   }
 
   private void addFileProperties(Properties properties) throws IOException {
@@ -173,6 +185,10 @@ public class Local extends AbstractCliCommands {
     }
     if (commandTopicSuffix != null) {
       properties.put(KsqlRestConfig.COMMAND_TOPIC_SUFFIX_CONFIG, commandTopicSuffix);
+    }
+
+    if (schemaRegistryUrl != null) {
+      properties.put(KsqlConfig.SCHEMA_REGISTRY_URL_PROPERTY, schemaRegistryUrl);
     }
   }
 }

--- a/ksql-cli/src/main/java/io/confluent/ksql/cli/commands/Local.java
+++ b/ksql-cli/src/main/java/io/confluent/ksql/cli/commands/Local.java
@@ -105,7 +105,8 @@ public class Local extends AbstractCliCommands {
       name = SCHEMA_REGISTRY_URL_OPTION_NAME,
       description = "The url of the schema registry server to be used. It defaults to " +
                     SCHEMA_REGISTRY_URL_OPTION_DEFAULT + ". Avro support requires a functioning"
-                    + " schema registry which the KSQL instance can connect to."
+                    + " schema registry which the KSQL instance can connect to. Setting this will"
+                    + " override the schema registry url in the properties file, if set."
   )
   String schemaRegistryUrl;
 

--- a/ksql-cli/src/main/java/io/confluent/ksql/cli/commands/Local.java
+++ b/ksql-cli/src/main/java/io/confluent/ksql/cli/commands/Local.java
@@ -104,8 +104,8 @@ public class Local extends AbstractCliCommands {
   @Option(
       name = SCHEMA_REGISTRY_URL_OPTION_NAME,
       description = "The url of the schema registry server to be used. It defaults to " +
-                    SCHEMA_REGISTRY_URL_OPTION_DEFAULT + ". Avro support requires a functioning "
-                    + "schema registry which the KSQL instance can connect to."
+                    SCHEMA_REGISTRY_URL_OPTION_DEFAULT + ". Avro support requires a functioning"
+                    + " schema registry which the KSQL instance can connect to."
   )
   String schemaRegistryUrl;
 


### PR DESCRIPTION
With this patch, we can use schema registry in the quickstart docker images. We would need to update the https://github.com/confluentinc/ksql/blob/master/docs/quickstart/quickstart-docker.md so that we update the `exec` command to:

```
docker-compose exec ksql-cli ksql-cli local --bootstrap-server kafka:29092 --schema-registry-url schema-registry:8081
```