### PR TITLE
Avoid NPE if not function exists that handles required types.

### DIFF
--- a/ksql-common/src/main/java/io/confluent/ksql/function/UdfFactory.java
+++ b/ksql-common/src/main/java/io/confluent/ksql/function/UdfFactory.java
@@ -25,6 +25,7 @@ import java.util.stream.Collectors;
 
 import io.confluent.ksql.function.udf.Kudf;
 import io.confluent.ksql.util.KsqlException;
+import io.confluent.ksql.util.SchemaUtil;
 
 public class UdfFactory {
   private final String name;
@@ -74,6 +75,16 @@ public class UdfFactory {
   }
 
   public KsqlFunction getFunction(final List<Schema.Type> paramTypes) {
-    return functions.get(paramTypes);
+    final KsqlFunction function = functions.get(paramTypes);
+    if (function != null) {
+      return function;
+    }
+
+    final String sqlParamTypes = paramTypes.stream()
+        .map(SchemaUtil::getSchemaTypeAsSqlType)
+        .collect(Collectors.joining(", ", "[", "]"));
+
+    throw new KsqlException("Function '" + name
+                            + "' does not accept parameters of types:" + sqlParamTypes);
   }
 }

--- a/ksql-common/src/main/java/io/confluent/ksql/util/SchemaUtil.java
+++ b/ksql-common/src/main/java/io/confluent/ksql/util/SchemaUtil.java
@@ -191,6 +191,15 @@ public class SchemaUtil {
           .put("MAP", "MAP")
           .build();
 
+  public static String getSchemaTypeAsSqlType(final Schema.Type type) {
+    final String sqlType = TYPE_MAP.get(type.name());
+    if (sqlType == null) {
+      throw new IllegalArgumentException("Unknown schema type: " + type);
+    }
+
+    return sqlType;
+  }
+
   public static String getSchemaFieldType(final Field field) {
     if (field.schema().type() == Schema.Type.ARRAY) {
       return "ARRAY[" + getSchemaFieldType(field.schema().valueSchema().fields().get(0)) + "]";

--- a/ksql-common/src/test/java/io/confluent/ksql/function/UdfFactoryTest.java
+++ b/ksql-common/src/test/java/io/confluent/ksql/function/UdfFactoryTest.java
@@ -1,0 +1,53 @@
+/*
+ * Copyright 2018 Confluent Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.confluent.ksql.function;
+
+import com.google.common.collect.ImmutableList;
+
+import org.apache.kafka.common.KafkaException;
+import org.apache.kafka.connect.data.Schema;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+
+import io.confluent.ksql.function.udf.Kudf;
+
+public class UdfFactoryTest {
+
+  @Rule
+  public final ExpectedException expectedException = ExpectedException.none();
+
+  private UdfFactory factory;
+
+  @Before
+  public void setUp() throws Exception {
+    factory = new UdfFactory("TestFunc", TestFunc.class);
+  }
+
+  @Test
+  public void shouldThrowIfNoVariantFoundThatAcceptsSuppliedParamTypes() {
+    expectedException.expect(KafkaException.class);
+    expectedException.expectMessage("Function 'TestFunc' does not accept parameters of types:[VARCHAR(STRING), BIGINT]");
+
+    factory.getFunction(ImmutableList.of(Schema.Type.STRING, Schema.Type.INT64));
+  }
+
+  private abstract class TestFunc implements Kudf {
+
+  }
+}

--- a/ksql-common/src/test/java/io/confluent/ksql/util/SchemaUtilTest.java
+++ b/ksql-common/src/test/java/io/confluent/ksql/util/SchemaUtilTest.java
@@ -28,6 +28,7 @@ import java.util.Map;
 import java.util.Optional;
 
 import static org.hamcrest.CoreMatchers.equalTo;
+import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.CoreMatchers.sameInstance;
 import static org.hamcrest.MatcherAssert.assertThat;
 
@@ -374,6 +375,20 @@ public class SchemaUtilTest {
     assertThat("Invalid SQL type.", sqlType5, equalTo("VARCHAR"));
     assertThat("Invalid SQL type.", sqlType6, equalTo("ARRAY<DOUBLE>"));
     assertThat("Invalid SQL type.", sqlType7, equalTo("MAP<VARCHAR,DOUBLE>"));
+  }
+
+  @Test
+  public void shouldGetCorrectSqlTypeFromSchemaType() {
+    assertThat(SchemaUtil.getSchemaTypeAsSqlType(Schema.Type.STRING), is("VARCHAR(STRING)"));
+    assertThat(SchemaUtil.getSchemaTypeAsSqlType(Schema.Type.INT64), is("BIGINT"));
+    assertThat(SchemaUtil.getSchemaTypeAsSqlType(Schema.Type.INT32), is("INTEGER"));
+    assertThat(SchemaUtil.getSchemaTypeAsSqlType(Schema.Type.FLOAT64), is("DOUBLE"));
+    assertThat(SchemaUtil.getSchemaTypeAsSqlType(Schema.Type.BOOLEAN), is("BOOLEAN"));
+  }
+
+  @Test(expected = IllegalArgumentException.class)
+  public void shouldThrowOnUnknownSchemaType() {
+    SchemaUtil.getSchemaTypeAsSqlType(Schema.Type.STRUCT);
   }
 
   @Test


### PR DESCRIPTION
### Description 
Current a statement such as `select concat('foo',1) from blah;` results in NPE:

```java.lang.NullPointerException```

With this change it results in:

```Function 'CONCAT' does not accept parameters of types:[STRING, INT64]```

Replaces #1399 (Rebased onto 5.0 branch)

### Testing done 
Added unit test + manual testing.

### Reviewer checklist
- [ ] Ensure docs are updated if necessary. (eg. if a user visible feature is being added or changed).
- [ ] Ensure relevant issues are linked (description should include text like "Fixes #<issue number>")