### PR TITLE
Remove in-page TOCs

### DIFF
--- a/docs/capacity-planning.rst
+++ b/docs/capacity-planning.rst
@@ -18,10 +18,6 @@ KSQL is a simple and powerful tool for building streaming applications on top of
          Streams capacity planning guide <streams_sizing>`
          is another useful resource for KSQL capacity planning.
 
-.. contents:: Contents
-    :local:
-    :depth: 2
-
 Approach To Sizing
 ==================
 

--- a/docs/faq.rst
+++ b/docs/faq.rst
@@ -3,10 +3,6 @@
 Frequently Asked Questions
 ==========================
 
-.. contents:: Contents
-    :local:
-    :depth: 1
-
 ==============================
 What are the benefits of KSQL?
 ==============================

--- a/docs/installation/installing.rst
+++ b/docs/installation/installing.rst
@@ -14,10 +14,6 @@ Docker support
     You can deploy KSQL in Docker, however the current release does not yet ship with ready-to-use KSQL Docker images for
     production. These images are coming soon.
 
-.. contents::
-    :local:
-
-
 ---------------------------------------
 Supported Versions and Interoperability
 ---------------------------------------

--- a/docs/installation/server-config/avro-schema.rst
+++ b/docs/installation/server-config/avro-schema.rst
@@ -7,9 +7,6 @@ KSQL can read and write messages in Avro format by integrating with :ref:`Conflu
 KSQL automatically retrieves (read) and registers (write) Avro schemas as needed and thus saves you from both having to
 manually define columns and data types in KSQL and from manual interaction with the Schema Registry.
 
-.. contents:: Contents
-    :local:
-
 Supported functionality
 ^^^^^^^^^^^^^^^^^^^^^^^
 

--- a/docs/installation/server-config/config-reference.rst
+++ b/docs/installation/server-config/config-reference.rst
@@ -5,9 +5,6 @@ KSQL Configuration Parameter Reference
 
 Here are some common configuration properties that you can customize.
 
-.. contents::
-    :local:
-
 Kafka Streams and Kafka Client Settings
 ---------------------------------------
 

--- a/docs/installation/server-config/security.rst
+++ b/docs/installation/server-config/security.rst
@@ -16,9 +16,6 @@ file and then :ref:`start the KSQL server <start_ksql-server>` with your configu
 
     $ <path-to-confluent>/bin/ksql-server-start <path-to-confluent>/etc/ksql/ksql-server.properties
 
-.. contents:: Table of Contents
-    :local:
-
 Configuring KSQL for |ccloud|
 -----------------------------
 

--- a/docs/syntax-reference.rst
+++ b/docs/syntax-reference.rst
@@ -8,11 +8,6 @@ KSQL has similar semantics to SQL:
 - Terminate KSQL statements with a semicolon ``;``
 - Use a back-slash ``\`` to indicate continuation of a multi-line statement on the next line
 
-.. contents:: Contents
-    :local:
-    :depth: 1
-
-
 ===========
 Terminology
 ===========
@@ -135,11 +130,6 @@ KSQL statements
        -  In the CLI you must use a backslash (``\``) to indicate
           continuation of a statement on the next line.
        -  Do not use ``\`` for multi-line statements in ``.sql`` files.
-
-
-.. contents:: Available KSQL statements:
-    :local:
-    :depth: 1
 
 .. _create-stream:
 

--- a/docs/tutorials/examples.rst
+++ b/docs/tutorials/examples.rst
@@ -5,11 +5,6 @@ KSQL Examples
 
 These examples use a ``pageviews`` stream and a ``users`` table.
 
-.. contents:: Contents
-    :local:
-    :depth: 2
-
-
 Creating streams
 ----------------
 


### PR DESCRIPTION
### Description 
In-page TOCs aren't necessary now, since the docs site has floating in-page nav in the right column. Remove all `.. contents::` blocks.