### PR TITLE
Fix Rest API redirects.

### DIFF
--- a/ksql-rest-app/src/main/java/io/confluent/ksql/rest/server/KsqlRestApplication.java
+++ b/ksql-rest-app/src/main/java/io/confluent/ksql/rest/server/KsqlRestApplication.java
@@ -151,18 +151,10 @@ public class KsqlRestApplication extends Application<KsqlRestConfig> implements 
     this.serverInfo = serverInfo;
 
     this.commandRunnerThread = new Thread(commandRunner);
-    final String ksqlInstallDir = config.getString(KsqlRestConfig.INSTALL_DIR_CONFIG);
 
-    if (ksqlInstallDir == null || ksqlInstallDir.trim().isEmpty() && isUiEnabled) {
-      log.warn("System property {} is not set. User interface will be disabled",
-          KsqlRestConfig.INSTALL_DIR_CONFIG);
-      this.uiFolder = null;
-    } else if (isUiEnabled) {
-      this.uiFolder = ksqlInstallDir + "/ui";
-    } else {
-      this.uiFolder = null;
-    }
-    this.isUiEnabled = isUiEnabled && uiFolder != null;
+    final String ksqlInstallDir = config.getString(KsqlRestConfig.INSTALL_DIR_CONFIG);
+    this.uiFolder = isUiEnabled ? ksqlInstallDir + "/ui" : null;
+    this.isUiEnabled = isUiEnabled;
   }
 
   @Override
@@ -291,8 +283,14 @@ public class KsqlRestApplication extends Application<KsqlRestConfig> implements 
   )
       throws Exception {
 
-    Map<String, Object> ksqlConfProperties = new HashMap<>();
-    ksqlConfProperties.putAll(restConfig.getKsqlConfigProperties());
+    final String ksqlInstallDir = restConfig.getString(KsqlRestConfig.INSTALL_DIR_CONFIG);
+    if (ksqlInstallDir == null || ksqlInstallDir.trim().isEmpty() && isUiEnabled) {
+      log.warn("System property {} is not set. User interface will be disabled",
+               KsqlRestConfig.INSTALL_DIR_CONFIG);
+      isUiEnabled = false;
+    }
+
+    Map<String, Object> ksqlConfProperties = new HashMap<>(restConfig.getKsqlConfigProperties());
 
     KsqlConfig ksqlConfig = new KsqlConfig(ksqlConfProperties);
 
@@ -381,9 +379,7 @@ public class KsqlRestApplication extends Application<KsqlRestConfig> implements 
         commandStore
     );
 
