### PR TITLE
Set the default server url if CLI starts with no args

### DIFF
--- a/ksql-cli/src/main/java/io/confluent/ksql/Ksql.java
+++ b/ksql-cli/src/main/java/io/confluent/ksql/Ksql.java
@@ -35,6 +35,9 @@ import io.confluent.ksql.version.metrics.collector.KsqlModuleType;
 public class Ksql {
 
   public static void main(String[] args) throws IOException {
+    if (args.length == 0) {
+      args = new String[]{"http://localhost:8080"};
+    }
     final Options options = Options.parse(args);
     if (options == null) {
       System.exit(-1);

--- a/ksql-cli/src/main/java/io/confluent/ksql/Ksql.java
+++ b/ksql-cli/src/main/java/io/confluent/ksql/Ksql.java
@@ -35,10 +35,8 @@ import io.confluent.ksql.version.metrics.collector.KsqlModuleType;
 public class Ksql {
 
   public static void main(String[] args) throws IOException {
-    if (args.length == 0) {
-      args = new String[]{"http://localhost:8080"};
-    }
-    final Options options = Options.parse(args);
+    final Options options = args.length == 0 ? Options.parse("http://localhost:8080")
+                                             : Options.parse(args);
     if (options == null) {
       System.exit(-1);
     }


### PR DESCRIPTION
Currently we require ksql server url to be specified when starting KSQL cli. To keep the quick start and integration with confluent CLI simple this PR will use `http://localhost:8080` as the default server url when the cli is called without any args. If there is args in starting the cli the server url should be specified.  