### PR TITLE
messages-per-sec -> c-messages-per-sec

### DIFF
--- a/ksql-common/src/main/java/io/confluent/ksql/metrics/ConsumerCollector.java
+++ b/ksql-common/src/main/java/io/confluent/ksql/metrics/ConsumerCollector.java
@@ -115,7 +115,7 @@ public class ConsumerCollector implements MetricCollector {
     // Note: synchronized due to metrics registry not handling concurrent add/check-exists
     // activity in a reliable way
     synchronized (this.metrics) {
-      addSensor(key, "messages-per-sec", new Rate(), sensors, false);
+      addSensor(key, "c-messages-per-sec", new Rate(), sensors, false);
       addSensor(key, "c-total-messages", new Total(), sensors, false);
       addSensor(key, "c-failed-messages", new Total(), sensors, true);
       addSensor(key, "c-total-message-bytes", new Total(), sensors, false,
@@ -200,7 +200,7 @@ public class ConsumerCollector implements MetricCollector {
 
     return allStats
         .stream()
-        .filter(stat -> stat.name().contains("messages-per-sec"))
+        .filter(stat -> stat.name().contains("c-messages-per-sec"))
         .mapToDouble(TopicSensors.Stat::getValue)
         .sum();
   }

--- a/ksql-common/src/main/java/io/confluent/ksql/metrics/ConsumerCollector.java
+++ b/ksql-common/src/main/java/io/confluent/ksql/metrics/ConsumerCollector.java
@@ -115,10 +115,10 @@ public class ConsumerCollector implements MetricCollector {
     // Note: synchronized due to metrics registry not handling concurrent add/check-exists
     // activity in a reliable way
     synchronized (this.metrics) {
-      addSensor(key, "c-messages-per-sec", new Rate(), sensors, false);
-      addSensor(key, "c-total-messages", new Total(), sensors, false);
-      addSensor(key, "c-failed-messages", new Total(), sensors, true);
-      addSensor(key, "c-total-message-bytes", new Total(), sensors, false,
+      addSensor(key, "consumer-messages-per-sec", new Rate(), sensors, false);
+      addSensor(key, "consumer-total-messages", new Total(), sensors, false);
+      addSensor(key, "consumer-failed-messages", new Total(), sensors, true);
+      addSensor(key, "consumer-total-message-bytes", new Total(), sensors, false,
           (r) -> {
             if (r == null) {
               return 0.0;
@@ -200,7 +200,7 @@ public class ConsumerCollector implements MetricCollector {
 
     return allStats
         .stream()
-        .filter(stat -> stat.name().contains("c-messages-per-sec"))
+        .filter(stat -> stat.name().contains("consumer-messages-per-sec"))
         .mapToDouble(TopicSensors.Stat::getValue)
         .sum();
   }
@@ -212,7 +212,7 @@ public class ConsumerCollector implements MetricCollector {
 
     return allStats
         .stream()
-        .filter(stat -> stat.name().contains("c-total-messages"))
+        .filter(stat -> stat.name().contains("consumer-total-messages"))
         .mapToDouble(TopicSensors.Stat::getValue)
         .sum();
   }
@@ -224,7 +224,7 @@ public class ConsumerCollector implements MetricCollector {
 
     return allStats
         .stream()
-        .filter(stat -> stat.name().contains("c-total-message-bytes"))
+        .filter(stat -> stat.name().contains("consumer-total-message-bytes"))
         .mapToDouble(TopicSensors.Stat::getValue)
         .sum();
   }

--- a/ksql-common/src/main/java/io/confluent/ksql/metrics/MetricCollector.java
+++ b/ksql-common/src/main/java/io/confluent/ksql/metrics/MetricCollector.java
@@ -81,6 +81,4 @@ interface MetricCollector extends ConsumerInterceptor, ProducerInterceptor {
   default double totalBytesConsumption() {
     return 0;
   }
-
-  default Map<String, Double> totalMessageConsumptionByTopic() { return null; }
 }

--- a/ksql-common/src/main/java/io/confluent/ksql/metrics/MetricCollector.java
+++ b/ksql-common/src/main/java/io/confluent/ksql/metrics/MetricCollector.java
@@ -81,4 +81,6 @@ interface MetricCollector extends ConsumerInterceptor, ProducerInterceptor {
   default double totalBytesConsumption() {
     return 0;
   }
+
+  default Map<String, Double> totalMessageConsumptionByTopic() { return null; }
 }

--- a/ksql-common/src/test/java/io/confluent/ksql/metrics/ConsumerCollectorTest.java
+++ b/ksql-common/src/test/java/io/confluent/ksql/metrics/ConsumerCollectorTest.java
@@ -38,7 +38,7 @@ public class ConsumerCollectorTest {
     Collection<TopicSensors.Stat> stats = collector.stats(TEST_TOPIC, false);
     assertNotNull(stats);
 
-    assertThat( stats.toString(), containsString("name=messages-per-sec,"));
+    assertThat( stats.toString(), containsString("name=c-messages-per-sec,"));
     assertThat( stats.toString(), containsString("total-messages, value=100.0"));
   }
 }

--- a/ksql-common/src/test/java/io/confluent/ksql/metrics/ConsumerCollectorTest.java
+++ b/ksql-common/src/test/java/io/confluent/ksql/metrics/ConsumerCollectorTest.java
@@ -38,7 +38,7 @@ public class ConsumerCollectorTest {
     Collection<TopicSensors.Stat> stats = collector.stats(TEST_TOPIC, false);
     assertNotNull(stats);
 
-    assertThat( stats.toString(), containsString("name=c-messages-per-sec,"));
+    assertThat( stats.toString(), containsString("name=consumer-messages-per-sec,"));
     assertThat( stats.toString(), containsString("total-messages, value=100.0"));
   }
 }


### PR DESCRIPTION
Rename messages-per-sec in the consumer interceptor to c-messages-per-sec
so that it has a different name from the corresponding stat in the producer
interceptor.