-    RootDocument rootDocument = new RootDocument(isUiEnabled,
-                                                 restConfig.getList(RestConfig.LISTENERS_CONFIG)
-                                                     .get(0));
+    RootDocument rootDocument = new RootDocument(isUiEnabled);
 
     StatusResource statusResource = new StatusResource(statementExecutor);
     StreamedQueryResource streamedQueryResource = new StreamedQueryResource(

--- a/ksql-rest-app/src/main/java/io/confluent/ksql/rest/server/resources/RootDocument.java
+++ b/ksql-rest-app/src/main/java/io/confluent/ksql/rest/server/resources/RootDocument.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2017 Confluent Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -16,39 +16,33 @@
 
 package io.confluent.ksql.rest.server.resources;
 
+import java.net.URI;
+
 import javax.ws.rs.GET;
 import javax.ws.rs.Path;
 import javax.ws.rs.Produces;
+import javax.ws.rs.core.Context;
 import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.Response;
-import java.net.URI;
-import java.net.URISyntaxException;
+import javax.ws.rs.core.UriBuilder;
+import javax.ws.rs.core.UriInfo;
 
 @Path("/")
 @Produces(MediaType.APPLICATION_JSON)
 public class RootDocument {
 
-  private final boolean uiEnabled;
-  private final String uiUrl;
-  private final String infoUrl;
+  private final String postFix;
 
-  public RootDocument(boolean uiEnabled, String baseUrl) {
-    this.uiEnabled = uiEnabled;
-    this.uiUrl = baseUrl + "/index.html";
-    this.infoUrl = baseUrl + "/info";
+  public RootDocument(boolean uiEnabled) {
+    this.postFix = uiEnabled ? "index.html" : "info";
   }
 
   @GET
-  public Response get() {
-    try {
-      if (uiEnabled) {
-        return Response.temporaryRedirect(new URI(uiUrl)).build();
-      } else {
-        return Response.temporaryRedirect(new URI(infoUrl)).build();
-      }
-    } catch (URISyntaxException e) {
-      e.printStackTrace();
-    }
-    return Response.serverError().build();
+  public Response get(@Context final UriInfo uriInfo) {
+    final URI uri = UriBuilder.fromUri(uriInfo.getAbsolutePath())
+        .path(postFix)
+        .build();
+
+    return Response.temporaryRedirect(uri).build();
   }
 }

--- a/ksql-rest-app/src/test/java/io/confluent/ksql/rest/server/resources/RootDocumentTest.java
+++ b/ksql-rest-app/src/test/java/io/confluent/ksql/rest/server/resources/RootDocumentTest.java
@@ -1,0 +1,74 @@
+/*
+ * Copyright 2018 Confluent Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.confluent.ksql.rest.server.resources;
+
+import org.eclipse.jetty.http.HttpStatus;
+import org.junit.Test;
+
+import java.net.URI;
+import java.net.URISyntaxException;
+
+import javax.ws.rs.core.Response;
+import javax.ws.rs.core.UriInfo;
+
+import static org.easymock.EasyMock.expect;
+import static org.easymock.EasyMock.mock;
+import static org.easymock.EasyMock.replay;
+import static org.hamcrest.CoreMatchers.is;
+import static org.junit.Assert.*;
+
+/**
+ * @author andy
+ * created 17/04/2018
+ */
+public class RootDocumentTest {
+
+  @Test
+  public void shouldRedirectToUI() throws Exception {
+    // Given:
+    final RootDocument doc = new RootDocument(true);
+    final UriInfo uriInfo = uriInfo("http://something");
+
+    // When:
+    final Response response = doc.get(uriInfo);
+
+    // Then:
+    assertThat(response.getStatus(), is(HttpStatus.TEMPORARY_REDIRECT_307));
+    assertThat(response.getLocation().toString(), is("http://something/index.html"));
+  }
+
+  @Test
+  public void shouldRedirectToInfoIfNoUI() throws Exception {
+    // Given:
+    final RootDocument doc = new RootDocument(false);
+    final UriInfo uriInfo = uriInfo("http://some/proxy");
+
+    // When:
+    final Response response = doc.get(uriInfo);
+
+    // Then:
+    assertThat(response.getStatus(), is(HttpStatus.TEMPORARY_REDIRECT_307));
+    assertThat(response.getLocation().toString(), is("http://some/proxy/info"));
+  }
+
+  private UriInfo uriInfo(final String uri) throws URISyntaxException {
+    final UriInfo uriInfo = mock(UriInfo.class);
+    expect(uriInfo.getAbsolutePath()).andReturn(new URI(uri));
+    replay(uriInfo);
+    return uriInfo;
+  }
+}


### PR DESCRIPTION
PR contains two fixes:
 - Fix relating to #1081: Root `/` redirect currently forces a redirect based on the listener uri defined in the config e.g. `http://localhost:8088/info`, where as it should redirect using the current part, e.g. `http://127.0.0.1:8088` should redirect to `http://127.0.0.1:8088/info`, not `http://localhost:8088`.  (This fixes the redirect in #1081, but probably not the underlying issue with K8).
 - Fix redirect when 'uiEnabled' but no UI: current impl was redirecting from root '/' to /index.html' even if there was no UI war or expanded UI files available.