### PR TITLE
Added integer support for the current udafs.

### DIFF
--- a/ksql-engine/src/main/java/io/confluent/ksql/function/udaf/max/IntegerMaxKudaf.java
+++ b/ksql-engine/src/main/java/io/confluent/ksql/function/udaf/max/IntegerMaxKudaf.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2017 Confluent Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -12,14 +12,14 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- **/
+ */
 
 package io.confluent.ksql.function.udaf.max;
 
 import org.apache.kafka.connect.data.Schema;
 import org.apache.kafka.streams.kstream.Merger;
 
-import java.util.Arrays;
+import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 
@@ -28,27 +28,24 @@ import io.confluent.ksql.parser.tree.Expression;
 
 public class IntegerMaxKudaf extends KsqlAggregateFunction<Integer, Integer> {
 
-  public IntegerMaxKudaf(Integer argIndexInValue) {
+  public IntegerMaxKudaf(int argIndexInValue) {
     super(argIndexInValue, () -> Integer.MIN_VALUE, Schema.INT32_SCHEMA,
-          Arrays.asList(Schema.INT32_SCHEMA)
+          Collections.singletonList(Schema.INT32_SCHEMA)
     );
   }
 
   @Override
   public Integer aggregate(Integer currentVal, Integer currentAggVal) {
-    if (currentVal > currentAggVal) {
-      return currentVal;
+    if (currentVal == null) {
+      return currentAggVal;
     }
-    return currentAggVal;
+    return Math.max(currentVal, currentAggVal);
   }
 
   @Override
   public Merger<String, Integer> getMerger() {
     return (aggKey, aggOne, aggTwo) -> {
-      if (aggOne > aggTwo) {
-        return aggOne;
-      }
-      return aggTwo;
+      return Math.max(aggOne, aggTwo);
     };
   }
 

--- a/ksql-engine/src/main/java/io/confluent/ksql/function/udaf/max/IntegerMaxKudaf.java
+++ b/ksql-engine/src/main/java/io/confluent/ksql/function/udaf/max/IntegerMaxKudaf.java
@@ -1,0 +1,61 @@
+/**
+ * Copyright 2017 Confluent Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ **/
+
+package io.confluent.ksql.function.udaf.max;
+
+import org.apache.kafka.connect.data.Schema;
+import org.apache.kafka.streams.kstream.Merger;
+
+import java.util.Arrays;
+import java.util.List;
+import java.util.Map;
+
+import io.confluent.ksql.function.KsqlAggregateFunction;
+import io.confluent.ksql.parser.tree.Expression;
+
+public class IntegerMaxKudaf extends KsqlAggregateFunction<Integer, Integer> {
+
+  public IntegerMaxKudaf(Integer argIndexInValue) {
+    super(argIndexInValue, () -> Integer.MIN_VALUE, Schema.INT32_SCHEMA,
+          Arrays.asList(Schema.INT32_SCHEMA)
+    );
+  }
+
+  @Override
+  public Integer aggregate(Integer currentVal, Integer currentAggVal) {
+    if (currentVal > currentAggVal) {
+      return currentVal;
+    }
+    return currentAggVal;
+  }
+
+  @Override
+  public Merger<String, Integer> getMerger() {
+    return (aggKey, aggOne, aggTwo) -> {
+      if (aggOne > aggTwo) {
+        return aggOne;
+      }
+      return aggTwo;
+    };
+  }
+
+  @Override
+  public KsqlAggregateFunction<Integer, Integer> getInstance(Map<String, Integer> expressionNames,
+                                                           List<Expression> functionArguments) {
+    int udafIndex = expressionNames.get(functionArguments.get(0).toString());
+    return new IntegerMaxKudaf(udafIndex);
+  }
+}

--- a/ksql-engine/src/main/java/io/confluent/ksql/function/udaf/max/MaxAggFunctionFactory.java
+++ b/ksql-engine/src/main/java/io/confluent/ksql/function/udaf/max/MaxAggFunctionFactory.java
@@ -28,7 +28,9 @@ import io.confluent.ksql.util.KsqlException;
 public class MaxAggFunctionFactory extends AggregateFunctionFactory {
 
   public MaxAggFunctionFactory() {
-    super("MAX", Arrays.asList(new DoubleMaxKudaf(-1), new LongMaxKudaf(-1)));
+    super("MAX", Arrays.asList(new DoubleMaxKudaf(-1),
+                               new LongMaxKudaf(-1),
+                               new IntegerMaxKudaf(-1)));
   }
 
   @Override

--- a/ksql-engine/src/main/java/io/confluent/ksql/function/udaf/min/IntegerMinKudaf.java
+++ b/ksql-engine/src/main/java/io/confluent/ksql/function/udaf/min/IntegerMinKudaf.java
@@ -39,7 +39,7 @@ public class IntegerMinKudaf extends KsqlAggregateFunction<Integer, Integer> {
     if (currentVal == null) {
       return currentAggVal;
     }
-    return Math.min(currentAggVal, currentAggVal);
+    return Math.min(currentVal, currentAggVal);
   }
 
   @Override

--- a/ksql-engine/src/main/java/io/confluent/ksql/function/udaf/min/IntegerMinKudaf.java
+++ b/ksql-engine/src/main/java/io/confluent/ksql/function/udaf/min/IntegerMinKudaf.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2017 Confluent Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -12,7 +12,7 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- **/
+ */
 
 package io.confluent.ksql.function.udaf.min;
 
@@ -20,6 +20,7 @@ import org.apache.kafka.connect.data.Schema;
 import org.apache.kafka.streams.kstream.Merger;
 
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 
@@ -28,27 +29,24 @@ import io.confluent.ksql.parser.tree.Expression;
 
 public class IntegerMinKudaf extends KsqlAggregateFunction<Integer, Integer> {
 
-  IntegerMinKudaf(Integer argIndexInValue) {
+  IntegerMinKudaf(int argIndexInValue) {
     super(argIndexInValue, () -> Integer.MAX_VALUE, Schema.INT32_SCHEMA,
-          Arrays.asList(Schema.INT32_SCHEMA)
+          Collections.singletonList(Schema.INT32_SCHEMA)
     );
   }
 
   @Override
   public Integer aggregate(Integer currentVal, Integer currentAggVal) {
-    if (currentVal < currentAggVal) {
-      return currentVal;
+    if (currentVal == null) {
+      return currentAggVal;
     }
-    return currentAggVal;
+    return Math.min(currentAggVal, currentAggVal);
   }
 
   @Override
   public Merger<String, Integer> getMerger() {
     return (aggKey, aggOne, aggTwo) -> {
-      if (aggOne < aggTwo) {
-        return aggOne;
-      }
-      return aggTwo;
+     return Math.min(aggOne, aggTwo);
     };
   }
 

--- a/ksql-engine/src/main/java/io/confluent/ksql/function/udaf/min/IntegerMinKudaf.java
+++ b/ksql-engine/src/main/java/io/confluent/ksql/function/udaf/min/IntegerMinKudaf.java
@@ -19,7 +19,6 @@ package io.confluent.ksql.function.udaf.min;
 import org.apache.kafka.connect.data.Schema;
 import org.apache.kafka.streams.kstream.Merger;
 
-import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
@@ -46,7 +45,7 @@ public class IntegerMinKudaf extends KsqlAggregateFunction<Integer, Integer> {
   @Override
   public Merger<String, Integer> getMerger() {
     return (aggKey, aggOne, aggTwo) -> {
-     return Math.min(aggOne, aggTwo);
+      return Math.min(aggOne, aggTwo);
     };
   }
 

--- a/ksql-engine/src/main/java/io/confluent/ksql/function/udaf/min/IntegerMinKudaf.java
+++ b/ksql-engine/src/main/java/io/confluent/ksql/function/udaf/min/IntegerMinKudaf.java
@@ -1,0 +1,61 @@
+/**
+ * Copyright 2017 Confluent Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ **/
+
+package io.confluent.ksql.function.udaf.min;
+
+import org.apache.kafka.connect.data.Schema;
+import org.apache.kafka.streams.kstream.Merger;
+
+import java.util.Arrays;
+import java.util.List;
+import java.util.Map;
+
+import io.confluent.ksql.function.KsqlAggregateFunction;
+import io.confluent.ksql.parser.tree.Expression;
+
+public class IntegerMinKudaf extends KsqlAggregateFunction<Integer, Integer> {
+
+  IntegerMinKudaf(Integer argIndexInValue) {
+    super(argIndexInValue, () -> Integer.MAX_VALUE, Schema.INT32_SCHEMA,
+          Arrays.asList(Schema.INT32_SCHEMA)
+    );
+  }
+
+  @Override
+  public Integer aggregate(Integer currentVal, Integer currentAggVal) {
+    if (currentVal < currentAggVal) {
+      return currentVal;
+    }
+    return currentAggVal;
+  }
+
+  @Override
+  public Merger<String, Integer> getMerger() {
+    return (aggKey, aggOne, aggTwo) -> {
+      if (aggOne < aggTwo) {
+        return aggOne;
+      }
+      return aggTwo;
+    };
+  }
+
+  @Override
+  public KsqlAggregateFunction<Integer, Integer> getInstance(Map<String, Integer> expressionNames,
+                                                           List<Expression> functionArguments) {
+    int udafIndex = expressionNames.get(functionArguments.get(0).toString());
+    return new IntegerMinKudaf(udafIndex);
+  }
+}

--- a/ksql-engine/src/main/java/io/confluent/ksql/function/udaf/min/MinAggFunctionFactory.java
+++ b/ksql-engine/src/main/java/io/confluent/ksql/function/udaf/min/MinAggFunctionFactory.java
@@ -28,7 +28,9 @@ import io.confluent.ksql.util.KsqlException;
 public class MinAggFunctionFactory extends AggregateFunctionFactory {
 
   public MinAggFunctionFactory() {
-    super("MIN", Arrays.asList(new DoubleMinKudaf(-1), new LongMinKudaf(-1)));
+    super("MIN", Arrays.asList(new DoubleMinKudaf(-1),
+                               new LongMinKudaf(-1),
+                               new IntegerMinKudaf(-1)));
   }
 
   @Override

--- a/ksql-engine/src/main/java/io/confluent/ksql/function/udaf/sum/IntegerSumKudaf.java
+++ b/ksql-engine/src/main/java/io/confluent/ksql/function/udaf/sum/IntegerSumKudaf.java
@@ -1,0 +1,55 @@
+/**
+ * Copyright 2017 Confluent Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ **/
+
+package io.confluent.ksql.function.udaf.sum;
+
+import org.apache.kafka.connect.data.Schema;
+import org.apache.kafka.streams.kstream.Merger;
+
+import java.util.Arrays;
+import java.util.List;
+import java.util.Map;
+
+import io.confluent.ksql.function.KsqlAggregateFunction;
+import io.confluent.ksql.parser.tree.Expression;
+
+public class IntegerSumKudaf extends KsqlAggregateFunction<Integer, Integer> {
+
+  IntegerSumKudaf(Integer argIndexInValue) {
+    super(argIndexInValue, () -> 0, Schema.INT32_SCHEMA,
+          Arrays.asList(Schema.INT32_SCHEMA)
+    );
+  }
+
+  @Override
+  public Integer aggregate(Integer currentVal, Integer currentAggVal) {
+    return currentVal + currentAggVal;
+  }
+
+  @Override
+  public Merger<String, Integer> getMerger() {
+    return (aggKey, aggOne, aggTwo) -> aggOne + aggTwo;
+  }
+
+  @Override
+  public KsqlAggregateFunction<Integer, Integer> getInstance(Map<String, Integer> expressionNames,
+                                                           List<Expression> functionArguments) {
+    int udafIndex = expressionNames.get(functionArguments.get(0).toString());
+    return new IntegerSumKudaf(udafIndex);
+  }
+
+
+}

--- a/ksql-engine/src/main/java/io/confluent/ksql/function/udaf/sum/IntegerSumKudaf.java
+++ b/ksql-engine/src/main/java/io/confluent/ksql/function/udaf/sum/IntegerSumKudaf.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2017 Confluent Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -12,7 +12,7 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- **/
+ */
 
 package io.confluent.ksql.function.udaf.sum;
 
@@ -20,6 +20,7 @@ import org.apache.kafka.connect.data.Schema;
 import org.apache.kafka.streams.kstream.Merger;
 
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 
@@ -28,14 +29,17 @@ import io.confluent.ksql.parser.tree.Expression;
 
 public class IntegerSumKudaf extends KsqlAggregateFunction<Integer, Integer> {
 
-  IntegerSumKudaf(Integer argIndexInValue) {
+  IntegerSumKudaf(int argIndexInValue) {
     super(argIndexInValue, () -> 0, Schema.INT32_SCHEMA,
-          Arrays.asList(Schema.INT32_SCHEMA)
+          Collections.singletonList(Schema.INT32_SCHEMA)
     );
   }
 
   @Override
   public Integer aggregate(Integer currentVal, Integer currentAggVal) {
+    if (currentVal == null) {
+      return currentAggVal;
+    }
     return currentVal + currentAggVal;
   }
 

--- a/ksql-engine/src/main/java/io/confluent/ksql/function/udaf/sum/IntegerSumKudaf.java
+++ b/ksql-engine/src/main/java/io/confluent/ksql/function/udaf/sum/IntegerSumKudaf.java
@@ -19,7 +19,6 @@ package io.confluent.ksql.function.udaf.sum;
 import org.apache.kafka.connect.data.Schema;
 import org.apache.kafka.streams.kstream.Merger;
 
-import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;

--- a/ksql-engine/src/main/java/io/confluent/ksql/function/udaf/sum/SumAggFunctionFactory.java
+++ b/ksql-engine/src/main/java/io/confluent/ksql/function/udaf/sum/SumAggFunctionFactory.java
@@ -27,7 +27,9 @@ import java.util.List;
 public class SumAggFunctionFactory extends AggregateFunctionFactory {
 
   public SumAggFunctionFactory() {
-    super("SUM", Arrays.asList(new DoubleSumKudaf(-1), new LongSumKudaf(-1)));
+    super("SUM", Arrays.asList(new DoubleSumKudaf(-1),
+                               new LongSumKudaf(-1),
+                               new IntegerSumKudaf(-1)));
   }
 
   @Override

--- a/ksql-engine/src/test/java/io/confluent/ksql/function/udaf/max/IntegerMaxKudafTest.java
+++ b/ksql-engine/src/test/java/io/confluent/ksql/function/udaf/max/IntegerMaxKudafTest.java
@@ -1,0 +1,46 @@
+/**
+ * Copyright 2017 Confluent Inc.
+ *
+ * Licensed under the Apache License, Version 2 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ **/
+
+package io.confluent.ksql.function.udaf.max;
+
+import org.apache.kafka.connect.data.Schema;
+import org.junit.Test;
+
+import java.util.Collections;
+
+import io.confluent.ksql.function.KsqlAggregateFunction;
+
+import static org.hamcrest.CoreMatchers.equalTo;
+import static org.hamcrest.CoreMatchers.instanceOf;
+import static org.junit.Assert.assertThat;
+
+public class IntegerMaxKudafTest {
+
+  @Test
+  public void shouldFindCorrectMax() {
+    KsqlAggregateFunction aggregateFunction = new MaxAggFunctionFactory()
+        .getProperAggregateFunction(Collections.singletonList(Schema.INT32_SCHEMA));
+    assertThat(aggregateFunction, instanceOf(IntegerMaxKudaf.class));
+    IntegerMaxKudaf integerMaxKudaf = (IntegerMaxKudaf) aggregateFunction;
+    int[] values = new int[]{3, 5, 8, 2, 3, 4, 5};
+    int currentMax = Integer.MIN_VALUE;
+    for (int i: values) {
+      currentMax = integerMaxKudaf.aggregate(i, currentMax);
+    }
+    assertThat(8, equalTo(currentMax));
+  }
+
+}

--- a/ksql-engine/src/test/java/io/confluent/ksql/function/udaf/min/IntegerMinKudafTest.java
+++ b/ksql-engine/src/test/java/io/confluent/ksql/function/udaf/min/IntegerMinKudafTest.java
@@ -1,0 +1,46 @@
+/**
+ * Copyright 2017 Confluent Inc.
+ *
+ * Licensed under the Apache License, Version 2 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ **/
+
+package io.confluent.ksql.function.udaf.min;
+
+
+import org.apache.kafka.connect.data.Schema;
+import org.junit.Test;
+
+import java.util.Collections;
+
+import io.confluent.ksql.function.KsqlAggregateFunction;
+
+import static org.hamcrest.CoreMatchers.equalTo;
+import static org.hamcrest.CoreMatchers.instanceOf;
+import static org.junit.Assert.assertThat;
+
+public class IntegerMinKudafTest {
+
+  @Test
+  public void shouldFindCorrectMin() {
+    KsqlAggregateFunction aggregateFunction = new MinAggFunctionFactory()
+        .getProperAggregateFunction(Collections.singletonList(Schema.INT32_SCHEMA));
+    assertThat(aggregateFunction, instanceOf(IntegerMinKudaf.class));
+    IntegerMinKudaf integerMinKudaf = (IntegerMinKudaf) aggregateFunction;
+    int[] values = new int[]{3, 5, 8, 2, 3, 4, 5};
+    int currentMin = Integer.MAX_VALUE;
+    for (int i: values) {
+      currentMin = integerMinKudaf.aggregate(i, currentMin);
+    }
+    assertThat(2, equalTo(currentMin));
+  }
+}

--- a/ksql-engine/src/test/java/io/confluent/ksql/function/udaf/sum/IntegerSumKudafTest.java
+++ b/ksql-engine/src/test/java/io/confluent/ksql/function/udaf/sum/IntegerSumKudafTest.java
@@ -1,0 +1,31 @@
+package io.confluent.ksql.function.udaf.sum;
+
+
+import org.apache.kafka.connect.data.Schema;
+import org.junit.Test;
+
+import java.util.Collections;
+
+import io.confluent.ksql.function.KsqlAggregateFunction;
+import io.confluent.ksql.function.udaf.min.IntegerMinKudaf;
+
+import static org.hamcrest.CoreMatchers.equalTo;
+import static org.hamcrest.CoreMatchers.instanceOf;
+import static org.junit.Assert.assertThat;
+
+public class IntegerSumKudafTest {
+
+  @Test
+  public void shouldComputeCorrectSum() {
+    KsqlAggregateFunction aggregateFunction = new SumAggFunctionFactory()
+        .getProperAggregateFunction(Collections.singletonList(Schema.INT32_SCHEMA));
+    assertThat(aggregateFunction, instanceOf(IntegerSumKudaf.class));
+    IntegerSumKudaf integerSumKudaf = (IntegerSumKudaf) aggregateFunction;
+    int[] values = new int[]{3, 5, 8, 2, 3, 4, 5};
+    int currentMin = 0;
+    for (int i: values) {
+      currentMin = integerSumKudaf.aggregate(i, currentMin);
+    }
+    assertThat(30, equalTo(currentMin));
+  }
+}

--- a/ksql-engine/src/test/java/io/confluent/ksql/function/udaf/sum/IntegerSumKudafTest.java
+++ b/ksql-engine/src/test/java/io/confluent/ksql/function/udaf/sum/IntegerSumKudafTest.java
@@ -2,6 +2,7 @@ package io.confluent.ksql.function.udaf.sum;
 
 
 import org.apache.kafka.connect.data.Schema;
+import org.apache.kafka.streams.kstream.Merger;
 import org.junit.Test;
 
 import java.util.Collections;
@@ -17,15 +18,32 @@ public class IntegerSumKudafTest {
 
   @Test
   public void shouldComputeCorrectSum() {
-    KsqlAggregateFunction aggregateFunction = new SumAggFunctionFactory()
-        .getProperAggregateFunction(Collections.singletonList(Schema.INT32_SCHEMA));
-    assertThat(aggregateFunction, instanceOf(IntegerSumKudaf.class));
-    IntegerSumKudaf integerSumKudaf = (IntegerSumKudaf) aggregateFunction;
+    IntegerSumKudaf integerSumKudaf = getIntegerSumKudaf();
     int[] values = new int[]{3, 5, 8, 2, 3, 4, 5};
     int currentMin = 0;
     for (int i: values) {
       currentMin = integerSumKudaf.aggregate(i, currentMin);
     }
     assertThat(30, equalTo(currentMin));
+  }
+
+  @Test
+  public void shouldComputeCorrectSumMerge() {
+    IntegerSumKudaf integerSumKudaf = getIntegerSumKudaf();
+    Merger<String, Integer> merger = integerSumKudaf.getMerger();
+    Integer mergeResult1 = merger.apply("Key", 10, 12);
+    assertThat(mergeResult1, equalTo(22));
+    Integer mergeResult2 = merger.apply("Key", 10, -12);
+    assertThat(mergeResult2, equalTo(-2));
+    Integer mergeResult3 = merger.apply("Key", -10, 0);
+    assertThat(mergeResult3, equalTo(-10));
+
+  }
+
+  private IntegerSumKudaf getIntegerSumKudaf() {
+    KsqlAggregateFunction aggregateFunction = new SumAggFunctionFactory()
+        .getProperAggregateFunction(Collections.singletonList(Schema.INT32_SCHEMA));
+    assertThat(aggregateFunction, instanceOf(IntegerSumKudaf.class));
+    return  (IntegerSumKudaf) aggregateFunction;
   }
 }


### PR DESCRIPTION
Our internal udafs(sum, min,max) will support integer type.
Later we should implement these UDAFs similar to topk with generics.
This fixes https://github.com/confluentinc/ksql/issues/730