### PR TITLE
Introducing a new family of url functions. replaces #1492

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -6,8 +6,7 @@ Version 5.2.0
 
 KSQL 5.2 includes new features, including:
 
-* Added a new family of UDFs for improved handling of URIs (e.g. extracting information/decoding
-information), see :doc:`developer-guide/syntax-reference` for all URL functions
+* Added a new family of UDFs for improved handling of URIs (e.g. extracting information/decoding information), see :ref:`UDF table <functions>` for all URL functions
 
 KSQL 5.2 includes bug fixes, including:
 

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -6,7 +6,8 @@ Version 5.2.0
 
 KSQL 5.2 includes new features, including:
 
-* Added a new family of UDFs for improved handling of URIs (e.g. extracting information/decoding information)
+* Added a new family of UDFs for improved handling of URIs (e.g. extracting information/decoding
+information), see :doc:`developer-guide/syntax-reference` for all URL functions
 
 KSQL 5.2 includes bug fixes, including:
 

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -1,6 +1,15 @@
 Changelog
 =========
 
+Version 5.2.0
+-------------
+
+KSQL 5.2 includes new features, including:
+
+* Added a new family of UDFs for improved handling of URIs (e.g. extracting information/decoding information)
+
+KSQL 5.2 includes bug fixes, including:
+
 Version 5.1.0
 -------------
 

--- a/docs/developer-guide/syntax-reference.rst
+++ b/docs/developer-guide/syntax-reference.rst
@@ -1364,20 +1364,31 @@ Scalar functions
 +------------------------+---------------------------------------------------------------------------+---------------------------------------------------+
 | URL_DECODE_PARAM       |  ``URL_DECODE_PARAM(col1)``                                               | Unescapes the URL-param-encoded [1]_ value in     |
 |                        |                                                                           | col1. This is the inverse of the URL_ENCODE_PARAM |
-|                        |                                                                           | function.                                         |
+|                        |                                                                           |                                                   |
+|                        |                                                                           | e.g ``URL_DECODE_PARAM('url%20encoded')`` would   |
+|                        |                                                                           | return ``'url encoded'``.                         |
 +------------------------+---------------------------------------------------------------------------+---------------------------------------------------+
 | URL_ENCODE_PARAM       |  ``URL_ENCODE_PARAM(col1)``                                               | Escapes the value of col1 such that it can safely |
 |                        |                                                                           | be used in URL query parameters. Note that this   |
 |                        |                                                                           | is not the same as encoding a value for use in    |
 |                        |                                                                           | the path portion of a URL.                        |
+|                        |                                                                           |                                                   |
+|                        |                                                                           | e.g ``URL_ENCODE_PARAM('url encoded')`` would     |
+|                        |                                                                           | return ``'url%20encoded'``.                       |
 +------------------------+---------------------------------------------------------------------------+---------------------------------------------------+
 | URL_EXTRACT_FRAGMENT   |  ``URL_EXTRACT_FRAGMENT(url)``                                            | Extract the fragment portion of the specified     |
 |                        |                                                                           | value. Returns NULL if no fragment is present or  |
 |                        |                                                                           | supplied value is not a valid URI.                |
+|                        |                                                                           |                                                   |
+|                        |                                                                           | e.g. for the url ``http://test.com?query#frag``,  |
+|                        |                                                                           | this UDF will return ``frag``                     |
 +------------------------+---------------------------------------------------------------------------+---------------------------------------------------+
 | URL_EXTRACT_HOST       |  ``URL_EXTRACT_HOST(url)``                                                | Extract the host-name portion of the specified    |
 |                        |                                                                           | value. Returns NULL if the supplied value is not  |
 |                        |                                                                           | a valid URI according to RFC-2396.                |
+|                        |                                                                           |                                                   |
+|                        |                                                                           | e.g. for the url ``http://test.com?query#frag``,  |
+|                        |                                                                           | this UDF will return ``test.com``                 |
 +------------------------+---------------------------------------------------------------------------+---------------------------------------------------+
 | URL_EXTRACT_PARAMETER  |  ``URL_EXTRACT_PARAMETER(url, parameter_name)``                           | Extract the value of the requested parameter from |
 |                        |                                                                           | the query-string of the url value. Returns NULL   |
@@ -1386,22 +1397,38 @@ Scalar functions
 |                        |                                                                           | input URL is not a valid URI.                     |
 |                        |                                                                           | To get all the parameter names and values from a  |
 |                        |                                                                           | URL as a single string, see URL_EXTRACT_QUERY.    |
+|                        |                                                                           |                                                   |
+|                        |                                                                           | e.g. for the url ``http://test.com?a=foo&b=bar``, |
+|                        |                                                                           | this UDF will return ``foo`` when parameterized on|
+|                        |                                                                           | `a` and ``bar`` when parameterized on `b`         |
 +------------------------+---------------------------------------------------------------------------+---------------------------------------------------+
 | URL_EXTRACT_PATH       |  ``URL_EXTRACT_PATH(url)``                                                | Extracts the path from the specified url value.   |
 |                        |                                                                           | Returns NULL if the supplied value is not a valid |
 |                        |                                                                           | URI, but returns "" if the path is empty.         |
+|                        |                                                                           |                                                   |
+|                        |                                                                           | e.g. for the url ``http://test.com/path/to#a``,   |
+|                        |                                                                           | this UDF will return ``path/to``                  |
 +------------------------+---------------------------------------------------------------------------+---------------------------------------------------+
 | URL_EXTRACT_PORT       |  ``URL_EXTRACT_PORT(url)``                                                | Extract the port number from the specified value. |
 |                        |                                                                           | Returns NULL if the supplied value is not a valid |
 |                        |                                                                           | URI or does not contain an explicit port number.  |
+|                        |                                                                           |                                                   |
+|                        |                                                                           | e.g. for the url ``http://test@localhost:8080``,  |
+|                        |                                                                           | this UDF will return ``8080``                     |
 +------------------------+---------------------------------------------------------------------------+---------------------------------------------------+
 | URL_EXTRACT_PROTOCOL   |  ``URL_EXTRACT_PROTOCOL(url)``                                            | Extract the protocol from the specified value,    |
 |                        |                                                                           | e.g. 'https'. Returns NULL if the supplied value  |
 |                        |                                                                           | is not a valid URI or it contains no protocol.    |
+|                        |                                                                           |                                                   |
+|                        |                                                                           | e.g. for the url ``http://test.com?a=foo&b=bar``, |
+|                        |                                                                           | this UDF will return ``http``                     |
 +------------------------+---------------------------------------------------------------------------+---------------------------------------------------+
 | URL_EXTRACT_QUERY      |  ``URL_EXTRACT_QUERY(url)``                                               | Extract the decoded query-string portion of the   |
 |                        |                                                                           | specified URL. Returns NULL if no query-string    |
 |                        |                                                                           | is present or the URL is not a valid URI.         |
+|                        |                                                                           |                                                   |
+|                        |                                                                           | e.g. for the url ``http://test.com?a=foo&b=bar``, |
+|                        |                                                                           | this UDF will return ``a=foo&b=bar``              |
 +------------------------+---------------------------------------------------------------------------+---------------------------------------------------+
 
 .. [1] All KSQL URL functions assume URI syntax defined in `RFC 39386`_.

--- a/docs/developer-guide/syntax-reference.rst
+++ b/docs/developer-guide/syntax-reference.rst
@@ -1379,34 +1379,39 @@ Scalar functions
 +------------------------+---------------------------------------------------------------------------+---------------------------------------------------+
 | URL_EXTRACT_FRAGMENT   |  ``URL_EXTRACT_FRAGMENT(url)``                                            | Extract the fragment portion of the specified     |
 |                        |                                                                           | value. Returns NULL if ``url`` is not a valid URL |
+|                        |                                                                           | or if the fragment does not exist. Any encoded    |
+|                        |                                                                           | value will be decoded.                            |
 |                        |                                                                           |                                                   |
-|                        |                                                                           | Input: ``http://test.com?query#frag``,            |
+|                        |                                                                           | Input: ``http://test.com#frag``,                  |
 |                        |                                                                           | Output: ``frag``                                  |
+|                        |                                                                           | Input: ``http://test.com#frag%20space``,          |
+|                        |                                                                           | Output: ``frag space``                            |
 +------------------------+---------------------------------------------------------------------------+---------------------------------------------------+
 | URL_EXTRACT_HOST       |  ``URL_EXTRACT_HOST(url)``                                                | Extract the host-name portion of the specified    |
 |                        |                                                                           | value. Returns NULL if the ``url`` is not a valid |
 |                        |                                                                           | URI according to RFC-2396.                        |
 |                        |                                                                           |                                                   |
-|                        |                                                                           | Input: ``http://test.com?query#frag``,            |
+|                        |                                                                           | Input: ``http://test.com:8080/path``,             |
 |                        |                                                                           | Output: ``test.com``                              |
 +------------------------+---------------------------------------------------------------------------+---------------------------------------------------+
 | URL_EXTRACT_PARAMETER  |  ``URL_EXTRACT_PARAMETER(url, parameter_name)``                           | Extract the value of the requested parameter from |
 |                        |                                                                           | the query-string of ``url``. Returns NULL         |
 |                        |                                                                           | if the parameter is not present, has no value     |
 |                        |                                                                           | specified for it in the query-string, or ``url``  |
-|                        |                                                                           | is not a valid URI.                               |
+|                        |                                                                           | is not a valid URI. Encodes the param and decodes |
+|                        |                                                                           | the output (see examples).                        |
 |                        |                                                                           |                                                   |
 |                        |                                                                           | To get all of the parameter values from a         |
 |                        |                                                                           | URL as a single string, see ``URL_EXTRACT_QUERY.``|
 |                        |                                                                           |                                                   |
-|                        |                                                                           | Input: ``http://test.com?a=foo&b=bar``, `a`       |
-|                        |                                                                           | Output: ``foo``                                   |
+|                        |                                                                           | Input: ``http://test.com?a%20b=c%20d``, ``a b``   |
+|                        |                                                                           | Output: ``c d``                                   |
 |                        |                                                                           | Input: ``http://test.com?a=foo&b=bar``, `b`       |
 |                        |                                                                           | Output: ``bar``                                   |
 +------------------------+---------------------------------------------------------------------------+---------------------------------------------------+
 | URL_EXTRACT_PATH       |  ``URL_EXTRACT_PATH(url)``                                                | Extracts the path from ``url``.                   |
 |                        |                                                                           | Returns NULL if ``url`` is not a valid URI but    |
-|                        |                                                                           | returns "" if the path is empty.                  |
+|                        |                                                                           | returns an empty string if the path is empty.     |
 |                        |                                                                           |                                                   |
 |                        |                                                                           | Input: ``http://test.com/path/to#a``              |
 |                        |                                                                           | Output: ``path/to``                               |
@@ -1415,7 +1420,7 @@ Scalar functions
 |                        |                                                                           | Returns NULL if ``url`` is not a valid URI or does|
 |                        |                                                                           | not contain an explicit port number.              |
 |                        |                                                                           |                                                   |
-|                        |                                                                           | Input: ``http://test@localhost:8080``             |
+|                        |                                                                           | Input: ``http://localhost:8080/path``             |
 |                        |                                                                           | Output: ``8080``                                  |
 +------------------------+---------------------------------------------------------------------------+---------------------------------------------------+
 | URL_EXTRACT_PROTOCOL   |  ``URL_EXTRACT_PROTOCOL(url)``                                            | Extract the protocol from ``url``. Returns NULL if|
@@ -1428,8 +1433,8 @@ Scalar functions
 |                        |                                                                           | ``url``. Returns NULL if no query-string is       |
 |                        |                                                                           | present or ``url`` is not a valid URI.            |
 |                        |                                                                           |                                                   |
-|                        |                                                                           | e.g. for the url ``http://test.com?a=foo&b=bar``, |
-|                        |                                                                           | this UDF will return ``a=foo&b=bar``              |
+|                        |                                                                           | Input: ``http://test.com?a=foo%20bar&b=baz``,     |
+|                        |                                                                           | Output: ``a=foo bar&b=baz``                       |
 +------------------------+---------------------------------------------------------------------------+---------------------------------------------------+
 
 .. _URL-param-encoded:

--- a/docs/developer-guide/syntax-reference.rst
+++ b/docs/developer-guide/syntax-reference.rst
@@ -1362,8 +1362,8 @@ Scalar functions
 +------------------------+---------------------------------------------------------------------------+---------------------------------------------------+
 | UCASE                  |  ``UCASE(col1)``                                                          | Convert a string to uppercase.                    |
 +------------------------+---------------------------------------------------------------------------+---------------------------------------------------+
-| URL_DECODE_PARAM       |  ``URL_DECODE_PARAM(col1)``                                               | Unescapes the URL-param-encoded value in col1.    |
-|                        |                                                                           | This is the inverse of the URL_ENCODE_PARAM       |
+| URL_DECODE_PARAM       |  ``URL_DECODE_PARAM(col1)``                                               | Unescapes the URL-param-encoded [1]_ value in     |
+|                        |                                                                           | col1. This is the inverse of the URL_ENCODE_PARAM |
 |                        |                                                                           | function.                                         |
 +------------------------+---------------------------------------------------------------------------+---------------------------------------------------+
 | URL_ENCODE_PARAM       |  ``URL_ENCODE_PARAM(col1)``                                               | Escapes the value of col1 such that it can safely |
@@ -1403,6 +1403,13 @@ Scalar functions
 |                        |                                                                           | specified URL. Returns NULL if no query-string    |
 |                        |                                                                           | is present or the URL is not a valid URI.         |
 +------------------------+---------------------------------------------------------------------------+---------------------------------------------------+
+
+.. [1] All KSQL URL functions assume URI syntax defined in `RFC 39386`_.
+   For more information on the structure of a URI, including definitions of the various components,
+   see Section 3 of the RFC. For encoding/decoding, the ``application/x-www-form-urlencoded``
+   convention is followed.
+
+.. _RFC 39386: https://tools.ietf.org/html/rfc3986
 
 .. _ksql_aggregate_functions:
 

--- a/docs/developer-guide/syntax-reference.rst
+++ b/docs/developer-guide/syntax-reference.rst
@@ -1362,79 +1362,82 @@ Scalar functions
 +------------------------+---------------------------------------------------------------------------+---------------------------------------------------+
 | UCASE                  |  ``UCASE(col1)``                                                          | Convert a string to uppercase.                    |
 +------------------------+---------------------------------------------------------------------------+---------------------------------------------------+
-| URL_DECODE_PARAM       |  ``URL_DECODE_PARAM(col1)``                                               | Unescapes the URL-param-encoded [1]_ value in     |
-|                        |                                                                           | col1. This is the inverse of the URL_ENCODE_PARAM |
+| URL_DECODE_PARAM       |  ``URL_DECODE_PARAM(col1)``                                               | Unescapes the `URL-param-encoded`_ value in       |
+|                        |                                                                           | ``col1`` This is the inverse of URL_ENCODE_PARAM  |
+|                        |                                                                           | :superscript:`*`                                  |
 |                        |                                                                           |                                                   |
-|                        |                                                                           | e.g ``URL_DECODE_PARAM('url%20encoded')`` would   |
-|                        |                                                                           | return ``'url encoded'``.                         |
+|                        |                                                                           | Input: ``'url%20encoded``                         |
+|                        |                                                                           | Output: ``url encoded``                           |
 +------------------------+---------------------------------------------------------------------------+---------------------------------------------------+
-| URL_ENCODE_PARAM       |  ``URL_ENCODE_PARAM(col1)``                                               | Escapes the value of col1 such that it can safely |
-|                        |                                                                           | be used in URL query parameters. Note that this   |
-|                        |                                                                           | is not the same as encoding a value for use in    |
-|                        |                                                                           | the path portion of a URL.                        |
+| URL_ENCODE_PARAM       |  ``URL_ENCODE_PARAM(col1)``                                               | Escapes the value of ``col1`` such that it can    |
+|                        |                                                                           | safely be used in URL query parameters. Note that |
+|                        |                                                                           | this is not the same as encoding a value for use  |
+|                        |                                                                           | in the path portion of a URL.                     |
 |                        |                                                                           |                                                   |
-|                        |                                                                           | e.g ``URL_ENCODE_PARAM('url encoded')`` would     |
-|                        |                                                                           | return ``'url%20encoded'``.                       |
+|                        |                                                                           | Input: ``url encoded``                            |
+|                        |                                                                           | Output: ``'url%20encoded``                        |
 +------------------------+---------------------------------------------------------------------------+---------------------------------------------------+
 | URL_EXTRACT_FRAGMENT   |  ``URL_EXTRACT_FRAGMENT(url)``                                            | Extract the fragment portion of the specified     |
-|                        |                                                                           | value. Returns NULL if no fragment is present or  |
-|                        |                                                                           | supplied value is not a valid URI.                |
+|                        |                                                                           | value. Returns NULL if ``url`` is not a valid URL |
 |                        |                                                                           |                                                   |
