### PR TITLE
Fix the way `LIMIT` clauses are handled

### DIFF
--- a/docs/api.rst
+++ b/docs/api.rst
@@ -194,7 +194,8 @@ The query resource lets you stream the output records of a ``SELECT`` statement 
    :>json object row: A single row being returned. This will be null if an error is being returned.
    :>json array  row.columns: The values contained in the row.
    :>json ?      row.columns[i]: The value contained in a single column for the row. The value type depends on the type of the column.
-   :>json string errorMessage: If this field is non-null, an error has been encountered while running the statement. No additional rows are returned and the server will end the response. Note that when the limit is reached for a query that specified a limit in the LIMIT clause, the server returns a row with error message "LIMIT reached for the partition."
+   :>json string finalMessage: If this field is non-null, it contains a final message from the server. No additional rows will be returned and the server will end the response.
+   :>json string errorMessage: If this field is non-null, an error has been encountered while running the statement. No additional rows are returned and the server will end the response.
 
 
    **Example request**

--- a/docs/includes/ksql-includes.rst
+++ b/docs/includes/ksql-includes.rst
@@ -169,7 +169,7 @@ the latest offset.
        Page_24
        Page_73
        Page_78
-       LIMIT reached for the partition.
+       LIMIT reached
        Query terminated
 
 #. Create a persistent query by using the ``CREATE STREAM`` keywords to precede the ``SELECT`` statement. The results from this
@@ -279,7 +279,7 @@ the latest offset.
        FEMALE | Region_9 | 6
        MALE | Region_8 | 2
        OTHER | Region_5 | 4
-       LIMIT reached for the partition.
+       LIMIT reached
        Query terminated
        ksql>
 

--- a/docs/syntax-reference.rst
+++ b/docs/syntax-reference.rst
@@ -630,7 +630,8 @@ SELECT
       [ WINDOW window_expression ]
       [ WHERE condition ]
       [ GROUP BY grouping_expression ]
-      [ HAVING having_expression ];
+      [ HAVING having_expression ]
+      [ LIMIT count ];
 
 **Description**
 
@@ -655,6 +656,16 @@ Example:
     SELECT * FROM pageviews
       WHERE ROWTIME >= 1510923225000
         AND ROWTIME <= 1510923228000;
+
+A ``LIMIT`` can be used to limit the number of rows returned. Once the limit is reached the query will terminate.
+
+Example:
+
+.. code:: sql
+
+    SELECT * FROM pageviews LIMIT 5;
+
+If no limit is supplied the query will run until terminated, streaming back all results to the console.
 
 **Tip:** If you want to select older data, you can configure KSQL to query the stream from the beginning.  You must
 run this configuration before running the query:

