### PR TITLE
Handle QualifiedNameReference when selecting stream/table keys

### DIFF
--- a/docs/syntax-reference.rst
+++ b/docs/syntax-reference.rst
@@ -332,6 +332,11 @@ its corresponding topic.
 If the PARTITION BY clause is present, then the resulting stream will
 have the specified column as its key.
 
+For joins, the key of the resulting stream will be the value from the column
+from the left stream that was used in the join criteria. This column will be
+registered as the key of the resulting stream if included in the selected
+columns.
+
 The WITH clause for the result supports the following properties:
 
 +---------------+------------------------------------------------------------------------------------------------------+
@@ -402,6 +407,11 @@ CREATE TABLE AS SELECT
 Create a new KSQL table along with the corresponding Kafka topic and
 stream the result of the SELECT query as a changelog into the topic.
 Note that the WINDOW clause can only be used if the ``from_item`` is a stream.
+
+For joins, the key of the resulting table will be the value from the column
+from the left table that was used in the join criteria. This column will be
+registered as the key of the resulting table if included in the selected
+columns.
 
 The WITH clause supports the following properties:
 

--- a/ksql-common/src/main/java/io/confluent/ksql/util/SchemaUtil.java
+++ b/ksql-common/src/main/java/io/confluent/ksql/util/SchemaUtil.java
@@ -101,17 +101,16 @@ public class SchemaUtil {
     return typeToSchema.getOrDefault(type, () -> handleParametrizedType(type)).get();
   }
 
