### PR TITLE
Add UDF split() that splits a message by a given delimiter.

### DIFF
--- a/docs/developer-guide/syntax-reference.rst
+++ b/docs/developer-guide/syntax-reference.rst
@@ -1263,6 +1263,18 @@ Scalar functions
 +------------------------+---------------------------------------------------------------------------+---------------------------------------------------+
 | ROUND                  |  ``ROUND(col1)``                                                          | Round a value to the nearest BIGINT value.        |
 +------------------------+---------------------------------------------------------------------------+---------------------------------------------------+
+| SPLIT                  |  ``SPLIT(col1, delimiter)``                                               | Splits a string into an array of substrings based |
+|                        |                                                                           | on a delimiter. If the delimiter is not found,    |
+|                        |                                                                           | then the original string is returned as the only  |
+|                        |                                                                           | element in the array. If the delimiter is empty,  |
+|                        |                                                                           | then all characters in the string are split.      |
+|                        |                                                                           | If either, string or delimiter, are NULL, then a  |
+|                        |                                                                           | NULL value is returned.                           |
+|                        |                                                                           |                                                   |
+|                        |                                                                           | If the delimiter is found at the beginning or end |
+|                        |                                                                           | of the string, or there are contiguous delimiters,|
+|                        |                                                                           | then an empty space is added to the array.        |
++------------------------+---------------------------------------------------------------------------+---------------------------------------------------+
 | STRINGTODATE           |  ``STRINGTODATE(col1, 'yyyy-MM-dd')``                                     | Converts a string representation of a date in the |
 |                        |                                                                           | given format into an integer representing days    |
 |                        |                                                                           | since epoch. Single quotes in the timestamp       |

--- a/ksql-engine/src/main/java/io/confluent/ksql/function/udf/string/SplitKudf.java
+++ b/ksql-engine/src/main/java/io/confluent/ksql/function/udf/string/SplitKudf.java
@@ -21,13 +21,19 @@ import io.confluent.ksql.function.udf.UdfDescription;
 import io.confluent.ksql.function.udf.UdfParameter;
 import java.util.Arrays;
 import java.util.List;
