### PR TITLE
Remove requirement for "value" parameter in UdfParameter annotation

### DIFF
--- a/docs/developer-guide/udf.rst
+++ b/docs/developer-guide/udf.rst
@@ -233,6 +233,9 @@ can be used to better describe what the parameter does, for example:
        @UdfParameter("str") final String str,
        @UdfParameter(value = "pos", description = "Starting position of the substring") final int pos)
 
+If your Java8 class is compiled with the ``-parameter`` compiler flag, the name of the parameter
+will be inferred from the method declaration.
+
 Configurable UDF
 ~~~~~~~~~~~~~~~~
 

--- a/ksql-engine/pom.xml
+++ b/ksql-engine/pom.xml
@@ -147,6 +147,17 @@
     <build>
         <plugins>
             <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <configuration>
+                    <compilerArgs>
+                        <arg>-Xlint:all,-options,-path</arg>
+                        <arg>-parameters</arg>
+                        <arg>-Werror</arg>
+                    </compilerArgs>
+                </configuration>
+            </plugin>
+            <plugin>
                 <groupId>org.antlr</groupId>
                 <artifactId>antlr4-maven-plugin</artifactId>
                 <version>${antlr.version}</version>

--- a/ksql-engine/src/main/java/io/confluent/ksql/function/UdfLoader.java
+++ b/ksql-engine/src/main/java/io/confluent/ksql/function/UdfLoader.java
@@ -36,6 +36,7 @@ import java.io.File;
 import java.io.IOException;
 import java.lang.reflect.Method;
 import java.lang.reflect.Modifier;
+import java.lang.reflect.Parameter;
 import java.lang.reflect.Type;
 import java.nio.file.Files;
 import java.nio.file.Path;
@@ -256,7 +257,11 @@ public class UdfLoader {
           .map(UdfParameter.class::cast)
           .findAny();
 
-      final String name = annotation.map(UdfParameter::value).orElse("");
+      final Parameter param = method.getParameters()[idx];
+      final String name = annotation.map(UdfParameter::value)
+          .filter(val -> !val.isEmpty())
+          .orElse(param.isNamePresent() ? param.getName() : "");
+
       final String doc = annotation.map(UdfParameter::description).orElse("");
       return SchemaUtil.getSchemaFromType(type, name, doc);
     }).collect(Collectors.toList());

