### PR TITLE
Fix issue where Avro subject does not exist

### DIFF
--- a/ksql-engine/src/test/java/io/confluent/ksql/util/AvroUtilTest.java
+++ b/ksql-engine/src/test/java/io/confluent/ksql/util/AvroUtilTest.java
@@ -17,15 +17,11 @@
 
 package io.confluent.ksql.util;
 
-import static org.easymock.EasyMock.anyObject;
-import static org.easymock.EasyMock.anyString;
-import static org.easymock.EasyMock.eq;
-import static org.easymock.EasyMock.expect;
-import static org.easymock.EasyMock.mock;
-import static org.easymock.EasyMock.replay;
-import static org.hamcrest.CoreMatchers.equalTo;
+import static org.hamcrest.Matchers.contains;
 import static org.hamcrest.Matchers.is;
 import static org.junit.Assert.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.when;
 
 import io.confluent.kafka.schemaregistry.client.SchemaMetadata;
 import io.confluent.kafka.schemaregistry.client.SchemaRegistryClient;
@@ -39,166 +35,159 @@ import io.confluent.ksql.parser.tree.AbstractStreamCreateStatement;
 import io.confluent.ksql.parser.tree.Array;
 import io.confluent.ksql.parser.tree.Map;
 import io.confluent.ksql.parser.tree.PrimitiveType;
-import io.confluent.ksql.parser.tree.Statement;
 import io.confluent.ksql.parser.tree.TableElement;
 import io.confluent.ksql.parser.tree.Type;
 import io.confluent.ksql.serde.avro.KsqlAvroTopicSerDe;
-import java.io.IOException;
-import java.util.Arrays;
 import java.util.List;
 import org.apache.kafka.connect.data.Schema;
-import org.easymock.EasyMock;
+import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ExpectedException;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnitRunner;
 
