### PR TITLE
Ksql 919 assert correct conversion in string time udfs

### DIFF
--- a/ksql-engine/src/test/java/io/confluent/ksql/function/udf/datetime/StringToTimestampTest.java
+++ b/ksql-engine/src/test/java/io/confluent/ksql/function/udf/datetime/StringToTimestampTest.java
@@ -93,8 +93,7 @@ public class StringToTimestampTest {
           try {
             shouldCovertStringToTimestamp();
           } catch (ParseException e) {
-            e.printStackTrace();
-            Assert.fail();
+            Assert.fail(e.getMessage());
           }
           udf.evaluate("1988-01-12 10:12:13.456", "yyyy-MM-dd HH:mm:ss.SSS");
         });

--- a/ksql-engine/src/test/java/io/confluent/ksql/function/udf/datetime/StringToTimestampTest.java
+++ b/ksql-engine/src/test/java/io/confluent/ksql/function/udf/datetime/StringToTimestampTest.java
@@ -16,9 +16,11 @@
 
 package io.confluent.ksql.function.udf.datetime;
 
+import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
 
+import java.text.ParseException;
 import java.text.SimpleDateFormat;
 import java.util.stream.IntStream;
 
@@ -37,21 +39,25 @@ public class StringToTimestampTest {
   }
 
   @Test
-  public void shouldCovertStringToTimestamp() {
+  public void shouldCovertStringToTimestamp() throws ParseException {
     // When:
     final Object result = udf.evaluate("2021-12-01 12:10:11.123", "yyyy-MM-dd HH:mm:ss.SSS");
 
     // Then:
-    assertThat(result, is(1638360611123L));
+    long expectedResult = new SimpleDateFormat("yyyy-MM-dd HH:mm:ss.SSS")
+        .parse("2021-12-01 12:10:11.123").getTime();
+    assertThat(result, is(expectedResult));
   }
 
   @Test
-  public void shouldSupportEmbeddedChars() {
+  public void shouldSupportEmbeddedChars() throws ParseException {
     // When:
     final Object result = udf.evaluate("2021-12-01T12:10:11.123Fred", "yyyy-MM-dd'T'HH:mm:ss.SSS'Fred'");
 
     // Then:
-    assertThat(result, is(1638360611123L));
+    long expectedResult = new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss.SSS'Fred'")
+        .parse("2021-12-01T12:10:11.123Fred").getTime();
+    assertThat(result, is(expectedResult));
   }
 
   @Test(expected = KsqlFunctionException.class)
@@ -84,7 +90,12 @@ public class StringToTimestampTest {
     IntStream.range(0, 10_000)
         .parallel()
         .forEach(idx -> {
-          shouldCovertStringToTimestamp();
+          try {
+            shouldCovertStringToTimestamp();
+          } catch (ParseException e) {
+            e.printStackTrace();
+            Assert.fail();
+          }
           udf.evaluate("1988-01-12 10:12:13.456", "yyyy-MM-dd HH:mm:ss.SSS");
         });
   }

--- a/ksql-engine/src/test/java/io/confluent/ksql/function/udf/datetime/TimestampToStringTest.java
+++ b/ksql-engine/src/test/java/io/confluent/ksql/function/udf/datetime/TimestampToStringTest.java
@@ -20,6 +20,7 @@ import org.junit.Before;
 import org.junit.Test;
 
 import java.text.SimpleDateFormat;
+import java.util.Date;
 import java.util.stream.IntStream;
 
 import io.confluent.ksql.function.KsqlFunctionException;
@@ -42,7 +43,9 @@ public class TimestampToStringTest {
     final Object result = udf.evaluate(1638360611123L, "yyyy-MM-dd HH:mm:ss.SSS");
 
     // Then:
-    assertThat(result, is("2021-12-01 12:10:11.123"));
+    String expectedResult = new SimpleDateFormat("yyyy-MM-dd HH:mm:ss.SSS")
+        .format(new Date(1638360611123L));
+    assertThat(result, is(expectedResult));
   }
 
   @Test
@@ -51,7 +54,9 @@ public class TimestampToStringTest {
     final Object result = udf.evaluate(1638360611123L, "yyyy-MM-dd'T'HH:mm:ss.SSS'Fred'");
 
     // Then:
-    assertThat(result, is("2021-12-01T12:10:11.123Fred"));
+    String expectedResult = new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss.SSS'Fred'")
+        .format(new Date(1638360611123L));
+    assertThat(result, is(expectedResult));
   }
 
   @Test(expected = KsqlFunctionException.class)


### PR DESCRIPTION
Use the local time to assert test correctness, otherwise, tests will fail because of using UTC.
This fixes #919 