### PR TITLE
KSQL-840 Fix Regression in DDL error message, don't show the exception stack.

### DIFF
--- a/ksql-engine/src/main/java/io/confluent/ksql/ddl/commands/DDLCommandExec.java
+++ b/ksql-engine/src/main/java/io/confluent/ksql/ddl/commands/DDLCommandExec.java
@@ -19,7 +19,6 @@ package io.confluent.ksql.ddl.commands;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import io.confluent.ksql.exception.ExceptionUtil;
 import io.confluent.ksql.metastore.MetaStore;
 import io.confluent.ksql.util.KsqlException;
 
@@ -60,7 +59,7 @@ public class DDLCommandExec {
       return ddlCommand.run(metaStore);
     } catch (Exception e) {
       LOGGER.warn(String.format("executeOnMetaStore:%s", ddlCommand), e);
-      return new DDLCommandResult(false, ExceptionUtil.stackTraceToString(e));
+      return new DDLCommandResult(false, e.getMessage());
     }
   }
 }

--- a/ksql-rest-app/src/test/java/io/confluent/ksql/rest/server/resources/KsqlResourceTest.java
+++ b/ksql-rest-app/src/test/java/io/confluent/ksql/rest/server/resources/KsqlResourceTest.java
@@ -449,7 +449,8 @@ public class KsqlResourceTest {
     assertThat("Incorrect drop statement.", result.size(), equalTo(1));
     assertThat(result.get(0), instanceOf(ErrorMessageEntity.class));
     ErrorMessageEntity errorMessageEntity = (ErrorMessageEntity) result.get(0);
-    assertTrue(errorMessageEntity.getErrorMessage().getMessage().contains("Incompatible data source type is STREAM, but statement was DROP TABLE"));
+    assertTrue(errorMessageEntity.getErrorMessage().getMessage().equalsIgnoreCase("Incompatible data source type"
+                                                                   + " is STREAM, but statement was DROP TABLE"));
   }
 
   @Test
@@ -462,7 +463,8 @@ public class KsqlResourceTest {
     assertThat("Incorrect drop statement.", result.size(), equalTo(1));
     assertThat(result.get(0), instanceOf(ErrorMessageEntity.class));
     ErrorMessageEntity errorMessageEntity = (ErrorMessageEntity) result.get(0);
-    assertTrue(errorMessageEntity.getErrorMessage().getMessage().contains("Incompatible data source type is TABLE, but statement was DROP STREAM"));
+    assertTrue(errorMessageEntity.getErrorMessage().getMessage().equalsIgnoreCase("Incompatible data source type"
+                                                                   + " is TABLE, but statement was DROP STREAM"));
   }
 
   @Test


### PR DESCRIPTION
This fixes a regression. Don't include the exception stack in DDL error message. 
This fixes #840 

Before this fix if we had an error in DDL statement we would see the following in CLI:
ksql> drop table pageviews_original;

