### PR TITLE
Struct fields can be read as string.

### DIFF
--- a/ksql-engine/src/test/resources/query-validation-tests/simple-struct.json
+++ b/ksql-engine/src/test/resources/query-validation-tests/simple-struct.json
@@ -392,6 +392,248 @@
       ]
     },
     {
+      "format": ["JSON"],
+      "statements": [
+        "CREATE STREAM orders (ordertime bigint, orderid bigint, itemid VARCHAR, ORDERUNITS double, ARRAYCOL array<double>, MAPCOL map<varchar, double>, address STRUCT < number bigint, street varchar, city varchar, state varchar, zipcode bigint>) WITH (kafka_topic='test_topic', key='orderid', value_format='{FORMAT}');",
+        "CREATE STREAM s1 AS SELECT itemid, EXTRACTJSONFIELD(itemid, '$.ITEMID') FROM orders;"
+      ],
+      "name": "simple struct read struct as json string",
+      "inputs": [
+        {
+          "topic": "test_topic",
+          "timestamp": 0,
+          "value": {
+            "ORDERID": 1,
+            "ITEMID": {
+              "ITEMID": 6,
+              "CATEGORY": {
+                "ID": 2,
+                "NAME": "Food"
+              },
+              "NAME": "Item_6"
+            },
+            "ORDERTIME": 1528224275715,
+            "MAPCOL": {
+              "key3": 3.8688222734507915,
+              "key2": 5.878674158377773,
+              "key1": 2.706938954083115
+            },
+            "ORDERUNITS": 2.0,
+            "ADDRESS": {
+              "CITY": "CITY_0",
+              "STATE": "STATE_1",
+              "STREET": "STREET_4",
+              "NUMBER": 376,
+              "ZIPCODE": 621
+            },
+            "ARRAYCOL": [
+              6.27276558443913,
+              8.720822816653817,
+              4.904955205015469,
+              0.28466518164817933,
+              5.276269704236784
+            ]
+          },
+          "key": 0
+        },
+        {
+          "topic": "test_topic",
+          "timestamp": 0,
+          "value": {
+            "ORDERID": 2,
+            "ITEMID": {
+              "ITEMID": 6,
+              "CATEGORY": {
+                "ID": 2,
+                "NAME": "Produce"
+              },
+              "NAME": "Item_6"
+            },
+            "ORDERTIME": 1528224280668,
+            "MAPCOL": {
+              "key3": 0.08025583241041634,
+              "key2": 7.886688738692968,
+              "key1": 7.997268326700826
+            },
+            "ORDERUNITS": 4.0,
+            "ADDRESS": {
+              "CITY": "CITY_3",
+              "STATE": "STATE_6",
+              "STREET": "STREET_5",
+              "NUMBER": 29,
+              "ZIPCODE": 46
+            },
+            "ARRAYCOL": [
+              5.028181423106411,
+              4.223556791057725,
+              7.503771637501132,
+              1.8346470572995977,
+              8.628168574256188
+            ]
+          },
+          "key": 100
+        },
+        {
+          "topic": "test_topic",
+          "timestamp": 0,
+          "value": {
+            "ORDERID": 3,
+            "ITEMID": {
+              "ITEMID": 6,
+              "CATEGORY": {
+                "ID": 2,
+                "NAME": "Produce"
+              },
+              "NAME": "Item_6"
+            },
+            "ORDERTIME": 1528224281566,
+            "MAPCOL": {
+              "key3": 8.232202829012866,
+              "key2": 4.76749034853443,
+              "key1": 3.908548556676262
+            },
+            "ORDERUNITS": 6.0,
+            "ADDRESS": {
+              "CITY": "CITY_9",
+              "STATE": "STATE_9",
+              "STREET": "STREET_3",
+              "NUMBER": 219,
+              "ZIPCODE": 287
+            },
+            "ARRAYCOL": [
+              9.404053021473551,
+              2.005832055529364,
+              0.16252060679229574,
+              8.030440873506674,
+              2.6822009490877683
+            ]
+          },
+          "key": 101
+        },
+        {
+          "topic": "test_topic",
+          "timestamp": 0,
+          "value": {
+            "ORDERID": 4,
+            "ITEMID": {
+              "ITEMID": 2,
+              "CATEGORY": {
+                "ID": 1,
+                "NAME": "Food"
+              },
+              "NAME": "Item_2"
+            },
+            "ORDERTIME": 1528224285603,
+            "MAPCOL": {
+              "key3": 8.58507015716884,
+              "key2": 8.690191464522353,
+              "key1": 3.966253991851106
+            },
+            "ORDERUNITS": 3.0,
+            "ADDRESS": {
+              "CITY": "CITY_3",
+              "STATE": "STATE_5",
+              "STREET": "STREET_8",
+              "NUMBER": 380,
+              "ZIPCODE": 866
+            },
+            "ARRAYCOL": [
+              9.887072401304447,
+              5.217021497196517,
+              5.604857288119519,
+              4.628527278923561,
+              6.367135367927281
+            ]
+          },
+          "key": 101
+        },
+        {
+          "topic": "test_topic",
+          "timestamp": 0,
+          "value": {
+            "ORDERID": 5,
+            "ITEMID": {
+              "ITEMID": 5,
+              "CATEGORY": {
+                "ID": 1,
+                "NAME": "Produce"
+              },
+              "NAME": "Item_5"
+            },
+            "ORDERTIME": 1528224286568,
+            "MAPCOL": {
+              "key3": 4.9160189684727,
+              "key2": 1.3876747586974092,
+              "key1": 6.688854425726891
+            },
+            "ORDERUNITS": 5.0,
+            "ADDRESS": {
+              "CITY": "CITY_6",
+              "STATE": "STATE_3",
+              "STREET": "STREET_8",
+              "NUMBER": 294,
+              "ZIPCODE": 724
+            },
+            "ARRAYCOL": [
+              1.6856668854084866,
+              3.4970511301361484,
+              9.143163282671962,
+              2.196065628133206,
+              4.343961390870502
+            ]
+          },
+          "key": 101
+        }
+      ],
+      "outputs": [
+        {
+          "topic": "S1",
+          "timestamp": 0,
+          "value": {
+            "ITEMID": "{\"CATEGORY\":{\"ID\":2,\"NAME\":\"Food\"},\"ITEMID\":6,\"NAME\":\"Item_6\"}",
+            "KSQL_COL_1": "6"
+          },
+          "key": 0
+        },
+        {
+          "topic": "S1",
+          "timestamp": 0,
+          "value": {
+            "ITEMID": "{\"CATEGORY\":{\"ID\":2,\"NAME\":\"Produce\"},\"ITEMID\":6,\"NAME\":\"Item_6\"}",
+            "KSQL_COL_1": "6"
+          },
+          "key": 100
+        },
+        {
+          "topic": "S1",
+          "timestamp": 0,
+          "value": {
+            "ITEMID": "{\"CATEGORY\":{\"ID\":2,\"NAME\":\"Produce\"},\"ITEMID\":6,\"NAME\":\"Item_6\"}",
+            "KSQL_COL_1": "6"
+          },
+          "key": 101
+        },
+        {
+          "topic": "S1",
+          "timestamp": 0,
+          "value": {
+            "ITEMID": "{\"CATEGORY\":{\"ID\":1,\"NAME\":\"Food\"},\"ITEMID\":2,\"NAME\":\"Item_2\"}",
+            "KSQL_COL_1": "2"
+          },
+          "key": 101
+        },
+        {
+          "topic": "S1",
+          "timestamp": 0,
+          "value": {
+            "ITEMID":  "{\"CATEGORY\":{\"ID\":1,\"NAME\":\"Produce\"},\"ITEMID\":5,\"NAME\":\"Item_5\"}",
+            "KSQL_COL_1": "5"
+          },
+          "key": 101
+        }
+      ]
+    },
+    {
       "name": "simple struct select filter",
       "format": ["AVRO", "JSON"],
       "statements": [

--- a/ksql-serde/pom.xml
+++ b/ksql-serde/pom.xml
@@ -25,6 +25,11 @@
         </dependency>
 
         <dependency>
+            <groupId>com.google.code.gson</groupId>
+            <artifactId>gson</artifactId>
+        </dependency>
+
+        <dependency>
             <groupId>io.confluent</groupId>
             <artifactId>kafka-schema-registry-client</artifactId>
         </dependency>

--- a/ksql-serde/src/main/java/io/confluent/ksql/serde/json/KsqlJsonDeserializer.java
+++ b/ksql-serde/src/main/java/io/confluent/ksql/serde/json/KsqlJsonDeserializer.java
@@ -16,6 +16,7 @@
 
 package io.confluent.ksql.serde.json;
 
+import com.google.gson.Gson;
 import io.confluent.ksql.GenericRow;
 import io.confluent.ksql.serde.util.SerdeUtils;
 import io.confluent.ksql.util.KsqlException;
@@ -37,10 +38,13 @@ public class KsqlJsonDeserializer implements Deserializer<GenericRow> {
   private final Schema schema;
   private final JsonConverter jsonConverter;
 
+  private final Gson gson;
+
   /**
    * Default constructor needed by Kafka
    */
   public KsqlJsonDeserializer(final Schema schema, final boolean isInternal) {
+    gson = new Gson();
     // If this is a Deserializer for an internal topic in the streams app
     if (isInternal) {
       this.schema = schema;
@@ -105,7 +109,7 @@ public class KsqlJsonDeserializer implements Deserializer<GenericRow> {
       case FLOAT64:
         return SerdeUtils.toDouble(columnVal);
       case STRING:
-        return columnVal.toString();
+        return processString(columnVal);
       case ARRAY:
         return enforceFieldTypeForArray(fieldSchema, (List<?>) columnVal);
       case MAP:
@@ -115,6 +119,13 @@ public class KsqlJsonDeserializer implements Deserializer<GenericRow> {
       default:
         throw new KsqlException("Type is not supported: " + fieldSchema.type());
     }
+  }
+
+  private String processString(final Object columnVal) {
+    if (columnVal instanceof Map) {
+      return gson.toJson(columnVal);
+    }
+    return columnVal.toString();
   }
 
   private List<?> enforceFieldTypeForArray(final Schema fieldSchema, final List<?> arrayList) {

--- a/ksql-serde/src/test/java/io/confluent/ksql/serde/json/KsqlJsonDeserializerTest.java
+++ b/ksql-serde/src/test/java/io/confluent/ksql/serde/json/KsqlJsonDeserializerTest.java
@@ -142,7 +142,7 @@ public class KsqlJsonDeserializerTest {
   }
 
   @Test
-  public void shouldCreatedJsonStringForStructIfDefinedAsVarchar() throws JsonProcessingException {
+  public void shouldCreateJsonStringForStructIfDefinedAsVarchar() throws JsonProcessingException {
     final Schema schema = SchemaBuilder.struct()
         .field("itemid".toUpperCase(), Schema.OPTIONAL_STRING_SCHEMA)
         .build();

--- a/ksql-serde/src/test/java/io/confluent/ksql/serde/json/KsqlJsonDeserializerTest.java
+++ b/ksql-serde/src/test/java/io/confluent/ksql/serde/json/KsqlJsonDeserializerTest.java
@@ -149,9 +149,7 @@ public class KsqlJsonDeserializerTest {
     final KsqlJsonDeserializer deserializer = new KsqlJsonDeserializer(schema, false);
     final Map<String, Object> row = new HashMap<>();
     row.put("itemid", "{\"CATEGORY\":{\"ID\":2,\"NAME\":\"Food\"},\"ITEMID\":6,\"NAME\":\"Item_6\"}");
-
-    System.out.println(objectMapper.writeValueAsString(row));
-
+    
     final GenericRow expected = new GenericRow(Arrays.asList("{\"CATEGORY\":{\"ID\":2,\"NAME\":\"Food\"},\"ITEMID\":6,\"NAME\":\"Item_6\"}"));
     final GenericRow genericRow = deserializer.deserialize("", "{\"itemid\":{\"CATEGORY\":{\"ID\":2,\"NAME\":\"Food\"},\"ITEMID\":6,\"NAME\":\"Item_6\"}}".getBytes());
     assertThat(genericRow, equalTo(expected));

--- a/pom.xml
+++ b/pom.xml
@@ -77,6 +77,7 @@
         <airline.version>2.2.0</airline.version>
         <antlr.version>4.7</antlr.version>
         <csv.version>1.4</csv.version>
+        <gson.version>2.8.5</gson.version>
         <guava.version>24.0-jre</guava.version>
         <inject.version>1</inject.version>
         <janino.version>3.0.7</janino.version>
@@ -251,6 +252,12 @@
                 <groupId>org.apache.commons</groupId>
                 <artifactId>commons-csv</artifactId>
                 <version>${csv.version}</version>
+            </dependency>
+
+            <dependency>
+                <groupId>com.google.code.gson</groupId>
+                <artifactId>gson</artifactId>
+                <version>${gson.version}</version>
             </dependency>
 
             <dependency>


### PR DESCRIPTION
### Description 
This PR fixes the regression we had after adding struct support. 
We can now define a struct field as varchar which results in reading the whole filed as a json string.
This will help users to either choose to define a struct structure over a field or use it as string and use `EXTRACTJSONFIELD` udf to fetch specific field.
Note that this will only work for streams/tables with JSON format and is not intended to be used on AVRO format.
This is a fix for #1562 

### Testing done 
Unit and integration tests were added.

### Reviewer checklist
- [ ] Ensure docs are updated if necessary. (eg. if a user visible feature is being added or changed).
- [ ] Ensure relevant issues are linked (description should include text like "Fixes #<issue number>")

