### PR TITLE
[MINOR]: remove unused map from command store `getRestoreCommands`

### DIFF
--- a/ksql-rest-app/src/main/java/io/confluent/ksql/rest/server/computation/CommandStore.java
+++ b/ksql-rest-app/src/main/java/io/confluent/ksql/rest/server/computation/CommandStore.java
@@ -192,7 +192,6 @@ public class CommandStore implements CommandQueue, Closeable {
 
     log.debug("Reading prior command records");
 
-    final Map<CommandId, ConsumerRecord<CommandId, Command>> commands = Maps.newLinkedHashMap();
     ConsumerRecords<CommandId, Command> records =
         commandConsumer.poll(POLLING_TIMEOUT_FOR_COMMAND_TOPIC);
     while (!records.isEmpty()) {
@@ -209,7 +208,7 @@ public class CommandStore implements CommandQueue, Closeable {
       }
       records = commandConsumer.poll(POLLING_TIMEOUT_FOR_COMMAND_TOPIC);
     }
-    log.debug("Retrieved records:" + commands.size());
+    log.debug("Retrieved records:" + restoreCommands.size());
     return restoreCommands;
   }
 


### PR DESCRIPTION
### Description 
Remove the map in `getRestoreCommands` as it is not used anymore


### Reviewer checklist
- [ ] Ensure docs are updated if necessary. (eg. if a user visible feature is being added or changed).
- [ ] Ensure relevant issues are linked (description should include text like "Fixes #<issue number>")

