### PR TITLE
Minor: Fix flakey KafkaTopicClient integration tests

### DIFF
--- a/ksql-engine/src/test/java/io/confluent/ksql/util/KafkaTopicClientImplIntegrationTest.java
+++ b/ksql-engine/src/test/java/io/confluent/ksql/util/KafkaTopicClientImplIntegrationTest.java
@@ -33,6 +33,7 @@ import java.util.Collections;
 import java.util.Map;
 import java.util.Set;
 import java.util.UUID;
+import java.util.function.Supplier;
 
 import io.confluent.ksql.testutils.EmbeddedSingleNodeKafkaCluster;
 
@@ -63,6 +64,8 @@ public class KafkaTopicClientImplIntegrationTest {
         AdminClientConfig.BOOTSTRAP_SERVERS_CONFIG, KAFKA.bootstrapServers()));
 
     client = new KafkaTopicClientImpl(adminClient);
+
+    allowForAsyncTopicCreation();
   }
 
   @After
@@ -201,4 +204,15 @@ public class KafkaTopicClientImplIntegrationTest {
     return client.describeTopics(Collections.singletonList(topicName)).get(topicName);
   }
 
+  private void allowForAsyncTopicCreation() {
+    final Supplier<Set<String>> topicNamesSupplier = () -> {
+      try {
+        return adminClient.listTopics().names().get();
+      } catch (final Exception e) {
+        return Collections.emptySet();
+      }
+    };
+
+    assertThatEventually(topicNamesSupplier, hasItem(testTopic));
+  }
 }


### PR DESCRIPTION
Topic creation is async, via ZK, but the test wasn't taking this into account. Leading to occasional failures where the test managed to check for existance of the topic _before_ the broker had picked up the new topic from ZK.