### PR TITLE
Expect ksql-run-class parameters after the class name

### DIFF
--- a/bin/ksql-run-class
+++ b/bin/ksql-run-class
@@ -101,6 +101,9 @@ then
   usage
 fi
 
+MAIN="$1"
+shift
+
 DAEMON_NAME=""
 GC_LOG_ENABLED=""
 DAEMON_MODE=""
@@ -129,9 +132,6 @@ while [ $# -gt 0 ]; do
       ;;
   esac
 done
-
-MAIN="$1"
-shift
 
 
 # GC options

--- a/bin/ksql-server-start
+++ b/bin/ksql-server-start
@@ -22,17 +22,7 @@ fi
 
 EXTRA_ARGS="-name ksql-server -loggc"
 
-COMMAND=$1
-case $COMMAND in 
-    -daemon)
-        EXTRA_ARGS="-daemon "$EXTRA_ARGS
-        shift
-        ;;
-    *)
-        ;;
-esac
-
 # TODO: Enable specification of properties via command-line arg in the KsqlRestApplication class
 # so that useful defaults for bootstrap server, port, etc. can be established here
 
-exec "$base_dir"/bin/ksql-run-class $EXTRA_ARGS io.confluent.ksql.rest.server.KsqlRestApplication "$@"
+exec "$base_dir"/bin/ksql-run-class io.confluent.ksql.rest.server.KsqlRestApplication $EXTRA_ARGS "$@"


### PR DESCRIPTION
We inadvertantly changed ksql-run-class to ignore parameters for the shell
script by popping the class off after parsing parameters rather than before.