### PR TITLE
Use version 5.0.0 for KSQL server image

### DIFF
--- a/docs/tutorials/docker-compose.yml
+++ b/docs/tutorials/docker-compose.yml
@@ -39,7 +39,7 @@ services:
       SCHEMA_REGISTRY_KAFKASTORE_CONNECTION_URL: zookeeper:32181
 
   ksql-server:
-    image: confluentinc/cp-ksql-server:5.0.0-rc3
+    image: "confluentinc/cp-ksql-server:5.0.0"
     depends_on:
       - kafka
       - schema-registry


### PR DESCRIPTION
About 9 weeks back the commit 47f29cc9 fixed Docker image version references to consistently refer to `5.0.0`, but only in branch `5.0.0-post`.

This was apparently never merged back into `master`.  This PR fixes the inconsistency.