### PR TITLE
MINOR: Fix bug encountered when restoring RUN SCRIPT command.

### DIFF
--- a/ksql-rest-app/src/main/java/io/confluent/ksql/rest/server/computation/StatementExecutor.java
+++ b/ksql-rest-app/src/main/java/io/confluent/ksql/rest/server/computation/StatementExecutor.java
@@ -222,7 +222,7 @@ public class StatementExecutor {
       terminateQuery((TerminateQuery) statement, mode);
       successMessage = "Query terminated.";
     } else if (statement instanceof RunScript) {
-      handleRunScript(command);
+      handleRunScript(command, mode);
     } else {
       throw new Exception(String.format(
           "Unexpected statement type: %s",
@@ -237,7 +237,7 @@ public class StatementExecutor {
     putFinalStatus(commandId, queuedCommandStatus, successStatus);
   }
 
-  private void handleRunScript(final Command command) {
+  private void handleRunScript(final Command command, final Mode mode) {
 
     if (command.getOverwriteProperties().containsKey(KsqlConstants.RUN_SCRIPT_STATEMENTS_CONTENT)) {
       final String queries =
@@ -251,10 +251,13 @@ public class StatementExecutor {
           ksqlConfig.overrideBreakingConfigsWithOriginalValues(command.getOriginalProperties()),
           overriddenProperties
       );
-      for (final QueryMetadata queryMetadata : queryMetadataList) {
-        if (queryMetadata instanceof PersistentQueryMetadata) {
-          final PersistentQueryMetadata persistentQueryMd = (PersistentQueryMetadata) queryMetadata;
-          persistentQueryMd.start();
+      if (mode == Mode.EXECUTE) {
+        for (final QueryMetadata queryMetadata : queryMetadataList) {
+          if (queryMetadata instanceof PersistentQueryMetadata) {
+            final PersistentQueryMetadata persistentQueryMd =
+                (PersistentQueryMetadata) queryMetadata;
+            persistentQueryMd.start();
+          }
         }
       }
     } else {


### PR DESCRIPTION
### Description 

Currently, if you execute a RUN SCRIPT where the script contains a persistent query, then try to restart the KSQL server, the server will fail to restart. This happens because recent changes we introduced to the recovery logic result in the server attempting to start the persistent query created by the RUN SCRIPT twice, resulting in the following error:
```
[2018-12-12 19:59:46,205] ERROR Failed to start KSQL (io.confluent.ksql.rest.server.KsqlServerMain:47)
java.lang.IllegalStateException: Can only set StateListener in CREATED state. Current state is: REBALANCING
    at org.apache.kafka.streams.KafkaStreams.setStateListener(KafkaStreams.java:332)
    at java.util.Optional.ifPresent(Optional.java:159)
    at io.confluent.ksql.util.QueryMetadata.start(QueryMetadata.java:183)
    at java.util.ArrayList.forEach(ArrayList.java:1257)
    at java.util.Collections$UnmodifiableCollection.forEach(Collections.java:1080)
    at io.confluent.ksql.rest.server.computation.StatementExecutor.handleRestoration(StatementExecutor.java:104)
    at io.confluent.ksql.rest.server.computation.CommandRunner.processPriorCommands(CommandRunner.java:89)
    at io.confluent.ksql.rest.server.KsqlRestApplication.buildApplication(KsqlRestApplication.java:384)
    at io.confluent.ksql.rest.server.KsqlServerMain.createExecutable(KsqlServerMain.java:82)
    at io.confluent.ksql.rest.server.KsqlServerMain.main(KsqlServerMain.java:44)
```

The fix is simple: only start RUN SCRIPT queries once when recovering.

### Testing done 

Manual testing done. Added unit test.

### Reviewer checklist
- [ ] Ensure docs are updated if necessary. (eg. if a user visible feature is being added or changed).
- [ ] Ensure relevant issues are linked (description should include text like "Fixes #<issue number>")

