### PR TITLE
don't bomb on non-existing plugin dir

### DIFF
--- a/ksql-engine/src/main/java/io/confluent/ksql/function/UdfLoader.java
+++ b/ksql-engine/src/main/java/io/confluent/ksql/function/UdfLoader.java
@@ -100,11 +100,11 @@ public class UdfLoader {
         if (!pluginDir.exists() && !pluginDir.isDirectory()) {
           LOGGER.info("UDFs can't be loaded as as dir {} doesn't exist or is not a directory",
               pluginDir);
-        } else {
-          Files.find(pluginDir.toPath(), 1, (path, attributes) -> path.toString().endsWith(".jar"))
-              .map(path -> UdfClassLoader.newClassLoader(path, parentClassLoader, blacklist))
-              .forEach(classLoader -> loadUdfs(classLoader, Optional.of(classLoader.getJarPath())));
+          return;
         }
+        Files.find(pluginDir.toPath(), 1, (path, attributes) -> path.toString().endsWith(".jar"))
+            .map(path -> UdfClassLoader.newClassLoader(path, parentClassLoader, blacklist))
+            .forEach(classLoader -> loadUdfs(classLoader, Optional.of(classLoader.getJarPath())));
       } catch (final IOException e) {
         LOGGER.error("Failed to load UDFs from location {}", pluginDir, e);
       }

--- a/ksql-engine/src/main/java/io/confluent/ksql/function/UdfLoader.java
+++ b/ksql-engine/src/main/java/io/confluent/ksql/function/UdfLoader.java
@@ -97,9 +97,14 @@ public class UdfLoader {
     loadUdfs(parentClassLoader, Optional.empty());
     if (loadCustomerUdfs) {
       try {
-        Files.find(pluginDir.toPath(), 1, (path, attributes) -> path.toString().endsWith(".jar"))
-            .map(path -> UdfClassLoader.newClassLoader(path, parentClassLoader, blacklist))
-            .forEach(classLoader -> loadUdfs(classLoader, Optional.of(classLoader.getJarPath())));
+        if (!pluginDir.exists() && !pluginDir.isDirectory()) {
+          LOGGER.info("UDFs can't be loaded as as dir {} doesn't exist or is not a directory",
+              pluginDir);
+        } else {
+          Files.find(pluginDir.toPath(), 1, (path, attributes) -> path.toString().endsWith(".jar"))
+              .map(path -> UdfClassLoader.newClassLoader(path, parentClassLoader, blacklist))
+              .forEach(classLoader -> loadUdfs(classLoader, Optional.of(classLoader.getJarPath())));
+        }
       } catch (final IOException e) {
         LOGGER.error("Failed to load UDFs from location {}", pluginDir, e);
       }

--- a/ksql-engine/src/test/java/io/confluent/ksql/function/UdfLoaderTest.java
+++ b/ksql-engine/src/test/java/io/confluent/ksql/function/UdfLoaderTest.java
@@ -211,6 +211,17 @@ public class UdfLoaderTest {
     metaStore.getUdfFactory("tostring");
   }
 
+  @Test
+  public void shouldNotThrowWhenExtDirDoesntExist() {
+    final ImmutableMap<Object, Object> configMap
+        = ImmutableMap.builder().put(KsqlConfig.KSQL_EXT_DIR, "foo/bar")
+        .put(KsqlConfig.KSQL_UDF_SECURITY_MANAGER_ENABLED, false)
+        .build();
+    final KsqlConfig config
+        = new KsqlConfig(configMap);
+    UdfLoader.newInstance(config, new MetaStoreImpl(new InternalFunctionRegistry()), "").load();
+  }
+
   private UdfLoader createUdfLoader(final MetaStore metaStore,
                                     final boolean loadCustomerUdfs,
                                     final boolean collectMetrics) {


### PR DESCRIPTION
### Description 
Don't throw exception when the ext dir doesn't exist and trying to load udfs. Just log and skip

### Reviewer checklist
- [ ] Ensure docs are updated if necessary. (eg. if a user visible feature is being added or changed).
- [ ] Ensure relevant issues are linked (description should include text like "Fixes #<issue number>")

