### PR TITLE
5.0.x fix flaky

### DIFF
--- a/ksql-rest-app/src/test/java/io/confluent/ksql/rest/server/mock/MockApplication.java
+++ b/ksql-rest-app/src/test/java/io/confluent/ksql/rest/server/mock/MockApplication.java
@@ -17,6 +17,7 @@
 package io.confluent.ksql.rest.server.mock;
 
 import io.confluent.ksql.rest.server.KsqlRestConfig;
+import io.confluent.ksql.rest.server.mock.MockStreamedQueryResource.TestStreamWriter;
 import io.confluent.rest.Application;
 import javax.ws.rs.core.Configurable;
 import org.glassfish.jersey.server.ServerProperties;
@@ -40,5 +41,23 @@ public class MockApplication extends Application<KsqlRestConfig> {
     configurable.register(streamedQueryResource);
     configurable.register(new MockStatusResource());
     configurable.property(ServerProperties.OUTBOUND_CONTENT_LENGTH_BUFFER, 0);
+  }
+
+  @Override
+  public void stop() {
+    for (TestStreamWriter testStreamWriter : streamedQueryResource.getWriters()) {
+      try {
+        testStreamWriter.finished();
+      } catch (final Exception e) {
+        System.err.println("Failed to finish stream writer");
+        e.printStackTrace(System.err);
+      }
+    }
+    try {
+      super.stop();
+    } catch (final Exception e) {
+      System.err.println("Failed to stop app");
+      e.printStackTrace(System.err);
+    }
   }
 }

--- a/ksql-rest-app/src/test/java/io/confluent/ksql/rest/server/resources/KsqlResourceTest.java
+++ b/ksql-rest-app/src/test/java/io/confluent/ksql/rest/server/resources/KsqlResourceTest.java
@@ -75,7 +75,6 @@ import io.confluent.ksql.rest.server.computation.CommandStore;
 import io.confluent.ksql.rest.server.computation.StatementExecutor;
 import io.confluent.ksql.rest.server.utils.TestUtils;
 import io.confluent.ksql.rest.util.EntityUtil;
-import io.confluent.ksql.schema.registry.MockSchemaRegistryClientFactory;
 import io.confluent.ksql.serde.DataSource;
 import io.confluent.ksql.serde.json.KsqlJsonTopicSerDe;
 import io.confluent.ksql.util.FakeKafkaTopicClient;
@@ -94,7 +93,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.Properties;
 import java.util.concurrent.Future;
-import java.util.function.Supplier;
 import java.util.stream.Collectors;
 import javax.ws.rs.core.Response;
 import org.apache.commons.lang3.concurrent.ConcurrentUtils;
@@ -110,13 +108,18 @@ import org.apache.kafka.connect.data.SchemaBuilder;
 import org.easymock.EasyMock;
 import org.junit.After;
 import org.junit.Before;
+import org.junit.Rule;
 import org.junit.Test;
+import org.junit.rules.Timeout;
 
 public class KsqlResourceTest {
   private KsqlConfig ksqlConfig;
   private KsqlRestConfig ksqlRestConfig;
   private FakeKafkaTopicClient kafkaTopicClient;
   private KsqlEngine ksqlEngine;
+
+  @Rule
+  public final Timeout timeout = Timeout.seconds(30);
 
   @Before
   public void setUp() throws IOException, RestClientException {


### PR DESCRIPTION
### Description 
Related to PR #2184, which fixes the same thing in master. This is a more minimal change to fix a flaky: `KsqlRestClientTest.shouldInterruptScannerOnClose`.

The PR also makes a change to `MockApplication` to swallow any exceptions while stopping. This is because it occasionally throws a `TimeoutException`.  As it is test only code and a quick debug didn't flag up anything obvious, I've changed the code to swallow the issue.

### Testing done 
Test only change.  Ran it over a thousand times without failure.

### Reviewer checklist
- [ ] Ensure docs are updated if necessary. (eg. if a user visible feature is being added or changed).
- [ ] Ensure relevant issues are linked (description should include text like "Fixes #<issue number>")

