### PR TITLE
Updated AST builder to handle dot notation.

### DIFF
--- a/checkstyle/suppressions.xml
+++ b/checkstyle/suppressions.xml
@@ -23,7 +23,7 @@
     <suppress files="(DataGenProducer|DataGen|Generator|PhysicalPlanBuilder|StatementRewriter).java"
               checks="ClassDataAbstractionCouplingCheck"/>
     <suppress
-            files="(ExpressionTypeManager|KsqlResource|Console|KsqlEngine|PhysicalPlanBuilder|DropSourceCommand).java"
+            files="(ExpressionTypeManager|KsqlResource|Console|KsqlEngine|PhysicalPlanBuilder|DropSourceCommand|AstBuilder).java"
               checks="CyclomaticComplexityCheck"/>
 
     <!-- EXAMPLES! -->

--- a/ksql-metastore/src/test/java/io/confluent/ksql/util/MetaStoreFixture.java
+++ b/ksql-metastore/src/test/java/io/confluent/ksql/util/MetaStoreFixture.java
@@ -16,6 +16,7 @@
 
 package io.confluent.ksql.util;
 
+import org.apache.kafka.connect.data.Schema;
 import org.apache.kafka.connect.data.SchemaBuilder;
 
 import io.confluent.ksql.function.FunctionRegistry;
