### PR TITLE
Add KSQL support for BETWEEN in predicates #1004.

### DIFF
--- a/docs/developer-guide/syntax-reference.rst
+++ b/docs/developer-guide/syntax-reference.rst
@@ -959,6 +959,27 @@ Example:
       FROM users
       WHERE user_id LIKE 'santa%';
 
+BETWEEN
+~~~~~~~
+
+**Synopsis**
+
+.. code:: sql
+
+    WHERE expression [NOT] BETWEEN start_expression AND end_expression;
+
+The BETWEEN operator is used to indicate that a certain value must lie within
+(inclusive of boundaries) a specified range. Currently KSQL supports numeric
+and string values for comparison.
+
+Example:
+
+.. code:: sql
+
+  SELECT event
+    FROM events
+    WHERE event_id BETWEEN 10 AND 20
+
 SHOW FUNCTIONS
 --------------
 

--- a/docs/developer-guide/syntax-reference.rst
+++ b/docs/developer-guide/syntax-reference.rst
@@ -969,8 +969,8 @@ BETWEEN
     WHERE expression [NOT] BETWEEN start_expression AND end_expression;
 
 The BETWEEN operator is used to indicate that a certain value must lie within
-a specified range, inclusive of boundaries. Currently, KSQL supports numeric
-and string values for comparison.
+a specified range, inclusive of boundaries. Currently, KSQL supports any expression
+that resolves to a numeric or string value for comparison.
 
 Example:
 

--- a/ksql-engine/src/main/java/io/confluent/ksql/codegen/CodeGenRunner.java
+++ b/ksql-engine/src/main/java/io/confluent/ksql/codegen/CodeGenRunner.java
@@ -21,6 +21,7 @@ import io.confluent.ksql.function.UdfFactory;
 import io.confluent.ksql.function.udf.Kudf;
 import io.confluent.ksql.parser.tree.ArithmeticBinaryExpression;
 import io.confluent.ksql.parser.tree.AstVisitor;
+import io.confluent.ksql.parser.tree.BetweenPredicate;
 import io.confluent.ksql.parser.tree.Cast;
 import io.confluent.ksql.parser.tree.ComparisonExpression;
 import io.confluent.ksql.parser.tree.DereferenceExpression;
@@ -228,6 +229,14 @@ public class CodeGenRunner {
         final Object context) {
       process(node.getLeft(), null);
       process(node.getRight(), null);
+      return null;
+    }
+
+    @Override
+    protected Object visitBetweenPredicate(final BetweenPredicate node, final Object context) {
+      process(node.getValue(), null);
+      process(node.getMax(), null);
+      process(node.getMin(), null);
       return null;
     }
 

--- a/ksql-engine/src/main/java/io/confluent/ksql/util/ExpressionTypeManager.java
+++ b/ksql-engine/src/main/java/io/confluent/ksql/util/ExpressionTypeManager.java
@@ -19,6 +19,7 @@ import io.confluent.ksql.function.KsqlAggregateFunction;
 import io.confluent.ksql.function.UdfFactory;
 import io.confluent.ksql.function.udf.structfieldextractor.FetchFieldFromStruct;
 import io.confluent.ksql.parser.tree.ArithmeticBinaryExpression;
+import io.confluent.ksql.parser.tree.BetweenPredicate;
 import io.confluent.ksql.parser.tree.BooleanLiteral;
 import io.confluent.ksql.parser.tree.Cast;
 import io.confluent.ksql.parser.tree.ComparisonExpression;
@@ -112,6 +113,13 @@ public class ExpressionTypeManager
   protected Expression visitComparisonExpression(
       final ComparisonExpression node, final ExpressionTypeContext expressionTypeContext) {
     expressionTypeContext.setSchema(Schema.OPTIONAL_BOOLEAN_SCHEMA);
+    return null;
+  }
+
+  @Override
+  protected Expression visitBetweenPredicate(final BetweenPredicate node,
+      final ExpressionTypeContext context) {
+    context.setSchema(Schema.OPTIONAL_BOOLEAN_SCHEMA);
     return null;
   }
 

