### PR TITLE
Metrics refactor + fix a couple issues

### DIFF
--- a/ksql-common/src/main/java/io/confluent/ksql/errors/LogMetricAndContinueExceptionHandler.java
+++ b/ksql-common/src/main/java/io/confluent/ksql/errors/LogMetricAndContinueExceptionHandler.java
@@ -16,7 +16,7 @@
 
 package io.confluent.ksql.errors;
 
-import io.confluent.ksql.metrics.MetricCollectors;
+import io.confluent.ksql.metrics.StreamsErrorCollector;
 import java.util.Map;
 import org.apache.kafka.clients.consumer.ConsumerRecord;
 import org.apache.kafka.streams.errors.DeserializationExceptionHandler;
@@ -42,7 +42,7 @@ public class LogMetricAndContinueExceptionHandler implements DeserializationExce
         exception
     );
 
-    MetricCollectors.recordError(record.topic());
+    StreamsErrorCollector.recordError(context.applicationId(), record.topic());
     return DeserializationHandlerResponse.CONTINUE;
   }
 

--- a/ksql-common/src/main/java/io/confluent/ksql/metrics/ConsumerCollector.java
+++ b/ksql-common/src/main/java/io/confluent/ksql/metrics/ConsumerCollector.java
@@ -16,10 +16,6 @@
 
 package io.confluent.ksql.metrics;
 
-import static io.confluent.ksql.metrics.MetricCollectors.CONSUMER_MESSAGES_PER_SEC;
-import static io.confluent.ksql.metrics.MetricCollectors.CONSUMER_TOTAL_BYTES;
-import static io.confluent.ksql.metrics.MetricCollectors.CONSUMER_TOTAL_MESSAGES;
-
 import com.google.common.collect.ImmutableMap;
 import io.confluent.common.utils.Time;
 import java.util.ArrayList;
