### PR TITLE
Fix erroneous '$' in the usage message for ksq-server-start script

### DIFF
--- a/bin/ksql-server-start
+++ b/bin/ksql-server-start
@@ -8,7 +8,7 @@ set -ue
 
 if [ $# -lt 1 ]; 
 then
-    echo "$USAGE: $0 [-daemon] ksqlserver.properties"
+    echo "USAGE: $0 [-daemon] ksqlserver.properties"
     exit 1
 fi
 


### PR DESCRIPTION
Fixes #698 