### PR TITLE
Fix handling of table tombstones

### DIFF
--- a/ksql-engine/src/test/java/io/confluent/ksql/planner/plan/JoinNodeTest.java
+++ b/ksql-engine/src/test/java/io/confluent/ksql/planner/plan/JoinNodeTest.java
@@ -199,10 +199,10 @@ public class JoinNodeTest {
     buildJoin();
     final Topology topology = builder.build();
     final TopologyDescription.Processor leftJoin
-        = (TopologyDescription.Processor) getNodeByName(topology, "KSTREAM-LEFTJOIN-0000000014");
+        = (TopologyDescription.Processor) getNodeByName(topology, "KSTREAM-LEFTJOIN-0000000015");
     final List<String> predecessors = leftJoin.predecessors().stream().map(TopologyDescription.Node::name).collect(Collectors.toList());
-    assertThat(leftJoin.stores(), equalTo(Utils.mkSet("KSTREAM-REDUCE-STATE-STORE-0000000003")));
-    assertThat(predecessors, equalTo(Collections.singletonList("KSTREAM-SOURCE-0000000013")));
+    assertThat(leftJoin.stores(), equalTo(Utils.mkSet("KSTREAM-AGGREGATE-STATE-STORE-0000000004")));
+    assertThat(predecessors, equalTo(Collections.singletonList("KSTREAM-SOURCE-0000000014")));
   }
 
   @Test

--- a/ksql-engine/src/test/java/io/confluent/ksql/planner/plan/StructuredDataSourceNodeTest.java
+++ b/ksql-engine/src/test/java/io/confluent/ksql/planner/plan/StructuredDataSourceNodeTest.java
@@ -20,13 +20,19 @@ import org.apache.kafka.connect.data.Field;
 import org.apache.kafka.connect.data.Schema;
 import org.apache.kafka.connect.data.SchemaBuilder;
 import org.apache.kafka.streams.StreamsBuilder;
+import org.apache.kafka.streams.Topology;
 import org.apache.kafka.streams.TopologyDescription;
 import org.junit.Before;
 import org.junit.Test;
 
+import java.util.Arrays;
 import java.util.Collections;
+import java.util.Comparator;
 import java.util.HashMap;
+import java.util.LinkedList;
 import java.util.List;
+import java.util.ListIterator;
+import java.util.Set;
 import java.util.stream.Collectors;
 
 import io.confluent.kafka.schemaregistry.client.MockSchemaRegistryClient;
@@ -44,7 +50,9 @@ import io.confluent.ksql.util.timestamp.LongColumnTimestampExtractionPolicy;
 import static io.confluent.ksql.planner.plan.PlanTestUtil.getNodeByName;
 import static io.confluent.ksql.planner.plan.PlanTestUtil.verifyProcessorNode;
 import static org.hamcrest.CoreMatchers.equalTo;
+import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.CoreMatchers.nullValue;
+import static org.hamcrest.CoreMatchers.startsWith;
 import static org.hamcrest.MatcherAssert.assertThat;
 
 public class StructuredDataSourceNodeTest {
@@ -142,4 +150,46 @@ public class StructuredDataSourceNodeTest {
     assertThat(result.getClass(), equalTo(SchemaKTable.class));
   }
 
+  @Test
+  public void shouldTransformKStreamToKTableCorrectly() {
+    StructuredDataSourceNode node = new StructuredDataSourceNode(
+        new PlanNodeId("0"),
+        new KsqlTable("sqlExpression", "datasource",
+            schema,
+            schema.field("field"),
+            new LongColumnTimestampExtractionPolicy("timestamp"),
+            new KsqlTopic("topic2", "topic2",
+                new KsqlJsonTopicSerDe()),
+            "statestore",
+            false),
+        schema);
+    builder = new StreamsBuilder();
+    build(node);
+    Topology topology = builder.build();
+    final TopologyDescription description = topology.describe();
+
+    List<String> expectedPlan = Arrays.asList(
+        "SOURCE", "MAPVALUES", "TRANSFORMVALUES", "MAPVALUES", "AGGREGATE");
+
+    assertThat(description.subtopologies().size(), equalTo(1));
+    Set<TopologyDescription.Node> nodes = description.subtopologies().iterator().next().nodes();
+    // Get the source node
+    TopologyDescription.Node streamsNode = nodes.iterator().next();
+    while (!streamsNode.predecessors().isEmpty()) {
+      streamsNode = streamsNode.predecessors().iterator().next();
+    }
+    // Walk the plan and make sure it matches
+    ListIterator<String> expectedPlanIt = expectedPlan.listIterator();
+    assertThat(nodes.size(), equalTo(expectedPlan.size()));
+    while (true) {
+      assertThat(streamsNode.name(), startsWith("KSTREAM-" + expectedPlanIt.next()));
+      if (streamsNode.successors().isEmpty()) {
+        assertThat(expectedPlanIt.hasNext(), is(false));
+        break;
+      }
+      assertThat(expectedPlanIt.hasNext(), is(true));
+      assertThat(streamsNode.successors().size(), equalTo(1));
+      streamsNode = streamsNode.successors().iterator().next();
+    }
+  }
 }

--- a/ksql-engine/src/test/resources/query-validation-tests/table-update-delete.json
+++ b/ksql-engine/src/test/resources/query-validation-tests/table-update-delete.json
@@ -1,0 +1,31 @@
+{
+  "comments": [
+    "You can specify multiple statements per test case, i.e., to set up the various streams needed",
+    "for joins etc, but currently only the final topology will be verified. This should be enough",
+    "for most tests as we can simulate the outputs from previous stages into the final stage. If we",
+    "take a modular approach to testing we can still verify that it all works correctly, i.e, if we",
+    "verify the output of a select or aggregate is correct, we can use simulated output to feed into",
+    "a join or another aggregate."
+  ],
+  "tests": [
+    {
+      "name": "table-update-delete",
+      "statements": [
+        "CREATE TABLE TEST (ID bigint, NAME varchar, VALUE int) WITH (kafka_topic='test_topic', value_format='DELIMITED', key='ID');",
+        "CREATE STREAM T1 as SELECT NAME, VALUE FROM test;"
+      ],
+      "inputs": [
+        {"topic": "test_topic", "key": 1, "value": "1,one,100", "timestamp": 0},
+        {"topic": "test_topic", "key": 2, "value": "2,two,200", "timestamp": 0},
+        {"topic": "test_topic", "key": 1, "value": "1,one,300", "timestamp": 0},
+        {"topic": "test_topic", "key": 1, "value": null, "timestamp": 0}
+      ],
+      "outputs": [
+        {"topic": "T1", "key": 1, "value": "one,100", "timestamp": 0},
+        {"topic": "T1", "key": 2, "value": "two,200", "timestamp": 0},
+        {"topic": "T1", "key": 1, "value": "one,300", "timestamp": 0},
+        {"topic": "T1", "key": 1, "value": null, "timestamp": 0}
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
Changelog topics for tables can contain tombstone records with null values to
indicate that a given key is deleted from a table. KSQL implements tables by
building a KStream over the changelog topic, applying some transformations for
adding columns (one of which Kafka Streams only supports for KStreams), and
then reducing the result into a KTable. The problem is that Kafka Streams
filters out null values in the reduce and aggregation processors for
GroupedKStreams. This patch works around this problem by mapping to
Optional<GenericRow> just before grouping and aggregating into the final
KTable, and then implementing an aggregator for handling Optional.EMPTY as
a tombstone

Fixes #1169 