### PR TITLE
hide internal functions from list/show command

### DIFF
--- a/ksql-common/src/main/java/io/confluent/ksql/function/AggregateFunctionFactory.java
+++ b/ksql-common/src/main/java/io/confluent/ksql/function/AggregateFunctionFactory.java
@@ -32,7 +32,7 @@ public abstract class AggregateFunctionFactory {
 
   public AggregateFunctionFactory(final String functionName,
                                   final List<KsqlAggregateFunction<?, ?>> aggregateFunctionList) {
-    this(new UdfMetadata(functionName, "", "confluent", "", KsqlFunction.INTERNAL_PATH),
+    this(new UdfMetadata(functionName, "", "confluent", "", KsqlFunction.INTERNAL_PATH, false),
         aggregateFunctionList);
   }
 
@@ -71,5 +71,9 @@ public abstract class AggregateFunctionFactory {
 
   protected List<KsqlAggregateFunction<?, ?>> getAggregateFunctionList() {
     return aggregateFunctionList;
+  }
+
+  public boolean isInternal() {
+    return metadata.isInternal();
   }
 }

--- a/ksql-common/src/main/java/io/confluent/ksql/function/UdfFactory.java
+++ b/ksql-common/src/main/java/io/confluent/ksql/function/UdfFactory.java
@@ -95,6 +95,10 @@ public class UdfFactory {
     functions.values().forEach(consumer);
   }
 
+  public boolean isInternal() {
+    return metadata.isInternal();
+  }
+
   public String getPath() {
     return metadata.getPath();
   }

--- a/ksql-common/src/main/java/io/confluent/ksql/function/udf/UdfMetadata.java
+++ b/ksql-common/src/main/java/io/confluent/ksql/function/udf/UdfMetadata.java
@@ -24,18 +24,20 @@ public class UdfMetadata {
   private final String author;
   private final String version;
   private final String path;
+  private final boolean internal;
 
   public UdfMetadata(final String name,
                      final String description,
                      final String author,
                      final String version,
-                     final String path
-  ) {
+                     final String path,
+                     final boolean internal) {
     this.name = Objects.requireNonNull(name, "name cant be null");
     this.description = Objects.requireNonNull(description, "description can't be null");
     this.author = Objects.requireNonNull(author, "author can't be null");
     this.version = Objects.requireNonNull(version, "version can't be null");
     this.path = Objects.requireNonNull(path, "path can't be null");
+    this.internal = internal;
   }
 
   public String getName() {
@@ -58,6 +60,10 @@ public class UdfMetadata {
     return path;
   }
 
+  public boolean isInternal() {
+    return internal;
+  }
+
   @Override
   public String toString() {
     return "UdfMetadata{"
@@ -66,6 +72,7 @@ public class UdfMetadata {
         + ", author='" + author + '\''
         + ", version='" + version + '\''
         + ", path='" + path + "'"
+        + ", internal=" + internal
         + '}';
   }
 }

--- a/ksql-common/src/test/java/io/confluent/ksql/function/TestFunctionRegistry.java
+++ b/ksql-common/src/test/java/io/confluent/ksql/function/TestFunctionRegistry.java
@@ -44,7 +44,7 @@ public class TestFunctionRegistry implements FunctionRegistry {
             "",
             "",
             "",
-            "")));
+            "", false)));
     final UdfFactory udfFactory = udfs.get(ksqlFunction.getFunctionName());
     udfFactory.addFunction(ksqlFunction);  }
 

--- a/ksql-common/src/test/java/io/confluent/ksql/function/UdfFactoryTest.java
+++ b/ksql-common/src/test/java/io/confluent/ksql/function/UdfFactoryTest.java
@@ -41,7 +41,7 @@ public class UdfFactoryTest {
 
   private final String functionName = "TestFunc";
   private final UdfFactory factory = new UdfFactory(TestFunc.class,
-      new UdfMetadata(functionName, "", "", "", "internal"));
+      new UdfMetadata(functionName, "", "", "", "internal", false));
   
   @Test
   public void shouldThrowIfNoVariantFoundThatAcceptsSuppliedParamTypes() {

--- a/ksql-engine/src/main/java/io/confluent/ksql/function/InternalFunctionRegistry.java
+++ b/ksql-engine/src/main/java/io/confluent/ksql/function/InternalFunctionRegistry.java
@@ -92,14 +92,18 @@ public class InternalFunctionRegistry implements FunctionRegistry {
   @SuppressWarnings("unchecked")
   @Override
   public void addFunction(final KsqlFunction ksqlFunction) {
+    addFunction(ksqlFunction, false);
+  }
+
+  private void addFunction(final KsqlFunction ksqlFunction, final boolean internal) {
     addFunctionFactory(new UdfFactory(
         ksqlFunction.getKudfClass(),
         new UdfMetadata(ksqlFunction.getFunctionName(),
             ksqlFunction.getDescription(),
             "confluent",
             "",
-            KsqlFunction.INTERNAL_PATH
-            )));
+            KsqlFunction.INTERNAL_PATH,
+            internal)));
     final UdfFactory udfFactory = ksqlFunctionMap.get(ksqlFunction.getFunctionName().toUpperCase());
     udfFactory.addFunction(ksqlFunction);
   }