-|                        |                                                                           | e.g. for the url ``http://test.com?query#frag``,  |
-|                        |                                                                           | this UDF will return ``frag``                     |
+|                        |                                                                           | Input: ``http://test.com?query#frag``,            |
+|                        |                                                                           | Output: ``frag``                                  |
 +------------------------+---------------------------------------------------------------------------+---------------------------------------------------+
 | URL_EXTRACT_HOST       |  ``URL_EXTRACT_HOST(url)``                                                | Extract the host-name portion of the specified    |
-|                        |                                                                           | value. Returns NULL if the supplied value is not  |
-|                        |                                                                           | a valid URI according to RFC-2396.                |
+|                        |                                                                           | value. Returns NULL if the ``url`` is not a valid |
+|                        |                                                                           | URI according to RFC-2396.                        |
 |                        |                                                                           |                                                   |
-|                        |                                                                           | e.g. for the url ``http://test.com?query#frag``,  |
-|                        |                                                                           | this UDF will return ``test.com``                 |
+|                        |                                                                           | Input: ``http://test.com?query#frag``,            |
+|                        |                                                                           | Output: ``test.com``                              |
 +------------------------+---------------------------------------------------------------------------+---------------------------------------------------+
 | URL_EXTRACT_PARAMETER  |  ``URL_EXTRACT_PARAMETER(url, parameter_name)``                           | Extract the value of the requested parameter from |
-|                        |                                                                           | the query-string of the url value. Returns NULL   |
+|                        |                                                                           | the query-string of ``url``. Returns NULL         |
 |                        |                                                                           | if the parameter is not present, has no value     |
-|                        |                                                                           | specified for it in the query-string, or the      |
-|                        |                                                                           | input URL is not a valid URI.                     |
-|                        |                                                                           | To get all the parameter names and values from a  |
-|                        |                                                                           | URL as a single string, see URL_EXTRACT_QUERY.    |
+|                        |                                                                           | specified for it in the query-string, or ``url``  |
+|                        |                                                                           | is not a valid URI.                               |
 |                        |                                                                           |                                                   |
-|                        |                                                                           | e.g. for the url ``http://test.com?a=foo&b=bar``, |
-|                        |                                                                           | this UDF will return ``foo`` when parameterized on|
-|                        |                                                                           | `a` and ``bar`` when parameterized on `b`         |
-+------------------------+---------------------------------------------------------------------------+---------------------------------------------------+
-| URL_EXTRACT_PATH       |  ``URL_EXTRACT_PATH(url)``                                                | Extracts the path from the specified url value.   |
-|                        |                                                                           | Returns NULL if the supplied value is not a valid |
-|                        |                                                                           | URI, but returns "" if the path is empty.         |
+|                        |                                                                           | To get all of the parameter values from a         |
+|                        |                                                                           | URL as a single string, see ``URL_EXTRACT_QUERY.``|
 |                        |                                                                           |                                                   |
-|                        |                                                                           | e.g. for the url ``http://test.com/path/to#a``,   |
-|                        |                                                                           | this UDF will return ``path/to``                  |
+|                        |                                                                           | Input: ``http://test.com?a=foo&b=bar``, `a`       |
+|                        |                                                                           | Output: ``foo``                                   |
+|                        |                                                                           | Input: ``http://test.com?a=foo&b=bar``, `b`       |
+|                        |                                                                           | Output: ``bar``                                   |
 +------------------------+---------------------------------------------------------------------------+---------------------------------------------------+
-| URL_EXTRACT_PORT       |  ``URL_EXTRACT_PORT(url)``                                                | Extract the port number from the specified value. |
-|                        |                                                                           | Returns NULL if the supplied value is not a valid |
-|                        |                                                                           | URI or does not contain an explicit port number.  |
+| URL_EXTRACT_PATH       |  ``URL_EXTRACT_PATH(url)``                                                | Extracts the path from ``url``.                   |
+|                        |                                                                           | Returns NULL if ``url`` is not a valid URI but    |
+|                        |                                                                           | returns "" if the path is empty.                  |
 |                        |                                                                           |                                                   |
-|                        |                                                                           | e.g. for the url ``http://test@localhost:8080``,  |
-|                        |                                                                           | this UDF will return ``8080``                     |
+|                        |                                                                           | Input: ``http://test.com/path/to#a``              |
+|                        |                                                                           | Output: ``path/to``                               |
 +------------------------+---------------------------------------------------------------------------+---------------------------------------------------+
-| URL_EXTRACT_PROTOCOL   |  ``URL_EXTRACT_PROTOCOL(url)``                                            | Extract the protocol from the specified value,    |
-|                        |                                                                           | e.g. 'https'. Returns NULL if the supplied value  |
-|                        |                                                                           | is not a valid URI or it contains no protocol.    |
+| URL_EXTRACT_PORT       |  ``URL_EXTRACT_PORT(url)``                                                | Extract the port number from ``url``.             |
+|                        |                                                                           | Returns NULL if ``url`` is not a valid URI or does|
+|                        |                                                                           | not contain an explicit port number.              |
 |                        |                                                                           |                                                   |
-|                        |                                                                           | e.g. for the url ``http://test.com?a=foo&b=bar``, |
-|                        |                                                                           | this UDF will return ``http``                     |
+|                        |                                                                           | Input: ``http://test@localhost:8080``             |
+|                        |                                                                           | Output: ``8080``                                  |
 +------------------------+---------------------------------------------------------------------------+---------------------------------------------------+
-| URL_EXTRACT_QUERY      |  ``URL_EXTRACT_QUERY(url)``                                               | Extract the decoded query-string portion of the   |
-|                        |                                                                           | specified URL. Returns NULL if no query-string    |
-|                        |                                                                           | is present or the URL is not a valid URI.         |
+| URL_EXTRACT_PROTOCOL   |  ``URL_EXTRACT_PROTOCOL(url)``                                            | Extract the protocol from ``url``. Returns NULL if|
+|                        |                                                                           | ``url`` is an invalid URI or has no protocol.     |
+|                        |                                                                           |                                                   |
+|                        |                                                                           | Input: ``http://test.com?a=foo&b=bar``            |
+|                        |                                                                           | Output: ``http``                                  |
++------------------------+---------------------------------------------------------------------------+---------------------------------------------------+
+| URL_EXTRACT_QUERY      |  ``URL_EXTRACT_QUERY(url)``                                               | Extract the decoded query-string portion of       |
+|                        |                                                                           | ``url``. Returns NULL if no query-string is       |
+|                        |                                                                           | present or ``url`` is not a valid URI.            |
 |                        |                                                                           |                                                   |
 |                        |                                                                           | e.g. for the url ``http://test.com?a=foo&b=bar``, |
 |                        |                                                                           | this UDF will return ``a=foo&b=bar``              |
 +------------------------+---------------------------------------------------------------------------+---------------------------------------------------+
 
-.. [1] All KSQL URL functions assume URI syntax defined in `RFC 39386`_.
-   For more information on the structure of a URI, including definitions of the various components,
-   see Section 3 of the RFC. For encoding/decoding, the ``application/x-www-form-urlencoded``
-   convention is followed.
+.. _URL-param-encoded:
+
+:superscript:`*` All KSQL URL functions assume URI syntax defined in `RFC 39386`_.
+For more information on the structure of a URI, including definitions of the various components,
+see Section 3 of the RFC. For encoding/decoding, the ``application/x-www-form-urlencoded``
+convention is followed.
 
 .. _RFC 39386: https://tools.ietf.org/html/rfc3986
 

--- a/docs/developer-guide/syntax-reference.rst
+++ b/docs/developer-guide/syntax-reference.rst
@@ -1362,6 +1362,47 @@ Scalar functions
 +------------------------+---------------------------------------------------------------------------+---------------------------------------------------+
 | UCASE                  |  ``UCASE(col1)``                                                          | Convert a string to uppercase.                    |
 +------------------------+---------------------------------------------------------------------------+---------------------------------------------------+
+| URL_DECODE_PARAM       |  ``URL_DECODE_PARAM(col1)``                                               | Unescapes the URL-param-encoded value in col1.    |
+|                        |                                                                           | This is the inverse of the URL_ENCODE_PARAM       |
+|                        |                                                                           | function.                                         |
++------------------------+---------------------------------------------------------------------------+---------------------------------------------------+
+| URL_ENCODE_PARAM       |  ``URL_ENCODE_PARAM(col1)``                                               | Escapes the value of col1 such that it can safely |
+|                        |                                                                           | be used in URL query parameters. Note that this   |
+|                        |                                                                           | is not the same as encoding a value for use in    |
+|                        |                                                                           | the path portion of a URL.                        |
++------------------------+---------------------------------------------------------------------------+---------------------------------------------------+
+| URL_EXTRACT_FRAGMENT   |  ``URL_EXTRACT_FRAGMENT(url)``                                            | Extract the fragment portion of the specified     |
+|                        |                                                                           | value. Returns NULL if no fragment is present or  |
+|                        |                                                                           | supplied value is not a valid URI.                |
++------------------------+---------------------------------------------------------------------------+---------------------------------------------------+
+| URL_EXTRACT_HOST       |  ``URL_EXTRACT_HOST(url)``                                                | Extract the host-name portion of the specified    |
+|                        |                                                                           | value. Returns NULL if the supplied value is not  |
+|                        |                                                                           | a valid URI according to RFC-2396.                |
++------------------------+---------------------------------------------------------------------------+---------------------------------------------------+
+| URL_EXTRACT_PARAMETER  |  ``URL_EXTRACT_PARAMETER(url, parameter_name)``                           | Extract the value of the requested parameter from |
+|                        |                                                                           | the query-string of the url value. Returns NULL   |
+|                        |                                                                           | if the parameter is not present, has no value     |
+|                        |                                                                           | specified for it in the query-string, or the      |
+|                        |                                                                           | input URL is not a valid URI.                     |
+|                        |                                                                           | To get all the parameter names and values from a  |
+|                        |                                                                           | URL as a single string, see URL_EXTRACT_QUERY.    |
++------------------------+---------------------------------------------------------------------------+---------------------------------------------------+
+| URL_EXTRACT_PATH       |  ``URL_EXTRACT_PATH(url)``                                                | Extracts the path from the specified url value.   |
+|                        |                                                                           | Returns NULL if the supplied value is not a valid |
+|                        |                                                                           | URI, but returns "" if the path is empty.         |
++------------------------+---------------------------------------------------------------------------+---------------------------------------------------+
+| URL_EXTRACT_PORT       |  ``URL_EXTRACT_PORT(url)``                                                | Extract the port number from the specified value. |
+|                        |                                                                           | Returns NULL if the supplied value is not a valid |
+|                        |                                                                           | URI or does not contain an explicit port number.  |
++------------------------+---------------------------------------------------------------------------+---------------------------------------------------+
+| URL_EXTRACT_PROTOCOL   |  ``URL_EXTRACT_PROTOCOL(url)``                                            | Extract the protocol from the specified value,    |
+|                        |                                                                           | e.g. 'https'. Returns NULL if the supplied value  |
+|                        |                                                                           | is not a valid URI or it contains no protocol.    |
++------------------------+---------------------------------------------------------------------------+---------------------------------------------------+
+| URL_EXTRACT_QUERY      |  ``URL_EXTRACT_QUERY(url)``                                               | Extract the decoded query-string portion of the   |
+|                        |                                                                           | specified URL. Returns NULL if no query-string    |
+|                        |                                                                           | is present or the URL is not a valid URI.         |
++------------------------+---------------------------------------------------------------------------+---------------------------------------------------+
 
 .. _ksql_aggregate_functions:
 

--- a/ksql-common/src/main/java/io/confluent/ksql/util/KsqlConstants.java
+++ b/ksql-common/src/main/java/io/confluent/ksql/util/KsqlConstants.java
@@ -56,6 +56,4 @@ public final class KsqlConstants {
   public static final String AVRO_SCHEMA_NAME = "KsqlDataSourceSchema";
   public static final String DEFAULT_AVRO_SCHEMA_FULL_NAME =
           AVRO_SCHEMA_NAMESPACE + "." + AVRO_SCHEMA_NAME;
-
-  public static final String CONFLUENT_AUTHOR = "Confluent";
 }

--- a/ksql-common/src/main/java/io/confluent/ksql/util/KsqlConstants.java
+++ b/ksql-common/src/main/java/io/confluent/ksql/util/KsqlConstants.java
@@ -56,4 +56,6 @@ public final class KsqlConstants {
   public static final String AVRO_SCHEMA_NAME = "KsqlDataSourceSchema";
   public static final String DEFAULT_AVRO_SCHEMA_FULL_NAME =
           AVRO_SCHEMA_NAMESPACE + "." + AVRO_SCHEMA_NAME;
+
+  public static final String CONFLUENT_AUTHOR = "Confluent";
 }

--- a/ksql-engine/src/main/java/io/confluent/ksql/function/InternalFunctionRegistry.java
+++ b/ksql-engine/src/main/java/io/confluent/ksql/function/InternalFunctionRegistry.java
@@ -241,7 +241,6 @@ public class InternalFunctionRegistry implements FunctionRegistry {
         "RANDOM", RandomKudf.class);
     addFunction(random);
 
