### PR TITLE
Downgrade UDF compiler output to trace to stop it spamming the  build logs

### DIFF
--- a/ksql-engine/src/main/java/io/confluent/ksql/function/UdfCompiler.java
+++ b/ksql-engine/src/main/java/io/confluent/ksql/function/UdfCompiler.java
@@ -174,7 +174,7 @@ public class UdfCompiler {
           method,
           functionName,
           description);
-      LOGGER.debug("Generated class for functionName={}, method={} class{}\n",
+      LOGGER.trace("Generated class for functionName={}, method={} class{}\n",
           functionName,
           method.getName(),
           udafClass);
@@ -323,7 +323,7 @@ public class UdfCompiler {
         .collect(Collectors.joining(",",
             prefix, ");"));
 
-    LOGGER.debug("generated code for udf method = {}\n{}", method, code);
+    LOGGER.trace("generated code for udf method = {}\n{}", method, code);
     return code;
   }
 


### PR DESCRIPTION
The UDF compiler outputs all generated code at debug when run. This is spamming the logs when you run associated tests, making issues harder to track down.

Now that UDFs are in and stable, let's downgrade the output to TRACE.