### PR TITLE
The DESCRIBE ACL on the __consumer_offsets topic is not required.

### DIFF
--- a/docs/installation/server-config/security.rst
+++ b/docs/installation/server-config/security.rst
@@ -170,7 +170,6 @@ Standard ACLs
     The authenticated KSQL user always requires:
 
     - ``DESCRIBE_CONFIGS`` permission on the ``CLUSTER`` resource type.
-    - ``DESCRIBE`` permission on the ``__consumer_offsets`` topic.
 
 Input topics
     An input topic is one that has been imported into KSQL using a ``CREATE STREAM`` or ``CREATE TABLE``

--- a/ksql-engine/src/test/java/io/confluent/ksql/integration/SecureIntegrationTest.java
+++ b/ksql-engine/src/test/java/io/confluent/ksql/integration/SecureIntegrationTest.java
@@ -189,9 +189,6 @@ public class SecureIntegrationTest {
     givenAllowAcl(NORMAL_USER, ResourceType.TOPIC, INPUT_TOPIC,
                   ImmutableSet.of(AclOperation.DESCRIBE, AclOperation.READ));
 
-    givenAllowAcl(NORMAL_USER, ResourceType.TOPIC, "__consumer_offsets",
-                  ImmutableSet.of(AclOperation.DESCRIBE));
-
     givenAllowAcl(NORMAL_USER, ResourceType.TOPIC, outputTopic,
                   ImmutableSet.of(AclOperation.DESCRIBE, AclOperation.WRITE));
 
@@ -237,9 +234,6 @@ public class SecureIntegrationTest {
     givenAllowAcl(NORMAL_USER, ResourceType.TOPIC, INPUT_TOPIC,
                   ImmutableSet.of(AclOperation.DESCRIBE, AclOperation.READ));
 
-    givenAllowAcl(NORMAL_USER, ResourceType.TOPIC, "__consumer_offsets",
-                  ImmutableSet.of(AclOperation.DESCRIBE));
-
     givenAllowAcl(NORMAL_USER, ResourceType.TOPIC, outputTopic,
                   ImmutableSet.of(AclOperation.DESCRIBE, AclOperation.WRITE));
 
@@ -272,9 +266,6 @@ public class SecureIntegrationTest {
 
     givenAllowAcl(NORMAL_USER, ResourceType.TOPIC, INPUT_TOPIC,
                   ImmutableSet.of(AclOperation.DESCRIBE, AclOperation.READ));
-
-    givenAllowAcl(NORMAL_USER, ResourceType.TOPIC, "__consumer_offsets",
-                  ImmutableSet.of(AclOperation.DESCRIBE));
 
     givenAllowAcl(NORMAL_USER, ResourceType.TOPIC, outputTopic,
                   ImmutableSet.of(AclOperation.DESCRIBE, AclOperation.WRITE));


### PR DESCRIPTION
Update docs to reflect that the `DESCRIBE` ACL is _not_ required on the `__consumer_offsets` topics for KSQL to work.

Reviewed under https://github.com/confluentinc/ksql/pull/1252