### PR TITLE
Add unit tests for deserializing a comprehensive set of avro/connect …

### DIFF
--- a/ksql-serde/src/main/java/io/confluent/ksql/serde/connect/ConnectDataTranslator.java
+++ b/ksql-serde/src/main/java/io/confluent/ksql/serde/connect/ConnectDataTranslator.java
@@ -73,17 +73,11 @@ public class ConnectDataTranslator implements DataTranslator {
                             final Schema schema,
                             final Schema connectSchema,
                             final Schema.Type... validTypes) {
-    Arrays.asList(validTypes).stream()
+    Arrays.stream(validTypes)
         .filter(connectSchema.type()::equals)
         .findFirst()
         .orElseThrow(
             () -> createTypeMismatchException(pathStr, schema, connectSchema));
-  }
-
-  private void validateType(final String pathStr,
-                            final Schema schema,
-                            final Schema connectSchema) {
-    validateType(pathStr, schema, connectSchema, schema.type());
   }
 
   private void validateSchema(final String pathStr,
@@ -95,7 +89,7 @@ public class ConnectDataTranslator implements DataTranslator {
       case ARRAY:
       case MAP:
       case STRUCT:
-        validateType(pathStr, schema, connectSchema);
+        validateType(pathStr, schema, connectSchema, schema.type());
         break;
       case INT64:
         validateType(

--- a/ksql-serde/src/main/java/io/confluent/ksql/serde/util/SerdeUtils.java
+++ b/ksql-serde/src/main/java/io/confluent/ksql/serde/util/SerdeUtils.java
@@ -20,7 +20,6 @@ import io.confluent.ksql.util.KsqlException;
 import java.util.Objects;
 
 public class SerdeUtils {
-
   public static boolean toBoolean(final Object object) {
     Objects.requireNonNull(object, "Object cannot be null");
     if (object instanceof Boolean) {

--- a/ksql-serde/src/test/java/io/confluent/ksql/serde/avro/KsqlGenericRowAvroDeserializerTest.java
+++ b/ksql-serde/src/test/java/io/confluent/ksql/serde/avro/KsqlGenericRowAvroDeserializerTest.java
@@ -242,7 +242,7 @@ public class KsqlGenericRowAvroDeserializerTest {
     map.put(AbstractKafkaAvroSerDeConfig.SCHEMA_REGISTRY_URL_CONFIG, "");
     final KafkaAvroSerializer kafkaAvroSerializer = new KafkaAvroSerializer(schemaRegistryClient, map);
 
-    byte[] bytes = kafkaAvroSerializer.serialize("test-topic", avroRecord);
+    final byte[] bytes = kafkaAvroSerializer.serialize("test-topic", avroRecord);
 
     final Deserializer<GenericRow> deserializer =
         new KsqlAvroTopicSerDe().getGenericRowSerde(

--- a/ksql-serde/src/test/java/io/confluent/ksql/serde/avro/KsqlGenericRowAvroDeserializerTest.java
+++ b/ksql-serde/src/test/java/io/confluent/ksql/serde/avro/KsqlGenericRowAvroDeserializerTest.java
@@ -19,12 +19,9 @@ package io.confluent.ksql.serde.avro;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import io.confluent.connect.avro.AvroConverter;
-import org.apache.avro.LogicalType;
 import org.apache.avro.LogicalTypes;
 import org.apache.avro.generic.GenericData;
-import org.apache.avro.generic.GenericDatumWriter;
 import org.apache.avro.generic.GenericRecord;
-import org.apache.avro.io.DatumWriter;
 import org.apache.kafka.common.serialization.Deserializer;
 import org.apache.kafka.connect.data.Schema;
 import org.apache.kafka.connect.data.SchemaBuilder;
@@ -54,7 +51,7 @@ import static org.hamcrest.CoreMatchers.equalTo;
 
 
 public class KsqlGenericRowAvroDeserializerTest {
-  final String schemaStr = "{"
+  private final String schemaStr = "{"
                      + "\"namespace\": \"kql\","
                      + " \"name\": \"orders\","
                      + " \"type\": \"record\","
@@ -70,9 +67,9 @@ public class KsqlGenericRowAvroDeserializerTest {
                      + " ]"
                      + "}";
 
-  final Schema schema;
-  final org.apache.avro.Schema avroSchema;
-  final KsqlConfig ksqlConfig;
+  private final Schema schema;
+  private final org.apache.avro.Schema avroSchema;
+  private final KsqlConfig ksqlConfig;
 
   public KsqlGenericRowAvroDeserializerTest() {
     final org.apache.avro.Schema.Parser parser = new org.apache.avro.Schema.Parser();
@@ -103,19 +100,13 @@ public class KsqlGenericRowAvroDeserializerTest {
   @SuppressWarnings("unchecked")
   public void shouldDeserializeCorrectly() {
     final SchemaRegistryClient schemaRegistryClient = new MockSchemaRegistryClient();
-    final List columns = Arrays.asList(
-        1511897796092L, 1L, "item_1", 10.0, Arrays.asList((Double)100.0),
+    final List<Object> columns = Arrays.asList(
+        1511897796092L, 1L, "item_1", 10.0, Collections.singletonList(100.0),
         Collections.singletonMap("key1", 100.0));
 
     final GenericRow genericRow = new GenericRow(columns);
-
-    final Deserializer<GenericRow> deserializer =
-        new KsqlAvroTopicSerDe().getGenericRowSerde(
-            schema, ksqlConfig, false, schemaRegistryClient).deserializer();
-
-    final byte[] serializedRow = getSerializedRow("t1", schemaRegistryClient, avroSchema, genericRow);
-
-    final GenericRow row = deserializer.deserialize("t1", serializedRow);
+    final GenericRow row = serializeDeserializeRow(
+        schema, "t1", schemaRegistryClient, avroSchema, genericRow);
     Assert.assertNotNull(row);
     assertThat("Incorrect deserializarion", row.getColumns().size(), equalTo(6));
     assertThat("Incorrect deserializarion", row.getColumns().get(0), equalTo(1511897796092L));
@@ -140,23 +131,19 @@ public class KsqlGenericRowAvroDeserializerTest {
         .field("orderunits".toUpperCase(), Schema.OPTIONAL_FLOAT64_SCHEMA)
         .build();
     final SchemaRegistryClient schemaRegistryClient = new MockSchemaRegistryClient();
-    final List columns = Arrays.asList(
+    final List<Object> columns = Arrays.asList(
         1511897796092L, 1L, "item_1", 10.0, Collections.emptyList(), Collections.emptyMap());
 
-    GenericRow genericRow = new GenericRow(columns);
+    final GenericRow genericRow = new GenericRow(columns);
+    final GenericRow row = serializeDeserializeRow(
+        newSchema, "t1", schemaRegistryClient, avroSchema, genericRow);
 
-    final Deserializer<GenericRow> deserializer =
-        new KsqlAvroTopicSerDe().getGenericRowSerde(
-            newSchema, ksqlConfig, false, schemaRegistryClient).deserializer();
-
-    byte[] serializedRow = getSerializedRow("t1", schemaRegistryClient, avroSchema, genericRow);
-    final GenericRow row = deserializer.deserialize("t1", serializedRow);
     Assert.assertNotNull(row);
     assertThat("Incorrect deserializarion", row.getColumns().size(), equalTo(4));
-    assertThat("Incorrect deserializarion", (Long)row.getColumns().get(0), equalTo(1511897796092L));
-    assertThat("Incorrect deserializarion", (Long)row.getColumns().get(1), equalTo
+    assertThat("Incorrect deserializarion", row.getColumns().get(0), equalTo(1511897796092L));
+    assertThat("Incorrect deserializarion", row.getColumns().get(1), equalTo
         (1L));
-    assertThat("Incorrect deserializarion", (String)row.getColumns().get(2), equalTo
+    assertThat("Incorrect deserializarion", row.getColumns().get(2), equalTo
         ( "item_1"));
   }
 
@@ -177,41 +164,51 @@ public class KsqlGenericRowAvroDeserializerTest {
     final org.apache.avro.Schema.Parser parser = new org.apache.avro.Schema.Parser();
     final org.apache.avro.Schema avroSchema1 = parser.parse(schemaStr1);
     final SchemaRegistryClient schemaRegistryClient = new MockSchemaRegistryClient();
-    final List columns = Arrays.asList(1511897796092L, 1L, "item_1", 10.0);
+    final List<Object> columns = Arrays.asList(1511897796092L, 1L, "item_1", 10.0);
 
     final GenericRow genericRow = new GenericRow(columns);
-    final byte[] serializedRow = getSerializedRow("t1", schemaRegistryClient, avroSchema1, genericRow);
+    final GenericRow row = serializeDeserializeRow(
+        schema, "t1", schemaRegistryClient, avroSchema1, genericRow);
 
-    Deserializer<GenericRow> deserializer =
-        new KsqlAvroTopicSerDe().getGenericRowSerde(
-            schema, ksqlConfig, false, schemaRegistryClient).deserializer();
-
-    final GenericRow row = deserializer.deserialize("t1", serializedRow);
     assertThat("Incorrect deserializarion", row.getColumns().size(), equalTo(6));
-    assertThat("Incorrect deserializarion", (Long)row.getColumns().get(0), equalTo(1511897796092L));
-    assertThat("Incorrect deserializarion", (Long)row.getColumns().get(1), equalTo
+    assertThat("Incorrect deserializarion", row.getColumns().get(0), equalTo(1511897796092L));
+    assertThat("Incorrect deserializarion", row.getColumns().get(1), equalTo
         (1L));
-    assertThat("Incorrect deserializarion", (String)row.getColumns().get(2), equalTo
+    assertThat("Incorrect deserializarion", row.getColumns().get(2), equalTo
         ( "item_1"));
     Assert.assertNull(row.getColumns().get(4));
     Assert.assertNull(row.getColumns().get(5));
   }
 
-  private byte[] getSerializedRow(String topicName, SchemaRegistryClient schemaRegistryClient,
-                                  org.apache.avro.Schema rowAvroSchema,
-                                  GenericRow genericRow) {
-    final Map map = new HashMap();
-    // Automatically register the schema in the Schema Registry if it has not been registered.
+  private GenericRow serializeDeserializeAvroRecord(final Schema schema,
+                                                    final String topicName,
+                                                    final SchemaRegistryClient schemaRegistryClient,
+                                                    final GenericRecord avroRecord) {
+    final Map<String, Object> map = new HashMap<>();
     map.put(AbstractKafkaAvroSerDeConfig.AUTO_REGISTER_SCHEMAS, true);
     map.put(AbstractKafkaAvroSerDeConfig.SCHEMA_REGISTRY_URL_CONFIG, "");
     final KafkaAvroSerializer kafkaAvroSerializer = new KafkaAvroSerializer(schemaRegistryClient, map);
+
+    final byte[] bytes = kafkaAvroSerializer.serialize(topicName, avroRecord);
+
+    final Deserializer<GenericRow> deserializer =
+        new KsqlAvroTopicSerDe().getGenericRowSerde(
+            schema, ksqlConfig, false, schemaRegistryClient).deserializer();
+
+    return deserializer.deserialize(topicName, bytes);
+  }
+
+  private GenericRow serializeDeserializeRow(final Schema schema,
+                                             final String topicName,
+                                             final SchemaRegistryClient schemaRegistryClient,
+                                             final org.apache.avro.Schema rowAvroSchema,
+                                             final GenericRow genericRow) {
     final GenericRecord avroRecord = new GenericData.Record(rowAvroSchema);
     final List<org.apache.avro.Schema.Field> fields = rowAvroSchema.getFields();
     for (int i = 0; i < genericRow.getColumns().size(); i++) {
       avroRecord.put(fields.get(i).name(), genericRow.getColumns().get(i));
     }
-
-    return kafkaAvroSerializer.serialize(topicName, avroRecord);
+    return serializeDeserializeAvroRecord(schema, topicName, schemaRegistryClient, avroRecord);
   }
 
   private void shouldDeserializeTypeCorrectly(final org.apache.avro.Schema avroSchema,
@@ -237,18 +234,8 @@ public class KsqlGenericRowAvroDeserializerTest {
     final GenericRecord avroRecord = new GenericData.Record(avroRecordSchema);
     avroRecord.put("field0", avroValue);
 
-    final Map map = new HashMap();
-    map.put(AbstractKafkaAvroSerDeConfig.AUTO_REGISTER_SCHEMAS, true);
-    map.put(AbstractKafkaAvroSerDeConfig.SCHEMA_REGISTRY_URL_CONFIG, "");
-    final KafkaAvroSerializer kafkaAvroSerializer = new KafkaAvroSerializer(schemaRegistryClient, map);
-
-    final byte[] bytes = kafkaAvroSerializer.serialize("test-topic", avroRecord);
-
-    final Deserializer<GenericRow> deserializer =
-        new KsqlAvroTopicSerDe().getGenericRowSerde(
-            ksqlRecordSchema, ksqlConfig, false, schemaRegistryClient).deserializer();
-
-    final GenericRow row = deserializer.deserialize("test-topic", bytes);
+    final GenericRow row = serializeDeserializeAvroRecord(
+        ksqlRecordSchema, "test-topic", schemaRegistryClient, avroRecord);
 
     assertThat(row.getColumns().size(), equalTo(1));
     assertThat(row.getColumns().get(0), equalTo(ksqlValue));

--- a/ksql-serde/src/test/java/io/confluent/ksql/serde/connect/ConnectDataTranslatorTest.java
+++ b/ksql-serde/src/test/java/io/confluent/ksql/serde/connect/ConnectDataTranslatorTest.java
@@ -163,6 +163,7 @@ public class ConnectDataTranslatorTest {
     } catch (DataException e) {
       assertThat(e.getMessage(), containsString(Schema.Type.STRING.getName()));
       assertThat(e.getMessage(), containsString(Schema.Type.INT32.getName()));
+      assertThat(e.getMessage(), containsString("FIELD"));
     }
   }
 
@@ -239,6 +240,7 @@ public class ConnectDataTranslatorTest {
     } catch (DataException e) {
       assertThat(e.getMessage(), containsString(Schema.Type.INT32.getName()));
       assertThat(e.getMessage(), containsString(Schema.Type.STRING.getName()));
+      assertThat(e.getMessage(), containsString("STRUCT->INT"));
     }
   }
 


### PR DESCRIPTION
…types

This patch adds unit tests for deserializing the various avro and connect types
into their compatible ksql types. It also includes fixes for a few issues found
from testing:
    - conversion of int8/16/32 to larger integer types
    - conversion of logical types into valid ksql types
    - better error message when there is a type mismatch

### Description 
_What behavior do you want to change, why, how does your patch achieve the changes?_

### Testing done 
_Describe the testing stategy. Unit and integration tests are expected for any behavior changes._

### Reviewer checklist
- [ ] Ensure docs are updated if necessary. (eg. if a user visible feature is being added or changed).
- [ ] Ensure relevant issues are linked (description should include text like "Fixes #<issue number>")

