### PR TITLE
Include function names in error message for unsupported table aggrega…

### DIFF
--- a/ksql-engine/src/main/java/io/confluent/ksql/function/AggregateFunctionFactory.java
+++ b/ksql-engine/src/main/java/io/confluent/ksql/function/AggregateFunctionFactory.java
@@ -23,8 +23,9 @@ import java.util.List;
 
 public abstract class AggregateFunctionFactory {
 
-  final String functionName;
   final List<KsqlAggregateFunction> aggregateFunctionList;
+
+  protected final String functionName;
 
   public AggregateFunctionFactory(String functionName,
                                   List<KsqlAggregateFunction> aggregateFunctionList) {

--- a/ksql-engine/src/main/java/io/confluent/ksql/function/BaseAggregateFunction.java
+++ b/ksql-engine/src/main/java/io/confluent/ksql/function/BaseAggregateFunction.java
@@ -32,11 +32,14 @@ public abstract class BaseAggregateFunction<V, A> implements KsqlAggregateFuncti
   private final Schema returnType;
   private final List<Schema> arguments;
 
-  public BaseAggregateFunction(Integer argIndexInValue) {
-    this(argIndexInValue, null, null, null);
+  protected final String functionName;
+
+  public BaseAggregateFunction(String functionName, Integer argIndexInValue) {
+    this(functionName, argIndexInValue, null, null, null);
   }
 
   public BaseAggregateFunction(
+      String functionName,
       final int argIndexInValue,
       final Supplier<A> initialValueSupplier,
       final Schema returnType,
@@ -46,6 +49,7 @@ public abstract class BaseAggregateFunction<V, A> implements KsqlAggregateFuncti
     this.initialValueSupplier = initialValueSupplier;
     this.returnType = returnType;
     this.arguments = arguments;
+    this.functionName = functionName;
   }
 
   public boolean hasSameArgTypes(List<Schema> argTypeList) {
@@ -53,6 +57,10 @@ public abstract class BaseAggregateFunction<V, A> implements KsqlAggregateFuncti
       throw new KsqlException("Argument type list is null.");
     }
     return this.arguments.equals(argTypeList);
+  }
+
+  public String getFunctionName() {
+    return functionName;
   }
 
   public Supplier<A> getInitialValueSupplier() {

--- a/ksql-engine/src/main/java/io/confluent/ksql/function/KsqlAggregateFunction.java
+++ b/ksql-engine/src/main/java/io/confluent/ksql/function/KsqlAggregateFunction.java
@@ -31,13 +31,15 @@ public interface KsqlAggregateFunction<V, A> {
       final Map<String, Integer> expressionNames,
       final List<Expression> functionArguments);
 
-  boolean hasSameArgTypes(List<Schema> argTypeList);
+  String getFunctionName();
 
   Supplier<A> getInitialValueSupplier();
 
   int getArgIndexInValue();
 
   Schema getReturnType();
+
+  boolean hasSameArgTypes(List<Schema> argTypeList);
 
   /**
    * Merges values inside the window.

--- a/ksql-engine/src/main/java/io/confluent/ksql/function/udaf/count/CountAggFunctionFactory.java
+++ b/ksql-engine/src/main/java/io/confluent/ksql/function/udaf/count/CountAggFunctionFactory.java
@@ -25,9 +25,10 @@ import io.confluent.ksql.function.AggregateFunctionFactory;
 import io.confluent.ksql.function.KsqlAggregateFunction;
 
 public class CountAggFunctionFactory extends AggregateFunctionFactory {
+  private static final String FUNCTION_NAME = "COUNT";
 
   public CountAggFunctionFactory() {
-    super("COUNT", Collections.singletonList(new CountKudaf(-1)));
+    super(FUNCTION_NAME, Collections.singletonList(new CountKudaf(FUNCTION_NAME, -1)));
   }
 
   @Override

--- a/ksql-engine/src/main/java/io/confluent/ksql/function/udaf/count/CountKudaf.java
+++ b/ksql-engine/src/main/java/io/confluent/ksql/function/udaf/count/CountKudaf.java
@@ -31,8 +31,8 @@ import io.confluent.ksql.parser.tree.Expression;
 public class CountKudaf
     extends BaseAggregateFunction<Object, Long> implements TableAggregationFunction<Object, Long> {
 
-  CountKudaf(int argIndexInValue) {
-    super(argIndexInValue, () -> 0L, Schema.INT64_SCHEMA,
+  CountKudaf(String functionName, int argIndexInValue) {
+    super(functionName, argIndexInValue, () -> 0L, Schema.INT64_SCHEMA,
           Collections.singletonList(Schema.FLOAT64_SCHEMA)
     );
   }
@@ -56,7 +56,7 @@ public class CountKudaf
   public KsqlAggregateFunction<Object, Long> getInstance(Map<String, Integer> expressionNames,
                                                          List<Expression> functionArguments) {
     int udafIndex = expressionNames.get(functionArguments.get(0).toString());
-    return new CountKudaf(udafIndex);
+    return new CountKudaf(functionName, udafIndex);
   }
 
   @Override

--- a/ksql-engine/src/main/java/io/confluent/ksql/function/udaf/max/DoubleMaxKudaf.java
+++ b/ksql-engine/src/main/java/io/confluent/ksql/function/udaf/max/DoubleMaxKudaf.java
@@ -29,8 +29,8 @@ import io.confluent.ksql.parser.tree.Expression;
 
 public class DoubleMaxKudaf extends BaseAggregateFunction<Double, Double> {
 
-  DoubleMaxKudaf(int argIndexInValue) {
-    super(argIndexInValue, () -> Double.NEGATIVE_INFINITY, Schema.FLOAT64_SCHEMA,
+  DoubleMaxKudaf(String functionName, int argIndexInValue) {
+    super(functionName, argIndexInValue, () -> Double.NEGATIVE_INFINITY, Schema.FLOAT64_SCHEMA,
           Collections.singletonList(Schema.FLOAT64_SCHEMA)
     );
   }
@@ -57,6 +57,6 @@ public class DoubleMaxKudaf extends BaseAggregateFunction<Double, Double> {
   public KsqlAggregateFunction<Double, Double> getInstance(Map<String, Integer> expressionNames,
                                                            List<Expression> functionArguments) {
     int udafIndex = expressionNames.get(functionArguments.get(0).toString());
-    return new DoubleMaxKudaf(udafIndex);
+    return new DoubleMaxKudaf(functionName, udafIndex);
   }
 }

--- a/ksql-engine/src/main/java/io/confluent/ksql/function/udaf/max/IntegerMaxKudaf.java
+++ b/ksql-engine/src/main/java/io/confluent/ksql/function/udaf/max/IntegerMaxKudaf.java
@@ -29,8 +29,8 @@ import io.confluent.ksql.parser.tree.Expression;
 
 public class IntegerMaxKudaf extends BaseAggregateFunction<Integer, Integer> {
 
-  public IntegerMaxKudaf(int argIndexInValue) {
-    super(argIndexInValue, () -> Integer.MIN_VALUE, Schema.INT32_SCHEMA,
+  IntegerMaxKudaf(String functionName, int argIndexInValue) {
+    super(functionName, argIndexInValue, () -> Integer.MIN_VALUE, Schema.INT32_SCHEMA,
           Collections.singletonList(Schema.INT32_SCHEMA)
     );
   }
@@ -45,15 +45,13 @@ public class IntegerMaxKudaf extends BaseAggregateFunction<Integer, Integer> {
 
   @Override
   public Merger<String, Integer> getMerger() {
-    return (aggKey, aggOne, aggTwo) -> {
-      return Math.max(aggOne, aggTwo);
-    };
+    return (aggKey, aggOne, aggTwo) -> Math.max(aggOne, aggTwo);
   }
 
   @Override
   public KsqlAggregateFunction<Integer, Integer> getInstance(Map<String, Integer> expressionNames,
                                                            List<Expression> functionArguments) {
     int udafIndex = expressionNames.get(functionArguments.get(0).toString());
-    return new IntegerMaxKudaf(udafIndex);
+    return new IntegerMaxKudaf(functionName, udafIndex);
   }
 }

--- a/ksql-engine/src/main/java/io/confluent/ksql/function/udaf/max/LongMaxKudaf.java
+++ b/ksql-engine/src/main/java/io/confluent/ksql/function/udaf/max/LongMaxKudaf.java
@@ -29,8 +29,8 @@ import io.confluent.ksql.parser.tree.Expression;
 
 public class LongMaxKudaf extends BaseAggregateFunction<Long, Long> {
 
-  LongMaxKudaf(int argIndexInValue) {
-    super(argIndexInValue, () -> Long.MIN_VALUE, Schema.INT64_SCHEMA,
+  LongMaxKudaf(String functionName, int argIndexInValue) {
+    super(functionName, argIndexInValue, () -> Long.MIN_VALUE, Schema.INT64_SCHEMA,
           Collections.singletonList(Schema.INT64_SCHEMA)
     );
   }
@@ -57,6 +57,6 @@ public class LongMaxKudaf extends BaseAggregateFunction<Long, Long> {
   public KsqlAggregateFunction<Long, Long> getInstance(Map<String, Integer> expressionNames,
                                                        List<Expression> functionArguments) {
     int udafIndex = expressionNames.get(functionArguments.get(0).toString());
-    return new LongMaxKudaf(udafIndex);
+    return new LongMaxKudaf(functionName, udafIndex);
   }
 }

--- a/ksql-engine/src/main/java/io/confluent/ksql/function/udaf/max/MaxAggFunctionFactory.java
+++ b/ksql-engine/src/main/java/io/confluent/ksql/function/udaf/max/MaxAggFunctionFactory.java
@@ -26,11 +26,15 @@ import io.confluent.ksql.function.KsqlAggregateFunction;
 import io.confluent.ksql.util.KsqlException;
 
 public class MaxAggFunctionFactory extends AggregateFunctionFactory {
+  private static final String FUNCTION_NAME = "MAX";
 
   public MaxAggFunctionFactory() {
-    super("MAX", Arrays.asList(new DoubleMaxKudaf(-1),
-                               new LongMaxKudaf(-1),
-                               new IntegerMaxKudaf(-1)));
+    super(
+        FUNCTION_NAME,
+        Arrays.asList(
+            new DoubleMaxKudaf(FUNCTION_NAME, -1),
+            new LongMaxKudaf(FUNCTION_NAME, -1),
+            new IntegerMaxKudaf(FUNCTION_NAME, -1)));
   }
 
   @Override

--- a/ksql-engine/src/main/java/io/confluent/ksql/function/udaf/min/DoubleMinKudaf.java
+++ b/ksql-engine/src/main/java/io/confluent/ksql/function/udaf/min/DoubleMinKudaf.java
@@ -29,8 +29,8 @@ import io.confluent.ksql.parser.tree.Expression;
 
 public class DoubleMinKudaf extends BaseAggregateFunction<Double, Double> {
 
-  DoubleMinKudaf(int argIndexInValue) {
-    super(argIndexInValue, () -> Double.MAX_VALUE, Schema.FLOAT64_SCHEMA,
+  DoubleMinKudaf(String functionName, int argIndexInValue) {
+    super(functionName, argIndexInValue, () -> Double.MAX_VALUE, Schema.FLOAT64_SCHEMA,
           Collections.singletonList(Schema.FLOAT64_SCHEMA)
     );
   }
@@ -57,6 +57,6 @@ public class DoubleMinKudaf extends BaseAggregateFunction<Double, Double> {
   public KsqlAggregateFunction<Double, Double> getInstance(Map<String, Integer> expressionNames,
                                                            List<Expression> functionArguments) {
     int udafIndex = expressionNames.get(functionArguments.get(0).toString());
-    return new DoubleMinKudaf(udafIndex);
+    return new DoubleMinKudaf(functionName, udafIndex);
   }
 }

--- a/ksql-engine/src/main/java/io/confluent/ksql/function/udaf/min/IntegerMinKudaf.java
+++ b/ksql-engine/src/main/java/io/confluent/ksql/function/udaf/min/IntegerMinKudaf.java
@@ -29,8 +29,8 @@ import io.confluent.ksql.parser.tree.Expression;
 
 public class IntegerMinKudaf extends BaseAggregateFunction<Integer, Integer> {
 
-  IntegerMinKudaf(int argIndexInValue) {
-    super(argIndexInValue, () -> Integer.MAX_VALUE, Schema.INT32_SCHEMA,
+  IntegerMinKudaf(String functionName, int argIndexInValue) {
+    super(functionName, argIndexInValue, () -> Integer.MAX_VALUE, Schema.INT32_SCHEMA,
           Collections.singletonList(Schema.INT32_SCHEMA)
     );
   }
@@ -54,6 +54,6 @@ public class IntegerMinKudaf extends BaseAggregateFunction<Integer, Integer> {
   public KsqlAggregateFunction<Integer, Integer> getInstance(Map<String, Integer> expressionNames,
                                                            List<Expression> functionArguments) {
     int udafIndex = expressionNames.get(functionArguments.get(0).toString());
-    return new IntegerMinKudaf(udafIndex);
+    return new IntegerMinKudaf(functionName, udafIndex);
   }
 }

--- a/ksql-engine/src/main/java/io/confluent/ksql/function/udaf/min/LongMinKudaf.java
+++ b/ksql-engine/src/main/java/io/confluent/ksql/function/udaf/min/LongMinKudaf.java
@@ -29,8 +29,8 @@ import io.confluent.ksql.parser.tree.Expression;
 
 public class LongMinKudaf extends BaseAggregateFunction<Long, Long> {
 
-  LongMinKudaf(int argIndexInValue) {
-    super(argIndexInValue, () -> Long.MAX_VALUE, Schema.INT64_SCHEMA,
+  LongMinKudaf(String functionName, int argIndexInValue) {
+    super(functionName, argIndexInValue, () -> Long.MAX_VALUE, Schema.INT64_SCHEMA,
           Collections.singletonList(Schema.INT64_SCHEMA)
     );
   }
@@ -57,6 +57,6 @@ public class LongMinKudaf extends BaseAggregateFunction<Long, Long> {
   public KsqlAggregateFunction<Long, Long> getInstance(Map<String, Integer> expressionNames,
                                                        List<Expression> functionArguments) {
     int udafIndex = expressionNames.get(functionArguments.get(0).toString());
-    return new LongMinKudaf(udafIndex);
+    return new LongMinKudaf(functionName, udafIndex);
   }
 }

--- a/ksql-engine/src/main/java/io/confluent/ksql/function/udaf/min/MinAggFunctionFactory.java
+++ b/ksql-engine/src/main/java/io/confluent/ksql/function/udaf/min/MinAggFunctionFactory.java
@@ -26,11 +26,14 @@ import io.confluent.ksql.function.KsqlAggregateFunction;
 import io.confluent.ksql.util.KsqlException;
 
 public class MinAggFunctionFactory extends AggregateFunctionFactory {
+  private static final String FUNCTION_NAME = "MIN";
 
   public MinAggFunctionFactory() {
-    super("MIN", Arrays.asList(new DoubleMinKudaf(-1),
-                               new LongMinKudaf(-1),
-                               new IntegerMinKudaf(-1)));
+    super(
+        FUNCTION_NAME,
+        Arrays.asList(
+            new DoubleMinKudaf(FUNCTION_NAME, -1), new LongMinKudaf(FUNCTION_NAME, -1),
+            new IntegerMinKudaf(FUNCTION_NAME, -1)));
   }
 
   @Override

--- a/ksql-engine/src/main/java/io/confluent/ksql/function/udaf/sum/DoubleSumKudaf.java
+++ b/ksql-engine/src/main/java/io/confluent/ksql/function/udaf/sum/DoubleSumKudaf.java
@@ -32,8 +32,8 @@ public class DoubleSumKudaf
     extends BaseAggregateFunction<Double, Double>
     implements TableAggregationFunction<Double, Double> {
 
-  DoubleSumKudaf(int argIndexInValue) {
-    super(argIndexInValue, () -> 0.0, Schema.FLOAT64_SCHEMA,
+  DoubleSumKudaf(String functionName, int argIndexInValue) {
+    super(functionName, argIndexInValue, () -> 0.0, Schema.FLOAT64_SCHEMA,
           Collections.singletonList(Schema.FLOAT64_SCHEMA)
     );
   }
@@ -57,7 +57,7 @@ public class DoubleSumKudaf
   public KsqlAggregateFunction<Double, Double> getInstance(Map<String, Integer> expressionNames,
                                                            List<Expression> functionArguments) {
     int udafIndex = expressionNames.get(functionArguments.get(0).toString());
-    return new DoubleSumKudaf(udafIndex);
+    return new DoubleSumKudaf(functionName, udafIndex);
   }
 
 

--- a/ksql-engine/src/main/java/io/confluent/ksql/function/udaf/sum/IntegerSumKudaf.java
+++ b/ksql-engine/src/main/java/io/confluent/ksql/function/udaf/sum/IntegerSumKudaf.java
@@ -32,8 +32,8 @@ public class IntegerSumKudaf
     extends BaseAggregateFunction<Integer, Integer>
     implements TableAggregationFunction<Integer, Integer> {
 
-  IntegerSumKudaf(int argIndexInValue) {
-    super(argIndexInValue, () -> 0, Schema.INT32_SCHEMA,
+  IntegerSumKudaf(String functionName, int argIndexInValue) {
+    super(functionName, argIndexInValue, () -> 0, Schema.INT32_SCHEMA,
           Collections.singletonList(Schema.INT32_SCHEMA)
     );
   }
@@ -60,6 +60,6 @@ public class IntegerSumKudaf
   public KsqlAggregateFunction<Integer, Integer> getInstance(Map<String, Integer> expressionNames,
                                                            List<Expression> functionArguments) {
     int udafIndex = expressionNames.get(functionArguments.get(0).toString());
-    return new IntegerSumKudaf(udafIndex);
+    return new IntegerSumKudaf(functionName, udafIndex);
   }
 }

--- a/ksql-engine/src/main/java/io/confluent/ksql/function/udaf/sum/LongSumKudaf.java
+++ b/ksql-engine/src/main/java/io/confluent/ksql/function/udaf/sum/LongSumKudaf.java
@@ -31,8 +31,8 @@ import io.confluent.ksql.parser.tree.Expression;
 public class LongSumKudaf
     extends BaseAggregateFunction<Long, Long> implements TableAggregationFunction<Long, Long> {
 
-  LongSumKudaf(int argIndexInValue) {
-    super(argIndexInValue, () -> 0L, Schema.INT64_SCHEMA,
+  LongSumKudaf(String functionName, int argIndexInValue) {
+    super(functionName, argIndexInValue, () -> 0L, Schema.INT64_SCHEMA,
           Collections.singletonList(Schema.INT64_SCHEMA));
   }
 
@@ -55,6 +55,6 @@ public class LongSumKudaf
   public KsqlAggregateFunction<Long, Long> getInstance(Map<String, Integer> expressionNames,
                                                        List<Expression> functionArguments) {
     int udafIndex = expressionNames.get(functionArguments.get(0).toString());
-    return new LongSumKudaf(udafIndex);
+    return new LongSumKudaf(functionName, udafIndex);
   }
 }

--- a/ksql-engine/src/main/java/io/confluent/ksql/function/udaf/sum/SumAggFunctionFactory.java
+++ b/ksql-engine/src/main/java/io/confluent/ksql/function/udaf/sum/SumAggFunctionFactory.java
@@ -25,11 +25,14 @@ import java.util.Arrays;
 import java.util.List;
 
 public class SumAggFunctionFactory extends AggregateFunctionFactory {
+  private static final String FUNCTION_NAME = "SUM";
 
   public SumAggFunctionFactory() {
-    super("SUM", Arrays.asList(new DoubleSumKudaf(-1),
-                               new LongSumKudaf(-1),
-                               new IntegerSumKudaf(-1)));
+    super(
+        FUNCTION_NAME,
+        Arrays.asList(
+            new DoubleSumKudaf(FUNCTION_NAME, -1), new LongSumKudaf(FUNCTION_NAME, -1),
+            new IntegerSumKudaf(FUNCTION_NAME,-1)));
   }
 
   @Override

--- a/ksql-engine/src/main/java/io/confluent/ksql/function/udaf/topk/TopKAggregateFunctionFactory.java
+++ b/ksql-engine/src/main/java/io/confluent/ksql/function/udaf/topk/TopKAggregateFunctionFactory.java
@@ -47,32 +47,36 @@ public class TopKAggregateFunctionFactory extends AggregateFunctionFactory {
     switch (argSchema.type()) {
       case INT32:
         return new TopkKudaf<>(
-                -1,
-                topKSize,
-                SchemaBuilder.array(Schema.INT32_SCHEMA).build(),
-                Collections.singletonList(Schema.INT32_SCHEMA),
-                Integer.class);
+            functionName,
+            -1,
+            topKSize,
+            SchemaBuilder.array(Schema.INT32_SCHEMA).build(),
+            Collections.singletonList(Schema.INT32_SCHEMA),
+            Integer.class);
       case INT64:
         return new TopkKudaf<>(
-                -1,
-                topKSize,
-                SchemaBuilder.array(Schema.INT64_SCHEMA).build(),
-                Collections.singletonList(Schema.INT64_SCHEMA),
-                Long.class);
+            functionName,
+            -1,
+            topKSize,
+            SchemaBuilder.array(Schema.INT64_SCHEMA).build(),
+            Collections.singletonList(Schema.INT64_SCHEMA),
+            Long.class);
       case FLOAT64:
         return new TopkKudaf<>(
-                -1,
-                topKSize,
-                SchemaBuilder.array(Schema.FLOAT64_SCHEMA).build(),
-                Collections.singletonList(Schema.FLOAT64_SCHEMA),
-                Double.class);
+            functionName,
+            -1,
+            topKSize,
+            SchemaBuilder.array(Schema.FLOAT64_SCHEMA).build(),
+            Collections.singletonList(Schema.FLOAT64_SCHEMA),
+            Double.class);
       case STRING:
         return new TopkKudaf<>(
-                -1,
-                topKSize,
-                SchemaBuilder.array(Schema.STRING_SCHEMA).build(),
-                Collections.singletonList(Schema.STRING_SCHEMA),
-                String.class);
+            functionName,
+            -1,
+            topKSize,
+            SchemaBuilder.array(Schema.STRING_SCHEMA).build(),
+            Collections.singletonList(Schema.STRING_SCHEMA),
+            String.class);
       default:
         throw new KsqlException("No TOPK aggregate function with " + argumentType.get(0)
                                 + " argument type exists!");

--- a/ksql-engine/src/main/java/io/confluent/ksql/function/udaf/topk/TopkKudaf.java
+++ b/ksql-engine/src/main/java/io/confluent/ksql/function/udaf/topk/TopkKudaf.java
@@ -40,15 +40,17 @@ public class TopkKudaf<T extends Comparable<? super T>> extends BaseAggregateFun
   private final Comparator<T> comparator;
 
   @SuppressWarnings("unchecked")
-  TopkKudaf(final int argIndexInValue,
+  TopkKudaf(final String functionName,
+            final int argIndexInValue,
             final int topKSize,
             final Schema returnType,
             final List<Schema> argumentTypes,
             final Class<T> clazz) {
-    super(argIndexInValue,
+    super(functionName,
+        argIndexInValue,
         () -> (T[]) Array.newInstance(clazz, topKSize),
-          returnType,
-          argumentTypes
+        returnType,
+        argumentTypes
     );
     this.topKSize = topKSize;
     this.returnType = returnType;
@@ -128,6 +130,6 @@ public class TopkKudaf<T extends Comparable<? super T>> extends BaseAggregateFun
 
     final int udafIndex = expressionNames.get(functionArguments.get(0).toString());
     final int topKSize = Integer.parseInt(functionArguments.get(1).toString());
-    return new TopkKudaf<>(udafIndex, topKSize, returnType, argumentTypes, clazz);
+    return new TopkKudaf<>(functionName, udafIndex, topKSize, returnType, argumentTypes, clazz);
   }
 }

--- a/ksql-engine/src/main/java/io/confluent/ksql/function/udaf/topkdistinct/TopkDistinctAggFunctionFactory.java
+++ b/ksql-engine/src/main/java/io/confluent/ksql/function/udaf/topkdistinct/TopkDistinctAggFunctionFactory.java
@@ -39,13 +39,13 @@ public class TopkDistinctAggFunctionFactory extends AggregateFunctionFactory {
     Schema argSchema = argTypeList.get(0);
     switch (argSchema.type()) {
       case INT32:
-        return new TopkDistinctKudaf<>(-1, 0, Schema.INT32_SCHEMA, Integer.class);
+        return new TopkDistinctKudaf<>(functionName, -1, 0, Schema.INT32_SCHEMA, Integer.class);
       case INT64:
-        return new TopkDistinctKudaf<>(-1, 0, Schema.INT64_SCHEMA, Long.class);
+        return new TopkDistinctKudaf<>(functionName, -1, 0, Schema.INT64_SCHEMA, Long.class);
       case FLOAT64:
-        return new TopkDistinctKudaf<>(-1, 0, Schema.FLOAT64_SCHEMA, Double.class);
+        return new TopkDistinctKudaf<>(functionName, -1, 0, Schema.FLOAT64_SCHEMA, Double.class);
       case STRING:
-        return new TopkDistinctKudaf<>(-1, 0, Schema.STRING_SCHEMA, String.class);
+        return new TopkDistinctKudaf<>(functionName, -1, 0, Schema.STRING_SCHEMA, String.class);
       default:
         throw new KsqlException("No TOPKDISTINCT aggregate function with " + argTypeList.get(0)
                                 + " argument type exists!");

--- a/ksql-engine/src/main/java/io/confluent/ksql/function/udaf/topkdistinct/TopkDistinctKudaf.java
+++ b/ksql-engine/src/main/java/io/confluent/ksql/function/udaf/topkdistinct/TopkDistinctKudaf.java
@@ -42,14 +42,17 @@ public class TopkDistinctKudaf<T extends Comparable<? super T>>
   private final Schema outputSchema;
 
   @SuppressWarnings("unchecked")
-  TopkDistinctKudaf(final int argIndexInValue,
+  TopkDistinctKudaf(final String functionName,
+                    final int argIndexInValue,
                     final int tkVal,
                     final Schema outputSchema,
                     final Class<T> ttClass) {
-    super(argIndexInValue,
-        () -> (T[]) Array.newInstance(ttClass, tkVal),
-          SchemaBuilder.array(outputSchema).build(),
-          Collections.singletonList(outputSchema)
+    super(
+        functionName,
+        argIndexInValue,
+            () -> (T[]) Array.newInstance(ttClass, tkVal),
+        SchemaBuilder.array(outputSchema).build(),
+        Collections.singletonList(outputSchema)
     );
 
     this.tkVal = tkVal;
@@ -137,6 +140,6 @@ public class TopkDistinctKudaf<T extends Comparable<? super T>>
 
     final int udafIndex = expressionNames.get(functionArguments.get(0).toString());
     final int tkValFromArg = Integer.parseInt(functionArguments.get(1).toString());
-    return new TopkDistinctKudaf<>(udafIndex, tkValFromArg, outputSchema, ttClass);
+    return new TopkDistinctKudaf<>(functionName, udafIndex, tkValFromArg, outputSchema, ttClass);
   }
 }

--- a/ksql-engine/src/test/java/io/confluent/ksql/function/udaf/topkdistinct/DoubleTopkDistinctKudafTest.java
+++ b/ksql-engine/src/test/java/io/confluent/ksql/function/udaf/topkdistinct/DoubleTopkDistinctKudafTest.java
@@ -27,7 +27,7 @@ public class DoubleTopkDistinctKudafTest {
 
   Double[] valueArray;
   private final TopkDistinctKudaf<Double> doubleTopkDistinctKudaf
-          = new TopkDistinctKudaf<>(0, 3, Schema.FLOAT64_SCHEMA, Double.class);
+          = TopKDistinctTestUtils.getTopKDistinctKudaf(3, Schema.FLOAT64_SCHEMA);
 
   @Before
   public void setup() {

--- a/ksql-engine/src/test/java/io/confluent/ksql/function/udaf/topkdistinct/IntTopkDistinctKudafTest.java
+++ b/ksql-engine/src/test/java/io/confluent/ksql/function/udaf/topkdistinct/IntTopkDistinctKudafTest.java
@@ -33,7 +33,7 @@ public class IntTopkDistinctKudafTest {
 
   private Integer[] valueArray;
   private final TopkDistinctKudaf<Integer> intTopkDistinctKudaf =
-      new TopkDistinctKudaf<>(0, 3, Schema.INT32_SCHEMA, Integer.class);
+      TopKDistinctTestUtils.getTopKDistinctKudaf(3, Schema.INT32_SCHEMA);
 
   @Before
   public void setup() {
@@ -113,7 +113,7 @@ public class IntTopkDistinctKudafTest {
   public void shouldBeThreadSafe() {
     // Given:
     final TopkDistinctKudaf<Integer> intTopkDistinctKudaf =
-        new TopkDistinctKudaf<>(0, 12, Schema.INT32_SCHEMA, Integer.class);
+        TopKDistinctTestUtils.getTopKDistinctKudaf(12, Schema.INT32_SCHEMA);
 
     final List<Integer> values = ImmutableList.of(10, 30, 45, 10, 50, 60, 20, 70, 80, 35, 25);
 
@@ -142,7 +142,7 @@ public class IntTopkDistinctKudafTest {
     final int iterations = 1_000_000_000;
     final int topX = 10;
     final TopkDistinctKudaf<Integer> intTopkDistinctKudaf =
-        new TopkDistinctKudaf<>(0, topX, Schema.INT32_SCHEMA, Integer.class);
+        TopKDistinctTestUtils.getTopKDistinctKudaf(topX, Schema.INT32_SCHEMA);
     final Integer[] aggregate = IntStream.range(0, topX)
         .mapToObj(idx -> null)
         .toArray(Integer[]::new);
@@ -162,7 +162,7 @@ public class IntTopkDistinctKudafTest {
     final int iterations = 1_000_000_000;
     final int topX = 10;
     final TopkDistinctKudaf<Integer> intTopkDistinctKudaf =
-        new TopkDistinctKudaf<>(0, topX, Schema.INT32_SCHEMA, Integer.class);
+        TopKDistinctTestUtils.getTopKDistinctKudaf(topX, Schema.INT32_SCHEMA);
 
     final Integer[] aggregate1 = IntStream.range(0, topX)
         .mapToObj(v -> v % 2 == 0 ? v + 1 : v)

--- a/ksql-engine/src/test/java/io/confluent/ksql/function/udaf/topkdistinct/LongTopkDistinctKudafTest.java
+++ b/ksql-engine/src/test/java/io/confluent/ksql/function/udaf/topkdistinct/LongTopkDistinctKudafTest.java
@@ -27,7 +27,7 @@ public class LongTopkDistinctKudafTest {
 
   Long[] valueArray;
   private final TopkDistinctKudaf<Long> longTopkDistinctKudaf
-          = new TopkDistinctKudaf<>(0, 3, Schema.INT64_SCHEMA, Long.class);
+          = TopKDistinctTestUtils.getTopKDistinctKudaf(3, Schema.INT64_SCHEMA);
 
   @Before
   public void setup() {

--- a/ksql-engine/src/test/java/io/confluent/ksql/function/udaf/topkdistinct/StringTopkDistinctKudafTest.java
+++ b/ksql-engine/src/test/java/io/confluent/ksql/function/udaf/topkdistinct/StringTopkDistinctKudafTest.java
@@ -27,7 +27,7 @@ public class StringTopkDistinctKudafTest {
 
   String[] valueArray;
   private final TopkDistinctKudaf<String> stringTopkDistinctKudaf
-          = new TopkDistinctKudaf<>(0, 3, Schema.STRING_SCHEMA, String.class);
+          = TopKDistinctTestUtils.getTopKDistinctKudaf(3, Schema.STRING_SCHEMA);
 
   @Before
   public void setup() {

--- a/ksql-engine/src/test/java/io/confluent/ksql/function/udaf/topkdistinct/TopKDistinctTestUtils.java
+++ b/ksql-engine/src/test/java/io/confluent/ksql/function/udaf/topkdistinct/TopKDistinctTestUtils.java
@@ -1,0 +1,24 @@
+package io.confluent.ksql.function.udaf.topkdistinct;
+
+import io.confluent.ksql.parser.tree.Expression;
+import io.confluent.ksql.parser.tree.LongLiteral;
+import io.confluent.ksql.parser.tree.QualifiedName;
+import io.confluent.ksql.parser.tree.QualifiedNameReference;
+import org.apache.kafka.connect.data.Schema;
+
+import java.util.Arrays;
+import java.util.Collections;
+
+public class TopKDistinctTestUtils {
+  @SuppressWarnings("unchecked")
+  public static <T extends Comparable<? super T>> TopkDistinctKudaf<T> getTopKDistinctKudaf(int topk, Schema schema) {
+    Expression fooExpression = new QualifiedNameReference(QualifiedName.of("foo"));
+    Expression topKExpression = new LongLiteral(Integer.toString(topk));
+    return (TopkDistinctKudaf<T>) new TopkDistinctAggFunctionFactory()
+        .getProperAggregateFunction(
+            Collections.singletonList(schema))
+        .getInstance(
+            Collections.singletonMap("foo", 0),
+            Arrays.asList(fooExpression, topKExpression));
+  }
+}


### PR DESCRIPTION
…tions

Some aggregation functions cannot be used to aggregate tables. After this patch, the
error message raised if such functions are used includes the functions used in the bad
statement.

### Description 
Some aggregation functions cannot be used to aggregate tables. After this patch, the
error message raised if such functions are used includes the functions used in the bad
statement.

Fixes #1221 

### Testing done 
Added unit test that validates the new error message with multiple bad functions.

### Reviewer checklist
- [x] Ensure docs are updated if necessary. (eg. if a user visible feature is being added or changed).
- [x] Ensure relevant issues are linked (description should include text like "Fixes #<issue number>")

