### PR TITLE
Use the default state store name for windowed aggregates

### DIFF
--- a/ksql-engine/src/main/java/io/confluent/ksql/planner/plan/AggregateNode.java
+++ b/ksql-engine/src/main/java/io/confluent/ksql/planner/plan/AggregateNode.java
@@ -242,7 +242,7 @@ public class AggregateNode extends PlanNode {
             ),
             aggValToValColumnMap
         ), getWindowExpression(),
-        aggValueGenericRowSerde, "KSQL_Agg_Query_" + System.currentTimeMillis()
+        aggValueGenericRowSerde
     );
 
     SchemaKTable result = new SchemaKTable(

--- a/ksql-engine/src/main/java/io/confluent/ksql/structured/SchemaKGroupedStream.java
+++ b/ksql-engine/src/main/java/io/confluent/ksql/structured/SchemaKGroupedStream.java
@@ -69,15 +69,12 @@ public class SchemaKGroupedStream {
       final Initializer initializer,
       final UdafAggregator aggregator,
       final WindowExpression windowExpression,
-      final Serde<GenericRow> topicValueSerDe,
-      final String storeName
-  ) {
+      final Serde<GenericRow> topicValueSerDe) {
     final KTable aggKtable;
     if (windowExpression != null) {
       final Materialized<String, GenericRow, ?> materialized
-          = Materialized.<String, GenericRow, WindowStore<Bytes, byte[]>>as(storeName)
-          .withKeySerde(Serdes.String())
-          .withValueSerde(topicValueSerDe);
+          = Materialized.<String, GenericRow, WindowStore<Bytes, byte[]>>with(
+              Serdes.String(), topicValueSerDe);
 
       final KsqlWindowExpression ksqlWindowExpression = windowExpression.getKsqlWindowExpression();
       aggKtable = ksqlWindowExpression.applyAggregate(

--- a/ksql-engine/src/main/java/io/confluent/ksql/util/KafkaTopicClientImpl.java
+++ b/ksql-engine/src/main/java/io/confluent/ksql/util/KafkaTopicClientImpl.java
@@ -208,7 +208,7 @@ public class KafkaTopicClientImpl implements KafkaTopicClient {
     } catch (InterruptedException | ExecutionException ex) {
       log.error("Failed to initialize TopicClient: {}", ex.getMessage());
       throw new KsqlException("Could not fetch broker information. KSQL cannot initialize "
-                              + "AdminClient.");
+                              + "AdminClient.", ex);
     }
   }
 

--- a/ksql-engine/src/test/java/io/confluent/ksql/planner/plan/AggregateNodeTest.java
+++ b/ksql-engine/src/test/java/io/confluent/ksql/planner/plan/AggregateNodeTest.java
@@ -81,19 +81,19 @@ public class AggregateNodeTest {
   @Test
   public void shouldHaveSourceNodeForSecondSubtopolgy() {
     buildRequireRekey();
-    final TopologyDescription.Source node = (TopologyDescription.Source) getNodeByName(builder.build(), "KSTREAM-SOURCE-0000000008");
+    final TopologyDescription.Source node = (TopologyDescription.Source) getNodeByName(builder.build(), "KSTREAM-SOURCE-0000000009");
     final List<String> successors = node.successors().stream().map(TopologyDescription.Node::name).collect(Collectors.toList());
     assertThat(node.predecessors(), equalTo(Collections.emptySet()));
-    assertThat(successors, equalTo(Collections.singletonList("KSTREAM-AGGREGATE-0000000005")));
-    assertThat(node.topics(), containsString("[KSQL_Agg_Query_"));
+    assertThat(successors, equalTo(Collections.singletonList("KSTREAM-AGGREGATE-0000000006")));
+    assertThat(node.topics(), containsString("[KSTREAM-AGGREGATE-STATE-STORE-0000000005"));
     assertThat(node.topics(), containsString("-repartition]"));
   }
 
   @Test
   public void shouldHaveSinkNodeWithSameTopicAsSecondSource() {
     buildRequireRekey();
-    TopologyDescription.Sink sink = (TopologyDescription.Sink) getNodeByName(builder.build(), "KSTREAM-SINK-0000000006");
-    final TopologyDescription.Source source = (TopologyDescription.Source) getNodeByName(builder.build(), "KSTREAM-SOURCE-0000000008");
+    TopologyDescription.Sink sink = (TopologyDescription.Sink) getNodeByName(builder.build(), "KSTREAM-SINK-0000000007");
+    final TopologyDescription.Source source = (TopologyDescription.Source) getNodeByName(builder.build(), "KSTREAM-SOURCE-0000000009");
     assertThat(sink.successors(), equalTo(Collections.emptySet()));
     assertThat("[" + sink.topic() + "]", equalTo(source.topics()));
   }


### PR DESCRIPTION
Have streams choose a state store name for windowed aggregates, instead of providing
a name with a timestamp. This ensures that each KSQL server will pick the same name.

Sneak in a change to pass the causing AdminClient exception when throwing KsqlException
from KafkaTopiClient