+  public static boolean matchFieldName(final Field field, final String fieldName) {
+    return field.name().equals(fieldName)
+        || field.name().equals(fieldName.substring(fieldName.indexOf(".") + 1));
+  }
+
   public static Optional<Field> getFieldByName(final Schema schema, final String fieldName) {
-    if (schema.fields() != null) {
-      for (Field field : schema.fields()) {
-        if (field.name().equals(fieldName)) {
-          return Optional.of(field);
-        } else if (field.name().equals(fieldName.substring(fieldName.indexOf(".") + 1))) {
-          return Optional.of(field);
-        }
-      }
-    }
-    return Optional.empty();
+    return schema.fields()
+        .stream()
+        .filter(f -> matchFieldName(f, fieldName))
+        .findFirst();
   }
 
   public static Schema getTypeSchema(final String sqlType) {

--- a/ksql-common/src/test/java/io/confluent/ksql/util/SchemaUtilTest.java
+++ b/ksql-common/src/test/java/io/confluent/ksql/util/SchemaUtilTest.java
@@ -220,6 +220,24 @@ public class SchemaUtilTest {
   }
 
   @Test
+  public void shouldMatchName() {
+    Field field = new Field("foo", 0, Schema.INT32_SCHEMA);
+    assertThat(SchemaUtil.matchFieldName(field, "foo"), is(true));
+  }
+
+  @Test
+  public void shouldNotMatchDifferentName() {
+    Field field = new Field("foo", 0, Schema.INT32_SCHEMA);
+    assertThat(SchemaUtil.matchFieldName(field, "bar"), is(false));
+  }
+
+  @Test
+  public void shouldMatchNameWithAlias() {
+    Field field = new Field("foo", 0, Schema.INT32_SCHEMA);
+    assertThat(SchemaUtil.matchFieldName(field, "bar.foo"), is(true));
+  }
+
+  @Test
   public void shouldGetTheCorrectFieldName() {
     Optional<Field> field = SchemaUtil.getFieldByName(schema, "orderid".toUpperCase());
     Assert.assertTrue(field.isPresent());

--- a/ksql-engine/src/test/java/io/confluent/ksql/structured/SchemaKStreamTest.java
+++ b/ksql-engine/src/test/java/io/confluent/ksql/structured/SchemaKStreamTest.java
@@ -194,10 +194,14 @@ public class SchemaKStreamTest {
     String selectQuery = "SELECT * FROM test1;";
     PlanNode logicalPlan = planBuilder.buildLogicalPlan(selectQuery);
     ProjectNode projectNode = (ProjectNode) logicalPlan.getSources().get(0);
-    initialSchemaKStream = new SchemaKStream(logicalPlan.getTheSourceNode().getSchema(), kStream,
-        ksqlStream.getKeyField(), new ArrayList<>(),
-        SchemaKStream.Type.SOURCE, ksqlConfig,
-        functionRegistry, schemaRegistryClient);
+    initialSchemaKStream = new SchemaKStream(
+        logicalPlan.getTheSourceNode().getSchema(),
+        kStream,
+        ksqlStream.getKeyField(),
+        new ArrayList<>(),
+        SchemaKStream.Type.SOURCE,
+        functionRegistry,
+        new MockSchemaRegistryClient());
 
     List<Pair<String, Expression>> projectNameExpressionPairList = projectNode.getProjectNameExpressionPairList();
     SchemaKStream projectedSchemaKStream = initialSchemaKStream.select(projectNameExpressionPairList);

--- a/ksql-engine/src/test/java/io/confluent/ksql/structured/SchemaKStreamTest.java
+++ b/ksql-engine/src/test/java/io/confluent/ksql/structured/SchemaKStreamTest.java
@@ -140,7 +140,7 @@ public class SchemaKStreamTest {
     joinSchema = getJoinSchema(ksqlStream.getSchema(), secondKsqlStream.getSchema());
   }
 
-  private Serde<GenericRow> getRowSerde(KsqlTopic topic, Schema schema) {
+  private Serde<GenericRow> getRowSerde(final KsqlTopic topic, final Schema schema) {
     return topic.getKsqlTopicSerDe().getGenericRowSerde(schema,
                                                         new KsqlConfig(Collections.emptyMap()),
                                                         false, new MockSchemaRegistryClient());
@@ -148,15 +148,15 @@ public class SchemaKStreamTest {
 
   @Test
   public void testSelectSchemaKStream() {
-    String selectQuery = "SELECT col0, col2, col3 FROM test1 WHERE col0 > 100;";
-    PlanNode logicalPlan = planBuilder.buildLogicalPlan(selectQuery);
-    ProjectNode projectNode = (ProjectNode) logicalPlan.getSources().get(0);
+    final String selectQuery = "SELECT col0, col2, col3 FROM test1 WHERE col0 > 100;";
+    final PlanNode logicalPlan = planBuilder.buildLogicalPlan(selectQuery);
+    final ProjectNode projectNode = (ProjectNode) logicalPlan.getSources().get(0);
     initialSchemaKStream = new SchemaKStream(logicalPlan.getTheSourceNode().getSchema(), kStream,
                                              ksqlStream.getKeyField(), new ArrayList<>(),
                                              SchemaKStream.Type.SOURCE, functionRegistry, new MockSchemaRegistryClient());
 
-    List<Pair<String, Expression>> projectNameExpressionPairList = projectNode.getProjectNameExpressionPairList();
-    SchemaKStream projectedSchemaKStream = initialSchemaKStream.select(projectNameExpressionPairList);
+    final List<Pair<String, Expression>> projectNameExpressionPairList = projectNode.getProjectNameExpressionPairList();
+    final SchemaKStream projectedSchemaKStream = initialSchemaKStream.select(projectNameExpressionPairList);
     Assert.assertTrue(projectedSchemaKStream.getSchema().fields().size() == 3);
     Assert.assertTrue(projectedSchemaKStream.getSchema().field("COL0") ==
                       projectedSchemaKStream.getSchema().fields().get(0));
@@ -175,15 +175,15 @@ public class SchemaKStreamTest {
 
   @Test
   public void shouldUpdateKeyIfRenamed() {
-    String selectQuery = "SELECT col0 as NEWKEY, col2, col3 FROM test1;";
-    PlanNode logicalPlan = planBuilder.buildLogicalPlan(selectQuery);
-    ProjectNode projectNode = (ProjectNode) logicalPlan.getSources().get(0);
+    final String selectQuery = "SELECT col0 as NEWKEY, col2, col3 FROM test1;";
+    final PlanNode logicalPlan = planBuilder.buildLogicalPlan(selectQuery);
+    final ProjectNode projectNode = (ProjectNode) logicalPlan.getSources().get(0);
     initialSchemaKStream = new SchemaKStream(logicalPlan.getTheSourceNode().getSchema(), kStream,
         ksqlStream.getKeyField(), new ArrayList<>(),
         SchemaKStream.Type.SOURCE, functionRegistry, new MockSchemaRegistryClient());
 
-    List<Pair<String, Expression>> projectNameExpressionPairList = projectNode.getProjectNameExpressionPairList();
-    SchemaKStream projectedSchemaKStream = initialSchemaKStream.select(projectNameExpressionPairList);
+    final List<Pair<String, Expression>> projectNameExpressionPairList = projectNode.getProjectNameExpressionPairList();
+    final SchemaKStream projectedSchemaKStream = initialSchemaKStream.select(projectNameExpressionPairList);
     assertThat(
         projectedSchemaKStream.getKeyField(),
         equalTo(new Field("NEWKEY", 0, Schema.OPTIONAL_INT64_SCHEMA)));
@@ -191,9 +191,10 @@ public class SchemaKStreamTest {
 
   @Test
   public void shouldPreserveKeyOnSelectStar() {
-    String selectQuery = "SELECT * FROM test1;";
-    PlanNode logicalPlan = planBuilder.buildLogicalPlan(selectQuery);
-    ProjectNode projectNode = (ProjectNode) logicalPlan.getSources().get(0);
+    final String selectQuery = "SELECT * FROM test1;";
+    final PlanNode logicalPlan = planBuilder.buildLogicalPlan(selectQuery);
+    final ProjectNode projectNode = (ProjectNode) logicalPlan.getSources().get(0);
+
     initialSchemaKStream = new SchemaKStream(
         logicalPlan.getTheSourceNode().getSchema(),
         kStream,
@@ -203,24 +204,24 @@ public class SchemaKStreamTest {
         functionRegistry,
         new MockSchemaRegistryClient());
 
-    List<Pair<String, Expression>> projectNameExpressionPairList = projectNode.getProjectNameExpressionPairList();
-    SchemaKStream projectedSchemaKStream = initialSchemaKStream.select(projectNameExpressionPairList);
+    final List<Pair<String, Expression>> projectNameExpressionPairList = projectNode.getProjectNameExpressionPairList();
+    final SchemaKStream projectedSchemaKStream = initialSchemaKStream.select(projectNameExpressionPairList);
     assertThat(
         projectedSchemaKStream.getKeyField(),
-        equalTo(new Field("COL0", 2, Schema.OPTIONAL_INT64_SCHEMA)));
+        equalTo(initialSchemaKStream.getKeyField()));
   }
 
   @Test
   public void shouldUpdateKeyIfMovedToDifferentIndex() {
-    String selectQuery = "SELECT col2, col0, col3 FROM test1;";
-    PlanNode logicalPlan = planBuilder.buildLogicalPlan(selectQuery);
-    ProjectNode projectNode = (ProjectNode) logicalPlan.getSources().get(0);
+    final String selectQuery = "SELECT col2, col0, col3 FROM test1;";
+    final PlanNode logicalPlan = planBuilder.buildLogicalPlan(selectQuery);
+    final ProjectNode projectNode = (ProjectNode) logicalPlan.getSources().get(0);
     initialSchemaKStream = new SchemaKStream(logicalPlan.getTheSourceNode().getSchema(), kStream,
         ksqlStream.getKeyField(), new ArrayList<>(),
         SchemaKStream.Type.SOURCE, functionRegistry, new MockSchemaRegistryClient());
 
-    List<Pair<String, Expression>> projectNameExpressionPairList = projectNode.getProjectNameExpressionPairList();
-    SchemaKStream projectedSchemaKStream = initialSchemaKStream.select(projectNameExpressionPairList);
+    final List<Pair<String, Expression>> projectNameExpressionPairList = projectNode.getProjectNameExpressionPairList();
+    final SchemaKStream projectedSchemaKStream = initialSchemaKStream.select(projectNameExpressionPairList);
     assertThat(
         projectedSchemaKStream.getKeyField(),
         equalTo(new Field("COL0", 1, Schema.OPTIONAL_INT64_SCHEMA)));
@@ -228,27 +229,27 @@ public class SchemaKStreamTest {
 
   @Test
   public void shouldDropKeyIfNotSelected() {
-    String selectQuery = "SELECT col2, col3 FROM test1;";
-    PlanNode logicalPlan = planBuilder.buildLogicalPlan(selectQuery);
-    ProjectNode projectNode = (ProjectNode) logicalPlan.getSources().get(0);
+    final String selectQuery = "SELECT col2, col3 FROM test1;";
+    final PlanNode logicalPlan = planBuilder.buildLogicalPlan(selectQuery);
+    final ProjectNode projectNode = (ProjectNode) logicalPlan.getSources().get(0);
     initialSchemaKStream = new SchemaKStream(logicalPlan.getTheSourceNode().getSchema(), kStream,
         ksqlStream.getKeyField(), new ArrayList<>(),
         SchemaKStream.Type.SOURCE, functionRegistry, new MockSchemaRegistryClient());
 
-    List<Pair<String, Expression>> projectNameExpressionPairList = projectNode.getProjectNameExpressionPairList();
-    SchemaKStream projectedSchemaKStream = initialSchemaKStream.select(projectNameExpressionPairList);
+    final List<Pair<String, Expression>> projectNameExpressionPairList = projectNode.getProjectNameExpressionPairList();
+    final SchemaKStream projectedSchemaKStream = initialSchemaKStream.select(projectNameExpressionPairList);
     assertThat(projectedSchemaKStream.getKeyField(), nullValue());
   }
 
   @Test
   public void testSelectWithExpression() {
-    String selectQuery = "SELECT col0, LEN(UCASE(col2)), col3*3+5 FROM test1 WHERE col0 > 100;";
-    PlanNode logicalPlan = planBuilder.buildLogicalPlan(selectQuery);
-    ProjectNode projectNode = (ProjectNode) logicalPlan.getSources().get(0);
+    final String selectQuery = "SELECT col0, LEN(UCASE(col2)), col3*3+5 FROM test1 WHERE col0 > 100;";
+    final PlanNode logicalPlan = planBuilder.buildLogicalPlan(selectQuery);
+    final ProjectNode projectNode = (ProjectNode) logicalPlan.getSources().get(0);
     initialSchemaKStream = new SchemaKStream(logicalPlan.getTheSourceNode().getSchema(), kStream,
                                              ksqlStream.getKeyField(), new ArrayList<>(),
                                              SchemaKStream.Type.SOURCE, functionRegistry, new MockSchemaRegistryClient());
-    SchemaKStream projectedSchemaKStream = initialSchemaKStream.select(projectNode.getProjectNameExpressionPairList());
+    final SchemaKStream projectedSchemaKStream = initialSchemaKStream.select(projectNode.getProjectNameExpressionPairList());
     Assert.assertTrue(projectedSchemaKStream.getSchema().fields().size() == 3);
     Assert.assertTrue(projectedSchemaKStream.getSchema().field("COL0") ==
                       projectedSchemaKStream.getSchema().fields().get(0));
@@ -266,14 +267,14 @@ public class SchemaKStreamTest {
 
   @Test
   public void testFilter() {
-    String selectQuery = "SELECT col0, col2, col3 FROM test1 WHERE col0 > 100;";
-    PlanNode logicalPlan = planBuilder.buildLogicalPlan(selectQuery);
-    FilterNode filterNode = (FilterNode) logicalPlan.getSources().get(0).getSources().get(0);
+    final String selectQuery = "SELECT col0, col2, col3 FROM test1 WHERE col0 > 100;";
+    final PlanNode logicalPlan = planBuilder.buildLogicalPlan(selectQuery);
+    final FilterNode filterNode = (FilterNode) logicalPlan.getSources().get(0).getSources().get(0);
 
     initialSchemaKStream = new SchemaKStream(logicalPlan.getTheSourceNode().getSchema(), kStream,
                                              ksqlStream.getKeyField(), new ArrayList<>(),
                                              SchemaKStream.Type.SOURCE, functionRegistry, new MockSchemaRegistryClient());
-    SchemaKStream filteredSchemaKStream = initialSchemaKStream.filter(filterNode.getPredicate());
+    final SchemaKStream filteredSchemaKStream = initialSchemaKStream.filter(filterNode.getPredicate());
 
     Assert.assertTrue(filteredSchemaKStream.getSchema().fields().size() == 8);
     Assert.assertTrue(filteredSchemaKStream.getSchema().field("TEST1.COL0") ==
@@ -295,13 +296,13 @@ public class SchemaKStreamTest {
 
   @Test
   public void testSelectKey() {
-    String selectQuery = "SELECT col0, col2, col3 FROM test1 WHERE col0 > 100;";
-    PlanNode logicalPlan = planBuilder.buildLogicalPlan(selectQuery);
+    final String selectQuery = "SELECT col0, col2, col3 FROM test1 WHERE col0 > 100;";
+    final PlanNode logicalPlan = planBuilder.buildLogicalPlan(selectQuery);
 
     initialSchemaKStream = new SchemaKStream(logicalPlan.getTheSourceNode().getSchema(), kStream,
         ksqlStream.getKeyField(), new ArrayList<>(),
         SchemaKStream.Type.SOURCE, functionRegistry, new MockSchemaRegistryClient());
-    SchemaKStream rekeyedSchemaKStream = initialSchemaKStream.selectKey(initialSchemaKStream
+    final SchemaKStream rekeyedSchemaKStream = initialSchemaKStream.selectKey(initialSchemaKStream
         .getSchema().fields()
         .get(3), true);
     assertThat(rekeyedSchemaKStream.getKeyField().name().toUpperCase(), equalTo("TEST1.COL1"));
@@ -309,19 +310,19 @@ public class SchemaKStreamTest {
 
   @Test
   public void testGroupByKey() {
-    String selectQuery = "SELECT col0, col1 FROM test1 WHERE col0 > 100;";
-    PlanNode logicalPlan = planBuilder.buildLogicalPlan(selectQuery);
+    final String selectQuery = "SELECT col0, col1 FROM test1 WHERE col0 > 100;";
+    final PlanNode logicalPlan = planBuilder.buildLogicalPlan(selectQuery);
     initialSchemaKStream = new SchemaKStream(logicalPlan.getTheSourceNode().getSchema(), kStream,
         ksqlStream.getKeyField(), new ArrayList<>(),
         SchemaKStream.Type.SOURCE, functionRegistry, new MockSchemaRegistryClient());
 
-    Expression keyExpression = new DereferenceExpression(
+    final Expression keyExpression = new DereferenceExpression(
         new QualifiedNameReference(QualifiedName.of("TEST1")), "COL0");
-    KsqlTopicSerDe ksqlTopicSerDe = new KsqlJsonTopicSerDe();
-    Serde<GenericRow> rowSerde = ksqlTopicSerDe.getGenericRowSerde(
+    final KsqlTopicSerDe ksqlTopicSerDe = new KsqlJsonTopicSerDe();
+    final Serde<GenericRow> rowSerde = ksqlTopicSerDe.getGenericRowSerde(
         initialSchemaKStream.getSchema(), null, false, null);
-    List<Expression> groupByExpressions = Arrays.asList(keyExpression);
-    SchemaKGroupedStream groupedSchemaKStream = initialSchemaKStream.groupBy(
+    final List<Expression> groupByExpressions = Arrays.asList(keyExpression);
+    final SchemaKGroupedStream groupedSchemaKStream = initialSchemaKStream.groupBy(
         Serdes.String(), rowSerde, groupByExpressions);
 
     Assert.assertEquals(groupedSchemaKStream.getKeyField().name(), "COL0");
@@ -329,21 +330,21 @@ public class SchemaKStreamTest {
 
   @Test
   public void testGroupByMultipleColumns() {
-    String selectQuery = "SELECT col0, col1 FROM test1 WHERE col0 > 100;";
-    PlanNode logicalPlan = planBuilder.buildLogicalPlan(selectQuery);
+    final String selectQuery = "SELECT col0, col1 FROM test1 WHERE col0 > 100;";
+    final PlanNode logicalPlan = planBuilder.buildLogicalPlan(selectQuery);
     initialSchemaKStream = new SchemaKStream(logicalPlan.getTheSourceNode().getSchema(), kStream,
         ksqlStream.getKeyField(), new ArrayList<>(),
         SchemaKStream.Type.SOURCE, functionRegistry, new MockSchemaRegistryClient());
 
-    Expression col0Expression = new DereferenceExpression(
+    final Expression col0Expression = new DereferenceExpression(
         new QualifiedNameReference(QualifiedName.of("TEST1")), "COL0");
-    Expression col1Expression = new DereferenceExpression(
+    final Expression col1Expression = new DereferenceExpression(
         new QualifiedNameReference(QualifiedName.of("TEST1")), "COL1");
-    KsqlTopicSerDe ksqlTopicSerDe = new KsqlJsonTopicSerDe();
-    Serde<GenericRow> rowSerde = ksqlTopicSerDe.getGenericRowSerde(
+    final KsqlTopicSerDe ksqlTopicSerDe = new KsqlJsonTopicSerDe();
+    final Serde<GenericRow> rowSerde = ksqlTopicSerDe.getGenericRowSerde(
         initialSchemaKStream.getSchema(), null, false, null);
-    List<Expression> groupByExpressions = Arrays.asList(col1Expression, col0Expression);
-    SchemaKGroupedStream groupedSchemaKStream = initialSchemaKStream.groupBy(
+    final List<Expression> groupByExpressions = Arrays.asList(col1Expression, col0Expression);
+    final SchemaKGroupedStream groupedSchemaKStream = initialSchemaKStream.groupBy(
         Serdes.String(), rowSerde, groupByExpressions);
 
     Assert.assertEquals(groupedSchemaKStream.getKeyField().name(), "TEST1.COL1|+|TEST1.COL0");
@@ -483,17 +484,17 @@ public class SchemaKStreamTest {
                  joinedKStream.sourceSchemaKStreams);
   }
 
-  Schema getJoinSchema(Schema leftSchema, Schema rightSchema) {
-    SchemaBuilder schemaBuilder = SchemaBuilder.struct();
-    String leftAlias = "left";
-    String rightAlias = "right";
-    for (Field field : leftSchema.fields()) {
-      String fieldName = leftAlias + "." + field.name();
+  private Schema getJoinSchema(final Schema leftSchema, final Schema rightSchema) {
+    final SchemaBuilder schemaBuilder = SchemaBuilder.struct();
+    final String leftAlias = "left";
+    final String rightAlias = "right";
+    for (final Field field : leftSchema.fields()) {
+      final String fieldName = leftAlias + "." + field.name();
       schemaBuilder.field(fieldName, field.schema());
     }
 
-    for (Field field : rightSchema.fields()) {
-      String fieldName = rightAlias + "." + field.name();
+    for (final Field field : rightSchema.fields()) {
+      final String fieldName = rightAlias + "." + field.name();
       schemaBuilder.field(fieldName, field.schema());
     }
     return schemaBuilder.build();

--- a/ksql-engine/src/test/java/io/confluent/ksql/structured/SchemaKStreamTest.java
+++ b/ksql-engine/src/test/java/io/confluent/ksql/structured/SchemaKStreamTest.java
@@ -190,6 +190,23 @@ public class SchemaKStreamTest {
   }
 
   @Test
+  public void shouldPreserveKeyOnSelectStar() {
+    String selectQuery = "SELECT * FROM test1;";
+    PlanNode logicalPlan = planBuilder.buildLogicalPlan(selectQuery);
+    ProjectNode projectNode = (ProjectNode) logicalPlan.getSources().get(0);
+    initialSchemaKStream = new SchemaKStream(logicalPlan.getTheSourceNode().getSchema(), kStream,
+        ksqlStream.getKeyField(), new ArrayList<>(),
+        SchemaKStream.Type.SOURCE, ksqlConfig,
+        functionRegistry, schemaRegistryClient);
+
+    List<Pair<String, Expression>> projectNameExpressionPairList = projectNode.getProjectNameExpressionPairList();
+    SchemaKStream projectedSchemaKStream = initialSchemaKStream.select(projectNameExpressionPairList);
+    assertThat(
+        projectedSchemaKStream.getKeyField(),
+        equalTo(new Field("COL0", 2, Schema.OPTIONAL_INT64_SCHEMA)));
+  }
+
+  @Test
   public void shouldUpdateKeyIfMovedToDifferentIndex() {
     String selectQuery = "SELECT col2, col0, col3 FROM test1;";
     PlanNode logicalPlan = planBuilder.buildLogicalPlan(selectQuery);

--- a/ksql-engine/src/test/resources/query-validation-tests/joins.json
+++ b/ksql-engine/src/test/resources/query-validation-tests/joins.json
@@ -314,7 +314,7 @@
       ]
     },
     {
-      "name": "multi-way join",
+      "name": "table join pipeline",
       "format": ["JSON"],
       "statements": [
         "CREATE TABLE TEST (ID bigint, NAME varchar, VALUE bigint) WITH (kafka_topic='left_topic', value_format='{FORMAT}', key='ID');",

--- a/ksql-engine/src/test/resources/query-validation-tests/joins.json
+++ b/ksql-engine/src/test/resources/query-validation-tests/joins.json
@@ -312,6 +312,27 @@
         {"topic": "INNER_JOIN", "key": 0, "value": {"T_ID": 0, "NAME": "foo", "VALUE": 100, "F1": "zero", "F2": 0}, "timestamp": 10000},
         {"topic": "INNER_JOIN", "key": 0, "value": {"T_ID": 0, "NAME": "bar", "VALUE": 99, "F1": "a", "F2": 10}, "timestamp": 15000}
       ]
+    },
+    {
+      "name": "multi-way join",
+      "format": ["JSON"],
+      "statements": [
+        "CREATE TABLE TEST (ID bigint, NAME varchar, VALUE bigint) WITH (kafka_topic='left_topic', value_format='{FORMAT}', key='ID');",
+        "CREATE TABLE TEST_TABLE (ID bigint, F1 varchar, F2 bigint) WITH (kafka_topic='right_topic', value_format='{FORMAT}', key='ID');",
+        "CREATE TABLE TEST_TABLE_2 (ID bigint, F3 varchar) WITH (kafka_topic='right_topic_2', value_format='{FORMAT}', key='ID');",
+        "CREATE TABLE INNER_JOIN WITH (PARTITIONS=1) as SELECT t.id, name, value, f1, f2 FROM test t join TEST_TABLE tt on t.id = tt.id;",
+        "CREATE TABLE INNER_JOIN_2 AS SELECT t_id, name, f1, f3 FROM inner_join tt join TEST_TABLE_2 t ON t.id = tt.t_id;"
+      ],
+      "inputs": [
+        {"topic": "INNER_JOIN", "key": 0, "value": {"T_ID": 0, "NAME": "X", "VALUE": 0, "F1": "yo dawg", "F2": 50}, "timestamp": 0},
+        {"topic": "right_topic_2", "key": 0, "value": {"ID": 0, "F3": "I heard you like joins"}, "timestamp": 10000},
+        {"topic": "INNER_JOIN", "key": 100, "value": {"T_ID": 100, "NAME": "X", "VALUE": 0, "F1": "KSQL has table-table joins", "F2": 50}, "timestamp": 15000},
+        {"topic": "right_topic_2", "key": 100, "value": {"ID": 100, "F3": "so now you can join your join"}, "timestamp": 20000}
+      ],
+      "outputs": [
+        {"topic": "INNER_JOIN_2", "key": 0, "value": {"T_ID": 0, "NAME": "X", "F1": "yo dawg", "F3": "I heard you like joins"}, "timestamp": 10000},
+        {"topic": "INNER_JOIN_2", "key": 100, "value": {"T_ID": 100, "NAME": "X", "F1": "KSQL has table-table joins", "F3": "so now you can join your join"}, "timestamp": 20000}
+      ]
     }
   ]
 }


### PR DESCRIPTION
### Description 

SchemaKStream.select may get a QualifiedNameReference as the expression
in a select call. The logic that looks for and preserves the key field in
the resulting SchemaKStream needs to handle expressions of this type. It
also needs to handle cases where the key field name is fully qualified, as
happens with joins.

Fixes #1686. Fixes #1550 .

### Testing done 
_Describe the testing stategy. Unit and integration tests are expected for any behavior changes._

### Reviewer checklist
- [ ] Ensure docs are updated if necessary. (eg. if a user visible feature is being added or changed).
- [ ] Ensure relevant issues are linked (description should include text like "Fixes #<issue number>")

