### PR TITLE
Remove deprecated punctuate

### DIFF
--- a/ksql-engine/src/main/java/io/confluent/ksql/physical/AddTimestampColumn.java
+++ b/ksql-engine/src/main/java/io/confluent/ksql/physical/AddTimestampColumn.java
@@ -41,11 +41,6 @@ public class AddTimestampColumn implements ValueTransformerSupplier<GenericRow, 
       }
 
       @Override
-      public GenericRow punctuate(long l) {
-        return null;
-      }
-
-      @Override
       public void close() {
       }
     };


### PR DESCRIPTION
punctuate is removed in ValueTransformer in https://github.com/apache/kafka/pull/4993

### Reviewer checklist
- [ ] Ensure docs are updated if necessary. (eg. if a user visible feature is being added or changed).
- [ ] Ensure relevant issues are linked (description should include text like "Fixes #<issue number>")

