### PR TITLE
Specify a namespace for avro schemas

### DIFF
--- a/ksql-common/src/main/java/io/confluent/ksql/util/KsqlConstants.java
+++ b/ksql-common/src/main/java/io/confluent/ksql/util/KsqlConstants.java
@@ -48,4 +48,8 @@ public class KsqlConstants {
 
   public static final String DOT = ".";
   public static final String STRUCT_FIELD_REF = "->";
+
+  public static final String AVRO_SCHEMA_NAMESPACE = "io.confluent.ksql.avro_schemas";
+  public static final String AVRO_SCHEMA_NAME = "KsqlDataSourceSchema";
+  public static final String AVRO_SCHEMA_FULL_NAME = AVRO_SCHEMA_NAMESPACE + "." + AVRO_SCHEMA_NAME;
 }

--- a/ksql-serde/src/main/java/io/confluent/ksql/serde/avro/AvroDataTranslator.java
+++ b/ksql-serde/src/main/java/io/confluent/ksql/serde/avro/AvroDataTranslator.java
@@ -21,6 +21,7 @@ import com.google.common.collect.Iterables;
 import io.confluent.ksql.GenericRow;
 import io.confluent.ksql.serde.connect.ConnectDataTranslator;
 import io.confluent.ksql.serde.connect.DataTranslator;
+import io.confluent.ksql.util.KsqlConstants;
 import org.apache.kafka.connect.data.Field;
 import org.apache.kafka.connect.data.Schema;
 import org.apache.kafka.connect.data.SchemaBuilder;
@@ -75,7 +76,6 @@ public class AvroDataTranslator implements DataTranslator {
 
   private static class TypeNameGenerator {
     private static final String DELIMITER = "_";
-    private static final String DEFAULT_SCHEMA_NAME_BASE = "KSQLDefaultSchemaName";
 
     static final String MAP_KEY_NAME = "MapKey";
     static final String MAP_VALUE_NAME = "MapValue";
@@ -83,7 +83,7 @@ public class AvroDataTranslator implements DataTranslator {
     private Iterable<String> names;
 
     TypeNameGenerator() {
-      this(ImmutableList.of(DEFAULT_SCHEMA_NAME_BASE));
+      this(ImmutableList.of(KsqlConstants.AVRO_SCHEMA_FULL_NAME));
     }
 
     private TypeNameGenerator(final Iterable<String> names) {

--- a/ksql-serde/src/test/java/io/confluent/ksql/serde/avro/KsqlGenericRowAvroSerializerTest.java
+++ b/ksql-serde/src/test/java/io/confluent/ksql/serde/avro/KsqlGenericRowAvroSerializerTest.java
@@ -18,6 +18,7 @@ package io.confluent.ksql.serde.avro;
 
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
+import io.confluent.ksql.util.KsqlConstants;
 import org.apache.avro.generic.GenericData;
 import org.apache.avro.generic.GenericRecord;
 import org.apache.avro.util.Utf8;
@@ -201,6 +202,8 @@ public class KsqlGenericRowAvroSerializerTest {
     final KafkaAvroDeserializer deserializer = new KafkaAvroDeserializer(schemaRegistryClient);
     final GenericRecord avroRecord = (GenericRecord) deserializer.deserialize("topic", bytes);
 
+    assertThat(avroRecord.getSchema().getNamespace(), equalTo(KsqlConstants.AVRO_SCHEMA_NAMESPACE));
+    assertThat(avroRecord.getSchema().getName(), equalTo(KsqlConstants.AVRO_SCHEMA_NAME));
     assertThat(avroRecord.getSchema().getFields().size(), equalTo(1));
     final org.apache.avro.Schema.Field field = avroRecord.getSchema().getFields().get(0);
     assertThat(field.schema().getType(), equalTo(org.apache.avro.Schema.Type.UNION));
@@ -306,7 +309,9 @@ public class KsqlGenericRowAvroSerializerTest {
   @Test
   public void shouldSerializeStruct() {
     final org.apache.avro.Schema avroSchema
-        = org.apache.avro.SchemaBuilder.record("KSQLDefaultSchemaName_field0").fields()
+        = org.apache.avro.SchemaBuilder.record(KsqlConstants.AVRO_SCHEMA_NAME + "_field0")
+        .namespace(KsqlConstants.AVRO_SCHEMA_NAMESPACE)
+        .fields()
         .name("field1")
         .type().unionOf().nullType().and().intType().endUnion()
         .nullDefault()


### PR DESCRIPTION
The avro serializer should provide a namespace in the avro schemas that it generates.
This ensures that users can compile the schema into a class that can be imported from
their own java code. Without the namespace, the generated code is placed in the default
package, and cannot be imported.

### Description 
_What behavior do you want to change, why, how does your patch achieve the changes?_

### Testing done 
_Describe the testing stategy. Unit and integration tests are expected for any behavior changes._

### Reviewer checklist
- [ ] Ensure docs are updated if necessary. (eg. if a user visible feature is being added or changed).
- [ ] Ensure relevant issues are linked (description should include text like "Fixes #<issue number>")

