### PR TITLE
Handle null in sum aggregates

### DIFF
--- a/ksql-engine/src/main/java/io/confluent/ksql/function/udaf/sum/DoubleSumKudaf.java
+++ b/ksql-engine/src/main/java/io/confluent/ksql/function/udaf/sum/DoubleSumKudaf.java
@@ -37,6 +37,9 @@ public class DoubleSumKudaf
 
   @Override
   public Double aggregate(final Double currentValue, final Double aggregateValue) {
+    if (currentValue == null) {
+      return aggregateValue;
+    }
     return currentValue + aggregateValue;
   }
 

--- a/ksql-engine/src/main/java/io/confluent/ksql/function/udaf/sum/LongSumKudaf.java
+++ b/ksql-engine/src/main/java/io/confluent/ksql/function/udaf/sum/LongSumKudaf.java
@@ -35,6 +35,9 @@ public class LongSumKudaf
 
   @Override
   public Long aggregate(final Long currentValue, final Long aggregateValue) {
+    if (currentValue == null) {
+      return aggregateValue;
+    }
     return currentValue + aggregateValue;
   }
 

--- a/ksql-engine/src/test/java/io/confluent/ksql/function/udaf/sum/DoubleSumKudafTest.java
+++ b/ksql-engine/src/test/java/io/confluent/ksql/function/udaf/sum/DoubleSumKudafTest.java
@@ -8,7 +8,7 @@ import java.util.Collections;
 import org.apache.kafka.connect.data.Schema;
 
 public class DoubleSumKudafTest extends BaseSumKudafTest<Double, DoubleSumKudaf> {
-  protected TGenerator<Double> getTGenerator() {
+  protected TGenerator<Double> getNumberGenerator() {
     return Double::valueOf;
   }
 

--- a/ksql-engine/src/test/java/io/confluent/ksql/function/udaf/sum/IntegerSumKudafTest.java
+++ b/ksql-engine/src/test/java/io/confluent/ksql/function/udaf/sum/IntegerSumKudafTest.java
@@ -9,7 +9,7 @@ import java.util.Collections;
 import org.apache.kafka.connect.data.Schema;
 
 public class IntegerSumKudafTest extends BaseSumKudafTest<Integer, IntegerSumKudaf>{
-  protected TGenerator<Integer> getTGenerator() {
+  protected TGenerator<Integer> getNumberGenerator() {
     return Integer::valueOf;
   }
 

--- a/ksql-engine/src/test/java/io/confluent/ksql/function/udaf/sum/LongSumKudafTest.java
+++ b/ksql-engine/src/test/java/io/confluent/ksql/function/udaf/sum/LongSumKudafTest.java
@@ -8,7 +8,7 @@ import java.util.Collections;
 import org.apache.kafka.connect.data.Schema;
 
 public class LongSumKudafTest extends BaseSumKudafTest<Long, LongSumKudaf> {
-  protected TGenerator<Long> getTGenerator() {
+  protected TGenerator<Long> getNumberGenerator() {
     return Long::valueOf;
   }
 


### PR DESCRIPTION
### Description 
Fix NPE in Long and Double Sum aggregators when a null value is encountered. Rather than throwing an NPE just return the existing aggregate.

Fixes: #1892

### Testing done 
Added unit test to ensure all sum aggregators handle null

### Reviewer checklist
- [ ] Ensure docs are updated if necessary. (eg. if a user visible feature is being added or changed).
- [ ] Ensure relevant issues are linked (description should include text like "Fixes #<issue number>")
