### PR TITLE
KSQL-1656: Fix build error caused by moving topics

### DIFF
--- a/docs/developer-guide/syntax-reference.rst
+++ b/docs/developer-guide/syntax-reference.rst
@@ -198,7 +198,7 @@ The WITH clause supports the following properties:
 +-------------------------+--------------------------------------------------------------------------------------------+
 
 
-.. include:: includes/ksql-includes.rst
+.. include:: ../includes/ksql-includes.rst
     :start-line: 2
     :end-line: 6
 
@@ -274,7 +274,7 @@ The WITH clause supports the following properties:
 |                         | according to the timestamp in ``ROWTIME``.                                                 |
 +-------------------------+--------------------------------------------------------------------------------------------+
 
-.. include:: includes/ksql-includes.rst
+.. include:: ../includes/ksql-includes.rst
     :start-line: 2
     :end-line: 6
 
@@ -345,7 +345,7 @@ The WITH clause for the result supports the following properties:
 |               | the window into which each row of ``bar`` is place is determined by bar's ``ROWTIME``, not ``t2``.   |
 +---------------+------------------------------------------------------------------------------------------------------+
 
-.. include:: includes/ksql-includes.rst
+.. include:: ../includes/ksql-includes.rst
     :start-line: 2
     :end-line: 6
 
@@ -411,7 +411,7 @@ The WITH clause supports the following properties:
 |               | the window into which each row of ``bar`` is placed is determined by bar's ``ROWTIME``, not ``t2``.  |
 +---------------+------------------------------------------------------------------------------------------------------+
 
-.. include:: includes/ksql-includes.rst
+.. include:: ../includes/ksql-includes.rst
     :start-line: 2
     :end-line: 6
 

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -84,6 +84,4 @@ KSQL Documentation
     operations
     capacity-planning
     tutorials/index
-    syntax-reference
-    api
     faq


### PR DESCRIPTION
### Description 
Forgot to remove references to moved topics in the root index.rst, causing build breakage. Also changed path to the `includes` directory.
