### PR TITLE
KSQL-1723: Fix misplaced labels

### DIFF
--- a/docs/developer-guide/syntax-reference.rst
+++ b/docs/developer-guide/syntax-reference.rst
@@ -263,8 +263,6 @@ Example:
       WITH (VALUE_FORMAT = 'JSON',
             KAFKA_TOPIC = 'my-pageviews-topic');
 
-.. _create-table:
-
 If the name of a column in your source topic is one of the reserved words in KSQL you can use back quotes to define the column.
 The same applies to the field names in a STRUCT type.
 For indsance, if in the above example we had another field called ``Properties``, which is a reserved word in KSQL, you can
@@ -276,8 +274,7 @@ use the following statement to declare your stream:
       WITH (VALUE_FORMAT = 'JSON',
             KAFKA_TOPIC = 'my-pageviews-topic');
 
-.. _create-stream-reserved:
-
+.. _create-table:
 
 CREATE TABLE
 ------------
@@ -363,11 +360,9 @@ Example:
         KAFKA_TOPIC = 'my-users-topic',
         KEY = 'user_id');
 
-.. _create-stream-as-select:
-
 If the name of a column in your source topic is one of the reserved words in KSQL you can use back quotes to define the column.
 The same applies to the field names in a STRUCT type.
-For indsance, if in the above example we had another field called ``Properties``, which is a reserved word in KSQL, you can
+For instance, if in the above example we had another field called ``Properties``, which is a reserved word in KSQL, you can
 use the following statement to declare your table:
 
 .. code:: sql
@@ -376,7 +371,7 @@ use the following statement to declare your table:
             KAFKA_TOPIC = 'my-users-topic',
             KEY = 'user_id');
 
-.. _create-table-reserved:
+.. _create-stream-as-select:
 
 CREATE STREAM AS SELECT
 -----------------------

--- a/docs/tutorials/examples.rst
+++ b/docs/tutorials/examples.rst
@@ -304,3 +304,58 @@ zipcode for each user:
              regionid \
       FROM pageviews_enriched;
 
+.. _running-ksql-command-line:
+
+Running KSQL Statements From the Command Line
+---------------------------------------------
+
+In addition to using the KSQL CLI or launching KSQL servers with the
+``--queries-file`` configuration, you can also execute KSQL statements directly
+from your terminal. This can be useful for scripting.
+
+The following examples show common usage:
+
+-   This example uses pipelines to run KSQL CLI commands.
+
+    .. code:: bash
+
+        $ echo -e "SHOW TOPICS;\nexit" | ksql
+
+-   This example uses the Bash `here document <http://tldp.org/LDP/abs/html/here-docs.html>`__ (``<<``) to run KSQL CLI commands.
+
+    .. code:: bash
+
+        $ ksql <<EOF
+        > SHOW TOPICS;
+        > SHOW STREAMS;
+        > exit
+        > EOF
+
+-   This example uses a Bash `here string <http://tldp.org/LDP/abs/html/x17837.html>`__ (``<<<``) to run KSQL CLI commands on
+    an explicitly defined KSQL server endpoint.
+
+    .. code:: bash
+
+        $ ksql http://localhost:8088 <<< "SHOW TOPICS;
+        SHOW STREAMS;
+        exit"
+
+-   This example creates a stream from a predefined script (``application.sql``) using the ``RUN SCRIPT`` command and
+    then runs a query by using the Bash `here document <http://tldp.org/LDP/abs/html/here-docs.html>`__ (``<<``) feature.
+
+    .. code:: bash
+
+        $ cat /path/to/local/application.sql
+        CREATE STREAM pageviews_copy AS SELECT * FROM pageviews;
+
+    .. code:: bash
+
+        $ ksql http://localhost:8088 <<EOF
+        > RUN SCRIPT '/path/to/local/application.sql';
+        > exit
+        > EOF
+
+    .. note:: The ``RUN SCRIPT`` command only supports a subset of KSQL CLI commands, including running DDL statements
+              (CREATE STREAM, CREATE TABLE), persistent queries (CREATE STREAM AS SELECT, CREATE TABLE AS SELECT), and
+              setting configuration options (SET statement). Other statements and commands such as ``SHOW TOPICS`` and
+              ``SHOW STREAMS`` will be ignored.


### PR DESCRIPTION
### Description 
Some labels had drifted around and become detached from their corresponding headings. Also, re-added the command-line section which seems to have gotten lost in the transition from `4.1.2-post`.
