### PR TITLE
Added `isKsqlSink` flag to the KSQL topics in the metastore.

### DIFF
--- a/ksql-engine/src/main/java/io/confluent/ksql/QueryEngine.java
+++ b/ksql-engine/src/main/java/io/confluent/ksql/QueryEngine.java
@@ -270,7 +270,7 @@ class QueryEngine {
       }
     }
 
-    final KsqlTopic ksqlTopic = new KsqlTopic(name, name, null);
+    final KsqlTopic ksqlTopic = new KsqlTopic(name, name, null, true);
     return new KsqlStream(
         "QueryEngine-DDLCommand-Not-Needed",
         name,

--- a/ksql-engine/src/main/java/io/confluent/ksql/analyzer/Analyzer.java
+++ b/ksql-engine/src/main/java/io/confluent/ksql/analyzer/Analyzer.java
@@ -170,7 +170,8 @@ public class Analyzer extends DefaultTraversalVisitor<Node, AnalysisContext> {
       newIntoKsqlTopic = new KsqlTopic(
           intoKafkaTopicName,
           intoKafkaTopicName,
-          intoTopicSerde
+          intoTopicSerde,
+          true
       );
     } else {
       newIntoKsqlTopic = metaStore.getTopic(intoKafkaTopicName);

--- a/ksql-engine/src/main/java/io/confluent/ksql/ddl/commands/RegisterTopicCommand.java
+++ b/ksql-engine/src/main/java/io/confluent/ksql/ddl/commands/RegisterTopicCommand.java
@@ -99,7 +99,7 @@ public class RegisterTopicCommand implements DdlCommand {
       }
     }
 
-    final KsqlTopic ksqlTopic = new KsqlTopic(topicName, kafkaTopicName, topicSerDe);
+    final KsqlTopic ksqlTopic = new KsqlTopic(topicName, kafkaTopicName, topicSerDe, false);
 
     // TODO: Need to check if the topic exists.
     // Add the topic to the metastore

--- a/ksql-engine/src/main/java/io/confluent/ksql/planner/plan/KsqlStructuredDataOutputNode.java
+++ b/ksql-engine/src/main/java/io/confluent/ksql/planner/plan/KsqlStructuredDataOutputNode.java
@@ -206,7 +206,8 @@ public class KsqlStructuredDataOutputNode extends OutputNode {
     builder.withKsqlTopic(new KsqlTopic(
         getKsqlTopic().getName(),
         getKsqlTopic().getKafkaTopicName(),
-        ksqlAvroTopicSerDe
+        ksqlAvroTopicSerDe,
+        true
     ));
   }
 

--- a/ksql-engine/src/test/java/io/confluent/ksql/codegen/CodeGenRunnerTest.java
+++ b/ksql-engine/src/test/java/io/confluent/ksql/codegen/CodeGenRunnerTest.java
@@ -129,7 +129,7 @@ public class CodeGenRunnerTest {
         final KsqlTopic ksqlTopic = new KsqlTopic(
             "CODEGEN_TEST",
             "codegen_test",
-            new KsqlJsonTopicSerDe());
+            new KsqlJsonTopicSerDe(), false);
         final KsqlStream ksqlStream = new KsqlStream(
             "sqlexpression",
             "CODEGEN_TEST", metaStoreSchema,

--- a/ksql-engine/src/test/java/io/confluent/ksql/planner/plan/KsqlStructuredDataOutputNodeTest.java
+++ b/ksql-engine/src/test/java/io/confluent/ksql/planner/plan/KsqlStructuredDataOutputNodeTest.java
@@ -77,7 +77,7 @@ public class KsqlStructuredDataOutputNodeTest {
       schema.field("key"),
       new LongColumnTimestampExtractionPolicy("timestamp"),
       new KsqlTopic("input", "input",
-          new KsqlJsonTopicSerDe()));
+          new KsqlJsonTopicSerDe(), false));
   private final StructuredDataSourceNode sourceNode = new StructuredDataSourceNode(
       new PlanNodeId("0"),
       dataSource,
@@ -108,7 +108,7 @@ public class KsqlStructuredDataOutputNodeTest {
         schema,
         new LongColumnTimestampExtractionPolicy("timestamp"),
         schema.field("key"),
-        new KsqlTopic("output", "output", new KsqlJsonTopicSerDe()),
+        new KsqlTopic("output", "output", new KsqlJsonTopicSerDe(), true),
         "output",
         props,
         Optional.empty(),
@@ -255,7 +255,7 @@ public class KsqlStructuredDataOutputNodeTest {
             schema,
             schema.field("key"),
             new MetadataTimestampExtractionPolicy(),
-            new KsqlTopic("input", "input", new KsqlJsonTopicSerDe()),
+            new KsqlTopic("input", "input", new KsqlJsonTopicSerDe(), false),
             "TableStateStore",
             isWindowed),
         schema);
@@ -266,7 +266,7 @@ public class KsqlStructuredDataOutputNodeTest {
         schema,
         new MetadataTimestampExtractionPolicy(),
         schema.field("key"),
-        new KsqlTopic("output", "output", new KsqlJsonTopicSerDe()),
+        new KsqlTopic("output", "output", new KsqlJsonTopicSerDe(), true),
         "output",
         props,
         Optional.empty(),

--- a/ksql-engine/src/test/java/io/confluent/ksql/planner/plan/StructuredDataSourceNodeTest.java
+++ b/ksql-engine/src/test/java/io/confluent/ksql/planner/plan/StructuredDataSourceNodeTest.java
@@ -70,7 +70,7 @@ public class StructuredDataSourceNodeTest {
           schema.field("key"),
           new LongColumnTimestampExtractionPolicy("timestamp"),
           new KsqlTopic("topic", "topic",
-              new KsqlJsonTopicSerDe())),
+              new KsqlJsonTopicSerDe(), false)),
       schema);
 
   @Before
