### PR TITLE
Collect metrics for UDFs

### DIFF
--- a/checkstyle/suppressions.xml
+++ b/checkstyle/suppressions.xml
@@ -17,7 +17,7 @@
     <suppress files="(ExpressionTreeRewriter|AstBuilder|KsqlParser).java" checks="ClassDataAbstractionCouplingCheck"/>
     <suppress
             files="(QueryEngine|LogicalPlanner|FunctionRegistry|KsqlEngine|SchemaKStream|Analyzer|AggregateNode).java" checks="ClassDataAbstractionCouplingCheck"/>
-    <suppress files="(KafkaConsumerGroupClientImpl.java)" checks="ClassDataAbstractionCouplingCheck"/>
+    <suppress files="(KafkaConsumerGroupClientImpl|UdfLoader).java" checks="ClassDataAbstractionCouplingCheck"/>
     <suppress files="(KsqlResource|KsqlRestApplication|StandaloneExecutor|KsqlRestClient).java" checks="ClassDataAbstractionCouplingCheck"/>
     <suppress files="Console.java" checks="ClassDataAbstractionCouplingCheck"/>
     <suppress files="(DataGenProducer|DataGen|Generator|PhysicalPlanBuilder).java"

--- a/ksql-common/src/main/java/io/confluent/ksql/util/KsqlConfig.java
+++ b/ksql-common/src/main/java/io/confluent/ksql/util/KsqlConfig.java
@@ -78,6 +78,8 @@ public class KsqlConfig extends AbstractConfig implements Cloneable {
   public static final boolean defaultAvroSchemaUnionNull = true;
   public static final String KSQL_STREAMS_PREFIX = "ksql.streams.";
 
+  public static final String KSQL_COLLECT_UDF_METRICS = "ksql.udf.collect.metrics";
+
   private final Map<String, Object> ksqlConfigProps;
   private final Map<String, Object> ksqlStreamConfigProps;
 
@@ -156,7 +158,16 @@ public class KsqlConfig extends AbstractConfig implements Cloneable {
             true,
             ConfigDef.Importance.MEDIUM,
             "Whether or not custom UDF jars found in the ext dir should be loaded. Default is true "
+        ).define(
+            KSQL_COLLECT_UDF_METRICS,
+            ConfigDef.Type.BOOLEAN,
+            false,
+            ConfigDef.Importance.LOW,
+            "Whether or not metrics should be collected for custom udfs. Default is false. Note: "
+                + "this will add some overhead to udf invocation. It is recommended that this "
+                + " be set to false in production."
         )
+
         .withClientSslSupport();
   }
 

--- a/ksql-engine/src/main/java/io/confluent/ksql/function/UdfLoader.java
+++ b/ksql-engine/src/main/java/io/confluent/ksql/function/UdfLoader.java
@@ -18,6 +18,13 @@ package io.confluent.ksql.function;
 
 import com.google.common.base.Preconditions;
 
+import org.apache.kafka.common.metrics.Metrics;
+import org.apache.kafka.common.metrics.Sensor;
+import org.apache.kafka.common.metrics.stats.Avg;
+import org.apache.kafka.common.metrics.stats.Count;
+import org.apache.kafka.common.metrics.stats.Max;
+import org.apache.kafka.common.metrics.stats.Rate;
+import org.apache.kafka.common.utils.SystemTime;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -27,6 +34,7 @@ import java.lang.reflect.Method;
 import java.nio.file.Files;
 import java.util.Arrays;
 import java.util.Objects;
+import java.util.concurrent.TimeUnit;
 import java.util.function.Predicate;
 import java.util.stream.Collectors;
 
@@ -34,6 +42,7 @@ import io.confluent.ksql.function.udf.PluggableUdf;
 import io.confluent.ksql.function.udf.Udf;
 import io.confluent.ksql.function.udf.UdfDescription;
 import io.confluent.ksql.metastore.MetaStore;
+import io.confluent.ksql.metrics.MetricCollectors;
 import io.confluent.ksql.util.KsqlConfig;
 import io.confluent.ksql.util.KsqlException;
 import io.confluent.ksql.util.SchemaUtil;
