### PR TITLE
Hide ssl configs and refactor KsqlResourceTest

### DIFF
--- a/ksql-cli/src/test/java/io/confluent/ksql/CliTest.java
+++ b/ksql-cli/src/test/java/io/confluent/ksql/CliTest.java
@@ -251,10 +251,6 @@ public class CliTest {
             "" + (KsqlConstants.defaultSinkWindowChangeLogAdditionalRetention + 1)
         ),
 
-        ImmutableList.of(
-            SslConfigs.SSL_KEYSTORE_PASSWORD_CONFIG, "", "NULL"
-        ),
-
         // SESSION OVERRIDES:
         ImmutableList.of(
             KsqlConfig.KSQL_STREAMS_PREFIX + ConsumerConfig.AUTO_OFFSET_RESET_CONFIG,

--- a/ksql-common/src/test/java/io/confluent/ksql/util/KsqlConfigTest.java
+++ b/ksql-common/src/test/java/io/confluent/ksql/util/KsqlConfigTest.java
@@ -347,7 +347,6 @@ public class KsqlConfigTest {
 
     // Then:
     assertThat(result.get(KsqlConfig.KSQL_SERVICE_ID_CONFIG), is("not sensitive"));
-    assertThat(result.get(SslConfigs.SSL_KEYSTORE_PASSWORD_CONFIG), is("[hidden]"));
   }
 
   @Test

--- a/ksql-engine/src/main/java/io/confluent/ksql/KsqlEngine.java
+++ b/ksql-engine/src/main/java/io/confluent/ksql/KsqlEngine.java
@@ -95,11 +95,11 @@ public class KsqlEngine implements Closeable {
 
   private static final Logger log = LoggerFactory.getLogger(KsqlEngine.class);
 
-  // TODO: Decide if any other properties belong in here
-  private static final Set<String> IMMUTABLE_PROPERTIES = ImmutableSet.of(
-      StreamsConfig.BOOTSTRAP_SERVERS_CONFIG,
-      KsqlConfig.KSQL_EXT_DIR
-  );
+  private static final Set<String> IMMUTABLE_PROPERTIES = ImmutableSet.<String>builder()
+      .add(StreamsConfig.BOOTSTRAP_SERVERS_CONFIG)
+      .add(KsqlConfig.KSQL_EXT_DIR)
+      .addAll(KsqlConfig.SSL_CONFIG_NAMES)
+      .build();
 
   private final MetaStore metaStore;
   private final KafkaTopicClient topicClient;

--- a/ksql-engine/src/main/java/io/confluent/ksql/util/AvroUtil.java
+++ b/ksql-engine/src/main/java/io/confluent/ksql/util/AvroUtil.java
@@ -79,13 +79,11 @@ public final class AvroUtil {
 
     try {
       final String avroSchemaString = schemaMetadata.getSchema();
-      streamsProperties.put(DdlConfig.AVRO_SCHEMA, avroSchemaString);
-      final AbstractStreamCreateStatement abstractStreamCreateStatementCopy = addAvroFields(
+      return addAvroFields(
               abstractStreamCreateStatement,
               AvroSchemaTranslator.toKsqlSchema(avroSchemaString),
               schemaMetadata.getId()
       );
-      return abstractStreamCreateStatementCopy;
 
     } catch (final Exception e) {
       throw new KsqlException("Unable to verify if the Avro schema for topic " + kafkaTopicName

--- a/ksql-rest-app/src/main/java/io/confluent/ksql/rest/entity/CommandStatusEntity.java
+++ b/ksql-rest-app/src/main/java/io/confluent/ksql/rest/entity/CommandStatusEntity.java
@@ -88,4 +88,12 @@ public class CommandStatusEntity extends KsqlEntity {
   public int hashCode() {
     return Objects.hash(getCommandId(), getCommandStatus());
   }
+
+  @Override
+  public String toString() {
+    return "CommandStatusEntity{"
+        + "commandId=" + commandId
+        + ", commandStatus=" + commandStatus
+        + '}';
+  }
 }

--- a/ksql-rest-app/src/test/java/io/confluent/ksql/rest/server/resources/KsqlResourceTest.java
+++ b/ksql-rest-app/src/test/java/io/confluent/ksql/rest/server/resources/KsqlResourceTest.java
@@ -491,7 +491,7 @@ public class KsqlResourceTest {
   public void shouldReturn5xxOnSystemError() {
     // Given:
     final KsqlEngine mockEngine = givenMockEngine(engine ->
-        EasyMock.expect(engine.getStatements(EasyMock.anyString()))
+        EasyMock.expect(engine.parseStatements(EasyMock.anyString()))
             .andThrow(new RuntimeException("internal error")));
 
     // When:
@@ -510,8 +510,8 @@ public class KsqlResourceTest {
     // Given:
     final String ksqlString = "CREATE STREAM test_explain AS SELECT * FROM test_stream;";
     final KsqlEngine mockEngine = givenMockEngine(engine -> {
-      EasyMock.expect(engine.getStatements(EasyMock.anyString()))
-          .andReturn(ksqlEngine.getStatements(ksqlString));
+      EasyMock.expect(engine.parseStatements(EasyMock.anyString()))
+          .andReturn(ksqlEngine.parseStatements(ksqlString));
 
       EasyMock.expect(engine.getQueryExecutionPlan(EasyMock.anyObject(), EasyMock.anyObject()))
           .andThrow(new RuntimeException("internal error"));

--- a/ksql-rest-app/src/test/java/io/confluent/ksql/rest/server/resources/KsqlResourceTest.java
+++ b/ksql-rest-app/src/test/java/io/confluent/ksql/rest/server/resources/KsqlResourceTest.java
@@ -17,17 +17,18 @@
 package io.confluent.ksql.rest.server.resources;
 
 import static org.hamcrest.CoreMatchers.containsString;
-import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.CoreMatchers.hasItem;
 import static org.hamcrest.CoreMatchers.hasItems;
 import static org.hamcrest.CoreMatchers.instanceOf;
-import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.contains;
+import static org.hamcrest.Matchers.containsInAnyOrder;
 import static org.hamcrest.Matchers.empty;
+import static org.hamcrest.Matchers.hasSize;
+import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.not;
-import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertThat;
-import static org.junit.Assert.assertTrue;
 
+import com.google.common.collect.ImmutableMap;
 import io.confluent.kafka.schemaregistry.client.MockSchemaRegistryClient;
 import io.confluent.kafka.schemaregistry.client.SchemaRegistryClient;
 import io.confluent.kafka.schemaregistry.client.rest.exceptions.RestClientException;
@@ -35,14 +36,11 @@ import io.confluent.kafka.serializers.KafkaJsonDeserializer;
 import io.confluent.kafka.serializers.KafkaJsonDeserializerConfig;
 import io.confluent.kafka.serializers.KafkaJsonSerializer;
 import io.confluent.ksql.KsqlEngine;
-import io.confluent.ksql.ddl.DdlConfig;
 import io.confluent.ksql.metastore.KsqlStream;
 import io.confluent.ksql.metastore.KsqlTable;
 import io.confluent.ksql.metastore.KsqlTopic;
 import io.confluent.ksql.metastore.MetaStore;
-import io.confluent.ksql.parser.tree.Expression;
 import io.confluent.ksql.parser.tree.Statement;
-import io.confluent.ksql.parser.tree.StringLiteral;
 import io.confluent.ksql.rest.entity.CommandStatus;
 import io.confluent.ksql.rest.entity.CommandStatusEntity;
 import io.confluent.ksql.rest.entity.EntityQueryId;
@@ -69,19 +67,16 @@ import io.confluent.ksql.rest.entity.SourceInfo;
 import io.confluent.ksql.rest.entity.StreamsList;
 import io.confluent.ksql.rest.entity.TablesList;
 import io.confluent.ksql.rest.server.KsqlRestConfig;
-import io.confluent.ksql.rest.server.StatementParser;
 import io.confluent.ksql.rest.server.computation.Command;
 import io.confluent.ksql.rest.server.computation.CommandId;
 import io.confluent.ksql.rest.server.computation.CommandIdAssigner;
-import io.confluent.ksql.rest.server.computation.QueuedCommandStatus;
 import io.confluent.ksql.rest.server.computation.CommandStore;
-import io.confluent.ksql.rest.server.computation.StatementExecutor;
+import io.confluent.ksql.rest.server.computation.QueuedCommandStatus;
 import io.confluent.ksql.rest.server.utils.TestUtils;
 import io.confluent.ksql.rest.util.EntityUtil;
 import io.confluent.ksql.serde.DataSource;
 import io.confluent.ksql.serde.json.KsqlJsonTopicSerDe;
 import io.confluent.ksql.util.FakeKafkaTopicClient;
-import io.confluent.ksql.util.KafkaTopicClient;
 import io.confluent.ksql.util.KsqlConfig;
 import io.confluent.ksql.util.KsqlConstants;
 import io.confluent.ksql.util.PersistentQueryMetadata;
@@ -96,6 +91,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Properties;
 import java.util.concurrent.Future;
+import java.util.function.Consumer;
 import java.util.stream.Collectors;
 import javax.ws.rs.core.Response;
 import org.apache.commons.lang3.concurrent.ConcurrentUtils;
@@ -111,29 +107,47 @@ import org.apache.kafka.connect.data.Schema;
 import org.apache.kafka.connect.data.SchemaBuilder;
 import org.apache.kafka.streams.StreamsConfig;
 import org.easymock.EasyMock;
-import org.hamcrest.Matchers;
+import org.easymock.EasyMockRunner;
+import org.easymock.Mock;
+import org.easymock.MockType;
+import org.eclipse.jetty.http.HttpStatus.Code;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
+import org.junit.runner.RunWith;
 
 @SuppressWarnings("unchecked")
+@RunWith(EasyMockRunner.class)
 public class KsqlResourceTest {
+
+  private static final long STATE_CLEANUP_DELAY_MS_DEFAULT = 10 * 60 * 1000L;
+  private static final int FETCH_MIN_BYTES_DEFAULT = 1;
+  private static final long BUFFER_MEMORY_DEFAULT = 32 * 1024 * 1024L;
+  private static final long DISTRIBUTED_COMMAND_RESPONSE_TIMEOUT = 1000;
+
   private KsqlConfig ksqlConfig;
   private KsqlRestConfig ksqlRestConfig;
   private FakeKafkaTopicClient kafkaTopicClient;
   private KsqlEngine ksqlEngine;
+  @Mock(MockType.NICE)
+  private CommandStore mockCommandStore;
+  private KsqlResource ksqlResource;
 
   @Before
   public void setUp() throws IOException, RestClientException {
     final SchemaRegistryClient schemaRegistryClient = new MockSchemaRegistryClient();
     registerSchema(schemaRegistryClient);
-    ksqlRestConfig = new KsqlRestConfig(TestKsqlResourceUtil.getDefaultKsqlConfig());
+    ksqlRestConfig = new KsqlRestConfig(getDefaultKsqlConfig());
     ksqlConfig = new KsqlConfig(ksqlRestConfig.getKsqlConfigProperties());
     kafkaTopicClient = new FakeKafkaTopicClient();
     ksqlEngine = TestUtils.createKsqlEngine(
         ksqlConfig,
         kafkaTopicClient,
         () -> schemaRegistryClient);
+
+    addTestTopicAndSources();
+
+    givenKsqlResourceWith(ksqlConfig, ksqlEngine);
   }
 
   @After
@@ -141,239 +155,56 @@ public class KsqlResourceTest {
     ksqlEngine.close();
   }
 
-  private static class TestCommandProducer<K, V> extends KafkaProducer<K, V> {
-    public TestCommandProducer(final Map configs, final Serializer keySerializer, final Serializer valueSerializer) {
-      super(configs, keySerializer, valueSerializer);
-    }
-
-    @Override
-    public Future<RecordMetadata> send(final ProducerRecord record) {
-      // Fake result: only for testing purpose
-      return ConcurrentUtils.constantFuture(new RecordMetadata(null, 0L, 0L, 0L, 0L, 0, 0));
-    }
-  }
-
-  private static class TestCommandConsumer<K, V> extends KafkaConsumer<K, V> {
-    public TestCommandConsumer(
-        final Map configs, final Deserializer keyDeserializer, final Deserializer valueDeserializer) {
-      super(configs, keyDeserializer, valueDeserializer);
-    }
-  }
-
-  private static class TestKsqlResourceUtil {
-
-    public static final long DISTRIBUTED_COMMAND_RESPONSE_TIMEOUT = 1000;
-
-    public static KsqlResource get(final KsqlConfig ksqlConfig, final KsqlEngine ksqlEngine) {
-      final Properties defaultKsqlConfig = getDefaultKsqlConfig();
-
-      final KafkaConsumer<CommandId, Command> commandConsumer = new TestCommandConsumer<>(
-          defaultKsqlConfig,
-          getJsonDeserializer(CommandId.class, true),
-          getJsonDeserializer(Command.class, false)
-      );
-
-      final KafkaProducer<CommandId, Command> commandProducer = new TestCommandProducer<>(
-          defaultKsqlConfig,
-          getJsonSerializer(true),
-          getJsonSerializer(false)
-      );
-
-      final CommandStore commandStore = new CommandStore("__COMMANDS_TOPIC",
-          commandConsumer, commandProducer, new CommandIdAssigner(ksqlEngine.getMetaStore()));
-      return get(ksqlConfig, ksqlEngine, commandStore);
-    }
-
-    public static KsqlResource get(final KsqlConfig ksqlConfig,
-                                   final KsqlEngine ksqlEngine,
-                                   final CommandStore commandStore) {
-      addTestTopicAndSources(ksqlEngine.getMetaStore(), ksqlEngine.getTopicClient());
-      return new KsqlResource(ksqlConfig, ksqlEngine, commandStore, DISTRIBUTED_COMMAND_RESPONSE_TIMEOUT);
-    }
-
-    private static Properties getDefaultKsqlConfig() {
-      final Map<String, Object> configMap = new HashMap<>();
-      configMap.put(ConsumerConfig.BOOTSTRAP_SERVERS_CONFIG, "localhost:9092");
-      configMap.put("commit.interval.ms", 0);
-      configMap.put("cache.max.bytes.buffering", 0);
-      configMap.put("auto.offset.reset", "earliest");
-      configMap.put("ksql.command.topic.suffix", "commands");
-      configMap.put(RestConfig.LISTENERS_CONFIG, "http://localhost:8088");
-
-      final Properties properties = new Properties();
-      properties.putAll(configMap);
-
-      return properties;
-    }
-
-    private static void addTestTopicAndSources(final MetaStore metaStore, final KafkaTopicClient kafkaTopicClient) {
-      final Schema schema1 = SchemaBuilder.struct().field("S1_F1", Schema.OPTIONAL_BOOLEAN_SCHEMA);
-      addSource(
-          metaStore, kafkaTopicClient, DataSource.DataSourceType.KTABLE,
-          "TEST_TABLE", "KAFKA_TOPIC_1", "KSQL_TOPIC_1", schema1);
-      final Schema schema2 = SchemaBuilder.struct().field("S2_F1", Schema.OPTIONAL_STRING_SCHEMA);
-      addSource(
-          metaStore, kafkaTopicClient, DataSource.DataSourceType.KSTREAM,
-          "TEST_STREAM", "KAFKA_TOPIC_2", "KSQL_TOPIC_2", schema2);
-      kafkaTopicClient.createTopic("orders-topic", 1, (short)1);
-    }
-
-    public static void addSource(
-        final MetaStore metaStore, final KafkaTopicClient kafkaTopicClient, final DataSource.DataSourceType type, final String sourceName,
-        final String topicName, final String ksqlTopicName, final Schema schema) {
-      final KsqlTopic ksqlTopic = new KsqlTopic(ksqlTopicName, topicName, new KsqlJsonTopicSerDe());
-      kafkaTopicClient.createTopic(topicName, 1, (short)1);
-      metaStore.putTopic(ksqlTopic);
-      if (type == DataSource.DataSourceType.KSTREAM) {
-        metaStore.putSource(
-            new KsqlStream(
-                "statementText", sourceName, schema, schema.fields().get(0),
-                new MetadataTimestampExtractionPolicy(), ksqlTopic));
-      }
-      if (type == DataSource.DataSourceType.KTABLE) {
-        metaStore.putSource(
-            new KsqlTable(
-                "statementText", sourceName, schema, schema.fields().get(0),
-                new MetadataTimestampExtractionPolicy(), ksqlTopic, "statestore", false));
-      }
-    }
-
-    private static <T> Deserializer<T> getJsonDeserializer(final Class<T> classs, final boolean isKey) {
-      final Deserializer<T> result = new KafkaJsonDeserializer<>();
-      final String typeConfigProperty = isKey
-                                  ? KafkaJsonDeserializerConfig.JSON_KEY_TYPE
-                                  : KafkaJsonDeserializerConfig.JSON_VALUE_TYPE;
-
-      final Map<String, ?> props = Collections.singletonMap(
-          typeConfigProperty,
-          classs
-      );
-      result.configure(props, isKey);
-      return result;
-    }
-
-    private static <T> Serializer<T> getJsonSerializer(final boolean isKey) {
-      final Serializer<T> result = new KafkaJsonSerializer<>();
-      result.configure(Collections.emptyMap(), isKey);
-      return result;
-    }
-
-  }
-
-  private <R> R makeSingleRequest(
-      final KsqlResource testResource,
-      final String ksqlString,
-      final Map<String, Object> streamsProperties,
-      final Class<R> responseClass) {
-
-    final Object responseEntity = handleKsqlStatements(
-        testResource, new KsqlRequest(ksqlString, streamsProperties)
-    ).getEntity();
-    assertThat(responseEntity, instanceOf(List.class));
-
-    final List responseList = (List) responseEntity;
-    assertEquals(1, responseList.size());
-
-    final Object responseElement = responseList.get(0);
-    assertThat(responseElement, instanceOf(responseClass));
-
-    return responseClass.cast(responseElement);
-  }
-
   @Test
-  public void testInstantRegisterTopic() {
-    final KsqlResource testResource = TestKsqlResourceUtil.get(ksqlConfig, ksqlEngine);
-
-    final String ksqlTopic = "FOO";
-    final String kafkaTopic = "bar";
-    final String format = "json";
-
-    final String ksqlString =
-        String.format("REGISTER TOPIC %s WITH (kafka_topic='%s', value_format='%s');",
-                      ksqlTopic,
-                      kafkaTopic, format);
-
-    final Map<String, Expression> createTopicProperties = new HashMap<>();
-    createTopicProperties.put(DdlConfig.KAFKA_TOPIC_NAME_PROPERTY, new StringLiteral(kafkaTopic));
-    createTopicProperties.put(DdlConfig.VALUE_FORMAT_PROPERTY, new StringLiteral(format));
-
-    final CommandId commandId = new CommandId(CommandId.Type.TOPIC, ksqlTopic, CommandId.Action.CREATE);
-    final CommandStatus commandStatus = new CommandStatus(
-        CommandStatus.Status.QUEUED,
-        "Statement written to command topic"
-    );
-
-    final CommandStatusEntity expectedCommandStatusEntity =
-        new CommandStatusEntity(ksqlString, commandId, commandStatus);
-
-    final Map<String, Object> streamsProperties = Collections.emptyMap();
-
+  public void shouldInstantRegisterTopic() {
+    // When:
     final KsqlEntity testKsqlEntity = makeSingleRequest(
-        testResource,
-        ksqlString,
-        streamsProperties,
-        KsqlEntity.class
-    );
+        "REGISTER TOPIC FOO WITH (kafka_topic='bar', value_format='json');",
+        KsqlEntity.class);
 
-    assertEquals(expectedCommandStatusEntity, testKsqlEntity);
+    /// Then:
+    final CommandId commandId = new CommandId(CommandId.Type.TOPIC, "FOO", CommandId.Action.CREATE);
+    final CommandStatus commandStatus = new CommandStatus(
+        CommandStatus.Status.QUEUED, "Statement written to command topic");
+
+    final CommandStatusEntity expectedCommandStatusEntity = new CommandStatusEntity(
+        "REGISTER TOPIC FOO WITH (kafka_topic='bar', value_format='json');", commandId,
+        commandStatus);
+
+    assertThat(testKsqlEntity, is(expectedCommandStatusEntity));
   }
 
   @Test
-  public void testListRegisteredTopics() {
-    final KsqlResource testResource = TestKsqlResourceUtil.get(ksqlConfig, ksqlEngine);
-    final String ksqlString = "LIST REGISTERED TOPICS;";
-
+  public void shouldListRegisteredTopics() {
+    // When:
     final KsqlTopicsList ksqlTopicsList = makeSingleRequest(
-        testResource,
-        ksqlString,
-        Collections.emptyMap(),
-        KsqlTopicsList.class
-    );
+        "LIST REGISTERED TOPICS;", KsqlTopicsList.class);
 
-    final Collection<KsqlTopicInfo> testTopics = ksqlTopicsList.getTopics();
-    final Collection<KsqlTopicInfo> expectedTopics = testResource.getKsqlEngine().getMetaStore()
+    // Then:
+    final Collection<KsqlTopicInfo> expectedTopics = ksqlEngine.getMetaStore()
         .getAllKsqlTopics().values().stream()
         .map(KsqlTopicInfo::new)
         .collect(Collectors.toList());
 
-    assertEquals(expectedTopics.size(), testTopics.size());
-
-    for (final KsqlTopicInfo testTopic : testTopics) {
-      assertTrue(expectedTopics.contains(testTopic));
-    }
-
-    for (final KsqlTopicInfo expectedTopic : expectedTopics) {
-      assertTrue(testTopics.contains(expectedTopic));
-    }
+    assertThat(ksqlTopicsList.getTopics(), is(expectedTopics));
   }
 
   @Test
-  public void testShowQueries() {
-    final KsqlResource testResource = TestKsqlResourceUtil.get(ksqlConfig, ksqlEngine);
-    final String ksqlString = "SHOW QUERIES;";
+  public void shouldShowNoQueries() {
+    // When:
+    final Queries queries = makeSingleRequest("SHOW QUERIES;", Queries.class);
 
-    final Queries queries = makeSingleRequest(
-        testResource,
-        ksqlString,
-        Collections.emptyMap(),
-        Queries.class
-    );
-    final List<RunningQuery> testQueries = queries.getQueries();
-
-    assertEquals(0, testQueries.size());
+    // Then:
+    assertThat(queries.getQueries(), is(empty()));
   }
 
   @Test
   public void shouldListFunctions() {
-    final KsqlResource testResource = TestKsqlResourceUtil.get(ksqlConfig, ksqlEngine);
+    // When:
     final FunctionNameList functionList = makeSingleRequest(
-        testResource,
-        "LIST FUNCTIONS;",
-        Collections.emptyMap(),
-        FunctionNameList.class
-    );
+        "LIST FUNCTIONS;", FunctionNameList.class);
 
-    // not going to check every function
+    // Then:
     assertThat(functionList.getFunctions(), hasItems(
         new SimpleFunctionInfo("TIMESTAMPTOSTRING", FunctionType.scalar),
         new SimpleFunctionInfo("ARRAYCONTAINS", FunctionType.scalar),
@@ -381,297 +212,189 @@ public class KsqlResourceTest {
         new SimpleFunctionInfo("TOPK", FunctionType.aggregate),
         new SimpleFunctionInfo("MAX", FunctionType.aggregate)));
 
-    // shouldn't contain internal functions
-    assertThat(functionList.getFunctions(),
+    assertThat("shouldn't contain internal functions", functionList.getFunctions(),
         not(hasItem(new SimpleFunctionInfo("FETCH_FIELD_FROM_STRUCT", FunctionType.scalar))));
   }
 
-
   @Test
   public void shouldReturnDescriptionsForShowStreamsExtended() {
-    final KsqlResource testResource = TestKsqlResourceUtil.get(ksqlConfig, ksqlEngine);
-
+    // Given:
     final Schema schema = SchemaBuilder.struct()
         .field("FIELD1", Schema.OPTIONAL_BOOLEAN_SCHEMA)
         .field("FIELD2", Schema.OPTIONAL_STRING_SCHEMA);
-    TestKsqlResourceUtil.addSource(
-        testResource.getKsqlEngine().getMetaStore(), testResource.getKsqlEngine().getTopicClient(),
+
+    ensureSource(
         DataSource.DataSourceType.KSTREAM, "new_stream", "new_topic",
         "new_ksql_topic", schema);
 
-    final String ksqlString = "SHOW STREAMS EXTENDED;";
+    // When:
     final SourceDescriptionList descriptionList = makeSingleRequest(
-        testResource, ksqlString, Collections.emptyMap(), SourceDescriptionList.class);
-    assertThat(descriptionList.getSourceDescriptions().size(), equalTo(2));
-    assertThat(
-        descriptionList.getSourceDescriptions(),
-        hasItem(
-            new SourceDescription(
-                testResource.getKsqlEngine().getMetaStore().getSource("TEST_STREAM"),
-                true, "JSON", Collections.emptyList(), Collections.emptyList(),
-                kafkaTopicClient)));
-    assertThat(
-        descriptionList.getSourceDescriptions(),
-        hasItem(
-            new SourceDescription(
-                testResource.getKsqlEngine().getMetaStore().getSource("new_stream"),
-                true, "JSON", Collections.emptyList(), Collections.emptyList(),
-                kafkaTopicClient)));
+        "SHOW STREAMS EXTENDED;", SourceDescriptionList.class);
+
+    // Then:
+    assertThat(descriptionList.getSourceDescriptions(), containsInAnyOrder(
+        new SourceDescription(
+            ksqlEngine.getMetaStore().getSource("TEST_STREAM"),
+            true, "JSON", Collections.emptyList(), Collections.emptyList(),
+            kafkaTopicClient),
+        new SourceDescription(
+            ksqlEngine.getMetaStore().getSource("new_stream"),
+            true, "JSON", Collections.emptyList(), Collections.emptyList(),
+            kafkaTopicClient)));
   }
 
   @Test
   public void shouldReturnDescriptionsForShowTablesExtended() {
-    final KsqlResource testResource = TestKsqlResourceUtil.get(ksqlConfig, ksqlEngine);
-
+    // Given:
     final Schema schema = SchemaBuilder.struct()
         .field("FIELD1", Schema.OPTIONAL_BOOLEAN_SCHEMA)
         .field("FIELD2", Schema.OPTIONAL_STRING_SCHEMA);
-    TestKsqlResourceUtil.addSource(
-        testResource.getKsqlEngine().getMetaStore(), testResource.getKsqlEngine().getTopicClient(),
+
+    ensureSource(
         DataSource.DataSourceType.KTABLE, "new_table", "new_topic",
         "new_ksql_topic", schema);
 
-    final String ksqlString = "SHOW TABLES EXTENDED;";
+    // When:
     final SourceDescriptionList descriptionList = makeSingleRequest(
-        testResource, ksqlString, Collections.emptyMap(), SourceDescriptionList.class);
-    assertThat(descriptionList.getSourceDescriptions().size(), equalTo(2));
-    assertThat(
-        descriptionList.getSourceDescriptions(),
-        hasItem(
-            new SourceDescription(
-                testResource.getKsqlEngine().getMetaStore().getSource("TEST_TABLE"),
-                true, "JSON", Collections.emptyList(), Collections.emptyList(),
-                kafkaTopicClient)));
-    assertThat(
-        descriptionList.getSourceDescriptions(),
-        hasItem(
-             new SourceDescription(
-                testResource.getKsqlEngine().getMetaStore().getSource("new_table"),
-                 true, "JSON", Collections.emptyList(), Collections.emptyList(),
-                kafkaTopicClient)));
+        "SHOW TABLES EXTENDED;", SourceDescriptionList.class);
+
+    // Then:
+    assertThat(descriptionList.getSourceDescriptions(), containsInAnyOrder(
+        new SourceDescription(
+            ksqlEngine.getMetaStore().getSource("TEST_TABLE"),
+            true, "JSON", Collections.emptyList(), Collections.emptyList(),
+            kafkaTopicClient),
+        new SourceDescription(
+            ksqlEngine.getMetaStore().getSource("new_table"),
+            true, "JSON", Collections.emptyList(), Collections.emptyList(),
+            kafkaTopicClient)));
   }
 
   @Test
   public void shouldReturnDescriptionsForShowQueriesExtended() {
-    final KsqlResource testResource = TestKsqlResourceUtil.get(ksqlConfig, ksqlEngine);
-
+    // Given:
     final Map<String, Object> overriddenProperties =
         Collections.singletonMap("ksql.streams.auto.offset.reset", "earliest");
-    final List<QueryMetadata> queryMetadata = ksqlEngine.buildMultipleQueries(
+
+    final List<PersistentQueryMetadata> queryMetadata = createQueries(
         "CREATE STREAM test_describe_1 AS SELECT * FROM test_stream;" +
-            "CREATE STREAM test_describe_2 AS SELECT * FROM test_stream;",
-        ksqlConfig, overriddenProperties);
+            "CREATE STREAM test_describe_2 AS SELECT * FROM test_stream;", overriddenProperties);
 
-    final String ksqlString = "SHOW QUERIES EXTENDED;";
+    // When:
     final QueryDescriptionList descriptionList = makeSingleRequest(
-        testResource, ksqlString, Collections.emptyMap(), QueryDescriptionList.class);
-    assertThat(descriptionList.getQueryDescriptions().size(), equalTo(2));
-    assertThat(
-        descriptionList.getQueryDescriptions(),
-        hasItem(QueryDescription.forQueryMetadata(queryMetadata.get(0))));
-    assertThat(
-        descriptionList.getQueryDescriptions(),
-        hasItem(QueryDescription.forQueryMetadata(queryMetadata.get(1))));
+        "SHOW QUERIES EXTENDED;", QueryDescriptionList.class);
+
+    // Then:
+    assertThat(descriptionList.getQueryDescriptions(), containsInAnyOrder(
+        QueryDescription.forQueryMetadata(queryMetadata.get(0)),
+        QueryDescription.forQueryMetadata(queryMetadata.get(1))));
   }
 
   @Test
-  public void testDescribeStatement() {
-    final KsqlResource testResource = TestKsqlResourceUtil.get(ksqlConfig, ksqlEngine);
+  public void shouldDescribeStatement() {
+    // Given:
+    final List<RunningQuery> queries = createRunningQueries(
+        "CREATE STREAM described_stream AS SELECT * FROM test_stream;"
+            + "CREATE STREAM down_stream AS SELECT * FROM described_stream;",
+        Collections.emptyMap());
 
-    final List<QueryMetadata> queries = ksqlEngine.buildMultipleQueries(
-        "CREATE STREAM described_stream AS SELECT * FROM test_stream;" +
-            "CREATE STREAM down_stream AS SELECT * FROM described_stream;",
-         ksqlConfig, Collections.emptyMap());
-    final String streamName = "DESCRIBED_STREAM";
-    final String ksqlString = String.format("DESCRIBE %s;", streamName);
-    final SourceDescriptionEntity testDescription = makeSingleRequest(
-        testResource,
-        ksqlString,
-        Collections.emptyMap(),
-        SourceDescriptionEntity.class);
+    // When:
+    final SourceDescriptionEntity description = makeSingleRequest(
+        "DESCRIBE DESCRIBED_STREAM;", SourceDescriptionEntity.class);
 
-    final List<RunningQuery> writeQueries = Collections.singletonList(
-        new RunningQuery(
-            queries.get(0).getStatementString(),
-            ((PersistentQueryMetadata)queries.get(0)).getSinkNames(),
-            new EntityQueryId(
-                ((PersistentQueryMetadata)queries.get(0)).getQueryId())));
-    final List<RunningQuery> readQueries = Collections.singletonList(
-        new RunningQuery(
-            queries.get(1).getStatementString(),
-            ((PersistentQueryMetadata)queries.get(1)).getSinkNames(),
-            new EntityQueryId(
-                ((PersistentQueryMetadata)queries.get(1)).getQueryId())));
-    final SourceDescription expectedDescription =
-        new SourceDescription(
-            testResource.getKsqlEngine().getMetaStore().getSource(streamName), false, "JSON",
-            readQueries, writeQueries,null);
-    assertEquals(expectedDescription, testDescription.getSourceDescription());
+    // Then:
+    final SourceDescription expectedDescription = new SourceDescription(
+        ksqlEngine.getMetaStore().getSource("DESCRIBED_STREAM"), false, "JSON",
+        Collections.singletonList(queries.get(1)), Collections.singletonList(queries.get(0)), null);
+
+    assertThat(description.getSourceDescription(), is(expectedDescription));
   }
 
   @Test
-  public void testListStreamsStatement() {
-    final KsqlResource testResource = TestKsqlResourceUtil.get(ksqlConfig, ksqlEngine);
-    final String ksqlString = "LIST STREAMS;";
+  public void shouldListStreamsStatement() {
+    // When:
+    final StreamsList streamsList = makeSingleRequest("LIST STREAMS;", StreamsList.class);
 
-    final StreamsList streamsList = makeSingleRequest(
-        testResource,
-        ksqlString,
-        Collections.emptyMap(),
-        StreamsList.class
-    );
-
-    final List<SourceInfo.Stream> testStreams = streamsList.getStreams();
-    assertEquals(1, testStreams.size());
-
-    final SourceInfo expectedStream =
-        new SourceInfo.Stream((KsqlStream) testResource.getKsqlEngine().getMetaStore().getSource("TEST_STREAM"));
-
-    assertEquals(expectedStream, testStreams.get(0));
+    // Then:
+    assertThat(streamsList.getStreams(), contains(sourceStream("TEST_STREAM")));
   }
 
   @Test
-  public void testListTablesStatement() {
-    final KsqlResource testResource = TestKsqlResourceUtil.get(ksqlConfig, ksqlEngine);
-    final String ksqlString = "LIST TABLES;";
+  public void shouldListTablesStatement() {
+    // When:
+    final TablesList tablesList = makeSingleRequest("LIST TABLES;", TablesList.class);
 
-    final TablesList tablesList = makeSingleRequest(
-        testResource,
-        ksqlString,
-        Collections.emptyMap(),
-        TablesList.class
-    );
-
-    final List<SourceInfo.Table> testTables = tablesList.getTables();
-    assertEquals(1, testTables.size());
-
-    final SourceInfo expectedTable =
-        new SourceInfo.Table((KsqlTable) testResource.getKsqlEngine().getMetaStore().getSource("TEST_TABLE"));
-
-    assertEquals(expectedTable, testTables.get(0));
-  }
-
-  private Response handleKsqlStatements(final KsqlResource ksqlResource, final KsqlRequest ksqlRequest) {
-    try {
-      return ksqlResource.handleKsqlStatements(ksqlRequest);
-    } catch (final Throwable t) {
-      return new KsqlExceptionMapper().toResponse(t);
-    }
+    // Then:
+    assertThat(tablesList.getTables(), contains(sourceTable("TEST_TABLE")));
   }
 
   @Test
   public void shouldFailForIncorrectCSASStatementResultType() {
-    final KsqlResource testResource = TestKsqlResourceUtil.get(ksqlConfig, ksqlEngine);
-    final String ksqlString1 = "CREATE STREAM s1 AS SELECT * FROM test_table;";
+    // When:
+    final KsqlErrorMessage result = makeFailingRequest(
+        "CREATE STREAM s1 AS SELECT * FROM test_table;", Code.BAD_REQUEST);
 
-    final Response response1 = handleKsqlStatements(
-        testResource, new KsqlRequest(ksqlString1, new HashMap<>()));
-    assertThat(response1.getStatus(), equalTo(Response.Status.BAD_REQUEST.getStatusCode()));
-    assertThat(response1.getEntity(), instanceOf(KsqlErrorMessage.class));
-    final KsqlErrorMessage result1 = (KsqlErrorMessage) response1.getEntity();
-    assertThat(
-        "",
-        result1.getMessage(),
-        equalTo(
-            "Invalid result type. Your SELECT query produces a TABLE. " +
-                "Please use CREATE TABLE AS SELECT statement instead."));
+    // Then:
+    assertThat(result.getMessage(), is(
+        "Invalid result type. Your SELECT query produces a TABLE. " +
+            "Please use CREATE TABLE AS SELECT statement instead."));
+  }
 
-    final String ksqlString2 = "CREATE STREAM s2 AS SELECT S2_F1 , count(S2_F1) FROM test_stream group by "
-                         + "s2_f1;";
+  @Test
+  public void shouldFailForIncorrectCSASStatementResultTypeWithGroupBy() {
+    // When:
+    final KsqlErrorMessage result = makeFailingRequest(
+        "CREATE STREAM s2 AS SELECT S2_F1, count(S2_F1) FROM test_stream group by s2_f1;",
+        Code.BAD_REQUEST);
 
-    final Response response2 = handleKsqlStatements(
-        testResource, new KsqlRequest(ksqlString2, new HashMap<>()));
-    assertThat(response2.getStatus(), equalTo(Response.Status.BAD_REQUEST.getStatusCode()));
-    assertThat(response2.getEntity(), instanceOf(KsqlErrorMessage.class));
-    final KsqlErrorMessage result2 = (KsqlErrorMessage) response2.getEntity();
-    assertThat(
-        "",
-        result2.getMessage(),
-        equalTo(
-            "Invalid result type. Your SELECT query produces a TABLE. " +
+    // Then:
+    assertThat(result.getMessage(), is(
+        "Invalid result type. Your SELECT query produces a TABLE. " +
             "Please use CREATE TABLE AS SELECT statement instead."));
   }
 
   @Test
   public void shouldFailForIncorrectCTASStatementResultType() {
-    final KsqlResource testResource = TestKsqlResourceUtil.get(ksqlConfig, ksqlEngine);
-    final String ksqlString = "CREATE TABLE s1 AS SELECT * FROM test_stream;";
+    // When:
+    final KsqlErrorMessage result = makeFailingRequest(
+        "CREATE TABLE s1 AS SELECT * FROM test_stream;", Code.BAD_REQUEST);
 
-    final Response response = handleKsqlStatements(
-        testResource, new KsqlRequest(ksqlString, new HashMap<>()));
-    assertThat(response.getStatus(), equalTo(Response.Status.BAD_REQUEST.getStatusCode()));
-    assertThat(response.getEntity(), instanceOf(KsqlErrorMessage.class));
-    final KsqlErrorMessage result = (KsqlErrorMessage) response.getEntity();
-    assertThat(
-        result.getMessage(),
-        containsString(
-            "Invalid result type. Your SELECT query produces a STREAM. "
-                + "Please use CREATE STREAM AS SELECT statement instead."));
+    // Then:
+    assertThat(result.getMessage(), containsString(
+        "Invalid result type. Your SELECT query produces a STREAM. "
+            + "Please use CREATE STREAM AS SELECT statement instead."));
   }
 
   @Test
   public void shouldFailForIncorrectDropStreamStatement() {
-    final KsqlResource testResource = TestKsqlResourceUtil.get(ksqlConfig, ksqlEngine);
-    final String ksqlString = "DROP TABLE test_stream;";
-    final Response response = handleKsqlStatements(
-        testResource, new KsqlRequest(ksqlString, new HashMap<>()));
-    assertThat(response.getStatus(), equalTo(Response.Status.BAD_REQUEST.getStatusCode()));
-    assertThat(response.getEntity(), instanceOf(KsqlErrorMessage.class));
-    final KsqlErrorMessage result = (KsqlErrorMessage) response.getEntity();
-    assertThat(
-        result.getMessage().toLowerCase(),
-        equalTo("incompatible data source type is stream, but statement was drop table"));
+    // When:
+    final KsqlErrorMessage result = makeFailingRequest(
+        "DROP TABLE test_stream;", Code.BAD_REQUEST);
+
+    // Then:
+    assertThat(result.getMessage().toLowerCase(),
+        is("incompatible data source type is stream, but statement was drop table"));
   }
 
   @Test
   public void shouldFailForIncorrectDropTableStatement() {
-    final KsqlResource testResource = TestKsqlResourceUtil.get(ksqlConfig, ksqlEngine);
-    final String ksqlString = "DROP STREAM test_table;";
-    final Response response = handleKsqlStatements(
-        testResource, new KsqlRequest(ksqlString, new HashMap<>()));
-    assertThat(response.getStatus(), equalTo(Response.Status.BAD_REQUEST.getStatusCode()));
-    assertThat(response.getEntity(), instanceOf(KsqlErrorMessage.class));
-    final KsqlErrorMessage result = (KsqlErrorMessage) response.getEntity();
+    // When:
+    final KsqlErrorMessage result = makeFailingRequest(
+        "DROP STREAM test_table;", Code.BAD_REQUEST);
+
+    // Then:
     assertThat(result.getMessage().toLowerCase(),
-        equalTo("incompatible data source type is table, but statement was drop stream"));
+        is("incompatible data source type is table, but statement was drop stream"));
   }
 
-  @Test
-  public void shouldDistributeStatementWithConfig() {
-    final String ksqlString =
-        "CREATE TABLE ORDERS " +
-            "(ORDERTIME BIGINT, ORDERID BIGINT, ITEMID STRING, ORDERUNITS DOUBLE, " +
-            "ARRAYCOL ARRAY<DOUBLE>, MAPCOL MAP<VARCHAR, DOUBLE>) " +
-            "WITH (KAFKA_TOPIC='orders-topic', VALUE_FORMAT='avro', " +
-            "AVRO_SCHEMA_ID='1', KEY='orderid');";
-
-    final CommandId commandId = new CommandId("TABLE", "orders", "CREATE");
-    final QueuedCommandStatus queuedCommandStatus
-        = new QueuedCommandStatus(commandId);
-    final CommandStatus successStatus
-        = new CommandStatus(CommandStatus.Status.SUCCESS, "success");
-    queuedCommandStatus.setFinalStatus(successStatus);
-    final CommandStore commandStore = EasyMock.mock(CommandStore.class);
-    EasyMock.expect(commandStore.enqueueCommand(
-        EasyMock.eq(ksqlString), EasyMock.anyObject(Statement.class),
-        EasyMock.same(ksqlConfig), EasyMock.anyObject(Map.class)))
-        .andReturn(queuedCommandStatus);
-    EasyMock.replay(commandStore);
-
-    final KsqlResource testResource = TestKsqlResourceUtil.get(
-        ksqlConfig, ksqlEngine, commandStore);
-
-    handleKsqlStatements(
-        testResource, new KsqlRequest(ksqlString, new HashMap<>()));
-
-    EasyMock.verify(commandStore);
-  }
-
-  @SuppressWarnings("unchecked")
   @Test
   public void shouldCreateTableWithInference() {
-    final String ksqlString = "CREATE TABLE orders WITH (KAFKA_TOPIC='orders-topic', "
-        + "VALUE_FORMAT = 'avro', KEY = 'orderid');";
+    // Given:
+    final QueuedCommandStatus queuedCommandStatus
+        = new QueuedCommandStatus(new CommandId("TABLE", "orders", "CREATE"));
+    queuedCommandStatus.setFinalStatus(
+        new CommandStatus(CommandStatus.Status.SUCCESS, "success"));
+
     final String ksqlStringWithSchema =
         "CREATE TABLE ORDERS " +
             "(ORDERTIME BIGINT, ORDERID BIGINT, ITEMID STRING, ORDERUNITS DOUBLE, " +
@@ -679,80 +402,392 @@ public class KsqlResourceTest {
             "WITH (KAFKA_TOPIC='orders-topic', VALUE_FORMAT='avro', " +
             "AVRO_SCHEMA_ID='1', KEY='orderid');";
 
-    final CommandId commandId = new CommandId("TABLE", "orders", "CREATE");
-    final QueuedCommandStatus queuedCommandStatus
-        = new QueuedCommandStatus(commandId);
-    final CommandStatus successStatus =
-        new CommandStatus(CommandStatus.Status.SUCCESS, "success");
-    queuedCommandStatus.setFinalStatus(successStatus);
-    final CommandStore commandStore = EasyMock.mock(CommandStore.class);
-    EasyMock.expect(commandStore.enqueueCommand(
+    EasyMock.expect(mockCommandStore.enqueueCommand(
         EasyMock.eq(ksqlStringWithSchema), EasyMock.anyObject(Statement.class),
         EasyMock.same(ksqlConfig), EasyMock.anyObject(Map.class)))
         .andReturn(queuedCommandStatus);
-    final StatementExecutor statementExecutor = EasyMock.mock(StatementExecutor.class);
-    EasyMock.replay(commandStore, statementExecutor);
 
-    final KsqlResource testResource = TestKsqlResourceUtil.get(
-        ksqlConfig, ksqlEngine, commandStore);
+    EasyMock.replay(mockCommandStore);
 
-    final Response response = handleKsqlStatements(
-        testResource, new KsqlRequest(ksqlString, new HashMap<>()));
-    final KsqlEntityList result = (KsqlEntityList) response.getEntity();
-    assertThat("Incorrect response.", result.size(), equalTo(1));
-    assertThat(result.get(0), instanceOf(CommandStatusEntity.class));
-    final CommandStatusEntity commandStatusEntity = (CommandStatusEntity) result.get(0);
-    assertThat(
-        commandStatusEntity.getCommandId().getType().name().toUpperCase(),
-        equalTo("TABLE"));
+    givenKsqlResourceWith(ksqlConfig, ksqlEngine, mockCommandStore);
 
-    EasyMock.verify(commandStore, statementExecutor);
+    // When:
+    final CommandStatusEntity result = makeSingleRequest(
+        "CREATE TABLE orders WITH (KAFKA_TOPIC='orders-topic', VALUE_FORMAT='avro', KEY='orderid');",
+        CommandStatusEntity.class);
+
+    // Then:
+    assertThat(result.getCommandId().getType().name().toUpperCase(), is("TABLE"));
+    EasyMock.verify(mockCommandStore);
   }
 
   @Test
   public void shouldFailCreateTableWithInferenceWithIncorrectKey() {
-    final KsqlResource testResource = TestKsqlResourceUtil.get(ksqlConfig, ksqlEngine);
-    final String ksqlString = "CREATE TABLE orders WITH (KAFKA_TOPIC='orders-topic', "
-                              + "VALUE_FORMAT = 'avro', KEY = 'orderid1');";
+    // When:
+    final KsqlErrorMessage response = makeFailingRequest(
+        "CREATE TABLE orders WITH (KAFKA_TOPIC='orders-topic', "
+            + "VALUE_FORMAT = 'avro', KEY = 'orderid1');",
+        Code.BAD_REQUEST);
 
-    final Response response = handleKsqlStatements(
-        testResource, new KsqlRequest(ksqlString, new HashMap<>()));
-    assertThat(response.getStatus(), equalTo(Response.Status.BAD_REQUEST.getStatusCode()));
-    assertThat(response.getEntity(), instanceOf(KsqlStatementErrorMessage.class));
-    final KsqlStatementErrorMessage result = (KsqlStatementErrorMessage)response.getEntity();
-    assertThat(result.getErrorCode(), equalTo(Errors.ERROR_CODE_BAD_STATEMENT));
+    // Then:
+    assertThat(response, instanceOf(KsqlStatementErrorMessage.class));
+    assertThat(response.getErrorCode(), is(Errors.ERROR_CODE_BAD_STATEMENT));
   }
 
   @Test
   public void shouldFailBareQuery() {
-    final KsqlResource testResource = TestKsqlResourceUtil.get(ksqlConfig, ksqlEngine);
-    final String ksqlString = "SELECT * FROM test_table;";
-    final Response response = handleKsqlStatements(
-        testResource, new KsqlRequest(ksqlString, new HashMap<>()));
-    assertThat(response.getStatus(), equalTo(Response.Status.BAD_REQUEST.getStatusCode()));
-    assertThat(response.getEntity(), instanceOf(KsqlStatementErrorMessage.class));
-    final KsqlStatementErrorMessage result = (KsqlStatementErrorMessage)response.getEntity();
-    assertThat(result.getErrorCode(), equalTo(Errors.ERROR_CODE_QUERY_ENDPOINT));
+    // When:
+    final KsqlErrorMessage result = makeFailingRequest(
+        "SELECT * FROM test_table;", Code.BAD_REQUEST);
+
+    // Then:
+    assertThat(result, is(instanceOf(KsqlStatementErrorMessage.class)));
+    assertThat(result.getErrorCode(), is(Errors.ERROR_CODE_QUERY_ENDPOINT));
   }
 
   @Test
   public void shouldFailPrintTopic() {
-    final KsqlResource testResource = TestKsqlResourceUtil.get(ksqlConfig, ksqlEngine);
-    final String ksqlString = "PRINT 'orders-topic';";
-    final Response response = handleKsqlStatements(
-        testResource, new KsqlRequest(ksqlString, new HashMap<>()));
-    assertThat(response.getStatus(), equalTo(Response.Status.BAD_REQUEST.getStatusCode()));
-    assertThat(response.getEntity(), instanceOf(KsqlStatementErrorMessage.class));
-    final KsqlStatementErrorMessage result = (KsqlStatementErrorMessage)response.getEntity();
-    assertThat(result.getErrorCode(), equalTo(Errors.ERROR_CODE_QUERY_ENDPOINT));
+    // When:
+    final KsqlErrorMessage result = makeFailingRequest("PRINT 'orders-topic';", Code.BAD_REQUEST);
+
+    // Then:
+    assertThat(result, is(instanceOf(KsqlStatementErrorMessage.class)));
+    assertThat(result.getErrorCode(), is(Errors.ERROR_CODE_QUERY_ENDPOINT));
   }
 
+  @Test
+  public void shouldFillExplainQueryWithCorrectInfo() {
+    // Given:
+    final String ksqlQueryString = "SELECT * FROM test_stream;";
+    final String ksqlString = "EXPLAIN " + ksqlQueryString;
+
+    // When:
+    final QueryDescriptionEntity query = makeSingleRequest(
+        ksqlString, QueryDescriptionEntity.class);
+
+    // Then:
+    validateQueryDescription(ksqlQueryString, Collections.emptyMap(), query);
+  }
+
+  @Test
+  public void shouldFillExplainQueryByIDWithCorrectInfo() {
+    // Given:
+    final Map<String, Object> overriddenProperties =
+        Collections.singletonMap("ksql.streams.auto.offset.reset", "earliest");
+
+    final PersistentQueryMetadata queryMetadata = createQuery(
+        "CREATE STREAM test_explain AS SELECT * FROM test_stream;",
+        overriddenProperties);
+
+    // When:
+    final QueryDescriptionEntity query = makeSingleRequest(
+        "EXPLAIN " + queryMetadata.getQueryId() + ";", QueryDescriptionEntity.class);
+
+    // Then:
+    validateQueryDescription(queryMetadata, overriddenProperties, query);
+  }
+
+  @Test
+  public void shouldReturn5xxOnSystemError() {
+    // Given:
+    final KsqlEngine mockEngine = givenMockEngine(engine ->
+        EasyMock.expect(engine.getStatements(EasyMock.anyString()))
+            .andThrow(new RuntimeException("internal error")));
+
+    // When:
+    final KsqlErrorMessage result = makeFailingRequest(
+        "CREATE STREAM test_explain AS SELECT * FROM test_stream;",
+        Code.INTERNAL_SERVER_ERROR);
+
+    // Then:
+    assertThat(result.getErrorCode(), is(Errors.ERROR_CODE_SERVER_ERROR));
+    assertThat(result.getMessage(), containsString("internal error"));
+    EasyMock.verify(mockEngine);
+  }
+
+  @Test
+  public void shouldReturn5xxOnStatementSystemError() {
+    // Given:
+    final String ksqlString = "CREATE STREAM test_explain AS SELECT * FROM test_stream;";
+    final KsqlEngine mockEngine = givenMockEngine(engine -> {
+      EasyMock.expect(engine.getStatements(EasyMock.anyString()))
+          .andReturn(ksqlEngine.getStatements(ksqlString));
+
+      EasyMock.expect(engine.getQueryExecutionPlan(EasyMock.anyObject(), EasyMock.anyObject()))
+          .andThrow(new RuntimeException("internal error"));
+    });
+
+    // Then:
+    final KsqlErrorMessage result = makeFailingRequest(
+        ksqlString, Code.INTERNAL_SERVER_ERROR);
+
+    // Then:
+    assertThat(result.getErrorCode(), is(Errors.ERROR_CODE_SERVER_ERROR));
+    assertThat(result.getMessage(), containsString("internal error"));
+    EasyMock.verify(mockEngine);
+  }
+
+  @Test
+  public void shouldListPropertiesWithOverrides() {
+    // Given:
+    final Map<String, Object> overrides = Collections.singletonMap("auto.offset.reset", "latest");
+
+    // When:
+    final PropertiesList props = makeSingleRequest(
+        new KsqlRequest("list properties;", overrides), PropertiesList.class);
+
+    // Then:
+    assertThat(props.getProperties().get("ksql.streams.auto.offset.reset"), is("latest"));
+    assertThat(props.getOverwrittenProperties(), hasItem("ksql.streams.auto.offset.reset"));
+  }
+
+  @Test
+  public void shouldListPropertiesWithNoOverrides() {
+    // When:
+    final PropertiesList props = makeSingleRequest("list properties;", PropertiesList.class);
+
+    // Then:
+    assertThat(props.getOverwrittenProperties(), is(empty()));
+  }
+
+  @Test
+  public void shouldListDefaultKsqlProperty() {
+    // Given:
+    givenKsqlConfigWith(ImmutableMap.<String, Object>builder()
+        .put(StreamsConfig.STATE_DIR_CONFIG, "/tmp/kafka-streams")
+        .build());
+
+    // When:
+    final PropertiesList props = makeSingleRequest("list properties;", PropertiesList.class);
+
+    // Then:
+    assertThat(props.getDefaultProperties(),
+        hasItem(KsqlConfig.KSQL_STREAMS_PREFIX + StreamsConfig.STATE_DIR_CONFIG));
+  }
+
+  @Test
+  public void shouldListServerOverriddenKsqlProperty() {
+    // Given:
+    givenKsqlConfigWith(ImmutableMap.<String, Object>builder()
+        .put(StreamsConfig.STATE_DIR_CONFIG, "/tmp/other")
+        .build());
+
+    // When:
+    final PropertiesList props = makeSingleRequest("list properties;", PropertiesList.class);
+
+    // Then:
+    assertThat(props.getDefaultProperties(),
+        not(hasItem(containsString(StreamsConfig.STATE_DIR_CONFIG))));
+  }
+
+  @Test
+  public void shouldListDefaultStreamProperty() {
+    // Given:
+    givenKsqlConfigWith(ImmutableMap.<String, Object>builder()
+        .put(StreamsConfig.STATE_CLEANUP_DELAY_MS_CONFIG, STATE_CLEANUP_DELAY_MS_DEFAULT)
+        .build());
+
+    // When:
+    final PropertiesList props = makeSingleRequest("list properties;", PropertiesList.class);
+
+    // Then:
+    assertThat(props.getDefaultProperties(),
+        hasItem(KsqlConfig.KSQL_STREAMS_PREFIX + StreamsConfig.STATE_CLEANUP_DELAY_MS_CONFIG));
+  }
+
+  @Test
+  public void shouldListServerOverriddenStreamProperty() {
+    // Given:
+    givenKsqlConfigWith(ImmutableMap.<String, Object>builder()
+        .put(StreamsConfig.STATE_CLEANUP_DELAY_MS_CONFIG, STATE_CLEANUP_DELAY_MS_DEFAULT + 1)
+        .build());
+
+    // When:
+    final PropertiesList props = makeSingleRequest("list properties;", PropertiesList.class);
+
+    // Then:
+    assertThat(props.getDefaultProperties(),
+        not(hasItem(containsString(StreamsConfig.STATE_CLEANUP_DELAY_MS_CONFIG))));
+  }
+
+  @Test
+  public void shouldListDefaultConsumerConfig() {
+    // Given:
+    givenKsqlConfigWith(ImmutableMap.<String, Object>builder()
+        .put(KsqlConfig.KSQL_STREAMS_PREFIX + StreamsConfig.CONSUMER_PREFIX
+            + ConsumerConfig.FETCH_MIN_BYTES_CONFIG, FETCH_MIN_BYTES_DEFAULT)
+        .build());
+
+    // When:
+    final PropertiesList props = makeSingleRequest("list properties;", PropertiesList.class);
+
+    // Then:
+    assertThat(props.getDefaultProperties(),
+        hasItem(KsqlConfig.KSQL_STREAMS_PREFIX + StreamsConfig.CONSUMER_PREFIX
+            + ConsumerConfig.FETCH_MIN_BYTES_CONFIG));
+  }
+
+  @Test
+  public void shouldListServerOverriddenConsumerConfig() {
+    // Given:
+    givenKsqlConfigWith(ImmutableMap.<String, Object>builder()
+        .put(KsqlConfig.KSQL_STREAMS_PREFIX + StreamsConfig.CONSUMER_PREFIX
+            + ConsumerConfig.FETCH_MIN_BYTES_CONFIG, FETCH_MIN_BYTES_DEFAULT + 1)
+        .build());
+
+    // When:
+    final PropertiesList props = makeSingleRequest("list properties;", PropertiesList.class);
+
+    // Then:
+    assertThat(props.getDefaultProperties(),
+        not(hasItem(containsString(ConsumerConfig.FETCH_MIN_BYTES_CONFIG))));
+  }
+
+  @Test
+  public void shouldListDefaultProducerConfig() {
+    // Given:
+    givenKsqlConfigWith(ImmutableMap.<String, Object>builder()
+        .put(StreamsConfig.PRODUCER_PREFIX + ProducerConfig.BUFFER_MEMORY_CONFIG,
+            BUFFER_MEMORY_DEFAULT)
+        .build());
+
+    // When:
+    final PropertiesList props = makeSingleRequest("list properties;", PropertiesList.class);
+
+    // Then:
+    assertThat(props.getDefaultProperties(),
+        hasItem(KsqlConfig.KSQL_STREAMS_PREFIX + StreamsConfig.PRODUCER_PREFIX
+            + ProducerConfig.BUFFER_MEMORY_CONFIG));
+  }
+
+  @Test
+  public void shouldListServerOverriddenProducerConfig() {
+    // Given:
+    givenKsqlConfigWith(ImmutableMap.<String, Object>builder()
+        .put(StreamsConfig.PRODUCER_PREFIX + ProducerConfig.BUFFER_MEMORY_CONFIG,
+            BUFFER_MEMORY_DEFAULT + 1)
+        .build());
+
+    // When:
+    final PropertiesList props = makeSingleRequest("list properties;", PropertiesList.class);
+
+    // Then:
+    assertThat(props.getDefaultProperties(),
+        not(hasItem(containsString(ProducerConfig.BUFFER_MEMORY_CONFIG))));
+  }
+
+  @Test
+  public void shouldNotIncludeSslPropertiesInListPropertiesOutput() {
+    // When:
+    final PropertiesList props = makeSingleRequest("list properties;", PropertiesList.class);
+
+    // Then:
+    assertThat(props.getProperties().keySet(),
+        not(hasItems(KsqlConfig.SSL_CONFIG_NAMES.toArray(new String[0]))));
+  }
+
+  @SuppressWarnings("SameParameterValue")
+  private SourceInfo.Table sourceTable(final String name) {
+    final KsqlTable table = (KsqlTable) ksqlResource
+        .getKsqlEngine().getMetaStore().getSource(name);
+    return new SourceInfo.Table(table);
+  }
+
+  @SuppressWarnings("SameParameterValue")
+  private SourceInfo.Stream sourceStream(final String name) {
+    final KsqlStream stream = (KsqlStream) ksqlResource
+        .getKsqlEngine().getMetaStore().getSource(name);
+    return new SourceInfo.Stream(stream);
+  }
+
+  private KsqlEngine givenMockEngine(final Consumer<KsqlEngine> mockInitializer) {
+    final KsqlEngine mockEngine = EasyMock.niceMock(KsqlEngine.class);
+    EasyMock.expect(mockEngine.getMetaStore()).andReturn(ksqlEngine.getMetaStore()).anyTimes();
+    EasyMock.expect(mockEngine.getTopicClient()).andReturn(ksqlEngine.getTopicClient()).anyTimes();
+    mockInitializer.accept(mockEngine);
+    EasyMock.replay(mockEngine);
+    givenKsqlResourceWith(ksqlConfig, mockEngine);
+    return mockEngine;
+  }
+
+  private List<PersistentQueryMetadata> createQueries(
+      final String sql,
+      final Map<String, Object> overriddenProperties) {
+    return ksqlEngine.buildMultipleQueries(sql, ksqlConfig, overriddenProperties)
+        .stream()
+        .map(PersistentQueryMetadata.class::cast)
+        .collect(Collectors.toList());
+  }
+
+  @SuppressWarnings("SameParameterValue")
+  private PersistentQueryMetadata createQuery(
+      final String ksqlQueryString,
+      final Map<String, Object> overriddenProperties) {
+    return createQueries(ksqlQueryString, overriddenProperties).get(0);
+  }
+
+  @SuppressWarnings("SameParameterValue")
+  private List<RunningQuery> createRunningQueries(
+      final String sql,
+      final Map<String, Object> overriddenProperties) {
+
+    return createQueries(sql, overriddenProperties)
+        .stream()
+        .map(md -> new RunningQuery(
+            md.getStatementString(),
+            md.getSinkNames(),
+            new EntityQueryId(md.getQueryId())))
+        .collect(Collectors.toList());
+  }
+
+  private void givenKsqlConfigWith(final Map<String, Object> additionalConfig) {
+    final Map<String, Object> config = ksqlRestConfig.getKsqlConfigProperties();
+    config.putAll(additionalConfig);
+    ksqlConfig = new KsqlConfig(config);
+
+    givenKsqlResourceWith(ksqlConfig, ksqlEngine);
+  }
+
+  private KsqlErrorMessage makeFailingRequest(final String ksql, final Code errorCode) {
+    try {
+      final Response response = ksqlResource.handleKsqlStatements(
+          new KsqlRequest(ksql, Collections.emptyMap()));
+      assertThat(response.getStatus(), is(errorCode.getCode()));
+      assertThat(response.getEntity(), instanceOf(KsqlErrorMessage.class));
+      return (KsqlErrorMessage) response.getEntity();
+    } catch (final Throwable t) {
+      return (KsqlErrorMessage) new KsqlExceptionMapper().toResponse(t).getEntity();
+    }
+  }
+
+  private <T extends KsqlEntity> T makeSingleRequest(
+      final String sql,
+      final Class<T> expectedEntityType) {
+    return makeSingleRequest(new KsqlRequest(sql, Collections.emptyMap()), expectedEntityType);
+  }
+
+  private <T extends KsqlEntity> T makeSingleRequest(
+      final KsqlRequest ksqlRequest,
+      final Class<T> expectedEntityType) {
+
+    final Response response = ksqlResource.handleKsqlStatements(ksqlRequest);
+
+    assertThat(response.getStatus(), is(Response.Status.OK.getStatusCode()));
+    assertThat(response.getEntity(), instanceOf(KsqlEntityList.class));
+    final KsqlEntityList entityList = (KsqlEntityList) response.getEntity();
+    assertThat(entityList, hasSize(1));
+    assertThat(entityList.get(0), instanceOf(expectedEntityType));
+    return expectedEntityType.cast(entityList.get(0));
+  }
+
+  @SuppressWarnings("SameParameterValue")
   private void validateQueryDescription(
       final String ksqlQueryString,
       final Map<String, Object> overriddenProperties,
       final KsqlEntity entity) {
-    final QueryMetadata queryMetadata = ksqlEngine.buildMultipleQueries(
-        ksqlQueryString, ksqlConfig, overriddenProperties).get(0);
+    final QueryMetadata queryMetadata = ksqlEngine
+        .buildMultipleQueries(ksqlQueryString, ksqlConfig, overriddenProperties).get(0);
+
     validateQueryDescription(queryMetadata, overriddenProperties, entity);
   }
 
@@ -763,202 +798,144 @@ public class KsqlResourceTest {
     assertThat(entity, instanceOf(QueryDescriptionEntity.class));
     final QueryDescriptionEntity queryDescriptionEntity = (QueryDescriptionEntity) entity;
     final QueryDescription queryDescription = queryDescriptionEntity.getQueryDescription();
-    assertThat(
-        queryDescription.getFields(),
-        equalTo(
-            EntityUtil.buildSourceSchemaEntity(
-                queryMetadata.getOutputNode().getSchema())
-        )
-    );
-    assertThat(
-        queryDescription.getOverriddenProperties(),
-        equalTo(overriddenProperties));
-  }
-
-  @Test
-  public void shouldFillExplainQueryWithCorrectInfo() {
-    final KsqlResource testResource = TestKsqlResourceUtil.get(ksqlConfig, ksqlEngine);
-    final String ksqlQueryString = "SELECT * FROM test_stream;";
-    final String ksqlString = "EXPLAIN " + ksqlQueryString;
-    final Response response = handleKsqlStatements(
-        testResource, new KsqlRequest(ksqlString, new HashMap<>()));
-    final KsqlEntityList result = (KsqlEntityList) response.getEntity();
-    assertThat("Response should have 1 entity", result.size(), equalTo(1));
-    validateQueryDescription(
-        ksqlQueryString,
-        Collections.emptyMap(),
-        result.get(0));
-  }
-
-  @Test
-  public void shouldFillExplainQueryByIDWithCorrectInfo() {
-    final KsqlResource testResource = TestKsqlResourceUtil.get(ksqlConfig, ksqlEngine);
-
-    final String ksqlQueryString = "CREATE STREAM test_explain AS SELECT * FROM test_stream;";
-    final Map<String, Object> overriddenProperties =
-        Collections.singletonMap("ksql.streams.auto.offset.reset", "earliest");
-    final PersistentQueryMetadata queryMetadata =
-        (PersistentQueryMetadata) ksqlEngine.buildMultipleQueries(
-            ksqlQueryString,
-            ksqlConfig, overriddenProperties).get(0);
-
-    final String ksqlString = "EXPLAIN " + queryMetadata.getQueryId() + ";";
-    final Response response = testResource.handleKsqlStatements(new KsqlRequest(ksqlString, new HashMap<>()));
-    final KsqlEntityList result = (KsqlEntityList) response.getEntity();
-    assertThat("Response should have 1 entity", result.size(), equalTo(1));
-    validateQueryDescription(queryMetadata, overriddenProperties, result.get(0));
-  }
-
-  @Test
-  public void shouldReturn5xxOnSystemError() {
-    final String ksqlString = "CREATE STREAM test_explain AS SELECT * FROM test_stream;";
-    // Set up a mock engine to mirror the returns of the real engine
-    final KsqlEngine mockEngine = EasyMock.niceMock(KsqlEngine.class);
-    EasyMock.expect(mockEngine.getMetaStore()).andReturn(ksqlEngine.getMetaStore()).anyTimes();
-    EasyMock.expect(mockEngine.getTopicClient()).andReturn(ksqlEngine.getTopicClient()).anyTimes();
-    EasyMock.expect(
-        mockEngine.getStatements(ksqlString)).andThrow(
-            new RuntimeException("internal error"));
-    EasyMock.replay(mockEngine);
-
-    final KsqlResource testResource = TestKsqlResourceUtil.get(ksqlConfig, mockEngine);
-    final Response response = handleKsqlStatements(
-        testResource, new KsqlRequest(ksqlString, Collections.emptyMap()));
-    assertThat(response.getStatus(), equalTo(Response.Status.INTERNAL_SERVER_ERROR.getStatusCode()));
-    assertThat(response.getEntity(), instanceOf(KsqlErrorMessage.class));
-    final KsqlErrorMessage result = (KsqlErrorMessage)response.getEntity();
-    assertThat(result.getErrorCode(), equalTo(Errors.ERROR_CODE_SERVER_ERROR));
-    assertThat(result.getMessage(), containsString("internal error"));
-
-    EasyMock.verify(mockEngine);
-  }
-
-  @Test
-  public void shouldReturn5xxOnStatementSystemError() {
-    final String ksqlString = "CREATE STREAM test_explain AS SELECT * FROM test_stream;";
-    // Set up a mock engine to mirror the returns of the real engine
-    final KsqlEngine mockEngine = EasyMock.niceMock(KsqlEngine.class);
-    EasyMock.expect(mockEngine.getMetaStore()).andReturn(ksqlEngine.getMetaStore()).anyTimes();
-    EasyMock.expect(mockEngine.getTopicClient()).andReturn(ksqlEngine.getTopicClient()).anyTimes();
-    EasyMock.replay(mockEngine);
-    final KsqlResource testResource = TestKsqlResourceUtil.get(ksqlConfig, mockEngine);
-
-    EasyMock.reset(mockEngine);
-    EasyMock.expect(
-        mockEngine.getStatements(ksqlString)).andReturn(ksqlEngine.getStatements(ksqlString));
-    EasyMock.expect(mockEngine.getQueryExecutionPlan(EasyMock.anyObject(), EasyMock.anyObject()))
-        .andThrow(new RuntimeException("internal error"));
-    EasyMock.replay(mockEngine);
-
-    final Response response = handleKsqlStatements(
-        testResource, new KsqlRequest(ksqlString, Collections.emptyMap()));
-    assertThat(response.getStatus(), equalTo(Response.Status.INTERNAL_SERVER_ERROR.getStatusCode()));
-    assertThat(response.getEntity(), instanceOf(KsqlErrorMessage.class));
-    final KsqlErrorMessage result = (KsqlStatementErrorMessage)response.getEntity();
-    assertThat(result.getErrorCode(), equalTo(Errors.ERROR_CODE_SERVER_ERROR));
-    assertThat(result.getMessage(), containsString("internal error"));
-
-    EasyMock.verify(mockEngine);
-  }
-
-  @Test
-  public void shouldListPropertiesWithOverrides() {
-    final String ksqlString = "list properties;";
-    final KsqlResource testResource = TestKsqlResourceUtil.get(ksqlConfig, ksqlEngine);
-    final Response response = handleKsqlStatements(
-        testResource,
-        new KsqlRequest(ksqlString, Collections.singletonMap("auto.offset.reset", "latest")));
-
-    assertThat(response.getStatus(), equalTo(Response.Status.OK.getStatusCode()));
-    assertThat(response.getEntity(), instanceOf(KsqlEntityList.class));
-    final KsqlEntityList entityList = (KsqlEntityList)response.getEntity();
-    assertThat(entityList.size(), equalTo(1));
-    assertThat(entityList.get(0), instanceOf(PropertiesList.class));
-    final PropertiesList propertiesList = (PropertiesList)entityList.get(0);
-    assertThat(
-        propertiesList.getProperties().get("ksql.streams.auto.offset.reset"),
-        equalTo("latest"));
-    assertThat(
-        propertiesList.getOverwrittenProperties(),
-        hasItem(equalTo("ksql.streams.auto.offset.reset")));
-  }
-
-  @Test
-  public void shouldListPropertiesWithNoOverrides() {
-    final String ksqlString = "list properties;";
-    final KsqlResource testResource = TestKsqlResourceUtil.get(ksqlConfig, ksqlEngine);
-    final Response response
-        = handleKsqlStatements(testResource, new KsqlRequest(ksqlString, Collections.emptyMap()));
-
-    assertThat(response.getStatus(), equalTo(Response.Status.OK.getStatusCode()));
-    assertThat(response.getEntity(), instanceOf(KsqlEntityList.class));
-    final KsqlEntityList entityList = (KsqlEntityList)response.getEntity();
-    assertThat(entityList.size(), equalTo(1));
-    assertThat(entityList.get(0), instanceOf(PropertiesList.class));
-    final PropertiesList propertiesList = (PropertiesList)entityList.get(0);
-    assertThat(propertiesList.getOverwrittenProperties(), is(empty()));
-  }
-
-  @Test
-  public void shouldListPropertiesWithDefault() {
-    final String ksqlString = "list properties;";
-    final Map<String, Object> originals = ksqlRestConfig.getKsqlConfigProperties();
-    originals.put(StreamsConfig.STATE_DIR_CONFIG, "/tmp/kafka-streams");  //<-default
-    originals.put(KsqlConfig.KSQL_STREAMS_PREFIX + StreamsConfig.CONSUMER_PREFIX
-        + ConsumerConfig.FETCH_MIN_BYTES_CONFIG, "101");
-    originals.put(StreamsConfig.PRODUCER_PREFIX
-        + ProducerConfig.BUFFER_MEMORY_CONFIG, "102");
-    originals.put(KsqlConfig.KSQL_STREAMS_PREFIX + StreamsConfig.CLIENT_ID_CONFIG, "custom-id");
-    originals.put(StreamsConfig.RETRIES_CONFIG, 69);
-    ksqlConfig = new KsqlConfig(originals);
-
-    final KsqlResource testResource = TestKsqlResourceUtil.get(ksqlConfig, ksqlEngine);
-    final Response response = handleKsqlStatements(
-        testResource, new KsqlRequest(ksqlString, Collections.emptyMap()));
-
-    assertThat(response.getStatus(), equalTo(Response.Status.OK.getStatusCode()));
-    assertThat(response.getEntity(), instanceOf(KsqlEntityList.class));
-    final KsqlEntityList entityList = (KsqlEntityList)response.getEntity();
-    assertThat(entityList.size(), equalTo(1));
-    assertThat(entityList.get(0), instanceOf(PropertiesList.class));
-    final PropertiesList props = (PropertiesList)entityList.get(0);
-
-    assertThat(props.getDefaultProperties(),
-        hasItem(KsqlConfig.KSQL_STREAMS_PREFIX + StreamsConfig.STATE_DIR_CONFIG));
-
-    assertThat(props.getDefaultProperties(),
-        not(hasItem(KsqlConfig.KSQL_STREAMS_PREFIX + StreamsConfig.CONSUMER_PREFIX
-        + ConsumerConfig.FETCH_MIN_BYTES_CONFIG)));
-
-    assertThat(props.getDefaultProperties(),
-        not(hasItem(KsqlConfig.KSQL_STREAMS_PREFIX + StreamsConfig.PRODUCER_PREFIX
-            + ProducerConfig.BUFFER_MEMORY_CONFIG)));
-
-    assertThat(props.getDefaultProperties(),
-        not(hasItem(KsqlConfig.KSQL_STREAMS_PREFIX + StreamsConfig.CLIENT_ID_CONFIG)));
-
-    assertThat(props.getDefaultProperties(),
-        not(hasItem(KsqlConfig.KSQL_STREAMS_PREFIX + StreamsConfig.RETRIES_CONFIG)));
+    assertThat(queryDescription.getFields(), is(
+        EntityUtil.buildSourceSchemaEntity(queryMetadata.getOutputNode().getSchema())));
+    assertThat(queryDescription.getOverriddenProperties(), is(overriddenProperties));
   }
 
   private void registerSchema(final SchemaRegistryClient schemaRegistryClient)
       throws IOException, RestClientException {
     final String ordersAveroSchemaStr = "{"
-                                  + "\"namespace\": \"kql\","
-                                  + " \"name\": \"orders\","
-                                  + " \"type\": \"record\","
-                                  + " \"fields\": ["
-                                  + "     {\"name\": \"ordertime\", \"type\": \"long\"},"
-                                  + "     {\"name\": \"orderid\",  \"type\": \"long\"},"
-                                  + "     {\"name\": \"itemid\", \"type\": \"string\"},"
-                                  + "     {\"name\": \"orderunits\", \"type\": \"double\"},"
-                                  + "     {\"name\": \"arraycol\", \"type\": {\"type\": \"array\", \"items\": \"double\"}},"
-                                  + "     {\"name\": \"mapcol\", \"type\": {\"type\": \"map\", \"values\": \"double\"}}"
-                                  + " ]"
-                                  + "}";
+        + "\"namespace\": \"kql\","
+        + " \"name\": \"orders\","
+        + " \"type\": \"record\","
+        + " \"fields\": ["
+        + "     {\"name\": \"ordertime\", \"type\": \"long\"},"
+        + "     {\"name\": \"orderid\",  \"type\": \"long\"},"
+        + "     {\"name\": \"itemid\", \"type\": \"string\"},"
+        + "     {\"name\": \"orderunits\", \"type\": \"double\"},"
+        + "     {\"name\": \"arraycol\", \"type\": {\"type\": \"array\", \"items\": \"double\"}},"
+        + "     {\"name\": \"mapcol\", \"type\": {\"type\": \"map\", \"values\": \"double\"}}"
+        + " ]"
+        + "}";
     final org.apache.avro.Schema.Parser parser = new org.apache.avro.Schema.Parser();
     final org.apache.avro.Schema avroSchema = parser.parse(ordersAveroSchemaStr);
     schemaRegistryClient.register("orders-topic" + KsqlConstants.SCHEMA_REGISTRY_VALUE_SUFFIX,
-                                  avroSchema);
+        avroSchema);
+  }
+
+  private static class TestCommandProducer<K, V> extends KafkaProducer<K, V> {
+
+    private TestCommandProducer(final Map configs, final Serializer keySerializer,
+        final Serializer valueSerializer) {
+      super(configs, keySerializer, valueSerializer);
+    }
+
+    @Override
+    public Future<RecordMetadata> send(final ProducerRecord record) {
+      // Fake result: only for testing purpose
+      return ConcurrentUtils.constantFuture(new RecordMetadata(
+          null, 0L, 0L, 0L, 0L, 0, 0));
+    }
+  }
+
+  private void givenKsqlResourceWith(final KsqlConfig ksqlConfig, final KsqlEngine ksqlEngine) {
+    final Properties defaultKsqlConfig = getDefaultKsqlConfig();
+
+    final KafkaConsumer<CommandId, Command> commandConsumer = new KafkaConsumer<>(
+        defaultKsqlConfig,
+        getJsonDeserializer(CommandId.class, true),
+        getJsonDeserializer(Command.class, false)
+    );
+
+    final KafkaProducer<CommandId, Command> commandProducer = new TestCommandProducer<>(
+        defaultKsqlConfig,
+        getJsonSerializer(true),
+        getJsonSerializer(false)
+    );
+
+    final CommandStore commandStore = new CommandStore("__COMMANDS_TOPIC",
+        commandConsumer, commandProducer, new CommandIdAssigner(ksqlEngine.getMetaStore()));
+
+    givenKsqlResourceWith(ksqlConfig, ksqlEngine, commandStore);
+  }
+
+  private void givenKsqlResourceWith(
+      final KsqlConfig ksqlConfig,
+      final KsqlEngine ksqlEngine,
+      final CommandStore commandStore) {
+    ksqlResource = new KsqlResource(
+        ksqlConfig, ksqlEngine, commandStore, DISTRIBUTED_COMMAND_RESPONSE_TIMEOUT);
+  }
+
+  private static <T> Deserializer<T> getJsonDeserializer(final Class<T> type, final boolean isKey) {
+    final String typeConfigProperty = isKey
+        ? KafkaJsonDeserializerConfig.JSON_KEY_TYPE
+        : KafkaJsonDeserializerConfig.JSON_VALUE_TYPE;
+
+    final Deserializer<T> result = new KafkaJsonDeserializer<>();
+    result.configure(Collections.singletonMap(typeConfigProperty,type), isKey);
+    return result;
+  }
+
+  private static <T> Serializer<T> getJsonSerializer(final boolean isKey) {
+    final Serializer<T> result = new KafkaJsonSerializer<>();
+    result.configure(Collections.emptyMap(), isKey);
+    return result;
+  }
+
+  private void addTestTopicAndSources() {
+    final Schema schema1 = SchemaBuilder.struct().field("S1_F1", Schema.OPTIONAL_BOOLEAN_SCHEMA);
+    ensureSource(
+        DataSource.DataSourceType.KTABLE,
+        "TEST_TABLE", "KAFKA_TOPIC_1", "KSQL_TOPIC_1", schema1);
+    final Schema schema2 = SchemaBuilder.struct().field("S2_F1", Schema.OPTIONAL_STRING_SCHEMA);
+    ensureSource(
+        DataSource.DataSourceType.KSTREAM,
+        "TEST_STREAM", "KAFKA_TOPIC_2", "KSQL_TOPIC_2", schema2);
+    kafkaTopicClient.createTopic("orders-topic", 1, (short) 1);
+  }
+
+  private void ensureSource(
+      final DataSource.DataSourceType type,
+      final String sourceName,
+      final String topicName,
+      final String ksqlTopicName,
+      final Schema schema) {
+    final MetaStore metaStore = ksqlEngine.getMetaStore();
+    if (metaStore.getTopic(ksqlTopicName) != null) {
+      return;
+    }
+
+    final KsqlTopic ksqlTopic = new KsqlTopic(ksqlTopicName, topicName, new KsqlJsonTopicSerDe());
+    kafkaTopicClient.createTopic(topicName, 1, (short) 1);
+    metaStore.putTopic(ksqlTopic);
+    if (type == DataSource.DataSourceType.KSTREAM) {
+      metaStore.putSource(
+          new KsqlStream(
+              "statementText", sourceName, schema, schema.fields().get(0),
+              new MetadataTimestampExtractionPolicy(), ksqlTopic));
+    }
+    if (type == DataSource.DataSourceType.KTABLE) {
+      metaStore.putSource(
+          new KsqlTable(
+              "statementText", sourceName, schema, schema.fields().get(0),
+              new MetadataTimestampExtractionPolicy(), ksqlTopic, "statestore", false));
+    }
+  }
+
+  private static Properties getDefaultKsqlConfig() {
+    final Map<String, Object> configMap = new HashMap<>();
+    configMap.put(ConsumerConfig.BOOTSTRAP_SERVERS_CONFIG, "localhost:9092");
+    configMap.put("commit.interval.ms", 0);
+    configMap.put("cache.max.bytes.buffering", 0);
+    configMap.put("auto.offset.reset", "earliest");
+    configMap.put("ksql.command.topic.suffix", "commands");
+    configMap.put(RestConfig.LISTENERS_CONFIG, "http://localhost:8088");
+
+    final Properties properties = new Properties();
+    properties.putAll(configMap);
+
+    return properties;
   }
 }


### PR DESCRIPTION
### Description 
There are two changes in this PR. (Sorry! `KsqlResourceTest` was just annoying me ;)).
1. Hide the SSL configuration. It's no longer listed in `show properties` and can no longer be `set`.
1. Refactored `KsqlResourceTest` to make the tests more succinct / readable.

I also want to call out the change to `AvroUtil` where I've removed a line:

```
streamsProperties.put(DdlConfig.AVRO_SCHEMA, avroSchemaString);
```

I've removed it because:
- it smells: it's mutating a param passed in that comes from the top level `KsqlResource.handleKsqlStatements`, where it can modify the state passed to future calls.
- it doesn't seem that anything reads the property, ever.
- no tests fail when I remove it.

Let me know if you know of a reason why that's there!

### Testing done 
Tests + manual

### Reviewer checklist
- [ ] Ensure docs are updated if necessary. (eg. if a user visible feature is being added or changed).
- [ ] Ensure relevant issues are linked (description should include text like "Fixes #<issue number>")

