### PR TITLE
KSQL-1707: Fix doc build warnings

### DIFF
--- a/docs/installation/server-config/security.rst
+++ b/docs/installation/server-config/security.rst
@@ -1,7 +1,7 @@
 .. _ksql-security:
 
 Configuring Security for KSQL
-=============
+=============================
 
 KSQL supports many of the security features of both Apache Kafka and the |sr|.
 
@@ -34,7 +34,7 @@ The following configuration connects KSQL with the Confluent Schema Registry ove
 #. Specify the HTTPS endpoint in the ``ksql.schema.registry.url`` setting in the
    KSQL server configuration file:
 
-   .. code:: bash
+   ::
 
         ksql.schema.registry.url=https://<host-name-of-schema-registry>:<ssl-port>
 
@@ -66,7 +66,8 @@ Configuring Kafka Encrypted Communication
 
 This configuration enables KSQL to connect to a Kafka cluster over SSL, with a user supplied trust store:
 
-.. code:: bash
+::
+
     security.protocol=SSL
     ssl.truststore.location=/etc/kafka/secrets/kafka.client.truststore.jks
     ssl.truststore.password=confluent
@@ -84,7 +85,7 @@ Configuring Kafka Authentication
 This configuration enables KSQL to connect to a secure Kafka cluster using PLAIN SASL, where the SSL certificates have been
 signed by a CA trusted by the default JVM trust store.
 
-.. code:: bash
+::
 
     security.protocol=SASL_SSL
     sasl.mechanism=PLAIN
@@ -135,7 +136,7 @@ the principal is the user the KSQL server has authenticated as, with the Apache 
 that includes the authenticated KSQL user.
 
 .. tip:: For more information about ACLs see :ref:`kafka_authorization` and for more information about interactive and
-non-interactive queries, see :ref:`restrict-ksql-interactive`.
+   non-interactive queries, see :ref:`restrict-ksql-interactive`.
 
 .. _config-security-ksql-acl-interactive:
 
@@ -225,8 +226,7 @@ Configuring |c3-short| Monitoring Interceptors
 This configuration enables SASL and SSL for the :ref:`monitoring intercepts <controlcenter_clients>` that integrate KSQL
 with |c3-short|.
 
-
-.. code:: bash
+::
 
     # Confluent Monitoring Interceptors for Control Center streams monitoring
     producer.interceptor.classes=io.confluent.monitoring.clients.interceptor.MonitoringProducerInterceptor


### PR DESCRIPTION
### Description 
Replace `.. code: bash` blocks with `::` blocks.