### PR TITLE
Handle rename of KafkaConsumerService to ConsumerService

### DIFF
--- a/ksql-engine/src/main/java/io/confluent/ksql/util/KafkaConsumerGroupClientImpl.java
+++ b/ksql-engine/src/main/java/io/confluent/ksql/util/KafkaConsumerGroupClientImpl.java
@@ -66,8 +66,8 @@ public class KafkaConsumerGroupClientImpl implements KafkaConsumerGroupClient {
 
     ConsumerGroupCommand.ConsumerGroupCommandOptions opts =
         new ConsumerGroupCommand.ConsumerGroupCommandOptions(args);
-    ConsumerGroupCommand.KafkaConsumerGroupService consumerGroupService =
-        new ConsumerGroupCommand.KafkaConsumerGroupService(opts);
+    ConsumerGroupCommand.ConsumerGroupService consumerGroupService =
+        new ConsumerGroupCommand.ConsumerGroupService(opts);
 
     try {
       scala.collection.immutable.List<String> consumerGroups = consumerGroupService.listGroups();


### PR DESCRIPTION
Note that this class is internal in Kafka and we should migrate to
the the AdminClient, which is a public API, as soon as possible.
