### PR TITLE
Remove cp-ksql-server from the build to unblock packaging

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -38,7 +38,6 @@
         <module>ksql-version-metrics-client</module>
         <module>ksql-console-scripts</module>
         <module>ksql-package</module>
-        <module>cp-ksql-server</module>
     </modules>
 
     <repositories>


### PR DESCRIPTION
### Description 
Packaging is failing because cp-ksql-server can't build becasue it can't find monitoring interceptors. This is likely a bug in packaging, but disabling this module for now to unblock the preview release.

### Testing done 
None.

### Reviewer checklist
- [ ] Ensure docs are updated if necessary. (eg. if a user visible feature is being added or changed).
- [ ] Ensure relevant issues are linked (description should include text like "Fixes #<issue number>")

