### PR TITLE
Clarify that KSQL timestamps are in milliseconds.

### DIFF
--- a/docs/syntax-reference.rst
+++ b/docs/syntax-reference.rst
@@ -162,7 +162,7 @@ The supported column data types are:
 
 KSQL adds the implicit columns ``ROWTIME`` and ``ROWKEY`` to every
 stream and table, which represent the corresponding Kafka message
-timestamp and message key, respectively.
+timestamp and message key, respectively. The timestamp has milliseconds accuracy.
 
 The WITH clause supports the following properties:
 
@@ -184,8 +184,8 @@ The WITH clause supports the following properties:
 | TIMESTAMP               | By default, the implicit ``ROWTIME`` column is the timestamp of the message in the Kafka   |
 |                         | topic. The TIMESTAMP property can be used to override ``ROWTIME`` with the contents of the |
 |                         | specified field/column within the Kafka message value (similar to timestamp extractors     |
-|                         | in Kafka's Streams API). Time-based operations such as windowing will process a record     |
-|                         | according to the timestamp in ``ROWTIME``.                                                 |
+|                         | in Kafka's Streams API). Timestamps have a millisecond accuracy. Time-based operations,    |
+|                         | such as windowing, will process a record according to the timestamp in ``ROWTIME``.        |
 +-------------------------+--------------------------------------------------------------------------------------------+
 | TIMESTAMP_FORMAT        | Used in conjunction with TIMESTAMP. If not set will assume that the timestamp field is a   |
 |                         | long. If it is set, then the TIMESTAMP field must be of type varchar and have a format     |
@@ -233,7 +233,7 @@ The supported column data types are:
 
 KSQL adds the implicit columns ``ROWTIME`` and ``ROWKEY`` to every
 stream and table, which represent the corresponding Kafka message
-timestamp and message key, respectively.
+timestamp and message key, respectively. The timestamp has milliseconds accuracy.
 
 KSQL has currently the following equirements for creating a table from a Kafka topic:
 
@@ -265,8 +265,8 @@ The WITH clause supports the following properties:
 | TIMESTAMP               | By default, the implicit ``ROWTIME`` column is the timestamp of the message in the Kafka   |
 |                         | topic. The TIMESTAMP property can be used to override ``ROWTIME`` with the contents of the |
 |                         | specified field/column within the Kafka message value (similar to timestamp extractors in  |
-|                         | Kafka's Streams API). Time-based operations such as windowing will process a record        |
-|                         | according to the timestamp in ``ROWTIME``.                                                 |
+|                         | Kafka's Streams API). Timestamps have a millisecond accuracy. Time-based operations, such  |
+|                         | as windowing, will process a record according to the timestamp in ``ROWTIME``.             |
 +-------------------------+--------------------------------------------------------------------------------------------+
 | TIMESTAMP_FORMAT        | Used in conjunction with TIMESTAMP. If not set will assume that the timestamp field is a   |
 |                         | long. If it is set, then the TIMESTAMP field must be of type varchar and have a format     |
@@ -335,6 +335,7 @@ The WITH clause for the result supports the following properties:
 |               | any downstream queries. Downstream queries that use time-based operations, such as windowing,        |
 |               | will process records in this stream based on the timestamp in this field. By default,                |
 |               | such queries will also use this field to set the timestamp on any records emitted to Kafka.          |
+|               | Timestamps have a millisecond accuracy.
 |               |                                                                                                      |
 |               | If not supplied, the ``ROWTIME`` of the source stream will be used.                                  |
 |               |                                                                                                      |
@@ -401,6 +402,7 @@ The WITH clause supports the following properties:
 | TIMESTAMP     | Sets a field within this tables's schema to be used as the default source of ``ROWTIME`` for         |
 |               | any downstream queries. Downstream queries that use time-based operations, such as windowing,        |
 |               | will process records in this stream based on the timestamp in this field.                            |
+|               | Timestamps have a millisecond accuracy.                                                              |
 |               |                                                                                                      |
 |               | If not supplied, the ``ROWTIME`` of the source stream will be used.                                  |
 |               |                                                                                                      |
@@ -848,13 +850,13 @@ Scalar functions
 +------------------------+------------------------------------------------------------+---------------------------------------------------+
 | STRINGTOTIMESTAMP      |  ``STRINGTOTIMESTAMP(col1, 'yyyy-MM-dd HH:mm:ss.SSS')``    | Converts a string value in the given              |
 |                        |                                                            | format into the BIGINT value                      |
-|                        |                                                            | that represents the timestamp.                    |
+|                        |                                                            | that represents the millisecond timestamp.        |
 +------------------------+------------------------------------------------------------+---------------------------------------------------+
 | SUBSTRING              |  ``SUBSTRING(col1, 2, 5)``                                 | Return the substring with the start and end       |
 |                        |                                                            | indices                                           |
 +------------------------+------------------------------------------------------------+---------------------------------------------------+
-| TIMESTAMPTOSTRING      |  ``TIMESTAMPTOSTRING(ROWTIME, 'yyyy-MM-dd HH:mm:ss.SSS')`` | Converts a BIGINT timestamp value into the        |
-|                        |                                                            | string representation of the timestamp in         |
+| TIMESTAMPTOSTRING      |  ``TIMESTAMPTOSTRING(ROWTIME, 'yyyy-MM-dd HH:mm:ss.SSS')`` | Converts a BIGINT millisecond timestamp value into|
+|                        |                                                            | the string representation of the timestamp in     |
 |                        |                                                            | the given format.                                 |
 +------------------------+------------------------------------------------------------+---------------------------------------------------+
 | TRIM                   |  ``TRIM(col1)``                                            | Trim the spaces from the beginning and end of     |


### PR DESCRIPTION
Fixes #1214 

Questions coming up on community slack channel on the resolution of timestamps in KSQL.