### PR TITLE
Filter out internal topics in SHOW TOPICS

### DIFF
--- a/ksql-cli/src/test/java/io/confluent/ksql/CliTest.java
+++ b/ksql-cli/src/test/java/io/confluent/ksql/CliTest.java
@@ -132,8 +132,8 @@ public class CliTest extends TestRunner {
 
   private static void testListOrShowCommands() {
     TestResult.OrderedResult testResult = (TestResult.OrderedResult) TestResult.init(true);
-    testResult.addRows(Arrays.asList(Arrays.asList(commandTopicName, "true", "1", "1", "0", "0"),
-        Arrays.asList(orderDataProvider.topicName(), "false", "1", "1", "0", "0")));
+    testResult.addRows(Arrays.asList(Arrays.asList(orderDataProvider.topicName(), "false", "1",
+                                                   "1", "0", "0")));
     testListOrShow("topics", testResult);
     testListOrShow("registered topics", build(COMMANDS_KSQL_TOPIC_NAME, commandTopicName, "JSON"));
     testListOrShow("streams", EMPTY_RESULT);

--- a/ksql-common/src/main/java/io/confluent/ksql/util/KsqlConstants.java
+++ b/ksql-common/src/main/java/io/confluent/ksql/util/KsqlConstants.java
@@ -19,6 +19,7 @@ package io.confluent.ksql.util;
 public class KsqlConstants {
 
   public static final String KSQL_INTERNAL_TOPIC_PREFIX = "_confluent-ksql-";
+  public static final String CONFLUENT_INTERNAL_TOPIC_PREFIX = "__confluent";
 
   public static final String SINK_NUMBER_OF_PARTITIONS = "PARTITIONS";
   public static final String SINK_NUMBER_OF_REPLICAS = "REPLICAS";

--- a/ksql-engine/src/main/java/io/confluent/ksql/util/KafkaTopicClient.java
+++ b/ksql-engine/src/main/java/io/confluent/ksql/util/KafkaTopicClient.java
@@ -72,6 +72,13 @@ public interface KafkaTopicClient extends Closeable {
   Set<String> listTopicNames();
 
   /**
+   * [warn] synchronous call
+   *
+   * @return set of all non-internal topics
+   */
+  Set<String> listNonInternalTopicNames();
+
+  /**
    * [warn] synchronous call to get the response
    *
    * @param topicNames topicNames to describe

--- a/ksql-engine/src/main/java/io/confluent/ksql/util/KafkaTopicClientImpl.java
+++ b/ksql-engine/src/main/java/io/confluent/ksql/util/KafkaTopicClientImpl.java
@@ -131,7 +131,8 @@ public class KafkaTopicClientImpl implements KafkaTopicClient {
   @Override
   public Set<String> listNonInternalTopicNames() {
     return listTopicNames().stream()
-        .filter((topic) -> !topic.startsWith(KsqlConstants.KSQL_INTERNAL_TOPIC_PREFIX))
+        .filter((topic) -> !(topic.startsWith(KsqlConstants.KSQL_INTERNAL_TOPIC_PREFIX)
+                             || topic.startsWith(KsqlConstants.CONFLUENT_INTERNAL_TOPIC_PREFIX)))
         .collect(Collectors.toSet());
   }
 

--- a/ksql-engine/src/main/java/io/confluent/ksql/util/KafkaTopicClientImpl.java
+++ b/ksql-engine/src/main/java/io/confluent/ksql/util/KafkaTopicClientImpl.java
@@ -115,7 +115,7 @@ public class KafkaTopicClientImpl implements KafkaTopicClient {
   @Override
   public boolean isTopicExists(final String topic) {
     log.trace("Checking for existence of topic '{}'", topic);
-    return listTopicNames().contains(topic);
+    return listTopicNames(true).contains(topic);
   }
 
   @Override

--- a/ksql-engine/src/test/java/io/confluent/ksql/util/FakeKafkaTopicClient.java
+++ b/ksql-engine/src/test/java/io/confluent/ksql/util/FakeKafkaTopicClient.java
@@ -112,7 +112,8 @@ public class FakeKafkaTopicClient implements KafkaTopicClient {
   @Override
   public Set<String> listNonInternalTopicNames() {
     return topicMap.keySet().stream()
-        .filter((topic) -> !topic.startsWith(KsqlConstants.KSQL_INTERNAL_TOPIC_PREFIX))
+        .filter((topic) -> (!topic.startsWith(KsqlConstants.KSQL_INTERNAL_TOPIC_PREFIX)
+                            || !topic.startsWith(KsqlConstants.CONFLUENT_INTERNAL_TOPIC_PREFIX)))
         .collect(Collectors.toSet());
   }
 

--- a/ksql-engine/src/test/java/io/confluent/ksql/util/FakeKafkaTopicClient.java
+++ b/ksql-engine/src/test/java/io/confluent/ksql/util/FakeKafkaTopicClient.java
@@ -110,6 +110,13 @@ public class FakeKafkaTopicClient implements KafkaTopicClient {
   }
 
   @Override
+  public Set<String> listNonInternalTopicNames() {
+    return topicMap.keySet().stream()
+        .filter((topic) -> !topic.startsWith(KsqlConstants.KSQL_INTERNAL_TOPIC_PREFIX))
+        .collect(Collectors.toSet());
+  }
+
+  @Override
   public Map<String, TopicDescription> describeTopics(Collection<String> topicNames) {
     return listTopicNames()
         .stream()

--- a/ksql-engine/src/test/java/io/confluent/ksql/util/KafkaTopicClientTest.java
+++ b/ksql-engine/src/test/java/io/confluent/ksql/util/KafkaTopicClientTest.java
@@ -196,7 +196,7 @@ public class KafkaTopicClientTest {
     expect(adminClient.describeConfigs(anyObject())).andReturn(getDescribeConfigsResult());
     replay(adminClient);
     KafkaTopicClient kafkaTopicClient = new KafkaTopicClientImpl(adminClient);
-    Set<String> names = kafkaTopicClient.listTopicNames();
+    Set<String> names = kafkaTopicClient.listNonInternalTopicNames();
     assertThat(names, equalTo(Utils.mkSet(topicName1, topicName2, topicName3)));
     verify(adminClient);
   }

--- a/ksql-engine/src/test/java/io/confluent/ksql/util/KafkaTopicClientTest.java
+++ b/ksql-engine/src/test/java/io/confluent/ksql/util/KafkaTopicClientTest.java
@@ -73,6 +73,9 @@ public class KafkaTopicClientTest {
                                                       "default",
                                                       "query_CTAS_USERS_BY_CITY-KSTREAM-AGGREGATE"
                                                       + "-STATE-STORE-0000000006-changelog");
+  private final String confluentInternalTopic =
+      String.format("%s-%s", KsqlConstants.CONFLUENT_INTERNAL_TOPIC_PREFIX,
+                    "confluent-control-center");
 
 
   @Before
@@ -341,7 +344,8 @@ public class KafkaTopicClientTest {
   private ListTopicsResult getListTopicsResultWithInternalTopics() {
     ListTopicsResult listTopicsResult = mock(ListTopicsResult.class);
     List<String> topicNamesList = Arrays.asList(topicName1, topicName2, topicName3,
-                                                internalTopic1, internalTopic2);
+                                                internalTopic1, internalTopic2,
+                                                confluentInternalTopic);
     expect(listTopicsResult.names()).andReturn(KafkaFuture.completedFuture(new HashSet<>
                                                                                (topicNamesList)));
     replay(listTopicsResult);

--- a/ksql-engine/src/test/java/io/confluent/ksql/util/KafkaTopicClientTest.java
+++ b/ksql-engine/src/test/java/io/confluent/ksql/util/KafkaTopicClientTest.java
@@ -233,7 +233,8 @@ public class KafkaTopicClientTest {
     expect(adminClient.describeCluster()).andReturn(getDescribeClusterResult());
     expect(adminClient.listTopics()).andReturn(getListTopicsResultWithInternalTopics());
     expect(adminClient.describeConfigs(anyObject())).andReturn(getDescribeConfigsResult());
-    expect(adminClient.deleteTopics(anyObject())).andReturn(getDeleteInternalTopicsResult());
+    expect(adminClient.deleteTopics(Arrays.asList(internalTopic2, internalTopic1)))
+        .andReturn(getDeleteInternalTopicsResult());
     replay(adminClient);
     KafkaTopicClient kafkaTopicClient = new KafkaTopicClientImpl(adminClient);
     String applicationId = String.format("%s%s",

--- a/ksql-engine/src/test/java/io/confluent/ksql/util/KafkaTopicClientTest.java
+++ b/ksql-engine/src/test/java/io/confluent/ksql/util/KafkaTopicClientTest.java
@@ -61,8 +61,19 @@ public class KafkaTopicClientTest {
   private Node node;
 
   private final String topicName1 = "topic1";
-  private final String topicName2 = "ksql_query_2-KSTREAM-MAP-0000000012-repartition";
-  private final String topicName3 = "ksql_query_2-KSTREAM-REDUCE-STATE-STORE-0000000003-changelog";
+  private final String topicName2 = "topic2";
+  private final String topicName3 = "topic3";
+  private final String internalTopic1 = String.format("%s%s_%s",
+                                                      KsqlConstants.KSQL_INTERNAL_TOPIC_PREFIX,
+                                                      "default",
+                                                      "query_CTAS_USERS_BY_CITY-KSTREAM-AGGREGATE"
+                                                      + "-STATE-STORE-0000000006-repartition");
+  private final String internalTopic2 = String.format("%s%s_%s",
+                                                      KsqlConstants.KSQL_INTERNAL_TOPIC_PREFIX,
+                                                      "default",
+                                                      "query_CTAS_USERS_BY_CITY-KSTREAM-AGGREGATE"
+                                                      + "-STATE-STORE-0000000006-changelog");
+
 
   @Before
   public void init() {
@@ -178,6 +189,19 @@ public class KafkaTopicClientTest {
   }
 
   @Test
+  public void shouldFilterInternalTopics() {
+    AdminClient adminClient = mock(AdminClient.class);
+    expect(adminClient.describeCluster()).andReturn(getDescribeClusterResult());
+    expect(adminClient.listTopics()).andReturn(getListTopicsResultWithInternalTopics());
+    expect(adminClient.describeConfigs(anyObject())).andReturn(getDescribeConfigsResult());
+    replay(adminClient);
+    KafkaTopicClient kafkaTopicClient = new KafkaTopicClientImpl(adminClient);
+    Set<String> names = kafkaTopicClient.listTopicNames();
+    assertThat(names, equalTo(Utils.mkSet(topicName1, topicName2, topicName3)));
+    verify(adminClient);
+  }
+
+  @Test
   public void testListTopicNames() {
     AdminClient adminClient = mock(AdminClient.class);
     expect(adminClient.describeCluster()).andReturn(getDescribeClusterResult());
@@ -207,12 +231,15 @@ public class KafkaTopicClientTest {
   public void testDeleteInternalTopics() {
     AdminClient adminClient = mock(AdminClient.class);
     expect(adminClient.describeCluster()).andReturn(getDescribeClusterResult());
-    expect(adminClient.listTopics()).andReturn(getListTopicsResult());
+    expect(adminClient.listTopics()).andReturn(getListTopicsResultWithInternalTopics());
     expect(adminClient.describeConfigs(anyObject())).andReturn(getDescribeConfigsResult());
-    expect(adminClient.deleteTopics(anyObject())).andReturn(getDeleteTopicsResult());
+    expect(adminClient.deleteTopics(anyObject())).andReturn(getDeleteInternalTopicsResult());
     replay(adminClient);
     KafkaTopicClient kafkaTopicClient = new KafkaTopicClientImpl(adminClient);
-    kafkaTopicClient.deleteInternalTopics("ksql_query_2");
+    String applicationId = String.format("%s%s",
+                                         KsqlConstants.KSQL_INTERNAL_TOPIC_PREFIX,
+                                         "default_query_CTAS_USERS_BY_CITY");
+    kafkaTopicClient.deleteInternalTopics(applicationId);
     verify(adminClient);
   }
 
@@ -271,6 +298,16 @@ public class KafkaTopicClientTest {
     return createTopicsResult;
   }
 
+  private DeleteTopicsResult getDeleteInternalTopicsResult() {
+    DeleteTopicsResult deleteTopicsResult = mock(DeleteTopicsResult.class);
+    Map<String, KafkaFuture<Void>> deletedTopics = new HashMap<>();
+    deletedTopics.put(internalTopic1, KafkaFuture.allOf());
+    deletedTopics.put(internalTopic2, KafkaFuture.allOf());
+    expect(deleteTopicsResult.values()).andReturn(deletedTopics);
+    replay(deleteTopicsResult);
+    return deleteTopicsResult;
+  }
+
   private DeleteTopicsResult getDeleteTopicsResult() {
     DeleteTopicsResult deleteTopicsResult = mock(DeleteTopicsResult.class);
     expect(deleteTopicsResult.values()).andReturn(Collections.singletonMap(topicName1, KafkaFuture
@@ -297,6 +334,16 @@ public class KafkaTopicClientTest {
     expect(resultFuture.get()).andThrow(new ExecutionException(
         new NotControllerException("Not Controller")));
     replay(listTopicsResult, resultFuture);
+    return listTopicsResult;
+  }
+
+  private ListTopicsResult getListTopicsResultWithInternalTopics() {
+    ListTopicsResult listTopicsResult = mock(ListTopicsResult.class);
+    List<String> topicNamesList = Arrays.asList(topicName1, topicName2, topicName3,
+                                                internalTopic1, internalTopic2);
+    expect(listTopicsResult.names()).andReturn(KafkaFuture.completedFuture(new HashSet<>
+                                                                               (topicNamesList)));
+    replay(listTopicsResult);
     return listTopicsResult;
   }
 

--- a/ksql-rest-app/src/main/java/io/confluent/ksql/rest/server/resources/KsqlResource.java
+++ b/ksql-rest-app/src/main/java/io/confluent/ksql/rest/server/resources/KsqlResource.java
@@ -292,7 +292,7 @@ public class KsqlResource {
       return KafkaTopicsList.build(
           statementText,
           getKsqlTopics(),
-          client.describeTopics(client.listTopicNames()),
+          client.describeTopics(client.listNonInternalTopicNames()),
           ksqlEngine.getKsqlConfig(),
           kafkaConsumerGroupClient
       );

--- a/ksql-rest-app/src/test/java/io/confluent/ksql/rest/server/mock/MockKafkaTopicClient.java
+++ b/ksql-rest-app/src/test/java/io/confluent/ksql/rest/server/mock/MockKafkaTopicClient.java
@@ -59,6 +59,11 @@ public class MockKafkaTopicClient implements KafkaTopicClient {
   }
 
   @Override
+  public Set<String> listNonInternalTopicNames() {
+    return Collections.EMPTY_SET;
+  }
+
+  @Override
   public Map<String, TopicDescription> describeTopics(Collection<String> topicNames) {
     return Collections.EMPTY_MAP;
   }


### PR DESCRIPTION
Fixes #910 

In the future, we can add a `SHOW TOPICS ALL;` command to include the internal topics. But for GA, it might make sense to not show them through KSQL at all -- they add little value.