### PR TITLE
KSQL-758-Add an optional properties file for data-gen 

### DIFF
--- a/ksql-examples/src/main/resources/datagen.properties
+++ b/ksql-examples/src/main/resources/datagen.properties
@@ -1,0 +1,2 @@
+
+interceptor.classes=io.confluent.monitoring.clients.interceptor.MonitoringProducerInterceptor

--- a/ksql-examples/src/main/resources/datagen.properties
+++ b/ksql-examples/src/main/resources/datagen.properties
@@ -1,2 +1,2 @@
-
+# This properties file should ONLY be used when you run KSQL with Confluent Enterprise Platform.
 interceptor.classes=io.confluent.monitoring.clients.interceptor.MonitoringProducerInterceptor


### PR DESCRIPTION
Added an optional properties file for data-gen that can be used to register interceptors when KSQL is used with CE.