### PR TITLE
Don't clobber columns when executing partition by

### DIFF
--- a/ksql-engine/src/main/java/io/confluent/ksql/planner/plan/JoinNode.java
+++ b/ksql-engine/src/main/java/io/confluent/ksql/planner/plan/JoinNode.java
@@ -230,7 +230,7 @@ public class JoinNode extends PlanNode {
           + " in schema:"
           + schema));
       return
-          stream.selectKey(field);
+          stream.selectKey(field, true);
     }
     return stream;
   }

--- a/ksql-engine/src/main/java/io/confluent/ksql/planner/plan/KsqlStructuredDataOutputNode.java
+++ b/ksql-engine/src/main/java/io/confluent/ksql/planner/plan/KsqlStructuredDataOutputNode.java
@@ -182,7 +182,7 @@ public class KsqlStructuredDataOutputNode extends OutputNode {
           )));
 
       outputNodeBuilder.withKeyField(keyField);
-      return result.selectKey(keyField);
+      return result.selectKey(keyField, false);
     }
     return result;
   }

--- a/ksql-engine/src/main/java/io/confluent/ksql/structured/QueuedSchemaKStream.java
+++ b/ksql-engine/src/main/java/io/confluent/ksql/structured/QueuedSchemaKStream.java
@@ -127,7 +127,7 @@ public class QueuedSchemaKStream extends SchemaKStream {
   }
 
   @Override
