### PR TITLE
new family of url functions, now targeting 5.0.x branch. replaces #1348

### DIFF
--- a/docs/syntax-reference.rst
+++ b/docs/syntax-reference.rst
@@ -940,6 +940,46 @@ Scalar functions
 +------------------------+------------------------------------------------------------+---------------------------------------------------+
 | UCASE                  |  ``UCASE(col1)``                                           | Convert a string to uppercase                     |
 +------------------------+------------------------------------------------------------+---------------------------------------------------+
+| URL_DECODE_PARAM       |  ``URL_DECODE_PARAM(col1)``                                | Unescapes the URL-param-encoded value in col1.    |
+|                        |                                                            | This is the inverse of the URL_ENCODE function.   |
++------------------------+------------------------------------------------------------+---------------------------------------------------+
+| URL_ENCODE_PARAM       |  ``URL_ENCODE_PARAM(col1)``                                | Escapes the value of col1 such that it can safely |
+|                        |                                                            | be used in URL query parameters. Note that this   |
+|                        |                                                            | is not the same as encoding a value for use in    |
+|                        |                                                            | the path portion of a URL.                        |
++------------------------+------------------------------------------------------------+---------------------------------------------------+
+| URL_EXTRACT_FRAGMENT   |  ``URL_EXTRACT_FRAGMENT(url)``                             | Extract the fragment portion of the specified     |
+|                        |                                                            | value. Returns NULL if no fragment is present or  |
+|                        |                                                            | supplied value is not a valid URI.                |
++------------------------+------------------------------------------------------------+---------------------------------------------------+
+| URL_EXTRACT_HOST       |  ``URL_EXTRACT_HOST(url)``                                 | Extract the host-name portion of the specified    |
+|                        |                                                            | value. Returns NULL if the supplied value is not  |
+|                        |                                                            | a valid URI according to RFC-2396.                |
++------------------------+------------------------------------------------------------+---------------------------------------------------+
+| URL_EXTRACT_PARAMETER  |  ``URL_EXTRACT_PARAMETER(url, parameter_name)``            | Extract the value of the requested parameter from |
+|                        |                                                            | the query-string of the url value. Returns NULL   |
+|                        |                                                            | if the parameter is not present, has no value     |
+|                        |                                                            | specified for it in the query-string, or the      |
+|                        |                                                            | input URL is not a valid URI.                     |
+|                        |                                                            | To get all the parameter names and values from a  |
+|                        |                                                            | URL as a single string, see URL_EXTRACT_QUERY.    |
++------------------------+------------------------------------------------------------+---------------------------------------------------+
+| URL_EXTRACT_PATH       |  ``URL_EXTRACT_PATH(url)``                                 | Extracts the path from the specified url value.   |
+|                        |                                                            | Returns NULL if the supplied value is not a valid |
+|                        |                                                            | URI or contains no path component.                |
++------------------------+------------------------------------------------------------+---------------------------------------------------+
+| URL_EXTRACT_PORT       |  ``URL_EXTRACT_PORT(url)``                                 | Extract the port number from the specified value. |
+|                        |                                                            | Returns NULL if the supplied value is not a valid |
+|                        |                                                            | URI or does not contain an explicit port number.  |
++------------------------+------------------------------------------------------------+---------------------------------------------------+
+| URL_EXTRACT_PROTOCOL   |  ``URL_EXTRACT_PROTOCOL(url)``                             | Extract the protocol from the specified value,    |
+|                        |                                                            | e.g. 'https'. Returns NULL if the supplied value  |
+|                        |                                                            | is not a valid URI or it contains no protocol.    |
++------------------------+------------------------------------------------------------+---------------------------------------------------+
+| URL_EXTRACT_QUERY      |  ``URL_EXTRACT_QUERY(url)``                                | Extract the decoded query-string portion of the   |
+|                        |                                                            | specified URL. Returns NULL if no query-string    |
+|                        |                                                            | is present or the URL is not a valid URI.         |
++------------------------+------------------------------------------------------------+---------------------------------------------------+
 
 ===================
 Aggregate functions

--- a/ksql-engine/src/main/java/io/confluent/ksql/function/InternalFunctionRegistry.java
+++ b/ksql-engine/src/main/java/io/confluent/ksql/function/InternalFunctionRegistry.java
@@ -41,6 +41,15 @@ import io.confluent.ksql.function.udf.string.LenKudf;
 import io.confluent.ksql.function.udf.string.TrimKudf;
 import io.confluent.ksql.function.udf.string.UCaseKudf;
 import io.confluent.ksql.function.udf.structfieldextractor.FetchFieldFromStruct;
