### PR TITLE
DOCS-345 - Add docker instructions variant to KSQL quickstart

### DIFF
--- a/docs/quickstart.rst
+++ b/docs/quickstart.rst
@@ -8,9 +8,14 @@ Quick Start
     The |cp| :ref:`quickstart` is the easiest way to get you up and running with |cp| and KSQL. It will demonstrate a simple
     workflow with topic management, monitoring, and using KSQL to write streaming queries against data in Kafka.
 
-KSQL Tutorials
-    - :ref:`Using KSQL to write streaming queries against data in Kafka <ksql_quickstart-local>`. This tutorial demonstrates a simple workflow using KSQL to write streaming queries against messages in Kafka.
-    - :ref:`Using KSQL to Collect, Analyze, and Report Aggregate Data <ksql_clickstream-local>`. Learn how to use KSQL, ElasticSearch, and Grafana to analyze data feeds and build a real-time dashboard for reporting and alerting.
+KSQL Tutorials and Examples
+    The :ref:`KSQL tutorials and examples <ksql_tutorials>` page provides introductory and advanced KSQL usage scenarios
+    in both local and Docker-based versions.
+
+    - :ref:`Writing Streaming Queries Against Kafka Using KSQL <ksql_tutorials>`. This tutorial demonstrates
+      a simple workflow using KSQL to write streaming queries against messages in Kafka.
+    - :ref:`Clickstream Data Analysis Pipeline Using KSQL <ksql_tutorials>`. Learn how to use KSQL,
+      ElasticSearch, and Grafana to analyze data feeds and build a real-time dashboard for reporting and alerting.
 
 
 

--- a/docs/tutorials/index.rst
+++ b/docs/tutorials/index.rst
@@ -12,7 +12,6 @@ KSQL Tutorials and Examples
     clickstream-local
     examples
 
-
 KSQL Basics
     This tutorial demonstrates a simple workflow using KSQL to write streaming queries against messages in Kafka.
 


### PR DESCRIPTION
Internal staging server: http://staging-docs.confluent.io.s3-website-us-west-2.amazonaws.com/PR/768/4.1.x/ksql/docs/quickstart.html