### PR TITLE
Fixes to allow upgrade of spotbugs

### DIFF
--- a/ksql-common/src/main/java/io/confluent/ksql/metrics/StreamsErrorCollector.java
+++ b/ksql-common/src/main/java/io/confluent/ksql/metrics/StreamsErrorCollector.java
@@ -61,7 +61,7 @@ public final class StreamsErrorCollector implements MetricCollector {
         .increment(null, true);
   }
 
-  private TopicSensors buildSensors(final String topic) {
+  private TopicSensors<Object> buildSensors(final String topic) {
     final List<TopicSensors.SensorMetric<Object>> sensors = new ArrayList<>();
     synchronized (this.metrics) {
       sensors.add(

--- a/ksql-engine/src/main/java/io/confluent/ksql/function/UdfCompiler.java
+++ b/ksql-engine/src/main/java/io/confluent/ksql/function/UdfCompiler.java
@@ -17,6 +17,7 @@
 package io.confluent.ksql.function;
 
 import avro.shaded.com.google.common.collect.ImmutableMap;
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import io.confluent.ksql.function.udaf.TableUdaf;
 import io.confluent.ksql.function.udaf.Udaf;
 import io.confluent.ksql.function.udaf.UdfArgSupplier;
@@ -129,6 +130,8 @@ public class UdfCompiler {
   private final Optional<Metrics> metrics;
 
   @SuppressWarnings("OptionalUsedAsFieldOrParameterType")
+  @SuppressFBWarnings(value = "RCN_REDUNDANT_NULLCHECK_WOULD_HAVE_BEEN_A_NPE",
+      justification = "https://github.com/spotbugs/spotbugs/issues/600")
   public UdfCompiler(final Optional<Metrics> metrics) {
     this.metrics = Objects.requireNonNull(metrics, "metrics can't be null");
     try (InputStream inputStream = getClass().getClassLoader()

--- a/ksql-engine/src/main/java/io/confluent/ksql/function/udf/json/ArrayContainsKudf.java
+++ b/ksql-engine/src/main/java/io/confluent/ksql/function/udf/json/ArrayContainsKudf.java
@@ -29,6 +29,8 @@ import static com.fasterxml.jackson.core.JsonToken.VALUE_TRUE;
 import com.fasterxml.jackson.core.JsonFactory;
 import com.fasterxml.jackson.core.JsonParser;
 import com.fasterxml.jackson.core.JsonToken;
+
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import io.confluent.ksql.function.KsqlFunctionException;
 import io.confluent.ksql.function.udf.Kudf;
 import io.confluent.ksql.util.ArrayUtil;
@@ -80,6 +82,8 @@ public class ArrayContainsKudf implements Kudf {
     throw new KsqlFunctionException("Invalid type parameters for " + Arrays.toString(args));
   }
 
+  @SuppressFBWarnings(value = "RCN_REDUNDANT_NULLCHECK_WOULD_HAVE_BEEN_A_NPE",
+      justification = "https://github.com/spotbugs/spotbugs/issues/600")
   private boolean jsonStringArrayContains(final Object searchValue, final String jsonArray) {
     final JsonToken valueType = getType(searchValue);
     try (JsonParser parser = JSON_FACTORY.createParser(jsonArray)) {

--- a/ksql-rest-app/src/main/java/io/confluent/ksql/rest/client/KsqlRestClient.java
+++ b/ksql-rest-app/src/main/java/io/confluent/ksql/rest/client/KsqlRestClient.java
@@ -19,6 +19,8 @@ package io.confluent.ksql.rest.client;
 import com.fasterxml.jackson.databind.DeserializationFeature;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.datatype.jdk8.Jdk8Module;
+
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import io.confluent.ksql.rest.client.exception.KsqlRestClientException;
 import io.confluent.ksql.rest.client.properties.LocalProperties;
 import io.confluent.ksql.rest.entity.CommandStatus;
@@ -151,6 +153,8 @@ public class KsqlRestClient implements Closeable {
     client.close();
   }
 
+  @SuppressFBWarnings(value = "RCN_REDUNDANT_NULLCHECK_WOULD_HAVE_BEEN_A_NPE",
+      justification = "https://github.com/spotbugs/spotbugs/issues/600")
   private <T> RestResponse<T> getRequest(final String path, final Class<T> type) {
 
     try (Response response = client.target(serverAddress)

--- a/ksql-rest-app/src/main/java/io/confluent/ksql/rest/server/KsqlRestApplication.java
+++ b/ksql-rest-app/src/main/java/io/confluent/ksql/rest/server/KsqlRestApplication.java
@@ -21,6 +21,8 @@ import com.google.common.collect.ImmutableMap;
 import com.google.common.util.concurrent.ListeningScheduledExecutorService;
 import com.google.common.util.concurrent.MoreExecutors;
 import com.google.common.util.concurrent.ThreadFactoryBuilder;
+
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import io.confluent.kafka.serializers.KafkaJsonDeserializer;
 import io.confluent.kafka.serializers.KafkaJsonDeserializerConfig;
 import io.confluent.kafka.serializers.KafkaJsonSerializer;
@@ -390,6 +392,8 @@ public final class KsqlRestApplication extends Application<KsqlRestConfig> imple
     );
   }
 
+  @SuppressFBWarnings(value = "RCN_REDUNDANT_NULLCHECK_WOULD_HAVE_BEEN_A_NPE",
+      justification = "https://github.com/spotbugs/spotbugs/issues/600")
   private static String getKafkaClusterId(final KsqlConfig ksqlConfig) {
 
     try (AdminClient client = AdminClient.create(ksqlConfig.getKsqlAdminClientConfigProps())) {

--- a/ksql-test-util/pom.xml
+++ b/ksql-test-util/pom.xml
@@ -89,5 +89,11 @@
       <artifactId>guava-testlib</artifactId>
       <scope>compile</scope>
     </dependency>
+
+    <dependency>
+      <groupId>com.github.spotbugs</groupId>
+      <artifactId>spotbugs-annotations</artifactId>
+    </dependency>
+
   </dependencies>
 </project>

--- a/ksql-test-util/src/main/java/io/confluent/ksql/test/util/KafkaEmbedded.java
+++ b/ksql-test-util/src/main/java/io/confluent/ksql/test/util/KafkaEmbedded.java
@@ -18,6 +18,7 @@ package io.confluent.ksql.test.util;
 
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import java.io.File;
 import java.io.IOException;
 import java.util.Map;
@@ -154,6 +155,8 @@ class KafkaEmbedded {
    * @param replication The replication factor for (partitions of) this topic.
    * @param topicConfig Additional topic-level configuration settings.
    */
+  @SuppressFBWarnings(value = "RCN_REDUNDANT_NULLCHECK_WOULD_HAVE_BEEN_A_NPE",
+      justification = "https://github.com/spotbugs/spotbugs/issues/600")
   void createTopic(final String topic,
       final int partitions,
       final int replication,


### PR DESCRIPTION
### Description 
This fixes one minor bug affecting JDK 11 builds and adds a few suppressions (due to https://github.com/spotbugs/spotbugs/issues/600, which it doesn't look like there's active progress being made on it). The suppressions are only an issue in KSQL since it's failing more aggressively. An upgrade to spotbugs is required to move forward with general JDK 11 support.

### Testing done 
Ran unit tests

### Reviewer checklist
- [ ] Ensure docs are updated if necessary. (eg. if a user visible feature is being added or changed).
- [ ] Ensure relevant issues are linked (description should include text like "Fixes #<issue number>")

