### PR TITLE
KSQL-883: Add KafkaClientSupplier to KSQL API

### DIFF
--- a/ksql-engine/src/main/java/io/confluent/ksql/KsqlContext.java
+++ b/ksql-engine/src/main/java/io/confluent/ksql/KsqlContext.java
@@ -17,6 +17,7 @@
 package io.confluent.ksql;
 
 import org.apache.kafka.clients.admin.AdminClient;
+import org.apache.kafka.streams.KafkaClientSupplier;
 import org.apache.kafka.streams.StreamsConfig;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -53,6 +54,14 @@ public class KsqlContext {
       KsqlConfig ksqlConfig,
       SchemaRegistryClient schemaRegistryClient
   ) {
+    return create(ksqlConfig, schemaRegistryClient, null);
+  }
+
+  public static KsqlContext create(
+      KsqlConfig ksqlConfig,
+      SchemaRegistryClient schemaRegistryClient,
+      KafkaClientSupplier clientSupplier
+  ) {
     if (ksqlConfig == null) {
       ksqlConfig = new KsqlConfig(Collections.emptyMap());
     }
@@ -78,6 +87,7 @@ public class KsqlContext {
               ksqlConfig,
               topicClient,
               schemaRegistryClient,
+              clientSupplier,
               new MetaStoreImpl()
           )
       );
@@ -108,8 +118,12 @@ public class KsqlContext {
    * Execute the ksql statement in this context.
    */
   public void sql(String sql) throws Exception {
-    List<QueryMetadata> queryMetadataList = ksqlEngine.buildMultipleQueries(sql, Collections
-        .emptyMap());
+    sql(sql, Collections.emptyMap());
+  }
+
+  public void sql(String sql, Map<String, Object> overriddenProperties) throws Exception {
+    List<QueryMetadata> queryMetadataList = ksqlEngine.buildMultipleQueries(sql,
+        overriddenProperties);
 
     for (QueryMetadata queryMetadata : queryMetadataList) {
       if (queryMetadata instanceof PersistentQueryMetadata) {

--- a/ksql-engine/src/main/java/io/confluent/ksql/QueryEngine.java
+++ b/ksql-engine/src/main/java/io/confluent/ksql/QueryEngine.java
@@ -18,6 +18,7 @@ package io.confluent.ksql;
 
 import org.apache.kafka.connect.data.Schema;
 import org.apache.kafka.connect.data.SchemaBuilder;
+import org.apache.kafka.streams.KafkaClientSupplier;
 import org.apache.kafka.streams.StreamsBuilder;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -50,6 +51,7 @@ import io.confluent.ksql.parser.tree.SelectItem;
 import io.confluent.ksql.parser.tree.SingleColumn;
 import io.confluent.ksql.parser.tree.Statement;
 import io.confluent.ksql.parser.tree.StringLiteral;
+import io.confluent.ksql.physical.KafkaStreamsBuilderImpl;
 import io.confluent.ksql.physical.PhysicalPlanBuilder;
 import io.confluent.ksql.planner.LogicalPlanner;
 import io.confluent.ksql.planner.plan.KsqlStructuredDataOutputNode;
@@ -139,6 +141,7 @@ class QueryEngine {
       final List<Pair<String, PlanNode>> logicalPlans,
       final List<Pair<String, Statement>> statementList,
       final Map<String, Object> overriddenProperties,
+      final KafkaClientSupplier clientSupplier,
       final boolean updateMetastore
   ) throws Exception {
 
@@ -161,7 +164,7 @@ class QueryEngine {
       } else {
         buildQueryPhysicalPlan(
             physicalPlans, statementPlanPair,
-            overriddenProperties, updateMetastore
+            overriddenProperties, clientSupplier, updateMetastore
         );
       }
 
@@ -173,6 +176,7 @@ class QueryEngine {
       final List<QueryMetadata> physicalPlans,
       final Pair<String, PlanNode> statementPlanPair,
       final Map<String, Object> overriddenProperties,
+      final KafkaClientSupplier clientSupplier,
       final boolean updateMetastore
   ) throws Exception {
 
@@ -188,7 +192,8 @@ class QueryEngine {
         overriddenProperties,
         updateMetastore,
         ksqlEngine.getMetaStore(),
-        ksqlEngine.getSchemaRegistryClient()
+        ksqlEngine.getSchemaRegistryClient(),
+        new KafkaStreamsBuilderImpl(clientSupplier)
     );
 
     physicalPlans.add(physicalPlanBuilder.buildPhysicalPlan(statementPlanPair));

--- a/ksql-engine/src/main/java/io/confluent/ksql/physical/KafkaStreamsBuilderImpl.java
+++ b/ksql-engine/src/main/java/io/confluent/ksql/physical/KafkaStreamsBuilderImpl.java
@@ -14,13 +14,27 @@
 
 package io.confluent.ksql.physical;
 
+import org.apache.kafka.streams.KafkaClientSupplier;
 import org.apache.kafka.streams.KafkaStreams;
 import org.apache.kafka.streams.StreamsBuilder;
 import org.apache.kafka.streams.StreamsConfig;
 
 public class KafkaStreamsBuilderImpl implements KafkaStreamsBuilder {
+
+  KafkaClientSupplier clientSupplier;
+
+  public KafkaStreamsBuilderImpl() {
+    this(null);
+  }
+
+  public KafkaStreamsBuilderImpl(KafkaClientSupplier clientSupplier) {
+    this.clientSupplier = clientSupplier;
+  }
+
   @Override
   public KafkaStreams buildKafkaStreams(StreamsBuilder builder, StreamsConfig conf) {
-    return new KafkaStreams(builder.build(), conf);
+    return clientSupplier != null
+      ? new KafkaStreams(builder.build(), conf, clientSupplier)
+      : new KafkaStreams(builder.build(), conf);
   }
 }


### PR DESCRIPTION
This allows KafkaClientSupplier to be passed to KSQL