### PR TITLE
Improve error messages for Avro/SR interaction. 

### DIFF
--- a/ksql-common/src/main/java/io/confluent/ksql/util/KsqlConstants.java
+++ b/ksql-common/src/main/java/io/confluent/ksql/util/KsqlConstants.java
@@ -48,4 +48,9 @@ public class KsqlConstants {
 
   public static final String DOT = ".";
   public static final String STRUCT_FIELD_REF = "->";
+
+  public static final String DOC_URL_SR_SERIALISER =
+          "https://docs.confluent.io/current/schema-registry/docs/serializer-formatter.html";
+  public static final String DOC_URL_SR_REST_GETSUBJECTS =
+          "https://docs.confluent.io/current/schema-registry/docs/api.html#get--subjects";
 }

--- a/ksql-engine/src/main/java/io/confluent/ksql/util/AvroUtil.java
+++ b/ksql-engine/src/main/java/io/confluent/ksql/util/AvroUtil.java
@@ -87,15 +87,18 @@ public class AvroUtil {
       return abstractStreamCreateStatementCopy;
 
     } catch (final Exception e) {
-      throw new KsqlException("KSQL does not currently support the Avro schema for topic "+kafkaTopicName+
-              ".\nReason: " + e.getMessage()+"\n\n"+
-              "Please see https://github.com/confluentinc/ksql/issues/ to see if this particular reason is already\n"+
-              "known, and if not log a new issue. Please include the full Avro schema that you are trying to use."
+      throw new KsqlException("Unable to verify if the Avro schema for topic " + kafkaTopicName
+              + " is compatible with KSQL.\nReason: " + e.getMessage() + "\n\n"
+              + "Please see https://github.com/confluentinc/ksql/issues/ to see if this "
+              + "particular reason is already\n"
+              + "known, and if not log a new issue. Please include the full Avro schema "
+              + "that you are trying to use."
       );
     }
   }
 
