### PR TITLE
minor cleanup of string-masking UDF param handling

### DIFF
--- a/ksql-engine/src/main/java/io/confluent/ksql/function/udf/string/MaskKeepLeftKudf.java
+++ b/ksql-engine/src/main/java/io/confluent/ksql/function/udf/string/MaskKeepLeftKudf.java
@@ -14,7 +14,6 @@
 
 package io.confluent.ksql.function.udf.string;
 
-import io.confluent.ksql.function.KsqlFunctionException;
 import io.confluent.ksql.function.udf.Udf;
 import io.confluent.ksql.function.udf.UdfDescription;
 
@@ -24,6 +23,7 @@ import io.confluent.ksql.function.udf.UdfDescription;
         + " Default masking rules will replace all upper-case characters with 'X', all lower-case"
         + " characters with 'x', all digits with 'n', and any other character with '-'.")
 public class MaskKeepLeftKudf {
+  private final String udfName = Masker.getMaskUdfName(this);
 
   @Udf(description = "Returns a masked version of the input string. All characters except for the"
       + " first n will be replaced according to the default masking rules.")
@@ -49,7 +49,7 @@ public class MaskKeepLeftKudf {
   }
 
   private String doMask(final Masker masker, final String input, final int numChars) {
-    validateParams(numChars);
+    Masker.validateParams(this.udfName, numChars);
     if (input == null) {
       return null;
     }
@@ -60,10 +60,4 @@ public class MaskKeepLeftKudf {
     return output.toString();
   }
 
-  private void validateParams(final int numChars) {
-    if (numChars < 0) {
-      throw new KsqlFunctionException(
-          "mask_keep_left requires a non-negative number of characters not to mask");
-    }
-  }
 }

--- a/ksql-engine/src/main/java/io/confluent/ksql/function/udf/string/MaskKeepLeftKudf.java
+++ b/ksql-engine/src/main/java/io/confluent/ksql/function/udf/string/MaskKeepLeftKudf.java
@@ -17,13 +17,13 @@ package io.confluent.ksql.function.udf.string;
 import io.confluent.ksql.function.udf.Udf;
 import io.confluent.ksql.function.udf.UdfDescription;
 
-@UdfDescription(name = "mask_keep_left", author = "Confluent",
+@UdfDescription(name = MaskKeepLeftKudf.NAME, author = "Confluent",
     description = "Returns a version of the input string with all but the"
         + " specified number of left-most characters masked out."
         + " Default masking rules will replace all upper-case characters with 'X', all lower-case"
         + " characters with 'x', all digits with 'n', and any other character with '-'.")
 public class MaskKeepLeftKudf {
-  private final String udfName = Masker.getMaskUdfName(this);
+  protected static final String NAME = "mask_keep_left";
 
   @Udf(description = "Returns a masked version of the input string. All characters except for the"
       + " first n will be replaced according to the default masking rules.")
@@ -49,7 +49,7 @@ public class MaskKeepLeftKudf {
   }
 
   private String doMask(final Masker masker, final String input, final int numChars) {
-    Masker.validateParams(this.udfName, numChars);
+    Masker.validateParams(this.NAME, numChars);
     if (input == null) {
       return null;
     }

--- a/ksql-engine/src/main/java/io/confluent/ksql/function/udf/string/MaskKeepLeftKudf.java
+++ b/ksql-engine/src/main/java/io/confluent/ksql/function/udf/string/MaskKeepLeftKudf.java
@@ -49,7 +49,7 @@ public class MaskKeepLeftKudf {
   }
 
   private String doMask(final Masker masker, final String input, final int numChars) {
-    Masker.validateParams(this.NAME, numChars);
+    Masker.validateParams(NAME, numChars);
     if (input == null) {
       return null;
     }

--- a/ksql-engine/src/main/java/io/confluent/ksql/function/udf/string/MaskKeepRightKudf.java
+++ b/ksql-engine/src/main/java/io/confluent/ksql/function/udf/string/MaskKeepRightKudf.java
@@ -14,7 +14,6 @@
 
 package io.confluent.ksql.function.udf.string;
 
-import io.confluent.ksql.function.KsqlFunctionException;
 import io.confluent.ksql.function.udf.Udf;
 import io.confluent.ksql.function.udf.UdfDescription;
 
@@ -24,6 +23,7 @@ import io.confluent.ksql.function.udf.UdfDescription;
         + " Default masking rules will replace all upper-case characters with 'X', all lower-case"
         + " characters with 'x', all digits with 'n', and any other character with '-'.")
 public class MaskKeepRightKudf {
+  private final String udfName = Masker.getMaskUdfName(this);
 
   @Udf(description = "Returns a masked version of the input string. All characters except for the"
       + " last n will be replaced according to the default masking rules.")
@@ -49,7 +49,7 @@ public class MaskKeepRightKudf {
   }
 
   private String doMask(final Masker masker, final String input, final int numChars) {
-    validateParams(numChars);
+    Masker.validateParams(udfName, numChars);
     if (input == null) {
       return null;
     }
@@ -58,12 +58,5 @@ public class MaskKeepRightKudf {
     output.append(masker.mask(input.substring(0, charsToMask)));
     output.append(input.substring(charsToMask));
     return output.toString();
-  }
-
-  private void validateParams(final int numChars) {
-    if (numChars < 0) {
-      throw new KsqlFunctionException(
-          "mask_keep_right requires a non-negative number of characters not to mask");
-    }
   }
 }

--- a/ksql-engine/src/main/java/io/confluent/ksql/function/udf/string/MaskKeepRightKudf.java
+++ b/ksql-engine/src/main/java/io/confluent/ksql/function/udf/string/MaskKeepRightKudf.java
@@ -17,13 +17,13 @@ package io.confluent.ksql.function.udf.string;
 import io.confluent.ksql.function.udf.Udf;
 import io.confluent.ksql.function.udf.UdfDescription;
 
-@UdfDescription(name = "mask_keep_right", author = "Confluent",
+@UdfDescription(name = MaskKeepRightKudf.NAME, author = "Confluent",
     description = "Returns a version of the input string with all but the"
         + " specified number of right-most characters masked out."
         + " Default masking rules will replace all upper-case characters with 'X', all lower-case"
         + " characters with 'x', all digits with 'n', and any other character with '-'.")
 public class MaskKeepRightKudf {
-  private final String udfName = Masker.getMaskUdfName(this);
+  protected static final String NAME = "mask_keep_right";
 
   @Udf(description = "Returns a masked version of the input string. All characters except for the"
       + " last n will be replaced according to the default masking rules.")
@@ -49,7 +49,7 @@ public class MaskKeepRightKudf {
   }
 
   private String doMask(final Masker masker, final String input, final int numChars) {
-    Masker.validateParams(udfName, numChars);
+    Masker.validateParams(NAME, numChars);
     if (input == null) {
       return null;
     }

--- a/ksql-engine/src/main/java/io/confluent/ksql/function/udf/string/MaskLeftKudf.java
+++ b/ksql-engine/src/main/java/io/confluent/ksql/function/udf/string/MaskLeftKudf.java
@@ -14,7 +14,6 @@
 
 package io.confluent.ksql.function.udf.string;
 
-import io.confluent.ksql.function.KsqlFunctionException;
 import io.confluent.ksql.function.udf.Udf;
 import io.confluent.ksql.function.udf.UdfDescription;
 
@@ -24,6 +23,7 @@ import io.confluent.ksql.function.udf.UdfDescription;
         + " Default masking rules will replace all upper-case characters with 'X', all lower-case"
         + " characters with 'x', all digits with 'n', and any other character with '-'.")
 public class MaskLeftKudf {
+  private final String udfName = Masker.getMaskUdfName(this);
 
   @Udf(description = "Returns a masked version of the input string. The first n characters"
       + " will be replaced according to the default masking rules.")
@@ -49,7 +49,7 @@ public class MaskLeftKudf {
   }
 
   private String doMask(final Masker masker, final String input, final int numChars) {
-    validateParams(numChars);
+    Masker.validateParams(udfName, numChars);
     if (input == null) {
       return null;
     }
@@ -58,12 +58,5 @@ public class MaskLeftKudf {
     output.append(masker.mask(input.substring(0, charsToMask)));
     output.append(input.substring(charsToMask));
     return output.toString();
-  }
-
-  private void validateParams(final int numChars) {
-    if (numChars < 0) {
-      throw new KsqlFunctionException(
-          "mask_left requires a non-negative number of characters to mask");
-    }
   }
 }

--- a/ksql-engine/src/main/java/io/confluent/ksql/function/udf/string/MaskLeftKudf.java
+++ b/ksql-engine/src/main/java/io/confluent/ksql/function/udf/string/MaskLeftKudf.java
@@ -17,13 +17,13 @@ package io.confluent.ksql.function.udf.string;
 import io.confluent.ksql.function.udf.Udf;
 import io.confluent.ksql.function.udf.UdfDescription;
 
-@UdfDescription(name = "mask_left", author = "Confluent",
+@UdfDescription(name = MaskLeftKudf.NAME, author = "Confluent",
     description = "Returns a version of the input string with the"
         + " specified number of characters, starting from the beginning of the string, masked out."
         + " Default masking rules will replace all upper-case characters with 'X', all lower-case"
         + " characters with 'x', all digits with 'n', and any other character with '-'.")
 public class MaskLeftKudf {
-  private final String udfName = Masker.getMaskUdfName(this);
+  protected static final String NAME = "mask_left";
 
   @Udf(description = "Returns a masked version of the input string. The first n characters"
       + " will be replaced according to the default masking rules.")
@@ -49,7 +49,7 @@ public class MaskLeftKudf {
   }
 
   private String doMask(final Masker masker, final String input, final int numChars) {
-    Masker.validateParams(udfName, numChars);
+    Masker.validateParams(NAME, numChars);
     if (input == null) {
       return null;
     }

--- a/ksql-engine/src/main/java/io/confluent/ksql/function/udf/string/MaskRightKudf.java
+++ b/ksql-engine/src/main/java/io/confluent/ksql/function/udf/string/MaskRightKudf.java
@@ -14,7 +14,6 @@
 
 package io.confluent.ksql.function.udf.string;
 
-import io.confluent.ksql.function.KsqlFunctionException;
 import io.confluent.ksql.function.udf.Udf;
 import io.confluent.ksql.function.udf.UdfDescription;
 
@@ -24,6 +23,7 @@ import io.confluent.ksql.function.udf.UdfDescription;
         + " Default masking rules will replace all upper-case characters with 'X', all lower-case"
         + " characters with 'x', all digits with 'n', and any other character with '-'.")
 public class MaskRightKudf {
+  private final String udfName = Masker.getMaskUdfName(this);
 
   @Udf(description = "Returns a masked version of the input string. The last n characters"
       + " will be replaced according to the default masking rules.")
@@ -49,7 +49,7 @@ public class MaskRightKudf {
   }
 
   private String doMask(final Masker masker, final String input, final int numChars) {
-    validateParams(numChars);
+    Masker.validateParams(udfName, numChars);
     if (input == null) {
       return null;
     }
@@ -58,12 +58,5 @@ public class MaskRightKudf {
     output.append(input.substring(0, charsToKeep));
     output.append(masker.mask(input.substring(charsToKeep)));
     return output.toString();
-  }
-
-  private void validateParams(final int numChars) {
-    if (numChars < 0) {
-      throw new KsqlFunctionException(
-          "mask_right requires a non-negative number of characters to mask");
-    }
   }
 }

--- a/ksql-engine/src/main/java/io/confluent/ksql/function/udf/string/MaskRightKudf.java
+++ b/ksql-engine/src/main/java/io/confluent/ksql/function/udf/string/MaskRightKudf.java
@@ -17,13 +17,13 @@ package io.confluent.ksql.function.udf.string;
 import io.confluent.ksql.function.udf.Udf;
 import io.confluent.ksql.function.udf.UdfDescription;
 
-@UdfDescription(name = "mask_right", author = "Confluent",
+@UdfDescription(name = MaskRightKudf.NAME, author = "Confluent",
     description = "Returns a version of the input string with the"
         + " specified number of characters, counting back from the end of the string, masked out."
         + " Default masking rules will replace all upper-case characters with 'X', all lower-case"
         + " characters with 'x', all digits with 'n', and any other character with '-'.")
 public class MaskRightKudf {
-  private final String udfName = Masker.getMaskUdfName(this);
+  protected static final String NAME = "mask_right";
 
   @Udf(description = "Returns a masked version of the input string. The last n characters"
       + " will be replaced according to the default masking rules.")
@@ -49,7 +49,7 @@ public class MaskRightKudf {
   }
 
   private String doMask(final Masker masker, final String input, final int numChars) {
-    Masker.validateParams(udfName, numChars);
+    Masker.validateParams(NAME, numChars);
     if (input == null) {
       return null;
     }

--- a/ksql-engine/src/main/java/io/confluent/ksql/function/udf/string/Masker.java
+++ b/ksql-engine/src/main/java/io/confluent/ksql/function/udf/string/Masker.java
@@ -14,6 +14,9 @@
 
 package io.confluent.ksql.function.udf.string;
 
+import io.confluent.ksql.function.KsqlFunctionException;
+import io.confluent.ksql.function.udf.UdfDescription;
+
 class Masker {
 
   private static final int DEFAULT_UPPERCASE_MASK = 'X';
@@ -73,5 +76,16 @@ class Masker {
 
   static int getMaskCharacter(final String stringMask) {
     return stringMask == null ? NO_MASK : stringMask.codePointAt(0);
+  }
+
+  static void validateParams(final String udfName, final int numChars) {
+    if (numChars < 0) {
+      throw new KsqlFunctionException(
+          "function " + udfName + " requires a non-negative number of characters to mask or skip");
+    }
+  }
+
+  static String getMaskUdfName(final Object maskObject) {
+    return maskObject.getClass().getAnnotation(UdfDescription.class).name();
   }
 }

--- a/ksql-engine/src/main/java/io/confluent/ksql/function/udf/string/Masker.java
+++ b/ksql-engine/src/main/java/io/confluent/ksql/function/udf/string/Masker.java
@@ -15,7 +15,6 @@
 package io.confluent.ksql.function.udf.string;
 
 import io.confluent.ksql.function.KsqlFunctionException;
-import io.confluent.ksql.function.udf.UdfDescription;
 
 class Masker {
 
@@ -83,9 +82,5 @@ class Masker {
       throw new KsqlFunctionException(
           "function " + udfName + " requires a non-negative number of characters to mask or skip");
     }
-  }
-
-  static String getMaskUdfName(final Object maskObject) {
-    return maskObject.getClass().getAnnotation(UdfDescription.class).name();
   }
 }

--- a/ksql-engine/src/test/java/io/confluent/ksql/function/udf/string/MaskKeepLeftKudfTest.java
+++ b/ksql-engine/src/test/java/io/confluent/ksql/function/udf/string/MaskKeepLeftKudfTest.java
@@ -44,7 +44,7 @@ public class MaskKeepLeftKudfTest {
   @Test
   public void shouldThrowIfLengthIsNegative() {
     expectedException.expect(KsqlFunctionException.class);
-    expectedException.expectMessage("mask_keep_left requires a non-negative number");
+    expectedException.expectMessage("function mask_keep_left requires a non-negative number");
     udf.mask("AbCd#$123xy Z", -1);
  }
 

--- a/ksql-engine/src/test/java/io/confluent/ksql/function/udf/string/MaskKeepRightKudfTest.java
+++ b/ksql-engine/src/test/java/io/confluent/ksql/function/udf/string/MaskKeepRightKudfTest.java
@@ -44,7 +44,7 @@ public class MaskKeepRightKudfTest {
   @Test
   public void shouldThrowIfLengthIsNegative() {
     expectedException.expect(KsqlFunctionException.class);
-    expectedException.expectMessage("mask_keep_right requires a non-negative number");
+    expectedException.expectMessage("function mask_keep_right requires a non-negative number");
     udf.mask("AbCd#$123xy Z", -1);
  }
 

--- a/ksql-engine/src/test/java/io/confluent/ksql/function/udf/string/MaskLeftKudfTest.java
+++ b/ksql-engine/src/test/java/io/confluent/ksql/function/udf/string/MaskLeftKudfTest.java
@@ -44,7 +44,7 @@ public class MaskLeftKudfTest {
   @Test
   public void shouldThrowIfLengthIsNegative() {
     expectedException.expect(KsqlFunctionException.class);
-    expectedException.expectMessage("mask_left requires a non-negative number");
+    expectedException.expectMessage("function mask_left requires a non-negative number");
     udf.mask("AbCd#$123xy Z", -1);
   }
 

--- a/ksql-engine/src/test/java/io/confluent/ksql/function/udf/string/MaskRightKudfTest.java
+++ b/ksql-engine/src/test/java/io/confluent/ksql/function/udf/string/MaskRightKudfTest.java
@@ -44,7 +44,7 @@ public class MaskRightKudfTest {
   @Test
   public void shouldThrowIfLengthIsNegative() {
     expectedException.expect(KsqlFunctionException.class);
-    expectedException.expectMessage("mask_right requires a non-negative number");
+    expectedException.expectMessage("function mask_right requires a non-negative number");
     udf.mask("AbCd#$123xy Z", -1);
   }
 


### PR DESCRIPTION
Move duplicated validateParams() method to the Masker class.
This commit is part of the PR-1504 (https://github.com/confluentinc/ksql/pull/1504)

### Description 
Do minor cleanup on the mask classes by removing a duplicated validation method, and move it
to the Masker class.

### Testing done 
All unit tests passed locally.

### Reviewer checklist
- [ ] Ensure docs are updated if necessary. (eg. if a user visible feature is being added or changed).
- [ ] Ensure relevant issues are linked (description should include text like "Fixes #<issue number>")