+import io.confluent.ksql.function.udf.url.UrlDecodeParamKudf;
+import io.confluent.ksql.function.udf.url.UrlEncodeParamKudf;
+import io.confluent.ksql.function.udf.url.UrlExtractFragmentKudf;
+import io.confluent.ksql.function.udf.url.UrlExtractHostKudf;
+import io.confluent.ksql.function.udf.url.UrlExtractParameterKudf;
+import io.confluent.ksql.function.udf.url.UrlExtractPathKudf;
+import io.confluent.ksql.function.udf.url.UrlExtractPortKudf;
+import io.confluent.ksql.function.udf.url.UrlExtractProtocolKudf;
+import io.confluent.ksql.function.udf.url.UrlExtractQueryKudf;
 import io.confluent.ksql.util.KsqlException;
 import org.apache.kafka.connect.data.Schema;
 import org.apache.kafka.connect.data.SchemaBuilder;
@@ -77,6 +86,7 @@ public class InternalFunctionRegistry implements FunctionRegistry {
     addDateTimeFunctions();
     addGeoFunctions();
     addJsonFunctions();
+    addUrlFunctions();
     addStructFieldFetcher();
     addUdafFunctions();
   }
@@ -226,7 +236,6 @@ public class InternalFunctionRegistry implements FunctionRegistry {
         "RANDOM", RandomKudf.class);
     addFunction(random);
 
-
   }
 
 
@@ -298,6 +307,45 @@ public class InternalFunctionRegistry implements FunctionRegistry {
         Arrays.asList(SchemaBuilder.array(Schema.OPTIONAL_FLOAT64_SCHEMA).optional().build(),
             Schema.OPTIONAL_FLOAT64_SCHEMA),
         "ARRAYCONTAINS", ArrayContainsKudf.class));
+  }
+
+  private void addUrlFunctions() {
+    KsqlFunction urlEncodeParam = new KsqlFunction(Schema.STRING_SCHEMA,
+        Arrays.asList(Schema.STRING_SCHEMA), "url_encode_param", UrlEncodeParamKudf.class);
+    addFunction(urlEncodeParam);
+
+    KsqlFunction urlDecodeParam = new KsqlFunction(Schema.STRING_SCHEMA,
+        Arrays.asList(Schema.STRING_SCHEMA), "url_decode_param", UrlDecodeParamKudf.class);
+    addFunction(urlDecodeParam);
+
+    KsqlFunction urlProtocol = new KsqlFunction(Schema.STRING_SCHEMA,
+        Arrays.asList(Schema.STRING_SCHEMA), "url_extract_protocol", UrlExtractProtocolKudf.class);
+    addFunction(urlProtocol);
+
+    KsqlFunction urlHost = new KsqlFunction(Schema.STRING_SCHEMA,
+        Arrays.asList(Schema.STRING_SCHEMA), "url_extract_host", UrlExtractHostKudf.class);
+    addFunction(urlHost);
+
+    KsqlFunction urlPort = new KsqlFunction(Schema.STRING_SCHEMA,
+        Arrays.asList(Schema.STRING_SCHEMA), "url_extract_port", UrlExtractPortKudf.class);
+    addFunction(urlPort);
+
+    KsqlFunction urlPath = new KsqlFunction(Schema.STRING_SCHEMA,
+        Arrays.asList(Schema.STRING_SCHEMA), "url_extract_path", UrlExtractPathKudf.class);
+    addFunction(urlPath);
+
+    KsqlFunction urlQuery = new KsqlFunction(Schema.STRING_SCHEMA,
+        Arrays.asList(Schema.STRING_SCHEMA), "url_extract_query", UrlExtractQueryKudf.class);
+    addFunction(urlQuery);
+
+    KsqlFunction urlParameter = new KsqlFunction(Schema.STRING_SCHEMA,
+        Arrays.asList(Schema.STRING_SCHEMA, Schema.STRING_SCHEMA), "url_extract_parameter",
+        UrlExtractParameterKudf.class);
+    addFunction(urlParameter);
+
+    KsqlFunction urlFragment = new KsqlFunction(Schema.STRING_SCHEMA,
+        Arrays.asList(Schema.STRING_SCHEMA), "url_extract_fragment", UrlExtractFragmentKudf.class);
+    addFunction(urlFragment);
   }
 
   /***************************************

--- a/ksql-engine/src/main/java/io/confluent/ksql/function/udf/url/UrlDecodeParamKudf.java
+++ b/ksql-engine/src/main/java/io/confluent/ksql/function/udf/url/UrlDecodeParamKudf.java
@@ -1,0 +1,39 @@
+/**
+ * Copyright 2018 Confluent Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ **/
+
+package io.confluent.ksql.function.udf.url;
+
+import io.confluent.ksql.function.KsqlFunctionException;
+import io.confluent.ksql.function.udf.Kudf;
+import java.io.UnsupportedEncodingException;
+import java.net.URLDecoder;
+
+import static java.nio.charset.StandardCharsets.UTF_8;
+
+
+
+public class UrlDecodeParamKudf implements Kudf {
+
+  @Override
+  public Object evaluate(final Object... args) {
+    if (args.length != 1) {
+      throw new KsqlFunctionException("url_decode udf requires one input argument.");
+    }
+    try {
+      return URLDecoder.decode(args[0].toString(), UTF_8.name());
+    } catch (final UnsupportedEncodingException e) {
+      throw new KsqlFunctionException("url_decode udf encountered an encoding exception", e);
+    }
+  }
+}

