### PR TITLE
Add service id to ksql metric names

### DIFF
--- a/docs/installation/upgrading.rst
+++ b/docs/installation/upgrading.rst
@@ -39,3 +39,11 @@ Notable changes in 4.1:
 * Configuration: Advanced KSQL users can configure the Kafka Streams and Kafka producer/consumer client settings used
   by KSQL.  This is achieved by using prefixes for the respective configuration settings.
   See :ref:`ksql-param-reference` as well as :ref:`ksql-server-config` and :ref:`install_cli-config` for details.
+
+Upgrading from KSQL 4.1 and 5.0 (Developer Preview) to KSQL 5.1
+-------------------------------------------------------
+
+* KSQL server:
+
+    * The KSQL engine metrics are now prefixed with the ``ksql.service.id``. If you have been using any metric monitoring
+      tool you need to update your metric names.

--- a/docs/installation/upgrading.rst
+++ b/docs/installation/upgrading.rst
@@ -40,10 +40,11 @@ Notable changes in 4.1:
   by KSQL.  This is achieved by using prefixes for the respective configuration settings.
   See :ref:`ksql-param-reference` as well as :ref:`ksql-server-config` and :ref:`install_cli-config` for details.
 
-Upgrading from KSQL 4.1 and 5.0 (Developer Preview) to KSQL 5.1
--------------------------------------------------------
+Upgrading from KSQL 5.0.0 and below to KSQL 5.1
+-----------------------------------------------
 
 * KSQL server:
 
     * The KSQL engine metrics are now prefixed with the ``ksql.service.id``. If you have been using any metric monitoring
       tool you need to update your metric names.
+      For instance, assuming ``ksql.service.id`` is set to ``default``, ``messages-produced-per-sec`` will be changed to ``_confluent-ksql-default_messages-consumed-per-sec``.

--- a/ksql-engine/src/main/java/io/confluent/ksql/KsqlContext.java
+++ b/ksql-engine/src/main/java/io/confluent/ksql/KsqlContext.java
@@ -16,11 +16,11 @@
 
 package io.confluent.ksql;
 
-import io.confluent.kafka.schemaregistry.client.CachedSchemaRegistryClient;
 import io.confluent.kafka.schemaregistry.client.SchemaRegistryClient;
 import io.confluent.ksql.function.InternalFunctionRegistry;
 import io.confluent.ksql.metastore.MetaStore;
 import io.confluent.ksql.metastore.MetaStoreImpl;
+import io.confluent.ksql.schema.registry.KsqlSchemaRegistryClientFactory;
 import io.confluent.ksql.util.KafkaTopicClient;
 import io.confluent.ksql.util.KafkaTopicClientImpl;
 import io.confluent.ksql.util.KsqlConfig;
