### PR TITLE
Add config for ext dir

### DIFF
--- a/ext/resource-blacklist.txt
+++ b/ext/resource-blacklist.txt
@@ -1,12 +1,14 @@
 # Classes/Packages that aren't allowed to be loaded by UDFs.
-java.lang.Compiler
+# if a class name ends with $ it will only match that class
+# otherwise it will match anything beginning with the string
+java.lang.Compiler$
 java.lang.instrument
 java.lang.invoke
 java.lang.management
 java.lang.Process
 java.lang.ref
-java.lang.Runtime
-java.lang.Shutdown
+java.lang.Runtime$
+java.lang.Shutdown$
 java.lang.Thread
 java.util.concurrent
 java.util.jar

--- a/ksql-common/src/main/java/io/confluent/ksql/util/KsqlConfig.java
+++ b/ksql-common/src/main/java/io/confluent/ksql/util/KsqlConfig.java
@@ -46,6 +46,8 @@ public class KsqlConfig extends AbstractConfig implements Cloneable {
 
   public static final String KSQL_ENABLE_UDFS = "ksql.udfs.enabled";
 
+  public static final String KSQL_EXT_DIR = "ksql.extension.dir";
+
   public static final String SINK_WINDOW_CHANGE_LOG_ADDITIONAL_RETENTION_MS_PROPERTY =
       "ksql.sink.window.change.log.additional.retention";
 
@@ -92,6 +94,8 @@ public class KsqlConfig extends AbstractConfig implements Cloneable {
   private final Map<String, Object> ksqlStreamConfigProps;
 
   private static final ConfigDef CONFIG_DEF;
+
+  public static final String DEFAULT_EXT_DIR = "ext";
 
   static {
     CONFIG_DEF = new ConfigDef()
@@ -180,6 +184,13 @@ public class KsqlConfig extends AbstractConfig implements Cloneable {
             "Whether or not metrics should be collected for custom udfs. Default is false. Note: "
                 + "this will add some overhead to udf invocation. It is recommended that this "
                 + " be set to false in production."
+        )
+        .define(
+            KSQL_EXT_DIR,
+            ConfigDef.Type.STRING,
+            DEFAULT_EXT_DIR,
+            ConfigDef.Importance.LOW,
+            "The path to look for and load extensions such as UDFs from."
         )
 
         .withClientSslSupport();

--- a/ksql-engine/src/main/java/io/confluent/ksql/function/UdfLoader.java
+++ b/ksql-engine/src/main/java/io/confluent/ksql/function/UdfLoader.java
@@ -189,7 +189,10 @@ public class UdfLoader {
   ) {
     final Boolean loadCustomerUdfs = config.getBoolean(KsqlConfig.KSQL_ENABLE_UDFS);
     final Boolean collectMetrics = config.getBoolean(KsqlConfig.KSQL_COLLECT_UDF_METRICS);
-    final File pluginDir = new File(ksqlInstallDir, "ext");
+    final String extDirName = config.getString(KsqlConfig.KSQL_EXT_DIR);
+    final File pluginDir = KsqlConfig.DEFAULT_EXT_DIR.equals(extDirName)
+        ? new File(ksqlInstallDir, extDirName)
+        : new File(extDirName);
     return new UdfLoader(metaStore,
         pluginDir,
         Thread.currentThread().getContextClassLoader(),

--- a/ksql-engine/src/test/java/io/confluent/ksql/function/BlacklistTest.java
+++ b/ksql-engine/src/test/java/io/confluent/ksql/function/BlacklistTest.java
@@ -95,6 +95,14 @@ public class BlacklistTest {
     assertTrue(blacklist.test("java.util.Map"));
   }
 
+  @Test
+  public void shouldNotBlackListAllClassesIfItemEndsWith$() throws IOException {
+    writeBlacklist(ImmutableList.<String>builder().add("java.lang.Runtime$").build());
+    final Blacklist blacklist = new Blacklist(this.blacklistFile);
+    assertTrue(blacklist.test("java.lang.Runtime"));
+    assertFalse(blacklist.test("java.lang.RuntimeException"));
+  }
+
   private void writeBlacklist(final List<String> blacklisted) throws IOException {
     Files.write(blacklistFile.toPath(), blacklisted, StandardCharsets.UTF_8);
   }

--- a/ksql-engine/src/test/java/io/confluent/ksql/function/UdfLoaderTest.java
+++ b/ksql-engine/src/test/java/io/confluent/ksql/function/UdfLoaderTest.java
@@ -171,6 +171,7 @@ public class UdfLoaderTest {
   @Test
   public void shouldUseConfigForExtDir() {
     final MetaStore metaStore = new MetaStoreImpl(new InternalFunctionRegistry());
+    // The tostring function is in the udf-example.jar that is found in src/test/resources
     final KsqlConfig config
         = new KsqlConfig(Collections.singletonMap(KsqlConfig.KSQL_EXT_DIR, "src/test/resources"));
     UdfLoader.newInstance(config, metaStore, "").load();

--- a/ksql-engine/src/test/java/io/confluent/ksql/function/UdfLoaderTest.java
+++ b/ksql-engine/src/test/java/io/confluent/ksql/function/UdfLoaderTest.java
@@ -31,6 +31,7 @@ import io.confluent.ksql.function.udf.Kudf;
 import io.confluent.ksql.function.udf.PluggableUdf;
 import io.confluent.ksql.metastore.MetaStore;
 import io.confluent.ksql.metastore.MetaStoreImpl;
+import io.confluent.ksql.util.KsqlConfig;
 import io.confluent.ksql.util.KsqlException;
 
 import static org.hamcrest.CoreMatchers.equalTo;
@@ -165,6 +166,16 @@ public class UdfLoaderTest {
         not(nullValue()));
     assertThat(metrics.metric(metrics.metricName("ksql-udf-substring-rate", "ksql-udf-substring")),
         not(nullValue()));
+  }
+
+  @Test
+  public void shouldUseConfigForExtDir() {
+    final MetaStore metaStore = new MetaStoreImpl(new InternalFunctionRegistry());
+    final KsqlConfig config
+        = new KsqlConfig(Collections.singletonMap(KsqlConfig.KSQL_EXT_DIR, "src/test/resources"));
+    UdfLoader.newInstance(config, metaStore, "").load();
+    // will throw if it doesn't exist
+    metaStore.getUdfFactory("tostring");
   }
 
   private UdfLoader createUdfLoader(final MetaStore metaStore,

--- a/ksql-engine/src/test/resources/resource-blacklist.txt
+++ b/ksql-engine/src/test/resources/resource-blacklist.txt
@@ -1,0 +1,1 @@
+java.lang.Runtime$


### PR DESCRIPTION
### Description 
Add a new config option `ksql.extension.dir` to configure the directory where UDFs and any future extensions should be loaded from.

### Testing done 
Added new test to make sure it works

### Reviewer checklist
- [ ] Ensure docs are updated if necessary. (eg. if a user visible feature is being added or changed).
- [ ] Ensure relevant issues are linked (description should include text like "Fixes #<issue number>")

