### PR TITLE
Minor: fix issue with parsing SQL files with trailing white space.

### DIFF
--- a/ksql-cli/src/main/java/io/confluent/ksql/cli/Cli.java
+++ b/ksql-cli/src/main/java/io/confluent/ksql/cli/Cli.java
@@ -212,19 +212,23 @@ public class Cli implements Closeable, AutoCloseable {
     }
   }
 
+  @SuppressWarnings("RedundantStringOperation") // Incorrect warning. Operation is not redundant
   private List<String> getLogicalLines(final String input) {
     // TODO: Convert the input string into an InputStream, then feed it to the terminal via
     // TerminalBuilder.streams(InputStream, OutputStream)
     final List<String> result = new ArrayList<>();
     StringBuilder logicalLine = new StringBuilder();
     for (final String physicalLine : input.split("\n")) {
-      if (!physicalLine.trim().isEmpty()) {
-        if (physicalLine.endsWith("\\")) {
-          logicalLine.append(physicalLine.substring(0, physicalLine.length() - 1));
-        } else {
-          result.add(logicalLine.append(physicalLine).toString().trim());
-          logicalLine = new StringBuilder();
-        }
+      final String trimmed = physicalLine.trim();
+      if (trimmed.isEmpty()) {
+        continue;
+      }
+
+      if (trimmed.endsWith("\\")) {
+        logicalLine.append(trimmed.substring(0, trimmed.length() - 1));
+      } else {
+        result.add(logicalLine.append(trimmed).toString().trim());
+        logicalLine = new StringBuilder();
       }
     }
     return result;

--- a/ksql-cli/src/main/java/io/confluent/ksql/cli/Cli.java
+++ b/ksql-cli/src/main/java/io/confluent/ksql/cli/Cli.java
@@ -52,6 +52,7 @@ import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Paths;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.List;
 import java.util.Objects;
 import java.util.Optional;
@@ -214,23 +215,21 @@ public class Cli implements Closeable, AutoCloseable {
 
   @SuppressWarnings("RedundantStringOperation") // Incorrect warning. Operation is not redundant
   private List<String> getLogicalLines(final String input) {
-    // TODO: Convert the input string into an InputStream, then feed it to the terminal via
-    // TerminalBuilder.streams(InputStream, OutputStream)
     final List<String> result = new ArrayList<>();
-    StringBuilder logicalLine = new StringBuilder();
-    for (final String physicalLine : input.split("\n")) {
-      final String trimmed = physicalLine.trim();
-      if (trimmed.isEmpty()) {
-        continue;
-      }
+    final StringBuilder logicalLine = new StringBuilder();
 
-      if (trimmed.endsWith("\\")) {
-        logicalLine.append(trimmed.substring(0, trimmed.length() - 1));
-      } else {
-        result.add(logicalLine.append(trimmed).toString().trim());
-        logicalLine = new StringBuilder();
-      }
-    }
+    Arrays.stream(input.split("\n"))
+        .map(String::trim)
+        .filter(line -> !line.isEmpty())
+        .forEach(physicalLine -> {
+          if (physicalLine.endsWith("\\")) {
+            logicalLine.append(physicalLine.substring(0, physicalLine.length() - 1));
+          } else {
+            result.add(logicalLine.append(physicalLine).toString().trim());
+            logicalLine.setLength(0);
+          }
+        });
+
     return result;
   }
 

--- a/ksql-cli/src/test/java/io/confluent/ksql/CliTest.java
+++ b/ksql-cli/src/test/java/io/confluent/ksql/CliTest.java
@@ -462,6 +462,12 @@ public class CliTest {
   }
 
   @Test
+  public void testCommandsOverMultipleLines() throws Exception {
+    localCli.runNonInteractively("he\\\nlp");
+    localCli.runNonInteractively("he\\ \nlp");
+  }
+
+  @Test
   public void shouldHandleRegisterTopic() throws Exception {
     localCli.handleLine("REGISTER TOPIC foo WITH (value_format = 'csv', kafka_topic='foo');");
   }


### PR DESCRIPTION
### Description 

Fixes #1846

fix issue with parsing SQL files where there is trailing white space after command continuation character '\'.

### Testing done 
Added test + manual

### Reviewer checklist
- [ ] Ensure docs are updated if necessary. (eg. if a user visible feature is being added or changed).
- [ ] Ensure relevant issues are linked (description should include text like "Fixes #<issue number>")