-  public SchemaKStream selectKey(Field newKeyField) {
+  public SchemaKStream selectKey(Field newKeyField, boolean updateRowKey) {
     throw new UnsupportedOperationException();
   }
 

--- a/ksql-engine/src/main/java/io/confluent/ksql/structured/SchemaKStream.java
+++ b/ksql-engine/src/main/java/io/confluent/ksql/structured/SchemaKStream.java
@@ -240,16 +240,19 @@ public class SchemaKStream {
       return this;
     }
 
-    KStream keyedKStream = kstream.map((key, value) -> {
+
+    KStream keyedKStream = kstream.selectKey((key, value) -> {
       String newKey =
           value
               .getColumns()
               .get(SchemaUtil.getFieldIndexByName(schema, newKeyField.name()))
               .toString();
+      return newKey;
+    }).mapValues((key, row) -> {
       if (updateRowKey) {
-        value.getColumns().set(SchemaUtil.ROWKEY_NAME_INDEX, key);
+        row.getColumns().set(SchemaUtil.ROWKEY_NAME_INDEX, key);
       }
-      return KeyValue.pair(newKey, value);
+      return row;
     });
 
     return new SchemaKStream(

--- a/ksql-engine/src/main/java/io/confluent/ksql/structured/SchemaKStream.java
+++ b/ksql-engine/src/main/java/io/confluent/ksql/structured/SchemaKStream.java
@@ -21,7 +21,6 @@ import org.apache.kafka.common.serialization.Serdes;
 import org.apache.kafka.connect.data.Field;
 import org.apache.kafka.connect.data.Schema;
 import org.apache.kafka.connect.data.SchemaBuilder;
-import org.apache.kafka.streams.KeyValue;
 import org.apache.kafka.streams.kstream.Joined;
 import org.apache.kafka.streams.kstream.KGroupedStream;
 import org.apache.kafka.streams.kstream.KStream;

--- a/ksql-engine/src/main/java/io/confluent/ksql/structured/SchemaKStream.java
+++ b/ksql-engine/src/main/java/io/confluent/ksql/structured/SchemaKStream.java
@@ -233,7 +233,7 @@ public class SchemaKStream {
   }
 
   @SuppressWarnings("unchecked")
-  public SchemaKStream selectKey(final Field newKeyField) {
+  public SchemaKStream selectKey(final Field newKeyField, boolean updateRowKey) {
     if (keyField != null
         && keyField.name().equals(newKeyField.name())) {
       return this;
@@ -248,7 +248,9 @@ public class SchemaKStream {
               .toString();
       return newKey;
     }).mapValues((key, row) -> {
-      row.getColumns().set(SchemaUtil.ROWKEY_NAME_INDEX, key);
+      if (updateRowKey) {
+        row.getColumns().set(SchemaUtil.ROWKEY_NAME_INDEX, key);
+      }
       return row;
     });
 

--- a/ksql-engine/src/test/java/io/confluent/ksql/integration/EndToEndIntegrationTest.java
+++ b/ksql-engine/src/test/java/io/confluent/ksql/integration/EndToEndIntegrationTest.java
@@ -116,6 +116,48 @@ public class EndToEndIntegrationTest {
     validateCreateStreamUsingLikeClause(derivedStream);
   }
 
+  @Test
+  public void shouldRetainSelectedColumnsInPartitionBy() throws Exception {
+    String createStreamStatement = String.format("CREATE STREAM pageviews_by_viewtime as select "
+                                                 + "viewtime, pageid, userid from "
+                                                 + "pageviews_original "
+                                                 + "partition by "
+                                                 + "viewtime;");
+
+    List<QueryMetadata> queries = ksqlEngine.buildMultipleQueries(createStreamStatement,
+                                                                  Collections.emptyMap());
+
+    assertEquals(1, queries.size());
+    assertTrue(queries.get(0) instanceof PersistentQueryMetadata);
+
+    PersistentQueryMetadata persistentQueryMetadata = (PersistentQueryMetadata) queries.get(0);
+    persistentQueryMetadata.getKafkaStreams().start();
+
+    String query = String.format("SELECT * from pageviews_by_viewtime;");
+
+    queries = ksqlEngine.buildMultipleQueries(query, Collections.emptyMap());
+
+    assertEquals(1, queries.size());
+    assertTrue(queries.get(0) instanceof QueuedQueryMetadata);
+
+    QueuedQueryMetadata queryMetadata = (QueuedQueryMetadata) queries.get(0);
+    queryMetadata.getKafkaStreams().start();
+
+    BlockingQueue<KeyValue<String, GenericRow>> rowQueue = queryMetadata.getRowQueue();
+    KeyValue<String, GenericRow> nextRow = rowQueue.poll();
+    if (nextRow != null) {
+      List<Object> columns = nextRow.value.getColumns();
+      assertEquals(5, columns.size());
+      String pageid = columns.get(3).toString();
+      assertEquals(5, pageid.length());
+      assertEquals("PAGE_", pageid.substring(0, 5));
+
+      String userid = columns.get(4).toString();
+      assertEquals(5, userid.length());
+      assertEquals("USER_", userid.substring(0, 5));
+    }
+  }
+
   private void validateSelectAllFromUsers() throws Exception {
     String query = String.format("SELECT * from %s;", userTable);
     log.debug("Sending query: {}", query);

--- a/ksql-engine/src/test/java/io/confluent/ksql/integration/EndToEndIntegrationTest.java
+++ b/ksql-engine/src/test/java/io/confluent/ksql/integration/EndToEndIntegrationTest.java
@@ -17,7 +17,6 @@ package io.confluent.ksql.integration;
 
 import io.confluent.ksql.GenericRow;
 import io.confluent.ksql.KsqlEngine;
-import io.confluent.ksql.serde.DataSource;
 import io.confluent.ksql.util.KafkaTopicClient;
 import io.confluent.ksql.util.KafkaTopicClientImpl;
 import io.confluent.ksql.util.KsqlConfig;
@@ -49,9 +48,10 @@ import java.util.Set;
 import java.util.concurrent.BlockingQueue;
 import java.util.concurrent.TimeUnit;
 
+import static org.hamcrest.core.IsInstanceOf.instanceOf;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
-import static org.testng.Assert.assertNotNull;
+import static org.junit.Assert.assertThat;
 
 /**
  * This test emulates the end to end flow in the quick start guide and ensures that the outputs at each stage
@@ -128,7 +128,7 @@ public class EndToEndIntegrationTest {
                                                                   Collections.emptyMap());
 
     assertEquals(1, queries.size());
-    assertTrue(queries.get(0) instanceof PersistentQueryMetadata);
+    assertThat(queries.get(0), instanceOf(PersistentQueryMetadata.class));
 
     PersistentQueryMetadata persistentQueryMetadata = (PersistentQueryMetadata) queries.get(0);
     persistentQueryMetadata.getKafkaStreams().start();
@@ -138,7 +138,7 @@ public class EndToEndIntegrationTest {
     queries = ksqlEngine.buildMultipleQueries(query, Collections.emptyMap());
 
     assertEquals(1, queries.size());
-    assertTrue(queries.get(0) instanceof QueuedQueryMetadata);
+    assertThat(queries.get(0), instanceOf(QueuedQueryMetadata.class));
 
     QueuedQueryMetadata queryMetadata = (QueuedQueryMetadata) queries.get(0);
     queryMetadata.getKafkaStreams().start();

--- a/ksql-engine/src/test/java/io/confluent/ksql/structured/SchemaKStreamTest.java
+++ b/ksql-engine/src/test/java/io/confluent/ksql/structured/SchemaKStreamTest.java
@@ -33,7 +33,7 @@ import io.confluent.ksql.serde.json.KsqlJsonTopicSerDe;
 import io.confluent.ksql.util.KsqlConfig;
 import io.confluent.ksql.util.MetaStoreFixture;
 import io.confluent.ksql.util.Pair;
-import io.confluent.ksql.util.SerDeUtil;
+
 import org.apache.kafka.common.serialization.Serde;
 import org.apache.kafka.common.serialization.Serdes;
 import org.apache.kafka.connect.data.Schema;
@@ -162,7 +162,7 @@ public class SchemaKStreamTest {
                                              SchemaKStream.Type.SOURCE, functionRegistry, new MockSchemaRegistryClient());
     SchemaKStream rekeyedSchemaKStream = initialSchemaKStream.selectKey(initialSchemaKStream
                                                                             .getSchema().fields()
-                                                                            .get(1));
+                                                                            .get(1), true);
     Assert.assertTrue(rekeyedSchemaKStream.getKeyField().name().equalsIgnoreCase("TEST1.COL1"));
 
   }

--- a/ksql-engine/src/test/resources/query-validation-tests.json
+++ b/ksql-engine/src/test/resources/query-validation-tests.json
@@ -342,8 +342,33 @@
         {"topic": "AVG", "key": 1, "value": "1,100", "timestamp": 0},
         {"topic": "AVG", "key": 1, "value": "1,55", "timestamp": 0}
       ]
+    },
+    {
+      "name": "partition by with projection select some",
+      "statements": [
+        "CREATE STREAM TEST (ID bigint, NAME varchar, VALUE bigint) with (kafka_topic='test_topic', value_format = 'delimited', key='ID');",
+        "CREATE STREAM REPARTITIONED AS select name,id from TEST partition by name;"
+      ],
+      "inputs": [
+        {"topic": "test_topic", "key": 0, "value": "0,zero,50", "timestamp": 0}
+      ],
+      "outputs": [
+        {"topic": "REPARTITIONED", "key": "zero", "value": "zero,0", "timestamp": 0}
+      ]
+    },
+    {
+      "name": "partition by with projection select all",
+      "statements": [
+        "CREATE STREAM TEST (ID bigint, NAME varchar, VALUE bigint) with (kafka_topic='test_topic', value_format = 'delimited', key='ID');",
+        "CREATE STREAM REPARTITIONED AS select * from TEST partition by name;"
+      ],
+      "inputs": [
+        {"topic": "test_topic", "key": 0, "value": "0,zero,50", "timestamp": 0}
+      ],
+      "outputs": [
+        {"topic": "REPARTITIONED", "key": "zero", "value": "0,zero,50", "timestamp": 0}
+      ]
     }
-
   ]
 
 }


### PR DESCRIPTION
Fixes #799 

I have been able to reproduce the bug with the query validation test as well as the integration test. Both are included here, though we probably should remove the integration test before merge.

The problem is that when you select specific fields with a partition by, the new key clobbers the second field of the output. The reason is that the schema passed to the `KStream` object in `KsqlStructuredDataOutputNode` has the `ROWKEY`, and `ROWTIME` fields removed. However, inside the `KStream.selectKey` method that's executed due to the `PARTITION BY` clause, we write the new key at column 1 of the value (where the `ROWKEY` would be), hence clobbering it.  

We should not overwrite the key field since it doesn't always exist in the schema. 

I am still trying to figure out why the `SELECT *` statement with a `PARTITION BY` clause never had a problem, and why it continues to work with my patch (there are tests which prove that `SELECT *` still works).