### PR TITLE
Fix the regression for literal aggregate argument.

### DIFF
--- a/ksql-engine/src/main/java/io/confluent/ksql/analyzer/AggregateAnalyzer.java
+++ b/ksql-engine/src/main/java/io/confluent/ksql/analyzer/AggregateAnalyzer.java
@@ -68,7 +68,8 @@ public class AggregateAnalyzer extends DefaultTraversalVisitor<Node, AnalysisCon
         aggregateAnalysis.addAggregateFunctionArgument(argExpression);
         node.getArguments().add(argExpression);
       } else {
-        aggregateAnalysis.addAggregateFunctionArgument(node.getArguments().get(0));
+        node.getArguments().forEach(argExpression ->
+            aggregateAnalysis.addAggregateFunctionArgument(argExpression));
       }
       aggregateAnalysis.addFunction(node);
       hasAggregateFunction = true;

--- a/ksql-engine/src/main/java/io/confluent/ksql/planner/plan/AggregateNode.java
+++ b/ksql-engine/src/main/java/io/confluent/ksql/planner/plan/AggregateNode.java
@@ -43,6 +43,7 @@ import io.confluent.ksql.util.KsqlException;
 import io.confluent.ksql.util.Pair;
 import io.confluent.ksql.util.SchemaUtil;
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -58,7 +59,7 @@ import org.apache.kafka.streams.StreamsBuilder;
 
 public class AggregateNode extends PlanNode {
 
-  static final String INTERNAL_COLUMN_NAME_PREFIX = "KSQL_INTERNAL_COL_";
+  private static final String INTERNAL_COLUMN_NAME_PREFIX = "KSQL_INTERNAL_COL_";
 
   private final PlanNode source;
   private final Schema schema;
@@ -143,10 +144,10 @@ public class AggregateNode extends PlanNode {
     if (finalSelectExpressions.size() != schema.fields().size()) {
       throw new RuntimeException(
           "Incompatible aggregate schema, field count must match, "
-          + "selected field count:"
-          + finalSelectExpressions.size()
-          + " schema field count:"
-          + schema.fields().size());
+              + "selected field count:"
+              + finalSelectExpressions.size()
+              + " schema field count:"
+              + schema.fields().size());
     }
     for (int i = 0; i < finalSelectExpressions.size(); i++) {
       finalSelectExpressionList.add(new Pair<>(
@@ -166,6 +167,7 @@ public class AggregateNode extends PlanNode {
     return visitor.visitAggregate(this, context);
   }
 
+  @SuppressWarnings("unchecked") // needs investigating
   @Override
   public SchemaKStream buildStream(
       final StreamsBuilder builder,
@@ -187,7 +189,7 @@ public class AggregateNode extends PlanNode {
 
     // Pre aggregate computations
     final InternalSchema internalSchema = new InternalSchema(getRequiredColumnList(),
-                                                       getAggregateFunctionArguments());
+        getAggregateFunctionArguments());
 
     final SchemaKStream aggregateArgExpanded =
         sourceSchemaKStream.select(internalSchema.getAggArgExpansionList());
@@ -306,7 +308,7 @@ public class AggregateNode extends PlanNode {
         initializer.addAggregateIntializer(aggregateFunction.getInitialValueSupplier());
 
         aggregateSchema.field("AGG_COL_"
-                              + udafIndexInAggSchema, aggregateFunction.getReturnType());
+            + udafIndexInAggSchema, aggregateFunction.getReturnType());
       }
       return aggValToAggFunctionMap;
     } catch (final Exception e) {
@@ -321,12 +323,12 @@ public class AggregateNode extends PlanNode {
   }
 
   private KsqlAggregateFunction getAggregateFunction(final FunctionRegistry functionRegistry,
-                                                     final InternalSchema internalSchema,
-                                                     final FunctionCall functionCall,
-                                                     final Schema schema) {
+      final InternalSchema internalSchema,
+      final FunctionCall functionCall,
+      final Schema schema) {
     final ExpressionTypeManager expressionTypeManager =
         new ExpressionTypeManager(schema, functionRegistry);
-    final List<Expression> functionArgs = internalSchema.getInternalExpressionList(
+    final List<Expression> functionArgs = internalSchema.getInternalArgsExpressionList(
         functionCall.getArguments());
     final Schema expressionType = expressionTypeManager.getExpressionSchema(functionArgs.get(0));
     final KsqlAggregateFunction aggregateFunctionInfo = functionRegistry
@@ -348,7 +350,7 @@ public class AggregateNode extends PlanNode {
       schemaBuilder.field(fields.get(i).name(), fields.get(i).schema());
     }
     for (int aggFunctionVarSuffix = 0;
-         aggFunctionVarSuffix < getFunctionList().size(); aggFunctionVarSuffix++) {
+        aggFunctionVarSuffix < getFunctionList().size(); aggFunctionVarSuffix++) {
       final KsqlAggregateFunction aggregateFunction = getAggregateFunction(
           functionRegistry,
           internalSchema,
@@ -356,7 +358,7 @@ public class AggregateNode extends PlanNode {
           schema);
       schemaBuilder.field(
           AggregateExpressionRewriter.AGGREGATE_FUNCTION_VARIABLE_PREFIX
-          + aggFunctionVarSuffix,
+              + aggFunctionVarSuffix,
           aggregateFunction.getReturnType()
       );
     }
@@ -364,7 +366,7 @@ public class AggregateNode extends PlanNode {
     return schemaBuilder.build();
   }
 
-  class InternalSchema {
+  private static class InternalSchema {
     private final List<Pair<String, Expression>> aggArgExpansionList = new ArrayList<>();
     private final Map<String, Integer> internalNameToIndexMap = new HashMap<>();
     private final Map<String, String> expressionToInternalColumnNameMap = new HashMap<>();
@@ -393,29 +395,57 @@ public class AggregateNode extends PlanNode {
           });
     }
 
-    List<Expression> getInternalExpressionList(final List<Expression> expressionList) {
-      return expressionList.stream()
-          .map(argExpression -> argExpression instanceof Literal
-                                ? argExpression
-                                : new QualifiedNameReference(
-                                    QualifiedName.of(getExpressionToInternalColumnNameMap()
-                                            .get(argExpression.toString()))))
+    List<Expression> getInternalExpressionList(final List<Expression> argExpressionList) {
+      return argExpressionList.stream()
+          .map(argExpression -> new QualifiedNameReference(
+              QualifiedName.of(getExpressionToInternalColumnNameMap()
+                  .get(argExpression.toString()))))
           .collect(Collectors.toList());
+    }
+
+    /**
+     * Return the aggregate function arguments based on the internal expressions.
+     * Currently we support aggregate functions with at most two arguments where
+     * the second argument should be a literal.
+     * @param argExpressionList The list of parameters for the aggregate fuunction.
+     * @return The list of arguments based on the internal expressions for the aggregate function.
+     */
+    List<Expression> getInternalArgsExpressionList(final List<Expression> argExpressionList) {
+      // Currently we only support aggregations on one column only
+      if (argExpressionList.size() > 2) {
+        throw new KsqlException("Currently, KSQL UDAFs can only have two arguments.");
+      }
+      final List<Expression> internalExpressionList = new ArrayList<>();
+      if (argExpressionList.isEmpty()) {
+        return Collections.emptyList();
+      }
+      internalExpressionList.add(new QualifiedNameReference(
+          QualifiedName.of(getExpressionToInternalColumnNameMap()
+              .get(argExpressionList.get(0).toString())
+          )));
+      if (argExpressionList.size() == 2) {
+        if (! (argExpressionList.get(1) instanceof Literal)) {
+          throw new KsqlException("Currently, second argument in UDAF should be literal.");
+        }
+        internalExpressionList.add(argExpressionList.get(1));
+      }
+      return internalExpressionList;
+
     }
 
     List<Pair<String, Expression>> updateFinalSelectExpressions(
         final List<Pair<String, Expression>> finalSelectExpressions) {
       return finalSelectExpressions.stream()
           .map(finalSelectExpression ->
-                   expressionToInternalColumnNameMap
-                       .containsKey(finalSelectExpression.getRight().toString())
-                   ? new Pair<>(finalSelectExpression.getLeft(),
-                                (Expression)
-                                    new QualifiedNameReference(
-                                        QualifiedName.of(
-                                            expressionToInternalColumnNameMap
-                                                .get(finalSelectExpression.getRight().toString()))))
-                   : new Pair<>(finalSelectExpression.getLeft(), finalSelectExpression.getRight()))
+              expressionToInternalColumnNameMap
+                  .containsKey(finalSelectExpression.getRight().toString())
+                  ? new Pair<>(finalSelectExpression.getLeft(),
+                  (Expression)
+                      new QualifiedNameReference(
+                          QualifiedName.of(
+                              expressionToInternalColumnNameMap
+                                  .get(finalSelectExpression.getRight().toString()))))
+                  : new Pair<>(finalSelectExpression.getLeft(), finalSelectExpression.getRight()))
           .collect(Collectors.toList());
     }
 

--- a/ksql-engine/src/test/resources/query-validation-tests/sum.json
+++ b/ksql-engine/src/test/resources/query-validation-tests/sum.json
@@ -85,6 +85,69 @@
         {"topic": "S2", "key": 0, "value": {"ID":0,"SUM_VAL":40.0}, "timestamp": 0},
         {"topic": "S2", "key": 0, "value": {"ID":0,"SUM_VAL":50.0}, "timestamp": 0}
       ]
+    },
+    {
+      "name": "sum with constant int arg",
+      "statements": [
+        "CREATE STREAM TEST (ID bigint, NAME varchar, VALUE map<varchar, double>) WITH (kafka_topic='test_topic', value_format='JSON', key='ID');",
+        "CREATE TABLE S2 as SELECT id, sum(2) AS sum_val FROM test group by id;"
+      ],
+      "inputs": [
+        {"topic": "test_topic", "key": 0, "value": {"id": 0, "name": "zero","value":{"key1":10.0, "key2":1.0}}, "timestamp": 0},
+        {"topic": "test_topic", "key": 0, "value": {"id": 0, "name": "zero", "value": {"key1":10.0, "key2":1.0}}, "timestamp": 0},
+        {"topic": "test_topic", "key": 0, "value": {"id": 0, "name": "zero", "value": {"key1":10.0, "key2":1.0}}, "timestamp": 0},
+        {"topic": "test_topic", "key": 0, "value": {"id": 0, "name": "zero", "value": {"key1":10.0, "key2":1.0}}, "timestamp": 0},
+        {"topic": "test_topic", "key": 0, "value": {"id": 0, "name": "zero", "value": {"key1":10.0, "key2":1.0}}, "timestamp": 0}
+      ],
+      "outputs": [
+        {"topic": "S2", "key": 0, "value": {"ID":0,"SUM_VAL":2}, "timestamp": 0},
+        {"topic": "S2", "key": 0, "value": {"ID":0,"SUM_VAL":4}, "timestamp": 0},
+        {"topic": "S2", "key": 0, "value": {"ID":0,"SUM_VAL":6}, "timestamp": 0},
+        {"topic": "S2", "key": 0, "value": {"ID":0,"SUM_VAL":8}, "timestamp": 0},
+        {"topic": "S2", "key": 0, "value": {"ID":0,"SUM_VAL":10}, "timestamp": 0}
+      ]
+    },
+    {
+      "name": "sum with constant long arg",
+      "statements": [
+        "CREATE STREAM TEST (ID bigint, NAME varchar, VALUE map<varchar, double>) WITH (kafka_topic='test_topic', value_format='JSON', key='ID');",
+        "CREATE TABLE S2 as SELECT id, sum(cast (2 as BIGINT)) AS sum_val FROM test group by id;"
+      ],
+      "inputs": [
+        {"topic": "test_topic", "key": 0, "value": {"id": 0, "name": "zero","value":{"key1":10.0, "key2":1.0}}, "timestamp": 0},
+        {"topic": "test_topic", "key": 0, "value": {"id": 0, "name": "zero", "value": {"key1":10.0, "key2":1.0}}, "timestamp": 0},
+        {"topic": "test_topic", "key": 0, "value": {"id": 0, "name": "zero", "value": {"key1":10.0, "key2":1.0}}, "timestamp": 0},
+        {"topic": "test_topic", "key": 0, "value": {"id": 0, "name": "zero", "value": {"key1":10.0, "key2":1.0}}, "timestamp": 0},
+        {"topic": "test_topic", "key": 0, "value": {"id": 0, "name": "zero", "value": {"key1":10.0, "key2":1.0}}, "timestamp": 0}
+      ],
+      "outputs": [
+        {"topic": "S2", "key": 0, "value": {"ID":0,"SUM_VAL":2}, "timestamp": 0},
+        {"topic": "S2", "key": 0, "value": {"ID":0,"SUM_VAL":4}, "timestamp": 0},
+        {"topic": "S2", "key": 0, "value": {"ID":0,"SUM_VAL":6}, "timestamp": 0},
+        {"topic": "S2", "key": 0, "value": {"ID":0,"SUM_VAL":8}, "timestamp": 0},
+        {"topic": "S2", "key": 0, "value": {"ID":0,"SUM_VAL":10}, "timestamp": 0}
+      ]
+    },
+    {
+      "name": "sum with constant double arg",
+      "statements": [
+        "CREATE STREAM TEST (ID bigint, NAME varchar, VALUE map<varchar, double>) WITH (kafka_topic='test_topic', value_format='JSON', key='ID');",
+        "CREATE TABLE S2 as SELECT id, sum(1.0) AS sum_val FROM test group by id;"
+      ],
+      "inputs": [
+        {"topic": "test_topic", "key": 0, "value": {"id": 0, "name": "zero","value":{"key1":10.0, "key2":1.0}}, "timestamp": 0},
+        {"topic": "test_topic", "key": 0, "value": {"id": 0, "name": "zero", "value": {"key1":10.0, "key2":1.0}}, "timestamp": 0},
+        {"topic": "test_topic", "key": 0, "value": {"id": 0, "name": "zero", "value": {"key1":10.0, "key2":1.0}}, "timestamp": 0},
+        {"topic": "test_topic", "key": 0, "value": {"id": 0, "name": "zero", "value": {"key1":10.0, "key2":1.0}}, "timestamp": 0},
+        {"topic": "test_topic", "key": 0, "value": {"id": 0, "name": "zero", "value": {"key1":10.0, "key2":1.0}}, "timestamp": 0}
+      ],
+      "outputs": [
+        {"topic": "S2", "key": 0, "value": {"ID":0,"SUM_VAL":1.0}, "timestamp": 0},
+        {"topic": "S2", "key": 0, "value": {"ID":0,"SUM_VAL":2.0}, "timestamp": 0},
+        {"topic": "S2", "key": 0, "value": {"ID":0,"SUM_VAL":3.0}, "timestamp": 0},
+        {"topic": "S2", "key": 0, "value": {"ID":0,"SUM_VAL":4.0}, "timestamp": 0},
+        {"topic": "S2", "key": 0, "value": {"ID":0,"SUM_VAL":5.0}, "timestamp": 0}
+      ]
     }
   ]
 }


### PR DESCRIPTION
### Description 
This is a temporary fix for handling literal as arguments in aggregate functions. This fixes #1895. 
We had the limitation of having at most two arguments for aggregate functions where the second one is literal. This patch fixes the regression but does not remove the limitation. 
Removing the limitation needs more thorough work that should be done in future.

### Testing done 
added integration tests.

### Reviewer checklist
- [ ] Ensure docs are updated if necessary. (eg. if a user visible feature is being added or changed).
- [ ] Ensure relevant issues are linked (description should include text like "Fixes #<issue number>")

