### PR TITLE
Update Clickstream to no longer need the duplicate _TS streams and tables.

### DIFF
--- a/docs/tutorials/clickstream-docker.rst
+++ b/docs/tutorials/clickstream-docker.rst
@@ -168,7 +168,7 @@ Load the Streaming Data to KSQL
 
        .. code:: bash
 
-           $ ksql-server-start /etc/ksql/ksql-server.properties > /tmp/ksql-logs/ksql-server.log 2>&1 &
+           $ ksql-server-start /etc/ksql/ksql-server.properties > /tmp/ksql-server.log 2>&1 &
 
     2. Start the CLI and point it to the server.
 

--- a/docs/tutorials/clickstream-docker.rst
+++ b/docs/tutorials/clickstream-docker.rst
@@ -340,7 +340,7 @@ Send the KSQL tables to Elasticsearch and Grafana.
        Charting  CLICK_USER_SESSIONS
        Charting  USER_IP_ACTIVITY
        Charting  CLICKSTREAM_STATUS_CODES
-       Charting  ENRICHED_ERROR_CODES
+       Charting  ENRICHED_ERROR_CODES_COUNT
        Charting  ERRORS_PER_MIN_ALERT
        Charting  ERRORS_PER_MIN
        Charting  EVENTS_PER_MIN_MAX_AVG
@@ -359,20 +359,18 @@ Send the KSQL tables to Elasticsearch and Grafana.
    .. code:: bash
 
        Loading Grafana ClickStream Dashboard
-       {"slug":"click-stream-analysis","status":"success","version":5}
+       {"id":1,"slug":"click-stream-analysis","status":"success","uid":"VhmK8Mkik","url":"/d/VhmK8Mkik/click-stream-analysis","version":1}
 
        Navigate to:
-          http://localhost:3000/dashboard/db/click-stream-analysis (non-docker)
+          http://localhost:3000/d/VhmK8Mkik/click-stream-analysis (non-docker)
        or
-          http://localhost:33000/dashboard/db/click-stream-analysis (docker)
+          http://localhost:33000/d/VhmK8Mkik/click-stream-analysis (docker)
 
-#.  Go to your browser and view the Grafana output at
-    `http://localhost:33000/dashboard/db/click-stream-analysis <http://localhost:33000/dashboard/db/click-stream-analysis>`_. You can
-    login with user ID ``admin`` and password ``admin``.
+#.  Open your your browser using the second url output from the previous step's command.
+    You can login with user ID ``admin`` and password ``admin``.
 
     **Important:** If you already have Grafana UI open, you may need to
-    enter the specific clickstream URL:
-    http://localhost:33000/dashboard/db/click-stream-analysis.
+    enter the specific clickstream URL output by the previous step
 
     .. image:: ../img/grafana-success.png
        :alt: Grafana UI success

--- a/docs/tutorials/clickstream-docker.rst
+++ b/docs/tutorials/clickstream-docker.rst
@@ -220,7 +220,6 @@ Verify the data
         -----------------------------------------------------------------------------
          WEB_USERS                  | clickstream_users          | JSON   | false
          ERRORS_PER_MIN_ALERT       | ERRORS_PER_MIN_ALERT       | JSON   | true
-         CLICKSTREAM_CODES_TS       | CLICKSTREAM_CODES_TS       | JSON   | false
          USER_IP_ACTIVITY           | USER_IP_ACTIVITY           | JSON   | true
          CLICKSTREAM_CODES          | clickstream_codes          | JSON   | false
          PAGES_PER_MIN              | PAGES_PER_MIN              | JSON   | true
@@ -243,15 +242,7 @@ Verify the data
          Stream Name               | Kafka Topic               | Format
         ----------------------------------------------------------------
          USER_CLICKSTREAM          | USER_CLICKSTREAM          | JSON
-         EVENTS_PER_MIN_MAX_AVG_TS | EVENTS_PER_MIN_MAX_AVG_TS | JSON
-         ERRORS_PER_MIN_TS         | ERRORS_PER_MIN_TS         | JSON
-         EVENTS_PER_MIN_TS         | EVENTS_PER_MIN_TS         | JSON
          ENRICHED_ERROR_CODES      | ENRICHED_ERROR_CODES      | JSON
-         ERRORS_PER_MIN_ALERT_TS   | ERRORS_PER_MIN_ALERT_TS   | JSON
-         CLICK_USER_SESSIONS_TS    | CLICK_USER_SESSIONS_TS    | JSON
-         PAGES_PER_MIN_TS          | PAGES_PER_MIN_TS          | JSON
-         ENRICHED_ERROR_CODES_TS   | ENRICHED_ERROR_CODES_TS   | JSON
-         USER_IP_ACTIVITY_TS       | USER_IP_ACTIVITY_TS       | JSON
          CUSTOMER_CLICKSTREAM      | CUSTOMER_CLICKSTREAM      | JSON
          CLICKSTREAM               | clickstream               | JSON
 
