### PR TITLE
Minor: add Hamcrest matchers for KsqlRestException and KsqlErrorMessage

### DIFF
--- a/ksql-rest-app/src/main/java/io/confluent/ksql/rest/server/resources/KsqlRestException.java
+++ b/ksql-rest-app/src/main/java/io/confluent/ksql/rest/server/resources/KsqlRestException.java
@@ -23,7 +23,7 @@ import javax.ws.rs.core.Response;
  * internal function call of a resource
  */
 public class KsqlRestException extends RuntimeException {
-  Response response;
+  private final Response response;
 
   public KsqlRestException(final Response response) {
     this.response = response;

--- a/ksql-rest-app/src/test/java/io/confluent/ksql/rest/entity/KsqlErrorMessageMatchers.java
+++ b/ksql-rest-app/src/test/java/io/confluent/ksql/rest/entity/KsqlErrorMessageMatchers.java
@@ -1,0 +1,93 @@
+/*
+ * Copyright 2018 Confluent Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.confluent.ksql.rest.entity;
+
+import org.hamcrest.Description;
+import org.hamcrest.Matcher;
+import org.hamcrest.TypeSafeDiagnosingMatcher;
+
+public final class KsqlErrorMessageMatchers {
+
+  private KsqlErrorMessageMatchers() {
+  }
+
+  /**
+   * Matches a {@code KsqlErrorMessage} where the error message matches the supplied matcher.
+   *
+   * @param expected - the message matcher
+   * @return the matcher.
+   */
+  public static Matcher<? super KsqlErrorMessage> errorMessage(
+      final Matcher<? extends String> expected
+  ) {
+    return new TypeSafeDiagnosingMatcher<KsqlErrorMessage>() {
+      @Override
+      protected boolean matchesSafely(
+          final KsqlErrorMessage actual,
+          final Description mismatchDescription
+      ) {
+        if (!expected.matches(actual.getMessage())) {
+          mismatchDescription.appendText("but message ");
+          expected.describeMismatch(actual.getMessage(), mismatchDescription);
+          return false;
+        }
+
+        return true;
+      }
+
+      @Override
+      public void describeTo(final Description description) {
+        description
+            .appendText("message ")
+            .appendDescriptionOf(expected);
+      }
+    };
+  }
+
+  /**
+   * Matches a {@code KsqlErrorMessage} where the error code matches the supplied matcher.
+   *
+   * @param expected - the message matcher
+   * @return the matcher.
+   */
+  public static Matcher<? super KsqlErrorMessage> errorCode(
+      final Matcher<Integer> expected
+  ) {
+    return new TypeSafeDiagnosingMatcher<KsqlErrorMessage>() {
+      @Override
+      protected boolean matchesSafely(
+          final KsqlErrorMessage actual,
+          final Description mismatchDescription
+      ) {
+        if (!expected.matches(actual.getErrorCode())) {
+          mismatchDescription.appendText("but error code ");
+          expected.describeMismatch(actual.getErrorCode(), mismatchDescription);
+          return false;
+        }
+
+        return true;
+      }
+
+      @Override
+      public void describeTo(final Description description) {
+        description
+            .appendText("error code ")
+            .appendDescriptionOf(expected);
+      }
+    };
+  }
+}

--- a/ksql-rest-app/src/test/java/io/confluent/ksql/rest/server/resources/KsqlRestExceptionMatchers.java
+++ b/ksql-rest-app/src/test/java/io/confluent/ksql/rest/server/resources/KsqlRestExceptionMatchers.java
@@ -1,0 +1,105 @@
+/*
+ * Copyright 2018 Confluent Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.confluent.ksql.rest.server.resources;
+
+import io.confluent.ksql.rest.entity.KsqlErrorMessage;
+import org.eclipse.jetty.http.HttpStatus;
+import org.eclipse.jetty.http.HttpStatus.Code;
+import org.hamcrest.Description;
+import org.hamcrest.Matcher;
+import org.hamcrest.TypeSafeDiagnosingMatcher;
+
+public final class KsqlRestExceptionMatchers {
+
+  private KsqlRestExceptionMatchers() {
+  }
+
+  /**
+   * Matches a {@code KsqlRestException} where the status code matchers the supplier matcher.
+   *
+   * @param expected matcher defining the expected value(s).
+   * @return the matcher.
+   */
+  public static Matcher<? super KsqlRestException> exceptionStatusCode(
+      final Matcher<HttpStatus.Code> expected
+  ) {
+    return new TypeSafeDiagnosingMatcher<KsqlRestException>() {
+      @Override
+      protected boolean matchesSafely(
+          final KsqlRestException actual,
+          final Description mismatchDescription
+      ) {
+        final Code actualCode = HttpStatus.getCode(actual.getResponse().getStatus());
+        if (!expected.matches(actualCode)) {
+          mismatchDescription.appendText("but status code ");
+          expected.describeMismatch(actualCode, mismatchDescription);
+          return false;
+        }
+        return true;
+      }
+
+      @Override
+      public void describeTo(final Description description) {
+        description
+            .appendText("status code ")
+            .appendDescriptionOf(expected);
+      }
+    };
+  }
+
+  /**
+   * Matches a {@code KsqlRestException} where the response entity holds a {@link KsqlErrorMessage}
+   * that matches the supplied matcher.
+   *
+   * @param expected - see {@link io.confluent.ksql.rest.entity.KsqlErrorMessageMatchers}
+   * @return the matcher.
+   */
+  public static Matcher<? super KsqlRestException> exceptionKsqlErrorMessage(
+      final Matcher<? super KsqlErrorMessage> expected
+  ) {
+    return new TypeSafeDiagnosingMatcher<KsqlRestException>() {
+      @Override
+      protected boolean matchesSafely(
+          final KsqlRestException actual,
+          final Description mismatchDescription
+      ) {
+        final Object entity = actual.getResponse().getEntity();
+        if (!(entity instanceof KsqlErrorMessage)) {
+          mismatchDescription
+              .appendText("but entity was instance of ")
+              .appendValue(entity.getClass());
+          return false;
+        }
+
+        final KsqlErrorMessage errorMessage = (KsqlErrorMessage) entity;
+        if (!expected.matches(errorMessage)) {
+          expected.describeMismatch(errorMessage, mismatchDescription);
+          return false;
+        }
+
+        return true;
+      }
+
+      @Override
+      public void describeTo(final Description description) {
+        description
+            .appendText(KsqlErrorMessage.class.getSimpleName() + " where ")
+            .appendDescriptionOf(expected);
+      }
+    };
+  }
+}

