### PR TITLE
Quote struct fields with reserved names

### DIFF
--- a/ksql-engine/src/test/resources/query-validation-tests/project-filter.json
+++ b/ksql-engine/src/test/resources/query-validation-tests/project-filter.json
@@ -105,6 +105,36 @@
       "outputs": [
         {"topic": "topic_s", "key": 0, "value": "4294967296,456,foo", "timestamp": 0}
       ]
+    },
+    {
+      "name": "Project field with reserved name",
+      "statements": [
+        "CREATE STREAM TEST (START STRING, `END` STRING) WITH (KAFKA_TOPIC='test_topic', value_format='JSON');",
+        "CREATE STREAM S1 AS SELECT `END` FROM TEST;"
+      ],
+      "inputs": [
+        {"topic": "test_topic", "key": 0, "value": {"START": "hello", "END": "foo"}, "timestamp": 0},
+        {"topic": "test_topic", "key": 0, "value": {"START": "world", "END": "bar"}, "timestamp": 0}
+      ],
+      "outputs": [
+        {"topic": "S1", "key": 0, "value": {"END": "foo"}, "timestamp": 0},
+        {"topic": "S1", "key": 0, "value": {"END": "bar"}, "timestamp": 0}
+      ]
+    },
+    {
+      "name": "Project struct field with reserved name",
+      "statements": [
+        "CREATE STREAM TEST (S STRUCT<START STRING, `END` STRING>) WITH (KAFKA_TOPIC='test_topic', value_format='JSON');",
+        "CREATE STREAM S1 AS SELECT S->`END` FROM TEST;"
+      ],
+      "inputs": [
+        {"topic": "test_topic", "key": 0, "value": {"S": {"START": "hello", "END": "foo"}}, "timestamp": 0},
+        {"topic": "test_topic", "key": 0, "value": {"S": {"START": "world", "END": "bar"}}, "timestamp": 0}
+      ],
+      "outputs": [
+        {"topic": "S1", "key": 0, "value": {"S__END": "foo"}, "timestamp": 0},
+        {"topic": "S1", "key": 0, "value": {"S__END": "bar"}, "timestamp": 0}
+      ]
     }
   ]
 }

