### PR TITLE
Use Apache commons CSV package for both serializer and deserializer i…

### DIFF
--- a/ksql-serde/src/main/java/io/confluent/ksql/serde/delimited/KsqlDelimitedDeserializer.java
+++ b/ksql-serde/src/main/java/io/confluent/ksql/serde/delimited/KsqlDelimitedDeserializer.java
@@ -80,7 +80,7 @@ public class KsqlDelimitedDeserializer implements Deserializer<GenericRow> {
 
   private Object enforceFieldType(Schema fieldSchema, String delimitedField) {
 
-    if (delimitedField.length() == 0) {
+    if (delimitedField.isEmpty()) {
       return null;
     }
     switch (fieldSchema.type()) {

--- a/ksql-serde/src/main/java/io/confluent/ksql/serde/delimited/KsqlDelimitedDeserializer.java
+++ b/ksql-serde/src/main/java/io/confluent/ksql/serde/delimited/KsqlDelimitedDeserializer.java
@@ -66,8 +66,6 @@ public class KsqlDelimitedDeserializer implements Deserializer<GenericRow> {
       for (int i = 0; i < csvRecord.size(); i++) {
         if (csvRecord.get(i) == null) {
           columns.add(null);
-        } else if (csvRecord.get(i).toString().equalsIgnoreCase("null")) {
-          columns.add(null);
         } else {
           columns.add(enforceFieldType(schema.fields().get(i).schema(), csvRecord.get(i)));
         }
@@ -82,6 +80,9 @@ public class KsqlDelimitedDeserializer implements Deserializer<GenericRow> {
 
   private Object enforceFieldType(Schema fieldSchema, String delimitedField) {
 
+    if (delimitedField.length() == 0) {
+      return null;
+    }
     switch (fieldSchema.type()) {
       case BOOLEAN:
         return Boolean.parseBoolean(delimitedField);
@@ -92,11 +93,7 @@ public class KsqlDelimitedDeserializer implements Deserializer<GenericRow> {
       case FLOAT64:
         return Double.parseDouble(delimitedField);
       case STRING:
-        if (delimitedField.startsWith("'") && delimitedField.endsWith("'")) {
-          return delimitedField.substring(0, delimitedField.length()-1).substring(1);
-        } else {
-          throw new KsqlException("String type is in incorrect format: " + delimitedField);
-        }
+        return delimitedField;
       case ARRAY:
       case MAP:
       default:

--- a/ksql-serde/src/main/java/io/confluent/ksql/serde/delimited/KsqlDelimitedSerializer.java
+++ b/ksql-serde/src/main/java/io/confluent/ksql/serde/delimited/KsqlDelimitedSerializer.java
@@ -17,11 +17,14 @@
 package io.confluent.ksql.serde.delimited;
 
 import io.confluent.ksql.GenericRow;
-import io.confluent.ksql.util.KsqlException;
 
+import org.apache.commons.csv.CSVFormat;
+import org.apache.commons.csv.CSVPrinter;
+import org.apache.kafka.common.errors.SerializationException;
 import org.apache.kafka.common.serialization.Serializer;
 import org.apache.kafka.connect.data.Schema;
 
+import java.io.StringWriter;
 import java.nio.charset.StandardCharsets;
 import java.util.Map;
 
@@ -44,27 +47,14 @@ public class KsqlDelimitedSerializer implements Serializer<GenericRow> {
     if (genericRow == null) {
       return null;
     }
-
     try {
-      StringBuilder recordString = new StringBuilder();
-      for (int i = 0; i < genericRow.getColumns().size(); i++) {
-        if (i != 0) {
-          recordString.append(",");
-        }
-        if (genericRow.getColumns().get(i) == null) {
-          recordString.append("null");
-        } else if (schema.fields().get(i).schema() == Schema.STRING_SCHEMA) {
-          recordString.append("'" + genericRow.getColumns().get(i).toString() + "'");
-        } else {
-          recordString.append(genericRow.getColumns().get(i).toString());
-        }
-
-      }
-      return recordString.toString().getBytes(StandardCharsets.UTF_8);
+      StringWriter stringWriter = new StringWriter();
+      CSVPrinter csvPrinter = new CSVPrinter(stringWriter, CSVFormat.DEFAULT);
+      csvPrinter.printRecord(genericRow.getColumns());
+      return stringWriter.toString().getBytes(StandardCharsets.UTF_8);
     } catch (Exception e) {
-      throw new KsqlException(e.getMessage(), e);
+      throw new SerializationException("Error serializing CSV message", e);
     }
-
 
   }
 

--- a/ksql-serde/src/test/java/io/confluent/ksql/serde/delimited/KsqlDelimitedDeserializerTest.java
+++ b/ksql-serde/src/test/java/io/confluent/ksql/serde/delimited/KsqlDelimitedDeserializerTest.java
@@ -45,7 +45,7 @@ public class KsqlDelimitedDeserializerTest {
 
   @Test
   public void shouldDeserializeDelimitedCorrectly() {
-    String rowString = "1511897796092,1,'item_1',10.0";
+    String rowString = "1511897796092,1,item_1,10.0\r\n";
 
     KsqlDelimitedDeserializer ksqlJsonDeserializer = new KsqlDelimitedDeserializer(orderSchema);
 
@@ -61,7 +61,7 @@ public class KsqlDelimitedDeserializerTest {
   @Test
   public void shouldDeserializeJsonCorrectlyWithRedundantFields() throws JsonProcessingException {
 
-    String rowString = "1511897796092,1,'item_1',null";
+    String rowString = "1511897796092,1,item_1,\r\n";
 
     KsqlDelimitedDeserializer ksqlJsonDeserializer = new KsqlDelimitedDeserializer(orderSchema);
 

--- a/ksql-serde/src/test/java/io/confluent/ksql/serde/delimited/KsqlDelimitedDeserializerTest.java
+++ b/ksql-serde/src/test/java/io/confluent/ksql/serde/delimited/KsqlDelimitedDeserializerTest.java
@@ -55,7 +55,6 @@ public class KsqlDelimitedDeserializerTest {
     assertThat((Long) genericRow.getColumns().get(1), equalTo(1L));
     assertThat((String) genericRow.getColumns().get(2), equalTo("item_1"));
     assertThat((Double) genericRow.getColumns().get(3), equalTo(10.0));
-
   }
 
   @Test

--- a/ksql-serde/src/test/java/io/confluent/ksql/serde/delimited/KsqlDelimitedSerializerTest.java
+++ b/ksql-serde/src/test/java/io/confluent/ksql/serde/delimited/KsqlDelimitedSerializerTest.java
@@ -21,6 +21,7 @@ import org.apache.kafka.connect.data.SchemaBuilder;
 import org.junit.Before;
 import org.junit.Test;
 
+import java.io.IOException;
 import java.util.Arrays;
 import java.util.List;
 
@@ -45,24 +46,24 @@ public class KsqlDelimitedSerializerTest {
   }
 
   @Test
-  public void shouldSerializeRowCorrectly() {
+  public void shouldSerializeRowCorrectly() throws IOException {
     List columns = Arrays.asList(1511897796092L, 1L, "item_1", 10.0);
     GenericRow genericRow = new GenericRow(columns);
     KsqlDelimitedSerializer ksqlDelimitedSerializer = new KsqlDelimitedSerializer(orderSchema);
     byte[] bytes = ksqlDelimitedSerializer.serialize("t1", genericRow);
 
     String delimitedString = new String(bytes);
-    assertThat("Incorrect serialization.", delimitedString, equalTo("1511897796092,1,'item_1',10.0"));
+    assertThat("Incorrect serialization.", delimitedString, equalTo("1511897796092,1,item_1,10.0\r\n"));
   }
 
   @Test
-  public void shouldSerializeRowWithNull() {
+  public void shouldSerializeRowWithNull() throws IOException {
     List columns = Arrays.asList(1511897796092L, 1L, "item_1", null);
     GenericRow genericRow = new GenericRow(columns);
     KsqlDelimitedSerializer ksqlDelimitedSerializer = new KsqlDelimitedSerializer(orderSchema);
     byte[] bytes = ksqlDelimitedSerializer.serialize("t1", genericRow);
 
     String delimitedString = new String(bytes);
-    assertThat("Incorrect serialization.", delimitedString, equalTo("1511897796092,1,'item_1',null"));
+    assertThat("Incorrect serialization.", delimitedString, equalTo("1511897796092,1,item_1,\r\n"));
   }
 }


### PR DESCRIPTION
…n delimited format.
Previously we only had Apache Commons CSV package in deserializer for delimited format. This PR uses the same package for both serializing and deserializing the delimited format.