@@ -43,6 +39,10 @@ import org.apache.kafka.common.metrics.stats.Rate;
 import org.apache.kafka.common.metrics.stats.Total;
 
 public class ConsumerCollector implements MetricCollector, ConsumerInterceptor {
+  public static final String CONSUMER_MESSAGES_PER_SEC = "consumer-messages-per-sec";
+  public static final String CONSUMER_TOTAL_MESSAGES = "consumer-total-messages";
+  public static final String CONSUMER_TOTAL_BYTES = "consumer-total-bytes";
+
   private final Map<String, TopicSensors<ConsumerRecord>> topicSensors = new HashMap<>();
   private Metrics metrics;
   private String id;

--- a/ksql-common/src/main/java/io/confluent/ksql/metrics/ConsumerCollector.java
+++ b/ksql-common/src/main/java/io/confluent/ksql/metrics/ConsumerCollector.java
@@ -16,6 +16,10 @@
 
 package io.confluent.ksql.metrics;
 
+import static io.confluent.ksql.metrics.MetricCollectors.CONSUMER_MESSAGES_PER_SEC;
+import static io.confluent.ksql.metrics.MetricCollectors.CONSUMER_TOTAL_BYTES;
+import static io.confluent.ksql.metrics.MetricCollectors.CONSUMER_TOTAL_MESSAGES;
+
 import com.google.common.collect.ImmutableMap;
 import io.confluent.common.utils.Time;
 import java.util.ArrayList;
@@ -27,6 +31,7 @@ import java.util.function.Function;
 import java.util.stream.Stream;
 import java.util.stream.StreamSupport;
 import org.apache.kafka.clients.consumer.ConsumerConfig;
+import org.apache.kafka.clients.consumer.ConsumerInterceptor;
 import org.apache.kafka.clients.consumer.ConsumerRecord;
 import org.apache.kafka.clients.consumer.ConsumerRecords;
 import org.apache.kafka.common.MetricName;
@@ -37,8 +42,7 @@ import org.apache.kafka.common.metrics.Sensor;
 import org.apache.kafka.common.metrics.stats.Rate;
 import org.apache.kafka.common.metrics.stats.Total;
 
-public class ConsumerCollector implements MetricCollector {
-
+public class ConsumerCollector implements MetricCollector, ConsumerInterceptor {
   private final Map<String, TopicSensors<ConsumerRecord>> topicSensors = new HashMap<>();
   private Metrics metrics;
   private String id;
@@ -70,13 +74,12 @@ public class ConsumerCollector implements MetricCollector {
   }
 
   @Override
-  public String getGroupId() {
-    return this.groupId;
+  public void onCommit(final Map map) {
   }
 
   @Override
-  public String getId() {
-    return id;
+  public String getGroupId() {
+    return this.groupId;
   }
 
   @Override
@@ -90,10 +93,6 @@ public class ConsumerCollector implements MetricCollector {
     final Stream<ConsumerRecord> stream =
         StreamSupport.stream(consumerRecords.spliterator(), false);
     stream.forEach(record -> record(record.topic().toLowerCase(), false, record));
-  }
-
-  public void recordError(final String topic) {
-    record(topic, true, null);
   }
 
   private void record(final String topic, final boolean isError, final ConsumerRecord record) {
@@ -113,10 +112,9 @@ public class ConsumerCollector implements MetricCollector {
     // Note: synchronized due to metrics registry not handling concurrent add/check-exists
     // activity in a reliable way
     synchronized (this.metrics) {
-      addSensor(key, "consumer-messages-per-sec", new Rate(), sensors, false);
-      addSensor(key, "consumer-total-messages", new Total(), sensors, false);
-      addSensor(key, "consumer-failed-messages", new Total(), sensors, true);
-      addSensor(key, "consumer-total-message-bytes", new Total(), sensors, false,
+      addSensor(key, CONSUMER_MESSAGES_PER_SEC, new Rate(), sensors, false);
+      addSensor(key, CONSUMER_TOTAL_MESSAGES, new Total(), sensors, false);
+      addSensor(key, CONSUMER_TOTAL_BYTES, new Total(), sensors, false,
           (r) -> {
             if (r == null) {
               return 0.0;
@@ -124,7 +122,6 @@ public class ConsumerCollector implements MetricCollector {
               return ((double) r.serializedValueSize() + r.serializedKeySize());
             }
           });
-      addSensor(key, "failed-messages-per-sec", new Rate(), sensors, true);
     }
     return sensors;
   }
@@ -173,7 +170,6 @@ public class ConsumerCollector implements MetricCollector {
     });
   }
 
-
   public void close() {
     MetricCollectors.remove(this.id);
     topicSensors.values().forEach(v -> v.close(metrics));
@@ -181,61 +177,12 @@ public class ConsumerCollector implements MetricCollector {
 
   @Override
   public Collection<TopicSensors.Stat> stats(final String topic, final boolean isError) {
-    final List<TopicSensors.Stat> list = new ArrayList<>();
-    topicSensors
-        .values()
-        .stream()
-        .filter(counter -> counter.isTopic(topic))
-        .forEach(record -> list.addAll(record.stats(isError)));
-    return list;
-  }
-
-
-  @Override
-  public double currentMessageConsumptionRate() {
-    final List<TopicSensors.Stat> allStats = new ArrayList<>();
-    topicSensors.values().forEach(record -> allStats.addAll(record.stats(false)));
-
-    return allStats
-        .stream()
-        .filter(stat -> stat.name().contains("consumer-messages-per-sec"))
-        .mapToDouble(TopicSensors.Stat::getValue)
-        .sum();
+    return MetricUtils.stats(topic, isError, topicSensors.values());
   }
 
   @Override
-  public double totalMessageConsumption() {
-    final List<TopicSensors.Stat> allStats = new ArrayList<>();
-    topicSensors.values().forEach(record -> allStats.addAll(record.stats(false)));
-
-    return allStats
-        .stream()
-        .filter(stat -> stat.name().contains("consumer-total-messages"))
-        .mapToDouble(TopicSensors.Stat::getValue)
-        .sum();
-  }
-
-  @Override
-  public double totalBytesConsumption() {
-    final List<TopicSensors.Stat> allStats = new ArrayList<>();
-    topicSensors.values().forEach(record -> allStats.addAll(record.stats(false)));
-
-    return allStats
-        .stream()
-        .filter(stat -> stat.name().contains("consumer-total-message-bytes"))
-        .mapToDouble(TopicSensors.Stat::getValue)
-        .sum();
-  }
-
-  @Override
-  public double errorRate() {
-    final List<TopicSensors.Stat> allStats = new ArrayList<>();
-    topicSensors.values().forEach(record -> allStats.addAll(record.errorRateStats()));
-
-    return allStats
-        .stream()
-        .mapToDouble(TopicSensors.Stat::getValue)
-        .sum();
+  public double aggregateStat(final String name, final boolean isError) {
+    return MetricUtils.aggregateStat(name, isError, topicSensors.values());
   }
 
   @Override

--- a/ksql-common/src/main/java/io/confluent/ksql/metrics/MetricCollector.java
+++ b/ksql-common/src/main/java/io/confluent/ksql/metrics/MetricCollector.java
@@ -17,67 +17,17 @@
 package io.confluent.ksql.metrics;
 
 import java.util.Collection;
-import java.util.Map;
-import org.apache.kafka.clients.consumer.ConsumerInterceptor;
-import org.apache.kafka.clients.consumer.ConsumerRecords;
-import org.apache.kafka.clients.producer.ProducerInterceptor;
-import org.apache.kafka.clients.producer.ProducerRecord;
-import org.apache.kafka.clients.producer.RecordMetadata;
 
-interface MetricCollector extends ConsumerInterceptor, ProducerInterceptor {
-  default ConsumerRecords onConsume(final ConsumerRecords consumerRecords) {
-    return consumerRecords;
-  }
-
-  default ProducerRecord onSend(final ProducerRecord producerRecord) {
-    return producerRecord;
-  }
-
-  default void onAcknowledgement(final RecordMetadata recordMetadata, final Exception e) {  }
-
-  default void close() {  }
-
-  default void onCommit(final Map map) {  }
-
-  default void configure(final Map<String, ?> map) {  }
-
+interface MetricCollector {
   default String getGroupId() {
     return null;
   }
 
-  String getId();
-
   Collection<TopicSensors.Stat> stats(String topic, boolean isError);
 
-  void recordError(String topic);
-
-  double errorRate();
-
-  /**
-   * Get the current message production across all topics tracked by this collector.
-   */
-  default double currentMessageProductionRate() {
-    return 0;
+  default double errorRate() {
+    return 0.0;
   }
 
-  /**
-   * Get the current message consumption rate across all topics tracked by this collector.
-   */
-  default double currentMessageConsumptionRate() {
-    return 0;
-  }
-
-  /**
-   * Get the total message consumption across all topics tracked by this collector.
-   */
-  default double totalMessageConsumption() {
-    return 0;
-  }
-
-  /**
-   * Get the total bytes consumed across all topics tracked by this collector.
-   */
-  default double totalBytesConsumption() {
-    return 0;
-  }
+  double aggregateStat(String name, boolean isError);
 }

--- a/ksql-common/src/main/java/io/confluent/ksql/metrics/MetricCollectors.java
+++ b/ksql-common/src/main/java/io/confluent/ksql/metrics/MetricCollectors.java
@@ -36,15 +36,6 @@ import org.apache.kafka.common.utils.SystemTime;
  * streams/tables/queries for ksql entities (Stream, Table, Query)
  */
 public final class MetricCollectors {
-  public static final String PRODUCER_MESSAGES_PER_SEC = "messages-per-sec";
-  public static final String PRODUCER_TOTAL_MESSAGES = "total-messages";
-  public static final String CONSUMER_MESSAGES_PER_SEC = "consumer-messages-per-sec";
-  public static final String CONSUMER_TOTAL_MESSAGES = "consumer-total-messages";
-  public static final String CONSUMER_TOTAL_BYTES = "consumer-total-bytes";
-  public static final String CONSUMER_FAILED_MESSAGES = "consumer-failed-messages";
-  public static final String CONSUMER_FAILED_MESSAGES_PER_SEC
-      = "consumer-failed-messages-per-sec";
-
   private static Map<String, MetricCollector> collectorMap;
   private static Metrics metrics;
 
@@ -154,7 +145,7 @@ public final class MetricCollectors {
             Collectors.groupingBy(
               MetricCollector::getGroupId,
               Collectors.summingDouble(
-                  m -> m.aggregateStat(CONSUMER_MESSAGES_PER_SEC, false)
+                  m -> m.aggregateStat(ConsumerCollector.CONSUMER_MESSAGES_PER_SEC, false)
               )
           )
         )
@@ -168,19 +159,19 @@ public final class MetricCollectors {
   }
 
   public static double currentProductionRate() {
-    return aggregateStat(PRODUCER_MESSAGES_PER_SEC, false);
+    return aggregateStat(ProducerCollector.PRODUCER_MESSAGES_PER_SEC, false);
   }
 
   public static double currentConsumptionRate() {
-    return aggregateStat(CONSUMER_MESSAGES_PER_SEC, false);
+    return aggregateStat(ConsumerCollector.CONSUMER_MESSAGES_PER_SEC, false);
   }
 
   public static double totalMessageConsumption() {
-    return aggregateStat(CONSUMER_TOTAL_MESSAGES, false);
+    return aggregateStat(ConsumerCollector.CONSUMER_TOTAL_MESSAGES, false);
   }
 
   public static double totalBytesConsumption() {
-    return aggregateStat(CONSUMER_TOTAL_BYTES, false);
+    return aggregateStat(ConsumerCollector.CONSUMER_TOTAL_BYTES, false);
   }
 
   public static double currentErrorRate() {

--- a/ksql-common/src/main/java/io/confluent/ksql/metrics/MetricUtils.java
+++ b/ksql-common/src/main/java/io/confluent/ksql/metrics/MetricUtils.java
@@ -1,0 +1,32 @@
+package io.confluent.ksql.metrics;
+
+import io.confluent.ksql.metrics.TopicSensors.Stat;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.List;
+
+public class MetricUtils {
+  public static <T> double aggregateStat(
+      final String name,
+      final boolean isError,
+      final Collection<TopicSensors<T>> sensors) {
+    final List<Stat> allStats = new ArrayList<>();
+    sensors.forEach(record -> allStats.addAll(record.stats(isError)));
+    return allStats
+        .stream()
+        .filter(stat -> stat.name().equals(name))
+        .mapToDouble(TopicSensors.Stat::getValue)
+        .sum();
+  }
+
+  public static <T> Collection<TopicSensors.Stat> stats(
+      final String topic,
+      final boolean isError,
+      final Collection<TopicSensors<T>> sensors) {
+    final List<TopicSensors.Stat> list = new ArrayList<>();
+    sensors.stream()
+        .filter(counter -> counter.isTopic(topic))
+        .forEach(record -> list.addAll(record.stats(isError)));
+    return list;
+  }
+}

--- a/ksql-common/src/main/java/io/confluent/ksql/metrics/ProducerCollector.java
+++ b/ksql-common/src/main/java/io/confluent/ksql/metrics/ProducerCollector.java
@@ -16,6 +16,9 @@
 
 package io.confluent.ksql.metrics;
 
+import static io.confluent.ksql.metrics.MetricCollectors.PRODUCER_MESSAGES_PER_SEC;
+import static io.confluent.ksql.metrics.MetricCollectors.PRODUCER_TOTAL_MESSAGES;
+
 import com.google.common.collect.ImmutableMap;
 import io.confluent.common.utils.Time;
 import java.util.ArrayList;
@@ -24,7 +27,9 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import org.apache.kafka.clients.producer.ProducerConfig;
+import org.apache.kafka.clients.producer.ProducerInterceptor;
 import org.apache.kafka.clients.producer.ProducerRecord;
+import org.apache.kafka.clients.producer.RecordMetadata;
 import org.apache.kafka.common.MetricName;
 import org.apache.kafka.common.metrics.KafkaMetric;
 import org.apache.kafka.common.metrics.MeasurableStat;
@@ -33,9 +38,9 @@ import org.apache.kafka.common.metrics.Sensor;
 import org.apache.kafka.common.metrics.stats.Rate;
 import org.apache.kafka.common.metrics.stats.Total;
 
-public class ProducerCollector implements MetricCollector {
+public class ProducerCollector implements MetricCollector, ProducerInterceptor {
 
-  private final Map<String, TopicSensors<?>> topicSensors = new HashMap<>();
+  private final Map<String, TopicSensors<ProducerRecord>> topicSensors = new HashMap<>();
   private Metrics metrics;
   private String id;
   private Time time;
@@ -57,18 +62,13 @@ public class ProducerCollector implements MetricCollector {
   }
 
   @Override
-  public String getId() {
-    return id;
+  public void onAcknowledgement(final RecordMetadata recordMetadata, final Exception e) {
   }
 
   @Override
   public ProducerRecord onSend(final ProducerRecord record) {
     collect(record, false);
     return record;
-  }
-
-  public void recordError(final String topic) {
-    collect(true, topic.toLowerCase());
   }
 
   private void collect(final ProducerRecord record, final boolean isError) {
@@ -88,10 +88,8 @@ public class ProducerCollector implements MetricCollector {
     // Note: synchronized due to metrics registry not handling concurrent add/check-exists
     // activity in a reliable way
     synchronized (metrics) {
-      addSensor(key, "messages-per-sec", new Rate(), sensors, false);
-      addSensor(key, "total-messages", new Total(), sensors, false);
-      addSensor(key, "failed-messages", new Total(), sensors, true);
-      addSensor(key, "failed-messages-per-sec", new Rate(), sensors, true);
+      addSensor(key, PRODUCER_MESSAGES_PER_SEC, new Rate(), sensors);
+      addSensor(key, PRODUCER_TOTAL_MESSAGES, new Total(), sensors);
     }
     return sensors;
   }
@@ -100,8 +98,7 @@ public class ProducerCollector implements MetricCollector {
       final String key,
       final String metricNameString,
       final MeasurableStat stat,
-      final List<TopicSensors.SensorMetric<ProducerRecord>> results,
-      final boolean isError
+      final List<TopicSensors.SensorMetric<ProducerRecord>> results
   ) {
     final String name = "prod-" + key + "-" + metricNameString + "-" + id;
 
@@ -120,7 +117,7 @@ public class ProducerCollector implements MetricCollector {
     }
     final KafkaMetric metric = metrics.metrics().get(metricName);
 
-    results.add(new TopicSensors.SensorMetric<ProducerRecord>(sensor, metric, time, isError) {
+    results.add(new TopicSensors.SensorMetric<ProducerRecord>(sensor, metric, time, false) {
       void record(final ProducerRecord record) {
         sensor.record(1);
         super.record(record);
@@ -140,36 +137,12 @@ public class ProducerCollector implements MetricCollector {
 
   @Override
   public Collection<TopicSensors.Stat> stats(final String topic, final boolean isError) {
-    final List<TopicSensors.Stat> list = new ArrayList<>();
-    topicSensors
-        .values()
-        .stream()
-        .filter(counter -> counter.isTopic(topic))
-        .forEach(record -> list.addAll(record.stats(isError)));
-    return list;
+    return MetricUtils.stats(topic, isError, topicSensors.values());
   }
 
   @Override
-  public double currentMessageProductionRate() {
-    final List<TopicSensors.Stat> allStats = new ArrayList<>();
-    topicSensors.values().forEach(record -> allStats.addAll(record.stats(false)));
-
-    return allStats
-        .stream()
-        .filter(stat -> stat.name().contains("messages-per-sec"))
-        .mapToDouble(TopicSensors.Stat::getValue)
-        .sum();
-  }
-
-  @Override
-  public double errorRate() {
-    final List<TopicSensors.Stat> allStats = new ArrayList<>();
-    topicSensors.values().forEach(record -> allStats.addAll(record.errorRateStats()));
-
-    return allStats
-        .stream()
-        .mapToDouble(TopicSensors.Stat::getValue)
-        .sum();
+  public double aggregateStat(final String name, final boolean isError) {
+    return MetricUtils.aggregateStat(name, isError, topicSensors.values());
   }
 
   @Override

--- a/ksql-common/src/main/java/io/confluent/ksql/metrics/ProducerCollector.java
+++ b/ksql-common/src/main/java/io/confluent/ksql/metrics/ProducerCollector.java
@@ -16,9 +16,6 @@
 
 package io.confluent.ksql.metrics;
 
-import static io.confluent.ksql.metrics.MetricCollectors.PRODUCER_MESSAGES_PER_SEC;
-import static io.confluent.ksql.metrics.MetricCollectors.PRODUCER_TOTAL_MESSAGES;
-
 import com.google.common.collect.ImmutableMap;
 import io.confluent.common.utils.Time;
 import java.util.ArrayList;
@@ -39,6 +36,8 @@ import org.apache.kafka.common.metrics.stats.Rate;
 import org.apache.kafka.common.metrics.stats.Total;
 
 public class ProducerCollector implements MetricCollector, ProducerInterceptor {
+  public static final String PRODUCER_MESSAGES_PER_SEC = "messages-per-sec";
+  public static final String PRODUCER_TOTAL_MESSAGES = "total-messages";
 
   private final Map<String, TopicSensors<ProducerRecord>> topicSensors = new HashMap<>();
   private Metrics metrics;

--- a/ksql-common/src/main/java/io/confluent/ksql/metrics/StreamsErrorCollector.java
+++ b/ksql-common/src/main/java/io/confluent/ksql/metrics/StreamsErrorCollector.java
@@ -1,0 +1,145 @@
+/**
+ * Copyright 2018 Confluent Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ **/
+
+package io.confluent.ksql.metrics;
+
+import static io.confluent.ksql.metrics.MetricCollectors.CONSUMER_FAILED_MESSAGES;
+import static io.confluent.ksql.metrics.MetricCollectors.CONSUMER_FAILED_MESSAGES_PER_SEC;
+
+import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.Maps;
+import io.confluent.common.utils.Time;
+import io.confluent.ksql.metrics.TopicSensors.SensorMetric;
+import io.confluent.ksql.metrics.TopicSensors.Stat;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.List;
+import java.util.Map;
+import java.util.function.Function;
+import org.apache.kafka.common.MetricName;
+import org.apache.kafka.common.metrics.KafkaMetric;
+import org.apache.kafka.common.metrics.MeasurableStat;
+import org.apache.kafka.common.metrics.Metrics;
+import org.apache.kafka.common.metrics.Sensor;
+import org.apache.kafka.common.metrics.stats.Rate;
+import org.apache.kafka.common.metrics.stats.Total;
+
+public final class StreamsErrorCollector implements MetricCollector {
+  private static final Map<String, StreamsErrorCollector> COLLECTORS = Maps.newConcurrentMap();
+
+  private final Map<String, TopicSensors<Object>> topicSensors = Maps.newConcurrentMap();
+  private String id;
+  private final Metrics metrics;
+  private final Time time;
+
+  private StreamsErrorCollector() {
+    this.metrics = MetricCollectors.getMetrics();
+    this.time = MetricCollectors.getTime();
+  }
+
+  public void setId(final String id) {
+    this.id = id;
+  }
+
+  private void collect(final String topic) {
+    topicSensors
+        .computeIfAbsent(topic, this::buildSensors)
+        .increment(null, true);
+  }
+
+  private TopicSensors buildSensors(final String topic) {
+    final List<TopicSensors.SensorMetric<Object>> sensors = new ArrayList<>();
+    synchronized (this.metrics) {
+      sensors.add(
+          buildSensor(topic, CONSUMER_FAILED_MESSAGES, new Total(), o -> 1.0));
+      sensors.add(
+          buildSensor(topic, CONSUMER_FAILED_MESSAGES_PER_SEC, new Rate(), o -> 1.0));
+    };
+    return new TopicSensors<>(topic, sensors);
+  }
+
+  private SensorMetric<Object> buildSensor(
+      final String key,
+      final String metricNameString,
+      final MeasurableStat stat,
+      final Function<Object, Double> recordValue
+  ) {
+    final String name = "sec-" + key + "-" + metricNameString + "-" + id;
+
+    final MetricName metricName = new MetricName(
+        metricNameString,
+        "consumer-metrics",
+        "consumer-" + name,
+        ImmutableMap.of("key", key, "id", id)
+    );
+    final Sensor sensor = metrics.sensor(name);
+    sensor.add(metricName, stat);
+
+    final KafkaMetric metric = metrics.metrics().get(metricName);
+
+    return new TopicSensors.SensorMetric<Object>(sensor, metric, time, true) {
+      void record(final Object o) {
+        sensor.record(recordValue.apply(o));
+        super.record(o);
+      }
+    };
+  }
+
+  private void cleanup() {
+    MetricCollectors.remove(id);
+    topicSensors.values().forEach(v -> v.close(metrics));
+  }
+
+  @Override
+  public double errorRate() {
+    final List<TopicSensors.Stat> allStats = new ArrayList<>();
+    topicSensors.values().forEach(record -> allStats.addAll(record.errorRateStats()));
+    return allStats
+        .stream()
+        .mapToDouble(TopicSensors.Stat::getValue)
+        .sum();
+  }
+
+  @Override
+  public double aggregateStat(final String name, final boolean isError) {
+    return MetricUtils.aggregateStat(name, isError, topicSensors.values());
+  }
+
+  @Override
+  public Collection<Stat> stats(final String topic, final boolean isError) {
+    return MetricUtils.stats(topic, isError, topicSensors.values());
+  }
+
+  public static void recordError(final String applicationId, final String topic) {
+    final StreamsErrorCollector errorCollector = COLLECTORS.computeIfAbsent(
+        applicationId,
+        aid -> {
+          final StreamsErrorCollector ec = new StreamsErrorCollector();
+          final String collectorId = MetricCollectors.addCollector(aid, ec);
+          ec.setId(collectorId);
+          return ec;
+        }
+    );
+    errorCollector.collect(topic);
+  }
+
+  public static void notifyApplicationClose(final String applicationId) {
+    final StreamsErrorCollector errorCollector = COLLECTORS.remove(applicationId);
+    if (errorCollector != null) {
+      errorCollector.cleanup();
+    }
+  }
+}

--- a/ksql-common/src/main/java/io/confluent/ksql/metrics/StreamsErrorCollector.java
+++ b/ksql-common/src/main/java/io/confluent/ksql/metrics/StreamsErrorCollector.java
@@ -16,9 +16,6 @@
 
 package io.confluent.ksql.metrics;
 
-import static io.confluent.ksql.metrics.MetricCollectors.CONSUMER_FAILED_MESSAGES;
-import static io.confluent.ksql.metrics.MetricCollectors.CONSUMER_FAILED_MESSAGES_PER_SEC;
-
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.Maps;
 import io.confluent.common.utils.Time;
@@ -38,6 +35,10 @@ import org.apache.kafka.common.metrics.stats.Rate;
 import org.apache.kafka.common.metrics.stats.Total;
 
 public final class StreamsErrorCollector implements MetricCollector {
+  public static final String CONSUMER_FAILED_MESSAGES = "consumer-failed-messages";
+  public static final String CONSUMER_FAILED_MESSAGES_PER_SEC
+      = "consumer-failed-messages-per-sec";
+
   private static final Map<String, StreamsErrorCollector> COLLECTORS = Maps.newConcurrentMap();
 
   private final Map<String, TopicSensors<Object>> topicSensors = Maps.newConcurrentMap();

--- a/ksql-common/src/test/java/io/confluent/ksql/metrics/ConsumerCollectorTest.java
+++ b/ksql-common/src/test/java/io/confluent/ksql/metrics/ConsumerCollectorTest.java
@@ -22,7 +22,7 @@ public class ConsumerCollectorTest {
   private static final String TEST_TOPIC = "testtopic";
 
   @Test
-  public void shouldDisplayRateThroughput() throws Exception {
+  public void shouldDisplayRateThroughput() {
 
     final ConsumerCollector collector = new ConsumerCollector();//
     collector.configure(new Metrics(), "group", new SystemTime());

--- a/ksql-common/src/test/java/io/confluent/ksql/metrics/MetricCollectorsTest.java
+++ b/ksql-common/src/test/java/io/confluent/ksql/metrics/MetricCollectorsTest.java
@@ -38,16 +38,15 @@ public class MetricCollectorsTest {
   }
 
   @Test
-  public void shouldAggregateStats() throws Exception {
+  public void shouldAggregateStats() {
     final List<TopicSensors.Stat> stats = Arrays.asList(new TopicSensors.Stat("metric", 1, 1l), new TopicSensors.Stat("metric", 1, 1l), new TopicSensors.Stat("metric", 1, 1l));
     final Map<String, TopicSensors.Stat> aggregateMetrics = MetricCollectors.getAggregateMetrics(stats);
     assertThat(aggregateMetrics.size(), equalTo(1));
     assertThat(aggregateMetrics.values().iterator().next().getValue(), equalTo(3.0));
   }
 
-
   @Test
-  public void shouldKeepWorkingWhenDuplicateTopicConsumerIsRemoved() throws Exception {
+  public void shouldKeepWorkingWhenDuplicateTopicConsumerIsRemoved() {
 
     final ConsumerCollector collector1 = new ConsumerCollector();
     collector1.configure(ImmutableMap.of(ConsumerConfig.GROUP_ID_CONFIG, "stream-thread-1") );
@@ -66,7 +65,7 @@ public class MetricCollectorsTest {
     collector1.onConsume(consumerRecords);
     collector2.onConsume(consumerRecords);
 
-    final String firstPassStats = MetricCollectors.getStatsFor(TEST_TOPIC, false);
+    final String firstPassStats = MetricCollectors.getAndFormatStatsFor(TEST_TOPIC, false);
 
     assertTrue("Missed stats, got:" + firstPassStats, firstPassStats.contains("total-messages:         2"));
 
@@ -74,14 +73,14 @@ public class MetricCollectorsTest {
 
     collector1.onConsume(consumerRecords);
 
-    final String statsForTopic2 =  MetricCollectors.getStatsFor(TEST_TOPIC, false);
+    final String statsForTopic2 =  MetricCollectors.getAndFormatStatsFor(TEST_TOPIC, false);
 
     assertTrue("Missed stats, got:" + statsForTopic2, statsForTopic2.contains("total-messages:         2"));
   }
 
 
   @Test
-  public void shouldAggregateStatsAcrossAllProducers() throws Exception {
+  public void shouldAggregateStatsAcrossAllProducers() {
     final ProducerCollector collector1 = new ProducerCollector();
     collector1.configure(ImmutableMap.of(ProducerConfig.CLIENT_ID_CONFIG, "client1"));
 
@@ -104,7 +103,7 @@ public class MetricCollectorsTest {
 
 
   @Test
-  public void shouldAggregateStatsAcrossAllConsumers() throws Exception {
+  public void shouldAggregateStatsAcrossAllConsumers() {
     final ConsumerCollector collector1 = new ConsumerCollector();
     collector1.configure(ImmutableMap.of(ConsumerConfig.CLIENT_ID_CONFIG, "client1"));
 
@@ -127,7 +126,7 @@ public class MetricCollectorsTest {
   }
 
   @Test
-  public void shouldAggregateTotalMessageConsumptionAcrossAllConsumers() throws Exception {
+  public void shouldAggregateTotalMessageConsumptionAcrossAllConsumers() {
     final ConsumerCollector collector1 = new ConsumerCollector();
     collector1.configure(ImmutableMap.of(ConsumerConfig.CLIENT_ID_CONFIG, "client1"));
 
@@ -148,7 +147,7 @@ public class MetricCollectorsTest {
   }
 
   @Test
-  public void shouldAggregateTotalBytesConsumptionAcrossAllConsumers() throws Exception {
+  public void shouldAggregateTotalBytesConsumptionAcrossAllConsumers() {
     final ConsumerCollector collector1 = new ConsumerCollector();
     collector1.configure(ImmutableMap.of(ConsumerConfig.CLIENT_ID_CONFIG, "client1"));
 
@@ -171,7 +170,7 @@ public class MetricCollectorsTest {
   }
 
   @Test
-  public void shouldAggregateConsumptionStatsByQuery() throws Exception {
+  public void shouldAggregateConsumptionStatsByQuery() {
     final ConsumerCollector collector1 = new ConsumerCollector();
     collector1.configure(ImmutableMap.of(ConsumerConfig.GROUP_ID_CONFIG, "group1"));
 
@@ -208,7 +207,7 @@ public class MetricCollectorsTest {
   }
 
   @Test
-  public void shouldNotIncludeRestoreConsumersWhenComputingPerQueryStats() throws Exception {
+  public void shouldNotIncludeRestoreConsumersWhenComputingPerQueryStats() {
     final ConsumerCollector collector1 = new ConsumerCollector();
     collector1.configure(ImmutableMap.of(ConsumerConfig.GROUP_ID_CONFIG, "group1"));
 
@@ -253,20 +252,13 @@ public class MetricCollectorsTest {
   }
 
   @Test
-  public void shouldAggregateErrorRatesAcrossProducersAndConsumers() {
-    final ConsumerCollector consumerCollector = new ConsumerCollector();
-    consumerCollector.configure(ImmutableMap.of(ConsumerConfig.GROUP_ID_CONFIG, "groupfoo1"));
-
-    final ProducerCollector producerCollector = new ProducerCollector();
-    producerCollector.configure(ImmutableMap.of(ProducerConfig.CLIENT_ID_CONFIG, "clientfoo2"));
-
-    for (int i = 0; i < 1000; i++) {
-      consumerCollector.recordError(TEST_TOPIC);
-      producerCollector.recordError(TEST_TOPIC);
+  public void shouldAggregateDeserializationErrors() {
+    for (int i = 0; i < 2000; i++) {
+      StreamsErrorCollector.recordError("test-application", TEST_TOPIC);
     }
-
     // we have 2000 errors in one sample out of a 100. So the effective error rate computed
     // should be 20 for this run.
     assertEquals(20.0, Math.floor(MetricCollectors.currentErrorRate()), 0.1);
+    StreamsErrorCollector.notifyApplicationClose("test-application");
   }
 }

--- a/ksql-common/src/test/java/io/confluent/ksql/metrics/ProducerCollectorTest.java
+++ b/ksql-common/src/test/java/io/confluent/ksql/metrics/ProducerCollectorTest.java
@@ -13,7 +13,7 @@ public class ProducerCollectorTest {
 
   private static final String TEST_TOPIC = "test-topic".toLowerCase();
   @Test
-  public void shouldDisplayRateThroughput() throws Exception {
+  public void shouldDisplayRateThroughput() {
 
     final ProducerCollector collector = new ProducerCollector().configure(new Metrics(), "clientid", MetricCollectors.getTime());
 
@@ -25,21 +25,4 @@ public class ProducerCollectorTest {
 
     assertThat( stats.toString(), containsString("name=messages-per-sec,"));
   }
-
-  @Test
-  public void shouldRecordErrors() throws Exception {
-
-    final ProducerCollector collector = new ProducerCollector().configure(new Metrics(), "clientid", MetricCollectors.getTime());
-
-    for (int i = 0; i < 1000; i++){
-      collector.recordError(TEST_TOPIC);
-    }
-
-    final Collection<TopicSensors.Stat> stats = collector.stats("test-topic", true);
-
-    assertThat( stats.toString(), containsString("failed-messages"));
-    assertThat( stats.toString(), containsString("value=1000"));
-  }
-
-
 }

--- a/ksql-common/src/test/java/io/confluent/ksql/metrics/StreamsErrorCollectorTest.java
+++ b/ksql-common/src/test/java/io/confluent/ksql/metrics/StreamsErrorCollectorTest.java
@@ -1,0 +1,120 @@
+/**
+ * Copyright 2018 Confluent Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ **/
+
+package io.confluent.ksql.metrics;
+
+import io.confluent.ksql.metrics.TopicSensors.Stat;
+import java.util.Map;
+import java.util.stream.IntStream;
+import org.junit.Before;
+import org.junit.Test;
+
+import static io.confluent.ksql.metrics.MetricCollectors.CONSUMER_FAILED_MESSAGES;
+import static io.confluent.ksql.metrics.MetricCollectors.CONSUMER_FAILED_MESSAGES_PER_SEC;
+import static io.confluent.ksql.metrics.StreamsErrorCollector.notifyApplicationClose;
+import static io.confluent.ksql.metrics.StreamsErrorCollector.recordError;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.greaterThan;
+import static org.hamcrest.Matchers.hasItem;
+import static org.junit.Assert.assertThat;
+
+public class StreamsErrorCollectorTest {
+  private final static String TOPIC_NAME = "test-topic";
+  private final static String APPLICATION_ID_PREFIX = "test-app-id-";
+
+  private static int nApps;
+
+  private String applicationId;
+
+  private String buildApplicationId(final int index) {
+    return APPLICATION_ID_PREFIX + index;
+  }
+
+  private String buildApplicationId() {
+    nApps++;
+    return buildApplicationId(nApps);
+  }
+
+  @Before
+  public void setUp() {
+    while (nApps > 0) {
+      StreamsErrorCollector.notifyApplicationClose(buildApplicationId(nApps));
+      nApps--;
+    }
+    applicationId = buildApplicationId();
+  }
+
+  @Test
+  public void shouldCountStreamsErrors() {
+    // When:
+    final int nmsgs = 3;
+    IntStream.range(0, nmsgs).forEach(i -> recordError(applicationId, TOPIC_NAME));
+
+    // Then:
+    assertThat(
+        MetricCollectors.aggregateStat(CONSUMER_FAILED_MESSAGES, true),
+        equalTo(1.0 * nmsgs));
+  }
+
+  @Test
+  public void shouldComputeErrorRate() {
+    // When:
+    final int nmsgs = 3;
+    IntStream.range(0, nmsgs).forEach(i -> recordError(applicationId, TOPIC_NAME));
+
+    // Then:
+    assertThat(
+        MetricCollectors.aggregateStat(CONSUMER_FAILED_MESSAGES_PER_SEC, true),
+        greaterThan(0.0));
+  }
+
+  @Test
+  public void shouldComputeTopicLevelErrorStats() {
+    // Given:
+    final String otherTopic = "other-topic";
+
+    // When:
+    final int nmsgs = 3;
+    IntStream.range(0, nmsgs).forEach(i -> recordError(applicationId, TOPIC_NAME));
+    IntStream.range(0, nmsgs + 1).forEach(i -> recordError(applicationId, otherTopic));
+
+    // Then:
+    final Map<String, Stat> stats = MetricCollectors.getStatsFor(TOPIC_NAME, true);
+    assertThat(stats.keySet(), hasItem(CONSUMER_FAILED_MESSAGES));
+    assertThat(stats.get(CONSUMER_FAILED_MESSAGES).getValue(), equalTo(nmsgs * 1.0));
+    final Map<String, Stat> otherStats = MetricCollectors.getStatsFor(otherTopic, true);
+    assertThat(otherStats.keySet(), hasItem(CONSUMER_FAILED_MESSAGES));
+    assertThat(otherStats.get(CONSUMER_FAILED_MESSAGES).getValue(), equalTo((nmsgs + 1) * 1.0));
+  }
+
+  @Test
+  public void shouldComputeIndependentErrorStatsForQuery() {
+    // Given:
+    final String otherAppId = buildApplicationId();
+    final String otherTopicId = "other-topic-id";
+
+    // When:
+    final int nmsgs = 3;
+    IntStream.range(0, nmsgs).forEach(i -> recordError(applicationId, TOPIC_NAME));
+    IntStream.range(0, nmsgs + 1).forEach(i -> recordError(otherAppId, otherTopicId));
+    notifyApplicationClose(otherAppId);
+
+    // Then:
+    assertThat(
+        MetricCollectors.aggregateStat(CONSUMER_FAILED_MESSAGES, true),
+        equalTo(nmsgs * 1.0));
+  }
+}

--- a/ksql-common/src/test/java/io/confluent/ksql/metrics/StreamsErrorCollectorTest.java
+++ b/ksql-common/src/test/java/io/confluent/ksql/metrics/StreamsErrorCollectorTest.java
@@ -36,17 +36,17 @@ public class StreamsErrorCollectorTest {
   private final static String TOPIC_NAME = "test-topic";
   private final static String APPLICATION_ID_PREFIX = "test-app-id-";
 
-  private static int nApps;
+  private static int appCounter;
 
   private String applicationId;
 
-  private String buildApplicationId(final int index) {
+  private static String buildApplicationId(final int index) {
     return APPLICATION_ID_PREFIX + index;
   }
 
-  private String buildApplicationId() {
-    nApps++;
-    return buildApplicationId(nApps);
+  private static String buildApplicationId() {
+    appCounter++;
+    return buildApplicationId(appCounter);
   }
 
   @Before
@@ -56,9 +56,9 @@ public class StreamsErrorCollectorTest {
 
   @After
   public void tearDown() {
-    while (nApps > 0) {
-      StreamsErrorCollector.notifyApplicationClose(buildApplicationId(nApps));
-      nApps--;
+    while (appCounter > 0) {
+      StreamsErrorCollector.notifyApplicationClose(buildApplicationId(appCounter));
+      appCounter--;
     }
   }
 

--- a/ksql-engine/src/main/java/io/confluent/ksql/util/QueryMetadata.java
+++ b/ksql-engine/src/main/java/io/confluent/ksql/util/QueryMetadata.java
@@ -18,6 +18,7 @@ package io.confluent.ksql.util;
 
 import io.confluent.kafka.schemaregistry.client.SchemaRegistryClient;
 import io.confluent.ksql.internal.QueryStateListener;
+import io.confluent.ksql.metrics.StreamsErrorCollector;
 import io.confluent.ksql.planner.PlanSourceExtractorVisitor;
 import io.confluent.ksql.planner.plan.OutputNode;
 import io.confluent.ksql.serde.DataSource;
@@ -116,7 +117,6 @@ public class QueryMetadata {
   }
 
   public void close() {
-
     kafkaStreams.close();
     if (kafkaStreams.state() == KafkaStreams.State.NOT_RUNNING) {
       kafkaStreams.cleanUp();
@@ -126,6 +126,7 @@ public class QueryMetadata {
                 queryApplicationId, kafkaStreams.state());
     }
     queryStateListener.ifPresent(QueryStateListener::close);
+    StreamsErrorCollector.notifyApplicationClose(queryApplicationId);
   }
 
   private Set<String> getInternalSubjectNameSet(final SchemaRegistryClient schemaRegistryClient) {

--- a/ksql-engine/src/test/resources/query-validation-tests/average.json
+++ b/ksql-engine/src/test/resources/query-validation-tests/average.json
@@ -12,21 +12,21 @@
       "name": "calculate average in select",
       "statements": [
         "CREATE STREAM TEST (ID bigint, NAME varchar, VALUE bigint) WITH (kafka_topic='test_topic', value_format='DELIMITED', key='ID');",
-        "CREATE STREAM AVG AS select id, sum(value)/count(id) as avg from test GROUP BY id;"
+        "CREATE STREAM AVG AS select id, abs(sum(value)/count(id)) * 10 as avg from test GROUP BY id;"
       ],
       "inputs": [
-        {"topic": "test_topic", "key": 0, "value": "0,zero,50", "timestamp": 0},
-        {"topic": "test_topic", "key": 0, "value": "0,zero,10", "timestamp": 0},
-        {"topic": "test_topic", "key": 0, "value": "0,zero,15", "timestamp": 0},
+        {"topic": "test_topic", "key": 0, "value": "0,zero,-50", "timestamp": 0},
+        {"topic": "test_topic", "key": 0, "value": "0,zero,-10", "timestamp": 0},
+        {"topic": "test_topic", "key": 0, "value": "0,zero,-15", "timestamp": 0},
         {"topic": "test_topic", "key": 1, "value": "1,one,100", "timestamp": 0},
         {"topic": "test_topic", "key": 1, "value": "1,one,10", "timestamp": 0}
       ],
       "outputs": [
-        {"topic": "AVG", "key": 0, "value": "0,50", "timestamp": 0},
-        {"topic": "AVG", "key": 0, "value": "0,30", "timestamp": 0},
-        {"topic": "AVG", "key": 0, "value": "0,25", "timestamp": 0},
-        {"topic": "AVG", "key": 1, "value": "1,100", "timestamp": 0},
-        {"topic": "AVG", "key": 1, "value": "1,55", "timestamp": 0}
+        {"topic": "AVG", "key": 0, "value": "0,500.0", "timestamp": 0},
+        {"topic": "AVG", "key": 0, "value": "0,300.0", "timestamp": 0},
+        {"topic": "AVG", "key": 0, "value": "0,250.0", "timestamp": 0},
+        {"topic": "AVG", "key": 1, "value": "1,1000.0", "timestamp": 0},
+        {"topic": "AVG", "key": 1, "value": "1,550.0", "timestamp": 0}
       ]
     }
   ]

--- a/ksql-metastore/src/main/java/io/confluent/ksql/metastore/StructuredDataSource.java
+++ b/ksql-metastore/src/main/java/io/confluent/ksql/metastore/StructuredDataSource.java
@@ -88,6 +88,10 @@ public abstract class StructuredDataSource implements DataSource {
     return ksqlTopic.getTopicName();
   }
 
+  public String getKafkaTopicName() {
+    return ksqlTopic.getKafkaTopicName();
+  }
+
   public abstract QueryId getPersistentQueryId();
 
   public String getSqlExpression() {

--- a/ksql-rest-app/src/main/java/io/confluent/ksql/rest/entity/SourceDescription.java
+++ b/ksql-rest-app/src/main/java/io/confluent/ksql/rest/entity/SourceDescription.java
@@ -107,25 +107,25 @@ public class SourceDescription {
         Optional.ofNullable(dataSource.getKeyField()).map(Field::name).orElse(""),
         Optional.ofNullable(dataSource.getTimestampExtractionPolicy())
             .map(TimestampExtractionPolicy::timestampField).orElse(""),
-        (extended ? MetricCollectors.getStatsFor(dataSource.getTopicName(), false) : ""),
-        (extended ? MetricCollectors.getStatsFor(dataSource.getTopicName(), true) : ""),
+        (extended
+            ? MetricCollectors.getAndFormatStatsFor(
+                dataSource.getKafkaTopicName(), false) : ""),
+        (extended
+            ? MetricCollectors.getAndFormatStatsFor(
+                dataSource.getKafkaTopicName(), true) : ""),
         extended,
         format,
-        dataSource.getKsqlTopic().getKafkaTopicName(),
+        dataSource.getKafkaTopicName(),
         (
             extended && topicClient != null ? getPartitions(
                 topicClient,
-                dataSource
-                    .getKsqlTopic()
-                    .getKafkaTopicName()
+                dataSource.getKafkaTopicName()
             ) : 0
         ),
         (
             extended && topicClient != null ? getReplication(
                 topicClient,
-                dataSource
-                    .getKsqlTopic()
-                    .getKafkaTopicName()
+                dataSource.getKafkaTopicName()
             ) : 0
         )
     );

--- a/ksql-rest-app/src/test/java/io/confluent/ksql/rest/entity/SourceDescriptionTest.java
+++ b/ksql-rest-app/src/test/java/io/confluent/ksql/rest/entity/SourceDescriptionTest.java
@@ -1,0 +1,105 @@
+/**
+ * Copyright 2018 Confluent Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ **/
+
+package io.confluent.ksql.rest.entity;
+
+import static org.hamcrest.CoreMatchers.containsString;
+import static org.junit.Assert.assertThat;
+
+import com.google.common.collect.ImmutableMap;
+import io.confluent.ksql.metastore.KsqlStream;
+import io.confluent.ksql.metastore.KsqlTopic;
+import io.confluent.ksql.metastore.StructuredDataSource;
+import io.confluent.ksql.metrics.ConsumerCollector;
+import io.confluent.ksql.metrics.MetricCollectors;
+import io.confluent.ksql.metrics.StreamsErrorCollector;
+import io.confluent.ksql.serde.json.KsqlJsonTopicSerDe;
+import io.confluent.ksql.util.timestamp.MetadataTimestampExtractionPolicy;
+import java.util.Arrays;
+import java.util.Collections;
+import org.apache.kafka.clients.consumer.ConsumerConfig;
+import org.apache.kafka.clients.consumer.ConsumerRecord;
+import org.apache.kafka.clients.consumer.ConsumerRecords;
+import org.apache.kafka.common.TopicPartition;
+import org.apache.kafka.common.record.TimestampType;
+import org.apache.kafka.connect.data.Schema;
+import org.apache.kafka.connect.data.SchemaBuilder;
+import org.junit.Test;
+
+public class SourceDescriptionTest {
+  private StructuredDataSource buildDataSource(final String kafkaTopicName) {
+    final Schema schema = SchemaBuilder.struct()
+        .field("field0", Schema.OPTIONAL_INT32_SCHEMA)
+        .build();
+    final KsqlTopic topic = new KsqlTopic("internal", kafkaTopicName, new KsqlJsonTopicSerDe());
+    return new KsqlStream(
+        "query", "stream", schema, schema.fields().get(0),
+        new MetadataTimestampExtractionPolicy(), topic);
+  }
+
+  private ConsumerRecords buildRecords(final String kafkaTopicName) {
+    return new ConsumerRecords<>(
+        ImmutableMap.of(
+            new TopicPartition(kafkaTopicName, 1), Arrays.asList(
+                new ConsumerRecord<>(
+                    kafkaTopicName,
+                    1,
+                    1,
+                    1l,
+                    TimestampType.CREATE_TIME,
+                    1l,
+                    10,
+                    10,
+                    "key",
+                    "1234567890")
+            )
+        )
+    );
+  }
+
+  @Test
+  public void shouldReturnStatsBasedOnKafkaTopic() {
+    // Given:
+    final String kafkaTopicName = "kafka";
+    final String appId = "app";
+    final StructuredDataSource dataSource = buildDataSource(kafkaTopicName);
+    final ConsumerCollector consumerCollector = new ConsumerCollector();
+
+    // When:
+    consumerCollector.configure(
+        Collections.singletonMap(ConsumerConfig.CLIENT_ID_CONFIG, "client"));
+    consumerCollector.onConsume(buildRecords(kafkaTopicName));
+    StreamsErrorCollector.recordError(appId, kafkaTopicName);
+    final SourceDescription sourceDescription = new SourceDescription(
+        dataSource,
+        true,
+        "json",
+        Collections.emptyList(),
+        Collections.emptyList(),
+        null);
+
+    // Then:
+    assertThat(
+        sourceDescription.getStatistics(),
+        containsString(MetricCollectors.CONSUMER_TOTAL_MESSAGES));
+    assertThat(
+        sourceDescription.getErrorStats(),
+        containsString(MetricCollectors.CONSUMER_FAILED_MESSAGES));
+
+    StreamsErrorCollector.notifyApplicationClose(appId);
+    consumerCollector.close();
+  }
+}


### PR DESCRIPTION
This patch refactors the metrics collection code a bit, and fixes some
bugs along the way:

Clean up the MetricCollector interface. The functions that actually collect
metrics can be left out of this interface - they are specific to the type of
collector. It really should just be an interface for MetricCollectors to
query metrics values from.

Rather than codifying the different metrics into their own functions, access
them by string constants. This reduces the boilerplate needed for adding new
metrics.

Move error collection metrics into a new collector - StreamsErrorCollector.
StreamsErrorCollector is invoked directly from the streams error handler. There
is an instance for each running streams app that has hit an error. This change
ensures that error metric counts are associated with apps. Previously, errors
would be counted against an arbitrary producer or consumer collector, which
could result in invalid error metric values after queries are teminated.

Use the kafka topic name to get metrics for SourceDescription.

### Description 
_What behavior do you want to change, why, how does your patch achieve the changes?_

### Testing done 
_Describe the testing strategy. Unit and integration tests are expected for any behavior changes._

### Reviewer checklist
- [ ] Ensure docs are updated if necessary. (eg. if a user visible feature is being added or changed).
- [ ] Ensure relevant issues are linked (description should include text like "Fixes #<issue number>")

