### PR TITLE
Updates to make the docker quickstart work in CP 4.1

### DIFF
--- a/docs/includes/ksql-includes.rst
+++ b/docs/includes/ksql-includes.rst
@@ -61,17 +61,11 @@ Create and produce data to the Kafka topics ``pageviews`` and ``users``. These s
 
 .. tip:: You can also produce Kafka data using the ``kafka-console-producer`` CLI provided with |cp|.
 
-.. _create-a-stream-and-table:
-
--------------------------
-Create a Stream and Table
--------------------------
-
-These examples query messages from Kafka topics called ``pageviews`` and ``users`` using the following schemas:
-
-.. image:: ../img/ksql-quickstart-schemas.jpg
-
-#. Launch the KSQL CLI. The ``local`` argument starts KSQL in :ref:`standalone mode <modes-of-operation>`.
+-------------------
+Launch the KSQL CLI
+-------------------
+To launch the CLI, run the following command. It will route the CLI logs to the ``./ksql_logs`` directory. By default,
+the CLI will look for a KSQL Server running at ``http://localhost:8088``.
 
    .. code:: bash
 
@@ -82,6 +76,17 @@ These examples query messages from Kafka topics called ``pageviews`` and ``users
    .. include:: ../includes/ksql-includes.rst
       :start-line: 17
       :end-line: 38
+
+.. _create-a-stream-and-table:
+
+-------------------------
+Create a Stream and Table
+-------------------------
+
+These examples query messages from Kafka topics called ``pageviews`` and ``users`` using the following schemas:
+
+.. image:: ../img/ksql-quickstart-schemas.jpg
+
 
 #. Create a stream ``pageviews_original`` from the Kafka topic ``pageviews``, specifying the ``value_format`` of ``DELIMITED``.
 

--- a/docs/tutorials/basics-docker.rst
+++ b/docs/tutorials/basics-docker.rst
@@ -46,7 +46,7 @@ Download the Tutorial and Start KSQL
       :end-line: 38
 
 .. include:: ../includes/ksql-includes.rst
-    :start-line: 40
+    :start-line: 80
     :end-line: 317
 
 Appendix

--- a/docs/tutorials/basics-docker.rst
+++ b/docs/tutorials/basics-docker.rst
@@ -39,7 +39,7 @@ Download the Tutorial and Start KSQL
 
    .. code:: bash
 
-       $ docker-compose exec ksql-cli ksql-cli local --bootstrap-server kafka:29092 --schema-registry-url http://schema-registry:8081
+       $ docker-compose exec ksql-cli ksql http://ksql-server:8088
 
    .. include:: ../includes/ksql-includes.rst
       :start-line: 17

--- a/docs/tutorials/basics-local.rst
+++ b/docs/tutorials/basics-local.rst
@@ -18,10 +18,10 @@ this Kafka cluster. KSQL is installed in the |cp| by default.
 
 .. include:: ../includes/ksql-includes.rst
       :start-line: 40
-      :end-line: 63
+      :end-line: 79
 
 .. include:: ../includes/ksql-includes.rst
-      :start-line: 63
+      :start-line: 80 
       :end-line: 317
 
 Confluent Platform

--- a/docs/tutorials/docker-compose.yml
+++ b/docs/tutorials/docker-compose.yml
@@ -53,7 +53,7 @@ services:
 
   # Runs the Kafka KSQL data generator for topic called "pageviews"
   ksql-datagen-pageviews:
-    image: "confluentinc/ksql-examples:0.5"
+    image: "confluentinc/ksql-examples:4.1.x-rc1"
     hostname: ksql-datagen-pageviews
     depends_on:
       - kafka
@@ -83,7 +83,7 @@ services:
 
   # Runs the Kafka KSQL data generator for topic called "users"
   ksql-datagen-users:
-    image: "confluentinc/ksql-examples:0.5"
+    image: "confluentinc/ksql-examples:4.1.x-rc1"
     hostname: ksql-datagen-users
     depends_on:
       - kafka
