### PR TITLE
Fix some issues with comparison op codegen (#751)

### DIFF
--- a/ksql-engine/src/main/java/io/confluent/ksql/codegen/SqlToJavaVisitor.java
+++ b/ksql-engine/src/main/java/io/confluent/ksql/codegen/SqlToJavaVisitor.java
@@ -310,30 +310,6 @@ public class SqlToJavaVisitor {
       }
     }
 
-    private String visitArrayComparisonExpression(ComparisonExpression.Type type) {
-      switch (type) {
-        case EQUAL:
-          return "(java.util.Arrays.equals(%1$s, %2$s))";
-        case NOT_EQUAL:
-        case IS_DISTINCT_FROM:
-          return "!(java.util.Arrays.equals(%1$s, %2$s))";
-        default:
-          throw new KsqlException("Unexpected array comparison: " + type.getValue());
-      }
-    }
-
-    private String visitMapComparisonExpression(ComparisonExpression.Type type) {
-      switch (type) {
-        case EQUAL:
-          return "(%1$s.equals(%2$s))";
-        case NOT_EQUAL:
-        case IS_DISTINCT_FROM:
-          return " (!%1$s.equals(%2$s))";
-        default:
-          throw new KsqlException("Unexpected map comparison: " + type.getValue());
-      }
-    }
-
     private String visitScalarComparisonExpression(ComparisonExpression.Type type) {
       switch (type) {
         case EQUAL:
@@ -377,11 +353,9 @@ public class SqlToJavaVisitor {
           exprFormat += visitStringComparisonExpression(node.getType());
           break;
         case MAP:
-          exprFormat += visitMapComparisonExpression(node.getType());
-          break;
+          throw new KsqlException("Cannot compare MAP values");
         case ARRAY:
-          exprFormat += visitArrayComparisonExpression(node.getType());
-          break;
+          throw new KsqlException("Cannot compare ARRAY values");
         case BOOLEAN:
           exprFormat += visitBooleanComparisonExpression(node.getType());
           break;

--- a/ksql-engine/src/test/java/io/confluent/ksql/codegen/CodeGenRunnerTest.java
+++ b/ksql-engine/src/test/java/io/confluent/ksql/codegen/CodeGenRunnerTest.java
@@ -20,9 +20,12 @@ import io.confluent.ksql.analyzer.Analysis;
 import io.confluent.ksql.analyzer.AnalysisContext;
 import io.confluent.ksql.analyzer.Analyzer;
 import io.confluent.ksql.function.FunctionRegistry;
+import io.confluent.ksql.metastore.KsqlStream;
+import io.confluent.ksql.metastore.KsqlTopic;
 import io.confluent.ksql.metastore.MetaStore;
 import io.confluent.ksql.parser.KsqlParser;
 import io.confluent.ksql.parser.tree.Statement;
+import io.confluent.ksql.serde.json.KsqlJsonTopicSerDe;
 import io.confluent.ksql.util.ExpressionMetadata;
 import io.confluent.ksql.util.GenericRowValueTypeEnforcer;
 import io.confluent.ksql.util.MetaStoreFixture;
@@ -32,7 +35,14 @@ import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
 
+import java.util.HashMap;
 import java.util.List;
+
+import static org.hamcrest.CoreMatchers.anyOf;
+import static org.hamcrest.CoreMatchers.equalTo;
+import static org.hamcrest.CoreMatchers.instanceOf;
+import static org.hamcrest.MatcherAssert.assertThat;
+
 
 public class CodeGenRunnerTest {
 
@@ -45,12 +55,51 @@ public class CodeGenRunnerTest {
     @Before
     public void init() {
         metaStore = MetaStoreFixture.getNewMetaStore();
-      functionRegistry = new FunctionRegistry();
+        functionRegistry = new FunctionRegistry();
         schema = SchemaBuilder.struct()
-                .field("TEST1.COL0", SchemaBuilder.INT64_SCHEMA)
-                .field("TEST1.COL1", SchemaBuilder.STRING_SCHEMA)
-                .field("TEST1.COL2", SchemaBuilder.STRING_SCHEMA)
-                .field("TEST1.COL3", SchemaBuilder.FLOAT64_SCHEMA);
+                .field("CODEGEN_TEST.COL0", SchemaBuilder.INT64_SCHEMA)
+                .field("CODEGEN_TEST.COL1", SchemaBuilder.STRING_SCHEMA)
+                .field("CODEGEN_TEST.COL2", SchemaBuilder.STRING_SCHEMA)
+                .field("CODEGEN_TEST.COL3", SchemaBuilder.FLOAT64_SCHEMA)
+                .field("CODEGEN_TEST.COL4", SchemaBuilder.FLOAT64_SCHEMA)
+                .field("CODEGEN_TEST.COL5", SchemaBuilder.INT32_SCHEMA)
+                .field("CODEGEN_TEST.COL6", SchemaBuilder.BOOLEAN_SCHEMA)
+                .field("CODEGEN_TEST.COL7", SchemaBuilder.BOOLEAN_SCHEMA)
+                .field("CODEGEN_TEST.COL8", SchemaBuilder.INT64_SCHEMA)
+                .field("CODEGEN_TEST.COL9", SchemaBuilder.array(SchemaBuilder.INT32_SCHEMA))
+                .field("CODEGEN_TEST.COL10", SchemaBuilder.array(SchemaBuilder.INT32_SCHEMA))
+                .field("CODEGEN_TEST.COL11",
+                    SchemaBuilder.map(SchemaBuilder.INT32_SCHEMA, SchemaBuilder.INT32_SCHEMA))
+                .field("CODEGEN_TEST.COL12",
+                    SchemaBuilder.map(SchemaBuilder.INT32_SCHEMA, SchemaBuilder.INT32_SCHEMA));
+        Schema metaStoreSchema = SchemaBuilder.struct()
+            .field("COL0", SchemaBuilder.INT64_SCHEMA)
+            .field("COL1", SchemaBuilder.STRING_SCHEMA)
+            .field("COL2", SchemaBuilder.STRING_SCHEMA)
+            .field("COL3", SchemaBuilder.FLOAT64_SCHEMA)
+            .field("COL4", SchemaBuilder.FLOAT64_SCHEMA)
+            .field("COL5", SchemaBuilder.INT32_SCHEMA)
+            .field("COL6", SchemaBuilder.BOOLEAN_SCHEMA)
+            .field("COL7", SchemaBuilder.BOOLEAN_SCHEMA)
+            .field("COL8", SchemaBuilder.INT64_SCHEMA)
+            .field("COL9", SchemaBuilder.array(SchemaBuilder.INT32_SCHEMA))
+            .field("COL10", SchemaBuilder.array(SchemaBuilder.INT32_SCHEMA))
+            .field("COL11",
+                SchemaBuilder.map(SchemaBuilder.INT32_SCHEMA, SchemaBuilder.INT32_SCHEMA))
+            .field("COL12",
+                SchemaBuilder.map(SchemaBuilder.INT32_SCHEMA, SchemaBuilder.INT32_SCHEMA));
+        KsqlTopic ksqlTopic = new KsqlTopic(
+            "CODEGEN_TEST",
+            "codegen_test",
+            new KsqlJsonTopicSerDe());
+        KsqlStream ksqlStream = new KsqlStream(
+            "sqlexpression",
+            "CODEGEN_TEST", metaStoreSchema,
+            metaStoreSchema.field("COL0"),
+            null,
+            ksqlTopic);
+        metaStore.putTopic(ksqlTopic);
+        metaStore.putSource(ksqlStream);
         codeGenRunner = new CodeGenRunner(schema, functionRegistry);
     }
 
@@ -63,9 +112,288 @@ public class CodeGenRunnerTest {
         return analysis;
     }
 
+    private boolean evalBooleanExpr(String queryFormat, int cola, int colb, Object values[])
+            throws Exception {
+        String simpleQuery = String.format(queryFormat, cola, colb);
+        Analysis analysis = analyzeQuery(simpleQuery);
+
+        ExpressionMetadata expressionEvaluatorMetadata0 = codeGenRunner.buildCodeGenFromParseTree
+            (analysis.getSelectExpressions().get(0));
+        Assert.assertTrue(expressionEvaluatorMetadata0.getIndexes().length == 2);
+        int idx0 = expressionEvaluatorMetadata0.getIndexes()[0];
+        int idx1 = expressionEvaluatorMetadata0.getIndexes()[1];
+        Assert.assertThat(idx0, anyOf(equalTo(cola), equalTo(colb)));
+        Assert.assertThat(idx1, anyOf(equalTo(cola), equalTo(colb)));
+        Assert.assertNotEquals(idx0, idx1);
+        if (idx0 == colb) {
+            Object tmp = values[0];
+            values[0] = values[1];
+            values[1] = tmp;
+        }
+        Assert.assertEquals(expressionEvaluatorMetadata0.getUdfs().length, 2);
+        Object result0 = expressionEvaluatorMetadata0.getExpressionEvaluator().evaluate(values);
+        assertThat(result0, instanceOf(Boolean.class));
+        return (Boolean)result0;
+    }
+
+    private boolean evalBooleanExprEq(int cola, int colb, Object values[]) throws Exception {
+        return evalBooleanExpr("SELECT col%d = col%d FROM CODEGEN_TEST;", cola, colb, values);
+    }
+
+    private boolean evalBooleanExprNeq(int cola, int colb, Object values[]) throws Exception {
+        return evalBooleanExpr("SELECT col%d != col%d FROM CODEGEN_TEST;", cola, colb, values);
+    }
+
+    private boolean evalBooleanExprIsDistinctFrom(int cola, int colb, Object values[]) throws Exception {
+        return evalBooleanExpr("SELECT col%d IS DISTINCT FROM col%d FROM CODEGEN_TEST;", cola, colb, values);
+    }
+
+    private boolean evalBooleanExprLessThan(int cola, int colb, Object values[]) throws Exception {
+        return evalBooleanExpr("SELECT col%d < col%d FROM CODEGEN_TEST;", cola, colb, values);
+    }
+
+
+    private boolean evalBooleanExprLessThanEq(int cola, int colb, Object values[]) throws Exception {
+        return evalBooleanExpr("SELECT col%d <= col%d FROM CODEGEN_TEST;", cola, colb, values);
+    }
+
+    private boolean evalBooleanExprGreaterThan(int cola, int colb, Object values[]) throws Exception {
+        return evalBooleanExpr("SELECT col%d > col%d FROM CODEGEN_TEST;", cola, colb, values);
+    }
+
+    private boolean evalBooleanExprGreaterThanEq(int cola, int colb, Object values[]) throws Exception {
+        return evalBooleanExpr("SELECT col%d >= col%d FROM CODEGEN_TEST;", cola, colb, values);
+    }
+
+    @Test
+    public void testNullEquals() throws Exception {
+        Assert.assertFalse(evalBooleanExprEq(5, 0, new Object[]{null, 12344L}));
+        Assert.assertFalse(evalBooleanExprEq(5, 0, new Object[]{null, null}));
+    }
+
+    @Test
+    public void testIsDistinctFrom() throws Exception {
+        Assert.assertFalse(evalBooleanExprIsDistinctFrom(5, 0, new Object[]{12344, 12344L}));
+        Assert.assertTrue(evalBooleanExprIsDistinctFrom(5, 0, new Object[]{12345, 12344L}));
+        Assert.assertTrue(evalBooleanExprIsDistinctFrom(5, 0, new Object[]{null, 12344L}));
+        Assert.assertFalse(evalBooleanExprIsDistinctFrom(5, 0, new Object[]{null, null}));
+    }
+
+    @Test
+    public void testIsNull() throws Exception {
+        String simpleQuery = "SELECT col0 IS NULL FROM CODEGEN_TEST;";
+        Analysis analysis = analyzeQuery(simpleQuery);
+
+        ExpressionMetadata expressionEvaluatorMetadata0 = codeGenRunner.buildCodeGenFromParseTree
+            (analysis.getSelectExpressions().get(0));
+        Assert.assertTrue(expressionEvaluatorMetadata0.getIndexes().length == 1);
+        int idx0 = expressionEvaluatorMetadata0.getIndexes()[0];
+        Assert.assertEquals(idx0, 0);
+        Assert.assertEquals(expressionEvaluatorMetadata0.getUdfs().length, 1);
+
+        Object result0 = expressionEvaluatorMetadata0.getExpressionEvaluator().evaluate(new Object[]{null});
+        assertThat(result0, instanceOf(Boolean.class));
+        Assert.assertTrue((Boolean)result0);
+
+        result0 = expressionEvaluatorMetadata0.getExpressionEvaluator().evaluate(new Object[]{12345L});
+        assertThat(result0, instanceOf(Boolean.class));
+        Assert.assertFalse((Boolean)result0);
+    }
+
+    @Test
+    public void testIsNotNull() throws Exception {
+        String simpleQuery = "SELECT col0 IS NOT NULL FROM CODEGEN_TEST;";
+        Analysis analysis = analyzeQuery(simpleQuery);
+
+        ExpressionMetadata expressionEvaluatorMetadata0 = codeGenRunner.buildCodeGenFromParseTree
+            (analysis.getSelectExpressions().get(0));
+        Assert.assertTrue(expressionEvaluatorMetadata0.getIndexes().length == 1);
+        int idx0 = expressionEvaluatorMetadata0.getIndexes()[0];
+        Assert.assertEquals(idx0, 0);
+        Assert.assertEquals(expressionEvaluatorMetadata0.getUdfs().length, 1);
+
+        Object result0 = expressionEvaluatorMetadata0.getExpressionEvaluator().evaluate(new Object[]{null});
+        assertThat(result0, instanceOf(Boolean.class));
+        Assert.assertFalse((Boolean)result0);
+
+        result0 = expressionEvaluatorMetadata0.getExpressionEvaluator().evaluate(new Object[]{12345L});
+        assertThat(result0, instanceOf(Boolean.class));
+        Assert.assertTrue((Boolean)result0);
+    }
+
+    @Test
+    public void testBooleanExprScalarEq() throws Exception {
+        // int32
+        Assert.assertFalse(evalBooleanExprEq(5, 0, new Object[]{12345, 12344L}));
+        Assert.assertTrue(evalBooleanExprEq(5, 0, new Object[]{12345, 12345L}));
+        // int64
+        Assert.assertFalse(evalBooleanExprEq(8, 5, new Object[]{12345L, 12344}));
+        Assert.assertTrue(evalBooleanExprEq(8, 5, new Object[]{12345L, 12345}));
+        // double
+        Assert.assertFalse(evalBooleanExprEq(4, 3, new Object[]{12345.0, 12344.0}));
+        Assert.assertTrue(evalBooleanExprEq(4, 3, new Object[]{12345.0, 12345.0}));
+    }
+
+    @Test
+    public void testBooleanExprBooleanEq() throws Exception {
+        Assert.assertFalse(evalBooleanExprEq(7, 6, new Object[]{false, true}));
+        Assert.assertTrue(evalBooleanExprEq(7, 6, new Object[]{true, true}));
+    }
+
+    @Test
+    public void testBooleanExprStringEq() throws Exception {
+        Assert.assertFalse(evalBooleanExprEq(1, 2, new Object[]{"abc", "def"}));
+        Assert.assertTrue(evalBooleanExprEq(1, 2, new Object[]{"abc", "abc"}));
+    }
+
+    @Test
+    public void testBooleanExprArrayEq() throws Exception {
+        Integer a1[] = new Integer[]{1, 2, 3};
+        Integer a2[] = new Integer[]{1, 2, 3};
+        Integer b[] = new Integer[]{4, 5, 6};
+
+        Assert.assertFalse(evalBooleanExprEq(9, 10, new Object[]{a1, b}));
+        Assert.assertTrue(evalBooleanExprEq(9, 10, new Object[]{a1, a2}));
+    }
+
+    @Test
+    public void testBooleanExprMapEq() throws Exception {
+        HashMap<Integer, Integer> a1 = new HashMap<>();
+        a1.put(1, 2);
+        HashMap<Integer, Integer> a2 = new HashMap<>(a1);
+        HashMap<Integer, Integer> b = new HashMap<>();
+        b.put(5, 6);
+
+        Assert.assertFalse(evalBooleanExprEq(11, 12, new Object[]{a1, b}));
+        Assert.assertTrue(evalBooleanExprEq(11, 12, new Object[]{a1, a2}));
+    }
+
+    @Test
+    public void testBooleanExprScalarNeq() throws Exception {
+        // int32
+        Assert.assertTrue(evalBooleanExprNeq(5, 0, new Object[]{12345, 12344L}));
+        Assert.assertFalse(evalBooleanExprNeq(5, 0, new Object[]{12345, 12345L}));
+        // int64
+        Assert.assertTrue(evalBooleanExprNeq(8, 5, new Object[]{12345L, 12344}));
+        Assert.assertFalse(evalBooleanExprNeq(8, 5, new Object[]{12345L, 12345}));
+        // double
+        Assert.assertTrue(evalBooleanExprNeq(4, 3, new Object[]{12345.0, 12344.0}));
+        Assert.assertFalse(evalBooleanExprNeq(4, 3, new Object[]{12345.0, 12345.0}));
+    }
+
+    @Test
+    public void testBooleanExprBooleanNeq() throws Exception {
+        Assert.assertTrue(evalBooleanExprNeq(7, 6, new Object[]{false, true}));
+        Assert.assertFalse(evalBooleanExprNeq(7, 6, new Object[]{true, true}));
+    }
+
+    @Test
+    public void testBooleanExprStringNeq() throws Exception {
+        Assert.assertTrue(evalBooleanExprNeq(1, 2, new Object[]{"abc", "def"}));
+        Assert.assertFalse(evalBooleanExprNeq(1, 2, new Object[]{"abc", "abc"}));
+    }
+
+    @Test
+    public void testBooleanExprArrayNeq() throws Exception {
+        Integer a1[] = new Integer[]{1, 2, 3};
+        Integer a2[] = new Integer[]{1, 2, 3};
+        Integer b[] = new Integer[]{4, 5, 6};
+
+        Assert.assertTrue(evalBooleanExprNeq(9, 10, new Object[]{a1, b}));
+        Assert.assertFalse(evalBooleanExprNeq(9, 10, new Object[]{a1, a2}));
+    }
+
+    @Test
+    public void testBooleanExprMapNeq() throws Exception {
+        HashMap<Integer, Integer> a1 = new HashMap<>();
+        a1.put(1, 2);
+        HashMap<Integer, Integer> a2 = new HashMap<>(a1);
+        HashMap<Integer, Integer> b = new HashMap<>();
+        b.put(5, 6);
+
+        Assert.assertTrue(evalBooleanExprNeq(11, 12, new Object[]{a1, b}));
+        Assert.assertFalse(evalBooleanExprNeq(11, 12, new Object[]{a1, a2}));
+    }
+
+    @Test
+    public void testBooleanExprScalarLessThan() throws Exception {
+        // int32
+        Assert.assertTrue(evalBooleanExprLessThan(5, 0, new Object[]{12344, 12345L}));
+        Assert.assertFalse(evalBooleanExprLessThan(5, 0, new Object[]{12346, 12345L}));
+        // int64
+        Assert.assertTrue(evalBooleanExprLessThan(8, 5, new Object[]{12344L, 12345}));
+        Assert.assertFalse(evalBooleanExprLessThan(8, 5, new Object[]{12346L, 12345}));
+        // double
+        Assert.assertTrue(evalBooleanExprLessThan(4, 3, new Object[]{12344.0, 12345.0}));
+        Assert.assertFalse(evalBooleanExprLessThan(4, 3, new Object[]{12346.0, 12345.0}));
+    }
+
+    @Test
+    public void testBooleanExprStringLessThan() throws Exception {
+        Assert.assertTrue(evalBooleanExprLessThan(1, 2, new Object[]{"abc", "def"}));
+        Assert.assertFalse(evalBooleanExprLessThan(1, 2, new Object[]{"abc", "abc"}));
+    }
+
+    @Test
+    public void testBooleanExprScalarLessThanEq() throws Exception {
+        // int32
+        Assert.assertTrue(evalBooleanExprLessThanEq(5, 0, new Object[]{12345, 12345L}));
+        Assert.assertFalse(evalBooleanExprLessThanEq(5, 0, new Object[]{12346, 12345L}));
+        // int64
+        Assert.assertTrue(evalBooleanExprLessThanEq(8, 5, new Object[]{12345L, 12345}));
+        Assert.assertFalse(evalBooleanExprLessThanEq(8, 5, new Object[]{12346L, 12345}));
+        // double
+        Assert.assertTrue(evalBooleanExprLessThanEq(4, 3, new Object[]{12344.0, 12345.0}));
+        Assert.assertFalse(evalBooleanExprLessThanEq(4, 3, new Object[]{12346.0, 12345.0}));
+    }
+
+    @Test
+    public void testBooleanExprStringLessThanEq() throws Exception {
+        Assert.assertTrue(evalBooleanExprLessThanEq(1, 2, new Object[]{"abc", "abc"}));
+        Assert.assertFalse(evalBooleanExprLessThanEq(1, 2, new Object[]{"abc", "abb"}));
+    }
+
+    @Test
+    public void testBooleanExprScalarGreaterThan() throws Exception {
+        // int32
+        Assert.assertTrue(evalBooleanExprGreaterThan(5, 0, new Object[]{12346, 12345L}));
+        Assert.assertFalse(evalBooleanExprGreaterThan(5, 0, new Object[]{12345, 12345L}));
+        // int64
+        Assert.assertTrue(evalBooleanExprGreaterThan(8, 5, new Object[]{12346L, 12345}));
+        Assert.assertFalse(evalBooleanExprGreaterThan(8, 5, new Object[]{12345L, 12345}));
+        // double
+        Assert.assertTrue(evalBooleanExprGreaterThan(4, 3, new Object[]{12346.0, 12345.0}));
+        Assert.assertFalse(evalBooleanExprGreaterThan(4, 3, new Object[]{12344.0, 12345.0}));
+    }
+
+    @Test
+    public void testBooleanExprStringGreaterThan() throws Exception {
+        Assert.assertTrue(evalBooleanExprGreaterThan(1, 2, new Object[]{"def", "abc"}));
+        Assert.assertFalse(evalBooleanExprGreaterThan(1, 2, new Object[]{"abc", "abc"}));
+    }
+
+    @Test
+    public void testBooleanExprScalarGreaterThanEq() throws Exception {
+        // int32
+        Assert.assertTrue(evalBooleanExprGreaterThanEq(5, 0, new Object[]{12345, 12345L}));
+        Assert.assertFalse(evalBooleanExprGreaterThanEq(5, 0, new Object[]{12344, 12345L}));
+        // int64
+        Assert.assertTrue(evalBooleanExprGreaterThanEq(8, 5, new Object[]{12345L, 12345}));
+        Assert.assertFalse(evalBooleanExprGreaterThanEq(8, 5, new Object[]{12344L, 12345}));
+        // double
+        Assert.assertTrue(evalBooleanExprGreaterThanEq(4, 3, new Object[]{12346.0, 12345.0}));
+        Assert.assertFalse(evalBooleanExprGreaterThanEq(4, 3, new Object[]{12344.0, 12345.0}));
+    }
+
+    @Test
+    public void testBooleanExprStringGreaterThanEq() throws Exception {
+        Assert.assertTrue(evalBooleanExprGreaterThanEq(1, 2, new Object[]{"def", "abc"}));
+        Assert.assertFalse(evalBooleanExprGreaterThanEq(1, 2, new Object[]{"abc", "def"}));
+    }
+
     @Test
     public void testArithmaticExpr() throws Exception {
-        String simpleQuery = "SELECT col0+col3, col2, col3+10, col0*25, 12*4+2 FROM test1 WHERE col0 > 100;";
+        String simpleQuery = "SELECT col0+col3, col2, col3+10, col0*25, 12*4+2 FROM codegen_test WHERE col0 > 100;";
         Analysis analysis = analyzeQuery(simpleQuery);
 
         ExpressionMetadata expressionEvaluatorMetadata0 = codeGenRunner.buildCodeGenFromParseTree
@@ -96,9 +424,23 @@ public class CodeGenRunnerTest {
         Assert.assertTrue(((Long)result2) == 50);
     }
 
+    private Object evaluateU1DF(ExpressionMetadata expressionEvaluator, Object arg) throws Exception {
+        Object args[] = new Object[2];
+        int argsIdx = 0;
+        for (int i : expressionEvaluator.getIndexes()) {
+            if (i == -1) {
+                args[argsIdx] = expressionEvaluator.getUdfs()[argsIdx];
+            } else {
+                args[argsIdx] = arg;
+            }
+            argsIdx++;
+        }
+        return expressionEvaluator.getExpressionEvaluator().evaluate(args);
+    }
+
     @Test
     public void testU1DFExpr() throws Exception {
-        String simpleQuery = "SELECT FLOOR(col3), CEIL(col3*3), ABS(col0+1.34), RANDOM()+10, ROUND(col3*2)+12 FROM test1;";
+        String simpleQuery = "SELECT FLOOR(col3), CEIL(col3*3), ABS(col0+1.34), RANDOM()+10, ROUND(col3*2)+12 FROM codegen_test;";
         Analysis analysis = analyzeQuery(simpleQuery);
         GenericRowValueTypeEnforcer genericRowValueTypeEnforcer = new GenericRowValueTypeEnforcer(schema);
 
@@ -116,9 +458,7 @@ public class CodeGenRunnerTest {
         ExpressionMetadata expressionEvaluator1 = codeGenRunner.buildCodeGenFromParseTree(analysis
                                                                                             .getSelectExpressions().get(1));
         Object argObj1 = genericRowValueTypeEnforcer.enforceFieldType(3, 1.5);
-        Object result1 = expressionEvaluator1.getExpressionEvaluator().evaluate(new
-                                                             Object[]{expressionEvaluator1.getUdfs()
-                                                                          [0], argObj1});
+        Object result1 = evaluateU1DF(expressionEvaluator1, argObj1);
         Assert.assertTrue(argObj1 instanceof Double);
         Assert.assertTrue(result1 instanceof Double);
         Assert.assertTrue(((Double)result1) == 5.0);
@@ -127,9 +467,7 @@ public class CodeGenRunnerTest {
         ExpressionMetadata expressionEvaluator2 = codeGenRunner.buildCodeGenFromParseTree(analysis
                                                                                             .getSelectExpressions().get(2));
         Object argObj2 = genericRowValueTypeEnforcer.enforceFieldType(0, 15);
-        Object result2 = expressionEvaluator2.getExpressionEvaluator().evaluate(new
-                                                             Object[]{expressionEvaluator2.getUdfs()
-                                                                          [0], argObj2});
+        Object result2 = evaluateU1DF(expressionEvaluator2, argObj2);
         Assert.assertTrue(argObj2 instanceof Long);
         Assert.assertTrue(result2 instanceof Double);
         Assert.assertTrue(((Double)result2) == 16.34);
@@ -144,9 +482,7 @@ public class CodeGenRunnerTest {
         ExpressionMetadata expressionEvaluator4 = codeGenRunner.buildCodeGenFromParseTree(analysis
                                                                                             .getSelectExpressions().get(4));
         Object argObj4 = genericRowValueTypeEnforcer.enforceFieldType(3, 1.5);
-        Object result4 = expressionEvaluator4.getExpressionEvaluator().evaluate(new
-                                                             Object[]{expressionEvaluator4.getUdfs()
-                                                                          [0], argObj4});
+        Object result4 = evaluateU1DF(expressionEvaluator4, argObj4);
         Assert.assertTrue(argObj4 instanceof Double);
         Assert.assertTrue(result4 instanceof Long);
         Assert.assertTrue(((Long)result4) == 15);
@@ -156,7 +492,7 @@ public class CodeGenRunnerTest {
     @Test
     public void testStringUDFExpr() throws Exception {
         GenericRowValueTypeEnforcer genericRowValueTypeEnforcer = new GenericRowValueTypeEnforcer(schema);
-        String simpleQuery = "SELECT LCASE(col1), UCASE(col2), TRIM(col1), CONCAT(col1,'_test'), SUBSTRING(col1, 1, 3) FROM test1;";
+        String simpleQuery = "SELECT LCASE(col1), UCASE(col2), TRIM(col1), CONCAT(col1,'_test'), SUBSTRING(col1, 1, 3) FROM codegen_test;";
         Analysis analysis = analyzeQuery(simpleQuery);
 
 

--- a/ksql-engine/src/test/java/io/confluent/ksql/codegen/CodeGenRunnerTest.java
+++ b/ksql-engine/src/test/java/io/confluent/ksql/codegen/CodeGenRunnerTest.java
@@ -51,19 +51,19 @@ public class CodeGenRunnerTest {
     private CodeGenRunner codeGenRunner;
     private FunctionRegistry functionRegistry;
 
-    final private static int COL0_INDEX = 0;
-    final private static int COL1_INDEX = 1;
-    final private static int COL2_INDEX = 2;
-    final private static int COL3_INDEX = 3;
-    final private static int COL4_INDEX = 4;
-    final private static int COL5_INDEX = 5;
-    final private static int COL6_INDEX = 6;
-    final private static int COL7_INDEX = 7;
-    final private static int COL8_INDEX = 8;
-    final private static int COL9_INDEX = 9;
-    final private static int COL10_INDEX = 10;
-    final private static int COL11_INDEX = 11;
-    final private static int COL12_INDEX = 12;
+    final private static int INT64_INDEX1 = 0;
+    final private static int STRING_INDEX1 = 1;
+    final private static int STRING_INDEX2 = 2;
+    final private static int FLOAT64_INDEX1 = 3;
+    final private static int FLOAT64_INDEX2 = 4;
+    final private static int INT32_INDEX1 = 5;
+    final private static int BOOLEAN_INDEX1 = 6;
+    final private static int BOOLEAN_INDEX2 = 7;
+    final private static int INT64_INDEX2 = 8;
+    final private static int ARRAY_INDEX1 = 9;
+    final private static int ARRAY_INDEX2 = 10;
+    final private static int MAP_INDEX1 = 11;
+    final private static int MAP_INDEX2 = 12;
 
     @Before
     public void init() {
@@ -180,16 +180,16 @@ public class CodeGenRunnerTest {
 
     @Test
     public void testNullEquals() throws Exception {
-        assertThat(evalBooleanExprEq(COL5_INDEX, COL0_INDEX, new Object[]{null, 12344L}), is(false));
-        assertThat(evalBooleanExprEq(COL5_INDEX, COL0_INDEX, new Object[]{null, null}), is(false));
+        Assert.assertThat(evalBooleanExprEq(INT32_INDEX1, INT64_INDEX1, new Object[]{null, 12344L}), is(false));
+        Assert.assertThat(evalBooleanExprEq(INT32_INDEX1, INT64_INDEX1, new Object[]{null, null}), is(false));
     }
 
     @Test
     public void testIsDistinctFrom() throws Exception {
-        assertThat(evalBooleanExprIsDistinctFrom(COL5_INDEX, COL0_INDEX, new Object[]{12344, 12344L}), is(false));
-        assertThat(evalBooleanExprIsDistinctFrom(COL5_INDEX, COL0_INDEX, new Object[]{12345, 12344L}), is(true));
-        assertThat(evalBooleanExprIsDistinctFrom(COL5_INDEX, COL0_INDEX, new Object[]{null, 12344L}), is(true));
-        assertThat(evalBooleanExprIsDistinctFrom(COL5_INDEX, COL0_INDEX, new Object[]{null, null}), is(false));
+        Assert.assertThat(evalBooleanExprIsDistinctFrom(INT32_INDEX1, INT64_INDEX1, new Object[]{12344, 12344L}), is(false));
+        assertThat(evalBooleanExprIsDistinctFrom(INT32_INDEX1, INT64_INDEX1, new Object[]{12345, 12344L}), is(true));
+        assertThat(evalBooleanExprIsDistinctFrom(INT32_INDEX1, INT64_INDEX1, new Object[]{null, 12344L}), is(true));
+        Assert.assertThat(evalBooleanExprIsDistinctFrom(INT32_INDEX1, INT64_INDEX1, new Object[]{null, null}), is(false));
     }
 
     @Test
@@ -210,7 +210,7 @@ public class CodeGenRunnerTest {
 
         result0 = expressionEvaluatorMetadata0.getExpressionEvaluator().evaluate(new Object[]{12345L});
         assertThat(result0, instanceOf(Boolean.class));
-        assertThat((Boolean)result0, is(false));
+        Assert.assertThat((Boolean)result0, is(false));
     }
 
     @Test
@@ -227,7 +227,7 @@ public class CodeGenRunnerTest {
 
         Object result0 = expressionEvaluatorMetadata0.getExpressionEvaluator().evaluate(new Object[]{null});
         assertThat(result0, instanceOf(Boolean.class));
-        assertThat((Boolean)result0, is(false));
+        Assert.assertThat((Boolean)result0, is(false));
 
         result0 = expressionEvaluatorMetadata0.getExpressionEvaluator().evaluate(new Object[]{12345L});
         assertThat(result0, instanceOf(Boolean.class));
@@ -237,26 +237,26 @@ public class CodeGenRunnerTest {
     @Test
     public void testBooleanExprScalarEq() throws Exception {
         // int32
-        assertThat(evalBooleanExprEq(COL5_INDEX, COL0_INDEX, new Object[]{12345, 12344L}), is(false));
-        assertThat(evalBooleanExprEq(COL5_INDEX, COL0_INDEX, new Object[]{12345, 12345L}), is(true));
+        Assert.assertThat(evalBooleanExprEq(INT32_INDEX1, INT64_INDEX1, new Object[]{12345, 12344L}), is(false));
+        assertThat(evalBooleanExprEq(INT32_INDEX1, INT64_INDEX1, new Object[]{12345, 12345L}), is(true));
         // int64
-        assertThat(evalBooleanExprEq(COL8_INDEX, COL5_INDEX, new Object[]{12345L, 12344}), is(false));
-        assertThat(evalBooleanExprEq(COL8_INDEX, COL5_INDEX, new Object[]{12345L, 12345}), is(true));
+        Assert.assertThat(evalBooleanExprEq(INT64_INDEX2, INT32_INDEX1, new Object[]{12345L, 12344}), is(false));
+        assertThat(evalBooleanExprEq(INT64_INDEX2, INT32_INDEX1, new Object[]{12345L, 12345}), is(true));
         // double
-        assertThat(evalBooleanExprEq(COL4_INDEX, COL3_INDEX, new Object[]{12345.0, 12344.0}), is(false));
-        assertThat(evalBooleanExprEq(COL4_INDEX, COL3_INDEX, new Object[]{12345.0, 12345.0}), is(true));
+        Assert.assertThat(evalBooleanExprEq(FLOAT64_INDEX2, FLOAT64_INDEX1, new Object[]{12345.0, 12344.0}), is(false));
+        assertThat(evalBooleanExprEq(FLOAT64_INDEX2, FLOAT64_INDEX1, new Object[]{12345.0, 12345.0}), is(true));
     }
 
     @Test
     public void testBooleanExprBooleanEq() throws Exception {
-        assertThat(evalBooleanExprEq(COL7_INDEX, COL6_INDEX, new Object[]{false, true}), is(false));
-        assertThat(evalBooleanExprEq(COL7_INDEX, COL6_INDEX, new Object[]{true, true}), is(true));
+        Assert.assertThat(evalBooleanExprEq(BOOLEAN_INDEX2, BOOLEAN_INDEX1, new Object[]{false, true}), is(false));
+        assertThat(evalBooleanExprEq(BOOLEAN_INDEX2, BOOLEAN_INDEX1, new Object[]{true, true}), is(true));
     }
 
     @Test
     public void testBooleanExprStringEq() throws Exception {
-        assertThat(evalBooleanExprEq(COL1_INDEX, COL2_INDEX, new Object[]{"abc", "def"}), is(false));
-        assertThat(evalBooleanExprEq(COL1_INDEX, COL2_INDEX, new Object[]{"abc", "abc"}), is(true));
+        Assert.assertThat(evalBooleanExprEq(STRING_INDEX1, STRING_INDEX2, new Object[]{"abc", "def"}), is(false));
+        assertThat(evalBooleanExprEq(STRING_INDEX1, STRING_INDEX2, new Object[]{"abc", "abc"}), is(true));
     }
 
     @Test
@@ -264,7 +264,7 @@ public class CodeGenRunnerTest {
         Integer a1[] = new Integer[]{1, 2, 3};
         Integer a2[] = new Integer[]{1, 2, 3};
         try {
-            evalBooleanExprEq(COL9_INDEX, COL10_INDEX, new Object[]{a1, a2});
+            evalBooleanExprEq(ARRAY_INDEX1, ARRAY_INDEX2, new Object[]{a1, a2});
             Assert.fail("Array comparison should throw exception");
         } catch (KsqlException e) {
             assertThat(e.getMessage(), equalTo("Cannot compare ARRAY values"));
@@ -278,7 +278,7 @@ public class CodeGenRunnerTest {
         HashMap<Integer, Integer> a2 = new HashMap<>(a1);
 
         try {
-            evalBooleanExprEq(COL11_INDEX, COL12_INDEX, new Object[]{a1, a2});
+            evalBooleanExprEq(MAP_INDEX1, MAP_INDEX2, new Object[]{a1, a2});
         } catch (KsqlException e) {
             assertThat(e.getMessage(), equalTo("Cannot compare MAP values"));
         }
@@ -287,102 +287,102 @@ public class CodeGenRunnerTest {
     @Test
     public void testBooleanExprScalarNeq() throws Exception {
         // int32
-        assertThat(evalBooleanExprNeq(COL5_INDEX, COL0_INDEX, new Object[]{12345, 12344L}), is(true));
-        assertThat(evalBooleanExprNeq(COL5_INDEX, COL0_INDEX, new Object[]{12345, 12345L}), is(false));
+        assertThat(evalBooleanExprNeq(INT32_INDEX1, INT64_INDEX1, new Object[]{12345, 12344L}), is(true));
+        Assert.assertThat(evalBooleanExprNeq(INT32_INDEX1, INT64_INDEX1, new Object[]{12345, 12345L}), is(false));
         // int64
-        assertThat(evalBooleanExprNeq(COL8_INDEX, COL5_INDEX, new Object[]{12345L, 12344}), is(true));
-        assertThat(evalBooleanExprNeq(COL8_INDEX, COL5_INDEX, new Object[]{12345L, 12345}), is(false));
+        assertThat(evalBooleanExprNeq(INT64_INDEX2, INT32_INDEX1, new Object[]{12345L, 12344}), is(true));
+        Assert.assertThat(evalBooleanExprNeq(INT64_INDEX2, INT32_INDEX1, new Object[]{12345L, 12345}), is(false));
         // double
-        assertThat(evalBooleanExprNeq(COL4_INDEX, COL3_INDEX, new Object[]{12345.0, 12344.0}), is(true));
-        assertThat(evalBooleanExprNeq(COL4_INDEX, COL3_INDEX, new Object[]{12345.0, 12345.0}), is(false));
+        assertThat(evalBooleanExprNeq(FLOAT64_INDEX2, FLOAT64_INDEX1, new Object[]{12345.0, 12344.0}), is(true));
+        Assert.assertThat(evalBooleanExprNeq(FLOAT64_INDEX2, FLOAT64_INDEX1, new Object[]{12345.0, 12345.0}), is(false));
     }
 
     @Test
     public void testBooleanExprBooleanNeq() throws Exception {
-        assertThat(evalBooleanExprNeq(COL7_INDEX, COL6_INDEX, new Object[]{false, true}), is(true));
-        assertThat(evalBooleanExprNeq(COL7_INDEX, COL6_INDEX, new Object[]{true, true}), is(false));
+        assertThat(evalBooleanExprNeq(BOOLEAN_INDEX2, BOOLEAN_INDEX1, new Object[]{false, true}), is(true));
+        Assert.assertThat(evalBooleanExprNeq(BOOLEAN_INDEX2, BOOLEAN_INDEX1, new Object[]{true, true}), is(false));
     }
 
     @Test
     public void testBooleanExprStringNeq() throws Exception {
-        assertThat(evalBooleanExprNeq(COL1_INDEX, COL2_INDEX, new Object[]{"abc", "def"}), is(true));
-        assertThat(evalBooleanExprNeq(COL1_INDEX, COL2_INDEX, new Object[]{"abc", "abc"}), is(false));
+        assertThat(evalBooleanExprNeq(STRING_INDEX1, STRING_INDEX2, new Object[]{"abc", "def"}), is(true));
+        Assert.assertThat(evalBooleanExprNeq(STRING_INDEX1, STRING_INDEX2, new Object[]{"abc", "abc"}), is(false));
     }
 
     @Test
     public void testBooleanExprScalarLessThan() throws Exception {
         // int32
-        assertThat(evalBooleanExprLessThan(COL5_INDEX, COL0_INDEX, new Object[]{12344, 12345L}), is(true));
-        assertThat(evalBooleanExprLessThan(COL5_INDEX, COL0_INDEX, new Object[]{12346, 12345L}), is(false));
+        assertThat(evalBooleanExprLessThan(INT32_INDEX1, INT64_INDEX1, new Object[]{12344, 12345L}), is(true));
+        Assert.assertThat(evalBooleanExprLessThan(INT32_INDEX1, INT64_INDEX1, new Object[]{12346, 12345L}), is(false));
         // int64
-        assertThat(evalBooleanExprLessThan(COL8_INDEX, COL5_INDEX, new Object[]{12344L, 12345}), is(true));
-        assertThat(evalBooleanExprLessThan(COL8_INDEX, COL5_INDEX, new Object[]{12346L, 12345}), is(false));
+        assertThat(evalBooleanExprLessThan(INT64_INDEX2, INT32_INDEX1, new Object[]{12344L, 12345}), is(true));
+        Assert.assertThat(evalBooleanExprLessThan(INT64_INDEX2, INT32_INDEX1, new Object[]{12346L, 12345}), is(false));
         // double
-        assertThat(evalBooleanExprLessThan(COL4_INDEX, COL3_INDEX, new Object[]{12344.0, 12345.0}), is(true));
-        assertThat(evalBooleanExprLessThan(COL4_INDEX, COL3_INDEX, new Object[]{12346.0, 12345.0}), is(false));
+        assertThat(evalBooleanExprLessThan(FLOAT64_INDEX2, FLOAT64_INDEX1, new Object[]{12344.0, 12345.0}), is(true));
+        Assert.assertThat(evalBooleanExprLessThan(FLOAT64_INDEX2, FLOAT64_INDEX1, new Object[]{12346.0, 12345.0}), is(false));
     }
 
     @Test
     public void testBooleanExprStringLessThan() throws Exception {
-        assertThat(evalBooleanExprLessThan(COL1_INDEX, COL2_INDEX, new Object[]{"abc", "def"}), is(true));
-        assertThat(evalBooleanExprLessThan(COL1_INDEX, COL2_INDEX, new Object[]{"abc", "abc"}), is(false));
+        assertThat(evalBooleanExprLessThan(STRING_INDEX1, STRING_INDEX2, new Object[]{"abc", "def"}), is(true));
+        Assert.assertThat(evalBooleanExprLessThan(STRING_INDEX1, STRING_INDEX2, new Object[]{"abc", "abc"}), is(false));
     }
 
     @Test
     public void testBooleanExprScalarLessThanEq() throws Exception {
         // int32
-        assertThat(evalBooleanExprLessThanEq(COL5_INDEX, COL0_INDEX, new Object[]{12345, 12345L}), is(true));
-        assertThat(evalBooleanExprLessThanEq(COL5_INDEX, COL0_INDEX, new Object[]{12346, 12345L}), is(false));
+        assertThat(evalBooleanExprLessThanEq(INT32_INDEX1, INT64_INDEX1, new Object[]{12345, 12345L}), is(true));
+        Assert.assertThat(evalBooleanExprLessThanEq(INT32_INDEX1, INT64_INDEX1, new Object[]{12346, 12345L}), is(false));
         // int64
-        assertThat(evalBooleanExprLessThanEq(COL8_INDEX, COL5_INDEX, new Object[]{12345L, 12345}), is(true));
-        assertThat(evalBooleanExprLessThanEq(COL8_INDEX, COL5_INDEX, new Object[]{12346L, 12345}), is(false));
+        assertThat(evalBooleanExprLessThanEq(INT64_INDEX2, INT32_INDEX1, new Object[]{12345L, 12345}), is(true));
+        Assert.assertThat(evalBooleanExprLessThanEq(INT64_INDEX2, INT32_INDEX1, new Object[]{12346L, 12345}), is(false));
         // double
-        assertThat(evalBooleanExprLessThanEq(COL4_INDEX, COL3_INDEX, new Object[]{12344.0, 12345.0}), is(true));
-        assertThat(evalBooleanExprLessThanEq(COL4_INDEX, COL3_INDEX, new Object[]{12346.0, 12345.0}), is(false));
+        assertThat(evalBooleanExprLessThanEq(FLOAT64_INDEX2, FLOAT64_INDEX1, new Object[]{12344.0, 12345.0}), is(true));
+        Assert.assertThat(evalBooleanExprLessThanEq(FLOAT64_INDEX2, FLOAT64_INDEX1, new Object[]{12346.0, 12345.0}), is(false));
     }
 
     @Test
     public void testBooleanExprStringLessThanEq() throws Exception {
-        assertThat(evalBooleanExprLessThanEq(COL1_INDEX, COL2_INDEX, new Object[]{"abc", "abc"}), is(true));
-        assertThat(evalBooleanExprLessThanEq(COL1_INDEX, COL2_INDEX, new Object[]{"abc", "abb"}), is(false));
+        assertThat(evalBooleanExprLessThanEq(STRING_INDEX1, STRING_INDEX2, new Object[]{"abc", "abc"}), is(true));
+        Assert.assertThat(evalBooleanExprLessThanEq(STRING_INDEX1, STRING_INDEX2, new Object[]{"abc", "abb"}), is(false));
     }
 
     @Test
     public void testBooleanExprScalarGreaterThan() throws Exception {
         // int32
-        assertThat(evalBooleanExprGreaterThan(COL5_INDEX, COL0_INDEX, new Object[]{12346, 12345L}), is(true));
-        assertThat(evalBooleanExprGreaterThan(COL5_INDEX, COL0_INDEX, new Object[]{12345, 12345L}), is(false));
+        assertThat(evalBooleanExprGreaterThan(INT32_INDEX1, INT64_INDEX1, new Object[]{12346, 12345L}), is(true));
+        Assert.assertThat(evalBooleanExprGreaterThan(INT32_INDEX1, INT64_INDEX1, new Object[]{12345, 12345L}), is(false));
         // int64
-        assertThat(evalBooleanExprGreaterThan(COL8_INDEX, COL5_INDEX, new Object[]{12346L, 12345}), is(true));
-        assertThat(evalBooleanExprGreaterThan(COL8_INDEX, COL5_INDEX, new Object[]{12345L, 12345}), is(false));
+        assertThat(evalBooleanExprGreaterThan(INT64_INDEX2, INT32_INDEX1, new Object[]{12346L, 12345}), is(true));
+        Assert.assertThat(evalBooleanExprGreaterThan(INT64_INDEX2, INT32_INDEX1, new Object[]{12345L, 12345}), is(false));
         // double
-        assertThat(evalBooleanExprGreaterThan(COL4_INDEX, COL3_INDEX, new Object[]{12346.0, 12345.0}), is(true));
-        assertThat(evalBooleanExprGreaterThan(COL4_INDEX, COL3_INDEX, new Object[]{12344.0, 12345.0}), is(false));
+        assertThat(evalBooleanExprGreaterThan(FLOAT64_INDEX2, FLOAT64_INDEX1, new Object[]{12346.0, 12345.0}), is(true));
+        Assert.assertThat(evalBooleanExprGreaterThan(FLOAT64_INDEX2, FLOAT64_INDEX1, new Object[]{12344.0, 12345.0}), is(false));
     }
 
     @Test
     public void testBooleanExprStringGreaterThan() throws Exception {
-        assertThat(evalBooleanExprGreaterThan(COL1_INDEX, COL2_INDEX, new Object[]{"def", "abc"}), is(true));
-        assertThat(evalBooleanExprGreaterThan(COL1_INDEX, COL2_INDEX, new Object[]{"abc", "abc"}), is(false));
+        assertThat(evalBooleanExprGreaterThan(STRING_INDEX1, STRING_INDEX2, new Object[]{"def", "abc"}), is(true));
+        Assert.assertThat(evalBooleanExprGreaterThan(STRING_INDEX1, STRING_INDEX2, new Object[]{"abc", "abc"}), is(false));
     }
 
     @Test
     public void testBooleanExprScalarGreaterThanEq() throws Exception {
         // int32
-        assertThat(evalBooleanExprGreaterThanEq(COL5_INDEX, COL0_INDEX, new Object[]{12345, 12345L}), is(true));
-        assertThat(evalBooleanExprGreaterThanEq(COL5_INDEX, COL0_INDEX, new Object[]{12344, 12345L}), is(false));
+        assertThat(evalBooleanExprGreaterThanEq(INT32_INDEX1, INT64_INDEX1, new Object[]{12345, 12345L}), is(true));
+        Assert.assertThat(evalBooleanExprGreaterThanEq(INT32_INDEX1, INT64_INDEX1, new Object[]{12344, 12345L}), is(false));
         // int64
-        assertThat(evalBooleanExprGreaterThanEq(COL8_INDEX, COL5_INDEX, new Object[]{12345L, 12345}), is(true));
-        assertThat(evalBooleanExprGreaterThanEq(COL8_INDEX, COL5_INDEX, new Object[]{12344L, 12345}), is(false));
+        assertThat(evalBooleanExprGreaterThanEq(INT64_INDEX2, INT32_INDEX1, new Object[]{12345L, 12345}), is(true));
+        Assert.assertThat(evalBooleanExprGreaterThanEq(INT64_INDEX2, INT32_INDEX1, new Object[]{12344L, 12345}), is(false));
         // double
-        assertThat(evalBooleanExprGreaterThanEq(COL4_INDEX, COL3_INDEX, new Object[]{12346.0, 12345.0}), is(true));
-        assertThat(evalBooleanExprGreaterThanEq(COL4_INDEX, COL3_INDEX, new Object[]{12344.0, 12345.0}), is(false));
+        assertThat(evalBooleanExprGreaterThanEq(FLOAT64_INDEX2, FLOAT64_INDEX1, new Object[]{12346.0, 12345.0}), is(true));
+        Assert.assertThat(evalBooleanExprGreaterThanEq(FLOAT64_INDEX2, FLOAT64_INDEX1, new Object[]{12344.0, 12345.0}), is(false));
     }
 
     @Test
     public void testBooleanExprStringGreaterThanEq() throws Exception {
-        assertThat(evalBooleanExprGreaterThanEq(COL1_INDEX, COL2_INDEX, new Object[]{"def", "abc"}), is(true));
-        assertThat(evalBooleanExprGreaterThanEq(COL1_INDEX, COL2_INDEX, new Object[]{"abc", "def"}), is(false));
+        assertThat(evalBooleanExprGreaterThanEq(STRING_INDEX1, STRING_INDEX2, new Object[]{"def", "abc"}), is(true));
+        Assert.assertThat(evalBooleanExprGreaterThanEq(STRING_INDEX1, STRING_INDEX2, new Object[]{"abc", "def"}), is(false));
     }
 
     @Test

--- a/ksql-engine/src/test/java/io/confluent/ksql/codegen/CodeGenRunnerTest.java
+++ b/ksql-engine/src/test/java/io/confluent/ksql/codegen/CodeGenRunnerTest.java
@@ -180,16 +180,16 @@ public class CodeGenRunnerTest {
 
     @Test
     public void testNullEquals() throws Exception {
-        Assert.assertThat(evalBooleanExprEq(COL5_INDEX, COL0_INDEX, new Object[]{null, 12344L}), is(false));
-        Assert.assertThat(evalBooleanExprEq(COL5_INDEX, COL0_INDEX, new Object[]{null, null}), is(false));
+        assertThat(evalBooleanExprEq(COL5_INDEX, COL0_INDEX, new Object[]{null, 12344L}), is(false));
+        assertThat(evalBooleanExprEq(COL5_INDEX, COL0_INDEX, new Object[]{null, null}), is(false));
     }
 
     @Test
     public void testIsDistinctFrom() throws Exception {
-        Assert.assertThat(evalBooleanExprIsDistinctFrom(COL5_INDEX, COL0_INDEX, new Object[]{12344, 12344L}), is(false));
+        assertThat(evalBooleanExprIsDistinctFrom(COL5_INDEX, COL0_INDEX, new Object[]{12344, 12344L}), is(false));
         assertThat(evalBooleanExprIsDistinctFrom(COL5_INDEX, COL0_INDEX, new Object[]{12345, 12344L}), is(true));
         assertThat(evalBooleanExprIsDistinctFrom(COL5_INDEX, COL0_INDEX, new Object[]{null, 12344L}), is(true));
-        Assert.assertThat(evalBooleanExprIsDistinctFrom(COL5_INDEX, COL0_INDEX, new Object[]{null, null}), is(false));
+        assertThat(evalBooleanExprIsDistinctFrom(COL5_INDEX, COL0_INDEX, new Object[]{null, null}), is(false));
     }
 
     @Test
@@ -210,7 +210,7 @@ public class CodeGenRunnerTest {
 
         result0 = expressionEvaluatorMetadata0.getExpressionEvaluator().evaluate(new Object[]{12345L});
         assertThat(result0, instanceOf(Boolean.class));
-        Assert.assertThat((Boolean)result0, is(false));
+        assertThat((Boolean)result0, is(false));
     }
 
     @Test
@@ -227,7 +227,7 @@ public class CodeGenRunnerTest {
 
         Object result0 = expressionEvaluatorMetadata0.getExpressionEvaluator().evaluate(new Object[]{null});
         assertThat(result0, instanceOf(Boolean.class));
-        Assert.assertThat((Boolean)result0, is(false));
+        assertThat((Boolean)result0, is(false));
 
         result0 = expressionEvaluatorMetadata0.getExpressionEvaluator().evaluate(new Object[]{12345L});
         assertThat(result0, instanceOf(Boolean.class));
@@ -237,25 +237,25 @@ public class CodeGenRunnerTest {
     @Test
     public void testBooleanExprScalarEq() throws Exception {
         // int32
-        Assert.assertThat(evalBooleanExprEq(COL5_INDEX, COL0_INDEX, new Object[]{12345, 12344L}), is(false));
+        assertThat(evalBooleanExprEq(COL5_INDEX, COL0_INDEX, new Object[]{12345, 12344L}), is(false));
         assertThat(evalBooleanExprEq(COL5_INDEX, COL0_INDEX, new Object[]{12345, 12345L}), is(true));
         // int64
-        Assert.assertThat(evalBooleanExprEq(COL8_INDEX, COL5_INDEX, new Object[]{12345L, 12344}), is(false));
+        assertThat(evalBooleanExprEq(COL8_INDEX, COL5_INDEX, new Object[]{12345L, 12344}), is(false));
         assertThat(evalBooleanExprEq(COL8_INDEX, COL5_INDEX, new Object[]{12345L, 12345}), is(true));
         // double
-        Assert.assertThat(evalBooleanExprEq(COL4_INDEX, COL3_INDEX, new Object[]{12345.0, 12344.0}), is(false));
+        assertThat(evalBooleanExprEq(COL4_INDEX, COL3_INDEX, new Object[]{12345.0, 12344.0}), is(false));
         assertThat(evalBooleanExprEq(COL4_INDEX, COL3_INDEX, new Object[]{12345.0, 12345.0}), is(true));
     }
 
     @Test
     public void testBooleanExprBooleanEq() throws Exception {
-        Assert.assertThat(evalBooleanExprEq(COL7_INDEX, COL6_INDEX, new Object[]{false, true}), is(false));
+        assertThat(evalBooleanExprEq(COL7_INDEX, COL6_INDEX, new Object[]{false, true}), is(false));
         assertThat(evalBooleanExprEq(COL7_INDEX, COL6_INDEX, new Object[]{true, true}), is(true));
     }
 
     @Test
     public void testBooleanExprStringEq() throws Exception {
-        Assert.assertThat(evalBooleanExprEq(COL1_INDEX, COL2_INDEX, new Object[]{"abc", "def"}), is(false));
+        assertThat(evalBooleanExprEq(COL1_INDEX, COL2_INDEX, new Object[]{"abc", "def"}), is(false));
         assertThat(evalBooleanExprEq(COL1_INDEX, COL2_INDEX, new Object[]{"abc", "abc"}), is(true));
     }
 
@@ -288,101 +288,101 @@ public class CodeGenRunnerTest {
     public void testBooleanExprScalarNeq() throws Exception {
         // int32
         assertThat(evalBooleanExprNeq(COL5_INDEX, COL0_INDEX, new Object[]{12345, 12344L}), is(true));
-        Assert.assertThat(evalBooleanExprNeq(COL5_INDEX, COL0_INDEX, new Object[]{12345, 12345L}), is(false));
+        assertThat(evalBooleanExprNeq(COL5_INDEX, COL0_INDEX, new Object[]{12345, 12345L}), is(false));
         // int64
         assertThat(evalBooleanExprNeq(COL8_INDEX, COL5_INDEX, new Object[]{12345L, 12344}), is(true));
-        Assert.assertThat(evalBooleanExprNeq(COL8_INDEX, COL5_INDEX, new Object[]{12345L, 12345}), is(false));
+        assertThat(evalBooleanExprNeq(COL8_INDEX, COL5_INDEX, new Object[]{12345L, 12345}), is(false));
         // double
         assertThat(evalBooleanExprNeq(COL4_INDEX, COL3_INDEX, new Object[]{12345.0, 12344.0}), is(true));
-        Assert.assertThat(evalBooleanExprNeq(COL4_INDEX, COL3_INDEX, new Object[]{12345.0, 12345.0}), is(false));
+        assertThat(evalBooleanExprNeq(COL4_INDEX, COL3_INDEX, new Object[]{12345.0, 12345.0}), is(false));
     }
 
     @Test
     public void testBooleanExprBooleanNeq() throws Exception {
         assertThat(evalBooleanExprNeq(COL7_INDEX, COL6_INDEX, new Object[]{false, true}), is(true));
-        Assert.assertThat(evalBooleanExprNeq(COL7_INDEX, COL6_INDEX, new Object[]{true, true}), is(false));
+        assertThat(evalBooleanExprNeq(COL7_INDEX, COL6_INDEX, new Object[]{true, true}), is(false));
     }
 
     @Test
     public void testBooleanExprStringNeq() throws Exception {
         assertThat(evalBooleanExprNeq(COL1_INDEX, COL2_INDEX, new Object[]{"abc", "def"}), is(true));
-        Assert.assertThat(evalBooleanExprNeq(COL1_INDEX, COL2_INDEX, new Object[]{"abc", "abc"}), is(false));
+        assertThat(evalBooleanExprNeq(COL1_INDEX, COL2_INDEX, new Object[]{"abc", "abc"}), is(false));
     }
 
     @Test
     public void testBooleanExprScalarLessThan() throws Exception {
         // int32
         assertThat(evalBooleanExprLessThan(COL5_INDEX, COL0_INDEX, new Object[]{12344, 12345L}), is(true));
-        Assert.assertThat(evalBooleanExprLessThan(COL5_INDEX, COL0_INDEX, new Object[]{12346, 12345L}), is(false));
+        assertThat(evalBooleanExprLessThan(COL5_INDEX, COL0_INDEX, new Object[]{12346, 12345L}), is(false));
         // int64
         assertThat(evalBooleanExprLessThan(COL8_INDEX, COL5_INDEX, new Object[]{12344L, 12345}), is(true));
-        Assert.assertThat(evalBooleanExprLessThan(COL8_INDEX, COL5_INDEX, new Object[]{12346L, 12345}), is(false));
+        assertThat(evalBooleanExprLessThan(COL8_INDEX, COL5_INDEX, new Object[]{12346L, 12345}), is(false));
         // double
         assertThat(evalBooleanExprLessThan(COL4_INDEX, COL3_INDEX, new Object[]{12344.0, 12345.0}), is(true));
-        Assert.assertThat(evalBooleanExprLessThan(COL4_INDEX, COL3_INDEX, new Object[]{12346.0, 12345.0}), is(false));
+        assertThat(evalBooleanExprLessThan(COL4_INDEX, COL3_INDEX, new Object[]{12346.0, 12345.0}), is(false));
     }
 
     @Test
     public void testBooleanExprStringLessThan() throws Exception {
         assertThat(evalBooleanExprLessThan(COL1_INDEX, COL2_INDEX, new Object[]{"abc", "def"}), is(true));
-        Assert.assertThat(evalBooleanExprLessThan(COL1_INDEX, COL2_INDEX, new Object[]{"abc", "abc"}), is(false));
+        assertThat(evalBooleanExprLessThan(COL1_INDEX, COL2_INDEX, new Object[]{"abc", "abc"}), is(false));
     }
 
     @Test
     public void testBooleanExprScalarLessThanEq() throws Exception {
         // int32
         assertThat(evalBooleanExprLessThanEq(COL5_INDEX, COL0_INDEX, new Object[]{12345, 12345L}), is(true));
-        Assert.assertThat(evalBooleanExprLessThanEq(COL5_INDEX, COL0_INDEX, new Object[]{12346, 12345L}), is(false));
+        assertThat(evalBooleanExprLessThanEq(COL5_INDEX, COL0_INDEX, new Object[]{12346, 12345L}), is(false));
         // int64
         assertThat(evalBooleanExprLessThanEq(COL8_INDEX, COL5_INDEX, new Object[]{12345L, 12345}), is(true));
-        Assert.assertThat(evalBooleanExprLessThanEq(COL8_INDEX, COL5_INDEX, new Object[]{12346L, 12345}), is(false));
+        assertThat(evalBooleanExprLessThanEq(COL8_INDEX, COL5_INDEX, new Object[]{12346L, 12345}), is(false));
         // double
         assertThat(evalBooleanExprLessThanEq(COL4_INDEX, COL3_INDEX, new Object[]{12344.0, 12345.0}), is(true));
-        Assert.assertThat(evalBooleanExprLessThanEq(COL4_INDEX, COL3_INDEX, new Object[]{12346.0, 12345.0}), is(false));
+        assertThat(evalBooleanExprLessThanEq(COL4_INDEX, COL3_INDEX, new Object[]{12346.0, 12345.0}), is(false));
     }
 
     @Test
     public void testBooleanExprStringLessThanEq() throws Exception {
         assertThat(evalBooleanExprLessThanEq(COL1_INDEX, COL2_INDEX, new Object[]{"abc", "abc"}), is(true));
-        Assert.assertThat(evalBooleanExprLessThanEq(COL1_INDEX, COL2_INDEX, new Object[]{"abc", "abb"}), is(false));
+        assertThat(evalBooleanExprLessThanEq(COL1_INDEX, COL2_INDEX, new Object[]{"abc", "abb"}), is(false));
     }
 
     @Test
     public void testBooleanExprScalarGreaterThan() throws Exception {
         // int32
         assertThat(evalBooleanExprGreaterThan(COL5_INDEX, COL0_INDEX, new Object[]{12346, 12345L}), is(true));
-        Assert.assertThat(evalBooleanExprGreaterThan(COL5_INDEX, COL0_INDEX, new Object[]{12345, 12345L}), is(false));
+        assertThat(evalBooleanExprGreaterThan(COL5_INDEX, COL0_INDEX, new Object[]{12345, 12345L}), is(false));
         // int64
         assertThat(evalBooleanExprGreaterThan(COL8_INDEX, COL5_INDEX, new Object[]{12346L, 12345}), is(true));
-        Assert.assertThat(evalBooleanExprGreaterThan(COL8_INDEX, COL5_INDEX, new Object[]{12345L, 12345}), is(false));
+        assertThat(evalBooleanExprGreaterThan(COL8_INDEX, COL5_INDEX, new Object[]{12345L, 12345}), is(false));
         // double
         assertThat(evalBooleanExprGreaterThan(COL4_INDEX, COL3_INDEX, new Object[]{12346.0, 12345.0}), is(true));
-        Assert.assertThat(evalBooleanExprGreaterThan(COL4_INDEX, COL3_INDEX, new Object[]{12344.0, 12345.0}), is(false));
+        assertThat(evalBooleanExprGreaterThan(COL4_INDEX, COL3_INDEX, new Object[]{12344.0, 12345.0}), is(false));
     }
 
     @Test
     public void testBooleanExprStringGreaterThan() throws Exception {
         assertThat(evalBooleanExprGreaterThan(COL1_INDEX, COL2_INDEX, new Object[]{"def", "abc"}), is(true));
-        Assert.assertThat(evalBooleanExprGreaterThan(COL1_INDEX, COL2_INDEX, new Object[]{"abc", "abc"}), is(false));
+        assertThat(evalBooleanExprGreaterThan(COL1_INDEX, COL2_INDEX, new Object[]{"abc", "abc"}), is(false));
     }
 
     @Test
     public void testBooleanExprScalarGreaterThanEq() throws Exception {
         // int32
         assertThat(evalBooleanExprGreaterThanEq(COL5_INDEX, COL0_INDEX, new Object[]{12345, 12345L}), is(true));
-        Assert.assertThat(evalBooleanExprGreaterThanEq(COL5_INDEX, COL0_INDEX, new Object[]{12344, 12345L}), is(false));
+        assertThat(evalBooleanExprGreaterThanEq(COL5_INDEX, COL0_INDEX, new Object[]{12344, 12345L}), is(false));
         // int64
         assertThat(evalBooleanExprGreaterThanEq(COL8_INDEX, COL5_INDEX, new Object[]{12345L, 12345}), is(true));
-        Assert.assertThat(evalBooleanExprGreaterThanEq(COL8_INDEX, COL5_INDEX, new Object[]{12344L, 12345}), is(false));
+        assertThat(evalBooleanExprGreaterThanEq(COL8_INDEX, COL5_INDEX, new Object[]{12344L, 12345}), is(false));
         // double
         assertThat(evalBooleanExprGreaterThanEq(COL4_INDEX, COL3_INDEX, new Object[]{12346.0, 12345.0}), is(true));
-        Assert.assertThat(evalBooleanExprGreaterThanEq(COL4_INDEX, COL3_INDEX, new Object[]{12344.0, 12345.0}), is(false));
+        assertThat(evalBooleanExprGreaterThanEq(COL4_INDEX, COL3_INDEX, new Object[]{12344.0, 12345.0}), is(false));
     }
 
     @Test
     public void testBooleanExprStringGreaterThanEq() throws Exception {
         assertThat(evalBooleanExprGreaterThanEq(COL1_INDEX, COL2_INDEX, new Object[]{"def", "abc"}), is(true));
-        Assert.assertThat(evalBooleanExprGreaterThanEq(COL1_INDEX, COL2_INDEX, new Object[]{"abc", "def"}), is(false));
+        assertThat(evalBooleanExprGreaterThanEq(COL1_INDEX, COL2_INDEX, new Object[]{"abc", "def"}), is(false));
     }
 
     @Test

--- a/ksql-engine/src/test/java/io/confluent/ksql/codegen/CodeGenRunnerTest.java
+++ b/ksql-engine/src/test/java/io/confluent/ksql/codegen/CodeGenRunnerTest.java
@@ -28,6 +28,7 @@ import io.confluent.ksql.parser.tree.Statement;
 import io.confluent.ksql.serde.json.KsqlJsonTopicSerDe;
 import io.confluent.ksql.util.ExpressionMetadata;
 import io.confluent.ksql.util.GenericRowValueTypeEnforcer;
+import io.confluent.ksql.util.KsqlException;
 import io.confluent.ksql.util.MetaStoreFixture;
 import org.apache.kafka.connect.data.Schema;
 import org.apache.kafka.connect.data.SchemaBuilder;
@@ -38,9 +39,7 @@ import org.junit.Test;
 import java.util.HashMap;
 import java.util.List;
 
-import static org.hamcrest.CoreMatchers.anyOf;
-import static org.hamcrest.CoreMatchers.equalTo;
-import static org.hamcrest.CoreMatchers.instanceOf;
+import static org.hamcrest.CoreMatchers.*;
 import static org.hamcrest.MatcherAssert.assertThat;
 
 
@@ -51,6 +50,20 @@ public class CodeGenRunnerTest {
     private Schema schema;
     private CodeGenRunner codeGenRunner;
     private FunctionRegistry functionRegistry;
+
+    final private static int COL0_INDEX = 0;
+    final private static int COL1_INDEX = 1;
+    final private static int COL2_INDEX = 2;
+    final private static int COL3_INDEX = 3;
+    final private static int COL4_INDEX = 4;
+    final private static int COL5_INDEX = 5;
+    final private static int COL6_INDEX = 6;
+    final private static int COL7_INDEX = 7;
+    final private static int COL8_INDEX = 8;
+    final private static int COL9_INDEX = 9;
+    final private static int COL10_INDEX = 10;
+    final private static int COL11_INDEX = 11;
+    final private static int COL12_INDEX = 12;
 
     @Before
     public void init() {
@@ -119,18 +132,18 @@ public class CodeGenRunnerTest {
 
         ExpressionMetadata expressionEvaluatorMetadata0 = codeGenRunner.buildCodeGenFromParseTree
             (analysis.getSelectExpressions().get(0));
-        Assert.assertTrue(expressionEvaluatorMetadata0.getIndexes().length == 2);
+        assertThat(expressionEvaluatorMetadata0.getIndexes().length, equalTo(2));
         int idx0 = expressionEvaluatorMetadata0.getIndexes()[0];
         int idx1 = expressionEvaluatorMetadata0.getIndexes()[1];
-        Assert.assertThat(idx0, anyOf(equalTo(cola), equalTo(colb)));
-        Assert.assertThat(idx1, anyOf(equalTo(cola), equalTo(colb)));
-        Assert.assertNotEquals(idx0, idx1);
+        assertThat(idx0, anyOf(equalTo(cola), equalTo(colb)));
+        assertThat(idx1, anyOf(equalTo(cola), equalTo(colb)));
+        assertThat(idx0, not(equalTo(idx1)));
         if (idx0 == colb) {
             Object tmp = values[0];
             values[0] = values[1];
             values[1] = tmp;
         }
-        Assert.assertEquals(expressionEvaluatorMetadata0.getUdfs().length, 2);
+        assertThat(expressionEvaluatorMetadata0.getUdfs().length, equalTo(2));
         Object result0 = expressionEvaluatorMetadata0.getExpressionEvaluator().evaluate(values);
         assertThat(result0, instanceOf(Boolean.class));
         return (Boolean)result0;
@@ -167,16 +180,16 @@ public class CodeGenRunnerTest {
 
     @Test
     public void testNullEquals() throws Exception {
-        Assert.assertFalse(evalBooleanExprEq(5, 0, new Object[]{null, 12344L}));
-        Assert.assertFalse(evalBooleanExprEq(5, 0, new Object[]{null, null}));
+        Assert.assertThat(evalBooleanExprEq(COL5_INDEX, COL0_INDEX, new Object[]{null, 12344L}), is(false));
+        Assert.assertThat(evalBooleanExprEq(COL5_INDEX, COL0_INDEX, new Object[]{null, null}), is(false));
     }
 
     @Test
     public void testIsDistinctFrom() throws Exception {
-        Assert.assertFalse(evalBooleanExprIsDistinctFrom(5, 0, new Object[]{12344, 12344L}));
-        Assert.assertTrue(evalBooleanExprIsDistinctFrom(5, 0, new Object[]{12345, 12344L}));
-        Assert.assertTrue(evalBooleanExprIsDistinctFrom(5, 0, new Object[]{null, 12344L}));
-        Assert.assertFalse(evalBooleanExprIsDistinctFrom(5, 0, new Object[]{null, null}));
+        Assert.assertThat(evalBooleanExprIsDistinctFrom(COL5_INDEX, COL0_INDEX, new Object[]{12344, 12344L}), is(false));
+        assertThat(evalBooleanExprIsDistinctFrom(COL5_INDEX, COL0_INDEX, new Object[]{12345, 12344L}), is(true));
+        assertThat(evalBooleanExprIsDistinctFrom(COL5_INDEX, COL0_INDEX, new Object[]{null, 12344L}), is(true));
+        Assert.assertThat(evalBooleanExprIsDistinctFrom(COL5_INDEX, COL0_INDEX, new Object[]{null, null}), is(false));
     }
 
     @Test
@@ -186,18 +199,18 @@ public class CodeGenRunnerTest {
 
         ExpressionMetadata expressionEvaluatorMetadata0 = codeGenRunner.buildCodeGenFromParseTree
             (analysis.getSelectExpressions().get(0));
-        Assert.assertTrue(expressionEvaluatorMetadata0.getIndexes().length == 1);
+        assertThat(expressionEvaluatorMetadata0.getIndexes().length, equalTo(1));
         int idx0 = expressionEvaluatorMetadata0.getIndexes()[0];
-        Assert.assertEquals(idx0, 0);
-        Assert.assertEquals(expressionEvaluatorMetadata0.getUdfs().length, 1);
+        assertThat(idx0, equalTo(0));
+        assertThat(expressionEvaluatorMetadata0.getUdfs().length, equalTo(1));
 
         Object result0 = expressionEvaluatorMetadata0.getExpressionEvaluator().evaluate(new Object[]{null});
         assertThat(result0, instanceOf(Boolean.class));
-        Assert.assertTrue((Boolean)result0);
+        assertThat((Boolean)result0, is(true));
 
         result0 = expressionEvaluatorMetadata0.getExpressionEvaluator().evaluate(new Object[]{12345L});
         assertThat(result0, instanceOf(Boolean.class));
-        Assert.assertFalse((Boolean)result0);
+        Assert.assertThat((Boolean)result0, is(false));
     }
 
     @Test
@@ -207,188 +220,169 @@ public class CodeGenRunnerTest {
 
         ExpressionMetadata expressionEvaluatorMetadata0 = codeGenRunner.buildCodeGenFromParseTree
             (analysis.getSelectExpressions().get(0));
-        Assert.assertTrue(expressionEvaluatorMetadata0.getIndexes().length == 1);
+        assertThat(expressionEvaluatorMetadata0.getIndexes().length, equalTo(1));
         int idx0 = expressionEvaluatorMetadata0.getIndexes()[0];
-        Assert.assertEquals(idx0, 0);
-        Assert.assertEquals(expressionEvaluatorMetadata0.getUdfs().length, 1);
+        assertThat(idx0, equalTo(0));
+        assertThat(expressionEvaluatorMetadata0.getUdfs().length, equalTo(1));
 
         Object result0 = expressionEvaluatorMetadata0.getExpressionEvaluator().evaluate(new Object[]{null});
         assertThat(result0, instanceOf(Boolean.class));
-        Assert.assertFalse((Boolean)result0);
+        Assert.assertThat((Boolean)result0, is(false));
 
         result0 = expressionEvaluatorMetadata0.getExpressionEvaluator().evaluate(new Object[]{12345L});
         assertThat(result0, instanceOf(Boolean.class));
-        Assert.assertTrue((Boolean)result0);
+        assertThat((Boolean)result0, is(true));
     }
 
     @Test
     public void testBooleanExprScalarEq() throws Exception {
         // int32
-        Assert.assertFalse(evalBooleanExprEq(5, 0, new Object[]{12345, 12344L}));
-        Assert.assertTrue(evalBooleanExprEq(5, 0, new Object[]{12345, 12345L}));
+        Assert.assertThat(evalBooleanExprEq(COL5_INDEX, COL0_INDEX, new Object[]{12345, 12344L}), is(false));
+        assertThat(evalBooleanExprEq(COL5_INDEX, COL0_INDEX, new Object[]{12345, 12345L}), is(true));
         // int64
-        Assert.assertFalse(evalBooleanExprEq(8, 5, new Object[]{12345L, 12344}));
-        Assert.assertTrue(evalBooleanExprEq(8, 5, new Object[]{12345L, 12345}));
+        Assert.assertThat(evalBooleanExprEq(COL8_INDEX, COL5_INDEX, new Object[]{12345L, 12344}), is(false));
+        assertThat(evalBooleanExprEq(COL8_INDEX, COL5_INDEX, new Object[]{12345L, 12345}), is(true));
         // double
-        Assert.assertFalse(evalBooleanExprEq(4, 3, new Object[]{12345.0, 12344.0}));
-        Assert.assertTrue(evalBooleanExprEq(4, 3, new Object[]{12345.0, 12345.0}));
+        Assert.assertThat(evalBooleanExprEq(COL4_INDEX, COL3_INDEX, new Object[]{12345.0, 12344.0}), is(false));
+        assertThat(evalBooleanExprEq(COL4_INDEX, COL3_INDEX, new Object[]{12345.0, 12345.0}), is(true));
     }
 
     @Test
     public void testBooleanExprBooleanEq() throws Exception {
-        Assert.assertFalse(evalBooleanExprEq(7, 6, new Object[]{false, true}));
-        Assert.assertTrue(evalBooleanExprEq(7, 6, new Object[]{true, true}));
+        Assert.assertThat(evalBooleanExprEq(COL7_INDEX, COL6_INDEX, new Object[]{false, true}), is(false));
+        assertThat(evalBooleanExprEq(COL7_INDEX, COL6_INDEX, new Object[]{true, true}), is(true));
     }
 
     @Test
     public void testBooleanExprStringEq() throws Exception {
-        Assert.assertFalse(evalBooleanExprEq(1, 2, new Object[]{"abc", "def"}));
-        Assert.assertTrue(evalBooleanExprEq(1, 2, new Object[]{"abc", "abc"}));
+        Assert.assertThat(evalBooleanExprEq(COL1_INDEX, COL2_INDEX, new Object[]{"abc", "def"}), is(false));
+        assertThat(evalBooleanExprEq(COL1_INDEX, COL2_INDEX, new Object[]{"abc", "abc"}), is(true));
     }
 
     @Test
-    public void testBooleanExprArrayEq() throws Exception {
+    public void testBooleanExprArrayComparisonFails() throws Exception {
         Integer a1[] = new Integer[]{1, 2, 3};
         Integer a2[] = new Integer[]{1, 2, 3};
-        Integer b[] = new Integer[]{4, 5, 6};
-
-        Assert.assertFalse(evalBooleanExprEq(9, 10, new Object[]{a1, b}));
-        Assert.assertTrue(evalBooleanExprEq(9, 10, new Object[]{a1, a2}));
+        try {
+            evalBooleanExprEq(COL9_INDEX, COL10_INDEX, new Object[]{a1, a2});
+            Assert.fail("Array comparison should throw exception");
+        } catch (KsqlException e) {
+            assertThat(e.getMessage(), equalTo("Cannot compare ARRAY values"));
+        }
     }
 
     @Test
-    public void testBooleanExprMapEq() throws Exception {
+    public void testBooleanExprMapComparisonFails() throws Exception {
         HashMap<Integer, Integer> a1 = new HashMap<>();
         a1.put(1, 2);
         HashMap<Integer, Integer> a2 = new HashMap<>(a1);
-        HashMap<Integer, Integer> b = new HashMap<>();
-        b.put(5, 6);
 
-        Assert.assertFalse(evalBooleanExprEq(11, 12, new Object[]{a1, b}));
-        Assert.assertTrue(evalBooleanExprEq(11, 12, new Object[]{a1, a2}));
+        try {
+            evalBooleanExprEq(COL11_INDEX, COL12_INDEX, new Object[]{a1, a2});
+        } catch (KsqlException e) {
+            assertThat(e.getMessage(), equalTo("Cannot compare MAP values"));
+        }
     }
 
     @Test
     public void testBooleanExprScalarNeq() throws Exception {
         // int32
-        Assert.assertTrue(evalBooleanExprNeq(5, 0, new Object[]{12345, 12344L}));
-        Assert.assertFalse(evalBooleanExprNeq(5, 0, new Object[]{12345, 12345L}));
+        assertThat(evalBooleanExprNeq(COL5_INDEX, COL0_INDEX, new Object[]{12345, 12344L}), is(true));
+        Assert.assertThat(evalBooleanExprNeq(COL5_INDEX, COL0_INDEX, new Object[]{12345, 12345L}), is(false));
         // int64
-        Assert.assertTrue(evalBooleanExprNeq(8, 5, new Object[]{12345L, 12344}));
-        Assert.assertFalse(evalBooleanExprNeq(8, 5, new Object[]{12345L, 12345}));
+        assertThat(evalBooleanExprNeq(COL8_INDEX, COL5_INDEX, new Object[]{12345L, 12344}), is(true));
+        Assert.assertThat(evalBooleanExprNeq(COL8_INDEX, COL5_INDEX, new Object[]{12345L, 12345}), is(false));
         // double
-        Assert.assertTrue(evalBooleanExprNeq(4, 3, new Object[]{12345.0, 12344.0}));
-        Assert.assertFalse(evalBooleanExprNeq(4, 3, new Object[]{12345.0, 12345.0}));
+        assertThat(evalBooleanExprNeq(COL4_INDEX, COL3_INDEX, new Object[]{12345.0, 12344.0}), is(true));
+        Assert.assertThat(evalBooleanExprNeq(COL4_INDEX, COL3_INDEX, new Object[]{12345.0, 12345.0}), is(false));
     }
 
     @Test
     public void testBooleanExprBooleanNeq() throws Exception {
-        Assert.assertTrue(evalBooleanExprNeq(7, 6, new Object[]{false, true}));
-        Assert.assertFalse(evalBooleanExprNeq(7, 6, new Object[]{true, true}));
+        assertThat(evalBooleanExprNeq(COL7_INDEX, COL6_INDEX, new Object[]{false, true}), is(true));
+        Assert.assertThat(evalBooleanExprNeq(COL7_INDEX, COL6_INDEX, new Object[]{true, true}), is(false));
     }
 
     @Test
     public void testBooleanExprStringNeq() throws Exception {
-        Assert.assertTrue(evalBooleanExprNeq(1, 2, new Object[]{"abc", "def"}));
-        Assert.assertFalse(evalBooleanExprNeq(1, 2, new Object[]{"abc", "abc"}));
-    }
-
-    @Test
-    public void testBooleanExprArrayNeq() throws Exception {
-        Integer a1[] = new Integer[]{1, 2, 3};
-        Integer a2[] = new Integer[]{1, 2, 3};
-        Integer b[] = new Integer[]{4, 5, 6};
-
-        Assert.assertTrue(evalBooleanExprNeq(9, 10, new Object[]{a1, b}));
-        Assert.assertFalse(evalBooleanExprNeq(9, 10, new Object[]{a1, a2}));
-    }
-
-    @Test
-    public void testBooleanExprMapNeq() throws Exception {
-        HashMap<Integer, Integer> a1 = new HashMap<>();
-        a1.put(1, 2);
-        HashMap<Integer, Integer> a2 = new HashMap<>(a1);
-        HashMap<Integer, Integer> b = new HashMap<>();
-        b.put(5, 6);
-
-        Assert.assertTrue(evalBooleanExprNeq(11, 12, new Object[]{a1, b}));
-        Assert.assertFalse(evalBooleanExprNeq(11, 12, new Object[]{a1, a2}));
+        assertThat(evalBooleanExprNeq(COL1_INDEX, COL2_INDEX, new Object[]{"abc", "def"}), is(true));
+        Assert.assertThat(evalBooleanExprNeq(COL1_INDEX, COL2_INDEX, new Object[]{"abc", "abc"}), is(false));
     }
 
     @Test
     public void testBooleanExprScalarLessThan() throws Exception {
         // int32
-        Assert.assertTrue(evalBooleanExprLessThan(5, 0, new Object[]{12344, 12345L}));
-        Assert.assertFalse(evalBooleanExprLessThan(5, 0, new Object[]{12346, 12345L}));
+        assertThat(evalBooleanExprLessThan(COL5_INDEX, COL0_INDEX, new Object[]{12344, 12345L}), is(true));
+        Assert.assertThat(evalBooleanExprLessThan(COL5_INDEX, COL0_INDEX, new Object[]{12346, 12345L}), is(false));
         // int64
-        Assert.assertTrue(evalBooleanExprLessThan(8, 5, new Object[]{12344L, 12345}));
-        Assert.assertFalse(evalBooleanExprLessThan(8, 5, new Object[]{12346L, 12345}));
+        assertThat(evalBooleanExprLessThan(COL8_INDEX, COL5_INDEX, new Object[]{12344L, 12345}), is(true));
+        Assert.assertThat(evalBooleanExprLessThan(COL8_INDEX, COL5_INDEX, new Object[]{12346L, 12345}), is(false));
         // double
-        Assert.assertTrue(evalBooleanExprLessThan(4, 3, new Object[]{12344.0, 12345.0}));
-        Assert.assertFalse(evalBooleanExprLessThan(4, 3, new Object[]{12346.0, 12345.0}));
+        assertThat(evalBooleanExprLessThan(COL4_INDEX, COL3_INDEX, new Object[]{12344.0, 12345.0}), is(true));
+        Assert.assertThat(evalBooleanExprLessThan(COL4_INDEX, COL3_INDEX, new Object[]{12346.0, 12345.0}), is(false));
     }
 
     @Test
     public void testBooleanExprStringLessThan() throws Exception {
-        Assert.assertTrue(evalBooleanExprLessThan(1, 2, new Object[]{"abc", "def"}));
-        Assert.assertFalse(evalBooleanExprLessThan(1, 2, new Object[]{"abc", "abc"}));
+        assertThat(evalBooleanExprLessThan(COL1_INDEX, COL2_INDEX, new Object[]{"abc", "def"}), is(true));
+        Assert.assertThat(evalBooleanExprLessThan(COL1_INDEX, COL2_INDEX, new Object[]{"abc", "abc"}), is(false));
     }
 
     @Test
     public void testBooleanExprScalarLessThanEq() throws Exception {
         // int32
-        Assert.assertTrue(evalBooleanExprLessThanEq(5, 0, new Object[]{12345, 12345L}));
-        Assert.assertFalse(evalBooleanExprLessThanEq(5, 0, new Object[]{12346, 12345L}));
+        assertThat(evalBooleanExprLessThanEq(COL5_INDEX, COL0_INDEX, new Object[]{12345, 12345L}), is(true));
+        Assert.assertThat(evalBooleanExprLessThanEq(COL5_INDEX, COL0_INDEX, new Object[]{12346, 12345L}), is(false));
         // int64
-        Assert.assertTrue(evalBooleanExprLessThanEq(8, 5, new Object[]{12345L, 12345}));
-        Assert.assertFalse(evalBooleanExprLessThanEq(8, 5, new Object[]{12346L, 12345}));
+        assertThat(evalBooleanExprLessThanEq(COL8_INDEX, COL5_INDEX, new Object[]{12345L, 12345}), is(true));
+        Assert.assertThat(evalBooleanExprLessThanEq(COL8_INDEX, COL5_INDEX, new Object[]{12346L, 12345}), is(false));
         // double
-        Assert.assertTrue(evalBooleanExprLessThanEq(4, 3, new Object[]{12344.0, 12345.0}));
-        Assert.assertFalse(evalBooleanExprLessThanEq(4, 3, new Object[]{12346.0, 12345.0}));
+        assertThat(evalBooleanExprLessThanEq(COL4_INDEX, COL3_INDEX, new Object[]{12344.0, 12345.0}), is(true));
+        Assert.assertThat(evalBooleanExprLessThanEq(COL4_INDEX, COL3_INDEX, new Object[]{12346.0, 12345.0}), is(false));
     }
 
     @Test
     public void testBooleanExprStringLessThanEq() throws Exception {
-        Assert.assertTrue(evalBooleanExprLessThanEq(1, 2, new Object[]{"abc", "abc"}));
-        Assert.assertFalse(evalBooleanExprLessThanEq(1, 2, new Object[]{"abc", "abb"}));
+        assertThat(evalBooleanExprLessThanEq(COL1_INDEX, COL2_INDEX, new Object[]{"abc", "abc"}), is(true));
+        Assert.assertThat(evalBooleanExprLessThanEq(COL1_INDEX, COL2_INDEX, new Object[]{"abc", "abb"}), is(false));
     }
 
     @Test
     public void testBooleanExprScalarGreaterThan() throws Exception {
         // int32
-        Assert.assertTrue(evalBooleanExprGreaterThan(5, 0, new Object[]{12346, 12345L}));
-        Assert.assertFalse(evalBooleanExprGreaterThan(5, 0, new Object[]{12345, 12345L}));
+        assertThat(evalBooleanExprGreaterThan(COL5_INDEX, COL0_INDEX, new Object[]{12346, 12345L}), is(true));
+        Assert.assertThat(evalBooleanExprGreaterThan(COL5_INDEX, COL0_INDEX, new Object[]{12345, 12345L}), is(false));
         // int64
-        Assert.assertTrue(evalBooleanExprGreaterThan(8, 5, new Object[]{12346L, 12345}));
-        Assert.assertFalse(evalBooleanExprGreaterThan(8, 5, new Object[]{12345L, 12345}));
+        assertThat(evalBooleanExprGreaterThan(COL8_INDEX, COL5_INDEX, new Object[]{12346L, 12345}), is(true));
+        Assert.assertThat(evalBooleanExprGreaterThan(COL8_INDEX, COL5_INDEX, new Object[]{12345L, 12345}), is(false));
         // double
-        Assert.assertTrue(evalBooleanExprGreaterThan(4, 3, new Object[]{12346.0, 12345.0}));
-        Assert.assertFalse(evalBooleanExprGreaterThan(4, 3, new Object[]{12344.0, 12345.0}));
+        assertThat(evalBooleanExprGreaterThan(COL4_INDEX, COL3_INDEX, new Object[]{12346.0, 12345.0}), is(true));
+        Assert.assertThat(evalBooleanExprGreaterThan(COL4_INDEX, COL3_INDEX, new Object[]{12344.0, 12345.0}), is(false));
     }
 
     @Test
     public void testBooleanExprStringGreaterThan() throws Exception {
-        Assert.assertTrue(evalBooleanExprGreaterThan(1, 2, new Object[]{"def", "abc"}));
-        Assert.assertFalse(evalBooleanExprGreaterThan(1, 2, new Object[]{"abc", "abc"}));
+        assertThat(evalBooleanExprGreaterThan(COL1_INDEX, COL2_INDEX, new Object[]{"def", "abc"}), is(true));
+        Assert.assertThat(evalBooleanExprGreaterThan(COL1_INDEX, COL2_INDEX, new Object[]{"abc", "abc"}), is(false));
     }
 
     @Test
     public void testBooleanExprScalarGreaterThanEq() throws Exception {
         // int32
-        Assert.assertTrue(evalBooleanExprGreaterThanEq(5, 0, new Object[]{12345, 12345L}));
-        Assert.assertFalse(evalBooleanExprGreaterThanEq(5, 0, new Object[]{12344, 12345L}));
+        assertThat(evalBooleanExprGreaterThanEq(COL5_INDEX, COL0_INDEX, new Object[]{12345, 12345L}), is(true));
+        Assert.assertThat(evalBooleanExprGreaterThanEq(COL5_INDEX, COL0_INDEX, new Object[]{12344, 12345L}), is(false));
         // int64
-        Assert.assertTrue(evalBooleanExprGreaterThanEq(8, 5, new Object[]{12345L, 12345}));
-        Assert.assertFalse(evalBooleanExprGreaterThanEq(8, 5, new Object[]{12344L, 12345}));
+        assertThat(evalBooleanExprGreaterThanEq(COL8_INDEX, COL5_INDEX, new Object[]{12345L, 12345}), is(true));
+        Assert.assertThat(evalBooleanExprGreaterThanEq(COL8_INDEX, COL5_INDEX, new Object[]{12344L, 12345}), is(false));
         // double
-        Assert.assertTrue(evalBooleanExprGreaterThanEq(4, 3, new Object[]{12346.0, 12345.0}));
-        Assert.assertFalse(evalBooleanExprGreaterThanEq(4, 3, new Object[]{12344.0, 12345.0}));
+        assertThat(evalBooleanExprGreaterThanEq(COL4_INDEX, COL3_INDEX, new Object[]{12346.0, 12345.0}), is(true));
+        Assert.assertThat(evalBooleanExprGreaterThanEq(COL4_INDEX, COL3_INDEX, new Object[]{12344.0, 12345.0}), is(false));
     }
 
     @Test
     public void testBooleanExprStringGreaterThanEq() throws Exception {
-        Assert.assertTrue(evalBooleanExprGreaterThanEq(1, 2, new Object[]{"def", "abc"}));
-        Assert.assertFalse(evalBooleanExprGreaterThanEq(1, 2, new Object[]{"abc", "def"}));
+        assertThat(evalBooleanExprGreaterThanEq(COL1_INDEX, COL2_INDEX, new Object[]{"def", "abc"}), is(true));
+        Assert.assertThat(evalBooleanExprGreaterThanEq(COL1_INDEX, COL2_INDEX, new Object[]{"abc", "def"}), is(false));
     }
 
     @Test
@@ -398,30 +392,30 @@ public class CodeGenRunnerTest {
 
         ExpressionMetadata expressionEvaluatorMetadata0 = codeGenRunner.buildCodeGenFromParseTree
             (analysis.getSelectExpressions().get(0));
-        Assert.assertTrue(expressionEvaluatorMetadata0.getIndexes().length == 2);
-        Assert.assertTrue(expressionEvaluatorMetadata0.getIndexes()[0] == 3);
-        Assert.assertTrue(expressionEvaluatorMetadata0.getIndexes()[1] == 0);
-        Assert.assertTrue(expressionEvaluatorMetadata0.getUdfs().length == 2);
+        assertThat(expressionEvaluatorMetadata0.getIndexes().length, equalTo(2));
+        assertThat(expressionEvaluatorMetadata0.getIndexes()[0], equalTo(3));
+        assertThat(expressionEvaluatorMetadata0.getIndexes()[1], equalTo(0));
+        assertThat(expressionEvaluatorMetadata0.getUdfs().length, equalTo(2));
         Object result0 = expressionEvaluatorMetadata0.getExpressionEvaluator().evaluate(new Object[]{10.0, 5l});
-        Assert.assertTrue(result0 instanceof Double);
-        Assert.assertTrue(((Double)result0) == 15.0);
+        assertThat(result0, instanceOf(Double.class));
+        assertThat(((Double)result0), equalTo(15.0));
 
         ExpressionMetadata expressionEvaluatorMetadata1 = codeGenRunner.buildCodeGenFromParseTree
             (analysis.getSelectExpressions().get(3));
-        Assert.assertTrue(expressionEvaluatorMetadata1.getIndexes().length == 1);
-        Assert.assertTrue(expressionEvaluatorMetadata1.getIndexes()[0] == 0);
-        Assert.assertTrue(expressionEvaluatorMetadata1.getUdfs().length == 1);
+        assertThat(expressionEvaluatorMetadata1.getIndexes().length, equalTo(1));
+        assertThat(expressionEvaluatorMetadata1.getIndexes()[0], equalTo(0));
+        assertThat(expressionEvaluatorMetadata1.getUdfs().length, equalTo(1));
         Object result1 = expressionEvaluatorMetadata1.getExpressionEvaluator().evaluate(new Object[]{5l});
-        Assert.assertTrue(result1 instanceof Long);
-        Assert.assertTrue(((Long)result1) == 125l);
+        assertThat(result1, instanceOf(Long.class));
+        assertThat(((Long)result1), equalTo(125l));
 
         ExpressionMetadata expressionEvaluatorMetadata2 = codeGenRunner.buildCodeGenFromParseTree
             (analysis.getSelectExpressions().get(4));
-        Assert.assertTrue(expressionEvaluatorMetadata2.getIndexes().length == 0);
-        Assert.assertTrue(expressionEvaluatorMetadata2.getUdfs().length == 0);
+        assertThat(expressionEvaluatorMetadata2.getIndexes().length, equalTo(0));
+        assertThat(expressionEvaluatorMetadata2.getUdfs().length, equalTo(0));
         Object result2 = expressionEvaluatorMetadata2.getExpressionEvaluator().evaluate(new Object[]{});
-        Assert.assertTrue(result2 instanceof Long);
-        Assert.assertTrue(((Long)result2) == 50);
+        assertThat(result2, instanceOf(Long.class));
+        assertThat(((Long)result2), equalTo(50L));
     }
 
     private Object evaluateU1DF(ExpressionMetadata expressionEvaluator, Object arg) throws Exception {
@@ -451,41 +445,41 @@ public class CodeGenRunnerTest {
         Object result0 = expressionEvaluator0.getExpressionEvaluator().evaluate(new
                                                              Object[]{expressionEvaluator0.getUdfs()
                                                                           [0], argObj0});
-        Assert.assertTrue(argObj0 instanceof Double);
-        Assert.assertTrue(result0 instanceof Double);
-        Assert.assertTrue(((Double)result0) == 1.0);
+        assertThat(argObj0, instanceOf(Double.class));
+        assertThat(result0, instanceOf(Double.class));
+        assertThat(((Double)result0), equalTo(1.0));
 
         ExpressionMetadata expressionEvaluator1 = codeGenRunner.buildCodeGenFromParseTree(analysis
                                                                                             .getSelectExpressions().get(1));
         Object argObj1 = genericRowValueTypeEnforcer.enforceFieldType(3, 1.5);
         Object result1 = evaluateU1DF(expressionEvaluator1, argObj1);
-        Assert.assertTrue(argObj1 instanceof Double);
-        Assert.assertTrue(result1 instanceof Double);
-        Assert.assertTrue(((Double)result1) == 5.0);
+        assertThat(argObj1, instanceOf(Double.class));
+        assertThat(result1, instanceOf(Double.class));
+        assertThat(((Double)result1), equalTo(5.0));
 
 
         ExpressionMetadata expressionEvaluator2 = codeGenRunner.buildCodeGenFromParseTree(analysis
                                                                                             .getSelectExpressions().get(2));
         Object argObj2 = genericRowValueTypeEnforcer.enforceFieldType(0, 15);
         Object result2 = evaluateU1DF(expressionEvaluator2, argObj2);
-        Assert.assertTrue(argObj2 instanceof Long);
-        Assert.assertTrue(result2 instanceof Double);
-        Assert.assertTrue(((Double)result2) == 16.34);
+        assertThat(argObj2, instanceOf(Long.class));
+        assertThat(result2, instanceOf(Double.class));
+        assertThat(((Double)result2), equalTo(16.34));
 
         ExpressionMetadata expressionEvaluator3 = codeGenRunner.buildCodeGenFromParseTree(analysis
                                                                                             .getSelectExpressions().get(3));
         Object result3 = expressionEvaluator3.getExpressionEvaluator().evaluate(new
                                                              Object[]{expressionEvaluator3.getUdfs()[0]});
-        Assert.assertTrue(result3 instanceof Double);
-        Assert.assertTrue(((Double)result3).intValue() == 10);
+        assertThat(result3, instanceOf(Double.class));
+        assertThat(((Double)result3).intValue(), equalTo(10));
 
         ExpressionMetadata expressionEvaluator4 = codeGenRunner.buildCodeGenFromParseTree(analysis
                                                                                             .getSelectExpressions().get(4));
         Object argObj4 = genericRowValueTypeEnforcer.enforceFieldType(3, 1.5);
         Object result4 = evaluateU1DF(expressionEvaluator4, argObj4);
-        Assert.assertTrue(argObj4 instanceof Double);
-        Assert.assertTrue(result4 instanceof Long);
-        Assert.assertTrue(((Long)result4) == 15);
+        assertThat(argObj4, instanceOf(Double.class));
+        assertThat(result4, instanceOf(Long.class));
+        assertThat(((Long)result4), equalTo(15L));
 
     }
 
@@ -502,8 +496,8 @@ public class CodeGenRunnerTest {
         Object result0 = expressionEvaluator0.getExpressionEvaluator().evaluate(new
                                                              Object[]{expressionEvaluator0.getUdfs()
                                                                           [0], argObj0});
-        Assert.assertTrue(result0 instanceof String);
-        Assert.assertTrue(result0.equals("hello"));
+        assertThat(result0, instanceOf(String.class));
+        assertThat(result0, equalTo("hello"));
 
         ExpressionMetadata expressionEvaluator1 = codeGenRunner.buildCodeGenFromParseTree(analysis
                                                                                             .getSelectExpressions().get(1));
@@ -511,8 +505,8 @@ public class CodeGenRunnerTest {
         Object result1 = expressionEvaluator1.getExpressionEvaluator().evaluate(new
                                                              Object[]{expressionEvaluator1.getUdfs()
                                                                           [0], argObj1});
-        Assert.assertTrue(result1 instanceof String);
-        Assert.assertTrue(result1.equals("HELLO"));
+        assertThat(result1, instanceOf(String.class));
+        assertThat(result1, equalTo("HELLO"));
 
         ExpressionMetadata expressionEvaluator2 = codeGenRunner.buildCodeGenFromParseTree(analysis
                                                                                             .getSelectExpressions().get(2));
@@ -520,8 +514,8 @@ public class CodeGenRunnerTest {
         Object result2 = expressionEvaluator2.getExpressionEvaluator().evaluate(new
                                                              Object[]{expressionEvaluator2.getUdfs()
                                                                           [0], argObj2});
-        Assert.assertTrue(result2 instanceof String);
-        Assert.assertTrue(result2.equals("Hello"));
+        assertThat(result2, instanceOf(String.class));
+        assertThat(result2, equalTo("Hello"));
 
         ExpressionMetadata expressionEvaluator3 = codeGenRunner.buildCodeGenFromParseTree(analysis
                                                                                             .getSelectExpressions().get(3));
@@ -529,8 +523,8 @@ public class CodeGenRunnerTest {
         Object result3 = expressionEvaluator3.getExpressionEvaluator().evaluate(new
                                                              Object[]{expressionEvaluator3.getUdfs()
                                                                           [0], argObj3});
-        Assert.assertTrue(result3 instanceof String);
-        Assert.assertTrue(result3.equals("Hello_test"));
+        assertThat(result3, instanceOf(String.class));
+        assertThat(result3, equalTo("Hello_test"));
 
     }
 


### PR DESCRIPTION
* Fix some issues with comparison op codegen

Use the right operations for the various operand types:
    - For non-boolean scalars, use (<= && >=) to check for equality.
      == does a reference check rather than a value check. .equals
      requires the argument to be of the same type as the object, so
      equality comparisons between different types dont work. (e.g.
      BIGINT and INT).
    - For boolean scalars, only support == and !=. Implement using
      Boolean.compare
    - For Strings, use .equals for == and !=, and compareTo for other
      operators.
    - For array/map, only support == and != and implement using
      .equals

This patch also includes handling of null operands. The implemented
behaviour is informed by Postgres semantics for null operands. For
every operator other than IS DISTINCT FROM, return false if either
operand is null. Postgres actually returns null, but janino refuses to
accept null for a Boolean, so we return false for now. For
IS DISTINCT FROM, return true if exactly one of the operators is null,
false if they are both null, and defer to != otherwise.

* Fix some review comments + test cases