### PR TITLE
Add a QueryTranslationTest command parameter to specify tests to execute

### DIFF
--- a/ksql-engine/src/test/java/io/confluent/ksql/EndToEndEngineTestUtil.java
+++ b/ksql-engine/src/test/java/io/confluent/ksql/EndToEndEngineTestUtil.java
@@ -99,9 +99,9 @@ final class EndToEndEngineTestUtil {
 
   // Pass a single test or multiple tests separated by commas to the test framework.
   // Example:
-  //     mvn test -pl ksql-engine -Dtest=QueryTranslationTest -DtestFile=test1.json
-  //     mvn test -pl ksql-engine -Dtest=QueryTranslationTest -DtestFile=test1.json,test2,json
-  private static final String PARAM_TEST_FILE = "testFile";
+  //     mvn test -pl ksql-engine -Dtest=QueryTranslationTest -Dksql.test.files=test1.json
+  //     mvn test -pl ksql-engine -Dtest=QueryTranslationTest -Dksql.test.files=test1.json,test2,json
+  private static final String KSQL_TEST_FILES = "ksql.test.files";
 
   static {
     // don't use the actual metastore, aim is just to get the functions into the registry.
@@ -796,11 +796,11 @@ final class EndToEndEngineTestUtil {
   }
 
   /**
-   * Returns a list of files specified in the system property 'testFile'. The list may be specified
-   * as a comma-separated string.
+   * Returns a list of files specified in the system property 'ksql.test.file'.
+   * The list may be specified as a comma-separated string.
    */
-  public static List<String> getTestFileList() {
-    String propValue = System.getProperty(PARAM_TEST_FILE);
+  public static List<String> getTestFilesParam() {
+    String propValue = System.getProperty(KSQL_TEST_FILES);
     if (propValue == null || propValue.trim().isEmpty()) {
       return null;
     }
@@ -813,8 +813,8 @@ final class EndToEndEngineTestUtil {
 
     List<Path> testPaths;
 
-    // Use the list of files separated by comma passed to this method, or find
-    // all the tests in the specified directory
+    // Use the list of files passed to this method, or find all the tests in the
+    // specified directory
     if (files != null && !files.isEmpty()) {
       testPaths = getTests(dir, files);
     } else {

--- a/ksql-engine/src/test/java/io/confluent/ksql/EndToEndEngineTestUtil.java
+++ b/ksql-engine/src/test/java/io/confluent/ksql/EndToEndEngineTestUtil.java
@@ -54,6 +54,7 @@ import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.nio.file.StandardOpenOption;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Collection;
 import java.util.HashMap;
 import java.util.List;
@@ -100,7 +101,7 @@ final class EndToEndEngineTestUtil {
   // Example:
   //     mvn test -pl ksql-engine -Dtest=QueryTranslationTest -DtestFile=test1.json
   //     mvn test -pl ksql-engine -Dtest=QueryTranslationTest -DtestFile=test1.json,test2,json
-  public static final String PARAM_TEST_FILE = "testFile";
+  private static final String PARAM_TEST_FILE = "testFile";
 
   static {
     // don't use the actual metastore, aim is just to get the functions into the registry.
@@ -785,33 +786,37 @@ final class EndToEndEngineTestUtil {
     }
   }
 
-  private static List<Path> getTestFiles(final Path dir, final String files) {
+  private static List<Path> getTests(final Path dir, final List<String> files) {
     List<Path> filePaths = new ArrayList<>();
-    for (String jsonFile : files.split(",")) {
-      filePaths.add(dir.resolve(jsonFile.trim()));
+    for (String file : files) {
+      filePaths.add(dir.resolve(file.trim()));
     }
 
     return filePaths;
   }
 
-  public static String getTestProperty(final String propName) {
-    String propValue = System.getProperty(propName);
+  /**
+   * Returns a list of files specified in the system property 'testFile'. The list may be specified
+   * as a comma-separated string.
+   */
+  public static List<String> getTestFileList() {
+    String propValue = System.getProperty(PARAM_TEST_FILE);
     if (propValue == null || propValue.trim().isEmpty()) {
       return null;
     }
 
-    return propValue.trim();
+    return Arrays.asList(propValue.trim().split(","));
   }
 
-  static Stream<JsonTestCase> findTestCases(final Path dir, final String files) {
+  static Stream<JsonTestCase> findTestCases(final Path dir, final List<String> files) {
     final ClassLoader classLoader = EndToEndEngineTestUtil.class.getClassLoader();
 
     List<Path> testPaths;
 
     // Use the list of files separated by comma passed to this method, or find
     // all the tests in the specified directory
-    if (files != null && !files.trim().isEmpty()) {
-      testPaths = getTestFiles(dir, files);
+    if (files != null && !files.isEmpty()) {
+      testPaths = getTests(dir, files);
     } else {
       testPaths = findTests(dir);
     }

--- a/ksql-engine/src/test/java/io/confluent/ksql/QueryTranslationTest.java
+++ b/ksql-engine/src/test/java/io/confluent/ksql/QueryTranslationTest.java
@@ -15,6 +15,7 @@
 package io.confluent.ksql;
 
 import static io.confluent.ksql.EndToEndEngineTestUtil.ExpectedException;
+import static io.confluent.ksql.EndToEndEngineTestUtil.PARAM_TEST_FILE;
 import static io.confluent.ksql.EndToEndEngineTestUtil.Record;
 import static io.confluent.ksql.EndToEndEngineTestUtil.SerdeSupplier;
 import static io.confluent.ksql.EndToEndEngineTestUtil.StringSerdeSupplier;
@@ -99,10 +100,21 @@ import org.junit.runners.Parameterized;
  *        ii. Then run "mvn test -Dtopology.version=X -Dtest=QueryTranslationTest -pl ksql-engine"
  *            (without the quotes).  Again X is the version you want to run the tests against.
  *
+ *
  *   Note that for both options above the version must exist
  *   under the src/test/resources/expected_topology directory.
  *
  *  For instructions on how to generate new topologies, see TopologyFileGenerator.java.
+ *
+ *  This test also accepts a parameter to execute a list of given test files. To run the test, use
+ *  the following example:
+ *
+ *     mvn test -pl ksql-engine -Dtest=QueryTranslationTest -DtestFile=sum.json
+ *     or
+ *     mvn test -pl ksql-engine -Dtest=QueryTranslationTest -DtestFile=sum.json,substring.json
+ *
+ *  The above commands can execute only a single test (sum.json) or multiple tests
+ *  (sum.json and substring.json).
  */
 
 @RunWith(Parameterized.class)
@@ -148,7 +160,9 @@ public class QueryTranslationTest {
   }
 
   static Stream<TestCase> buildTestCases() {
-    return EndToEndEngineTestUtil.findTestCases(QUERY_VALIDATION_TEST_DIR)
+    String testFiles = EndToEndEngineTestUtil.getTestProperty(PARAM_TEST_FILE);
+
+    return EndToEndEngineTestUtil.findTestCases(QUERY_VALIDATION_TEST_DIR, testFiles)
         .flatMap(test -> {
           final JsonNode formatsNode = test.getNode().get("format");
           if (formatsNode == null) {

--- a/ksql-engine/src/test/java/io/confluent/ksql/QueryTranslationTest.java
+++ b/ksql-engine/src/test/java/io/confluent/ksql/QueryTranslationTest.java
@@ -15,7 +15,6 @@
 package io.confluent.ksql;
 
 import static io.confluent.ksql.EndToEndEngineTestUtil.ExpectedException;
-import static io.confluent.ksql.EndToEndEngineTestUtil.PARAM_TEST_FILE;
 import static io.confluent.ksql.EndToEndEngineTestUtil.Record;
 import static io.confluent.ksql.EndToEndEngineTestUtil.SerdeSupplier;
 import static io.confluent.ksql.EndToEndEngineTestUtil.StringSerdeSupplier;
@@ -160,7 +159,7 @@ public class QueryTranslationTest {
   }
 
   static Stream<TestCase> buildTestCases() {
-    String testFiles = EndToEndEngineTestUtil.getTestProperty(PARAM_TEST_FILE);
+    List<String> testFiles = EndToEndEngineTestUtil.getTestFileList();
 
     return EndToEndEngineTestUtil.findTestCases(QUERY_VALIDATION_TEST_DIR, testFiles)
         .flatMap(test -> {

--- a/ksql-engine/src/test/java/io/confluent/ksql/QueryTranslationTest.java
+++ b/ksql-engine/src/test/java/io/confluent/ksql/QueryTranslationTest.java
@@ -159,7 +159,7 @@ public class QueryTranslationTest {
   }
 
   static Stream<TestCase> buildTestCases() {
-    List<String> testFiles = EndToEndEngineTestUtil.getTestFileList();
+    List<String> testFiles = EndToEndEngineTestUtil.getTestFilesParam();
 
     return EndToEndEngineTestUtil.findTestCases(QUERY_VALIDATION_TEST_DIR, testFiles)
         .flatMap(test -> {

--- a/ksql-engine/src/test/java/io/confluent/ksql/QueryTranslationTest.java
+++ b/ksql-engine/src/test/java/io/confluent/ksql/QueryTranslationTest.java
@@ -159,7 +159,7 @@ public class QueryTranslationTest {
   }
 
   static Stream<TestCase> buildTestCases() {
-    List<String> testFiles = EndToEndEngineTestUtil.getTestFilesParam();
+    final List<String> testFiles = EndToEndEngineTestUtil.getTestFilesParam();
 
     return EndToEndEngineTestUtil.findTestCases(QUERY_VALIDATION_TEST_DIR, testFiles)
         .flatMap(test -> {

--- a/ksql-engine/src/test/java/io/confluent/ksql/SchemaTranslationTest.java
+++ b/ksql-engine/src/test/java/io/confluent/ksql/SchemaTranslationTest.java
@@ -15,7 +15,6 @@
 package io.confluent.ksql;
 
 import static io.confluent.ksql.EndToEndEngineTestUtil.AvroSerdeSupplier;
-import static io.confluent.ksql.EndToEndEngineTestUtil.PARAM_TEST_FILE;
 import static io.confluent.ksql.EndToEndEngineTestUtil.TestCase;
 import static io.confluent.ksql.EndToEndEngineTestUtil.Record;
 import static io.confluent.ksql.EndToEndEngineTestUtil.Topic;
@@ -69,7 +68,7 @@ public class SchemaTranslationTest {
 
   @Parameterized.Parameters(name = "{0}")
   public static Collection<Object[]> data() {
-    String testFiles = EndToEndEngineTestUtil.getTestProperty(PARAM_TEST_FILE);
+    List<String> testFiles = EndToEndEngineTestUtil.getTestFileList();
 
     return findTestCases(SCHEMA_VALIDATION_TEST_DIR, testFiles)
         .map(SchemaTranslationTest::loadTest)

--- a/ksql-engine/src/test/java/io/confluent/ksql/SchemaTranslationTest.java
+++ b/ksql-engine/src/test/java/io/confluent/ksql/SchemaTranslationTest.java
@@ -68,7 +68,7 @@ public class SchemaTranslationTest {
 
   @Parameterized.Parameters(name = "{0}")
   public static Collection<Object[]> data() {
-    List<String> testFiles = EndToEndEngineTestUtil.getTestFilesParam();
+    final List<String> testFiles = EndToEndEngineTestUtil.getTestFilesParam();
 
     return findTestCases(SCHEMA_VALIDATION_TEST_DIR, testFiles)
         .map(SchemaTranslationTest::loadTest)

--- a/ksql-engine/src/test/java/io/confluent/ksql/SchemaTranslationTest.java
+++ b/ksql-engine/src/test/java/io/confluent/ksql/SchemaTranslationTest.java
@@ -15,6 +15,7 @@
 package io.confluent.ksql;
 
 import static io.confluent.ksql.EndToEndEngineTestUtil.AvroSerdeSupplier;
+import static io.confluent.ksql.EndToEndEngineTestUtil.PARAM_TEST_FILE;
 import static io.confluent.ksql.EndToEndEngineTestUtil.TestCase;
 import static io.confluent.ksql.EndToEndEngineTestUtil.Record;
 import static io.confluent.ksql.EndToEndEngineTestUtil.Topic;
@@ -68,7 +69,9 @@ public class SchemaTranslationTest {
 
   @Parameterized.Parameters(name = "{0}")
   public static Collection<Object[]> data() {
-    return findTestCases(SCHEMA_VALIDATION_TEST_DIR)
+    String testFiles = EndToEndEngineTestUtil.getTestProperty(PARAM_TEST_FILE);
+
+    return findTestCases(SCHEMA_VALIDATION_TEST_DIR, testFiles)
         .map(SchemaTranslationTest::loadTest)
         .map(q -> new Object[]{q.getName(), q})
         .collect(Collectors.toList());

--- a/ksql-engine/src/test/java/io/confluent/ksql/SchemaTranslationTest.java
+++ b/ksql-engine/src/test/java/io/confluent/ksql/SchemaTranslationTest.java
@@ -68,7 +68,7 @@ public class SchemaTranslationTest {
 
   @Parameterized.Parameters(name = "{0}")
   public static Collection<Object[]> data() {
-    List<String> testFiles = EndToEndEngineTestUtil.getTestFileList();
+    List<String> testFiles = EndToEndEngineTestUtil.getTestFilesParam();
 
     return findTestCases(SCHEMA_VALIDATION_TEST_DIR, testFiles)
         .map(SchemaTranslationTest::loadTest)


### PR DESCRIPTION
### Description 
The new parameter accepts a list of comma separated JSON test files to execute. This parameter allows developers to specify their own tests to execute and make debugging faster.

Example:
Execute a single test called 'sum.json'
`mvn test -pl ksql-engine -Dtest=QueryTranslationTest -Dksql.test.files=sum.json`

Execute multiple tests called 'sum.json' and 'substring.json'
`mvn test -pl ksql-engine -Dtest=QueryTranslationTest -Dksql.test.files=sum.json,substring.json`

Execute all tests:
`mvn test -pl ksql-engine -Dtest=QueryTranslationTest`

The same parameter works for `SchemaTranslationTest`.
### Testing done 
The same QueryTranslationTest and SchemaTranslationTest validate that all tests are executed.
I also executed the example commands manually to verify they are working correctly.

### Reviewer checklist
- [ ] Ensure docs are updated if necessary. (eg. if a user visible feature is being added or changed).
- [ ] Ensure relevant issues are linked (description should include text like "Fixes #<issue number>")

