### PR TITLE
Skip building jars for the ksql cp docker image.

### DIFF
--- a/cp-ksql-server/pom.xml
+++ b/cp-ksql-server/pom.xml
@@ -91,6 +91,16 @@
                     </execution>
                 </executions>
             </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-jar-plugin</artifactId>
+                <version>2.6</version>
+                <executions>
+                    <execution>
+                        <phase>none</phase>
+                    </execution>
+                </executions>
+            </plugin>
         </plugins>
     </build>
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -38,7 +38,6 @@
         <module>ksql-version-metrics-client</module>
         <module>ksql-console-scripts</module>
         <module>ksql-package</module>
-        <module>cp-ksql-server</module>
     </modules>
 
     <repositories>

--- a/pom.xml
+++ b/pom.xml
@@ -38,6 +38,7 @@
         <module>ksql-version-metrics-client</module>
         <module>ksql-console-scripts</module>
         <module>ksql-package</module>
+        <module>cp-ksql-server</module>
     </modules>
 
     <repositories>


### PR DESCRIPTION
### Description 
Currently packaging is blocked because this fails to build during the packaging job because it tries to build an empty jar. This patch disables building jars for the docker image module.

### Testing done 
None.

### Reviewer checklist
- [ ] Ensure docs are updated if necessary. (eg. if a user visible feature is being added or changed).
- [ ] Ensure relevant issues are linked (description should include text like "Fixes #<issue number>")

