### PR TITLE
Fix local quickstart docs

### DIFF
--- a/docs/includes/ksql-includes.rst
+++ b/docs/includes/ksql-includes.rst
@@ -75,7 +75,7 @@ These examples query messages from Kafka topics called ``pageviews`` and ``users
 
    .. code:: bash
 
-       $ <path-to-confluent>/bin/ksql-cli local
+       $ <path-to-confluent>/bin/ksql
 
    After KSQL is started, your terminal should resemble this.
 
@@ -83,7 +83,8 @@ These examples query messages from Kafka topics called ``pageviews`` and ``users
       :start-line: 17
       :end-line: 38
 
-    #. Create a stream ``pageviews_original`` from the Kafka topic ``pageviews``, specifying the ``value_format`` of ``DELIMITED``.
+#. Create a stream ``pageviews_original`` from the Kafka topic ``pageviews``, specifying the ``value_format`` of ``DELIMITED``.
+
    Describe the new STREAM. Notice that KSQL created additional columns called ``ROWTIME``, which corresponds to the Kafka message timestamp,
    and ``ROWKEY``, which corresponds to the Kafka message key.
 

--- a/docs/tutorials/basics-local.rst
+++ b/docs/tutorials/basics-local.rst
@@ -20,22 +20,6 @@ this Kafka cluster. KSQL is installed in the |cp| by default.
       :start-line: 40
       :end-line: 63
 
-----------
-Start KSQL
-----------
-
-Launch the KSQL CLI.
-
-.. code:: bash
-
-      $ <path-to-confluent>/bin/ksql
-
-After KSQL is started, your terminal should resemble this.
-
-.. include:: ../includes/ksql-includes.rst
-      :start-line: 17
-      :end-line: 38
-
 .. include:: ../includes/ksql-includes.rst
       :start-line: 63
       :end-line: 317


### PR DESCRIPTION
- ksql-cli local --> ksql
- Get rid of redundant cli start instructions
- fix some typos that prevent the cli welcome msg from rendering