### PR TITLE
Change KafkaConsumerGroupClient to use AdminClient

### DIFF
--- a/ksql-engine/src/main/java/io/confluent/ksql/KsqlContext.java
+++ b/ksql-engine/src/main/java/io/confluent/ksql/KsqlContext.java
@@ -31,6 +31,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Set;
+import org.apache.kafka.clients.admin.AdminClient;
 import org.apache.kafka.streams.KafkaClientSupplier;
 import org.apache.kafka.streams.processor.internals.DefaultKafkaClientSupplier;
 import org.slf4j.Logger;
@@ -62,8 +63,10 @@ public class KsqlContext {
   ) {
     Objects.requireNonNull(ksqlConfig, "ksqlConfig cannot be null.");
     Objects.requireNonNull(schemaRegistryClient, "schemaRegistryClient cannot be null.");
+    final AdminClient adminClient = clientSupplier
+        .getAdminClient(ksqlConfig.getKsqlAdminClientConfigProps());
     final KafkaTopicClient kafkaTopicClient = new
-        KafkaTopicClientImpl(ksqlConfig.getKsqlAdminClientConfigProps());
+        KafkaTopicClientImpl(adminClient);
     final MetaStore metaStore = new MetaStoreImpl(new InternalFunctionRegistry());
     final KsqlEngine engine = new KsqlEngine(
         kafkaTopicClient,

--- a/ksql-engine/src/main/java/io/confluent/ksql/KsqlEngine.java
+++ b/ksql-engine/src/main/java/io/confluent/ksql/KsqlEngine.java
@@ -79,6 +79,7 @@ import java.util.concurrent.Executors;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.TimeUnit;
 import java.util.stream.Collectors;
+import org.apache.kafka.clients.admin.AdminClient;
 import org.apache.kafka.streams.KafkaClientSupplier;
 import org.apache.kafka.streams.StreamsConfig;
 import org.apache.kafka.streams.processor.internals.DefaultKafkaClientSupplier;
@@ -107,17 +108,20 @@ public class KsqlEngine implements Closeable {
   private final SchemaRegistryClient schemaRegistryClient;
   private final QueryIdGenerator queryIdGenerator;
   private final KafkaClientSupplier clientSupplier;
+  private final AdminClient adminClient;
 
   private final String serviceId;
 
-  public KsqlEngine(final KsqlConfig initializationKsqlConfig) {
-    this(
-        new KafkaTopicClientImpl(initializationKsqlConfig.getKsqlAdminClientConfigProps()),
-        new KsqlSchemaRegistryClientFactory(initializationKsqlConfig).create(),
-        new DefaultKafkaClientSupplier(),
+  public static KsqlEngine create(final KsqlConfig ksqlConfig) {
+    final DefaultKafkaClientSupplier clientSupplier = new DefaultKafkaClientSupplier();
+    final AdminClient adminClient = clientSupplier
+        .getAdminClient(ksqlConfig.getKsqlAdminClientConfigProps());
+    return new KsqlEngine(new KafkaTopicClientImpl(adminClient),
+        new KsqlSchemaRegistryClientFactory(ksqlConfig).create(),
+        clientSupplier,
         new MetaStoreImpl(new InternalFunctionRegistry()),
-        initializationKsqlConfig
-    );
+        ksqlConfig,
+        adminClient);
   }
 
   // called externally by tests only
@@ -135,12 +139,28 @@ public class KsqlEngine implements Closeable {
     );
   }
 
+  KsqlEngine(final KafkaTopicClient kafkaTopicClient,
+             final SchemaRegistryClient schemaRegistryClient,
+             final KafkaClientSupplier kafkaClientSupplier,
+             final MetaStore metaStore,
+             final KsqlConfig initializationKsqlConfig) {
+    this(kafkaTopicClient,
+        schemaRegistryClient,
+        kafkaClientSupplier,
+        metaStore,
+        initializationKsqlConfig,
+        kafkaClientSupplier.getAdminClient(
+            initializationKsqlConfig.getKsqlAdminClientConfigProps()));
+
+  }
+
   // called externally by tests only
   KsqlEngine(final KafkaTopicClient topicClient,
              final SchemaRegistryClient schemaRegistryClient,
              final KafkaClientSupplier clientSupplier,
              final MetaStore metaStore,
-             final KsqlConfig initializationKsqlConfig
+             final KsqlConfig initializationKsqlConfig,
+             final AdminClient adminClient
   ) {
     this.metaStore = Objects.requireNonNull(metaStore, "metaStore can't be null");
     this.topicClient = Objects.requireNonNull(topicClient, "topicClient can't be null");
@@ -158,6 +178,7 @@ public class KsqlEngine implements Closeable {
     this.engineMetrics = new KsqlEngineMetrics("ksql-engine", this);
     this.aggregateMetricsCollector = Executors.newSingleThreadScheduledExecutor();
     this.queryIdGenerator = new QueryIdGenerator();
+    this.adminClient = Objects.requireNonNull(adminClient, "adminCluent can't be null");
     aggregateMetricsCollector.scheduleAtFixedRate(
         engineMetrics::updateMetrics,
         1000,
@@ -554,7 +575,7 @@ public class KsqlEngine implements Closeable {
     for (final QueryMetadata queryMetadata : allLiveQueries) {
       queryMetadata.close();
     }
-    topicClient.close();
+    adminClient.close();
     engineMetrics.close();
     aggregateMetricsCollector.shutdown();
   }
@@ -599,5 +620,9 @@ public class KsqlEngine implements Closeable {
 
   public List<AggregateFunctionFactory> listAggregateFunctions() {
     return metaStore.listAggregateFunctions();
+  }
+
+  public AdminClient getAdminClient() {
+    return adminClient;
   }
 }

--- a/ksql-engine/src/main/java/io/confluent/ksql/util/KafkaConsumerGroupClient.java
+++ b/ksql-engine/src/main/java/io/confluent/ksql/util/KafkaConsumerGroupClient.java
@@ -18,31 +18,30 @@ package io.confluent.ksql.util;
 
 import java.util.ArrayList;
 import java.util.Collection;
-import java.util.HashMap;
+import java.util.HashSet;
 import java.util.List;
-import java.util.Map;
+import java.util.Objects;
+import java.util.Set;
 import org.apache.kafka.common.TopicPartition;
 
-public interface KafkaConsumerGroupClient extends AutoCloseable {
+public interface KafkaConsumerGroupClient {
 
   List<String> listGroups();
 
   ConsumerGroupSummary describeConsumerGroup(String group);
 
-  void close();
-
   /**
    * API POJOs
    */
   class ConsumerGroupSummary {
-    final Map<String, ConsumerSummary> consumerSummaries = new HashMap<>();
+    final Set<ConsumerSummary> consumerSummaries = new HashSet<>();
 
-    public Collection<ConsumerSummary> consumers() {
-      return consumerSummaries.values();
+    public ConsumerGroupSummary(final Set<ConsumerSummary> summaries) {
+      consumerSummaries.addAll(summaries);
     }
 
-    public void addConsumerSummary(final ConsumerSummary consumerSummary) {
-      this.consumerSummaries.put(consumerSummary.getConsumerId(), consumerSummary);
+    public Collection<ConsumerSummary> consumers() {
+      return consumerSummaries;
     }
   }
 
@@ -58,12 +57,29 @@ public interface KafkaConsumerGroupClient extends AutoCloseable {
       this.partitions.add(topicPartition);
     }
 
-    public String getConsumerId() {
-      return consumerId;
-    }
-
     public List<TopicPartition> partitions() {
       return partitions;
+    }
+
+    void addPartitions(final Set<TopicPartition> topicPartitions) {
+      this.partitions.addAll(topicPartitions);
+    }
+
+    @Override
+    public boolean equals(final Object o) {
+      if (this == o) {
+        return true;
+      }
+      if (o == null || getClass() != o.getClass()) {
+        return false;
+      }
+      final ConsumerSummary that = (ConsumerSummary) o;
+      return Objects.equals(consumerId, that.consumerId);
+    }
+
+    @Override
+    public int hashCode() {
+      return Objects.hash(consumerId);
     }
   }
 }

--- a/ksql-engine/src/main/java/io/confluent/ksql/util/KafkaConsumerGroupClientImpl.java
+++ b/ksql-engine/src/main/java/io/confluent/ksql/util/KafkaConsumerGroupClientImpl.java
@@ -16,149 +16,62 @@
 
 package io.confluent.ksql.util;
 
-import java.io.File;
-import java.io.FileOutputStream;
-import java.io.IOException;
-import java.nio.file.Files;
-import java.nio.file.attribute.FileAttribute;
-import java.nio.file.attribute.PosixFilePermission;
-import java.nio.file.attribute.PosixFilePermissions;
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.HashSet;
+import io.confluent.ksql.exception.KafkaResponseGetFailedException;
+import io.confluent.ksql.util.ExecutorUtil.RetryBehaviour;
+import java.util.Collections;
 import java.util.List;
 import java.util.Map;
-import java.util.Properties;
 import java.util.Set;
-import kafka.admin.AdminClient;
-import kafka.admin.ConsumerGroupCommand;
-import org.apache.kafka.common.TopicPartition;
-import org.apache.kafka.common.config.ConfigDef;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
+import java.util.stream.Collectors;
+import org.apache.kafka.clients.admin.AdminClient;
+import org.apache.kafka.clients.admin.ConsumerGroupDescription;
+import org.apache.kafka.clients.admin.ConsumerGroupListing;
 
-/**
- * Acts as a ConsumerGroup facade over the scala layer
- * Note: This functionality will very shortly be added to the java admin client, maybe even in
- * the upcoming 1.1. release: https://cwiki.apache.org/confluence/pages/viewpage
- * .action?pageId=74686265
- * Also, the Scala admin client is on the path to deprecation. See issue #642
- */
 public class KafkaConsumerGroupClientImpl implements KafkaConsumerGroupClient {
 
-  private static final Logger log = LoggerFactory.getLogger(KafkaConsumerGroupClientImpl.class);
-  private static final int ADMIN_CLIENT_TIMEOUT_MS = 1000;
   private final AdminClient adminClient;
-  private final KsqlConfig ksqlConfig;
 
-  public KafkaConsumerGroupClientImpl(final KsqlConfig ksqlConfig) {
-    this.ksqlConfig = ksqlConfig;
-    final Properties props = new Properties();
-    props.putAll(ConfigDef.convertToStringMapWithPasswordValues(
-        ksqlConfig.getKsqlAdminClientConfigProps()));
-    this.adminClient = AdminClient.create(props);
+  public KafkaConsumerGroupClientImpl(final AdminClient adminClient) {
+    this.adminClient = adminClient;
   }
 
   @Override
   public List<String> listGroups() {
-
-    final String[] args = consumerGroupCommandOptions();
-
-    final ConsumerGroupCommand.ConsumerGroupCommandOptions opts =
-        new ConsumerGroupCommand.ConsumerGroupCommandOptions(args);
-    final ConsumerGroupCommand.ConsumerGroupService groupService =
-        new ConsumerGroupCommand.ConsumerGroupService(opts);
-
     try {
-      final scala.collection.immutable.List<String> consumerGroups = groupService.listGroups();
-      final scala.collection.Iterator<String> consumerGroupsIterator = consumerGroups.iterator();
-      final ArrayList<String> results = new ArrayList<>();
-      while (consumerGroupsIterator.hasNext()) {
-        results.add(consumerGroupsIterator.next());
-      }
-      return results;
-    } finally {
-      groupService.close();
+      return ExecutorUtil.executeWithRetries(
+          () -> adminClient.listConsumerGroups().all().get(),
+          RetryBehaviour.ON_RETRYABLE)
+          .stream()
+          .map(ConsumerGroupListing::groupId).collect(Collectors.toList());
+    } catch (final Exception e) {
+      throw new KafkaResponseGetFailedException("Failed to retrieve Kafka consumer groups", e);
     }
-  }
-
-  private String[] consumerGroupCommandOptions() {
-    // The ConsumerGroupCommand we use instantiates its own admin client. However, the configs
-    // for the underlying admin client can be passed only through a properties file. So we dump
-    // the admin client configs to a temporary file and then use that file to configure the
-    // underlying admin client correctly.
-    final Map<String, String> clientConfigProps = ConfigDef.convertToStringMapWithPasswordValues(
-        ksqlConfig.getKsqlAdminClientConfigProps());
-    try {
-      // this is dangerous - we could be writing a password out here
-      final File tmpConfigFile = flushPropertiesToTempFile(clientConfigProps);
-      return new String[]{
-          "--bootstrap-server", (String) clientConfigProps.get("bootstrap.servers"),
-          "--command-config", tmpConfigFile.getAbsolutePath()
-      };
-    } catch (final IOException e) {
-      log.error("Could not configure the list groups command.", e);
-      throw new KsqlException("Could not list groups", e);
-    }
-  }
-
-  private File flushPropertiesToTempFile(final Map<String, String> configProps) throws IOException {
-    final FileAttribute<Set<PosixFilePermission>> attributes
-        = PosixFilePermissions.asFileAttribute(new HashSet<>(
-            Arrays.asList(PosixFilePermission.OWNER_WRITE,
-                          PosixFilePermission.OWNER_READ)));
-    final File configFile
-        = Files.createTempFile("ksqlclient", "properties", attributes).toFile();
-    configFile.deleteOnExit();
-
-    try (FileOutputStream outputStream = new FileOutputStream(configFile)) {
-      final Properties clientProps = new Properties();
-      for (final Map.Entry<String, String> property
-          : configProps.entrySet()) {
-        clientProps.put(property.getKey(), property.getValue());
-      }
-      clientProps.store(outputStream, "Configuration properties of KSQL AdminClient");
-    }
-    return configFile;
-  }
-
-  @Override
-  public void close() {
-    adminClient.close();
   }
 
   public ConsumerGroupSummary describeConsumerGroup(final String group) {
 
-    final AdminClient.ConsumerGroupSummary consumerGroupSummary = adminClient.describeConsumerGroup(
-        group,
-        ADMIN_CLIENT_TIMEOUT_MS
-    );
-    final scala.collection.immutable.List<AdminClient.ConsumerSummary> consumerSummaryList =
-        consumerGroupSummary.consumers().get();
-    final scala.collection.Iterator<AdminClient.ConsumerSummary> consumerSummaryIterator =
-        consumerSummaryList.iterator();
+    try {
+      final Map<String, ConsumerGroupDescription> groups = ExecutorUtil
+          .executeWithRetries(
+              () -> adminClient.describeConsumerGroups(Collections.singleton(group)).all().get(),
+              RetryBehaviour.ON_RETRYABLE);
 
-    final ConsumerGroupSummary results = new ConsumerGroupSummary();
+      final Set<ConsumerSummary> results = groups
+          .values()
+          .stream()
+          .flatMap(g ->
+              g.members()
+                  .stream()
+                  .map(member -> {
+                    final ConsumerSummary summary = new ConsumerSummary(member.consumerId());
+                    summary.addPartitions(member.assignment().topicPartitions());
+                    return summary;
+                  })).collect(Collectors.toSet());
 
-    while (consumerSummaryIterator.hasNext()) {
-      final AdminClient.ConsumerSummary consumerSummary = consumerSummaryIterator.next();
+      return new ConsumerGroupSummary(results);
 
-      final ConsumerSummary consumerSummary1 = new ConsumerSummary(consumerSummary.consumerId());
-      results.addConsumerSummary(consumerSummary1);
-
-      final scala.collection.immutable.List<TopicPartition> topicPartitionList =
-          consumerSummary.assignment();
-      final scala.collection.Iterator<TopicPartition> topicPartitionIterator =
-          topicPartitionList.iterator();
-
-      while (topicPartitionIterator.hasNext()) {
-        final TopicPartition topicPartition = topicPartitionIterator.next();
-        consumerSummary1.addPartition(new TopicPartition(
-            topicPartition.topic(),
-            topicPartition.partition()
-        ));
-      }
+    } catch (final Exception e) {
+      throw new KafkaResponseGetFailedException("Failed to describe Kafka consumer groups", e);
     }
-    return results;
   }
 }

--- a/ksql-engine/src/main/java/io/confluent/ksql/util/KafkaTopicClient.java
+++ b/ksql-engine/src/main/java/io/confluent/ksql/util/KafkaTopicClient.java
@@ -16,7 +16,6 @@
 
 package io.confluent.ksql.util;
 
-import java.io.Closeable;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
@@ -25,7 +24,7 @@ import java.util.Optional;
 import java.util.Set;
 import org.apache.kafka.clients.admin.TopicDescription;
 
-public interface KafkaTopicClient extends Closeable {
+public interface KafkaTopicClient  {
 
   enum TopicCleanupPolicy {
     COMPACT,
@@ -128,9 +127,4 @@ public interface KafkaTopicClient extends Closeable {
    * Delete the internal topics of a given application.
    */
   void deleteInternalTopics(String applicationId);
-
-  /**
-   * Close the underlying Kafka admin client.
-   */
-  void close();
 }

--- a/ksql-engine/src/main/java/io/confluent/ksql/util/KafkaTopicClientImpl.java
+++ b/ksql-engine/src/main/java/io/confluent/ksql/util/KafkaTopicClientImpl.java
@@ -50,20 +50,11 @@ public class KafkaTopicClientImpl implements KafkaTopicClient {
   private final boolean isDeleteTopicEnabled;
 
   /**
-   * Construct a topic client.
-   *
-   * @param adminClientConfig the admin client config.
-   */
-  public KafkaTopicClientImpl(final Map<String, Object> adminClientConfig) {
-    this(AdminClient.create(adminClientConfig));
-  }
-
-  /**
    * Construct a topic client from an existing admin client.
    *
    * @param adminClient the admin client. Note: Will be closed on {@link #close()}.
    */
-  KafkaTopicClientImpl(final AdminClient adminClient) {
+  public KafkaTopicClientImpl(final AdminClient adminClient) {
     this.adminClient = Objects.requireNonNull(adminClient, "adminClient");
     this.isDeleteTopicEnabled = isTopicDeleteEnabled(adminClient);
   }
@@ -276,10 +267,6 @@ public class KafkaTopicClientImpl implements KafkaTopicClient {
     return topicName.startsWith(applicationId + "-")
            && (topicName.endsWith(KsqlConstants.STREAMS_CHANGELOG_TOPIC_SUFFIX)
                || topicName.endsWith(KsqlConstants.STREAMS_REPARTITION_TOPIC_SUFFIX));
-  }
-
-  public void close() {
-    this.adminClient.close();
   }
 
   private void validateTopicProperties(final String topic,

--- a/ksql-engine/src/test/java/io/confluent/ksql/KsqlEngineTest.java
+++ b/ksql-engine/src/test/java/io/confluent/ksql/KsqlEngineTest.java
@@ -51,6 +51,7 @@ import java.util.Collections;
 import java.util.List;
 import org.apache.avro.Schema;
 import org.apache.avro.SchemaBuilder;
+import org.apache.kafka.clients.admin.AdminClient;
 import org.apache.kafka.common.utils.Utils;
 import org.apache.kafka.streams.StreamsConfig;
 import org.apache.kafka.streams.processor.internals.DefaultKafkaClientSupplier;
@@ -322,19 +323,25 @@ public class KsqlEngineTest {
   }
 
   @Test
-  public void shouldCloseInternallyCreatedTopicClientOnClose() {
+  public void shouldCloseAdminClientOnClose() {
     // Given:
-    final KafkaTopicClient topicClient = niceMock(KafkaTopicClient.class);
-    topicClient.close();
+    final AdminClient adminClient = niceMock(AdminClient.class);
+    adminClient.close();
     expectLastCall();
-    replay(topicClient);
+    replay(adminClient);
     final KsqlEngine ksqlEngine
-        = new KsqlEngine(topicClient, schemaRegistryClient, metaStore, ksqlConfig);
+        = new KsqlEngine(
+            new FakeKafkaTopicClient(),
+            schemaRegistryClient,
+            new DefaultKafkaClientSupplier(),
+            metaStore,
+            ksqlConfig,
+          adminClient);
 
     // When:
     ksqlEngine.close();
 
     // Then:
-    verify(topicClient);
+    verify(adminClient);
   }
 }

--- a/ksql-engine/src/test/java/io/confluent/ksql/integration/EndToEndIntegrationTest.java
+++ b/ksql-engine/src/test/java/io/confluent/ksql/integration/EndToEndIntegrationTest.java
@@ -87,7 +87,7 @@ public class EndToEndIntegrationTest {
 
     ksqlConfig = testHarness.ksqlConfig.clone();
 
-    ksqlEngine = new KsqlEngine(ksqlConfig);
+    ksqlEngine = KsqlEngine.create(ksqlConfig);
 
     testHarness.createTopic(pageViewTopic);
     testHarness.createTopic(usersTopic);

--- a/ksql-engine/src/test/java/io/confluent/ksql/integration/IntegrationTestHarness.java
+++ b/ksql-engine/src/test/java/io/confluent/ksql/integration/IntegrationTestHarness.java
@@ -29,6 +29,7 @@ import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.stream.Collectors;
+import org.apache.kafka.clients.admin.AdminClient;
 import org.apache.kafka.clients.consumer.ConsumerConfig;
 import org.apache.kafka.clients.consumer.ConsumerInterceptor;
 import org.apache.kafka.clients.consumer.ConsumerRecord;
@@ -71,6 +72,7 @@ public class IntegrationTestHarness {
   private final AtomicInteger producedCount;
 
   private static IntegrationTestHarness THIS;
+  private AdminClient adminClient;
 
   public IntegrationTestHarness() {
     this.schemaRegistryClient = new MockSchemaRegistryClient();
@@ -324,11 +326,13 @@ public class IntegrationTestHarness {
     configMap.putAll(callerConfigMap);
 
     this.ksqlConfig = new KsqlConfig(configMap);
-    this.topicClient = new KafkaTopicClientImpl(ksqlConfig.getKsqlAdminClientConfigProps());
+    this.adminClient = AdminClient.create(ksqlConfig.getKsqlAdminClientConfigProps());
+    this.topicClient = new KafkaTopicClientImpl(
+        adminClient);
   }
 
   public void stop() {
-    this.topicClient.close();
+    this.adminClient.close();
     this.embeddedKafkaCluster.stop();
   }
 

--- a/ksql-engine/src/test/java/io/confluent/ksql/integration/JsonFormatTest.java
+++ b/ksql-engine/src/test/java/io/confluent/ksql/integration/JsonFormatTest.java
@@ -81,7 +81,7 @@ public class JsonFormatTest {
     configMap.put("auto.offset.reset", "earliest");
 
     ksqlConfig = new KsqlConfig(configMap);
-    ksqlEngine = new KsqlEngine(ksqlConfig);
+    ksqlEngine = KsqlEngine.create(ksqlConfig);
     topicClient = ksqlEngine.getTopicClient();
     metaStore = ksqlEngine.getMetaStore();
 

--- a/ksql-engine/src/test/java/io/confluent/ksql/integration/KafkaConsumerGroupClientTest.java
+++ b/ksql-engine/src/test/java/io/confluent/ksql/integration/KafkaConsumerGroupClientTest.java
@@ -1,0 +1,145 @@
+/*
+ * Copyright 2018 Confluent Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.confluent.ksql.integration;
+
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.containsInAnyOrder;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.collection.IsCollectionWithSize.hasSize;
+
+import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.Streams;
+import io.confluent.ksql.util.KafkaConsumerGroupClient;
+import io.confluent.ksql.util.KafkaConsumerGroupClient.ConsumerSummary;
+import io.confluent.ksql.util.KafkaConsumerGroupClientImpl;
+import io.confluent.ksql.util.OrderDataProvider;
+import java.time.Duration;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import org.apache.kafka.clients.admin.AdminClient;
+import org.apache.kafka.clients.consumer.ConsumerConfig;
+import org.apache.kafka.clients.consumer.KafkaConsumer;
+import org.apache.kafka.test.IntegrationTest;
+import org.apache.kafka.test.TestUtils;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+
+/**
+ * Unfortunately needs to be an integration test as there is no way
+ * of stubbing results from the admin client as constructors are package-private. Mocking
+ * the results would be tedious and distract from the actual testing.
+ */
+@Category({IntegrationTest.class})
+public class KafkaConsumerGroupClientTest {
+
+  private IntegrationTestHarness testHarness;
+  private AdminClient adminClient;
+  private KafkaConsumerGroupClient consumerGroupClient;
+
+
+  @Before
+  public void startUp() throws Exception {
+    testHarness = new IntegrationTestHarness();
+    testHarness.start(ImmutableMap
+        .of(ConsumerConfig.AUTO_OFFSET_RESET_CONFIG, "earliest"));
+    adminClient = AdminClient.create(testHarness.ksqlConfig.getKsqlAdminClientConfigProps());
+    consumerGroupClient = new KafkaConsumerGroupClientImpl(adminClient);
+  }
+
+  @After
+  public void shutdown() {
+    adminClient.close();
+    testHarness.stop();
+  }
+
+  @Test
+  public void shouldListNoConsumerGroupsWhenThereAreNone() {
+    assertThat(consumerGroupClient.listGroups(), equalTo(Collections.<String>emptyList()));
+  }
+
+  @Test
+  public void shouldListConsumerGroupsWhenTheyExist() throws InterruptedException {
+    createTopic();
+    final List<String> consumerGroups = new ArrayList<>();
+    verifyListsGroups("group1", consumerGroups);
+    verifyListsGroups("group2", consumerGroups);
+  }
+
+  @Test
+  public void shouldDescribeGroup() throws InterruptedException {
+    createTopic();
+    final String group = "theGroup";
+    try (final KafkaConsumer<String, byte[]> c1 = createConsumer(group)) {
+      verifyDescribeGroup(1, group, Collections.singletonList(c1));
+      try (final KafkaConsumer<String, byte[]> c2 = createConsumer(group)) {
+       verifyDescribeGroup(2, group, Arrays.asList(c1, c2));
+      }
+    }
+  }
+
+  private void verifyDescribeGroup(
+      final int expectedConsumers,
+      final String group,
+      final List<KafkaConsumer<String, byte[]>> consumers)
+      throws InterruptedException {
+    final List<ConsumerSummary> summaries = new ArrayList<>();
+    TestUtils.waitForCondition(() -> {
+      consumers.forEach(consumer -> consumer.poll(Duration.ofMillis(1)));
+      summaries.clear();
+      summaries.addAll(consumerGroupClient.describeConsumerGroup(group).consumers());
+      return summaries.size() == expectedConsumers
+          && summaries.stream().mapToLong(summary -> summary.partitions().size()).sum() == 3;
+    }, 30000, "didn't receive expected number of consumers and/or partitions for group");
+
+  }
+
+  private void verifyListsGroups(final String newGroup, final List<String> consumerGroups)
+      throws InterruptedException {
+    consumerGroups.add(newGroup);
+    try(final KafkaConsumer<String, byte[]> consumer = createConsumer(newGroup)) {
+      final List<String> actual = waitForGroups(consumerGroups.size(), consumer);
+      assertThat(actual, containsInAnyOrder(consumerGroups.toArray()));
+    }
+  }
+
+  private List<String> waitForGroups(final int expectedNumberOfGroups,
+      final KafkaConsumer<String, byte[]> consumer) throws InterruptedException {
+    TestUtils.waitForCondition(
+        () -> {
+          consumer.poll(Duration.ofMillis(1));
+          return consumerGroupClient.listGroups().size() == expectedNumberOfGroups;
+        },
+        "didn't receive exepected number of groups: " + expectedNumberOfGroups);
+    return consumerGroupClient.listGroups();
+  }
+
+  private void createTopic() {
+    testHarness.createTopic("test", 3, (short) 1);
+    testHarness.publishTestData("test", new OrderDataProvider(), System.currentTimeMillis());
+  }
+
+  private KafkaConsumer<String, byte[]> createConsumer(final String group) {
+    return testHarness.createSubscribedConsumer("test", group);
+  }
+
+
+}

--- a/ksql-engine/src/test/java/io/confluent/ksql/testutils/EmbeddedSingleNodeKafkaCluster.java
+++ b/ksql-engine/src/test/java/io/confluent/ksql/testutils/EmbeddedSingleNodeKafkaCluster.java
@@ -112,7 +112,7 @@ public class EmbeddedSingleNodeKafkaCluster extends ExternalResource {
 
     zookeeper = new ZooKeeperEmbedded();
     brokerConfig.put(SimpleAclAuthorizer.ZkUrlProp(), zookeeper.connectString());
-
+    brokerConfig.put("group.initial.rebalance.delay.ms", 0);
     broker = new KafkaEmbedded(effectiveBrokerConfigFrom());
     clientConfig.put(ConsumerConfig.BOOTSTRAP_SERVERS_CONFIG, bootstrapServers());
     authorizer.configure(ImmutableMap.of(ZKConfig.ZkConnectProp(), zookeeperConnect()));

--- a/ksql-engine/src/test/java/io/confluent/ksql/util/FakeKafkaTopicClient.java
+++ b/ksql-engine/src/test/java/io/confluent/ksql/util/FakeKafkaTopicClient.java
@@ -144,8 +144,4 @@ public class FakeKafkaTopicClient implements KafkaTopicClient {
   @Override
   public void deleteInternalTopics(final String applicationId) {
   }
-
-  @Override
-  public void close() {  }
-
 }

--- a/ksql-engine/src/test/java/io/confluent/ksql/util/KafkaTopicClientImplIntegrationTest.java
+++ b/ksql-engine/src/test/java/io/confluent/ksql/util/KafkaTopicClientImplIntegrationTest.java
@@ -67,7 +67,7 @@ public class KafkaTopicClientImplIntegrationTest {
 
   @After
   public void tearDown() {
-    client.close();
+    adminClient.close();
   }
 
   @Test

--- a/ksql-engine/src/test/java/io/confluent/ksql/util/KafkaTopicClientImplTest.java
+++ b/ksql-engine/src/test/java/io/confluent/ksql/util/KafkaTopicClientImplTest.java
@@ -375,23 +375,6 @@ public class KafkaTopicClientImplTest {
     verify(adminClient);
   }
 
-  @Test
-  public void shouldCloseAdminClient() {
-    // Given:
-    adminClient.close();
-    expectLastCall();
-
-    replay(adminClient);
-
-    final KafkaTopicClient kafkaTopicClient = new KafkaTopicClientImpl(adminClient);
-
-    // When:
-    kafkaTopicClient.close();
-
-    // Then:
-    verify(adminClient);
-  }
-
   @SuppressWarnings("unchecked")
   private static DescribeTopicsResult describeTopicReturningUnknownPartitionException() {
     final DescribeTopicsResult describeTopicsResult = niceMock(DescribeTopicsResult.class);

--- a/ksql-rest-app/src/main/java/io/confluent/ksql/rest/server/KsqlRestApplication.java
+++ b/ksql-rest-app/src/main/java/io/confluent/ksql/rest/server/KsqlRestApplication.java
@@ -281,7 +281,7 @@ public final class KsqlRestApplication extends Application<KsqlRestConfig> imple
 
     final KsqlConfig ksqlConfig = new KsqlConfig(restConfig.getKsqlConfigProperties());
 
-    final KsqlEngine ksqlEngine = new KsqlEngine(ksqlConfig);
+    final KsqlEngine ksqlEngine = KsqlEngine.create(ksqlConfig);
     final KafkaTopicClient topicClient = ksqlEngine.getTopicClient();
     UdfLoader.newInstance(ksqlConfig, ksqlEngine.getMetaStore(), ksqlInstallDir).load();
 

--- a/ksql-rest-app/src/main/java/io/confluent/ksql/rest/server/StandaloneExecutor.java
+++ b/ksql-rest-app/src/main/java/io/confluent/ksql/rest/server/StandaloneExecutor.java
@@ -89,7 +89,7 @@ public class StandaloneExecutor implements Executable {
                                           final String queriesFile,
                                           final String installDir) {
     final KsqlConfig ksqlConfig = new KsqlConfig(properties);
-    final KsqlEngine ksqlEngine = new KsqlEngine(ksqlConfig);
+    final KsqlEngine ksqlEngine = KsqlEngine.create(ksqlConfig);
     final UdfLoader udfLoader = UdfLoader.newInstance(ksqlConfig,
         ksqlEngine.getMetaStore(),
         installDir);

--- a/ksql-rest-app/src/main/java/io/confluent/ksql/rest/server/resources/KsqlResource.java
+++ b/ksql-rest-app/src/main/java/io/confluent/ksql/rest/server/resources/KsqlResource.java
@@ -340,16 +340,15 @@ public class KsqlResource {
 
   private KafkaTopicsList listTopics(final String statementText) {
     final KafkaTopicClient client = ksqlEngine.getTopicClient();
-    try (KafkaConsumerGroupClient kafkaConsumerGroupClient
-             = new KafkaConsumerGroupClientImpl(ksqlConfig)) {
-      return KafkaTopicsList.build(
-          statementText,
-          getKsqlTopics(),
-          client.describeTopics(client.listNonInternalTopicNames()),
-          ksqlConfig,
-          kafkaConsumerGroupClient
-      );
-    }
+    final KafkaConsumerGroupClient kafkaConsumerGroupClient
+        = new KafkaConsumerGroupClientImpl(ksqlEngine.getAdminClient());
+    return KafkaTopicsList.build(
+        statementText,
+        getKsqlTopics(),
+        client.describeTopics(client.listNonInternalTopicNames()),
+        ksqlConfig,
+        kafkaConsumerGroupClient
+    );
   }
 
   private Collection<KsqlTopic> getKsqlTopics() {

--- a/ksql-rest-app/src/test/java/io/confluent/ksql/rest/entity/KafkaTopicsListTest.java
+++ b/ksql-rest-app/src/test/java/io/confluent/ksql/rest/entity/KafkaTopicsListTest.java
@@ -44,8 +44,9 @@ public class KafkaTopicsListTest {
     final TopicPartition topicPartition = new TopicPartition("test-topic", 1);
     final KafkaConsumerGroupClientImpl.ConsumerSummary consumerSummary = new KafkaConsumerGroupClientImpl.ConsumerSummary("consumer-id");
     consumerSummary.addPartition(topicPartition);
-    final KafkaConsumerGroupClientImpl.ConsumerGroupSummary consumerGroupSummary = new KafkaConsumerGroupClientImpl.ConsumerGroupSummary();
-    consumerGroupSummary.addConsumerSummary(consumerSummary);
+    final KafkaConsumerGroupClientImpl.ConsumerGroupSummary consumerGroupSummary
+        = new KafkaConsumerGroupClientImpl.ConsumerGroupSummary(Collections.singleton(consumerSummary));
+
 
 
 

--- a/ksql-rest-app/src/test/java/io/confluent/ksql/rest/server/mock/MockKafkaTopicClient.java
+++ b/ksql-rest-app/src/test/java/io/confluent/ksql/rest/server/mock/MockKafkaTopicClient.java
@@ -80,8 +80,4 @@ public class MockKafkaTopicClient implements KafkaTopicClient {
   @Override
   public void deleteInternalTopics(final String applicationId) {
   }
-
-  @Override
-  public void close() {
-  }
 }


### PR DESCRIPTION
### Description 
Changed the KafkaConsumerGroupClientImpl to use the new AdminClient.
Other updates to KSLQEngine and KafkaTopicClient so that we share the admin client

Fixes #642 

### Testing done 
Run existing tests

### Reviewer checklist
- [ ] Ensure docs are updated if necessary. (eg. if a user visible feature is being added or changed).
- [ ] Ensure relevant issues are linked (description should include text like "Fixes #<issue number>")

