### PR TITLE
Add null checks to min, max, and count UDAFs

### DIFF
--- a/docs/developer-guide/syntax-reference.rst
+++ b/docs/developer-guide/syntax-reference.rst
@@ -242,7 +242,7 @@ The WITH clause supports the following properties:
 | WINDOW_TYPE             | By default, the topic is assumed to contain non-windowed data. If the data is windowed,    |
 |                         | i.e. was created using KSQL using a query that contains a ``WINDOW`` clause, then the      |
 |                         | ``WINDOW_TYPE`` property can be used to provide the window type. Valid values are          |
-|                         | ``SESSION``, ``HOPPING`, and ``TUMBLING``.                                                  |
+|                         | ``SESSION``, ``HOPPING`, and ``TUMBLING``.                                                 |
 +-------------------------+--------------------------------------------------------------------------------------------+
 
 
@@ -345,7 +345,7 @@ The WITH clause supports the following properties:
 | WINDOW_TYPE             | By default, the topic is assumed to contain non-windowed data. If the data is windowed,    |
 |                         | i.e. was created using KSQL using a query that contains a ``WINDOW`` clause, then the      |
 |                         | ``WINDOW_TYPE`` property can be used to provide the window type. Valid values are          |
-|                         | ``SESSION``, ``HOPPING`, and ``TUMBLING``.                                                  |
+|                         | ``SESSION``, ``HOPPING`, and ``TUMBLING``.                                                 |
 +-------------------------+--------------------------------------------------------------------------------------------+
 
 .. include:: ../includes/ksql-includes.rst
@@ -1278,7 +1278,7 @@ Scalar functions
 Aggregate functions
 ===================
 
-+------------------------+---------------------------+----------------------------------------------------------------------------------+
++------------------------+---------------------------+------------+---------------------------------------------------------------------+
 | Function               | Example                   | Input Type | Description                                                         |
 +========================+===========================+============+=====================================================================+
 | COLLECT_LIST           | ``COLLECT_LIST(col1)``    | Stream,    | Return an array containing all the values of ``col1`` from each     |
@@ -1307,8 +1307,10 @@ Aggregate functions
 |                        |                           |            | late-arriving record, then the records from the second window in    |
 |                        |                           |            | the order they were originally processed.                           |
 +------------------------+---------------------------+------------+---------------------------------------------------------------------+
-| COUNT                  | ``COUNT(col1)``           | Stream,    | Count the number of rows                                            |
-|                        |                           | Table      |                                                                     |
+| COUNT                  | ``COUNT(col1)``,          | Stream,    | Count the number of rows. When ``col1`` is specified, the count     |
+|                        | ``COUNT(*)``              | Table      | returned will be the number of rows where ``col1`` is non-null.     |
+|                        |                           |            | When ``*`` is specified, the count returned will be the total       |
+|                        |                           |            | number of rows.                                                     |
 +------------------------+---------------------------+------------+---------------------------------------------------------------------+
 | HISTOGRAM              | ``HISTOGRAM(col1)``       | Stream,    | Return a map containing the distinct String values of ``col1``      |
 |                        |                           | Table      | mapped to the number of times each one occurs for the given window. |
@@ -1322,16 +1324,20 @@ Aggregate functions
 |                        |                           |            | late-arriving record, then the records from the second window in    |
 |                        |                           |            | the order they were originally processed.                           |
 +------------------------+---------------------------+------------+---------------------------------------------------------------------+
-| MAX                    | ``MAX(col1)``             | Stream     | Return the maximum value for a given column and window              |
+| MAX                    | ``MAX(col1)``             | Stream     | Return the maximum value for a given column and window.             |
+|                        |                           |            | Note: rows where ``col1`` is null will be ignored.                  |
 +------------------------+---------------------------+------------+---------------------------------------------------------------------+