--- a/docs/tutorials/clickstream-docker.rst
+++ b/docs/tutorials/clickstream-docker.rst
@@ -261,7 +261,7 @@ Verify the data
         1503585408009 | 222.168.57.122 | 1503585408009 | 24/Aug/2017:07:36:48 -0700 | 111.249.79.93 | GET /images/track.png HTTP/1.1 | 406 | 22 | 4096 | Mozilla/5.0 (compatible; Googlebot/2.1; +http://www.google.com/bot.html)
         1503585408019 | 122.145.8.244 | 1503585408019 | 24/Aug/2017:07:36:48 -0700 | 122.249.79.233 | GET /site/user_status.html HTTP/1.1 | 404 | 6 | 4006 | Mozilla/5.0 (compatible; Googlebot/2.1; +http://www.google.com/bot.html)
         1503585408029 | 222.152.45.45 | 1503585408029 | 24/Aug/2017:07:36:48 -0700 | 222.249.79.93 | GET /images/track.png HTTP/1.1 | 200 | 29 | 14096 | Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/59.0.3071.115 Safari/537.36
-        LIMIT reached for the partition.
+        LIMIT reached
         Query terminated
 
     **View the events per minute**
@@ -280,7 +280,7 @@ Verify the data
         1521108180000 | 5 : Window{start=1521108180000 end=-} | 5 | 24
         1521108180000 | 9 : Window{start=1521108180000 end=-} | 9 | 19
         1521108180000 | 34 : Window{start=1521108180000 end=-} | 34 | 18
-        LIMIT reached for the partition.
+        LIMIT reached
         Query terminated
 
     **View pages per minute**
@@ -298,7 +298,7 @@ Verify the data
         1503585480000 | 16 : Window{start=1503585480000 end=-} | 16 | 6
         1503585475000 | 25 : Window{start=1503585475000 end=-} | 25 | 20
         1503585480000 | 37 : Window{start=1503585480000 end=-} | 37 | 6
-        LIMIT reached for the partition.
+        LIMIT reached
         Query terminated
 
 .. _view-grafana-docker:

--- a/ksql-cli/src/main/java/io/confluent/ksql/cli/Cli.java
+++ b/ksql-cli/src/main/java/io/confluent/ksql/cli/Cli.java
@@ -428,13 +428,7 @@ public class Cli implements Closeable, AutoCloseable {
               try {
                 StreamedRow row = queryStream.next();
                 terminal.printStreamedRow(row);
-                if (row.getErrorMessage() != null) {
-                  // got an error in the stream, which means we have reached the end.
-                  // the stream interface that queryStream uses isn't smart enough to figure
-                  // out when the socket is closed, so just break here since we know there will
-                  // be nothing more to read.
-                  LOGGER.debug("Going to stop reading results for row {} since there was an error"
-                               + " in the response stream: {}", row, row.getErrorMessage());
+                if (row.getFinalMessage() != null || row.getErrorMessage() != null) {
                   break;
                 }
               } catch (IOException exception) {

--- a/ksql-cli/src/main/java/io/confluent/ksql/cli/console/Console.java
+++ b/ksql-cli/src/main/java/io/confluent/ksql/cli/console/Console.java
@@ -19,15 +19,6 @@ package io.confluent.ksql.cli.console;
 import com.fasterxml.jackson.core.JsonGenerator;
 import com.fasterxml.jackson.databind.ObjectMapper;
 
-import io.confluent.ksql.rest.entity.FieldSchemaInfo;
-import io.confluent.ksql.rest.entity.KsqlErrorMessage;
-import io.confluent.ksql.rest.entity.KsqlStatementErrorMessage;
-import io.confluent.ksql.rest.entity.QueryDescription;
-import io.confluent.ksql.rest.entity.QueryDescriptionEntity;
-import io.confluent.ksql.rest.entity.QueryDescriptionList;
-import io.confluent.ksql.rest.entity.RunningQuery;
-import io.confluent.ksql.rest.entity.SourceDescriptionEntity;
-import io.confluent.ksql.rest.entity.SourceDescriptionList;
 import org.apache.commons.lang3.StringUtils;
 import org.jline.reader.EndOfFileException;
 import org.jline.terminal.Terminal;
@@ -53,15 +44,24 @@ import io.confluent.ksql.rest.client.KsqlRestClient;
 import io.confluent.ksql.rest.entity.CommandStatus;
 import io.confluent.ksql.rest.entity.CommandStatusEntity;
 import io.confluent.ksql.rest.entity.ExecutionPlan;
+import io.confluent.ksql.rest.entity.FieldSchemaInfo;
 import io.confluent.ksql.rest.entity.KafkaTopicsList;
 import io.confluent.ksql.rest.entity.KsqlEntity;
 import io.confluent.ksql.rest.entity.KsqlEntityList;
+import io.confluent.ksql.rest.entity.KsqlErrorMessage;
+import io.confluent.ksql.rest.entity.KsqlStatementErrorMessage;
 import io.confluent.ksql.rest.entity.KsqlTopicsList;
 import io.confluent.ksql.rest.entity.PropertiesList;
 import io.confluent.ksql.rest.entity.Queries;
+import io.confluent.ksql.rest.entity.QueryDescription;
+import io.confluent.ksql.rest.entity.QueryDescriptionEntity;
+import io.confluent.ksql.rest.entity.QueryDescriptionList;
+import io.confluent.ksql.rest.entity.RunningQuery;
 import io.confluent.ksql.rest.entity.SchemaMapper;
 import io.confluent.ksql.rest.entity.ServerInfo;
 import io.confluent.ksql.rest.entity.SourceDescription;
+import io.confluent.ksql.rest.entity.SourceDescriptionEntity;
+import io.confluent.ksql.rest.entity.SourceDescriptionList;
 import io.confluent.ksql.rest.entity.StreamedRow;
 import io.confluent.ksql.rest.entity.StreamsList;
 import io.confluent.ksql.rest.entity.TablesList;
@@ -152,20 +152,26 @@ public abstract class Console implements Closeable {
   public void printStreamedRow(StreamedRow row) throws IOException {
     if (row.getErrorMessage() != null) {
       printErrorMessage(row.getErrorMessage());
-    } else {
-      switch (outputFormat) {
-        case JSON:
-          printAsJson(row.getRow().getColumns());
-          break;
-        case TABULAR:
-          printAsTable(row.getRow());
-          break;
-        default:
-          throw new RuntimeException(String.format(
-              "Unexpected output format: '%s'",
-              outputFormat.name()
-          ));
-      }
+      return;
+    }
+
+    if (row.getFinalMessage() != null) {
+      writer().println(row.getFinalMessage());
+      return;
+    }
+
+    switch (outputFormat) {
+      case JSON:
+        printAsJson(row.getRow().getColumns());
+        break;
+      case TABULAR:
+        printAsTable(row.getRow());
+        break;
+      default:
+        throw new RuntimeException(String.format(
+            "Unexpected output format: '%s'",
+            outputFormat.name()
+        ));
     }
   }
 

--- a/ksql-cli/src/test/java/io/confluent/ksql/cli/console/ConsoleTest.java
+++ b/ksql-cli/src/test/java/io/confluent/ksql/cli/console/ConsoleTest.java
@@ -18,7 +18,6 @@ package io.confluent.ksql.cli.console;
 
 import com.google.common.collect.ImmutableList;
 
-import io.confluent.ksql.rest.entity.RunningQuery;
 import org.apache.kafka.connect.data.Field;
 import org.apache.kafka.connect.data.SchemaBuilder;
 import org.junit.After;
@@ -48,6 +47,7 @@ import io.confluent.ksql.rest.entity.KsqlTopicInfo;
 import io.confluent.ksql.rest.entity.KsqlTopicsList;
 import io.confluent.ksql.rest.entity.PropertiesList;
 import io.confluent.ksql.rest.entity.Queries;
+import io.confluent.ksql.rest.entity.RunningQuery;
 import io.confluent.ksql.rest.entity.SourceDescription;
 import io.confluent.ksql.rest.entity.SourceDescriptionEntity;
 import io.confluent.ksql.rest.entity.SourceInfo;
@@ -60,6 +60,7 @@ import io.confluent.ksql.util.SchemaUtil;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.Matchers.is;
 
 @RunWith(Parameterized.class)
 public class ConsoleTest {
@@ -85,14 +86,23 @@ public class ConsoleTest {
 
   @Test
   public void testPrintGenericStreamedRow() throws IOException {
-    StreamedRow row = new StreamedRow(new GenericRow(ImmutableList.of("col_1", "col_2")));
+    StreamedRow row = StreamedRow.row(new GenericRow(ImmutableList.of("col_1", "col_2")));
     terminal.printStreamedRow(row);
   }
 
   @Test
   public void testPrintErrorStreamedRow() throws IOException {
-    StreamedRow row = new StreamedRow(new FakeException());
-    terminal.printStreamedRow(row);
+    final FakeException exception = new FakeException();
+
+    terminal.printStreamedRow(StreamedRow.error(exception));
+
+    assertThat(terminal.getOutputString(), is(exception.getMessage() + "\n"));
+  }
+
+  @Test
+  public void testPrintFinalMessageStreamedRow() throws IOException {
+    terminal.printStreamedRow(StreamedRow.finalMessage("Some message"));
+    assertThat(terminal.getOutputString(), is("Some message\n"));
   }
 
   @Test

--- a/ksql-clickstream-demo/non-docker-clickstream.md
+++ b/ksql-clickstream-demo/non-docker-clickstream.md
@@ -214,7 +214,7 @@ These steps will guide you through how to setup your environment and run the cli
     1503585408009 | 222.168.57.122 | 1503585408009 | 24/Aug/2017:07:36:48 -0700 | 111.249.79.93 | GET /images/track.png HTTP/1.1 | 406 | 22 | 4096 | Mozilla/5.0 (compatible; Googlebot/2.1; +http://www.google.com/bot.html)
     1503585408019 | 122.145.8.244 | 1503585408019 | 24/Aug/2017:07:36:48 -0700 | 122.249.79.233 | GET /site/user_status.html HTTP/1.1 | 404 | 6 | 4006 | Mozilla/5.0 (compatible; Googlebot/2.1; +http://www.google.com/bot.html)
     1503585408029 | 222.152.45.45 | 1503585408029 | 24/Aug/2017:07:36:48 -0700 | 222.249.79.93 | GET /images/track.png HTTP/1.1 | 200 | 29 | 14096 | Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/59.0.3071.115 Safari/537.36
-    LIMIT reached for the partition.
+    LIMIT reached
     Query terminated
     ```
     
@@ -232,7 +232,7 @@ These steps will guide you through how to setup your environment and run the cli
     1503585450000 | 8^�8 | 1503585450000 | 8 | 35
     1503585450000 | 36^�8 | 1503585450000 | 36 | 14
     1503585450000 | 24^�8 | 1503585450000 | 24 | 22
-    LIMIT reached for the partition.
+    LIMIT reached
     Query terminated
     ```
 
@@ -250,7 +250,7 @@ These steps will guide you through how to setup your environment and run the cli
     1503585480000 | 16 : Window{start=1503585480000 end=-} | 16 | 6
     1503585475000 | 25 : Window{start=1503585475000 end=-} | 25 | 20
     1503585480000 | 37 : Window{start=1503585480000 end=-} | 37 | 6
-    LIMIT reached for the partition.
+    LIMIT reached
     Query terminated    
     ```
 

--- a/ksql-engine/src/main/java/io/confluent/ksql/planner/plan/KsqlBareOutputNode.java
+++ b/ksql-engine/src/main/java/io/confluent/ksql/planner/plan/KsqlBareOutputNode.java
@@ -32,6 +32,7 @@ import io.confluent.ksql.util.KafkaTopicClient;
 import io.confluent.ksql.util.KsqlConfig;
 import io.confluent.ksql.util.timestamp.TimestampExtractionPolicy;
 
+@SuppressWarnings("OptionalUsedAsFieldOrParameterType")
 public class KsqlBareOutputNode extends OutputNode {
 
   @JsonCreator
@@ -42,8 +43,6 @@ public class KsqlBareOutputNode extends OutputNode {
                             @JsonProperty("timestampExtraction")
                               final TimestampExtractionPolicy extractionPolicy) {
     super(id, source, schema, limit, extractionPolicy);
-
-
   }
 
   public String getKafkaTopicName() {
@@ -69,6 +68,6 @@ public class KsqlBareOutputNode extends OutputNode {
         props, schemaRegistryClient);
 
     schemaKStream.setOutputNode(this);
-    return schemaKStream.toQueue(getLimit());
+    return schemaKStream.toQueue();
   }
 }

--- a/ksql-engine/src/main/java/io/confluent/ksql/planner/plan/OutputNode.java
+++ b/ksql-engine/src/main/java/io/confluent/ksql/planner/plan/OutputNode.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2017 Confluent Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -16,20 +16,26 @@
 
 package io.confluent.ksql.planner.plan;
 
+import com.google.common.collect.ImmutableList;
+
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
-import com.google.common.collect.ImmutableList;
-import io.confluent.ksql.util.KafkaTopicClient;
+
 import org.apache.kafka.connect.data.Schema;
 
-import javax.annotation.concurrent.Immutable;
 import java.util.List;
+import java.util.Objects;
 import java.util.Optional;
+import java.util.concurrent.atomic.AtomicInteger;
 
+import javax.annotation.concurrent.Immutable;
+
+import io.confluent.ksql.util.KafkaTopicClient;
 import io.confluent.ksql.util.timestamp.TimestampExtractionPolicy;
 
 import static java.util.Objects.requireNonNull;
 
+@SuppressWarnings("OptionalUsedAsFieldOrParameterType")
 @Immutable
 public abstract class OutputNode
     extends PlanNode {
@@ -38,14 +44,34 @@ public abstract class OutputNode
   private final Schema schema;
   private final Optional<Integer> limit;
   private final TimestampExtractionPolicy timestampExtractionPolicy;
+  private final InternalCallback callback;
+
+  public interface LimitHandler {
+    void limitReached();
+  }
+
+  public interface Callback {
+
+    /**
+     * Called to determine is an output row should be queued for output.
+     *
+     * @return {@code true} if it should be sent, {@code false} otherwise.
+     */
+    boolean shouldQueue();
+
+    /**
+     * Called once a row has been queued for output.
+     */
+    void onQueued();
+  }
 
   @JsonCreator
-  protected OutputNode(@JsonProperty("id") final PlanNodeId id,
-                       @JsonProperty("source") final PlanNode source,
-                       @JsonProperty("schema") final Schema schema,
-                       @JsonProperty("limit") final Optional<Integer> limit,
-                       @JsonProperty("timestamp_policy")
-                         final TimestampExtractionPolicy timestampExtractionPolicy) {
+  protected OutputNode(
+      @JsonProperty("id") final PlanNodeId id,
+      @JsonProperty("source") final PlanNode source,
+      @JsonProperty("schema") final Schema schema,
+      @JsonProperty("limit") final Optional<Integer> limit,
+      @JsonProperty("timestamp_policy") final TimestampExtractionPolicy timestampExtractionPolicy) {
     super(id);
     requireNonNull(source, "source is null");
     requireNonNull(schema, "schema is null");
@@ -55,6 +81,9 @@ public abstract class OutputNode
     this.schema = schema;
     this.limit = limit;
     this.timestampExtractionPolicy = timestampExtractionPolicy;
+    this.callback = limit
+        .map(l -> (InternalCallback) new LimitCallback(l))
+        .orElseGet(NoCallback::new);
   }
 
   @Override
@@ -69,6 +98,17 @@ public abstract class OutputNode
 
   public Optional<Integer> getLimit() {
     return limit;
+  }
+
+  /**
+   * @return a callback to be called before outputting.
+   */
+  public Callback getCallback() {
+    return callback;
+  }
+
+  public void setLimitHandler(final LimitHandler limitHandler) {
+    callback.setLimitHandler(limitHandler);
   }
 
   @JsonProperty
@@ -94,4 +134,57 @@ public abstract class OutputNode
     return source.getTheSourceNode().getTimestampExtractionPolicy();
   }
 
+  private interface InternalCallback extends Callback {
+
+    void setLimitHandler(LimitHandler limitHandler);
+  }
+
+  private static class LimitCallback implements InternalCallback {
+
+    private final AtomicInteger remaining;
+    private final AtomicInteger queued;
+    private volatile LimitHandler limitHandler = () -> {
+    };
+
+    private LimitCallback(final int limit) {
+      if (limit <= 0) {
+        throw new IllegalArgumentException("limit must be positive, was:" + limit);
+      }
+      this.remaining = new AtomicInteger(limit);
+      this.queued = new AtomicInteger(limit);
+    }
+
+    @Override
+    public void setLimitHandler(final LimitHandler limitHandler) {
+      this.limitHandler = Objects.requireNonNull(limitHandler, "limitHandler");
+    }
+
+    @Override
+    public boolean shouldQueue() {
+      return remaining.decrementAndGet() >= 0;
+    }
+
+    @Override
+    public void onQueued() {
+      if (queued.decrementAndGet() == 0) {
+        limitHandler.limitReached();
+      }
+    }
+  }
+
+  private static class NoCallback implements InternalCallback {
+
+    @Override
+    public void setLimitHandler(final LimitHandler limitHandler) {
+    }
+
+    @Override
+    public boolean shouldQueue() {
+      return true;
+    }
+
+    @Override
+    public void onQueued() {
+    }
+  }
 }

--- a/ksql-engine/src/main/java/io/confluent/ksql/structured/QueuedSchemaKStream.java
+++ b/ksql-engine/src/main/java/io/confluent/ksql/structured/QueuedSchemaKStream.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2017 Confluent Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -26,14 +26,11 @@ import org.apache.kafka.streams.kstream.Windowed;
 
 import java.util.List;
 import java.util.Objects;
-import java.util.Optional;
 import java.util.Set;
 import java.util.concurrent.BlockingQueue;
 import java.util.concurrent.LinkedBlockingQueue;
 
-import io.confluent.kafka.schemaregistry.client.SchemaRegistryClient;
 import io.confluent.ksql.GenericRow;
-import io.confluent.ksql.function.FunctionRegistry;
 import io.confluent.ksql.parser.tree.Expression;
 import io.confluent.ksql.planner.plan.OutputNode;
 import io.confluent.ksql.serde.KsqlTopicSerDe;
@@ -46,45 +43,20 @@ public class QueuedSchemaKStream extends SchemaKStream {
   private final BlockingQueue<KeyValue<String, GenericRow>> rowQueue =
       new LinkedBlockingQueue<>(100);
 
-  private QueuedSchemaKStream(
-      final Schema schema,
-      final KStream kstream,
-      final Field keyField,
-      final List<SchemaKStream> sourceSchemaKStreams,
-      final Type type,
-      final FunctionRegistry functionRegistry,
-      final Optional<Integer> limit,
-      final OutputNode outputNode,
-      final SchemaRegistryClient schemaRegistryClient
-  ) {
+  QueuedSchemaKStream(final SchemaKStream schemaKStream) {
     super(
-        schema,
-        kstream,
-        keyField,
-        sourceSchemaKStreams,
-        type,
-        functionRegistry,
-        schemaRegistryClient
-    );
-    setOutputNode(outputNode);
-    kstream.foreach(new QueuedSchemaKStream.QueuePopulator(rowQueue, limit));
-  }
-
-  QueuedSchemaKStream(
-      SchemaKStream schemaKStream,
-      Optional<Integer> limit
-  ) {
-    this(
         schemaKStream.schema,
         schemaKStream.getKstream(),
         schemaKStream.keyField,
         schemaKStream.sourceSchemaKStreams,
         Type.SINK,
         schemaKStream.functionRegistry,
-        limit,
-        schemaKStream.outputNode(),
         schemaKStream.schemaRegistryClient
     );
+
+    final OutputNode output = schemaKStream.outputNode();
+    setOutputNode(output);
+    kstream.foreach(new QueuedSchemaKStream.QueuePopulator(rowQueue, output.getCallback()));
   }
 
   public BlockingQueue<KeyValue<String, GenericRow>> getQueue() {
@@ -153,18 +125,17 @@ public class QueuedSchemaKStream extends SchemaKStream {
     return super.getSourceSchemaKStreams();
   }
 
+  @SuppressWarnings("OptionalUsedAsFieldOrParameterType")
   protected static class QueuePopulator<K> implements ForeachAction<K, GenericRow> {
-
     private final BlockingQueue<KeyValue<String, GenericRow>> queue;
-    private final Optional<Integer> limit;
-    private int counter = 0;
+    private final OutputNode.Callback callback;
 
     QueuePopulator(
-        BlockingQueue<KeyValue<String, GenericRow>> queue,
-        Optional<Integer> limit
+        final BlockingQueue<KeyValue<String, GenericRow>> queue,
+        final OutputNode.Callback callback
     ) {
       this.queue = queue;
-      this.limit = limit;
+      this.callback = Objects.requireNonNull(callback, "callback");
     }
 
     @Override
@@ -173,23 +144,27 @@ public class QueuedSchemaKStream extends SchemaKStream {
         if (row == null) {
           return;
         }
-        if (limit.isPresent()) {
-          counter++;
-          if (counter > limit.get()) {
-            throw new KsqlException("LIMIT reached for the partition.");
-          }
+
+        if (!callback.shouldQueue()) {
+          return;
         }
-        String keyString;
-        if (key instanceof Windowed) {
-          Windowed windowedKey = (Windowed) key;
-          keyString = String.format("%s : %s", windowedKey.key(), windowedKey.window());
-        } else {
-          keyString = Objects.toString(key);
-        }
+
+        final String keyString = getStringKey(key);
         queue.put(new KeyValue<>(keyString, row));
+
+        callback.onQueued();
       } catch (InterruptedException exception) {
         throw new KsqlException("InterruptedException while enqueueing:" + key);
       }
+    }
+
+    private String getStringKey(final K key) {
+      if (key instanceof Windowed) {
+        Windowed windowedKey = (Windowed) key;
+        return String.format("%s : %s", windowedKey.key(), windowedKey.window());
+      }
+
+      return Objects.toString(key);
     }
   }
 }

--- a/ksql-engine/src/main/java/io/confluent/ksql/structured/SchemaKStream.java
+++ b/ksql-engine/src/main/java/io/confluent/ksql/structured/SchemaKStream.java
@@ -27,12 +27,12 @@ import org.apache.kafka.streams.kstream.KStream;
 import org.apache.kafka.streams.kstream.Produced;
 import org.apache.kafka.streams.kstream.Serialized;
 import org.apache.kafka.streams.kstream.ValueJoiner;
+import org.codehaus.commons.compiler.CompileException;
 
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
-import java.util.Optional;
 import java.util.Set;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
@@ -41,8 +41,8 @@ import io.confluent.kafka.schemaregistry.client.SchemaRegistryClient;
 import io.confluent.ksql.GenericRow;
 import io.confluent.ksql.codegen.CodeGenRunner;
 import io.confluent.ksql.function.FunctionRegistry;
-import io.confluent.ksql.parser.tree.Expression;
 import io.confluent.ksql.parser.tree.DereferenceExpression;
+import io.confluent.ksql.parser.tree.Expression;
 import io.confluent.ksql.parser.tree.QualifiedNameReference;
 import io.confluent.ksql.planner.plan.OutputNode;
 import io.confluent.ksql.serde.KsqlTopicSerDe;
@@ -52,9 +52,9 @@ import io.confluent.ksql.util.KsqlConfig;
 import io.confluent.ksql.util.KsqlException;
 import io.confluent.ksql.util.Pair;
 import io.confluent.ksql.util.SchemaUtil;
-import org.codehaus.commons.compiler.CompileException;
 
 
+@SuppressWarnings("OptionalUsedAsFieldOrParameterType")
 public class SchemaKStream {
   public enum Type { SOURCE, PROJECT, FILTER, AGGREGATE, SINK, REKEY, JOIN, TOSTREAM }
 
@@ -88,8 +88,8 @@ public class SchemaKStream {
     this.schemaRegistryClient = schemaRegistryClient;
   }
 
-  public QueuedSchemaKStream toQueue(Optional<Integer> limit) {
-    return new QueuedSchemaKStream(this, limit);
+  public QueuedSchemaKStream toQueue() {
+    return new QueuedSchemaKStream(this);
   }
 
   public SchemaKStream into(

--- a/ksql-engine/src/main/java/io/confluent/ksql/structured/SchemaKTable.java
+++ b/ksql-engine/src/main/java/io/confluent/ksql/structured/SchemaKTable.java
@@ -33,7 +33,6 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
-import java.util.Optional;
 import java.util.Set;
 
 import io.confluent.kafka.schemaregistry.client.SchemaRegistryClient;
@@ -116,8 +115,8 @@ public class SchemaKTable extends SchemaKStream {
   }
 
   @Override
-  public QueuedSchemaKStream toQueue(Optional<Integer> limit) {
-    return new QueuedSchemaKStream(this, limit);
+  public QueuedSchemaKStream toQueue() {
+    return new QueuedSchemaKStream(this);
   }
 
   @SuppressWarnings("unchecked")

--- a/ksql-engine/src/main/java/io/confluent/ksql/util/QueuedQueryMetadata.java
+++ b/ksql-engine/src/main/java/io/confluent/ksql/util/QueuedQueryMetadata.java
@@ -75,11 +75,14 @@ public class QueuedQueryMetadata extends QueryMetadata {
     return Objects.hash(rowQueue, super.hashCode());
   }
 
+  public void setLimitHandler(final OutputNode.LimitHandler limitHandler) {
+    getOutputNode().setLimitHandler(limitHandler);
+  }
+
   private class StateListener implements KafkaStreams.StateListener {
     @Override
     public void onChange(final KafkaStreams.State newState, final KafkaStreams.State oldState) {
-      isRunning.set(newState == KafkaStreams.State.RUNNING
-                    || newState == KafkaStreams.State.REBALANCING);
+      isRunning.set(newState != KafkaStreams.State.NOT_RUNNING);
     }
   }
 }

--- a/ksql-engine/src/test/java/io/confluent/ksql/planner/plan/OutputNodeTest.java
+++ b/ksql-engine/src/test/java/io/confluent/ksql/planner/plan/OutputNodeTest.java
@@ -1,0 +1,174 @@
+/*
+ * Copyright 2018 Confluent Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.confluent.ksql.planner.plan;
+
+import junit.framework.AssertionFailedError;
+
+import org.apache.kafka.connect.data.Field;
+import org.apache.kafka.connect.data.Schema;
+import org.apache.kafka.streams.StreamsBuilder;
+import org.easymock.EasyMockRunner;
+import org.easymock.Mock;
+import org.easymock.MockType;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import java.util.Map;
+import java.util.Optional;
+
+import io.confluent.kafka.schemaregistry.client.SchemaRegistryClient;
+import io.confluent.ksql.function.FunctionRegistry;
+import io.confluent.ksql.structured.SchemaKStream;
+import io.confluent.ksql.util.KafkaTopicClient;
+import io.confluent.ksql.util.KsqlConfig;
+import io.confluent.ksql.util.timestamp.TimestampExtractionPolicy;
+
+import static org.easymock.EasyMock.expectLastCall;
+import static org.easymock.EasyMock.replay;
+import static org.easymock.EasyMock.verify;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+
+@SuppressWarnings("OptionalUsedAsFieldOrParameterType")
+@RunWith(EasyMockRunner.class)
+public class OutputNodeTest {
+  @Mock(MockType.NICE)
+  private Schema schema;
+  @Mock(MockType.NICE)
+  private PlanNodeId id;
+  @Mock(MockType.NICE)
+  private PlanNode source;
+  @Mock(MockType.NICE)
+  private TimestampExtractionPolicy timestampExtractionPolicy;
+  @Mock
+  private OutputNode.LimitHandler limitHandler;
+  private OutputNode node;
+  private OutputNode.Callback callback;
+
+  @Test
+  public void shouldNotBlowUpIfNoLimitHandlerRegistered() {
+    // Given:
+    node = new TestOutputNode(id, source, schema, Optional.of(1), timestampExtractionPolicy);
+    callback = node.getCallback();
+
+    // When:
+    callback.shouldQueue();
+    callback.onQueued();
+
+    // Then:
+    // No exception thrown.
+  }
+
+  @Test
+  public void shouldNotCallLimitHandlerWhenNoLimit() {
+    // Given:
+    givenOutputNodeWithLimit(Optional.empty());
+
+    limitHandler.limitReached();
+    expectLastCall().andThrow(new AssertionFailedError()).anyTimes();
+
+    replay(limitHandler);
+
+    // When:
+    callback.shouldQueue();
+    callback.onQueued();
+
+    // Then:
+    verify(limitHandler);
+  }
+
+  @Test
+  public void shouldQueueUntilLimitReached() {
+    // Given:
+    givenOutputNodeWithLimit(Optional.of(2));
+
+    // Then:
+    assertThat(callback.shouldQueue(), is(true));
+    assertThat(callback.shouldQueue(), is(true));
+    assertThat(callback.shouldQueue(), is(false));
+  }
+
+  @Test
+  public void shouldNotCallLimitHandlerIfOnlyPredicateCalled() {
+    // Given:
+    givenOutputNodeWithLimit(Optional.of(1));
+
+    limitHandler.limitReached();
+    expectLastCall().andThrow(new AssertionFailedError()).anyTimes();
+
+    replay(limitHandler);
+
+    // When:
+    callback.shouldQueue();
+    callback.shouldQueue();
+
+    // Then:
+    verify(limitHandler);
+  }
+
+  @Test
+  public void shouldCallLimitHandlerExactlyOnceWhenLimitReached() {
+    // Given:
+    givenOutputNodeWithLimit(Optional.of(2));
+
+    limitHandler.limitReached();
+    expectLastCall().once();
+
+    replay(limitHandler);
+
+    // When:
+    callback.onQueued();
+    callback.onQueued();
+    callback.onQueued();
+    callback.onQueued();
+    callback.onQueued();
+
+    // Then:
+    verify(limitHandler);
+  }
+
+  private void givenOutputNodeWithLimit(final Optional<Integer> limit) {
+    node = new TestOutputNode(id, source, schema, limit, timestampExtractionPolicy);
+    node.setLimitHandler(limitHandler);
+    callback = node.getCallback();
+  }
+
+  private static class TestOutputNode extends OutputNode {
+
+    private TestOutputNode(final PlanNodeId id,
+                           final PlanNode source,
+                           final Schema schema,
+                           final Optional<Integer> limit,
+                           final TimestampExtractionPolicy timestampExtractionPolicy) {
+      super(id, source, schema, limit, timestampExtractionPolicy);
+    }
+
+    @Override
+    public Field getKeyField() {
+      return null;
+    }
+
+    @Override
+    public SchemaKStream buildStream(final StreamsBuilder builder, final KsqlConfig ksqlConfig,
+                                     final KafkaTopicClient kafkaTopicClient,
+                                     final FunctionRegistry functionRegistry,
+                                     final Map<String, Object> props,
+                                     final SchemaRegistryClient schemaRegistryClient) {
+      return null;
+    }
+  }
+}

--- a/ksql-rest-app/src/main/java/io/confluent/ksql/rest/server/resources/streaming/QueryStreamWriter.java
+++ b/ksql-rest-app/src/main/java/io/confluent/ksql/rest/server/resources/streaming/QueryStreamWriter.java
@@ -34,8 +34,10 @@ import java.util.Map;
 import java.util.concurrent.TimeUnit;
 
 import javax.ws.rs.core.StreamingOutput;
+
 import io.confluent.ksql.GenericRow;
 import io.confluent.ksql.KsqlEngine;
+import io.confluent.ksql.planner.plan.OutputNode;
 import io.confluent.ksql.rest.entity.StreamedRow;
 import io.confluent.ksql.util.KsqlException;
 import io.confluent.ksql.util.QueryMetadata;
@@ -48,9 +50,9 @@ class QueryStreamWriter implements StreamingOutput {
   private final QueuedQueryMetadata queryMetadata;
   private final long disconnectCheckInterval;
   private final ObjectMapper objectMapper;
-  private Throwable streamsException;
   private final KsqlEngine ksqlEngine;
-
+  private volatile Exception streamsException;
+  private volatile boolean limitReached = false;
 
   QueryStreamWriter(
       KsqlEngine ksqlEngine,
@@ -70,16 +72,16 @@ class QueryStreamWriter implements StreamingOutput {
 
     this.disconnectCheckInterval = disconnectCheckInterval;
     this.queryMetadata = ((QueuedQueryMetadata) queryMetadata);
-
+    this.queryMetadata.getOutputNode().setLimitHandler(new LimitHandler());
     this.queryMetadata.getKafkaStreams().setUncaughtExceptionHandler(new StreamsExceptionHandler());
     this.ksqlEngine = ksqlEngine;
     queryMetadata.getKafkaStreams().start();
   }
 
   @Override
-  public void write(OutputStream out) throws IOException {
+  public void write(OutputStream out) {
     try {
-      while (true) {
+      while (queryMetadata.isRunning() && !limitReached) {
         KeyValue<String, GenericRow> value = queryMetadata.getRowQueue().poll(
             disconnectCheckInterval,
             TimeUnit.MILLISECONDS
@@ -94,24 +96,24 @@ class QueryStreamWriter implements StreamingOutput {
         }
         drainAndThrowOnError(out);
       }
-    } catch (EOFException exception) {
+
+      drain(out);
+
+      if (limitReached) {
+        objectMapper.writeValue(out, StreamedRow.finalMessage("Limit Reached"));
+        out.write("\n".getBytes(StandardCharsets.UTF_8));
+        out.flush();
+      }
+    } catch (final EOFException exception) {
       // The user has terminated the connection; we can stop writing
       log.warn("Query terminated due to exception:" + exception.toString());
-    } catch (InterruptedException exception) {
+    } catch (final InterruptedException exception) {
       // The most likely cause of this is the server shutting down. Should just try to close
       // gracefully, without writing any more to the connection stream.
       log.warn("Interrupted while writing to connection stream");
-    } catch (Throwable exception) {
+    } catch (final Exception exception) {
       log.error("Exception occurred while writing to connection stream: ", exception);
-      out.write("\n".getBytes(StandardCharsets.UTF_8));
-      if (exception.getCause() instanceof KsqlException) {
-        objectMapper.writeValue(out, new StreamedRow(exception.getCause()));
-      } else {
-        objectMapper.writeValue(out, new StreamedRow(exception));
-      }
-      out.write("\n".getBytes(StandardCharsets.UTF_8));
-      out.flush();
-
+      outputException(out, exception);
     } finally {
       ksqlEngine.removeTemporaryQuery(queryMetadata);
       queryMetadata.close();
@@ -120,31 +122,55 @@ class QueryStreamWriter implements StreamingOutput {
   }
 
   private void write(OutputStream output, GenericRow row) throws IOException {
-    objectMapper.writeValue(output, new StreamedRow(row));
+    objectMapper.writeValue(output, StreamedRow.row(row));
     output.write("\n".getBytes(StandardCharsets.UTF_8));
     output.flush();
   }
 
-  private void drainAndThrowOnError(final OutputStream out) throws Throwable {
-    if (streamsException == null) {
-      return;
+  private void outputException(final OutputStream out, final Throwable exception) {
+    try {
+      out.write("\n".getBytes(StandardCharsets.UTF_8));
+      if (exception.getCause() instanceof KsqlException) {
+        objectMapper.writeValue(out, StreamedRow.error(exception.getCause()));
+      } else {
+        objectMapper.writeValue(out, StreamedRow.error(exception));
+      }
+      out.write("\n".getBytes(StandardCharsets.UTF_8));
+      out.flush();
+    } catch (final IOException e) {
+      log.debug("Client disconnected while attempting to write an error message");
     }
+  }
 
+  private void drainAndThrowOnError(final OutputStream out) throws Exception {
+    if (streamsException != null) {
+      drain(out);
+      throw streamsException;
+    }
+  }
+
+  private void drain(final OutputStream out) throws IOException {
     final List<KeyValue<String, GenericRow>> rows = Lists.newArrayList();
     queryMetadata.getRowQueue().drainTo(rows);
 
     for (final KeyValue<String, GenericRow> row : rows) {
       write(out, row.value);
     }
-
-    throw streamsException;
   }
 
   private class StreamsExceptionHandler implements Thread.UncaughtExceptionHandler {
-
     @Override
     public void uncaughtException(Thread thread, Throwable exception) {
-      streamsException = exception;
+      streamsException = exception instanceof Exception
+                         ? (Exception) exception
+                         : new RuntimeException(exception);
+    }
+  }
+
+  private class LimitHandler implements OutputNode.LimitHandler {
+    @Override
+    public void limitReached() {
+      limitReached = true;
     }
   }
 }

--- a/ksql-rest-app/src/main/java/io/confluent/ksql/rest/server/resources/streaming/QueryStreamWriter.java
+++ b/ksql-rest-app/src/main/java/io/confluent/ksql/rest/server/resources/streaming/QueryStreamWriter.java
@@ -72,7 +72,7 @@ class QueryStreamWriter implements StreamingOutput {
 
     this.disconnectCheckInterval = disconnectCheckInterval;
     this.queryMetadata = ((QueuedQueryMetadata) queryMetadata);
-    this.queryMetadata.getOutputNode().setLimitHandler(new LimitHandler());
+    this.queryMetadata.setLimitHandler(new LimitHandler());
     this.queryMetadata.getKafkaStreams().setUncaughtExceptionHandler(new StreamsExceptionHandler());
     this.ksqlEngine = ksqlEngine;
     queryMetadata.getKafkaStreams().start();

--- a/ksql-rest-app/src/main/java/io/confluent/ksql/rest/server/resources/streaming/WSQueryEndpoint.java
+++ b/ksql-rest-app/src/main/java/io/confluent/ksql/rest/server/resources/streaming/WSQueryEndpoint.java
@@ -24,14 +24,12 @@ import com.google.common.util.concurrent.ListeningScheduledExecutorService;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 
-import io.confluent.ksql.rest.entity.Versions;
 import org.apache.kafka.streams.KeyValue;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.io.IOException;
 import java.util.Arrays;
-
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
@@ -55,6 +53,7 @@ import io.confluent.ksql.parser.tree.Query;
 import io.confluent.ksql.parser.tree.Statement;
 import io.confluent.ksql.rest.entity.KsqlRequest;
 import io.confluent.ksql.rest.entity.StreamedRow;
+import io.confluent.ksql.rest.entity.Versions;
 import io.confluent.ksql.rest.server.StatementParser;
 import io.confluent.ksql.util.QueuedQueryMetadata;
 
@@ -166,7 +165,7 @@ public class WSQueryEndpoint {
 
         for (KeyValue<String, GenericRow> row : rows) {
           try {
-            String buffer = mapper.writeValueAsString(new StreamedRow(row.value));
+            String buffer = mapper.writeValueAsString(StreamedRow.row(row.value));
             session.getAsyncRemote().sendText(
                 buffer, result -> {
                   if (!result.isOK()) {

--- a/ksql-rest-app/src/test/java/io/confluent/ksql/rest/entity/QueryDescriptionTest.java
+++ b/ksql-rest-app/src/test/java/io/confluent/ksql/rest/entity/QueryDescriptionTest.java
@@ -1,5 +1,20 @@
 package io.confluent.ksql.rest.entity;
 
+import org.apache.kafka.connect.data.Field;
+import org.apache.kafka.connect.data.Schema;
+import org.apache.kafka.connect.data.SchemaBuilder;
+import org.apache.kafka.streams.KafkaStreams;
+import org.apache.kafka.streams.StreamsBuilder;
+import org.apache.kafka.streams.Topology;
+import org.apache.kafka.streams.TopologyDescription;
+import org.junit.Test;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.Map;
+import java.util.Optional;
+import java.util.concurrent.LinkedBlockingQueue;
+
 import io.confluent.kafka.schemaregistry.client.SchemaRegistryClient;
 import io.confluent.ksql.function.FunctionRegistry;
 import io.confluent.ksql.metastore.KsqlStream;
@@ -17,23 +32,10 @@ import io.confluent.ksql.util.PersistentQueryMetadata;
 import io.confluent.ksql.util.QueryMetadata;
 import io.confluent.ksql.util.QueuedQueryMetadata;
 import io.confluent.ksql.util.timestamp.MetadataTimestampExtractionPolicy;
-import org.apache.kafka.connect.data.Field;
-import org.apache.kafka.connect.data.Schema;
-import org.apache.kafka.connect.data.SchemaBuilder;
-import org.apache.kafka.streams.KafkaStreams;
-import org.apache.kafka.streams.StreamsBuilder;
-import org.apache.kafka.streams.Topology;
-import org.apache.kafka.streams.TopologyDescription;
-import org.junit.Test;
-
-import java.util.Arrays;
-import java.util.Collections;
-import java.util.Map;
-import java.util.Optional;
-import java.util.concurrent.LinkedBlockingQueue;
 
 import static org.easymock.EasyMock.expect;
 import static org.easymock.EasyMock.mock;
+import static org.easymock.EasyMock.niceMock;
 import static org.easymock.EasyMock.replay;
 import static org.hamcrest.CoreMatchers.equalTo;
 import static org.junit.Assert.assertThat;
@@ -81,7 +83,7 @@ public class QueryDescriptionTest {
 
   @Test
   public void shouldSetFieldsCorrectlyForQueryMetadata() {
-    KafkaStreams queryStreams = mock(KafkaStreams.class);
+    KafkaStreams queryStreams = niceMock(KafkaStreams.class);
     FakeSourceNode sourceNode = new FakeSourceNode("source");
     OutputNode outputNode = new FakeOutputNode(sourceNode);
     Topology topology = mock(Topology.class);
@@ -111,7 +113,7 @@ public class QueryDescriptionTest {
 
   @Test
   public void shouldSetFieldsCorrectlyForPersistentQueryMetadata() {
-    KafkaStreams queryStreams = mock(KafkaStreams.class);
+    KafkaStreams queryStreams = niceMock(KafkaStreams.class);
     FakeSourceNode sourceNode = new FakeSourceNode("source");
     OutputNode outputNode = new FakeOutputNode(sourceNode);
     Topology topology = mock(Topology.class);

--- a/ksql-rest-app/src/test/java/io/confluent/ksql/rest/server/mock/MockStreamedQueryResource.java
+++ b/ksql-rest-app/src/test/java/io/confluent/ksql/rest/server/mock/MockStreamedQueryResource.java
@@ -16,6 +16,9 @@
 
 package io.confluent.ksql.rest.server.mock;
 
+import com.fasterxml.jackson.core.JsonGenerator;
+import com.fasterxml.jackson.databind.ObjectMapper;
+
 import java.io.IOException;
 import java.io.OutputStream;
 import java.nio.charset.StandardCharsets;
@@ -32,10 +35,8 @@ import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.Response;
 import javax.ws.rs.core.StreamingOutput;
 
-import com.fasterxml.jackson.core.JsonGenerator;
-import com.fasterxml.jackson.databind.ObjectMapper;
-import io.confluent.ksql.rest.entity.KsqlRequest;
 import io.confluent.ksql.GenericRow;
+import io.confluent.ksql.rest.entity.KsqlRequest;
 import io.confluent.ksql.rest.entity.StreamedRow;
 
 @Path("/query")
@@ -65,7 +66,7 @@ public class MockStreamedQueryResource {
       List<Object> rowColumns = new java.util.LinkedList<Object>();
       rowColumns.add(data);
       GenericRow row = new GenericRow(rowColumns);
-      objectMapper.writeValue(out, new StreamedRow(row));
+      objectMapper.writeValue(out, StreamedRow.row(row));
       out.write("\n".getBytes(StandardCharsets.UTF_8));
       out.flush();
     }

--- a/ksql-rest-app/src/test/java/io/confluent/ksql/rest/server/resources/StreamedQueryResourceTest.java
+++ b/ksql-rest-app/src/test/java/io/confluent/ksql/rest/server/resources/StreamedQueryResourceTest.java
@@ -18,29 +18,11 @@ package io.confluent.ksql.rest.server.resources;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 
-import io.confluent.kafka.schemaregistry.client.MockSchemaRegistryClient;
-import io.confluent.ksql.KsqlEngine;
-import io.confluent.ksql.planner.PlanSourceExtractorVisitor;
-import io.confluent.ksql.rest.entity.KsqlErrorMessage;
-import io.confluent.ksql.serde.DataSource;
-import io.confluent.ksql.parser.tree.Query;
-import io.confluent.ksql.GenericRow;
-import io.confluent.ksql.planner.plan.OutputNode;
-import io.confluent.ksql.rest.entity.KsqlRequest;
-import io.confluent.ksql.rest.entity.StreamedRow;
-import io.confluent.ksql.rest.server.StatementParser;
-import io.confluent.ksql.rest.server.resources.streaming.StreamedQueryResource;
-import io.confluent.ksql.util.KafkaTopicClient;
-import io.confluent.ksql.util.KafkaTopicClientImpl;
-import io.confluent.ksql.util.KsqlException;
-import io.confluent.ksql.util.QueuedQueryMetadata;
 import org.apache.kafka.connect.data.SchemaBuilder;
 import org.apache.kafka.streams.KafkaStreams;
 import org.apache.kafka.streams.KeyValue;
 import org.junit.Test;
 
-import javax.ws.rs.core.Response;
-import javax.ws.rs.core.StreamingOutput;
 import java.io.EOFException;
 import java.io.IOException;
 import java.io.PipedInputStream;
@@ -52,10 +34,31 @@ import java.util.Scanner;
 import java.util.concurrent.SynchronousQueue;
 import java.util.concurrent.atomic.AtomicReference;
 
+import javax.ws.rs.core.Response;
+import javax.ws.rs.core.StreamingOutput;
+
+import io.confluent.kafka.schemaregistry.client.MockSchemaRegistryClient;
+import io.confluent.ksql.GenericRow;
+import io.confluent.ksql.KsqlEngine;
+import io.confluent.ksql.parser.tree.Query;
+import io.confluent.ksql.planner.PlanSourceExtractorVisitor;
+import io.confluent.ksql.planner.plan.OutputNode;
+import io.confluent.ksql.rest.entity.KsqlErrorMessage;
+import io.confluent.ksql.rest.entity.KsqlRequest;
+import io.confluent.ksql.rest.entity.StreamedRow;
+import io.confluent.ksql.rest.server.StatementParser;
+import io.confluent.ksql.rest.server.resources.streaming.StreamedQueryResource;
+import io.confluent.ksql.serde.DataSource;
+import io.confluent.ksql.util.KafkaTopicClient;
+import io.confluent.ksql.util.KafkaTopicClientImpl;
+import io.confluent.ksql.util.KsqlException;
+import io.confluent.ksql.util.QueuedQueryMetadata;
+
 import static org.easymock.EasyMock.anyObject;
 import static org.easymock.EasyMock.expect;
 import static org.easymock.EasyMock.expectLastCall;
 import static org.easymock.EasyMock.mock;
+import static org.easymock.EasyMock.niceMock;
 import static org.easymock.EasyMock.replay;
 import static org.easymock.EasyMock.reset;
 import static org.easymock.EasyMock.verify;
@@ -126,6 +129,7 @@ public class StreamedQueryResourceTest {
   @SuppressWarnings("unchecked")
   @Test
   public void shouldStreamRowsCorrectly() throws Throwable {
+    final int NUM_ROWS = 5;
     final AtomicReference<Throwable> threadException = new AtomicReference<>(null);
     final Thread.UncaughtExceptionHandler threadExceptionHandler =
         (thread, exception) -> threadException.compareAndSet(null, exception);
@@ -140,7 +144,7 @@ public class StreamedQueryResourceTest {
       @Override
       public void run() {
         try {
-          for (int i = 0; ; i++) {
+          for (int i = 0; i != NUM_ROWS; i++) {
             String key = Integer.toString(i);
             GenericRow value = new GenericRow(Collections.singletonList(i));
             synchronized (writtenRows) {
@@ -166,8 +170,10 @@ public class StreamedQueryResourceTest {
     expectLastCall();
     mockKafkaStreams.cleanUp();
     expectLastCall();
+    mockKafkaStreams.setStateListener(anyObject());
+    expectLastCall();
 
-    final OutputNode mockOutputNode = mock(OutputNode.class);
+    final OutputNode mockOutputNode = niceMock(OutputNode.class);
     expect(mockOutputNode.accept(anyObject(PlanSourceExtractorVisitor.class), anyObject()))
         .andReturn(null);
 
@@ -178,7 +184,7 @@ public class StreamedQueryResourceTest {
     expect(mockKsqlEngine.getTopicClient()).andReturn(mockKafkaTopicClient);
     expect(mockKsqlEngine.getSchemaRegistryClient()).andReturn(new MockSchemaRegistryClient());
 
-    replay(mockOutputNode);
+    replay(mockOutputNode, mockKafkaStreams);
     final QueuedQueryMetadata queuedQueryMetadata =
         new QueuedQueryMetadata(queryString, mockKafkaStreams, mockOutputNode, "",
                                 rowQueue, DataSource.DataSourceType.KSTREAM, "",
@@ -194,7 +200,7 @@ public class StreamedQueryResourceTest {
     StatementParser mockStatementParser = mock(StatementParser.class);
     expect(mockStatementParser.parseSingleStatement(queryString)).andReturn(mock(Query.class));
 
-    replay(mockKsqlEngine, mockStatementParser, mockKafkaStreams, mockOutputNode);
+    replay(mockKsqlEngine, mockStatementParser, mockOutputNode);
 
     StreamedQueryResource testResource = new StreamedQueryResource(mockKsqlEngine, mockStatementParser, 1000);
 
@@ -221,7 +227,7 @@ public class StreamedQueryResourceTest {
 
     Scanner responseScanner = new Scanner(responseInputStream);
     ObjectMapper objectMapper = new ObjectMapper();
-    for (int i = 0; i < 5; i++) {
+    for (int i = 0; i != NUM_ROWS; i++) {
       if (!responseScanner.hasNextLine()) {
         throw new Exception("Response input stream failed to have expected line available");
       }

--- a/ksql-rest-app/src/test/java/io/confluent/ksql/rest/server/resources/streaming/QueryStreamWriterTest.java
+++ b/ksql-rest-app/src/test/java/io/confluent/ksql/rest/server/resources/streaming/QueryStreamWriterTest.java
@@ -115,7 +115,7 @@ public class QueryStreamWriterTest {
 
     createWriter();
 
-    givenUncaughtException(new KsqlException("LIMIT reached for the partition."));
+    givenUncaughtException(new KsqlException("Server went Boom"));
 
     // When:
     writer.write(out);

--- a/ksql-rest-app/src/test/java/io/confluent/ksql/rest/server/resources/streaming/QueryStreamWriterTest.java
+++ b/ksql-rest-app/src/test/java/io/confluent/ksql/rest/server/resources/streaming/QueryStreamWriterTest.java
@@ -91,7 +91,6 @@ public class QueryStreamWriterTest {
     limitHandlerCapture = newCapture();
 
     final KafkaStreams kStreams = niceMock(KafkaStreams.class);
-    final OutputNode outputNode = niceMock(OutputNode.class);
 
     kStreams.setUncaughtExceptionHandler(capture(ehCapture));
     expectLastCall();
@@ -102,12 +101,10 @@ public class QueryStreamWriterTest {
     expect(ksqlEngine.buildMultipleQueries(anyObject(), anyObject()))
         .andReturn(ImmutableList.of(queryMetadata));
 
-    expect(queryMetadata.getOutputNode()).andReturn(outputNode).anyTimes();
-
-    outputNode.setLimitHandler(capture(limitHandlerCapture));
+    queryMetadata.setLimitHandler(capture(limitHandlerCapture));
     expectLastCall().once();
 
-    replay(kStreams, outputNode);
+    replay(kStreams);
   }
 
   @Test

--- a/ksql-rest-app/src/test/java/io/confluent/ksql/rest/server/resources/streaming/WSQueryEndpointTest.java
+++ b/ksql-rest-app/src/test/java/io/confluent/ksql/rest/server/resources/streaming/WSQueryEndpointTest.java
@@ -1,16 +1,10 @@
 package io.confluent.ksql.rest.server.resources.streaming;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.common.util.concurrent.ListenableScheduledFuture;
 import com.google.common.util.concurrent.ListeningScheduledExecutorService;
-import io.confluent.ksql.GenericRow;
-import io.confluent.ksql.KsqlEngine;
-import io.confluent.ksql.parser.tree.Query;
-import io.confluent.ksql.rest.entity.KsqlRequest;
-import io.confluent.ksql.rest.entity.StreamedRow;
-import io.confluent.ksql.rest.entity.Versions;
-import io.confluent.ksql.rest.server.StatementParser;
-import io.confluent.ksql.util.QueuedQueryMetadata;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+
 import org.apache.kafka.connect.data.Schema;
 import org.apache.kafka.connect.data.SchemaBuilder;
 import org.apache.kafka.streams.KafkaStreams;
@@ -19,12 +13,7 @@ import org.easymock.Capture;
 import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
 
-import javax.websocket.CloseReason;
-import javax.websocket.RemoteEndpoint;
-import javax.websocket.Session;
-
 import java.io.IOException;
-import java.nio.ByteBuffer;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashMap;
@@ -35,8 +24,18 @@ import java.util.concurrent.BlockingQueue;
 import java.util.concurrent.LinkedBlockingQueue;
 import java.util.concurrent.TimeUnit;
 
-import static org.junit.Assert.assertThat;
-import static org.hamcrest.CoreMatchers.equalTo;
+import javax.websocket.CloseReason;
+import javax.websocket.RemoteEndpoint;
+import javax.websocket.Session;
+
+import io.confluent.ksql.GenericRow;
+import io.confluent.ksql.KsqlEngine;
+import io.confluent.ksql.parser.tree.Query;
+import io.confluent.ksql.rest.entity.KsqlRequest;
+import io.confluent.ksql.rest.entity.StreamedRow;
+import io.confluent.ksql.rest.entity.Versions;
+import io.confluent.ksql.rest.server.StatementParser;
+import io.confluent.ksql.util.QueuedQueryMetadata;
 
 import static org.easymock.EasyMock.anyObject;
 import static org.easymock.EasyMock.capture;
@@ -47,6 +46,8 @@ import static org.easymock.EasyMock.mock;
 import static org.easymock.EasyMock.replay;
 import static org.easymock.EasyMock.same;
 import static org.easymock.EasyMock.verify;
+import static org.hamcrest.CoreMatchers.equalTo;
+import static org.junit.Assert.assertThat;
 
 public class WSQueryEndpointTest {
   private KsqlEngine ksqlEngine;
@@ -188,7 +189,7 @@ public class WSQueryEndpointTest {
     expectLastCall().once();
     for (KeyValue<String, GenericRow> row : rows) {
       async.sendText(
-          eq(objectMapper.writeValueAsString(new StreamedRow(row.value))),
+          eq(objectMapper.writeValueAsString(StreamedRow.row(row.value))),
           anyObject());
       expectLastCall().once();
     }


### PR DESCRIPTION
### Description 
Limit clauses spam the logs with errors and warnings (#1215), is tracked per-partition, and is not documented (#697).

This PR addresses these issues.
- no longer spams the logs with errors, (fixes #1215)
- limit is now _across_ partitions, not _per_ partition.
- server can now send a 'final message' to the CLI, e.g. 'Limit Reached', (rather than using an error message to terminate the receive loop).
- LIMIT added to the docs, (fixes #697)

### Testing done 
- Added suitable unit tests.

### Reviewer checklist
- [ ] Ensure docs are updated if necessary. (eg. if a user visible feature is being added or changed).
- [x] Ensure relevant issues are linked (description should include text like "Fixes #<issue number>")

