### PR TITLE
Retry commands on unexpected exceptions

### DIFF
--- a/ksql-common/src/main/java/io/confluent/ksql/util/RetryUtil.java
+++ b/ksql-common/src/main/java/io/confluent/ksql/util/RetryUtil.java
@@ -1,0 +1,92 @@
+/**
+ * Copyright 2018 Confluent Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ **/
+
+package io.confluent.ksql.util;
+
+import java.io.PrintWriter;
+import java.io.StringWriter;
+import java.util.Arrays;
+import java.util.function.Consumer;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public final class RetryUtil {
+  private static final Logger log = LoggerFactory.getLogger(RetryUtil.class);
+
+  private RetryUtil() {
+  }
+
+  public static void retryWithBackoff(
+      final int maxRetries,
+      final int initialWaitMs,
+      final int maxWaitMs,
+      final Runnable runnable,
+      final Class<?>... passThroughExceptions) {
+    retryWithBackoff(
+        maxRetries,
+        initialWaitMs,
+        maxWaitMs,
+        runnable,
+        duration -> {
+          try {
+            Thread.sleep(duration);
+          } catch (final InterruptedException e) {
+            log.debug("retryWithBackoff interrupted while sleeping");
+          }
+        },
+        passThroughExceptions
+    );
+  }
+
+  static void retryWithBackoff(
+      final int maxRetries,
+      final int initialWaitMs,
+      final int maxWaitMs,
+      final Runnable runnable,
+      final Consumer<Long> sleep,
+      final Class<?>... passThroughExceptions) {
+    long wait = initialWaitMs;
+    int i = 0;
+    while (true) {
+      try {
+        runnable.run();
+        return;
+      } catch (final RuntimeException exception) {
+        Arrays.stream(passThroughExceptions)
+            .filter(pte -> pte.isInstance(exception))
+            .findFirst()
+            .ifPresent(
+                e -> {
+                  throw exception;
+                });
+        i++;
+        if (i > maxRetries) {
+          throw exception;
+        }
+        final StringWriter stringWriter = new StringWriter();
+        final PrintWriter printWriter = new PrintWriter(stringWriter);
+        exception.printStackTrace(printWriter);
+        log.error(
+            "Exception encountered running command: {}. Retrying in {} ms",
+            exception.getMessage(),
+            wait);
+        log.error("Stack trace: " + stringWriter.toString());
+        sleep.accept(wait);
+        wait = wait * 2 > maxWaitMs ? maxWaitMs : wait * 2;
+      }
+    }
+  }
+}

--- a/ksql-common/src/test/java/io/confluent/ksql/util/RetryUtilTest.java
+++ b/ksql-common/src/test/java/io/confluent/ksql/util/RetryUtilTest.java
@@ -1,0 +1,83 @@
+/**
+ * Copyright 2018 Confluent Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ **/
+
+package io.confluent.ksql.util;
+
+import java.util.function.Consumer;
+import org.junit.Test;
+import org.mockito.InOrder;
+import org.mockito.Mockito;
+
+import static org.junit.Assert.fail;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+
+public class RetryUtilTest {
+  final Runnable runnable = mock(Runnable.class);
+  @SuppressWarnings("unchecked")
+  final Consumer<Long> sleep = mock(Consumer.class);
+
+  @Test
+  public void shouldReturnOnSuccess() {
+    RetryUtil.retryWithBackoff(10, 0, 0, runnable);
+    verify(runnable, times(1)).run();
+  }
+
+  @Test
+  public void shouldBackoffOnFailure() {
+    doThrow(new RuntimeException("error")).when(runnable).run();
+    try {
+      RetryUtil.retryWithBackoff(3, 1, 100, runnable, sleep);
+      fail("retry should have thrown");
+    } catch (final RuntimeException e) {
+    }
+    verify(runnable, times(4)).run();
+    final InOrder inOrder = Mockito.inOrder(sleep);
+    inOrder.verify(sleep).accept((long) 1);
+    inOrder.verify(sleep).accept((long) 2);
+    inOrder.verify(sleep).accept((long) 4);
+    inOrder.verifyNoMoreInteractions();
+  }
+
+  @Test
+  public void shouldRespectMaxWait() {
+    doThrow(new RuntimeException("error")).when(runnable).run();
+    try {
+      RetryUtil.retryWithBackoff(3, 1, 3, runnable, sleep);
+      fail("retry should have thrown");
+    } catch (final RuntimeException e) {
+    }
+    verify(runnable, times(4)).run();
+    final InOrder inOrder = Mockito.inOrder(sleep);
+    inOrder.verify(sleep).accept((long) 1);
+    inOrder.verify(sleep).accept((long) 2);
+    inOrder.verify(sleep).accept((long) 3);
+    inOrder.verifyNoMoreInteractions();
+  }
+
+  @Test
+  public void shouldThrowPassThroughExceptions() {
+    doThrow(new IllegalArgumentException("error")).when(runnable).run();
+    try {
+      RetryUtil.retryWithBackoff(3, 1, 3, runnable, IllegalArgumentException.class);
+      fail("retry should have thrown");
+    } catch (final IllegalArgumentException e) {
+    }
+    verify(runnable, times(1)).run();
+  }
+}

