### PR TITLE
KSQL-493: Fix producer thread leak

### DIFF
--- a/ksql-rest-app/src/main/java/io/confluent/ksql/rest/server/resources/KsqlResource.java
+++ b/ksql-rest-app/src/main/java/io/confluent/ksql/rest/server/resources/KsqlResource.java
@@ -411,7 +411,7 @@ public class KsqlResource {
         new AvroUtil().validatePersistentQueryResults((PersistentQueryMetadata) queryMetadata,
                                                       ksqlEngine.getSchemaRegistryClient());
       }
-
+      queryMetadata.close();
       return queryMetadata.getExecutionPlan();
     });
 
@@ -425,6 +425,7 @@ public class KsqlResource {
         new AvroUtil().validatePersistentQueryResults((PersistentQueryMetadata) queryMetadata,
                                                       ksqlEngine.getSchemaRegistryClient());
       }
+      queryMetadata.close();
       return queryMetadata.getExecutionPlan();
     });
 


### PR DESCRIPTION
Close QueryMetadata objects created during ddl verification.
This in turn closes KafkaStreams, which *should* stop the
producer thread. This is currently not happening due to:
https://issues.apache.org/jira/browse/KAFKA-6383

There is a PR open to fix that issue:
https://github.com/apache/kafka/pull/4343