@@ -48,7 +57,9 @@ public class UdfLoader {
   private final ClassLoader parentClassLoader;
   private final Predicate<String> blacklist;
   private final UdfCompiler compiler;
+  private final Metrics metrics;
   private final boolean loadCustomerUdfs;
+  private final boolean collectMetrics;
 
 
   public UdfLoader(final MetaStore metaStore,
@@ -56,14 +67,18 @@ public class UdfLoader {
                    final ClassLoader parentClassLoader,
                    final Predicate<String> blacklist,
                    final UdfCompiler compiler,
-                   final boolean loadCustomerUdfs) {
+                   final Metrics metrics,
+                   final boolean loadCustomerUdfs,
+                   final boolean collectMetrics) {
     this.metaStore = Objects.requireNonNull(metaStore, "metaStore can't be null");
     this.pluginDir = Objects.requireNonNull(pluginDir, "pluginDir can't be null");
     this.parentClassLoader = Objects.requireNonNull(parentClassLoader,
         "parentClassLoader can't be null");
     this.blacklist = Objects.requireNonNull(blacklist, "blacklist can't be null");
     this.compiler = Objects.requireNonNull(compiler, "compiler can't be null");
+    this.metrics = Objects.requireNonNull(metrics, "metrics can't be null");
     this.loadCustomerUdfs = loadCustomerUdfs;
+    this.collectMetrics = collectMetrics;
   }
 
   public void load() {
@@ -115,15 +130,24 @@ public class UdfLoader {
   private void addFunction(final UdfDescription annotation,
                            final Method method,
                            final UdfInvoker udf) {
+    final String sensorName = "ksql-udf-" + annotation.name();
+    addSensor(sensorName, annotation.name());
     metaStore.addFunction(new KsqlFunction(
         SchemaUtil.getSchemaFromType(method.getReturnType()),
         Arrays.stream(method.getGenericParameterTypes())
             .map(SchemaUtil::getSchemaFromType).collect(Collectors.toList()),
         annotation.name(),
-        PluggableUdf.class,
+        collectMetrics ? UdfMetricProducer.class : PluggableUdf.class,
         () -> {
           try {
-            return new PluggableUdf(udf, method.getDeclaringClass().newInstance());
+            final PluggableUdf theUdf
+                = new PluggableUdf(udf, method.getDeclaringClass().newInstance());
+            if (collectMetrics) {
+              return new UdfMetricProducer(metrics.getSensor(sensorName),
+                  theUdf,
+                  new SystemTime());
+            }
+            return theUdf;
           } catch (Exception e) {
             throw new KsqlException("Failed to create instance for UDF="
                 + annotation.name()
@@ -133,11 +157,31 @@ public class UdfLoader {
         }));
   }
 
+  private void addSensor(final String sensorName, final String udfName) {
+    if (collectMetrics && metrics.getSensor(sensorName) == null) {
+      final Sensor sensor = metrics.sensor(sensorName);
+      sensor.add(metrics.metricName(sensorName + "-avg", sensorName,
+          "Average time for an invocation of " + udfName + " udf"),
+          new Avg());
+      sensor.add(metrics.metricName(sensorName + "-max", sensorName,
+          "Max time for an invocation of " + udfName + " udf"),
+          new Max());
+      sensor.add(metrics.metricName(sensorName + "-count", sensorName,
+          "Total number of invocations of " + udfName + " udf"),
+          new Count());
+      sensor.add(metrics.metricName(sensorName + "-rate", sensorName,
+          "The average number of occurrence of " + udfName + " operation per second "
+              + udfName + " udf"),
+          new Rate(TimeUnit.SECONDS, new Count()));
+    }
+  }
+
   public static UdfLoader newInstance(final KsqlConfig config,
                                       final MetaStore metaStore,
                                       final String ksqlInstallDir
   ) {
     final Boolean loadCustomerUdfs = config.getBoolean(KsqlConfig.KSQL_ENABLE_UDFS);
+    final Boolean collectMetrics = config.getBoolean(KsqlConfig.KSQL_COLLECT_UDF_METRICS);
     final File pluginDir = new File(ksqlInstallDir, "ext");
 
     Preconditions.checkArgument(!loadCustomerUdfs || pluginDir.isDirectory(),
@@ -148,7 +192,9 @@ public class UdfLoader {
         Thread.currentThread().getContextClassLoader(),
         new Blacklist(new File(pluginDir, "resource-blacklist.txt")),
         new UdfCompiler(),
-        loadCustomerUdfs);
+        MetricCollectors.getMetrics(),
+        loadCustomerUdfs,
+        collectMetrics);
   }
 
 }

--- a/ksql-engine/src/main/java/io/confluent/ksql/function/UdfMetricProducer.java
+++ b/ksql-engine/src/main/java/io/confluent/ksql/function/UdfMetricProducer.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright 2018 Confluent Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.confluent.ksql.function;
+
+import org.apache.kafka.common.metrics.Sensor;
+import org.apache.kafka.common.utils.Time;
+
+import io.confluent.ksql.function.udf.Kudf;
+
+/**
+ * Capture metrics for a given Kudf
+ */
+class UdfMetricProducer implements Kudf {
+  private final Sensor sensor;
+  private final Kudf kudf;
+  private final Time time;
+
+  public UdfMetricProducer(final Sensor sensor,
+                           final Kudf kudf,
+                           final Time time) {
+    this.sensor = sensor;
+    this.kudf = kudf;
+    this.time = time;
+  }
+
+  @Override
+  public Object evaluate(final Object... args) {
+    final long start = time.nanoseconds();
+    try {
+      return kudf.evaluate(args);
+    } finally {
+      sensor.record(time.nanoseconds() - start);
+    }
+  }
+}

--- a/ksql-engine/src/main/java/io/confluent/ksql/function/udf/PluggableUdf.java
+++ b/ksql-engine/src/main/java/io/confluent/ksql/function/udf/PluggableUdf.java
@@ -23,7 +23,6 @@ import io.confluent.ksql.function.UdfInvoker;
  * This may change if we ever get rid of Kudf. As it stands we need
  * to do a conversion from custom UDF -> Kudf so we can support stong
  * typing etc.
- * Will eventually capture metrics.
  */
 public class PluggableUdf implements Kudf {
 

--- a/ksql-engine/src/test/java/io/confluent/ksql/codegen/CodeGenRunnerTest.java
+++ b/ksql-engine/src/test/java/io/confluent/ksql/codegen/CodeGenRunnerTest.java
@@ -18,6 +18,7 @@ package io.confluent.ksql.codegen;
 
 import com.google.common.collect.ImmutableMap;
 
+import org.apache.kafka.common.metrics.Metrics;
 import org.apache.kafka.connect.data.Schema;
 import org.apache.kafka.connect.data.SchemaBuilder;
 import org.apache.kafka.test.TestUtils;
@@ -38,6 +39,7 @@ import io.confluent.ksql.analyzer.Analyzer;
 import io.confluent.ksql.function.InternalFunctionRegistry;
 import io.confluent.ksql.function.UdfCompiler;
 import io.confluent.ksql.function.UdfLoader;
+import io.confluent.ksql.function.UdfLoaderUtil;
 import io.confluent.ksql.function.udf.Kudf;
 import io.confluent.ksql.metastore.KsqlStream;
 import io.confluent.ksql.metastore.KsqlTopic;
@@ -91,11 +93,7 @@ public class CodeGenRunnerTest {
     public void init() {
         metaStore = MetaStoreFixture.getNewMetaStore(functionRegistry);
         // load substring function
-        new UdfLoader(metaStore,
-            TestUtils.tempDirectory(),
-            getClass().getClassLoader(),
-            value -> false, new UdfCompiler(), true)
-            .load();
+        UdfLoaderUtil.load(metaStore);
 
         final Schema schema = SchemaBuilder.struct()
             .field("CODEGEN_TEST.COL0", SchemaBuilder.OPTIONAL_INT64_SCHEMA)

--- a/ksql-engine/src/test/java/io/confluent/ksql/codegen/SqlToJavaVisitorTest.java
+++ b/ksql-engine/src/test/java/io/confluent/ksql/codegen/SqlToJavaVisitorTest.java
@@ -14,6 +14,7 @@ import io.confluent.ksql.function.InternalFunctionRegistry;
 import io.confluent.ksql.function.UdfCompiler;
 import io.confluent.ksql.function.UdfLoader;
 import io.confluent.ksql.function.UdfLoaderTest;
+import io.confluent.ksql.function.UdfLoaderUtil;
 import io.confluent.ksql.metastore.MetaStore;
 import io.confluent.ksql.parser.KsqlParser;
 import io.confluent.ksql.parser.tree.Statement;
@@ -36,11 +37,7 @@ public class SqlToJavaVisitorTest {
   public void init() {
     metaStore = MetaStoreFixture.getNewMetaStore(functionRegistry);
     // load udfs that are not hardcoded
-    new UdfLoader(metaStore,
-        TestUtils.tempDir(),
-        UdfLoaderTest.class.getClassLoader(),
-        value -> false,
-        new UdfCompiler(), true).load();
+    UdfLoaderUtil.load(metaStore);
 
     final Schema addressSchema = SchemaBuilder.struct()
         .field("NUMBER",Schema.OPTIONAL_INT64_SCHEMA)

--- a/ksql-engine/src/test/java/io/confluent/ksql/function/UdfLoaderUtil.java
+++ b/ksql-engine/src/test/java/io/confluent/ksql/function/UdfLoaderUtil.java
@@ -1,0 +1,33 @@
+/*
+ * Copyright 2018 Confluent Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.confluent.ksql.function;
+
+import org.apache.kafka.common.metrics.Metrics;
+import org.apache.kafka.test.TestUtils;
+
+import io.confluent.ksql.metastore.MetaStore;
+
+public class UdfLoaderUtil {
+
+  public static void load(final MetaStore metaStore) {
+    new UdfLoader(metaStore,
+        TestUtils.tempDirectory(),
+        UdfLoaderUtil.class.getClassLoader(),
+        value -> false, new UdfCompiler(), new Metrics(), true, false)
+        .load();
+  }
+}

--- a/ksql-engine/src/test/java/io/confluent/ksql/function/UdfMetricProducerTest.java
+++ b/ksql-engine/src/test/java/io/confluent/ksql/function/UdfMetricProducerTest.java
@@ -1,0 +1,79 @@
+/*
+ * Copyright 2018 Confluent Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.confluent.ksql.function;
+
+import org.apache.kafka.common.MetricName;
+import org.apache.kafka.common.metrics.KafkaMetric;
+import org.apache.kafka.common.metrics.Metrics;
+import org.apache.kafka.common.metrics.Sensor;
+import org.apache.kafka.common.metrics.stats.Avg;
+import org.apache.kafka.common.utils.MockTime;
+import org.apache.kafka.common.utils.Time;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.util.concurrent.TimeUnit;
+
+import static org.hamcrest.CoreMatchers.equalTo;
+import static org.hamcrest.MatcherAssert.assertThat;
+
+public class UdfMetricProducerTest {
+
+  private final Time time = new MockTime();
+  private final Metrics metrics = new Metrics(time);
+  private final Sensor sensor = metrics.sensor("my-udf");
+  private final MetricName metricName = metrics.metricName("avg", "blah");
+
+  @Before
+  public void before() {
+    sensor.add(metricName, new Avg());
+  }
+
+  @Test
+  public void shouldRecordMetrics() {
+    final UdfMetricProducer metricProducer
+        = new UdfMetricProducer(sensor, args -> {
+      time.sleep(100);
+      return null;
+    }, time);
+
+    metricProducer.evaluate("foo");
+
+    final KafkaMetric metric = metrics.metric(metricName);
+    final Double actual = (Double) metric.metricValue();
+    assertThat(actual.longValue(), equalTo(TimeUnit.MILLISECONDS.toNanos(100)));
+  }
+
+  @Test
+  public void shouldRecordEvenIfExceptionThrown(){
+    final UdfMetricProducer metricProducer
+        = new UdfMetricProducer(sensor, args -> {
+          time.sleep(10);
+     throw new RuntimeException("boom");
+    }, time);
+
+    try {
+      metricProducer.evaluate("foo");
+    } catch (Exception e) {
+      // ignored
+    }
+
+    final KafkaMetric metric = metrics.metric(metricName);
+    final Double actual = (Double) metric.metricValue();
+    assertThat(actual.longValue(), equalTo(TimeUnit.MILLISECONDS.toNanos(10)));
+  }
+}

--- a/ksql-engine/src/test/java/io/confluent/ksql/integration/UdfIntTest.java
+++ b/ksql-engine/src/test/java/io/confluent/ksql/integration/UdfIntTest.java
@@ -10,6 +10,7 @@ import io.confluent.ksql.util.ItemDataProvider;
 import io.confluent.ksql.util.OrderDataProvider;
 import io.confluent.ksql.util.SchemaUtil;
 import org.apache.kafka.clients.producer.RecordMetadata;
+import org.apache.kafka.common.metrics.Metrics;
 import org.apache.kafka.common.serialization.StringDeserializer;
 import org.apache.kafka.connect.data.Schema;
 import org.apache.kafka.test.TestUtils;
@@ -58,7 +59,7 @@ public class UdfIntTest {
     new UdfLoader(ksqlContext.getMetaStore(),
         TestUtils.tempDirectory(),
         getClass().getClassLoader(),
-        value -> true, new UdfCompiler(), true)
+        value -> true, new UdfCompiler(), new Metrics(), true, false)
         .load();
 
     /**

--- a/ksql-engine/src/test/java/io/confluent/ksql/util/ExpressionTypeManagerTest.java
+++ b/ksql-engine/src/test/java/io/confluent/ksql/util/ExpressionTypeManagerTest.java
@@ -23,11 +23,13 @@ import io.confluent.ksql.function.InternalFunctionRegistry;
 import io.confluent.ksql.function.UdfCompiler;
 import io.confluent.ksql.function.UdfLoader;
 import io.confluent.ksql.function.UdfLoaderTest;
+import io.confluent.ksql.function.UdfLoaderUtil;
 import io.confluent.ksql.metastore.MetaStore;
 import io.confluent.ksql.parser.KsqlParser;
 import io.confluent.ksql.parser.tree.Statement;
 import kafka.utils.TestUtils;
 
+import org.apache.kafka.common.metrics.Metrics;
 import org.apache.kafka.connect.data.Schema;
 import org.apache.kafka.connect.data.SchemaBuilder;
 import org.junit.Assert;
@@ -50,11 +52,7 @@ public class ExpressionTypeManagerTest {
     public void init() {
         metaStore = MetaStoreFixture.getNewMetaStore(functionRegistry);
         // load udfs that are not hardcoded
-        new UdfLoader(metaStore,
-            TestUtils.tempDir(),
-            UdfLoaderTest.class.getClassLoader(),
-            value -> false,
-            new UdfCompiler(), true).load();
+        UdfLoaderUtil.load(metaStore);
         schema = SchemaBuilder.struct()
                 .field("TEST1.COL0", SchemaBuilder.OPTIONAL_INT64_SCHEMA)
                 .field("TEST1.COL1", SchemaBuilder.OPTIONAL_STRING_SCHEMA)


### PR DESCRIPTION
### Description 
Adds collection of metrics for UDFs if the config `ksql.udf.collect.metrics` is set to `true`. The default is `false`.

As it stands the metrics are global (rather than per query) as they are intended for testing purposes rather than production, i.e., i think the overhead may be too much to collect them on every invocation.

### Testing done 
Added unit tests to ensure the metrics get added or not added depending on the configuration. Add tests to ensure the metrics are collected.

### Reviewer checklist
- [ ] Ensure docs are updated if necessary. (eg. if a user visible feature is being added or changed).
- [ ] Ensure relevant issues are linked (description should include text like "Fixes #<issue number>")