+@RunWith(MockitoJUnitRunner.class)
 public class AvroUtilTest {
+
+  private static final String AVRO_SCHEMA_STRING = "{"
+      + "\"namespace\": \"some.namespace\","
+      + " \"name\": \"orders\","
+      + " \"type\": \"record\","
+      + " \"fields\": ["
+      + "     {\"name\": \"ordertime\", \"type\": \"long\"},"
+      + "     {\"name\": \"orderid\",  \"type\": \"long\"},"
+      + "     {\"name\": \"itemid\", \"type\": \"string\"},"
+      + "     {\"name\": \"orderunits\", \"type\": \"double\"},"
+      + "     {\"name\": \"arraycol\", \"type\": {\"type\": \"array\", \"items\": \"double\"}},"
+      + "     {\"name\": \"mapcol\", \"type\": {\"type\": \"map\", \"values\": \"double\"}}"
+      + " ]"
+      + "}";
+
+  private static final org.apache.avro.Schema RESULT_AVRO_SCHEMA =
+      new org.apache.avro.Schema.Parser().parse(AVRO_SCHEMA_STRING);
+
+  private static final Schema RESULT_SCHEMA = AvroUtil.toKsqlSchema(AVRO_SCHEMA_STRING);
+
+  private static final KsqlTopic RESULT_TOPIC =
+      new KsqlTopic("registered-name", "actual-name", new KsqlAvroTopicSerDe(), false);
 
   @Rule
   public final ExpectedException expectedException = ExpectedException.none();
 
-  private String ordersAvroSchemaStr = "{"
-                     + "\"namespace\": \"kql\","
-                     + " \"name\": \"orders\","
-                     + " \"type\": \"record\","
-                     + " \"fields\": ["
-                     + "     {\"name\": \"ordertime\", \"type\": \"long\"},"
-                     + "     {\"name\": \"orderid\",  \"type\": \"long\"},"
-                     + "     {\"name\": \"itemid\", \"type\": \"string\"},"
-                     + "     {\"name\": \"orderunits\", \"type\": \"double\"},"
-                     + "     {\"name\": \"arraycol\", \"type\": {\"type\": \"array\", \"items\": \"double\"}},"
-                     + "     {\"name\": \"mapcol\", \"type\": {\"type\": \"map\", \"values\": \"double\"}}"
-                     + " ]"
-                     + "}";
+  @Mock
+  private SchemaRegistryClient srClient;
+  @Mock
+  private PersistentQueryMetadata persistentQuery;
+  private AbstractStreamCreateStatement statement;
+
+  @Before
+  public void setUp() {
+    when(persistentQuery.getResultSchema()).thenReturn(RESULT_SCHEMA);
+    when(persistentQuery.getResultTopic()).thenReturn(RESULT_TOPIC);
+    when(persistentQuery.getResultTopicSerde())
+        .thenReturn(RESULT_TOPIC.getKsqlTopicSerDe().getSerDe());
+
+    statement = createStreamCreateSql();
+  }
 
   @Test
   public void shouldPassAvroCheck() throws Exception {
-    final SchemaRegistryClient schemaRegistryClient = mock(SchemaRegistryClient.class);
-    final SchemaMetadata schemaMetadata = new SchemaMetadata(1, 1, ordersAvroSchemaStr);
-    expect(schemaRegistryClient.getLatestSchemaMetadata(anyString())).andReturn(schemaMetadata);
-    replay(schemaRegistryClient);
-    final AbstractStreamCreateStatement abstractStreamCreateStatement = getAbstractStreamCreateStatement
-        ("CREATE STREAM S1 WITH (kafka_topic='s1_topic', "
-                                     + "value_format='avro' );");
-    final AbstractStreamCreateStatement newAbstractStreamCreateStatement = AvroUtil.checkAndSetAvroSchema(
-        abstractStreamCreateStatement, schemaRegistryClient);
-    assertThat(
-        newAbstractStreamCreateStatement.getElements(),
-        equalTo(
-            Arrays.asList(
-                new TableElement("ORDERTIME", new PrimitiveType(Type.KsqlType.BIGINT)),
-                new TableElement("ORDERID", new PrimitiveType(Type.KsqlType.BIGINT)),
-                new TableElement("ITEMID", new PrimitiveType(Type.KsqlType.STRING)),
-                new TableElement("ORDERUNITS", new PrimitiveType(Type.KsqlType.DOUBLE)),
-                new TableElement("ARRAYCOL", new Array(new PrimitiveType(Type.KsqlType.DOUBLE))),
-                new TableElement("MAPCOL", new Map(new PrimitiveType(Type.KsqlType.DOUBLE)))
-            )
-        )
-    );
+    // Given:
+    when(srClient.getLatestSchemaMetadata(any())).thenReturn(
+        new SchemaMetadata(1, 1, AVRO_SCHEMA_STRING));
+
+    // When:
+    final AbstractStreamCreateStatement result =
+        AvroUtil.checkAndSetAvroSchema(statement, srClient);
+
+    // Then:
+    assertThat(result.getElements(), contains(
+        new TableElement("ORDERTIME", new PrimitiveType(Type.KsqlType.BIGINT)),
+        new TableElement("ORDERID", new PrimitiveType(Type.KsqlType.BIGINT)),
+        new TableElement("ITEMID", new PrimitiveType(Type.KsqlType.STRING)),
+        new TableElement("ORDERUNITS", new PrimitiveType(Type.KsqlType.DOUBLE)),
+        new TableElement("ARRAYCOL", new Array(new PrimitiveType(Type.KsqlType.DOUBLE))),
+        new TableElement("MAPCOL", new Map(new PrimitiveType(Type.KsqlType.DOUBLE)))
+    ));
   }
 
   @Test
   public void shouldThrowIfAvroSchemaNotCompatibleWithKsql() throws Exception {
+    // Given:
+    when(srClient.getLatestSchemaMetadata(any())).thenReturn(
+        new SchemaMetadata(1, 1, "{\"type\": \"record\"}"));
+
+    // Expect:
     expectedException.expect(KsqlException.class);
     expectedException.expectMessage(
-            "Unable to verify if the Avro schema for topic s1_topic is compatible with KSQL.\n" +
-                    "Reason: No name in schema: {\"type\":\"record\"}\n" +
-                    "\n" +
-                    "Please see https://github.com/confluentinc/ksql/issues/ to see if this particular reason is already\n" +
-                    "known, and if not log a new issue. Please include the full Avro schema that you are trying to use.");
+        "Unable to verify if the Avro schema for topic s1_topic is compatible with KSQL.\n"
+            + "Reason: No name in schema: {\"type\":\"record\"}\n\n"
+            + "Please see https://github.com/confluentinc/ksql/issues/ to see if this particular reason is already\n"
+            + "known, and if not log a new issue. Please include the full Avro schema that you are trying to use.");
 
-    final SchemaRegistryClient schemaRegistryClient = mock(SchemaRegistryClient.class);
-    final SchemaMetadata schemaMetadata = new SchemaMetadata(1, 1, "{\"type\": \"record\"}");
-    expect(schemaRegistryClient.getLatestSchemaMetadata(anyString())).andReturn(schemaMetadata);
-    replay(schemaRegistryClient);
-    final AbstractStreamCreateStatement abstractStreamCreateStatement = getAbstractStreamCreateStatement
-        ("CREATE STREAM S1 WITH "
-         + "(kafka_topic='s1_topic', "
-         + "value_format='avro' );");
-
-    AvroUtil.checkAndSetAvroSchema(abstractStreamCreateStatement, schemaRegistryClient);
+    // When:
+    AvroUtil.checkAndSetAvroSchema(statement, srClient);
   }
 
   @Test
   public void shouldNotPassAvroCheckIfSchemaDoesNotExist() throws Exception {
+    // Given:
+    when(srClient.getLatestSchemaMetadata(any()))
+        .thenThrow(new RestClientException("Not found", 404, 40401));
+
+    // Expect:
     expectedException.expect(KsqlException.class);
     expectedException.expectMessage(
-            "Avro schema for message values on topic s1_topic does not exist in the Schema Registry.\n" +
-                    "Subject: s1_topic-value\n" +
-                    "\n" +
-                    "Possible causes include:\n" +
-                    "- The topic itself does not exist\n" +
-                    "\t-> Use SHOW TOPICS; to check\n" +
-                    "- Messages on the topic are not Avro serialized\n" +
-                    "\t-> Use PRINT 's1_topic' FROM BEGINNING; to verify\n" +
-                    "- Messages on the topic have not been serialized using the Confluent Schema Registry Avro serializer\n" +
-                    "\t-> See https://docs.confluent.io/current/schema-registry/docs/serializer-formatter.html\n" +
-                    "- The schema is registered on a different instance of the Schema Registry\n" +
-                    "\t-> Use the REST API to list available subjects\n\t" +
-                    "https://docs.confluent.io/current/schema-registry/docs/api.html#get--subjects\n");
+        "Avro schema for message values on topic s1_topic does not exist in the Schema Registry.\n"
+            + "Subject: s1_topic-value\n\n"
+            + "Possible causes include:\n"
+            + "- The topic itself does not exist\n"
+            + "\t-> Use SHOW TOPICS; to check\n" +
+            "- Messages on the topic are not Avro serialized\n"
+            + "\t-> Use PRINT 's1_topic' FROM BEGINNING; to verify\n"
+            + "- Messages on the topic have not been serialized using the Confluent Schema Registry Avro serializer\n"
+            + "\t-> See https://docs.confluent.io/current/schema-registry/docs/serializer-formatter.html\n"
+            + "- The schema is registered on a different instance of the Schema Registry\n"
+            + "\t-> Use the REST API to list available subjects\n\t"
+            + "https://docs.confluent.io/current/schema-registry/docs/api.html#get--subjects\n");
 
