### PR TITLE
Wrap api query id strings in a class

### DIFF
--- a/ksql-cli/src/main/java/io/confluent/ksql/cli/console/Console.java
+++ b/ksql-cli/src/main/java/io/confluent/ksql/cli/console/Console.java
@@ -396,7 +396,7 @@ public abstract class Console implements Closeable {
       tableBuilder.withColumnHeaders("Query ID", "Kafka Topic", "Query String");
       runningQueries.forEach(
           r -> tableBuilder.withRow(
-              r.getId(), String.join(",", r.getSinks()), r.getQueryString()));
+              r.getId().getId(), String.join(",", r.getSinks()), r.getQueryString()));
       tableBuilder.withFooterLine("For detailed information on a Query run: EXPLAIN <Query ID>;");
     } else if (ksqlEntity instanceof SourceDescriptionEntity) {
       SourceDescriptionEntity sourceDescriptionEntity = (SourceDescriptionEntity) ksqlEntity;
@@ -531,7 +531,7 @@ public abstract class Console implements Closeable {
           "-----------------------------------"
       ));
       for (RunningQuery writeQuery : source.getWriteQueries()) {
-        writer().println(writeQuery.getId() + " : " + writeQuery.getQueryString());
+        writer().println(writeQuery.getId().getId() + " : " + writeQuery.getQueryString());
       }
       writer().println("\nFor query topology and execution plan please run: EXPLAIN <QueryId>");
     }
