### PR TITLE
remove close callback in QueryMetadata

### DIFF
--- a/ksql-engine/src/main/java/io/confluent/ksql/KsqlContext.java
+++ b/ksql-engine/src/main/java/io/confluent/ksql/KsqlContext.java
@@ -124,6 +124,6 @@ public class KsqlContext {
   }
 
   public void terminateQuery(final QueryId queryId) {
-    ksqlEngine.getPersistentQuery(queryId).ifPresent(QueryMetadata::close);
+    ksqlEngine.getPersistentQuery(queryId).ifPresent(ksqlEngine::closeQuery);
   }
 }

--- a/ksql-engine/src/main/java/io/confluent/ksql/QueryEngine.java
+++ b/ksql-engine/src/main/java/io/confluent/ksql/QueryEngine.java
@@ -37,7 +37,6 @@ import io.confluent.ksql.util.QueryIdGenerator;
 import io.confluent.ksql.util.QueryMetadata;
 import java.util.Map;
 import java.util.Objects;
-import java.util.function.Consumer;
 import org.apache.kafka.common.serialization.Serdes;
 import org.apache.kafka.connect.data.Schema;
 import org.apache.kafka.connect.data.SchemaBuilder;
@@ -53,15 +52,12 @@ class QueryEngine {
   private static final Logger LOG = LoggerFactory.getLogger(QueryEngine.class);
 
   private final ServiceContext serviceContext;
-  private final Consumer<QueryMetadata> queryCloseCallback;
   private final QueryIdGenerator queryIdGenerator;
 
   QueryEngine(
-      final ServiceContext serviceContext,
-      final Consumer<QueryMetadata> queryCloseCallback
+      final ServiceContext serviceContext
   ) {
     this.serviceContext = Objects.requireNonNull(serviceContext, "serviceContext");
-    this.queryCloseCallback = Objects.requireNonNull(queryCloseCallback, "queryCloseCallback");
     this.queryIdGenerator = new QueryIdGenerator();
   }
 
@@ -106,8 +102,7 @@ class QueryEngine {
         overriddenProperties,
         metaStore,
         queryIdGenerator,
-        new KafkaStreamsBuilderImpl(clientSupplier),
-        queryCloseCallback
+        new KafkaStreamsBuilderImpl(clientSupplier)
     );
 
     return physicalPlanBuilder.buildPhysicalPlan(logicalPlanNode);

--- a/ksql-engine/src/main/java/io/confluent/ksql/physical/PhysicalPlanBuilder.java
+++ b/ksql-engine/src/main/java/io/confluent/ksql/physical/PhysicalPlanBuilder.java
@@ -46,8 +46,6 @@ import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
-import java.util.function.Consumer;
-
 import org.apache.kafka.clients.consumer.ConsumerConfig;
 import org.apache.kafka.clients.producer.ProducerConfig;
 import org.apache.kafka.connect.data.Field;
@@ -67,7 +65,6 @@ public class PhysicalPlanBuilder {
   private final MetaStore metaStore;
   private final QueryIdGenerator queryIdGenerator;
   private final KafkaStreamsBuilder kafkaStreamsBuilder;
-  private final Consumer<QueryMetadata> queryCloseCallback;
 
   public PhysicalPlanBuilder(
       final StreamsBuilder builder,
@@ -77,8 +74,7 @@ public class PhysicalPlanBuilder {
       final Map<String, Object> overriddenProperties,
       final MetaStore metaStore,
       final QueryIdGenerator queryIdGenerator,
-      final KafkaStreamsBuilder kafkaStreamsBuilder,
-      final Consumer<QueryMetadata> queryCloseCallback
+      final KafkaStreamsBuilder kafkaStreamsBuilder
   ) {
     this.builder = Objects.requireNonNull(builder, "builder");
     this.ksqlConfig = Objects.requireNonNull(ksqlConfig, "ksqlConfig");
@@ -89,7 +85,6 @@ public class PhysicalPlanBuilder {
     this.metaStore = Objects.requireNonNull(metaStore, "metaStore");
     this.queryIdGenerator = Objects.requireNonNull(queryIdGenerator, "queryIdGenerator");
     this.kafkaStreamsBuilder = Objects.requireNonNull(kafkaStreamsBuilder, "kafkaStreamsBuilder");
-    this.queryCloseCallback = Objects.requireNonNull(queryCloseCallback, "queryCloseCallback");
   }
 
   private QueryId computeQueryId(final PlanNode planNode) {
@@ -201,8 +196,7 @@ public class PhysicalPlanBuilder {
         applicationId,
         builder.build(),
         streamsProperties,
-        overriddenProperties,
-        queryCloseCallback
+        overriddenProperties
     );
   }
 
@@ -278,8 +272,7 @@ public class PhysicalPlanBuilder {
         sinkDataSource.getKsqlTopic(),
         topology,
         streamsProperties,
-        overriddenProperties,
-        queryCloseCallback
+        overriddenProperties
     );
   }
 

--- a/ksql-engine/src/main/java/io/confluent/ksql/util/PersistentQueryMetadata.java
+++ b/ksql-engine/src/main/java/io/confluent/ksql/util/PersistentQueryMetadata.java
@@ -23,7 +23,6 @@ import java.util.HashSet;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Set;
-import java.util.function.Consumer;
 import org.apache.kafka.streams.KafkaStreams;
 import org.apache.kafka.streams.Topology;
 
@@ -46,8 +45,7 @@ public class PersistentQueryMetadata extends QueryMetadata {
                                  final KsqlTopic resultTopic,
                                  final Topology topology,
                                  final Map<String, Object> streamsProperties,
-                                 final Map<String, Object> overriddenProperties,
-                                 final Consumer<QueryMetadata> closeCallback) {
+                                 final Map<String, Object> overriddenProperties) {
     // CHECKSTYLE_RULES.ON: ParameterNumberCheck
     super(
         statementString,
@@ -58,8 +56,8 @@ public class PersistentQueryMetadata extends QueryMetadata {
         queryApplicationId,
         topology,
         streamsProperties,
-        overriddenProperties,
-        closeCallback);
+        overriddenProperties
+    );
     this.id = Objects.requireNonNull(id, "id");
     this.resultTopic = Objects.requireNonNull(resultTopic, "resultTopic");
     this.sinkNames = new HashSet<>();

--- a/ksql-engine/src/main/java/io/confluent/ksql/util/QueryMetadata.java
+++ b/ksql-engine/src/main/java/io/confluent/ksql/util/QueryMetadata.java
@@ -24,7 +24,6 @@ import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
 import java.util.Set;
-import java.util.function.Consumer;
 import org.apache.kafka.connect.data.Schema;
 import org.apache.kafka.streams.KafkaStreams;
 import org.apache.kafka.streams.Topology;
@@ -44,7 +43,6 @@ public class QueryMetadata {
   private final Topology topoplogy;
   private final Map<String, Object> streamsProperties;
   private final Map<String, Object> overriddenProperties;
-  private final Consumer<QueryMetadata> closeCallback;
   private final Set<String> sourceNames;
 
   private Optional<QueryStateListener> queryStateListener = Optional.empty();
@@ -59,8 +57,7 @@ public class QueryMetadata {
       final String queryApplicationId,
       final Topology topoplogy,
       final Map<String, Object> streamsProperties,
-      final Map<String, Object> overriddenProperties,
-      final Consumer<QueryMetadata> closeCallback
+      final Map<String, Object> overriddenProperties
   ) {
     this.statementString = Objects.requireNonNull(statementString, "statementString");
     this.kafkaStreams = Objects.requireNonNull(kafkaStreams, "kafkaStreams");
@@ -75,7 +72,6 @@ public class QueryMetadata {
     this.overriddenProperties =
         ImmutableMap.copyOf(
             Objects.requireNonNull(overriddenProperties, "overriddenProperties"));
-    this.closeCallback = Objects.requireNonNull(closeCallback, "closeCallback");
 
     final PlanSourceExtractorVisitor<?, ?> visitor = new PlanSourceExtractorVisitor<>();
     visitor.process(outputNode, null);
@@ -145,8 +141,6 @@ public class QueryMetadata {
     kafkaStreams.cleanUp();
 
     queryStateListener.ifPresent(QueryStateListener::close);
-
-    closeCallback.accept(this);
   }
 
   public void start() {

--- a/ksql-engine/src/main/java/io/confluent/ksql/util/QueuedQueryMetadata.java
+++ b/ksql-engine/src/main/java/io/confluent/ksql/util/QueuedQueryMetadata.java
@@ -21,7 +21,6 @@ import java.util.Map;
 import java.util.Objects;
 import java.util.concurrent.BlockingQueue;
 import java.util.concurrent.atomic.AtomicBoolean;
-import java.util.function.Consumer;
 import org.apache.kafka.streams.KafkaStreams;
 import org.apache.kafka.streams.KeyValue;
 import org.apache.kafka.streams.Topology;
@@ -42,8 +41,7 @@ public class QueuedQueryMetadata extends QueryMetadata {
       final String queryApplicationId,
       final Topology topology,
       final Map<String, Object> streamsProperties,
-      final Map<String, Object> overriddenProperties,
-      final Consumer<QueryMetadata> closeCallback) {
+      final Map<String, Object> overriddenProperties) {
     // CHECKSTYLE_RULES.ON: ParameterNumberCheck
     super(
         statementString,
@@ -54,8 +52,8 @@ public class QueuedQueryMetadata extends QueryMetadata {
         queryApplicationId,
         topology,
         streamsProperties,
-        overriddenProperties,
-        closeCallback);
+        overriddenProperties
+    );
     this.rowQueue = Objects.requireNonNull(rowQueue, "rowQueue"); 
   }
 

--- a/ksql-engine/src/test/java/io/confluent/ksql/KsqlEngineTest.java
+++ b/ksql-engine/src/test/java/io/confluent/ksql/KsqlEngineTest.java
@@ -321,7 +321,7 @@ public class KsqlEngineTest {
             + "create table foo as select * from test2;",
         KSQL_CONFIG, Collections.emptyMap()).get(1);
 
-    secondQuery.close();
+    ksqlEngine.closeQuery(secondQuery);
 
     // When:
     KsqlEngineTestUtil.execute(ksqlEngine, "drop table foo;", KSQL_CONFIG, Collections.emptyMap());
@@ -486,7 +486,7 @@ public class KsqlEngineTest {
         "create stream bar with (value_format = 'avro') as select * from test1;",
         KSQL_CONFIG, Collections.emptyMap()).get(0);
 
-    query.close();
+    ksqlEngine.closeQuery(query);
 
     final Schema schema = SchemaBuilder
         .record("Test").fields()
@@ -511,7 +511,7 @@ public class KsqlEngineTest {
         "create table bar with (value_format = 'avro') as select * from test2;",
         KSQL_CONFIG, Collections.emptyMap()).get(0);
 
-    query.close();
+    ksqlEngine.closeQuery(query);
 
     final Schema schema = SchemaBuilder
         .record("Test").fields()
@@ -537,7 +537,7 @@ public class KsqlEngineTest {
         + "create stream foo as select * from test1;",
         KSQL_CONFIG, Collections.emptyMap()).get(0);
 
-    query.close();
+    ksqlEngine.closeQuery(query);
 
     final Schema schema = SchemaBuilder
         .record("Test").fields()
@@ -623,7 +623,7 @@ public class KsqlEngineTest {
         "create table bar with (value_format = 'avro') as select * from test2;",
         KSQL_CONFIG, Collections.emptyMap()).get(0);
 
-    query.close();
+    ksqlEngine.closeQuery(query);
 
     final Schema schema = SchemaBuilder
         .record("Test").fields()
@@ -650,7 +650,7 @@ public class KsqlEngineTest {
     query.start();
 
     // When:
-    query.close();
+    ksqlEngine.closeQuery(query);
 
     // Then:
     verify(topicClient).deleteInternalTopics(query.getQueryApplicationId());
@@ -664,7 +664,7 @@ public class KsqlEngineTest {
         KSQL_CONFIG, Collections.emptyMap()).get(0);
 
     // When:
-    query.close();
+    ksqlEngine.closeQuery(query);
 
     // Then:
     verify(topicClient, never()).deleteInternalTopics(any());
@@ -682,7 +682,7 @@ public class KsqlEngineTest {
 
 
     // When:
-    query.close();
+    ksqlEngine.closeQuery(query);
 
     // Then:
     assertThat(ksqlEngine.getPersistentQuery(getQueryId(query)), is(Optional.empty()));
@@ -700,7 +700,7 @@ public class KsqlEngineTest {
         KSQL_CONFIG, Collections.emptyMap()).get(0);
 
     // When:
-    query.close();
+    ksqlEngine.closeQuery(query);
 
     // Then:
     assertThat(ksqlEngine.numberOfLiveQueries(), is(startingLiveQueries));

--- a/ksql-engine/src/test/java/io/confluent/ksql/integration/JsonFormatTest.java
+++ b/ksql-engine/src/test/java/io/confluent/ksql/integration/JsonFormatTest.java
@@ -267,7 +267,7 @@ public class JsonFormatTest {
 
   private void terminateQuery() {
     ksqlEngine.getPersistentQuery(queryId)
-        .ifPresent(QueryMetadata::close);
+        .ifPresent(ksqlEngine::closeQuery);
   }
 
 }

--- a/ksql-engine/src/test/java/io/confluent/ksql/integration/SecureIntegrationTest.java
+++ b/ksql-engine/src/test/java/io/confluent/ksql/integration/SecureIntegrationTest.java
@@ -122,7 +122,7 @@ public class SecureIntegrationTest {
   public void after() {
     if (queryId != null) {
       ksqlEngine.getPersistentQuery(queryId)
-          .ifPresent(QueryMetadata::close);
+          .ifPresent(ksqlEngine::closeQuery);
     }
     if (ksqlEngine != null) {
       ksqlEngine.close();

--- a/ksql-engine/src/test/java/io/confluent/ksql/integration/WindowingIntTest.java
+++ b/ksql-engine/src/test/java/io/confluent/ksql/integration/WindowingIntTest.java
@@ -32,6 +32,7 @@ import io.confluent.ksql.services.KafkaTopicClient.TopicCleanupPolicy;
 import io.confluent.ksql.test.util.KsqlIdentifierTestUtil;
 import io.confluent.ksql.test.util.TopicTestUtil;
 import io.confluent.ksql.util.OrderDataProvider;
+import io.confluent.ksql.util.PersistentQueryMetadata;
 import io.confluent.ksql.util.QueryMetadata;
 import java.time.Duration;
 import java.util.Arrays;
@@ -228,7 +229,9 @@ public class WindowingIntTest {
   private void assertTopicsCleanedUp(final TopicCleanupPolicy topicCleanupPolicy) {
     assertThat("Initial topics", getTopicNames(), hasSize(5));
 
-    ksqlContext.getPersistentQueries().forEach(QueryMetadata::close);
+    ksqlContext.getPersistentQueries().stream()
+        .map(PersistentQueryMetadata::getQueryId)
+        .forEach(ksqlContext::terminateQuery);
 
     assertThatEventually("After cleanup", this::getTopicNames,
         containsInAnyOrder(resultStream0, resultStream1));

--- a/ksql-engine/src/test/java/io/confluent/ksql/physical/PhysicalPlanBuilderTest.java
+++ b/ksql-engine/src/test/java/io/confluent/ksql/physical/PhysicalPlanBuilderTest.java
@@ -163,8 +163,7 @@ public class PhysicalPlanBuilderTest {
         overrideProperties,
         metaStore,
         new QueryIdGenerator(),
-        testKafkaStreamsBuilder,
-        queryCloseCallback
+        testKafkaStreamsBuilder
     );
   }
 

--- a/ksql-engine/src/test/java/io/confluent/ksql/util/QueryMetadataTest.java
+++ b/ksql-engine/src/test/java/io/confluent/ksql/util/QueryMetadataTest.java
@@ -48,8 +48,6 @@ public class QueryMetadataTest {
   private KafkaStreams kafkaStreams;
   @Mock
   private QueryStateListener listener;
-  @Mock
-  private Consumer<QueryMetadata> closeCallback;
   private QueryMetadata query;
 
   @Before
@@ -63,8 +61,7 @@ public class QueryMetadataTest {
         QUERY_APPLICATION_ID,
         topoplogy,
         Collections.emptyMap(),
-        Collections.emptyMap(),
-        closeCallback
+        Collections.emptyMap()
     );
   }
 
@@ -117,14 +114,12 @@ public class QueryMetadataTest {
   }
 
   @Test
-  public void shouldCloseKStreamsAppOnCloseThenCloseCallback() {
+  public void shouldCloseKStreamsAppOnClose() {
     // When:
     query.close();
 
     // Then:
-    final InOrder inOrder = inOrder(kafkaStreams, closeCallback);
-    inOrder.verify(kafkaStreams).close();
-    inOrder.verify(closeCallback).accept(query);
+    verify(kafkaStreams).close();
   }
 
   @Test

--- a/ksql-rest-app/src/main/java/io/confluent/ksql/rest/server/resources/streaming/StreamPublisher.java
+++ b/ksql-rest-app/src/main/java/io/confluent/ksql/rest/server/resources/streaming/StreamPublisher.java
@@ -109,7 +109,7 @@ class StreamPublisher implements Flow.Publisher<Collection<StreamedRow>> {
       if (!closed) {
         closed = true;
         log.info("Terminating query {}", queryMetadata.getQueryApplicationId());
-        queryMetadata.close();
+        ksqlEngine.closeQuery(queryMetadata);
       }
     }
   }

--- a/ksql-rest-app/src/main/java/io/confluent/ksql/rest/server/resources/streaming/StreamedQueryResource.java
+++ b/ksql-rest-app/src/main/java/io/confluent/ksql/rest/server/resources/streaming/StreamedQueryResource.java
@@ -154,7 +154,8 @@ public class StreamedQueryResource {
     final QueryStreamWriter queryStreamWriter = new QueryStreamWriter(
         (QueuedQueryMetadata) query,
         disconnectCheckInterval.toMillis(),
-        objectMapper);
+        objectMapper,
+        ksqlEngine);
 
     log.info("Streaming query '{}'", statement.getStatementText());
     return Response.ok().entity(queryStreamWriter).build();

--- a/ksql-rest-app/src/main/java/io/confluent/ksql/rest/util/ClusterTerminator.java
+++ b/ksql-rest-app/src/main/java/io/confluent/ksql/rest/util/ClusterTerminator.java
@@ -22,7 +22,6 @@ import io.confluent.ksql.services.ServiceContext;
 import io.confluent.ksql.util.ExecutorUtil;
 import io.confluent.ksql.util.KsqlConfig;
 import io.confluent.ksql.util.KsqlException;
-import io.confluent.ksql.util.QueryMetadata;
 import java.util.Collections;
 import java.util.List;
 import java.util.Objects;
@@ -57,7 +56,7 @@ public class ClusterTerminator {
   }
 
   private void terminatePersistentQueries() {
-    ksqlEngine.getPersistentQueries().forEach(QueryMetadata::close);
+    ksqlEngine.getPersistentQueries().forEach(ksqlEngine::closeQuery);
   }
 
   private void deleteSinkTopics(final List<String> deleteTopicPatterns) {

--- a/ksql-rest-app/src/test/java/io/confluent/ksql/rest/entity/QueryDescriptionTest.java
+++ b/ksql-rest-app/src/test/java/io/confluent/ksql/rest/entity/QueryDescriptionTest.java
@@ -131,8 +131,8 @@ public class QueryDescriptionTest {
         "app id",
         topology,
         streamsProperties,
-        streamsProperties,
-        queryCloseCallback);
+        streamsProperties
+    );
 
     final QueryDescription queryDescription = QueryDescription.forQueryMetadata(queryMetadata);
 
@@ -176,8 +176,8 @@ public class QueryDescriptionTest {
         sinkTopic,
         topology,
         streamsProperties,
-        streamsProperties,
-        queryCloseCallback);
+        streamsProperties
+    );
     final QueryDescription queryDescription = QueryDescription.forQueryMetadata(queryMetadata);
     assertThat(queryDescription.getId().getId(), equalTo("query_id"));
     assertThat(queryDescription.getSinks(), equalTo(Collections.singleton("fake_sink")));

--- a/ksql-rest-app/src/test/java/io/confluent/ksql/rest/server/computation/StatementExecutorTest.java
+++ b/ksql-rest-app/src/test/java/io/confluent/ksql/rest/server/computation/StatementExecutorTest.java
@@ -28,6 +28,8 @@ import static org.hamcrest.Matchers.containsInAnyOrder;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.not;
 import static org.hamcrest.Matchers.notNullValue;
+import static org.mockito.Mockito.doNothing;
+import static org.mockito.Mockito.when;
 
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSet;
@@ -63,11 +65,13 @@ import io.confluent.ksql.util.KsqlConfig;
 import io.confluent.ksql.util.KsqlConstants;
 import io.confluent.ksql.util.Pair;
 import io.confluent.ksql.util.PersistentQueryMetadata;
+import io.confluent.ksql.util.QueryMetadata;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+import org.easymock.EasyMock;
 import org.easymock.EasyMockSupport;
 import org.easymock.IArgumentMatcher;
 import org.hamcrest.CoreMatchers;
@@ -577,6 +581,8 @@ public class StatementExecutorTest extends EasyMockSupport {
     expect(mockEngine.getMetaStore()).andStubReturn(mockMetaStore);
     expect(mockEngine.getPersistentQuery(new QueryId("query-id"))).andReturn(Optional.of(mockQueryMetadata));
     mockQueryMetadata.close();
+    expectLastCall();
+    mockEngine.closeQuery(EasyMock.anyObject(QueryMetadata.class));
     expectLastCall();
     expect(mockEngine.executeDdlStatement("DROP", mockDropStream, Collections.emptyMap()))
         .andReturn(new DdlCommandResult(true, "SUCCESS"));

--- a/ksql-rest-app/src/test/java/io/confluent/ksql/rest/server/resources/streaming/QueryStreamWriterTest.java
+++ b/ksql-rest-app/src/test/java/io/confluent/ksql/rest/server/resources/streaming/QueryStreamWriterTest.java
@@ -178,7 +178,7 @@ public class QueryStreamWriterTest {
   private void createWriter() {
     replay(queryMetadata, ksqlEngine, rowQueue);
 
-    writer = new QueryStreamWriter(queryMetadata, 1000, objectMapper);
+    writer = new QueryStreamWriter(queryMetadata, 1000, objectMapper, ksqlEngine);
 
     out = new ByteArrayOutputStream();
     limitHandler = limitHandlerCapture.getValue();

--- a/ksql-rest-app/src/test/java/io/confluent/ksql/rest/util/ClusterTerminatorTest.java
+++ b/ksql-rest-app/src/test/java/io/confluent/ksql/rest/util/ClusterTerminatorTest.java
@@ -37,6 +37,7 @@ import io.confluent.ksql.services.ServiceContext;
 import io.confluent.ksql.util.KsqlConfig;
 import io.confluent.ksql.util.KsqlException;
 import io.confluent.ksql.util.PersistentQueryMetadata;
+import io.confluent.ksql.util.QueryMetadata;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.Map;
@@ -85,6 +86,10 @@ public class ClusterTerminatorTest {
     when(ksqlConfig.getString(KsqlConfig.KSQL_SERVICE_ID_CONFIG)).thenReturn("command_topic");
     when(ksqlEngine.getPersistentQueries())
         .thenReturn(ImmutableList.of(persistentQuery0, persistentQuery1));
+    Mockito.doAnswer(invocation -> {
+      ((QueryMetadata) invocation.getArgument(0)).close();
+      return null;
+    }).when(ksqlEngine).closeQuery(Mockito.any());
   }
 
   @Test


### PR DESCRIPTION
### Description 
Instead of passing in a callback, call the method directly on the instance of `ksqlEngine` wherever close is called. This is to prevent unnecessary leaking of upwards references to `KsqlEngine` and will allow us to move ownership of ServiceContext up to the top-level (extension of #2394)

### Testing done 
Existing test coverage.

### Reviewer checklist
- [ ] Ensure docs are updated if necessary. (eg. if a user visible feature is being added or changed).
- [ ] Ensure relevant issues are linked (description should include text like "Fixes #<issue number>")

