### PR TITLE
Allow tests with Kafka cluster to be run more than once in IDE.

### DIFF
--- a/ksql-engine/src/test/java/io/confluent/ksql/testutils/EmbeddedSingleNodeKafkaCluster.java
+++ b/ksql-engine/src/test/java/io/confluent/ksql/testutils/EmbeddedSingleNodeKafkaCluster.java
@@ -113,9 +113,10 @@ public class EmbeddedSingleNodeKafkaCluster extends ExternalResource {
     log.debug("Initiating embedded Kafka cluster startup");
 
     zookeeper = new ZooKeeperEmbedded();
+    brokerConfig.put(SimpleAclAuthorizer.ZkUrlProp(), zookeeper.connectString());
+
     broker = new KafkaEmbedded(effectiveBrokerConfigFrom());
     clientConfig.put(ConsumerConfig.BOOTSTRAP_SERVERS_CONFIG, bootstrapServers());
-    brokerConfig.put(SimpleAclAuthorizer.ZkUrlProp(), zookeeper.connectString());
     authorizer.configure(ImmutableMap.of(ZKConfig.ZkConnectProp(), zookeeperConnect()));
   }
 


### PR DESCRIPTION
Current embedded test kafka cluster fails with a error when trying to run a test more than once in the IDE. This PR fixes this.