### PR TITLE
remove references to monitoring interceptors

### DIFF
--- a/cp-ksql-server/pom.xml
+++ b/cp-ksql-server/pom.xml
@@ -48,12 +48,6 @@
         </dependency>
 
         <dependency>
-            <groupId>io.confluent</groupId>
-            <artifactId>monitoring-interceptors</artifactId>
-            <version>${project.version}</version>
-        </dependency>
-
-        <dependency>
             <groupId>${project.groupId}</groupId>
             <artifactId>ksql-rest-app</artifactId>
             <version>${project.version}</version>

--- a/ksql-examples/pom.xml
+++ b/ksql-examples/pom.xml
@@ -51,12 +51,6 @@
             <scope>test</scope>
         </dependency>
 
-	<dependency>
-            <groupId>io.confluent</groupId>
-            <artifactId>monitoring-interceptors</artifactId>
-            <version>${project.version}</version>
-        </dependency>
-
         <dependency>
             <groupId>io.confluent.avro</groupId>
             <artifactId>avro-random-generator</artifactId>


### PR DESCRIPTION
Revert "Add Monitoring Interceptors to ksql-examples Docker image (#1969)"
This reverts commit ce549e2641b33bcd5c2eb97cc8ff9c70de270cdf.

removes dependency on monitoring interceptors from cp-ksql-server

### Testing done 
build works

### Reviewer checklist
- [ ] Ensure docs are updated if necessary. (eg. if a user visible feature is being added or changed).
- [ ] Ensure relevant issues are linked (description should include text like "Fixes #<issue number>")