--- a/ksql-engine/src/main/java/io/confluent/ksql/function/udf/url/UrlEncodeParamKudf.java
+++ b/ksql-engine/src/main/java/io/confluent/ksql/function/udf/url/UrlEncodeParamKudf.java
@@ -1,0 +1,32 @@
+/**
+ * Copyright 2018 Confluent Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ **/
+
+package io.confluent.ksql.function.udf.url;
+
+import com.google.common.escape.Escaper;
+import com.google.common.net.UrlEscapers;
+import io.confluent.ksql.function.KsqlFunctionException;
+import io.confluent.ksql.function.udf.Kudf;
+
+public class UrlEncodeParamKudf implements Kudf {
+
+  @Override
+  public Object evaluate(final Object... args) {
+    if (args.length != 1) {
+      throw new KsqlFunctionException("url_encode udf requires one input argument.");
+    }
+    final Escaper escaper = UrlEscapers.urlFormParameterEscaper();
+    return escaper.escape(args[0].toString());
+  }
+}

--- a/ksql-engine/src/main/java/io/confluent/ksql/function/udf/url/UrlExtractFragmentKudf.java
+++ b/ksql-engine/src/main/java/io/confluent/ksql/function/udf/url/UrlExtractFragmentKudf.java
@@ -1,0 +1,31 @@
+/**
+ * Copyright 2018 Confluent Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ **/
+
+package io.confluent.ksql.function.udf.url;
+
+import java.net.URI;
+import io.confluent.ksql.function.KsqlFunctionException;
+import io.confluent.ksql.function.udf.Kudf;
+
+public class UrlExtractFragmentKudf implements Kudf {
+
+  @Override
+  public Object evaluate(final Object... args) {
+    if (args.length != 1) {
+      throw new KsqlFunctionException("url_extract_fragment udf requires one input argument.");
+    }
+    final URI uri = UrlParser.parseUrl(args[0].toString());
+    return uri == null ? null : uri.getFragment();
+  }
+}

--- a/ksql-engine/src/main/java/io/confluent/ksql/function/udf/url/UrlExtractHostKudf.java
+++ b/ksql-engine/src/main/java/io/confluent/ksql/function/udf/url/UrlExtractHostKudf.java
@@ -1,0 +1,31 @@
+/**
+ * Copyright 2018 Confluent Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ **/
+
+package io.confluent.ksql.function.udf.url;
+
+import java.net.URI;
+import io.confluent.ksql.function.KsqlFunctionException;
+import io.confluent.ksql.function.udf.Kudf;
+
+public class UrlExtractHostKudf implements Kudf {
+
+  @Override
+  public Object evaluate(final Object... args) {
+    if (args.length != 1) {
+      throw new KsqlFunctionException("url_extract_host udf requires one input argument.");
+    }
+    final URI uri = UrlParser.parseUrl(args[0].toString());
+    return uri == null ? null : uri.getHost();
+  }
+}

--- a/ksql-engine/src/main/java/io/confluent/ksql/function/udf/url/UrlExtractParameterKudf.java
+++ b/ksql-engine/src/main/java/io/confluent/ksql/function/udf/url/UrlExtractParameterKudf.java
@@ -1,0 +1,57 @@
+/**
+ * Copyright 2018 Confluent Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ **/
+
+package io.confluent.ksql.function.udf.url;
+
+import java.net.URI;
+import java.util.Iterator;
+import com.google.common.base.Splitter;
+import io.confluent.ksql.function.KsqlFunctionException;
+import io.confluent.ksql.function.udf.Kudf;
+
+public class UrlExtractParameterKudf implements Kudf {
+
+  private static final Splitter PARAM_SPLITTER = Splitter.on('&');
+  private static final Splitter KV_SPLITTER = Splitter.on('=').limit(2);
+
+  @Override
+  public Object evaluate(final Object... args) {
+    if (args.length != 2) {
+      throw new KsqlFunctionException("url_extract_parameter udf requires two input arguments.");
+    }
+
+    final URI uri = UrlParser.parseUrl(args[0].toString());
+    if (uri == null) {
+      return null;
+    }
+
+    final String query = uri.getQuery();
+    if (query == null) {
+      return null;
+    }
+
+    final String paramToFind = args[1].toString();
+    for (final String thisParam : PARAM_SPLITTER.split(query)) {
+      final Iterator<String> arg = KV_SPLITTER.split(thisParam).iterator();
+      if (arg.next().equalsIgnoreCase(paramToFind)) {
+        if (arg.hasNext()) {
+          return arg.next();
+        }
+        // key was found but value is empty
+        return null;
+      }
+    }
+    return null;
+  }
+}

