### PR TITLE
Enable 'SHOW TOPICS' to work with secure kafka clusters

### DIFF
--- a/ksql-engine/src/main/java/io/confluent/ksql/util/KafkaConsumerGroupClientImpl.java
+++ b/ksql-engine/src/main/java/io/confluent/ksql/util/KafkaConsumerGroupClientImpl.java
@@ -103,15 +103,16 @@ public class KafkaConsumerGroupClientImpl implements KafkaConsumerGroupClient {
             Arrays.asList(PosixFilePermission.OWNER_WRITE,
                           PosixFilePermission.OWNER_READ)));
     File configFile = Files.createTempFile("ksqlclient", "properties", attributes).toFile();
-    FileOutputStream outputStream = new FileOutputStream(configFile);
-    Properties clientProps = new Properties();
-    for (Map.Entry<String, Object> property
-        : configProps.entrySet()) {
-      clientProps.put(property.getKey(), property.getValue());
-    }
-    clientProps.store(outputStream, "Configuration properties of KSQL AdminClient");
-    outputStream.close();
     configFile.deleteOnExit();
+
+    try(FileOutputStream outputStream = new FileOutputStream(configFile)) {
+      Properties clientProps = new Properties();
+      for (Map.Entry<String, Object> property
+          : configProps.entrySet()) {
+        clientProps.put(property.getKey(), property.getValue());
+      }
+      clientProps.store(outputStream, "Configuration properties of KSQL AdminClient");
+    }
     return configFile;
   }
 


### PR DESCRIPTION
Fixes #740 

The `ConsumerGroupCommand` which we use to list groups instantiates its own admin client instance. The only way to configure this instance is to pass the configurations through a file.

This patch creates a temporary file, dumps the admin client properties to it, and then passes this file as an argument to the consumer group command.

I tested that this actually works against a secure cluster. Not sure what tests to add as part of this patch. Unit tests would require extensive mocking, which seems to be low ROI given that the use of the `ConsumerGroupCommand` itself is on the deprecation path. See #642 .

I am open to creative suggestions for low cost testing of this change.