### PR TITLE
Include monitoring interceptor config in streams configs

### DIFF
--- a/ksql-common/src/main/java/io/confluent/ksql/util/KsqlConfig.java
+++ b/ksql-common/src/main/java/io/confluent/ksql/util/KsqlConfig.java
@@ -416,8 +416,7 @@ public class KsqlConfig extends AbstractConfig implements Cloneable {
         .forEach(
             configValue -> props.put(
                 configValue.key,
-                ConfigDef.convertToString(configValue.value, configValue.type.get()))
-        );
+                ConfigDef.convertToString(configValue.value, configValue.type.get())));
     return Collections.unmodifiableMap(props);
   }
 

--- a/ksql-common/src/test/java/io/confluent/ksql/util/KsqlConfigTest.java
+++ b/ksql-common/src/test/java/io/confluent/ksql/util/KsqlConfigTest.java
@@ -28,6 +28,7 @@ import org.hamcrest.core.IsEqual;
 import org.junit.Test;
 
 import static org.hamcrest.CoreMatchers.equalTo;
+import static org.hamcrest.CoreMatchers.hasItem;
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.CoreMatchers.not;
 import static org.hamcrest.CoreMatchers.nullValue;
@@ -138,7 +139,16 @@ public class KsqlConfigTest {
   }
 
   @Test
-  public void shouldCleanStreamsProperties() {
+  public void shouldSetMonitoringInterceptorConfigProperties() {
+    final KsqlConfig ksqlConfig = new KsqlConfig(Collections.singletonMap(
+        "confluent.monitoring.interceptor.topic", "foo"));
+    final Object result
+        = ksqlConfig.getKsqlStreamConfigProps().get("confluent.monitoring.interceptor.topic");
+    assertThat(result, equalTo("foo"));
+  }
+
+  @Test
+  public void shouldObfuscateSecretStreamsProperties() {
     final String password = "super-secret-password";
     final KsqlConfig ksqlConfig = new KsqlConfig(Collections.singletonMap(
         SslConfigs.SSL_KEY_PASSWORD_CONFIG, password
@@ -150,6 +160,14 @@ public class KsqlConfigTest {
         ksqlConfig.getKsqlConfigPropsWithSecretsObfuscated().get(SslConfigs.SSL_KEY_PASSWORD_CONFIG),
         not(equalTo(password))
     );
+  }
+
+  @Test
+  public void shouldFilterPropertiesForWhichTypeUnknown() {
+    final KsqlConfig ksqlConfig = new KsqlConfig(Collections.singletonMap("you.shall.not.pass", "wizard"));
+    assertThat(
+        ksqlConfig.getAllConfigPropsWithSecretsObfuscated().keySet(),
+        not(hasItem("you.shall.not.pass")));
   }
 
   @Test


### PR DESCRIPTION
This patch fixes a problem in KsqlConfig where monitoring interceptor
configs were not included in streams configs. The fix involves including
configs for which we could not resolve a type in the streams config map.
Such configs are passed to streams but filtered from the secret-obfuscating
calls.

### Description 
_What behavior do you want to change, why, how does your patch achieve the changes?_

### Testing done 
_Describe the testing stategy. Unit and integration tests are expected for any behavior changes._

### Reviewer checklist
- [ ] Ensure docs are updated if necessary. (eg. if a user visible feature is being added or changed).
- [ ] Ensure relevant issues are linked (description should include text like "Fixes #<issue number>")