@@ -641,7 +641,7 @@ public abstract class Console implements Closeable {
   }
 
   private void printQueryDescription(QueryDescription query) {
-    writer().println(String.format("%-20s : %s", "ID", query.getId()));
+    writer().println(String.format("%-20s : %s", "ID", query.getId().getId()));
     if (query.getStatementText().length() > 0) {
       writer().println(String.format("%-20s : %s", "SQL", query.getStatementText()));
     }

--- a/ksql-cli/src/test/java/io/confluent/ksql/cli/console/ConsoleTest.java
+++ b/ksql-cli/src/test/java/io/confluent/ksql/cli/console/ConsoleTest.java
@@ -18,6 +18,8 @@ package io.confluent.ksql.cli.console;
 
 import com.google.common.collect.ImmutableList;
 
+import io.confluent.ksql.rest.entity.EntityQueryId;
+import io.confluent.ksql.rest.entity.RunningQuery;
 import org.apache.kafka.connect.data.Field;
 import org.apache.kafka.connect.data.SchemaBuilder;
 import org.junit.After;
@@ -113,7 +115,9 @@ public class ConsoleTest {
     properties.put("k3", true);
 
     List<RunningQuery> queries = new ArrayList<>();
-    queries.add(new RunningQuery("select * from t1", Collections.singleton("Test"), "0"));
+    queries.add(
+        new RunningQuery(
+            "select * from t1", Collections.singleton("Test"), new EntityQueryId("0")));
 
     for (int i = 0; i < 5; i++) {
       KsqlEntityList entityList = new KsqlEntityList(ImmutableList.of(

--- a/ksql-rest-app/src/main/java/io/confluent/ksql/rest/entity/EntityQueryId.java
+++ b/ksql-rest-app/src/main/java/io/confluent/ksql/rest/entity/EntityQueryId.java
@@ -1,0 +1,52 @@
+/**
+ * Copyright 2018 Confluent Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ **/
+
+package io.confluent.ksql.rest.entity;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonValue;
+import io.confluent.ksql.query.QueryId;
+
+import java.util.Objects;
+
+public class EntityQueryId {
+  private final String id;
+
+  public EntityQueryId(QueryId queryId) {
+    this.id = queryId.getId();
+  }
+
+  @JsonCreator
+  public EntityQueryId(final String id) {
+    this.id = id;
+  }
+
+  @JsonValue
+  public String getId() {
+    return id;
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    return o instanceof EntityQueryId
+        && Objects.equals(((EntityQueryId) o).id, id);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hashCode(id);
+  }
+}

--- a/ksql-rest-app/src/main/java/io/confluent/ksql/rest/entity/QueryDescription.java
+++ b/ksql-rest-app/src/main/java/io/confluent/ksql/rest/entity/QueryDescription.java
@@ -33,7 +33,7 @@ import io.confluent.ksql.util.SchemaUtil;
 
 public class QueryDescription {
 
-  private final String id;
+  private final EntityQueryId id;
   private final String statementText;
   private final List<FieldSchemaInfo> schema;
   private final Set<String> sources;
@@ -44,7 +44,7 @@ public class QueryDescription {
 
   @JsonCreator
   public QueryDescription(
-      @JsonProperty("id") String id,
+      @JsonProperty("id") EntityQueryId id,
       @JsonProperty("statementText") String statementText,
       @JsonProperty("schema") List<FieldSchemaInfo> schema,
       @JsonProperty("sources") Set<String> sources,
@@ -65,7 +65,7 @@ public class QueryDescription {
 
   private QueryDescription(String id, QueryMetadata queryMetadata, Set<String> sinks) {
     this(
-        id,
+        new EntityQueryId(id),
         queryMetadata.getStatementString(),
         queryMetadata.getResultSchema().fields().stream().map(
             field -> new FieldSchemaInfo(field.name(), SchemaUtil.describeSchema(field.schema()))
@@ -86,7 +86,7 @@ public class QueryDescription {
     return new QueryDescription("", queryMetadata, Collections.emptySet());
   }
 
-  public String getId() {
+  public EntityQueryId getId() {
     return id;
   }
 

--- a/ksql-rest-app/src/main/java/io/confluent/ksql/rest/entity/RunningQuery.java
+++ b/ksql-rest-app/src/main/java/io/confluent/ksql/rest/entity/RunningQuery.java
@@ -25,13 +25,13 @@ import java.util.Set;
 public class RunningQuery {
   private final String queryString;
   private final Set<String> sinks;
-  private final String id;
+  private final EntityQueryId id;
 
   @JsonCreator
   public RunningQuery(
       @JsonProperty("statementText") String queryString,
       @JsonProperty("sinks") Set<String> sinks,
-      @JsonProperty("id") String id
+      @JsonProperty("id") EntityQueryId id
   ) {
     this.queryString = queryString;
     this.sinks = sinks;
@@ -46,7 +46,7 @@ public class RunningQuery {
     return sinks;
   }
 
-  public String getId() {
+  public EntityQueryId getId() {
     return id;
   }
 

--- a/ksql-rest-app/src/main/java/io/confluent/ksql/rest/server/resources/KsqlResource.java
+++ b/ksql-rest-app/src/main/java/io/confluent/ksql/rest/server/resources/KsqlResource.java
@@ -17,6 +17,7 @@
 package io.confluent.ksql.rest.server.resources;
 
 import io.confluent.ksql.parser.tree.PrintTopic;
+import io.confluent.ksql.rest.entity.EntityQueryId;
 import io.confluent.ksql.rest.entity.QueryDescriptionEntity;
 import io.confluent.ksql.rest.entity.QueryDescription;
 import io.confluent.ksql.rest.entity.QueryDescriptionList;
@@ -380,7 +381,7 @@ public class KsqlResource {
                 q -> new RunningQuery(
                     q.getStatementString(),
                     q.getSinkNames(),
-                    q.getQueryId().getId()))
+                    new EntityQueryId(q.getQueryId())))
             .collect(Collectors.toList()));
   }
 
@@ -431,7 +432,7 @@ public class KsqlResource {
         .stream()
         .filter(predicate)
         .map(q -> new RunningQuery(
-            q.getStatementString(), q.getSinkNames(), q.getQueryId().getId()))
+            q.getStatementString(), q.getSinkNames(), new EntityQueryId(q.getQueryId())))
         .collect(Collectors.toList());
   }
 

--- a/ksql-rest-app/src/test/java/io/confluent/ksql/rest/entity/EntityQueryIDTest.java
+++ b/ksql-rest-app/src/test/java/io/confluent/ksql/rest/entity/EntityQueryIDTest.java
@@ -1,0 +1,24 @@
+package io.confluent.ksql.rest.entity;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.Test;
+
+import java.io.IOException;
+
+import static org.hamcrest.CoreMatchers.equalTo;
+import static org.junit.Assert.assertThat;
+
+public class EntityQueryIDTest {
+  ObjectMapper objectMapper = new ObjectMapper();
+
+  @Test
+  public void shouldSerializeCorrectly() throws IOException {
+    String id = "query-id";
+    String serialized = String.format("\"%s\"", id);
+
+    EntityQueryId deserialized = objectMapper.readValue(serialized, EntityQueryId.class);
+
+    assertThat(deserialized.getId(), equalTo(id));
+    assertThat(objectMapper.writeValueAsString(id), equalTo(serialized));
+  }
+}

--- a/ksql-rest-app/src/test/java/io/confluent/ksql/rest/entity/QueryDescriptionTest.java
+++ b/ksql-rest-app/src/test/java/io/confluent/ksql/rest/entity/QueryDescriptionTest.java
@@ -98,7 +98,7 @@ public class QueryDescriptionTest {
 
     QueryDescription queryDescription = QueryDescription.forQueryMetadata(queryMetadata);
 
-    assertThat(queryDescription.getId(), equalTo(""));
+    assertThat(queryDescription.getId().getId(), equalTo(""));
     assertThat(queryDescription.getExecutionPlan(), equalTo("execution plan"));
     assertThat(queryDescription.getSources(), equalTo(Collections.singleton("source")));
     assertThat(queryDescription.getStatementText(), equalTo("test statement"));
@@ -131,7 +131,7 @@ public class QueryDescriptionTest {
         new QueryId("query_id"), DataSource.DataSourceType.KSTREAM, "app id", null,
         sinkTopic, topology, streamsProperties);
     QueryDescription queryDescription = QueryDescription.forQueryMetadata(queryMetadata);
-    assertThat(queryDescription.getId(), equalTo("query_id"));
+    assertThat(queryDescription.getId().getId(), equalTo("query_id"));
     assertThat(queryDescription.getSinks(), equalTo(Collections.singleton("fake_sink")));
   }
 }

--- a/ksql-rest-app/src/test/java/io/confluent/ksql/rest/server/resources/KsqlResourceTest.java
+++ b/ksql-rest-app/src/test/java/io/confluent/ksql/rest/server/resources/KsqlResourceTest.java
@@ -16,6 +16,7 @@
 
 package io.confluent.ksql.rest.server.resources;
 
+import io.confluent.ksql.rest.entity.EntityQueryId;
 import org.apache.commons.lang3.concurrent.ConcurrentUtils;
 import org.apache.kafka.clients.consumer.ConsumerConfig;
 import org.apache.kafka.clients.consumer.KafkaConsumer;
@@ -453,12 +454,14 @@ public class KsqlResourceTest {
         new RunningQuery(
             queries.get(0).getStatementString(),
             ((PersistentQueryMetadata)queries.get(0)).getSinkNames(),
-            ((PersistentQueryMetadata)queries.get(0)).getQueryId().getId()));
+            new EntityQueryId(
+                ((PersistentQueryMetadata)queries.get(0)).getQueryId())));
     List<RunningQuery> readQueries = Collections.singletonList(
         new RunningQuery(
             queries.get(1).getStatementString(),
             ((PersistentQueryMetadata)queries.get(1)).getSinkNames(),
-            ((PersistentQueryMetadata)queries.get(1)).getQueryId().getId()));
+            new EntityQueryId(
+                ((PersistentQueryMetadata)queries.get(1)).getQueryId())));
     SourceDescription expectedDescription =
         new SourceDescription(
             testResource.getKsqlEngine().getMetaStore().getSource(streamName), false, "JSON",


### PR DESCRIPTION
Adds an EntityQueryId class to represent Query IDs in the API. We don't
use the existing QueryId class as its fairly decoupled from the API and
should be free to change as we evolve how query ids are generated. On the
other hand the representation of the id in the API must not change.

Fixes #1234

### Reviewer checklist
- [x] Ensure docs are updated if necessary. (eg. if a user visible feature is being added or changed).
- [x] Ensure relevant issues are linked (description should include text like "Fixes #<issue number>")

