### PR TITLE
Support SR SSL configuration without the use of environment variables.

### DIFF
--- a/ksql-common/src/main/java/io/confluent/ksql/util/KsqlConfig.java
+++ b/ksql-common/src/main/java/io/confluent/ksql/util/KsqlConfig.java
@@ -24,7 +24,6 @@ import org.apache.kafka.streams.StreamsConfig;
 
 import java.util.HashMap;
 import java.util.Map;
-import java.util.Set;
 import java.util.stream.Collectors;
 
 import io.confluent.ksql.errors.LogMetricAndContinueExceptionHandler;
@@ -38,6 +37,8 @@ public class KsqlConfig extends AbstractConfig implements Cloneable {
   public static final String SINK_NUMBER_OF_PARTITIONS_PROPERTY = "ksql.sink.partitions";
 
   public static final String SINK_NUMBER_OF_REPLICAS_PROPERTY = "ksql.sink.replicas";
+
+  public static final String KSQL_SCHEMA_REGISTRY_PREFIX = "ksql.schema.registry.";
 
   public static final String SCHEMA_REGISTRY_URL_PROPERTY = "ksql.schema.registry.url";
 
@@ -75,10 +76,10 @@ public class KsqlConfig extends AbstractConfig implements Cloneable {
       defaultSchemaRegistryUrl = "http://localhost:8081";
 
   public static final boolean defaultAvroSchemaUnionNull = true;
-  public static final String KSQL_STREAMS_PREFIX      = "ksql.streams.";
+  public static final String KSQL_STREAMS_PREFIX = "ksql.streams.";
 
-  Map<String, Object> ksqlConfigProps;
-  Map<String, Object> ksqlStreamConfigProps;
+  private final Map<String, Object> ksqlConfigProps;
+  private final Map<String, Object> ksqlStreamConfigProps;
 
   private static final ConfigDef CONFIG_DEF;
 
@@ -143,8 +144,7 @@ public class KsqlConfig extends AbstractConfig implements Cloneable {
             defaultSchemaRegistryUrl,
             ConfigDef.Importance.MEDIUM,
             "The URL for the schema registry, defaults to http://localhost:8081"
-        )
-    ;
+        ).withClientSslSupport();
   }
 
   private static Map<String, Object> commonConfigs(Map<String, Object> props) {
@@ -201,13 +201,8 @@ public class KsqlConfig extends AbstractConfig implements Cloneable {
   }
 
   public Map<String, Object> getKsqlAdminClientConfigProps() {
-    Set<String> adminClientConfigProperties = AdminClientConfig.configNames();
-    Map<String, Object> adminClientConfigs = new HashMap<>();
-    for (Map.Entry<String, Object> entry : ksqlStreamConfigProps.entrySet()) {
-      if (adminClientConfigProperties.contains(entry.getKey())) {
-        adminClientConfigs.put(entry.getKey(), entry.getValue());
-      }
-    }
+    final Map<String, Object> adminClientConfigs = new HashMap<>(ksqlStreamConfigProps);
+    adminClientConfigs.keySet().retainAll(AdminClientConfig.configNames());
     return adminClientConfigs;
   }
 
@@ -236,14 +231,22 @@ public class KsqlConfig extends AbstractConfig implements Cloneable {
     return new KsqlConfig(clonedProperties);
   }
 
-  public KsqlConfig cloneWithPropertyOverwrite(Map<String, Object> props) {
-    Map<String, Object> clonedProperties = new HashMap<>();
-    clonedProperties.putAll(ksqlConfigProps);
-    clonedProperties.putAll(
-        ksqlStreamConfigProps.entrySet().stream()
-            .collect(Collectors.toMap(e -> KSQL_STREAMS_PREFIX + e.getKey(), e -> e.getValue())));
-    clonedProperties.putAll(props);
-    KsqlConfig clone = new KsqlConfig(clonedProperties);
+  public KsqlConfig cloneWithPropertyOverwrite(final Map<String, Object> props) {
+    final Map<String, Object> cloned = new HashMap<>();
+
+    cloned.putAll(ksqlConfigProps.entrySet().stream()
+                      .filter(e -> e.getValue() != null)
+                      .collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue)));
+
+    cloned.putAll(ksqlStreamConfigProps.entrySet().stream()
+                      .filter(e -> e.getValue() != null)
+                      .collect(Collectors.toMap(
+                          e -> KSQL_STREAMS_PREFIX + e.getKey(),
+                          Map.Entry::getValue)));
+
+    cloned.putAll(props);
+
+    final KsqlConfig clone = new KsqlConfig(cloned);
     // re-apply streams configs so that any un-prefixed overwrite settings
     // take precedence over older prefixed settings
     clone.applyStreamsConfig(props);

--- a/ksql-engine/src/main/java/io/confluent/ksql/KsqlEngine.java
+++ b/ksql-engine/src/main/java/io/confluent/ksql/KsqlEngine.java
@@ -38,7 +38,6 @@ import java.util.concurrent.Executors;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.TimeUnit;
 
-import io.confluent.kafka.schemaregistry.client.CachedSchemaRegistryClient;
 import io.confluent.kafka.schemaregistry.client.SchemaRegistryClient;
 import io.confluent.ksql.ddl.DdlConfig;
 import io.confluent.ksql.ddl.commands.CommandFactories;
@@ -73,6 +72,7 @@ import io.confluent.ksql.parser.tree.Statement;
 import io.confluent.ksql.parser.tree.Table;
 import io.confluent.ksql.planner.plan.PlanNode;
 import io.confluent.ksql.query.QueryId;
+import io.confluent.ksql.schema.registry.KsqlSchemaRegistryClientFactory;
 import io.confluent.ksql.serde.DataSource;
 import io.confluent.ksql.util.DataSourceExtractor;
 import io.confluent.ksql.util.KafkaTopicClient;
@@ -91,7 +91,7 @@ public class KsqlEngine implements Closeable, QueryTerminator {
       StreamsConfig.BOOTSTRAP_SERVERS_CONFIG
   );
 
-  private KsqlConfig ksqlConfig;
+  private final KsqlConfig ksqlConfig;
 
   private final MetaStore metaStore;
   private final KafkaTopicClient topicClient;
@@ -112,10 +112,7 @@ public class KsqlEngine implements Closeable, QueryTerminator {
     this(
         ksqlConfig,
         topicClient,
-        new CachedSchemaRegistryClient(
-            (String) ksqlConfig.get(KsqlConfig.SCHEMA_REGISTRY_URL_PROPERTY),
-            1000
-        ),
+        new KsqlSchemaRegistryClientFactory(ksqlConfig).create(),
         new MetaStoreImpl()
     );
   }

--- a/ksql-engine/src/main/java/io/confluent/ksql/schema/registry/KsqlSchemaRegistryClientFactory.java
+++ b/ksql-engine/src/main/java/io/confluent/ksql/schema/registry/KsqlSchemaRegistryClientFactory.java
@@ -1,0 +1,67 @@
+/*
+ * Copyright 2018 Confluent Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.confluent.ksql.schema.registry;
+
+import org.apache.kafka.common.network.Mode;
+import org.apache.kafka.common.security.ssl.SslFactory;
+
+import java.util.function.Supplier;
+
+import javax.net.ssl.SSLContext;
+
+import io.confluent.kafka.schemaregistry.client.CachedSchemaRegistryClient;
+import io.confluent.kafka.schemaregistry.client.SchemaRegistryClient;
+import io.confluent.kafka.schemaregistry.client.rest.RestService;
+import io.confluent.ksql.util.KsqlConfig;
+
+/**
+ * Configurable Schema Registry client factory, enabling SSL.
+ */
+public class KsqlSchemaRegistryClientFactory {
+
+  private final SslFactory sslFactory;
+  private final Supplier<RestService> serviceSupplier;
+
+  public KsqlSchemaRegistryClientFactory(final KsqlConfig config) {
+    this(config,
+         () -> new RestService(config.getString(KsqlConfig.SCHEMA_REGISTRY_URL_PROPERTY)),
+         new SslFactory(Mode.CLIENT));
+
+    // Force config exception now:
+    config.getString(KsqlConfig.SCHEMA_REGISTRY_URL_PROPERTY);
+  }
+
+  KsqlSchemaRegistryClientFactory(final KsqlConfig config,
+                                  final Supplier<RestService> serviceSupplier,
+                                  final SslFactory sslFactory) {
+    this.sslFactory = sslFactory;
+    this.serviceSupplier = serviceSupplier;
+
+    this.sslFactory
+        .configure(config.valuesWithPrefixOverride(KsqlConfig.KSQL_SCHEMA_REGISTRY_PREFIX));
+  }
+
+  public SchemaRegistryClient create() {
+    final RestService restService = serviceSupplier.get();
+    final SSLContext sslContext = sslFactory.sslContext();
+    if (sslContext != null) {
+      restService.setSslSocketFactory(sslContext.getSocketFactory());
+    }
+
+    return new CachedSchemaRegistryClient(restService, 1000);
+  }
+}

--- a/ksql-engine/src/main/java/io/confluent/ksql/schema/registry/KsqlSchemaRegistryClientFactory.java
+++ b/ksql-engine/src/main/java/io/confluent/ksql/schema/registry/KsqlSchemaRegistryClientFactory.java
@@ -37,8 +37,7 @@ public class KsqlSchemaRegistryClientFactory {
   private final Supplier<RestService> serviceSupplier;
 
   public KsqlSchemaRegistryClientFactory(final KsqlConfig config) {
-    this(config,
-         () -> new RestService(config.getString(KsqlConfig.SCHEMA_REGISTRY_URL_PROPERTY)),
+    this(config, () -> new RestService(config.getString(KsqlConfig.SCHEMA_REGISTRY_URL_PROPERTY)),
          new SslFactory(Mode.CLIENT));
 
     // Force config exception now:

--- a/ksql-engine/src/test/java/io/confluent/ksql/integration/SecureIntegrationTest.java
+++ b/ksql-engine/src/test/java/io/confluent/ksql/integration/SecureIntegrationTest.java
@@ -310,11 +310,8 @@ public class SecureIntegrationTest {
         (hostname, sslSession) -> hostname.equals("localhost"));
 
     try {
-      System.setProperty("javax.net.ssl.trustStore", ClientTrustStore.trustStorePath());
-      System.setProperty("javax.net.ssl.trustStorePassword", "password");
-
       final Map<String, Object> ksqlConfig = getKsqlConfig(SUPER_USER);
-      ksqlConfig.put(KsqlConfig.SCHEMA_REGISTRY_URL_PROPERTY, "https://localhost:8481");
+      ksqlConfig.put("ksql.schema.registry.url", "https://localhost:8481");
       givenTestSetupWithConfig(ksqlConfig);
 
       // Then:

--- a/ksql-engine/src/test/java/io/confluent/ksql/schema/registry/KsqlSchemaRegistryClientFactoryTest.java
+++ b/ksql-engine/src/test/java/io/confluent/ksql/schema/registry/KsqlSchemaRegistryClientFactoryTest.java
@@ -1,0 +1,165 @@
+/*
+ * Copyright 2018 Confluent Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.confluent.ksql.schema.registry;
+
+import com.google.common.collect.ImmutableMap;
+
+import org.apache.kafka.common.config.SslConfigs;
+import org.apache.kafka.common.network.Mode;
+import org.apache.kafka.common.security.ssl.SslFactory;
+import org.easymock.EasyMock;
+import org.easymock.EasyMockRunner;
+import org.easymock.Mock;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import java.util.Collections;
+import java.util.Map;
+import java.util.function.Supplier;
+
+import javax.net.ssl.SSLContext;
+
+import io.confluent.kafka.schemaregistry.client.SchemaRegistryClient;
+import io.confluent.kafka.schemaregistry.client.rest.RestService;
+import io.confluent.ksql.util.KsqlConfig;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.notNullValue;
+
+/**
+ * @author andy
+ * created 3/26/18
+ */
+@RunWith(EasyMockRunner.class)
+public class KsqlSchemaRegistryClientFactoryTest {
+
+  private static final SSLContext SSL_CONTEXT = getTestSslContext();
+
+  @Mock
+  private Supplier<RestService> restServiceSupplier;
+
+  @Mock
+  private RestService restService;
+
+  @Mock
+  private SslFactory sslFactory;
+
+  @Before
+  public void setUp() {
+    EasyMock.expect(restServiceSupplier.get()).andReturn(restService);
+    EasyMock.replay(restServiceSupplier);
+
+    EasyMock.expect(sslFactory.sslContext()).andReturn(SSL_CONTEXT);
+  }
+
+  @Test
+  public void shouldSetSocketFactoryWhenNoSpecificSslConfig() {
+    // Given:
+    final KsqlConfig config = config();
+
+    final Map<String, Object> expectedConfigs = defaultConfigs();
+    setUpMocksWithExpectedConfig(expectedConfigs);
+
+    // When:
+    final SchemaRegistryClient client =
+        new KsqlSchemaRegistryClientFactory(config, restServiceSupplier, sslFactory).create();
+
+    // Then:
+    assertThat(client, is(notNullValue()));
+    EasyMock.verify(restService);
+  }
+
+  @Test
+  public void shouldPickUpNonPrefixedSslConfig() {
+    // Given:
+    final KsqlConfig config = config(
+        SslConfigs.SSL_PROTOCOL_CONFIG, "SSLv3"
+    );
+
+    final Map<String, Object> expectedConfigs = defaultConfigs();
+    expectedConfigs.put(SslConfigs.SSL_PROTOCOL_CONFIG, "SSLv3");
+    setUpMocksWithExpectedConfig(expectedConfigs);
+
+    // When:
+    final SchemaRegistryClient client =
+        new KsqlSchemaRegistryClientFactory(config, restServiceSupplier, sslFactory).create();
+
+    // Then:
+    assertThat(client, is(notNullValue()));
+    EasyMock.verify(restService);
+  }
+
+  @Test
+  public void shouldPickUpPrefixedSslConfig() {
+    // Given:
+    final KsqlConfig config = config(
+        "ksql.schema.registry." + SslConfigs.SSL_PROTOCOL_CONFIG, "SSLv3"
+    );
+
+    final Map<String, Object> expectedConfigs = defaultConfigs();
+    expectedConfigs.put(SslConfigs.SSL_PROTOCOL_CONFIG, "SSLv3");
+    setUpMocksWithExpectedConfig(expectedConfigs);
+
+    // When:
+    final SchemaRegistryClient client =
+        new KsqlSchemaRegistryClientFactory(config, restServiceSupplier, sslFactory).create();
+
+    // Then:
+    assertThat(client, is(notNullValue()));
+    EasyMock.verify(restService);
+  }
+
+  private void setUpMocksWithExpectedConfig(final Map<String, Object> expectedConfigs) {
+    sslFactory.configure(expectedConfigs);
+    EasyMock.expectLastCall();
+
+    restService.setSslSocketFactory(EasyMock.anyObject(SSL_CONTEXT.getSocketFactory().getClass()));
+    EasyMock.expectLastCall();
+
+    EasyMock.replay(restService, sslFactory);
+  }
+
+  private static Map<String, Object> defaultConfigs() {
+    return config().valuesWithPrefixOverride(KsqlConfig.KSQL_SCHEMA_REGISTRY_PREFIX);
+  }
+
+  private static KsqlConfig config() {
+    return new KsqlConfig(ImmutableMap.of());
+  }
+
+  private static KsqlConfig config(final String k1, final Object v1) {
+    return new KsqlConfig(ImmutableMap.of(k1, v1));
+  }
+
+  private static KsqlConfig config(final String k1, final Object v1,
+                                   final String k2, final Object v2) {
+    return new KsqlConfig(ImmutableMap.of(k1, v1, k2, v2));
+  }
+
+  // Can't mock SSLContext.
+  private static SSLContext getTestSslContext() {
+    final SslFactory sslFactory = new SslFactory(Mode.CLIENT);
+
+    final Map<String, Object> configs = new KsqlConfig(Collections.emptyMap())
+        .valuesWithPrefixOverride(KsqlConfig.KSQL_SCHEMA_REGISTRY_PREFIX);
+
+    sslFactory.configure(configs);
+    return sslFactory.sslContext();
+  }
+}


### PR DESCRIPTION
Fix for #950 

This PR explicitly adds the SSL config names to the KSQL configuration, extends the `ksql.schema.registry.` prefix to allow SSL overrides specific to the SR to be supplied, and then wires this all up to configure the `SslSocketFactory` used by the SR Client.

For example, where the same SSL configuration is needed from the Schema Registry as for the Kafka brokers, then config like this can be used:

```
# Configure SR to use HTTPS end pint:
ksql.schema.registry.url=https://some.secure.url

# Common SSL config, (picked up by both Kafka and SR clients):
security.protocol=SSL
ssl.truststore.location=/etc/kafka/secrets/kafka.client.truststore.jks
ssl.truststore.password=confluent
```

Where SR requires different configuration, it also supports overrides:

```
# Configure SR to use HTTPS end pint:
ksql.schema.registry.url=https://some.secure.url
ksql.schema.registry.security.protocol=SSL
ksql.schema.registry.ssl.truststore.location=/etc/kafka/secrets/kafka.client.truststore.jks
ksql.schema.registry.ssl.truststore.password=confluent
```

Still to do... 
- [ ] SASL Support.
- [ ] Update Docs.