### PR TITLE
KSQL-1707: Fix doc build warnings

### DIFF
--- a/docs/installation/server-config/security.rst
+++ b/docs/installation/server-config/security.rst
@@ -8,7 +8,7 @@ KSQL supports many of the security features of both Apache Kafka and |sr|.
 - KSQL supports Apache Kafka security features such as :ref:`SSL for encryption <kafka_ssl_encryption>`,
   :ref:`SASL for authentication <kafka_sasl_auth>`, and :ref:`authorization with ACLs <kafka_authorization>`.
 - KSQL supports :ref:`Schema Registry security features <schemaregistry_security>` such SSL for encryption
-and mutual authentication for authorization.
+  and mutual authentication for authorization.
 
 To configure security for KSQL, add your configuration settings to the ``<path-to-confluent>/etc/ksql/ksql-server.properties``
 file and then :ref:`start the KSQL server <start_ksql-server>` with your configuration file specified.
@@ -57,7 +57,7 @@ Use the following to configure KSQL to communicate with |sr| over HTTPS, with
 mutual authentication, with an explicit trustStore, and where the SSL configuration is shared
 between Kafka and |sr|:
 
-.. code:: bash
+::
 
     ksql.schema.registry.url=https://<host-name-of-schema-registry>:<ssl-port>
     ssl.truststore.location=/etc/kafka/secrets/ksql.truststore.jks
@@ -70,7 +70,7 @@ Use the following to configure KSQL to communicate with |sr| over HTTP, without
 mutual authentication and with an explicit trustStore. These settings explicitly configure only
 KSQL to |sr| SSL communication.
 
-.. code:: bash
+::
 
     ksql.schema.registry.url=https://<host-name-of-schema-registry>:<ssl-port>
     ksql.schema.registry.ssl.truststore.location=/etc/kafka/secrets/sr.truststore.jks
@@ -82,7 +82,8 @@ The exact settings will vary depending on the encryption and authentication mech
 You can pass authentication settings to the |sr| client used by KSQL
 by adding the following to your KSQL server config.
 
-.. code:: bash
+::
+
     ksql.schema.registry.basic.auth.credentials.source=USER_INFO
     ksql.schema.registry.basic.auth.user.info=username:password
 


### PR DESCRIPTION
### Description 
Replace `..code:: bash` blocks with `::` blocks for plaintext.