### PR TITLE
Add _command_topic as the default suffix for the command topic.

### DIFF
--- a/ksql-common/src/main/java/io/confluent/ksql/util/KsqlConfig.java
+++ b/ksql-common/src/main/java/io/confluent/ksql/util/KsqlConfig.java
@@ -54,7 +54,7 @@ public class KsqlConfig extends AbstractConfig implements Cloneable {
   public static final String
       KSQL_SERVICE_ID_CONFIG = "ksql.service.id";
   public static final String
-      KSQL_SERVICE_ID_DEFAULT = "ksql_";
+      KSQL_SERVICE_ID_DEFAULT = "default_";
 
   public static final String
       KSQL_PERSISTENT_QUERY_NAME_PREFIX_CONFIG = "ksql.persistent.prefix";

--- a/ksql-rest-app/src/main/java/io/confluent/ksql/rest/server/KsqlRestConfig.java
+++ b/ksql-rest-app/src/main/java/io/confluent/ksql/rest/server/KsqlRestConfig.java
@@ -70,6 +70,8 @@ public class KsqlRestConfig extends RestConfig {
   public static final String INSTALL_DIR_DOC
       = "The directory that ksql is installed in. This is set in the ksql-server-start script.";
 
+  public static final String COMMAND_TOPIC_SUFFIX = "command_topic";
+
   private static final ConfigDef CONFIG_DEF;
 
   static {
@@ -133,9 +135,10 @@ public class KsqlRestConfig extends RestConfig {
 
   public String getCommandTopic(String ksqlServiceId) {
     return String.format(
-        "%s-%s",
+        "%s-%s_%s",
         KsqlConstants.KSQL_INTERNAL_TOPIC_PREFIX,
-        ksqlServiceId
+        ksqlServiceId,
+        COMMAND_TOPIC_SUFFIX
     );
   }
 

--- a/ksql-rest-app/src/main/java/io/confluent/ksql/rest/server/KsqlRestConfig.java
+++ b/ksql-rest-app/src/main/java/io/confluent/ksql/rest/server/KsqlRestConfig.java
@@ -135,7 +135,7 @@ public class KsqlRestConfig extends RestConfig {
 
   public String getCommandTopic(String ksqlServiceId) {
     return String.format(
-        "%s-%s_%s",
+        "%s%s_%s",
         KsqlConstants.KSQL_INTERNAL_TOPIC_PREFIX,
         ksqlServiceId,
         COMMAND_TOPIC_SUFFIX

--- a/ksql-rest-app/src/test/java/io/confluent/ksql/rest/server/KsqlRestConfigTest.java
+++ b/ksql-rest-app/src/test/java/io/confluent/ksql/rest/server/KsqlRestConfigTest.java
@@ -83,7 +83,8 @@ public class KsqlRestConfigTest {
   public void ensureCorrectCommandTopicName() {
     KsqlRestConfig config = new KsqlRestConfig(getBaseProperties());
     String commandTopicName = config.getCommandTopic("TestKSql");
-    assertThat(commandTopicName, equalTo("_confluent-ksql--TestKSql"));
+    assertThat(commandTopicName,
+               equalTo("_confluent-ksql--TestKSql_" + KsqlRestConfig.COMMAND_TOPIC_SUFFIX));
   }
 
 }

--- a/ksql-rest-app/src/test/java/io/confluent/ksql/rest/server/KsqlRestConfigTest.java
+++ b/ksql-rest-app/src/test/java/io/confluent/ksql/rest/server/KsqlRestConfigTest.java
@@ -84,7 +84,7 @@ public class KsqlRestConfigTest {
     KsqlRestConfig config = new KsqlRestConfig(getBaseProperties());
     String commandTopicName = config.getCommandTopic("TestKSql");
     assertThat(commandTopicName,
-               equalTo("_confluent-ksql--TestKSql_" + KsqlRestConfig.COMMAND_TOPIC_SUFFIX));
+               equalTo("_confluent-ksql-TestKSql_" + KsqlRestConfig.COMMAND_TOPIC_SUFFIX));
   }
 
 }


### PR DESCRIPTION
Currently, the command topic is composed of the following:
`_confluent-ksql-<ksql.service.id>`.

By default, this means the command topic is `_confluent-ksql-ksql_`.
This isn't a very helpful name for the command topic.

This patch adds a `_command-topic` suffix to the command topic. This
menas that the default command topic would be
`_confluent-ksql-ksql__command_topic`.

If you set the `ksql.service.id` to be `production` then your command
topic would be `_confluent-ksql-production_command_topic`.

Seems like a more operator friendly name for a very important topic.