### PR TITLE
SourceDescription cleanup + listing with descriptions

### DIFF
--- a/ksql-cli/src/test/java/io/confluent/ksql/cli/console/ConsoleTest.java
+++ b/ksql-cli/src/test/java/io/confluent/ksql/cli/console/ConsoleTest.java
@@ -136,7 +136,7 @@ public class ConsoleTest {
                 "TestSource", Collections.emptyList(), Collections.emptyList(),
                 buildTestSchema(2), DataSource.DataSourceType.KTABLE.getKqlType(),
                 "key", "2000-01-01", "stats", "errors", true, "avro", "kadka-topic",
-                2, 1)));
+                2, 1))));
 
     terminal.printKsqlEntityList(entityList);
 

--- a/ksql-cli/src/test/java/io/confluent/ksql/cli/console/ConsoleTest.java
+++ b/ksql-cli/src/test/java/io/confluent/ksql/cli/console/ConsoleTest.java
@@ -40,6 +40,7 @@ import io.confluent.ksql.query.QueryId;
 import io.confluent.ksql.rest.client.KsqlRestClient;
 import io.confluent.ksql.rest.entity.CommandStatusEntity;
 import io.confluent.ksql.rest.entity.ExecutionPlan;
+import io.confluent.ksql.rest.entity.FieldSchemaInfo;
 import io.confluent.ksql.rest.entity.KafkaTopicInfo;
 import io.confluent.ksql.rest.entity.KafkaTopicsList;
 import io.confluent.ksql.rest.entity.KsqlEntityList;
@@ -48,6 +49,7 @@ import io.confluent.ksql.rest.entity.KsqlTopicsList;
 import io.confluent.ksql.rest.entity.PropertiesList;
 import io.confluent.ksql.rest.entity.Queries;
 import io.confluent.ksql.rest.entity.SourceDescription;
+import io.confluent.ksql.rest.entity.SourceDescriptionEntity;
 import io.confluent.ksql.rest.entity.SourceInfo;
 import io.confluent.ksql.rest.entity.StreamedRow;
 import io.confluent.ksql.rest.entity.StreamsList;