io.confluent.ksql.util.KsqlException: Incompatible data source type is STREAM, but statement was DROP TABLE
	at io.confluent.ksql.ddl.commands.DropSourceCommand.run(DropSourceCommand.java:50)
	at io.confluent.ksql.ddl.commands.DDLCommandExec.executeOnMetaStore(DDLCommandExec.java:60)
	at io.confluent.ksql.ddl.commands.DDLCommandExec.execute(DDLCommandExec.java:54)
	at io.confluent.ksql.rest.server.resources.KsqlResource.executeDDLCommand(KsqlResource.java:608)
	at io.confluent.ksql.rest.server.resources.KsqlResource.lambda$registerDdlCommandTasks$11(KsqlResource.java:585)
	at io.confluent.ksql.rest.server.resources.KsqlResource.getStatementExecutionPlan(KsqlResource.java:450)
	at io.confluent.ksql.rest.server.resources.KsqlResource.validateStatement(KsqlResource.java:256)
	at io.confluent.ksql.rest.server.resources.KsqlResource.executeStatement(KsqlResource.java:232)
	at io.confluent.ksql.rest.server.resources.KsqlResource.handleKsqlStatements(KsqlResource.java:148)
	at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
	at sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
	at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
	at java.lang.reflect.Method.invoke(Method.java:498)
	at org.glassfish.jersey.server.model.internal.ResourceMethodInvocationHandlerFactory$1.invoke(ResourceMethodInvocationHandlerFactory.java:81)
	at org.glassfish.jersey.server.model.internal.AbstractJavaResourceMethodDispatcher$1.run(AbstractJavaResourceMethodDispatcher.java:144)
	at org.glassfish.jersey.server.model.internal.AbstractJavaResourceMethodDispatcher.invoke(AbstractJavaResourceMethodDispatcher.java:161)
	at org.glassfish.jersey.server.model.internal.JavaResourceMethodDispatcherProvider$ResponseOutInvoker.doDispatch(JavaResourceMethodDispatcherProvider.java:160)
	at org.glassfish.jersey.server.model.internal.AbstractJavaResourceMethodDispatcher.dispatch(AbstractJavaResourceMethodDispatcher.java:99)
	at org.glassfish.jersey.server.model.ResourceMethodInvoker.invoke(ResourceMethodInvoker.java:389)
	at org.glassfish.jersey.server.model.ResourceMethodInvoker.apply(ResourceMethodInvoker.java:347)
	at org.glassfish.jersey.server.model.ResourceMethodInvoker.apply(ResourceMethodInvoker.java:102)
	at org.glassfish.jersey.server.ServerRuntime$2.run(ServerRuntime.java:326)
	at org.glassfish.jersey.internal.Errors$1.call(Errors.java:271)
	at org.glassfish.jersey.internal.Errors$1.call(Errors.java:267)
	at org.glassfish.jersey.internal.Errors.process(Errors.java:315)
	at org.glassfish.jersey.internal.Errors.process(Errors.java:297)
	at org.glassfish.jersey.internal.Errors.process(Errors.java:267)
	at org.glassfish.jersey.process.internal.RequestScope.runInScope(RequestScope.java:317)
	at org.glassfish.jersey.server.ServerRuntime.process(ServerRuntime.java:305)
	at org.glassfish.jersey.server.ApplicationHandler.handle(ApplicationHandler.java:1154)
	at org.glassfish.jersey.servlet.WebComponent.serviceImpl(WebComponent.java:473)
	at org.glassfish.jersey.servlet.ServletContainer.serviceImpl(ServletContainer.java:408)
	at org.glassfish.jersey.servlet.ServletContainer.doFilter(ServletContainer.java:583)
	at org.glassfish.jersey.servlet.ServletContainer.doFilter(ServletContainer.java:524)
	at org.glassfish.jersey.servlet.ServletContainer.doFilter(ServletContainer.java:461)
	at org.eclipse.jetty.servlet.ServletHandler$CachedChain.doFilter(ServletHandler.java:1652)
	at org.eclipse.jetty.servlet.ServletHandler.doHandle(ServletHandler.java:585)
	at org.eclipse.jetty.server.session.SessionHandler.doHandle(SessionHandler.java:221)
	at org.eclipse.jetty.server.handler.ContextHandler.doHandle(ContextHandler.java:1127)
	at org.eclipse.jetty.servlet.ServletHandler.doScope(ServletHandler.java:515)
	at org.eclipse.jetty.server.session.SessionHandler.doScope(SessionHandler.java:185)
	at org.eclipse.jetty.server.handler.ContextHandler.doScope(ContextHandler.java:1061)
	at org.eclipse.jetty.server.handler.ScopedHandler.handle(ScopedHandler.java:141)
	at org.eclipse.jetty.server.handler.HandlerCollection.handle(HandlerCollection.java:110)
	at org.eclipse.jetty.server.handler.HandlerWrapper.handle(HandlerWrapper.java:97)
	at org.eclipse.jetty.server.handler.StatisticsHandler.handle(StatisticsHandler.java:159)
	at org.eclipse.jetty.server.handler.HandlerWrapper.handle(HandlerWrapper.java:97)
	at org.eclipse.jetty.server.Server.handle(Server.java:499)
	at org.eclipse.jetty.server.HttpChannel.handle(HttpChannel.java:311)
	at org.eclipse.jetty.server.HttpConnection.onFillable(HttpConnection.java:258)
	at org.eclipse.jetty.io.AbstractConnection$2.run(AbstractConnection.java:544)
	at org.eclipse.jetty.util.thread.QueuedThreadPool.runJob(QueuedThreadPool.java:635)
	at org.eclipse.jetty.util.thread.QueuedThreadPool$3.run(QueuedThreadPool.java:555)
	at java.lang.Thread.run(Thread.java:745)


