### PR TITLE
Bump timeout for CliTest

### DIFF
--- a/ksql-cli/src/test/java/io/confluent/ksql/TestRunner.java
+++ b/ksql-cli/src/test/java/io/confluent/ksql/TestRunner.java
@@ -61,7 +61,7 @@ public abstract class TestRunner {
         finalResults.clear();
         finalResults.addAll(actualResult.data);
         return actualResult.data.containsAll(expectedResult.data);
-      }, 10000, "Did not get the expected result '" + expectedResult + ", in a timely fashion.");
+      }, 30000, "Did not get the expected result '" + expectedResult + ", in a timely fashion.");
     } catch (AssertionError e) {
       throw new AssertionError(
           "CLI test runner command result mismatch expected: " + expectedResult + ", actual: " + finalResults, e);


### PR DESCRIPTION
Both the `CliTest.testSelectLimit` and `CliTest.testSelectStar` fail occasionally. From the stack traces we see that only some of the results are populated before hitting the timeout. This suggests that bumping the timeout might help stabilize the test.

```
java.lang.AssertionError: CLI test runner command result mismatch expected: [[ORDER_1, ITEM_1], [ORDER_2, ITEM_2], [ORDER_3, ITEM_3]], actual: [[ORDER_1, ITEM_1]]
	at io.confluent.ksql.CliTest.selectWithLimit(CliTest.java:215)
	at io.confluent.ksql.CliTest.testSelectLimit(CliTest.java:354)
Caused by: java.lang.AssertionError: Condition not met within timeout 10000. Did not get the expected result '[[ORDER_1, ITEM_1], [ORDER_2, ITEM_2], [ORDER_3, ITEM_3]], in a timely fashion.
	at io.confluent.ksql.CliTest.selectWithLimit(CliTest.java:215)
	at io.confluent.ksql.CliTest.testSelectLimit(CliTest.java:354)

```