### PR TITLE
Fix race condition when multiple nodes try to create the same topic

### DIFF
--- a/ksql-engine/src/main/java/io/confluent/ksql/util/KafkaTopicClientImpl.java
+++ b/ksql-engine/src/main/java/io/confluent/ksql/util/KafkaTopicClientImpl.java
@@ -68,14 +68,14 @@ public class KafkaTopicClientImpl implements KafkaTopicClient {
   public void createTopic(
       final String topic,
       final int numPartitions,
-      final short replicatonFactor,
+      final short replicationFactor,
       final Map<String, String> configs
   ) {
     if (isTopicExists(topic)) {
-      validateTopicProperties(topic, numPartitions, replicatonFactor);
+      validateTopicProperties(topic, numPartitions, replicationFactor);
       return;
     }
-    NewTopic newTopic = new NewTopic(topic, numPartitions, replicatonFactor);
+    NewTopic newTopic = new NewTopic(topic, numPartitions, replicationFactor);
     newTopic.configs(configs);
     try {
       log.info("Creating topic '{}'", topic);
@@ -89,7 +89,7 @@ public class KafkaTopicClientImpl implements KafkaTopicClient {
         // if the topic already exists, it is most likely because another node just created it.
         // ensure that it matches the partition count and replication factor before returning
         // success
-        validateTopicProperties(topic, numPartitions, replicatonFactor);
+        validateTopicProperties(topic, numPartitions, replicationFactor);
         return;
       }
       throw new KafkaResponseGetFailedException("Failed to guarantee existence of topic" + topic,
@@ -209,12 +209,12 @@ public class KafkaTopicClientImpl implements KafkaTopicClient {
     this.adminClient.close();
   }
 
-  private void validateTopicProperties(String topic, int numPartitions, short replicatonFactor) {
+  private void validateTopicProperties(String topic, int numPartitions, short replicationFactor) {
     Map<String, TopicDescription> topicDescriptions =
         describeTopics(Collections.singletonList(topic));
     TopicDescription topicDescription = topicDescriptions.get(topic);
     if (topicDescription.partitions().size() != numPartitions
-        || topicDescription.partitions().get(0).replicas().size() < replicatonFactor) {
+        || topicDescription.partitions().get(0).replicas().size() < replicationFactor) {
       throw new KafkaTopicException(String.format(
           "Topic '%s' does not conform to the requirements Partitions:%d v %d. Replication: %d "
           + "v %d",
@@ -222,7 +222,7 @@ public class KafkaTopicClientImpl implements KafkaTopicClient {
           topicDescription.partitions().size(),
           numPartitions,
           topicDescription.partitions().get(0).replicas().size(),
-          replicatonFactor
+          replicationFactor
       ));
     }
     // Topic with the partitons and replicas exists, reuse it!
@@ -231,7 +231,7 @@ public class KafkaTopicClientImpl implements KafkaTopicClient {
         + "exists",
         topic,
         numPartitions,
-        replicatonFactor
+        replicationFactor
     );
   }
 

--- a/ksql-engine/src/main/java/io/confluent/ksql/util/KafkaTopicClientImpl.java
+++ b/ksql-engine/src/main/java/io/confluent/ksql/util/KafkaTopicClientImpl.java
@@ -26,6 +26,7 @@ import org.apache.kafka.clients.admin.TopicDescription;
 import org.apache.kafka.common.KafkaFuture;
 import org.apache.kafka.common.Node;
 import org.apache.kafka.common.config.ConfigResource;
+import org.apache.kafka.common.errors.TopicExistsException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -71,29 +72,7 @@ public class KafkaTopicClientImpl implements KafkaTopicClient {
       final Map<String, String> configs
   ) {
     if (isTopicExists(topic)) {
-      Map<String, TopicDescription> topicDescriptions =
-          describeTopics(Collections.singletonList(topic));
-      TopicDescription topicDescription = topicDescriptions.get(topic);
-      if (topicDescription.partitions().size() != numPartitions
-          || topicDescription.partitions().get(0).replicas().size() < replicatonFactor) {
-        throw new KafkaTopicException(String.format(
-            "Topic '%s' does not conform to the requirements Partitions:%d v %d. Replication: %d "
-            + "v %d",
-            topic,
-            topicDescription.partitions().size(),
-            numPartitions,
-            topicDescription.partitions().get(0).replicas().size(),
-            replicatonFactor
-        ));
-      }
-      // Topic with the partitons and replicas exists, reuse it!
-      log.debug(
-          "Did not create topic {} with {} partitions and replication-factor {} since it already "
-          + "exists",
-          topic,
-          numPartitions,
-          replicatonFactor
-      );
+      validateTopicProperties(topic, numPartitions, replicatonFactor);
       return;
     }
     NewTopic newTopic = new NewTopic(topic, numPartitions, replicatonFactor);
@@ -102,11 +81,19 @@ public class KafkaTopicClientImpl implements KafkaTopicClient {
       log.info("Creating topic '{}'", topic);
       adminClient.createTopics(Collections.singleton(newTopic)).all().get();
 
-    } catch (InterruptedException | ExecutionException e) {
+    } catch (InterruptedException e) {
       throw new KafkaResponseGetFailedException(
-          "Failed to guarantee existence of topic " + topic,
-          e
-      );
+          "Failed to guarantee existence of topic " + topic, e);
+    } catch (ExecutionException e) {
+      if (e.getCause() instanceof TopicExistsException) {
+        // if the topic already exists, it is most likely because another node just created it.
+        // ensure that it matches the partition count and replication factor before returning
+        // success
+        validateTopicProperties(topic, numPartitions, replicatonFactor);
+        return;
+      }
+      throw new KafkaResponseGetFailedException("Failed to guarantee existence of topic" + topic,
+                                                e);
     }
   }
 
@@ -220,6 +207,32 @@ public class KafkaTopicClientImpl implements KafkaTopicClient {
 
   public void close() {
     this.adminClient.close();
+  }
+
+  private void validateTopicProperties(String topic, int numPartitions, short replicatonFactor) {
+    Map<String, TopicDescription> topicDescriptions =
+        describeTopics(Collections.singletonList(topic));
+    TopicDescription topicDescription = topicDescriptions.get(topic);
+    if (topicDescription.partitions().size() != numPartitions
+        || topicDescription.partitions().get(0).replicas().size() < replicatonFactor) {
+      throw new KafkaTopicException(String.format(
+          "Topic '%s' does not conform to the requirements Partitions:%d v %d. Replication: %d "
+          + "v %d",
+          topic,
+          topicDescription.partitions().size(),
+          numPartitions,
+          topicDescription.partitions().get(0).replicas().size(),
+          replicatonFactor
+      ));
+    }
+    // Topic with the partitons and replicas exists, reuse it!
+    log.debug(
+        "Did not create topic {} with {} partitions and replication-factor {} since it already "
+        + "exists",
+        topic,
+        numPartitions,
+        replicatonFactor
+    );
   }
 
 }


### PR DESCRIPTION
Currently, when a `CREATE STREAM AS` or `CREATE TABLE AS` statement is submitted to a KSQL cluster with multiple nodes, the statement is written to the command topic first. Each node reads from the command topic and executes the statement independently.

The last stage of executing the physical plan is to create the output topic for the new stream or table. In this method, we first check whether the topic exists, and if not it is created. 

However, there is a race condition when multiple nodes are executing the same statement. Each one will find the topic doesn't exist and all of them will try to create it simultaneously. Only one will succeed, and the rest will fail with a `TopicExistsException`. We should not treat this exception as an error, but instead just validate that the parameters are right and continue.

The patch updates the behavior accordingly.