### PR TITLE
KSQL-1494: Test permutations of optimizations on and off

### DIFF
--- a/ksql-engine/src/test/java/io/confluent/ksql/EndToEndEngineTestUtil.java
+++ b/ksql-engine/src/test/java/io/confluent/ksql/EndToEndEngineTestUtil.java
@@ -596,11 +596,11 @@ final class EndToEndEngineTestUtil {
       final Map<String, Object> updatedConfigs = new HashMap<>(originalConfigs);
 
       final KsqlConfig ksqlConfig = new KsqlConfig(ImmutableMap.copyOf(updatedConfigs));
-      final KsqlEngine ksqlEngine = getKsqlEngine(ksqlConfig);
-      final Topology topology = getStreamsTopology(query, ksqlEngine, ksqlConfig);
-      final Map<String, String> configsToPersist = ksqlConfig.getAllConfigPropsWithSecretsObfuscated();
-      writeExpectedTopologyFile(query.name, topology, configsToPersist, objectWriter, topologyDir);
-      ksqlEngine.close();
+      try(final KsqlEngine ksqlEngine = getKsqlEngine(schemaRegistryClientFactory, ksqlConfig)) {
+          final Topology topology = getStreamsTopology(query, ksqlEngine, ksqlConfig);
+          final Map<String, String> configsToPersist = ksqlConfig.getAllConfigPropsWithSecretsObfuscated();
+          writeExpectedTopologyFile(query.name, topology, configsToPersist, objectWriter, topologyDir);
+      }
     });
   }
 

