### PR TITLE
Key constraints

### DIFF
--- a/docs/key-constraints.rst
+++ b/docs/key-constraints.rst
@@ -17,10 +17,10 @@ In the case of streams, the `KEY` property is optional. KSQL uses it as a hint t
 
 In either case, when setting `KEY` the user must be sure that the following is true:
 
-    - The type of the column set in `KEY` must be `STRING` or `VARCHAR`.
-    - The value in the message key must be the same as the value in the column set in `KEY`.
+    - `KEY` must be set to a column of type `STRING` or `VARCHAR`.
+    - The value in the message key must be the same as the value in the column set in `KEY` for every record.
 
-If those constraints are not met, then the results of aggregation and join queries may be incorrect. However, with a couple extra steps you can still use KSQL if your data doesn't meet the first requirement. The following section explains how.
+If those constraints are not met, then the results of aggregation and join queries may be incorrect. However, if your data doesn't meet the fist requirement, you can still use KSQL with a couple extra steps. The following section explains how.
 
 ===============================================
 What To Do If Your Key Is In A Different Format

--- a/docs/key-constraints.rst
+++ b/docs/key-constraints.rst
@@ -15,16 +15,16 @@ In the case of tables, the `KEY` property is required.
 
 In the case of streams, the `KEY` property is optional. KSQL uses it as a hint to determine if a repartition can be avoided when performing aggregations and joins.
 
-In either case, when setting `KEY` the user must be sure that the following is true:
+In either case, when setting `KEY` the user must be sure that *both* of the following statements are true:
 
     - `KEY` must be set to a column of type `STRING` or `VARCHAR`.
     - The value in the message key must be the same as the value in the column set in `KEY` for every record.
 
-If those constraints are not met, then the results of aggregation and join queries may be incorrect. However, if your data doesn't meet the fist requirement, you can still use KSQL with a couple extra steps. The following section explains how.
+If those constraints are not met, then the results of aggregation and join queries may be incorrect. However, if your data doesn't meet these requirements, you can still use KSQL with a couple extra steps. The following section explains how.
 
-===============================================
-What To Do If Your Key Is In A Different Format
-===============================================
+=============================================================
+What To Do If Your Key Is Not Set or Is In A Different Format
+=============================================================
 
 Streams
 -------
@@ -34,11 +34,16 @@ For streams, just leave out the `KEY` property from the `WITH` clause. KSQL will
 Tables
 ------
 
-For tables, you can still use KSQL if the record key is not in the required format as long as the record key is a unary function of the value in the desired key column. To do so, first create a stream to have KSQL write the record key, and then declare the table on the output topic of the stream:
+For tables, you can still use KSQL if the record key is not in the required format as long as *one* of the following statements is true:
+
+    - the record key is a unary function of the value in the desired key column.
+    - it is ok for the records in the topic to be reordered before being inserted into the table
+
+To do so, first create a stream to have KSQL write the record key, and then declare the table on the output topic of the stream:
 
 .. code:: sql
 
     CREATE STREAM users_stream (userid INT, username STRING, city STRING, email STRING) WITH (KAFKA_TOPIC=‘users’, VALUE_FORMAT=‘JSON’);
-    CREATE STREAM users_with_key WITH(KAFKA_TOPIC=‘users_with_key’) AS SELECT * FROM users_stream PARTITION BY userid;
-    CREATE TABLE users (userid INT, username STRING, city STRING, email STRING) WITH (KAFKA_TOPIC=‘users_with_key’, VALUE_FORMAT=‘JSON’, KEY=‘userid’);
+    CREATE STREAM users_with_key WITH(KAFKA_TOPIC=‘users_with_key’) AS SELECT CAST(userid as STRING) as userid_string, username, city, email FROM users_stream PARTITION BY userid_string;
+    CREATE TABLE users_table (userid_string STRING, username STRING, city STRING, email STRING) WITH (KAFKA_TOPIC=‘users_with_key’, VALUE_FORMAT=‘JSON’, KEY=‘userid_string’);
 

--- a/docs/syntax-reference.rst
+++ b/docs/syntax-reference.rst
@@ -143,7 +143,7 @@ Property                  Description
  KAFKA_TOPIC (required)   | The name of the Kafka topic that backs this stream. The topic must already exist in Kafka.
  VALUE_FORMAT (required)  | Specifies the serialization format of the message value in the topic. Supported formats:
                           | ``JSON``, ``DELIMITED`` (comma-separated value), and ``AVRO``.
- KEY                      | Associates the message key in the Kafka topic with a column in the KSQL stream. You must be sure that the record key corresponds to the value in the key column and is in the right format. For more information, see :ref:`ksql_key_restraints`
+ KEY                      | Associates the message key in the Kafka topic with a column in the KSQL stream. You must be sure that the record key corresponds to the value in the key column and is in the right format. For more information, see :ref:`ksql_key_constraints`
  TIMESTAMP                | Associates a field within the message value in the Kafka topic with the ``ROWTIME`` column
                           | in the KSQL stream. If not supplied, the timestamp of the Kafka message, from the source
                           | stream, will be used. Time-based operations such as windowing will process
