### PR TITLE
Make UDFs thread-safe.

### DIFF
--- a/ksql-engine/src/main/java/io/confluent/ksql/function/KsqlAggregateFunction.java
+++ b/ksql-engine/src/main/java/io/confluent/ksql/function/KsqlAggregateFunction.java
@@ -28,7 +28,7 @@ import io.confluent.ksql.util.KsqlException;
 
 public abstract class KsqlAggregateFunction<V, A> {
   private final int argIndexInValue;
-  private final Supplier<A> intialValueSupplier;
+  private final Supplier<A> initialValueSupplier;
   private final Schema returnType;
   private final List<Schema> arguments;
 
@@ -38,12 +38,12 @@ public abstract class KsqlAggregateFunction<V, A> {
 
   public KsqlAggregateFunction(
       final int argIndexInValue,
-      final Supplier<A> intialValueSupplier,
+      final Supplier<A> initialValueSupplier,
       final Schema returnType,
       final List<Schema> arguments
   ) {
     this.argIndexInValue = argIndexInValue;
-    this.intialValueSupplier = intialValueSupplier;
+    this.initialValueSupplier = initialValueSupplier;
     this.returnType = returnType;
     this.arguments = arguments;
   }
@@ -62,8 +62,8 @@ public abstract class KsqlAggregateFunction<V, A> {
 
   public abstract A aggregate(V currentVal, A currentAggVal);
 
-  public Supplier<A> getIntialValueSupplier() {
-    return intialValueSupplier;
+  public Supplier<A> getInitialValueSupplier() {
+    return initialValueSupplier;
   }
 
   public int getArgIndexInValue() {

--- a/ksql-engine/src/main/java/io/confluent/ksql/function/udaf/count/CountAggFunctionFactory.java
+++ b/ksql-engine/src/main/java/io/confluent/ksql/function/udaf/count/CountAggFunctionFactory.java
@@ -16,17 +16,18 @@
 
 package io.confluent.ksql.function.udaf.count;
 
-import io.confluent.ksql.function.AggregateFunctionFactory;
-import io.confluent.ksql.function.KsqlAggregateFunction;
 import org.apache.kafka.connect.data.Schema;
 
-import java.util.Arrays;
+import java.util.Collections;
 import java.util.List;
+
+import io.confluent.ksql.function.AggregateFunctionFactory;
+import io.confluent.ksql.function.KsqlAggregateFunction;
 
 public class CountAggFunctionFactory extends AggregateFunctionFactory {
 
   public CountAggFunctionFactory() {
-    super("COUNT", Arrays.asList(new CountKudaf(-1)));
+    super("COUNT", Collections.singletonList(new CountKudaf(-1)));
   }
 
   @Override

--- a/ksql-engine/src/main/java/io/confluent/ksql/function/udaf/count/CountKudaf.java
+++ b/ksql-engine/src/main/java/io/confluent/ksql/function/udaf/count/CountKudaf.java
@@ -16,20 +16,21 @@
 
 package io.confluent.ksql.function.udaf.count;
 
-import io.confluent.ksql.function.KsqlAggregateFunction;
-import io.confluent.ksql.parser.tree.Expression;
-
 import org.apache.kafka.connect.data.Schema;
 import org.apache.kafka.streams.kstream.Merger;
 
-import java.util.Arrays;
+import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 
+import io.confluent.ksql.function.KsqlAggregateFunction;
+import io.confluent.ksql.parser.tree.Expression;
+
 public class CountKudaf extends KsqlAggregateFunction<Object, Long> {
 
-  CountKudaf(Integer argIndexInValue) {
-    super(argIndexInValue, () -> 0L, Schema.INT64_SCHEMA, Arrays.asList(Schema.FLOAT64_SCHEMA)
+  CountKudaf(int argIndexInValue) {
+    super(argIndexInValue, () -> 0L, Schema.INT64_SCHEMA,
+          Collections.singletonList(Schema.FLOAT64_SCHEMA)
     );
   }
 

--- a/ksql-engine/src/main/java/io/confluent/ksql/function/udaf/max/DoubleMaxKudaf.java
+++ b/ksql-engine/src/main/java/io/confluent/ksql/function/udaf/max/DoubleMaxKudaf.java
@@ -19,7 +19,7 @@ package io.confluent.ksql.function.udaf.max;
 import org.apache.kafka.connect.data.Schema;
 import org.apache.kafka.streams.kstream.Merger;
 
-import java.util.Arrays;
+import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 
@@ -28,9 +28,9 @@ import io.confluent.ksql.parser.tree.Expression;
 
 public class DoubleMaxKudaf extends KsqlAggregateFunction<Double, Double> {
 
-  DoubleMaxKudaf(Integer argIndexInValue) {
+  DoubleMaxKudaf(int argIndexInValue) {
     super(argIndexInValue, () -> Double.MIN_VALUE, Schema.FLOAT64_SCHEMA,
-          Arrays.asList(Schema.FLOAT64_SCHEMA)
+          Collections.singletonList(Schema.FLOAT64_SCHEMA)
     );
   }
 

--- a/ksql-engine/src/main/java/io/confluent/ksql/function/udaf/max/LongMaxKudaf.java
+++ b/ksql-engine/src/main/java/io/confluent/ksql/function/udaf/max/LongMaxKudaf.java
@@ -19,7 +19,7 @@ package io.confluent.ksql.function.udaf.max;
 import org.apache.kafka.connect.data.Schema;
 import org.apache.kafka.streams.kstream.Merger;
 
-import java.util.Arrays;
+import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 
@@ -28,9 +28,9 @@ import io.confluent.ksql.parser.tree.Expression;
 
 public class LongMaxKudaf extends KsqlAggregateFunction<Long, Long> {
 
-  LongMaxKudaf(Integer argIndexInValue) {
+  LongMaxKudaf(int argIndexInValue) {
     super(argIndexInValue, () -> Long.MIN_VALUE, Schema.INT64_SCHEMA,
-          Arrays.asList(Schema.INT64_SCHEMA)
+          Collections.singletonList(Schema.INT64_SCHEMA)
     );
   }
 

--- a/ksql-engine/src/main/java/io/confluent/ksql/function/udaf/min/DoubleMinKudaf.java
+++ b/ksql-engine/src/main/java/io/confluent/ksql/function/udaf/min/DoubleMinKudaf.java
@@ -19,7 +19,7 @@ package io.confluent.ksql.function.udaf.min;
 import org.apache.kafka.connect.data.Schema;
 import org.apache.kafka.streams.kstream.Merger;
 
-import java.util.Arrays;
+import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 
@@ -28,9 +28,9 @@ import io.confluent.ksql.parser.tree.Expression;
 
 public class DoubleMinKudaf extends KsqlAggregateFunction<Double, Double> {
 
-  DoubleMinKudaf(Integer argIndexInValue) {
+  DoubleMinKudaf(int argIndexInValue) {
     super(argIndexInValue, () -> Double.MAX_VALUE, Schema.FLOAT64_SCHEMA,
-          Arrays.asList(Schema.FLOAT64_SCHEMA)
+          Collections.singletonList(Schema.FLOAT64_SCHEMA)
     );
   }
 

--- a/ksql-engine/src/main/java/io/confluent/ksql/function/udaf/min/LongMinKudaf.java
+++ b/ksql-engine/src/main/java/io/confluent/ksql/function/udaf/min/LongMinKudaf.java
@@ -19,7 +19,7 @@ package io.confluent.ksql.function.udaf.min;
 import org.apache.kafka.connect.data.Schema;
 import org.apache.kafka.streams.kstream.Merger;
 
-import java.util.Arrays;
+import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 
@@ -28,9 +28,9 @@ import io.confluent.ksql.parser.tree.Expression;
 
 public class LongMinKudaf extends KsqlAggregateFunction<Long, Long> {
 
-  LongMinKudaf(Integer argIndexInValue) {
+  LongMinKudaf(int argIndexInValue) {
     super(argIndexInValue, () -> Long.MAX_VALUE, Schema.INT64_SCHEMA,
-          Arrays.asList(Schema.INT64_SCHEMA)
+          Collections.singletonList(Schema.INT64_SCHEMA)
     );
   }
 

--- a/ksql-engine/src/main/java/io/confluent/ksql/function/udaf/sum/DoubleSumKudaf.java
+++ b/ksql-engine/src/main/java/io/confluent/ksql/function/udaf/sum/DoubleSumKudaf.java
@@ -16,21 +16,21 @@
 
 package io.confluent.ksql.function.udaf.sum;
 
-import io.confluent.ksql.function.KsqlAggregateFunction;
-import io.confluent.ksql.parser.tree.Expression;
-
 import org.apache.kafka.connect.data.Schema;
 import org.apache.kafka.streams.kstream.Merger;
 
-import java.util.Arrays;
+import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 
+import io.confluent.ksql.function.KsqlAggregateFunction;
+import io.confluent.ksql.parser.tree.Expression;
+
 public class DoubleSumKudaf extends KsqlAggregateFunction<Double, Double> {
 
-  DoubleSumKudaf(Integer argIndexInValue) {
+  DoubleSumKudaf(int argIndexInValue) {
     super(argIndexInValue, () -> 0.0, Schema.FLOAT64_SCHEMA,
-          Arrays.asList(Schema.FLOAT64_SCHEMA)
+          Collections.singletonList(Schema.FLOAT64_SCHEMA)
     );
   }
 

--- a/ksql-engine/src/main/java/io/confluent/ksql/function/udaf/sum/LongSumKudaf.java
+++ b/ksql-engine/src/main/java/io/confluent/ksql/function/udaf/sum/LongSumKudaf.java
@@ -16,21 +16,21 @@
 
 package io.confluent.ksql.function.udaf.sum;
 
-import io.confluent.ksql.function.KsqlAggregateFunction;
-import io.confluent.ksql.parser.tree.Expression;
-
 import org.apache.kafka.connect.data.Schema;
 import org.apache.kafka.streams.kstream.Merger;
 
-import java.util.Arrays;
+import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 
+import io.confluent.ksql.function.KsqlAggregateFunction;
+import io.confluent.ksql.parser.tree.Expression;
+
 public class LongSumKudaf extends KsqlAggregateFunction<Long, Long> {
 
-  LongSumKudaf(Integer argIndexInValue) {
+  LongSumKudaf(int argIndexInValue) {
     super(argIndexInValue, () -> 0L, Schema.INT64_SCHEMA,
-          Arrays.asList(Schema.INT64_SCHEMA));
+          Collections.singletonList(Schema.INT64_SCHEMA));
   }
 
   @Override

--- a/ksql-engine/src/main/java/io/confluent/ksql/function/udaf/topk/TopKAggregateFunctionFactory.java
+++ b/ksql-engine/src/main/java/io/confluent/ksql/function/udaf/topk/TopKAggregateFunctionFactory.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2017 Confluent Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -17,15 +17,14 @@
 package io.confluent.ksql.function.udaf.topk;
 
 import org.apache.kafka.connect.data.Schema;
+import org.apache.kafka.connect.data.SchemaBuilder;
 
-import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 
 import io.confluent.ksql.function.AggregateFunctionFactory;
 import io.confluent.ksql.function.KsqlAggregateFunction;
 import io.confluent.ksql.util.KsqlException;
-import org.apache.kafka.connect.data.SchemaBuilder;
 
 public class TopKAggregateFunctionFactory extends AggregateFunctionFactory {
   private final int topKSize;
@@ -35,7 +34,7 @@ public class TopKAggregateFunctionFactory extends AggregateFunctionFactory {
   }
 
   public TopKAggregateFunctionFactory(int topKSize) {
-    super("TOPK", Arrays.asList());
+    super("TOPK", Collections.emptyList());
     this.topKSize = topKSize;
   }
 

--- a/ksql-engine/src/main/java/io/confluent/ksql/function/udaf/topk/TopkKudaf.java
+++ b/ksql-engine/src/main/java/io/confluent/ksql/function/udaf/topk/TopkKudaf.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2017 Confluent Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -16,41 +16,59 @@
 
 package io.confluent.ksql.function.udaf.topk;
 
-import io.confluent.ksql.function.KsqlAggregateFunction;
-import io.confluent.ksql.parser.tree.Expression;
-import io.confluent.ksql.util.ArrayUtil;
-import io.confluent.ksql.util.KsqlException;
 import org.apache.kafka.connect.data.Schema;
 import org.apache.kafka.streams.kstream.Merger;
 
+import java.lang.reflect.Array;
 import java.util.Arrays;
-import java.util.Collections;
 import java.util.Comparator;
 import java.util.List;
 import java.util.Map;
 
-public class TopkKudaf<T> extends KsqlAggregateFunction<T, T[]> {
+import io.confluent.ksql.function.KsqlAggregateFunction;
+import io.confluent.ksql.parser.tree.Expression;
+import io.confluent.ksql.util.ArrayUtil;
+import io.confluent.ksql.util.KsqlException;
+
+public class TopkKudaf<T extends Comparable<? super T>> extends KsqlAggregateFunction<T, T[]> {
+
   private final int topKSize;
-  private final Object[] tempTopKArray;
   private final Class<T> clazz;
   private final Schema returnType;
   private final List<Schema> argumentTypes;
+  private final Comparator<T> comparator;
+  private final ThreadLocal<T[]> tempTopKArray;
 
+  @SuppressWarnings("unchecked")
   TopkKudaf(int argIndexInValue,
             int topKSize,
             Schema returnType,
             List<Schema> argumentTypes,
             Class<T> clazz) {
     super(argIndexInValue,
-        () -> (T[]) new Object[topKSize],
-        returnType,
-        argumentTypes
+        () -> (T[]) Array.newInstance(clazz, topKSize),
+          returnType,
+          argumentTypes
     );
     this.topKSize = topKSize;
-    this.tempTopKArray = new Object[topKSize + 1];
     this.returnType = returnType;
     this.argumentTypes = argumentTypes;
     this.clazz = clazz;
+    this.tempTopKArray = ThreadLocal
+        .withInitial(() -> (T[]) Array.newInstance(clazz, topKSize + 1));
+    this.comparator = (v1, v2) -> {
+      if (v1 == null && v2 == null) {
+        return 0;
+      }
+      if (v1 == null) {
+        return 1;
+      }
+      if (v2 == null) {
+        return -1;
+      }
+
+      return Comparator.<T>reverseOrder().compare(v1, v2);
+    };
   }
 
   @SuppressWarnings("unchecked")
@@ -61,49 +79,35 @@ public class TopkKudaf<T> extends KsqlAggregateFunction<T, T[]> {
       return currentAggVal;
     }
 
-    int nullIndex = ArrayUtil.getNullIndex(currentAggVal);
+    final int nullIndex = ArrayUtil.getNullIndex(currentAggVal);
     if (nullIndex != -1) {
       currentAggVal[nullIndex] = currentVal;
-      Arrays.sort(currentAggVal, comparator());
+      Arrays.sort(currentAggVal, comparator);
       return currentAggVal;
     }
-    System.arraycopy(currentAggVal, 0, tempTopKArray, 0, topKSize);
-    tempTopKArray[topKSize] = currentVal;
-    Arrays.sort(tempTopKArray, Collections.reverseOrder());
-    return Arrays.copyOf((T[]) tempTopKArray, topKSize);
+
+    final T[] tmp = tempTopKArray.get();
+    System.arraycopy(currentAggVal, 0, tmp, 0, topKSize);
+    tmp[topKSize] = currentVal;
+    Arrays.sort(tmp, comparator);
+    return Arrays.copyOf(tmp, topKSize);
   }
 
-  public static <T> Comparator<T> comparator() {
-    return (v1, v2) -> {
-      if(v1 == null && v2 == null) {
-        return 0;
-      }
-      if (v1 == null) {
-        return 1;
-      }
-      if (v2 == null) {
-        return -1;
-      }
-
-      return - ((Comparable)v1).compareTo(v2);
-    };
-  }
-
+  @SuppressWarnings("unchecked")
   @Override
   public Merger<String, T[]> getMerger() {
     // TODO: For now we just use a simple algorithm. Maybe try finding a faster algorithm later
     return (aggKey, aggOne, aggTwo) -> {
-      int nullId1 = ArrayUtil.getNullIndex(aggOne) == -1? topKSize : ArrayUtil.getNullIndex(aggOne);
-      int nullId2 = ArrayUtil.getNullIndex(aggTwo) == -1? topKSize : ArrayUtil.getNullIndex(aggTwo);
-      T[] tempMergeTopKArray = (T[]) new Object[nullId1 + nullId2];
+      int nullId1 =
+          ArrayUtil.getNullIndex(aggOne) == -1 ? topKSize : ArrayUtil.getNullIndex(aggOne);
+      int nullId2 =
+          ArrayUtil.getNullIndex(aggTwo) == -1 ? topKSize : ArrayUtil.getNullIndex(aggTwo);
+      T[] tempMergeTopKArray = (T[]) Array.newInstance(clazz, nullId1 + nullId2);
 
-      for (int i = 0; i < nullId1; i++) {
-        tempMergeTopKArray[i] = aggOne[i];
-      }
-      for (int i = nullId1; i < nullId1 + nullId2; i++) {
-        tempMergeTopKArray[i] = aggTwo[i - nullId1];
-      }
-      Arrays.sort(tempMergeTopKArray, Collections.reverseOrder());
+      System.arraycopy(aggOne, 0, tempMergeTopKArray, 0, nullId1);
+      System.arraycopy(aggTwo, 0, tempMergeTopKArray, nullId1,nullId1 + nullId2 - nullId1);
+      Arrays.sort(tempMergeTopKArray, comparator);
+
       if (tempMergeTopKArray.length < topKSize) {
         tempMergeTopKArray = ArrayUtil.padWithNull(clazz, tempMergeTopKArray, topKSize);
         return tempMergeTopKArray;
@@ -117,10 +121,10 @@ public class TopkKudaf<T> extends KsqlAggregateFunction<T, T[]> {
                                                    final List<Expression> functionArguments) {
     if (functionArguments.size() != 2) {
       throw new KsqlException(String.format("Invalid parameter count. Need 2 args, got %d arg(s)",
-                              functionArguments.size()));
+                                            functionArguments.size()));
     }
     int udafIndex = expressionNames.get(functionArguments.get(0).toString());
     int topKSize = Integer.parseInt(functionArguments.get(1).toString());
-    return new TopkKudaf(udafIndex, topKSize, returnType, argumentTypes, clazz);
+    return new TopkKudaf<>(udafIndex, topKSize, returnType, argumentTypes, clazz);
   }
 }

--- a/ksql-engine/src/main/java/io/confluent/ksql/function/udaf/topk/TopkKudaf.java
+++ b/ksql-engine/src/main/java/io/confluent/ksql/function/udaf/topk/TopkKudaf.java
@@ -105,7 +105,7 @@ public class TopkKudaf<T extends Comparable<? super T>> extends KsqlAggregateFun
       T[] tempMergeTopKArray = (T[]) Array.newInstance(clazz, nullId1 + nullId2);
 
       System.arraycopy(aggOne, 0, tempMergeTopKArray, 0, nullId1);
-      System.arraycopy(aggTwo, 0, tempMergeTopKArray, nullId1, nullId1 + nullId2 - nullId1);
+      System.arraycopy(aggTwo, 0, tempMergeTopKArray, nullId1, nullId2);
       Arrays.sort(tempMergeTopKArray, comparator);
 
       if (tempMergeTopKArray.length < topKSize) {

--- a/ksql-engine/src/main/java/io/confluent/ksql/function/udaf/topk/TopkKudaf.java
+++ b/ksql-engine/src/main/java/io/confluent/ksql/function/udaf/topk/TopkKudaf.java
@@ -45,7 +45,7 @@ public class TopkKudaf<T extends Comparable<? super T>> extends KsqlAggregateFun
             List<Schema> argumentTypes,
             Class<T> clazz) {
     super(argIndexInValue,
-          () -> (T[]) Array.newInstance(clazz, topKSize),
+        () -> (T[]) Array.newInstance(clazz, topKSize),
           returnType,
           argumentTypes
     );

--- a/ksql-engine/src/main/java/io/confluent/ksql/function/udaf/topkdistinct/TopkDistinctKudaf.java
+++ b/ksql-engine/src/main/java/io/confluent/ksql/function/udaf/topkdistinct/TopkDistinctKudaf.java
@@ -34,17 +34,17 @@ import io.confluent.ksql.util.KsqlException;
 
 public class TopkDistinctKudaf<T> extends KsqlAggregateFunction<T, T[]> {
 
-  private Integer tkVal;
+  private int tkVal;
   private T[] tempTopkArray;
   private Class<T> ttClass;
 
-  TopkDistinctKudaf(Integer argIndexInValue,
-                    Integer tkVal,
+  TopkDistinctKudaf(int argIndexInValue,
+                    int tkVal,
                     Class<T> ttClass) {
     super(argIndexInValue,
         () -> (T[]) Array.newInstance(ttClass, tkVal),
           SchemaBuilder.array(Schema.FLOAT64_SCHEMA).build(),
-          Arrays.asList(Schema.FLOAT64_SCHEMA)
+          Collections.singletonList(Schema.FLOAT64_SCHEMA)
     );
 
     this.tkVal = tkVal;
@@ -111,7 +111,7 @@ public class TopkDistinctKudaf<T> extends KsqlAggregateFunction<T, T[]> {
     }
     int udafIndex = expressionNames.get(functionArguments.get(0).toString());
     Integer tkValFromArg = Integer.parseInt(functionArguments.get(1).toString());
-    return new TopkDistinctKudaf(udafIndex, tkValFromArg, ttClass);
+    return new TopkDistinctKudaf<>(udafIndex, tkValFromArg, ttClass);
   }
 
 }

--- a/ksql-engine/src/main/java/io/confluent/ksql/function/udaf/topkdistinct/TopkDistinctKudaf.java
+++ b/ksql-engine/src/main/java/io/confluent/ksql/function/udaf/topkdistinct/TopkDistinctKudaf.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2017 Confluent Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -23,21 +23,24 @@ import org.apache.kafka.streams.kstream.Merger;
 import java.lang.reflect.Array;
 import java.util.Arrays;
 import java.util.Collections;
+import java.util.Comparator;
 import java.util.List;
 import java.util.Map;
 
 import io.confluent.ksql.function.KsqlAggregateFunction;
-import io.confluent.ksql.function.udaf.topk.TopkKudaf;
 import io.confluent.ksql.parser.tree.Expression;
 import io.confluent.ksql.util.ArrayUtil;
 import io.confluent.ksql.util.KsqlException;
 
-public class TopkDistinctKudaf<T> extends KsqlAggregateFunction<T, T[]> {
+public class TopkDistinctKudaf<T extends Comparable<? super T>>
+    extends KsqlAggregateFunction<T, T[]> {
 
-  private int tkVal;
-  private T[] tempTopkArray;
-  private Class<T> ttClass;
+  private final int tkVal;
+  private final Class<T> ttClass;
+  private final Comparator<T> comparator;
+  private final ThreadLocal<T[]> tempTopKArray;
 
+  @SuppressWarnings("unchecked")
   TopkDistinctKudaf(int argIndexInValue,
                     int tkVal,
                     Class<T> ttClass) {
@@ -48,8 +51,22 @@ public class TopkDistinctKudaf<T> extends KsqlAggregateFunction<T, T[]> {
     );
 
     this.tkVal = tkVal;
-    this.tempTopkArray = (T[]) Array.newInstance(ttClass,tkVal + 1);
     this.ttClass = ttClass;
+    this.tempTopKArray = ThreadLocal
+        .withInitial(() -> (T[]) Array.newInstance(ttClass, tkVal + 1));
+    this.comparator = (v1, v2) -> {
+      if (v1 == null && v2 == null) {
+        return 0;
+      }
+      if (v1 == null) {
+        return 1;
+      }
+      if (v2 == null) {
+        return -1;
+      }
+
+      return Comparator.<T>reverseOrder().compare(v1, v2);
+    };
   }
 
   @Override
@@ -63,37 +80,42 @@ public class TopkDistinctKudaf<T> extends KsqlAggregateFunction<T, T[]> {
     int nullIndex = ArrayUtil.getNullIndex(currentAggVal);
     if (nullIndex != -1) {
       currentAggVal[nullIndex] = currentVal;
-      Arrays.sort(currentAggVal, TopkKudaf.comparator());
+      Arrays.sort(currentAggVal, comparator);
       return currentAggVal;
     }
 
-    System.arraycopy(currentAggVal, 0, tempTopkArray, 0, tkVal);
-    tempTopkArray[tkVal] = currentVal;
-    Arrays.sort(tempTopkArray, Collections.reverseOrder());
-    return Arrays.copyOf(tempTopkArray, tkVal);
+    final T[] tmp = tempTopKArray.get();
+    System.arraycopy(currentAggVal, 0, tmp, 0, tkVal);
+    tmp[tkVal] = currentVal;
+    Arrays.sort(tmp, comparator);
+    return Arrays.copyOf(tmp, tkVal);
   }
 
+  @SuppressWarnings("unchecked")
   @Override
   public Merger<String, T[]> getMerger() {
     return (aggKey, aggOne, aggTwo) -> {
 
-      int nullIndex1 = ArrayUtil.getNullIndex(aggOne) == -1? tkVal: ArrayUtil.getNullIndex(aggOne);
-      int nullIndex2 = ArrayUtil.getNullIndex(aggTwo) == -1? tkVal: ArrayUtil.getNullIndex(aggTwo);
+      int
+          nullIndex1 =
+          ArrayUtil.getNullIndex(aggOne) == -1 ? tkVal : ArrayUtil.getNullIndex(aggOne);
+      int
+          nullIndex2 =
+          ArrayUtil.getNullIndex(aggTwo) == -1 ? tkVal : ArrayUtil.getNullIndex(aggTwo);
       T[] tempMergeTopkArray = (T[]) Array.newInstance(ttClass, nullIndex1 + nullIndex2);
 
-      for (int i = 0; i < nullIndex1; i++) {
-        tempMergeTopkArray[i] = aggOne[i];
-      }
+      System.arraycopy(aggOne, 0, tempMergeTopkArray, 0, nullIndex1);
+
       int duplicateCount = 0;
       for (int i = nullIndex1; i < nullIndex1 + nullIndex2; i++) {
         if (ArrayUtil.containsValue(aggTwo[i - nullIndex1], aggOne)) {
-          duplicateCount ++;
+          duplicateCount++;
         } else {
           tempMergeTopkArray[i - duplicateCount] = aggTwo[i - nullIndex1];
         }
       }
       tempMergeTopkArray = ArrayUtil.getNoNullArray(ttClass, tempMergeTopkArray);
-      Arrays.sort(tempMergeTopkArray, Collections.reverseOrder());
+      Arrays.sort(tempMergeTopkArray, comparator);
       if (tempMergeTopkArray.length < tkVal) {
         tempMergeTopkArray = ArrayUtil.padWithNull(ttClass, tempMergeTopkArray, tkVal);
         return tempMergeTopkArray;
@@ -104,7 +126,7 @@ public class TopkDistinctKudaf<T> extends KsqlAggregateFunction<T, T[]> {
 
   @Override
   public KsqlAggregateFunction<T, T[]> getInstance(Map<String, Integer> expressionNames,
-                                                             List<Expression> functionArguments) {
+                                                   List<Expression> functionArguments) {
     if (functionArguments.size() != 2) {
       throw new KsqlException(String.format("Invalid parameter count. Need 2 args, got %d arg(s)"
                                             + ".", functionArguments.size()));
@@ -113,5 +135,4 @@ public class TopkDistinctKudaf<T> extends KsqlAggregateFunction<T, T[]> {
     Integer tkValFromArg = Integer.parseInt(functionArguments.get(1).toString());
     return new TopkDistinctKudaf<>(udafIndex, tkValFromArg, ttClass);
   }
-
 }

--- a/ksql-engine/src/main/java/io/confluent/ksql/function/udf/Kudf.java
+++ b/ksql-engine/src/main/java/io/confluent/ksql/function/udf/Kudf.java
@@ -17,8 +17,5 @@
 package io.confluent.ksql.function.udf;
 
 public interface Kudf {
-
-  void init();
-
   Object evaluate(Object... args);
 }

--- a/ksql-engine/src/main/java/io/confluent/ksql/function/udf/datetime/StringToTimestamp.java
+++ b/ksql-engine/src/main/java/io/confluent/ksql/function/udf/datetime/StringToTimestamp.java
@@ -28,10 +28,6 @@ public class StringToTimestamp implements Kudf {
   private DateFormat dateFormat = null;
 
   @Override
-  public void init() {
-  }
-
-  @Override
   public Object evaluate(Object... args) {
     if (args.length != 2) {
       throw new KsqlFunctionException("StringToTimestamp udf should have two input argument:"

--- a/ksql-engine/src/main/java/io/confluent/ksql/function/udf/datetime/StringToTimestamp.java
+++ b/ksql-engine/src/main/java/io/confluent/ksql/function/udf/datetime/StringToTimestamp.java
@@ -18,14 +18,19 @@ package io.confluent.ksql.function.udf.datetime;
 
 import java.sql.Timestamp;
 import java.time.LocalDateTime;
+import java.time.ZoneId;
+import java.time.ZonedDateTime;
 import java.time.format.DateTimeFormatter;
+import java.time.format.DateTimeFormatterBuilder;
+import java.time.temporal.ChronoField;
+import java.time.temporal.TemporalAccessor;
 
 import io.confluent.ksql.function.KsqlFunctionException;
 import io.confluent.ksql.function.udf.Kudf;
 
 public class StringToTimestamp implements Kudf {
 
-  private DateTimeFormatter formatter;
+  private DateTimeFormatter threadSafeFormatter;
 
   @Override
   public Object evaluate(final Object... args) {
@@ -37,17 +42,36 @@ public class StringToTimestamp implements Kudf {
     try {
       ensureInitialized(args);
 
-      final LocalDateTime dateTime = LocalDateTime.parse(args[0].toString(), formatter);
+      TemporalAccessor parsed = threadSafeFormatter.parseBest(
+          args[0].toString(), ZonedDateTime::from, LocalDateTime::from);
+
+      if (parsed == null) {
+        throw new KsqlFunctionException("Value could not be parsed");
+      }
+
+      if (parsed instanceof ZonedDateTime) {
+        parsed = ((ZonedDateTime) parsed)
+            .withZoneSameInstant(ZoneId.systemDefault())
+            .toLocalDateTime();
+      }
+
+      final LocalDateTime dateTime = (LocalDateTime) parsed;
       return Timestamp.valueOf(dateTime).getTime();
     } catch (final Exception e) {
-      throw new KsqlFunctionException("Exception running StringToTimestamp(" + args[0] +", "
-          + args[1] + ") : " + e.getMessage(), e);
+      throw new KsqlFunctionException("Exception running StringToTimestamp(" + args[0] + ", "
+                                      + args[1] + ") : " + e.getMessage(), e);
     }
   }
 
   private void ensureInitialized(final Object[] args) {
-    if (formatter == null) {
-      formatter = DateTimeFormatter.ofPattern(args[1].toString());
+    if (threadSafeFormatter == null) {
+      threadSafeFormatter = new DateTimeFormatterBuilder()
+          .appendPattern(args[1].toString())
+          .parseDefaulting(ChronoField.YEAR_OF_ERA, 1970)
+          .parseDefaulting(ChronoField.MONTH_OF_YEAR, 1)
+          .parseDefaulting(ChronoField.DAY_OF_MONTH, 1)
+          .parseDefaulting(ChronoField.HOUR_OF_DAY, 0)
+          .toFormatter();
     }
   }
 }

--- a/ksql-engine/src/main/java/io/confluent/ksql/function/udf/datetime/TimestampToString.java
+++ b/ksql-engine/src/main/java/io/confluent/ksql/function/udf/datetime/TimestampToString.java
@@ -26,10 +26,6 @@ import io.confluent.ksql.function.udf.Kudf;
 public class TimestampToString implements Kudf {
 
   private DateFormat dateFormat = null;
-  @Override
-  public void init() {
-
-  }
 
   @Override
   public Object evaluate(Object... args) {

--- a/ksql-engine/src/main/java/io/confluent/ksql/function/udf/datetime/TimestampToString.java
+++ b/ksql-engine/src/main/java/io/confluent/ksql/function/udf/datetime/TimestampToString.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2017 Confluent Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -16,16 +16,15 @@
 
 package io.confluent.ksql.function.udf.datetime;
 
-import java.text.DateFormat;
-import java.text.SimpleDateFormat;
-import java.util.Date;
+import java.sql.Timestamp;
+import java.time.format.DateTimeFormatter;
 
 import io.confluent.ksql.function.KsqlFunctionException;
 import io.confluent.ksql.function.udf.Kudf;
 
 public class TimestampToString implements Kudf {
 
-  private DateFormat dateFormat = null;
+  private DateTimeFormatter formatter;
 
   @Override
   public Object evaluate(Object... args) {
@@ -33,14 +32,21 @@ public class TimestampToString implements Kudf {
       throw new KsqlFunctionException("TimestampToString udf should have two input argument:"
                                       + " date value and format.");
     }
+
     try {
-      if(dateFormat == null) {
-        dateFormat = new SimpleDateFormat(args[1].toString());
-      }
-      return dateFormat.format(new Date((long)args[0]));
+      ensureInitialized(args);
+
+      final Timestamp timestamp = new Timestamp((Long) args[0]);
+      return timestamp.toLocalDateTime().format(formatter);
     } catch (Exception e) {
-      throw new KsqlFunctionException("Exception running TimestampToString(" + args[0] +" , "
-          + args[1] + ") : " + e.getMessage(), e);
+      throw new KsqlFunctionException("Exception running TimestampToString(" + args[0] + " , "
+                                      + args[1] + ") : " + e.getMessage(), e);
+    }
+  }
+
+  private void ensureInitialized(final Object[] args) {
+    if (formatter == null) {
+      formatter = DateTimeFormatter.ofPattern(args[1].toString());
     }
   }
 }

--- a/ksql-engine/src/main/java/io/confluent/ksql/function/udf/json/ArrayContainsKudf.java
+++ b/ksql-engine/src/main/java/io/confluent/ksql/function/udf/json/ArrayContainsKudf.java
@@ -43,10 +43,6 @@ public class ArrayContainsKudf
           .disable(CANONICALIZE_FIELD_NAMES);
 
   @Override
-  public void init() {
-  }
-
-  @Override
   public Object evaluate(Object... args) {
     if (args.length != 2) {
       throw new KsqlFunctionException("ARRAY_CONTAINS udf should have two input argument. "

--- a/ksql-engine/src/main/java/io/confluent/ksql/function/udf/json/JsonExtractStringKudf.java
+++ b/ksql-engine/src/main/java/io/confluent/ksql/function/udf/json/JsonExtractStringKudf.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2017 Confluent Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -16,58 +16,74 @@
 
 package io.confluent.ksql.function.udf.json;
 
+import com.google.common.collect.ImmutableList;
+
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
-import com.google.common.collect.ImmutableList;
-import io.confluent.ksql.function.KsqlFunctionException;
-import io.confluent.ksql.function.udf.Kudf;
-import io.confluent.ksql.util.KsqlException;
-import io.confluent.ksql.util.json.JsonPathTokenizer;
+import com.fasterxml.jackson.databind.node.ArrayNode;
 
 import java.io.IOException;
+import java.util.List;
+
+import io.confluent.ksql.function.KsqlFunctionException;
+import io.confluent.ksql.function.udf.Kudf;
+import io.confluent.ksql.util.json.JsonPathTokenizer;
 
 public class JsonExtractStringKudf implements Kudf {
   private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper();
 
-  private String path = null;
-  private ImmutableList<String> tokens = null;
+  private List<String> tokens = null;
 
   @Override
   public Object evaluate(Object... args) {
     if (args.length != 2) {
-      throw new KsqlFunctionException("getStringFromJson udf should have two input argument.");
+      throw new KsqlFunctionException("getStringFromJson udf should have two input arguments:"
+                                      + " JSON document and JSON path.");
     }
-    String jsonString = args[0].toString();
-    if (path == null) {
-      path = args[1].toString();
-      JsonPathTokenizer jsonPathTokenizer = new JsonPathTokenizer(path);
-      tokens = ImmutableList.copyOf(jsonPathTokenizer);
-    }
-    JsonNode jsonNode;
-    try {
-      jsonNode = OBJECT_MAPPER.readTree(jsonString);
-    } catch (IOException e) {
-      throw new KsqlException("Invalid JSON format.", e);
-    }
-    JsonNode currentNode = jsonNode;
+
+    ensureInitialized(args);
+
+    JsonNode currentNode = parseJsonDoc(args[0]);
     for (String token: tokens) {
+      if (currentNode instanceof ArrayNode) {
+        try {
+          final int index = Integer.parseInt(token);
+          currentNode = currentNode.get(index);
+        } catch (NumberFormatException e) {
+          return null;
+        }
+      } else {
+          currentNode = currentNode.get(token);
+      }
+
       if (currentNode == null) {
         return null;
       }
-      try {
-        int index = Integer.parseInt(token);
-        currentNode = currentNode.get(index);
-      } catch (NumberFormatException e) {
-        currentNode = currentNode.get(token);
-      }
     }
-    if (currentNode == null) {
-      return null;
-    }
+
     if (currentNode.isTextual()) {
       return currentNode.asText();
     } else {
       return currentNode.toString();
+    }
+  }
+
+  private void ensureInitialized(final Object[] args) {
+    if (tokens != null) {
+      return;
+    }
+
+    final String path = args[1].toString();
+    final JsonPathTokenizer tokenizer = new JsonPathTokenizer(path);
+    tokens = ImmutableList.copyOf(tokenizer);
+  }
+
+  private static JsonNode parseJsonDoc(final Object arg) {
+    final String jsonString = arg.toString();
+    try {
+      return OBJECT_MAPPER.readTree(jsonString);
+    } catch (IOException e) {
+      throw new KsqlFunctionException("Invalid JSON format:" + jsonString, e);
     }
   }
 }

--- a/ksql-engine/src/main/java/io/confluent/ksql/function/udf/json/JsonExtractStringKudf.java
+++ b/ksql-engine/src/main/java/io/confluent/ksql/function/udf/json/JsonExtractStringKudf.java
@@ -44,7 +44,7 @@ public class JsonExtractStringKudf implements Kudf {
     ensureInitialized(args);
 
     JsonNode currentNode = parseJsonDoc(args[0]);
-    for (String token: tokens) {
+    for (String token : tokens) {
       if (currentNode instanceof ArrayNode) {
         try {
           final int index = Integer.parseInt(token);
@@ -53,7 +53,7 @@ public class JsonExtractStringKudf implements Kudf {
           return null;
         }
       } else {
-          currentNode = currentNode.get(token);
+        currentNode = currentNode.get(token);
       }
 
       if (currentNode == null) {

--- a/ksql-engine/src/main/java/io/confluent/ksql/function/udf/json/JsonExtractStringKudf.java
+++ b/ksql-engine/src/main/java/io/confluent/ksql/function/udf/json/JsonExtractStringKudf.java
@@ -33,10 +33,6 @@ public class JsonExtractStringKudf implements Kudf {
   private ImmutableList<String> tokens = null;
 
   @Override
-  public void init() {
-  }
-
-  @Override
   public Object evaluate(Object... args) {
     if (args.length != 2) {
       throw new KsqlFunctionException("getStringFromJson udf should have two input argument.");

--- a/ksql-engine/src/main/java/io/confluent/ksql/function/udf/json/JsonExtractStringKudf.java
+++ b/ksql-engine/src/main/java/io/confluent/ksql/function/udf/json/JsonExtractStringKudf.java
@@ -20,6 +20,7 @@ import com.google.common.collect.ImmutableList;
 
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.ObjectReader;
 import com.fasterxml.jackson.databind.node.ArrayNode;
 
 import java.io.IOException;
@@ -30,7 +31,7 @@ import io.confluent.ksql.function.udf.Kudf;
 import io.confluent.ksql.util.json.JsonPathTokenizer;
 
 public class JsonExtractStringKudf implements Kudf {
-  private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper();
+  private static final ObjectReader OBJECT_READER = new ObjectMapper().reader();
 
   private List<String> tokens = null;
 
@@ -81,7 +82,7 @@ public class JsonExtractStringKudf implements Kudf {
   private static JsonNode parseJsonDoc(final Object arg) {
     final String jsonString = arg.toString();
     try {
-      return OBJECT_MAPPER.readTree(jsonString);
+      return OBJECT_READER.readTree(jsonString);
     } catch (IOException e) {
       throw new KsqlFunctionException("Invalid JSON format:" + jsonString, e);
     }

--- a/ksql-engine/src/main/java/io/confluent/ksql/function/udf/math/AbsKudf.java
+++ b/ksql-engine/src/main/java/io/confluent/ksql/function/udf/math/AbsKudf.java
@@ -22,10 +22,6 @@ import io.confluent.ksql.function.udf.Kudf;
 public class AbsKudf implements Kudf {
 
   @Override
-  public void init() {
-  }
-
-  @Override
   public Object evaluate(Object... args) {
     if (args.length != 1) {
       throw new KsqlFunctionException("Abs udf should have one input argument.");

--- a/ksql-engine/src/main/java/io/confluent/ksql/function/udf/math/CeilKudf.java
+++ b/ksql-engine/src/main/java/io/confluent/ksql/function/udf/math/CeilKudf.java
@@ -22,10 +22,6 @@ import io.confluent.ksql.function.udf.Kudf;
 public class CeilKudf implements Kudf {
 
   @Override
-  public void init() {
-  }
-
-  @Override
   public Object evaluate(Object... args) {
     if (args.length != 1) {
       throw new KsqlFunctionException("Ceil udf should have one input argument.");

--- a/ksql-engine/src/main/java/io/confluent/ksql/function/udf/math/FloorKudf.java
+++ b/ksql-engine/src/main/java/io/confluent/ksql/function/udf/math/FloorKudf.java
@@ -22,10 +22,6 @@ import io.confluent.ksql.function.udf.Kudf;
 public class FloorKudf implements Kudf {
 
   @Override
-  public void init() {
-  }
-
-  @Override
   public Object evaluate(Object... args) {
     if (args.length != 1) {
       throw new KsqlFunctionException("Floor udf should have one input argument.");

--- a/ksql-engine/src/main/java/io/confluent/ksql/function/udf/math/RandomKudf.java
+++ b/ksql-engine/src/main/java/io/confluent/ksql/function/udf/math/RandomKudf.java
@@ -22,11 +22,6 @@ import io.confluent.ksql.function.udf.Kudf;
 public class RandomKudf implements Kudf {
 
   @Override
-  public void init() {
-
-  }
-
-  @Override
   public Object evaluate(Object... args) {
     if (args.length != 0) {
       throw new KsqlFunctionException("Random udf should have no input argument.");

--- a/ksql-engine/src/main/java/io/confluent/ksql/function/udf/math/RoundKudf.java
+++ b/ksql-engine/src/main/java/io/confluent/ksql/function/udf/math/RoundKudf.java
@@ -22,10 +22,6 @@ import io.confluent.ksql.function.udf.Kudf;
 public class RoundKudf implements Kudf {
 
   @Override
-  public void init() {
-  }
-
-  @Override
   public Object evaluate(Object... args) {
     if (args.length != 1) {
       throw new KsqlFunctionException("Len udf should have one input argument.");

--- a/ksql-engine/src/main/java/io/confluent/ksql/function/udf/string/ConcatKudf.java
+++ b/ksql-engine/src/main/java/io/confluent/ksql/function/udf/string/ConcatKudf.java
@@ -22,11 +22,6 @@ import io.confluent.ksql.function.udf.Kudf;
 public class ConcatKudf implements Kudf {
 
   @Override
-  public void init() {
-
-  }
-
-  @Override
   public Object evaluate(Object... args) {
     if (args.length != 2) {
       throw new KsqlFunctionException("Concat udf should have two input argument.");

--- a/ksql-engine/src/main/java/io/confluent/ksql/function/udf/string/IfNullKudf.java
+++ b/ksql-engine/src/main/java/io/confluent/ksql/function/udf/string/IfNullKudf.java
@@ -22,11 +22,6 @@ import io.confluent.ksql.function.udf.Kudf;
 public class IfNullKudf implements Kudf {
 
   @Override
-  public void init() {
-
-  }
-
-  @Override
   public Object evaluate(Object... args) {
     if (args.length != 2) {
       throw new KsqlFunctionException("IfNull udf should have two input argument.");

--- a/ksql-engine/src/main/java/io/confluent/ksql/function/udf/string/LCaseKudf.java
+++ b/ksql-engine/src/main/java/io/confluent/ksql/function/udf/string/LCaseKudf.java
@@ -22,11 +22,6 @@ import io.confluent.ksql.function.udf.Kudf;
 public class LCaseKudf implements Kudf {
 
   @Override
-  public void init() {
-
-  }
-
-  @Override
   public Object evaluate(Object... args) {
     if (args.length != 1) {
       throw new KsqlFunctionException("LCase udf should have one input argument.");

--- a/ksql-engine/src/main/java/io/confluent/ksql/function/udf/string/LenKudf.java
+++ b/ksql-engine/src/main/java/io/confluent/ksql/function/udf/string/LenKudf.java
@@ -22,11 +22,6 @@ import io.confluent.ksql.function.udf.Kudf;
 public class LenKudf implements Kudf {
 
   @Override
-  public void init() {
-
-  }
-
-  @Override
   public Object evaluate(Object... args) {
     if (args.length != 1) {
       throw new KsqlFunctionException("Length udf should have one input argument.");

--- a/ksql-engine/src/main/java/io/confluent/ksql/function/udf/string/SubstringKudf.java
+++ b/ksql-engine/src/main/java/io/confluent/ksql/function/udf/string/SubstringKudf.java
@@ -22,11 +22,6 @@ import io.confluent.ksql.function.udf.Kudf;
 public class SubstringKudf implements Kudf {
 
   @Override
-  public void init() {
-
-  }
-
-  @Override
   public Object evaluate(Object... args) {
     if ((args.length < 2) || (args.length > 3)) {
       throw new KsqlFunctionException("Substring udf should have two or three input argument.");

--- a/ksql-engine/src/main/java/io/confluent/ksql/function/udf/string/TrimKudf.java
+++ b/ksql-engine/src/main/java/io/confluent/ksql/function/udf/string/TrimKudf.java
@@ -22,11 +22,6 @@ import io.confluent.ksql.function.udf.Kudf;
 public class TrimKudf implements Kudf {
 
   @Override
-  public void init() {
-
-  }
-
-  @Override
   public Object evaluate(Object... args) {
     if (args.length != 1) {
       throw new KsqlFunctionException("Trim udf should have one input argument.");

--- a/ksql-engine/src/main/java/io/confluent/ksql/function/udf/string/UCaseKudf.java
+++ b/ksql-engine/src/main/java/io/confluent/ksql/function/udf/string/UCaseKudf.java
@@ -22,11 +22,6 @@ import io.confluent.ksql.function.udf.Kudf;
 public class UCaseKudf implements Kudf {
 
   @Override
-  public void init() {
-
-  }
-
-  @Override
   public Object evaluate(Object... args) {
     if (args.length != 1) {
       throw new KsqlFunctionException("UCase udf should have one input argument.");

--- a/ksql-engine/src/main/java/io/confluent/ksql/planner/plan/AggregateNode.java
+++ b/ksql-engine/src/main/java/io/confluent/ksql/planner/plan/AggregateNode.java
@@ -28,13 +28,6 @@ import org.apache.kafka.connect.data.Schema;
 import org.apache.kafka.connect.data.SchemaBuilder;
 import org.apache.kafka.streams.StreamsBuilder;
 
-import io.confluent.ksql.util.AggregateExpressionRewriter;
-import io.confluent.ksql.util.KafkaTopicClient;
-import io.confluent.ksql.util.KsqlConfig;
-import io.confluent.ksql.util.KsqlException;
-import io.confluent.ksql.util.Pair;
-import io.confluent.ksql.util.SchemaUtil;
-
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
@@ -325,7 +318,7 @@ public class AggregateNode extends PlanNode {
         );
 
         aggValToAggFunctionMap.put(udafIndexInAggSchema++, aggregateFunction);
-        initializer.addAggregateIntializer(aggregateFunction.getIntialValueSupplier());
+        initializer.addAggregateIntializer(aggregateFunction.getInitialValueSupplier());
 
         aggregateSchema.field("AGG_COL_"
                               + udafIndexInAggSchema, aggregateFunction.getReturnType());

--- a/ksql-engine/src/test/java/io/confluent/ksql/function/udaf/topk/IntTopkKudafTest.java
+++ b/ksql-engine/src/test/java/io/confluent/ksql/function/udaf/topk/IntTopkKudafTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2017 Confluent Inc.
  *
  * Licensed under the Apache License, Version 2 (the "License");
@@ -16,98 +16,113 @@
 
 package io.confluent.ksql.function.udaf.topk;
 
-import io.confluent.ksql.function.KsqlAggregateFunction;
+import com.google.common.collect.ImmutableList;
+
 import org.apache.kafka.connect.data.Schema;
 import org.junit.Before;
 import org.junit.Test;
 
 import java.util.Collections;
 import java.util.List;
+import java.util.stream.IntStream;
+
+import io.confluent.ksql.function.KsqlAggregateFunction;
 
 import static org.hamcrest.CoreMatchers.equalTo;
+import static org.hamcrest.CoreMatchers.is;
 import static org.junit.Assert.assertThat;
 
 public class IntTopkKudafTest {
-  private Object[] valueArray;
-  private TopKAggregateFunctionFactory topKFactory;
-  private List<Schema> argumentType;
 
+  private Integer[] valueArray;
+  private KsqlAggregateFunction<Integer, Integer[]> topkKudaf;
+
+  @SuppressWarnings("unchecked")
   @Before
   public void setup() {
     valueArray = new Integer[]{10, 30, 45, 10, 50, 60, 20, 60, 80, 35, 25};
-    topKFactory = new TopKAggregateFunctionFactory(3);
-    argumentType = Collections.singletonList(Schema.INT32_SCHEMA);
+    topkKudaf = new TopKAggregateFunctionFactory(3)
+        .getProperAggregateFunction(Collections.singletonList(Schema.INT32_SCHEMA));
   }
 
-  @SuppressWarnings("unchecked")
   @Test
   public void shouldAggregateTopK() {
-    KsqlAggregateFunction<Object, Object[]> topkKudaf =
-            topKFactory.getProperAggregateFunction(argumentType);
-    Object[] currentVal = new Integer[]{null, null, null};
-    for (Object value : valueArray) {
-      currentVal = topkKudaf.aggregate(value , currentVal);
+    Integer[] currentVal = new Integer[]{null, null, null};
+    for (Integer value : valueArray) {
+      currentVal = topkKudaf.aggregate(value, currentVal);
     }
 
     assertThat("Invalid results.", currentVal, equalTo(new Integer[]{80, 60, 60}));
   }
 
-  @SuppressWarnings("unchecked")
   @Test
   public void shouldAggregateTopKWithLessThanKValues() {
-    KsqlAggregateFunction<Object, Object[]> topkKudaf =
-            topKFactory.getProperAggregateFunction(argumentType);
-    Object[] currentVal = new Integer[]{null, null, null};
+    Integer[] currentVal = new Integer[]{null, null, null};
     currentVal = topkKudaf.aggregate(10, currentVal);
 
     assertThat("Invalid results.", currentVal, equalTo(new Integer[]{10, null, null}));
   }
 
-  @SuppressWarnings("unchecked")
   @Test
   public void shouldMergeTopK() {
-    KsqlAggregateFunction<Object, Object[]> topkKudaf =
-            topKFactory.getProperAggregateFunction(argumentType);
     Integer[] array1 = new Integer[]{50, 45, 25};
     Integer[] array2 = new Integer[]{60, 55, 48};
 
     assertThat("Invalid results.", topkKudaf.getMerger().apply("key", array1, array2),
-            equalTo(new Integer[]{60, 55, 50}));
+               equalTo(new Integer[]{60, 55, 50}));
   }
 
-  @SuppressWarnings("unchecked")
   @Test
   public void shouldMergeTopKWithNulls() {
-    KsqlAggregateFunction<Object, Object[]> topkKudaf =
-            topKFactory.getProperAggregateFunction(argumentType);
     Integer[] array1 = new Integer[]{50, 45, null};
     Integer[] array2 = new Integer[]{60, null, null};
 
     assertThat("Invalid results.", topkKudaf.getMerger().apply("key", array1, array2),
-            equalTo(new Integer[]{60, 50, 45}));
+               equalTo(new Integer[]{60, 50, 45}));
   }
 
-  @SuppressWarnings("unchecked")
   @Test
   public void shouldMergeTopKWithMoreNulls() {
-    KsqlAggregateFunction<Object, Object[]> topkKudaf =
-            topKFactory.getProperAggregateFunction(argumentType);
     Integer[] array1 = new Integer[]{50, null, null};
     Integer[] array2 = new Integer[]{60, null, null};
 
     assertThat("Invalid results.", topkKudaf.getMerger().apply("key", array1, array2),
-            equalTo(new Integer[]{60, 50, null}));
+               equalTo(new Integer[]{60, 50, null}));
+  }
+
+  @Test
+  public void shouldAggregateAndProducedOrderedTopK() {
+    Object[] aggregate = topkKudaf.aggregate(1, new Integer[]{null, null, null});
+    assertThat(aggregate, equalTo(new Integer[]{1, null, null}));
+    Object[] agg2 = topkKudaf.aggregate(100, new Integer[]{1, null, null});
+    assertThat(agg2, equalTo(new Integer[]{100, 1, null}));
   }
 
   @SuppressWarnings("unchecked")
   @Test
-  public void shouldAggregateAndProducedOrderedTopK() {
-    KsqlAggregateFunction<Object, Object[]> topkKudaf =
-        topKFactory.getProperAggregateFunction(argumentType);
+  public void shouldBeThreadSafe() {
+    // Given:
+    topkKudaf = new TopKAggregateFunctionFactory(12)
+        .getProperAggregateFunction(Collections.singletonList(Schema.INT32_SCHEMA));
 
-    Object[] aggregate = topkKudaf.aggregate(1, new Object[3]);
-    assertThat(aggregate, equalTo(new Integer[] {1, null, null}));
-    Object[] agg2 = topkKudaf.aggregate(100, new Integer[] {1, null, null});
-    assertThat(agg2, equalTo(new Integer[] {100, 1, null}));
+    final List<Integer> values = ImmutableList.of(10, 30, 45, 10, 50, 60, 20, 70, 80, 35, 25);
+
+    // When:
+    final Object[] result = IntStream.range(0, 4)
+        .parallel()
+        .mapToObj(threadNum -> {
+          Integer[] aggregate = new Integer[]
+              {1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1};
+
+          for (int value : values) {
+            aggregate = topkKudaf.aggregate(value + threadNum, aggregate);
+          }
+          return aggregate;
+        })
+        .reduce((agg1, agg2) -> topkKudaf.getMerger().apply("blah", agg1, agg2))
+        .orElse(new Integer[0]);
+
+    // Then:
+    assertThat(result, is(new Object[]{83, 82, 81, 80, 73, 72, 71, 70, 63, 62, 61, 60}));
   }
 }

--- a/ksql-engine/src/test/java/io/confluent/ksql/function/udaf/topk/IntTopkKudafTest.java
+++ b/ksql-engine/src/test/java/io/confluent/ksql/function/udaf/topk/IntTopkKudafTest.java
@@ -112,7 +112,7 @@ public class IntTopkKudafTest {
         .parallel()
         .mapToObj(threadNum -> {
           Integer[] aggregate = new Integer[]
-              {1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1};
+              {0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0};
 
           for (int value : values) {
             aggregate = topkKudaf.aggregate(value + threadNum, aggregate);

--- a/ksql-engine/src/test/java/io/confluent/ksql/function/udaf/topkdistinct/IntTopkDistinctKudafTest.java
+++ b/ksql-engine/src/test/java/io/confluent/ksql/function/udaf/topkdistinct/IntTopkDistinctKudafTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2017 Confluent Inc.
  *
  * Licensed under the Apache License, Version 2 (the "License");
@@ -16,30 +16,34 @@
 
 package io.confluent.ksql.function.udaf.topkdistinct;
 
+import com.google.common.collect.ImmutableList;
+
 import org.junit.Before;
 import org.junit.Test;
 
-import io.confluent.ksql.function.KsqlAggregateFunction;
+import java.util.List;
+import java.util.stream.IntStream;
 
 import static org.hamcrest.CoreMatchers.equalTo;
+import static org.hamcrest.CoreMatchers.is;
 import static org.junit.Assert.assertThat;
 
 public class IntTopkDistinctKudafTest {
 
   private Integer[] valueArray;
-  private final TopkDistinctKudaf<Integer> intTopkDistinctKudaf = new TopkDistinctKudaf<>(0, 3, Integer.class);
+  private final TopkDistinctKudaf<Integer> intTopkDistinctKudaf =
+      new TopkDistinctKudaf<>(0, 3, Integer.class);
 
   @Before
   public void setup() {
     valueArray = new Integer[]{10, 30, 45, 10, 50, 60, 20, 60, 80, 35, 25,
-                              60, 80};
-
+                               60, 80};
   }
 
   @Test
   public void shouldAggregateTopK() {
     Integer[] currentVal = new Integer[]{null, null, null};
-    for (Integer d: valueArray) {
+    for (Integer d : valueArray) {
       currentVal = intTopkDistinctKudaf.aggregate(d, currentVal);
     }
 
@@ -59,8 +63,9 @@ public class IntTopkDistinctKudafTest {
     Integer[] array1 = new Integer[]{50, 45, 25};
     Integer[] array2 = new Integer[]{60, 50, 48};
 
-    assertThat("Invalid results.", intTopkDistinctKudaf.getMerger().apply("key", array1, array2), equalTo(
-        new Integer[]{60, 50, 48}));
+    assertThat("Invalid results.", intTopkDistinctKudaf.getMerger().apply("key", array1, array2),
+               equalTo(
+                   new Integer[]{60, 50, 48}));
   }
 
   @Test
@@ -68,8 +73,9 @@ public class IntTopkDistinctKudafTest {
     Integer[] array1 = new Integer[]{50, 45, null};
     Integer[] array2 = new Integer[]{60, null, null};
 
-    assertThat("Invalid results.", intTopkDistinctKudaf.getMerger().apply("key", array1, array2), equalTo(
-        new Integer[]{60, 50, 45}));
+    assertThat("Invalid results.", intTopkDistinctKudaf.getMerger().apply("key", array1, array2),
+               equalTo(
+                   new Integer[]{60, 50, 45}));
   }
 
   @Test
@@ -77,8 +83,9 @@ public class IntTopkDistinctKudafTest {
     Integer[] array1 = new Integer[]{50, 45, null};
     Integer[] array2 = new Integer[]{60, 50, null};
 
-    assertThat("Invalid results.", intTopkDistinctKudaf.getMerger().apply("key", array1, array2), equalTo(
-        new Integer[]{60, 50, 45}));
+    assertThat("Invalid results.", intTopkDistinctKudaf.getMerger().apply("key", array1, array2),
+               equalTo(
+                   new Integer[]{60, 50, 45}));
   }
 
   @Test
@@ -86,16 +93,45 @@ public class IntTopkDistinctKudafTest {
     Integer[] array1 = new Integer[]{60, null, null};
     Integer[] array2 = new Integer[]{60, null, null};
 
-    assertThat("Invalid results.", intTopkDistinctKudaf.getMerger().apply("key", array1, array2), equalTo(
-        new Integer[]{60, null, null}));
+    assertThat("Invalid results.", intTopkDistinctKudaf.getMerger().apply("key", array1, array2),
+               equalTo(
+                   new Integer[]{60, null, null}));
   }
 
   @SuppressWarnings("unchecked")
   @Test
   public void shouldAggregateAndProducedOrderedTopK() {
     Object[] aggregate = intTopkDistinctKudaf.aggregate(1, new Integer[3]);
-    assertThat(aggregate, equalTo(new Integer[] {1, null, null}));
-    Object[] agg2 = intTopkDistinctKudaf.aggregate(100, new Integer[] {1, null, null});
-    assertThat(agg2, equalTo(new Integer[] {100, 1, null}));
+    assertThat(aggregate, equalTo(new Integer[]{1, null, null}));
+    Object[] agg2 = intTopkDistinctKudaf.aggregate(100, new Integer[]{1, null, null});
+    assertThat(agg2, equalTo(new Integer[]{100, 1, null}));
+  }
+
+  @SuppressWarnings("unchecked")
+  @Test
+  public void shouldBeThreadSafe() {
+    // Given:
+    final TopkDistinctKudaf<Integer> intTopkDistinctKudaf =
+        new TopkDistinctKudaf<>(0, 12, Integer.class);
+
+    final List<Integer> values = ImmutableList.of(10, 30, 45, 10, 50, 60, 20, 70, 80, 35, 25);
+
+    // When:
+    final Object[] result = IntStream.range(0, 4)
+        .parallel()
+        .mapToObj(threadNum -> {
+          Integer[] aggregate = new Integer[]
+              {1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1};
+
+          for (int value : values) {
+            aggregate = intTopkDistinctKudaf.aggregate(value + threadNum, aggregate);
+          }
+          return aggregate;
+        })
+        .reduce((agg1, agg2) -> intTopkDistinctKudaf.getMerger().apply("blah", agg1, agg2))
+        .orElse(new Integer[0]);
+
+    // Then:
+    assertThat(result, is(new Object[]{83, 82, 81, 80, 73, 72, 71, 70, 63, 62, 61, 60}));
   }
 }

--- a/ksql-engine/src/test/java/io/confluent/ksql/function/udf/datetime/StringToTimestampTest.java
+++ b/ksql-engine/src/test/java/io/confluent/ksql/function/udf/datetime/StringToTimestampTest.java
@@ -1,0 +1,73 @@
+/*
+ * Copyright 2018 Confluent Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.confluent.ksql.function.udf.datetime;
+
+import org.junit.Before;
+import org.junit.Test;
+
+import java.util.stream.IntStream;
+
+import io.confluent.ksql.function.KsqlFunctionException;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.junit.Assert.assertThat;
+
+public class StringToTimestampTest {
+
+  private StringToTimestamp udf;
+
+  @Before
+  public void setUp(){
+    udf = new StringToTimestamp();
+  }
+
+  @Test
+  public void shouldCovertStringToTimestamp() {
+    // When:
+    final Object result = udf.evaluate("2021-12-01 12:10:11.123", "yyyy-MM-dd HH:mm:ss.SSS");
+
+    // Then:
+    assertThat(result, is(1638360611123L));
+  }
+
+  @Test(expected = KsqlFunctionException.class)
+  public void shouldThrowIfTooFewParameters() {
+    udf.evaluate("2021-12-01 12:10:11.123");
+  }
+
+  @Test(expected = KsqlFunctionException.class)
+  public void shouldThrowIfTooManyParameters() {
+    udf.evaluate("2021-12-01 12:10:11.123", "yyyy-MM-dd HH:mm:ss.SSS", "extra");
+  }
+
+  @Test(expected = KsqlFunctionException.class)
+  public void shouldThrowIfFormatInvalid() {
+    udf.evaluate("2021-12-01 12:10:11.123", "invalid");
+  }
+
+  @Test(expected = KsqlFunctionException.class)
+  public void shouldThrowIfParseFails() {
+    udf.evaluate("invalid", "yyyy-MM-dd'T'HH:mm:ss.SSS");
+  }
+
+  @Test
+  public void shouldBeThreadSafe() {
+    IntStream.range(0, 10_000)
+        .parallel()
+        .forEach(idx -> shouldCovertStringToTimestamp());
+  }
+}

--- a/ksql-engine/src/test/java/io/confluent/ksql/function/udf/datetime/TimestampToStringTest.java
+++ b/ksql-engine/src/test/java/io/confluent/ksql/function/udf/datetime/TimestampToStringTest.java
@@ -1,0 +1,73 @@
+/*
+ * Copyright 2018 Confluent Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.confluent.ksql.function.udf.datetime;
+
+import org.junit.Before;
+import org.junit.Test;
+
+import java.util.stream.IntStream;
+
+import io.confluent.ksql.function.KsqlFunctionException;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.junit.Assert.assertThat;
+
+public class TimestampToStringTest {
+
+  private TimestampToString udf;
+
+  @Before
+  public void setUp(){
+    udf = new TimestampToString();
+  }
+
+  @Test
+  public void shouldCovertTimestampToString() {
+    // When:
+    final Object result = udf.evaluate(1638360611123L, "yyyy-MM-dd HH:mm:ss.SSS");
+
+    // Then:
+    assertThat(result, is("2021-12-01 12:10:11.123"));
+  }
+
+  @Test(expected = KsqlFunctionException.class)
+  public void shouldThrowIfTooFewParameters() {
+    udf.evaluate(1638360611123L);
+  }
+
+  @Test(expected = KsqlFunctionException.class)
+  public void shouldThrowIfTooManyParameters() {
+    udf.evaluate(1638360611123L, "yyyy-MM-dd HH:mm:ss.SSS", "extra");
+  }
+
+  @Test(expected = KsqlFunctionException.class)
+  public void shouldThrowIfFormatInvalid() {
+    udf.evaluate("2021-12-01 12:10:11.123", "invalid");
+  }
+
+  @Test(expected = KsqlFunctionException.class)
+  public void shouldThrowIfNotTimestamp() {
+    udf.evaluate("invalid", "2021-12-01 12:10:11.123");
+  }
+
+  @Test
+  public void shouldBeThreadSafe() {
+    IntStream.range(0, 10_000)
+        .parallel()
+        .forEach(idx -> shouldCovertTimestampToString());
+  }
+}

--- a/ksql-engine/src/test/java/io/confluent/ksql/function/udf/json/ArrayContainsKudfTest.java
+++ b/ksql-engine/src/test/java/io/confluent/ksql/function/udf/json/ArrayContainsKudfTest.java
@@ -9,11 +9,6 @@ public class ArrayContainsKudfTest
 {
     private ArrayContainsKudf jsonUdf = new ArrayContainsKudf();
 
-    @Before
-    public void setUp() {
-        jsonUdf.init();
-    }
-
     @Test
     public void shouldReturnFalseOnEmptyArray() {
         assertEquals(false, jsonUdf.evaluate("[]", true));

--- a/ksql-engine/src/test/java/io/confluent/ksql/function/udf/json/JsonExtractStringKudfTest.java
+++ b/ksql-engine/src/test/java/io/confluent/ksql/function/udf/json/JsonExtractStringKudfTest.java
@@ -1,0 +1,109 @@
+/*
+ * Copyright 2018 Confluent Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.confluent.ksql.function.udf.json;
+
+import org.junit.Before;
+import org.junit.Test;
+
+import java.util.stream.IntStream;
+
+import io.confluent.ksql.function.KsqlFunctionException;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.CoreMatchers.nullValue;
+import static org.junit.Assert.assertThat;
+
+public class JsonExtractStringKudfTest {
+  private final String JSON_DOC = "{"
+                                  + "\"thing1\":{\"thing2\":\"hello\"},"
+                                  + "\"array\":[101,102]"
+                                  + "}";
+
+  private JsonExtractStringKudf udf;
+
+  @Before
+  public void setUp() {
+    udf = new JsonExtractStringKudf();
+  }
+
+  @Test
+  public void shouldExtractJsonField() {
+    // When:
+    final Object result = udf.evaluate(JSON_DOC, "$.thing1.thing2");
+
+    // Then:
+    assertThat(result, is("hello"));
+  }
+
+  @Test
+  public void shouldExtractJsonDoc() {
+    // When:
+    final Object result = udf.evaluate(JSON_DOC, "$.thing1");
+
+    // Then:
+    assertThat(result, is("{\"thing2\":\"hello\"}"));
+  }
+
+  @Test
+  public void shouldExtractWholeJsonDoc() {
+    // When:
+    final Object result = udf.evaluate(JSON_DOC, "$");
+
+    // Then:
+    assertThat(result, is(JSON_DOC));
+  }
+
+  @Test
+  public void shouldExtractJsonArrayField() {
+    // When:
+    final Object result = udf.evaluate(JSON_DOC, "$.array.1");
+
+    // Then:
+    assertThat(result, is("102"));
+  }
+
+  @Test
+  public void shouldReturnNullIfNodeNotFound() {
+    // When:
+    final Object result = udf.evaluate(JSON_DOC, "$.will.not.find.me");
+
+    // Then:
+    assertThat(result, is(nullValue()));
+  }
+
+  @Test(expected = KsqlFunctionException.class)
+  public void shouldThrowIfTooFewParameters() {
+    udf.evaluate(JSON_DOC);
+  }
+
+  @Test(expected = KsqlFunctionException.class)
+  public void shouldThrowIfTooManyParameters() {
+    udf.evaluate(JSON_DOC, "$.thing1", "extra");
+  }
+
+  @Test(expected = KsqlFunctionException.class)
+  public void shouldThrowOnInvalidJsonDoc() {
+    udf.evaluate("this is NOT a JSON doc", "$.thing1");
+  }
+
+  @Test
+  public void shouldBeThreadSafe() {
+    IntStream.range(0, 10_000)
+        .parallel()
+        .forEach(idx -> shouldExtractJsonField());
+  }
+}


### PR DESCRIPTION
Fix for #828

Fixed up a few KUDF types that weren't thread safe. Managed to avoid using TLS here by switching to thread-safe `java.time` types.

Fixed up a few KUDAF types that weren't thread safe. Managed to avoid using TLS here by reworking the algorithms.

There's some code clean up in here to, but have kept that in separate commits. This includes the removal of the unused `init` function from each UDF.