--- a/ksql-engine/src/test/java/io/confluent/ksql/EndToEndEngineTestUtil.java
+++ b/ksql-engine/src/test/java/io/confluent/ksql/EndToEndEngineTestUtil.java
@@ -589,20 +589,18 @@ final class EndToEndEngineTestUtil {
 
   static void writeExpectedTopologyFiles(final String topologyDir, List<Query> queryList) {
 
-    final Random randomPort = new Random();
     final ObjectWriter objectWriter = new ObjectMapper().writerWithDefaultPrettyPrinter();
 
     queryList.forEach(query -> {
       final Map<String, Object> originalConfigs = getConfigs(null);
       final Map<String, Object> updatedConfigs = new HashMap<>(originalConfigs);
-      // need to overwrite the bootstrap servers for generating file
-      updatedConfigs.put(ConsumerConfig.BOOTSTRAP_SERVERS_CONFIG, "localhost:" + randomPort.nextInt(4000));
 
       final KsqlConfig ksqlConfig = new KsqlConfig(ImmutableMap.copyOf(updatedConfigs));
       final KsqlEngine ksqlEngine = getKsqlEngine(ksqlConfig);
       final Topology topology = getStreamsTopology(query, ksqlEngine, ksqlConfig);
       final Map<String, String> configsToPersist = ksqlConfig.getAllConfigPropsWithSecretsObfuscated();
       writeExpectedTopologyFile(query.name, topology, configsToPersist, objectWriter, topologyDir);
+      ksqlEngine.close();
     });
   }
 

--- a/ksql-engine/src/test/java/io/confluent/ksql/EndToEndEngineTestUtil.java
+++ b/ksql-engine/src/test/java/io/confluent/ksql/EndToEndEngineTestUtil.java
@@ -789,8 +789,7 @@ final class EndToEndEngineTestUtil {
         .put(StreamsConfig.CACHE_MAX_BYTES_BUFFERING_CONFIG, 0)
         .put(StreamsConfig.STATE_DIR_CONFIG, TestUtils.tempDirectory().getPath())
         .put(StreamsConfig.APPLICATION_ID_CONFIG, "some.ksql.service.id")
-        .put(KsqlConfig.KSQL_SERVICE_ID_CONFIG, "some.ksql.service.id")
-        .put(StreamsConfig.TOPOLOGY_OPTIMIZATION, "all");
+        .put(KsqlConfig.KSQL_SERVICE_ID_CONFIG, "some.ksql.service.id");
 
       if(additionalConfigs != null){
           mapBuilder.putAll(additionalConfigs);
@@ -799,9 +798,13 @@ final class EndToEndEngineTestUtil {
 
   }
 
-  static void shouldBuildAndExecuteQuery(final Query query) {
+  static void shouldBuildAndExecuteQuery(final Query query, final String optimizationsSetting) {
+    final SchemaRegistryClient schemaRegistryClient = new MockSchemaRegistryClient();
+    final Supplier<SchemaRegistryClient> schemaRegistryClientFactory = () -> schemaRegistryClient;
+    final Map<String, Object> optimizationConfig = new HashMap<>();
+    optimizationConfig.put(StreamsConfig.TOPOLOGY_OPTIMIZATION, optimizationsSetting);
 
-    final Map<String, Object> config = getConfigs(new HashMap<>());
+    final Map<String, Object> config = getConfigs(optimizationConfig);
     final Properties streamsProperties = new Properties();
     streamsProperties.putAll(config);
     final KsqlConfig currentConfigs = new KsqlConfig(config);

--- a/ksql-engine/src/test/java/io/confluent/ksql/EndToEndEngineTestUtil.java
+++ b/ksql-engine/src/test/java/io/confluent/ksql/EndToEndEngineTestUtil.java
@@ -596,7 +596,7 @@ final class EndToEndEngineTestUtil {
       final Map<String, Object> updatedConfigs = new HashMap<>(originalConfigs);
 
       final KsqlConfig ksqlConfig = new KsqlConfig(ImmutableMap.copyOf(updatedConfigs));
-      try(final KsqlEngine ksqlEngine = getKsqlEngine(schemaRegistryClientFactory, ksqlConfig)) {
+      try(final KsqlEngine ksqlEngine = getKsqlEngine(ksqlConfig)) {
           final Topology topology = getStreamsTopology(query, ksqlEngine, ksqlConfig);
           final Map<String, String> configsToPersist = ksqlConfig.getAllConfigPropsWithSecretsObfuscated();
           writeExpectedTopologyFile(query.name, topology, configsToPersist, objectWriter, topologyDir);
@@ -797,8 +797,7 @@ final class EndToEndEngineTestUtil {
   }
 
   static void shouldBuildAndExecuteQuery(final Query query, final String optimizationsSetting) {
-    final SchemaRegistryClient schemaRegistryClient = new MockSchemaRegistryClient();
-    final Supplier<SchemaRegistryClient> schemaRegistryClientFactory = () -> schemaRegistryClient;
+
     final Map<String, Object> optimizationConfig = new HashMap<>();
     optimizationConfig.put(StreamsConfig.TOPOLOGY_OPTIMIZATION, optimizationsSetting);
 

--- a/ksql-engine/src/test/java/io/confluent/ksql/QueryTranslationTest.java
+++ b/ksql-engine/src/test/java/io/confluent/ksql/QueryTranslationTest.java
@@ -105,6 +105,8 @@ public class QueryTranslationTest {
   /**
    * @param name  - unused. Is just so the tests get named.
    * @param query - query to run.
+   * @param optimizationsOff - turns off streams optimizations
+   * @param  optimizationsOn - turns on all streams optimizations
    */
   @SuppressWarnings("unused")
   public QueryTranslationTest(final String name, final Query query, final String optimizationsOn, final String optimizationsOff) {

--- a/ksql-engine/src/test/java/io/confluent/ksql/QueryTranslationTest.java
+++ b/ksql-engine/src/test/java/io/confluent/ksql/QueryTranslationTest.java
@@ -52,6 +52,7 @@ import java.util.stream.StreamSupport;
 import org.apache.kafka.connect.data.Field;
 import org.apache.kafka.connect.data.Schema;
 import org.apache.kafka.connect.data.SchemaBuilder;
+import org.apache.kafka.streams.StreamsConfig;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
@@ -98,19 +99,28 @@ public class QueryTranslationTest {
   private static final String TOPOLOGY_VERSION_PROP = "topology.version";
 
   private final Query query;
+  private final String optimizationsOn;
+  private final String optimizationsOff;
 
   /**
    * @param name  - unused. Is just so the tests get named.
    * @param query - query to run.
    */
   @SuppressWarnings("unused")
-  public QueryTranslationTest(final String name, final Query query) {
+  public QueryTranslationTest(final String name, final Query query, final String optimizationsOn, final String optimizationsOff) {
     this.query = Objects.requireNonNull(query, "query");
+    this.optimizationsOff = optimizationsOff;
+    this.optimizationsOn = optimizationsOn;
   }
 
   @Test
-  public void shouldBuildAndExecuteQueries() {
-    EndToEndEngineTestUtil.shouldBuildAndExecuteQuery(this.query);
+  public void shouldBuildAndExecuteQueries_Optimized() {
+    EndToEndEngineTestUtil.shouldBuildAndExecuteQuery(this.query, optimizationsOn);
+  }
+
+  @Test
+  public void shouldBuildAndExecuteQueries_No_Optimization() {
+    EndToEndEngineTestUtil.shouldBuildAndExecuteQuery(this.query, optimizationsOff);
   }
 
   @Parameterized.Parameters(name = "{0}")
@@ -127,7 +137,7 @@ public class QueryTranslationTest {
               q.setPersistedProperties(topologyAndConfigs.configs);
             }
           })
-          .map(query -> new Object[]{query.getName(), query})
+          .map(query -> new Object[]{query.getName(), query, StreamsConfig.OPTIMIZE, StreamsConfig.NO_OPTIMIZATION})
           .collect(Collectors.toCollection(ArrayList::new));
   }
 

--- a/ksql-engine/src/test/java/io/confluent/ksql/SchemaTranslationTest.java
+++ b/ksql-engine/src/test/java/io/confluent/ksql/SchemaTranslationTest.java
@@ -28,6 +28,7 @@ import java.util.Random;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 import org.apache.avro.Schema;
+import org.apache.kafka.streams.StreamsConfig;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
@@ -42,15 +43,32 @@ public class SchemaTranslationTest {
 
   private final String name;
   private final Query query;
+  private final String optimizationsOn;
+  private final String optimizationsOff;
 
-  public SchemaTranslationTest(final String name, final Query query) {
+
+  /**
+   * @param name  - unused. Is just so the tests get named.
+   * @param query - query to run.
+   * @param optimizationsOff - turns off streams optimizations
+   * @param  optimizationsOn - turns on all streams optimizations
+   */
+  @SuppressWarnings("unused")
+  public SchemaTranslationTest(final String name, final Query query, final String optimizationsOn, final String optimizationsOff) {
     this.name = name;
     this.query = query;
+    this.optimizationsOn = optimizationsOn;
+    this.optimizationsOff = optimizationsOff;
   }
 
   @Test
-  public void shouldBuildAndExecuteQueries() {
-    EndToEndEngineTestUtil.shouldBuildAndExecuteQuery(this.query, "none");
+  public void shouldBuildAndExecuteQueriesOptimized() {
+    EndToEndEngineTestUtil.shouldBuildAndExecuteQuery(this.query, optimizationsOn);
+  }
+
+  @Test
+  public void shouldBuildAndExecuteQueriesNotOptimized() {
+    EndToEndEngineTestUtil.shouldBuildAndExecuteQuery(this.query, optimizationsOff);
   }
 
   @Parameterized.Parameters(name = "{0}")

--- a/ksql-engine/src/test/java/io/confluent/ksql/SchemaTranslationTest.java
+++ b/ksql-engine/src/test/java/io/confluent/ksql/SchemaTranslationTest.java
@@ -50,7 +50,7 @@ public class SchemaTranslationTest {
 
   @Test
   public void shouldBuildAndExecuteQueries() {
-    EndToEndEngineTestUtil.shouldBuildAndExecuteQuery(this.query);
+    EndToEndEngineTestUtil.shouldBuildAndExecuteQuery(this.query, "none");
   }
 
   @Parameterized.Parameters(name = "{0}")

--- a/ksql-engine/src/test/java/io/confluent/ksql/SchemaTranslationTest.java
+++ b/ksql-engine/src/test/java/io/confluent/ksql/SchemaTranslationTest.java
@@ -75,7 +75,7 @@ public class SchemaTranslationTest {
   public static Collection<Object[]> data() {
     return findTestCases(SCHEMA_VALIDATION_TEST_DIR)
         .map(SchemaTranslationTest::loadTest)
-        .map(q -> new Object[]{q.getName(), q})
+        .map(q -> new Object[]{q.getName(), q, StreamsConfig.OPTIMIZE, StreamsConfig.NO_OPTIMIZATION})
         .collect(Collectors.toList());
   }
 


### PR DESCRIPTION
### Description 
I changed the `QueryTranslationTest` to now run all tests with optimizations set to `all`  and `none`.  I also made a minor change to `SchemaTranslationTest` as it uses `EndToEndEngineTestUtil` as well.

We'll need to discuss how to approach the permutations as more optimization versions are available.  Each new version will require an additional test method (very low overhead to add), but increases the total test count by 128.  While that seems acceptable for now, more permutations across versions will quickly explode the test count making it somewhat of a burden to run as unit test each time.

### Testing done 
I ran the existing `QueryTranslationTest` which now runs 256 tests, 128 with optimizations off and 128 with optimizations on.

### Reviewer checklist
- [ ] Ensure docs are updated if necessary. (eg. if a user visible feature is being added or changed).
- [ ] Ensure relevant issues are linked (description should include text like "Fixes #<issue number>")

