### PR TITLE
Fix the build failures caused by upstream KStreams change.

### DIFF
--- a/ksql-parser/src/test/java/io/confluent/ksql/parser/tree/HoppingWindowExpressionTest.java
+++ b/ksql-parser/src/test/java/io/confluent/ksql/parser/tree/HoppingWindowExpressionTest.java
@@ -17,6 +17,7 @@
 
 package io.confluent.ksql.parser.tree;
 
+import static io.confluent.ksql.parser.util.TimeWindowsMatcher.timeWindows;
 import static org.easymock.EasyMock.same;
 
 import io.confluent.ksql.GenericRow;
@@ -44,7 +45,7 @@ public class HoppingWindowExpressionTest {
     final Initializer initializer = () -> 0;
     final Materialized<String, GenericRow, WindowStore<Bytes, byte[]>> store = Materialized.as("store");
 
-    EasyMock.expect(stream.windowedBy(TimeWindows.of(10000L).advanceBy(4L))).andReturn(windowedKStream);
+    EasyMock.expect(stream.windowedBy(timeWindows(TimeWindows.of(10000L).advanceBy(4L)))).andReturn(windowedKStream);
     EasyMock.expect(windowedKStream.aggregate(same(initializer), same(aggregator), same(store))).andReturn(null);
     EasyMock.replay(stream, windowedKStream);
 

--- a/ksql-parser/src/test/java/io/confluent/ksql/parser/tree/TumblingWindowExpressionTest.java
+++ b/ksql-parser/src/test/java/io/confluent/ksql/parser/tree/TumblingWindowExpressionTest.java
@@ -16,6 +16,7 @@
 
 package io.confluent.ksql.parser.tree;
 
+import static io.confluent.ksql.parser.util.TimeWindowsMatcher.timeWindows;
 import static org.easymock.EasyMock.same;
 
 import io.confluent.ksql.GenericRow;
@@ -43,7 +44,7 @@ public class TumblingWindowExpressionTest {
     final Initializer initializer = () -> 0;
     final Materialized<String, GenericRow, WindowStore<Bytes, byte[]>> store = Materialized.as("store");
 
-    EasyMock.expect(stream.windowedBy(TimeWindows.of(10000L))).andReturn(windowedKStream);
+    EasyMock.expect(stream.windowedBy(timeWindows(TimeWindows.of(10000L)))).andReturn(windowedKStream);
     EasyMock.expect(windowedKStream.aggregate(same(initializer), same(aggregator), same(store))).andReturn(null);
     EasyMock.replay(stream, windowedKStream);
 

--- a/ksql-parser/src/test/java/io/confluent/ksql/parser/util/TimeWindowsMatcher.java
+++ b/ksql-parser/src/test/java/io/confluent/ksql/parser/util/TimeWindowsMatcher.java
@@ -1,0 +1,52 @@
+/*
+ * Copyright 2018 Confluent Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.confluent.ksql.parser.util;
+
+import org.apache.kafka.streams.kstream.TimeWindows;
+import org.easymock.EasyMock;
+import org.easymock.IArgumentMatcher;
+
+/**
+ * Hopefully temporary matcher to work around the fact that TimeWindows has had its equals and
+ * hashcode removed.
+ */
+public final class TimeWindowsMatcher {
+
+  public static TimeWindows timeWindows(final TimeWindows expected){
+    EasyMock.reportMatcher(new IArgumentMatcher() {
+      @Override
+      public boolean matches(final Object argument) {
+        if (!(argument instanceof TimeWindows)) {
+          return false;
+        }
+
+        final TimeWindows actual = (TimeWindows)argument;
+        return actual.size() == expected.size()
+            && actual.advanceMs == expected.advanceMs
+            && actual.gracePeriodMs() == expected.gracePeriodMs();
+      }
+
+      @Override
+      public void appendTo(final StringBuffer buffer) {
+        buffer.append("timeWindow(\"").append(expected).append("\")");
+      }
+    });
+    return null;
+  }
+
+  private TimeWindowsMatcher(){}
+}


### PR DESCRIPTION
### Description 
upstream change to KStreams saw `equals` and `hashcode` removed from `TimedWindows`. Fixed by adding EasyMock matcher.

### Testing done 
ran tests.

### Reviewer checklist
- [ ] Ensure docs are updated if necessary. (eg. if a user visible feature is being added or changed).
- [ ] Ensure relevant issues are linked (description should include text like "Fixes #<issue number>")

