### PR TITLE
Fix bad merge which retained a reference to MetastoreUtil 

### DIFF
--- a/ksql-engine/src/test/java/io/confluent/ksql/planner/plan/KsqlStructuredDataOutputNodeTest.java
+++ b/ksql-engine/src/test/java/io/confluent/ksql/planner/plan/KsqlStructuredDataOutputNodeTest.java
@@ -201,7 +201,6 @@ public class KsqlStructuredDataOutputNodeTest {
         streamsBuilder,
         ksqlConfig,
         topicClientForNonWindowTable,
-        new MetastoreUtil(),
         new FunctionRegistry(),
         new HashMap<>(),
         new MockSchemaRegistryClient());
@@ -222,7 +221,6 @@ public class KsqlStructuredDataOutputNodeTest {
         streamsBuilder,
         ksqlConfig,
         topicClientForWindowTable,
-        new MetastoreUtil(),
         new FunctionRegistry(),
         new HashMap<>(),
         new MockSchemaRegistryClient());
@@ -242,7 +240,6 @@ public class KsqlStructuredDataOutputNodeTest {
         streamsBuilder,
         ksqlConfig,
         topicClientForWindowTable,
-        new MetastoreUtil(),
         new FunctionRegistry(),
         new HashMap<>(),
         new MockSchemaRegistryClient());


### PR DESCRIPTION
Bad merge was by me at [eea96453](https://github.com/confluentinc/ksql/commit/eea96453dea11cec678c4d8b8b0f868471ef55c7).

MetastoreUtil doesn't exist on master.