### PR TITLE
Convert invalid avro field names before serializing

### DIFF
--- a/ksql-engine/src/test/java/io/confluent/ksql/integration/UdfIntTest.java
+++ b/ksql-engine/src/test/java/io/confluent/ksql/integration/UdfIntTest.java
@@ -10,7 +10,6 @@ import io.confluent.ksql.util.ItemDataProvider;
 import io.confluent.ksql.util.OrderDataProvider;
 import io.confluent.ksql.util.SchemaUtil;
 import org.apache.kafka.clients.producer.RecordMetadata;
-import org.apache.kafka.common.metrics.Metrics;
 import org.apache.kafka.common.serialization.StringDeserializer;
 import org.apache.kafka.connect.data.Schema;
 import org.apache.kafka.test.TestUtils;

--- a/ksql-serde/src/main/java/io/confluent/ksql/serde/avro/AvroDataTranslator.java
+++ b/ksql-serde/src/main/java/io/confluent/ksql/serde/avro/AvroDataTranslator.java
@@ -1,3 +1,19 @@
+/**
+ * Copyright 2018 Confluent Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ **/
+
 package io.confluent.ksql.serde.avro;
 
 import com.google.common.collect.ImmutableList;

--- a/ksql-serde/src/main/java/io/confluent/ksql/serde/avro/AvroDataTranslator.java
+++ b/ksql-serde/src/main/java/io/confluent/ksql/serde/avro/AvroDataTranslator.java
@@ -1,0 +1,156 @@
+package io.confluent.ksql.serde.avro;
+
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.Iterables;
+import io.confluent.ksql.GenericRow;
+import io.confluent.ksql.serde.connect.ConnectDataTranslator;
+import io.confluent.ksql.serde.connect.DataTranslator;
+import org.apache.kafka.connect.data.Field;
+import org.apache.kafka.connect.data.Schema;
+import org.apache.kafka.connect.data.SchemaBuilder;
+import org.apache.kafka.connect.data.Struct;
+
+import java.util.LinkedList;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+
+public class AvroDataTranslator implements DataTranslator {
+  private final DataTranslator innerTranslator;
+  private final Schema ksqlSchema;
+  private final Schema avroCompatibleSchema;
+
+  public AvroDataTranslator(final Schema ksqlSchema) {
+    this.ksqlSchema = ksqlSchema;
+    this.avroCompatibleSchema = buildAvroCompatibleSchema(
+        ksqlSchema,
+        new TypeNameGenerator());
+    this.innerTranslator = new ConnectDataTranslator(avroCompatibleSchema);
+  }
+
+  @Override
+  public GenericRow toKsqlRow(Schema connectSchema, Object connectObject) {
+    final GenericRow avroCompatibleRow = innerTranslator.toKsqlRow(connectSchema, connectObject);
+    final List<Object> columns = new LinkedList<>();
+    for (int i = 0; i < avroCompatibleRow.getColumns().size(); i++) {
+      columns.add(
+          replaceSchema(
+              ksqlSchema.fields().get(i).schema(),
+              avroCompatibleRow.getColumns().get(i)));
+    }
+    return new GenericRow(columns);
+  }
+
+  @Override
+  public Struct toConnectRow(final GenericRow genericRow) {
+    final List<Object> columns = new LinkedList<>();
+    for (int i = 0; i < genericRow.getColumns().size(); i++) {
+      columns.add(
+          replaceSchema(
+              avroCompatibleSchema.fields().get(i).schema(),
+              genericRow.getColumns().get(i)));
+    }
+    return innerTranslator.toConnectRow(new GenericRow(columns));
+  }
+
+  private static class TypeNameGenerator {
+    private static final String DELIMITER = "_";
+    private static final String DEFAULT_SCHEMA_NAME_BASE = "KSQLDefaultSchemaName";
+
+    static final String MAP_KEY_NAME = "MapKey";
+    static final String MAP_VALUE_NAME = "MapValue";
+
+    private Iterable<String> names;
+
+    TypeNameGenerator() {
+      this(ImmutableList.of(DEFAULT_SCHEMA_NAME_BASE));
+    }
+
+    private TypeNameGenerator(Iterable<String> names) {
+      this.names = names;
+    }
+
+    TypeNameGenerator with(String name) {
+      return new TypeNameGenerator(Iterables.concat(names, ImmutableList.of(name)));
+    }
+
+    public String name() {
+      return String.join(DELIMITER, names);
+    }
+  }
+
+  private String avroCompatibleFieldName(final Field field) {
+    // Currently the only incompatible field names expected are fully qualified
+    // column identifiers. Once quoted identifier support is introduced we will
+    // need to implement something more generic here.
+    return field.name().replace(".", "_");
+  }
+
+  private Schema buildAvroCompatibleSchema(final Schema schema,
+                                           final TypeNameGenerator typeNameGenerator) {
+    final SchemaBuilder schemaBuilder;
+    switch (schema.type()) {
+      default:
+        return schema;
+      case STRUCT:
+        schemaBuilder = SchemaBuilder.struct();
+        if (schema.name() == null) {
+          schemaBuilder.name(typeNameGenerator.name());
+        }
+        for (final Field f : schema.fields()) {
+          schemaBuilder.field(
+              avroCompatibleFieldName(f),
+              buildAvroCompatibleSchema(f.schema(), typeNameGenerator.with(f.name())));
+        }
+        break;
+      case ARRAY:
+        schemaBuilder = SchemaBuilder.array(
+            buildAvroCompatibleSchema(schema.valueSchema(), typeNameGenerator));
+        break;
+      case MAP:
+        schemaBuilder = SchemaBuilder.map(
+            buildAvroCompatibleSchema(schema.keySchema(),
+                typeNameGenerator.with(TypeNameGenerator.MAP_KEY_NAME)),
+            buildAvroCompatibleSchema(schema.valueSchema(),
+                typeNameGenerator.with(TypeNameGenerator.MAP_VALUE_NAME)));
+        break;
+    }
+    if (schema.isOptional()) {
+      schemaBuilder.optional();
+    }
+    return schemaBuilder.build();
+  }
+
+  @SuppressWarnings("unchecked")
+  private Object replaceSchema(Schema schema, Object object) {
+    if (object == null) {
+      return null;
+    }
+    switch (schema.type()) {
+      case ARRAY:
+        return ((List) object).stream()
+            .map(e -> replaceSchema(schema.valueSchema(), e))
+            .collect(Collectors.toList());
+      case MAP:
+        return ((Map<Object, Object>) object).entrySet().stream()
+            .collect(
+                Collectors.toMap(
+                    e -> replaceSchema(schema.keySchema(), e.getKey()),
+                    e -> replaceSchema(schema.valueSchema(), e.getValue())
+                )
+            );
+
+      case STRUCT:
+        final Struct struct = new Struct(schema);
+        schema.fields().forEach(
+            f -> struct.put(
+                f.name(),
+                replaceSchema(f.schema(), ((Struct) object).get(f.name())))
+        );
+        return struct;
+      default:
+        return object;
+    }
+  }
+}

