### PR TITLE
Fix spacing in struct schema string

### DIFF
--- a/ksql-parser/src/main/java/io/confluent/ksql/parser/ExpressionFormatter.java
+++ b/ksql-parser/src/main/java/io/confluent/ksql/parser/ExpressionFormatter.java
@@ -116,10 +116,9 @@ public final class ExpressionFormatter {
     @Override
     protected String visitStruct(Struct node, Boolean unmangleNames) {
       return "STRUCT<" + Joiner.on(", ").join(node.getItems().stream()
-                                                .map((child) ->
-                                                         child.getLeft()
-                                                         + process(child.getRight(), unmangleNames))
-                                                .collect(toList())) + ">";
+          .map((child) ->
+              child.getLeft() + " " + process(child.getRight(), unmangleNames))
+          .collect(toList())) + ">";
     }
 
     @Override

--- a/ksql-parser/src/test/java/io/confluent/ksql/parser/ExpressionFormatterTest.java
+++ b/ksql-parser/src/test/java/io/confluent/ksql/parser/ExpressionFormatterTest.java
@@ -17,9 +17,15 @@
 
 package io.confluent.ksql.parser;
 
+import com.google.common.collect.ImmutableList;
+import io.confluent.ksql.parser.tree.Array;
+import io.confluent.ksql.parser.tree.Map;
+import io.confluent.ksql.parser.tree.PrimitiveType;
+import io.confluent.ksql.parser.tree.Struct;
+import io.confluent.ksql.parser.tree.Type;
+import io.confluent.ksql.util.Pair;
 import org.junit.Test;
 
-import java.util.Arrays;
 import java.util.Collections;
 import java.util.Optional;
 import java.util.concurrent.TimeUnit;
@@ -348,4 +354,28 @@ public class ExpressionFormatterTest {
     assertThat(ExpressionFormatter.formatExpression(new InListExpression(Collections.singletonList(new StringLiteral("a")))), equalTo("('a')"));
   }
 
+  @Test
+  public void shouldFormatStruct() {
+    final Struct struct
+        = new Struct(
+            ImmutableList.of(
+                new Pair<>("field1", new PrimitiveType(Type.KsqlType.INTEGER)),
+                new Pair<>("field2", new PrimitiveType(Type.KsqlType.STRING))
+            ));
+    assertThat(
+        ExpressionFormatter.formatExpression(struct),
+        equalTo("STRUCT<field1 INTEGER, field2 STRING>"));
+  }
+
+  @Test
+  public void shouldFormatMap() {
+    final Map map = new Map(new PrimitiveType(Type.KsqlType.BIGINT));
+    assertThat(ExpressionFormatter.formatExpression(map), equalTo("MAP<VARCHAR, BIGINT>"));
+  }
+
+  @Test
+  public void shouldFormatArray() {
+    final Array array = new Array(new PrimitiveType(Type.KsqlType.BOOLEAN));
+    assertThat(ExpressionFormatter.formatExpression(array), equalTo("ARRAY<BOOLEAN>"));
+  }
 }

--- a/ksql-parser/src/test/java/io/confluent/ksql/parser/SqlFormatterTest.java
+++ b/ksql-parser/src/test/java/io/confluent/ksql/parser/SqlFormatterTest.java
@@ -237,6 +237,5 @@ public class SqlFormatterTest {
         + "FROM ADDRESS A\n"
         + "  \n"));
   }
-
 }
 


### PR DESCRIPTION
Add a space between the field name and type when generating sql string
from expression

### Description 
_What behavior do you want to change, why, how does your patch achieve the changes?_

### Testing done 
_Describe the testing stategy. Unit and integration tests are expected for any behavior changes._

### Reviewer checklist
- [ ] Ensure docs are updated if necessary. (eg. if a user visible feature is being added or changed).
- [ ] Ensure relevant issues are linked (description should include text like "Fixes #<issue number>")

