### PR TITLE
Check that listener config is provided when the rest server is started

### DIFF
--- a/ksql-rest-app/src/main/java/io/confluent/ksql/rest/server/KsqlRestConfig.java
+++ b/ksql-rest-app/src/main/java/io/confluent/ksql/rest/server/KsqlRestConfig.java
@@ -18,6 +18,7 @@ package io.confluent.ksql.rest.server;
 
 import io.confluent.common.config.ConfigDef;
 import io.confluent.ksql.util.KsqlConfig;
+import io.confluent.ksql.util.KsqlException;
 import io.confluent.rest.RestConfig;
 
 import java.util.Map;
@@ -117,6 +118,10 @@ public class KsqlRestConfig extends RestConfig {
 
   public KsqlRestConfig(Map<?, ?> props) {
     super(CONFIG_DEF, props);
+    if (getList(RestConfig.LISTENERS_CONFIG).isEmpty()) {
+      throw new KsqlException(RestConfig.LISTENERS_CONFIG + " must be supplied.  "
+          + RestConfig.LISTENERS_DOC);
+    }
   }
 
   // Bit of a hack to get around the fact that RestConfig.originals() is private for some reason

--- a/ksql-rest-app/src/test/java/io/confluent/ksql/rest/server/KsqlRestApplicationTest.java
+++ b/ksql-rest-app/src/test/java/io/confluent/ksql/rest/server/KsqlRestApplicationTest.java
@@ -22,11 +22,13 @@ import org.easymock.EasyMock;
 import org.junit.Test;
 
 import java.util.Collections;
+import java.util.HashMap;
 import java.util.Map;
 
 import io.confluent.ksql.exception.KafkaTopicException;
 import io.confluent.ksql.util.KafkaTopicClient;
 import io.confluent.ksql.util.KsqlConfig;
+import io.confluent.rest.RestConfig;
 
 
 public class KsqlRestApplicationTest {
@@ -36,6 +38,10 @@ public class KsqlRestApplicationTest {
   private final Map<String, String> commandTopicConfig = Collections.singletonMap(
       TopicConfig.RETENTION_MS_CONFIG,
       String.valueOf(Long.MAX_VALUE));
+  private final KsqlRestConfig restConfig =
+      new KsqlRestConfig(
+          Collections.singletonMap(RestConfig.LISTENERS_CONFIG,
+          "http://localhost:8080"));
 
   @Test
   public void shouldCreateCommandTopicIfItDoesntExist() {
@@ -46,7 +52,7 @@ public class KsqlRestApplicationTest {
     EasyMock.expectLastCall();
     EasyMock.replay(topicClient);
 
-    KsqlRestApplication.createCommandTopicIfNecessary(new KsqlRestConfig(Collections.emptyMap()),
+    KsqlRestApplication.createCommandTopicIfNecessary(restConfig,
         topicClient,
         COMMAND_TOPIC);
 
@@ -60,13 +66,14 @@ public class KsqlRestApplicationTest {
 
     EasyMock.replay(topicClient);
 
-    KsqlRestApplication.createCommandTopicIfNecessary(new KsqlRestConfig(Collections.emptyMap()),
+    KsqlRestApplication.createCommandTopicIfNecessary(restConfig,
         topicClient,
         COMMAND_TOPIC);
 
     EasyMock.verify(topicClient);
   }
 
+  @SuppressWarnings("unchecked")
   @Test
   public void shouldCreateCommandTopicWithNumReplicasFromConfig() {
     topicClient.createTopic(COMMAND_TOPIC,
@@ -78,7 +85,10 @@ public class KsqlRestApplicationTest {
 
     KsqlRestApplication.createCommandTopicIfNecessary(
         new KsqlRestConfig(
-            Collections.singletonMap(KsqlConfig.SINK_NUMBER_OF_REPLICAS_PROPERTY, 3)),
+            new HashMap(){{
+              put(RestConfig.LISTENERS_CONFIG, "http://localhost:8080");
+              put(KsqlConfig.SINK_NUMBER_OF_REPLICAS_PROPERTY, 3);
+            }}),
         topicClient,
         COMMAND_TOPIC);
 
@@ -95,7 +105,7 @@ public class KsqlRestApplicationTest {
     EasyMock.expectLastCall().andThrow(new KafkaTopicException("blah"));
     EasyMock.replay(topicClient);
 
-    KsqlRestApplication.createCommandTopicIfNecessary(new KsqlRestConfig(Collections.emptyMap()),
+    KsqlRestApplication.createCommandTopicIfNecessary(restConfig,
         topicClient,
         COMMAND_TOPIC);
 

--- a/ksql-rest-app/src/test/java/io/confluent/ksql/rest/server/KsqlRestConfigTest.java
+++ b/ksql-rest-app/src/test/java/io/confluent/ksql/rest/server/KsqlRestConfigTest.java
@@ -22,6 +22,8 @@ import org.junit.Test;
 import java.util.HashMap;
 import java.util.Map;
 
+import io.confluent.rest.RestConfig;
+
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotEquals;
 import static org.junit.Assert.assertNotSame;
@@ -33,11 +35,8 @@ public class KsqlRestConfigTest {
     result.put(StreamsConfig.BOOTSTRAP_SERVERS_CONFIG, "localhost:9092");
     result.put(StreamsConfig.APPLICATION_ID_CONFIG, "ksql_config_test");
     result.put(KsqlRestConfig.COMMAND_TOPIC_SUFFIX_CONFIG, "commands");
+    result.put(RestConfig.LISTENERS_CONFIG, "http://localhost:8080");
     return result;
-  }
-
-  private void assertKeyEquals(String key, Map<String, ?> expected, Map<String, ?> test) {
-    assertEquals(expected.get(key), test.get(key));
   }
 
   @Test

--- a/ksql-rest-app/src/test/java/io/confluent/ksql/rest/server/resources/KsqlResourceTest.java
+++ b/ksql-rest-app/src/test/java/io/confluent/ksql/rest/server/resources/KsqlResourceTest.java
@@ -42,6 +42,7 @@ import io.confluent.ksql.rest.server.mock.MockKafkaTopicClient;
 import io.confluent.ksql.serde.json.KsqlJsonTopicSerDe;
 import io.confluent.ksql.util.KsqlConfig;
 import io.confluent.ksql.util.KsqlConstants;
+import io.confluent.rest.RestConfig;
 
 import org.apache.commons.lang3.concurrent.ConcurrentUtils;
 import org.apache.kafka.clients.consumer.ConsumerConfig;
@@ -76,11 +77,10 @@ import static org.junit.Assert.*;
 public class KsqlResourceTest {
   private KsqlRestConfig ksqlRestConfig;
   private KsqlEngine ksqlEngine;
-  private SchemaRegistryClient schemaRegistryClient;
 
   @Before
   public void setUp() throws IOException, RestClientException {
-    schemaRegistryClient = new MockSchemaRegistryClient();
+    SchemaRegistryClient schemaRegistryClient = new MockSchemaRegistryClient();
     registerSchema(schemaRegistryClient);
     ksqlRestConfig = new KsqlRestConfig(TestKsqlResourceUtil.getDefaultKsqlConfig());
     KsqlConfig ksqlConfig = new KsqlConfig(ksqlRestConfig.getKsqlStreamsProperties());
@@ -88,7 +88,7 @@ public class KsqlResourceTest {
   }
 
   @After
-  public void tearDown() throws IOException {
+  public void tearDown() {
     ksqlEngine.close();
   }
 
@@ -148,6 +148,7 @@ public class KsqlResourceTest {
       configMap.put("cache.max.bytes.buffering", 0);
       configMap.put("auto.offset.reset", "earliest");
       configMap.put("ksql.command.topic.suffix", "commands");
+      configMap.put(RestConfig.LISTENERS_CONFIG, "http://localhost:8080");
 
       Properties properties = new Properties();
       properties.putAll(configMap);


### PR DESCRIPTION
See #772

Throw an exception with the config documentation rather than getting an `IndexOutOfBounds`