--- a/ksql-serde/src/main/java/io/confluent/ksql/serde/avro/AvroDataTranslator.java
+++ b/ksql-serde/src/main/java/io/confluent/ksql/serde/avro/AvroDataTranslator.java
@@ -46,7 +46,7 @@ public class AvroDataTranslator implements DataTranslator {
   }
 
   @Override
-  public GenericRow toKsqlRow(Schema connectSchema, Object connectObject) {
+  public GenericRow toKsqlRow(final Schema connectSchema, final Object connectObject) {
     final GenericRow avroCompatibleRow = innerTranslator.toKsqlRow(connectSchema, connectObject);
     final List<Object> columns = new LinkedList<>();
     for (int i = 0; i < avroCompatibleRow.getColumns().size(); i++) {
@@ -83,11 +83,11 @@ public class AvroDataTranslator implements DataTranslator {
       this(ImmutableList.of(DEFAULT_SCHEMA_NAME_BASE));
     }
 
-    private TypeNameGenerator(Iterable<String> names) {
+    private TypeNameGenerator(final Iterable<String> names) {
       this.names = names;
     }
 
-    TypeNameGenerator with(String name) {
+    TypeNameGenerator with(final String name) {
       return new TypeNameGenerator(Iterables.concat(names, ImmutableList.of(name)));
     }
 
@@ -139,7 +139,7 @@ public class AvroDataTranslator implements DataTranslator {
   }
 
   @SuppressWarnings("unchecked")
-  private Object replaceSchema(Schema schema, Object object) {
+  private Object replaceSchema(final Schema schema, final Object object) {
     if (object == null) {
       return null;
     }

--- a/ksql-serde/src/main/java/io/confluent/ksql/serde/avro/KsqlAvroTopicSerDe.java
+++ b/ksql-serde/src/main/java/io/confluent/ksql/serde/avro/KsqlAvroTopicSerDe.java
@@ -56,13 +56,12 @@ public class KsqlAvroTopicSerDe extends KsqlTopicSerDe {
   }
 
   @Override
-  public Serde<GenericRow> getGenericRowSerde(Schema schema,
+  public Serde<GenericRow> getGenericRowSerde(final Schema schemaMaybeWithSource,
                                               final KsqlConfig ksqlConfig,
                                               final boolean isInternal,
                                               final SchemaRegistryClient schemaRegistryClient) {
-    if (isInternal) {
-      schema = SchemaUtil.getSchemaWithNoAlias(schema);
-    }
+    final Schema schema = isInternal
+        ? SchemaUtil.getSchemaWithNoAlias(schemaMaybeWithSource) : schemaMaybeWithSource;
     final Serializer<GenericRow> genericRowSerializer =
         new KsqlConnectSerializer(
             new AvroDataTranslator(schema),

--- a/ksql-serde/src/main/java/io/confluent/ksql/serde/avro/KsqlAvroTopicSerDe.java
+++ b/ksql-serde/src/main/java/io/confluent/ksql/serde/avro/KsqlAvroTopicSerDe.java
@@ -23,6 +23,7 @@ import io.confluent.kafka.serializers.AbstractKafkaAvroSerDeConfig;
 import io.confluent.ksql.serde.connect.ConnectDataTranslator;
 import io.confluent.ksql.serde.connect.KsqlConnectDeserializer;
 import io.confluent.ksql.serde.connect.KsqlConnectSerializer;
+import io.confluent.ksql.util.SchemaUtil;
 import org.apache.kafka.common.serialization.Deserializer;
 import org.apache.kafka.common.serialization.Serde;
 import org.apache.kafka.common.serialization.Serdes;
@@ -56,16 +57,21 @@ public class KsqlAvroTopicSerDe extends KsqlTopicSerDe {
   }
 
   @Override
-  public Serde<GenericRow> getGenericRowSerde(final Schema schema,
+  public Serde<GenericRow> getGenericRowSerde(Schema schema,
                                               final KsqlConfig ksqlConfig,
                                               final boolean isInternal,
                                               final SchemaRegistryClient schemaRegistryClient) {
+    if (isInternal) {
+      schema = SchemaUtil.getSchemaWithNoAlias(schema);
+    }
     final Serializer<GenericRow> genericRowSerializer =
-        new KsqlConnectSerializer(schema, getAvroConverter(schemaRegistryClient, ksqlConfig));
+        new KsqlConnectSerializer(
+            new AvroDataTranslator(schema),
+            getAvroConverter(schemaRegistryClient, ksqlConfig));
     final Deserializer<GenericRow> genericRowDeserializer =
         new KsqlConnectDeserializer(
-            schema,
-            getAvroConverter(schemaRegistryClient, ksqlConfig), new ConnectDataTranslator());
+            getAvroConverter(schemaRegistryClient, ksqlConfig),
+            new AvroDataTranslator(schema));
     return Serdes.serdeFrom(genericRowSerializer, genericRowDeserializer);
   }
 }

--- a/ksql-serde/src/main/java/io/confluent/ksql/serde/avro/KsqlAvroTopicSerDe.java
+++ b/ksql-serde/src/main/java/io/confluent/ksql/serde/avro/KsqlAvroTopicSerDe.java
@@ -20,7 +20,6 @@ import com.google.common.collect.ImmutableMap;
 import io.confluent.connect.avro.AvroConverter;
 import io.confluent.connect.avro.AvroDataConfig;
 import io.confluent.kafka.serializers.AbstractKafkaAvroSerDeConfig;
-import io.confluent.ksql.serde.connect.ConnectDataTranslator;
 import io.confluent.ksql.serde.connect.KsqlConnectDeserializer;
 import io.confluent.ksql.serde.connect.KsqlConnectSerializer;
 import io.confluent.ksql.util.SchemaUtil;

--- a/ksql-serde/src/main/java/io/confluent/ksql/serde/connect/ConnectDataTranslator.java
+++ b/ksql-serde/src/main/java/io/confluent/ksql/serde/connect/ConnectDataTranslator.java
@@ -27,9 +27,16 @@ import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
 
-public class ConnectDataTranslator {
-  GenericRow toKsqlRow(final Schema schema, final Schema connectSchema,
-                       final Object connectData) {
+public class ConnectDataTranslator implements DataTranslator {
+  private final Schema schema;
+
+  public ConnectDataTranslator(final Schema schema) {
+    this.schema = schema;
+  }
+
+  @Override
+  public GenericRow toKsqlRow(final Schema connectSchema,
+                              final Object connectData) {
     if (!schema.type().equals(Schema.Type.STRUCT)) {
       throw new KsqlException("Schema for a KSQL row should be a struct");
     }
@@ -125,5 +132,13 @@ public class ConnectDataTranslator {
             Collectors.toMap(
                 f -> f.name().toUpperCase(),
                 Field::name));
+  }
+
+  public Struct toConnectRow(GenericRow row) {
+    Struct struct = new Struct(schema);
+    for (int i = 0; i < schema.fields().size(); i++) {
+      struct.put(schema.fields().get(i).name(), row.getColumns().get(i));
+    }
+    return struct;
   }
 }

--- a/ksql-serde/src/main/java/io/confluent/ksql/serde/connect/ConnectDataTranslator.java
+++ b/ksql-serde/src/main/java/io/confluent/ksql/serde/connect/ConnectDataTranslator.java
@@ -134,8 +134,8 @@ public class ConnectDataTranslator implements DataTranslator {
                 Field::name));
   }
 
-  public Struct toConnectRow(GenericRow row) {
-    Struct struct = new Struct(schema);
+  public Struct toConnectRow(final GenericRow row) {
+    final Struct struct = new Struct(schema);
     for (int i = 0; i < schema.fields().size(); i++) {
       struct.put(schema.fields().get(i).name(), row.getColumns().get(i));
     }

--- a/ksql-serde/src/main/java/io/confluent/ksql/serde/connect/DataTranslator.java
+++ b/ksql-serde/src/main/java/io/confluent/ksql/serde/connect/DataTranslator.java
@@ -1,0 +1,11 @@
+package io.confluent.ksql.serde.connect;
+
+import io.confluent.ksql.GenericRow;
+import org.apache.kafka.connect.data.Schema;
+import org.apache.kafka.connect.data.Struct;
+
+public interface DataTranslator {
+  GenericRow toKsqlRow(final Schema connectSchema, final Object connectData);
+
+  Struct toConnectRow(final GenericRow genericRow);
+}

--- a/ksql-serde/src/main/java/io/confluent/ksql/serde/connect/DataTranslator.java
+++ b/ksql-serde/src/main/java/io/confluent/ksql/serde/connect/DataTranslator.java
@@ -1,3 +1,19 @@
+/**
+ * Copyright 2018 Confluent Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ **/
+
 package io.confluent.ksql.serde.connect;
 
 import io.confluent.ksql.GenericRow;

--- a/ksql-serde/src/main/java/io/confluent/ksql/serde/connect/KsqlConnectDeserializer.java
+++ b/ksql-serde/src/main/java/io/confluent/ksql/serde/connect/KsqlConnectDeserializer.java
@@ -25,15 +25,12 @@ import org.apache.kafka.connect.storage.Converter;
 import java.util.Map;
 
 public class KsqlConnectDeserializer implements Deserializer<GenericRow> {
-  final Schema schema;
   final Converter converter;
-  final ConnectDataTranslator connectToKsqlTranslator;
+  final DataTranslator connectToKsqlTranslator;
 
   public KsqlConnectDeserializer(
-      final Schema schema,
       final Converter converter,
-      final ConnectDataTranslator connectToKsqlTranslator) {
-    this.schema = schema;
+      final DataTranslator connectToKsqlTranslator) {
     this.converter = converter;
     this.connectToKsqlTranslator = connectToKsqlTranslator;
   }
@@ -46,8 +43,7 @@ public class KsqlConnectDeserializer implements Deserializer<GenericRow> {
   @Override
   public GenericRow deserialize(final String topic, final byte[] bytes) {
     final SchemaAndValue schemaAndValue = converter.toConnectData(topic, bytes);
-    return connectToKsqlTranslator.toKsqlRow(
-        schema, schemaAndValue.schema(), schemaAndValue.value());
+    return connectToKsqlTranslator.toKsqlRow(schemaAndValue.schema(), schemaAndValue.value());
   }
 
   @Override

--- a/ksql-serde/src/main/java/io/confluent/ksql/serde/connect/KsqlConnectDeserializer.java
+++ b/ksql-serde/src/main/java/io/confluent/ksql/serde/connect/KsqlConnectDeserializer.java
@@ -18,7 +18,6 @@ package io.confluent.ksql.serde.connect;
 
 import io.confluent.ksql.GenericRow;
 import org.apache.kafka.common.serialization.Deserializer;
-import org.apache.kafka.connect.data.Schema;
 import org.apache.kafka.connect.data.SchemaAndValue;
 import org.apache.kafka.connect.storage.Converter;
 

--- a/ksql-serde/src/main/java/io/confluent/ksql/serde/connect/KsqlConnectSerializer.java
+++ b/ksql-serde/src/main/java/io/confluent/ksql/serde/connect/KsqlConnectSerializer.java
@@ -16,28 +16,21 @@
 
 package io.confluent.ksql.serde.connect;
 
-import com.google.common.collect.ImmutableList;
-import com.google.common.collect.Iterables;
-import com.google.common.collect.Streams;
 import io.confluent.ksql.GenericRow;
 import org.apache.kafka.common.errors.SerializationException;
 import org.apache.kafka.common.serialization.Serializer;
-import org.apache.kafka.connect.data.Field;
-import org.apache.kafka.connect.data.Schema;
-import org.apache.kafka.connect.data.SchemaBuilder;
 import org.apache.kafka.connect.data.Struct;
 import org.apache.kafka.connect.storage.Converter;
 
-import java.util.List;
 import java.util.Map;
-import java.util.stream.Collectors;
 
 public class KsqlConnectSerializer implements Serializer<GenericRow> {
-  private final Schema schema;
+  private final DataTranslator translator;
   private final Converter converter;
 
-  public KsqlConnectSerializer(final Schema schema, final Converter converter) {
-    this.schema = addNames(schema, new TypeNameGenerator());
+  public KsqlConnectSerializer(final DataTranslator translator,
+                               final Converter converter) {
+    this.translator = translator;
     this.converter = converter;
   }
 
@@ -46,14 +39,9 @@ public class KsqlConnectSerializer implements Serializer<GenericRow> {
     if (genericRow == null) {
       return null;
     }
-
+    final Struct struct = translator.toConnectRow(genericRow);
     try {
-      final Struct struct = new Struct(schema);
-      Streams.forEachPair(
-          schema.fields().stream(),
-          genericRow.getColumns().stream(),
-          (field, value) -> struct.put(field.name(), replaceSchema(field.schema(), value)));
-      return converter.fromConnectData(topic, schema, struct);
+      return converter.fromConnectData(topic, struct.schema(), struct);
     } catch (Exception e) {
       throw new SerializationException(
           "Error serializing row to topic " + topic + " using Converter API", e);
@@ -66,89 +54,5 @@ public class KsqlConnectSerializer implements Serializer<GenericRow> {
 
   @Override
   public void close() {
-  }
-
-  private static class TypeNameGenerator {
-    private static final String DELIMITER = "_";
-    private static final String DEFAULT_SCHEMA_NAME_BASE = "KSQLDefaultSchemaName";
-
-    private Iterable<String> names;
-
-    TypeNameGenerator() {
-      this(ImmutableList.of(DEFAULT_SCHEMA_NAME_BASE));
-    }
-
-    private TypeNameGenerator(Iterable<String> names) {
-      this.names = names;
-    }
-
-    TypeNameGenerator with(String name) {
-      return new TypeNameGenerator(Iterables.concat(names, ImmutableList.of(name)));
-    }
-
-    public String name() {
-      return String.join(DELIMITER, names);
-    }
-  }
-
-  private Schema addNames(final Schema schema, final TypeNameGenerator typeNameGenerator) {
-    final SchemaBuilder schemaBuilder;
-    switch (schema.type()) {
-      default:
-        return schema;
-      case STRUCT:
-        schemaBuilder = SchemaBuilder.struct();
-        if (schema.name() == null) {
-          schemaBuilder.name(typeNameGenerator.name());
-        }
-        for (final Field f : schema.fields()) {
-          schemaBuilder.field(f.name(), addNames(f.schema(), typeNameGenerator.with(f.name())));
-        }
-        break;
-      case ARRAY:
-        schemaBuilder = SchemaBuilder.array(addNames(schema.valueSchema(), typeNameGenerator));
-        break;
-      case MAP:
-        schemaBuilder = SchemaBuilder.map(
-            addNames(schema.keySchema(), typeNameGenerator),
-            addNames(schema.valueSchema(), typeNameGenerator));
-        break;
-    }
-    if (schema.isOptional()) {
-      schemaBuilder.optional();
-    }
-    return schemaBuilder.build();
-  }
-
-  @SuppressWarnings("unchecked")
-  private Object replaceSchema(Schema schema, Object object) {
-    if (object == null) {
-      return null;
-    }
-    switch (schema.type()) {
-      case ARRAY:
-        return ((List) object).stream()
-            .map(e -> replaceSchema(schema.valueSchema(), e))
-            .collect(Collectors.toList());
-      case MAP:
-        return ((Map<Object, Object>) object).entrySet().stream()
-            .collect(
-                Collectors.toMap(
-                    e -> replaceSchema(schema.keySchema(), e.getKey()),
-                    e -> replaceSchema(schema.valueSchema(), e.getValue())
-                )
-            );
-
-      case STRUCT:
-        final Struct struct = new Struct(schema);
-        schema.fields().forEach(
-            f -> struct.put(
-                f.name(),
-                replaceSchema(f.schema(), ((Struct) object).get(f.name())))
-        );
-        return struct;
-      default:
-        return object;
-    }
   }
 }

--- a/ksql-serde/src/test/java/io/confluent/ksql/serde/avro/AvroDataTranslatorTest.java
+++ b/ksql-serde/src/test/java/io/confluent/ksql/serde/avro/AvroDataTranslatorTest.java
@@ -17,7 +17,7 @@ import static org.junit.Assert.assertThat;
 
 public class AvroDataTranslatorTest {
   @Test
-  public void shoudRenameStructDereference() {
+  public void shoudRenameSourceDereference() {
     final Schema schema = SchemaBuilder.struct()
         .field("STREAM_NAME.COLUMN_NAME", Schema.OPTIONAL_INT32_SCHEMA)
         .optional()

--- a/ksql-serde/src/test/java/io/confluent/ksql/serde/avro/KsqlGenericRowAvroSerializerTest.java
+++ b/ksql-serde/src/test/java/io/confluent/ksql/serde/avro/KsqlGenericRowAvroSerializerTest.java
@@ -23,6 +23,7 @@ import org.apache.kafka.common.errors.SerializationException;
 import org.apache.kafka.common.serialization.Serializer;
 import org.apache.kafka.connect.data.Schema;
 import org.apache.kafka.connect.data.SchemaBuilder;
+import org.apache.kafka.connect.errors.DataException;
 import org.junit.Assert;
 import org.junit.Test;
 
@@ -166,7 +167,7 @@ public class KsqlGenericRowAvroSerializerTest {
     try {
       serializer.serialize("t1", genericRow);
       Assert.fail("Did not fail for incompatible types.");
-    } catch (SerializationException e) {
+    } catch (DataException e) {
     }
 
   }


### PR DESCRIPTION
This patch updates the avro serdes to convert invalid avro field names before serializing.
As part of this change, we've moved the code that sets struct schema names, along with the
code that sets invalid field names into a translator that does avro-specific things called
AvroDataTranslator.

### Description 
_What behavior do you want to change, why, how does your patch achieve the changes?_

### Testing done 
_Describe the testing stategy. Unit and integration tests are expected for any behavior changes._

### Reviewer checklist
- [ ] Ensure docs are updated if necessary. (eg. if a user visible feature is being added or changed).
- [ ] Ensure relevant issues are linked (description should include text like "Fixes #<issue number>")

