### PR TITLE
MINOR: Cause 'ksql help' and 'ksql -help' to behave the same as 'ksql…

### DIFF
--- a/bin/ksql-run-class
+++ b/bin/ksql-run-class
@@ -89,14 +89,10 @@ if [ -z "$KSQL_JVM_PERFORMANCE_OPTS" ]; then
   KSQL_JVM_PERFORMANCE_OPTS="-server -XX:+UseConcMarkSweepGC -XX:+CMSClassUnloadingEnabled -XX:+CMSScavengeBeforeRemark -XX:+ExplicitGCInvokesConcurrent -XX:NewRatio=1 -Djava.awt.headless=true"
 fi
 
-usage() {
-    echo "USAGE: $0 [-daemon] [opts] [-help]"
-    exit 1
-}
-
 if [ $# -lt 1 ];
 then
-  usage
+  echo "USAGE: $0 [-daemon] [opts] [-help]"
+    exit 1
 fi
 
 MAIN="$1"
@@ -106,6 +102,9 @@ DAEMON_NAME=""
 GC_LOG_ENABLED=""
 DAEMON_MODE=""
 HELP=""
+if [ "$1" = "help" ]; then
+  HELP="true"
+fi
 while [ $# -gt 0 ]; do
   COMMAND="$1"
   case "$COMMAND" in
@@ -156,7 +155,8 @@ fi
 
 
 if [ "x$HELP" = "xtrue" ]; then
-  usage
+  exec "$JAVA" -cp "$KSQL_CLASSPATH" "$MAIN" --help
+  exit 1
 fi
 
 OPTIONS=($KSQL_HEAP_OPTS)

--- a/ksql-examples/src/main/java/io/confluent/ksql/datagen/DataGen.java
+++ b/ksql-examples/src/main/java/io/confluent/ksql/datagen/DataGen.java
@@ -277,7 +277,7 @@ public final class DataGen {
       // CHECKSTYLE_RULES.OFF: CyclomaticComplexity
       private Builder parseArg(final String arg) throws IOException {
         // CHECKSTYLE_RULES.ON: CyclomaticComplexity
-        if ("help".equals(arg)) {
+        if ("help".equals(arg) || "--help".equals(arg)) {
           help = true;
           return this;
         }


### PR DESCRIPTION
… -h' and 'ksql --help'

### Description 
_What behavior do you want to change, why, how does your patch achieve the changes?_

Fixes https://github.com/confluentinc/ksql/issues/1444, by redirecting 'ksql help' and 'ksql -help' to 'ksql --help'.

### Testing done 
_Describe the testing strategy. Unit and integration tests are expected for any behavior changes._

Verified that "ksql", "ksql-server-start", and "ksql-datagen" (the only three scripts affected by changes to "ksql-run-class") are as expected when run with each of the help flags.

### Reviewer checklist
- [ ] Ensure docs are updated if necessary. (eg. if a user visible feature is being added or changed).
- [ ] Ensure relevant issues are linked (description should include text like "Fixes #<issue number>")

