### PR TITLE
Post fix udf instance names to ensure they are unique.

### DIFF
--- a/ksql-engine/src/main/java/io/confluent/ksql/codegen/CodeGenRunner.java
+++ b/ksql-engine/src/main/java/io/confluent/ksql/codegen/CodeGenRunner.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2017 Confluent Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -110,9 +110,10 @@ public class CodeGenRunner {
 
   private static class Visitor extends AstVisitor<Object, Object> {
 
-    final Schema schema;
-    final Map<String, Class> parameterMap;
-    final FunctionRegistry functionRegistry;
+    private final Schema schema;
+    private final Map<String, Class> parameterMap;
+    private final FunctionRegistry functionRegistry;
+    private int functionCounter = 0;
 
     Visitor(Schema schema, FunctionRegistry functionRegistry) {
       this.schema = schema;
@@ -129,7 +130,7 @@ public class CodeGenRunner {
       String functionName = node.getName().getSuffix();
       KsqlFunction ksqlFunction = functionRegistry.getFunction(functionName);
       parameterMap.put(
-          node.getName().getSuffix(),
+          node.getName().getSuffix() + "_" + functionCounter++,
           ksqlFunction.getKudfClass()
       );
       for (Expression argExpr : node.getArguments()) {
@@ -177,6 +178,7 @@ public class CodeGenRunner {
         throw new RuntimeException(
             "Cannot find the select field in the available fields: " + node.toString());
       }
+
       parameterMap.put(
           schemaField.get().name().replace(".", "_"),
           SchemaUtil.getJavaType(schemaField.get().schema())
@@ -221,5 +223,4 @@ public class CodeGenRunner {
       return null;
     }
   }
-
 }

--- a/ksql-engine/src/test/java/io/confluent/ksql/codegen/CodeGenRunnerTest.java
+++ b/ksql-engine/src/test/java/io/confluent/ksql/codegen/CodeGenRunnerTest.java
@@ -16,14 +16,20 @@
 
 package io.confluent.ksql.codegen;
 
+import com.google.common.collect.ImmutableMap;
+
 import org.apache.kafka.connect.data.Schema;
 import org.apache.kafka.connect.data.SchemaBuilder;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
 
+import java.lang.reflect.InvocationTargetException;
 import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
+import java.util.function.Function;
+import java.util.stream.Collectors;
 
 import io.confluent.ksql.analyzer.Analysis;
 import io.confluent.ksql.analyzer.AnalysisContext;
@@ -34,6 +40,7 @@ import io.confluent.ksql.metastore.KsqlStream;
 import io.confluent.ksql.metastore.KsqlTopic;
 import io.confluent.ksql.metastore.MetaStore;
 import io.confluent.ksql.parser.KsqlParser;
+import io.confluent.ksql.parser.tree.Expression;
 import io.confluent.ksql.parser.tree.Statement;
 import io.confluent.ksql.serde.json.KsqlJsonTopicSerDe;
 import io.confluent.ksql.util.ExpressionMetadata;
@@ -41,57 +48,61 @@ import io.confluent.ksql.util.GenericRowValueTypeEnforcer;
 import io.confluent.ksql.util.KsqlException;
 import io.confluent.ksql.util.MetaStoreFixture;
 
-import static org.hamcrest.CoreMatchers.anyOf;
-import static org.hamcrest.CoreMatchers.equalTo;
-import static org.hamcrest.CoreMatchers.instanceOf;
-import static org.hamcrest.CoreMatchers.is;
-import static org.hamcrest.CoreMatchers.not;
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.anyOf;
+import static org.hamcrest.Matchers.both;
+import static org.hamcrest.Matchers.contains;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.greaterThanOrEqualTo;
+import static org.hamcrest.Matchers.instanceOf;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.lessThanOrEqualTo;
+import static org.hamcrest.Matchers.not;
 
 
 @SuppressWarnings("SameParameterValue")
 public class CodeGenRunnerTest {
 
     private static final KsqlParser KSQL_PARSER = new KsqlParser();
-    private MetaStore metaStore;
-    private Schema schema;
-    private CodeGenRunner codeGenRunner;
-    private FunctionRegistry functionRegistry;
 
-    final private static int INT64_INDEX1 = 0;
-    final private static int STRING_INDEX1 = 1;
-    final private static int STRING_INDEX2 = 2;
-    final private static int FLOAT64_INDEX1 = 3;
-    final private static int FLOAT64_INDEX2 = 4;
-    final private static int INT32_INDEX1 = 5;
-    final private static int BOOLEAN_INDEX1 = 6;
-    final private static int BOOLEAN_INDEX2 = 7;
-    final private static int INT64_INDEX2 = 8;
-    final private static int ARRAY_INDEX1 = 9;
-    final private static int ARRAY_INDEX2 = 10;
-    final private static int MAP_INDEX1 = 11;
-    final private static int MAP_INDEX2 = 12;
+    private static final int INT64_INDEX1 = 0;
+    private static final int STRING_INDEX1 = 1;
+    private static final int STRING_INDEX2 = 2;
+    private static final int FLOAT64_INDEX1 = 3;
+    private static final int FLOAT64_INDEX2 = 4;
+    private static final int INT32_INDEX1 = 5;
+    private static final int BOOLEAN_INDEX1 = 6;
+    private static final int BOOLEAN_INDEX2 = 7;
+    private static final int INT64_INDEX2 = 8;
+    private static final int ARRAY_INDEX1 = 9;
+    private static final int ARRAY_INDEX2 = 10;
+    private static final int MAP_INDEX1 = 11;
+    private static final int MAP_INDEX2 = 12;
+
+    private MetaStore metaStore;
+    private CodeGenRunner codeGenRunner;
+    private GenericRowValueTypeEnforcer genericRowValueTypeEnforcer;
 
     @Before
     public void init() {
         metaStore = MetaStoreFixture.getNewMetaStore();
-        functionRegistry = new FunctionRegistry();
-        schema = SchemaBuilder.struct()
-                .field("CODEGEN_TEST.COL0", SchemaBuilder.INT64_SCHEMA)
-                .field("CODEGEN_TEST.COL1", SchemaBuilder.STRING_SCHEMA)
-                .field("CODEGEN_TEST.COL2", SchemaBuilder.STRING_SCHEMA)
-                .field("CODEGEN_TEST.COL3", SchemaBuilder.FLOAT64_SCHEMA)
-                .field("CODEGEN_TEST.COL4", SchemaBuilder.FLOAT64_SCHEMA)
-                .field("CODEGEN_TEST.COL5", SchemaBuilder.INT32_SCHEMA)
-                .field("CODEGEN_TEST.COL6", SchemaBuilder.BOOLEAN_SCHEMA)
-                .field("CODEGEN_TEST.COL7", SchemaBuilder.BOOLEAN_SCHEMA)
-                .field("CODEGEN_TEST.COL8", SchemaBuilder.INT64_SCHEMA)
-                .field("CODEGEN_TEST.COL9", SchemaBuilder.array(SchemaBuilder.INT32_SCHEMA))
-                .field("CODEGEN_TEST.COL10", SchemaBuilder.array(SchemaBuilder.INT32_SCHEMA))
-                .field("CODEGEN_TEST.COL11",
-                    SchemaBuilder.map(SchemaBuilder.INT32_SCHEMA, SchemaBuilder.INT32_SCHEMA))
-                .field("CODEGEN_TEST.COL12",
-                    SchemaBuilder.map(SchemaBuilder.INT32_SCHEMA, SchemaBuilder.INT32_SCHEMA));
+        final FunctionRegistry functionRegistry = new FunctionRegistry();
+        final Schema schema = SchemaBuilder.struct()
+            .field("CODEGEN_TEST.COL0", SchemaBuilder.INT64_SCHEMA)
+            .field("CODEGEN_TEST.COL1", SchemaBuilder.STRING_SCHEMA)
+            .field("CODEGEN_TEST.COL2", SchemaBuilder.STRING_SCHEMA)
+            .field("CODEGEN_TEST.COL3", SchemaBuilder.FLOAT64_SCHEMA)
+            .field("CODEGEN_TEST.COL4", SchemaBuilder.FLOAT64_SCHEMA)
+            .field("CODEGEN_TEST.COL5", SchemaBuilder.INT32_SCHEMA)
+            .field("CODEGEN_TEST.COL6", SchemaBuilder.BOOLEAN_SCHEMA)
+            .field("CODEGEN_TEST.COL7", SchemaBuilder.BOOLEAN_SCHEMA)
+            .field("CODEGEN_TEST.COL8", SchemaBuilder.INT64_SCHEMA)
+            .field("CODEGEN_TEST.COL9", SchemaBuilder.array(SchemaBuilder.INT32_SCHEMA))
+            .field("CODEGEN_TEST.COL10", SchemaBuilder.array(SchemaBuilder.INT32_SCHEMA))
+            .field("CODEGEN_TEST.COL11",
+                   SchemaBuilder.map(SchemaBuilder.INT32_SCHEMA, SchemaBuilder.INT32_SCHEMA))
+            .field("CODEGEN_TEST.COL12",
+                   SchemaBuilder.map(SchemaBuilder.INT32_SCHEMA, SchemaBuilder.INT32_SCHEMA));
         Schema metaStoreSchema = SchemaBuilder.struct()
             .field("COL0", SchemaBuilder.INT64_SCHEMA)
             .field("COL1", SchemaBuilder.STRING_SCHEMA)
@@ -121,82 +132,21 @@ public class CodeGenRunnerTest {
         metaStore.putTopic(ksqlTopic);
         metaStore.putSource(ksqlStream);
         codeGenRunner = new CodeGenRunner(schema, functionRegistry);
-    }
-
-    private Analysis analyzeQuery(String queryStr) {
-        List<Statement> statements = KSQL_PARSER.buildAst(queryStr, metaStore);
-        // Analyze the query to resolve the references and extract oeprations
-        Analysis analysis = new Analysis();
-        Analyzer analyzer = new Analyzer(queryStr, analysis, metaStore);
-        analyzer.process(statements.get(0), new AnalysisContext(null));
-        return analysis;
-    }
-
-    private boolean evalBooleanExpr(String queryFormat, int cola, int colb, Object values[])
-            throws Exception {
-        String simpleQuery = String.format(queryFormat, cola, colb);
-        Analysis analysis = analyzeQuery(simpleQuery);
-
-        ExpressionMetadata expressionEvaluatorMetadata0 = codeGenRunner.buildCodeGenFromParseTree
-            (analysis.getSelectExpressions().get(0));
-        assertThat(expressionEvaluatorMetadata0.getIndexes().length, equalTo(2));
-        int idx0 = expressionEvaluatorMetadata0.getIndexes()[0];
-        int idx1 = expressionEvaluatorMetadata0.getIndexes()[1];
-        assertThat(idx0, anyOf(equalTo(cola), equalTo(colb)));
-        assertThat(idx1, anyOf(equalTo(cola), equalTo(colb)));
-        assertThat(idx0, not(equalTo(idx1)));
-        if (idx0 == colb) {
-            Object tmp = values[0];
-            values[0] = values[1];
-            values[1] = tmp;
-        }
-        assertThat(expressionEvaluatorMetadata0.getUdfs().length, equalTo(2));
-        Object result0 = expressionEvaluatorMetadata0.getExpressionEvaluator().evaluate(values);
-        assertThat(result0, instanceOf(Boolean.class));
-        return (Boolean)result0;
-    }
-
-    private boolean evalBooleanExprEq(int cola, int colb, Object values[]) throws Exception {
-        return evalBooleanExpr("SELECT col%d = col%d FROM CODEGEN_TEST;", cola, colb, values);
-    }
-
-    private boolean evalBooleanExprNeq(int cola, int colb, Object values[]) throws Exception {
-        return evalBooleanExpr("SELECT col%d != col%d FROM CODEGEN_TEST;", cola, colb, values);
-    }
-
-    private boolean evalBooleanExprIsDistinctFrom(int cola, int colb, Object values[]) throws Exception {
-        return evalBooleanExpr("SELECT col%d IS DISTINCT FROM col%d FROM CODEGEN_TEST;", cola, colb, values);
-    }
-
-    private boolean evalBooleanExprLessThan(int cola, int colb, Object values[]) throws Exception {
-        return evalBooleanExpr("SELECT col%d < col%d FROM CODEGEN_TEST;", cola, colb, values);
-    }
-
-
-    private boolean evalBooleanExprLessThanEq(int cola, int colb, Object values[]) throws Exception {
-        return evalBooleanExpr("SELECT col%d <= col%d FROM CODEGEN_TEST;", cola, colb, values);
-    }
-
-    private boolean evalBooleanExprGreaterThan(int cola, int colb, Object values[]) throws Exception {
-        return evalBooleanExpr("SELECT col%d > col%d FROM CODEGEN_TEST;", cola, colb, values);
-    }
-
-    private boolean evalBooleanExprGreaterThanEq(int cola, int colb, Object values[]) throws Exception {
-        return evalBooleanExpr("SELECT col%d >= col%d FROM CODEGEN_TEST;", cola, colb, values);
+        genericRowValueTypeEnforcer = new GenericRowValueTypeEnforcer(schema);
     }
 
     @Test
     public void testNullEquals() throws Exception {
-        Assert.assertThat(evalBooleanExprEq(INT32_INDEX1, INT64_INDEX1, new Object[]{null, 12344L}), is(false));
-        Assert.assertThat(evalBooleanExprEq(INT32_INDEX1, INT64_INDEX1, new Object[]{null, null}), is(false));
+        assertThat(evalBooleanExprEq(INT32_INDEX1, INT64_INDEX1, new Object[]{null, 12344L}),is(false));
+        assertThat(evalBooleanExprEq(INT32_INDEX1, INT64_INDEX1, new Object[]{null, null}), is(false));
     }
 
     @Test
     public void testIsDistinctFrom() throws Exception {
-        Assert.assertThat(evalBooleanExprIsDistinctFrom(INT32_INDEX1, INT64_INDEX1, new Object[]{12344, 12344L}), is(false));
+        assertThat(evalBooleanExprIsDistinctFrom(INT32_INDEX1, INT64_INDEX1, new Object[]{12344, 12344L}), is(false));
         assertThat(evalBooleanExprIsDistinctFrom(INT32_INDEX1, INT64_INDEX1, new Object[]{12345, 12344L}), is(true));
         assertThat(evalBooleanExprIsDistinctFrom(INT32_INDEX1, INT64_INDEX1, new Object[]{null, 12344L}), is(true));
-        Assert.assertThat(evalBooleanExprIsDistinctFrom(INT32_INDEX1, INT64_INDEX1, new Object[]{null, null}), is(false));
+        assertThat(evalBooleanExprIsDistinctFrom(INT32_INDEX1, INT64_INDEX1, new Object[]{null, null}), is(false));
     }
 
     @Test
@@ -217,7 +167,7 @@ public class CodeGenRunnerTest {
 
         result0 = expressionEvaluatorMetadata0.getExpressionEvaluator().evaluate(new Object[]{12345L});
         assertThat(result0, instanceOf(Boolean.class));
-        Assert.assertThat(result0, is(false));
+        assertThat(result0, is(false));
     }
 
     @Test
@@ -234,7 +184,7 @@ public class CodeGenRunnerTest {
 
         Object result0 = expressionEvaluatorMetadata0.getExpressionEvaluator().evaluate(new Object[]{null});
         assertThat(result0, instanceOf(Boolean.class));
-        Assert.assertThat(result0, is(false));
+        assertThat(result0, is(false));
 
         result0 = expressionEvaluatorMetadata0.getExpressionEvaluator().evaluate(new Object[]{12345L});
         assertThat(result0, instanceOf(Boolean.class));
@@ -244,25 +194,25 @@ public class CodeGenRunnerTest {
     @Test
     public void testBooleanExprScalarEq() throws Exception {
         // int32
-        Assert.assertThat(evalBooleanExprEq(INT32_INDEX1, INT64_INDEX1, new Object[]{12345, 12344L}), is(false));
+        assertThat(evalBooleanExprEq(INT32_INDEX1, INT64_INDEX1, new Object[]{12345, 12344L}), is(false));
         assertThat(evalBooleanExprEq(INT32_INDEX1, INT64_INDEX1, new Object[]{12345, 12345L}), is(true));
         // int64
-        Assert.assertThat(evalBooleanExprEq(INT64_INDEX2, INT32_INDEX1, new Object[]{12345L, 12344}), is(false));
+        assertThat(evalBooleanExprEq(INT64_INDEX2, INT32_INDEX1, new Object[]{12345L, 12344}), is(false));
         assertThat(evalBooleanExprEq(INT64_INDEX2, INT32_INDEX1, new Object[]{12345L, 12345}), is(true));
         // double
-        Assert.assertThat(evalBooleanExprEq(FLOAT64_INDEX2, FLOAT64_INDEX1, new Object[]{12345.0, 12344.0}), is(false));
+        assertThat(evalBooleanExprEq(FLOAT64_INDEX2, FLOAT64_INDEX1, new Object[]{12345.0, 12344.0}), is(false));
         assertThat(evalBooleanExprEq(FLOAT64_INDEX2, FLOAT64_INDEX1, new Object[]{12345.0, 12345.0}), is(true));
     }
 
     @Test
     public void testBooleanExprBooleanEq() throws Exception {
-        Assert.assertThat(evalBooleanExprEq(BOOLEAN_INDEX2, BOOLEAN_INDEX1, new Object[]{false, true}), is(false));
+        assertThat(evalBooleanExprEq(BOOLEAN_INDEX2, BOOLEAN_INDEX1, new Object[]{false, true}), is(false));
         assertThat(evalBooleanExprEq(BOOLEAN_INDEX2, BOOLEAN_INDEX1, new Object[]{true, true}), is(true));
     }
 
     @Test
     public void testBooleanExprStringEq() throws Exception {
-        Assert.assertThat(evalBooleanExprEq(STRING_INDEX1, STRING_INDEX2, new Object[]{"abc", "def"}), is(false));
+        assertThat(evalBooleanExprEq(STRING_INDEX1, STRING_INDEX2, new Object[]{"abc", "def"}), is(false));
         assertThat(evalBooleanExprEq(STRING_INDEX1, STRING_INDEX2, new Object[]{"abc", "abc"}), is(true));
     }
 
@@ -295,260 +245,288 @@ public class CodeGenRunnerTest {
     public void testBooleanExprScalarNeq() throws Exception {
         // int32
         assertThat(evalBooleanExprNeq(INT32_INDEX1, INT64_INDEX1, new Object[]{12345, 12344L}), is(true));
-        Assert.assertThat(evalBooleanExprNeq(INT32_INDEX1, INT64_INDEX1, new Object[]{12345, 12345L}), is(false));
+        assertThat(evalBooleanExprNeq(INT32_INDEX1, INT64_INDEX1, new Object[]{12345, 12345L}), is(false));
         // int64
         assertThat(evalBooleanExprNeq(INT64_INDEX2, INT32_INDEX1, new Object[]{12345L, 12344}), is(true));
-        Assert.assertThat(evalBooleanExprNeq(INT64_INDEX2, INT32_INDEX1, new Object[]{12345L, 12345}), is(false));
+        assertThat(evalBooleanExprNeq(INT64_INDEX2, INT32_INDEX1, new Object[]{12345L, 12345}), is(false));
         // double
         assertThat(evalBooleanExprNeq(FLOAT64_INDEX2, FLOAT64_INDEX1, new Object[]{12345.0, 12344.0}), is(true));
-        Assert.assertThat(evalBooleanExprNeq(FLOAT64_INDEX2, FLOAT64_INDEX1, new Object[]{12345.0, 12345.0}), is(false));
+        assertThat(evalBooleanExprNeq(FLOAT64_INDEX2, FLOAT64_INDEX1, new Object[]{12345.0, 12345.0}), is(false));
     }
 
     @Test
     public void testBooleanExprBooleanNeq() throws Exception {
         assertThat(evalBooleanExprNeq(BOOLEAN_INDEX2, BOOLEAN_INDEX1, new Object[]{false, true}), is(true));
-        Assert.assertThat(evalBooleanExprNeq(BOOLEAN_INDEX2, BOOLEAN_INDEX1, new Object[]{true, true}), is(false));
+        assertThat(evalBooleanExprNeq(BOOLEAN_INDEX2, BOOLEAN_INDEX1, new Object[]{true, true}), is(false));
     }
 
     @Test
     public void testBooleanExprStringNeq() throws Exception {
         assertThat(evalBooleanExprNeq(STRING_INDEX1, STRING_INDEX2, new Object[]{"abc", "def"}), is(true));
-        Assert.assertThat(evalBooleanExprNeq(STRING_INDEX1, STRING_INDEX2, new Object[]{"abc", "abc"}), is(false));
+        assertThat(evalBooleanExprNeq(STRING_INDEX1, STRING_INDEX2, new Object[]{"abc", "abc"}), is(false));
     }
 
     @Test
     public void testBooleanExprScalarLessThan() throws Exception {
         // int32
         assertThat(evalBooleanExprLessThan(INT32_INDEX1, INT64_INDEX1, new Object[]{12344, 12345L}), is(true));
-        Assert.assertThat(evalBooleanExprLessThan(INT32_INDEX1, INT64_INDEX1, new Object[]{12346, 12345L}), is(false));
+        assertThat(evalBooleanExprLessThan(INT32_INDEX1, INT64_INDEX1, new Object[]{12346, 12345L}), is(false));
         // int64
         assertThat(evalBooleanExprLessThan(INT64_INDEX2, INT32_INDEX1, new Object[]{12344L, 12345}), is(true));
-        Assert.assertThat(evalBooleanExprLessThan(INT64_INDEX2, INT32_INDEX1, new Object[]{12346L, 12345}), is(false));
+        assertThat(evalBooleanExprLessThan(INT64_INDEX2, INT32_INDEX1, new Object[]{12346L, 12345}), is(false));
         // double
         assertThat(evalBooleanExprLessThan(FLOAT64_INDEX2, FLOAT64_INDEX1, new Object[]{12344.0, 12345.0}), is(true));
-        Assert.assertThat(evalBooleanExprLessThan(FLOAT64_INDEX2, FLOAT64_INDEX1, new Object[]{12346.0, 12345.0}), is(false));
+        assertThat(evalBooleanExprLessThan(FLOAT64_INDEX2, FLOAT64_INDEX1, new Object[]{12346.0, 12345.0}), is(false));
     }
 
     @Test
     public void testBooleanExprStringLessThan() throws Exception {
         assertThat(evalBooleanExprLessThan(STRING_INDEX1, STRING_INDEX2, new Object[]{"abc", "def"}), is(true));
-        Assert.assertThat(evalBooleanExprLessThan(STRING_INDEX1, STRING_INDEX2, new Object[]{"abc", "abc"}), is(false));
+        assertThat(evalBooleanExprLessThan(STRING_INDEX1, STRING_INDEX2, new Object[]{"abc", "abc"}), is(false));
     }
 
     @Test
     public void testBooleanExprScalarLessThanEq() throws Exception {
         // int32
         assertThat(evalBooleanExprLessThanEq(INT32_INDEX1, INT64_INDEX1, new Object[]{12345, 12345L}), is(true));
-        Assert.assertThat(evalBooleanExprLessThanEq(INT32_INDEX1, INT64_INDEX1, new Object[]{12346, 12345L}), is(false));
+        assertThat(evalBooleanExprLessThanEq(INT32_INDEX1, INT64_INDEX1, new Object[]{12346, 12345L}), is(false));
         // int64
         assertThat(evalBooleanExprLessThanEq(INT64_INDEX2, INT32_INDEX1, new Object[]{12345L, 12345}), is(true));
-        Assert.assertThat(evalBooleanExprLessThanEq(INT64_INDEX2, INT32_INDEX1, new Object[]{12346L, 12345}), is(false));
+        assertThat(evalBooleanExprLessThanEq(INT64_INDEX2, INT32_INDEX1, new Object[]{12346L, 12345}), is(false));
         // double
         assertThat(evalBooleanExprLessThanEq(FLOAT64_INDEX2, FLOAT64_INDEX1, new Object[]{12344.0, 12345.0}), is(true));
-        Assert.assertThat(evalBooleanExprLessThanEq(FLOAT64_INDEX2, FLOAT64_INDEX1, new Object[]{12346.0, 12345.0}), is(false));
+        assertThat(evalBooleanExprLessThanEq(FLOAT64_INDEX2, FLOAT64_INDEX1, new Object[]{12346.0, 12345.0}), is(false));
     }
 
     @Test
     public void testBooleanExprStringLessThanEq() throws Exception {
         assertThat(evalBooleanExprLessThanEq(STRING_INDEX1, STRING_INDEX2, new Object[]{"abc", "abc"}), is(true));
-        Assert.assertThat(evalBooleanExprLessThanEq(STRING_INDEX1, STRING_INDEX2, new Object[]{"abc", "abb"}), is(false));
+        assertThat(evalBooleanExprLessThanEq(STRING_INDEX1, STRING_INDEX2, new Object[]{"abc", "abb"}), is(false));
     }
 
     @Test
     public void testBooleanExprScalarGreaterThan() throws Exception {
         // int32
         assertThat(evalBooleanExprGreaterThan(INT32_INDEX1, INT64_INDEX1, new Object[]{12346, 12345L}), is(true));
-        Assert.assertThat(evalBooleanExprGreaterThan(INT32_INDEX1, INT64_INDEX1, new Object[]{12345, 12345L}), is(false));
+        assertThat(evalBooleanExprGreaterThan(INT32_INDEX1, INT64_INDEX1, new Object[]{12345, 12345L}), is(false));
         // int64
         assertThat(evalBooleanExprGreaterThan(INT64_INDEX2, INT32_INDEX1, new Object[]{12346L, 12345}), is(true));
-        Assert.assertThat(evalBooleanExprGreaterThan(INT64_INDEX2, INT32_INDEX1, new Object[]{12345L, 12345}), is(false));
+        assertThat(evalBooleanExprGreaterThan(INT64_INDEX2, INT32_INDEX1, new Object[]{12345L, 12345}), is(false));
         // double
         assertThat(evalBooleanExprGreaterThan(FLOAT64_INDEX2, FLOAT64_INDEX1, new Object[]{12346.0, 12345.0}), is(true));
-        Assert.assertThat(evalBooleanExprGreaterThan(FLOAT64_INDEX2, FLOAT64_INDEX1, new Object[]{12344.0, 12345.0}), is(false));
+        assertThat(evalBooleanExprGreaterThan(FLOAT64_INDEX2, FLOAT64_INDEX1, new Object[]{12344.0, 12345.0}), is(false));
     }
 
     @Test
     public void testBooleanExprStringGreaterThan() throws Exception {
         assertThat(evalBooleanExprGreaterThan(STRING_INDEX1, STRING_INDEX2, new Object[]{"def", "abc"}), is(true));
-        Assert.assertThat(evalBooleanExprGreaterThan(STRING_INDEX1, STRING_INDEX2, new Object[]{"abc", "abc"}), is(false));
+        assertThat(evalBooleanExprGreaterThan(STRING_INDEX1, STRING_INDEX2, new Object[]{"abc", "abc"}), is(false));
     }
 
     @Test
     public void testBooleanExprScalarGreaterThanEq() throws Exception {
         // int32
         assertThat(evalBooleanExprGreaterThanEq(INT32_INDEX1, INT64_INDEX1, new Object[]{12345, 12345L}), is(true));
-        Assert.assertThat(evalBooleanExprGreaterThanEq(INT32_INDEX1, INT64_INDEX1, new Object[]{12344, 12345L}), is(false));
+        assertThat(evalBooleanExprGreaterThanEq(INT32_INDEX1, INT64_INDEX1, new Object[]{12344, 12345L}), is(false));
         // int64
         assertThat(evalBooleanExprGreaterThanEq(INT64_INDEX2, INT32_INDEX1, new Object[]{12345L, 12345}), is(true));
-        Assert.assertThat(evalBooleanExprGreaterThanEq(INT64_INDEX2, INT32_INDEX1, new Object[]{12344L, 12345}), is(false));
+        assertThat(evalBooleanExprGreaterThanEq(INT64_INDEX2, INT32_INDEX1, new Object[]{12344L, 12345}), is(false));
         // double
         assertThat(evalBooleanExprGreaterThanEq(FLOAT64_INDEX2, FLOAT64_INDEX1, new Object[]{12346.0, 12345.0}), is(true));
-        Assert.assertThat(evalBooleanExprGreaterThanEq(FLOAT64_INDEX2, FLOAT64_INDEX1, new Object[]{12344.0, 12345.0}), is(false));
+        assertThat(evalBooleanExprGreaterThanEq(FLOAT64_INDEX2, FLOAT64_INDEX1, new Object[]{12344.0, 12345.0}), is(false));
     }
 
     @Test
     public void testBooleanExprStringGreaterThanEq() throws Exception {
         assertThat(evalBooleanExprGreaterThanEq(STRING_INDEX1, STRING_INDEX2, new Object[]{"def", "abc"}), is(true));
-        Assert.assertThat(evalBooleanExprGreaterThanEq(STRING_INDEX1, STRING_INDEX2, new Object[]{"abc", "def"}), is(false));
+        assertThat(evalBooleanExprGreaterThanEq(STRING_INDEX1, STRING_INDEX2, new Object[]{"abc", "def"}), is(false));
     }
 
     @Test
-    public void testArithmaticExpr() throws Exception {
-        String simpleQuery = "SELECT col0+col3, col2, col3+10, col0*25, 12*4+2 FROM codegen_test WHERE col0 > 100;";
+    public void shouldHandleArithmeticExpr() {
+        // Given:
+        final String query =
+            "SELECT col0+col3, col3+10, col0*25, 12*4+2 FROM codegen_test WHERE col0 > 100;";
+
+        final Map<Integer, Object> inputValues = ImmutableMap.of(0, 5L, 3, 15.0);
+
+        // When:
+        final List<Object> columns = executeExpression(query, inputValues);
+
+        // Then:
+        assertThat(columns, contains(20.0, 25.0, 125L, 50L));
+    }
+
+    @Test
+    public void shouldHandleMathUdfs() {
+        // Given:
+        final String query =
+            "SELECT FLOOR(col3), CEIL(col3*3), ABS(col0+1.34), ROUND(col3*2)+12 FROM codegen_test;";
+
+        final Map<Integer, Object> inputValues = ImmutableMap.of(0, 15, 3, 1.5);
+
+        // When:
+        final List<Object> columns = executeExpression(query, inputValues);
+
+        // Then:
+        assertThat(columns, contains(1.0, 5.0, 16.34, 15L));
+    }
+
+    @Test
+    public void shouldHandleRandomUdf() {
+        // Given:
+        final String query = "SELECT RANDOM()+10, RANDOM()+col0 FROM codegen_test;";
+        final Map<Integer, Object> inputValues = ImmutableMap.of(0, 15);
+
+        // When:
+        final List<Object> columns = executeExpression(query, inputValues);
+
+        // Then:
+        assertThat(columns.get(0), is(instanceOf(Double.class)));
+        assertThat((Double)columns.get(0),
+                   is(both(greaterThanOrEqualTo(10.0)).and(lessThanOrEqualTo(11.0))));
+
+        assertThat(columns.get(1), is(instanceOf(Double.class)));
+        assertThat((Double)columns.get(1),
+                   is(both(greaterThanOrEqualTo(15.0)).and(lessThanOrEqualTo(16.0))));
+    }
+
+    @Test
+    public void shouldHandleStringUdfs() {
+        // Given:
+        final String query =
+            "SELECT LCASE(col1), UCASE(col1), TRIM(col1), CONCAT(col1,'_test'), SUBSTRING(col1, 1, 3)"
+            + " FROM codegen_test;";
+
+        final Map<Integer, Object> inputValues = ImmutableMap.of(1, " Hello ");
+
+        // When:
+        final List<Object> columns = executeExpression(query, inputValues);
+
+        // Then:
+        assertThat(columns, contains(" hello ", " HELLO ", "Hello", " Hello _test", "He"));
+    }
+
+    @Test
+    public void shouldHandleNestedUdfs() {
+        final String query =
+            "SELECT "
+            + "CONCAT(EXTRACTJSONFIELD(col1,'$.name'),CONCAT('-',EXTRACTJSONFIELD(col1,'$.value')))"
+            + " FROM codegen_test;";
+
+        final Map<Integer, Object> inputValues = ImmutableMap.of(1, "{\"name\":\"fred\",\"value\":1}");
+
+        // When:
+        final List<Object> columns = executeExpression(query, inputValues);
+
+        // Then:
+        assertThat(columns, contains("fred-1"));
+    }
+
+    private List<Object> executeExpression(final String query,
+                                           final Map<Integer, Object> inputValues) {
+        final Analysis analysis = analyzeQuery(query);
+
+        final Function<Expression, ExpressionMetadata> buildCodeGenFromParseTree =
+            exp -> {
+                try {
+                    return codeGenRunner.buildCodeGenFromParseTree(exp);
+                } catch (Exception e) {
+                    throw new RuntimeException(e);
+                }
+            };
+
+        return analysis.getSelectExpressions().stream()
+            .map(buildCodeGenFromParseTree)
+            .map(md -> evaluate(md, inputValues))
+            .collect(Collectors.toList());
+    }
+
+    private Analysis analyzeQuery(String queryStr) {
+        final List<Statement> statements = KSQL_PARSER.buildAst(queryStr, metaStore);
+        // Analyze the query to resolve the references and extract oeprations
+        final Analysis analysis = new Analysis();
+        final Analyzer analyzer = new Analyzer(queryStr, analysis, metaStore);
+        analyzer.process(statements.get(0), new AnalysisContext(null));
+        return analysis;
+    }
+
+    private boolean evalBooleanExprEq(int cola, int colb, Object values[]) throws Exception {
+        return evalBooleanExpr("SELECT col%d = col%d FROM CODEGEN_TEST;", cola, colb, values);
+    }
+
+    private boolean evalBooleanExprNeq(int cola, int colb, Object values[]) throws Exception {
+        return evalBooleanExpr("SELECT col%d != col%d FROM CODEGEN_TEST;", cola, colb, values);
+    }
+
+    private boolean evalBooleanExprIsDistinctFrom(int cola, int colb, Object values[]) throws Exception {
+        return evalBooleanExpr("SELECT col%d IS DISTINCT FROM col%d FROM CODEGEN_TEST;", cola, colb, values);
+    }
+
+    private boolean evalBooleanExprLessThan(int cola, int colb, Object values[]) throws Exception {
+        return evalBooleanExpr("SELECT col%d < col%d FROM CODEGEN_TEST;", cola, colb, values);
+    }
+
+    private boolean evalBooleanExprLessThanEq(int cola, int colb, Object values[]) throws Exception {
+        return evalBooleanExpr("SELECT col%d <= col%d FROM CODEGEN_TEST;", cola, colb, values);
+    }
+
+    private boolean evalBooleanExprGreaterThan(int cola, int colb, Object values[]) throws Exception {
+        return evalBooleanExpr("SELECT col%d > col%d FROM CODEGEN_TEST;", cola, colb, values);
+    }
+
+    private boolean evalBooleanExprGreaterThanEq(int cola, int colb, Object values[]) throws Exception {
+        return evalBooleanExpr("SELECT col%d >= col%d FROM CODEGEN_TEST;", cola, colb, values);
+    }
+
+    private boolean evalBooleanExpr(String queryFormat, int cola, int colb, Object values[])
+        throws Exception {
+        String simpleQuery = String.format(queryFormat, cola, colb);
         Analysis analysis = analyzeQuery(simpleQuery);
 
         ExpressionMetadata expressionEvaluatorMetadata0 = codeGenRunner.buildCodeGenFromParseTree
             (analysis.getSelectExpressions().get(0));
         assertThat(expressionEvaluatorMetadata0.getIndexes().length, equalTo(2));
-        assertThat(expressionEvaluatorMetadata0.getIndexes()[0], equalTo(3));
-        assertThat(expressionEvaluatorMetadata0.getIndexes()[1], equalTo(0));
-        assertThat(expressionEvaluatorMetadata0.getUdfs().length, equalTo(2));
-        Object result0 = expressionEvaluatorMetadata0.getExpressionEvaluator().evaluate(new Object[]{10.0,
-                                                                                                     5L});
-        assertThat(result0, instanceOf(Double.class));
-        assertThat(result0, equalTo(15.0));
-
-        ExpressionMetadata expressionEvaluatorMetadata1 = codeGenRunner.buildCodeGenFromParseTree
-            (analysis.getSelectExpressions().get(3));
-        assertThat(expressionEvaluatorMetadata1.getIndexes().length, equalTo(1));
-        assertThat(expressionEvaluatorMetadata1.getIndexes()[0], equalTo(0));
-        assertThat(expressionEvaluatorMetadata1.getUdfs().length, equalTo(1));
-        Object result1 = expressionEvaluatorMetadata1.getExpressionEvaluator().evaluate(new Object[]{5L});
-        assertThat(result1, instanceOf(Long.class));
-        assertThat(result1, equalTo(125L));
-
-        ExpressionMetadata expressionEvaluatorMetadata2 = codeGenRunner.buildCodeGenFromParseTree
-            (analysis.getSelectExpressions().get(4));
-        assertThat(expressionEvaluatorMetadata2.getIndexes().length, equalTo(0));
-        assertThat(expressionEvaluatorMetadata2.getUdfs().length, equalTo(0));
-        Object result2 = expressionEvaluatorMetadata2.getExpressionEvaluator().evaluate(new Object[]{});
-        assertThat(result2, instanceOf(Long.class));
-        assertThat(result2, equalTo(50L));
-    }
-
-    private Object evaluateU1DF(ExpressionMetadata expressionEvaluator, Object arg) throws Exception {
-        Object args[] = new Object[2];
-        int argsIdx = 0;
-        for (int i : expressionEvaluator.getIndexes()) {
-            if (i == -1) {
-                args[argsIdx] = expressionEvaluator.getUdfs()[argsIdx];
-            } else {
-                args[argsIdx] = arg;
-            }
-            argsIdx++;
+        int idx0 = expressionEvaluatorMetadata0.getIndexes()[0];
+        int idx1 = expressionEvaluatorMetadata0.getIndexes()[1];
+        assertThat(idx0, anyOf(equalTo(cola), equalTo(colb)));
+        assertThat(idx1, anyOf(equalTo(cola), equalTo(colb)));
+        assertThat(idx0, not(equalTo(idx1)));
+        if (idx0 == colb) {
+            Object tmp = values[0];
+            values[0] = values[1];
+            values[1] = tmp;
         }
-        return expressionEvaluator.getExpressionEvaluator().evaluate(args);
+        assertThat(expressionEvaluatorMetadata0.getUdfs().length, equalTo(2));
+        Object result0 = expressionEvaluatorMetadata0.getExpressionEvaluator().evaluate(values);
+        assertThat(result0, instanceOf(Boolean.class));
+        return (Boolean)result0;
     }
 
-    @Test
-    public void testU1DFExpr() throws Exception {
-        String simpleQuery = "SELECT FLOOR(col3), CEIL(col3*3), ABS(col0+1.34), RANDOM()+10, ROUND(col3*2)+12 FROM codegen_test;";
-        Analysis analysis = analyzeQuery(simpleQuery);
-        GenericRowValueTypeEnforcer genericRowValueTypeEnforcer = new GenericRowValueTypeEnforcer(schema);
-
-        ExpressionMetadata expressionEvaluator0 = codeGenRunner.buildCodeGenFromParseTree(analysis
-                                                                         .getSelectExpressions()
-                                                                                              .get(0));
-        Object argObj0 = genericRowValueTypeEnforcer.enforceFieldType(3, 1.5);
-        Object result0 = expressionEvaluator0.getExpressionEvaluator()
-            .evaluate(new Object[]{argObj0, expressionEvaluator0.getUdfs()[1]});
-        assertThat(argObj0, instanceOf(Double.class));
-        assertThat(result0, instanceOf(Double.class));
-        assertThat(result0, equalTo(1.0));
-
-        ExpressionMetadata expressionEvaluator1 = codeGenRunner.buildCodeGenFromParseTree(analysis
-                                                                                            .getSelectExpressions().get(1));
-        Object argObj1 = genericRowValueTypeEnforcer.enforceFieldType(3, 1.5);
-        Object result1 = evaluateU1DF(expressionEvaluator1, argObj1);
-        assertThat(argObj1, instanceOf(Double.class));
-        assertThat(result1, instanceOf(Double.class));
-        assertThat(result1, equalTo(5.0));
-
-
-        ExpressionMetadata expressionEvaluator2 = codeGenRunner.buildCodeGenFromParseTree(analysis
-                                                                                            .getSelectExpressions().get(2));
-        Object argObj2 = genericRowValueTypeEnforcer.enforceFieldType(0, 15);
-        Object result2 = evaluateU1DF(expressionEvaluator2, argObj2);
-        assertThat(argObj2, instanceOf(Long.class));
-        assertThat(result2, instanceOf(Double.class));
-        assertThat(result2, equalTo(16.34));
-
-        ExpressionMetadata expressionEvaluator3 = codeGenRunner.buildCodeGenFromParseTree(analysis
-                                                                                            .getSelectExpressions().get(3));
-        Object result3 = expressionEvaluator3.getExpressionEvaluator().evaluate(new
-                                                             Object[]{expressionEvaluator3.getUdfs()[0]});
-        assertThat(result3, instanceOf(Double.class));
-        assertThat(((Double)result3).intValue(), equalTo(10));
-
-        ExpressionMetadata expressionEvaluator4 = codeGenRunner.buildCodeGenFromParseTree(analysis
-                                                                                            .getSelectExpressions().get(4));
-        Object argObj4 = genericRowValueTypeEnforcer.enforceFieldType(3, 1.5);
-        Object result4 = evaluateU1DF(expressionEvaluator4, argObj4);
-        assertThat(argObj4, instanceOf(Double.class));
-        assertThat(result4, instanceOf(Long.class));
-        assertThat(result4, equalTo(15L));
-
+    private Object evaluate(final ExpressionMetadata md,
+                            final Map<Integer, Object> inputValues) {
+        try {
+            return md.getExpressionEvaluator().evaluate(buildParams(md, inputValues));
+        } catch (InvocationTargetException e) {
+            throw new RuntimeException(e);
+        }
     }
 
-    @Test
-    public void testStringUDFExpr() throws Exception {
-        GenericRowValueTypeEnforcer genericRowValueTypeEnforcer = new GenericRowValueTypeEnforcer(schema);
-        String simpleQuery = "SELECT LCASE(col1), UCASE(col2), TRIM(col1), CONCAT(col1,'_test'), SUBSTRING(col1, 1, 3) FROM codegen_test;";
-        Analysis analysis = analyzeQuery(simpleQuery);
+    private Object[] buildParams(final ExpressionMetadata metadata,
+                                 final Map<Integer, Object> inputValues) {
+        final Kudf[] udfs = metadata.getUdfs();
+        final Object[] params = new Object[udfs.length];
 
+        int argsIdx = 0;
+        for (int i : metadata.getIndexes()) {
+            if (i == -1) {
+                params[argsIdx] = udfs[argsIdx++];
+            } else {
+                Object param = genericRowValueTypeEnforcer.enforceFieldType(i, inputValues.get(i));
+                params[argsIdx++] = param;
+            }
+        }
 
-        ExpressionMetadata expressionEvaluator0 = codeGenRunner.buildCodeGenFromParseTree(analysis
-                                                                                            .getSelectExpressions().get(0));
-        Object argObj0 = genericRowValueTypeEnforcer.enforceFieldType(2, "Hello");
-        Object result0 = expressionEvaluator0.getExpressionEvaluator().evaluate(new
-                                                             Object[]{expressionEvaluator0.getUdfs()
-                                                                          [0], argObj0});
-        assertThat(result0, instanceOf(String.class));
-        assertThat(result0, equalTo("hello"));
-
-        ExpressionMetadata expressionEvaluator1 = codeGenRunner.buildCodeGenFromParseTree(analysis
-                                                                                            .getSelectExpressions().get(1));
-        Object argObj1 = genericRowValueTypeEnforcer.enforceFieldType(2, "Hello");
-        Object result1 = expressionEvaluator1.getExpressionEvaluator().evaluate(new
-                                                             Object[]{expressionEvaluator1.getUdfs()
-                                                                          [0], argObj1});
-        assertThat(result1, instanceOf(String.class));
-        assertThat(result1, equalTo("HELLO"));
-
-        ExpressionMetadata expressionEvaluator2 = codeGenRunner.buildCodeGenFromParseTree(analysis
-                                                                                            .getSelectExpressions().get(2));
-        Object argObj2 = genericRowValueTypeEnforcer.enforceFieldType(2, " Hello ");
-        Object result2 = expressionEvaluator2.getExpressionEvaluator().evaluate(new
-                                                             Object[]{argObj2, expressionEvaluator2.getUdfs()
-                                                                          [1]});
-        assertThat(result2, instanceOf(String.class));
-        assertThat(result2, equalTo("Hello"));
-
-        ExpressionMetadata expressionEvaluator3 = codeGenRunner.buildCodeGenFromParseTree(analysis
-                                                                                            .getSelectExpressions().get(3));
-        Object argObj3 = genericRowValueTypeEnforcer.enforceFieldType(2, "Hello");
-        Object result3 = expressionEvaluator3.getExpressionEvaluator().evaluate(new
-                                                             Object[]{expressionEvaluator3.getUdfs()
-                                                                          [0], argObj3});
-        assertThat(result3, instanceOf(String.class));
-        assertThat(result3, equalTo("Hello_test"));
-
-    }
-
-    @Test
-    public void testNestedUdf() throws Exception {
-        final Analysis analysis = analyzeQuery(
-            "SELECT CONCAT(SUBSTRING(col1,1,3),CONCAT('-',SUBSTRING(col1,4,5))) "
-            + "FROM codegen_test;");
-
-        ExpressionMetadata expressionEvaluator0 = codeGenRunner.buildCodeGenFromParseTree(
-            analysis.getSelectExpressions().get(0));
-
-        final Kudf[] udfs = expressionEvaluator0.getUdfs();
-
-        Object result0 = expressionEvaluator0.getExpressionEvaluator()
-                .evaluate(new Object[]{udfs[0], udfs[1], udfs[2], udfs[3], "Hello"});
-
-        assertThat(result0, equalTo("el-o"));
+        return params;
     }
 }

--- a/ksql-engine/src/test/resources/query-validation-tests/extract-json-field.json
+++ b/ksql-engine/src/test/resources/query-validation-tests/extract-json-field.json
@@ -1,0 +1,22 @@
+{
+  "comments": [
+    "Tests covering the use of the EXTRACTJSONFIELD function"
+  ],
+  "tests": [
+    {
+      "name": "concat two extracted fields",
+      "statements": [
+        "CREATE STREAM TEST (source VARCHAR) WITH (kafka_topic='test_topic', value_format='JSON');",
+        "CREATE STREAM OUTPUT AS SELECT EXTRACTJSONFIELD(source, '$.name') AS SOURCE, EXTRACTJSONFIELD(source, '$.version') AS VERSION, CONCAT(EXTRACTJSONFIELD(source, '$.name'), EXTRACTJSONFIELD(source, '$.version')) AS BOTH FROM TEST;"
+      ],
+      "inputs": [
+        {"topic": "test_topic", "key": 0, "value": "{\"source\": {\"name\": \"cdc\", \"version\": \"1\"}}", "timestamp": 0},
+        {"topic": "test_topic", "key": 0, "value": "{\"source\": {\"name\": \"cdd\", \"version\": \"2\"}}", "timestamp": 0}
+      ],
+      "outputs": [
+        {"topic": "OUTPUT", "key": 0, "value": "{\"SOURCE\":\"cdc\",\"VERSION\":\"1\",\"BOTH\":\"cdc1\"}", "timestamp": 0},
+        {"topic": "OUTPUT", "key": 0, "value": "{\"SOURCE\":\"cdd\",\"VERSION\":\"2\",\"BOTH\":\"cdd2\"}", "timestamp": 0}
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
### Description 

Without the postfixing the code generator shares UDF instances, causing for strange results. e.g. #1328.

So, for example, without this change an expression such as:
```
CONCAT(EXTRACTJSONFIELD(source, '$.name'), EXTRACTJSONFIELD(source, '$.version')) 
```

Will be converted the following approx Java code (casts removed for readability):
```
CONCAT.evaluate(
   EXTRACTJSONFIELD.evaluate(TEST_SOURCE, "$.name"), 
   EXTRACTJSONFIELD.evaluate(TEST_SOURCE, "$.version")
);
```
Where the same `EXTRACTJSONFIELD` usf instance is called twice, meaning it can't cache results of, for example, parsing the json path.  With the change the java code looks like this:
```
CONCAT_0.evaluate(
   EXTRACTJSONFIELD_1.evaluate(TEST_SOURCE, "$.name"), 
   EXTRACTJSONFIELD_2.evaluate(TEST_SOURCE, "$.version")
);
```
Meaning there are two separate UDF instances.

Fixes #1328

### Testing done 
Suitable unit tests added.

### Reviewer checklist
- [ ] Ensure docs are updated if necessary. (eg. if a user visible feature is being added or changed).
- [ ] Ensure relevant issues are linked (description should include text like "Fixes #<issue number>")

