### PR TITLE
Add logging to the CliTest

### DIFF
--- a/ksql-cli/src/main/java/io/confluent/ksql/cli/Cli.java
+++ b/ksql-cli/src/main/java/io/confluent/ksql/cli/Cli.java
@@ -278,7 +278,7 @@ public class Cli implements Closeable, AutoCloseable {
   }
 
   private void handleStatements(String line)
-      throws IOException, InterruptedException, ExecutionException {
+      throws IOException, ExecutionException {
     StringBuilder consecutiveStatements = new StringBuilder();
     for (SqlBaseParser.SingleStatementContext statementContext :
         new KsqlParser().getStatements(line)) {
@@ -356,7 +356,7 @@ public class Cli implements Closeable, AutoCloseable {
       StringBuilder consecutiveStatements,
       SqlBaseParser.SingleStatementContext statementContext,
       String statementText
-  ) throws IOException, InterruptedException, ExecutionException {
+  ) throws IOException, ExecutionException {
     if (consecutiveStatements.length() != 0) {
       printKsqlResponse(
           restClient.makeKsqlRequest(consecutiveStatements.toString())
@@ -409,7 +409,7 @@ public class Cli implements Closeable, AutoCloseable {
   }
 
   private void handleStreamedQuery(String query)
-      throws InterruptedException, ExecutionException {
+      throws ExecutionException {
     RestResponse<KsqlRestClient.QueryStream> queryResponse =
         restClient.makeQueryRequest(query);
 
@@ -454,6 +454,9 @@ public class Cli implements Closeable, AutoCloseable {
           }
         } catch (CancellationException exception) {
           // It's fine
+        } catch (InterruptedException e) {
+          Thread.interrupted();
+          LOGGER.info("Ignoring interrupt", e);
         }
       } finally {
         terminal.writer().println("Query terminated");
@@ -469,7 +472,7 @@ public class Cli implements Closeable, AutoCloseable {
   }
 
   private void handlePrintedTopic(String printTopic)
-      throws InterruptedException, ExecutionException, IOException {
+      throws ExecutionException, IOException {
     RestResponse<InputStream> topicResponse =
         restClient.makePrintTopicRequest(printTopic);
 
@@ -499,6 +502,9 @@ public class Cli implements Closeable, AutoCloseable {
           topicResponse.getResponse().close();
           terminal.writer().println("Topic printing ceased");
           terminal.flush();
+        } catch (InterruptedException e) {
+          Thread.interrupted();
+          LOGGER.info("Ignoring interruption", e);
         }
       }
     } else {

--- a/ksql-cli/src/test/java/io/confluent/ksql/CliTest.java
+++ b/ksql-cli/src/test/java/io/confluent/ksql/CliTest.java
@@ -157,6 +157,7 @@ public class CliTest extends TestRunner {
     Map<String, Object> configMap = new HashMap<>();
     configMap.put(ConsumerConfig.BOOTSTRAP_SERVERS_CONFIG, CLUSTER.bootstrapServers());
     configMap.put(KsqlRestConfig.LISTENERS_CONFIG, CliUtils.getLocalServerAddress(PORT));
+    configMap.put(KsqlRestConfig.DISTRIBUTED_COMMAND_RESPONSE_TIMEOUT_MS_CONFIG, 30000);
     configMap.put("application.id", "KSQL");
     configMap.put("commit.interval.ms", 0);
     configMap.put("cache.max.bytes.buffering", 0);

--- a/ksql-cli/src/test/java/io/confluent/ksql/CliTest.java
+++ b/ksql-cli/src/test/java/io/confluent/ksql/CliTest.java
@@ -157,7 +157,6 @@ public class CliTest extends TestRunner {
     Map<String, Object> configMap = new HashMap<>();
     configMap.put(ConsumerConfig.BOOTSTRAP_SERVERS_CONFIG, CLUSTER.bootstrapServers());
     configMap.put(KsqlRestConfig.LISTENERS_CONFIG, CliUtils.getLocalServerAddress(PORT));
-    configMap.put(KsqlRestConfig.DISTRIBUTED_COMMAND_RESPONSE_TIMEOUT_MS_CONFIG, 30000);
     configMap.put("application.id", "KSQL");
     configMap.put("commit.interval.ms", 0);
     configMap.put("cache.max.bytes.buffering", 0);

--- a/ksql-cli/src/test/resources/log4j.properties
+++ b/ksql-cli/src/test/resources/log4j.properties
@@ -1,0 +1,17 @@
+# For the general syntax of property based configuration files see
+# the documentation of org.apache.log4j.PropertyConfigurator.
+
+log4j.rootLogger=WARN, default.file, stdout
+
+log4j.appender.default.file=io.confluent.ksql.util.TimestampLogFileAppender
+log4j.appender.default.file.ImmediateFlush=true
+log4j.appender.default.file.append=false
+log4j.appender.default.file.file=/tmp/ksql-logs/cli-%timestamp.log
+log4j.appender.default.file.layout=org.apache.log4j.PatternLayout
+log4j.appender.default.file.layout.ConversionPattern=[%d] %p %m (%c:%L)%n
+
+log4j.appender.stdout=org.apache.log4j.ConsoleAppender
+log4j.appender.stdout.layout=org.apache.log4j.PatternLayout
+log4j.appender.stdout.layout.ConversionPattern=[%d] %p %m (%c:%L)%n
+
+log4j.logger.io.confluent.ksql.cli.Cli=DEBUG

--- a/ksql-cli/src/test/resources/log4j.properties
+++ b/ksql-cli/src/test/resources/log4j.properties
@@ -1,14 +1,7 @@
 # For the general syntax of property based configuration files see
 # the documentation of org.apache.log4j.PropertyConfigurator.
 
-log4j.rootLogger=WARN, default.file, stdout
-
-log4j.appender.default.file=io.confluent.ksql.util.TimestampLogFileAppender
-log4j.appender.default.file.ImmediateFlush=true
-log4j.appender.default.file.append=false
-log4j.appender.default.file.file=/tmp/ksql-logs/cli-%timestamp.log
-log4j.appender.default.file.layout=org.apache.log4j.PatternLayout
-log4j.appender.default.file.layout.ConversionPattern=[%d] %p %m (%c:%L)%n
+log4j.rootLogger=WARN, stdout
 
 log4j.appender.stdout=org.apache.log4j.ConsoleAppender
 log4j.appender.stdout.layout=org.apache.log4j.PatternLayout


### PR DESCRIPTION
The `CliTest.testSelectLimit` still fails occasionally on Jenkins. The problem is that there are no logs for the run since the log files are not accessible on jenkins. This patch adds a logging configuration to redirect the logs to Stdout

Another notable thing from recent failures is only some of the expected outputs are printed. There is a point in the code where we abort reading from the server if the response stream contains a non-null error. If we get a spurious error, then it would explain the test failures. So this patch adds a log line at the point where we stop reading. 

With this, we should be able to better diagnose the root cause of the failures.