### PR TITLE
Add upgrade guide for developer preview releases

### DIFF
--- a/docs/includes/ksql-includes.rst
+++ b/docs/includes/ksql-includes.rst
@@ -67,7 +67,7 @@ Create and produce data to the Kafka topics ``pageviews`` and ``users``. These s
 -------------------
 Launch the KSQL CLI
 -------------------
-To launch the CLI, run the following command. It will route the CLI logs to the ``./ksql_logs`` directory. By default,
+To launch the CLI, run the following command. It will route the CLI logs to the ``.ksql_logs`` directory. By default,
 the CLI will look for a KSQL Server running at ``http://localhost:8088``.
 
 .. code:: bash
@@ -333,3 +333,17 @@ To enable JMX metrics, set ``JMX_PORT`` before starting the KSQL server:
 
     $ export JMX_PORT=1099 && \
       <path-to-confluent>/bin/ksql-server-start <path-to-confluent>/etc/ksql/ksql-server.properties
+
+.. log limitations
+
+.. important:: By default KSQL attempts to store its logs in a directory called ``logs`` that is relative to the location
+               of the ``ksql`` executable. For example, if ``ksql`` is installed at ``/usr/local/bin/ksql``, then it would
+               attempt to store its logs in ``/usr/local/logs``. If you are running ``ksql`` from the default |cp|
+               location, ``<path-to-confluent>/bin``, you must override this default behavior by using the ``LOG_DIR`` variable.
+
+               For example, to store your logs in the ``ksql_logs`` directory within your current working directory, run this
+               command when starting the KSQL CLI:
+
+               .. code:: bash
+
+                    $ LOG_DIR=./ksql_logs <path-to-confluent>/bin/ksql

--- a/docs/installation/installing.rst
+++ b/docs/installation/installing.rst
@@ -113,6 +113,10 @@ You can start the KSQL CLI by providing the connection information to the KSQL s
 
     $ LOG_DIR=./ksql_logs <path-to-confluent>/bin/ksql http://localhost:8088
 
+.. include:: ../includes/ksql-includes.rst
+    :start-line: 338
+    :end-line: 349
+
 After KSQL is started, your terminal should resemble this.
 
 .. include:: ../includes/ksql-includes.rst

--- a/docs/installation/upgrading.rst
+++ b/docs/installation/upgrading.rst
@@ -3,5 +3,39 @@
 Upgrading KSQL
 ==============
 
-Upgrade one server at a time (i.e. rolling restart). The remaining servers should have sufficient spare capacity to take
-over temporarily for unavailable servers.
+Upgrade one KSQL server at a time (i.e. rolling restart). The remaining KSQL servers should have sufficient spare
+capacity to take over temporarily for unavailable, restarting servers.
+
+
+Upgrading from KSQL 0.x (Developer Preview) to KSQL 4.1
+-------------------------------------------------------
+
+KSQL 4.1 is not backward-compatible with the previous KSQL 0.x developer preview releases.
+In particular, you must manually migrate queries running in the older preview releases of KSQL to the 4.1 version by
+issuing statements like ``CREATE STREAM`` and ``CREATE TABLE`` again.
+
+Notable changes in 4.1:
+
+* KSQL CLI:
+
+    * The ``ksql-cli`` command was renamed to ``ksql``.
+    * The CLI no longer supports what was formerly called "standalone" or "local" mode, where ``ksql-cli`` would run
+      both the CLI and also a KSQL server process inside the same JVM.  In 4.1, ``ksql`` will only run the CLI.  For
+      local development and testing, you can now run ``confluent start`` (which will also launch a KSQL server),
+      followed by ``ksql`` to start the CLI. This setup is used for the
+      :ref:`Confluent Platform quickstart <quickstart>`.  Alternatively, you can start the KSQL server directly as
+      described in :ref:`install_ksql-server`, followed by ``ksql`` to start the CLI.
+
+* KSQL server:
+
+    * The default ``listeners`` address was changed to ``http://localhost:8088`` (KSQL 0.x used
+      ``http://localhost:8080``).
+    * Assigning KSQL servers to a specific KSQL cluster has been simplified and is now done with the
+      ``ksql.service.id`` setting.  See :ref:`ksql-server-config` for details.
+
+* Executing ``.sql`` files: To run pre-defined KSQL queries stored in a ``.sql`` file, see
+  :ref:`restrict-ksql-interactive`.
+
+* Configuration: Advanced KSQL users can configure the Kafka Streams and Kafka producer/consumer client settings used
+  by KSQL.  This is achieved by using prefixes for the respective configuration settings.
+  See :ref:`ksql-param-reference` as well as :ref:`ksql-server-config` and :ref:`install_cli-config` for details.

--- a/docs/tutorials/basics-docker.rst
+++ b/docs/tutorials/basics-docker.rst
@@ -15,7 +15,6 @@ this Kafka cluster. KSQL is installed in the |cp| by default.
     - `macOS <https://docs.docker.com/docker-for-mac/install/>`__
     - `All platforms <https://docs.docker.com/engine/installation/>`__
 - `Git <https://git-scm.com/downloads>`__
-- Java: Minimum version 1.8
 
 ------------------------------------
 Download the Tutorial and Start KSQL

--- a/docs/tutorials/basics-local.rst
+++ b/docs/tutorials/basics-local.rst
@@ -18,7 +18,15 @@ this Kafka cluster. KSQL is installed in the |cp| by default.
 
 .. include:: ../includes/ksql-includes.rst
       :start-line: 42
-      :end-line: 81
+      :end-line: 76
+
+.. include:: ../includes/ksql-includes.rst
+      :start-line: 338
+      :end-line: 349
+
+.. include:: ../includes/ksql-includes.rst
+      :start-line: 76
+      :end-line: 82
 
 .. include:: ../includes/ksql-includes.rst
       :start-line: 82

--- a/docs/tutorials/clickstream-docker.rst
+++ b/docs/tutorials/clickstream-docker.rst
@@ -26,13 +26,13 @@ your local host.
 
 .. code:: bash
 
-    $ docker run -p 33000:3000 -it confluentinc/ksql-clickstream-demo:0.5 bash
+    $ docker run -p 33000:3000 -it confluentinc/ksql-clickstream-demo:4.1.0 bash
 
 Your output should resemble:
 
 .. code:: bash
 
-    Unable to find image 'confluentinc/ksql-clickstream-demo:0.5' locally
+    Unable to find image 'confluentinc/ksql-clickstream-demo:4.1.0' locally
     latest: Pulling from confluentinc/ksql-clickstream-demo
     ad74af05f5a2: Already exists
     d02e292e7b5e: Already exists


### PR DESCRIPTION
This should help existing KSQL users to upgrade more easily from Dev Preview releases to KSQL GA. 

We have been doing a lot of 1-1 Q&A already in the public KSQL Slack community (`#ksql` channel at https://launchpass.com/confluentcommunity), but this doesn't scale.  Better have proper information available in the docs.