### PR TITLE
Add version compatibility information to KSQL docs

### DIFF
--- a/docs/includes/ksql-supported-versions.rst
+++ b/docs/includes/ksql-supported-versions.rst
@@ -1,0 +1,8 @@
+You can use KSQL with compatible |cp| and Apache Kafka versions.
+
+==================== ================
+KSQL version         4.1
+==================== ================
+Apache Kafka version 0.11.0 and later
+|cp| version         3.3.0 and later
+==================== ================

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -75,3 +75,12 @@ KSQL CLI
     You can interactively write KSQL queries by using the KSQL command line interface (CLI). The KSQL CLI acts as a
     client to the KSQL server. For production scenarios you may also configure KSQL servers to run in non-interactive
     "headless" configuration, thereby preventing KSQL CLI access.
+
+
+.. raw:: html
+
+   <h2>Supported Versions and Interoperability</h2>
+
+---------------------
+
+.. include:: includes/ksql-supported-versions.rst

--- a/docs/installation/installing.rst
+++ b/docs/installation/installing.rst
@@ -3,15 +3,7 @@
 Supported Versions and Interoperability
 =======================================
 
-You can use KSQL with compatible |cp| and Apache Kafka versions.
-
-==================== ================
-KSQL version         4.1
-==================== ================
-Apache Kafka version 0.11.0 and later
-|cp| version         3.3.0 and later
-==================== ================
-
+.. include:: ../includes/ksql-supported-versions.rst
 
 .. _install_overview:
 

--- a/docs/installation/installing.rst
+++ b/docs/installation/installing.rst
@@ -1,3 +1,18 @@
+.. _ksql_supported_versions:
+
+Supported Versions and Interoperability
+=======================================
+
+You can use KSQL with compatible |cp| and Apache Kafka versions.
+
+==================== ================
+KSQL version         4.1
+==================== ================
+Apache Kafka version 0.11.0 and later
+|cp| version         3.3.0 and later
+==================== ================
+
+
 .. _install_overview:
 
 Installing KSQL


### PR DESCRIPTION
Would appear here (mockup):

----
<img width="400" border="1" alt="screen shot 2018-04-19 at 10 51 07" src="https://user-images.githubusercontent.com/294849/38981486-d5776178-43bf-11e8-8375-7fed7273cbb8.png">

----

We have this information already at https://docs.confluent.io/current/installation/versions-interoperability.html#ksql, but (a) this is very hard to find because it's very much out of your way when your are browsing the KSQL chapter in the docs and (b) this information (think: the code/text itself) should also be part of the KSQL GH repo.

We can address, in a separate PR, where we can use a better `includes` setup so that we don't duplicate this text/information in our various .rst files.