@@ -111,15 +111,48 @@ services:
     extra_hosts:
       - "moby:127.0.0.1"
 
+  # Runs the Kafka KSQL data generator for topic called "users"
+  ksql-server:
+    image: "confluentinc/ksql-cli:4.1.x-rc1"
+    hostname: ksql-server
+    ports:
+      - '8088:8088'
+    depends_on:
+      - kafka
+      - schema-registry
+    # Note: The container's `run` script will perform the same readiness checks
+    # for Kafka and Confluent Schema Registry, but that's ok because they complete fast.
+    # The reason we check for readiness here is that we can insert a sleep time
+    # for topic creation before we start the application.
+    command: "bash -c 'echo Waiting for Kafka to be ready... && \
+                       cub kafka-ready -b kafka:29092 1 20 && \
+                       echo Waiting for Confluent Schema Registry to be ready... && \
+                       cub sr-ready schema-registry 8081 20 && \
+                       echo Waiting a few seconds for topic creation to finish... && \
+                       sleep 2 && \
+                       /usr/bin/ksql-server-start /etc/ksql/ksql-server.properties'"
+    environment:
+      KSQL_CONFIG_DIR: "/etc/ksql"
+      KSQL_OPTS: "-Dbootstrap.servers=kafka:29092 -Dksql.schema.registry.url=http://schema-registry:8081 -Dlisteners=http://0.0.0.0:8088"
+      KSQL_LOG4J_OPTS: "-Dlog4j.configuration=file:/etc/ksql/log4j-rolling.properties"
+      STREAMS_BOOTSTRAP_SERVERS: kafka:29092
+      STREAMS_SCHEMA_REGISTRY_HOST: schema-registry
+      STREAMS_SCHEMA_REGISTRY_PORT: 8081
+
+    extra_hosts:
+      - "moby:127.0.0.1"
+
+
   # Runs the Kafka KSQL application
   ksql-cli:
-    image: "confluentinc/ksql-cli:0.5"
+    image: "confluentinc/ksql-cli:4.1.x-rc1"
     hostname: ksql-cli
     depends_on:
       - kafka
       - schema-registry
       - ksql-datagen-pageviews
       - ksql-datagen-users
+      - ksql-server
     command: "perl -e 'while(1){ sleep 99999 }'"
     environment:
       KSQL_CONFIG_DIR: "/etc/ksql"

--- a/docs/tutorials/docker-compose.yml
+++ b/docs/tutorials/docker-compose.yml
@@ -111,7 +111,7 @@ services:
     extra_hosts:
       - "moby:127.0.0.1"
 
-  # Runs the Kafka KSQL data generator for topic called "users"
+  # Runs the Kafka KSQL Server
   ksql-server:
     image: "confluentinc/ksql-cli:4.1.x-rc1"
     hostname: ksql-server
@@ -135,15 +135,12 @@ services:
       KSQL_CONFIG_DIR: "/etc/ksql"
       KSQL_OPTS: "-Dbootstrap.servers=kafka:29092 -Dksql.schema.registry.url=http://schema-registry:8081 -Dlisteners=http://0.0.0.0:8088"
       KSQL_LOG4J_OPTS: "-Dlog4j.configuration=file:/etc/ksql/log4j-rolling.properties"
-      STREAMS_BOOTSTRAP_SERVERS: kafka:29092
-      STREAMS_SCHEMA_REGISTRY_HOST: schema-registry
-      STREAMS_SCHEMA_REGISTRY_PORT: 8081
 
     extra_hosts:
       - "moby:127.0.0.1"
 
 
-  # Runs the Kafka KSQL application
+  # Runs the KSQL CLI
   ksql-cli:
     image: "confluentinc/ksql-cli:4.1.x-rc1"
     hostname: ksql-cli


### PR DESCRIPTION
Since we no longer have a `ksql-cli local` mode, we need to start the server separately, and then have the cli connect to it. 

This updates the documentation and the docker-compose.yml to introduce a `ksql-server` container which runs the server.