--- a/ksql-engine/src/test/java/io/confluent/ksql/codegen/CodeGenRunnerTest.java
+++ b/ksql-engine/src/test/java/io/confluent/ksql/codegen/CodeGenRunnerTest.java
@@ -25,6 +25,7 @@ import static org.hamcrest.Matchers.hasSize;
 import static org.hamcrest.Matchers.instanceOf;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.lessThanOrEqualTo;
+import static org.hamcrest.Matchers.nullValue;
 import static org.junit.internal.matchers.ThrowableMessageMatcher.hasMessage;
 
 import com.google.common.collect.ImmutableList;
@@ -368,6 +369,120 @@ public class CodeGenRunnerTest {
     }
 
     @Test
+    public void testBetweenExprScalar() {
+        // int
+        assertThat(evalBetweenClauseScalar(INT32_INDEX1, 1, 0, 2), is(true));
+        assertThat(evalBetweenClauseScalar(INT32_INDEX1, 0, 0, 2), is(true));
+        assertThat(evalBetweenClauseScalar(INT32_INDEX1, 3, 0, 2), is(false));
+        assertThat(evalBetweenClauseScalar(INT32_INDEX1, null, 0, 2), is(false));
+
+        // long
+        assertThat(evalBetweenClauseScalar(INT64_INDEX1, 12345L, 12344L, 12346L), is(true));
+        assertThat(evalBetweenClauseScalar(INT64_INDEX1, 12344L, 12344L, 12346L), is(true));
+        assertThat(evalBetweenClauseScalar(INT64_INDEX1, 12345L, 0, 2L), is(false));
+        assertThat(evalBetweenClauseScalar(INT64_INDEX1, null, 0, 2L), is(false));
+
+        // double
+        assertThat(evalBetweenClauseScalar(FLOAT64_INDEX1, 1.0d, 0.1d, 1.9d), is(true));
+        assertThat(evalBetweenClauseScalar(FLOAT64_INDEX1, 0.1d, 0.1d, 1.9d), is(true));
+        assertThat(evalBetweenClauseScalar(FLOAT64_INDEX1, 2.0d, 0.1d, 1.9d), is(false));
+        assertThat(evalBetweenClauseScalar(FLOAT64_INDEX1, null, 0.1d, 1.9d), is(false));
+    }
+
+    @Test
+    public void testNotBetweenScalar() {
+        // int
+        assertThat(evalNotBetweenClauseScalar(INT32_INDEX1, 1, 0, 2), is(false));
+        assertThat(evalNotBetweenClauseScalar(INT32_INDEX1, 0, 0, 2), is(false));
+        assertThat(evalNotBetweenClauseScalar(INT32_INDEX1, 3, 0, 2), is(true));
+        assertThat(evalNotBetweenClauseScalar(INT32_INDEX1, null, 0, 2), is(true));
+
+        // long
+        assertThat(evalNotBetweenClauseScalar(INT64_INDEX1, 12345L, 12344L, 12346L), is(false));
+        assertThat(evalNotBetweenClauseScalar(INT64_INDEX1, 12344L, 12344L, 12346L), is(false));
+        assertThat(evalNotBetweenClauseScalar(INT64_INDEX1, 12345L, 0, 2L), is(true));
+        assertThat(evalNotBetweenClauseScalar(INT64_INDEX1, null, 0, 2L), is(true));
+
+        // double
+        assertThat(evalNotBetweenClauseScalar(FLOAT64_INDEX1, 1.0d, 0.1d, 1.9d), is(false));
+        assertThat(evalNotBetweenClauseScalar(FLOAT64_INDEX1, 0.1d, 0.1d, 1.9d), is(false));
+        assertThat(evalNotBetweenClauseScalar(FLOAT64_INDEX1, 2.0d, 0.1d, 1.9d), is(true));
+        assertThat(evalNotBetweenClauseScalar(FLOAT64_INDEX1, null, 0.1d, 1.9d), is(true));
+    }
+
+    @Test
+    public void testBetweenExprString() {
+        // constants
+        assertThat(evalBetweenClauseString(STRING_INDEX1, "b", "'a'", "'c'"), is(true));
+        assertThat(evalBetweenClauseString(STRING_INDEX1, "a", "'a'", "'c'"), is(true));
+        assertThat(evalBetweenClauseString(STRING_INDEX1, "d", "'a'", "'c'"), is(false));
+        assertThat(evalBetweenClauseString(STRING_INDEX1, null, "'a'", "'c'"), is(false));
+
+        // columns
+        assertThat(evalBetweenClauseString(STRING_INDEX1, "S2", "col" + STRING_INDEX2, "'S3'"), is(true));
+        assertThat(evalBetweenClauseString(STRING_INDEX1, "S3", "col" + STRING_INDEX2, "'S3'"), is(true));
+        assertThat(evalBetweenClauseString(STRING_INDEX1, "S4", "col" + STRING_INDEX2, "'S3'"), is(false));
+        assertThat(evalBetweenClauseString(STRING_INDEX1, null, "col" + STRING_INDEX2, "'S3'"), is(false));
+    }
+
+    @Test
+    public void testNotBetweenExprString() {
+        // constants
+        assertThat(evalNotBetweenClauseString(STRING_INDEX1, "b", "'a'", "'c'"), is(false));
+        assertThat(evalNotBetweenClauseString(STRING_INDEX1, "a", "'a'", "'c'"), is(false));
+        assertThat(evalNotBetweenClauseString(STRING_INDEX1, "d", "'a'", "'c'"), is(true));
+        assertThat(evalNotBetweenClauseString(STRING_INDEX1, null, "'a'", "'c'"), is(true));
+
+        // columns
+        assertThat(evalNotBetweenClauseString(STRING_INDEX1, "S2", "col" + STRING_INDEX2, "'S3'"), is(false));
+        assertThat(evalNotBetweenClauseString(STRING_INDEX1, "S3", "col" + STRING_INDEX2, "'S3'"), is(false));
+        assertThat(evalNotBetweenClauseString(STRING_INDEX1, "S4", "col" + STRING_INDEX2, "'S3'"), is(true));
+        assertThat(evalNotBetweenClauseString(STRING_INDEX1, null, "col" + STRING_INDEX2, "'S3'"), is(true));
+    }
+
+    @Test
+    public void testInvalidBetweenArrayValue() {
+        // Given:
+        expectedException.expect(KsqlException.class);
+        expectedException.expectMessage("Code generation failed for Filter: "
+            + "Cannot execute between with ARRAY values. "
+            + "expression:(NOT (CODEGEN_TEST.COL9 BETWEEN 'a' AND 'c'))");
+        expectedException.expectCause(hasMessage(
+            equalTo("Cannot execute between with ARRAY values")));
+
+        // When:
+        evalNotBetweenClauseObject(ARRAY_INDEX1, new Object[]{1, 2}, "'a'", "'c'");
+    }
+
+    @Test
+    public void testInvalidBetweenMapValue() {
+        // Given:
+        expectedException.expect(KsqlException.class);
+        expectedException.expectMessage("Code generation failed for Filter: "
+            + "Cannot execute between with MAP values. "
+            + "expression:(NOT (CODEGEN_TEST.COL11 BETWEEN 'a' AND 'c'))");
+        expectedException.expectCause(hasMessage(
+            equalTo("Cannot execute between with MAP values")));
+
+        // When:
+        evalNotBetweenClauseObject(MAP_INDEX1, ImmutableMap.of(1, 2), "'a'", "'c'");
+    }
+
+    @Test
+    public void testInvalidBetweenBooleanValue() {
+        // Given:
+        expectedException.expect(KsqlException.class);
+        expectedException.expectMessage("Code generation failed for Filter: "
+            + "Cannot execute between with BOOLEAN values. "
+            + "expression:(NOT (CODEGEN_TEST.COL6 BETWEEN 'a' AND 'c'))");
+        expectedException.expectCause(hasMessage(
+            equalTo("Cannot execute between with BOOLEAN values")));
+
+        // When:
+        evalNotBetweenClauseObject(BOOLEAN_INDEX1, true, "'a'", "'c'");
+    }
+
+    @Test
     public void shouldHandleArithmeticExpr() {
         // Given:
         final String query =
@@ -559,6 +674,45 @@ public class CodeGenRunnerTest {
         final List<Object> columns = new ArrayList<>(ONE_ROW);
         columns.set(cola, values[0]);
         columns.set(colb, values[1]);
+
+        final Object result0 = expressionEvaluatorMetadata0.evaluate(genericRow(columns));
+        assertThat(result0, instanceOf(Boolean.class));
+        return (Boolean)result0;
+    }
+
+    private boolean evalBetweenClauseScalar(final int col, final Number val, final Number min, final Number max) {
+        final String simpleQuery = String.format("SELECT * FROM CODEGEN_TEST WHERE col%d BETWEEN %s AND %s;", col, min.toString(), max.toString());
+        return evalBetweenClause(simpleQuery, col, val);
+    }
+
+    private boolean evalNotBetweenClauseScalar(final int col, final Number val, final Number min, final Number max) {
+        final String simpleQuery = String.format("SELECT * FROM CODEGEN_TEST WHERE col%d NOT BETWEEN %s AND %s;", col, min.toString(), max.toString());
+        return evalBetweenClause(simpleQuery, col, val);
+    }
+
+    private boolean evalBetweenClauseString(final int col, final String val, final String min, final String max) {
+        final String simpleQuery = String.format("SELECT * FROM CODEGEN_TEST WHERE col%d BETWEEN %s AND %s;", col, min, max);
+        return evalBetweenClause(simpleQuery, col, val);
+    }
+
+    private boolean evalNotBetweenClauseString(final int col, final String val, final String min, final String max) {
+        final String simpleQuery = String.format("SELECT * FROM CODEGEN_TEST WHERE col%d NOT BETWEEN %s AND %s;", col, min, max);
+        return evalBetweenClause(simpleQuery, col, val);
+    }
+
+    private boolean evalNotBetweenClauseObject(final int col, final Object val, final String min, final String max) {
+        final String simpleQuery = String.format("SELECT * FROM CODEGEN_TEST WHERE col%d NOT BETWEEN %s AND %s;", col, min, max);
+        return evalBetweenClause(simpleQuery, col, val);
+    }
+
+    private boolean evalBetweenClause(final String simpleQuery, final int col, final Object val) {
+        final Analysis analysis = analyzeQuery(simpleQuery, metaStore);
+
+        final ExpressionMetadata expressionEvaluatorMetadata0 = codeGenRunner.buildCodeGenFromParseTree
+            (analysis.getWhereExpression(), "Filter");
+
+        final List<Object> columns = new ArrayList<>(ONE_ROW);
+        columns.set(col, val);
 
         final Object result0 = expressionEvaluatorMetadata0.evaluate(genericRow(columns));
         assertThat(result0, instanceOf(Boolean.class));

--- a/ksql-engine/src/test/java/io/confluent/ksql/codegen/CodeGenRunnerTest.java
+++ b/ksql-engine/src/test/java/io/confluent/ksql/codegen/CodeGenRunnerTest.java
@@ -445,10 +445,10 @@ public class CodeGenRunnerTest {
         // Given:
         expectedException.expect(KsqlException.class);
         expectedException.expectMessage("Code generation failed for Filter: "
-            + "Cannot execute between with ARRAY values. "
+            + "Cannot execute BETWEEN with ARRAY values. "
             + "expression:(NOT (CODEGEN_TEST.COL9 BETWEEN 'a' AND 'c'))");
         expectedException.expectCause(hasMessage(
-            equalTo("Cannot execute between with ARRAY values")));
+            equalTo("Cannot execute BETWEEN with ARRAY values")));
 
         // When:
         evalNotBetweenClauseObject(ARRAY_INDEX1, new Object[]{1, 2}, "'a'", "'c'");
@@ -459,10 +459,10 @@ public class CodeGenRunnerTest {
         // Given:
         expectedException.expect(KsqlException.class);
         expectedException.expectMessage("Code generation failed for Filter: "
-            + "Cannot execute between with MAP values. "
+            + "Cannot execute BETWEEN with MAP values. "
             + "expression:(NOT (CODEGEN_TEST.COL11 BETWEEN 'a' AND 'c'))");
         expectedException.expectCause(hasMessage(
-            equalTo("Cannot execute between with MAP values")));
+            equalTo("Cannot execute BETWEEN with MAP values")));
 
         // When:
         evalNotBetweenClauseObject(MAP_INDEX1, ImmutableMap.of(1, 2), "'a'", "'c'");
