### PR TITLE
Include example schemas in the packaging build

### DIFF
--- a/ksql-examples/src/assembly/package.xml
+++ b/ksql-examples/src/assembly/package.xml
@@ -20,6 +20,13 @@
             </includes>
         </fileSet>
         <fileSet>
+            <directory>src/main/resources</directory>
+            <outputDirectory>share/resources/ksql-examples</outputDirectory>
+            <includes>
+                <include>*.avro</include>
+            </includes>
+        </fileSet>
+        <fileSet>
             <directory>${project.parent.basedir}</directory>
             <outputDirectory></outputDirectory>
             <includes>


### PR DESCRIPTION
### Description 
Today, the system tests run downstream of packaging. This can be evidenced by lines like this in the system test output:

 ```
python -m muckrake_runner.run_tests muckrake/tests/ --aws --num-workers 40 --install-type tarball --resource-url https://s3-us-west-2.amazonaws.com/jenkins-confluent-packages/5.0.x/48/archive/5.0/confluent-5.0.0-SNAPSHOT-2.11.tar.gz --results-root /home/jenkins/workspace/st-confluent-platform_5.0.x-CR42KGVJVSIDOZSYD6BWYUIUM3NQVDLBM2BHHPXMVWKP2V3SVVBA/results --parallel
```

As mentioned here (https://github.com/confluentinc/muckrake/pull/570#discussion_r196894404) our hard coding of the path for the schema files would be a problem with from-package system test runs.

That is indeed a problem. But the larger problem is that the schema files are not packaged at all tarballs:

```
amehta-macbook-pro-2:confluent-5.0.0-SNAPSHOT apurva$ find . -name "*.avro"
amehta-macbook-pro-2:confluent-5.0.0-SNAPSHOT apurva$
```

This patch adds the schema files to the maven assembly. It is probably the first step in getting the schema files packaged in the eventual tarballs. Once we achieve the latter, we need to update the system tests to look for the schema files in the unpacked tarball location.

### Testing done 
`mvn package` results in the schema files showing up in `ksql-examples/target/ksql-examples-5.1.0-SNAPSHOT-package/share/resources/ksql-examples/`

### Reviewer checklist
- [ ] Ensure docs are updated if necessary. (eg. if a user visible feature is being added or changed).
- [ ] Ensure relevant issues are linked (description should include text like "Fixes #<issue number>")

