### PR TITLE
Ensure that the list of interceptors is modifiable before mutating it

### DIFF
--- a/ksql-engine/src/main/java/io/confluent/ksql/physical/PhysicalPlanBuilder.java
+++ b/ksql-engine/src/main/java/io/confluent/ksql/physical/PhysicalPlanBuilder.java
@@ -319,6 +319,7 @@ public class PhysicalPlanBuilder {
     return String.format("%s_%d", original, System.currentTimeMillis());
   }
 
+  @SuppressWarnings("unchecked")
   private void updateListProperty(Map<String, Object> properties, String key, Object value) {
     Object obj = properties.getOrDefault(key, new LinkedList<String>());
     List valueList;
@@ -330,7 +331,9 @@ public class PhysicalPlanBuilder {
       String asString = (String) obj;
       valueList = new LinkedList<>(Arrays.asList(asString.split("\\s*,\\s*")));
     } else if (obj instanceof List) {
-      valueList = (List) obj;
+      // The incoming list could be an instance of an immutable list. So we create a modifiable
+      // List out of it to ensure that it is mutable.
+      valueList = new LinkedList<>((List) obj);
     } else {
       throw new KsqlException("Expecting list or string for property: " + key);
     }

--- a/ksql-engine/src/test/java/io/confluent/ksql/integration/IntegrationTestHarness.java
+++ b/ksql-engine/src/test/java/io/confluent/ksql/integration/IntegrationTestHarness.java
@@ -7,6 +7,7 @@ import org.apache.kafka.clients.consumer.ConsumerRecord;
 import org.apache.kafka.clients.consumer.KafkaConsumer;
 import org.apache.kafka.clients.producer.KafkaProducer;
 import org.apache.kafka.clients.producer.ProducerConfig;
+import org.apache.kafka.clients.producer.ProducerInterceptor;
 import org.apache.kafka.clients.producer.ProducerRecord;
 import org.apache.kafka.clients.producer.RecordMetadata;
 import org.apache.kafka.common.serialization.ByteArrayDeserializer;
@@ -245,6 +246,22 @@ public class IntegrationTestHarness {
   EmbeddedSingleNodeKafkaCluster embeddedKafkaCluster = null;
 
 
+  public static class DummyProducerInterceptor implements ProducerInterceptor {
+
+    public void onAcknowledgement(RecordMetadata rm, Exception e) {
+    }
+
+    public ProducerRecord onSend(ProducerRecord producerRecords) {
+      return producerRecords;
+    }
+
+    public void close() {
+    }
+
+    public void configure(Map<String, ?> map) {
+    }
+  }
+
 
   public void start(final Map<String, Object> callerConfigMap) throws Exception {
     embeddedKafkaCluster = new EmbeddedSingleNodeKafkaCluster();
@@ -257,6 +274,7 @@ public class IntegrationTestHarness {
     configMap.put("cache.max.bytes.buffering", 0);
     configMap.put("auto.offset.reset", "earliest");
     configMap.put(StreamsConfig.STATE_DIR_CONFIG, TestUtils.tempDirectory().getPath());
+    configMap.put("producer.interceptor.classes", DummyProducerInterceptor.class.getName());
     configMap.putAll(callerConfigMap);
 
     this.ksqlConfig = new KsqlConfig(configMap);


### PR DESCRIPTION
### Description 
Fixes #1545 .

The `PhysicalPlanBuilder` assumes that the list of interceptors is a modifiable list. This is an unsafe assumption which is no longer true. 

This patch simply copies the existing list into a modifiable LinkedList which should always be modifiable.

### Testing done 
Added an integration test which ensures that the list of interceptors can be modified by the `PhysicalPlanBuilder`.

### Reviewer checklist
- [ ] Ensure docs are updated if necessary. (eg. if a user visible feature is being added or changed).
- [ ] Ensure relevant issues are linked (description should include text like "Fixes #<issue number>")