+import java.util.regex.Pattern;
 
 @UdfDescription(name = SplitKudf.NAME, author = "Confluent",
-    description = "Splits a string into an array of substrings based on a delimiter.")
+    description = "Splits a string into an array of substrings based on a delimiter. "
+        + "If the delimiter is found at the beginning of the string, end of the string, or there "
+        + "are contiguous delimiters in the string, then empty strings are added to the array. "
+        + "If the delimiter is not found, then the original string is returned as the only "
+        + "element in the array. If the delimiter is empty, then all characters in the string are "
+        + "split.")
 public class SplitKudf {
-  protected static final String NAME = "split";
+  static final String NAME = "split";
 
-  private static final String EMPTY_DELIMITER = "";
+  private static final Pattern EMPTY_DELIMITER = Pattern.compile("");
 
   @Udf(description = "Splits a string into an array of substrings based on a delimiter.")
   public List<String> split(
@@ -49,12 +55,13 @@ public class SplitKudf {
     try {
       // Guava Splitter does not accept empty delimiters. Use the Java split() method instead.
       if (delimiter.isEmpty()) {
-        return Arrays.asList(string.split(EMPTY_DELIMITER));
+        return Arrays.asList(EMPTY_DELIMITER.split(string));
       } else {
         return Splitter.on(delimiter).splitToList(string);
       }
     } catch (Exception e) {
-      throw new KsqlFunctionException("Invalid delimiter used in the split() function.", e);
+      throw new KsqlFunctionException(
+          String.format("Invalid delimiter '%s' in the split() function.", delimiter), e);
     }
   }
 }

--- a/ksql-engine/src/main/java/io/confluent/ksql/function/udf/string/SplitKudf.java
+++ b/ksql-engine/src/main/java/io/confluent/ksql/function/udf/string/SplitKudf.java
@@ -1,0 +1,60 @@
+/*
+ * Copyright 2018 Confluent Inc.
+ *
+ * Licensed under the Confluent Community License; you may not use this file
+ * except in compliance with the License.  You may obtain a copy of the License at
+ *
+ * http://www.confluent.io/confluent-community-license
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package io.confluent.ksql.function.udf.string;
+
+import com.google.common.base.Splitter;
+import io.confluent.ksql.function.KsqlFunctionException;
+import io.confluent.ksql.function.udf.Udf;
+import io.confluent.ksql.function.udf.UdfDescription;
+import io.confluent.ksql.function.udf.UdfParameter;
+import java.util.Arrays;
+import java.util.List;
+
+@UdfDescription(name = SplitKudf.NAME, author = "Confluent",
+    description = "Splits a string into an array of substrings based on a delimiter.")
+public class SplitKudf {
+  protected static final String NAME = "split";
+
+  private static final String EMPTY_DELIMITER = "";
+
+  @Udf(description = "Splits a string into an array of substrings based on a delimiter.")
+  public List<String> split(
+      @UdfParameter(value = "string",
+          description = "The string to be split. If NULL, then function returns NULL.")
+      final String string,
+      @UdfParameter(value = "delimiter",
+          description = "The delimiter to split a string by. If NULL, then function returns NULL.")
+      final String delimiter) {
+    if (string == null || delimiter == null) {
+      return null;
+    }
+
+    // Java split() accepts regular expressions as a delimiter, but the behavior of this UDF split()
+    // is to accept only literal strings. This method uses Guava Splitter instead, which does not
+    // accept any regex pattern. This is to avoid a confusion to users when splitting by regex
+    // special characters, such as '.' and '|'.
+
+    try {
+      // Guava Splitter does not accept empty delimiters. Use the Java split() method instead.
+      if (delimiter.isEmpty()) {
+        return Arrays.asList(string.split(EMPTY_DELIMITER));
+      } else {
+        return Splitter.on(delimiter).splitToList(string);
+      }
+    } catch (Exception e) {
+      throw new KsqlFunctionException("Invalid delimiter used in the split() function.", e);
+    }
+  }
+}

--- a/ksql-engine/src/test/java/io/confluent/ksql/function/udf/string/SplitKudfTest.java
+++ b/ksql-engine/src/test/java/io/confluent/ksql/function/udf/string/SplitKudfTest.java
@@ -37,21 +37,34 @@ public class SplitKudfTest {
   }
 
   @Test
-  public void shouldSplitStringByGivenAnEmptyDelimiter() {
+  public void shouldSplitAllCharactersByGivenAnEmptyDelimiter() {
     assertThat(splitUdf.split("", ""), contains(""));
     assertThat(splitUdf.split("x-y", ""), contains("x", "-", "y"));
   }
 
   @Test
-  public void shouldSplitStringByGivenAStringDelimiter() {
+  public void shouldSplitStringByGivenDelimiter() {
     assertThat(splitUdf.split("x-y", "-"), contains("x", "y"));
     assertThat(splitUdf.split("x-y", "x"), contains("", "-y"));
     assertThat(splitUdf.split("x-y", "y"), contains("x-", ""));
     assertThat(splitUdf.split("a.b.c.d", "."), contains("a", "b", "c", "d"));
 
-    // Add empty spaces if the delimiter is at the beginning, end, or they are contiguous
+  }
+
+  @Test
+  public void shouldSplitAndAddEmptySpacesIfDelimiterIsFoundAtTheBeginningOrEnd() {
     assertThat(splitUdf.split("$A", "$"), contains("", "A"));
+    assertThat(splitUdf.split("$A$B", "$"), contains("", "A", "B"));
     assertThat(splitUdf.split("A$", "$"), contains("A", ""));
+    assertThat(splitUdf.split("A$B$", "$"), contains("A", "B", ""));
+    assertThat(splitUdf.split("$A$B$", "$"), contains("", "A", "B", ""));
+  }
+
+  @Test
+  public void shouldSplitAndAddEmptySpacesIfDelimiterIsFoundInContiguousPositions() {
     assertThat(splitUdf.split("A||A", "|"), contains("A", "", "A"));
+    assertThat(splitUdf.split("z||A||z", "|"), contains("z", "", "A", "", "z"));
+    assertThat(splitUdf.split("||A||A", "|"), contains("", "", "A", "", "A"));
+    assertThat(splitUdf.split("A||A||", "|"), contains("A", "", "A", "", ""));
   }
 }

--- a/ksql-engine/src/test/java/io/confluent/ksql/function/udf/string/SplitKudfTest.java
+++ b/ksql-engine/src/test/java/io/confluent/ksql/function/udf/string/SplitKudfTest.java
@@ -1,0 +1,57 @@
+/*
+ * Copyright 2018 Confluent Inc.
+ *
+ * Licensed under the Confluent Community License; you may not use this file
+ * except in compliance with the License.  You may obtain a copy of the License at
+ *
+ * http://www.confluent.io/confluent-community-license
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+package io.confluent.ksql.function.udf.string;
+
+import static org.hamcrest.Matchers.contains;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.nullValue;
+import static org.junit.Assert.assertThat;
+
+import org.junit.Test;
+
+public class SplitKudfTest {
+  private final static SplitKudf splitUdf = new SplitKudf();
+
+  @Test
+  public void shouldReturnNullOnAnyNullParameters() {
+    assertThat(splitUdf.split(null, ""), is(nullValue()));
+    assertThat(splitUdf.split("", null), is(nullValue()));
+    assertThat(splitUdf.split(null, null), is(nullValue()));
+  }
+
+  @Test
+  public void shouldReturnOriginalStringOnNotFoundDelimiter() {
+    assertThat(splitUdf.split("", "."), contains(""));
+    assertThat(splitUdf.split("x-y", "."), contains("x-y"));
+  }
+
+  @Test
+  public void shouldSplitStringByGivenAnEmptyDelimiter() {
+    assertThat(splitUdf.split("", ""), contains(""));
+    assertThat(splitUdf.split("x-y", ""), contains("x", "-", "y"));
+  }
+
+  @Test
+  public void shouldSplitStringByGivenAStringDelimiter() {
+    assertThat(splitUdf.split("x-y", "-"), contains("x", "y"));
+    assertThat(splitUdf.split("x-y", "x"), contains("", "-y"));
+    assertThat(splitUdf.split("x-y", "y"), contains("x-", ""));
+    assertThat(splitUdf.split("a.b.c.d", "."), contains("a", "b", "c", "d"));
+
+    // Add empty spaces if the delimiter is at the beginning, end, or they are contiguous
+    assertThat(splitUdf.split("$A", "$"), contains("", "A"));
+    assertThat(splitUdf.split("A$", "$"), contains("A", ""));
+    assertThat(splitUdf.split("A||A", "|"), contains("A", "", "A"));
+  }
+}

--- a/ksql-engine/src/test/resources/query-validation-tests/split.json
+++ b/ksql-engine/src/test/resources/query-validation-tests/split.json
@@ -1,0 +1,89 @@
+{
+  "comments": [
+    "Tests covering the use of the SPLIT function."
+  ],
+  "tests": [
+    {
+      "name": "split a message by using the '.' delimiter",
+      "statements": [
+        "CREATE STREAM TEST (message VARCHAR) WITH (kafka_topic='test_topic', value_format='JSON');",
+        "CREATE STREAM OUTPUT AS SELECT SPLIT(message, '.') as split_msg FROM TEST;"
+      ],
+      "inputs": [
+        {"topic": "test_topic", "key": 1, "value": {"message": "a.b.c"}, "timestamp": 0},
+        {"topic": "test_topic", "key": 2, "value": {"message": ".abc."}, "timestamp": 0},
+        {"topic": "test_topic", "key": 3, "value": {"message": "..a.."}, "timestamp": 0},
+        {"topic": "test_topic", "key": 4, "value": {"message": "abc"}, "timestamp": 0},
+        {"topic": "test_topic", "key": 5, "value": {"message": ""}, "timestamp": 0}
+      ],
+      "outputs": [
+        {"topic": "OUTPUT", "key": 1, "value": {"SPLIT_MSG":["a", "b", "c"]}, "timestamp": 0},
+        {"topic": "OUTPUT", "key": 2, "value": {"SPLIT_MSG":["", "abc", ""]}, "timestamp": 0},
+        {"topic": "OUTPUT", "key": 3, "value": {"SPLIT_MSG":["", "", "a", "", ""]}, "timestamp": 0},
+        {"topic": "OUTPUT", "key": 4, "value": {"SPLIT_MSG":["abc"]}, "timestamp": 0},
+        {"topic": "OUTPUT", "key": 5, "value": {"SPLIT_MSG":[""]}, "timestamp": 0}
+      ]
+    },
+    {
+      "name": "split a message by using the '$$' delimiter",
+      "statements": [
+        "CREATE STREAM TEST (message VARCHAR) WITH (kafka_topic='test_topic', value_format='JSON');",
+        "CREATE STREAM OUTPUT AS SELECT SPLIT(message, '$$') as split_msg FROM TEST;"
+      ],
+      "inputs": [
+        {"topic": "test_topic", "key": 1, "value": {"message": "a$$b.c"}, "timestamp": 0},
+        {"topic": "test_topic", "key": 2, "value": {"message": ".abc$$"}, "timestamp": 0},
+        {"topic": "test_topic", "key": 3, "value": {"message": ".$$a.."}, "timestamp": 0},
+        {"topic": "test_topic", "key": 4, "value": {"message": "abc"}, "timestamp": 0},
+        {"topic": "test_topic", "key": 5, "value": {"message": ""}, "timestamp": 0}
+      ],
+      "outputs": [
+        {"topic": "OUTPUT", "key": 1, "value": {"SPLIT_MSG":["a", "b.c"]}, "timestamp": 0},
+        {"topic": "OUTPUT", "key": 2, "value": {"SPLIT_MSG":[".abc", ""]}, "timestamp": 0},
+        {"topic": "OUTPUT", "key": 3, "value": {"SPLIT_MSG":[".", "a.."]}, "timestamp": 0},
+        {"topic": "OUTPUT", "key": 4, "value": {"SPLIT_MSG":["abc"]}, "timestamp": 0},
+        {"topic": "OUTPUT", "key": 5, "value": {"SPLIT_MSG":[""]}, "timestamp": 0}
+      ]
+    },
+    {
+      "name": "split all characters by using the '' delimiter",
+      "statements": [
+        "CREATE STREAM TEST (message VARCHAR) WITH (kafka_topic='test_topic', value_format='JSON');",
+        "CREATE STREAM OUTPUT AS SELECT SPLIT(message, '') as split_msg FROM TEST;"
+      ],
+      "inputs": [
+        {"topic": "test_topic", "key": 1, "value": {"message": "a.b.c"}, "timestamp": 0},
+        {"topic": "test_topic", "key": 2, "value": {"message": ".abc."}, "timestamp": 0},
+        {"topic": "test_topic", "key": 3, "value": {"message": "..a.."}, "timestamp": 0},
+        {"topic": "test_topic", "key": 4, "value": {"message": "abc"}, "timestamp": 0},
+        {"topic": "test_topic", "key": 5, "value": {"message": ""}, "timestamp": 0}
+      ],
+      "outputs": [
+        {"topic": "OUTPUT", "key": 1, "value": {"SPLIT_MSG":["a", "." ,"b", ".", "c"]}, "timestamp": 0},
+        {"topic": "OUTPUT", "key": 2, "value": {"SPLIT_MSG":[".", "a", "b", "c", "."]}, "timestamp": 0},
+        {"topic": "OUTPUT", "key": 3, "value": {"SPLIT_MSG":[".", ".", "a", ".", "."]}, "timestamp": 0},
+        {"topic": "OUTPUT", "key": 4, "value": {"SPLIT_MSG":["a", "b", "c"]}, "timestamp": 0},
+        {"topic": "OUTPUT", "key": 5, "value": {"SPLIT_MSG":[""]}, "timestamp": 0}
+      ]
+    },
+    {
+      "name": "split a message by commas and display pos 0 and 2 of the returned array",
+      "statements": [
+        "CREATE STREAM TEST (message VARCHAR) WITH (kafka_topic='test_topic', value_format='JSON');",
+        "CREATE STREAM OUTPUT AS SELECT SPLIT(message, ',')[0] as s1, SPLIT(message, ',')[2] as s2 FROM TEST;"
+      ],
+      "inputs": [
+        {"topic": "test_topic", "key": 1, "value": {"message": "a,b,c"}, "timestamp": 0},
+        {"topic": "test_topic", "key": 2, "value": {"message": ",A,"}, "timestamp": 0},
+        {"topic": "test_topic", "key": 3, "value": {"message": "A,,A"}, "timestamp": 0},
+        {"topic": "test_topic", "key": 4, "value": {"message": "1,2,3,4,5"}, "timestamp": 0}
+      ],
+      "outputs": [
+        {"topic": "OUTPUT", "key": 1, "value": {"S1": "a", "S2": "c"}, "timestamp": 0},
+        {"topic": "OUTPUT", "key": 2, "value": {"S1": "", "S2": ""}, "timestamp": 0},
+        {"topic": "OUTPUT", "key": 3, "value": {"S1": "A", "S2": "A"}, "timestamp": 0},
+        {"topic": "OUTPUT", "key": 4, "value": {"S1": "1", "S2": "3"}, "timestamp": 0}
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
This fixes https://github.com/confluentinc/ksql/issues/2349

### Description 
A new UDF function SPLIT(string, delimiter) is added that splits a string into an array of substrings using the given delimiter. The below behavior is similar (if not identical) to other RDBMS that handle the split() function.

Example:
Having a record with col1 using the string 'x-y-z', the following spit() method creates the array [x, y, z]:
`SELECT split(message, '-')[0] as s1 , split(message, '-')[2] as s2 FROM stream;`

|s1| s2|
|---|---|
|x|z|
 
The UDF split() only accepts literals as delimiter. Regular expressions use a different API implementation, so we could leave such behavior in a future REGEX_SPLIT() or something.

If the delimiter is found at the beginning of the string, end of the string, or there are contiguous delimiters in the string, then empty strings are added to the array.

Example:
Having a record with col1 using the string '-x-', the following spit() method creates the array [, x, ]:
`SELECT split(message, '-')[0] as s1 , split(message, '-')[1] as s2 FROM stream;`

|s1| s2|
|---|---|
||x|

Example
Having a record with col1 using the string '--x', the following spit() method creates the array [, , x]:
`SELECT split(message, '-')[0] as s1 , split(message, '-')[1] as s2 FROM stream;`

|s1| s2|
|---|---|
|||

More examples can be found on `query-validations-tests/split.json`

### Testing done 
Unit tests in `SplitKudfTest` are added.
Integration tests in `query-validations-tests/split.json` are added.

### Reviewer checklist
- [ ] Ensure docs are updated if necessary. (eg. if a user visible feature is being added or changed).
- [ ] Ensure relevant issues are linked (description should include text like "Fixes #<issue number>")

