### PR TITLE
Display stats timestamps in unambiguous format.

### DIFF
--- a/ksql-common/src/main/java/io/confluent/ksql/metrics/TopicSensors.java
+++ b/ksql-common/src/main/java/io/confluent/ksql/metrics/TopicSensors.java
@@ -19,11 +19,11 @@ package io.confluent.ksql.metrics;
 import com.google.common.base.MoreObjects;
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import io.confluent.common.utils.Time;
-import java.text.SimpleDateFormat;
+import java.time.Instant;
+import java.time.ZoneOffset;
+import java.time.format.DateTimeFormatter;
 import java.util.Collection;
-import java.util.Date;
 import java.util.List;
-import java.util.Locale;
 import java.util.stream.Collectors;
 import org.apache.kafka.common.metrics.KafkaMetric;
 import org.apache.kafka.common.metrics.Metrics;
@@ -60,7 +60,7 @@ class TopicSensors<R> {
     return sensors
         .stream()
         .filter(sensor -> sensor.errorMetric == isError)
-        .map(sensor -> sensor.asStat())
+        .map(SensorMetric::asStat)
         .collect(Collectors.toList());
   }
 
@@ -84,7 +84,7 @@ class TopicSensors<R> {
     }
 
     @SuppressFBWarnings("FE_FLOATING_POINT_EQUALITY")
-    public String formatted() {
+    String formatted() {
       if (value == Math.round(value)) {
         return String.format("%16s:%10.0f", name, value);
       } else {
@@ -96,12 +96,10 @@ class TopicSensors<R> {
       if (timestamp == 0) {
         return "n/a";
       }
-      return SimpleDateFormat.getDateTimeInstance(
-          3,
-          1,
-          Locale.getDefault()
-      ).format(new Date(timestamp)
-      );
+
+      return Instant.ofEpochMilli(timestamp)
+          .atOffset(ZoneOffset.UTC)
+          .format(DateTimeFormatter.ISO_OFFSET_DATE_TIME);
     }
 
     @Override
@@ -210,7 +208,7 @@ class TopicSensors<R> {
       return super.toString() + " " + asStat().toString();
     }
 
-    public Stat asStat() {
+    Stat asStat() {
       return new Stat(metric.metricName().name(), value(), lastEvent);
     }
   }

--- a/ksql-common/src/test/java/io/confluent/ksql/metrics/TopicSensorsTest.java
+++ b/ksql-common/src/test/java/io/confluent/ksql/metrics/TopicSensorsTest.java
@@ -1,0 +1,38 @@
+/*
+ * Copyright 2018 Confluent Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.confluent.ksql.metrics;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+
+import io.confluent.ksql.metrics.TopicSensors.Stat;
+import org.junit.Test;
+
+public class TopicSensorsTest {
+
+  @Test
+  public void shouldFormatTimestampInUnambiguousFormatAndUTC() {
+    // Given:
+    final Stat stat = new Stat("stat", 5.0, 1538842403035L);
+
+    // When:
+    final String timestamp = stat.timestamp();
+
+    // Then:
+    assertThat(timestamp, is("2018-10-06T16:13:23.035Z"));
+  }
+}


### PR DESCRIPTION


### Description 
Switch the format for the timestamp on statistics to be unambiguous.  Output is now:

```
Local runtime statistics
------------------------
...    last-message: 2018-10-06T16:17:17.782Z
```

Fixes #2002

### Testing done 
Added test.

### Reviewer checklist
- [ ] Ensure docs are updated if necessary. (eg. if a user visible feature is being added or changed).
- [ ] Ensure relevant issues are linked (description should include text like "Fixes #<issue number>")

