### PR TITLE
Nick's print ctrl-c message to interrupt streaming results

### DIFF
--- a/ksql-cli/src/main/java/io/confluent/ksql/cli/console/Console.java
+++ b/ksql-cli/src/main/java/io/confluent/ksql/cli/console/Console.java
@@ -20,6 +20,7 @@ import com.fasterxml.jackson.core.JsonGenerator;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.common.collect.Maps;
 import io.confluent.ksql.GenericRow;
+import io.confluent.ksql.cli.console.KsqlTerminal.StatusClosable;
 import io.confluent.ksql.cli.console.cmd.CliCommandRegisterUtil;
 import io.confluent.ksql.cli.console.cmd.CliSpecificCommand;
 import io.confluent.ksql.cli.console.table.Table;
@@ -208,9 +209,9 @@ public final class Console implements Closeable {
     terminal.clearScreen();
   }
 
-  public abstract void printHowToInterruptMsg();
-
-  public abstract void clearStatusMsg();
+  public StatusClosable setStatusMessage(final String message) {
+    return terminal.setStatusMessage(message);
+  }
 
   public void handle(final Signal signal, final SignalHandler signalHandler) {
     terminal.handle(signal, signalHandler);

--- a/ksql-cli/src/main/java/io/confluent/ksql/cli/console/JLineTerminal.java
+++ b/ksql-cli/src/main/java/io/confluent/ksql/cli/console/JLineTerminal.java
@@ -20,28 +20,42 @@ import java.io.IOException;
 import java.io.PrintWriter;
 import java.nio.file.Path;
 import java.util.ArrayList;
-import java.util.Arrays;
+import java.util.Collections;
 import java.util.List;
+import java.util.Objects;
+import java.util.function.Function;
 import java.util.function.Predicate;
 import org.jline.terminal.Terminal;
 import org.jline.terminal.TerminalBuilder;
 import org.jline.utils.AttributedString;
-import org.jline.utils.AttributedStringBuilder;
 import org.jline.utils.AttributedStyle;
 import org.jline.utils.InfoCmp;
 import org.jline.utils.Status;
 
 class JLineTerminal implements KsqlTerminal {
 
+  private static final AttributedString DEFAULT_STATUS_MSG =
+      new AttributedString("", AttributedStyle.DEFAULT);
+
   private final org.jline.terminal.Terminal terminal;
   private final JLineReader lineReader;
+  private final Function<Terminal, Status> statusFactory;
 
   JLineTerminal(
       final Predicate<String> cliLinePredicate,
       final Path historyFilePath
   ) {
+    this(cliLinePredicate, historyFilePath, Status::getStatus);
+  }
+
+  JLineTerminal(
+      final Predicate<String> cliLinePredicate,
+      final Path historyFilePath,
+      final Function<Terminal, Status> statusFactory
+  ) {
     this.terminal = buildTerminal();
     this.lineReader = new JLineReader(this.terminal, historyFilePath, cliLinePredicate);
+    this.statusFactory = Objects.requireNonNull(statusFactory, "statusFactory");
   }
 
   @Override
@@ -87,22 +101,6 @@ class JLineTerminal implements KsqlTerminal {
   }
 
   @Override
-  public void printHowToInterruptMsg() {
-    final Status statusBar = Status.getStatus(terminal);
-    final AttributedStringBuilder sb = new AttributedStringBuilder();
-    sb.style(AttributedStyle.INVERSE);
-    sb.append("Press CTRL-C to interrupt");
-    statusBar.update(Arrays.asList(sb.toAttributedString()));
-  }
-
-  @Override
-  public void clearStatusMsg() {
-    final Status statusBar = Status.getStatus(terminal);
-    statusBar.update(Arrays.asList(new AttributedString("", AttributedStyle.DEFAULT)));
-    statusBar.reset();
-    statusBar.redraw();
-  }
-
   public List<HistoryEntry> getHistory() {
     final List<HistoryEntry> history = new ArrayList<>();
     lineReader.getHistory()
@@ -110,10 +108,20 @@ class JLineTerminal implements KsqlTerminal {
     return history;
   }
 
+  @Override
+  public StatusClosable setStatusMessage(final String message) {
+    updateStatusBar(new AttributedString(message, AttributedStyle.INVERSE));
+    return () -> updateStatusBar(DEFAULT_STATUS_MSG);
+  }
+
+  private void updateStatusBar(final AttributedString message) {
+    final Status statusBar = statusFactory.apply(terminal);
+    statusBar.update(Collections.singletonList(message));
+  }
+
   private static Terminal buildTerminal() {
-    final Terminal terminal;
     try {
-      terminal = TerminalBuilder.builder().system(true).build();
+      final Terminal terminal = TerminalBuilder.builder().system(true).build();
 
       // Ignore ^C when not reading a line
       terminal.handle(Terminal.Signal.INT, Terminal.SignalHandler.SIG_IGN);

--- a/ksql-cli/src/main/java/io/confluent/ksql/cli/console/KsqlTerminal.java
+++ b/ksql-cli/src/main/java/io/confluent/ksql/cli/console/KsqlTerminal.java
@@ -16,6 +16,7 @@
 
 package io.confluent.ksql.cli.console;
 
+import java.io.Closeable;
 import java.io.PrintWriter;
 import java.util.List;
 import java.util.Objects;
@@ -36,6 +37,22 @@ public interface KsqlTerminal {
   List<HistoryEntry> getHistory();
 
   void handle(Terminal.Signal signal, Terminal.SignalHandler signalHandler);
+
+  @FunctionalInterface
+  interface StatusClosable extends Closeable {
+
+    void close();
+  }
+
+  /**
+   * Set a status message in the terminal.
+   *
+   * <p>The message is removed once the returned {@link StatusClosable} is closed.
+   *
+   * @param message the message to display
+   * @return the closable that will remove the status message.
+   */
+  StatusClosable setStatusMessage(String message);
 
   void close();
 

--- a/ksql-cli/src/test/java/io/confluent/ksql/TestTerminal.java
+++ b/ksql-cli/src/test/java/io/confluent/ksql/TestTerminal.java
@@ -19,6 +19,7 @@ package io.confluent.ksql;
 import io.confluent.ksql.cli.console.KsqlTerminal;
 import java.io.PrintWriter;
 import java.io.StringWriter;
+import java.util.ArrayList;
 import java.util.List;
 import java.util.function.Supplier;
 import org.jline.terminal.Terminal;
@@ -80,12 +81,7 @@ public class TestTerminal implements KsqlTerminal {
   }
 
   @Override
-  public void printHowToInterruptMsg() {
-    // Ignore
-  }
-
-  @Override
-  public void clearStatusMsg() {
-    // Ignore
+  public StatusClosable setStatusMessage(final String message) {
+    return () -> {};
   }
 }

--- a/ksql-cli/src/test/java/io/confluent/ksql/cli/console/JLineTerminalTest.java
+++ b/ksql-cli/src/test/java/io/confluent/ksql/cli/console/JLineTerminalTest.java
@@ -1,0 +1,82 @@
+/*
+ * Copyright 2018 Confluent Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.confluent.ksql.cli.console;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.clearInvocations;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.google.common.collect.ImmutableList;
+import io.confluent.ksql.cli.console.KsqlTerminal.StatusClosable;
+import java.io.File;
+import java.util.function.Function;
+import java.util.function.Predicate;
+import org.apache.kafka.test.TestUtils;
+import org.jline.terminal.Terminal;
+import org.jline.utils.AttributedString;
+import org.jline.utils.AttributedStyle;
+import org.jline.utils.Status;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnitRunner;
+
+@RunWith(MockitoJUnitRunner.class)
+public class JLineTerminalTest {
+
+  @Mock
+  private Predicate<String> cliLinePredicate;
+  @Mock
+  private Function<Terminal, Status> statusFactory;
+  @Mock
+  private Status statusBar;
+  private JLineTerminal terminal;
+
+  @Before
+  public void setUp() throws Exception {
+    when(statusFactory.apply(any())).thenReturn(statusBar);
+
+    final File historyFile = TestUtils.tempFile();
+    terminal = new JLineTerminal(cliLinePredicate, historyFile.toPath(), statusFactory);
+  }
+
+  @Test
+  public void shouldSetStatusMessage() {
+    // When:
+    terminal.setStatusMessage("test message");
+
+    // Then:
+    verify(statusBar)
+        .update(ImmutableList.of(new AttributedString("test message", AttributedStyle.INVERSE)));
+  }
+
+  @Test
+  public void shouldResetStatusMessage() {
+    // Given:
+    final StatusClosable closable = terminal.setStatusMessage("test message");
+    clearInvocations(statusBar);
+
+    // When:
+    closable.close();
+
+    // Then:
+    verify(statusBar)
+        .update(ImmutableList.of(new AttributedString("", AttributedStyle.DEFAULT)));
+  }
+}


### PR DESCRIPTION
### Description 
This PR replaces https://github.com/confluentinc/ksql/pull/2108.  It's just nick's changes with:
- the merge issues resolved
- a slight refactor to make it easier to ensure the status message is always reset
- a test case or two.

### Testing done 
Tests added + manual

### Reviewer checklist
- [ ] Ensure docs are updated if necessary. (eg. if a user visible feature is being added or changed).
- [ ] Ensure relevant issues are linked (description should include text like "Fixes #<issue number>")