@@ -280,17 +271,18 @@ Verify the data
 
     .. code:: bash
 
-        ksql> SELECT * FROM EVENTS_PER_MIN_TS LIMIT 5;
+        ksql> SELECT * FROM EVENTS_PER_MIN LIMIT 5;
 
     Your output should resemble:
 
     .. code:: bash
 
-        1503585450000 | 29 : | 1503585450000 | 29 | 19
-        1503585450000 | 37 : | 1503585450000 | 37 | 25
-        1503585450000 | 8 : | 1503585450000 | 8 | 35
-        1503585450000 | 36 : | 1503585450000 | 36 | 14
-        1503585450000 | 24 : | 1503585450000 | 24 | 22
+        1521108180000 | 6 : Window{start=1521108180000 end=-} | 6 | 24
+        1521108180000 | 4 : Window{start=1521108180000 end=-} | 4 | 23
+        1521108180000 | 35 : Window{start=1521108180000 end=-} | 35 | 20
+        1521108180000 | 5 : Window{start=1521108180000 end=-} | 5 | 24
+        1521108180000 | 9 : Window{start=1521108180000 end=-} | 9 | 19
+        1521108180000 | 34 : Window{start=1521108180000 end=-} | 34 | 18
         LIMIT reached for the partition.
         Query terminated
 
@@ -345,16 +337,16 @@ Send the KSQL tables to Elasticsearch and Grafana.
 
        Loading Clickstream-Demo TABLES to Confluent-Connect => Elastic => Grafana datasource
        Logging to: /tmp/ksql-connect.log
-       Charting  CLICK_USER_SESSIONS_TS
-       Charting  USER_IP_ACTIVITY_TS
-       Charting  CLICKSTREAM_STATUS_CODES_TS
-       Charting  ENRICHED_ERROR_CODES_TS
-       Charting  ERRORS_PER_MIN_ALERT_TS
-       Charting  ERRORS_PER_MIN_TS
-       Charting  EVENTS_PER_MIN_MAX_AVG_TS
-       Charting  EVENTS_PER_MIN_TS
-       Charting  PAGES_PER_MIN_TS
-       Navigate to http://localhost:3000/dashboard/db/click-stream-analysis
+       Charting  CLICK_USER_SESSIONS
+       Charting  USER_IP_ACTIVITY
+       Charting  CLICKSTREAM_STATUS_CODES
+       Charting  ENRICHED_ERROR_CODES
+       Charting  ERRORS_PER_MIN_ALERT
+       Charting  ERRORS_PER_MIN
+       Charting  EVENTS_PER_MIN_MAX_AVG
+       Charting  EVENTS_PER_MIN
+       Charting  PAGES_PER_MIN
+       Done
 
 4. Load the dashboard into Grafana.
 
@@ -368,6 +360,11 @@ Send the KSQL tables to Elasticsearch and Grafana.
 
        Loading Grafana ClickStream Dashboard
        {"slug":"click-stream-analysis","status":"success","version":5}
+
+       Navigate to:
+          http://localhost:3000/dashboard/db/click-stream-analysis (non-docker)
+       or
+          http://localhost:33000/dashboard/db/click-stream-analysis (docker)
 
 #.  Go to your browser and view the Grafana output at
     `http://localhost:33000/dashboard/db/click-stream-analysis <http://localhost:33000/dashboard/db/click-stream-analysis>`_. You can
@@ -388,8 +385,7 @@ is named after the streams and tables captured in the ``clickstream-schema.sql``
 
 Things to try
     * Understand how the ``clickstream-schema.sql`` file is structured. We use a **DataGen.KafkaTopic.clickstream -> Stream -> Table** (for window &
-      analytics with group-by) -> Table (to Add EVENT_TS for time-index) ->
-      ElasticSearch/Connect topic
+      analytics with group-by) -> ElasticSearch/Connect topic
     * Run the KSQL CLI ``LIST TOPICS;`` command to see where data is persisted
     * Run the KSQL CLI ``history`` command
 

--- a/docs/tutorials/clickstream-local.rst
+++ b/docs/tutorials/clickstream-local.rst
@@ -167,7 +167,6 @@ Verify the data
         -----------------------------------------------------------------------------
          WEB_USERS                  | clickstream_users          | JSON   | false
          ERRORS_PER_MIN_ALERT       | ERRORS_PER_MIN_ALERT       | JSON   | true
-         CLICKSTREAM_CODES_TS       | CLICKSTREAM_CODES_TS       | JSON   | false
          USER_IP_ACTIVITY           | USER_IP_ACTIVITY           | JSON   | true
          CLICKSTREAM_CODES          | clickstream_codes          | JSON   | false
          PAGES_PER_MIN              | PAGES_PER_MIN              | JSON   | true
