### PR TITLE
KSQL-1718: Fix build warnings in ksql-includes.rst

### DIFF
--- a/docs/includes/ksql-includes.rst
+++ b/docs/includes/ksql-includes.rst
@@ -1,4 +1,4 @@
-.. _offsetreset_start
+.. offsetreset_start
 
 .. tip:: Run the following to tell KSQL to read from the `beginning` of the topic: 
 
@@ -9,7 +9,7 @@
     `You can skip this if you have already run it within your current`
     `KSQL CLI session.`
 
-.. _offsetreset_end
+.. offsetreset_end
 
 .. Avro_note_start
 
@@ -106,8 +106,6 @@ After KSQL is started, your terminal should resemble this.
 .. basics_tutorial_02_end
 
 .. basics_tutorial_03_start
-
-.. _create-a-stream-and-table-inc:
 
 -------------------------
 Create a Stream and Table
@@ -440,7 +438,7 @@ To enable JMX metrics, set ``JMX_PORT`` before starting the KSQL server:
 
 .. log_limitations_end
 
-.. __struct_support_01_start
+.. struct_support_01_start
 
 Using Nested Schemas (STRUCT) in KSQL
 -------------------------------------
@@ -452,9 +450,9 @@ Here we’ll use the ``ksql-datagen`` tool to create some sample data
 which includes a nested ``address`` field. Run this in a new window, and 
 leave it running. 
 
-.. __struct_support_01_end
+.. struct_support_01_end
 
-.. __struct_support_02_start
+.. struct_support_02_start
 
 From the KSQL command prompt, register the topic in KSQL:
 
@@ -515,11 +513,11 @@ Your output should resemble:
 Press Ctrl-C to cancel the ``SELECT`` query. 
 
 
-.. __struct_support_02_end
+.. struct_support_02_end
 
-.. __stream_stream_join:
+.. stream_stream_join:
 
-.. __ss-join_01_start
+.. ss-join_01_start
 
 Stream-Stream join
 ------------------
@@ -531,9 +529,9 @@ key, it is possible to see shipment information alongside the order.
 
 First, populate the ``orders`` and ``shipments`` topics:
 
-.. __ss-join_01_end
+.. ss-join_01_end
 
-.. __ss-join_02_start
+.. ss-join_02_start
 
 Register both topics with KSQL:
 
@@ -557,8 +555,8 @@ After each ``CREATE STREAM`` statement you should get the message:
 Query the data to confirm that it is present in the topics. 
 
 .. include:: ../includes/ksql-includes.rst
-    :start-after: _offsetreset_start
-    :end-before: _offsetreset_end
+    :start-after: offsetreset_start
+    :end-before: offsetreset_end
 
 For the ``NEW_ORDERS`` topic, run: 
 
@@ -614,11 +612,11 @@ specified.
 Press Ctrl-C to cancel the ``SELECT`` query and return to the KSQL prompt.
 
 
-.. __ss-join_02_end
+.. ss-join_02_end
 
-.. __table_table_join:
+.. table_table_join:
 
-.. __tt-join_01_start
+.. tt-join_01_start
 
 Table-Table join
 ----------------
@@ -633,9 +631,9 @@ being enriched with data about the size of the warehouse from another.
 
 First, populate the two topics:
 
-.. __tt-join_01_end
+.. tt-join_01_end
 
-.. __tt-join_02_start
+.. tt-join_02_start
 
 Register both as KSQL tables:
 
@@ -716,11 +714,9 @@ Your output should resemble:
     Limit Reached
     Query terminated
 
-.. __tt-join_02_end
+.. tt-join_02_end
 
-.. __insert_into:
-
-.. __insert-into_01_start
+.. insert-into-01-start
 
 INSERT INTO
 -----------
@@ -732,9 +728,9 @@ from different sources.
 Run two datagen processes, each writing to a different topic, simulating
 order data arriving from a local installation vs from a third-party:
 
-.. __insert-into_01_end
+.. insert-into-01-end
 
-.. __insert-into_02_start
+.. insert-into_02_start
 
 In KSQL, register the source topic for each:
 
@@ -853,5 +849,5 @@ Your output should resemble:
     InsertQuery_1     | ALL_ORDERS  | INSERT INTO ALL_ORDERS SELECT '3RD PARTY' AS SRC, * FROM ORDERS_SRC_3RDPARTY;
     -------------------------------------------------------------------------------------------------------------------
 
-.. __insert-into_02_end
+.. insert-into_02_end
 

--- a/docs/tutorials/basics-docker.rst
+++ b/docs/tutorials/basics-docker.rst
@@ -76,11 +76,11 @@ Download the Tutorial and Start KSQL
     :start-after: basics_tutorial_03_start
     :end-before: basics_tutorial_03_end
 
-.. _struct_support: 
+.. _struct-support-docker: 
 
 .. include:: ../includes/ksql-includes.rst
-    :start-after: __struct_support_01_start
-    :end-before: __struct_support_01_end
+    :start-after: struct_support_01_start
+    :end-before: struct_support_01_end
 
 .. code:: bash
 
@@ -94,14 +94,14 @@ Download the Tutorial and Start KSQL
             schemaRegistryUrl=http://schema-registry:8081
 
 .. include:: ../includes/ksql-includes.rst
-    :start-after: __struct_support_02_start
-    :end-before: __struct_support_02_end
+    :start-after: struct_support_02_start
+    :end-before: struct_support_02_end
 
-.. _ss-joins: 
+.. _ss-joins-docker:
 
 .. include:: ../includes/ksql-includes.rst
