### PR TITLE
EmbeddedSingleNodeKafkaCluster to support additional Jaas Config

### DIFF
--- a/ksql-cli/src/test/java/io/confluent/ksql/CliTest.java
+++ b/ksql-cli/src/test/java/io/confluent/ksql/CliTest.java
@@ -84,7 +84,7 @@ import org.junit.rules.RuleChain;
 @Ignore
 public class CliTest {
 
-  private static final EmbeddedSingleNodeKafkaCluster CLUSTER = new EmbeddedSingleNodeKafkaCluster();
+  private static final EmbeddedSingleNodeKafkaCluster CLUSTER = EmbeddedSingleNodeKafkaCluster.build();
 
   private static final TestKsqlRestApp REST_APP = TestKsqlRestApp
       .builder(CLUSTER::bootstrapServers)

--- a/ksql-engine/src/test/java/io/confluent/ksql/integration/IntegrationTestHarness.java
+++ b/ksql-engine/src/test/java/io/confluent/ksql/integration/IntegrationTestHarness.java
@@ -340,7 +340,7 @@ public class IntegrationTestHarness {
 
 
   public void start(final Map<String, Object> callerConfigMap) throws Exception {
-    embeddedKafkaCluster = new EmbeddedSingleNodeKafkaCluster();
+    embeddedKafkaCluster = EmbeddedSingleNodeKafkaCluster.build();
     embeddedKafkaCluster.start();
     final Map<String, Object> configMap = new HashMap<>();
 

--- a/ksql-engine/src/test/java/io/confluent/ksql/integration/JsonFormatTest.java
+++ b/ksql-engine/src/test/java/io/confluent/ksql/integration/JsonFormatTest.java
@@ -60,7 +60,7 @@ public class JsonFormatTest {
   private static final String messageLogStream = "message_log";
 
   @ClassRule
-  public static final EmbeddedSingleNodeKafkaCluster CLUSTER = new EmbeddedSingleNodeKafkaCluster();
+  public static final EmbeddedSingleNodeKafkaCluster CLUSTER = EmbeddedSingleNodeKafkaCluster.build();
 
   private MetaStore metaStore;
   private KsqlConfig ksqlConfig;

--- a/ksql-rest-app/src/test/java/io/confluent/ksql/rest/server/computation/StatementExecutorTest.java
+++ b/ksql-rest-app/src/test/java/io/confluent/ksql/rest/server/computation/StatementExecutorTest.java
@@ -82,7 +82,7 @@ public class StatementExecutorTest extends EasyMockSupport {
   }
 
   @ClassRule
-  public static final EmbeddedSingleNodeKafkaCluster CLUSTER = new EmbeddedSingleNodeKafkaCluster();
+  public static final EmbeddedSingleNodeKafkaCluster CLUSTER = EmbeddedSingleNodeKafkaCluster.build();
 
   @Test
   public void shouldHandleCorrectDDLStatement() {

--- a/ksql-rest-app/src/test/java/io/confluent/ksql/test/util/TestKsqlRestApp.java
+++ b/ksql-rest-app/src/test/java/io/confluent/ksql/test/util/TestKsqlRestApp.java
@@ -20,6 +20,7 @@ import io.confluent.ksql.rest.server.KsqlRestApplication;
 import io.confluent.ksql.rest.server.KsqlRestConfig;
 import io.confluent.ksql.util.KsqlConfig;
 import io.confluent.ksql.version.metrics.VersionCheckerAgent;
+import io.confluent.ksql.version.metrics.collector.KsqlModuleType;
 import java.net.URL;
 import java.util.ArrayList;
 import java.util.Collections;
@@ -27,9 +28,9 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
+import java.util.Properties;
 import java.util.function.Supplier;
 import org.apache.kafka.clients.consumer.ConsumerConfig;
-import org.easymock.EasyMock;
 import org.junit.rules.ExternalResource;
 
 /**
@@ -89,8 +90,9 @@ public class TestKsqlRestApp extends ExternalResource {
     }
 
     try {
-      restServer = KsqlRestApplication.buildApplication(buildConfig(),
-          EasyMock.mock(VersionCheckerAgent.class)
+      restServer = KsqlRestApplication.buildApplication(
+          buildConfig(),
+          new NoOpVersionCheckerAgent()
       );
     } catch (final Exception e) {
       throw new RuntimeException("Failed to initialise", e);
@@ -164,6 +166,12 @@ public class TestKsqlRestApp extends ExternalResource {
 
     public TestKsqlRestApp build() {
       return new TestKsqlRestApp(bootstrapServers, additionalProps);
+    }
+  }
+
+  private static class NoOpVersionCheckerAgent implements VersionCheckerAgent {
+    @Override
+    public void start(final KsqlModuleType moduleType, final Properties ksqlProperties) {
     }
   }
 }


### PR DESCRIPTION
### Description 
Enhanced `EmbeddedSingleNodeKafkaCluster` to allow others to inject additional Jaas Config. (Required by other places this is used), and made it so the config can be changed between tests.

Plus, as this class is now exposed to other projects... also hide the constructor and forced used of builder, as this gives us move control.

Also, removed some unnecessary dependencies from `TestKsqlRestApp`.

### Testing done 
Test only change.

### Reviewer checklist
- [ ] Ensure docs are updated if necessary. (eg. if a user visible feature is being added or changed).
- [ ] Ensure relevant issues are linked (description should include text like "Fixes #<issue number>")

