### PR TITLE
Fix handling of CLI CTRL+C handling and hence fix flaky test.

### DIFF
--- a/ksql-rest-app/src/main/java/io/confluent/ksql/rest/client/KsqlRestClient.java
+++ b/ksql-rest-app/src/main/java/io/confluent/ksql/rest/client/KsqlRestClient.java
@@ -35,6 +35,7 @@ import java.io.Closeable;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.InputStreamReader;
+import java.net.SocketTimeoutException;
 import java.net.URI;
 import java.net.URL;
 import java.nio.charset.StandardCharsets;
@@ -44,17 +45,21 @@ import java.util.Iterator;
 import java.util.Map;
 import java.util.NoSuchElementException;
 import java.util.Objects;
+import java.util.Optional;
 import java.util.Properties;
 import java.util.Scanner;
+import java.util.concurrent.TimeUnit;
 import java.util.function.Function;
 import javax.naming.AuthenticationException;
 import javax.ws.rs.client.Client;
 import javax.ws.rs.client.ClientBuilder;
 import javax.ws.rs.client.Entity;
+import javax.ws.rs.client.WebTarget;
 import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.Response;
 import javax.ws.rs.core.Response.Status;
 import org.apache.commons.compress.utils.IOUtils;
+import org.glassfish.jersey.client.ClientProperties;
 import org.glassfish.jersey.client.authentication.HttpAuthenticationFeature;
 
 // CHECKSTYLE_RULES.OFF: ClassDataAbstractionCoupling
