### PR TITLE
Remove Java requirements and fix clickstream version

### DIFF
--- a/docs/tutorials/basics-docker.rst
+++ b/docs/tutorials/basics-docker.rst
@@ -15,7 +15,6 @@ this Kafka cluster. KSQL is installed in the |cp| by default.
     - `macOS <https://docs.docker.com/docker-for-mac/install/>`__
     - `All platforms <https://docs.docker.com/engine/installation/>`__
 - `Git <https://git-scm.com/downloads>`__
-- Java: Minimum version 1.8
 
 ------------------------------------
 Download the Tutorial and Start KSQL

--- a/docs/tutorials/clickstream-docker.rst
+++ b/docs/tutorials/clickstream-docker.rst
@@ -26,13 +26,13 @@ your local host.
 
 .. code:: bash
 
-    $ docker run -p 33000:3000 -it confluentinc/ksql-clickstream-demo:0.5 bash
+    $ docker run -p 33000:3000 -it confluentinc/ksql-clickstream-demo:4.1.0 bash
 
 Your output should resemble:
 
 .. code:: bash
 
-    Unable to find image 'confluentinc/ksql-clickstream-demo:0.5' locally
+    Unable to find image 'confluentinc/ksql-clickstream-demo:4.1.0' locally
     latest: Pulling from confluentinc/ksql-clickstream-demo
     ad74af05f5a2: Already exists
     d02e292e7b5e: Already exists


### PR DESCRIPTION
- Remove java 1.8 requirement from docker quickstart
- Update clickstream version from `0.5` to `4.1.0`