### PR TITLE
Sending the local properies as string so the server.

### DIFF
--- a/ksql-rest-app/src/main/java/io/confluent/ksql/rest/client/KsqlRestClient.java
+++ b/ksql-rest-app/src/main/java/io/confluent/ksql/rest/client/KsqlRestClient.java
@@ -331,7 +331,7 @@ public class KsqlRestClient implements Closeable {
   }
 
   public Object setProperty(final String property, final Object value) {
-    return localProperties.set(property, value);
+    return localProperties.set(property, value, false);
   }
 
   public Object unsetProperty(final String property) {

--- a/ksql-rest-app/src/main/java/io/confluent/ksql/rest/client/properties/LocalProperties.java
+++ b/ksql-rest-app/src/main/java/io/confluent/ksql/rest/client/properties/LocalProperties.java
@@ -52,6 +52,7 @@ public class LocalProperties {
    *
    * @param property the name of the property
    * @param value the value for the property
+   * @param useParsed Indicates if the value should be set to the parsed value or the original value
    * @return the previous value for the property, or {@code null}.
    */
   public Object set(final String property, final Object value, final boolean useParsed) {

--- a/ksql-rest-app/src/main/java/io/confluent/ksql/rest/client/properties/LocalProperties.java
+++ b/ksql-rest-app/src/main/java/io/confluent/ksql/rest/client/properties/LocalProperties.java
@@ -44,9 +44,20 @@ public class LocalProperties {
    * @return the previous value for the property, or {@code null}.
    */
   public Object set(final String property, final Object value) {
+    return set(property, value, true);
+  }
+
+  /**
+   * Set property.
+   *
+   * @param property the name of the property
+   * @param value the value for the property
+   * @return the previous value for the property, or {@code null}.
+   */
+  public Object set(final String property, final Object value, final boolean useParsed) {
     Objects.requireNonNull(value, "value");
     final Object parsed = parser.parse(property, value);
-    return props.put(property, parsed);
+    return props.put(property, useParsed ? parsed : value);
   }
 
   /**

--- a/ksql-rest-app/src/test/java/io/confluent/ksql/rest/client/properties/LocalPropertiesTest.java
+++ b/ksql-rest-app/src/test/java/io/confluent/ksql/rest/client/properties/LocalPropertiesTest.java
@@ -94,6 +94,17 @@ public class LocalPropertiesTest {
   }
 
   @Test
+  public void shouldOverrideInitialValueWithNewUnparsedValue() {
+    // When:
+    final Object oldValue = propsWithMockParser.set("prop-1", "new-val", false);
+
+    // Then:
+    assertThat(oldValue, is("initial-val-1"));
+    assertThat(propsWithMockParser.toMap().get("prop-1"), is("new-val"));
+    assertThat(propsWithMockParser.toMap().get("prop-2"), is("initial-val-2"));
+  }
+
+  @Test
   public void shouldUnsetOverriddenValue() {
     // Given:
     propsWithMockParser.set("prop-1", "new-val");
@@ -120,6 +131,17 @@ public class LocalPropertiesTest {
     // Then:
     assertThat(oldValue, is(nullValue()));
     assertThat(propsWithMockParser.toMap().get("new-prop"), is("parsed-val"));
+    assertThat(propsWithMockParser.toMap().get("prop-2"), is("initial-val-2"));
+  }
+
+  @Test
+  public void shouldSetNewUnparsedValue() {
+    // When:
+    final Object oldValue = propsWithMockParser.set("new-prop", "new-val", false);
+
+    // Then:
+    assertThat(oldValue, is(nullValue()));
+    assertThat(propsWithMockParser.toMap().get("new-prop"), is("new-val"));
     assertThat(propsWithMockParser.toMap().get("prop-2"), is("initial-val-2"));
   }
 


### PR DESCRIPTION
### Description 
Fixes #2099 
In 5.1 we added more capability to check the correctness of the properties in KSQL CLI. But we changed the way we send the properties in KSQLRequest and instead of sending all properties in String format for value we enforced the correct format depending on the property name. This results in a problem with types like `short` when we send the request to the rest endpoint in JSON format. For instance, the server will read the number as `integer` instead of `short` and we will receive `UnsupportedOperationException`.
This PR goes back to send the property values in string format. We still perform checks for the new properties user passes through `set` command. 

In the long run we need to update the server side properties management to perform the same checks for the properties that are passed via the properties files and also enforce the types when reading from the REST endpoint and read from the command line.

### Testing done 
_Describe the testing strategy. Unit and integration tests are expected for any behavior changes._

### Reviewer checklist
- [ ] Ensure docs are updated if necessary. (eg. if a user visible feature is being added or changed).
- [ ] Ensure relevant issues are linked (description should include text like "Fixes #<issue number>")