@@ -473,10 +473,10 @@ public class CodeGenRunnerTest {
         // Given:
         expectedException.expect(KsqlException.class);
         expectedException.expectMessage("Code generation failed for Filter: "
-            + "Cannot execute between with BOOLEAN values. "
+            + "Cannot execute BETWEEN with BOOLEAN values. "
             + "expression:(NOT (CODEGEN_TEST.COL6 BETWEEN 'a' AND 'c'))");
         expectedException.expectCause(hasMessage(
-            equalTo("Cannot execute between with BOOLEAN values")));
+            equalTo("Cannot execute BETWEEN with BOOLEAN values")));
 
         // When:
         evalNotBetweenClauseObject(BOOLEAN_INDEX1, true, "'a'", "'c'");

--- a/ksql-engine/src/test/resources/query-validation-tests/between.json
+++ b/ksql-engine/src/test/resources/query-validation-tests/between.json
@@ -160,6 +160,47 @@
         {"topic": "OUTPUT", "key": 1, "value": {"THING": 1}, "timestamp": 0},
         {"topic": "OUTPUT", "key": 5, "value": {"THING": 5}, "timestamp": 0}
       ]
+    },
+    {
+      "name": "test BETWEEN with array dereference",
+      "format": ["JSON"],
+      "statements": [
+        "CREATE STREAM TEST (source array<int>) WITH (kafka_topic='test_topic', value_format='JSON');",
+        "CREATE STREAM OUTPUT AS SELECT source[1] AS THING FROM TEST WHERE source[1] BETWEEN 2 AND 4;"
+      ],
+      "inputs": [
+        {"topic": "test_topic", "key": 1, "value": {"source": [10,1]}, "timestamp": 0},
+        {"topic": "test_topic", "key": 2, "value": {"source": [10,2]}, "timestamp": 0},
+        {"topic": "test_topic", "key": 3, "value": {"source": [10,3]}, "timestamp": 0},
+        {"topic": "test_topic", "key": 4, "value": {"source": [10,4]}, "timestamp": 0},
+        {"topic": "test_topic", "key": 5, "value": {"source": [10,5]}, "timestamp": 0}
+      ],
+      "outputs": [
+        {"topic": "OUTPUT", "key": 2, "value": {"THING": 2}, "timestamp": 0},
+        {"topic": "OUTPUT", "key": 3, "value": {"THING": 3}, "timestamp": 0},
+        {"topic": "OUTPUT", "key": 4, "value": {"THING": 4}, "timestamp": 0}
+      ]
+    },
+    {
+      "name": "test BETWEEN with string values",
+      "format": ["JSON"],
+      "statements": [
+        "CREATE STREAM TEST (source string) WITH (kafka_topic='test_topic', value_format='JSON');",
+        "CREATE STREAM OUTPUT AS SELECT source AS THING FROM TEST WHERE source BETWEEN SUBSTRING('zb',2) AND 'c';"
+      ],
+      "inputs": [
+        {"topic": "test_topic", "key": 0, "value": {"source": null}, "timestamp": 0},
+        {"topic": "test_topic", "key": 1, "value": {"source": "a"}, "timestamp": 0},
+        {"topic": "test_topic", "key": 2, "value": {"source": "b"}, "timestamp": 0},
+        {"topic": "test_topic", "key": 3, "value": {"source": "ba"}, "timestamp": 0},
+        {"topic": "test_topic", "key": 4, "value": {"source": "c"}, "timestamp": 0},
+        {"topic": "test_topic", "key": 5, "value": {"source": "ca"}, "timestamp": 0}
+      ],
+      "outputs": [
+        {"topic": "OUTPUT", "key": 2, "value": {"THING": "b"}, "timestamp": 0},
+        {"topic": "OUTPUT", "key": 3, "value": {"THING": "ba"}, "timestamp": 0},
+        {"topic": "OUTPUT", "key": 4, "value": {"THING": "c"}, "timestamp": 0}
+      ]
     }
   ]
 }

