### PR TITLE
Clean up aggregate function and remove duplicate columns from aggregate select mapper

### DIFF
--- a/ksql-common/src/main/java/io/confluent/ksql/function/AggregateFunctionArguments.java
+++ b/ksql-common/src/main/java/io/confluent/ksql/function/AggregateFunctionArguments.java
@@ -16,26 +16,15 @@
 
 package io.confluent.ksql.function;
 
-import com.google.common.base.Preconditions;
 import com.google.common.collect.ImmutableList;
 import io.confluent.ksql.util.KsqlException;
 import java.util.List;
-import java.util.Map;
 import java.util.Objects;
 
 public class AggregateFunctionArguments {
 
   private final int udafIndex;
   private final List<String> args;
-
-  public AggregateFunctionArguments(final Map<String, Integer> expressionNames,
-                                    final List<String> args) {
-    Preconditions.checkArgument(expressionNames != null && !expressionNames.isEmpty(),
-        "expressionNames can't be null or empty");
-    Preconditions.checkArgument(args != null && !args.isEmpty(), "args can't be null or empty");
-    this.udafIndex = expressionNames.get(args.get(0));
-    this.args = ImmutableList.copyOf(args);
-  }
 
   public AggregateFunctionArguments(final int index,  final List<String> args) {
     this.udafIndex = index;

--- a/ksql-common/src/main/java/io/confluent/ksql/function/AggregateFunctionArguments.java
+++ b/ksql-common/src/main/java/io/confluent/ksql/function/AggregateFunctionArguments.java
@@ -21,6 +21,7 @@ import com.google.common.collect.ImmutableList;
 import io.confluent.ksql.util.KsqlException;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 
 public class AggregateFunctionArguments {
 
@@ -34,6 +35,15 @@ public class AggregateFunctionArguments {
     Preconditions.checkArgument(args != null && !args.isEmpty(), "args can't be null or empty");
     this.udafIndex = expressionNames.get(args.get(0));
     this.args = ImmutableList.copyOf(args);
+  }
+
+  public AggregateFunctionArguments(final int index,  final List<String> args) {
+    this.udafIndex = index;
+    this.args = ImmutableList.copyOf(Objects.requireNonNull(args, "args"));
+
+    if (index < 0) {
+      throw new IllegalArgumentException("index is negative: " + index);
+    }
   }
 
   public int udafIndex() {

--- a/ksql-engine/src/main/java/io/confluent/ksql/planner/plan/AggregateNode.java
+++ b/ksql-engine/src/main/java/io/confluent/ksql/planner/plan/AggregateNode.java
@@ -46,8 +46,10 @@ import io.confluent.ksql.util.SelectExpression;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 import java.util.function.Supplier;
 import java.util.stream.Collectors;
 import org.apache.kafka.common.serialization.Serde;
@@ -309,7 +311,7 @@ public class AggregateNode extends PlanNode {
       throw new KsqlException(
           String.format(
               "Failed to create aggregate val to function map. expressionNames:%s",
-              internalSchema.getInternalNameToIndexMap()
+              internalSchema.internalNameToIndexMap.keySet()
           ),
           e
       );
@@ -328,9 +330,13 @@ public class AggregateNode extends PlanNode {
     final KsqlAggregateFunction aggregateFunctionInfo = functionRegistry
         .getAggregate(functionCall.getName().toString(), expressionType);
 
-    return aggregateFunctionInfo.getInstance(
-        new AggregateFunctionArguments(internalSchema.getInternalNameToIndexMap(),
-            functionArgs.stream().map(Expression::toString).collect(Collectors.toList())));
+    final List<String> args = functionArgs.stream()
+        .map(Expression::toString)
+        .collect(Collectors.toList());
+
+    final int udafIndex = internalSchema.internalNameToIndexMap.get(args.get(0));
+
+    return aggregateFunctionInfo.getInstance(new AggregateFunctionArguments(udafIndex, args));
   }
 
   private Schema buildAggregateSchema(
@@ -368,19 +374,21 @@ public class AggregateNode extends PlanNode {
     InternalSchema(
         final List<Expression> requiredColumnList,
         final List<Expression> aggregateFunctionArguments) {
-      collectAggregateArgExpressions(requiredColumnList);
-      collectAggregateArgExpressions(aggregateFunctionArguments);
+      final Set<String> seen = new HashSet<>();
+      collectAggregateArgExpressions(requiredColumnList, seen);
+      collectAggregateArgExpressions(aggregateFunctionArguments, seen);
     }
 
-
     private void collectAggregateArgExpressions(
-        final List<Expression> expressions
+        final List<Expression> expressions,
+        final Set<String> seen
     ) {
       expressions.stream()
-          .filter(e -> !internalNameToIndexMap.containsKey(e.toString()))
+          .filter(e -> !seen.contains(e.toString()))
           .forEach(expression -> {
             final String internalColumnName = INTERNAL_COLUMN_NAME_PREFIX
                 + aggArgExpansionList.size();
+            seen.add(expression.toString());
             internalNameToIndexMap.put(internalColumnName, aggArgExpansionList.size());
             aggArgExpansionList.add(SelectExpression.of(internalColumnName, expression));
             expressionToInternalColumnNameMap
@@ -454,13 +462,9 @@ public class AggregateNode extends PlanNode {
       return aggArgExpansionList;
     }
 
-    Map<String, Integer> getInternalNameToIndexMap() {
-      return internalNameToIndexMap;
-    }
 
     private Map<String, String> getExpressionToInternalColumnNameMap() {
       return expressionToInternalColumnNameMap;
     }
   }
-
 }

--- a/ksql-engine/src/test/java/io/confluent/ksql/function/KudafUndoAggregatorTest.java
+++ b/ksql-engine/src/test/java/io/confluent/ksql/function/KudafUndoAggregatorTest.java
@@ -44,13 +44,12 @@ public class KudafUndoAggregatorTest {
     aggValToValColumnMap.put(0, 1);
     aggValToValColumnMap.put(1, 0);
     final Map<Integer, TableAggregationFunction> aggValToAggFunctionMap = new HashMap<>();
-    final Map<String, Integer> expressionNames = Collections.singletonMap("baz", 2);
     final KsqlAggregateFunction functionInfo = functionRegistry.getAggregate(
         "SUM", Schema.OPTIONAL_INT32_SCHEMA);
     assertThat(functionInfo, instanceOf(TableAggregationFunction.class));
     aggValToAggFunctionMap.put(
         2, (TableAggregationFunction)functionInfo.getInstance(
-            new AggregateFunctionArguments(expressionNames, Collections.singletonList("baz"))
+            new AggregateFunctionArguments(2, Collections.singletonList("baz"))
         ));
 
     final GenericRow row = new GenericRow(Arrays.asList("snow", "jon", 3));

--- a/ksql-engine/src/test/java/io/confluent/ksql/function/UdfCompilerTest.java
+++ b/ksql-engine/src/test/java/io/confluent/ksql/function/UdfCompilerTest.java
@@ -128,8 +128,7 @@ public class UdfCompilerTest {
         "desc"
     );
     assertThat(function.getInstance(
-        new AggregateFunctionArguments(Collections.singletonMap("udfIndex", 0),
-            Collections.singletonList("udfIndex"))),
+        new AggregateFunctionArguments(0, Collections.singletonList("udfIndex"))),
         not(nullValue()));
   }
 
@@ -154,8 +153,7 @@ public class UdfCompilerTest {
         "desc"
     );
     final KsqlAggregateFunction instance = function.getInstance(
-        new AggregateFunctionArguments(Collections.singletonMap("udfIndex", 0),
-            Arrays.asList("udfIndex", "some string")));
+        new AggregateFunctionArguments(0, Arrays.asList("udfIndex", "some string")));
     assertThat(instance,
         not(nullValue()));
     assertThat(instance, not(instanceOf(TableAggregationFunction.class)));
@@ -174,8 +172,7 @@ public class UdfCompilerTest {
     );
 
     final KsqlAggregateFunction<Long, Long> executable = function.getInstance(
-        new AggregateFunctionArguments(Collections.singletonMap("udfIndex", 0),
-            Collections.singletonList("udfIndex")));
+        new AggregateFunctionArguments(0, Collections.singletonList("udfIndex")));
 
     executable.aggregate(1L, 1L);
     executable.aggregate(1L, 1L);

--- a/ksql-engine/src/test/java/io/confluent/ksql/function/UdfLoaderTest.java
+++ b/ksql-engine/src/test/java/io/confluent/ksql/function/UdfLoaderTest.java
@@ -93,8 +93,7 @@ public class UdfLoaderTest {
     final KsqlAggregateFunction aggregate
         = metaStore.getAggregate("test_udaf", Schema.OPTIONAL_INT64_SCHEMA);
     final KsqlAggregateFunction<Long, Long> instance = aggregate.getInstance(
-        new AggregateFunctionArguments(Collections.singletonMap("udfIndex", 0),
-            Collections.singletonList("udfIndex")));
+        new AggregateFunctionArguments(0, Collections.singletonList("udfIndex")));
     assertThat(instance.getInitialValueSupplier().get(), equalTo(0L));
     assertThat(instance.aggregate(1L, 1L), equalTo(2L));
     assertThat(instance.getMerger().apply("k", 2L, 3L), equalTo(5L));

--- a/ksql-engine/src/test/java/io/confluent/ksql/function/udaf/topkdistinct/TopKDistinctTestUtils.java
+++ b/ksql-engine/src/test/java/io/confluent/ksql/function/udaf/topkdistinct/TopKDistinctTestUtils.java
@@ -13,7 +13,6 @@ public class TopKDistinctTestUtils {
         .getProperAggregateFunction(
             Collections.singletonList(schema))
         .getInstance(
-            new AggregateFunctionArguments(Collections.singletonMap("foo", 0),
-                Arrays.asList("foo", Integer.toString(topk))));
+            new AggregateFunctionArguments(0, Arrays.asList("foo", Integer.toString(topk))));
   }
 }

--- a/ksql-engine/src/test/java/io/confluent/ksql/physical/PhysicalPlanBuilderTest.java
+++ b/ksql-engine/src/test/java/io/confluent/ksql/physical/PhysicalPlanBuilderTest.java
@@ -169,7 +169,7 @@ public class PhysicalPlanBuilderTest {
         "\t\t > [ AGGREGATE ] Schema: [KSQL_INTERNAL_COL_0 : BIGINT, KSQL_INTERNAL_COL_1 : DOUBLE, KSQL_AGG_VARIABLE_0 : DOUBLE, KSQL_AGG_VARIABLE_1 : BIGINT].",
         lines[1]);
     Assert.assertEquals(
-        "\t\t\t\t > [ PROJECT ] Schema: [KSQL_INTERNAL_COL_0 : BIGINT, KSQL_INTERNAL_COL_1 : DOUBLE, KSQL_INTERNAL_COL_2 : DOUBLE, KSQL_INTERNAL_COL_3 : DOUBLE].",
+        "\t\t\t\t > [ PROJECT ] Schema: [KSQL_INTERNAL_COL_0 : BIGINT, KSQL_INTERNAL_COL_1 : DOUBLE].",
         lines[2]);
     Assert.assertEquals(
         "\t\t\t\t\t\t > [ FILTER ] Schema: [TEST1.ROWTIME : BIGINT, TEST1.ROWKEY : BIGINT, TEST1.COL0 : BIGINT, TEST1.COL1 : VARCHAR, TEST1.COL2 : VARCHAR, TEST1.COL3 : DOUBLE, TEST1.COL4 : ARRAY<DOUBLE>, TEST1.COL5 : MAP<VARCHAR,DOUBLE>].",


### PR DESCRIPTION
### Description 
While working on the group by stuff I noticed the weird pattern in `AggregateFunctionArguments` where it is passed a map in its constructor, only get a single value from it using another passed in arg:

```
public AggregateFunctionArguments(
    final Map<String, Integer> expressionNames,
    final List<String> args) {
    this.udafIndex = expressionNames.get(args.get(0));  <-- only use of expressionNames, which can be moved into the calling code. 
    this.args = ImmutableList.copyOf(args);
  }
```

So, changed this to just take the index!

Also noticed that the `AggregateNode` wasn't deduplicating non-aggregate source fields. This line of code:

```
 .filter(e -> !internalNameToIndexMap.containsKey(e.toString()))
```

Was trying to de-dup by matching the string form of an expression to the internal column name - which is never going to match!  No point spending the time processing these duplicate fields on each and every row we process.

Fixing this required changing one `PhysicalPlanBuilderTest` to remove the duplicate columns from the query plan.

### Testing done 
The usual.

### Reviewer checklist
- [ ] Ensure docs are updated if necessary. (eg. if a user visible feature is being added or changed).
- [ ] Ensure relevant issues are linked (description should include text like "Fixes #<issue number>")

