### PR TITLE
Formatting for CLI start command

### DIFF
--- a/docs/includes/ksql-includes.rst
+++ b/docs/includes/ksql-includes.rst
@@ -70,15 +70,15 @@ Launch the KSQL CLI
 To launch the CLI, run the following command. It will route the CLI logs to the ``./ksql_logs`` directory. By default,
 the CLI will look for a KSQL Server running at ``http://localhost:8088``.
 
-   .. code:: bash
+.. code:: bash
 
-       $ LOG_DIR=./ksql_logs <path-to-confluent>/bin/ksql
+   $ LOG_DIR=./ksql_logs <path-to-confluent>/bin/ksql
 
-   After KSQL is started, your terminal should resemble this.
+After KSQL is started, your terminal should resemble this.
 
-   .. include:: ../includes/ksql-includes.rst
-      :start-line: 19
-      :end-line: 40
+.. include:: ../includes/ksql-includes.rst
+  :start-line: 19
+  :end-line: 40
 
 .. _create-a-stream-and-table:
 

--- a/docs/installation/installing.rst
+++ b/docs/installation/installing.rst
@@ -122,52 +122,52 @@ After KSQL is started, your terminal should resemble this.
 Tip
     You can view the KSQL CLI help text by running ``<path-to-confluent>/bin/ksql --help``.
 
-         .. code:: bash
+    .. code:: bash
 
-                NAME
-                        ksql - KSQL CLI
+            NAME
+                    ksql - KSQL CLI
 
-                SYNOPSIS
-                        ksql [ --config-file <configFile> ] [ {-h | --help} ]
-                                [ --output <outputFormat> ]
-                                [ --query-row-limit <streamedQueryRowLimit> ]
-                                [ --query-timeout <streamedQueryTimeoutMs> ] [--] <server>
+            SYNOPSIS
+                    ksql [ --config-file <configFile> ] [ {-h | --help} ]
+                            [ --output <outputFormat> ]
+                            [ --query-row-limit <streamedQueryRowLimit> ]
+                            [ --query-timeout <streamedQueryTimeoutMs> ] [--] <server>
 
-                OPTIONS
-                        --config-file <configFile>
-                            A file specifying configs for Ksql and its underlying Kafka Streams
-                            instance(s). Refer to KSQL documentation for a list of available
-                            configs.
+            OPTIONS
+                    --config-file <configFile>
+                        A file specifying configs for Ksql and its underlying Kafka Streams
+                        instance(s). Refer to KSQL documentation for a list of available
+                        configs.
 
-                        -h, --help
-                            Display help information
+                    -h, --help
+                        Display help information
 
-                        --output <outputFormat>
-                            The output format to use (either 'JSON' or 'TABULAR'; can be changed
-                            during REPL as well; defaults to TABULAR)
+                    --output <outputFormat>
+                        The output format to use (either 'JSON' or 'TABULAR'; can be changed
+                        during REPL as well; defaults to TABULAR)
 
-                        --query-row-limit <streamedQueryRowLimit>
-                            An optional maximum number of rows to read from streamed queries
+                    --query-row-limit <streamedQueryRowLimit>
+                        An optional maximum number of rows to read from streamed queries
 
-                            This options value must fall in the following range: value >= 1
-
-
-                        --query-timeout <streamedQueryTimeoutMs>
-                            An optional time limit (in milliseconds) for streamed queries
-
-                            This options value must fall in the following range: value >= 1
+                        This options value must fall in the following range: value >= 1
 
 
-                        --
-                            This option can be used to separate command-line options from the
-                            list of arguments (useful when arguments might be mistaken for
-                            command-line options)
+                    --query-timeout <streamedQueryTimeoutMs>
+                        An optional time limit (in milliseconds) for streamed queries
 
-                        <server>
-                            The address of the Ksql server to connect to (ex:
-                            http://confluent.io:9098)
+                        This options value must fall in the following range: value >= 1
 
-                            This option may occur a maximum of 1 times
+
+                    --
+                        This option can be used to separate command-line options from the
+                        list of arguments (useful when arguments might be mistaken for
+                        command-line options)
+
+                    <server>
+                        The address of the Ksql server to connect to (ex:
+                        http://confluent.io:9098)
+
+                        This option may occur a maximum of 1 times
                             
                             
 -----------------------------


### PR DESCRIPTION
Fixes current formatting. 
![image](https://user-images.githubusercontent.com/11722533/38591872-d1e3a612-3ced-11e8-9b78-51f1b3647923.png)

Now looks like:
![image](https://user-images.githubusercontent.com/11722533/38591894-f47aba6c-3ced-11e8-81df-2e1e0303697a.png)