--- a/ksql-engine/src/main/java/io/confluent/ksql/function/udf/url/UrlExtractPathKudf.java
+++ b/ksql-engine/src/main/java/io/confluent/ksql/function/udf/url/UrlExtractPathKudf.java
@@ -1,0 +1,31 @@
+/**
+ * Copyright 2018 Confluent Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ **/
+
+package io.confluent.ksql.function.udf.url;
+
+import java.net.URI;
+import io.confluent.ksql.function.KsqlFunctionException;
+import io.confluent.ksql.function.udf.Kudf;
+
+public class UrlExtractPathKudf implements Kudf {
+
+  @Override
+  public Object evaluate(final Object... args) {
+    if (args.length != 1) {
+      throw new KsqlFunctionException("url_extract_path udf requires one input argument.");
+    }
+    final URI uri = UrlParser.parseUrl(args[0].toString());
+    return uri == null ? null : uri.getPath();
+  }
+}

--- a/ksql-engine/src/main/java/io/confluent/ksql/function/udf/url/UrlExtractPortKudf.java
+++ b/ksql-engine/src/main/java/io/confluent/ksql/function/udf/url/UrlExtractPortKudf.java
@@ -1,0 +1,34 @@
+/**
+ * Copyright 2018 Confluent Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ **/
+
+package io.confluent.ksql.function.udf.url;
+
+import java.net.URI;
+import io.confluent.ksql.function.KsqlFunctionException;
+import io.confluent.ksql.function.udf.Kudf;
+
+public class UrlExtractPortKudf implements Kudf {
+
+  @Override
+  public Object evaluate(final Object... args) {
+    if (args.length != 1) {
+      throw new KsqlFunctionException("url_extract_port udf requires one input argument.");
+    }
+    final URI uri = UrlParser.parseUrl(args[0].toString());
+    if ((uri == null) || (uri.getPort() < 0)) {
+      return null;
+    }
+    return uri.getPort();
+  }
+}

--- a/ksql-engine/src/main/java/io/confluent/ksql/function/udf/url/UrlExtractProtocolKudf.java
+++ b/ksql-engine/src/main/java/io/confluent/ksql/function/udf/url/UrlExtractProtocolKudf.java
@@ -1,0 +1,31 @@
+/**
+ * Copyright 2018 Confluent Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ **/
+
+package io.confluent.ksql.function.udf.url;
+
+import java.net.URI;
+import io.confluent.ksql.function.KsqlFunctionException;
+import io.confluent.ksql.function.udf.Kudf;
+
+public class UrlExtractProtocolKudf implements Kudf {
+
+  @Override
+  public Object evaluate(final Object... args) {
+    if (args.length != 1) {
+      throw new KsqlFunctionException("url_extract_protocol udf requires one input argument.");
+    }
+    final URI uri = UrlParser.parseUrl(args[0].toString());
+    return uri == null ? null : uri.getScheme();
+  }
+}

--- a/ksql-engine/src/main/java/io/confluent/ksql/function/udf/url/UrlExtractQueryKudf.java
+++ b/ksql-engine/src/main/java/io/confluent/ksql/function/udf/url/UrlExtractQueryKudf.java
@@ -1,0 +1,31 @@
+/**
+ * Copyright 2018 Confluent Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ **/
+
+package io.confluent.ksql.function.udf.url;
+
+import java.net.URI;
+import io.confluent.ksql.function.KsqlFunctionException;
+import io.confluent.ksql.function.udf.Kudf;
+
+public class UrlExtractQueryKudf implements Kudf {
+
+  @Override
+  public Object evaluate(final Object... args) {
+    if (args.length != 1) {
+      throw new KsqlFunctionException("url_extract_query udf requires one input argument.");
+    }
+    final URI uri = UrlParser.parseUrl(args[0].toString());
+    return uri == null ? null : uri.getQuery();
+  }
+}

--- a/ksql-engine/src/main/java/io/confluent/ksql/function/udf/url/UrlParser.java
+++ b/ksql-engine/src/main/java/io/confluent/ksql/function/udf/url/UrlParser.java
@@ -1,0 +1,29 @@
+/**
+ * Copyright 2018 Confluent Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ **/
+
+package io.confluent.ksql.function.udf.url;
+
+import java.net.URI;
+import java.net.URISyntaxException;
+
+class UrlParser {
+
+  static URI parseUrl(final String url) {
+    try {
+      return new URI(url);
+    } catch (final URISyntaxException e) {
+      return null;
+    }
+  }
+}

