### PR TITLE
Bump the timeout for waiting for commands to be executed after being read from the command topic.

### DIFF
--- a/ksql-rest-app/src/main/java/io/confluent/ksql/rest/server/KsqlRestConfig.java
+++ b/ksql-rest-app/src/main/java/io/confluent/ksql/rest/server/KsqlRestConfig.java
@@ -47,7 +47,7 @@ public class KsqlRestConfig extends RestConfig {
   public static final ConfigDef.Type
       DISTRIBUTED_COMMAND_RESPONSE_TIMEOUT_MS_TYPE = ConfigDef.Type.LONG;
   public static final Long
-      DISTRIBUTED_COMMAND_RESPONSE_TIMEOUT_MS_DEFAULT = 1000L;
+      DISTRIBUTED_COMMAND_RESPONSE_TIMEOUT_MS_DEFAULT = 5000L;
   public static final ConfigDef.Importance
       DISTRIBUTED_COMMAND_RESPONSE_TIMEOUT_MS_IMPORTANCE = ConfigDef.Importance.LOW;
   public static final String


### PR DESCRIPTION
Today, when we receive a POST request to run a new query, we first write
the command to a the command topic and then wait until it is consumed
from the topic, parsed, analyzed, and started, before sending the
response to the client.

The code that parses, analyzes, and runs the query happens in a
background thread.

The thread handling the REST request only waits for a second for the
whole process to complete before returning an error. This is too short
since the execution involves creating the sink topics, making sure that
they have the right replication factor, etc.

Would be better to bump the wait time to something like 5 seconds to
ensure robust execution. Keeping a high timeout is not very risky, since
we would not have too many concurrent POST requests to execute queries
anyawy. Our advertised limit for concurrent queries is 10.