@@ -191,15 +190,7 @@ Verify the data
          Stream Name               | Kafka Topic               | Format
         ----------------------------------------------------------------
          USER_CLICKSTREAM          | USER_CLICKSTREAM          | JSON
-         EVENTS_PER_MIN_MAX_AVG_TS | EVENTS_PER_MIN_MAX_AVG_TS | JSON
-         ERRORS_PER_MIN_TS         | ERRORS_PER_MIN_TS         | JSON
-         EVENTS_PER_MIN_TS         | EVENTS_PER_MIN_TS         | JSON
          ENRICHED_ERROR_CODES      | ENRICHED_ERROR_CODES      | JSON
-         ERRORS_PER_MIN_ALERT_TS   | ERRORS_PER_MIN_ALERT_TS   | JSON
-         CLICK_USER_SESSIONS_TS    | CLICK_USER_SESSIONS_TS    | JSON
-         PAGES_PER_MIN_TS          | PAGES_PER_MIN_TS          | JSON
-         ENRICHED_ERROR_CODES_TS   | ENRICHED_ERROR_CODES_TS   | JSON
-         USER_IP_ACTIVITY_TS       | USER_IP_ACTIVITY_TS       | JSON
          CUSTOMER_CLICKSTREAM      | CUSTOMER_CLICKSTREAM      | JSON
          CLICKSTREAM               | clickstream               | JSON
 
@@ -226,17 +217,18 @@ Verify the data
 
     .. code:: bash
 
-        ksql> SELECT * FROM EVENTS_PER_MIN_TS LIMIT 5;
+        ksql> SELECT * FROM EVENTS_PER_MIN LIMIT 5;
 
     Your output should resemble:
 
     .. code:: bash
 
-        1503585450000 | 29 : | 1503585450000 | 29 | 19
-        1503585450000 | 37 : | 1503585450000 | 37 | 25
-        1503585450000 | 8 : | 1503585450000 | 8 | 35
-        1503585450000 | 36 : | 1503585450000 | 36 | 14
-        1503585450000 | 24 : | 1503585450000 | 24 | 22
+        1521108180000 | 6 : Window{start=1521108180000 end=-} | 6 | 24
+        1521108180000 | 4 : Window{start=1521108180000 end=-} | 4 | 23
+        1521108180000 | 35 : Window{start=1521108180000 end=-} | 35 | 20
+        1521108180000 | 5 : Window{start=1521108180000 end=-} | 5 | 24
+        1521108180000 | 9 : Window{start=1521108180000 end=-} | 9 | 19
+        1521108180000 | 34 : Window{start=1521108180000 end=-} | 34 | 18
         LIMIT reached for the partition.
         Query terminated
 
@@ -284,20 +276,16 @@ In this step, you send the KSQL tables to Elasticsearch and Grafana and then vie
 
        Loading Clickstream-Demo TABLES to Confluent-Connect => Elastic => Grafana datasource
        Logging to: /tmp/ksql-connect.log
-       Charting  CLICK_USER_SESSIONS_TS
-       Charting  USER_IP_ACTIVITY_TS
-       Charting  CLICKSTREAM_STATUS_CODES_TS
-       Charting  ENRICHED_ERROR_CODES_TS
-       Charting  ERRORS_PER_MIN_ALERT_TS
-       Charting  ERRORS_PER_MIN_TS
-       Charting  EVENTS_PER_MIN_MAX_AVG_TS
-       Charting  EVENTS_PER_MIN_TS
-       Charting  PAGES_PER_MIN_TS
-       Navigate to http://localhost:3000/dashboard/db/click-stream-analysis
-
-   **Important:** The ``http://localhost:3000/`` URL is only
-   available inside the container. We will access the dashboard with
-   a slightly different URL, after running the next command.
+       Charting  CLICK_USER_SESSIONS
+       Charting  USER_IP_ACTIVITY
+       Charting  CLICKSTREAM_STATUS_CODES
+       Charting  ENRICHED_ERROR_CODES
+       Charting  ERRORS_PER_MIN_ALERT
+       Charting  ERRORS_PER_MIN
+       Charting  EVENTS_PER_MIN_MAX_AVG
+       Charting  EVENTS_PER_MIN
+       Charting  PAGES_PER_MIN
+       Done
 
 #. Load the dashboard into Grafana.
 
@@ -311,6 +299,11 @@ In this step, you send the KSQL tables to Elasticsearch and Grafana and then vie
 
        Loading Grafana ClickStream Dashboard
        {"slug":"click-stream-analysis","status":"success","version":1}
+
+       Navigate to:
+          http://localhost:3000/dashboard/db/click-stream-analysis (non-docker)
+       or
+          http://localhost:33000/dashboard/db/click-stream-analysis (docker)
 
 #.  Go to your browser and view the Grafana output at `http://localhost:3000/dashboard/db/click-stream-analysis <http://localhost:3000/dashboard/db/click-stream-analysis>`_. You can login with user ID ``admin`` and password ``admin``.
 