@@ -328,7 +332,7 @@ public class InternalFunctionRegistry implements FunctionRegistry {
             Schema.STRING_SCHEMA),
         FetchFieldFromStruct.FUNCTION_NAME,
         FetchFieldFromStruct.class);
-    addFunction(fetchFieldFromStruct);
+    addFunction(fetchFieldFromStruct, true);
   }
 
   private void addUdafFunctions() {

--- a/ksql-engine/src/main/java/io/confluent/ksql/function/UdfLoader.java
+++ b/ksql-engine/src/main/java/io/confluent/ksql/function/UdfLoader.java
@@ -188,7 +188,8 @@ public class UdfLoader {
               udafAnnotation.description(),
               udafAnnotation.author(),
               udafAnnotation.version(),
-              path),
+              path,
+              false),
               aggregateFunctions));
     };
   }
@@ -241,7 +242,8 @@ public class UdfLoader {
             classLevelAnnotaion.description(),
             classLevelAnnotaion.author(),
             classLevelAnnotaion.version(),
-            path)));
+            path,
+            false)));
 
     metaStore.addFunction(new KsqlFunction(
         SchemaUtil.getSchemaFromType(method.getReturnType()),

--- a/ksql-rest-app/src/main/java/io/confluent/ksql/rest/server/resources/KsqlResource.java
+++ b/ksql-rest-app/src/main/java/io/confluent/ksql/rest/server/resources/KsqlResource.java
@@ -549,10 +549,12 @@ public class KsqlResource {
   private KsqlEntity listFunctions(final String statementText) {
     final List<SimpleFunctionInfo> all = ksqlEngine.listScalarFunctions()
         .stream()
+        .filter(factory -> !factory.isInternal())
         .map(factory -> new SimpleFunctionInfo(factory.getName().toUpperCase(),
             FunctionType.scalar)).collect(Collectors.toList());
     all.addAll(ksqlEngine.listAggregateFunctions()
         .stream()
+        .filter(factory -> !factory.isInternal())
         .map(factory -> new SimpleFunctionInfo(factory.getName().toUpperCase(),
             FunctionType.aggregate))
         .collect(Collectors.toList()));

--- a/ksql-rest-app/src/test/java/io/confluent/ksql/rest/server/resources/KsqlResourceTest.java
+++ b/ksql-rest-app/src/test/java/io/confluent/ksql/rest/server/resources/KsqlResourceTest.java
@@ -109,6 +109,7 @@ import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.CoreMatchers.hasItem;
 import static org.hamcrest.CoreMatchers.hasItems;
 import static org.hamcrest.CoreMatchers.instanceOf;
+import static org.hamcrest.Matchers.not;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertThat;
 import static org.junit.Assert.assertTrue;
@@ -376,7 +377,12 @@ public class KsqlResourceTest {
         new SimpleFunctionInfo("CONCAT", FunctionType.scalar),
         new SimpleFunctionInfo("TOPK", FunctionType.aggregate),
         new SimpleFunctionInfo("MAX", FunctionType.aggregate)));
+
+    // shouldn't contain internal functions
+    assertThat(functionList.getFunctions(),
+        not(hasItem(new SimpleFunctionInfo("FETCH_FIELD_FROM_STRUCT", FunctionType.aggregate))));
   }
+
 
   @Test
   public void shouldReturnDescriptionsForShowStreamsExtended() {


### PR DESCRIPTION
### Description 
We should hide internal UDFs that aren't supposed to be used by ksql users, i.e., FETCH_FIELD_FROM_STRUCT.

### Testing done 
Updated `KsqlResourceTest` to ensure internal functions aren't returned

### Reviewer checklist
- [ ] Ensure docs are updated if necessary. (eg. if a user visible feature is being added or changed).
- [ ] Ensure relevant issues are linked (description should include text like "Fixes #<issue number>")