--- a/ksql-rest-app/src/main/java/io/confluent/ksql/rest/server/KsqlRestApplication.java
+++ b/ksql-rest-app/src/main/java/io/confluent/ksql/rest/server/KsqlRestApplication.java
@@ -277,8 +277,7 @@ public final class KsqlRestApplication extends Application<KsqlRestConfig> imple
   public static KsqlRestApplication buildApplication(
       final KsqlRestConfig restConfig,
       final VersionCheckerAgent versionCheckerAgent
-  )
-      throws Exception {
+  ) {
 
     final String ksqlInstallDir = restConfig.getString(KsqlRestConfig.INSTALL_DIR_CONFIG);
 
@@ -355,7 +354,8 @@ public final class KsqlRestApplication extends Application<KsqlRestConfig> imple
 
     final CommandRunner commandRunner = new CommandRunner(
         statementExecutor,
-        commandStore
+        commandStore,
+        restConfig.getInt(KsqlRestConfig.COMMAND_RETRY_LIMIT_CONFIG)
     );
 
     final RootDocument rootDocument = new RootDocument();

--- a/ksql-rest-app/src/main/java/io/confluent/ksql/rest/server/KsqlRestApplication.java
+++ b/ksql-rest-app/src/main/java/io/confluent/ksql/rest/server/KsqlRestApplication.java
@@ -276,7 +276,8 @@ public final class KsqlRestApplication extends Application<KsqlRestConfig> imple
 
   public static KsqlRestApplication buildApplication(
       final KsqlRestConfig restConfig,
-      final VersionCheckerAgent versionCheckerAgent
+      final VersionCheckerAgent versionCheckerAgent,
+      final int maxStatementRetries
   ) {
 
     final String ksqlInstallDir = restConfig.getString(KsqlRestConfig.INSTALL_DIR_CONFIG);
@@ -355,7 +356,7 @@ public final class KsqlRestApplication extends Application<KsqlRestConfig> imple
     final CommandRunner commandRunner = new CommandRunner(
         statementExecutor,
         commandStore,
-        restConfig.getInt(KsqlRestConfig.COMMAND_RETRY_LIMIT_CONFIG)
+        maxStatementRetries
     );
 
     final RootDocument rootDocument = new RootDocument();

--- a/ksql-rest-app/src/main/java/io/confluent/ksql/rest/server/KsqlRestConfig.java
+++ b/ksql-rest-app/src/main/java/io/confluent/ksql/rest/server/KsqlRestConfig.java
@@ -59,6 +59,11 @@ public class KsqlRestConfig extends RestConfig {
   private static final String KSQL_WEBSOCKETS_NUM_THREADS_DOC =
       "The number of websocket threads to handle query results";
 
+  public static final String COMMAND_RETRY_LIMIT_CONFIG = "command.retry.limit";
+  private static final String COMMAND_RETRY_LIMIT_DOC =
+      "The max number of times to retry a command before failing";
+  private static final int COMMAND_RETRY_LIMIT_DEFAULT = Integer.MAX_VALUE;
+
   private static final ConfigDef CONFIG_DEF;
 
   static {
@@ -86,6 +91,12 @@ public class KsqlRestConfig extends RestConfig {
         5,
         Importance.LOW,
         KSQL_WEBSOCKETS_NUM_THREADS_DOC
+    ).define(
+        COMMAND_RETRY_LIMIT_CONFIG,
+        Type.INT,
+        COMMAND_RETRY_LIMIT_DEFAULT,
+        Importance.LOW,
+        COMMAND_RETRY_LIMIT_DOC
     );
   }
 

--- a/ksql-rest-app/src/main/java/io/confluent/ksql/rest/server/KsqlRestConfig.java
+++ b/ksql-rest-app/src/main/java/io/confluent/ksql/rest/server/KsqlRestConfig.java
@@ -59,11 +59,6 @@ public class KsqlRestConfig extends RestConfig {
   private static final String KSQL_WEBSOCKETS_NUM_THREADS_DOC =
       "The number of websocket threads to handle query results";
 
-  public static final String COMMAND_RETRY_LIMIT_CONFIG = "command.retry.limit";
-  private static final String COMMAND_RETRY_LIMIT_DOC =
-      "The max number of times to retry a command before failing";
-  private static final int COMMAND_RETRY_LIMIT_DEFAULT = Integer.MAX_VALUE;
-
   private static final ConfigDef CONFIG_DEF;
 
   static {
@@ -91,12 +86,6 @@ public class KsqlRestConfig extends RestConfig {
         5,
         Importance.LOW,
         KSQL_WEBSOCKETS_NUM_THREADS_DOC
-    ).define(
-        COMMAND_RETRY_LIMIT_CONFIG,
-        Type.INT,
-        COMMAND_RETRY_LIMIT_DEFAULT,
-        Importance.LOW,
-        COMMAND_RETRY_LIMIT_DOC
     );
   }
 

--- a/ksql-rest-app/src/main/java/io/confluent/ksql/rest/server/KsqlServerMain.java
+++ b/ksql-rest-app/src/main/java/io/confluent/ksql/rest/server/KsqlServerMain.java
@@ -81,7 +81,8 @@ public class KsqlServerMain {
     final KsqlRestConfig restConfig = new KsqlRestConfig(properties);
     return KsqlRestApplication.buildApplication(
         restConfig,
-        new KsqlVersionCheckerAgent()
+        new KsqlVersionCheckerAgent(),
+        Integer.MAX_VALUE
     );
   }
 }

--- a/ksql-rest-app/src/main/java/io/confluent/ksql/rest/server/computation/CommandRunner.java
+++ b/ksql-rest-app/src/main/java/io/confluent/ksql/rest/server/computation/CommandRunner.java
@@ -21,7 +21,6 @@ import java.io.PrintWriter;
 import java.io.StringWriter;
 import java.util.List;
 import java.util.Optional;
-import java.util.concurrent.atomic.AtomicBoolean;
 import org.apache.kafka.common.errors.WakeupException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -36,18 +35,22 @@ public class CommandRunner implements Runnable, Closeable {
 
   private static final Logger log = LoggerFactory.getLogger(CommandRunner.class);
 
+  private static final int STATEMENT_RETRY_MS = 1000;
+
   private final StatementExecutor statementExecutor;
   private final CommandStore commandStore;
-  private final AtomicBoolean closed;
+  private volatile boolean closed;
+  private final int maxRetries;
 
   public CommandRunner(
       final StatementExecutor statementExecutor,
-      final CommandStore commandStore
+      final CommandStore commandStore,
+      final int maxRetries
   ) {
     this.statementExecutor = statementExecutor;
     this.commandStore = commandStore;
-
-    closed = new AtomicBoolean(false);
+    this.maxRetries = maxRetries;
+    closed = false;
   }
 
   /**
@@ -57,12 +60,12 @@ public class CommandRunner implements Runnable, Closeable {
   @Override
   public void run() {
     try {
-      while (!closed.get()) {
+      while (!closed) {
         log.debug("Polling for new writes to command topic");
         fetchAndRunCommands();
       }
     } catch (final WakeupException wue) {
-      if (!closed.get()) {
+      if (!closed) {
         throw wue;
       }
     }
@@ -73,7 +76,7 @@ public class CommandRunner implements Runnable, Closeable {
    */
   @Override
   public void close() {
-    closed.set(true);
+    closed = true;
     commandStore.close();
   }
 
@@ -85,28 +88,63 @@ public class CommandRunner implements Runnable, Closeable {
         .forEach(c -> executeStatement(c.getCommand().get(), c.getCommandId(), c.getStatus()));
   }
 
+
+
   /**
    * Read and execute all commands on the command topic, starting at the earliest offset.
    * @throws Exception TODO: Refine this.
    */
   public void processPriorCommands() {
     final RestoreCommands restoreCommands = commandStore.getRestoreCommands();
-    statementExecutor.handleRestoration(restoreCommands);
+    restoreCommands.forEach(
+        (commandId, command, terminatedQueries, wasDropped) -> {
+          executeStatementWithRetries(
+              () -> statementExecutor.handleStatementWithTerminatedQueries(
+                  command,
+                  commandId,
+                  Optional.empty(),
+                  terminatedQueries,
+                  wasDropped
+              )
+          );
+        }
+    );
   }
 
   private void executeStatement(final Command command,
                                 final CommandId commandId,
                                 final Optional<QueuedCommandStatus> status) {
     log.info("Executing statement: " + command.getStatement());
-    try {
-      statementExecutor.handleStatement(command, commandId, status);
-    } catch (final WakeupException wue) {
-      throw wue;
-    } catch (final Exception exception) {
-      final StringWriter stringWriter = new StringWriter();
-      final PrintWriter printWriter = new PrintWriter(stringWriter);
-      exception.printStackTrace(printWriter);
-      log.error("Exception encountered during poll-parse-execute loop: " + stringWriter.toString());
+    executeStatementWithRetries(
+        () -> statementExecutor.handleStatement(command, commandId, status)
+    );
+  }
+
+  private void executeStatementWithRetries(final Runnable runnable) {
+    RuntimeException finalException = null;
+    for (int i = 0; i < maxRetries && !closed; i++) {
+      try {
+        runnable.run();
+        return;
+      } catch (final WakeupException wue) {
+        throw wue;
+      } catch (final RuntimeException exception) {
+        final StringWriter stringWriter = new StringWriter();
+        final PrintWriter printWriter = new PrintWriter(stringWriter);
+        finalException = exception;
+        exception.printStackTrace(printWriter);
+        log.error(
+            "Exception encountered running command: {}. Retrying in {} ms",
+            exception.getMessage(),
+            STATEMENT_RETRY_MS);
+        log.error("Stack trace: " + stringWriter.toString());
+        try {
+          Thread.sleep(STATEMENT_RETRY_MS);
+        } catch (final InterruptedException e) {
+          log.debug("Interrupted while sleeping on command retry.");
+        }
+      }
     }
+    throw finalException;
   }
 }

--- a/ksql-rest-app/src/test/java/io/confluent/ksql/rest/integration/RestApiTest.java
+++ b/ksql-rest-app/src/test/java/io/confluent/ksql/rest/integration/RestApiTest.java
@@ -70,6 +70,7 @@ public class RestApiTest {
   private static final String PAGE_VIEW_STREAM = "pageviews_original";
 
   private static final int NUM_RETRIES = 5;
+  private static final int COMMAND_RETRY_LIMIT = 3;
   private static KsqlRestApplication restApplication;
 
   private static String serverAddress;
@@ -175,6 +176,7 @@ public class RestApiTest {
         final int port = randomFreeLocalPort();
         serverAddress = "http://localhost:" + port;
         configs.put(RestConfig.LISTENERS_CONFIG, serverAddress);
+        configs.put(KsqlRestConfig.COMMAND_RETRY_LIMIT_CONFIG, COMMAND_RETRY_LIMIT);
         restApplication = KsqlRestApplication.buildApplication(new KsqlRestConfig(configs),
                                                                new DummyVersionCheckerAgent());
         restApplication.start();

--- a/ksql-rest-app/src/test/java/io/confluent/ksql/rest/integration/RestApiTest.java
+++ b/ksql-rest-app/src/test/java/io/confluent/ksql/rest/integration/RestApiTest.java
@@ -176,9 +176,10 @@ public class RestApiTest {
         final int port = randomFreeLocalPort();
         serverAddress = "http://localhost:" + port;
         configs.put(RestConfig.LISTENERS_CONFIG, serverAddress);
-        configs.put(KsqlRestConfig.COMMAND_RETRY_LIMIT_CONFIG, COMMAND_RETRY_LIMIT);
-        restApplication = KsqlRestApplication.buildApplication(new KsqlRestConfig(configs),
-                                                               new DummyVersionCheckerAgent());
+        restApplication = KsqlRestApplication.buildApplication(
+            new KsqlRestConfig(configs),
+            new DummyVersionCheckerAgent(),
+            3);
         restApplication.start();
         return;
       } catch (BindException e) {

--- a/ksql-rest-app/src/test/java/io/confluent/ksql/rest/server/computation/CommandRunnerTest.java
+++ b/ksql-rest-app/src/test/java/io/confluent/ksql/rest/server/computation/CommandRunnerTest.java
@@ -117,7 +117,7 @@ public class CommandRunnerTest {
         same(command.getCommandId()),
         same(command.getStatus()));
     final RuntimeException exception = new RuntimeException("something bad happened");
-    expectLastCall().andThrow(exception).times(3);
+    expectLastCall().andThrow(exception).times(4);
     expect(commandStore.getNewCommands()).andReturn(commands);
     replay(statementExecutor, commandStore);
     final CommandRunner commandRunner = new CommandRunner(statementExecutor, commandStore, 3);

--- a/ksql-rest-app/src/test/java/io/confluent/ksql/rest/server/computation/CommandRunnerTest.java
+++ b/ksql-rest-app/src/test/java/io/confluent/ksql/rest/server/computation/CommandRunnerTest.java
@@ -16,16 +16,19 @@
 
 package io.confluent.ksql.rest.server.computation;
 
-import static org.easymock.EasyMock.anyObject;
 import static org.easymock.EasyMock.expect;
 import static org.easymock.EasyMock.expectLastCall;
 import static org.easymock.EasyMock.mock;
 import static org.easymock.EasyMock.replay;
 import static org.easymock.EasyMock.same;
 import static org.easymock.EasyMock.verify;
+import static org.hamcrest.CoreMatchers.equalTo;
+import static org.junit.Assert.assertThat;
+import static org.junit.Assert.fail;
 
 import io.confluent.ksql.rest.server.utils.TestUtils;
 import io.confluent.ksql.util.Pair;
+import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
 import java.util.stream.Collectors;
@@ -33,6 +36,8 @@ import java.util.stream.Collectors;
 import org.junit.Test;
 
 public class CommandRunnerTest {
+  final StatementExecutor statementExecutor = mock(StatementExecutor.class);
+  final CommandStore commandStore = mock(CommandStore.class);
 
   private List<QueuedCommand> getQueuedCommands() {
     final List<Pair<CommandId, Command>> commandList = new TestUtils().getAllPriorCommandRecords();
@@ -42,9 +47,21 @@ public class CommandRunnerTest {
         .collect(Collectors.toList());
   }
 
+  private RestoreCommands getRestoreCommands(final List<Pair<CommandId, Command>> commandList) {
+    final RestoreCommands restoreCommands = new RestoreCommands();
+    commandList.forEach(
+        idCommandPair -> restoreCommands.addCommand(idCommandPair.left, idCommandPair.right)
+    );
+    return restoreCommands;
+  }
+
+  private RestoreCommands getRestoreCommands() {
+    return getRestoreCommands(new TestUtils().getAllPriorCommandRecords());
+  }
+
   @Test
   public void shouldFetchAndRunNewCommandsFromCommandTopic() {
-    final StatementExecutor statementExecutor = mock(StatementExecutor.class);
+    // Given:
     final List<QueuedCommand> commands = getQueuedCommands();
     commands.forEach(
         c -> {
@@ -53,29 +70,131 @@ public class CommandRunnerTest {
           expectLastCall();
         }
     );
-    replay(statementExecutor);
-
-    final CommandStore commandStore = mock(CommandStore.class);
     expect(commandStore.getNewCommands()).andReturn(commands);
-    replay(commandStore);
-    final CommandRunner commandRunner = new CommandRunner(statementExecutor, commandStore);
+    replay(statementExecutor, commandStore);
+    final CommandRunner commandRunner = new CommandRunner(statementExecutor, commandStore, 1);
+
+    // When:
     commandRunner.fetchAndRunCommands();
+
+    // Then:
+    verify(statementExecutor);
+  }
+
+  @Test
+  public void shouldRetryCommands() {
+    // Given:
+    final List<QueuedCommand> commands = Collections.singletonList(getQueuedCommands().get(0));
+    final QueuedCommand command = commands.get(0);
+    statementExecutor.handleStatement(
+        same(command.getCommand().get()),
+        same(command.getCommandId()),
+        same(command.getStatus()));
+    expectLastCall().andThrow(new RuntimeException("Something bad happened"));
+    statementExecutor.handleStatement(
+        same(command.getCommand().get()),
+        same(command.getCommandId()),
+        same(command.getStatus()));
+    expectLastCall();
+    expect(commandStore.getNewCommands()).andReturn(commands);
+    replay(statementExecutor, commandStore);
+    final CommandRunner commandRunner = new CommandRunner(statementExecutor, commandStore, 3);
+
+    // When:
+    commandRunner.fetchAndRunCommands();
+
+    // Then:
+    verify(statementExecutor);
+  }
+
+  @Test
+  public void shouldGiveUpAfterRetryLimit() {
+    // Given:
+    final List<QueuedCommand> commands = Collections.singletonList(getQueuedCommands().get(0));
+    final QueuedCommand command = commands.get(0);
+    statementExecutor.handleStatement(
+        same(command.getCommand().get()),
+        same(command.getCommandId()),
+        same(command.getStatus()));
+    final RuntimeException exception = new RuntimeException("something bad happened");
+    expectLastCall().andThrow(exception).times(3);
+    expect(commandStore.getNewCommands()).andReturn(commands);
+    replay(statementExecutor, commandStore);
+    final CommandRunner commandRunner = new CommandRunner(statementExecutor, commandStore, 3);
+
+    // When:
+    try {
+      commandRunner.fetchAndRunCommands();
+
+      // Then:
+      fail("Should have thrown exception");
+    } catch (final RuntimeException caught) {
+      assertThat(caught, equalTo(exception));
+    }
     verify(statementExecutor);
   }
 
   @Test
   public void shouldFetchAndRunPriorCommandsFromCommandTopic() {
-    final StatementExecutor statementExecutor = mock(StatementExecutor.class);
-    statementExecutor.handleRestoration(anyObject());
-    expectLastCall();
+    // Given:
+    final RestoreCommands restoreCommands = getRestoreCommands();
+    restoreCommands.forEach(
+        (commandId, command, terminatedQueries, wasDropped) -> {
+          statementExecutor.handleStatementWithTerminatedQueries(
+              command,
+              commandId,
+              Optional.empty(),
+              terminatedQueries,
+              wasDropped);
+          expectLastCall();
+        }
+    );
     replay(statementExecutor);
-    final CommandStore commandStore = mock(CommandStore.class);
-    expect(commandStore.getRestoreCommands()).andReturn(new RestoreCommands());
+    expect(commandStore.getRestoreCommands()).andReturn(restoreCommands);
     replay(commandStore);
-    final CommandRunner commandRunner = new CommandRunner(statementExecutor, commandStore);
+    final CommandRunner commandRunner = new CommandRunner(statementExecutor, commandStore, 1);
+
+    // When:
     commandRunner.processPriorCommands();
 
+    // Then:
     verify(statementExecutor);
   }
 
+  @Test
+  public void shouldRetryCommandsWhenRestoring() {
+    // Given:
+    final List<Pair<CommandId, Command>> commands = new TestUtils().getAllPriorCommandRecords();
+    final CommandId failedCommandId = commands.get(0).getLeft();
+    final Command failedCommand = commands.get(0).getRight();
+    final RestoreCommands restoreCommands = getRestoreCommands(commands);
+    statementExecutor.handleStatementWithTerminatedQueries(
+        failedCommand,
+        failedCommandId,
+        Optional.empty(),
+        Collections.emptyMap(),
+        false);
+    expectLastCall().andThrow(new RuntimeException("something bad happened"));
+    restoreCommands.forEach(
+        (commandId, command, terminatedQueries, wasDropped) -> {
+          statementExecutor.handleStatementWithTerminatedQueries(
+              command,
+              commandId,
+              Optional.empty(),
+              terminatedQueries,
+              wasDropped);
+          expectLastCall();
+        }
+    );
+    replay(statementExecutor);
+    expect(commandStore.getRestoreCommands()).andReturn(restoreCommands);
+    replay(commandStore);
+    final CommandRunner commandRunner = new CommandRunner(statementExecutor, commandStore, 3);
+
+    // When:
+    commandRunner.processPriorCommands();
+
+    // Then:
+    verify(statementExecutor);
+  }
 }

--- a/ksql-rest-app/src/test/java/io/confluent/ksql/test/util/TestKsqlRestApp.java
+++ b/ksql-rest-app/src/test/java/io/confluent/ksql/test/util/TestKsqlRestApp.java
@@ -141,7 +141,8 @@ public class TestKsqlRestApp extends ExternalResource {
     try {
       restServer = KsqlRestApplication.buildApplication(
           buildConfig(),
-          new NoOpVersionCheckerAgent()
+          new NoOpVersionCheckerAgent(),
+          3
       );
     } catch (final Exception e) {
       throw new RuntimeException("Failed to initialise", e);
@@ -188,7 +189,6 @@ public class TestKsqlRestApp extends ExternalResource {
 
     config.put(ConsumerConfig.BOOTSTRAP_SERVERS_CONFIG, bootstrapServers.get());
     config.putIfAbsent(KsqlRestConfig.LISTENERS_CONFIG, "http://localhost:0,https://localhost:0");
-    config.put(KsqlRestConfig.COMMAND_RETRY_LIMIT_CONFIG, COMMAND_RETRY_LIMIT);
     return new KsqlRestConfig(config);
   }
 

--- a/ksql-rest-app/src/test/java/io/confluent/ksql/test/util/TestKsqlRestApp.java
+++ b/ksql-rest-app/src/test/java/io/confluent/ksql/test/util/TestKsqlRestApp.java
@@ -61,6 +61,7 @@ import org.junit.rules.ExternalResource;
  * }</pre>
  */
 public class TestKsqlRestApp extends ExternalResource {
+  private final int COMMAND_RETRY_LIMIT = 3;
 
   private final Map<String, ?> baseConfig;
   private final Supplier<String> bootstrapServers;
@@ -187,6 +188,7 @@ public class TestKsqlRestApp extends ExternalResource {
 
     config.put(ConsumerConfig.BOOTSTRAP_SERVERS_CONFIG, bootstrapServers.get());
     config.putIfAbsent(KsqlRestConfig.LISTENERS_CONFIG, "http://localhost:0,https://localhost:0");
+    config.put(KsqlRestConfig.COMMAND_RETRY_LIMIT_CONFIG, COMMAND_RETRY_LIMIT);
     return new KsqlRestConfig(config);
   }
 


### PR DESCRIPTION
### Description 

This patch changes CommandRunner to retry commands when it hits an error that
may not be hit by other KSQL servers. If it just ignores such errors, the servers
in a cluster could become inconsistent. The number of retries is controlled by a
config that defaults to INT_MAX. We set it to a lower number for tests to ensure
we dont accidentally hang while running tests.

### Testing done 

Unit tests

### Reviewer checklist
- [ ] Ensure docs are updated if necessary. (eg. if a user visible feature is being added or changed).
- [ ] Ensure relevant issues are linked (description should include text like "Fixes #<issue number>")