-    final SchemaRegistryClient schemaRegistryClient = mock(SchemaRegistryClient.class);
-    expect(schemaRegistryClient.getLatestSchemaMetadata(anyString()))
-            .andThrow(new RestClientException("Not found", 404, 40401));
-    replay(schemaRegistryClient);
-    final AbstractStreamCreateStatement abstractStreamCreateStatement = getAbstractStreamCreateStatement
-        ("CREATE STREAM S1 WITH "
-         + "(kafka_topic='s1_topic', "
-         + "value_format='avro' );");
-    AvroUtil.checkAndSetAvroSchema(abstractStreamCreateStatement, schemaRegistryClient);
-  }
-
-  private PersistentQueryMetadata buildStubPersistentQueryMetadata(final Schema resultSchema,
-                                                                   final KsqlTopic resultTopic) {
-    final PersistentQueryMetadata mockPersistentQueryMetadata = mock(PersistentQueryMetadata.class);
-    expect(mockPersistentQueryMetadata.getResultSchema()).andStubReturn(resultSchema);
-    expect(mockPersistentQueryMetadata.getResultTopic()).andStubReturn(resultTopic);
-    expect(mockPersistentQueryMetadata.getResultTopicSerde()).andStubReturn(
-        resultTopic.getKsqlTopicSerDe().getSerDe());
-    replay(mockPersistentQueryMetadata);
-    return mockPersistentQueryMetadata;
+    // When:
+    AvroUtil.checkAndSetAvroSchema(statement, srClient);
   }
 
   @Test