@@ -108,10 +110,12 @@ public class ConsoleTest {
           new CommandStatusEntity("e", "topic/1/create", "SUCCESS", "Success Message"),
           new PropertiesList("e", properties),
           new Queries("e", queries),
-          new SourceDescription(
-              "e", "TestSource", Collections.emptyList(), Collections.emptyList(), buildTestSchema(i),
-              DataSource.DataSourceType.KTABLE.getKqlType(), "key", "2000-01-01", "stats", "errors",
-              false, "avro", "kadka-topic", "topology", "executionPlan", 1, 1, Collections.emptyMap()),
+          new SourceDescriptionEntity(
+              "e",
+              new SourceDescription(
+                  "TestSource", Collections.emptyList(), Collections.emptyList(), buildTestSchema(i),
+                  DataSource.DataSourceType.KTABLE.getKqlType(), "key", "2000-01-01", "stats",
+                  "errors", false, "avro", "kadka-topic", 1, 1)),
           new TopicDescription("e", "TestTopic", "TestKafkaTopic", "AVRO", "schemaString"),
           new StreamsList("e", ImmutableList.of(new SourceInfo.Stream("TestStream", "TestTopic", "AVRO"))),
           new TablesList("e", ImmutableList.of(new SourceInfo.Table("TestTable", "TestTopic", "JSON", false))),
@@ -126,12 +130,13 @@ public class ConsoleTest {
   @Test
   public void shouldPrintTopicDescribeExtended() throws IOException {
     final KsqlEntityList entityList = new KsqlEntityList(ImmutableList.of(
-        new SourceDescription(
-            "e", "TestSource", Collections.emptyList(), Collections.emptyList(), buildTestSchema(2),
-            DataSource.DataSourceType.KTABLE.getKqlType(), "key", "2000-01-01", "stats", "errors",
-            true, "avro", "kadka-topic", "topology", "executionPlan", 2, 1,
-            Collections.emptyMap())
-    ));
+        new SourceDescriptionEntity(
+            "e",
+            new SourceDescription(
+                "TestSource", Collections.emptyList(), Collections.emptyList(),
+                buildTestSchema(2), DataSource.DataSourceType.KTABLE.getKqlType(),
+                "key", "2000-01-01", "stats", "errors", true, "avro", "kadka-topic",
+                2, 1)));
 
     terminal.printKsqlEntityList(entityList);
 
@@ -143,16 +148,16 @@ public class ConsoleTest {
     }
   }
 
-  private static List<SourceDescription.FieldSchemaInfo> buildTestSchema(int size) {
+  private List<FieldSchemaInfo> buildTestSchema(int size) {
     SchemaBuilder dataSourceBuilder = SchemaBuilder.struct().name("TestSchema");
     for (int i = 0; i < size; i++) {
       dataSourceBuilder.field("f_" + i, SchemaUtil.getTypeSchema("STRING"));
     }
 
-    List<SourceDescription.FieldSchemaInfo> res = new ArrayList<>();
+    List<FieldSchemaInfo> res = new ArrayList<>();
     List<Field> fields = dataSourceBuilder.build().fields();
     for (Field field : fields) {
-      res.add(new SourceDescription.FieldSchemaInfo(field.name(), SchemaUtil.getSchemaFieldName(field)));
+      res.add(new FieldSchemaInfo(field.name(), SchemaUtil.getSchemaFieldName(field)));
     }
 
     return res;

--- a/ksql-engine/src/main/java/io/confluent/ksql/util/PersistentQueryMetadata.java
+++ b/ksql-engine/src/main/java/io/confluent/ksql/util/PersistentQueryMetadata.java
@@ -18,7 +18,6 @@ package io.confluent.ksql.util;
 
 import io.confluent.ksql.metastore.KsqlTopic;
 import io.confluent.ksql.metastore.StructuredDataSource;
-import io.confluent.ksql.planner.PlanSourceExtractorVisitor;
 import io.confluent.ksql.query.QueryId;
 import io.confluent.ksql.serde.DataSource;
 import io.confluent.ksql.planner.plan.OutputNode;
@@ -35,7 +34,6 @@ public class PersistentQueryMetadata extends QueryMetadata {
   private final QueryId id;
   private final KsqlTopic resultTopic;
 
-  private final Set<String> sourceNames;
   private final Set<String> sinkNames;
 
   public PersistentQueryMetadata(final String statementString,
@@ -54,9 +52,6 @@ public class PersistentQueryMetadata extends QueryMetadata {
           queryApplicationId, kafkaTopicClient, topology, overriddenProperties);
     this.id = id;
     this.resultTopic = resultTopic;
-    PlanSourceExtractorVisitor planSourceExtractorVisitor = new PlanSourceExtractorVisitor();
-    planSourceExtractorVisitor.process(outputNode, null);
-    this.sourceNames = planSourceExtractorVisitor.getSourceNames();
     this.sinkNames = new HashSet<>();
     this.sinkNames.add(sinkDataSource.getName());
   }
@@ -71,10 +66,6 @@ public class PersistentQueryMetadata extends QueryMetadata {
 
   public String getEntity() {
     return getOutputNode().getId().toString();
-  }
-
-  public Set<String> getSourceNames() {
-    return sourceNames;
   }
 
   public Set<String> getSinkNames() {

--- a/ksql-engine/src/main/java/io/confluent/ksql/util/QueryMetadata.java
+++ b/ksql-engine/src/main/java/io/confluent/ksql/util/QueryMetadata.java
@@ -17,6 +17,7 @@
 package io.confluent.ksql.util;
 
 import io.confluent.kafka.schemaregistry.client.SchemaRegistryClient;
+import io.confluent.ksql.planner.PlanSourceExtractorVisitor;
 import io.confluent.ksql.serde.DataSource;
 import io.confluent.ksql.planner.plan.OutputNode;
 
@@ -42,8 +43,9 @@ public class QueryMetadata {
   private final KafkaTopicClient kafkaTopicClient;
   private final Topology topoplogy;
   private final Map<String, Object> overriddenProperties;
+  private final Set<String> sourceNames;
 
-  public QueryMetadata(final String statementString,
+  protected QueryMetadata(final String statementString,
                        final KafkaStreams kafkaStreams,
                        final OutputNode outputNode,
                        final String executionPlan,
@@ -61,6 +63,9 @@ public class QueryMetadata {
     this.kafkaTopicClient = kafkaTopicClient;
     this.topoplogy = topoplogy;
     this.overriddenProperties = overriddenProperties;
+    PlanSourceExtractorVisitor planSourceExtractorVisitor = new PlanSourceExtractorVisitor();
+    planSourceExtractorVisitor.process(outputNode, null);
+    this.sourceNames = planSourceExtractorVisitor.getSourceNames();
   }
 
   public Map<String, Object> getOverriddenProperties() {
@@ -97,6 +102,10 @@ public class QueryMetadata {
 
   public Schema getResultSchema() {
     return outputNode.getSchema();
+  }
+
+  public Set<String> getSourceNames() {
+    return sourceNames;
   }
 
   public void close() {

--- a/ksql-parser/src/main/antlr4/io/confluent/ksql/parser/SqlBase.g4
+++ b/ksql-parser/src/main/antlr4/io/confluent/ksql/parser/SqlBase.g4
@@ -39,11 +39,11 @@ statement
     | (LIST | SHOW) PROPERTIES                                              #listProperties
     | (LIST | SHOW) TOPICS                                                  #listTopics
     | (LIST | SHOW) REGISTERED TOPICS                                       #listRegisteredTopics
-    | (LIST | SHOW) STREAMS                                                 #listStreams
-    | (LIST | SHOW) TABLES                                                  #listTables
+    | (LIST | SHOW) STREAMS DESCRIPTIONS?                                   #listStreams
+    | (LIST | SHOW) TABLES DESCRIPTIONS?                                    #listTables
     | DESCRIBE EXTENDED? (qualifiedName | TOPIC qualifiedName)              #showColumns
     | PRINT (qualifiedName | STRING) (FROM BEGINNING)? ((INTERVAL | SAMPLE) number)?   #printTopic
-    | (LIST | SHOW) QUERIES                                                 #listQueries
+    | (LIST | SHOW) QUERIES DESCRIPTIONS?                                   #listQueries
     | TERMINATE QUERY? qualifiedName                                        #terminateQuery
     | SET STRING EQ STRING                                                  #setProperty
     | UNSET STRING                                                          #unsetProperty
@@ -523,6 +523,7 @@ INSERT: 'INSERT';
 DELETE: 'DELETE';
 INTO: 'INTO';
 CONSTRAINT: 'CONSTRAINT';
+DESCRIPTIONS: 'DESCRIPTIONS';
 DESCRIBE: 'DESCRIBE';
 EXTENDED: 'EXTENDED';
 PRINT: 'PRINT';

--- a/ksql-parser/src/main/antlr4/io/confluent/ksql/parser/SqlBase.g4
+++ b/ksql-parser/src/main/antlr4/io/confluent/ksql/parser/SqlBase.g4
@@ -39,11 +39,11 @@ statement
     | (LIST | SHOW) PROPERTIES                                              #listProperties
     | (LIST | SHOW) TOPICS                                                  #listTopics
     | (LIST | SHOW) REGISTERED TOPICS                                       #listRegisteredTopics
-    | (LIST | SHOW) STREAMS DESCRIPTIONS?                                   #listStreams
-    | (LIST | SHOW) TABLES DESCRIPTIONS?                                    #listTables
+    | (LIST | SHOW) STREAMS EXTENDED?                                   #listStreams
+    | (LIST | SHOW) TABLES EXTENDED?                                    #listTables
     | DESCRIBE EXTENDED? (qualifiedName | TOPIC qualifiedName)              #showColumns
     | PRINT (qualifiedName | STRING) (FROM BEGINNING)? ((INTERVAL | SAMPLE) number)?   #printTopic
-    | (LIST | SHOW) QUERIES DESCRIPTIONS?                                   #listQueries
+    | (LIST | SHOW) QUERIES EXTENDED?                                   #listQueries
     | TERMINATE QUERY? qualifiedName                                        #terminateQuery
     | SET STRING EQ STRING                                                  #setProperty
     | UNSET STRING                                                          #unsetProperty
@@ -523,7 +523,6 @@ INSERT: 'INSERT';
 DELETE: 'DELETE';
 INTO: 'INTO';
 CONSTRAINT: 'CONSTRAINT';
-DESCRIPTIONS: 'DESCRIPTIONS';
 DESCRIBE: 'DESCRIBE';
 EXTENDED: 'EXTENDED';
 PRINT: 'PRINT';

--- a/ksql-parser/src/main/java/io/confluent/ksql/parser/AstBuilder.java
+++ b/ksql-parser/src/main/java/io/confluent/ksql/parser/AstBuilder.java
@@ -624,18 +624,21 @@ public class AstBuilder extends SqlBaseBaseVisitor<Node> {
 
   @Override
   public Node visitListStreams(SqlBaseParser.ListStreamsContext context) {
-    return new ListStreams(Optional.ofNullable(getLocation(context)));
+    return new ListStreams(
+        Optional.ofNullable(getLocation(context)), context.DESCRIPTIONS() != null);
   }
 
   @Override
   public Node visitListTables(SqlBaseParser.ListTablesContext context) {
-    return new ListTables(Optional.ofNullable(getLocation(context)));
+    return new ListTables(
+        Optional.ofNullable(getLocation(context)), context.DESCRIPTIONS() != null);
   }
 
 
   @Override
   public Node visitListQueries(SqlBaseParser.ListQueriesContext context) {
-    return new ListQueries(Optional.ofNullable(getLocation(context)));
+    return new ListQueries(
+        Optional.ofNullable(getLocation(context)), context.DESCRIPTIONS() != null);
   }
 
   @Override

--- a/ksql-parser/src/main/java/io/confluent/ksql/parser/AstBuilder.java
+++ b/ksql-parser/src/main/java/io/confluent/ksql/parser/AstBuilder.java
@@ -625,20 +625,20 @@ public class AstBuilder extends SqlBaseBaseVisitor<Node> {
   @Override
   public Node visitListStreams(SqlBaseParser.ListStreamsContext context) {
     return new ListStreams(
-        Optional.ofNullable(getLocation(context)), context.DESCRIPTIONS() != null);
+        Optional.ofNullable(getLocation(context)), context.EXTENDED() != null);
   }
 
   @Override
   public Node visitListTables(SqlBaseParser.ListTablesContext context) {
     return new ListTables(
-        Optional.ofNullable(getLocation(context)), context.DESCRIPTIONS() != null);
+        Optional.ofNullable(getLocation(context)), context.EXTENDED() != null);
   }
 
 
   @Override
   public Node visitListQueries(SqlBaseParser.ListQueriesContext context) {
     return new ListQueries(
-        Optional.ofNullable(getLocation(context)), context.DESCRIPTIONS() != null);
+        Optional.ofNullable(getLocation(context)), context.EXTENDED() != null);
   }
 
   @Override

--- a/ksql-parser/src/main/java/io/confluent/ksql/parser/tree/ListQueries.java
+++ b/ksql-parser/src/main/java/io/confluent/ksql/parser/tree/ListQueries.java
@@ -22,15 +22,15 @@ import java.util.Optional;
 import static com.google.common.base.MoreObjects.toStringHelper;
 
 public class ListQueries extends Statement {
-  boolean showDescriptions;
+  boolean showExtended;
 
-  public ListQueries(Optional<NodeLocation> location, boolean showDescriptions) {
+  public ListQueries(Optional<NodeLocation> location, boolean showExtended) {
     super(location);
-    this.showDescriptions = showDescriptions;
+    this.showExtended = showExtended;
   }
 
-  public boolean getShowDescriptions() {
-    return showDescriptions;
+  public boolean getShowExtended() {
+    return showExtended;
   }
 
   @Override

--- a/ksql-parser/src/main/java/io/confluent/ksql/parser/tree/ListQueries.java
+++ b/ksql-parser/src/main/java/io/confluent/ksql/parser/tree/ListQueries.java
@@ -22,9 +22,15 @@ import java.util.Optional;
 import static com.google.common.base.MoreObjects.toStringHelper;
 
 public class ListQueries extends Statement {
+  boolean showDescriptions;
 
-  public ListQueries(Optional<NodeLocation> location) {
+  public ListQueries(Optional<NodeLocation> location, boolean showDescriptions) {
     super(location);
+    this.showDescriptions = showDescriptions;
+  }
+
+  public boolean getShowDescriptions() {
+    return showDescriptions;
   }
 
   @Override

--- a/ksql-parser/src/main/java/io/confluent/ksql/parser/tree/ListStreams.java
+++ b/ksql-parser/src/main/java/io/confluent/ksql/parser/tree/ListStreams.java
@@ -23,15 +23,15 @@ import static com.google.common.base.MoreObjects.toStringHelper;
 
 public class ListStreams
     extends Statement {
-  boolean showDescriptions;
+  boolean showExtended;
 
-  public ListStreams(Optional<NodeLocation> location, boolean showDescriptions) {
+  public ListStreams(Optional<NodeLocation> location, boolean showExtended) {
     super(location);
-    this.showDescriptions = showDescriptions;
+    this.showExtended = showExtended;
   }
 
-  public boolean getShowDescriptions() {
-    return showDescriptions;
+  public boolean getShowExtended() {
+    return showExtended;
   }
 
   @Override

--- a/ksql-parser/src/main/java/io/confluent/ksql/parser/tree/ListStreams.java
+++ b/ksql-parser/src/main/java/io/confluent/ksql/parser/tree/ListStreams.java
@@ -23,9 +23,15 @@ import static com.google.common.base.MoreObjects.toStringHelper;
 
 public class ListStreams
     extends Statement {
+  boolean showDescriptions;
 
-  public ListStreams(Optional<NodeLocation> location) {
+  public ListStreams(Optional<NodeLocation> location, boolean showDescriptions) {
     super(location);
+    this.showDescriptions = showDescriptions;
+  }
+
+  public boolean getShowDescriptions() {
+    return showDescriptions;
   }
 
   @Override

--- a/ksql-parser/src/main/java/io/confluent/ksql/parser/tree/ListTables.java
+++ b/ksql-parser/src/main/java/io/confluent/ksql/parser/tree/ListTables.java
@@ -22,15 +22,15 @@ import java.util.Optional;
 import static com.google.common.base.MoreObjects.toStringHelper;
 
 public class ListTables extends Statement {
-  boolean showDescriptions;
+  boolean showExtended;
 
-  public ListTables(Optional<NodeLocation> location, boolean showDescriptions) {
+  public ListTables(Optional<NodeLocation> location, boolean showExtended) {
     super(location);
-    this.showDescriptions = showDescriptions;
+    this.showExtended = showExtended;
   }
 
-  public boolean getShowDescriptions() {
-    return showDescriptions;
+  public boolean getShowExtended() {
+    return showExtended;
   }
 
   @Override

--- a/ksql-parser/src/main/java/io/confluent/ksql/parser/tree/ListTables.java
+++ b/ksql-parser/src/main/java/io/confluent/ksql/parser/tree/ListTables.java
@@ -22,9 +22,15 @@ import java.util.Optional;
 import static com.google.common.base.MoreObjects.toStringHelper;
 
 public class ListTables extends Statement {
+  boolean showDescriptions;
 
-  public ListTables(Optional<NodeLocation> location) {
+  public ListTables(Optional<NodeLocation> location, boolean showDescriptions) {
     super(location);
+    this.showDescriptions = showDescriptions;
+  }
+
+  public boolean getShowDescriptions() {
+    return showDescriptions;
   }
 
   @Override

--- a/ksql-parser/src/test/java/io/confluent/ksql/parser/KsqlParserTest.java
+++ b/ksql-parser/src/test/java/io/confluent/ksql/parser/KsqlParserTest.java
@@ -541,7 +541,7 @@ public class KsqlParserTest {
     Assert.assertTrue(statement instanceof ListStreams);
     ListStreams listStreams = (ListStreams) statement;
     Assert.assertTrue(listStreams.toString().equalsIgnoreCase("ListStreams{}"));
-    Assert.assertThat(listStreams.getShowDescriptions(), is(false));
+    Assert.assertThat(listStreams.getShowExtended(), is(false));
   }
 
   @Test
@@ -551,7 +551,7 @@ public class KsqlParserTest {
     Assert.assertTrue(statement instanceof ListTables);
     ListTables listTables = (ListTables) statement;
     Assert.assertTrue(listTables.toString().equalsIgnoreCase("ListTables{}"));
-    Assert.assertThat(listTables.getShowDescriptions(), is(false));
+    Assert.assertThat(listTables.getShowExtended(), is(false));
   }
 
   @Test
@@ -560,7 +560,7 @@ public class KsqlParserTest {
     Statement statement = KSQL_PARSER.buildAst(statementString, metaStore).get(0);
     Assert.assertThat(statement, instanceOf(ListQueries.class));
     ListQueries listQueries = (ListQueries)statement;
-    Assert.assertThat(listQueries.getShowDescriptions(), is(false));
+    Assert.assertThat(listQueries.getShowExtended(), is(false));
   }
 
   @Test
@@ -615,28 +615,28 @@ public class KsqlParserTest {
 
   @Test
   public void shouldSetShowDescriptionsForShowStreamsDescriptions() {
-    String statementString = "SHOW STREAMS DESCRIPTIONS;";
+    String statementString = "SHOW STREAMS EXTENDED;";
     Statement statement = KSQL_PARSER.buildAst(statementString, metaStore).get(0);
     Assert.assertThat(statement, instanceOf(ListStreams.class));
     ListStreams listStreams = (ListStreams)statement;
-    Assert.assertThat(listStreams.getShowDescriptions(), is(true));
+    Assert.assertThat(listStreams.getShowExtended(), is(true));
   }
 
   @Test
   public void shouldSetShowDescriptionsForShowTablesDescriptions() {
-    String statementString = "SHOW TABLES DESCRIPTIONS;";
+    String statementString = "SHOW TABLES EXTENDED;";
     Statement statement = KSQL_PARSER.buildAst(statementString, metaStore).get(0);
     Assert.assertThat(statement, instanceOf(ListTables.class));
     ListTables listTables = (ListTables)statement;
-    Assert.assertThat(listTables.getShowDescriptions(), is(true));
+    Assert.assertThat(listTables.getShowExtended(), is(true));
   }
 
   @Test
   public void shouldSetShowDescriptionsForShowQueriesDescriptions() {
-    String statementString = "SHOW QUERIES DESCRIPTIONS;";
+    String statementString = "SHOW QUERIES EXTENDED;";
     Statement statement = KSQL_PARSER.buildAst(statementString, metaStore).get(0);
     Assert.assertThat(statement, instanceOf(ListQueries.class));
     ListQueries listQueries = (ListQueries)statement;
-    Assert.assertThat(listQueries.getShowDescriptions(), is(true));
+    Assert.assertThat(listQueries.getShowExtended(), is(true));
   }
 }

--- a/ksql-parser/src/test/java/io/confluent/ksql/parser/KsqlParserTest.java
+++ b/ksql-parser/src/test/java/io/confluent/ksql/parser/KsqlParserTest.java
@@ -27,6 +27,7 @@ import io.confluent.ksql.parser.tree.CreateTable;
 import io.confluent.ksql.parser.tree.DropStream;
 import io.confluent.ksql.parser.tree.DropTable;
 import io.confluent.ksql.parser.tree.ListProperties;
+import io.confluent.ksql.parser.tree.ListQueries;
 import io.confluent.ksql.parser.tree.ListStreams;
 import io.confluent.ksql.parser.tree.ListTables;
 import io.confluent.ksql.parser.tree.ListTopics;
@@ -46,6 +47,7 @@ import org.junit.Test;
 import java.util.List;
 
 import static org.hamcrest.CoreMatchers.equalTo;
+import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.CoreMatchers.nullValue;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.core.IsInstanceOf.instanceOf;
@@ -64,7 +66,7 @@ public class KsqlParserTest {
   }
 
   @Test
-  public void testSimpleQuery() throws Exception {
+  public void testSimpleQuery() {
     String simpleQuery = "SELECT col0, col2, col3 FROM test1 WHERE col0 > 100;";
     Statement statement = KSQL_PARSER.buildAst(simpleQuery, metaStore).get(0);
 
@@ -83,7 +85,7 @@ public class KsqlParserTest {
   }
 
   @Test
-  public void testProjection() throws Exception {
+  public void testProjection() {
     String queryStr = "SELECT col0, col2, col3 FROM test1;";
     Statement statement = KSQL_PARSER.buildAst(queryStr, metaStore).get(0);
     Assert.assertTrue("testProjection fails", statement instanceof Query);
@@ -98,7 +100,7 @@ public class KsqlParserTest {
   }
 
   @Test
-  public void testProjectionWithArrayMap() throws Exception {
+  public void testProjectionWithArrayMap() {
     String queryStr = "SELECT col0, col2, col3, col4[0], col5['key1'] FROM test1;";
     Statement statement = KSQL_PARSER.buildAst(queryStr, metaStore).get(0);
     Assert.assertTrue("testProjectionWithArrayMap fails", statement instanceof Query);
@@ -121,7 +123,7 @@ public class KsqlParserTest {
   }
 
   @Test
-  public void testProjectFilter() throws Exception {
+  public void testProjectFilter() {
     String queryStr = "SELECT col0, col2, col3 FROM test1 WHERE col0 > 100;";
     Statement statement = KSQL_PARSER.buildAst(queryStr, metaStore).get(0);
     Assert.assertTrue("testSimpleQuery fails", statement instanceof Query);
@@ -137,7 +139,7 @@ public class KsqlParserTest {
   }
 
   @Test
-  public void testBinaryExpression() throws Exception {
+  public void testBinaryExpression() {
     String queryStr = "SELECT col0+10, col2, col3-col1 FROM test1;";
     Statement statement = KSQL_PARSER.buildAst(queryStr, metaStore).get(0);
     Assert.assertTrue("testBinaryExpression fails", statement instanceof Query);
@@ -150,7 +152,7 @@ public class KsqlParserTest {
   }
 
   @Test
-  public void testBooleanExpression() throws Exception {
+  public void testBooleanExpression() {
     String queryStr = "SELECT col0 = 10, col2, col3 > col1 FROM test1;";
     Statement statement = KSQL_PARSER.buildAst(queryStr, metaStore).get(0);
     Assert.assertTrue("testBooleanExpression fails", statement instanceof Query);
@@ -163,7 +165,7 @@ public class KsqlParserTest {
   }
 
   @Test
-  public void testLiterals() throws Exception {
+  public void testLiterals() {
     String queryStr = "SELECT 10, col2, 'test', 2.5, true, -5 FROM test1;";
     Statement statement = KSQL_PARSER.buildAst(queryStr, metaStore).get(0);
     Assert.assertTrue("testLiterals fails", statement instanceof Query);
@@ -196,7 +198,7 @@ public class KsqlParserTest {
   }
 
   @Test
-  public void testBooleanLogicalExpression() throws Exception {
+  public void testBooleanLogicalExpression() {
     String
         queryStr =
         "SELECT 10, col2, 'test', 2.5, true, -5 FROM test1 WHERE col1 = 10 AND col2 LIKE 'val' OR col4 > 2.6 ;";
@@ -220,7 +222,7 @@ public class KsqlParserTest {
   }
 
   @Test
-  public void testSimpleLeftJoin() throws Exception {
+  public void testSimpleLeftJoin() {
     String
         queryStr =
         "SELECT t1.col1, t2.col1, t2.col4, col5, t2.col2 FROM test1 t1 LEFT JOIN test2 t2 ON "
@@ -240,7 +242,7 @@ public class KsqlParserTest {
   }
 
   @Test
-  public void testLeftJoinWithFilter() throws Exception {
+  public void testLeftJoinWithFilter() {
     String
         queryStr =
         "SELECT t1.col1, t2.col1, t2.col4, t2.col2 FROM test1 t1 LEFT JOIN test2 t2 ON t1.col1 = "
@@ -261,7 +263,7 @@ public class KsqlParserTest {
   }
 
   @Test
-  public void testSelectAll() throws Exception {
+  public void testSelectAll() {
     String queryStr = "SELECT * FROM test1 t1;";
     Statement statement = KSQL_PARSER.buildAst(queryStr, metaStore).get(0);
     Assert.assertTrue("testSelectAll fails", statement instanceof Query);
@@ -273,7 +275,7 @@ public class KsqlParserTest {
   }
 
   @Test
-  public void testSelectAllJoin() throws Exception {
+  public void testSelectAllJoin() {
     String
         queryStr =
         "SELECT * FROM test1 t1 LEFT JOIN test2 t2 ON t1.col1 = t2.col1 WHERE t2.col2 = 'test';";
@@ -291,7 +293,7 @@ public class KsqlParserTest {
   }
 
   @Test
-  public void testUDF() throws Exception {
+  public void testUDF() {
     String queryStr = "SELECT lcase(col1), concat(col2,'hello'), floor(abs(col3)) FROM test1 t1;";
     Statement statement = KSQL_PARSER.buildAst(queryStr, metaStore).get(0);
     Assert.assertTrue("testSelectAll fails", statement instanceof Query);
@@ -313,7 +315,7 @@ public class KsqlParserTest {
   }
 
   @Test
-  public void testRegisterTopic() throws Exception {
+  public void testRegisterTopic() {
     String
         queryStr =
         "REGISTER TOPIC orders_topic WITH (value_format = 'avro', "
@@ -328,7 +330,7 @@ public class KsqlParserTest {
   }
 
   @Test
-  public void testCreateStreamWithTopic() throws Exception {
+  public void testCreateStreamWithTopic() {
     String
         queryStr =
         "CREATE STREAM orders (ordertime bigint, orderid varchar, itemid varchar, orderunits "
@@ -343,7 +345,7 @@ public class KsqlParserTest {
   }
 
   @Test
-  public void testCreateStream() throws Exception {
+  public void testCreateStream() {
     String
         queryStr =
         "CREATE STREAM orders (ordertime bigint, orderid varchar, itemid varchar, orderunits "
@@ -362,7 +364,7 @@ public class KsqlParserTest {
   }
 
   @Test
-  public void testCreateTableWithTopic() throws Exception {
+  public void testCreateTableWithTopic() {
     String
         queryStr =
         "CREATE TABLE users (usertime bigint, userid varchar, regionid varchar, gender varchar) WITH (registered_topic = 'users_topic', key='userid', statestore='user_statestore');";
@@ -376,7 +378,7 @@ public class KsqlParserTest {
   }
 
   @Test
-  public void testCreateTable() throws Exception {
+  public void testCreateTable() {
     String
         queryStr =
         "CREATE TABLE users (usertime bigint, userid varchar, regionid varchar, gender varchar) "
@@ -394,7 +396,7 @@ public class KsqlParserTest {
   }
 
   @Test
-  public void testCreateStreamAsSelect() throws Exception {
+  public void testCreateStreamAsSelect() {
 
     String
         queryStr =
@@ -417,7 +419,7 @@ public class KsqlParserTest {
       around in the variables <format> and <kafkaTopic> cause things to break).
    */
   @Ignore
-  public void testCreateTopicFormatWithoutQuotes() throws Exception {
+  public void testCreateTopicFormatWithoutQuotes() {
     String ksqlTopic = "unquoted_topic";
     String format = "json";
     String kafkaTopic = "case_insensitive_kafka_topic";
@@ -439,7 +441,7 @@ public class KsqlParserTest {
   }
 
   @Test
-  public void testShouldFailIfWrongKeyword() throws Exception {
+  public void testShouldFailIfWrongKeyword() {
     try {
       String simpleQuery = "SELLECT col0, col2, col3 FROM test1 WHERE col0 > 100;";
       Statement statement = KSQL_PARSER.buildAst(simpleQuery, metaStore).get(0);
@@ -451,7 +453,7 @@ public class KsqlParserTest {
   }
 
   @Test
-  public void testSelectTumblingWindow() throws Exception {
+  public void testSelectTumblingWindow() {
 
     String
         queryStr =
@@ -472,7 +474,7 @@ public class KsqlParserTest {
   }
 
   @Test
-  public void testSelectHoppingWindow() throws Exception {
+  public void testSelectHoppingWindow() {
 
     String
         queryStr =
@@ -501,7 +503,7 @@ public class KsqlParserTest {
     System.out.println(statements);
   }
   @Test
-  public void testSelectSessionWindow() throws Exception {
+  public void testSelectSessionWindow() {
 
     String
         queryStr =
@@ -524,7 +526,7 @@ public class KsqlParserTest {
   }
 
   @Test
-  public void testShowTopics() throws Exception {
+  public void testShowTopics() {
     String simpleQuery = "SHOW TOPICS;";
     Statement statement = KSQL_PARSER.buildAst(simpleQuery, metaStore).get(0);
     Assert.assertTrue(statement instanceof ListTopics);
@@ -533,25 +535,36 @@ public class KsqlParserTest {
   }
 
   @Test
-  public void testShowStreams() throws Exception {
+  public void testShowStreams() {
     String simpleQuery = "SHOW STREAMS;";
     Statement statement = KSQL_PARSER.buildAst(simpleQuery, metaStore).get(0);
     Assert.assertTrue(statement instanceof ListStreams);
     ListStreams listStreams = (ListStreams) statement;
     Assert.assertTrue(listStreams.toString().equalsIgnoreCase("ListStreams{}"));
+    Assert.assertThat(listStreams.getShowDescriptions(), is(false));
   }
 
   @Test
-  public void testShowTables() throws Exception {
+  public void testShowTables() {
     String simpleQuery = "SHOW TABLES;";
     Statement statement = KSQL_PARSER.buildAst(simpleQuery, metaStore).get(0);
     Assert.assertTrue(statement instanceof ListTables);
     ListTables listTables = (ListTables) statement;
     Assert.assertTrue(listTables.toString().equalsIgnoreCase("ListTables{}"));
+    Assert.assertThat(listTables.getShowDescriptions(), is(false));
   }
 
   @Test
-  public void testShowProperties() throws Exception {
+  public void shouldReturnListQueriesForShowQueries() {
+    String statementString = "SHOW QUERIES;";
+    Statement statement = KSQL_PARSER.buildAst(statementString, metaStore).get(0);
+    Assert.assertThat(statement, instanceOf(ListQueries.class));
+    ListQueries listQueries = (ListQueries)statement;
+    Assert.assertThat(listQueries.getShowDescriptions(), is(false));
+  }
+
+  @Test
+  public void testShowProperties() {
     String simpleQuery = "SHOW PROPERTIES;";
     Statement statement = KSQL_PARSER.buildAst(simpleQuery, metaStore).get(0);
     Assert.assertTrue(statement instanceof ListProperties);
@@ -560,7 +573,7 @@ public class KsqlParserTest {
   }
 
   @Test
-  public void testSetProperties() throws Exception {
+  public void testSetProperties() {
     String simpleQuery = "set 'auto.offset.reset'='earliest';";
     Statement statement = KSQL_PARSER.buildAst(simpleQuery, metaStore).get(0);
     Assert.assertTrue(statement instanceof SetProperty);
@@ -571,7 +584,7 @@ public class KsqlParserTest {
   }
 
   @Test
-  public void testSelectSinkProperties() throws Exception {
+  public void testSelectSinkProperties() {
     String simpleQuery = "create stream s1 with (timestamp='orderid', partitions = 3) as select "
                          + "col1, col2"
                          + " from orders where col2 is null and col3 is not null or (col3*col2 = "
@@ -587,7 +600,7 @@ public class KsqlParserTest {
   }
 
   @Test
-  public void testDrop() throws Exception {
+  public void testDrop() {
     String simpleQuery = "DROP STREAM STREAM1; DROP TABLE TABLE1;";
     List<Statement> statements =  KSQL_PARSER.buildAst(simpleQuery, metaStore);
     Statement statement0 =statements.get(0);
@@ -600,4 +613,30 @@ public class KsqlParserTest {
     Assert.assertTrue(dropTable.getName().toString().equalsIgnoreCase("TABLE1"));
   }
 
+  @Test
+  public void shouldSetShowDescriptionsForShowStreamsDescriptions() {
+    String statementString = "SHOW STREAMS DESCRIPTIONS;";
+    Statement statement = KSQL_PARSER.buildAst(statementString, metaStore).get(0);
+    Assert.assertThat(statement, instanceOf(ListStreams.class));
+    ListStreams listStreams = (ListStreams)statement;
+    Assert.assertThat(listStreams.getShowDescriptions(), is(true));
+  }
+
+  @Test
+  public void shouldSetShowDescriptionsForShowTablesDescriptions() {
+    String statementString = "SHOW TABLES DESCRIPTIONS;";
+    Statement statement = KSQL_PARSER.buildAst(statementString, metaStore).get(0);
+    Assert.assertThat(statement, instanceOf(ListTables.class));
+    ListTables listTables = (ListTables)statement;
+    Assert.assertThat(listTables.getShowDescriptions(), is(true));
+  }
+
+  @Test
+  public void shouldSetShowDescriptionsForShowQueriesDescriptions() {
+    String statementString = "SHOW QUERIES DESCRIPTIONS;";
+    Statement statement = KSQL_PARSER.buildAst(statementString, metaStore).get(0);
+    Assert.assertThat(statement, instanceOf(ListQueries.class));
+    ListQueries listQueries = (ListQueries)statement;
+    Assert.assertThat(listQueries.getShowDescriptions(), is(true));
+  }
 }

--- a/ksql-rest-app/src/main/java/io/confluent/ksql/rest/entity/FieldSchemaInfo.java
+++ b/ksql-rest-app/src/main/java/io/confluent/ksql/rest/entity/FieldSchemaInfo.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2017 Confluent Inc.
+ * Copyright 2018 Confluent Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -18,31 +18,29 @@ package io.confluent.ksql.rest.entity;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
-import com.fasterxml.jackson.annotation.JsonSubTypes;
-import com.fasterxml.jackson.annotation.JsonTypeName;
 
-import java.util.ArrayList;
-import java.util.Collection;
-import java.util.List;
 import java.util.Objects;
 
-@JsonTypeName("streams")
-@JsonSubTypes({})
-public class StreamsList extends KsqlEntity {
+public class FieldSchemaInfo {
 
-  private final Collection<SourceInfo.Stream> streams;
+  private final String name;
+  private final String type;
 
   @JsonCreator
-  public StreamsList(
-      @JsonProperty("statementText") String statementText,
-      @JsonProperty("streams") Collection<SourceInfo.Stream> streams
+  public FieldSchemaInfo(
+      @JsonProperty("name") String name,
+      @JsonProperty("type") String type
   ) {
-    super(statementText);
-    this.streams = streams;
+    this.name = name;
+    this.type = type;
   }
 
-  public List<SourceInfo.Stream> getStreams() {
-    return new ArrayList<>(streams);
+  public String getName() {
+    return name;
+  }
+
+  public String getType() {
+    return type;
   }
 
   @Override
@@ -50,15 +48,17 @@ public class StreamsList extends KsqlEntity {
     if (this == o) {
       return true;
     }
-    if (!(o instanceof StreamsList)) {
+    if (!(o instanceof FieldSchemaInfo)) {
       return false;
     }
-    StreamsList that = (StreamsList) o;
-    return Objects.equals(getStreams(), that.getStreams());
+    FieldSchemaInfo that = (FieldSchemaInfo) o;
+    return Objects.equals(getName(), that.getName())
+        && Objects.equals(getType(), that.getType());
   }
 
   @Override
   public int hashCode() {
-    return Objects.hash(getStreams());
+    return Objects.hash(getName(), getType());
   }
 }
+

--- a/ksql-rest-app/src/main/java/io/confluent/ksql/rest/entity/KsqlEntity.java
+++ b/ksql-rest-app/src/main/java/io/confluent/ksql/rest/entity/KsqlEntity.java
@@ -21,19 +21,22 @@ import com.fasterxml.jackson.annotation.JsonTypeInfo;
 
 @JsonTypeInfo(
     use = JsonTypeInfo.Id.NAME,
-    include = JsonTypeInfo.As.WRAPPER_OBJECT
+    include = JsonTypeInfo.As.PROPERTY
 )
 @JsonSubTypes({
     @JsonSubTypes.Type(value = CommandStatusEntity.class, name = "currentStatus"),
     @JsonSubTypes.Type(value = PropertiesList.class, name = "properties"),
     @JsonSubTypes.Type(value = Queries.class, name = "queries"),
-    @JsonSubTypes.Type(value = SourceDescription.class, name = "description"),
+    @JsonSubTypes.Type(value = SourceDescriptionEntity.class, name = "description"),
+    @JsonSubTypes.Type(value = QueryDescriptionEntity.class, name = "query_description"),
     @JsonSubTypes.Type(value = TopicDescription.class, name = "topic_description"),
     @JsonSubTypes.Type(value = StreamsList.class, name = "streams"),
     @JsonSubTypes.Type(value = TablesList.class, name = "tables"),
     @JsonSubTypes.Type(value = KsqlTopicsList.class, name = "ksql_topics"),
     @JsonSubTypes.Type(value = KafkaTopicsList.class, name = "kafka_topics"),
-    @JsonSubTypes.Type(value = ExecutionPlan.class, name = "executionPlan")
+    @JsonSubTypes.Type(value = ExecutionPlan.class, name = "executionPlan"),
+    @JsonSubTypes.Type(value = SourceDescriptionList.class, name = "source_descriptions"),
+    @JsonSubTypes.Type(value = QueryDescriptionList.class, name = "query_descriptions")
 })
 public abstract class KsqlEntity {
   private final String statementText;

--- a/ksql-rest-app/src/main/java/io/confluent/ksql/rest/entity/QueryDescription.java
+++ b/ksql-rest-app/src/main/java/io/confluent/ksql/rest/entity/QueryDescription.java
@@ -56,12 +56,12 @@ public class QueryDescription {
   ) {
     this.id = id;
     this.statementText = statementText;
-    this.schema = schema;
-    this.sources = sources;
-    this.sinks = sinks;
+    this.schema = Collections.unmodifiableList(schema);
+    this.sources = Collections.unmodifiableSet(sources);
+    this.sinks = Collections.unmodifiableSet(sinks);
     this.topology = topology;
     this.executionPlan = executionPlan;
-    this.overriddenProperties = overriddenProperties;
+    this.overriddenProperties = Collections.unmodifiableMap(overriddenProperties);
   }
 
   private QueryDescription(QueryId queryId, QueryMetadata queryMetadata) {
@@ -127,18 +127,19 @@ public class QueryDescription {
       return false;
     }
     QueryDescription that = (QueryDescription) o;
-    return Objects.equals(getId(), that.getId())
-        && Objects.equals(getStatementText(), that.getStatementText())
-        && Objects.equals(getSchema(), that.getSchema())
-        && Objects.equals(getTopology(), that.getTopology())
-        && Objects.equals(getExecutionPlan(), that.getExecutionPlan())
-        && Objects.equals(getSources(), that.getSources())
-        && Objects.equals(getSinks(), that.getSinks())
-        && Objects.equals(getOverriddenProperties(), that.getOverriddenProperties());
+    return Objects.equals(id, that.id)
+        && Objects.equals(statementText, that.statementText)
+        && Objects.equals(schema, that.schema)
+        && Objects.equals(topology, that.topology)
+        && Objects.equals(executionPlan, that.executionPlan)
+        && Objects.equals(sources, that.sources)
+        && Objects.equals(sinks, that.sinks)
+        && Objects.equals(overriddenProperties, that.overriddenProperties);
   }
 
   @Override
   public int hashCode() {
-    return Objects.hash(getId());
+    return Objects.hash(
+        id, statementText, schema, topology, executionPlan, sources, sinks, overriddenProperties);
   }
 }

--- a/ksql-rest-app/src/main/java/io/confluent/ksql/rest/entity/QueryDescription.java
+++ b/ksql-rest-app/src/main/java/io/confluent/ksql/rest/entity/QueryDescription.java
@@ -1,0 +1,144 @@
+/**
+ * Copyright 2018 Confluent Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ **/
+
+package io.confluent.ksql.rest.entity;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+import io.confluent.ksql.query.QueryId;
+import io.confluent.ksql.util.PersistentQueryMetadata;
+import io.confluent.ksql.util.QueryMetadata;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+import io.confluent.ksql.util.SchemaUtil;
+
+public class QueryDescription {
+
+  private final QueryId id;
+  private final String statementText;
+  private final List<FieldSchemaInfo> schema;
+  private final Set<String> sources;
+  private final Set<String> sinks;
+  private final String topology;
+  private final String executionPlan;
+  private final Map<String, Object> overriddenProperties;
+
+  @JsonCreator
+  public QueryDescription(
+      @JsonProperty("id") QueryId id,
+      @JsonProperty("statementText") String statementText,
+      @JsonProperty("schema") List<FieldSchemaInfo> schema,
+      @JsonProperty("sources") Set<String> sources,
+      @JsonProperty("sinks") Set<String> sinks,
+      @JsonProperty("topology") String topology,
+      @JsonProperty("executionPlan") String executionPlan,
+      @JsonProperty("overriddenProperties") Map<String, Object> overriddenProperties
+  ) {
+    this.id = id;
+    this.statementText = statementText;
+    this.schema = schema;
+    this.sources = sources;
+    this.sinks = sinks;
+    this.topology = topology;
+    this.executionPlan = executionPlan;
+    this.overriddenProperties = overriddenProperties;
+  }
+
+  private QueryDescription(QueryId queryId, QueryMetadata queryMetadata) {
+    this(
+        queryId,
+        queryMetadata.getStatementString(),
+        queryMetadata.getResultSchema().fields().stream().map(
+            field -> new FieldSchemaInfo(field.name(), SchemaUtil.getSchemaFieldName(field))
+        ).collect(Collectors.toList()),
+        queryMetadata.getSourceNames(),
+        Collections.emptySet(),
+        queryMetadata.getTopologyDescription(),
+        queryMetadata.getExecutionPlan(),
+        queryMetadata.getOverriddenProperties());
+  }
+
+  public static QueryDescription forQueryMetadata(QueryMetadata queryMetadata) {
+    if (queryMetadata instanceof PersistentQueryMetadata) {
+      return new QueryDescription(
+          ((PersistentQueryMetadata) queryMetadata).getQueryId(), queryMetadata);
+    }
+    return new QueryDescription(new QueryId(""), queryMetadata);
+  }
+
+  public QueryId getId() {
+    return id;
+  }
+
+  public String getStatementText() {
+    return statementText;
+  }
+
+  public List<FieldSchemaInfo> getSchema() {
+    return schema;
+  }
+
+  public String getTopology() {
+    return topology;
+  }
+
+  public String getExecutionPlan() {
+    return executionPlan;
+  }
+
+  public Set<String> getSources() {
+    return sources;
+  }
+
+  public Set<String> getSinks() {
+    return sinks;
+  }
+
+  public Map<String, Object> getOverriddenProperties() {
+    return overriddenProperties;
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (!(o instanceof QueryDescription)) {
+      return false;
+    }
+    QueryDescription that = (QueryDescription) o;
+    return Objects.equals(getId(), that.getId())
+        && Objects.equals(getStatementText(), that.getStatementText())
+        && Objects.equals(getSchema(), that.getSchema())
+        && Objects.equals(getTopology(), that.getTopology())
+        && Objects.equals(getExecutionPlan(), that.getExecutionPlan())
+        && Objects.equals(getSources(), that.getSources())
+        && Objects.equals(getSinks(), that.getSinks())
+        && Objects.equals(getOverriddenProperties(), that.getOverriddenProperties());
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(getId());
+  }
+}

--- a/ksql-rest-app/src/main/java/io/confluent/ksql/rest/entity/QueryDescriptionEntity.java
+++ b/ksql-rest-app/src/main/java/io/confluent/ksql/rest/entity/QueryDescriptionEntity.java
@@ -48,8 +48,8 @@ public class QueryDescriptionEntity extends KsqlEntity {
     if (!(o instanceof QueryDescriptionEntity)) {
       return false;
     }
-    QueryDescriptionEntity queryDescriptionEntity = (QueryDescriptionEntity) o;
-    return Objects.equals(getQueryDescription(), queryDescriptionEntity.getQueryDescription());
+    QueryDescriptionEntity other = (QueryDescriptionEntity) o;
+    return Objects.equals(queryDescription, other.queryDescription);
   }
 
   @Override

--- a/ksql-rest-app/src/main/java/io/confluent/ksql/rest/entity/QueryDescriptionEntity.java
+++ b/ksql-rest-app/src/main/java/io/confluent/ksql/rest/entity/QueryDescriptionEntity.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2017 Confluent Inc.
+ * Copyright 2018 Confluent Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -21,28 +21,23 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonSubTypes;
 import com.fasterxml.jackson.annotation.JsonTypeName;
 
-import java.util.ArrayList;
-import java.util.Collection;
-import java.util.List;
 import java.util.Objects;
 
-@JsonTypeName("streams")
+@JsonTypeName("description")
 @JsonSubTypes({})
-public class StreamsList extends KsqlEntity {
-
-  private final Collection<SourceInfo.Stream> streams;
+public class QueryDescriptionEntity extends KsqlEntity {
+  private QueryDescription queryDescription;
 
   @JsonCreator
-  public StreamsList(
+  public QueryDescriptionEntity(
       @JsonProperty("statementText") String statementText,
-      @JsonProperty("streams") Collection<SourceInfo.Stream> streams
-  ) {
+      @JsonProperty("description") QueryDescription queryDescription) {
     super(statementText);
-    this.streams = streams;
+    this.queryDescription = queryDescription;
   }
 
-  public List<SourceInfo.Stream> getStreams() {
-    return new ArrayList<>(streams);
+  public QueryDescription getQueryDescription() {
+    return queryDescription;
   }
 
   @Override
@@ -50,15 +45,15 @@ public class StreamsList extends KsqlEntity {
     if (this == o) {
       return true;
     }
-    if (!(o instanceof StreamsList)) {
+    if (!(o instanceof ExecutionPlan)) {
       return false;
     }
-    StreamsList that = (StreamsList) o;
-    return Objects.equals(getStreams(), that.getStreams());
+    ExecutionPlan executionPlan = (ExecutionPlan) o;
+    return Objects.equals(getQueryDescription(), executionPlan.getExecutionPlan());
   }
 
   @Override
   public int hashCode() {
-    return Objects.hash(getStreams());
+    return Objects.hash(getQueryDescription());
   }
 }

--- a/ksql-rest-app/src/main/java/io/confluent/ksql/rest/entity/QueryDescriptionEntity.java
+++ b/ksql-rest-app/src/main/java/io/confluent/ksql/rest/entity/QueryDescriptionEntity.java
@@ -26,7 +26,7 @@ import java.util.Objects;
 @JsonTypeName("description")
 @JsonSubTypes({})
 public class QueryDescriptionEntity extends KsqlEntity {
-  private QueryDescription queryDescription;
+  private final QueryDescription queryDescription;
 
   @JsonCreator
   public QueryDescriptionEntity(

--- a/ksql-rest-app/src/main/java/io/confluent/ksql/rest/entity/QueryDescriptionEntity.java
+++ b/ksql-rest-app/src/main/java/io/confluent/ksql/rest/entity/QueryDescriptionEntity.java
@@ -45,11 +45,11 @@ public class QueryDescriptionEntity extends KsqlEntity {
     if (this == o) {
       return true;
     }
-    if (!(o instanceof ExecutionPlan)) {
+    if (!(o instanceof QueryDescriptionEntity)) {
       return false;
     }
-    ExecutionPlan executionPlan = (ExecutionPlan) o;
-    return Objects.equals(getQueryDescription(), executionPlan.getExecutionPlan());
+    QueryDescriptionEntity queryDescriptionEntity = (QueryDescriptionEntity) o;
+    return Objects.equals(getQueryDescription(), queryDescriptionEntity.getQueryDescription());
   }
 
   @Override

--- a/ksql-rest-app/src/main/java/io/confluent/ksql/rest/entity/QueryDescriptionList.java
+++ b/ksql-rest-app/src/main/java/io/confluent/ksql/rest/entity/QueryDescriptionList.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2017 Confluent Inc.
+ * Copyright 2018 Confluent Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -18,31 +18,26 @@ package io.confluent.ksql.rest.entity;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
-import com.fasterxml.jackson.annotation.JsonSubTypes;
 import com.fasterxml.jackson.annotation.JsonTypeName;
 
-import java.util.ArrayList;
-import java.util.Collection;
 import java.util.List;
 import java.util.Objects;
 
-@JsonTypeName("streams")
-@JsonSubTypes({})
-public class StreamsList extends KsqlEntity {
-
-  private final Collection<SourceInfo.Stream> streams;
+@JsonTypeName("query_descriptions")
+public class QueryDescriptionList extends KsqlEntity {
+  private final List<QueryDescription> queryDescriptions;
 
   @JsonCreator
-  public StreamsList(
+  public QueryDescriptionList(
       @JsonProperty("statementText") String statementText,
-      @JsonProperty("streams") Collection<SourceInfo.Stream> streams
+      @JsonProperty("queryDescriptions") List<QueryDescription> queryDescriptions
   ) {
     super(statementText);
-    this.streams = streams;
+    this.queryDescriptions = queryDescriptions;
   }
 
-  public List<SourceInfo.Stream> getStreams() {
-    return new ArrayList<>(streams);
+  public List<QueryDescription> getQueryDescriptions() {
+    return queryDescriptions;
   }
 
   @Override
@@ -50,15 +45,15 @@ public class StreamsList extends KsqlEntity {
     if (this == o) {
       return true;
     }
-    if (!(o instanceof StreamsList)) {
+    if (!(o instanceof QueryDescriptionList)) {
       return false;
     }
-    StreamsList that = (StreamsList) o;
-    return Objects.equals(getStreams(), that.getStreams());
+    QueryDescriptionList that = (QueryDescriptionList) o;
+    return Objects.equals(queryDescriptions, that.queryDescriptions);
   }
 
   @Override
   public int hashCode() {
-    return Objects.hash(getStreams());
+    return Objects.hash(queryDescriptions);
   }
 }

--- a/ksql-rest-app/src/main/java/io/confluent/ksql/rest/entity/SourceDescription.java
+++ b/ksql-rest-app/src/main/java/io/confluent/ksql/rest/entity/SourceDescription.java
@@ -25,6 +25,7 @@ import org.apache.kafka.clients.admin.TopicDescription;
 import org.apache.kafka.connect.data.Field;
 
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
@@ -74,9 +75,9 @@ public class SourceDescription {
       @JsonProperty("replication") int replication
   ) {
     this.name = name;
-    this.readQueries = readQueries;
-    this.writeQueries = writeQueries;
-    this.schema = schema;
+    this.readQueries = Collections.unmodifiableList(readQueries);
+    this.writeQueries = Collections.unmodifiableList(writeQueries);
+    this.schema = Collections.unmodifiableList(schema);
     this.type = type;
     this.key = key;
     this.timestamp = timestamp;
@@ -212,15 +213,22 @@ public class SourceDescription {
       return false;
     }
     SourceDescription that = (SourceDescription) o;
-    return Objects.equals(getName(), that.getName())
-           && Objects.equals(getSchema(), that.getSchema())
-           && getType().equals(that.getType())
-           && Objects.equals(getKey(), that.getKey())
-           && Objects.equals(getTimestamp(), that.getTimestamp());
+    return Objects.equals(name, that.name)
+           && Objects.equals(schema, that.schema)
+           && extended == that.extended
+           && Objects.equals(type, that.type)
+           && Objects.equals(serdes, that.serdes)
+           && Objects.equals(topic, that.topic)
+           && Objects.equals(key, that.key)
+           && Objects.equals(writeQueries, that.writeQueries)
+           && Objects.equals(readQueries, that.readQueries)
+           && Objects.equals(timestamp, that.timestamp)
+           && Objects.equals(statistics, that.statistics)
+           && Objects.equals(errorStats, that.errorStats);
   }
 
   @Override
   public int hashCode() {
-    return Objects.hash(getName(), getSchema(), getType(), getKey(), getTimestamp());
+    return Objects.hash(name, schema, type, key, timestamp);
   }
 }

--- a/ksql-rest-app/src/main/java/io/confluent/ksql/rest/entity/SourceDescription.java
+++ b/ksql-rest-app/src/main/java/io/confluent/ksql/rest/entity/SourceDescription.java
@@ -204,6 +204,31 @@ public class SourceDescription {
     return errorStats;
   }
 
+  private boolean equals2(SourceDescription that) {
+    if (!Objects.equals(topic, that.topic)) {
+      return false;
+    }
+    if (!Objects.equals(key, that.key)) {
+      return false;
+    }
+    if (!Objects.equals(writeQueries, that.writeQueries)) {
+      return false;
+    }
+    if (!Objects.equals(readQueries, that.readQueries)) {
+      return false;
+    }
+    if (!Objects.equals(timestamp, that.timestamp)) {
+      return false;
+    }
+    if (!Objects.equals(statistics, that.statistics)) {
+      return false;
+    }
+    if (!Objects.equals(errorStats, that.errorStats)) {
+      return false;
+    }
+    return true;
+  }
+
   @Override
   public boolean equals(Object o) {
     if (this == o) {
@@ -213,18 +238,22 @@ public class SourceDescription {
       return false;
     }
     SourceDescription that = (SourceDescription) o;
-    return Objects.equals(name, that.name)
-           && Objects.equals(schema, that.schema)
-           && extended == that.extended
-           && Objects.equals(type, that.type)
-           && Objects.equals(serdes, that.serdes)
-           && Objects.equals(topic, that.topic)
-           && Objects.equals(key, that.key)
-           && Objects.equals(writeQueries, that.writeQueries)
-           && Objects.equals(readQueries, that.readQueries)
-           && Objects.equals(timestamp, that.timestamp)
-           && Objects.equals(statistics, that.statistics)
-           && Objects.equals(errorStats, that.errorStats);
+    if (!Objects.equals(name, that.name)) {
+      return false;
+    }
+    if (!Objects.equals(schema, that.schema)) {
+      return false;
+    }
+    if (!Objects.equals(extended, that.extended)) {
+      return false;
+    }
+    if (!Objects.equals(type, that.type)) {
+      return false;
+    }
+    if (!Objects.equals(serdes, that.serdes)) {
+      return false;
+    }
+    return equals2(that);
   }
 
   @Override

--- a/ksql-rest-app/src/main/java/io/confluent/ksql/rest/entity/SourceDescription.java
+++ b/ksql-rest-app/src/main/java/io/confluent/ksql/rest/entity/SourceDescription.java
@@ -21,12 +21,10 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonSubTypes;
 import com.fasterxml.jackson.annotation.JsonTypeName;
 
-import io.confluent.ksql.util.PersistentQueryMetadata;
 import org.apache.kafka.clients.admin.TopicDescription;
 import org.apache.kafka.connect.data.Field;
 
 import java.util.Arrays;
-import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
@@ -35,14 +33,13 @@ import java.util.stream.Collectors;
 
 import io.confluent.ksql.metastore.StructuredDataSource;
 import io.confluent.ksql.metrics.MetricCollectors;
-import io.confluent.ksql.planner.plan.KsqlStructuredDataOutputNode;
 import io.confluent.ksql.util.KafkaTopicClient;
 import io.confluent.ksql.util.SchemaUtil;
 import io.confluent.ksql.util.timestamp.TimestampExtractionPolicy;
 
 @JsonTypeName("description")
 @JsonSubTypes({})
-public class SourceDescription extends KsqlEntity {
+public class SourceDescription {
 
   private final String name;
   private final List<String> readQueries;
@@ -56,15 +53,11 @@ public class SourceDescription extends KsqlEntity {
   private final boolean extended;
   private final String serdes;
   private final String topic;
-  private final String topology;
-  private final String executionPlan;
   private final int partitions;
   private final int replication;
-  private final Map<String, Object> overriddenProperties;
 
   @JsonCreator
   public SourceDescription(
-      @JsonProperty("statementText") String statementText,
       @JsonProperty("name") String name,
       @JsonProperty("readQueries") List<String> readQueries,
       @JsonProperty("writeQueries") List<String> writeQueries,
@@ -77,13 +70,9 @@ public class SourceDescription extends KsqlEntity {
       @JsonProperty("extended") boolean extended,
       @JsonProperty("serdes") String serdes,
       @JsonProperty("topic") String topic,
-      @JsonProperty("topology") String topology,
-      @JsonProperty("executionPlan") String executionPlan,
       @JsonProperty("parititions") int partitions,
-      @JsonProperty("replication") int replication,
-      @JsonProperty("overriddenProperties") Map<String, Object> overriddenProperties
+      @JsonProperty("replication") int replication
   ) {
-    super(statementText);
     this.name = name;
     this.readQueries = readQueries;
     this.writeQueries = writeQueries;
@@ -96,25 +85,19 @@ public class SourceDescription extends KsqlEntity {
     this.extended = extended;
     this.serdes = serdes;
     this.topic = topic;
-    this.topology = topology;
-    this.executionPlan = executionPlan;
     this.partitions = partitions;
     this.replication = replication;
-    this.overriddenProperties = overriddenProperties;
   }
 
   public SourceDescription(
       StructuredDataSource dataSource,
       boolean extended,
       String serdes,
-      String topology,
-      String executionPlan,
       List<String> readQueries,
       List<String> writeQueries,
       KafkaTopicClient topicClient
   ) {
     this(
-        "",
         dataSource.getName(),
         readQueries,
         writeQueries,
@@ -131,8 +114,6 @@ public class SourceDescription extends KsqlEntity {
         extended,
         serdes,
         dataSource.getKsqlTopic().getKafkaTopicName(),
-        topology,
-        executionPlan,
         (
             extended && topicClient != null ? getPartitions(
                 topicClient,
@@ -148,48 +129,7 @@ public class SourceDescription extends KsqlEntity {
                     .getKsqlTopic()
                     .getKafkaTopicName()
             ) : 0
-        ),
-        Collections.emptyMap()
-    );
-  }
-
-  private static KsqlStructuredDataOutputNode outputNodeFromMetadata(
-      PersistentQueryMetadata metadata) {
-    return (KsqlStructuredDataOutputNode) metadata.getOutputNode();
-  }
-
-  public SourceDescription(
-      PersistentQueryMetadata queryMetadata,
-      KafkaTopicClient topicClient
-  ) {
-    this(
-        queryMetadata.getStatementString(),
-        queryMetadata.getStatementString(),
-        Collections.EMPTY_LIST,
-        Collections.EMPTY_LIST,
-        queryMetadata.getResultSchema().fields().stream().map(
-            field ->
-              new FieldSchemaInfo(field.name(), SchemaUtil
-                  .getSchemaFieldName(field))
-            ).collect(Collectors.toList()),
-        "QUERY",
-        Optional.ofNullable(outputNodeFromMetadata(queryMetadata)
-            .getKeyField()).map(Field::name).orElse(""),
-        Optional.ofNullable(outputNodeFromMetadata(queryMetadata)
-            .getTimestampExtractionPolicy()).map(TimestampExtractionPolicy::timestampField)
-            .orElse(""),
-        MetricCollectors.getStatsFor(
-            outputNodeFromMetadata(queryMetadata).getKafkaTopicName(), false),
-        MetricCollectors.getStatsFor(
-            outputNodeFromMetadata(queryMetadata).getKafkaTopicName(), true),
-        true,
-        outputNodeFromMetadata(queryMetadata).getTopicSerde().getSerDe().name(),
-        outputNodeFromMetadata(queryMetadata).getKafkaTopicName(),
-        queryMetadata.getTopologyDescription(),
-        queryMetadata.getExecutionPlan(),
-        getPartitions(topicClient, outputNodeFromMetadata(queryMetadata).getKafkaTopicName()),
-        getReplication(topicClient, outputNodeFromMetadata(queryMetadata).getKafkaTopicName()),
-        queryMetadata.getOverriddenProperties()
+        )
     );
   }
 
@@ -261,59 +201,6 @@ public class SourceDescription extends KsqlEntity {
 
   public String getErrorStats() {
     return errorStats;
-  }
-
-  public String getTopology() {
-    return topology;
-  }
-
-  public String getExecutionPlan() {
-    return executionPlan;
-  }
-
-  public Map<String, Object> getOverriddenProperties() {
-    return overriddenProperties;
-  }
-
-  public static class FieldSchemaInfo {
-
-    private final String name;
-    private final String type;
-
-    @JsonCreator
-    public FieldSchemaInfo(
-        @JsonProperty("name") String name,
-        @JsonProperty("type") String type
-    ) {
-      this.name = name;
-      this.type = type;
-    }
-
-    public String getName() {
-      return name;
-    }
-
-    public String getType() {
-      return type;
-    }
-
-    @Override
-    public boolean equals(Object o) {
-      if (this == o) {
-        return true;
-      }
-      if (!(o instanceof FieldSchemaInfo)) {
-        return false;
-      }
-      FieldSchemaInfo that = (FieldSchemaInfo) o;
-      return Objects.equals(getName(), that.getName())
-             && Objects.equals(getType(), that.getType());
-    }
-
-    @Override
-    public int hashCode() {
-      return Objects.hash(getName(), getType());
-    }
   }
 
   @Override

--- a/ksql-rest-app/src/main/java/io/confluent/ksql/rest/entity/SourceDescriptionEntity.java
+++ b/ksql-rest-app/src/main/java/io/confluent/ksql/rest/entity/SourceDescriptionEntity.java
@@ -26,7 +26,7 @@ import java.util.Objects;
 @JsonTypeName("description")
 @JsonSubTypes({})
 public class SourceDescriptionEntity extends KsqlEntity {
-  private SourceDescription sourceDescription;
+  private final SourceDescription sourceDescription;
 
   @JsonCreator
   public SourceDescriptionEntity(

--- a/ksql-rest-app/src/main/java/io/confluent/ksql/rest/entity/SourceDescriptionEntity.java
+++ b/ksql-rest-app/src/main/java/io/confluent/ksql/rest/entity/SourceDescriptionEntity.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2017 Confluent Inc.
+ * Copyright 2018 Confluent Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -21,28 +21,23 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonSubTypes;
 import com.fasterxml.jackson.annotation.JsonTypeName;
 
-import java.util.ArrayList;
-import java.util.Collection;
-import java.util.List;
 import java.util.Objects;
 
-@JsonTypeName("streams")
+@JsonTypeName("description")
 @JsonSubTypes({})
-public class StreamsList extends KsqlEntity {
-
-  private final Collection<SourceInfo.Stream> streams;
+public class SourceDescriptionEntity extends KsqlEntity {
+  private SourceDescription sourceDescription;
 
   @JsonCreator
-  public StreamsList(
+  public SourceDescriptionEntity(
       @JsonProperty("statementText") String statementText,
-      @JsonProperty("streams") Collection<SourceInfo.Stream> streams
-  ) {
+      @JsonProperty("description") SourceDescription sourceDescription) {
     super(statementText);
-    this.streams = streams;
+    this.sourceDescription = sourceDescription;
   }
 
-  public List<SourceInfo.Stream> getStreams() {
-    return new ArrayList<>(streams);
+  public SourceDescription getSourceDescription() {
+    return sourceDescription;
   }
 
   @Override
@@ -50,15 +45,15 @@ public class StreamsList extends KsqlEntity {
     if (this == o) {
       return true;
     }
-    if (!(o instanceof StreamsList)) {
+    if (!(o instanceof ExecutionPlan)) {
       return false;
     }
-    StreamsList that = (StreamsList) o;
-    return Objects.equals(getStreams(), that.getStreams());
+    ExecutionPlan executionPlan = (ExecutionPlan) o;
+    return Objects.equals(getSourceDescription(), executionPlan.getExecutionPlan());
   }
 
   @Override
   public int hashCode() {
-    return Objects.hash(getStreams());
+    return Objects.hash(getSourceDescription());
   }
 }

--- a/ksql-rest-app/src/main/java/io/confluent/ksql/rest/entity/SourceDescriptionEntity.java
+++ b/ksql-rest-app/src/main/java/io/confluent/ksql/rest/entity/SourceDescriptionEntity.java
@@ -48,8 +48,8 @@ public class SourceDescriptionEntity extends KsqlEntity {
     if (!(o instanceof SourceDescriptionEntity)) {
       return false;
     }
-    SourceDescriptionEntity sourceDescriptionEntity = (SourceDescriptionEntity)o;
-    return Objects.equals(getSourceDescription(), sourceDescriptionEntity.getSourceDescription());
+    SourceDescriptionEntity other = (SourceDescriptionEntity)o;
+    return Objects.equals(sourceDescription, other.sourceDescription);
   }
 
   @Override

--- a/ksql-rest-app/src/main/java/io/confluent/ksql/rest/entity/SourceDescriptionEntity.java
+++ b/ksql-rest-app/src/main/java/io/confluent/ksql/rest/entity/SourceDescriptionEntity.java
@@ -45,11 +45,11 @@ public class SourceDescriptionEntity extends KsqlEntity {
     if (this == o) {
       return true;
     }
-    if (!(o instanceof ExecutionPlan)) {
+    if (!(o instanceof SourceDescriptionEntity)) {
       return false;
     }
-    ExecutionPlan executionPlan = (ExecutionPlan) o;
-    return Objects.equals(getSourceDescription(), executionPlan.getExecutionPlan());
+    SourceDescriptionEntity sourceDescriptionEntity = (SourceDescriptionEntity)o;
+    return Objects.equals(getSourceDescription(), sourceDescriptionEntity.getSourceDescription());
   }
 
   @Override

--- a/ksql-rest-app/src/main/java/io/confluent/ksql/rest/entity/SourceDescriptionList.java
+++ b/ksql-rest-app/src/main/java/io/confluent/ksql/rest/entity/SourceDescriptionList.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2017 Confluent Inc.
+ * Copyright 2018 Confluent Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -18,31 +18,27 @@ package io.confluent.ksql.rest.entity;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
-import com.fasterxml.jackson.annotation.JsonSubTypes;
 import com.fasterxml.jackson.annotation.JsonTypeName;
 
-import java.util.ArrayList;
-import java.util.Collection;
 import java.util.List;
 import java.util.Objects;
 
-@JsonTypeName("streams")
-@JsonSubTypes({})
-public class StreamsList extends KsqlEntity {
+@JsonTypeName("source_descriptions")
+public class SourceDescriptionList extends KsqlEntity {
 
-  private final Collection<SourceInfo.Stream> streams;
+  private final List<SourceDescription> sourceDescriptions;
 
   @JsonCreator
-  public StreamsList(
+  public SourceDescriptionList(
       @JsonProperty("statementText") String statementText,
-      @JsonProperty("streams") Collection<SourceInfo.Stream> streams
+      @JsonProperty("sourceDescriptions") List<SourceDescription> sourceDescriptions
   ) {
     super(statementText);
-    this.streams = streams;
+    this.sourceDescriptions = sourceDescriptions;
   }
 
-  public List<SourceInfo.Stream> getStreams() {
-    return new ArrayList<>(streams);
+  public List<SourceDescription> getSourceDescriptions() {
+    return sourceDescriptions;
   }
 
   @Override
@@ -50,15 +46,15 @@ public class StreamsList extends KsqlEntity {
     if (this == o) {
       return true;
     }
-    if (!(o instanceof StreamsList)) {
+    if (!(o instanceof SourceDescriptionList)) {
       return false;
     }
-    StreamsList that = (StreamsList) o;
-    return Objects.equals(getStreams(), that.getStreams());
+    SourceDescriptionList that = (SourceDescriptionList) o;
+    return Objects.equals(sourceDescriptions, that.sourceDescriptions);
   }
 
   @Override
   public int hashCode() {
-    return Objects.hash(getStreams());
+    return Objects.hash(sourceDescriptions);
   }
 }

--- a/ksql-rest-app/src/main/java/io/confluent/ksql/rest/entity/TablesList.java
+++ b/ksql-rest-app/src/main/java/io/confluent/ksql/rest/entity/TablesList.java
@@ -20,13 +20,11 @@ import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonSubTypes;
 import com.fasterxml.jackson.annotation.JsonTypeName;
-import io.confluent.ksql.metastore.KsqlTable;
 
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
 import java.util.Objects;
-import java.util.stream.Collectors;
 
 @JsonTypeName("tables")
 @JsonSubTypes({})
@@ -40,12 +38,6 @@ public class TablesList extends KsqlEntity {
   ) {
     super(statementText);
     this.tables = tables;
-  }
-
-  public static TablesList fromKsqlTables(String statementText, Collection<KsqlTable> ksqlTables) {
-    Collection<SourceInfo.Table> tableInfos =
-        ksqlTables.stream().map(SourceInfo.Table::new).collect(Collectors.toList());
-    return new TablesList(statementText, tableInfos);
   }
 
   public List<SourceInfo.Table> getTables() {

--- a/ksql-rest-app/src/main/java/io/confluent/ksql/rest/server/resources/KsqlResource.java
+++ b/ksql-rest-app/src/main/java/io/confluent/ksql/rest/server/resources/KsqlResource.java
@@ -270,11 +270,11 @@ public class KsqlResource {
     } else if (statement instanceof ListRegisteredTopics) {
       return listRegisteredTopics(statementText);
     } else if (statement instanceof ListStreams) {
-      return listStreams(statementText, ((ListStreams)statement).getShowDescriptions());
+      return listStreams(statementText, ((ListStreams)statement).getShowExtended());
     } else if (statement instanceof ListTables) {
-      return listTables(statementText, ((ListTables)statement).getShowDescriptions());
+      return listTables(statementText, ((ListTables)statement).getShowExtended());
     } else if (statement instanceof ListQueries) {
-      return showQueries(statementText, ((ListQueries)statement).getShowDescriptions());
+      return showQueries(statementText, ((ListQueries)statement).getShowExtended());
     } else if (statement instanceof ShowColumns) {
       ShowColumns showColumns = (ShowColumns) statement;
       if (showColumns.isTopic()) {

--- a/ksql-rest-app/src/test/java/io/confluent/ksql/rest/entity/KafkaTopicsListTest.java
+++ b/ksql-rest-app/src/test/java/io/confluent/ksql/rest/entity/KafkaTopicsListTest.java
@@ -79,10 +79,12 @@ public class KafkaTopicsListTest {
         ImmutableList.of(new KafkaTopicInfo("thetopic", true, ImmutableList.of(1, 2, 3), 42, 12))
     );
     String json = mapper.writeValueAsString(expected);
-    assertEquals("{\"kafka_topics\":{\"statementText\":\"SHOW TOPICS;\","
-                        + "\"topics\":[{\"name\":\"thetopic\",\"registered\":true,"
-                        + "\"replicaInfo\":[1,2,3],\"consumerCount\":42,"
-                        + "\"consumerGroupCount\":12}]}}", json);
+    assertEquals(
+        "{\"@type\":\"kafka_topics\",\"statementText\":\"SHOW TOPICS;\"," +
+        "\"topics\":[{\"name\":\"thetopic\",\"registered\":true," +
+        "\"replicaInfo\":[1,2,3],\"consumerCount\":42," +
+        "\"consumerGroupCount\":12}]}",
+        json);
 
     KafkaTopicsList actual = mapper.readValue(json, KafkaTopicsList.class);
     assertEquals(expected, actual);

--- a/ksql-rest-app/src/test/java/io/confluent/ksql/rest/entity/KsqlTopicsListTest.java
+++ b/ksql-rest-app/src/test/java/io/confluent/ksql/rest/entity/KsqlTopicsListTest.java
@@ -36,9 +36,10 @@ public class KsqlTopicsListTest {
         ImmutableList.of(new KsqlTopicInfo("ksqltopic", "kafkatopic", DataSourceSerDe.JSON))
     );
     String json = mapper.writeValueAsString(expected);
-    assertEquals("{\"ksql_topics\":{\"statementText\":\"SHOW TOPICS;\","
-                        + "\"topics\":[{\"name\":\"ksqltopic\",\"kafkaTopic\":\"kafkatopic\","
-                        + "\"format\":\"JSON\"}]}}", json);
+    assertEquals(
+        "{\"@type\":\"ksql_topics\",\"statementText\":\"SHOW TOPICS;\"," +
+        "\"topics\":[{\"name\":\"ksqltopic\",\"kafkaTopic\":\"kafkatopic\",\"format\":\"JSON\"}]}",
+        json);
 
     KsqlTopicsList actual = mapper.readValue(json, KsqlTopicsList.class);
     assertEquals(expected, actual);

--- a/ksql-rest-app/src/test/java/io/confluent/ksql/rest/entity/QueryDescriptionTest.java
+++ b/ksql-rest-app/src/test/java/io/confluent/ksql/rest/entity/QueryDescriptionTest.java
@@ -1,0 +1,134 @@
+package io.confluent.ksql.rest.entity;
+
+import io.confluent.kafka.schemaregistry.client.SchemaRegistryClient;
+import io.confluent.ksql.function.FunctionRegistry;
+import io.confluent.ksql.metastore.KsqlStream;
+import io.confluent.ksql.metastore.KsqlTopic;
+import io.confluent.ksql.planner.plan.OutputNode;
+import io.confluent.ksql.planner.plan.PlanNodeId;
+import io.confluent.ksql.planner.plan.StructuredDataSourceNode;
+import io.confluent.ksql.query.QueryId;
+import io.confluent.ksql.serde.DataSource;
+import io.confluent.ksql.serde.json.KsqlJsonTopicSerDe;
+import io.confluent.ksql.structured.SchemaKStream;
+import io.confluent.ksql.util.KafkaTopicClient;
+import io.confluent.ksql.util.KsqlConfig;
+import io.confluent.ksql.util.PersistentQueryMetadata;
+import io.confluent.ksql.util.QueryMetadata;
+import io.confluent.ksql.util.QueuedQueryMetadata;
+import io.confluent.ksql.util.timestamp.MetadataTimestampExtractionPolicy;
+import org.apache.kafka.connect.data.Field;
+import org.apache.kafka.connect.data.Schema;
+import org.apache.kafka.connect.data.SchemaBuilder;
+import org.apache.kafka.streams.KafkaStreams;
+import org.apache.kafka.streams.StreamsBuilder;
+import org.apache.kafka.streams.Topology;
+import org.apache.kafka.streams.TopologyDescription;
+import org.junit.Test;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.Map;
+import java.util.Optional;
+import java.util.concurrent.LinkedBlockingQueue;
+
+import static org.easymock.EasyMock.expect;
+import static org.easymock.EasyMock.mock;
+import static org.easymock.EasyMock.replay;
+import static org.hamcrest.CoreMatchers.equalTo;
+import static org.junit.Assert.assertThat;
+
+public class QueryDescriptionTest {
+  private static Schema SCHEMA =
+      SchemaBuilder.struct()
+          .field("field1", SchemaBuilder.int32().build())
+          .field("field2", SchemaBuilder.string().build())
+          .build();
+  private static String STATEMENT = "statement";
+
+  private static class FakeSourceNode extends StructuredDataSourceNode {
+    FakeSourceNode(String name) {
+      super(
+          new PlanNodeId("fake"),
+          new KsqlStream(
+              STATEMENT, name, SCHEMA, SCHEMA.fields().get(0),
+              new MetadataTimestampExtractionPolicy(),
+              new KsqlTopic(name, name, new KsqlJsonTopicSerDe())),
+          SCHEMA);
+    }
+  }
+
+  private static class FakeOutputNode extends OutputNode {
+    FakeOutputNode(FakeSourceNode sourceNode) {
+      super(
+          new PlanNodeId("fake"), sourceNode, SCHEMA, Optional.of(new Integer(1)),
+          new MetadataTimestampExtractionPolicy());
+    }
+
+    @Override
+    public Field getKeyField() {
+      return null;
+    }
+
+    @Override
+    public SchemaKStream buildStream(
+        StreamsBuilder builder, KsqlConfig ksqlConfig, KafkaTopicClient kafkaTopicClient,
+        FunctionRegistry functionRegistry, Map<String, Object> props,
+        SchemaRegistryClient schemaRegistryClient) {
+      return null;
+    }
+  }
+
+  @Test
+  public void shouldSetFieldsCorrectlyForQueryMetadata() {
+    KafkaStreams queryStreams = mock(KafkaStreams.class);
+    FakeSourceNode sourceNode = new FakeSourceNode("source");
+    OutputNode outputNode = new FakeOutputNode(sourceNode);
+    Topology topology = mock(Topology.class);
+    TopologyDescription topologyDescription = mock(TopologyDescription.class);
+    expect(topology.describe()).andReturn(topologyDescription);
+    replay(queryStreams, topology, topologyDescription);
+    Map<String, Object> streamsProperties = Collections.singletonMap("k", "v");
+    QueryMetadata queryMetadata = new QueuedQueryMetadata(
+        "test statement", queryStreams, outputNode, "execution plan",
+        new LinkedBlockingQueue<>(), DataSource.DataSourceType.KSTREAM, "app id",
+        null, topology, streamsProperties);
+
+    QueryDescription queryDescription = QueryDescription.forQueryMetadata(queryMetadata);
+
+    assertThat(queryDescription.getId().getId(), equalTo(""));
+    assertThat(queryDescription.getExecutionPlan(), equalTo("execution plan"));
+    assertThat(queryDescription.getSources(), equalTo(Collections.singleton("source")));
+    assertThat(queryDescription.getStatementText(), equalTo("test statement"));
+    assertThat(queryDescription.getTopology(), equalTo(topologyDescription.toString()));
+    assertThat(
+        queryDescription.getSchema(),
+        equalTo(
+            Arrays.asList(
+                new FieldSchemaInfo("field1", "INTEGER"),
+                new FieldSchemaInfo("field2", "VARCHAR(STRING)"))));
+  }
+
+  @Test
+  public void shouldSetIdCorrectlyForPersistentQueryMetadata() {
+    KafkaStreams queryStreams = mock(KafkaStreams.class);
+    FakeSourceNode sourceNode = new FakeSourceNode("source");
+    OutputNode outputNode = new FakeOutputNode(sourceNode);
+    Topology topology = mock(Topology.class);
+    TopologyDescription topologyDescription = mock(TopologyDescription.class);
+    expect(topology.describe()).andReturn(topologyDescription);
+    replay(topology, topologyDescription);
+    KsqlTopic sinkTopic = new KsqlTopic("fake_sink", "fake_sink", new KsqlJsonTopicSerDe());
+    KsqlStream fakeSink = new KsqlStream(
+        STATEMENT, "fake_sink", SCHEMA, SCHEMA.fields().get(0),
+        new MetadataTimestampExtractionPolicy(), sinkTopic);
+    Map<String, Object> streamsProperties = Collections.singletonMap("k", "v");
+
+    PersistentQueryMetadata queryMetadata = new PersistentQueryMetadata(
+        "test statement", queryStreams, outputNode, fakeSink,"execution plan",
+        new QueryId("query_id"), DataSource.DataSourceType.KSTREAM, "app id", null,
+        sinkTopic, topology, streamsProperties);
+    QueryDescription queryDescription = QueryDescription.forQueryMetadata(queryMetadata);
+    assertThat(queryDescription.getId().getId(), equalTo("query_id"));
+  }
+}

--- a/ksql-rest-app/src/test/java/io/confluent/ksql/rest/server/resources/KsqlResourceTest.java
+++ b/ksql-rest-app/src/test/java/io/confluent/ksql/rest/server/resources/KsqlResourceTest.java
@@ -16,7 +16,14 @@
 
 package io.confluent.ksql.rest.server.resources;
 
+import io.confluent.ksql.rest.entity.FieldSchemaInfo;
 import io.confluent.ksql.rest.entity.KsqlStatementErrorMessage;
+import io.confluent.ksql.rest.entity.QueryDescription;
+import io.confluent.ksql.rest.entity.QueryDescriptionEntity;
+import io.confluent.ksql.rest.entity.QueryDescriptionList;
+import io.confluent.ksql.rest.entity.SourceDescriptionEntity;
+import io.confluent.ksql.rest.entity.SourceDescriptionList;
+import io.confluent.ksql.serde.DataSource;
 import io.confluent.ksql.util.FakeKafkaTopicClient;
 import io.confluent.ksql.util.KafkaTopicClient;
 import io.confluent.ksql.util.PersistentQueryMetadata;
@@ -49,6 +56,7 @@ import java.util.concurrent.Future;
 import java.util.stream.Collectors;
 
 import javax.ws.rs.core.Response;
+import javax.xml.transform.Source;
 
 import io.confluent.kafka.schemaregistry.client.MockSchemaRegistryClient;
 import io.confluent.kafka.schemaregistry.client.SchemaRegistryClient;
@@ -100,6 +108,7 @@ import io.confluent.rest.RestConfig;
 
 import static org.hamcrest.CoreMatchers.containsString;
 import static org.hamcrest.CoreMatchers.equalTo;
+import static org.hamcrest.CoreMatchers.hasItem;
 import static org.hamcrest.CoreMatchers.instanceOf;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertThat;
@@ -191,34 +200,34 @@ public class KsqlResourceTest {
 
     private static void addTestTopicAndSources(MetaStore metaStore, KafkaTopicClient kafkaTopicClient) {
       Schema schema1 = SchemaBuilder.struct().field("S1_F1", Schema.BOOLEAN_SCHEMA);
-      KsqlTopic ksqlTopic1 = new KsqlTopic("KSQL_TOPIC_1", "KAFKA_TOPIC_1", new KsqlJsonTopicSerDe());
-      metaStore.putTopic(ksqlTopic1);
-      metaStore.putSource(new KsqlTable(
-          "statementText",
-          "TEST_TABLE",
-          schema1,
-          schema1.field("S1_F1"),
-          new MetadataTimestampExtractionPolicy(),
-          ksqlTopic1,
-          "statestore",
-          false));
-
-      Schema schema2 = SchemaBuilder.struct().field("S2_F1", Schema.STRING_SCHEMA)
-          .field("S2_F2", Schema.INT32_SCHEMA);
-      KsqlTopic ksqlTopic2 = new KsqlTopic(
-          "KSQL_TOPIC_2",
-          "KAFKA_TOPIC_2",
-          new KsqlJsonTopicSerDe());
-      metaStore.putTopic(ksqlTopic2);
-      metaStore.putSource(new KsqlStream(
-          "statementText",
-          "TEST_STREAM",
-          schema2,
-          schema2.field("S2_F2"),
-          new MetadataTimestampExtractionPolicy(),
-          ksqlTopic2));
+      addSource(
+          metaStore, kafkaTopicClient, DataSource.DataSourceType.KTABLE,
+          "TEST_TABLE", "KAFKA_TOPIC_1", "KSQL_TOPIC_1", schema1);
+      Schema schema2 = SchemaBuilder.struct().field("S2_F1", Schema.STRING_SCHEMA);
+      addSource(
+          metaStore, kafkaTopicClient, DataSource.DataSourceType.KSTREAM,
+          "TEST_STREAM", "KAFKA_TOPIC_2", "KSQL_TOPIC_2", schema2);
       kafkaTopicClient.createTopic("orders-topic", 1, (short)1);
+    }
 
+    public static void addSource(
+        MetaStore metaStore, KafkaTopicClient kafkaTopicClient, DataSource.DataSourceType type, String sourceName,
+        String topicName, String ksqlTopicName, Schema schema) {
+      KsqlTopic ksqlTopic = new KsqlTopic(ksqlTopicName, topicName, new KsqlJsonTopicSerDe());
+      kafkaTopicClient.createTopic(topicName, 1, (short)1);
+      metaStore.putTopic(ksqlTopic);
+      if (type == DataSource.DataSourceType.KSTREAM) {
+        metaStore.putSource(
+            new KsqlStream(
+                "statementText", sourceName, schema, schema.fields().get(0),
+                new MetadataTimestampExtractionPolicy(), ksqlTopic));
+      }
+      if (type == DataSource.DataSourceType.KTABLE) {
+        metaStore.putSource(
+            new KsqlTable(
+                "statementText", sourceName, schema, schema.fields().get(0),
+                new MetadataTimestampExtractionPolicy(), ksqlTopic, "statestore", false));
+      }
     }
 
     private static <T> Deserializer<T> getJsonDeserializer(Class<T> classs, boolean isKey) {
@@ -341,13 +350,6 @@ public class KsqlResourceTest {
   public void testShowQueries() throws Exception {
     KsqlResource testResource = TestKsqlResourceUtil.get(ksqlEngine);
     final String ksqlString = "SHOW QUERIES;";
-    final ListQueries ksqlStatement = new ListQueries(Optional.empty());
-    final String testKafkaTopic = "lol";
-
-    final String testQueryStatement = String.format(
-        "CREATE STREAM %s AS SELECT * FROM test_stream WHERE S2_F2 > 69;",
-        testKafkaTopic
-    );
 
     Queries queries = makeSingleRequest(
         testResource,
@@ -361,30 +363,119 @@ public class KsqlResourceTest {
   }
 
   @Test
+  public void shouldReturnDescriptionsForShowStreamsDescriptions() throws Exception {
+    KsqlResource testResource = TestKsqlResourceUtil.get(ksqlEngine);
+
+    Schema schema = SchemaBuilder.struct()
+        .field("FIELD1", Schema.BOOLEAN_SCHEMA)
+        .field("FIELD2", Schema.STRING_SCHEMA);
+    TestKsqlResourceUtil.addSource(
+        testResource.getKsqlEngine().getMetaStore(), testResource.getKsqlEngine().getTopicClient(),
+        DataSource.DataSourceType.KSTREAM, "new_stream", "new_topic",
+        "new_ksql_topic", schema);
+
+    String ksqlString = "SHOW STREAMS DESCRIPTIONS;";
+    SourceDescriptionList descriptionList = makeSingleRequest(
+        testResource, ksqlString, Collections.emptyMap(), SourceDescriptionList.class);
+    assertThat(descriptionList.getSourceDescriptions().size(), equalTo(2));
+    assertThat(
+        descriptionList.getSourceDescriptions(),
+        hasItem(
+            new SourceDescription(
+                testResource.getKsqlEngine().getMetaStore().getSource("TEST_STREAM"),
+                true, "serdes", Collections.EMPTY_LIST, Collections.EMPTY_LIST,
+                kafkaTopicClient)));
+    assertThat(
+        descriptionList.getSourceDescriptions(),
+        hasItem(
+            new SourceDescription(
+                testResource.getKsqlEngine().getMetaStore().getSource("new_stream"),
+                true, "serdes", Collections.EMPTY_LIST, Collections.EMPTY_LIST,
+                kafkaTopicClient)));
+  }
+
+  @Test
+  public void shouldReturnDescriptionsForShowTablesDescriptions() throws Exception {
+    KsqlResource testResource = TestKsqlResourceUtil.get(ksqlEngine);
+
+    Schema schema = SchemaBuilder.struct()
+        .field("FIELD1", Schema.BOOLEAN_SCHEMA)
+        .field("FIELD2", Schema.STRING_SCHEMA);
+    TestKsqlResourceUtil.addSource(
+        testResource.getKsqlEngine().getMetaStore(), testResource.getKsqlEngine().getTopicClient(),
+        DataSource.DataSourceType.KTABLE, "new_table", "new_topic",
+        "new_ksql_topic", schema);
+
+    String ksqlString = "SHOW TABLES DESCRIPTIONS;";
+    SourceDescriptionList descriptionList = makeSingleRequest(
+        testResource, ksqlString, Collections.emptyMap(), SourceDescriptionList.class);
+    assertThat(descriptionList.getSourceDescriptions().size(), equalTo(2));
+    assertThat(
+        descriptionList.getSourceDescriptions(),
+        hasItem(
+            new SourceDescription(
+                testResource.getKsqlEngine().getMetaStore().getSource("TEST_TABLE"),
+                true, "serdes", Collections.EMPTY_LIST, Collections.EMPTY_LIST,
+                kafkaTopicClient)));
+    assertThat(
+        descriptionList.getSourceDescriptions(),
+        hasItem(
+             new SourceDescription(
+                testResource.getKsqlEngine().getMetaStore().getSource("new_table"),
+                 true, "serdes", Collections.EMPTY_LIST, Collections.EMPTY_LIST,
+                kafkaTopicClient)));
+  }
+
+  @Test
+  public void shouldReturnDescriptionsForShowQueriesDescriptions() throws Exception {
+    KsqlResource testResource = TestKsqlResourceUtil.get(ksqlEngine);
+
+    Map<String, Object> overriddenProperties =
+        Collections.singletonMap("ksql.streams.auto.offset.reset", "earliest");
+    List<QueryMetadata> queryMetadata = ksqlEngine.buildMultipleQueries(
+        "CREATE STREAM test_describe_1 AS SELECT * FROM test_stream;" +
+            "CREATE STREAM test_describe_2 AS SELECT * FROM test_stream;",
+        overriddenProperties);
+
+    String ksqlString = "SHOW QUERIES DESCRIPTIONS;";
+    QueryDescriptionList descriptionList = makeSingleRequest(
+        testResource, ksqlString, Collections.emptyMap(), QueryDescriptionList.class);
+    assertThat(descriptionList.getQueryDescriptions().size(), equalTo(2));
+    assertThat(
+        descriptionList.getQueryDescriptions(),
+        hasItem(QueryDescription.forQueryMetadata(queryMetadata.get(0))));
+    assertThat(
+        descriptionList.getQueryDescriptions(),
+        hasItem(QueryDescription.forQueryMetadata(queryMetadata.get(1))));
+  }
+
+  @Test
   public void testDescribeStatement() throws Exception {
     KsqlResource testResource = TestKsqlResourceUtil.get(ksqlEngine);
     final String tableName = "TEST_TABLE";
     final String ksqlString = String.format("DESCRIBE %s;", tableName);
     final ShowColumns ksqlStatement = new ShowColumns(QualifiedName.of(tableName), false, false);
 
-    SourceDescription testDescription = makeSingleRequest(
+    SourceDescriptionEntity testDescription = makeSingleRequest(
         testResource,
         ksqlString,
         Collections.emptyMap(),
-        SourceDescription.class
+        SourceDescriptionEntity.class
     );
 
     SourceDescription expectedDescription =
-        new SourceDescription(testResource.getKsqlEngine().getMetaStore().getSource(tableName), false, "serdes", "topo", "exec-plan", Collections.EMPTY_LIST, Collections.EMPTY_LIST,null);
+        new SourceDescription(
+            testResource.getKsqlEngine().getMetaStore().getSource(tableName), false, "serdes",
+            Collections.EMPTY_LIST, Collections.EMPTY_LIST,null);
 
-    assertEquals(expectedDescription, testDescription);
+    assertEquals(expectedDescription, testDescription.getSourceDescription());
   }
 
   @Test
   public void testListStreamsStatement() throws Exception {
     KsqlResource testResource = TestKsqlResourceUtil.get(ksqlEngine);
     final String ksqlString = "LIST STREAMS;";
-    final ListStreams ksqlStatement = new ListStreams(Optional.empty());
+    final ListStreams ksqlStatement = new ListStreams(Optional.empty(), false);
 
     StreamsList streamsList = makeSingleRequest(
         testResource,
@@ -406,7 +497,7 @@ public class KsqlResourceTest {
   public void testListTablesStatement() throws Exception {
     KsqlResource testResource = TestKsqlResourceUtil.get(ksqlEngine);
     final String ksqlString = "LIST TABLES;";
-    final ListTables ksqlStatement = new ListTables(Optional.empty());
+    final ListTables ksqlStatement = new ListTables(Optional.empty(), false);
 
     TablesList tablesList = makeSingleRequest(
         testResource,
@@ -568,7 +659,6 @@ public class KsqlResourceTest {
       String ksqlQueryString,
       Map<String, Object> overriddenProperties,
       KsqlEntity entity) throws Exception {
-    assertThat(entity, instanceOf(SourceDescription.class));
     QueryMetadata queryMetadata = ksqlEngine.buildMultipleQueries(
         ksqlQueryString, overriddenProperties).get(0);
     validateQueryDescription(queryMetadata, overriddenProperties, entity);
@@ -578,21 +668,19 @@ public class KsqlResourceTest {
       QueryMetadata queryMetadata,
       Map<String, Object> overriddenProperties,
       KsqlEntity entity) {
-    assertThat(entity, instanceOf(SourceDescription.class));
-    SourceDescription sourceDescription = (SourceDescription) entity;
-    assertThat(sourceDescription.getType(), equalTo("QUERY"));
-    assertThat(sourceDescription.getExecutionPlan(), equalTo(queryMetadata.getExecutionPlan()));
-    assertThat(sourceDescription.getTopology(), equalTo(queryMetadata.getTopologyDescription()));
+    assertThat(entity, instanceOf(QueryDescriptionEntity.class));
+    QueryDescriptionEntity queryDescriptionEntity = (QueryDescriptionEntity) entity;
+    QueryDescription queryDescription = queryDescriptionEntity.getQueryDescription();
     assertThat(
-        sourceDescription.getSchema(),
+        queryDescription.getSchema(),
         equalTo(
             queryMetadata.getOutputNode().getSchema().fields()
                 .stream()
-                .map(f -> new SourceDescription.FieldSchemaInfo(
+                .map(f -> new FieldSchemaInfo(
                     f.name(), SchemaUtil.getSchemaFieldName(f)))
                 .collect(Collectors.toList())));
     assertThat(
-        sourceDescription.getOverriddenProperties(),
+        queryDescription.getOverriddenProperties(),
         equalTo(overriddenProperties));
   }
 

--- a/ksql-rest-app/src/test/java/io/confluent/ksql/rest/server/resources/KsqlResourceTest.java
+++ b/ksql-rest-app/src/test/java/io/confluent/ksql/rest/server/resources/KsqlResourceTest.java
@@ -363,7 +363,7 @@ public class KsqlResourceTest {
   }
 
   @Test
-  public void shouldReturnDescriptionsForShowStreamsDescriptions() throws Exception {
+  public void shouldReturnDescriptionsForShowStreamsExtended() throws Exception {
     KsqlResource testResource = TestKsqlResourceUtil.get(ksqlEngine);
 
     Schema schema = SchemaBuilder.struct()
@@ -374,7 +374,7 @@ public class KsqlResourceTest {
         DataSource.DataSourceType.KSTREAM, "new_stream", "new_topic",
         "new_ksql_topic", schema);
 
-    String ksqlString = "SHOW STREAMS DESCRIPTIONS;";
+    String ksqlString = "SHOW STREAMS EXTENDED;";
     SourceDescriptionList descriptionList = makeSingleRequest(
         testResource, ksqlString, Collections.emptyMap(), SourceDescriptionList.class);
     assertThat(descriptionList.getSourceDescriptions().size(), equalTo(2));
@@ -383,19 +383,19 @@ public class KsqlResourceTest {
         hasItem(
             new SourceDescription(
                 testResource.getKsqlEngine().getMetaStore().getSource("TEST_STREAM"),
-                true, "serdes", Collections.EMPTY_LIST, Collections.EMPTY_LIST,
+                true, "JSON", Collections.EMPTY_LIST, Collections.EMPTY_LIST,
                 kafkaTopicClient)));
     assertThat(
         descriptionList.getSourceDescriptions(),
         hasItem(
             new SourceDescription(
                 testResource.getKsqlEngine().getMetaStore().getSource("new_stream"),
-                true, "serdes", Collections.EMPTY_LIST, Collections.EMPTY_LIST,
+                true, "JSON", Collections.EMPTY_LIST, Collections.EMPTY_LIST,
                 kafkaTopicClient)));
   }
 
   @Test
-  public void shouldReturnDescriptionsForShowTablesDescriptions() throws Exception {
+  public void shouldReturnDescriptionsForShowTablesExtended() throws Exception {
     KsqlResource testResource = TestKsqlResourceUtil.get(ksqlEngine);
 
     Schema schema = SchemaBuilder.struct()
@@ -406,7 +406,7 @@ public class KsqlResourceTest {
         DataSource.DataSourceType.KTABLE, "new_table", "new_topic",
         "new_ksql_topic", schema);
 
-    String ksqlString = "SHOW TABLES DESCRIPTIONS;";
+    String ksqlString = "SHOW TABLES EXTENDED;";
     SourceDescriptionList descriptionList = makeSingleRequest(
         testResource, ksqlString, Collections.emptyMap(), SourceDescriptionList.class);
     assertThat(descriptionList.getSourceDescriptions().size(), equalTo(2));
@@ -415,19 +415,19 @@ public class KsqlResourceTest {
         hasItem(
             new SourceDescription(
                 testResource.getKsqlEngine().getMetaStore().getSource("TEST_TABLE"),
-                true, "serdes", Collections.EMPTY_LIST, Collections.EMPTY_LIST,
+                true, "JSON", Collections.EMPTY_LIST, Collections.EMPTY_LIST,
                 kafkaTopicClient)));
     assertThat(
         descriptionList.getSourceDescriptions(),
         hasItem(
              new SourceDescription(
                 testResource.getKsqlEngine().getMetaStore().getSource("new_table"),
-                 true, "serdes", Collections.EMPTY_LIST, Collections.EMPTY_LIST,
+                 true, "JSON", Collections.EMPTY_LIST, Collections.EMPTY_LIST,
                 kafkaTopicClient)));
   }
 
   @Test
-  public void shouldReturnDescriptionsForShowQueriesDescriptions() throws Exception {
+  public void shouldReturnDescriptionsForShowQueriesExtended() throws Exception {
     KsqlResource testResource = TestKsqlResourceUtil.get(ksqlEngine);
 
     Map<String, Object> overriddenProperties =
@@ -437,7 +437,7 @@ public class KsqlResourceTest {
             "CREATE STREAM test_describe_2 AS SELECT * FROM test_stream;",
         overriddenProperties);
 
-    String ksqlString = "SHOW QUERIES DESCRIPTIONS;";
+    String ksqlString = "SHOW QUERIES EXTENDED;";
     QueryDescriptionList descriptionList = makeSingleRequest(
         testResource, ksqlString, Collections.emptyMap(), QueryDescriptionList.class);
     assertThat(descriptionList.getQueryDescriptions().size(), equalTo(2));
@@ -465,7 +465,7 @@ public class KsqlResourceTest {
 
     SourceDescription expectedDescription =
         new SourceDescription(
-            testResource.getKsqlEngine().getMetaStore().getSource(tableName), false, "serdes",
+            testResource.getKsqlEngine().getMetaStore().getSource(tableName), false, "JSON",
             Collections.EMPTY_LIST, Collections.EMPTY_LIST,null);
 
     assertEquals(expectedDescription, testDescription.getSourceDescription());


### PR DESCRIPTION
This patch decouples source and query descriptions. SourceDescription
now describes a single data source (stream or table). The fields specific
to queries are pulled out into QueryDescription. QueryDescription also
includes the sources read from and written to.

This patch also makes it so that SourceDescription and QueryDescription are
not KsqlEntities. A KsqlEntity should be used to return the result of executing
a ksql statement (we should probably also change that name at some point, but
this patch refrains from doing so for the sake of keeping the diff manageable.).
With this change we can return a SourceDescription as part of a composition that
itself is a KsqlEntity.

Finally, add support for a DESCRIPTIONS flag to SHOW, which returns descriptions
instead of the more concise listing objects.

Fixes #1090 