### PR TITLE
Update docs to state array index starts from 0

### DIFF
--- a/docs/syntax-reference.rst
+++ b/docs/syntax-reference.rst
@@ -243,7 +243,7 @@ The supported column data types are:
 -  ``DOUBLE``
 -  ``VARCHAR`` (or ``STRING``)
 -  ``ARRAY<ArrayType>`` (JSON and AVRO only)
--  ``MAP<VARCHAR, ValueType>`` (JSON and AVRO only)
+-  ``MAP<VARCHAR, ValueType>`` (JSON and AVRO only. Index starts from 0)
 -  ``STRUCT<FieldName FieldType, ...>`` (JSON and AVRO only) The STRUCT type requires you to specify a list of fields.
    For each field you must specify the field name (FieldName) and field type (FieldType). The field type can be any of
    the supported KSQL types, including the complex types ``MAP``, ``ARRAY``, and ``STRUCT``. ``STRUCT`` fields can be

--- a/docs/syntax-reference.rst
+++ b/docs/syntax-reference.rst
@@ -165,7 +165,7 @@ The supported column data types are:
 -  ``BIGINT``
 -  ``DOUBLE``
 -  ``VARCHAR`` (or ``STRING``)
--  ``ARRAY<ArrayType>`` (JSON and AVRO only)
+-  ``ARRAY<ArrayType>`` (JSON and AVRO only. Index starts from 0)
 -  ``MAP<VARCHAR, ValueType>`` (JSON and AVRO only)
 -  ``STRUCT<FieldName FieldType, ...>`` (JSON and AVRO only) The STRUCT type requires you to specify a list of fields.
    For each field you must specify the field name (FieldName) and field type (FieldType). The field type can be any of

--- a/docs/syntax-reference.rst
+++ b/docs/syntax-reference.rst
@@ -242,8 +242,8 @@ The supported column data types are:
 -  ``BIGINT``
 -  ``DOUBLE``
 -  ``VARCHAR`` (or ``STRING``)
--  ``ARRAY<ArrayType>`` (JSON and AVRO only)
--  ``MAP<VARCHAR, ValueType>`` (JSON and AVRO only. Index starts from 0)
+-  ``ARRAY<ArrayType>`` (JSON and AVRO only. Index starts from 0)
+-  ``MAP<VARCHAR, ValueType>`` (JSON and AVRO only)
 -  ``STRUCT<FieldName FieldType, ...>`` (JSON and AVRO only) The STRUCT type requires you to specify a list of fields.
    For each field you must specify the field name (FieldName) and field type (FieldType). The field type can be any of
    the supported KSQL types, including the complex types ``MAP``, ``ARRAY``, and ``STRUCT``. ``STRUCT`` fields can be


### PR DESCRIPTION
### Description 
Update the docs to indicate that array index starts from 0.
Many SQL systems have array index starting from 1 but some others like Hive have array index starting at 0. 
This is the current behavior. We can discuss about if we want to change this to start from 1.

### Testing done 
_Describe the testing stategy. Unit and integration tests are expected for any behavior changes._

### Reviewer checklist
- [ ] Ensure docs are updated if necessary. (eg. if a user visible feature is being added or changed).
- [ ] Ensure relevant issues are linked (description should include text like "Fixes #<issue number>")

