### PR TITLE
Allow CAST() to evaluate numeric arithmetic expressions

### DIFF
--- a/ksql-common/src/main/java/io/confluent/ksql/util/SchemaUtil.java
+++ b/ksql-common/src/main/java/io/confluent/ksql/util/SchemaUtil.java
@@ -454,7 +454,7 @@ public final class SchemaUtil {
     );
   }
 
-  static Schema resolveArithmeticType(final Schema.Type left,
+  public static Schema resolveArithmeticType(final Schema.Type left,
                                       final Schema.Type right) {
 
     final Schema schema = ARITHMETIC_TYPE_MAPPINGS.get(new Pair<>(left, right));

--- a/ksql-engine/src/main/java/io/confluent/ksql/codegen/SqlToJavaVisitor.java
+++ b/ksql-engine/src/main/java/io/confluent/ksql/codegen/SqlToJavaVisitor.java
@@ -477,9 +477,13 @@ public class SqlToJavaVisitor {
     ) {
       final Pair<String, Schema> left = process(node.getLeft(), unmangleNames);
       final Pair<String, Schema> right = process(node.getRight(), unmangleNames);
+
+      final Schema schema =
+          SchemaUtil.resolveArithmeticType(left.getRight().type(), right.getRight().type());
+
       return new Pair<>(
           "(" + left.getLeft() + " " + node.getType().getValue() + " " + right.getLeft() + ")",
-          Schema.OPTIONAL_FLOAT64_SCHEMA
+          schema
       );
     }
 

--- a/ksql-engine/src/test/java/io/confluent/ksql/codegen/CodeGenRunnerTest.java
+++ b/ksql-engine/src/test/java/io/confluent/ksql/codegen/CodeGenRunnerTest.java
@@ -497,6 +497,42 @@ public class CodeGenRunnerTest {
     }
 
     @Test
+    public void testCastNumericArithmeticExpressions() {
+        final Map<Integer, Object> inputValues =
+            ImmutableMap.of(0, 1, 3, 3, 4, 4, 5, 5);
+
+        // INT64 - INT32
+        assertThat(executeExpression(
+            "SELECT "
+                + "CAST((col5 - col0) AS INTEGER),"
+                + "CAST((col5 - col0) AS BIGINT),"
+                + "CAST((col5 - col0) AS DOUBLE),"
+                + "CAST((col5 - col0) AS STRING)"
+                + "FROM codegen_test;",
+            inputValues), contains(4, 4L, 4.0, "4"));
+
+        // FLOAT64 - FLOAT64
+        assertThat(executeExpression(
+            "SELECT "
+                + "CAST((col4 - col3) AS INTEGER),"
+                + "CAST((col4 - col3) AS BIGINT),"
+                + "CAST((col4 - col3) AS DOUBLE),"
+                + "CAST((col4 - col3) AS STRING)"
+                + "FROM codegen_test;",
+            inputValues), contains(1, 1L, 1.0, "1.0"));
+
+        // FLOAT64 - INT64
+        assertThat(executeExpression(
+            "SELECT "
+                + "CAST((col4 - col0) AS INTEGER),"
+                + "CAST((col4 - col0) AS BIGINT),"
+                + "CAST((col4 - col0) AS DOUBLE),"
+                + "CAST((col4 - col0) AS STRING)"
+                + "FROM codegen_test;",
+            inputValues), contains(3, 3L, 3.0, "3.0"));
+    }
+
+    @Test
     public void shouldHandleMathUdfs() {
         // Given:
         final String query =


### PR DESCRIPTION
This fixes https://github.com/confluentinc/ksql/issues/2032

### Description 
Any type of arithmetic expression inside a CAST() function that uses different parameters types than the one to return for casting resulted in an error while attempting to do the type conversion.

Example:
- ROWTIME is a BIGINT column to be cast to DOUBLE

Works
```
ksql> SELECT CAST(ROWTIME AS DOUBLE) - CAST(ROWTIME AS DOUBLE) FROM ATM_TXNS_GESS_02 ;
0.0
0.0
```

Doesn't work:
ROWTIME is a BIGINT column to be cast to DOUBLE
```
ksql> SELECT CAST((ROWTIME - ROWTIME) AS DOUBLE) FROM ATM_TXNS_GESS_02 ;
Code generation failed for SelectValueMapper
Caused by: Line 1, Column 55: Assignment conversion not possible from type "long" to type "java.lang.Double"
```

The reason is that SqlToJavaVisitor.visitArithmeticBinary() was always specifying that the result value of the expression was a FLOAT64 even if both columns were INT64. This led to visitCast() to not generate a Java expression to do the conversion (because FLOAT64 to DOUBLE does not require a conversion).

The fix is just to get the correct resulted type of the arithmetic expression and return it to the visitCast() so it correctly decides what type of Java expression to generate.

### Testing done 
Added a few test cases on the CodeGenRunnerTest to evaluate arithmetic expressions.

### Reviewer checklist
- [ ] Ensure docs are updated if necessary. (eg. if a user visible feature is being added or changed).
- [ ] Ensure relevant issues are linked (description should include text like "Fixes #<issue number>")