-  private static SchemaMetadata getSchemaMetadata(final AbstractStreamCreateStatement abstractStreamCreateStatement,
+  private static SchemaMetadata getSchemaMetadata(final AbstractStreamCreateStatement
+                                                          abstractStreamCreateStatement,
                                                   final SchemaRegistryClient schemaRegistryClient,
                                                   final String kafkaTopicName) {
     try {
@@ -106,23 +109,27 @@ public class AvroUtil {
       );
     } catch (final RestClientException e) {
       if (e.getStatus() == HttpStatus.SC_NOT_FOUND) {
-        throw new KsqlException("Avro schema for message values on topic " + kafkaTopicName +
-                " does not exist in the Schema Registry.\n"+
-                "Subject: " + kafkaTopicName + KsqlConstants.SCHEMA_REGISTRY_VALUE_SUFFIX + "\n\n" +
-                "Possible causes include:\n" +
-                "- The topic itself does not exist\n"+
-                "\t-> Use SHOW TOPICS; to check\n" +
-                "- Messages on the topic are not Avro serialized\n" +
-                "\t-> Use PRINT '"+ kafkaTopicName+"' FROM BEGINNING; to verify\n" +
-                "- Messages on the topic have not been serialized using the Confluent Schema Registry Avro serializer\n" +
-                "\t-> See https://docs.confluent.io/current/schema-registry/docs/serializer-formatter.html\n" +
-                "- The schema is registered on a different instance of the Schema Registry\n" +
-                "\t-> Use the REST API to list available subjects\n\t   https://docs.confluent.io/current/schema-registry/docs/api.html#get--subjects\n"
+        throw new KsqlException("Avro schema for message values on topic " + kafkaTopicName
+                + " does not exist in the Schema Registry.\n"
+                + "Subject: " + kafkaTopicName + KsqlConstants.SCHEMA_REGISTRY_VALUE_SUFFIX + "\n\n"
+                + "Possible causes include:\n"
+                + "- The topic itself does not exist\n"
+                + "\t-> Use SHOW TOPICS; to check\n"
+                + "- Messages on the topic are not Avro serialized\n"
+                + "\t-> Use PRINT '" + kafkaTopicName + "' FROM BEGINNING; to verify\n"
+                + "- Messages on the topic have not been serialized using the Confluent Schema "
+                + "Registry Avro serializer\n"
+                + "\t-> See " + KsqlConstants.DOC_URL_SR_SERIALISER + "\n"
+                + "- The schema is registered on a different instance of the Schema Registry\n"
+                + "\t-> Use the REST API to list available subjects\n\t"
+                + KsqlConstants.DOC_URL_SR_REST_GETSUBJECTS + "\n"
                 );
       }
-      throw new KsqlException("Schema registry fetch for topic " + kafkaTopicName + " request failed.\n", e);
+      throw new KsqlException("Schema registry fetch for topic " + kafkaTopicName
+              + " request failed.\n", e);
     } catch (final Exception e) {
-      throw new KsqlException("Schema registry fetch for topic " + kafkaTopicName + " request failed.\n", e);
+      throw new KsqlException("Schema registry fetch for topic " + kafkaTopicName
+              + " request failed.\n", e);
     }
   }
 

--- a/ksql-engine/src/test/java/io/confluent/ksql/util/AvroUtilTest.java
+++ b/ksql-engine/src/test/java/io/confluent/ksql/util/AvroUtilTest.java
@@ -21,6 +21,7 @@ import io.confluent.ksql.parser.tree.PrimitiveType;
 import io.confluent.ksql.serde.avro.AvroSchemaTranslator;
 import org.apache.kafka.connect.data.Schema;
 import org.easymock.EasyMock;
+import org.junit.Rule;
 import org.junit.Test;
 
 import java.io.IOException;
@@ -42,6 +43,7 @@ import io.confluent.ksql.parser.tree.Statement;
 import io.confluent.ksql.parser.tree.TableElement;
 import io.confluent.ksql.parser.tree.Type;
 import io.confluent.ksql.serde.avro.KsqlAvroTopicSerDe;
+import org.junit.rules.ExpectedException;
 
 import static org.easymock.EasyMock.anyObject;
 import static org.easymock.EasyMock.anyString;
@@ -53,6 +55,9 @@ import static org.hamcrest.CoreMatchers.equalTo;
 import static org.junit.Assert.fail;
 
 public class AvroUtilTest {
+
+  @Rule
+  public final ExpectedException expectedException = ExpectedException.none();
 
   private String ordersAvroSchemaStr = "{"
                      + "\"namespace\": \"kql\","
@@ -95,25 +100,56 @@ public class AvroUtilTest {
   }
 
   @Test
-  public void shouldNotPassAvroCheckIfSchemaDoesNotExist() throws Exception {
-    SchemaRegistryClient schemaRegistryClient = mock(SchemaRegistryClient.class);
-    SchemaMetadata schemaMetadata = new SchemaMetadata(1, 1, null);
+  public void shouldThrowIfAvroSchemaNotCompatibleWithKsql() throws Exception {
+    expectedException.expect(KsqlException.class);
+    expectedException.expectMessage(
+            "KSQL does not currently support the Avro schema for topic s1_topic.\n" +
+                    "Reason: No name in schema: {\"type\":\"record\"}\n" +
+                    "\n" +
+                    "Please see https://github.com/confluentinc/ksql/issues/ to see if this particular reason is already\n" +
+                    "known, and if not log a new issue. Please include the full Avro schema that you are trying to use.");
+
+    final SchemaRegistryClient schemaRegistryClient = mock(SchemaRegistryClient.class);
+    final SchemaMetadata schemaMetadata = new SchemaMetadata(1, 1, "{\"type\": \"record\"}");
     expect(schemaRegistryClient.getLatestSchemaMetadata(anyString())).andReturn(schemaMetadata);
     replay(schemaRegistryClient);
-    AbstractStreamCreateStatement abstractStreamCreateStatement = getAbstractStreamCreateStatement
+    final AbstractStreamCreateStatement abstractStreamCreateStatement = getAbstractStreamCreateStatement
         ("CREATE STREAM S1 WITH "
          + "(kafka_topic='s1_topic', "
          + "value_format='avro' );");
-    try {
-      AvroUtil.checkAndSetAvroSchema(abstractStreamCreateStatement, new HashMap<>(), schemaRegistryClient);
-      fail();
-    } catch (Exception e) {
-      assertThat("Expected different message message.", e.getMessage().trim(),
-          equalTo("Unable to verify the AVRO schema is compatible with KSQL. null"));
-    }
+
+    AvroUtil.checkAndSetAvroSchema(abstractStreamCreateStatement, new HashMap<>(), schemaRegistryClient);
   }
 
+  @Test
+  public void shouldNotPassAvroCheckIfSchemaDoesNotExist() throws Exception {
+    expectedException.expect(KsqlException.class);
+    expectedException.expectMessage(
+            "Avro schema for message values on topic s1_topic does not exist in the Schema Registry.\n" +
+                    "Subject: s1_topic-value\n" +
+                    "\n" +
+                    "Possible causes include:\n" +
+                    "- The topic itself does not exist\n" +
+                    "\t-> Use SHOW TOPICS; to check\n" +
+                    "- Messages on the topic are not Avro serialized\n" +
+                    "\t-> Use PRINT 's1_topic' FROM BEGINNING; to verify\n" +
+                    "- Messages on the topic have not been serialized using the Confluent Schema Registry Avro serializer\n" +
+                    "\t-> See https://docs.confluent.io/current/schema-registry/docs/serializer-formatter.html\n" +
+                    "- The schema is registered on a different instance of the Schema Registry\n" +
+                    "\t-> Use the REST API to list available subjects\n" +
+                    "\t   https://docs.confluent.io/current/schema-registry/docs/api.html#get--subjects\n");
 
+    final SchemaRegistryClient schemaRegistryClient = mock(SchemaRegistryClient.class);
+    expect(schemaRegistryClient.getLatestSchemaMetadata(anyString()))
+            .andThrow(new RestClientException("Not found", 404, 40401));
+    replay(schemaRegistryClient);
+    final AbstractStreamCreateStatement abstractStreamCreateStatement = getAbstractStreamCreateStatement
+        ("CREATE STREAM S1 WITH "
+         + "(kafka_topic='s1_topic', "
+         + "value_format='avro' );");
+
+    AvroUtil.checkAndSetAvroSchema(abstractStreamCreateStatement, new HashMap<>(), schemaRegistryClient);
+  }
 
   private PersistentQueryMetadata buildStubPersistentQueryMetadata(Schema resultSchema,
                                                                    KsqlTopic resultTopic) {

--- a/ksql-engine/src/test/java/io/confluent/ksql/util/AvroUtilTest.java
+++ b/ksql-engine/src/test/java/io/confluent/ksql/util/AvroUtilTest.java
@@ -103,7 +103,7 @@ public class AvroUtilTest {
   public void shouldThrowIfAvroSchemaNotCompatibleWithKsql() throws Exception {
     expectedException.expect(KsqlException.class);
     expectedException.expectMessage(
-            "KSQL does not currently support the Avro schema for topic s1_topic.\n" +
+            "Unable to verify if the Avro schema for topic s1_topic is compatible with KSQL.\n" +
                     "Reason: No name in schema: {\"type\":\"record\"}\n" +
                     "\n" +
                     "Please see https://github.com/confluentinc/ksql/issues/ to see if this particular reason is already\n" +
@@ -136,8 +136,8 @@ public class AvroUtilTest {
                     "- Messages on the topic have not been serialized using the Confluent Schema Registry Avro serializer\n" +
                     "\t-> See https://docs.confluent.io/current/schema-registry/docs/serializer-formatter.html\n" +
                     "- The schema is registered on a different instance of the Schema Registry\n" +
-                    "\t-> Use the REST API to list available subjects\n" +
-                    "\t   https://docs.confluent.io/current/schema-registry/docs/api.html#get--subjects\n");
+                    "\t-> Use the REST API to list available subjects\n\t" +
+                    "https://docs.confluent.io/current/schema-registry/docs/api.html#get--subjects\n");
 
     final SchemaRegistryClient schemaRegistryClient = mock(SchemaRegistryClient.class);
     expect(schemaRegistryClient.getLatestSchemaMetadata(anyString()))


### PR DESCRIPTION
Fixes #707, #1555, helps with #713

### Description 

Existing error message is ambiguous and too generic. Has led to lots of confusion in the community. This is intended to address that. 

Two error conditions are handled, with the current/new messages as below: 

#### Schema not compatible

##### Current

```
ksql> create stream twitter with (kafka_topic='twitter_avro_03',value_format='avro');
 Unable to verify the AVRO schema is compatible with KSQL. Map key must be of type STRING
```

##### New

```
ksql> create stream twitter with (kafka_topic='twitter_avro_03',value_format='avro');
KSQL does not currently support the Avro schema for topic twitter_avro_03.
Reason: Map key must be of type STRING

Please see https://github.com/confluentinc/ksql/issues/ to see if this particular reason is already
known, and if not log a new issue. Please include the full Avro schema that you are trying to use.
```

#### Schema not found

##### Current

```
ksql> create stream wh with (kafka_topic='warehouse_location2', value_format='avro');
 Unable to verify the AVRO schema is compatible with KSQL. Subject not found.; error code: 40401
```

##### New

```
ksql> create stream wh with (kafka_topic='warehouse_location', value_format='avro');
Avro schema for message values on topic warehouse_location does not exist in the Schema Registry.
Subject: warehouse_location-value

Possible causes include:
- The topic itself does not exist
        -> Use SHOW TOPICS; to check
- Messages on the topic are not Avro serialized
        -> Use PRINT 'warehouse_location' FROM BEGINNING; to verify
- Messages on the topic have not been serialized using the Confluent Schema Registry Avro serializer
        -> See https://docs.confluent.io/current/schema-registry/docs/serializer-formatter.html
- The schema is registered on a different instance of the Schema Registry
        -> Use the REST API to list available subjects
           https://docs.confluent.io/current/schema-registry/docs/api.html#get--subjects
```

### Testing done 

Updated relevant tests in `AvroUtilTest`.

### Reviewer checklist
- [ ] Ensure docs are updated if necessary. (eg. if a user visible feature is being added or changed).
- [ ] Ensure relevant issues are linked (description should include text like "Fixes #<issue number>")

