### PR TITLE
More improvements to the way CLI handles comments in multi-line statements

### DIFF
--- a/ksql-cli/src/main/java/io/confluent/ksql/cli/console/JLineReader.java
+++ b/ksql-cli/src/main/java/io/confluent/ksql/cli/console/JLineReader.java
@@ -68,9 +68,7 @@ public class JLineReader implements io.confluent.ksql.cli.console.LineReader {
 
   @Override
   public String readLine() {
-    final String line = lineReader
-        .readLine(prompt)
-        .replace("\n", " ");
+    final String line = lineReader.readLine(prompt);
 
     addToHistory(line);
     return line;

--- a/ksql-cli/src/main/java/io/confluent/ksql/cli/console/KsqlLineParser.java
+++ b/ksql-cli/src/main/java/io/confluent/ksql/cli/console/KsqlLineParser.java
@@ -44,16 +44,16 @@ final class KsqlLineParser implements Parser {
   public ParsedLine parse(final String line, final int cursor, final ParseContext context) {
     final ParsedLine parsed = delegate.parse(line, cursor, context);
 
-    if (cliCmdPredicate.test(line)) {
-      return parsed;
-    }
-
     if (context != ParseContext.ACCEPT_LINE) {
       return parsed;
     }
 
     final String bare = CommentStripper.strip(parsed.line());
     if (bare.isEmpty()) {
+      return parsed;
+    }
+
+    if (cliCmdPredicate.test(bare)) {
       return parsed;
     }
 

--- a/ksql-cli/src/test/java/io/confluent/ksql/cli/console/CommentStripperTest.java
+++ b/ksql-cli/src/test/java/io/confluent/ksql/cli/console/CommentStripperTest.java
@@ -106,6 +106,7 @@ public class CommentStripperTest {
     assertThat(CommentStripper.strip(line), is("'this isn''t a comment -- the first quote isn''t closed'"));
     assertThat(CommentStripper.strip(line2), is("'''this isn''t a comment -- the first quote isn''t closed'"));
   }
+
   @Test
   public void shouldCorrectHandleEscapedDoubleQuotes() {
     // Given:
@@ -115,5 +116,25 @@ public class CommentStripperTest {
     // Then:
     assertThat(CommentStripper.strip(line), is("\"this isn''t a comment -- the first quote isn''t closed\""));
     assertThat(CommentStripper.strip(line2), is("\"\"\"this isn''t a comment -- the first quote isn''t closed\""));
+  }
+
+  @Test
+  public void shouldHandleMultiLine() {
+    // Given:
+    final String line = "some multi-line\n"
+        + "statement";
+
+    // Then:
+    assertThat(CommentStripper.strip(line), is("some multi-line\nstatement"));
+  }
+
+  @Test
+  public void shouldTerminateCommentAtNewLine() {
+    // Given:
+    final String line = "some multi-line -- this is a comment\n"
+        + "statement";
+
+    // Then:
+    assertThat(CommentStripper.strip(line), is("some multi-line\nstatement"));
   }
 }

--- a/ksql-parser/src/test/java/io/confluent/ksql/parser/KsqlParserTest.java
+++ b/ksql-parser/src/test/java/io/confluent/ksql/parser/KsqlParserTest.java
@@ -1211,4 +1211,29 @@ public class KsqlParserTest {
     assertThat(statements, hasSize(1));
     assertThat(statements.get(0).getStatement(), is(instanceOf(ListStreams.class)));
   }
+
+  @Test
+  public void shouldParseMultiLineWithInlineComments() {
+    final String statementString =
+        "SHOW -- inline comment\n"
+        + "STREAMS;";
+
+    final List<PreparedStatement<?>> statements =  KSQL_PARSER.buildAst(statementString, metaStore);
+
+    assertThat(statements, hasSize(1));
+    assertThat(statements.get(0).getStatement(), is(instanceOf(ListStreams.class)));
+  }
+
+  @Test
+  public void shouldParseMultiLineWithInlineBracketedComments() {
+    final String statementString =
+        "SHOW /* inline\n"
+            + "comment */\n"
+            + "STREAMS;";
+
+    final List<PreparedStatement<?>> statements =  KSQL_PARSER.buildAst(statementString, metaStore);
+
+    assertThat(statements, hasSize(1));
+    assertThat(statements.get(0).getStatement(), is(instanceOf(ListStreams.class)));
+  }
 }


### PR DESCRIPTION
### Description 
Following on from @vcrfxia insights in the last pr: https://github.com/confluentinc/ksql/pull/2214#pullrequestreview-180072120, this PR adds more improvements to the way the CLI handles inline comments.

It can now handle something like this example being cut and paste into the CLI:

```sql
SELECT -- a comment
   -- another comment
   foo, -- cos we really like comments
   -- can't get enough of 'em
   bar -- love'em
   -- best thing since sliced bread
FROM -- better than fake news
x;
```

To support I've enhanced the `CommentStripper` to handle multi-line statements with embedded comments.

I've also had to switch the `JLineReader` to _not_ replace new lines with spaces. So if the input contains multiple lines, so does the output. But the parser is fine with this.  History also still works, though a single history item can now span multiple lines, e.g. running:

```
ksql>show
> -- awesome, another comment.
> streams;
```

Works, and then you can list history, which shows the command over multiple lines:

```
ksql> history
1: show
-- awesome, another comment.
streams;
```

### Testing done 
Added appropriate unit test and manual sanity testing.

### Reviewer checklist
- [ ] Ensure docs are updated if necessary. (eg. if a user visible feature is being added or changed).
- [ ] Ensure relevant issues are linked (description should include text like "Fixes #<issue number>")

