### PR TITLE
Improved CLI history handling

### DIFF
--- a/ksql-cli/src/main/java/io/confluent/ksql/cli/console/Console.java
+++ b/ksql-cli/src/main/java/io/confluent/ksql/cli/console/Console.java
@@ -932,7 +932,7 @@ public abstract class Console implements Closeable {
     @Override
     public void execute(final String commandStrippedLine) {
       for (final org.jline.reader.History.Entry historyEntry : lineReader.getHistory()) {
-        writer().printf("%4d: %s%n", historyEntry.index(), historyEntry.line());
+        writer().printf("%4d: %s%n", historyEntry.index() + 1, historyEntry.line());
       }
       flush();
     }

--- a/ksql-cli/src/test/java/io/confluent/ksql/cli/console/JLineReaderTest.java
+++ b/ksql-cli/src/test/java/io/confluent/ksql/cli/console/JLineReaderTest.java
@@ -2,25 +2,32 @@ package io.confluent.ksql.cli.console;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.contains;
-
+import static org.hamcrest.Matchers.hasSize;
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
+import java.io.File;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
 import java.nio.charset.StandardCharsets;
-import java.nio.file.Files;
 import java.nio.file.Path;
+import java.nio.file.Paths;
 import java.util.ArrayList;
 import java.util.List;
+import org.jline.reader.EndOfFileException;
 import org.jline.terminal.Terminal;
 import org.jline.terminal.impl.DumbTerminal;
+import org.junit.Rule;
 import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
 
 public class JLineReaderTest {
 
+  @Rule
+  public TemporaryFolder tempFolder = new TemporaryFolder();
+
   @Test
-  public void shouldSaveCommandsWithLeadingSpacesToHistory() throws IOException  {
+  public void shouldSaveCommandsWithLeadingSpacesToHistory() throws IOException {
     final String input = "  show streams\n";
     final JLineReader reader = createReaderForInput(input);
 
@@ -32,12 +39,111 @@ public class JLineReaderTest {
     assertThat(commands, contains(input.trim()));
   }
 
+  @Test
+  public void shouldExpandHistoricalLine() throws Exception {
+    final JLineReader reader = createReaderForInput("foo\n bar\n  baz \n!2\n");
+    final List<String> commands = new ArrayList<>();
+    try {
+      while (true) {
+         String line = reader.readLine();
+         commands.add(line.trim());
+      }
+    } catch (EndOfFileException e) {
+      // this indicates end of input in JLine
+    }
+    assertThat(commands, hasSize(4));
+    assertThat(commands, contains("foo", "bar", "baz", "bar"));
+  }
+
+  @Test
+  public void shouldExpandRelativeLine() throws Exception {
+    final JLineReader reader = createReaderForInput("foo\n bar\n  baz \n!-3\n");
+    final List<String> commands = new ArrayList<>();
+    try {
+      while (true) {
+         String line = reader.readLine();
+         commands.add(line.trim());
+      }
+    } catch (EndOfFileException e) {
+      // this indicates end of input in JLine
+    }
+    assertThat(commands, hasSize(4));
+    assertThat(commands, contains("foo", "bar", "baz", "foo"));
+  }
+
+  @Test
+  public void shouldNotExpandHistoryUnlessAtStartOfLine() throws Exception {
+    final JLineReader reader = createReaderForInput("foo\n bar\n  baz \n !2\n");
+    final List<String> commands = new ArrayList<>();
+    try {
+      while (true) {
+         String line = reader.readLine();
+         commands.add(line.trim());
+      }
+    } catch (EndOfFileException e) {
+      // this indicates end of input in JLine
+    }
+    assertThat(commands, hasSize(4));
+    assertThat(commands, contains("foo", "bar", "baz", "!2"));
+  }
+
+  @Test
+  public void shouldExpandHistoricalSearch() throws Exception {
+    final JLineReader reader = createReaderForInput("foo\n bar\n  baz \n!?ba\n");
+    final List<String> commands = new ArrayList<>();
+    try {
+      while (true) {
+         String line = reader.readLine();
+         commands.add(line.trim());
+      }
+    } catch (EndOfFileException e) {
+      // this indicates end of input in JLine
+    }
+    assertThat(commands, hasSize(4));
+    assertThat(commands, contains("foo", "bar", "baz", "baz"));
+  }
+
+  @Test
+  public void shouldExpandLastLine() throws Exception {
+    final JLineReader reader = createReaderForInput("foo\n bar\n  baz \n!!\n");
+    final List<String> commands = new ArrayList<>();
+    try {
+      while (true) {
+         String line = reader.readLine();
+         commands.add(line.trim());
+      }
+    } catch (EndOfFileException e) {
+      // this indicates end of input in JLine
+    }
+    assertThat(commands, hasSize(4));
+    assertThat(commands, contains("foo", "bar", "baz", "baz"));
+  }
+
+  @Test
+  public void shouldExpandHistoricalLineWithReplacement() throws Exception {
+    final JLineReader reader = createReaderForInput("foo\n select col1, col2 from d \n^col2^xyz^\n");
+    final List<String> commands = new ArrayList<>();
+    try {
+      while (true) {
+         String line = reader.readLine();
+         commands.add(line.trim());
+      }
+    } catch (EndOfFileException e) {
+      // this indicates end of input in JLine
+    }
+    assertThat(commands, hasSize(3));
+    assertThat(commands, contains("foo", "select col1, col2 from d", "select col1, xyz from d"));
+  }
+
+
+
   private JLineReader createReaderForInput(final String input) throws IOException {
-    final InputStream inputStream = new ByteArrayInputStream(
-        input.getBytes(StandardCharsets.UTF_8));
+    final InputStream inputStream =
+        new ByteArrayInputStream(input.getBytes(StandardCharsets.UTF_8));
     final OutputStream outputStream = new ByteArrayOutputStream(512);
     final Terminal terminal = new DumbTerminal(inputStream, outputStream);
-    final Path historyFilePath = Files.createTempFile("ksql-history", "txt");
+    File tempHistoryFile = tempFolder.newFile("ksql-history.txt");
+    final Path historyFilePath = Paths.get(tempHistoryFile.getAbsolutePath());
     return new JLineReader(terminal, historyFilePath);
   }
 }

--- a/pom.xml
+++ b/pom.xml
@@ -81,7 +81,7 @@
         <guava.version>24.0-jre</guava.version>
         <inject.version>1</inject.version>
         <janino.version>3.0.7</janino.version>
-        <jline.version>3.3.1</jline.version>
+        <jline.version>3.9.0</jline.version>
         <jna.version>4.4.0</jna.version>
         <jsr305.version>3.0.2</jsr305.version>
         <really.executable.jar.version>1.5.0</really.executable.jar.version>


### PR DESCRIPTION
### Description 
Updated the way the CLI handles a users command history so that it can be used more like a bash shell.
Specifically, the following shortcut commands can now be entered as the first text of a new command line with the following effects:

- `!!`  - rerun the most recent command
- `!42` - rerun the command with index 42, as printed by the `history` command
- `!-3` - reverse history reference, here rerunning the third most recent command
- `!?foo` - reverse search through the history of commands and rerun the first one containing `foo`
- `^foo^bar^` - rerun the most recent command but with all occurrences of `foo` within it replaced by `bar`

Could use some suggestions as to where best to add this info into the docs pls!

### Testing done 
New and improved unit tests for the CLI line-reader plus manual testing of the build output

### Reviewer checklist
- [ ] Ensure docs are updated if necessary. (eg. if a user visible feature is being added or changed).
- [ ] Ensure relevant issues are linked (description should include text like "Fixes #<issue number>")

