### PR TITLE
[WIP - DON'T MERGE YET] Update docker-compose.yml for KSQL 4.1 and CP 4.1

### DIFF
--- a/docs/tutorials/docker-compose.yml
+++ b/docs/tutorials/docker-compose.yml
@@ -2,7 +2,7 @@
 version: '2'
 services:
   zookeeper:
-    image: "confluentinc/cp-zookeeper:4.0.0"
+    image: "confluentinc/cp-zookeeper:4.1.0"
     hostname: zookeeper
     ports:
       - '32181:32181'
@@ -13,7 +13,7 @@ services:
       - "moby:127.0.0.1"
 
   kafka:
-    image: "confluentinc/cp-enterprise-kafka:4.0.0"
+    image: "confluentinc/cp-enterprise-kafka:4.1.0"
     hostname: kafka
     ports:
       - '9092:9092'
@@ -38,7 +38,7 @@ services:
       - "moby:127.0.0.1"
 
   schema-registry:
-    image: "confluentinc/cp-schema-registry:latest"
+    image: "confluentinc/cp-schema-registry:4.1.0"
     hostname: schema-registry
     depends_on:
       - zookeeper

--- a/docs/tutorials/docker-compose.yml
+++ b/docs/tutorials/docker-compose.yml
@@ -53,7 +53,7 @@ services:
 
   # Runs the Kafka KSQL data generator for topic called "pageviews"
   ksql-datagen-pageviews:
-    image: "confluentinc/ksql-examples:4.1.x-rc1"
+    image: "confluentinc/ksql-examples:4.1.0"
     hostname: ksql-datagen-pageviews
     depends_on:
       - kafka
@@ -83,7 +83,7 @@ services:
 
   # Runs the Kafka KSQL data generator for topic called "users"
   ksql-datagen-users:
-    image: "confluentinc/ksql-examples:4.1.x-rc1"
+    image: "confluentinc/ksql-examples:4.1.0"
     hostname: ksql-datagen-users
     depends_on:
       - kafka
@@ -113,7 +113,7 @@ services:
 
   # Runs the Kafka KSQL Server
   ksql-server:
-    image: "confluentinc/ksql-cli:4.1.x-rc1"
+    image: "confluentinc/ksql-cli:4.1.0"
     hostname: ksql-server
     ports:
       - '8088:8088'
@@ -142,7 +142,7 @@ services:
 
   # Runs the KSQL CLI
   ksql-cli:
-    image: "confluentinc/ksql-cli:4.1.x-rc1"
+    image: "confluentinc/ksql-cli:4.1.0"
     hostname: ksql-cli
     depends_on:
       - kafka


### PR DESCRIPTION
*IMPORTANT*: This PR should only be merged once the KSQL 4.1.0 images (tag) are available. The latest KSQL images on Docker Hub have the tag `4.1.x-rc1` now.