### PR TITLE
Disable server identification verification for SecureIntegrationTest

### DIFF
--- a/ksql-engine/src/test/java/io/confluent/ksql/testutils/EmbeddedSingleNodeKafkaCluster.java
+++ b/ksql-engine/src/test/java/io/confluent/ksql/testutils/EmbeddedSingleNodeKafkaCluster.java
@@ -23,6 +23,7 @@ import com.google.common.io.Files;
 import org.apache.kafka.clients.consumer.ConsumerConfig;
 import org.apache.kafka.common.acl.AclOperation;
 import org.apache.kafka.common.acl.AclPermissionType;
+import org.apache.kafka.common.config.SslConfigs;
 import org.apache.kafka.common.resource.Resource;
 import org.apache.kafka.common.security.JaasUtils;
 import org.apache.kafka.common.security.auth.KafkaPrincipal;
@@ -328,9 +329,11 @@ public class EmbeddedSingleNodeKafkaCluster extends ExternalResource {
       brokerConfig.put(KafkaConfig.InterBrokerSecurityProtocolProp(), SASL_SSL.name());
       brokerConfig.put(KafkaConfig.SaslMechanismInterBrokerProtocolProp(), "PLAIN");
       brokerConfig.putAll(ServerKeyStore.keyStoreProps());
+      brokerConfig.put(SslConfigs.SSL_ENDPOINT_IDENTIFICATION_ALGORITHM_CONFIG, "");
 
       clientConfig.putAll(SecureKafkaHelper.getSecureCredentialsConfig(VALID_USER1));
       clientConfig.putAll(ClientTrustStore.trustStoreProps());
+      clientConfig.put(SslConfigs.SSL_ENDPOINT_IDENTIFICATION_ALGORITHM_CONFIG, "");
       return this;
     }
 

--- a/ksql-engine/src/test/java/io/confluent/ksql/testutils/secure/ClientTrustStore.java
+++ b/ksql-engine/src/test/java/io/confluent/ksql/testutils/secure/ClientTrustStore.java
@@ -56,7 +56,8 @@ public final class ClientTrustStore {
   public static Map<String, ?> trustStoreProps() {
     return ImmutableMap.of(
         SslConfigs.SSL_TRUSTSTORE_LOCATION_CONFIG, trustStorePath(),
-        SslConfigs.SSL_TRUSTSTORE_PASSWORD_CONFIG, trustStorePassword()
+        SslConfigs.SSL_TRUSTSTORE_PASSWORD_CONFIG, trustStorePassword(),
+        SslConfigs.SSL_ENDPOINT_IDENTIFICATION_ALGORITHM_CONFIG, ""
     );
   }
 

--- a/ksql-engine/src/test/java/io/confluent/ksql/testutils/secure/SecureKafkaHelper.java
+++ b/ksql-engine/src/test/java/io/confluent/ksql/testutils/secure/SecureKafkaHelper.java
@@ -18,6 +18,7 @@ package io.confluent.ksql.testutils.secure;
 
 import org.apache.kafka.clients.CommonClientConfigs;
 import org.apache.kafka.common.config.SaslConfigs;
+import org.apache.kafka.common.config.SslConfigs;
 import org.apache.kafka.common.security.auth.SecurityProtocol;
 import org.apache.kafka.common.security.plain.PlainLoginModule;
 
@@ -46,6 +47,7 @@ public final class SecureKafkaHelper {
   public static void addSecureCredentialsToConfig(final Map<String, Object> props) {
     props.put(CommonClientConfigs.SECURITY_PROTOCOL_CONFIG, SecurityProtocol.SASL_SSL.name);
     props.put(SaslConfigs.SASL_MECHANISM, PLAIN_SASL_MECHANISM);
+    props.put(SslConfigs.SSL_ENDPOINT_IDENTIFICATION_ALGORITHM_CONFIG, "");
   }
 
   public static String buildJaasConfig(final Credentials credentials) {


### PR DESCRIPTION
Kafka recently enabled server id verification by default for all tls connections.
This breaks our secure integration test, which doesn't include a valid common or
dns name in its certs. Furthermore, since some of the embedded services listen on
local addresses other than localhost and lo/lo0, we can no longer statically generate
the certs for the test. This patch explicitly disables the check for all the test
clients.

### Description 
_What behavior do you want to change, why, how does your patch achieve the changes?_

### Testing done 
_Describe the testing stategy. Unit and integration tests are expected for any behavior changes._

### Reviewer checklist
- [ ] Ensure docs are updated if necessary. (eg. if a user visible feature is being added or changed).
- [ ] Ensure relevant issues are linked (description should include text like "Fixes #<issue number>")

