### PR TITLE
KSQL-1709: Replace plaintext code blocks with ::

### DIFF
--- a/docs/installation/installing.rst
+++ b/docs/installation/installing.rst
@@ -70,7 +70,7 @@ Tip
 
     Here are the default settings:
 
-    .. code:: bash
+    ::
 
         bootstrap.servers=localhost:9092
         listeners=http://localhost:8088
@@ -92,7 +92,7 @@ Tip
 
 .. tip:: You can view the KSQL server help text by running ``<path-to-confluent>/bin/ksql-server-start --help``.
 
-         .. code:: bash
+         ::
 
                 NAME
                         server - KSQL Cluster
@@ -146,10 +146,9 @@ After KSQL is started, your terminal should resemble this.
     :start-line: 19
     :end-line: 40
 
-Tip
-    You can view the KSQL CLI help text by running ``<path-to-confluent>/bin/ksql --help``.
+.. tip:: You can view the KSQL CLI help text by running ``<path-to-confluent>/bin/ksql --help``.
 
-    .. code:: bash
+    ::
 
             NAME
                     ksql - KSQL CLI

--- a/docs/tutorials/basics-docker.rst
+++ b/docs/tutorials/basics-docker.rst
@@ -83,7 +83,7 @@ following methods.
 
    Your data input should resemble this.
 
-   .. code:: bash
+   ::
 
        key1:v1,v2,v3
        key2:v4,v5,v6
@@ -100,7 +100,7 @@ following methods.
 
    Your data input should resemble this.
 
-   .. code:: bash
+   ::
 
        key1:{"id":"key1","col1":"v1","col2":"v2","col3":"v3"}
        key2:{"id":"key2","col1":"v4","col2":"v5","col3":"v6"}
@@ -121,7 +121,7 @@ environment is properly setup.
 
    Your output should resemble this. Take note of the ``Up`` state.
 
-   .. code:: bash
+   ::
 
                Name                        Command               State                           Ports
        -------------------------------------------------------------------------------------------------------------------------
@@ -143,7 +143,7 @@ environment is properly setup.
 
    Your output should resemble this.
 
-   .. code:: bash
+   ::
 
        _confluent-metrics
        _schemas
@@ -161,7 +161,7 @@ environment is properly setup.
 
    Your output should resemble this.
 
-   .. code:: bash
+   ::
 
        1491040409254    1491040409254,User_5,Page_70
        1488611895904    1488611895904,User_8,Page_76
@@ -173,7 +173,7 @@ environment is properly setup.
 
    Your output should resemble this.
 
-   .. code:: bash
+   ::
 
        User_2   {"registertime":1509789307038,"gender":"FEMALE","regionid":"Region_1","userid":"User_2"}
        User_6   {"registertime":1498248577697,"gender":"OTHER","regionid":"Region_8","userid":"User_6"}

--- a/docs/tutorials/clickstream-docker.rst
+++ b/docs/tutorials/clickstream-docker.rst
@@ -23,7 +23,7 @@ your local host.
 
 Your output should resemble:
 
-.. code:: bash
+::
 
     Unable to find image 'confluentinc/ksql-clickstream-demo:4.1.0' locally
     latest: Pulling from confluentinc/ksql-clickstream-demo
@@ -63,7 +63,7 @@ Configure and Start Elastic, Grafana, and |cp|
 
     Your output should resemble:
 
-    .. code:: bash
+    ::
 
         [....] Starting Elasticsearch Server:sysctl: setting key "vm.max_map_count": Read-only file system
         . ok
@@ -76,7 +76,7 @@ Configure and Start Elastic, Grafana, and |cp|
 
     Your output should resemble:
 
-    .. code:: bash
+    ::
 
         [ ok ] Starting Grafana Server:.
 
@@ -88,7 +88,7 @@ Configure and Start Elastic, Grafana, and |cp|
 
     Your output should resemble:
 
