### PR TITLE
[minor] Test syntax and query termination

### DIFF
--- a/ksql-engine/src/test/java/io/confluent/ksql/util/json/JsonPathTokenizerTest.java
+++ b/ksql-engine/src/test/java/io/confluent/ksql/util/json/JsonPathTokenizerTest.java
@@ -18,11 +18,14 @@ package io.confluent.ksql.util.json;
 
 
 import com.google.common.collect.ImmutableList;
-import org.junit.Assert;
 import org.junit.Test;
 
 import java.io.IOException;
 import java.util.List;
+
+import static org.hamcrest.core.Is.is;
+import static org.hamcrest.core.IsEqual.equalTo;
+import static org.junit.Assert.assertThat;
 
 public class JsonPathTokenizerTest {
 
@@ -31,12 +34,12 @@ public class JsonPathTokenizerTest {
     JsonPathTokenizer jsonPathTokenizer = new JsonPathTokenizer("$.logs[0].cloud.region");
     ImmutableList<String> tokens = ImmutableList.copyOf(jsonPathTokenizer);
     List<String> tokenList = tokens.asList();
-    Assert.assertTrue(tokenList.size() == 4);
-    Assert.assertTrue(tokenList.get(0).equalsIgnoreCase("logs"));
-    Assert.assertTrue(tokenList.get(1).equalsIgnoreCase("0"));
-    Assert.assertTrue(tokenList.get(2).equalsIgnoreCase("cloud"));
-    Assert.assertTrue(tokenList.get(3).equalsIgnoreCase("region"));
+    assertThat(tokenList.size(), is(equalTo(4)));
+    assertThat(tokenList.get(0), is(equalTo("logs")));
 
+    assertThat(tokenList.get(1), is(equalTo("0")));
+    assertThat(tokenList.get(2), is(equalTo("cloud")));
+    assertThat(tokenList.get(3), is(equalTo("region")));
   }
 
 }


### PR DESCRIPTION
- [x] updated `JsonPathTokenizerTest` to use `assertThat` syntax
- [x] updated `JsonFormatTest` to handle query termination after test run