### PR TITLE
Upgrade handling step 1: clean up KSQL configs

### DIFF
--- a/ksql-cli/src/main/java/io/confluent/ksql/cli/Cli.java
+++ b/ksql-cli/src/main/java/io/confluent/ksql/cli/Cli.java
@@ -35,7 +35,6 @@ import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Paths;
 import java.util.ArrayList;
-import java.util.Collections;
 import java.util.List;
 import java.util.Objects;
 import java.util.Optional;
@@ -65,7 +64,6 @@ import io.confluent.ksql.rest.entity.CommandStatusEntity;
 import io.confluent.ksql.rest.entity.KsqlEntity;
 import io.confluent.ksql.rest.entity.KsqlEntityList;
 import io.confluent.ksql.rest.entity.KsqlErrorMessage;
-import io.confluent.ksql.rest.entity.PropertiesList;
 import io.confluent.ksql.rest.entity.StreamedRow;
 import io.confluent.ksql.rest.server.resources.Errors;
 import io.confluent.ksql.util.CliUtils;
@@ -380,13 +378,9 @@ public class Cli implements Closeable, AutoCloseable {
     return consecutiveStatements;
   }
 
-  private void listProperties(String statementText) throws IOException {
-    KsqlEntityList ksqlEntityList = restClient.makeKsqlRequest(statementText).getResponse();
-    PropertiesList propertiesList = (PropertiesList) ksqlEntityList.get(0);
-    propertiesList.getProperties().putAll(restClient.getLocalProperties());
-    terminal.printKsqlEntityList(
-        Collections.singletonList(propertiesList)
-    );
+  private void listProperties(final String statementText) throws IOException {
+    final KsqlEntityList ksqlEntityList = restClient.makeKsqlRequest(statementText).getResponse();
+    terminal.printKsqlEntityList(ksqlEntityList);
   }
 
   private void printKsqlResponse(RestResponse<KsqlEntityList> response) throws IOException {

--- a/ksql-cli/src/main/java/io/confluent/ksql/util/CliUtils.java
+++ b/ksql-cli/src/main/java/io/confluent/ksql/util/CliUtils.java
@@ -29,6 +29,7 @@ import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.Map;
 import java.util.Optional;
+import java.util.stream.Collectors;
 
 import io.confluent.ksql.ddl.DdlConfig;
 import io.confluent.ksql.parser.AstBuilder;
@@ -80,18 +81,18 @@ public class CliUtils {
     }
   }
 
-  public static PropertiesList propertiesListWithOverrides(
-      PropertiesList propertiesList,
-      Map<String, Object> localProperties
-  ) {
-    Map<String, Object> properties = propertiesList.getProperties();
-    for (Map.Entry<String, Object> localPropertyEntry : localProperties.entrySet()) {
-      properties.put(
-          "(LOCAL OVERRIDE) " + localPropertyEntry.getKey(),
-          localPropertyEntry.getValue()
-      );
-    }
-    return new PropertiesList(propertiesList.getStatementText(), properties);
+  public static Map<String, Object> propertiesListWithOverrides(
+      final PropertiesList propertiesList) {
+    return propertiesList.getProperties().entrySet()
+        .stream()
+        .collect(
+            Collectors.toMap(
+              e ->
+                  propertiesList.getOverwrittenProperties().contains(e.getKey())
+                      ? e.getKey() + " (LOCAL OVERRIDE)" : e.getKey(),
+              Map.Entry::getValue
+            )
+        );
   }
 
   public static String getLocalServerAddress(int portNumber) {

--- a/ksql-cli/src/test/java/io/confluent/ksql/CliTest.java
+++ b/ksql-cli/src/test/java/io/confluent/ksql/CliTest.java
@@ -189,10 +189,10 @@ public class CliTest extends TestRunner {
     Map<String, Object> configMap = new HashMap<>();
     configMap.put(ConsumerConfig.BOOTSTRAP_SERVERS_CONFIG, CLUSTER.bootstrapServers());
     configMap.put(KsqlRestConfig.LISTENERS_CONFIG, CliUtils.getLocalServerAddress(PORT));
-    configMap.put("application.id", "KSQL");
-    configMap.put("commit.interval.ms", 0);
-    configMap.put("cache.max.bytes.buffering", 0);
-    configMap.put("auto.offset.reset", "earliest");
+    configMap.put(KsqlConfig.KSQL_STREAMS_PREFIX + "application.id", "KSQL");
+    configMap.put(KsqlConfig.KSQL_STREAMS_PREFIX + "commit.interval.ms", 0);
+    configMap.put(KsqlConfig.KSQL_STREAMS_PREFIX + "cache.max.bytes.buffering", 0);
+    configMap.put(KsqlConfig.KSQL_STREAMS_PREFIX + "auto.offset.reset", "earliest");
     configMap.put(KsqlConfig.KSQL_ENABLE_UDFS, false);
     return configMap;
   }
@@ -206,7 +206,9 @@ public class CliTest extends TestRunner {
   private static Map<String, Object> validStartUpConfigs() {
     // TODO: these configs should be set with other configs on start-up, rather than setup later.
     Map<String, Object> startConfigs = genDefaultConfigMap();
-    startConfigs.put("num.stream.threads", 4);
+    startConfigs.remove(ConsumerConfig.BOOTSTRAP_SERVERS_CONFIG);
+    startConfigs.remove(KsqlRestConfig.LISTENERS_CONFIG);
+    startConfigs.put(KsqlConfig.KSQL_STREAMS_PREFIX + "num.stream.threads", 4);
 
     startConfigs.put(SINK_NUMBER_OF_REPLICAS_PROPERTY, 1);
     startConfigs.put(SINK_NUMBER_OF_PARTITIONS_PROPERTY, 4);
@@ -217,7 +219,10 @@ public class CliTest extends TestRunner {
     startConfigs.put(KSQL_TABLE_STATESTORE_NAME_SUFFIX_CONFIG, KSQL_TABLE_STATESTORE_NAME_SUFFIX_DEFAULT);
     startConfigs.put(KSQL_PERSISTENT_QUERY_NAME_PREFIX_CONFIG, KSQL_PERSISTENT_QUERY_NAME_PREFIX_DEFAULT);
     startConfigs.put(KsqlConfig.SCHEMA_REGISTRY_URL_PROPERTY, KsqlConfig.defaultSchemaRegistryUrl);
-    startConfigs.put(StreamsConfig.DEFAULT_DESERIALIZATION_EXCEPTION_HANDLER_CLASS_CONFIG, LogMetricAndContinueExceptionHandler.class.getName());
+    startConfigs.put(
+        KsqlConfig.KSQL_STREAMS_PREFIX
+            + StreamsConfig.DEFAULT_DESERIALIZATION_EXCEPTION_HANDLER_CLASS_CONFIG,
+        LogMetricAndContinueExceptionHandler.class.getName());
     return startConfigs;
   }
 

--- a/ksql-cli/src/test/java/io/confluent/ksql/cli/console/ConsoleTest.java
+++ b/ksql-cli/src/test/java/io/confluent/ksql/cli/console/ConsoleTest.java
@@ -123,7 +123,7 @@ public class ConsoleTest {
     for (int i = 0; i < 5; i++) {
       KsqlEntityList entityList = new KsqlEntityList(ImmutableList.of(
           new CommandStatusEntity("e", "topic/1/create", "SUCCESS", "Success Message"),
-          new PropertiesList("e", properties),
+          new PropertiesList("e", properties, Collections.emptyList()),
           new Queries("e", queries),
           new SourceDescriptionEntity(
               "e",

--- a/ksql-cli/src/test/java/io/confluent/ksql/util/CliUtilsTest.java
+++ b/ksql-cli/src/test/java/io/confluent/ksql/util/CliUtilsTest.java
@@ -23,7 +23,7 @@ import org.apache.kafka.clients.consumer.ConsumerConfig;
 import org.junit.Test;
 
 import static org.hamcrest.CoreMatchers.equalTo;
-import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.Matchers.hasKey;
 import static org.junit.Assert.assertThat;
 import static org.junit.Assert.fail;
 
@@ -57,7 +57,7 @@ public class CliUtilsTest {
     );
     final Map<String, Object> properties = CliUtils.propertiesListWithOverrides(serverPropertiesList);
 
-    assertThat(properties.containsKey(key + " (LOCAL OVERRIDE)"), is(true));
+    assertThat(properties, hasKey(key + " (LOCAL OVERRIDE)"));
     assertThat(properties.get(key + " (LOCAL OVERRIDE)"), equalTo("earliest"));
   }
 

--- a/ksql-common/src/main/java/io/confluent/ksql/util/KsqlConfig.java
+++ b/ksql-common/src/main/java/io/confluent/ksql/util/KsqlConfig.java
@@ -88,7 +88,6 @@ public class KsqlConfig extends AbstractConfig implements Cloneable {
   public static final String KSQL_COLLECT_UDF_METRICS = "ksql.udf.collect.metrics";
   public static final String KSQL_UDF_SECURITY_MANAGER_ENABLED = "ksql.udf.enable.security.manager";
 
-  private final Map<String, Object> ksqlConfigProps;
   private final Map<String, Object> ksqlStreamConfigProps;
 
   private static final ConfigDef CONFIG_DEF;
@@ -247,10 +246,6 @@ public class KsqlConfig extends AbstractConfig implements Cloneable {
     }
 
     applyStreamsConfig(originals());
-  }
-
-  public Map<String, Object> getKsqlConfigProps() {
-    return Collections.unmodifiableMap(values());
   }
 
   public Map<String, Object> getKsqlStreamConfigProps() {

--- a/ksql-common/src/main/java/io/confluent/ksql/util/KsqlConstants.java
+++ b/ksql-common/src/main/java/io/confluent/ksql/util/KsqlConstants.java
@@ -43,4 +43,6 @@ public class KsqlConstants {
   public static final int defaultNumberOfStreamsThreads = 4;
 
   public static final String RUN_SCRIPT_STATEMENTS_CONTENT = "ksql.run.script.statements";
+  public static final String KSQL_TIMESTAMP_COLUMN_INDEX = "ksql.timestamp.column.index";
+  public static final String STRING_TIMESTAMP_FORMAT = "ksq.timestamp.string.format";
 }

--- a/ksql-common/src/main/java/io/confluent/ksql/util/timestamp/LongColumnTimestampExtractionPolicy.java
+++ b/ksql-common/src/main/java/io/confluent/ksql/util/timestamp/LongColumnTimestampExtractionPolicy.java
@@ -19,6 +19,7 @@ package io.confluent.ksql.util.timestamp;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
 
+import io.confluent.ksql.util.KsqlConstants;
 import org.apache.kafka.streams.StreamsConfig;
 
 import java.util.Map;
@@ -40,8 +41,8 @@ public class LongColumnTimestampExtractionPolicy implements TimestampExtractionP
   @Override
   public void applyTo(final KsqlConfig config, final Map<String, Object> newStreamProperties) {
     newStreamProperties.put(
-        KsqlConfig.KSQL_TIMESTAMP_COLUMN_INDEX,
-        config.get(KsqlConfig.KSQL_TIMESTAMP_COLUMN_INDEX)
+        KsqlConstants.KSQL_TIMESTAMP_COLUMN_INDEX,
+        config.getKsqlTimestampColumnIndex()
     );
     newStreamProperties.put(
         StreamsConfig.DEFAULT_TIMESTAMP_EXTRACTOR_CLASS_CONFIG,

--- a/ksql-common/src/main/java/io/confluent/ksql/util/timestamp/LongTimestampExtractor.java
+++ b/ksql-common/src/main/java/io/confluent/ksql/util/timestamp/LongTimestampExtractor.java
@@ -17,7 +17,7 @@
 package io.confluent.ksql.util.timestamp;
 
 import io.confluent.ksql.GenericRow;
-import io.confluent.ksql.util.KsqlConfig;
+import io.confluent.ksql.util.KsqlConstants;
 import org.apache.kafka.clients.consumer.ConsumerRecord;
 import org.apache.kafka.common.Configurable;
 import org.apache.kafka.streams.processor.TimestampExtractor;
@@ -34,8 +34,8 @@ public class LongTimestampExtractor implements TimestampExtractor, Configurable 
 
   @Override
   public void configure(Map<String, ?> map) {
-    if (map.containsKey(KsqlConfig.KSQL_TIMESTAMP_COLUMN_INDEX)) {
-      timestampColumnindex = (Integer) map.get(KsqlConfig.KSQL_TIMESTAMP_COLUMN_INDEX);
+    if (map.containsKey(KsqlConstants.KSQL_TIMESTAMP_COLUMN_INDEX)) {
+      timestampColumnindex = (Integer) map.get(KsqlConstants.KSQL_TIMESTAMP_COLUMN_INDEX);
     }
   }
 

--- a/ksql-common/src/main/java/io/confluent/ksql/util/timestamp/StringTimestampExtractionPolicy.java
+++ b/ksql-common/src/main/java/io/confluent/ksql/util/timestamp/StringTimestampExtractionPolicy.java
@@ -19,6 +19,7 @@ package io.confluent.ksql.util.timestamp;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
 
+import io.confluent.ksql.util.KsqlConstants;
 import org.apache.kafka.streams.StreamsConfig;
 
 import java.util.Map;
@@ -45,14 +46,14 @@ public class StringTimestampExtractionPolicy implements TimestampExtractionPolic
   public void applyTo(final KsqlConfig config,
                       final Map<String, Object> newStreamProperties) {
     newStreamProperties.put(
-        KsqlConfig.KSQL_TIMESTAMP_COLUMN_INDEX,
-        config.get(KsqlConfig.KSQL_TIMESTAMP_COLUMN_INDEX)
+        KsqlConstants.KSQL_TIMESTAMP_COLUMN_INDEX,
+        config.getKsqlTimestampColumnIndex()
     );
     newStreamProperties.put(
         StreamsConfig.DEFAULT_TIMESTAMP_EXTRACTOR_CLASS_CONFIG,
         StringTimestampExtractor.class
     );
-    newStreamProperties.put(KsqlConfig.STRING_TIMESTAMP_FORMAT, format);
+    newStreamProperties.put(KsqlConstants.STRING_TIMESTAMP_FORMAT, format);
   }
 
   @Override

--- a/ksql-common/src/main/java/io/confluent/ksql/util/timestamp/StringTimestampExtractor.java
+++ b/ksql-common/src/main/java/io/confluent/ksql/util/timestamp/StringTimestampExtractor.java
@@ -16,6 +16,7 @@
 
 package io.confluent.ksql.util.timestamp;
 
+import io.confluent.ksql.util.KsqlConstants;
 import org.apache.kafka.clients.consumer.ConsumerRecord;
 import org.apache.kafka.common.Configurable;
 import org.apache.kafka.common.config.ConfigException;
@@ -24,7 +25,6 @@ import org.apache.kafka.streams.processor.TimestampExtractor;
 import java.util.Map;
 
 import io.confluent.ksql.GenericRow;
-import io.confluent.ksql.util.KsqlConfig;
 import io.confluent.ksql.util.KsqlException;
 
 public class StringTimestampExtractor implements TimestampExtractor, Configurable {
@@ -50,16 +50,16 @@ public class StringTimestampExtractor implements TimestampExtractor, Configurabl
 
   @Override
   public void configure(final Map<String, ?> map) {
-    format = (String) map.get(KsqlConfig.STRING_TIMESTAMP_FORMAT);
+    format = (String) map.get(KsqlConstants.STRING_TIMESTAMP_FORMAT);
     if (format == null) {
       throw new ConfigException("Value of "
-          + KsqlConfig.STRING_TIMESTAMP_FORMAT
+          + KsqlConstants.STRING_TIMESTAMP_FORMAT
           + " must not be null");
     }
-    final Integer index = (Integer) map.get(KsqlConfig.KSQL_TIMESTAMP_COLUMN_INDEX);
+    final Integer index = (Integer) map.get(KsqlConstants.KSQL_TIMESTAMP_COLUMN_INDEX);
     if (index == null || index < 0) {
       throw new ConfigException("Value of "
-          + KsqlConfig.KSQL_TIMESTAMP_COLUMN_INDEX
+          + KsqlConstants.KSQL_TIMESTAMP_COLUMN_INDEX
           + " must be an integer >= 0");
     }
     this.timestampColumn = index;

--- a/ksql-common/src/test/java/io/confluent/ksql/util/KsqlConfigTest.java
+++ b/ksql-common/src/test/java/io/confluent/ksql/util/KsqlConfigTest.java
@@ -89,7 +89,7 @@ public class KsqlConfigTest {
     final KsqlConfig ksqlConfigClone = ksqlConfig.cloneWithPropertyOverwrite(
         Collections.singletonMap(
             KsqlConfig.KSQL_SERVICE_ID_CONFIG, "test-2"));
-    Object result = ksqlConfigClone.getKsqlConfigProps().get(KsqlConfig.KSQL_SERVICE_ID_CONFIG);
+    String result = ksqlConfigClone.getString(KsqlConfig.KSQL_SERVICE_ID_CONFIG);
     assertThat(result, equalTo("test-2"));
   }
 

--- a/ksql-common/src/test/java/io/confluent/ksql/util/KsqlConfigTest.java
+++ b/ksql-common/src/test/java/io/confluent/ksql/util/KsqlConfigTest.java
@@ -41,8 +41,8 @@ public class KsqlConfigTest {
 
     KsqlConfig ksqlConfig = new KsqlConfig(initialProps);
 
-    assertThat(ksqlConfig.get(KsqlConfig.SINK_NUMBER_OF_PARTITIONS_PROPERTY), equalTo(10));
-    assertThat(ksqlConfig.get(KsqlConfig.SINK_NUMBER_OF_REPLICAS_PROPERTY), equalTo((short) 3));
+    assertThat(ksqlConfig.getInt(KsqlConfig.SINK_NUMBER_OF_PARTITIONS_PROPERTY), equalTo(10));
+    assertThat(ksqlConfig.getShort(KsqlConfig.SINK_NUMBER_OF_REPLICAS_PROPERTY), equalTo((short) 3));
 
   }
 

--- a/ksql-common/src/test/java/io/confluent/ksql/util/timestamp/LongTimestampExtractionPolicyTest.java
+++ b/ksql-common/src/test/java/io/confluent/ksql/util/timestamp/LongTimestampExtractionPolicyTest.java
@@ -17,7 +17,9 @@
 
 package io.confluent.ksql.util.timestamp;
 
+import io.confluent.ksql.util.KsqlConstants;
 import org.apache.kafka.streams.StreamsConfig;
+import org.junit.Before;
 import org.junit.Test;
 
 import java.util.Collections;
@@ -31,17 +33,21 @@ import static org.hamcrest.MatcherAssert.assertThat;
 
 public class LongTimestampExtractionPolicyTest {
 
-  private final KsqlConfig config = new KsqlConfig(Collections.singletonMap(
-      KsqlConfig.KSQL_TIMESTAMP_COLUMN_INDEX, 1));
+  private final KsqlConfig config = new KsqlConfig(Collections.emptyMap());
 
   private final Map<String, Object> properties = new HashMap<>();
   private final LongColumnTimestampExtractionPolicy policy
       = new LongColumnTimestampExtractionPolicy("field");
 
+  @Before
+  public void setup() {
+    config.setKsqlTimestampColumnIndex(1);
+  }
+
   @Test
   public void shouldSetTimestampColumnIndexFromConfig() {
     policy.applyTo(config, properties);
-    assertThat(properties.get(KsqlConfig.KSQL_TIMESTAMP_COLUMN_INDEX), equalTo(1));
+    assertThat(properties.get(KsqlConstants.KSQL_TIMESTAMP_COLUMN_INDEX), equalTo(1));
   }
 
   @Test

--- a/ksql-common/src/test/java/io/confluent/ksql/util/timestamp/StringTimestampExtractionPolicyTest.java
+++ b/ksql-common/src/test/java/io/confluent/ksql/util/timestamp/StringTimestampExtractionPolicyTest.java
@@ -17,7 +17,9 @@
 
 package io.confluent.ksql.util.timestamp;
 
+import io.confluent.ksql.util.KsqlConstants;
 import org.apache.kafka.streams.StreamsConfig;
+import org.junit.Before;
 import org.junit.Test;
 
 import java.util.Collections;
@@ -32,17 +34,21 @@ import static org.hamcrest.MatcherAssert.assertThat;
 public class StringTimestampExtractionPolicyTest {
 
   private static final String format = "yyyy-MM-DD";
-  private final KsqlConfig config = new KsqlConfig(Collections.singletonMap(
-      KsqlConfig.KSQL_TIMESTAMP_COLUMN_INDEX, 1));
+  private final KsqlConfig config = new KsqlConfig(Collections.emptyMap());
 
   private final Map<String, Object> properties = new HashMap<>();
   private final StringTimestampExtractionPolicy policy
       = new StringTimestampExtractionPolicy("field", format);
 
+  @Before
+  public void setup() {
+    config.setKsqlTimestampColumnIndex(1);
+  }
+
   @Test
   public void shouldSetTimestampColumnIndexFromConfig() {
     policy.applyTo(config, properties);
-    assertThat(properties.get(KsqlConfig.KSQL_TIMESTAMP_COLUMN_INDEX), equalTo(1));
+    assertThat(properties.get(KsqlConstants.KSQL_TIMESTAMP_COLUMN_INDEX), equalTo(1));
   }
 
   @Test
@@ -55,7 +61,7 @@ public class StringTimestampExtractionPolicyTest {
   @Test
   public void shouldSetFormatInProperties() {
     policy.applyTo(config, properties);
-    assertThat(properties.get(KsqlConfig.STRING_TIMESTAMP_FORMAT),
+    assertThat(properties.get(KsqlConstants.STRING_TIMESTAMP_FORMAT),
         equalTo(format));
   }
 

--- a/ksql-common/src/test/java/io/confluent/ksql/util/timestamp/StringTimestampExtractorTest.java
+++ b/ksql-common/src/test/java/io/confluent/ksql/util/timestamp/StringTimestampExtractorTest.java
@@ -17,6 +17,7 @@
 
 package io.confluent.ksql.util.timestamp;
 
+import io.confluent.ksql.util.KsqlConstants;
 import org.apache.kafka.clients.consumer.ConsumerRecord;
 import org.apache.kafka.common.config.ConfigException;
 import org.junit.Test;
@@ -28,7 +29,6 @@ import java.util.HashMap;
 import java.util.Map;
 
 import io.confluent.ksql.GenericRow;
-import io.confluent.ksql.util.KsqlConfig;
 
 import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.MatcherAssert.assertThat;
@@ -42,8 +42,8 @@ public class StringTimestampExtractorTest {
   @Test
   public void shouldExtractTimestampFromStringWIthFormat() throws ParseException {
     final Map props = new HashMap() {{
-      put(KsqlConfig.STRING_TIMESTAMP_FORMAT, format);
-      put(KsqlConfig.KSQL_TIMESTAMP_COLUMN_INDEX, 0);
+      put(KsqlConstants.STRING_TIMESTAMP_FORMAT, format);
+      put(KsqlConstants.KSQL_TIMESTAMP_COLUMN_INDEX, 0);
     }};
     timestampExtractor.configure(props);
     final String stringTime = "2010-Jan-11";
@@ -59,22 +59,22 @@ public class StringTimestampExtractorTest {
   @Test(expected = ConfigException.class)
   public void shouldThrowIfFormatNotSuppliedDuringConfigure() {
     timestampExtractor.configure(Collections.singletonMap(
-        KsqlConfig.KSQL_TIMESTAMP_COLUMN_INDEX,
+        KsqlConstants.KSQL_TIMESTAMP_COLUMN_INDEX,
         0));
   }
 
   @Test(expected = ConfigException.class)
   public void shouldThrowIfColumnIndexNotSet() {
     timestampExtractor.configure(Collections.singletonMap(
-        KsqlConfig.STRING_TIMESTAMP_FORMAT,
+        KsqlConstants.STRING_TIMESTAMP_FORMAT,
         format));
   }
 
   @Test(expected = ConfigException.class)
   public void shouldThrowIfColumnIndexIsNegative() {
     final Map props = new HashMap() {{
-      put(KsqlConfig.STRING_TIMESTAMP_FORMAT, format);
-      put(KsqlConfig.KSQL_TIMESTAMP_COLUMN_INDEX, -1);
+      put(KsqlConstants.STRING_TIMESTAMP_FORMAT, format);
+      put(KsqlConstants.KSQL_TIMESTAMP_COLUMN_INDEX, -1);
     }};
     timestampExtractor.configure(props);
   }
@@ -83,8 +83,8 @@ public class StringTimestampExtractorTest {
   @Test(expected = ConfigException.class)
   public void shouldThrowOnInvalidFormat() {
     final Map props = new HashMap() {{
-      put(KsqlConfig.STRING_TIMESTAMP_FORMAT, "lahdfl");
-      put(KsqlConfig.KSQL_TIMESTAMP_COLUMN_INDEX, 0);
+      put(KsqlConstants.STRING_TIMESTAMP_FORMAT, "lahdfl");
+      put(KsqlConstants.KSQL_TIMESTAMP_COLUMN_INDEX, 0);
     }};
     timestampExtractor.configure(props);
 

--- a/ksql-engine/src/main/java/io/confluent/ksql/KsqlEngine.java
+++ b/ksql-engine/src/main/java/io/confluent/ksql/KsqlEngine.java
@@ -616,10 +616,9 @@ public class KsqlEngine implements Closeable {
   }
 
   public Map<String, Object> getKsqlConfigProperties(Map<String, Object> overwriteProperties) {
-    return
-        ksqlConfig
-            .cloneWithPropertyOverwrite(overwriteProperties)
-            .getAllProps();
+    return ksqlConfig
+        .cloneWithPropertyOverwrite(overwriteProperties)
+        .getAllProps();
   }
 
   public KsqlConfig getKsqlConfig() {

--- a/ksql-engine/src/main/java/io/confluent/ksql/KsqlEngine.java
+++ b/ksql-engine/src/main/java/io/confluent/ksql/KsqlEngine.java
@@ -130,7 +130,7 @@ public class KsqlEngine implements Closeable {
                     final MetaStore metaStore) {
 
     this(ksqlConfig, topicClient, new CachedSchemaRegistryClient(
-        (String) ksqlConfig.get(KsqlConfig.SCHEMA_REGISTRY_URL_PROPERTY), 1000),
+         ksqlConfig.getString(KsqlConfig.SCHEMA_REGISTRY_URL_PROPERTY), 1000),
          metaStore
     );
   }
@@ -615,11 +615,11 @@ public class KsqlEngine implements Closeable {
     return new ArrayList<>(IMMUTABLE_PROPERTIES);
   }
 
-  public Map<String, Object> getKsqlConfigProperties() {
-    Map<String, Object> configProperties = new HashMap<>();
-    configProperties.putAll(ksqlConfig.getKsqlConfigProps());
-    configProperties.putAll(ksqlConfig.getKsqlStreamConfigProps());
-    return configProperties;
+  public Map<String, Object> getKsqlConfigProperties(Map<String, Object> overwriteProperties) {
+    return
+        ksqlConfig
+            .cloneWithPropertyOverwrite(overwriteProperties)
+            .getAllProps();
   }
 
   public KsqlConfig getKsqlConfig() {

--- a/ksql-engine/src/main/java/io/confluent/ksql/physical/PhysicalPlanBuilder.java
+++ b/ksql-engine/src/main/java/io/confluent/ksql/physical/PhysicalPlanBuilder.java
@@ -24,6 +24,7 @@ import org.apache.kafka.streams.StreamsConfig;
 import org.apache.kafka.streams.Topology;
 
 import java.util.Arrays;
+import java.util.HashMap;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
@@ -126,9 +127,9 @@ public class PhysicalPlanBuilder {
     }
     String serviceId = getServiceId();
     String persistanceQueryPrefix =
-        ksqlConfig.get(KsqlConfig.KSQL_PERSISTENT_QUERY_NAME_PREFIX_CONFIG).toString();
+        ksqlConfig.getString(KsqlConfig.KSQL_PERSISTENT_QUERY_NAME_PREFIX_CONFIG);
     String transientQueryPrefix =
-        ksqlConfig.get(KsqlConfig.KSQL_TRANSIENT_QUERY_NAME_PREFIX_CONFIG).toString();
+        ksqlConfig.getString(KsqlConfig.KSQL_TRANSIENT_QUERY_NAME_PREFIX_CONFIG);
 
     if (isBareQuery) {
       return buildPlanForBareQuery(
@@ -225,7 +226,7 @@ public class PhysicalPlanBuilder {
               outputNode.getTimestampExtractionPolicy(),
               outputNode.getKsqlTopic(),
               outputNode.getId().toString()
-                  + ksqlConfig.get(KsqlConfig.KSQL_TABLE_STATESTORE_NAME_SUFFIX_CONFIG),
+                  + ksqlConfig.getString(KsqlConfig.KSQL_TABLE_STATESTORE_NAME_SUFFIX_CONFIG),
               schemaKTable.isWindowed()
           );
     } else {
@@ -344,23 +345,12 @@ public class PhysicalPlanBuilder {
       final KsqlConfig ksqlConfig,
       final Map<String, Object> overriddenProperties
   ) {
-    Map<String, Object> newStreamsProperties = ksqlConfig.getKsqlStreamConfigProps();
+    final Map<String, Object> newStreamsProperties
+        = new HashMap<>(ksqlConfig.getKsqlStreamConfigProps());
     newStreamsProperties.putAll(overriddenProperties);
     newStreamsProperties.put(StreamsConfig.APPLICATION_ID_CONFIG, applicationId);
-    newStreamsProperties.put(
-        ConsumerConfig.AUTO_OFFSET_RESET_CONFIG,
-        ksqlConfig.get(ConsumerConfig.AUTO_OFFSET_RESET_CONFIG)
-    );
-    newStreamsProperties.put(
-        StreamsConfig.COMMIT_INTERVAL_MS_CONFIG,
-        ksqlConfig.get(StreamsConfig.COMMIT_INTERVAL_MS_CONFIG)
-    );
-    newStreamsProperties.put(
-        StreamsConfig.CACHE_MAX_BYTES_BUFFERING_CONFIG,
-        ksqlConfig.get(StreamsConfig.CACHE_MAX_BYTES_BUFFERING_CONFIG)
-    );
 
-    final Integer timestampIndex = (Integer) ksqlConfig.get(KsqlConfig.KSQL_TIMESTAMP_COLUMN_INDEX);
+    final Integer timestampIndex = ksqlConfig.getKsqlTimestampColumnIndex();
     if (timestampIndex != null && timestampIndex >= 0) {
       outputNode.getSourceTimestampExtractionPolicy().applyTo(ksqlConfig, newStreamsProperties);
     }
@@ -402,7 +392,7 @@ public class PhysicalPlanBuilder {
   // Package private because of test
   String getServiceId() {
     return KsqlConstants.KSQL_INTERNAL_TOPIC_PREFIX
-           + ksqlConfig.get(KsqlConfig.KSQL_SERVICE_ID_CONFIG).toString();
+           + ksqlConfig.getString(KsqlConfig.KSQL_SERVICE_ID_CONFIG);
   }
 }
 

--- a/ksql-engine/src/main/java/io/confluent/ksql/planner/plan/StructuredDataSourceNode.java
+++ b/ksql-engine/src/main/java/io/confluent/ksql/planner/plan/StructuredDataSourceNode.java
@@ -153,8 +153,7 @@ public class StructuredDataSourceNode
       final SchemaRegistryClient schemaRegistryClient
   ) {
     if (!(getTimestampExtractionPolicy() instanceof MetadataTimestampExtractionPolicy)) {
-      ksqlConfig.put(KsqlConfig.KSQL_TIMESTAMP_COLUMN_INDEX,
-          getTimeStampColumnIndex());
+      ksqlConfig.setKsqlTimestampColumnIndex(getTimeStampColumnIndex());
     }
     KsqlTopicSerDe ksqlTopicSerDe = getStructuredDataSource()
         .getKsqlTopic().getKsqlTopicSerDe();

--- a/ksql-engine/src/test/java/io/confluent/ksql/integration/EndToEndIntegrationTest.java
+++ b/ksql-engine/src/test/java/io/confluent/ksql/integration/EndToEndIntegrationTest.java
@@ -15,6 +15,7 @@
  **/
 package io.confluent.ksql.integration;
 
+import com.google.common.collect.ImmutableMap;
 import org.apache.kafka.clients.consumer.ConsumerConfig;
 import org.apache.kafka.common.utils.Utils;
 import org.apache.kafka.streams.KeyValue;
@@ -82,11 +83,9 @@ public class EndToEndIntegrationTest {
   @Before
   public void before() throws Exception {
     testHarness = new IntegrationTestHarness();
-    testHarness.start();
-    Map<String, Object> streamsConfig = testHarness.ksqlConfig.getKsqlStreamConfigProps();
-    streamsConfig.put(ConsumerConfig.AUTO_OFFSET_RESET_CONFIG, "earliest");
+    testHarness.start(ImmutableMap.of(ConsumerConfig.AUTO_OFFSET_RESET_CONFIG, "earliest"));
 
-    KsqlConfig ksqlconfig = new KsqlConfig(streamsConfig);
+    KsqlConfig ksqlconfig = testHarness.ksqlConfig.clone();
 
     ksqlEngine = new KsqlEngine(ksqlconfig);
 

--- a/ksql-engine/src/test/java/io/confluent/ksql/integration/IntegrationTestHarness.java
+++ b/ksql-engine/src/test/java/io/confluent/ksql/integration/IntegrationTestHarness.java
@@ -120,7 +120,8 @@ public class IntegrationTestHarness {
   private Properties properties() {
     Properties producerConfig = new Properties();
     producerConfig.put(ProducerConfig.BOOTSTRAP_SERVERS_CONFIG,
-                       ksqlConfig.get(ProducerConfig.BOOTSTRAP_SERVERS_CONFIG));
+                       ksqlConfig.getKsqlStreamConfigProps().get(
+                           ProducerConfig.BOOTSTRAP_SERVERS_CONFIG));
     producerConfig.put(ProducerConfig.ACKS_CONFIG, "all");
     producerConfig.put(ProducerConfig.RETRIES_CONFIG, 0);
     return producerConfig;
@@ -230,7 +231,8 @@ public class IntegrationTestHarness {
   private Properties consumerConfig() {
     Properties consumerConfig = new Properties();
     consumerConfig.put(ConsumerConfig.BOOTSTRAP_SERVERS_CONFIG,
-                       ksqlConfig.get(ProducerConfig.BOOTSTRAP_SERVERS_CONFIG));
+                       ksqlConfig.getKsqlStreamConfigProps().get(
+                           ProducerConfig.BOOTSTRAP_SERVERS_CONFIG));
     consumerConfig.put(ConsumerConfig.GROUP_ID_CONFIG,
                        CONSUMER_GROUP_ID_PREFIX + System.currentTimeMillis());
     consumerConfig.put(ConsumerConfig.AUTO_OFFSET_RESET_CONFIG, "earliest");
@@ -244,7 +246,7 @@ public class IntegrationTestHarness {
 
 
 
-  public void start() throws Exception {
+  public void start(final Map<String, Object> callerConfigMap) throws Exception {
     embeddedKafkaCluster = new EmbeddedSingleNodeKafkaCluster();
     embeddedKafkaCluster.start();
     Map<String, Object> configMap = new HashMap<>();
@@ -255,6 +257,7 @@ public class IntegrationTestHarness {
     configMap.put("cache.max.bytes.buffering", 0);
     configMap.put("auto.offset.reset", "earliest");
     configMap.put(StreamsConfig.STATE_DIR_CONFIG, TestUtils.tempDirectory().getPath());
+    configMap.putAll(callerConfigMap);
 
     this.ksqlConfig = new KsqlConfig(configMap);
     this.topicClient = new KafkaTopicClientImpl(ksqlConfig.getKsqlAdminClientConfigProps());

--- a/ksql-engine/src/test/java/io/confluent/ksql/integration/JoinIntTest.java
+++ b/ksql-engine/src/test/java/io/confluent/ksql/integration/JoinIntTest.java
@@ -51,7 +51,7 @@ public class JoinIntTest {
   @Before
   public void before() throws Exception {
     testHarness = new IntegrationTestHarness();
-    testHarness.start();
+    testHarness.start(Collections.emptyMap());
     Map<String, Object> ksqlStreamConfigProps = new HashMap<>();
     ksqlStreamConfigProps.putAll(testHarness.ksqlConfig.getKsqlStreamConfigProps());
     // turn caching off to improve join consistency

--- a/ksql-engine/src/test/java/io/confluent/ksql/integration/StreamsSelectAndProjectIntTest.java
+++ b/ksql-engine/src/test/java/io/confluent/ksql/integration/StreamsSelectAndProjectIntTest.java
@@ -45,7 +45,7 @@ public class StreamsSelectAndProjectIntTest {
   @Before
   public void before() throws Exception {
     testHarness = new IntegrationTestHarness();
-    testHarness.start();
+    testHarness.start(Collections.emptyMap());
     ksqlContext = KsqlContext.create(testHarness.ksqlConfig, testHarness.schemaRegistryClient);
     testHarness.createTopic(jsonTopicName);
     testHarness.createTopic(avroTopicName);

--- a/ksql-engine/src/test/java/io/confluent/ksql/integration/UdfIntTest.java
+++ b/ksql-engine/src/test/java/io/confluent/ksql/integration/UdfIntTest.java
@@ -49,7 +49,7 @@ public class UdfIntTest {
   @Before
   public void before() throws Exception {
     testHarness = new IntegrationTestHarness();
-    testHarness.start();
+    testHarness.start(Collections.emptyMap());
     ksqlContext = KsqlContext.create(testHarness.ksqlConfig, testHarness.schemaRegistryClient);
     testHarness.createTopic(jsonTopicName);
 

--- a/ksql-engine/src/test/java/io/confluent/ksql/integration/WindowingIntTest.java
+++ b/ksql-engine/src/test/java/io/confluent/ksql/integration/WindowingIntTest.java
@@ -13,6 +13,7 @@ import org.junit.experimental.categories.Category;
 
 import java.time.LocalTime;
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Set;
@@ -42,7 +43,7 @@ public class WindowingIntTest {
   @Before
   public void before() throws Exception {
     testHarness = new IntegrationTestHarness();
-    testHarness.start();
+    testHarness.start(Collections.emptyMap());
     ksqlContext = KsqlContext.create(testHarness.ksqlConfig);
     testHarness.createTopic(topicName);
 

--- a/ksql-engine/src/test/java/io/confluent/ksql/planner/plan/KsqlStructuredDataOutputNodeTest.java
+++ b/ksql-engine/src/test/java/io/confluent/ksql/planner/plan/KsqlStructuredDataOutputNodeTest.java
@@ -99,7 +99,7 @@ public class KsqlStructuredDataOutputNodeTest {
     props.put(KsqlConfig.SINK_NUMBER_OF_PARTITIONS_PROPERTY, 4);
     props.put(KsqlConfig.SINK_NUMBER_OF_REPLICAS_PROPERTY, (short)3);
     createOutputNode(props);
-    topicClient.createTopic(eq("output"), anyInt(), anyShort(), eq(Collections.emptyMap()));
+    topicClient.createTopic(eq("output"), eq(4), eq((short)3), eq(Collections.emptyMap()));
     EasyMock.expectLastCall();
     EasyMock.replay(topicClient);
     stream = buildStream();
@@ -161,16 +161,6 @@ public class KsqlStructuredDataOutputNodeTest {
         new Field("key", 6, Schema.OPTIONAL_STRING_SCHEMA));
     final List<Field> fields = stream.outputNode().getSchema().fields();
     assertThat(fields, equalTo(expected));
-  }
-
-  @Test
-  public void shouldUpdateReplicationPartitionsInConfig() {
-    assertThat(ksqlConfig.get(KsqlConfig.SINK_NUMBER_OF_REPLICAS_PROPERTY), equalTo(Integer.valueOf(3).shortValue()));
-  }
-
-  @Test
-  public void shouldUpdatePartitionsInConfig() {
-    assertThat(ksqlConfig.get(KsqlConfig.SINK_NUMBER_OF_PARTITIONS_PROPERTY), equalTo(4));
   }
 
   @Test

--- a/ksql-engine/src/test/java/io/confluent/ksql/planner/plan/StructuredDataSourceNodeTest.java
+++ b/ksql-engine/src/test/java/io/confluent/ksql/planner/plan/StructuredDataSourceNodeTest.java
@@ -16,6 +16,7 @@
 
 package io.confluent.ksql.planner.plan;
 
+import io.confluent.ksql.util.KsqlConstants;
 import org.apache.kafka.connect.data.Field;
 import org.apache.kafka.connect.data.Schema;
 import org.apache.kafka.connect.data.SchemaBuilder;
@@ -123,7 +124,7 @@ public class StructuredDataSourceNodeTest {
 
   @Test
   public void shouldAddTimestampIndexToConfig() {
-    assertThat(ksqlConfig.get(KsqlConfig.KSQL_TIMESTAMP_COLUMN_INDEX), equalTo(1));
+    assertThat(ksqlConfig.getKsqlTimestampColumnIndex(), equalTo(1));
   }
 
   @Test

--- a/ksql-rest-app/src/main/java/io/confluent/ksql/rest/entity/KafkaTopicsList.java
+++ b/ksql-rest-app/src/main/java/io/confluent/ksql/rest/entity/KafkaTopicsList.java
@@ -161,13 +161,11 @@ public class KafkaTopicsList extends KsqlEntity {
   ) {
     Map<String, TopicDescription> filteredKafkaTopics = new HashMap<>();
     String serviceId = KsqlConstants.KSQL_INTERNAL_TOPIC_PREFIX
-                       + ksqlConfig.get(KsqlConfig.KSQL_SERVICE_ID_CONFIG).toString();
-    String persistentQueryPrefix = ksqlConfig.get(
-        KsqlConfig.KSQL_PERSISTENT_QUERY_NAME_PREFIX_CONFIG
-    ).toString();
-    String transientQueryPrefix = ksqlConfig.get(
-        KsqlConfig.KSQL_TRANSIENT_QUERY_NAME_PREFIX_CONFIG
-    ).toString();
+                       + ksqlConfig.getString(KsqlConfig.KSQL_SERVICE_ID_CONFIG);
+    String persistentQueryPrefix = ksqlConfig.getString(
+        KsqlConfig.KSQL_PERSISTENT_QUERY_NAME_PREFIX_CONFIG);
+    String transientQueryPrefix = ksqlConfig.getString(
+        KsqlConfig.KSQL_TRANSIENT_QUERY_NAME_PREFIX_CONFIG);
 
     for (Map.Entry<String, TopicDescription> entry : kafkaTopicDescriptions.entrySet()) {
       if (!entry.getKey().startsWith(serviceId + persistentQueryPrefix)

--- a/ksql-rest-app/src/main/java/io/confluent/ksql/rest/entity/PropertiesList.java
+++ b/ksql-rest-app/src/main/java/io/confluent/ksql/rest/entity/PropertiesList.java
@@ -19,39 +19,42 @@ package io.confluent.ksql.rest.entity;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
 
+import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 
 public class PropertiesList extends KsqlEntity {
   private final Map<String, Object> properties;
+  private final List<String> overwrittenProperties;
 
   @JsonCreator
   public PropertiesList(
       @JsonProperty("statementText") String statementText,
-      @JsonProperty("properties")    Map<String, Object> properties
+      @JsonProperty("properties") Map<String, Object> properties,
+      @JsonProperty("overwrittenProperties") List<String> overwrittenProperties
   ) {
     super(statementText);
     this.properties = properties;
+    this.overwrittenProperties = overwrittenProperties;
   }
 
   public Map<String, Object> getProperties() {
     return properties;
   }
 
+  public List<String> getOverwrittenProperties() {
+    return overwrittenProperties;
+  }
+
   @Override
   public boolean equals(Object o) {
-    if (this == o) {
-      return true;
-    }
-    if (!(o instanceof PropertiesList)) {
-      return false;
-    }
-    PropertiesList that = (PropertiesList) o;
-    return Objects.equals(getProperties(), that.getProperties());
+    return o instanceof PropertiesList
+        && Objects.equals(properties, ((PropertiesList)o).properties)
+        && Objects.equals(overwrittenProperties, ((PropertiesList)o).overwrittenProperties);
   }
 
   @Override
   public int hashCode() {
-    return Objects.hash(getProperties());
+    return Objects.hash(properties, overwrittenProperties);
   }
 }

--- a/ksql-rest-app/src/main/java/io/confluent/ksql/rest/server/StandaloneExecutor.java
+++ b/ksql-rest-app/src/main/java/io/confluent/ksql/rest/server/StandaloneExecutor.java
@@ -16,7 +16,6 @@
 
 package io.confluent.ksql.rest.server;
 
-import org.apache.kafka.streams.StreamsConfig;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -90,12 +89,6 @@ public class StandaloneExecutor implements Executable {
                                           final String queriesFile,
                                           final String installDir) {
     final KsqlConfig ksqlConfig = new KsqlConfig(properties);
-    Map<String, Object> streamsProperties = ksqlConfig.getKsqlStreamConfigProps();
-    if (!streamsProperties.containsKey(StreamsConfig.APPLICATION_ID_CONFIG)) {
-      streamsProperties.put(
-          StreamsConfig.APPLICATION_ID_CONFIG, KsqlConfig.KSQL_SERVICE_ID_DEFAULT);
-    }
-
     final KsqlEngine ksqlEngine = new KsqlEngine(ksqlConfig);
     final UdfLoader udfLoader = UdfLoader.newInstance(ksqlConfig,
         ksqlEngine.getMetaStore(),

--- a/ksql-rest-app/src/main/java/io/confluent/ksql/rest/server/StandaloneExecutor.java
+++ b/ksql-rest-app/src/main/java/io/confluent/ksql/rest/server/StandaloneExecutor.java
@@ -28,7 +28,6 @@ import java.io.OutputStreamWriter;
 import java.io.PrintWriter;
 import java.nio.charset.StandardCharsets;
 import java.util.List;
-import java.util.Map;
 import java.util.Objects;
 import java.util.Properties;
 import java.util.concurrent.CountDownLatch;

--- a/ksql-rest-app/src/main/java/io/confluent/ksql/rest/server/resources/streaming/StreamedQueryResource.java
+++ b/ksql-rest-app/src/main/java/io/confluent/ksql/rest/server/resources/streaming/StreamedQueryResource.java
@@ -121,8 +121,9 @@ public class StreamedQueryResource {
               + "To print a case-sensitive topic apply quotations, for example: print \'topic\';",
               topicName)));
     }
-    final Map<String, Object> properties
-        = ksqlEngine.getKsqlConfigProperties(clientLocalProperties);
+    final Map<String, Object> properties = ksqlEngine.getKsqlConfig()
+        .cloneWithPropertyOverwrite(clientLocalProperties)
+        .getKsqlStreamConfigProps();
     final TopicStreamWriter topicStreamWriter = new TopicStreamWriter(
         ksqlEngine.getSchemaRegistryClient(),
         properties,

--- a/ksql-rest-app/src/main/java/io/confluent/ksql/rest/server/resources/streaming/StreamedQueryResource.java
+++ b/ksql-rest-app/src/main/java/io/confluent/ksql/rest/server/resources/streaming/StreamedQueryResource.java
@@ -121,9 +121,9 @@ public class StreamedQueryResource {
               + "To print a case-sensitive topic apply quotations, for example: print \'topic\';",
               topicName)));
     }
-    Map<String, Object> properties = ksqlEngine.getKsqlConfigProperties();
-    properties.putAll(clientLocalProperties);
-    TopicStreamWriter topicStreamWriter = new TopicStreamWriter(
+    final Map<String, Object> properties
+        = ksqlEngine.getKsqlConfigProperties(clientLocalProperties);
+    final TopicStreamWriter topicStreamWriter = new TopicStreamWriter(
         ksqlEngine.getSchemaRegistryClient(),
         properties,
         topicName,

--- a/ksql-rest-app/src/main/java/io/confluent/ksql/rest/server/resources/streaming/WSQueryEndpoint.java
+++ b/ksql-rest-app/src/main/java/io/confluent/ksql/rest/server/resources/streaming/WSQueryEndpoint.java
@@ -140,7 +140,7 @@ public class WSQueryEndpoint {
         new PrintPublisher(
             exec,
             ksqlEngine.getSchemaRegistryClient(),
-            ksqlEngine.getKsqlConfigProperties(),
+            ksqlEngine.getKsqlConfigProperties(Collections.emptyMap()),
             topicName,
             printTopic.getFromBeginning()
         ).subscribe(topicSubscriber);

--- a/ksql-rest-app/src/main/java/io/confluent/ksql/rest/server/resources/streaming/WSQueryEndpoint.java
+++ b/ksql-rest-app/src/main/java/io/confluent/ksql/rest/server/resources/streaming/WSQueryEndpoint.java
@@ -140,7 +140,7 @@ public class WSQueryEndpoint {
         new PrintPublisher(
             exec,
             ksqlEngine.getSchemaRegistryClient(),
-            ksqlEngine.getKsqlConfigProperties(Collections.emptyMap()),
+            ksqlEngine.getKsqlConfig().getKsqlStreamConfigProps(),
             topicName,
             printTopic.getFromBeginning()
         ).subscribe(topicSubscriber);

--- a/ksql-rest-app/src/test/java/io/confluent/ksql/rest/server/resources/KsqlResourceTest.java
+++ b/ksql-rest-app/src/test/java/io/confluent/ksql/rest/server/resources/KsqlResourceTest.java
@@ -625,7 +625,6 @@ public class KsqlResourceTest {
   @SuppressWarnings("unchecked")
   @Test
   public void shouldCreateTableWithInference() {
-    KsqlResource testResource = TestKsqlResourceUtil.get(ksqlEngine);
     final String ksqlString = "CREATE TABLE orders WITH (KAFKA_TOPIC='orders-topic', "
         + "VALUE_FORMAT = 'avro', KEY = 'orderid');";
     final String ksqlStringWithSchema =

--- a/ksql-rest-app/src/test/java/io/confluent/ksql/rest/server/resources/KsqlResourceTest.java
+++ b/ksql-rest-app/src/test/java/io/confluent/ksql/rest/server/resources/KsqlResourceTest.java
@@ -819,9 +819,8 @@ public class KsqlResourceTest {
   public void shouldListPropertiesWithOverrides() {
     final String ksqlString = "list properties;";
     final KsqlResource testResource = TestKsqlResourceUtil.get(ksqlEngine);
-    final Response response
-        = handleKsqlStatements(
-            testResource,
+    final Response response = handleKsqlStatements(
+        testResource,
         new KsqlRequest(ksqlString, Collections.singletonMap("auto.offset.reset", 100)));
 
     assertThat(response.getStatus(), equalTo(Response.Status.OK.getStatusCode()));


### PR DESCRIPTION
### Description 
This patch does some housekeeping of our KSQL configs:
- Make KsqlConfig read-only. Having a read-only object makes the code that
  uses it much easier to reason about. Previously we had a put interface used
  to tweak config at process start, and to pass around data between internal
  classes. Tweaking configs can be solved by preprocessing the properties or
  using the clone-with-overwrites interface before passing the KsqlConfig object
  to all the classes that need it. The latter usage (passing around data between
  internal classes) is just a bad way to pass data around. I was able to clean
  up all the places we were doing this, except for the timestamp column index case
  where different plan nodes use the ksql.timestamp.column.index config to pass
  around the column used to extract timestamps. For the time being I left in an
  interface to handle this case specifically ([gs]etKsqlTimestampColumnIndex).
- Filter the passed in configs for each subsystem (for now just streams).
- Use fully-qualified config names in listings. The use of un-qualified names is
  just a convenience when setting the configs.
- Get rid of the generic get() interface and use the typed interfaces provided
  by AbstractConfig.
- Extend the "list properties" response to indicate which properties are overridden.
- Print out all the configs in the CLI in sorted order

### Testing done 
Most of the changes rework existing code, so existing tests provide coverage. Added unit tests for new functionality.

### Reviewer checklist
- [ ] Ensure docs are updated if necessary. (eg. if a user visible feature is being added or changed).
- [ ] Ensure relevant issues are linked (description should include text like "Fixes #<issue number>")

