### PR TITLE
Renable the build of the cp-ksql-server docker image

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -4,7 +4,7 @@ dockerfile {
     dockerUpstreamTag = '4.1.x-latest'  // Make sure PR builder points at a valid upstream tag.
     slackChannel = '#ksql-eng'
     upstreamProjects = 'confluentinc/schema-registry'
-    dockerRepos = ['confluentinc/ksql-examples', 'confluentinc/ksql-cli', 'confluentinc/ksql-clickstream-demo', 'confluentinc/cp-ksql-cli']
+    dockerRepos = ['confluentinc/ksql-examples', 'confluentinc/ksql-cli', 'confluentinc/ksql-clickstream-demo', 'confluentinc/cp-ksql-cli', 'confluentinc/cp-ksql-server']
     extraBuildArgs = '-Ddocker.skip=false'
     extraDeployArgs = '-Ddocker.skip=true'
 }

--- a/cp-ksql-server/include/etc/confluent/docker/configure
+++ b/cp-ksql-server/include/etc/confluent/docker/configure
@@ -35,4 +35,4 @@ dub template "/etc/confluent/docker/${COMPONENT}.properties.template" "/etc/${CO
 dub template "/etc/confluent/docker/log4j.properties.template" "/etc/${COMPONENT}/log4j.properties"
 
 # Ensure that KSQL picks up the correct log4j properties file
-export KSQL_LOG4J_OPTS=/etc/${COMPONENT}/log4j.properties
+export KSQL_LOG4J_OPTS=-Dlog4j.configuration=file:/etc/${COMPONENT}/log4j.properties

--- a/ksql-clickstream-demo/Dockerfile
+++ b/ksql-clickstream-demo/Dockerfile
@@ -10,7 +10,7 @@ ARG ARTIFACT_ID
 EXPOSE 3000
 
 ENV ES_JAVA_OPTS="-Xms512M -Xmx512M"
-ENV KSQL_CLASSPATH=/usr/share/java/${ARTIFACT_ID}/${ARTIFACT_ID}-${PROJECT_VERSION}-standalone.jar
+ENV KSQL_CLASSPATH=/usr/share/java/${ARTIFACT_ID}/*
 ENV KSQL_CONFIG_DIR="/etc/ksql"
 ENV KSQL_LOG4J_OPTS="-Dlog4j.configuration=file:/etc/ksql/log4j-rolling.properties"
 
@@ -25,7 +25,7 @@ RUN wget -q https://s3-us-west-2.amazonaws.com/grafana-releases/release/grafana_
     && rm grafana_5.0.3_amd64.deb \
     && rm elasticsearch-5.6.8.deb
 
-ADD target/${ARTIFACT_ID}-${PROJECT_VERSION}-standalone.jar /usr/share/java/${ARTIFACT_ID}/${ARTIFACT_ID}-${PROJECT_VERSION}-standalone.jar
+ADD target/${ARTIFACT_ID}-${PROJECT_VERSION}-package/share/java/${ARTIFACT_ID}/* /usr/share/java/${ARTIFACT_ID}/
 ADD target/${ARTIFACT_ID}-${PROJECT_VERSION}-package/bin/* /usr/bin/
 ADD target/${ARTIFACT_ID}-${PROJECT_VERSION}-package/etc/* /etc/ksql/
 

--- a/ksql-examples/Dockerfile
+++ b/ksql-examples/Dockerfile
@@ -5,7 +5,7 @@ FROM ${DOCKER_REGISTRY}confluentinc/cp-base
 ARG PROJECT_VERSION
 ARG ARTIFACT_ID
 
-ADD target/${ARTIFACT_ID}-${PROJECT_VERSION}-standalone.jar /usr/share/java/${ARTIFACT_ID}/${ARTIFACT_ID}-${PROJECT_VERSION}-standalone.jar
+ADD target/${ARTIFACT_ID}-${PROJECT_VERSION}-package/share/java/${ARTIFACT_ID}/* /usr/share/java/${ARTIFACT_ID}/
 ADD target/${ARTIFACT_ID}-${PROJECT_VERSION}-package/bin/* /usr/bin/
 ADD target/${ARTIFACT_ID}-${PROJECT_VERSION}-package/etc/* /etc/ksql/
 ADD target/${ARTIFACT_ID}-${PROJECT_VERSION}-package/share/doc/* /usr/share/doc/${ARTIFACT_ID}/

--- a/pom.xml
+++ b/pom.xml
@@ -39,6 +39,7 @@
         <module>ksql-console-scripts</module>
         <module>ksql-package</module>
         <module>cp-ksql-cli</module>
+        <module>cp-ksql-server</module>
     </modules>
 
     <repositories>


### PR DESCRIPTION
### Description 

Now that the circular dependency packaging issue has been worked around, let's re-enable the build of the cp-ksql-server docker image.

This patch also fixes the logging for cp-ksql-server so that it is actually controlled by the log4j config.

Finally, this patch drops the use of standalone jars from the `ksql-clickstream-demo` and `ksql-examples` docker images as the use of standalone jars is discouraged.

### Testing done 
The log out put of cp-ksql-server includes timestamps, as expected:
```bash
$ docker logs -f `container-id`
[2018-06-21 00:31:16,558] INFO Server up and running (io.confluent.ksql.rest.server.KsqlServerMain:61)
[2018-06-21 00:31:16,559] INFO Waiting 10078 ms for the monitored service to finish starting up... (io.confluent.support.metrics.BaseMetricsReporter:206)
[2018-06-21 00:31:26,639] INFO Monitored service is now ready (io.confluent.support.metrics.BaseMetricsReporter:217)
```
I also verified that `ksql-datagen` works correctly in a rebuild `ksql-examples` image, and that all the ksql binaries work as expected in the `ksql-clickstream-demo` image.

### Reviewer checklist
- [ ] Ensure docs are updated if necessary. (eg. if a user visible feature is being added or changed).
- [ ] Ensure relevant issues are linked (description should include text like "Fixes #<issue number>")