--- a/ksql-engine/src/main/java/io/confluent/ksql/function/udf/datetime/DateToString.java
+++ b/ksql-engine/src/main/java/io/confluent/ksql/function/udf/datetime/DateToString.java
@@ -41,10 +41,10 @@ public class DateToString {
       + " using the given format pattern. The format pattern should be in the format"
       + " expected by java.time.format.DateTimeFormatter")
   public String dateToString(
-      @UdfParameter(value = "epochDays",
+      @UdfParameter(
           description = "The Epoch Day to convert,"
               + " based on the epoch 1970-01-01") final int epochDays,
-      @UdfParameter(value = "formatPattern",
+      @UdfParameter(
           description = "The format pattern should be in the format expected by"
               + " java.time.format.DateTimeFormatter.") final String formatPattern) {
     try {

--- a/ksql-engine/src/main/java/io/confluent/ksql/function/udf/datetime/StringToDate.java
+++ b/ksql-engine/src/main/java/io/confluent/ksql/function/udf/datetime/StringToDate.java
@@ -41,9 +41,9 @@ public class StringToDate {
   @Udf(description = "Converts formattedDate, a string representation of a date into"
       + " an integer representing days since epoch using the given formatPattern.")
   public int stringToDate(
-      @UdfParameter(value = "formattedDate",
+      @UdfParameter(
           description = "The string representation of a date.") final String formattedDate,
-      @UdfParameter(value = "formatPattern",
+      @UdfParameter(
           description = "The format pattern should be in the format expected by"
               + " java.time.format.DateTimeFormatter.") final String formatPattern) {
     try {

--- a/ksql-engine/src/main/java/io/confluent/ksql/function/udf/datetime/StringToTimestamp.java
+++ b/ksql-engine/src/main/java/io/confluent/ksql/function/udf/datetime/StringToTimestamp.java
@@ -40,9 +40,9 @@ public class StringToTimestamp {
       + " Single quotes in the timestamp format can be escaped with '',"
       + " for example: 'yyyy-MM-dd''T''HH:mm:ssX'.")
   public long stringToTimestamp(
-      @UdfParameter(value = "formattedTimestamp",
+      @UdfParameter(
           description = "The string representation of a date.") final String formattedTimestamp,
-      @UdfParameter(value = "formatPattern",
+      @UdfParameter(
           description = "The format pattern should be in the format expected by"
               + " java.time.format.DateTimeFormatter.") final String formatPattern) {
     try {
@@ -60,12 +60,12 @@ public class StringToTimestamp {
       + " Single quotes in the timestamp format can be escaped with '',"
       + " for example: 'yyyy-MM-dd''T''HH:mm:ssX'.")
   public long stringToTimestamp(
-      @UdfParameter(value = "formattedTimestamp",
+      @UdfParameter(
           description = "The string representation of a date.") final String formattedTimestamp,
-      @UdfParameter(value = "formatPattern",
+      @UdfParameter(
           description = "The format pattern should be in the format expected by"
               + " java.time.format.DateTimeFormatter.") final String formatPattern,
-      @UdfParameter(value = "timeZone",
+      @UdfParameter(
           description =  " timeZone is a java.util.TimeZone ID format, for example: \"UTC\","
               + " \"America/Los_Angeles\", \"PDT\", \"Europe/London\"") final String timeZone) {
     try {

--- a/ksql-engine/src/main/java/io/confluent/ksql/function/udf/datetime/TimestampToString.java
+++ b/ksql-engine/src/main/java/io/confluent/ksql/function/udf/datetime/TimestampToString.java
@@ -43,10 +43,10 @@ public class TimestampToString {
       + " The format pattern should be in the format expected"
       + " by java.time.format.DateTimeFormatter")
   public String timestampToString(
-      @UdfParameter(value = "epochMilli",
+      @UdfParameter(
           description = "Milliseconds since"
               + " January 1, 1970, 00:00:00 GMT.") final long epochMilli,
-      @UdfParameter(value = "formatPattern",
+      @UdfParameter(
           description = "The format pattern should be in the format expected by"
               + " java.time.format.DateTimeFormatter.") final String formatPattern) {
     try {
@@ -67,13 +67,13 @@ public class TimestampToString {
       + " string representation of the timestamp in the given format. Single quotes in the"
       + " timestamp format can be escaped with '', for example: 'yyyy-MM-dd''T''HH:mm:ssX'")
   public String timestampToString(
-      @UdfParameter(value = "epochMilli",
+      @UdfParameter(
           description = "Milliseconds since"
               + " January 1, 1970, 00:00:00 GMT.") final long epochMilli,
-      @UdfParameter(value = "formatPattern",
+      @UdfParameter(
           description = "The format pattern should be in the format expected by"
               + " java.time.format.DateTimeFormatter.") final String formatPattern,
-      @UdfParameter(value = "timeZone",
+      @UdfParameter(
           description =  " timeZone is a java.util.TimeZone ID format, for example: \"UTC\","
               + " \"America/Los_Angeles\", \"PDT\", \"Europe/London\"") final String timeZone) {
     try {

--- a/ksql-engine/src/main/java/io/confluent/ksql/function/udf/string/SplitKudf.java
+++ b/ksql-engine/src/main/java/io/confluent/ksql/function/udf/string/SplitKudf.java
@@ -37,10 +37,10 @@ public class SplitKudf {
 
   @Udf(description = "Splits a string into an array of substrings based on a delimiter.")
   public List<String> split(
-      @UdfParameter(value = "string",
+      @UdfParameter(
           description = "The string to be split. If NULL, then function returns NULL.")
       final String string,
-      @UdfParameter(value = "delimiter",
+      @UdfParameter(
           description = "The delimiter to split a string by. If NULL, then function returns NULL.")
       final String delimiter) {
     if (string == null || delimiter == null) {

--- a/ksql-engine/src/main/java/io/confluent/ksql/function/udf/string/Substring.java
+++ b/ksql-engine/src/main/java/io/confluent/ksql/function/udf/string/Substring.java
@@ -47,9 +47,9 @@ public class Substring implements Configurable {
   @Udf(description = "Returns a substring of str that starts at pos"
       + " and continues to the end of the string")
   public String substring(
-      @UdfParameter(value = "str",
+      @UdfParameter(
           description = "The source string. If null, then function returns null.") final String str,
-      @UdfParameter(value = "pos",
+      @UdfParameter(
           description = "The base-one position the substring starts from."
               + " If null, then function returns null."
               + " (If in legacy mode, this argument is base-zero)") final Integer pos) {
@@ -58,13 +58,13 @@ public class Substring implements Configurable {
 
   @Udf(description = "Returns a substring of str that starts at pos and is of length len")
   public String substring(
-      @UdfParameter(value = "str",
+      @UdfParameter(
           description = "The source string. If null, then function returns null.") final String str,
-      @UdfParameter(value = "pos",
+      @UdfParameter(
           description = "The base-one position the substring starts from."
               + " If null, then function returns null."
               + " (If in legacy mode, this argument is base-zero)") final Integer pos,
-      @UdfParameter(value = "len",
+      @UdfParameter(
           description = "The length of the substring to extract."
               + " If null, then function returns null."
               + " (If in legacy mode, this argument is the endIndex (exclusive),"

--- a/ksql-engine/src/test/java/io/confluent/ksql/function/UdfLoaderTest.java
+++ b/ksql-engine/src/test/java/io/confluent/ksql/function/UdfLoaderTest.java
@@ -175,13 +175,19 @@ public class UdfLoaderTest {
   public void shouldSupportUdfParameterAnnotation() {
     final UdfFactory substring = metaStore.getUdfFactory("somefunction");
     final KsqlFunction function = substring.getFunction(
-        ImmutableList.of(Schema.OPTIONAL_STRING_SCHEMA, Schema.OPTIONAL_STRING_SCHEMA));
+        ImmutableList.of(
+            Schema.OPTIONAL_STRING_SCHEMA,
+            Schema.OPTIONAL_STRING_SCHEMA,
+            Schema.OPTIONAL_STRING_SCHEMA));
+
     final List<Schema> arguments = function.getArguments();
 
     assertThat(arguments.get(0).name(), is("justValue"));
     assertThat(arguments.get(0).doc(), is(""));
     assertThat(arguments.get(1).name(), is("valueAndDescription"));
     assertThat(arguments.get(1).doc(), is("Some description"));
+    assertThat(arguments.get(2).name(), is("noValue"));
+    assertThat(arguments.get(2).doc(), is(""));
   }
 
   @Test
@@ -353,9 +359,9 @@ public class UdfLoaderTest {
   public static class SomeFunctionUdf {
     @Udf
     public int foo(
-        @UdfParameter("justValue") final String v1,
-        @UdfParameter(value = "valueAndDescription",
-            description = "Some description") final String v2) {
+        @UdfParameter("justValue") final String v0,
+        @UdfParameter(value = "valueAndDescription", description = "Some description") final String v1,
+        @UdfParameter final String noValue) {
       return 0;
     }
   }

--- a/ksql-udf/src/main/java/io/confluent/ksql/function/udf/UdfParameter.java
+++ b/ksql-udf/src/main/java/io/confluent/ksql/function/udf/UdfParameter.java
@@ -25,13 +25,14 @@ import java.lang.annotation.Target;
  * Optionally, applied to @Udf function parameters.
  */
 public @interface UdfParameter {
+
   /**
    * The name of the parameter
    *
    * <p>This text is displayed when the user calls {@code DESCRIBE FUNCTION ...}.
    * @return parameter name.
    */
-  String value();
+  String value() default "";
 
   /**
    * The parameter description.


### PR DESCRIPTION
### Description 
If the class file was compiled with java8's `-parameter` flag, the name of the parameter will be inferred from the method declaration. This reduces clutter when reading/writing UDF classes.

### Testing done 
- Unit tests

### Reviewer checklist
- [ ] Ensure docs are updated if necessary. (eg. if a user visible feature is being added or changed).
- [ ] Ensure relevant issues are linked (description should include text like "Fixes #<issue number>")

