### PR TITLE
Make ExpressionMetadata thread-safe

### DIFF
--- a/ksql-engine/src/main/java/io/confluent/ksql/codegen/CodeGenRunner.java
+++ b/ksql-engine/src/main/java/io/confluent/ksql/codegen/CodeGenRunner.java
@@ -37,6 +37,7 @@ import io.confluent.ksql.parser.tree.QualifiedNameReference;
 import io.confluent.ksql.parser.tree.SubscriptExpression;
 import io.confluent.ksql.util.ExpressionMetadata;
 import io.confluent.ksql.util.ExpressionTypeManager;
+import io.confluent.ksql.util.GenericRowValueTypeEnforcer;
 import io.confluent.ksql.util.KsqlConfig;
 import io.confluent.ksql.util.KsqlException;
 import io.confluent.ksql.util.SchemaUtil;
@@ -134,7 +135,12 @@ public class CodeGenRunner {
 
       ee.cook(javaCode);
 
-      return new ExpressionMetadata(ee, columnIndexes, kudfObjects, expressionType, schema);
+      return new ExpressionMetadata(
+          ee,
+          columnIndexes,
+          kudfObjects,
+          expressionType,
+          new GenericRowValueTypeEnforcer(schema));
     } catch (final KsqlException | CompileException e) {
       throw new KsqlException("Code generation failed for " + type
           + ": " + e.getMessage()

--- a/ksql-engine/src/test/java/io/confluent/ksql/util/ExpressionMetadataTest.java
+++ b/ksql-engine/src/test/java/io/confluent/ksql/util/ExpressionMetadataTest.java
@@ -1,0 +1,145 @@
+package io.confluent.ksql.util;
+
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.is;
+import static org.junit.Assert.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.Mockito.reset;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.google.common.collect.ImmutableList;
+import io.confluent.ksql.GenericRow;
+import io.confluent.ksql.function.udf.Kudf;
+import java.lang.reflect.InvocationTargetException;
+import java.util.Collections;
+import java.util.List;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+import org.apache.kafka.connect.data.Schema;
+import org.codehaus.commons.compiler.IExpressionEvaluator;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnit;
+import org.mockito.junit.MockitoRule;
+
+public class ExpressionMetadataTest {
+  private static final Long RETURN_VALUE = 12345L;
+
+  @Mock
+  private IExpressionEvaluator expressionEvaluator;
+  private List<Kudf> udfs;
+  @Mock
+  private Kudf udf;
+  private final Schema expressionType = Schema.OPTIONAL_INT64_SCHEMA;
+  @Mock
+  private GenericRowValueTypeEnforcer typeEnforcer;
+  @Mock
+  private Object parameter1;
+  @Mock
+  private Object parameter2;
+  private ExpressionMetadata expressionMetadata;
+
+  @Rule
+  public final MockitoRule mockitoRule = MockitoJUnit.rule();
+
+  @Before
+  public void setup() throws InvocationTargetException {
+    when(typeEnforcer.enforceFieldType(anyInt(), any()))
+        .thenReturn(parameter1)
+        .thenReturn(parameter2);
+    when(expressionEvaluator.evaluate(any())).thenReturn(RETURN_VALUE);
+    udfs = ImmutableList.of(udf);
+  }
+
+  @Test
+  public void shouldEvaluateExpressionWithNoUdfsCorrectly() throws InvocationTargetException {
+    // Given:
+    expressionMetadata = new ExpressionMetadata(
+        expressionEvaluator,
+        ImmutableList.of(1, 0),
+        Collections.emptyList(),
+        expressionType,
+        typeEnforcer);
+
+    // When:
+    final Object result = expressionMetadata.evaluate(new GenericRow(123, 456));
+
+    // Then:
+    assertThat(result, equalTo(RETURN_VALUE));
+    verify(typeEnforcer, times(1)).enforceFieldType(1, 456);
+    verify(typeEnforcer, times(1)).enforceFieldType(0, 123);
+    verify(expressionEvaluator).evaluate(new Object[]{parameter1, parameter2});
+  }
+
+  @Test
+  public void shouldEvaluateExpressionWithUdfsCorrectly() throws InvocationTargetException {
+    // Given:
+    expressionMetadata = new ExpressionMetadata(
+        expressionEvaluator,
+        ImmutableList.of(-1, 0),
+        udfs,
+        expressionType,
+        typeEnforcer);
+
+    // When:
+    final Object result = expressionMetadata.evaluate(new GenericRow(123));
+
+    // Then:
+    assertThat(result, equalTo(RETURN_VALUE));
+    verify(typeEnforcer, times(1)).enforceFieldType(0, 123);
+    verify(expressionEvaluator).evaluate(new Object[]{udf, parameter1});
+  }
+
+  @Test
+  public void shouldPerformThreadSafeParameterEvaluation()
+      throws InterruptedException, InvocationTargetException {
+    // Given:
+    final CountDownLatch threadLatch = new CountDownLatch(1);
+    final CountDownLatch mainLatch = new CountDownLatch(1);
+    final Object thread1Param1 = 1;
+    final Object thread1Param2 = 2;
+    final Object thread2Param1 = 3;
+    final Object thread2Param2 = 4;
+    reset(typeEnforcer);
+    when(typeEnforcer.enforceFieldType(0, 123))
+        .thenReturn(thread1Param1);
+    when(typeEnforcer.enforceFieldType(1, 456))
+        .thenAnswer(
+            invocation -> {
+              threadLatch.countDown();
+              assertThat(mainLatch.await(10, TimeUnit.SECONDS), is(true));
+              return thread1Param2;
+            });
+    when(typeEnforcer.enforceFieldType(0, 100))
+        .thenReturn(thread2Param1);
+    when(typeEnforcer.enforceFieldType(1, 200))
+        .thenReturn(thread2Param2);
+    expressionMetadata = new ExpressionMetadata(
+        expressionEvaluator,
+        ImmutableList.of(0, 1),
+        Collections.emptyList(),
+        expressionType,
+        typeEnforcer);
+
+    // When:
+    final Thread thread = new Thread(
+        () -> expressionMetadata.evaluate(new GenericRow(123, 456))
+    );
+    thread.start();
+    assertThat(threadLatch.await(10, TimeUnit.SECONDS), is(true));
+    expressionMetadata.evaluate(new GenericRow(100, 200));
+    mainLatch.countDown();
+    thread.join();
+
+    // Then:
+    verify(expressionEvaluator, times(1))
+        .evaluate(new Object[]{thread1Param1, thread1Param2});
+    verify(expressionEvaluator, times(1))
+        .evaluate(new Object[]{thread2Param1, thread2Param2});
+  }
+}


### PR DESCRIPTION
### Description 

Use a thread-local to store the parameter array built by ExpressionMetadata
to pass in to the expression evaluator. This patch also includes a unit test
for ExpressionMetadata, with a test to ensure we build the parameters in a
thread-safe way.

### Testing done 
Unit test for ExpressionMetadata

### Reviewer checklist
- [ ] Ensure docs are updated if necessary. (eg. if a user visible feature is being added or changed).
- [ ] Ensure relevant issues are linked (description should include text like "Fixes #<issue number>")