-| MIN                    | ``MIN(col1)``             | Stream     | Return the minimum value for a given column and window              |
+| MIN                    | ``MIN(col1)``             | Stream     | Return the minimum value for a given column and window.             |
+|                        |                           |            | Note: rows where ``col1`` is null will be ignored.                  |
 +------------------------+---------------------------+------------+---------------------------------------------------------------------+
 | SUM                    | ``SUM(col1)``             | Stream,    | Sums the column values                                              |
-|                        |                           | Table      |                                                                     |
+|                        |                           | Table      | Note: rows where ``col1`` is null will be ignored.                  |
 +------------------------+---------------------------+------------+---------------------------------------------------------------------+
 | TOPK                   | ``TOPK(col1, k)``         | Stream     | Return the Top *K* values for the given column and window           |
+|                        |                           |            | Note: rows where ``col1`` is null will be ignored.                  |
 +------------------------+---------------------------+------------+---------------------------------------------------------------------+
 | TOPKDISTINCT           | ``TOPKDISTINCT(col1, k)`` | Stream     | Return the distinct Top *K* values for the given column and window  |
+|                        |                           |            | Note: rows where ``col1`` is null will be ignored.                  |
 +------------------------+---------------------------+------------+---------------------------------------------------------------------+
 | WindowStart            | ``WindowStart()``         | Stream     | Extract the start time of the current window, in milliseconds.      |
 |                        |                           | Table      | If the query is not windowed the function will return null.         |

--- a/ksql-engine/src/main/java/io/confluent/ksql/function/udaf/count/CountKudaf.java
+++ b/ksql-engine/src/main/java/io/confluent/ksql/function/udaf/count/CountKudaf.java
@@ -37,6 +37,9 @@ public class CountKudaf
 
   @Override
   public Long aggregate(final Object currentValue, final Long aggregateValue) {
+    if (currentValue == null) {
+      return aggregateValue;
+    }
     return aggregateValue + 1;
   }
 
@@ -47,6 +50,9 @@ public class CountKudaf
 
   @Override
   public Long undo(final Object valueToUndo, final Long aggregateValue) {
+    if (valueToUndo == null) {
+      return aggregateValue;
+    }
     return aggregateValue - 1;
   }
 

