### PR TITLE
Return more stuff from the rest API

### DIFF
--- a/ksql-cli/src/test/java/io/confluent/ksql/cli/console/ConsoleTest.java
+++ b/ksql-cli/src/test/java/io/confluent/ksql/cli/console/ConsoleTest.java
@@ -108,7 +108,10 @@ public class ConsoleTest {
           new ErrorMessageEntity("e", new FakeException()),
           new PropertiesList("e", properties),
           new Queries("e", queries),
-          new SourceDescription("e", "TestSource", Collections.EMPTY_LIST, Collections.EMPTY_LIST, buildTestSchema(i), DataSource.DataSourceType.KTABLE.getKqlType(), "key", "2000-01-01", "stats", "errors", false, "avro", "kadka-topic", "topology", "executionPlan", 1, 1),
+          new SourceDescription(
+              "e", "TestSource", Collections.EMPTY_LIST, Collections.EMPTY_LIST, buildTestSchema(i),
+              DataSource.DataSourceType.KTABLE.getKqlType(), "key", "2000-01-01", "stats", "errors",
+              false, "avro", "kadka-topic", "topology", "executionPlan", 1, 1, Collections.emptyMap()),
           new TopicDescription("e", "TestTopic", "TestKafkaTopic", "AVRO", "schemaString"),
           new StreamsList("e", Arrays.asList(new SourceInfo.Stream("TestStream", "TestTopic", "AVRO"))),
           new TablesList("e", Arrays.asList(new SourceInfo.Table("TestTable", "TestTopic", "JSON", false))),

--- a/ksql-engine/src/main/java/io/confluent/ksql/physical/PhysicalPlanBuilder.java
+++ b/ksql-engine/src/main/java/io/confluent/ksql/physical/PhysicalPlanBuilder.java
@@ -209,7 +209,8 @@ public class PhysicalPlanBuilder {
             ? DataSource.DataSourceType.KTABLE : DataSource.DataSourceType.KSTREAM,
         applicationId,
         kafkaTopicClient,
-        builder.build()
+        builder.build(),
+        overriddenStreamsProperties
     );
   }
 
@@ -280,7 +281,8 @@ public class PhysicalPlanBuilder {
         kafkaTopicClient,
         outputNode.getSchema(),
         sinkDataSource.getKsqlTopic(),
-        topology
+        topology,
+        overriddenStreamsProperties
     );
   }
 

