### PR TITLE
More optimization on TopK functions.

### DIFF
--- a/ksql-engine/src/main/java/io/confluent/ksql/function/udaf/topkdistinct/TopkDistinctKudaf.java
+++ b/ksql-engine/src/main/java/io/confluent/ksql/function/udaf/topkdistinct/TopkDistinctKudaf.java
@@ -40,9 +40,9 @@ public class TopkDistinctKudaf<T extends Comparable<? super T>>
   private final Comparator<T> comparator;
 
   @SuppressWarnings("unchecked")
-  TopkDistinctKudaf(int argIndexInValue,
-                    int tkVal,
-                    Class<T> ttClass) {
+  TopkDistinctKudaf(final int argIndexInValue,
+                    final int tkVal,
+                    final Class<T> ttClass) {
     super(argIndexInValue,
         () -> (T[]) Array.newInstance(ttClass, tkVal),
           SchemaBuilder.array(Schema.FLOAT64_SCHEMA).build(),
@@ -67,22 +67,24 @@ public class TopkDistinctKudaf<T extends Comparable<? super T>>
   }
 
   @Override
-  public T[] aggregate(T currentVal, T[] currentAggVal) {
+  public T[] aggregate(final T currentVal, final T[] currentAggVal) {
     if (currentVal == null) {
-      return currentAggVal;
-    }
-    if (ArrayUtil.containsValue(currentVal, currentAggVal)) {
-      return currentAggVal;
-    }
-    int nullIndex = ArrayUtil.getNullIndex(currentAggVal);
-    if (nullIndex != -1) {
-      currentAggVal[nullIndex] = currentVal;
-      Arrays.sort(currentAggVal, comparator);
       return currentAggVal;
     }
 
     final T last = currentAggVal[currentAggVal.length - 1];
-    if (currentVal.compareTo(last) <= 0) {
+    if (last != null && currentVal.compareTo(last) <= 0) {
+      return currentAggVal;
+    }
+
+    if (ArrayUtil.containsValue(currentVal, currentAggVal)) {
+      return currentAggVal;
+    }
+
+    final int nullIndex = ArrayUtil.getNullIndex(currentAggVal);
+    if (nullIndex != -1) {
+      currentAggVal[nullIndex] = currentVal;
+      Arrays.sort(currentAggVal, comparator);
       return currentAggVal;
     }
 
@@ -95,38 +97,35 @@ public class TopkDistinctKudaf<T extends Comparable<? super T>>
   @Override
   public Merger<String, T[]> getMerger() {
     return (aggKey, aggOne, aggTwo) -> {
+      final T[] merged = (T[]) Array.newInstance(ttClass, tkVal);
 
-      int
-          nullIndex1 =
-          ArrayUtil.getNullIndex(aggOne) == -1 ? tkVal : ArrayUtil.getNullIndex(aggOne);
-      int
-          nullIndex2 =
-          ArrayUtil.getNullIndex(aggTwo) == -1 ? tkVal : ArrayUtil.getNullIndex(aggTwo);
-      T[] tempMergeTopkArray = (T[]) Array.newInstance(ttClass, nullIndex1 + nullIndex2);
+      int idx1 = 0;
+      int idx2 = 0;
+      for (int i = 0; i != tkVal; ++i) {
+        final T v1 = idx1 < aggOne.length ? aggOne[idx1] : null;
+        final T v2 = idx2 < aggTwo.length ? aggTwo[idx2] : null;
 
-      System.arraycopy(aggOne, 0, tempMergeTopkArray, 0, nullIndex1);
-
-      int duplicateCount = 0;
-      for (int i = nullIndex1; i < nullIndex1 + nullIndex2; i++) {
-        if (ArrayUtil.containsValue(aggTwo[i - nullIndex1], aggOne)) {
-          duplicateCount++;
+        final int result = comparator.compare(v1, v2);
+        if (result < 0) {
+          merged[i] = v1;
+          idx1++;
+        } else if (result == 0) {
+          merged[i] = v1;
+          idx1++;
+          idx2++;
         } else {
-          tempMergeTopkArray[i - duplicateCount] = aggTwo[i - nullIndex1];
+          merged[i] = v2;
+          idx2++;
         }
       }
-      tempMergeTopkArray = ArrayUtil.getNoNullArray(ttClass, tempMergeTopkArray);
-      Arrays.sort(tempMergeTopkArray, comparator);
-      if (tempMergeTopkArray.length < tkVal) {
-        tempMergeTopkArray = ArrayUtil.padWithNull(ttClass, tempMergeTopkArray, tkVal);
-        return tempMergeTopkArray;
-      }
-      return Arrays.copyOf(tempMergeTopkArray, tkVal);
+
+      return merged;
     };
   }
 
   @Override
-  public KsqlAggregateFunction<T, T[]> getInstance(Map<String, Integer> expressionNames,
-                                                   List<Expression> functionArguments) {
+  public KsqlAggregateFunction<T, T[]> getInstance(final Map<String, Integer> expressionNames,
+                                                   final List<Expression> functionArguments) {
     if (functionArguments.size() != 2) {
       throw new KsqlException(String.format("Invalid parameter count. Need 2 args, got %d arg(s)"
                                             + ".", functionArguments.size()));

--- a/ksql-engine/src/main/java/io/confluent/ksql/util/ArrayUtil.java
+++ b/ksql-engine/src/main/java/io/confluent/ksql/util/ArrayUtil.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2017 Confluent Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -16,13 +16,13 @@
 
 package io.confluent.ksql.util;
 
-import java.lang.reflect.Array;
 import java.util.Arrays;
 import java.util.Objects;
 
-public class ArrayUtil {
+public final class ArrayUtil {
+  private ArrayUtil(){}
 
-  public static <T> int getNullIndex(T[] array) {
+  public static <T> int getNullIndex(final T[] array) {
     for (int i = 0; i < array.length; i++) {
       if (array[i] == null) {
         return i;
@@ -31,33 +31,7 @@ public class ArrayUtil {
     return -1;
   }
 
-  public static <T> T[] getNoNullArray(Class<T> clazz, T[] array) {
-    int nullIndex = getNullIndex(array);
-    if (nullIndex == -1) {
-      return array;
-    }
-    T[] noNullArray = (T[]) Array.newInstance(clazz, nullIndex);
-    for (int i = 0; i < noNullArray.length; i++) {
-      noNullArray[i] = array[i];
-    }
-    return noNullArray;
-  }
-
-  public static <T> T[] padWithNull(Class<T> clazz, T[] array, int finalLength) {
-    if (array.length >= finalLength) {
-      return array;
-    }
-    T[] paddedArray = (T[]) Array.newInstance(clazz, finalLength);
-    for(int i = 0; i < array.length; i++) {
-      paddedArray[i] = array[i];
-    }
-    for (int i = array.length; i < finalLength; i++) {
-      paddedArray[i] = null;
-    }
-    return paddedArray;
-  }
-
-  public static <T> boolean containsValue(T value, T[] array) {
+  public static <T> boolean containsValue(final T value, final T[] array) {
     return Arrays.stream(array).anyMatch(o -> Objects.equals(o, value));
   }
 }

--- a/ksql-engine/src/test/java/io/confluent/ksql/function/udaf/topk/StringTopkKudafTest.java
+++ b/ksql-engine/src/test/java/io/confluent/ksql/function/udaf/topk/StringTopkKudafTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2017 Confluent Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -16,7 +16,6 @@
 
 package io.confluent.ksql.function.udaf.topk;
 
-import io.confluent.ksql.function.KsqlAggregateFunction;
 import org.apache.kafka.connect.data.Schema;
 import org.junit.Before;
 import org.junit.Test;
@@ -24,13 +23,15 @@ import org.junit.Test;
 import java.util.Collections;
 import java.util.List;
 
+import io.confluent.ksql.function.KsqlAggregateFunction;
+
 import static org.hamcrest.CoreMatchers.equalTo;
 import static org.junit.Assert.assertThat;
 
 public class StringTopkKudafTest {
-  Object[] valueArray;
-  TopKAggregateFunctionFactory topKFactory;
-  List<Schema> argumentType;
+  private Object[] valueArray;
+  private TopKAggregateFunctionFactory topKFactory;
+  private List<Schema> argumentType;
 
   @Before
   public void setup() {
@@ -66,8 +67,8 @@ public class StringTopkKudafTest {
   public void shouldMergeTopK() {
     KsqlAggregateFunction<Object, Object[]> topkKudaf =
             topKFactory.getProperAggregateFunction(argumentType);
-    String[] array1 = new String[]{"123", "Hello", "paper"};
-    String[] array2 = new String[]{"Hi", "456", "Zzz"};
+    String[] array1 = new String[]{"paper", "Hello", "123"};
+    String[] array2 = new String[]{"Zzz", "Hi", "456"};
 
     assertThat("Invalid results.", topkKudaf.getMerger().apply("key", array1, array2),
             equalTo(new String[]{"paper", "Zzz", "Hi"}));

--- a/ksql-engine/src/test/java/io/confluent/ksql/function/udaf/topkdistinct/IntTopkDistinctKudafTest.java
+++ b/ksql-engine/src/test/java/io/confluent/ksql/function/udaf/topkdistinct/IntTopkDistinctKudafTest.java
@@ -134,4 +134,48 @@ public class IntTopkDistinctKudafTest {
     // Then:
     assertThat(result, is(new Object[]{83, 82, 81, 80, 73, 72, 71, 70, 63, 62, 61, 60}));
   }
+
+  @SuppressWarnings("unchecked")
+  //@Test
+  public void testAggregatePerformance() {
+    final int iterations = 1_000_000_000;
+    final int topX = 10;
+    final TopkDistinctKudaf<Integer> intTopkDistinctKudaf =
+        new TopkDistinctKudaf<>(0, topX, Integer.class);
+    final Integer[] aggregate = IntStream.range(0, topX)
+        .mapToObj(idx -> null)
+        .toArray(Integer[]::new);
+    final long start = System.currentTimeMillis();
+
+    for(int i = 0; i != iterations; ++i) {
+      intTopkDistinctKudaf.aggregate(i, aggregate);
+    }
+
+    final long took = System.currentTimeMillis() - start;
+    System.out.println(took + "ms, " + ((double)took)/iterations);
+  }
+
+  @SuppressWarnings("unchecked")
+  //@Test
+  public void testMergePerformance() {
+    final int iterations = 1_000_000_000;
+    final int topX = 10;
+    final TopkDistinctKudaf<Integer> intTopkDistinctKudaf =
+        new TopkDistinctKudaf<>(0, topX, Integer.class);
+
+    final Integer[] aggregate1 = IntStream.range(0, topX)
+        .mapToObj(v -> v % 2 == 0 ? v + 1 : v)
+        .toArray(Integer[]::new);
+    final Integer[] aggregate2 = IntStream.range(0, topX)
+        .mapToObj(v -> v % 2 == 0 ? v : v + 1)
+        .toArray(Integer[]::new);
+    final long start = System.currentTimeMillis();
+
+    for(int i = 0; i != iterations; ++i) {
+      intTopkDistinctKudaf.getMerger().apply("ignored", aggregate1, aggregate2);
+    }
+
+    final long took = System.currentTimeMillis() - start;
+    System.out.println(took + "ms, " + ((double)took)/iterations);
+  }
 }

--- a/ksql-engine/src/test/java/io/confluent/ksql/util/ArrayUtilTest.java
+++ b/ksql-engine/src/test/java/io/confluent/ksql/util/ArrayUtilTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2017 Confluent Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -35,22 +35,6 @@ public class ArrayUtilTest {
   }
 
   @Test
-  public void shouldPadWithNullCorrectly() {
-    Double[] doubles1 = new Double[]{10.0, null, null};
-    Double[] doubles2 = new Double[]{null, null, null};
-    Double[] doubles3 = new Double[]{10.0, 9.0, 8.0};
-
-    assertThat(ArrayUtil.padWithNull(Double.class, doubles1, 5), equalTo(new Double[]{10.0,
-                                                                                      null, null,
-                                                                                      null, null}));
-    assertThat(ArrayUtil.padWithNull(Double.class, doubles2, 5), equalTo(new Double[]{null, null,
-                                                                                      null, null, null}));
-    assertThat(ArrayUtil.padWithNull(Double.class, doubles3, 5), equalTo(new Double[]{10.0, 9.0, 8.0, null, null}));
-    assertThat(ArrayUtil.padWithNull(Double.class, doubles3, 2), equalTo(new Double[]{10.0, 9.0, 8.0}));
-  }
-
-
-  @Test
   public void shouldCheckArrayItemsCorrectly() {
     Double[] doubles = new Double[]{10.0, null, null};
     Long[] longs = new Long[]{10L, 35L, 70L, null};
@@ -61,6 +45,5 @@ public class ArrayUtilTest {
     Assert.assertTrue(ArrayUtil.containsValue(35L, longs));
     Assert.assertTrue(ArrayUtil.containsValue(70, integers));
     Assert.assertTrue(ArrayUtil.containsValue("hi", strings));
-
   }
 }


### PR DESCRIPTION
Fix for #880.

PR looks to:
- early out of `aggregate` even earlier.
- remove unnecessary array creation `Merger`
- reduce size of required array in `Merger`
- zip the two source arrays together, taking advantage of the fact the source topK arrays are already sorted.
- remove unused code from `ArrayUtil`

Note: This change does rely on the fact that the source arrays passing into the `Merger` are already sorted.  I assume that the `Merger` will always be passed source arrays created by itself, and so this is a safe assumption.


