### PR TITLE
Stop printing the topic output promptly

### DIFF
--- a/ksql-cli/src/main/java/io/confluent/ksql/cli/Cli.java
+++ b/ksql-cli/src/main/java/io/confluent/ksql/cli/Cli.java
@@ -439,7 +439,7 @@ public class Cli implements Closeable, AutoCloseable {
           StandardCharsets.UTF_8.name()
       )) {
         final Future<?> topicPrintFuture = queryStreamExecutorService.submit(() -> {
-          while (topicStreamScanner.hasNextLine()) {
+          while (topicStreamScanner.hasNextLine() && !Thread.isInterrupted()) {
             final String line = topicStreamScanner.nextLine();
             if (!line.isEmpty()) {
               terminal.writer().println(line);

--- a/ksql-cli/src/main/java/io/confluent/ksql/cli/Cli.java
+++ b/ksql-cli/src/main/java/io/confluent/ksql/cli/Cli.java
@@ -439,7 +439,7 @@ public class Cli implements Closeable, AutoCloseable {
           StandardCharsets.UTF_8.name()
       )) {
         final Future<?> topicPrintFuture = queryStreamExecutorService.submit(() -> {
-          while (topicStreamScanner.hasNextLine() && !Thread.isInterrupted()) {
+          while (!Thread.currentThread().isInterrupted() && topicStreamScanner.hasNextLine()) {
             final String line = topicStreamScanner.nextLine();
             if (!line.isEmpty()) {
               terminal.writer().println(line);


### PR DESCRIPTION
### Description 
Change the console print command so that it responds to ctrl-c in a timely fashion
Fixes: #1759

### Testing done 
Manual testing - loaded up topic and continuous production. Ensured that printing exits almost immediately.

### Reviewer checklist
- [ ] Ensure docs are updated if necessary. (eg. if a user visible feature is being added or changed).
- [ ] Ensure relevant issues are linked (description should include text like "Fixes #<issue number>")