### PR TITLE
Pass schema registry client configs onto the schema registry client

### DIFF
--- a/docs/installation/server-config/security.rst
+++ b/docs/installation/server-config/security.rst
@@ -76,6 +76,14 @@ KSQL to Schema Registry SSL communication.
 
 The exact settings will vary depending on the encryption and authentication mechanisms the
 Confluent Schema Registry is using, and how your SSL certificates are signed.
+
+You can pass authentication settings to the Schema Registry client used by KSQL
+by adding the following to your KSQL server config.
+
+.. code:: bash
+    ksql.schema.registry.basic.auth.credentials.source=USER_INFO
+    ksql.schema.registry.basic.auth.user.info=username:password
+
 For more information, see :ref:`schemaregistry_security`.
 
 .. _config-security-kafka:

--- a/ksql-engine/src/main/java/io/confluent/ksql/schema/registry/KsqlSchemaRegistryClientFactory.java
+++ b/ksql-engine/src/main/java/io/confluent/ksql/schema/registry/KsqlSchemaRegistryClientFactory.java
@@ -16,7 +16,6 @@
 
 package io.confluent.ksql.schema.registry;
 
-
 import org.apache.kafka.common.network.Mode;
 import org.apache.kafka.common.security.ssl.SslFactory;
 
@@ -41,7 +40,8 @@ public class KsqlSchemaRegistryClientFactory {
   private final SchemaRegistryClientFactory schemaRegistryClientFactory;
 
   interface SchemaRegistryClientFactory {
-    CachedSchemaRegistryClient create(RestService service, int identityMapCapacity,
+    CachedSchemaRegistryClient create(RestService service,
+                                      int identityMapCapacity,
                                       Map<String, Object> clientConfigs);
   }
 

--- a/ksql-engine/src/test/java/io/confluent/ksql/schema/registry/KsqlSchemaRegistryClientFactoryTest.java
+++ b/ksql-engine/src/test/java/io/confluent/ksql/schema/registry/KsqlSchemaRegistryClientFactoryTest.java
@@ -145,10 +145,10 @@ public class KsqlSchemaRegistryClientFactoryTest {
 
     final Map<String, Object> expectedConfigs = schemaRegistryClientConfigs.entrySet()
         .stream()
-        .map((e) -> new AbstractMap.SimpleEntry<>(
-              e.getKey().replaceFirst(KsqlConfig.KSQL_SCHEMA_REGISTRY_PREFIX, ""), e.getValue())
-        )
-        .collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue));
+        .collect(Collectors.toMap(
+            e -> e.getKey().replaceFirst(KsqlConfig.KSQL_SCHEMA_REGISTRY_PREFIX, ""),
+            Map.Entry::getValue
+        ));
 
     // When:
     final KsqlSchemaRegistryClientFactory factory = new KsqlSchemaRegistryClientFactory(config);

--- a/ksql-engine/src/test/java/io/confluent/ksql/schema/registry/KsqlSchemaRegistryClientFactoryTest.java
+++ b/ksql-engine/src/test/java/io/confluent/ksql/schema/registry/KsqlSchemaRegistryClientFactoryTest.java
@@ -43,7 +43,7 @@ import io.confluent.ksql.util.KsqlConfig;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.notNullValue;
-import static org.testng.AssertJUnit.assertEquals;
+import static org.junit.Assert.assertEquals;
 
 /**
  * @author andy
@@ -71,7 +71,6 @@ public class KsqlSchemaRegistryClientFactoryTest {
     EasyMock.expect(sslFactory.sslContext()).andReturn(SSL_CONTEXT);
   }
 
-  @SuppressWarnings("unchecked")
   @Test
   public void shouldSetSocketFactoryWhenNoSpecificSslConfig() {
     // Given:
@@ -83,14 +82,13 @@ public class KsqlSchemaRegistryClientFactoryTest {
     // When:
     final SchemaRegistryClient client =
         new KsqlSchemaRegistryClientFactory(config, restServiceSupplier, sslFactory,
-                                            Collections.EMPTY_MAP).create();
+                                            Collections.emptyMap()).create();
 
     // Then:
     assertThat(client, is(notNullValue()));
     EasyMock.verify(restService);
   }
 
-  @SuppressWarnings("unchecked")
   @Test
   public void shouldPickUpNonPrefixedSslConfig() {
     // Given:
@@ -105,14 +103,13 @@ public class KsqlSchemaRegistryClientFactoryTest {
     // When:
     final SchemaRegistryClient client =
         new KsqlSchemaRegistryClientFactory(config, restServiceSupplier, sslFactory,
-                                            Collections.EMPTY_MAP).create();
+                                            Collections.emptyMap()).create();
 
     // Then:
     assertThat(client, is(notNullValue()));
     EasyMock.verify(restService);
   }
 
-  @SuppressWarnings("unchecked")
   @Test
   public void shouldPickUpPrefixedSslConfig() {
     // Given:
@@ -127,7 +124,7 @@ public class KsqlSchemaRegistryClientFactoryTest {
     // When:
     final SchemaRegistryClient client =
         new KsqlSchemaRegistryClientFactory(config, restServiceSupplier, sslFactory,
-                                            Collections.EMPTY_MAP).create();
+                                            Collections.emptyMap()).create();
 
 
     // Then:


### PR DESCRIPTION
### Description 
Currently, the we don't pass any schema registry configurations in the ksql config file onto the schema registry client. This means we can't configure basic auth for the schema registry client through ksql. This patch enables passing basic auth parameters to the schema registry client

### Testing done 
Added a unit test which checks that the config parameters with the `ksql.schema.registry` prefix are passed on to the underlying schema registry client.

### Reviewer checklist
- [ ] Ensure docs are updated if necessary. (eg. if a user visible feature is being added or changed).
- [ ] Ensure relevant issues are linked (description should include text like "Fixes #<issue number>")

