### PR TITLE
Ensure the command topic has a long retention on start up.

### DIFF
--- a/ksql-engine/src/main/java/io/confluent/ksql/util/KafkaTopicClient.java
+++ b/ksql-engine/src/main/java/io/confluent/ksql/util/KafkaTopicClient.java
@@ -22,6 +22,7 @@ import java.io.Closeable;
 import java.util.Collection;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import java.util.Set;
 
 public interface KafkaTopicClient extends Closeable {
@@ -31,7 +32,6 @@ public interface KafkaTopicClient extends Closeable {
     DELETE,
     COMPACT_DELETE
   }
-
 
   /**
    * Create a new topic with the specified name, numPartitions and replicatonFactor.
@@ -45,7 +45,7 @@ public interface KafkaTopicClient extends Closeable {
    * Create a new topic with the specified name, numPartitions and replicatonFactor.
    * [warn] synchronous call to get the response
    *
-   * @param topic name of the topic to create
+   * @param topic   name of the topic to create
    * @param configs any additional topic configs to use
    */
   void createTopic(
@@ -72,19 +72,42 @@ public interface KafkaTopicClient extends Closeable {
   Set<String> listTopicNames();
 
   /**
-   * [warn] synchronous call to get the response
+   * Synchronous call to get a one or more topic's description.
    *
    * @param topicNames topicNames to describe
+   * @return map of topic name to description.
    */
   Map<String, TopicDescription> describeTopics(Collection<String> topicNames);
 
   /**
-   * [warn] synchronous call to get the response
+   * Synchronous call to get the config of a topic.
    *
-   * @param topicName topicNames to describe
+   * @param topicName the name of the topic.
+   * @return map of topic config if the topic is known, {@link Optional#empty()} otherwise.
    */
-  public TopicCleanupPolicy getTopicCleanupPolicy(String topicName);
+  Map<String, String> getTopicConfig(String topicName);
 
+  /**
+   * Synchronous call to write topic config overrides to ZK.
+   *
+   * <p>This will add additional overrides, and not replace any existing, unless they have the same
+   * name.
+   *
+   * <p>Note: each broker will pick up this change asynchronously.
+   *
+   * @param topicName the name of the topic.
+   * @param overrides new overrides to add.
+   * @return {@code true} if any of the {@code overrides} did not already exist
+   */
+  boolean addTopicConfig(String topicName, Map<String, Object> overrides);
+
+  /**
+   * Synchronous call to get a topic's cleanup policy
+   *
+   * @param topicName topicNames to retrieve cleanup policy for.
+   * @return the clean up policy of the topic.
+   */
+  TopicCleanupPolicy getTopicCleanupPolicy(String topicName);
 
   /**
    * Delete the list of the topics in the given list.
@@ -100,5 +123,4 @@ public interface KafkaTopicClient extends Closeable {
    * Close the underlying Kafka admin client.
    */
   void close();
-
 }

--- a/ksql-engine/src/test/java/io/confluent/ksql/testutils/AssertEventually.java
+++ b/ksql-engine/src/test/java/io/confluent/ksql/testutils/AssertEventually.java
@@ -1,0 +1,75 @@
+/*
+ * Copyright 2018 Confluent Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.confluent.ksql.testutils;
+
+import org.hamcrest.Matcher;
+
+import java.util.concurrent.TimeUnit;
+import java.util.function.Supplier;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+
+/**
+ * @author andy
+ * created 3/28/18
+ */
+public class AssertEventually {
+  private static final long DEFAULT_TIMEOUT_MS = TimeUnit.SECONDS.toMillis(30);
+  private static final long MAX_PAUSE_PERIOD_MS = TimeUnit.SECONDS.toMillis(1);
+
+  public static <T> T assertThatEventually(final Supplier<? extends T> actualSupplier,
+                                           final Matcher<? super T> expected) {
+    return assertThatEventually("", actualSupplier, expected);
+  }
+
+  public static <T> T assertThatEventually(final String message,
+                                           final Supplier<? extends T> actualSupplier,
+                                           final Matcher<? super T> expected) {
+    return assertThatEventually(message, actualSupplier, expected, DEFAULT_TIMEOUT_MS, TimeUnit.MILLISECONDS);
+  }
+
+  public static <T> T assertThatEventually(final String message,
+                                           final Supplier<? extends T> actualSupplier,
+                                           final Matcher<? super T> expected,
+                                           final long timeout,
+                                           final TimeUnit unit) {
+    try {
+
+      final long end = System.currentTimeMillis() + unit.toMillis(timeout);
+
+      long period = 1;
+      while (System.currentTimeMillis() < end) {
+        final T actual = actualSupplier.get();
+        if (expected.matches(actual)) {
+          return actual;
+        }
+
+        Thread.sleep(period);
+        period = Math.min(period * 2, MAX_PAUSE_PERIOD_MS);
+      }
+
+      final T actual = actualSupplier.get();
+      assertThat(message, actual, expected);
+      return actual;
+    } catch (final InterruptedException e) {
+      throw new RuntimeException(e);
+    }
+  }
+
+  private AssertEventually() {
+  }
+}

--- a/ksql-engine/src/test/java/io/confluent/ksql/util/FakeKafkaTopicClient.java
+++ b/ksql-engine/src/test/java/io/confluent/ksql/util/FakeKafkaTopicClient.java
@@ -16,7 +16,6 @@
 
 package io.confluent.ksql.util;
 
-import org.apache.kafka.clients.admin.DescribeConfigsResult;
 import org.apache.kafka.clients.admin.TopicDescription;
 
 import java.util.Collection;
@@ -98,6 +97,16 @@ public class FakeKafkaTopicClient implements KafkaTopicClient {
   @Override
   public Map<String, TopicDescription> describeTopics(Collection<String> topicNames) {
     return Collections.emptyMap();
+  }
+
+  @Override
+  public Map<String, String> getTopicConfig(String topicName) {
+    return Collections.emptyMap();
+  }
+
+  @Override
+  public boolean addTopicConfig(String topicName, Map<String, Object> overrides) {
+    return false;
   }
 
   @Override

--- a/ksql-engine/src/test/java/io/confluent/ksql/util/KafkaTopicClientImplTest.java
+++ b/ksql-engine/src/test/java/io/confluent/ksql/util/KafkaTopicClientImplTest.java
@@ -1,0 +1,157 @@
+/*
+ * Copyright 2018 Confluent Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.confluent.ksql.util;
+
+import com.google.common.collect.ImmutableMap;
+
+import org.apache.kafka.clients.admin.AdminClient;
+import org.apache.kafka.clients.admin.AdminClientConfig;
+import org.apache.kafka.common.config.TopicConfig;
+import org.apache.kafka.test.IntegrationTest;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.ClassRule;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+
+import java.util.Collections;
+import java.util.Map;
+import java.util.Set;
+import java.util.UUID;
+
+import io.confluent.ksql.testutils.EmbeddedSingleNodeKafkaCluster;
+
+import static io.confluent.ksql.testutils.AssertEventually.assertThatEventually;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.hasItem;
+import static org.hamcrest.Matchers.hasItems;
+import static org.hamcrest.Matchers.is;
+
+@Category({IntegrationTest.class})
+public class KafkaTopicClientImplTest {
+  @ClassRule
+  public static final EmbeddedSingleNodeKafkaCluster KAFKA =
+      EmbeddedSingleNodeKafkaCluster.newBuilder().build();
+
+  private String testTopic;
+  private KafkaTopicClient client;
+  private AdminClient adminClient;
+
+  @Before
+  public void setUp() {
+    testTopic = UUID.randomUUID().toString();
+    KAFKA.createTopic(testTopic);
+
+    adminClient = AdminClient.create(ImmutableMap.of(
+        AdminClientConfig.BOOTSTRAP_SERVERS_CONFIG, KAFKA.bootstrapServers()));
+
+    client = new KafkaTopicClientImpl(adminClient);
+  }
+
+  @After
+  public void tearDown() {
+    adminClient.close();
+  }
+
+  @Test
+  public void shouldGetTopicConfig() {
+    // When:
+    final Map<String, String> config = client.getTopicConfig(testTopic);
+
+    // Then:
+    assertThat(config.keySet(), hasItems(
+        TopicConfig.RETENTION_MS_CONFIG,
+        TopicConfig.CLEANUP_POLICY_CONFIG,
+        TopicConfig.COMPRESSION_TYPE_CONFIG));
+  }
+
+  @Test
+  public void shouldSetTopicConfig() {
+    // When:
+    final boolean changed =
+        client.addTopicConfig(testTopic, ImmutableMap.of(TopicConfig.RETENTION_MS_CONFIG, "1245678"));
+
+    // Then:
+    assertThat(changed, is(true));
+    assertThatEventually(() -> getTopicConfig(TopicConfig.RETENTION_MS_CONFIG), is("1245678"));
+  }
+
+  @Test
+  public void shouldSetTopicConfigWhenNothingChanged() {
+    // Given:
+    client.addTopicConfig(testTopic, ImmutableMap.of(TopicConfig.RETENTION_MS_CONFIG, "56784567"));
+
+    // When:
+    final boolean changed =
+        client.addTopicConfig(testTopic, ImmutableMap.of(TopicConfig.RETENTION_MS_CONFIG, "56784567"));
+
+    // Then:
+    assertThat(changed, is(false));
+  }
+
+  @Test
+  public void shouldNotRemovePreviousOverridesWhenAddingNew() {
+    // Given:
+    client.addTopicConfig(testTopic, ImmutableMap.of(TopicConfig.COMPRESSION_TYPE_CONFIG, "snappy"));
+
+    // When:
+    client.addTopicConfig(testTopic, ImmutableMap.of(TopicConfig.RETENTION_MS_CONFIG, "987654321"));
+
+    // Then:
+    assertThatEventually(() -> getTopicConfig(TopicConfig.RETENTION_MS_CONFIG), is("987654321"));
+    assertThat(getTopicConfig(TopicConfig.COMPRESSION_TYPE_CONFIG), is("snappy"));
+  }
+
+  @Test
+  public void shouldGetTopicCleanupPolicy() {
+    // Given:
+    client.addTopicConfig(testTopic, ImmutableMap.of(TopicConfig.CLEANUP_POLICY_CONFIG, "delete"));
+
+    // Then:
+    assertThatEventually(() -> client.getTopicCleanupPolicy(testTopic),
+                         is(KafkaTopicClient.TopicCleanupPolicy.DELETE));
+  }
+
+  @Test
+  public void shouldListTopics() {
+    // When:
+    final Set<String> topicNames = client.listTopicNames();
+
+    // Then:
+    assertThat(topicNames, hasItem(testTopic));
+  }
+
+  @Test
+  public void shouldDetectIfTopicExists() {
+    assertThat(client.isTopicExists(testTopic), is(true));
+    assertThat(client.isTopicExists("Unknown"), is(false));
+  }
+
+  @Test
+  public void shouldDeleteTopics() {
+    // When:
+    client.deleteTopics(Collections.singletonList(testTopic));
+
+    // Then:
+    assertThat(client.isTopicExists(testTopic), is(false));
+  }
+
+  private String getTopicConfig(final String configName) {
+    final Map<String, String> configs = client.getTopicConfig(testTopic);
+    return configs.get(configName);
+  }
+}

--- a/ksql-rest-app/src/test/java/io/confluent/ksql/rest/server/mock/MockKafkaTopicClient.java
+++ b/ksql-rest-app/src/test/java/io/confluent/ksql/rest/server/mock/MockKafkaTopicClient.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2017 Confluent Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -16,9 +16,6 @@
 
 package io.confluent.ksql.rest.server.mock;
 
-import io.confluent.ksql.util.KafkaTopicClient;
-
-import org.apache.kafka.clients.admin.DescribeConfigsResult;
 import org.apache.kafka.clients.admin.TopicDescription;
 
 import java.util.Collection;
@@ -26,6 +23,8 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+
+import io.confluent.ksql.util.KafkaTopicClient;
 
 /**
  * Fake Kafka Client is for test only, none of its methods should be called.
@@ -55,14 +54,23 @@ public class MockKafkaTopicClient implements KafkaTopicClient {
 
   @Override
   public Set<String> listTopicNames() {
-    return Collections.EMPTY_SET;
+    return Collections.emptySet();
   }
 
   @Override
   public Map<String, TopicDescription> describeTopics(Collection<String> topicNames) {
-    return Collections.EMPTY_MAP;
+    return Collections.emptyMap();
   }
 
+  @Override
+  public Map<String, String> getTopicConfig(String topicName) {
+    return Collections.emptyMap();
+  }
+
+  @Override
+  public boolean addTopicConfig(String topicName, Map<String, Object> overrides) {
+    return false;
+  }
 
   @Override
   public TopicCleanupPolicy getTopicCleanupPolicy(String topicName) {
@@ -80,5 +88,4 @@ public class MockKafkaTopicClient implements KafkaTopicClient {
   @Override
   public void close() {
   }
-
 }

--- a/ksql-rest-app/src/test/java/io/confluent/ksql/rest/server/resources/KsqlResourceTest.java
+++ b/ksql-rest-app/src/test/java/io/confluent/ksql/rest/server/resources/KsqlResourceTest.java
@@ -16,34 +16,6 @@
 
 package io.confluent.ksql.rest.server.resources;
 
-import io.confluent.kafka.schemaregistry.client.MockSchemaRegistryClient;
-import io.confluent.kafka.schemaregistry.client.SchemaRegistryClient;
-import io.confluent.kafka.schemaregistry.client.rest.exceptions.RestClientException;
-import io.confluent.kafka.serializers.KafkaJsonDeserializer;
-import io.confluent.kafka.serializers.KafkaJsonDeserializerConfig;
-import io.confluent.kafka.serializers.KafkaJsonSerializer;
-import io.confluent.ksql.KsqlEngine;
-import io.confluent.ksql.ddl.DdlConfig;
-import io.confluent.ksql.metastore.KsqlStream;
-import io.confluent.ksql.metastore.KsqlTable;
-import io.confluent.ksql.metastore.KsqlTopic;
-import io.confluent.ksql.metastore.MetaStore;
-import io.confluent.ksql.metastore.MetaStoreImpl;
-import io.confluent.ksql.parser.tree.*;
-import io.confluent.ksql.rest.entity.*;
-import io.confluent.ksql.rest.server.KsqlRestConfig;
-import io.confluent.ksql.rest.server.StatementParser;
-import io.confluent.ksql.rest.server.computation.Command;
-import io.confluent.ksql.rest.server.computation.CommandId;
-import io.confluent.ksql.rest.server.computation.CommandIdAssigner;
-import io.confluent.ksql.rest.server.computation.CommandStore;
-import io.confluent.ksql.rest.server.computation.StatementExecutor;
-import io.confluent.ksql.rest.server.mock.MockKafkaTopicClient;
-import io.confluent.ksql.serde.json.KsqlJsonTopicSerDe;
-import io.confluent.ksql.util.KsqlConfig;
-import io.confluent.ksql.util.KsqlConstants;
-import io.confluent.rest.RestConfig;
-
 import org.apache.commons.lang3.concurrent.ConcurrentUtils;
 import org.apache.kafka.clients.consumer.ConsumerConfig;
 import org.apache.kafka.clients.consumer.KafkaConsumer;
@@ -58,7 +30,6 @@ import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 
-import javax.ws.rs.core.Response;
 import java.io.IOException;
 import java.util.Collection;
 import java.util.Collections;
@@ -70,9 +41,61 @@ import java.util.Properties;
 import java.util.concurrent.Future;
 import java.util.stream.Collectors;
 
+import javax.ws.rs.core.Response;
+
+import io.confluent.kafka.schemaregistry.client.MockSchemaRegistryClient;
+import io.confluent.kafka.schemaregistry.client.SchemaRegistryClient;
+import io.confluent.kafka.schemaregistry.client.rest.exceptions.RestClientException;
+import io.confluent.kafka.serializers.KafkaJsonDeserializer;
+import io.confluent.kafka.serializers.KafkaJsonDeserializerConfig;
+import io.confluent.kafka.serializers.KafkaJsonSerializer;
+import io.confluent.ksql.KsqlEngine;
+import io.confluent.ksql.ddl.DdlConfig;
+import io.confluent.ksql.metastore.KsqlStream;
+import io.confluent.ksql.metastore.KsqlTable;
+import io.confluent.ksql.metastore.KsqlTopic;
+import io.confluent.ksql.metastore.MetaStore;
+import io.confluent.ksql.metastore.MetaStoreImpl;
+import io.confluent.ksql.parser.tree.Expression;
+import io.confluent.ksql.parser.tree.ListQueries;
+import io.confluent.ksql.parser.tree.ListRegisteredTopics;
+import io.confluent.ksql.parser.tree.ListStreams;
+import io.confluent.ksql.parser.tree.ListTables;
+import io.confluent.ksql.parser.tree.QualifiedName;
+import io.confluent.ksql.parser.tree.RegisterTopic;
+import io.confluent.ksql.parser.tree.ShowColumns;
+import io.confluent.ksql.parser.tree.Statement;
+import io.confluent.ksql.parser.tree.StringLiteral;
+import io.confluent.ksql.rest.entity.CommandStatus;
+import io.confluent.ksql.rest.entity.CommandStatusEntity;
+import io.confluent.ksql.rest.entity.ErrorMessageEntity;
+import io.confluent.ksql.rest.entity.KsqlEntity;
+import io.confluent.ksql.rest.entity.KsqlEntityList;
+import io.confluent.ksql.rest.entity.KsqlRequest;
+import io.confluent.ksql.rest.entity.KsqlTopicInfo;
+import io.confluent.ksql.rest.entity.KsqlTopicsList;
+import io.confluent.ksql.rest.entity.Queries;
+import io.confluent.ksql.rest.entity.SourceDescription;
+import io.confluent.ksql.rest.entity.StreamsList;
+import io.confluent.ksql.rest.entity.TablesList;
+import io.confluent.ksql.rest.server.KsqlRestConfig;
+import io.confluent.ksql.rest.server.StatementParser;
+import io.confluent.ksql.rest.server.computation.Command;
+import io.confluent.ksql.rest.server.computation.CommandId;
+import io.confluent.ksql.rest.server.computation.CommandIdAssigner;
+import io.confluent.ksql.rest.server.computation.CommandStore;
+import io.confluent.ksql.rest.server.computation.StatementExecutor;
+import io.confluent.ksql.rest.server.mock.MockKafkaTopicClient;
+import io.confluent.ksql.serde.json.KsqlJsonTopicSerDe;
+import io.confluent.ksql.util.KsqlConfig;
+import io.confluent.ksql.util.KsqlConstants;
+import io.confluent.rest.RestConfig;
+
 import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.CoreMatchers.instanceOf;
-import static org.junit.Assert.*;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertThat;
+import static org.junit.Assert.assertTrue;
 
 public class KsqlResourceTest {
   private KsqlRestConfig ksqlRestConfig;
@@ -512,7 +535,5 @@ public class KsqlResourceTest {
     org.apache.avro.Schema avroSchema = parser.parse(ordersAveroSchemaStr);
     schemaRegistryClient.register("orders-topic" + KsqlConstants.SCHEMA_REGISTRY_VALUE_SUFFIX,
                                   avroSchema);
-
   }
-
 }


### PR DESCRIPTION
(Previous releases created the command topic with default retention, which is likely to cause loss of command messages over time).

Fix for #1047.