### PR TITLE
Output more info to help with debugging system tests.

### DIFF
--- a/ksql-examples/src/main/java/io/confluent/ksql/datagen/DataGenProducer.java
+++ b/ksql-examples/src/main/java/io/confluent/ksql/datagen/DataGenProducer.java
@@ -54,6 +54,8 @@ public abstract class DataGenProducer {
       int messageCount,
       long maxInterval
   ) {
+    System.out.println("Outputting " + messageCount + " to " + kafkaTopicName);
+
     if (maxInterval < 0) {
       maxInterval = INTER_MESSAGE_MAX_INTERVAL;
     }
@@ -169,9 +171,9 @@ public abstract class DataGenProducer {
       if (e != null) {
         System.err.println("Error when sending message to topic: '" + topic + "', with key: '"
                            + keyString + "', and value: '" + valueString + "'");
-        e.printStackTrace();
+        e.printStackTrace(System.err);
       } else {
-        System.err.println(keyString + " --> (" + valueString + ")");
+        System.out.println(keyString + " --> (" + valueString + ") ts:" + metadata.timestamp());
       }
     }
   }


### PR DESCRIPTION
Minor tweak to the output from datagen, now:

- includes timestamp of the messages sent to Kafka
- outputs successfully sent messages to Standard.out, not err.
- outputs a message before starting.