### PR TITLE
Added stringtodate and datetostring UDFs for 5.1.x

### DIFF
--- a/docs/developer-guide/syntax-reference.rst
+++ b/docs/developer-guide/syntax-reference.rst
@@ -1095,7 +1095,7 @@ The explanation for each operator includes a supporting example based on the fol
 Scalar functions
 ================
 
-+------------------------+------------------------------------------------------------+---------------------------------------------------+
++------------------------+---------------------------------------------------------------------------+---------------------------------------------------+
 | Function               | Example                                                                   | Description                                       |
 +========================+===========================================================================+===================================================+
 | ABS                    |  ``ABS(col1)``                                                            | The absolute value of a value                     |
@@ -1106,14 +1106,14 @@ Scalar functions
 | CEIL                   |  ``CEIL(col1)``                                                           | The ceiling of a value.                           |
 +------------------------+---------------------------------------------------------------------------+---------------------------------------------------+
 | CONCAT                 |  ``CONCAT(col1, '_hello')``                                               | Concatenate two strings.                          |
-+------------------------+------------------------------------------------------------+---------------------------------------------------+
-| DATETOSTRING           |  ``DATETOSTRING(START_DATE, 'yyyy-MM-dd')``                | Converts an INT date value into                   |
-|                        |                                                            | the string representation of the date in          |
-|                        |                                                            | the given format. Single quotes in the            |
-|                        |                                                            | timestamp format can be escaped with '', for      |
-|                        |                                                            | example: 'yyyy-MM-dd''T'''.                       |
-|                        |                                                            | The integer represents days since epoch           |
-|                        |                                                            | matching the encoding used by Kafka Connect dates.|
++------------------------+---------------------------------------------------------------------------+---------------------------------------------------+
+| DATETOSTRING           |  ``DATETOSTRING(START_DATE, 'yyyy-MM-dd')``                               | Converts an integer representation of a date into |
+|                        |                                                                           | a string representing the date in                 |
+|                        |                                                                           | the given format. Single quotes in the            |
+|                        |                                                                           | timestamp format can be escaped with '', for      |
+|                        |                                                                           | example: 'yyyy-MM-dd''T'''.                       |
+|                        |                                                                           | The integer represents days since epoch           |
+|                        |                                                                           | matching the encoding used by Kafka Connect dates.|
 +------------------------+---------------------------------------------------------------------------+---------------------------------------------------+
 | EXTRACTJSONFIELD       |  ``EXTRACTJSONFIELD(message, '$.log.cloud')``                             | Given a string column in JSON format, extract     |
 |                        |                                                                           | the field that matches.                           |
@@ -1183,18 +1183,21 @@ Scalar functions
 | RANDOM                 |  ``RANDOM()``                                                             | Return a random DOUBLE value between 0.0 and 1.0. |
 +------------------------+---------------------------------------------------------------------------+---------------------------------------------------+
 | ROUND                  |  ``ROUND(col1)``                                                          | Round a value to the nearest BIGINT value.        |
-+------------------------+------------------------------------------------------------+---------------------------------------------------+
-| STRINGTODATE           |  ``STRINGTODATE(col1, 'yyyy-MM-dd')``                      | Converts a string value in the given              |
-|                        |                                                            | format into the INT value                         |
-|                        |                                                            | that represents days since epoch. Single          |
-|                        |                                                            | quotes in the timestamp format can be escaped with|
-|                        |                                                            | '', for example: 'yyyy-MM-dd''T'''.               |
 +------------------------+---------------------------------------------------------------------------+---------------------------------------------------+
-| STRINGTOTIMESTAMP      |  ``STRINGTOTIMESTAMP(col1, 'yyyy-MM-dd HH:mm:ss.SSS')``                   | Converts a string value in the given              |
+| STRINGTODATE           |  ``STRINGTODATE(col1, 'yyyy-MM-dd')``                                     | Converts a string representation of a date in the |
+|                        |                                                                           | given format into an integer representing days    |
+|                        |                                                                           | since epoch. Single quotes in the timestamp       |
+|                        |                                                                           | format can be escaped with '', for example:       |
+|                        |                                                                           | 'yyyy-MM-dd''T'''.                                |
++------------------------+---------------------------------------------------------------------------+---------------------------------------------------+
+| STRINGTOTIMESTAMP      |  ``STRINGTOTIMESTAMP(col1, 'yyyy-MM-dd HH:mm:ss.SSS' [, TIMEZONE])``      | Converts a string value in the given              |
 |                        |                                                                           | format into the BIGINT value                      |
 |                        |                                                                           | that represents the millisecond timestamp. Single |
 |                        |                                                                           | quotes in the timestamp format can be escaped with|
 |                        |                                                                           | '', for example: 'yyyy-MM-dd''T''HH:mm:ssX'.      |
