### PR TITLE
Remove ksql-clickstream-demo dependency from packaging module

### DIFF
--- a/ksql-package/pom.xml
+++ b/ksql-package/pom.xml
@@ -27,11 +27,6 @@
         </dependency>
         <dependency>
             <groupId>io.confluent.ksql</groupId>
-            <artifactId>ksql-clickstream-demo</artifactId>
-            <version>${project.version}</version>
-        </dependency>
-        <dependency>
-            <groupId>io.confluent.ksql</groupId>
             <artifactId>ksql-common</artifactId>
         </dependency>
         <dependency>


### PR DESCRIPTION
### Description 
#1875 removed ksql-clickstream-demo, but the dependency in ksql-package wasn't removed.

If you have cached artifacts available, including as we do in CI, this can be easy to miss because the dependency will still be resolved *despite* the fact that the build in this same repository no longer generates it.

### Testing done 
Removed all local caches and artifact repositories other than a cache of maven central, built with target `package`, and things all work and don't resolve any clickstream assets other than some avro schemas.

### Reviewer checklist
- [ ] Ensure docs are updated if necessary. (eg. if a user visible feature is being added or changed).
- [ ] Ensure relevant issues are linked (description should include text like "Fixes #<issue number>")

