### PR TITLE
KSQL-1718: Fix duplicate label in sql-includes.rst

### DIFF
--- a/docs/includes/ksql-includes.rst
+++ b/docs/includes/ksql-includes.rst
@@ -80,7 +80,7 @@ After KSQL is started, your terminal should resemble this.
   :start-line: 19
   :end-line: 40
 
-.. _create-a-stream-and-table:
+.. _create-a-stream-and-table-inc:
 
 -------------------------
 Create a Stream and Table


### PR DESCRIPTION
### Description 
Rename `create-a-stream-and-table` label to `create-a-stream-and-table-inc`.