@@ -41,13 +41,11 @@ public class KsqlContext {
   private static final Logger log = LoggerFactory.getLogger(KsqlContext.class);
   private final KsqlConfig ksqlConfig;
   private final KsqlEngine ksqlEngine;
-  private static final String KAFKA_BOOTSTRAP_SERVER_OPTION_DEFAULT = "localhost:9092";
 
   public static KsqlContext create(final KsqlConfig ksqlConfig) {
     return create(
         ksqlConfig,
-        new CachedSchemaRegistryClient(
-            KsqlConfig.defaultSchemaRegistryUrl, 1000));
+        new KsqlSchemaRegistryClientFactory(ksqlConfig).create());
   }
 
   public static KsqlContext create(

--- a/ksql-engine/src/main/java/io/confluent/ksql/KsqlContext.java
+++ b/ksql-engine/src/main/java/io/confluent/ksql/KsqlContext.java
@@ -31,7 +31,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import org.apache.kafka.streams.KafkaClientSupplier;
-import org.apache.kafka.streams.StreamsConfig;
 import org.apache.kafka.streams.processor.internals.DefaultKafkaClientSupplier;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -43,7 +42,7 @@ public class KsqlContext {
   private final KsqlEngine ksqlEngine;
   private static final String KAFKA_BOOTSTRAP_SERVER_OPTION_DEFAULT = "localhost:9092";
 
-  public static KsqlContext create(KsqlConfig ksqlConfig) {
+  public static KsqlContext create(final KsqlConfig ksqlConfig) {
     return create(
         ksqlConfig,
         new CachedSchemaRegistryClient(
@@ -51,26 +50,17 @@ public class KsqlContext {
   }
 
   public static KsqlContext create(
-      KsqlConfig ksqlConfig,
-      SchemaRegistryClient schemaRegistryClient
+      final KsqlConfig ksqlConfig,
+      final SchemaRegistryClient schemaRegistryClient
   ) {
     return create(ksqlConfig, schemaRegistryClient, new DefaultKafkaClientSupplier());
   }
 
   public static KsqlContext create(
-      KsqlConfig ksqlConfig,
-      SchemaRegistryClient schemaRegistryClient,
-      KafkaClientSupplier clientSupplier
+      final KsqlConfig ksqlConfig,
+      final SchemaRegistryClient schemaRegistryClient,
+      final KafkaClientSupplier clientSupplier
   ) {
-    if (ksqlConfig == null) {
-      ksqlConfig = new KsqlConfig(Collections.emptyMap());
-    }
-    if (!ksqlConfig.getKsqlStreamConfigProps().containsKey(
-        StreamsConfig.BOOTSTRAP_SERVERS_CONFIG)) {
-      ksqlConfig = ksqlConfig.cloneWithPropertyOverwrite(
-          Collections.singletonMap(
-              StreamsConfig.BOOTSTRAP_SERVERS_CONFIG, KAFKA_BOOTSTRAP_SERVER_OPTION_DEFAULT));
-    }
 
     final KafkaTopicClient kafkaTopicClient = new
         KafkaTopicClientImpl(ksqlConfig.getKsqlAdminClientConfigProps());

--- a/ksql-engine/src/main/java/io/confluent/ksql/KsqlContext.java
+++ b/ksql-engine/src/main/java/io/confluent/ksql/KsqlContext.java
@@ -66,12 +66,7 @@ public class KsqlContext {
               StreamsConfig.BOOTSTRAP_SERVERS_CONFIG, KAFKA_BOOTSTRAP_SERVER_OPTION_DEFAULT));
     }
 
-    final KsqlEngine engine = new KsqlEngine(
-        new KafkaTopicClientImpl(ksqlConfig.getKsqlAdminClientConfigProps()),
-        schemaRegistryClient == null
-            ? new KsqlSchemaRegistryClientFactory(ksqlConfig).create() : schemaRegistryClient,
-        clientSupplier
-    );
+    final KsqlEngine engine = new KsqlEngine(ksqlConfig);
 
     return new KsqlContext(ksqlConfig, engine);
   }

--- a/ksql-engine/src/main/java/io/confluent/ksql/KsqlContext.java
+++ b/ksql-engine/src/main/java/io/confluent/ksql/KsqlContext.java
@@ -29,6 +29,7 @@ import io.confluent.ksql.util.QueryMetadata;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Set;
 import org.apache.kafka.streams.KafkaClientSupplier;
 import org.apache.kafka.streams.processor.internals.DefaultKafkaClientSupplier;
@@ -61,7 +62,8 @@ public class KsqlContext {
       final SchemaRegistryClient schemaRegistryClient,
       final KafkaClientSupplier clientSupplier
   ) {
-
+    Objects.requireNonNull(ksqlConfig, "ksqlConfig cannot be null.");
+    Objects.requireNonNull(schemaRegistryClient, "schemaRegistryClient cannot be null.");
     final KafkaTopicClient kafkaTopicClient = new
         KafkaTopicClientImpl(ksqlConfig.getKsqlAdminClientConfigProps());
     final MetaStore metaStore = new MetaStoreImpl(new InternalFunctionRegistry());

--- a/ksql-engine/src/main/java/io/confluent/ksql/KsqlContext.java
+++ b/ksql-engine/src/main/java/io/confluent/ksql/KsqlContext.java
@@ -18,8 +18,6 @@ package io.confluent.ksql;
 
 import io.confluent.kafka.schemaregistry.client.SchemaRegistryClient;
 import io.confluent.ksql.metastore.MetaStore;
-import io.confluent.ksql.schema.registry.KsqlSchemaRegistryClientFactory;
-import io.confluent.ksql.util.KafkaTopicClientImpl;
 import io.confluent.ksql.util.KsqlConfig;
 import io.confluent.ksql.util.PersistentQueryMetadata;
 import io.confluent.ksql.util.QueryMetadata;

--- a/ksql-engine/src/main/java/io/confluent/ksql/KsqlEngine.java
+++ b/ksql-engine/src/main/java/io/confluent/ksql/KsqlEngine.java
@@ -112,7 +112,7 @@ public class KsqlEngine implements Closeable {
   private final QueryIdGenerator queryIdGenerator;
   private final KafkaClientSupplier clientSupplier;
 
-  private final KsqlConfig initializationKsqlConfig;
+  private final String serviceId;
 
   public KsqlEngine(final KsqlConfig initializationKsqlConfig) {
     this(
@@ -151,8 +151,7 @@ public class KsqlEngine implements Closeable {
     this.schemaRegistryClient =
         Objects.requireNonNull(schemaRegistryClient, "schemaRegistryClient can't be null");
     this.clientSupplier = Objects.requireNonNull(clientSupplier, "clientSupplier can't be null");
-    this.initializationKsqlConfig =
-        Objects.requireNonNull(initializationKsqlConfig, "ksqlConfig can't be null");;
+    this.serviceId = initializationKsqlConfig.getString(KsqlConfig.KSQL_SERVICE_ID_CONFIG);
     this.ddlCommandExec = new DdlCommandExec(this.metaStore);
     this.queryEngine = new QueryEngine(
         this,
@@ -538,8 +537,8 @@ public class KsqlEngine implements Closeable {
     return ddlCommandExec;
   }
 
-  public KsqlConfig getInitializationKsqlConfig() {
-    return initializationKsqlConfig;
+  public String getServiceId() {
+    return serviceId;
   }
 
   public boolean terminateQuery(final QueryId queryId, final boolean closeStreams) {

--- a/ksql-engine/src/main/java/io/confluent/ksql/KsqlEngine.java
+++ b/ksql-engine/src/main/java/io/confluent/ksql/KsqlEngine.java
@@ -112,15 +112,15 @@ public class KsqlEngine implements Closeable {
   private final QueryIdGenerator queryIdGenerator;
   private final KafkaClientSupplier clientSupplier;
 
-  private final KsqlConfig ksqlConfig;
+  private final KsqlConfig initializationKsqlConfig;
 
-  public KsqlEngine(final KsqlConfig ksqlConfig) {
+  public KsqlEngine(final KsqlConfig initializationKsqlConfig) {
     this(
-        new KafkaTopicClientImpl(ksqlConfig.getKsqlAdminClientConfigProps()),
-        new KsqlSchemaRegistryClientFactory(ksqlConfig).create(),
+        new KafkaTopicClientImpl(initializationKsqlConfig.getKsqlAdminClientConfigProps()),
+        new KsqlSchemaRegistryClientFactory(initializationKsqlConfig).create(),
         new DefaultKafkaClientSupplier(),
         new MetaStoreImpl(new InternalFunctionRegistry()),
-        ksqlConfig
+        initializationKsqlConfig
     );
   }
 
@@ -128,14 +128,14 @@ public class KsqlEngine implements Closeable {
   public KsqlEngine(final KafkaTopicClient topicClient,
                     final SchemaRegistryClient schemaRegistryClient,
                     final MetaStore metaStore,
-                    final KsqlConfig ksqlConfig
+                    final KsqlConfig initializationKsqlConfig
   ) {
     this(
         topicClient,
         schemaRegistryClient,
         new DefaultKafkaClientSupplier(),
         metaStore,
-        ksqlConfig
+        initializationKsqlConfig
     );
   }
 
@@ -144,14 +144,15 @@ public class KsqlEngine implements Closeable {
              final SchemaRegistryClient schemaRegistryClient,
              final KafkaClientSupplier clientSupplier,
              final MetaStore metaStore,
-             final KsqlConfig ksqlConfig
+             final KsqlConfig initializationKsqlConfig
   ) {
     this.metaStore = Objects.requireNonNull(metaStore, "metaStore can't be null");
     this.topicClient = Objects.requireNonNull(topicClient, "topicClient can't be null");
     this.schemaRegistryClient =
         Objects.requireNonNull(schemaRegistryClient, "schemaRegistryClient can't be null");
     this.clientSupplier = Objects.requireNonNull(clientSupplier, "clientSupplier can't be null");
-    this.ksqlConfig = Objects.requireNonNull(ksqlConfig, "ksqlConfig can't be null");;
+    this.initializationKsqlConfig =
+        Objects.requireNonNull(initializationKsqlConfig, "ksqlConfig can't be null");;
     this.ddlCommandExec = new DdlCommandExec(this.metaStore);
     this.queryEngine = new QueryEngine(
         this,
@@ -537,8 +538,8 @@ public class KsqlEngine implements Closeable {
     return ddlCommandExec;
   }
 
-  public KsqlConfig getKsqlConfig() {
-    return ksqlConfig;
+  public KsqlConfig getInitializationKsqlConfig() {
+    return initializationKsqlConfig;
   }
 
   public boolean terminateQuery(final QueryId queryId, final boolean closeStreams) {

--- a/ksql-engine/src/main/java/io/confluent/ksql/KsqlEngine.java
+++ b/ksql-engine/src/main/java/io/confluent/ksql/KsqlEngine.java
@@ -112,37 +112,30 @@ public class KsqlEngine implements Closeable {
   private final QueryIdGenerator queryIdGenerator;
   private final KafkaClientSupplier clientSupplier;
 
+  private final KsqlConfig ksqlConfig;
+
   public KsqlEngine(final KsqlConfig ksqlConfig) {
     this(
         new KafkaTopicClientImpl(ksqlConfig.getKsqlAdminClientConfigProps()),
         new KsqlSchemaRegistryClientFactory(ksqlConfig).create(),
         new DefaultKafkaClientSupplier(),
-        new MetaStoreImpl(new InternalFunctionRegistry())
-    );
-  }
-
-  public KsqlEngine(final KafkaTopicClient kafkaTopicClient,
-                    final SchemaRegistryClient schemaRegistryClient,
-                    final KafkaClientSupplier clientSupplier
-  ) {
-    this(
-        kafkaTopicClient,
-        schemaRegistryClient,
-        clientSupplier,
-        new MetaStoreImpl(new InternalFunctionRegistry())
+        new MetaStoreImpl(new InternalFunctionRegistry()),
+        ksqlConfig
     );
   }
 
   // called externally by tests only
   public KsqlEngine(final KafkaTopicClient topicClient,
                     final SchemaRegistryClient schemaRegistryClient,
-                    final MetaStore metaStore
+                    final MetaStore metaStore,
+                    final KsqlConfig ksqlConfig
   ) {
     this(
         topicClient,
         schemaRegistryClient,
         new DefaultKafkaClientSupplier(),
-        metaStore
+        metaStore,
+        ksqlConfig
     );
   }
 
@@ -150,13 +143,15 @@ public class KsqlEngine implements Closeable {
   KsqlEngine(final KafkaTopicClient topicClient,
              final SchemaRegistryClient schemaRegistryClient,
              final KafkaClientSupplier clientSupplier,
-             final MetaStore metaStore
+             final MetaStore metaStore,
+             final KsqlConfig ksqlConfig
   ) {
     this.metaStore = Objects.requireNonNull(metaStore, "metaStore can't be null");
     this.topicClient = Objects.requireNonNull(topicClient, "topicClient can't be null");
     this.schemaRegistryClient =
         Objects.requireNonNull(schemaRegistryClient, "schemaRegistryClient can't be null");
     this.clientSupplier = Objects.requireNonNull(clientSupplier, "clientSupplier can't be null");
+    this.ksqlConfig = Objects.requireNonNull(ksqlConfig, "ksqlConfig can't be null");;
     this.ddlCommandExec = new DdlCommandExec(this.metaStore);
     this.queryEngine = new QueryEngine(
         this,
@@ -540,6 +535,10 @@ public class KsqlEngine implements Closeable {
 
   public DdlCommandExec getDdlCommandExec() {
     return ddlCommandExec;
+  }
+
+  public KsqlConfig getKsqlConfig() {
+    return ksqlConfig;
   }
 
   public boolean terminateQuery(final QueryId queryId, final boolean closeStreams) {

--- a/ksql-engine/src/main/java/io/confluent/ksql/internal/KsqlEngineMetrics.java
+++ b/ksql-engine/src/main/java/io/confluent/ksql/internal/KsqlEngineMetrics.java
@@ -18,7 +18,6 @@ package io.confluent.ksql.internal;
 
 import io.confluent.ksql.KsqlEngine;
 import io.confluent.ksql.metrics.MetricCollectors;
-import io.confluent.ksql.util.KsqlConfig;
 import io.confluent.ksql.util.KsqlConstants;
 import java.io.Closeable;
 import java.util.ArrayList;

--- a/ksql-engine/src/main/java/io/confluent/ksql/internal/KsqlEngineMetrics.java
+++ b/ksql-engine/src/main/java/io/confluent/ksql/internal/KsqlEngineMetrics.java
@@ -204,7 +204,7 @@ public class KsqlEngineMetrics implements Closeable {
 
   private Sensor configureIdleQueriesSensor(Metrics metrics) {
     Sensor sensor = createSensor(metrics, "num-idle-queries");
-    sensor.add(metrics.metricName("num-idle-queries", this.metricGroupName), new Value());
+    sensor.add(metrics.metricName(ksqlServiceId + "num-idle-queries", this.metricGroupName), new Value());
     return sensor;
   }
 

--- a/ksql-engine/src/main/java/io/confluent/ksql/internal/KsqlEngineMetrics.java
+++ b/ksql-engine/src/main/java/io/confluent/ksql/internal/KsqlEngineMetrics.java
@@ -54,7 +54,7 @@ public class KsqlEngineMetrics implements Closeable {
   public KsqlEngineMetrics(String metricGroupPrefix, KsqlEngine ksqlEngine) {
     this.ksqlEngine = ksqlEngine;
     this.ksqlServiceId = KsqlConstants.KSQL_INTERNAL_TOPIC_PREFIX
-        + ksqlEngine.getKsqlConfig().getString(KsqlConfig.KSQL_SERVICE_ID_CONFIG);
+        + ksqlEngine.getInitializationKsqlConfig().getString(KsqlConfig.KSQL_SERVICE_ID_CONFIG);
     this.sensors = new ArrayList<>();
     this.metricGroupName = metricGroupPrefix + "-query-stats";
 
@@ -204,7 +204,9 @@ public class KsqlEngineMetrics implements Closeable {
 
   private Sensor configureIdleQueriesSensor(Metrics metrics) {
     Sensor sensor = createSensor(metrics, "num-idle-queries");
-    sensor.add(metrics.metricName(ksqlServiceId + "num-idle-queries", this.metricGroupName), new Value());
+    sensor.add(metrics.metricName(
+        ksqlServiceId + "num-idle-queries", this.metricGroupName),
+        new Value());
     return sensor;
   }
 

--- a/ksql-engine/src/main/java/io/confluent/ksql/internal/KsqlEngineMetrics.java
+++ b/ksql-engine/src/main/java/io/confluent/ksql/internal/KsqlEngineMetrics.java
@@ -18,6 +18,8 @@ package io.confluent.ksql.internal;
 
 import io.confluent.ksql.KsqlEngine;
 import io.confluent.ksql.metrics.MetricCollectors;
+import io.confluent.ksql.util.KsqlConfig;
+import io.confluent.ksql.util.KsqlConstants;
 import java.io.Closeable;
 import java.util.ArrayList;
 import java.util.Collection;
@@ -32,6 +34,7 @@ import org.apache.kafka.common.metrics.stats.Min;
 import org.apache.kafka.common.metrics.stats.Value;
 
 public class KsqlEngineMetrics implements Closeable {
+
   private final List<Sensor> sensors;
   private final String metricGroupName;
   private final Sensor numActiveQueries;
@@ -43,11 +46,15 @@ public class KsqlEngineMetrics implements Closeable {
   private final Sensor messageConsumptionByQuery;
   private final Sensor errorRate;
 
+  private final String ksqlServiceId;
+
 
   private final KsqlEngine ksqlEngine;
 
   public KsqlEngineMetrics(String metricGroupPrefix, KsqlEngine ksqlEngine) {
     this.ksqlEngine = ksqlEngine;
+    this.ksqlServiceId = KsqlConstants.KSQL_INTERNAL_TOPIC_PREFIX
+        + ksqlEngine.getKsqlConfig().getString(KsqlConfig.KSQL_SERVICE_ID_CONFIG);
     this.sensors = new ArrayList<>();
     this.metricGroupName = metricGroupPrefix + "-query-stats";
 
@@ -57,7 +64,7 @@ public class KsqlEngineMetrics implements Closeable {
     this.messagesIn = configureMessagesIn(metrics);
     this.totalMessagesIn = configureTotalMessagesIn(metrics);
     this.totalBytesIn = configureTotalBytesIn(metrics);
-    this.messagesOut =  configureMessagesOut(metrics);
+    this.messagesOut = configureMessagesOut(metrics);
     this.numIdleQueries = configureIdleQueriesSensor(metrics);
     this.messageConsumptionByQuery = configureMessageConsumptionByQuerySensor(metrics);
     this.errorRate = configureErrorRate(metrics);
@@ -111,13 +118,13 @@ public class KsqlEngineMetrics implements Closeable {
   private Sensor configureErrorRate(Metrics metrics) {
     Sensor sensor = createSensor(metrics, metricGroupName + "-error-rate");
     sensor.add(
-        metrics.metricName("error-rate", this.metricGroupName,
-                           "The number of messages which were consumed but not processed. "
-                           + "Messages may not be processed if, for instance, the message "
-                           + "contents could not be deserialized due to an incompatible schema. "
-                           + "Alternately, a consumed messages may not have been produced, hence "
-                           + "being effectively dropped. Such messages would also be counted "
-                           + "toward the error rate."),
+        metrics.metricName(ksqlServiceId + "error-rate", this.metricGroupName,
+            "The number of messages which were consumed but not processed. "
+                + "Messages may not be processed if, for instance, the message "
+                + "contents could not be deserialized due to an incompatible schema. "
+                + "Alternately, a consumed messages may not have been produced, hence "
+                + "being effectively dropped. Such messages would also be counted "
+                + "toward the error rate."),
         new Value());
     return sensor;
   }
@@ -125,8 +132,8 @@ public class KsqlEngineMetrics implements Closeable {
   private Sensor configureMessagesOut(Metrics metrics) {
     Sensor sensor = createSensor(metrics, metricGroupName + "-messages-produced");
     sensor.add(
-        metrics.metricName("messages-produced-per-sec", this.metricGroupName,
-                           "The number of messages produced per second across all queries"),
+        metrics.metricName(ksqlServiceId + "messages-produced-per-sec", this.metricGroupName,
+            "The number of messages produced per second across all queries"),
         new Value());
 
     return sensor;
@@ -135,8 +142,8 @@ public class KsqlEngineMetrics implements Closeable {
   private Sensor configureMessagesIn(Metrics metrics) {
     Sensor sensor = createSensor(metrics, metricGroupName + "-messages-consumed");
     sensor.add(
-        metrics.metricName("messages-consumed-per-sec", this.metricGroupName,
-                           "The number of messages consumed per second across all queries"),
+        metrics.metricName(ksqlServiceId + "messages-consumed-per-sec", this.metricGroupName,
+            "The number of messages consumed per second across all queries"),
         new Value());
     return sensor;
   }
@@ -144,7 +151,7 @@ public class KsqlEngineMetrics implements Closeable {
   private Sensor configureTotalMessagesIn(Metrics metrics) {
     Sensor sensor = createSensor(metrics, metricGroupName + "-total-messages-consumed");
     sensor.add(
-        metrics.metricName("messages-consumed-total", this.metricGroupName,
+        metrics.metricName(ksqlServiceId + "messages-consumed-total", this.metricGroupName,
             "The total number of messages consumed across all queries"),
         new Value());
     return sensor;
@@ -153,7 +160,7 @@ public class KsqlEngineMetrics implements Closeable {
   private Sensor configureTotalBytesIn(Metrics metrics) {
     Sensor sensor = createSensor(metrics, metricGroupName + "-total-bytes-consumed");
     sensor.add(
-        metrics.metricName("bytes-consumed-total", this.metricGroupName,
+        metrics.metricName(ksqlServiceId + "bytes-consumed-total", this.metricGroupName,
             "The total number of bytes consumed across all queries"),
         new Value());
     return sensor;
@@ -162,8 +169,8 @@ public class KsqlEngineMetrics implements Closeable {
   private Sensor configureNumActiveQueries(Metrics metrics) {
     Sensor sensor = createSensor(metrics, metricGroupName + "-active-queries");
     sensor.add(
-        metrics.metricName("num-active-queries", this.metricGroupName,
-                           "The current number of active queries running in this engine"),
+        metrics.metricName(ksqlServiceId + "num-active-queries", this.metricGroupName,
+            "The current number of active queries running in this engine"),
         new MeasurableStat() {
           @Override
           public double measure(MetricConfig metricConfig, long l) {
@@ -177,8 +184,8 @@ public class KsqlEngineMetrics implements Closeable {
         });
 
     sensor.add(
-        metrics.metricName("num-persistent-queries", this.metricGroupName,
-                           "The current number of persistent queries running in this engine"),
+        metrics.metricName(ksqlServiceId + "num-persistent-queries", this.metricGroupName,
+            "The current number of persistent queries running in this engine"),
         new MeasurableStat() {
           @Override
           public double measure(MetricConfig metricConfig, long l) {
@@ -202,10 +209,18 @@ public class KsqlEngineMetrics implements Closeable {
   }
 
   private Sensor configureMessageConsumptionByQuerySensor(Metrics metrics) {
-    Sensor sensor = createSensor(metrics, "message-consumption-by-query");
-    sensor.add(metrics.metricName("messages-consumed-max", this.metricGroupName), new Max());
-    sensor.add(metrics.metricName("messages-consumed-min", this.metricGroupName), new Min());
-    sensor.add(metrics.metricName("messages-consumed-avg", this.metricGroupName), new Avg());
+    Sensor sensor = createSensor(
+        metrics,
+        ksqlServiceId + "message-consumption-by-query");
+    sensor.add(
+        metrics.metricName(ksqlServiceId + "messages-consumed-max", this.metricGroupName),
+        new Max());
+    sensor.add(
+        metrics.metricName(ksqlServiceId + "messages-consumed-min", this.metricGroupName),
+        new Min());
+    sensor.add(
+        metrics.metricName(ksqlServiceId + "messages-consumed-avg", this.metricGroupName),
+        new Avg());
     return sensor;
   }
 

--- a/ksql-engine/src/main/java/io/confluent/ksql/internal/KsqlEngineMetrics.java
+++ b/ksql-engine/src/main/java/io/confluent/ksql/internal/KsqlEngineMetrics.java
@@ -53,8 +53,7 @@ public class KsqlEngineMetrics implements Closeable {
 
   public KsqlEngineMetrics(String metricGroupPrefix, KsqlEngine ksqlEngine) {
     this.ksqlEngine = ksqlEngine;
-    this.ksqlServiceId = KsqlConstants.KSQL_INTERNAL_TOPIC_PREFIX
-        + ksqlEngine.getInitializationKsqlConfig().getString(KsqlConfig.KSQL_SERVICE_ID_CONFIG);
+    this.ksqlServiceId = KsqlConstants.KSQL_INTERNAL_TOPIC_PREFIX + ksqlEngine.getServiceId();
     this.sensors = new ArrayList<>();
     this.metricGroupName = metricGroupPrefix + "-query-stats";
 

--- a/ksql-engine/src/test/java/io/confluent/ksql/EndToEndEngineTestUtil.java
+++ b/ksql-engine/src/test/java/io/confluent/ksql/EndToEndEngineTestUtil.java
@@ -570,7 +570,8 @@ class EndToEndEngineTestUtil {
     try (final KsqlEngine ksqlEngine = new KsqlEngine(
         new FakeKafkaTopicClient(),
         schemaRegistryClient,
-        metaStore
+        metaStore,
+        ksqlConfig
     )) {
       query.initializeTopics(ksqlEngine);
       final TopologyTestDriver testDriver

--- a/ksql-engine/src/test/java/io/confluent/ksql/KsqlEngineTest.java
+++ b/ksql-engine/src/test/java/io/confluent/ksql/KsqlEngineTest.java
@@ -68,7 +68,8 @@ public class KsqlEngineTest {
       topicClient,
       schemaRegistryClient,
       new DefaultKafkaClientSupplier(),
-      metaStore);
+      metaStore,
+      ksqlConfig);
 
   @After
   public void closeEngine() {
@@ -326,7 +327,8 @@ public class KsqlEngineTest {
     topicClient.close();
     expectLastCall();
     replay(topicClient);
-    final KsqlEngine ksqlEngine = new KsqlEngine(topicClient, schemaRegistryClient, metaStore);
+    final KsqlEngine ksqlEngine
+        = new KsqlEngine(topicClient, schemaRegistryClient, metaStore, ksqlConfig);
 
     // When:
     ksqlEngine.close();

--- a/ksql-engine/src/test/java/io/confluent/ksql/internal/KsqlEngineMetricsTest.java
+++ b/ksql-engine/src/test/java/io/confluent/ksql/internal/KsqlEngineMetricsTest.java
@@ -57,7 +57,7 @@ public class KsqlEngineMetricsTest {
     ksqlEngine = EasyMock.niceMock(KsqlEngine.class);
     final KsqlConfig ksqlConfig = new KsqlConfig(
         Collections.singletonMap(KsqlConfig.KSQL_SERVICE_ID_CONFIG, ksqlServiceId));
-    EasyMock.expect(ksqlEngine.getInitializationKsqlConfig()).andReturn(ksqlConfig);
+    EasyMock.expect(ksqlEngine.getServiceId()).andReturn(ksqlServiceId);
     EasyMock.replay(ksqlEngine);
     engineMetrics = new KsqlEngineMetrics(METRIC_GROUP, ksqlEngine);
   }

--- a/ksql-engine/src/test/java/io/confluent/ksql/internal/KsqlEngineMetricsTest.java
+++ b/ksql-engine/src/test/java/io/confluent/ksql/internal/KsqlEngineMetricsTest.java
@@ -57,7 +57,7 @@ public class KsqlEngineMetricsTest {
     ksqlEngine = EasyMock.niceMock(KsqlEngine.class);
     final KsqlConfig ksqlConfig = new KsqlConfig(
         Collections.singletonMap(KsqlConfig.KSQL_SERVICE_ID_CONFIG, ksqlServiceId));
-    EasyMock.expect(ksqlEngine.getKsqlConfig()).andReturn(ksqlConfig);
+    EasyMock.expect(ksqlEngine.getInitializationKsqlConfig()).andReturn(ksqlConfig);
     EasyMock.replay(ksqlEngine);
     engineMetrics = new KsqlEngineMetrics(METRIC_GROUP, ksqlEngine);
   }

--- a/ksql-engine/src/test/java/io/confluent/ksql/physical/PhysicalPlanBuilderTest.java
+++ b/ksql-engine/src/test/java/io/confluent/ksql/physical/PhysicalPlanBuilderTest.java
@@ -189,7 +189,8 @@ public class PhysicalPlanBuilderTest {
     KsqlEngine ksqlEngine = new KsqlEngine(
         kafkaTopicClient,
         schemaRegistryClient,
-        new MetaStoreImpl(new InternalFunctionRegistry()));
+        new MetaStoreImpl(new InternalFunctionRegistry()),
+        ksqlConfig);
 
     List<QueryMetadata> queryMetadataList = ksqlEngine.buildMultipleQueries(
         createStream + "\n " + csasQuery + "\n " + insertIntoQuery,
@@ -221,7 +222,8 @@ public class PhysicalPlanBuilderTest {
     KsqlEngine ksqlEngine = new KsqlEngine(
         new FakeKafkaTopicClient(),
         schemaRegistryClient,
-        new MetaStoreImpl(new InternalFunctionRegistry()));
+        new MetaStoreImpl(new InternalFunctionRegistry()),
+        ksqlConfig);
     try {
       List<QueryMetadata> queryMetadataList = ksqlEngine.buildMultipleQueries(
           createStream + "\n " + insertIntoQuery,
@@ -249,7 +251,8 @@ public class PhysicalPlanBuilderTest {
     KsqlEngine ksqlEngine = new KsqlEngine(
         kafkaTopicClient,
         schemaRegistryClient,
-        new MetaStoreImpl(new InternalFunctionRegistry()));
+        new MetaStoreImpl(new InternalFunctionRegistry()),
+        ksqlConfig);
 
     try {
       List<QueryMetadata> queryMetadataList = ksqlEngine.buildMultipleQueries(
@@ -278,7 +281,8 @@ public class PhysicalPlanBuilderTest {
     KsqlEngine ksqlEngine = new KsqlEngine(
         kafkaTopicClient,
         schemaRegistryClient,
-        new MetaStoreImpl(new InternalFunctionRegistry()));
+        new MetaStoreImpl(new InternalFunctionRegistry()),
+        ksqlConfig);
 
     List<QueryMetadata> queryMetadataList = ksqlEngine.buildMultipleQueries(
         createTable + "\n " + csasQuery + "\n " + insertIntoQuery,
@@ -316,7 +320,8 @@ public class PhysicalPlanBuilderTest {
     KsqlEngine ksqlEngine = new KsqlEngine(
         kafkaTopicClient,
         schemaRegistryClient,
-        new MetaStoreImpl(new InternalFunctionRegistry()));
+        new MetaStoreImpl(new InternalFunctionRegistry()),
+        ksqlConfig);
 
     try {
       List<QueryMetadata> queryMetadataList = ksqlEngine.buildMultipleQueries(
@@ -342,7 +347,8 @@ public class PhysicalPlanBuilderTest {
     KsqlEngine ksqlEngine = new KsqlEngine(
         kafkaTopicClient,
         schemaRegistryClient,
-        new MetaStoreImpl(new InternalFunctionRegistry()));
+        new MetaStoreImpl(new InternalFunctionRegistry()),
+        ksqlConfig);
 
     List<QueryMetadata> queryMetadataList = ksqlEngine.buildMultipleQueries(
         createStream + "\n " + csasQuery + "\n " + insertIntoQuery,
@@ -371,7 +377,8 @@ public class PhysicalPlanBuilderTest {
     KsqlEngine ksqlEngine = new KsqlEngine(
         kafkaTopicClient,
         schemaRegistryClient,
-        new MetaStoreImpl(new InternalFunctionRegistry()));
+        new MetaStoreImpl(new InternalFunctionRegistry()),
+        ksqlConfig);
 
     try {
       List<QueryMetadata> queryMetadataList = ksqlEngine.buildMultipleQueries(
@@ -583,7 +590,8 @@ public class PhysicalPlanBuilderTest {
     KsqlEngine ksqlEngine = new KsqlEngine(
         kafkaTopicClient,
         schemaRegistryClient,
-        new MetaStoreImpl(new InternalFunctionRegistry()));
+        new MetaStoreImpl(new InternalFunctionRegistry()),
+        ksqlConfig);
 
     List<QueryMetadata> queryMetadataList = ksqlEngine.buildMultipleQueries(createStream + "\n " +
         csasQuery + "\n " +

--- a/ksql-rest-app/src/test/java/io/confluent/ksql/rest/server/utils/TestUtils.java
+++ b/ksql-rest-app/src/test/java/io/confluent/ksql/rest/server/utils/TestUtils.java
@@ -79,7 +79,8 @@ public class TestUtils {
         super(
             topicClient,
             schemaRegistryClient,
-            new MetaStoreImpl(new InternalFunctionRegistry()));
+            new MetaStoreImpl(new InternalFunctionRegistry()),
+            ksqlConfig);
       }
     };
 


### PR DESCRIPTION
### Description 
Currently some of the KSQL metrics don't have ksql service id. This PR adds the KSQL service id to these metrics making sure they are unique. 
### Testing done 
Added unit tests.

### Reviewer checklist
- [ ] Ensure docs are updated if necessary. (eg. if a user visible feature is being added or changed).
- [ ] Ensure relevant issues are linked (description should include text like "Fixes #<issue number>")

