### PR TITLE
KSQL-1760: Fix text block indents and incorrect include symbols

### DIFF
--- a/docs/includes/ksql-includes.rst
+++ b/docs/includes/ksql-includes.rst
@@ -663,8 +663,8 @@ key (``WAREHOUSE_ID``) - the output should show that they are equal. If
 they are not, the join will not succeed or behave as expected.
 
 .. include:: ../includes/ksql-includes.rst
-    :start-after: _offsetreset_start
-    :end-before: _offsetreset_end
+    :start-after: offsetreset_start
+    :end-before: offsetreset_end
 
 .. code:: sql
 

--- a/docs/tutorials/basics-docker.rst
+++ b/docs/tutorials/basics-docker.rst
@@ -38,27 +38,27 @@ Download the Tutorial and Start KSQL
 
 #. From two separate terminal windows, run the data generator tool to simulate "user" and "pageview" data: 
 
-    .. code:: bash
+   .. code:: bash
 
-        $ docker run --network tutorials_default --rm --name datagen-pageviews \
-            confluentinc/ksql-examples:5.0.0 \
-            ksql-datagen \
-                bootstrap-server=kafka:39092 \
-                quickstart=pageviews \
-                format=delimited \
-                topic=pageviews \
-                maxInterval=500 
+      $ docker run --network tutorials_default --rm --name datagen-pageviews \
+          confluentinc/ksql-examples:5.0.0 \
+          ksql-datagen \
+              bootstrap-server=kafka:39092 \
+              quickstart=pageviews \
+              format=delimited \
+              topic=pageviews \
+              maxInterval=500 
 
-    .. code:: bash
+   .. code:: bash
 
-        $ docker run --network tutorials_default --rm --name datagen-users \
-            confluentinc/ksql-examples:5.0.0 \
-            ksql-datagen \
-                bootstrap-server=kafka:39092 \
-                quickstart=users \
-                format=json \
-                topic=users \
-                maxInterval=100 
+      $ docker run --network tutorials_default --rm --name datagen-users \
+          confluentinc/ksql-examples:5.0.0 \
+          ksql-datagen \
+              bootstrap-server=kafka:39092 \
+              quickstart=users \
+              format=json \
+              topic=users \
+              maxInterval=100 
 
 #. From the host machine, start KSQL CLI
 
@@ -211,17 +211,17 @@ Docker
 
 To stop all Data Generator containers, run the following: 
 
-    .. code:: bash
+.. code:: bash
 
-        docker ps|grep ksql-datagen|awk '{print $1}'|xargs -Ifoo docker stop foo
+    docker ps|grep ksql-datagen|awk '{print $1}'|xargs -Ifoo docker stop foo
 
 If you are running |cp| using Docker Compose, you can stop it and remove 
 the containers and their data with this command.
 
-   .. code:: bash
+.. code:: bash
 
-       $ cd docs/tutorials/
-       $ docker-compose down
+    $ cd docs/tutorials/
+    $ docker-compose down
 
 
 Appendix


### PR DESCRIPTION
### Description 
There were a few wonky indents and also a bug I introduced when I refactored `start-after/end-before` symbol names.