### PR TITLE
Set old/new ratio to 1 (#826)

### DIFF
--- a/bin/ksql-run-class
+++ b/bin/ksql-run-class
@@ -86,7 +86,7 @@ fi
 
 # JVM performance options
 if [ -z "$KSQL_JVM_PERFORMANCE_OPTS" ]; then
-  KSQL_JVM_PERFORMANCE_OPTS="-server -XX:+UseParNewGC -XX:+UseConcMarkSweepGC -XX:+CMSClassUnloadingEnabled -XX:+CMSScavengeBeforeRemark -XX:+DisableExplicitGC -Djava.awt.headless=true"
+  KSQL_JVM_PERFORMANCE_OPTS="-server -XX:+UseParNewGC -XX:+UseConcMarkSweepGC -XX:+CMSClassUnloadingEnabled -XX:+CMSScavengeBeforeRemark -XX:+DisableExplicitGC -XX:NewRatio=1 -Djava.awt.headless=true"
 fi
 
 usage() {


### PR DESCRIPTION
KSQL requires a large newgen space for memory allocated and freed
as it processes each record. Use a 1:1 old-new ratio.