### PR TITLE
HOTFIX: Bump POM version for cp-ksql-server

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,7 +1,7 @@
 #!/usr/bin/env groovy
 
 dockerfile {
-    dockerUpstreamTag = '4.1.x-latest'  // Make sure PR builder points at a valid upstream tag.
+    dockerUpstreamTag = '5.0.x-latest'  // Make sure PR builder points at a valid upstream tag.
     slackChannel = '#ksql-eng'
     upstreamProjects = 'confluentinc/schema-registry'
     dockerRepos = ['confluentinc/ksql-examples', 'confluentinc/ksql-cli', 'confluentinc/ksql-clickstream-demo', 'confluentinc/cp-ksql-server']

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,7 +1,7 @@
 #!/usr/bin/env groovy
 
 dockerfile {
-    dockerUpstreamTag = '5.0.x-latest'  // Make sure PR builder points at a valid upstream tag.
+    dockerUpstreamTag = '4.1.x-latest'  // Make sure PR builder points at a valid upstream tag.
     slackChannel = '#ksql-eng'
     upstreamProjects = 'confluentinc/schema-registry'
     dockerRepos = ['confluentinc/ksql-examples', 'confluentinc/ksql-cli', 'confluentinc/ksql-clickstream-demo', 'confluentinc/cp-ksql-server']

--- a/cp-ksql-server/pom.xml
+++ b/cp-ksql-server/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>io.confluent.ksql</groupId>
         <artifactId>ksql-parent</artifactId>
-        <version>4.1.2-SNAPSHOT</version>
+        <version>5.0.0-SNAPSHOT</version>
     </parent>
 
     <groupId>io.confluent.ksql</groupId>


### PR DESCRIPTION
### Description 
When #1322 merged onto master, it retained the incorrect `4.1.2-SNAPSHOT` version,  breaking the build. This  PR fixes the build.

### Testing done 
`mvn -U clean package -DskipTests` now works.

### Reviewer checklist
- [ ] Ensure docs are updated if necessary. (eg. if a user visible feature is being added or changed).
- [ ] Ensure relevant issues are linked (description should include text like "Fixes #<issue number>")

