### PR TITLE
 Close topic printing immediately after it is cancelled in Cli

### DIFF
--- a/ksql-cli/src/main/java/io/confluent/ksql/cli/Cli.java
+++ b/ksql-cli/src/main/java/io/confluent/ksql/cli/Cli.java
@@ -505,10 +505,10 @@ public class Cli implements Closeable, AutoCloseable {
         try {
           topicPrintFuture.get();
         } catch (CancellationException exception) {
+          topicResponse.getResponse().close();
           terminal.writer().println("Topic printing ceased");
           terminal.flush();
         }
-        topicResponse.getResponse().close();
       }
     } else {
       terminal.writer().println(topicResponse.getErrorMessage().getMessage());


### PR DESCRIPTION
Currently when cancelling topic printing in Cli, after Topic printing ceased is shown the topic content is not immediately stopped and continues to show a few rows.

We should close the topic response immediately after the printing is cancelled.
