### PR TITLE
Simplify the method startRestServer() by replacing while loop.

### DIFF
--- a/ksql-rest-app/src/test/java/io/confluent/ksql/rest/integration/RestApiTest.java
+++ b/ksql-rest-app/src/test/java/io/confluent/ksql/rest/integration/RestApiTest.java
@@ -169,23 +169,24 @@ public class RestApiTest {
   }
 
   private static void startRestServer(Map<String, Object> configs) throws Exception {
-    int retries = NUM_RETRIES;
-    while (0 < retries) {
+    for (int tryIndex = 0; tryIndex < NUM_RETRIES; ++tryIndex) {
       try {
-        final int port = randomFreeLocalPort();
-        serverAddress = "http://localhost:" + port;
-        configs.put(RestConfig.LISTENERS_CONFIG, serverAddress);
-        restApplication = KsqlRestApplication.buildApplication(new KsqlRestConfig(configs),
-                                                               new DummyVersionCheckerAgent());
-        restApplication.start();
+        startRestServerOnce(configs);
         return;
       } catch (BindException e) {
         LOGGER.info("Failed to start rest server due to bind exception.", e);
-        retries--;
-        if (retries == 0) {
-          LOGGER.error("Could not start server after {} retries", NUM_RETRIES);
-        }
       }
     }
+    LOGGER.error("Could not start server after {} retries", NUM_RETRIES);
   }
+
+  private static void startRestServerOnce(Map<String, Object> configs) throws Exception {
+    final int port = randomFreeLocalPort();
+    serverAddress = "http://localhost:" + port;
+    configs.put(RestConfig.LISTENERS_CONFIG, serverAddress);
+    restApplication = KsqlRestApplication.buildApplication(new KsqlRestConfig(configs),
+                                                           new DummyVersionCheckerAgent());
+    restApplication.start();
+  }
+
 }


### PR DESCRIPTION
### Description 
**Problem:** The method `RestApiTest::startRestServer()` was more complex than required.
**Solution:** Replace the `for` loop with a `while` loop and extract a new helper method.

### Testing done 
 No new tests.

### Reviewer checklist
- [ ] Ensure docs are updated if necessary. (eg. if a user visible feature is being added or changed).
- [ ] Ensure relevant issues are linked (description should include text like "Fixes #<issue number>")


#### Request for your help
I work on semi-automatic refactoring pull requests.
If you want to help me help you, and you think this project will benefit from refactoring PRs, please click the link below.
[![Yes - I want a refactoring service](https://refactormachine.com/wp-content/uploads/2018/09/yes-e1537456577294.jpeg)](https://refactormachine.com/refactoring-pull-requests-yes/)
If this PR annoys you, please click on the link below, so I will stop doing it in other repos as well
[![No please - it annoys me](https://refactormachine.com/wp-content/uploads/2018/09/no-e1537456561421.jpeg)](https://refactormachine.com/free-refactoring-pull-requests-service-no/)
Assaf