### PR TITLE
Write standalone mode configs to a kafka topic and read/merge before …

### DIFF
--- a/ksql-rest-app/src/main/java/io/confluent/ksql/rest/server/CommandTopic.java
+++ b/ksql-rest-app/src/main/java/io/confluent/ksql/rest/server/CommandTopic.java
@@ -18,7 +18,7 @@ import com.google.common.collect.Lists;
 import io.confluent.ksql.rest.server.computation.Command;
 import io.confluent.ksql.rest.server.computation.CommandId;
 import io.confluent.ksql.rest.server.computation.QueuedCommand;
-import io.confluent.ksql.rest.util.CommandTopicJsonSerdeUtil;
+import io.confluent.ksql.rest.util.InternalTopicJsonSerdeUtil;
 import java.time.Duration;
 import java.util.Collections;
 import java.util.List;
@@ -56,13 +56,13 @@ public class CommandTopic {
         commandTopicName,
         new KafkaConsumer<>(
             Objects.requireNonNull(kafkaConsumerProperties, "kafkaClientProperties"),
-            CommandTopicJsonSerdeUtil.getJsonDeserializer(CommandId.class, true),
-            CommandTopicJsonSerdeUtil.getJsonDeserializer(Command.class, false)
+            InternalTopicJsonSerdeUtil.getJsonDeserializer(CommandId.class, true),
+            InternalTopicJsonSerdeUtil.getJsonDeserializer(Command.class, false)
         ),
         new KafkaProducer<>(
             Objects.requireNonNull(kafkaProducerProperties, "kafkaClientProperties"),
-            CommandTopicJsonSerdeUtil.getJsonSerializer(true),
-            CommandTopicJsonSerdeUtil.getJsonSerializer(false)
+            InternalTopicJsonSerdeUtil.getJsonSerializer(true),
+            InternalTopicJsonSerdeUtil.getJsonSerializer(false)
         ));
   }
 

--- a/ksql-rest-app/src/main/java/io/confluent/ksql/rest/server/KsqlRestApplication.java
+++ b/ksql-rest-app/src/main/java/io/confluent/ksql/rest/server/KsqlRestApplication.java
@@ -17,7 +17,6 @@ package io.confluent.ksql.rest.server;
 import static io.confluent.ksql.rest.server.KsqlRestConfig.DISTRIBUTED_COMMAND_RESPONSE_TIMEOUT_MS_CONFIG;
 
 import com.fasterxml.jackson.jaxrs.base.JsonParseExceptionMapper;
-import com.google.common.collect.ImmutableMap;
 import com.google.common.util.concurrent.ListeningScheduledExecutorService;
 import com.google.common.util.concurrent.MoreExecutors;
 import com.google.common.util.concurrent.ThreadFactoryBuilder;
@@ -55,9 +54,10 @@ import io.confluent.ksql.rest.server.resources.StatusResource;
 import io.confluent.ksql.rest.server.resources.streaming.StreamedQueryResource;
 import io.confluent.ksql.rest.server.resources.streaming.WSQueryEndpoint;
 import io.confluent.ksql.rest.util.ClusterTerminator;
+import io.confluent.ksql.rest.util.KsqlInternalTopicUtils;
+import io.confluent.ksql.rest.util.ProcessingLogConfig;
 import io.confluent.ksql.rest.util.ProcessingLogServerUtils;
 import io.confluent.ksql.services.DefaultServiceContext;
-import io.confluent.ksql.services.KafkaTopicClient;
 import io.confluent.ksql.services.ServiceContext;
 import io.confluent.ksql.util.KsqlConfig;
 import io.confluent.ksql.util.KsqlException;
@@ -92,7 +92,6 @@ import javax.websocket.server.ServerEndpoint;
 import javax.websocket.server.ServerEndpointConfig;
 import javax.websocket.server.ServerEndpointConfig.Configurator;
 import javax.ws.rs.core.Configurable;
-import org.apache.kafka.common.config.TopicConfig;
 import org.apache.kafka.common.errors.UnsupportedVersionException;
 import org.eclipse.jetty.server.ServerConnector;
 import org.eclipse.jetty.websocket.jsr356.server.ServerContainer;
@@ -303,7 +302,6 @@ public final class KsqlRestApplication extends Application<KsqlRestConfig> imple
       final Function<Supplier<Boolean>, VersionCheckerAgent> versionCheckerFactory,
       final int maxStatementRetries
   ) {
-
     final String ksqlInstallDir = restConfig.getString(KsqlRestConfig.INSTALL_DIR_CONFIG);
 
     final KsqlConfig ksqlConfig = new KsqlConfig(restConfig.getKsqlConfigProperties());
@@ -325,9 +323,9 @@ public final class KsqlRestApplication extends Application<KsqlRestConfig> imple
 
     UdfLoader.newInstance(ksqlConfig, functionRegistry, ksqlInstallDir).load();
 
-    final String ksqlServiceId = ksqlConfig.getString(KsqlConfig.KSQL_SERVICE_ID_CONFIG);
-    final String commandTopic = KsqlRestConfig.getCommandTopic(ksqlServiceId);
-    ensureCommandTopic(restConfig, serviceContext.getTopicClient(), commandTopic);
+    final String commandTopic = KsqlInternalTopicUtils.getTopicName(
+        ksqlConfig, KsqlRestConfig.COMMAND_TOPIC_SUFFIX);
+    KsqlInternalTopicUtils.ensureTopic(commandTopic, ksqlConfig, serviceContext.getTopicClient());
 
     final Map<String, Expression> commandTopicProperties = new HashMap<>();
     commandTopicProperties.put(
@@ -454,51 +452,6 @@ public final class KsqlRestApplication extends Application<KsqlRestConfig> imple
       );
     } catch (final Exception e) {
       throw new KsqlException("Failed to get Kafka cluster information", e);
-    }
-  }
-
-  static void ensureCommandTopic(final KsqlRestConfig restConfig,
-                                 final KafkaTopicClient topicClient,
-                                 final String commandTopic) {
-    final long requiredTopicRetention = Long.MAX_VALUE;
-    if (topicClient.isTopicExists(commandTopic)) {
-      final ImmutableMap<String, Object> requiredConfig =
-          ImmutableMap.of(TopicConfig.RETENTION_MS_CONFIG, requiredTopicRetention);
-
-      if (topicClient.addTopicConfig(commandTopic, requiredConfig)) {
-        log.info("Corrected retention.ms on command topic. topic:{}, retention.ms:{}",
-                 commandTopic, requiredTopicRetention);
-      }
-
-      return;
-    }
-
-    try {
-      short replicationFactor = 1;
-      if (restConfig.getOriginals().containsKey(KsqlConfig.SINK_NUMBER_OF_REPLICAS_PROPERTY)) {
-        replicationFactor = Short.parseShort(
-            restConfig
-                .getOriginals()
-                .get(KsqlConfig.SINK_NUMBER_OF_REPLICAS_PROPERTY)
-                .toString()
-        );
-      }
-      if (replicationFactor < 2) {
-        log.warn("Creating topic {} with replication factor of {} which is less than 2. "
-                 + "This is not advisable in a production environment. ",
-                commandTopic, replicationFactor);
-      }
-
-      // for now we create the command topic with infinite retention so that we
-      // don't lose any data in case of fail over etc.
-      topicClient.createTopic(
-          commandTopic,
-          1,
-          replicationFactor,
-          Collections.singletonMap(TopicConfig.RETENTION_MS_CONFIG, requiredTopicRetention)
-      );
-    } catch (final KafkaTopicExistsException e) {
-      log.info("Command Topic Exists: {}", e.getMessage());
     }
   }
 

--- a/ksql-rest-app/src/main/java/io/confluent/ksql/rest/server/KsqlRestApplication.java
+++ b/ksql-rest-app/src/main/java/io/confluent/ksql/rest/server/KsqlRestApplication.java
@@ -24,7 +24,6 @@ import io.confluent.ksql.KsqlEngine;
 import io.confluent.ksql.ddl.DdlConfig;
 import io.confluent.ksql.ddl.commands.CreateStreamCommand;
 import io.confluent.ksql.ddl.commands.RegisterTopicCommand;
-import io.confluent.ksql.exception.KafkaTopicExistsException;
 import io.confluent.ksql.function.InternalFunctionRegistry;
 import io.confluent.ksql.function.MutableFunctionRegistry;
 import io.confluent.ksql.function.UdfLoader;

--- a/ksql-rest-app/src/main/java/io/confluent/ksql/rest/server/KsqlRestApplication.java
+++ b/ksql-rest-app/src/main/java/io/confluent/ksql/rest/server/KsqlRestApplication.java
@@ -55,7 +55,6 @@ import io.confluent.ksql.rest.server.resources.streaming.StreamedQueryResource;
 import io.confluent.ksql.rest.server.resources.streaming.WSQueryEndpoint;
 import io.confluent.ksql.rest.util.ClusterTerminator;
 import io.confluent.ksql.rest.util.KsqlInternalTopicUtils;
-import io.confluent.ksql.rest.util.ProcessingLogConfig;
 import io.confluent.ksql.rest.util.ProcessingLogServerUtils;
 import io.confluent.ksql.services.DefaultServiceContext;
 import io.confluent.ksql.services.ServiceContext;

--- a/ksql-rest-app/src/main/java/io/confluent/ksql/rest/server/StandaloneExecutorFactory.java
+++ b/ksql-rest-app/src/main/java/io/confluent/ksql/rest/server/StandaloneExecutorFactory.java
@@ -20,6 +20,9 @@ import io.confluent.ksql.function.MutableFunctionRegistry;
 import io.confluent.ksql.function.UdfLoader;
 import io.confluent.ksql.processing.log.ProcessingLogConfig;
 import io.confluent.ksql.processing.log.ProcessingLogContext;
+import io.confluent.ksql.rest.server.computation.ConfigStore;
+import io.confluent.ksql.rest.server.computation.KafkaConfigStore;
+import io.confluent.ksql.rest.util.ProcessingLogConfig;
 import io.confluent.ksql.services.DefaultServiceContext;
 import io.confluent.ksql.services.ServiceContext;
 import io.confluent.ksql.util.KsqlConfig;
