### PR TITLE
Don't ignore leading spaces when saving history

### DIFF
--- a/ksql-cli/src/main/java/io/confluent/ksql/cli/console/JLineReader.java
+++ b/ksql-cli/src/main/java/io/confluent/ksql/cli/console/JLineReader.java
@@ -29,7 +29,6 @@ import org.slf4j.LoggerFactory;
 
 import java.io.IOException;
 import java.nio.file.Path;
-import java.nio.file.Paths;
 
 import io.confluent.ksql.util.CliUtils;
 
@@ -54,7 +53,7 @@ public class JLineReader implements io.confluent.ksql.cli.console.LineReader {
     }
   }
 
-  public JLineReader(Terminal terminal) {
+  public JLineReader(Terminal terminal, Path historyFilePath) {
     // The combination of parser/expander here allow for multiple-line commands connected by '\\'
     DefaultParser parser = new DefaultParser();
     parser.setEofOnEscapedNewLine(true);
@@ -73,11 +72,6 @@ public class JLineReader implements io.confluent.ksql.cli.console.LineReader {
     this.lineReader.setOpt(LineReader.Option.HISTORY_IGNORE_DUPS);
     this.lineReader.unsetOpt(LineReader.Option.HISTORY_IGNORE_SPACE);
 
-    Path historyFilePath = Paths.get(System.getProperty(
-        "history-file",
-        System.getProperty("user.home")
-        + "/.ksql-history"
-    )).toAbsolutePath();
     if (CliUtils.createFile(historyFilePath)) {
       this.lineReader.setVariable(LineReader.HISTORY_FILE, historyFilePath);
       LOGGER.info("Command history saved at: " + historyFilePath);

--- a/ksql-cli/src/main/java/io/confluent/ksql/cli/console/JLineReader.java
+++ b/ksql-cli/src/main/java/io/confluent/ksql/cli/console/JLineReader.java
@@ -71,7 +71,7 @@ public class JLineReader implements io.confluent.ksql.cli.console.LineReader {
         .build();
 
     this.lineReader.setOpt(LineReader.Option.HISTORY_IGNORE_DUPS);
-    this.lineReader.setOpt(LineReader.Option.HISTORY_IGNORE_SPACE);
+    this.lineReader.unsetOpt(LineReader.Option.HISTORY_IGNORE_SPACE);
 
     Path historyFilePath = Paths.get(System.getProperty(
         "history-file",

--- a/ksql-cli/src/main/java/io/confluent/ksql/cli/console/JLineReader.java
+++ b/ksql-cli/src/main/java/io/confluent/ksql/cli/console/JLineReader.java
@@ -53,7 +53,7 @@ public class JLineReader implements io.confluent.ksql.cli.console.LineReader {
     }
   }
 
-  public JLineReader(Terminal terminal, Path historyFilePath) {
+  public JLineReader(final Terminal terminal, final Path historyFilePath) {
     // The combination of parser/expander here allow for multiple-line commands connected by '\\'
     DefaultParser parser = new DefaultParser();
     parser.setEofOnEscapedNewLine(true);

--- a/ksql-cli/src/main/java/io/confluent/ksql/cli/console/JLineTerminal.java
+++ b/ksql-cli/src/main/java/io/confluent/ksql/cli/console/JLineTerminal.java
@@ -22,6 +22,8 @@ import org.jline.utils.InfoCmp;
 
 import java.io.IOException;
 import java.io.PrintWriter;
+import java.nio.file.Path;
+import java.nio.file.Paths;
 
 import io.confluent.ksql.rest.client.KsqlRestClient;
 
@@ -68,7 +70,12 @@ public class JLineTerminal extends Console {
 
   @Override
   protected JLineReader buildLineReader() {
-    return new JLineReader(this.terminal);
+    Path historyFilePath = Paths.get(System.getProperty(
+        "history-file",
+        System.getProperty("user.home")
+        + "/.ksql-history"
+    )).toAbsolutePath();
+    return new JLineReader(this.terminal, historyFilePath);
   }
 
   @Override

--- a/ksql-cli/src/main/java/io/confluent/ksql/cli/console/JLineTerminal.java
+++ b/ksql-cli/src/main/java/io/confluent/ksql/cli/console/JLineTerminal.java
@@ -70,7 +70,7 @@ public class JLineTerminal extends Console {
 
   @Override
   protected JLineReader buildLineReader() {
-    Path historyFilePath = Paths.get(System.getProperty(
+    final Path historyFilePath = Paths.get(System.getProperty(
         "history-file",
         System.getProperty("user.home")
         + "/.ksql-history"

--- a/ksql-cli/src/test/java/io/confluent/ksql/cli/console/JLineReaderTest.java
+++ b/ksql-cli/src/test/java/io/confluent/ksql/cli/console/JLineReaderTest.java
@@ -2,7 +2,6 @@ package io.confluent.ksql.cli.console;
 
 import org.jline.terminal.Terminal;
 import org.jline.terminal.impl.DumbTerminal;
-import org.junit.Before;
 import org.junit.Test;
 
 import java.io.ByteArrayInputStream;
@@ -16,7 +15,8 @@ import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.List;
 
-import static org.testng.Assert.assertEquals;
+import static org.hamcrest.Matchers.contains;
+import static org.hamcrest.MatcherAssert.assertThat;
 
 public class JLineReaderTest {
 
@@ -30,15 +30,15 @@ public class JLineReaderTest {
     final List<String> commands = new ArrayList<>();
     reader.getHistory().forEach(entry -> commands.add(entry.line()));
 
-    assertEquals(1, commands.size());
-    assertEquals(input.trim(), commands.get(0));
+    assertThat(commands, contains(input.trim()));
   }
 
   private JLineReader createReaderForInput(String input) throws IOException {
-    InputStream inputStream = new ByteArrayInputStream(input.getBytes(StandardCharsets.UTF_8));
-    OutputStream outputStream = new ByteArrayOutputStream(512);
-    Terminal terminal = new DumbTerminal(inputStream, outputStream);
-    Path historyFilePath = Files.createTempFile("ksql-history", "txt").toAbsolutePath();
+    final InputStream inputStream = new ByteArrayInputStream(
+        input.getBytes(StandardCharsets.UTF_8));
+    final OutputStream outputStream = new ByteArrayOutputStream(512);
+    final Terminal terminal = new DumbTerminal(inputStream, outputStream);
+    Path historyFilePath = Files.createTempFile("ksql-history", "txt");
     return new JLineReader(terminal, historyFilePath);
   }
 }

--- a/ksql-cli/src/test/java/io/confluent/ksql/cli/console/JLineReaderTest.java
+++ b/ksql-cli/src/test/java/io/confluent/ksql/cli/console/JLineReaderTest.java
@@ -1,0 +1,44 @@
+package io.confluent.ksql.cli.console;
+
+import org.jline.terminal.Terminal;
+import org.jline.terminal.impl.DumbTerminal;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.testng.Assert.assertEquals;
+
+public class JLineReaderTest {
+
+  @Test
+  public void shouldSaveCommandsWithLeadingSpacesToHistory() throws IOException  {
+    final String input = "  show streams\n";
+    final JLineReader reader = createReaderForInput(input);
+
+    reader.readLine();
+
+    final List<String> commands = new ArrayList<>();
+    reader.getHistory().forEach(entry -> commands.add(entry.line()));
+
+    assertEquals(1, commands.size());
+    assertEquals(input.trim(), commands.get(0));
+  }
+
+  private JLineReader createReaderForInput(String input) throws IOException {
+    InputStream inputStream = new ByteArrayInputStream(input.getBytes(StandardCharsets.UTF_8));
+    OutputStream outputStream = new ByteArrayOutputStream(512);
+    Terminal terminal = new DumbTerminal(inputStream, outputStream);
+    Path historyFilePath = Files.createTempFile("ksql-history", "txt").toAbsolutePath();
+    return new JLineReader(terminal, historyFilePath);
+  }
+}


### PR DESCRIPTION
### Description 
Currently we don't log commands starting with spaces to the CLI history. This is considered bad UX. This patch changes a setting in the underlying JLine3 library we use so that we log commands which start with a space.

### Testing done 
Added a test case which ensures that commands with a leading space are saved to history.

### Reviewer checklist
- [ ] Ensure docs are updated if necessary. (eg. if a user visible feature is being added or changed).
- [ ] Ensure relevant issues are linked (description should include text like "Fixes #<issue number>")

