### PR TITLE
Minor: fix incorrect use of java doc style comment in copyright.

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2018 Confluent Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 #!/usr/bin/env groovy
 
 dockerfile {

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,19 +1,3 @@
-/*
- * Copyright 2018 Confluent Inc.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- * http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
 #!/usr/bin/env groovy
 
 dockerfile {

--- a/checkstyle/suppressions.xml
+++ b/checkstyle/suppressions.xml
@@ -1,5 +1,21 @@
 <?xml version="1.0"?>
 
+<!--
+  ~ Copyright 2018 Confluent Inc.
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~ http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
 <!DOCTYPE suppressions PUBLIC
   "-//Puppy Crawl//DTD Suppressions 1.1//EN"
   "http://www.puppycrawl.com/dtds/suppressions_1_1.dtd">

--- a/config/datagen.properties
+++ b/config/datagen.properties
@@ -1,2 +1,18 @@
+#
+# Copyright 2018 Confluent Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
 # This properties file should ONLY be used when you run KSQL with Confluent Enterprise Platform.
 interceptor.classes=io.confluent.monitoring.clients.interceptor.MonitoringProducerInterceptor

--- a/config/ksql-server.properties
+++ b/config/ksql-server.properties
@@ -1,2 +1,18 @@
+#
+# Copyright 2018 Confluent Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
 bootstrap.servers=localhost:9092
 listeners=http://localhost:8088

--- a/config/log4j-file.properties
+++ b/config/log4j-file.properties
@@ -1,3 +1,19 @@
+#
+# Copyright 2018 Confluent Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
 # For the general syntax of property based configuration files see
 # the documentation of org.apache.log4j.PropertyConfigurator.
 

--- a/config/log4j-rolling.properties
+++ b/config/log4j-rolling.properties
@@ -1,3 +1,19 @@
+#
+# Copyright 2018 Confluent Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
 # this is a sample log4j config that will roll log files
 # lines with `File=` may need to be updated for your environment
 

--- a/config/log4j-silent.properties
+++ b/config/log4j-silent.properties
@@ -1,1 +1,17 @@
+#
+# Copyright 2018 Confluent Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
 log4j.rootLogger=OFF

--- a/config/log4j.properties
+++ b/config/log4j.properties
@@ -1,3 +1,19 @@
+#
+# Copyright 2018 Confluent Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
 log4j.rootLogger=INFO, stdout
 
 log4j.appender.stdout=org.apache.log4j.ConsoleAppender

--- a/ksql-cli/pom.xml
+++ b/ksql-cli/pom.xml
@@ -1,4 +1,20 @@
 <?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ Copyright 2018 Confluent Inc.
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~ http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
 <project xmlns="http://maven.apache.org/POM/4.0.0"
          xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">

--- a/ksql-cli/src/assembly/development.xml
+++ b/ksql-cli/src/assembly/development.xml
@@ -1,3 +1,19 @@
+<!--
+  ~ Copyright 2018 Confluent Inc.
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~ http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
 <assembly xmlns="http://maven.apache.org/plugins/maven-assembly-plugin/assembly/1.1.2"
           xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
           xsi:schemaLocation="http://maven.apache.org/plugins/maven-assembly-plugin/assembly/1.1.2

--- a/ksql-cli/src/assembly/package.xml
+++ b/ksql-cli/src/assembly/package.xml
@@ -1,3 +1,19 @@
+<!--
+  ~ Copyright 2018 Confluent Inc.
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~ http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
 <assembly xmlns="http://maven.apache.org/plugins/maven-assembly-plugin/assembly/1.1.2"
           xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
           xsi:schemaLocation="http://maven.apache.org/plugins/maven-assembly-plugin/assembly/1.1.2

--- a/ksql-cli/src/assembly/standalone.xml
+++ b/ksql-cli/src/assembly/standalone.xml
@@ -1,3 +1,19 @@
+<!--
+  ~ Copyright 2018 Confluent Inc.
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~ http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
 <assembly xmlns="http://maven.apache.org/plugins/maven-assembly-plugin/assembly/1.1.2"
           xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
           xsi:schemaLocation="http://maven.apache.org/plugins/maven-assembly-plugin/assembly/1.1.2

--- a/ksql-cli/src/main/java/io/confluent/ksql/cli/Options.java
+++ b/ksql-cli/src/main/java/io/confluent/ksql/cli/Options.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2018 Confluent Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/ksql-cli/src/main/java/io/confluent/ksql/cli/console/LineReader.java
+++ b/ksql-cli/src/main/java/io/confluent/ksql/cli/console/LineReader.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2017 Confluent Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/ksql-cli/src/main/java/io/confluent/ksql/cli/console/OutputFormat.java
+++ b/ksql-cli/src/main/java/io/confluent/ksql/cli/console/OutputFormat.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2017 Confluent Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/ksql-cli/src/main/java/io/confluent/ksql/util/CliUtils.java
+++ b/ksql-cli/src/main/java/io/confluent/ksql/util/CliUtils.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2017 Confluent Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/ksql-cli/src/main/java/io/confluent/ksql/util/TimestampLogFileAppender.java
+++ b/ksql-cli/src/main/java/io/confluent/ksql/util/TimestampLogFileAppender.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2017 Confluent Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/ksql-cli/src/main/resources/log4j.properties
+++ b/ksql-cli/src/main/resources/log4j.properties
@@ -1,3 +1,19 @@
+#
+# Copyright 2018 Confluent Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
 # For the general syntax of property based configuration files see
 # the documentation of org.apache.log4j.PropertyConfigurator.
 

--- a/ksql-cli/src/test/java/io/confluent/ksql/FakeException.java
+++ b/ksql-cli/src/test/java/io/confluent/ksql/FakeException.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2017 Confluent Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/ksql-cli/src/test/java/io/confluent/ksql/TestResult.java
+++ b/ksql-cli/src/test/java/io/confluent/ksql/TestResult.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2017 Confluent Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/ksql-cli/src/test/java/io/confluent/ksql/cli/commands/OptionsTest.java
+++ b/ksql-cli/src/test/java/io/confluent/ksql/cli/commands/OptionsTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2017 Confluent Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/ksql-cli/src/test/java/io/confluent/ksql/cli/console/JLineReaderTest.java
+++ b/ksql-cli/src/test/java/io/confluent/ksql/cli/console/JLineReaderTest.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2018 Confluent Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package io.confluent.ksql.cli.console;
 
 import static org.easymock.EasyMock.anyString;

--- a/ksql-cli/src/test/java/io/confluent/ksql/util/CliUtilsTest.java
+++ b/ksql-cli/src/test/java/io/confluent/ksql/util/CliUtilsTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2017 Confluent Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/ksql-cli/src/test/resources/log4j.properties
+++ b/ksql-cli/src/test/resources/log4j.properties
@@ -1,3 +1,19 @@
+#
+# Copyright 2018 Confluent Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
 # For the general syntax of property based configuration files see
 # the documentation of org.apache.log4j.PropertyConfigurator.
 

--- a/ksql-clickstream-demo/demo/connect-config/connect.properties
+++ b/ksql-clickstream-demo/demo/connect-config/connect.properties
@@ -1,2 +1,18 @@
+#
+# Copyright 2018 Confluent Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
 transforms=FilterNulls
 transforms.FilterNulls.type=io.confluent.transforms.NullFilter

--- a/ksql-common/pom.xml
+++ b/ksql-common/pom.xml
@@ -1,4 +1,20 @@
 <?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ Copyright 2018 Confluent Inc.
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~ http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
 <project xmlns="http://maven.apache.org/POM/4.0.0"
          xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">

--- a/ksql-common/src/main/java/io/confluent/ksql/GenericRow.java
+++ b/ksql-common/src/main/java/io/confluent/ksql/GenericRow.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2017 Confluent Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/ksql-common/src/main/java/io/confluent/ksql/errors/LogMetricAndContinueExceptionHandler.java
+++ b/ksql-common/src/main/java/io/confluent/ksql/errors/LogMetricAndContinueExceptionHandler.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2017 Confluent Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/ksql-common/src/main/java/io/confluent/ksql/function/AggregateFunctionFactory.java
+++ b/ksql-common/src/main/java/io/confluent/ksql/function/AggregateFunctionFactory.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2017 Confluent Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/ksql-common/src/main/java/io/confluent/ksql/function/FunctionRegistry.java
+++ b/ksql-common/src/main/java/io/confluent/ksql/function/FunctionRegistry.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2018 Confluent Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/ksql-common/src/main/java/io/confluent/ksql/function/KsqlAggregateFunction.java
+++ b/ksql-common/src/main/java/io/confluent/ksql/function/KsqlAggregateFunction.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2017 Confluent Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/ksql-common/src/main/java/io/confluent/ksql/function/KsqlFunction.java
+++ b/ksql-common/src/main/java/io/confluent/ksql/function/KsqlFunction.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2017 Confluent Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/ksql-common/src/main/java/io/confluent/ksql/function/UdafAggregator.java
+++ b/ksql-common/src/main/java/io/confluent/ksql/function/UdafAggregator.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2017 Confluent Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/ksql-common/src/main/java/io/confluent/ksql/function/udf/Kudf.java
+++ b/ksql-common/src/main/java/io/confluent/ksql/function/udf/Kudf.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2017 Confluent Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/ksql-common/src/main/java/io/confluent/ksql/metrics/ConsumerCollector.java
+++ b/ksql-common/src/main/java/io/confluent/ksql/metrics/ConsumerCollector.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2017 Confluent Inc.
  * <p>
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/ksql-common/src/main/java/io/confluent/ksql/metrics/MetricCollector.java
+++ b/ksql-common/src/main/java/io/confluent/ksql/metrics/MetricCollector.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2017 Confluent Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/ksql-common/src/main/java/io/confluent/ksql/metrics/ProducerCollector.java
+++ b/ksql-common/src/main/java/io/confluent/ksql/metrics/ProducerCollector.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2017 Confluent Inc.
  * <p>
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/ksql-common/src/main/java/io/confluent/ksql/metrics/StreamsErrorCollector.java
+++ b/ksql-common/src/main/java/io/confluent/ksql/metrics/StreamsErrorCollector.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2018 Confluent Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/ksql-common/src/main/java/io/confluent/ksql/query/QueryId.java
+++ b/ksql-common/src/main/java/io/confluent/ksql/query/QueryId.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2017 Confluent Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except

--- a/ksql-common/src/main/java/io/confluent/ksql/util/KsqlException.java
+++ b/ksql-common/src/main/java/io/confluent/ksql/util/KsqlException.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2017 Confluent Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/ksql-common/src/main/java/io/confluent/ksql/util/KsqlReferentialIntegrityException.java
+++ b/ksql-common/src/main/java/io/confluent/ksql/util/KsqlReferentialIntegrityException.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2017 Confluent Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/ksql-common/src/main/java/io/confluent/ksql/util/RetryUtil.java
+++ b/ksql-common/src/main/java/io/confluent/ksql/util/RetryUtil.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2018 Confluent Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/ksql-common/src/main/java/io/confluent/ksql/util/timestamp/LongColumnTimestampExtractionPolicy.java
+++ b/ksql-common/src/main/java/io/confluent/ksql/util/timestamp/LongColumnTimestampExtractionPolicy.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2018 Confluent Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/ksql-common/src/main/java/io/confluent/ksql/util/timestamp/LongTimestampExtractor.java
+++ b/ksql-common/src/main/java/io/confluent/ksql/util/timestamp/LongTimestampExtractor.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2018 Confluent Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/ksql-common/src/main/java/io/confluent/ksql/util/timestamp/MetadataTimestampExtractionPolicy.java
+++ b/ksql-common/src/main/java/io/confluent/ksql/util/timestamp/MetadataTimestampExtractionPolicy.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2018 Confluent Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/ksql-common/src/main/java/io/confluent/ksql/util/timestamp/StringTimestampExtractionPolicy.java
+++ b/ksql-common/src/main/java/io/confluent/ksql/util/timestamp/StringTimestampExtractionPolicy.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2018 Confluent Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/ksql-common/src/main/java/io/confluent/ksql/util/timestamp/StringTimestampExtractor.java
+++ b/ksql-common/src/main/java/io/confluent/ksql/util/timestamp/StringTimestampExtractor.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2018 Confluent Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/ksql-common/src/main/java/io/confluent/ksql/util/timestamp/StringToTimestampParser.java
+++ b/ksql-common/src/main/java/io/confluent/ksql/util/timestamp/StringToTimestampParser.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2018 Confluent Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/ksql-common/src/main/java/io/confluent/ksql/util/timestamp/TimestampExtractionPolicy.java
+++ b/ksql-common/src/main/java/io/confluent/ksql/util/timestamp/TimestampExtractionPolicy.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2018 Confluent Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/ksql-common/src/test/java/io/confluent/ksql/GenericRowTest.java
+++ b/ksql-common/src/test/java/io/confluent/ksql/GenericRowTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2018 Confluent Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/ksql-common/src/test/java/io/confluent/ksql/function/TestFunctionRegistry.java
+++ b/ksql-common/src/test/java/io/confluent/ksql/function/TestFunctionRegistry.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2017 Confluent Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/ksql-common/src/test/java/io/confluent/ksql/metrics/ConsumerCollectorTest.java
+++ b/ksql-common/src/test/java/io/confluent/ksql/metrics/ConsumerCollectorTest.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2018 Confluent Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package io.confluent.ksql.metrics;
 
 import static org.hamcrest.CoreMatchers.containsString;

--- a/ksql-common/src/test/java/io/confluent/ksql/metrics/MetricCollectorsTest.java
+++ b/ksql-common/src/test/java/io/confluent/ksql/metrics/MetricCollectorsTest.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2018 Confluent Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package io.confluent.ksql.metrics;
 
 import static org.hamcrest.CoreMatchers.equalTo;

--- a/ksql-common/src/test/java/io/confluent/ksql/metrics/ProducerCollectorTest.java
+++ b/ksql-common/src/test/java/io/confluent/ksql/metrics/ProducerCollectorTest.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2018 Confluent Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package io.confluent.ksql.metrics;
 
 import static org.hamcrest.CoreMatchers.containsString;

--- a/ksql-common/src/test/java/io/confluent/ksql/metrics/StreamsErrorCollectorTest.java
+++ b/ksql-common/src/test/java/io/confluent/ksql/metrics/StreamsErrorCollectorTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2018 Confluent Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/ksql-common/src/test/java/io/confluent/ksql/util/ErrorMessageUtilTest.java
+++ b/ksql-common/src/test/java/io/confluent/ksql/util/ErrorMessageUtilTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2017 Confluent Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/ksql-common/src/test/java/io/confluent/ksql/util/RetryUtilTest.java
+++ b/ksql-common/src/test/java/io/confluent/ksql/util/RetryUtilTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2018 Confluent Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/ksql-common/src/test/java/io/confluent/ksql/util/timestamp/LongColumnTimestampExtractionPolicyTest.java
+++ b/ksql-common/src/test/java/io/confluent/ksql/util/timestamp/LongColumnTimestampExtractionPolicyTest.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2018 Confluent Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package io.confluent.ksql.util.timestamp;
 
 import com.google.common.testing.EqualsTester;

--- a/ksql-common/src/test/java/io/confluent/ksql/util/timestamp/MetadataTimestampExtractionPolicyTest.java
+++ b/ksql-common/src/test/java/io/confluent/ksql/util/timestamp/MetadataTimestampExtractionPolicyTest.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2018 Confluent Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package io.confluent.ksql.util.timestamp;
 
 import com.google.common.testing.EqualsTester;

--- a/ksql-common/src/test/java/io/confluent/ksql/util/timestamp/StringTimestampExtractionPolicyTest.java
+++ b/ksql-common/src/test/java/io/confluent/ksql/util/timestamp/StringTimestampExtractionPolicyTest.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2018 Confluent Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package io.confluent.ksql.util.timestamp;
 
 import com.google.common.testing.EqualsTester;

--- a/ksql-console-scripts/pom.xml
+++ b/ksql-console-scripts/pom.xml
@@ -1,3 +1,19 @@
+<!--
+  ~ Copyright 2018 Confluent Inc.
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~ http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
 <project xmlns="http://maven.apache.org/POM/4.0.0"
  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 xsi:schemaLocation="http://maven.apache.org/POM/4.0.0

--- a/ksql-console-scripts/src/assembly/resources.xml
+++ b/ksql-console-scripts/src/assembly/resources.xml
@@ -1,3 +1,19 @@
+<!--
+  ~ Copyright 2018 Confluent Inc.
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~ http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
 <assembly>
   <id>resources</id>
   <formats>

--- a/ksql-engine/pom.xml
+++ b/ksql-engine/pom.xml
@@ -1,4 +1,20 @@
 <?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ Copyright 2018 Confluent Inc.
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~ http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
 <project xmlns="http://maven.apache.org/POM/4.0.0"
          xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">

--- a/ksql-engine/src/main/java/io/confluent/ksql/analyzer/AggregateAnalysis.java
+++ b/ksql-engine/src/main/java/io/confluent/ksql/analyzer/AggregateAnalysis.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2017 Confluent Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/ksql-engine/src/main/java/io/confluent/ksql/analyzer/AggregateAnalyzer.java
+++ b/ksql-engine/src/main/java/io/confluent/ksql/analyzer/AggregateAnalyzer.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2017 Confluent Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/ksql-engine/src/main/java/io/confluent/ksql/analyzer/Analysis.java
+++ b/ksql-engine/src/main/java/io/confluent/ksql/analyzer/Analysis.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2017 Confluent Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/ksql-engine/src/main/java/io/confluent/ksql/analyzer/AnalysisContext.java
+++ b/ksql-engine/src/main/java/io/confluent/ksql/analyzer/AnalysisContext.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2017 Confluent Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/ksql-engine/src/main/java/io/confluent/ksql/analyzer/Analyzer.java
+++ b/ksql-engine/src/main/java/io/confluent/ksql/analyzer/Analyzer.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2017 Confluent Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/ksql-engine/src/main/java/io/confluent/ksql/analyzer/ExpressionAnalyzer.java
+++ b/ksql-engine/src/main/java/io/confluent/ksql/analyzer/ExpressionAnalyzer.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2017 Confluent Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/ksql-engine/src/main/java/io/confluent/ksql/ddl/commands/CommandFactories.java
+++ b/ksql-engine/src/main/java/io/confluent/ksql/ddl/commands/CommandFactories.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2017 Confluent Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/ksql-engine/src/main/java/io/confluent/ksql/ddl/commands/CreateStreamCommand.java
+++ b/ksql-engine/src/main/java/io/confluent/ksql/ddl/commands/CreateStreamCommand.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2017 Confluent Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/ksql-engine/src/main/java/io/confluent/ksql/ddl/commands/CreateTableCommand.java
+++ b/ksql-engine/src/main/java/io/confluent/ksql/ddl/commands/CreateTableCommand.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2017 Confluent Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/ksql-engine/src/main/java/io/confluent/ksql/ddl/commands/DdlCommand.java
+++ b/ksql-engine/src/main/java/io/confluent/ksql/ddl/commands/DdlCommand.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2017 Confluent Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/ksql-engine/src/main/java/io/confluent/ksql/ddl/commands/DdlCommandExec.java
+++ b/ksql-engine/src/main/java/io/confluent/ksql/ddl/commands/DdlCommandExec.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2017 Confluent Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/ksql-engine/src/main/java/io/confluent/ksql/ddl/commands/DdlCommandFactory.java
+++ b/ksql-engine/src/main/java/io/confluent/ksql/ddl/commands/DdlCommandFactory.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2017 Confluent Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/ksql-engine/src/main/java/io/confluent/ksql/ddl/commands/DdlCommandResult.java
+++ b/ksql-engine/src/main/java/io/confluent/ksql/ddl/commands/DdlCommandResult.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2017 Confluent Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/ksql-engine/src/main/java/io/confluent/ksql/ddl/commands/DropTopicCommand.java
+++ b/ksql-engine/src/main/java/io/confluent/ksql/ddl/commands/DropTopicCommand.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2017 Confluent Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/ksql-engine/src/main/java/io/confluent/ksql/ddl/commands/RegisterTopicCommand.java
+++ b/ksql-engine/src/main/java/io/confluent/ksql/ddl/commands/RegisterTopicCommand.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2017 Confluent Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/ksql-engine/src/main/java/io/confluent/ksql/ddl/commands/SetPropertyCommand.java
+++ b/ksql-engine/src/main/java/io/confluent/ksql/ddl/commands/SetPropertyCommand.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2017 Confluent Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/ksql-engine/src/main/java/io/confluent/ksql/ddl/commands/UnsetPropertyCommand.java
+++ b/ksql-engine/src/main/java/io/confluent/ksql/ddl/commands/UnsetPropertyCommand.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2018 Confluent Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/ksql-engine/src/main/java/io/confluent/ksql/exception/KafkaResponseGetFailedException.java
+++ b/ksql-engine/src/main/java/io/confluent/ksql/exception/KafkaResponseGetFailedException.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2017 Confluent Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/ksql-engine/src/main/java/io/confluent/ksql/exception/KafkaTopicClientException.java
+++ b/ksql-engine/src/main/java/io/confluent/ksql/exception/KafkaTopicClientException.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2017 Confluent Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/ksql-engine/src/main/java/io/confluent/ksql/exception/KafkaTopicException.java
+++ b/ksql-engine/src/main/java/io/confluent/ksql/exception/KafkaTopicException.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2017 Confluent Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/ksql-engine/src/main/java/io/confluent/ksql/function/BaseAggregateFunction.java
+++ b/ksql-engine/src/main/java/io/confluent/ksql/function/BaseAggregateFunction.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2018 Confluent Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/ksql-engine/src/main/java/io/confluent/ksql/function/InternalFunctionRegistry.java
+++ b/ksql-engine/src/main/java/io/confluent/ksql/function/InternalFunctionRegistry.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2017 Confluent Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/ksql-engine/src/main/java/io/confluent/ksql/function/KsqlFunctionException.java
+++ b/ksql-engine/src/main/java/io/confluent/ksql/function/KsqlFunctionException.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2017 Confluent Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/ksql-engine/src/main/java/io/confluent/ksql/function/TableAggregationFunction.java
+++ b/ksql-engine/src/main/java/io/confluent/ksql/function/TableAggregationFunction.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2018 Confluent Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/ksql-engine/src/main/java/io/confluent/ksql/function/udaf/KudafAggregator.java
+++ b/ksql-engine/src/main/java/io/confluent/ksql/function/udaf/KudafAggregator.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2017 Confluent Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/ksql-engine/src/main/java/io/confluent/ksql/function/udaf/KudafInitializer.java
+++ b/ksql-engine/src/main/java/io/confluent/ksql/function/udaf/KudafInitializer.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2017 Confluent Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/ksql-engine/src/main/java/io/confluent/ksql/function/udaf/KudafUndoAggregator.java
+++ b/ksql-engine/src/main/java/io/confluent/ksql/function/udaf/KudafUndoAggregator.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2018 Confluent Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/ksql-engine/src/main/java/io/confluent/ksql/function/udaf/count/CountAggFunctionFactory.java
+++ b/ksql-engine/src/main/java/io/confluent/ksql/function/udaf/count/CountAggFunctionFactory.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2017 Confluent Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/ksql-engine/src/main/java/io/confluent/ksql/function/udaf/count/CountKudaf.java
+++ b/ksql-engine/src/main/java/io/confluent/ksql/function/udaf/count/CountKudaf.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2017 Confluent Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/ksql-engine/src/main/java/io/confluent/ksql/function/udaf/max/DoubleMaxKudaf.java
+++ b/ksql-engine/src/main/java/io/confluent/ksql/function/udaf/max/DoubleMaxKudaf.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2017 Confluent Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/ksql-engine/src/main/java/io/confluent/ksql/function/udaf/max/LongMaxKudaf.java
+++ b/ksql-engine/src/main/java/io/confluent/ksql/function/udaf/max/LongMaxKudaf.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2017 Confluent Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/ksql-engine/src/main/java/io/confluent/ksql/function/udaf/max/MaxAggFunctionFactory.java
+++ b/ksql-engine/src/main/java/io/confluent/ksql/function/udaf/max/MaxAggFunctionFactory.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2017 Confluent Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/ksql-engine/src/main/java/io/confluent/ksql/function/udaf/min/DoubleMinKudaf.java
+++ b/ksql-engine/src/main/java/io/confluent/ksql/function/udaf/min/DoubleMinKudaf.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2017 Confluent Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/ksql-engine/src/main/java/io/confluent/ksql/function/udaf/min/LongMinKudaf.java
+++ b/ksql-engine/src/main/java/io/confluent/ksql/function/udaf/min/LongMinKudaf.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2017 Confluent Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/ksql-engine/src/main/java/io/confluent/ksql/function/udaf/sum/DoubleSumKudaf.java
+++ b/ksql-engine/src/main/java/io/confluent/ksql/function/udaf/sum/DoubleSumKudaf.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2017 Confluent Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/ksql-engine/src/main/java/io/confluent/ksql/function/udaf/sum/LongSumKudaf.java
+++ b/ksql-engine/src/main/java/io/confluent/ksql/function/udaf/sum/LongSumKudaf.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2017 Confluent Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/ksql-engine/src/main/java/io/confluent/ksql/function/udaf/sum/SumAggFunctionFactory.java
+++ b/ksql-engine/src/main/java/io/confluent/ksql/function/udaf/sum/SumAggFunctionFactory.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2017 Confluent Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/ksql-engine/src/main/java/io/confluent/ksql/function/udaf/topkdistinct/TopkDistinctAggFunctionFactory.java
+++ b/ksql-engine/src/main/java/io/confluent/ksql/function/udaf/topkdistinct/TopkDistinctAggFunctionFactory.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2017 Confluent Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/ksql-engine/src/main/java/io/confluent/ksql/function/udf/geo/GeoDistanceKudf.java
+++ b/ksql-engine/src/main/java/io/confluent/ksql/function/udf/geo/GeoDistanceKudf.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2018 Confluent Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except

--- a/ksql-engine/src/main/java/io/confluent/ksql/function/udf/json/ArrayContainsKudf.java
+++ b/ksql-engine/src/main/java/io/confluent/ksql/function/udf/json/ArrayContainsKudf.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2017 Confluent Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/ksql-engine/src/main/java/io/confluent/ksql/function/udf/math/CeilKudf.java
+++ b/ksql-engine/src/main/java/io/confluent/ksql/function/udf/math/CeilKudf.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2017 Confluent Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/ksql-engine/src/main/java/io/confluent/ksql/function/udf/math/FloorKudf.java
+++ b/ksql-engine/src/main/java/io/confluent/ksql/function/udf/math/FloorKudf.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2017 Confluent Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/ksql-engine/src/main/java/io/confluent/ksql/function/udf/math/RandomKudf.java
+++ b/ksql-engine/src/main/java/io/confluent/ksql/function/udf/math/RandomKudf.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2017 Confluent Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/ksql-engine/src/main/java/io/confluent/ksql/function/udf/math/RoundKudf.java
+++ b/ksql-engine/src/main/java/io/confluent/ksql/function/udf/math/RoundKudf.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2017 Confluent Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/ksql-engine/src/main/java/io/confluent/ksql/function/udf/string/IfNullKudf.java
+++ b/ksql-engine/src/main/java/io/confluent/ksql/function/udf/string/IfNullKudf.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2017 Confluent Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/ksql-engine/src/main/java/io/confluent/ksql/function/udf/string/LCaseKudf.java
+++ b/ksql-engine/src/main/java/io/confluent/ksql/function/udf/string/LCaseKudf.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2017 Confluent Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/ksql-engine/src/main/java/io/confluent/ksql/function/udf/string/LenKudf.java
+++ b/ksql-engine/src/main/java/io/confluent/ksql/function/udf/string/LenKudf.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2017 Confluent Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/ksql-engine/src/main/java/io/confluent/ksql/function/udf/string/MaskKeepLeftKudf.java
+++ b/ksql-engine/src/main/java/io/confluent/ksql/function/udf/string/MaskKeepLeftKudf.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2018 Confluent Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except

--- a/ksql-engine/src/main/java/io/confluent/ksql/function/udf/string/MaskKeepRightKudf.java
+++ b/ksql-engine/src/main/java/io/confluent/ksql/function/udf/string/MaskKeepRightKudf.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2018 Confluent Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except

--- a/ksql-engine/src/main/java/io/confluent/ksql/function/udf/string/MaskKudf.java
+++ b/ksql-engine/src/main/java/io/confluent/ksql/function/udf/string/MaskKudf.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2018 Confluent Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except

--- a/ksql-engine/src/main/java/io/confluent/ksql/function/udf/string/MaskLeftKudf.java
+++ b/ksql-engine/src/main/java/io/confluent/ksql/function/udf/string/MaskLeftKudf.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2018 Confluent Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except

--- a/ksql-engine/src/main/java/io/confluent/ksql/function/udf/string/MaskRightKudf.java
+++ b/ksql-engine/src/main/java/io/confluent/ksql/function/udf/string/MaskRightKudf.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2018 Confluent Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except

--- a/ksql-engine/src/main/java/io/confluent/ksql/function/udf/string/Masker.java
+++ b/ksql-engine/src/main/java/io/confluent/ksql/function/udf/string/Masker.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2018 Confluent Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except

--- a/ksql-engine/src/main/java/io/confluent/ksql/function/udf/string/TrimKudf.java
+++ b/ksql-engine/src/main/java/io/confluent/ksql/function/udf/string/TrimKudf.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2017 Confluent Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/ksql-engine/src/main/java/io/confluent/ksql/function/udf/string/UCaseKudf.java
+++ b/ksql-engine/src/main/java/io/confluent/ksql/function/udf/string/UCaseKudf.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2017 Confluent Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/ksql-engine/src/main/java/io/confluent/ksql/internal/KsqlEngineMetrics.java
+++ b/ksql-engine/src/main/java/io/confluent/ksql/internal/KsqlEngineMetrics.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2017 Confluent Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/ksql-engine/src/main/java/io/confluent/ksql/physical/AddTimestampColumn.java
+++ b/ksql-engine/src/main/java/io/confluent/ksql/physical/AddTimestampColumn.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2017 Confluent Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/ksql-engine/src/main/java/io/confluent/ksql/planner/LogicalPlanner.java
+++ b/ksql-engine/src/main/java/io/confluent/ksql/planner/LogicalPlanner.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2017 Confluent Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/ksql-engine/src/main/java/io/confluent/ksql/planner/PlanException.java
+++ b/ksql-engine/src/main/java/io/confluent/ksql/planner/PlanException.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2017 Confluent Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/ksql-engine/src/main/java/io/confluent/ksql/planner/PlanSourceExtractorVisitor.java
+++ b/ksql-engine/src/main/java/io/confluent/ksql/planner/PlanSourceExtractorVisitor.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2017 Confluent Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/ksql-engine/src/main/java/io/confluent/ksql/planner/plan/FilterNode.java
+++ b/ksql-engine/src/main/java/io/confluent/ksql/planner/plan/FilterNode.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2017 Confluent Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/ksql-engine/src/main/java/io/confluent/ksql/planner/plan/JoinNode.java
+++ b/ksql-engine/src/main/java/io/confluent/ksql/planner/plan/JoinNode.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2017 Confluent Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/ksql-engine/src/main/java/io/confluent/ksql/planner/plan/KsqlBareOutputNode.java
+++ b/ksql-engine/src/main/java/io/confluent/ksql/planner/plan/KsqlBareOutputNode.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2017 Confluent Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/ksql-engine/src/main/java/io/confluent/ksql/planner/plan/KsqlStructuredDataOutputNode.java
+++ b/ksql-engine/src/main/java/io/confluent/ksql/planner/plan/KsqlStructuredDataOutputNode.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2017 Confluent Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/ksql-engine/src/main/java/io/confluent/ksql/planner/plan/PlanNode.java
+++ b/ksql-engine/src/main/java/io/confluent/ksql/planner/plan/PlanNode.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2017 Confluent Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/ksql-engine/src/main/java/io/confluent/ksql/planner/plan/PlanNodeId.java
+++ b/ksql-engine/src/main/java/io/confluent/ksql/planner/plan/PlanNodeId.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2017 Confluent Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/ksql-engine/src/main/java/io/confluent/ksql/planner/plan/PlanVisitor.java
+++ b/ksql-engine/src/main/java/io/confluent/ksql/planner/plan/PlanVisitor.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2017 Confluent Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/ksql-engine/src/main/java/io/confluent/ksql/planner/plan/ProjectNode.java
+++ b/ksql-engine/src/main/java/io/confluent/ksql/planner/plan/ProjectNode.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2017 Confluent Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/ksql-engine/src/main/java/io/confluent/ksql/planner/plan/StructuredDataSourceNode.java
+++ b/ksql-engine/src/main/java/io/confluent/ksql/planner/plan/StructuredDataSourceNode.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2017 Confluent Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/ksql-engine/src/main/java/io/confluent/ksql/structured/SqlPredicate.java
+++ b/ksql-engine/src/main/java/io/confluent/ksql/structured/SqlPredicate.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2017 Confluent Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/ksql-engine/src/main/java/io/confluent/ksql/util/AggregateExpressionRewriter.java
+++ b/ksql-engine/src/main/java/io/confluent/ksql/util/AggregateExpressionRewriter.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2017 Confluent Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/ksql-engine/src/main/java/io/confluent/ksql/util/ExpressionTypeManager.java
+++ b/ksql-engine/src/main/java/io/confluent/ksql/util/ExpressionTypeManager.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2017 Confluent Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/ksql-engine/src/main/java/io/confluent/ksql/util/GenericRowValueTypeEnforcer.java
+++ b/ksql-engine/src/main/java/io/confluent/ksql/util/GenericRowValueTypeEnforcer.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2017 Confluent Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/ksql-engine/src/main/java/io/confluent/ksql/util/KafkaConsumerGroupClient.java
+++ b/ksql-engine/src/main/java/io/confluent/ksql/util/KafkaConsumerGroupClient.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2018 Confluent Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/ksql-engine/src/main/java/io/confluent/ksql/util/PersistentQueryMetadata.java
+++ b/ksql-engine/src/main/java/io/confluent/ksql/util/PersistentQueryMetadata.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2017 Confluent Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/ksql-engine/src/main/java/io/confluent/ksql/util/QueryIdGenerator.java
+++ b/ksql-engine/src/main/java/io/confluent/ksql/util/QueryIdGenerator.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2017 Confluent Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/ksql-engine/src/main/java/io/confluent/ksql/util/QueryMetadata.java
+++ b/ksql-engine/src/main/java/io/confluent/ksql/util/QueryMetadata.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2017 Confluent Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/ksql-engine/src/main/java/io/confluent/ksql/util/Version.java
+++ b/ksql-engine/src/main/java/io/confluent/ksql/util/Version.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2017 Confluent Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/ksql-engine/src/main/resources/log4j.properties
+++ b/ksql-engine/src/main/resources/log4j.properties
@@ -1,3 +1,19 @@
+#
+# Copyright 2018 Confluent Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
 log4j.rootLogger=WARN,stdout
 
 log4j.logger.io.confluent.ksql=INFO

--- a/ksql-engine/src/main/resources/version.properties
+++ b/ksql-engine/src/main/resources/version.properties
@@ -1,1 +1,17 @@
+#
+# Copyright 2018 Confluent Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
 version=${project.version}

--- a/ksql-engine/src/test/java/io/confluent/ksql/KsqlContextTest.java
+++ b/ksql-engine/src/test/java/io/confluent/ksql/KsqlContextTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2017 Confluent Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/ksql-engine/src/test/java/io/confluent/ksql/KsqlEngineTestUtil.java
+++ b/ksql-engine/src/test/java/io/confluent/ksql/KsqlEngineTestUtil.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2018 Confluent Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package io.confluent.ksql;
 
 import io.confluent.kafka.schemaregistry.client.SchemaRegistryClient;

--- a/ksql-engine/src/test/java/io/confluent/ksql/QueryTranslationTest.java
+++ b/ksql-engine/src/test/java/io/confluent/ksql/QueryTranslationTest.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2018 Confluent Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package io.confluent.ksql;
 
 import static io.confluent.ksql.EndToEndEngineTestUtil.ExpectedException;

--- a/ksql-engine/src/test/java/io/confluent/ksql/SchemaTranslationTest.java
+++ b/ksql-engine/src/test/java/io/confluent/ksql/SchemaTranslationTest.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2018 Confluent Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package io.confluent.ksql;
 
 import static io.confluent.ksql.EndToEndEngineTestUtil.AvroSerdeSupplier;

--- a/ksql-engine/src/test/java/io/confluent/ksql/TopologyFileGenerator.java
+++ b/ksql-engine/src/test/java/io/confluent/ksql/TopologyFileGenerator.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2018 Confluent Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package io.confluent.ksql;
 
 import io.confluent.ksql.EndToEndEngineTestUtil.TestCase;

--- a/ksql-engine/src/test/java/io/confluent/ksql/analyzer/AnalyzerTest.java
+++ b/ksql-engine/src/test/java/io/confluent/ksql/analyzer/AnalyzerTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2017 Confluent Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/ksql-engine/src/test/java/io/confluent/ksql/codegen/SqlToJavaVisitorTest.java
+++ b/ksql-engine/src/test/java/io/confluent/ksql/codegen/SqlToJavaVisitorTest.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2018 Confluent Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package io.confluent.ksql.codegen;
 
 import static io.confluent.ksql.testutils.AnalysisTestUtil.analyzeQuery;

--- a/ksql-engine/src/test/java/io/confluent/ksql/ddl/commands/DropSourceCommandTest.java
+++ b/ksql-engine/src/test/java/io/confluent/ksql/ddl/commands/DropSourceCommandTest.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2018 Confluent Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package io.confluent.ksql.ddl.commands;
 
 import static org.hamcrest.CoreMatchers.equalTo;

--- a/ksql-engine/src/test/java/io/confluent/ksql/function/InternalFunctionRegistryTest.java
+++ b/ksql-engine/src/test/java/io/confluent/ksql/function/InternalFunctionRegistryTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2017 Confluent Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/ksql-engine/src/test/java/io/confluent/ksql/function/KudafUndoAggregatorTest.java
+++ b/ksql-engine/src/test/java/io/confluent/ksql/function/KudafUndoAggregatorTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2018 Confluent Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/ksql-engine/src/test/java/io/confluent/ksql/function/udaf/array/CollectListUdafTest.java
+++ b/ksql-engine/src/test/java/io/confluent/ksql/function/udaf/array/CollectListUdafTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2018 Confluent Inc.
  *
  * Licensed under the Apache License, Version 2 (the "License"); you may not use this file except in

--- a/ksql-engine/src/test/java/io/confluent/ksql/function/udaf/array/CollectSetUdafTest.java
+++ b/ksql-engine/src/test/java/io/confluent/ksql/function/udaf/array/CollectSetUdafTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2018 Confluent Inc.
  *
  * Licensed under the Apache License, Version 2 (the "License"); you may not use this file except in

--- a/ksql-engine/src/test/java/io/confluent/ksql/function/udaf/map/HistogramUdafTest.java
+++ b/ksql-engine/src/test/java/io/confluent/ksql/function/udaf/map/HistogramUdafTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2018 Confluent Inc.
  *
  * Licensed under the Apache License, Version 2 (the "License"); you may not use this file except in

--- a/ksql-engine/src/test/java/io/confluent/ksql/function/udaf/max/IntegerMaxKudafTest.java
+++ b/ksql-engine/src/test/java/io/confluent/ksql/function/udaf/max/IntegerMaxKudafTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2017 Confluent Inc.
  *
  * Licensed under the Apache License, Version 2 (the "License");

--- a/ksql-engine/src/test/java/io/confluent/ksql/function/udaf/min/IntegerMinKudafTest.java
+++ b/ksql-engine/src/test/java/io/confluent/ksql/function/udaf/min/IntegerMinKudafTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2017 Confluent Inc.
  *
  * Licensed under the Apache License, Version 2 (the "License");

--- a/ksql-engine/src/test/java/io/confluent/ksql/function/udaf/sum/BaseSumKudafTest.java
+++ b/ksql-engine/src/test/java/io/confluent/ksql/function/udaf/sum/BaseSumKudafTest.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2018 Confluent Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package io.confluent.ksql.function.udaf.sum;
 
 import static org.hamcrest.CoreMatchers.equalTo;

--- a/ksql-engine/src/test/java/io/confluent/ksql/function/udaf/sum/DoubleSumKudafTest.java
+++ b/ksql-engine/src/test/java/io/confluent/ksql/function/udaf/sum/DoubleSumKudafTest.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2018 Confluent Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package io.confluent.ksql.function.udaf.sum;
 
 import static org.hamcrest.CoreMatchers.instanceOf;

--- a/ksql-engine/src/test/java/io/confluent/ksql/function/udaf/sum/IntegerSumKudafTest.java
+++ b/ksql-engine/src/test/java/io/confluent/ksql/function/udaf/sum/IntegerSumKudafTest.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2018 Confluent Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package io.confluent.ksql.function.udaf.sum;
 
 import static org.hamcrest.CoreMatchers.instanceOf;

--- a/ksql-engine/src/test/java/io/confluent/ksql/function/udaf/sum/LongSumKudafTest.java
+++ b/ksql-engine/src/test/java/io/confluent/ksql/function/udaf/sum/LongSumKudafTest.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2018 Confluent Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package io.confluent.ksql.function.udaf.sum;
 
 import static org.hamcrest.CoreMatchers.instanceOf;

--- a/ksql-engine/src/test/java/io/confluent/ksql/function/udaf/topk/DoubleTopkKudafTest.java
+++ b/ksql-engine/src/test/java/io/confluent/ksql/function/udaf/topk/DoubleTopkKudafTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2017 Confluent Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/ksql-engine/src/test/java/io/confluent/ksql/function/udaf/topk/LongTopkKudafTest.java
+++ b/ksql-engine/src/test/java/io/confluent/ksql/function/udaf/topk/LongTopkKudafTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2017 Confluent Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/ksql-engine/src/test/java/io/confluent/ksql/function/udaf/topkdistinct/DoubleTopkDistinctKudafTest.java
+++ b/ksql-engine/src/test/java/io/confluent/ksql/function/udaf/topkdistinct/DoubleTopkDistinctKudafTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2017 Confluent Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/ksql-engine/src/test/java/io/confluent/ksql/function/udaf/topkdistinct/LongTopkDistinctKudafTest.java
+++ b/ksql-engine/src/test/java/io/confluent/ksql/function/udaf/topkdistinct/LongTopkDistinctKudafTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2017 Confluent Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/ksql-engine/src/test/java/io/confluent/ksql/function/udaf/topkdistinct/StringTopkDistinctKudafTest.java
+++ b/ksql-engine/src/test/java/io/confluent/ksql/function/udaf/topkdistinct/StringTopkDistinctKudafTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2017 Confluent Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/ksql-engine/src/test/java/io/confluent/ksql/function/udaf/topkdistinct/TopKDistinctTestUtils.java
+++ b/ksql-engine/src/test/java/io/confluent/ksql/function/udaf/topkdistinct/TopKDistinctTestUtils.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2018 Confluent Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package io.confluent.ksql.function.udaf.topkdistinct;
 
 import io.confluent.ksql.function.AggregateFunctionArguments;

--- a/ksql-engine/src/test/java/io/confluent/ksql/function/udf/geo/GeoDistanceKudfTest.java
+++ b/ksql-engine/src/test/java/io/confluent/ksql/function/udf/geo/GeoDistanceKudfTest.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2018 Confluent Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package io.confluent.ksql.function.udf.geo;
 
 import static org.junit.Assert.assertEquals;

--- a/ksql-engine/src/test/java/io/confluent/ksql/function/udf/json/ArrayContainsKudfTest.java
+++ b/ksql-engine/src/test/java/io/confluent/ksql/function/udf/json/ArrayContainsKudfTest.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2018 Confluent Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package io.confluent.ksql.function.udf.json;
 
 import static org.junit.Assert.assertEquals;

--- a/ksql-engine/src/test/java/io/confluent/ksql/integration/EndToEndIntegrationTest.java
+++ b/ksql-engine/src/test/java/io/confluent/ksql/integration/EndToEndIntegrationTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2017 Confluent Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/ksql-engine/src/test/java/io/confluent/ksql/integration/IntegrationTestHarness.java
+++ b/ksql-engine/src/test/java/io/confluent/ksql/integration/IntegrationTestHarness.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2018 Confluent Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package io.confluent.ksql.integration;
 
 import io.confluent.kafka.schemaregistry.client.MockSchemaRegistryClient;

--- a/ksql-engine/src/test/java/io/confluent/ksql/integration/JoinIntTest.java
+++ b/ksql-engine/src/test/java/io/confluent/ksql/integration/JoinIntTest.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2018 Confluent Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package io.confluent.ksql.integration;
 
 import io.confluent.common.utils.IntegrationTest;

--- a/ksql-engine/src/test/java/io/confluent/ksql/integration/StreamsSelectAndProjectIntTest.java
+++ b/ksql-engine/src/test/java/io/confluent/ksql/integration/StreamsSelectAndProjectIntTest.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2018 Confluent Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package io.confluent.ksql.integration;
 
 import static org.hamcrest.CoreMatchers.equalTo;

--- a/ksql-engine/src/test/java/io/confluent/ksql/integration/UdfIntTest.java
+++ b/ksql-engine/src/test/java/io/confluent/ksql/integration/UdfIntTest.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2018 Confluent Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package io.confluent.ksql.integration;
 
 import static org.hamcrest.CoreMatchers.equalTo;

--- a/ksql-engine/src/test/java/io/confluent/ksql/integration/WindowingIntTest.java
+++ b/ksql-engine/src/test/java/io/confluent/ksql/integration/WindowingIntTest.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2018 Confluent Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package io.confluent.ksql.integration;
 
 import static io.confluent.ksql.integration.IntegrationTestHarness.RESULTS_POLL_MAX_TIME_MS;

--- a/ksql-engine/src/test/java/io/confluent/ksql/physical/PhysicalPlanBuilderTest.java
+++ b/ksql-engine/src/test/java/io/confluent/ksql/physical/PhysicalPlanBuilderTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2017 Confluent Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except

--- a/ksql-engine/src/test/java/io/confluent/ksql/planner/plan/PlanTestUtil.java
+++ b/ksql-engine/src/test/java/io/confluent/ksql/planner/plan/PlanTestUtil.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2017 Confluent Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/ksql-engine/src/test/java/io/confluent/ksql/structured/KsqlValueJoinerTest.java
+++ b/ksql-engine/src/test/java/io/confluent/ksql/structured/KsqlValueJoinerTest.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2018 Confluent Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package io.confluent.ksql.structured;
 
 import static org.junit.Assert.assertEquals;

--- a/ksql-engine/src/test/java/io/confluent/ksql/structured/SchemaKGroupedTableTest.java
+++ b/ksql-engine/src/test/java/io/confluent/ksql/structured/SchemaKGroupedTableTest.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2018 Confluent Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package io.confluent.ksql.structured;
 
 import static org.hamcrest.CoreMatchers.equalTo;

--- a/ksql-engine/src/test/java/io/confluent/ksql/structured/SchemaKStreamTest.java
+++ b/ksql-engine/src/test/java/io/confluent/ksql/structured/SchemaKStreamTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2017 Confluent Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/ksql-engine/src/test/java/io/confluent/ksql/util/AvroSchemaInferenceTest.java
+++ b/ksql-engine/src/test/java/io/confluent/ksql/util/AvroSchemaInferenceTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2018 Confluent Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/ksql-engine/src/test/java/io/confluent/ksql/util/AvroUtilTest.java
+++ b/ksql-engine/src/test/java/io/confluent/ksql/util/AvroUtilTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2017 Confluent Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/ksql-engine/src/test/java/io/confluent/ksql/util/ExpressionTypeManagerTest.java
+++ b/ksql-engine/src/test/java/io/confluent/ksql/util/ExpressionTypeManagerTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2017 Confluent Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/ksql-engine/src/test/java/io/confluent/ksql/util/FakeKafkaTopicClient.java
+++ b/ksql-engine/src/test/java/io/confluent/ksql/util/FakeKafkaTopicClient.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2017 Confluent Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/ksql-engine/src/test/java/io/confluent/ksql/util/GenericRowValueTypeEnforcerTest.java
+++ b/ksql-engine/src/test/java/io/confluent/ksql/util/GenericRowValueTypeEnforcerTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2017 Confluent Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/ksql-engine/src/test/java/io/confluent/ksql/util/ItemDataProvider.java
+++ b/ksql-engine/src/test/java/io/confluent/ksql/util/ItemDataProvider.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2017 Confluent Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/ksql-engine/src/test/java/io/confluent/ksql/util/MetricsTestUtil.java
+++ b/ksql-engine/src/test/java/io/confluent/ksql/util/MetricsTestUtil.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2018 Confluent Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/ksql-engine/src/test/java/io/confluent/ksql/util/OrderDataProvider.java
+++ b/ksql-engine/src/test/java/io/confluent/ksql/util/OrderDataProvider.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2017 Confluent Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/ksql-engine/src/test/java/io/confluent/ksql/util/PageViewDataProvider.java
+++ b/ksql-engine/src/test/java/io/confluent/ksql/util/PageViewDataProvider.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2017 Confluent Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/ksql-engine/src/test/java/io/confluent/ksql/util/QueryMetadataTest.java
+++ b/ksql-engine/src/test/java/io/confluent/ksql/util/QueryMetadataTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2018 Confluent Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/ksql-engine/src/test/java/io/confluent/ksql/util/TestDataProvider.java
+++ b/ksql-engine/src/test/java/io/confluent/ksql/util/TestDataProvider.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2017 Confluent Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/ksql-engine/src/test/java/io/confluent/ksql/util/UserDataProvider.java
+++ b/ksql-engine/src/test/java/io/confluent/ksql/util/UserDataProvider.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2017 Confluent Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/ksql-engine/src/test/resources/log4j.properties
+++ b/ksql-engine/src/test/resources/log4j.properties
@@ -1,3 +1,19 @@
+#
+# Copyright 2018 Confluent Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
 log4j.rootLogger=WARN,stdout
 
 log4j.logger.io.confluent.ksql=DEBUG

--- a/ksql-etc/pom.xml
+++ b/ksql-etc/pom.xml
@@ -1,3 +1,19 @@
+<!--
+  ~ Copyright 2018 Confluent Inc.
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~ http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
 <project xmlns="http://maven.apache.org/POM/4.0.0"
  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 xsi:schemaLocation="http://maven.apache.org/POM/4.0.0

--- a/ksql-etc/src/assembly/resources.xml
+++ b/ksql-etc/src/assembly/resources.xml
@@ -1,3 +1,19 @@
+<!--
+  ~ Copyright 2018 Confluent Inc.
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~ http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
 <assembly>
   <id>resources</id>
   <formats>

--- a/ksql-examples/pom.xml
+++ b/ksql-examples/pom.xml
@@ -1,4 +1,20 @@
 <?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ Copyright 2018 Confluent Inc.
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~ http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
 <project xmlns="http://maven.apache.org/POM/4.0.0"
          xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">

--- a/ksql-examples/src/assembly/development.xml
+++ b/ksql-examples/src/assembly/development.xml
@@ -1,3 +1,19 @@
+<!--
+  ~ Copyright 2018 Confluent Inc.
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~ http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
 <assembly xmlns="http://maven.apache.org/plugins/maven-assembly-plugin/assembly/1.1.2"
           xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
           xsi:schemaLocation="http://maven.apache.org/plugins/maven-assembly-plugin/assembly/1.1.2

--- a/ksql-examples/src/assembly/package.xml
+++ b/ksql-examples/src/assembly/package.xml
@@ -1,3 +1,19 @@
+<!--
+  ~ Copyright 2018 Confluent Inc.
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~ http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
 <assembly xmlns="http://maven.apache.org/plugins/maven-assembly-plugin/assembly/1.1.2"
           xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
           xsi:schemaLocation="http://maven.apache.org/plugins/maven-assembly-plugin/assembly/1.1.2

--- a/ksql-examples/src/assembly/standalone.xml
+++ b/ksql-examples/src/assembly/standalone.xml
@@ -1,3 +1,19 @@
+<!--
+  ~ Copyright 2018 Confluent Inc.
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~ http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
 <assembly xmlns="http://maven.apache.org/plugins/maven-assembly-plugin/assembly/1.1.2"
           xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
           xsi:schemaLocation="http://maven.apache.org/plugins/maven-assembly-plugin/assembly/1.1.2

--- a/ksql-examples/src/main/java/io/confluent/ksql/datagen/AvroProducer.java
+++ b/ksql-examples/src/main/java/io/confluent/ksql/datagen/AvroProducer.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2017 Confluent Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/ksql-examples/src/main/java/io/confluent/ksql/datagen/DelimitedProducer.java
+++ b/ksql-examples/src/main/java/io/confluent/ksql/datagen/DelimitedProducer.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2017 Confluent Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/ksql-examples/src/main/java/io/confluent/ksql/datagen/JsonProducer.java
+++ b/ksql-examples/src/main/java/io/confluent/ksql/datagen/JsonProducer.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2017 Confluent Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/ksql-examples/src/main/java/io/confluent/ksql/datagen/SessionManager.java
+++ b/ksql-examples/src/main/java/io/confluent/ksql/datagen/SessionManager.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2017 Confluent Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except

--- a/ksql-examples/src/main/resources/ksql-server.properties
+++ b/ksql-examples/src/main/resources/ksql-server.properties
@@ -1,3 +1,19 @@
+#
+# Copyright 2018 Confluent Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
 # used when running bin/ksql-server <file.properties>
 # submuit
 bootstrap.servers=localhost:9092

--- a/ksql-examples/src/test/java/io/confluent/ksql/datagen/SessionManagerTest.java
+++ b/ksql-examples/src/test/java/io/confluent/ksql/datagen/SessionManagerTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2017 Confluent Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/ksql-metastore/pom.xml
+++ b/ksql-metastore/pom.xml
@@ -1,4 +1,20 @@
 <?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ Copyright 2018 Confluent Inc.
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~ http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
 <project xmlns="http://maven.apache.org/POM/4.0.0"
          xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">

--- a/ksql-metastore/src/main/java/io/confluent/ksql/metastore/KsqlStdOut.java
+++ b/ksql-metastore/src/main/java/io/confluent/ksql/metastore/KsqlStdOut.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2017 Confluent Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/ksql-metastore/src/main/java/io/confluent/ksql/metastore/KsqlStream.java
+++ b/ksql-metastore/src/main/java/io/confluent/ksql/metastore/KsqlStream.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2017 Confluent Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/ksql-metastore/src/main/java/io/confluent/ksql/metastore/KsqlTopic.java
+++ b/ksql-metastore/src/main/java/io/confluent/ksql/metastore/KsqlTopic.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2017 Confluent Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/ksql-metastore/src/main/java/io/confluent/ksql/metastore/MetaStore.java
+++ b/ksql-metastore/src/main/java/io/confluent/ksql/metastore/MetaStore.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2017 Confluent Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/ksql-metastore/src/main/java/io/confluent/ksql/metastore/MetaStoreImpl.java
+++ b/ksql-metastore/src/main/java/io/confluent/ksql/metastore/MetaStoreImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2017 Confluent Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/ksql-metastore/src/main/java/io/confluent/ksql/metastore/ReferentialIntegrityTableEntry.java
+++ b/ksql-metastore/src/main/java/io/confluent/ksql/metastore/ReferentialIntegrityTableEntry.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2017 Confluent Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/ksql-metastore/src/test/java/io/confluent/ksql/metastore/MetastoreTest.java
+++ b/ksql-metastore/src/test/java/io/confluent/ksql/metastore/MetastoreTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2017 Confluent Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/ksql-package/pom.xml
+++ b/ksql-package/pom.xml
@@ -1,4 +1,20 @@
 <?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ Copyright 2018 Confluent Inc.
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~ http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
 <project xmlns="http://maven.apache.org/POM/4.0.0"
          xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">

--- a/ksql-package/src/assembly/development.xml
+++ b/ksql-package/src/assembly/development.xml
@@ -1,3 +1,19 @@
+<!--
+  ~ Copyright 2018 Confluent Inc.
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~ http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
 <assembly xmlns="http://maven.apache.org/plugins/maven-assembly-plugin/assembly/1.1.2"
           xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
           xsi:schemaLocation="http://maven.apache.org/plugins/maven-assembly-plugin/assembly/1.1.2

--- a/ksql-package/src/assembly/package.xml
+++ b/ksql-package/src/assembly/package.xml
@@ -1,3 +1,19 @@
+<!--
+  ~ Copyright 2018 Confluent Inc.
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~ http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
 <assembly xmlns="http://maven.apache.org/plugins/maven-assembly-plugin/assembly/1.1.2"
           xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
           xsi:schemaLocation="http://maven.apache.org/plugins/maven-assembly-plugin/assembly/1.1.2

--- a/ksql-package/src/assembly/standalone.xml
+++ b/ksql-package/src/assembly/standalone.xml
@@ -1,3 +1,19 @@
+<!--
+  ~ Copyright 2018 Confluent Inc.
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~ http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
 <assembly xmlns="http://maven.apache.org/plugins/maven-assembly-plugin/assembly/1.1.2"
           xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
           xsi:schemaLocation="http://maven.apache.org/plugins/maven-assembly-plugin/assembly/1.1.2

--- a/ksql-parser/pom.xml
+++ b/ksql-parser/pom.xml
@@ -1,4 +1,20 @@
 <?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ Copyright 2018 Confluent Inc.
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~ http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
 <project xmlns="http://maven.apache.org/POM/4.0.0"
          xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">

--- a/ksql-parser/src/main/java/io/confluent/ksql/parser/CaseInsensitiveStream.java
+++ b/ksql-parser/src/main/java/io/confluent/ksql/parser/CaseInsensitiveStream.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2017 Confluent Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/ksql-parser/src/main/java/io/confluent/ksql/parser/DefaultTraversalVisitor.java
+++ b/ksql-parser/src/main/java/io/confluent/ksql/parser/DefaultTraversalVisitor.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2017 Confluent Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/ksql-parser/src/main/java/io/confluent/ksql/parser/ExpressionFormatter.java
+++ b/ksql-parser/src/main/java/io/confluent/ksql/parser/ExpressionFormatter.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2017 Confluent Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/ksql-parser/src/main/java/io/confluent/ksql/parser/KsqlParserErrorStrategy.java
+++ b/ksql-parser/src/main/java/io/confluent/ksql/parser/KsqlParserErrorStrategy.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2017 Confluent Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/ksql-parser/src/main/java/io/confluent/ksql/parser/ParsingException.java
+++ b/ksql-parser/src/main/java/io/confluent/ksql/parser/ParsingException.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2017 Confluent Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/ksql-parser/src/main/java/io/confluent/ksql/parser/SqlFormatter.java
+++ b/ksql-parser/src/main/java/io/confluent/ksql/parser/SqlFormatter.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2017 Confluent Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/ksql-parser/src/main/java/io/confluent/ksql/parser/rewrite/SetParentVisitor.java
+++ b/ksql-parser/src/main/java/io/confluent/ksql/parser/rewrite/SetParentVisitor.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2017 Confluent Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/ksql-parser/src/main/java/io/confluent/ksql/parser/rewrite/StatementRewriteForStruct.java
+++ b/ksql-parser/src/main/java/io/confluent/ksql/parser/rewrite/StatementRewriteForStruct.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2018 Confluent Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/ksql-parser/src/main/java/io/confluent/ksql/parser/tree/AbstractStreamCreateStatement.java
+++ b/ksql-parser/src/main/java/io/confluent/ksql/parser/tree/AbstractStreamCreateStatement.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2017 Confluent Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/ksql-parser/src/main/java/io/confluent/ksql/parser/tree/AbstractStreamDropStatement.java
+++ b/ksql-parser/src/main/java/io/confluent/ksql/parser/tree/AbstractStreamDropStatement.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2017 Confluent Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/ksql-parser/src/main/java/io/confluent/ksql/parser/tree/AliasedRelation.java
+++ b/ksql-parser/src/main/java/io/confluent/ksql/parser/tree/AliasedRelation.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2017 Confluent Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/ksql-parser/src/main/java/io/confluent/ksql/parser/tree/AllColumns.java
+++ b/ksql-parser/src/main/java/io/confluent/ksql/parser/tree/AllColumns.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2017 Confluent Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/ksql-parser/src/main/java/io/confluent/ksql/parser/tree/ArithmeticBinaryExpression.java
+++ b/ksql-parser/src/main/java/io/confluent/ksql/parser/tree/ArithmeticBinaryExpression.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2017 Confluent Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/ksql-parser/src/main/java/io/confluent/ksql/parser/tree/ArithmeticUnaryExpression.java
+++ b/ksql-parser/src/main/java/io/confluent/ksql/parser/tree/ArithmeticUnaryExpression.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2017 Confluent Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/ksql-parser/src/main/java/io/confluent/ksql/parser/tree/Array.java
+++ b/ksql-parser/src/main/java/io/confluent/ksql/parser/tree/Array.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2017 Confluent Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/ksql-parser/src/main/java/io/confluent/ksql/parser/tree/AstVisitor.java
+++ b/ksql-parser/src/main/java/io/confluent/ksql/parser/tree/AstVisitor.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2017 Confluent Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/ksql-parser/src/main/java/io/confluent/ksql/parser/tree/BetweenPredicate.java
+++ b/ksql-parser/src/main/java/io/confluent/ksql/parser/tree/BetweenPredicate.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2017 Confluent Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/ksql-parser/src/main/java/io/confluent/ksql/parser/tree/BinaryLiteral.java
+++ b/ksql-parser/src/main/java/io/confluent/ksql/parser/tree/BinaryLiteral.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2017 Confluent Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/ksql-parser/src/main/java/io/confluent/ksql/parser/tree/BooleanLiteral.java
+++ b/ksql-parser/src/main/java/io/confluent/ksql/parser/tree/BooleanLiteral.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2017 Confluent Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/ksql-parser/src/main/java/io/confluent/ksql/parser/tree/Cast.java
+++ b/ksql-parser/src/main/java/io/confluent/ksql/parser/tree/Cast.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2017 Confluent Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/ksql-parser/src/main/java/io/confluent/ksql/parser/tree/ComparisonExpression.java
+++ b/ksql-parser/src/main/java/io/confluent/ksql/parser/tree/ComparisonExpression.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2017 Confluent Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/ksql-parser/src/main/java/io/confluent/ksql/parser/tree/CreateAsSelect.java
+++ b/ksql-parser/src/main/java/io/confluent/ksql/parser/tree/CreateAsSelect.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2017 Confluent Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/ksql-parser/src/main/java/io/confluent/ksql/parser/tree/CreateStream.java
+++ b/ksql-parser/src/main/java/io/confluent/ksql/parser/tree/CreateStream.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2017 Confluent Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/ksql-parser/src/main/java/io/confluent/ksql/parser/tree/CreateStreamAsSelect.java
+++ b/ksql-parser/src/main/java/io/confluent/ksql/parser/tree/CreateStreamAsSelect.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2017 Confluent Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/ksql-parser/src/main/java/io/confluent/ksql/parser/tree/CreateTable.java
+++ b/ksql-parser/src/main/java/io/confluent/ksql/parser/tree/CreateTable.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2017 Confluent Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/ksql-parser/src/main/java/io/confluent/ksql/parser/tree/CreateTableAsSelect.java
+++ b/ksql-parser/src/main/java/io/confluent/ksql/parser/tree/CreateTableAsSelect.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2017 Confluent Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/ksql-parser/src/main/java/io/confluent/ksql/parser/tree/CreateView.java
+++ b/ksql-parser/src/main/java/io/confluent/ksql/parser/tree/CreateView.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2017 Confluent Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/ksql-parser/src/main/java/io/confluent/ksql/parser/tree/DdlStatement.java
+++ b/ksql-parser/src/main/java/io/confluent/ksql/parser/tree/DdlStatement.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2017 Confluent Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/ksql-parser/src/main/java/io/confluent/ksql/parser/tree/DecimalLiteral.java
+++ b/ksql-parser/src/main/java/io/confluent/ksql/parser/tree/DecimalLiteral.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2017 Confluent Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/ksql-parser/src/main/java/io/confluent/ksql/parser/tree/DefaultAstVisitor.java
+++ b/ksql-parser/src/main/java/io/confluent/ksql/parser/tree/DefaultAstVisitor.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2017 Confluent Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/ksql-parser/src/main/java/io/confluent/ksql/parser/tree/DefaultExpressionTraversalVisitor.java
+++ b/ksql-parser/src/main/java/io/confluent/ksql/parser/tree/DefaultExpressionTraversalVisitor.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2017 Confluent Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/ksql-parser/src/main/java/io/confluent/ksql/parser/tree/Delete.java
+++ b/ksql-parser/src/main/java/io/confluent/ksql/parser/tree/Delete.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2017 Confluent Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/ksql-parser/src/main/java/io/confluent/ksql/parser/tree/DereferenceExpression.java
+++ b/ksql-parser/src/main/java/io/confluent/ksql/parser/tree/DereferenceExpression.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2017 Confluent Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/ksql-parser/src/main/java/io/confluent/ksql/parser/tree/DoubleLiteral.java
+++ b/ksql-parser/src/main/java/io/confluent/ksql/parser/tree/DoubleLiteral.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2017 Confluent Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/ksql-parser/src/main/java/io/confluent/ksql/parser/tree/DropStream.java
+++ b/ksql-parser/src/main/java/io/confluent/ksql/parser/tree/DropStream.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2017 Confluent Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/ksql-parser/src/main/java/io/confluent/ksql/parser/tree/DropTable.java
+++ b/ksql-parser/src/main/java/io/confluent/ksql/parser/tree/DropTable.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2017 Confluent Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/ksql-parser/src/main/java/io/confluent/ksql/parser/tree/DropTopic.java
+++ b/ksql-parser/src/main/java/io/confluent/ksql/parser/tree/DropTopic.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2017 Confluent Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/ksql-parser/src/main/java/io/confluent/ksql/parser/tree/DropView.java
+++ b/ksql-parser/src/main/java/io/confluent/ksql/parser/tree/DropView.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2017 Confluent Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/ksql-parser/src/main/java/io/confluent/ksql/parser/tree/EmptyStatement.java
+++ b/ksql-parser/src/main/java/io/confluent/ksql/parser/tree/EmptyStatement.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2017 Confluent Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/ksql-parser/src/main/java/io/confluent/ksql/parser/tree/ExistsPredicate.java
+++ b/ksql-parser/src/main/java/io/confluent/ksql/parser/tree/ExistsPredicate.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2017 Confluent Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/ksql-parser/src/main/java/io/confluent/ksql/parser/tree/Explain.java
+++ b/ksql-parser/src/main/java/io/confluent/ksql/parser/tree/Explain.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2017 Confluent Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/ksql-parser/src/main/java/io/confluent/ksql/parser/tree/ExplainFormat.java
+++ b/ksql-parser/src/main/java/io/confluent/ksql/parser/tree/ExplainFormat.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2017 Confluent Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/ksql-parser/src/main/java/io/confluent/ksql/parser/tree/ExplainOption.java
+++ b/ksql-parser/src/main/java/io/confluent/ksql/parser/tree/ExplainOption.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2017 Confluent Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/ksql-parser/src/main/java/io/confluent/ksql/parser/tree/ExplainType.java
+++ b/ksql-parser/src/main/java/io/confluent/ksql/parser/tree/ExplainType.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2017 Confluent Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/ksql-parser/src/main/java/io/confluent/ksql/parser/tree/ExportCatalog.java
+++ b/ksql-parser/src/main/java/io/confluent/ksql/parser/tree/ExportCatalog.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2017 Confluent Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/ksql-parser/src/main/java/io/confluent/ksql/parser/tree/Expression.java
+++ b/ksql-parser/src/main/java/io/confluent/ksql/parser/tree/Expression.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2017 Confluent Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/ksql-parser/src/main/java/io/confluent/ksql/parser/tree/ExpressionRewriter.java
+++ b/ksql-parser/src/main/java/io/confluent/ksql/parser/tree/ExpressionRewriter.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2017 Confluent Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/ksql-parser/src/main/java/io/confluent/ksql/parser/tree/Extract.java
+++ b/ksql-parser/src/main/java/io/confluent/ksql/parser/tree/Extract.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2017 Confluent Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/ksql-parser/src/main/java/io/confluent/ksql/parser/tree/FieldReference.java
+++ b/ksql-parser/src/main/java/io/confluent/ksql/parser/tree/FieldReference.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2017 Confluent Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/ksql-parser/src/main/java/io/confluent/ksql/parser/tree/FrameBound.java
+++ b/ksql-parser/src/main/java/io/confluent/ksql/parser/tree/FrameBound.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2017 Confluent Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/ksql-parser/src/main/java/io/confluent/ksql/parser/tree/FunctionCall.java
+++ b/ksql-parser/src/main/java/io/confluent/ksql/parser/tree/FunctionCall.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2017 Confluent Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/ksql-parser/src/main/java/io/confluent/ksql/parser/tree/GenericLiteral.java
+++ b/ksql-parser/src/main/java/io/confluent/ksql/parser/tree/GenericLiteral.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2017 Confluent Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/ksql-parser/src/main/java/io/confluent/ksql/parser/tree/GroupBy.java
+++ b/ksql-parser/src/main/java/io/confluent/ksql/parser/tree/GroupBy.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2017 Confluent Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/ksql-parser/src/main/java/io/confluent/ksql/parser/tree/GroupingElement.java
+++ b/ksql-parser/src/main/java/io/confluent/ksql/parser/tree/GroupingElement.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2017 Confluent Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/ksql-parser/src/main/java/io/confluent/ksql/parser/tree/HoppingWindowExpression.java
+++ b/ksql-parser/src/main/java/io/confluent/ksql/parser/tree/HoppingWindowExpression.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2017 Confluent Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/ksql-parser/src/main/java/io/confluent/ksql/parser/tree/InListExpression.java
+++ b/ksql-parser/src/main/java/io/confluent/ksql/parser/tree/InListExpression.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2017 Confluent Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/ksql-parser/src/main/java/io/confluent/ksql/parser/tree/InPredicate.java
+++ b/ksql-parser/src/main/java/io/confluent/ksql/parser/tree/InPredicate.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2017 Confluent Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/ksql-parser/src/main/java/io/confluent/ksql/parser/tree/InsertInto.java
+++ b/ksql-parser/src/main/java/io/confluent/ksql/parser/tree/InsertInto.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2017 Confluent Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/ksql-parser/src/main/java/io/confluent/ksql/parser/tree/IntegerLiteral.java
+++ b/ksql-parser/src/main/java/io/confluent/ksql/parser/tree/IntegerLiteral.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2017 Confluent Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/ksql-parser/src/main/java/io/confluent/ksql/parser/tree/IntervalLiteral.java
+++ b/ksql-parser/src/main/java/io/confluent/ksql/parser/tree/IntervalLiteral.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2017 Confluent Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/ksql-parser/src/main/java/io/confluent/ksql/parser/tree/IsNotNullPredicate.java
+++ b/ksql-parser/src/main/java/io/confluent/ksql/parser/tree/IsNotNullPredicate.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2017 Confluent Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/ksql-parser/src/main/java/io/confluent/ksql/parser/tree/IsNullPredicate.java
+++ b/ksql-parser/src/main/java/io/confluent/ksql/parser/tree/IsNullPredicate.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2017 Confluent Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/ksql-parser/src/main/java/io/confluent/ksql/parser/tree/Join.java
+++ b/ksql-parser/src/main/java/io/confluent/ksql/parser/tree/Join.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2017 Confluent Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/ksql-parser/src/main/java/io/confluent/ksql/parser/tree/JoinCriteria.java
+++ b/ksql-parser/src/main/java/io/confluent/ksql/parser/tree/JoinCriteria.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2017 Confluent Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/ksql-parser/src/main/java/io/confluent/ksql/parser/tree/JoinOn.java
+++ b/ksql-parser/src/main/java/io/confluent/ksql/parser/tree/JoinOn.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2017 Confluent Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/ksql-parser/src/main/java/io/confluent/ksql/parser/tree/KsqlWindowExpression.java
+++ b/ksql-parser/src/main/java/io/confluent/ksql/parser/tree/KsqlWindowExpression.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2017 Confluent Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/ksql-parser/src/main/java/io/confluent/ksql/parser/tree/LikePredicate.java
+++ b/ksql-parser/src/main/java/io/confluent/ksql/parser/tree/LikePredicate.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2017 Confluent Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/ksql-parser/src/main/java/io/confluent/ksql/parser/tree/ListProperties.java
+++ b/ksql-parser/src/main/java/io/confluent/ksql/parser/tree/ListProperties.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2017 Confluent Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/ksql-parser/src/main/java/io/confluent/ksql/parser/tree/ListQueries.java
+++ b/ksql-parser/src/main/java/io/confluent/ksql/parser/tree/ListQueries.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2017 Confluent Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/ksql-parser/src/main/java/io/confluent/ksql/parser/tree/ListRegisteredTopics.java
+++ b/ksql-parser/src/main/java/io/confluent/ksql/parser/tree/ListRegisteredTopics.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2017 Confluent Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/ksql-parser/src/main/java/io/confluent/ksql/parser/tree/ListStreams.java
+++ b/ksql-parser/src/main/java/io/confluent/ksql/parser/tree/ListStreams.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2017 Confluent Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/ksql-parser/src/main/java/io/confluent/ksql/parser/tree/ListTables.java
+++ b/ksql-parser/src/main/java/io/confluent/ksql/parser/tree/ListTables.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2017 Confluent Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/ksql-parser/src/main/java/io/confluent/ksql/parser/tree/ListTopics.java
+++ b/ksql-parser/src/main/java/io/confluent/ksql/parser/tree/ListTopics.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2017 Confluent Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/ksql-parser/src/main/java/io/confluent/ksql/parser/tree/Literal.java
+++ b/ksql-parser/src/main/java/io/confluent/ksql/parser/tree/Literal.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2017 Confluent Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/ksql-parser/src/main/java/io/confluent/ksql/parser/tree/LoadProperties.java
+++ b/ksql-parser/src/main/java/io/confluent/ksql/parser/tree/LoadProperties.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2017 Confluent Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/ksql-parser/src/main/java/io/confluent/ksql/parser/tree/LogicalBinaryExpression.java
+++ b/ksql-parser/src/main/java/io/confluent/ksql/parser/tree/LogicalBinaryExpression.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2017 Confluent Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/ksql-parser/src/main/java/io/confluent/ksql/parser/tree/LongLiteral.java
+++ b/ksql-parser/src/main/java/io/confluent/ksql/parser/tree/LongLiteral.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2017 Confluent Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/ksql-parser/src/main/java/io/confluent/ksql/parser/tree/Map.java
+++ b/ksql-parser/src/main/java/io/confluent/ksql/parser/tree/Map.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2017 Confluent Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/ksql-parser/src/main/java/io/confluent/ksql/parser/tree/Node.java
+++ b/ksql-parser/src/main/java/io/confluent/ksql/parser/tree/Node.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2017 Confluent Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/ksql-parser/src/main/java/io/confluent/ksql/parser/tree/NodeLocation.java
+++ b/ksql-parser/src/main/java/io/confluent/ksql/parser/tree/NodeLocation.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2017 Confluent Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/ksql-parser/src/main/java/io/confluent/ksql/parser/tree/NotExpression.java
+++ b/ksql-parser/src/main/java/io/confluent/ksql/parser/tree/NotExpression.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2017 Confluent Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/ksql-parser/src/main/java/io/confluent/ksql/parser/tree/NullIfExpression.java
+++ b/ksql-parser/src/main/java/io/confluent/ksql/parser/tree/NullIfExpression.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2017 Confluent Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/ksql-parser/src/main/java/io/confluent/ksql/parser/tree/NullLiteral.java
+++ b/ksql-parser/src/main/java/io/confluent/ksql/parser/tree/NullLiteral.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2017 Confluent Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/ksql-parser/src/main/java/io/confluent/ksql/parser/tree/PrimitiveType.java
+++ b/ksql-parser/src/main/java/io/confluent/ksql/parser/tree/PrimitiveType.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2017 Confluent Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/ksql-parser/src/main/java/io/confluent/ksql/parser/tree/PrintTopic.java
+++ b/ksql-parser/src/main/java/io/confluent/ksql/parser/tree/PrintTopic.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2017 Confluent Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/ksql-parser/src/main/java/io/confluent/ksql/parser/tree/QualifiedName.java
+++ b/ksql-parser/src/main/java/io/confluent/ksql/parser/tree/QualifiedName.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2017 Confluent Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/ksql-parser/src/main/java/io/confluent/ksql/parser/tree/QualifiedNameReference.java
+++ b/ksql-parser/src/main/java/io/confluent/ksql/parser/tree/QualifiedNameReference.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2017 Confluent Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/ksql-parser/src/main/java/io/confluent/ksql/parser/tree/Query.java
+++ b/ksql-parser/src/main/java/io/confluent/ksql/parser/tree/Query.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2017 Confluent Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/ksql-parser/src/main/java/io/confluent/ksql/parser/tree/QueryBody.java
+++ b/ksql-parser/src/main/java/io/confluent/ksql/parser/tree/QueryBody.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2017 Confluent Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/ksql-parser/src/main/java/io/confluent/ksql/parser/tree/QuerySpecification.java
+++ b/ksql-parser/src/main/java/io/confluent/ksql/parser/tree/QuerySpecification.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2017 Confluent Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/ksql-parser/src/main/java/io/confluent/ksql/parser/tree/RegisterTopic.java
+++ b/ksql-parser/src/main/java/io/confluent/ksql/parser/tree/RegisterTopic.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2017 Confluent Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/ksql-parser/src/main/java/io/confluent/ksql/parser/tree/Relation.java
+++ b/ksql-parser/src/main/java/io/confluent/ksql/parser/tree/Relation.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2017 Confluent Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/ksql-parser/src/main/java/io/confluent/ksql/parser/tree/RenameColumn.java
+++ b/ksql-parser/src/main/java/io/confluent/ksql/parser/tree/RenameColumn.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2017 Confluent Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/ksql-parser/src/main/java/io/confluent/ksql/parser/tree/RenameTable.java
+++ b/ksql-parser/src/main/java/io/confluent/ksql/parser/tree/RenameTable.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2017 Confluent Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/ksql-parser/src/main/java/io/confluent/ksql/parser/tree/RunScript.java
+++ b/ksql-parser/src/main/java/io/confluent/ksql/parser/tree/RunScript.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2017 Confluent Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/ksql-parser/src/main/java/io/confluent/ksql/parser/tree/SearchedCaseExpression.java
+++ b/ksql-parser/src/main/java/io/confluent/ksql/parser/tree/SearchedCaseExpression.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2017 Confluent Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/ksql-parser/src/main/java/io/confluent/ksql/parser/tree/Select.java
+++ b/ksql-parser/src/main/java/io/confluent/ksql/parser/tree/Select.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2017 Confluent Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/ksql-parser/src/main/java/io/confluent/ksql/parser/tree/SelectItem.java
+++ b/ksql-parser/src/main/java/io/confluent/ksql/parser/tree/SelectItem.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2017 Confluent Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/ksql-parser/src/main/java/io/confluent/ksql/parser/tree/SessionWindowExpression.java
+++ b/ksql-parser/src/main/java/io/confluent/ksql/parser/tree/SessionWindowExpression.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2017 Confluent Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/ksql-parser/src/main/java/io/confluent/ksql/parser/tree/SetOperation.java
+++ b/ksql-parser/src/main/java/io/confluent/ksql/parser/tree/SetOperation.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2017 Confluent Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/ksql-parser/src/main/java/io/confluent/ksql/parser/tree/SetProperty.java
+++ b/ksql-parser/src/main/java/io/confluent/ksql/parser/tree/SetProperty.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2017 Confluent Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/ksql-parser/src/main/java/io/confluent/ksql/parser/tree/SetSession.java
+++ b/ksql-parser/src/main/java/io/confluent/ksql/parser/tree/SetSession.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2017 Confluent Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/ksql-parser/src/main/java/io/confluent/ksql/parser/tree/ShowColumns.java
+++ b/ksql-parser/src/main/java/io/confluent/ksql/parser/tree/ShowColumns.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2017 Confluent Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/ksql-parser/src/main/java/io/confluent/ksql/parser/tree/ShowCreate.java
+++ b/ksql-parser/src/main/java/io/confluent/ksql/parser/tree/ShowCreate.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2017 Confluent Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/ksql-parser/src/main/java/io/confluent/ksql/parser/tree/ShowFunctions.java
+++ b/ksql-parser/src/main/java/io/confluent/ksql/parser/tree/ShowFunctions.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2017 Confluent Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/ksql-parser/src/main/java/io/confluent/ksql/parser/tree/ShowPartitions.java
+++ b/ksql-parser/src/main/java/io/confluent/ksql/parser/tree/ShowPartitions.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2017 Confluent Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/ksql-parser/src/main/java/io/confluent/ksql/parser/tree/SimpleCaseExpression.java
+++ b/ksql-parser/src/main/java/io/confluent/ksql/parser/tree/SimpleCaseExpression.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2017 Confluent Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/ksql-parser/src/main/java/io/confluent/ksql/parser/tree/SimpleGroupBy.java
+++ b/ksql-parser/src/main/java/io/confluent/ksql/parser/tree/SimpleGroupBy.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2017 Confluent Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/ksql-parser/src/main/java/io/confluent/ksql/parser/tree/SingleColumn.java
+++ b/ksql-parser/src/main/java/io/confluent/ksql/parser/tree/SingleColumn.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2017 Confluent Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/ksql-parser/src/main/java/io/confluent/ksql/parser/tree/StackableAstVisitor.java
+++ b/ksql-parser/src/main/java/io/confluent/ksql/parser/tree/StackableAstVisitor.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2017 Confluent Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/ksql-parser/src/main/java/io/confluent/ksql/parser/tree/Statement.java
+++ b/ksql-parser/src/main/java/io/confluent/ksql/parser/tree/Statement.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2017 Confluent Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/ksql-parser/src/main/java/io/confluent/ksql/parser/tree/Statements.java
+++ b/ksql-parser/src/main/java/io/confluent/ksql/parser/tree/Statements.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2017 Confluent Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/ksql-parser/src/main/java/io/confluent/ksql/parser/tree/StringLiteral.java
+++ b/ksql-parser/src/main/java/io/confluent/ksql/parser/tree/StringLiteral.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2017 Confluent Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/ksql-parser/src/main/java/io/confluent/ksql/parser/tree/Struct.java
+++ b/ksql-parser/src/main/java/io/confluent/ksql/parser/tree/Struct.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2017 Confluent Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/ksql-parser/src/main/java/io/confluent/ksql/parser/tree/SubqueryExpression.java
+++ b/ksql-parser/src/main/java/io/confluent/ksql/parser/tree/SubqueryExpression.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2017 Confluent Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/ksql-parser/src/main/java/io/confluent/ksql/parser/tree/SubscriptExpression.java
+++ b/ksql-parser/src/main/java/io/confluent/ksql/parser/tree/SubscriptExpression.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2017 Confluent Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/ksql-parser/src/main/java/io/confluent/ksql/parser/tree/SymbolReference.java
+++ b/ksql-parser/src/main/java/io/confluent/ksql/parser/tree/SymbolReference.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2017 Confluent Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/ksql-parser/src/main/java/io/confluent/ksql/parser/tree/TableElement.java
+++ b/ksql-parser/src/main/java/io/confluent/ksql/parser/tree/TableElement.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2017 Confluent Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/ksql-parser/src/main/java/io/confluent/ksql/parser/tree/TableSubquery.java
+++ b/ksql-parser/src/main/java/io/confluent/ksql/parser/tree/TableSubquery.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2017 Confluent Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/ksql-parser/src/main/java/io/confluent/ksql/parser/tree/TerminateQuery.java
+++ b/ksql-parser/src/main/java/io/confluent/ksql/parser/tree/TerminateQuery.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2017 Confluent Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/ksql-parser/src/main/java/io/confluent/ksql/parser/tree/TimeLiteral.java
+++ b/ksql-parser/src/main/java/io/confluent/ksql/parser/tree/TimeLiteral.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2017 Confluent Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/ksql-parser/src/main/java/io/confluent/ksql/parser/tree/TimestampLiteral.java
+++ b/ksql-parser/src/main/java/io/confluent/ksql/parser/tree/TimestampLiteral.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2017 Confluent Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/ksql-parser/src/main/java/io/confluent/ksql/parser/tree/TumblingWindowExpression.java
+++ b/ksql-parser/src/main/java/io/confluent/ksql/parser/tree/TumblingWindowExpression.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2017 Confluent Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/ksql-parser/src/main/java/io/confluent/ksql/parser/tree/Type.java
+++ b/ksql-parser/src/main/java/io/confluent/ksql/parser/tree/Type.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2017 Confluent Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/ksql-parser/src/main/java/io/confluent/ksql/parser/tree/UnsetProperty.java
+++ b/ksql-parser/src/main/java/io/confluent/ksql/parser/tree/UnsetProperty.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2017 Confluent Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/ksql-parser/src/main/java/io/confluent/ksql/parser/tree/Values.java
+++ b/ksql-parser/src/main/java/io/confluent/ksql/parser/tree/Values.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2017 Confluent Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/ksql-parser/src/main/java/io/confluent/ksql/parser/tree/WhenClause.java
+++ b/ksql-parser/src/main/java/io/confluent/ksql/parser/tree/WhenClause.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2017 Confluent Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/ksql-parser/src/main/java/io/confluent/ksql/parser/tree/Window.java
+++ b/ksql-parser/src/main/java/io/confluent/ksql/parser/tree/Window.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2017 Confluent Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/ksql-parser/src/main/java/io/confluent/ksql/parser/tree/WindowExpression.java
+++ b/ksql-parser/src/main/java/io/confluent/ksql/parser/tree/WindowExpression.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2017 Confluent Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/ksql-parser/src/main/java/io/confluent/ksql/parser/tree/WindowFrame.java
+++ b/ksql-parser/src/main/java/io/confluent/ksql/parser/tree/WindowFrame.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2017 Confluent Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/ksql-parser/src/main/java/io/confluent/ksql/parser/tree/WindowName.java
+++ b/ksql-parser/src/main/java/io/confluent/ksql/parser/tree/WindowName.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2017 Confluent Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/ksql-parser/src/main/java/io/confluent/ksql/parser/tree/WithQuery.java
+++ b/ksql-parser/src/main/java/io/confluent/ksql/parser/tree/WithQuery.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2017 Confluent Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/ksql-parser/src/main/java/io/confluent/ksql/util/ParserUtil.java
+++ b/ksql-parser/src/main/java/io/confluent/ksql/util/ParserUtil.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2018 Confluent Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/ksql-parser/src/main/java/io/confluent/ksql/util/TypeUtil.java
+++ b/ksql-parser/src/main/java/io/confluent/ksql/util/TypeUtil.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2017 Confluent Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/ksql-parser/src/test/java/io/confluent/ksql/parser/tree/SessionWindowExpressionTest.java
+++ b/ksql-parser/src/test/java/io/confluent/ksql/parser/tree/SessionWindowExpressionTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2017 Confluent Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/ksql-parser/src/test/java/io/confluent/ksql/parser/tree/WithinExpressionTest.java
+++ b/ksql-parser/src/test/java/io/confluent/ksql/parser/tree/WithinExpressionTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2018 Confluent Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/ksql-parser/src/test/java/io/confluent/ksql/parser/util/ParserUtilTest.java
+++ b/ksql-parser/src/test/java/io/confluent/ksql/parser/util/ParserUtilTest.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2018 Confluent Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package io.confluent.ksql.parser.util;
 
 import io.confluent.ksql.util.ParserUtil;

--- a/ksql-parser/src/test/java/io/confluent/ksql/parser/util/TypeUtilTest.java
+++ b/ksql-parser/src/test/java/io/confluent/ksql/parser/util/TypeUtilTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2017 Confluent Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/ksql-parser/src/test/resources/log4j.properties
+++ b/ksql-parser/src/test/resources/log4j.properties
@@ -1,3 +1,19 @@
+#
+# Copyright 2018 Confluent Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
 log4j.rootLogger=WARN,stdout
 
 log4j.appender.stdout=org.apache.log4j.ConsoleAppender

--- a/ksql-rest-app/pom.xml
+++ b/ksql-rest-app/pom.xml
@@ -1,4 +1,20 @@
 <?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ Copyright 2018 Confluent Inc.
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~ http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
 <project xmlns="http://maven.apache.org/POM/4.0.0"
          xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">

--- a/ksql-rest-app/src/assembly/development.xml
+++ b/ksql-rest-app/src/assembly/development.xml
@@ -1,3 +1,19 @@
+<!--
+  ~ Copyright 2018 Confluent Inc.
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~ http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
 <assembly xmlns="http://maven.apache.org/plugins/maven-assembly-plugin/assembly/1.1.2"
           xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
           xsi:schemaLocation="http://maven.apache.org/plugins/maven-assembly-plugin/assembly/1.1.2

--- a/ksql-rest-app/src/assembly/package.xml
+++ b/ksql-rest-app/src/assembly/package.xml
@@ -1,3 +1,19 @@
+<!--
+  ~ Copyright 2018 Confluent Inc.
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~ http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
 <assembly xmlns="http://maven.apache.org/plugins/maven-assembly-plugin/assembly/1.1.2"
           xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
           xsi:schemaLocation="http://maven.apache.org/plugins/maven-assembly-plugin/assembly/1.1.2

--- a/ksql-rest-app/src/assembly/standalone.xml
+++ b/ksql-rest-app/src/assembly/standalone.xml
@@ -1,3 +1,19 @@
+<!--
+  ~ Copyright 2018 Confluent Inc.
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~ http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
 <assembly xmlns="http://maven.apache.org/plugins/maven-assembly-plugin/assembly/1.1.2"
           xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
           xsi:schemaLocation="http://maven.apache.org/plugins/maven-assembly-plugin/assembly/1.1.2

--- a/ksql-rest-app/src/main/java/io/confluent/ksql/rest/client/exception/KsqlRestClientException.java
+++ b/ksql-rest-app/src/main/java/io/confluent/ksql/rest/client/exception/KsqlRestClientException.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2017 Confluent Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/ksql-rest-app/src/main/java/io/confluent/ksql/rest/server/Executable.java
+++ b/ksql-rest-app/src/main/java/io/confluent/ksql/rest/server/Executable.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2018 Confluent Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/ksql-rest-app/src/main/java/io/confluent/ksql/rest/server/ServerOptions.java
+++ b/ksql-rest-app/src/main/java/io/confluent/ksql/rest/server/ServerOptions.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2018 Confluent Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/ksql-rest-app/src/main/java/io/confluent/ksql/rest/server/computation/Command.java
+++ b/ksql-rest-app/src/main/java/io/confluent/ksql/rest/server/computation/Command.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2017 Confluent Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/ksql-rest-app/src/main/java/io/confluent/ksql/rest/server/computation/CommandId.java
+++ b/ksql-rest-app/src/main/java/io/confluent/ksql/rest/server/computation/CommandId.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2017 Confluent Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/ksql-rest-app/src/main/java/io/confluent/ksql/rest/server/computation/CommandIdAssigner.java
+++ b/ksql-rest-app/src/main/java/io/confluent/ksql/rest/server/computation/CommandIdAssigner.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2017 Confluent Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/ksql-rest-app/src/main/java/io/confluent/ksql/rest/server/computation/CommandRunner.java
+++ b/ksql-rest-app/src/main/java/io/confluent/ksql/rest/server/computation/CommandRunner.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2017 Confluent Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/ksql-rest-app/src/main/java/io/confluent/ksql/rest/server/computation/QueuedCommand.java
+++ b/ksql-rest-app/src/main/java/io/confluent/ksql/rest/server/computation/QueuedCommand.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2018 Confluent Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/ksql-rest-app/src/main/java/io/confluent/ksql/rest/server/computation/QueuedCommandStatus.java
+++ b/ksql-rest-app/src/main/java/io/confluent/ksql/rest/server/computation/QueuedCommandStatus.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2017 Confluent Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/ksql-rest-app/src/main/java/io/confluent/ksql/rest/server/computation/ReplayableCommandQueue.java
+++ b/ksql-rest-app/src/main/java/io/confluent/ksql/rest/server/computation/ReplayableCommandQueue.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2018 Confluent Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/ksql-rest-app/src/main/java/io/confluent/ksql/rest/server/computation/StatementExecutor.java
+++ b/ksql-rest-app/src/main/java/io/confluent/ksql/rest/server/computation/StatementExecutor.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2017 Confluent Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/ksql-rest-app/src/main/java/io/confluent/ksql/rest/server/resources/KsqlExceptionMapper.java
+++ b/ksql-rest-app/src/main/java/io/confluent/ksql/rest/server/resources/KsqlExceptionMapper.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2017 Confluent Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/ksql-rest-app/src/main/java/io/confluent/ksql/rest/server/resources/KsqlResource.java
+++ b/ksql-rest-app/src/main/java/io/confluent/ksql/rest/server/resources/KsqlResource.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2017 Confluent Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/ksql-rest-app/src/main/java/io/confluent/ksql/rest/server/resources/KsqlRestException.java
+++ b/ksql-rest-app/src/main/java/io/confluent/ksql/rest/server/resources/KsqlRestException.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2018 Confluent Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/ksql-rest-app/src/main/java/io/confluent/ksql/rest/server/resources/ServerInfoResource.java
+++ b/ksql-rest-app/src/main/java/io/confluent/ksql/rest/server/resources/ServerInfoResource.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2017 Confluent Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/ksql-rest-app/src/main/java/io/confluent/ksql/rest/server/resources/StatusResource.java
+++ b/ksql-rest-app/src/main/java/io/confluent/ksql/rest/server/resources/StatusResource.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2017 Confluent Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/ksql-rest-app/src/main/java/io/confluent/ksql/rest/server/resources/streaming/Flow.java
+++ b/ksql-rest-app/src/main/java/io/confluent/ksql/rest/server/resources/streaming/Flow.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2018 Confluent Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/ksql-rest-app/src/main/java/io/confluent/ksql/rest/server/resources/streaming/PollingSubscription.java
+++ b/ksql-rest-app/src/main/java/io/confluent/ksql/rest/server/resources/streaming/PollingSubscription.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2018 Confluent Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/ksql-rest-app/src/main/java/io/confluent/ksql/rest/server/resources/streaming/PrintPublisher.java
+++ b/ksql-rest-app/src/main/java/io/confluent/ksql/rest/server/resources/streaming/PrintPublisher.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2018 Confluent Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/ksql-rest-app/src/main/java/io/confluent/ksql/rest/server/resources/streaming/StreamPublisher.java
+++ b/ksql-rest-app/src/main/java/io/confluent/ksql/rest/server/resources/streaming/StreamPublisher.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2018 Confluent Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/ksql-rest-app/src/main/java/io/confluent/ksql/rest/server/resources/streaming/StreamedQueryResource.java
+++ b/ksql-rest-app/src/main/java/io/confluent/ksql/rest/server/resources/streaming/StreamedQueryResource.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2017 Confluent Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/ksql-rest-app/src/main/java/io/confluent/ksql/rest/util/JsonMapper.java
+++ b/ksql-rest-app/src/main/java/io/confluent/ksql/rest/util/JsonMapper.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2018 Confluent Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/ksql-rest-app/src/main/resources/log4j.properties
+++ b/ksql-rest-app/src/main/resources/log4j.properties
@@ -1,3 +1,19 @@
+#
+# Copyright 2018 Confluent Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
 log4j.rootLogger=WARN,stdout
 
 log4j.logger.io.confluent.ksql=INFO

--- a/ksql-rest-app/src/test/java/io/confluent/ksql/rest/client/KsqlRestClientTest.java
+++ b/ksql-rest-app/src/test/java/io/confluent/ksql/rest/client/KsqlRestClientTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2017 Confluent Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/ksql-rest-app/src/test/java/io/confluent/ksql/rest/entity/EntityQueryIDTest.java
+++ b/ksql-rest-app/src/test/java/io/confluent/ksql/rest/entity/EntityQueryIDTest.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2018 Confluent Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package io.confluent.ksql.rest.entity;
 
 import static org.hamcrest.CoreMatchers.equalTo;

--- a/ksql-rest-app/src/test/java/io/confluent/ksql/rest/entity/KafkaTopicsListTest.java
+++ b/ksql-rest-app/src/test/java/io/confluent/ksql/rest/entity/KafkaTopicsListTest.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2018 Confluent Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package io.confluent.ksql.rest.entity;
 
 import static org.easymock.EasyMock.expect;

--- a/ksql-rest-app/src/test/java/io/confluent/ksql/rest/entity/KsqlTopicsListTest.java
+++ b/ksql-rest-app/src/test/java/io/confluent/ksql/rest/entity/KsqlTopicsListTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2018 Confluent Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/ksql-rest-app/src/test/java/io/confluent/ksql/rest/entity/QueryDescriptionTest.java
+++ b/ksql-rest-app/src/test/java/io/confluent/ksql/rest/entity/QueryDescriptionTest.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2018 Confluent Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package io.confluent.ksql.rest.entity;
 
 import static org.easymock.EasyMock.expect;

--- a/ksql-rest-app/src/test/java/io/confluent/ksql/rest/entity/SchemaDescriptionFormatTest.java
+++ b/ksql-rest-app/src/test/java/io/confluent/ksql/rest/entity/SchemaDescriptionFormatTest.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2018 Confluent Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package io.confluent.ksql.rest.entity;
 
 import static org.hamcrest.CoreMatchers.equalTo;

--- a/ksql-rest-app/src/test/java/io/confluent/ksql/rest/entity/ServerInfoTest.java
+++ b/ksql-rest-app/src/test/java/io/confluent/ksql/rest/entity/ServerInfoTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2018 Confluent Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/ksql-rest-app/src/test/java/io/confluent/ksql/rest/entity/SourceDescriptionTest.java
+++ b/ksql-rest-app/src/test/java/io/confluent/ksql/rest/entity/SourceDescriptionTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2018 Confluent Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/ksql-rest-app/src/test/java/io/confluent/ksql/rest/server/ServerOptionsTest.java
+++ b/ksql-rest-app/src/test/java/io/confluent/ksql/rest/server/ServerOptionsTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2018 Confluent Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/ksql-rest-app/src/test/java/io/confluent/ksql/rest/server/StandaloneExecutorTest.java
+++ b/ksql-rest-app/src/test/java/io/confluent/ksql/rest/server/StandaloneExecutorTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2018 Confluent Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/ksql-rest-app/src/test/java/io/confluent/ksql/rest/server/computation/CommandRunnerTest.java
+++ b/ksql-rest-app/src/test/java/io/confluent/ksql/rest/server/computation/CommandRunnerTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2017 Confluent Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/ksql-rest-app/src/test/java/io/confluent/ksql/rest/server/computation/CommandTest.java
+++ b/ksql-rest-app/src/test/java/io/confluent/ksql/rest/server/computation/CommandTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2018 Confluent Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/ksql-rest-app/src/test/java/io/confluent/ksql/rest/server/mock/MockApplication.java
+++ b/ksql-rest-app/src/test/java/io/confluent/ksql/rest/server/mock/MockApplication.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2017 Confluent Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/ksql-rest-app/src/test/java/io/confluent/ksql/rest/server/mock/MockKsqlResources.java
+++ b/ksql-rest-app/src/test/java/io/confluent/ksql/rest/server/mock/MockKsqlResources.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2017 Confluent Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/ksql-rest-app/src/test/java/io/confluent/ksql/rest/server/mock/MockStatusResource.java
+++ b/ksql-rest-app/src/test/java/io/confluent/ksql/rest/server/mock/MockStatusResource.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2017 Confluent Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/ksql-rest-app/src/test/java/io/confluent/ksql/rest/server/mock/MockStreamedQueryResource.java
+++ b/ksql-rest-app/src/test/java/io/confluent/ksql/rest/server/mock/MockStreamedQueryResource.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2017 Confluent Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/ksql-rest-app/src/test/java/io/confluent/ksql/rest/server/resources/KsqlExceptionMapperTest.java
+++ b/ksql-rest-app/src/test/java/io/confluent/ksql/rest/server/resources/KsqlExceptionMapperTest.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2018 Confluent Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package io.confluent.ksql.rest.server.resources;
 
 import static org.hamcrest.CoreMatchers.equalTo;

--- a/ksql-rest-app/src/test/java/io/confluent/ksql/rest/server/resources/StatusResourceTest.java
+++ b/ksql-rest-app/src/test/java/io/confluent/ksql/rest/server/resources/StatusResourceTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2017 Confluent Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/ksql-rest-app/src/test/java/io/confluent/ksql/rest/server/resources/streaming/PollingSubscriptionTest.java
+++ b/ksql-rest-app/src/test/java/io/confluent/ksql/rest/server/resources/streaming/PollingSubscriptionTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2018 Confluent Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/ksql-rest-app/src/test/java/io/confluent/ksql/rest/server/resources/streaming/TopicStreamTest.java
+++ b/ksql-rest-app/src/test/java/io/confluent/ksql/rest/server/resources/streaming/TopicStreamTest.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2018 Confluent Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package io.confluent.ksql.rest.server.resources.streaming;
 
 import static org.easymock.EasyMock.anyInt;

--- a/ksql-rest-app/src/test/java/io/confluent/ksql/rest/server/resources/streaming/WSQueryEndpointTest.java
+++ b/ksql-rest-app/src/test/java/io/confluent/ksql/rest/server/resources/streaming/WSQueryEndpointTest.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2018 Confluent Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package io.confluent.ksql.rest.server.resources.streaming;
 
 import static org.hamcrest.Matchers.is;

--- a/ksql-rest-app/src/test/java/io/confluent/ksql/rest/server/resources/streaming/WebSocketSubscriberTest.java
+++ b/ksql-rest-app/src/test/java/io/confluent/ksql/rest/server/resources/streaming/WebSocketSubscriberTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2018 Confluent Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/ksql-rest-app/src/test/java/io/confluent/ksql/rest/server/utils/TestUtils.java
+++ b/ksql-rest-app/src/test/java/io/confluent/ksql/rest/server/utils/TestUtils.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2017 Confluent Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/ksql-rest-app/src/test/java/io/confluent/ksql/rest/util/EntityUtilTest.java
+++ b/ksql-rest-app/src/test/java/io/confluent/ksql/rest/util/EntityUtilTest.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2018 Confluent Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package io.confluent.ksql.rest.util;
 
 import static org.hamcrest.CoreMatchers.equalTo;

--- a/ksql-serde/pom.xml
+++ b/ksql-serde/pom.xml
@@ -1,4 +1,20 @@
 <?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ Copyright 2018 Confluent Inc.
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~ http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
 <project xmlns="http://maven.apache.org/POM/4.0.0"
          xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">

--- a/ksql-serde/src/main/java/io/confluent/ksql/serde/DataSource.java
+++ b/ksql-serde/src/main/java/io/confluent/ksql/serde/DataSource.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2017 Confluent Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/ksql-serde/src/main/java/io/confluent/ksql/serde/avro/AvroDataTranslator.java
+++ b/ksql-serde/src/main/java/io/confluent/ksql/serde/avro/AvroDataTranslator.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2018 Confluent Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/ksql-serde/src/main/java/io/confluent/ksql/serde/avro/KsqlAvroTopicSerDe.java
+++ b/ksql-serde/src/main/java/io/confluent/ksql/serde/avro/KsqlAvroTopicSerDe.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2017 Confluent Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/ksql-serde/src/main/java/io/confluent/ksql/serde/connect/ConnectDataTranslator.java
+++ b/ksql-serde/src/main/java/io/confluent/ksql/serde/connect/ConnectDataTranslator.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2018 Confluent Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/ksql-serde/src/main/java/io/confluent/ksql/serde/connect/ConnectSchemaTranslator.java
+++ b/ksql-serde/src/main/java/io/confluent/ksql/serde/connect/ConnectSchemaTranslator.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2018 Confluent Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/ksql-serde/src/main/java/io/confluent/ksql/serde/connect/DataTranslator.java
+++ b/ksql-serde/src/main/java/io/confluent/ksql/serde/connect/DataTranslator.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2018 Confluent Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/ksql-serde/src/main/java/io/confluent/ksql/serde/connect/KsqlConnectDeserializer.java
+++ b/ksql-serde/src/main/java/io/confluent/ksql/serde/connect/KsqlConnectDeserializer.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2018 Confluent Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/ksql-serde/src/main/java/io/confluent/ksql/serde/connect/KsqlConnectSerializer.java
+++ b/ksql-serde/src/main/java/io/confluent/ksql/serde/connect/KsqlConnectSerializer.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2018 Confluent Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/ksql-serde/src/main/java/io/confluent/ksql/serde/delimited/KsqlDelimitedDeserializer.java
+++ b/ksql-serde/src/main/java/io/confluent/ksql/serde/delimited/KsqlDelimitedDeserializer.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2017 Confluent Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/ksql-serde/src/main/java/io/confluent/ksql/serde/delimited/KsqlDelimitedSerializer.java
+++ b/ksql-serde/src/main/java/io/confluent/ksql/serde/delimited/KsqlDelimitedSerializer.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2017 Confluent Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/ksql-serde/src/main/java/io/confluent/ksql/serde/delimited/KsqlDelimitedTopicSerDe.java
+++ b/ksql-serde/src/main/java/io/confluent/ksql/serde/delimited/KsqlDelimitedTopicSerDe.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2017 Confluent Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/ksql-serde/src/main/java/io/confluent/ksql/serde/json/KsqlJsonTopicSerDe.java
+++ b/ksql-serde/src/main/java/io/confluent/ksql/serde/json/KsqlJsonTopicSerDe.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2017 Confluent Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/ksql-serde/src/main/java/io/confluent/ksql/serde/tls/ThreadLocalCloseable.java
+++ b/ksql-serde/src/main/java/io/confluent/ksql/serde/tls/ThreadLocalCloseable.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2018 Confluent Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/ksql-serde/src/main/java/io/confluent/ksql/serde/tls/ThreadLocalDeserializer.java
+++ b/ksql-serde/src/main/java/io/confluent/ksql/serde/tls/ThreadLocalDeserializer.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2018 Confluent Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/ksql-serde/src/main/java/io/confluent/ksql/serde/tls/ThreadLocalSerializer.java
+++ b/ksql-serde/src/main/java/io/confluent/ksql/serde/tls/ThreadLocalSerializer.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2018 Confluent Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/ksql-serde/src/test/java/io/confluent/ksql/serde/avro/AvroDataTranslatorTest.java
+++ b/ksql-serde/src/test/java/io/confluent/ksql/serde/avro/AvroDataTranslatorTest.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2018 Confluent Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package io.confluent.ksql.serde.avro;
 
 import static org.hamcrest.CoreMatchers.equalTo;

--- a/ksql-serde/src/test/java/io/confluent/ksql/serde/avro/KsqlGenericRowAvroDeserializerTest.java
+++ b/ksql-serde/src/test/java/io/confluent/ksql/serde/avro/KsqlGenericRowAvroDeserializerTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2017 Confluent Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/ksql-serde/src/test/java/io/confluent/ksql/serde/connect/ConnectDataTranslatorTest.java
+++ b/ksql-serde/src/test/java/io/confluent/ksql/serde/connect/ConnectDataTranslatorTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2018 Confluent Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/ksql-serde/src/test/java/io/confluent/ksql/serde/connect/ConnectSchemaTranslatorTest.java
+++ b/ksql-serde/src/test/java/io/confluent/ksql/serde/connect/ConnectSchemaTranslatorTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2018 Confluent Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/ksql-serde/src/test/java/io/confluent/ksql/serde/delimited/KsqlDelimitedDeserializerTest.java
+++ b/ksql-serde/src/test/java/io/confluent/ksql/serde/delimited/KsqlDelimitedDeserializerTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2017 Confluent Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/ksql-serde/src/test/java/io/confluent/ksql/serde/delimited/KsqlDelimitedSerializerTest.java
+++ b/ksql-serde/src/test/java/io/confluent/ksql/serde/delimited/KsqlDelimitedSerializerTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2017 Confluent Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/ksql-serde/src/test/java/io/confluent/ksql/serde/json/KsqlJsonDeserializerTest.java
+++ b/ksql-serde/src/test/java/io/confluent/ksql/serde/json/KsqlJsonDeserializerTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2017 Confluent Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/ksql-serde/src/test/java/io/confluent/ksql/serde/json/KsqlJsonSerializerTest.java
+++ b/ksql-serde/src/test/java/io/confluent/ksql/serde/json/KsqlJsonSerializerTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2017 Confluent Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/ksql-serde/src/test/java/io/confluent/ksql/serde/tls/ThreadLocalCloseableTest.java
+++ b/ksql-serde/src/test/java/io/confluent/ksql/serde/tls/ThreadLocalCloseableTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2018 Confluent Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/ksql-serde/src/test/java/io/confluent/ksql/serde/tls/ThreadLocalDeserializerTest.java
+++ b/ksql-serde/src/test/java/io/confluent/ksql/serde/tls/ThreadLocalDeserializerTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2018 Confluent Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/ksql-serde/src/test/java/io/confluent/ksql/serde/tls/ThreadLocalSerializerTest.java
+++ b/ksql-serde/src/test/java/io/confluent/ksql/serde/tls/ThreadLocalSerializerTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2018 Confluent Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/ksql-serde/src/test/java/io/confluent/ksql/serde/util/SerdeUtilsTest.java
+++ b/ksql-serde/src/test/java/io/confluent/ksql/serde/util/SerdeUtilsTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2017 Confluent Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/ksql-tools/pom.xml
+++ b/ksql-tools/pom.xml
@@ -1,4 +1,20 @@
 <?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ Copyright 2018 Confluent Inc.
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~ http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
 <project xmlns="http://maven.apache.org/POM/4.0.0"
          xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">

--- a/ksql-tools/src/assembly/development.xml
+++ b/ksql-tools/src/assembly/development.xml
@@ -1,3 +1,19 @@
+<!--
+  ~ Copyright 2018 Confluent Inc.
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~ http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
 <assembly xmlns="http://maven.apache.org/plugins/maven-assembly-plugin/assembly/1.1.2"
           xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
           xsi:schemaLocation="http://maven.apache.org/plugins/maven-assembly-plugin/assembly/1.1.2

--- a/ksql-tools/src/assembly/package.xml
+++ b/ksql-tools/src/assembly/package.xml
@@ -1,3 +1,19 @@
+<!--
+  ~ Copyright 2018 Confluent Inc.
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~ http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
 <assembly xmlns="http://maven.apache.org/plugins/maven-assembly-plugin/assembly/1.1.2"
           xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
           xsi:schemaLocation="http://maven.apache.org/plugins/maven-assembly-plugin/assembly/1.1.2

--- a/ksql-tools/src/assembly/standalone.xml
+++ b/ksql-tools/src/assembly/standalone.xml
@@ -1,3 +1,19 @@
+<!--
+  ~ Copyright 2018 Confluent Inc.
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~ http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
 <assembly xmlns="http://maven.apache.org/plugins/maven-assembly-plugin/assembly/1.1.2"
           xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
           xsi:schemaLocation="http://maven.apache.org/plugins/maven-assembly-plugin/assembly/1.1.2

--- a/ksql-tools/src/main/java/io/confluent/ksql/tools/printmetrics/ArgumentParseException.java
+++ b/ksql-tools/src/main/java/io/confluent/ksql/tools/printmetrics/ArgumentParseException.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2018 Confluent Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/ksql-tools/src/main/java/io/confluent/ksql/tools/printmetrics/PrintMetricsException.java
+++ b/ksql-tools/src/main/java/io/confluent/ksql/tools/printmetrics/PrintMetricsException.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2018 Confluent Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/ksql-udf/pom.xml
+++ b/ksql-udf/pom.xml
@@ -1,4 +1,20 @@
 <?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ Copyright 2018 Confluent Inc.
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~ http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
 <project xmlns="http://maven.apache.org/POM/4.0.0"
          xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">

--- a/ksql-version-metrics-client/pom.xml
+++ b/ksql-version-metrics-client/pom.xml
@@ -1,4 +1,20 @@
 <?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ Copyright 2018 Confluent Inc.
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~ http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
 <project xmlns="http://maven.apache.org/POM/4.0.0"
          xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">

--- a/ksql-version-metrics-client/src/main/java/io/confluent/ksql/version/metrics/KsqlVersionChecker.java
+++ b/ksql-version-metrics-client/src/main/java/io/confluent/ksql/version/metrics/KsqlVersionChecker.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2017 Confluent Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except

--- a/ksql-version-metrics-client/src/test/java/io/confluent/ksql/version/metrics/KsqlVersionCheckerResponseHandlerTest.java
+++ b/ksql-version-metrics-client/src/test/java/io/confluent/ksql/version/metrics/KsqlVersionCheckerResponseHandlerTest.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2018 Confluent Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package io.confluent.ksql.version.metrics;
 
 import static org.easymock.EasyMock.expect;

--- a/licenses/licenses.html
+++ b/licenses/licenses.html
@@ -1,3 +1,19 @@
+<!--
+  ~ Copyright 2018 Confluent Inc.
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~ http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
 <HTML><HEAD><style>
 table {
     border-collapse: collapse;

--- a/pom.xml
+++ b/pom.xml
@@ -1,4 +1,20 @@
 <?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ Copyright 2018 Confluent Inc.
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~ http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
 <project xmlns="http://maven.apache.org/POM/4.0.0"
          xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">


### PR DESCRIPTION
### Description 
- The use of java doc style comments, i.e. `/**`, in the copyright notice at the top of the file is incorrect.
- Add missing copyrights.

This is a none-functional change to fix all the outstanding incorrect copyrights in one go.

### Testing done 
No code changed.

### Reviewer checklist
- [ ] Ensure docs are updated if necessary. (eg. if a user visible feature is being added or changed).
- [ ] Ensure relevant issues are linked (description should include text like "Fixes #<issue number>")

