### PR TITLE
minor cleanup of string-masking UDF param handling

### DIFF
--- a/ksql-engine/src/main/java/io/confluent/ksql/function/udf/string/MaskKeepLeftKudf.java
+++ b/ksql-engine/src/main/java/io/confluent/ksql/function/udf/string/MaskKeepLeftKudf.java
@@ -14,7 +14,6 @@
 
 package io.confluent.ksql.function.udf.string;
 
-import io.confluent.ksql.function.KsqlFunctionException;
 import io.confluent.ksql.function.udf.Udf;
 import io.confluent.ksql.function.udf.UdfDescription;
 
@@ -25,6 +24,8 @@ import io.confluent.ksql.function.udf.UdfDescription;
         + " characters with 'x', all digits with 'n', and any other character with '-'.")
 public class MaskKeepLeftKudf {
 
+  private final String udfName = this.getClass().getAnnotation(UdfDescription.class).name();
+  
   @Udf(description = "Returns a masked version of the input string. All characters except for the"
       + " first n will be replaced according to the default masking rules.")
   public String mask(final String input, final int numChars) {
@@ -49,7 +50,7 @@ public class MaskKeepLeftKudf {
   }
 
   private String doMask(final Masker masker, final String input, final int numChars) {
-    validateParams(numChars);
+    Masker.validateParams(this.udfName, numChars);
     if (input == null) {
       return null;
     }
@@ -60,10 +61,4 @@ public class MaskKeepLeftKudf {
     return output.toString();
   }
 
-  private void validateParams(final int numChars) {
-    if (numChars < 0) {
-      throw new KsqlFunctionException(
-          "mask_keep_left requires a non-negative number of characters not to mask");
-    }
-  }
 }

--- a/ksql-engine/src/main/java/io/confluent/ksql/function/udf/string/MaskKeepRightKudf.java
+++ b/ksql-engine/src/main/java/io/confluent/ksql/function/udf/string/MaskKeepRightKudf.java
@@ -14,7 +14,6 @@
 
 package io.confluent.ksql.function.udf.string;
 
-import io.confluent.ksql.function.KsqlFunctionException;
 import io.confluent.ksql.function.udf.Udf;
 import io.confluent.ksql.function.udf.UdfDescription;
 
@@ -24,6 +23,8 @@ import io.confluent.ksql.function.udf.UdfDescription;
         + " Default masking rules will replace all upper-case characters with 'X', all lower-case"
         + " characters with 'x', all digits with 'n', and any other character with '-'.")
 public class MaskKeepRightKudf {
+
+  private final String udfName = this.getClass().getAnnotation(UdfDescription.class).name();
 
   @Udf(description = "Returns a masked version of the input string. All characters except for the"
       + " last n will be replaced according to the default masking rules.")
@@ -49,7 +50,7 @@ public class MaskKeepRightKudf {
   }
 
   private String doMask(final Masker masker, final String input, final int numChars) {
-    validateParams(numChars);
+    Masker.validateParams(udfName, numChars);
     if (input == null) {
       return null;
     }
@@ -58,12 +59,5 @@ public class MaskKeepRightKudf {
     output.append(masker.mask(input.substring(0, charsToMask)));
     output.append(input.substring(charsToMask));
     return output.toString();
-  }
-
-  private void validateParams(final int numChars) {
-    if (numChars < 0) {
-      throw new KsqlFunctionException(
-          "mask_keep_right requires a non-negative number of characters not to mask");
-    }
   }
 }

--- a/ksql-engine/src/main/java/io/confluent/ksql/function/udf/string/MaskKudf.java
+++ b/ksql-engine/src/main/java/io/confluent/ksql/function/udf/string/MaskKudf.java
@@ -23,8 +23,6 @@ import io.confluent.ksql.function.udf.UdfDescription;
         + " characters with 'x', all digits with 'n', and any other character with '-'.")
 public class MaskKudf {
 
-  private final String udfName = this.getClass().getAnnotation(UdfDescription.class).name();
-
   @Udf(description = "Returns a masked version of the input string. All characters of the input"
       + " will be replaced according to the default masking rules.")
   public String mask(final String input) {

--- a/ksql-engine/src/main/java/io/confluent/ksql/function/udf/string/MaskKudf.java
+++ b/ksql-engine/src/main/java/io/confluent/ksql/function/udf/string/MaskKudf.java
@@ -23,6 +23,8 @@ import io.confluent.ksql.function.udf.UdfDescription;
         + " characters with 'x', all digits with 'n', and any other character with '-'.")
 public class MaskKudf {
 
+  private final String udfName = this.getClass().getAnnotation(UdfDescription.class).name();
+
   @Udf(description = "Returns a masked version of the input string. All characters of the input"
       + " will be replaced according to the default masking rules.")
   public String mask(final String input) {

--- a/ksql-engine/src/main/java/io/confluent/ksql/function/udf/string/MaskLeftKudf.java
+++ b/ksql-engine/src/main/java/io/confluent/ksql/function/udf/string/MaskLeftKudf.java
@@ -14,7 +14,6 @@
 
 package io.confluent.ksql.function.udf.string;
 
-import io.confluent.ksql.function.KsqlFunctionException;
 import io.confluent.ksql.function.udf.Udf;
 import io.confluent.ksql.function.udf.UdfDescription;
 
@@ -24,6 +23,8 @@ import io.confluent.ksql.function.udf.UdfDescription;
         + " Default masking rules will replace all upper-case characters with 'X', all lower-case"
         + " characters with 'x', all digits with 'n', and any other character with '-'.")
 public class MaskLeftKudf {
+
+  private final String udfName = this.getClass().getAnnotation(UdfDescription.class).name();
 
   @Udf(description = "Returns a masked version of the input string. The first n characters"
       + " will be replaced according to the default masking rules.")
@@ -49,7 +50,7 @@ public class MaskLeftKudf {
   }
 
   private String doMask(Masker masker, final String input, final int numChars) {
-    validateParams(numChars);
+    Masker.validateParams(udfName, numChars);
     if (input == null) {
       return null;
     }
@@ -58,12 +59,5 @@ public class MaskLeftKudf {
     output.append(masker.mask(input.substring(0, charsToMask)));
     output.append(input.substring(charsToMask));
     return output.toString();
-  }
-
-  private void validateParams(int numChars) {
-    if (numChars < 0) {
-      throw new KsqlFunctionException(
-          "mask_left requires a non-negative number of characters to mask");
-    }
   }
 }

--- a/ksql-engine/src/main/java/io/confluent/ksql/function/udf/string/MaskRightKudf.java
+++ b/ksql-engine/src/main/java/io/confluent/ksql/function/udf/string/MaskRightKudf.java
@@ -14,7 +14,6 @@
 
 package io.confluent.ksql.function.udf.string;
 
-import io.confluent.ksql.function.KsqlFunctionException;
 import io.confluent.ksql.function.udf.Udf;
 import io.confluent.ksql.function.udf.UdfDescription;
 
@@ -24,6 +23,8 @@ import io.confluent.ksql.function.udf.UdfDescription;
         + " Default masking rules will replace all upper-case characters with 'X', all lower-case"
         + " characters with 'x', all digits with 'n', and any other character with '-'.")
 public class MaskRightKudf {
+
+  private final String udfName = this.getClass().getAnnotation(UdfDescription.class).name();
 
   @Udf(description = "Returns a masked version of the input string. The last n characters"
       + " will be replaced according to the default masking rules.")
@@ -49,7 +50,7 @@ public class MaskRightKudf {
   }
 
   private String doMask(final Masker masker, final String input, final int numChars) {
-    validateParams(numChars);
+    Masker.validateParams(udfName, numChars);
     if (input == null) {
       return null;
     }
@@ -58,12 +59,5 @@ public class MaskRightKudf {
     output.append(input.substring(0, charsToKeep));
     output.append(masker.mask(input.substring(charsToKeep)));
     return output.toString();
-  }
-
-  private void validateParams(final int numChars) {
-    if (numChars < 0) {
-      throw new KsqlFunctionException(
-          "mask_right requires a non-negative number of characters to mask");
-    }
   }
 }

--- a/ksql-engine/src/main/java/io/confluent/ksql/function/udf/string/Masker.java
+++ b/ksql-engine/src/main/java/io/confluent/ksql/function/udf/string/Masker.java
@@ -14,6 +14,8 @@
 
 package io.confluent.ksql.function.udf.string;
 
+import io.confluent.ksql.function.KsqlFunctionException;
+
 class Masker {
 
   private static final int DEFAULT_UPPERCASE_MASK = 'X';
@@ -71,7 +73,14 @@ class Masker {
     return c;
   }
 
-  static int getMaskCharacter(String stringMask) {
+  static int getMaskCharacter(final String stringMask) {
     return stringMask == null ? NO_MASK : stringMask.codePointAt(0);
+  }
+
+  static void validateParams(final String udfName, final int numChars) {
+    if (numChars < 0) {
+      throw new KsqlFunctionException(
+          "function " + udfName + " requires a non-negative number of characters to mask or skip");
+    }
   }
 }

--- a/ksql-engine/src/test/java/io/confluent/ksql/function/udf/string/MaskKeepLeftKudfTest.java
+++ b/ksql-engine/src/test/java/io/confluent/ksql/function/udf/string/MaskKeepLeftKudfTest.java
@@ -43,7 +43,7 @@ public class MaskKeepLeftKudfTest {
   @Test
   public void shouldThrowIfLengthIsNegative() {
     expectedException.expect(KsqlFunctionException.class);
-    expectedException.expectMessage("mask_keep_left requires a non-negative number");
+    expectedException.expectMessage("function mask_keep_left requires a non-negative number");
     final String result = udf.mask("AbCd#$123xy Z", -1);
  }
 

--- a/ksql-engine/src/test/java/io/confluent/ksql/function/udf/string/MaskKeepRightKudfTest.java
+++ b/ksql-engine/src/test/java/io/confluent/ksql/function/udf/string/MaskKeepRightKudfTest.java
@@ -43,7 +43,7 @@ public class MaskKeepRightKudfTest {
   @Test
   public void shouldThrowIfLengthIsNegative() {
     expectedException.expect(KsqlFunctionException.class);
-    expectedException.expectMessage("mask_keep_right requires a non-negative number");
+    expectedException.expectMessage("function mask_keep_right requires a non-negative number");
     final String result = udf.mask("AbCd#$123xy Z", -1);
  }
 

--- a/ksql-engine/src/test/java/io/confluent/ksql/function/udf/string/MaskLeftKudfTest.java
+++ b/ksql-engine/src/test/java/io/confluent/ksql/function/udf/string/MaskLeftKudfTest.java
@@ -43,7 +43,7 @@ public class MaskLeftKudfTest {
   @Test
   public void shouldThrowIfLengthIsNegative() {
     expectedException.expect(KsqlFunctionException.class);
-    expectedException.expectMessage("mask_left requires a non-negative number");
+    expectedException.expectMessage("function mask_left requires a non-negative number");
     final String result = udf.mask("AbCd#$123xy Z", -1);
   }
 

--- a/ksql-engine/src/test/java/io/confluent/ksql/function/udf/string/MaskRightKudfTest.java
+++ b/ksql-engine/src/test/java/io/confluent/ksql/function/udf/string/MaskRightKudfTest.java
@@ -43,7 +43,7 @@ public class MaskRightKudfTest {
   @Test
   public void shouldThrowIfLengthIsNegative() {
     expectedException.expect(KsqlFunctionException.class);
-    expectedException.expectMessage("mask_right requires a non-negative number");
+    expectedException.expectMessage("function mask_right requires a non-negative number");
     final String result = udf.mask("AbCd#$123xy Z", -1);
   }
 


### PR DESCRIPTION
Small follow-on change from #1482 to tighten and re-use a little UDF-parameter validation logic for the new string-masking functions, per @apurvam 's comments.