--- a/ksql-engine/src/test/java/io/confluent/ksql/function/udf/url/UrlDecodeParamKudfTest.java
+++ b/ksql-engine/src/test/java/io/confluent/ksql/function/udf/url/UrlDecodeParamKudfTest.java
@@ -1,0 +1,65 @@
+/*
+ * Copyright 2018 Confluent Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package io.confluent.ksql.function.udf.url;
+
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+import io.confluent.ksql.function.KsqlFunctionException;
+import org.junit.Before;
+import static org.hamcrest.CoreMatchers.equalTo;
+import static org.hamcrest.MatcherAssert.assertThat;
+
+public class UrlDecodeParamKudfTest {
+
+  private UrlDecodeParamKudf decodeUdf;
+
+  @Before
+  public void setUp() {
+    decodeUdf = new UrlDecodeParamKudf();
+  }
+
+  @Rule
+  public final ExpectedException expectedException = ExpectedException.none();
+
+  @Test
+  public void shouldDecodeEncodedValue() {
+    assertThat(decodeUdf.evaluate("%3Ffoo+%24bar"), equalTo("?foo $bar"));
+  }
+
+  @Test
+  public void shouldReturnSpecialCharsIntact() {
+    assertThat(".-*_ should all pass through without being encoded", decodeUdf.evaluate("foo.-*_bar"), equalTo("foo.-*_bar"));
+  }
+
+  @Test
+  public void shouldReturnEmptyStringForEmptyInput() {
+    assertThat(decodeUdf.evaluate(""), equalTo(""));
+  }
+
+  @Test
+  public void shouldFailWithTooFewParams() {
+    expectedException.expect(KsqlFunctionException.class);
+    expectedException.expectMessage("url_decode udf requires one input");
+    decodeUdf.evaluate();
+  }
+
+  @Test
+  public void shouldFailWithTooManyParams() {
+    expectedException.expect(KsqlFunctionException.class);
+    expectedException.expectMessage("url_decode udf requires one input");
+    decodeUdf.evaluate("foo", "bar");
+  }
+}

--- a/ksql-engine/src/test/java/io/confluent/ksql/function/udf/url/UrlEncodeParamKudfTest.java
+++ b/ksql-engine/src/test/java/io/confluent/ksql/function/udf/url/UrlEncodeParamKudfTest.java
@@ -1,0 +1,65 @@
+/*
+ * Copyright 2018 Confluent Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package io.confluent.ksql.function.udf.url;
+
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+import io.confluent.ksql.function.KsqlFunctionException;
+import static org.hamcrest.CoreMatchers.equalTo;
+import static org.hamcrest.MatcherAssert.assertThat;
+import org.junit.Before;
+
+public class UrlEncodeParamKudfTest {
+
+  private UrlEncodeParamKudf encodeUdf;
+
+  @Before
+  public void setUp() {
+    encodeUdf = new UrlEncodeParamKudf();
+  }
+
+  @Rule
+  public final ExpectedException expectedException = ExpectedException.none();
+
+  @Test
+  public void shouldEncodeValue() {
+    assertThat(encodeUdf.evaluate("?foo $bar"), equalTo("%3Ffoo+%24bar"));
+  }
+
+  @Test
+  public void shouldReturnSpecialCharsIntact() {
+    assertThat(".-*_ should all pass through without being encoded", encodeUdf.evaluate("foo.-*_bar"), equalTo("foo.-*_bar"));
+  }
+
+  @Test
+  public void shouldReturnEmptyStringForEmptyInput() {
+    assertThat(encodeUdf.evaluate(""), equalTo(""));
+  }
+
+  @Test
+  public void shouldFailWithTooFewParams() {
+    expectedException.expect(KsqlFunctionException.class);
+    expectedException.expectMessage("url_encode udf requires one input");
+    encodeUdf.evaluate();
+  }
+
+  @Test
+  public void shouldFailWithTooManyParams() {
+    expectedException.expect(KsqlFunctionException.class);
+    expectedException.expectMessage("url_encode udf requires one input");
+    encodeUdf.evaluate("foo", "bar");
+  }
+}

--- a/ksql-engine/src/test/java/io/confluent/ksql/function/udf/url/UrlExtractFragmentKudfTest.java
+++ b/ksql-engine/src/test/java/io/confluent/ksql/function/udf/url/UrlExtractFragmentKudfTest.java
@@ -1,0 +1,67 @@
+/*
+ * Copyright 2018 Confluent Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package io.confluent.ksql.function.udf.url;
+
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+import io.confluent.ksql.function.KsqlFunctionException;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.CoreMatchers.equalTo;
+import static org.hamcrest.CoreMatchers.nullValue;
+import org.junit.Before;
+
+public class UrlExtractFragmentKudfTest {
+
+  private UrlExtractFragmentKudf extractUdf;
+
+  @Before
+  public void setUp() {
+    extractUdf = new UrlExtractFragmentKudf();
+  }
+
+  @Rule
+  public final ExpectedException expectedException = ExpectedException.none();
+
+
+  @Test
+  public void shouldExtractFragmentIfPresent() {
+    assertThat(extractUdf.evaluate("https://docs.confluent.io/current/ksql/docs/syntax-reference.html#scalar-functions"), equalTo("scalar-functions"));
+  }
+
+  @Test
+  public void shouldReturnNullIfNoFragment() {
+    assertThat(extractUdf.evaluate("https://docs.confluent.io/current/ksql/docs/syntax-reference.html"), nullValue());
+  }
+
+  @Test
+  public void shouldReturnNullForInvalidUrl() {
+    assertThat(extractUdf.evaluate("http://257.1/bogus/[url"), nullValue());
+  }
+
+  @Test
+  public void shouldFailWithTooFewParams() {
+    expectedException.expect(KsqlFunctionException.class);
+    expectedException.expectMessage("url_extract_fragment udf requires one input");
+    extractUdf.evaluate();
+  }
+
+  @Test
+  public void shouldFailWithTooManyParams() {
+    expectedException.expect(KsqlFunctionException.class);
+    expectedException.expectMessage("url_extract_fragment udf requires one input");
+    extractUdf.evaluate("foo", "bar");
+  }
+}

--- a/ksql-engine/src/test/java/io/confluent/ksql/function/udf/url/UrlExtractHostKudfTest.java
+++ b/ksql-engine/src/test/java/io/confluent/ksql/function/udf/url/UrlExtractHostKudfTest.java
@@ -1,0 +1,67 @@
+/*
+ * Copyright 2018 Confluent Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package io.confluent.ksql.function.udf.url;
+
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+import io.confluent.ksql.function.KsqlFunctionException;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.CoreMatchers.equalTo;
+import static org.hamcrest.CoreMatchers.nullValue;
+import org.junit.Before;
+
+public class UrlExtractHostKudfTest {
+
+  private UrlExtractHostKudf extractUdf;
+
+  @Before
+  public void setUp() {
+    extractUdf = new UrlExtractHostKudf();
+  }
+
+  @Rule
+  public final ExpectedException expectedException = ExpectedException.none();
+
+
+  @Test
+  public void shouldExtractHostIfPresent() {
+    assertThat(extractUdf.evaluate("https://docs.confluent.io/current/ksql/docs/syntax-reference.html#scalar-functions"), equalTo("docs.confluent.io"));
+  }
+
+  @Test
+  public void shouldReturnNullIfNoHost() {
+    assertThat(extractUdf.evaluate("https:///current/ksql/docs/syntax-reference.html#scalar-functions"), nullValue());
+  }
+
+  @Test
+  public void shouldReturnNullForInvalidUrl() {
+    assertThat(extractUdf.evaluate("http://257.1/bogus/[url"), nullValue());
+  }
+
+  @Test
+  public void shouldFailWithTooFewParams() {
+    expectedException.expect(KsqlFunctionException.class);
+    expectedException.expectMessage("url_extract_host udf requires one input");
+    extractUdf.evaluate();
+  }
+
+  @Test
+  public void shouldFailWithTooManyParams() {
+    expectedException.expect(KsqlFunctionException.class);
+    expectedException.expectMessage("url_extract_host udf requires one input");
+    extractUdf.evaluate("foo", "bar");
+  }
+}

--- a/ksql-engine/src/test/java/io/confluent/ksql/function/udf/url/UrlExtractParameterKudfTest.java
+++ b/ksql-engine/src/test/java/io/confluent/ksql/function/udf/url/UrlExtractParameterKudfTest.java
@@ -1,0 +1,72 @@
+/*
+ * Copyright 2018 Confluent Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package io.confluent.ksql.function.udf.url;
+
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+import io.confluent.ksql.function.KsqlFunctionException;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.CoreMatchers.equalTo;
+import static org.hamcrest.CoreMatchers.nullValue;
+import org.junit.Before;
+
+public class UrlExtractParameterKudfTest {
+
+  private UrlExtractParameterKudf extractUdf;
+
+  @Before
+  public void setUp() {
+    extractUdf = new UrlExtractParameterKudf();
+  }
+
+  @Rule
+  public final ExpectedException expectedException = ExpectedException.none();
+
+
+  @Test
+  public void shouldExtractParamValueIfPresent() {
+    assertThat(extractUdf.evaluate("https://docs.confluent.io/current/ksql/docs/syntax-reference.html?foo%20bar=baz&blank#scalar-functions", "foo bar"), equalTo("baz"));
+  }
+
+  @Test
+  public void shouldReturnNullIfParamHasNoValue() {
+    assertThat(extractUdf.evaluate("https://docs.confluent.io/current/ksql/docs/syntax-reference.html?foo%20bar=baz&blank#scalar-functions", "blank"), nullValue());
+  }
+
+  @Test
+  public void shouldReturnNullIfParamNotPresent() {
+    assertThat(extractUdf.evaluate("https://docs.confluent.io/current/ksql/docs/syntax-reference.html?foo%20bar=baz&blank#scalar-functions", "absent"), nullValue());
+  }
+
+  @Test
+  public void shouldReturnNullForInvalidUrl() {
+    assertThat(extractUdf.evaluate("http://257.1/bogus/[url", "foo bar"), nullValue());
+  }
+
+  @Test
+  public void shouldFailWithTooFewParams() {
+    expectedException.expect(KsqlFunctionException.class);
+    expectedException.expectMessage("url_extract_parameter udf requires two input");
+    extractUdf.evaluate();
+  }
+
+  @Test
+  public void shouldFailWithTooManyParams() {
+    expectedException.expect(KsqlFunctionException.class);
+    expectedException.expectMessage("url_extract_parameter udf requires two input");
+    extractUdf.evaluate("foo", "bar", "baz");
+  }
+}

--- a/ksql-engine/src/test/java/io/confluent/ksql/function/udf/url/UrlExtractPathKudfTest.java
+++ b/ksql-engine/src/test/java/io/confluent/ksql/function/udf/url/UrlExtractPathKudfTest.java
@@ -1,0 +1,67 @@
+/*
+ * Copyright 2018 Confluent Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package io.confluent.ksql.function.udf.url;
+
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+import io.confluent.ksql.function.KsqlFunctionException;
+import static org.hamcrest.CoreMatchers.equalTo;
+import static org.hamcrest.CoreMatchers.nullValue;
+import static org.hamcrest.MatcherAssert.assertThat;
+import org.junit.Before;
+
+public class UrlExtractPathKudfTest {
+
+  private UrlExtractPathKudf extractUdf;
+
+  @Before
+  public void setUp() {
+    extractUdf = new UrlExtractPathKudf();
+  }
+
+  @Rule
+  public final ExpectedException expectedException = ExpectedException.none();
+
+
+  @Test
+  public void shouldExtractPathIfPresent() {
+    assertThat(extractUdf.evaluate("https://docs.confluent.io/current/ksql/docs/syntax-reference.html#scalar-functions"), equalTo("/current/ksql/docs/syntax-reference.html"));
+  }
+
+  @Test
+  public void shouldReturnSlashIfNoPath() {
+    assertThat(extractUdf.evaluate("https://docs.confluent.io/"), equalTo("/"));
+  }
+
+  @Test
+  public void shouldReturnNullForInvalidUrl() {
+    assertThat(extractUdf.evaluate("http://257.1/bogus/[url"), nullValue());
+  }
+
+  @Test
+  public void shouldFailWithTooFewParams() {
+    expectedException.expect(KsqlFunctionException.class);
+    expectedException.expectMessage("url_extract_path udf requires one input");
+    extractUdf.evaluate();
+  }
+
+  @Test
+  public void shouldFailWithTooManyParams() {
+    expectedException.expect(KsqlFunctionException.class);
+    expectedException.expectMessage("url_extract_path udf requires one input");
+    extractUdf.evaluate("foo", "bar");
+  }
+}

--- a/ksql-engine/src/test/java/io/confluent/ksql/function/udf/url/UrlExtractPortKudfTest.java
+++ b/ksql-engine/src/test/java/io/confluent/ksql/function/udf/url/UrlExtractPortKudfTest.java
@@ -1,0 +1,67 @@
+/*
+ * Copyright 2018 Confluent Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package io.confluent.ksql.function.udf.url;
+
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+import io.confluent.ksql.function.KsqlFunctionException;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.CoreMatchers.equalTo;
+import static org.hamcrest.CoreMatchers.nullValue;
+import org.junit.Before;
+
+public class UrlExtractPortKudfTest {
+
+  private UrlExtractPortKudf extractUdf;
+
+  @Before
+  public void setUp() {
+    extractUdf = new UrlExtractPortKudf();
+  }
+
+  @Rule
+  public final ExpectedException expectedException = ExpectedException.none();
+
+
+  @Test
+  public void shouldExtractPortIfPresent() {
+    assertThat(extractUdf.evaluate("https://docs.confluent.io:8080/current/ksql/docs/syntax-reference.html#scalar-functions"), equalTo(8080));
+  }
+
+  @Test
+  public void shouldReturnNullIfNoPort() {
+    assertThat(extractUdf.evaluate("https://docs.confluent.io/current/ksql/docs/syntax-reference.html#scalar-functions"), nullValue());
+  }
+
+  @Test
+  public void shouldReturnNullForInvalidUrl() {
+    assertThat(extractUdf.evaluate("http://257.1/bogus/[url"), nullValue());
+  }
+
+  @Test
+  public void shouldFailWithTooFewParams() {
+    expectedException.expect(KsqlFunctionException.class);
+    expectedException.expectMessage("url_extract_port udf requires one input");
+    extractUdf.evaluate();
+  }
+
+  @Test
+  public void shouldFailWithTooManyParams() {
+    expectedException.expect(KsqlFunctionException.class);
+    expectedException.expectMessage("url_extract_port udf requires one input");
+    extractUdf.evaluate("foo", "bar");
+  }
+}

--- a/ksql-engine/src/test/java/io/confluent/ksql/function/udf/url/UrlExtractProtocolKudfTest.java
+++ b/ksql-engine/src/test/java/io/confluent/ksql/function/udf/url/UrlExtractProtocolKudfTest.java
@@ -1,0 +1,67 @@
+/*
+ * Copyright 2018 Confluent Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package io.confluent.ksql.function.udf.url;
+
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+import io.confluent.ksql.function.KsqlFunctionException;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.CoreMatchers.equalTo;
+import static org.hamcrest.CoreMatchers.nullValue;
+import org.junit.Before;
+
+public class UrlExtractProtocolKudfTest {
+
+  private UrlExtractProtocolKudf extractUdf;
+
+  @Before
+  public void setUp() {
+    extractUdf = new UrlExtractProtocolKudf();
+  }
+
+  @Rule
+  public final ExpectedException expectedException = ExpectedException.none();
+
+
+  @Test
+  public void shouldExtractProtocolIfPresent() {
+    assertThat(extractUdf.evaluate("https://docs.confluent.io/current/ksql/docs/syntax-reference.html#scalar-functions"), equalTo("https"));
+  }
+
+  @Test
+  public void shouldReturnNullIfNoProtocol() {
+    assertThat(extractUdf.evaluate("///current/ksql/docs/syntax-reference.html#scalar-functions"), nullValue());
+  }
+
+  @Test
+  public void shouldReturnNullForInvalidUrl() {
+    assertThat(extractUdf.evaluate("http://257.1/bogus/[url"), nullValue());
+  }
+
+  @Test
+  public void shouldFailWithTooFewParams() {
+    expectedException.expect(KsqlFunctionException.class);
+    expectedException.expectMessage("url_extract_protocol udf requires one input");
+    extractUdf.evaluate();
+  }
+
+  @Test
+  public void shouldFailWithTooManyParams() {
+    expectedException.expect(KsqlFunctionException.class);
+    expectedException.expectMessage("url_extract_protocol udf requires one input");
+    extractUdf.evaluate("foo", "bar");
+  }
+}

--- a/ksql-engine/src/test/java/io/confluent/ksql/function/udf/url/UrlExtractQueryKudfTest.java
+++ b/ksql-engine/src/test/java/io/confluent/ksql/function/udf/url/UrlExtractQueryKudfTest.java
@@ -1,0 +1,67 @@
+/*
+ * Copyright 2018 Confluent Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package io.confluent.ksql.function.udf.url;
+
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+import io.confluent.ksql.function.KsqlFunctionException;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.CoreMatchers.equalTo;
+import static org.hamcrest.CoreMatchers.nullValue;
+import org.junit.Before;
+
+public class UrlExtractQueryKudfTest {
+
+  private UrlExtractQueryKudf extractUdf;
+
+  @Before
+  public void setUp() {
+    extractUdf = new UrlExtractQueryKudf();
+  }
+
+  @Rule
+  public final ExpectedException expectedException = ExpectedException.none();
+
+
+  @Test
+  public void shouldExtractQueryIfPresent() {
+    assertThat(extractUdf.evaluate("https://docs.confluent.io/current/ksql/docs/syntax-reference.html?a=b&foo%20bar=baz&c=d&e#scalar-functions"), equalTo("a=b&foo bar=baz&c=d&e"));
+  }
+
+  @Test
+  public void shouldReturnNullIfNoQuery() {
+    assertThat(extractUdf.evaluate("https://current/ksql/docs/syntax-reference.html#scalar-functions"), nullValue());
+  }
+
+  @Test
+  public void shouldReturnNullForInvalidUrl() {
+    assertThat(extractUdf.evaluate("http://257.1/bogus/[url"), nullValue());
+  }
+
+  @Test
+  public void shouldFailWithTooFewParams() {
+    expectedException.expect(KsqlFunctionException.class);
+    expectedException.expectMessage("url_extract_query udf requires one input");
+    extractUdf.evaluate();
+  }
+
+  @Test
+  public void shouldFailWithTooManyParams() {
+    expectedException.expect(KsqlFunctionException.class);
+    expectedException.expectMessage("url_extract_query udf requires one input");
+    extractUdf.evaluate("foo", "bar");
+  }
+}


### PR DESCRIPTION
Moved all the new UDFs for URL-parsing from PR #1348 to target 5.0.x instead of master. 

I believe all of @big-andy-coates previous comments should be addressed already in this version.