### PR TITLE
KSQL-235:  dont block on socket read

### DIFF
--- a/ksql-rest-app/src/test/java/io/confluent/ksql/rest/client/KsqlRestClientTest.java
+++ b/ksql-rest-app/src/test/java/io/confluent/ksql/rest/client/KsqlRestClientTest.java
@@ -32,6 +32,8 @@ import org.junit.Test;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
 
 import io.confluent.ksql.rest.server.KsqlRestConfig;
 import io.confluent.ksql.rest.server.computation.CommandId;
@@ -77,71 +79,74 @@ public class KsqlRestClientTest {
 
 
   @Test
-  public void testStreamQuery() throws InterruptedException {
-    MockStreamedQueryResource sqr = mockApplication.getStreamedQueryResource();
-    RestResponse<KsqlRestClient.QueryStream> queryResponse = ksqlRestClient.makeQueryRequest
-        ("Select *");
-    Assert.assertNotNull(queryResponse);
-    Assert.assertTrue(queryResponse.isSuccessful());
-    List<MockStreamedQueryResource.TestStreamWriter> writers = sqr.getWriters();
-    Assert.assertEquals(1, writers.size());
-    MockStreamedQueryResource.TestStreamWriter writer = writers.get(0);
-    writer.enq("hello");
-    KsqlRestClient.QueryStream queryStream = queryResponse.getResponse();
-    Thread t = new Thread() {
-      public void run() {
-        queryStream.hasNext();
-     }
-    };
-    t.start();
-    t.join(10000);
-    Assert.assertFalse(t.isAlive());
-    Assert.assertTrue(queryStream.hasNext());
-    StreamedRow sr = queryStream.next();
-    Assert.assertNotNull(sr);
-    GenericRow row = sr.getRow();
-    Assert.assertEquals(1, row.getColumns().
-            size());
-    Assert.assertEquals("hello", row.getColumns().
-            get(0));
-    writer.finished();
-  }
-
-  @Test
-  public void testInterruptStreamedQuery() throws InterruptedException {
+  public void testStreamRowFromServer() throws InterruptedException {
     MockStreamedQueryResource sqr = mockApplication.getStreamedQueryResource();
     RestResponse<KsqlRestClient.QueryStream> queryResponse = ksqlRestClient.makeQueryRequest
             ("Select *");
     Assert.assertNotNull(queryResponse);
     Assert.assertTrue(queryResponse.isSuccessful());
+
+    // Get the stream writer from the mock server and load it up with a row
     List<MockStreamedQueryResource.TestStreamWriter> writers = sqr.getWriters();
     Assert.assertEquals(1, writers.size());
     MockStreamedQueryResource.TestStreamWriter writer = writers.get(0);
-    writer.enq("hello");
-    KsqlRestClient.QueryStream queryStream = queryResponse.getResponse();
-    Assert.assertTrue(queryStream.hasNext());
-    StreamedRow sr = queryStream.next();
-    Assert.assertNotNull(sr);
-    GenericRow row = sr.getRow();
-    Assert.assertEquals(1, row.getColumns().size());
-    Assert.assertEquals("hello", row.getColumns().get(0));
-    List<Boolean> threw = new java.util.LinkedList<>();
-    threw.add(false);
-    Thread t = new Thread() {
-      public void run() {
+    try {
+      writer.enq("hello");
+
+      // Try and receive the row. Do this from another thread to avoid blocking indefinitely
+      KsqlRestClient.QueryStream queryStream = queryResponse.getResponse();
+      Thread t = new Thread(() -> queryStream.hasNext());
+      t.setDaemon(true);
+      t.start();
+      t.join(10000);
+      Assert.assertFalse(t.isAlive());
+      Assert.assertTrue(queryStream.hasNext());
+
+      StreamedRow sr = queryStream.next();
+      Assert.assertNotNull(sr);
+      GenericRow row = sr.getRow();
+      Assert.assertEquals(1, row.getColumns().
+              size());
+      Assert.assertEquals("hello", row.getColumns().
+              get(0));
+    } finally {
+      writer.finished();
+    }
+  }
+
+  @Test
+  public void shouldInterruptScannerOnClose() throws InterruptedException {
+    MockStreamedQueryResource sqr = mockApplication.getStreamedQueryResource();
+    RestResponse<KsqlRestClient.QueryStream> queryResponse = ksqlRestClient.makeQueryRequest
+            ("Select *");
+    Assert.assertNotNull(queryResponse);
+    Assert.assertTrue(queryResponse.isSuccessful());
+
+    List<MockStreamedQueryResource.TestStreamWriter> writers = sqr.getWriters();
+    Assert.assertEquals(1, writers.size());
+    try {
+      // Try and receive a row. This will block since there is no data to return
+      KsqlRestClient.QueryStream queryStream = queryResponse.getResponse();
+      CountDownLatch threw = new CountDownLatch(1);
+      Thread t = new Thread(() -> {
         try {
           queryStream.hasNext();
         } catch (IllegalStateException e) {
-          threw.set(0, true);
+          threw.countDown();
         }
-      }
-    };
-    t.start();
-    Thread.sleep(100);
-    queryStream.close();
-    t.join(10000);
-    Assert.assertTrue(threw.get(0));
-    writer.finished();
+      });
+      t.setDaemon(true);
+      t.start();
+
+      // Let the thread run and then close the stream. Verify that it was interrupted
+      Thread.sleep(100);
+      queryStream.close();
+      Assert.assertTrue(threw.await(10, TimeUnit.SECONDS));
+      t.join(10000);
+      Assert.assertFalse(t.isAlive());
+    } finally {
+      writers.get(0).finished();
+    }
   }
 
   @Test

--- a/ksql-rest-app/src/test/java/io/confluent/ksql/rest/server/mock/MockApplication.java
+++ b/ksql-rest-app/src/test/java/io/confluent/ksql/rest/server/mock/MockApplication.java
@@ -20,18 +20,26 @@ import javax.ws.rs.core.Configurable;
 
 import io.confluent.ksql.rest.server.KsqlRestConfig;
 import io.confluent.rest.Application;
+import org.glassfish.jersey.server.ServerProperties;
 
 
 public class MockApplication extends Application<KsqlRestConfig> {
+  private MockStreamedQueryResource streamedQueryResource;
 
   public MockApplication(KsqlRestConfig config) {
     super(config);
+    streamedQueryResource = new MockStreamedQueryResource();
+  }
+
+  public MockStreamedQueryResource getStreamedQueryResource() {
+    return streamedQueryResource;
   }
 
   @Override
   public void setupResources(Configurable<?> configurable, KsqlRestConfig ksqlRestConfig) {
     configurable.register(new MockKsqlResources());
-    configurable.register(new MockStreamedQueryResource());
+    configurable.register(streamedQueryResource);
     configurable.register(new MockStatusResource());
+    configurable.property(ServerProperties.OUTBOUND_CONTENT_LENGTH_BUFFER, 0);
   }
 }

--- a/ksql-rest-app/src/test/java/io/confluent/ksql/rest/server/mock/MockStreamedQueryResource.java
+++ b/ksql-rest-app/src/test/java/io/confluent/ksql/rest/server/mock/MockStreamedQueryResource.java
@@ -81,7 +81,7 @@ public class MockStreamedQueryResource {
         } catch (InterruptedException e) {
           throw new RuntimeException("take interrupted");
         }
-        if (data == "") {
+        if (data.equals("")) {
           break;
         }
         writeRow(data, out);

--- a/ksql-rest-app/src/test/java/io/confluent/ksql/rest/server/mock/MockStreamedQueryResource.java
+++ b/ksql-rest-app/src/test/java/io/confluent/ksql/rest/server/mock/MockStreamedQueryResource.java
@@ -18,6 +18,10 @@ package io.confluent.ksql.rest.server.mock;
 
 import java.io.IOException;
 import java.io.OutputStream;
+import java.nio.charset.StandardCharsets;
+import java.util.List;
+import java.util.concurrent.BlockingQueue;
+import java.util.concurrent.LinkedBlockingQueue;
 
 import javax.ws.rs.Consumes;
 import javax.ws.rs.POST;
@@ -28,26 +32,59 @@ import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.Response;
 import javax.ws.rs.core.StreamingOutput;
 
+import com.fasterxml.jackson.core.JsonGenerator;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import io.confluent.ksql.rest.entity.KsqlRequest;
+import io.confluent.ksql.GenericRow;
+import io.confluent.ksql.rest.entity.StreamedRow;
 
 @Path("/query")
 @Produces(MediaType.APPLICATION_JSON)
 public class MockStreamedQueryResource {
+  List<TestStreamWriter> writers = new java.util.LinkedList<>();
 
   @POST
   @Consumes(MediaType.APPLICATION_JSON)
   public Response streamQuery(KsqlRequest request) throws Exception {
     TestStreamWriter testStreamWriter = new TestStreamWriter();
+    writers.add(testStreamWriter);
     return Response.ok().entity(testStreamWriter).build();
   }
 
-  private class TestStreamWriter implements StreamingOutput {
+  public List<TestStreamWriter> getWriters() { return writers; }
+
+  public class TestStreamWriter implements StreamingOutput {
+    BlockingQueue<String> dataq = new LinkedBlockingQueue<>();
+    ObjectMapper objectMapper = new ObjectMapper().disable(JsonGenerator.Feature.AUTO_CLOSE_TARGET);
+
+    public void enq(String data) throws InterruptedException { dataq.put(data); }
+
+    public void finished() throws InterruptedException { dataq.put(""); }
+
+    private void writeRow(String data, OutputStream out) throws IOException {
+      List<Object> rowColumns = new java.util.LinkedList<Object>();
+      rowColumns.add(data);
+      GenericRow row = new GenericRow(rowColumns);
+      objectMapper.writeValue(out, new StreamedRow(row));
+      out.write("\n".getBytes(StandardCharsets.UTF_8));
+      out.flush();
+    }
 
     @Override
     public void write(OutputStream out) throws IOException, WebApplicationException {
-      synchronized (out) {
-        out.write("Hello".getBytes());
-        out.flush();
+      out.write("\n".getBytes(StandardCharsets.UTF_8));
+      out.flush();
+      while (true) {
+        String data;
+        try {
+          data = dataq.take();
+        } catch (InterruptedException e) {
+          throw new RuntimeException("take interrupted");
+        }
+        if (data == "") {
+          break;
+        }
+        writeRow(data, out);
       }
     }
   }


### PR DESCRIPTION
KSQL-235: dont block on socket read

Avoid blocking on socket reads from the cli when
streaming a query response. The read cannot be interrupted,
so the user cannot abort the query via ctl-c until then next
response chunk arrives. Instead, have read poll the input
stream periodically and sleep interruptably between poll
attempts.
 