### PR TITLE
Rename SPAN to WITHIN everywhere

### DIFF
--- a/ksql-engine/src/main/java/io/confluent/ksql/analyzer/Analyzer.java
+++ b/ksql-engine/src/main/java/io/confluent/ksql/analyzer/Analyzer.java
@@ -294,7 +294,7 @@ public class Analyzer extends DefaultTraversalVisitor<Node, AnalysisContext> {
             rightKeyFieldName,
             leftAlias,
             rightAlias,
-            node.getSpanExpression().orElse(null),
+            node.getWithinExpression().orElse(null),
             leftDataSource.getDataSourceType(),
             rightDataSource.getDataSourceType()
         );

--- a/ksql-engine/src/main/java/io/confluent/ksql/planner/plan/JoinNode.java
+++ b/ksql-engine/src/main/java/io/confluent/ksql/planner/plan/JoinNode.java
@@ -463,7 +463,7 @@ public class JoinNode extends PlanNode {
       if (joinNode.withinExpression != null) {
         throw new KsqlException("A window definition was provided for a Table-Table join. These "
                                 + "joins are not windowed. Please drop the window definition "
-                                + "(ie. the WITHIN clause) and try to execute your Table-Table "
+                                + "(i.e. the WITHIN clause) and try to execute your Table-Table "
                                 + "join again.");
       }
 

--- a/ksql-engine/src/test/java/io/confluent/ksql/planner/plan/JoinNodeTest.java
+++ b/ksql-engine/src/test/java/io/confluent/ksql/planner/plan/JoinNodeTest.java
@@ -51,7 +51,7 @@ import io.confluent.ksql.function.InternalFunctionRegistry;
 import io.confluent.ksql.metastore.KsqlTopic;
 import io.confluent.ksql.metastore.MetaStore;
 import io.confluent.ksql.metastore.StructuredDataSource;
-import io.confluent.ksql.parser.tree.SpanExpression;
+import io.confluent.ksql.parser.tree.WithinExpression;
 import io.confluent.ksql.serde.DataSource;
 import io.confluent.ksql.serde.KsqlTopicSerDe;
 import io.confluent.ksql.structured.LogicalPlanBuilder;
@@ -253,12 +253,12 @@ public class JoinNodeTest {
 
     setupStream(right, rightSchemaKStream, rightSchema, 2);
 
-    final SpanExpression spanExpression = new SpanExpression(10, TimeUnit.SECONDS);
+    final WithinExpression withinExpression = new WithinExpression(10, TimeUnit.SECONDS);
 
     expect(leftSchemaKStream.leftJoin(eq(rightSchemaKStream),
                                       eq(joinSchema),
                                       eq(joinKey),
-                                      eq(spanExpression.joinWindow()),
+                                      eq(withinExpression.joinWindow()),
                                       anyObject(Serde.class),
                                       anyObject(Serde.class)))
         .andReturn(niceMock(SchemaKStream.class));
@@ -273,7 +273,7 @@ public class JoinNodeTest {
                                            rightKeyFieldName,
                                            leftAlias,
                                            rightAlias,
-                                           spanExpression,
+                                           withinExpression,
                                            DataSource.DataSourceType.KSTREAM,
                                            DataSource.DataSourceType.KSTREAM);
 
@@ -301,12 +301,12 @@ public class JoinNodeTest {
 
     setupStream(right, rightSchemaKStream, rightSchema, 2);
 
-    final SpanExpression spanExpression = new SpanExpression(10, TimeUnit.SECONDS);
+    final WithinExpression withinExpression = new WithinExpression(10, TimeUnit.SECONDS);
 
     expect(leftSchemaKStream.join(eq(rightSchemaKStream),
                                   eq(joinSchema),
                                   eq(joinKey),
-                                  eq(spanExpression.joinWindow()),
+                                  eq(withinExpression.joinWindow()),
                                   anyObject(Serde.class),
                                   anyObject(Serde.class)))
         .andReturn(niceMock(SchemaKStream.class));
@@ -321,7 +321,7 @@ public class JoinNodeTest {
                                            rightKeyFieldName,
                                            leftAlias,
                                            rightAlias,
-                                           spanExpression,
+                                           withinExpression,
                                            DataSource.DataSourceType.KSTREAM,
                                            DataSource.DataSourceType.KSTREAM);
 
@@ -349,12 +349,12 @@ public class JoinNodeTest {
 
     setupStream(right, rightSchemaKStream, rightSchema, 2);
 
-    final SpanExpression spanExpression = new SpanExpression(10, TimeUnit.SECONDS);
+    final WithinExpression withinExpression = new WithinExpression(10, TimeUnit.SECONDS);
 
     expect(leftSchemaKStream.outerJoin(eq(rightSchemaKStream),
                                        eq(joinSchema),
                                        eq(joinKey),
-                                       eq(spanExpression.joinWindow()),
+                                       eq(withinExpression.joinWindow()),
                                        anyObject(Serde.class),
                                        anyObject(Serde.class)))
         .andReturn(niceMock(SchemaKStream.class));
@@ -369,7 +369,7 @@ public class JoinNodeTest {
                                            rightKeyFieldName,
                                            leftAlias,
                                            rightAlias,
-                                           spanExpression,
+                                           withinExpression,
                                            DataSource.DataSourceType.KSTREAM,
                                            DataSource.DataSourceType.KSTREAM);
 
@@ -421,7 +421,7 @@ public class JoinNodeTest {
                            mockSchemaRegistryClient);
       fail("Should have raised an exception since no join window was specified");
     } catch (KsqlException e) {
-      assertTrue(e.getMessage().startsWith("Stream-Stream joins must have a SPAN clause specified"
+      assertTrue(e.getMessage().startsWith("Stream-Stream joins must have a WITHIN clause specified"
                                            + ". None was provided."));
     }
 
@@ -446,7 +446,7 @@ public class JoinNodeTest {
 
     expectSourceName(left);
     expectSourceName(right);
-    final SpanExpression spanExpression = new SpanExpression(10, TimeUnit.SECONDS);
+    final WithinExpression withinExpression = new WithinExpression(10, TimeUnit.SECONDS);
 
     replay(left, right, leftSchemaKStream, rightSchemaKStream);
 
@@ -458,7 +458,7 @@ public class JoinNodeTest {
                                            rightKeyFieldName,
                                            leftAlias,
                                            rightAlias,
-                                           spanExpression,
+                                           withinExpression,
                                            DataSource.DataSourceType.KSTREAM,
                                            DataSource.DataSourceType.KSTREAM);
 
@@ -604,8 +604,8 @@ public class JoinNodeTest {
       fail("Should have failed to build the stream since stream-table outer joins are not "
            + "supported");
     } catch (KsqlException e) {
-      assertEquals("Outer joins between streams and tables (stream: left, table: right) are not "
-                   + "supported.", e.getMessage());
+      assertEquals("Full outer joins between streams and tables (stream: left, table: right) are "
+                   + "not supported.", e.getMessage());
     }
 
     verify(left, right, leftSchemaKStream, rightSchemaKTable);
@@ -626,7 +626,7 @@ public class JoinNodeTest {
     expect(right.getSchema()).andReturn(rightSchema);
     expect(right.getPartitions(mockKafkaTopicClient)).andReturn(3);
 
-    final SpanExpression spanExpression = new SpanExpression(10, TimeUnit.SECONDS);
+    final WithinExpression withinExpression = new WithinExpression(10, TimeUnit.SECONDS);
 
     replay(left, right, leftSchemaKStream, rightSchemaKTable);
 
@@ -638,7 +638,7 @@ public class JoinNodeTest {
                                            rightKeyFieldName,
                                            leftAlias,
                                            rightAlias,
-                                           spanExpression,
+                                           withinExpression,
                                            DataSource.DataSourceType.KSTREAM,
                                            DataSource.DataSourceType.KTABLE);
 
@@ -804,7 +804,7 @@ public class JoinNodeTest {
     expect(right.getSchema()).andReturn(rightSchema);
     expect(right.getPartitions(mockKafkaTopicClient)).andReturn(3);
 
-    final SpanExpression spanExpression = new SpanExpression(10, TimeUnit.SECONDS);
+    final WithinExpression withinExpression = new WithinExpression(10, TimeUnit.SECONDS);
 
     replay(left, right, leftSchemaKTable, rightSchemaKTable);
 
@@ -816,7 +816,7 @@ public class JoinNodeTest {
                                            rightKeyFieldName,
                                            leftAlias,
                                            rightAlias,
-                                           spanExpression,
+                                           withinExpression,
                                            DataSource.DataSourceType.KTABLE,
                                            DataSource.DataSourceType.KTABLE);
 

--- a/ksql-engine/src/test/resources/query-validation-tests/joins.json
+++ b/ksql-engine/src/test/resources/query-validation-tests/joins.json
@@ -13,7 +13,7 @@
       "statements": [
         "CREATE STREAM TEST (ID bigint, NAME varchar, VALUE bigint) WITH (kafka_topic='left_topic', value_format='DELIMITED', key='ID');",
         "CREATE STREAM TEST_STREAM (ID bigint, F1 varchar, F2 bigint) WITH (kafka_topic='right_topic', value_format='DELIMITED', key='ID');",
-        "CREATE STREAM LEFT_OUTER_JOIN as SELECT t.id, name, value, f1, f2 FROM test t left join TEST_STREAM tt on t.id = tt.id SPAN 11 seconds;"
+        "CREATE STREAM LEFT_OUTER_JOIN as SELECT t.id, name, value, f1, f2 FROM test t left join TEST_STREAM tt WITHIN 11 seconds ON t.id = tt.id;"
       ],
       "inputs": [
         {"topic": "left_topic", "key": 0, "value": "0,zero,0", "timestamp": 0},
@@ -41,7 +41,7 @@
       "statements": [
         "CREATE STREAM TEST (ID bigint, NAME varchar, VALUE bigint) WITH (kafka_topic='left_topic', value_format='DELIMITED', key='ID');",
         "CREATE STREAM TEST_STREAM (ID bigint, F1 varchar, F2 bigint) WITH (kafka_topic='right_topic', value_format='DELIMITED', key='ID');",
-        "CREATE STREAM INNER_JOIN as SELECT t.id, name, value, f1, f2 FROM test t join TEST_STREAM tt on t.id = tt.id SPAN 11 seconds;"
+        "CREATE STREAM INNER_JOIN as SELECT t.id, name, value, f1, f2 FROM test t join TEST_STREAM tt WITHIN 11 SECONDS ON t.id = tt.id;"
       ],
       "inputs": [
         {"topic": "left_topic", "key": 0, "value": "0,zero,0", "timestamp": 0},
@@ -65,7 +65,7 @@
       "statements": [
         "CREATE STREAM TEST (ID bigint, NAME varchar, VALUE bigint) WITH (kafka_topic='left_topic', value_format='DELIMITED', key='ID');",
         "CREATE STREAM TEST_STREAM (ID bigint, F1 varchar, F2 bigint) WITH (kafka_topic='right_topic', value_format='DELIMITED', key='ID');",
-        "CREATE STREAM INNER_JOIN as SELECT t.id, name, value, f1, f2 FROM test t join TEST_STREAM tt on t.id = tt.id SPAN (11 seconds, 10 seconds);"
+        "CREATE STREAM INNER_JOIN as SELECT t.id, name, value, f1, f2 FROM test t join TEST_STREAM tt WITHIN (11 seconds, 10 seconds) on t.id = tt.id;"
       ],
       "inputs": [
         {"topic": "left_topic", "key": 0, "value": "0,zero,0", "timestamp": 0},
@@ -88,7 +88,7 @@
       "statements": [
         "CREATE STREAM TEST (ID bigint, NAME varchar, VALUE bigint) WITH (kafka_topic='left_topic', value_format='DELIMITED', key='ID');",
         "CREATE STREAM TEST_STREAM (ID bigint, F1 varchar, F2 bigint) WITH (kafka_topic='right_topic', value_format='DELIMITED', key='ID');",
-        "CREATE STREAM INNER_JOIN as SELECT t.id, name, value, f1, f2 FROM test t join TEST_STREAM tt on t.id = tt.id SPAN 10 seconds;"
+        "CREATE STREAM INNER_JOIN as SELECT t.id, name, value, f1, f2 FROM test t join TEST_STREAM tt WITHIN 10 seconds on t.id = tt.id;"
       ],
       "inputs": [
         {"topic": "left_topic", "key": 0, "value": "0,zero,0", "timestamp": 0},
@@ -115,7 +115,7 @@
       "statements": [
         "CREATE STREAM TEST (ID bigint, NAME varchar, VALUE bigint) WITH (kafka_topic='left_topic', value_format='DELIMITED', key='ID');",
         "CREATE STREAM TEST_STREAM (ID bigint, F1 varchar, F2 bigint) WITH (kafka_topic='right_topic', value_format='DELIMITED', key='ID');",
-        "CREATE STREAM LEFT_OUTER_JOIN as SELECT t.id, name, value, f1, f2 FROM test t FULL OUTER join TEST_STREAM tt on t.id = tt.id SPAN 11 seconds;"
+        "CREATE STREAM LEFT_OUTER_JOIN as SELECT t.id, name, value, f1, f2 FROM test t FULL OUTER join TEST_STREAM tt WITHIN 11 seconds on t.id = tt.id;"
       ],
       "inputs": [
         {"topic": "left_topic", "key": 0, "value": "0,zero,0", "timestamp": 0},

--- a/ksql-parser/src/main/antlr4/io/confluent/ksql/parser/SqlBase.g4
+++ b/ksql-parser/src/main/antlr4/io/confluent/ksql/parser/SqlBase.g4
@@ -173,7 +173,8 @@ selectItem
 
 
 relation
-    : left=aliasedRelation joinType JOIN right=aliasedRelation joinCriteria joinWindow? #joinRelation
+    : left=aliasedRelation joinType JOIN right=aliasedRelation joinWindow? joinCriteria
+    #joinRelation
     | aliasedRelation #relationDefault
     ;
 
@@ -184,12 +185,12 @@ joinType
     ;
 
 joinWindow
-    : (SPAN spanExpression)?
+    : (WITHIN withinExpression)?
     ;
 
-spanExpression
-    : '(' joinWindowSize ',' joinWindowSize ')' # spanWithBeforeAndAfter
-    | joinWindowSize # singleSpan
+withinExpression
+    : '(' joinWindowSize ',' joinWindowSize ')' # joinWindowWithBeforeAndAfter
+    | joinWindowSize # singleJoinWindow
     ;
 
 joinWindowSize
@@ -424,7 +425,7 @@ SOME: 'SOME';
 ANY: 'ANY';
 DISTINCT: 'DISTINCT';
 WHERE: 'WHERE';
-SPAN: 'SPAN';
+WITHIN: 'WITHIN';
 WINDOW: 'WINDOW';
 GROUP: 'GROUP';
 BY: 'BY';

--- a/ksql-parser/src/main/java/io/confluent/ksql/parser/SqlFormatter.java
+++ b/ksql-parser/src/main/java/io/confluent/ksql/parser/SqlFormatter.java
@@ -253,12 +253,11 @@ public final class SqlFormatter {
           new KsqlException("Join criteria is missing")
       );
 
+      node.getWithinExpression().map((e) -> builder.append(e.toString()));
       JoinOn on = (JoinOn) criteria;
       builder.append(" ON (")
           .append(ExpressionFormatter.formatExpression(on.getExpression()))
           .append(")");
-
-      node.getSpanExpression().map((e) -> builder.append(e.toString()));
 
       return null;
     }

--- a/ksql-parser/src/main/java/io/confluent/ksql/parser/rewrite/StatementRewriter.java
+++ b/ksql-parser/src/main/java/io/confluent/ksql/parser/rewrite/StatementRewriter.java
@@ -841,7 +841,7 @@ public class StatementRewriter extends DefaultAstVisitor<Node, Object> {
                 node.getType(),
                 (Relation) process(node.getLeft(), context),
                 (Relation) process(node.getRight(), context),
-                node.getCriteria(), node.getSpanExpression()
+                node.getCriteria(), node.getWithinExpression()
             )
         )
         .orElse(

--- a/ksql-parser/src/main/java/io/confluent/ksql/parser/tree/Join.java
+++ b/ksql-parser/src/main/java/io/confluent/ksql/parser/tree/Join.java
@@ -26,20 +26,20 @@ import static java.util.Objects.requireNonNull;
 public class Join
     extends Relation {
 
-  private final Optional<SpanExpression> spanExpression;
+  private final Optional<WithinExpression> withinExpression;
 
   public Join(Type type, Relation left, Relation right, Optional<JoinCriteria> criteria) {
     this(Optional.empty(), type, left, right, criteria, null);
   }
 
   public Join(NodeLocation location, Type type, Relation left, Relation right,
-              Optional<JoinCriteria> criteria, Optional<SpanExpression> spanExpression) {
-    this(Optional.of(location), type, left, right, criteria, spanExpression);
+              Optional<JoinCriteria> criteria, Optional<WithinExpression> withinExpression) {
+    this(Optional.of(location), type, left, right, criteria, withinExpression);
   }
 
   private Join(Optional<NodeLocation> location, Type type, Relation left, Relation right,
                Optional<JoinCriteria> criteria,
-               Optional<SpanExpression> spanExpression) {
+               Optional<WithinExpression> withinExpression) {
     super(location);
     requireNonNull(left, "left is null");
     requireNonNull(right, "right is null");
@@ -49,7 +49,7 @@ public class Join
     this.left = left;
     this.right = right;
     this.criteria = criteria;
-    this.spanExpression = spanExpression;
+    this.withinExpression = withinExpression;
   }
 
   public enum Type {
@@ -90,8 +90,8 @@ public class Join
     return criteria;
   }
 
-  public Optional<SpanExpression> getSpanExpression() {
-    return spanExpression;
+  public Optional<WithinExpression> getWithinExpression() {
+    return withinExpression;
   }
 
   @Override
@@ -123,11 +123,11 @@ public class Join
            && Objects.equals(left, join.left)
            && Objects.equals(right, join.right)
            && Objects.equals(criteria, join.criteria)
-           && Objects.equals(spanExpression, join.spanExpression);
+           && Objects.equals(withinExpression, join.withinExpression);
   }
 
   @Override
   public int hashCode() {
-    return Objects.hash(type, left, right, criteria, spanExpression);
+    return Objects.hash(type, left, right, criteria, withinExpression);
   }
 }

--- a/ksql-parser/src/main/java/io/confluent/ksql/parser/tree/WithinExpression.java
+++ b/ksql-parser/src/main/java/io/confluent/ksql/parser/tree/WithinExpression.java
@@ -22,7 +22,7 @@ import java.util.Objects;
 import java.util.Optional;
 import java.util.concurrent.TimeUnit;
 
-public class SpanExpression extends Node {
+public class WithinExpression extends Node {
 
   private final long before;
   private final long after;
@@ -30,18 +30,19 @@ public class SpanExpression extends Node {
   private final TimeUnit afterTimeUnit;
   private final JoinWindows joinWindows;
 
-  public SpanExpression(final long size, final TimeUnit timeUnit) {
+  public WithinExpression(final long size, final TimeUnit timeUnit) {
     this(size, size, timeUnit, timeUnit);
   }
 
-  public SpanExpression(final long before, final long after, final TimeUnit beforeTimeUnit,
-                        final TimeUnit afterTimeUnit) {
+  public WithinExpression(final long before, final long after, final TimeUnit beforeTimeUnit,
+                          final TimeUnit afterTimeUnit) {
     this(Optional.empty(), before, after, beforeTimeUnit, afterTimeUnit);
   }
 
 
-  private SpanExpression(final Optional<NodeLocation> location, final long before, final long after,
-                         final TimeUnit beforeTimeUnit, final TimeUnit afterTimeUnit) {
+  private WithinExpression(final Optional<NodeLocation> location, final long before,
+                           final long after, final TimeUnit beforeTimeUnit,
+                           final TimeUnit afterTimeUnit) {
     super(location);
     this.before = before;
     this.after = after;
@@ -57,7 +58,7 @@ public class SpanExpression extends Node {
   @Override
   public String toString() {
     final StringBuilder builder = new StringBuilder();
-    builder.append(" SPAN ");
+    builder.append(" WITHIN ");
     if (before == after) {
       builder.append(before).append(' ').append(beforeTimeUnit);
     } else {
@@ -87,10 +88,10 @@ public class SpanExpression extends Node {
     if (o == null || getClass() != o.getClass()) {
       return false;
     }
-    SpanExpression spanExpression = (SpanExpression) o;
-    return before == spanExpression.before  && after == spanExpression.after
-           && Objects.equals(beforeTimeUnit, spanExpression.beforeTimeUnit)
-           && Objects.equals(afterTimeUnit, spanExpression.afterTimeUnit);
+    WithinExpression withinExpression = (WithinExpression) o;
+    return before == withinExpression.before && after == withinExpression.after
+           && Objects.equals(beforeTimeUnit, withinExpression.beforeTimeUnit)
+           && Objects.equals(afterTimeUnit, withinExpression.afterTimeUnit);
   }
 
   private JoinWindows createJoinWindows() {

--- a/ksql-parser/src/test/java/io/confluent/ksql/parser/KsqlParserTest.java
+++ b/ksql-parser/src/test/java/io/confluent/ksql/parser/KsqlParserTest.java
@@ -43,7 +43,7 @@ import io.confluent.ksql.parser.tree.Query;
 import io.confluent.ksql.parser.tree.QuerySpecification;
 import io.confluent.ksql.parser.tree.SetProperty;
 import io.confluent.ksql.parser.tree.SingleColumn;
-import io.confluent.ksql.parser.tree.SpanExpression;
+import io.confluent.ksql.parser.tree.WithinExpression;
 import io.confluent.ksql.parser.tree.Statement;
 import io.confluent.ksql.parser.tree.Struct;
 import io.confluent.ksql.parser.tree.Type;
@@ -60,7 +60,6 @@ import org.junit.Test;
 
 import java.util.List;
 import java.util.concurrent.TimeUnit;
-import org.junit.rules.ExpectedException;
 
 import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.CoreMatchers.is;
@@ -818,9 +817,10 @@ public class KsqlParserTest {
   }
 
   @Test
-  public void shouldSetSpanExpressionWithSingleSpan() {
-    final String statementString = "CREATE STREAM foobar as SELECT * from TEST1 JOIN ORDERS ON "
-                                   + "TEST1.col1 = ORDERS.ORDERID SPAN 10 SECONDS;";
+  public void shouldSetWithinExpressionWithSingleWithin() {
+    final String statementString = "CREATE STREAM foobar as SELECT * from TEST1 JOIN ORDERS WITHIN"
+                                   + " 10 SECONDS ON "
+                                   + "TEST1.col1 = ORDERS.ORDERID ;";
 
     final Statement statement = KSQL_PARSER.buildAst(statementString, metaStore).get(0);
 
@@ -837,21 +837,22 @@ public class KsqlParserTest {
 
     final Join join = (Join) specification.getFrom();
 
-    assertTrue(join.getSpanExpression().isPresent());
+    assertTrue(join.getWithinExpression().isPresent());
 
-    final SpanExpression spanExpression = join.getSpanExpression().get();
+    final WithinExpression withinExpression = join.getWithinExpression().get();
 
-    assertEquals(10L, spanExpression.getBefore());
-    assertEquals(10L, spanExpression.getAfter());
-    assertEquals(TimeUnit.SECONDS, spanExpression.getBeforeTimeUnit());
+    assertEquals(10L, withinExpression.getBefore());
+    assertEquals(10L, withinExpression.getAfter());
+    assertEquals(TimeUnit.SECONDS, withinExpression.getBeforeTimeUnit());
     assertEquals(Join.Type.INNER, join.getType());
   }
 
 
   @Test
-  public void shouldSetSpanExpressionWithBeforeAndAfter() {
-    final String statementString = "CREATE STREAM foobar as SELECT * from TEST1 JOIN ORDERS ON "
-                                   + "TEST1.col1 = ORDERS.ORDERID SPAN (10 seconds, 20 minutes);";
+  public void shouldSetWithinExpressionWithBeforeAndAfter() {
+    final String statementString = "CREATE STREAM foobar as SELECT * from TEST1 JOIN ORDERS "
+                                   + "WITHIN (10 seconds, 20 minutes) ON "
+                                   + "TEST1.col1 = ORDERS.ORDERID ;";
 
     final Statement statement = KSQL_PARSER.buildAst(statementString, metaStore).get(0);
 
@@ -868,14 +869,14 @@ public class KsqlParserTest {
 
     final Join join = (Join) specification.getFrom();
 
-    assertTrue(join.getSpanExpression().isPresent());
+    assertTrue(join.getWithinExpression().isPresent());
 
-    final SpanExpression spanExpression = join.getSpanExpression().get();
+    final WithinExpression withinExpression = join.getWithinExpression().get();
 
-    assertEquals(10L, spanExpression.getBefore());
-    assertEquals(20L, spanExpression.getAfter());
-    assertEquals(TimeUnit.SECONDS, spanExpression.getBeforeTimeUnit());
-    assertEquals(TimeUnit.MINUTES, spanExpression.getAfterTimeUnit());
+    assertEquals(10L, withinExpression.getBefore());
+    assertEquals(20L, withinExpression.getAfter());
+    assertEquals(TimeUnit.SECONDS, withinExpression.getBeforeTimeUnit());
+    assertEquals(TimeUnit.MINUTES, withinExpression.getAfterTimeUnit());
     assertEquals(Join.Type.INNER, join.getType());
   }
 

--- a/ksql-parser/src/test/java/io/confluent/ksql/parser/KsqlParserTest.java
+++ b/ksql-parser/src/test/java/io/confluent/ksql/parser/KsqlParserTest.java
@@ -818,9 +818,8 @@ public class KsqlParserTest {
 
   @Test
   public void shouldSetWithinExpressionWithSingleWithin() {
-    final String statementString = "CREATE STREAM foobar as SELECT * from TEST1 JOIN ORDERS WITHIN"
-                                   + " 10 SECONDS ON "
-                                   + "TEST1.col1 = ORDERS.ORDERID ;";
+    final String statementString = "CREATE STREAM foobar as SELECT * from TEST1 JOIN ORDERS WITHIN "
+                                   + "10 SECONDS ON TEST1.col1 = ORDERS.ORDERID ;";
 
     final Statement statement = KSQL_PARSER.buildAst(statementString, metaStore).get(0);
 
@@ -851,8 +850,8 @@ public class KsqlParserTest {
   @Test
   public void shouldSetWithinExpressionWithBeforeAndAfter() {
     final String statementString = "CREATE STREAM foobar as SELECT * from TEST1 JOIN ORDERS "
-                                   + "WITHIN (10 seconds, 20 minutes) ON "
-                                   + "TEST1.col1 = ORDERS.ORDERID ;";
+                                   + "WITHIN (10 seconds, 20 minutes) "
+                                   + "ON TEST1.col1 = ORDERS.ORDERID ;";
 
     final Statement statement = KSQL_PARSER.buildAst(statementString, metaStore).get(0);
 

--- a/ksql-parser/src/test/java/io/confluent/ksql/parser/SqlFormatterTest.java
+++ b/ksql-parser/src/test/java/io/confluent/ksql/parser/SqlFormatterTest.java
@@ -26,7 +26,6 @@ import io.confluent.ksql.ddl.DdlConfig;
 import io.confluent.ksql.parser.tree.*;
 
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
@@ -86,13 +85,13 @@ public class SqlFormatterTest {
 
 
   @Test
-  public void shouldFormatLeftJoinWithSpan() {
+  public void shouldFormatLeftJoinWithWithin() {
     final Join join = new Join(location, Join.Type.LEFT, leftAlias, rightAlias,
                          Optional.of(criteria),
-                         Optional.of(new SpanExpression(10, TimeUnit.SECONDS)));
+                         Optional.of(new WithinExpression(10, TimeUnit.SECONDS)));
 
-    final String expected = "left L\nLEFT OUTER JOIN right R ON (('left.col0' = 'right.col0')) "
-                           + "SPAN 10 SECONDS";
+    final String expected = "left L\nLEFT OUTER JOIN right R WITHIN 10 SECONDS ON "
+                            + "(('left.col0' = 'right.col0'))";
     assertEquals(expected, SqlFormatter.formatSql(join));
   }
 
@@ -110,10 +109,10 @@ public class SqlFormatterTest {
   public void shouldFormatInnerJoin() {
     final Join join = new Join(location, Join.Type.INNER, leftAlias, rightAlias,
                                Optional.of(criteria),
-                               Optional.of(new SpanExpression(10, TimeUnit.SECONDS)));
+                               Optional.of(new WithinExpression(10, TimeUnit.SECONDS)));
 
-    final String expected = "left L\nINNER JOIN right R ON (('left.col0' = 'right.col0')) "
-                            + "SPAN 10 SECONDS";
+    final String expected = "left L\nINNER JOIN right R WITHIN 10 SECONDS ON "
+                            + "(('left.col0' = 'right.col0'))";
     assertEquals(expected, SqlFormatter.formatSql(join));
   }
 
@@ -132,10 +131,10 @@ public class SqlFormatterTest {
   public void shouldFormatOuterJoin() {
     final Join join = new Join(location, Join.Type.OUTER, leftAlias, rightAlias,
                                Optional.of(criteria),
-                               Optional.of(new SpanExpression(10, TimeUnit.SECONDS)));
+                               Optional.of(new WithinExpression(10, TimeUnit.SECONDS)));
 
-    final String expected = "left L\nFULL OUTER JOIN right R ON (('left.col0' = 'right.col0')) "
-                            + "SPAN 10 SECONDS";
+    final String expected = "left L\nFULL OUTER JOIN right R WITHIN 10 SECONDS ON"
+                            + " (('left.col0' = 'right.col0'))";
     assertEquals(expected, SqlFormatter.formatSql(join));
   }
 

--- a/ksql-parser/src/test/java/io/confluent/ksql/parser/tree/WithinExpressionTest.java
+++ b/ksql-parser/src/test/java/io/confluent/ksql/parser/tree/WithinExpressionTest.java
@@ -22,18 +22,18 @@ import java.util.concurrent.TimeUnit;
 
 import static org.testng.AssertJUnit.assertEquals;
 
-public class SpanExpressionTest {
+public class WithinExpressionTest {
 
   @Test
-  public void shouldDisplayCorrectStringWithSingleSpan() {
-    SpanExpression expression = new SpanExpression(20, TimeUnit.SECONDS);
-    assertEquals(" SPAN 20 SECONDS", expression.toString());
+  public void shouldDisplayCorrectStringWithSingleWithin() {
+    WithinExpression expression = new WithinExpression(20, TimeUnit.SECONDS);
+    assertEquals(" WITHIN 20 SECONDS", expression.toString());
   }
 
   @Test
-  public void shouldDisplayCorrectSTringWithBeforeAndAfter() {
-    SpanExpression expression = new SpanExpression(30, 40, TimeUnit.MINUTES, TimeUnit.HOURS);
-    assertEquals(" SPAN (30 MINUTES, 40 HOURS)", expression.toString());
+  public void shouldDisplayCorrectStringWithBeforeAndAfter() {
+    WithinExpression expression = new WithinExpression(30, 40, TimeUnit.MINUTES, TimeUnit.HOURS);
+    assertEquals(" WITHIN (30 MINUTES, 40 HOURS)", expression.toString());
   }
 
 }


### PR DESCRIPTION
### Description 
Based on discussions, we decided to use the `WITHIN` keyword to define the join window in stream stream joins rather than `SPAN` which is what #1417 implemented.

This patch changes `SPAN` to `WITHIN` everywhere, and also moves the `WITHIN` clause to before the join criteria. 

The mechanism was simple:
1. Update the grammar. Fix all the resulting compile failures.
2. Run tests, fix failures.
3. Grep the code base for `SPAN`, `Span`, and `span` and rename appropriate usages to `WITHIN`, `Within`, and `within` respectively. This takes care of error messages, log lines, variable names, etc.

### Testing done 
Updated tests to check for `WITHIN` instead of `SPAN`.

### Reviewer checklist
- [ ] Ensure docs are updated if necessary. (eg. if a user visible feature is being added or changed).
- [ ] Ensure relevant issues are linked (description should include text like "Fixes #<issue number>")

