### PR TITLE
Using ksql topic name instead of Kafka topic name in topic map in met…

### DIFF
--- a/ksql-engine/src/main/java/io/confluent/ksql/analyzer/Analyzer.java
+++ b/ksql-engine/src/main/java/io/confluent/ksql/analyzer/Analyzer.java
@@ -166,15 +166,15 @@ public class Analyzer extends DefaultTraversalVisitor<Node, AnalysisContext> {
       }
 
       newIntoKsqlTopic = new KsqlTopic(
-          intoKafkaTopicName,
+          intoStructuredDataSource.getName(),
           intoKafkaTopicName,
           intoTopicSerde
       );
     } else {
-      newIntoKsqlTopic = metaStore.getTopic(intoKafkaTopicName);
+      newIntoKsqlTopic = metaStore.getTopic(intoStructuredDataSource.getName());
       if (newIntoKsqlTopic == null) {
         throw new KsqlException(
-            "Sink topic " + intoKafkaTopicName + " does not exist in th e metastore.");
+            "Sink topic " + intoKafkaTopicName + " does not exist in the metastore.");
       }
     }
 

--- a/ksql-engine/src/main/java/io/confluent/ksql/physical/PhysicalPlanBuilder.java
+++ b/ksql-engine/src/main/java/io/confluent/ksql/physical/PhysicalPlanBuilder.java
@@ -207,7 +207,7 @@ public class PhysicalPlanBuilder {
       final String statement
   ) {
 
-    if (metaStore.getTopic(outputNode.getKafkaTopicName()) == null) {
+    if (metaStore.getTopic(outputNode.getKsqlTopic().getName()) == null) {
       metaStore.putTopic(outputNode.getKsqlTopic());
     }
     StructuredDataSource sinkDataSource;

--- a/ksql-engine/src/main/java/io/confluent/ksql/planner/LogicalPlanner.java
+++ b/ksql-engine/src/main/java/io/confluent/ksql/planner/LogicalPlanner.java
@@ -107,7 +107,7 @@ public class LogicalPlanner {
           extractionPolicy,
           sourcePlanNode.getKeyField(),
           intoDataSource.getKsqlTopic(),
-          intoDataSource.getKsqlTopic().getTopicName(),
+          intoDataSource.getKsqlTopic().getKafkaTopicName(),
           intoProperties,
           analysis.getLimitClause(),
           analysis.isDoCreateInto()

--- a/ksql-engine/src/main/java/io/confluent/ksql/planner/plan/KsqlStructuredDataOutputNode.java
+++ b/ksql-engine/src/main/java/io/confluent/ksql/planner/plan/KsqlStructuredDataOutputNode.java
@@ -58,12 +58,12 @@ public class KsqlStructuredDataOutputNode extends OutputNode {
       @JsonProperty("timestamp") final TimestampExtractionPolicy timestampExtractionPolicy,
       @JsonProperty("key") final Field keyField,
       @JsonProperty("ksqlTopic") final KsqlTopic ksqlTopic,
-      @JsonProperty("topicName") final String topicName,
+      @JsonProperty("topicName") final String kafkaTopicName,
       @JsonProperty("outputProperties") final Map<String, Object> outputProperties,
       @JsonProperty("limit") final Optional<Integer> limit,
       @JsonProperty("doCreateInto") final boolean doCreateInto) {
     super(id, source, schema, limit, timestampExtractionPolicy);
-    this.kafkaTopicName = topicName;
+    this.kafkaTopicName = kafkaTopicName;
     this.keyField = keyField;
     this.ksqlTopic = ksqlTopic;
     this.outputProperties = outputProperties;
@@ -258,7 +258,7 @@ public class KsqlStructuredDataOutputNode extends OutputNode {
     private TimestampExtractionPolicy timestampExtractionPolicy;
     private Field keyField;
     private KsqlTopic ksqlTopic;
-    private String topicName;
+    private String kafkaTopicName;
     private Map<String, Object> outputProperties;
     private Optional<Integer> limit;
     private boolean doCreateInto;
@@ -271,7 +271,7 @@ public class KsqlStructuredDataOutputNode extends OutputNode {
           timestampExtractionPolicy,
           keyField,
           ksqlTopic,
-          topicName,
+          kafkaTopicName,
           outputProperties,
           limit,
           doCreateInto);
@@ -285,7 +285,7 @@ public class KsqlStructuredDataOutputNode extends OutputNode {
           .withTimestampExtractionPolicy(original.getTimestampExtractionPolicy())
           .withKeyField(original.getKeyField())
           .withKsqlTopic(original.getKsqlTopic())
-          .withTopicName(original.getKafkaTopicName())
+          .withKafkaTopicName(original.getKafkaTopicName())
           .withOutputProperties(original.getOutputProperties())
           .withLimit(original.getLimit())
           .withDoCreateInto(original.isDoCreateInto());
@@ -302,8 +302,8 @@ public class KsqlStructuredDataOutputNode extends OutputNode {
       return this;
     }
 
-    Builder withTopicName(String topicName) {
-      this.topicName = topicName;
+    Builder withKafkaTopicName(String kafkaTopicName) {
+      this.kafkaTopicName = kafkaTopicName;
       return this;
     }
 

--- a/ksql-engine/src/test/resources/query-validation-tests/project-filter.json
+++ b/ksql-engine/src/test/resources/query-validation-tests/project-filter.json
@@ -91,6 +91,20 @@
       "outputs": [
         {"topic": "S1", "key": 0, "value": "4294967296,456,foo", "timestamp": 0}
       ]
+    },
+    {
+      "name": "CSAS with custom Kafka topic name",
+      "statements": [
+        "CREATE STREAM TEST (C1 BIGINT, C2 INTEGER, C3 STRING) WITH (KAFKA_TOPIC='test_topic', value_format='DELIMITED');",
+        "CREATE STREAM S1 WITH (KAFKA_TOPIC='topic_s') AS SELECT * FROM TEST WHERE C1 = 4294967296;"
+      ],
+      "inputs": [
+        {"topic": "test_topic", "key": 0, "value": "123,456,foo", "timestamp": 0},
+        {"topic": "test_topic", "key": 0, "value": "4294967296,456,foo", "timestamp": 0}
+      ],
+      "outputs": [
+        {"topic": "topic_s", "key": 0, "value": "4294967296,456,foo", "timestamp": 0}
+      ]
     }
   ]
 }


### PR DESCRIPTION
…astore.

### Description 
We should use KSQL topic name in the metastore instead of kafka topic name. This PR fixes #1711.
 
### Testing done 
_Describe the testing stategy. Unit and integration tests are expected for any behavior changes._

### Reviewer checklist
- [ ] Ensure docs are updated if necessary. (eg. if a user visible feature is being added or changed).
- [ ] Ensure relevant issues are linked (description should include text like "Fixes #<issue number>")