@@ -326,8 +319,7 @@ is named after the streams and tables captured in the ``clickstream-schema.sql``
 
 Things to try
     * Understand how the ``clickstream-schema.sql`` file is structured. We use a **DataGen.KafkaTopic.clickstream -> Stream -> Table** (for window &
-      analytics with group-by) -> Table (to Add EVENT_TS for time-index) ->
-      ElasticSearch/Connect topic
+      analytics with group-by) -> ElasticSearch/Connect topic
     * Run the KSQL CLI ``LIST TOPICS;`` command to see where data is persisted
     * Run the KSQL CLI ``history`` command
 

--- a/docs/tutorials/clickstream-local.rst
+++ b/docs/tutorials/clickstream-local.rst
@@ -24,12 +24,14 @@ These steps will guide you through how to setup your environment and run the cli
 
 - :ref:`Confluent Platform <installation>` is installed and running. This installation includes a Kafka broker, KSQL, |c3-short|,
   |zk|, Schema Registry, REST Proxy, and Kafka Connect.
--  `ElasticSearch <https://www.elastic.co/guide/en/elasticsearch/guide/current/running-elasticsearch.html>`__
--  `Grafana <http://docs.grafana.org/installation/>`__
+-  `ElasticSearch v5.6 <https://www.elastic.co/guide/en/elasticsearch/guide/current/running-elasticsearch.html>`__
+-  `Grafana v5.0 <http://docs.grafana.org/installation/>`__
 -  `Git <https://git-scm.com/downloads>`__
 -  `Maven <https://maven.apache.org/install.html>`__
 -  Java: Minimum version 1.8. Install Oracle Java JRE or JDK >= 1.8 on
    your local machine
+
+Note: This demo has been tested with ElasticSearch v5.6.8 and Grafana v5.0.3. Mileage with other versions may vary.
 
 ---------------------
 Download the Tutorial
@@ -56,8 +58,8 @@ Configure and Start Elastic and Grafana
 #.  Start the Elastic and Grafana servers. ElasticSearch should be running on the default port 9200. Grafana
     should be running on the default port 3000.
 
-    -  `Start Elastic <https://www.elastic.co/guide/en/elasticsearch/guide/current/running-elasticsearch.html>`__
-    -  `Start Grafana <http://docs.grafana.org/installation/>`__
+    -  `Start Elastic 5.6 <https://www.elastic.co/guide/en/elasticsearch/guide/current/running-elasticsearch.html>`__
+    -  `Start Grafana 5.0 <http://docs.grafana.org/installation/>`__
 
 
 ---------------------------
@@ -279,7 +281,7 @@ In this step, you send the KSQL tables to Elasticsearch and Grafana and then vie
        Charting  CLICK_USER_SESSIONS
        Charting  USER_IP_ACTIVITY
        Charting  CLICKSTREAM_STATUS_CODES
-       Charting  ENRICHED_ERROR_CODES
+       Charting  ENRICHED_ERROR_CODES_COUNT
        Charting  ERRORS_PER_MIN_ALERT
        Charting  ERRORS_PER_MIN
        Charting  EVENTS_PER_MIN_MAX_AVG
@@ -298,17 +300,18 @@ In this step, you send the KSQL tables to Elasticsearch and Grafana and then vie
    .. code:: bash
 
        Loading Grafana ClickStream Dashboard
-       {"slug":"click-stream-analysis","status":"success","version":1}
+       {"id":1,"slug":"click-stream-analysis","status":"success","uid":"VhmK8Mkik","url":"/d/VhmK8Mkik/click-stream-analysis","version":1}
 
        Navigate to:
-          http://localhost:3000/dashboard/db/click-stream-analysis (non-docker)
+          http://localhost:3000/d/VhmK8Mkik/click-stream-analysis (non-docker)
        or
-          http://localhost:33000/dashboard/db/click-stream-analysis (docker)
+          http://localhost:33000/d/VhmK8Mkik/click-stream-analysis (docker)
 
-#.  Go to your browser and view the Grafana output at `http://localhost:3000/dashboard/db/click-stream-analysis <http://localhost:3000/dashboard/db/click-stream-analysis>`_. You can login with user ID ``admin`` and password ``admin``.
+#.  Open your your browser using the first url output from the previous step's command.
+    You can login with user ID ``admin`` and password ``admin``.
 
-    **Important:** If you already have Grafana UI open, you may need to enter the specific clickstream URL as
-    `http://localhost:3000/dashboard/db/click-stream-analysis <http://localhost:3000/dashboard/db/click-stream-analysis>`_.
+    **Important:** If you already have Grafana UI open, you may need to
+    enter the specific clickstream URL output by the previous step
 
     .. image:: ../img/grafana-success.png
 

