### PR TITLE
Enhance end-to-end integration test.

### DIFF
--- a/ksql-engine/src/main/java/io/confluent/ksql/KsqlEngine.java
+++ b/ksql-engine/src/main/java/io/confluent/ksql/KsqlEngine.java
@@ -522,7 +522,7 @@ public class KsqlEngine implements Closeable, QueryTerminator {
 
   @Override
   public void close() {
-    for (QueryMetadata queryMetadata : livePersistentQueries) {
+    for (QueryMetadata queryMetadata : allLiveQueries) {
       queryMetadata.close();
     }
     topicClient.close();

--- a/ksql-engine/src/test/java/io/confluent/ksql/integration/EndToEndIntegrationTest.java
+++ b/ksql-engine/src/test/java/io/confluent/ksql/integration/EndToEndIntegrationTest.java
@@ -15,26 +15,18 @@
  **/
 package io.confluent.ksql.integration;
 
-import io.confluent.common.utils.IntegrationTest;
-import io.confluent.ksql.GenericRow;
-import io.confluent.ksql.KsqlEngine;
-import io.confluent.ksql.util.KafkaTopicClient;
-import io.confluent.ksql.util.KafkaTopicClientImpl;
-import io.confluent.ksql.util.KsqlConfig;
-import io.confluent.ksql.util.PageViewDataProvider;
-import io.confluent.ksql.util.PersistentQueryMetadata;
-import io.confluent.ksql.util.QueryMetadata;
-import io.confluent.ksql.util.QueuedQueryMetadata;
-import io.confluent.ksql.util.UserDataProvider;
 import org.apache.kafka.clients.admin.AdminClient;
 import org.apache.kafka.clients.consumer.ConsumerConfig;
 import org.apache.kafka.common.utils.Utils;
 import org.apache.kafka.streams.KeyValue;
+import org.apache.kafka.test.IntegrationTest;
 import org.apache.kafka.test.TestUtils;
 import org.junit.After;
 import org.junit.Before;
+import org.junit.Rule;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
+import org.junit.rules.Timeout;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -47,10 +39,24 @@ import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.BlockingQueue;
 import java.util.concurrent.TimeUnit;
+import java.util.stream.Collectors;
 
+import io.confluent.ksql.GenericRow;
+import io.confluent.ksql.KsqlEngine;
+import io.confluent.ksql.util.KafkaTopicClient;
+import io.confluent.ksql.util.KafkaTopicClientImpl;
+import io.confluent.ksql.util.KsqlConfig;
+import io.confluent.ksql.util.PageViewDataProvider;
+import io.confluent.ksql.util.QueryMetadata;
+import io.confluent.ksql.util.QueuedQueryMetadata;
+import io.confluent.ksql.util.UserDataProvider;
+
+import static java.lang.String.format;
+import static org.hamcrest.Matchers.either;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.startsWith;
 import static org.hamcrest.core.IsInstanceOf.instanceOf;
 import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.assertThat;
 
 /**
@@ -59,18 +65,21 @@ import static org.junit.Assert.assertThat;
  */
 @Category({IntegrationTest.class})
 public class EndToEndIntegrationTest {
+
   private static final Logger log = LoggerFactory.getLogger(EndToEndIntegrationTest.class);
   private IntegrationTestHarness testHarness;
   private KsqlEngine ksqlEngine;
 
   private PageViewDataProvider pageViewDataProvider;
-  private UserDataProvider userDataProvider;
 
   private final String pageViewTopic = "pageviews";
   private final String usersTopic = "users";
 
   private final String pageViewStream = "pageviews_original";
   private final String userTable = "users_original";
+
+  @Rule
+  public final Timeout timeout = Timeout.seconds(120);
 
   @Before
   public void before() throws Exception {
@@ -89,102 +98,38 @@ public class EndToEndIntegrationTest {
     testHarness.createTopic(usersTopic);
 
     pageViewDataProvider = new PageViewDataProvider();
-    userDataProvider = new UserDataProvider();
 
-    testHarness.publishTestData(usersTopic, userDataProvider, System.currentTimeMillis() - 10000);
+    testHarness.publishTestData(
+        usersTopic, new UserDataProvider(), System.currentTimeMillis() - 10000);
     testHarness.publishTestData(pageViewTopic, pageViewDataProvider, System.currentTimeMillis());
 
-    ksqlEngine.buildMultipleQueries(String.format("CREATE TABLE %s (registertime bigint, gender varchar, regionid varchar, " +
-            "userid varchar) WITH (kafka_topic='%s', value_format='JSON', key = 'userid');",
-                                                         userTable,
-                                                         usersTopic), Collections.emptyMap());
-    ksqlEngine.buildMultipleQueries(String.format("CREATE STREAM %s (viewtime bigint, userid varchar, pageid varchar) " +
-            "WITH (kafka_topic='%s', value_format='JSON');", pageViewStream, pageViewTopic), Collections.emptyMap());
+    ksqlEngine.buildMultipleQueries(
+        format("CREATE TABLE %s (registertime bigint, gender varchar, regionid varchar, " +
+               "userid varchar) WITH (kafka_topic='%s', value_format='JSON', key = 'userid');",
+               userTable,
+               usersTopic), Collections.emptyMap());
+    ksqlEngine.buildMultipleQueries(
+        format("CREATE STREAM %s (viewtime bigint, userid varchar, pageid varchar) " +
+               "WITH (kafka_topic='%s', value_format='JSON');", pageViewStream,
+               pageViewTopic), Collections.emptyMap());
   }
 
   @After
-  public void after() throws Exception {
+  public void after() {
     ksqlEngine.close();
     testHarness.stop();
   }
 
   @Test
-  public void testKSQLFromEndToEnd() throws Exception {
-    validateSelectFromPageViewsWithSpecificColumn();
-    validateSelectAllFromUsers();
-    String derivedStream = validateSelectAllFromDerivedStream();
-    validateCreateStreamUsingLikeClause(derivedStream);
-  }
-
-  @Test
-  public void shouldRetainSelectedColumnsInPartitionBy() throws Exception {
-    String createStreamStatement = String.format("CREATE STREAM pageviews_by_viewtime as select "
-                                                 + "viewtime, pageid, userid from "
-                                                 + "pageviews_original "
-                                                 + "partition by "
-                                                 + "viewtime;");
-
-    List<QueryMetadata> queries = ksqlEngine.buildMultipleQueries(createStreamStatement,
-                                                                  Collections.emptyMap());
-
-    assertEquals(1, queries.size());
-    assertThat(queries.get(0), instanceOf(PersistentQueryMetadata.class));
-
-    PersistentQueryMetadata persistentQueryMetadata = (PersistentQueryMetadata) queries.get(0);
-    persistentQueryMetadata.getKafkaStreams().start();
-
-    String query = String.format("SELECT * from pageviews_by_viewtime;");
-
-    queries = ksqlEngine.buildMultipleQueries(query, Collections.emptyMap());
-
-    assertEquals(1, queries.size());
-    assertThat(queries.get(0), instanceOf(QueuedQueryMetadata.class));
-
-    QueuedQueryMetadata queryMetadata = (QueuedQueryMetadata) queries.get(0);
-    queryMetadata.getKafkaStreams().start();
-
-    BlockingQueue<KeyValue<String, GenericRow>> rowQueue = queryMetadata.getRowQueue();
-    TestUtils.waitForCondition(() -> {
-      KeyValue<String, GenericRow> nextRow;
-      try {
-        nextRow = rowQueue.poll(1000, TimeUnit.MILLISECONDS);
-      } catch (InterruptedException e) {
-        Thread.currentThread().interrupt();
-        return false;
-      }
-      if (nextRow != null) {
-        List<Object> columns = nextRow.value.getColumns();
-        assertEquals(5, columns.size());
-        String pageid = columns.get(3).toString();
-        assertEquals(6, pageid.length());
-        assertEquals("PAGE_", pageid.substring(0, 5));
-
-        String userid = columns.get(4).toString();
-        assertEquals(6, userid.length());
-        assertEquals("USER_", userid.substring(0, 5));
-        return true;
-      }
-      return false;
-    }, 10000, "Could not retrieve a record from the derived topic for 10 seconds");
-  }
-
-  private void validateSelectAllFromUsers() throws Exception {
-    String query = String.format("SELECT * from %s;", userTable);
-    log.debug("Sending query: {}", query);
-
-    List<QueryMetadata> queries = ksqlEngine.buildMultipleQueries(query, Collections.emptyMap());
-
-    assertEquals(1, queries.size());
-    assertTrue(queries.get(0) instanceof QueuedQueryMetadata);
-
-    QueuedQueryMetadata queryMetadata = (QueuedQueryMetadata) queries.get(0);
-    queryMetadata.getKafkaStreams().start();
+  public void shouldSelectAllFromUsers() throws Exception {
+    final QueuedQueryMetadata queryMetadata = executeQuery(
+        "SELECT * from %s;", userTable);
 
     BlockingQueue<KeyValue<String, GenericRow>> rowQueue = queryMetadata.getRowQueue();
 
     Set<String> actualUsers = new HashSet<>();
     Set<String> expectedUsers = Utils.mkSet("USER_0", "USER_1", "USER_2", "USER_3", "USER_4");
-    while (actualUsers.size() < 5) {
+    while (actualUsers.size() < expectedUsers.size()) {
       KeyValue<String, GenericRow> nextRow = rowQueue.poll();
       if (nextRow != null) {
         List<Object> columns = nextRow.value.getColumns();
@@ -193,25 +138,18 @@ public class EndToEndIntegrationTest {
       }
     }
     assertEquals(expectedUsers, actualUsers);
-    queryMetadata.getKafkaStreams().close();
   }
 
-  private void validateSelectFromPageViewsWithSpecificColumn() throws Exception {
-    String query = String.format("SELECT pageid from %s;", pageViewStream);
-    log.debug("Sending query: {}", query);
-
-    List<QueryMetadata> queries = ksqlEngine.buildMultipleQueries(query, Collections.emptyMap());
-
-    assertEquals(1, queries.size());
-    assertTrue(queries.get(0) instanceof QueuedQueryMetadata);
-
-    QueuedQueryMetadata queryMetadata = (QueuedQueryMetadata) queries.get(0);
-    queryMetadata.getKafkaStreams().start();
+  @Test
+  public void shouldSelectFromPageViewsWithSpecificColumn() throws Exception {
+    final QueuedQueryMetadata queryMetadata =
+        executeQuery("SELECT pageid from %s;", pageViewStream);
 
     BlockingQueue<KeyValue<String, GenericRow>> rowQueue = queryMetadata.getRowQueue();
 
     List<String> actualPages = new ArrayList<>();
-    List<String> expectedPages = Arrays.asList("PAGE_1", "PAGE_2", "PAGE_3", "PAGE_4", "PAGE_5", "PAGE_5", "PAGE_5");
+    List<String> expectedPages =
+        Arrays.asList("PAGE_1", "PAGE_2", "PAGE_3", "PAGE_4", "PAGE_5", "PAGE_5", "PAGE_5");
     while (actualPages.size() < expectedPages.size()) {
       KeyValue<String, GenericRow> nextRow = rowQueue.poll();
       if (nextRow != null) {
@@ -226,26 +164,25 @@ public class EndToEndIntegrationTest {
     queryMetadata.getKafkaStreams().close();
   }
 
-  private String validateSelectAllFromDerivedStream() throws Exception {
+  @Test
+  public void shouldSelectAllFromDerivedStream() throws Exception {
 
-    String derivedStream = "pageviews_female";
-    createPageViewsFemaleStream(derivedStream);
+    executeStatement(
+        "CREATE STREAM pageviews_female"
+        + " AS SELECT %s.userid AS userid, pageid, regionid, gender "
+        + " FROM %s "
+        + " LEFT JOIN %s ON %s.userid = %s.userid"
+        + " WHERE gender = 'FEMALE';",
+        userTable, pageViewStream, userTable, pageViewStream,
+        userTable);
 
-    String selectQuery = String.format("SELECT * from %s;", derivedStream);
-
-    List<QueryMetadata> queries = ksqlEngine.buildMultipleQueries(selectQuery, Collections.emptyMap());
-
-    assertEquals(1, queries.size());
-    assertTrue(queries.get(0) instanceof QueuedQueryMetadata);
-
-    QueuedQueryMetadata queryMetadata = (QueuedQueryMetadata) queries.get(0);
-    queryMetadata.getKafkaStreams().start();
+    final QueuedQueryMetadata queryMetadata = executeQuery(
+        "SELECT * from pageviews_female;");
 
     List<KeyValue<String, GenericRow>> results = new ArrayList<>();
     BlockingQueue<KeyValue<String, GenericRow>> rowQueue = queryMetadata.getRowQueue();
 
     // From the mock data, we expect exactly 3 page views from female users.
-
     List<String> expectedPages = Arrays.asList("PAGE_2", "PAGE_5", "PAGE_5");
     List<String> expectedUsers = Arrays.asList("USER_2", "USER_0", "USER_2");
     List<String> actualPages = new ArrayList<>();
@@ -253,7 +190,7 @@ public class EndToEndIntegrationTest {
 
     TestUtils.waitForCondition(() -> {
       try {
-        log.debug("polling from {}", derivedStream);
+        log.debug("polling from pageviews_female");
         KeyValue<String, GenericRow> nextRow = rowQueue.poll(8000, TimeUnit.MILLISECONDS);
         if (nextRow != null) {
           results.add(nextRow);
@@ -261,17 +198,18 @@ public class EndToEndIntegrationTest {
           // If we didn't receive any records on the output topic for 8 seconds, it probably means that the join
           // failed because the table data wasn't populated when the stream data was consumed. We should just
           // re populate the stream data to try the join again.
-          log.warn("repopulating data in {} because the join returned empty results.", pageViewTopic);
-          testHarness.publishTestData(pageViewTopic, pageViewDataProvider, System.currentTimeMillis());
+          log.warn("repopulating data in {} because the join returned empty results.",
+                   pageViewTopic);
+          testHarness
+              .publishTestData(pageViewTopic, pageViewDataProvider, System.currentTimeMillis());
         }
-      }
-      catch (Exception e) {
-        log.error("Got exception when polling from " + derivedStream, e);
+      } catch (Exception e) {
+        log.error("Got exception when polling from pageviews_female", e);
       }
       return 3 <= results.size();
     }, 30000, "Could not consume any records from " + pageViewTopic + " for 30 seconds");
 
-    for (KeyValue<String, GenericRow> result: results) {
+    for (KeyValue<String, GenericRow> result : results) {
       List<Object> columns = result.value.getColumns();
       log.debug("pageview join: {}", columns);
 
@@ -285,75 +223,108 @@ public class EndToEndIntegrationTest {
 
     assertEquals(expectedPages, actualPages);
     assertEquals(expectedUsers, actualUsers);
-
-    return derivedStream;
   }
 
-  private void validateCreateStreamUsingLikeClause(String inputStream) throws Exception {
-    String outputStream = createStreamUsingLikeClause(inputStream);
-    String selectPageViewsFromRegion = String.format("SELECT userid, pageid from %s;", outputStream);
-    List<QueryMetadata> queries = ksqlEngine.buildMultipleQueries(selectPageViewsFromRegion,
-            Collections.emptyMap());
+  @Test
+  public void shouldCreateStreamUsingLikeClause() throws Exception {
 
-    assertEquals(1, queries.size());
-    assertTrue(queries.get(0) instanceof QueuedQueryMetadata);
+    executeStatement(
+        "CREATE STREAM pageviews_like_p5"
+        + " WITH (kafka_topic='pageviews_enriched_r0', value_format='DELIMITED')"
+        + " AS SELECT * FROM %s"
+        + " WHERE pageId LIKE '%%_5';",
+        pageViewStream);
 
-    QueuedQueryMetadata queryMetadata = (QueuedQueryMetadata) queries.get(0);
-    queryMetadata.getKafkaStreams().start();
+    final QueuedQueryMetadata queryMetadata =
+        executeQuery("SELECT userid, pageid from pageviews_like_p5;");
 
-    BlockingQueue<KeyValue<String, GenericRow>> rowQueue = queryMetadata.getRowQueue();
+    final List<Object> columns = waitForFirstRow(queryMetadata);
 
-    List<String> actualPages = new ArrayList<>();
-    List<String> expectedPages = Arrays.asList("PAGE_5");
-
-    TestUtils.waitForCondition(() -> {
-      try {
-        log.debug("polling from {}", outputStream);
-        KeyValue<String, GenericRow> nextRow = rowQueue.poll(1000, TimeUnit.MILLISECONDS);
-        if (nextRow != null) {
-          List<Object> columns = nextRow.value.getColumns();
-          assertEquals(2, columns.size());
-          log.debug("pageview from region 0: {}", nextRow.value.getColumns());
-          actualPages.add((String) columns.get(1));
-        }
-      } catch (Exception e) {
-        log.warn("Failed to read data from " + outputStream, e);
-      }
-      return 1 <= actualPages.size();
-    }, 30000, "Could not read data from " + outputStream + " for 30 seconds");
-
-    assertEquals(expectedPages, actualPages);
-    queryMetadata.getKafkaStreams().close();
+    assertThat(columns.get(1), is("PAGE_5"));
   }
 
-  private String createStreamUsingLikeClause(String inputStream) throws Exception {
-    String outputStream = "pageviews_female_like_r0";
-    String createStatement = String.format("CREATE STREAM %s WITH (kafka_topic='pageviews_enriched_r0', " +
-            "value_format='DELIMITED') AS SELECT * FROM %s WHERE regionid LIKE '%%_0';", outputStream, inputStream);
+  @Test
+  public void shouldRetainSelectedColumnsInPartitionBy() throws Exception {
 
-    List<QueryMetadata> queryMetadata = ksqlEngine.buildMultipleQueries(createStatement, Collections.emptyMap());
-    assertEquals(1, queryMetadata.size());
-    queryMetadata.get(0).getKafkaStreams().start();
-    return outputStream;
+    executeStatement(
+        "CREATE STREAM pageviews_by_viewtime "
+        + "AS SELECT viewtime, pageid, userid "
+        + "from %s "
+        + "partition by viewtime;",
+        pageViewStream);
+
+    final QueuedQueryMetadata queryMetadata = executeQuery(
+        "SELECT * from pageviews_by_viewtime;");
+
+    final List<Object> columns = waitForFirstRow(queryMetadata);
+
+    assertThat(columns.get(3).toString(), startsWith("PAGE_"));
+    assertThat(columns.get(4).toString(), startsWith("USER_"));
   }
 
-  private PersistentQueryMetadata createPageViewsFemaleStream(String streamName) throws Exception {
-    String createStreamStatement = String.format("CREATE STREAM %s AS SELECT %s.userid AS userid, " +
-                    "pageid, regionid, gender FROM %s LEFT JOIN %s ON " +
-                    "%s.userid = %s.userid WHERE gender = 'FEMALE';", streamName,
-            userTable, pageViewStream, userTable, pageViewStream, userTable);
+  @Test
+  public void shouldSupportDroppingAndRecreatingJoinQuery() throws Exception {
+    final String createStreamStatement = format(
+        "create stream cart_event_product as "
+        + "select pv.pageid, u.gender "
+        + "from %s pv left join %s u on pv.userid=u.userid;",
+        pageViewStream, userTable);
 
-    log.debug("Creating {} using: {}", streamName, createStreamStatement);
+    executeStatement(createStreamStatement);
 
-    List<QueryMetadata> queries = ksqlEngine.buildMultipleQueries(createStreamStatement,
-            Collections.emptyMap());
+    executeStatement("DROP STREAM cart_event_product;");
 
-    assertEquals(1, queries.size());
-    assertTrue(queries.get(0) instanceof PersistentQueryMetadata);
+    executeStatement(createStreamStatement);
 
-    PersistentQueryMetadata persistentQueryMetadata = (PersistentQueryMetadata) queries.get(0);
-    persistentQueryMetadata.getKafkaStreams().start();
-    return persistentQueryMetadata;
+    final QueuedQueryMetadata queryMetadata = executeQuery(
+        "SELECT * from cart_event_product;");
 
+    final List<Object> columns = waitForFirstRow(queryMetadata);
+
+    assertThat(columns.get(1).toString(), startsWith("USER_"));
+    assertThat(columns.get(2).toString(), startsWith("PAGE_"));
+    assertThat(columns.get(3).toString(), either(is("FEMALE")).or(is("MALE")));
+  }
+
+  private QueryMetadata executeStatement(final String statement,
+                                         final String... args) throws Exception {
+    final String formatted = String.format(statement, args);
+    log.debug("Sending statement: {}", formatted);
+
+    final List<QueryMetadata> queries =
+        ksqlEngine.buildMultipleQueries(formatted, Collections.emptyMap());
+
+    queries.forEach(QueryMetadata::start);
+
+    return queries.isEmpty() ? null : queries.get(0);
+  }
+
+  private QueuedQueryMetadata executeQuery(final String statement,
+                                           final String... args) throws Exception {
+    final QueryMetadata queryMetadata = executeStatement(statement, args);
+    assertThat(queryMetadata, instanceOf(QueuedQueryMetadata.class));
+    return (QueuedQueryMetadata) queryMetadata;
+  }
+
+  private static List<Object> waitForFirstRow(
+      final QueuedQueryMetadata queryMetadata) throws Exception {
+    return verifyAvailableRows(queryMetadata, 1).get(0).getColumns();
+  }
+
+  private static List<GenericRow> verifyAvailableRows(final QueuedQueryMetadata queryMetadata,
+                                                      final int expectedRows) throws Exception {
+    final BlockingQueue<KeyValue<String, GenericRow>> rowQueue = queryMetadata.getRowQueue();
+
+    TestUtils.waitForCondition(
+        () -> rowQueue.size() >= expectedRows,
+        30_000,
+        expectedRows + " rows where not available after 30 seconds");
+
+    final List<KeyValue<String, GenericRow>> rows = new ArrayList<>();
+    rowQueue.drainTo(rows);
+
+    return rows.stream()
+        .map(kv -> kv.value)
+        .collect(Collectors.toList());
   }
 }


### PR DESCRIPTION
As part of my triaging / investigating #1055 I've added a new `shouldSupportDroppingAndRecreatingJoinQuery` to the `EndToEndIntegrationTest`.

While in there, I found the existing tests verbose and hard to understand, with some tests testing many things. So I've refactored the test a little to make it cleaner and clearer.

