### PR TITLE
Clean up how we pass configs around when building the physical plan

### DIFF
--- a/ksql-common/src/test/java/io/confluent/ksql/util/KsqlConfigTest.java
+++ b/ksql-common/src/test/java/io/confluent/ksql/util/KsqlConfigTest.java
@@ -260,6 +260,27 @@ public class KsqlConfigTest {
   }
 
   @Test
+  public void shouldCloneWithMultipleOverwrites() {
+    final KsqlConfig ksqlConfig = new KsqlConfig(ImmutableMap.of(
+        ConsumerConfig.AUTO_COMMIT_INTERVAL_MS_CONFIG, "123",
+        ConsumerConfig.AUTO_OFFSET_RESET_CONFIG, "latest"
+    ));
+    final KsqlConfig clone = ksqlConfig.cloneWithPropertyOverwrite(ImmutableMap.of(
+        StreamsConfig.NUM_STREAM_THREADS_CONFIG, "2",
+        ConsumerConfig.AUTO_COMMIT_INTERVAL_MS_CONFIG, "456"
+    ));
+    final KsqlConfig cloneClone = clone.cloneWithPropertyOverwrite(ImmutableMap.of(
+        ConsumerConfig.AUTO_OFFSET_RESET_CONFIG, "earliest",
+        StreamsConfig.METADATA_MAX_AGE_CONFIG, "13"
+    ));
+    final Map<String, ?> props = cloneClone.getKsqlStreamConfigProps();
+    assertThat(props.get(ConsumerConfig.AUTO_COMMIT_INTERVAL_MS_CONFIG), equalTo(456));
+    assertThat(props.get(ConsumerConfig.AUTO_OFFSET_RESET_CONFIG), equalTo("earliest"));
+    assertThat(props.get(StreamsConfig.NUM_STREAM_THREADS_CONFIG), equalTo(2));
+    assertThat(props.get(StreamsConfig.METADATA_MAX_AGE_CONFIG), equalTo(13L));
+  }
+
+  @Test
   public void shouldCloneWithPrefixedStreamPropertyOverwrite() {
     final KsqlConfig ksqlConfig = new KsqlConfig(Collections.singletonMap(
         KsqlConfig.KSQL_STREAMS_PREFIX + ConsumerConfig.FETCH_MIN_BYTES_CONFIG, "100"));

--- a/ksql-engine/src/main/java/io/confluent/ksql/physical/PhysicalPlanBuilder.java
+++ b/ksql-engine/src/main/java/io/confluent/ksql/physical/PhysicalPlanBuilder.java
@@ -108,7 +108,6 @@ public class PhysicalPlanBuilder {
             ksqlConfig,
             serviceContext,
             functionRegistry,
-            overriddenProperties,
             queryId
         );
     final OutputNode outputNode = resultStream.outputNode();
@@ -184,7 +183,6 @@ public class PhysicalPlanBuilder {
     final Map<String, Object> streamsProperties = buildStreamsProperties(
         applicationId,
         ksqlConfig,
-        overriddenProperties,
         queryId
     );
     final KafkaStreams streams = kafkaStreamsBuilder.buildKafkaStreams(builder, streamsProperties);
@@ -260,7 +258,6 @@ public class PhysicalPlanBuilder {
     final Map<String, Object> streamsProperties = buildStreamsProperties(
         applicationId,
         ksqlConfig,
-        overriddenProperties,
         queryId
     );
     final KafkaStreams streams = kafkaStreamsBuilder.buildKafkaStreams(builder, streamsProperties);
@@ -358,12 +355,10 @@ public class PhysicalPlanBuilder {
   private static Map<String, Object> buildStreamsProperties(
       final String applicationId,
       final KsqlConfig ksqlConfig,
-      final Map<String, Object> overriddenProperties,
       final QueryId queryId
   ) {
     final Map<String, Object> newStreamsProperties
         = new HashMap<>(ksqlConfig.getKsqlStreamConfigProps());
-    newStreamsProperties.putAll(overriddenProperties);
     newStreamsProperties.put(StreamsConfig.APPLICATION_ID_CONFIG, applicationId);
     newStreamsProperties.put(
         ProductionExceptionHandlerUtil.KSQL_PRODUCTION_ERROR_LOGGER_NAME,

--- a/ksql-engine/src/main/java/io/confluent/ksql/planner/plan/AggregateNode.java
+++ b/ksql-engine/src/main/java/io/confluent/ksql/planner/plan/AggregateNode.java
@@ -180,7 +180,6 @@ public class AggregateNode extends PlanNode {
       final KsqlConfig ksqlConfig,
       final ServiceContext serviceContext,
       final FunctionRegistry functionRegistry,
-      final Map<String, Object> props,
       final QueryId queryId
   ) {
     final QueryContext.Stacker contextStacker = buildNodeContext(queryId);
@@ -190,7 +189,6 @@ public class AggregateNode extends PlanNode {
         ksqlConfig,
         serviceContext,
         functionRegistry,
-        props,
         queryId
     );
 

--- a/ksql-engine/src/main/java/io/confluent/ksql/planner/plan/FilterNode.java
+++ b/ksql-engine/src/main/java/io/confluent/ksql/planner/plan/FilterNode.java
@@ -25,7 +25,6 @@ import io.confluent.ksql.services.ServiceContext;
 import io.confluent.ksql.structured.SchemaKStream;
 import io.confluent.ksql.util.KsqlConfig;
 import java.util.List;
-import java.util.Map;
 import javax.annotation.concurrent.Immutable;
 import org.apache.kafka.connect.data.Field;
 import org.apache.kafka.connect.data.Schema;
@@ -92,14 +91,12 @@ public class FilterNode
       final KsqlConfig ksqlConfig,
       final ServiceContext serviceContext,
       final FunctionRegistry functionRegistry,
-      final Map<String, Object> props,
       final QueryId queryId) {
     return getSource().buildStream(
         builder,
         ksqlConfig,
         serviceContext,
         functionRegistry,
-        props,
         queryId
     ).filter(getPredicate(), buildNodeContext(queryId));
   }

--- a/ksql-engine/src/main/java/io/confluent/ksql/planner/plan/JoinNode.java
+++ b/ksql-engine/src/main/java/io/confluent/ksql/planner/plan/JoinNode.java
@@ -33,7 +33,7 @@ import io.confluent.ksql.util.Pair;
 import io.confluent.ksql.util.QueryLoggerUtil;
 import io.confluent.ksql.util.SchemaUtil;
 import java.util.Arrays;
-import java.util.HashMap;
+import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
@@ -178,7 +178,6 @@ public class JoinNode extends PlanNode {
       final KsqlConfig ksqlConfig,
       final ServiceContext serviceContext,
       final FunctionRegistry functionRegistry,
-      final Map<String, Object> props,
       final QueryId queryId) {
 
     ensureMatchingPartitionCounts(serviceContext.getTopicClient());
@@ -188,7 +187,6 @@ public class JoinNode extends PlanNode {
         ksqlConfig,
         serviceContext,
         functionRegistry,
-        props,
         this,
         queryId,
         buildNodeContext(queryId));
@@ -233,7 +231,6 @@ public class JoinNode extends PlanNode {
         final KsqlConfig ksqlConfig,
         final ServiceContext serviceContext,
         final FunctionRegistry functionRegistry,
-        final Map<String, Object> props,
         final JoinNode joinNode,
         final QueryId queryId,
         final QueryContext.Stacker contextStacker
@@ -245,7 +242,6 @@ public class JoinNode extends PlanNode {
               ksqlConfig,
               serviceContext,
               functionRegistry,
-              props,
               joinNode,
               queryId,
               contextStacker),
@@ -255,7 +251,6 @@ public class JoinNode extends PlanNode {
               ksqlConfig,
               serviceContext,
               functionRegistry,
-              props,
               joinNode,
               queryId,
               contextStacker),
@@ -265,7 +260,6 @@ public class JoinNode extends PlanNode {
               ksqlConfig,
               serviceContext,
               functionRegistry,
-              props,
               joinNode,
               queryId,
               contextStacker)
@@ -287,7 +281,6 @@ public class JoinNode extends PlanNode {
     protected final KsqlConfig ksqlConfig;
     private final ServiceContext serviceContext;
     protected final FunctionRegistry functionRegistry;
-    protected final Map<String, Object> props;
     final JoinNode joinNode;
     final QueryContext.Stacker contextStacker;
     final QueryId queryId;
@@ -297,7 +290,6 @@ public class JoinNode extends PlanNode {
         final KsqlConfig ksqlConfig,
         final ServiceContext serviceContext,
         final FunctionRegistry functionRegistry,
-        final Map<String, Object> props,
         final JoinNode joinNode,
         final QueryId queryId,
         final QueryContext.Stacker contextStacker
@@ -306,7 +298,6 @@ public class JoinNode extends PlanNode {
       this.ksqlConfig = Objects.requireNonNull(ksqlConfig, "ksqlConfig");
       this.serviceContext = Objects.requireNonNull(serviceContext, "serviceContext");
       this.functionRegistry = Objects.requireNonNull(functionRegistry, "functionRegistry");
-      this.props = Objects.requireNonNull(props, "props");
       this.joinNode = Objects.requireNonNull(joinNode, "joinNode");
       this.queryId = Objects.requireNonNull(queryId, "queryId");
       this.contextStacker = Objects.requireNonNull(contextStacker, "contextStacker");
@@ -322,7 +313,6 @@ public class JoinNode extends PlanNode {
               ksqlConfig,
               serviceContext,
               functionRegistry,
-              props,
               queryId),
           keyFieldName,
           contextStacker);
@@ -332,16 +322,12 @@ public class JoinNode extends PlanNode {
     protected SchemaKTable buildTable(final PlanNode node,
                                       final String keyFieldName,
                                       final String tableName) {
-
-      final Map<String, Object> joinTableProps = new HashMap<>(props);
-      joinTableProps.put(ConsumerConfig.AUTO_OFFSET_RESET_CONFIG, "earliest");
-
       final SchemaKStream schemaKStream = node.buildStream(
           builder,
-          ksqlConfig,
+          ksqlConfig.cloneWithPropertyOverwrite(
+              Collections.singletonMap(ConsumerConfig.AUTO_OFFSET_RESET_CONFIG, "earliest")),
           serviceContext,
           functionRegistry,
-          joinTableProps,
           queryId);
 
       if (!(schemaKStream instanceof SchemaKTable)) {
@@ -413,7 +399,6 @@ public class JoinNode extends PlanNode {
         final KsqlConfig ksqlConfig,
         final ServiceContext serviceContext,
         final FunctionRegistry functionRegistry,
-        final Map<String, Object> props,
         final JoinNode joinNode,
         final QueryId queryId,
         final QueryContext.Stacker contextStacker
@@ -423,7 +408,6 @@ public class JoinNode extends PlanNode {
           ksqlConfig,
           serviceContext,
           functionRegistry,
-          props,
           joinNode,
           queryId,
           contextStacker);
@@ -498,7 +482,6 @@ public class JoinNode extends PlanNode {
         final KsqlConfig ksqlConfig,
         final ServiceContext serviceContext,
         final FunctionRegistry functionRegistry,
-        final Map<String, Object> props,
         final JoinNode joinNode,
         final QueryId queryId,
         final QueryContext.Stacker contextStacker
@@ -508,7 +491,6 @@ public class JoinNode extends PlanNode {
           ksqlConfig,
           serviceContext,
           functionRegistry,
-          props,
           joinNode,
           queryId,
           contextStacker);
@@ -566,7 +548,6 @@ public class JoinNode extends PlanNode {
         final KsqlConfig ksqlConfig,
         final ServiceContext serviceContext,
         final FunctionRegistry functionRegistry,
-        final Map<String, Object> props,
         final JoinNode joinNode,
         final QueryId queryId,
         final QueryContext.Stacker contextStacker
@@ -576,7 +557,6 @@ public class JoinNode extends PlanNode {
           ksqlConfig,
           serviceContext,
           functionRegistry,
-          props,
           joinNode,
           queryId,
           contextStacker);

--- a/ksql-engine/src/main/java/io/confluent/ksql/planner/plan/KsqlBareOutputNode.java
+++ b/ksql-engine/src/main/java/io/confluent/ksql/planner/plan/KsqlBareOutputNode.java
@@ -23,7 +23,6 @@ import io.confluent.ksql.structured.SchemaKStream;
 import io.confluent.ksql.util.KsqlConfig;
 import io.confluent.ksql.util.QueryIdGenerator;
 import io.confluent.ksql.util.timestamp.TimestampExtractionPolicy;
-import java.util.Map;
 import java.util.Optional;
 import java.util.concurrent.ThreadLocalRandom;
 import org.apache.kafka.connect.data.Field;
@@ -63,14 +62,12 @@ public class KsqlBareOutputNode extends OutputNode {
       final KsqlConfig ksqlConfig,
       final ServiceContext serviceContext,
       final FunctionRegistry functionRegistry,
-      final Map<String, Object> props,
       final QueryId queryId) {
     final SchemaKStream schemaKStream = getSource().buildStream(
         builder,
         ksqlConfig,
         serviceContext,
         functionRegistry,
-        props,
         queryId);
 
     schemaKStream.setOutputNode(this);

--- a/ksql-engine/src/main/java/io/confluent/ksql/planner/plan/KsqlStructuredDataOutputNode.java
+++ b/ksql-engine/src/main/java/io/confluent/ksql/planner/plan/KsqlStructuredDataOutputNode.java
@@ -103,7 +103,6 @@ public class KsqlStructuredDataOutputNode extends OutputNode {
       final KsqlConfig ksqlConfig,
       final ServiceContext serviceContext,
       final FunctionRegistry functionRegistry,
-      final Map<String, Object> props,
       final QueryId queryId
   ) {
     final PlanNode source = getSource();
@@ -112,7 +111,6 @@ public class KsqlStructuredDataOutputNode extends OutputNode {
         ksqlConfig,
         serviceContext,
         functionRegistry,
-        props,
         queryId
     );
 

--- a/ksql-engine/src/main/java/io/confluent/ksql/planner/plan/PlanNode.java
+++ b/ksql-engine/src/main/java/io/confluent/ksql/planner/plan/PlanNode.java
@@ -26,7 +26,6 @@ import io.confluent.ksql.structured.QueryContext;
 import io.confluent.ksql.structured.SchemaKStream;
 import io.confluent.ksql.util.KsqlConfig;
 import java.util.List;
-import java.util.Map;
 import org.apache.kafka.connect.data.Field;
 import org.apache.kafka.connect.data.Schema;
 import org.apache.kafka.streams.StreamsBuilder;
@@ -83,6 +82,5 @@ public abstract class PlanNode {
       KsqlConfig ksqlConfig,
       ServiceContext serviceContext,
       FunctionRegistry functionRegistry,
-      Map<String, Object> props,
       QueryId queryId);
 }

--- a/ksql-engine/src/main/java/io/confluent/ksql/planner/plan/ProjectNode.java
+++ b/ksql-engine/src/main/java/io/confluent/ksql/planner/plan/ProjectNode.java
@@ -28,7 +28,6 @@ import io.confluent.ksql.util.KsqlException;
 import io.confluent.ksql.util.SelectExpression;
 import java.util.ArrayList;
 import java.util.List;
-import java.util.Map;
 import java.util.Objects;
 import javax.annotation.concurrent.Immutable;
 import org.apache.kafka.connect.data.Field;
@@ -104,14 +103,12 @@ public class ProjectNode
       final KsqlConfig ksqlConfig,
       final ServiceContext serviceContext,
       final FunctionRegistry functionRegistry,
-      final Map<String, Object> props,
       final QueryId queryId) {
     return getSource().buildStream(
         builder,
         ksqlConfig,
         serviceContext, 
         functionRegistry,
-        props,
         queryId
     ).select(
         getProjectSelectExpressions(),

--- a/ksql-engine/src/main/java/io/confluent/ksql/planner/plan/StructuredDataSourceNode.java
+++ b/ksql-engine/src/main/java/io/confluent/ksql/planner/plan/StructuredDataSourceNode.java
@@ -161,7 +161,6 @@ public class StructuredDataSourceNode
       final KsqlConfig ksqlConfig,
       final ServiceContext serviceContext,
       final FunctionRegistry functionRegistry,
-      final Map<String, Object> props,
       final QueryId queryId
   ) {
     final QueryContext.Stacker contextStacker = buildNodeContext(queryId);
@@ -185,7 +184,7 @@ public class StructuredDataSourceNode
       final QueryContext.Stacker reduceContextStacker = contextStacker.push(REDUCE_OP_NAME);
       final KTable<?, GenericRow> kTable = createKTable(
           builder,
-          getAutoOffsetReset(props),
+          getAutoOffsetReset(ksqlConfig.getKsqlStreamConfigProps()),
           genericRowSerde,
           table.getKsqlTopic().getKsqlTopicSerDe().getGenericRowSerde(
               getSchema(),

--- a/ksql-engine/src/test/java/io/confluent/ksql/physical/PhysicalPlanBuilderTest.java
+++ b/ksql-engine/src/test/java/io/confluent/ksql/physical/PhysicalPlanBuilderTest.java
@@ -164,7 +164,7 @@ public class PhysicalPlanBuilderTest {
     final InternalFunctionRegistry functionRegistry = new InternalFunctionRegistry();
     return new PhysicalPlanBuilder(
         streamsBuilder,
-        ksqlConfig,
+        ksqlConfig.cloneWithPropertyOverwrite(overrideProperties),
         serviceContext,
         functionRegistry,
         overrideProperties,

--- a/ksql-engine/src/test/java/io/confluent/ksql/planner/plan/AggregateNodeTest.java
+++ b/ksql-engine/src/test/java/io/confluent/ksql/planner/plan/AggregateNodeTest.java
@@ -303,7 +303,6 @@ public class AggregateNodeTest {
             ksqlConfig,
             serviceContext,
             new InternalFunctionRegistry(),
-            new HashMap<>(),
             queryId);
   }
 

--- a/ksql-engine/src/test/java/io/confluent/ksql/planner/plan/FilterNodeTest.java
+++ b/ksql-engine/src/test/java/io/confluent/ksql/planner/plan/FilterNodeTest.java
@@ -64,7 +64,7 @@ public class FilterNodeTest {
   @Before
   @SuppressWarnings("unchecked")
   public void setup() {
-    when(sourceNode.buildStream(any(), any(), any(), any(), any(), any()))
+    when(sourceNode.buildStream(any(), any(), any(), any(), any()))
         .thenReturn(schemaKStream);
     when(sourceNode.getNodeOutputType()).thenReturn(DataSourceType.KSTREAM);
     when(schemaKStream.filter(any(), any()))
@@ -80,7 +80,6 @@ public class FilterNodeTest {
         ksqlConfig,
         serviceContext,
         functionRegistry,
-        props,
         queryId
     );
 
@@ -90,7 +89,6 @@ public class FilterNodeTest {
         same(ksqlConfig),
         same(serviceContext),
         same(functionRegistry),
-        same(props),
         same(queryId)
     );
     verify(schemaKStream).filter(

--- a/ksql-engine/src/test/java/io/confluent/ksql/planner/plan/KsqlBareOutputNodeTest.java
+++ b/ksql-engine/src/test/java/io/confluent/ksql/planner/plan/KsqlBareOutputNodeTest.java
@@ -153,7 +153,6 @@ public class KsqlBareOutputNodeTest {
         new KsqlConfig(Collections.emptyMap()),
         serviceContext,
         new InternalFunctionRegistry(),
-        new HashMap<>(),
         queryId);
   }
 

--- a/ksql-engine/src/test/java/io/confluent/ksql/planner/plan/KsqlStructuredDataOutputNodeTest.java
+++ b/ksql-engine/src/test/java/io/confluent/ksql/planner/plan/KsqlStructuredDataOutputNodeTest.java
@@ -154,7 +154,6 @@ public class KsqlStructuredDataOutputNodeTest {
         ksqlConfig,
         serviceContext,
         new InternalFunctionRegistry(),
-        new HashMap<>(),
         QUERY_ID);
   }
 

--- a/ksql-engine/src/test/java/io/confluent/ksql/planner/plan/OutputNodeTest.java
+++ b/ksql-engine/src/test/java/io/confluent/ksql/planner/plan/OutputNodeTest.java
@@ -174,7 +174,6 @@ public class OutputNodeTest {
         final KsqlConfig ksqlConfig,
         final ServiceContext serviceContext,
         final FunctionRegistry functionRegistry,
-        final Map<String, Object> props,
         final QueryId queryId
     ) {
       return null;

--- a/ksql-engine/src/test/java/io/confluent/ksql/planner/plan/ProjectNodeTest.java
+++ b/ksql-engine/src/test/java/io/confluent/ksql/planner/plan/ProjectNodeTest.java
@@ -36,7 +36,6 @@ import io.confluent.ksql.util.KsqlException;
 import io.confluent.ksql.util.SelectExpression;
 import java.util.Arrays;
 import java.util.Collections;
-import java.util.HashMap;
 import java.util.List;
 import org.apache.kafka.connect.data.Field;
 import org.apache.kafka.connect.data.Schema;
@@ -61,7 +60,6 @@ public class ProjectNodeTest {
   private final KsqlConfig ksqlConfig = new KsqlConfig(Collections.emptyMap());
   private final ServiceContext serviceContext = TestServiceContext.create();
   private final InternalFunctionRegistry functionRegistry = new InternalFunctionRegistry();
-  private final HashMap<String, Object> props = new HashMap<>();
   private final QueryId queryId = new QueryId("project-test");
 
   @Rule
@@ -99,7 +97,6 @@ public class ProjectNodeTest {
         ksqlConfig,
         serviceContext,
         functionRegistry,
-        props,
         queryId);
   }
 
@@ -119,7 +116,6 @@ public class ProjectNodeTest {
         ksqlConfig,
         serviceContext,
         functionRegistry,
-        props,
         queryId);
 
     // Then:
@@ -134,7 +130,6 @@ public class ProjectNodeTest {
         same(ksqlConfig),
         same(serviceContext),
         same(functionRegistry),
-        same(props),
         same(queryId)
     );
   }
@@ -148,7 +143,6 @@ public class ProjectNodeTest {
         any(KsqlConfig.class),
         any(ServiceContext.class),
         any(InternalFunctionRegistry.class),
-        anyMap(),
         same(queryId))
     ).thenReturn(stream);
   }

--- a/ksql-engine/src/test/java/io/confluent/ksql/planner/plan/StructuredDataSourceNodeTest.java
+++ b/ksql-engine/src/test/java/io/confluent/ksql/planner/plan/StructuredDataSourceNodeTest.java
@@ -203,7 +203,6 @@ public class StructuredDataSourceNodeTest {
         realConfig,
         serviceContext,
         functionRegistry,
-        Collections.emptyMap(),
         queryId
     );
 
@@ -336,7 +335,6 @@ public class StructuredDataSourceNodeTest {
         realConfig,
         serviceContext,
         new InternalFunctionRegistry(),
-        new HashMap<>(),
         queryId);
   }
 

--- a/ksql-rest-app/src/test/java/io/confluent/ksql/rest/entity/QueryDescriptionTest.java
+++ b/ksql-rest-app/src/test/java/io/confluent/ksql/rest/entity/QueryDescriptionTest.java
@@ -99,7 +99,6 @@ public class QueryDescriptionTest {
         final KsqlConfig ksqlConfig,
         final ServiceContext serviceContext,
         final FunctionRegistry functionRegistry,
-        final Map<String, Object> props,
         final QueryId queryId
     ) {
       return null;


### PR DESCRIPTION
### Description 
When building the physical plan, we pass around KsqlConfig as well as the overridden
properties supplied by the client. This is unnecessary, since KsqlConfig has already
been updated to reflect the property overrides. This patch cleans this up so that we
just use KsqlConfig.

### Testing done 
No new functionality so the existing tests should suffice.

### Reviewer checklist
- [ ] Ensure docs are updated if necessary. (eg. if a user visible feature is being added or changed).
- [ ] Ensure relevant issues are linked (description should include text like "Fixes #<issue number>")

