### PR TITLE
Fix the clickstream demo

### DIFF
--- a/docs/syntax-reference.rst
+++ b/docs/syntax-reference.rst
@@ -547,33 +547,35 @@ Example of explaining a running query:
 
 .. _drop-stream:
 
-DROP STREAM
------------
+DROP STREAM [IF EXISTS]
+-----------------------
 
 **Synopsis**
 
 .. code:: sql
 
-    DROP STREAM stream_name;
+    DROP STREAM [IF EXISTS] stream_name;
 
 **Description**
 
-Drops an existing stream.
+* DROP STREAM: Drops an existing stream.
+* DROP STREAM IF EXISTS: Drops a stream. Does not fail if the stream does not exist.
 
 .. _drop-table:
 
-DROP TABLE
-----------
+DROP TABLE [IF EXISTS]
+----------------------
 
 **Synopsis**
 
 .. code:: sql
 
-    DROP TABLE table_name;
+    DROP TABLE [IF EXISTS] table_name;
 
 **Description**
 
-Drops an existing table.
+* DROP TABLE: Drops an existing table.
+* DROP TABLE IF EXISTS: Drops a table. Does not fail if the table does not exist.
 
 PRINT
 -----

--- a/ksql-clickstream-demo/demo/clickstream-analysis-dashboard.json
+++ b/ksql-clickstream-demo/demo/clickstream-analysis-dashboard.json
@@ -35,14 +35,6 @@
         "pluginName": "Elasticsearch"
       },
       {
-        "name": "events_per_min_max_avg",
-        "label": "events_per_min_max_avg",
-        "description": "",
-        "type": "datasource",
-        "pluginId": "elasticsearch",
-        "pluginName": "Elasticsearch"
-      },
-      {
         "name": "enriched_error_codes_count",
         "label": "enriched_error_codes_count",
         "description": "",
@@ -578,118 +570,6 @@
             "timeFrom": null,
             "timeShift": null,
             "title": "Page Views using LIKE filtering",
-            "tooltip": {
-              "shared": true,
-              "sort": 0,
-              "value_type": "individual"
-            },
-            "type": "graph",
-            "xaxis": {
-              "buckets": null,
-              "mode": "time",
-              "name": null,
-              "show": true,
-              "values": []
-            },
-            "yaxes": [
-              {
-                "format": "short",
-                "label": null,
-                "logBase": 1,
-                "max": null,
-                "min": null,
-                "show": true
-              },
-              {
-                "format": "short",
-                "label": null,
-                "logBase": 1,
-                "max": null,
-                "min": null,
-                "show": true
-              }
-            ]
-          },
-          {
-            "aliasColors": {},
-            "bars": false,
-            "dashLength": 10,
-            "dashes": false,
-            "datasource": "events_per_min_max_avg",
-            "fill": 1,
-            "id": 1,
-            "legend": {
-              "alignAsTable": true,
-              "avg": true,
-              "current": false,
-              "hideEmpty": false,
-              "hideZero": false,
-              "max": false,
-              "min": false,
-              "rightSide": false,
-              "show": true,
-              "total": true,
-              "values": true
-            },
-            "lines": true,
-            "linewidth": 1,
-            "links": [],
-            "nullPointMode": "null",
-            "percentage": false,
-            "pointradius": 3,
-            "points": false,
-            "renderer": "flot",
-            "seriesOverrides": [],
-            "spaceLength": 10,
-            "span": 6,
-            "stack": false,
-            "steppedLine": false,
-            "targets": [
-              {
-                "bucketAggs": [
-                  {
-                    "field": "EVENT_TS",
-                    "id": "2",
-                    "settings": {
-                      "interval": "10s",
-                      "min_doc_count": 0,
-                      "trimEdges": 0
-                    },
-                    "type": "date_histogram"
-                  }
-                ],
-                "dsType": "elasticsearch",
-                "metrics": [
-                  {
-                    "field": "MAX",
-                    "id": "1",
-                    "meta": {},
-                    "settings": {},
-                    "type": "avg"
-                  },
-                  {
-                    "field": "AVG",
-                    "id": "3",
-                    "meta": {},
-                    "settings": {},
-                    "type": "avg"
-                  },
-                  {
-                    "field": "MIN",
-                    "id": "4",
-                    "meta": {},
-                    "settings": {},
-                    "type": "avg"
-                  }
-                ],
-                "refId": "A",
-                "timeField": "EVENT_TS"
-              }
-            ],
-            "thresholds": [],
-            "timeFrom": null,
-            "timeShift": null,
-            "title": "Min Max  Avg events using UDFs",
             "tooltip": {
               "shared": true,
               "sort": 0,

--- a/ksql-clickstream-demo/demo/clickstream-schema.sql
+++ b/ksql-clickstream-demo/demo/clickstream-schema.sql
@@ -5,7 +5,7 @@ set 'auto.offset.reset'='earliest';
 
 
 -- 1. SOURCE of ClickStream
-DROP STREAM clickstream;
+DROP STREAM IF EXISTS clickstream;
 CREATE STREAM clickstream (_time bigint,time varchar, ip varchar, request varchar, status int, userid int, bytes bigint, agent varchar) with (kafka_topic = 'clickstream', value_format = 'json');
 
 
@@ -16,21 +16,16 @@ CREATE STREAM clickstream (_time bigint,time varchar, ip varchar, request varcha
 ----------------------------------------------------------------------------------------------------------------------------
 
  -- number of events per minute - think about key-for-distribution-purpose - shuffling etc - shouldnt use 'userid'
-DROP TABLE events_per_min;
+DROP TABLE IF EXISTS events_per_min;
 CREATE table events_per_min AS SELECT userid, count(*) AS events FROM clickstream window TUMBLING (size 60 second) GROUP BY userid;
-
--- VIEW
-DROP TABLE events_per_min_max_avg;
-CREATE TABLE events_per_min_max_avg AS SELECT userid, min(events) AS min, max(events) AS max, sum(events)/count(events) AS avg from events_per_min  WINDOW TUMBLING (size 60 second) GROUP BY userid;
-
 
 -- 3. BUILD STATUS_CODES
 -- static table
-DROP TABLE clickstream_codes;
+DROP TABLE IF EXISTS clickstream_codes;
 CREATE TABLE clickstream_codes (code int, definition varchar) with (key='code', kafka_topic = 'clickstream_codes', value_format = 'json');
 
 -- 4. BUILD PAGE_VIEWS
-DROP TABLE pages_per_min;
+DROP TABLE IF EXISTS pages_per_min;
 CREATE TABLE pages_per_min AS SELECT userid, count(*) AS pages FROM clickstream WINDOW HOPPING (size 60 second, advance by 5 second) WHERE request like '%html%' GROUP BY userid ;
 
 ----------------------------------------------------------------------------------------------------------------------------
@@ -40,15 +35,15 @@ CREATE TABLE pages_per_min AS SELECT userid, count(*) AS pages FROM clickstream 
 ----------------------------------------------------------------------------------------------------------------------------
 
 -- Use 'HAVING' Filter to show ERROR codes > 400 where count > 5
-DROP TABLE ERRORS_PER_MIN_ALERT;
+DROP TABLE IF EXISTS ERRORS_PER_MIN_ALERT;
 CREATE TABLE ERRORS_PER_MIN_ALERT AS SELECT status, count(*) AS errors FROM clickstream window HOPPING ( size 30 second, advance by 20 second) WHERE status > 400 GROUP BY status HAVING count(*) > 5 AND count(*) is not NULL;
 
-DROP TABLE ERRORS_PER_MIN;
+DROP TABLE IF EXISTS ERRORS_PER_MIN;
 CREATE table ERRORS_PER_MIN AS SELECT status, count(*) AS errors FROM clickstream window HOPPING ( size 60 second, advance by 5  second) WHERE status > 400 GROUP BY status;
 
 -- VIEW - Enrich Codes with errors with Join to Status-Code definition
-DROP STREAM ENRICHED_ERROR_CODES;
-DROP TABLE ENRICHED_ERROR_CODES_COUNT;
+DROP STREAM IF EXISTS ENRICHED_ERROR_CODES;
+DROP TABLE IF EXISTS ENRICHED_ERROR_CODES_COUNT;
 
 --Join using a STREAM
 CREATE STREAM ENRICHED_ERROR_CODES AS SELECT code, definition FROM clickstream LEFT JOIN clickstream_codes ON clickstream.status = clickstream_codes.code;
@@ -63,23 +58,23 @@ CREATE TABLE ENRICHED_ERROR_CODES_COUNT AS SELECT code, definition, COUNT(*) AS 
 ----------------------------------------------------------------------------------------------------------------------------
 
 -- users lookup table
-DROP TABLE WEB_USERS;
+DROP TABLE IF EXISTS WEB_USERS;
 CREATE TABLE WEB_USERS (user_id int, registered_At long, username varchar, first_name varchar, last_name varchar, city varchar, level varchar) with (key='user_id', kafka_topic = 'clickstream_users', value_format = 'json');
 
 -- Clickstream enriched with user account data
-DROP STREAM customer_clickstream;
+DROP STREAM IF EXISTS customer_clickstream;
 CREATE STREAM customer_clickstream WITH (PARTITIONS=2) AS SELECT userid, u.first_name, u.last_name, u.level, time, ip, request, status, agent FROM clickstream c LEFT JOIN web_users u ON c.userid = u.user_id;
 
 -- Find error views by important users
---DROP STREAM platinum_customers_with_errors
+--DROP STREAM IF EXISTS platinum_customers_with_errors
 --CREATE stream platinum_customers_with_errors WITH (PARTITIONS=2) AS seLECT * FROM customer_clickstream WHERE status > 400 AND level = 'Platinum';
 
 -- Find error views by important users in one shot
---DROP STREAM platinum_errors;
+--DROP STREAM IF EXISTS platinum_errors;
 --CREATE STREAM platinum_errors WITH (PARTITIONS=2) AS SELECT userid, u.first_name, u.last_name, u.city, u.level, time, ip, request, status, agent FROM clickstream c LEFT JOIN web_users u ON c.userid = u.user_id WHERE status > 400 AND level = 'Platinum';
 --
 ---- Trend of errors from important users
---DROP TABLE platinum_page_errors_per_5_min;
+--DROP TABLE IF EXISTS platinum_page_errors_per_5_min;
 --CREATE TABLE platinum_errors_per_5_min AS SELECT userid, first_name, last_name, city, count(*) AS running_count FROM platinum_errors WINDOW TUMBLING (SIZE 5 MINUTE) WHERE request LIKE '%html%' GROUP BY userid, first_name, last_name, city;
 
 
@@ -88,11 +83,11 @@ CREATE STREAM customer_clickstream WITH (PARTITIONS=2) AS SELECT userid, u.first
 --
 -- View IP, username and City Versus web-site-activity (hits)
 ----------------------------------------------------------------------------------------------------------------------------
-DROP STREAM USER_CLICKSTREAM;
+DROP STREAM IF EXISTS USER_CLICKSTREAM;
 CREATE STREAM USER_CLICKSTREAM AS SELECT userid, u.username, ip, u.city, request, status, bytes FROM clickstream c LEFT JOIN web_users u ON c.userid = u.user_id;
 
 -- Aggregate (count&groupBy) using a TABLE-Window
-DROP TABLE USER_IP_ACTIVITY;
+DROP TABLE IF EXISTS USER_IP_ACTIVITY;
 CREATE TABLE USER_IP_ACTIVITY AS SELECT username, ip, city, COUNT(*) AS count FROM USER_CLICKSTREAM WINDOW TUMBLING (size 60 second) GROUP BY username, ip, city HAVING COUNT(*) > 1;
 
 ----------------------------------------------------------------------------------------------------------------------------
@@ -102,7 +97,7 @@ CREATE TABLE USER_IP_ACTIVITY AS SELECT username, ip, city, COUNT(*) AS count FR
 --
 ----------------------------------------------------------------------------------------------------------------------------
 
-DROP TABLE CLICK_USER_SESSIONS;
+DROP TABLE IF EXISTS CLICK_USER_SESSIONS;
 CREATE TABLE CLICK_USER_SESSIONS AS SELECT username, count(*) AS events FROM USER_CLICKSTREAM window SESSION (300 second) GROUP BY username;
 
 ----------------------------------------------------------------------------------------------------------------------------
@@ -112,9 +107,9 @@ CREATE TABLE CLICK_USER_SESSIONS AS SELECT username, count(*) AS events FROM USE
 --
 ----------------------------------------------------------------------------------------------------------------------------
 
---DROP TABLE PER_USER_KBYTES;
+--DROP TABLE IF EXISTS PER_USER_KBYTES;
 --CREATE TABLE PER_USER_KBYTES AS SELECT username, sum(bytes)/1024 AS kbytes FROM USER_CLICKSTREAM window SESSION (300 second) GROUP BY username;
 
---DROP TABLE MALICIOUS_USER_SESSIONS;
+--DROP TABLE IF EXISTS MALICIOUS_USER_SESSIONS;
 --CREATE TABLE MALICIOUS_USER_SESSIONS AS SELECT username, ip,  sum(bytes)/1024 AS kbytes FROM USER_CLICKSTREAM window SESSION (300 second) GROUP BY username, ip  HAVING sum(bytes)/1024 > 50;
 

--- a/ksql-clickstream-demo/demo/ksql-tables-to-grafana.sh
+++ b/ksql-clickstream-demo/demo/ksql-tables-to-grafana.sh
@@ -11,7 +11,7 @@ echo "Logging to:" $LOG_FILE
 
 
 
-declare -a tables=('click_user_sessions' 'user_ip_activity' 'enriched_error_codes_count' 'errors_per_min_alert' 'errors_per_min' 'events_per_min_max_avg' 'events_per_min' 'pages_per_min');
+declare -a tables=('click_user_sessions' 'user_ip_activity' 'enriched_error_codes_count' 'errors_per_min_alert' 'errors_per_min' 'events_per_min' 'pages_per_min');
 for i in "${tables[@]}"
 do
 

--- a/ksql-engine/src/main/java/io/confluent/ksql/ddl/commands/DropSourceCommand.java
+++ b/ksql-engine/src/main/java/io/confluent/ksql/ddl/commands/DropSourceCommand.java
@@ -28,6 +28,7 @@ import io.confluent.ksql.util.KsqlException;
 public class DropSourceCommand implements DdlCommand {
 
   private final String sourceName;
+  private final boolean ifExists;
   private final DataSource.DataSourceType dataSourceType;
   private final SchemaRegistryClient schemaRegistryClient;
 
@@ -37,6 +38,7 @@ public class DropSourceCommand implements DdlCommand {
       final SchemaRegistryClient schemaRegistryClient) {
 
     this.sourceName = statement.getName().getSuffix();
+    this.ifExists = statement.getIfExists();
     this.dataSourceType = dataSourceType;
     this.schemaRegistryClient = schemaRegistryClient;
   }
@@ -45,6 +47,9 @@ public class DropSourceCommand implements DdlCommand {
   public DdlCommandResult run(MetaStore metaStore, boolean isValidatePhase) {
     StructuredDataSource dataSource = metaStore.getSource(sourceName);
     if (dataSource == null) {
+      if (ifExists) {
+        return new DdlCommandResult(true, "Source " + sourceName + " does not exist.");
+      }
       throw new KsqlException("Source " + sourceName + " does not exist.");
     }
     if (dataSource.getDataSourceType() != dataSourceType) {

--- a/ksql-engine/src/test/java/io/confluent/ksql/ddl/commands/DropSourceCommandTest.java
+++ b/ksql-engine/src/test/java/io/confluent/ksql/ddl/commands/DropSourceCommandTest.java
@@ -1,0 +1,39 @@
+package io.confluent.ksql.ddl.commands;
+
+import io.confluent.kafka.schemaregistry.client.SchemaRegistryClient;
+import io.confluent.ksql.metastore.MetaStore;
+import io.confluent.ksql.metastore.StructuredDataSource;
+import io.confluent.ksql.parser.tree.DropStream;
+import io.confluent.ksql.parser.tree.QualifiedName;
+import io.confluent.ksql.util.KsqlException;
+import io.confluent.ksql.util.MetaStoreFixture;
+import org.easymock.EasyMock;
+import org.junit.Test;
+
+import static org.hamcrest.CoreMatchers.equalTo;
+import static org.junit.Assert.assertThat;
+import static org.junit.Assert.fail;
+
+public class DropSourceCommandTest {
+  MetaStore metaStore = MetaStoreFixture.getNewMetaStore();
+
+  @Test
+  public void shouldSucceedOnMissingSourceWithIfExists() {
+    DropSourceCommand dropSourceCommand = new DropSourceCommand(
+        new DropStream(QualifiedName.of("foo"), true), StructuredDataSource.DataSourceType.KSTREAM,
+        EasyMock.niceMock(SchemaRegistryClient.class));
+    DdlCommandResult result = dropSourceCommand.run(metaStore, false);
+    assertThat(result.getMessage(), equalTo("Source foo does not exist."));
+  }
+
+  @Test
+  public void shouldFailOnMissingSourceWithNoIfExists() {
+    DropSourceCommand dropSourceCommand = new DropSourceCommand(
+        new DropStream(QualifiedName.of("foo"), false), StructuredDataSource.DataSourceType.KSTREAM,
+        EasyMock.niceMock(SchemaRegistryClient.class));
+    try {
+      dropSourceCommand.run(metaStore, false);
+      fail("Should raise a Ksql Exception if source not found");
+    } catch (KsqlException e) {}
+  }
+}

--- a/ksql-parser/src/main/java/io/confluent/ksql/parser/SqlFormatter.java
+++ b/ksql-parser/src/main/java/io/confluent/ksql/parser/SqlFormatter.java
@@ -623,7 +623,7 @@ public final class SqlFormatter {
     @Override
     protected Void visitDropTable(DropTable node, Integer context) {
       builder.append("DROP TABLE ");
-      if (node.isExists()) {
+      if (node.getIfExists()) {
         builder.append("IF EXISTS ");
       }
       builder.append(node.getName());

--- a/ksql-parser/src/main/java/io/confluent/ksql/parser/tree/AbstractStreamDropStatement.java
+++ b/ksql-parser/src/main/java/io/confluent/ksql/parser/tree/AbstractStreamDropStatement.java
@@ -23,5 +23,7 @@ public abstract class AbstractStreamDropStatement extends Statement {
     super(location);
   }
 
+  public abstract boolean getIfExists();
+
   public abstract QualifiedName getName();
 }

--- a/ksql-parser/src/main/java/io/confluent/ksql/parser/tree/DropStream.java
+++ b/ksql-parser/src/main/java/io/confluent/ksql/parser/tree/DropStream.java
@@ -25,28 +25,28 @@ public class DropStream
     extends AbstractStreamDropStatement implements DdlStatement {
 
   private final QualifiedName streamName;
-  private final boolean exists;
+  private final boolean ifExists;
 
-  public DropStream(QualifiedName tableName, boolean exists) {
-    this(Optional.empty(), tableName, exists);
+  public DropStream(QualifiedName tableName, boolean ifExists) {
+    this(Optional.empty(), tableName, ifExists);
   }
 
-  public DropStream(NodeLocation location, QualifiedName tableName, boolean exists) {
-    this(Optional.of(location), tableName, exists);
+  public DropStream(NodeLocation location, QualifiedName tableName, boolean ifExists) {
+    this(Optional.of(location), tableName, ifExists);
   }
 
-  private DropStream(Optional<NodeLocation> location, QualifiedName streamName, boolean exists) {
+  private DropStream(Optional<NodeLocation> location, QualifiedName streamName, boolean ifExists) {
     super(location);
     this.streamName = streamName;
-    this.exists = exists;
+    this.ifExists = ifExists;
   }
 
   public QualifiedName getName() {
     return streamName;
   }
 
-  public boolean isExists() {
-    return exists;
+  public boolean getIfExists() {
+    return ifExists;
   }
 
   @Override
@@ -56,7 +56,7 @@ public class DropStream
 
   @Override
   public int hashCode() {
-    return Objects.hash(streamName, exists);
+    return Objects.hash(streamName, ifExists);
   }
 
   @Override
@@ -69,14 +69,14 @@ public class DropStream
     }
     DropStream o = (DropStream) obj;
     return Objects.equals(streamName, o.streamName)
-           && (exists == o.exists);
+           && (ifExists == o.ifExists);
   }
 
   @Override
   public String toString() {
     return toStringHelper(this)
         .add("tableName", streamName)
-        .add("exists", exists)
+        .add("ifExists", ifExists)
         .toString();
   }
 }

--- a/ksql-parser/src/main/java/io/confluent/ksql/parser/tree/DropTable.java
+++ b/ksql-parser/src/main/java/io/confluent/ksql/parser/tree/DropTable.java
@@ -24,28 +24,28 @@ import static com.google.common.base.MoreObjects.toStringHelper;
 public class DropTable extends AbstractStreamDropStatement implements DdlStatement {
 
   private final QualifiedName tableName;
-  private final boolean exists;
+  private final boolean ifExists;
 
-  public DropTable(QualifiedName tableName, boolean exists) {
-    this(Optional.empty(), tableName, exists);
+  public DropTable(QualifiedName tableName, boolean ifExists) {
+    this(Optional.empty(), tableName, ifExists);
   }
 
-  public DropTable(NodeLocation location, QualifiedName tableName, boolean exists) {
-    this(Optional.of(location), tableName, exists);
+  public DropTable(NodeLocation location, QualifiedName tableName, boolean ifExists) {
+    this(Optional.of(location), tableName, ifExists);
   }
 
-  private DropTable(Optional<NodeLocation> location, QualifiedName tableName, boolean exists) {
+  private DropTable(Optional<NodeLocation> location, QualifiedName tableName, boolean ifExists) {
     super(location);
     this.tableName = tableName;
-    this.exists = exists;
+    this.ifExists = ifExists;
   }
 
   public QualifiedName getName() {
     return tableName;
   }
 
-  public boolean isExists() {
-    return exists;
+  public boolean getIfExists() {
+    return ifExists;
   }
 
   @Override
@@ -55,7 +55,7 @@ public class DropTable extends AbstractStreamDropStatement implements DdlStateme
 
   @Override
   public int hashCode() {
-    return Objects.hash(tableName, exists);
+    return Objects.hash(tableName, ifExists);
   }
 
   @Override
@@ -68,14 +68,14 @@ public class DropTable extends AbstractStreamDropStatement implements DdlStateme
     }
     DropTable o = (DropTable) obj;
     return Objects.equals(tableName, o.tableName)
-           && (exists == o.exists);
+           && (ifExists == o.ifExists);
   }
 
   @Override
   public String toString() {
     return toStringHelper(this)
         .add("tableName", tableName)
-        .add("exists", exists)
+        .add("ifExists", ifExists)
         .toString();
   }
 }

--- a/ksql-parser/src/test/java/io/confluent/ksql/parser/KsqlParserTest.java
+++ b/ksql-parser/src/test/java/io/confluent/ksql/parser/KsqlParserTest.java
@@ -601,21 +601,51 @@ public class KsqlParserTest {
   }
 
   @Test
-  public void testDrop() {
-    String simpleQuery = "DROP STREAM STREAM1; DROP TABLE TABLE1;";
+  public void shouldParseDropStream() {
+    String simpleQuery = "DROP STREAM STREAM1;";
     List<Statement> statements =  KSQL_PARSER.buildAst(simpleQuery, metaStore);
-    Statement statement0 =statements.get(0);
-    Statement statement1 =statements.get(1);
-    Assert.assertTrue(statement0 instanceof DropStream);
-    Assert.assertTrue(statement1 instanceof DropTable);
-    DropStream dropStream = (DropStream)  statement0;
-    DropTable dropTable = (DropTable) statement1;
-    Assert.assertTrue(dropStream.getName().toString().equalsIgnoreCase("STREAM1"));
-    Assert.assertTrue(dropTable.getName().toString().equalsIgnoreCase("TABLE1"));
+    Statement statement =statements.get(0);
+    assertThat(statement, instanceOf(DropStream.class));
+    DropStream dropStream = (DropStream)  statement;
+    assertThat(dropStream.getName().toString().toUpperCase(), equalTo("STREAM1"));
+    assertThat(dropStream.getIfExists(), is(false));
   }
 
   @Test
-  public void testInsertInto() throws Exception {
+  public void shouldParseDropTable() {
+    String simpleQuery = "DROP TABLE TABLE1;";
+    List<Statement> statements =  KSQL_PARSER.buildAst(simpleQuery, metaStore);
+    Statement statement =statements.get(0);
+    assertThat(statement, instanceOf(DropTable.class));
+    DropTable dropTable = (DropTable)  statement;
+    assertThat(dropTable.getName().toString().toUpperCase(), equalTo("TABLE1"));
+    assertThat(dropTable.getIfExists(), is(false));
+  }
+
+  @Test
+  public void shouldParseDropStreamIfExists() {
+    String simpleQuery = "DROP STREAM IF EXISTS STREAM1;";
+    List<Statement> statements =  KSQL_PARSER.buildAst(simpleQuery, metaStore);
+    Statement statement =statements.get(0);
+    assertThat(statement, instanceOf(DropStream.class));
+    DropStream dropStream = (DropStream)  statement;
+    assertThat(dropStream.getName().toString().toUpperCase(), equalTo("STREAM1"));
+    assertThat(dropStream.getIfExists(), is(true));
+  }
+
+  @Test
+  public void shouldParseDropTableIfExists() {
+    String simpleQuery = "DROP TABLE IF EXISTS TABLE1;";
+    List<Statement> statements =  KSQL_PARSER.buildAst(simpleQuery, metaStore);
+    Statement statement =statements.get(0);
+    assertThat(statement, instanceOf(DropTable.class));
+    DropTable dropTable = (DropTable)  statement;
+    assertThat(dropTable.getName().toString().toUpperCase(), equalTo("TABLE1"));
+    assertThat(dropTable.getIfExists(), is(true));
+  }
+
+  @Test
+  public void testInsertInto() {
     String insertIntoString = "INSERT INTO test2 SELECT col0, col2, col3 FROM test1 WHERE col0 > "
                             + "100;";
     Statement statement = KSQL_PARSER.buildAst(insertIntoString, metaStore).get(0);
@@ -636,6 +666,7 @@ public class KsqlParserTest {
 
   }
 
+  @Test
   public void shouldSetShowDescriptionsForShowStreamsDescriptions() {
     String statementString = "SHOW STREAMS EXTENDED;";
     Statement statement = KSQL_PARSER.buildAst(statementString, metaStore).get(0);


### PR DESCRIPTION
This patch fixes a bunch of issues with the clickstream demo:
- Currently we DROP each source before creating it. As part of the referential
  integrity changes we started failing if the source didn't exist. Our grammar
  has a way to specify that DROP shouldn't fail in this case by including
  "IF EXISTS" before the data source name. This patch implements the IF EXISTS
   behaviour and changes all the DROP statements in the demo to DROP IF EXISTS
- Get rid of the events_per_min_max_avg table. Its a windowed aggregation of a
  table, which is not a supported query type. This has been spuriously working
  due to issue #1232, which will be fixed in another patch.

### Description 
_What behavior do you want to change, why, how does your patch achieve the changes?_

### Testing done 
_Describe the testing stategy. Unit and integration tests are expected for any behavior changes._

### Reviewer checklist
- [ ] Ensure docs are updated if necessary. (eg. if a user visible feature is being added or changed).
- [ ] Ensure relevant issues are linked (description should include text like "Fixes #<issue number>")

