### PR TITLE
Reduce log level when loading blacklist to INFO from ERROR

### DIFF
--- a/ext/resource-blacklist.txt
+++ b/ext/resource-blacklist.txt
@@ -1,14 +1,14 @@
 # Classes/Packages that aren't allowed to be loaded by UDFs.
 # if a class name ends with $ it will only match that class
-# otherwise it will match anything beginning with the string
-java.lang.Compiler$
-java.lang.instrument
-java.lang.invoke
-java.lang.management
-java.lang.Process
-java.lang.ref
-java.lang.Shutdown
-java.lang.Thread
-java.util.concurrent
-java.util.jar
-java.util.zip
+# otherwise it will match anything beginning with the string.
+
+# For example, the following line would match only the java.lang.Compiler class.
+#java.lang.Compiler$
+
+# The following line would match any classes that begin with java.lang.Compiler
+#java.lang.Compiler
+
+# The following line would match any classes that are in the java.lang.invoke package
+#java.lang.invoke
+
+

--- a/ksql-engine/src/main/java/io/confluent/ksql/function/Blacklist.java
+++ b/ksql-engine/src/main/java/io/confluent/ksql/function/Blacklist.java
@@ -72,7 +72,7 @@ public class Blacklist implements Predicate<String> {
       }
       logger.info("Setting UDF blacklisted classes to: " + blackList);
     } catch (final IOException e) {
-      logger.info("Failed to load resource blacklist from {}"
+      logger.warn("Failed to load resource blacklist from {}"
           + " no classes will be blacklisted", inputFile);
     }
   }

--- a/ksql-engine/src/main/java/io/confluent/ksql/function/Blacklist.java
+++ b/ksql-engine/src/main/java/io/confluent/ksql/function/Blacklist.java
@@ -47,13 +47,17 @@ import java.util.stream.Collectors;
  */
 public class Blacklist implements Predicate<String> {
   private static final Logger logger = LoggerFactory.getLogger(Blacklist.class);
-  private static final String BLACKLIST_ALL = ".*";
+  private static final String BLACKLIST_NONE = "";
   private static final String BLACKLIST_PREFIX = "^(?:";
   private static final String BLACKLIST_SUFFIX = ")\\.?.*$";
 
-  private String blackList = BLACKLIST_ALL;
+  private String blackList = BLACKLIST_NONE;
 
   Blacklist(final File inputFile) {
+    if (!inputFile.exists()) {
+      logger.info("Blacklist file: {} not found. No classes will be blacklisted", inputFile);
+      return;
+    }
     try {
       this.blackList = Files.readLines(inputFile, Charset.forName(StandardCharsets.UTF_8.name()))
           .stream()
@@ -64,12 +68,12 @@ public class Blacklist implements Predicate<String> {
           .collect(Collectors.joining("|", BLACKLIST_PREFIX, BLACKLIST_SUFFIX));
 
       if (this.blackList.equals(BLACKLIST_PREFIX + BLACKLIST_SUFFIX)) {
-        this.blackList = "";
+        this.blackList = BLACKLIST_NONE;
       }
       logger.info("Setting UDF blacklisted classes to: " + blackList);
-    } catch (IOException e) {
-      logger.error("failed to load resource blacklist from " + inputFile
-          + " all classes will be blacklisted");
+    } catch (final IOException e) {
+      logger.info("Failed to load resource blacklist from {}"
+          + " no classes will be blacklisted", inputFile);
     }
   }
 

--- a/ksql-engine/src/test/java/io/confluent/ksql/function/BlacklistTest.java
+++ b/ksql-engine/src/test/java/io/confluent/ksql/function/BlacklistTest.java
@@ -60,13 +60,13 @@ public class BlacklistTest {
 
   @SuppressWarnings("ResultOfMethodCallIgnored")
   @Test
-  public void shouldBlacklistEverythingIfFailsToLoadFile() {
+  public void shouldNotBlacklistAnythingIfFailsToLoadFile() {
     blacklistFile.delete();
     final Blacklist blacklist = new Blacklist(this.blacklistFile);
-    assertTrue(blacklist.test("java.lang.Process"));
-    assertTrue(blacklist.test("java.util.List"));
-    assertTrue(blacklist.test("java.lang.ProcessEnvironment"));
-    assertTrue(blacklist.test("java.lang.Class"));
+    assertFalse(blacklist.test("java.lang.Process"));
+    assertFalse(blacklist.test("java.util.List"));
+    assertFalse(blacklist.test("java.lang.ProcessEnvironment"));
+    assertFalse(blacklist.test("java.lang.Class"));
   }
 
   @SuppressWarnings("ResultOfMethodCallIgnored")


### PR DESCRIPTION
- Reduce log level to WARN when can't load the blacklist file.
- Update blacklisting such that no classes are blacklisted if the file is not found or can't be loaded.
- Change the default file such that it allows everything.

Fixes #1515


### Testing done 
Updated unit test

### Reviewer checklist
- [ ] Ensure docs are updated if necessary. (eg. if a user visible feature is being added or changed).
- [ ] Ensure relevant issues are linked (description should include text like "Fixes #<issue number>")

