### PR TITLE
Cherry-picks changes from 4.1.x that are not in 4.1.0-post

### DIFF
--- a/docs/faq.rst
+++ b/docs/faq.rst
@@ -78,7 +78,6 @@ KSQL currently supports formats:
 -  JSON
 -  Avro message values are supported. Avro keys are not yet supported. Requires |sr| and ``ksql.schema.registry.url`` in the
    KSQL server configuration file. For more information, see :ref:`install_ksql-avro-schema`.
-
 ====================================
 Is KSQL fully compliant to ANSI SQL?
 ====================================
@@ -150,9 +149,13 @@ You can configure your servers to run a set of predefined queries by using ``ksq
 How do I use Avro data and integrate with Confluent Schema Registry?
 ====================================================================
 
-Configure the ``ksql.schema.registry.url`` property in the KSQL server configuration to point to Schema Registry (see :ref:`install_ksql-avro-schema`).
+Configure the ``ksql.schema.registry.url`` property in the KSQL server configuration to point to Schema Registry
+(see :ref:`install_ksql-avro-schema`).
 
-.. important:: To use Avro data with KSQL you must have Schema Registry installed. This is included by default with |cp|.
+.. important::
+
+    - To use Avro data with KSQL you must have Schema Registry installed. This is included by default with |cp|.
+    - Avro message values are supported. Avro keys are not yet supported.
 
 =========================
 How can I scale out KSQL?

--- a/docs/includes/ksql-includes.rst
+++ b/docs/includes/ksql-includes.rst
@@ -67,7 +67,7 @@ Create and produce data to the Kafka topics ``pageviews`` and ``users``. These s
 -------------------
 Launch the KSQL CLI
 -------------------
-To launch the CLI, run the following command. It will route the CLI logs to the ``./ksql_logs`` directory. By default,
+To launch the CLI, run the following command. It will route the CLI logs to the ``.ksql_logs`` directory. By default,
 the CLI will look for a KSQL Server running at ``http://localhost:8088``.
 
 .. code:: bash
@@ -333,3 +333,17 @@ To enable JMX metrics, set ``JMX_PORT`` before starting the KSQL server:
 
     $ export JMX_PORT=1099 && \
       <path-to-confluent>/bin/ksql-server-start <path-to-confluent>/etc/ksql/ksql-server.properties
+
+.. log limitations
+
+.. important:: By default KSQL attempts to store its logs in a directory called ``logs`` that is relative to the location
+               of the ``ksql`` executable. For example, if ``ksql`` is installed at ``/usr/local/bin/ksql``, then it would
+               attempt to store its logs in ``/usr/local/logs``. If you are running ``ksql`` from the default |cp|
+               location, ``<path-to-confluent>/bin``, you must override this default behavior by using the ``LOG_DIR`` variable.
+
+               For example, to store your logs in the ``ksql_logs`` directory within your current working directory, run this
+               command when starting the KSQL CLI:
+
+               .. code:: bash
+
+                    $ LOG_DIR=./ksql_logs <path-to-confluent>/bin/ksql

--- a/docs/includes/ksql-includes.rst
+++ b/docs/includes/ksql-includes.rst
@@ -67,8 +67,8 @@ Create and produce data to the Kafka topics ``pageviews`` and ``users``. These s
 -------------------
 Launch the KSQL CLI
 -------------------
-To launch the CLI, run the following command. It will route the CLI logs to the ``.ksql_logs`` directory. By default,
-the CLI will look for a KSQL Server running at ``http://localhost:8088``.
+To launch the CLI, run the following command. It will route the CLI logs to the ``./ksql_logs`` directory, relative to
+your current directory. By default, the CLI will look for a KSQL Server running at ``http://localhost:8088``.
 
 .. code:: bash
 

--- a/docs/includes/ksql-includes.rst
+++ b/docs/includes/ksql-includes.rst
@@ -1,7 +1,7 @@
 .. Avro note
 
 .. note::
-    - To use Avro, you must have Confluent Schema Registry enabled and set ``ksql.schema.registry.url`` in the KSQL
+    - To use Avro, you must have |sr| enabled and ``ksql.schema.registry.url`` must be set in the KSQL
       server configuration file. See :ref:`install_ksql-avro-schema`.
     - Avro field names are not case sensitive in KSQL. This matches the KSQL column name behavior.
 

--- a/docs/installation/installing.rst
+++ b/docs/installation/installing.rst
@@ -113,6 +113,10 @@ You can start the KSQL CLI by providing the connection information to the KSQL s
 
     $ LOG_DIR=./ksql_logs <path-to-confluent>/bin/ksql http://localhost:8088
 
+.. include:: ../includes/ksql-includes.rst
+    :start-line: 338
+    :end-line: 349
+
 After KSQL is started, your terminal should resemble this.
 
 .. include:: ../includes/ksql-includes.rst

--- a/docs/tutorials/basics-docker.rst
+++ b/docs/tutorials/basics-docker.rst
@@ -15,7 +15,6 @@ this Kafka cluster. KSQL is installed in the |cp| by default.
     - `macOS <https://docs.docker.com/docker-for-mac/install/>`__
     - `All platforms <https://docs.docker.com/engine/installation/>`__
 - `Git <https://git-scm.com/downloads>`__
-- Java: Minimum version 1.8
 
 ------------------------------------
 Download the Tutorial and Start KSQL

--- a/docs/tutorials/basics-local.rst
+++ b/docs/tutorials/basics-local.rst
@@ -18,7 +18,15 @@ this Kafka cluster. KSQL is installed in the |cp| by default.
 
 .. include:: ../includes/ksql-includes.rst
       :start-line: 42
-      :end-line: 81
+      :end-line: 76
+
+.. include:: ../includes/ksql-includes.rst
+      :start-line: 338
+      :end-line: 349
+
+.. include:: ../includes/ksql-includes.rst
+      :start-line: 76
+      :end-line: 82
 
 .. include:: ../includes/ksql-includes.rst
       :start-line: 82

--- a/docs/tutorials/clickstream-docker.rst
+++ b/docs/tutorials/clickstream-docker.rst
@@ -26,13 +26,13 @@ your local host.
 
 .. code:: bash
 
-    $ docker run -p 33000:3000 -it confluentinc/ksql-clickstream-demo:0.5 bash
+    $ docker run -p 33000:3000 -it confluentinc/ksql-clickstream-demo:4.1.0 bash
 
 Your output should resemble:
 
 .. code:: bash
 
-    Unable to find image 'confluentinc/ksql-clickstream-demo:0.5' locally
+    Unable to find image 'confluentinc/ksql-clickstream-demo:4.1.0' locally
     latest: Pulling from confluentinc/ksql-clickstream-demo
     ad74af05f5a2: Already exists
     d02e292e7b5e: Already exists


### PR DESCRIPTION
Adds back in items commited to the wrong branch:

https://github.com/confluentinc/ksql/pull/1150 (fe83ea0a88087f9ef23c2e63d66904db962cba87)
https://github.com/confluentinc/ksql/pull/1152 (1e6e169c6207ea48a5eaba4feed6290499785559)
https://github.com/confluentinc/ksql/pull/1156 (7b85f658d0c74a30c7ac52cae187d950cf9d0a3a)
https://github.com/confluentinc/ksql/pull/1172/commits/def5f4732ce7ad7e92ec14549cdf96220d1a9c def5f4732ce7ad7e92ec14549cdf96220d1a9cc1