### PR TITLE
Java 10 support

### DIFF
--- a/ksql-engine/pom.xml
+++ b/ksql-engine/pom.xml
@@ -102,7 +102,7 @@
         <dependency>
             <groupId>io.github.lukehutch</groupId>
             <artifactId>fast-classpath-scanner</artifactId>
-            <version>2.21</version>
+            <version>3.1.6</version>
         </dependency>
 
         <!-- Required for running tests -->

--- a/ksql-engine/src/main/java/io/confluent/ksql/function/UdfLoader.java
+++ b/ksql-engine/src/main/java/io/confluent/ksql/function/UdfLoader.java
@@ -117,8 +117,11 @@ public class UdfLoader {
   private void loadUdfs(final ClassLoader loader, final Optional<Path> path) {
     final String pathLoadedFrom
         = path.map(Path::toString).orElse(KsqlFunction.INTERNAL_PATH);
-    new FastClasspathScanner()
-        .overrideClassLoaders(loader)
+    final FastClasspathScanner fastClasspathScanner = new FastClasspathScanner();
+    if (loader != parentClassLoader) {
+      fastClasspathScanner.overrideClassLoaders(loader);
+    }
+    fastClasspathScanner
         .ignoreParentClassLoaders()
         // if we are loading from the parent classloader then restrict the name space to only
         // jars/dirs containing "ksql-engine". This is so we don't end up scanning every jar


### PR DESCRIPTION
### Description 
Update the version of fast-classpath-scanner to 3.1.6 which supports java 9+.
One fix in `UDFLoader` so that it works with the built-in UDFs

Fixes #1523

### Testing done 
Ran build on java 10 & java 8

### Reviewer checklist
- [ ] Ensure docs are updated if necessary. (eg. if a user visible feature is being added or changed).
- [ ] Ensure relevant issues are linked (description should include text like "Fixes #<issue number>")
