### PR TITLE
Bump airline version to 2.6.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -75,7 +75,7 @@
         <exec-maven-plugin.version>1.2.1</exec-maven-plugin.version>
         <podam.version>6.0.2.RELEASE</podam.version>
         <airlift.version>0.29</airlift.version>
-        <airline.version>2.2.0</airline.version>
+        <airline.version>2.6.0</airline.version>
         <antlr.version>4.7</antlr.version>
         <csv.version>1.4</csv.version>
         <gson.version>2.8.5</gson.version>


### PR DESCRIPTION
### Description 
We need the new version to be able to bump to a later version of commons-collections, which in turn has several security vulnerabilities. 

```
Apache Commons Collections 3.2.1 apachecommonscollections1429984 2051354 CVE-2017-15708 High confluent-5.0.0-2.11.tar.gz/confluent-5.0.0/share/java/ksql commons-collections-3.2.1.jar Retired

Apache Commons Collections 3.2.1 apachecommonscollections1429984 2051354 CVE-2017-15708 High confluent-5.0.0-2.11.tar.gz/confluent-5.0.0/share/java/ksql commons-collections-3.2.1.jar Divest

Apache Commons Collections 3.2.1 apachecommonscollections1429984 2051354 CVE-2015-6420 High confluent-5.0.0-2.11.tar.gz/confluent-5.0.0/share/java/ksql commons-collections-3.2.1.jar Retired

Apache Commons Collections 3.2.1 apachecommonscollections1429984 2051354 CVE-2015-6420 High confluent-5.0.0-2.11.tar.gz/confluent-5.0.0/share/java/ksql commons-collections-3.2.1.jar Divest

Apache Commons Collections 4.0 apachecommonscollections1429984 3460604 CVE-2015-6420 High confluent-5.0.0-2.11.tar.gz/confluent-5.0.0/share/java/ksql commons-collections4-4.0.jar EOL
```

### Testing done 
`mvn package` works.

### Reviewer checklist
- [ ] Ensure docs are updated if necessary. (eg. if a user visible feature is being added or changed).
- [ ] Ensure relevant issues are linked (description should include text like "Fixes #<issue number>")

