### PR TITLE
Better reporting of invalid serverAddress or connection issues in CLI

### DIFF
--- a/ksql-cli/src/main/java/io/confluent/ksql/Ksql.java
+++ b/ksql-cli/src/main/java/io/confluent/ksql/Ksql.java
@@ -17,6 +17,8 @@
 package io.confluent.ksql;
 
 import org.apache.kafka.streams.StreamsConfig;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import java.io.FileInputStream;
 import java.io.IOException;
@@ -27,12 +29,14 @@ import io.confluent.ksql.cli.Cli;
 import io.confluent.ksql.cli.Options;
 import io.confluent.ksql.cli.console.JLineTerminal;
 import io.confluent.ksql.rest.client.KsqlRestClient;
+import io.confluent.ksql.util.ErrorMessageUtil;
 import io.confluent.ksql.util.KsqlConfig;
 import io.confluent.ksql.util.KsqlException;
 import io.confluent.ksql.version.metrics.KsqlVersionCheckerAgent;
 import io.confluent.ksql.version.metrics.collector.KsqlModuleType;
 
 public class Ksql {
+  private static final Logger LOGGER = LoggerFactory.getLogger(Ksql.class);
 
   public static void main(String[] args) throws IOException {
     final Options options = args.length == 0 ? Options.parse("http://localhost:8088")
@@ -41,23 +45,30 @@ public class Ksql {
       System.exit(-1);
     }
 
-    final Properties properties = loadProperties(options.getConfigFile());
-    final KsqlRestClient restClient =
-        new KsqlRestClient(options.getServer(), properties);
+    try {
 
-    options.getUserNameAndPassword().ifPresent(
-        creds -> restClient.setupAuthenticationCredentials(creds.left, creds.right)
-    );
+      final Properties properties = loadProperties(options.getConfigFile());
+      final KsqlRestClient restClient = new KsqlRestClient(options.getServer(), properties);
 
-    final KsqlVersionCheckerAgent versionChecker = new KsqlVersionCheckerAgent();
-    versionChecker.start(KsqlModuleType.CLI, properties);
+      options.getUserNameAndPassword().ifPresent(
+          creds -> restClient.setupAuthenticationCredentials(creds.left, creds.right)
+      );
 
-    try (final Cli cli = new Cli(options.getStreamedQueryRowLimit(),
-        options.getStreamedQueryTimeoutMs(),
-        restClient,
-        new JLineTerminal(options.getOutputFormat(), restClient))
-    ) {
-      cli.runInteractively();
+      final KsqlVersionCheckerAgent versionChecker = new KsqlVersionCheckerAgent();
+      versionChecker.start(KsqlModuleType.CLI, properties);
+
+      try (final Cli cli = new Cli(options.getStreamedQueryRowLimit(),
+                                   options.getStreamedQueryTimeoutMs(),
+                                   restClient,
+                                   new JLineTerminal(options.getOutputFormat(), restClient))
+      ) {
+        cli.runInteractively();
+      }
+    } catch (final Exception e) {
+      final String msg = ErrorMessageUtil.buildErrorMessage(e);
+      LOGGER.error(msg);
+      System.err.println(msg);
+      System.exit(-1);
     }
   }
 

--- a/ksql-rest-app/src/main/java/io/confluent/ksql/rest/client/KsqlRestClient.java
+++ b/ksql-rest-app/src/main/java/io/confluent/ksql/rest/client/KsqlRestClient.java
@@ -16,32 +16,21 @@
 
 package io.confluent.ksql.rest.client;
 
+import com.google.common.collect.Maps;
+
 import com.fasterxml.jackson.databind.DeserializationFeature;
 import com.fasterxml.jackson.databind.ObjectMapper;
-import io.confluent.ksql.rest.client.exception.KsqlRestClientException;
-import io.confluent.ksql.rest.entity.CommandStatus;
-import io.confluent.ksql.rest.entity.CommandStatuses;
-import io.confluent.ksql.rest.server.resources.Errors;
-import io.confluent.ksql.rest.entity.KsqlEntityList;
-import io.confluent.ksql.rest.entity.KsqlErrorMessage;
-import io.confluent.ksql.rest.entity.KsqlRequest;
-import io.confluent.ksql.rest.entity.SchemaMapper;
-import io.confluent.ksql.rest.entity.ServerInfo;
-import io.confluent.ksql.rest.entity.StreamedRow;
-import io.confluent.rest.validation.JacksonMessageBodyProvider;
+
 import org.glassfish.jersey.client.authentication.HttpAuthenticationFeature;
 
-import javax.naming.AuthenticationException;
-import javax.ws.rs.client.Client;
-import javax.ws.rs.client.ClientBuilder;
-import javax.ws.rs.client.Entity;
-import javax.ws.rs.core.MediaType;
-import javax.ws.rs.core.Response;
 import java.io.Closeable;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.InputStreamReader;
+import java.net.URI;
+import java.net.URL;
 import java.nio.charset.StandardCharsets;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.Iterator;
 import java.util.Map;
@@ -50,48 +39,55 @@ import java.util.Objects;
 import java.util.Properties;
 import java.util.Scanner;
 
+import javax.naming.AuthenticationException;
+import javax.ws.rs.client.Client;
+import javax.ws.rs.client.ClientBuilder;
+import javax.ws.rs.client.Entity;
+import javax.ws.rs.core.MediaType;
+import javax.ws.rs.core.Response;
+
+import io.confluent.ksql.rest.client.exception.KsqlRestClientException;
+import io.confluent.ksql.rest.entity.CommandStatus;
+import io.confluent.ksql.rest.entity.CommandStatuses;
+import io.confluent.ksql.rest.entity.KsqlEntityList;
+import io.confluent.ksql.rest.entity.KsqlErrorMessage;
+import io.confluent.ksql.rest.entity.KsqlRequest;
+import io.confluent.ksql.rest.entity.SchemaMapper;
+import io.confluent.ksql.rest.entity.ServerInfo;
+import io.confluent.ksql.rest.entity.StreamedRow;
+import io.confluent.ksql.rest.server.resources.Errors;
+import io.confluent.rest.validation.JacksonMessageBodyProvider;
+
 public class KsqlRestClient implements Closeable, AutoCloseable {
 
   private final Client client;
 
-  private String serverAddress;
+  private URI serverAddress;
 
   private final Map<String, Object> localProperties;
 
   private boolean hasUserCredentials = false;
 
   public KsqlRestClient(final String serverAddress) {
-    this(serverAddress, new HashMap<>());
+    this(serverAddress, Collections.emptyMap());
   }
 
   public KsqlRestClient(final String serverAddress, final Properties properties) {
     this(serverAddress, propertiesToMap(properties));
   }
 
-  public KsqlRestClient(String serverAddress, Map<String, Object> localProperties) {
-    this.serverAddress = serverAddress;
-    this.localProperties = localProperties;
-    ObjectMapper objectMapper = new SchemaMapper().registerToObjectMapper(new ObjectMapper());
-    objectMapper.configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES,
-        false);
-    objectMapper.configure(DeserializationFeature.FAIL_ON_NULL_FOR_PRIMITIVES, false);
-    JacksonMessageBodyProvider jsonProvider = new JacksonMessageBodyProvider(objectMapper);
-    this.client = ClientBuilder.newBuilder().register(jsonProvider).build();
-  }
-
-  private static Map<String, Object> propertiesToMap(final Properties properties) {
-    final Map<String, Object> propertiesMap = new HashMap<>();
-    properties.stringPropertyNames().forEach(
-        prop -> propertiesMap.put(prop, properties.getProperty(prop)));
-
-    return propertiesMap;
+  public KsqlRestClient(final String serverAddress, final Map<String, Object> localProperties) {
+    this(buildClient(), serverAddress, localProperties);
   }
 
   // Visible for testing
-  KsqlRestClient(Client client, String serverAddress) {
-    this.client = client;
-    this.serverAddress = serverAddress;
-    this.localProperties = new HashMap<>();
+  KsqlRestClient(final Client client,
+                 final String serverAddress,
+                 final Map<String, Object> localProperties) {
+    this.client = Objects.requireNonNull(client, "client");
+    this.serverAddress = parseServerAddress(serverAddress);
+    this.localProperties = Maps.newHashMap(
+        Objects.requireNonNull(localProperties, "localProperties"));
   }
 
   public void setupAuthenticationCredentials(String userName, String password) {
@@ -108,12 +104,12 @@ public class KsqlRestClient implements Closeable, AutoCloseable {
     return hasUserCredentials;
   }
 
-  public String getServerAddress() {
+  public URI getServerAddress() {
     return serverAddress;
   }
 
-  public void setServerAddress(String serverAddress) {
-    this.serverAddress = serverAddress;
+  public void setServerAddress(final String serverAddress) {
+    this.serverAddress = parseServerAddress(serverAddress);
   }
 
   public RestResponse<ServerInfo> makeRootRequest() {
@@ -333,12 +329,36 @@ public class KsqlRestClient implements Closeable, AutoCloseable {
   }
 
   public Object setProperty(String property, Object value) {
-    Object oldValue = localProperties.get(property);
-    localProperties.put(property, value);
-    return oldValue;
+    return localProperties.put(property, value);
   }
 
   public boolean unsetProperty(String property) {
     return localProperties.remove(property) != null;
+  }
+
+  private static Map<String, Object> propertiesToMap(final Properties properties) {
+    final Map<String, Object> propertiesMap = new HashMap<>();
+    properties.stringPropertyNames().forEach(
+        prop -> propertiesMap.put(prop, properties.getProperty(prop)));
+
+    return propertiesMap;
+  }
+
+  private static URI parseServerAddress(final String serverAddress) {
+    Objects.requireNonNull(serverAddress, "serverAddress");
+    try {
+      return new URL(serverAddress).toURI();
+    } catch (final Exception e) {
+      throw new KsqlRestClientException(
+          "The supplied serverAddress is invalid: " + serverAddress, e);
+    }
+  }
+
+  private static Client buildClient() {
+    final ObjectMapper objectMapper = new SchemaMapper().registerToObjectMapper(new ObjectMapper());
+    objectMapper.configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false);
+    objectMapper.configure(DeserializationFeature.FAIL_ON_NULL_FOR_PRIMITIVES, false);
+    final JacksonMessageBodyProvider jsonProvider = new JacksonMessageBodyProvider(objectMapper);
+    return ClientBuilder.newBuilder().register(jsonProvider).build();
   }
 }

--- a/ksql-rest-app/src/test/java/io/confluent/ksql/rest/client/KsqlRestClientTest.java
+++ b/ksql-rest-app/src/test/java/io/confluent/ksql/rest/client/KsqlRestClientTest.java
@@ -40,6 +40,7 @@ import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.Response;
 
 import io.confluent.ksql.GenericRow;
+import io.confluent.ksql.rest.client.exception.KsqlRestClientException;
 import io.confluent.ksql.rest.entity.CommandStatus;
 import io.confluent.ksql.rest.entity.CommandStatuses;
 import io.confluent.ksql.rest.entity.ExecutionPlan;
@@ -51,7 +52,6 @@ import io.confluent.ksql.rest.server.KsqlRestConfig;
 import io.confluent.ksql.rest.server.computation.CommandId;
 import io.confluent.ksql.rest.server.mock.MockApplication;
 import io.confluent.ksql.rest.server.mock.MockStreamedQueryResource;
-import io.confluent.ksql.rest.server.resources.KsqlRestException;
 import io.confluent.ksql.rest.server.utils.TestUtils;
 
 import static org.junit.Assert.assertThat;
@@ -186,7 +186,7 @@ public class KsqlRestClientTest {
     Assert.assertThat(commandStatus.getStatus(), CoreMatchers.equalTo(CommandStatus.Status.SUCCESS));
   }
 
-  @Test(expected = KsqlRestException.class)
+  @Test(expected = KsqlRestClientException.class)
   public void shouldThrowOnInvalidServerAddress() {
     new KsqlRestClient("not-valid-address", Collections.emptyMap());
   }


### PR DESCRIPTION
- Move the position of the warning, on startup, if the CLI can not connect to the server, to _after_ the welcome message to make it more obvious, and make it an "ERROR".
- Application now exists on startup, with a suitable message, if the server address is not a valid URL. (It will continue if it is a valid URL, but can't connect).
- The `server` command now reports an error if it can't connect to the server. (Useful for support to ensure CLI can connect).
- The `server http://new-server:port` command now validates the passed in server details are a valid URL. If they are not, it reports an error and does NOT update internal state. If they are valid the internal state is updated, the connection is tested and a confirmation message is returned to the user.
- Refactored KsqlRestClient constructors.

Fix for #970

## Output on startup if serverAddress is invalid:
```
11:14 $ ./bin/ksql httq:\\no-valid:8000
The supplied serverAddress is invalid: httq:\no-valid:8000
Caused by: unknown protocol: httq
11:14 $ 
```

## Output on starting CLI if can't connect:
```
11:04 $ ./bin/ksql
                  
                  ===========================================
                  =        _  __ _____  ____  _             =
                  =       | |/ // ____|/ __ \| |            =
                  =       | ' /| (___ | |  | | |            =
                  =       |  <  \___ \| |  | | |            =
                  =       | . \ ____) | |__| | |____        =
                  =       |_|\_\_____/ \___\_\______|       =
                  =                                         =
                  =  Streaming SQL Engine for Apache Kafka® =
                  ===========================================

Copyright 2017 Confluent Inc.

CLI v5.0.0-SNAPSHOT, Server v<unknown> located at http://localhost:8088

Having trouble? Type 'help' (case-insensitive) for a rundown of how things work!


**************** ERROR ********************
Remote server address may not be valid.
Address: http://localhost:8088
Error issuing GET to KSQL server
Caused by: java.net.ConnectException: Connection refused (Connection refused)
Caused by: Could not connect to the server.
*******************************************

ksql> 

```

## Output from `server` command if can't connect:
```
ksql> server
http://localhost:8088

**************** ERROR ********************
Remote server address may not be valid.
Address: http://localhost:8088
Error issuing GET to KSQL server
Caused by: java.net.ConnectException: Connection refused (Connection refused)
Caused by: Could not connect to the server.
*******************************************

ksql> 
```

## Output from `server blah` on success:
```
ksql> server http://localhost:8088
Server updated

ksql>
```

## Output from `server blah` command if invalid:
```
ksql> server IAmNotUrl
The supplied serverAddress is invalid: IAmNotUrl
Caused by: no protocol: IAmNotUrl
ksql> 

```

## Output from `server blah` command if valid and can't connect:
```
ksql> server http://localhost:8088
Server updated
**************** ERROR ********************
Remote server address may not be valid.
Address: http://localhost:8088
Error issuing GET to KSQL server
Caused by: java.net.ConnectException: Connection refused (Connection refused)
Caused by: Could not connect to the server.
*******************************************

ksql> 
```