-  public void shouldValidatePersistentQueryResultCorrectly()
-      throws IOException, RestClientException {
-    final SchemaRegistryClient schemaRegistryClient = mock(SchemaRegistryClient.class);
-    final KsqlTopic resultTopic = new KsqlTopic("testTopic", "testTopic", new KsqlAvroTopicSerDe(), false);
-    final Schema resultSchema = AvroUtil.toKsqlSchema(ordersAvroSchemaStr);
-    final PersistentQueryMetadata persistentQueryMetadata = buildStubPersistentQueryMetadata(resultSchema, resultTopic);
-    final org.apache.avro.Schema.Parser parser = new org.apache.avro.Schema.Parser();
-    final org.apache.avro.Schema avroSchema = parser.parse(ordersAvroSchemaStr);
-    expect(schemaRegistryClient.testCompatibility(eq("testTopic-value"), EasyMock.isA(avroSchema.getClass())))
-        .andReturn(true);
-    replay(schemaRegistryClient);
-    final boolean result = AvroUtil.isValidSchemaEvolution(persistentQueryMetadata, schemaRegistryClient);
+  public void shouldReturnValidEvolution() throws Exception {
+    // Given:
+    when(srClient.testCompatibility(any(), any())).thenReturn(true);
+
+    // When:
+    final boolean result = AvroUtil.isValidSchemaEvolution(persistentQuery, srClient);
+
+    // Then:
     assertThat(result, is(true));
   }
 
   @Test
-  public void shouldFailForInvalidResultAvroSchema()
-      throws IOException, RestClientException {
-    final SchemaRegistryClient schemaRegistryClient = mock(SchemaRegistryClient.class);
-    final KsqlTopic resultTopic = new KsqlTopic("testTopic", "testTopic", new KsqlAvroTopicSerDe(),
-        false);
-    final Schema resultSchema = AvroUtil.toKsqlSchema(ordersAvroSchemaStr);
-    final PersistentQueryMetadata persistentQueryMetadata = buildStubPersistentQueryMetadata(
-        resultSchema, resultTopic);
-    expect(schemaRegistryClient.testCompatibility(anyString(), anyObject())).andReturn(false);
-    replay(schemaRegistryClient);
+  public void shouldReturnInvalidEvolution() throws Exception {
+    // Given:
+    when(srClient.testCompatibility(any(), any())).thenReturn(false);
 
-    final boolean result = AvroUtil
-        .isValidSchemaEvolution(persistentQueryMetadata, schemaRegistryClient);
+    // When:
+    final boolean result = AvroUtil.isValidSchemaEvolution(persistentQuery, srClient);
+
+    // Then:
     assertThat(result, is(false));
   }
 
-  private AbstractStreamCreateStatement getAbstractStreamCreateStatement(final String statementString) {
-    final List<PreparedStatement<?>> statementList = new KsqlParser().buildAst
-        (statementString, new MetaStoreImpl(new InternalFunctionRegistry()));
-    if (statementList.get(0).getStatement() instanceof AbstractStreamCreateStatement) {
-      return (AbstractStreamCreateStatement) statementList.get(0).getStatement();
-    }
-    throw new KsqlException("Invalid statement." + statementString);
-  }
+  private static AbstractStreamCreateStatement createStreamCreateSql() {
+    final List<PreparedStatement<?>> statementList = new KsqlParser()
+        .buildAst(
+            "CREATE STREAM S1 WITH (kafka_topic='s1_topic', value_format='avro');",
+            new MetaStoreImpl(new InternalFunctionRegistry())
+        );
 
+    return (AbstractStreamCreateStatement) statementList.get(0).getStatement();
+  }
 }


### PR DESCRIPTION
### Description 
Fixes #2258 

There are two commits:
- First switches the test from EasyMock to Mockito and refactors.
- Second fixes two issues:
  1. code could not handle the SR returning 404 error if subject was not know. Code now accepts this and the compatibility test will pass.
  2. code was passing the registered topic name, not the kafka topic name, as the subject.  

### Testing done 
Usual.

### Reviewer checklist
- [ ] Ensure docs are updated if necessary. (eg. if a user visible feature is being added or changed).
- [ ] Ensure relevant issues are linked (description should include text like "Fixes #<issue number>")

