### PR TITLE
Harden allowed SELECT syntax

### DIFF
--- a/ksql-parser/src/main/antlr4/io/confluent/ksql/parser/SqlBase.g4
+++ b/ksql-parser/src/main/antlr4/io/confluent/ksql/parser/SqlBase.g4
@@ -106,9 +106,9 @@ queryPrimary
     ;
 
 querySpecification
-    : SELECT STREAM? selectItem (',' selectItem)*
+    : SELECT selectItem (',' selectItem)*
       (INTO into=relationPrimary)?
-      (FROM from=relation (',' relation)*)?
+      FROM from=relation
       (WINDOW  windowExpression)?
       (WHERE where=booleanExpression)?
       (GROUP BY groupBy)?


### PR DESCRIPTION
### Description 
Fix for #1425

Harden syntax to:
- _Not_ have optional stream name as the first entry in a select statement.
- _Require_ a `FROM` statement, rather than it being optional, but resulting in NPE if missing.
- _Not_ having supporting multiple sources in the `FROM` statement.

### Testing done 
Manual tested.  

Output from the statement in issue #1425, which is an invalid statement, is now a much more helpful message, rather than an NPE:

```
ksql> select message\
from ratings;
line 1:27: mismatched input ';' expecting {',', 'FROM', 'INTO'}
Caused by: org.antlr.v4.runtime.InputMismatchException
```

### Reviewer checklist
- [ ] Ensure docs are updated if necessary. (eg. if a user visible feature is being added or changed).
- [ ] Ensure relevant issues are linked (description should include text like "Fixes #<issue number>")

