### PR TITLE
Minor: Admin client leak

### DIFF
--- a/ksql-cli/src/test/java/io/confluent/ksql/CliTest.java
+++ b/ksql-cli/src/test/java/io/confluent/ksql/CliTest.java
@@ -104,6 +104,7 @@ public class CliTest extends TestRunner {
 
   private static OrderDataProvider orderDataProvider;
   private static int result_stream_no = 0;
+  private static KsqlRestApplication restServer;
 
   @BeforeClass
   public static void setUp() throws Exception {
@@ -122,8 +123,8 @@ public class CliTest extends TestRunner {
     orderDataProvider = new OrderDataProvider();
     CLUSTER.createTopic(orderDataProvider.topicName());
 
-    KsqlRestApplication restServer = KsqlRestApplication.buildApplication(restServerConfig, false,
-        EasyMock.mock(VersionCheckerAgent.class)
+    restServer = KsqlRestApplication.buildApplication(restServerConfig, false,
+                                                      EasyMock.mock(VersionCheckerAgent.class)
     );
 
     restServer.start();
@@ -179,6 +180,7 @@ public class CliTest extends TestRunner {
 
     localCli.close();
     terminal.close();
+    restServer.stop();
   }
 
   private static Map<String, Object> genDefaultConfigMap() {

--- a/ksql-cli/src/test/java/io/confluent/ksql/CliTest.java
+++ b/ksql-cli/src/test/java/io/confluent/ksql/CliTest.java
@@ -161,8 +161,8 @@ public class CliTest extends TestRunner {
 
   private static void testListOrShowCommands() {
     TestResult.OrderedResult testResult = (TestResult.OrderedResult) TestResult.init(true);
-    testResult.addRows(Arrays.asList(Arrays.asList(orderDataProvider.topicName(), "false", "1",
-                                                   "1", "0", "0")));
+    testResult.addRows(Collections.singletonList(Arrays.asList(orderDataProvider.topicName(), "false", "1",
+                                                "1", "0", "0")));
     testListOrShow("topics", testResult);
     testListOrShow("registered topics", build(COMMANDS_KSQL_TOPIC_NAME, commandTopicName, "JSON"));
     testListOrShow("streams", EMPTY_RESULT);
@@ -213,13 +213,12 @@ public class CliTest extends TestRunner {
     startConfigs.put(KSQL_SERVICE_ID_CONFIG, KSQL_SERVICE_ID_DEFAULT);
     startConfigs.put(KSQL_TABLE_STATESTORE_NAME_SUFFIX_CONFIG, KSQL_TABLE_STATESTORE_NAME_SUFFIX_DEFAULT);
     startConfigs.put(KSQL_PERSISTENT_QUERY_NAME_PREFIX_CONFIG, KSQL_PERSISTENT_QUERY_NAME_PREFIX_DEFAULT);
-    startConfigs.put(StreamsConfig.DEFAULT_DESERIALIZATION_EXCEPTION_HANDLER_CLASS_CONFIG,  "org.apache.kafka.streams.errors.LogAndContinueExceptionHandler");
     startConfigs.put(KsqlConfig.SCHEMA_REGISTRY_URL_PROPERTY, KsqlConfig.defaultSchemaRegistryUrl);
     startConfigs.put(StreamsConfig.DEFAULT_DESERIALIZATION_EXCEPTION_HANDLER_CLASS_CONFIG, LogMetricAndContinueExceptionHandler.class.getName());
     return startConfigs;
   }
 
-  private static void testCreateStreamAsSelect(String selectQuery, Schema resultSchema, Map<String, GenericRow> expectedResults) throws Exception {
+  private static void testCreateStreamAsSelect(String selectQuery, Schema resultSchema, Map<String, GenericRow> expectedResults) {
     if (!selectQuery.endsWith(";")) {
       selectQuery += ";";
     }
@@ -260,9 +259,7 @@ public class CliTest extends TestRunner {
   @Test
   public void testPrint() throws InterruptedException {
 
-    Thread wait = new Thread(() -> {
-        CliTest.this.run("print 'ORDER_TOPIC' FROM BEGINNING INTERVAL 2;", false);
-    });
+    Thread wait = new Thread(() -> run("print 'ORDER_TOPIC' FROM BEGINNING INTERVAL 2;", false));
 
     wait.start();
     Thread.sleep(1000);
@@ -308,7 +305,7 @@ public class CliTest extends TestRunner {
   }
 
   @Test
-  public void testSelectStar() throws Exception {
+  public void testSelectStar() {
     testCreateStreamAsSelect(
         "SELECT * FROM " + orderDataProvider.kstreamName(),
         orderDataProvider.schema(),
@@ -317,7 +314,7 @@ public class CliTest extends TestRunner {
   }
 
   @Test
-  public void testSelectProject() throws Exception {
+  public void testSelectProject() {
     Map<String, GenericRow> expectedResults = new HashMap<>();
     expectedResults.put("1", new GenericRow(Arrays.asList("ITEM_1", 10.0, new
         Double[]{100.0,
@@ -372,7 +369,7 @@ public class CliTest extends TestRunner {
   }
 
   @Test
-  public void testSelectFilter() throws Exception {
+  public void testSelectFilter() {
     Map<String, GenericRow> expectedResults = new HashMap<>();
     Map<String, Double> mapField = new HashMap<>();
     mapField.put("key1", 1.0);

--- a/ksql-engine/src/main/java/io/confluent/ksql/util/KafkaConsumerGroupClientImpl.java
+++ b/ksql-engine/src/main/java/io/confluent/ksql/util/KafkaConsumerGroupClientImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2018 Confluent Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -90,11 +90,10 @@ public class KafkaConsumerGroupClientImpl implements KafkaConsumerGroupClient {
     Map<String, Object> clientConfigProps = ksqlConfig.getKsqlAdminClientConfigProps();
     try {
       File tmpConfigFile = flushPropertiesToTempFile(clientConfigProps);
-      String[] args = {
+      return new String[]{
           "--bootstrap-server", (String) clientConfigProps.get("bootstrap.servers"),
           "--command-config", tmpConfigFile.getAbsolutePath()
       };
-      return args;
     } catch (IOException e) {
       log.error("Could not configure the list groups command.", e);
       throw new KsqlException("Could not list groups", e);

--- a/ksql-engine/src/main/java/io/confluent/ksql/util/KafkaConsumerGroupClientImpl.java
+++ b/ksql-engine/src/main/java/io/confluent/ksql/util/KafkaConsumerGroupClientImpl.java
@@ -68,13 +68,18 @@ public class KafkaConsumerGroupClientImpl implements KafkaConsumerGroupClient {
         new ConsumerGroupCommand.ConsumerGroupCommandOptions(args);
     ConsumerGroupCommand.KafkaConsumerGroupService consumerGroupService =
         new ConsumerGroupCommand.KafkaConsumerGroupService(opts);
-    scala.collection.immutable.List<String> consumerGroups = consumerGroupService.listGroups();
-    scala.collection.Iterator<String> consumerGroupsIterator = consumerGroups.iterator();
-    ArrayList<String> results = new ArrayList<>();
-    while (consumerGroupsIterator.hasNext()) {
-      results.add(consumerGroupsIterator.next());
+
+    try {
+      scala.collection.immutable.List<String> consumerGroups = consumerGroupService.listGroups();
+      scala.collection.Iterator<String> consumerGroupsIterator = consumerGroups.iterator();
+      ArrayList<String> results = new ArrayList<>();
+      while (consumerGroupsIterator.hasNext()) {
+        results.add(consumerGroupsIterator.next());
+      }
+      return results;
+    } finally {
+      consumerGroupService.close();
     }
-    return results;
   }
 
   private String[] consumerGroupCommandOptions() {

--- a/ksql-rest-app/src/main/java/io/confluent/ksql/rest/server/KsqlRestApplication.java
+++ b/ksql-rest-app/src/main/java/io/confluent/ksql/rest/server/KsqlRestApplication.java
@@ -148,7 +148,7 @@ public class KsqlRestApplication extends Application<KsqlRestConfig> implements 
     this.versionCheckerAgent = versionCheckerAgent;
     this.serverInfo = serverInfo;
 
-    this.commandRunnerThread = new Thread(commandRunner);
+    this.commandRunnerThread = new Thread(commandRunner, "CommandRunner");
 
     final String ksqlInstallDir = config.getString(KsqlRestConfig.INSTALL_DIR_CONFIG);
     this.uiFolder = isUiEnabled ? ksqlInstallDir + "/ui" : null;


### PR DESCRIPTION
- Fixes a leak of an `AdminClient` instance on the `list topics;` statement.
- Fixes a resource leak in the `CliTest`
- Fixes a load of code warnings, (in separate commit).