-    .. code:: bash
+    ::
 
         Starting zookeeper
         zookeeper is [UP]
@@ -120,7 +120,7 @@ Create the Clickstream Data
 
     Your output should resemble:
 
-    .. code:: bash
+    ::
 
         Writing console output to /tmp/ksql-logs/ksql.out
 
@@ -132,7 +132,7 @@ Create the Clickstream Data
 
     Your output should resemble:
 
-    .. code:: bash
+    ::
 
         200 --> ([ 200 | 'Successful' ])
         302 --> ([ 302 | 'Redirect' ])
@@ -148,7 +148,7 @@ Create the Clickstream Data
 
     Your output should resemble:
 
-    .. code:: bash
+    ::
 
         1 --> ([ 1 | 'GlenAlan_23344' | 1424796387808 | 'Curran' | 'Lalonde' | 'Palo Alto' | 'Gold' ])
         2 --> ([ 2 | 'ArlyneW8ter' | 1433932319457 | 'Oriana' | 'Vanyard' | 'London' | 'Platinum' ])
@@ -183,7 +183,7 @@ Load the Streaming Data to KSQL
 
     The output should resemble:
 
-    .. code:: bash
+    ::
 
          Message
         ---------
@@ -204,7 +204,7 @@ Verify the data
 
     Your output should resemble:
 
-    .. code:: bash
+    ::
 
          Table Name                 | Kafka Topic                | Format | Windowed
         -----------------------------------------------------------------------------
@@ -227,7 +227,7 @@ Verify the data
 
     Your output should resemble:
 
-    .. code:: bash
+    ::
 
          Stream Name               | Kafka Topic               | Format
         ----------------------------------------------------------------
@@ -247,7 +247,7 @@ Verify the data
 
     Your output should resemble:
 
-    .. code:: bash
+    ::
 
         1503585407989 | 222.245.174.248 | 1503585407989 | 24/Aug/2017:07:36:47 -0700 | 233.90.225.227 | GET /site/login.html HTTP/1.1 | 407 | 19 | 4096 | Mozilla/5.0 (compatible; Googlebot/2.1; +http://www.google.com/bot.html)
         1503585407999 | 233.168.257.122 | 1503585407999 | 24/Aug/2017:07:36:47 -0700 | 233.173.215.103 | GET /site/user_status.html HTTP/1.1 | 200 | 15 | 14096 | Mozilla/5.0 (compatible; Googlebot/2.1; +http://www.google.com/bot.html)
@@ -265,7 +265,7 @@ Verify the data
 
     Your output should resemble:
 
-    .. code:: bash
+    ::
 
         1521108180000 | 6 : Window{start=1521108180000 end=-} | 6 | 24
         1521108180000 | 4 : Window{start=1521108180000 end=-} | 4 | 23
@@ -284,7 +284,7 @@ Verify the data
 
     Your output should resemble:
 
-    .. code:: bash
+    ::
 
         1503585475000 | 4 : Window{start=1503585475000 end=-} | 4 | 14
         1503585480000 | 25 : Window{start=1503585480000 end=-} | 25 | 9
@@ -323,7 +323,7 @@ Send the KSQL tables to Elasticsearch and Grafana.
 
    Your output should resemble:
 
-   .. code:: bash
+   ::
 
        Loading Clickstream-Demo TABLES to Confluent-Connect => Elastic => Grafana datasource
        Logging to: /tmp/ksql-connect.log
@@ -346,7 +346,7 @@ Send the KSQL tables to Elasticsearch and Grafana.
 
    Your output should resemble:
 
-   .. code:: bash
+   ::
 
        Loading Grafana ClickStream Dashboard
        {"id":1,"slug":"click-stream-analysis","status":"success","uid":"VhmK8Mkik","url":"/d/VhmK8Mkik/click-stream-analysis","version":1}


### PR DESCRIPTION
### Description 
Replace `.. code:: bash` blocks with `::` blocks to fix doc build warnings.