### PR TITLE
Add more diagnostics for shouldInterruptScannerOnClose test

### DIFF
--- a/ksql-rest-app/src/main/java/io/confluent/ksql/rest/entity/StreamedRow.java
+++ b/ksql-rest-app/src/main/java/io/confluent/ksql/rest/entity/StreamedRow.java
@@ -102,4 +102,15 @@ public class StreamedRow {
       throw new IllegalArgumentException("Exactly one parameter should be non-null. got: " + fs);
     }
   }
+
+  @Override
+  public String toString() {
+    if (row != null) {
+      return row.toString();
+    }
+    if (finalMessage != null) {
+      return finalMessage;
+    }
+    return errorMessage.toString();
+  }
 }

--- a/ksql-rest-app/src/test/java/io/confluent/ksql/rest/entity/StreamedRowTest.java
+++ b/ksql-rest-app/src/test/java/io/confluent/ksql/rest/entity/StreamedRowTest.java
@@ -1,0 +1,39 @@
+package io.confluent.ksql.rest.entity;
+
+import static org.hamcrest.Matchers.equalTo;
+import static org.junit.Assert.assertThat;
+
+import io.confluent.ksql.GenericRow;
+import io.confluent.ksql.util.KsqlException;
+import org.junit.Test;
+
+public class StreamedRowTest {
+  @Test
+  public void shouldReturnRowStringForRow() {
+    // When:
+    final GenericRow genericRow = new GenericRow(1, 2, 3);
+    final StreamedRow row = StreamedRow.row(genericRow);
+
+    // Then:
+    assertThat(row.toString(), equalTo(genericRow.toString()));
+  }
+
+  @Test
+  public void shouldReturnErrorStringForErrorRow() {
+    // When:
+    final KsqlException exception = new KsqlException("badbadbad");
+    final StreamedRow row = StreamedRow.error(exception);
+
+    // Then:
+    assertThat(row.toString(), equalTo(row.getErrorMessage().toString()));
+  }
+
+  @Test
+  public void shouldReturnFinalMessageStringForFinalRow() {
+    // When:
+    final StreamedRow row = StreamedRow.finalMessage("foo");
+
+    // Then:
+    assertThat(row.toString(), equalTo(row.getFinalMessage()));
+  }
+}


### PR DESCRIPTION
This patch adds some more diagnostics to the shouldInterruptScannerOnClose test. Whenever the scanner
thread exits incorrectly, it sets a string which is asserted on later in the test.

### Description 
_What behavior do you want to change, why, how does your patch achieve the changes?_

### Testing done 
_Describe the testing strategy. Unit and integration tests are expected for any behavior changes._

### Reviewer checklist
- [ ] Ensure docs are updated if necessary. (eg. if a user visible feature is being added or changed).
- [ ] Ensure relevant issues are linked (description should include text like "Fixes #<issue number>")

