### PR TITLE
Add example avro schemas to the ksql packaging build

### DIFF
--- a/ksql-package/src/assembly/package.xml
+++ b/ksql-package/src/assembly/package.xml
@@ -45,6 +45,14 @@
                 <include>*</include>
             </includes>
         </fileSet>
+        <fileSet>
+            <directory>${project.parent.basedir}/ksql-examples/src/main/resources</directory>
+            <outputDirectory>resources/example-schemas</outputDirectory>
+            <includes>
+                <include>*.avro</include>
+            </includes>
+        </fileSet>
+
     </fileSets>
     <dependencySets>
         <dependencySet>


### PR DESCRIPTION
### Description 
Follow up for #1528, the previous patch didn't include the schemas in the right module.

### Testing done 
Ran a build and verified that the avro schemas were found in `ksql-examples/target/ksql-package-5.0.0-SNAPSHOT/resources/example-schemas`.

### Reviewer checklist
- [ ] Ensure docs are updated if necessary. (eg. if a user visible feature is being added or changed).
- [ ] Ensure relevant issues are linked (description should include text like "Fixes #<issue number>")

