### PR TITLE
Fix queries with limit

### DIFF
--- a/ksql-cli/src/test/java/io/confluent/ksql/CliTest.java
+++ b/ksql-cli/src/test/java/io/confluent/ksql/CliTest.java
@@ -209,6 +209,11 @@ public class CliTest extends TestRunner {
     );
   }
 
+  private static void selectWithLimit(String selectQuery, int limit, TestResult.OrderedResult expectedResults) {
+    selectQuery += " LIMIT " + limit + ";";
+    test(selectQuery, expectedResults);
+  }
+
   @Test
   public void testPropertySetUnset() {
     test("set 'application.id' = 'Test_App'", EMPTY_RESULT);
@@ -317,6 +322,21 @@ public class CliTest extends TestRunner {
         orderDataProvider.schema(),
         expectedResults
         );
+  }
+
+  @Test
+  public void testSelectLimit() throws Exception {
+    TestResult.OrderedResult expectedResult = TestResult.build();
+    Map<String, GenericRow> streamData = orderDataProvider.data();
+    int limit = 3;
+    for (int i = 1; i <= limit; i++) {
+      GenericRow srcRow = streamData.get(Integer.toString(i));
+      List<Object> columns = srcRow.getColumns();
+      GenericRow resultRow = new GenericRow(Arrays.asList(columns.get(1), columns.get(2)));
+      expectedResult.addRow(resultRow);
+    }
+    selectWithLimit(
+        "SELECT ORDERID, ITEMID FROM " + orderDataProvider.kstreamName(), limit, expectedResult);
   }
 
   @Test

--- a/ksql-cli/src/test/java/io/confluent/ksql/TestResult.java
+++ b/ksql-cli/src/test/java/io/confluent/ksql/TestResult.java
@@ -34,9 +34,21 @@ public abstract class TestResult {
   Collection<List<String>> data;
   private boolean sealed = false;
 
+  protected TestResult() {}
+
+  protected TestResult(TestResult model) {
+    sealed = model.sealed;
+  }
+
   static class OrderedResult extends TestResult {
     private OrderedResult() {
       data = new ArrayList<>();
+    }
+
+    private OrderedResult(OrderedResult model) {
+      super(model);
+      data = new ArrayList<>();
+      data.addAll(model.data);
     }
 
     private OrderedResult(String singleRow) {
@@ -51,11 +63,22 @@ public abstract class TestResult {
     public String toString() {
       return data.toString();
     }
+
+    @Override
+    public OrderedResult copy() {
+      return new OrderedResult(this);
+    }
   }
 
   static class UnorderedResult extends TestResult {
     private UnorderedResult() {
       data = new HashSet<>();
+    }
+
+    private UnorderedResult(UnorderedResult model) {
+      super(model);
+      data = new HashSet<>();
+      data.addAll(model.data);
     }
 
     private UnorderedResult(Map<String, Object> map) {
@@ -75,6 +98,11 @@ public abstract class TestResult {
       }
       return map.values().toString();
     }
+
+    @Override
+    public UnorderedResult copy() {
+      return new UnorderedResult(this);
+    }
   }
 
   static UnorderedResult build(Map<String, Object> map) {
@@ -89,9 +117,13 @@ public abstract class TestResult {
     return new OrderedResult(StringUtil.join(", ", Arrays.asList(cols)));
   }
 
+  static OrderedResult build() { return new OrderedResult(); }
+
   static TestResult init(boolean requireOrder) {
     return requireOrder ? new OrderedResult() : new UnorderedResult();
   }
+
+  public abstract TestResult copy();
 
   void addRow(GenericRow row) {
     if (sealed) {

--- a/ksql-cli/src/test/java/io/confluent/ksql/TestRunner.java
+++ b/ksql-cli/src/test/java/io/confluent/ksql/TestRunner.java
@@ -66,12 +66,13 @@ public abstract class TestRunner {
         finalResults.clear();
         finalResults.addAll(actualResult.data);
         return actualResult.data.containsAll(expectedResult.data);
-      }, 10000, "Did not get the expected result '" + expectedResult + ", in a timely fashion. Received " +
-              "following results instead: " + finalResults);
+      }, 10000, "Did not get the expected result '" + expectedResult + ", in a timely fashion.");
+    } catch (AssertionError e) {
+      System.err.println("CLI test runner command result mismatch expected: " + expectedResult + ", actual: " + finalResults);
+      throw e;
     } catch (InterruptedException e) {
       fail("Test got interrutped when waiting for result " + expectedResult.toString());
     }
-
   }
 
   protected static TestResult run(String command, boolean requireOrder) throws CliTestFailedException {

--- a/ksql-cli/src/test/java/io/confluent/ksql/TestRunner.java
+++ b/ksql-cli/src/test/java/io/confluent/ksql/TestRunner.java
@@ -68,8 +68,8 @@ public abstract class TestRunner {
         return actualResult.data.containsAll(expectedResult.data);
       }, 10000, "Did not get the expected result '" + expectedResult + ", in a timely fashion.");
     } catch (AssertionError e) {
-      System.err.println("CLI test runner command result mismatch expected: " + expectedResult + ", actual: " + finalResults);
-      throw e;
+      throw new AssertionError(
+          "CLI test runner command result mismatch expected: " + expectedResult + ", actual: " + finalResults, e);
     } catch (InterruptedException e) {
       fail("Test got interrutped when waiting for result " + expectedResult.toString());
     }

--- a/ksql-cli/src/test/java/io/confluent/ksql/TestTerminal.java
+++ b/ksql-cli/src/test/java/io/confluent/ksql/TestTerminal.java
@@ -47,8 +47,8 @@ public class TestTerminal extends Console {
     output = TestResult.init(requireOrder);
   }
 
-  public TestResult getTestResult() {
-    return output;
+  public synchronized TestResult getTestResult() {
+    return output.copy();
   }
 
   public String getOutputString() {
@@ -56,7 +56,7 @@ public class TestTerminal extends Console {
   }
 
   @Override
-  public void addResult(GenericRow row) {
+  public synchronized void addResult(GenericRow row) {
     output.addRow(row);
   }
 


### PR DESCRIPTION
The isReady method of the InputStreamReader used to poll the
input stream for transient queries never gives any indication
that socket was closed by the remote server. Since stream queries
only terminate on error from the server or client side abort,
look out for an error row and stop processing the query when
one is received.