--- a/ksql-engine/src/main/java/io/confluent/ksql/physical/PhysicalPlanBuilder.java
+++ b/ksql-engine/src/main/java/io/confluent/ksql/physical/PhysicalPlanBuilder.java
@@ -279,7 +279,6 @@ public class PhysicalPlanBuilder {
             : DataSource.DataSourceType.KSTREAM,
         applicationId,
         kafkaTopicClient,
-        outputNode.getSchema(),
         sinkDataSource.getKsqlTopic(),
         topology,
         overriddenStreamsProperties

--- a/ksql-engine/src/main/java/io/confluent/ksql/util/PersistentQueryMetadata.java
+++ b/ksql-engine/src/main/java/io/confluent/ksql/util/PersistentQueryMetadata.java
@@ -25,6 +25,7 @@ import org.apache.kafka.connect.data.Schema;
 import org.apache.kafka.streams.KafkaStreams;
 import org.apache.kafka.streams.Topology;
 
+import java.util.Map;
 import java.util.Objects;
 
 public class PersistentQueryMetadata extends QueryMetadata {
@@ -44,9 +45,10 @@ public class PersistentQueryMetadata extends QueryMetadata {
                                  final KafkaTopicClient kafkaTopicClient,
                                  final Schema resultSchema,
                                  final KsqlTopic resultTopic,
-                                 final Topology topology) {
+                                 final Topology topology,
+                                 final Map<String, Object> overriddenProperties) {
     super(statementString, kafkaStreams, outputNode, executionPlan, dataSourceType,
-          queryApplicationId, kafkaTopicClient, topology);
+          queryApplicationId, kafkaTopicClient, topology, overriddenProperties);
     this.id = id;
     this.resultSchema = resultSchema;
     this.resultTopic = resultTopic;

--- a/ksql-engine/src/main/java/io/confluent/ksql/util/PersistentQueryMetadata.java
+++ b/ksql-engine/src/main/java/io/confluent/ksql/util/PersistentQueryMetadata.java
@@ -21,7 +21,6 @@ import io.confluent.ksql.query.QueryId;
 import io.confluent.ksql.serde.DataSource;
 import io.confluent.ksql.planner.plan.OutputNode;
 
-import org.apache.kafka.connect.data.Schema;
 import org.apache.kafka.streams.KafkaStreams;
 import org.apache.kafka.streams.Topology;
 
@@ -31,9 +30,7 @@ import java.util.Objects;
 public class PersistentQueryMetadata extends QueryMetadata {
 
   private final QueryId id;
-  private final Schema resultSchema;
   private final KsqlTopic resultTopic;
-
 
   public PersistentQueryMetadata(final String statementString,
                                  final KafkaStreams kafkaStreams,
@@ -43,24 +40,17 @@ public class PersistentQueryMetadata extends QueryMetadata {
                                  final DataSource.DataSourceType dataSourceType,
                                  final String queryApplicationId,
                                  final KafkaTopicClient kafkaTopicClient,
-                                 final Schema resultSchema,
                                  final KsqlTopic resultTopic,
                                  final Topology topology,
                                  final Map<String, Object> overriddenProperties) {
     super(statementString, kafkaStreams, outputNode, executionPlan, dataSourceType,
           queryApplicationId, kafkaTopicClient, topology, overriddenProperties);
     this.id = id;
-    this.resultSchema = resultSchema;
     this.resultTopic = resultTopic;
-
   }
 
   public QueryId getId() {
     return id;
-  }
-
-  public Schema getResultSchema() {
-    return resultSchema;
   }
 
   public KsqlTopic getResultTopic() {

--- a/ksql-engine/src/main/java/io/confluent/ksql/util/QueryMetadata.java
+++ b/ksql-engine/src/main/java/io/confluent/ksql/util/QueryMetadata.java
@@ -19,6 +19,7 @@ package io.confluent.ksql.util;
 import io.confluent.ksql.serde.DataSource;
 import io.confluent.ksql.planner.plan.OutputNode;
 
+import org.apache.kafka.connect.data.Schema;
 import org.apache.kafka.streams.KafkaStreams;
 import org.apache.kafka.streams.Topology;
 import org.slf4j.Logger;
@@ -89,6 +90,10 @@ public class QueryMetadata {
 
   public Topology getTopology() {
     return topoplogy;
+  }
+
+  public Schema getResultSchema() {
+    return outputNode.getSchema();
   }
 
   public void close() {

--- a/ksql-engine/src/main/java/io/confluent/ksql/util/QueryMetadata.java
+++ b/ksql-engine/src/main/java/io/confluent/ksql/util/QueryMetadata.java
@@ -24,6 +24,7 @@ import org.apache.kafka.streams.Topology;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import java.util.Map;
 import java.util.Objects;
 
 public class QueryMetadata {
@@ -36,6 +37,7 @@ public class QueryMetadata {
   private final String queryApplicationId;
   private final KafkaTopicClient kafkaTopicClient;
   private final Topology topoplogy;
+  private final Map<String, Object> overriddenProperties;
 
   public QueryMetadata(final String statementString,
                        final KafkaStreams kafkaStreams,
@@ -44,7 +46,8 @@ public class QueryMetadata {
                        final DataSource.DataSourceType dataSourceType,
                        final String queryApplicationId,
                        final KafkaTopicClient kafkaTopicClient,
-                       final Topology topoplogy) {
+                       final Topology topoplogy,
+                       final Map<String, Object> overriddenProperties) {
     this.statementString = statementString;
     this.kafkaStreams = kafkaStreams;
     this.outputNode = outputNode;
@@ -53,6 +56,11 @@ public class QueryMetadata {
     this.queryApplicationId = queryApplicationId;
     this.kafkaTopicClient = kafkaTopicClient;
     this.topoplogy = topoplogy;
+    this.overriddenProperties = overriddenProperties;
+  }
+
+  public Map<String, Object> getOverriddenProperties() {
+    return overriddenProperties;
   }
 
   public String getStatementString() {

--- a/ksql-engine/src/main/java/io/confluent/ksql/util/QueuedQueryMetadata.java
+++ b/ksql-engine/src/main/java/io/confluent/ksql/util/QueuedQueryMetadata.java
@@ -24,6 +24,7 @@ import org.apache.kafka.streams.KafkaStreams;
 import org.apache.kafka.streams.KeyValue;
 import org.apache.kafka.streams.Topology;
 
+import java.util.Map;
 import java.util.Objects;
 import java.util.concurrent.BlockingQueue;
 
@@ -40,9 +41,9 @@ public class QueuedQueryMetadata extends QueryMetadata {
       final DataSource.DataSourceType dataSourceType,
       final String queryApplicationId,
       final KafkaTopicClient kafkaTopicClient,
-      final Topology topology) {
+      final Topology topology, Map<String, Object> overriddenProperties) {
     super(statementString, kafkaStreams, outputNode, executionPlan, dataSourceType,
-          queryApplicationId, kafkaTopicClient, topology);
+          queryApplicationId, kafkaTopicClient, topology, overriddenProperties);
     this.rowQueue = rowQueue;
   }
 

--- a/ksql-engine/src/main/java/io/confluent/ksql/util/QueuedQueryMetadata.java
+++ b/ksql-engine/src/main/java/io/confluent/ksql/util/QueuedQueryMetadata.java
@@ -41,7 +41,8 @@ public class QueuedQueryMetadata extends QueryMetadata {
       final DataSource.DataSourceType dataSourceType,
       final String queryApplicationId,
       final KafkaTopicClient kafkaTopicClient,
-      final Topology topology, Map<String, Object> overriddenProperties) {
+      final Topology topology,
+      final Map<String, Object> overriddenProperties) {
     super(statementString, kafkaStreams, outputNode, executionPlan, dataSourceType,
           queryApplicationId, kafkaTopicClient, topology, overriddenProperties);
     this.rowQueue = rowQueue;

--- a/ksql-engine/src/test/java/io/confluent/ksql/KsqlContextTest.java
+++ b/ksql-engine/src/test/java/io/confluent/ksql/KsqlContextTest.java
@@ -71,21 +71,12 @@ public class KsqlContextTest {
     KafkaStreams queryStreams = mock(KafkaStreams.class);
     queryStreams.start();
     expectLastCall();
-    PersistentQueryMetadata persistentQueryMetadata = new PersistentQueryMetadata(queryid.toString(),
-                                                                                   queryStreams,
-                                                                                  null,
-                                                                                  "",
-                                                                                   queryid,
-                                                                                   type,
-                                                                                  "KSQL_query_" + queryid,
-                                                                                  null,
-                                                                      null,
-                                                                                  null,
-                                                                                  null,
-                                                                                   Collections.emptyMap());
+    PersistentQueryMetadata persistentQueryMetadata = new PersistentQueryMetadata(
+        queryid.toString(), queryStreams, null, "", queryid, type,
+        "KSQL_query_" + queryid, null, null, null,
+        Collections.emptyMap());
 
     return Arrays.asList(persistentQueryMetadata);
-
   }
 
 }

--- a/ksql-engine/src/test/java/io/confluent/ksql/KsqlContextTest.java
+++ b/ksql-engine/src/test/java/io/confluent/ksql/KsqlContextTest.java
@@ -75,13 +75,14 @@ public class KsqlContextTest {
                                                                                    queryStreams,
                                                                                   null,
                                                                                   "",
-                                                                                  queryid,
-                                                                                  type,
+                                                                                   queryid,
+                                                                                   type,
                                                                                   "KSQL_query_" + queryid,
                                                                                   null,
-        null,
+                                                                      null,
                                                                                   null,
-                                                                                  null);
+                                                                                  null,
+                                                                                   Collections.emptyMap());
 
     return Arrays.asList(persistentQueryMetadata);
 

--- a/ksql-engine/src/test/java/io/confluent/ksql/util/AvroUtilTest.java
+++ b/ksql-engine/src/test/java/io/confluent/ksql/util/AvroUtilTest.java
@@ -23,6 +23,7 @@ import org.junit.Test;
 
 import java.io.IOException;
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 
@@ -120,9 +121,10 @@ public class AvroUtilTest {
                                                                                   DataSource.DataSourceType.KSTREAM,
                                                                                   "",
                                                                                   mock(KafkaTopicClient.class),
-        resultSchema,
+                                                                                  resultSchema,
                                                                                   resultTopic,
-                                                                                  null);
+                                                                                  null,
+                                                                                  Collections.emptyMap());
     org.apache.avro.Schema.Parser parser = new org.apache.avro.Schema.Parser();
     org.apache.avro.Schema avroSchema = parser.parse(ordersAveroSchemaStr);
     expect(schemaRegistryClient.testCompatibility(anyString(), EasyMock.isA(avroSchema.getClass())))
@@ -146,9 +148,10 @@ public class AvroUtilTest {
                                                                                   DataSource.DataSourceType.KSTREAM,
                                                                                   "",
                                                                                   mock(KafkaTopicClient.class),
-        resultSchema,
+                                                                                  resultSchema,
                                                                                   resultTopic,
-                                                                                  null);
+                                                                                  null,
+                                                                                  Collections.emptyMap());
     expect(schemaRegistryClient.testCompatibility(anyString(), anyObject())).andReturn(false);
     replay(schemaRegistryClient);
     try {

--- a/ksql-engine/src/test/java/io/confluent/ksql/util/AvroUtilTest.java
+++ b/ksql-engine/src/test/java/io/confluent/ksql/util/AvroUtilTest.java
@@ -17,6 +17,7 @@
 
 package io.confluent.ksql.util;
 
+import kafka.Kafka;
 import org.apache.kafka.connect.data.Schema;
 import org.easymock.EasyMock;
 import org.junit.Test;
@@ -107,24 +108,26 @@ public class AvroUtilTest {
     }
   }
 
+
+
+  private PersistentQueryMetadata buildStubPersistentQueryMetadata(Schema resultSchema,
+                                                                   KsqlTopic resultTopic) {
+    PersistentQueryMetadata mockPersistentQueryMetadata = mock(PersistentQueryMetadata.class);
+    expect(mockPersistentQueryMetadata.getResultSchema()).andStubReturn(resultSchema);
+    expect(mockPersistentQueryMetadata.getResultTopic()).andStubReturn(resultTopic);
+    expect(mockPersistentQueryMetadata.getResultTopicSerde()).andStubReturn(
+        resultTopic.getKsqlTopicSerDe().getSerDe());
+    replay(mockPersistentQueryMetadata);
+    return mockPersistentQueryMetadata;
+  }
+
   @Test
   public void shouldValidatePersistentQueryResultCorrectly()
       throws IOException, RestClientException {
     SchemaRegistryClient schemaRegistryClient = mock(SchemaRegistryClient.class);
     KsqlTopic resultTopic = new KsqlTopic("testTopic", "testTopic", new KsqlAvroTopicSerDe());
     Schema resultSchema = SerDeUtil.getSchemaFromAvro(ordersAveroSchemaStr);
-    PersistentQueryMetadata persistentQueryMetadata = new PersistentQueryMetadata("",
-                                                                                  null,
-                                                                                  null,
-                                                                                  "",
-                                                                                  null,
-                                                                                  DataSource.DataSourceType.KSTREAM,
-                                                                                  "",
-                                                                                  mock(KafkaTopicClient.class),
-                                                                                  resultSchema,
-                                                                                  resultTopic,
-                                                                                  null,
-                                                                                  Collections.emptyMap());
+    PersistentQueryMetadata persistentQueryMetadata = buildStubPersistentQueryMetadata(resultSchema, resultTopic);
     org.apache.avro.Schema.Parser parser = new org.apache.avro.Schema.Parser();
     org.apache.avro.Schema avroSchema = parser.parse(ordersAveroSchemaStr);
     expect(schemaRegistryClient.testCompatibility(anyString(), EasyMock.isA(avroSchema.getClass())))
@@ -140,18 +143,7 @@ public class AvroUtilTest {
     KsqlTopic resultTopic = new KsqlTopic("testTopic", "testTopic", new KsqlAvroTopicSerDe
         ());
     Schema resultSchema = SerDeUtil.getSchemaFromAvro(ordersAveroSchemaStr);
-    PersistentQueryMetadata persistentQueryMetadata = new PersistentQueryMetadata("",
-                                                                                  null,
-                                                                                  null,
-                                                                                  "",
-                                                                                  null,
-                                                                                  DataSource.DataSourceType.KSTREAM,
-                                                                                  "",
-                                                                                  mock(KafkaTopicClient.class),
-                                                                                  resultSchema,
-                                                                                  resultTopic,
-                                                                                  null,
-                                                                                  Collections.emptyMap());
+    PersistentQueryMetadata persistentQueryMetadata = buildStubPersistentQueryMetadata(resultSchema, resultTopic);
     expect(schemaRegistryClient.testCompatibility(anyString(), anyObject())).andReturn(false);
     replay(schemaRegistryClient);
     try {

--- a/ksql-rest-app/src/main/java/io/confluent/ksql/rest/client/KsqlRestClient.java
+++ b/ksql-rest-app/src/main/java/io/confluent/ksql/rest/client/KsqlRestClient.java
@@ -16,6 +16,7 @@
 
 package io.confluent.ksql.rest.client;
 
+import com.fasterxml.jackson.databind.DeserializationFeature;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import io.confluent.ksql.rest.client.exception.KsqlRestClientException;
 import io.confluent.ksql.rest.entity.CommandStatus;
@@ -70,6 +71,8 @@ public class KsqlRestClient implements Closeable, AutoCloseable {
     this.serverAddress = serverAddress;
     this.localProperties = localProperties;
     ObjectMapper objectMapper = new SchemaMapper().registerToObjectMapper(new ObjectMapper());
+    objectMapper.configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES,
+        false);
     JacksonMessageBodyProvider jsonProvider = new JacksonMessageBodyProvider(objectMapper);
     this.client = ClientBuilder.newBuilder().register(jsonProvider).build();
   }

--- a/ksql-rest-app/src/main/java/io/confluent/ksql/rest/entity/ServerInfo.java
+++ b/ksql-rest-app/src/main/java/io/confluent/ksql/rest/entity/ServerInfo.java
@@ -30,13 +30,16 @@ import java.util.Objects;
 public class ServerInfo {
   private final String version;
   private final String kafkaClusterId;
+  private final String ksqlServiceId;
 
   @JsonCreator
   public ServerInfo(
       @JsonProperty("version") String version,
-      @JsonProperty("kafkaClusterId") String kafkaClusterId) {
+      @JsonProperty("kafkaClusterId") String kafkaClusterId,
+      @JsonProperty("ksqlServiceId") String ksqlServiceId) {
     this.version = version;
     this.kafkaClusterId = kafkaClusterId;
+    this.ksqlServiceId = ksqlServiceId;
   }
 
   public String getVersion() {
@@ -45,6 +48,10 @@ public class ServerInfo {
 
   public String getKafkaClusterId() {
     return kafkaClusterId;
+  }
+
+  public String getKsqlServiceId() {
+    return ksqlServiceId;
   }
 
   @Override
@@ -57,7 +64,8 @@ public class ServerInfo {
     }
     ServerInfo that = (ServerInfo) o;
     return Objects.equals(version, that.version)
-           && Objects.equals(kafkaClusterId, that.kafkaClusterId);
+           && Objects.equals(kafkaClusterId, that.kafkaClusterId)
+           && Objects.equals(ksqlServiceId, that.ksqlServiceId);
   }
 
   @Override

--- a/ksql-rest-app/src/main/java/io/confluent/ksql/rest/entity/SourceDescription.java
+++ b/ksql-rest-app/src/main/java/io/confluent/ksql/rest/entity/SourceDescription.java
@@ -21,6 +21,7 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonSubTypes;
 import com.fasterxml.jackson.annotation.JsonTypeName;
 
+import io.confluent.ksql.util.PersistentQueryMetadata;
 import org.apache.kafka.clients.admin.TopicDescription;
 import org.apache.kafka.connect.data.Field;
 
@@ -58,6 +59,7 @@ public class SourceDescription extends KsqlEntity {
   private final String executionPlan;
   private final int partitions;
   private final int replication;
+  private final Map<String, Object> overriddenProperties;
 
   @JsonCreator
   public SourceDescription(
@@ -77,7 +79,8 @@ public class SourceDescription extends KsqlEntity {
       @JsonProperty("topology") String topology,
       @JsonProperty("executionPlan") String executionPlan,
       @JsonProperty("parititions") int partitions,
-      @JsonProperty("replication") int replication
+      @JsonProperty("replication") int replication,
+      @JsonProperty("overriddenProperties") Map<String, Object> overriddenProperties
   ) {
     super(statementText);
     this.name = name;
@@ -96,6 +99,7 @@ public class SourceDescription extends KsqlEntity {
     this.executionPlan = executionPlan;
     this.partitions = partitions;
     this.replication = replication;
+    this.overriddenProperties = overriddenProperties;
   }
 
   public SourceDescription(
@@ -114,10 +118,9 @@ public class SourceDescription extends KsqlEntity {
         readQueries,
         writeQueries,
         dataSource.getSchema().fields().stream().map(
-            field -> {
-              return new FieldSchemaInfo(field.name(), SchemaUtil
-                  .getSchemaFieldName(field));
-            }).collect(Collectors.toList()),
+            field -> new FieldSchemaInfo(
+                field.name(), SchemaUtil.getSchemaFieldName(field))
+            ).collect(Collectors.toList()),
         dataSource.getDataSourceType().getKqlType(),
         Optional.ofNullable(dataSource.getKeyField()).map(Field::name).orElse(""),
         Optional.ofNullable(dataSource.getTimestampField()).map(Field::name).orElse(""),
@@ -143,36 +146,47 @@ public class SourceDescription extends KsqlEntity {
                     .getKsqlTopic()
                     .getKafkaTopicName()
             ) : 0
-        )
+        ),
+        Collections.emptyMap()
     );
   }
 
+  private static KsqlStructuredDataOutputNode outputNodeFromMetadata(
+      PersistentQueryMetadata metadata) {
+    return (KsqlStructuredDataOutputNode) metadata.getOutputNode();
+  }
+
   public SourceDescription(
-      KsqlStructuredDataOutputNode outputNode,
-      String statementString,
-      String name,
-      String topoplogy,
-      String executionPlan,
+      PersistentQueryMetadata queryMetadata,
       KafkaTopicClient topicClient
   ) {
     this(
-        statementString,
-        name,
+        queryMetadata.getStatementString(),
+        queryMetadata.getStatementString(),
         Collections.EMPTY_LIST,
         Collections.EMPTY_LIST,
-        Collections.EMPTY_LIST,
+        queryMetadata.getResultSchema().fields().stream().map(
+            field ->
+              new FieldSchemaInfo(field.name(), SchemaUtil
+                  .getSchemaFieldName(field))
+            ).collect(Collectors.toList()),
         "QUERY",
-        Optional.ofNullable(outputNode.getKeyField()).map(Field::name).orElse(""),
-        Optional.ofNullable(outputNode.getTimestampField()).map(Field::name).orElse(""),
-        MetricCollectors.getStatsFor(outputNode.getKafkaTopicName(), false),
-        MetricCollectors.getStatsFor(outputNode.getKafkaTopicName(), true),
+        Optional.ofNullable(outputNodeFromMetadata(queryMetadata)
+            .getKeyField()).map(Field::name).orElse(""),
+        Optional.ofNullable(outputNodeFromMetadata(queryMetadata)
+            .getTimestampField()).map(Field::name).orElse(""),
+        MetricCollectors.getStatsFor(
+            outputNodeFromMetadata(queryMetadata).getKafkaTopicName(), false),
+        MetricCollectors.getStatsFor(
+            outputNodeFromMetadata(queryMetadata).getKafkaTopicName(), true),
         true,
-        outputNode.getTopicSerde().getSerDe().name(),
-        outputNode.getKafkaTopicName(),
-        topoplogy,
-        executionPlan,
-        getPartitions(topicClient, outputNode.getKafkaTopicName()),
-        getReplication(topicClient, outputNode.getKafkaTopicName())
+        outputNodeFromMetadata(queryMetadata).getTopicSerde().getSerDe().name(),
+        outputNodeFromMetadata(queryMetadata).getKafkaTopicName(),
+        queryMetadata.getTopologyDescription(),
+        queryMetadata.getExecutionPlan(),
+        getPartitions(topicClient, outputNodeFromMetadata(queryMetadata).getKafkaTopicName()),
+        getReplication(topicClient, outputNodeFromMetadata(queryMetadata).getKafkaTopicName()),
+        queryMetadata.getOverriddenProperties()
     );
   }
 
@@ -252,6 +266,10 @@ public class SourceDescription extends KsqlEntity {
 
   public String getExecutionPlan() {
     return executionPlan;
+  }
+
+  public Map<String, Object> getOverriddenProperties() {
+    return overriddenProperties;
   }
 
   public static class FieldSchemaInfo {

--- a/ksql-rest-app/src/main/java/io/confluent/ksql/rest/server/KsqlRestApplication.java
+++ b/ksql-rest-app/src/main/java/io/confluent/ksql/rest/server/KsqlRestApplication.java
@@ -255,8 +255,9 @@ public class KsqlRestApplication extends Application<KsqlRestConfig> implements 
       );
     }
 
+    String ksqlServiceId = ksqlConfig.getString(KsqlConfig.KSQL_SERVICE_ID_CONFIG);
     String commandTopic =
-        restConfig.getCommandTopic(ksqlConfig.getString(KsqlConfig.KSQL_SERVICE_ID_CONFIG));
+        restConfig.getCommandTopic(ksqlServiceId);
     ensureCommandTopic(restConfig, topicClient, commandTopic);
 
     Map<String, Expression> commandTopicProperties = new HashMap<>();
@@ -355,7 +356,7 @@ public class KsqlRestApplication extends Application<KsqlRestConfig> implements 
         ksqlResource,
         isUiEnabled,
         versionCheckerAgent,
-        new ServerInfo(Version.getVersion(), kafkaClusterId)
+        new ServerInfo(Version.getVersion(), kafkaClusterId, ksqlServiceId)
     );
   }
 

--- a/ksql-rest-app/src/main/java/io/confluent/ksql/rest/server/resources/KsqlResource.java
+++ b/ksql-rest-app/src/main/java/io/confluent/ksql/rest/server/resources/KsqlResource.java
@@ -448,6 +448,7 @@ public class KsqlResource {
         String executionPlan = executionPlanAndQuery.getLeft();
         QueryMetadata queryMetadata = executionPlanAndQuery.getRight();
         List<SourceDescription.FieldSchemaInfo> schemaInfoList = Collections.emptyList();
+        Map<String, Object> overriddenProperties = Collections.emptyMap();
         String topologyDescription = "";
         if (queryMetadata != null) {
           schemaInfoList = queryMetadata.getOutputNode().getSchema().fields().stream().map(
@@ -456,6 +457,7 @@ public class KsqlResource {
                     .getSchemaFieldName(field));
               }).collect(Collectors.toList());
           topologyDescription = queryMetadata.getTopologyDescription();
+          overriddenProperties = queryMetadata.getOverriddenProperties();
         }
         return new SourceDescription(
             "",
@@ -475,7 +477,7 @@ public class KsqlResource {
             executionPlan,
             0,
             0,
-            queryMetadata.getOverriddenProperties()
+            overriddenProperties
         );
       } catch (KsqlException ksqlException) {
         throw ksqlException;

--- a/ksql-rest-app/src/main/java/io/confluent/ksql/rest/server/resources/KsqlResource.java
+++ b/ksql-rest-app/src/main/java/io/confluent/ksql/rest/server/resources/KsqlResource.java
@@ -449,7 +449,7 @@ public class KsqlResource {
         Map<String, Object> overriddenProperties = Collections.emptyMap();
         String topologyDescription = "";
         if (queryMetadata != null) {
-          schemaInfoList = queryMetadata.getOutputNode().getSchema().fields().stream().map(
+          schemaInfoList = queryMetadata.getResultSchema().fields().stream().map(
               field -> new SourceDescription.FieldSchemaInfo(
                   field.name(), SchemaUtil.getSchemaFieldName(field))
           ).collect(Collectors.toList());

--- a/ksql-rest-app/src/test/java/io/confluent/ksql/rest/entity/ServerInfoTest.java
+++ b/ksql-rest-app/src/test/java/io/confluent/ksql/rest/entity/ServerInfoTest.java
@@ -31,27 +31,7 @@ public class ServerInfoTest {
   private static final String KAFKA_CLUSTER_ID = "test-kafka-cluster";
   private static final String KSQL_SERVICE_ID = "test-ksql-service";
 
-  private ServerInfo serverInfo;
-
-  @Before
-  public void setUp() {
-    serverInfo = new ServerInfo(VERSION, KAFKA_CLUSTER_ID, KSQL_SERVICE_ID);
-  }
-
-  @Test
-  public void shouldGetVersion() {
-    Assert.assertThat(serverInfo.getVersion(), equalTo(VERSION));
-  }
-
-  @Test
-  public void shouldGetKafkaClusterId() {
-    Assert.assertThat(serverInfo.getKafkaClusterId(), equalTo(KAFKA_CLUSTER_ID));
-  }
-
-  @Test
-  public void shouldGetKsqlServiceId() {
-    Assert.assertThat(serverInfo.getKsqlServiceId(), equalTo(KSQL_SERVICE_ID));
-  }
+  private ServerInfo serverInfo = new ServerInfo(VERSION, KAFKA_CLUSTER_ID, KSQL_SERVICE_ID);
 
   @Test
   public void testSerializeDeserialize() throws IOException {

--- a/ksql-rest-app/src/test/java/io/confluent/ksql/rest/entity/ServerInfoTest.java
+++ b/ksql-rest-app/src/test/java/io/confluent/ksql/rest/entity/ServerInfoTest.java
@@ -1,0 +1,63 @@
+/**
+ * Copyright 2018 Confluent Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ **/
+
+package io.confluent.ksql.rest.entity;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.io.IOException;
+
+import static org.hamcrest.CoreMatchers.equalTo;
+
+public class ServerInfoTest {
+  private static final String VERSION = "test-version";
+  private static final String KAFKA_CLUSTER_ID = "test-kafka-cluster";
+  private static final String KSQL_SERVICE_ID = "test-ksql-service";
+
+  private ServerInfo serverInfo;
+
+  @Before
+  public void setUp() {
+    serverInfo = new ServerInfo(VERSION, KAFKA_CLUSTER_ID, KSQL_SERVICE_ID);
+  }
+
+  @Test
+  public void shouldGetVersion() {
+    Assert.assertThat(serverInfo.getVersion(), equalTo(VERSION));
+  }
+
+  @Test
+  public void shouldGetKafkaClusterId() {
+    Assert.assertThat(serverInfo.getKafkaClusterId(), equalTo(KAFKA_CLUSTER_ID));
+  }
+
+  @Test
+  public void shouldGetKsqlServiceId() {
+    Assert.assertThat(serverInfo.getKsqlServiceId(), equalTo(KSQL_SERVICE_ID));
+  }
+
+  @Test
+  public void testSerializeDeserialize() throws IOException {
+    ObjectMapper mapper = new ObjectMapper();
+    byte[] bytes = mapper.writeValueAsBytes(serverInfo);
+    ServerInfo deserializedServerInfo = mapper.readValue(bytes, ServerInfo.class);
+    Assert.assertThat(serverInfo, equalTo(deserializedServerInfo));
+  }
+}

--- a/ksql-rest-app/src/test/java/io/confluent/ksql/rest/server/resources/KsqlResourceTest.java
+++ b/ksql-rest-app/src/test/java/io/confluent/ksql/rest/server/resources/KsqlResourceTest.java
@@ -540,7 +540,7 @@ public class KsqlResourceTest {
   private void validateQueryDescription(
       QueryMetadata queryMetadata,
       Map<String, Object> overriddenProperties,
-      KsqlEntity entity) throws Exception {
+      KsqlEntity entity) {
     SourceDescription sourceDescription = (SourceDescription) entity;
     assertThat(sourceDescription.getType(), equalTo("QUERY"));
     assertThat(sourceDescription.getExecutionPlan(), equalTo(queryMetadata.getExecutionPlan()));

--- a/ksql-rest-app/src/test/java/io/confluent/ksql/rest/server/resources/KsqlResourceTest.java
+++ b/ksql-rest-app/src/test/java/io/confluent/ksql/rest/server/resources/KsqlResourceTest.java
@@ -16,6 +16,11 @@
 
 package io.confluent.ksql.rest.server.resources;
 
+import io.confluent.ksql.util.FakeKafkaTopicClient;
+import io.confluent.ksql.util.KafkaTopicClient;
+import io.confluent.ksql.util.PersistentQueryMetadata;
+import io.confluent.ksql.util.QueryMetadata;
+import io.confluent.ksql.util.SchemaUtil;
 import org.apache.commons.lang3.concurrent.ConcurrentUtils;
 import org.apache.kafka.clients.consumer.ConsumerConfig;
 import org.apache.kafka.clients.consumer.KafkaConsumer;
@@ -86,7 +91,6 @@ import io.confluent.ksql.rest.server.computation.CommandId;
 import io.confluent.ksql.rest.server.computation.CommandIdAssigner;
 import io.confluent.ksql.rest.server.computation.CommandStore;
 import io.confluent.ksql.rest.server.computation.StatementExecutor;
-import io.confluent.ksql.rest.server.mock.MockKafkaTopicClient;
 import io.confluent.ksql.serde.json.KsqlJsonTopicSerDe;
 import io.confluent.ksql.util.KsqlConfig;
 import io.confluent.ksql.util.KsqlConstants;
@@ -100,6 +104,7 @@ import static org.junit.Assert.assertTrue;
 
 public class KsqlResourceTest {
   private KsqlRestConfig ksqlRestConfig;
+  private FakeKafkaTopicClient kafkaTopicClient;
   private KsqlEngine ksqlEngine;
 
   @Before
@@ -108,7 +113,9 @@ public class KsqlResourceTest {
     registerSchema(schemaRegistryClient);
     ksqlRestConfig = new KsqlRestConfig(TestKsqlResourceUtil.getDefaultKsqlConfig());
     KsqlConfig ksqlConfig = new KsqlConfig(ksqlRestConfig.getKsqlConfigProperties());
-    ksqlEngine = new KsqlEngine(ksqlConfig, new MockKafkaTopicClient(), schemaRegistryClient, new MetaStoreImpl());
+    kafkaTopicClient = new FakeKafkaTopicClient();
+    ksqlEngine = new KsqlEngine(
+        ksqlConfig, kafkaTopicClient, schemaRegistryClient, new MetaStoreImpl());
   }
 
   @After
@@ -160,7 +167,7 @@ public class KsqlResourceTest {
                                                    commandConsumer, commandProducer, new CommandIdAssigner(ksqlEngine.getMetaStore()));
       StatementExecutor statementExecutor = new StatementExecutor(ksqlEngine, new StatementParser(ksqlEngine));
 
-      addTestTopicAndSources(ksqlEngine.getMetaStore());
+      addTestTopicAndSources(ksqlEngine.getMetaStore(), ksqlEngine.getTopicClient());
       return new KsqlResource(ksqlEngine, commandStore, statementExecutor, DISTRIBUTED_COMMAND_RESPONSE_TIMEOUT);
     }
 
@@ -180,7 +187,7 @@ public class KsqlResourceTest {
       return properties;
     }
 
-    private static void addTestTopicAndSources(MetaStore metaStore) {
+    private static void addTestTopicAndSources(MetaStore metaStore, KafkaTopicClient kafkaTopicClient) {
       Schema schema1 = SchemaBuilder.struct().field("S1_F1", Schema.BOOLEAN_SCHEMA);
       KsqlTopic ksqlTopic1 = new KsqlTopic("KSQL_TOPIC_1", "KAFKA_TOPIC_1", new KsqlJsonTopicSerDe());
       metaStore.putTopic(ksqlTopic1);
@@ -192,6 +199,7 @@ public class KsqlResourceTest {
       metaStore.putTopic(ksqlTopic2);
       metaStore.putSource(new KsqlStream("statementText", "TEST_STREAM", schema2, schema2.field("S2_F2"), null,
                                          ksqlTopic2));
+      kafkaTopicClient.createTopic("orders-topic", 1, (short)1);
     }
 
     private static <T> Deserializer<T> getJsonDeserializer(Class<T> classs, boolean isKey) {
@@ -500,9 +508,11 @@ public class KsqlResourceTest {
     Response response = testResource.handleKsqlStatements(new KsqlRequest(ksqlString, new HashMap<>()));
     KsqlEntityList result = (KsqlEntityList) response.getEntity();
     assertThat("Incorrect response.", result.size(), equalTo(1));
-    assertTrue(result.get(0) instanceof CommandStatusEntity);
+    assertThat(result.get(0), instanceOf(CommandStatusEntity.class));
     CommandStatusEntity commandStatusEntity = (CommandStatusEntity) result.get(0);
-    assertTrue(commandStatusEntity.getCommandId().getType().name().equalsIgnoreCase("TABLE"));
+    assertThat(
+        commandStatusEntity.getCommandId().getType().name().toUpperCase(),
+        equalTo("TABLE"));
   }
 
   @Test
@@ -515,6 +525,71 @@ public class KsqlResourceTest {
     KsqlEntityList result = (KsqlEntityList) response.getEntity();
     assertThat("Incorrect response.", result.size(), equalTo(1));
     assertThat(result.get(0), instanceOf(ErrorMessageEntity.class));
+  }
+
+  private void validateQueryDescription(
+      String ksqlQueryString,
+      Map<String, Object> overriddenProperties,
+      KsqlEntity entity) throws Exception {
+    assertThat(entity, instanceOf(SourceDescription.class));
+    QueryMetadata queryMetadata = ksqlEngine.buildMultipleQueries(
+        ksqlQueryString, overriddenProperties).get(0);
+    validateQueryDescription(queryMetadata, overriddenProperties, entity);
+  }
+
+  private void validateQueryDescription(
+      QueryMetadata queryMetadata,
+      Map<String, Object> overriddenProperties,
+      KsqlEntity entity) throws Exception {
+    SourceDescription sourceDescription = (SourceDescription) entity;
+    assertThat(sourceDescription.getType(), equalTo("QUERY"));
+    assertThat(sourceDescription.getExecutionPlan(), equalTo(queryMetadata.getExecutionPlan()));
+    assertThat(sourceDescription.getTopology(), equalTo(queryMetadata.getTopologyDescription()));
+    assertThat(
+        sourceDescription.getSchema(),
+        equalTo(
+            queryMetadata.getOutputNode().getSchema().fields()
+                .stream()
+                .map(f -> new SourceDescription.FieldSchemaInfo(
+                    f.name(), SchemaUtil.getSchemaFieldName(f)))
+                .collect(Collectors.toList())));
+    assertThat(
+        sourceDescription.getOverriddenProperties(),
+        equalTo(overriddenProperties));
+  }
+
+  @Test
+  public void shouldFillExplainQueryWithCorrectInfo() throws Exception {
+    KsqlResource testResource = TestKsqlResourceUtil.get(ksqlEngine, ksqlRestConfig);
+    final String ksqlQueryString = "SELECT * FROM test_stream;";
+    final String ksqlString = "EXPLAIN " + ksqlQueryString;
+    Response response = testResource.handleKsqlStatements(
+        new KsqlRequest(ksqlString, new HashMap<>()));
+    KsqlEntityList result = (KsqlEntityList) response.getEntity();
+    assertThat("Response should have 1 entity", result.size(), equalTo(1));
+    validateQueryDescription(
+        ksqlQueryString,
+        Collections.singletonMap("ksql.streams.auto.offset.reset", "earliest"),
+        result.get(0));
+  }
+
+  @Test
+  public void shouldFillExplainQueryByIDWithCorrectInfo() throws Exception {
+    KsqlResource testResource = TestKsqlResourceUtil.get(ksqlEngine, ksqlRestConfig);
+
+    final String ksqlQueryString = "CREATE STREAM test_explain AS SELECT * FROM test_stream;";
+    Map<String, Object> overriddenProperties =
+        Collections.singletonMap("ksql.streams.auto.offset.reset", "earliest");
+    PersistentQueryMetadata queryMetadata =
+        (PersistentQueryMetadata) ksqlEngine.buildMultipleQueries(
+            ksqlQueryString,
+            overriddenProperties).get(0);
+
+    final String ksqlString = "EXPLAIN " + queryMetadata.getId() + ";";
+    Response response = testResource.handleKsqlStatements(new KsqlRequest(ksqlString, new HashMap<>()));
+    KsqlEntityList result = (KsqlEntityList) response.getEntity();
+    assertThat("Response should have 1 entity", result.size(), equalTo(1));
+    validateQueryDescription(queryMetadata, overriddenProperties, result.get(0));
   }
 
   private void registerSchema(SchemaRegistryClient schemaRegistryClient)

--- a/ksql-rest-app/src/test/java/io/confluent/ksql/rest/server/resources/KsqlResourceTest.java
+++ b/ksql-rest-app/src/test/java/io/confluent/ksql/rest/server/resources/KsqlResourceTest.java
@@ -569,7 +569,7 @@ public class KsqlResourceTest {
     assertThat("Response should have 1 entity", result.size(), equalTo(1));
     validateQueryDescription(
         ksqlQueryString,
-        Collections.singletonMap("ksql.streams.auto.offset.reset", "earliest"),
+        Collections.emptyMap(),
         result.get(0));
   }
 

--- a/ksql-rest-app/src/test/java/io/confluent/ksql/rest/server/resources/KsqlResourceTest.java
+++ b/ksql-rest-app/src/test/java/io/confluent/ksql/rest/server/resources/KsqlResourceTest.java
@@ -541,6 +541,7 @@ public class KsqlResourceTest {
       QueryMetadata queryMetadata,
       Map<String, Object> overriddenProperties,
       KsqlEntity entity) {
+    assertThat(entity, instanceOf(SourceDescription.class));
     SourceDescription sourceDescription = (SourceDescription) entity;
     assertThat(sourceDescription.getType(), equalTo("QUERY"));
     assertThat(sourceDescription.getExecutionPlan(), equalTo(queryMetadata.getExecutionPlan()));

--- a/ksql-rest-app/src/test/java/io/confluent/ksql/rest/server/resources/StreamedQueryResourceTest.java
+++ b/ksql-rest-app/src/test/java/io/confluent/ksql/rest/server/resources/StreamedQueryResourceTest.java
@@ -113,8 +113,7 @@ public class StreamedQueryResourceTest {
     final QueuedQueryMetadata queuedQueryMetadata =
         new QueuedQueryMetadata(queryString, mockKafkaStreams, mockOutputNode, "",
                                 rowQueue, DataSource.DataSourceType.KSTREAM, "",
-                                mockKafkaTopicClient,
-            null);
+                                mockKafkaTopicClient, null, Collections.emptyMap());
     expect(mockKsqlEngine.buildMultipleQueries(queryString, requestStreamsProperties))
         .andReturn(Collections.singletonList(queuedQueryMetadata));
     mockKsqlEngine.removeTemporaryQuery(queuedQueryMetadata);


### PR DESCRIPTION
Return the schema of the data being produced by a query in its
EXPLAIN output.

Return overridden properties a query is using in its EXPLAIN
output.

Include the KSQL service id in the response from /info