### PR TITLE
Fix hash code equals contract

### DIFF
--- a/ksql-engine/src/main/java/io/confluent/ksql/util/QueryMetadata.java
+++ b/ksql-engine/src/main/java/io/confluent/ksql/util/QueryMetadata.java
@@ -27,7 +27,6 @@ import org.slf4j.LoggerFactory;
 import java.util.Objects;
 
 public class QueryMetadata {
-
   private static final Logger log = LoggerFactory.getLogger(QueryMetadata.class);
   private final String statementString;
   private final KafkaStreams kafkaStreams;
@@ -37,7 +36,6 @@ public class QueryMetadata {
   private final String queryApplicationId;
   private final KafkaTopicClient kafkaTopicClient;
   private final Topology topoplogy;
-
 
   public QueryMetadata(final String statementString,
                        final KafkaStreams kafkaStreams,

--- a/ksql-engine/src/main/java/io/confluent/ksql/util/QueryMetadata.java
+++ b/ksql-engine/src/main/java/io/confluent/ksql/util/QueryMetadata.java
@@ -113,7 +113,7 @@ public class QueryMetadata {
 
   @Override
   public int hashCode() {
-    return Objects.hash(kafkaStreams, outputNode, queryApplicationId);
+    return Objects.hash(statementString, kafkaStreams, outputNode, queryApplicationId);
   }
 
   public void start() {


### PR DESCRIPTION
Objects which are `.equals()` MUST have the same `.hashCode()`.