### PR TITLE
Dont rekey streams for aggregate if group by key

### DIFF
--- a/ksql-common/src/main/java/io/confluent/ksql/util/SchemaUtil.java
+++ b/ksql-common/src/main/java/io/confluent/ksql/util/SchemaUtil.java
@@ -24,6 +24,7 @@ import org.apache.kafka.connect.data.SchemaBuilder;
 
 import java.util.HashMap;
 import java.util.HashSet;
+import java.util.List;
 import java.util.Optional;
 import java.util.Set;
 
@@ -348,5 +349,21 @@ public class SchemaUtil {
       schemaBuilder.field(name, field.schema());
     }
     return schemaBuilder.build();
+  }
+
+  public static int getIndexInSchema(final String fieldName, final Schema schema) {
+    List<Field> fields = schema.fields();
+    for (int i = 0; i < fields.size(); i++) {
+      Field field = fields.get(i);
+      if (field.name().equals(fieldName)) {
+        return i;
+      }
+    }
+    throw new KsqlException(
+        "Couldn't find field with name="
+            + fieldName
+            + " in schema. fields="
+            + fields
+    );
   }
 }

--- a/ksql-common/src/main/java/io/confluent/ksql/util/SchemaUtil.java
+++ b/ksql-common/src/main/java/io/confluent/ksql/util/SchemaUtil.java
@@ -329,20 +329,24 @@ public class SchemaUtil {
     return schemaBuilder.build();
   }
 
+  public static String getFieldNameWithNoAlias(Field field) {
+    String name = field.name();
+    if (name.contains(".")) {
+      return name.substring(name.indexOf(".") + 1);
+    } else {
+      return name;
+    }
+  }
+
   /**
    * Remove the alias when reading/writing from outside
    */
   public static Schema getSchemaWithNoAlias(Schema schema) {
     SchemaBuilder schemaBuilder = SchemaBuilder.struct();
     for (Field field : schema.fields()) {
-      String name = field.name();
-      if (name.contains(".")) {
-        schemaBuilder.field(name.substring(name.indexOf(".") + 1), field.schema());
-      } else {
-        schemaBuilder.field(name, field.schema());
-      }
+      String name = getFieldNameWithNoAlias(field);
+      schemaBuilder.field(name, field.schema());
     }
-
     return schemaBuilder.build();
   }
 }

--- a/ksql-common/src/test/java/io/confluent/ksql/util/SchemaUtilTest.java
+++ b/ksql-common/src/test/java/io/confluent/ksql/util/SchemaUtilTest.java
@@ -275,4 +275,16 @@ public class SchemaUtilTest {
     assertThat("Invalid SQL type.", sqlType7, equalTo("MAP<VARCHAR,DOUBLE>"));
   }
 
+  @Test
+  public void shouldStripAliasFromFieldName() {
+    Schema schemaWithAlias = SchemaUtil.buildSchemaWithAlias(schema, "alias");
+    assertThat("Invalid field name", SchemaUtil.getFieldNameWithNoAlias(schemaWithAlias.fields().get(0)),
+        equalTo(schema.fields().get(0).name()));
+  }
+
+  @Test
+  public void shouldReturnFieldNameWithoutAliasAsIs() {
+    assertThat("Invalid field name", SchemaUtil.getFieldNameWithNoAlias(schema.fields().get(0)),
+        equalTo(schema.fields().get(0).name()));
+  }
 }

