### PR TITLE
Add Monitoring Interceptors to ksql-examples Docker image

### DIFF
--- a/ksql-examples/pom.xml
+++ b/ksql-examples/pom.xml
@@ -39,6 +39,12 @@
         </dependency>
 
         <dependency>
+            <groupId>io.confluent</groupId>
+            <artifactId>monitoring-interceptors</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+
+        <dependency>
             <groupId>junit</groupId>
             <artifactId>junit</artifactId>
             <scope>test</scope>


### PR DESCRIPTION
### Description 

Add Monitoring Interceptors to ksql-examples Docker image so that demos built using datagen can automagically work with C3.

### Testing done 

None. 
