### PR TITLE
Checkstyle comments come in pairs.

### DIFF
--- a/ksql-engine/src/main/java/io/confluent/ksql/ddl/commands/CommandFactories.java
+++ b/ksql-engine/src/main/java/io/confluent/ksql/ddl/commands/CommandFactories.java
@@ -34,6 +34,8 @@ import java.util.Map;
 
 // CHECKSTYLE_RULES.OFF: ClassDataAbstractionCoupling
 public class CommandFactories implements DdlCommandFactory {
+  // CHECKSTYLE_RULES.ON: ClassDataAbstractionCoupling
+
   private final Map<Class<? extends DdlStatement>, DdlCommandFactory> factories = new HashMap<>();
 
   public CommandFactories(


### PR DESCRIPTION
### Description 
Checkstyle should comments come in pairs.

If you disable a rule with a comment, but then don't add another comment to turn it back on, then it will be disabled for the rest of the file.  While this is't a problem in this case, I think it is _safer_ to always pair up the comments as this makes it less likely someone will cut & paste the single comment somewhere where it _does_ matter that its not being closed.

Another alternative to suppression comments, which I've just found, is to use annotations. I think this is probably a better approach than comments as its auto-closing, e.g.

```
@SuppressWarnings("checkstyle:methodlength")
public void someLongMethod() throws Exception {
}
```

Scratch that, the IDE plugins don't like suppression filters :(



### Testing done 
none - I'm living dangerously

### Reviewer checklist
- [ ] Ensure docs are updated if necessary. (eg. if a user visible feature is being added or changed).
- [ ] Ensure relevant issues are linked (description should include text like "Fixes #<issue number>")

