### PR TITLE
Fix run class to work with Java 10 and use ExplicitGCInvokesConcurrent

### DIFF
--- a/bin/ksql-run-class
+++ b/bin/ksql-run-class
@@ -86,7 +86,7 @@ fi
 
 # JVM performance options
 if [ -z "$KSQL_JVM_PERFORMANCE_OPTS" ]; then
-  KSQL_JVM_PERFORMANCE_OPTS="-server -XX:+UseConcMarkSweepGC -XX:+CMSClassUnloadingEnabled -XX:+CMSScavengeBeforeRemark -XX:+DisableExplicitGC -XX:NewRatio=1 -Djava.awt.headless=true"
+  KSQL_JVM_PERFORMANCE_OPTS="-server -XX:+UseConcMarkSweepGC -XX:+CMSClassUnloadingEnabled -XX:+CMSScavengeBeforeRemark -XX:+ExplicitGCInvokesConcurrent -XX:NewRatio=1 -Djava.awt.headless=true"
 fi
 
 usage() {
@@ -138,9 +138,15 @@ GC_LOG_FILE_NAME=''
 KSQL_GC_LOG_OPTS=""
 if [ "x$GC_LOG_ENABLED" = "xtrue" ]; then
   GC_LOG_FILE_NAME=$DAEMON_NAME$GC_FILE_SUFFIX
-  # the first segment of the version number, which is '1' for releases before Java 9
+  # The first segment of the version number, which is '1' for releases before Java 9
   # it then becomes '9', '10', ...
-  JAVA_MAJOR_VERSION=$($JAVA -version 2>&1 | sed -E -n 's/.* version "([^.-]*).*"/\1/p')
+  # Some examples of the first line of `java --version`:
+  # 8 -> java version "1.8.0_152"
+  # 9.0.4 -> java version "9.0.4"
+  # 10 -> java version "10" 2018-03-20
+  # 10.0.1 -> java version "10.0.1" 2018-04-17
+  # We need to match to the end of the line to prevent sed from printing the characters that do not match
+  JAVA_MAJOR_VERSION=$($JAVA -version 2>&1 | sed -E -n 's/.* version "([0-9]*).*$/\1/p')
   if [[ "$JAVA_MAJOR_VERSION" -ge "9" ]] ; then
     KSQL_GC_LOG_OPTS="-Xlog:gc*:file=$LOG_DIR/$GC_LOG_FILE_NAME:time,tags:filecount=10,filesize=102400"
   else


### PR DESCRIPTION
### Description 
* Configure GC logging correctly when running with Java 10 (port of https://github.com/apache/kafka/pull/4895)
* Use ExplicitGCInvokesConcurrent instead of DisableExplicitGC (port
of https://github.com/apache/kafka/pull/3371)

### Testing done 
Ran ./bin/ksql with Java 10 and verified that the JVM was able to start.

### Reviewer checklist
- [x] Ensure docs are updated if necessary. (eg. if a user visible feature is being added or changed).
- [x] Ensure relevant issues are linked (description should include text like "Fixes #<issue number>")