--- a/docs/tutorials/clickstream-local.rst
+++ b/docs/tutorials/clickstream-local.rst
@@ -123,7 +123,7 @@ Load the Streaming Data to KSQL
     .. code:: bash
 
         $ <path-to-confluent>/bin/ksql-server-start <path-to-confluent>/etc/ksql/ksql-server.properties\
-          > /tmp/ksql-logs/ksql-server.log 2>&1 &
+          > /tmp/ksql-server.log 2>&1 &
 
     You should see the KSQL CLI welcome screen.
 

--- a/ksql-clickstream-demo/Dockerfile
+++ b/ksql-clickstream-demo/Dockerfile
@@ -14,12 +14,12 @@ ENV KSQL_CLASSPATH=/usr/share/java/${ARTIFACT_ID}/${ARTIFACT_ID}-${PROJECT_VERSI
 ENV KSQL_CONFIG_DIR="/etc/ksql"
 ENV KSQL_LOG4J_OPTS="-Dlog4j.configuration=file:/etc/ksql/log4j-rolling.properties"
 
-RUN wget -q https://s3-us-west-2.amazonaws.com/grafana-releases/release/grafana_4.4.3_amd64.deb \
-    && wget -q https://artifacts.elastic.co/downloads/elasticsearch/elasticsearch-5.5.2.deb \
-    && dpkg -i grafana_4.4.3_amd64.deb \
-    && dpkg -i elasticsearch-5.5.2.deb \
-    && rm grafana_4.4.3_amd64.deb \
-    && rm elasticsearch-5.5.2.deb
+RUN wget -q https://s3-us-west-2.amazonaws.com/grafana-releases/release/grafana_5.0.3_amd64.deb \
+    && wget -q https://artifacts.elastic.co/downloads/elasticsearch/elasticsearch-5.6.8.deb \
+    && dpkg -i grafana_5.0.3_amd64.deb \
+    && dpkg -i elasticsearch-5.6.8.deb \
+    && rm grafana_5.0.3_amd64.deb \
+    && rm elasticsearch-5.6.8.deb
 
 ADD target/${ARTIFACT_ID}-${PROJECT_VERSION}-standalone.jar /usr/share/java/${ARTIFACT_ID}/${ARTIFACT_ID}-${PROJECT_VERSION}-standalone.jar
 ADD target/${ARTIFACT_ID}-${PROJECT_VERSION}-package/bin/* /usr/bin/

--- a/ksql-clickstream-demo/demo/clickstream-analysis-dashboard.json
+++ b/ksql-clickstream-demo/demo/clickstream-analysis-dashboard.json
@@ -43,8 +43,8 @@
         "pluginName": "Elasticsearch"
       },
       {
-        "name": "enriched_error_codes",
-        "label": "enriched_error_codes",
+        "name": "enriched_error_codes_count",
+        "label": "enriched_error_codes_count",
         "description": "",
         "type": "datasource",
         "pluginId": "elasticsearch",
@@ -749,7 +749,7 @@
                 "value": "Max"
               }
             ],
-            "datasource": "enriched_error_codes",
+            "datasource": "enriched_error_codes_count",
             "fontSize": "100%",
             "id": 9,
             "links": [],

--- a/ksql-clickstream-demo/demo/clickstream-analysis-dashboard.json
+++ b/ksql-clickstream-demo/demo/clickstream-analysis-dashboard.json
@@ -3,56 +3,56 @@
   {
     "__inputs": [
       {
-        "name": "errors_per_min_alert_ts",
-        "label": "errors_per_min_alert_ts",
+        "name": "errors_per_min_alert",
+        "label": "errors_per_min_alert",
         "description": "",
         "type": "datasource",
         "pluginId": "elasticsearch",
         "pluginName": "Elasticsearch"
       },
       {
-        "name": "user_ip_activity_ts",
-        "label": "user_ip_activity_ts",
+        "name": "user_ip_activity",
+        "label": "user_ip_activity",
         "description": "",
         "type": "datasource",
         "pluginId": "elasticsearch",
         "pluginName": "Elasticsearch"
       },
       {
-        "name": "click_user_sessions_ts",
-        "label": "click_user_sessions_ts",
+        "name": "click_user_sessions",
+        "label": "click_user_sessions",
         "description": "",
         "type": "datasource",
         "pluginId": "elasticsearch",
         "pluginName": "Elasticsearch"
       },
       {
-        "name": "DS_PAGES_PER_MIN_TS",
-        "label": "pages_per_min_ts",
+        "name": "DS_PAGES_PER_MIN",
+        "label": "pages_per_min",
         "description": "",
         "type": "datasource",
         "pluginId": "elasticsearch",
         "pluginName": "Elasticsearch"
       },
       {
-        "name": "events_per_min_max_avg_ts",
-        "label": "events_per_min_max_avg_ts",
+        "name": "events_per_min_max_avg",
+        "label": "events_per_min_max_avg",
         "description": "",
         "type": "datasource",
         "pluginId": "elasticsearch",
         "pluginName": "Elasticsearch"
       },
       {
-        "name": "enriched_error_codes_ts",
-        "label": "enriched_error_codes_ts",
+        "name": "enriched_error_codes",
+        "label": "enriched_error_codes",
         "description": "",
         "type": "datasource",
         "pluginId": "elasticsearch",
         "pluginName": "Elasticsearch"
       },
       {
-        "name": "events_per_min_ts",
-        "label": "events_per_min_ts",
+        "name": "events_per_min",
+        "label": "events_per_min",
         "description": "",
         "type": "datasource",
         "pluginId": "elasticsearch",
@@ -105,7 +105,7 @@
             "bars": false,
             "dashLength": 10,
             "dashes": false,
-            "datasource": "errors_per_min_alert_ts",
+            "datasource": "errors_per_min_alert",
             "fill": 1,
             "id": 7,
             "legend": {
@@ -228,7 +228,7 @@
                 "value": "Count"
               }
             ],
-            "datasource": "user_ip_activity_ts",
+            "datasource": "user_ip_activity",
             "fontSize": "100%",
             "id": 10,
             "links": [],
@@ -399,7 +399,7 @@
             "bars": false,
             "dashLength": 10,
             "dashes": false,
-            "datasource": "click_user_sessions_ts",
+            "datasource": "click_user_sessions",
             "fill": 1,
             "id": 8,
             "legend": {
@@ -519,7 +519,7 @@
             "bars": false,
             "dashLength": 10,
             "dashes": false,
-            "datasource": "pages_per_min_ts",
+            "datasource": "pages_per_min",
             "fill": 1,
             "id": 3,
             "legend": {
@@ -615,7 +615,7 @@
             "bars": false,
             "dashLength": 10,
             "dashes": false,
-            "datasource": "events_per_min_max_avg_ts",
+            "datasource": "events_per_min_max_avg",
             "fill": 1,
             "id": 1,
             "legend": {
@@ -749,7 +749,7 @@
                 "value": "Max"
               }
             ],
-            "datasource": "enriched_error_codes_ts",
+            "datasource": "enriched_error_codes",
             "fontSize": "100%",
             "id": 9,
             "links": [],
@@ -880,7 +880,7 @@
             "bars": false,
             "dashLength": 10,
             "dashes": false,
-            "datasource": "events_per_min_ts",
+            "datasource": "events_per_min",
             "fill": 1,
             "id": 2,
             "legend": {

--- a/ksql-clickstream-demo/demo/clickstream-analysis-dashboard.sh
+++ b/ksql-clickstream-demo/demo/clickstream-analysis-dashboard.sh
@@ -11,3 +11,10 @@ curl -X "POST" "http://localhost:3000/api/dashboards/db" \
 	     --user admin:admin \
 	     --data-binary @clickstream-analysis-dashboard.json
 
+
+echo ""
+echo ""
+echo "Navigate to:"
+echo "  http://localhost:3000/dashboard/db/click-stream-analysis (non-docker)"
+echo "or"
+echo "  http://localhost:33000/dashboard/db/click-stream-analysis (docker)"

--- a/ksql-clickstream-demo/demo/clickstream-analysis-dashboard.sh
+++ b/ksql-clickstream-demo/demo/clickstream-analysis-dashboard.sh
@@ -6,15 +6,23 @@
 
 echo "Loading Grafana ClickStream Dashboard"
 
-curl -X "POST" "http://localhost:3000/api/dashboards/db" \
+RESP="$(curl -X "POST" "http://localhost:3000/api/dashboards/db" \
 	    -H "Content-Type: application/json" \
 	     --user admin:admin \
-	     --data-binary @clickstream-analysis-dashboard.json
+	     --data-binary @clickstream-analysis-dashboard.json)"
 
-
+echo $RESP
 echo ""
 echo ""
+
+if [[ $RESP =~ .*\"url\":\"([^\"]*)\".* ]]
+then
+    url="${BASH_REMATCH[1]}"
+else
+    url="/dashboard/db/click-stream-analysis"
+fi
+
 echo "Navigate to:"
-echo "  http://localhost:3000/dashboard/db/click-stream-analysis (non-docker)"
+echo "  http://localhost:3000${url} (non-docker)"
 echo "or"
-echo "  http://localhost:33000/dashboard/db/click-stream-analysis (docker)"
+echo "  http://localhost:33000${url} (docker)"

--- a/ksql-clickstream-demo/demo/drop-clickstream-schema.sql
+++ b/ksql-clickstream-demo/demo/drop-clickstream-schema.sql
@@ -1,19 +1,12 @@
 DROP STREAM clickstream;
 DROP TABLE events_per_min;
-DROP TABLE events_per_min_ts;
 DROP TABLE events_per_min_max_avg;
-DROP TABLE events_per_min_max_avg_ts;
 DROP TABLE clickstream_codes;
-DROP TABLE clickstream_codes_ts;
 DROP TABLE pages_per_min;
-DROP TABLE pages_per_min_ts;
 DROP TABLE ERRORS_PER_MIN_ALERT;
-DROP TABLE ERRORS_PER_MIN_ALERT_TS;
 DROP TABLE ERRORS_PER_MIN;
-DROP TABLE ERRORS_PER_MIN_TS;
 DROP STREAM ENRICHED_ERROR_CODES;
 DROP TABLE ENRICHED_ERROR_CODES_COUNT;
-DROP STREAM ENRICHED_ERROR_CODES_TS;
 DROP TABLE WEB_USERS;
 DROP STREAM customer_clickstream;
 DROP STREAM platinum_customers_with_errors;
@@ -22,22 +15,10 @@ DROP TABLE PLATINUM_ERRORS_PER_5_MIN;
 DROP TABLE platinum_page_errors_per_5_min;
 DROP STREAM USER_CLICKSTREAM;
 DROP TABLE USER_IP_ACTIVITY;
-DROP TABLE USER_IP_ACTIVITY_TS;
 DROP TABLE CLICK_USER_SESSIONS;
-DROP TABLE CLICK_USER_SESSIONS_TS;
 DROP TABLE PER_USER_KBYTES;
-DROP TABLE PER_USER_KBYTES_TS;
 DROP TABLE MALICIOUS_USER_SESSIONS;
---
---terminate 1;
---terminate 2;
---terminate 3;
---terminate 4;
---terminate 5;
---terminate 6;
---terminate 7;
---terminate 8;
---terminate 9;
+
 
 
 

--- a/ksql-clickstream-demo/demo/elastic-dynamic-template.sh
+++ b/ksql-clickstream-demo/demo/elastic-dynamic-template.sh
@@ -2,6 +2,8 @@
 
 echo "Loading Elastic Dynamic Template to ensure _TS fields are used for TimeStamp"
 
+curl -XDELETE "http://localhost:9200/_template/kafkaconnect/"
+
 curl -XPUT "http://localhost:9200/_template/kafkaconnect/" -H 'Content-Type: application/json' -d'
 {
   "template": "*",
@@ -12,9 +14,9 @@ curl -XPUT "http://localhost:9200/_template/kafkaconnect/" -H 'Content-Type: app
   "mappings": {
     "_default_": {
       "dynamic_templates": [
-{
+        {
           "dates": {
-            "match": "*_TS",
+            "match": "EVENT_TS",
             "mapping": {
               "type": "date"
             }

--- a/ksql-clickstream-demo/demo/elastic-dynamic-template.sh
+++ b/ksql-clickstream-demo/demo/elastic-dynamic-template.sh
@@ -27,7 +27,7 @@ curl -XPUT "http://localhost:9200/_template/kafkaconnect/" -H 'Content-Type: app
             "match": "*",
             "match_mapping_type": "string",
             "mapping": {
-              "type": "string",
+              "type": "keyword",
               "index": "not_analyzed"
             }
           }

--- a/ksql-clickstream-demo/demo/ksql-connect-es-grafana.sh
+++ b/ksql-clickstream-demo/demo/ksql-connect-es-grafana.sh
@@ -19,6 +19,8 @@ echo "Connecting:" $table_name
 ./elastic-dynamic-template.sh
 
 # Tell Kafka to send this Table-Topic to Elastic
+# Note the addition of the FilterNulls transform, which converts null values to null records, which Connect ignores.
+# Note the addition of the ExtractTimestamp transform, which exposes the Kafka record's timestamp to Elastic in a field called EVENT_TS.
 echo "Adding Kafka Connect Elastic Source es_sink_$TABLE_NAME:"
 echo
 echo

--- a/ksql-clickstream-demo/demo/ksql-connect-es-grafana.sh
+++ b/ksql-clickstream-demo/demo/ksql-connect-es-grafana.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-## An "all-in-once script" to load up a new table and connect all of the relevant parts to allow data to pipe through from KSQL.KafkaTopic->Connect->Elastic->Grafana[DataSource]
+## An "all-in-one script" to load up a new table and connect all of the relevant parts to allow data to pipe through from KSQL.KafkaTopic->Connect->Elastic->Grafana[DataSource]
 ## Accepts a KSQL TABLE_NAME where the data is to be sourced from.
 
 
@@ -19,8 +19,9 @@ echo "Connecting:" $table_name
 ./elastic-dynamic-template.sh
 
 # Tell Kafka to send this Table-Topic to Elastic
-echo "Adding Elastic Source\n\n"
-
+echo "Adding Kafka Connect Elastic Source es_sink_$TABLE_NAME:"
+echo
+echo
 
 curl -X "POST" "http://localhost:8083/connectors/" \
      -H "Content-Type: application/json" \
@@ -36,14 +37,17 @@ curl -X "POST" "http://localhost:8083/connectors/" \
     "value.converter": "org.apache.kafka.connect.json.JsonConverter",
     "type.name": "type.name=kafkaconnect",
     "topic.index.map": "'$TABLE_NAME':'$table_name'",
-     "connection.url": "http://localhost:9200",
-    "transforms": "FilterNulls",
-    "transforms.FilterNulls.type": "io.confluent.transforms.NullFilter"
+    "connection.url": "http://localhost:9200",
+    "transforms": "FilterNulls,ExtractTimestamp",
+    "transforms.FilterNulls.type": "io.confluent.transforms.NullFilter",
+    "transforms.ExtractTimestamp.type": "org.apache.kafka.connect.transforms.InsertField$Value",
+    "transforms.ExtractTimestamp.timestamp.field" : "EVENT_TS"
   }
 }'
 
 
-echo ""
+echo
+echo
 echo "Adding Grafana Source"
 
 ## Add the Elastic DataSource into Grafana
@@ -51,8 +55,4 @@ curl -X "POST" "http://localhost:3000/api/datasources" \
 	    -H "Content-Type: application/json" \
 	     --user admin:admin \
 	     -d $'{"id":1,"orgId":1,"name":"'$table_name'","type":"elasticsearch","typeLogoUrl":"public/app/plugins/datasource/elasticsearch/img/elasticsearch.svg","access":"proxy","url":"http://localhost:9200","password":"","user":"","database":"'$table_name'","basicAuth":false,"isDefault":false,"jsonData":{"timeField":"EVENT_TS"}}'
-
-
-
-
 

--- a/ksql-clickstream-demo/demo/ksql-tables-to-grafana.sh
+++ b/ksql-clickstream-demo/demo/ksql-tables-to-grafana.sh
@@ -11,7 +11,7 @@ echo "Logging to:" $LOG_FILE
 
 
 
-declare -a tables=('click_user_sessions' 'user_ip_activity' 'enriched_error_codes' 'errors_per_min_alert' 'errors_per_min' 'events_per_min_max_avg' 'events_per_min' 'pages_per_min');
+declare -a tables=('click_user_sessions' 'user_ip_activity' 'enriched_error_codes_count' 'errors_per_min_alert' 'errors_per_min' 'events_per_min_max_avg' 'events_per_min' 'pages_per_min');
 for i in "${tables[@]}"
 do
 

--- a/ksql-clickstream-demo/demo/ksql-tables-to-grafana.sh
+++ b/ksql-clickstream-demo/demo/ksql-tables-to-grafana.sh
@@ -11,7 +11,7 @@ echo "Logging to:" $LOG_FILE
 
 
 
-declare -a tables=('click_user_sessions_ts' 'user_ip_activity_ts' 'clickstream_status_codes_ts' 'enriched_error_codes_ts' 'errors_per_min_alert_ts' 'errors_per_min_ts' 'events_per_min_max_avg_ts' 'events_per_min_ts' 'pages_per_min_ts');
+declare -a tables=('click_user_sessions' 'user_ip_activity' 'enriched_error_codes' 'errors_per_min_alert' 'errors_per_min' 'events_per_min_max_avg' 'events_per_min' 'pages_per_min');
 for i in "${tables[@]}"
 do
 
@@ -27,22 +27,25 @@ do
 
     ## Cleanup existing data
 
-    # Elastic
+    echo >> $LOG_FILE
+    echo "Remove any existing Elastic search config"  >> $LOG_FILE
     curl -X "DELETE" "http://localhost:9200/""$table_name" >> $LOG_FILE 2>&1
 
-    # Connect
+    echo >> $LOG_FILE
+    echo "Remove any existing Connect config"  >> $LOG_FILE
     curl -X "DELETE" "http://localhost:8083/connectors/es_sink_""$TABLE_NAME" >> $LOG_FILE 2>&1
 
-#    # Grafana
+    echo >> $LOG_FILE
+    echo "Remove any existing Grafana config"  >> $LOG_FILE
     curl -X "DELETE" "http://localhost:3000/api/datasources/name/""$table_name"   --user admin:admin >> $LOG_FILE 2>&1
 
     # Wire in the new connection path
-    echo "\n\nConnecting KSQL->Elastic->Grafana " "$table_name" >> $LOG_FILE 2>&1
+    echo >> $LOG_FILE
+    echo "Connecting KSQL->Elastic->Grafana " "$table_name" >> $LOG_FILE 2>&1
     ./ksql-connect-es-grafana.sh "$table_name" >> $LOG_FILE 2>&1
 done
 
-echo "Navigate to http://localhost:3000/dashboard/db/click-stream-analysis"
-
+echo "Done"
 
 # ========================
 #   REST API Notes


### PR DESCRIPTION
Fix for #835

Changes:
- Upgrade grafana and elastic
- Install connect transformer to extract record timestamp and expose to elastic
- update grafana install script to parse new variable URL
- updated docs to be explicit about versions