+|                        |                                                                           | TIMEZONE is an optional parameter and it is a     |
+|                        |                                                                           | java.util.TimeZone ID format, for example: "UTC", |
+|                        |                                                                           | "America/Los_Angeles", "PDT", "Europe/London"     |
 +------------------------+---------------------------------------------------------------------------+---------------------------------------------------+
 | SUBSTRING              |  ``SUBSTRING(col1, 2, 5)``                                                | ``SUBSTRING(str, pos, [len]``.                    |
 |                        |                                                                           | Return a substring of ``str`` that starts at      |

--- a/docs/developer-guide/syntax-reference.rst
+++ b/docs/developer-guide/syntax-reference.rst
@@ -1095,7 +1095,7 @@ The explanation for each operator includes a supporting example based on the fol
 Scalar functions
 ================
 
-+------------------------+---------------------------------------------------------------------------+---------------------------------------------------+
++------------------------+------------------------------------------------------------+---------------------------------------------------+
 | Function               | Example                                                                   | Description                                       |
 +========================+===========================================================================+===================================================+
 | ABS                    |  ``ABS(col1)``                                                            | The absolute value of a value                     |
@@ -1106,6 +1106,14 @@ Scalar functions
 | CEIL                   |  ``CEIL(col1)``                                                           | The ceiling of a value.                           |
 +------------------------+---------------------------------------------------------------------------+---------------------------------------------------+
 | CONCAT                 |  ``CONCAT(col1, '_hello')``                                               | Concatenate two strings.                          |
++------------------------+------------------------------------------------------------+---------------------------------------------------+
+| DATETOSTRING           |  ``DATETOSTRING(START_DATE, 'yyyy-MM-dd')``                | Converts an INT date value into                   |
+|                        |                                                            | the string representation of the date in          |
+|                        |                                                            | the given format. Single quotes in the            |
+|                        |                                                            | timestamp format can be escaped with '', for      |
+|                        |                                                            | example: 'yyyy-MM-dd''T'''.                       |
+|                        |                                                            | The integer represents days since epoch           |
+|                        |                                                            | matching the encoding used by Kafka Connect dates.|
 +------------------------+---------------------------------------------------------------------------+---------------------------------------------------+
 | EXTRACTJSONFIELD       |  ``EXTRACTJSONFIELD(message, '$.log.cloud')``                             | Given a string column in JSON format, extract     |
 |                        |                                                                           | the field that matches.                           |
@@ -1175,6 +1183,12 @@ Scalar functions
 | RANDOM                 |  ``RANDOM()``                                                             | Return a random DOUBLE value between 0.0 and 1.0. |
 +------------------------+---------------------------------------------------------------------------+---------------------------------------------------+
 | ROUND                  |  ``ROUND(col1)``                                                          | Round a value to the nearest BIGINT value.        |
++------------------------+------------------------------------------------------------+---------------------------------------------------+
+| STRINGTODATE           |  ``STRINGTODATE(col1, 'yyyy-MM-dd')``                      | Converts a string value in the given              |
+|                        |                                                            | format into the INT value                         |
+|                        |                                                            | that represents days since epoch. Single          |
+|                        |                                                            | quotes in the timestamp format can be escaped with|
+|                        |                                                            | '', for example: 'yyyy-MM-dd''T'''.               |
 +------------------------+---------------------------------------------------------------------------+---------------------------------------------------+
 | STRINGTOTIMESTAMP      |  ``STRINGTOTIMESTAMP(col1, 'yyyy-MM-dd HH:mm:ss.SSS')``                   | Converts a string value in the given              |
 |                        |                                                                           | format into the BIGINT value                      |

--- a/ksql-cli/src/test/java/io/confluent/ksql/CliTest.java
+++ b/ksql-cli/src/test/java/io/confluent/ksql/CliTest.java
@@ -661,17 +661,37 @@ public class CliTest {
   @Test
   public void shouldDescribeScalarFunction() throws Exception {
     final String expectedOutput =
-        "Name        : TIMESTAMPTOSTRING\n" +
-        "Author      : confluent\n" +
-        "Type        : scalar\n" +
-        "Jar         : internal\n" +
-        "Variations  : \n" +
-        "\n" +
-        "\tVariation   : TIMESTAMPTOSTRING(BIGINT, VARCHAR)\n" +
-        "\tReturns     : VARCHAR\n";
+        "Name        : TIMESTAMPTOSTRING\n"
+            + "Author      : Confluent\n"
+            + "Overview    : Converts a BIGINT millisecond timestamp value into the string"
+            + " representation of the \n"
+            + "              timestamp in the given format.\n"
+            + "Type        : scalar\n"
+            + "Jar         : internal\n"
+            + "Variations  :";
 
     localCli.handleLine("describe function timestamptostring;");
-    assertThat(terminal.getOutputString(), containsString(expectedOutput));
+    final String outputString = terminal.getOutputString();
+    assertThat(outputString, containsString(expectedOutput));
+
+    // variations for Udfs are loaded non-deterministically. Don't assume which variation is first
+    final String expectedVariation =
+        "\tVariation   : TIMESTAMPTOSTRING(epochMilli BIGINT, formatPattern VARCHAR)\n" +
+                "\tReturns     : VARCHAR\n" +
+                "\tDescription : Converts a BIGINT millisecond timestamp value into the string" +
+                " representation of the \n" +
+                "                timestamp in the given format. Single quotes in the timestamp" +
+                " format can be escaped \n" +
+                "                with '', for example: 'yyyy-MM-dd''T''HH:mm:ssX' The system" +
+                " default time zone is \n" +
+                "                used when no time zone is explicitly provided. The format" +
+                " pattern should be in the \n" +
+                "                format expected by java.time.format.DateTimeFormatter\n" +
+                "\tepochMilli  : Milliseconds since January 1, 1970, 00:00:00 GMT.\n" +
+                "\tformatPattern: The format pattern should be in the format expected by \n" +
+                "                 java.time.format.DateTimeFormatter.";
+    
+    assertThat(outputString, containsString(expectedVariation));
   }
 
   @Test

--- a/ksql-common/src/main/java/io/confluent/ksql/util/timestamp/StringToTimestampParser.java
+++ b/ksql-common/src/main/java/io/confluent/ksql/util/timestamp/StringToTimestampParser.java
@@ -40,6 +40,10 @@ public class StringToTimestampParser {
   }
 
   public long parse(final String text) {
+    return parse(text, ZoneId.systemDefault());
+  }
+
+  public long parse(final String text, final ZoneId zoneId) {
     TemporalAccessor parsed = formatter.parseBest(
         text,
         ZonedDateTime::from,
@@ -51,13 +55,13 @@ public class StringToTimestampParser {
           +  "cannot be parsed into a timestamp");
     }
 
-    if (parsed instanceof ZonedDateTime) {
-      parsed = ((ZonedDateTime) parsed)
-          .withZoneSameInstant(ZoneId.systemDefault())
-          .toLocalDateTime();
+    if (parsed instanceof LocalDateTime) {
+      parsed = ((LocalDateTime) parsed).atZone(zoneId);
     }
 
-    final LocalDateTime dateTime = (LocalDateTime) parsed;
+    final LocalDateTime dateTime = ((ZonedDateTime) parsed)
+        .withZoneSameInstant(ZoneId.systemDefault())
+        .toLocalDateTime();
     return Timestamp.valueOf(dateTime).getTime();
   }
 

--- a/ksql-engine/src/main/java/io/confluent/ksql/function/InternalFunctionRegistry.java
+++ b/ksql-engine/src/main/java/io/confluent/ksql/function/InternalFunctionRegistry.java
@@ -24,8 +24,6 @@ import io.confluent.ksql.function.udaf.sum.SumAggFunctionFactory;
 import io.confluent.ksql.function.udaf.topk.TopKAggregateFunctionFactory;
 import io.confluent.ksql.function.udaf.topkdistinct.TopkDistinctAggFunctionFactory;
 import io.confluent.ksql.function.udf.UdfMetadata;
-import io.confluent.ksql.function.udf.datetime.StringToTimestamp;
-import io.confluent.ksql.function.udf.datetime.TimestampToString;
 import io.confluent.ksql.function.udf.geo.GeoDistanceKudf;
 import io.confluent.ksql.function.udf.json.ArrayContainsKudf;
 import io.confluent.ksql.function.udf.json.JsonExtractStringKudf;
@@ -75,7 +73,6 @@ public class InternalFunctionRegistry implements FunctionRegistry {
   private void init() {
     addStringFunctions();
     addMathFunctions();
-    addDateTimeFunctions();
     addGeoFunctions();
     addJsonFunctions();
     addStructFieldFetcher();
@@ -246,25 +243,6 @@ public class InternalFunctionRegistry implements FunctionRegistry {
         "RANDOM", RandomKudf.class);
     addFunction(random);
 
-
-  }
-
-
-  private void addDateTimeFunctions() {
-
-    final KsqlFunction timestampToString = new KsqlFunction(
-        Schema.OPTIONAL_STRING_SCHEMA,
-        Arrays.asList(Schema.OPTIONAL_INT64_SCHEMA, Schema.OPTIONAL_STRING_SCHEMA),
-        "TIMESTAMPTOSTRING",
-        TimestampToString.class);
-    addFunction(timestampToString);
-
-    final KsqlFunction stringToTimestamp = new KsqlFunction(
-        Schema.OPTIONAL_INT64_SCHEMA,
-        Arrays.asList(Schema.OPTIONAL_STRING_SCHEMA, Schema.OPTIONAL_STRING_SCHEMA),
-        "STRINGTOTIMESTAMP",
-        StringToTimestamp.class);
-    addFunction(stringToTimestamp);
 
   }
 

--- a/ksql-engine/src/main/java/io/confluent/ksql/function/udf/datetime/DateToString.java
+++ b/ksql-engine/src/main/java/io/confluent/ksql/function/udf/datetime/DateToString.java
@@ -1,29 +1,62 @@
+/*
+ * Copyright 2018 Confluent Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package io.confluent.ksql.function.udf.datetime;
 
 import com.google.common.cache.CacheBuilder;
 import com.google.common.cache.CacheLoader;
 import com.google.common.cache.LoadingCache;
+import io.confluent.ksql.function.KsqlFunctionException;
 import io.confluent.ksql.function.udf.Udf;
 import io.confluent.ksql.function.udf.UdfDescription;
+import io.confluent.ksql.function.udf.UdfParameter;
 import java.time.LocalDate;
 import java.time.format.DateTimeFormatter;
+import java.util.concurrent.ExecutionException;
 
 @UdfDescription(name = "datetostring", author = "Confluent",
-    description = "Converts an integer representing days since epoch to a date string using the given format pattern."
-        + " Note this is the format Kafka Connect uses to represent dates with no time component."
-        + " The format pattern should be in the format expected by java.time.format.DateTimeFormatter")
+    description = "Converts an integer representing days since epoch to a date string"
+        + " using the given format pattern. Note this is the format Kafka Connect uses"
+        + " to represent dates with no time component.  The format pattern should be"
+        + " in the format expected by java.time.format.DateTimeFormatter")
 public class DateToString {
 
   private final LoadingCache<String, DateTimeFormatter> formatters =
       CacheBuilder.newBuilder()
-        .maximumSize(1000)
-        .build(CacheLoader.from(DateTimeFormatter::ofPattern));
+          .maximumSize(1000)
+          .build(CacheLoader.from(DateTimeFormatter::ofPattern));
 
-  @Udf(description = "Converts an integer representing days since epoch to a string using the given format pattern."
-      + " The format pattern should be in the format expected by java.time.format.DateTimeFormatter")
-  public String dateToString(final Integer daysSinceEpoch, final String formatPattern) {
-    final DateTimeFormatter formatter = formatters.getUnchecked(formatPattern);
-    return LocalDate.ofEpochDay(daysSinceEpoch).format(formatter);
+  @Udf(description = "Converts an integer representing days since epoch to a string"
+      + " using the given format pattern. The format pattern should be in the format"
+      + " expected by java.time.format.DateTimeFormatter")
+  public String dateToString(
+      @UdfParameter(value = "epochDays",
+          description = "The Epoch Day to convert,"
+              + " based on the epoch 1970-01-01") final int epochDays,
+      @UdfParameter(value = "formatPattern",
+          description = "The format pattern should be in the format expected by"
+              + " java.time.format.DateTimeFormatter.") final String formatPattern) {
+    try {
+      final DateTimeFormatter formatter = formatters.get(formatPattern);
+      return LocalDate.ofEpochDay(epochDays).format(formatter);
+    } catch (final ExecutionException | RuntimeException e) {
+      throw new KsqlFunctionException("Failed to format date " + epochDays
+          + " with formatter '" + formatPattern
+          + "': " + e.getMessage(), e);
+    }
   }
 
 }

--- a/ksql-engine/src/main/java/io/confluent/ksql/function/udf/datetime/DateToString.java
+++ b/ksql-engine/src/main/java/io/confluent/ksql/function/udf/datetime/DateToString.java
@@ -1,0 +1,29 @@
+package io.confluent.ksql.function.udf.datetime;
+
+import com.google.common.cache.CacheBuilder;
+import com.google.common.cache.CacheLoader;
+import com.google.common.cache.LoadingCache;
+import io.confluent.ksql.function.udf.Udf;
+import io.confluent.ksql.function.udf.UdfDescription;
+import java.time.LocalDate;
+import java.time.format.DateTimeFormatter;
+
+@UdfDescription(name = "datetostring", author = "Confluent",
+    description = "Converts an integer representing days since epoch to a date string using the given format pattern."
+        + " Note this is the format Kafka Connect uses to represent dates with no time component."
+        + " The format pattern should be in the format expected by java.time.format.DateTimeFormatter")
+public class DateToString {
+
+  private final LoadingCache<String, DateTimeFormatter> formatters =
+      CacheBuilder.newBuilder()
+        .maximumSize(1000)
+        .build(CacheLoader.from(DateTimeFormatter::ofPattern));
+
+  @Udf(description = "Converts an integer representing days since epoch to a string using the given format pattern."
+      + " The format pattern should be in the format expected by java.time.format.DateTimeFormatter")
+  public String dateToString(final Integer daysSinceEpoch, final String formatPattern) {
+    final DateTimeFormatter formatter = formatters.getUnchecked(formatPattern);
+    return LocalDate.ofEpochDay(daysSinceEpoch).format(formatter);
+  }
+
+}

--- a/ksql-engine/src/main/java/io/confluent/ksql/function/udf/datetime/StringToDate.java
+++ b/ksql-engine/src/main/java/io/confluent/ksql/function/udf/datetime/StringToDate.java
@@ -1,18 +1,38 @@
+/*
+ * Copyright 2018 Confluent Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package io.confluent.ksql.function.udf.datetime;
 
 import com.google.common.cache.CacheBuilder;
 import com.google.common.cache.CacheLoader;
 import com.google.common.cache.LoadingCache;
+import io.confluent.ksql.function.KsqlFunctionException;
 import io.confluent.ksql.function.udf.Udf;
 import io.confluent.ksql.function.udf.UdfDescription;
+import io.confluent.ksql.function.udf.UdfParameter;
 import java.time.LocalDate;
 import java.time.format.DateTimeFormatter;
+import java.util.concurrent.ExecutionException;
 
 @UdfDescription(name = "stringtodate", author = "Confluent",
     description = "Converts a string representation of a date into an integer representing"
         + " days since epoch using the given format pattern."
         + " Note this is the format Kafka Connect uses to represent dates with no time component."
-        + " The format pattern should be in the format expected by java.time.format.DateTimeFormatter")
+        + " The format pattern should be in the format expected by"
+        + " java.time.format.DateTimeFormatter")
 public class StringToDate {
 
   private final LoadingCache<String, DateTimeFormatter> formatters =
@@ -20,12 +40,22 @@ public class StringToDate {
           .maximumSize(1000)
           .build(CacheLoader.from(DateTimeFormatter::ofPattern));
 
-  @Udf(description = "Converts a string representation of a date into an integer representing"
-      + " days since epoch using the given format pattern."
-      + " The format pattern should be in the format expected by java.time.format.DateTimeFormatter")
-  public int stringToDate(final String formattedDate, final String formatPattern) {
-    DateTimeFormatter formatter = formatters.getUnchecked(formatPattern);
-    return ((int)LocalDate.parse(formattedDate, formatter).toEpochDay());
+  @Udf(description = "Converts formattedDate, a string representation of a date into"
+      + " an integer representing days since epoch using the given formatPattern.")
+  public int stringToDate(
+      @UdfParameter(value = "formattedDate",
+          description = "The string representation of a date.") final String formattedDate,
+      @UdfParameter(value = "formatPattern",
+          description = "The format pattern should be in the format expected by"
+              + " java.time.format.DateTimeFormatter.") final String formatPattern) {
+    try {
+      final DateTimeFormatter formatter = formatters.get(formatPattern);
+      return ((int)LocalDate.parse(formattedDate, formatter).toEpochDay());
+    } catch (final ExecutionException | RuntimeException e) {
+      throw new KsqlFunctionException("Failed to parse date '" + formattedDate
+          + "' with formatter '" + formatPattern
+          + "': " + e.getMessage(), e);
+    }
   }
 
 }

--- a/ksql-engine/src/main/java/io/confluent/ksql/function/udf/datetime/StringToDate.java
+++ b/ksql-engine/src/main/java/io/confluent/ksql/function/udf/datetime/StringToDate.java
@@ -1,0 +1,31 @@
+package io.confluent.ksql.function.udf.datetime;
+
+import com.google.common.cache.CacheBuilder;
+import com.google.common.cache.CacheLoader;
+import com.google.common.cache.LoadingCache;
+import io.confluent.ksql.function.udf.Udf;
+import io.confluent.ksql.function.udf.UdfDescription;
+import java.time.LocalDate;
+import java.time.format.DateTimeFormatter;
+
+@UdfDescription(name = "stringtodate", author = "Confluent",
+    description = "Converts a string representation of a date into an integer representing"
+        + " days since epoch using the given format pattern."
+        + " Note this is the format Kafka Connect uses to represent dates with no time component."
+        + " The format pattern should be in the format expected by java.time.format.DateTimeFormatter")
+public class StringToDate {
+
+  private final LoadingCache<String, DateTimeFormatter> formatters =
+      CacheBuilder.newBuilder()
+          .maximumSize(1000)
+          .build(CacheLoader.from(DateTimeFormatter::ofPattern));
+
+  @Udf(description = "Converts a string representation of a date into an integer representing"
+      + " days since epoch using the given format pattern."
+      + " The format pattern should be in the format expected by java.time.format.DateTimeFormatter")
+  public int stringToDate(final String formattedDate, final String formatPattern) {
+    DateTimeFormatter formatter = formatters.getUnchecked(formatPattern);
+    return ((int)LocalDate.parse(formattedDate, formatter).toEpochDay());
+  }
+
+}

--- a/ksql-engine/src/main/java/io/confluent/ksql/function/udf/datetime/StringToTimestamp.java
+++ b/ksql-engine/src/main/java/io/confluent/ksql/function/udf/datetime/StringToTimestamp.java
@@ -16,32 +16,68 @@
 
 package io.confluent.ksql.function.udf.datetime;
 
+import com.google.common.cache.CacheBuilder;
+import com.google.common.cache.CacheLoader;
+import com.google.common.cache.LoadingCache;
 import io.confluent.ksql.function.KsqlFunctionException;
-import io.confluent.ksql.function.udf.Kudf;
+import io.confluent.ksql.function.udf.Udf;
+import io.confluent.ksql.function.udf.UdfDescription;
+import io.confluent.ksql.function.udf.UdfParameter;
 import io.confluent.ksql.util.timestamp.StringToTimestampParser;
+import java.time.ZoneId;
+import java.util.concurrent.ExecutionException;
 
-public class StringToTimestamp implements Kudf {
+@UdfDescription(name = "stringtotimestamp", author = "Confluent",
+    description = "Converts a string representation of a date in the given format"
+        + " into the BIGINT value that represents the millisecond timestamp.")
+public class StringToTimestamp {
 
-  private StringToTimestampParser timestampParser;
+  private final LoadingCache<String, StringToTimestampParser> parsers =
+      CacheBuilder.newBuilder()
+          .maximumSize(1000)
+          .build(CacheLoader.from(StringToTimestampParser::new));
 
-  @Override
-  public Object evaluate(final Object... args) {
-    if (args.length != 2) {
-      throw new KsqlFunctionException("StringToTimestamp udf should have two input argument:"
-                                      + " date value and format.");
-    }
+  @Udf(description = "Converts a string representation of a date in the given format"
+      + " into the BIGINT value that represents the millisecond timestamp."
+      + " Single quotes in the timestamp format can be escaped with '',"
+      + " for example: 'yyyy-MM-dd''T''HH:mm:ssX'.")
+  public long stringToTimestamp(
+      @UdfParameter(value = "formattedTimestamp",
+          description = "The string representation of a date.") final String formattedTimestamp,
+      @UdfParameter(value = "formatPattern",
+          description = "The format pattern should be in the format expected by"
+              + " java.time.format.DateTimeFormatter.") final String formatPattern) {
     try {
-      ensureInitialized(args);
-      return timestampParser.parse(args[0].toString());
-    } catch (final Exception e) {
-      throw new KsqlFunctionException("Exception running StringToTimestamp(" + args[0] + ", "
-                                      + args[1] + ") : " + e.getMessage(), e);
+      final StringToTimestampParser timestampParser = parsers.get(formatPattern);
+      return timestampParser.parse(formattedTimestamp);
+    } catch (final ExecutionException | RuntimeException e) {
+      throw new KsqlFunctionException("Failed to parse timestamp '" + formattedTimestamp
+           + "' with formatter '" + formatPattern
+          + "': " + e.getMessage(), e);
     }
   }
 
-  private void ensureInitialized(final Object[] args) {
-    if (timestampParser == null) {
-      timestampParser = new StringToTimestampParser(args[1].toString());
+  @Udf(description = "Converts a string representation of a date at the given time zone"
+      + " in the given format into the BIGINT value that represents the millisecond timestamp."
+      + " Single quotes in the timestamp format can be escaped with '',"
+      + " for example: 'yyyy-MM-dd''T''HH:mm:ssX'.")
+  public long stringToTimestamp(
+      @UdfParameter(value = "formattedTimestamp",
+          description = "The string representation of a date.") final String formattedTimestamp,
+      @UdfParameter(value = "formatPattern",
+          description = "The format pattern should be in the format expected by"
+              + " java.time.format.DateTimeFormatter.") final String formatPattern,
+      @UdfParameter(value = "timeZone",
+          description =  " timeZone is a java.util.TimeZone ID format, for example: \"UTC\","
+              + " \"America/Los_Angeles\", \"PDT\", \"Europe/London\"") final String timeZone) {
+    try {
+      final StringToTimestampParser timestampParser = parsers.get(formatPattern);
+      final ZoneId zoneId = ZoneId.of(timeZone);
+      return timestampParser.parse(formattedTimestamp, zoneId);
+    } catch (final ExecutionException | RuntimeException e) {
+      throw new KsqlFunctionException("Failed to parse timestamp '" + formattedTimestamp
+          + "' at timezone '" + timeZone + "' with formatter '" + formatPattern
+          + "': " + e.getMessage(), e);
     }
   }
 

--- a/ksql-engine/src/test/java/io/confluent/ksql/function/udf/datetime/DateToStringTest.java
+++ b/ksql-engine/src/test/java/io/confluent/ksql/function/udf/datetime/DateToStringTest.java
@@ -1,0 +1,127 @@
+/*
+ * Copyright 2018 Confluent Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.confluent.ksql.function.udf.datetime;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.junit.Assert.assertThat;
+import static org.junit.Assert.fail;
+
+import com.google.common.util.concurrent.UncheckedExecutionException;
+import io.confluent.ksql.function.KsqlFunctionException;
+import java.text.ParseException;
+import java.text.SimpleDateFormat;
+import java.util.Calendar;
+import java.util.Date;
+import java.util.TimeZone;
+import java.util.stream.IntStream;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+
+public class DateToStringTest {
+
+  private static final long MILLIS_PER_DAY = 24 * 60 * 60 * 1000;
+  private static final TimeZone UTC = TimeZone.getTimeZone("UTC");
+
+  private DateToString udf;
+
+  @Rule
+  public final ExpectedException expectedException = ExpectedException.none();
+
+  @Before
+  public void setUp(){
+    udf = new DateToString();
+  }
+
+  @Test
+  public void shouldConvertDateToString() {
+    // When:
+    final String result = udf.dateToString(16383, "yyyy-MM-dd");
+
+    // Then:
+    final String expectedResult = expectedResult(16383, "yyyy-MM-dd");
+    assertThat(result, is(expectedResult));
+  }
+
+  @Test
+  public void shouldRoundTripWithStringToDate() {
+    final String format = "dd/MM/yyyy'Freya'";
+    final StringToDate stringToDate = new StringToDate();
+    IntStream.range(-10_000, 20_000)
+        .parallel()
+        .forEach(idx -> {
+          final String result = udf.dateToString(idx, format);
+          final String expectedResult = expectedResult(idx, format);
+          assertThat(result, is(expectedResult));
+
+          final int daysSinceEpoch = stringToDate.stringToDate(result, format);
+          assertThat(daysSinceEpoch, is(idx));
+        });
+  }
+
+  @Test
+  public void shouldSupportEmbeddedChars() {
+    // When:
+    final Object result = udf.dateToString(12345, "yyyy-dd-MM'Fred'");
+
+    // Then:
+    final String expectedResult = expectedResult(12345, "yyyy-dd-MM'Fred'");
+    assertThat(result, is(expectedResult));
+  }
+
+  @Test
+  public void shouldThrowIfFormatInvalid() {
+    expectedException.expect(UncheckedExecutionException.class);
+    expectedException.expectMessage("Unknown pattern letter: i");
+    udf.dateToString(44444, "invalid");
+  }
+
+  @Test
+  public void shouldBeThreadSafe() {
+    IntStream.range(0, 10_000)
+        .parallel()
+        .forEach(idx -> {
+          shouldConvertDateToString();
+          udf.dateToString(55555, "yyyy-MM-dd");
+        });
+  }
+
+  @Test
+  public void shouldWorkWithManyDifferentFormatters() {
+    IntStream.range(0, 10_000)
+        .parallel()
+        .forEach(idx -> {
+          try {
+            final String pattern = "yyyy-MM-dd'X" + idx + "'";
+            final String result = udf.dateToString(idx, pattern);
+            final String expectedResult = expectedResult(idx, pattern);
+            assertThat(result, is(expectedResult));
+          } catch (final Exception e) {
+            Assert.fail(e.getMessage());
+          }
+        });
+  }
+
+  private String expectedResult(final int daysSinceEpoch, final String formatPattern) {
+    SimpleDateFormat dateFormat = new SimpleDateFormat(formatPattern);
+    dateFormat.setCalendar(Calendar.getInstance(UTC));
+    return dateFormat.format(new java.util.Date(daysSinceEpoch * MILLIS_PER_DAY));
+  }
+
+}

--- a/ksql-engine/src/test/java/io/confluent/ksql/function/udf/datetime/StringToDateTest.java
+++ b/ksql-engine/src/test/java/io/confluent/ksql/function/udf/datetime/StringToDateTest.java
@@ -1,0 +1,130 @@
+/*
+ * Copyright 2018 Confluent Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.confluent.ksql.function.udf.datetime;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.junit.Assert.assertThat;
+import static org.junit.Assert.fail;
+
+import com.google.common.util.concurrent.UncheckedExecutionException;
+import io.confluent.ksql.function.KsqlFunctionException;
+import java.text.ParseException;
+import java.text.SimpleDateFormat;
+import java.time.format.DateTimeParseException;
+import java.util.Calendar;
+import java.util.Date;
+import java.util.Locale;
+import java.util.TimeZone;
+import java.util.stream.IntStream;
+import org.apache.kafka.connect.errors.DataException;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+
+public class StringToDateTest {
+
+  private static final long MILLIS_PER_DAY = 24 * 60 * 60 * 1000;
+  private static final TimeZone UTC = TimeZone.getTimeZone("UTC");
+
+  private StringToDate udf;
+
+  @Before
+  public void setUp(){
+    udf = new StringToDate();
+  }
+
+  @Test
+  public void shouldConvertStringToDate() throws ParseException {
+    // When:
+    final int result = udf.stringToDate("2021-12-01", "yyyy-MM-dd");
+
+    // Then:
+    final int expectedResult = expectedResult("2021-12-01", "yyyy-MM-dd");
+    assertThat(result, is(expectedResult));
+  }
+
+  @Test
+  public void shouldSupportEmbeddedChars() throws ParseException {
+    // When:
+    final Object result = udf.stringToDate("2021-12-01Fred", "yyyy-MM-dd'Fred'");
+
+    // Then:
+    final int expectedResult = expectedResult("2021-12-01Fred", "yyyy-MM-dd'Fred'");
+    assertThat(result, is(expectedResult));
+  }
+
+  @Test(expected = UncheckedExecutionException.class)
+  public void shouldThrowIfFormatInvalid() {
+    udf.stringToDate("2021-12-01", "invalid");
+  }
+
+  @Test(expected = DateTimeParseException.class)
+  public void shouldThrowIfParseFails() {
+    udf.stringToDate("invalid", "yyyy-MM-dd");
+  }
+
+  @Test(expected = DateTimeParseException.class)
+  public void shouldThrowOnEmptyString() {
+    udf.stringToDate("", "yyyy-MM-dd");
+  }
+
+  @Test
+  public void shouldBeThreadSafe() {
+    IntStream.range(0, 10_000)
+        .parallel()
+        .forEach(idx -> {
+          try {
+            shouldConvertStringToDate();
+          } catch (final Exception e) {
+            Assert.fail(e.getMessage());
+          }
+          udf.stringToDate("1988-01-12", "yyyy-MM-dd");
+        });
+  }
+
+  @Test
+  public void shouldWorkWithManyDifferentFormatters() {
+    IntStream.range(0, 10_000)
+        .parallel()
+        .forEach(idx -> {
+          try {
+            final String sourceDate = "2021-12-01X" + idx;
+            final String pattern = "yyyy-MM-dd'X" + idx + "'";
+            final int result = udf.stringToDate(sourceDate, pattern);
+            final int expectedResult = expectedResult(sourceDate, pattern);
+            assertThat(result, is(expectedResult));
+          } catch (final Exception e) {
+            Assert.fail(e.getMessage());
+          }
+        });
+  }
+
+
+  private int expectedResult(final String formattedDate, final String formatPattern) throws ParseException {
+    SimpleDateFormat dateFormat = new SimpleDateFormat(formatPattern);
+    dateFormat.setCalendar(Calendar.getInstance(UTC));
+    Date parsedDate = dateFormat.parse(formattedDate);
+    Calendar calendar = Calendar.getInstance(UTC);
+    calendar.setTime(parsedDate);
+    if (calendar.get(Calendar.HOUR_OF_DAY) != 0 || calendar.get(Calendar.MINUTE) != 0 ||
+        calendar.get(Calendar.SECOND) != 0 || calendar.get(Calendar.MILLISECOND) != 0) {
+      fail("Date should not have any time fields set to non-zero values.");
+    }
+    return (int)(calendar.getTimeInMillis() / MILLIS_PER_DAY);
+  }
+
+}

--- a/ksql-engine/src/test/java/io/confluent/ksql/function/udf/datetime/StringToTimestampTest.java
+++ b/ksql-engine/src/test/java/io/confluent/ksql/function/udf/datetime/StringToTimestampTest.java
@@ -25,21 +25,27 @@ import java.text.SimpleDateFormat;
 import java.util.stream.IntStream;
 import org.junit.Assert;
 import org.junit.Before;
+import org.junit.Rule;
 import org.junit.Test;
+import org.junit.rules.ExpectedException;
 
 public class StringToTimestampTest {
 
   private StringToTimestamp udf;
 
+  @Rule
+  public final ExpectedException expectedException = ExpectedException.none();
+
   @Before
-  public void setUp(){
+  public void setUp() {
     udf = new StringToTimestamp();
   }
 
   @Test
   public void shouldConvertStringToTimestamp() throws ParseException {
     // When:
-    final Object result = udf.evaluate("2021-12-01 12:10:11.123", "yyyy-MM-dd HH:mm:ss.SSS");
+    final Object result = udf.stringToTimestamp("2021-12-01 12:10:11.123",
+        "yyyy-MM-dd HH:mm:ss.SSS");
 
     // Then:
     final long expectedResult = new SimpleDateFormat("yyyy-MM-dd HH:mm:ss.SSS")
@@ -50,7 +56,8 @@ public class StringToTimestampTest {
   @Test
   public void shouldSupportEmbeddedChars() throws ParseException {
     // When:
-    final Object result = udf.evaluate("2021-12-01T12:10:11.123Fred", "yyyy-MM-dd'T'HH:mm:ss.SSS'Fred'");
+    final Object result = udf.stringToTimestamp("2021-12-01T12:10:11.123Fred",
+        "yyyy-MM-dd'T'HH:mm:ss.SSS'Fred'");
 
     // Then:
     final long expectedResult = new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss.SSS'Fred'")
@@ -58,29 +65,45 @@ public class StringToTimestampTest {
     assertThat(result, is(expectedResult));
   }
 
-  @Test(expected = KsqlFunctionException.class)
-  public void shouldThrowIfTooFewParameters() {
-    udf.evaluate("2021-12-01 12:10:11.123");
+  @Test
+  public void shouldSupportUTCTimeZone() {
+    // When:
+    final Object result = udf.stringToTimestamp("2018-08-15 17:10:43",
+        "yyyy-MM-dd HH:mm:ss", "UTC");
+
+    // Then:
+    assertThat(result, is(1534353043000L));
   }
 
-  @Test(expected = KsqlFunctionException.class)
-  public void shouldThrowIfTooManyParameters() {
-    udf.evaluate("2021-12-01 12:10:11.123", "yyyy-MM-dd HH:mm:ss.SSS", "extra");
+  @Test
+  public void shouldSupportPSTTimeZone() {
+    // When:
+    final Object result = udf.stringToTimestamp("2018-08-15 10:10:43",
+        "yyyy-MM-dd HH:mm:ss", "America/Los_Angeles");
+
+    // Then:
+    assertThat(result, is(1534353043000L));
   }
 
-  @Test(expected = KsqlFunctionException.class)
+  @Test
   public void shouldThrowIfFormatInvalid() {
-    udf.evaluate("2021-12-01 12:10:11.123", "invalid");
+    expectedException.expect(KsqlFunctionException.class);
+    expectedException.expectMessage("Unknown pattern letter: i");
+    udf.stringToTimestamp("2021-12-01 12:10:11.123", "invalid");
   }
 
-  @Test(expected = KsqlFunctionException.class)
+  @Test
   public void shouldThrowIfParseFails() {
-    udf.evaluate("invalid", "yyyy-MM-dd'T'HH:mm:ss.SSS");
+    expectedException.expect(KsqlFunctionException.class);
+    expectedException.expectMessage("Text 'invalid' could not be parsed at index 0");
+    udf.stringToTimestamp("invalid", "yyyy-MM-dd'T'HH:mm:ss.SSS");
   }
 
-  @Test(expected = KsqlFunctionException.class)
+  @Test
   public void shouldThrowOnEmptyString() {
-    udf.evaluate("", "yyyy-MM-dd'T'HH:mm:ss.SSS");
+    expectedException.expect(KsqlFunctionException.class);
+    expectedException.expectMessage("Text '' could not be parsed at index 0");
+    udf.stringToTimestamp("", "yyyy-MM-dd'T'HH:mm:ss.SSS");
   }
 
   @Test
@@ -93,7 +116,25 @@ public class StringToTimestampTest {
           } catch (final ParseException e) {
             Assert.fail(e.getMessage());
           }
-          udf.evaluate("1988-01-12 10:12:13.456", "yyyy-MM-dd HH:mm:ss.SSS");
+          udf.stringToTimestamp("1988-01-12 10:12:13.456",
+              "yyyy-MM-dd HH:mm:ss.SSS");
+        });
+  }
+
+  @Test
+  public void shouldWorkWithManyDifferentFormatters() {
+    IntStream.range(0, 10_000)
+        .parallel()
+        .forEach(idx -> {
+          try {
+            final String sourceDate = "2018-12-01 10:12:13.456X" + idx;
+            final String pattern = "yyyy-MM-dd HH:mm:ss.SSS'X" + idx + "'";
+            final long result = udf.stringToTimestamp(sourceDate, pattern);
+            final long expectedResult = new SimpleDateFormat(pattern).parse(sourceDate).getTime();
+            assertThat(result, is(expectedResult));
+          } catch (final Exception e) {
+            Assert.fail(e.getMessage());
+          }
         });
   }
 
@@ -122,7 +163,8 @@ public class StringToTimestampTest {
 
   private void assertLikeSimpleDateFormat(final String value, final String format) throws Exception {
     final long expected = new SimpleDateFormat(format).parse(value).getTime();
-    final Object result = new StringToTimestamp().evaluate(value, format);
+    final Object result = new StringToTimestamp().stringToTimestamp(value, format);
     assertThat(result, is(expected));
   }
+
 }

--- a/ksql-engine/src/test/java/io/confluent/ksql/function/udf/datetime/StringToTimestampTest.java
+++ b/ksql-engine/src/test/java/io/confluent/ksql/function/udf/datetime/StringToTimestampTest.java
@@ -37,7 +37,7 @@ public class StringToTimestampTest {
   }
 
   @Test
-  public void shouldCovertStringToTimestamp() throws ParseException {
+  public void shouldConvertStringToTimestamp() throws ParseException {
     // When:
     final Object result = udf.evaluate("2021-12-01 12:10:11.123", "yyyy-MM-dd HH:mm:ss.SSS");
 
@@ -80,7 +80,7 @@ public class StringToTimestampTest {
 
   @Test(expected = KsqlFunctionException.class)
   public void shouldThrowOnEmptyString() {
-    udf.evaluate("invalid", "yyyy-MM-dd'T'HH:mm:ss.SSS");
+    udf.evaluate("", "yyyy-MM-dd'T'HH:mm:ss.SSS");
   }
 
   @Test
@@ -89,7 +89,7 @@ public class StringToTimestampTest {
         .parallel()
         .forEach(idx -> {
           try {
-            shouldCovertStringToTimestamp();
+            shouldConvertStringToTimestamp();
           } catch (final ParseException e) {
             Assert.fail(e.getMessage());
           }

--- a/ksql-engine/src/test/java/io/confluent/ksql/function/udf/datetime/TimestampToStringTest.java
+++ b/ksql-engine/src/test/java/io/confluent/ksql/function/udf/datetime/TimestampToStringTest.java
@@ -41,7 +41,7 @@ public class TimestampToStringTest {
   }
 
   @Test
-  public void shouldCovertTimestampToString() {
+  public void shouldConvertTimestampToString() {
     // When:
     final Object result = udf.evaluate(1638360611123L, "yyyy-MM-dd HH:mm:ss.SSS");
 
@@ -128,14 +128,14 @@ public class TimestampToStringTest {
   public void shouldThrowIfFormatInvalid() {
     expectedException.expect(KsqlFunctionException.class);
     expectedException.expectMessage("Unknown pattern letter: i");
-    udf.evaluate("2021-12-01 12:10:11.123", "invalid");
+    udf.evaluate(1638360611123L, "invalid");
   }
 
   @Test
   public void shouldThrowIfNotTimestamp() {
     expectedException.expect(KsqlFunctionException.class);
     expectedException.expectMessage("java.lang.String cannot be cast to java.lang.Long");
-    udf.evaluate("invalid", "2021-12-01 12:10:11.123");
+    udf.evaluate("invalid", "yyyy-MM-dd HH:mm:ss.SSS");
   }
 
   @Test
@@ -143,7 +143,7 @@ public class TimestampToStringTest {
     IntStream.range(0, 10_000)
         .parallel()
         .forEach(idx -> {
-          shouldCovertTimestampToString();
+          shouldConvertTimestampToString();
           udf.evaluate(1538361611123L, "yyyy-MM-dd HH:mm:ss.SSS");
         });
   }

--- a/ksql-engine/src/test/java/io/confluent/ksql/function/udf/datetime/TimestampToStringTest.java
+++ b/ksql-engine/src/test/java/io/confluent/ksql/function/udf/datetime/TimestampToStringTest.java
@@ -23,6 +23,7 @@ import io.confluent.ksql.function.KsqlFunctionException;
 import java.text.SimpleDateFormat;
 import java.util.Date;
 import java.util.stream.IntStream;
+import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
@@ -36,14 +37,15 @@ public class TimestampToStringTest {
   public final ExpectedException expectedException = ExpectedException.none();
 
   @Before
-  public void setUp(){
+  public void setUp() {
     udf = new TimestampToString();
   }
 
   @Test
   public void shouldConvertTimestampToString() {
     // When:
-    final Object result = udf.evaluate(1638360611123L, "yyyy-MM-dd HH:mm:ss.SSS");
+    final Object result = udf.timestampToString(1638360611123L,
+        "yyyy-MM-dd HH:mm:ss.SSS");
 
     // Then:
     final String expectedResult = new SimpleDateFormat("yyyy-MM-dd HH:mm:ss.SSS")
@@ -54,7 +56,8 @@ public class TimestampToStringTest {
   @Test
   public void testUTCTimeZone() {
     // When:
-    final Object result = udf.evaluate(1534353043000L, "yyyy-MM-dd HH:mm:ss", "UTC");
+    final Object result = udf.timestampToString(1534353043000L,
+        "yyyy-MM-dd HH:mm:ss", "UTC");
 
     // Then:
     assertThat(result, is("2018-08-15 17:10:43"));
@@ -63,7 +66,7 @@ public class TimestampToStringTest {
   @Test
   public void testPSTTimeZone() {
     // When:
-    final Object result = udf.evaluate(1534353043000L,
+    final Object result = udf.timestampToString(1534353043000L,
         "yyyy-MM-dd HH:mm:ss", "America/Los_Angeles");
 
     // Then:
@@ -74,11 +77,11 @@ public class TimestampToStringTest {
   public void testTimeZoneInFormat() {
     // When:
     final long timestamp = 1534353043000L;
-    final Object localTime = udf.evaluate(timestamp,
+    final Object localTime = udf.timestampToString(timestamp,
         "yyyy-MM-dd HH:mm:ss zz");
-    final Object pacificTime = udf.evaluate(timestamp,
+    final Object pacificTime = udf.timestampToString(timestamp,
         "yyyy-MM-dd HH:mm:ss zz", "America/Los_Angeles");
-    final Object universalTime = udf.evaluate(timestamp,
+    final Object universalTime = udf.timestampToString(timestamp,
         "yyyy-MM-dd HH:mm:ss zz", "UTC");
 
     // Then:
@@ -94,13 +97,15 @@ public class TimestampToStringTest {
   public void shouldThrowIfInvalidTimeZone() {
     expectedException.expect(KsqlFunctionException.class);
     expectedException.expectMessage("Unknown time-zone ID: PST");
-    udf.evaluate(1638360611123L, "yyyy-MM-dd HH:mm:ss.SSS", "PST");
+    udf.timestampToString(1638360611123L,
+        "yyyy-MM-dd HH:mm:ss.SSS", "PST");
   }
 
   @Test
   public void shouldSupportEmbeddedChars() {
     // When:
-    final Object result = udf.evaluate(1638360611123L, "yyyy-MM-dd'T'HH:mm:ss.SSS'Fred'");
+    final Object result = udf.timestampToString(1638360611123L,
+        "yyyy-MM-dd'T'HH:mm:ss.SSS'Fred'");
 
     // Then:
     final String expectedResult = new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss.SSS'Fred'")
@@ -109,33 +114,10 @@ public class TimestampToStringTest {
   }
 
   @Test
-  public void shouldThrowIfTooFewParameters() {
-    expectedException.expect(KsqlFunctionException.class);
-    expectedException.expectMessage(
-        "should have at least two input arguments: date value and format.");
-    udf.evaluate(1638360611123L);
-  }
-
-  @Test
-  public void shouldThrowIfTooManyParameters() {
-    expectedException.expect(KsqlFunctionException.class);
-    expectedException.expectMessage(
-        "should have at most three input arguments: date value, format and zone.");
-    udf.evaluate(1638360611123L, "yyyy-MM-dd HH:mm:ss.SSS", "UTC", "extra");
-  }
-
-  @Test
   public void shouldThrowIfFormatInvalid() {
     expectedException.expect(KsqlFunctionException.class);
     expectedException.expectMessage("Unknown pattern letter: i");
-    udf.evaluate(1638360611123L, "invalid");
-  }
-
-  @Test
-  public void shouldThrowIfNotTimestamp() {
-    expectedException.expect(KsqlFunctionException.class);
-    expectedException.expectMessage("java.lang.String cannot be cast to java.lang.Long");
-    udf.evaluate("invalid", "yyyy-MM-dd HH:mm:ss.SSS");
+    udf.timestampToString(1638360611123L, "invalid");
   }
 
   @Test
@@ -144,7 +126,41 @@ public class TimestampToStringTest {
         .parallel()
         .forEach(idx -> {
           shouldConvertTimestampToString();
-          udf.evaluate(1538361611123L, "yyyy-MM-dd HH:mm:ss.SSS");
+          udf.timestampToString(1538361611123L, "yyyy-MM-dd HH:mm:ss.SSS");
+        });
+  }
+
+  @Test
+  public void shouldWorkWithManyDifferentFormatters() {
+    IntStream.range(0, 10_000)
+        .parallel()
+        .forEach(idx -> {
+          try {
+            final String pattern = "yyyy-MM-dd HH:mm:ss.SSS'X" + idx + "'";
+            final long millis = 1538361611123L + idx;
+            final String result = udf.timestampToString(millis, pattern);
+            final String expectedResult = new SimpleDateFormat(pattern).format(new Date(millis));
+            assertThat(result, is(expectedResult));
+          } catch (final Exception e) {
+            Assert.fail(e.getMessage());
+          }
+        });
+  }
+
+  @Test
+  public void shouldRoundTripWithStringToTimestamp() {
+    final String pattern = "yyyy-MM-dd HH:mm:ss.SSS'Freya'";
+    final StringToTimestamp stringToTimestamp = new StringToTimestamp();
+    IntStream.range(-10_000, 20_000)
+        .parallel()
+        .forEach(idx -> {
+          final long millis = 1538361611123L + idx;
+          final String result = udf.timestampToString(millis, pattern);
+          final String expectedResult = new SimpleDateFormat(pattern).format(new Date(millis));
+          assertThat(result, is(expectedResult));
+
+          final long roundtripMillis = stringToTimestamp.stringToTimestamp(result, pattern);
+          assertThat(roundtripMillis, is(millis));
         });
   }
 
@@ -179,7 +195,8 @@ public class TimestampToStringTest {
 
   private void assertLikeSimpleDateFormat(final String format) {
     final String expected = new SimpleDateFormat(format).format(1538361611123L);
-    final Object result = new TimestampToString().evaluate(1538361611123L, format);
+    final Object result = new TimestampToString()
+        .timestampToString(1538361611123L, format);
     assertThat(result, is(expected));
   }
 }

--- a/ksql-engine/src/test/resources/query-validation-tests/datestring.json
+++ b/ksql-engine/src/test/resources/query-validation-tests/datestring.json
@@ -1,12 +1,4 @@
 {
-  "comments": [
-    "You can specify multiple statements per test case, i.e., to set up the various streams needed",
-    "for joins etc, but currently only the final topology will be verified. This should be enough",
-    "for most tests as we can simulate the outputs from previous stages into the final stage. If we",
-    "take a modular approach to testing we can still verify that it all works correctly, i.e, if we",
-    "verify the output of a select or aggregate is correct, we can use simulated output to feed into",
-    "a join or another aggregate."
-  ],
   "tests": [
     {
       "name": "date to string",

--- a/ksql-engine/src/test/resources/query-validation-tests/datestring.json
+++ b/ksql-engine/src/test/resources/query-validation-tests/datestring.json
@@ -1,0 +1,36 @@
+{
+  "comments": [
+    "You can specify multiple statements per test case, i.e., to set up the various streams needed",
+    "for joins etc, but currently only the final topology will be verified. This should be enough",
+    "for most tests as we can simulate the outputs from previous stages into the final stage. If we",
+    "take a modular approach to testing we can still verify that it all works correctly, i.e, if we",
+    "verify the output of a select or aggregate is correct, we can use simulated output to feed into",
+    "a join or another aggregate."
+  ],
+  "tests": [
+    {
+      "name": "date to string",
+      "statements": [
+        "CREATE STREAM TEST (ID bigint, START_DATE int, DATE_FORMAT varchar) WITH (kafka_topic='test_topic', value_format='JSON');",
+        "CREATE STREAM DATE_STREAM AS select ID, datetostring(START_DATE, DATE_FORMAT) as CUSTOM_FORMATTED_START_DATE from test;"
+      ],
+      "inputs": [
+        {"topic": "test_topic", "key": 1, "value": {"ID": 1, "START_DATE": 17662, "DATE_FORMAT": "yyyy-MM-dd"}, "timestamp": 0},
+        {"topic": "test_topic", "key": 2, "value": {"ID": 2, "START_DATE": 18027, "DATE_FORMAT": "dd/MM/yyyy"}, "timestamp": 0},
+        {"topic": "test_topic", "key": 3, "value": {"ID": 3, "START_DATE": 18993, "DATE_FORMAT": "dd-MMM-yyyy"}, "timestamp": 0},
+        {"topic": "test_topic", "key": 4, "value": {"ID": 4, "START_DATE": 0, "DATE_FORMAT": "dd-MM-yyyy"}, "timestamp": 0},
+        {"topic": "test_topic", "key": 5, "value": {"ID": 5, "START_DATE": -1, "DATE_FORMAT": "dd-MM-yyyy'Sophia'"}, "timestamp": 0}
+
+      ],
+      "outputs": [
+        {"topic": "DATE_STREAM", "key": 1, "value": {"ID": 1, "CUSTOM_FORMATTED_START_DATE": "2018-05-11"}, "timestamp": 0},
+        {"topic": "DATE_STREAM", "key": 2, "value": {"ID": 2, "CUSTOM_FORMATTED_START_DATE": "11/05/2019"}, "timestamp": 0},
+        {"topic": "DATE_STREAM", "key": 3, "value": {"ID": 3, "CUSTOM_FORMATTED_START_DATE": "01-Jan-2022"}, "timestamp": 0},
+        {"topic": "DATE_STREAM", "key": 4, "value": {"ID": 4, "CUSTOM_FORMATTED_START_DATE": "01-01-1970"}, "timestamp": 0},
+        {"topic": "DATE_STREAM", "key": 5, "value": {"ID": 5, "CUSTOM_FORMATTED_START_DATE": "31-12-1969Sophia"}, "timestamp": 0}
+      ]
+    }
+  ]
+}
+
+

--- a/ksql-engine/src/test/resources/query-validation-tests/stringdate.json
+++ b/ksql-engine/src/test/resources/query-validation-tests/stringdate.json
@@ -1,12 +1,4 @@
 {
-  "comments": [
-    "You can specify multiple statements per test case, i.e., to set up the various streams needed",
-    "for joins etc, but currently only the final topology will be verified. This should be enough",
-    "for most tests as we can simulate the outputs from previous stages into the final stage. If we",
-    "take a modular approach to testing we can still verify that it all works correctly, i.e, if we",
-    "verify the output of a select or aggregate is correct, we can use simulated output to feed into",
-    "a join or another aggregate."
-  ],
   "tests": [
     {
       "name": "string to date",
@@ -15,7 +7,7 @@
         "CREATE STREAM TS AS select id, stringtodate(date, format) as ts from test;"
       ],
       "inputs": [
-        {"topic": "test_topic", "key": 0, "value": "0,zero,2018-05-11,yyyy-MM-dd", "timestamp": 0},
+        {"topic": "test_topic", "key": 0, "value": "0,zero,2018-05-11Lit,yyyy-MM-dd'Lit'", "timestamp": 0},
         {"topic": "test_topic", "key": 1, "value": "1,zero,11/05/2019,dd/MM/yyyy", "timestamp": 0},
         {"topic": "test_topic", "key": 2, "value": "2,zero,01-Jan-2022,dd-MMM-yyyy", "timestamp": 0},
         {"topic": "test_topic", "key": 3, "value": "3,yyy,01-01-1970,dd-MM-yyyy", "timestamp": 0}

--- a/ksql-engine/src/test/resources/query-validation-tests/stringdate.json
+++ b/ksql-engine/src/test/resources/query-validation-tests/stringdate.json
@@ -1,0 +1,31 @@
+{
+  "comments": [
+    "You can specify multiple statements per test case, i.e., to set up the various streams needed",
+    "for joins etc, but currently only the final topology will be verified. This should be enough",
+    "for most tests as we can simulate the outputs from previous stages into the final stage. If we",
+    "take a modular approach to testing we can still verify that it all works correctly, i.e, if we",
+    "verify the output of a select or aggregate is correct, we can use simulated output to feed into",
+    "a join or another aggregate."
+  ],
+  "tests": [
+    {
+      "name": "string to date",
+      "statements": [
+        "CREATE STREAM TEST (ID bigint, NAME varchar, date varchar, format varchar) WITH (kafka_topic='test_topic', value_format='DELIMITED', key='ID');",
+        "CREATE STREAM TS AS select id, stringtodate(date, format) as ts from test;"
+      ],
+      "inputs": [
+        {"topic": "test_topic", "key": 0, "value": "0,zero,2018-05-11,yyyy-MM-dd", "timestamp": 0},
+        {"topic": "test_topic", "key": 1, "value": "1,zero,11/05/2019,dd/MM/yyyy", "timestamp": 0},
+        {"topic": "test_topic", "key": 2, "value": "2,zero,01-Jan-2022,dd-MMM-yyyy", "timestamp": 0},
+        {"topic": "test_topic", "key": 3, "value": "3,yyy,01-01-1970,dd-MM-yyyy", "timestamp": 0}
+      ],
+      "outputs": [
+        {"topic": "TS", "key": 0, "value": "0,17662", "timestamp": 0},
+        {"topic": "TS", "key": 1, "value": "1,18027", "timestamp": 0},
+        {"topic": "TS", "key": 2, "value": "2,18993", "timestamp": 0},
+        {"topic": "TS", "key": 3, "value": "3,0", "timestamp": 0}
+      ]
+    }
+  ]
+}

--- a/ksql-rest-app/src/test/java/io/confluent/ksql/rest/server/resources/KsqlResourceTest.java
+++ b/ksql-rest-app/src/test/java/io/confluent/ksql/rest/server/resources/KsqlResourceTest.java
@@ -202,7 +202,7 @@ public class KsqlResourceTest {
 
     // Then:
     assertThat(functionList.getFunctions(), hasItems(
-        new SimpleFunctionInfo("TIMESTAMPTOSTRING", FunctionType.scalar),
+        new SimpleFunctionInfo("EXTRACTJSONFIELD", FunctionType.scalar),
         new SimpleFunctionInfo("ARRAYCONTAINS", FunctionType.scalar),
         new SimpleFunctionInfo("CONCAT", FunctionType.scalar),
         new SimpleFunctionInfo("TOPK", FunctionType.aggregate),


### PR DESCRIPTION
### Description 
Added `stringtodate` and `datetostring` UDFs to convert to and from a formatted date string and an integer representing days since epoch. This format is used by Kafka Connect to represent Date objects with no time or time zone component.

In a separate commit on the same PR I also updated `stringtotimestamp` and `timestamptostring` to use the new UDF api and to support dynamically supplied format patterns.

This is #1890 cherry picked for the 5.1.x branch.

### Testing done 
Added tests for all new functionality and ran locally. Generated and views updated docs locally.

### Reviewer checklist
- [ ] Ensure docs are updated if necessary. (eg. if a user visible feature is being added or changed).
- [ ] Ensure relevant issues are linked (description should include text like "Fixes #<issue number>")

