### PR TITLE
DoubleMaxKudaf doesn't work correctly

### DIFF
--- a/ksql-engine/src/main/java/io/confluent/ksql/function/udaf/max/DoubleMaxKudaf.java
+++ b/ksql-engine/src/main/java/io/confluent/ksql/function/udaf/max/DoubleMaxKudaf.java
@@ -29,7 +29,7 @@ import io.confluent.ksql.parser.tree.Expression;
 public class DoubleMaxKudaf extends KsqlAggregateFunction<Double, Double> {
 
   DoubleMaxKudaf(int argIndexInValue) {
-    super(argIndexInValue, () -> -Double.MAX_VALUE, Schema.FLOAT64_SCHEMA,
+    super(argIndexInValue, () -> Double.NEGATIVE_INFINITY, Schema.FLOAT64_SCHEMA,
           Collections.singletonList(Schema.FLOAT64_SCHEMA)
     );
   }

--- a/ksql-engine/src/main/java/io/confluent/ksql/function/udaf/max/DoubleMaxKudaf.java
+++ b/ksql-engine/src/main/java/io/confluent/ksql/function/udaf/max/DoubleMaxKudaf.java
@@ -29,7 +29,7 @@ import io.confluent.ksql.parser.tree.Expression;
 public class DoubleMaxKudaf extends KsqlAggregateFunction<Double, Double> {
 
   DoubleMaxKudaf(int argIndexInValue) {
-    super(argIndexInValue, () -> Double.MIN_VALUE, Schema.FLOAT64_SCHEMA,
+    super(argIndexInValue, () -> -Double.MAX_VALUE, Schema.FLOAT64_SCHEMA,
           Collections.singletonList(Schema.FLOAT64_SCHEMA)
     );
   }

--- a/ksql-engine/src/test/resources/query-validation-tests.json
+++ b/ksql-engine/src/test/resources/query-validation-tests.json
@@ -379,8 +379,14 @@
         {
           "topic": "test_topic",
           "key": 0,
-          "value": "0,100,0.0",
+          "value": "0,100,-Infinity",
           "timestamp": 0
+        },
+        {
+            "topic": "test_topic",
+            "key": 0,
+            "value": "0,100,0.0",
+            "timestamp": 0
         },
         {
           "topic": "test_topic",
@@ -420,6 +426,12 @@
         }
       ],
       "outputs": [
+        {
+          "topic": "S2",
+          "key": 0,
+          "value": "0,-Infinity",
+          "timestamp": 0
+        },
         {
           "topic": "S2",
           "key": 0,

--- a/ksql-engine/src/test/resources/query-validation-tests.json
+++ b/ksql-engine/src/test/resources/query-validation-tests.json
@@ -368,6 +368,32 @@
       "outputs": [
         {"topic": "REPARTITIONED", "key": "zero", "value": "0,zero,50", "timestamp": 0}
       ]
+    },
+    {
+      "name": "max double group by",
+      "statements": [
+        "CREATE STREAM TEST (ID bigint, NAME varchar, VALUE double) WITH (kafka_topic='test_topic', value_format='DELIMITED', key='ID');",
+        "CREATE TABLE S2 as SELECT id, max(value) FROM test group by id;"
+      ],
+      "inputs": [
+        {"topic": "test_topic", "key": 0, "value": "0,100,0.0", "timestamp": 0},
+        {"topic": "test_topic", "key": 0, "value": "0,100,5.1", "timestamp": 0},
+        {"topic": "test_topic", "key": 100, "value": "100,100,100.1", "timestamp": 0},
+        {"topic": "test_topic", "key": 100, "value": "100,100,6.4", "timestamp": 0},
+        {"topic": "test_topic", "key": 100, "value": "100,100,300.8", "timestamp": 0},
+        {"topic": "test_topic", "key": 0, "value": "0,zero,2000.99", "timestamp": 0},
+        {"topic": "test_topic", "key": 0, "value": "0,100,100.11", "timestamp": 0}
+
+      ],
+      "outputs": [
+        {"topic": "S2", "key": 0, "value": "0,0.0", "timestamp": 0},
+        {"topic": "S2", "key": 0, "value": "0,5.1", "timestamp": 0},
+        {"topic": "S2", "key": 100, "value": "100,100.1", "timestamp": 0},
+        {"topic": "S2", "key": 100, "value": "100,100.1", "timestamp": 0},
+        {"topic": "S2", "key": 100, "value": "100,300.8", "timestamp": 0},
+        {"topic": "S2", "key": 0, "value": "0,2000.99", "timestamp": 0},
+        {"topic": "S2", "key": 0, "value": "0,2000.99", "timestamp": 0}
+      ]
     }
   ]
 


### PR DESCRIPTION
It uses `Double.MIN_VALUE` as the inital value. This is a positive number so doesn't behave as anticipated.

Fixes #908 