### PR TITLE
MINOR: Backport easymock dependency on ksql-test-util to 5.1.x

### DIFF
--- a/ksql-test-util/pom.xml
+++ b/ksql-test-util/pom.xml
@@ -83,6 +83,12 @@
     </dependency>
 
     <dependency>
+      <groupId>org.easymock</groupId>
+      <artifactId>easymock</artifactId>
+      <scope>compile</scope>
+    </dependency>
+
+    <dependency>
       <groupId>com.google.guava</groupId>
       <artifactId>guava-testlib</artifactId>
       <scope>compile</scope>


### PR DESCRIPTION
### Description 
Tests that import `TestKsqlRestApp` on 5.1.x need the dependency on easymock (same as it's imported on `master` branch currently

### Testing done 
_Ran unit tests on this repo as well as dependent repos importing `TestKsqlRestApp`_

### Reviewer checklist
- [ ] Ensure docs are updated if necessary. (eg. if a user visible feature is being added or changed).
- [ ] Ensure relevant issues are linked (description should include text like "Fixes #<issue number>")