--- a/ksql-engine/src/main/java/io/confluent/ksql/codegen/CodeGenRunner.java
+++ b/ksql-engine/src/main/java/io/confluent/ksql/codegen/CodeGenRunner.java
@@ -65,8 +65,7 @@ public class CodeGenRunner {
   public ExpressionMetadata buildCodeGenFromParseTree(
       final Expression expression
   ) throws Exception {
-    CodeGenRunner codeGenRunner = new CodeGenRunner(schema, functionRegistry);
-    Map<String, Class> parameterMap = codeGenRunner.getParameterInfo(expression);
+    Map<String, Class> parameterMap = getParameterInfo(expression);
 
     String[] parameterNames = new String[parameterMap.size()];
     Class[] parameterTypes = new Class[parameterMap.size()];

--- a/ksql-engine/src/main/java/io/confluent/ksql/ddl/commands/CreateStreamCommand.java
+++ b/ksql-engine/src/main/java/io/confluent/ksql/ddl/commands/CreateStreamCommand.java
@@ -22,6 +22,7 @@ import io.confluent.ksql.metastore.KsqlStream;
 import io.confluent.ksql.metastore.MetaStore;
 import io.confluent.ksql.parser.tree.CreateStream;
 import io.confluent.ksql.util.KafkaTopicClient;
+import io.confluent.ksql.util.SchemaUtil;
 
 
 public class CreateStreamCommand extends AbstractCreateStreamCommand {
@@ -45,8 +46,10 @@ public class CreateStreamCommand extends AbstractCreateStreamCommand {
         sqlExpression,
         sourceName,
         schema,
-        (keyColumnName.length() == 0) ? null : schema.field(keyColumnName),
-        (timestampColumnName.length() == 0) ? null : schema.field(timestampColumnName),
+        (keyColumnName.length() == 0) ?
+            null : SchemaUtil.getFieldByName(schema, keyColumnName).orElse(null),
+        (timestampColumnName.length() == 0) ?
+            null : SchemaUtil.getFieldByName(schema, timestampColumnName).orElse(null),
         metaStore.getTopic(topicName)
     );
 

--- a/ksql-engine/src/main/java/io/confluent/ksql/ddl/commands/CreateStreamCommand.java
+++ b/ksql-engine/src/main/java/io/confluent/ksql/ddl/commands/CreateStreamCommand.java
@@ -47,9 +47,11 @@ public class CreateStreamCommand extends AbstractCreateStreamCommand {
         sourceName,
         schema,
         (keyColumnName.length() == 0) ?
-            null : SchemaUtil.getFieldByName(schema, keyColumnName).orElse(null),
+            null :
+            SchemaUtil.getFieldByName(schema, keyColumnName).orElse(null),
         (timestampColumnName.length() == 0) ?
-            null : SchemaUtil.getFieldByName(schema, timestampColumnName).orElse(null),
+            null :
+            SchemaUtil.getFieldByName(schema, timestampColumnName).orElse(null),
         metaStore.getTopic(topicName)
     );
 

--- a/ksql-engine/src/main/java/io/confluent/ksql/ddl/commands/CreateTableCommand.java
+++ b/ksql-engine/src/main/java/io/confluent/ksql/ddl/commands/CreateTableCommand.java
@@ -68,9 +68,11 @@ public class CreateTableCommand extends AbstractCreateStreamCommand {
         sourceName,
         schema,
         (keyColumnName.length() == 0) ?
-            null : SchemaUtil.getFieldByName(schema, keyColumnName).orElse(null),
+            null :
+            SchemaUtil.getFieldByName(schema, keyColumnName).orElse(null),
         (timestampColumnName.length() == 0) ?
-            null : SchemaUtil.getFieldByName(schema, timestampColumnName).orElse(null),
+            null :
+            SchemaUtil.getFieldByName(schema, timestampColumnName).orElse(null),
         metaStore.getTopic(topicName),
         stateStoreName, isWindowed
     );

--- a/ksql-engine/src/main/java/io/confluent/ksql/ddl/commands/CreateTableCommand.java
+++ b/ksql-engine/src/main/java/io/confluent/ksql/ddl/commands/CreateTableCommand.java
@@ -25,6 +25,7 @@ import io.confluent.ksql.parser.tree.CreateTable;
 import io.confluent.ksql.parser.tree.Expression;
 import io.confluent.ksql.util.KafkaTopicClient;
 import io.confluent.ksql.util.KsqlException;
+import io.confluent.ksql.util.SchemaUtil;
 import io.confluent.ksql.util.StringUtil;
 
 public class CreateTableCommand extends AbstractCreateStreamCommand {
@@ -66,8 +67,10 @@ public class CreateTableCommand extends AbstractCreateStreamCommand {
         sqlExpression,
         sourceName,
         schema,
-        (keyColumnName.length() == 0) ? null : schema.field(keyColumnName),
-        (timestampColumnName.length() == 0) ? null : schema.field(timestampColumnName),
+        (keyColumnName.length() == 0) ?
+            null : SchemaUtil.getFieldByName(schema, keyColumnName).orElse(null),
+        (timestampColumnName.length() == 0) ?
+            null : SchemaUtil.getFieldByName(schema, timestampColumnName).orElse(null),
         metaStore.getTopic(topicName),
         stateStoreName, isWindowed
     );

--- a/ksql-engine/src/main/java/io/confluent/ksql/planner/plan/AggregateNode.java
+++ b/ksql-engine/src/main/java/io/confluent/ksql/planner/plan/AggregateNode.java
@@ -21,7 +21,6 @@ import com.google.common.collect.ImmutableList;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
 
-import io.confluent.ksql.parser.tree.DereferenceExpression;
 import org.apache.kafka.common.serialization.Serde;
 import org.apache.kafka.common.serialization.Serdes;
 import org.apache.kafka.connect.data.Field;
@@ -30,12 +29,6 @@ import org.apache.kafka.connect.data.SchemaBuilder;
 import org.apache.kafka.streams.StreamsBuilder;
 import org.apache.kafka.streams.kstream.KStream;
 import org.apache.kafka.streams.kstream.KeyValueMapper;
-import io.confluent.ksql.util.AggregateExpressionRewriter;
-import io.confluent.ksql.util.KafkaTopicClient;
-import io.confluent.ksql.util.KsqlConfig;
-import io.confluent.ksql.util.KsqlException;
-import io.confluent.ksql.util.Pair;
-import io.confluent.ksql.util.SchemaUtil;
 
 import java.util.ArrayList;
 import java.util.Collections;
@@ -52,6 +45,7 @@ import io.confluent.ksql.function.KsqlAggregateFunction;
 import io.confluent.ksql.function.udaf.KudafAggregator;
 import io.confluent.ksql.function.udaf.KudafInitializer;
 import io.confluent.ksql.metastore.MetastoreUtil;
+import io.confluent.ksql.parser.tree.DereferenceExpression;
 import io.confluent.ksql.parser.tree.Expression;
 import io.confluent.ksql.parser.tree.FunctionCall;
 import io.confluent.ksql.parser.tree.WindowExpression;
@@ -59,6 +53,12 @@ import io.confluent.ksql.serde.KsqlTopicSerDe;
 import io.confluent.ksql.structured.SchemaKGroupedStream;
 import io.confluent.ksql.structured.SchemaKStream;
 import io.confluent.ksql.structured.SchemaKTable;
+import io.confluent.ksql.util.AggregateExpressionRewriter;
+import io.confluent.ksql.util.KafkaTopicClient;
+import io.confluent.ksql.util.KsqlConfig;
+import io.confluent.ksql.util.KsqlException;
+import io.confluent.ksql.util.Pair;
+import io.confluent.ksql.util.SchemaUtil;
 
 
 public class AggregateNode extends PlanNode {

--- a/ksql-engine/src/main/java/io/confluent/ksql/structured/QueuedSchemaKStream.java
+++ b/ksql-engine/src/main/java/io/confluent/ksql/structured/QueuedSchemaKStream.java
@@ -132,7 +132,9 @@ public class QueuedSchemaKStream extends SchemaKStream {
   }
 
   @Override
-  public SchemaKGroupedStream groupByKey(Serde keySerde, Serde valSerde) {
+  public SchemaKGroupedStream groupBy(
+      final Serde<String> keySerde, final Serde<GenericRow> valSerde,
+      final List<Expression> groupByExpressions) {
     throw new UnsupportedOperationException();
   }
 

--- a/ksql-engine/src/main/java/io/confluent/ksql/structured/SchemaKGroupedStream.java
+++ b/ksql-engine/src/main/java/io/confluent/ksql/structured/SchemaKGroupedStream.java
@@ -60,6 +60,10 @@ public class SchemaKGroupedStream {
     this.schemaRegistryClient = schemaRegistryClient;
   }
 
+  public Field getKeyField() {
+    return keyField;
+  }
+
   @SuppressWarnings("unchecked")
   public SchemaKTable aggregate(
       final Initializer initializer,

--- a/ksql-engine/src/main/java/io/confluent/ksql/structured/SchemaKStream.java
+++ b/ksql-engine/src/main/java/io/confluent/ksql/structured/SchemaKStream.java
@@ -316,7 +316,7 @@ public class SchemaKStream {
     }
 
     KGroupedStream kgroupedStream = kstream.groupBy(
-        (KeyValueMapper<String, GenericRow, String>) (key, value) -> {
+        (key, value) -> {
           StringBuilder newKey = new StringBuilder();
           boolean addSeparator1 = false;
           for (int index : newKeyIndexes) {

--- a/ksql-engine/src/main/java/io/confluent/ksql/structured/SchemaKStream.java
+++ b/ksql-engine/src/main/java/io/confluent/ksql/structured/SchemaKStream.java
@@ -42,6 +42,7 @@ import io.confluent.ksql.GenericRow;
 import io.confluent.ksql.codegen.CodeGenRunner;
 import io.confluent.ksql.function.FunctionRegistry;
 import io.confluent.ksql.parser.tree.Expression;
+import io.confluent.ksql.parser.tree.DereferenceExpression;
 import io.confluent.ksql.planner.plan.OutputNode;
 import io.confluent.ksql.serde.KsqlTopicSerDe;
 import io.confluent.ksql.util.ExpressionMetadata;
@@ -263,19 +264,84 @@ public class SchemaKStream {
     );
   }
 
-  public SchemaKGroupedStream groupByKey(
-      final Serde<String> keySerde,
-      final Serde<GenericRow> valSerde
-  ) {
-    KGroupedStream kgroupedStream = kstream.groupByKey(Serialized.with(keySerde, valSerde));
+  private String fieldNameFromExpression(Expression expression) {
+    if (expression instanceof DereferenceExpression) {
+      DereferenceExpression dereferenceExpression =
+          (DereferenceExpression) expression;
+      return dereferenceExpression.getFieldName();
+    }
+    return null;
+  }
+
+  private boolean rekeyRequired(List<Expression> groupByExpressions) {
+    Field keyField = getKeyField();
+    if (keyField == null) {
+      return true;
+    }
+    String keyFieldName = SchemaUtil.getFieldNameWithNoAlias(keyField);
+    return !(groupByExpressions.size() == 1
+        && fieldNameFromExpression(groupByExpressions.get(0)).equals(keyFieldName));
+  }
+
+  public SchemaKGroupedStream groupBy(
+      final Serde<String> keySerde, final Serde<GenericRow> valSerde,
+      final List<Expression> groupByExpressions) {
+    boolean rekey = rekeyRequired(groupByExpressions);
+
+    if (!rekey) {
+      KGroupedStream kgroupedStream = kstream.groupByKey(Serialized.with(keySerde, valSerde));
+      return new SchemaKGroupedStream(
+          schema,
+          kgroupedStream,
+          keyField,
+          Collections.singletonList(this),
+          functionRegistry,
+          schemaRegistryClient
+      );
+    }
+
+    // Collect the column indexes, and build the new key as <column1>+<column2>+...
+    StringBuilder aggregateKeyName = new StringBuilder();
+    List<Integer> newKeyIndexes = new ArrayList<>();
+    boolean addSeparator = false;
+    for (Expression groupByExpr : groupByExpressions) {
+      if (addSeparator) {
+        aggregateKeyName.append("|+|");
+      } else {
+        addSeparator = true;
+      }
+      aggregateKeyName.append(groupByExpr.toString());
+      newKeyIndexes.add(
+          SchemaUtil.getIndexInSchema(groupByExpr.toString(), getSchema()));
+    }
+
+    KGroupedStream kgroupedStream = kstream.groupBy(
+        (KeyValueMapper<String, GenericRow, String>) (key, value) -> {
+          StringBuilder newKey = new StringBuilder();
+          boolean addSeparator1 = false;
+          for (int index : newKeyIndexes) {
+            if (addSeparator1) {
+              newKey.append("|+|");
+            } else {
+              addSeparator1 = true;
+            }
+            newKey.append(String.valueOf(value.getColumns().get(index)));
+          }
+          return newKey.toString();
+        }, Serialized.with(keySerde, valSerde));
+
+    // TODO: if the key is a prefix of the grouping columns then we can
+    //       use the repartition reflection hack to tell streams not to
+    //       repartition.
+
+    Field newKeyField = new Field(aggregateKeyName.toString(), -1, Schema.STRING_SCHEMA);
     return new SchemaKGroupedStream(
         schema,
         kgroupedStream,
-        keyField,
+        newKeyField,
         Collections.singletonList(this),
         functionRegistry,
-        schemaRegistryClient
-    );
+        schemaRegistryClient);
   }
 
   public Field getKeyField() {

--- a/ksql-engine/src/test/java/io/confluent/ksql/physical/PhysicalPlanBuilderTest.java
+++ b/ksql-engine/src/test/java/io/confluent/ksql/physical/PhysicalPlanBuilderTest.java
@@ -148,9 +148,8 @@ public class PhysicalPlanBuilderTest {
         + ", KSQL_COL_2 : INT64].");
     Assert.assertEquals(lines[1], "\t\t > [ AGGREGATE ] Schema: [TEST1.COL0 : INT64 , TEST1.COL3 : FLOAT64 , KSQL_AGG_VARIABLE_0 : FLOAT64 , KSQL_AGG_VARIABLE_1 : INT64].");
     Assert.assertEquals(lines[2], "\t\t\t\t > [ PROJECT ] Schema: [TEST1.COL0 : INT64 , TEST1.COL3 : FLOAT64].");
-    Assert.assertEquals(lines[3], "\t\t\t\t\t\t > [ REKEY ] Schema: [TEST1.COL0 : INT64 , TEST1.COL1 : STRING , TEST1.COL2 : STRING , TEST1.COL3 : FLOAT64 , TEST1.COL4 : ARRAY , TEST1.COL5 : MAP].");
-    Assert.assertEquals(lines[4], "\t\t\t\t\t\t\t\t > [ FILTER ] Schema: [TEST1.COL0 : INT64 , TEST1.COL1 : STRING , TEST1.COL2 : STRING , TEST1.COL3 : FLOAT64 , TEST1.COL4 : ARRAY , TEST1.COL5 : MAP].");
-    Assert.assertEquals(lines[5], "\t\t\t\t\t\t\t\t\t\t > [ SOURCE ] Schema: [TEST1.COL0 : INT64 , TEST1.COL1 : STRING , TEST1.COL2 : STRING , TEST1.COL3 : FLOAT64 , TEST1.COL4 : ARRAY , TEST1.COL5 : MAP].");
+    Assert.assertEquals(lines[3], "\t\t\t\t\t\t > [ FILTER ] Schema: [TEST1.COL0 : INT64 , TEST1.COL1 : STRING , TEST1.COL2 : STRING , TEST1.COL3 : FLOAT64 , TEST1.COL4 : ARRAY , TEST1.COL5 : MAP].");
+    Assert.assertEquals(lines[4], "\t\t\t\t\t\t\t\t > [ SOURCE ] Schema: [TEST1.COL0 : INT64 , TEST1.COL1 : STRING , TEST1.COL2 : STRING , TEST1.COL3 : FLOAT64 , TEST1.COL4 : ARRAY , TEST1.COL5 : MAP].");
   }
 
   @Test

--- a/ksql-engine/src/test/java/io/confluent/ksql/planner/plan/AggregateNodeTest.java
+++ b/ksql-engine/src/test/java/io/confluent/ksql/planner/plan/AggregateNodeTest.java
@@ -94,10 +94,10 @@ public class AggregateNodeTest {
   @Test
   public void shouldHaveSourceNodeForSecondSubtopolgy() {
     buildRequireRekey();
-    final TopologyDescription.Source node = (TopologyDescription.Source) getNodeByName(builder.build(), "KSTREAM-SOURCE-0000000012");
+    final TopologyDescription.Source node = (TopologyDescription.Source) getNodeByName(builder.build(), "KSTREAM-SOURCE-0000000008");
     final List<String> successors = node.successors().stream().map(TopologyDescription.Node::name).collect(Collectors.toList());
     assertThat(node.predecessors(), equalTo(Collections.emptySet()));
-    assertThat(successors, equalTo(Collections.singletonList("KSTREAM-AGGREGATE-0000000009")));
+    assertThat(successors, equalTo(Collections.singletonList("KSTREAM-AGGREGATE-0000000005")));
     assertThat(node.topics(), containsString("[KSQL_Agg_Query_"));
     assertThat(node.topics(), containsString("-repartition]"));
   }
@@ -105,8 +105,8 @@ public class AggregateNodeTest {
   @Test
   public void shouldHaveSinkNodeWithSameTopicAsSecondSource() {
     buildRequireRekey();
-    TopologyDescription.Sink sink = (TopologyDescription.Sink) getNodeByName(builder.build(), "KSTREAM-SINK-0000000010");
-    final TopologyDescription.Source source = (TopologyDescription.Source) getNodeByName(builder.build(), "KSTREAM-SOURCE-0000000012");
+    TopologyDescription.Sink sink = (TopologyDescription.Sink) getNodeByName(builder.build(), "KSTREAM-SINK-0000000006");
+    final TopologyDescription.Source source = (TopologyDescription.Source) getNodeByName(builder.build(), "KSTREAM-SOURCE-0000000008");
     assertThat(sink.successors(), equalTo(Collections.emptySet()));
     assertThat("[" + sink.topic() + "]", equalTo(source.topics()));
   }
@@ -142,10 +142,10 @@ public class AggregateNodeTest {
   }
 
   private SchemaKStream buildRequireRekey() {
-    return buildQuery("SELECT col1, col4, sum(col3), count(col3) FROM test2 window TUMBLING ( "
+    return buildQuery("SELECT col1, sum(col3), count(col3) FROM test1 window TUMBLING ( "
         + "size 2 "
         + "second) "
-        + "WHERE col4 = TRUE GROUP BY col1;");
+        + "GROUP BY col1;");
   }
 
   private SchemaKStream buildQuery(String queryString) {


### PR DESCRIPTION
When building the kafka streams app for aggregates, dont rekey the
stream if grouping by the key. This avoids expensive repartitioning
in one case where it is not required.