--- a/ksql-engine/src/test/resources/query-validation-tests/between.json
+++ b/ksql-engine/src/test/resources/query-validation-tests/between.json
@@ -1,0 +1,165 @@
+{
+  "comments": [
+    "Tests covering the use of the BETWEEN function"
+  ],
+  "tests": [
+    {
+      "name": "test BETWEEN with integers",
+      "format": ["JSON"],
+      "statements": [
+        "CREATE STREAM TEST (source int) WITH (kafka_topic='test_topic', value_format='JSON');",
+        "CREATE STREAM OUTPUT AS SELECT source AS THING FROM TEST WHERE source BETWEEN 2 AND 4;"
+      ],
+      "inputs": [
+        {"topic": "test_topic", "key": 0, "value": {"source": null}, "timestamp": 0},
+        {"topic": "test_topic", "key": 1, "value": {"source": 1}, "timestamp": 0},
+        {"topic": "test_topic", "key": 2, "value": {"source": 2}, "timestamp": 0},
+        {"topic": "test_topic", "key": 3, "value": {"source": 3}, "timestamp": 0},
+        {"topic": "test_topic", "key": 4, "value": {"source": 4}, "timestamp": 0},
+        {"topic": "test_topic", "key": 5, "value": {"source": 5}, "timestamp": 0}
+      ],
+      "outputs": [
+        {"topic": "OUTPUT", "key": 2, "value": {"THING": 2}, "timestamp": 0},
+        {"topic": "OUTPUT", "key": 3, "value": {"THING": 3}, "timestamp": 0},
+        {"topic": "OUTPUT", "key": 4, "value": {"THING": 4}, "timestamp": 0}
+      ]
+    },
+    {
+      "name": "test BETWEEN with bigint",
+      "format": ["JSON"],
+      "statements": [
+        "CREATE STREAM TEST (source bigint) WITH (kafka_topic='test_topic', value_format='JSON');",
+        "CREATE STREAM OUTPUT AS SELECT source AS THING FROM TEST WHERE source BETWEEN 2 AND 4;"
+      ],
+      "inputs": [
+        {"topic": "test_topic", "key": 0, "value": {"source": null}, "timestamp": 0},
+        {"topic": "test_topic", "key": 1, "value": {"source": 1}, "timestamp": 0},
+        {"topic": "test_topic", "key": 2, "value": {"source": 2}, "timestamp": 0},
+        {"topic": "test_topic", "key": 3, "value": {"source": 3}, "timestamp": 0},
+        {"topic": "test_topic", "key": 4, "value": {"source": 4}, "timestamp": 0},
+        {"topic": "test_topic", "key": 5, "value": {"source": 5}, "timestamp": 0}
+      ],
+      "outputs": [
+        {"topic": "OUTPUT", "key": 2, "value": {"THING": 2}, "timestamp": 0},
+        {"topic": "OUTPUT", "key": 3, "value": {"THING": 3}, "timestamp": 0},
+        {"topic": "OUTPUT", "key": 4, "value": {"THING": 4}, "timestamp": 0}
+      ]
+    },
+    {
+      "name": "test BETWEEN with floating point",
+      "format": ["JSON"],
+      "statements": [
+        "CREATE STREAM TEST (source double) WITH (kafka_topic='test_topic', value_format='JSON');",
+        "CREATE STREAM OUTPUT AS SELECT source AS THING FROM TEST WHERE source BETWEEN 2 AND 3.9;"
+      ],
+      "inputs": [
+        {"topic": "test_topic", "key": 0, "value": {"source": null}, "timestamp": 0},
+        {"topic": "test_topic", "key": 1, "value": {"source": 1.9}, "timestamp": 0},
+        {"topic": "test_topic", "key": 2, "value": {"source": 2.0}, "timestamp": 0},
+        {"topic": "test_topic", "key": 3, "value": {"source": 2.1}, "timestamp": 0},
+        {"topic": "test_topic", "key": 4, "value": {"source": 3.9}, "timestamp": 0},
+        {"topic": "test_topic", "key": 5, "value": {"source": 4.0}, "timestamp": 0}
+      ],
+      "outputs": [
+        {"topic": "OUTPUT", "key": 2, "value": {"THING": 2.0}, "timestamp": 0},
+        {"topic": "OUTPUT", "key": 3, "value": {"THING": 2.1}, "timestamp": 0},
+        {"topic": "OUTPUT", "key": 4, "value": {"THING": 3.9}, "timestamp": 0}
+      ]
+    },
+    {
+      "name": "test BETWEEN with string values",
+      "format": ["JSON"],
+      "statements": [
+        "CREATE STREAM TEST (source string) WITH (kafka_topic='test_topic', value_format='JSON');",
+        "CREATE STREAM OUTPUT AS SELECT source AS THING FROM TEST WHERE source BETWEEN 'b' AND 'c';"
+      ],
+      "inputs": [
+        {"topic": "test_topic", "key": 0, "value": {"source": null}, "timestamp": 0},
+        {"topic": "test_topic", "key": 1, "value": {"source": "a"}, "timestamp": 0},
+        {"topic": "test_topic", "key": 2, "value": {"source": "b"}, "timestamp": 0},
+        {"topic": "test_topic", "key": 3, "value": {"source": "ba"}, "timestamp": 0},
+        {"topic": "test_topic", "key": 4, "value": {"source": "c"}, "timestamp": 0},
+        {"topic": "test_topic", "key": 5, "value": {"source": "ca"}, "timestamp": 0}
+      ],
+      "outputs": [
+        {"topic": "OUTPUT", "key": 2, "value": {"THING": "b"}, "timestamp": 0},
+        {"topic": "OUTPUT", "key": 3, "value": {"THING": "ba"}, "timestamp": 0},
+        {"topic": "OUTPUT", "key": 4, "value": {"THING": "c"}, "timestamp": 0}
+      ]
+    },
+    {
+      "name": "test NOT BETWEEN with integers",
+      "format": ["JSON"],
+      "statements": [
+        "CREATE STREAM TEST (source int) WITH (kafka_topic='test_topic', value_format='JSON');",
+        "CREATE STREAM OUTPUT AS SELECT source AS THING FROM TEST WHERE source NOT BETWEEN 2 AND 4;"
+      ],
+      "inputs": [
+        {"topic": "test_topic", "key": 1, "value": {"source": 1}, "timestamp": 0},
+        {"topic": "test_topic", "key": 2, "value": {"source": 2}, "timestamp": 0},
+        {"topic": "test_topic", "key": 3, "value": {"source": 3}, "timestamp": 0},
+        {"topic": "test_topic", "key": 4, "value": {"source": 4}, "timestamp": 0},
+        {"topic": "test_topic", "key": 5, "value": {"source": 5}, "timestamp": 0}
+      ],
+      "outputs": [
+        {"topic": "OUTPUT", "key": 1, "value": {"THING": 1}, "timestamp": 0},
+        {"topic": "OUTPUT", "key": 5, "value": {"THING": 5}, "timestamp": 0}
+      ]
+    },
+    {
+      "name": "test BETWEEN with integers and variable values",
+      "format": ["JSON"],
+      "statements": [
+        "CREATE STREAM TEST (source int, min int, max int) WITH (kafka_topic='test_topic', value_format='JSON');",
+        "CREATE STREAM OUTPUT AS SELECT source AS THING FROM TEST WHERE source BETWEEN min AND max;"
+      ],
+      "inputs": [
+        {"topic": "test_topic", "key": 0, "value": {"source": null, "min":  0, "max": 2}, "timestamp": 0},
+        {"topic": "test_topic", "key": 1, "value": {"source": 1, "min":  0, "max": 2}, "timestamp": 0},
+        {"topic": "test_topic", "key": 2, "value": {"source": 2, "min":  null, "max": 2}, "timestamp": 0},
+        {"topic": "test_topic", "key": 3, "value": {"source": 3, "min":  0, "max": null}, "timestamp": 0},
+        {"topic": "test_topic", "key": 4, "value": {"source": 4, "min":  null, "max": null}, "timestamp": 0}
+      ],
+      "outputs": [
+        {"topic": "OUTPUT", "key": 1, "value": {"THING": 1}, "timestamp": 0}
+      ]
+    },
+    {
+      "name": "test BETWEEN with integers and expressions",
+      "format": ["JSON"],
+      "statements": [
+        "CREATE STREAM TEST (source int, avg int) WITH (kafka_topic='test_topic', value_format='JSON');",
+        "CREATE STREAM OUTPUT AS SELECT source AS THING FROM TEST WHERE source + 2 BETWEEN avg / 2 AND avg * 2;"
+      ],
+      "inputs": [
+        {"topic": "test_topic", "key": 1, "value": {"source": null, "avg":  10}, "timestamp": 0},
+        {"topic": "test_topic", "key": 2, "value": {"source": 1, "avg":  10}, "timestamp": 0},
+        {"topic": "test_topic", "key": 3, "value": {"source": 10, "avg":  10}, "timestamp": 0},
+        {"topic": "test_topic", "key": 4, "value": {"source": 4, "avg":  10}, "timestamp": 0}
+      ],
+      "outputs": [
+        {"topic": "OUTPUT", "key": 3, "value": {"THING": 10}, "timestamp": 0},
+        {"topic": "OUTPUT", "key": 4, "value": {"THING": 4}, "timestamp": 0}
+      ]
+    },
+    {
+      "name": "test NOT BETWEEN with integers",
+      "format": ["JSON"],
+      "statements": [
+        "CREATE STREAM TEST (source int) WITH (kafka_topic='test_topic', value_format='JSON');",
+        "CREATE STREAM OUTPUT AS SELECT source AS THING FROM TEST WHERE source NOT BETWEEN 2 AND 4;"
+      ],
+      "inputs": [
+        {"topic": "test_topic", "key": 1, "value": {"source": 1}, "timestamp": 0},
+        {"topic": "test_topic", "key": 2, "value": {"source": 2}, "timestamp": 0},
+        {"topic": "test_topic", "key": 3, "value": {"source": 3}, "timestamp": 0},
+        {"topic": "test_topic", "key": 4, "value": {"source": 4}, "timestamp": 0},
+        {"topic": "test_topic", "key": 5, "value": {"source": 5}, "timestamp": 0}
+      ],
+      "outputs": [
+        {"topic": "OUTPUT", "key": 1, "value": {"THING": 1}, "timestamp": 0},
+        {"topic": "OUTPUT", "key": 5, "value": {"THING": 5}, "timestamp": 0}
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
This is standard SQL that users would expect to be supported, which
makes queries that compare ranges easier to read. See #1004 

### Description 

Introduce support for BETWEEN, for queries such as 
```
SELECT * FROM topic WHERE field BETWEEN valA AND valB
```

The BETWEEN operation follows convention in that the range is *inclusive* of the endpoints. Any `null` values will immediately fail the between range (in either the field or either of the endpoints). Similar to comparisons, either literals or field references may be used in the limits.

*Open Question:* Should we support comparisons with dates?

### Testing done 
- Unit testing
- Integration testing with `between.json`

### Reviewer checklist
- [ ] Ensure docs are updated if necessary. (eg. if a user visible feature is being added or changed).
- [ ] Ensure relevant issues are linked (description should include text like "Fixes #<issue number>")