-    :start-after: __ss-join_01_start
-    :end-before: __ss-join_01_end
+    :start-after: ss-join_01_start
+    :end-before: ss-join_01_end
 
 .. code:: bash
 
@@ -129,14 +129,14 @@ Download the Tutorial and Start KSQL
     EOF
 
 .. include:: ../includes/ksql-includes.rst
-    :start-after: __ss-join_02_start
-    :end-before: __ss-join_02_end
+    :start-after: ss-join_02_start
+    :end-before: ss-join_02_end
 
-.. _tt-joins: 
+.. _tt-joins-docker: 
 
 .. include:: ../includes/ksql-includes.rst
-    :start-after: __tt-join_01_start
-    :end-before: __tt-join_01_end
+    :start-after: tt-join_01_start
+    :end-before: tt-join_01_end
 
 .. code:: bash
 
@@ -165,14 +165,14 @@ Download the Tutorial and Start KSQL
     EOF
 
 .. include:: ../includes/ksql-includes.rst
-    :start-after: __tt-join_02_start
-    :end-before: __tt-join_02_end
+    :start-after: tt-join_02_start
+    :end-before: tt-join_02_end
 
-.. _insert-into: 
+.. _insert-into-docker:
 
 .. include:: ../includes/ksql-includes.rst
-    :start-after: __insert-into_01_start
-    :end-before: __insert-into_01_end
+    :start-after: insert-into-01-start
+    :end-before: insert-into-01-end
 
 .. code:: bash
 
@@ -197,10 +197,10 @@ Download the Tutorial and Start KSQL
             schemaRegistryUrl=http://schema-registry:8081
 
 .. include:: ../includes/ksql-includes.rst
-    :start-after: __insert-into_02_start
-    :end-before: __insert-into_02_end
+    :start-after: insert-into_02_start
+    :end-before: insert-into_02_end
 
-.. _terminate: 
+.. _terminate-docker: 
 
 .. include:: ../includes/ksql-includes.rst
     :start-after: terminate_and_exit__start

--- a/docs/tutorials/basics-local.rst
+++ b/docs/tutorials/basics-local.rst
@@ -34,11 +34,11 @@ Watch the `screencast of Reading Kafka Data from KSQL <https://www.youtube.com/e
       :start-after: basics_tutorial_03_start
       :end-before: basics_tutorial_03_end
 
-.. _struct_support: 
+.. _struct-support-local: 
 
 .. include:: ../includes/ksql-includes.rst
-    :start-after: __struct_support_01_start
-    :end-before: __struct_support_01_end
+    :start-after: struct_support_01_start
+    :end-before: struct_support_01_end
 
 .. code:: bash
 
@@ -48,14 +48,14 @@ Watch the `screencast of Reading Kafka Data from KSQL <https://www.youtube.com/e
             topic=orders 
 
 .. include:: ../includes/ksql-includes.rst
-    :start-after: __struct_support_02_start
-    :end-before: __struct_support_02_end
+    :start-after: struct_support_02_start
+    :end-before: struct_support_02_end
 
-.. _ss-joins: 
+.. _ss-joins-local: 
 
 .. include:: ../includes/ksql-includes.rst
-    :start-after: __ss-join_01_start
-    :end-before: __ss-join_01_end
+    :start-after: ss-join_01_start
+    :end-before: ss-join_01_end
 
 .. code:: bash
 
@@ -86,15 +86,15 @@ Watch the `screencast of Reading Kafka Data from KSQL <https://www.youtube.com/e
             Error while fetching metadata with correlation id 1 : {shipments=LEADER_NOT_AVAILABLE} (org.apache.kafka.clients.NetworkClient)
 
 .. include:: ../includes/ksql-includes.rst
-    :start-after: __ss-join_02_start
-    :end-before: __ss-join_02_end
+    :start-after: ss-join_02_start
+    :end-before: ss-join_02_end
 
 
-.. _tt-joins: 
+.. _tt-joins-local: 
 
 .. include:: ../includes/ksql-includes.rst
-    :start-after: __tt-join_01_start
-    :end-before: __tt-join_01_end
+    :start-after: tt-join_01_start
+    :end-before: tt-join_01_end
 
 .. code:: bash
 
@@ -119,14 +119,14 @@ Watch the `screencast of Reading Kafka Data from KSQL <https://www.youtube.com/e
     EOF
 
 .. include:: ../includes/ksql-includes.rst
-    :start-after: __tt-join_02_start
-    :end-before: __tt-join_02_end
+    :start-after: tt-join_02_start
+    :end-before: tt-join_02_end
 
-.. _insert-into: 
+.. _insert-into-local: 
 
 .. include:: ../includes/ksql-includes.rst
-    :start-after: __insert-into_01_start
-    :end-before: __insert-into_01_end
+    :start-after: insert-into-01-start
+    :end-before: insert-into-01-end
 
 .. tip:: Each of these commands should be run in a separate window. When the exercise is finished, exit them by pressing Ctrl-C.
 
@@ -143,10 +143,10 @@ Watch the `screencast of Reading Kafka Data from KSQL <https://www.youtube.com/e
             topic=orders_3rdparty 
 
 .. include:: ../includes/ksql-includes.rst
-    :start-after: __insert-into_02_start
-    :end-before: __insert-into_02_end
+    :start-after: insert-into_02_start
+    :end-before: insert-into_02_end
 
-.. _terminate: 
+.. _terminate-local: 
 
 .. include:: ../includes/ksql-includes.rst
       :start-after: terminate_and_exit__start


### PR DESCRIPTION
### Description 
Remove prepended `__` from labels, which were generating malformed links.
