### PR TITLE
Table to table agg support CDC null event

### DIFF
--- a/ksql-common/src/main/java/io/confluent/ksql/metrics/MetricCollector.java
+++ b/ksql-common/src/main/java/io/confluent/ksql/metrics/MetricCollector.java
@@ -66,4 +66,18 @@ interface MetricCollector extends ConsumerInterceptor, ProducerInterceptor {
   default double currentMessageConsumptionRate() {
     return 0;
   }
+
+  /**
+   * Get the total message consumption across all topics tracked by this collector.
+   */
+  default double totalMessageConsumption() {
+    return 0;
+  }
+
+  /**
+   * Get the total bytes consumed across all topics tracked by this collector.
+   */
+  default double totalBytesConsumption() {
+    return 0;
+  }
 }

--- a/ksql-common/src/main/java/io/confluent/ksql/metrics/MetricCollectors.java
+++ b/ksql-common/src/main/java/io/confluent/ksql/metrics/MetricCollectors.java
@@ -154,6 +154,18 @@ public class MetricCollectors {
         .sum();
   }
 
+  public static double totalMessageConsumption() {
+    return collectorMap.values().stream()
+        .mapToDouble(MetricCollector::totalMessageConsumption)
+        .sum();
+  }
+
+  public static double totalBytesConsumption() {
+    return collectorMap.values().stream()
+        .mapToDouble(MetricCollector::totalBytesConsumption)
+        .sum();
+  }
+
   public static double currentErrorRate() {
     return collectorMap.values().stream()
         .mapToDouble(MetricCollector::errorRate)

--- a/ksql-engine/src/main/java/io/confluent/ksql/internal/KsqlEngineMetrics.java
+++ b/ksql-engine/src/main/java/io/confluent/ksql/internal/KsqlEngineMetrics.java
@@ -38,6 +38,8 @@ public class KsqlEngineMetrics implements Closeable {
   private final String metricGroupName;
   private final Sensor numActiveQueries;
   private final Sensor messagesIn;
+  private final Sensor totalMessagesIn;
+  private final Sensor totalBytesIn;
   private final Sensor messagesOut;
   private final Sensor numIdleQueries;
   private final Sensor messageConsumptionByQuery;
@@ -55,6 +57,8 @@ public class KsqlEngineMetrics implements Closeable {
 
     this.numActiveQueries = configureNumActiveQueries(metrics);
     this.messagesIn = configureMessagesIn(metrics);
+    this.totalMessagesIn = configureTotalMessagesIn(metrics);
+    this.totalBytesIn = configureTotalBytesIn(metrics);
     this.messagesOut =  configureMessagesOut(metrics);
     this.numIdleQueries = configureIdleQueriesSensor(metrics);
     this.messageConsumptionByQuery = configureMessageConsumptionByQuerySensor(metrics);
@@ -69,6 +73,8 @@ public class KsqlEngineMetrics implements Closeable {
 
   public void updateMetrics() {
     recordMessagesConsumed(MetricCollectors.currentConsumptionRate());
+    recordTotalMessagesConsumed(MetricCollectors.totalMessageConsumption());
+    recordTotalBytesConsumed(MetricCollectors.totalBytesConsumption());
     recordMessagesProduced(MetricCollectors.currentProductionRate());
     recordMessageConsumptionByQueryStats(MetricCollectors.currentConsumptionRateByQuery());
     recordErrorRate(MetricCollectors.currentErrorRate());
@@ -90,6 +96,14 @@ public class KsqlEngineMetrics implements Closeable {
 
   private void recordMessagesConsumed(double value) {
     this.messagesIn.record(value);
+  }
+
+  private void recordTotalBytesConsumed(double value) {
+    this.totalBytesIn.record(value);
+  }
+
+  private void recordTotalMessagesConsumed(double value) {
+    this.totalMessagesIn.record(value);
   }
 
   private void recordErrorRate(double value) {
@@ -125,6 +139,24 @@ public class KsqlEngineMetrics implements Closeable {
     sensor.add(
         metrics.metricName("messages-consumed-per-sec", this.metricGroupName,
                            "The number of messages consumed per second across all queries"),
+        new Value());
+    return sensor;
+  }
+
+  private Sensor configureTotalMessagesIn(Metrics metrics) {
+    Sensor sensor = createSensor(metrics, metricGroupName + "-total-messages-consumed");
+    sensor.add(
+        metrics.metricName("messages-consumed-total", this.metricGroupName,
+            "The total number of messages consumed across all queries"),
+        new Value());
+    return sensor;
+  }
+
+  private Sensor configureTotalBytesIn(Metrics metrics) {
+    Sensor sensor = createSensor(metrics, metricGroupName + "-total-bytes-consumed");
+    sensor.add(
+        metrics.metricName("bytes-consumed-total", this.metricGroupName,
+            "The total number of bytes consumed across all queries"),
         new Value());
     return sensor;
   }

--- a/ksql-engine/src/main/java/io/confluent/ksql/structured/SelectValueMapper.java
+++ b/ksql-engine/src/main/java/io/confluent/ksql/structured/SelectValueMapper.java
@@ -47,6 +47,9 @@ class SelectValueMapper implements ValueMapper<GenericRow, GenericRow> {
 
   @Override
   public GenericRow apply(final GenericRow row) {
+    if (row == null) {
+      return null;
+    }
     final List<Object> newColumns = new ArrayList<>();
     for (int i = 0; i < expressionPairList.size(); i++) {
       try {


### PR DESCRIPTION
When running the clickstream demo I have been seeing loads of Null-Ptr exceptioins in the ksql.logs.
This is caused by an upstream table expiring window data.

SRC: CREATE TABLE CLICK_USER_SESSIONS AS SELECT username, count(*) AS events FROM USER_CLICKSTREAM window SESSION (300 second) GROUP BY username;

DEST: CREATE TABLE CLICK_USER_SESSIONS_TS AS SELECT rowTime AS event_ts, * FROM CLICK_USER_SESSIONS;

In this case, when a user-session finishes in CLICK_USER_SESSIONS it emits the 'null' and causes the NullPtr in SelectValueMapper