### PR TITLE
Use mapValues overloads from KIP-149

### DIFF
--- a/ksql-engine/src/main/java/io/confluent/ksql/structured/SchemaKStream.java
+++ b/ksql-engine/src/main/java/io/confluent/ksql/structured/SchemaKStream.java
@@ -48,7 +48,7 @@ import io.confluent.ksql.util.KsqlConfig;
 import io.confluent.ksql.util.KsqlException;
 import io.confluent.ksql.util.Pair;
 import io.confluent.ksql.util.SchemaUtil;
-import org.apache.kafka.streams.kstream.ValueMapperWithKey;
+
 
 public class SchemaKStream {
 

--- a/ksql-engine/src/main/java/io/confluent/ksql/structured/SchemaKStream.java
+++ b/ksql-engine/src/main/java/io/confluent/ksql/structured/SchemaKStream.java
@@ -21,11 +21,9 @@ import org.apache.kafka.common.serialization.Serdes;
 import org.apache.kafka.connect.data.Field;
 import org.apache.kafka.connect.data.Schema;
 import org.apache.kafka.connect.data.SchemaBuilder;
-import org.apache.kafka.streams.KeyValue;
 import org.apache.kafka.streams.kstream.Joined;
 import org.apache.kafka.streams.kstream.KGroupedStream;
 import org.apache.kafka.streams.kstream.KStream;
-import org.apache.kafka.streams.kstream.KeyValueMapper;
 import org.apache.kafka.streams.kstream.Produced;
 import org.apache.kafka.streams.kstream.Serialized;
 import org.apache.kafka.streams.kstream.ValueJoiner;
@@ -50,6 +48,7 @@ import io.confluent.ksql.util.KsqlConfig;
 import io.confluent.ksql.util.KsqlException;
 import io.confluent.ksql.util.Pair;
 import io.confluent.ksql.util.SchemaUtil;
+import org.apache.kafka.streams.kstream.ValueMapperWithKey;
 
 public class SchemaKStream {
 
@@ -96,9 +95,9 @@ public class SchemaKStream {
   ) {
 
     kstream
-        .map((key, row) -> {
+        .mapValues(row -> {
           if (row == null) {
-            return new KeyValue<>(key, null);
+            return null;
           }
           List<Object> columns = new ArrayList<>();
           for (int i = 0; i < row.getColumns().size(); i++) {
@@ -106,7 +105,7 @@ public class SchemaKStream {
               columns.add(row.getColumns().get(i));
             }
           }
-          return new KeyValue<>(key, new GenericRow(columns));
+          return new GenericRow(columns);
         }).to(kafkaTopicName, Produced.with(Serdes.String(), topicValueSerDe));
     return this;
   }
@@ -247,9 +246,9 @@ public class SchemaKStream {
               .get(SchemaUtil.getFieldIndexByName(schema, newKeyField.name()))
               .toString();
       return newKey;
-    }).map((KeyValueMapper<String, GenericRow, KeyValue<String, GenericRow>>) (key, row) -> {
+    }).mapValues((key, row) -> {
       row.getColumns().set(SchemaUtil.ROWKEY_NAME_INDEX, key);
-      return new KeyValue<>(key, row);
+      return row;
     });
 
     return new SchemaKStream(

--- a/ksql-engine/src/test/java/io/confluent/ksql/planner/plan/AggregateNodeTest.java
+++ b/ksql-engine/src/test/java/io/confluent/ksql/planner/plan/AggregateNodeTest.java
@@ -18,7 +18,6 @@ package io.confluent.ksql.planner.plan;
 
 import org.apache.kafka.connect.data.Field;
 import org.apache.kafka.connect.data.Schema;
-import org.apache.kafka.connect.data.SchemaBuilder;
 import org.apache.kafka.streams.StreamsBuilder;
 import org.apache.kafka.streams.TopologyDescription;
 import org.easymock.EasyMock;
@@ -29,17 +28,11 @@ import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
-import java.util.Map;
-import java.util.Optional;
 import java.util.stream.Collectors;
 
 import io.confluent.kafka.schemaregistry.client.MockSchemaRegistryClient;
-import io.confluent.ksql.ddl.DdlConfig;
 import io.confluent.ksql.function.FunctionRegistry;
-import io.confluent.ksql.metastore.KsqlStream;
-import io.confluent.ksql.metastore.KsqlTopic;
 import io.confluent.ksql.metastore.MetastoreUtil;
-import io.confluent.ksql.serde.json.KsqlJsonTopicSerDe;
 import io.confluent.ksql.structured.LogicalPlanBuilder;
 import io.confluent.ksql.structured.SchemaKStream;
 import io.confluent.ksql.structured.SchemaKTable;
@@ -47,18 +40,12 @@ import io.confluent.ksql.util.KafkaTopicClient;
 import io.confluent.ksql.util.KsqlConfig;
 import io.confluent.ksql.util.MetaStoreFixture;
 
-import static io.confluent.ksql.planner.plan.PlanTestUtil.MAP_NODE;
+import static io.confluent.ksql.planner.plan.PlanTestUtil.MAPVALUES_NODE;
 import static io.confluent.ksql.planner.plan.PlanTestUtil.SOURCE_NODE;
-import static io.confluent.ksql.planner.plan.PlanTestUtil.TRANSFORM_NODE;
 import static io.confluent.ksql.planner.plan.PlanTestUtil.getNodeByName;
-import static io.confluent.ksql.planner.plan.PlanTestUtil.verifyProcessorNode;
-import static org.easymock.EasyMock.anyInt;
-import static org.easymock.EasyMock.anyShort;
-import static org.easymock.EasyMock.eq;
 import static org.hamcrest.CoreMatchers.containsString;
 import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.core.IsInstanceOf.instanceOf;
 import static org.junit.Assert.assertTrue;
 
 public class AggregateNodeTest {
@@ -90,7 +77,7 @@ public class AggregateNodeTest {
     final TopologyDescription.Source node = (TopologyDescription.Source) getNodeByName(builder.build(), SOURCE_NODE);
     final List<String> successors = node.successors().stream().map(TopologyDescription.Node::name).collect(Collectors.toList());
     assertThat(node.predecessors(), equalTo(Collections.emptySet()));
-    assertThat(successors, equalTo(Collections.singletonList(MAP_NODE)));
+    assertThat(successors, equalTo(Collections.singletonList(MAPVALUES_NODE)));
     assertThat(node.topics(), equalTo("[test1]"));
   }
 

--- a/ksql-engine/src/test/java/io/confluent/ksql/planner/plan/JoinNodeTest.java
+++ b/ksql-engine/src/test/java/io/confluent/ksql/planner/plan/JoinNodeTest.java
@@ -40,7 +40,6 @@ import io.confluent.ksql.function.FunctionRegistry;
 import io.confluent.ksql.metastore.MetaStore;
 import io.confluent.ksql.metastore.MetastoreUtil;
 import io.confluent.ksql.metastore.StructuredDataSource;
-import io.confluent.ksql.serde.WindowedSerde;
 import io.confluent.ksql.structured.LogicalPlanBuilder;
 import io.confluent.ksql.structured.SchemaKStream;
 import io.confluent.ksql.structured.SchemaKTable;
@@ -49,7 +48,7 @@ import io.confluent.ksql.util.KsqlConfig;
 import io.confluent.ksql.util.KsqlException;
 import io.confluent.ksql.util.MetaStoreFixture;
 
-import static io.confluent.ksql.planner.plan.PlanTestUtil.MAP_NODE;
+import static io.confluent.ksql.planner.plan.PlanTestUtil.MAPVALUES_NODE;
 import static io.confluent.ksql.planner.plan.PlanTestUtil.SOURCE_NODE;
 import static io.confluent.ksql.planner.plan.PlanTestUtil.getNodeByName;
 import static org.hamcrest.CoreMatchers.equalTo;
@@ -85,7 +84,7 @@ public class JoinNodeTest {
     final TopologyDescription.Source node = (TopologyDescription.Source) getNodeByName(builder.build(), SOURCE_NODE);
     final List<String> successors = node.successors().stream().map(TopologyDescription.Node::name).collect(Collectors.toList());
     assertThat(node.predecessors(), equalTo(Collections.emptySet()));
-    assertThat(successors, equalTo(Collections.singletonList(MAP_NODE)));
+    assertThat(successors, equalTo(Collections.singletonList(MAPVALUES_NODE)));
     assertThat(node.topics(), equalTo("[test2]"));
   }
 

--- a/ksql-engine/src/test/java/io/confluent/ksql/planner/plan/KsqlBareOutputNodeTest.java
+++ b/ksql-engine/src/test/java/io/confluent/ksql/planner/plan/KsqlBareOutputNodeTest.java
@@ -46,11 +46,11 @@ import static org.hamcrest.MatcherAssert.assertThat;
 
 public class KsqlBareOutputNodeTest {
 
-  private static final String TRANSFORM_NODE = "KSTREAM-TRANSFORMVALUES-0000000002";
   private static final String SOURCE_NODE = "KSTREAM-SOURCE-0000000000";
-  private static final String MAP_NODE = "KSTREAM-MAP-0000000001";
+  private static final String SOURCE_MAPVALUES_NODE = "KSTREAM-MAPVALUES-0000000001";
+  private static final String TRANSFORM_NODE = "KSTREAM-TRANSFORMVALUES-0000000002";
   private static final String FILTER_NODE = "KSTREAM-FILTER-0000000003";
-  private static final String MAP_VALUES_NODE = "KSTREAM-MAPVALUES-0000000004";
+  private static final String FILTER_MAPVALUES_NODE = "KSTREAM-MAPVALUES-0000000004";
   private static final String FOREACH_NODE = "KSTREAM-FOREACH-0000000005";
   private SchemaKStream stream;
   private StreamsBuilder builder;
@@ -69,13 +69,13 @@ public class KsqlBareOutputNodeTest {
     final TopologyDescription.Source node = (TopologyDescription.Source) getNodeByName(SOURCE_NODE);
     final List<String> successors = node.successors().stream().map(TopologyDescription.Node::name).collect(Collectors.toList());
     assertThat(node.predecessors(), equalTo(Collections.emptySet()));
-    assertThat(successors, equalTo(Collections.singletonList(MAP_NODE)));
+    assertThat(successors, equalTo(Collections.singletonList(SOURCE_MAPVALUES_NODE)));
     assertThat(node.topics(), equalTo("[test1]"));
   }
 
   @Test
   public void shouldBuildMapNode() throws Exception {
-    verifyProcessorNode((TopologyDescription.Processor) getNodeByName(MAP_NODE),
+    verifyProcessorNode((TopologyDescription.Processor) getNodeByName(SOURCE_MAPVALUES_NODE),
         Collections.singletonList(SOURCE_NODE),
         Collections.singletonList(TRANSFORM_NODE));
   }
@@ -83,25 +83,25 @@ public class KsqlBareOutputNodeTest {
   @Test
   public void shouldBuildTransformNode() {
     final TopologyDescription.Processor node = (TopologyDescription.Processor) getNodeByName(TRANSFORM_NODE);
-    verifyProcessorNode(node, Collections.singletonList(MAP_NODE), Collections.singletonList(FILTER_NODE));
+    verifyProcessorNode(node, Collections.singletonList(SOURCE_MAPVALUES_NODE), Collections.singletonList(FILTER_NODE));
   }
 
   @Test
   public void shouldBuildFilterNode() {
     final TopologyDescription.Processor node = (TopologyDescription.Processor) getNodeByName(FILTER_NODE);
-    verifyProcessorNode(node, Collections.singletonList(TRANSFORM_NODE), Collections.singletonList(MAP_VALUES_NODE));
+    verifyProcessorNode(node, Collections.singletonList(TRANSFORM_NODE), Collections.singletonList(FILTER_MAPVALUES_NODE));
   }
 
   @Test
   public void shouldBuildMapValuesNode() {
-    final TopologyDescription.Processor node = (TopologyDescription.Processor) getNodeByName(MAP_VALUES_NODE);
+    final TopologyDescription.Processor node = (TopologyDescription.Processor) getNodeByName(FILTER_MAPVALUES_NODE);
     verifyProcessorNode(node, Collections.singletonList(FILTER_NODE), Collections.singletonList(FOREACH_NODE));
   }
 
   @Test
   public void shouldBuildForEachNode() {
     final TopologyDescription.Processor node = (TopologyDescription.Processor) getNodeByName(FOREACH_NODE);
-    verifyProcessorNode(node, Collections.singletonList(MAP_VALUES_NODE), Collections.emptyList());
+    verifyProcessorNode(node, Collections.singletonList(FILTER_MAPVALUES_NODE), Collections.emptyList());
   }
 
   @Test

--- a/ksql-engine/src/test/java/io/confluent/ksql/planner/plan/KsqlStructuredDataOutputNodeTest.java
+++ b/ksql-engine/src/test/java/io/confluent/ksql/planner/plan/KsqlStructuredDataOutputNodeTest.java
@@ -44,7 +44,7 @@ import io.confluent.ksql.structured.SchemaKStream;
 import io.confluent.ksql.util.KafkaTopicClient;
 import io.confluent.ksql.util.KsqlConfig;
 
-import static io.confluent.ksql.planner.plan.PlanTestUtil.MAP_NODE;
+import static io.confluent.ksql.planner.plan.PlanTestUtil.MAPVALUES_NODE;
 import static io.confluent.ksql.planner.plan.PlanTestUtil.SOURCE_NODE;
 import static io.confluent.ksql.planner.plan.PlanTestUtil.TRANSFORM_NODE;
 import static io.confluent.ksql.planner.plan.PlanTestUtil.getNodeByName;
@@ -58,7 +58,7 @@ import static org.hamcrest.core.IsInstanceOf.instanceOf;
 
 public class KsqlStructuredDataOutputNodeTest {
   private final KafkaTopicClient topicClient = EasyMock.createNiceMock(KafkaTopicClient.class);
-  private static final String MAP_OUTPUT_NODE = "KSTREAM-MAP-0000000003";
+  private static final String MAPVALUES_OUTPUT_NODE = "KSTREAM-MAPVALUES-0000000003";
   private static final String OUTPUT_NODE = "KSTREAM-SINK-0000000004";
 
   private final Schema schema = SchemaBuilder.struct()
@@ -115,14 +115,14 @@ public class KsqlStructuredDataOutputNodeTest {
     final TopologyDescription.Source node = (TopologyDescription.Source) getNodeByName(builder.build(), SOURCE_NODE);
     final List<String> successors = node.successors().stream().map(TopologyDescription.Node::name).collect(Collectors.toList());
     assertThat(node.predecessors(), equalTo(Collections.emptySet()));
-    assertThat(successors, equalTo(Collections.singletonList(MAP_NODE)));
+    assertThat(successors, equalTo(Collections.singletonList(MAPVALUES_NODE)));
     assertThat(node.topics(), equalTo("[input]"));
   }
 
 
   @Test
   public void shouldBuildMapNodePriorToOutput() {
-    verifyProcessorNode((TopologyDescription.Processor) getNodeByName(builder.build(), MAP_OUTPUT_NODE),
+    verifyProcessorNode((TopologyDescription.Processor) getNodeByName(builder.build(), MAPVALUES_OUTPUT_NODE),
         Collections.singletonList(TRANSFORM_NODE),
         Collections.singletonList(OUTPUT_NODE));
   }
@@ -132,7 +132,7 @@ public class KsqlStructuredDataOutputNodeTest {
     final TopologyDescription.Sink sink = (TopologyDescription.Sink) getNodeByName(builder.build(), OUTPUT_NODE);
     final List<String> predecessors = sink.predecessors().stream().map(TopologyDescription.Node::name).collect(Collectors.toList());
     assertThat(sink.successors(), equalTo(Collections.emptySet()));
-    assertThat(predecessors, equalTo(Collections.singletonList(MAP_OUTPUT_NODE)));
+    assertThat(predecessors, equalTo(Collections.singletonList(MAPVALUES_OUTPUT_NODE)));
     assertThat(sink.topic(), equalTo("output"));
   }
 

--- a/ksql-engine/src/test/java/io/confluent/ksql/planner/plan/PlanTestUtil.java
+++ b/ksql-engine/src/test/java/io/confluent/ksql/planner/plan/PlanTestUtil.java
@@ -31,7 +31,7 @@ public class PlanTestUtil {
 
   static final String TRANSFORM_NODE = "KSTREAM-TRANSFORMVALUES-0000000002";
   static final String SOURCE_NODE = "KSTREAM-SOURCE-0000000000";
-  static final String MAP_NODE = "KSTREAM-MAP-0000000001";
+  static final String MAPVALUES_NODE = "KSTREAM-MAPVALUES-0000000001";
 
   static TopologyDescription.Node getNodeByName(final Topology topology, final String nodeName) {
     final TopologyDescription description = topology.describe();

--- a/ksql-engine/src/test/java/io/confluent/ksql/planner/plan/StructuredDataSourceNodeTest.java
+++ b/ksql-engine/src/test/java/io/confluent/ksql/planner/plan/StructuredDataSourceNodeTest.java
@@ -89,13 +89,13 @@ public class StructuredDataSourceNodeTest {
     final TopologyDescription.Source node = (TopologyDescription.Source) getNodeByName(builder.build(), PlanTestUtil.SOURCE_NODE);
     final List<String> successors = node.successors().stream().map(TopologyDescription.Node::name).collect(Collectors.toList());
     assertThat(node.predecessors(), equalTo(Collections.emptySet()));
-    assertThat(successors, equalTo(Collections.singletonList(PlanTestUtil.MAP_NODE)));
+    assertThat(successors, equalTo(Collections.singletonList(PlanTestUtil.MAPVALUES_NODE)));
     assertThat(node.topics(), equalTo("[topic]"));
   }
 
   @Test
   public void shouldBuildMapNode() throws Exception {
-    verifyProcessorNode((TopologyDescription.Processor) getNodeByName(builder.build(), PlanTestUtil.MAP_NODE),
+    verifyProcessorNode((TopologyDescription.Processor) getNodeByName(builder.build(), PlanTestUtil.MAPVALUES_NODE),
         Collections.singletonList(PlanTestUtil.SOURCE_NODE),
         Collections.singletonList(PlanTestUtil.TRANSFORM_NODE));
   }
@@ -103,7 +103,7 @@ public class StructuredDataSourceNodeTest {
   @Test
   public void shouldBuildTransformNode() {
     final TopologyDescription.Processor node = (TopologyDescription.Processor) getNodeByName(builder.build(), PlanTestUtil.TRANSFORM_NODE);
-    verifyProcessorNode(node, Collections.singletonList(PlanTestUtil.MAP_NODE), Collections.emptyList());
+    verifyProcessorNode(node, Collections.singletonList(PlanTestUtil.MAPVALUES_NODE), Collections.emptyList());
   }
 
   @Test


### PR DESCRIPTION
* Use overloaded mapValues from KIP-149 to remove the resetRepartitionFlag function.
* Use mapValues than map that does not need to access the key at all.