@@ -134,7 +134,7 @@ public class StructuredDataSourceNodeTest {
             schema.field("field"),
             new LongColumnTimestampExtractionPolicy("timestamp"),
             new KsqlTopic("topic2", "topic2",
-                new KsqlJsonTopicSerDe()),
+                new KsqlJsonTopicSerDe(), false),
             "statestore",
             false),
         schema);
@@ -151,7 +151,7 @@ public class StructuredDataSourceNodeTest {
             schema.field("field"),
             new LongColumnTimestampExtractionPolicy("timestamp"),
             new KsqlTopic("topic2", "topic2",
-                new KsqlJsonTopicSerDe()),
+                new KsqlJsonTopicSerDe(), false),
             "statestore",
             false),
         schema);

--- a/ksql-engine/src/test/java/io/confluent/ksql/util/AvroUtilTest.java
+++ b/ksql-engine/src/test/java/io/confluent/ksql/util/AvroUtilTest.java
@@ -163,7 +163,7 @@ public class AvroUtilTest {
   public void shouldValidatePersistentQueryResultCorrectly()
       throws IOException, RestClientException {
     final SchemaRegistryClient schemaRegistryClient = mock(SchemaRegistryClient.class);
-    final KsqlTopic resultTopic = new KsqlTopic("testTopic", "testTopic", new KsqlAvroTopicSerDe());
+    final KsqlTopic resultTopic = new KsqlTopic("testTopic", "testTopic", new KsqlAvroTopicSerDe(), false);
     final Schema resultSchema = AvroSchemaTranslator.toKsqlSchema(ordersAvroSchemaStr);
     final PersistentQueryMetadata persistentQueryMetadata = buildStubPersistentQueryMetadata(resultSchema, resultTopic);
     final org.apache.avro.Schema.Parser parser = new org.apache.avro.Schema.Parser();
@@ -178,8 +178,7 @@ public class AvroUtilTest {
   public void shouldFailForInvalidResultAvroSchema()
       throws IOException, RestClientException {
     final SchemaRegistryClient schemaRegistryClient = mock(SchemaRegistryClient.class);
-    final KsqlTopic resultTopic = new KsqlTopic("testTopic", "testTopic", new KsqlAvroTopicSerDe
-        ());
+    final KsqlTopic resultTopic = new KsqlTopic("testTopic", "testTopic", new KsqlAvroTopicSerDe(), false);
     final Schema resultSchema = AvroSchemaTranslator.toKsqlSchema(ordersAvroSchemaStr);
     final PersistentQueryMetadata persistentQueryMetadata = buildStubPersistentQueryMetadata(resultSchema, resultTopic);
     expect(schemaRegistryClient.testCompatibility(anyString(), anyObject())).andReturn(false);

--- a/ksql-metastore/src/main/java/io/confluent/ksql/metastore/KsqlTopic.java
+++ b/ksql-metastore/src/main/java/io/confluent/ksql/metastore/KsqlTopic.java
@@ -24,12 +24,17 @@ public class KsqlTopic implements DataSource {
   private final String topicName;
   private final String kafkaTopicName;
   private final KsqlTopicSerDe ksqlTopicSerDe;
+  private final boolean isKsqlSink;
 
-  public KsqlTopic(final String topicName, final String kafkaTopicName, final KsqlTopicSerDe
-      ksqlTopicSerDe) {
+  public KsqlTopic(
+      final String topicName,
+      final String kafkaTopicName,
+      final KsqlTopicSerDe ksqlTopicSerDe,
+      final boolean isKsqlSink) {
     this.topicName = topicName;
     this.kafkaTopicName = kafkaTopicName;
     this.ksqlTopicSerDe = ksqlTopicSerDe;
+    this.isKsqlSink = isKsqlSink;
   }
 
   public KsqlTopicSerDe getKsqlTopicSerDe() {
@@ -42,6 +47,10 @@ public class KsqlTopic implements DataSource {
 
   public String getTopicName() {
     return topicName;
+  }
+
+  public boolean isKsqlSink() {
+    return isKsqlSink;
   }
 
   @Override

--- a/ksql-metastore/src/test/java/io/confluent/ksql/metastore/MetastoreTest.java
+++ b/ksql-metastore/src/test/java/io/confluent/ksql/metastore/MetastoreTest.java
@@ -41,7 +41,7 @@ public class MetastoreTest {
 
   @Test
   public void testTopicMap() {
-    final KsqlTopic ksqlTopic1 = new KsqlTopic("testTopic", "testTopicKafka", new KsqlJsonTopicSerDe());
+    final KsqlTopic ksqlTopic1 = new KsqlTopic("testTopic", "testTopicKafka", new KsqlJsonTopicSerDe(), false);
     metaStore.putTopic(ksqlTopic1);
     final KsqlTopic ksqlTopic2 = metaStore.getTopic("testTopic");
     Assert.assertNotNull(ksqlTopic2);

--- a/ksql-metastore/src/test/java/io/confluent/ksql/util/MetaStoreFixture.java
+++ b/ksql-metastore/src/test/java/io/confluent/ksql/util/MetaStoreFixture.java
@@ -55,7 +55,7 @@ public class MetaStoreFixture {
 
     final KsqlTopic
         ksqlTopic1 =
-        new KsqlTopic("TEST1", "test1", serde.get());
+        new KsqlTopic("TEST1", "test1", serde.get(), false);
 
     final KsqlStream ksqlStream = new KsqlStream("sqlexpression",
         "TEST1",
@@ -78,7 +78,7 @@ public class MetaStoreFixture {
 
     final KsqlTopic
         ksqlTopic2 =
-        new KsqlTopic("TEST2", "test2", serde.get());
+        new KsqlTopic("TEST2", "test2", serde.get(), false);
     final KsqlTable ksqlTable = new KsqlTable(
         "sqlexpression",
         "TEST2",
@@ -125,7 +125,7 @@ public class MetaStoreFixture {
 
     final KsqlTopic
         ksqlTopicOrders =
-        new KsqlTopic("ORDERS_TOPIC", "orders_topic", serde.get());
+        new KsqlTopic("ORDERS_TOPIC", "orders_topic", serde.get(), false);
 
     final KsqlStream ksqlStreamOrders = new KsqlStream(
         "sqlexpression",
@@ -149,7 +149,7 @@ public class MetaStoreFixture {
 
     final KsqlTopic
         ksqlTopic3 =
-        new KsqlTopic("TEST3", "test3", serde.get());
+        new KsqlTopic("TEST3", "test3", serde.get(), false);
     final KsqlTable ksqlTable3 = new KsqlTable(
         "sqlexpression",
         "TEST3",
@@ -172,7 +172,7 @@ public class MetaStoreFixture {
 
     final KsqlTopic
         nestedArrayStructMapTopic =
-        new KsqlTopic("NestedArrayStructMap", "NestedArrayStructMap_topic", serde.get());
+        new KsqlTopic("NestedArrayStructMap", "NestedArrayStructMap_topic", serde.get(), false);
 
     final KsqlStream nestedArrayStructMapOrders = new KsqlStream(
         "sqlexpression",

--- a/ksql-parser/src/main/java/io/confluent/ksql/parser/AstBuilder.java
+++ b/ksql-parser/src/main/java/io/confluent/ksql/parser/AstBuilder.java
@@ -1531,7 +1531,7 @@ public class AstBuilder extends SqlBaseBaseVisitor<Node> {
     }
 
     final KsqlTopic ksqlTopic =
-        new KsqlTopic(into.getName().toString(), into.getName().toString(), null);
+        new KsqlTopic(into.getName().toString(), into.getName().toString(), null, true);
 
     final StructuredDataSource resultStream =
         new KsqlStream(

--- a/ksql-parser/src/test/java/io/confluent/ksql/parser/KsqlParserTest.java
+++ b/ksql-parser/src/test/java/io/confluent/ksql/parser/KsqlParserTest.java
@@ -128,7 +128,7 @@ public class KsqlParserTest {
 
     final KsqlTopic
         ksqlTopicOrders =
-        new KsqlTopic("ADDRESS_TOPIC", "orders_topic", new KsqlJsonTopicSerDe());
+        new KsqlTopic("ADDRESS_TOPIC", "orders_topic", new KsqlJsonTopicSerDe(), false);
 
     final KsqlStream ksqlStreamOrders = new KsqlStream(
         "sqlexpression",
@@ -143,7 +143,7 @@ public class KsqlParserTest {
 
     final KsqlTopic
         ksqlTopicItems =
-        new KsqlTopic("ITEMS_TOPIC", "item_topic", new KsqlJsonTopicSerDe());
+        new KsqlTopic("ITEMS_TOPIC", "item_topic", new KsqlJsonTopicSerDe(), false);
     final KsqlTable ksqlTableOrders = new KsqlTable(
         "sqlexpression",
         "ITEMID",

--- a/ksql-parser/src/test/java/io/confluent/ksql/parser/SqlFormatterTest.java
+++ b/ksql-parser/src/test/java/io/confluent/ksql/parser/SqlFormatterTest.java
@@ -117,7 +117,7 @@ public class SqlFormatterTest {
 
     final KsqlTopic
         ksqlTopicOrders =
-        new KsqlTopic("ADDRESS_TOPIC", "orders_topic", new KsqlJsonTopicSerDe());
+        new KsqlTopic("ADDRESS_TOPIC", "orders_topic", new KsqlJsonTopicSerDe(), false);
 
     final KsqlStream ksqlStreamOrders = new KsqlStream(
         "sqlexpression",
@@ -132,7 +132,7 @@ public class SqlFormatterTest {
 
     final KsqlTopic
         ksqlTopicItems =
-        new KsqlTopic("ITEMS_TOPIC", "item_topic", new KsqlJsonTopicSerDe());
+        new KsqlTopic("ITEMS_TOPIC", "item_topic", new KsqlJsonTopicSerDe(), false);
     final KsqlTable ksqlTableOrders = new KsqlTable(
         "sqlexpression",
         "ITEMID",

--- a/ksql-rest-app/src/test/java/io/confluent/ksql/rest/entity/QueryDescriptionTest.java
+++ b/ksql-rest-app/src/test/java/io/confluent/ksql/rest/entity/QueryDescriptionTest.java
@@ -55,7 +55,7 @@ public class QueryDescriptionTest {
           new KsqlStream(
               STATEMENT, name, SCHEMA, SCHEMA.fields().get(0),
               new MetadataTimestampExtractionPolicy(),
-              new KsqlTopic(name, name, new KsqlJsonTopicSerDe())),
+              new KsqlTopic(name, name, new KsqlJsonTopicSerDe(), false)),
           SCHEMA);
     }
   }
@@ -121,7 +121,7 @@ public class QueryDescriptionTest {
     final TopologyDescription topologyDescription = mock(TopologyDescription.class);
     expect(topology.describe()).andReturn(topologyDescription);
     replay(topology, topologyDescription);
-    final KsqlTopic sinkTopic = new KsqlTopic("fake_sink", "fake_sink", new KsqlJsonTopicSerDe());
+    final KsqlTopic sinkTopic = new KsqlTopic("fake_sink", "fake_sink", new KsqlJsonTopicSerDe(), true);
     final KsqlStream fakeSink = new KsqlStream(
         STATEMENT, "fake_sink", SCHEMA, SCHEMA.fields().get(0),
         new MetadataTimestampExtractionPolicy(), sinkTopic);

--- a/ksql-rest-app/src/test/java/io/confluent/ksql/rest/entity/SourceDescriptionTest.java
+++ b/ksql-rest-app/src/test/java/io/confluent/ksql/rest/entity/SourceDescriptionTest.java
@@ -63,7 +63,7 @@ public class SourceDescriptionTest {
     final Schema schema = SchemaBuilder.struct()
         .field("field0", Schema.OPTIONAL_INT32_SCHEMA)
         .build();
-    final KsqlTopic topic = new KsqlTopic("internal", kafkaTopicName, new KsqlJsonTopicSerDe());
+    final KsqlTopic topic = new KsqlTopic("internal", kafkaTopicName, new KsqlJsonTopicSerDe(), true);
     return new KsqlStream(
         "query", "stream", schema, schema.fields().get(0),
         new MetadataTimestampExtractionPolicy(), topic);

--- a/ksql-rest-app/src/test/java/io/confluent/ksql/rest/server/resources/KsqlResourceTest.java
+++ b/ksql-rest-app/src/test/java/io/confluent/ksql/rest/server/resources/KsqlResourceTest.java
@@ -832,7 +832,7 @@ public class KsqlResourceTest {
       return;
     }
 
-    final KsqlTopic ksqlTopic = new KsqlTopic(ksqlTopicName, topicName, new KsqlJsonTopicSerDe());
+    final KsqlTopic ksqlTopic = new KsqlTopic(ksqlTopicName, topicName, new KsqlJsonTopicSerDe(), false);
     kafkaTopicClient.createTopic(topicName, 1, (short) 1);
     metaStore.putTopic(ksqlTopic);
     if (type == DataSource.DataSourceType.KSTREAM) {


### PR DESCRIPTION
### Description 
Added a new flag to the ksql topic in the metastore indicating if it is used as a sink topic in KSQL or not.
Only topics corresponding to the sink stream/tables that are created using CSAS/CTAS statements will have true value for the flag.

### Testing done 
Added unit test.

### Reviewer checklist
- [ ] Ensure docs are updated if necessary. (eg. if a user visible feature is being added or changed).
- [ ] Ensure relevant issues are linked (description should include text like "Fixes #<issue number>")

