### PR TITLE
Docker: set /etc/ksql-server writable by root group 

### DIFF
--- a/cp-ksql-server/Dockerfile
+++ b/cp-ksql-server/Dockerfile
@@ -1,7 +1,7 @@
 ARG DOCKER_UPSTREAM_REGISTRY
 ARG DOCKER_UPSTREAM_TAG
 
-FROM ${DOCKER_UPSTREAM_REGISTRY}confluentinc/cp-base-new:${DOCKER_UPSTREAM_TAG}
+FROM ${DOCKER_UPSTREAM_REGISTRY}confluentinc/cp-base:${DOCKER_UPSTREAM_TAG}
 
 EXPOSE 8088
 
@@ -24,7 +24,8 @@ ADD target/${ARTIFACT_ID}-${PROJECT_VERSION}-package/etc/* /etc/ksql/
 
 COPY include/etc/confluent/docker /etc/confluent/docker
 
-RUN mkdir -p /etc/${COMPONENT} /etc/${COMPONENT}/secrets
+RUN mkdir -p /etc/${COMPONENT} /etc/${COMPONENT}/secrets \
+    && chmod -R g+w /etc/${COMPONENT}
 
 RUN chmod +x /etc/confluent/docker/run
 RUN chmod +x /etc/confluent/docker/configure


### PR DESCRIPTION
(in order to be compliant with openshift in non-privileged mode)

### Description 
When launching the container whith a non-root user (but that belongs to the root group), it ends up with an error :  `Command [/usr/local/bin/dub path /etc/ksql-server/ writable] FAILED !`
fixes #2284 

### Testing done 
Try to launch the container with a non root user : 

`docker run --user=104 --group-add=0 --rm confluentinc/cp-ksql-server:5.0.1`

`dub path /etc/"${COMPONENT}"/ writable`
`+ dub path /etc/ksql-server/ writable`
`Command [/usr/local/bin/dub path /etc/ksql-server/ writable] FAILED !`

### Reviewer checklist
- [ ] Ensure docs are updated if necessary. (eg. if a user visible feature is being added or changed).
- [ ] Ensure relevant issues are linked (description should include text like "Fixes #<issue number>")

