### PR TITLE
Use a thread-local avro serdes for running queries

### DIFF
--- a/ksql-engine/src/main/java/io/confluent/ksql/KsqlContext.java
+++ b/ksql-engine/src/main/java/io/confluent/ksql/KsqlContext.java
@@ -45,19 +45,16 @@ public class KsqlContext {
   public static KsqlContext create(final KsqlConfig ksqlConfig) {
     return create(
         ksqlConfig,
-        new KsqlSchemaRegistryClientFactory(ksqlConfig),
-        new KsqlSchemaRegistryClientFactory(ksqlConfig).get());
+        new KsqlSchemaRegistryClientFactory(ksqlConfig));
   }
 
   public static KsqlContext create(
       final KsqlConfig ksqlConfig,
-      final Supplier<SchemaRegistryClient> schemaRegistryClientFactory,
-      final SchemaRegistryClient schemaRegistryClient
+      final Supplier<SchemaRegistryClient> schemaRegistryClientFactory
   ) {
     return create(
         ksqlConfig,
         schemaRegistryClientFactory,
-        schemaRegistryClient,
         new DefaultKafkaClientSupplier()
     );
   }
@@ -65,7 +62,6 @@ public class KsqlContext {
   public static KsqlContext create(
       KsqlConfig ksqlConfig,
       final Supplier<SchemaRegistryClient> schemaRegistryClientFactory,
-      final SchemaRegistryClient schemaRegistryClient,
       final KafkaClientSupplier clientSupplier
   ) {
     if (ksqlConfig == null) {
@@ -81,8 +77,6 @@ public class KsqlContext {
     final KsqlEngine engine = new KsqlEngine(
         new KafkaTopicClientImpl(ksqlConfig.getKsqlAdminClientConfigProps()),
         schemaRegistryClientFactory,
-        schemaRegistryClient == null
-            ? new KsqlSchemaRegistryClientFactory(ksqlConfig).get() : schemaRegistryClient,
         clientSupplier
     );
 

--- a/ksql-engine/src/main/java/io/confluent/ksql/KsqlContext.java
+++ b/ksql-engine/src/main/java/io/confluent/ksql/KsqlContext.java
@@ -45,7 +45,7 @@ public class KsqlContext {
   public static KsqlContext create(final KsqlConfig ksqlConfig) {
     return create(
         ksqlConfig,
-        new KsqlSchemaRegistryClientFactory(ksqlConfig));
+        (new KsqlSchemaRegistryClientFactory(ksqlConfig))::get);
   }
 
   public static KsqlContext create(

--- a/ksql-engine/src/main/java/io/confluent/ksql/KsqlEngine.java
+++ b/ksql-engine/src/main/java/io/confluent/ksql/KsqlEngine.java
@@ -127,13 +127,12 @@ public class KsqlEngine implements Closeable {
 
   public KsqlEngine(final KafkaTopicClient kafkaTopicClient,
                     final Supplier<SchemaRegistryClient> schemaRegistryClientFactory,
-                    final SchemaRegistryClient schemaRegistryClient,
                     final KafkaClientSupplier clientSupplier
   ) {
     this(
         kafkaTopicClient,
         schemaRegistryClientFactory,
-        schemaRegistryClient,
+        schemaRegistryClientFactory.get(),
         clientSupplier,
         new MetaStoreImpl(new InternalFunctionRegistry())
     );
@@ -142,13 +141,12 @@ public class KsqlEngine implements Closeable {
   // called externally by tests only
   public KsqlEngine(final KafkaTopicClient topicClient,
                     final Supplier<SchemaRegistryClient> schemaRegistryClientFactory,
-                    final SchemaRegistryClient schemaRegistryClient,
                     final MetaStore metaStore
   ) {
     this(
         topicClient,
         schemaRegistryClientFactory,
-        schemaRegistryClient,
+        schemaRegistryClientFactory.get(),
         new DefaultKafkaClientSupplier(),
         metaStore
     );

--- a/ksql-engine/src/main/java/io/confluent/ksql/KsqlEngine.java
+++ b/ksql-engine/src/main/java/io/confluent/ksql/KsqlEngine.java
@@ -119,7 +119,6 @@ public class KsqlEngine implements Closeable {
     this(
         new KafkaTopicClientImpl(ksqlConfig.getKsqlAdminClientConfigProps()),
         new KsqlSchemaRegistryClientFactory(ksqlConfig),
-        new KsqlSchemaRegistryClientFactory(ksqlConfig).get(),
         new DefaultKafkaClientSupplier(),
         new MetaStoreImpl(new InternalFunctionRegistry())
     );
@@ -132,7 +131,6 @@ public class KsqlEngine implements Closeable {
     this(
         kafkaTopicClient,
         schemaRegistryClientFactory,
-        schemaRegistryClientFactory.get(),
         clientSupplier,
         new MetaStoreImpl(new InternalFunctionRegistry())
     );
@@ -146,7 +144,6 @@ public class KsqlEngine implements Closeable {
     this(
         topicClient,
         schemaRegistryClientFactory,
-        schemaRegistryClientFactory.get(),
         new DefaultKafkaClientSupplier(),
         metaStore
     );
@@ -155,7 +152,6 @@ public class KsqlEngine implements Closeable {
   // called externally by tests only
   KsqlEngine(final KafkaTopicClient topicClient,
              final Supplier<SchemaRegistryClient> schemaRegistryClientFactory,
-             final SchemaRegistryClient schemaRegistryClient,
              final KafkaClientSupplier clientSupplier,
              final MetaStore metaStore
   ) {
@@ -164,8 +160,7 @@ public class KsqlEngine implements Closeable {
     this.schemaRegistryClientFactory =
         Objects.requireNonNull(
             schemaRegistryClientFactory, "schemaRegistryClientFactory can't be null");
-    this.schemaRegistryClient =
-        Objects.requireNonNull(schemaRegistryClient, "schemaRegistryClient can't be null");
+    this.schemaRegistryClient = this.schemaRegistryClientFactory.get();
     this.clientSupplier = Objects.requireNonNull(clientSupplier, "clientSupplier can't be null");
     this.ddlCommandExec = new DdlCommandExec(this.metaStore);
     this.queryEngine = new QueryEngine(

--- a/ksql-engine/src/main/java/io/confluent/ksql/KsqlEngine.java
+++ b/ksql-engine/src/main/java/io/confluent/ksql/KsqlEngine.java
@@ -118,7 +118,7 @@ public class KsqlEngine implements Closeable {
   public KsqlEngine(final KsqlConfig ksqlConfig) {
     this(
         new KafkaTopicClientImpl(ksqlConfig.getKsqlAdminClientConfigProps()),
-        new KsqlSchemaRegistryClientFactory(ksqlConfig),
+        (new KsqlSchemaRegistryClientFactory(ksqlConfig))::get,
         new DefaultKafkaClientSupplier(),
         new MetaStoreImpl(new InternalFunctionRegistry())
     );
@@ -160,7 +160,9 @@ public class KsqlEngine implements Closeable {
     this.schemaRegistryClientFactory =
         Objects.requireNonNull(
             schemaRegistryClientFactory, "schemaRegistryClientFactory can't be null");
-    this.schemaRegistryClient = this.schemaRegistryClientFactory.get();
+    this.schemaRegistryClient =
+        Objects.requireNonNull(
+            this.schemaRegistryClientFactory.get(), "Schema registry can't be null");
     this.clientSupplier = Objects.requireNonNull(clientSupplier, "clientSupplier can't be null");
     this.ddlCommandExec = new DdlCommandExec(this.metaStore);
     this.queryEngine = new QueryEngine(

--- a/ksql-engine/src/main/java/io/confluent/ksql/KsqlEngine.java
+++ b/ksql-engine/src/main/java/io/confluent/ksql/KsqlEngine.java
@@ -81,6 +81,8 @@ import java.util.Set;
 import java.util.concurrent.Executors;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.TimeUnit;
+import java.util.function.Supplier;
+
 import org.antlr.v4.runtime.CharStream;
 import org.antlr.v4.runtime.misc.Interval;
 import org.apache.kafka.streams.KafkaClientSupplier;
@@ -108,6 +110,7 @@ public class KsqlEngine implements Closeable {
   private final Set<QueryMetadata> allLiveQueries;
   private final KsqlEngineMetrics engineMetrics;
   private final ScheduledExecutorService aggregateMetricsCollector;
+  private final Supplier<SchemaRegistryClient> schemaRegistryClientFactory;
   private final SchemaRegistryClient schemaRegistryClient;
   private final QueryIdGenerator queryIdGenerator;
   private final KafkaClientSupplier clientSupplier;
@@ -115,18 +118,21 @@ public class KsqlEngine implements Closeable {
   public KsqlEngine(final KsqlConfig ksqlConfig) {
     this(
         new KafkaTopicClientImpl(ksqlConfig.getKsqlAdminClientConfigProps()),
-        new KsqlSchemaRegistryClientFactory(ksqlConfig).create(),
+        new KsqlSchemaRegistryClientFactory(ksqlConfig),
+        new KsqlSchemaRegistryClientFactory(ksqlConfig).get(),
         new DefaultKafkaClientSupplier(),
         new MetaStoreImpl(new InternalFunctionRegistry())
     );
   }
 
   public KsqlEngine(final KafkaTopicClient kafkaTopicClient,
+                    final Supplier<SchemaRegistryClient> schemaRegistryClientFactory,
                     final SchemaRegistryClient schemaRegistryClient,
                     final KafkaClientSupplier clientSupplier
   ) {
     this(
         kafkaTopicClient,
+        schemaRegistryClientFactory,
         schemaRegistryClient,
         clientSupplier,
         new MetaStoreImpl(new InternalFunctionRegistry())
@@ -135,11 +141,13 @@ public class KsqlEngine implements Closeable {
 
   // called externally by tests only
   public KsqlEngine(final KafkaTopicClient topicClient,
+                    final Supplier<SchemaRegistryClient> schemaRegistryClientFactory,
                     final SchemaRegistryClient schemaRegistryClient,
                     final MetaStore metaStore
   ) {
     this(
         topicClient,
+        schemaRegistryClientFactory,
         schemaRegistryClient,
         new DefaultKafkaClientSupplier(),
         metaStore
@@ -148,12 +156,16 @@ public class KsqlEngine implements Closeable {
 
   // called externally by tests only
   KsqlEngine(final KafkaTopicClient topicClient,
+             final Supplier<SchemaRegistryClient> schemaRegistryClientFactory,
              final SchemaRegistryClient schemaRegistryClient,
              final KafkaClientSupplier clientSupplier,
              final MetaStore metaStore
   ) {
     this.metaStore = Objects.requireNonNull(metaStore, "metaStore can't be null");
     this.topicClient = Objects.requireNonNull(topicClient, "topicClient can't be null");
+    this.schemaRegistryClientFactory =
+        Objects.requireNonNull(
+            schemaRegistryClientFactory, "schemaRegistryClientFactory can't be null");
     this.schemaRegistryClient =
         Objects.requireNonNull(schemaRegistryClient, "schemaRegistryClient can't be null");
     this.clientSupplier = Objects.requireNonNull(clientSupplier, "clientSupplier can't be null");
@@ -602,11 +614,12 @@ public class KsqlEngine implements Closeable {
     return queryEngine.handleDdlStatement(sqlExpression, statement);
   }
 
+  public Supplier<SchemaRegistryClient> getSchemaRegistryClientFactory() {
+    return schemaRegistryClientFactory;
+  }
+
   public SchemaRegistryClient getSchemaRegistryClient() {
-    if (schemaRegistryClient != null) {
-      return schemaRegistryClient;
-    }
-    throw new KsqlException("Cannot access the Schema Registry. Schema Registry client is null.");
+    return schemaRegistryClient;
   }
 
   public QueryIdGenerator getQueryIdGenerator() {

--- a/ksql-engine/src/main/java/io/confluent/ksql/QueryEngine.java
+++ b/ksql-engine/src/main/java/io/confluent/ksql/QueryEngine.java
@@ -189,7 +189,7 @@ class QueryEngine {
         overriddenProperties,
         updateMetastore,
         ksqlEngine.getMetaStore(),
-        ksqlEngine.getSchemaRegistryClient(),
+        ksqlEngine.getSchemaRegistryClientFactory(),
         ksqlEngine.getQueryIdGenerator(),
         new KafkaStreamsBuilderImpl(clientSupplier)
     );

--- a/ksql-engine/src/main/java/io/confluent/ksql/physical/PhysicalPlanBuilder.java
+++ b/ksql-engine/src/main/java/io/confluent/ksql/physical/PhysicalPlanBuilder.java
@@ -50,6 +50,8 @@ import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.concurrent.ThreadLocalRandom;
+import java.util.function.Supplier;
+
 import org.apache.kafka.clients.consumer.ConsumerConfig;
 import org.apache.kafka.clients.producer.ProducerConfig;
 import org.apache.kafka.connect.data.Field;
@@ -68,7 +70,7 @@ public class PhysicalPlanBuilder {
   private final Map<String, Object> overriddenStreamsProperties;
   private final MetaStore metaStore;
   private final boolean updateMetastore;
-  private final SchemaRegistryClient schemaRegistryClient;
+  private final Supplier<SchemaRegistryClient> schemaRegistryClientFactory;
   private final QueryIdGenerator queryIdGenerator;
   private final KafkaStreamsBuilder kafkaStreamsBuilder;
 
@@ -80,7 +82,7 @@ public class PhysicalPlanBuilder {
       final Map<String, Object> overriddenStreamsProperties,
       final boolean updateMetastore,
       final MetaStore metaStore,
-      final SchemaRegistryClient schemaRegistryClient,
+      final Supplier<SchemaRegistryClient> schemaRegistryClientFactory,
       final QueryIdGenerator queryIdGenerator,
       final KafkaStreamsBuilder kafkaStreamsBuilder
   ) {
@@ -91,7 +93,7 @@ public class PhysicalPlanBuilder {
     this.overriddenStreamsProperties = overriddenStreamsProperties;
     this.metaStore = metaStore;
     this.updateMetastore = updateMetastore;
-    this.schemaRegistryClient = schemaRegistryClient;
+    this.schemaRegistryClientFactory = schemaRegistryClientFactory;
     this.queryIdGenerator = queryIdGenerator;
     this.kafkaStreamsBuilder = kafkaStreamsBuilder;
   }
@@ -105,7 +107,7 @@ public class PhysicalPlanBuilder {
             kafkaTopicClient,
             functionRegistry,
             overriddenStreamsProperties,
-            schemaRegistryClient
+            schemaRegistryClientFactory
         );
     final OutputNode outputNode = resultStream.outputNode();
     final boolean isBareQuery = outputNode instanceof KsqlBareOutputNode;

--- a/ksql-engine/src/main/java/io/confluent/ksql/planner/plan/AggregateNode.java
+++ b/ksql-engine/src/main/java/io/confluent/ksql/planner/plan/AggregateNode.java
@@ -46,6 +46,7 @@ import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.function.Supplier;
 import java.util.stream.Collectors;
 import org.apache.kafka.common.serialization.Serde;
 import org.apache.kafka.common.serialization.Serdes;
@@ -172,7 +173,7 @@ public class AggregateNode extends PlanNode {
       final KafkaTopicClient kafkaTopicClient,
       final FunctionRegistry functionRegistry,
       final Map<String, Object> props,
-      final SchemaRegistryClient schemaRegistryClient
+      final Supplier<SchemaRegistryClient> schemaRegistryClientFactory
   ) {
     final StructuredDataSourceNode streamSourceNode = getTheSourceNode();
     final SchemaKStream sourceSchemaKStream = getSource().buildStream(
@@ -181,7 +182,7 @@ public class AggregateNode extends PlanNode {
         kafkaTopicClient,
         functionRegistry,
         props,
-        schemaRegistryClient
+        schemaRegistryClientFactory
     );
 
     // Pre aggregate computations
@@ -198,7 +199,7 @@ public class AggregateNode extends PlanNode {
         aggregateArgExpanded.getSchema(),
         ksqlConfig,
         true,
-        schemaRegistryClient
+        schemaRegistryClientFactory
     );
 
     final List<Expression> internalGroupByColumns = internalSchema.getInternalExpressionList(
@@ -225,7 +226,7 @@ public class AggregateNode extends PlanNode {
         aggStageSchema,
         ksqlConfig,
         true,
-        schemaRegistryClient
+        schemaRegistryClientFactory
     );
 
     final KudafInitializer initializer = new KudafInitializer(aggValToValColumnMap.size());
@@ -250,7 +251,7 @@ public class AggregateNode extends PlanNode {
         schemaKTable.isWindowed(),
         SchemaKStream.Type.AGGREGATE,
         functionRegistry,
-        schemaRegistryClient
+        schemaRegistryClientFactory.get()
     );
 
     if (getHavingExpressions() != null) {

--- a/ksql-engine/src/main/java/io/confluent/ksql/planner/plan/FilterNode.java
+++ b/ksql-engine/src/main/java/io/confluent/ksql/planner/plan/FilterNode.java
@@ -27,6 +27,7 @@ import io.confluent.ksql.util.KafkaTopicClient;
 import io.confluent.ksql.util.KsqlConfig;
 import java.util.List;
 import java.util.Map;
+import java.util.function.Supplier;
 import javax.annotation.concurrent.Immutable;
 import org.apache.kafka.connect.data.Field;
 import org.apache.kafka.connect.data.Schema;
@@ -89,14 +90,15 @@ public class FilterNode
   }
 
   @Override
-  public SchemaKStream buildStream(final StreamsBuilder builder,
-                                   final KsqlConfig ksqlConfig,
-                                   final KafkaTopicClient kafkaTopicClient,
-                                   final FunctionRegistry functionRegistry,
-                                   final Map<String, Object> props,
-                                   final SchemaRegistryClient schemaRegistryClient) {
+  public SchemaKStream buildStream(
+      final StreamsBuilder builder,
+      final KsqlConfig ksqlConfig,
+      final KafkaTopicClient kafkaTopicClient,
+      final FunctionRegistry functionRegistry,
+      final Map<String, Object> props,
+      final Supplier<SchemaRegistryClient> schemaRegistryClientFactory) {
     return getSource().buildStream(builder, ksqlConfig, kafkaTopicClient,
-        functionRegistry, props, schemaRegistryClient)
+        functionRegistry, props, schemaRegistryClientFactory)
         .filter(getPredicate());
   }
 }

--- a/ksql-engine/src/main/java/io/confluent/ksql/planner/plan/KsqlBareOutputNode.java
+++ b/ksql-engine/src/main/java/io/confluent/ksql/planner/plan/KsqlBareOutputNode.java
@@ -26,6 +26,8 @@ import io.confluent.ksql.util.KsqlConfig;
 import io.confluent.ksql.util.timestamp.TimestampExtractionPolicy;
 import java.util.Map;
 import java.util.Optional;
+import java.util.function.Supplier;
+
 import org.apache.kafka.connect.data.Field;
 import org.apache.kafka.connect.data.Schema;
 import org.apache.kafka.streams.StreamsBuilder;
@@ -53,17 +55,18 @@ public class KsqlBareOutputNode extends OutputNode {
   }
 
   @Override
-  public SchemaKStream buildStream(final StreamsBuilder builder,
-                                   final KsqlConfig ksqlConfig,
-                                   final KafkaTopicClient kafkaTopicClient,
-                                   final FunctionRegistry functionRegistry,
-                                   final Map<String, Object> props,
-                                   final SchemaRegistryClient schemaRegistryClient) {
+  public SchemaKStream buildStream(
+      final StreamsBuilder builder,
+      final KsqlConfig ksqlConfig,
+      final KafkaTopicClient kafkaTopicClient,
+      final FunctionRegistry functionRegistry,
+      final Map<String, Object> props,
+      final Supplier<SchemaRegistryClient> schemaRegistryClientFactory) {
     final SchemaKStream schemaKStream = getSource().buildStream(builder,
         ksqlConfig,
         kafkaTopicClient,
         functionRegistry,
-        props, schemaRegistryClient);
+        props, schemaRegistryClientFactory);
 
     schemaKStream.setOutputNode(this);
     return schemaKStream.toQueue();

--- a/ksql-engine/src/main/java/io/confluent/ksql/planner/plan/KsqlStructuredDataOutputNode.java
+++ b/ksql-engine/src/main/java/io/confluent/ksql/planner/plan/KsqlStructuredDataOutputNode.java
@@ -36,6 +36,8 @@ import java.util.Collections;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
+import java.util.function.Supplier;
+
 import org.apache.kafka.common.config.TopicConfig;
 import org.apache.kafka.connect.data.Field;
 import org.apache.kafka.connect.data.Schema;
@@ -90,7 +92,7 @@ public class KsqlStructuredDataOutputNode extends OutputNode {
       final KafkaTopicClient kafkaTopicClient,
       final FunctionRegistry functionRegistry,
       final Map<String, Object> props,
-      final SchemaRegistryClient schemaRegistryClient
+      final Supplier<SchemaRegistryClient> schemaRegistryClientFactory
   ) {
     final PlanNode source = getSource();
     final SchemaKStream schemaKStream = source.buildStream(
@@ -99,7 +101,7 @@ public class KsqlStructuredDataOutputNode extends OutputNode {
         kafkaTopicClient,
         functionRegistry,
         props,
-        schemaRegistryClient
+        schemaRegistryClientFactory
     );
 
     final Set<Integer> rowkeyIndexes = SchemaUtil.getRowTimeRowKeyIndexes(getSchema());
@@ -124,7 +126,7 @@ public class KsqlStructuredDataOutputNode extends OutputNode {
         outputNodeBuilder,
         functionRegistry,
         outputProperties,
-        schemaRegistryClient
+        schemaRegistryClientFactory
     );
 
     final KsqlStructuredDataOutputNode noRowKey = outputNodeBuilder.build();
@@ -139,7 +141,8 @@ public class KsqlStructuredDataOutputNode extends OutputNode {
     result.into(
         noRowKey.getKafkaTopicName(),
         noRowKey.getKsqlTopic().getKsqlTopicSerDe()
-            .getGenericRowSerde(noRowKey.getSchema(), ksqlConfig, false, schemaRegistryClient),
+            .getGenericRowSerde(
+                noRowKey.getSchema(), ksqlConfig, false, schemaRegistryClientFactory),
         rowkeyIndexes
     );
 
@@ -162,7 +165,7 @@ public class KsqlStructuredDataOutputNode extends OutputNode {
       final KsqlStructuredDataOutputNode.Builder outputNodeBuilder,
       final FunctionRegistry functionRegistry,
       final Map<String, Object> outputProperties,
-      final SchemaRegistryClient schemaRegistryClient
+      final Supplier<SchemaRegistryClient> schemaRegistryClientFactory
   ) {
 
     if (schemaKStream instanceof SchemaKTable) {
@@ -176,7 +179,7 @@ public class KsqlStructuredDataOutputNode extends OutputNode {
         Collections.singletonList(schemaKStream),
         SchemaKStream.Type.SINK,
         functionRegistry,
-        schemaRegistryClient
+        schemaRegistryClientFactory.get()
     );
 
     if (outputProperties.containsKey(DdlConfig.PARTITION_BY_PROPERTY)) {

--- a/ksql-engine/src/main/java/io/confluent/ksql/planner/plan/PlanNode.java
+++ b/ksql-engine/src/main/java/io/confluent/ksql/planner/plan/PlanNode.java
@@ -26,6 +26,8 @@ import io.confluent.ksql.util.KafkaTopicClient;
 import io.confluent.ksql.util.KsqlConfig;
 import java.util.List;
 import java.util.Map;
+import java.util.function.Supplier;
+
 import org.apache.kafka.connect.data.Field;
 import org.apache.kafka.connect.data.Schema;
 import org.apache.kafka.streams.StreamsBuilder;
@@ -70,5 +72,5 @@ public abstract class PlanNode {
                                             KafkaTopicClient kafkaTopicClient,
                                             FunctionRegistry functionRegistry,
                                             Map<String, Object> props,
-                                            SchemaRegistryClient schemaRegistryClient);
+                                            Supplier<SchemaRegistryClient> schemaRegistryClient);
 }

--- a/ksql-engine/src/main/java/io/confluent/ksql/planner/plan/PlanNode.java
+++ b/ksql-engine/src/main/java/io/confluent/ksql/planner/plan/PlanNode.java
@@ -67,10 +67,11 @@ public abstract class PlanNode {
 
   protected abstract int getPartitions(KafkaTopicClient kafkaTopicClient);
 
-  public abstract SchemaKStream buildStream(StreamsBuilder builder,
-                                            KsqlConfig ksqlConfig,
-                                            KafkaTopicClient kafkaTopicClient,
-                                            FunctionRegistry functionRegistry,
-                                            Map<String, Object> props,
-                                            Supplier<SchemaRegistryClient> schemaRegistryClientFactory);
+  public abstract SchemaKStream buildStream(
+      StreamsBuilder builder,
+      KsqlConfig ksqlConfig,
+      KafkaTopicClient kafkaTopicClient,
+      FunctionRegistry functionRegistry,
+      Map<String, Object> props,
+      Supplier<SchemaRegistryClient> schemaRegistryClientFactory);
 }

--- a/ksql-engine/src/main/java/io/confluent/ksql/planner/plan/PlanNode.java
+++ b/ksql-engine/src/main/java/io/confluent/ksql/planner/plan/PlanNode.java
@@ -72,5 +72,5 @@ public abstract class PlanNode {
                                             KafkaTopicClient kafkaTopicClient,
                                             FunctionRegistry functionRegistry,
                                             Map<String, Object> props,
-                                            Supplier<SchemaRegistryClient> schemaRegistryClient);
+                                            Supplier<SchemaRegistryClient> schemaRegistryClientFactory);
 }

--- a/ksql-engine/src/main/java/io/confluent/ksql/planner/plan/ProjectNode.java
+++ b/ksql-engine/src/main/java/io/confluent/ksql/planner/plan/ProjectNode.java
@@ -33,6 +33,7 @@ import io.confluent.ksql.util.Pair;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
+import java.util.function.Supplier;
 import javax.annotation.concurrent.Immutable;
 import org.apache.kafka.connect.data.Field;
 import org.apache.kafka.connect.data.Schema;
@@ -111,14 +112,15 @@ public class ProjectNode
   }
 
   @Override
-  public SchemaKStream buildStream(final StreamsBuilder builder,
-                                   final KsqlConfig ksqlConfig,
-                                   final KafkaTopicClient kafkaTopicClient,
-                                   final FunctionRegistry functionRegistry,
-                                   final Map<String, Object> props,
-                                   final SchemaRegistryClient schemaRegistryClient) {
+  public SchemaKStream buildStream(
+      final StreamsBuilder builder,
+      final KsqlConfig ksqlConfig,
+      final KafkaTopicClient kafkaTopicClient,
+      final FunctionRegistry functionRegistry,
+      final Map<String, Object> props,
+      final Supplier<SchemaRegistryClient> schemaRegistryClientFactory) {
     return getSource().buildStream(builder, ksqlConfig, kafkaTopicClient,
-        functionRegistry, props, schemaRegistryClient)
+        functionRegistry, props, schemaRegistryClientFactory)
         .select(getProjectNameExpressionPairList());
   }
 }

--- a/ksql-engine/src/main/java/io/confluent/ksql/schema/registry/KsqlSchemaRegistryClientFactory.java
+++ b/ksql-engine/src/main/java/io/confluent/ksql/schema/registry/KsqlSchemaRegistryClientFactory.java
@@ -29,7 +29,7 @@ import org.apache.kafka.common.security.ssl.SslFactory;
 /**
  * Configurable Schema Registry client factory, enabling SSL.
  */
-public class KsqlSchemaRegistryClientFactory {
+public class KsqlSchemaRegistryClientFactory implements Supplier<SchemaRegistryClient> {
 
   private final SslFactory sslFactory;
   private final Supplier<RestService> serviceSupplier;
@@ -47,9 +47,7 @@ public class KsqlSchemaRegistryClientFactory {
     this(config,
         () -> new RestService(config.getString(KsqlConfig.SCHEMA_REGISTRY_URL_PROPERTY)),
         new SslFactory(Mode.CLIENT),
-        (service, mapCapacity, clientConfigs) -> new CachedSchemaRegistryClient(service,
-                                                                                mapCapacity,
-                                                                                clientConfigs)
+        CachedSchemaRegistryClient::new
     );
 
     // Force config exception now:
@@ -71,7 +69,7 @@ public class KsqlSchemaRegistryClientFactory {
     this.schemaRegistryClientFactory = schemaRegistryClientFactory;
   }
 
-  public SchemaRegistryClient create() {
+  public SchemaRegistryClient get() {
     final RestService restService = serviceSupplier.get();
     final SSLContext sslContext = sslFactory.sslContext();
     if (sslContext != null) {

--- a/ksql-engine/src/main/java/io/confluent/ksql/schema/registry/KsqlSchemaRegistryClientFactory.java
+++ b/ksql-engine/src/main/java/io/confluent/ksql/schema/registry/KsqlSchemaRegistryClientFactory.java
@@ -69,6 +69,7 @@ public class KsqlSchemaRegistryClientFactory implements Supplier<SchemaRegistryC
     this.schemaRegistryClientFactory = schemaRegistryClientFactory;
   }
 
+  @Override
   public SchemaRegistryClient get() {
     final RestService restService = serviceSupplier.get();
     final SSLContext sslContext = sslFactory.sslContext();

--- a/ksql-engine/src/main/java/io/confluent/ksql/schema/registry/KsqlSchemaRegistryClientFactory.java
+++ b/ksql-engine/src/main/java/io/confluent/ksql/schema/registry/KsqlSchemaRegistryClientFactory.java
@@ -29,7 +29,7 @@ import org.apache.kafka.common.security.ssl.SslFactory;
 /**
  * Configurable Schema Registry client factory, enabling SSL.
  */
-public class KsqlSchemaRegistryClientFactory implements Supplier<SchemaRegistryClient> {
+public class KsqlSchemaRegistryClientFactory {
 
   private final SslFactory sslFactory;
   private final Supplier<RestService> serviceSupplier;
@@ -69,7 +69,6 @@ public class KsqlSchemaRegistryClientFactory implements Supplier<SchemaRegistryC
     this.schemaRegistryClientFactory = schemaRegistryClientFactory;
   }
 
-  @Override
   public SchemaRegistryClient get() {
     final RestService restService = serviceSupplier.get();
     final SSLContext sslContext = sslFactory.sslContext();

--- a/ksql-engine/src/main/java/io/confluent/ksql/schema/registry/MockSchemaRegistryClientFactory.java
+++ b/ksql-engine/src/main/java/io/confluent/ksql/schema/registry/MockSchemaRegistryClientFactory.java
@@ -1,0 +1,29 @@
+/*
+ * Copyright 2018 Confluent Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.confluent.ksql.schema.registry;
+
+import io.confluent.kafka.schemaregistry.client.MockSchemaRegistryClient;
+import io.confluent.kafka.schemaregistry.client.SchemaRegistryClient;
+
+import java.util.function.Supplier;
+
+public class MockSchemaRegistryClientFactory implements Supplier<SchemaRegistryClient> {
+  @Override
+  public SchemaRegistryClient get() {
+    return new MockSchemaRegistryClient();
+  }
+}

--- a/ksql-engine/src/main/java/io/confluent/ksql/schema/registry/MockSchemaRegistryClientFactory.java
+++ b/ksql-engine/src/main/java/io/confluent/ksql/schema/registry/MockSchemaRegistryClientFactory.java
@@ -19,10 +19,7 @@ package io.confluent.ksql.schema.registry;
 import io.confluent.kafka.schemaregistry.client.MockSchemaRegistryClient;
 import io.confluent.kafka.schemaregistry.client.SchemaRegistryClient;
 
-import java.util.function.Supplier;
-
-public class MockSchemaRegistryClientFactory implements Supplier<SchemaRegistryClient> {
-  @Override
+public class MockSchemaRegistryClientFactory {
   public SchemaRegistryClient get() {
     return new MockSchemaRegistryClient();
   }

--- a/ksql-engine/src/test/java/io/confluent/ksql/EndToEndEngineTestUtil.java
+++ b/ksql-engine/src/test/java/io/confluent/ksql/EndToEndEngineTestUtil.java
@@ -472,7 +472,6 @@ class EndToEndEngineTestUtil {
     try (final KsqlEngine ksqlEngine = new KsqlEngine(
         new FakeKafkaTopicClient(),
         schemaRegistryClientFactory,
-        schemaRegistryClient,
         metaStore
     )) {
       query.initializeTopics(ksqlEngine);

--- a/ksql-engine/src/test/java/io/confluent/ksql/EndToEndEngineTestUtil.java
+++ b/ksql-engine/src/test/java/io/confluent/ksql/EndToEndEngineTestUtil.java
@@ -27,6 +27,7 @@ import io.confluent.ksql.function.InternalFunctionRegistry;
 import io.confluent.ksql.function.UdfLoaderUtil;
 import io.confluent.ksql.metastore.MetaStore;
 import io.confluent.ksql.metastore.MetaStoreImpl;
+import io.confluent.ksql.schema.registry.MockSchemaRegistryClientFactory;
 import io.confluent.ksql.util.FakeKafkaTopicClient;
 import io.confluent.ksql.util.KsqlConfig;
 import io.confluent.ksql.util.KsqlConstants;
@@ -40,6 +41,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Properties;
+import java.util.function.Supplier;
 import java.util.stream.Collectors;
 import org.apache.avro.generic.GenericData;
 import org.apache.avro.generic.GenericRecord;
@@ -453,6 +455,7 @@ class EndToEndEngineTestUtil {
   static void shouldBuildAndExecuteQuery(final Query query) {
     final MetaStore metaStore = new MetaStoreImpl(functionRegistry);
     final SchemaRegistryClient schemaRegistryClient = new MockSchemaRegistryClient();
+    final Supplier<SchemaRegistryClient> schemaRegistryClientFactory = () -> schemaRegistryClient;
 
     final Map<String, Object> config = new HashMap<String, Object>() {{
       put(ConsumerConfig.BOOTSTRAP_SERVERS_CONFIG, "localhost:0");
@@ -468,6 +471,7 @@ class EndToEndEngineTestUtil {
 
     try (final KsqlEngine ksqlEngine = new KsqlEngine(
         new FakeKafkaTopicClient(),
+        schemaRegistryClientFactory,
         schemaRegistryClient,
         metaStore
     )) {

--- a/ksql-engine/src/test/java/io/confluent/ksql/KsqlEngineTest.java
+++ b/ksql-engine/src/test/java/io/confluent/ksql/KsqlEngineTest.java
@@ -16,9 +16,13 @@
 
 package io.confluent.ksql;
 
+import static org.easymock.EasyMock.anyBoolean;
+import static org.easymock.EasyMock.anyObject;
+import static org.easymock.EasyMock.expect;
 import static org.easymock.EasyMock.expectLastCall;
 import static org.easymock.EasyMock.niceMock;
 import static org.easymock.EasyMock.replay;
+import static org.easymock.EasyMock.same;
 import static org.easymock.EasyMock.verify;
 import static org.hamcrest.CoreMatchers.containsString;
 import static org.hamcrest.CoreMatchers.equalTo;
@@ -29,7 +33,6 @@ import static org.hamcrest.MatcherAssert.assertThat;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.common.collect.ImmutableMap;
-import io.confluent.kafka.schemaregistry.client.MockSchemaRegistryClient;
 import io.confluent.kafka.schemaregistry.client.SchemaRegistryClient;
 import io.confluent.ksql.function.InternalFunctionRegistry;
 import io.confluent.ksql.metastore.MetaStore;
@@ -37,6 +40,9 @@ import io.confluent.ksql.metastore.StructuredDataSource;
 import io.confluent.ksql.parser.exception.ParseFailedException;
 import io.confluent.ksql.parser.tree.Statement;
 import io.confluent.ksql.query.QueryId;
+import io.confluent.ksql.schema.registry.MockSchemaRegistryClientFactory;
+import io.confluent.ksql.serde.KsqlTopicSerDe;
+import io.confluent.ksql.serde.json.KsqlJsonTopicSerDe;
 import io.confluent.ksql.util.FakeKafkaTopicClient;
 import io.confluent.ksql.util.KafkaTopicClient;
 import io.confluent.ksql.util.KsqlConfig;
@@ -48,6 +54,8 @@ import io.confluent.ksql.util.QueryMetadata;
 import java.nio.ByteBuffer;
 import java.util.Collections;
 import java.util.List;
+import java.util.function.Supplier;
+
 import org.apache.avro.Schema;
 import org.apache.avro.SchemaBuilder;
 import org.apache.kafka.common.utils.Utils;
@@ -57,15 +65,20 @@ import org.junit.After;
 import org.junit.Assert;
 import org.junit.Test;
 
+import static org.easymock.EasyMock.mock;
+
 public class KsqlEngineTest {
 
   private final KafkaTopicClient topicClient = new FakeKafkaTopicClient();
-  private final SchemaRegistryClient schemaRegistryClient = new MockSchemaRegistryClient();
+  private final Supplier<SchemaRegistryClient> schemaRegistryClientFactory
+      = new MockSchemaRegistryClientFactory();
+  private final SchemaRegistryClient schemaRegistryClient = schemaRegistryClientFactory.get();
   private final MetaStore metaStore = MetaStoreFixture.getNewMetaStore(new InternalFunctionRegistry());
   private final KsqlConfig ksqlConfig
       = new KsqlConfig(ImmutableMap.of(StreamsConfig.BOOTSTRAP_SERVERS_CONFIG, "localhost:9092"));
   private final KsqlEngine ksqlEngine = new KsqlEngine(
       topicClient,
+      schemaRegistryClientFactory,
       schemaRegistryClient,
       new DefaultKafkaClientSupplier(),
       metaStore);
@@ -326,12 +339,45 @@ public class KsqlEngineTest {
     topicClient.close();
     expectLastCall();
     replay(topicClient);
-    final KsqlEngine ksqlEngine = new KsqlEngine(topicClient, schemaRegistryClient, metaStore);
+    final KsqlEngine ksqlEngine = new KsqlEngine(
+        topicClient,
+        schemaRegistryClientFactory,
+        schemaRegistryClient,
+        metaStore);
 
     // When:
     ksqlEngine.close();
 
     // Then:
     verify(topicClient);
+  }
+
+  @Test
+  public void shouldUseSerdeSupplierToBuildQueries() {
+    final KsqlTopicSerDe mockKsqlSerde = mock(KsqlTopicSerDe.class);
+    final MetaStore metaStore =
+        MetaStoreFixture.getNewMetaStore(new InternalFunctionRegistry(), () -> mockKsqlSerde);
+    final KsqlEngine ksqlEngine = new KsqlEngine(
+        topicClient,
+        schemaRegistryClientFactory,
+        schemaRegistryClient,
+        new DefaultKafkaClientSupplier(),
+        metaStore
+    );
+
+    expect(
+        mockKsqlSerde.getGenericRowSerde(
+            anyObject(org.apache.kafka.connect.data.Schema.class),
+            anyObject(KsqlConfig.class),
+            anyBoolean(),
+            same(schemaRegistryClientFactory)))
+        .andDelegateTo(new KsqlJsonTopicSerDe())
+        .atLeastOnce();
+
+    replay(mockKsqlSerde);
+
+    ksqlEngine.createQueries("create table bar as select * from test2;", ksqlConfig);
+
+    verify(mockKsqlSerde);
   }
 }

--- a/ksql-engine/src/test/java/io/confluent/ksql/KsqlEngineTest.java
+++ b/ksql-engine/src/test/java/io/confluent/ksql/KsqlEngineTest.java
@@ -33,6 +33,7 @@ import static org.hamcrest.MatcherAssert.assertThat;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.common.collect.ImmutableMap;
+import io.confluent.kafka.schemaregistry.client.MockSchemaRegistryClient;
 import io.confluent.kafka.schemaregistry.client.SchemaRegistryClient;
 import io.confluent.ksql.function.InternalFunctionRegistry;
 import io.confluent.ksql.metastore.MetaStore;
@@ -70,9 +71,9 @@ import static org.easymock.EasyMock.mock;
 public class KsqlEngineTest {
 
   private final KafkaTopicClient topicClient = new FakeKafkaTopicClient();
-  private final Supplier<SchemaRegistryClient> schemaRegistryClientFactory
-      = new MockSchemaRegistryClientFactory();
-  private final SchemaRegistryClient schemaRegistryClient = schemaRegistryClientFactory.get();
+  private final SchemaRegistryClient schemaRegistryClient = new MockSchemaRegistryClient();
+  private final Supplier<SchemaRegistryClient> schemaRegistryClientFactory =
+      () -> schemaRegistryClient;
   private final MetaStore metaStore = MetaStoreFixture.getNewMetaStore(new InternalFunctionRegistry());
   private final KsqlConfig ksqlConfig
       = new KsqlConfig(ImmutableMap.of(StreamsConfig.BOOTSTRAP_SERVERS_CONFIG, "localhost:9092"));
@@ -342,7 +343,6 @@ public class KsqlEngineTest {
     final KsqlEngine ksqlEngine = new KsqlEngine(
         topicClient,
         schemaRegistryClientFactory,
-        schemaRegistryClient,
         metaStore);
 
     // When:

--- a/ksql-engine/src/test/java/io/confluent/ksql/KsqlEngineTest.java
+++ b/ksql-engine/src/test/java/io/confluent/ksql/KsqlEngineTest.java
@@ -41,7 +41,6 @@ import io.confluent.ksql.metastore.StructuredDataSource;
 import io.confluent.ksql.parser.exception.ParseFailedException;
 import io.confluent.ksql.parser.tree.Statement;
 import io.confluent.ksql.query.QueryId;
-import io.confluent.ksql.schema.registry.MockSchemaRegistryClientFactory;
 import io.confluent.ksql.serde.KsqlTopicSerDe;
 import io.confluent.ksql.serde.json.KsqlJsonTopicSerDe;
 import io.confluent.ksql.util.FakeKafkaTopicClient;

--- a/ksql-engine/src/test/java/io/confluent/ksql/KsqlEngineTest.java
+++ b/ksql-engine/src/test/java/io/confluent/ksql/KsqlEngineTest.java
@@ -80,7 +80,6 @@ public class KsqlEngineTest {
   private final KsqlEngine ksqlEngine = new KsqlEngine(
       topicClient,
       schemaRegistryClientFactory,
-      schemaRegistryClient,
       new DefaultKafkaClientSupplier(),
       metaStore);
 
@@ -360,7 +359,6 @@ public class KsqlEngineTest {
     final KsqlEngine ksqlEngine = new KsqlEngine(
         topicClient,
         schemaRegistryClientFactory,
-        schemaRegistryClient,
         new DefaultKafkaClientSupplier(),
         metaStore
     );

--- a/ksql-engine/src/test/java/io/confluent/ksql/integration/IntegrationTestHarness.java
+++ b/ksql-engine/src/test/java/io/confluent/ksql/integration/IntegrationTestHarness.java
@@ -4,7 +4,6 @@ package io.confluent.ksql.integration;
 import io.confluent.kafka.schemaregistry.client.MockSchemaRegistryClient;
 import io.confluent.kafka.schemaregistry.client.SchemaRegistryClient;
 import io.confluent.ksql.GenericRow;
-import io.confluent.ksql.schema.registry.MockSchemaRegistryClientFactory;
 import io.confluent.ksql.serde.DataSource;
 import io.confluent.ksql.serde.avro.KsqlAvroTopicSerDe;
 import io.confluent.ksql.serde.delimited.KsqlDelimitedDeserializer;
@@ -27,7 +26,6 @@ import java.util.concurrent.ExecutionException;
 import java.util.concurrent.Future;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
-import java.util.concurrent.atomic.AtomicInteger;
 import java.util.function.Supplier;
 
 import org.apache.kafka.clients.consumer.ConsumerConfig;
@@ -326,7 +324,8 @@ public class IntegrationTestHarness {
         return new KsqlJsonSerializer(schema);
       case AVRO:
         return new KsqlAvroTopicSerDe().getGenericRowSerde(
-            schema, new KsqlConfig(Collections.emptyMap()), false, this.schemaRegistryClient
+            schema, new KsqlConfig(Collections.emptyMap()), false,
+            () -> this.schemaRegistryClient
         ).serializer();
       case DELIMITED:
         return new KsqlDelimitedSerializer(schema);
@@ -342,7 +341,8 @@ public class IntegrationTestHarness {
         return new KsqlJsonDeserializer(schema, false);
       case AVRO:
         return new KsqlAvroTopicSerDe().getGenericRowSerde(
-            schema, new KsqlConfig(Collections.emptyMap()), false, this.schemaRegistryClient
+            schema, new KsqlConfig(Collections.emptyMap()), false,
+            () -> this.schemaRegistryClient
         ).deserializer();
       case DELIMITED:
         return new KsqlDelimitedDeserializer(schema);

--- a/ksql-engine/src/test/java/io/confluent/ksql/integration/IntegrationTestHarness.java
+++ b/ksql-engine/src/test/java/io/confluent/ksql/integration/IntegrationTestHarness.java
@@ -4,6 +4,7 @@ package io.confluent.ksql.integration;
 import io.confluent.kafka.schemaregistry.client.MockSchemaRegistryClient;
 import io.confluent.kafka.schemaregistry.client.SchemaRegistryClient;
 import io.confluent.ksql.GenericRow;
+import io.confluent.ksql.schema.registry.MockSchemaRegistryClientFactory;
 import io.confluent.ksql.serde.DataSource;
 import io.confluent.ksql.serde.avro.KsqlAvroTopicSerDe;
 import io.confluent.ksql.serde.delimited.KsqlDelimitedDeserializer;
@@ -26,6 +27,9 @@ import java.util.concurrent.ExecutionException;
 import java.util.concurrent.Future;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.function.Supplier;
+
 import org.apache.kafka.clients.consumer.ConsumerConfig;
 import org.apache.kafka.clients.consumer.ConsumerRecord;
 import org.apache.kafka.clients.consumer.KafkaConsumer;
@@ -55,12 +59,14 @@ public class IntegrationTestHarness {
   public KsqlConfig ksqlConfig;
   private KafkaTopicClientImpl topicClient;
 
+  public Supplier<SchemaRegistryClient> schemaRegistryClientFactory;
   public SchemaRegistryClient schemaRegistryClient;
 
   private final Map<String, Object> unifiedConfigs = new HashMap<>();
 
   public IntegrationTestHarness() {
     this.schemaRegistryClient = new MockSchemaRegistryClient();
+    this.schemaRegistryClientFactory = () -> this.schemaRegistryClient;
   }
 
   public KafkaTopicClient topicClient() {

--- a/ksql-engine/src/test/java/io/confluent/ksql/integration/JoinIntTest.java
+++ b/ksql-engine/src/test/java/io/confluent/ksql/integration/JoinIntTest.java
@@ -55,6 +55,7 @@ public class JoinIntTest {
     ksqlStreamConfigProps.put(StreamsConfig.CACHE_MAX_BYTES_BUFFERING_CONFIG, 0);
     ksqlStreamConfigProps.put(ConsumerConfig.AUTO_OFFSET_RESET_CONFIG, "latest");
     ksqlContext = KsqlContext.create(new KsqlConfig(ksqlStreamConfigProps),
+                                     testHarness.schemaRegistryClientFactory,
                                      testHarness.schemaRegistryClient);
 
     /**

--- a/ksql-engine/src/test/java/io/confluent/ksql/integration/JoinIntTest.java
+++ b/ksql-engine/src/test/java/io/confluent/ksql/integration/JoinIntTest.java
@@ -55,8 +55,7 @@ public class JoinIntTest {
     ksqlStreamConfigProps.put(StreamsConfig.CACHE_MAX_BYTES_BUFFERING_CONFIG, 0);
     ksqlStreamConfigProps.put(ConsumerConfig.AUTO_OFFSET_RESET_CONFIG, "latest");
     ksqlContext = KsqlContext.create(new KsqlConfig(ksqlStreamConfigProps),
-                                     testHarness.schemaRegistryClientFactory,
-                                     testHarness.schemaRegistryClient);
+                                     testHarness.schemaRegistryClientFactory);
 
     /**
      * Setup test data

--- a/ksql-engine/src/test/java/io/confluent/ksql/integration/StreamsSelectAndProjectIntTest.java
+++ b/ksql-engine/src/test/java/io/confluent/ksql/integration/StreamsSelectAndProjectIntTest.java
@@ -43,7 +43,10 @@ public class StreamsSelectAndProjectIntTest {
   public void before() throws Exception {
     testHarness = new IntegrationTestHarness();
     testHarness.start(Collections.emptyMap());
-    ksqlContext = KsqlContext.create(testHarness.ksqlConfig, testHarness.schemaRegistryClient);
+    ksqlContext = KsqlContext.create(
+        testHarness.ksqlConfig,
+        testHarness.schemaRegistryClientFactory,
+        testHarness.schemaRegistryClient);
     testHarness.createTopic(jsonTopicName);
     testHarness.createTopic(avroTopicName);
 

--- a/ksql-engine/src/test/java/io/confluent/ksql/integration/StreamsSelectAndProjectIntTest.java
+++ b/ksql-engine/src/test/java/io/confluent/ksql/integration/StreamsSelectAndProjectIntTest.java
@@ -45,8 +45,7 @@ public class StreamsSelectAndProjectIntTest {
     testHarness.start(Collections.emptyMap());
     ksqlContext = KsqlContext.create(
         testHarness.ksqlConfig,
-        testHarness.schemaRegistryClientFactory,
-        testHarness.schemaRegistryClient);
+        testHarness.schemaRegistryClientFactory);
     testHarness.createTopic(jsonTopicName);
     testHarness.createTopic(avroTopicName);
 

--- a/ksql-engine/src/test/java/io/confluent/ksql/integration/UdfIntTest.java
+++ b/ksql-engine/src/test/java/io/confluent/ksql/integration/UdfIntTest.java
@@ -49,7 +49,10 @@ public class UdfIntTest {
   public void before() throws Exception {
     testHarness = new IntegrationTestHarness();
     testHarness.start(Collections.emptyMap());
-    ksqlContext = KsqlContext.create(testHarness.ksqlConfig, testHarness.schemaRegistryClient);
+    ksqlContext = KsqlContext.create(
+        testHarness.ksqlConfig,
+        testHarness.schemaRegistryClientFactory,
+        testHarness.schemaRegistryClient);
     testHarness.createTopic(jsonTopicName);
 
     testHarness.createTopic(avroTopicName);

--- a/ksql-engine/src/test/java/io/confluent/ksql/integration/UdfIntTest.java
+++ b/ksql-engine/src/test/java/io/confluent/ksql/integration/UdfIntTest.java
@@ -51,8 +51,7 @@ public class UdfIntTest {
     testHarness.start(Collections.emptyMap());
     ksqlContext = KsqlContext.create(
         testHarness.ksqlConfig,
-        testHarness.schemaRegistryClientFactory,
-        testHarness.schemaRegistryClient);
+        testHarness.schemaRegistryClientFactory);
     testHarness.createTopic(jsonTopicName);
 
     testHarness.createTopic(avroTopicName);

--- a/ksql-engine/src/test/java/io/confluent/ksql/physical/PhysicalPlanBuilderTest.java
+++ b/ksql-engine/src/test/java/io/confluent/ksql/physical/PhysicalPlanBuilderTest.java
@@ -73,7 +73,6 @@ public class PhysicalPlanBuilderTest {
   private LogicalPlanBuilder planBuilder;
   private final Supplier<SchemaRegistryClient> schemaRegistryClientFactory
       = new MockSchemaRegistryClientFactory();
-  private final SchemaRegistryClient schemaRegistryClient = schemaRegistryClientFactory.get();
   private final KsqlConfig ksqlConfig = new KsqlConfig(
       ImmutableMap.of(
           ConsumerConfig.BOOTSTRAP_SERVERS_CONFIG, "localhost:9092",
@@ -192,7 +191,6 @@ public class PhysicalPlanBuilderTest {
     final KsqlEngine ksqlEngine = new KsqlEngine(
         kafkaTopicClient,
         schemaRegistryClientFactory,
-        schemaRegistryClient,
         new MetaStoreImpl(new InternalFunctionRegistry()));
 
     final List<QueryMetadata> queryMetadataList = ksqlEngine.buildMultipleQueries(
@@ -225,7 +223,6 @@ public class PhysicalPlanBuilderTest {
     final KsqlEngine ksqlEngine = new KsqlEngine(
         new FakeKafkaTopicClient(),
         schemaRegistryClientFactory,
-        schemaRegistryClient,
         new MetaStoreImpl(new InternalFunctionRegistry()));
     try {
       final List<QueryMetadata> queryMetadataList = ksqlEngine.buildMultipleQueries(
@@ -254,7 +251,6 @@ public class PhysicalPlanBuilderTest {
     final KsqlEngine ksqlEngine = new KsqlEngine(
         kafkaTopicClient,
         schemaRegistryClientFactory,
-        schemaRegistryClient,
         new MetaStoreImpl(new InternalFunctionRegistry()));
 
     try {
@@ -284,7 +280,6 @@ public class PhysicalPlanBuilderTest {
     final KsqlEngine ksqlEngine = new KsqlEngine(
         kafkaTopicClient,
         schemaRegistryClientFactory,
-        schemaRegistryClient,
         new MetaStoreImpl(new InternalFunctionRegistry()));
 
     final List<QueryMetadata> queryMetadataList = ksqlEngine.buildMultipleQueries(
@@ -323,7 +318,6 @@ public class PhysicalPlanBuilderTest {
     final KsqlEngine ksqlEngine = new KsqlEngine(
         kafkaTopicClient,
         schemaRegistryClientFactory,
-        schemaRegistryClient,
         new MetaStoreImpl(new InternalFunctionRegistry()));
 
     try {
@@ -350,7 +344,6 @@ public class PhysicalPlanBuilderTest {
     final KsqlEngine ksqlEngine = new KsqlEngine(
         kafkaTopicClient,
         schemaRegistryClientFactory,
-        schemaRegistryClient,
         new MetaStoreImpl(new InternalFunctionRegistry()));
 
     final List<QueryMetadata> queryMetadataList = ksqlEngine.buildMultipleQueries(
@@ -380,7 +373,6 @@ public class PhysicalPlanBuilderTest {
     final KsqlEngine ksqlEngine = new KsqlEngine(
         kafkaTopicClient,
         schemaRegistryClientFactory,
-        schemaRegistryClient,
         new MetaStoreImpl(new InternalFunctionRegistry()));
 
     try {
@@ -593,7 +585,6 @@ public class PhysicalPlanBuilderTest {
     final KsqlEngine ksqlEngine = new KsqlEngine(
         kafkaTopicClient,
         schemaRegistryClientFactory,
-        schemaRegistryClient,
         new MetaStoreImpl(new InternalFunctionRegistry()));
 
     final List<QueryMetadata> queryMetadataList = ksqlEngine.buildMultipleQueries(createStream + "\n " +

--- a/ksql-engine/src/test/java/io/confluent/ksql/physical/PhysicalPlanBuilderTest.java
+++ b/ksql-engine/src/test/java/io/confluent/ksql/physical/PhysicalPlanBuilderTest.java
@@ -72,7 +72,7 @@ public class PhysicalPlanBuilderTest {
   private final MetaStore metaStore = MetaStoreFixture.getNewMetaStore(new InternalFunctionRegistry());
   private LogicalPlanBuilder planBuilder;
   private final Supplier<SchemaRegistryClient> schemaRegistryClientFactory
-      = new MockSchemaRegistryClientFactory();
+      = new MockSchemaRegistryClientFactory()::get;
   private final KsqlConfig ksqlConfig = new KsqlConfig(
       ImmutableMap.of(
           ConsumerConfig.BOOTSTRAP_SERVERS_CONFIG, "localhost:9092",

--- a/ksql-engine/src/test/java/io/confluent/ksql/planner/plan/AggregateNodeTest.java
+++ b/ksql-engine/src/test/java/io/confluent/ksql/planner/plan/AggregateNodeTest.java
@@ -26,6 +26,7 @@ import static org.junit.Assert.assertTrue;
 
 import io.confluent.kafka.schemaregistry.client.MockSchemaRegistryClient;
 import io.confluent.ksql.function.InternalFunctionRegistry;
+import io.confluent.ksql.schema.registry.MockSchemaRegistryClientFactory;
 import io.confluent.ksql.structured.LogicalPlanBuilder;
 import io.confluent.ksql.structured.SchemaKStream;
 import io.confluent.ksql.structured.SchemaKTable;
@@ -147,7 +148,7 @@ public class AggregateNodeTest {
         ksqlConfig,
         topicClient,
         new InternalFunctionRegistry(),
-        new HashMap<>(), new MockSchemaRegistryClient());
+        new HashMap<>(), new MockSchemaRegistryClientFactory());
   }
 
 }

--- a/ksql-engine/src/test/java/io/confluent/ksql/planner/plan/AggregateNodeTest.java
+++ b/ksql-engine/src/test/java/io/confluent/ksql/planner/plan/AggregateNodeTest.java
@@ -148,7 +148,7 @@ public class AggregateNodeTest {
         ksqlConfig,
         topicClient,
         new InternalFunctionRegistry(),
-        new HashMap<>(), new MockSchemaRegistryClientFactory());
+        new HashMap<>(), new MockSchemaRegistryClientFactory()::get);
   }
 
 }

--- a/ksql-engine/src/test/java/io/confluent/ksql/planner/plan/JoinNodeTest.java
+++ b/ksql-engine/src/test/java/io/confluent/ksql/planner/plan/JoinNodeTest.java
@@ -161,7 +161,7 @@ public class JoinNodeTest {
         ksqlConfig,
         topicClient,
         new InternalFunctionRegistry(),
-        new HashMap<>(), new MockSchemaRegistryClientFactory());
+        new HashMap<>(), new MockSchemaRegistryClientFactory()::get);
   }
 
   private void

--- a/ksql-engine/src/test/java/io/confluent/ksql/planner/plan/JoinNodeTest.java
+++ b/ksql-engine/src/test/java/io/confluent/ksql/planner/plan/JoinNodeTest.java
@@ -41,6 +41,7 @@ import io.confluent.ksql.metastore.KsqlTopic;
 import io.confluent.ksql.metastore.MetaStore;
 import io.confluent.ksql.metastore.StructuredDataSource;
 import io.confluent.ksql.parser.tree.WithinExpression;
+import io.confluent.ksql.schema.registry.MockSchemaRegistryClientFactory;
 import io.confluent.ksql.serde.DataSource;
 import io.confluent.ksql.serde.KsqlTopicSerDe;
 import io.confluent.ksql.structured.LogicalPlanBuilder;
@@ -59,6 +60,7 @@ import java.util.Optional;
 import java.util.Set;
 import java.util.concurrent.TimeUnit;
 import java.util.function.Predicate;
+import java.util.function.Supplier;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 
@@ -93,7 +95,7 @@ public class JoinNodeTest {
   private KsqlConfig mockKsqlConfig;
   private KafkaTopicClient mockKafkaTopicClient;
   private FunctionRegistry mockFunctionRegistry;
-  private SchemaRegistryClient mockSchemaRegistryClient;
+  private Supplier<SchemaRegistryClient> mockSchemaRegistryClientFactory;
   private final Schema leftSchema = createSchema();
   private final Schema rightSchema = createSchema();
   private final Schema joinSchema = joinSchema();
@@ -114,12 +116,13 @@ public class JoinNodeTest {
   private Field joinKey;
 
   @Before
+  @SuppressWarnings("unchecked")
   public void setUp() {
     mockStreamsBuilder = niceMock(StreamsBuilder.class);
     mockKsqlConfig = niceMock(KsqlConfig.class);
     mockKafkaTopicClient = niceMock(KafkaTopicClient.class);
     mockFunctionRegistry = niceMock(FunctionRegistry.class);
-    mockSchemaRegistryClient = niceMock(SchemaRegistryClient.class);
+    mockSchemaRegistryClientFactory = niceMock(Supplier.class);
 
     properties = new HashMap<>();
 
@@ -158,7 +161,7 @@ public class JoinNodeTest {
         ksqlConfig,
         topicClient,
         new InternalFunctionRegistry(),
-        new HashMap<>(), new MockSchemaRegistryClient());
+        new HashMap<>(), new MockSchemaRegistryClientFactory());
   }
 
   private void
@@ -283,7 +286,7 @@ public class JoinNodeTest {
                          mockKafkaTopicClient,
                          mockFunctionRegistry,
                          properties,
-                         mockSchemaRegistryClient);
+                         mockSchemaRegistryClientFactory);
 
     verify(left, right, leftSchemaKStream, rightSchemaKStream);
 
@@ -331,7 +334,7 @@ public class JoinNodeTest {
                          mockKafkaTopicClient,
                          mockFunctionRegistry,
                          properties,
-                         mockSchemaRegistryClient);
+                         mockSchemaRegistryClientFactory);
 
     verify(left, right, leftSchemaKStream, rightSchemaKStream);
 
@@ -379,7 +382,7 @@ public class JoinNodeTest {
                          mockKafkaTopicClient,
                          mockFunctionRegistry,
                          properties,
-                         mockSchemaRegistryClient);
+                         mockSchemaRegistryClientFactory);
 
     verify(left, right, leftSchemaKStream, rightSchemaKStream);
 
@@ -419,7 +422,7 @@ public class JoinNodeTest {
                            mockKafkaTopicClient,
                            mockFunctionRegistry,
                            properties,
-                           mockSchemaRegistryClient);
+                           mockSchemaRegistryClientFactory);
       fail("Should have raised an exception since no join window was specified");
     } catch (final KsqlException e) {
       assertTrue(e.getMessage().startsWith("Stream-Stream joins must have a WITHIN clause specified"
@@ -469,7 +472,7 @@ public class JoinNodeTest {
                            mockKafkaTopicClient,
                            mockFunctionRegistry,
                            properties,
-                           mockSchemaRegistryClient);
+                           mockSchemaRegistryClientFactory);
       fail("should have raised an exception since the number of partitions on the input sources "
            + "don't match");
     } catch (final KsqlException e) {
@@ -527,7 +530,7 @@ public class JoinNodeTest {
           mockKafkaTopicClient,
           mockFunctionRegistry,
           properties,
-          mockSchemaRegistryClient);
+          mockSchemaRegistryClientFactory);
     } catch (final KsqlException e) {
       assertThat(
           e.getMessage(),
@@ -576,7 +579,7 @@ public class JoinNodeTest {
                          mockKafkaTopicClient,
                          mockFunctionRegistry,
                          properties,
-                         mockSchemaRegistryClient);
+                         mockSchemaRegistryClientFactory);
 
     verify(left, right, leftSchemaKStream, rightSchemaKTable);
 
@@ -620,7 +623,7 @@ public class JoinNodeTest {
                          mockKafkaTopicClient,
                          mockFunctionRegistry,
                          properties,
-                         mockSchemaRegistryClient);
+                         mockSchemaRegistryClientFactory);
 
     verify(left, right, leftSchemaKStream, rightSchemaKTable);
 
@@ -658,7 +661,7 @@ public class JoinNodeTest {
                            mockKafkaTopicClient,
                            mockFunctionRegistry,
                            properties,
-                           mockSchemaRegistryClient);
+                           mockSchemaRegistryClientFactory);
       fail("Should have failed to build the stream since stream-table outer joins are not "
            + "supported");
     } catch (final KsqlException e) {
@@ -706,7 +709,7 @@ public class JoinNodeTest {
                            mockKafkaTopicClient,
                            mockFunctionRegistry,
                            properties,
-                           mockSchemaRegistryClient);
+                           mockSchemaRegistryClientFactory);
       fail("should have raised an exception since a join window was provided for a stream-table "
            + "join");
     } catch (final KsqlException e) {
@@ -750,7 +753,7 @@ public class JoinNodeTest {
           mockKafkaTopicClient,
           mockFunctionRegistry,
           properties,
-          mockSchemaRegistryClient);
+          mockSchemaRegistryClientFactory);
     } catch (final KsqlException e) {
       assertThat(
           e.getMessage(),
@@ -794,7 +797,7 @@ public class JoinNodeTest {
           mockKafkaTopicClient,
           mockFunctionRegistry,
           properties,
-          mockSchemaRegistryClient);
+          mockSchemaRegistryClientFactory);
     } catch (final KsqlException e) {
       assertThat(
           e.getMessage(),
@@ -842,7 +845,7 @@ public class JoinNodeTest {
                          mockKafkaTopicClient,
                          mockFunctionRegistry,
                          properties,
-                         mockSchemaRegistryClient);
+                         mockSchemaRegistryClientFactory);
 
     verify(left, right, leftSchemaKTable, rightSchemaKTable);
 
@@ -885,7 +888,7 @@ public class JoinNodeTest {
                          mockKafkaTopicClient,
                          mockFunctionRegistry,
                          properties,
-                         mockSchemaRegistryClient);
+                         mockSchemaRegistryClientFactory);
 
     verify(left, right, leftSchemaKTable, rightSchemaKTable);
 
@@ -928,7 +931,7 @@ public class JoinNodeTest {
                          mockKafkaTopicClient,
                          mockFunctionRegistry,
                          properties,
-                         mockSchemaRegistryClient);
+                         mockSchemaRegistryClientFactory);
 
     verify(left, right, leftSchemaKTable, rightSchemaKTable);
 
@@ -970,7 +973,7 @@ public class JoinNodeTest {
                            mockKafkaTopicClient,
                            mockFunctionRegistry,
                            properties,
-                           mockSchemaRegistryClient);
+                           mockSchemaRegistryClientFactory);
       fail("should have raised an exception since a join window was provided for a stream-table "
            + "join");
     } catch (final KsqlException e) {
@@ -999,7 +1002,7 @@ public class JoinNodeTest {
                             mockKafkaTopicClient,
                             mockFunctionRegistry,
                             properties,
-                            mockSchemaRegistryClient))
+                            mockSchemaRegistryClientFactory))
         .andReturn(table);
   }
 
@@ -1062,7 +1065,7 @@ public class JoinNodeTest {
 
     final Serde<GenericRow> serde = niceMock(Serde.class);
     expect(node.getSchema()).andReturn(schema);
-    expect(ksqlTopicSerde.getGenericRowSerde(schema, ksqlConfig, false, mockSchemaRegistryClient))
+    expect(ksqlTopicSerde.getGenericRowSerde(schema, ksqlConfig, false, mockSchemaRegistryClientFactory))
         .andReturn(serde);
     replay(structuredDataSource, ksqlTopic, ksqlTopicSerde);
   }
@@ -1074,7 +1077,7 @@ public class JoinNodeTest {
                             mockKafkaTopicClient,
                             mockFunctionRegistry,
                             properties,
-                            mockSchemaRegistryClient))
+                            mockSchemaRegistryClientFactory))
         .andReturn(result);
 
     expect(result.getSchema()).andReturn(schema);

--- a/ksql-engine/src/test/java/io/confluent/ksql/planner/plan/KsqlBareOutputNodeTest.java
+++ b/ksql-engine/src/test/java/io/confluent/ksql/planner/plan/KsqlBareOutputNodeTest.java
@@ -121,7 +121,7 @@ public class KsqlBareOutputNodeTest {
     return planNode.buildStream(builder, new KsqlConfig(Collections.emptyMap()),
         new FakeKafkaTopicClient(),
         new InternalFunctionRegistry(),
-        new HashMap<>(), new MockSchemaRegistryClientFactory());
+        new HashMap<>(), new MockSchemaRegistryClientFactory()::get);
   }
 
   private TopologyDescription.Node getNodeByName(final String nodeName) {

--- a/ksql-engine/src/test/java/io/confluent/ksql/planner/plan/KsqlBareOutputNodeTest.java
+++ b/ksql-engine/src/test/java/io/confluent/ksql/planner/plan/KsqlBareOutputNodeTest.java
@@ -24,6 +24,7 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import io.confluent.kafka.schemaregistry.client.MockSchemaRegistryClient;
 import io.confluent.ksql.function.InternalFunctionRegistry;
 import io.confluent.ksql.metastore.MetaStore;
+import io.confluent.ksql.schema.registry.MockSchemaRegistryClientFactory;
 import io.confluent.ksql.structured.LogicalPlanBuilder;
 import io.confluent.ksql.structured.SchemaKStream;
 import io.confluent.ksql.util.FakeKafkaTopicClient;
@@ -120,7 +121,7 @@ public class KsqlBareOutputNodeTest {
     return planNode.buildStream(builder, new KsqlConfig(Collections.emptyMap()),
         new FakeKafkaTopicClient(),
         new InternalFunctionRegistry(),
-        new HashMap<>(), new MockSchemaRegistryClient());
+        new HashMap<>(), new MockSchemaRegistryClientFactory());
   }
 
   private TopologyDescription.Node getNodeByName(final String nodeName) {

--- a/ksql-engine/src/test/java/io/confluent/ksql/planner/plan/KsqlStructuredDataOutputNodeTest.java
+++ b/ksql-engine/src/test/java/io/confluent/ksql/planner/plan/KsqlStructuredDataOutputNodeTest.java
@@ -33,6 +33,7 @@ import io.confluent.ksql.function.InternalFunctionRegistry;
 import io.confluent.ksql.metastore.KsqlStream;
 import io.confluent.ksql.metastore.KsqlTable;
 import io.confluent.ksql.metastore.KsqlTopic;
+import io.confluent.ksql.schema.registry.MockSchemaRegistryClientFactory;
 import io.confluent.ksql.serde.json.KsqlJsonTopicSerDe;
 import io.confluent.ksql.structured.SchemaKStream;
 import io.confluent.ksql.structured.SchemaKTable;
@@ -178,7 +179,7 @@ public class KsqlStructuredDataOutputNodeTest {
         ksqlConfig,
         topicClient,
         new InternalFunctionRegistry(),
-        new HashMap<>(), new MockSchemaRegistryClient());
+        new HashMap<>(), new MockSchemaRegistryClientFactory());
   }
 
   @Test
@@ -196,7 +197,7 @@ public class KsqlStructuredDataOutputNodeTest {
         topicClientForNonWindowTable,
         new InternalFunctionRegistry(),
         new HashMap<>(),
-        new MockSchemaRegistryClient());
+        new MockSchemaRegistryClientFactory());
     assertThat(schemaKStream, instanceOf(SchemaKTable.class));
     EasyMock.verify();
 
@@ -216,7 +217,7 @@ public class KsqlStructuredDataOutputNodeTest {
         topicClientForWindowTable,
         new InternalFunctionRegistry(),
         new HashMap<>(),
-        new MockSchemaRegistryClient());
+        new MockSchemaRegistryClientFactory());
     assertThat(schemaKStream, instanceOf(SchemaKTable.class));
     EasyMock.verify();
 
@@ -235,7 +236,7 @@ public class KsqlStructuredDataOutputNodeTest {
         topicClientForWindowTable,
         new InternalFunctionRegistry(),
         new HashMap<>(),
-        new MockSchemaRegistryClient());
+        new MockSchemaRegistryClientFactory());
     assertThat(schemaKStream, instanceOf(SchemaKStream.class));
     EasyMock.verify();
 

--- a/ksql-engine/src/test/java/io/confluent/ksql/planner/plan/KsqlStructuredDataOutputNodeTest.java
+++ b/ksql-engine/src/test/java/io/confluent/ksql/planner/plan/KsqlStructuredDataOutputNodeTest.java
@@ -179,7 +179,7 @@ public class KsqlStructuredDataOutputNodeTest {
         ksqlConfig,
         topicClient,
         new InternalFunctionRegistry(),
-        new HashMap<>(), new MockSchemaRegistryClientFactory());
+        new HashMap<>(), new MockSchemaRegistryClientFactory()::get);
   }
 
   @Test
@@ -197,7 +197,7 @@ public class KsqlStructuredDataOutputNodeTest {
         topicClientForNonWindowTable,
         new InternalFunctionRegistry(),
         new HashMap<>(),
-        new MockSchemaRegistryClientFactory());
+        new MockSchemaRegistryClientFactory()::get);
     assertThat(schemaKStream, instanceOf(SchemaKTable.class));
     EasyMock.verify();
 
@@ -217,7 +217,7 @@ public class KsqlStructuredDataOutputNodeTest {
         topicClientForWindowTable,
         new InternalFunctionRegistry(),
         new HashMap<>(),
-        new MockSchemaRegistryClientFactory());
+        new MockSchemaRegistryClientFactory()::get);
     assertThat(schemaKStream, instanceOf(SchemaKTable.class));
     EasyMock.verify();
 
@@ -236,7 +236,7 @@ public class KsqlStructuredDataOutputNodeTest {
         topicClientForWindowTable,
         new InternalFunctionRegistry(),
         new HashMap<>(),
-        new MockSchemaRegistryClientFactory());
+        new MockSchemaRegistryClientFactory()::get);
     assertThat(schemaKStream, instanceOf(SchemaKStream.class));
     EasyMock.verify();
 

--- a/ksql-engine/src/test/java/io/confluent/ksql/planner/plan/OutputNodeTest.java
+++ b/ksql-engine/src/test/java/io/confluent/ksql/planner/plan/OutputNodeTest.java
@@ -30,6 +30,8 @@ import io.confluent.ksql.util.KsqlConfig;
 import io.confluent.ksql.util.timestamp.TimestampExtractionPolicy;
 import java.util.Map;
 import java.util.Optional;
+import java.util.function.Supplier;
+
 import junit.framework.AssertionFailedError;
 import org.apache.kafka.connect.data.Field;
 import org.apache.kafka.connect.data.Schema;
@@ -164,7 +166,7 @@ public class OutputNodeTest {
                                      final KafkaTopicClient kafkaTopicClient,
                                      final FunctionRegistry functionRegistry,
                                      final Map<String, Object> props,
-                                     final SchemaRegistryClient schemaRegistryClient) {
+                                     final Supplier<SchemaRegistryClient> schemaRegistryClient) {
       return null;
     }
   }

--- a/ksql-engine/src/test/java/io/confluent/ksql/planner/plan/ProjectNodeTest.java
+++ b/ksql-engine/src/test/java/io/confluent/ksql/planner/plan/ProjectNodeTest.java
@@ -23,6 +23,7 @@ import io.confluent.kafka.schemaregistry.client.MockSchemaRegistryClient;
 import io.confluent.kafka.schemaregistry.client.SchemaRegistryClient;
 import io.confluent.ksql.function.InternalFunctionRegistry;
 import io.confluent.ksql.parser.tree.BooleanLiteral;
+import io.confluent.ksql.schema.registry.MockSchemaRegistryClientFactory;
 import io.confluent.ksql.structured.SchemaKStream;
 import io.confluent.ksql.util.FakeKafkaTopicClient;
 import io.confluent.ksql.util.KafkaTopicClient;
@@ -32,6 +33,8 @@ import io.confluent.ksql.util.Pair;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashMap;
+import java.util.function.Supplier;
+
 import org.apache.kafka.connect.data.Field;
 import org.apache.kafka.connect.data.Schema;
 import org.apache.kafka.connect.data.SchemaBuilder;
@@ -68,7 +71,7 @@ public class ProjectNodeTest {
         ksqlConfig,
         kafkaTopicClient,
         functionRegistry,
-        props, new MockSchemaRegistryClient());
+        props, new MockSchemaRegistryClientFactory());
   }
 
   @Test
@@ -95,18 +98,19 @@ public class ProjectNodeTest {
         ksqlConfig,
         kafkaTopicClient,
         functionRegistry,
-        props, new MockSchemaRegistryClient());
+        props, new MockSchemaRegistryClientFactory());
 
     EasyMock.verify(stream);
   }
 
+  @SuppressWarnings("unchecked")
   private void mockSourceNode() {
     EasyMock.expect(source.getKeyField()).andReturn(new Field("field1", 0, Schema.OPTIONAL_STRING_SCHEMA));
     EasyMock.expect(source.buildStream(anyObject(StreamsBuilder.class),
         anyObject(KsqlConfig.class),
         anyObject(KafkaTopicClient.class),
         anyObject(InternalFunctionRegistry.class),
-        eq(props), anyObject(SchemaRegistryClient.class))).andReturn(stream);
+        eq(props), anyObject(Supplier.class))).andReturn(stream);
   }
 
 

--- a/ksql-engine/src/test/java/io/confluent/ksql/planner/plan/ProjectNodeTest.java
+++ b/ksql-engine/src/test/java/io/confluent/ksql/planner/plan/ProjectNodeTest.java
@@ -19,8 +19,6 @@ package io.confluent.ksql.planner.plan;
 import static org.easymock.EasyMock.anyObject;
 import static org.easymock.EasyMock.eq;
 
-import io.confluent.kafka.schemaregistry.client.MockSchemaRegistryClient;
-import io.confluent.kafka.schemaregistry.client.SchemaRegistryClient;
 import io.confluent.ksql.function.InternalFunctionRegistry;
 import io.confluent.ksql.parser.tree.BooleanLiteral;
 import io.confluent.ksql.schema.registry.MockSchemaRegistryClientFactory;
@@ -71,7 +69,7 @@ public class ProjectNodeTest {
         ksqlConfig,
         kafkaTopicClient,
         functionRegistry,
-        props, new MockSchemaRegistryClientFactory());
+        props, new MockSchemaRegistryClientFactory()::get);
   }
 
   @Test
@@ -98,7 +96,7 @@ public class ProjectNodeTest {
         ksqlConfig,
         kafkaTopicClient,
         functionRegistry,
-        props, new MockSchemaRegistryClientFactory());
+        props, new MockSchemaRegistryClientFactory()::get);
 
     EasyMock.verify(stream);
   }

--- a/ksql-engine/src/test/java/io/confluent/ksql/planner/plan/StructuredDataSourceNodeTest.java
+++ b/ksql-engine/src/test/java/io/confluent/ksql/planner/plan/StructuredDataSourceNodeTest.java
@@ -29,6 +29,7 @@ import io.confluent.ksql.function.InternalFunctionRegistry;
 import io.confluent.ksql.metastore.KsqlStream;
 import io.confluent.ksql.metastore.KsqlTable;
 import io.confluent.ksql.metastore.KsqlTopic;
+import io.confluent.ksql.schema.registry.MockSchemaRegistryClientFactory;
 import io.confluent.ksql.serde.json.KsqlJsonTopicSerDe;
 import io.confluent.ksql.structured.SchemaKStream;
 import io.confluent.ksql.structured.SchemaKTable;
@@ -83,7 +84,7 @@ public class StructuredDataSourceNodeTest {
         ksqlConfig,
         new FakeKafkaTopicClient(),
         new InternalFunctionRegistry(),
-        new HashMap<>(), new MockSchemaRegistryClient());
+        new HashMap<>(), new MockSchemaRegistryClientFactory());
   }
 
 

--- a/ksql-engine/src/test/java/io/confluent/ksql/planner/plan/StructuredDataSourceNodeTest.java
+++ b/ksql-engine/src/test/java/io/confluent/ksql/planner/plan/StructuredDataSourceNodeTest.java
@@ -24,7 +24,6 @@ import static org.hamcrest.CoreMatchers.nullValue;
 import static org.hamcrest.CoreMatchers.startsWith;
 import static org.hamcrest.MatcherAssert.assertThat;
 
-import io.confluent.kafka.schemaregistry.client.MockSchemaRegistryClient;
 import io.confluent.ksql.function.InternalFunctionRegistry;
 import io.confluent.ksql.metastore.KsqlStream;
 import io.confluent.ksql.metastore.KsqlTable;
@@ -84,7 +83,7 @@ public class StructuredDataSourceNodeTest {
         ksqlConfig,
         new FakeKafkaTopicClient(),
         new InternalFunctionRegistry(),
-        new HashMap<>(), new MockSchemaRegistryClientFactory());
+        new HashMap<>(), new MockSchemaRegistryClientFactory()::get);
   }
 
 

--- a/ksql-engine/src/test/java/io/confluent/ksql/schema/registry/KsqlSchemaRegistryClientFactoryTest.java
+++ b/ksql-engine/src/test/java/io/confluent/ksql/schema/registry/KsqlSchemaRegistryClientFactoryTest.java
@@ -84,7 +84,7 @@ public class KsqlSchemaRegistryClientFactoryTest {
     // When:
     final SchemaRegistryClient client =
         new KsqlSchemaRegistryClientFactory(config, restServiceSupplier, sslFactory,
-                                            schemaRegistryClientFactory).create();
+                                            schemaRegistryClientFactory).get();
 
     // Then:
     assertThat(client, is(notNullValue()));
@@ -105,7 +105,7 @@ public class KsqlSchemaRegistryClientFactoryTest {
     // When:
     final SchemaRegistryClient client =
         new KsqlSchemaRegistryClientFactory(config, restServiceSupplier, sslFactory,
-                                            schemaRegistryClientFactory).create();
+                                            schemaRegistryClientFactory).get();
 
     // Then:
     assertThat(client, is(notNullValue()));
@@ -126,7 +126,7 @@ public class KsqlSchemaRegistryClientFactoryTest {
     // When:
     final SchemaRegistryClient client =
         new KsqlSchemaRegistryClientFactory(config, restServiceSupplier, sslFactory,
-                                            schemaRegistryClientFactory).create();
+                                            schemaRegistryClientFactory).get();
 
 
     // Then:
@@ -167,7 +167,7 @@ public class KsqlSchemaRegistryClientFactoryTest {
         new KsqlSchemaRegistryClientFactory(config,
                                             restServiceSupplier,
                                             sslFactory,
-                                            clientFactory).create();
+                                            clientFactory).get();
 
     // Then:
     EasyMock.verify(clientFactory);

--- a/ksql-engine/src/test/java/io/confluent/ksql/structured/SchemaKGroupedTableTest.java
+++ b/ksql-engine/src/test/java/io/confluent/ksql/structured/SchemaKGroupedTableTest.java
@@ -4,6 +4,7 @@ import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.CoreMatchers.instanceOf;
 
 import io.confluent.kafka.schemaregistry.client.MockSchemaRegistryClient;
+import io.confluent.kafka.schemaregistry.client.SchemaRegistryClient;
 import io.confluent.ksql.GenericRow;
 import io.confluent.ksql.function.InternalFunctionRegistry;
 import io.confluent.ksql.function.KsqlAggregateFunction;
@@ -72,7 +73,7 @@ public class SchemaKGroupedTableTest {
             .collect(Collectors.toList());
     final KsqlTopicSerDe ksqlTopicSerDe = new KsqlJsonTopicSerDe();
     final Serde<GenericRow> rowSerde = ksqlTopicSerDe.getGenericRowSerde(
-        initialSchemaKTable.getSchema(), null, false, null);
+        initialSchemaKTable.getSchema(), null, false, (SchemaRegistryClient) null);
     final SchemaKGroupedStream groupedSchemaKTable = initialSchemaKTable.groupBy(
         Serdes.String(), rowSerde, groupByExpressions);
     Assert.assertThat(groupedSchemaKTable, instanceOf(SchemaKGroupedTable.class));
@@ -95,7 +96,7 @@ public class SchemaKGroupedTableTest {
           Collections.singletonMap(0, 0),
           windowExpression,
           new KsqlJsonTopicSerDe().getGenericRowSerde(
-              ksqlTable.getSchema(), ksqlConfig, false, null)
+              ksqlTable.getSchema(), ksqlConfig, false, (SchemaRegistryClient) null)
       );
       Assert.fail("Should fail to build topology for aggregation with window");
     } catch(final KsqlException e) {
@@ -120,7 +121,7 @@ public class SchemaKGroupedTableTest {
           Collections.singletonMap(0, 0),
           null,
           new KsqlJsonTopicSerDe().getGenericRowSerde(
-              ksqlTable.getSchema(), ksqlConfig, false, null)
+              ksqlTable.getSchema(), ksqlConfig, false, (SchemaRegistryClient) null)
       );
       Assert.fail("Should fail to build topology for aggregation with unsupported function");
     } catch(final KsqlException e) {

--- a/ksql-engine/src/test/java/io/confluent/ksql/structured/SchemaKGroupedTableTest.java
+++ b/ksql-engine/src/test/java/io/confluent/ksql/structured/SchemaKGroupedTableTest.java
@@ -4,7 +4,6 @@ import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.CoreMatchers.instanceOf;
 
 import io.confluent.kafka.schemaregistry.client.MockSchemaRegistryClient;
-import io.confluent.kafka.schemaregistry.client.SchemaRegistryClient;
 import io.confluent.ksql.GenericRow;
 import io.confluent.ksql.function.InternalFunctionRegistry;
 import io.confluent.ksql.function.KsqlAggregateFunction;
@@ -18,6 +17,7 @@ import io.confluent.ksql.parser.tree.QualifiedNameReference;
 import io.confluent.ksql.parser.tree.TumblingWindowExpression;
 import io.confluent.ksql.parser.tree.WindowExpression;
 import io.confluent.ksql.planner.plan.PlanNode;
+import io.confluent.ksql.schema.registry.MockSchemaRegistryClientFactory;
 import io.confluent.ksql.serde.KsqlTopicSerDe;
 import io.confluent.ksql.serde.json.KsqlJsonTopicSerDe;
 import io.confluent.ksql.util.KsqlConfig;
@@ -58,7 +58,7 @@ public class SchemaKGroupedTableTest {
     kTable = builder
         .table(ksqlTable.getKsqlTopic().getKafkaTopicName(), Consumed.with(Serdes.String()
             , ksqlTable.getKsqlTopic().getKsqlTopicSerDe().getGenericRowSerde(ksqlTable.getSchema(), new
-                KsqlConfig(Collections.emptyMap()), false, new MockSchemaRegistryClient())));
+                KsqlConfig(Collections.emptyMap()), false, new MockSchemaRegistryClientFactory()::get)));
 
   }
 
@@ -73,7 +73,7 @@ public class SchemaKGroupedTableTest {
             .collect(Collectors.toList());
     final KsqlTopicSerDe ksqlTopicSerDe = new KsqlJsonTopicSerDe();
     final Serde<GenericRow> rowSerde = ksqlTopicSerDe.getGenericRowSerde(
-        initialSchemaKTable.getSchema(), null, false, (SchemaRegistryClient) null);
+        initialSchemaKTable.getSchema(), null, false, () -> null);
     final SchemaKGroupedStream groupedSchemaKTable = initialSchemaKTable.groupBy(
         Serdes.String(), rowSerde, groupByExpressions);
     Assert.assertThat(groupedSchemaKTable, instanceOf(SchemaKGroupedTable.class));
@@ -96,7 +96,7 @@ public class SchemaKGroupedTableTest {
           Collections.singletonMap(0, 0),
           windowExpression,
           new KsqlJsonTopicSerDe().getGenericRowSerde(
-              ksqlTable.getSchema(), ksqlConfig, false, (SchemaRegistryClient) null)
+              ksqlTable.getSchema(), ksqlConfig, false, () -> null)
       );
       Assert.fail("Should fail to build topology for aggregation with window");
     } catch(final KsqlException e) {
@@ -121,7 +121,7 @@ public class SchemaKGroupedTableTest {
           Collections.singletonMap(0, 0),
           null,
           new KsqlJsonTopicSerDe().getGenericRowSerde(
-              ksqlTable.getSchema(), ksqlConfig, false, (SchemaRegistryClient) null)
+              ksqlTable.getSchema(), ksqlConfig, false, () -> null)
       );
       Assert.fail("Should fail to build topology for aggregation with unsupported function");
     } catch(final KsqlException e) {

--- a/ksql-engine/src/test/java/io/confluent/ksql/structured/SchemaKStreamTest.java
+++ b/ksql-engine/src/test/java/io/confluent/ksql/structured/SchemaKStreamTest.java
@@ -29,6 +29,7 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.Assert.assertEquals;
 
 import io.confluent.kafka.schemaregistry.client.MockSchemaRegistryClient;
+import io.confluent.kafka.schemaregistry.client.SchemaRegistryClient;
 import io.confluent.ksql.GenericRow;
 import io.confluent.ksql.function.InternalFunctionRegistry;
 import io.confluent.ksql.metastore.KsqlStream;
@@ -320,7 +321,7 @@ public class SchemaKStreamTest {
         new QualifiedNameReference(QualifiedName.of("TEST1")), "COL0");
     final KsqlTopicSerDe ksqlTopicSerDe = new KsqlJsonTopicSerDe();
     final Serde<GenericRow> rowSerde = ksqlTopicSerDe.getGenericRowSerde(
-        initialSchemaKStream.getSchema(), null, false, null);
+        initialSchemaKStream.getSchema(), null, false, (SchemaRegistryClient) null);
     final List<Expression> groupByExpressions = Arrays.asList(keyExpression);
     final SchemaKGroupedStream groupedSchemaKStream = initialSchemaKStream.groupBy(
         Serdes.String(), rowSerde, groupByExpressions);
@@ -342,7 +343,7 @@ public class SchemaKStreamTest {
         new QualifiedNameReference(QualifiedName.of("TEST1")), "COL1");
     final KsqlTopicSerDe ksqlTopicSerDe = new KsqlJsonTopicSerDe();
     final Serde<GenericRow> rowSerde = ksqlTopicSerDe.getGenericRowSerde(
-        initialSchemaKStream.getSchema(), null, false, null);
+        initialSchemaKStream.getSchema(), null, false, (SchemaRegistryClient) null);
     final List<Expression> groupByExpressions = Arrays.asList(col1Expression, col0Expression);
     final SchemaKGroupedStream groupedSchemaKStream = initialSchemaKStream.groupBy(
         Serdes.String(), rowSerde, groupByExpressions);

--- a/ksql-engine/src/test/java/io/confluent/ksql/structured/SchemaKStreamTest.java
+++ b/ksql-engine/src/test/java/io/confluent/ksql/structured/SchemaKStreamTest.java
@@ -29,7 +29,6 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.Assert.assertEquals;
 
 import io.confluent.kafka.schemaregistry.client.MockSchemaRegistryClient;
-import io.confluent.kafka.schemaregistry.client.SchemaRegistryClient;
 import io.confluent.ksql.GenericRow;
 import io.confluent.ksql.function.InternalFunctionRegistry;
 import io.confluent.ksql.metastore.KsqlStream;
@@ -43,6 +42,7 @@ import io.confluent.ksql.parser.tree.QualifiedNameReference;
 import io.confluent.ksql.planner.plan.FilterNode;
 import io.confluent.ksql.planner.plan.PlanNode;
 import io.confluent.ksql.planner.plan.ProjectNode;
+import io.confluent.ksql.schema.registry.MockSchemaRegistryClientFactory;
 import io.confluent.ksql.serde.KsqlTopicSerDe;
 import io.confluent.ksql.serde.json.KsqlJsonTopicSerDe;
 import io.confluent.ksql.util.KsqlConfig;
@@ -142,9 +142,9 @@ public class SchemaKStreamTest {
   }
 
   private Serde<GenericRow> getRowSerde(final KsqlTopic topic, final Schema schema) {
-    return topic.getKsqlTopicSerDe().getGenericRowSerde(schema,
-                                                        new KsqlConfig(Collections.emptyMap()),
-                                                        false, new MockSchemaRegistryClient());
+    return topic.getKsqlTopicSerDe().getGenericRowSerde(
+        schema, new KsqlConfig(Collections.emptyMap()), false,
+        new MockSchemaRegistryClientFactory()::get);
   }
 
   @Test
@@ -321,7 +321,7 @@ public class SchemaKStreamTest {
         new QualifiedNameReference(QualifiedName.of("TEST1")), "COL0");
     final KsqlTopicSerDe ksqlTopicSerDe = new KsqlJsonTopicSerDe();
     final Serde<GenericRow> rowSerde = ksqlTopicSerDe.getGenericRowSerde(
-        initialSchemaKStream.getSchema(), null, false, (SchemaRegistryClient) null);
+        initialSchemaKStream.getSchema(), null, false, () -> null);
     final List<Expression> groupByExpressions = Arrays.asList(keyExpression);
     final SchemaKGroupedStream groupedSchemaKStream = initialSchemaKStream.groupBy(
         Serdes.String(), rowSerde, groupByExpressions);
@@ -343,7 +343,7 @@ public class SchemaKStreamTest {
         new QualifiedNameReference(QualifiedName.of("TEST1")), "COL1");
     final KsqlTopicSerDe ksqlTopicSerDe = new KsqlJsonTopicSerDe();
     final Serde<GenericRow> rowSerde = ksqlTopicSerDe.getGenericRowSerde(
-        initialSchemaKStream.getSchema(), null, false, (SchemaRegistryClient) null);
+        initialSchemaKStream.getSchema(), null, false, () -> null);
     final List<Expression> groupByExpressions = Arrays.asList(col1Expression, col0Expression);
     final SchemaKGroupedStream groupedSchemaKStream = initialSchemaKStream.groupBy(
         Serdes.String(), rowSerde, groupByExpressions);

--- a/ksql-engine/src/test/java/io/confluent/ksql/structured/SchemaKTableTest.java
+++ b/ksql-engine/src/test/java/io/confluent/ksql/structured/SchemaKTableTest.java
@@ -30,7 +30,6 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertThat;
 
 import io.confluent.kafka.schemaregistry.client.MockSchemaRegistryClient;
-import io.confluent.kafka.schemaregistry.client.SchemaRegistryClient;
 import io.confluent.ksql.GenericRow;
 import io.confluent.ksql.function.InternalFunctionRegistry;
 import io.confluent.ksql.metastore.KsqlTable;
@@ -43,6 +42,7 @@ import io.confluent.ksql.parser.tree.QualifiedNameReference;
 import io.confluent.ksql.planner.plan.FilterNode;
 import io.confluent.ksql.planner.plan.PlanNode;
 import io.confluent.ksql.planner.plan.ProjectNode;
+import io.confluent.ksql.schema.registry.MockSchemaRegistryClientFactory;
 import io.confluent.ksql.serde.KsqlTopicSerDe;
 import io.confluent.ksql.serde.json.KsqlJsonTopicSerDe;
 import io.confluent.ksql.util.KsqlConfig;
@@ -119,9 +119,9 @@ public class SchemaKTableTest {
   }
 
   private Serde<GenericRow> getRowSerde(final KsqlTopic topic, final Schema schema) {
-    return topic.getKsqlTopicSerDe().getGenericRowSerde(schema,
-                                                        new KsqlConfig(Collections.emptyMap()),
-                                                        false, new MockSchemaRegistryClient());
+    return topic.getKsqlTopicSerDe().getGenericRowSerde(
+        schema, new KsqlConfig(Collections.emptyMap()), false,
+        new MockSchemaRegistryClientFactory()::get);
   }
 
 
@@ -242,7 +242,7 @@ public class SchemaKTableTest {
         new QualifiedNameReference(QualifiedName.of("TEST2")), "COL2");
     final KsqlTopicSerDe ksqlTopicSerDe = new KsqlJsonTopicSerDe();
     final Serde<GenericRow> rowSerde = ksqlTopicSerDe.getGenericRowSerde(
-        initialSchemaKTable.getSchema(), null, false, (SchemaRegistryClient) null);
+        initialSchemaKTable.getSchema(), null, false, () -> null);
     final List<Expression> groupByExpressions = Arrays.asList(col2Expression, col1Expression);
     final SchemaKGroupedStream groupedSchemaKTable = initialSchemaKTable.groupBy(
         Serdes.String(), rowSerde, groupByExpressions);
@@ -279,7 +279,7 @@ public class SchemaKTableTest {
         new QualifiedNameReference(QualifiedName.of("TEST2")), "COL2");
     final List<Expression> groupByExpressions = Arrays.asList(col2Expression, col1Expression);
     final Serde<GenericRow> rowSerde = new KsqlJsonTopicSerDe().getGenericRowSerde(
-        initialSchemaKTable.getSchema(), null, false, (SchemaRegistryClient) null);
+        initialSchemaKTable.getSchema(), null, false, () -> null);
 
     // Call groupBy and extract the captured mapper
     initialSchemaKTable.groupBy(Serdes.String(), rowSerde, groupByExpressions);

--- a/ksql-engine/src/test/java/io/confluent/ksql/structured/SchemaKTableTest.java
+++ b/ksql-engine/src/test/java/io/confluent/ksql/structured/SchemaKTableTest.java
@@ -30,6 +30,7 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertThat;
 
 import io.confluent.kafka.schemaregistry.client.MockSchemaRegistryClient;
+import io.confluent.kafka.schemaregistry.client.SchemaRegistryClient;
 import io.confluent.ksql.GenericRow;
 import io.confluent.ksql.function.InternalFunctionRegistry;
 import io.confluent.ksql.metastore.KsqlTable;
@@ -241,7 +242,7 @@ public class SchemaKTableTest {
         new QualifiedNameReference(QualifiedName.of("TEST2")), "COL2");
     final KsqlTopicSerDe ksqlTopicSerDe = new KsqlJsonTopicSerDe();
     final Serde<GenericRow> rowSerde = ksqlTopicSerDe.getGenericRowSerde(
-        initialSchemaKTable.getSchema(), null, false, null);
+        initialSchemaKTable.getSchema(), null, false, (SchemaRegistryClient) null);
     final List<Expression> groupByExpressions = Arrays.asList(col2Expression, col1Expression);
     final SchemaKGroupedStream groupedSchemaKTable = initialSchemaKTable.groupBy(
         Serdes.String(), rowSerde, groupByExpressions);
@@ -278,7 +279,7 @@ public class SchemaKTableTest {
         new QualifiedNameReference(QualifiedName.of("TEST2")), "COL2");
     final List<Expression> groupByExpressions = Arrays.asList(col2Expression, col1Expression);
     final Serde<GenericRow> rowSerde = new KsqlJsonTopicSerDe().getGenericRowSerde(
-        initialSchemaKTable.getSchema(), null, false, null);
+        initialSchemaKTable.getSchema(), null, false, (SchemaRegistryClient) null);
 
     // Call groupBy and extract the captured mapper
     initialSchemaKTable.groupBy(Serdes.String(), rowSerde, groupByExpressions);

--- a/ksql-engine/src/test/java/io/confluent/ksql/structured/SqlPredicateTest.java
+++ b/ksql-engine/src/test/java/io/confluent/ksql/structured/SqlPredicateTest.java
@@ -31,6 +31,7 @@ import io.confluent.ksql.parser.tree.Statement;
 import io.confluent.ksql.planner.LogicalPlanner;
 import io.confluent.ksql.planner.plan.FilterNode;
 import io.confluent.ksql.planner.plan.PlanNode;
+import io.confluent.ksql.schema.registry.MockSchemaRegistryClientFactory;
 import io.confluent.ksql.util.KsqlConfig;
 import io.confluent.ksql.util.MetaStoreFixture;
 import java.util.ArrayList;
@@ -62,7 +63,7 @@ public class SqlPredicateTest {
     kStream = builder.stream(ksqlStream.getKsqlTopic().getKafkaTopicName(), Consumed.with(Serdes.String(),
                              ksqlStream.getKsqlTopic().getKsqlTopicSerDe().getGenericRowSerde(
                                  ksqlStream.getSchema(), new KsqlConfig(Collections.emptyMap()),
-                                                   false, new MockSchemaRegistryClient()
+                                                   false, new MockSchemaRegistryClientFactory()::get
                                                    )));
   }
 

--- a/ksql-examples/src/main/java/io/confluent/ksql/datagen/AvroProducer.java
+++ b/ksql-examples/src/main/java/io/confluent/ksql/datagen/AvroProducer.java
@@ -49,6 +49,7 @@ public class AvroProducer extends DataGenProducer {
       final String topicName
   ) {
     return new KsqlAvroTopicSerDe()
-        .getGenericRowSerde(kafkaSchema, ksqlConfig, false, schemaRegistryClient).serializer();
+        .getGenericRowSerde(kafkaSchema, ksqlConfig, false,
+            () -> schemaRegistryClient).serializer();
   }
 }

--- a/ksql-metastore/src/test/java/io/confluent/ksql/util/MetaStoreFixture.java
+++ b/ksql-metastore/src/test/java/io/confluent/ksql/util/MetaStoreFixture.java
@@ -22,14 +22,22 @@ import io.confluent.ksql.metastore.KsqlTable;
 import io.confluent.ksql.metastore.KsqlTopic;
 import io.confluent.ksql.metastore.MetaStore;
 import io.confluent.ksql.metastore.MetaStoreImpl;
+import io.confluent.ksql.serde.KsqlTopicSerDe;
 import io.confluent.ksql.serde.json.KsqlJsonTopicSerDe;
 import io.confluent.ksql.util.timestamp.MetadataTimestampExtractionPolicy;
 import org.apache.kafka.connect.data.Schema;
 import org.apache.kafka.connect.data.SchemaBuilder;
 
+import java.util.function.Supplier;
+
 public class MetaStoreFixture {
 
   public static MetaStore getNewMetaStore(final FunctionRegistry functionRegistry) {
+    return getNewMetaStore(functionRegistry, KsqlJsonTopicSerDe::new);
+  }
+
+  public static MetaStore getNewMetaStore(final FunctionRegistry functionRegistry,
+                                          final Supplier<KsqlTopicSerDe> serde) {
 
     final MetadataTimestampExtractionPolicy timestampExtractionPolicy
         = new MetadataTimestampExtractionPolicy();
@@ -47,7 +55,7 @@ public class MetaStoreFixture {
 
     final KsqlTopic
         ksqlTopic1 =
-        new KsqlTopic("TEST1", "test1", new KsqlJsonTopicSerDe());
+        new KsqlTopic("TEST1", "test1", serde.get());
 
     final KsqlStream ksqlStream = new KsqlStream("sqlexpression",
         "TEST1",
@@ -70,7 +78,7 @@ public class MetaStoreFixture {
 
     final KsqlTopic
         ksqlTopic2 =
-        new KsqlTopic("TEST2", "test2", new KsqlJsonTopicSerDe());
+        new KsqlTopic("TEST2", "test2", serde.get());
     final KsqlTable ksqlTable = new KsqlTable(
         "sqlexpression",
         "TEST2",
@@ -117,7 +125,7 @@ public class MetaStoreFixture {
 
     final KsqlTopic
         ksqlTopicOrders =
-        new KsqlTopic("ORDERS_TOPIC", "orders_topic", new KsqlJsonTopicSerDe());
+        new KsqlTopic("ORDERS_TOPIC", "orders_topic", serde.get());
 
     final KsqlStream ksqlStreamOrders = new KsqlStream(
         "sqlexpression",
@@ -141,7 +149,7 @@ public class MetaStoreFixture {
 
     final KsqlTopic
         ksqlTopic3 =
-        new KsqlTopic("TEST3", "test3", new KsqlJsonTopicSerDe());
+        new KsqlTopic("TEST3", "test3", serde.get());
     final KsqlTable ksqlTable3 = new KsqlTable(
         "sqlexpression",
         "TEST3",
@@ -164,7 +172,7 @@ public class MetaStoreFixture {
 
     final KsqlTopic
         nestedArrayStructMapTopic =
-        new KsqlTopic("NestedArrayStructMap", "NestedArrayStructMap_topic", new KsqlJsonTopicSerDe());
+        new KsqlTopic("NestedArrayStructMap", "NestedArrayStructMap_topic", serde.get());
 
     final KsqlStream nestedArrayStructMapOrders = new KsqlStream(
         "sqlexpression",

--- a/ksql-rest-app/src/test/java/io/confluent/ksql/rest/entity/QueryDescriptionTest.java
+++ b/ksql-rest-app/src/test/java/io/confluent/ksql/rest/entity/QueryDescriptionTest.java
@@ -29,6 +29,8 @@ import java.util.Collections;
 import java.util.Map;
 import java.util.Optional;
 import java.util.concurrent.LinkedBlockingQueue;
+import java.util.function.Supplier;
+
 import org.apache.kafka.connect.data.Field;
 import org.apache.kafka.connect.data.Schema;
 import org.apache.kafka.connect.data.SchemaBuilder;
@@ -72,9 +74,10 @@ public class QueryDescriptionTest {
 
     @Override
     public SchemaKStream buildStream(
-        final StreamsBuilder builder, final KsqlConfig ksqlConfig, final KafkaTopicClient kafkaTopicClient,
+        final StreamsBuilder builder, final KsqlConfig ksqlConfig,
+        final KafkaTopicClient kafkaTopicClient,
         final FunctionRegistry functionRegistry, final Map<String, Object> props,
-        final SchemaRegistryClient schemaRegistryClient) {
+        final Supplier<SchemaRegistryClient> schemaRegistryClient) {
       return null;
     }
   }

--- a/ksql-rest-app/src/test/java/io/confluent/ksql/rest/server/computation/StatementExecutorTest.java
+++ b/ksql-rest-app/src/test/java/io/confluent/ksql/rest/server/computation/StatementExecutorTest.java
@@ -36,6 +36,7 @@ import io.confluent.ksql.rest.entity.CommandStatus;
 import io.confluent.ksql.rest.server.StatementParser;
 import io.confluent.ksql.rest.server.mock.MockKafkaTopicClient;
 import io.confluent.ksql.rest.server.utils.TestUtils;
+import io.confluent.ksql.schema.registry.MockSchemaRegistryClientFactory;
 import io.confluent.ksql.testutils.EmbeddedSingleNodeKafkaCluster;
 import io.confluent.ksql.util.KsqlConfig;
 import io.confluent.ksql.util.Pair;
@@ -70,6 +71,7 @@ public class StatementExecutorTest extends EasyMockSupport {
     ksqlEngine = TestUtils.createKsqlEngine(
         ksqlConfig,
         new MockKafkaTopicClient(),
+        new MockSchemaRegistryClientFactory(),
         new MockSchemaRegistryClient());
 
     final StatementParser statementParser = new StatementParser(ksqlEngine);

--- a/ksql-rest-app/src/test/java/io/confluent/ksql/rest/server/computation/StatementExecutorTest.java
+++ b/ksql-rest-app/src/test/java/io/confluent/ksql/rest/server/computation/StatementExecutorTest.java
@@ -25,7 +25,6 @@ import static org.hamcrest.CoreMatchers.containsString;
 import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.MatcherAssert.assertThat;
 
-import io.confluent.kafka.schemaregistry.client.MockSchemaRegistryClient;
 import io.confluent.ksql.KsqlEngine;
 import io.confluent.ksql.metastore.MetaStore;
 import io.confluent.ksql.parser.tree.CreateStreamAsSelect;
@@ -71,7 +70,7 @@ public class StatementExecutorTest extends EasyMockSupport {
     ksqlEngine = TestUtils.createKsqlEngine(
         ksqlConfig,
         new MockKafkaTopicClient(),
-        new MockSchemaRegistryClientFactory());
+        new MockSchemaRegistryClientFactory()::get);
 
     final StatementParser statementParser = new StatementParser(ksqlEngine);
 

--- a/ksql-rest-app/src/test/java/io/confluent/ksql/rest/server/computation/StatementExecutorTest.java
+++ b/ksql-rest-app/src/test/java/io/confluent/ksql/rest/server/computation/StatementExecutorTest.java
@@ -71,8 +71,7 @@ public class StatementExecutorTest extends EasyMockSupport {
     ksqlEngine = TestUtils.createKsqlEngine(
         ksqlConfig,
         new MockKafkaTopicClient(),
-        new MockSchemaRegistryClientFactory(),
-        new MockSchemaRegistryClient());
+        new MockSchemaRegistryClientFactory());
 
     final StatementParser statementParser = new StatementParser(ksqlEngine);
 

--- a/ksql-rest-app/src/test/java/io/confluent/ksql/rest/server/resources/KsqlResourceTest.java
+++ b/ksql-rest-app/src/test/java/io/confluent/ksql/rest/server/resources/KsqlResourceTest.java
@@ -121,7 +121,7 @@ public class KsqlResourceTest {
   @Before
   public void setUp() throws IOException, RestClientException {
     final Supplier<SchemaRegistryClient> schemaRegistryClientFactory
-        = new MockSchemaRegistryClientFactory();
+        = new MockSchemaRegistryClientFactory()::get;
     final SchemaRegistryClient schemaRegistryClient = schemaRegistryClientFactory.get();
     registerSchema(schemaRegistryClient);
     ksqlRestConfig = new KsqlRestConfig(TestKsqlResourceUtil.getDefaultKsqlConfig());

--- a/ksql-rest-app/src/test/java/io/confluent/ksql/rest/server/resources/KsqlResourceTest.java
+++ b/ksql-rest-app/src/test/java/io/confluent/ksql/rest/server/resources/KsqlResourceTest.java
@@ -130,8 +130,7 @@ public class KsqlResourceTest {
     ksqlEngine = TestUtils.createKsqlEngine(
         ksqlConfig,
         kafkaTopicClient,
-        schemaRegistryClientFactory,
-        schemaRegistryClient);
+        schemaRegistryClientFactory);
   }
 
   @After

--- a/ksql-rest-app/src/test/java/io/confluent/ksql/rest/server/resources/KsqlResourceTest.java
+++ b/ksql-rest-app/src/test/java/io/confluent/ksql/rest/server/resources/KsqlResourceTest.java
@@ -75,6 +75,7 @@ import io.confluent.ksql.rest.server.computation.CommandStore;
 import io.confluent.ksql.rest.server.computation.StatementExecutor;
 import io.confluent.ksql.rest.server.utils.TestUtils;
 import io.confluent.ksql.rest.util.EntityUtil;
+import io.confluent.ksql.schema.registry.MockSchemaRegistryClientFactory;
 import io.confluent.ksql.serde.DataSource;
 import io.confluent.ksql.serde.json.KsqlJsonTopicSerDe;
 import io.confluent.ksql.util.FakeKafkaTopicClient;
@@ -93,6 +94,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Properties;
 import java.util.concurrent.Future;
+import java.util.function.Supplier;
 import java.util.stream.Collectors;
 import javax.ws.rs.core.Response;
 import org.apache.commons.lang3.concurrent.ConcurrentUtils;
@@ -118,12 +120,18 @@ public class KsqlResourceTest {
 
   @Before
   public void setUp() throws IOException, RestClientException {
-    final SchemaRegistryClient schemaRegistryClient = new MockSchemaRegistryClient();
+    final Supplier<SchemaRegistryClient> schemaRegistryClientFactory
+        = new MockSchemaRegistryClientFactory();
+    final SchemaRegistryClient schemaRegistryClient = schemaRegistryClientFactory.get();
     registerSchema(schemaRegistryClient);
     ksqlRestConfig = new KsqlRestConfig(TestKsqlResourceUtil.getDefaultKsqlConfig());
     ksqlConfig = new KsqlConfig(ksqlRestConfig.getKsqlConfigProperties());
     kafkaTopicClient = new FakeKafkaTopicClient();
-    ksqlEngine = TestUtils.createKsqlEngine(ksqlConfig, kafkaTopicClient, schemaRegistryClient);
+    ksqlEngine = TestUtils.createKsqlEngine(
+        ksqlConfig,
+        kafkaTopicClient,
+        schemaRegistryClientFactory,
+        schemaRegistryClient);
   }
 
   @After

--- a/ksql-rest-app/src/test/java/io/confluent/ksql/rest/server/resources/KsqlResourceTest.java
+++ b/ksql-rest-app/src/test/java/io/confluent/ksql/rest/server/resources/KsqlResourceTest.java
@@ -120,9 +120,7 @@ public class KsqlResourceTest {
 
   @Before
   public void setUp() throws IOException, RestClientException {
-    final Supplier<SchemaRegistryClient> schemaRegistryClientFactory
-        = new MockSchemaRegistryClientFactory()::get;
-    final SchemaRegistryClient schemaRegistryClient = schemaRegistryClientFactory.get();
+    final SchemaRegistryClient schemaRegistryClient = new MockSchemaRegistryClient();
     registerSchema(schemaRegistryClient);
     ksqlRestConfig = new KsqlRestConfig(TestKsqlResourceUtil.getDefaultKsqlConfig());
     ksqlConfig = new KsqlConfig(ksqlRestConfig.getKsqlConfigProperties());
@@ -130,7 +128,7 @@ public class KsqlResourceTest {
     ksqlEngine = TestUtils.createKsqlEngine(
         ksqlConfig,
         kafkaTopicClient,
-        schemaRegistryClientFactory);
+        () -> schemaRegistryClient);
   }
 
   @After

--- a/ksql-rest-app/src/test/java/io/confluent/ksql/rest/server/utils/TestUtils.java
+++ b/ksql-rest-app/src/test/java/io/confluent/ksql/rest/server/utils/TestUtils.java
@@ -31,6 +31,7 @@ import java.net.ServerSocket;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
+import java.util.function.Supplier;
 
 public class TestUtils {
 
@@ -74,11 +75,13 @@ public class TestUtils {
 
   public static KsqlEngine createKsqlEngine(final KsqlConfig ksqlConfig,
                                             final KafkaTopicClient topicClient,
+                                            final Supplier<SchemaRegistryClient> schemaRegistryClientFactory,
                                             final SchemaRegistryClient schemaRegistryClient) {
     class TestKsqlEngine extends KsqlEngine {
       private TestKsqlEngine() {
         super(
             topicClient,
+            schemaRegistryClientFactory,
             schemaRegistryClient,
             new MetaStoreImpl(new InternalFunctionRegistry()));
       }

--- a/ksql-rest-app/src/test/java/io/confluent/ksql/rest/server/utils/TestUtils.java
+++ b/ksql-rest-app/src/test/java/io/confluent/ksql/rest/server/utils/TestUtils.java
@@ -75,14 +75,12 @@ public class TestUtils {
 
   public static KsqlEngine createKsqlEngine(final KsqlConfig ksqlConfig,
                                             final KafkaTopicClient topicClient,
-                                            final Supplier<SchemaRegistryClient> schemaRegistryClientFactory,
-                                            final SchemaRegistryClient schemaRegistryClient) {
+                                            final Supplier<SchemaRegistryClient> schemaRegistryClientFactory) {
     class TestKsqlEngine extends KsqlEngine {
       private TestKsqlEngine() {
         super(
             topicClient,
             schemaRegistryClientFactory,
-            schemaRegistryClient,
             new MetaStoreImpl(new InternalFunctionRegistry()));
       }
     };

--- a/ksql-serde/src/main/java/io/confluent/ksql/serde/KsqlTopicSerDe.java
+++ b/ksql-serde/src/main/java/io/confluent/ksql/serde/KsqlTopicSerDe.java
@@ -20,8 +20,12 @@ package io.confluent.ksql.serde;
 import io.confluent.kafka.schemaregistry.client.SchemaRegistryClient;
 import io.confluent.ksql.GenericRow;
 import io.confluent.ksql.util.KsqlConfig;
+
+import java.util.function.Supplier;
+
 import org.apache.kafka.common.serialization.Serde;
 import org.apache.kafka.connect.data.Schema;
+
 
 public abstract class KsqlTopicSerDe {
 
@@ -39,4 +43,10 @@ public abstract class KsqlTopicSerDe {
                                                        KsqlConfig ksqlConfig,
                                                        boolean isInternal,
                                                        SchemaRegistryClient schemaRegistryClient);
+
+  public abstract Serde<GenericRow> getGenericRowSerde(
+      Schema schemaMaybeWithSource,
+      KsqlConfig ksqlConfig,
+      boolean isInternal,
+      Supplier<SchemaRegistryClient> schemaRegistryClientFactory);
 }

--- a/ksql-serde/src/main/java/io/confluent/ksql/serde/KsqlTopicSerDe.java
+++ b/ksql-serde/src/main/java/io/confluent/ksql/serde/KsqlTopicSerDe.java
@@ -39,11 +39,6 @@ public abstract class KsqlTopicSerDe {
     return serDe;
   }
 
-  public abstract Serde<GenericRow> getGenericRowSerde(Schema schema,
-                                                       KsqlConfig ksqlConfig,
-                                                       boolean isInternal,
-                                                       SchemaRegistryClient schemaRegistryClient);
-
   public abstract Serde<GenericRow> getGenericRowSerde(
       Schema schemaMaybeWithSource,
       KsqlConfig ksqlConfig,

--- a/ksql-serde/src/main/java/io/confluent/ksql/serde/avro/KsqlAvroTopicSerDe.java
+++ b/ksql-serde/src/main/java/io/confluent/ksql/serde/avro/KsqlAvroTopicSerDe.java
@@ -17,6 +17,7 @@
 package io.confluent.ksql.serde.avro;
 
 import com.google.common.collect.ImmutableMap;
+
 import io.confluent.connect.avro.AvroConverter;
 import io.confluent.connect.avro.AvroDataConfig;
 import io.confluent.kafka.schemaregistry.client.SchemaRegistryClient;
@@ -26,13 +27,19 @@ import io.confluent.ksql.serde.DataSource;
 import io.confluent.ksql.serde.KsqlTopicSerDe;
 import io.confluent.ksql.serde.connect.KsqlConnectDeserializer;
 import io.confluent.ksql.serde.connect.KsqlConnectSerializer;
+import io.confluent.ksql.serde.tls.ThreadLocalDeserializer;
+import io.confluent.ksql.serde.tls.ThreadLocalSerializer;
 import io.confluent.ksql.util.KsqlConfig;
 import io.confluent.ksql.util.SchemaUtil;
+
+import java.util.function.Supplier;
+
 import org.apache.kafka.common.serialization.Deserializer;
 import org.apache.kafka.common.serialization.Serde;
 import org.apache.kafka.common.serialization.Serdes;
 import org.apache.kafka.common.serialization.Serializer;
 import org.apache.kafka.connect.data.Schema;
+
 
 public class KsqlAvroTopicSerDe extends KsqlTopicSerDe {
 
@@ -55,20 +62,31 @@ public class KsqlAvroTopicSerDe extends KsqlTopicSerDe {
   }
 
   @Override
+  public Serde<GenericRow> getGenericRowSerde(
+      final Schema schemaMaybeWithSource,
+      final KsqlConfig ksqlConfig,
+      final boolean isInternal,
+      final Supplier<SchemaRegistryClient> schemaRegistryClientFactory) {
+    final Schema schema = isInternal
+        ? schemaMaybeWithSource : SchemaUtil.getSchemaWithNoAlias(schemaMaybeWithSource);
+    final Serializer<GenericRow> genericRowSerializer = new ThreadLocalSerializer(
+        () -> new KsqlConnectSerializer(
+            new AvroDataTranslator(schema),
+            getAvroConverter(schemaRegistryClientFactory.get(), ksqlConfig)));
+    final Deserializer<GenericRow> genericRowDeserializer = new ThreadLocalDeserializer(
+        () -> new KsqlConnectDeserializer(
+            getAvroConverter(schemaRegistryClientFactory.get(), ksqlConfig),
+            new AvroDataTranslator(schema))
+    );
+    return Serdes.serdeFrom(genericRowSerializer, genericRowDeserializer);
+  }
+
+  @Override
   public Serde<GenericRow> getGenericRowSerde(final Schema schemaMaybeWithSource,
                                               final KsqlConfig ksqlConfig,
                                               final boolean isInternal,
                                               final SchemaRegistryClient schemaRegistryClient) {
-    final Schema schema = isInternal
-        ? schemaMaybeWithSource : SchemaUtil.getSchemaWithNoAlias(schemaMaybeWithSource);
-    final Serializer<GenericRow> genericRowSerializer =
-        new KsqlConnectSerializer(
-            new AvroDataTranslator(schema),
-            getAvroConverter(schemaRegistryClient, ksqlConfig));
-    final Deserializer<GenericRow> genericRowDeserializer =
-        new KsqlConnectDeserializer(
-            getAvroConverter(schemaRegistryClient, ksqlConfig),
-            new AvroDataTranslator(schema));
-    return Serdes.serdeFrom(genericRowSerializer, genericRowDeserializer);
+    return getGenericRowSerde(
+        schemaMaybeWithSource, ksqlConfig, isInternal, () -> schemaRegistryClient);
   }
 }

--- a/ksql-serde/src/main/java/io/confluent/ksql/serde/avro/KsqlAvroTopicSerDe.java
+++ b/ksql-serde/src/main/java/io/confluent/ksql/serde/avro/KsqlAvroTopicSerDe.java
@@ -80,13 +80,4 @@ public class KsqlAvroTopicSerDe extends KsqlTopicSerDe {
     );
     return Serdes.serdeFrom(genericRowSerializer, genericRowDeserializer);
   }
-
-  @Override
-  public Serde<GenericRow> getGenericRowSerde(final Schema schemaMaybeWithSource,
-                                              final KsqlConfig ksqlConfig,
-                                              final boolean isInternal,
-                                              final SchemaRegistryClient schemaRegistryClient) {
-    return getGenericRowSerde(
-        schemaMaybeWithSource, ksqlConfig, isInternal, () -> schemaRegistryClient);
-  }
 }

--- a/ksql-serde/src/main/java/io/confluent/ksql/serde/delimited/KsqlDelimitedTopicSerDe.java
+++ b/ksql-serde/src/main/java/io/confluent/ksql/serde/delimited/KsqlDelimitedTopicSerDe.java
@@ -23,6 +23,8 @@ import io.confluent.ksql.serde.KsqlTopicSerDe;
 import io.confluent.ksql.util.KsqlConfig;
 import java.util.HashMap;
 import java.util.Map;
+import java.util.function.Supplier;
+
 import org.apache.kafka.common.serialization.Deserializer;
 import org.apache.kafka.common.serialization.Serde;
 import org.apache.kafka.common.serialization.Serdes;
@@ -49,5 +51,14 @@ public class KsqlDelimitedTopicSerDe extends KsqlTopicSerDe {
     genericRowDeserializer.configure(serdeProps, false);
 
     return Serdes.serdeFrom(genericRowSerializer, genericRowDeserializer);
+  }
+
+  @Override
+  public Serde<GenericRow> getGenericRowSerde(
+      final Schema schema,
+      final KsqlConfig ksqlConfig,
+      final boolean isInternal,
+      final Supplier<SchemaRegistryClient> schemaRegistryClientFactory) {
+    return getGenericRowSerde(schema, ksqlConfig, isInternal, schemaRegistryClientFactory.get());
   }
 }

--- a/ksql-serde/src/main/java/io/confluent/ksql/serde/delimited/KsqlDelimitedTopicSerDe.java
+++ b/ksql-serde/src/main/java/io/confluent/ksql/serde/delimited/KsqlDelimitedTopicSerDe.java
@@ -39,9 +39,11 @@ public class KsqlDelimitedTopicSerDe extends KsqlTopicSerDe {
   }
 
   @Override
-  public Serde<GenericRow> getGenericRowSerde(final Schema schema, final KsqlConfig ksqlConfig,
-                                              final boolean isInternal,
-                                              final SchemaRegistryClient schemaRegistryClient) {
+  public Serde<GenericRow> getGenericRowSerde(
+      final Schema schema,
+      final KsqlConfig ksqlConfig,
+      final boolean isInternal,
+      final Supplier<SchemaRegistryClient> schemaRegistryClientFactory) {
     final Map<String, Object> serdeProps = new HashMap<>();
 
     final Serializer<GenericRow> genericRowSerializer = new KsqlDelimitedSerializer(schema);
@@ -51,14 +53,5 @@ public class KsqlDelimitedTopicSerDe extends KsqlTopicSerDe {
     genericRowDeserializer.configure(serdeProps, false);
 
     return Serdes.serdeFrom(genericRowSerializer, genericRowDeserializer);
-  }
-
-  @Override
-  public Serde<GenericRow> getGenericRowSerde(
-      final Schema schema,
-      final KsqlConfig ksqlConfig,
-      final boolean isInternal,
-      final Supplier<SchemaRegistryClient> schemaRegistryClientFactory) {
-    return getGenericRowSerde(schema, ksqlConfig, isInternal, schemaRegistryClientFactory.get());
   }
 }

--- a/ksql-serde/src/main/java/io/confluent/ksql/serde/json/KsqlJsonTopicSerDe.java
+++ b/ksql-serde/src/main/java/io/confluent/ksql/serde/json/KsqlJsonTopicSerDe.java
@@ -23,6 +23,8 @@ import io.confluent.ksql.serde.KsqlTopicSerDe;
 import io.confluent.ksql.util.KsqlConfig;
 import java.util.HashMap;
 import java.util.Map;
+import java.util.function.Supplier;
+
 import org.apache.kafka.common.serialization.Deserializer;
 import org.apache.kafka.common.serialization.Serde;
 import org.apache.kafka.common.serialization.Serdes;
@@ -51,5 +53,14 @@ public class KsqlJsonTopicSerDe extends KsqlTopicSerDe {
     genericRowDeserializer.configure(serdeProps, false);
 
     return Serdes.serdeFrom(genericRowSerializer, genericRowDeserializer);
+  }
+
+  @Override
+  public Serde<GenericRow> getGenericRowSerde(
+      final Schema schema,
+      final KsqlConfig ksqlConfig,
+      final boolean isInternal,
+      final Supplier<SchemaRegistryClient> schemaRegistryClientFactory) {
+    return getGenericRowSerde(schema, ksqlConfig, isInternal, schemaRegistryClientFactory.get());
   }
 }

--- a/ksql-serde/src/main/java/io/confluent/ksql/serde/json/KsqlJsonTopicSerDe.java
+++ b/ksql-serde/src/main/java/io/confluent/ksql/serde/json/KsqlJsonTopicSerDe.java
@@ -41,7 +41,7 @@ public class KsqlJsonTopicSerDe extends KsqlTopicSerDe {
   @Override
   public Serde<GenericRow> getGenericRowSerde(final Schema schema, final KsqlConfig ksqlConfig,
       final boolean isInternal,
-      final SchemaRegistryClient schemaRegistryClient) {
+      final Supplier<SchemaRegistryClient> schemaRegistryClientFactory) {
     final Map<String, Object> serdeProps = new HashMap<>();
     serdeProps.put("JsonPOJOClass", GenericRow.class);
 
@@ -53,14 +53,5 @@ public class KsqlJsonTopicSerDe extends KsqlTopicSerDe {
     genericRowDeserializer.configure(serdeProps, false);
 
     return Serdes.serdeFrom(genericRowSerializer, genericRowDeserializer);
-  }
-
-  @Override
-  public Serde<GenericRow> getGenericRowSerde(
-      final Schema schema,
-      final KsqlConfig ksqlConfig,
-      final boolean isInternal,
-      final Supplier<SchemaRegistryClient> schemaRegistryClientFactory) {
-    return getGenericRowSerde(schema, ksqlConfig, isInternal, schemaRegistryClientFactory.get());
   }
 }

--- a/ksql-serde/src/main/java/io/confluent/ksql/serde/tls/ThreadLocalCloseable.java
+++ b/ksql-serde/src/main/java/io/confluent/ksql/serde/tls/ThreadLocalCloseable.java
@@ -1,0 +1,50 @@
+/**
+ * Copyright 2018 Confluent Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ **/
+
+package io.confluent.ksql.serde.tls;
+
+import java.io.Closeable;
+import java.io.IOException;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.function.Supplier;
+
+public abstract class ThreadLocalCloseable<T extends Closeable> implements Closeable {
+  private final List<T> created;
+  final ThreadLocal<T> local;
+
+  protected ThreadLocalCloseable(final Supplier<T> initialValueSupplier) {
+    this.created = new LinkedList<>();
+    this.local = new ThreadLocal<T>() {
+      @Override
+      protected synchronized T initialValue() {
+        created.add(initialValueSupplier.get());
+        return created.get(created.size() - 1);
+      }
+    };
+  }
+
+  @Override
+  public void close() {
+    for (final Closeable c : created) {
+      try {
+        c.close();
+      } catch (final IOException e) {
+        throw new RuntimeException(e);
+      }
+    }
+  }
+}

--- a/ksql-serde/src/main/java/io/confluent/ksql/serde/tls/ThreadLocalCloseable.java
+++ b/ksql-serde/src/main/java/io/confluent/ksql/serde/tls/ThreadLocalCloseable.java
@@ -22,7 +22,7 @@ import java.util.LinkedList;
 import java.util.List;
 import java.util.function.Supplier;
 
-public abstract class ThreadLocalCloseable<T extends Closeable> implements Closeable {
+public class ThreadLocalCloseable<T extends Closeable> implements Closeable {
   private final List<T> created;
   final ThreadLocal<T> local;
 
@@ -35,6 +35,10 @@ public abstract class ThreadLocalCloseable<T extends Closeable> implements Close
         return created.get(created.size() - 1);
       }
     };
+  }
+
+  public T get() {
+    return local.get();
   }
 
   @Override

--- a/ksql-serde/src/main/java/io/confluent/ksql/serde/tls/ThreadLocalDeserializer.java
+++ b/ksql-serde/src/main/java/io/confluent/ksql/serde/tls/ThreadLocalDeserializer.java
@@ -1,0 +1,42 @@
+/**
+ * Copyright 2018 Confluent Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ **/
+
+package io.confluent.ksql.serde.tls;
+
+import io.confluent.ksql.GenericRow;
+
+import java.util.Map;
+import java.util.function.Supplier;
+
+import org.apache.kafka.common.serialization.Deserializer;
+
+public class ThreadLocalDeserializer
+    extends ThreadLocalCloseable<Deserializer<GenericRow>>
+    implements Deserializer<GenericRow> {
+  public ThreadLocalDeserializer(final Supplier<Deserializer<GenericRow>> initialValueSupplier) {
+    super(initialValueSupplier);
+  }
+
+  @Override
+  public void configure(Map<String, ?> properties, boolean isKey) {
+    local.get().configure(properties, isKey);
+  }
+
+  @Override
+  public GenericRow deserialize(String topicName, byte[] record) {
+    return local.get().deserialize(topicName, record);
+  }
+}

--- a/ksql-serde/src/main/java/io/confluent/ksql/serde/tls/ThreadLocalDeserializer.java
+++ b/ksql-serde/src/main/java/io/confluent/ksql/serde/tls/ThreadLocalDeserializer.java
@@ -31,12 +31,12 @@ public class ThreadLocalDeserializer implements Deserializer<GenericRow> {
   }
 
   @Override
-  public void configure(Map<String, ?> properties, boolean isKey) {
+  public void configure(final Map<String, ?> properties, final boolean isKey) {
     deserializer.get().configure(properties, isKey);
   }
 
   @Override
-  public GenericRow deserialize(String topicName, byte[] record) {
+  public GenericRow deserialize(final String topicName, final byte[] record) {
     return deserializer.get().deserialize(topicName, record);
   }
 

--- a/ksql-serde/src/main/java/io/confluent/ksql/serde/tls/ThreadLocalSerializer.java
+++ b/ksql-serde/src/main/java/io/confluent/ksql/serde/tls/ThreadLocalSerializer.java
@@ -1,0 +1,43 @@
+/**
+ * Copyright 2018 Confluent Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ **/
+
+package io.confluent.ksql.serde.tls;
+
+import io.confluent.ksql.GenericRow;
+
+import java.util.Map;
+import java.util.function.Supplier;
+
+import org.apache.kafka.common.serialization.Serializer;
+
+public class ThreadLocalSerializer
+    extends ThreadLocalCloseable<Serializer<GenericRow>>
+    implements Serializer<GenericRow> {
+
+  public ThreadLocalSerializer(final Supplier<Serializer<GenericRow>> initialValueSupplier) {
+    super(initialValueSupplier);
+  }
+
+  @Override
+  public void configure(Map<String, ?> properties, boolean isKey) {
+    local.get().configure(properties, isKey);
+  }
+
+  @Override
+  public byte[] serialize(String topicName, GenericRow record) {
+    return local.get().serialize(topicName, record);
+  }
+}

--- a/ksql-serde/src/main/java/io/confluent/ksql/serde/tls/ThreadLocalSerializer.java
+++ b/ksql-serde/src/main/java/io/confluent/ksql/serde/tls/ThreadLocalSerializer.java
@@ -31,12 +31,12 @@ public class ThreadLocalSerializer implements Serializer<GenericRow> {
   }
 
   @Override
-  public void configure(Map<String, ?> properties, boolean isKey) {
+  public void configure(final Map<String, ?> properties, final boolean isKey) {
     serializer.get().configure(properties, isKey);
   }
 
   @Override
-  public byte[] serialize(String topicName, GenericRow record) {
+  public byte[] serialize(final String topicName, final GenericRow record) {
     return serializer.get().serialize(topicName, record);
   }
 

--- a/ksql-serde/src/test/java/io/confluent/ksql/serde/avro/KsqlGenericRowAvroDeserializerTest.java
+++ b/ksql-serde/src/test/java/io/confluent/ksql/serde/avro/KsqlGenericRowAvroDeserializerTest.java
@@ -191,7 +191,8 @@ public class KsqlGenericRowAvroDeserializerTest {
 
     final Deserializer<GenericRow> deserializer =
         new KsqlAvroTopicSerDe().getGenericRowSerde(
-            schema, ksqlConfig, false, schemaRegistryClient).deserializer();
+            schema, ksqlConfig, false,
+            () -> schemaRegistryClient).deserializer();
 
     return deserializer.deserialize(topicName, bytes);
   }
@@ -489,7 +490,8 @@ public class KsqlGenericRowAvroDeserializerTest {
 
     final Deserializer<GenericRow> deserializer =
         new KsqlAvroTopicSerDe().getGenericRowSerde(
-            ksqlRecordSchema, ksqlConfig, false, schemaRegistryClient).deserializer();
+            ksqlRecordSchema, ksqlConfig, false,
+            () -> schemaRegistryClient).deserializer();
 
     final GenericRow row = deserializer.deserialize("topic", bytes);
 

--- a/ksql-serde/src/test/java/io/confluent/ksql/serde/avro/KsqlGenericRowAvroSerializerTest.java
+++ b/ksql-serde/src/test/java/io/confluent/ksql/serde/avro/KsqlGenericRowAvroSerializerTest.java
@@ -68,7 +68,8 @@ public class KsqlGenericRowAvroSerializerTest {
 
     final Serializer<GenericRow> serializer =
         new KsqlAvroTopicSerDe().getGenericRowSerde(
-            schema, new KsqlConfig(Collections.emptyMap()), false, schemaRegistryClient
+            schema, new KsqlConfig(Collections.emptyMap()), false,
+            () -> schemaRegistryClient
         ).serializer();
 
     final List columns = Arrays.asList(
@@ -105,7 +106,8 @@ public class KsqlGenericRowAvroSerializerTest {
     final SchemaRegistryClient schemaRegistryClient = new MockSchemaRegistryClient();
     final Serializer<GenericRow> serializer =
         new KsqlAvroTopicSerDe().getGenericRowSerde(
-            schema, new KsqlConfig(Collections.emptyMap()), false, schemaRegistryClient
+            schema, new KsqlConfig(Collections.emptyMap()), false,
+            () -> schemaRegistryClient
         ).serializer();
 
     final List columns = Arrays.asList(
@@ -143,7 +145,8 @@ public class KsqlGenericRowAvroSerializerTest {
     final SchemaRegistryClient schemaRegistryClient = new MockSchemaRegistryClient();
     final Serializer<GenericRow> serializer =
         new KsqlAvroTopicSerDe().getGenericRowSerde(
-            schema, new KsqlConfig(Collections.emptyMap()), false, schemaRegistryClient
+            schema, new KsqlConfig(Collections.emptyMap()), false,
+            () -> schemaRegistryClient
         ).serializer();
 
     final List columns = Arrays.asList(1511897796092L, 1L, "item_1", 10.0, null, null);
@@ -158,7 +161,8 @@ public class KsqlGenericRowAvroSerializerTest {
     final SchemaRegistryClient schemaRegistryClient = new MockSchemaRegistryClient();
     final Serializer<GenericRow> serializer =
         new KsqlAvroTopicSerDe().getGenericRowSerde(
-            schema, new KsqlConfig(Collections.emptyMap()), false, schemaRegistryClient
+            schema, new KsqlConfig(Collections.emptyMap()), false,
+            () -> schemaRegistryClient
         ).serializer();
 
     final List columns = Arrays.asList(
@@ -192,7 +196,8 @@ public class KsqlGenericRowAvroSerializerTest {
     final SchemaRegistryClient schemaRegistryClient = new MockSchemaRegistryClient();
     final Serde<GenericRow> serde =
         new KsqlAvroTopicSerDe().getGenericRowSerde(
-            ksqlRecordSchema, new KsqlConfig(Collections.emptyMap()), false, schemaRegistryClient
+            ksqlRecordSchema, new KsqlConfig(Collections.emptyMap()), false,
+            () -> schemaRegistryClient
         );
 
     final byte[] bytes = serde.serializer().serialize("topic", ksqlRecord);
@@ -342,7 +347,8 @@ public class KsqlGenericRowAvroSerializerTest {
     final SchemaRegistryClient schemaRegistryClient = new MockSchemaRegistryClient();
     final Serde<GenericRow> serde =
         new KsqlAvroTopicSerDe().getGenericRowSerde(
-            ksqlRecordSchema, new KsqlConfig(Collections.emptyMap()), false, schemaRegistryClient
+            ksqlRecordSchema, new KsqlConfig(Collections.emptyMap()), false,
+            () -> schemaRegistryClient
         );
 
     final byte[] bytes = serde.serializer().serialize("topic", ksqlRecord);
@@ -368,7 +374,8 @@ public class KsqlGenericRowAvroSerializerTest {
     final SchemaRegistryClient schemaRegistryClient = new MockSchemaRegistryClient();
     final Serde<GenericRow> serde =
         new KsqlAvroTopicSerDe().getGenericRowSerde(
-            ksqlRecordSchema, new KsqlConfig(Collections.emptyMap()), true, schemaRegistryClient
+            ksqlRecordSchema, new KsqlConfig(Collections.emptyMap()), true,
+            () -> schemaRegistryClient
         );
 
     final byte[] bytes = serde.serializer().serialize("topic", ksqlRecord);

--- a/ksql-serde/src/test/java/io/confluent/ksql/serde/tls/ThreadLocalCloseableTest.java
+++ b/ksql-serde/src/test/java/io/confluent/ksql/serde/tls/ThreadLocalCloseableTest.java
@@ -32,22 +32,12 @@ import static org.hamcrest.CoreMatchers.equalTo;
 import static org.junit.Assert.assertThat;
 
 public class ThreadLocalCloseableTest {
-  private static class TestCloseable<T extends Closeable> extends ThreadLocalCloseable<T> {
-    TestCloseable(final Supplier<T> initialValueSupplier) {
-      super(initialValueSupplier);
-    }
-
-    void ping() {
-      local.get();
-    }
-  };
-
   @Test
   public void shouldCloseAllInstances() {
     final Object lock = new Object();
 
     final List<Closeable> closeables = new LinkedList<>();
-    final TestCloseable<Closeable> testCloseable = new TestCloseable<>(
+    final ThreadLocalCloseable<Closeable> testCloseable = new ThreadLocalCloseable<>(
         () -> {
           synchronized (lock) {
             final Closeable closeable = mock(Closeable.class);
@@ -67,7 +57,7 @@ public class ThreadLocalCloseableTest {
     final int iterations = 3;
     final List<Thread> threads = new LinkedList<>();
     for (int i = 0; i < iterations; i++) {
-      threads.add(new Thread(testCloseable::ping));
+      threads.add(new Thread(testCloseable::get));
       threads.get(threads.size() - 1).start();
     }
 

--- a/ksql-serde/src/test/java/io/confluent/ksql/serde/tls/ThreadLocalCloseableTest.java
+++ b/ksql-serde/src/test/java/io/confluent/ksql/serde/tls/ThreadLocalCloseableTest.java
@@ -1,0 +1,88 @@
+/**
+ * Copyright 2018 Confluent Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ **/
+
+package io.confluent.ksql.serde.tls;
+
+import org.easymock.EasyMock;
+import org.junit.Test;
+
+import java.io.Closeable;
+import java.io.IOException;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.function.Supplier;
+
+import static org.easymock.EasyMock.expectLastCall;
+import static org.easymock.EasyMock.mock;
+import static org.easymock.EasyMock.replay;
+import static org.hamcrest.CoreMatchers.equalTo;
+import static org.junit.Assert.assertThat;
+
+public class ThreadLocalCloseableTest {
+  private static class TestCloseable<T extends Closeable> extends ThreadLocalCloseable<T> {
+    TestCloseable(final Supplier<T> initialValueSupplier) {
+      super(initialValueSupplier);
+    }
+
+    void ping() {
+      local.get();
+    }
+  };
+
+  @Test
+  public void shouldCloseAllInstances() {
+    final Object lock = new Object();
+
+    final List<Closeable> closeables = new LinkedList<>();
+    final TestCloseable<Closeable> testCloseable = new TestCloseable<>(
+        () -> {
+          synchronized (lock) {
+            final Closeable closeable = mock(Closeable.class);
+            closeables.add(closeable);
+            try {
+              closeable.close();
+            } catch (IOException e) {
+              throw new RuntimeException(e);
+            }
+            expectLastCall();
+            replay(closeable);
+            return closeable;
+          }
+        }
+    );
+
+    final int iterations = 3;
+    final List<Thread> threads = new LinkedList<>();
+    for (int i = 0; i < iterations; i++) {
+      threads.add(new Thread(testCloseable::ping));
+      threads.get(threads.size() - 1).start();
+    }
+
+    threads.forEach(
+        t -> {
+          try {
+            t.join();
+          } catch (InterruptedException e) {
+            throw new RuntimeException(e);
+          }
+        });
+
+    testCloseable.close();
+
+    assertThat(closeables.size(), equalTo(iterations));
+    closeables.forEach(EasyMock::verify);
+  }
+}

--- a/ksql-serde/src/test/java/io/confluent/ksql/serde/tls/ThreadLocalCloseableTest.java
+++ b/ksql-serde/src/test/java/io/confluent/ksql/serde/tls/ThreadLocalCloseableTest.java
@@ -30,6 +30,7 @@ import static org.easymock.EasyMock.mock;
 import static org.easymock.EasyMock.replay;
 import static org.hamcrest.CoreMatchers.equalTo;
 import static org.junit.Assert.assertThat;
+import static org.junit.Assert.fail;
 
 public class ThreadLocalCloseableTest {
   @Test
@@ -74,5 +75,18 @@ public class ThreadLocalCloseableTest {
 
     assertThat(closeables.size(), equalTo(iterations));
     closeables.forEach(EasyMock::verify);
+  }
+
+  @Test
+  public void shouldThrowOnAccessAfterClose() {
+    final ThreadLocalCloseable<Closeable> testCloseable = new ThreadLocalCloseable<>(
+        () ->  () -> {}
+    );
+    testCloseable.close();
+    try {
+      testCloseable.get();
+      fail("get() should throw IllegalStateException");
+    } catch (final IllegalStateException e) {
+    }
   }
 }

--- a/ksql-serde/src/test/java/io/confluent/ksql/serde/tls/ThreadLocalDeserializerTest.java
+++ b/ksql-serde/src/test/java/io/confluent/ksql/serde/tls/ThreadLocalDeserializerTest.java
@@ -1,0 +1,64 @@
+/**
+ * Copyright 2018 Confluent Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ **/
+
+package io.confluent.ksql.serde.tls;
+
+import io.confluent.ksql.GenericRow;
+import org.apache.kafka.common.serialization.Deserializer;
+import org.easymock.EasyMock;
+import org.junit.Test;
+
+import java.util.Collections;
+import java.util.LinkedList;
+import java.util.List;
+
+import static org.easymock.EasyMock.anyObject;
+import static org.easymock.EasyMock.anyString;
+import static org.easymock.EasyMock.expect;
+import static org.easymock.EasyMock.mock;
+import static org.easymock.EasyMock.replay;
+import static org.hamcrest.CoreMatchers.equalTo;
+import static org.junit.Assert.assertThat;
+
+public class ThreadLocalDeserializerTest {
+  @Test
+  @SuppressWarnings("unchecked")
+  public void shouldUseAThreadLocalDeserializer() throws InterruptedException {
+    final List<Deserializer<GenericRow>> serializers = new LinkedList<>();
+
+    final ThreadLocalDeserializer serializer = new ThreadLocalDeserializer(
+        () -> {
+          final Deserializer<GenericRow> local = mock(Deserializer.class);
+          serializers.add(local);
+          expect(local.deserialize(anyString(), anyObject(byte[].class)))
+              .andReturn(new GenericRow(Collections.emptyList()))
+              .times(1);
+          replay(local);
+          return serializers.get(serializers.size() - 1);
+        }
+    );
+
+    for (int i = 0; i < 3; i++) {
+      final Thread t = new Thread(
+          () -> serializer.deserialize("foo", new byte[32])
+      );
+      t.start();
+      t.join();
+      assertThat(serializers.size(), equalTo(i + 1));
+      serializers.forEach(EasyMock::verify);
+    }
+  }
+}

--- a/ksql-serde/src/test/java/io/confluent/ksql/serde/tls/ThreadLocalSerializerTest.java
+++ b/ksql-serde/src/test/java/io/confluent/ksql/serde/tls/ThreadLocalSerializerTest.java
@@ -1,0 +1,64 @@
+/**
+ * Copyright 2018 Confluent Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ **/
+
+package io.confluent.ksql.serde.tls;
+
+import io.confluent.ksql.GenericRow;
+import org.apache.kafka.common.serialization.Serializer;
+import org.easymock.EasyMock;
+import org.junit.Test;
+
+import java.util.Collections;
+import java.util.LinkedList;
+import java.util.List;
+
+import static org.easymock.EasyMock.anyObject;
+import static org.easymock.EasyMock.anyString;
+import static org.easymock.EasyMock.expect;
+import static org.easymock.EasyMock.mock;
+import static org.easymock.EasyMock.replay;
+import static org.hamcrest.CoreMatchers.equalTo;
+import static org.junit.Assert.assertThat;
+
+public class ThreadLocalSerializerTest {
+  @Test
+  @SuppressWarnings("unchecked")
+  public void shouldUseAThreadLocalSerializer() throws InterruptedException {
+    final List<Serializer<GenericRow>> serializers = new LinkedList<>();
+
+    final ThreadLocalSerializer serializer = new ThreadLocalSerializer(
+        () -> {
+          final Serializer<GenericRow> local = mock(Serializer.class);
+          serializers.add(local);
+          expect(local.serialize(anyString(), anyObject(GenericRow.class)))
+              .andReturn(new byte[32])
+              .times(1);
+          replay(local);
+          return serializers.get(serializers.size() - 1);
+        }
+    );
+
+    for (int i = 0; i < 3; i++) {
+      final Thread t = new Thread(
+          () -> serializer.serialize("foo", new GenericRow(Collections.emptyList()))
+      );
+      t.start();
+      t.join();
+      assertThat(serializers.size(), equalTo(i + 1));
+      serializers.forEach(EasyMock::verify);
+    }
+  }
+}


### PR DESCRIPTION
### Description

This patch changes running queries to use a thread-local avro serde. The avro
serde has always had some synchronization overhead due to the schema cache in
the schema registry client. The change to avro converter adds to that overhead
with its own caches. Accessing these caches is particularly expensive since it
hashes the whole schema while synchronized.

We use ThreadLocal to make the serdes thread-local, since streams doesnt have
an interface for passing a supplier that can be used to instantiate a serde per
thread. This is implemented using a small utility library under the tls package.

Finally, this patch changes the engine to pass around a schema registry supplier
instead of a schema registry, so each thread can create its own.
 
### Testing done 
Unit tests + performance test to validate improvement

### Reviewer checklist
- [ ] Ensure docs are updated if necessary. (eg. if a user visible feature is being added or changed).
- [ ] Ensure relevant issues are linked (description should include text like "Fixes #<issue number>")

