### PR TITLE
Fix leaked admin client

### DIFF
--- a/ksql-engine/src/main/java/io/confluent/ksql/KsqlContext.java
+++ b/ksql-engine/src/main/java/io/confluent/ksql/KsqlContext.java
@@ -78,7 +78,8 @@ public class KsqlContext {
         schemaRegistryClientFactory,
         clientSupplier,
         metaStore,
-        ksqlConfig
+        ksqlConfig,
+        adminClient
     );
 
     return new KsqlContext(ksqlConfig, engine);


### PR DESCRIPTION
### Description 
Fixed a leak where an admin client is not closed.

This was spamming the logs of tests a lot with lines lines:

```
[2018-09-12 16:28:50,033] WARN [AdminClient clientId=adminclient-8] Connection to node 0 could not be established. Broker may not be available. (org.apache.kafka.clients.NetworkClient:671)
[2018-09-12 16:28:50,534] WARN [AdminClient clientId=adminclient-5] Connection to node 0 could not be established. Broker may not be available. (org.apache.kafka.clients.NetworkClient:671)
[2018-09-12 16:28:50,965] WARN [AdminClient clientId=adminclient-8] Connection to node 0 could not be established. Broker may not be available. (org.apache.kafka.clients.NetworkClient:671)
[2018-09-12 16:28:51,573] WARN [AdminClient clientId=adminclient-5] Connection to node 0 could not be established. Broker may not be available. (org.apache.kafka.clients.NetworkClient:671)
[2018-09-12 16:28:51,904] WARN [AdminClient clientId=adminclient-8] Connection to node 0 could not be established. Broker may not be available. (org.apache.kafka.clients.NetworkClient:671)
[2018-09-12 16:28:52,510] WARN [AdminClient clientId=adminclient-5] Connection to node 0 could not be established. Broker may not be available. (org.apache.kafka.clients.NetworkClient:671)
[2018-09-12 16:28:52,943] WARN [AdminClient clientId=adminclient-8] Connection to node 0 could not be established. Broker may not be available. (org.apache.kafka.clients.NetworkClient:671)
[2018-09-12 16:28:53,447] WARN [AdminClient clientId=adminclient-5] Connection to node 0 could not be established. Broker may not be available. (org.apache.kafka.clients.NetworkClient:671)
```

### Testing done 
usual

### Reviewer checklist
- [ ] Ensure docs are updated if necessary. (eg. if a user visible feature is being added or changed).
- [ ] Ensure relevant issues are linked (description should include text like "Fixes #<issue number>")