@@ -202,7 +202,7 @@ Property                  Description
  VALUE_FORMAT (required)  | Specifies the serialization format of the message value in the topic. Supported formats:
                           | ``JSON``, ``DELIMITED`` (comma-separated value), and ``AVRO``.
  KEY                      | Associates the message key in the Kafka topic with a column in the KSQL table. You must be sure that the record key corresponds to the value in the key column and is in
-the right format. For more information, see :ref:`ksql_key_restraints`
+the right format. For more information, see :ref:`ksql_key_constraints`
  TIMESTAMP                | Associates a field within the message value in the Kafka topic with the ``ROWTIME`` column
                           | in the KSQL table. If not supplied, the timestamp of the Kafka message, from the source
                           | stream, will be used. Time-based operations such as windowing will process

--- a/docs/syntax-reference.rst
+++ b/docs/syntax-reference.rst
@@ -143,7 +143,7 @@ Property                  Description
  KAFKA_TOPIC (required)   | The name of the Kafka topic that backs this stream. The topic must already exist in Kafka.
  VALUE_FORMAT (required)  | Specifies the serialization format of the message value in the topic. Supported formats:
                           | ``JSON``, ``DELIMITED`` (comma-separated value), and ``AVRO``.
- KEY                      | Associates the message key in the Kafka topic with a column in the KSQL stream.
+ KEY                      | Associates the message key in the Kafka topic with a column in the KSQL stream. You must be sure that the record key corresponds to the value in the key column and is in the right format. For more information, see :ref:`ksql_key_restraints`
  TIMESTAMP                | Associates a field within the message value in the Kafka topic with the ``ROWTIME`` column
                           | in the KSQL stream. If not supplied, the timestamp of the Kafka message, from the source
                           | stream, will be used. Time-based operations such as windowing will process
@@ -201,7 +201,8 @@ Property                  Description
  KAFKA_TOPIC (required)   | The name of the Kafka topic that backs this table. The topic must already exist in Kafka.
  VALUE_FORMAT (required)  | Specifies the serialization format of the message value in the topic. Supported formats:
                           | ``JSON``, ``DELIMITED`` (comma-separated value), and ``AVRO``.
- KEY                      | Associates the message key in the Kafka topic with a column in the KSQL table.
+ KEY                      | Associates the message key in the Kafka topic with a column in the KSQL table. You must be sure that the record key corresponds to the value in the key column and is in
+the right format. For more information, see :ref:`ksql_key_restraints`
  TIMESTAMP                | Associates a field within the message value in the Kafka topic with the ``ROWTIME`` column
                           | in the KSQL table. If not supplied, the timestamp of the Kafka message, from the source
                           | stream, will be used. Time-based operations such as windowing will process

--- a/docs/syntax-reference.rst
+++ b/docs/syntax-reference.rst
@@ -143,7 +143,9 @@ Property                  Description
  KAFKA_TOPIC (required)   | The name of the Kafka topic that backs this stream. The topic must already exist in Kafka.
  VALUE_FORMAT (required)  | Specifies the serialization format of the message value in the topic. Supported formats:
                           | ``JSON``, ``DELIMITED`` (comma-separated value), and ``AVRO``.
- KEY                      | Associates the message key in the Kafka topic with a column in the KSQL stream. You must be sure that the record key corresponds to the value in the key column and is in the right format. For more information, see :ref:`ksql_key_constraints`
+ KEY                      | Associates the message key in the Kafka topic with a column in the KSQL stream. You must
+                          | be sure that the record key corresponds to the value in the key column and is in the right
+                          | format. For more information, see :ref:`ksql_key_constraints`
  TIMESTAMP                | Associates a field within the message value in the Kafka topic with the ``ROWTIME`` column
                           | in the KSQL stream. If not supplied, the timestamp of the Kafka message, from the source
                           | stream, will be used. Time-based operations such as windowing will process
@@ -201,8 +203,9 @@ Property                  Description
  KAFKA_TOPIC (required)   | The name of the Kafka topic that backs this table. The topic must already exist in Kafka.
  VALUE_FORMAT (required)  | Specifies the serialization format of the message value in the topic. Supported formats:
                           | ``JSON``, ``DELIMITED`` (comma-separated value), and ``AVRO``.
- KEY                      | Associates the message key in the Kafka topic with a column in the KSQL table. You must be sure that the record key corresponds to the value in the key column and is in
-the right format. For more information, see :ref:`ksql_key_constraints`
+ KEY                      | Associates the message key in the Kafka topic with a column in the KSQL table. You must be
+                          | sure that the record key corresponds to the value in the key column and is in the right
+                          | format. For more information, see :ref:`ksql_key_constraints`
  TIMESTAMP                | Associates a field within the message value in the Kafka topic with the ``ROWTIME`` column
                           | in the KSQL table. If not supplied, the timestamp of the Kafka message, from the source
                           | stream, will be used. Time-based operations such as windowing will process


### PR DESCRIPTION
    First pass at key constraints doc. Explains that the key should be
    STRING/VARCHAR and match the message key. We could expand this to
    other data types so long as the user is sure that the key is the
    utf-8 encoded representation of the value, but that may be confusing.