### PR TITLE
Add config to limit number of active persistent queries

### DIFF
--- a/docs/installation/server-config/config-reference.rst
+++ b/docs/installation/server-config/config-reference.rst
@@ -164,7 +164,7 @@ ksql.active.persistent.query.limit
 
 The maximum number of persistent queries that may be running at any given time.
 Commands that would cause this limit to be exceeded are rejected.
-The default is ``Integer.MAX_VALUE``, which indicates that there is no limit.
+The default is no limit.
 
 Users may wish to configure this limit because throughput suffers as more queries are run simultaneously,
 and also because there is some small CPU overhead associated with starting each new query.

--- a/docs/installation/server-config/config-reference.rst
+++ b/docs/installation/server-config/config-reference.rst
@@ -158,12 +158,17 @@ These configurations control the general behavior of the KSQL server. These conf
 
 .. _ksql-active-persistent-query-limit:
 
------------------
+----------------------------------
 ksql.active.persistent.query.limit
------------------
+----------------------------------
 
 The maximum number of persistent queries that may be running at any given time.
-The default is ``Integer.MAX_VALUE`` (i.e., no limit).
+Commands that would cause this limit to be exceeded are rejected.
+The default is ``Integer.MAX_VALUE``, which indicates that there is no limit.
+
+Users may wish to configure this limit because throughput suffers as more queries are run simultaneously,
+and also because there is some small CPU overhead associated with starting each new query.
+See :ref:`KSQL Sizing Recommendations <important-sizing-factors>` for more details.
 
 .. _ksql-queries-file:
 

--- a/docs/installation/server-config/config-reference.rst
+++ b/docs/installation/server-config/config-reference.rst
@@ -156,6 +156,15 @@ These configurations control the general behavior of the KSQL server. These conf
 .. important:: KSQL server configuration settings take precedence over those set in the KSQL CLI. For example, if a value
                for ``ksql.streams.replication.factor`` is set in both the KSQL server and KSQL CLI, the KSQL server value is used.
 
+.. _ksql-active-persistent-query-limit:
+
+-----------------
+ksql.active.persistent.query.limit
+-----------------
+
+The maximum number of persistent queries that may be running at any given time.
+The default is ``Integer.MAX_VALUE`` (i.e., no limit).
+
 .. _ksql-queries-file:
 
 -----------------