@@ -84,11 +85,36 @@ public class MetaStoreFixture {
     metaStore.putTopic(ksqlTopic2);
     metaStore.putSource(ksqlTable);
 
-    SchemaBuilder schemaBuilderOrders = SchemaBuilder.struct()
-        .field("ORDERTIME", SchemaBuilder.OPTIONAL_INT64_SCHEMA)
-        .field("ORDERID", SchemaBuilder.OPTIONAL_STRING_SCHEMA)
-        .field("ITEMID", SchemaBuilder.OPTIONAL_STRING_SCHEMA)
-        .field("ORDERUNITS", SchemaBuilder.OPTIONAL_FLOAT64_SCHEMA);
+    final Schema addressSchema = SchemaBuilder.struct()
+        .field("NUMBER", Schema.OPTIONAL_INT64_SCHEMA)
+        .field("STREET", Schema.OPTIONAL_STRING_SCHEMA)
+        .field("CITY", Schema.OPTIONAL_STRING_SCHEMA)
+        .field("STATE", Schema.OPTIONAL_STRING_SCHEMA)
+        .field("ZIPCODE", Schema.OPTIONAL_INT64_SCHEMA)
+        .optional().build();
+
+    final Schema categorySchema = SchemaBuilder.struct()
+        .field("ID", Schema.OPTIONAL_INT64_SCHEMA)
+        .field("NAME", Schema.OPTIONAL_STRING_SCHEMA)
+        .optional().build();
+
+    final Schema itemInfoSchema = SchemaBuilder.struct()
+        .field("ITEMID", Schema.INT64_SCHEMA)
+        .field("NAME", Schema.STRING_SCHEMA)
+        .field("CATEGORY", categorySchema)
+        .optional().build();
+
+    final SchemaBuilder schemaBuilder = SchemaBuilder.struct();
+    final Schema schemaBuilderOrders = schemaBuilder
+        .field("ORDERTIME", Schema.INT64_SCHEMA)
+        .field("ORDERID", Schema.OPTIONAL_INT64_SCHEMA)
+        .field("ITEMID", Schema.OPTIONAL_STRING_SCHEMA)
+        .field("ITEMINFO", itemInfoSchema)
+        .field("ORDERUNITS", Schema.INT32_SCHEMA)
+        .field("ARRAYCOL",schemaBuilder.array(Schema.FLOAT64_SCHEMA).optional().build())
+        .field("MAPCOL", schemaBuilder.map(Schema.STRING_SCHEMA, Schema.FLOAT64_SCHEMA).optional().build())
+        .field("ADDRESS", addressSchema)
+        .build();
 
     KsqlTopic
         ksqlTopicOrders =

--- a/ksql-parser/src/main/java/io/confluent/ksql/parser/AstBuilder.java
+++ b/ksql-parser/src/main/java/io/confluent/ksql/parser/AstBuilder.java
@@ -1144,7 +1144,6 @@ public class AstBuilder extends SqlBaseBaseVisitor<Node> {
   @Override
   public Node visitColumnReference(SqlBaseParser.ColumnReferenceContext context) {
     final String columnName = getIdentifierText(context.identifier());
-    final String suffixFieldName = dotStack.empty() ? null : dotStack.peek();
     // If this is join.
     if (dataSourceExtractor.getJoinLeftSchema() != null) {
       boolean sameAsLeft = columnName.equalsIgnoreCase(dataSourceExtractor.getLeftAlias())
@@ -1152,7 +1151,7 @@ public class AstBuilder extends SqlBaseBaseVisitor<Node> {
       boolean sameAsRight = columnName.equalsIgnoreCase(dataSourceExtractor.getRightAlias())
           || columnName.equalsIgnoreCase(dataSourceExtractor.getRightName());
 
-      if (suffixFieldName != null
+      if (!dotStack.empty()
           && (sameAsLeft || sameAsRight)) {
         return new QualifiedNameReference(
             getLocation(context),
@@ -1179,7 +1178,7 @@ public class AstBuilder extends SqlBaseBaseVisitor<Node> {
         throw new InvalidColumnReferenceException("Field " + columnName + " is ambiguous.");
       }
     } else {
-      if (suffixFieldName != null
+      if (!dotStack.empty()
           && (columnName.equalsIgnoreCase(dataSourceExtractor.getFromAlias())
           || columnName.equalsIgnoreCase(dataSourceExtractor.getFromName()))) {
         return new QualifiedNameReference(

--- a/ksql-parser/src/main/java/io/confluent/ksql/parser/AstBuilder.java
+++ b/ksql-parser/src/main/java/io/confluent/ksql/parser/AstBuilder.java
@@ -204,7 +204,7 @@ public class AstBuilder extends SqlBaseBaseVisitor<Node> {
   @Override
   public Node visitCreateTable(SqlBaseParser.CreateTableContext context) {
     return new CreateTable(
-        getLocation(context),
+        Optional.of(getLocation(context)),
         getQualifiedName(context.qualifiedName()),
         visit(context.tableElement(), TableElement.class),
         context.EXISTS() != null,
@@ -225,7 +225,7 @@ public class AstBuilder extends SqlBaseBaseVisitor<Node> {
   @Override
   public Node visitCreateStream(SqlBaseParser.CreateStreamContext context) {
     return new CreateStream(
-        getLocation(context),
+        Optional.of(getLocation(context)),
         getQualifiedName(context.qualifiedName()),
         visit(context.tableElement(), TableElement.class),
         context.EXISTS() != null,
@@ -242,7 +242,7 @@ public class AstBuilder extends SqlBaseBaseVisitor<Node> {
     }
 
     return new CreateStreamAsSelect(
-        getLocation(context),
+        Optional.of(getLocation(context)),
         getQualifiedName(context.qualifiedName()),
         (Query) visitQuery(context.query()),
         context.EXISTS() != null,
@@ -254,7 +254,7 @@ public class AstBuilder extends SqlBaseBaseVisitor<Node> {
   @Override
   public Node visitCreateTableAs(SqlBaseParser.CreateTableAsContext context) {
     return new CreateTableAsSelect(
-        getLocation(context),
+        Optional.of(getLocation(context)),
         getQualifiedName(context.qualifiedName()),
         (Query) visitQuery(context.query()),
         context.EXISTS() != null,
@@ -269,8 +269,11 @@ public class AstBuilder extends SqlBaseBaseVisitor<Node> {
       partitionByColumn = Optional.of(new QualifiedNameReference(
           QualifiedName.of(getIdentifierText(context.identifier()))));
     }
-    return new InsertInto(getLocation(context), getQualifiedName(context.qualifiedName()),
-                                   (Query) visitQuery(context.query()), partitionByColumn);
+    return new InsertInto(
+        Optional.of(getLocation(context)),
+        getQualifiedName(context.qualifiedName()),
+        (Query) visitQuery(context.query()),
+        partitionByColumn);
   }
 
   @Override
@@ -285,7 +288,7 @@ public class AstBuilder extends SqlBaseBaseVisitor<Node> {
   @Override
   public Node visitDropTable(SqlBaseParser.DropTableContext context) {
     return new DropTable(
-        getLocation(context),
+        Optional.of(getLocation(context)),
         getQualifiedName(context.qualifiedName()),
         context.EXISTS() != null,
         context.DELETE() != null

--- a/ksql-parser/src/main/java/io/confluent/ksql/parser/AstBuilder.java
+++ b/ksql-parser/src/main/java/io/confluent/ksql/parser/AstBuilder.java
@@ -1146,9 +1146,9 @@ public class AstBuilder extends SqlBaseBaseVisitor<Node> {
     final String columnName = getIdentifierText(context.identifier());
     // If this is join.
     if (dataSourceExtractor.getJoinLeftSchema() != null) {
-      boolean sameAsLeft = columnName.equalsIgnoreCase(dataSourceExtractor.getLeftAlias())
+      final boolean sameAsLeft = columnName.equalsIgnoreCase(dataSourceExtractor.getLeftAlias())
           || columnName.equalsIgnoreCase(dataSourceExtractor.getLeftName());
-      boolean sameAsRight = columnName.equalsIgnoreCase(dataSourceExtractor.getRightAlias())
+      final boolean sameAsRight = columnName.equalsIgnoreCase(dataSourceExtractor.getRightAlias())
           || columnName.equalsIgnoreCase(dataSourceExtractor.getRightName());
 
       if (!dotStack.empty()
@@ -1161,14 +1161,14 @@ public class AstBuilder extends SqlBaseBaseVisitor<Node> {
       if (dataSourceExtractor.getCommonFieldNames().contains(columnName)) {
         throw new KsqlException("Field " + columnName + " is ambiguous.");
       } else if (dataSourceExtractor.getLeftFieldNames().contains(columnName)) {
-        Expression baseExpression =
+        final Expression baseExpression =
             new QualifiedNameReference(
                 getLocation(context),
                 QualifiedName.of(dataSourceExtractor.getLeftAlias())
             );
         return new DereferenceExpression(getLocation(context), baseExpression, columnName);
       } else if (dataSourceExtractor.getRightFieldNames().contains(columnName)) {
-        Expression baseExpression =
+        final Expression baseExpression =
             new QualifiedNameReference(
                 getLocation(context),
                 QualifiedName.of(dataSourceExtractor.getRightAlias())
@@ -1185,14 +1185,14 @@ public class AstBuilder extends SqlBaseBaseVisitor<Node> {
             getLocation(context),
             QualifiedName.of(columnName)
         );
-      } else {
-        Expression baseExpression =
-            new QualifiedNameReference(
-                getLocation(context),
-                QualifiedName.of(dataSourceExtractor.getFromAlias())
-            );
-        return new DereferenceExpression(getLocation(context), baseExpression, columnName);
       }
+
+      final Expression baseExpression =
+          new QualifiedNameReference(
+              getLocation(context),
+              QualifiedName.of(dataSourceExtractor.getFromAlias())
+          );
+      return new DereferenceExpression(getLocation(context), baseExpression, columnName);
     }
   }
 

--- a/ksql-parser/src/main/java/io/confluent/ksql/parser/rewrite/StatementRewriter.java
+++ b/ksql-parser/src/main/java/io/confluent/ksql/parser/rewrite/StatementRewriter.java
@@ -998,165 +998,82 @@ public class StatementRewriter extends DefaultAstVisitor<Node, Object> {
   }
 
   protected Node visitCreateStream(final CreateStream node, final Object context) {
-    return node.getLocation()
-        .map(location ->
-            new CreateStream(
-                node.getLocation(),
-                node.getName(),
-                node.getElements().stream()
-                    .map(tableElement -> (TableElement) process(tableElement, context))
-                    .collect(Collectors.toList()),
-                node.isNotExists(),
-                node.getProperties().entrySet().stream()
-                    .collect(Collectors.toMap(
-                        Map.Entry::getKey,
-                        e -> (Expression) process(e.getValue(), context)
-                    ))
-            )
-        )
-        .orElse(
-            new CreateStream(
-                node.getName(),
-                node.getElements().stream()
-                    .map(tableElement -> (TableElement) process(tableElement, context))
-                    .collect(Collectors.toList()),
-                node.isNotExists(),
-                node.getProperties().entrySet().stream()
-                    .collect(Collectors.toMap(
-                        Map.Entry::getKey,
-                        e -> (Expression) process(e.getValue(), context)
-                    ))
-            )
-        );
+    return new CreateStream(
+        node.getLocation(),
+        node.getName(),
+        node.getElements().stream()
+            .map(tableElement -> (TableElement) process(tableElement, context))
+            .collect(Collectors.toList()),
+        node.isNotExists(),
+        node.getProperties().entrySet().stream()
+            .collect(Collectors.toMap(
+                Map.Entry::getKey,
+                e -> (Expression) process(e.getValue(), context)
+            ))
+    );
   }
 
   protected Node visitCreateStreamAsSelect(final CreateStreamAsSelect node, final Object context) {
-    return node.getLocation()
-        .map(location ->
-            new CreateStreamAsSelect(
-                node.getLocation(),
-                node.getName(),
-                (Query) process(node.getQuery(), context),
-                node.isNotExists(),
-                node.getProperties().entrySet().stream()
-                    .collect(Collectors.toMap(
-                        Map.Entry::getKey,
-                        e -> (Expression) process(e.getValue(), context)
-                    )),
-                node.getPartitionByColumn().isPresent()
-                    ? Optional.ofNullable(
-                    (Expression) process(node.getPartitionByColumn().get(),
-                        context))
-                    : Optional.empty()
-            )
-        )
-        .orElse(
-            new CreateStreamAsSelect(node.getName(),
-                (Query) process(node.getQuery(), context),
-                node.isNotExists(),
-                node.getProperties().entrySet().stream()
-                    .collect(Collectors.toMap(
-                        Map.Entry::getKey,
-                        e -> (Expression) process(e.getValue(), context)
-                    )),
-                node.getPartitionByColumn().isPresent()
-                    ? Optional.ofNullable(
-                    (Expression) process(node.getPartitionByColumn().get(),
-                        context))
-                    : Optional.empty()
-            )
-        );
+    return new CreateStreamAsSelect(
+        node.getLocation(),
+        node.getName(),
+        (Query) process(node.getQuery(), context),
+        node.isNotExists(),
+        node.getProperties().entrySet().stream()
+            .collect(Collectors.toMap(
+                Map.Entry::getKey,
+                e -> (Expression) process(e.getValue(), context)
+            )),
+        node.getPartitionByColumn().isPresent()
+            ? Optional.ofNullable(
+            (Expression) process(node.getPartitionByColumn().get(),
+                context))
+            : Optional.empty()
+    );
   }
 
   protected Node visitCreateTable(final CreateTable node, final Object context) {
-    return node.getLocation()
-        .map(location ->
-            new CreateTable(node.getLocation(),
-                node.getName(),
-                node.getElements().stream()
-                    .map(tableElement -> (TableElement) process(tableElement, context))
-                    .collect(Collectors.toList()),
-                node.isNotExists(),
-                node.getProperties().entrySet().stream()
-                    .collect(Collectors.toMap(
-                        Map.Entry::getKey,
-                        e -> (Expression) process(e.getValue(), context)
-                    )))
-        )
-        .orElse(
-            new CreateTable(node.getName(),
-                node.getElements().stream()
-                    .map(tableElement -> (TableElement) process(tableElement, context))
-                    .collect(Collectors.toList()),
-                node.isNotExists(),
-                node.getProperties().entrySet().stream()
-                    .collect(Collectors.toMap(
-                        Map.Entry::getKey,
-                        e -> (Expression) process(e.getValue(), context)
-                    )))
-        );
+    return new CreateTable(node.getLocation(),
+        node.getName(),
+        node.getElements().stream()
+            .map(tableElement -> (TableElement) process(tableElement, context))
+            .collect(Collectors.toList()),
+        node.isNotExists(),
+        node.getProperties().entrySet().stream()
+            .collect(Collectors.toMap(
+                Map.Entry::getKey,
+                e -> (Expression) process(e.getValue(), context)
+            )));
   }
 
   protected Node visitCreateTableAsSelect(final CreateTableAsSelect node, final Object context) {
-    return node.getLocation()
-        .map(location ->
-            new CreateTableAsSelect(node.getLocation(),
-                node.getName(),
-                (Query) process(node.getQuery(), context),
-                node.isNotExists(),
-                node.getProperties().entrySet().stream()
-                    .collect(Collectors.toMap(
-                        Entry::getKey,
-                        e -> (Expression) process(e.getValue(), context)
-                    )))
-        )
-        .orElse(
-            new CreateTableAsSelect(node.getName(),
-                (Query) process(node.getQuery(), context),
-                node.isNotExists(),
-                node.getProperties().entrySet().stream()
-                    .collect(Collectors.toMap(
-                        Entry::getKey,
-                        e -> (Expression) process(e.getValue(), context)
-                    )))
-        );
+    return new CreateTableAsSelect(node.getLocation(),
+        node.getName(),
+        (Query) process(node.getQuery(), context),
+        node.isNotExists(),
+        node.getProperties().entrySet().stream()
+            .collect(Collectors.toMap(
+                Entry::getKey,
+                e -> (Expression) process(e.getValue(), context)
+            )));
   }
 
   protected Node visitInsertInto(final InsertInto node, final Object context) {
-    return node.getLocation()
-        .map(location ->
-            new InsertInto(node.getLocation(),
-                node.getTarget(),
-                (Query) process(node.getQuery(), context),
-                node.getPartitionByColumn().isPresent()
-                    ? Optional.ofNullable(
-                    (Expression) process(node.getPartitionByColumn().get(),
-                        context))
-                    : Optional.empty())
-        )
-        .orElse(
-            new InsertInto(node.getTarget(),
-                (Query) process(node.getQuery(), context),
-                node.getPartitionByColumn().isPresent()
-                    ? Optional.ofNullable(
-                    (Expression) process(node.getPartitionByColumn().get(), context))
-                    : Optional.empty())
-        );
+    return new InsertInto(node.getLocation(),
+        node.getTarget(),
+        (Query) process(node.getQuery(), context),
+        node.getPartitionByColumn().isPresent()
+            ? Optional.ofNullable(
+            (Expression) process(node.getPartitionByColumn().get(),
+                context))
+            : Optional.empty());
   }
 
   protected Node visitDropTable(final DropTable node, final Object context) {
-    return node.getLocation()
-        .map(location ->
-            new DropTable(node.getLocation(),
-                node.getTableName(),
-                node.getIfExists(),
-                node.isDeleteTopic())
-        )
-        .orElse(
-            new DropTable(node.getTableName(),
-                node.getIfExists(),
-                node.isDeleteTopic())
-        );
+    return new DropTable(node.getLocation(),
+        node.getTableName(),
+        node.getIfExists(),
+        node.isDeleteTopic());
   }
 
   protected Node visitRenameColumn(final RenameColumn node, final Object context) {

--- a/ksql-parser/src/main/java/io/confluent/ksql/parser/rewrite/StatementRewriter.java
+++ b/ksql-parser/src/main/java/io/confluent/ksql/parser/rewrite/StatementRewriter.java
@@ -1001,7 +1001,7 @@ public class StatementRewriter extends DefaultAstVisitor<Node, Object> {
     return node.getLocation()
         .map(location ->
             new CreateStream(
-                node.getLocation().get(),
+                node.getLocation(),
                 node.getName(),
                 node.getElements().stream()
                     .map(tableElement -> (TableElement) process(tableElement, context))
@@ -1034,7 +1034,7 @@ public class StatementRewriter extends DefaultAstVisitor<Node, Object> {
     return node.getLocation()
         .map(location ->
             new CreateStreamAsSelect(
-                node.getLocation().get(),
+                node.getLocation(),
                 node.getName(),
                 (Query) process(node.getQuery(), context),
                 node.isNotExists(),
@@ -1071,7 +1071,7 @@ public class StatementRewriter extends DefaultAstVisitor<Node, Object> {
   protected Node visitCreateTable(final CreateTable node, final Object context) {
     return node.getLocation()
         .map(location ->
-            new CreateTable(node.getLocation().get(),
+            new CreateTable(node.getLocation(),
                 node.getName(),
                 node.getElements().stream()
                     .map(tableElement -> (TableElement) process(tableElement, context))
@@ -1100,7 +1100,7 @@ public class StatementRewriter extends DefaultAstVisitor<Node, Object> {
   protected Node visitCreateTableAsSelect(final CreateTableAsSelect node, final Object context) {
     return node.getLocation()
         .map(location ->
-            new CreateTableAsSelect(node.getLocation().get(),
+            new CreateTableAsSelect(node.getLocation(),
                 node.getName(),
                 (Query) process(node.getQuery(), context),
                 node.isNotExists(),
@@ -1125,7 +1125,7 @@ public class StatementRewriter extends DefaultAstVisitor<Node, Object> {
   protected Node visitInsertInto(final InsertInto node, final Object context) {
     return node.getLocation()
         .map(location ->
-            new InsertInto(node.getLocation().get(),
+            new InsertInto(node.getLocation(),
                 node.getTarget(),
                 (Query) process(node.getQuery(), context),
                 node.getPartitionByColumn().isPresent()
@@ -1147,7 +1147,7 @@ public class StatementRewriter extends DefaultAstVisitor<Node, Object> {
   protected Node visitDropTable(final DropTable node, final Object context) {
     return node.getLocation()
         .map(location ->
-            new DropTable(node.getLocation().get(),
+            new DropTable(node.getLocation(),
                 node.getTableName(),
                 node.getIfExists(),
                 node.isDeleteTopic())

--- a/ksql-parser/src/main/java/io/confluent/ksql/parser/tree/CreateStream.java
+++ b/ksql-parser/src/main/java/io/confluent/ksql/parser/tree/CreateStream.java
@@ -39,12 +39,7 @@ public class CreateStream extends AbstractStreamCreateStatement implements DdlSt
     this(Optional.empty(), name, elements, notExists, properties);
   }
 
-  public CreateStream(NodeLocation location, QualifiedName name, List<TableElement> elements,
-                     boolean notExists, Map<String, Expression> properties) {
-    this(Optional.of(location), name, elements, notExists, properties);
-  }
-
-  private CreateStream(Optional<NodeLocation> location, QualifiedName name,
+  public CreateStream(Optional<NodeLocation> location, QualifiedName name,
                       List<TableElement> elements, boolean notExists,
                       Map<String, Expression> properties) {
     super(location);

--- a/ksql-parser/src/main/java/io/confluent/ksql/parser/tree/CreateStreamAsSelect.java
+++ b/ksql-parser/src/main/java/io/confluent/ksql/parser/tree/CreateStreamAsSelect.java
@@ -43,16 +43,6 @@ public class CreateStreamAsSelect extends Statement implements CreateAsSelect {
   }
 
   public CreateStreamAsSelect(
-      final NodeLocation location,
-      final QualifiedName name,
-      final Query query,
-      final boolean notExists,
-      final Map<String, Expression> properties,
-      final Optional<Expression> partitionByColumn) {
-    this(Optional.of(location), name, query, notExists, properties, partitionByColumn);
-  }
-
-  private CreateStreamAsSelect(
       final Optional<NodeLocation> location,
       final QualifiedName name,
       final Query query,

--- a/ksql-parser/src/main/java/io/confluent/ksql/parser/tree/CreateTable.java
+++ b/ksql-parser/src/main/java/io/confluent/ksql/parser/tree/CreateTable.java
@@ -40,12 +40,7 @@ public class CreateTable
     this(Optional.empty(), name, elements, notExists, properties);
   }
 
-  public CreateTable(NodeLocation location, QualifiedName name, List<TableElement> elements,
-                     boolean notExists, Map<String, Expression> properties) {
-    this(Optional.of(location), name, elements, notExists, properties);
-  }
-
-  private CreateTable(Optional<NodeLocation> location, QualifiedName name,
+  public CreateTable(Optional<NodeLocation> location, QualifiedName name,
                       List<TableElement> elements, boolean notExists,
                       Map<String, Expression> properties) {
     super(location);

--- a/ksql-parser/src/main/java/io/confluent/ksql/parser/tree/CreateTableAsSelect.java
+++ b/ksql-parser/src/main/java/io/confluent/ksql/parser/tree/CreateTableAsSelect.java
@@ -42,16 +42,6 @@ public class CreateTableAsSelect extends Statement implements CreateAsSelect {
   }
 
   public CreateTableAsSelect(
-      NodeLocation location,
-      QualifiedName name,
-      Query query,
-      boolean notExists,
-      Map<String, Expression> properties
-  ) {
-    this(Optional.of(location), name, query, notExists, properties);
-  }
-
-  private CreateTableAsSelect(
       Optional<NodeLocation> location,
       QualifiedName name,
       Query query,

--- a/ksql-parser/src/main/java/io/confluent/ksql/parser/tree/DropTable.java
+++ b/ksql-parser/src/main/java/io/confluent/ksql/parser/tree/DropTable.java
@@ -31,14 +31,7 @@ public class DropTable extends AbstractStreamDropStatement implements DdlStateme
     this(Optional.empty(), tableName, ifExists, deleteTopic);
   }
 
-  public DropTable(NodeLocation location,
-                   QualifiedName tableName,
-                   boolean ifExists,
-                   boolean deleteTopic) {
-    this(Optional.of(location), tableName, ifExists, deleteTopic);
-  }
-
-  private DropTable(Optional<NodeLocation> location,
+  public DropTable(Optional<NodeLocation> location,
                     QualifiedName tableName,
                     boolean ifExists,
                     boolean deleteTopic) {

--- a/ksql-parser/src/main/java/io/confluent/ksql/parser/tree/InsertInto.java
+++ b/ksql-parser/src/main/java/io/confluent/ksql/parser/tree/InsertInto.java
@@ -36,14 +36,6 @@ public final class InsertInto
   }
 
   public InsertInto(
-      NodeLocation location,
-      QualifiedName target,
-      Query query, Optional<Expression> partitionByColumn
-  ) {
-    this(Optional.of(location), target, query, partitionByColumn);
-  }
-
-  private InsertInto(
       Optional<NodeLocation> location,
       QualifiedName target,
       Query query,

--- a/ksql-parser/src/main/java/io/confluent/ksql/util/DataSourceExtractor.java
+++ b/ksql-parser/src/main/java/io/confluent/ksql/util/DataSourceExtractor.java
@@ -45,10 +45,14 @@ public class DataSourceExtractor extends SqlBaseBaseVisitor<Node> {
 
   private Schema joinLeftSchema;
   private Schema joinRightSchema;
+  private Schema fromSchema;
 
   private String fromAlias;
+  private String fromName;
   private String leftAlias;
+  private String leftName;
   private String rightAlias;
+  private String rightName;
 
   private Set<String> commonFieldNames = new HashSet<>();
   private Set<String> leftFieldNames = new HashSet<>();
@@ -86,12 +90,14 @@ public class DataSourceExtractor extends SqlBaseBaseVisitor<Node> {
 
     if (!isJoin) {
       this.fromAlias = alias;
+      this.fromName = table.getName().getSuffix().toUpperCase();
       StructuredDataSource
           fromDataSource =
           metaStore.getSource(table.getName().getSuffix());
       if (fromDataSource == null) {
         throw new KsqlException(table.getName().getSuffix() + " does not exist.");
       }
+      fromSchema = fromDataSource.getSchema();
       return null;
     }
 
@@ -117,6 +123,7 @@ public class DataSourceExtractor extends SqlBaseBaseVisitor<Node> {
     }
 
     this.leftAlias = left.getAlias();
+    this.leftName = ((Table) left.getRelation()).getName().getSuffix();
     StructuredDataSource
         leftDataSource =
         metaStore.getSource(((Table) left.getRelation()).getName().getSuffix());
@@ -127,6 +134,7 @@ public class DataSourceExtractor extends SqlBaseBaseVisitor<Node> {
     this.joinLeftSchema = leftDataSource.getSchema();
 
     this.rightAlias = right.getAlias();
+    this.rightName = ((Table) right.getRelation()).getName().getSuffix();
     StructuredDataSource
         rightDataSource =
         metaStore.getSource(((Table) right.getRelation()).getName().getSuffix());
@@ -185,6 +193,30 @@ public class DataSourceExtractor extends SqlBaseBaseVisitor<Node> {
 
   public Set<String> getRightFieldNames() {
     return rightFieldNames;
+  }
+
+  public Schema getJoinRightSchema() {
+    return joinRightSchema;
+  }
+
+  public String getFromName() {
+    return fromName;
+  }
+
+  public String getLeftName() {
+    return leftName;
+  }
+
+  public String getRightName() {
+    return rightName;
+  }
+
+  public boolean isJoin() {
+    return isJoin;
+  }
+
+  public Schema getFromSchema() {
+    return fromSchema;
   }
 
   private static QualifiedName getQualifiedName(SqlBaseParser.QualifiedNameContext context) {

--- a/ksql-parser/src/test/java/io/confluent/ksql/parser/KsqlParserTest.java
+++ b/ksql-parser/src/test/java/io/confluent/ksql/parser/KsqlParserTest.java
@@ -58,6 +58,7 @@ import org.junit.Ignore;
 import org.junit.Test;
 
 import java.util.List;
+import org.junit.rules.ExpectedException;
 
 import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.CoreMatchers.is;
@@ -812,28 +813,18 @@ public class KsqlParserTest {
     Assert.assertThat(listQueries.getShowExtended(), is(true));
   }
 
-  @Test
+  @Test(expected = KsqlException.class)
   public void shouldFailIfStreamColumnNameIsAmbiguous() {
     final String statementString =
         "CREATE STREAM S AS SELECT address FROM address a;";
-    try {
-      final List<Statement> statements = KSQL_PARSER.buildAst(statementString, metaStore);
-      Assert.fail();
-    } catch (KsqlException e) {
-      assertThat(e.getMessage(), equalTo("Ambiguous column name ADDRESS. You have stream/table with the same name/alias. Use stream/table name or alias as prefix when there is a column with the same name."));
-    }
+    final List<Statement> statements = KSQL_PARSER.buildAst(statementString, metaStore);
   }
 
-  @Test
+  @Test(expected = KsqlException.class)
   public void shouldFailIfStreamColumnNameWithNoAliasIsAmbiguous() {
     final String statementString =
         "CREATE STREAM S AS SELECT address.city FROM address a;";
-    try {
-      final List<Statement> statements = KSQL_PARSER.buildAst(statementString, metaStore);
-      Assert.fail();
-    } catch (KsqlException e) {
-      assertThat(e.getMessage(), equalTo("Ambiguous column name ADDRESS. You have stream/table with the same name/alias. Use stream/table name or alias as prefix when there is a column with the same name."));
-    }
+    final List<Statement> statements = KSQL_PARSER.buildAst(statementString, metaStore);
   }
 
   @Test
@@ -862,16 +853,11 @@ public class KsqlParserTest {
         equalTo("ADDRESS.ADDRESS.CITY CITY"));
   }
 
-  @Test
+  @Test(expected = KsqlException.class)
   public void shouldFailJoinQueryParseIfStreamColumnNameWithNoAliasIsAmbiguous() {
     final String statementString =
         "CREATE STREAM S AS SELECT itemid FROM address a JOIN itemid on a.itemid = itemid.itemid;";
-    try {
-      final List<Statement> statements = KSQL_PARSER.buildAst(statementString, metaStore);
-      Assert.fail();
-    } catch (KsqlException e) {
-      assertThat(e.getMessage(), equalTo("Ambiguous column name ITEMID. You have stream/table with the same name/alias. Use stream/table name or alias as prefix when there is a column with the same name."));
-    }
+    final List<Statement> statements = KSQL_PARSER.buildAst(statementString, metaStore);
   }
 
   @Test

--- a/ksql-parser/src/test/java/io/confluent/ksql/parser/KsqlParserTest.java
+++ b/ksql-parser/src/test/java/io/confluent/ksql/parser/KsqlParserTest.java
@@ -18,6 +18,9 @@ package io.confluent.ksql.parser;
 
 import io.confluent.ksql.ddl.DdlConfig;
 import io.confluent.ksql.function.TestFunctionRegistry;
+import io.confluent.ksql.metastore.KsqlStream;
+import io.confluent.ksql.metastore.KsqlTable;
+import io.confluent.ksql.metastore.KsqlTopic;
 import io.confluent.ksql.parser.exception.ParseFailedException;
 import io.confluent.ksql.metastore.MetaStore;
 import io.confluent.ksql.parser.tree.AliasedRelation;
@@ -25,6 +28,7 @@ import io.confluent.ksql.parser.tree.ComparisonExpression;
 import io.confluent.ksql.parser.tree.CreateStream;
 import io.confluent.ksql.parser.tree.CreateStreamAsSelect;
 import io.confluent.ksql.parser.tree.CreateTable;
+import io.confluent.ksql.parser.tree.DereferenceExpression;
 import io.confluent.ksql.parser.tree.DropStream;
 import io.confluent.ksql.parser.tree.DropTable;
 import io.confluent.ksql.parser.tree.InsertInto;
@@ -42,7 +46,12 @@ import io.confluent.ksql.parser.tree.SingleColumn;
 import io.confluent.ksql.parser.tree.Statement;
 import io.confluent.ksql.parser.tree.Struct;
 import io.confluent.ksql.parser.tree.Type;
+import io.confluent.ksql.serde.json.KsqlJsonTopicSerDe;
+import io.confluent.ksql.util.KsqlException;
 import io.confluent.ksql.util.MetaStoreFixture;
+import io.confluent.ksql.util.timestamp.MetadataTimestampExtractionPolicy;
+import org.apache.kafka.connect.data.Schema;
+import org.apache.kafka.connect.data.SchemaBuilder;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Ignore;
@@ -57,6 +66,7 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.core.IsInstanceOf.instanceOf;
 import static org.hamcrest.core.IsNot.not;
 
+
 public class KsqlParserTest {
 
   private static final KsqlParser KSQL_PARSER = new KsqlParser();
@@ -67,6 +77,67 @@ public class KsqlParserTest {
   public void init() {
 
     metaStore = MetaStoreFixture.getNewMetaStore(new TestFunctionRegistry());
+
+    final Schema addressSchema = SchemaBuilder.struct()
+        .field("NUMBER", Schema.OPTIONAL_INT64_SCHEMA)
+        .field("STREET", Schema.OPTIONAL_STRING_SCHEMA)
+        .field("CITY", Schema.OPTIONAL_STRING_SCHEMA)
+        .field("STATE", Schema.OPTIONAL_STRING_SCHEMA)
+        .field("ZIPCODE", Schema.OPTIONAL_INT64_SCHEMA)
+        .optional().build();
+
+    final Schema categorySchema = SchemaBuilder.struct()
+        .field("ID", Schema.OPTIONAL_INT64_SCHEMA)
+        .field("NAME", Schema.OPTIONAL_STRING_SCHEMA)
+        .optional().build();
+
+    final Schema itemInfoSchema = SchemaBuilder.struct()
+        .field("ITEMID", Schema.INT64_SCHEMA)
+        .field("NAME", Schema.STRING_SCHEMA)
+        .field("CATEGORY", categorySchema)
+        .optional().build();
+
+    final SchemaBuilder schemaBuilder = SchemaBuilder.struct();
+    final Schema schemaBuilderOrders = schemaBuilder
+        .field("ORDERTIME", Schema.INT64_SCHEMA)
+        .field("ORDERID", Schema.OPTIONAL_INT64_SCHEMA)
+        .field("ITEMID", Schema.OPTIONAL_STRING_SCHEMA)
+        .field("ITEMINFO", itemInfoSchema)
+        .field("ORDERUNITS", Schema.INT32_SCHEMA)
+        .field("ARRAYCOL",SchemaBuilder.array(Schema.FLOAT64_SCHEMA).optional().build())
+        .field("MAPCOL", SchemaBuilder.map(Schema.STRING_SCHEMA, Schema.FLOAT64_SCHEMA).optional().build())
+        .field("ADDRESS", addressSchema)
+        .build();
+
+    KsqlTopic
+        ksqlTopicOrders =
+        new KsqlTopic("ADDRESS_TOPIC", "orders_topic", new KsqlJsonTopicSerDe());
+
+    KsqlStream ksqlStreamOrders = new KsqlStream(
+        "sqlexpression",
+        "ADDRESS",
+        schemaBuilderOrders,
+        schemaBuilderOrders.field("ORDERTIME"),
+        new MetadataTimestampExtractionPolicy(),
+        ksqlTopicOrders);
+
+    metaStore.putTopic(ksqlTopicOrders);
+    metaStore.putSource(ksqlStreamOrders);
+
+    KsqlTopic
+        ksqlTopicItems =
+        new KsqlTopic("ITEMS_TOPIC", "item_topic", new KsqlJsonTopicSerDe());
+    KsqlTable ksqlTableOrders = new KsqlTable(
+        "sqlexpression",
+        "ITEMID",
+        itemInfoSchema,
+        itemInfoSchema.field("ITEMID"),
+        new MetadataTimestampExtractionPolicy(),
+        ksqlTopicItems,
+        "items",
+        false);
+    metaStore.putTopic(ksqlTopicItems);
+    metaStore.putSource(ksqlTableOrders);
   }
 
   @Test
@@ -222,6 +293,31 @@ public class KsqlParserTest {
     SingleColumn column2 = (SingleColumn)querySpecification.getSelect().getSelectItems().get(2);
     Assert.assertTrue("testProjection fails", column2.getAlias().get().equalsIgnoreCase("KSQL_COL_2"));
     Assert.assertTrue("testProjection fails", column2.getExpression().toString().equalsIgnoreCase("'test'"));
+
+  }
+
+  @Test
+  public void shouldParseStructFieldAccessCorrectly() {
+    String simpleQuery = "SELECT iteminfo.category.name, address.street FROM orders WHERE address.state = 'CA';";
+    Statement statement = KSQL_PARSER.buildAst(simpleQuery, metaStore).get(0);
+
+
+    Assert.assertTrue("testSimpleQuery fails", statement instanceof Query);
+    Query query = (Query) statement;
+    assertThat("testSimpleQuery fails", query.getQueryBody(), instanceOf(QuerySpecification.class));
+    QuerySpecification querySpecification = (QuerySpecification)query.getQueryBody();
+    assertThat("testSimpleQuery fails", querySpecification.getSelect().getSelectItems().size(), equalTo(2));
+    SingleColumn singleColumn0 = (SingleColumn) querySpecification.getSelect().getSelectItems().get(0);
+    SingleColumn singleColumn1 = (SingleColumn) querySpecification.getSelect().getSelectItems().get(1);
+    assertThat(singleColumn0.getExpression(), instanceOf(DereferenceExpression.class));
+    assertThat(singleColumn0.getExpression().toString(), equalTo("ORDERS.ITEMINFO.CATEGORY.NAME"));
+    DereferenceExpression dereferenceExpression0 = (DereferenceExpression) singleColumn0.getExpression();
+    assertThat(dereferenceExpression0.getBase().toString(), equalTo("ORDERS.ITEMINFO.CATEGORY"));
+    assertThat(dereferenceExpression0.getFieldName(), equalTo("NAME"));
+
+    DereferenceExpression dereferenceExpression1 = (DereferenceExpression) singleColumn1.getExpression();
+    assertThat(dereferenceExpression1.getBase().toString(), equalTo("ORDERS.ADDRESS"));
+    assertThat(dereferenceExpression1.getFieldName(), equalTo("STREET"));
 
   }
 
@@ -423,20 +519,18 @@ public class KsqlParserTest {
 
   @Test
   public void testCreateStreamAsSelect() {
-
-    String
-        queryStr =
+    final String queryStr =
         "CREATE STREAM bigorders_json WITH (value_format = 'json', "
         + "kafka_topic='bigorders_topic') AS SELECT * FROM orders WHERE orderunits > 5 ;";
     Statement statement = KSQL_PARSER.buildAst(queryStr, metaStore).get(0);
-    Assert.assertTrue("testCreateStreamAsSelect failed.", statement instanceof CreateStreamAsSelect);
+    assertThat( statement, instanceOf(CreateStreamAsSelect.class));
     CreateStreamAsSelect createStreamAsSelect = (CreateStreamAsSelect)statement;
-    Assert.assertTrue("testCreateTable failed.", createStreamAsSelect.getName().toString().equalsIgnoreCase("bigorders_json"));
-    Assert.assertTrue("testCreateTable failed.", createStreamAsSelect.getQuery().getQueryBody() instanceof QuerySpecification);
+    assertThat(createStreamAsSelect.getName().toString().toLowerCase(), equalTo("bigorders_json"));
+    assertThat(createStreamAsSelect.getQuery().getQueryBody(), instanceOf(QuerySpecification.class));
     QuerySpecification querySpecification = (QuerySpecification) createStreamAsSelect.getQuery().getQueryBody();
-    Assert.assertTrue("testCreateTable failed.", querySpecification.getSelect().getSelectItems().size() == 4);
-    Assert.assertTrue("testCreateTable failed.", querySpecification.getWhere().get().toString().equalsIgnoreCase("(ORDERS.ORDERUNITS > 5)"));
-    Assert.assertTrue("testCreateTable failed.", ((AliasedRelation)querySpecification.getFrom()).getAlias().equalsIgnoreCase("ORDERS"));
+    assertThat(querySpecification.getSelect().getSelectItems().size(), equalTo(8));
+    assertThat(querySpecification.getWhere().get().toString().toUpperCase(), equalTo("(ORDERS.ORDERUNITS > 5)"));
+    assertThat(((AliasedRelation)querySpecification.getFrom()).getAlias().toUpperCase(), equalTo("ORDERS"));
   }
 
   @Test
@@ -717,4 +811,79 @@ public class KsqlParserTest {
     ListQueries listQueries = (ListQueries)statement;
     Assert.assertThat(listQueries.getShowExtended(), is(true));
   }
+
+  @Test
+  public void shouldFailIfStreamColumnNameIsAmbiguis() {
+    final String statementString =
+        "CREATE STREAM S AS SELECT address FROM address a;";
+    try {
+      final List<Statement> statements = KSQL_PARSER.buildAst(statementString, metaStore);
+      Assert.fail();
+    } catch (KsqlException e) {
+      assertThat(e.getMessage(), equalTo("Ambiguous column name ADDRESS. You have stream/table with the same name/alias. Use stream/table name or alias as prefix when there is a column with the same name."));
+    }
+  }
+
+  @Test
+  public void shouldFailIfStreamColumnNameWithNoAliasIsAmbiguis() {
+    final String statementString =
+        "CREATE STREAM S AS SELECT address.city FROM address a;";
+    try {
+      final List<Statement> statements = KSQL_PARSER.buildAst(statementString, metaStore);
+      Assert.fail();
+    } catch (KsqlException e) {
+      assertThat(e.getMessage(), equalTo("Ambiguous column name ADDRESS. You have stream/table with the same name/alias. Use stream/table name or alias as prefix when there is a column with the same name."));
+    }
+  }
+
+  @Test
+  public void shouldPassIfStreamColumnNameWithAliasIsNotAmbiguis() {
+    final String statementString =
+        "CREATE STREAM S AS SELECT a.address.city FROM address a;";
+    final Statement statement = KSQL_PARSER.buildAst(statementString, metaStore).get(0);
+    assertThat(statement, instanceOf(CreateStreamAsSelect.class));
+    Query query = ((CreateStreamAsSelect) statement).getQuery();
+    assertThat(query.getQueryBody(), instanceOf(QuerySpecification.class));
+    QuerySpecification querySpecification = (QuerySpecification) query.getQueryBody();
+    assertThat(querySpecification.getSelect().getSelectItems().get(0).toString(),
+        equalTo("A.ADDRESS.CITY CITY"));
+  }
+
+  @Test
+  public void shouldPassIfStreamColumnNameIsNotAmbiguis() {
+    final String statementString =
+        "CREATE STREAM S AS SELECT address.address.city FROM address a;";
+    final Statement statement = KSQL_PARSER.buildAst(statementString, metaStore).get(0);
+    assertThat(statement, instanceOf(CreateStreamAsSelect.class));
+    Query query = ((CreateStreamAsSelect) statement).getQuery();
+    assertThat(query.getQueryBody(), instanceOf(QuerySpecification.class));
+    QuerySpecification querySpecification = (QuerySpecification) query.getQueryBody();
+    assertThat(querySpecification.getSelect().getSelectItems().get(0).toString(),
+        equalTo("ADDRESS.ADDRESS.CITY CITY"));
+  }
+
+  @Test
+  public void shouldFailJoinQueryParseIfStreamColumnNameWithNoAliasIsAmbiguis() {
+    final String statementString =
+        "CREATE STREAM S AS SELECT itemid FROM address a JOIN itemid on a.itemid = itemid.itemid;";
+    try {
+      final List<Statement> statements = KSQL_PARSER.buildAst(statementString, metaStore);
+      Assert.fail();
+    } catch (KsqlException e) {
+      assertThat(e.getMessage(), equalTo("Ambiguous column name ITEMID. You have stream/table with the same name/alias. Use stream/table name or alias as prefix when there is a column with the same name."));
+    }
+  }
+
+  @Test
+  public void shouldPassJoinQueryParseIfStreamColumnNameWithAliasIsNotAmbiguis() {
+    final String statementString =
+        "CREATE STREAM S AS SELECT itemid.itemid FROM address a JOIN itemid on a.itemid = itemid.itemid;";
+    final Statement statement = KSQL_PARSER.buildAst(statementString, metaStore).get(0);
+    assertThat(statement, instanceOf(CreateStreamAsSelect.class));
+    Query query = ((CreateStreamAsSelect) statement).getQuery();
+    assertThat(query.getQueryBody(), instanceOf(QuerySpecification.class));
+    QuerySpecification querySpecification = (QuerySpecification) query.getQueryBody();
+    assertThat(querySpecification.getSelect().getSelectItems().get(0).toString(), equalTo("ITEMID.ITEMID ITEMID_ITEMID"));
+  }
+
 }

--- a/ksql-parser/src/test/java/io/confluent/ksql/parser/KsqlParserTest.java
+++ b/ksql-parser/src/test/java/io/confluent/ksql/parser/KsqlParserTest.java
@@ -813,7 +813,7 @@ public class KsqlParserTest {
   }
 
   @Test
-  public void shouldFailIfStreamColumnNameIsAmbiguis() {
+  public void shouldFailIfStreamColumnNameIsAmbiguous() {
     final String statementString =
         "CREATE STREAM S AS SELECT address FROM address a;";
     try {
@@ -825,7 +825,7 @@ public class KsqlParserTest {
   }
 
   @Test
-  public void shouldFailIfStreamColumnNameWithNoAliasIsAmbiguis() {
+  public void shouldFailIfStreamColumnNameWithNoAliasIsAmbiguous() {
     final String statementString =
         "CREATE STREAM S AS SELECT address.city FROM address a;";
     try {
@@ -837,7 +837,7 @@ public class KsqlParserTest {
   }
 
   @Test
-  public void shouldPassIfStreamColumnNameWithAliasIsNotAmbiguis() {
+  public void shouldPassIfStreamColumnNameWithAliasIsNotAmbiguous() {
     final String statementString =
         "CREATE STREAM S AS SELECT a.address.city FROM address a;";
     final Statement statement = KSQL_PARSER.buildAst(statementString, metaStore).get(0);
@@ -850,7 +850,7 @@ public class KsqlParserTest {
   }
 
   @Test
-  public void shouldPassIfStreamColumnNameIsNotAmbiguis() {
+  public void shouldPassIfStreamColumnNameIsNotAmbiguous() {
     final String statementString =
         "CREATE STREAM S AS SELECT address.address.city FROM address a;";
     final Statement statement = KSQL_PARSER.buildAst(statementString, metaStore).get(0);
@@ -863,7 +863,7 @@ public class KsqlParserTest {
   }
 
   @Test
-  public void shouldFailJoinQueryParseIfStreamColumnNameWithNoAliasIsAmbiguis() {
+  public void shouldFailJoinQueryParseIfStreamColumnNameWithNoAliasIsAmbiguous() {
     final String statementString =
         "CREATE STREAM S AS SELECT itemid FROM address a JOIN itemid on a.itemid = itemid.itemid;";
     try {
@@ -875,7 +875,7 @@ public class KsqlParserTest {
   }
 
   @Test
-  public void shouldPassJoinQueryParseIfStreamColumnNameWithAliasIsNotAmbiguis() {
+  public void shouldPassJoinQueryParseIfStreamColumnNameWithAliasIsNotAmbiguous() {
     final String statementString =
         "CREATE STREAM S AS SELECT itemid.itemid FROM address a JOIN itemid on a.itemid = itemid.itemid;";
     final Statement statement = KSQL_PARSER.buildAst(statementString, metaStore).get(0);

--- a/ksql-parser/src/test/java/io/confluent/ksql/parser/KsqlParserTest.java
+++ b/ksql-parser/src/test/java/io/confluent/ksql/parser/KsqlParserTest.java
@@ -829,7 +829,7 @@ public class KsqlParserTest {
   @Test
   public void shouldNotAddPrefixIfStreamNameIsPrefix() {
     final String statementString =
-        "CREATE STREAM S AS SELECT address.city FROM address a;";
+        "CREATE STREAM S AS SELECT address.orderid FROM address a;";
     final List<Statement> statements = KSQL_PARSER.buildAst(statementString, metaStore);
     final Statement statement = KSQL_PARSER.buildAst(statementString, metaStore).get(0);
     assertThat(statement, instanceOf(CreateStreamAsSelect.class));
@@ -837,7 +837,7 @@ public class KsqlParserTest {
     assertThat(query.getQueryBody(), instanceOf(QuerySpecification.class));
     QuerySpecification querySpecification = (QuerySpecification) query.getQueryBody();
     assertThat(querySpecification.getSelect().getSelectItems().get(0).toString(),
-        equalTo("ADDRESS.CITY CITY"));
+        equalTo("ADDRESS.ORDERID ORDERID"));
   }
 
   @Test

--- a/ksql-parser/src/test/java/io/confluent/ksql/parser/rewrite/StatementRewriterTest.java
+++ b/ksql-parser/src/test/java/io/confluent/ksql/parser/rewrite/StatementRewriterTest.java
@@ -447,7 +447,7 @@ public class StatementRewriterTest {
     assertThat(createStreamAsSelect.getName().toString(), equalTo("BIGORDERS_JSON"));
     assertThat(createStreamAsSelect.getQuery().getQueryBody(), instanceOf(QuerySpecification.class));
     final QuerySpecification querySpecification = (QuerySpecification) createStreamAsSelect.getQuery().getQueryBody();
-    assertThat(querySpecification.getSelect().getSelectItems().size(), equalTo(4));
+    assertThat(querySpecification.getSelect().getSelectItems().size(), equalTo(8));
     assertThat(querySpecification.getWhere().get().toString(), equalTo("(ORDERS.ORDERUNITS > 5)"));
     assertThat(((AliasedRelation)querySpecification.getFrom()).getAlias(), equalTo("ORDERS"));
   }


### PR DESCRIPTION
### Description 
This PR makes changes in our AST so we can handle dot notation to access nested fields in struct correctly.
Previously we assumed that we have only one dot, stream/table name.column name. How we will be able to have more than one dot in a dereferenced node.
This is based on the previous PR for Query rewrite.
We also check for ambiguity resulting from having columns with the same name as the stream/table name.

### Testing done 
_Describe the testing stategy. Unit and integration tests are expected for any behavior changes._

### Reviewer checklist
- [ ] Ensure docs are updated if necessary. (eg. if a user visible feature is being added or changed).
- [ ] Ensure relevant issues are linked (description should include text like "Fixes #<issue number>")

