### PR TITLE
Prefixed output topics

### DIFF
--- a/ksql-common/src/main/java/io/confluent/ksql/util/KsqlConfig.java
+++ b/ksql-common/src/main/java/io/confluent/ksql/util/KsqlConfig.java
@@ -76,7 +76,7 @@ public class KsqlConfig extends AbstractConfig implements Cloneable {
       KSQL_OUTPUT_TOPIC_NAME_PREFIX_CONFIG = "ksql.output.topic.name.prefix";
   private static final String KSQL_OUTPUT_TOPIC_NAME_PREFIX_DOCS =
       "A prefix to add to any output topic names, where the statement does not include an explicit "
-      + "topic name. E.g. given 'ksql.output.topic.name.prefix = thing', then statement "
+      + "topic name. E.g. given 'ksql.output.topic.name.prefix = \"thing-\"', then statement "
       + "'CREATE STREAM S AS ...' will create a topic 'thing-S', where as the statement "
       + "'CREATE STREAM S WITH(KAFKA_TOPIC = 'foo') AS ...' will create a topic 'foo'.";
 

--- a/ksql-common/src/main/java/io/confluent/ksql/util/KsqlConfig.java
+++ b/ksql-common/src/main/java/io/confluent/ksql/util/KsqlConfig.java
@@ -73,6 +73,14 @@ public class KsqlConfig extends AbstractConfig implements Cloneable {
       KSQL_TABLE_STATESTORE_NAME_SUFFIX_DEFAULT = "_ksql_statestore";
 
   public static final String
+      KSQL_OUTPUT_TOPIC_NAME_PREFIX_CONFIG = "ksql.output.topic.name.prefix";
+  private static final String KSQL_OUTPUT_TOPIC_NAME_PREFIX_DOCS =
+      "A prefix to add to any output topic names, where the statement does not include an explicit "
+      + "topic name. E.g. given 'ksql.output.topic.name.prefix = thing', then statement "
+      + "'CREATE STREAM S AS ...' will create a topic 'thing-S', where as the statement "
+      + "'CREATE STREAM S WITH(KAFKA_TOPIC = 'foo') AS ...' will create a topic 'foo'.";
+
+  public static final String
       defaultSchemaRegistryUrl = "http://localhost:8081";
 
   public static final boolean defaultAvroSchemaUnionNull = true;
@@ -119,6 +127,12 @@ public class KsqlConfig extends AbstractConfig implements Cloneable {
             "Suffix for state store names in Tables. For instance if the suffix is "
             + "_ksql_statestore the state "
             + "store name would be ksql_query_1_ksql_statestore _ksql_statestore "
+        ).define(
+            KSQL_OUTPUT_TOPIC_NAME_PREFIX_CONFIG,
+            ConfigDef.Type.STRING,
+            "",
+            ConfigDef.Importance.LOW,
+            KSQL_OUTPUT_TOPIC_NAME_PREFIX_DOCS
         ).define(KSQL_TIMESTAMP_COLUMN_INDEX,
             ConfigDef.Type.INT,
             null,

--- a/ksql-engine/src/main/java/io/confluent/ksql/KsqlEngine.java
+++ b/ksql-engine/src/main/java/io/confluent/ksql/KsqlEngine.java
@@ -259,7 +259,8 @@ public class KsqlEngine implements Closeable {
     // Logical plan creation from the ASTs
     List<Pair<String, PlanNode>> logicalPlans = queryEngine.buildLogicalPlans(
         tempMetaStore,
-        statementList
+        statementList,
+        ksqlConfig.cloneWithPropertyOverwrite(overriddenProperties)
     );
 
     // Physical plan creation from logical plans.
@@ -291,8 +292,8 @@ public class KsqlEngine implements Closeable {
     // Logical plan creation from the ASTs
     List<Pair<String, PlanNode>> logicalPlans = queryEngine.buildLogicalPlans(
         metaStore,
-        Collections.singletonList(new Pair<>("", query))
-    );
+        Collections.singletonList(new Pair<>("", query)),
+        ksqlConfig);
 
     // Physical plan creation from logical plans.
     List<QueryMetadata> runningQueries = queryEngine.buildPhysicalPlans(

--- a/ksql-engine/src/main/java/io/confluent/ksql/QueryEngine.java
+++ b/ksql-engine/src/main/java/io/confluent/ksql/QueryEngine.java
@@ -55,6 +55,7 @@ import io.confluent.ksql.planner.LogicalPlanner;
 import io.confluent.ksql.planner.plan.KsqlStructuredDataOutputNode;
 import io.confluent.ksql.planner.plan.PlanNode;
 import io.confluent.ksql.util.AvroUtil;
+import io.confluent.ksql.util.KsqlConfig;
 import io.confluent.ksql.util.KsqlException;
 import io.confluent.ksql.util.Pair;
 import io.confluent.ksql.util.QueryMetadata;
@@ -75,8 +76,8 @@ class QueryEngine {
 
   List<Pair<String, PlanNode>> buildLogicalPlans(
       final MetaStore metaStore,
-      final List<Pair<String, Statement>> statementList
-  ) {
+      final List<Pair<String, Statement>> statementList,
+      final KsqlConfig config) {
 
     List<Pair<String, PlanNode>> logicalPlansList = new ArrayList<>();
     // TODO: the purpose of tempMetaStore here
@@ -87,7 +88,7 @@ class QueryEngine {
         PlanNode logicalPlan = buildQueryLogicalPlan(
             statementQueryPair.getLeft(),
             (Query) statementQueryPair.getRight(),
-            tempMetaStore
+            tempMetaStore, config
         );
         logicalPlansList.add(new Pair<>(statementQueryPair.getLeft(), logicalPlan));
       } else {
@@ -102,10 +103,12 @@ class QueryEngine {
   private PlanNode buildQueryLogicalPlan(
       final String sqlExpression,
       final Query query,
-      final MetaStore tempMetaStore) {
+      final MetaStore tempMetaStore,
+      final KsqlConfig config) {
     final QueryAnalyzer queryAnalyzer = new QueryAnalyzer(
         tempMetaStore,
-        ksqlEngine.getFunctionRegistry()
+        ksqlEngine.getFunctionRegistry(),
+        config
     );
     final Analysis analysis = queryAnalyzer.analyze(sqlExpression, query);
     final AggregateAnalysis aggAnalysis = queryAnalyzer.analyzeAggregate(query, analysis);

--- a/ksql-engine/src/main/java/io/confluent/ksql/QueryEngine.java
+++ b/ksql-engine/src/main/java/io/confluent/ksql/QueryEngine.java
@@ -16,7 +16,6 @@
 
 package io.confluent.ksql;
 
-import io.confluent.ksql.parser.SqlFormatter;
 import org.apache.kafka.connect.data.Schema;
 import org.apache.kafka.connect.data.SchemaBuilder;
 import org.apache.kafka.streams.KafkaClientSupplier;
@@ -40,6 +39,7 @@ import io.confluent.ksql.metastore.KsqlStream;
 import io.confluent.ksql.metastore.KsqlTopic;
 import io.confluent.ksql.metastore.MetaStore;
 import io.confluent.ksql.metastore.StructuredDataSource;
+import io.confluent.ksql.parser.SqlFormatter;
 import io.confluent.ksql.parser.tree.AbstractStreamCreateStatement;
 import io.confluent.ksql.parser.tree.DdlStatement;
 import io.confluent.ksql.parser.tree.Expression;
@@ -100,10 +100,9 @@ class QueryEngine {
   }
 
   private PlanNode buildQueryLogicalPlan(
-      String sqlExpression,
+      final String sqlExpression,
       final Query query,
-      final MetaStore tempMetaStore
-  ) {
+      final MetaStore tempMetaStore) {
     final QueryAnalyzer queryAnalyzer = new QueryAnalyzer(
         tempMetaStore,
         ksqlEngine.getFunctionRegistry()

--- a/ksql-engine/src/main/java/io/confluent/ksql/analyzer/Analyzer.java
+++ b/ksql-engine/src/main/java/io/confluent/ksql/analyzer/Analyzer.java
@@ -22,6 +22,7 @@ import org.apache.kafka.connect.data.Schema;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Set;
 
 import io.confluent.ksql.ddl.DdlConfig;
@@ -30,6 +31,7 @@ import io.confluent.ksql.metastore.KsqlStream;
 import io.confluent.ksql.metastore.KsqlTopic;
 import io.confluent.ksql.metastore.MetaStore;
 import io.confluent.ksql.metastore.StructuredDataSource;
+import io.confluent.ksql.parser.DefaultTraversalVisitor;
 import io.confluent.ksql.parser.tree.AliasedRelation;
 import io.confluent.ksql.parser.tree.AllColumns;
 import io.confluent.ksql.parser.tree.Cast;
@@ -49,7 +51,6 @@ import io.confluent.ksql.parser.tree.SelectItem;
 import io.confluent.ksql.parser.tree.SingleColumn;
 import io.confluent.ksql.parser.tree.Table;
 import io.confluent.ksql.parser.tree.WindowExpression;
-import io.confluent.ksql.parser.DefaultTraversalVisitor;
 import io.confluent.ksql.planner.plan.JoinNode;
 import io.confluent.ksql.planner.plan.PlanNodeId;
 import io.confluent.ksql.planner.plan.StructuredDataSourceNode;
@@ -73,10 +74,12 @@ public class Analyzer extends DefaultTraversalVisitor<Node, AnalysisContext> {
   private final Analysis analysis;
   private final MetaStore metaStore;
 
-  public Analyzer(String sqlExpression, Analysis analysis, MetaStore metaStore) {
-    this.sqlExpression = sqlExpression;
-    this.analysis = analysis;
-    this.metaStore = metaStore;
+  public Analyzer(final String sqlExpression,
+                  final Analysis analysis,
+                  final MetaStore metaStore) {
+    this.sqlExpression = Objects.requireNonNull(sqlExpression, "sqlExpression");
+    this.analysis = Objects.requireNonNull(analysis, "analysis");
+    this.metaStore = Objects.requireNonNull(metaStore, "metaStore");
   }
 
   @Override

--- a/ksql-engine/src/main/java/io/confluent/ksql/analyzer/Analyzer.java
+++ b/ksql-engine/src/main/java/io/confluent/ksql/analyzer/Analyzer.java
@@ -73,13 +73,22 @@ public class Analyzer extends DefaultTraversalVisitor<Node, AnalysisContext> {
   private final String sqlExpression;
   private final Analysis analysis;
   private final MetaStore metaStore;
+  private final String topicPrefix;
 
+  /**
+   * @param sqlExpression the sql expression to analyse
+   * @param analysis      where the results are stored.
+   * @param metaStore     the metastore to use.
+   * @param topicPrefix   the prefix to use for topic names where an explicit name is not specified.
+   */
   public Analyzer(final String sqlExpression,
                   final Analysis analysis,
-                  final MetaStore metaStore) {
+                  final MetaStore metaStore,
+                  final String topicPrefix) {
     this.sqlExpression = Objects.requireNonNull(sqlExpression, "sqlExpression");
     this.analysis = Objects.requireNonNull(analysis, "analysis");
     this.metaStore = Objects.requireNonNull(metaStore, "metaStore");
+    this.topicPrefix = Objects.requireNonNull(topicPrefix, "topicPrefix");
   }
 
   @Override
@@ -129,10 +138,9 @@ public class Analyzer extends DefaultTraversalVisitor<Node, AnalysisContext> {
     List<Pair<StructuredDataSource, String>> fromDataSources = analysis.getFromDataSources();
 
     StructuredDataSource intoStructuredDataSource = analysis.getInto();
-    String intoKafkaTopicName = analysis.getIntoKafkaTopicName();
-    if (intoKafkaTopicName == null) {
-      intoKafkaTopicName = intoStructuredDataSource.getName();
-    }
+    final String intoKafkaTopicName = analysis.getIntoKafkaTopicName() == null
+                                      ? topicPrefix + intoStructuredDataSource.getName()
+                                      : analysis.getIntoKafkaTopicName();
 
     KsqlTopic newIntoKsqlTopic;
     if (doCreateInto) {

--- a/ksql-engine/src/main/java/io/confluent/ksql/analyzer/QueryAnalyzer.java
+++ b/ksql-engine/src/main/java/io/confluent/ksql/analyzer/QueryAnalyzer.java
@@ -25,21 +25,25 @@ import io.confluent.ksql.parser.tree.ExpressionTreeRewriter;
 import io.confluent.ksql.parser.tree.Query;
 import io.confluent.ksql.parser.tree.QuerySpecification;
 import io.confluent.ksql.util.AggregateExpressionRewriter;
+import io.confluent.ksql.util.KsqlConfig;
 import io.confluent.ksql.util.KsqlException;
 
 public class QueryAnalyzer {
   private final MetaStore metaStore;
   private final FunctionRegistry functionRegistry;
+  private final KsqlConfig config;
 
   public QueryAnalyzer(final MetaStore metaStore,
-                       final FunctionRegistry functionRegistry) {
+                       final FunctionRegistry functionRegistry,
+                       final KsqlConfig config) {
     this.metaStore = Objects.requireNonNull(metaStore, "metaStore");
     this.functionRegistry = Objects.requireNonNull(functionRegistry, "functionRegistry");
+    this.config = Objects.requireNonNull(config, "config");
   }
 
   public Analysis analyze(final String sqlExpression, final Query query) {
     final Analysis analysis = new Analysis();
-    final Analyzer analyzer = new Analyzer(sqlExpression, analysis, metaStore);
+    final Analyzer analyzer = new Analyzer(sqlExpression, analysis, metaStore, topicPrefix());
     analyzer.process(query, new AnalysisContext());
     return analysis;
   }
@@ -127,5 +131,9 @@ public class QueryAnalyzer {
     if (numberOfNonAggProjections != groupBySize) {
       throw new KsqlException("Group by elements should match the SELECT expressions.");
     }
+  }
+
+  private String topicPrefix() {
+    return config.getString(KsqlConfig.KSQL_OUTPUT_TOPIC_NAME_PREFIX_CONFIG);
   }
 }

--- a/ksql-engine/src/main/java/io/confluent/ksql/analyzer/QueryAnalyzer.java
+++ b/ksql-engine/src/main/java/io/confluent/ksql/analyzer/QueryAnalyzer.java
@@ -16,6 +16,8 @@
 
 package io.confluent.ksql.analyzer;
 
+import java.util.Objects;
+
 import io.confluent.ksql.function.FunctionRegistry;
 import io.confluent.ksql.metastore.MetaStore;
 import io.confluent.ksql.parser.tree.Expression;
@@ -29,14 +31,15 @@ public class QueryAnalyzer {
   private final MetaStore metaStore;
   private final FunctionRegistry functionRegistry;
 
-  public QueryAnalyzer(final MetaStore metaStore, final FunctionRegistry functionRegistry) {
-    this.metaStore = metaStore;
-    this.functionRegistry = functionRegistry;
+  public QueryAnalyzer(final MetaStore metaStore,
+                       final FunctionRegistry functionRegistry) {
+    this.metaStore = Objects.requireNonNull(metaStore, "metaStore");
+    this.functionRegistry = Objects.requireNonNull(functionRegistry, "functionRegistry");
   }
 
   public Analysis analyze(final String sqlExpression, final Query query) {
-    Analysis analysis = new Analysis();
-    Analyzer analyzer = new Analyzer(sqlExpression, analysis, metaStore);
+    final Analysis analysis = new Analysis();
+    final Analyzer analyzer = new Analyzer(sqlExpression, analysis, metaStore);
     analyzer.process(query, new AnalysisContext());
     return analysis;
   }

--- a/ksql-engine/src/test/java/io/confluent/ksql/analyzer/AggregateAnalyzerTest.java
+++ b/ksql-engine/src/test/java/io/confluent/ksql/analyzer/AggregateAnalyzerTest.java
@@ -46,7 +46,7 @@ public class AggregateAnalyzerTest {
   private Analysis analyze(final String queryStr) {
     final List<Statement> statements = KSQL_PARSER.buildAst(queryStr, metaStore);
     final Analysis analysis = new Analysis();
-    final Analyzer analyzer = new Analyzer(queryStr, analysis, metaStore);
+    final Analyzer analyzer = new Analyzer(queryStr, analysis, metaStore, "");
     analyzer.process(statements.get(0), new AnalysisContext(null));
     return analysis;
   }

--- a/ksql-engine/src/test/java/io/confluent/ksql/analyzer/AggregateAnalyzerTest.java
+++ b/ksql-engine/src/test/java/io/confluent/ksql/analyzer/AggregateAnalyzerTest.java
@@ -16,20 +16,21 @@
 
 package io.confluent.ksql.analyzer;
 
-import io.confluent.ksql.function.InternalFunctionRegistry;
-import io.confluent.ksql.metastore.MetaStore;
-import io.confluent.ksql.parser.KsqlParser;
-import io.confluent.ksql.util.AggregateExpressionRewriter;
-import io.confluent.ksql.parser.tree.ComparisonExpression;
-import io.confluent.ksql.parser.tree.Expression;
-import io.confluent.ksql.parser.tree.ExpressionTreeRewriter;
-import io.confluent.ksql.parser.tree.Statement;
-import io.confluent.ksql.util.MetaStoreFixture;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
 
 import java.util.List;
+
+import io.confluent.ksql.function.InternalFunctionRegistry;
+import io.confluent.ksql.metastore.MetaStore;
+import io.confluent.ksql.parser.KsqlParser;
+import io.confluent.ksql.parser.tree.ComparisonExpression;
+import io.confluent.ksql.parser.tree.Expression;
+import io.confluent.ksql.parser.tree.ExpressionTreeRewriter;
+import io.confluent.ksql.parser.tree.Statement;
+import io.confluent.ksql.util.AggregateExpressionRewriter;
+import io.confluent.ksql.util.MetaStoreFixture;
 
 public class AggregateAnalyzerTest {
 
@@ -43,11 +44,9 @@ public class AggregateAnalyzerTest {
   }
 
   private Analysis analyze(final String queryStr) {
-    List<Statement> statements = KSQL_PARSER.buildAst(queryStr, metaStore);
-//    System.out.println(SqlFormatterQueryRewrite.formatSql(statements.get(0)).replace("\n", " "));
-    // Analyze the query to resolve the references and extract oeprations
-    Analysis analysis = new Analysis();
-    Analyzer analyzer = new Analyzer(queryStr, analysis, metaStore);
+    final List<Statement> statements = KSQL_PARSER.buildAst(queryStr, metaStore);
+    final Analysis analysis = new Analysis();
+    final Analyzer analyzer = new Analyzer(queryStr, analysis, metaStore);
     analyzer.process(statements.get(0), new AnalysisContext(null));
     return analysis;
   }

--- a/ksql-engine/src/test/java/io/confluent/ksql/analyzer/AnalyzerTest.java
+++ b/ksql-engine/src/test/java/io/confluent/ksql/analyzer/AnalyzerTest.java
@@ -16,17 +16,18 @@
 
 package io.confluent.ksql.analyzer;
 
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.util.List;
+
 import io.confluent.ksql.function.InternalFunctionRegistry;
 import io.confluent.ksql.metastore.MetaStore;
 import io.confluent.ksql.parser.KsqlParser;
 import io.confluent.ksql.parser.SqlFormatter;
 import io.confluent.ksql.parser.tree.Statement;
 import io.confluent.ksql.util.MetaStoreFixture;
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.Test;
-
-import java.util.List;
 
 public class AnalyzerTest {
 
@@ -40,16 +41,15 @@ public class AnalyzerTest {
   }
 
   private Analysis analyze(String queryStr) {
-    List<Statement> statements = KSQL_PARSER.buildAst(queryStr, metaStore);
-    // Analyze the query to resolve the references and extract oeprations
-    Analysis analysis = new Analysis();
-    Analyzer analyzer = new Analyzer("sqlExpression", analysis, metaStore);
+    final List<Statement> statements = KSQL_PARSER.buildAst(queryStr, metaStore);
+    final Analysis analysis = new Analysis();
+    final Analyzer analyzer = new Analyzer("sqlExpression", analysis, metaStore);
     analyzer.process(statements.get(0), new AnalysisContext(null));
     return analysis;
   }
 
   @Test
-  public void testSimpleQueryAnalysis() throws Exception {
+  public void testSimpleQueryAnalysis() {
     String simpleQuery = "SELECT col0, col2, col3 FROM test1 WHERE col0 > 100;";
     Analysis analysis = analyze(simpleQuery);
     Assert.assertNotNull("INTO is null", analysis.getInto());
@@ -88,7 +88,7 @@ public class AnalyzerTest {
   }
 
   @Test
-  public void testSimpleLeftJoinAnalysis() throws Exception {
+  public void testSimpleLeftJoinAnalysis() {
     String
         simpleQuery =
         "SELECT t1.col1, t2.col1, t2.col4, col5, t2.col2 FROM test1 t1 LEFT JOIN test2 t2 ON "
@@ -140,7 +140,7 @@ public class AnalyzerTest {
   }
 
   @Test
-  public void testBooleanExpressionAnalysis() throws Exception {
+  public void testBooleanExpressionAnalysis() {
     String queryStr = "SELECT col0 = 10, col2, col3 > col1 FROM test1;";
     Analysis analysis = analyze(queryStr);
 
@@ -171,7 +171,7 @@ public class AnalyzerTest {
   }
 
   @Test
-  public void testFilterAnalysis() throws Exception {
+  public void testFilterAnalysis() {
     String queryStr = "SELECT col0 = 10, col2, col3 > col1 FROM test1 WHERE col0 > 20;";
     Analysis analysis = analyze(queryStr);
 

--- a/ksql-engine/src/test/java/io/confluent/ksql/analyzer/AnalyzerTest.java
+++ b/ksql-engine/src/test/java/io/confluent/ksql/analyzer/AnalyzerTest.java
@@ -43,7 +43,7 @@ public class AnalyzerTest {
   private Analysis analyze(String queryStr) {
     final List<Statement> statements = KSQL_PARSER.buildAst(queryStr, metaStore);
     final Analysis analysis = new Analysis();
-    final Analyzer analyzer = new Analyzer("sqlExpression", analysis, metaStore);
+    final Analyzer analyzer = new Analyzer("sqlExpression", analysis, metaStore, "");
     analyzer.process(statements.get(0), new AnalysisContext(null));
     return analysis;
   }

--- a/ksql-engine/src/test/java/io/confluent/ksql/analyzer/QueryAnalyzerTest.java
+++ b/ksql-engine/src/test/java/io/confluent/ksql/analyzer/QueryAnalyzerTest.java
@@ -40,6 +40,7 @@ import io.confluent.ksql.parser.tree.QualifiedName;
 import io.confluent.ksql.parser.tree.QualifiedNameReference;
 import io.confluent.ksql.parser.tree.Query;
 import io.confluent.ksql.parser.tree.Statement;
+import io.confluent.ksql.util.KsqlConfig;
 import io.confluent.ksql.util.KsqlException;
 import io.confluent.ksql.util.MetaStoreFixture;
 import io.confluent.ksql.util.Pair;
@@ -54,7 +55,8 @@ public class QueryAnalyzerTest {
 
   private final MetaStore metaStore = MetaStoreFixture.getNewMetaStore(new InternalFunctionRegistry());
   private final KsqlParser ksqlParser = new KsqlParser();
-  private final QueryAnalyzer queryAnalyzer =  new QueryAnalyzer(metaStore, new InternalFunctionRegistry());
+  private final QueryAnalyzer queryAnalyzer =  new QueryAnalyzer(metaStore, new InternalFunctionRegistry(),
+                                                                 new KsqlConfig(Collections.emptyMap()));
 
   @Test
   public void shouldCreateAnalysisForSimpleQuery() {

--- a/ksql-engine/src/test/java/io/confluent/ksql/analyzer/QueryAnalyzerTest.java
+++ b/ksql-engine/src/test/java/io/confluent/ksql/analyzer/QueryAnalyzerTest.java
@@ -24,7 +24,6 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.Optional;
 
 import io.confluent.ksql.function.InternalFunctionRegistry;
 import io.confluent.ksql.metastore.KsqlStream;
@@ -36,7 +35,6 @@ import io.confluent.ksql.parser.tree.DereferenceExpression;
 import io.confluent.ksql.parser.tree.Expression;
 import io.confluent.ksql.parser.tree.InsertInto;
 import io.confluent.ksql.parser.tree.IntegerLiteral;
-import io.confluent.ksql.parser.tree.LongLiteral;
 import io.confluent.ksql.parser.tree.NodeLocation;
 import io.confluent.ksql.parser.tree.QualifiedName;
 import io.confluent.ksql.parser.tree.QualifiedNameReference;

--- a/ksql-engine/src/test/java/io/confluent/ksql/codegen/CodeGenRunnerTest.java
+++ b/ksql-engine/src/test/java/io/confluent/ksql/codegen/CodeGenRunnerTest.java
@@ -490,9 +490,8 @@ public class CodeGenRunnerTest {
 
     private Analysis analyzeQuery(String queryStr) {
         final List<Statement> statements = KSQL_PARSER.buildAst(queryStr, metaStore);
-        // Analyze the query to resolve the references and extract oeprations
         final Analysis analysis = new Analysis();
-        final Analyzer analyzer = new Analyzer(queryStr, analysis, metaStore);
+        final Analyzer analyzer = new Analyzer(queryStr, analysis, metaStore, "");
         analyzer.process(statements.get(0), new AnalysisContext(null));
         return analysis;
     }

--- a/ksql-engine/src/test/java/io/confluent/ksql/codegen/CodeGenRunnerTest.java
+++ b/ksql-engine/src/test/java/io/confluent/ksql/codegen/CodeGenRunnerTest.java
@@ -18,10 +18,8 @@ package io.confluent.ksql.codegen;
 
 import com.google.common.collect.ImmutableMap;
 
-import org.apache.kafka.common.metrics.Metrics;
 import org.apache.kafka.connect.data.Schema;
 import org.apache.kafka.connect.data.SchemaBuilder;
-import org.apache.kafka.test.TestUtils;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
@@ -37,8 +35,6 @@ import io.confluent.ksql.analyzer.Analysis;
 import io.confluent.ksql.analyzer.AnalysisContext;
 import io.confluent.ksql.analyzer.Analyzer;
 import io.confluent.ksql.function.InternalFunctionRegistry;
-import io.confluent.ksql.function.UdfCompiler;
-import io.confluent.ksql.function.UdfLoader;
 import io.confluent.ksql.function.UdfLoaderUtil;
 import io.confluent.ksql.function.udf.Kudf;
 import io.confluent.ksql.metastore.KsqlStream;

--- a/ksql-engine/src/test/java/io/confluent/ksql/codegen/SqlToJavaVisitorTest.java
+++ b/ksql-engine/src/test/java/io/confluent/ksql/codegen/SqlToJavaVisitorTest.java
@@ -57,7 +57,7 @@ public class SqlToJavaVisitorTest {
   private Analysis analyzeQuery(String queryStr) {
     final List<Statement> statements = KSQL_PARSER.buildAst(queryStr, metaStore);
     final Analysis analysis = new Analysis();
-    final Analyzer analyzer = new Analyzer("sqlExpression", analysis, metaStore);
+    final Analyzer analyzer = new Analyzer("sqlExpression", analysis, metaStore, "");
     analyzer.process(statements.get(0), new AnalysisContext(null));
     return analysis;
   }

--- a/ksql-engine/src/test/java/io/confluent/ksql/codegen/SqlToJavaVisitorTest.java
+++ b/ksql-engine/src/test/java/io/confluent/ksql/codegen/SqlToJavaVisitorTest.java
@@ -11,15 +11,11 @@ import io.confluent.ksql.analyzer.Analysis;
 import io.confluent.ksql.analyzer.AnalysisContext;
 import io.confluent.ksql.analyzer.Analyzer;
 import io.confluent.ksql.function.InternalFunctionRegistry;
-import io.confluent.ksql.function.UdfCompiler;
-import io.confluent.ksql.function.UdfLoader;
-import io.confluent.ksql.function.UdfLoaderTest;
 import io.confluent.ksql.function.UdfLoaderUtil;
 import io.confluent.ksql.metastore.MetaStore;
 import io.confluent.ksql.parser.KsqlParser;
 import io.confluent.ksql.parser.tree.Statement;
 import io.confluent.ksql.util.MetaStoreFixture;
-import kafka.utils.TestUtils;
 
 import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.CoreMatchers.is;
@@ -59,10 +55,9 @@ public class SqlToJavaVisitorTest {
   }
 
   private Analysis analyzeQuery(String queryStr) {
-    List<Statement> statements = KSQL_PARSER.buildAst(queryStr, metaStore);
-    // Analyze the query to resolve the references and extract oeprations
-    Analysis analysis = new Analysis();
-    Analyzer analyzer = new Analyzer("sqlExpression", analysis, metaStore);
+    final List<Statement> statements = KSQL_PARSER.buildAst(queryStr, metaStore);
+    final Analysis analysis = new Analysis();
+    final Analyzer analyzer = new Analyzer("sqlExpression", analysis, metaStore);
     analyzer.process(statements.get(0), new AnalysisContext(null));
     return analysis;
   }

--- a/ksql-engine/src/test/java/io/confluent/ksql/planner/LogicalPlannerTest.java
+++ b/ksql-engine/src/test/java/io/confluent/ksql/planner/LogicalPlannerTest.java
@@ -63,7 +63,7 @@ public class LogicalPlannerTest {
   private PlanNode buildLogicalPlan(String queryStr) {
     final List<Statement> statements = KSQL_PARSER.buildAst(queryStr, metaStore);
     final Analysis analysis = new Analysis();
-    final Analyzer analyzer = new Analyzer("sqlExpression", analysis, metaStore);
+    final Analyzer analyzer = new Analyzer("sqlExpression", analysis, metaStore, "");
     analyzer.process(statements.get(0), new AnalysisContext(null));
     final AggregateAnalysis aggregateAnalysis = new AggregateAnalysis();
     final AggregateAnalyzer aggregateAnalyzer = new AggregateAnalyzer(aggregateAnalysis, analysis,

--- a/ksql-engine/src/test/java/io/confluent/ksql/planner/LogicalPlannerTest.java
+++ b/ksql-engine/src/test/java/io/confluent/ksql/planner/LogicalPlannerTest.java
@@ -16,6 +16,13 @@
 
 package io.confluent.ksql.planner;
 
+import org.apache.kafka.connect.data.Schema;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.util.List;
+
 import io.confluent.ksql.analyzer.AggregateAnalysis;
 import io.confluent.ksql.analyzer.AggregateAnalyzer;
 import io.confluent.ksql.analyzer.Analysis;
@@ -35,12 +42,6 @@ import io.confluent.ksql.planner.plan.ProjectNode;
 import io.confluent.ksql.planner.plan.StructuredDataSourceNode;
 import io.confluent.ksql.serde.DataSource;
 import io.confluent.ksql.util.MetaStoreFixture;
-import org.apache.kafka.connect.data.Schema;
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.Test;
-
-import java.util.List;
 
 import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.CoreMatchers.instanceOf;
@@ -60,13 +61,12 @@ public class LogicalPlannerTest {
   }
 
   private PlanNode buildLogicalPlan(String queryStr) {
-    List<Statement> statements = KSQL_PARSER.buildAst(queryStr, metaStore);
-    // Analyze the query to resolve the references and extract oeprations
-    Analysis analysis = new Analysis();
-    Analyzer analyzer = new Analyzer("sqlExpression", analysis, metaStore);
+    final List<Statement> statements = KSQL_PARSER.buildAst(queryStr, metaStore);
+    final Analysis analysis = new Analysis();
+    final Analyzer analyzer = new Analyzer("sqlExpression", analysis, metaStore);
     analyzer.process(statements.get(0), new AnalysisContext(null));
-    AggregateAnalysis aggregateAnalysis = new AggregateAnalysis();
-    AggregateAnalyzer aggregateAnalyzer = new AggregateAnalyzer(aggregateAnalysis, analysis,
+    final AggregateAnalysis aggregateAnalysis = new AggregateAnalysis();
+    final AggregateAnalyzer aggregateAnalyzer = new AggregateAnalyzer(aggregateAnalysis, analysis,
                                                                 functionRegistry);
     for (Expression expression: analysis.getSelectExpressions()) {
       aggregateAnalyzer.process(expression, new AnalysisContext(null));

--- a/ksql-engine/src/test/java/io/confluent/ksql/structured/LogicalPlanBuilder.java
+++ b/ksql-engine/src/test/java/io/confluent/ksql/structured/LogicalPlanBuilder.java
@@ -46,7 +46,7 @@ public class LogicalPlanBuilder {
   public PlanNode buildLogicalPlan(String queryStr) {
     final List<Statement> statements = parser.buildAst(queryStr, metaStore);
     final Analysis analysis = new Analysis();
-    final Analyzer analyzer = new Analyzer(queryStr, analysis, metaStore);
+    final Analyzer analyzer = new Analyzer(queryStr, analysis, metaStore, "");
     analyzer.process(statements.get(0), new AnalysisContext(null));
     final AggregateAnalysis aggregateAnalysis = new AggregateAnalysis();
     final AggregateAnalyzer aggregateAnalyzer = new AggregateAnalyzer(aggregateAnalysis, analysis, functionRegistry);

--- a/ksql-engine/src/test/java/io/confluent/ksql/structured/LogicalPlanBuilder.java
+++ b/ksql-engine/src/test/java/io/confluent/ksql/structured/LogicalPlanBuilder.java
@@ -44,13 +44,13 @@ public class LogicalPlanBuilder {
   }
 
   public PlanNode buildLogicalPlan(String queryStr) {
-    List<Statement> statements = parser.buildAst(queryStr, metaStore);
-    Analysis analysis = new Analysis();
-    Analyzer analyzer = new Analyzer(queryStr, analysis, metaStore);
+    final List<Statement> statements = parser.buildAst(queryStr, metaStore);
+    final Analysis analysis = new Analysis();
+    final Analyzer analyzer = new Analyzer(queryStr, analysis, metaStore);
     analyzer.process(statements.get(0), new AnalysisContext(null));
-    AggregateAnalysis aggregateAnalysis = new AggregateAnalysis();
-    AggregateAnalyzer aggregateAnalyzer = new AggregateAnalyzer(aggregateAnalysis, analysis, functionRegistry);
-    AggregateExpressionRewriter aggregateExpressionRewriter = new AggregateExpressionRewriter
+    final AggregateAnalysis aggregateAnalysis = new AggregateAnalysis();
+    final AggregateAnalyzer aggregateAnalyzer = new AggregateAnalyzer(aggregateAnalysis, analysis, functionRegistry);
+    final AggregateExpressionRewriter aggregateExpressionRewriter = new AggregateExpressionRewriter
         (functionRegistry);
     for (Expression expression: analysis.getSelectExpressions()) {
       aggregateAnalyzer.process(expression, new AnalysisContext(null));

--- a/ksql-engine/src/test/java/io/confluent/ksql/structured/SqlPredicateTest.java
+++ b/ksql-engine/src/test/java/io/confluent/ksql/structured/SqlPredicateTest.java
@@ -16,6 +16,18 @@
 
 package io.confluent.ksql.structured;
 
+import org.apache.kafka.common.serialization.Serdes;
+import org.apache.kafka.streams.StreamsBuilder;
+import org.apache.kafka.streams.kstream.Consumed;
+import org.apache.kafka.streams.kstream.KStream;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+
 import io.confluent.kafka.schemaregistry.client.MockSchemaRegistryClient;
 import io.confluent.ksql.analyzer.AggregateAnalysis;
 import io.confluent.ksql.analyzer.AggregateAnalyzer;
@@ -33,18 +45,6 @@ import io.confluent.ksql.planner.plan.FilterNode;
 import io.confluent.ksql.planner.plan.PlanNode;
 import io.confluent.ksql.util.KsqlConfig;
 import io.confluent.ksql.util.MetaStoreFixture;
-
-import org.apache.kafka.common.serialization.Serdes;
-import org.apache.kafka.streams.StreamsBuilder;
-import org.apache.kafka.streams.kstream.Consumed;
-import org.apache.kafka.streams.kstream.KStream;
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.Test;
-
-import java.util.ArrayList;
-import java.util.Collections;
-import java.util.List;
 
 public class SqlPredicateTest {
   private SchemaKStream initialSchemaKStream;
@@ -70,13 +70,12 @@ public class SqlPredicateTest {
 
 
   private PlanNode buildLogicalPlan(String queryStr) {
-    List<Statement> statements = KSQL_PARSER.buildAst(queryStr, metaStore);
-    // Analyze the query to resolve the references and extract oeprations
-    Analysis analysis = new Analysis();
-    Analyzer analyzer = new Analyzer("sqlExpression", analysis, metaStore);
+    final List<Statement> statements = KSQL_PARSER.buildAst(queryStr, metaStore);
+    final Analysis analysis = new Analysis();
+    final Analyzer analyzer = new Analyzer("sqlExpression", analysis, metaStore);
     analyzer.process(statements.get(0), new AnalysisContext(null));
-    AggregateAnalysis aggregateAnalysis = new AggregateAnalysis();
-    AggregateAnalyzer aggregateAnalyzer = new AggregateAnalyzer(aggregateAnalysis,
+    final AggregateAnalysis aggregateAnalysis = new AggregateAnalysis();
+    final AggregateAnalyzer aggregateAnalyzer = new AggregateAnalyzer(aggregateAnalysis,
                                                                 analysis, functionRegistry);
     for (Expression expression: analysis.getSelectExpressions()) {
       aggregateAnalyzer.process(expression, new AnalysisContext(null));

--- a/ksql-engine/src/test/java/io/confluent/ksql/structured/SqlPredicateTest.java
+++ b/ksql-engine/src/test/java/io/confluent/ksql/structured/SqlPredicateTest.java
@@ -72,7 +72,7 @@ public class SqlPredicateTest {
   private PlanNode buildLogicalPlan(String queryStr) {
     final List<Statement> statements = KSQL_PARSER.buildAst(queryStr, metaStore);
     final Analysis analysis = new Analysis();
-    final Analyzer analyzer = new Analyzer("sqlExpression", analysis, metaStore);
+    final Analyzer analyzer = new Analyzer("sqlExpression", analysis, metaStore, "");
     analyzer.process(statements.get(0), new AnalysisContext(null));
     final AggregateAnalysis aggregateAnalysis = new AggregateAnalysis();
     final AggregateAnalyzer aggregateAnalyzer = new AggregateAnalyzer(aggregateAnalysis,

--- a/ksql-engine/src/test/java/io/confluent/ksql/util/ExpressionTypeManagerTest.java
+++ b/ksql-engine/src/test/java/io/confluent/ksql/util/ExpressionTypeManagerTest.java
@@ -16,20 +16,6 @@
 
 package io.confluent.ksql.util;
 
-import io.confluent.ksql.analyzer.Analysis;
-import io.confluent.ksql.analyzer.AnalysisContext;
-import io.confluent.ksql.analyzer.Analyzer;
-import io.confluent.ksql.function.InternalFunctionRegistry;
-import io.confluent.ksql.function.UdfCompiler;
-import io.confluent.ksql.function.UdfLoader;
-import io.confluent.ksql.function.UdfLoaderTest;
-import io.confluent.ksql.function.UdfLoaderUtil;
-import io.confluent.ksql.metastore.MetaStore;
-import io.confluent.ksql.parser.KsqlParser;
-import io.confluent.ksql.parser.tree.Statement;
-import kafka.utils.TestUtils;
-
-import org.apache.kafka.common.metrics.Metrics;
 import org.apache.kafka.connect.data.Schema;
 import org.apache.kafka.connect.data.SchemaBuilder;
 import org.junit.Assert;
@@ -37,6 +23,15 @@ import org.junit.Before;
 import org.junit.Test;
 
 import java.util.List;
+
+import io.confluent.ksql.analyzer.Analysis;
+import io.confluent.ksql.analyzer.AnalysisContext;
+import io.confluent.ksql.analyzer.Analyzer;
+import io.confluent.ksql.function.InternalFunctionRegistry;
+import io.confluent.ksql.function.UdfLoaderUtil;
+import io.confluent.ksql.metastore.MetaStore;
+import io.confluent.ksql.parser.KsqlParser;
+import io.confluent.ksql.parser.tree.Statement;
 
 import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.MatcherAssert.assertThat;

--- a/ksql-engine/src/test/java/io/confluent/ksql/util/ExpressionTypeManagerTest.java
+++ b/ksql-engine/src/test/java/io/confluent/ksql/util/ExpressionTypeManagerTest.java
@@ -56,10 +56,9 @@ public class ExpressionTypeManagerTest {
     }
 
     private Analysis analyzeQuery(String queryStr) {
-        List<Statement> statements = KSQL_PARSER.buildAst(queryStr, metaStore);
-        // Analyze the query to resolve the references and extract oeprations
-        Analysis analysis = new Analysis();
-        Analyzer analyzer = new Analyzer("sqlExpression", analysis, metaStore);
+        final List<Statement> statements = KSQL_PARSER.buildAst(queryStr, metaStore);
+        final Analysis analysis = new Analysis();
+        final Analyzer analyzer = new Analyzer("sqlExpression", analysis, metaStore, "");
         analyzer.process(statements.get(0), new AnalysisContext(null));
         return analysis;
     }

--- a/ksql-engine/src/test/resources/query-validation-tests/sink-topic-naming.json
+++ b/ksql-engine/src/test/resources/query-validation-tests/sink-topic-naming.json
@@ -1,0 +1,52 @@
+{
+  "comments": [
+    "Tests covering sink topic naming for a stream / table"
+  ],
+  "tests": [
+    {
+      "name": "sink-topic-naming: default topic name is stream name, in upper-case",
+      "statements": [
+        "CREATE STREAM TEST (source VARCHAR) WITH (kafka_topic='test_topic', value_format='JSON');",
+        "CREATE STREAM OutPut AS SELECT * FROM TEST;"
+      ],
+      "inputs": [
+        {"topic": "test_topic", "key": 1, "value": "{\"source\": \"s1\"}", "timestamp": 0}
+      ],
+      "outputs": [
+        {"topic": "OUTPUT", "key": 1, "value": "{\"SOURCE\":\"s1\"}", "timestamp": 0}
+      ]
+    },
+    {
+      "name": "sink-topic-naming: use supplied topic name, when supplied",
+      "properties": {
+        "ksql.output.topic.name.prefix": "some-prefix-"
+      },
+      "statements": [
+        "CREATE STREAM TEST (source VARCHAR) WITH (kafka_topic='test_topic', value_format='JSON');",
+        "CREATE STREAM OUTPUT WITH(KAFKA_TOPIC = 'Fred') AS SELECT * FROM TEST;"
+      ],
+      "inputs": [
+        {"topic": "test_topic", "key": 1, "value": "{\"source\": \"s1\"}", "timestamp": 0}
+      ],
+      "outputs": [
+        {"topic": "Fred", "key": 1, "value": "{\"SOURCE\":\"s1\"}", "timestamp": 0}
+      ]
+    },
+    {
+      "name": "sink-topic-naming: use prefixed default topic name when property set",
+      "properties": {
+        "ksql.output.topic.name.prefix": "some-prefix-"
+      },
+      "statements": [
+        "CREATE STREAM TEST (source VARCHAR) WITH (kafka_topic='test_topic', value_format='JSON');",
+        "CREATE STREAM OUTPUT AS SELECT * FROM TEST;"
+      ],
+      "inputs": [
+        {"topic": "test_topic", "key": 1, "value": "{\"source\": \"s1\"}", "timestamp": 0}
+      ],
+      "outputs": [
+        {"topic": "some-prefix-OUTPUT", "key": 1, "value": "{\"SOURCE\":\"s1\"}", "timestamp": 0}
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
### Description 
Added a new KsqlConig.KSQL_OUTPUT_TOPIC_NAME_PREFIX_CONFIG = "ksql.output.topic.name.prefix";

This allows users to specify a prefix to be applied to the names of any output topics that are created from statements without an explicit topic name supplied.

e.g.

Given `ksql.output.topic.name.prefix=my-first-prefix`

```
CREATE STREAM S AS ...  -- will use Kafka topic with name 'my-first-prefix-S'
CREATE STREAM S WITH(KAFKA_TOPIC='foo') AS ... -- will use Kafka topic with name 'foo'
```

This is useful for users of interactive KSQL clusters wanting to set up Kafka ACLs on a prefixed resource pattern in the Kafka cluster to allow users to create and use output topics. e.g. in the above example, an ACL could be set up to allow KSQL to create/write to any topic prefixed with 'my-first-prefix-'.  This allows cluster admins to bucket all the output topics of KSQL together under a common prefix

*NOTE* - there is one commit that is nothing but fixing up warnings in the code. So you may find it easier to review commit by commit.

### Testing done 
QueryTranslationTests and unit tests

### Reviewer checklist
- [ ] Ensure docs are updated if necessary. (eg. if a user visible feature is being added or changed).
- [ ] Ensure relevant issues are linked (description should include text like "Fixes #<issue number>")