--- a/ksql-rest-app/src/test/java/io/confluent/ksql/rest/util/CommandStoreUtilTest.java
+++ b/ksql-rest-app/src/test/java/io/confluent/ksql/rest/util/CommandStoreUtilTest.java
@@ -1,10 +1,10 @@
 package io.confluent.ksql.rest.util;
 
 
-import static org.hamcrest.CoreMatchers.instanceOf;
+import static io.confluent.ksql.rest.entity.KsqlErrorMessageMatchers.errorMessage;
+import static io.confluent.ksql.rest.server.resources.KsqlRestExceptionMatchers.exceptionKsqlErrorMessage;
+import static io.confluent.ksql.rest.server.resources.KsqlRestExceptionMatchers.exceptionStatusCode;
 import static org.hamcrest.CoreMatchers.is;
-import static org.hamcrest.MatcherAssert.assertThat;
-import static org.junit.Assert.fail;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.Mockito.doThrow;
@@ -12,16 +12,16 @@ import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
-import io.confluent.ksql.rest.entity.KsqlErrorMessage;
 import io.confluent.ksql.rest.entity.KsqlRequest;
 import io.confluent.ksql.rest.server.computation.ReplayableCommandQueue;
 import io.confluent.ksql.rest.server.resources.KsqlRestException;
 import java.time.Duration;
 import java.util.Optional;
 import java.util.concurrent.TimeoutException;
-import javax.ws.rs.core.Response;
 import org.eclipse.jetty.http.HttpStatus.Code;
+import org.junit.Rule;
 import org.junit.Test;
+import org.junit.rules.ExpectedException;
 import org.junit.runner.RunWith;
 import org.mockito.Mock;
 import org.mockito.junit.MockitoJUnitRunner;
@@ -31,6 +31,9 @@ public class CommandStoreUtilTest {
 
   private static final Duration TIMEOUT = Duration.ofMillis(5000L);
   private static final long SEQUENCE_NUMBER = 2;
+
+  @Rule
+  public final ExpectedException expectedException = ExpectedException.none();
 
   @Mock
   private ReplayableCommandQueue replayableCommandQueue;
@@ -68,18 +71,12 @@ public class CommandStoreUtilTest {
     doThrow(new TimeoutException("uh oh"))
         .when(replayableCommandQueue).ensureConsumedPast(SEQUENCE_NUMBER, TIMEOUT);
 
-    try {
-      // When:
-      CommandStoreUtil.httpWaitForCommandSequenceNumber(replayableCommandQueue, request, TIMEOUT);
+    // Expect:
+    expectedException.expect(KsqlRestException.class);
+    expectedException.expect(exceptionStatusCode(is(Code.SERVICE_UNAVAILABLE)));
+    expectedException.expect(exceptionKsqlErrorMessage(errorMessage(is("uh oh"))));
 
-      // Then:
-      fail("Should propagate error.");
-    } catch (final KsqlRestException e) {
-      final Response response = e.getResponse();
-      assertThat(response.getStatus(), is(Code.SERVICE_UNAVAILABLE.getCode()));
-      assertThat(response.getEntity(), is(instanceOf(KsqlErrorMessage.class)));
-      final KsqlErrorMessage message = (KsqlErrorMessage) (response.getEntity());
-      assertThat(message.getMessage(), is("uh oh"));
-    }
+    // When:
+    CommandStoreUtil.httpWaitForCommandSequenceNumber(replayableCommandQueue, request, TIMEOUT);
   }
 }


### PR DESCRIPTION
### Description 
Add some matchers for `KsqlRestException` and `KsqlErrorMessage`

(Mainly as an example of how to do this)

### Testing done 
Test only change.

### Reviewer checklist
- [ ] Ensure docs are updated if necessary. (eg. if a user visible feature is being added or changed).
- [ ] Ensure relevant issues are linked (description should include text like "Fixes #<issue number>")

