### PR TITLE
Add `@JsonIgnoreProperties(ignoreUnknown = true)` to all model POJOs.

### DIFF
--- a/ksql-rest-app/src/main/java/io/confluent/ksql/rest/entity/CommandStatus.java
+++ b/ksql-rest-app/src/main/java/io/confluent/ksql/rest/entity/CommandStatus.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2017 Confluent Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -17,12 +17,14 @@
 package io.confluent.ksql.rest.entity;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonSubTypes;
 import com.fasterxml.jackson.annotation.JsonTypeName;
 
 import java.util.Objects;
 
+@JsonIgnoreProperties(ignoreUnknown = true)
 @JsonTypeName("commandStatus")
 @JsonSubTypes({})
 public class CommandStatus {

--- a/ksql-rest-app/src/main/java/io/confluent/ksql/rest/entity/CommandStatusEntity.java
+++ b/ksql-rest-app/src/main/java/io/confluent/ksql/rest/entity/CommandStatusEntity.java
@@ -17,6 +17,7 @@
 package io.confluent.ksql.rest.entity;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonTypeInfo;
 
 import java.util.Map;
@@ -24,6 +25,7 @@ import java.util.Objects;
 
 import io.confluent.ksql.rest.server.computation.CommandId;
 
+@JsonIgnoreProperties(ignoreUnknown = true)
 public class CommandStatusEntity extends KsqlEntity {
   private final CommandId commandId;
   private final CommandStatus commandStatus;

--- a/ksql-rest-app/src/main/java/io/confluent/ksql/rest/entity/CommandStatuses.java
+++ b/ksql-rest-app/src/main/java/io/confluent/ksql/rest/entity/CommandStatuses.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2017 Confluent Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -17,15 +17,18 @@
 package io.confluent.ksql.rest.entity;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonSubTypes;
 import com.fasterxml.jackson.annotation.JsonTypeInfo;
 import com.fasterxml.jackson.annotation.JsonTypeName;
-import io.confluent.ksql.rest.server.computation.CommandId;
 
 import java.util.HashMap;
 import java.util.Map;
 import java.util.stream.Collectors;
 
+import io.confluent.ksql.rest.server.computation.CommandId;
+
+@JsonIgnoreProperties(ignoreUnknown = true)
 @JsonTypeName("commandStatuses")
 @JsonTypeInfo(
     include = JsonTypeInfo.As.WRAPPER_OBJECT,

--- a/ksql-rest-app/src/main/java/io/confluent/ksql/rest/entity/EntityQueryId.java
+++ b/ksql-rest-app/src/main/java/io/confluent/ksql/rest/entity/EntityQueryId.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2018 Confluent Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -17,11 +17,14 @@
 package io.confluent.ksql.rest.entity;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonValue;
-import io.confluent.ksql.query.QueryId;
 
 import java.util.Objects;
 
+import io.confluent.ksql.query.QueryId;
+
+@JsonIgnoreProperties(ignoreUnknown = true)
 public class EntityQueryId {
   private final String id;
 

--- a/ksql-rest-app/src/main/java/io/confluent/ksql/rest/entity/ExecutionPlan.java
+++ b/ksql-rest-app/src/main/java/io/confluent/ksql/rest/entity/ExecutionPlan.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2017 Confluent Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -17,10 +17,12 @@
 package io.confluent.ksql.rest.entity;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
 
 import java.util.Objects;
 
+@JsonIgnoreProperties(ignoreUnknown = true)
 public class ExecutionPlan extends KsqlEntity {
 
   private final String executionPlan;

--- a/ksql-rest-app/src/main/java/io/confluent/ksql/rest/entity/FieldInfo.java
+++ b/ksql-rest-app/src/main/java/io/confluent/ksql/rest/entity/FieldInfo.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2018 Confluent Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -17,10 +17,12 @@
 package io.confluent.ksql.rest.entity;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
 
 import java.util.Objects;
 
+@JsonIgnoreProperties(ignoreUnknown = true)
 public class FieldInfo {
   private final String name;
   private final SchemaInfo schema;

--- a/ksql-rest-app/src/main/java/io/confluent/ksql/rest/entity/FunctionDescriptionList.java
+++ b/ksql-rest-app/src/main/java/io/confluent/ksql/rest/entity/FunctionDescriptionList.java
@@ -17,12 +17,14 @@
 package io.confluent.ksql.rest.entity;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
 
 import java.util.Collection;
 import java.util.Collections;
 import java.util.Objects;
 
+@JsonIgnoreProperties(ignoreUnknown = true)
 public class FunctionDescriptionList extends KsqlEntity {
 
   private final String name;

--- a/ksql-rest-app/src/main/java/io/confluent/ksql/rest/entity/FunctionInfo.java
+++ b/ksql-rest-app/src/main/java/io/confluent/ksql/rest/entity/FunctionInfo.java
@@ -17,12 +17,14 @@
 package io.confluent.ksql.rest.entity;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
 
 import java.util.Collections;
 import java.util.List;
 import java.util.Objects;
 
+@JsonIgnoreProperties(ignoreUnknown = true)
 public class FunctionInfo {
 
   private final List<String> argumentTypes;

--- a/ksql-rest-app/src/main/java/io/confluent/ksql/rest/entity/FunctionNameList.java
+++ b/ksql-rest-app/src/main/java/io/confluent/ksql/rest/entity/FunctionNameList.java
@@ -16,12 +16,14 @@
 
 package io.confluent.ksql.rest.entity;
 
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
 
 import java.util.Collection;
 import java.util.Collections;
 import java.util.Objects;
 
+@JsonIgnoreProperties(ignoreUnknown = true)
 public class FunctionNameList extends KsqlEntity {
 
   private final Collection<SimpleFunctionInfo> functionNames;

--- a/ksql-rest-app/src/main/java/io/confluent/ksql/rest/entity/KafkaTopicInfo.java
+++ b/ksql-rest-app/src/main/java/io/confluent/ksql/rest/entity/KafkaTopicInfo.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2017 Confluent Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -17,12 +17,14 @@
 package io.confluent.ksql.rest.entity;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonSubTypes;
 
 import java.util.List;
 import java.util.Objects;
 
+@JsonIgnoreProperties(ignoreUnknown = true)
 @JsonSubTypes({})
 public class KafkaTopicInfo {
 

--- a/ksql-rest-app/src/main/java/io/confluent/ksql/rest/entity/KafkaTopicsList.java
+++ b/ksql-rest-app/src/main/java/io/confluent/ksql/rest/entity/KafkaTopicsList.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2017 Confluent Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -19,6 +19,7 @@ package io.confluent.ksql.rest.entity;
 import com.google.common.base.Preconditions;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
 
 import org.apache.kafka.clients.admin.TopicDescription;
@@ -43,6 +44,7 @@ import io.confluent.ksql.util.KafkaConsumerGroupClientImpl;
 import io.confluent.ksql.util.KsqlConfig;
 import io.confluent.ksql.util.KsqlConstants;
 
+@JsonIgnoreProperties(ignoreUnknown = true)
 public class KafkaTopicsList extends KsqlEntity {
 
   private final Collection<KafkaTopicInfo> topics;

--- a/ksql-rest-app/src/main/java/io/confluent/ksql/rest/entity/KsqlEntity.java
+++ b/ksql-rest-app/src/main/java/io/confluent/ksql/rest/entity/KsqlEntity.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2017 Confluent Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -16,9 +16,11 @@
 
 package io.confluent.ksql.rest.entity;
 
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonSubTypes;
 import com.fasterxml.jackson.annotation.JsonTypeInfo;
 
+@JsonIgnoreProperties(ignoreUnknown = true)
 @JsonTypeInfo(
     use = JsonTypeInfo.Id.NAME,
     include = JsonTypeInfo.As.PROPERTY

--- a/ksql-rest-app/src/main/java/io/confluent/ksql/rest/entity/KsqlEntityList.java
+++ b/ksql-rest-app/src/main/java/io/confluent/ksql/rest/entity/KsqlEntityList.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2017 Confluent Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -16,6 +16,7 @@
 
 package io.confluent.ksql.rest.entity;
 
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonSubTypes;
 
 import java.util.ArrayList;
@@ -25,6 +26,7 @@ import java.util.Collection;
  * Utility class to prevent type erasure from stripping annotation information from KsqlEntity
  * instances in a list
  */
+@JsonIgnoreProperties(ignoreUnknown = true)
 @JsonSubTypes({})
 public class KsqlEntityList extends ArrayList<KsqlEntity> {
   public KsqlEntityList() {

--- a/ksql-rest-app/src/main/java/io/confluent/ksql/rest/entity/KsqlErrorMessage.java
+++ b/ksql-rest-app/src/main/java/io/confluent/ksql/rest/entity/KsqlErrorMessage.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2017 Confluent Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -17,8 +17,10 @@
 package io.confluent.ksql.rest.entity;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonSubTypes;
+import com.fasterxml.jackson.annotation.JsonTypeInfo;
 
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -27,10 +29,10 @@ import java.util.List;
 import java.util.Objects;
 import java.util.stream.Collectors;
 
-import com.fasterxml.jackson.annotation.JsonTypeInfo;
 import io.confluent.ksql.util.ErrorMessageUtil;
 import io.confluent.rest.entities.ErrorMessage;
 
+@JsonIgnoreProperties(ignoreUnknown = true)
 @JsonTypeInfo(
     use = JsonTypeInfo.Id.NAME,
     include = JsonTypeInfo.As.PROPERTY)

--- a/ksql-rest-app/src/main/java/io/confluent/ksql/rest/entity/KsqlRequest.java
+++ b/ksql-rest-app/src/main/java/io/confluent/ksql/rest/entity/KsqlRequest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2017 Confluent Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -17,6 +17,7 @@
 package io.confluent.ksql.rest.entity;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonSubTypes;
 import java.util.Collections;
@@ -24,6 +25,7 @@ import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
 
+@JsonIgnoreProperties(ignoreUnknown = true)
 @JsonSubTypes({})
 public class KsqlRequest {
   private final String ksql;

--- a/ksql-rest-app/src/main/java/io/confluent/ksql/rest/entity/KsqlStatementErrorMessage.java
+++ b/ksql-rest-app/src/main/java/io/confluent/ksql/rest/entity/KsqlStatementErrorMessage.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2018 Confluent Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -16,6 +16,7 @@
 
 package io.confluent.ksql.rest.entity;
 
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
 
 import java.util.Collections;
@@ -24,10 +25,12 @@ import java.util.Objects;
 
 import io.confluent.ksql.util.ErrorMessageUtil;
 
+@JsonIgnoreProperties(ignoreUnknown = true)
 public class KsqlStatementErrorMessage extends KsqlErrorMessage {
   private final String statementText;
   private final KsqlEntityList entities;
 
+  @SuppressWarnings("WeakerAccess") // Invoked via reflection
   public KsqlStatementErrorMessage(
       @JsonProperty("error_code") int errorCode,
       @JsonProperty("message") String message,

--- a/ksql-rest-app/src/main/java/io/confluent/ksql/rest/entity/KsqlTopicInfo.java
+++ b/ksql-rest-app/src/main/java/io/confluent/ksql/rest/entity/KsqlTopicInfo.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2017 Confluent Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -17,14 +17,16 @@
 package io.confluent.ksql.rest.entity;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonSubTypes;
 
-import io.confluent.ksql.serde.DataSource;
-import io.confluent.ksql.metastore.KsqlTopic;
-
 import java.util.Objects;
 
+import io.confluent.ksql.metastore.KsqlTopic;
+import io.confluent.ksql.serde.DataSource;
+
+@JsonIgnoreProperties(ignoreUnknown = true)
 @JsonSubTypes({})
 public class KsqlTopicInfo {
   private final String name;

--- a/ksql-rest-app/src/main/java/io/confluent/ksql/rest/entity/KsqlTopicsList.java
+++ b/ksql-rest-app/src/main/java/io/confluent/ksql/rest/entity/KsqlTopicsList.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2017 Confluent Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -19,6 +19,7 @@ package io.confluent.ksql.rest.entity;
 import com.google.common.base.Preconditions;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
 
 import java.util.ArrayList;
@@ -28,6 +29,7 @@ import java.util.Objects;
 
 import io.confluent.ksql.metastore.KsqlTopic;
 
+@JsonIgnoreProperties(ignoreUnknown = true)
 public class KsqlTopicsList extends KsqlEntity {
   private final Collection<KsqlTopicInfo> topics;
 

--- a/ksql-rest-app/src/main/java/io/confluent/ksql/rest/entity/PropertiesList.java
+++ b/ksql-rest-app/src/main/java/io/confluent/ksql/rest/entity/PropertiesList.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2017 Confluent Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -17,12 +17,14 @@
 package io.confluent.ksql.rest.entity;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
 
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 
+@JsonIgnoreProperties(ignoreUnknown = true)
 public class PropertiesList extends KsqlEntity {
   private final Map<String, ?> properties;
   private final List<String> overwrittenProperties;

--- a/ksql-rest-app/src/main/java/io/confluent/ksql/rest/entity/Queries.java
+++ b/ksql-rest-app/src/main/java/io/confluent/ksql/rest/entity/Queries.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2017 Confluent Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -17,12 +17,14 @@
 package io.confluent.ksql.rest.entity;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
 
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Objects;
 
+@JsonIgnoreProperties(ignoreUnknown = true)
 public class Queries extends KsqlEntity {
   private final List<RunningQuery> queries;
 

--- a/ksql-rest-app/src/main/java/io/confluent/ksql/rest/entity/QueryDescription.java
+++ b/ksql-rest-app/src/main/java/io/confluent/ksql/rest/entity/QueryDescription.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2018 Confluent Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -17,11 +17,8 @@
 package io.confluent.ksql.rest.entity;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
-
-import io.confluent.ksql.rest.util.EntityUtil;
-import io.confluent.ksql.util.PersistentQueryMetadata;
-import io.confluent.ksql.util.QueryMetadata;
 
 import java.util.Collections;
 import java.util.List;
@@ -29,6 +26,11 @@ import java.util.Map;
 import java.util.Objects;
 import java.util.Set;
 
+import io.confluent.ksql.rest.util.EntityUtil;
+import io.confluent.ksql.util.PersistentQueryMetadata;
+import io.confluent.ksql.util.QueryMetadata;
+
+@JsonIgnoreProperties(ignoreUnknown = true)
 public class QueryDescription {
 
   private final EntityQueryId id;

--- a/ksql-rest-app/src/main/java/io/confluent/ksql/rest/entity/QueryDescriptionEntity.java
+++ b/ksql-rest-app/src/main/java/io/confluent/ksql/rest/entity/QueryDescriptionEntity.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2018 Confluent Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -17,10 +17,12 @@
 package io.confluent.ksql.rest.entity;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
 
 import java.util.Objects;
 
+@JsonIgnoreProperties(ignoreUnknown = true)
 public class QueryDescriptionEntity extends KsqlEntity {
   private final QueryDescription queryDescription;
 

--- a/ksql-rest-app/src/main/java/io/confluent/ksql/rest/entity/QueryDescriptionList.java
+++ b/ksql-rest-app/src/main/java/io/confluent/ksql/rest/entity/QueryDescriptionList.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2018 Confluent Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -17,11 +17,13 @@
 package io.confluent.ksql.rest.entity;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
 
 import java.util.List;
 import java.util.Objects;
 
+@JsonIgnoreProperties(ignoreUnknown = true)
 public class QueryDescriptionList extends KsqlEntity {
   private final List<QueryDescription> queryDescriptions;
 

--- a/ksql-rest-app/src/main/java/io/confluent/ksql/rest/entity/RunningQuery.java
+++ b/ksql-rest-app/src/main/java/io/confluent/ksql/rest/entity/RunningQuery.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2018 Confluent Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -17,11 +17,13 @@
 package io.confluent.ksql.rest.entity;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
 
 import java.util.Objects;
 import java.util.Set;
 
+@JsonIgnoreProperties(ignoreUnknown = true)
 public class RunningQuery {
   private final String queryString;
   private final Set<String> sinks;

--- a/ksql-rest-app/src/main/java/io/confluent/ksql/rest/entity/SchemaInfo.java
+++ b/ksql-rest-app/src/main/java/io/confluent/ksql/rest/entity/SchemaInfo.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2018 Confluent Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -17,12 +17,14 @@
 package io.confluent.ksql.rest.entity;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
 
 import java.util.List;
 import java.util.Objects;
 import java.util.Optional;
 
+@JsonIgnoreProperties(ignoreUnknown = true)
 public class SchemaInfo {
   public enum Type {
     INTEGER,

--- a/ksql-rest-app/src/main/java/io/confluent/ksql/rest/entity/ServerInfo.java
+++ b/ksql-rest-app/src/main/java/io/confluent/ksql/rest/entity/ServerInfo.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2017 Confluent Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -17,6 +17,7 @@
 package io.confluent.ksql.rest.entity;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonSubTypes;
 import com.fasterxml.jackson.annotation.JsonTypeInfo;
@@ -24,6 +25,7 @@ import com.fasterxml.jackson.annotation.JsonTypeName;
 
 import java.util.Objects;
 
+@JsonIgnoreProperties(ignoreUnknown = true)
 @JsonTypeInfo(include = JsonTypeInfo.As.WRAPPER_OBJECT, use = JsonTypeInfo.Id.NAME)
 @JsonTypeName("KsqlServerInfo")
 @JsonSubTypes({})

--- a/ksql-rest-app/src/main/java/io/confluent/ksql/rest/entity/SimpleFunctionInfo.java
+++ b/ksql-rest-app/src/main/java/io/confluent/ksql/rest/entity/SimpleFunctionInfo.java
@@ -17,10 +17,12 @@
 package io.confluent.ksql.rest.entity;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
 
 import java.util.Objects;
 
+@JsonIgnoreProperties(ignoreUnknown = true)
 public class SimpleFunctionInfo implements Comparable<SimpleFunctionInfo> {
 
   private final String name;

--- a/ksql-rest-app/src/main/java/io/confluent/ksql/rest/entity/SourceDescription.java
+++ b/ksql-rest-app/src/main/java/io/confluent/ksql/rest/entity/SourceDescription.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2017 Confluent Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -17,6 +17,7 @@
 package io.confluent.ksql.rest.entity;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonSubTypes;
 import com.fasterxml.jackson.annotation.JsonTypeName;
@@ -37,6 +38,7 @@ import io.confluent.ksql.metrics.MetricCollectors;
 import io.confluent.ksql.util.KafkaTopicClient;
 import io.confluent.ksql.util.timestamp.TimestampExtractionPolicy;
 
+@JsonIgnoreProperties(ignoreUnknown = true)
 @JsonTypeName("description")
 @JsonSubTypes({})
 public class SourceDescription {

--- a/ksql-rest-app/src/main/java/io/confluent/ksql/rest/entity/SourceDescriptionEntity.java
+++ b/ksql-rest-app/src/main/java/io/confluent/ksql/rest/entity/SourceDescriptionEntity.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2018 Confluent Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -17,10 +17,12 @@
 package io.confluent.ksql.rest.entity;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
 
 import java.util.Objects;
 
+@JsonIgnoreProperties(ignoreUnknown = true)
 public class SourceDescriptionEntity extends KsqlEntity {
   private final SourceDescription sourceDescription;
 

--- a/ksql-rest-app/src/main/java/io/confluent/ksql/rest/entity/SourceDescriptionList.java
+++ b/ksql-rest-app/src/main/java/io/confluent/ksql/rest/entity/SourceDescriptionList.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2018 Confluent Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -17,11 +17,13 @@
 package io.confluent.ksql.rest.entity;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
 
 import java.util.List;
 import java.util.Objects;
 
+@JsonIgnoreProperties(ignoreUnknown = true)
 public class SourceDescriptionList extends KsqlEntity {
 
   private final List<SourceDescription> sourceDescriptions;

--- a/ksql-rest-app/src/main/java/io/confluent/ksql/rest/entity/SourceInfo.java
+++ b/ksql-rest-app/src/main/java/io/confluent/ksql/rest/entity/SourceInfo.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2018 Confluent Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -17,6 +17,7 @@
 package io.confluent.ksql.rest.entity;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonSubTypes;
 import com.fasterxml.jackson.annotation.JsonTypeInfo;
@@ -28,6 +29,7 @@ import io.confluent.ksql.metastore.KsqlTable;
 import io.confluent.ksql.rest.entity.SourceInfo.Stream;
 import io.confluent.ksql.rest.entity.SourceInfo.Table;
 
+@JsonIgnoreProperties(ignoreUnknown = true)
 @JsonTypeInfo(use = JsonTypeInfo.Id.NAME, include = JsonTypeInfo.As.PROPERTY, property = "type")
 @JsonSubTypes(value = {
     @JsonSubTypes.Type(name = "STREAM", value = Stream.class),
@@ -44,6 +46,7 @@ public class SourceInfo {
     this.format = format;
   }
 
+  @JsonIgnoreProperties(ignoreUnknown = true)
   public static class Stream extends SourceInfo {
     @JsonCreator
     public Stream(
@@ -63,6 +66,7 @@ public class SourceInfo {
     }
   }
 
+  @JsonIgnoreProperties(ignoreUnknown = true)
   public static class Table extends SourceInfo {
     private final boolean isWindowed;
 

--- a/ksql-rest-app/src/main/java/io/confluent/ksql/rest/entity/StreamedRow.java
+++ b/ksql-rest-app/src/main/java/io/confluent/ksql/rest/entity/StreamedRow.java
@@ -17,6 +17,7 @@
 package io.confluent.ksql.rest.entity;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonSubTypes;
 
@@ -27,6 +28,7 @@ import java.util.Objects;
 import io.confluent.ksql.GenericRow;
 import io.confluent.ksql.rest.server.resources.Errors;
 
+@JsonIgnoreProperties(ignoreUnknown = true)
 @JsonSubTypes({})
 public class StreamedRow {
 

--- a/ksql-rest-app/src/main/java/io/confluent/ksql/rest/entity/StreamsList.java
+++ b/ksql-rest-app/src/main/java/io/confluent/ksql/rest/entity/StreamsList.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2017 Confluent Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -17,6 +17,7 @@
 package io.confluent.ksql.rest.entity;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
 
 import java.util.ArrayList;
@@ -24,6 +25,7 @@ import java.util.Collection;
 import java.util.List;
 import java.util.Objects;
 
+@JsonIgnoreProperties(ignoreUnknown = true)
 public class StreamsList extends KsqlEntity {
 
   private final Collection<SourceInfo.Stream> streams;

--- a/ksql-rest-app/src/main/java/io/confluent/ksql/rest/entity/TablesList.java
+++ b/ksql-rest-app/src/main/java/io/confluent/ksql/rest/entity/TablesList.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2017 Confluent Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -17,6 +17,7 @@
 package io.confluent.ksql.rest.entity;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
 
 import java.util.ArrayList;
@@ -24,6 +25,7 @@ import java.util.Collection;
 import java.util.List;
 import java.util.Objects;
 
+@JsonIgnoreProperties(ignoreUnknown = true)
 public class TablesList extends KsqlEntity {
   private final Collection<SourceInfo.Table> tables;
 

--- a/ksql-rest-app/src/main/java/io/confluent/ksql/rest/entity/TopicDescription.java
+++ b/ksql-rest-app/src/main/java/io/confluent/ksql/rest/entity/TopicDescription.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2017 Confluent Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -18,11 +18,12 @@ package io.confluent.ksql.rest.entity;
 
 
 import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
 
 import java.util.Objects;
 
-
+@JsonIgnoreProperties(ignoreUnknown = true)
 public class TopicDescription extends KsqlEntity {
   private final String name;
   private final String kafkaTopic;

--- a/ksql-rest-app/src/test/java/io/confluent/ksql/rest/entity/EntityTest.java
+++ b/ksql-rest-app/src/test/java/io/confluent/ksql/rest/entity/EntityTest.java
@@ -1,0 +1,63 @@
+/*
+ * Copyright 2018 Confluent Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.confluent.ksql.rest.entity;
+
+import com.google.common.collect.ImmutableSet;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+
+import java.util.Collection;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+import io.confluent.ksql.rest.util.ClassFinder;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.notNullValue;
+
+@RunWith(Parameterized.class)
+public class EntityTest {
+  private static final Set<Class<?>> BLACK_LIST = ImmutableSet.<Class<?>>builder()
+      .add(Versions.class)
+      .build();
+
+  private final Class<?> entityClass;
+
+  @Parameterized.Parameters(name = "{0}")
+  public static Collection<Class<?>> data() {
+    return ClassFinder.getClasses(FunctionInfo.class.getPackage().getName()).stream()
+        .filter(type -> !type.isEnum())
+        .filter(type -> !BLACK_LIST.contains(type))
+        .collect(Collectors.toList());
+  }
+
+  public EntityTest(final Class<?> entityClass) {
+    this.entityClass = entityClass;
+  }
+
+  @Test
+  public void shouldBeAttributedWithIgnoreUnknownProperties() {
+    final JsonIgnoreProperties annotation = entityClass.getAnnotation(JsonIgnoreProperties.class);
+    assertThat(entityClass + ": @JsonIgnoreProperties annotation missing", annotation, is(notNullValue()));
+    assertThat(entityClass + ": not ignoring unknown properties", annotation.ignoreUnknown(), is(true));
+  }
+}

--- a/ksql-rest-app/src/test/java/io/confluent/ksql/rest/util/ClassFinder.java
+++ b/ksql-rest-app/src/test/java/io/confluent/ksql/rest/util/ClassFinder.java
@@ -1,0 +1,88 @@
+/*
+ * Copyright 2018 Confluent Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.confluent.ksql.rest.util;
+
+import java.net.URL;
+import java.nio.file.FileSystems;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.PathMatcher;
+import java.nio.file.Paths;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.Enumeration;
+import java.util.List;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+public final class ClassFinder {
+
+  private static final String CLASS_FILE_EXT = ".class";
+  private static final PathMatcher CLASS_MATCHER =
+      FileSystems.getDefault().getPathMatcher("glob:**" + CLASS_FILE_EXT);
+
+  private ClassFinder() {
+  }
+
+  public static List<Class<?>> getClasses(final String packageName) {
+    try {
+      final ClassLoader classLoader = ClassFinder.class.getClassLoader();
+      final String path = packageName.replace('.', '/');
+      final Enumeration<URL> resources = classLoader.getResources(path);
+      final List<Path> dirs = new ArrayList<>();
+      while (resources.hasMoreElements()) {
+        final URL resource = resources.nextElement();
+        if (!resource.toString().contains("/test-classes/")) {
+          dirs.add(Paths.get(resource.getFile()));
+        }
+      }
+
+      return dirs.stream()
+          .flatMap(dir -> findClasses(dir, packageName).stream())
+          .collect(Collectors.toList());
+    } catch (final Exception e) {
+      throw new AssertionError("Failed to load classes in package: " + packageName, e);
+    }
+  }
+
+  private static List<Class<?>> findClasses(final Path directory, final String packageName) {
+    if (!directory.toFile().exists()) {
+      return Collections.emptyList();
+    }
+
+    try (final Stream<Path> paths = Files.walk(directory)) {
+      return paths
+          .filter(Files::isRegularFile)
+          .filter(CLASS_MATCHER::matches)
+          .map(path -> parseClass(packageName, path))
+          .collect(Collectors.toList());
+    } catch (final Exception e) {
+      throw new AssertionError("Failed to load classes in directory: " + directory, e);
+    }
+  }
+
+  private static Class<?> parseClass(final String packageName, final Path path) {
+    try {
+      final String name = path.getFileName().toString();
+      final String className = name.substring(0, name.length() - CLASS_FILE_EXT.length());
+      return Class.forName(packageName + '.' + className);
+    } catch (final Exception e) {
+      throw new RuntimeException(
+          "Failed to get class. packageName:" + packageName + ", path:" + path, e);
+    }
+  }
+}


### PR DESCRIPTION
### Description 

This allows for easier forwards and backwards compatibility between CLI and Server. Without this, any unknown fields in the JSON cause exceptions in the CLI.

Fixes #1626

### Testing done 
Added test to pick up this missing attribute on any new classes added to the `entity` package.

### Reviewer checklist
- [ ] Ensure docs are updated if necessary. (eg. if a user visible feature is being added or changed).
- [ ] Ensure relevant issues are linked (description should include text like "Fixes #<issue number>")