--- a/ksql-engine/src/main/java/io/confluent/ksql/function/udaf/max/DoubleMaxKudaf.java
+++ b/ksql-engine/src/main/java/io/confluent/ksql/function/udaf/max/DoubleMaxKudaf.java
@@ -35,20 +35,15 @@ public class DoubleMaxKudaf extends BaseAggregateFunction<Double, Double> {
 
   @Override
   public Double aggregate(final Double currentValue, final Double aggregateValue) {
-    if (currentValue > aggregateValue) {
-      return currentValue;
+    if (currentValue == null) {
+      return aggregateValue;
     }
-    return aggregateValue;
+    return Math.max(currentValue, aggregateValue);
   }
 
   @Override
   public Merger<String, Double> getMerger() {
-    return (aggKey, aggOne, aggTwo) -> {
-      if (aggOne > aggTwo) {
-        return aggOne;
-      }
-      return aggTwo;
-    };
+    return (aggKey, aggOne, aggTwo) -> Math.max(aggOne, aggTwo);
   }
 
   @Override

--- a/ksql-engine/src/main/java/io/confluent/ksql/function/udaf/max/LongMaxKudaf.java
+++ b/ksql-engine/src/main/java/io/confluent/ksql/function/udaf/max/LongMaxKudaf.java
@@ -34,20 +34,15 @@ public class LongMaxKudaf extends BaseAggregateFunction<Long, Long> {
 
   @Override
   public Long aggregate(final Long currentValue, final Long aggregateValue) {
-    if (currentValue > aggregateValue) {
-      return currentValue;
+    if (currentValue == null) {
+      return aggregateValue;
     }
-    return aggregateValue;
+    return Math.max(currentValue, aggregateValue);
   }
 
   @Override
   public Merger<String, Long> getMerger() {
-    return (aggKey, aggOne, aggTwo) -> {
-      if (aggOne > aggTwo) {
-        return aggOne;
-      }
-      return aggTwo;
-    };
+    return (aggKey, aggOne, aggTwo) -> Math.max(aggOne, aggTwo);
   }
 
   @Override

--- a/ksql-engine/src/main/java/io/confluent/ksql/function/udaf/min/DoubleMinKudaf.java
+++ b/ksql-engine/src/main/java/io/confluent/ksql/function/udaf/min/DoubleMinKudaf.java
@@ -34,20 +34,15 @@ public class DoubleMinKudaf extends BaseAggregateFunction<Double, Double> {
 
   @Override
   public Double aggregate(final Double currentValue, final Double aggregateValue) {
-    if (currentValue < aggregateValue) {
-      return currentValue;
+    if (currentValue == null) {
+      return aggregateValue;
     }
-    return aggregateValue;
+    return Math.min(currentValue, aggregateValue);
   }
 
   @Override
   public Merger<String, Double> getMerger() {
-    return (aggKey, aggOne, aggTwo) -> {
-      if (aggOne < aggTwo) {
-        return aggOne;
-      }
-      return aggTwo;
-    };
+    return (aggKey, aggOne, aggTwo) -> Math.min(aggOne, aggTwo);
   }
 
   @Override

--- a/ksql-engine/src/main/java/io/confluent/ksql/function/udaf/min/LongMinKudaf.java
+++ b/ksql-engine/src/main/java/io/confluent/ksql/function/udaf/min/LongMinKudaf.java
@@ -34,20 +34,15 @@ public class LongMinKudaf extends BaseAggregateFunction<Long, Long> {
 
   @Override
   public Long aggregate(final Long currentValue, final Long aggregateValue) {
-    if (currentValue < aggregateValue) {
-      return currentValue;
+    if (currentValue == null) {
+      return aggregateValue;
     }
-    return aggregateValue;
+    return Math.min(currentValue, aggregateValue);
   }
 
   @Override
   public Merger<String, Long> getMerger() {
-    return (aggKey, aggOne, aggTwo) -> {
-      if (aggOne < aggTwo) {
-        return aggOne;
-      }
-      return aggTwo;
-    };
+    return (aggKey, aggOne, aggTwo) -> Math.min(aggOne, aggTwo);
   }
 
   @Override

--- a/ksql-engine/src/test/java/io/confluent/ksql/function/udaf/count/CountKudafTest.java
+++ b/ksql-engine/src/test/java/io/confluent/ksql/function/udaf/count/CountKudafTest.java
@@ -1,0 +1,97 @@
+/*
+ * Copyright 2017 Confluent Inc.
+ *
+ * Licensed under the Apache License, Version 2 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ **/
+
+package io.confluent.ksql.function.udaf.count;
+
+import static org.hamcrest.CoreMatchers.equalTo;
+import static org.hamcrest.CoreMatchers.instanceOf;
+import static org.junit.Assert.assertThat;
+
+import io.confluent.ksql.function.KsqlAggregateFunction;
+import java.util.Collections;
+import org.apache.kafka.connect.data.Schema;
+import org.apache.kafka.streams.kstream.Merger;
+import org.junit.Test;
+
+public class CountKudafTest {
+
+  @Test
+  public void shouldGetCorrectCount() {
+    final CountKudaf doubleCountKudaf = getDoubleCountKudaf();
+    final double[] values = new double[]{3.0, 5.0, 8.0, 2.2, 3.5, 4.6, 5.0};
+    Long currentCount = 0L;
+    for (final double i: values) {
+      currentCount = doubleCountKudaf.aggregate(i, currentCount);
+    }
+    assertThat(7L, equalTo(currentCount));
+  }
+
+  @Test
+  public void shouldHandleNullCount() {
+    final CountKudaf doubleCountKudaf = getDoubleCountKudaf();
+    final double[] values = new double[]{3.0, 5.0, 8.0, 2.2, 3.5, 4.6, 5.0};
+    Long currentCount = 0L;
+
+    // aggregate null before any aggregation
+    currentCount = doubleCountKudaf.aggregate(null, currentCount);
+    assertThat(0L, equalTo(currentCount));
+
+    // now send each value to aggregation and verify
+    for (final double i: values) {
+      currentCount = doubleCountKudaf.aggregate(i, currentCount);
+    }
+    assertThat(7L, equalTo(currentCount));
+
+    // null should not affect count
+    currentCount = doubleCountKudaf.aggregate(null, currentCount);
+    assertThat(7L, equalTo(currentCount));
+  }
+
+  @Test
+  public void shouldUndoElement() {
+    final CountKudaf doubleCountKudaf = getDoubleCountKudaf();
+    final double[] values = new double[]{3.0, 5.0, 8.0, 2.2, 3.5, 4.6, 5.0};
+    Long currentCount = 0L;
+    for (final double i: values) {
+      currentCount = doubleCountKudaf.aggregate(i, currentCount);
+    }
+    assertThat(7L, equalTo(currentCount));
+    currentCount = doubleCountKudaf.undo(3.0, currentCount);
+    assertThat(6L, equalTo(currentCount));
+  }
+
+  @Test
+  public void shouldUndoElementHandleNull() {
+    final CountKudaf doubleCountKudaf = getDoubleCountKudaf();
+    final double[] values = new double[]{3.0, 5.0, 8.0, 2.2, 3.5, 4.6, 5.0};
+    Long currentCount = 0L;
+    for (final double i: values) {
+      currentCount = doubleCountKudaf.aggregate(i, currentCount);
+    }
+    assertThat(7L, equalTo(currentCount));
+    currentCount = doubleCountKudaf.undo(null, currentCount);
+    assertThat(7L, equalTo(currentCount));
+  }
+
+
+
+  private CountKudaf getDoubleCountKudaf() {
+    final KsqlAggregateFunction aggregateFunction = new CountAggFunctionFactory()
+        .getProperAggregateFunction(Collections.singletonList(Schema.OPTIONAL_FLOAT64_SCHEMA));
+    assertThat(aggregateFunction, instanceOf(CountKudaf.class));
+    return  (CountKudaf) aggregateFunction;
+  }
+}

--- a/ksql-engine/src/test/java/io/confluent/ksql/function/udaf/max/DoubleMaxKudafTest.java
+++ b/ksql-engine/src/test/java/io/confluent/ksql/function/udaf/max/DoubleMaxKudafTest.java
@@ -1,0 +1,82 @@
+/*
+ * Copyright 2017 Confluent Inc.
+ *
+ * Licensed under the Apache License, Version 2 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ **/
+
+package io.confluent.ksql.function.udaf.max;
+
+import static org.hamcrest.CoreMatchers.equalTo;
+import static org.hamcrest.CoreMatchers.instanceOf;
+import static org.junit.Assert.assertThat;
+
+import io.confluent.ksql.function.KsqlAggregateFunction;
+import java.util.Collections;
+import org.apache.kafka.connect.data.Schema;
+import org.apache.kafka.streams.kstream.Merger;
+import org.junit.Test;
+
+public class DoubleMaxKudafTest {
+
+  @Test
+  public void shouldFindCorrectMax() {
+    final DoubleMaxKudaf doubleMaxKudaf = getDoubleMaxKudaf();
+    final double[] values = new double[]{3.0, 5.0, 8.0, 2.2, 3.5, 4.6, 5.0};
+    double currentMax = Double.MIN_VALUE;
+    for (final double i: values) {
+      currentMax = doubleMaxKudaf.aggregate(i, currentMax);
+    }
+    assertThat(8.0, equalTo(currentMax));
+  }
+
+  @Test
+  public void shouldHandleNull() {
+    final DoubleMaxKudaf doubleMaxKudaf = getDoubleMaxKudaf();
+    final double[] values = new double[]{3.0, 5.0, 8.0, 2.2, 3.5, 4.6, 5.0};
+    double currentMax = Double.MIN_VALUE;
+
+    // aggregate null before any aggregation
+    currentMax = doubleMaxKudaf.aggregate(null, currentMax);
+    assertThat(Double.MIN_VALUE, equalTo(currentMax));
+
+    // now send each value to aggregation and verify
+    for (final double i: values) {
+      currentMax = doubleMaxKudaf.aggregate(i, currentMax);
+    }
+    assertThat(8.0, equalTo(currentMax));
+
+    // null should not impact result
+    currentMax = doubleMaxKudaf.aggregate(null, currentMax);
+    assertThat(8.0, equalTo(currentMax));
+  }
+  @Test
+  public void shouldFindCorrectMaxForMerge() {
+    final DoubleMaxKudaf doubleMaxKudaf = getDoubleMaxKudaf();
+    final Merger<String, Double> merger = doubleMaxKudaf.getMerger();
+    final Double mergeResult1 = merger.apply("Key", 10.0, 12.0);
+    assertThat(mergeResult1, equalTo(12.0));
+    final Double mergeResult2 = merger.apply("Key", 10.0, -12.0);
+    assertThat(mergeResult2, equalTo(10.0));
+    final Double mergeResult3 = merger.apply("Key", -10.0, 0.0);
+    assertThat(mergeResult3, equalTo(0.0));
+
+  }
+
+  private DoubleMaxKudaf getDoubleMaxKudaf() {
+    final KsqlAggregateFunction aggregateFunction = new MaxAggFunctionFactory()
+        .getProperAggregateFunction(Collections.singletonList(Schema.OPTIONAL_FLOAT64_SCHEMA));
+    assertThat(aggregateFunction, instanceOf(DoubleMaxKudaf.class));
+    return  (DoubleMaxKudaf) aggregateFunction;
+  }
+
+}

--- a/ksql-engine/src/test/java/io/confluent/ksql/function/udaf/max/IntegerMaxKudafTest.java
+++ b/ksql-engine/src/test/java/io/confluent/ksql/function/udaf/max/IntegerMaxKudafTest.java
@@ -40,6 +40,27 @@ public class IntegerMaxKudafTest {
   }
 
   @Test
+  public void shouldHandleNull() {
+    final IntegerMaxKudaf integerMaxKudaf = getIntegerMaxKudaf();
+    final int[] values = new int[]{3, 5, 8, 2, 3, 4, 5};
+    int currentMax = Integer.MIN_VALUE;
+
+    // null before any aggregation
+    currentMax = integerMaxKudaf.aggregate(null, currentMax);
+    assertThat(Integer.MIN_VALUE, equalTo(currentMax));
+
+    // now send each value to aggregation and verify
+    for (final int i: values) {
+      currentMax = integerMaxKudaf.aggregate(i, currentMax);
+    }
+    assertThat(8, equalTo(currentMax));
+
+    // null should not impact result
+    currentMax = integerMaxKudaf.aggregate(null, currentMax);
+    assertThat(8, equalTo(currentMax));
+  }
+
+  @Test
   public void shouldFindCorrectMaxForMerge() {
     final IntegerMaxKudaf integerMaxKudaf = getIntegerMaxKudaf();
     final Merger<String, Integer> merger = integerMaxKudaf.getMerger();

--- a/ksql-engine/src/test/java/io/confluent/ksql/function/udaf/max/LongMaxKudafTest.java
+++ b/ksql-engine/src/test/java/io/confluent/ksql/function/udaf/max/LongMaxKudafTest.java
@@ -1,0 +1,83 @@
+/*
+ * Copyright 2017 Confluent Inc.
+ *
+ * Licensed under the Apache License, Version 2 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ **/
+
+package io.confluent.ksql.function.udaf.max;
+
+import static org.hamcrest.CoreMatchers.equalTo;
+import static org.hamcrest.CoreMatchers.instanceOf;
+import static org.junit.Assert.assertThat;
+
+import io.confluent.ksql.function.KsqlAggregateFunction;
+import java.util.Collections;
+import org.apache.kafka.connect.data.Schema;
+import org.apache.kafka.streams.kstream.Merger;
+import org.junit.Test;
+
+public class LongMaxKudafTest {
+
+  @Test
+  public void shouldFindCorrectMax() {
+    final LongMaxKudaf longMaxKudaf = getLongMaxKudaf();
+    final long[] values = new long[]{3L, 5L, 8L, 2L, 3L, 4L, 5L};
+    long currentMax = Long.MIN_VALUE;
+    for (final long i: values) {
+      currentMax = longMaxKudaf.aggregate(i, currentMax);
+    }
+    assertThat(8L, equalTo(currentMax));
+  }
+
+  @Test
+  public void shouldHandleNull() {
+    final LongMaxKudaf longMaxKudaf = getLongMaxKudaf();
+    final long[] values = new long[]{3L, 5L, 8L, 2L, 3L, 4L, 5L};
+    long currentMax = Long.MIN_VALUE;
+
+    // null before any aggregation
+    currentMax = longMaxKudaf.aggregate(null, currentMax);
+    assertThat(Long.MIN_VALUE, equalTo(currentMax));
+
+    // now send each value to aggregation and verify
+    for (final long i: values) {
+      currentMax = longMaxKudaf.aggregate(i, currentMax);
+    }
+    assertThat(8L, equalTo(currentMax));
+
+    // null should not impact result
+    currentMax = longMaxKudaf.aggregate(null, currentMax);
+    assertThat(8L, equalTo(currentMax));
+  }
+
+  @Test
+  public void shouldFindCorrectMaxForMerge() {
+    final LongMaxKudaf longMaxKudaf = getLongMaxKudaf();
+    final Merger<String, Long> merger = longMaxKudaf.getMerger();
+    final Long mergeResult1 = merger.apply("Key", 10L, 12L);
+    assertThat(mergeResult1, equalTo(12L));
+    final Long mergeResult2 = merger.apply("Key", 10L, -12L);
+    assertThat(mergeResult2, equalTo(10L));
+    final Long mergeResult3 = merger.apply("Key", -10L, 0L);
+    assertThat(mergeResult3, equalTo(0L));
+
+  }
+
+  private LongMaxKudaf getLongMaxKudaf() {
+    final KsqlAggregateFunction aggregateFunction = new MaxAggFunctionFactory()
+        .getProperAggregateFunction(Collections.singletonList(Schema.OPTIONAL_INT64_SCHEMA));
+    assertThat(aggregateFunction, instanceOf(LongMaxKudaf.class));
+    return  (LongMaxKudaf) aggregateFunction;
+  }
+
+}

--- a/ksql-engine/src/test/java/io/confluent/ksql/function/udaf/min/DoubleMinKudafTest.java
+++ b/ksql-engine/src/test/java/io/confluent/ksql/function/udaf/min/DoubleMinKudafTest.java
@@ -1,0 +1,83 @@
+/*
+ * Copyright 2017 Confluent Inc.
+ *
+ * Licensed under the Apache License, Version 2 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ **/
+
+package io.confluent.ksql.function.udaf.min;
+
+import static org.hamcrest.CoreMatchers.equalTo;
+import static org.hamcrest.CoreMatchers.instanceOf;
+import static org.junit.Assert.assertThat;
+
+import io.confluent.ksql.function.KsqlAggregateFunction;
+import java.util.Collections;
+import org.apache.kafka.connect.data.Schema;
+import org.apache.kafka.streams.kstream.Merger;
+import org.junit.Test;
+
+public class DoubleMinKudafTest {
+
+  @Test
+  public void shouldFindCorrectMin() {
+    final DoubleMinKudaf doubleMinKudaf = getDoubleMinKudaf();
+    final double[] values = new double[]{3.0, 5.0, 8.0, 2.2, 3.5, 4.6, 5.0};
+    double currentMin = Double.MAX_VALUE;
+    for (final double i: values) {
+      currentMin = doubleMinKudaf.aggregate(i, currentMin);
+    }
+    assertThat(2.2, equalTo(currentMin));
+  }
+
+  @Test
+  public void shouldHandleNull() {
+    final DoubleMinKudaf doubleMinKudaf = getDoubleMinKudaf();
+    final double[] values = new double[]{3.0, 5.0, 8.0, 2.2, 3.5, 4.6, 5.0};
+    double currentMin = Double.MAX_VALUE;
+
+    // null before any aggregation
+    currentMin = doubleMinKudaf.aggregate(null, currentMin);
+    assertThat(Double.MAX_VALUE, equalTo(currentMin));
+
+    // now send each value to aggregation and verify
+    for (final double i: values) {
+      currentMin = doubleMinKudaf.aggregate(i, currentMin);
+    }
+    assertThat(2.2, equalTo(currentMin));
+
+    // null should not impact result
+    currentMin = doubleMinKudaf.aggregate(null, currentMin);
+    assertThat(2.2, equalTo(currentMin));
+  }
+
+  @Test
+  public void shouldFindCorrectMinForMerge() {
+    final DoubleMinKudaf doubleMinKudaf = getDoubleMinKudaf();
+    final Merger<String, Double> merger = doubleMinKudaf.getMerger();
+    final Double mergeResult1 = merger.apply("Key", 10.0, 12.0);
+    assertThat(mergeResult1, equalTo(10.0));
+    final Double mergeResult2 = merger.apply("Key", 10.0, -12.0);
+    assertThat(mergeResult2, equalTo(-12.0));
+    final Double mergeResult3 = merger.apply("Key", -10.0, 0.0);
+    assertThat(mergeResult3, equalTo(-10.0));
+
+  }
+
+
+  private DoubleMinKudaf getDoubleMinKudaf() {
+    final KsqlAggregateFunction aggregateFunction = new MinAggFunctionFactory()
+        .getProperAggregateFunction(Collections.singletonList(Schema.OPTIONAL_FLOAT64_SCHEMA));
+    assertThat(aggregateFunction, instanceOf(DoubleMinKudaf.class));
+    return  (DoubleMinKudaf) aggregateFunction;
+  }
+}

--- a/ksql-engine/src/test/java/io/confluent/ksql/function/udaf/min/IntegerMinKudafTest.java
+++ b/ksql-engine/src/test/java/io/confluent/ksql/function/udaf/min/IntegerMinKudafTest.java
@@ -40,6 +40,27 @@ public class IntegerMinKudafTest {
   }
 
   @Test
+  public void shouldHandleNull() {
+    final IntegerMinKudaf integerMinKudaf = getIntegerMinKudaf();
+    final int[] values = new int[]{3, 5, 8, 2, 3, 4, 5};
+    int currentMin = Integer.MAX_VALUE;
+
+    // aggregate null before any aggregation
+    currentMin = integerMinKudaf.aggregate(null, currentMin);
+    assertThat(Integer.MAX_VALUE, equalTo(currentMin));
+
+    // now send each value to aggregation and verify
+    for (final int i: values) {
+      currentMin = integerMinKudaf.aggregate(i, currentMin);
+    }
+    assertThat(2, equalTo(currentMin));
+
+    // null should not impact result
+    currentMin = integerMinKudaf.aggregate(null, currentMin);
+    assertThat(2, equalTo(currentMin));
+  }
+
+  @Test
   public void shouldFindCorrectMinForMerge() {
     final IntegerMinKudaf integerMinKudaf = getIntegerMinKudaf();
     final Merger<String, Integer> merger = integerMinKudaf.getMerger();

--- a/ksql-engine/src/test/java/io/confluent/ksql/function/udaf/min/LongMinKudafTest.java
+++ b/ksql-engine/src/test/java/io/confluent/ksql/function/udaf/min/LongMinKudafTest.java
@@ -1,0 +1,83 @@
+/*
+ * Copyright 2017 Confluent Inc.
+ *
+ * Licensed under the Apache License, Version 2 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ **/
+
+package io.confluent.ksql.function.udaf.min;
+
+import static org.hamcrest.CoreMatchers.equalTo;
+import static org.hamcrest.CoreMatchers.instanceOf;
+import static org.junit.Assert.assertThat;
+
+import io.confluent.ksql.function.KsqlAggregateFunction;
+import java.util.Collections;
+import org.apache.kafka.connect.data.Schema;
+import org.apache.kafka.streams.kstream.Merger;
+import org.junit.Test;
+
+public class LongMinKudafTest {
+
+  @Test
+  public void shouldFindCorrectMin() {
+    final LongMinKudaf longMinKudaf = getLongMinKudaf();
+    final long[] values = new long[]{3L, 5L, 8L, 2L, 3L, 4L, 5L};
+    long currentMin = Long.MAX_VALUE;
+    for (final long i: values) {
+      currentMin = longMinKudaf.aggregate(i, currentMin);
+    }
+    assertThat(2L, equalTo(currentMin));
+  }
+
+  @Test
+  public void shouldHandleNull() {
+    final LongMinKudaf longMinKudaf = getLongMinKudaf();
+    final long[] values = new long[]{3L, 5L, 8L, 2L, 3L, 4L, 5L};
+    long currentMin = Long.MAX_VALUE;
+
+    // aggregate null before any aggregation
+    currentMin = longMinKudaf.aggregate(null, currentMin);
+    assertThat(Long.MAX_VALUE, equalTo(currentMin));
+
+    // now send each value to aggregation and verify
+    for (final long i: values) {
+      currentMin = longMinKudaf.aggregate(i, currentMin);
+    }
+    assertThat(2L, equalTo(currentMin));
+
+    // null should not impact result
+    currentMin = longMinKudaf.aggregate(null, currentMin);
+    assertThat(2L, equalTo(currentMin));
+  }
+
+  @Test
+  public void shouldFindCorrectMinForMerge() {
+    final LongMinKudaf longMinKudaf = getLongMinKudaf();
+    final Merger<String, Long> merger = longMinKudaf.getMerger();
+    final Long mergeResult1 = merger.apply("Key", 10L, 12L);
+    assertThat(mergeResult1, equalTo(10L));
+    final Long mergeResult2 = merger.apply("Key", 10L, -12L);
+    assertThat(mergeResult2, equalTo(-12L));
+    final Long mergeResult3 = merger.apply("Key", -10L, 0L);
+    assertThat(mergeResult3, equalTo(-10L));
+
+  }
+
+
+  private LongMinKudaf getLongMinKudaf() {
+    final KsqlAggregateFunction aggregateFunction = new MinAggFunctionFactory()
+        .getProperAggregateFunction(Collections.singletonList(Schema.OPTIONAL_INT64_SCHEMA));
+    assertThat(aggregateFunction, instanceOf(LongMinKudaf.class));
+    return  (LongMinKudaf) aggregateFunction;
+  }
+}


### PR DESCRIPTION
### Description 
Fixes #2244 by adding the appropriate checks to ignore `null` values.
- add `null` checks to min and max UDAFs for `Double` and `Long` and count UDAF so `null` values do not impact those aggregations.
- Change min and max UDAFs for `Double` and `Long` to use `Math.min()` and `Math.max()` to be consistent with `Integer` UDAFs.
- add documentation for aggregate function handling of `null` values.

### Testing done 
Unit tests added to test `null` values for each combination where checks were added. 

Manual testing building ksql-server and client:
- tested original `min(<column>)`, `max(<column>)`,  and `count(<column>) for `Double` with `null` columns and verified no longer encountering `NullPointerException` and that correct value is returned.
- verify that `count(*)` returns count of all rows, including rows with `null` value(s).

### Reviewer checklist
- [x] Ensure docs are updated if necessary. (eg. if a user visible feature is being added or changed).
- [x] Ensure relevant issues are linked (description should include text like "Fixes #<issue number>")