### PR TITLE
refine ownership model for ServiceContext

### DIFF
--- a/ksql-engine/src/main/java/io/confluent/ksql/QueryEngine.java
+++ b/ksql-engine/src/main/java/io/confluent/ksql/QueryEngine.java
@@ -52,15 +52,12 @@ class QueryEngine {
 
   private static final Logger LOG = LoggerFactory.getLogger(QueryEngine.class);
 
-  private final ServiceContext serviceContext;
   private final Consumer<QueryMetadata> queryCloseCallback;
   private final QueryIdGenerator queryIdGenerator;
 
   QueryEngine(
-      final ServiceContext serviceContext,
       final Consumer<QueryMetadata> queryCloseCallback
   ) {
-    this.serviceContext = Objects.requireNonNull(serviceContext, "serviceContext");
     this.queryCloseCallback = Objects.requireNonNull(queryCloseCallback, "queryCloseCallback");
     this.queryIdGenerator = new QueryIdGenerator();
   }
@@ -92,7 +89,8 @@ class QueryEngine {
       final KsqlConfig ksqlConfig,
       final Map<String, Object> overriddenProperties,
       final KafkaClientSupplier clientSupplier,
-      final MetaStore metaStore
+      final MetaStore metaStore,
+      final ServiceContext serviceContext
   ) {
 
     final StreamsBuilder builder = new StreamsBuilder();
@@ -110,7 +108,7 @@ class QueryEngine {
         queryCloseCallback
     );
 
-    return physicalPlanBuilder.buildPhysicalPlan(logicalPlanNode);
+    return physicalPlanBuilder.buildPhysicalPlan(logicalPlanNode, serviceContext);
   }
 
   @SuppressWarnings("MethodMayBeStatic") // To allow action to be mocked.

--- a/ksql-engine/src/main/java/io/confluent/ksql/ddl/commands/DdlCommandFactory.java
+++ b/ksql-engine/src/main/java/io/confluent/ksql/ddl/commands/DdlCommandFactory.java
@@ -15,6 +15,7 @@
 package io.confluent.ksql.ddl.commands;
 
 import io.confluent.ksql.parser.tree.DdlStatement;
+import io.confluent.ksql.services.ServiceContext;
 import java.util.Map;
 
 public interface DdlCommandFactory {
@@ -22,6 +23,7 @@ public interface DdlCommandFactory {
       String sqlExpression,
       DdlStatement ddlStatement,
       Map<String, Object> properties,
-      boolean enforceTopicExistence
+      boolean enforceTopicExistence,
+      ServiceContext serviceContext
   );
 }

--- a/ksql-engine/src/main/java/io/confluent/ksql/physical/PhysicalPlanBuilder.java
+++ b/ksql-engine/src/main/java/io/confluent/ksql/physical/PhysicalPlanBuilder.java
@@ -61,7 +61,6 @@ public class PhysicalPlanBuilder {
 
   private final StreamsBuilder builder;
   private final KsqlConfig ksqlConfig;
-  private final ServiceContext serviceContext;
   private final FunctionRegistry functionRegistry;
   private final Map<String, Object> overriddenProperties;
   private final MetaStore metaStore;
@@ -82,7 +81,6 @@ public class PhysicalPlanBuilder {
   ) {
     this.builder = Objects.requireNonNull(builder, "builder");
     this.ksqlConfig = Objects.requireNonNull(ksqlConfig, "ksqlConfig");
-    this.serviceContext = Objects.requireNonNull(serviceContext, "serviceContext");
     this.functionRegistry = Objects.requireNonNull(functionRegistry, "functionRegistry");
     this.overriddenProperties =
         Objects.requireNonNull(overriddenProperties, "overriddenProperties");
@@ -99,7 +97,9 @@ public class PhysicalPlanBuilder {
     throw new RuntimeException("Unexpected output node for query");
   }
 
-  public QueryMetadata buildPhysicalPlan(final LogicalPlanNode logicalPlanNode) {
+  public QueryMetadata buildPhysicalPlan(
+      final LogicalPlanNode logicalPlanNode,
+      final ServiceContext serviceContext) {
     final QueryId queryId = computeQueryId(logicalPlanNode.getNode());
     final SchemaKStream resultStream = logicalPlanNode
         .getNode()

--- a/ksql-engine/src/test/java/io/confluent/ksql/KsqlContextTest.java
+++ b/ksql-engine/src/test/java/io/confluent/ksql/KsqlContextTest.java
@@ -50,8 +50,6 @@ public class KsqlContextTest {
   public final ExpectedException expectedException = ExpectedException.none();
 
   @Mock
-  private ServiceContext serviceContext;
-  @Mock
   private KsqlEngine ksqlEngine;
   @Mock
   private PersistentQueryMetadata persistentQuery;
@@ -65,7 +63,7 @@ public class KsqlContextTest {
 
   @Before
   public void setUp() {
-    ksqlContext = new KsqlContext(serviceContext, SOME_CONFIG, ksqlEngine);
+    ksqlContext = new KsqlContext(SOME_CONFIG, ksqlEngine);
 
     when(ksqlEngine.parseStatements(any()))
         .thenReturn(ImmutableList.of(statement0));
@@ -196,13 +194,11 @@ public class KsqlContextTest {
   }
 
   @Test
-  public void shouldCloseEngineBeforeServiceContextOnClose() {
+  public void shouldCloseEngine() {
     // When:
     ksqlContext.close();
 
     // Then:
-    final InOrder inOrder = inOrder(ksqlEngine, serviceContext);
-    inOrder.verify(ksqlEngine).close();
-    inOrder.verify(serviceContext).close();
+    verify(ksqlEngine).close();
   }
 }

--- a/ksql-engine/src/test/java/io/confluent/ksql/KsqlContextTestUtil.java
+++ b/ksql-engine/src/test/java/io/confluent/ksql/KsqlContextTestUtil.java
@@ -15,6 +15,9 @@
 package io.confluent.ksql;
 
 import io.confluent.kafka.schemaregistry.client.SchemaRegistryClient;
+import io.confluent.ksql.function.InternalFunctionRegistry;
+import io.confluent.ksql.internal.KsqlEngineMetrics;
+import io.confluent.ksql.metastore.MetaStoreImpl;
 import io.confluent.ksql.services.KafkaTopicClient;
 import io.confluent.ksql.services.KafkaTopicClientImpl;
 import io.confluent.ksql.services.ServiceContext;
@@ -54,12 +57,12 @@ public final class KsqlContextTestUtil {
         () -> schemaRegistryClient
     );
 
-    final KsqlEngine engine = new KsqlEngine(
-        serviceContext,
-        ksqlConfig.getString(KsqlConfig.KSQL_SERVICE_ID_CONFIG)
-    );
+    final KsqlEngine engine = new KsqlEngine(serviceContext,
+                                             ksqlConfig.getString(KsqlConfig.KSQL_SERVICE_ID_CONFIG),
+                                             new MetaStoreImpl(new InternalFunctionRegistry()),
+                                             KsqlEngineMetrics::new);
 
-    return new KsqlContext(serviceContext, ksqlConfig, engine);
+    return new KsqlContext(ksqlConfig, engine);
   }
 
   public static KsqlConfig createKsqlConfig(final EmbeddedSingleNodeKafkaCluster kafkaCluster) {

--- a/ksql-engine/src/test/java/io/confluent/ksql/ddl/commands/CommandFactoriesTest.java
+++ b/ksql-engine/src/test/java/io/confluent/ksql/ddl/commands/CommandFactoriesTest.java
@@ -52,7 +52,7 @@ public class CommandFactoriesTest {
 
   private final KafkaTopicClient topicClient = EasyMock.createNiceMock(KafkaTopicClient.class);
   private final ServiceContext serviceContext = EasyMock.createNiceMock(ServiceContext.class);
-  private final CommandFactories commandFactories = new CommandFactories(serviceContext);
+  private final CommandFactories commandFactories = new CommandFactories();
   private final HashMap<String, Expression> properties = new HashMap<>();
 
 
@@ -76,7 +76,7 @@ public class CommandFactoriesTest {
   public void shouldCreateDDLCommandForRegisterTopic() {
     final DdlCommand result = commandFactories.create(
         sqlExpression, new RegisterTopic(QualifiedName.of("blah"),
-            true, properties), NO_PROPS, true);
+            true, properties), NO_PROPS, true, serviceContext);
 
     assertThat(result, instanceOf(RegisterTopicCommand.class));
   }
@@ -86,7 +86,7 @@ public class CommandFactoriesTest {
     final DdlCommand result = commandFactories.create(
         sqlExpression, new CreateStream(QualifiedName.of("foo"),
             Collections.emptyList(), true, properties),
-        NO_PROPS, true);
+        NO_PROPS, true, serviceContext);
 
     assertThat(result, instanceOf(CreateStreamCommand.class));
   }
@@ -97,7 +97,7 @@ public class CommandFactoriesTest {
 
     final DdlCommand result = commandFactories
         .create(sqlExpression, createTable(tableProperties),
-            NO_PROPS, true);
+            NO_PROPS, true, serviceContext);
 
     assertThat(result, instanceOf(CreateTableCommand.class));
   }
@@ -109,7 +109,7 @@ public class CommandFactoriesTest {
 
     try {
       commandFactories
-          .create(sqlExpression, createTable(tableProperties), NO_PROPS, true);
+          .create(sqlExpression, createTable(tableProperties), NO_PROPS, true, serviceContext);
 
     } catch (final KsqlException e) {
       assertThat(e.getMessage(), equalTo("No column with the provided key column name in the "
@@ -125,7 +125,7 @@ public class CommandFactoriesTest {
 
     try {
       commandFactories
-          .create(sqlExpression, createTable(tableProperties), NO_PROPS, true);
+          .create(sqlExpression, createTable(tableProperties), NO_PROPS, true, serviceContext);
 
     } catch (final KsqlException e) {
       assertThat(e.getMessage(), equalTo("No column with the provided timestamp column name in the WITH clause, COL3, exists in the defined schema."));
@@ -139,7 +139,7 @@ public class CommandFactoriesTest {
 
     try {
       commandFactories.create(sqlExpression, createTable(properties),
-          NO_PROPS, true);
+          NO_PROPS, true, serviceContext);
 
     } catch (final KsqlException e) {
       assertThat(e.getMessage(), equalTo("Cannot define a TABLE without providing the KEY column name in the WITH clause."));
@@ -154,7 +154,7 @@ public class CommandFactoriesTest {
 
     try {
       commandFactories.create(sqlExpression, createTable(tableProperties),
-          NO_PROPS, true);
+          NO_PROPS, true, serviceContext);
 
     } catch (final KsqlException e) {
       assertThat(e.getMessage(), equalTo("Kafka topic does not exist: topic"));
@@ -168,14 +168,14 @@ public class CommandFactoriesTest {
     givenTopicsDoNotExist();
 
     commandFactories
-        .create(sqlExpression, createTable(tableProperties), NO_PROPS, false);
+        .create(sqlExpression, createTable(tableProperties), NO_PROPS, false, serviceContext);
   }
 
   @Test
   public void shouldCreateCommandForDropStream() {
     final DdlCommand result = commandFactories.create(sqlExpression,
         new DropStream(QualifiedName.of("foo"), true, true),
-        NO_PROPS, true
+        NO_PROPS, true, serviceContext
     );
     assertThat(result, instanceOf(DropSourceCommand.class));
   }
@@ -184,7 +184,7 @@ public class CommandFactoriesTest {
   public void shouldCreateCommandForDropTable() {
     final DdlCommand result = commandFactories.create(sqlExpression,
         new DropTable(QualifiedName.of("foo"), true, true),
-        NO_PROPS, true
+        NO_PROPS, true, serviceContext
     );
     assertThat(result, instanceOf(DropSourceCommand.class));
   }
@@ -193,7 +193,7 @@ public class CommandFactoriesTest {
   public void shouldCreateCommandForDropTopic() {
     final DdlCommand result = commandFactories.create(sqlExpression,
         new DropTopic(QualifiedName.of("foo"), true),
-        NO_PROPS, true
+        NO_PROPS, true, serviceContext
     );
     assertThat(result, instanceOf(DropTopicCommand.class));
   }
@@ -201,7 +201,7 @@ public class CommandFactoriesTest {
   @Test(expected = KsqlException.class)
   public void shouldThowKsqlExceptionIfCommandFactoryNotFound() {
     commandFactories.create(sqlExpression, new ExecutableDdlStatement() {},
-        NO_PROPS, true);
+        NO_PROPS, true, serviceContext);
   }
 
   private HashMap<String, Expression> validTableProps() {

--- a/ksql-engine/src/test/java/io/confluent/ksql/integration/IntegrationTestHarness.java
+++ b/ksql-engine/src/test/java/io/confluent/ksql/integration/IntegrationTestHarness.java
@@ -530,7 +530,7 @@ public class IntegrationTestHarness extends ExternalResource {
     }
 
     public TestKsqlContext build() {
-      return new TestKsqlContext(IntegrationTestHarness.this, additionalConfig);
+      return new TestKsqlContext(IntegrationTestHarness.this, additionalConfig, serviceContext.get());
     }
   }
 

--- a/ksql-engine/src/test/java/io/confluent/ksql/integration/JsonFormatTest.java
+++ b/ksql-engine/src/test/java/io/confluent/ksql/integration/JsonFormatTest.java
@@ -81,7 +81,7 @@ public class JsonFormatTest {
 
     ksqlConfig = KsqlContextTestUtil.createKsqlConfig(CLUSTER);
     serviceContext = DefaultServiceContext.create(ksqlConfig);
-    ksqlEngine = new KsqlEngine(serviceContext, ksqlConfig.getString(KsqlConfig.KSQL_SERVICE_ID_CONFIG));
+    ksqlEngine = new KsqlEngine(ksqlConfig);
     topicClient = serviceContext.getTopicClient();
     metaStore = ksqlEngine.getMetaStore();
 

--- a/ksql-engine/src/test/java/io/confluent/ksql/integration/SecureIntegrationTest.java
+++ b/ksql-engine/src/test/java/io/confluent/ksql/integration/SecureIntegrationTest.java
@@ -269,7 +269,7 @@ public class SecureIntegrationTest {
   private void givenTestSetupWithConfig(final Map<String, Object> ksqlConfigs) {
     ksqlConfig = new KsqlConfig(ksqlConfigs);
     serviceContext = DefaultServiceContext.create(ksqlConfig);
-    ksqlEngine = new KsqlEngine(serviceContext, ksqlConfig.getString(KSQL_SERVICE_ID_CONFIG));
+    ksqlEngine = new KsqlEngine(ksqlConfig);
 
     execInitCreateStreamQueries();
   }

--- a/ksql-engine/src/test/java/io/confluent/ksql/integration/TestKsqlContext.java
+++ b/ksql-engine/src/test/java/io/confluent/ksql/integration/TestKsqlContext.java
@@ -32,18 +32,20 @@ public final class TestKsqlContext extends ExternalResource {
 
   private final IntegrationTestHarness testHarness;
   private final Map<String, Object> additionalConfig;
+  private final ServiceContext serviceContext;
   private KsqlContext delegate;
 
   TestKsqlContext(
       final IntegrationTestHarness testHarness,
-      final Map<String, Object> additionalConfig
-  ) {
+      final Map<String, Object> additionalConfig,
+      final ServiceContext serviceContext) {
     this.testHarness = Objects.requireNonNull(testHarness, "testHarness");
     this.additionalConfig = Objects.requireNonNull(additionalConfig, "additionalConfig");
+    this.serviceContext = serviceContext;
   }
 
   public ServiceContext getServiceContext() {
-    return delegate.getServiceContext();
+    return serviceContext;
   }
 
   public MetaStore getMetaStore() {

--- a/ksql-engine/src/test/java/io/confluent/ksql/physical/PhysicalPlanBuilderTest.java
+++ b/ksql-engine/src/test/java/io/confluent/ksql/physical/PhysicalPlanBuilderTest.java
@@ -170,7 +170,7 @@ public class PhysicalPlanBuilderTest {
 
   private QueryMetadata buildPhysicalPlan(final String query) {
     final PlanNode logical = planBuilder.buildLogicalPlan(query);
-    return physicalPlanBuilder.buildPhysicalPlan(new LogicalPlanNode(query, logical));
+    return physicalPlanBuilder.buildPhysicalPlan(new LogicalPlanNode(query, logical), serviceContext);
   }
 
   @Test

--- a/ksql-rest-app/src/main/java/io/confluent/ksql/rest/server/KsqlRestApplication.java
+++ b/ksql-rest-app/src/main/java/io/confluent/ksql/rest/server/KsqlRestApplication.java
@@ -298,16 +298,14 @@ public final class KsqlRestApplication extends Application<KsqlRestConfig> imple
     final String ksqlInstallDir = restConfig.getString(KsqlRestConfig.INSTALL_DIR_CONFIG);
 
     final KsqlConfig ksqlConfig = new KsqlConfig(restConfig.getKsqlConfigProperties());
-
-    final ServiceContext serviceContext = DefaultServiceContext.create(ksqlConfig);
-
-    final KsqlEngine ksqlEngine = new KsqlEngine(
-        serviceContext, ksqlConfig.getString(KsqlConfig.KSQL_SERVICE_ID_CONFIG));
+    final KsqlEngine ksqlEngine = new KsqlEngine(ksqlConfig);
 
     UdfLoader.newInstance(ksqlConfig, ksqlEngine.getFunctionRegistry(), ksqlInstallDir).load();
 
     final String ksqlServiceId = ksqlConfig.getString(KsqlConfig.KSQL_SERVICE_ID_CONFIG);
     final String commandTopic = KsqlRestConfig.getCommandTopic(ksqlServiceId);
+
+    final ServiceContext serviceContext = DefaultServiceContext.create(ksqlConfig);
     ensureCommandTopic(restConfig, serviceContext.getTopicClient(), commandTopic);
 
     final Map<String, Expression> commandTopicProperties = new HashMap<>();
@@ -363,8 +361,7 @@ public final class KsqlRestApplication extends Application<KsqlRestConfig> imple
         commandStore,
         ksqlConfig,
         ksqlEngine,
-        maxStatementRetries,
-        serviceContext
+        maxStatementRetries
     );
 
     final RootDocument rootDocument = new RootDocument();

--- a/ksql-rest-app/src/main/java/io/confluent/ksql/rest/server/StandaloneExecutor.java
+++ b/ksql-rest-app/src/main/java/io/confluent/ksql/rest/server/StandaloneExecutor.java
@@ -27,7 +27,6 @@ import io.confluent.ksql.parser.tree.QueryContainer;
 import io.confluent.ksql.parser.tree.SetProperty;
 import io.confluent.ksql.parser.tree.Statement;
 import io.confluent.ksql.parser.tree.UnsetProperty;
-import io.confluent.ksql.services.ServiceContext;
 import io.confluent.ksql.util.KsqlConfig;
 import io.confluent.ksql.util.KsqlException;
 import io.confluent.ksql.util.PersistentQueryMetadata;
@@ -73,7 +72,6 @@ public class StandaloneExecutor implements Executable {
               castHandler(StandaloneExecutor::handlePersistentQuery, InsertInto.class))
           .build();
 
-  private final ServiceContext serviceContext;
   private final KsqlConfig ksqlConfig;
   private final KsqlEngine ksqlEngine;
   private final String queriesFile;
@@ -84,7 +82,6 @@ public class StandaloneExecutor implements Executable {
   private final VersionCheckerAgent versionCheckerAgent;
 
   StandaloneExecutor(
-      final ServiceContext serviceContext,
       final KsqlConfig ksqlConfig,
       final KsqlEngine ksqlEngine,
       final String queriesFile,
@@ -92,7 +89,6 @@ public class StandaloneExecutor implements Executable {
       final boolean failOnNoQueries,
       final VersionCheckerAgent versionCheckerAgent
   ) {
-    this.serviceContext = Objects.requireNonNull(serviceContext, "serviceContext");
     this.ksqlConfig = Objects.requireNonNull(ksqlConfig, "ksqlConfig");
     this.ksqlEngine = Objects.requireNonNull(ksqlEngine, "ksqlEngine");
     this.queriesFile = Objects.requireNonNull(queriesFile, "queriesFile");
@@ -122,11 +118,6 @@ public class StandaloneExecutor implements Executable {
       ksqlEngine.close();
     } catch (final Exception e) {
       log.warn("Failed to cleanly shutdown the KSQL Engine", e);
-    }
-    try {
-      serviceContext.close();
-    } catch (final Exception e) {
-      log.warn("Failed to cleanly shutdown services", e);
     }
     shutdownLatch.countDown();
   }

--- a/ksql-rest-app/src/main/java/io/confluent/ksql/rest/server/StandaloneExecutorFactory.java
+++ b/ksql-rest-app/src/main/java/io/confluent/ksql/rest/server/StandaloneExecutorFactory.java
@@ -16,8 +16,6 @@ package io.confluent.ksql.rest.server;
 
 import io.confluent.ksql.KsqlEngine;
 import io.confluent.ksql.function.UdfLoader;
-import io.confluent.ksql.services.DefaultServiceContext;
-import io.confluent.ksql.services.ServiceContext;
 import io.confluent.ksql.util.KsqlConfig;
 import io.confluent.ksql.version.metrics.KsqlVersionCheckerAgent;
 import java.util.Properties;
@@ -33,16 +31,12 @@ public final class StandaloneExecutorFactory {
   ) {
     final KsqlConfig ksqlConfig = new KsqlConfig(properties);
 
-    final ServiceContext serviceContext = DefaultServiceContext.create(ksqlConfig);
-
-    final KsqlEngine ksqlEngine = new KsqlEngine(
-        serviceContext, ksqlConfig.getString(KsqlConfig.KSQL_SERVICE_ID_CONFIG));
+    final KsqlEngine ksqlEngine = new KsqlEngine(ksqlConfig);
 
     final UdfLoader udfLoader =
         UdfLoader.newInstance(ksqlConfig, ksqlEngine.getFunctionRegistry(), installDir);
 
     return new StandaloneExecutor(
-        serviceContext,
         ksqlConfig,
         ksqlEngine,
         queriesFile,

--- a/ksql-rest-app/src/main/java/io/confluent/ksql/rest/server/computation/CommandRunner.java
+++ b/ksql-rest-app/src/main/java/io/confluent/ksql/rest/server/computation/CommandRunner.java
@@ -18,7 +18,6 @@ import io.confluent.ksql.KsqlEngine;
 import io.confluent.ksql.rest.entity.ClusterTerminateRequest;
 import io.confluent.ksql.rest.util.ClusterTerminator;
 import io.confluent.ksql.rest.util.TerminateCluster;
-import io.confluent.ksql.services.ServiceContext;
 import io.confluent.ksql.util.KsqlConfig;
 import io.confluent.ksql.util.PersistentQueryMetadata;
 import io.confluent.ksql.util.RetryUtil;
@@ -56,15 +55,14 @@ public class CommandRunner implements Runnable, Closeable {
       final CommandQueue commandStore,
       final KsqlConfig ksqlConfig,
       final KsqlEngine ksqlEngine,
-      final int maxRetries,
-      final ServiceContext serviceContext
+      final int maxRetries
   ) {
     this(
         statementExecutor,
         commandStore,
         ksqlEngine,
         maxRetries,
-        new ClusterTerminator(ksqlConfig, ksqlEngine, serviceContext)
+        new ClusterTerminator(ksqlConfig, ksqlEngine)
     );
   }
 

--- a/ksql-rest-app/src/test/java/io/confluent/ksql/rest/server/StandaloneExecutorTest.java
+++ b/ksql-rest-app/src/test/java/io/confluent/ksql/rest/server/StandaloneExecutorTest.java
@@ -94,7 +94,7 @@ public class StandaloneExecutorTest {
     when(engine.execute(any(), any(), any())).thenReturn(Optional.of(queryMd));
 
     standaloneExecutor = new StandaloneExecutor(
-        serviceContext, ksqlConfig, engine, queriesFile.toString(), udfLoader,
+        ksqlConfig, engine, queriesFile.toString(), udfLoader,
         false, versionCheckerAgent);
   }
 
@@ -343,18 +343,9 @@ public class StandaloneExecutorTest {
     verify(engine).close();
   }
 
-  @Test
-  public void shouldCloseServiceContextOnStop() {
-    // When:
-    standaloneExecutor.stop();
-
-    // Then:
-    verify(serviceContext).close();
-  }
-
   private void givenExecutorWillFailOnNoQueries() {
     standaloneExecutor = new StandaloneExecutor(
-        serviceContext, ksqlConfig, engine, queriesFile.toString(), udfLoader, true, versionCheckerAgent);
+        ksqlConfig, engine, queriesFile.toString(), udfLoader, true, versionCheckerAgent);
   }
 
   private void givenFileContainsAPersistentQuery() {

--- a/ksql-rest-app/src/test/java/io/confluent/ksql/rest/server/computation/RecoveryTest.java
+++ b/ksql-rest-app/src/test/java/io/confluent/ksql/rest/server/computation/RecoveryTest.java
@@ -36,6 +36,7 @@ import io.confluent.ksql.rest.server.StatementParser;
 import io.confluent.ksql.rest.server.computation.CommandId.Action;
 import io.confluent.ksql.rest.server.computation.CommandId.Type;
 import io.confluent.ksql.rest.server.resources.KsqlResource;
+import io.confluent.ksql.rest.util.ClusterTerminator;
 import io.confluent.ksql.serde.KsqlTopicSerDe;
 import io.confluent.ksql.services.FakeKafkaTopicClient;
 import io.confluent.ksql.services.ServiceContext;
@@ -175,10 +176,9 @@ public class RecoveryTest {
       this.commandRunner = new CommandRunner(
           statementExecutor,
           fakeCommandQueue,
-          ksqlConfig,
           ksqlEngine,
           1,
-          serviceContext
+          new ClusterTerminator(ksqlConfig, ksqlEngine, serviceContext.getTopicClient())
       );
     }
 

--- a/ksql-rest-app/src/test/java/io/confluent/ksql/rest/util/ClusterTerminatorTest.java
+++ b/ksql-rest-app/src/test/java/io/confluent/ksql/rest/util/ClusterTerminatorTest.java
@@ -33,7 +33,6 @@ import io.confluent.ksql.KsqlEngine;
 import io.confluent.ksql.metastore.KsqlTopic;
 import io.confluent.ksql.metastore.MetaStore;
 import io.confluent.ksql.services.KafkaTopicClient;
-import io.confluent.ksql.services.ServiceContext;
 import io.confluent.ksql.util.KsqlConfig;
 import io.confluent.ksql.util.KsqlException;
 import io.confluent.ksql.util.PersistentQueryMetadata;
@@ -69,8 +68,6 @@ public class ClusterTerminatorTest {
   private PersistentQueryMetadata persistentQuery1;
   @Mock
   private MetaStore metaStore;
-  @Mock
-  private ServiceContext serviceContext;
 
   @Rule
   public ExpectedException expectedException = ExpectedException.none();
@@ -79,8 +76,7 @@ public class ClusterTerminatorTest {
 
   @Before
   public void setup() {
-    when(serviceContext.getTopicClient()).thenReturn(kafkaTopicClient);
-    clusterTerminator = new ClusterTerminator(ksqlConfig, ksqlEngine, serviceContext);
+    clusterTerminator = new ClusterTerminator(ksqlConfig, ksqlEngine, kafkaTopicClient);
     when(ksqlEngine.getMetaStore()).thenReturn(metaStore);
     when(ksqlConfig.getString(KsqlConfig.KSQL_SERVICE_ID_CONFIG)).thenReturn("command_topic");
     when(ksqlEngine.getPersistentQueries())


### PR DESCRIPTION
### Description 
This patch refines the ownership model for ServiceContext so that only `KafkaRestApplication` and `KsqlEngine` hold onto a reference to a ServiceContext beyond a local variable or parameter (as instance field). This sets us up to inject modified ServiceContexts as dependencies without having to track down ownership leaks.

There is one other small change: we create an `ExecutionContext` on each execution instead of holding one primary one around. This clarifies the distinction between `ServiceContext` (created once per service) and `ExecutionContext` (created once per execution).

### Testing done 
- Existing unit test coverage for modified code is high

### Reviewer checklist
- [ ] Ensure docs are updated if necessary. (eg. if a user visible feature is being added or changed).
- [ ] Ensure relevant issues are linked (description should include text like "Fixes #<issue number>")

