### PR TITLE
Fix integration test annotations and remove maven-surefire-plugin overrides

### DIFF
--- a/ksql-cli/src/test/java/io/confluent/ksql/CliTest.java
+++ b/ksql-cli/src/test/java/io/confluent/ksql/CliTest.java
@@ -16,6 +16,7 @@
 
 package io.confluent.ksql;
 
+import io.confluent.common.utils.IntegrationTest;
 import io.confluent.ksql.cli.Cli;
 import io.confluent.ksql.cli.console.OutputFormat;
 import io.confluent.ksql.errors.LogMetricAndContinueExceptionHandler;
@@ -37,6 +38,7 @@ import org.junit.AfterClass;
 import org.junit.BeforeClass;
 import org.junit.ClassRule;
 import org.junit.Test;
+import org.junit.experimental.categories.Category;
 
 import java.util.*;
 
@@ -50,6 +52,7 @@ import static org.hamcrest.MatcherAssert.assertThat;
 /**
  * Most tests in CliTest are end-to-end integration tests, so it may expect a long running time.
  */
+@Category({IntegrationTest.class})
 public class CliTest extends TestRunner {
 
   @ClassRule

--- a/ksql-common/pom.xml
+++ b/ksql-common/pom.xml
@@ -64,15 +64,6 @@
         <plugins>
 
             <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-surefire-plugin</artifactId>
-                <configuration>
-                    <forkCount>1</forkCount>
-                    <reuseForks>false</reuseForks>
-                </configuration>
-            </plugin>
-
-            <plugin>
                 <groupId>net.alchim31.maven</groupId>
                 <artifactId>scala-maven-plugin</artifactId>
                 <version>3.2.1</version>

--- a/ksql-common/src/main/java/io/confluent/ksql/metrics/MetricCollectors.java
+++ b/ksql-common/src/main/java/io/confluent/ksql/metrics/MetricCollectors.java
@@ -40,7 +40,7 @@ import io.confluent.common.utils.Time;
 public class MetricCollectors {
 
 
-  private static final Map<String, MetricCollector> collectorMap = new ConcurrentHashMap<>();
+  private static Map<String, MetricCollector> collectorMap;
   private static Metrics metrics;
 
   static {
@@ -61,7 +61,13 @@ public class MetricCollectors {
         );
     List<MetricsReporter> reporters = new ArrayList<>();
     reporters.add(new JmxReporter("io.confluent.ksql.metrics"));
+    // Replace all static contents other than Time to ensure they are cleaned for tests that are
+    // not aware of the need to initialize/cleanup this test, in case test processes are reused.
+    // Tests aware of the class clean everything up properly to get the state into a clean state,
+    // a full, fresh instantiation here ensures something like KsqlEngineMetricsTest running after
+    // another test that used MetricsCollector without running cleanUp will behave correctly.
     metrics = new Metrics(metricConfig, reporters, new SystemTime());
+    collectorMap = new ConcurrentHashMap<>();
   }
 
   // visible for testing.

--- a/ksql-engine/pom.xml
+++ b/ksql-engine/pom.xml
@@ -159,15 +159,6 @@
             </plugin>
 
             <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-surefire-plugin</artifactId>
-                <configuration>
-                    <forkCount>1</forkCount>
-                    <reuseForks>false</reuseForks>
-                </configuration>
-            </plugin>
-
-            <plugin>
                 <groupId>net.alchim31.maven</groupId>
                 <artifactId>scala-maven-plugin</artifactId>
                 <version>3.2.1</version>

--- a/ksql-engine/src/test/java/io/confluent/ksql/integration/EndToEndIntegrationTest.java
+++ b/ksql-engine/src/test/java/io/confluent/ksql/integration/EndToEndIntegrationTest.java
@@ -15,6 +15,7 @@
  **/
 package io.confluent.ksql.integration;
 
+import io.confluent.common.utils.IntegrationTest;
 import io.confluent.ksql.GenericRow;
 import io.confluent.ksql.KsqlEngine;
 import io.confluent.ksql.util.KafkaTopicClient;
@@ -29,7 +30,6 @@ import org.apache.kafka.clients.admin.AdminClient;
 import org.apache.kafka.clients.consumer.ConsumerConfig;
 import org.apache.kafka.common.utils.Utils;
 import org.apache.kafka.streams.KeyValue;
-import org.apache.kafka.test.IntegrationTest;
 import org.apache.kafka.test.TestUtils;
 import org.junit.After;
 import org.junit.Before;

--- a/ksql-engine/src/test/java/io/confluent/ksql/integration/JoinIntTest.java
+++ b/ksql-engine/src/test/java/io/confluent/ksql/integration/JoinIntTest.java
@@ -1,5 +1,6 @@
 package io.confluent.ksql.integration;
 
+import io.confluent.common.utils.IntegrationTest;
 import io.confluent.ksql.GenericRow;
 import io.confluent.ksql.KsqlContext;
 import io.confluent.ksql.serde.DataSource;
@@ -12,7 +13,6 @@ import org.apache.kafka.clients.producer.RecordMetadata;
 import org.apache.kafka.common.serialization.StringDeserializer;
 import org.apache.kafka.connect.data.Schema;
 import org.apache.kafka.streams.StreamsConfig;
-import org.apache.kafka.test.IntegrationTest;
 import org.apache.kafka.test.TestUtils;
 import org.junit.After;
 import org.junit.Before;

--- a/ksql-engine/src/test/java/io/confluent/ksql/integration/JsonFormatTest.java
+++ b/ksql-engine/src/test/java/io/confluent/ksql/integration/JsonFormatTest.java
@@ -30,6 +30,7 @@ import org.junit.Assert;
 import org.junit.Before;
 import org.junit.ClassRule;
 import org.junit.Test;
+import org.junit.experimental.categories.Category;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -38,6 +39,7 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
 
+import io.confluent.common.utils.IntegrationTest;
 import io.confluent.ksql.GenericRow;
 import io.confluent.ksql.KsqlEngine;
 import io.confluent.ksql.metastore.MetaStore;
@@ -55,6 +57,7 @@ import io.confluent.ksql.util.TopicProducer;
 import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.MatcherAssert.assertThat;
 
+@Category({IntegrationTest.class})
 public class JsonFormatTest {
 
   private MetaStore metaStore;

--- a/ksql-engine/src/test/java/io/confluent/ksql/integration/StreamsSelectAndProjectIntTest.java
+++ b/ksql-engine/src/test/java/io/confluent/ksql/integration/StreamsSelectAndProjectIntTest.java
@@ -1,5 +1,6 @@
 package io.confluent.ksql.integration;
 
+import io.confluent.common.utils.IntegrationTest;
 import io.confluent.ksql.GenericRow;
 import io.confluent.ksql.KsqlContext;
 import io.confluent.ksql.serde.DataSource;
@@ -7,7 +8,6 @@ import io.confluent.ksql.util.OrderDataProvider;
 import org.apache.kafka.clients.producer.RecordMetadata;
 import org.apache.kafka.common.serialization.StringDeserializer;
 import org.apache.kafka.connect.data.Schema;
-import org.apache.kafka.test.IntegrationTest;
 import org.hamcrest.core.IsCollectionContaining;
 import org.junit.After;
 import org.junit.Assert;

--- a/ksql-engine/src/test/java/io/confluent/ksql/integration/UdfIntTest.java
+++ b/ksql-engine/src/test/java/io/confluent/ksql/integration/UdfIntTest.java
@@ -1,5 +1,6 @@
 package io.confluent.ksql.integration;
 
+import io.confluent.common.utils.IntegrationTest;
 import io.confluent.ksql.GenericRow;
 import io.confluent.ksql.KsqlContext;
 import io.confluent.ksql.serde.DataSource;
@@ -9,7 +10,6 @@ import io.confluent.ksql.util.SchemaUtil;
 import org.apache.kafka.clients.producer.RecordMetadata;
 import org.apache.kafka.common.serialization.StringDeserializer;
 import org.apache.kafka.connect.data.Schema;
-import org.apache.kafka.test.IntegrationTest;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;

--- a/ksql-engine/src/test/java/io/confluent/ksql/integration/WindowingIntTest.java
+++ b/ksql-engine/src/test/java/io/confluent/ksql/integration/WindowingIntTest.java
@@ -6,7 +6,6 @@ import org.apache.kafka.common.serialization.StringDeserializer;
 import org.apache.kafka.connect.data.Schema;
 import org.apache.kafka.streams.kstream.TimeWindowedDeserializer;
 import org.apache.kafka.streams.kstream.Windowed;
-import org.apache.kafka.test.IntegrationTest;
 import org.apache.kafka.test.TestUtils;
 import org.junit.After;
 import org.junit.Before;
@@ -19,6 +18,7 @@ import java.util.HashMap;
 import java.util.Map;
 import java.util.Set;
 
+import io.confluent.common.utils.IntegrationTest;
 import io.confluent.ksql.GenericRow;
 import io.confluent.ksql.KsqlContext;
 import io.confluent.ksql.util.KafkaTopicClient;

--- a/ksql-metastore/pom.xml
+++ b/ksql-metastore/pom.xml
@@ -39,15 +39,6 @@
     <build>
         <plugins>
             <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-surefire-plugin</artifactId>
-                <configuration>
-                    <forkCount>1</forkCount>
-                    <reuseForks>false</reuseForks>
-                </configuration>
-            </plugin>
-
-            <plugin>
                 <groupId>net.alchim31.maven</groupId>
                 <artifactId>scala-maven-plugin</artifactId>
                 <version>3.2.1</version>

--- a/ksql-parser/pom.xml
+++ b/ksql-parser/pom.xml
@@ -76,15 +76,6 @@
             </plugin>
 
             <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-surefire-plugin</artifactId>
-                <configuration>
-                    <forkCount>1</forkCount>
-                    <reuseForks>false</reuseForks>
-                </configuration>
-            </plugin>
-
-            <plugin>
                 <groupId>net.alchim31.maven</groupId>
                 <artifactId>scala-maven-plugin</artifactId>
                 <version>3.2.1</version>

--- a/ksql-serde/pom.xml
+++ b/ksql-serde/pom.xml
@@ -58,15 +58,6 @@
     <build>
         <plugins>
             <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-surefire-plugin</artifactId>
-                <configuration>
-                    <forkCount>1</forkCount>
-                    <reuseForks>false</reuseForks>
-                </configuration>
-            </plugin>
-
-            <plugin>
                 <groupId>net.alchim31.maven</groupId>
                 <artifactId>scala-maven-plugin</artifactId>
                 <version>3.2.1</version>


### PR DESCRIPTION
This includes one minor fix to the MetricsCollector to make it correctly
robust to reuse across tests that are both aware of its initialization/cleanup
and those that are not.