### PR TITLE
fix flaky retention bug in WindowingIntTest

### DIFF
--- a/ksql-cli/src/test/java/io/confluent/ksql/cli/BasicAuthFunctionalTest.java
+++ b/ksql-cli/src/test/java/io/confluent/ksql/cli/BasicAuthFunctionalTest.java
@@ -222,7 +222,6 @@ public class BasicAuthFunctionalTest {
 
     @OnWebSocketConnect
     public void onConnect(final Session session) {
-      session.close();
       latch.countDown();
     }
 

--- a/ksql-engine/src/test/java/io/confluent/ksql/integration/WindowingIntTest.java
+++ b/ksql-engine/src/test/java/io/confluent/ksql/integration/WindowingIntTest.java
@@ -68,9 +68,9 @@ public class WindowingIntTest {
 
   private static final Duration VERIFY_TIMEOUT = Duration.ofSeconds(60);
 
-  private long batch0SentMs;
-  private long batch1Delay;
-  private long tenSecWindowStartMs;
+  private final long batch0SentMs;
+  private final long batch1Delay;
+  private final long tenSecWindowStartMs;
 
   @ClassRule
   public static final IntegrationTestHarness TEST_HARNESS = IntegrationTestHarness.build();
@@ -85,15 +85,17 @@ public class WindowingIntTest {
   private Set<String> preExistingTopics;
   private KafkaTopicClient topicClient;
 
-  @Before
-  public void before() {
+  public WindowingIntTest() {
     final long currentTimeMillis = System.currentTimeMillis();
-
     // set the batch to be in the middle of a ten second window
     batch0SentMs = currentTimeMillis - (currentTimeMillis % TimeUnit.SECONDS.toMillis(10)) + (5001);
     tenSecWindowStartMs = batch0SentMs - (batch0SentMs % TimeUnit.SECONDS.toMillis(10));
     batch1Delay = 500;
 
+  }
+
+  @Before
+  public void before() {
     topicClient = ksqlContext.getServiceContext().getTopicClient();
 
     UdfLoaderUtil.load(ksqlContext.getFunctionRegistry());


### PR DESCRIPTION
### Description 
This fixes the flakiness of `WindowingIntTest`, which used to produce records with a fixed timestamp that resolved to `Sunday, September 9, 2001 1:46:45.001 AM`. This caused issues because topic retention defaults to 7 days and log compaction could happen while we were running the test, thereby deleting the messages before we could poll them. This fix dynamically assigns a time that ensures the messages are not cleaned up.

- I tried to change the topic retention to infinite for the orders stream, but the problem is that KStreams creates some of the internal topics and piping through that config would be out of scope. 
- I also tried setting the config to use the time it was appended to the log instead of produce record timestamp, but this breaks the unit tests that verify timestamps/rolling windows.

### Testing done 
Ran the test on repeat - passed a few hundred times consecutively. 

### Reviewer checklist
- [ ] Ensure docs are updated if necessary. (eg. if a user visible feature is being added or changed).
- [ ] Ensure relevant issues are linked (description should include text like "Fixes #<issue number>")

