### PR TITLE
Display correct message error when a stream is already created.

### DIFF
--- a/ksql-engine/src/main/java/io/confluent/ksql/ddl/commands/CreateStreamCommand.java
+++ b/ksql-engine/src/main/java/io/confluent/ksql/ddl/commands/CreateStreamCommand.java
@@ -18,6 +18,7 @@ import io.confluent.ksql.metastore.KsqlStream;
 import io.confluent.ksql.metastore.MetaStore;
 import io.confluent.ksql.parser.tree.CreateStream;
 import io.confluent.ksql.services.KafkaTopicClient;
+import io.confluent.ksql.util.KsqlException;
 import io.confluent.ksql.util.SchemaUtil;
 
 public class CreateStreamCommand extends AbstractCreateStreamCommand {
@@ -37,7 +38,12 @@ public class CreateStreamCommand extends AbstractCreateStreamCommand {
   @Override
   public DdlCommandResult run(final MetaStore metaStore) {
     if (registerTopicCommand != null) {
-      registerTopicCommand.run(metaStore);
+      try {
+        registerTopicCommand.run(metaStore);
+      } catch (KsqlException e) {
+        throw new KsqlException(String.format("Cannot create stream '%s': %s",
+                topicName, e.getMessage()));
+      }
     }
     checkMetaData(metaStore, sourceName, topicName);
     final KsqlStream ksqlStream = new KsqlStream<>(

--- a/ksql-engine/src/main/java/io/confluent/ksql/ddl/commands/CreateStreamCommand.java
+++ b/ksql-engine/src/main/java/io/confluent/ksql/ddl/commands/CreateStreamCommand.java
@@ -41,8 +41,9 @@ public class CreateStreamCommand extends AbstractCreateStreamCommand {
       try {
         registerTopicCommand.run(metaStore);
       } catch (KsqlException e) {
-        throw new KsqlException(String.format("Cannot create stream '%s': %s",
-                topicName, e.getMessage()));
+        final String errorMessage =
+                String.format("Cannot create stream '%s': %s", topicName, e.getMessage());
+        throw new KsqlException(errorMessage, e);
       }
     }
     checkMetaData(metaStore, sourceName, topicName);

--- a/ksql-engine/src/main/java/io/confluent/ksql/ddl/commands/CreateTableCommand.java
+++ b/ksql-engine/src/main/java/io/confluent/ksql/ddl/commands/CreateTableCommand.java
@@ -63,8 +63,9 @@ public class CreateTableCommand extends AbstractCreateStreamCommand {
       try {
         registerTopicCommand.run(metaStore);
       } catch (KsqlException e) {
-        throw new KsqlException(String.format("Cannot create table '%s': %s",
-                topicName, e.getMessage()));
+        final String errorMessage =
+                String.format("Cannot create table '%s': %s", topicName, e.getMessage());
+        throw new KsqlException(errorMessage, e);
       }
     }
     checkMetaData(metaStore, sourceName, topicName);

--- a/ksql-engine/src/main/java/io/confluent/ksql/ddl/commands/CreateTableCommand.java
+++ b/ksql-engine/src/main/java/io/confluent/ksql/ddl/commands/CreateTableCommand.java
@@ -60,7 +60,12 @@ public class CreateTableCommand extends AbstractCreateStreamCommand {
   @Override
   public DdlCommandResult run(final MetaStore metaStore) {
     if (registerTopicCommand != null) {
-      registerTopicCommand.run(metaStore);
+      try {
+        registerTopicCommand.run(metaStore);
+      } catch (KsqlException e) {
+        throw new KsqlException(String.format("Cannot create table '%s': %s",
+                topicName, e.getMessage()));
+      }
     }
     checkMetaData(metaStore, sourceName, topicName);
     final KsqlTable ksqlTable = new KsqlTable<>(

--- a/ksql-engine/src/main/java/io/confluent/ksql/ddl/commands/RegisterTopicCommand.java
+++ b/ksql-engine/src/main/java/io/confluent/ksql/ddl/commands/RegisterTopicCommand.java
@@ -104,8 +104,9 @@ public class RegisterTopicCommand implements DdlCommand {
       if (notExists) {
         return new DdlCommandResult(true, "Topic already registered.");
       } else {
-        throw new KsqlException(String.format("Failed to create because %s with name '%s' "
-            + "already exists.", getSourceType(metaStore), topicName));
+        final String sourceType = getSourceType(metaStore);
+        throw new KsqlException(String.format("%s with name '%s' already exists",
+                sourceType, topicName));
       }
     }
 
@@ -121,21 +122,21 @@ public class RegisterTopicCommand implements DdlCommand {
   private String getSourceType(final MetaStore metaStore) {
     final StructuredDataSource source = metaStore.getSource(topicName);
     if (source == null) {
-      return "an ENTITY";
+      return "An entity";
     }
 
     switch (source.getDataSourceType()) {
       case KSTREAM:
-        return "a STREAM";
+        return "A stream";
 
       case KTABLE:
-        return "a TABLE";
+        return "A table";
 
       case KTOPIC:
-        return "a TOPIC";
+        return "A topic";
 
       default:
-        return "an ENTITY";
+        return "An entity";
     }
   }
 }

--- a/ksql-engine/src/main/java/io/confluent/ksql/ddl/commands/RegisterTopicCommand.java
+++ b/ksql-engine/src/main/java/io/confluent/ksql/ddl/commands/RegisterTopicCommand.java
@@ -105,8 +105,9 @@ public class RegisterTopicCommand implements DdlCommand {
         return new DdlCommandResult(true, "Topic already registered.");
       } else {
         final String sourceType = getSourceType(metaStore);
-        throw new KsqlException(String.format("%s with name '%s' already exists",
-                sourceType, topicName));
+        final String errorMessage =
+                String.format("%s with name '%s' already exists", sourceType, topicName);
+        throw new KsqlException(errorMessage);
       }
     }
 
@@ -122,7 +123,7 @@ public class RegisterTopicCommand implements DdlCommand {
   private String getSourceType(final MetaStore metaStore) {
     final StructuredDataSource source = metaStore.getSource(topicName);
     if (source == null) {
-      return "An entity";
+      return "A topic";
     }
 
     switch (source.getDataSourceType()) {

--- a/ksql-engine/src/test/java/io/confluent/ksql/ddl/commands/CreateStreamCommandTest.java
+++ b/ksql-engine/src/test/java/io/confluent/ksql/ddl/commands/CreateStreamCommandTest.java
@@ -150,8 +150,8 @@ public class CreateStreamCommandTest {
     cmd.run(metaStore);
 
     // Then:
-    expectedException.expectMessage(
-        "Failed to create because a STREAM with name 'name' already exists.");
+    expectedException.expectMessage("Cannot create stream 'name': A stream " +
+            "with name 'name' already exists");
     cmd.run(metaStore);
   }
 

--- a/ksql-engine/src/test/java/io/confluent/ksql/ddl/commands/CreateStreamCommandTest.java
+++ b/ksql-engine/src/test/java/io/confluent/ksql/ddl/commands/CreateStreamCommandTest.java
@@ -16,12 +16,15 @@ package io.confluent.ksql.ddl.commands;
 
 import static org.easymock.MockType.NICE;
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.instanceOf;
 import static org.hamcrest.Matchers.is;
 
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import io.confluent.ksql.ddl.DdlConfig;
+import io.confluent.ksql.function.InternalFunctionRegistry;
+import io.confluent.ksql.metastore.MetaStore;
 import io.confluent.ksql.parser.tree.BooleanLiteral;
 import io.confluent.ksql.parser.tree.CreateStream;
 import io.confluent.ksql.parser.tree.Expression;
@@ -29,6 +32,7 @@ import io.confluent.ksql.parser.tree.QualifiedName;
 import io.confluent.ksql.parser.tree.StringLiteral;
 import io.confluent.ksql.services.KafkaTopicClient;
 import io.confluent.ksql.util.KsqlException;
+import io.confluent.ksql.util.MetaStoreFixture;
 import java.util.HashMap;
 import java.util.Map;
 import org.apache.kafka.common.serialization.Serdes;
@@ -51,6 +55,8 @@ public class CreateStreamCommandTest {
 
   @Rule
   public final ExpectedException expectedException = ExpectedException.none();
+
+  private final MetaStore metaStore = MetaStoreFixture.getNewMetaStore(new InternalFunctionRegistry());
 
   @Test
   public void shouldDefaultToStringKeySerde() {
@@ -118,6 +124,20 @@ public class CreateStreamCommandTest {
 
     // When:
     createCmd();
+  }
+
+  @Test
+  public void testCreateAlreadyRegisteredStreamThrowsException() {
+    // Given:
+    givenProperties(propsWith(ImmutableMap.of()));
+
+    // When:
+    final CreateStreamCommand cmd = createCmd();
+    cmd.run(metaStore, false);
+
+    // Then:
+    expectedException.expectMessage("Stream already exists: name");
+    cmd.run(metaStore, false);
   }
 
   @Test

--- a/ksql-engine/src/test/java/io/confluent/ksql/ddl/commands/CreateStreamCommandTest.java
+++ b/ksql-engine/src/test/java/io/confluent/ksql/ddl/commands/CreateStreamCommandTest.java
@@ -142,16 +142,18 @@ public class CreateStreamCommandTest {
 
   @Test
   public void testCreateAlreadyRegisteredStreamThrowsException() {
+    final CreateStreamCommand cmd;
+
     // Given:
     givenProperties(propsWith(ImmutableMap.of()));
-
-    // When:
-    final CreateStreamCommand cmd = createCmd();
+    cmd = createCmd();
     cmd.run(metaStore);
 
     // Then:
     expectedException.expectMessage("Cannot create stream 'name': A stream " +
             "with name 'name' already exists");
+
+    // When:
     cmd.run(metaStore);
   }
 

--- a/ksql-engine/src/test/java/io/confluent/ksql/ddl/commands/CreateStreamCommandTest.java
+++ b/ksql-engine/src/test/java/io/confluent/ksql/ddl/commands/CreateStreamCommandTest.java
@@ -127,20 +127,6 @@ public class CreateStreamCommandTest {
   }
 
   @Test
-  public void testCreateAlreadyRegisteredStreamThrowsException() {
-    // Given:
-    givenProperties(propsWith(ImmutableMap.of()));
-
-    // When:
-    final CreateStreamCommand cmd = createCmd();
-    cmd.run(metaStore, false);
-
-    // Then:
-    expectedException.expectMessage("Stream already exists: name");
-    cmd.run(metaStore, false);
-  }
-
-  @Test
   public void shouldThrowOnOldWindowProperty() {
     // Given:
     expectedException.expect(KsqlException.class);
@@ -152,6 +138,21 @@ public class CreateStreamCommandTest {
 
     // When:
     createCmd();
+  }
+
+  @Test
+  public void testCreateAlreadyRegisteredStreamThrowsException() {
+    // Given:
+    givenProperties(propsWith(ImmutableMap.of()));
+
+    // When:
+    final CreateStreamCommand cmd = createCmd();
+    cmd.run(metaStore, false);
+
+    // Then:
+    expectedException.expectMessage(
+        "Failed to create because a STREAM with name 'name' already exists.");
+    cmd.run(metaStore, false);
   }
 
   private CreateStreamCommand createCmd() {

--- a/ksql-engine/src/test/java/io/confluent/ksql/ddl/commands/CreateStreamCommandTest.java
+++ b/ksql-engine/src/test/java/io/confluent/ksql/ddl/commands/CreateStreamCommandTest.java
@@ -147,12 +147,12 @@ public class CreateStreamCommandTest {
 
     // When:
     final CreateStreamCommand cmd = createCmd();
-    cmd.run(metaStore, false);
+    cmd.run(metaStore);
 
     // Then:
     expectedException.expectMessage(
         "Failed to create because a STREAM with name 'name' already exists.");
-    cmd.run(metaStore, false);
+    cmd.run(metaStore);
   }
 
   private CreateStreamCommand createCmd() {

--- a/ksql-engine/src/test/java/io/confluent/ksql/ddl/commands/CreateTableCommandTest.java
+++ b/ksql-engine/src/test/java/io/confluent/ksql/ddl/commands/CreateTableCommandTest.java
@@ -152,8 +152,8 @@ public class CreateTableCommandTest {
     cmd.run(metaStore);
 
     // Then:
-    expectedException.expectMessage(
-        "Failed to create because a TABLE with name 'name' already exists.");
+    expectedException.expectMessage("Cannot create table 'name': A table " +
+            "with name 'name' already exists");
     cmd.run(metaStore);
   }
 

--- a/ksql-engine/src/test/java/io/confluent/ksql/ddl/commands/CreateTableCommandTest.java
+++ b/ksql-engine/src/test/java/io/confluent/ksql/ddl/commands/CreateTableCommandTest.java
@@ -149,12 +149,12 @@ public class CreateTableCommandTest {
 
     // When:
     final CreateTableCommand cmd = createCmd();
-    cmd.run(metaStore, false);
+    cmd.run(metaStore);
 
     // Then:
     expectedException.expectMessage(
         "Failed to create because a TABLE with name 'name' already exists.");
-    cmd.run(metaStore, false);
+    cmd.run(metaStore);
   }
 
   private CreateTableCommand createCmd() {

--- a/ksql-engine/src/test/java/io/confluent/ksql/ddl/commands/CreateTableCommandTest.java
+++ b/ksql-engine/src/test/java/io/confluent/ksql/ddl/commands/CreateTableCommandTest.java
@@ -22,6 +22,8 @@ import static org.hamcrest.Matchers.is;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import io.confluent.ksql.ddl.DdlConfig;
+import io.confluent.ksql.function.InternalFunctionRegistry;
+import io.confluent.ksql.metastore.MetaStore;
 import io.confluent.ksql.parser.tree.BooleanLiteral;
 import io.confluent.ksql.parser.tree.CreateTable;
 import io.confluent.ksql.parser.tree.Expression;
@@ -32,6 +34,7 @@ import io.confluent.ksql.parser.tree.TableElement;
 import io.confluent.ksql.parser.tree.Type.KsqlType;
 import io.confluent.ksql.services.KafkaTopicClient;
 import io.confluent.ksql.util.KsqlException;
+import io.confluent.ksql.util.MetaStoreFixture;
 import java.util.HashMap;
 import java.util.Map;
 import org.apache.kafka.common.serialization.Serdes;
@@ -54,6 +57,8 @@ public class CreateTableCommandTest {
 
   @Rule
   public final ExpectedException expectedException = ExpectedException.none();
+
+  private final MetaStore metaStore = MetaStoreFixture.getNewMetaStore(new InternalFunctionRegistry());
 
   @Test
   public void shouldDefaultToStringKeySerde() {
@@ -135,6 +140,21 @@ public class CreateTableCommandTest {
 
     // When:
     createCmd();
+  }
+
+  @Test
+  public void testCreateAlreadyRegisteredTableThrowsException() {
+    // Given:
+    givenProperties(propsWith(ImmutableMap.of()));
+
+    // When:
+    final CreateTableCommand cmd = createCmd();
+    cmd.run(metaStore, false);
+
+    // Then:
+    expectedException.expectMessage(
+        "Failed to create because a TABLE with name 'name' already exists.");
+    cmd.run(metaStore, false);
   }
 
   private CreateTableCommand createCmd() {

--- a/ksql-engine/src/test/java/io/confluent/ksql/ddl/commands/CreateTableCommandTest.java
+++ b/ksql-engine/src/test/java/io/confluent/ksql/ddl/commands/CreateTableCommandTest.java
@@ -144,16 +144,18 @@ public class CreateTableCommandTest {
 
   @Test
   public void testCreateAlreadyRegisteredTableThrowsException() {
+    final CreateTableCommand cmd;
+
     // Given:
     givenProperties(propsWith(ImmutableMap.of()));
-
-    // When:
-    final CreateTableCommand cmd = createCmd();
+    cmd = createCmd();
     cmd.run(metaStore);
 
     // Then:
     expectedException.expectMessage("Cannot create table 'name': A table " +
             "with name 'name' already exists");
+
+    // When:
     cmd.run(metaStore);
   }
 

--- a/ksql-engine/src/test/java/io/confluent/ksql/ddl/commands/RegisterTopicCommandTest.java
+++ b/ksql-engine/src/test/java/io/confluent/ksql/ddl/commands/RegisterTopicCommandTest.java
@@ -1,0 +1,81 @@
+/*
+ * Copyright 2018 Confluent Inc.
+ *
+ * Licensed under the Confluent Community License; you may not use this file
+ * except in compliance with the License.  You may obtain a copy of the License at
+ *
+ * http://www.confluent.io/confluent-community-license
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+package io.confluent.ksql.ddl.commands;
+
+import com.google.common.collect.ImmutableMap;
+import io.confluent.ksql.ddl.DdlConfig;
+import io.confluent.ksql.function.InternalFunctionRegistry;
+import io.confluent.ksql.metastore.MetaStore;
+import io.confluent.ksql.parser.tree.Expression;
+import io.confluent.ksql.parser.tree.QualifiedName;
+import io.confluent.ksql.parser.tree.RegisterTopic;
+import io.confluent.ksql.parser.tree.StringLiteral;
+import io.confluent.ksql.util.MetaStoreFixture;
+import org.easymock.EasyMock;
+import org.easymock.EasyMockRunner;
+import org.easymock.Mock;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+import org.junit.runner.RunWith;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import static org.easymock.MockType.NICE;
+
+@RunWith(EasyMockRunner.class)
+public class RegisterTopicCommandTest {
+
+    @Mock(NICE)
+    private RegisterTopic registerTopicStatement;
+
+    @Rule
+    public final ExpectedException expectedException = ExpectedException.none();
+
+    private final MetaStore metaStore = MetaStoreFixture.getNewMetaStore(new InternalFunctionRegistry());
+
+    @Test
+    public void testRegisterAlreadyRegisteredTopicThrowsException() {
+        final RegisterTopicCommand cmd;
+
+        // Given:
+        givenProperties(propsWith(ImmutableMap.of()));
+        cmd = createCmd();
+        cmd.run(metaStore);
+
+        // Then:
+        expectedException.expectMessage("A topic with name 'name' already exists");
+
+        // When:
+        cmd.run(metaStore);
+    }
+
+    private RegisterTopicCommand createCmd() {
+        return new RegisterTopicCommand(registerTopicStatement);
+    }
+
+    private Map<String, Expression> propsWith(final Map<String, Expression> props) {
+        Map<String, Expression> valid = new HashMap<>(props);
+        valid.putIfAbsent(DdlConfig.VALUE_FORMAT_PROPERTY, new StringLiteral("Json"));
+        valid.putIfAbsent(DdlConfig.KAFKA_TOPIC_NAME_PROPERTY, new StringLiteral("some-topic"));
+        return valid;
+    }
+
+    private void givenProperties(final Map<String, Expression> props) {
+        EasyMock.expect(registerTopicStatement.getProperties()).andReturn(props).anyTimes();
+        EasyMock.expect(registerTopicStatement.getName()).andReturn(QualifiedName.of("name")).anyTimes();
+        EasyMock.replay(registerTopicStatement);
+    }
+}


### PR DESCRIPTION
This fixes https://github.com/confluentinc/ksql/issues/2374

### Description 
If a Stream already exists with the same name, the error message returned uses the term Topic, which is incorrect.

```
ksql> CREATE STREAM PCAP (layers struct<frame struct<frame_frame_interface_id varchar>>) WITH (KAFKA_TOPIC='localPCAP', VALUE_FORMAT='JSON');
Topic already registered: PCAP
```

This patch changes the message to be:
```
ksql> CREATE STREAM PCAP (layers struct<frame struct<frame_frame_interface_id varchar>>) WITH (KAFKA_TOPIC='localPCAP', VALUE_FORMAT='JSON');
Stream already exists: PCAP
```

### Testing done 
One test case added to the `CreateStreamCommandTest` class.

### Reviewer checklist
- [ ] Ensure docs are updated if necessary. (eg. if a user visible feature is being added or changed).
- [ ] Ensure relevant issues are linked (description should include text like "Fixes #<issue number>")

