### PR TITLE
MINOR: Make README ksql blurb consistent with the one on 4.1.x

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,8 @@
 
 KSQL is the streaming SQL engine for Apache Kafka.
 
+KSQL is an open source streaming SQL engine for Apache Kafka. It provides a simple and completely interactive SQL interface for stream processing on Kafka; no need to write code in a programming language such as Java or Python. KSQL is open-source (Apache 2.0 licensed), distributed, scalable, reliable, and real-time. It supports a wide range of powerful stream processing operations including aggregations, joins, windowing, sessionization, and much more.
+
 Click here to watch a screencast of the KSQL demo on YouTube.
 <a href="https://www.youtube.com/watch?v=illEpCOcCVg" target="_blank"><img src="screencast.jpg" alt="KSQL screencast"></a></p>
 


### PR DESCRIPTION
Somehow the intro blurb for KSQL diverged from 4.1.x to master. This patch makes them consistent.