### PR TITLE
Add ksql-examples to the ksql package artifact so that datagen continues to work

### DIFF
--- a/ksql-package/pom.xml
+++ b/ksql-package/pom.xml
@@ -59,6 +59,10 @@
             <artifactId>ksql-version-metrics-client</artifactId>
         </dependency>
 
+        <dependency>
+            <groupId>io.confluent.ksql</groupId>
+            <artifactId>ksql-examples</artifactId>
+        </dependency>
         <!-- kafka -> zookeeper -> jline ends up including junit 3.8.1 here. Explicitly list the
              dependency and scope it to test to avoid pulling it in -->
         <dependency>


### PR DESCRIPTION

### Description 
#1929 removed the dependency on ksql-examples transitively. This means that the `ksql-datagen` tool would no longer work in the packaged ksql artifact, but would fail with the message `Error: Could not find or load main class io.confluent.ksql.datagen.DataGen`.

This also caused the system tests to fail because the test data could not be generated. 

This patch fixes the dependency so that ksql datagen continues to work.

### Testing done 
`mvn package` and then checked that `ksql-datagen` worked in the artifact `ksql-package/target/ksql-package-5.1.0-SNAPSHOT-package.tgz`

### Reviewer checklist
- [ ] Ensure docs are updated if necessary. (eg. if a user visible feature is being added or changed).
- [ ] Ensure relevant issues are linked (description should include text like "Fixes #<issue number>")

