### PR TITLE
Fix flaky CliTest

### DIFF
--- a/ksql-cli/src/test/java/io/confluent/ksql/cli/CliTest.java
+++ b/ksql-cli/src/test/java/io/confluent/ksql/cli/CliTest.java
@@ -41,6 +41,7 @@ import io.confluent.ksql.rest.client.KsqlRestClient;
 import io.confluent.ksql.rest.client.RestResponse;
 import io.confluent.ksql.rest.client.exception.KsqlRestClientException;
 import io.confluent.ksql.rest.entity.CommandStatus;
+import io.confluent.ksql.rest.entity.CommandStatus.Status;
 import io.confluent.ksql.rest.entity.CommandStatusEntity;
 import io.confluent.ksql.rest.entity.KsqlEntityList;
 import io.confluent.ksql.rest.entity.KsqlErrorMessage;
@@ -57,11 +58,13 @@ import io.confluent.ksql.util.TestDataProvider;
 import io.confluent.ksql.util.TopicConsumer;
 import io.confluent.ksql.util.TopicProducer;
 import java.net.URI;
+import java.util.Arrays;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.TimeUnit;
 import java.util.function.Supplier;
+import java.util.regex.Pattern;
 import javax.ws.rs.ProcessingException;
 import org.apache.kafka.clients.consumer.ConsumerConfig;
 import org.apache.kafka.common.serialization.StringDeserializer;
@@ -95,6 +98,9 @@ public class CliTest {
   private static final EmbeddedSingleNodeKafkaCluster CLUSTER = EmbeddedSingleNodeKafkaCluster.build();
   private static final String SERVER_OVERRIDE = "SERVER";
   private static final String SESSION_OVERRIDE = "SESSION";
+
+  private static final Pattern WRITE_QUERIES = Pattern
+      .compile(".*The following queries write into this source: \\[(.+)].*", Pattern.DOTALL);
 
   private static final TestKsqlRestApp REST_APP = TestKsqlRestApp
       .builder(CLUSTER::bootstrapServers)
@@ -307,9 +313,8 @@ public class CliTest {
     /* Assert Results */
     final Map<String, GenericRow> results = topicConsumer.readResults(resultKStreamName, resultSchema, expectedResults.size(), new StringDeserializer());
 
-    terminateQuery("CSAS_" + resultKStreamName + "_" + (result_stream_no - 1));
-
     dropStream(resultKStreamName);
+
     assertThat(results, equalTo(expectedResults));
   }
 
@@ -321,22 +326,26 @@ public class CliTest {
     Assert.assertThat(entityList.get(0), instanceOf(CommandStatusEntity.class));
     final CommandStatusEntity entity = (CommandStatusEntity) entityList.get(0);
     final CommandStatus status = entity.getCommandStatus();
-    assertThatEventually(
-        "",
-        () -> {
-          final RestResponse statusResponse = restClient.makeStatusRequest(entity.getCommandId().toString());
-          Assert.assertThat(statusResponse.isSuccessful(), is(true));
-          Assert.assertThat(statusResponse.get(), instanceOf(CommandStatus.class));
-          return ((CommandStatus) statusResponse.get()).getStatus();
-        },
-        anyOf(
-            is(CommandStatus.Status.SUCCESS),
-            is(CommandStatus.Status.TERMINATED),
-            is(CommandStatus.Status.ERROR)),
-        120,
-        TimeUnit.SECONDS
-    );
     Assert.assertThat(status, not(CommandStatus.Status.ERROR));
+
+    if (status.getStatus() != Status.SUCCESS) {
+      assertThatEventually(
+          "",
+          () -> {
+            final RestResponse statusResponse = restClient
+                .makeStatusRequest(entity.getCommandId().toString());
+            Assert.assertThat(statusResponse.isSuccessful(), is(true));
+            Assert.assertThat(statusResponse.get(), instanceOf(CommandStatus.class));
+            return ((CommandStatus) statusResponse.get()).getStatus();
+          },
+          anyOf(
+              is(CommandStatus.Status.SUCCESS),
+              is(CommandStatus.Status.TERMINATED),
+              is(CommandStatus.Status.ERROR)),
+          120,
+          TimeUnit.SECONDS
+      );
+    }
   }
 
   private static void terminateQuery(final String queryId) {
@@ -344,7 +353,24 @@ public class CliTest {
   }
 
   private static void dropStream(final String name) {
-    runStatement(String.format("drop stream %s;", name), restClient);
+    final String dropStatement = String.format("drop stream %s;", name);
+
+    final RestResponse response = restClient.makeKsqlRequest(dropStatement);
+    if (response.isSuccessful()) {
+      return;
+    }
+
+    final java.util.regex.Matcher matcher = WRITE_QUERIES
+        .matcher(response.getErrorMessage().getMessage());
+
+    if (!matcher.matches()) {
+      throw new RuntimeException("Failed to drop stream: " + response.getErrorMessage());
+    }
+
+    Arrays.stream(matcher.group(1).split("/w*,/w*"))
+        .forEach(CliTest::terminateQuery);
+
+    runStatement(dropStatement, restClient);
   }
 
   private void selectWithLimit(String selectQuery, final int limit, final TestResult expectedResults) {
@@ -390,6 +416,12 @@ public class CliTest {
       assertThatEventually(() -> terminal.getOutputString(), containsString("Format:JSON"));
     } finally {
       thread.interrupt();
+
+      try {
+        thread.join(0);
+      } catch (InterruptedException e) {
+        //
+      }
     }
   }
 

--- a/ksql-engine/src/test/java/io/confluent/ksql/util/TopicConsumer.java
+++ b/ksql-engine/src/test/java/io/confluent/ksql/util/TopicConsumer.java
@@ -28,6 +28,7 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Properties;
+import java.util.UUID;
 import org.apache.kafka.clients.consumer.ConsumerConfig;
 import org.apache.kafka.clients.consumer.ConsumerRecord;
 import org.apache.kafka.clients.consumer.KafkaConsumer;
@@ -55,7 +56,7 @@ public class TopicConsumer {
 
     final Properties consumerConfig = new Properties();
     consumerConfig.putAll(cluster.getClientProperties());
-    consumerConfig.put(ConsumerConfig.GROUP_ID_CONFIG, "filter-integration-test-standard-consumer");
+    consumerConfig.put(ConsumerConfig.GROUP_ID_CONFIG, UUID.randomUUID().toString());
     consumerConfig.put(ConsumerConfig.AUTO_OFFSET_RESET_CONFIG, "earliest");
 
     try (KafkaConsumer<K, V> consumer =


### PR DESCRIPTION
### Description 
A couple of issues were causing this test to be unstable:
- `testPrint` wasn't ensuring its test thread was stopped, so it could continue to output during other tests.
- terminateQuery wasn't reliable.  Code now parses the error message to get query ids. (https://github.com/confluentinc/ksql/issues/2177 would help here). 
- Consumers used by different tests were using the same consumer group, which led to issues with timeouts and general instability in the group.

I'll look to cherry pick these fixes into 5.1. and 5.0

### Testing done 
Test only change.

### Reviewer checklist
- [ ] Ensure docs are updated if necessary. (eg. if a user visible feature is being added or changed).
- [ ] Ensure relevant issues are linked (description should include text like "Fixes #<issue number>")