@@ -35,9 +38,14 @@ public final class StandaloneExecutorFactory {
       final String queriesFile,
       final String installDir
   ) {
-    final KsqlConfig ksqlConfig = new KsqlConfig(properties);
+    final KsqlConfig baseConfig = new KsqlConfig(properties);
 
-    final ServiceContext serviceContext = DefaultServiceContext.create(ksqlConfig);
+    final ServiceContext serviceContext = DefaultServiceContext.create(baseConfig);
+
+    final ConfigStore configStore = new KafkaConfigStore(
+        baseConfig,
+        serviceContext.getTopicClient());
+    final KsqlConfig ksqlConfig = configStore.getKsqlConfig();
 
     final ProcessingLogConfig processingLogConfig
         = new ProcessingLogConfig(properties);

--- a/ksql-rest-app/src/main/java/io/confluent/ksql/rest/server/StandaloneExecutorFactory.java
+++ b/ksql-rest-app/src/main/java/io/confluent/ksql/rest/server/StandaloneExecutorFactory.java
@@ -23,7 +23,6 @@ import io.confluent.ksql.processing.log.ProcessingLogContext;
 import io.confluent.ksql.rest.server.computation.ConfigStore;
 import io.confluent.ksql.rest.server.computation.KafkaConfigStore;
 import io.confluent.ksql.rest.util.KsqlInternalTopicUtils;
-import io.confluent.ksql.rest.util.ProcessingLogConfig;
 import io.confluent.ksql.services.DefaultServiceContext;
 import io.confluent.ksql.services.ServiceContext;
 import io.confluent.ksql.util.KsqlConfig;

--- a/ksql-rest-app/src/main/java/io/confluent/ksql/rest/server/computation/ConfigStore.java
+++ b/ksql-rest-app/src/main/java/io/confluent/ksql/rest/server/computation/ConfigStore.java
@@ -1,18 +1,16 @@
 /*
- * Copyright 2018 Confluent Inc.
+ * Copyright 2019 Confluent Inc.
  *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
+ * Licensed under the Confluent Community License; you may not use this file
+ * except in compliance with the License.  You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * http://www.confluent.io/confluent-community-license
  *
  * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- **/
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
 
 package io.confluent.ksql.rest.server.computation;
 

--- a/ksql-rest-app/src/main/java/io/confluent/ksql/rest/server/computation/ConfigStore.java
+++ b/ksql-rest-app/src/main/java/io/confluent/ksql/rest/server/computation/ConfigStore.java
@@ -1,0 +1,23 @@
+/*
+ * Copyright 2018 Confluent Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ **/
+
+package io.confluent.ksql.rest.server.computation;
+
+import io.confluent.ksql.util.KsqlConfig;
+
+public interface ConfigStore {
+  KsqlConfig getKsqlConfig();
+}

--- a/ksql-rest-app/src/main/java/io/confluent/ksql/rest/server/computation/ConfigStore.java
+++ b/ksql-rest-app/src/main/java/io/confluent/ksql/rest/server/computation/ConfigStore.java
@@ -17,5 +17,10 @@ package io.confluent.ksql.rest.server.computation;
 import io.confluent.ksql.util.KsqlConfig;
 
 public interface ConfigStore {
+
+  /**
+   * Gets the KSQL config to be used by a headless mode KSQL server.
+   * @return the KSQL config.
+   */
   KsqlConfig getKsqlConfig();
 }

--- a/ksql-rest-app/src/main/java/io/confluent/ksql/rest/server/computation/ConfigTopicKey.java
+++ b/ksql-rest-app/src/main/java/io/confluent/ksql/rest/server/computation/ConfigTopicKey.java
@@ -1,3 +1,17 @@
+/*
+ * Copyright 2019 Confluent Inc.
+ *
+ * Licensed under the Confluent Community License; you may not use this file
+ * except in compliance with the License.  You may obtain a copy of the License at
+ *
+ * http://www.confluent.io/confluent-community-license
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
 package io.confluent.ksql.rest.server.computation;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
@@ -19,7 +33,7 @@ abstract class ConfigTopicKey {
   public static class StringKey extends ConfigTopicKey {
     private final String value;
 
-    public StringKey(@JsonProperty("value") final String value) {
+    StringKey(@JsonProperty("value") final String value) {
       this.value = value;
     }
 
@@ -35,7 +49,7 @@ abstract class ConfigTopicKey {
       if (o == null || getClass() != o.getClass()) {
         return false;
       }
-      StringKey stringKey = (StringKey) o;
+      final StringKey stringKey = (StringKey) o;
       return Objects.equals(value, stringKey.value);
     }
 

--- a/ksql-rest-app/src/main/java/io/confluent/ksql/rest/server/computation/ConfigTopicKey.java
+++ b/ksql-rest-app/src/main/java/io/confluent/ksql/rest/server/computation/ConfigTopicKey.java
@@ -34,7 +34,10 @@ abstract class ConfigTopicKey {
     private final String value;
 
     StringKey(@JsonProperty("value") final String value) {
-      this.value = value;
+      this.value = Objects.requireNonNull(value, "value");
+      if (this.value.isEmpty()) {
+        throw new IllegalArgumentException("StringKey value must not be empty");
+      }
     }
 
     public String getValue() {

--- a/ksql-rest-app/src/main/java/io/confluent/ksql/rest/server/computation/ConfigTopicKey.java
+++ b/ksql-rest-app/src/main/java/io/confluent/ksql/rest/server/computation/ConfigTopicKey.java
@@ -1,0 +1,47 @@
+package io.confluent.ksql.rest.server.computation;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonSubTypes;
+import com.fasterxml.jackson.annotation.JsonTypeInfo;
+import com.fasterxml.jackson.annotation.JsonTypeInfo.As;
+import io.confluent.ksql.rest.server.computation.ConfigTopicKey.StringKey;
+import java.util.Objects;
+
+@JsonTypeInfo(
+    use = JsonTypeInfo.Id.NAME,
+    include = As.WRAPPER_OBJECT
+)
+@JsonSubTypes({
+    @JsonSubTypes.Type(value = StringKey.class, name = "string")
+})
+abstract class ConfigTopicKey {
+
+  public static class StringKey extends ConfigTopicKey {
+    private final String value;
+
+    public StringKey(@JsonProperty("value") final String value) {
+      this.value = value;
+    }
+
+    public String getValue() {
+      return value;
+    }
+
+    @Override
+    public boolean equals(final Object o) {
+      if (this == o) {
+        return true;
+      }
+      if (o == null || getClass() != o.getClass()) {
+        return false;
+      }
+      StringKey stringKey = (StringKey) o;
+      return Objects.equals(value, stringKey.value);
+    }
+
+    @Override
+    public int hashCode() {
+      return Objects.hash(value);
+    }
+  }
+}

--- a/ksql-rest-app/src/main/java/io/confluent/ksql/rest/server/computation/KafkaConfigStore.java
+++ b/ksql-rest-app/src/main/java/io/confluent/ksql/rest/server/computation/KafkaConfigStore.java
@@ -1,0 +1,203 @@
+/*
+ * Copyright 2018 Confluent Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ **/
+
+package io.confluent.ksql.rest.server.computation;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.google.common.collect.ImmutableMap;
+import io.confluent.kafka.serializers.KafkaJsonDeserializer;
+import io.confluent.kafka.serializers.KafkaJsonSerializer;
+import io.confluent.ksql.rest.util.KsqlInternalTopicUtils;
+import io.confluent.ksql.services.KafkaTopicClient;
+import io.confluent.ksql.util.KsqlConfig;
+import java.time.Duration;
+import java.time.temporal.ChronoUnit;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Optional;
+import java.util.function.Supplier;
+import org.apache.kafka.clients.consumer.ConsumerRecord;
+import org.apache.kafka.clients.consumer.ConsumerRecords;
+import org.apache.kafka.clients.consumer.KafkaConsumer;
+import org.apache.kafka.clients.producer.KafkaProducer;
+import org.apache.kafka.clients.producer.ProducerRecord;
+import org.apache.kafka.common.TopicPartition;
+import org.apache.kafka.common.config.TopicConfig;
+import org.apache.kafka.common.serialization.Deserializer;
+import org.apache.kafka.common.serialization.Serdes;
+import org.apache.kafka.common.serialization.Serializer;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class KafkaConfigStore implements ConfigStore {
+  private static final Logger log = LoggerFactory.getLogger(KafkaConfigStore.class);
+
+  private static final String CONFIG_TOPIC_SUFFIX = "configs";
+  private static final String CONFIG_MSG_KEY = "ksql-standalone-configs";
+
+  private final KsqlConfig ksqlConfig;
+
+  static Deserializer<KsqlProperties> createDeserializer() {
+    final KafkaJsonDeserializer<KsqlProperties> deserializer = new KafkaJsonDeserializer<>();
+    deserializer.configure(
+        ImmutableMap.of(
+            "json.fail.unknown.properties", false,
+            "json.value.type", KsqlProperties.class
+        ),
+        false
+    );
+    return deserializer;
+  }
+
+  private static KafkaConsumer<String, KsqlProperties> createConsumer(
+      final KsqlConfig ksqlConfig) {
+    return new KafkaConsumer<>(
+        ksqlConfig.getKsqlStreamConfigProps(),
+        Serdes.String().deserializer(),
+        createDeserializer());
+  }
+
+  private static KafkaProducer<String, KsqlProperties> createProducer(
+      final KsqlConfig ksqlConfig) {
+    final Serializer<KsqlProperties> serializer = new KafkaJsonSerializer<>();
+    serializer.configure(Collections.emptyMap(), false);
+    return new KafkaProducer<>(
+        ksqlConfig.getKsqlStreamConfigProps(),
+        Serdes.String().serializer(),
+        serializer);
+  }
+
+  public KafkaConfigStore(final KsqlConfig currentConfig, final KafkaTopicClient topicClient) {
+    this.ksqlConfig = currentConfig.overrideBreakingConfigsWithOriginalValues(
+        readMaybeWriteProperties(
+            currentConfig,
+            topicClient,
+            () -> createConsumer(currentConfig),
+            () -> createProducer(currentConfig)
+        )
+    );
+  }
+
+  // for testing
+  KafkaConfigStore(final KsqlConfig currentConfig,
+                   final KafkaTopicClient topicClient,
+                   final Supplier<KafkaConsumer<String, KsqlProperties>> consumer,
+                   final Supplier<KafkaProducer<String, KsqlProperties>> producer) {
+    this.ksqlConfig = currentConfig.overrideBreakingConfigsWithOriginalValues(
+        readMaybeWriteProperties(currentConfig, topicClient, consumer, producer)
+    );
+  }
+
+  @Override
+  public KsqlConfig getKsqlConfig() {
+    return ksqlConfig;
+  }
+
+  public static class KsqlProperties {
+    private final Map<String, String> ksqlProperties;
+
+    @JsonCreator
+    KsqlProperties(
+        @JsonProperty("ksqlProperties") final Map<String, String> ksqlProperties) {
+      this.ksqlProperties = ksqlProperties == null
+          ? Collections.emptyMap() : Collections.unmodifiableMap(ksqlProperties);
+    }
+
+    public Map<String, String> getKsqlProperties() {
+      return ksqlProperties;
+    }
+
+    @Override
+    public boolean equals(final Object o) {
+      return o instanceof KsqlProperties
+          && Objects.equals(ksqlProperties, ((KsqlProperties) o).ksqlProperties);
+    }
+
+    @Override
+    public int hashCode() {
+      return Objects.hash(ksqlProperties);
+    }
+  }
+
+  private Optional<KsqlProperties> readProperties(
+      final String topicName,
+      final Supplier<KafkaConsumer<String, KsqlProperties>> consumerSupplier) {
+    final TopicPartition topicPartition = new TopicPartition(topicName, 0);
+    final List<TopicPartition> topicPartitionAsList = Collections.singletonList(topicPartition);
+
+    try (KafkaConsumer<String, KsqlProperties> consumer = consumerSupplier.get()) {
+      consumer.assign(topicPartitionAsList);
+      consumer.seekToBeginning(topicPartitionAsList);
+
+      final Map<TopicPartition, Long> offsets = consumer.endOffsets(topicPartitionAsList);
+      final long endOffset = offsets.get(topicPartition);
+      while (consumer.position(topicPartition) < endOffset) {
+        log.debug(
+            "Reading from config topic. Position(%d) End(%d)",
+            consumer.position(topicPartition),
+            endOffset);
+        final ConsumerRecords<String, KsqlProperties> records
+            = consumer.poll(Duration.of(5, ChronoUnit.SECONDS));
+        final Optional<ConsumerRecord<String, KsqlProperties>> record =
+            records.records(topicPartition)
+                .stream()
+                .filter(r -> r.key().equals(CONFIG_MSG_KEY))
+                .findFirst();
+        if (record.isPresent()) {
+          log.info("Found existing config in config topic");
+          return Optional.of(record.get().value());
+        }
+      }
+      log.info("No config found on config topic");
+      return Optional.empty();
+    }
+  }
+
+  private void writeProperties(
+      final String topicName,
+      final KsqlProperties properties,
+      final Supplier<KafkaProducer<String, KsqlProperties>> producerSupplier) {
+    try (KafkaProducer<String, KsqlProperties> producer = producerSupplier.get()) {
+      producer.send(new ProducerRecord<>(topicName, CONFIG_MSG_KEY, properties));
+      producer.flush();
+    }
+  }
+
+  private Map<String, String> readMaybeWriteProperties(
+      final KsqlConfig ksqlConfig,
+      final KafkaTopicClient topicClient,
+      final Supplier<KafkaConsumer<String, KsqlProperties>> consumerSupplier,
+      final Supplier<KafkaProducer<String, KsqlProperties>> producerSupplier) {
+    final String topicName = KsqlInternalTopicUtils.getTopicName(ksqlConfig, CONFIG_TOPIC_SUFFIX);
+    log.info("Ensure existence of topic %s", topicName);
+    KsqlInternalTopicUtils.ensureTopic(
+        topicName, ksqlConfig, topicClient, TopicConfig.CLEANUP_POLICY_COMPACT);
+
+    final Optional<KsqlProperties> properties = readProperties(topicName, consumerSupplier);
+    if (properties.isPresent()) {
+      return properties.get().getKsqlProperties();
+    }
+
+    log.info("Writing current config to config topic");
+    writeProperties(topicName, new KsqlProperties(
+        ksqlConfig.getAllConfigPropsWithSecretsObfuscated()), producerSupplier);
+
+    return readProperties(topicName, consumerSupplier).get().getKsqlProperties();
+  }
+}

--- a/ksql-rest-app/src/main/java/io/confluent/ksql/rest/server/computation/WriteOnceStore.java
+++ b/ksql-rest-app/src/main/java/io/confluent/ksql/rest/server/computation/WriteOnceStore.java
@@ -1,0 +1,5 @@
+package io.confluent.ksql.rest.server.computation;
+
+public interface WriteOnceStore<V> {
+  V readMaybeWrite(V value);
+}

--- a/ksql-rest-app/src/main/java/io/confluent/ksql/rest/server/computation/WriteOnceStore.java
+++ b/ksql-rest-app/src/main/java/io/confluent/ksql/rest/server/computation/WriteOnceStore.java
@@ -1,5 +1,0 @@
-package io.confluent.ksql.rest.server.computation;
-
-public interface WriteOnceStore<V> {
-  V readMaybeWrite(V value);
-}

--- a/ksql-rest-app/src/main/java/io/confluent/ksql/rest/util/InternalTopicJsonSerdeUtil.java
+++ b/ksql-rest-app/src/main/java/io/confluent/ksql/rest/util/InternalTopicJsonSerdeUtil.java
@@ -22,11 +22,9 @@ import java.util.Map;
 import org.apache.kafka.common.serialization.Deserializer;
 import org.apache.kafka.common.serialization.Serializer;
 
+public final class InternalTopicJsonSerdeUtil {
 
-
-public final class CommandTopicJsonSerdeUtil {
-
-  private CommandTopicJsonSerdeUtil(){}
+  private InternalTopicJsonSerdeUtil(){}
 
   public static <T> Serializer<T> getJsonSerializer(final boolean isKey) {
     final Serializer<T> result = new KafkaJsonSerializer<>();

--- a/ksql-rest-app/src/main/java/io/confluent/ksql/rest/util/KsqlInternalTopicUtils.java
+++ b/ksql-rest-app/src/main/java/io/confluent/ksql/rest/util/KsqlInternalTopicUtils.java
@@ -1,0 +1,89 @@
+/*
+ * Copyright 2018 Confluent Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ **/
+
+package io.confluent.ksql.rest.util;
+
+import com.google.common.collect.ImmutableMap;
+import io.confluent.ksql.exception.KafkaTopicExistsException;
+import io.confluent.ksql.services.KafkaTopicClient;
+import io.confluent.ksql.util.KsqlConfig;
+import io.confluent.ksql.util.KsqlConstants;
+import org.apache.kafka.common.config.TopicConfig;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class KsqlInternalTopicUtils {
+  private static final Logger log = LoggerFactory.getLogger(KsqlInternalTopicUtils.class);
+
+  private static final int NPARTITIONS = 1;
+
+  public static String getTopicName(final KsqlConfig ksqlConfig, final String topicSuffix) {
+    return String.format(
+        "%s%s_%s",
+        KsqlConstants.KSQL_INTERNAL_TOPIC_PREFIX,
+        ksqlConfig.getString(KsqlConfig.KSQL_SERVICE_ID_CONFIG),
+        topicSuffix
+    );
+  }
+
+  public static void ensureTopic(final String name,
+                                 final KsqlConfig ksqlConfig,
+                                 final KafkaTopicClient topicClient) {
+    ensureTopic(name, ksqlConfig, topicClient, TopicConfig.CLEANUP_POLICY_DELETE);
+  }
+
+  public static void ensureTopic(final String name,
+                                 final KsqlConfig ksqlConfig,
+                                 final KafkaTopicClient topicClient,
+                                 final String cleanupPolicy) {
+    final long requiredTopicRetention = Long.MAX_VALUE;
+    if (topicClient.isTopicExists(name)) {
+      final ImmutableMap<String, Object> requiredConfig =
+          ImmutableMap.of(TopicConfig.RETENTION_MS_CONFIG, requiredTopicRetention);
+
+      if (topicClient.addTopicConfig(name, requiredConfig)) {
+        log.info(
+            "Corrected retention.ms on ksql internal topic. topic:{}, retention.ms:{}",
+            name,
+            requiredTopicRetention);
+      }
+
+      return;
+    }
+
+    try {
+      final short replicationFactor =
+          ksqlConfig.originals().containsKey(KsqlConfig.SINK_NUMBER_OF_REPLICAS_PROPERTY)
+            ? ksqlConfig.getShort(KsqlConfig.SINK_NUMBER_OF_REPLICAS_PROPERTY) : 1;
+      if (replicationFactor < 2) {
+        log.warn("Creating topic {} with replication factor of {} which is less than 2. "
+                + "This is not advisable in a production environment. ",
+            name, replicationFactor);
+      }
+
+      topicClient.createTopic(
+          name,
+          NPARTITIONS,
+          replicationFactor,
+          ImmutableMap.of(
+              TopicConfig.RETENTION_MS_CONFIG, requiredTopicRetention,
+              TopicConfig.CLEANUP_POLICY_CONFIG, cleanupPolicy)
+      );
+    } catch (final KafkaTopicExistsException e) {
+      log.info("Internal Topic {} Exists: {}", name, e.getMessage());
+    }
+  }
+}

--- a/ksql-rest-app/src/main/java/io/confluent/ksql/rest/util/KsqlInternalTopicUtils.java
+++ b/ksql-rest-app/src/main/java/io/confluent/ksql/rest/util/KsqlInternalTopicUtils.java
@@ -1,18 +1,16 @@
 /*
- * Copyright 2018 Confluent Inc.
+ * Copyright 2019 Confluent Inc.
  *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
+ * Licensed under the Confluent Community License; you may not use this file
+ * except in compliance with the License.  You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * http://www.confluent.io/confluent-community-license
  *
  * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- **/
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
 
 package io.confluent.ksql.rest.util;
 

--- a/ksql-rest-app/src/test/java/io/confluent/ksql/rest/server/KsqlRestApplicationTest.java
+++ b/ksql-rest-app/src/test/java/io/confluent/ksql/rest/server/KsqlRestApplicationTest.java
@@ -14,7 +14,6 @@
 
 package io.confluent.ksql.rest.server;
 
-import static org.easymock.EasyMock.anyObject;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
@@ -24,9 +23,9 @@ import static org.mockito.Mockito.when;
 import com.google.common.collect.ImmutableMap;
 import io.confluent.ksql.KsqlEngine;
 import io.confluent.ksql.KsqlExecutionContext;
-import io.confluent.ksql.exception.KafkaTopicExistsException;
 import io.confluent.ksql.parser.KsqlParser.PreparedStatement;
 import io.confluent.ksql.parser.tree.Statement;
+import io.confluent.ksql.parser.tree.AbstractStreamCreateStatement;
 import io.confluent.ksql.processing.log.ProcessingLogConfig;
 import io.confluent.ksql.rest.server.computation.CommandQueue;
 import io.confluent.ksql.rest.server.computation.CommandRunner;
@@ -36,7 +35,6 @@ import io.confluent.ksql.rest.server.resources.RootDocument;
 import io.confluent.ksql.rest.server.resources.StatusResource;
 import io.confluent.ksql.rest.server.resources.streaming.StreamedQueryResource;
 import io.confluent.ksql.rest.util.ProcessingLogServerUtils;
-import io.confluent.ksql.services.KafkaTopicClient;
 import io.confluent.ksql.services.ServiceContext;
 import io.confluent.ksql.util.FakeKafkaClientSupplier;
 import io.confluent.ksql.util.KsqlConfig;
@@ -44,10 +42,6 @@ import io.confluent.ksql.util.KsqlException;
 import io.confluent.ksql.version.metrics.VersionCheckerAgent;
 import io.confluent.rest.RestConfig;
 import java.util.Collections;
-import java.util.HashMap;
-import java.util.Map;
-import org.apache.kafka.common.config.TopicConfig;
-import org.easymock.EasyMock;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -56,13 +50,9 @@ import org.mockito.junit.MockitoJUnitRunner;
 
 @RunWith(MockitoJUnitRunner.class)
 public class KsqlRestApplicationTest {
-  private static final String COMMAND_TOPIC = "command_topic";
   private static final String LOG_STREAM_NAME = "log_stream";
   private static final String LOG_TOPIC_NAME = "log_topic";
 
-  private final KafkaTopicClient topicClient = EasyMock.createNiceMock(KafkaTopicClient.class);
-  private final Map<String, ?> commandTopicConfig = Collections.singletonMap(
-      TopicConfig.RETENTION_MS_CONFIG, Long.MAX_VALUE);
   private final KsqlRestConfig restConfig =
       new KsqlRestConfig(
           Collections.singletonMap(RestConfig.LISTENERS_CONFIG,
@@ -74,8 +64,6 @@ public class KsqlRestApplicationTest {
   private KsqlEngine ksqlEngine;
   @Mock
   private KsqlExecutionContext sandBox;
-  @Mock
-  private Statement statement;
   @Mock
   private KsqlConfig ksqlConfig;
   @Mock
@@ -136,93 +124,6 @@ public class KsqlRestApplicationTest {
 
     // Then:
     verify(serviceContext).close();
-  }
-
-  @Test
-  public void shouldCreateCommandTopicIfItDoesNotExist() {
-    topicClient.createTopic(COMMAND_TOPIC,
-        1,
-        (short) 1,
-        commandTopicConfig);
-    EasyMock.expectLastCall();
-    EasyMock.replay(topicClient);
-
-    KsqlRestApplication.ensureCommandTopic(restConfig,
-                                           topicClient,
-                                           COMMAND_TOPIC);
-
-    EasyMock.verify(topicClient);
-  }
-
-  @Test
-  public void shouldNotAttemptToCreateCommandTopicIfItExists() {
-    EasyMock.resetToStrict(topicClient);
-    EasyMock.expect(topicClient.isTopicExists(COMMAND_TOPIC)).andReturn(true);
-    EasyMock.expect(topicClient.addTopicConfig(anyObject(), anyObject())).andReturn(false);
-
-    EasyMock.replay(topicClient);
-
-    KsqlRestApplication.ensureCommandTopic(restConfig,
-                                           topicClient,
-                                           COMMAND_TOPIC);
-
-    EasyMock.verify(topicClient);
-  }
-
-  @Test
-  public void shouldEnsureCommandTopicHasInfiniteRetention() {
-    final Map<String, Object> retentionConfig = ImmutableMap.of(
-        TopicConfig.RETENTION_MS_CONFIG, Long.MAX_VALUE
-    );
-    EasyMock.expect(topicClient.isTopicExists(COMMAND_TOPIC)).andReturn(true);
-    EasyMock.expect(topicClient.addTopicConfig(COMMAND_TOPIC, retentionConfig)).andReturn(true);
-
-    EasyMock.replay(topicClient);
-
-    KsqlRestApplication.ensureCommandTopic(restConfig,
-                                           topicClient,
-                                           COMMAND_TOPIC);
-
-    EasyMock.verify(topicClient);
-  }
-
-  @SuppressWarnings("unchecked")
-  @Test
-  public void shouldCreateCommandTopicWithNumReplicasFromConfig() {
-    topicClient.createTopic(COMMAND_TOPIC,
-        1,
-        (short) 3,
-        commandTopicConfig);
-    EasyMock.expectLastCall();
-    EasyMock.replay(topicClient);
-
-    KsqlRestApplication.ensureCommandTopic(
-        new KsqlRestConfig(
-            new HashMap(){{
-              put(RestConfig.LISTENERS_CONFIG, "http://localhost:8080");
-              put(KsqlConfig.SINK_NUMBER_OF_REPLICAS_PROPERTY, 3);
-            }}),
-        topicClient,
-        COMMAND_TOPIC);
-
-    EasyMock.verify(topicClient);
-  }
-
-  @Test
-  public void shouldNotFailIfTopicExistsOnCreation() {
-    topicClient.createTopic(COMMAND_TOPIC,
-        1,
-        (short) 1,
-        commandTopicConfig);
-
-    EasyMock.expectLastCall().andThrow(new KafkaTopicExistsException("blah"));
-    EasyMock.replay(topicClient);
-
-    KsqlRestApplication.ensureCommandTopic(restConfig,
-                                           topicClient,
-                                           COMMAND_TOPIC);
-
-    EasyMock.verify(topicClient);
   }
 
   @Test

--- a/ksql-rest-app/src/test/java/io/confluent/ksql/rest/server/StandaloneExecutorFactoryTest.java
+++ b/ksql-rest-app/src/test/java/io/confluent/ksql/rest/server/StandaloneExecutorFactoryTest.java
@@ -1,0 +1,108 @@
+package io.confluent.ksql.rest.server;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.ArgumentMatchers.anyMap;
+import static org.mockito.ArgumentMatchers.anyShort;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.hamcrest.MockitoHamcrest.argThat;
+import static org.mockito.Mockito.when;
+
+import io.confluent.ksql.rest.server.computation.ConfigStore;
+import io.confluent.ksql.rest.util.KsqlInternalTopicUtils;
+import io.confluent.ksql.services.KafkaTopicClient;
+import io.confluent.ksql.services.ServiceContext;
+import io.confluent.ksql.util.KsqlConfig;
+import java.util.Collections;
+import java.util.Properties;
+import java.util.function.BiFunction;
+import java.util.function.Function;
+import org.hamcrest.Description;
+import org.hamcrest.Matcher;
+import org.hamcrest.TypeSafeMatcher;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.InOrder;
+import org.mockito.Mock;
+import org.mockito.Mockito;
+import org.mockito.junit.MockitoJUnitRunner;
+
+@RunWith(MockitoJUnitRunner.class)
+public class StandaloneExecutorFactoryTest {
+  private static final String QUERIES_FILE = "queries";
+  private static final String INSTALL_DIR = "install";
+
+  private final Properties properties = new Properties();
+  private final KsqlConfig baseConfig = new KsqlConfig(properties);
+  private final KsqlConfig mergedConfig = new KsqlConfig(Collections.emptyMap());
+  private final String configTopicName = KsqlInternalTopicUtils.getTopicName(
+      baseConfig,
+      StandaloneExecutorFactory.CONFIG_TOPIC_SUFFIX
+  );
+
+  @Mock
+  private Function<KsqlConfig, ServiceContext> serviceContextFactory;
+  @Mock
+  private BiFunction<String, KsqlConfig, ConfigStore> configStoreFactory;
+  @Mock
+  private ServiceContext serviceContext;
+  @Mock
+  private KafkaTopicClient topicClient;
+  @Mock
+  private ConfigStore configStore;
+
+  @Before
+  public void setup() {
+    when(serviceContextFactory.apply(any())).thenReturn(serviceContext);
+    when(serviceContext.getTopicClient()).thenReturn(topicClient);
+    when(configStoreFactory.apply(any(), any())).thenReturn(configStore);
+    when(topicClient.isTopicExists(configTopicName)).thenReturn(false);
+    when(configStore.getKsqlConfig()).thenReturn(mergedConfig);
+  }
+
+  private StandaloneExecutor create() {
+    return StandaloneExecutorFactory.create(
+        properties,
+        QUERIES_FILE,
+        INSTALL_DIR,
+        serviceContextFactory,
+        configStoreFactory
+    );
+  }
+
+  private Matcher<KsqlConfig> sameConfig(final KsqlConfig expected) {
+    return new KsqlConfigMatcher(expected);
+  }
+
+  private static class KsqlConfigMatcher extends TypeSafeMatcher<KsqlConfig> {
+    private final KsqlConfig expected;
+
+    public KsqlConfigMatcher(final KsqlConfig expected) {
+      this.expected = expected;
+    }
+
+    @Override
+    public void describeTo(final Description description) {
+      description.appendValue(expected.getAllConfigPropsWithSecretsObfuscated());
+    }
+
+    @Override
+    public boolean matchesSafely(final KsqlConfig ksqlConfig) {
+      return ksqlConfig.getAllConfigPropsWithSecretsObfuscated().equals(
+          expected.getAllConfigPropsWithSecretsObfuscated());
+    }
+  }
+
+  @Test
+  public void shouldCreateConfigTopicThenGetConfig() {
+    // When:
+    create();
+
+    // Then:
+    final InOrder inOrder = Mockito.inOrder(topicClient, configStoreFactory, configStore);
+    inOrder.verify(topicClient).createTopic(eq(configTopicName), anyInt(), anyShort(), anyMap());
+    inOrder.verify(configStoreFactory).apply(eq(configTopicName), argThat(sameConfig(baseConfig)));
+    inOrder.verify(configStore).getKsqlConfig();
+  }
+}

--- a/ksql-rest-app/src/test/java/io/confluent/ksql/rest/server/computation/ConfigTopicKeyTest.java
+++ b/ksql-rest-app/src/test/java/io/confluent/ksql/rest/server/computation/ConfigTopicKeyTest.java
@@ -1,0 +1,64 @@
+package io.confluent.ksql.rest.server.computation;
+
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.instanceOf;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.nullValue;
+import static org.junit.Assert.assertThat;
+
+import com.google.common.testing.EqualsTester;
+import io.confluent.ksql.rest.server.computation.ConfigTopicKey.StringKey;
+import io.confluent.ksql.rest.util.InternalTopicJsonSerdeUtil;
+import java.nio.charset.StandardCharsets;
+import org.apache.kafka.common.serialization.Deserializer;
+import org.apache.kafka.common.serialization.Serializer;
+import org.junit.Test;
+
+public class ConfigTopicKeyTest {
+  private final StringKey stringKey = new StringKey("string-key-value");
+  private final byte[] serialized
+      = "{\"string\":{\"value\":\"string-key-value\"}}".getBytes(StandardCharsets.UTF_8);
+  private final Serializer<ConfigTopicKey> serializer
+      = InternalTopicJsonSerdeUtil.getJsonSerializer(false);
+  private final Deserializer<ConfigTopicKey> deserializer
+      = InternalTopicJsonSerdeUtil.getJsonDeserializer(ConfigTopicKey.class, false);
+
+
+  @Test
+  public void shouldImplementEqualsForStringKey() {
+    new EqualsTester()
+        .addEqualityGroup(new StringKey("foo"), new StringKey("foo"))
+        .addEqualityGroup(new StringKey("bar"))
+        .testEquals();
+  }
+
+  @Test
+  public void shouldSerializeStringKey() {
+    // When:
+    final byte[] bytes = serializer.serialize("", stringKey);
+
+    // Then:
+    assertThat(bytes, equalTo(serialized));
+  }
+
+  @Test
+  public void shouldDeserializeStringKey() {
+    // When:
+    final ConfigTopicKey key = deserializer.deserialize("", serialized);
+
+    // Then:
+    assertThat(key, equalTo(stringKey));
+  }
+
+  @Test
+  public void shouldDeserializeStringKeyWithNoValue() {
+    // When:
+    final ConfigTopicKey key = deserializer.deserialize(
+        "",
+        "{\"string\":{}}".getBytes(StandardCharsets.UTF_8));
+
+    // Then:
+    assertThat(key, instanceOf(StringKey.class));
+    assertThat(((StringKey) key).getValue(), is(nullValue()));
+  }
+}

--- a/ksql-rest-app/src/test/java/io/confluent/ksql/rest/server/computation/ConfigTopicKeyTest.java
+++ b/ksql-rest-app/src/test/java/io/confluent/ksql/rest/server/computation/ConfigTopicKeyTest.java
@@ -15,28 +15,34 @@
 package io.confluent.ksql.rest.server.computation;
 
 import static org.hamcrest.Matchers.equalTo;
-import static org.hamcrest.Matchers.instanceOf;
-import static org.hamcrest.Matchers.is;
-import static org.hamcrest.Matchers.nullValue;
 import static org.junit.Assert.assertThat;
 
+import com.fasterxml.jackson.databind.exc.InvalidDefinitionException;
 import com.google.common.testing.EqualsTester;
 import io.confluent.ksql.rest.server.computation.ConfigTopicKey.StringKey;
 import io.confluent.ksql.rest.util.InternalTopicJsonSerdeUtil;
 import java.nio.charset.StandardCharsets;
+import org.apache.kafka.common.errors.SerializationException;
 import org.apache.kafka.common.serialization.Deserializer;
 import org.apache.kafka.common.serialization.Serializer;
+import org.hamcrest.Description;
+import org.hamcrest.TypeSafeMatcher;
+import org.junit.Rule;
 import org.junit.Test;
+import org.junit.rules.ExpectedException;
 
 public class ConfigTopicKeyTest {
-  private final StringKey stringKey = new StringKey("string-key-value");
-  private final byte[] serialized
+  private static final StringKey STRING_KEY = new StringKey("string-key-value");
+  private final byte[] SERIALIZED
       = "{\"string\":{\"value\":\"string-key-value\"}}".getBytes(StandardCharsets.UTF_8);
+
   private final Serializer<ConfigTopicKey> serializer
       = InternalTopicJsonSerdeUtil.getJsonSerializer(false);
   private final Deserializer<ConfigTopicKey> deserializer
       = InternalTopicJsonSerdeUtil.getJsonDeserializer(ConfigTopicKey.class, false);
 
+  @Rule
+  public final ExpectedException expectedException = ExpectedException.none();
 
   @Test
   public void shouldImplementEqualsForStringKey() {
@@ -49,30 +55,67 @@ public class ConfigTopicKeyTest {
   @Test
   public void shouldSerializeStringKey() {
     // When:
-    final byte[] bytes = serializer.serialize("", stringKey);
+    final byte[] bytes = serializer.serialize("", STRING_KEY);
 
     // Then:
-    assertThat(bytes, equalTo(serialized));
+    assertThat(bytes, equalTo(SERIALIZED));
   }
 
   @Test
   public void shouldDeserializeStringKey() {
     // When:
-    final ConfigTopicKey key = deserializer.deserialize("", serialized);
+    final ConfigTopicKey key = deserializer.deserialize("", SERIALIZED);
 
     // Then:
-    assertThat(key, equalTo(stringKey));
+    assertThat(key, equalTo(STRING_KEY));
+  }
+
+  private class IllegalArgumentMatcher extends TypeSafeMatcher<Exception> {
+    private final String msg;
+    private final Class<? extends Exception> exceptionClass;
+
+    IllegalArgumentMatcher(final Class<? extends Exception> exceptionClass, final String msg) {
+      this.msg = msg;
+      this.exceptionClass = exceptionClass;
+    }
+
+    @Override
+    public boolean matchesSafely(final Exception e) {
+      return e instanceof SerializationException
+          && e.getCause() instanceof InvalidDefinitionException
+          && exceptionClass.isInstance(e.getCause().getCause())
+          && e.getCause().getCause().getMessage().contains(msg);
+    }
+
+    @Override
+    public void describeTo(final Description description) {
+      description.appendValue(
+          "SerializationException w/ cause IllegalArgumentException(" + msg + ")");
+    }
+  }
+
+  private IllegalArgumentMatcher illegalString(
+      final Class<? extends Exception> exceptionClass,
+      final String msg) {
+    return new IllegalArgumentMatcher(exceptionClass, msg);
   }
 
   @Test
-  public void shouldDeserializeStringKeyWithNoValue() {
-    // When:
-    final ConfigTopicKey key = deserializer.deserialize(
-        "",
-        "{\"string\":{}}".getBytes(StandardCharsets.UTF_8));
-
+  public void shouldThrowOnStringKeyWithNoValue() {
     // Then:
-    assertThat(key, instanceOf(StringKey.class));
-    assertThat(((StringKey) key).getValue(), is(nullValue()));
+    expectedException.expect(illegalString(NullPointerException.class, ""));
+
+    // When:
+    deserializer.deserialize("", "{\"string\":{}}".getBytes(StandardCharsets.UTF_8));
+  }
+
+  @Test
+  public void shouldThrowOnStringKeyWithEmptyValue() {
+    // Then:
+    expectedException.expect(
+        illegalString(IllegalArgumentException.class, "StringKey value must not be empty"));
+
+    // When:
+    deserializer.deserialize("", "{\"string\":{\"value\": \"\"}}".getBytes(StandardCharsets.UTF_8));
   }
 }

--- a/ksql-rest-app/src/test/java/io/confluent/ksql/rest/server/computation/ConfigTopicKeyTest.java
+++ b/ksql-rest-app/src/test/java/io/confluent/ksql/rest/server/computation/ConfigTopicKeyTest.java
@@ -1,3 +1,17 @@
+/*
+ * Copyright 2019 Confluent Inc.
+ *
+ * Licensed under the Confluent Community License; you may not use this file
+ * except in compliance with the License.  You may obtain a copy of the License at
+ *
+ * http://www.confluent.io/confluent-community-license
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
 package io.confluent.ksql.rest.server.computation;
 
 import static org.hamcrest.Matchers.equalTo;

--- a/ksql-rest-app/src/test/java/io/confluent/ksql/rest/server/computation/ConfigTopicKeyTest.java
+++ b/ksql-rest-app/src/test/java/io/confluent/ksql/rest/server/computation/ConfigTopicKeyTest.java
@@ -70,7 +70,7 @@ public class ConfigTopicKeyTest {
     assertThat(key, equalTo(STRING_KEY));
   }
 
-  private class IllegalArgumentMatcher extends TypeSafeMatcher<Exception> {
+  private static class IllegalArgumentMatcher extends TypeSafeMatcher<Exception> {
     private final String msg;
     private final Class<? extends Exception> exceptionClass;
 

--- a/ksql-rest-app/src/test/java/io/confluent/ksql/rest/server/computation/KafkaConfigStoreTest.java
+++ b/ksql-rest-app/src/test/java/io/confluent/ksql/rest/server/computation/KafkaConfigStoreTest.java
@@ -24,6 +24,7 @@ import static org.mockito.Mockito.verifyZeroInteractions;
 import static org.mockito.Mockito.when;
 
 import com.google.common.collect.ImmutableMap;
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import io.confluent.ksql.rest.server.computation.KafkaConfigStore.KsqlProperties;
 import io.confluent.ksql.rest.util.KsqlInternalTopicUtils;
 import io.confluent.ksql.services.KafkaTopicClient;
@@ -189,6 +190,7 @@ public class KafkaConfigStoreTest {
   }
 
   @Test
+  @SuppressFBWarnings("DM_DEFAULT_ENCODING")
   public void shouldDeserializeMissingContentsToNull() {
     // When:
     final Deserializer<KafkaConfigStore.KsqlProperties> deserializer

--- a/ksql-rest-app/src/test/java/io/confluent/ksql/rest/server/computation/KafkaConfigStoreTest.java
+++ b/ksql-rest-app/src/test/java/io/confluent/ksql/rest/server/computation/KafkaConfigStoreTest.java
@@ -23,6 +23,7 @@ import static org.mockito.Mockito.when;
 
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import io.confluent.ksql.rest.server.computation.ConfigTopicKey.StringKey;
 import io.confluent.ksql.rest.server.computation.KafkaConfigStore.KsqlProperties;
 import io.confluent.ksql.rest.util.InternalTopicJsonSerdeUtil;
@@ -219,6 +220,7 @@ public class KafkaConfigStoreTest {
     inOrder.verify(producer).flush();
   }
 
+  @SuppressFBWarnings("RV_RETURN_VALUE_IGNORED_INFERRED")
   private void verifyMergedConfig(final KsqlConfig mergedConfig) {
     assertThat(mergedConfig, is(this.mergedConfig));
     verify(currentConfigProxy).overrideBreakingConfigsWithOriginalValues(

--- a/ksql-rest-app/src/test/java/io/confluent/ksql/rest/server/computation/KafkaConfigStoreTest.java
+++ b/ksql-rest-app/src/test/java/io/confluent/ksql/rest/server/computation/KafkaConfigStoreTest.java
@@ -14,22 +14,23 @@
 
 package io.confluent.ksql.rest.server.computation;
 
+import static org.hamcrest.CoreMatchers.is;
 import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.anyMap;
-import static org.mockito.ArgumentMatchers.anyString;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.verifyZeroInteractions;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoMoreInteractions;
 import static org.mockito.Mockito.when;
 
+import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
-import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import io.confluent.ksql.rest.server.computation.KafkaConfigStore.KsqlProperties;
-import io.confluent.ksql.rest.util.KsqlInternalTopicUtils;
-import io.confluent.ksql.services.KafkaTopicClient;
 import io.confluent.ksql.util.KsqlConfig;
 import java.nio.charset.StandardCharsets;
+import java.util.Arrays;
 import java.util.LinkedList;
+import java.util.ListIterator;
 import java.util.function.Supplier;
+import java.util.stream.Collectors;
 import org.apache.kafka.clients.consumer.ConsumerRecord;
 import org.apache.kafka.clients.consumer.ConsumerRecords;
 import org.apache.kafka.clients.consumer.KafkaConsumer;
@@ -37,6 +38,7 @@ import org.apache.kafka.clients.producer.KafkaProducer;
 import org.apache.kafka.clients.producer.ProducerRecord;
 import org.apache.kafka.common.TopicPartition;
 import org.apache.kafka.common.serialization.Deserializer;
+import org.apache.kafka.common.serialization.Serializer;
 import org.junit.Before;
 import org.junit.Test;
 
@@ -54,132 +56,268 @@ import static org.junit.Assert.assertThat;
 
 @RunWith(MockitoJUnitRunner.class)
 public class KafkaConfigStoreTest {
-  private final KsqlConfig ksqlConfig = new KsqlConfig(
-      ImmutableMap.of(
-        KsqlConfig.KSQL_SERVICE_ID_CONFIG, "test-service-id"
-      )
+  private final static String TOPIC_NAME = "topic";
+
+  private final KsqlConfig currentConfig = new KsqlConfig(
+      ImmutableMap.of(KsqlConfig.KSQL_PERSISTENT_QUERY_NAME_PREFIX_CONFIG, "current"));
+  private final KsqlConfig savedConfig = new KsqlConfig(
+      ImmutableMap.of(KsqlConfig.KSQL_PERSISTENT_QUERY_NAME_PREFIX_CONFIG, "saved"));
+  private final KsqlConfig badConfig = new KsqlConfig(
+      ImmutableMap.of(KsqlConfig.KSQL_PERSISTENT_QUERY_NAME_PREFIX_CONFIG, "bad"));
+
+  private final KsqlProperties properties = new KsqlProperties(
+      currentConfig.getAllConfigPropsWithSecretsObfuscated()
   );
-  private final String topicName = KsqlInternalTopicUtils.getTopicName(ksqlConfig, "configs");
-  private final TopicPartition topicPartition = new TopicPartition(topicName, 0);
+  private final KsqlProperties savedProperties = new KsqlProperties(
+      savedConfig.getAllConfigPropsWithSecretsObfuscated()
+  );
+  private final KsqlProperties badProperties = new KsqlProperties(
+      badConfig.getAllConfigPropsWithSecretsObfuscated()
+  );
+
+  private final TopicPartition topicPartition = new TopicPartition(TOPIC_NAME, 0);
   private final List<TopicPartition> topicPartitionAsList
       = Collections.singletonList(topicPartition);
+  private final List<ConsumerRecords<String, byte[]>> log = new LinkedList<>();
+  private final Serializer<KsqlProperties> serializer = KafkaConfigStore.createSerializer();
 
   @Mock
-  private Supplier<KafkaConsumer<String, KsqlProperties>> consumerSupplier;
+  private KafkaConsumer<String, byte[]> consumerBefore;
+  @Mock
+  private KafkaConsumer<String, byte[]> consumerAfter;
+  @Mock
+  private Supplier<KafkaConsumer<String, byte[]>> consumerSupplier;
   @Mock
   private Supplier<KafkaProducer<String, KsqlProperties>> producerSupplier;
   @Mock
   private KafkaProducer<String, KsqlProperties> producer;
   @Mock
-  private KafkaTopicClient topicClient;
+  private KsqlConfig currentConfigProxy;
+  @Mock
+  private KsqlConfig mergedConfig;
+  private InOrder inOrder;
 
   @Before
   @SuppressWarnings("unchecked")
   public void setUp() {
-    when(topicClient.isTopicExists(anyString())).thenReturn(true);
-    when(topicClient.addTopicConfig(anyString(), anyMap()))
-        .thenReturn(false);
     when(producerSupplier.get()).thenReturn(producer);
+    when(consumerSupplier.get()).thenReturn(consumerBefore).thenReturn(consumerAfter);
+    when(currentConfigProxy.getAllConfigPropsWithSecretsObfuscated()).thenReturn(
+        currentConfig.getAllConfigPropsWithSecretsObfuscated());
+    when(currentConfigProxy.overrideBreakingConfigsWithOriginalValues(any()))
+        .thenReturn(mergedConfig);
+    inOrder = Mockito.inOrder(consumerBefore, consumerAfter, producer);
   }
 
   private KsqlConfig getKsqlConfig() {
-    return new KafkaConfigStore(ksqlConfig, topicClient, consumerSupplier, producerSupplier)
-        .getKsqlConfig();
+    return new KafkaConfigStore(
+        TOPIC_NAME,
+        currentConfigProxy,
+        consumerSupplier,
+        producerSupplier
+    ).getKsqlConfig();
   }
 
-  @SuppressWarnings("unchecked")
-  private KafkaConsumer<String, KsqlProperties> expectRead(
-      final KafkaConfigStore.KsqlProperties... properties) {
-    final KafkaConsumer<String, KsqlProperties> consumer = mock(KafkaConsumer.class);
-    when(consumer.endOffsets(any()))
-        .thenReturn(ImmutableMap.of(topicPartition, (long)properties.length));
-    when(consumer.position(any())).thenReturn(0L).thenReturn((long) properties.length);
-    final List<ConsumerRecord<String, KafkaConfigStore.KsqlProperties>> records
+  private long endOffset(final List<ConsumerRecords<String, byte[]>> log) {
+    return log.stream().mapToLong(ConsumerRecords::count).sum();
+  }
+
+  private long endOffset() {
+    return endOffset(this.log);
+  }
+
+  private void addPollResult(
+      final String key,
+      final byte[]... properties) {
+    final List<ConsumerRecord<String, byte[]>> records
         = new LinkedList<>();
+    final long start = endOffset();
     for (int i = 0; i < properties.length; i++) {
       records.add(
-          new ConsumerRecord<>(
-              topicName,
-              0,
-              (long) i,
-              "ksql-standalone-configs",
-              properties[i]
-          )
+          new ConsumerRecord<>(TOPIC_NAME, 0, start + i, key, properties[i])
       );
     }
-    when(consumer.poll(any())).thenReturn(
-        new ConsumerRecords<>(
-            Collections.singletonMap(
-                topicPartition,
-                records
-            )
-        )
-    );
-    return consumer;
+    log.add(new ConsumerRecords<>(Collections.singletonMap(topicPartition, records)));
   }
 
-  private void verifyDrainLog(
-      final KafkaConsumer<String, KsqlProperties> consumer,
-      final InOrder inOrder,
-      final int nmsgs) {
+  private void addPollResult(
+      final String key,
+      final KsqlProperties... properties) {
+    addPollResult(
+        key,
+        Arrays.stream(properties)
+            .map(p -> serializer.serialize("", p))
+            .collect(Collectors.toList())
+            .toArray(new byte[properties.length][]));
+  }
+
+  private void addPollResult(final String key1, byte[] value1, final String key2, byte[] value2) {
+    final long start = endOffset();
+    log.add(new ConsumerRecords<>(Collections.singletonMap(
+        topicPartition,
+        Collections.singletonList(new ConsumerRecord<>(TOPIC_NAME, 0, start, key1, value1)
+    ))));
+    log.add(new ConsumerRecords<>(Collections.singletonMap(
+        topicPartition,
+        Collections.singletonList(new ConsumerRecord<>(TOPIC_NAME, 0, start + 1, key2, value2)
+    ))));
+  }
+
+  private void expectRead(final KafkaConsumer<String, byte[]> consumer) {
+    final long endOff = endOffset();
+    when(consumer.endOffsets(any())).thenReturn(ImmutableMap.of(topicPartition, endOff));
+    final ListIterator<ConsumerRecords<String, byte[]>> iterator
+        = ImmutableList.copyOf(log).listIterator();
+    when(consumer.position(topicPartition)).thenAnswer(
+        invocation -> endOffset(log.subList(0, iterator.nextIndex()))
+    );
+    when(consumer.poll(any())).thenAnswer(
+        invocation -> iterator.hasNext() ? iterator.next() : ConsumerRecords.empty());
+  }
+
+  private void verifyDrainLog(final KafkaConsumer<String, byte[]> consumer, final int nPolls) {
     inOrder.verify(consumer).assign(topicPartitionAsList);
     inOrder.verify(consumer).seekToBeginning(topicPartitionAsList);
-    for (int i = 0; i < nmsgs; i++) {
-      inOrder.verify(consumer).poll(any());
-    }
+    inOrder.verify(consumer, times(nPolls)).poll(any());
+    inOrder.verify(consumer).close();
   }
 
-  @Test
-  public void shouldWriteConfigIfNoConfigWritten() {
-    // Given:
-    final KafkaConsumer<String, KsqlProperties> consumerBefore = expectRead();
-    final KafkaConsumer<String, KsqlProperties> consumerAfter = expectRead(
-        new KafkaConfigStore.KsqlProperties(
-            ksqlConfig.getAllConfigPropsWithSecretsObfuscated()));
-    when(consumerSupplier.get()).thenReturn(consumerBefore).thenReturn(consumerAfter);
-
-    // When:
-    final KsqlConfig resolvedConfig = getKsqlConfig();
-
-    // Then:
-    assertThat(resolvedConfig.values(), equalTo(ksqlConfig.values()));
-    assertThat(
-        resolvedConfig.getKsqlStreamConfigProps(),
-        equalTo(ksqlConfig.getKsqlStreamConfigProps()));
-    final InOrder inOrder = Mockito.inOrder(consumerBefore, consumerAfter, producer);
-    verifyDrainLog(consumerBefore, inOrder, 0);
+  private void verifyProduce() {
     @SuppressWarnings("unchecked")
     final ArgumentCaptor<ProducerRecord<String, KafkaConfigStore.KsqlProperties>> msgCaptor
         = ArgumentCaptor.forClass(ProducerRecord.class);
     inOrder.verify(producer).send(msgCaptor.capture());
     assertThat(
         msgCaptor.getValue().value().getKsqlProperties(),
-        equalTo(ksqlConfig.getAllConfigPropsWithSecretsObfuscated()));
+        equalTo(currentConfig.getAllConfigPropsWithSecretsObfuscated()));
     inOrder.verify(producer).flush();
-    verifyDrainLog(consumerAfter, inOrder, 1);
+  }
+
+  private void verifyMergedConfig(final KsqlConfig mergedConfig) {
+    assertThat(mergedConfig, is(this.mergedConfig));
+    verify(currentConfigProxy).overrideBreakingConfigsWithOriginalValues(
+        savedConfig.getAllConfigPropsWithSecretsObfuscated());
   }
 
   @Test
-  public void shouldReadAndMergeExistingConfigIfExists() {
+  public void shouldIgnoreRecordsWithDifferentKey() {
     // Given:
-    final KsqlConfig persistedConfig = new KsqlConfig(
-        Collections.singletonMap(
-            KsqlConfig.KSQL_PERSISTENT_QUERY_NAME_PREFIX_CONFIG, "not-the-default"
-        )
-    );
-    final KafkaConsumer<String, KsqlProperties> consumer = expectRead(
-        new KafkaConfigStore.KsqlProperties(
-            persistedConfig.getAllConfigPropsWithSecretsObfuscated()));
-    when(consumerSupplier.get()).thenReturn(consumer);
+    addPollResult("foo", "val".getBytes());
+    addPollResult(KafkaConfigStore.CONFIG_MSG_KEY, serializer.serialize("", savedProperties));
+    expectRead(consumerBefore);
 
     // When:
-    final KsqlConfig resolvedConfig = getKsqlConfig();
+    getKsqlConfig();
 
     // Then:
-    assertThat(
-        resolvedConfig.getString(KsqlConfig.KSQL_PERSISTENT_QUERY_NAME_PREFIX_CONFIG),
-        equalTo("not-the-default"));
-    verifyZeroInteractions(producer);
+    verifyDrainLog(consumerBefore, 2);
+    inOrder.verifyNoMoreInteractions();
+  }
+
+  @Test
+  public void shouldIgnoreRecordsWithDifferentKeyWithinPoll() {
+    // Given:
+    addPollResult(
+        "foo", "val".getBytes(),
+        KafkaConfigStore.CONFIG_MSG_KEY, serializer.serialize("", savedProperties)
+    );
+    expectRead(consumerBefore);
+
+    // When:
+    getKsqlConfig();
+
+    // Then:
+    verifyDrainLog(consumerBefore, 1);
+    inOrder.verifyNoMoreInteractions();
+  }
+
+  @Test
+  public void shouldPollToEndOfTopic() {
+    // Given:
+    addPollResult("foo", "val".getBytes());
+    addPollResult("bar", "baz".getBytes());
+    expectRead(consumerBefore);
+    addPollResult(KafkaConfigStore.CONFIG_MSG_KEY, savedProperties);
+    expectRead(consumerAfter);
+
+    // When:
+    getKsqlConfig();
+
+    // Then:
+    verifyDrainLog(consumerBefore, 2);
+    verifyProduce();
+  }
+
+  @Test
+  public void shouldWriteConfigIfNoConfigWritten() {
+    // Given:
+    expectRead(consumerBefore);
+    addPollResult(KafkaConfigStore.CONFIG_MSG_KEY, properties);
+    expectRead(consumerAfter);
+
+    // When:
+    getKsqlConfig();
+
+    // Then:
+    verifyDrainLog(consumerBefore, 0);
+    verifyProduce();
+  }
+
+
+  @Test
+  public void shouldUseFirstPolledConfig() {
+    // Given:
+    addPollResult(KafkaConfigStore.CONFIG_MSG_KEY, savedProperties, badProperties);
+    expectRead(consumerBefore);
+
+    // When:
+    final KsqlConfig mergedConfig = getKsqlConfig();
+
+    // Then:
+    verifyMergedConfig(mergedConfig);
+  }
+
+  @Test
+  public void shouldNotWriteConfigIfExists() {
+    // Given:
+    addPollResult(KafkaConfigStore.CONFIG_MSG_KEY, savedProperties);
+    expectRead(consumerBefore);
+
+    // When:
+    getKsqlConfig();
+
+    // Then:
+    verifyNoMoreInteractions(producer);
+  }
+
+  @Test
+  public void shouldReadConfigAfterWrite() {
+    // Given:
+    expectRead(consumerBefore);
+    addPollResult(KafkaConfigStore.CONFIG_MSG_KEY, savedProperties, properties);
+    expectRead(consumerAfter);
+
+    // When:
+    final KsqlConfig mergedConfig = getKsqlConfig();
+
+    // Then:
+    verifyDrainLog(consumerBefore, 0);
+    verifyProduce();
+    verifyDrainLog(consumerAfter, 1);
+    verifyMergedConfig(mergedConfig);
+  }
+
+  @Test
+  public void shouldMergeExistingConfigIfExists() {
+    // Given:
+    addPollResult(KafkaConfigStore.CONFIG_MSG_KEY, savedProperties);
+    expectRead(consumerBefore);
+
+    // When:
+    final KsqlConfig mergedConfig = getKsqlConfig();
+
+    // Then:
+    verifyMergedConfig(mergedConfig);
   }
 
   @Test
@@ -188,7 +326,7 @@ public class KafkaConfigStoreTest {
     final Deserializer<KafkaConfigStore.KsqlProperties> deserializer
         = KafkaConfigStore.createDeserializer();
     final KafkaConfigStore.KsqlProperties ksqlProperties
-        = deserializer.deserialize(topicName, "{}".getBytes(StandardCharsets.UTF_8));
+        = deserializer.deserialize(TOPIC_NAME, "{}".getBytes(StandardCharsets.UTF_8));
 
     // Then:
     assertThat(ksqlProperties.getKsqlProperties(), equalTo(Collections.emptyMap()));

--- a/ksql-rest-app/src/test/java/io/confluent/ksql/rest/server/computation/KafkaConfigStoreTest.java
+++ b/ksql-rest-app/src/test/java/io/confluent/ksql/rest/server/computation/KafkaConfigStoreTest.java
@@ -1,0 +1,202 @@
+/*
+ * Copyright 2018 Confluent Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ **/
+
+package io.confluent.ksql.rest.server.computation;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyMap;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verifyZeroInteractions;
+import static org.mockito.Mockito.when;
+
+import com.google.common.collect.ImmutableMap;
+import io.confluent.ksql.rest.server.computation.KafkaConfigStore.KsqlProperties;
+import io.confluent.ksql.rest.util.KsqlInternalTopicUtils;
+import io.confluent.ksql.services.KafkaTopicClient;
+import io.confluent.ksql.util.KsqlConfig;
+import java.util.LinkedList;
+import java.util.function.Supplier;
+import org.apache.kafka.clients.consumer.ConsumerRecord;
+import org.apache.kafka.clients.consumer.ConsumerRecords;
+import org.apache.kafka.clients.consumer.KafkaConsumer;
+import org.apache.kafka.clients.producer.KafkaProducer;
+import org.apache.kafka.clients.producer.ProducerRecord;
+import org.apache.kafka.common.TopicPartition;
+import org.apache.kafka.common.serialization.Deserializer;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+
+import java.util.Collections;
+import java.util.List;
+import org.mockito.ArgumentCaptor;
+import org.mockito.InOrder;
+import org.mockito.Mock;
+import org.mockito.Mockito;
+import org.mockito.junit.MockitoJUnit;
+import org.mockito.junit.MockitoRule;
+
+import static org.hamcrest.CoreMatchers.equalTo;
+import static org.junit.Assert.assertThat;
+
+public class KafkaConfigStoreTest {
+  private final KsqlConfig ksqlConfig = new KsqlConfig(
+      ImmutableMap.of(
+        KsqlConfig.KSQL_SERVICE_ID_CONFIG, "test-service-id"
+      )
+  );
+  private final String topicName = KsqlInternalTopicUtils.getTopicName(ksqlConfig, "configs");
+  private final TopicPartition topicPartition = new TopicPartition(topicName, 0);
+  private final List<TopicPartition> topicPartitionAsList
+      = Collections.singletonList(topicPartition);
+
+  @Mock
+  private Supplier<KafkaConsumer<String, KsqlProperties>> consumerSupplier;
+  @Mock
+  private Supplier<KafkaProducer<String, KsqlProperties>> producerSupplier;
+  @Mock
+  private KafkaProducer<String, KsqlProperties> producer;
+  @Mock
+  private KafkaTopicClient topicClient;
+
+  private KafkaConfigStore configStore;
+
+  @Rule
+  public final MockitoRule mockitoRule = MockitoJUnit.rule();
+
+  @Before
+  @SuppressWarnings("unchecked")
+  public void setUp() {
+    when(topicClient.isTopicExists(anyString())).thenReturn(true);
+    when(topicClient.addTopicConfig(anyString(), anyMap()))
+        .thenReturn(false);
+    when(producerSupplier.get()).thenReturn(producer);
+  }
+
+  private void initConfigStore() {
+    configStore = new KafkaConfigStore(ksqlConfig, topicClient, consumerSupplier, producerSupplier);
+  }
+
+  @SuppressWarnings("unchecked")
+  private KafkaConsumer<String, KsqlProperties> expectRead(
+      final KafkaConfigStore.KsqlProperties... properties) {
+    final KafkaConsumer<String, KsqlProperties> consumer = mock(KafkaConsumer.class);
+    when(consumer.endOffsets(any()))
+        .thenReturn(ImmutableMap.of(topicPartition, (long)properties.length));
+    when(consumer.position(any())).thenReturn(0L).thenReturn((long) properties.length);
+    final List<ConsumerRecord<String, KafkaConfigStore.KsqlProperties>> records
+        = new LinkedList<>();
+    for (int i = 0; i < properties.length; i++) {
+      records.add(
+          new ConsumerRecord<>(
+              topicName,
+              0,
+              (long) i,
+              "ksql-standalone-configs",
+              properties[i]
+          )
+      );
+    }
+    when(consumer.poll(any())).thenReturn(
+        new ConsumerRecords<>(
+            Collections.singletonMap(
+                topicPartition,
+                records
+            )
+        )
+    );
+    return consumer;
+  }
+
+  private void verifyDrainLog(
+      final KafkaConsumer<String, KsqlProperties> consumer,
+      final InOrder inOrder,
+      final int nmsgs) {
+    inOrder.verify(consumer).assign(topicPartitionAsList);
+    inOrder.verify(consumer).seekToBeginning(topicPartitionAsList);
+    for (int i = 0; i < nmsgs; i++) {
+      inOrder.verify(consumer).poll(any());
+    }
+  }
+
+  @Test
+  public void shouldWriteConfigIfNoConfigWritten() {
+    // Given:
+    final KafkaConsumer<String, KsqlProperties> consumerBefore = expectRead();
+    final KafkaConsumer<String, KsqlProperties> consumerAfter = expectRead(
+        new KafkaConfigStore.KsqlProperties(
+            ksqlConfig.getAllConfigPropsWithSecretsObfuscated()));
+    when(consumerSupplier.get()).thenReturn(consumerBefore).thenReturn(consumerAfter);
+
+    // When:
+    initConfigStore();
+    final KsqlConfig resolvedConfig = configStore.getKsqlConfig();
+
+    // Then:
+    assertThat(resolvedConfig.values(), equalTo(ksqlConfig.values()));
+    assertThat(
+        resolvedConfig.getKsqlStreamConfigProps(),
+        equalTo(ksqlConfig.getKsqlStreamConfigProps()));
+    final InOrder inOrder = Mockito.inOrder(consumerBefore, consumerAfter, producer);
+    verifyDrainLog(consumerBefore, inOrder, 0);
+    @SuppressWarnings("unchecked")
+    final ArgumentCaptor<ProducerRecord<String, KafkaConfigStore.KsqlProperties>> msgCaptor
+        = ArgumentCaptor.forClass(ProducerRecord.class);
+    inOrder.verify(producer).send(msgCaptor.capture());
+    assertThat(
+        msgCaptor.getValue().value().getKsqlProperties(),
+        equalTo(ksqlConfig.getAllConfigPropsWithSecretsObfuscated()));
+    inOrder.verify(producer).flush();
+    verifyDrainLog(consumerAfter, inOrder, 1);
+  }
+
+  @Test
+  public void shouldReadAndMergeExistingConfigIfExists() {
+    // Given:
+    final KsqlConfig persistedConfig = new KsqlConfig(
+        Collections.singletonMap(
+            KsqlConfig.KSQL_PERSISTENT_QUERY_NAME_PREFIX_CONFIG, "not-the-default"
+        )
+    );
+    final KafkaConsumer<String, KsqlProperties> consumer = expectRead(
+        new KafkaConfigStore.KsqlProperties(
+            persistedConfig.getAllConfigPropsWithSecretsObfuscated()));
+    when(consumerSupplier.get()).thenReturn(consumer);
+
+    // When:
+    initConfigStore();
+    final KsqlConfig resolvedConfig = configStore.getKsqlConfig();
+
+    // Then:
+    assertThat(
+        resolvedConfig.getString(KsqlConfig.KSQL_PERSISTENT_QUERY_NAME_PREFIX_CONFIG),
+        equalTo("not-the-default"));
+    verifyZeroInteractions(producer);
+  }
+
+  @Test
+  public void shouldDeserializeMissingContentsToNull() {
+    // When:
+    final Deserializer<KafkaConfigStore.KsqlProperties> deserializer
+        = KafkaConfigStore.createDeserializer();
+    final KafkaConfigStore.KsqlProperties ksqlProperties
+        = deserializer.deserialize(topicName, "{}".getBytes());
+
+    // Then:
+    assertThat(ksqlProperties.getKsqlProperties(), equalTo(Collections.emptyMap()));
+  }
+}

--- a/ksql-rest-app/src/test/java/io/confluent/ksql/rest/util/KsqlInternalTopicUtilsTest.java
+++ b/ksql-rest-app/src/test/java/io/confluent/ksql/rest/util/KsqlInternalTopicUtilsTest.java
@@ -1,3 +1,17 @@
+/*
+ * Copyright 2019 Confluent Inc.
+ *
+ * Licensed under the Confluent Community License; you may not use this file
+ * except in compliance with the License.  You may obtain a copy of the License at
+ *
+ * http://www.confluent.io/confluent-community-license
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
 package io.confluent.ksql.rest.util;
 
 import static org.mockito.ArgumentMatchers.any;

--- a/ksql-rest-app/src/test/java/io/confluent/ksql/rest/util/KsqlInternalTopicUtilsTest.java
+++ b/ksql-rest-app/src/test/java/io/confluent/ksql/rest/util/KsqlInternalTopicUtilsTest.java
@@ -16,8 +16,11 @@ import io.confluent.ksql.util.KsqlConfig;
 import java.util.Map;
 import org.apache.kafka.common.config.TopicConfig;
 import org.junit.Before;
+import org.junit.Rule;
 import org.junit.Test;
 import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnit;
+import org.mockito.junit.MockitoRule;
 
 public class KsqlInternalTopicUtilsTest {
   private static final String TOPIC_NAME = "topic";
@@ -31,6 +34,9 @@ public class KsqlInternalTopicUtilsTest {
   private KafkaTopicClient topicClient;
   @Mock
   private KsqlConfig ksqlConfig;
+
+  @Rule
+  public final MockitoRule mockitoRule = MockitoJUnit.rule();
 
   @Before
   public void setUp() {
@@ -74,7 +80,7 @@ public class KsqlInternalTopicUtilsTest {
     KsqlInternalTopicUtils.ensureTopic(TOPIC_NAME, ksqlConfig, topicClient);
 
     // Then:
-    verify(topicClient.addTopicConfig(TOPIC_NAME, retentionConfig));
+    verify(topicClient).addTopicConfig(TOPIC_NAME, retentionConfig);
   }
 
   @SuppressWarnings("unchecked")

--- a/ksql-rest-app/src/test/java/io/confluent/ksql/rest/util/KsqlInternalTopicUtilsTest.java
+++ b/ksql-rest-app/src/test/java/io/confluent/ksql/rest/util/KsqlInternalTopicUtilsTest.java
@@ -1,0 +1,103 @@
+package io.confluent.ksql.rest.util;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.ArgumentMatchers.anyMap;
+import static org.mockito.ArgumentMatchers.anyShort;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.google.common.collect.ImmutableMap;
+import io.confluent.ksql.exception.KafkaTopicExistsException;
+import io.confluent.ksql.services.KafkaTopicClient;
+import io.confluent.ksql.util.KsqlConfig;
+import java.util.Map;
+import org.apache.kafka.common.config.TopicConfig;
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.Mock;
+
+public class KsqlInternalTopicUtilsTest {
+  private static final String TOPIC_NAME = "topic";
+  private static final short NREPLICAS = 1;
+
+  private final Map<String, ?> commandTopicConfig = ImmutableMap.of(
+      TopicConfig.RETENTION_MS_CONFIG, Long.MAX_VALUE,
+      TopicConfig.CLEANUP_POLICY_CONFIG, TopicConfig.CLEANUP_POLICY_DELETE);
+
+  @Mock
+  private KafkaTopicClient topicClient;
+  @Mock
+  private KsqlConfig ksqlConfig;
+
+  @Before
+  public void setUp() {
+    when(ksqlConfig.originals()).thenReturn(
+        ImmutableMap.of(KsqlConfig.SINK_NUMBER_OF_REPLICAS_PROPERTY, NREPLICAS)
+    );
+    when(ksqlConfig.getShort(KsqlConfig.SINK_NUMBER_OF_REPLICAS_PROPERTY)).thenReturn(NREPLICAS);
+    when(topicClient.isTopicExists(TOPIC_NAME)).thenReturn(false);
+  }
+
+  @Test
+  public void shouldCreateCommandTopicIfItDoesNotExist() {
+    // When:
+    KsqlInternalTopicUtils.ensureTopic(TOPIC_NAME, ksqlConfig, topicClient);
+
+    // Then:
+    verify(topicClient).createTopic(TOPIC_NAME, 1, NREPLICAS, commandTopicConfig);
+  }
+
+  @Test
+  public void shouldNotAttemptToCreateCommandTopicIfItExists() {
+    // Given:
+    when(topicClient.isTopicExists(TOPIC_NAME)).thenReturn(true);
+
+    // When:
+    KsqlInternalTopicUtils.ensureTopic(TOPIC_NAME, ksqlConfig, topicClient);
+
+    // Then:
+    verify(topicClient, never()).createTopic(any(), anyInt(), anyShort(), anyMap());
+  }
+
+  @Test
+  public void shouldEnsureCommandTopicHasInfiniteRetention() {
+    // Given:
+    final Map<String, Object> retentionConfig = ImmutableMap.of(
+        TopicConfig.RETENTION_MS_CONFIG, Long.MAX_VALUE
+    );
+    when(topicClient.isTopicExists(TOPIC_NAME)).thenReturn(true);
+
+    // When:
+    KsqlInternalTopicUtils.ensureTopic(TOPIC_NAME, ksqlConfig, topicClient);
+
+    // Then:
+    verify(topicClient.addTopicConfig(TOPIC_NAME, retentionConfig));
+  }
+
+  @SuppressWarnings("unchecked")
+  @Test
+  public void shouldCreateCommandTopicWithNumReplicasFromConfig() {
+    // Given:
+    when(ksqlConfig.getShort(KsqlConfig.SINK_NUMBER_OF_REPLICAS_PROPERTY)).thenReturn((short)3);
+
+    // When:
+    KsqlInternalTopicUtils.ensureTopic(TOPIC_NAME, ksqlConfig, topicClient);
+
+    // Then:
+    verify(topicClient).createTopic(TOPIC_NAME, 1, (short) 3, commandTopicConfig);
+  }
+
+  @Test
+  public void shouldNotFailIfTopicExistsOnCreation() {
+    // Given:
+    doThrow(new KafkaTopicExistsException("exists"))
+        .when(topicClient)
+        .createTopic(any(), anyInt(), anyShort(), anyMap());
+
+    // When/Then(no throw):
+    KsqlInternalTopicUtils.ensureTopic(TOPIC_NAME, ksqlConfig, topicClient);
+  }
+}

--- a/ksql-rest-app/src/test/java/io/confluent/ksql/rest/util/KsqlInternalTopicUtilsTest.java
+++ b/ksql-rest-app/src/test/java/io/confluent/ksql/rest/util/KsqlInternalTopicUtilsTest.java
@@ -37,8 +37,10 @@ import org.junit.rules.ExpectedException;
 import org.junit.runner.RunWith;
 import org.mockito.Mock;
 import org.mockito.junit.MockitoJUnit;
+import org.mockito.junit.MockitoJUnitRunner;
 import org.mockito.junit.MockitoRule;
 
+@RunWith(MockitoJUnitRunner.class)
 public class KsqlInternalTopicUtilsTest {
   private static final String TOPIC_NAME = "topic";
   private static final short NREPLICAS = 1;
@@ -52,8 +54,6 @@ public class KsqlInternalTopicUtilsTest {
   @Mock
   private KsqlConfig ksqlConfig;
 
-  @Rule
-  public final MockitoRule mockitoRule = MockitoJUnit.rule();
   @Rule
   public final ExpectedException expectedException = ExpectedException.none();
 

--- a/ksql-rest-app/src/test/java/io/confluent/ksql/rest/util/KsqlInternalTopicUtilsTest.java
+++ b/ksql-rest-app/src/test/java/io/confluent/ksql/rest/util/KsqlInternalTopicUtilsTest.java
@@ -10,6 +10,7 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import com.google.common.collect.ImmutableMap;
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import io.confluent.ksql.exception.KafkaTopicExistsException;
 import io.confluent.ksql.services.KafkaTopicClient;
 import io.confluent.ksql.util.KsqlConfig;
@@ -69,6 +70,7 @@ public class KsqlInternalTopicUtilsTest {
   }
 
   @Test
+  @SuppressFBWarnings("RV_RETURN_VALUE_IGNORED_NO_SIDE_EFFECT")
   public void shouldEnsureCommandTopicHasInfiniteRetention() {
     // Given:
     final Map<String, Object> retentionConfig = ImmutableMap.of(


### PR DESCRIPTION
…running

This patch changes the standalone mode executor to use configs persisted in a kafka
topic, rather than just the configs present in the config file. The main advantage
here is that new standalone apps can use the latest defaults without any special
configuration, and continue to work across upgrades even if the default configs
change in an incompatible way. The functionality is implemented behind an interface
called ConfigStore, that has a single method called getKsqlConfig. The implementation,
KafkaConfigStore works by reading configs from a designated kafka topic and merging
them with the configs provided at runtime. If no configs are present in the topic
KafkaConfigStore writes the current configs.

### Description 
_What behavior do you want to change, why, how does your patch achieve the changes?_

### Testing done 
_Describe the testing stategy. Unit and integration tests are expected for any behavior changes._

### Reviewer checklist
- [ ] Ensure docs are updated if necessary. (eg. if a user visible feature is being added or changed).
- [ ] Ensure relevant issues are linked (description should include text like "Fixes #<issue number>")

