### PR TITLE
Add ksql-examples to the class path when running ksql-datagen

### DIFF
--- a/bin/ksql-run-class
+++ b/bin/ksql-run-class
@@ -35,7 +35,7 @@ for project in ksql-engine ksql-examples ksql-rest-app ksql-cli; do
 done
 
 # Production jars - each one is prepended so they will appear in reverse order.  KSQL jars take precedence over other stuff passed in via CLASSPATH env var
-for library in "confluent-common" "rest-utils" "ksql-engine" "ksql-rest-app" "ksql-cli" "ksql" "monitoring-interceptors"; do
+for library in "confluent-common" "ksql-examples" "rest-utils" "ksql-engine" "ksql-rest-app" "ksql-cli" "ksql" "monitoring-interceptors"; do
   DIR="$base_dir/share/java/$library"
   if [ -d "$DIR" ]; then
     KSQL_CLASSPATH="$DIR/*:$KSQL_CLASSPATH"

--- a/docs/tutorials/docker-compose.yml
+++ b/docs/tutorials/docker-compose.yml
@@ -68,9 +68,9 @@ services:
                        cub sr-ready schema-registry 8081 20 && \
                        echo Waiting a few seconds for topic creation to finish... && \
                        sleep 2 && \
-                       java -jar /usr/share/java/ksql-examples/ksql-examples-5.0.0-SNAPSHOT-standalone.jar
+                       /usr/bin/ksql-datagen
                        quickstart=pageviews format=delimited topic=pageviews bootstrap-server=kafka:29092 maxInterval=100 iterations=1000 && \
-                       java -jar /usr/share/java/ksql-examples/ksql-examples-5.0.0-SNAPSHOT-standalone.jar
+                       /usr/bin/ksql-datagen
                        quickstart=pageviews format=delimited topic=pageviews bootstrap-server=kafka:29092 maxInterval=1000'"
     environment:
       KSQL_CONFIG_DIR: "/etc/ksql"
@@ -98,9 +98,9 @@ services:
                        cub sr-ready schema-registry 8081 20 && \
                        echo Waiting a few seconds for topic creation to finish... && \
                        sleep 2 && \
-                       java -jar /usr/share/java/ksql-examples/ksql-examples-5.0.0-SNAPSHOT-standalone.jar
+                        /usr/bin/ksql-datagen
                        quickstart=users format=json topic=users bootstrap-server=kafka:29092 maxInterval=100 iterations=1000 && \
-                       java -jar /usr/share/java/ksql-examples/ksql-examples-5.0.0-SNAPSHOT-standalone.jar
+                       /usr/bin/ksql-datagen
                        quickstart=users format=json topic=users bootstrap-server=kafka:29092 maxInterval=1000'"
     environment:
       KSQL_CONFIG_DIR: "/etc/ksql"

--- a/docs/tutorials/docker-compose.yml
+++ b/docs/tutorials/docker-compose.yml
@@ -98,7 +98,7 @@ services:
                        cub sr-ready schema-registry 8081 20 && \
                        echo Waiting a few seconds for topic creation to finish... && \
                        sleep 2 && \
-                        /usr/bin/ksql-datagen
+                       /usr/bin/ksql-datagen
                        quickstart=users format=json topic=users bootstrap-server=kafka:29092 maxInterval=100 iterations=1000 && \
                        /usr/bin/ksql-datagen
                        quickstart=users format=json topic=users bootstrap-server=kafka:29092 maxInterval=1000'"


### PR DESCRIPTION
### Description 
In the `ksql-examples` docker image, we can't run the `ksql-datagen` script directly because the class path isn't configured to look for jars in the right directory. Hence running that script will fail with a `ClassNotFoundException`. 

This patch updates the run script to include jars from the `ksql-examples` directory if it exists. It also updates the `docker-compose` quickstart to not reference the jars directly, but instead reference the run script. 

### Testing done 
I built the images locally, and then ran `docker-compose up -d` after updating the docker compose file to reference the new images. The quickstart works.

Also`ksql-datagen` can be now be accessed directly in the container, for example:

```bash
amehta-macbook-pro-2:tutorials apurva$ docker run -it 243c79eefd69  ksql-datagen
Schema file not provided
usage: DataGen [help] [bootstrap-server=<kafka bootstrap server(s)> (defaults to localhost:9092)] [quickstart=<quickstart preset> (case-insensitive; one of 'orders', 'users', or 'pageviews')] schema=<avro schema file> format=<message format> (case-insensitive; one of 'avro', 'json', or 'delimited') topic=<kafka topic name> key=<name of key column> [iterations=<number of rows> (defaults to 1,000,000)] [maxInterval=<Max time in ms between rows> (defaults to 500)] [propertiesFile=<file specifying Kafka client properties>]
amehta-macbook-pro-2:tutorials apurva$
```

Where `243c79eefd69` is the id of the ksql-examples image built with this patch.

### Reviewer checklist
- [ ] Ensure docs are updated if necessary. (eg. if a user visible feature is being added or changed).
- [ ] Ensure relevant issues are linked (description should include text like "Fixes #<issue number>")
