### PR TITLE
Rename DdlCommandTask to KsqlStatementTask in KsqlResources class.

### DIFF
--- a/ksql-rest-app/src/main/java/io/confluent/ksql/rest/server/resources/KsqlResource.java
+++ b/ksql-rest-app/src/main/java/io/confluent/ksql/rest/server/resources/KsqlResource.java
@@ -153,7 +153,7 @@ public class KsqlResource {
     this.commandStore = commandStore;
     this.statementExecutor = statementExecutor;
     this.distributedCommandResponseTimeout = distributedCommandResponseTimeout;
-    this.registerDdlCommandTasks();
+    this.registerKsqlStatementTasks();
   }
 
   @POST
@@ -611,7 +611,7 @@ public class KsqlResource {
 
   private final Map<Class, KsqlStatementTask> ksqlStatementTasks = new HashMap<>();
 
-  private void registerDdlCommandTasks() {
+  private void registerKsqlStatementTasks() {
     ksqlStatementTasks.put(Query.class,
         (statement, statementText, properties) ->
             ksqlEngine.getQueryExecutionPlan((Query)statement)


### PR DESCRIPTION
Renamed the DdlCommandTask to  KsqlStatementTask. The previous name was misleading since it is not just DDL but also DML.

### Description 
_What behavior do you want to change, why, how does your patch achieve the changes?_

### Testing done 
_Describe the testing stategy. Unit and integration tests are expected for any behavior changes._

### Reviewer checklist
- [ ] Ensure docs are updated if necessary. (eg. if a user visible feature is being added or changed).
- [ ] Ensure relevant issues are linked (description should include text like "Fixes #<issue number>")