@@ -125,7 +130,8 @@ public class KsqlRestClient implements Closeable {
 
   public RestResponse<KsqlEntityList> makeKsqlRequest(final String ksql) {
     final KsqlRequest jsonRequest = new KsqlRequest(ksql, localProperties.toMap());
-    return postRequest("ksql", jsonRequest, true, r -> r.readEntity(KsqlEntityList.class));
+    return postRequest("ksql", jsonRequest, Optional.empty(), true,
+        r -> r.readEntity(KsqlEntityList.class));
   }
 
   public RestResponse<CommandStatuses> makeStatusRequest() {
@@ -138,12 +144,14 @@ public class KsqlRestClient implements Closeable {
 
   public RestResponse<QueryStream> makeQueryRequest(final String ksql) {
     final KsqlRequest jsonRequest = new KsqlRequest(ksql, localProperties.toMap());
-    return postRequest("query", jsonRequest, false, QueryStream::new);
+    final Optional<Integer> readTimeoutMs = Optional.of(QueryStream.READ_TIMEOUT_MS);
+    return postRequest("query", jsonRequest, readTimeoutMs, false, QueryStream::new);
   }
 
   public RestResponse<InputStream> makePrintTopicRequest(final String ksql) {
     final KsqlRequest jsonRequest = new KsqlRequest(ksql, localProperties.toMap());
-    return postRequest("query", jsonRequest, false, r -> (InputStream)r.getEntity());
+    return postRequest("query", jsonRequest, Optional.empty(), false,
+        r -> (InputStream) r.getEntity());
   }
 
   @Override
@@ -170,14 +178,19 @@ public class KsqlRestClient implements Closeable {
   private <T> RestResponse<T> postRequest(
       final String path,
       final Object jsonEntity,
+      final Optional<Integer> readTimeoutMs,
       final boolean closeResponse,
       final Function<Response, T> mapper) {
 
     Response response = null;
 
     try {
-      response = client.target(serverAddress)
-          .path(path)
+      final WebTarget target = client.target(serverAddress)
+          .path(path);
+
+      readTimeoutMs.ifPresent(timeout -> target.property(ClientProperties.READ_TIMEOUT, timeout));
+
+      response = target
           .request(MediaType.APPLICATION_JSON_TYPE)
           .post(Entity.json(jsonEntity));
 
@@ -222,6 +235,8 @@ public class KsqlRestClient implements Closeable {
 
   public static final class QueryStream implements Closeable, Iterator<StreamedRow> {
 
+    private static final int READ_TIMEOUT_MS = (int)TimeUnit.SECONDS.toMillis(2);
+
     private final Response response;
     private final ObjectMapper objectMapper;
     private final Scanner responseScanner;
@@ -239,30 +254,23 @@ public class KsqlRestClient implements Closeable {
           StandardCharsets.UTF_8
       );
       this.responseScanner = new Scanner((buf) -> {
-        int wait = 1;
-        // poll the input stream's readiness between interruptable sleeps
-        // this ensures we cannot block indefinitely on read()
         while (true) {
-          if (closed) {
-            throw closedIllegalStateException("hasNext()");
-          }
-          if (isr.ready()) {
-            break;
-          }
-          synchronized (this) {
+          try {
+            return isr.read(buf);
+          } catch (final SocketTimeoutException e) {
+            // Read timeout:
             if (closed) {
-              throw closedIllegalStateException("hasNext()");
+              return -1;
             }
-            try {
-              wait = java.lang.Math.min(wait * 2, 200);
-              wait(wait);
-            } catch (final InterruptedException e) {
-              // this is expected
-              // just check the closed flag
+          } catch (final IOException e) {
+            // Can occur if isr closed:
+            if (closed) {
+              return -1;
             }
+
+            throw e;
           }
         }
-        return isr.read(buf);
       });
 
       this.bufferedRow = null;
@@ -270,37 +278,15 @@ public class KsqlRestClient implements Closeable {
 
     @Override
     public boolean hasNext() {
-      if (closed) {
-        throw closedIllegalStateException("hasNext()");
-      }
-
       if (bufferedRow != null) {
         return true;
       }
 
-      while (responseScanner.hasNextLine()) {
-        final String responseLine = responseScanner.nextLine().trim();
-        if (!responseLine.isEmpty()) {
-          try {
-            bufferedRow = objectMapper.readValue(responseLine, StreamedRow.class);
-          } catch (final IOException exception) {
-            // TODO: Should the exception be handled somehow else?
-            // Swallowing it silently seems like a bad idea...
-            throw new RuntimeException(exception);
-          }
-          return true;
-        }
-      }
-
-      return false;
+      return bufferNextRow();
     }
 
     @Override
     public StreamedRow next() {
-      if (closed) {
-        throw closedIllegalStateException("next()");
-      }
-
       if (!hasNext()) {
         throw new NoSuchElementException();
       }
@@ -313,20 +299,40 @@ public class KsqlRestClient implements Closeable {
     @Override
     public void close() {
       if (closed) {
-        throw closedIllegalStateException("close()");
+        return;
       }
 
       synchronized (this) {
         closed = true;
-        this.notifyAll();
       }
       responseScanner.close();
       response.close();
       IOUtils.closeQuietly(isr);
     }
 
-    private IllegalStateException closedIllegalStateException(final String methodName) {
-      return new IllegalStateException("Cannot call " + methodName + " when QueryStream is closed");
+    private boolean bufferNextRow() {
+      try {
+        while (responseScanner.hasNextLine()) {
+          final String responseLine = responseScanner.nextLine().trim();
+          if (!responseLine.isEmpty()) {
+            try {
+              bufferedRow = objectMapper.readValue(responseLine, StreamedRow.class);
+            } catch (final IOException exception) {
+              throw new RuntimeException(exception);
+            }
+            return true;
+          }
+        }
+
+        return false;
+      } catch (final IllegalStateException e) {
+        // Can happen is scanner is closed:
+        if (closed) {
+          return false;
+        }
+
+        throw e;
+      }
     }
   }
 

--- a/ksql-rest-app/src/main/java/io/confluent/ksql/rest/entity/StreamedRow.java
+++ b/ksql-rest-app/src/main/java/io/confluent/ksql/rest/entity/StreamedRow.java
@@ -73,6 +73,10 @@ public class StreamedRow {
     return finalMessage;
   }
 
+  public boolean isTerminal() {
+    return finalMessage != null || errorMessage != null;
+  }
+
   @Override
   public boolean equals(final Object o) {
     if (this == o) {

--- a/ksql-rest-app/src/test/java/io/confluent/ksql/rest/client/KsqlRestClientTest.java
+++ b/ksql-rest-app/src/test/java/io/confluent/ksql/rest/client/KsqlRestClientTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2017 Confluent Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -16,14 +16,22 @@
 
 package io.confluent.ksql.rest.client;
 
+import static org.hamcrest.Matchers.contains;
 import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.Matchers.hasSize;
+import static org.hamcrest.Matchers.instanceOf;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.notNullValue;
 import static org.junit.Assert.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.notNull;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import io.confluent.ksql.GenericRow;
+import io.confluent.ksql.rest.client.KsqlRestClient.QueryStream;
 import io.confluent.ksql.rest.client.exception.KsqlRestClientException;
 import io.confluent.ksql.rest.entity.CommandStatus;
 import io.confluent.ksql.rest.entity.CommandStatuses;
@@ -36,16 +44,16 @@ import io.confluent.ksql.rest.server.KsqlRestConfig;
 import io.confluent.ksql.rest.server.computation.CommandId;
 import io.confluent.ksql.rest.server.mock.MockApplication;
 import io.confluent.ksql.rest.server.mock.MockStreamedQueryResource;
+import io.confluent.ksql.rest.server.mock.MockStreamedQueryResource.TestStreamWriter;
 import io.confluent.ksql.rest.server.resources.Errors;
-import io.confluent.ksql.rest.server.utils.TestUtils;
 import java.net.URI;
+import java.time.Duration;
 import java.util.Collections;
-import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
-import java.util.concurrent.CountDownLatch;
-import java.util.concurrent.TimeUnit;
+import java.util.concurrent.CopyOnWriteArrayList;
+import java.util.concurrent.atomic.AtomicReference;
 import javax.ws.rs.client.Client;
 import javax.ws.rs.client.Invocation;
 import javax.ws.rs.client.WebTarget;
@@ -53,12 +61,14 @@ import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.Response;
 import javax.ws.rs.core.Response.Status;
 import org.apache.kafka.streams.StreamsConfig;
-import org.easymock.EasyMock;
 import org.junit.After;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.junit.MockitoJUnitRunner;
 
+@RunWith(MockitoJUnitRunner.class)
 public class KsqlRestClientTest {
 
   private MockApplication mockApplication;
@@ -66,114 +76,77 @@ public class KsqlRestClientTest {
 
   @Before
   public void init() throws Exception {
-    final int port = TestUtils.randomFreeLocalPort();
-    final Map<String, Object> props = new HashMap<>();
-    final String serverAddress = "http://localhost:" + port;
-    props.put(KsqlRestConfig.LISTENERS_CONFIG, serverAddress);
-    props.put(StreamsConfig.BOOTSTRAP_SERVERS_CONFIG, "localhost:9092");
-    props.put(StreamsConfig.APPLICATION_ID_CONFIG, "ksql_config_test");
+    final Map<String, Object> props = ImmutableMap.<String, Object>builder()
+        .put(KsqlRestConfig.LISTENERS_CONFIG, "http://localhost:0")
+        .put(StreamsConfig.BOOTSTRAP_SERVERS_CONFIG, "localhost:9092")
+        .put(StreamsConfig.APPLICATION_ID_CONFIG, "ksql_config_test")
+        .build();
+
     final KsqlRestConfig ksqlRestConfig = new KsqlRestConfig(props);
     mockApplication = new MockApplication(ksqlRestConfig);
     mockApplication.start();
 
-    ksqlRestClient = new KsqlRestClient(serverAddress);
+    ksqlRestClient = new KsqlRestClient(mockApplication.getServerAddress());
   }
 
   @After
-  public void cleanUp() throws Exception {
+  public void cleanUp() {
     mockApplication.stop();
   }
 
   @Test
   public void testKsqlResource() {
     final RestResponse<KsqlEntityList> results = ksqlRestClient.makeKsqlRequest("Test request");
-    Assert.assertNotNull(results);
-    Assert.assertTrue(results.isSuccessful());
+
+    assertThat(results, is(notNullValue()));
+    assertThat(results.isSuccessful(), is(true));
+
     final KsqlEntityList ksqlEntityList = results.getResponse();
-    Assert.assertTrue(ksqlEntityList.size() == 1);
-    Assert.assertTrue(ksqlEntityList.get(0) instanceof ExecutionPlan);
+    assertThat(ksqlEntityList, hasSize(1));
+    assertThat(ksqlEntityList.get(0), is(instanceOf(ExecutionPlan.class)));
   }
 
 
   @Test
   public void testStreamRowFromServer() throws InterruptedException {
-    final MockStreamedQueryResource sqr = mockApplication.getStreamedQueryResource();
+    // Given:
     final RestResponse<KsqlRestClient.QueryStream> queryResponse = ksqlRestClient.makeQueryRequest
-            ("Select *");
-    Assert.assertNotNull(queryResponse);
-    Assert.assertTrue(queryResponse.isSuccessful());
+        ("Select *");
 
-    // Get the stream writer from the mock server and load it up with a row
-    final List<MockStreamedQueryResource.TestStreamWriter> writers = sqr.getWriters();
-    Assert.assertEquals(1, writers.size());
-    final MockStreamedQueryResource.TestStreamWriter writer = writers.get(0);
-    try {
-      writer.enq("hello");
+    final ReceiverThread receiver = new ReceiverThread(queryResponse);
 
-      // Try and receive the row. Do this from another thread to avoid blocking indefinitely
-      final KsqlRestClient.QueryStream queryStream = queryResponse.getResponse();
-      final Thread t = new Thread(() -> queryStream.hasNext());
-      t.setDaemon(true);
-      t.start();
-      t.join(10000);
-      Assert.assertFalse(t.isAlive());
-      Assert.assertTrue(queryStream.hasNext());
+    final MockStreamedQueryResource.TestStreamWriter writer = getResponseWriter();
 
-      final StreamedRow sr = queryStream.next();
-      Assert.assertNotNull(sr);
-      final GenericRow row = sr.getRow();
-      Assert.assertEquals(1, row.getColumns().
-              size());
-      Assert.assertEquals("hello", row.getColumns().
-              get(0));
-      writer.enq("{\"row\":null,\"errorMessage\":null,\"finalMessage\":\"Limit Reached\"}");
-      final Thread t1 = new Thread(() -> queryStream.hasNext());
-      t1.setDaemon(true);
-      t1.start();
-      t1.join(10000);
-      Assert.assertFalse(t1.isAlive());
-      Assert.assertTrue(queryStream.hasNext());
-      final StreamedRow error_message = queryStream.next();
-      System.out.println();
+    // When:
+    writer.enq("hello");
+    writer.enq("world");
+    writer.enq("{\"row\":null,\"errorMessage\":null,\"finalMessage\":\"Limit Reached\"}");
+    writer.finished();
 
-    } finally {
-      writer.finished();
-    }
+    // Then:
+    assertThat(receiver.getRows(), contains(
+        StreamedRow.row(new GenericRow(ImmutableList.of("hello"))),
+        StreamedRow.row(new GenericRow(ImmutableList.of("world"))),
+        StreamedRow.finalMessage("Limit Reached")));
   }
 
   @Test
-  public void shouldInterruptScannerOnClose() throws InterruptedException {
-    final MockStreamedQueryResource sqr = mockApplication.getStreamedQueryResource();
-    final RestResponse<KsqlRestClient.QueryStream> queryResponse = ksqlRestClient.makeQueryRequest
-            ("Select *");
-    Assert.assertNotNull(queryResponse);
-    Assert.assertTrue(queryResponse.isSuccessful());
+  public void shouldReturnFalseFromHasNextIfClosedAsynchronously() throws Exception {
+    // Given:
+    final RestResponse<KsqlRestClient.QueryStream> queryResponse =
+        ksqlRestClient.makeQueryRequest("Select *");
 
-    final List<MockStreamedQueryResource.TestStreamWriter> writers = sqr.getWriters();
-    Assert.assertEquals(1, writers.size());
-    try {
-      // Try and receive a row. This will block since there is no data to return
-      final KsqlRestClient.QueryStream queryStream = queryResponse.getResponse();
-      final CountDownLatch threw = new CountDownLatch(1);
-      final Thread t = new Thread(() -> {
-        try {
-          queryStream.hasNext();
-        } catch (final IllegalStateException e) {
-          threw.countDown();
-        }
-      });
-      t.setDaemon(true);
-      t.start();
+    final QueryStream stream = queryResponse.getResponse();
 
-      // Let the thread run and then close the stream. Verify that it was interrupted
-      Thread.sleep(100);
-      queryStream.close();
-      Assert.assertTrue(threw.await(10, TimeUnit.SECONDS));
-      t.join(10000);
-      Assert.assertFalse(t.isAlive());
-    } finally {
-      writers.get(0).finished();
-    }
+    final Thread closeThread = givenStreamWillCloseIn(Duration.ofMillis(500), stream);
+
+    // When:
+    final boolean result = stream.hasNext();
+
+    // Then:
+    assertThat(result, is(false));
+    closeThread.join(1_000);
+    assertThat("invlaid test", closeThread.isAlive(), is(false));
   }
 
   @Test
@@ -393,25 +366,83 @@ public class KsqlRestClientTest {
 
   @SuppressWarnings("unchecked")
   private <T> void givenServerWillReturn(final int statusCode, final Optional<T> entity) {
+    final Response response = mock(Response.class);
+    when(response.getStatus()).thenReturn(statusCode);
 
-    final Response response = EasyMock.createNiceMock(Response.class);
-    EasyMock.expect(response.getStatus()).andReturn(statusCode).anyTimes();
-    entity.ifPresent(e ->
-        EasyMock.expect(response.readEntity((Class<T>)e.getClass())).andReturn(e).once());
+    entity.ifPresent(e -> when(response.readEntity((Class<T>) e.getClass())).thenReturn(e));
 
-    final Invocation.Builder builder = EasyMock.createNiceMock(Invocation.Builder.class);
-    EasyMock.expect(builder.get()).andReturn(response);
-    EasyMock.expect(builder.post(EasyMock.anyObject())).andReturn(response);
+    final Invocation.Builder builder = mock(Invocation.Builder.class);
+    when(builder.get()).thenReturn(response);
+    when(builder.post(any())).thenReturn(response);
 
-    final WebTarget target = EasyMock.createNiceMock(WebTarget.class);
-    EasyMock.expect(target.path(EasyMock.anyString())).andReturn(target);
-    EasyMock.expect(target.request(MediaType.APPLICATION_JSON_TYPE)).andReturn(builder);
+    final WebTarget target = mock(WebTarget.class);
+    when(target.path(any())).thenReturn(target);
+    when(target.request(MediaType.APPLICATION_JSON_TYPE)).thenReturn(builder);
 
-    final Client client = EasyMock.createNiceMock(Client.class);
-    EasyMock.expect(client.target(EasyMock.anyObject(URI.class))).andReturn(target);
-
-    EasyMock.replay(client, target, builder, response);
+    final Client client = mock(Client.class);
+    when(client.target(any(URI.class))).thenReturn(target);
 
     ksqlRestClient = new KsqlRestClient(client, "http://0.0.0.0", Collections.emptyMap());
+  }
+
+  private TestStreamWriter getResponseWriter() {
+    final MockStreamedQueryResource sqr = mockApplication.getStreamedQueryResource();
+    assertThat(sqr.getWriters(), hasSize(1));
+    return sqr.getWriters().get(0);
+  }
+
+  private Thread givenStreamWillCloseIn(final Duration duration, final QueryStream stream) {
+    final Thread thread = new Thread(() -> {
+      try {
+        Thread.sleep(duration.toMillis());
+        stream.close();
+      } catch (final Exception e) {
+        // Meh
+      }
+    });
+    thread.setDaemon(true);
+    thread.start();
+    return thread;
+  }
+
+  private static final class ReceiverThread {
+
+    private final KsqlRestClient.QueryStream queryStream;
+    private final List<StreamedRow> rows = new CopyOnWriteArrayList<>();
+    private final AtomicReference<Exception> exception = new AtomicReference<>();
+    private final Thread thread;
+
+    private ReceiverThread(final RestResponse<KsqlRestClient.QueryStream> queryResponse) {
+      assertThat("not successful", queryResponse.isSuccessful(), is(true));
+      this.queryStream = queryResponse.getResponse();
+      this.thread = new Thread(() -> {
+        try {
+          while (queryStream.hasNext()) {
+            final StreamedRow row = queryStream.next();
+            rows.add(row);
+          }
+
+        } catch (final Exception e) {
+          exception.set(e);
+        }
+      }, "receiver-thread");
+      thread.setDaemon(true);
+      thread.start();
+    }
+
+    private void waitForFirstRow() {
+      while (rows.isEmpty()) {
+        Thread.yield();
+      }
+    }
+
+    private List<StreamedRow> getRows() throws InterruptedException {
+      thread.join(20_000);
+      assertThat("Receive thread still running", thread.isAlive(),  is(false));
+      if (exception.get() != null) {
+        throw new RuntimeException(exception.get());
+      }
+      return rows;
+    }
   }
 }

--- a/ksql-rest-app/src/test/java/io/confluent/ksql/rest/server/mock/MockApplication.java
+++ b/ksql-rest-app/src/test/java/io/confluent/ksql/rest/server/mock/MockApplication.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2017 Confluent Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -17,8 +17,10 @@
 package io.confluent.ksql.rest.server.mock;
 
 import io.confluent.ksql.rest.server.KsqlRestConfig;
+import io.confluent.ksql.rest.server.mock.MockStreamedQueryResource.TestStreamWriter;
 import io.confluent.rest.Application;
 import javax.ws.rs.core.Configurable;
+import org.eclipse.jetty.server.NetworkTrafficServerConnector;
 import org.glassfish.jersey.server.ServerProperties;
 
 
@@ -40,5 +42,35 @@ public class MockApplication extends Application<KsqlRestConfig> {
     configurable.register(streamedQueryResource);
     configurable.register(new MockStatusResource());
     configurable.property(ServerProperties.OUTBOUND_CONTENT_LENGTH_BUFFER, 0);
+  }
+
+  @Override
+  public void stop() {
+    for (TestStreamWriter testStreamWriter : streamedQueryResource.getWriters()) {
+      try {
+        testStreamWriter.finished();
+      } catch (final Exception e) {
+        System.err.println("Failed to finish stream writer");
+        e.printStackTrace(System.err);
+      }
+    }
+
+   try {
+     super.stop();
+   } catch (final Exception e) {
+     System.err.println("Failed to stop app");
+     e.printStackTrace(System.err);
+   }
+  }
+
+  public String getServerAddress() {
+    if (server == null) {
+      throw new IllegalStateException("Not started");
+    }
+
+    final int localPort = ((NetworkTrafficServerConnector) server.getConnectors()[0])
+        .getLocalPort();
+    
+    return "http://localhost:"+ localPort;
   }
 }

--- a/ksql-rest-app/src/test/java/io/confluent/ksql/rest/server/utils/TestUtils.java
+++ b/ksql-rest-app/src/test/java/io/confluent/ksql/rest/server/utils/TestUtils.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2017 Confluent Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -65,6 +65,19 @@ public class TestUtils {
     return priorCommands;
   }
 
+  /**
+   * Find a free port.
+   *
+   * <p>Note: Has a inherent race condition:
+   * after finding the free port it releases it so the caller can use it. This opens up a window in
+   * which another application can grab the free port, causing the test to fail.
+   *
+   * <p>Use only where there is no alternative. Jetty, for example, can allocate its own free
+   * port. Where you do use it, ensure you do so in a loop that will retry if the port is no longer
+   * free by the time the test comes to using it.
+   *
+   * @return a port that was just free and hopefully still is.
+   */
   public static int randomFreeLocalPort() throws IOException {
     final ServerSocket s = new ServerSocket(0);
     final int port = s.getLocalPort();


### PR DESCRIPTION
### Description 

Investigating flaky test: KsqlRestClientTest.shouldInterruptScannerOnClose

Test is flaky because it relies on `Thread.sleep` to ensure different threads are synchronised. On investigation the code it is trying to test, which is dealing with streaming back query results, was not correctly handling the server closing the stream.

The handling of query streams was changed in this original PR:

https://github.com/confluentinc/ksql/commit/931083a0df76231afd8d5b9038d26cfd97784512

And looks to be because of an issue with SIG INT i.e. CTRL+C was being ignored.  The fix put in at the time was to poll `isReady` on the `InputStreamReader`, rather than calling the blocking `read` method. Unfortunately, this means the code does not detect when the server has either finished sending and closed the stream, or the server has just disappeared. 

Hence, changed the implementation to call `read`, but use a read timeout to effectively do a polling read.  This handles CTRL+C properly and also correctly returns `-1` indicating EOF.

Also switched test to Mockito.

### Testing done 
Add unit tests and manual testing.

### Reviewer checklist
- [ ] Ensure docs are updated if necessary. (eg. if a user visible feature is being added or changed).
- [ ] Ensure relevant issues are linked (description should include text like "Fixes #<issue number>")

