### PR TITLE
Refactor WebSocket endpoints and add support for print topic

### DIFF
--- a/ksql-rest-app/src/main/java/io/confluent/ksql/rest/server/resources/streaming/Flow.java
+++ b/ksql-rest-app/src/main/java/io/confluent/ksql/rest/server/resources/streaming/Flow.java
@@ -18,6 +18,10 @@ package io.confluent.ksql.rest.server.resources.streaming;
 
 import org.apache.kafka.connect.data.Schema;
 
+/**
+ * Flow constructs loosely borrowed from Java 9
+ * https://docs.oracle.com/javase/9/docs/api/java/util/concurrent/Flow.Subscription.html
+ */
 public class Flow {
 
   public interface Subscriber<T> {

--- a/ksql-rest-app/src/main/java/io/confluent/ksql/rest/server/resources/streaming/Flow.java
+++ b/ksql-rest-app/src/main/java/io/confluent/ksql/rest/server/resources/streaming/Flow.java
@@ -1,0 +1,47 @@
+/**
+ * Copyright 2018 Confluent Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ **/
+
+package io.confluent.ksql.rest.server.resources.streaming;
+
+import org.apache.kafka.connect.data.Schema;
+
+public class Flow {
+
+  public interface Subscriber<T> {
+
+    void onNext(T item);
+
+    void onError(Throwable e);
+
+    void onComplete();
+
+    void onSchema(Schema schema);
+
+    void onSubscribe(Subscription subscription);
+  }
+
+  public interface Subscription {
+
+    void cancel();
+
+    void request(long n);
+  }
+
+  public interface Publisher<T> {
+
+    void subscribe(Subscriber<T> subscriber);
+  }
+}

--- a/ksql-rest-app/src/main/java/io/confluent/ksql/rest/server/resources/streaming/Flow.java
+++ b/ksql-rest-app/src/main/java/io/confluent/ksql/rest/server/resources/streaming/Flow.java
@@ -19,7 +19,7 @@ package io.confluent.ksql.rest.server.resources.streaming;
 import org.apache.kafka.connect.data.Schema;
 
 /**
- * Flow constructs loosely borrowed from Java 9
+ * Flow constructs borrowed from Java 9
  * https://docs.oracle.com/javase/9/docs/api/java/util/concurrent/Flow.Subscription.html
  */
 public class Flow {
@@ -32,6 +32,13 @@ public class Flow {
 
     void onComplete();
 
+    /**
+     * this method is an addition to the Java 9 API
+     *
+     * <p>onSchema may be called right before the first onNext call
+     * to describe the message format, in case the stream has a schema
+     * @param schema schema for upcoming messages
+     */
     void onSchema(Schema schema);
 
     void onSubscribe(Subscription subscription);

--- a/ksql-rest-app/src/main/java/io/confluent/ksql/rest/server/resources/streaming/PollingSubscription.java
+++ b/ksql-rest-app/src/main/java/io/confluent/ksql/rest/server/resources/streaming/PollingSubscription.java
@@ -72,7 +72,9 @@ public abstract class PollingSubscription<T> implements Flow.Subscription {
         }
         T item = poll();
         if (item == null) {
-          future = exec.schedule(() -> request(1), BACKOFF_DELAY_MS, TimeUnit.MILLISECONDS);
+          if (!draining) {
+            future = exec.schedule(() -> request(1), BACKOFF_DELAY_MS, TimeUnit.MILLISECONDS);
+          }
         } else {
           subscriber.onNext(item);
         }

--- a/ksql-rest-app/src/main/java/io/confluent/ksql/rest/server/resources/streaming/PollingSubscription.java
+++ b/ksql-rest-app/src/main/java/io/confluent/ksql/rest/server/resources/streaming/PollingSubscription.java
@@ -16,6 +16,7 @@
 
 package io.confluent.ksql.rest.server.resources.streaming;
 
+import com.google.common.base.Preconditions;
 import com.google.common.util.concurrent.ListenableFuture;
 import com.google.common.util.concurrent.ListeningScheduledExecutorService;
 
@@ -57,6 +58,8 @@ public abstract class PollingSubscription<T> implements Flow.Subscription {
 
   @Override
   public void request(long n) {
+    Preconditions.checkArgument(n == 1, "number of requested items must be 1");
+
     if (needsSchema) {
       if (schema != null) {
         subscriber.onSchema(schema);

--- a/ksql-rest-app/src/main/java/io/confluent/ksql/rest/server/resources/streaming/PollingSubscription.java
+++ b/ksql-rest-app/src/main/java/io/confluent/ksql/rest/server/resources/streaming/PollingSubscription.java
@@ -1,0 +1,98 @@
+/**
+ * Copyright 2018 Confluent Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ **/
+
+package io.confluent.ksql.rest.server.resources.streaming;
+
+import com.google.common.util.concurrent.ListenableFuture;
+import com.google.common.util.concurrent.ListeningScheduledExecutorService;
+
+import org.apache.kafka.connect.data.Schema;
+
+import java.util.concurrent.TimeUnit;
+
+public class PollingSubscription<T> implements Flow.Subscription {
+
+  private static final int BACKOFF_DELAY_MS = 100;
+
+  public interface Pollable<T> {
+
+    Schema getSchema();
+
+    T poll();
+
+    boolean hasError();
+
+    Throwable getError();
+
+    void close();
+  }
+
+  private final Flow.Subscriber<T> subscriber;
+  private final ListeningScheduledExecutorService exec;
+  private final Pollable<T> pollable;
+
+  private boolean needsSchema = true;
+  private boolean draining = false;
+  private volatile ListenableFuture future;
+
+  public PollingSubscription(
+      ListeningScheduledExecutorService exec,
+      Flow.Subscriber<T> subscriber,
+      Pollable<T> pollable
+  ) {
+    this.exec = exec;
+    this.subscriber = subscriber;
+    this.pollable = pollable;
+  }
+
+  @Override
+  public void cancel() {
+    if (future != null) {
+      future.cancel(false);
+    }
+    exec.submit(pollable::close);
+  }
+
+  @Override
+  public void request(long n) {
+    if (needsSchema) {
+      final Schema schema = pollable.getSchema();
+      if (schema != null) {
+        subscriber.onSchema(schema);
+      }
+      needsSchema = false;
+    }
+    // check draining status since request can be reentrant
+    if (!draining) {
+      future = exec.submit(() -> {
+
+        if (pollable.hasError()) {
+          draining = true;
+        }
+        T item = pollable.poll();
+        if (item == null) {
+          future = exec.schedule(() -> request(1), BACKOFF_DELAY_MS, TimeUnit.MILLISECONDS);
+        } else {
+          subscriber.onNext(item);
+        }
+        if (draining) {
+          pollable.close();
+          subscriber.onError(pollable.getError());
+        }
+      });
+    }
+  }
+}

--- a/ksql-rest-app/src/main/java/io/confluent/ksql/rest/server/resources/streaming/PollingSubscription.java
+++ b/ksql-rest-app/src/main/java/io/confluent/ksql/rest/server/resources/streaming/PollingSubscription.java
@@ -66,7 +66,10 @@ public abstract class PollingSubscription<T> implements Flow.Subscription {
       }
       needsSchema = false;
     }
-    // check status since request can be reentrant
+    // check status since request() can be reentrant through subscriber.onNext()
+    // this is to prevent another thread from calling onNext again
+    // while the first one is draining and closing the subscription after having called onNext
+    // with the last element polled from the queue after being marked done.
     if (!draining) {
       future = exec.submit(() -> {
 

--- a/ksql-rest-app/src/main/java/io/confluent/ksql/rest/server/resources/streaming/PrintPublisher.java
+++ b/ksql-rest-app/src/main/java/io/confluent/ksql/rest/server/resources/streaming/PrintPublisher.java
@@ -1,0 +1,158 @@
+/**
+ * Copyright 2018 Confluent Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ **/
+
+package io.confluent.ksql.rest.server.resources.streaming;
+
+import com.google.common.util.concurrent.ListeningScheduledExecutorService;
+
+import org.apache.kafka.clients.consumer.ConsumerRecords;
+import org.apache.kafka.clients.consumer.KafkaConsumer;
+import org.apache.kafka.common.TopicPartition;
+import org.apache.kafka.common.serialization.BytesDeserializer;
+import org.apache.kafka.common.serialization.StringDeserializer;
+import org.apache.kafka.common.utils.Bytes;
+import org.apache.kafka.connect.data.Schema;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.IOException;
+import java.util.Collection;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.stream.Collectors;
+import java.util.stream.StreamSupport;
+
+import io.confluent.kafka.schemaregistry.client.SchemaRegistryClient;
+import io.confluent.ksql.rest.server.resources.streaming.PollingSubscription.Pollable;
+import io.confluent.ksql.rest.server.resources.streaming.TopicStream.Format;
+
+import static io.confluent.ksql.rest.server.resources.streaming.TopicStream.Format.getFormatter;
+
+public class PrintPublisher implements Flow.Publisher<Collection<String>> {
+
+  private static final Logger log = LoggerFactory.getLogger(PrintPublisher.class);
+
+  private final ListeningScheduledExecutorService exec;
+  private final SchemaRegistryClient schemaRegistryClient;
+  private final String topicName;
+  private final boolean fromBeginning;
+  private final Map<String, Object> consumerProperties;
+
+  private boolean closed = false;
+  private KafkaConsumer<String, Bytes> topicConsumer;
+
+  public PrintPublisher(
+      ListeningScheduledExecutorService exec,
+      SchemaRegistryClient schemaRegistryClient,
+      Map<String, Object> consumerProperties,
+      String topicName,
+      boolean fromBeginning
+  ) {
+    this.exec = exec;
+    this.schemaRegistryClient = schemaRegistryClient;
+    this.consumerProperties = consumerProperties;
+    this.topicName = topicName;
+    this.fromBeginning = fromBeginning;
+  }
+
+  @Override
+  public void subscribe(Flow.Subscriber<Collection<String>> subscriber) {
+    this.topicConsumer = new KafkaConsumer<>(
+        consumerProperties,
+        new StringDeserializer(),
+        new BytesDeserializer()
+    );
+
+    log.info("Running consumer for topic {}", topicName);
+    List<TopicPartition> topicPartitions = topicConsumer.partitionsFor(topicName)
+        .stream()
+        .map(partitionInfo -> new TopicPartition(partitionInfo.topic(), partitionInfo.partition()))
+        .collect(Collectors.toList());
+    topicConsumer.assign(topicPartitions);
+
+    if (fromBeginning) {
+      topicConsumer.seekToBeginning(topicPartitions);
+    }
+    subscriber.onSubscribe(new PollingSubscription<>(
+        exec,
+        subscriber,
+        new Pollable<Collection<String>>() {
+          Throwable error;
+          Format format = Format.UNDEFINED;
+
+          @Override
+          public Schema getSchema() {
+            return null;
+          }
+
+          @Override
+          public Collection<String> poll() {
+            try {
+              ConsumerRecords<String, Bytes> records = topicConsumer.poll(0);
+              if (records.isEmpty()) {
+                return null;
+              }
+              return StreamSupport
+                  .stream(records.records(topicName).spliterator(), false)
+                  .map((record) -> {
+                    if (record == null) {
+                      return null;
+                    }
+                    if (format == TopicStream.Format.UNDEFINED) {
+                      format = getFormatter(topicName, record, schemaRegistryClient);
+                    }
+                    try {
+                      return format.print(record);
+                    } catch (IOException e) {
+                      log.warn("Exception formatting record", e);
+                      return null;
+                    }
+                  })
+                  .filter(Objects::nonNull)
+                  .collect(Collectors.toList());
+            } catch (Exception e) {
+              error = e;
+              return null;
+            }
+          }
+
+          @Override
+          public boolean hasError() {
+            return error != null;
+          }
+
+          @Override
+          public Throwable getError() {
+            return error;
+          }
+
+          @Override
+          public void close() {
+            PrintPublisher.this.close();
+          }
+        }
+    ));
+  }
+
+  public synchronized void close() {
+    if (!closed) {
+      log.info("Closing consumer for topic {}", topicName);
+      closed = true;
+      topicConsumer.close();
+    }
+  }
+}

--- a/ksql-rest-app/src/main/java/io/confluent/ksql/rest/server/resources/streaming/PrintPublisher.java
+++ b/ksql-rest-app/src/main/java/io/confluent/ksql/rest/server/resources/streaming/PrintPublisher.java
@@ -27,6 +27,7 @@ import org.apache.kafka.common.utils.Bytes;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import java.time.Duration;
 import java.util.Collection;
 import java.util.List;
 import java.util.Map;
@@ -107,7 +108,7 @@ public class PrintPublisher implements Flow.Publisher<Collection<String>> {
     @Override
     public Collection<String> poll() {
       try {
-        ConsumerRecords<String, Bytes> records = topicConsumer.poll(0);
+        ConsumerRecords<String, Bytes> records = topicConsumer.poll(Duration.ZERO);
         if (records.isEmpty()) {
           return null;
         }

--- a/ksql-rest-app/src/main/java/io/confluent/ksql/rest/server/resources/streaming/StreamPublisher.java
+++ b/ksql-rest-app/src/main/java/io/confluent/ksql/rest/server/resources/streaming/StreamPublisher.java
@@ -1,0 +1,123 @@
+/**
+ * Copyright 2018 Confluent Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ **/
+
+package io.confluent.ksql.rest.server.resources.streaming;
+
+import com.google.common.collect.Lists;
+import com.google.common.util.concurrent.ListeningScheduledExecutorService;
+
+import org.apache.kafka.connect.data.Schema;
+import org.apache.kafka.streams.KeyValue;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.Collection;
+import java.util.List;
+import java.util.Map;
+
+import io.confluent.ksql.GenericRow;
+import io.confluent.ksql.KsqlEngine;
+import io.confluent.ksql.rest.entity.StreamedRow;
+import io.confluent.ksql.rest.server.resources.streaming.PollingSubscription.Pollable;
+import io.confluent.ksql.util.QueuedQueryMetadata;
+
+public class StreamPublisher implements Flow.Publisher<Collection<StreamedRow>> {
+
+  private static final Logger log = LoggerFactory.getLogger(StreamPublisher.class);
+
+  private final KsqlEngine ksqlEngine;
+  private final String queryString;
+  private final Map<String, Object> clientLocalProperties;
+  private final ListeningScheduledExecutorService exec;
+
+  private boolean closed = false;
+  private QueuedQueryMetadata queryMetadata;
+  private volatile Throwable error;
+
+  public StreamPublisher(
+      KsqlEngine ksqlEngine,
+      ListeningScheduledExecutorService exec,
+      String queryString,
+      Map<String, Object> clientLocalProperties
+  ) {
+    this.ksqlEngine = ksqlEngine;
+    this.exec = exec;
+    this.queryString = queryString;
+    this.clientLocalProperties = clientLocalProperties;
+  }
+
+  @Override
+  public synchronized void subscribe(Flow.Subscriber<Collection<StreamedRow>> subscriber) {
+    if (queryMetadata != null) {
+      throw new IllegalStateException("already subscribed");
+    }
+
+    queryMetadata = (QueuedQueryMetadata) ksqlEngine.buildMultipleQueries(
+        queryString,
+        clientLocalProperties
+    ).get(0);
+
+    queryMetadata.getKafkaStreams().setUncaughtExceptionHandler(
+        (thread, e) -> error = e
+    );
+    log.info("Running query {}", queryMetadata.getQueryApplicationId());
+    queryMetadata.getKafkaStreams().start();
+
+    subscriber.onSubscribe(
+        new PollingSubscription<>(exec, subscriber, new Pollable<Collection<StreamedRow>>() {
+          @Override
+          public Schema getSchema() {
+            return queryMetadata.getResultSchema();
+          }
+
+          @Override
+          public Collection<StreamedRow> poll() {
+            List<KeyValue<String, GenericRow>> rows = Lists.newLinkedList();
+            queryMetadata.getRowQueue().drainTo(rows);
+            if (rows.isEmpty()) {
+              return null;
+            } else {
+              return Lists.transform(rows, row -> new StreamedRow(row.value));
+            }
+          }
+
+          @Override
+          public boolean hasError() {
+            return error != null;
+          }
+
+          @Override
+          public Throwable getError() {
+            return error;
+          }
+
+          @Override
+          public void close() {
+            StreamPublisher.this.close();
+          }
+        })
+    );
+  }
+
+  private synchronized void close() {
+    if (!closed) {
+      closed = true;
+      log.info("Terminating query {}", queryMetadata.getQueryApplicationId());
+      queryMetadata.close();
+      ksqlEngine.removeTemporaryQuery(queryMetadata);
+    }
+  }
+}

--- a/ksql-rest-app/src/main/java/io/confluent/ksql/rest/server/resources/streaming/TopicStream.java
+++ b/ksql-rest-app/src/main/java/io/confluent/ksql/rest/server/resources/streaming/TopicStream.java
@@ -1,0 +1,148 @@
+/**
+ * Copyright 2018 Confluent Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ **/
+
+package io.confluent.ksql.rest.server.resources.streaming;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+
+import org.apache.avro.generic.GenericRecord;
+import org.apache.kafka.clients.consumer.ConsumerRecord;
+import org.apache.kafka.common.utils.Bytes;
+
+import java.io.IOException;
+import java.io.StringWriter;
+import java.text.DateFormat;
+import java.text.SimpleDateFormat;
+import java.util.Date;
+import java.util.Locale;
+
+import io.confluent.kafka.schemaregistry.client.SchemaRegistryClient;
+import io.confluent.kafka.serializers.KafkaAvroDeserializer;
+import io.confluent.ksql.util.SchemaUtil;
+
+public class TopicStream {
+
+  public enum Format {
+
+    UNDEFINED {
+    },
+    AVRO {
+      private String topicName;
+      private KafkaAvroDeserializer avroDeserializer;
+
+      @Override
+      public boolean isFormat(
+          String topicName, ConsumerRecord<String, Bytes> record,
+          SchemaRegistryClient schemaRegistryClient
+      ) {
+        this.topicName = topicName;
+        try {
+          avroDeserializer = new KafkaAvroDeserializer(schemaRegistryClient);
+          avroDeserializer.deserialize(topicName, record.value().get());
+          return true;
+        } catch (Throwable t) {
+          return false;
+        }
+      }
+
+      @Override
+      String print(ConsumerRecord<String, Bytes> consumerRecord) {
+        String time = dateFormat.format(new Date(consumerRecord.timestamp()));
+        GenericRecord record = (GenericRecord) avroDeserializer.deserialize(
+            topicName,
+            consumerRecord
+                .value()
+                .get()
+        );
+        String key = consumerRecord.key() != null ? consumerRecord.key() : "null";
+        return time + ", " + key + ", " + record.toString() + "\n";
+      }
+    },
+    JSON {
+      final ObjectMapper objectMapper = new ObjectMapper();
+
+      @Override
+      public boolean isFormat(
+          String topicName, ConsumerRecord<String, Bytes> record,
+          SchemaRegistryClient schemaRegistryClient
+      ) {
+        try {
+          objectMapper.readTree(record.value().toString());
+          return true;
+        } catch (Throwable t) {
+          return false;
+        }
+      }
+
+      @Override
+      String print(ConsumerRecord<String, Bytes> record) throws IOException {
+        JsonNode jsonNode = objectMapper.readTree(record.value().toString());
+        ObjectNode objectNode = objectMapper.createObjectNode();
+        objectNode.put(SchemaUtil.ROWTIME_NAME, record.timestamp());
+        objectNode.put(SchemaUtil.ROWKEY_NAME, (record.key() != null) ? record.key() : "null");
+        objectNode.setAll((ObjectNode) jsonNode);
+        StringWriter stringWriter = new StringWriter();
+        objectMapper.writeValue(stringWriter, objectNode);
+        return stringWriter.toString() + "\n";
+      }
+    },
+    STRING {
+      @Override
+      public boolean isFormat(
+          String topicName,
+          ConsumerRecord<String, Bytes> record,
+          SchemaRegistryClient schemaRegistryClient
+      ) {
+        /**
+         * STRING always returns true because its last in the enum list
+         */
+        return true;
+      }
+    };
+
+    final DateFormat dateFormat = SimpleDateFormat.getDateTimeInstance(3, 1, Locale.getDefault());
+
+    static Format getFormatter(
+        String topicName,
+        ConsumerRecord<String, Bytes> record,
+        SchemaRegistryClient schemaRegistryClient
+    ) {
+      Format result = Format.UNDEFINED;
+      while (!(result.isFormat(topicName, record, schemaRegistryClient))) {
+        result = Format.values()[result.ordinal() + 1];
+      }
+      return result;
+
+    }
+
+    boolean isFormat(
+        String topicName,
+        ConsumerRecord<String, Bytes> record,
+        SchemaRegistryClient schemaRegistryClient
+    ) {
+      return false;
+    }
+
+    String print(ConsumerRecord<String, Bytes> record) throws IOException {
+      String key = record.key() != null ? record.key() : "null";
+      return dateFormat.format(new Date(record.timestamp())) + " , " + key
+          + " , " + record.value().toString() + "\n";
+    }
+
+  }
+}

--- a/ksql-rest-app/src/main/java/io/confluent/ksql/rest/server/resources/streaming/TopicStreamWriter.java
+++ b/ksql-rest-app/src/main/java/io/confluent/ksql/rest/server/resources/streaming/TopicStreamWriter.java
@@ -16,11 +16,6 @@
 
 package io.confluent.ksql.rest.server.resources.streaming;
 
-import com.fasterxml.jackson.databind.JsonNode;
-import com.fasterxml.jackson.databind.ObjectMapper;
-import com.fasterxml.jackson.databind.node.ObjectNode;
-
-import org.apache.avro.generic.GenericRecord;
 import org.apache.kafka.clients.consumer.ConsumerRecord;
 import org.apache.kafka.clients.consumer.ConsumerRecords;
 import org.apache.kafka.clients.consumer.KafkaConsumer;
@@ -34,134 +29,19 @@ import org.slf4j.LoggerFactory;
 import java.io.EOFException;
 import java.io.IOException;
 import java.io.OutputStream;
-import java.io.StringWriter;
 import java.nio.charset.StandardCharsets;
-import java.text.DateFormat;
-import java.text.SimpleDateFormat;
-import java.util.Date;
 import java.util.List;
-import java.util.Locale;
 import java.util.Map;
 import java.util.stream.Collectors;
 
 import javax.ws.rs.core.StreamingOutput;
 
 import io.confluent.kafka.schemaregistry.client.SchemaRegistryClient;
-import io.confluent.kafka.serializers.KafkaAvroDeserializer;
-import io.confluent.ksql.util.SchemaUtil;
+import io.confluent.ksql.rest.server.resources.streaming.TopicStream.Format;
 
-import static io.confluent.ksql.rest.server.resources.streaming.TopicStreamWriter.Format.getFormatter;
+import static io.confluent.ksql.rest.server.resources.streaming.TopicStream.Format.getFormatter;
 
 public class TopicStreamWriter implements StreamingOutput {
-
-  public enum Format {
-
-    UNDEFINED {
-    },
-    AVRO {
-      private String topicName;
-      private KafkaAvroDeserializer avroDeserializer;
-
-      @Override
-      public boolean isFormat(
-          String topicName, ConsumerRecord<String, Bytes> record,
-          SchemaRegistryClient schemaRegistryClient
-      ) {
-        this.topicName = topicName;
-        try {
-          avroDeserializer = new KafkaAvroDeserializer(schemaRegistryClient);
-          avroDeserializer.deserialize(topicName, record.value().get());
-          return true;
-        } catch (Throwable t) {
-          return false;
-        }
-      }
-
-      @Override
-      String print(ConsumerRecord<String, Bytes> consumerRecord) {
-        String time = dateFormat.format(new Date(consumerRecord.timestamp()));
-        GenericRecord record = (GenericRecord) avroDeserializer.deserialize(
-            topicName,
-            consumerRecord
-                .value()
-                .get()
-        );
-        String key = consumerRecord.key() != null ? consumerRecord.key() : "null";
-        return time + ", " + key + ", " + record.toString() + "\n";
-      }
-    },
-    JSON {
-      final ObjectMapper objectMapper = new ObjectMapper();
-
-      @Override
-      public boolean isFormat(
-          String topicName, ConsumerRecord<String, Bytes> record,
-          SchemaRegistryClient schemaRegistryClient
-      ) {
-        try {
-          objectMapper.readTree(record.value().toString());
-          return true;
-        } catch (Throwable t) {
-          return false;
-        }
-      }
-
-      @Override
-      String print(ConsumerRecord<String, Bytes> record) throws IOException {
-        JsonNode jsonNode = objectMapper.readTree(record.value().toString());
-        ObjectNode objectNode = objectMapper.createObjectNode();
-        objectNode.put(SchemaUtil.ROWTIME_NAME, record.timestamp());
-        objectNode.put(SchemaUtil.ROWKEY_NAME, (record.key() != null) ? record.key() : "null");
-        objectNode.setAll((ObjectNode) jsonNode);
-        StringWriter stringWriter = new StringWriter();
-        objectMapper.writeValue(stringWriter, objectNode);
-        return stringWriter.toString() + "\n";
-      }
-    },
-    STRING {
-      @Override
-      public boolean isFormat(
-          String topicName,
-          ConsumerRecord<String, Bytes> record,
-          SchemaRegistryClient schemaRegistryClient
-      ) {
-        /**
-         * STRING always returns true because its last in the enum list
-         */
-        return true;
-      }
-    };
-
-    final DateFormat dateFormat = SimpleDateFormat.getDateTimeInstance(3, 1, Locale.getDefault());
-
-    static Format getFormatter(
-        String topicName,
-        ConsumerRecord<String, Bytes> record,
-        SchemaRegistryClient schemaRegistryClient
-    ) {
-      Format result = Format.UNDEFINED;
-      while (!(result.isFormat(topicName, record, schemaRegistryClient))) {
-        result = Format.values()[result.ordinal() + 1];
-      }
-      return result;
-
-    }
-
-    boolean isFormat(
-        String topicName,
-        ConsumerRecord<String, Bytes> record,
-        SchemaRegistryClient schemaRegistryClient
-    ) {
-      return false;
-    }
-
-    String print(ConsumerRecord<String, Bytes> record) throws IOException {
-      String key = record.key() != null ? record.key() : "null";
-      return dateFormat.format(new Date(record.timestamp())) + " , " + key
-          + " , " + record.value().toString() + "\n";
-    }
-
-  }
 
   private static final Logger log = LoggerFactory.getLogger(TopicStreamWriter.class);
   private final Long interval;

--- a/ksql-rest-app/src/main/java/io/confluent/ksql/rest/server/resources/streaming/WSQueryEndpoint.java
+++ b/ksql-rest-app/src/main/java/io/confluent/ksql/rest/server/resources/streaming/WSQueryEndpoint.java
@@ -17,14 +17,10 @@
 package io.confluent.ksql.rest.server.resources.streaming;
 
 import com.google.common.collect.Iterables;
-import com.google.common.collect.Lists;
-import com.google.common.util.concurrent.ListenableScheduledFuture;
 import com.google.common.util.concurrent.ListeningScheduledExecutorService;
 
-import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 
-import org.apache.kafka.streams.KeyValue;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -35,7 +31,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
-import java.util.concurrent.TimeUnit;
 
 import javax.websocket.CloseReason;
 import javax.websocket.CloseReason.CloseCodes;
@@ -47,26 +42,26 @@ import javax.websocket.Session;
 import javax.websocket.server.ServerEndpoint;
 
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
-import io.confluent.ksql.GenericRow;
 import io.confluent.ksql.KsqlEngine;
+import io.confluent.ksql.parser.tree.PrintTopic;
 import io.confluent.ksql.parser.tree.Query;
 import io.confluent.ksql.parser.tree.Statement;
 import io.confluent.ksql.rest.entity.KsqlRequest;
 import io.confluent.ksql.rest.entity.StreamedRow;
 import io.confluent.ksql.rest.entity.Versions;
 import io.confluent.ksql.rest.server.StatementParser;
-import io.confluent.ksql.util.QueuedQueryMetadata;
 
 @ServerEndpoint(value = "/query")
 public class WSQueryEndpoint {
 
   private static final Logger log = LoggerFactory.getLogger(WSQueryEndpoint.class);
-  private static final int WS_STREAMS_POLL_DELAY_MS = 500;
 
-  final ObjectMapper mapper;
-  final StatementParser statementParser;
-  final KsqlEngine ksqlEngine;
-  final ListeningScheduledExecutorService exec;
+  private final ObjectMapper mapper;
+  private final StatementParser statementParser;
+  private final KsqlEngine ksqlEngine;
+  private final ListeningScheduledExecutorService exec;
+
+  private WebSocketSubscriber subscriber;
 
   public WSQueryEndpoint(
       ObjectMapper mapper,
@@ -80,9 +75,6 @@ public class WSQueryEndpoint {
     this.exec = exec;
   }
 
-  private volatile QueuedQueryMetadata queryMetadata;
-  private volatile ListenableScheduledFuture future;
-
   @OnOpen
   public void onOpen(Session session, EndpointConfig endpointConfig) {
     log.debug("Opening websocket session {}", session.getId());
@@ -92,7 +84,10 @@ public class WSQueryEndpoint {
         Versions.KSQL_V1_WS_PARAM, Arrays.asList(Versions.KSQL_V1_WS));
     if (versionParam.size() != 1 || !versionParam.get(0).equals(Versions.KSQL_V1_WS)) {
       log.debug("Received invalid api version: {}", String.join(",", versionParam));
-      closeSession(session, new CloseReason(CloseCodes.CANNOT_ACCEPT,"Invalid version in request"));
+      closeSession(
+          session,
+          new CloseReason(CloseCodes.CANNOT_ACCEPT, "Invalid version in request")
+      );
       return;
     }
 
@@ -117,91 +112,55 @@ public class WSQueryEndpoint {
       return;
     }
 
-    Map<String, Object> clientLocalProperties =
-        Optional.ofNullable(request.getStreamsProperties()).orElse(Collections.emptyMap());
-
-    if (!(statement instanceof Query)) {
-      closeSession(session, new CloseReason(
-          CloseCodes.CANNOT_ACCEPT, String.format(
-          "Statement type `%s' not supported for this resource",
-          statement.getClass().getName()
-      )));
-      return;
-    }
-
     try {
-      queryMetadata = (QueuedQueryMetadata) ksqlEngine.buildMultipleQueries(
-          queryString,
-          clientLocalProperties
-      ).get(0);
+      if (statement instanceof Query) {
+        Map<String, Object> clientLocalProperties =
+            Optional.ofNullable(request.getStreamsProperties()).orElse(Collections.emptyMap());
 
-      try {
-        session.getBasicRemote().sendText(
-            mapper.writeValueAsString(queryMetadata.getResultSchema())
-        );
-      } catch (IOException e) {
-        log.error("Error sending schema", e);
-        closeSession(session, new CloseReason(
-            CloseCodes.PROTOCOL_ERROR,
-            "Unable to send schema"
-        ));
-        closeAndRemoveQuery();
-        return;
-      }
+        WebSocketSubscriber<StreamedRow> streamSubscriber =
+            new WebSocketSubscriber<>(session, mapper);
+        this.subscriber = streamSubscriber;
 
-      queryMetadata.getKafkaStreams().setUncaughtExceptionHandler((thread, e) -> {
-        log.error("streams exception in session {}", session.getId(), e);
-        closeSession(session, new CloseReason(
-            CloseCodes.UNEXPECTED_CONDITION,
-            "streams exception"
-        ));
-      });
-      log.info("Running query {}", queryMetadata.getQueryApplicationId());
-      queryMetadata.getKafkaStreams().start();
+        new StreamPublisher(ksqlEngine, exec, queryString, clientLocalProperties)
+            .subscribe(streamSubscriber);
+      } else if (statement instanceof PrintTopic) {
+        PrintTopic printTopic = (PrintTopic) statement;
+        final String topicName = printTopic.getTopic().toString();
 
-      future = exec.scheduleWithFixedDelay(() -> {
-        List<KeyValue<String, GenericRow>> rows = Lists.newLinkedList();
-        queryMetadata.getRowQueue().drainTo(rows);
-
-        for (KeyValue<String, GenericRow> row : rows) {
-          try {
-            String buffer = mapper.writeValueAsString(StreamedRow.row(row.value));
-            session.getAsyncRemote().sendText(
-                buffer, result -> {
-                  if (!result.isOK()) {
-                    log.warn(
-                        "Error sending websocket message for session {}",
-                        session.getId(),
-                        result.getException()
-                    );
-                  }
-                });
-          } catch (JsonProcessingException e) {
-            log.warn("Error serializing row in session {}", session.getId(), e);
-          }
+        if (!ksqlEngine.getTopicClient().isTopicExists(topicName)) {
+          closeSession(session, new CloseReason(
+                  CloseCodes.CANNOT_ACCEPT,
+                  "topic does not exist"
+          ));
+          return;
         }
-      }, 0, WS_STREAMS_POLL_DELAY_MS, TimeUnit.MILLISECONDS);
+        WebSocketSubscriber<String> topicSubscriber = new WebSocketSubscriber<>(session, mapper);
+        this.subscriber = topicSubscriber;
 
-      future.addListener(this::closeAndRemoveQuery, exec);
+        new PrintPublisher(
+            exec,
+            ksqlEngine.getSchemaRegistryClient(),
+            ksqlEngine.getKsqlConfigProperties(),
+            topicName,
+            printTopic.getFromBeginning()
+        ).subscribe(topicSubscriber);
+      } else {
+        closeSession(session, new CloseReason(
+            CloseCodes.CANNOT_ACCEPT, String.format(
+            "Statement type `%s' not supported for this resource",
+            statement.getClass().getName()
+        )));
+      }
     } catch (Exception e) {
       log.error("Error initializing query in session {}", session.getId(), e);
       closeSession(session, new CloseReason(
           CloseCodes.UNEXPECTED_CONDITION,
           "error initializing query"
       ));
-      closeAndRemoveQuery();
     }
   }
 
-  private void closeAndRemoveQuery() {
-    if (queryMetadata != null) {
-      log.info("Terminating query {}", queryMetadata.getQueryApplicationId());
-      queryMetadata.close();
-      ksqlEngine.removeTemporaryQuery(queryMetadata);
-    }
-  }
-
-  private static void closeSession(Session session, CloseReason reason) {
+  static void closeSession(Session session, CloseReason reason) {
     try {
       session.close(reason);
     } catch (IOException e) {
@@ -216,19 +175,20 @@ public class WSQueryEndpoint {
 
   @OnClose
   public void onClose(Session session, CloseReason closeReason) {
+    if (subscriber != null) {
+      subscriber.close();
+    }
     log.debug(
         "Closing websocket session {} ({}): {}",
         session.getId(),
         closeReason.getCloseCode(),
         closeReason.getReasonPhrase()
     );
-    if (future != null) {
-      future.cancel(true);
-    }
   }
 
   @OnError
   public void onError(Session session, Throwable t) {
     log.error("websocket error in session {}", session.getId(), t);
   }
+
 }

--- a/ksql-rest-app/src/main/java/io/confluent/ksql/rest/server/resources/streaming/WebSocketSubscriber.java
+++ b/ksql-rest-app/src/main/java/io/confluent/ksql/rest/server/resources/streaming/WebSocketSubscriber.java
@@ -1,0 +1,111 @@
+/**
+ * Copyright 2018 Confluent Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ **/
+
+package io.confluent.ksql.rest.server.resources.streaming;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+import org.apache.kafka.connect.data.Schema;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.IOException;
+import java.util.Collection;
+
+import javax.websocket.CloseReason;
+import javax.websocket.CloseReason.CloseCodes;
+import javax.websocket.Session;
+
+import static io.confluent.ksql.rest.server.resources.streaming.WSQueryEndpoint.closeSession;
+
+class WebSocketSubscriber<T> implements Flow.Subscriber<Collection<T>>, AutoCloseable {
+
+  private static final Logger log = LoggerFactory.getLogger(WebSocketSubscriber.class);
+  private final Session session;
+  private final ObjectMapper mapper;
+
+  private Flow.Subscription subscription;
+
+  public WebSocketSubscriber(Session session, ObjectMapper mapper) {
+    this.session = session;
+    this.mapper = mapper;
+  }
+
+  public void onSubscribe(Flow.Subscription subscription) {
+    this.subscription = subscription;
+    subscription.request(1);
+  }
+
+  @Override
+  public void onNext(Collection<T> rows) {
+    for (T row : rows) {
+      try {
+        String buffer = mapper.writeValueAsString(row);
+        session.getAsyncRemote().sendText(
+            buffer, result -> {
+              if (!result.isOK() && session.isOpen()) {
+                log.warn(
+                    "Error sending websocket message for session {}",
+                    session.getId(),
+                    result.getException()
+                );
+              }
+            });
+
+      } catch (JsonProcessingException e) {
+        log.warn("Error serializing row in session {}", session.getId(), e);
+      }
+    }
+    subscription.request(1);
+  }
+
+  @Override
+  public void onError(Throwable e) {
+    log.error("error in session {}", session.getId(), e);
+    closeSession(session, new CloseReason(
+        CloseCodes.UNEXPECTED_CONDITION,
+        "streams exception"
+    ));
+  }
+
+  @Override
+  public void onComplete() {
+    closeSession(session, new CloseReason(CloseCodes.NORMAL_CLOSURE, "done"));
+  }
+
+  @Override
+  public void onSchema(Schema schema) {
+    try {
+      session.getBasicRemote().sendText(
+          mapper.writeValueAsString(schema)
+      );
+    } catch (IOException e) {
+      log.error("Error sending schema", e);
+      closeSession(session, new CloseReason(
+          CloseCodes.PROTOCOL_ERROR,
+          "Unable to send schema"
+      ));
+    }
+  }
+
+  @Override
+  public void close() {
+    if (subscription != null) {
+      subscription.cancel();
+    }
+  }
+}

--- a/ksql-rest-app/src/main/java/io/confluent/ksql/rest/server/resources/streaming/WebSocketSubscriber.java
+++ b/ksql-rest-app/src/main/java/io/confluent/ksql/rest/server/resources/streaming/WebSocketSubscriber.java
@@ -54,6 +54,8 @@ class WebSocketSubscriber<T> implements Flow.Subscriber<Collection<T>>, AutoClos
   @Override
   public void onNext(Collection<T> rows) {
     for (T row : rows) {
+      // check if session is closed inside the loop to avoid
+      // logging too many async callback errors after close
       if (!closed) {
         try {
           String buffer = mapper.writeValueAsString(row);
@@ -73,7 +75,9 @@ class WebSocketSubscriber<T> implements Flow.Subscriber<Collection<T>>, AutoClos
         }
       }
     }
-    subscription.request(1);
+    if (!closed) {
+      subscription.request(1);
+    }
   }
 
   @Override

--- a/ksql-rest-app/src/test/java/io/confluent/ksql/rest/server/resources/streaming/PollingSubscriptionTest.java
+++ b/ksql-rest-app/src/test/java/io/confluent/ksql/rest/server/resources/streaming/PollingSubscriptionTest.java
@@ -1,0 +1,279 @@
+/**
+ * Copyright 2018 Confluent Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ **/
+
+package io.confluent.ksql.rest.server.resources.streaming;
+
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.Lists;
+import com.google.common.util.concurrent.MoreExecutors;
+
+import org.apache.kafka.connect.data.Schema;
+import org.apache.kafka.connect.data.SchemaBuilder;
+import org.junit.Test;
+
+import java.util.List;
+import java.util.Queue;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.Executors;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.TimeUnit;
+
+import io.confluent.ksql.rest.server.resources.streaming.Flow.Subscriber;
+import io.confluent.ksql.rest.server.resources.streaming.Flow.Subscription;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+
+
+public class PollingSubscriptionTest {
+
+  private static final ImmutableList<String> ELEMENTS = ImmutableList.of("a", "b", "c", "d", "e", "f");
+  private final ScheduledExecutorService multithreadedExec = Executors.newScheduledThreadPool(8);
+  final ScheduledExecutorService exec = Executors.newSingleThreadScheduledExecutor();
+
+  private static class TestSubscriber implements Subscriber<String> {
+
+    CountDownLatch done = new CountDownLatch(1);
+    Throwable error = null;
+    List<String> elements = Lists.newLinkedList();
+    Schema schema = null;
+    Subscription subscription;
+
+    @Override
+    public void onNext(String item) {
+      if (done.getCount() == 0) {
+        throw new IllegalStateException("already done");
+      }
+      elements.add(item);
+      subscription.request(1);
+    }
+
+    @Override
+    public void onError(Throwable e) {
+      if (done.getCount() == 0) {
+        throw new IllegalStateException("already done");
+      }
+      error = e;
+      done.countDown();
+    }
+
+    @Override
+    public void onComplete() {
+      if (done.getCount() == 0) {
+        throw new IllegalStateException("already done");
+      }
+      done.countDown();
+    }
+
+    @Override
+    public void onSchema(Schema s) {
+      if (done.getCount() == 0) {
+        throw new IllegalStateException("already done");
+      }
+      schema = s;
+    }
+
+    @Override
+    public void onSubscribe(Subscription subscription) {
+      this.subscription = subscription;
+      subscription.request(1);
+    }
+  }
+
+
+  class TestPublisher implements Flow.Publisher<String> {
+    TestPollingSubscription subscription;
+
+    @Override
+    public void subscribe(Subscriber<String> subscriber) {
+      subscription = createSubscription(subscriber);
+      subscriber.onSubscribe(subscription);
+    }
+
+    TestPollingSubscription createSubscription(Subscriber<String> subscriber) {
+      return new TestPollingSubscription(subscriber, exec);
+    }
+  }
+
+  static class TestPollingSubscription extends PollingSubscription<String> {
+    boolean closed;
+    Queue<String> queue = Lists.newLinkedList(ELEMENTS);
+
+    public TestPollingSubscription(Subscriber<String> subscriber, ScheduledExecutorService exec) {
+      super(
+          MoreExecutors.listeningDecorator(exec),
+          subscriber,
+          SchemaBuilder.STRING_SCHEMA
+      );
+    }
+
+    @Override
+    String poll() {
+      String value = queue.poll();
+      if (value != null) {
+        return value;
+      } else {
+        setDone();
+        return null;
+      }
+    }
+
+    @Override
+    synchronized void close() {
+      if (closed) {
+        fail("closed called more than once");
+      }
+      closed = true;
+    }
+  }
+
+  @Test
+  public void testBasicFlow() throws Exception {
+    TestSubscriber testSubscriber = new TestSubscriber();
+    TestPublisher testPublisher = new TestPublisher();
+    testPublisher.subscribe(testSubscriber);
+
+    assertTrue(testSubscriber.done.await(1000, TimeUnit.MILLISECONDS));
+    assertTrue(exec.shutdownNow().isEmpty());
+
+    assertTrue(testPublisher.subscription.closed);
+    assertNull(testSubscriber.error);
+    assertNotNull(testSubscriber.schema);
+    assertEquals(ELEMENTS, testSubscriber.elements);
+  }
+
+  @Test
+  public void testErrorDrainsNextElement() throws Exception {
+    TestSubscriber testSubscriber = new TestSubscriber();
+    TestPublisher testPublisher = new TestPublisher() {
+      @Override
+      TestPollingSubscription createSubscription(
+          Subscriber<String> subscriber
+      ) {
+        return new TestPollingSubscription(subscriber, exec) {
+          @Override
+          String poll() {
+            // return one element, then set error
+            String value = super.poll();
+            if (value != null) {
+              setError(new RuntimeException("something bad"));
+              return value;
+            }
+            return null;
+          }
+        };
+      }
+    };
+
+    testPublisher.subscribe(testSubscriber);
+
+    assertTrue(testSubscriber.done.await(1000, TimeUnit.MILLISECONDS));
+    assertTrue(exec.shutdownNow().isEmpty());
+
+    assertTrue(testPublisher.subscription.closed);
+    assertNotNull(testSubscriber.error);
+    assertEquals(ImmutableList.of("a", "b"), testSubscriber.elements);
+  }
+
+  @Test
+  public void testMultithreaded() throws Exception {
+    TestSubscriber testSubscriber = new TestSubscriber();
+    TestPublisher testPublisher = new TestPublisher() {
+      @Override
+      TestPollingSubscription createSubscription(
+          Subscriber<String> subscriber
+      ) {
+        return new TestPollingSubscription(subscriber, multithreadedExec);
+      }
+    };
+    testPublisher.subscribe(testSubscriber);
+
+    assertTrue(testSubscriber.done.await(1000, TimeUnit.MILLISECONDS));
+    assertTrue(multithreadedExec.shutdownNow().isEmpty());
+
+    assertTrue(testPublisher.subscription.closed);
+    assertNull(testSubscriber.error);
+    assertNotNull(testSubscriber.schema);
+    assertEquals(ELEMENTS, testSubscriber.elements);
+  }
+
+  @Test
+  public void testReentrantNextElement() throws Exception {
+    TestSubscriber testSubscriber = new TestSubscriber();
+    TestPublisher testPublisher = new TestPublisher() {
+      @Override
+      TestPollingSubscription createSubscription(
+          Subscriber<String> subscriber
+      ) {
+        return new TestPollingSubscription(subscriber, multithreadedExec) {
+          String nextValue;
+
+          @Override
+          String poll() {
+            // set Error, then return last element
+            String value = super.poll();
+            if (nextValue == null) {
+              nextValue = value;
+              setError(new RuntimeException("something bad"));
+              return null;
+            }
+            return nextValue;
+          }
+        };
+      }
+    };
+
+    testPublisher.subscribe(testSubscriber);
+
+    assertTrue(testSubscriber.done.await(1000, TimeUnit.MILLISECONDS));
+    assertTrue(multithreadedExec.shutdownNow().isEmpty());
+
+    assertTrue(testPublisher.subscription.closed);
+    assertNotNull(testSubscriber.error);
+    assertEquals(ImmutableList.of("a"), testSubscriber.elements);
+  }
+
+  @Test
+  public void testEmpty() throws Exception {
+    TestSubscriber testSubscriber = new TestSubscriber();
+    TestPublisher testPublisher = new TestPublisher() {
+      @Override
+      TestPollingSubscription createSubscription(
+          Subscriber<String> subscriber
+      ) {
+        return new TestPollingSubscription(subscriber, exec) {
+          @Override
+          String poll() {
+            setDone();
+            return null;
+          }
+        };
+      }
+    };
+
+    testPublisher.subscribe(testSubscriber);
+
+    assertTrue(testSubscriber.done.await(1000, TimeUnit.MILLISECONDS));
+    assertTrue(exec.shutdownNow().isEmpty());
+
+    assertTrue(testPublisher.subscription.closed);
+    assertNull(testSubscriber.error);
+    assertEquals(ImmutableList.of(), testSubscriber.elements);
+  }
+}

--- a/ksql-rest-app/src/test/java/io/confluent/ksql/rest/server/resources/streaming/PollingSubscriptionTest.java
+++ b/ksql-rest-app/src/test/java/io/confluent/ksql/rest/server/resources/streaming/PollingSubscriptionTest.java
@@ -276,4 +276,16 @@ public class PollingSubscriptionTest {
     assertNull(testSubscriber.error);
     assertEquals(ImmutableList.of(), testSubscriber.elements);
   }
+
+  @Test(expected = IllegalArgumentException.class)
+  public void testExpectsNEqualsOne() {
+    TestSubscriber testSubscriber = new TestSubscriber() {
+      @Override
+      public void onSubscribe(Subscription subscription) {
+        subscription.request(2);
+      }
+    };
+    TestPublisher testPublisher = new TestPublisher();
+    testPublisher.subscribe(testSubscriber);
+  }
 }

--- a/ksql-rest-app/src/test/java/io/confluent/ksql/rest/server/resources/streaming/TopicStreamTest.java
+++ b/ksql-rest-app/src/test/java/io/confluent/ksql/rest/server/resources/streaming/TopicStreamTest.java
@@ -1,7 +1,5 @@
 package io.confluent.ksql.rest.server.resources.streaming;
 
-import io.confluent.kafka.schemaregistry.client.SchemaRegistryClient;
-import io.confluent.kafka.serializers.KafkaAvroSerializer;
 import org.apache.avro.Schema;
 import org.apache.avro.generic.GenericData;
 import org.apache.kafka.clients.consumer.ConsumerRecord;
@@ -11,11 +9,20 @@ import org.junit.Test;
 import java.util.HashMap;
 import java.util.Map;
 
-import static org.easymock.EasyMock.*;
+import io.confluent.kafka.schemaregistry.client.SchemaRegistryClient;
+import io.confluent.kafka.serializers.KafkaAvroSerializer;
+import io.confluent.ksql.rest.server.resources.streaming.TopicStream.Format;
+
+import static org.easymock.EasyMock.anyInt;
+import static org.easymock.EasyMock.anyObject;
+import static org.easymock.EasyMock.anyString;
+import static org.easymock.EasyMock.expect;
+import static org.easymock.EasyMock.mock;
+import static org.easymock.EasyMock.replay;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 
-public class TopicStreamWriterFormatTest {
+public class TopicStreamTest {
 
   @Test
   public void shouldMatchAvroFormatter() throws Exception {
@@ -60,7 +67,7 @@ public class TopicStreamWriterFormatTest {
 
     /** Assert
      */
-    assertTrue(TopicStream.Format.AVRO.isFormat("topic", record, schemaRegistryClient));
+    assertTrue(Format.AVRO.isFormat("topic", record, schemaRegistryClient));
   }
 
   @Test
@@ -79,7 +86,7 @@ public class TopicStreamWriterFormatTest {
 
     /** Assert
      */
-    assertFalse(TopicStream.Format.AVRO.isFormat("topic", record, schemaRegistryClient));
+    assertFalse(Format.AVRO.isFormat("topic", record, schemaRegistryClient));
   }
 
   @Test
@@ -97,7 +104,7 @@ public class TopicStreamWriterFormatTest {
 
     ConsumerRecord<String, Bytes> record = new ConsumerRecord<String, Bytes>("topic", 1, 1, "key", new Bytes(json.getBytes()));
 
-    assertTrue(TopicStream.Format.JSON.isFormat("topic", record, schemaRegistryClient));
+    assertTrue(Format.JSON.isFormat("topic", record, schemaRegistryClient));
   }
 
   @Test
@@ -116,6 +123,6 @@ public class TopicStreamWriterFormatTest {
     ConsumerRecord<String, Bytes> record = new ConsumerRecord<String, Bytes>("topic", 1, 1, "key", new Bytes(json.getBytes()));
 
 
-    assertFalse(TopicStream.Format.JSON.isFormat("topic", record, schemaRegistryClient));
+    assertFalse(Format.JSON.isFormat("topic", record, schemaRegistryClient));
   }
 }

--- a/ksql-rest-app/src/test/java/io/confluent/ksql/rest/server/resources/streaming/TopicStreamWriterFormatTest.java
+++ b/ksql-rest-app/src/test/java/io/confluent/ksql/rest/server/resources/streaming/TopicStreamWriterFormatTest.java
@@ -60,7 +60,7 @@ public class TopicStreamWriterFormatTest {
 
     /** Assert
      */
-    assertTrue(TopicStreamWriter.Format.AVRO.isFormat("topic", record, schemaRegistryClient));
+    assertTrue(TopicStream.Format.AVRO.isFormat("topic", record, schemaRegistryClient));
   }
 
   @Test
@@ -79,7 +79,7 @@ public class TopicStreamWriterFormatTest {
 
     /** Assert
      */
-    assertFalse(TopicStreamWriter.Format.AVRO.isFormat("topic", record, schemaRegistryClient));
+    assertFalse(TopicStream.Format.AVRO.isFormat("topic", record, schemaRegistryClient));
   }
 
   @Test
@@ -97,7 +97,7 @@ public class TopicStreamWriterFormatTest {
 
     ConsumerRecord<String, Bytes> record = new ConsumerRecord<String, Bytes>("topic", 1, 1, "key", new Bytes(json.getBytes()));
 
-    assertTrue(TopicStreamWriter.Format.JSON.isFormat("topic", record, schemaRegistryClient));
+    assertTrue(TopicStream.Format.JSON.isFormat("topic", record, schemaRegistryClient));
   }
 
   @Test
@@ -116,6 +116,6 @@ public class TopicStreamWriterFormatTest {
     ConsumerRecord<String, Bytes> record = new ConsumerRecord<String, Bytes>("topic", 1, 1, "key", new Bytes(json.getBytes()));
 
 
-    assertFalse(TopicStreamWriter.Format.JSON.isFormat("topic", record, schemaRegistryClient));
+    assertFalse(TopicStream.Format.JSON.isFormat("topic", record, schemaRegistryClient));
   }
 }

--- a/ksql-rest-app/src/test/java/io/confluent/ksql/rest/server/resources/streaming/WebSocketSubscriberTest.java
+++ b/ksql-rest-app/src/test/java/io/confluent/ksql/rest/server/resources/streaming/WebSocketSubscriberTest.java
@@ -1,0 +1,191 @@
+/**
+ * Copyright 2018 Confluent Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ **/
+
+package io.confluent.ksql.rest.server.resources.streaming;
+
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+import org.apache.kafka.connect.data.SchemaBuilder;
+import org.easymock.Capture;
+import org.easymock.CaptureType;
+import org.easymock.EasyMock;
+import org.junit.Test;
+
+import java.io.IOException;
+import java.util.Map;
+
+import javax.websocket.CloseReason;
+import javax.websocket.CloseReason.CloseCodes;
+import javax.websocket.RemoteEndpoint.Async;
+import javax.websocket.RemoteEndpoint.Basic;
+import javax.websocket.Session;
+
+import io.confluent.ksql.rest.entity.SchemaMapper;
+import io.confluent.ksql.rest.server.resources.streaming.Flow.Subscription;
+
+import static org.junit.Assert.assertEquals;
+
+public class WebSocketSubscriberTest {
+
+  @Test
+  public void testSanity() throws Exception {
+    Session session = EasyMock.mock(Session.class);
+    Async async = EasyMock.mock(Async.class);
+
+    WebSocketSubscriber<Map<String, Object>> subscriber = new WebSocketSubscriber<>(session, new ObjectMapper());
+
+    Subscription subscription = EasyMock.mock(Subscription.class);
+
+    subscription.request(1);
+    EasyMock.expectLastCall().once();
+    EasyMock.replay(subscription);
+
+    subscriber.onSubscribe(subscription);
+
+    EasyMock.verify(subscription);
+
+    EasyMock.reset(subscription, session, async);
+
+    EasyMock.expect(session.getAsyncRemote()).andReturn(async).anyTimes();
+    Capture<String> json = EasyMock.newCapture(CaptureType.ALL);
+    async.sendText(EasyMock.capture(json), EasyMock.anyObject());
+    EasyMock.expectLastCall().times(3);
+
+    subscription.request(1);
+    EasyMock.expectLastCall().once();
+
+    session.close(EasyMock.anyObject());
+    EasyMock.expectLastCall().once();
+    subscription.cancel();
+
+    EasyMock.replay(subscription, session, async);
+    subscriber.onNext(ImmutableList.of(ImmutableMap.of("a", 1), ImmutableMap.of("b", 2), ImmutableMap.of("c", 3)));
+    assertEquals(ImmutableList.of("{\"a\":1}","{\"b\":2}","{\"c\":3}"), json.getValues());
+    subscriber.onComplete();
+    subscriber.close();
+
+    EasyMock.verify(subscription, session, async);
+  }
+
+  @Test
+  public void testStopSendingAfterClose() throws Exception {
+    Session session = EasyMock.mock(Session.class);
+    Async async = EasyMock.mock(Async.class);
+
+    WebSocketSubscriber<Map<String, Object>> subscriber = new WebSocketSubscriber<>(session, new ObjectMapper());
+    Subscription subscription = EasyMock.mock(Subscription.class);
+
+    subscription.request(1);
+    EasyMock.expectLastCall().once();
+    EasyMock.replay(subscription);
+    subscriber.onSubscribe(subscription);
+    EasyMock.verify(subscription);
+    EasyMock.reset(subscription, session, async);
+
+    EasyMock.expect(session.getAsyncRemote()).andReturn(async).anyTimes();
+    Capture<String> json = EasyMock.newCapture(CaptureType.ALL);
+    async.sendText(EasyMock.capture(json), EasyMock.anyObject());
+    subscription.request(1);
+    subscription.cancel();
+
+    EasyMock.replay(subscription, session, async);
+    subscriber.onNext(ImmutableList.of(ImmutableMap.of("a", 1)));
+    subscriber.close();
+    subscriber.onNext(ImmutableList.of(ImmutableMap.of("b", 2), ImmutableMap.of("c", 3)));
+    assertEquals(ImmutableList.of("{\"a\":1}"), json.getValues());
+
+    EasyMock.verify(subscription, session, async);
+  }
+
+
+  @Test
+  public void testOnSchema() throws Exception {
+    Session session = EasyMock.mock(Session.class);
+    Basic basic = EasyMock.mock(Basic.class);
+    ObjectMapper mapper = new ObjectMapper();
+    new SchemaMapper().registerToObjectMapper(mapper);
+
+    WebSocketSubscriber<Map<String, Object>> subscriber = new WebSocketSubscriber<>(session, mapper);
+    Subscription subscription = EasyMock.mock(Subscription.class);
+
+    subscription.request(1);
+    EasyMock.expectLastCall().once();
+
+    EasyMock.replay(subscription);
+    subscriber.onSubscribe(subscription);
+    EasyMock.verify(subscription);
+    EasyMock.reset(subscription);
+
+    session.getBasicRemote();
+    EasyMock.expectLastCall().andReturn(basic).once();
+    Capture<String> schema = EasyMock.newCapture();
+    basic.sendText(EasyMock.capture(schema));
+    EasyMock.expectLastCall().andThrow(new IOException("bad bad io")).once();
+
+    Capture<CloseReason> reason = EasyMock.newCapture();
+    session.close(EasyMock.capture(reason));
+    subscription.cancel();
+
+    EasyMock.replay(subscription, session, basic);
+
+    subscriber.onSchema(SchemaBuilder.struct().build());
+    subscriber.close();
+
+    assertEquals("{\"type\":\"struct\",\"fields\":[],\"optional\":false}", schema.getValue());
+    assertEquals("Unable to send schema", reason.getValue().getReasonPhrase());
+    assertEquals(CloseCodes.PROTOCOL_ERROR, reason.getValue().getCloseCode());
+
+    EasyMock.verify(subscription, session, basic);
+  }
+
+  @Test
+  public void testOnError() throws Exception {
+    Session session = EasyMock.mock(Session.class);
+    ObjectMapper mapper = new ObjectMapper();
+    new SchemaMapper().registerToObjectMapper(mapper);
+
+    WebSocketSubscriber<Map<String, Object>> subscriber = new WebSocketSubscriber<>(session, mapper);
+    Subscription subscription = EasyMock.mock(Subscription.class);
+
+    subscription.request(1);
+    EasyMock.expectLastCall().once();
+
+    EasyMock.replay(subscription);
+    subscriber.onSubscribe(subscription);
+    EasyMock.verify(subscription);
+    EasyMock.reset(subscription);
+
+    Capture<CloseReason> reason = EasyMock.newCapture();
+    EasyMock.expect(session.getId()).andReturn("abc123").once();
+    session.close(EasyMock.capture(reason));
+    EasyMock.expectLastCall().once();
+    subscription.cancel();
+    EasyMock.expectLastCall().once();
+
+    EasyMock.replay(subscription, session);
+
+    subscriber.onError(new RuntimeException("streams died"));
+    subscriber.close();
+
+    assertEquals("streams exception", reason.getValue().getReasonPhrase());
+    assertEquals(CloseCodes.UNEXPECTED_CONDITION, reason.getValue().getCloseCode());
+
+    EasyMock.verify(subscription, session);
+  }
+}


### PR DESCRIPTION
Refactors the websocket endpoint to not pause between batches of data and drain the queue on error
Uses constructs loosely borrowed from the jdk9 Flow (aka reactive-streams) api