--- a/ksql-engine/src/test/resources/query-validation-tests/project-filter.json
+++ b/ksql-engine/src/test/resources/query-validation-tests/project-filter.json
@@ -107,7 +107,7 @@
       ]
     },
     {
-      "name": "Project field with reserved name",
+      "name": "Project fields with reserved name",
       "statements": [
         "CREATE STREAM TEST (START STRING, `END` STRING) WITH (KAFKA_TOPIC='test_topic', value_format='JSON');",
         "CREATE STREAM S1 AS SELECT `END` FROM TEST;"
@@ -122,7 +122,7 @@
       ]
     },
     {
-      "name": "Project struct field with reserved name",
+      "name": "Project struct fields with reserved name",
       "statements": [
         "CREATE STREAM TEST (S STRUCT<START STRING, `END` STRING>) WITH (KAFKA_TOPIC='test_topic', value_format='JSON');",
         "CREATE STREAM S1 AS SELECT S->`END` FROM TEST;"

--- a/ksql-parser/pom.xml
+++ b/ksql-parser/pom.xml
@@ -60,6 +60,12 @@
             <artifactId>easymock</artifactId>
             <scope>test</scope>
         </dependency>
+	<dependency>
+            <groupId>org.hamcrest</groupId>
+            <artifactId>hamcrest-all</artifactId>
+            <version>${hamcrest.version}</version>
+            <scope>test</scope>
+        </dependency>
 
     </dependencies>
 

--- a/ksql-parser/src/main/java/io/confluent/ksql/parser/ExpressionFormatter.java
+++ b/ksql-parser/src/main/java/io/confluent/ksql/parser/ExpressionFormatter.java
@@ -72,6 +72,8 @@ import io.confluent.ksql.parser.tree.WhenClause;
 import io.confluent.ksql.parser.tree.Window;
 import io.confluent.ksql.parser.tree.WindowFrame;
 import io.confluent.ksql.util.KsqlConstants;
+import io.confluent.ksql.util.ParserUtil;
+
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Set;
@@ -116,7 +118,8 @@ public final class ExpressionFormatter {
     protected String visitStruct(Struct node, Boolean unmangleNames) {
       return "STRUCT<" + Joiner.on(", ").join(node.getItems().stream()
           .map((child) ->
-              child.getLeft() + " " + process(child.getRight(), unmangleNames))
+              ParserUtil.escapeIfLiteral(child.getLeft())
+                  + " " + process(child.getRight(), unmangleNames))
           .collect(toList())) + ">";
     }
 

--- a/ksql-parser/src/main/java/io/confluent/ksql/parser/SqlFormatter.java
+++ b/ksql-parser/src/main/java/io/confluent/ksql/parser/SqlFormatter.java
@@ -23,7 +23,6 @@ import static java.util.stream.Collectors.joining;
 
 import com.google.common.base.Joiner;
 import com.google.common.base.Strings;
-import com.google.common.collect.ImmutableSet;
 import io.confluent.ksql.parser.tree.AliasedRelation;
 import io.confluent.ksql.parser.tree.AllColumns;
 import io.confluent.ksql.parser.tree.AstVisitor;
@@ -66,42 +65,23 @@ import io.confluent.ksql.parser.tree.TableElement;
 import io.confluent.ksql.parser.tree.TableSubquery;
 import io.confluent.ksql.parser.tree.Values;
 import io.confluent.ksql.util.KsqlException;
+import io.confluent.ksql.util.ParserUtil;
+
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
-import java.util.Objects;
-import java.util.Set;
 import java.util.regex.Pattern;
-import java.util.stream.Collectors;
-import java.util.stream.IntStream;
 
 public final class SqlFormatter {
 
   private static final String INDENT = "   ";
   private static final Pattern NAME_PATTERN = Pattern.compile("[a-z_][a-z0-9_]*");
-  private static final Set<String> LITERALS_SET = ImmutableSet.copyOf(
-          IntStream.range(0, SqlBaseLexer.VOCABULARY.getMaxTokenType())
-                  .mapToObj(SqlBaseLexer.VOCABULARY::getLiteralName)
-                  .filter(Objects::nonNull)
-                  // literals start and end with ' - remove them
-                  .map(l -> l.substring(1, l.length() - 1))
-                  .map(String::toUpperCase)
-                  .collect(Collectors.toSet())
-  );
 
   private SqlFormatter() {
   }
 
-  private static boolean isLiteral(String name) {
-    return LITERALS_SET.contains(name.toUpperCase());
-  }
-
-  private static String escapeIfLiteral(String name) {
-    return isLiteral(name) ? "`" + name + "`" : name;
-  }
-
-  public static String formatSql(Node root) {
-    StringBuilder builder = new StringBuilder();
+  public static String formatSql(final Node root) {
+    final StringBuilder builder = new StringBuilder();
     new Formatter(builder, true).process(root, 0);
     return builder.toString();
   }
@@ -342,7 +322,7 @@ public final class SqlFormatter {
           } else {
             addComma = true;
           }
-          builder.append(escapeIfLiteral(tableElement.getName()))
+          builder.append(ParserUtil.escapeIfLiteral(tableElement.getName()))
               .append(" ")
               .append(tableElement.getType());
         }
@@ -382,7 +362,7 @@ public final class SqlFormatter {
           } else {
             addComma = true;
           }
-          builder.append(escapeIfLiteral(tableElement.getName()))
+          builder.append(ParserUtil.escapeIfLiteral(tableElement.getName()))
               .append(" ")
               .append(tableElement.getType());
         }

--- a/ksql-parser/src/main/java/io/confluent/ksql/util/ParserUtil.java
+++ b/ksql-parser/src/main/java/io/confluent/ksql/util/ParserUtil.java
@@ -1,0 +1,44 @@
+/**
+ * Copyright 2018 Confluent Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ **/
+
+package io.confluent.ksql.util;
+
+import com.google.common.collect.ImmutableSet;
+import io.confluent.ksql.parser.SqlBaseLexer;
+
+import java.util.Objects;
+import java.util.Set;
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
+
+public final class ParserUtil {
+  private ParserUtil() {
+  }
+
+  private static final Set<String> LITERALS_SET = ImmutableSet.copyOf(
+      IntStream.range(0, SqlBaseLexer.VOCABULARY.getMaxTokenType())
+          .mapToObj(SqlBaseLexer.VOCABULARY::getLiteralName)
+          .filter(Objects::nonNull)
+          // literals start and end with ' - remove them
+          .map(l -> l.substring(1, l.length() - 1))
+          .map(String::toUpperCase)
+          .collect(Collectors.toSet())
+  );
+
+  public static String escapeIfLiteral(final String name) {
+    return LITERALS_SET.contains(name.toUpperCase()) ? "`" + name + "`" : name;
+  }
+}

--- a/ksql-parser/src/test/java/io/confluent/ksql/parser/ExpressionFormatterTest.java
+++ b/ksql-parser/src/test/java/io/confluent/ksql/parser/ExpressionFormatterTest.java
@@ -363,6 +363,18 @@ public class ExpressionFormatterTest {
   }
 
   @Test
+  public void shouldFormatStructWithColumnWithReservedWordName() {
+    final Struct struct
+        = new Struct(
+        ImmutableList.of(
+            new Pair<>("END", new PrimitiveType(Type.KsqlType.INTEGER))
+        ));
+    assertThat(
+        ExpressionFormatter.formatExpression(struct),
+        equalTo("STRUCT<`END` INTEGER>"));
+  }
+
+  @Test
   public void shouldFormatMap() {
     final Map map = new Map(new PrimitiveType(Type.KsqlType.BIGINT));
     assertThat(ExpressionFormatter.formatExpression(map), equalTo("MAP<VARCHAR, BIGINT>"));

--- a/ksql-parser/src/test/java/io/confluent/ksql/parser/util/ParserUtilTest.java
+++ b/ksql-parser/src/test/java/io/confluent/ksql/parser/util/ParserUtilTest.java
@@ -1,0 +1,19 @@
+package io.confluent.ksql.parser.util;
+
+import io.confluent.ksql.util.ParserUtil;
+import org.junit.Test;
+
+import static org.hamcrest.Matchers.equalTo;
+import static org.junit.Assert.assertThat;
+
+public class ParserUtilTest {
+  @Test
+  public void shouldEscapeStringIfLiteral() {
+    assertThat(ParserUtil.escapeIfLiteral("END"), equalTo("`END`"));
+  }
+
+  @Test
+  public void shouldNotEscapeStringIfNotLiteral() {
+    assertThat(ParserUtil.escapeIfLiteral("NOT_A_LITERAL"), equalTo("NOT_A_LITERAL"));
+  }
+}


### PR DESCRIPTION
### Description 

SqlFormatter quotes column names if they conflict with words reserved by our
grammar. This patch moves that logic to a utility class, and calls the utility
from ExpressionFormatter so that the same is done for struct fields

Fixes #1536

### Testing done
 
Unit test for ExpressionFormatter

### Reviewer checklist
- [x] Ensure docs are updated if necessary. (eg. if a user visible feature is being added or changed).
- [x] Ensure relevant issues are linked (description should include text like "Fixes #<issue number>")

