### PR TITLE
Remove hardcoded tag and use default from dockerfile

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,7 +1,6 @@
 #!/usr/bin/env groovy
 
 dockerfile {
-    dockerUpstreamTag = '4.1.x-latest'  // Make sure PR builder points at a valid upstream tag.
     slackChannel = '#ksql-eng'
     upstreamProjects = 'confluentinc/schema-registry'
     dockerRepos = ['confluentinc/ksql-examples', 'confluentinc/ksql-cli', 'confluentinc/ksql-clickstream-demo', 'confluentinc/cp-ksql-server', 'confluentinc/cp-ksql-cli']


### PR DESCRIPTION
### Description 
The hardcoded tag won't work for other branches. Switch to auto-computed tag from https://github.com/confluentinc/jenkins-common/pull/75

### Testing done 
Ran test job with new jenkins-common and it correctly use the branch name (https://jenkins.confluent.io/job/mzheng-test-multibranch-pipeline/job/remove-use@4.1.x/1/console). As for PR, it's hard to test Jenkinsfile stuff for PR, but it should work.

### Reviewer checklist
- [ ] Ensure docs are updated if necessary. (eg. if a user visible feature is being added or changed).
- [ ] Ensure relevant issues are linked (description should include text like "Fixes #<issue number>")