-
   }
 
   private void addGeoFunctions() {

--- a/ksql-engine/src/main/java/io/confluent/ksql/function/udf/url/UrlDecodeParamKudf.java
+++ b/ksql-engine/src/main/java/io/confluent/ksql/function/udf/url/UrlDecodeParamKudf.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright 2018 Confluent Inc.
+ *
+ * Licensed under the Confluent Community License; you may not use this file
+ * except in compliance with the License.  You may obtain a copy of the License at
+ *
+ * http://www.confluent.io/confluent-community-license
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package io.confluent.ksql.function.udf.url;
+
+import static java.nio.charset.StandardCharsets.UTF_8;
+
+import io.confluent.ksql.function.KsqlFunctionException;
+import io.confluent.ksql.function.udf.Udf;
+import io.confluent.ksql.function.udf.UdfDescription;
+import io.confluent.ksql.util.KsqlConstants;
+import java.io.UnsupportedEncodingException;
+import java.net.URLDecoder;
+
+
+@UdfDescription(
+        name = UrlDecodeParamKudf.NAME,
+        author = KsqlConstants.CONFLUENT_AUTHOR,
+        description = "Decodes a previously encoded application/x-www-form-urlencoded String")
+public class UrlDecodeParamKudf {
+
+  static final String NAME = "url_decode_param";
+
+  @Udf(description = "Decodes a previously encoded application/x-www-form-urlencoded String")
+  public String decodeParam(final String input) {
+    try {
+      return URLDecoder.decode(input, UTF_8.name());
+    } catch (final UnsupportedEncodingException e) {
+      throw new KsqlFunctionException("url_decode udf encountered an encoding exception", e);
+    }
+  }
+}

--- a/ksql-engine/src/main/java/io/confluent/ksql/function/udf/url/UrlDecodeParamKudf.java
+++ b/ksql-engine/src/main/java/io/confluent/ksql/function/udf/url/UrlDecodeParamKudf.java
@@ -20,14 +20,12 @@ import io.confluent.ksql.function.KsqlFunctionException;
 import io.confluent.ksql.function.udf.Udf;
 import io.confluent.ksql.function.udf.UdfDescription;
 import io.confluent.ksql.function.udf.UdfParameter;
-import io.confluent.ksql.util.KsqlConstants;
 import java.io.UnsupportedEncodingException;
 import java.net.URLDecoder;
 
 
 @UdfDescription(
         name = UrlDecodeParamKudf.NAME,
-        author = KsqlConstants.CONFLUENT_AUTHOR,
         description = "Decodes a previously encoded application/x-www-form-urlencoded String")
 public class UrlDecodeParamKudf {
 

--- a/ksql-engine/src/main/java/io/confluent/ksql/function/udf/url/UrlDecodeParamKudf.java
+++ b/ksql-engine/src/main/java/io/confluent/ksql/function/udf/url/UrlDecodeParamKudf.java
@@ -19,6 +19,7 @@ import static java.nio.charset.StandardCharsets.UTF_8;
 import io.confluent.ksql.function.KsqlFunctionException;
 import io.confluent.ksql.function.udf.Udf;
 import io.confluent.ksql.function.udf.UdfDescription;
+import io.confluent.ksql.function.udf.UdfParameter;
 import io.confluent.ksql.util.KsqlConstants;
 import java.io.UnsupportedEncodingException;
 import java.net.URLDecoder;
@@ -33,11 +34,13 @@ public class UrlDecodeParamKudf {
   static final String NAME = "url_decode_param";
 
   @Udf(description = "Decodes a previously encoded application/x-www-form-urlencoded String")
-  public String decodeParam(final String input) {
+  public String decodeParam(
+      @UdfParameter(value = "input", description = "the value to decode") final String input) {
     try {
       return URLDecoder.decode(input, UTF_8.name());
     } catch (final UnsupportedEncodingException e) {
-      throw new KsqlFunctionException("url_decode udf encountered an encoding exception", e);
+      throw new KsqlFunctionException(
+          "url_decode udf encountered an encoding exception while decoding: " + input, e);
     }
   }
 }

--- a/ksql-engine/src/main/java/io/confluent/ksql/function/udf/url/UrlDecodeParamKudf.java
+++ b/ksql-engine/src/main/java/io/confluent/ksql/function/udf/url/UrlDecodeParamKudf.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018 Confluent Inc.
+ * Copyright 2019 Confluent Inc.
  *
  * Licensed under the Confluent Community License; you may not use this file
  * except in compliance with the License.  You may obtain a copy of the License at
@@ -24,16 +24,16 @@ import java.io.UnsupportedEncodingException;
 import java.net.URLDecoder;
 
 
-@UdfDescription(
-        name = UrlDecodeParamKudf.NAME,
-        description = "Decodes a previously encoded application/x-www-form-urlencoded String")
+@UdfDescription(name = UrlDecodeParamKudf.NAME, description = UrlDecodeParamKudf.DESCRIPTION)
 public class UrlDecodeParamKudf {
 
+  static final String DESCRIPTION =
+      "Decodes a previously encoded application/x-www-form-urlencoded String";
   static final String NAME = "url_decode_param";
 
-  @Udf(description = "Decodes a previously encoded application/x-www-form-urlencoded String")
+  @Udf(description = DESCRIPTION)
   public String decodeParam(
-      @UdfParameter(value = "input", description = "the value to decode") final String input) {
+      @UdfParameter(description = "the value to decode") final String input) {
     try {
       return URLDecoder.decode(input, UTF_8.name());
     } catch (final UnsupportedEncodingException e) {

--- a/ksql-engine/src/main/java/io/confluent/ksql/function/udf/url/UrlEncodeParamKudf.java
+++ b/ksql-engine/src/main/java/io/confluent/ksql/function/udf/url/UrlEncodeParamKudf.java
@@ -18,6 +18,7 @@ import com.google.common.escape.Escaper;
 import com.google.common.net.UrlEscapers;
 import io.confluent.ksql.function.udf.Udf;
 import io.confluent.ksql.function.udf.UdfDescription;
+import io.confluent.ksql.function.udf.UdfParameter;
 import io.confluent.ksql.util.KsqlConstants;
 
 @UdfDescription(
@@ -31,7 +32,8 @@ public class UrlEncodeParamKudf {
 
   @Udf(description = "Returns a version of 'input' with all URL sensitive characters encoded using"
                      + "the aplpication/x-www-form-urlencoded standard.")
-  public String encodeParam(final String input) {
+  public String encodeParam(
+      @UdfParameter(value = "input", description = "the value to encode") final String input) {
     final Escaper escaper = UrlEscapers.urlFormParameterEscaper();
     return escaper.escape(input);
   }

--- a/ksql-engine/src/main/java/io/confluent/ksql/function/udf/url/UrlEncodeParamKudf.java
+++ b/ksql-engine/src/main/java/io/confluent/ksql/function/udf/url/UrlEncodeParamKudf.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018 Confluent Inc.
+ * Copyright 2019 Confluent Inc.
  *
  * Licensed under the Confluent Community License; you may not use this file
  * except in compliance with the License.  You may obtain a copy of the License at
@@ -20,18 +20,17 @@ import io.confluent.ksql.function.udf.Udf;
 import io.confluent.ksql.function.udf.UdfDescription;
 import io.confluent.ksql.function.udf.UdfParameter;
 
-@UdfDescription(
-        name = UrlEncodeParamKudf.NAME,
-        description = "Returns a version of the input with all URL sensitive characters encoded "
-                      + "using the application/x-www-form-urlencoded standard.")
+@UdfDescription(name = UrlEncodeParamKudf.NAME, description = UrlEncodeParamKudf.DESCRIPTION)
 public class UrlEncodeParamKudf {
 
+  static final String DESCRIPTION =
+      "Returns a version of the input with all URL sensitive characters encoded "
+          + "using the application/x-www-form-urlencoded standard.";
   static final String NAME = "url_encode_param";
 
-  @Udf(description = "Returns a version of 'input' with all URL sensitive characters encoded using"
-                     + "the aplpication/x-www-form-urlencoded standard.")
+  @Udf(description = DESCRIPTION)
   public String encodeParam(
-      @UdfParameter(value = "input", description = "the value to encode") final String input) {
+      @UdfParameter(description = "the value to encode") final String input) {
     final Escaper escaper = UrlEscapers.urlFormParameterEscaper();
     return escaper.escape(input);
   }

--- a/ksql-engine/src/main/java/io/confluent/ksql/function/udf/url/UrlEncodeParamKudf.java
+++ b/ksql-engine/src/main/java/io/confluent/ksql/function/udf/url/UrlEncodeParamKudf.java
@@ -19,11 +19,9 @@ import com.google.common.net.UrlEscapers;
 import io.confluent.ksql.function.udf.Udf;
 import io.confluent.ksql.function.udf.UdfDescription;
 import io.confluent.ksql.function.udf.UdfParameter;
-import io.confluent.ksql.util.KsqlConstants;
 
 @UdfDescription(
         name = UrlEncodeParamKudf.NAME,
-        author = KsqlConstants.CONFLUENT_AUTHOR,
         description = "Returns a version of the input with all URL sensitive characters encoded "
                       + "using the application/x-www-form-urlencoded standard.")
 public class UrlEncodeParamKudf {

--- a/ksql-engine/src/main/java/io/confluent/ksql/function/udf/url/UrlEncodeParamKudf.java
+++ b/ksql-engine/src/main/java/io/confluent/ksql/function/udf/url/UrlEncodeParamKudf.java
@@ -1,0 +1,38 @@
+/*
+ * Copyright 2018 Confluent Inc.
+ *
+ * Licensed under the Confluent Community License; you may not use this file
+ * except in compliance with the License.  You may obtain a copy of the License at
+ *
+ * http://www.confluent.io/confluent-community-license
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package io.confluent.ksql.function.udf.url;
+
+import com.google.common.escape.Escaper;
+import com.google.common.net.UrlEscapers;
+import io.confluent.ksql.function.udf.Udf;
+import io.confluent.ksql.function.udf.UdfDescription;
+import io.confluent.ksql.util.KsqlConstants;
+
+@UdfDescription(
+        name = UrlEncodeParamKudf.NAME,
+        author = KsqlConstants.CONFLUENT_AUTHOR,
+        description = "Returns a version of the input with all URL sensitive characters encoded "
+                      + "using the application/x-www-form-urlencoded standard.")
+public class UrlEncodeParamKudf {
+
+  static final String NAME = "url_encode_param";
+
+  @Udf(description = "Returns a version of 'input' with all URL sensitive characters encoded using"
+                     + "the aplpication/x-www-form-urlencoded standard.")
+  public String encodeParam(final String input) {
+    final Escaper escaper = UrlEscapers.urlFormParameterEscaper();
+    return escaper.escape(input);
+  }
+}

--- a/ksql-engine/src/main/java/io/confluent/ksql/function/udf/url/UrlExtractFragmentKudf.java
+++ b/ksql-engine/src/main/java/io/confluent/ksql/function/udf/url/UrlExtractFragmentKudf.java
@@ -16,6 +16,7 @@ package io.confluent.ksql.function.udf.url;
 
 import io.confluent.ksql.function.udf.Udf;
 import io.confluent.ksql.function.udf.UdfDescription;
+import io.confluent.ksql.function.udf.UdfParameter;
 import io.confluent.ksql.util.KsqlConstants;
 
 import java.net.URI;
@@ -29,7 +30,9 @@ public class UrlExtractFragmentKudf {
   static final String NAME = "url_extract_fragment";
 
   @Udf(description = "Extracts the fragment of an application/x-www-form-urlencoded String input")
-  public String extractFragment(final String input) {
+  public String extractFragment(
+      @UdfParameter(value = "input", description = "a valid URL to extract a fragment from")
+      final String input) {
     return UrlParser.extract(input, URI::getFragment);
   }
 }

--- a/ksql-engine/src/main/java/io/confluent/ksql/function/udf/url/UrlExtractFragmentKudf.java
+++ b/ksql-engine/src/main/java/io/confluent/ksql/function/udf/url/UrlExtractFragmentKudf.java
@@ -1,0 +1,35 @@
+/*
+ * Copyright 2018 Confluent Inc.
+ *
+ * Licensed under the Confluent Community License; you may not use this file
+ * except in compliance with the License.  You may obtain a copy of the License at
+ *
+ * http://www.confluent.io/confluent-community-license
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package io.confluent.ksql.function.udf.url;
+
+import io.confluent.ksql.function.udf.Udf;
+import io.confluent.ksql.function.udf.UdfDescription;
+import io.confluent.ksql.util.KsqlConstants;
+
+import java.net.URI;
+
+@UdfDescription(
+        name = UrlExtractFragmentKudf.NAME,
+        author = KsqlConstants.CONFLUENT_AUTHOR,
+        description = "Extracts the fragment of an application/x-www-form-urlencoded String input")
+public class UrlExtractFragmentKudf {
+
+  static final String NAME = "url_extract_fragment";
+
+  @Udf(description = "Extracts the fragment of an application/x-www-form-urlencoded String input")
+  public String extractFragment(final String input) {
+    return UrlParser.extract(input, URI::getFragment);
+  }
+}

--- a/ksql-engine/src/main/java/io/confluent/ksql/function/udf/url/UrlExtractFragmentKudf.java
+++ b/ksql-engine/src/main/java/io/confluent/ksql/function/udf/url/UrlExtractFragmentKudf.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018 Confluent Inc.
+ * Copyright 2019 Confluent Inc.
  *
  * Licensed under the Confluent Community License; you may not use this file
  * except in compliance with the License.  You may obtain a copy of the License at

--- a/ksql-engine/src/main/java/io/confluent/ksql/function/udf/url/UrlExtractFragmentKudf.java
+++ b/ksql-engine/src/main/java/io/confluent/ksql/function/udf/url/UrlExtractFragmentKudf.java
@@ -17,13 +17,10 @@ package io.confluent.ksql.function.udf.url;
 import io.confluent.ksql.function.udf.Udf;
 import io.confluent.ksql.function.udf.UdfDescription;
 import io.confluent.ksql.function.udf.UdfParameter;
-import io.confluent.ksql.util.KsqlConstants;
-
 import java.net.URI;
 
 @UdfDescription(
         name = UrlExtractFragmentKudf.NAME,
-        author = KsqlConstants.CONFLUENT_AUTHOR,
         description = "Extracts the fragment of an application/x-www-form-urlencoded String input")
 public class UrlExtractFragmentKudf {
 

--- a/ksql-engine/src/main/java/io/confluent/ksql/function/udf/url/UrlExtractHostKudf.java
+++ b/ksql-engine/src/main/java/io/confluent/ksql/function/udf/url/UrlExtractHostKudf.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018 Confluent Inc.
+ * Copyright 2019 Confluent Inc.
  *
  * Licensed under the Confluent Community License; you may not use this file
  * except in compliance with the License.  You may obtain a copy of the License at
@@ -19,16 +19,16 @@ import io.confluent.ksql.function.udf.UdfDescription;
 import io.confluent.ksql.function.udf.UdfParameter;
 import java.net.URI;
 
-@UdfDescription(
-        name = UrlExtractHostKudf.NAME,
-        description = "Extracts the Host Name of an application/x-www-form-urlencoded String input")
+@UdfDescription(name = UrlExtractHostKudf.NAME, description = UrlExtractHostKudf.DESCRIPTION)
 public class UrlExtractHostKudf {
 
+  static final String DESCRIPTION =
+      "Extracts the Host Name of an application/x-www-form-urlencoded String input";
   static final String NAME = "url_extract_host";
 
-  @Udf(description = "Extracts the Host Name of an application/x-www-form-urlencoded String input")
+  @Udf(description = DESCRIPTION)
   public String extractHost(
-      @UdfParameter(value = "input", description = "a valid URL") final String input) {
+      @UdfParameter(description = "a valid URL") final String input) {
     return UrlParser.extract(input, URI::getHost);
   }
 }

--- a/ksql-engine/src/main/java/io/confluent/ksql/function/udf/url/UrlExtractHostKudf.java
+++ b/ksql-engine/src/main/java/io/confluent/ksql/function/udf/url/UrlExtractHostKudf.java
@@ -1,0 +1,35 @@
+/*
+ * Copyright 2018 Confluent Inc.
+ *
+ * Licensed under the Confluent Community License; you may not use this file
+ * except in compliance with the License.  You may obtain a copy of the License at
+ *
+ * http://www.confluent.io/confluent-community-license
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package io.confluent.ksql.function.udf.url;
+
+import io.confluent.ksql.function.udf.Udf;
+import io.confluent.ksql.function.udf.UdfDescription;
+import io.confluent.ksql.util.KsqlConstants;
+
+import java.net.URI;
+
+@UdfDescription(
+        name = UrlExtractHostKudf.NAME,
+        author = KsqlConstants.CONFLUENT_AUTHOR,
+        description = "Extracts the Host Name of an application/x-www-form-urlencoded String input")
+public class UrlExtractHostKudf {
+
+  static final String NAME = "url_extract_host";
+
+  @Udf(description = "Extracts the Host Name of an application/x-www-form-urlencoded String input")
+  public String extractHost(final String input) {
+    return UrlParser.extract(input, URI::getHost);
+  }
+}

--- a/ksql-engine/src/main/java/io/confluent/ksql/function/udf/url/UrlExtractHostKudf.java
+++ b/ksql-engine/src/main/java/io/confluent/ksql/function/udf/url/UrlExtractHostKudf.java
@@ -17,13 +17,10 @@ package io.confluent.ksql.function.udf.url;
 import io.confluent.ksql.function.udf.Udf;
 import io.confluent.ksql.function.udf.UdfDescription;
 import io.confluent.ksql.function.udf.UdfParameter;
-import io.confluent.ksql.util.KsqlConstants;
-
 import java.net.URI;
 
 @UdfDescription(
         name = UrlExtractHostKudf.NAME,
-        author = KsqlConstants.CONFLUENT_AUTHOR,
         description = "Extracts the Host Name of an application/x-www-form-urlencoded String input")
 public class UrlExtractHostKudf {
 

--- a/ksql-engine/src/main/java/io/confluent/ksql/function/udf/url/UrlExtractHostKudf.java
+++ b/ksql-engine/src/main/java/io/confluent/ksql/function/udf/url/UrlExtractHostKudf.java
@@ -16,6 +16,7 @@ package io.confluent.ksql.function.udf.url;
 
 import io.confluent.ksql.function.udf.Udf;
 import io.confluent.ksql.function.udf.UdfDescription;
+import io.confluent.ksql.function.udf.UdfParameter;
 import io.confluent.ksql.util.KsqlConstants;
 
 import java.net.URI;
@@ -29,7 +30,8 @@ public class UrlExtractHostKudf {
   static final String NAME = "url_extract_host";
 
   @Udf(description = "Extracts the Host Name of an application/x-www-form-urlencoded String input")
-  public String extractHost(final String input) {
+  public String extractHost(
+      @UdfParameter(value = "input", description = "a valid URL") final String input) {
     return UrlParser.extract(input, URI::getHost);
   }
 }

--- a/ksql-engine/src/main/java/io/confluent/ksql/function/udf/url/UrlExtractParameterKudf.java
+++ b/ksql-engine/src/main/java/io/confluent/ksql/function/udf/url/UrlExtractParameterKudf.java
@@ -18,13 +18,11 @@ import com.google.common.base.Splitter;
 import io.confluent.ksql.function.udf.Udf;
 import io.confluent.ksql.function.udf.UdfDescription;
 import io.confluent.ksql.function.udf.UdfParameter;
-import io.confluent.ksql.util.KsqlConstants;
 import java.net.URI;
 import java.util.List;
 
 @UdfDescription(
         name = UrlExtractParameterKudf.NAME,
-        author = KsqlConstants.CONFLUENT_AUTHOR,
         description = "Extracts a parameter with a specified name encoded inside an "
                       + "application/x-www-form-urlencoded String.")
 public class UrlExtractParameterKudf {

--- a/ksql-engine/src/main/java/io/confluent/ksql/function/udf/url/UrlExtractParameterKudf.java
+++ b/ksql-engine/src/main/java/io/confluent/ksql/function/udf/url/UrlExtractParameterKudf.java
@@ -1,0 +1,52 @@
+/*
+ * Copyright 2018 Confluent Inc.
+ *
+ * Licensed under the Confluent Community License; you may not use this file
+ * except in compliance with the License.  You may obtain a copy of the License at
+ *
+ * http://www.confluent.io/confluent-community-license
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package io.confluent.ksql.function.udf.url;
+
+import com.google.common.base.Splitter;
+import io.confluent.ksql.function.udf.Udf;
+import io.confluent.ksql.function.udf.UdfDescription;
+import io.confluent.ksql.util.KsqlConstants;
+import java.net.URI;
+import java.util.List;
+
+@UdfDescription(
+        name = UrlExtractParameterKudf.NAME,
+        author = KsqlConstants.CONFLUENT_AUTHOR,
+        description = "Extracts a parameter with a specified name encoded inside an "
+                      + "application/x-www-form-urlencoded String.")
+public class UrlExtractParameterKudf {
+
+  static final String NAME = "url_extract_parameter";
+
+  private static final Splitter PARAM_SPLITTER = Splitter.on('&');
+  private static final Splitter KV_SPLITTER = Splitter.on('=').limit(2);
+
+  @Udf(description = "Extracts a parameter with a specified name encoded inside an "
+          + "application/x-www-form-urlencoded String.")
+  public String extractParam(final String input, final String paramToFind) {
+    final String query = UrlParser.extract(input, URI::getQuery);
+    if (query == null) {
+      return null;
+    }
+
+    for (final String param : PARAM_SPLITTER.split(query)) {
+      final List<String> kvParam = KV_SPLITTER.splitToList(param);
+      if (kvParam.size() == 2 && kvParam.get(0).equals(paramToFind)) {
+        return kvParam.get(1);
+      }
+    }
+    return null;
+  }
+}

--- a/ksql-engine/src/main/java/io/confluent/ksql/function/udf/url/UrlExtractParameterKudf.java
+++ b/ksql-engine/src/main/java/io/confluent/ksql/function/udf/url/UrlExtractParameterKudf.java
@@ -17,6 +17,7 @@ package io.confluent.ksql.function.udf.url;
 import com.google.common.base.Splitter;
 import io.confluent.ksql.function.udf.Udf;
 import io.confluent.ksql.function.udf.UdfDescription;
+import io.confluent.ksql.function.udf.UdfParameter;
 import io.confluent.ksql.util.KsqlConstants;
 import java.net.URI;
 import java.util.List;
@@ -35,7 +36,13 @@ public class UrlExtractParameterKudf {
 
   @Udf(description = "Extracts a parameter with a specified name encoded inside an "
           + "application/x-www-form-urlencoded String.")
-  public String extractParam(final String input, final String paramToFind) {
+  public String extractParam(
+      @UdfParameter(value = "input", description = "a vald URL")
+      final String input,
+      @UdfParameter(
+          value = "paramToFind",
+          description = "the query parameter whose value will be extracted")
+      final String paramToFind) {
     final String query = UrlParser.extract(input, URI::getQuery);
     if (query == null) {
       return null;

--- a/ksql-engine/src/main/java/io/confluent/ksql/function/udf/url/UrlExtractParameterKudf.java
+++ b/ksql-engine/src/main/java/io/confluent/ksql/function/udf/url/UrlExtractParameterKudf.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018 Confluent Inc.
+ * Copyright 2019 Confluent Inc.
  *
  * Licensed under the Confluent Community License; you may not use this file
  * except in compliance with the License.  You may obtain a copy of the License at
@@ -22,25 +22,22 @@ import java.net.URI;
 import java.util.List;
 
 @UdfDescription(
-        name = UrlExtractParameterKudf.NAME,
-        description = "Extracts a parameter with a specified name encoded inside an "
-                      + "application/x-www-form-urlencoded String.")
+    name = UrlExtractParameterKudf.NAME,
+    description = UrlExtractParameterKudf.DESCRIPTION)
 public class UrlExtractParameterKudf {
 
+  static final String DESCRIPTION =
+      "Extracts a parameter with a specified name encoded inside an "
+      + "application/x-www-form-urlencoded String.";
   static final String NAME = "url_extract_parameter";
 
   private static final Splitter PARAM_SPLITTER = Splitter.on('&');
   private static final Splitter KV_SPLITTER = Splitter.on('=').limit(2);
 
-  @Udf(description = "Extracts a parameter with a specified name encoded inside an "
-          + "application/x-www-form-urlencoded String.")
+  @Udf(description = DESCRIPTION)
   public String extractParam(
-      @UdfParameter(value = "input", description = "a vald URL")
-      final String input,
-      @UdfParameter(
-          value = "paramToFind",
-          description = "the query parameter whose value will be extracted")
-      final String paramToFind) {
+      @UdfParameter(description = "a valid URL") final String input,
+      @UdfParameter(description = "the parameter key") final String paramToFind) {
     final String query = UrlParser.extract(input, URI::getQuery);
     if (query == null) {
       return null;
@@ -48,7 +45,9 @@ public class UrlExtractParameterKudf {
 
     for (final String param : PARAM_SPLITTER.split(query)) {
       final List<String> kvParam = KV_SPLITTER.splitToList(param);
-      if (kvParam.size() == 2 && kvParam.get(0).equals(paramToFind)) {
+      if (kvParam.size() == 1 && kvParam.get(0).equals(paramToFind)) {
+        return "";
+      } else if (kvParam.size() == 2 && kvParam.get(0).equals(paramToFind)) {
         return kvParam.get(1);
       }
     }

--- a/ksql-engine/src/main/java/io/confluent/ksql/function/udf/url/UrlExtractPathKudf.java
+++ b/ksql-engine/src/main/java/io/confluent/ksql/function/udf/url/UrlExtractPathKudf.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright 2018 Confluent Inc.
+ *
+ * Licensed under the Confluent Community License; you may not use this file
+ * except in compliance with the License.  You may obtain a copy of the License at
+ *
+ * http://www.confluent.io/confluent-community-license
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package io.confluent.ksql.function.udf.url;
+
+import io.confluent.ksql.function.udf.Udf;
+import io.confluent.ksql.function.udf.UdfDescription;
+import io.confluent.ksql.util.KsqlConstants;
+
+import java.net.URI;
+
+@UdfDescription(
+        name = UrlExtractPathKudf.NAME,
+        author = KsqlConstants.CONFLUENT_AUTHOR,
+        description = "Extracts the path of an application/x-www-form-urlencoded "
+                      + "encoded String input")
+public class UrlExtractPathKudf {
+
+  static final String NAME = "url_extract_path";
+
+  @Udf(description = "Extracts the path of an application/x-www-form-urlencoded "
+                             + "encoded String input")
+  public String extractPath(final String input) {
+    // A path component, consisting of a sequence of path segments separated by a slash (/). A path
+    // is always defined for a URI, though the defined path may be empty (zero length).
+    // source: https://en.wikipedia.org/wiki/Uniform_Resource_Identifier#Definition
+    return UrlParser.extract(input, URI::getPath);
+  }
+}

--- a/ksql-engine/src/main/java/io/confluent/ksql/function/udf/url/UrlExtractPathKudf.java
+++ b/ksql-engine/src/main/java/io/confluent/ksql/function/udf/url/UrlExtractPathKudf.java
@@ -17,13 +17,10 @@ package io.confluent.ksql.function.udf.url;
 import io.confluent.ksql.function.udf.Udf;
 import io.confluent.ksql.function.udf.UdfDescription;
 import io.confluent.ksql.function.udf.UdfParameter;
-import io.confluent.ksql.util.KsqlConstants;
-
 import java.net.URI;
 
 @UdfDescription(
         name = UrlExtractPathKudf.NAME,
-        author = KsqlConstants.CONFLUENT_AUTHOR,
         description = "Extracts the path of an application/x-www-form-urlencoded "
                       + "encoded String input")
 public class UrlExtractPathKudf {

--- a/ksql-engine/src/main/java/io/confluent/ksql/function/udf/url/UrlExtractPathKudf.java
+++ b/ksql-engine/src/main/java/io/confluent/ksql/function/udf/url/UrlExtractPathKudf.java
@@ -16,6 +16,7 @@ package io.confluent.ksql.function.udf.url;
 
 import io.confluent.ksql.function.udf.Udf;
 import io.confluent.ksql.function.udf.UdfDescription;
+import io.confluent.ksql.function.udf.UdfParameter;
 import io.confluent.ksql.util.KsqlConstants;
 
 import java.net.URI;
@@ -31,7 +32,9 @@ public class UrlExtractPathKudf {
 
   @Udf(description = "Extracts the path of an application/x-www-form-urlencoded "
                              + "encoded String input")
-  public String extractPath(final String input) {
+  public String extractPath(
+      @UdfParameter(value = "input", description = "a valid URL to extract the path from")
+      final String input) {
     // A path component, consisting of a sequence of path segments separated by a slash (/). A path
     // is always defined for a URI, though the defined path may be empty (zero length).
     // source: https://en.wikipedia.org/wiki/Uniform_Resource_Identifier#Definition

--- a/ksql-engine/src/main/java/io/confluent/ksql/function/udf/url/UrlExtractPathKudf.java
+++ b/ksql-engine/src/main/java/io/confluent/ksql/function/udf/url/UrlExtractPathKudf.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018 Confluent Inc.
+ * Copyright 2019 Confluent Inc.
  *
  * Licensed under the Confluent Community License; you may not use this file
  * except in compliance with the License.  You may obtain a copy of the License at
@@ -19,22 +19,16 @@ import io.confluent.ksql.function.udf.UdfDescription;
 import io.confluent.ksql.function.udf.UdfParameter;
 import java.net.URI;
 
-@UdfDescription(
-        name = UrlExtractPathKudf.NAME,
-        description = "Extracts the path of an application/x-www-form-urlencoded "
-                      + "encoded String input")
+@UdfDescription(name = UrlExtractPathKudf.NAME, description = UrlExtractPathKudf.DESCRIPTION)
 public class UrlExtractPathKudf {
 
+  static final String DESCRIPTION =
+      "Extracts the path of an application/x-www-form-urlencoded encoded String input";
   static final String NAME = "url_extract_path";
 
-  @Udf(description = "Extracts the path of an application/x-www-form-urlencoded "
-                             + "encoded String input")
+  @Udf(description = DESCRIPTION)
   public String extractPath(
-      @UdfParameter(value = "input", description = "a valid URL to extract the path from")
-      final String input) {
-    // A path component, consisting of a sequence of path segments separated by a slash (/). A path
-    // is always defined for a URI, though the defined path may be empty (zero length).
-    // source: https://en.wikipedia.org/wiki/Uniform_Resource_Identifier#Definition
+      @UdfParameter(description = "a valid URL") final String input) {
     return UrlParser.extract(input, URI::getPath);
   }
 }

--- a/ksql-engine/src/main/java/io/confluent/ksql/function/udf/url/UrlExtractPortKudf.java
+++ b/ksql-engine/src/main/java/io/confluent/ksql/function/udf/url/UrlExtractPortKudf.java
@@ -16,6 +16,7 @@ package io.confluent.ksql.function.udf.url;
 
 import io.confluent.ksql.function.udf.Udf;
 import io.confluent.ksql.function.udf.UdfDescription;
+import io.confluent.ksql.function.udf.UdfParameter;
 import io.confluent.ksql.util.KsqlConstants;
 import java.net.URI;
 
@@ -30,7 +31,9 @@ public class UrlExtractPortKudf {
 
   @Udf(description = "Extracts the port from an application/x-www-form-urlencoded encoded String"
                      + " If there is no port or the string is invalid, this will return null.")
-  public Integer extractPort(final String input) {
+  public Integer extractPort(
+      @UdfParameter(value = "input", description = "a valid URL to extract a port from")
+      final String input) {
     final Integer port = UrlParser.extract(input, URI::getPort);
     return (port == null || port < 0) ? null : port;
   }

--- a/ksql-engine/src/main/java/io/confluent/ksql/function/udf/url/UrlExtractPortKudf.java
+++ b/ksql-engine/src/main/java/io/confluent/ksql/function/udf/url/UrlExtractPortKudf.java
@@ -17,12 +17,10 @@ package io.confluent.ksql.function.udf.url;
 import io.confluent.ksql.function.udf.Udf;
 import io.confluent.ksql.function.udf.UdfDescription;
 import io.confluent.ksql.function.udf.UdfParameter;
-import io.confluent.ksql.util.KsqlConstants;
 import java.net.URI;
 
 @UdfDescription(
         name = UrlExtractPortKudf.NAME,
-        author = KsqlConstants.CONFLUENT_AUTHOR,
         description = "Extracts the port from an application/x-www-form-urlencoded encoded String."
                       + " If there is no port or the string is invalid, this will return null.")
 public class UrlExtractPortKudf {

--- a/ksql-engine/src/main/java/io/confluent/ksql/function/udf/url/UrlExtractPortKudf.java
+++ b/ksql-engine/src/main/java/io/confluent/ksql/function/udf/url/UrlExtractPortKudf.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright 2018 Confluent Inc.
+ *
+ * Licensed under the Confluent Community License; you may not use this file
+ * except in compliance with the License.  You may obtain a copy of the License at
+ *
+ * http://www.confluent.io/confluent-community-license
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package io.confluent.ksql.function.udf.url;
+
+import io.confluent.ksql.function.udf.Udf;
+import io.confluent.ksql.function.udf.UdfDescription;
+import io.confluent.ksql.util.KsqlConstants;
+import java.net.URI;
+
+@UdfDescription(
+        name = UrlExtractPortKudf.NAME,
+        author = KsqlConstants.CONFLUENT_AUTHOR,
+        description = "Extracts the port from an application/x-www-form-urlencoded encoded String."
+                      + " If there is no port or the string is invalid, this will return null.")
+public class UrlExtractPortKudf {
+
+  static final String NAME = "url_extract_port";
+
+  @Udf(description = "Extracts the port from an application/x-www-form-urlencoded encoded String"
+                     + " If there is no port or the string is invalid, this will return null.")
+  public Integer extractPort(final String input) {
+    final Integer port = UrlParser.extract(input, URI::getPort);
+    return (port == null || port < 0) ? null : port;
+  }
+}

--- a/ksql-engine/src/main/java/io/confluent/ksql/function/udf/url/UrlExtractPortKudf.java
+++ b/ksql-engine/src/main/java/io/confluent/ksql/function/udf/url/UrlExtractPortKudf.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018 Confluent Inc.
+ * Copyright 2019 Confluent Inc.
  *
  * Licensed under the Confluent Community License; you may not use this file
  * except in compliance with the License.  You may obtain a copy of the License at
@@ -19,20 +19,23 @@ import io.confluent.ksql.function.udf.UdfDescription;
 import io.confluent.ksql.function.udf.UdfParameter;
 import java.net.URI;
 
-@UdfDescription(
-        name = UrlExtractPortKudf.NAME,
-        description = "Extracts the port from an application/x-www-form-urlencoded encoded String."
-                      + " If there is no port or the string is invalid, this will return null.")
+@UdfDescription(name = UrlExtractPortKudf.NAME, description = UrlExtractPortKudf.DESCRIPTION)
 public class UrlExtractPortKudf {
 
+  static final String DESCRIPTION =
+      "Extracts the port from an application/x-www-form-urlencoded encoded String."
+          + " If there is no port or the string is invalid, this will return null.";
   static final String NAME = "url_extract_port";
 
-  @Udf(description = "Extracts the port from an application/x-www-form-urlencoded encoded String"
-                     + " If there is no port or the string is invalid, this will return null.")
+  @Udf(description = DESCRIPTION)
   public Integer extractPort(
-      @UdfParameter(value = "input", description = "a valid URL to extract a port from")
+      @UdfParameter(description = "a valid URL to extract a port from")
       final String input) {
     final Integer port = UrlParser.extract(input, URI::getPort);
+
+    // check for LT 0 because URI::getPort returns -1 if the port
+    // does not exist, but UrlParser#extract will return null if
+    // the URI is invalid
     return (port == null || port < 0) ? null : port;
   }
 }

--- a/ksql-engine/src/main/java/io/confluent/ksql/function/udf/url/UrlExtractProtocolKudf.java
+++ b/ksql-engine/src/main/java/io/confluent/ksql/function/udf/url/UrlExtractProtocolKudf.java
@@ -17,13 +17,10 @@ package io.confluent.ksql.function.udf.url;
 import io.confluent.ksql.function.udf.Udf;
 import io.confluent.ksql.function.udf.UdfDescription;
 import io.confluent.ksql.function.udf.UdfParameter;
-import io.confluent.ksql.util.KsqlConstants;
-
 import java.net.URI;
 
 @UdfDescription(
         name = UrlExtractProtocolKudf.NAME,
-        author = KsqlConstants.CONFLUENT_AUTHOR,
         description = "Extracts the Scheme Component (protocol) of an application/x-www-form-"
                       + "urlencoded encoded String input")
 public class UrlExtractProtocolKudf {

--- a/ksql-engine/src/main/java/io/confluent/ksql/function/udf/url/UrlExtractProtocolKudf.java
+++ b/ksql-engine/src/main/java/io/confluent/ksql/function/udf/url/UrlExtractProtocolKudf.java
@@ -16,6 +16,7 @@ package io.confluent.ksql.function.udf.url;
 
 import io.confluent.ksql.function.udf.Udf;
 import io.confluent.ksql.function.udf.UdfDescription;
+import io.confluent.ksql.function.udf.UdfParameter;
 import io.confluent.ksql.util.KsqlConstants;
 
 import java.net.URI;
@@ -31,7 +32,9 @@ public class UrlExtractProtocolKudf {
 
   @Udf(description = "Extracts the Scheme Component (protocol) of an application/x-www-form-"
                      + "urlencoded encoded String input")
-  public String extractProtocol(final String input) {
+  public String extractProtocol(
+      @UdfParameter(value = "input", description = "a valid URL to extract a protocl from")
+      final String input) {
     return UrlParser.extract(input, URI::getScheme);
   }
 }

--- a/ksql-engine/src/main/java/io/confluent/ksql/function/udf/url/UrlExtractProtocolKudf.java
+++ b/ksql-engine/src/main/java/io/confluent/ksql/function/udf/url/UrlExtractProtocolKudf.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018 Confluent Inc.
+ * Copyright 2019 Confluent Inc.
  *
  * Licensed under the Confluent Community License; you may not use this file
  * except in compliance with the License.  You may obtain a copy of the License at
@@ -21,16 +21,17 @@ import java.net.URI;
 
 @UdfDescription(
         name = UrlExtractProtocolKudf.NAME,
-        description = "Extracts the Scheme Component (protocol) of an application/x-www-form-"
-                      + "urlencoded encoded String input")
+        description = UrlExtractProtocolKudf.DESCRIPTION)
 public class UrlExtractProtocolKudf {
 
+  static final String DESCRIPTION =
+      "Extracts the Scheme Component (protocol) of an application/x-www-form-urlencoded "
+          + "encoded String input";
   static final String NAME = "url_extract_protocol";
 
-  @Udf(description = "Extracts the Scheme Component (protocol) of an application/x-www-form-"
-                     + "urlencoded encoded String input")
+  @Udf(description = DESCRIPTION)
   public String extractProtocol(
-      @UdfParameter(value = "input", description = "a valid URL to extract a protocl from")
+      @UdfParameter(description = "a valid URL to extract a protocl from")
       final String input) {
     return UrlParser.extract(input, URI::getScheme);
   }

--- a/ksql-engine/src/main/java/io/confluent/ksql/function/udf/url/UrlExtractProtocolKudf.java
+++ b/ksql-engine/src/main/java/io/confluent/ksql/function/udf/url/UrlExtractProtocolKudf.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright 2018 Confluent Inc.
+ *
+ * Licensed under the Confluent Community License; you may not use this file
+ * except in compliance with the License.  You may obtain a copy of the License at
+ *
+ * http://www.confluent.io/confluent-community-license
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package io.confluent.ksql.function.udf.url;
+
+import io.confluent.ksql.function.udf.Udf;
+import io.confluent.ksql.function.udf.UdfDescription;
+import io.confluent.ksql.util.KsqlConstants;
+
+import java.net.URI;
+
+@UdfDescription(
+        name = UrlExtractProtocolKudf.NAME,
+        author = KsqlConstants.CONFLUENT_AUTHOR,
+        description = "Extracts the Scheme Component (protocol) of an application/x-www-form-"
+                      + "urlencoded encoded String input")
+public class UrlExtractProtocolKudf {
+
+  static final String NAME = "url_extract_protocol";
+
+  @Udf(description = "Extracts the Scheme Component (protocol) of an application/x-www-form-"
+                     + "urlencoded encoded String input")
+  public String extractProtocol(final String input) {
+    return UrlParser.extract(input, URI::getScheme);
+  }
+}

--- a/ksql-engine/src/main/java/io/confluent/ksql/function/udf/url/UrlExtractQueryKudf.java
+++ b/ksql-engine/src/main/java/io/confluent/ksql/function/udf/url/UrlExtractQueryKudf.java
@@ -17,13 +17,10 @@ package io.confluent.ksql.function.udf.url;
 import io.confluent.ksql.function.udf.Udf;
 import io.confluent.ksql.function.udf.UdfDescription;
 import io.confluent.ksql.function.udf.UdfParameter;
-import io.confluent.ksql.util.KsqlConstants;
-
 import java.net.URI;
 
 @UdfDescription(
         name = UrlExtractQueryKudf.NAME,
-        author = KsqlConstants.CONFLUENT_AUTHOR,
         description = "Extracts the query parameters of an application/x-www-form-urlencoded "
                       + "encoded String input, if it exists.")
 public class UrlExtractQueryKudf {

--- a/ksql-engine/src/main/java/io/confluent/ksql/function/udf/url/UrlExtractQueryKudf.java
+++ b/ksql-engine/src/main/java/io/confluent/ksql/function/udf/url/UrlExtractQueryKudf.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018 Confluent Inc.
+ * Copyright 2019 Confluent Inc.
  *
  * Licensed under the Confluent Community License; you may not use this file
  * except in compliance with the License.  You may obtain a copy of the License at
@@ -19,18 +19,16 @@ import io.confluent.ksql.function.udf.UdfDescription;
 import io.confluent.ksql.function.udf.UdfParameter;
 import java.net.URI;
 
-@UdfDescription(
-        name = UrlExtractQueryKudf.NAME,
-        description = "Extracts the query parameters of an application/x-www-form-urlencoded "
-                      + "encoded String input, if it exists.")
+@UdfDescription(name = UrlExtractQueryKudf.NAME, description = UrlExtractQueryKudf.DESCRIPTION)
 public class UrlExtractQueryKudf {
 
+  static final String DESCRIPTION = "Extracts the query parameters of an "
+      + "application/x-www-form-urlencoded encoded String input, if it exists.";
   static final String NAME = "url_extract_query";
 
-  @Udf(description = "Extracts the query parameters of an application/x-www-form-urlencoded "
-                     + "encoded String input, if it exists.")
+  @Udf(description = DESCRIPTION)
   public String extractQuery(
-      @UdfParameter(value = "input", description = "a valid URL to extract a query from")
+      @UdfParameter(description = "a valid URL to extract a query from")
       final String input) {
     return UrlParser.extract(input, URI::getQuery);
   }

--- a/ksql-engine/src/main/java/io/confluent/ksql/function/udf/url/UrlExtractQueryKudf.java
+++ b/ksql-engine/src/main/java/io/confluent/ksql/function/udf/url/UrlExtractQueryKudf.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright 2018 Confluent Inc.
+ *
+ * Licensed under the Confluent Community License; you may not use this file
+ * except in compliance with the License.  You may obtain a copy of the License at
+ *
+ * http://www.confluent.io/confluent-community-license
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package io.confluent.ksql.function.udf.url;
+
+import io.confluent.ksql.function.udf.Udf;
+import io.confluent.ksql.function.udf.UdfDescription;
+import io.confluent.ksql.util.KsqlConstants;
+
+import java.net.URI;
+
+@UdfDescription(
+        name = UrlExtractQueryKudf.NAME,
+        author = KsqlConstants.CONFLUENT_AUTHOR,
+        description = "Extracts the query parameters of an application/x-www-form-urlencoded "
+                      + "encoded String input, if it exists.")
+public class UrlExtractQueryKudf {
+
+  static final String NAME = "url_extract_query";
+
+  @Udf(description = "Extracts the query parameters of an application/x-www-form-urlencoded "
+                     + "encoded String input, if it exists.")
+  public String extractQuery(final String input) {
+    return UrlParser.extract(input, URI::getQuery);
+  }
+}

--- a/ksql-engine/src/main/java/io/confluent/ksql/function/udf/url/UrlExtractQueryKudf.java
+++ b/ksql-engine/src/main/java/io/confluent/ksql/function/udf/url/UrlExtractQueryKudf.java
@@ -16,6 +16,7 @@ package io.confluent.ksql.function.udf.url;
 
 import io.confluent.ksql.function.udf.Udf;
 import io.confluent.ksql.function.udf.UdfDescription;
+import io.confluent.ksql.function.udf.UdfParameter;
 import io.confluent.ksql.util.KsqlConstants;
 
 import java.net.URI;
@@ -31,7 +32,9 @@ public class UrlExtractQueryKudf {
 
   @Udf(description = "Extracts the query parameters of an application/x-www-form-urlencoded "
                      + "encoded String input, if it exists.")
-  public String extractQuery(final String input) {
+  public String extractQuery(
+      @UdfParameter(value = "input", description = "a valid URL to extract a query from")
+      final String input) {
     return UrlParser.extract(input, URI::getQuery);
   }
 }

--- a/ksql-engine/src/main/java/io/confluent/ksql/function/udf/url/UrlParser.java
+++ b/ksql-engine/src/main/java/io/confluent/ksql/function/udf/url/UrlParser.java
@@ -44,7 +44,7 @@ final class UrlParser {
     try {
       return extract.apply(new URI(url));
     } catch (final URISyntaxException e) {
-      throw new KsqlFunctionException("URL parameter has invalid syntax: " + url, e);
+      throw new KsqlFunctionException("URL input has invalid syntax: " + url, e);
     }
   }
 }

--- a/ksql-engine/src/main/java/io/confluent/ksql/function/udf/url/UrlParser.java
+++ b/ksql-engine/src/main/java/io/confluent/ksql/function/udf/url/UrlParser.java
@@ -14,7 +14,6 @@
 
 package io.confluent.ksql.function.udf.url;
 
-import com.google.common.base.Preconditions;
 import io.confluent.ksql.function.KsqlFunctionException;
 import java.net.URI;
 import java.net.URISyntaxException;

--- a/ksql-engine/src/main/java/io/confluent/ksql/function/udf/url/UrlParser.java
+++ b/ksql-engine/src/main/java/io/confluent/ksql/function/udf/url/UrlParser.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright 2018 Confluent Inc.
+ *
+ * Licensed under the Confluent Community License; you may not use this file
+ * except in compliance with the License.  You may obtain a copy of the License at
+ *
+ * http://www.confluent.io/confluent-community-license
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package io.confluent.ksql.function.udf.url;
+
+import java.net.URI;
+import java.net.URISyntaxException;
+import java.util.function.Function;
+
+/**
+ * Utility class for extracting information from a String encoded URL
+ */
+final class UrlParser {
+
+  private UrlParser() { /* private constructor for utility class*/ }
+
+  /**
+   * @param url       an application/x-www-form-urlencoded string
+   * @param extract   a method that accepts a {@link URI} and returns the value to extract
+   *
+   * @return the value of {@code extract(url)} if present and valid, otherwise {@code null}
+   */
+  static <T> T extract(final String url, final Function<URI, T> extract) {
+    if (url == null || extract == null) {
+      return null;
+    }
+
+    try {
+      return extract.apply(new URI(url));
+    } catch (final URISyntaxException e) {
+      return null;
+    }
+  }
+}

--- a/ksql-engine/src/main/java/io/confluent/ksql/function/udf/url/UrlParser.java
+++ b/ksql-engine/src/main/java/io/confluent/ksql/function/udf/url/UrlParser.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018 Confluent Inc.
+ * Copyright 2019 Confluent Inc.
  *
  * Licensed under the Confluent Community License; you may not use this file
  * except in compliance with the License.  You may obtain a copy of the License at
@@ -26,7 +26,7 @@ import javax.annotation.Nonnull;
  */
 final class UrlParser {
 
-  private UrlParser() { /* private constructor for utility class*/ }
+  private UrlParser() { }
 
   /**
    * @param url       an application/x-www-form-urlencoded string
@@ -44,7 +44,7 @@ final class UrlParser {
     try {
       return extract.apply(new URI(url));
     } catch (final URISyntaxException e) {
-      throw new KsqlFunctionException("The passed in URL " + url + " has invalid syntax!", e);
+      throw new KsqlFunctionException("URL parameter has invalid syntax: " + url, e);
     }
   }
 }

--- a/ksql-engine/src/main/java/io/confluent/ksql/function/udf/url/UrlParser.java
+++ b/ksql-engine/src/main/java/io/confluent/ksql/function/udf/url/UrlParser.java
@@ -17,6 +17,7 @@ package io.confluent.ksql.function.udf.url;
 import io.confluent.ksql.function.KsqlFunctionException;
 import java.net.URI;
 import java.net.URISyntaxException;
+import java.util.Objects;
 import java.util.function.Function;
 import javax.annotation.Nonnull;
 
@@ -34,6 +35,8 @@ final class UrlParser {
    * @return the value of {@code extract(url)} if present and valid, otherwise {@code null}
    */
   static <T> T extract(final String url, @Nonnull final Function<URI, T> extract) {
+    Objects.requireNonNull(extract, "must supply a non-null extract method!");
+
     if (url == null) {
       return null;
     }

--- a/ksql-engine/src/main/java/io/confluent/ksql/function/udf/url/UrlParser.java
+++ b/ksql-engine/src/main/java/io/confluent/ksql/function/udf/url/UrlParser.java
@@ -14,9 +14,12 @@
 
 package io.confluent.ksql.function.udf.url;
 
+import com.google.common.base.Preconditions;
+import io.confluent.ksql.function.KsqlFunctionException;
 import java.net.URI;
 import java.net.URISyntaxException;
 import java.util.function.Function;
+import javax.annotation.Nonnull;
 
 /**
  * Utility class for extracting information from a String encoded URL
@@ -31,15 +34,15 @@ final class UrlParser {
    *
    * @return the value of {@code extract(url)} if present and valid, otherwise {@code null}
    */
-  static <T> T extract(final String url, final Function<URI, T> extract) {
-    if (url == null || extract == null) {
+  static <T> T extract(final String url, @Nonnull final Function<URI, T> extract) {
+    if (url == null) {
       return null;
     }
 
     try {
       return extract.apply(new URI(url));
     } catch (final URISyntaxException e) {
-      return null;
+      throw new KsqlFunctionException("The passed in URL " + url + " has invalid syntax!", e);
     }
   }
 }

--- a/ksql-engine/src/test/java/io/confluent/ksql/function/udf/url/UrlDecodeParamKudfTest.java
+++ b/ksql-engine/src/test/java/io/confluent/ksql/function/udf/url/UrlDecodeParamKudfTest.java
@@ -1,0 +1,51 @@
+/*
+ * Copyright 2018 Confluent Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package io.confluent.ksql.function.udf.url;
+
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+
+import static org.hamcrest.CoreMatchers.equalTo;
+import static org.hamcrest.MatcherAssert.assertThat;
+
+public class UrlDecodeParamKudfTest {
+
+  private UrlDecodeParamKudf decodeUdf;
+
+  @Before
+  public void setUp() {
+    decodeUdf = new UrlDecodeParamKudf();
+  }
+
+  @Rule
+  public final ExpectedException expectedException = ExpectedException.none();
+
+  @Test
+  public void shouldDecodeEncodedValue() {
+    assertThat(decodeUdf.decodeParam("%3Ffoo+%24bar"), equalTo("?foo $bar"));
+  }
+
+  @Test
+  public void shouldReturnSpecialCharsIntact() {
+    assertThat(".-*_ should all pass through without being encoded", decodeUdf.decodeParam("foo.-*_bar"), equalTo("foo.-*_bar"));
+  }
+
+  @Test
+  public void shouldReturnEmptyStringForEmptyInput() {
+    assertThat(decodeUdf.decodeParam(""), equalTo(""));
+  }
+}

--- a/ksql-engine/src/test/java/io/confluent/ksql/function/udf/url/UrlDecodeParamKudfTest.java
+++ b/ksql-engine/src/test/java/io/confluent/ksql/function/udf/url/UrlDecodeParamKudfTest.java
@@ -31,9 +31,6 @@ public class UrlDecodeParamKudfTest {
     decodeUdf = new UrlDecodeParamKudf();
   }
 
-  @Rule
-  public final ExpectedException expectedException = ExpectedException.none();
-
   @Test
   public void shouldDecodeEncodedValue() {
     assertThat(decodeUdf.decodeParam("%3Ffoo+%24bar"), equalTo("?foo $bar"));

--- a/ksql-engine/src/test/java/io/confluent/ksql/function/udf/url/UrlDecodeParamKudfTest.java
+++ b/ksql-engine/src/test/java/io/confluent/ksql/function/udf/url/UrlDecodeParamKudfTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018 Confluent Inc.
+ * Copyright 2019 Confluent Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License. You may obtain a copy of the License at

--- a/ksql-engine/src/test/java/io/confluent/ksql/function/udf/url/UrlEncodeParamKudfTest.java
+++ b/ksql-engine/src/test/java/io/confluent/ksql/function/udf/url/UrlEncodeParamKudfTest.java
@@ -31,9 +31,6 @@ public class UrlEncodeParamKudfTest {
     encodeUdf = new UrlEncodeParamKudf();
   }
 
-  @Rule
-  public final ExpectedException expectedException = ExpectedException.none();
-
   @Test
   public void shouldEncodeValue() {
     assertThat(encodeUdf.encodeParam("?foo $bar"), equalTo("%3Ffoo+%24bar"));

--- a/ksql-engine/src/test/java/io/confluent/ksql/function/udf/url/UrlEncodeParamKudfTest.java
+++ b/ksql-engine/src/test/java/io/confluent/ksql/function/udf/url/UrlEncodeParamKudfTest.java
@@ -1,0 +1,51 @@
+/*
+ * Copyright 2018 Confluent Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package io.confluent.ksql.function.udf.url;
+
+import static org.hamcrest.CoreMatchers.equalTo;
+import static org.hamcrest.MatcherAssert.assertThat;
+
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+
+public class UrlEncodeParamKudfTest {
+
+  private UrlEncodeParamKudf encodeUdf;
+
+  @Before
+  public void setUp() {
+    encodeUdf = new UrlEncodeParamKudf();
+  }
+
+  @Rule
+  public final ExpectedException expectedException = ExpectedException.none();
+
+  @Test
+  public void shouldEncodeValue() {
+    assertThat(encodeUdf.encodeParam("?foo $bar"), equalTo("%3Ffoo+%24bar"));
+  }
+
+  @Test
+  public void shouldReturnSpecialCharsIntact() {
+    assertThat(".-*_ should all pass through without being encoded", encodeUdf.encodeParam("foo.-*_bar"), equalTo("foo.-*_bar"));
+  }
+
+  @Test
+  public void shouldReturnEmptyStringForEmptyInput() {
+    assertThat(encodeUdf.encodeParam(""), equalTo(""));
+  }
+}

--- a/ksql-engine/src/test/java/io/confluent/ksql/function/udf/url/UrlEncodeParamKudfTest.java
+++ b/ksql-engine/src/test/java/io/confluent/ksql/function/udf/url/UrlEncodeParamKudfTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018 Confluent Inc.
+ * Copyright 2019 Confluent Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License. You may obtain a copy of the License at

--- a/ksql-engine/src/test/java/io/confluent/ksql/function/udf/url/UrlExtractFragmentKudfTest.java
+++ b/ksql-engine/src/test/java/io/confluent/ksql/function/udf/url/UrlExtractFragmentKudfTest.java
@@ -32,10 +32,6 @@ public class UrlExtractFragmentKudfTest {
     extractUdf = new UrlExtractFragmentKudf();
   }
 
-  @Rule
-  public final ExpectedException expectedException = ExpectedException.none();
-
-
   @Test
   public void shouldExtractFragmentIfPresent() {
     assertThat(extractUdf.extractFragment("https://docs.confluent.io/current/ksql/docs/syntax-reference.html#scalar-functions"), equalTo("scalar-functions"));

--- a/ksql-engine/src/test/java/io/confluent/ksql/function/udf/url/UrlExtractFragmentKudfTest.java
+++ b/ksql-engine/src/test/java/io/confluent/ksql/function/udf/url/UrlExtractFragmentKudfTest.java
@@ -57,7 +57,7 @@ public class UrlExtractFragmentKudfTest {
   public void shouldThrowExceptionForMalformedURL() {
     // Given:
     expectedException.expect(KsqlException.class);
-    expectedException.expectMessage("The passed in URL http://257.1/bogus/[url has invalid syntax!");
+    expectedException.expectMessage("URL input has invalid syntax: http://257.1/bogus/[url");
 
     // When:
     extractUdf.extractFragment("http://257.1/bogus/[url");

--- a/ksql-engine/src/test/java/io/confluent/ksql/function/udf/url/UrlExtractFragmentKudfTest.java
+++ b/ksql-engine/src/test/java/io/confluent/ksql/function/udf/url/UrlExtractFragmentKudfTest.java
@@ -14,6 +14,8 @@
 
 package io.confluent.ksql.function.udf.url;
 
+import io.confluent.ksql.util.KsqlException;
+import org.hamcrest.Matchers;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
@@ -22,10 +24,14 @@ import org.junit.rules.ExpectedException;
 import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.CoreMatchers.nullValue;
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.internal.matchers.ThrowableMessageMatcher.hasMessage;
 
 public class UrlExtractFragmentKudfTest {
 
   private UrlExtractFragmentKudf extractUdf;
+
+  @Rule
+  public final ExpectedException expectedException = ExpectedException.none();
 
   @Before
   public void setUp() {
@@ -43,8 +49,13 @@ public class UrlExtractFragmentKudfTest {
   }
 
   @Test
-  public void shouldReturnNullForInvalidUrl() {
-    assertThat(extractUdf.extractFragment("http://257.1/bogus/[url"), nullValue());
+  public void shouldThrowExceptionForMalformedURL() {
+    // Given:
+    expectedException.expect(KsqlException.class);
+    expectedException.expectMessage("The passed in URL http://257.1/bogus/[url has invalid syntax!");
+
+    // When:
+    extractUdf.extractFragment("http://257.1/bogus/[url");
   }
 
 }

--- a/ksql-engine/src/test/java/io/confluent/ksql/function/udf/url/UrlExtractFragmentKudfTest.java
+++ b/ksql-engine/src/test/java/io/confluent/ksql/function/udf/url/UrlExtractFragmentKudfTest.java
@@ -1,0 +1,54 @@
+/*
+ * Copyright 2018 Confluent Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package io.confluent.ksql.function.udf.url;
+
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+
+import static org.hamcrest.CoreMatchers.equalTo;
+import static org.hamcrest.CoreMatchers.nullValue;
+import static org.hamcrest.MatcherAssert.assertThat;
+
+public class UrlExtractFragmentKudfTest {
+
+  private UrlExtractFragmentKudf extractUdf;
+
+  @Before
+  public void setUp() {
+    extractUdf = new UrlExtractFragmentKudf();
+  }
+
+  @Rule
+  public final ExpectedException expectedException = ExpectedException.none();
+
+
+  @Test
+  public void shouldExtractFragmentIfPresent() {
+    assertThat(extractUdf.extractFragment("https://docs.confluent.io/current/ksql/docs/syntax-reference.html#scalar-functions"), equalTo("scalar-functions"));
+  }
+
+  @Test
+  public void shouldReturnNullIfNoFragment() {
+    assertThat(extractUdf.extractFragment("https://docs.confluent.io/current/ksql/docs/syntax-reference.html"), nullValue());
+  }
+
+  @Test
+  public void shouldReturnNullForInvalidUrl() {
+    assertThat(extractUdf.extractFragment("http://257.1/bogus/[url"), nullValue());
+  }
+
+}

--- a/ksql-engine/src/test/java/io/confluent/ksql/function/udf/url/UrlExtractFragmentKudfTest.java
+++ b/ksql-engine/src/test/java/io/confluent/ksql/function/udf/url/UrlExtractFragmentKudfTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018 Confluent Inc.
+ * Copyright 2019 Confluent Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License. You may obtain a copy of the License at
@@ -36,6 +36,11 @@ public class UrlExtractFragmentKudfTest {
   @Before
   public void setUp() {
     extractUdf = new UrlExtractFragmentKudf();
+  }
+
+  @Test
+  public void testEncodedFragment() {
+    assertThat(extractUdf.extractFragment("https://docs.confluent.io/current/ksql/docs/syntax-reference.html#scalar%20functions"), equalTo("scalar functions"));
   }
 
   @Test

--- a/ksql-engine/src/test/java/io/confluent/ksql/function/udf/url/UrlExtractHostKudfTest.java
+++ b/ksql-engine/src/test/java/io/confluent/ksql/function/udf/url/UrlExtractHostKudfTest.java
@@ -32,10 +32,6 @@ public class UrlExtractHostKudfTest {
     extractUdf = new UrlExtractHostKudf();
   }
 
-  @Rule
-  public final ExpectedException expectedException = ExpectedException.none();
-
-
   @Test
   public void shouldExtractHostIfPresent() {
     assertThat(extractUdf.extractHost("https://docs.confluent.io/current/ksql/docs/syntax-reference.html#scalar-functions"), equalTo("docs.confluent.io"));

--- a/ksql-engine/src/test/java/io/confluent/ksql/function/udf/url/UrlExtractHostKudfTest.java
+++ b/ksql-engine/src/test/java/io/confluent/ksql/function/udf/url/UrlExtractHostKudfTest.java
@@ -50,7 +50,7 @@ public class UrlExtractHostKudfTest {
   public void shouldThrowExceptionForMalformedURL() {
     // Given:
     expectedException.expect(KsqlException.class);
-    expectedException.expectMessage("The passed in URL http://257.1/bogus/[url has invalid syntax!");
+    expectedException.expectMessage("URL input has invalid syntax: http://257.1/bogus/[url");
 
     // When:
     extractUdf.extractHost("http://257.1/bogus/[url");

--- a/ksql-engine/src/test/java/io/confluent/ksql/function/udf/url/UrlExtractHostKudfTest.java
+++ b/ksql-engine/src/test/java/io/confluent/ksql/function/udf/url/UrlExtractHostKudfTest.java
@@ -14,6 +14,7 @@
 
 package io.confluent.ksql.function.udf.url;
 
+import io.confluent.ksql.util.KsqlException;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
@@ -26,6 +27,9 @@ import static org.hamcrest.MatcherAssert.assertThat;
 public class UrlExtractHostKudfTest {
 
   private UrlExtractHostKudf extractUdf;
+
+  @Rule
+  public final ExpectedException expectedException = ExpectedException.none();
 
   @Before
   public void setUp() {
@@ -43,8 +47,13 @@ public class UrlExtractHostKudfTest {
   }
 
   @Test
-  public void shouldReturnNullForInvalidUrl() {
-    assertThat(extractUdf.extractHost("http://257.1/bogus/[url"), nullValue());
+  public void shouldThrowExceptionForMalformedURL() {
+    // Given:
+    expectedException.expect(KsqlException.class);
+    expectedException.expectMessage("The passed in URL http://257.1/bogus/[url has invalid syntax!");
+
+    // When:
+    extractUdf.extractHost("http://257.1/bogus/[url");
   }
 
 }

--- a/ksql-engine/src/test/java/io/confluent/ksql/function/udf/url/UrlExtractHostKudfTest.java
+++ b/ksql-engine/src/test/java/io/confluent/ksql/function/udf/url/UrlExtractHostKudfTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018 Confluent Inc.
+ * Copyright 2019 Confluent Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License. You may obtain a copy of the License at
@@ -38,7 +38,7 @@ public class UrlExtractHostKudfTest {
 
   @Test
   public void shouldExtractHostIfPresent() {
-    assertThat(extractUdf.extractHost("https://docs.confluent.io/current/ksql/docs/syntax-reference.html#scalar-functions"), equalTo("docs.confluent.io"));
+    assertThat(extractUdf.extractHost("https://docs.confluent.io:8080/current/ksql/docs/syntax-reference.html#scalar-functions"), equalTo("docs.confluent.io"));
   }
 
   @Test

--- a/ksql-engine/src/test/java/io/confluent/ksql/function/udf/url/UrlExtractHostKudfTest.java
+++ b/ksql-engine/src/test/java/io/confluent/ksql/function/udf/url/UrlExtractHostKudfTest.java
@@ -1,0 +1,54 @@
+/*
+ * Copyright 2018 Confluent Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package io.confluent.ksql.function.udf.url;
+
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+
+import static org.hamcrest.CoreMatchers.equalTo;
+import static org.hamcrest.CoreMatchers.nullValue;
+import static org.hamcrest.MatcherAssert.assertThat;
+
+public class UrlExtractHostKudfTest {
+
+  private UrlExtractHostKudf extractUdf;
+
+  @Before
+  public void setUp() {
+    extractUdf = new UrlExtractHostKudf();
+  }
+
+  @Rule
+  public final ExpectedException expectedException = ExpectedException.none();
+
+
+  @Test
+  public void shouldExtractHostIfPresent() {
+    assertThat(extractUdf.extractHost("https://docs.confluent.io/current/ksql/docs/syntax-reference.html#scalar-functions"), equalTo("docs.confluent.io"));
+  }
+
+  @Test
+  public void shouldReturnNullIfNoHost() {
+    assertThat(extractUdf.extractHost("https:///current/ksql/docs/syntax-reference.html#scalar-functions"), nullValue());
+  }
+
+  @Test
+  public void shouldReturnNullForInvalidUrl() {
+    assertThat(extractUdf.extractHost("http://257.1/bogus/[url"), nullValue());
+  }
+
+}

--- a/ksql-engine/src/test/java/io/confluent/ksql/function/udf/url/UrlExtractParameterKudfTest.java
+++ b/ksql-engine/src/test/java/io/confluent/ksql/function/udf/url/UrlExtractParameterKudfTest.java
@@ -60,7 +60,7 @@ public class UrlExtractParameterKudfTest {
   public void shouldThrowExceptionForMalformedURL() {
     // Given:
     expectedException.expect(KsqlException.class);
-    expectedException.expectMessage("The passed in URL http://257.1/bogus/[url has invalid syntax!");
+    expectedException.expectMessage("URL input has invalid syntax: http://257.1/bogus/[url");
 
     // When:
     extractUdf.extractParam("http://257.1/bogus/[url", "foo bar");

--- a/ksql-engine/src/test/java/io/confluent/ksql/function/udf/url/UrlExtractParameterKudfTest.java
+++ b/ksql-engine/src/test/java/io/confluent/ksql/function/udf/url/UrlExtractParameterKudfTest.java
@@ -1,0 +1,64 @@
+/*
+ * Copyright 2018 Confluent Inc.
+ *
+ * Licensed under the Confluent Community License; you may not use this file
+ * except in compliance with the License.  You may obtain a copy of the License at
+ *
+ * http://www.confluent.io/confluent-community-license
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package io.confluent.ksql.function.udf.url;
+
+import static org.hamcrest.CoreMatchers.equalTo;
+import static org.hamcrest.CoreMatchers.nullValue;
+import static org.hamcrest.MatcherAssert.assertThat;
+
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+
+public class UrlExtractParameterKudfTest {
+
+  private UrlExtractParameterKudf extractUdf;
+
+  @Before
+  public void setUp() {
+    extractUdf = new UrlExtractParameterKudf();
+  }
+
+  @Rule
+  public final ExpectedException expectedException = ExpectedException.none();
+
+
+  @Test
+  public void shouldExtractParamValueIfPresent() {
+    assertThat(extractUdf.extractParam("https://docs.confluent.io?foo%20bar=baz&blank#scalar-functions", "foo bar"), equalTo("baz"));
+  }
+
+  @Test
+  public void shouldExtractParamValueCaseSensitive() {
+    assertThat(extractUdf.extractParam("https://docs.confluent.io?foo%20bar=baz&blank#scalar-functions", "foo Bar"), nullValue());
+  }
+
+  @Test
+  public void shouldReturnNullIfParamHasNoValue() {
+    assertThat(extractUdf.extractParam("https://docs.confluent.io?foo%20bar=baz&blank#scalar-functions", "blank"), nullValue());
+  }
+
+  @Test
+  public void shouldReturnNullIfParamNotPresent() {
+    assertThat(extractUdf.extractParam("https://docs.confluent.io?foo%20bar=baz&blank#scalar-functions", "absent"), nullValue());
+  }
+
+  @Test
+  public void shouldReturnNullForInvalidUrl() {
+    assertThat(extractUdf.extractParam("http://257.1/bogus/[url", "foo bar"), nullValue());
+  }
+
+}

--- a/ksql-engine/src/test/java/io/confluent/ksql/function/udf/url/UrlExtractParameterKudfTest.java
+++ b/ksql-engine/src/test/java/io/confluent/ksql/function/udf/url/UrlExtractParameterKudfTest.java
@@ -32,10 +32,6 @@ public class UrlExtractParameterKudfTest {
     extractUdf = new UrlExtractParameterKudf();
   }
 
-  @Rule
-  public final ExpectedException expectedException = ExpectedException.none();
-
-
   @Test
   public void shouldExtractParamValueIfPresent() {
     assertThat(extractUdf.extractParam("https://docs.confluent.io?foo%20bar=baz&blank#scalar-functions", "foo bar"), equalTo("baz"));

--- a/ksql-engine/src/test/java/io/confluent/ksql/function/udf/url/UrlExtractParameterKudfTest.java
+++ b/ksql-engine/src/test/java/io/confluent/ksql/function/udf/url/UrlExtractParameterKudfTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018 Confluent Inc.
+ * Copyright 2019 Confluent Inc.
  *
  * Licensed under the Confluent Community License; you may not use this file
  * except in compliance with the License.  You may obtain a copy of the License at
@@ -38,7 +38,7 @@ public class UrlExtractParameterKudfTest {
 
   @Test
   public void shouldExtractParamValueIfPresent() {
-    assertThat(extractUdf.extractParam("https://docs.confluent.io?foo%20bar=baz&blank#scalar-functions", "foo bar"), equalTo("baz"));
+    assertThat(extractUdf.extractParam("https://docs.confluent.io?foo%20bar=baz%20zab&blank#scalar-functions", "foo bar"), equalTo("baz zab"));
   }
 
   @Test
@@ -47,8 +47,8 @@ public class UrlExtractParameterKudfTest {
   }
 
   @Test
-  public void shouldReturnNullIfParamHasNoValue() {
-    assertThat(extractUdf.extractParam("https://docs.confluent.io?foo%20bar=baz&blank#scalar-functions", "blank"), nullValue());
+  public void shouldReturnEmptyStringIfParamHasNoValue() {
+    assertThat(extractUdf.extractParam("https://docs.confluent.io?foo%20bar=baz&blank#scalar-functions", "blank"), equalTo(""));
   }
 
   @Test

--- a/ksql-engine/src/test/java/io/confluent/ksql/function/udf/url/UrlExtractParameterKudfTest.java
+++ b/ksql-engine/src/test/java/io/confluent/ksql/function/udf/url/UrlExtractParameterKudfTest.java
@@ -18,6 +18,7 @@ import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.CoreMatchers.nullValue;
 import static org.hamcrest.MatcherAssert.assertThat;
 
+import io.confluent.ksql.util.KsqlException;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
@@ -26,6 +27,9 @@ import org.junit.rules.ExpectedException;
 public class UrlExtractParameterKudfTest {
 
   private UrlExtractParameterKudf extractUdf;
+
+  @Rule
+  public final ExpectedException expectedException = ExpectedException.none();
 
   @Before
   public void setUp() {
@@ -53,8 +57,13 @@ public class UrlExtractParameterKudfTest {
   }
 
   @Test
-  public void shouldReturnNullForInvalidUrl() {
-    assertThat(extractUdf.extractParam("http://257.1/bogus/[url", "foo bar"), nullValue());
+  public void shouldThrowExceptionForMalformedURL() {
+    // Given:
+    expectedException.expect(KsqlException.class);
+    expectedException.expectMessage("The passed in URL http://257.1/bogus/[url has invalid syntax!");
+
+    // When:
+    extractUdf.extractParam("http://257.1/bogus/[url", "foo bar");
   }
 
 }

--- a/ksql-engine/src/test/java/io/confluent/ksql/function/udf/url/UrlExtractPathKudfTest.java
+++ b/ksql-engine/src/test/java/io/confluent/ksql/function/udf/url/UrlExtractPathKudfTest.java
@@ -32,10 +32,6 @@ public class UrlExtractPathKudfTest {
     extractUdf = new UrlExtractPathKudf();
   }
 
-  @Rule
-  public final ExpectedException expectedException = ExpectedException.none();
-
-
   @Test
   public void shouldExtractPathIfPresent() {
     assertThat(extractUdf.extractPath("https://docs.confluent.io/current/ksql/docs/syntax-reference.html#scalar-functions"), equalTo("/current/ksql/docs/syntax-reference.html"));

--- a/ksql-engine/src/test/java/io/confluent/ksql/function/udf/url/UrlExtractPathKudfTest.java
+++ b/ksql-engine/src/test/java/io/confluent/ksql/function/udf/url/UrlExtractPathKudfTest.java
@@ -55,7 +55,7 @@ public class UrlExtractPathKudfTest {
   public void shouldThrowExceptionForMalformedURL() {
     // Given:
     expectedException.expect(KsqlException.class);
-    expectedException.expectMessage("The passed in URL http://257.1/bogus/[url has invalid syntax!");
+    expectedException.expectMessage("URL input has invalid syntax: http://257.1/bogus/[url");
 
     // When:
     extractUdf.extractPath("http://257.1/bogus/[url");

--- a/ksql-engine/src/test/java/io/confluent/ksql/function/udf/url/UrlExtractPathKudfTest.java
+++ b/ksql-engine/src/test/java/io/confluent/ksql/function/udf/url/UrlExtractPathKudfTest.java
@@ -1,0 +1,58 @@
+/*
+ * Copyright 2018 Confluent Inc.
+ *
+ * Licensed under the Confluent Community License; you may not use this file
+ * except in compliance with the License.  You may obtain a copy of the License at
+ *
+ * http://www.confluent.io/confluent-community-license
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package io.confluent.ksql.function.udf.url;
+
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+
+import static org.hamcrest.CoreMatchers.equalTo;
+import static org.hamcrest.CoreMatchers.nullValue;
+import static org.hamcrest.MatcherAssert.assertThat;
+
+public class UrlExtractPathKudfTest {
+
+  private UrlExtractPathKudf extractUdf;
+
+  @Before
+  public void setUp() {
+    extractUdf = new UrlExtractPathKudf();
+  }
+
+  @Rule
+  public final ExpectedException expectedException = ExpectedException.none();
+
+
+  @Test
+  public void shouldExtractPathIfPresent() {
+    assertThat(extractUdf.extractPath("https://docs.confluent.io/current/ksql/docs/syntax-reference.html#scalar-functions"), equalTo("/current/ksql/docs/syntax-reference.html"));
+  }
+
+  @Test
+  public void shouldReturnSlashIfRootPath() {
+    assertThat(extractUdf.extractPath("https://docs.confluent.io/"), equalTo("/"));
+  }
+
+  @Test
+  public void shouldReturnEmptyIfNoPath() {
+    assertThat(extractUdf.extractPath("https://docs.confluent.io"), equalTo(""));
+  }
+
+  @Test
+  public void shouldReturnNullForInvalidUrl() {
+    assertThat(extractUdf.extractPath("http://257.1/bogus/[url"), nullValue());
+  }
+}

--- a/ksql-engine/src/test/java/io/confluent/ksql/function/udf/url/UrlExtractPathKudfTest.java
+++ b/ksql-engine/src/test/java/io/confluent/ksql/function/udf/url/UrlExtractPathKudfTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018 Confluent Inc.
+ * Copyright 2019 Confluent Inc.
  *
  * Licensed under the Confluent Community License; you may not use this file
  * except in compliance with the License.  You may obtain a copy of the License at

--- a/ksql-engine/src/test/java/io/confluent/ksql/function/udf/url/UrlExtractPathKudfTest.java
+++ b/ksql-engine/src/test/java/io/confluent/ksql/function/udf/url/UrlExtractPathKudfTest.java
@@ -14,6 +14,7 @@
 
 package io.confluent.ksql.function.udf.url;
 
+import io.confluent.ksql.util.KsqlException;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
@@ -26,6 +27,9 @@ import static org.hamcrest.MatcherAssert.assertThat;
 public class UrlExtractPathKudfTest {
 
   private UrlExtractPathKudf extractUdf;
+
+  @Rule
+  public final ExpectedException expectedException = ExpectedException.none();
 
   @Before
   public void setUp() {
@@ -48,7 +52,12 @@ public class UrlExtractPathKudfTest {
   }
 
   @Test
-  public void shouldReturnNullForInvalidUrl() {
-    assertThat(extractUdf.extractPath("http://257.1/bogus/[url"), nullValue());
+  public void shouldThrowExceptionForMalformedURL() {
+    // Given:
+    expectedException.expect(KsqlException.class);
+    expectedException.expectMessage("The passed in URL http://257.1/bogus/[url has invalid syntax!");
+
+    // When:
+    extractUdf.extractPath("http://257.1/bogus/[url");
   }
 }

--- a/ksql-engine/src/test/java/io/confluent/ksql/function/udf/url/UrlExtractPortKudfTest.java
+++ b/ksql-engine/src/test/java/io/confluent/ksql/function/udf/url/UrlExtractPortKudfTest.java
@@ -31,10 +31,6 @@ public class UrlExtractPortKudfTest {
     extractUdf = new UrlExtractPortKudf();
   }
 
-  @Rule
-  public final ExpectedException expectedException = ExpectedException.none();
-
-
   @Test
   public void shouldExtractPortIfPresent() {
     assertThat(

--- a/ksql-engine/src/test/java/io/confluent/ksql/function/udf/url/UrlExtractPortKudfTest.java
+++ b/ksql-engine/src/test/java/io/confluent/ksql/function/udf/url/UrlExtractPortKudfTest.java
@@ -14,6 +14,7 @@
 
 package io.confluent.ksql.function.udf.url;
 
+import io.confluent.ksql.util.KsqlException;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
@@ -25,6 +26,9 @@ import static org.hamcrest.MatcherAssert.assertThat;
 public class UrlExtractPortKudfTest {
 
   private UrlExtractPortKudf extractUdf;
+
+  @Rule
+  public final ExpectedException expectedException = ExpectedException.none();
 
   @Before
   public void setUp() {
@@ -46,10 +50,13 @@ public class UrlExtractPortKudfTest {
   }
 
   @Test
-  public void shouldReturnNegOnelForInvalidUrl() {
-    assertThat(
-            extractUdf.extractPort("http://257.1/bogus/[url"),
-            equalTo(null));
+  public void shouldThrowExceptionForMalformedURL() {
+    // Given:
+    expectedException.expect(KsqlException.class);
+    expectedException.expectMessage("The passed in URL http://257.1/bogus/[url has invalid syntax!");
+
+    // When:
+    extractUdf.extractPort("http://257.1/bogus/[url");
   }
 
 }

--- a/ksql-engine/src/test/java/io/confluent/ksql/function/udf/url/UrlExtractPortKudfTest.java
+++ b/ksql-engine/src/test/java/io/confluent/ksql/function/udf/url/UrlExtractPortKudfTest.java
@@ -1,0 +1,59 @@
+/*
+ * Copyright 2018 Confluent Inc.
+ *
+ * Licensed under the Confluent Community License; you may not use this file
+ * except in compliance with the License.  You may obtain a copy of the License at
+ *
+ * http://www.confluent.io/confluent-community-license
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package io.confluent.ksql.function.udf.url;
+
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+
+import static org.hamcrest.CoreMatchers.equalTo;
+import static org.hamcrest.MatcherAssert.assertThat;
+
+public class UrlExtractPortKudfTest {
+
+  private UrlExtractPortKudf extractUdf;
+
+  @Before
+  public void setUp() {
+    extractUdf = new UrlExtractPortKudf();
+  }
+
+  @Rule
+  public final ExpectedException expectedException = ExpectedException.none();
+
+
+  @Test
+  public void shouldExtractPortIfPresent() {
+    assertThat(
+            extractUdf.extractPort("https://docs.confluent.io:8080/current/ksql/docs/syntax-reference.html#scalar-functions"),
+            equalTo(8080));
+  }
+
+  @Test
+  public void shouldReturnNullIfNoPort() {
+    assertThat(
+            extractUdf.extractPort("https://docs.confluent.io/current/ksql/docs/syntax-reference.html#scalar-functions"),
+            equalTo(null));
+  }
+
+  @Test
+  public void shouldReturnNegOnelForInvalidUrl() {
+    assertThat(
+            extractUdf.extractPort("http://257.1/bogus/[url"),
+            equalTo(null));
+  }
+
+}

--- a/ksql-engine/src/test/java/io/confluent/ksql/function/udf/url/UrlExtractPortKudfTest.java
+++ b/ksql-engine/src/test/java/io/confluent/ksql/function/udf/url/UrlExtractPortKudfTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018 Confluent Inc.
+ * Copyright 2019 Confluent Inc.
  *
  * Licensed under the Confluent Community License; you may not use this file
  * except in compliance with the License.  You may obtain a copy of the License at

--- a/ksql-engine/src/test/java/io/confluent/ksql/function/udf/url/UrlExtractPortKudfTest.java
+++ b/ksql-engine/src/test/java/io/confluent/ksql/function/udf/url/UrlExtractPortKudfTest.java
@@ -53,7 +53,7 @@ public class UrlExtractPortKudfTest {
   public void shouldThrowExceptionForMalformedURL() {
     // Given:
     expectedException.expect(KsqlException.class);
-    expectedException.expectMessage("The passed in URL http://257.1/bogus/[url has invalid syntax!");
+    expectedException.expectMessage("URL input has invalid syntax: http://257.1/bogus/[url");
 
     // When:
     extractUdf.extractPort("http://257.1/bogus/[url");

--- a/ksql-engine/src/test/java/io/confluent/ksql/function/udf/url/UrlExtractProtocolKudfTest.java
+++ b/ksql-engine/src/test/java/io/confluent/ksql/function/udf/url/UrlExtractProtocolKudfTest.java
@@ -1,0 +1,60 @@
+/*
+ * Copyright 2018 Confluent Inc.
+ *
+ * Licensed under the Confluent Community License; you may not use this file
+ * except in compliance with the License.  You may obtain a copy of the License at
+ *
+ * http://www.confluent.io/confluent-community-license
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package io.confluent.ksql.function.udf.url;
+
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+
+import static org.hamcrest.CoreMatchers.equalTo;
+import static org.hamcrest.CoreMatchers.nullValue;
+import static org.hamcrest.MatcherAssert.assertThat;
+
+public class UrlExtractProtocolKudfTest {
+
+  private UrlExtractProtocolKudf extractUdf;
+
+  @Before
+  public void setUp() {
+    extractUdf = new UrlExtractProtocolKudf();
+  }
+
+  @Rule
+  public final ExpectedException expectedException = ExpectedException.none();
+
+
+  @Test
+  public void shouldExtractProtocolIfPresent() {
+    assertThat(
+            extractUdf.extractProtocol("https://docs.confluent.io/current/ksql/docs/syntax-reference.html#scalar-functions"),
+            equalTo("https"));
+  }
+
+  @Test
+  public void shouldReturnNullIfNoProtocol() {
+    assertThat(
+            extractUdf.extractProtocol("///current/ksql/docs/syntax-reference.html#scalar-functions"),
+            nullValue());
+  }
+
+  @Test
+  public void shouldReturnNullForInvalidUrl() {
+    assertThat(
+            extractUdf.extractProtocol("http://257.1/bogus/[url"),
+            nullValue());
+  }
+
+}

--- a/ksql-engine/src/test/java/io/confluent/ksql/function/udf/url/UrlExtractProtocolKudfTest.java
+++ b/ksql-engine/src/test/java/io/confluent/ksql/function/udf/url/UrlExtractProtocolKudfTest.java
@@ -32,10 +32,6 @@ public class UrlExtractProtocolKudfTest {
     extractUdf = new UrlExtractProtocolKudf();
   }
 
-  @Rule
-  public final ExpectedException expectedException = ExpectedException.none();
-
-
   @Test
   public void shouldExtractProtocolIfPresent() {
     assertThat(

--- a/ksql-engine/src/test/java/io/confluent/ksql/function/udf/url/UrlExtractProtocolKudfTest.java
+++ b/ksql-engine/src/test/java/io/confluent/ksql/function/udf/url/UrlExtractProtocolKudfTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018 Confluent Inc.
+ * Copyright 2019 Confluent Inc.
  *
  * Licensed under the Confluent Community License; you may not use this file
  * except in compliance with the License.  You may obtain a copy of the License at

--- a/ksql-engine/src/test/java/io/confluent/ksql/function/udf/url/UrlExtractProtocolKudfTest.java
+++ b/ksql-engine/src/test/java/io/confluent/ksql/function/udf/url/UrlExtractProtocolKudfTest.java
@@ -14,6 +14,7 @@
 
 package io.confluent.ksql.function.udf.url;
 
+import io.confluent.ksql.util.KsqlException;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
@@ -26,6 +27,9 @@ import static org.hamcrest.MatcherAssert.assertThat;
 public class UrlExtractProtocolKudfTest {
 
   private UrlExtractProtocolKudf extractUdf;
+
+  @Rule
+  public final ExpectedException expectedException = ExpectedException.none();
 
   @Before
   public void setUp() {
@@ -47,10 +51,13 @@ public class UrlExtractProtocolKudfTest {
   }
 
   @Test
-  public void shouldReturnNullForInvalidUrl() {
-    assertThat(
-            extractUdf.extractProtocol("http://257.1/bogus/[url"),
-            nullValue());
+  public void shouldThrowExceptionForMalformedURL() {
+    // Given:
+    expectedException.expect(KsqlException.class);
+    expectedException.expectMessage("The passed in URL http://257.1/bogus/[url has invalid syntax!");
+
+    // When:
+    extractUdf.extractProtocol("http://257.1/bogus/[url");
   }
 
 }

--- a/ksql-engine/src/test/java/io/confluent/ksql/function/udf/url/UrlExtractProtocolKudfTest.java
+++ b/ksql-engine/src/test/java/io/confluent/ksql/function/udf/url/UrlExtractProtocolKudfTest.java
@@ -54,7 +54,7 @@ public class UrlExtractProtocolKudfTest {
   public void shouldThrowExceptionForMalformedURL() {
     // Given:
     expectedException.expect(KsqlException.class);
-    expectedException.expectMessage("The passed in URL http://257.1/bogus/[url has invalid syntax!");
+    expectedException.expectMessage("URL input has invalid syntax: http://257.1/bogus/[url");
 
     // When:
     extractUdf.extractProtocol("http://257.1/bogus/[url");

--- a/ksql-engine/src/test/java/io/confluent/ksql/function/udf/url/UrlExtractQueryKudfTest.java
+++ b/ksql-engine/src/test/java/io/confluent/ksql/function/udf/url/UrlExtractQueryKudfTest.java
@@ -32,10 +32,6 @@ public class UrlExtractQueryKudfTest {
     extractUdf = new UrlExtractQueryKudf();
   }
 
-  @Rule
-  public final ExpectedException expectedException = ExpectedException.none();
-
-
   @Test
   public void shouldExtractQueryIfPresent() {
     assertThat(extractUdf.extractQuery("https://docs.confluent.io/current/ksql/docs/syntax-reference.html?a=b&foo%20bar=baz&c=d&e#scalar-functions"), equalTo("a=b&foo bar=baz&c=d&e"));

--- a/ksql-engine/src/test/java/io/confluent/ksql/function/udf/url/UrlExtractQueryKudfTest.java
+++ b/ksql-engine/src/test/java/io/confluent/ksql/function/udf/url/UrlExtractQueryKudfTest.java
@@ -1,0 +1,54 @@
+/*
+ * Copyright 2018 Confluent Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package io.confluent.ksql.function.udf.url;
+
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+
+import static org.hamcrest.CoreMatchers.equalTo;
+import static org.hamcrest.CoreMatchers.nullValue;
+import static org.hamcrest.MatcherAssert.assertThat;
+
+public class UrlExtractQueryKudfTest {
+
+  private UrlExtractQueryKudf extractUdf;
+
+  @Before
+  public void setUp() {
+    extractUdf = new UrlExtractQueryKudf();
+  }
+
+  @Rule
+  public final ExpectedException expectedException = ExpectedException.none();
+
+
+  @Test
+  public void shouldExtractQueryIfPresent() {
+    assertThat(extractUdf.extractQuery("https://docs.confluent.io/current/ksql/docs/syntax-reference.html?a=b&foo%20bar=baz&c=d&e#scalar-functions"), equalTo("a=b&foo bar=baz&c=d&e"));
+  }
+
+  @Test
+  public void shouldReturnNullIfNoQuery() {
+    assertThat(extractUdf.extractQuery("https://current/ksql/docs/syntax-reference.html#scalar-functions"), nullValue());
+  }
+
+  @Test
+  public void shouldReturnNullForInvalidUrl() {
+    assertThat(extractUdf.extractQuery("http://257.1/bogus/[url"), nullValue());
+  }
+
+}

--- a/ksql-engine/src/test/java/io/confluent/ksql/function/udf/url/UrlExtractQueryKudfTest.java
+++ b/ksql-engine/src/test/java/io/confluent/ksql/function/udf/url/UrlExtractQueryKudfTest.java
@@ -50,7 +50,7 @@ public class UrlExtractQueryKudfTest {
   public void shouldThrowExceptionForMalformedURL() {
     // Given:
     expectedException.expect(KsqlException.class);
-    expectedException.expectMessage("The passed in URL http://257.1/bogus/[url has invalid syntax!");
+    expectedException.expectMessage("URL input has invalid syntax: http://257.1/bogus/[url");
 
     // When:
     extractUdf.extractQuery("http://257.1/bogus/[url");

--- a/ksql-engine/src/test/java/io/confluent/ksql/function/udf/url/UrlExtractQueryKudfTest.java
+++ b/ksql-engine/src/test/java/io/confluent/ksql/function/udf/url/UrlExtractQueryKudfTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018 Confluent Inc.
+ * Copyright 2019 Confluent Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License. You may obtain a copy of the License at

--- a/ksql-engine/src/test/java/io/confluent/ksql/function/udf/url/UrlExtractQueryKudfTest.java
+++ b/ksql-engine/src/test/java/io/confluent/ksql/function/udf/url/UrlExtractQueryKudfTest.java
@@ -14,6 +14,7 @@
 
 package io.confluent.ksql.function.udf.url;
 
+import io.confluent.ksql.util.KsqlException;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
@@ -26,6 +27,9 @@ import static org.hamcrest.MatcherAssert.assertThat;
 public class UrlExtractQueryKudfTest {
 
   private UrlExtractQueryKudf extractUdf;
+
+  @Rule
+  public final ExpectedException expectedException = ExpectedException.none();
 
   @Before
   public void setUp() {
@@ -43,8 +47,13 @@ public class UrlExtractQueryKudfTest {
   }
 
   @Test
-  public void shouldReturnNullForInvalidUrl() {
-    assertThat(extractUdf.extractQuery("http://257.1/bogus/[url"), nullValue());
+  public void shouldThrowExceptionForMalformedURL() {
+    // Given:
+    expectedException.expect(KsqlException.class);
+    expectedException.expectMessage("The passed in URL http://257.1/bogus/[url has invalid syntax!");
+
+    // When:
+    extractUdf.extractQuery("http://257.1/bogus/[url");
   }
 
 }

--- a/ksql-engine/src/test/resources/query-validation-tests/url.json
+++ b/ksql-engine/src/test/resources/query-validation-tests/url.json
@@ -1,0 +1,162 @@
+{
+  "comments": [
+    "Tests covering the use of all URL based operators.",
+    "See https://en.wikipedia.org/wiki/Uniform_Resource_Identifier#Definition"
+  ],
+  "tests": [
+    {
+      "name": "encode a url parameter using ENCODE_URL_PARAM",
+      "format": ["JSON"],
+      "statements": [
+        "CREATE STREAM TEST (url VARCHAR) WITH (kafka_topic='test_topic', value_format='JSON');",
+        "CREATE STREAM OUTPUT AS SELECT URL_ENCODE_PARAM(url) as ENCODED FROM TEST;"
+      ],
+      "inputs": [
+        {"topic":  "test_topic", "key":  1, "value": {"url": "?foo $bar"}, "timestamp":  0},
+        {"topic":  "test_topic", "key":  2, "value": {"url": "hello&world"}, "timestamp":  1},
+        {"topic":  "test_topic", "key":  3, "value": {"url": "nothing"}, "timestamp":  2}
+      ],
+      "outputs": [
+        {"topic":  "OUTPUT", "key":  1, "value":  {"ENCODED": "%3Ffoo+%24bar"}, "timestamp": 0},
+        {"topic":  "OUTPUT", "key":  2, "value":  {"ENCODED": "hello%26world"}, "timestamp": 1},
+        {"topic":  "OUTPUT", "key":  3, "value":  {"ENCODED": "nothing"}, "timestamp": 2}
+      ]
+    },
+    {
+      "name": "decode a url parameter using DECODE_URL_PARAM",
+      "format": ["JSON"],
+      "statements": [
+        "CREATE STREAM TEST (url VARCHAR) WITH (kafka_topic='test_topic', value_format='JSON');",
+        "CREATE STREAM OUTPUT AS SELECT URL_DECODE_PARAM(url) as DECODED FROM TEST;"
+      ],
+      "inputs": [
+        {"topic":  "test_topic", "key":  1, "value": {"url": "%3Ffoo+%24bar"}, "timestamp":  0},
+        {"topic":  "test_topic", "key":  2, "value": {"url": "hello%26world"}, "timestamp":  1},
+        {"topic":  "test_topic", "key":  3, "value": {"url": "nothing"}, "timestamp":  2}
+      ],
+      "outputs": [
+        {"topic":  "OUTPUT", "key":  1, "value":  {"DECODED": "?foo $bar"}, "timestamp": 0},
+        {"topic":  "OUTPUT", "key":  2, "value":  {"DECODED": "hello&world"}, "timestamp": 1},
+        {"topic":  "OUTPUT", "key":  3, "value":  {"DECODED": "nothing"}, "timestamp": 2}
+      ]
+    },
+    {
+      "name": "extract a fragment from a URL using URL_EXTRACT_FRAGMENT",
+      "format": ["JSON"],
+      "statements": [
+        "CREATE STREAM TEST (url VARCHAR) WITH (kafka_topic='test_topic', value_format='JSON');",
+        "CREATE STREAM OUTPUT AS SELECT URL_EXTRACT_FRAGMENT(url) as FRAGMENT FROM TEST;"
+      ],
+      "inputs": [
+        {"topic":  "test_topic", "key":  1, "value": {"url": "http://www.test.com/?query#fragment"}, "timestamp":  0},
+        {"topic":  "test_topic", "key":  2, "value": {"url": "http://www.nofragment.com"}, "timestamp":  1}
+      ],
+      "outputs": [
+        {"topic":  "OUTPUT", "key":  1, "value":  {"FRAGMENT": "fragment"}, "timestamp": 0},
+        {"topic":  "OUTPUT", "key":  2, "value":  {"FRAGMENT": null}, "timestamp": 1}
+      ]
+    },
+    {
+      "name": "extract a host from a URL using URL_EXTRACT_HOST",
+      "format": ["JSON"],
+      "statements": [
+        "CREATE STREAM TEST (url VARCHAR) WITH (kafka_topic='test_topic', value_format='JSON');",
+        "CREATE STREAM OUTPUT AS SELECT URL_EXTRACT_HOST(url) as HOST FROM TEST;"
+      ],
+      "inputs": [
+        {"topic":  "test_topic", "key":  1, "value": {"url": "http://www.test.com/?query#fragment"}, "timestamp":  0},
+        {"topic":  "test_topic", "key":  2, "value": {"url": "http://test@confluent.io:8080"}, "timestamp":  1}
+      ],
+      "outputs": [
+        {"topic":  "OUTPUT", "key":  1, "value":  {"HOST": "www.test.com"}, "timestamp": 0},
+        {"topic":  "OUTPUT", "key":  2, "value":  {"HOST": "confluent.io"}, "timestamp": 1}
+      ]
+    },
+    {
+      "name": "extract a parameter from a URL using URL_EXTRACT_PARAMETER",
+      "format": ["JSON"],
+      "statements": [
+        "CREATE STREAM TEST (url VARCHAR) WITH (kafka_topic='test_topic', value_format='JSON');",
+        "CREATE STREAM OUTPUT AS SELECT URL_EXTRACT_PARAMETER(url,'one') as PARAM_A, URL_EXTRACT_PARAMETER(url,'two') as PARAM_B FROM TEST;"
+      ],
+      "inputs": [
+        {"topic":  "test_topic", "key":  1, "value": {"url": "http://www.test.com/?one=a&two=b&three"}, "timestamp":  0}
+      ],
+      "outputs": [
+        {"topic":  "OUTPUT", "key":  1, "value":  {"PARAM_A": "a", "PARAM_B": "b"}, "timestamp": 0}
+      ]
+    },
+    {
+      "name": "extract a path from a URL using URL_EXTRACT_PATH",
+      "format": ["JSON"],
+      "statements": [
+        "CREATE STREAM TEST (url VARCHAR) WITH (kafka_topic='test_topic', value_format='JSON');",
+        "CREATE STREAM OUTPUT AS SELECT URL_EXTRACT_PATH(url) as PATH FROM TEST;"
+      ],
+      "inputs": [
+        {"topic":  "test_topic", "key":  1, "value": {"url": "http://www.test.com?query#fragment"}, "timestamp":  0},
+        {"topic":  "test_topic", "key":  2, "value": {"url": "http://www.test.com/path?query"}, "timestamp":  1},
+        {"topic":  "test_topic", "key":  3, "value": {"url": "http://test@confluent.io:8080/nested/path?query&jobs"}, "timestamp":  2}
+      ],
+      "outputs": [
+        {"topic":  "OUTPUT", "key":  1, "value":  {"PATH": ""}, "timestamp": 0},
+        {"topic":  "OUTPUT", "key":  2, "value":  {"PATH": "/path"}, "timestamp": 1},
+        {"topic":  "OUTPUT", "key":  3, "value":  {"PATH": "/nested/path"}, "timestamp": 2}
+      ]
+    },
+    {
+      "name": "extract a port from a URL using URL_EXTRACT_PORT",
+      "format": ["JSON"],
+      "statements": [
+        "CREATE STREAM TEST (url VARCHAR) WITH (kafka_topic='test_topic', value_format='JSON');",
+        "CREATE STREAM OUTPUT AS SELECT URL_EXTRACT_PORT(url) as PORT FROM TEST;"
+      ],
+      "inputs": [
+        {"topic":  "test_topic", "key":  1, "value": {"url": "http://test@confluent.io"}, "timestamp":  0},
+        {"topic":  "test_topic", "key":  2, "value": {"url": "http://test@confluent.io:8080/nested/path?query&jobs"}, "timestamp":  1}
+      ],
+      "outputs": [
+        {"topic":  "OUTPUT", "key":  1, "value":  {"PORT": null}, "timestamp": 0},
+        {"topic":  "OUTPUT", "key":  2, "value":  {"PORT": 8080}, "timestamp": 1}
+      ]
+    },
+    {
+      "name": "extract a protocol from a URL using URL_EXTRACT_PROTOCOL",
+      "format": ["JSON"],
+      "statements": [
+        "CREATE STREAM TEST (url VARCHAR) WITH (kafka_topic='test_topic', value_format='JSON');",
+        "CREATE STREAM OUTPUT AS SELECT URL_EXTRACT_PROTOCOL(url) as PROTOCOL FROM TEST;"
+      ],
+      "inputs": [
+        {"topic":  "test_topic", "key":  1, "value": {"url": "http://test@confluent.io"}, "timestamp":  0},
+        {"topic":  "test_topic", "key":  2, "value": {"url": "https://test@confluent.io:8080/nested/path?query&jobs"}, "timestamp":  1},
+        {"topic":  "test_topic", "key":  3, "value": {"url": "www.confluent.io"}, "timestamp":  2}
+      ],
+      "outputs": [
+        {"topic":  "OUTPUT", "key":  1, "value":  {"PROTOCOL": "http"}, "timestamp": 0},
+        {"topic":  "OUTPUT", "key":  2, "value":  {"PROTOCOL": "https"}, "timestamp": 1},
+        {"topic":  "OUTPUT", "key":  3, "value":  {"PROTOCOL": null}, "timestamp": 2}
+      ]
+    },
+    {
+      "name": "extract a query from a URL using URL_EXTRACT_QUERY",
+      "format": ["JSON"],
+      "statements": [
+        "CREATE STREAM TEST (url VARCHAR) WITH (kafka_topic='test_topic', value_format='JSON');",
+        "CREATE STREAM OUTPUT AS SELECT URL_EXTRACT_QUERY(url) as Q FROM TEST;"
+      ],
+      "inputs": [
+        {"topic":  "test_topic", "key":  1, "value": {"url": "http://www.test.com?query#fragment"}, "timestamp":  0},
+        {"topic":  "test_topic", "key":  2, "value": {"url": "http://www.test.com/path?q1&q2"}, "timestamp":  1},
+        {"topic":  "test_topic", "key":  3, "value": {"url": "http://test@confluent.io:8080/nested/path?q=2"}, "timestamp":  2},
+        {"topic":  "test_topic", "key":  4, "value": {"url": "http://test@confluent.io:8080/path"}, "timestamp":  3}
+      ],
+      "outputs": [
+        {"topic":  "OUTPUT", "key":  1, "value":  {"Q": "query"}, "timestamp": 0},
+        {"topic":  "OUTPUT", "key":  2, "value":  {"Q": "q1&q2"}, "timestamp": 1},
+        {"topic":  "OUTPUT", "key":  3, "value":  {"Q": "q=2"}, "timestamp": 2},
+        {"topic":  "OUTPUT", "key":  4, "value":  {"Q": null}, "timestamp": 3}
+      ]
+    }
+  ]
+}

--- a/ksql-engine/src/test/resources/query-validation-tests/url.json
+++ b/ksql-engine/src/test/resources/query-validation-tests/url.json
@@ -87,6 +87,20 @@
       ]
     },
     {
+      "name": "chain a call to URL_EXTRACT_PARAMETER with URL_DECODE_PARAM",
+      "format": ["JSON"],
+      "statements": [
+        "CREATE STREAM TEST (url VARCHAR) WITH (kafka_topic='test_topic', value_format='JSON');",
+        "CREATE STREAM OUTPUT AS SELECT URL_DECODE_PARAM(URL_EXTRACT_PARAMETER(url,'two')) as PARAM FROM TEST;"
+      ],
+      "inputs": [
+        {"topic":  "test_topic", "key":  1, "value": {"url": "http://www.test.com/?one=a&two=url%20encoded"}, "timestamp":  0}
+      ],
+      "outputs": [
+        {"topic":  "OUTPUT", "key":  1, "value":  {"PARAM":  "url encoded"}, "timestamp": 0}
+      ]
+    },
+    {
       "name": "extract a path from a URL using URL_EXTRACT_PATH",
       "format": ["JSON"],
       "statements": [

--- a/ksql-udf/src/main/java/io/confluent/ksql/function/udf/UdfDescription.java
+++ b/ksql-udf/src/main/java/io/confluent/ksql/function/udf/UdfDescription.java
@@ -59,7 +59,7 @@ public @interface UdfDescription {
    *
    * @return function author.
    */
-  String author();
+  String author() default "";
 
   /**
    * The version of the function.

--- a/ksql-udf/src/main/java/io/confluent/ksql/function/udf/UdfDescription.java
+++ b/ksql-udf/src/main/java/io/confluent/ksql/function/udf/UdfDescription.java
@@ -59,7 +59,7 @@ public @interface UdfDescription {
    *
    * @return function author.
    */
-  String author() default "";
+  String author() default "built in";
 
   /**
    * The version of the function.

--- a/ksql-udf/src/main/java/io/confluent/ksql/function/udf/UdfDescription.java
+++ b/ksql-udf/src/main/java/io/confluent/ksql/function/udf/UdfDescription.java
@@ -59,7 +59,7 @@ public @interface UdfDescription {
    *
    * @return function author.
    */
-  String author() default "built in";
+  String author();
 
   /**
    * The version of the function.


### PR DESCRIPTION
### Description 

Adds a new suite of URL processing functionalities to KSQL. These functionalities primarily target use cases involving clickstream data, but any data munging involving URIs can be benefitted from first-class support of these methods.

This was previously #1492 but was restructured to (1) target 5.1.x and (2) change usage of `KUdf` to `@UdfDescription`.

### Testing done 

- Unit tests for each new UDF
- Added url.json to the QueryTranslationTest
- Checkstyle tests
- Ran full integration-test

### Reviewer checklist
- [ ] Ensure docs are updated if necessary. (eg. if a user visible feature is being added or changed).
- [ ] Ensure relevant issues are linked (description should include text like "Fixes #<issue number>")

