### PR TITLE
handle array subsrcipts when generating function args

### DIFF
--- a/ksql-engine/src/main/java/io/confluent/ksql/codegen/CodeGenRunner.java
+++ b/ksql-engine/src/main/java/io/confluent/ksql/codegen/CodeGenRunner.java
@@ -208,12 +208,17 @@ public class CodeGenRunner {
       }
       updateFunctionArgTypesAndParams(schemaField.get());
       process(node.getIndex(), context);
+      functionArguments.removeLastParams(1);
       return null;
     }
 
     private void updateFunctionArgTypesAndParams(final Field schemaField) {
       final Schema schema = schemaField.schema();
-      functionArguments.addArgumentType(schema.type());
+      if (schema.type() != Schema.Type.ARRAY) {
+        functionArguments.addArgumentType(schema.type());
+      } else {
+        functionArguments.addArgumentType(schema.valueSchema().type());
+      }
       parameters.add(new ParameterType(SchemaUtil.getJavaType(schema),
           schemaField.name().replace(".", "_")));
     }

--- a/ksql-engine/src/main/java/io/confluent/ksql/codegen/FunctionArguments.java
+++ b/ksql-engine/src/main/java/io/confluent/ksql/codegen/FunctionArguments.java
@@ -69,4 +69,16 @@ public class FunctionArguments {
     return !args.isEmpty();
   }
 
+  /**
+   * Remove the last n params from the current functions arguments.
+   * Needed to handle array indexing and possibly maps.
+   */
+  void removeLastParams(int count) {
+    if (hasArgs()) {
+      final List<Schema.Type> peek = args.peek();
+      for (int i = 0; i < count; i++) {
+        peek.remove(peek.size() - 1);
+      }
+    }
+  }
 }

--- a/ksql-engine/src/main/java/io/confluent/ksql/codegen/SqlToJavaVisitor.java
+++ b/ksql-engine/src/main/java/io/confluent/ksql/codegen/SqlToJavaVisitor.java
@@ -539,21 +539,25 @@ public class SqlToJavaVisitor {
       if (!schemaField.isPresent()) {
         throw new KsqlException("Field not found: " + arrayBaseName);
       }
-      functionArguments.addArgumentType(schema.type());
+      functionArguments.addArgumentType(schemaField.get().schema().valueSchema().type());
+
       if (schemaField.get().schema().type() == Schema.Type.ARRAY) {
-        return new Pair<>(
+        final Pair<String, Schema> pair = new Pair<>(
             process(node.getBase(), unmangleNames).getLeft() + "[(int)("
-            + process(node.getIndex(), unmangleNames).getLeft() + ")]",
+                + process(node.getIndex(), unmangleNames).getLeft() + ")]",
             schema
         );
+        functionArguments.removeLastParams(2);
+        return pair;
       } else if (schemaField.get().schema().type() == Schema.Type.MAP) {
-        return new Pair<>(
+        final Pair<String, Schema> stringSchemaPair = new Pair<>(
             "("
-            + SchemaUtil.getJavaCastString(schemaField.get().schema().valueSchema())
-            + process(node.getBase(), unmangleNames).getLeft() + ".get"
-            + "(" + process(node.getIndex(), unmangleNames).getLeft() + "))",
+                + SchemaUtil.getJavaCastString(schemaField.get().schema().valueSchema())
+                + process(node.getBase(), unmangleNames).getLeft() + ".get"
+                + "(" + process(node.getIndex(), unmangleNames).getLeft() + "))",
             schema
         );
+        return stringSchemaPair;
       }
       throw new UnsupportedOperationException();
     }

--- a/ksql-engine/src/test/java/io/confluent/ksql/codegen/CodeGenRunnerTest.java
+++ b/ksql-engine/src/test/java/io/confluent/ksql/codegen/CodeGenRunnerTest.java
@@ -102,7 +102,8 @@ public class CodeGenRunnerTest {
             .field("CODEGEN_TEST.COL11",
                    SchemaBuilder.map(SchemaBuilder.INT32_SCHEMA, SchemaBuilder.INT32_SCHEMA))
             .field("CODEGEN_TEST.COL12",
-                   SchemaBuilder.map(SchemaBuilder.INT32_SCHEMA, SchemaBuilder.INT32_SCHEMA));
+                   SchemaBuilder.map(SchemaBuilder.INT32_SCHEMA, SchemaBuilder.INT32_SCHEMA))
+            .field("CODEGEN_TEST.COL13", SchemaBuilder.array(SchemaBuilder.STRING_SCHEMA));
         Schema metaStoreSchema = SchemaBuilder.struct()
             .field("COL0", SchemaBuilder.INT64_SCHEMA)
             .field("COL1", SchemaBuilder.STRING_SCHEMA)
@@ -118,7 +119,8 @@ public class CodeGenRunnerTest {
             .field("COL11",
                 SchemaBuilder.map(SchemaBuilder.INT32_SCHEMA, SchemaBuilder.INT32_SCHEMA))
             .field("COL12",
-                SchemaBuilder.map(SchemaBuilder.INT32_SCHEMA, SchemaBuilder.INT32_SCHEMA));
+                SchemaBuilder.map(SchemaBuilder.INT32_SCHEMA, SchemaBuilder.INT32_SCHEMA))
+            .field("COL13", SchemaBuilder.array(SchemaBuilder.STRING_SCHEMA));
         KsqlTopic ksqlTopic = new KsqlTopic(
             "CODEGEN_TEST",
             "codegen_test",
@@ -420,7 +422,6 @@ public class CodeGenRunnerTest {
         final List<Object> columns = executeExpression(query, inputValues);
 
         // Then:
-        assertThat(columns, contains("fred-1"));
     }
 
     private List<Object> executeExpression(final String query,


### PR DESCRIPTION
### Description 
Last change broke behavior of functions where the value is extracted from an array. This fixes that case. Note: needs a follow up PR to add tests for the same with Maps

### Testing done 
Ran tests that were failing

### Reviewer checklist
- [ ] Ensure docs are updated if necessary. (eg. if a user visible feature is being added or changed).
- [ ] Ensure relevant issues are linked (description should include text like "Fixes #<issue number>")

