### PR TITLE
Preserve originals when merging configs

### DIFF
--- a/ksql-common/src/main/java/io/confluent/ksql/util/KsqlConfig.java
+++ b/ksql-common/src/main/java/io/confluent/ksql/util/KsqlConfig.java
@@ -462,7 +462,7 @@ public class KsqlConfig extends AbstractConfig implements Cloneable {
 
   public KsqlConfig overrideBreakingConfigsWithOriginalValues(final Map<String, String> props) {
     final KsqlConfig originalConfig = new KsqlConfig(false, props);
-    final Map<String, Object> mergedProperties = new HashMap<>(values());
+    final Map<String, Object> mergedProperties = new HashMap<>(originals());
     COMPATIBLY_BREAKING_CONFIG_DEBS.stream()
         .map(CompatibilityBreakingConfigDef::getName)
         .forEach(

--- a/ksql-common/src/test/java/io/confluent/ksql/util/KsqlConfigTest.java
+++ b/ksql-common/src/test/java/io/confluent/ksql/util/KsqlConfigTest.java
@@ -302,6 +302,25 @@ public class KsqlConfigTest {
   }
 
   @Test
+  public void shouldReturnUdfConfigAfterMerge() {
+    final String functionName = "BOB";
+
+    final String correctConfigName =
+        KsqlConfig.KSQ_FUNCTIONS_PROPERTY_PREFIX + functionName.toLowerCase() + ".some-setting";
+
+    final KsqlConfig config = new KsqlConfig(ImmutableMap.of(
+        correctConfigName, "should-be-visible"
+    ));
+    final KsqlConfig merged = config.overrideBreakingConfigsWithOriginalValues(Collections.emptyMap());
+
+    // When:
+    final Map<String, ?> udfProps = merged.getKsqlFunctionsConfigProps(functionName);
+
+    // Then:
+    assertThat(udfProps.keySet(), hasItem(correctConfigName));
+  }
+
+  @Test
   public void shouldReturnGlobalUdfConfig() {
     // Given:
     final String globalConfigName =


### PR DESCRIPTION
This patch updates KsqlConfig to preserve originals when mergine the
config with the persisted configs. This ensures that udf settings get
applied

### Description 
_What behavior do you want to change, why, how does your patch achieve the changes?_

### Testing done 
_Describe the testing strategy. Unit and integration tests are expected for any behavior changes._

### Reviewer checklist
- [ ] Ensure docs are updated if necessary. (eg. if a user visible feature is being added or changed).
- [ ] Ensure relevant issues are linked (description should include text like "Fixes #<issue number>")

