### PR TITLE
Removing Array.newInstance calls

### DIFF
--- a/ksql-engine/src/main/java/io/confluent/ksql/function/udaf/topkdistinct/TopkDistinctKudaf.java
+++ b/ksql-engine/src/main/java/io/confluent/ksql/function/udaf/topkdistinct/TopkDistinctKudaf.java
@@ -33,23 +33,22 @@ import io.confluent.ksql.util.ArrayUtil;
 import io.confluent.ksql.util.KsqlException;
 
 public class TopkDistinctKudaf<T> extends KsqlAggregateFunction<T, T[]> {
-
-  private Integer tkVal;
-  private T[] tempTopkArray;
-  private Class<T> ttClass;
+  private final Integer topKSize;
+  private final Class<T> clazz;
+  private T[] tempTopKArray;
 
   TopkDistinctKudaf(Integer argIndexInValue,
-                    Integer tkVal,
-                    Class<T> ttClass) {
+                    Integer topKSize,
+                    Class<T> clazz) {
     super(argIndexInValue,
-        () -> (T[]) Array.newInstance(ttClass, tkVal),
+        () -> (T[]) new Object[topKSize],
           SchemaBuilder.array(Schema.FLOAT64_SCHEMA).build(),
           Arrays.asList(Schema.FLOAT64_SCHEMA)
     );
 
-    this.tkVal = tkVal;
-    this.tempTopkArray = (T[]) Array.newInstance(ttClass,tkVal + 1);
-    this.ttClass = ttClass;
+    this.topKSize = topKSize;
+    this.tempTopKArray = (T[]) new Object[topKSize + 1];
+    this.clazz = clazz;
   }
 
   @Override
@@ -67,19 +66,19 @@ public class TopkDistinctKudaf<T> extends KsqlAggregateFunction<T, T[]> {
       return currentAggVal;
     }
 
-    System.arraycopy(currentAggVal, 0, tempTopkArray, 0, tkVal);
-    tempTopkArray[tkVal] = currentVal;
-    Arrays.sort(tempTopkArray, Collections.reverseOrder());
-    return Arrays.copyOf(tempTopkArray, tkVal);
+    System.arraycopy(currentAggVal, 0, tempTopKArray, 0, topKSize);
+    tempTopKArray[topKSize] = currentVal;
+    Arrays.sort(tempTopKArray, Collections.reverseOrder());
+    return Arrays.copyOf(tempTopKArray, topKSize);
   }
 
   @Override
   public Merger<String, T[]> getMerger() {
     return (aggKey, aggOne, aggTwo) -> {
 
-      int nullIndex1 = ArrayUtil.getNullIndex(aggOne) == -1? tkVal: ArrayUtil.getNullIndex(aggOne);
-      int nullIndex2 = ArrayUtil.getNullIndex(aggTwo) == -1? tkVal: ArrayUtil.getNullIndex(aggTwo);
-      T[] tempMergeTopkArray = (T[]) Array.newInstance(ttClass, nullIndex1 + nullIndex2);
+      int nullIndex1 = ArrayUtil.getNullIndex(aggOne) == -1? topKSize : ArrayUtil.getNullIndex(aggOne);
+      int nullIndex2 = ArrayUtil.getNullIndex(aggTwo) == -1? topKSize : ArrayUtil.getNullIndex(aggTwo);
+      T[] tempMergeTopkArray = (T[]) new Object[nullIndex1 + nullIndex2];
 
       for (int i = 0; i < nullIndex1; i++) {
         tempMergeTopkArray[i] = aggOne[i];
@@ -92,13 +91,13 @@ public class TopkDistinctKudaf<T> extends KsqlAggregateFunction<T, T[]> {
           tempMergeTopkArray[i - duplicateCount] = aggTwo[i - nullIndex1];
         }
       }
-      tempMergeTopkArray = ArrayUtil.getNoNullArray(ttClass, tempMergeTopkArray);
+      tempMergeTopkArray = ArrayUtil.getNoNullArray(clazz, tempMergeTopkArray);
       Arrays.sort(tempMergeTopkArray, Collections.reverseOrder());
-      if (tempMergeTopkArray.length < tkVal) {
-        tempMergeTopkArray = ArrayUtil.padWithNull(ttClass, tempMergeTopkArray, tkVal);
+      if (tempMergeTopkArray.length < topKSize) {
+        tempMergeTopkArray = ArrayUtil.padWithNull(clazz, tempMergeTopkArray, topKSize);
         return tempMergeTopkArray;
       }
-      return Arrays.copyOf(tempMergeTopkArray, tkVal);
+      return Arrays.copyOf(tempMergeTopkArray, topKSize);
     };
   }
 
@@ -106,12 +105,12 @@ public class TopkDistinctKudaf<T> extends KsqlAggregateFunction<T, T[]> {
   public KsqlAggregateFunction<T, T[]> getInstance(Map<String, Integer> expressionNames,
                                                              List<Expression> functionArguments) {
     if (functionArguments.size() != 2) {
-      throw new KsqlException(String.format("Invalid parameter count. Need 2 args, got %d arg(s)"
-                                            + ".", functionArguments.size()));
+      throw new KsqlException(String.format("Invalid parameter count. Need 2 args, got %d arg(s).",
+              functionArguments.size()));
     }
     int udafIndex = expressionNames.get(functionArguments.get(0).toString());
-    Integer tkValFromArg = Integer.parseInt(functionArguments.get(1).toString());
-    return new TopkDistinctKudaf(udafIndex, tkValFromArg, ttClass);
+    int topKSize = Integer.parseInt(functionArguments.get(1).toString());
+    return new TopkDistinctKudaf(udafIndex, topKSize, clazz);
   }
 
 }

--- a/ksql-engine/src/main/java/io/confluent/ksql/function/udaf/topkdistinct/TopkDistinctKudaf.java
+++ b/ksql-engine/src/main/java/io/confluent/ksql/function/udaf/topkdistinct/TopkDistinctKudaf.java
@@ -20,7 +20,6 @@ import org.apache.kafka.connect.data.Schema;
 import org.apache.kafka.connect.data.SchemaBuilder;
 import org.apache.kafka.streams.kstream.Merger;
 
-import java.lang.reflect.Array;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;

--- a/ksql-engine/src/main/java/io/confluent/ksql/function/udaf/topkdistinct/TopkDistinctKudaf.java
+++ b/ksql-engine/src/main/java/io/confluent/ksql/function/udaf/topkdistinct/TopkDistinctKudaf.java
@@ -33,19 +33,18 @@ import io.confluent.ksql.util.ArrayUtil;
 import io.confluent.ksql.util.KsqlException;
 
 public class TopkDistinctKudaf<T> extends KsqlAggregateFunction<T, T[]> {
-  private final Integer topKSize;
+  private final int topKSize;
   private final Class<T> clazz;
   private T[] tempTopKArray;
 
   TopkDistinctKudaf(Integer argIndexInValue,
-                    Integer topKSize,
+                    int topKSize,
                     Class<T> clazz) {
     super(argIndexInValue,
         () -> (T[]) new Object[topKSize],
           SchemaBuilder.array(Schema.FLOAT64_SCHEMA).build(),
           Arrays.asList(Schema.FLOAT64_SCHEMA)
     );
-
     this.topKSize = topKSize;
     this.tempTopKArray = (T[]) new Object[topKSize + 1];
     this.clazz = clazz;

--- a/ksql-engine/src/main/java/io/confluent/ksql/util/ArrayUtil.java
+++ b/ksql-engine/src/main/java/io/confluent/ksql/util/ArrayUtil.java
@@ -16,10 +16,8 @@
 
 package io.confluent.ksql.util;
 
-import java.lang.reflect.Array;
 import java.util.Arrays;
 import java.util.Objects;
-import java.util.stream.IntStream;
 
 public class ArrayUtil {
 

--- a/ksql-engine/src/main/java/io/confluent/ksql/util/ArrayUtil.java
+++ b/ksql-engine/src/main/java/io/confluent/ksql/util/ArrayUtil.java
@@ -19,6 +19,7 @@ package io.confluent.ksql.util;
 import java.lang.reflect.Array;
 import java.util.Arrays;
 import java.util.Objects;
+import java.util.stream.IntStream;
 
 public class ArrayUtil {
 
@@ -36,7 +37,7 @@ public class ArrayUtil {
     if (nullIndex == -1) {
       return array;
     }
-    T[] noNullArray = (T[]) Array.newInstance(clazz, nullIndex);
+    T[] noNullArray = (T[]) new Object[nullIndex];
     for (int i = 0; i < noNullArray.length; i++) {
       noNullArray[i] = array[i];
     }
@@ -47,7 +48,7 @@ public class ArrayUtil {
     if (array.length >= finalLength) {
       return array;
     }
-    T[] paddedArray = (T[]) Array.newInstance(clazz, finalLength);
+    T[] paddedArray = (T[]) new Object[finalLength];
     for(int i = 0; i < array.length; i++) {
       paddedArray[i] = array[i];
     }

--- a/ksql-serde/src/main/java/io/confluent/ksql/serde/avro/KsqlGenericRowAvroDeserializer.java
+++ b/ksql-serde/src/main/java/io/confluent/ksql/serde/avro/KsqlGenericRowAvroDeserializer.java
@@ -121,12 +121,10 @@ public class KsqlGenericRowAvroDeserializer implements Deserializer<GenericRow> 
 
       case ARRAY:
         GenericData.Array genericArray = (GenericData.Array) value;
-        Class elementClass = SchemaUtil.getJavaType(fieldSchema.valueSchema());
-        Object[] arrayField =
-            (Object[]) java.lang.reflect.Array.newInstance(elementClass, genericArray.size());
-        for (int i = 0; i < genericArray.size(); i++) {
-          Object obj = enforceFieldType(fieldSchema.valueSchema(), genericArray.get(i));
-          arrayField[i] = obj;
+        int size = genericArray.size();
+        Object[] arrayField = new Object[size];
+        for (int i = 0; i < size; i++) {
+          arrayField[i] = enforceFieldType(fieldSchema.valueSchema(), genericArray.get(i));
         }
         return arrayField;
       case MAP:

--- a/ksql-serde/src/main/java/io/confluent/ksql/serde/json/KsqlJsonDeserializer.java
+++ b/ksql-serde/src/main/java/io/confluent/ksql/serde/json/KsqlJsonDeserializer.java
@@ -34,7 +34,6 @@ import java.util.Map;
 
 import io.confluent.ksql.GenericRow;
 import io.confluent.ksql.util.KsqlException;
-import io.confluent.ksql.util.SchemaUtil;
 
 public class KsqlJsonDeserializer implements Deserializer<GenericRow> {
 

--- a/ksql-serde/src/main/java/io/confluent/ksql/serde/json/KsqlJsonDeserializer.java
+++ b/ksql-serde/src/main/java/io/confluent/ksql/serde/json/KsqlJsonDeserializer.java
@@ -110,10 +110,9 @@ public class KsqlJsonDeserializer implements Deserializer<GenericRow> {
         }
       case ARRAY:
         ArrayNode arrayNode = (ArrayNode) fieldJsonNode;
-        Class elementClass = SchemaUtil.getJavaType(fieldSchema.valueSchema());
-        Object[] arrayField =
-            (Object[]) java.lang.reflect.Array.newInstance(elementClass, arrayNode.size());
-        for (int i = 0; i < arrayNode.size(); i++) {
+        int size = arrayNode.size();
+        Object[] arrayField = new Object[size];
+        for (int i = 0; i < size; i++) {
           arrayField[i] = enforceFieldType(fieldSchema.valueSchema(), arrayNode.get(i));
         }
         return arrayField;


### PR DESCRIPTION
`Array.newInstance` is java reflection API, which quite slow in practice and there is no real need for them. 

> Reflection is powerful, but should not be used indiscriminately. If it is possible to perform an operation without using reflection, then it is preferable to avoid using 

https://docs.oracle.com/javase/tutorial/reflect/