### PR TITLE
fix bad param passing when using sample or interval

### DIFF
--- a/ksql-cli/src/test/java/io/confluent/ksql/CliTest.java
+++ b/ksql-cli/src/test/java/io/confluent/ksql/CliTest.java
@@ -42,6 +42,7 @@ import java.util.*;
 
 import static io.confluent.ksql.TestResult.build;
 import static io.confluent.ksql.util.KsqlConfig.*;
+import static org.hamcrest.CoreMatchers.containsString;
 import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.MatcherAssert.assertThat;
 
@@ -212,6 +213,21 @@ public class CliTest extends TestRunner {
   private static void selectWithLimit(String selectQuery, int limit, TestResult.OrderedResult expectedResults) {
     selectQuery += " LIMIT " + limit + ";";
     test(selectQuery, expectedResults);
+  }
+
+  @Test
+  public void testPrint() throws InterruptedException {
+
+    Thread wait = new Thread(() -> {
+        CliTest.this.run("print 'ORDER_TOPIC' FROM BEGINNING INTERVAL 2;", false);
+    });
+
+    wait.start();
+    Thread.sleep(1000);
+    wait.interrupt();
+
+    String terminalOutput = terminal.getOutputString();
+    assertThat(terminalOutput, containsString("Format:JSON"));
   }
 
   @Test

--- a/ksql-parser/src/main/java/io/confluent/ksql/parser/AstBuilder.java
+++ b/ksql-parser/src/main/java/io/confluent/ksql/parser/AstBuilder.java
@@ -690,7 +690,7 @@ public class AstBuilder extends SqlBaseBaseVisitor<Node> {
           (SqlBaseParser.IntegerLiteralContext) context.number();
       return new PrintTopic(
           getLocation(context),
-          getQualifiedName(context.qualifiedName()),
+          topicName,
           fromBeginning,
           (LongLiteral) visitIntegerLiteral(integerLiteralContext)
       );


### PR DESCRIPTION
fixed param passing when using ```PRINT 'clickstream' FROM BEGINNING INTERVAL 10;```