### PR TITLE
Fix system tests (ish)

### DIFF
--- a/ksql-examples/pom.xml
+++ b/ksql-examples/pom.xml
@@ -18,7 +18,7 @@
         <cli.skip-execute>false</cli.skip-execute>
         <cli.main-class>${main-class}</cli.main-class>
         <docker.skip-build>false</docker.skip-build>
-        <arg.version>0.1.0</arg.version>
+        <arg.version>0.2.0</arg.version>
     </properties>
 
     <dependencies>

--- a/ksql-examples/src/test/java/io/confluent/ksql/datagen/GeneratorTest.java
+++ b/ksql-examples/src/test/java/io/confluent/ksql/datagen/GeneratorTest.java
@@ -1,0 +1,72 @@
+/*
+ * Copyright 2018 Confluent Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.confluent.ksql.datagen;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Random;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+import io.confluent.avro.random.generator.Generator;
+
+import static io.confluent.ksql.datagen.util.ResourceUtil.getResourceRoot;
+import static io.confluent.ksql.datagen.util.ResourceUtil.loadContent;
+
+@RunWith(Parameterized.class)
+public class GeneratorTest {
+
+  private static final Random RNG = new Random();
+  private final Path fileName;
+  private final String content;
+
+  @Parameterized.Parameters(name = "{0}")
+  public static Collection<Object[]> data() {
+    return findTestSchemas()
+        .map(fileName -> new Object[]{fileName, loadContent(fileName)})
+        .collect(Collectors.toCollection(ArrayList::new));
+  }
+
+  public GeneratorTest(final Path fileName, final String content) {
+    this.fileName = fileName;
+    this.content = content;
+  }
+
+  @Test
+  public void shouldHandleSchema() {
+    final Generator generator = new Generator(content, RNG);
+    final Object generated = generator.generate();
+    System.out.println(fileName + ": " + generated);
+  }
+
+  private static Stream<Path> findTestSchemas() {
+    try {
+      final Path resourceRoot = getResourceRoot();
+      return Files.list(resourceRoot)
+          .filter(path -> path.toString().endsWith(".avro"));
+
+    } catch (final Exception e) {
+      throw new RuntimeException("failed to find test schemas", e);
+    }
+  }
+}

--- a/ksql-examples/src/test/java/io/confluent/ksql/datagen/util/ResourceUtil.java
+++ b/ksql-examples/src/test/java/io/confluent/ksql/datagen/util/ResourceUtil.java
@@ -1,0 +1,57 @@
+/*
+ * Copyright 2018 Confluent Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.confluent.ksql.datagen.util;
+
+import java.io.IOException;
+import java.net.URI;
+import java.net.URISyntaxException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.FileSystem;
+import java.nio.file.FileSystems;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.Collections;
+import java.util.stream.Collectors;
+
+import io.confluent.ksql.datagen.GeneratorTest;
+
+public final class ResourceUtil {
+
+  private ResourceUtil() {
+  }
+
+  public static String loadContent(final Path filePath) {
+    try {
+      return Files.lines(filePath, StandardCharsets.UTF_8)
+          .collect(Collectors.joining("\n"));
+    } catch (final IOException ioe) {
+      throw new RuntimeException("failed to find test test-schema " + filePath, ioe);
+    }
+  }
+
+  @SuppressWarnings("ConstantConditions")
+  public static Path getResourceRoot() throws IOException, URISyntaxException {
+    final URI uri = GeneratorTest.class.getClassLoader().getResource("product.avro").toURI();
+    if ("jar".equals(uri.getScheme())) {
+      FileSystem fileSystem = FileSystems.newFileSystem(uri, Collections.emptyMap(), null);
+      return fileSystem.getPath("path/to/folder/inside/jar").getParent();
+    } else {
+      return Paths.get(uri).getParent();
+    }
+  }
+}


### PR DESCRIPTION
### Description 
System tests are failing locally due to a change in the DataGen that saw the internal Avro-Random-Generator code being swapped out for an external library. Unfortunately, the external library was missing functionality: the ability to generate STRING fields using iterators.

This PR updates to a new version of the avro-random-generator, to which STRING iteration have been added, and adds a test to detect any similar future errors.

### Testing done 
Added unit tests to ensure all avro schema with the examples project are supported by avro-random-generator.

### Reviewer checklist
- [x] Ensure docs are updated if necessary. (eg. if a user visible feature is being added or changed).
- [x] Ensure relevant issues are linked (description should include text like "Fixes #<issue number>")

