### PR TITLE
MINOR: The DESCRIBE ACL on the __consumer_offsets topic is not required.

### DIFF
--- a/docs/installation/server-config/security.rst
+++ b/docs/installation/server-config/security.rst
@@ -197,7 +197,6 @@ Standard ACLs
     The authenticated KSQL user always requires:
 
     - ``DESCRIBE_CONFIGS`` permission on the ``CLUSTER`` resource type.
-    - ``DESCRIBE`` permission on the ``__consumer_offsets`` topic.
 
 Input topics
     An input topic is one that has been imported into KSQL using a ``CREATE STREAM`` or ``CREATE TABLE``

--- a/ksql-engine/src/test/java/io/confluent/ksql/integration/SecureIntegrationTest.java
+++ b/ksql-engine/src/test/java/io/confluent/ksql/integration/SecureIntegrationTest.java
@@ -193,9 +193,6 @@ public class SecureIntegrationTest {
     givenAllowAcl(NORMAL_USER, ResourceType.TOPIC, INPUT_TOPIC,
                   ImmutableSet.of(AclOperation.DESCRIBE, AclOperation.READ));
 
-    givenAllowAcl(NORMAL_USER, ResourceType.TOPIC, "__consumer_offsets",
-                  ImmutableSet.of(AclOperation.DESCRIBE));
-
     givenAllowAcl(NORMAL_USER, ResourceType.TOPIC, outputTopic,
                   ImmutableSet.of(AclOperation.DESCRIBE, AclOperation.WRITE));
 
@@ -241,9 +238,6 @@ public class SecureIntegrationTest {
     givenAllowAcl(NORMAL_USER, ResourceType.TOPIC, INPUT_TOPIC,
                   ImmutableSet.of(AclOperation.DESCRIBE, AclOperation.READ));
 
-    givenAllowAcl(NORMAL_USER, ResourceType.TOPIC, "__consumer_offsets",
-                  ImmutableSet.of(AclOperation.DESCRIBE));
-
     givenAllowAcl(NORMAL_USER, ResourceType.TOPIC, outputTopic,
                   ImmutableSet.of(AclOperation.DESCRIBE, AclOperation.WRITE));
 
@@ -276,9 +270,6 @@ public class SecureIntegrationTest {
 
     givenAllowAcl(NORMAL_USER, ResourceType.TOPIC, INPUT_TOPIC,
                   ImmutableSet.of(AclOperation.DESCRIBE, AclOperation.READ));
-
-    givenAllowAcl(NORMAL_USER, ResourceType.TOPIC, "__consumer_offsets",
-                  ImmutableSet.of(AclOperation.DESCRIBE));
 
     givenAllowAcl(NORMAL_USER, ResourceType.TOPIC, outputTopic,
                   ImmutableSet.of(AclOperation.DESCRIBE, AclOperation.WRITE));


### PR DESCRIPTION
The docs state that the authenticated user that KSQL is running as will need a DESCRIBE ACL on the __consumer_offsets topic for KSQL to work with a secured Kafka cluster. This is not the case.  

This PR updates the integration tests, proving the ACL is not needed, and updates the docs.
