### PR TITLE
Use equals/compareTo for comparison expressions

### DIFF
--- a/ksql-engine/src/main/java/io/confluent/ksql/codegen/SqlToJavaVisitor.java
+++ b/ksql-engine/src/main/java/io/confluent/ksql/codegen/SqlToJavaVisitor.java
@@ -290,31 +290,41 @@ public class SqlToJavaVisitor {
     ) {
       Pair<String, Schema> left = process(node.getLeft(), unmangleNames);
       Pair<String, Schema> right = process(node.getRight(), unmangleNames);
-      if ((left.getRight().type() == Schema.Type.STRING) || (
-          right.getRight().type() == Schema.Type.STRING
-        )) {
-        if ("=".equals(node.getType().getValue())) {
+      switch(node.getType()) {
+        case EQUAL:
           return new Pair<>(
               "(" + left.getLeft() + ".equals(" + right.getLeft() + "))",
               Schema.BOOLEAN_SCHEMA
           );
-        } else if ("<>".equals(node.getType().getValue())) {
+        case NOT_EQUAL:
+        case IS_DISTINCT_FROM:
           return new Pair<>(
               " (!" + left.getLeft() + ".equals(" + right.getLeft() + "))",
               Schema.BOOLEAN_SCHEMA
           );
-        }
+        case GREATER_THAN:
+          return new Pair<>(
+              "(((Comparable)" + left.getLeft() + ").compareTo(" + right.getLeft() + ") > 0)",
+              Schema.BOOLEAN_SCHEMA
+          );
+        case GREATER_THAN_OR_EQUAL:
+          return new Pair<>(
+              "(((Comparable)" + left.getLeft() + ").compareTo(" + right.getLeft() + ") >= 0)",
+              Schema.BOOLEAN_SCHEMA
+          );
+        case LESS_THAN:
+          return new Pair<>(
+              "(((Comparable)" + left.getLeft() + ").compareTo(" + right.getLeft() + ") < 0)",
+              Schema.BOOLEAN_SCHEMA
+          );
+        case LESS_THAN_OR_EQUAL:
+          return new Pair<>(
+              "(((Comparable)" + left.getLeft() + ").compareTo(" + right.getLeft() + ") <= 0)",
+              Schema.BOOLEAN_SCHEMA
+          );
+        default:
+          throw new KsqlException("Unexpected comparison: " + node.getType().getValue());
       }
-      String typeStr = node.getType().getValue();
-      if ("=".equals(typeStr)) {
-        typeStr = "==";
-      } else if ("<>".equals(typeStr)) {
-        typeStr = "!=";
-      }
-      return new Pair<>(
-          "(" + left.getLeft() + " " + typeStr + " " + right.getLeft() + ")",
-          Schema.BOOLEAN_SCHEMA
-      );
     }
 
     @Override

--- a/ksql-engine/src/test/java/io/confluent/ksql/codegen/CodeGenRunnerTest.java
+++ b/ksql-engine/src/test/java/io/confluent/ksql/codegen/CodeGenRunnerTest.java
@@ -50,7 +50,9 @@ public class CodeGenRunnerTest {
                 .field("TEST1.COL0", SchemaBuilder.INT64_SCHEMA)
                 .field("TEST1.COL1", SchemaBuilder.STRING_SCHEMA)
                 .field("TEST1.COL2", SchemaBuilder.STRING_SCHEMA)
-                .field("TEST1.COL3", SchemaBuilder.FLOAT64_SCHEMA);
+                .field("TEST1.COL3", SchemaBuilder.FLOAT64_SCHEMA)
+                .field("TEST1.COL4", SchemaBuilder.INT32_SCHEMA)
+                .field("TEST1.COL5", SchemaBuilder.INT32_SCHEMA);
         codeGenRunner = new CodeGenRunner(schema, functionRegistry);
     }
 
@@ -61,6 +63,160 @@ public class CodeGenRunnerTest {
         Analyzer analyzer = new Analyzer(queryStr, analysis, metaStore);
         analyzer.process(statements.get(0), new AnalysisContext(null));
         return analysis;
+    }
+
+    @Test
+    public void testBooleanExprEq() throws Exception {
+        String simpleQuery = "SELECT col4 = col5 FROM test1;";
+        Analysis analysis = analyzeQuery(simpleQuery);
+
+        ExpressionMetadata expressionEvaluatorMetadata0 = codeGenRunner.buildCodeGenFromParseTree
+            (analysis.getSelectExpressions().get(0));
+        Assert.assertTrue(expressionEvaluatorMetadata0.getIndexes().length == 2);
+        Assert.assertTrue(expressionEvaluatorMetadata0.getIndexes()[0] == 5);
+        Assert.assertTrue(expressionEvaluatorMetadata0.getIndexes()[1] == 4);
+        Assert.assertEquals(expressionEvaluatorMetadata0.getUdfs().length, 2);
+        Object result0 = expressionEvaluatorMetadata0.getExpressionEvaluator().evaluate(
+            new Object[]{new Integer(1), new Integer(1)});
+        Assert.assertTrue(result0 instanceof Boolean);
+        Assert.assertTrue((Boolean)result0);
+        result0 = expressionEvaluatorMetadata0.getExpressionEvaluator().evaluate(
+            new Object[]{new Integer(2), new Integer(1)});
+        Assert.assertTrue(result0 instanceof Boolean);
+        Assert.assertFalse((Boolean)result0);
+    }
+
+    @Test
+    public void testBooleanExprNeq() throws Exception {
+        String simpleQuery = "SELECT col4 != col5 FROM test1;";
+        Analysis analysis = analyzeQuery(simpleQuery);
+
+        ExpressionMetadata expressionEvaluatorMetadata0 = codeGenRunner.buildCodeGenFromParseTree
+            (analysis.getSelectExpressions().get(0));
+        Assert.assertTrue(expressionEvaluatorMetadata0.getIndexes().length == 2);
+        Assert.assertTrue(expressionEvaluatorMetadata0.getIndexes()[0] == 5);
+        Assert.assertTrue(expressionEvaluatorMetadata0.getIndexes()[1] == 4);
+        Assert.assertEquals(expressionEvaluatorMetadata0.getUdfs().length, 2);
+        Object result0 = expressionEvaluatorMetadata0.getExpressionEvaluator().evaluate(
+            new Object[]{new Integer(1), new Integer(1)});
+        Assert.assertTrue(result0 instanceof Boolean);
+        Assert.assertFalse((Boolean)result0);
+        result0 = expressionEvaluatorMetadata0.getExpressionEvaluator().evaluate(
+            new Object[]{new Integer(2), new Integer(1)});
+        Assert.assertTrue(result0 instanceof Boolean);
+        Assert.assertTrue((Boolean)result0);
+    }
+
+    @Test
+    public void testBooleanExprLessThan() throws Exception {
+        String simpleQuery = "SELECT col4 < col5 FROM test1;";
+        Analysis analysis = analyzeQuery(simpleQuery);
+
+        ExpressionMetadata expressionEvaluatorMetadata0 = codeGenRunner.buildCodeGenFromParseTree
+            (analysis.getSelectExpressions().get(0));
+        Assert.assertTrue(expressionEvaluatorMetadata0.getIndexes().length == 2);
+        Assert.assertTrue(expressionEvaluatorMetadata0.getIndexes()[0] == 5);
+        Assert.assertTrue(expressionEvaluatorMetadata0.getIndexes()[1] == 4);
+        Assert.assertEquals(expressionEvaluatorMetadata0.getUdfs().length, 2);
+
+        Object result0 = expressionEvaluatorMetadata0.getExpressionEvaluator().evaluate(
+            new Object[]{new Integer(1), new Integer(2)});
+        Assert.assertTrue(result0 instanceof Boolean);
+        Assert.assertFalse((Boolean)result0);
+
+        result0 = expressionEvaluatorMetadata0.getExpressionEvaluator().evaluate(
+            new Object[]{new Integer(2), new Integer(2)});
+        Assert.assertTrue(result0 instanceof Boolean);
+        Assert.assertFalse((Boolean)result0);
+
+        result0 = expressionEvaluatorMetadata0.getExpressionEvaluator().evaluate(
+            new Object[]{new Integer(2), new Integer(1)});
+        Assert.assertTrue(result0 instanceof Boolean);
+        Assert.assertTrue((Boolean)result0);
+    }
+
+    @Test
+    public void testBooleanExprLessThanEq() throws Exception {
+        String simpleQuery = "SELECT col4 <= col5 FROM test1;";
+        Analysis analysis = analyzeQuery(simpleQuery);
+
+        ExpressionMetadata expressionEvaluatorMetadata0 = codeGenRunner.buildCodeGenFromParseTree
+            (analysis.getSelectExpressions().get(0));
+        Assert.assertTrue(expressionEvaluatorMetadata0.getIndexes().length == 2);
+        Assert.assertTrue(expressionEvaluatorMetadata0.getIndexes()[0] == 5);
+        Assert.assertTrue(expressionEvaluatorMetadata0.getIndexes()[1] == 4);
+        Assert.assertEquals(expressionEvaluatorMetadata0.getUdfs().length, 2);
+
+        Object result0 = expressionEvaluatorMetadata0.getExpressionEvaluator().evaluate(
+            new Object[]{new Integer(1), new Integer(2)});
+        Assert.assertTrue(result0 instanceof Boolean);
+        Assert.assertFalse((Boolean)result0);
+
+        result0 = expressionEvaluatorMetadata0.getExpressionEvaluator().evaluate(
+            new Object[]{new Integer(2), new Integer(2)});
+        Assert.assertTrue(result0 instanceof Boolean);
+        Assert.assertTrue((Boolean)result0);
+
+        result0 = expressionEvaluatorMetadata0.getExpressionEvaluator().evaluate(
+            new Object[]{new Integer(2), new Integer(1)});
+        Assert.assertTrue(result0 instanceof Boolean);
+        Assert.assertTrue((Boolean)result0);
+    }
+
+    @Test
+    public void testBooleanExprGreaterThan() throws Exception {
+        String simpleQuery = "SELECT col4 > col5 FROM test1;";
+        Analysis analysis = analyzeQuery(simpleQuery);
+
+        ExpressionMetadata expressionEvaluatorMetadata0 = codeGenRunner.buildCodeGenFromParseTree
+            (analysis.getSelectExpressions().get(0));
+        Assert.assertTrue(expressionEvaluatorMetadata0.getIndexes().length == 2);
+        Assert.assertTrue(expressionEvaluatorMetadata0.getIndexes()[0] == 5);
+        Assert.assertTrue(expressionEvaluatorMetadata0.getIndexes()[1] == 4);
+        Assert.assertEquals(expressionEvaluatorMetadata0.getUdfs().length, 2);
+
+        Object result0 = expressionEvaluatorMetadata0.getExpressionEvaluator().evaluate(
+            new Object[]{new Integer(1), new Integer(2)});
+        Assert.assertTrue(result0 instanceof Boolean);
+        Assert.assertTrue((Boolean)result0);
+
+        result0 = expressionEvaluatorMetadata0.getExpressionEvaluator().evaluate(
+            new Object[]{new Integer(2), new Integer(2)});
+        Assert.assertTrue(result0 instanceof Boolean);
+        Assert.assertFalse((Boolean)result0);
+
+        result0 = expressionEvaluatorMetadata0.getExpressionEvaluator().evaluate(
+            new Object[]{new Integer(2), new Integer(1)});
+        Assert.assertTrue(result0 instanceof Boolean);
+        Assert.assertFalse((Boolean)result0);
+    }
+
+    @Test
+    public void testBooleanExprGreaterThanEq() throws Exception {
+        String simpleQuery = "SELECT col4 >= col5 FROM test1;";
+        Analysis analysis = analyzeQuery(simpleQuery);
+
+        ExpressionMetadata expressionEvaluatorMetadata0 = codeGenRunner.buildCodeGenFromParseTree
+            (analysis.getSelectExpressions().get(0));
+        Assert.assertTrue(expressionEvaluatorMetadata0.getIndexes().length == 2);
+        Assert.assertTrue(expressionEvaluatorMetadata0.getIndexes()[0] == 5);
+        Assert.assertTrue(expressionEvaluatorMetadata0.getIndexes()[1] == 4);
+        Assert.assertEquals(expressionEvaluatorMetadata0.getUdfs().length, 2);
+
+        Object result0 = expressionEvaluatorMetadata0.getExpressionEvaluator().evaluate(
+            new Object[]{new Integer(1), new Integer(2)});
+        Assert.assertTrue(result0 instanceof Boolean);
+        Assert.assertTrue((Boolean)result0);
+
+        result0 = expressionEvaluatorMetadata0.getExpressionEvaluator().evaluate(
+            new Object[]{new Integer(2), new Integer(2)});
+        Assert.assertTrue(result0 instanceof Boolean);
+        Assert.assertTrue((Boolean)result0);
+
+        result0 = expressionEvaluatorMetadata0.getExpressionEvaluator().evaluate(
+            new Object[]{new Integer(2), new Integer(1)});
+        Assert.assertTrue(result0 instanceof Boolean);
+        Assert.assertFalse((Boolean)result0);
     }
 
     @Test

--- a/ksql-parser/src/main/java/io/confluent/ksql/parser/tree/ComparisonExpression.java
+++ b/ksql-parser/src/main/java/io/confluent/ksql/parser/tree/ComparisonExpression.java
@@ -24,6 +24,8 @@ import static java.util.Objects.requireNonNull;
 public class ComparisonExpression
     extends Expression {
 
+  Integer foo;
+
   public enum Type {
     EQUAL("="),
     NOT_EQUAL("<>"),


### PR DESCRIPTION
Use equals instead of ==/!= operators for comparison expressions. This
ensures that we check value equality for primitive types rather than
reference equality of the wrapper objets. This patch also includes a
change to use compareTo for ordering comparisons. Though not necessary
for primitives, this lets us support ordering comparisons for Strings
which would previously have failed.

Fixes #733 