### PR TITLE
Speed up Integration test

### DIFF
--- a/ksql-engine/src/test/java/io/confluent/ksql/integration/IntegrationTestHarness.java
+++ b/ksql-engine/src/test/java/io/confluent/ksql/integration/IntegrationTestHarness.java
@@ -15,6 +15,7 @@ import io.confluent.ksql.util.KafkaTopicClientImpl;
 import io.confluent.ksql.util.KsqlConfig;
 import io.confluent.ksql.util.KsqlException;
 import io.confluent.ksql.util.TestDataProvider;
+import java.time.Duration;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashMap;
@@ -190,8 +191,8 @@ public class IntegrationTestHarness {
       long pollEnd = pollStart + resultsPollMaxTimeMs;
       while (System.currentTimeMillis() < pollEnd &&
              continueConsuming(result.size(), expectedNumMessages)) {
-        for (ConsumerRecord<K, GenericRow> record :
-            consumer.poll(Math.max(1, pollEnd - System.currentTimeMillis()))) {
+        final Duration duration = Duration.ofMillis(Math.max(1, pollEnd - System.currentTimeMillis()));
+        for (ConsumerRecord<K, GenericRow> record : consumer.poll(duration)) {
           if (record.value() != null) {
             result.put(record.key(), record.value());
           }

--- a/ksql-engine/src/test/java/io/confluent/ksql/integration/UdfIntTest.java
+++ b/ksql-engine/src/test/java/io/confluent/ksql/integration/UdfIntTest.java
@@ -2,317 +2,276 @@ package io.confluent.ksql.integration;
 
 import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
 
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
 import io.confluent.common.utils.IntegrationTest;
 import io.confluent.ksql.GenericRow;
 import io.confluent.ksql.KsqlContext;
 import io.confluent.ksql.function.UdfCompiler;
 import io.confluent.ksql.function.UdfLoader;
 import io.confluent.ksql.serde.DataSource;
+import io.confluent.ksql.serde.DataSource.DataSourceSerDe;
 import io.confluent.ksql.util.ItemDataProvider;
 import io.confluent.ksql.util.OrderDataProvider;
 import io.confluent.ksql.util.SchemaUtil;
 import java.util.Arrays;
+import java.util.Collection;
 import java.util.Collections;
-import java.util.HashMap;
 import java.util.Map;
 import java.util.Optional;
+import java.util.concurrent.atomic.AtomicInteger;
 import org.apache.kafka.clients.producer.RecordMetadata;
 import org.apache.kafka.common.serialization.StringDeserializer;
 import org.apache.kafka.connect.data.Schema;
 import org.apache.kafka.test.TestUtils;
 import org.junit.After;
+import org.junit.AfterClass;
 import org.junit.Before;
+import org.junit.BeforeClass;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
 
+@RunWith(Parameterized.class)
 @Category({IntegrationTest.class})
 public class UdfIntTest {
 
-  private IntegrationTestHarness testHarness;
+  private static final String JSON_TOPIC_NAME = "jsonTopic";
+  private static final String JSON_STREAM_NAME = "orders_json";
+  private static final String AVRO_TOPIC_NAME = "avroTopic";
+  private static final String AVRO_STREAM_NAME = "orders_avro";
+  private static final String DELIMITED_TOPIC_NAME = "delimitedTopic";
+  private static final String DELIMITED_STREAM_NAME = "items_delimited";
+  private static final AtomicInteger COUNTER = new AtomicInteger();
+  private static final IntegrationTestHarness TEST_HARNESS = new IntegrationTestHarness();
+
+  private static Schema ITEM_DATA_SCHEMA;
+  private static Map<String, RecordMetadata> jsonRecordMetadataMap;
+  private static Map<String, RecordMetadata> avroRecordMetadataMap;
+
+  private final DataSourceSerDe format;
+  private final String sourceStreamName;
+  private final Map<String, RecordMetadata> recordMetadata;
+
+  private String resultStreamName;
   private KsqlContext ksqlContext;
-  private Map<String, RecordMetadata> jsonRecordMetadataMap;
-  private String jsonTopicName = "jsonTopic";
-  private String jsonStreamName = "orders_json";
 
-  private Map<String, RecordMetadata> avroRecordMetadataMap;
-  private String avroTopicName = "avroTopic";
-  private String avroStreamName = "orders_avro";
+  @Parameterized.Parameters(name = "{0}")
+  public static Collection<DataSource.DataSourceSerDe> formats() {
+    return ImmutableList.of(DataSourceSerDe.AVRO, DataSourceSerDe.JSON);
+  }
 
-  private String delimitedTopicName = "delimitedTopic";
-  private String delimitedStreamName = "items_delimited";
+  @BeforeClass
+  public static void classSetUp() throws Exception {
+    TEST_HARNESS.start(Collections.emptyMap());
 
-  private OrderDataProvider orderDataProvider;
-  private ItemDataProvider itemDataProvider;
+    TEST_HARNESS.createTopic(JSON_TOPIC_NAME);
+    TEST_HARNESS.createTopic(AVRO_TOPIC_NAME);
+    TEST_HARNESS.createTopic(DELIMITED_TOPIC_NAME);
+
+    final OrderDataProvider orderDataProvider = new OrderDataProvider();
+    final ItemDataProvider itemDataProvider = new ItemDataProvider();
+
+    jsonRecordMetadataMap = ImmutableMap.copyOf(TEST_HARNESS.publishTestData(JSON_TOPIC_NAME,
+        orderDataProvider,
+        null,
+        DataSource.DataSourceSerDe.JSON));
+
+    avroRecordMetadataMap = ImmutableMap.copyOf(TEST_HARNESS.publishTestData(AVRO_TOPIC_NAME,
+        orderDataProvider,
+        null,
+        DataSource.DataSourceSerDe.AVRO));
+
+    TEST_HARNESS.publishTestData(DELIMITED_TOPIC_NAME,
+        itemDataProvider,
+        null,
+        DataSource.DataSourceSerDe.DELIMITED);
+
+    ITEM_DATA_SCHEMA = itemDataProvider.schema();
+  }
+
+  @AfterClass
+  public static void classTearDown() {
+    TEST_HARNESS.stop();
+  }
+
+  public UdfIntTest(final DataSource.DataSourceSerDe format) {
+    this.format = format;
+    switch (format) {
+      case AVRO:
+        this.sourceStreamName = AVRO_STREAM_NAME;
+        this.recordMetadata = avroRecordMetadataMap;
+        break;
+      default:
+        this.sourceStreamName = JSON_STREAM_NAME;
+        this.recordMetadata = jsonRecordMetadataMap;
+        break;
+    }
+  }
 
   @Before
-  public void before() throws Exception {
-    testHarness = new IntegrationTestHarness();
-    testHarness.start(Collections.emptyMap());
-    ksqlContext = KsqlContext.create(testHarness.ksqlConfig, testHarness.schemaRegistryClient);
-    testHarness.createTopic(jsonTopicName);
+  public void before() {
+    resultStreamName = "OUTPUT-" + COUNTER.getAndIncrement();
 
-    testHarness.createTopic(avroTopicName);
+    ksqlContext = KsqlContext.create(TEST_HARNESS.ksqlConfig, TEST_HARNESS.schemaRegistryClient);
 
     // load substring udf from classpath
     new UdfLoader(ksqlContext.getMetaStore(),
         TestUtils.tempDirectory(),
-        getClass().getClassLoader(),
+        UdfIntTest.class.getClassLoader(),
         value -> true, new UdfCompiler(Optional.empty()), Optional.empty(), true)
         .load();
 
-    /**
-     * Setup test data
-     */
-    orderDataProvider = new OrderDataProvider();
-    itemDataProvider = new ItemDataProvider();
-    jsonRecordMetadataMap = testHarness.publishTestData(jsonTopicName,
-                                                        orderDataProvider,
-                                                        null,
-                                                        DataSource.DataSourceSerDe.JSON);
-    avroRecordMetadataMap = testHarness.publishTestData(avroTopicName,
-                                                        orderDataProvider,
-                                                        null,
-                                                        DataSource.DataSourceSerDe.AVRO);
-    testHarness.publishTestData(delimitedTopicName,
-                                itemDataProvider,
-                                null,
-                                DataSource.DataSourceSerDe.DELIMITED);
-    createOrdersStream();
-
+    createSourceStreams();
   }
 
   @After
-  public void after() throws Exception {
+  public void after() {
     ksqlContext.close();
-    testHarness.stop();
   }
 
   @Test
-  public void testApplyUdfsToColumnsJson() throws Exception {
-    testApplyUdfsToColumns("SelectUDFsStreamJson".toUpperCase(),
-                           jsonStreamName,
-                           DataSource.DataSourceSerDe.JSON);
-  }
-
-  @Test
-  public void testApplyUdfsToColumnsAvro() throws Exception {
-    testApplyUdfsToColumns("SelectUDFsStreamAvro".toUpperCase(),
-                           avroStreamName,
-                           DataSource.DataSourceSerDe.AVRO);
-  }
-
-  @Test
-  public void testShouldCastSelectedColumnsJson() throws Exception {
-    testShouldCastSelectedColumns("CastExpressionStream".toUpperCase(),
-                                  jsonStreamName,
-                                  DataSource.DataSourceSerDe.JSON);
-  }
-
-  @Test
-  public void testShouldCastSelectedColumnsAvro() throws Exception {
-    testShouldCastSelectedColumns("CastExpressionStreamAvro".toUpperCase(),
-                                  avroStreamName,
-                                  DataSource.DataSourceSerDe.AVRO);
-  }
-
-
-  @Test
-  public void testTimestampColumnSelectionJson() throws Exception {
-    testTimestampColumnSelection("ORIGINALSTREAM",
-                                 "TIMESTAMPSTREAM",
-                                 jsonStreamName,
-                                 DataSource.DataSourceSerDe.JSON,
-                                 jsonRecordMetadataMap);
-  }
-
-
-  @Test
-  public void testTimestampColumnSelectionAvro() throws Exception {
-    testTimestampColumnSelection("ORIGINALSTREAM_AVRO",
-                                 "TIMESTAMPSTREAM_AVRO",
-                                 avroStreamName,
-                                 DataSource.DataSourceSerDe.AVRO,
-                                 avroRecordMetadataMap);
-  }
-
-  private void testApplyUdfsToColumns(String resultStreamName,
-                                      String inputStreamName,
-                                      DataSource.DataSourceSerDe dataSourceSerde) throws Exception {
-
+  public void testApplyUdfsToColumns() {
+    // Given:
     final String queryString = String.format(
-        "CREATE STREAM %s AS SELECT %s FROM %s WHERE %s;",
+        "CREATE STREAM \"%s\" AS SELECT "
+            + "ITEMID, "
+            + "ORDERUNITS*10, "
+            + "PRICEARRAY[0]+10, "
+            + "KEYVALUEMAP['key1'] * KEYVALUEMAP['key2']+10, "
+            + "PRICEARRAY[1] > 1000 "
+            + "FROM %s WHERE ORDERUNITS > 20 AND ITEMID LIKE '%%_8';",
         resultStreamName,
-        "ITEMID, ORDERUNITS*10, PRICEARRAY[0]+10, KEYVALUEMAP['key1']*KEYVALUEMAP['key2']+10, "
-        + "PRICEARRAY[1]>1000",
-        inputStreamName,
-        "ORDERUNITS > 20 AND ITEMID LIKE '%_8'"
+        sourceStreamName
     );
 
+    // When:
     ksqlContext.sql(queryString);
 
-    Schema resultSchema = ksqlContext.getMetaStore().getSource(resultStreamName).getSchema();
+    // Then:
+    final Map<String, GenericRow> results = consumeOutputMessages();
 
-    Map<String, GenericRow> expectedResults =
-        Collections.singletonMap("8",
-                                 new GenericRow(Arrays.asList(null,
-                                                              null,
-                                                              "ITEM_8",
-                                                              800.0,
-                                                              1110.0,
-                                                              12.0,
-                                                              true)));
-
-    Map<String, GenericRow> results =
-        testHarness.consumeData(resultStreamName,
-                                resultSchema,
-                                4,
-                                new StringDeserializer(),
-                                IntegrationTestHarness.RESULTS_POLL_MAX_TIME_MS,
-                                dataSourceSerde);
-
-    assertThat(results, equalTo(expectedResults));
+    assertThat(results, is(ImmutableMap.of("8",
+        new GenericRow(Arrays.asList("ITEM_8", 800.0, 1110.0, 12.0, true)))));
   }
-
-  private void testShouldCastSelectedColumns(String resultStreamName,
-                                             String inputStreamName,
-                                             DataSource.DataSourceSerDe dataSourceSerde)
-      throws Exception {
-    final String selectColumns =
-        " CAST (ORDERUNITS AS INTEGER), CAST( PRICEARRAY[1]>1000 AS STRING), CAST (SUBSTRING"
-        + "(ITEMID, 6) AS DOUBLE), CAST(ORDERUNITS AS VARCHAR) ";
-
-    final String queryString = String.format(
-        "CREATE STREAM %s AS SELECT %s FROM %s WHERE %s;",
-        resultStreamName,
-        selectColumns,
-        inputStreamName,
-        "ORDERUNITS > 20 AND ITEMID LIKE '%_8'"
-    );
-
-    ksqlContext.sql(queryString);
-
-    Schema resultSchema = ksqlContext.getMetaStore().getSource(resultStreamName).getSchema();
-
-    Map<String, GenericRow> expectedResults =
-        Collections.singletonMap("8",
-                                 new GenericRow(Arrays.asList(
-                                     null,
-                                     null,
-                                     80,
-                                     "true",
-                                     8.0,
-                                     "80.0")));
-
-    Map<String, GenericRow> results =
-        testHarness.consumeData(resultStreamName,
-                                resultSchema,
-                                4,
-                                new StringDeserializer(),
-                                IntegrationTestHarness.RESULTS_POLL_MAX_TIME_MS, dataSourceSerde);
-
-    assertThat(results, equalTo(expectedResults));
-  }
-
-  private void testTimestampColumnSelection(String stream1Name, String stream2Name, String
-      inputStreamName, DataSource.DataSourceSerDe dataSourceSerDe, Map<String, RecordMetadata>
-                                                recordMetadataMap) throws Exception {
-
-    final String query1String =
-        String.format("CREATE STREAM %s AS SELECT ROWKEY AS RKEY, "
-                      + "ROWTIME+10000 AS "
-                      + "RTIME, ROWTIME+100 AS RT100, ORDERID, ITEMID "
-                      + "FROM %s WHERE ORDERUNITS > 20 AND ITEMID = 'ITEM_8'; "
-                      + "CREATE STREAM %s AS SELECT ROWKEY AS NEWRKEY, "
-                      + "ROWTIME AS NEWRTIME, RKEY, RTIME, RT100, ORDERID, ITEMID "
-                      + "FROM %s ;", stream1Name,
-                      inputStreamName, stream2Name, stream1Name);
-
-    ksqlContext.sql(query1String);
-
-    Schema resultSchema = SchemaUtil.removeImplicitRowTimeRowKeyFromSchema(
-        ksqlContext.getMetaStore().getSource(stream2Name).getSchema());
-
-    Map<String, GenericRow> expectedResults = new HashMap<>();
-    expectedResults.put("8",
-                        new GenericRow(Arrays.asList(
-                            "8",
-                            recordMetadataMap.get("8").timestamp(),
-                            "8",
-                            recordMetadataMap.get("8").timestamp() + 10000,
-                            recordMetadataMap.get("8").timestamp() + 100,
-                            "ORDER_6",
-                            "ITEM_8")));
-
-    Map<String, GenericRow> results =
-        testHarness.consumeData(stream2Name,
-                                resultSchema,
-                                expectedResults.size(),
-                                new StringDeserializer(),
-                                IntegrationTestHarness.RESULTS_POLL_MAX_TIME_MS, dataSourceSerDe);
-
-    assertThat(results, equalTo(expectedResults));
-  }
-
 
   @Test
-  public void testApplyUdfsToColumnsDelimited() throws Exception {
-    final String testStreamName = "SelectUDFsStreamDelimited".toUpperCase();
-
+  public void testShouldCastSelectedColumns() {
+    // Given:
     final String queryString = String.format(
-        "CREATE STREAM %s AS SELECT %s FROM %s WHERE %s;",
-        testStreamName,
-        "ID, DESCRIPTION",
-        delimitedStreamName,
-        "ID LIKE '%_1'"
+        "CREATE STREAM \"%s\" AS SELECT "
+            + "CAST (ORDERUNITS AS INTEGER), "
+            + "CAST( PRICEARRAY[1]>1000 AS STRING), "
+            + "CAST (SUBSTRING(ITEMID, 6) AS DOUBLE), "
+            + "CAST(ORDERUNITS AS VARCHAR) "
+            + "FROM %s WHERE ORDERUNITS > 20 AND ITEMID LIKE '%%_8';",
+        resultStreamName,
+        sourceStreamName
     );
 
+    // When:
     ksqlContext.sql(queryString);
 
-    Map<String, GenericRow> expectedResults =
-        Collections.singletonMap("ITEM_1",
-                                 new GenericRow(Arrays.asList(
-                                     "ITEM_1",
-                                     "home cinema")));
+    // Then:
+    final Map<String, GenericRow> results = consumeOutputMessages();
 
-    Map<String, GenericRow> results =
-        testHarness.consumeData(
-            testStreamName,
-            itemDataProvider.schema(),
-            1,
-            new StringDeserializer(),
-            IntegrationTestHarness.RESULTS_POLL_MAX_TIME_MS,
-            DataSource.DataSourceSerDe.DELIMITED);
-
-    assertThat(results, equalTo(expectedResults));
+    assertThat(results, is(ImmutableMap.of("8",
+        new GenericRow(Arrays.asList(80, "true", 8.0, "80.0")))));
   }
 
-  private void createOrdersStream() throws Exception {
-    ksqlContext.sql(String.format("CREATE STREAM %s (ORDERTIME bigint, ORDERID varchar, "
-                                  + "ITEMID varchar, "
-                                  + "ORDERUNITS double, "
-                                  + "PRICEARRAY array<double>, "
-                                  + "KEYVALUEMAP map<varchar, double>) "
-                                  + "WITH (kafka_topic='%s', value_format='%s');",
-                                  jsonStreamName,
-                                  jsonTopicName,
-                                  DataSource.DataSourceSerDe.JSON.name()));
+  @Test
+  public void testTimestampColumnSelection() {
+    // Given:
+    final String originalStream = "ORIGINALSTREAM" + COUNTER.getAndIncrement();
 
-    ksqlContext.sql(String.format("CREATE STREAM %s (ORDERTIME bigint, "
-                                  + "ORDERID varchar, "
-                                  + "ITEMID varchar, "
-                                  + "ORDERUNITS double, "
-                                  + "PRICEARRAY array<double>, "
-                                  + "KEYVALUEMAP map<varchar, double>) "
-                                  + "WITH (kafka_topic='%s', value_format='%s');",
-                                  avroStreamName,
-                                  avroTopicName,
-                                  DataSource.DataSourceSerDe.AVRO.name()));
+    final String queryString = String.format(
+        "CREATE STREAM \"%s\" AS SELECT "
+            + "ROWKEY AS RKEY, ROWTIME+10000 AS RTIME, ROWTIME+100 AS RT100, ORDERID, ITEMID "
+            + "FROM %s WHERE ORDERUNITS > 20 AND ITEMID = 'ITEM_8';"
+            + ""
+            + "CREATE STREAM \"%s\" AS SELECT "
+            + "ROWKEY AS NEWRKEY, ROWTIME AS NEWRTIME, RKEY, RTIME, RT100, ORDERID, ITEMID "
+            + "FROM %s;",
+        originalStream, sourceStreamName, resultStreamName, originalStream);
+
+    // When:
+    ksqlContext.sql(queryString);
+
+    // Then:
+    final Map<String, GenericRow> results = consumeOutputMessages();
+
+    final long ts = recordMetadata.get("8").timestamp();
+
+    assertThat(results, equalTo(ImmutableMap.of("8",
+        new GenericRow(Arrays.asList("8", ts, "8", ts + 10000, ts + 100, "ORDER_6", "ITEM_8")))));
+  }
+
+  @Test
+  public void testApplyUdfsToColumnsDelimited() {
+    // Given:
+    final String queryString = String.format(
+        "CREATE STREAM \"%s\" AS SELECT ID, DESCRIPTION FROM %s WHERE ID LIKE '%%_1';",
+        resultStreamName, DELIMITED_STREAM_NAME
+    );
+
+    // When:
+    ksqlContext.sql(queryString);
+
+    // Then:
+    final Map<String, GenericRow> results =
+        consumeOutputMessages(ITEM_DATA_SCHEMA, DataSource.DataSourceSerDe.DELIMITED);
+
+    assertThat(results, equalTo(Collections.singletonMap("ITEM_1",
+        new GenericRow(Arrays.asList("ITEM_1", "home cinema")))));
+  }
+
+  private void createSourceStreams() {
+    createOrdersStream(JSON_TOPIC_NAME, JSON_STREAM_NAME, DataSourceSerDe.JSON);
+    createOrdersStream(AVRO_TOPIC_NAME, AVRO_STREAM_NAME, DataSourceSerDe.AVRO);
+
     ksqlContext.sql(String.format("CREATE STREAM %s (ID varchar, DESCRIPTION varchar) WITH "
-                     + "(kafka_topic='%s', value_format='%s');",
-                                  delimitedStreamName,
-                                  delimitedTopicName,
-                                  DataSource.DataSourceSerDe.DELIMITED.name()));
+            + "(kafka_topic='%s', value_format='%s');",
+        DELIMITED_STREAM_NAME,
+        DELIMITED_TOPIC_NAME,
+        DataSource.DataSourceSerDe.DELIMITED.name()));
   }
 
+  private void createOrdersStream(
+      final String topicName, final String streamName, final DataSource.DataSourceSerDe format) {
+
+    ksqlContext.sql(String.format("CREATE STREAM %s ("
+            + "ORDERTIME bigint, "
+            + "ORDERID varchar, "
+            + "ITEMID varchar, "
+            + "ORDERUNITS double, "
+            + "PRICEARRAY array<double>, "
+            + "KEYVALUEMAP map<varchar, double>) "
+            + "WITH (kafka_topic='%s', value_format='%s');",
+        streamName,
+        topicName,
+        format.name()));
+  }
+
+  private Map<String, GenericRow> consumeOutputMessages() {
+    final Schema resultSchema = SchemaUtil.removeImplicitRowTimeRowKeyFromSchema(
+        ksqlContext.getMetaStore().getSource(resultStreamName).getSchema());
+
+    return consumeOutputMessages(resultSchema, format);
+  }
+
+  private Map<String, GenericRow> consumeOutputMessages(
+      final Schema resultSchema,
+      final DataSourceSerDe serDeFormat) {
+
+    return TEST_HARNESS.consumeData(
+        resultStreamName,
+        resultSchema,
+        1,
+        new StringDeserializer(),
+        IntegrationTestHarness.RESULTS_POLL_MAX_TIME_MS,
+        serDeFormat);
+  }
 }

--- a/ksql-engine/src/test/resources/log4j.properties
+++ b/ksql-engine/src/test/resources/log4j.properties
@@ -1,4 +1,4 @@
-log4j.rootLogger=WARN,stdout
+log4j.rootLogger=INFO,stdout
 
 log4j.logger.io.confluent.ksql=DEBUG
 log4j.logger.io.confluent.ksql.integration=DEBUG

--- a/ksql-engine/src/test/resources/log4j.properties
+++ b/ksql-engine/src/test/resources/log4j.properties
@@ -1,4 +1,4 @@
-log4j.rootLogger=INFO,stdout
+log4j.rootLogger=WARN,stdout
 
 log4j.logger.io.confluent.ksql=DEBUG
 log4j.logger.io.confluent.ksql.integration=DEBUG

--- a/ksql-serde/src/main/java/io/confluent/ksql/serde/json/KsqlJsonDeserializer.java
+++ b/ksql-serde/src/main/java/io/confluent/ksql/serde/json/KsqlJsonDeserializer.java
@@ -38,10 +38,13 @@ import org.apache.kafka.connect.data.Schema;
 import org.apache.kafka.connect.data.SchemaAndValue;
 import org.apache.kafka.connect.data.Struct;
 import org.apache.kafka.connect.json.JsonConverter;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 public class KsqlJsonDeserializer implements Deserializer<GenericRow> {
 
-  //TODO: Possibily use Streaming API instead of ObjectMapper for better performance
+  private static final Logger LOG = LoggerFactory.getLogger(KsqlJsonSerializer.class);
+
   private final ObjectMapper objectMapper = new ObjectMapper();
 
   private final Schema schema;
@@ -67,21 +70,24 @@ public class KsqlJsonDeserializer implements Deserializer<GenericRow> {
 
   @Override
   public GenericRow deserialize(final String topic, final byte[] bytes) {
-    if (bytes == null) {
-      return null;
-    }
     try {
-      return getGenericRow(bytes);
+      final GenericRow row = getGenericRow(bytes);
+      if (LOG.isTraceEnabled()) {
+        LOG.trace("Deserialized row. topic:{}, row:{}", topic, row);
+      }
+      return row;
     } catch (Exception e) {
       throw new SerializationException(
-          "KsqlJsonDeserializer failed to deserialize data for topic: " + topic,
-          e
-      );
+          "KsqlJsonDeserializer failed to deserialize data for topic: " + topic, e);
     }
   }
 
   @SuppressWarnings("unchecked")
   private GenericRow getGenericRow(final byte[] rowJsonBytes) throws IOException {
+    if (rowJsonBytes == null) {
+      return null;
+    }
+
     final JsonNode jsonNode = objectMapper.readTree(rowJsonBytes);
     final CaseInsensitiveJsonNode caseInsensitiveJsonNode = new CaseInsensitiveJsonNode(jsonNode);
 

--- a/ksql-serde/src/main/java/io/confluent/ksql/serde/json/KsqlJsonSerializer.java
+++ b/ksql-serde/src/main/java/io/confluent/ksql/serde/json/KsqlJsonSerializer.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2017 Confluent Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -24,8 +24,12 @@ import org.apache.kafka.common.serialization.Serializer;
 import org.apache.kafka.connect.data.Schema;
 import org.apache.kafka.connect.data.Struct;
 import org.apache.kafka.connect.json.JsonConverter;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 public class KsqlJsonSerializer implements Serializer<GenericRow> {
+
+  private static final Logger LOG = LoggerFactory.getLogger(KsqlJsonSerializer.class);
 
   private final Schema schema;
   private final JsonConverter jsonConverter;
@@ -46,6 +50,10 @@ public class KsqlJsonSerializer implements Serializer<GenericRow> {
 
   @Override
   public byte[] serialize(final String topic, final GenericRow data) {
+    if (LOG.isTraceEnabled()) {
+      LOG.trace("Serializing row. topic:{}, row:{}", topic, data);
+    }
+
     if (data == null) {
       return null;
     }


### PR DESCRIPTION
### Description 
`UdfInfTest` was talking over 5 minutes to run!  By changing it to only start Kafka / ZK once and to only wait for the expected number of messages, it now runs in under 50s.

### Testing done 
Change is a test.

### Reviewer checklist
- [ ] Ensure docs are updated if necessary. (eg. if a user visible feature is being added or changed).
- [ ] Ensure relevant issues are linked (description should include text like "Fixes #<issue number>")

