### PR TITLE
disable spotbugs false-positive with Java 11

### DIFF
--- a/findbugs/findbugs-exclude.xml
+++ b/findbugs/findbugs-exclude.xml
@@ -32,6 +32,12 @@ For a detailed description of findbugs bug categories, see http://findbugs.sourc
         <Class name="~io.confluent.ksql.parser.SqlBaseParser.*"/>
     </Match>
 
+
+    <!-- false positive in Java 11, see https://github.com/spotbugs/spotbugs/issues/756 -->
+    <Match>
+        <Bug pattern="RCN_REDUNDANT_NULLCHECK_WOULD_HAVE_BEEN_A_NPE"/>
+    </Match>
+
     <!-- other issues we should fix in the future -->
     <Match>
         <Class name="io.confluent.ksql.util.KsqlConfig"/>


### PR DESCRIPTION
This is a workaround for the following issue using spotbugs and Java 11
https://github.com/spotbugs/spotbugs/issues/756
