### PR TITLE
Prevent deletion of topics during recovery. Fixes #2329 (partially)

### DIFF
--- a/ksql-parser/src/main/java/io/confluent/ksql/parser/rewrite/StatementRewriter.java
+++ b/ksql-parser/src/main/java/io/confluent/ksql/parser/rewrite/StatementRewriter.java
@@ -1026,7 +1026,7 @@ public class StatementRewriter extends DefaultAstVisitor<Node, Object> {
 
   protected Node visitDropTable(final DropTable node, final Object context) {
     return new DropTable(node.getLocation(),
-        node.getTableName(),
+        node.getName(),
         node.getIfExists(),
         node.isDeleteTopic());
   }

--- a/ksql-parser/src/main/java/io/confluent/ksql/parser/tree/AbstractStreamDropStatement.java
+++ b/ksql-parser/src/main/java/io/confluent/ksql/parser/tree/AbstractStreamDropStatement.java
@@ -14,14 +14,65 @@
 
 package io.confluent.ksql.parser.tree;
 
+import com.google.common.base.MoreObjects;
+import java.util.Objects;
 import java.util.Optional;
 
 public abstract class AbstractStreamDropStatement extends Statement {
-  public AbstractStreamDropStatement(final Optional<NodeLocation> location) {
+
+  private final QualifiedName name;
+  private final boolean ifExists;
+  private final boolean deleteTopic;
+
+  public AbstractStreamDropStatement(final Optional<NodeLocation> location,
+                                     final QualifiedName name,
+                                     final boolean deleteTopic,
+                                     final boolean ifExists) {
     super(location);
+    this.name = name;
+    this.deleteTopic = deleteTopic;
+    this.ifExists = ifExists;
   }
 
-  public abstract boolean getIfExists();
+  public QualifiedName getName() {
+    return name;
+  }
 
-  public abstract QualifiedName getName();
+  public boolean isDeleteTopic() {
+    return deleteTopic;
+  }
+
+  public boolean getIfExists() {
+    return ifExists;
+  }
+
+  @Override
+  public boolean equals(final Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+
+    final AbstractStreamDropStatement that = (AbstractStreamDropStatement) o;
+    return deleteTopic == that.deleteTopic
+        && ifExists == that.ifExists
+        && Objects.equals(name, that.name);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(name, deleteTopic, ifExists);
+  }
+
+  @Override
+  public String toString() {
+    return MoreObjects.toStringHelper(this)
+        .add("name", name)
+        .add("deleteTopic", deleteTopic)
+        .add("ifExists", ifExists)
+        .toString();
+  }
+
 }

--- a/ksql-parser/src/main/java/io/confluent/ksql/parser/tree/AbstractStreamDropStatement.java
+++ b/ksql-parser/src/main/java/io/confluent/ksql/parser/tree/AbstractStreamDropStatement.java
@@ -24,12 +24,13 @@ public abstract class AbstractStreamDropStatement extends Statement {
   private final boolean ifExists;
   private final boolean deleteTopic;
 
-  public AbstractStreamDropStatement(final Optional<NodeLocation> location,
-                                     final QualifiedName name,
-                                     final boolean deleteTopic,
-                                     final boolean ifExists) {
+  AbstractStreamDropStatement(
+      final Optional<NodeLocation> location,
+      final QualifiedName name,
+      final boolean deleteTopic,
+      final boolean ifExists) {
     super(location);
-    this.name = name;
+    this.name = Objects.requireNonNull(name, "name can't be null");
     this.deleteTopic = deleteTopic;
     this.ifExists = ifExists;
   }

--- a/ksql-parser/src/main/java/io/confluent/ksql/parser/tree/DropStream.java
+++ b/ksql-parser/src/main/java/io/confluent/ksql/parser/tree/DropStream.java
@@ -40,10 +40,6 @@ public class DropStream
     super(location, streamName, deleteTopic, ifExists);
   }
 
-  public QualifiedName getStreamName() {
-    return getName();
-  }
-
   @Override
   public <R, C> R accept(final AstVisitor<R, C> visitor, final C context) {
     return visitor.visitDropStream(this, context);

--- a/ksql-parser/src/main/java/io/confluent/ksql/parser/tree/DropStream.java
+++ b/ksql-parser/src/main/java/io/confluent/ksql/parser/tree/DropStream.java
@@ -14,17 +14,10 @@
 
 package io.confluent.ksql.parser.tree;
 
-import static com.google.common.base.MoreObjects.toStringHelper;
-
-import java.util.Objects;
 import java.util.Optional;
 
 public class DropStream
     extends AbstractStreamDropStatement implements ExecutableDdlStatement {
-
-  private final QualifiedName streamName;
-  private final boolean ifExists;
-  private final boolean deleteTopic;
 
   public DropStream(
       final QualifiedName tableName,
@@ -40,30 +33,15 @@ public class DropStream
     this(Optional.of(location), tableName, ifExists, deleteTopic);
   }
 
-  private DropStream(final Optional<NodeLocation> location,
+  public DropStream(final Optional<NodeLocation> location,
                      final QualifiedName streamName,
                      final boolean ifExists,
                      final boolean deleteTopic) {
-    super(location);
-    this.streamName = streamName;
-    this.ifExists = ifExists;
-    this.deleteTopic = deleteTopic;
-  }
-
-  public QualifiedName getName() {
-    return streamName;
-  }
-
-  public boolean getIfExists() {
-    return ifExists;
+    super(location, streamName, deleteTopic, ifExists);
   }
 
   public QualifiedName getStreamName() {
-    return streamName;
-  }
-
-  public boolean isDeleteTopic() {
-    return deleteTopic;
+    return getName();
   }
 
   @Override
@@ -71,31 +49,4 @@ public class DropStream
     return visitor.visitDropStream(this, context);
   }
 
-  @Override
-  public int hashCode() {
-    return Objects.hash(streamName, ifExists);
-  }
-
-  @Override
-  public boolean equals(final Object obj) {
-    if (this == obj) {
-      return true;
-    }
-    if ((obj == null) || (getClass() != obj.getClass())) {
-      return false;
-    }
-    final DropStream o = (DropStream) obj;
-    return Objects.equals(streamName, o.streamName)
-           && (ifExists == o.ifExists)
-           && (deleteTopic == o.deleteTopic);
-  }
-
-  @Override
-  public String toString() {
-    return toStringHelper(this)
-        .add("tableName", streamName)
-        .add("ifExists", ifExists)
-        .add("deleteTopic", deleteTopic)
-        .toString();
-  }
 }

--- a/ksql-parser/src/main/java/io/confluent/ksql/parser/tree/DropTable.java
+++ b/ksql-parser/src/main/java/io/confluent/ksql/parser/tree/DropTable.java
@@ -14,16 +14,9 @@
 
 package io.confluent.ksql.parser.tree;
 
-import static com.google.common.base.MoreObjects.toStringHelper;
-
-import java.util.Objects;
 import java.util.Optional;
 
 public class DropTable extends AbstractStreamDropStatement implements ExecutableDdlStatement {
-
-  private final QualifiedName tableName;
-  private final boolean ifExists;
-  private final boolean deleteTopic;
 
   public DropTable(
       final QualifiedName tableName,
@@ -36,58 +29,15 @@ public class DropTable extends AbstractStreamDropStatement implements Executable
                     final QualifiedName tableName,
                     final boolean ifExists,
                     final boolean deleteTopic) {
-    super(location);
-    this.tableName = tableName;
-    this.ifExists = ifExists;
-    this.deleteTopic = deleteTopic;
-  }
-
-  public QualifiedName getName() {
-    return tableName;
-  }
-
-  public boolean getIfExists() {
-    return ifExists;
+    super(location, tableName, deleteTopic, ifExists);
   }
 
   public QualifiedName getTableName() {
-    return tableName;
-  }
-
-  public boolean isDeleteTopic() {
-    return deleteTopic;
+    return getName();
   }
 
   @Override
   public <R, C> R accept(final AstVisitor<R, C> visitor, final C context) {
     return visitor.visitDropTable(this, context);
-  }
-
-  @Override
-  public int hashCode() {
-    return Objects.hash(tableName, ifExists);
-  }
-
-  @Override
-  public boolean equals(final Object obj) {
-    if (this == obj) {
-      return true;
-    }
-    if ((obj == null) || (getClass() != obj.getClass())) {
-      return false;
-    }
-    final DropTable o = (DropTable) obj;
-    return Objects.equals(tableName, o.tableName)
-           && (ifExists == o.ifExists)
-           && (deleteTopic == o.deleteTopic);
-  }
-
-  @Override
-  public String toString() {
-    return toStringHelper(this)
-        .add("tableName", tableName)
-        .add("ifExists", ifExists)
-        .add("deleteTopic", deleteTopic)
-        .toString();
   }
 }

--- a/ksql-parser/src/main/java/io/confluent/ksql/parser/tree/DropTable.java
+++ b/ksql-parser/src/main/java/io/confluent/ksql/parser/tree/DropTable.java
@@ -32,10 +32,6 @@ public class DropTable extends AbstractStreamDropStatement implements Executable
     super(location, tableName, deleteTopic, ifExists);
   }
 
-  public QualifiedName getTableName() {
-    return getName();
-  }
-
   @Override
   public <R, C> R accept(final AstVisitor<R, C> visitor, final C context) {
     return visitor.visitDropTable(this, context);

--- a/ksql-parser/src/test/java/io/confluent/ksql/parser/tree/AbstractStreamDropStatementTest.java
+++ b/ksql-parser/src/test/java/io/confluent/ksql/parser/tree/AbstractStreamDropStatementTest.java
@@ -1,0 +1,27 @@
+package io.confluent.ksql.parser.tree;
+
+import com.google.common.testing.EqualsTester;
+import java.util.Optional;
+import org.junit.Test;
+
+public class AbstractStreamDropStatementTest {
+
+  @Test
+  public void testHashAndEquals() {
+    new EqualsTester()
+        // equals should ignore NodeLocation
+        .addEqualityGroup(
+            new DropStream(Optional.empty(), QualifiedName.of("a"), true, true),
+            new DropStream(Optional.empty(), QualifiedName.of("a"), true, true),
+            new DropStream(Optional.of(new NodeLocation(0, 0)), QualifiedName.of("a"), true, true),
+            new DropStream(Optional.of(new NodeLocation(0, 1)), QualifiedName.of("a"), true, true))
+        // equals should check qualified names
+        .addEqualityGroup(new DropStream(Optional.empty(), QualifiedName.of("b"), true, true))
+        // equals should check ifExists
+        .addEqualityGroup(new DropStream(Optional.empty(), QualifiedName.of("a"), false, true))
+        // equals should check deleteTopic
+        .addEqualityGroup(new DropStream(Optional.empty(), QualifiedName.of("a"), true, false))
+        .testEquals();
+  }
+
+}

--- a/ksql-rest-app/src/test/java/io/confluent/ksql/rest/server/computation/StatementExecutorTest.java
+++ b/ksql-rest-app/src/test/java/io/confluent/ksql/rest/server/computation/StatementExecutorTest.java
@@ -18,6 +18,7 @@ import static org.easymock.EasyMock.anyObject;
 import static org.easymock.EasyMock.eq;
 import static org.easymock.EasyMock.expect;
 import static org.easymock.EasyMock.expectLastCall;
+import static org.easymock.EasyMock.matches;
 import static org.easymock.EasyMock.replay;
 import static org.easymock.EasyMock.reportMatcher;
 import static org.easymock.EasyMock.verify;
@@ -30,6 +31,7 @@ import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.not;
 
 import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
 import io.confluent.ksql.KsqlEngine;
 import io.confluent.ksql.ddl.commands.DdlCommandResult;
@@ -68,6 +70,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+import org.easymock.EasyMock;
 import org.easymock.EasyMockSupport;
 import org.easymock.IArgumentMatcher;
 import org.hamcrest.CoreMatchers;
@@ -570,6 +573,10 @@ public class StatementExecutorTest extends EasyMockSupport {
   public void shouldCascade4Dot1DropStreamCommand() {
     // Given:
     final DropStream mockDropStream = mockDropStream("foo");
+    expect(mockDropStream.getLocation()).andStubReturn(Optional.empty());
+    expect(mockDropStream.isDeleteTopic()).andStubReturn(false);
+    expect(mockDropStream.getIfExists()).andStubReturn(true);
+
     expect(mockMetaStore.getSource("foo"))
         .andStubReturn(mock(StructuredDataSource.class));
     expect(mockMetaStore.getQueriesWithSink("foo"))
@@ -578,7 +585,8 @@ public class StatementExecutorTest extends EasyMockSupport {
     expect(mockEngine.getPersistentQuery(new QueryId("query-id"))).andReturn(Optional.of(mockQueryMetadata));
     mockQueryMetadata.close();
     expectLastCall();
-    expect(mockEngine.executeDdlStatement("DROP", mockDropStream, Collections.emptyMap()))
+    expect(mockEngine.executeDdlStatement(
+        matches("DROP"), anyObject(DropStream.class), eq(ImmutableMap.of())))
         .andReturn(new DdlCommandResult(true, "SUCCESS"));
     replayAll();
 
@@ -599,8 +607,13 @@ public class StatementExecutorTest extends EasyMockSupport {
     // Given:
     final String drop = "DROP";
     final DropStream mockDropStream = mockDropStream("foo");
-    expect(mockEngine.executeDdlStatement(drop, mockDropStream, Collections.emptyMap()))
-        .andReturn(new DdlCommandResult(true, "SUCCESS"));
+    expect(mockDropStream.getLocation()).andStubReturn(Optional.empty());
+    expect(mockDropStream.isDeleteTopic()).andStubReturn(false);
+    expect(mockDropStream.getIfExists()).andStubReturn(true);
+
+    expect(mockEngine.executeDdlStatement(
+        matches("DROP"), anyObject(DropStream.class), eq(ImmutableMap.of())))
+        .andReturn(new DdlCommandResult(true, "SUCCESS"));;
     replayAll();
 
     // When:

--- a/ksql-rest-app/src/test/java/io/confluent/ksql/rest/server/computation/StatementExecutorTest.java
+++ b/ksql-rest-app/src/test/java/io/confluent/ksql/rest/server/computation/StatementExecutorTest.java
@@ -70,7 +70,6 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
-import org.easymock.EasyMock;
 import org.easymock.EasyMockSupport;
 import org.easymock.IArgumentMatcher;
 import org.hamcrest.CoreMatchers;
@@ -501,7 +500,7 @@ public class StatementExecutorTest extends EasyMockSupport {
   private DropStream mockDropStream(final String name) {
     final DropStream mockDropStream = mock(DropStream.class);
     expect(mockDropStream.getName()).andStubReturn(QualifiedName.of(name));
-    expect(mockDropStream.getStreamName()).andStubReturn(QualifiedName.of(name));
+    expect(mockDropStream.getName()).andStubReturn(QualifiedName.of(name));
     expect(mockParser.parseSingleStatement("DROP"))
         .andReturn(new PreparedStatement<>("DROP", mockDropStream));
     return mockDropStream;


### PR DESCRIPTION
### Description 
This is a minimally invasive change to prevent us from deleting topics that were potentially recreated during recovery mode for the interactive KSQL server. Today, we replay all events in the case of a crash (including create/delete topics). This causes an issue if a user issues a delete, expects KSQL to relinquish ownership of that topic and creates it again outside of KSQL. In this scenario, recovery mode will delete the recreated topic.

This is only a partial fix. We still execute create topic commands during recovery, so it is possible that we will recreate a topic that the user manually deleted, and leave it there as a zombie topic. This is less serious and the scope of that change is much larger, so we will leave that for another time.

See #2329 for further discussion.

**P.S.** This also includes a small refactor of common functionality in `AbstractStreamDropCommand`

### Testing done 
- Unit testing
- Restarting a custom KSQL server and attaching a debugger to validate end-to-end

### Reviewer checklist
- [ ] Ensure docs are updated if necessary. (eg. if a user visible feature is being added or changed).
- [ ] Ensure relevant issues are linked (description should include text like "Fixes #<issue number>")

