### PR TITLE
detect cdc delete event

### DIFF
--- a/ksql-engine/src/main/java/io/confluent/ksql/structured/SelectValueMapper.java
+++ b/ksql-engine/src/main/java/io/confluent/ksql/structured/SelectValueMapper.java
@@ -47,6 +47,9 @@ class SelectValueMapper implements ValueMapper<GenericRow, GenericRow> {
 
   @Override
   public GenericRow apply(final GenericRow row) {
+    if (row == null) {
+      return row;
+    }
     final List<Object> newColumns = new ArrayList<>();
     for (int i = 0; i < expressionPairList.size(); i++) {
       try {


### PR DESCRIPTION
When running the clickstream demo I have been seeing loads of Null-Ptr exceptioins in the ksql.logs.
This is caused by an upstream table expiring window data.

SRC: CREATE TABLE CLICK_USER_SESSIONS AS SELECT username, count(*) AS events FROM USER_CLICKSTREAM window SESSION (300 second) GROUP BY username;

DEST: CREATE TABLE CLICK_USER_SESSIONS_TS AS SELECT rowTime AS event_ts, * FROM CLICK_USER_SESSIONS;

In this case, when a user-session finishes in CLICK_USER_SESSIONS it emits the 'null' and causes the NullPtr in SelectValueMapper for Node: CLICK_USER_SESSIONS_TS