--- a/ksql-common/src/main/java/io/confluent/ksql/util/KsqlConfig.java
+++ b/ksql-common/src/main/java/io/confluent/ksql/util/KsqlConfig.java
@@ -57,6 +57,12 @@ public class KsqlConfig extends AbstractConfig implements Cloneable {
 
   public static final String KSQL_EXT_DIR = "ksql.extension.dir";
 
+  public static final String KSQL_ACTIVE_PERSISTENT_QUERY_LIMIT_CONFIG =
+      "ksql.active.persistent.query.limit";
+  private static final int KSQL_ACTIVE_PERSISTENT_QUERY_LIMIT_DEFAULT = Integer.MAX_VALUE;
+  private static final String KSQL_ACTIVE_PERSISTENT_QUERY_LIMIT_DOC =
+      "The maximum number of active, persistent queries that may be present at a time.";
+
   public static final String SINK_WINDOW_CHANGE_LOG_ADDITIONAL_RETENTION_MS_PROPERTY =
       "ksql.sink.window.change.log.additional.retention";
 
@@ -277,6 +283,12 @@ public class KsqlConfig extends AbstractConfig implements Cloneable {
             DEFAULT_EXT_DIR,
             ConfigDef.Importance.LOW,
             "The path to look for and load extensions such as UDFs from."
+        ).define(
+            KSQL_ACTIVE_PERSISTENT_QUERY_LIMIT_CONFIG,
+            ConfigDef.Type.INT,
+            KSQL_ACTIVE_PERSISTENT_QUERY_LIMIT_DEFAULT,
+            ConfigDef.Importance.LOW,
+            KSQL_ACTIVE_PERSISTENT_QUERY_LIMIT_DOC
         ).define(
             KSQL_UDF_SECURITY_MANAGER_ENABLED,
             ConfigDef.Type.BOOLEAN,

--- a/ksql-engine/src/main/java/io/confluent/ksql/KsqlEngine.java
+++ b/ksql-engine/src/main/java/io/confluent/ksql/KsqlEngine.java
@@ -552,6 +552,10 @@ public class KsqlEngine implements Closeable {
     return this.livePersistentQueries.size();
   }
 
+  public boolean hasReachedMaxNumberOfPersistentQueries(final KsqlConfig ksqlConfig) {
+    return numberOfPersistentQueries()
+        >= ksqlConfig.getInt(KsqlConfig.KSQL_ACTIVE_PERSISTENT_QUERY_LIMIT_CONFIG);
+  }
 
   @Override
   public void close() {

--- a/ksql-engine/src/main/java/io/confluent/ksql/KsqlEngine.java
+++ b/ksql-engine/src/main/java/io/confluent/ksql/KsqlEngine.java
@@ -557,6 +557,11 @@ public class KsqlEngine implements Closeable {
         >= ksqlConfig.getInt(KsqlConfig.KSQL_ACTIVE_PERSISTENT_QUERY_LIMIT_CONFIG);
   }
 
+  public boolean hasExceededMaxNumberOfPersistentQueries(final KsqlConfig ksqlConfig) {
+    return numberOfPersistentQueries()
+        > ksqlConfig.getInt(KsqlConfig.KSQL_ACTIVE_PERSISTENT_QUERY_LIMIT_CONFIG);
+  }
+
   @Override
   public void close() {
     for (final QueryMetadata queryMetadata : allLiveQueries) {

--- a/ksql-engine/src/main/java/io/confluent/ksql/KsqlEngine.java
+++ b/ksql-engine/src/main/java/io/confluent/ksql/KsqlEngine.java
@@ -264,8 +264,8 @@ public class KsqlEngine implements Closeable {
       if (queryMetadata instanceof PersistentQueryMetadata) {
         final PersistentQueryMetadata persistentQueryMd = (PersistentQueryMetadata) queryMetadata;
         metaStore.updateForPersistentQuery(persistentQueryMd.getQueryId().getId(),
-            persistentQueryMd.getSourceNames(),
-            persistentQueryMd.getSinkNames());
+                                           persistentQueryMd.getSourceNames(),
+                                           persistentQueryMd.getSinkNames());
       }
     }
     return runningQueries;

--- a/ksql-engine/src/main/java/io/confluent/ksql/QueryEngine.java
+++ b/ksql-engine/src/main/java/io/confluent/ksql/QueryEngine.java
@@ -215,7 +215,8 @@ class QueryEngine {
         metaStore,
         ksqlEngine.getSchemaRegistryClientFactory(),
         ksqlEngine.getQueryIdGenerator(),
-        new KafkaStreamsBuilderImpl(clientSupplier)
+        new KafkaStreamsBuilderImpl(clientSupplier),
+        queryMetadata -> ksqlEngine.addActiveQuery(queryMetadata, ksqlConfig)
     );
     physicalPlans.add(physicalPlanBuilder.buildPhysicalPlan(logicalPlanNode));
   }

--- a/ksql-engine/src/main/java/io/confluent/ksql/internal/KsqlEngineMetrics.java
+++ b/ksql-engine/src/main/java/io/confluent/ksql/internal/KsqlEngineMetrics.java
@@ -108,14 +108,14 @@ public class KsqlEngineMetrics implements Closeable {
     return sensors;
   }
 
-  public void registerQueries(final List<QueryMetadata> queryMetadataList) {
-    queryMetadataList.forEach(queryMetadata -> queryMetadata.registerQueryStateListener(
+  public void registerQuery(final QueryMetadata queryMetadata) {
+    queryMetadata.registerQueryStateListener(
         new QueryStateListener(
             metrics,
             queryMetadata.getKafkaStreams(),
             queryMetadata.getQueryApplicationId()
         )
-    ));
+    );
   }
 
   private void recordMessageConsumptionByQueryStats(

--- a/ksql-engine/src/main/java/io/confluent/ksql/physical/PhysicalPlanBuilder.java
+++ b/ksql-engine/src/main/java/io/confluent/ksql/physical/PhysicalPlanBuilder.java
@@ -49,6 +49,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.concurrent.ThreadLocalRandom;
+import java.util.function.Consumer;
 import java.util.function.Supplier;
 
 import org.apache.kafka.clients.consumer.ConsumerConfig;
@@ -72,7 +73,9 @@ public class PhysicalPlanBuilder {
   private final Supplier<SchemaRegistryClient> schemaRegistryClientFactory;
   private final QueryIdGenerator queryIdGenerator;
   private final KafkaStreamsBuilder kafkaStreamsBuilder;
+  private final Consumer<QueryMetadata> onStartQueryEvent;
 
+  // CHECKSTYLE_RULES.OFF: ParameterNumberCheck
   public PhysicalPlanBuilder(
       final StreamsBuilder builder,
       final KsqlConfig ksqlConfig,
@@ -83,8 +86,10 @@ public class PhysicalPlanBuilder {
       final MetaStore metaStore,
       final Supplier<SchemaRegistryClient> schemaRegistryClientFactory,
       final QueryIdGenerator queryIdGenerator,
-      final KafkaStreamsBuilder kafkaStreamsBuilder
+      final KafkaStreamsBuilder kafkaStreamsBuilder,
+      final Consumer<QueryMetadata> onStartQueryEvent
   ) {
+    // CHECKSTYLE_RULES.ON: ParameterNumberCheck
     this.builder = builder;
     this.ksqlConfig = ksqlConfig;
     this.kafkaTopicClient = kafkaTopicClient;
@@ -95,6 +100,7 @@ public class PhysicalPlanBuilder {
     this.schemaRegistryClientFactory = schemaRegistryClientFactory;
     this.queryIdGenerator = queryIdGenerator;
     this.kafkaStreamsBuilder = kafkaStreamsBuilder;
+    this.onStartQueryEvent = Objects.requireNonNull(onStartQueryEvent, "onStartQueryEvent");
   }
 
   public QueryMetadata buildPhysicalPlan(final LogicalPlanNode logicalPlanNode) {
@@ -194,7 +200,8 @@ public class PhysicalPlanBuilder {
         applicationId,
         kafkaTopicClient,
         builder.build(),
-        overriddenStreamsProperties
+        overriddenStreamsProperties,
+        onStartQueryEvent
     );
   }
 
@@ -272,7 +279,8 @@ public class PhysicalPlanBuilder {
         kafkaTopicClient,
         sinkDataSource.getKsqlTopic(),
         topology,
-        overriddenStreamsProperties
+        overriddenStreamsProperties,
+        onStartQueryEvent
     );
   }
 

--- a/ksql-engine/src/main/java/io/confluent/ksql/util/PersistentQueryMetadata.java
+++ b/ksql-engine/src/main/java/io/confluent/ksql/util/PersistentQueryMetadata.java
@@ -25,6 +25,7 @@ import java.util.HashSet;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Set;
+import java.util.function.Consumer;
 import org.apache.kafka.streams.KafkaStreams;
 import org.apache.kafka.streams.Topology;
 
@@ -47,10 +48,12 @@ public class PersistentQueryMetadata extends QueryMetadata {
                                  final KafkaTopicClient kafkaTopicClient,
                                  final KsqlTopic resultTopic,
                                  final Topology topology,
-                                 final Map<String, Object> overriddenProperties) {
+                                 final Map<String, Object> overriddenProperties,
+                                 final Consumer<QueryMetadata> onStartEvent) {
     // CHECKSTYLE_RULES.ON: ParameterNumberCheck
     super(statementString, kafkaStreams, outputNode, executionPlan, dataSourceType,
-          queryApplicationId, kafkaTopicClient, topology, overriddenProperties);
+          queryApplicationId, kafkaTopicClient, topology, overriddenProperties,
+          onStartEvent);
     this.id = id;
     this.resultTopic = resultTopic;
     this.sinkNames = new HashSet<>();

--- a/ksql-engine/src/main/java/io/confluent/ksql/util/QueuedQueryMetadata.java
+++ b/ksql-engine/src/main/java/io/confluent/ksql/util/QueuedQueryMetadata.java
@@ -23,6 +23,7 @@ import java.util.Map;
 import java.util.Objects;
 import java.util.concurrent.BlockingQueue;
 import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.function.Consumer;
 import org.apache.kafka.streams.KafkaStreams;
 import org.apache.kafka.streams.KeyValue;
 import org.apache.kafka.streams.Topology;
@@ -32,6 +33,7 @@ public class QueuedQueryMetadata extends QueryMetadata {
   private final BlockingQueue<KeyValue<String, GenericRow>> rowQueue;
   private final AtomicBoolean isRunning = new AtomicBoolean(true);
 
+  // CHECKSTYLE_RULES.OFF: ParameterNumberCheck
   public QueuedQueryMetadata(
       final String statementString,
       final KafkaStreams kafkaStreams,
@@ -42,9 +44,12 @@ public class QueuedQueryMetadata extends QueryMetadata {
       final String queryApplicationId,
       final KafkaTopicClient kafkaTopicClient,
       final Topology topology,
-      final Map<String, Object> overriddenProperties) {
+      final Map<String, Object> overriddenProperties,
+      final Consumer<QueryMetadata> onStartEvent) {
+    // CHECKSTYLE_RULES.ON: ParameterNumberCheck
     super(statementString, kafkaStreams, outputNode, executionPlan, dataSourceType,
-          queryApplicationId, kafkaTopicClient, topology, overriddenProperties);
+          queryApplicationId, kafkaTopicClient, topology, overriddenProperties,
+          onStartEvent);
     this.rowQueue = rowQueue;
   }
 

--- a/ksql-engine/src/test/java/io/confluent/ksql/KsqlContextTest.java
+++ b/ksql-engine/src/test/java/io/confluent/ksql/KsqlContextTest.java
@@ -102,7 +102,8 @@ public class KsqlContextTest {
                                                                                   null,
                                                                                   null,
                                                                                   null,
-                                                                                  null);
+                                                                                  null,
+                                                                                  md -> {});
 
     return Collections.singletonList(persistentQueryMetadata);
   }

--- a/ksql-engine/src/test/java/io/confluent/ksql/KsqlEngineTest.java
+++ b/ksql-engine/src/test/java/io/confluent/ksql/KsqlEngineTest.java
@@ -321,6 +321,9 @@ public class KsqlEngineTest {
         "create stream s1  with (value_format = 'avro') as select * from test1;"
         + "create table t1 as select col1, count(*) from s1 group by col1;",
         ksqlConfig, Collections.emptyMap());
+    for (final QueryMetadata queryMetadata : queries) {
+      ksqlEngine.addActiveQuery(queryMetadata, ksqlConfig);
+    }
     final Schema schema = SchemaBuilder
         .record("Test").fields()
         .name("clientHash").type().fixed("MD5").size(16).noDefault()

--- a/ksql-engine/src/test/java/io/confluent/ksql/physical/PhysicalPlanBuilderTest.java
+++ b/ksql-engine/src/test/java/io/confluent/ksql/physical/PhysicalPlanBuilderTest.java
@@ -134,7 +134,8 @@ public class PhysicalPlanBuilderTest {
         metaStore,
         schemaRegistryClientFactory,
         new QueryIdGenerator(),
-        testKafkaStreamsBuilder
+        testKafkaStreamsBuilder,
+        md -> {}
     );
 
   }

--- a/ksql-engine/src/test/java/io/confluent/ksql/util/QueryMetadataTest.java
+++ b/ksql-engine/src/test/java/io/confluent/ksql/util/QueryMetadataTest.java
@@ -22,19 +22,25 @@ import io.confluent.ksql.serde.DataSource;
 import io.confluent.ksql.serde.DataSource.DataSourceType;
 import java.util.Collections;
 import java.util.Map;
+import java.util.function.Consumer;
 import org.apache.kafka.common.MetricName;
 import org.apache.kafka.common.metrics.Metrics;
 import org.apache.kafka.streams.KafkaStreams;
 import org.apache.kafka.streams.KafkaStreams.State;
 import org.apache.kafka.streams.Topology;
 import org.easymock.EasyMock;
+import org.easymock.EasyMockRunner;
+import org.easymock.Mock;
+import org.easymock.MockType;
 import org.junit.Before;
 import org.junit.Test;
+import org.junit.runner.RunWith;
 
 import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.CoreMatchers.nullValue;
 import static org.hamcrest.MatcherAssert.assertThat;
 
+@RunWith(EasyMockRunner.class)
 public class QueryMetadataTest {
 
   private final String statementString = "foo";
@@ -47,9 +53,13 @@ public class QueryMetadataTest {
   private final Map<String, Object> overriddenProperties = Collections.emptyMap();
 
   private KafkaStreams kafkaStreams;
+  private QueryMetadata queryMetadata;
   private Metrics metrics;
   private MetricName metricName;
   private final String metricGroupName = "ksql-queries";
+
+  @Mock(MockType.NICE)
+  private Consumer<QueryMetadata> onStartQueryEvent;
 
   @Before
   public void setup() {
@@ -59,16 +69,9 @@ public class QueryMetadataTest {
         Collections.singletonMap("status", queryApplicationId));
     outputNode = EasyMock.niceMock(OutputNode.class);
     kafkaStreams = EasyMock.niceMock(KafkaStreams.class);
-  }
+    EasyMock.replay(kafkaStreams, outputNode, onStartQueryEvent);
 
-  @Test
-  public void shouldAddandRemoveTheMetricOnClose() {
-    EasyMock.expect(kafkaStreams.state()).andReturn(State.RUNNING).once();
-    EasyMock.expect(kafkaStreams.state()).andReturn(State.NOT_RUNNING).once();
-    EasyMock.replay(kafkaStreams, outputNode);
-    final QueryStateListener queryStateListener = new QueryStateListener(metrics, kafkaStreams, queryApplicationId);
-    kafkaStreams.setStateListener(EasyMock.eq(queryStateListener));
-    final QueryMetadata queryMetadata = new QueryMetadata(
+    queryMetadata = new QueryMetadata(
         statementString,
         kafkaStreams,
         outputNode,
@@ -77,8 +80,20 @@ public class QueryMetadataTest {
         queryApplicationId,
         kafkaTopicClient,
         topoplogy,
-        overriddenProperties
+        overriddenProperties,
+        onStartQueryEvent
     );
+  }
+
+  @Test
+  public void shouldAddAndRemoveTheMetricOnClose() {
+    EasyMock.reset(kafkaStreams);
+    EasyMock.expect(kafkaStreams.state()).andReturn(State.RUNNING).once();
+    EasyMock.expect(kafkaStreams.state()).andReturn(State.NOT_RUNNING).once();
+    EasyMock.replay(kafkaStreams);
+    final QueryStateListener queryStateListener = new QueryStateListener(metrics, kafkaStreams, queryApplicationId);
+    kafkaStreams.setStateListener(EasyMock.eq(queryStateListener));
+
     queryMetadata.registerQueryStateListener(queryStateListener);
     queryMetadata.start();
     assertThat(metrics.metric(metricName).metricName().name(), equalTo("query-status"));
@@ -93,4 +108,30 @@ public class QueryMetadataTest {
 
   }
 
+  @Test
+  public void shouldFireEventOnStart() {
+    // Given:
+    EasyMock.reset(onStartQueryEvent);
+    onStartQueryEvent.accept(EasyMock.anyObject(QueryMetadata.class));
+    EasyMock.expectLastCall();
+    EasyMock.replay(onStartQueryEvent);
+
+    // When:
+    queryMetadata.start();
+
+    // Then:
+    EasyMock.verify(onStartQueryEvent);
+  }
+
+  @Test(expected = KsqlException.class)
+  public void shouldThrowIfStartEventThrows() {
+    // Given:
+    EasyMock.reset(onStartQueryEvent);
+    onStartQueryEvent.accept(EasyMock.anyObject(QueryMetadata.class));
+    EasyMock.expectLastCall().andThrow(new KsqlException("Boom"));
+    EasyMock.replay(onStartQueryEvent);
+
+    // When:
+    queryMetadata.start();
+  }
 }

--- a/ksql-rest-app/src/main/java/io/confluent/ksql/rest/server/StandaloneExecutor.java
+++ b/ksql-rest-app/src/main/java/io/confluent/ksql/rest/server/StandaloneExecutor.java
@@ -256,7 +256,14 @@ public class StandaloneExecutor implements Executable {
   private void handlePersistentQuery(
       final String statementString,
       final Map<String, Object> configProperties) {
-
+    if (ksqlEngine.hasReachedMaxNumberOfPersistentQueries(ksqlConfig)) {
+      throw new KsqlException(
+          String.format(
+              "Not executing query '%s' due to limit on number of active, persistent queries.",
+              statementString
+          )
+      );
+    }
     final List<QueryMetadata> queryMetadataList =
         ksqlEngine.buildMultipleQueries(statementString, ksqlConfig, configProperties);
     if (queryMetadataList.size() != 1

--- a/ksql-rest-app/src/main/java/io/confluent/ksql/rest/server/StandaloneExecutor.java
+++ b/ksql-rest-app/src/main/java/io/confluent/ksql/rest/server/StandaloneExecutor.java
@@ -259,8 +259,12 @@ public class StandaloneExecutor implements Executable {
     if (ksqlEngine.hasReachedMaxNumberOfPersistentQueries(ksqlConfig)) {
       throw new KsqlException(
           String.format(
-              "Not executing query '%s' due to limit on number of active, persistent queries.",
-              statementString
+              "Not executing query '%s' since the limit on number of active, persistent queries "
+                  + "has been reached (%d persistent queries currently running. Limit is %d). "
+                  + "This limit can be reconfigured via the 'ksql-server.properties' file.",
+              statementString,
+              ksqlEngine.numberOfPersistentQueries(),
+              ksqlConfig.getInt(KsqlConfig.KSQL_ACTIVE_PERSISTENT_QUERY_LIMIT_CONFIG)
           )
       );
     }

--- a/ksql-rest-app/src/main/java/io/confluent/ksql/rest/server/StandaloneExecutor.java
+++ b/ksql-rest-app/src/main/java/io/confluent/ksql/rest/server/StandaloneExecutor.java
@@ -235,6 +235,7 @@ public class StandaloneExecutor implements Executable {
 
   private void executeStatements(final String queries) {
     final List<PreparedStatement> preparedStatements = ksqlEngine.parseStatements(queries);
+    ksqlEngine.checkPersistentQueryCapacity(preparedStatements, ksqlConfig, queries);
 
     if (failOnNoQueries) {
       final boolean noQueries = preparedStatements.stream()
@@ -256,18 +257,6 @@ public class StandaloneExecutor implements Executable {
   private void handlePersistentQuery(
       final String statementString,
       final Map<String, Object> configProperties) {
-    if (ksqlEngine.hasReachedMaxNumberOfPersistentQueries(ksqlConfig)) {
-      throw new KsqlException(
-          String.format(
-              "Not executing query '%s' since the limit on number of active, persistent queries "
-                  + "has been reached (%d persistent queries currently running. Limit is %d). "
-                  + "This limit can be reconfigured via the 'ksql-server.properties' file.",
-              statementString,
-              ksqlEngine.numberOfPersistentQueries(),
-              ksqlConfig.getInt(KsqlConfig.KSQL_ACTIVE_PERSISTENT_QUERY_LIMIT_CONFIG)
-          )
-      );
-    }
     final List<QueryMetadata> queryMetadataList =
         ksqlEngine.buildMultipleQueries(statementString, ksqlConfig, configProperties);
     if (queryMetadataList.size() != 1

--- a/ksql-rest-app/src/main/java/io/confluent/ksql/rest/server/computation/StatementExecutor.java
+++ b/ksql-rest-app/src/main/java/io/confluent/ksql/rest/server/computation/StatementExecutor.java
@@ -261,7 +261,7 @@ public class StatementExecutor {
           ksqlConfig.overrideBreakingConfigsWithOriginalValues(command.getOriginalProperties()),
           overriddenProperties
       );
-      if (ksqlEngine.hasReachedMaxNumberOfPersistentQueries(ksqlConfig)) {
+      if (ksqlEngine.hasExceededMaxNumberOfPersistentQueries(ksqlConfig)) {
         for (final QueryMetadata queryMetadata : queryMetadataList) {
           if (queryMetadata instanceof PersistentQueryMetadata) {
             final PersistentQueryMetadata persistentQueryMd =

--- a/ksql-rest-app/src/main/java/io/confluent/ksql/rest/server/resources/KsqlResource.java
+++ b/ksql-rest-app/src/main/java/io/confluent/ksql/rest/server/resources/KsqlResource.java
@@ -211,9 +211,15 @@ public class KsqlResource {
         && ksqlEngine.hasReachedMaxNumberOfPersistentQueries(ksqlConfig)) {
       throw new KsqlException(
           String.format(
-              "Cannot execute statement '%s' due to limit on number of active,"
-                  + " persistent queries.",
-              statementText
+              "Not executing statement '%s' since the limit on number "
+                  + "of active, persistent queries has been reached "
+                  + "(%d persistent queries currently running. Limit is %d). "
+                  + "Use the TERMINATE command to terminate existing queries "
+                  + "(if running in interactive mode), "
+                  + "or reconfigure the limit via the 'ksql-server.properties' file.",
+              statementText,
+              ksqlEngine.numberOfPersistentQueries(),
+              ksqlConfig.getInt(KsqlConfig.KSQL_ACTIVE_PERSISTENT_QUERY_LIMIT_CONFIG)
           )
       );
     }

--- a/ksql-rest-app/src/test/java/io/confluent/ksql/rest/entity/QueryDescriptionTest.java
+++ b/ksql-rest-app/src/test/java/io/confluent/ksql/rest/entity/QueryDescriptionTest.java
@@ -96,7 +96,7 @@ public class QueryDescriptionTest {
     final QueryMetadata queryMetadata = new QueuedQueryMetadata(
         "test statement", queryStreams, outputNode, "execution plan",
         new LinkedBlockingQueue<>(), DataSource.DataSourceType.KSTREAM, "app id",
-        null, topology, streamsProperties);
+        null, topology, streamsProperties, md -> {});
 
     final QueryDescription queryDescription = QueryDescription.forQueryMetadata(queryMetadata);
 
@@ -131,7 +131,7 @@ public class QueryDescriptionTest {
     final PersistentQueryMetadata queryMetadata = new PersistentQueryMetadata(
         "test statement", queryStreams, outputNode, fakeSink,"execution plan",
         new QueryId("query_id"), DataSource.DataSourceType.KSTREAM, "app id", null,
-        sinkTopic, topology, streamsProperties);
+        sinkTopic, topology, streamsProperties, md -> {});
     final QueryDescription queryDescription = QueryDescription.forQueryMetadata(queryMetadata);
     assertThat(queryDescription.getId().getId(), equalTo("query_id"));
     assertThat(queryDescription.getSinks(), equalTo(Collections.singleton("fake_sink")));

--- a/ksql-rest-app/src/test/java/io/confluent/ksql/rest/server/StandaloneExecutorTest.java
+++ b/ksql-rest-app/src/test/java/io/confluent/ksql/rest/server/StandaloneExecutorTest.java
@@ -289,4 +289,21 @@ public class StandaloneExecutorTest {
     EasyMock.verify(query, persistentQueryMetadata, engine);
   }
 
+  @Test
+  public void shouldFailIfExceedActivePersistentQueriesLimit() {
+    expectedException.expect(KsqlException.class);
+    expectedException.expectMessage("limit on number of active, persistent queries.");
+
+    EasyMock.expect(engine.parseStatements(anyString())).andReturn(ImmutableList.of(
+        new PreparedStatement("CSAS3", new CreateStreamAsSelect(qualifiedName, query, false, Collections.emptyMap(), Optional.empty()))
+    ));
+    EasyMock.expect(persistentQueryMetadata.getDataSourceType()).andReturn(DataSourceType.KSTREAM);
+    EasyMock.expect(engine.getQueryExecutionPlan(query, ksqlConfig))
+        .andReturn(persistentQueryMetadata).once();
+    EasyMock.expect(engine.hasReachedMaxNumberOfPersistentQueries(ksqlConfig)).andReturn(true);
+
+    EasyMock.replay(query, persistentQueryMetadata, engine);
+    standaloneExecutor.start();
+    EasyMock.verify(query, persistentQueryMetadata, engine);
+  }
 }

--- a/ksql-rest-app/src/test/java/io/confluent/ksql/rest/server/StandaloneExecutorTest.java
+++ b/ksql-rest-app/src/test/java/io/confluent/ksql/rest/server/StandaloneExecutorTest.java
@@ -292,7 +292,8 @@ public class StandaloneExecutorTest {
   @Test
   public void shouldFailIfExceedActivePersistentQueriesLimit() {
     expectedException.expect(KsqlException.class);
-    expectedException.expectMessage("limit on number of active, persistent queries.");
+    expectedException.expectMessage(
+        "the limit on number of active, persistent queries has been reached");
 
     EasyMock.expect(engine.parseStatements(anyString())).andReturn(ImmutableList.of(
         new PreparedStatement("CSAS3", new CreateStreamAsSelect(qualifiedName, query, false, Collections.emptyMap(), Optional.empty()))

--- a/ksql-rest-app/src/test/java/io/confluent/ksql/rest/server/StandaloneExecutorTest.java
+++ b/ksql-rest-app/src/test/java/io/confluent/ksql/rest/server/StandaloneExecutorTest.java
@@ -288,23 +288,4 @@ public class StandaloneExecutorTest {
     standaloneExecutor.start();
     EasyMock.verify(query, persistentQueryMetadata, engine);
   }
-
-  @Test
-  public void shouldFailIfExceedActivePersistentQueriesLimit() {
-    expectedException.expect(KsqlException.class);
-    expectedException.expectMessage(
-        "the limit on number of active, persistent queries has been reached");
-
-    EasyMock.expect(engine.parseStatements(anyString())).andReturn(ImmutableList.of(
-        new PreparedStatement("CSAS3", new CreateStreamAsSelect(qualifiedName, query, false, Collections.emptyMap(), Optional.empty()))
-    ));
-    EasyMock.expect(persistentQueryMetadata.getDataSourceType()).andReturn(DataSourceType.KSTREAM);
-    EasyMock.expect(engine.getQueryExecutionPlan(query, ksqlConfig))
-        .andReturn(persistentQueryMetadata).once();
-    EasyMock.expect(engine.hasReachedMaxNumberOfPersistentQueries(ksqlConfig)).andReturn(true);
-
-    EasyMock.replay(query, persistentQueryMetadata, engine);
-    standaloneExecutor.start();
-    EasyMock.verify(query, persistentQueryMetadata, engine);
-  }
 }

--- a/ksql-rest-app/src/test/java/io/confluent/ksql/rest/server/StandaloneExecutorTest.java
+++ b/ksql-rest-app/src/test/java/io/confluent/ksql/rest/server/StandaloneExecutorTest.java
@@ -288,4 +288,5 @@ public class StandaloneExecutorTest {
     standaloneExecutor.start();
     EasyMock.verify(query, persistentQueryMetadata, engine);
   }
+
 }

--- a/ksql-rest-app/src/test/java/io/confluent/ksql/rest/server/computation/StatementExecutorTest.java
+++ b/ksql-rest-app/src/test/java/io/confluent/ksql/rest/server/computation/StatementExecutorTest.java
@@ -451,7 +451,8 @@ public class StatementExecutorTest extends EasyMockSupport {
     assertThat(
         commandStatus.get().getMessage(),
         containsString(
-            "Reached maximum allowed number of active, persistent queries."));
+            "the statement causes the limit on number of active, "
+            + "persistent queries to be exceeded"));
   }
 
   private void createStreamsAndTables() {

--- a/ksql-rest-app/src/test/java/io/confluent/ksql/rest/server/resources/KsqlResourceTest.java
+++ b/ksql-rest-app/src/test/java/io/confluent/ksql/rest/server/resources/KsqlResourceTest.java
@@ -545,7 +545,7 @@ public class KsqlResourceTest {
     assertThat(result.getErrorCode(), is(Errors.ERROR_CODE_BAD_STATEMENT));
     assertThat(
         result.getMessage(),
-        containsString("due to limit on number of active, persistent queries.")
+        containsString("the limit on number of active, persistent queries has been reached")
     );
     EasyMock.verify(ksqlEngine);
   }

--- a/ksql-rest-app/src/test/java/io/confluent/ksql/rest/server/resources/StreamedQueryResourceTest.java
+++ b/ksql-rest-app/src/test/java/io/confluent/ksql/rest/server/resources/StreamedQueryResourceTest.java
@@ -192,7 +192,7 @@ public class StreamedQueryResourceTest {
     final QueuedQueryMetadata queuedQueryMetadata =
         new QueuedQueryMetadata(queryString, mockKafkaStreams, mockOutputNode, "",
             rowQueue, DataSource.DataSourceType.KSTREAM, "",
-            mockKafkaTopicClient, null, Collections.emptyMap());
+            mockKafkaTopicClient, null, Collections.emptyMap(), md -> {});
     reset(mockOutputNode);
     expect(mockOutputNode.getSchema())
         .andReturn(SchemaBuilder.struct().field("f1", SchemaBuilder.OPTIONAL_INT32_SCHEMA));


### PR DESCRIPTION
### Description 
_What behavior do you want to change, why, how does your patch achieve the changes?_

Add config for specifying the maximum number of persistent queries that should run at any time. Defaults to no limit.

This is accomplished in three ways:
1) Queries are no longer added to `persistentQueries`, `livePersistentQueries`, and `allLiveQueries` in KsqlEngine until the queries are started. The persistent query limit is checked when starting queries, and an error is thrown if starting the query would cause the limit to be exceeded.
2) KsqlResource checks the limit before writing commands to the command topic, to avoid writing commands that would cause the limit to be exceeded, with the exception of RUN SCRIPT commands. RUN SCRIPT commands will still be written to the command topic, but will throw an exception before executing if they would cause the limit to be exceeded. Interactive mode continues to accept subsequent statements as usual.
3) In headless mode, StandaloneExecutor checks the limit and fails atomically (i.e., executes no statements) if executing the statements would cause the limit to be exceeded.

Fixes https://github.com/confluentinc/ksql/issues/725.

### Testing done 
_Describe the testing strategy. Unit and integration tests are expected for any behavior changes._

Added tests.

### Reviewer checklist
- [ ] Ensure docs are updated if necessary. (eg. if a user visible feature is being added or changed).
- [ ] Ensure relevant issues are linked (description should include text like "Fixes #<issue number>")

