### PR TITLE
Support LIMIT clause for PRINT statements. Resolves #1316

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -7,6 +7,7 @@ Version 5.2.0
 KSQL 5.2 includes new features, including:
 
 * Added a new family of UDFs for improved handling of URIs (e.g. extracting information/decoding information), see :ref:`UDF table <functions>` for all URL functions
+* Added ``LIMIT`` keyword support for ``PRINT`` (`#1316 <https://github.com/confluentinc/ksql/issues/1316>`_)
 
 KSQL 5.2 includes bug fixes, including:
 

--- a/docs/developer-guide/syntax-reference.rst
+++ b/docs/developer-guide/syntax-reference.rst
@@ -776,7 +776,7 @@ PRINT
 
 .. code:: sql
 
-    PRINT qualifiedName [FROM BEGINNING] [INTERVAL]
+    PRINT qualifiedName [FROM BEGINNING] [INTERVAL] [LIMIT]
 
 **Description**
 
@@ -792,6 +792,8 @@ The PRINT statement supports the following properties:
 | FROM BEGINNING          | Print starting with the first message in the topic. If not specified, PRINT starts with the most recent message. |
 +-------------------------+------------------------------------------------------------------------------------------------------------------+
 | INTERVAL                | Print every nth message. The default is 1, meaning that every message is printed.                                |
++-------------------------+------------------------------------------------------------------------------------------------------------------+
+| LIMIT                   | Stop printing after n messages. The default is to never stop printing and requires ^C to terminate.              |
 +-------------------------+------------------------------------------------------------------------------------------------------------------+
 
 For example:

--- a/docs/developer-guide/syntax-reference.rst
+++ b/docs/developer-guide/syntax-reference.rst
@@ -793,7 +793,7 @@ The PRINT statement supports the following properties:
 +-------------------------+------------------------------------------------------------------------------------------------------------------+
 | INTERVAL                | Print every nth message. The default is 1, meaning that every message is printed.                                |
 +-------------------------+------------------------------------------------------------------------------------------------------------------+
-| LIMIT                   | Stop printing after n messages. The default is to never stop printing and requires ^C to terminate.              |
+| LIMIT                   | Stop printing after n messages. The default is to never stop printing and requires Ctrl+C to terminate.          |
 +-------------------------+------------------------------------------------------------------------------------------------------------------+
 
 For example:

--- a/docs/developer-guide/syntax-reference.rst
+++ b/docs/developer-guide/syntax-reference.rst
@@ -793,8 +793,7 @@ The PRINT statement supports the following properties:
 +-------------------------+------------------------------------------------------------------------------------------------------------------+
 | INTERVAL interval       | Print every ``interval``th message. The default is 1, meaning that every message is printed.                     |
 +-------------------------+------------------------------------------------------------------------------------------------------------------+
-| LIMIT limit             | Stop printing after ``limit`` messages. The default value, ``ALL``, will never stop printing and requires Ctrl+C |
-|                         | to terminate.                                                                                                    |
+| LIMIT limit             | Stop printing after ``limit`` messages. The default value is unlimited, requiring Ctrl+C to terminate the query. |
 +-------------------------+------------------------------------------------------------------------------------------------------------------+
 
 For example:

--- a/docs/developer-guide/syntax-reference.rst
+++ b/docs/developer-guide/syntax-reference.rst
@@ -776,7 +776,7 @@ PRINT
 
 .. code:: sql
 
-    PRINT qualifiedName [FROM BEGINNING] [INTERVAL] [LIMIT]
+    PRINT qualifiedName [FROM BEGINNING] [INTERVAL interval] [LIMIT limit]
 
 **Description**
 
@@ -791,9 +791,10 @@ The PRINT statement supports the following properties:
 +=========================+==================================================================================================================+
 | FROM BEGINNING          | Print starting with the first message in the topic. If not specified, PRINT starts with the most recent message. |
 +-------------------------+------------------------------------------------------------------------------------------------------------------+
-| INTERVAL                | Print every nth message. The default is 1, meaning that every message is printed.                                |
+| INTERVAL interval       | Print every ``interval``th message. The default is 1, meaning that every message is printed.                     |
 +-------------------------+------------------------------------------------------------------------------------------------------------------+
-| LIMIT                   | Stop printing after n messages. The default is to never stop printing and requires Ctrl+C to terminate.          |
+| LIMIT limit             | Stop printing after ``limit`` messages. The default value, ``ALL``, will never stop printing and requires Ctrl+C |
+|                         | to terminate.                                                                                                    |
 +-------------------------+------------------------------------------------------------------------------------------------------------------+
 
 For example:

--- a/ksql-engine/src/main/java/io/confluent/ksql/KsqlEngine.java
+++ b/ksql-engine/src/main/java/io/confluent/ksql/KsqlEngine.java
@@ -728,7 +728,7 @@ public class KsqlEngine implements KsqlExecutionContext, Closeable {
     private static Query addInto(
         final QuerySpecification querySpecification,
         final String intoName,
-        final Optional<String> limit,
+        final Optional<Integer> limit,
         final Map<String, Expression> intoProperties,
         final Optional<Expression> partitionByExpression,
         final boolean doCreateTable) {

--- a/ksql-engine/src/main/java/io/confluent/ksql/KsqlEngine.java
+++ b/ksql-engine/src/main/java/io/confluent/ksql/KsqlEngine.java
@@ -76,6 +76,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
+import java.util.OptionalInt;
 import java.util.Set;
 import java.util.concurrent.Executors;
 import java.util.concurrent.ScheduledExecutorService;
@@ -728,7 +729,7 @@ public class KsqlEngine implements KsqlExecutionContext, Closeable {
     private static Query addInto(
         final QuerySpecification querySpecification,
         final String intoName,
-        final Optional<Integer> limit,
+        final OptionalInt limit,
         final Map<String, Expression> intoProperties,
         final Optional<Expression> partitionByExpression,
         final boolean doCreateTable) {

--- a/ksql-engine/src/main/java/io/confluent/ksql/analyzer/Analyzer.java
+++ b/ksql-engine/src/main/java/io/confluent/ksql/analyzer/Analyzer.java
@@ -111,25 +111,13 @@ public class Analyzer extends DefaultTraversalVisitor<Node, AnalysisContext> {
 
     process(node.getSelect(), new AnalysisContext(
         AnalysisContext.ParentType.SELECT));
-    if (node.getWhere().isPresent()) {
-      analyzeWhere(node.getWhere().get());
-    }
-    if (node.getGroupBy().isPresent()) {
-      analyzeGroupBy(node.getGroupBy().get());
-    }
 
-    if (node.getWindowExpression().isPresent()) {
-      analyzeWindowExpression(node.getWindowExpression().get());
-    }
+    node.getWhere().ifPresent(this::analyzeWhere);
+    node.getGroupBy().ifPresent(this::analyzeGroupBy);
+    node.getWindowExpression().ifPresent(this::analyzeWindowExpression);
+    node.getHaving().ifPresent(this::analyzeHaving);
+    node.getLimit().ifPresent(analysis::setLimitClause);
 
-    if (node.getHaving().isPresent()) {
-      analyzeHaving(node.getHaving().get());
-    }
-
-    if (node.getLimit().isPresent()) {
-      final String limitStr = node.getLimit().get();
-      analysis.setLimitClause(Integer.parseInt(limitStr));
-    }
     analyzeExpressions();
 
     return null;

--- a/ksql-parser/pom.xml
+++ b/ksql-parser/pom.xml
@@ -54,6 +54,11 @@
             <artifactId>antlr4-runtime</artifactId>
         </dependency>
 
+        <dependency>
+            <groupId>org.apache.commons</groupId>
+            <artifactId>commons-lang3</artifactId>
+        </dependency>
+
         <!-- Required for running tests -->
 
         <dependency>

--- a/ksql-parser/src/main/antlr4/io/confluent/ksql/parser/SqlBase.g4
+++ b/ksql-parser/src/main/antlr4/io/confluent/ksql/parser/SqlBase.g4
@@ -87,14 +87,22 @@ tableProperty
 
 queryNoWith:
       queryTerm
-      (LIMIT limit=(INTEGER_VALUE | ALL))?
+      limitClause
     ;
 
 printClause
       : (FROM BEGINNING)?
-      ((INTERVAL | SAMPLE) number)?
-      (LIMIT limit=(INTEGER_VALUE | ALL))?
+      intervalClause
+      limitClause
       ;
+
+intervalClause
+    : ((INTERVAL | SAMPLE) number)?
+    ;
+
+limitClause
+    : (LIMIT number)?
+    ;
 
 queryTerm
     : queryPrimary                                                             #queryTermDefault
@@ -334,7 +342,6 @@ nonReserved
 SELECT: 'SELECT';
 FROM: 'FROM';
 AS: 'AS';
-ALL: 'ALL';
 DISTINCT: 'DISTINCT';
 WHERE: 'WHERE';
 WITHIN: 'WITHIN';

--- a/ksql-parser/src/main/antlr4/io/confluent/ksql/parser/SqlBase.g4
+++ b/ksql-parser/src/main/antlr4/io/confluent/ksql/parser/SqlBase.g4
@@ -35,13 +35,13 @@ statement
     | (LIST | SHOW) PROPERTIES                                              #listProperties
     | (LIST | SHOW) TOPICS                                                  #listTopics
     | (LIST | SHOW) REGISTERED TOPICS                                       #listRegisteredTopics
-    | (LIST | SHOW) STREAMS EXTENDED?                                   #listStreams
-    | (LIST | SHOW) TABLES EXTENDED?                                    #listTables
-    | (LIST | SHOW) FUNCTIONS                                            #listFunctions
+    | (LIST | SHOW) STREAMS EXTENDED?                                       #listStreams
+    | (LIST | SHOW) TABLES EXTENDED?                                        #listTables
+    | (LIST | SHOW) FUNCTIONS                                               #listFunctions
     | DESCRIBE EXTENDED? (qualifiedName | TOPIC qualifiedName)              #showColumns
     | DESCRIBE FUNCTION qualifiedName                                       #describeFunction
-    | PRINT (qualifiedName | STRING) (FROM BEGINNING)? ((INTERVAL | SAMPLE) number)?   #printTopic
-    | (LIST | SHOW) QUERIES EXTENDED?                                   #listQueries
+    | PRINT (qualifiedName | STRING) printClause                            #printTopic
+    | (LIST | SHOW) QUERIES EXTENDED?                                       #listQueries
     | TERMINATE QUERY? qualifiedName                                        #terminateQuery
     | SET STRING EQ STRING                                                  #setProperty
     | UNSET STRING                                                          #unsetProperty
@@ -61,8 +61,8 @@ statement
             (WITH tableProperties)? AS query                                #createTableAs
     | INSERT INTO qualifiedName query (PARTITION BY identifier)?            #insertInto
     | DROP TOPIC (IF EXISTS)? qualifiedName                                 #dropTopic
-    | DROP STREAM (IF EXISTS)? qualifiedName (DELETE TOPIC)?                  #dropStream
-    | DROP TABLE (IF EXISTS)? qualifiedName  (DELETE TOPIC)?                  #dropTable
+    | DROP STREAM (IF EXISTS)? qualifiedName (DELETE TOPIC)?                #dropStream
+    | DROP TABLE (IF EXISTS)? qualifiedName  (DELETE TOPIC)?                #dropTable
     | EXPLAIN ANALYZE?
             (statement | qualifiedName)         #explain
     | EXPORT CATALOG TO STRING                                              #exportCatalog
@@ -89,6 +89,12 @@ queryNoWith:
       queryTerm
       (LIMIT limit=(INTEGER_VALUE | ALL))?
     ;
+
+printClause
+      : (FROM BEGINNING)?
+      ((INTERVAL | SAMPLE) number)?
+      (LIMIT limit=(INTEGER_VALUE | ALL))?
+      ;
 
 queryTerm
     : queryPrimary                                                             #queryTermDefault

--- a/ksql-parser/src/main/java/io/confluent/ksql/parser/AstBuilder.java
+++ b/ksql-parser/src/main/java/io/confluent/ksql/parser/AstBuilder.java
@@ -127,6 +127,7 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+import java.util.OptionalInt;
 import java.util.concurrent.TimeUnit;
 import org.antlr.v4.runtime.ParserRuleContext;
 import org.antlr.v4.runtime.Token;
@@ -327,9 +328,9 @@ public class AstBuilder extends SqlBaseBaseVisitor<Node> {
     final QueryBody term = (QueryBody) visit(context.queryTerm());
 
     final NumberContext limitContext = context.limitClause().number();
-    final Optional<Integer> limit = (limitContext == null)
-        ? Optional.empty()
-        : Optional.of(processIntegerNumber(limitContext, "QUERY"));
+    final OptionalInt limit = (limitContext == null)
+        ? OptionalInt.empty()
+        : OptionalInt.of(processIntegerNumber(limitContext, "LIMIT"));
 
     if (term instanceof QuerySpecification) {
       // When we have a simple query specification
@@ -352,7 +353,7 @@ public class AstBuilder extends SqlBaseBaseVisitor<Node> {
               query.getHaving(),
               limit
           ),
-          Optional.empty()
+          OptionalInt.empty()
       );
     }
 
@@ -399,7 +400,7 @@ public class AstBuilder extends SqlBaseBaseVisitor<Node> {
         visitIfPresent(context.where, Expression.class),
         visitIfPresent(context.groupBy(), GroupBy.class),
         visitIfPresent(context.having, Expression.class),
-        Optional.empty()
+        OptionalInt.empty()
     );
   }
 
@@ -778,14 +779,14 @@ public class AstBuilder extends SqlBaseBaseVisitor<Node> {
     }
 
     final NumberContext intervalContext = context.printClause().intervalClause().number();
-    final Optional<Integer> interval = (intervalContext == null)
-        ? Optional.empty()
-        : Optional.of(processIntegerNumber(intervalContext, "PRINT"));
+    final OptionalInt interval = (intervalContext == null)
+        ? OptionalInt.empty()
+        : OptionalInt.of(processIntegerNumber(intervalContext, "INTERVAL"));
 
     final NumberContext limitContext = context.printClause().limitClause().number();
-    final Optional<Integer> limit = (limitContext == null)
-        ? Optional.empty()
-        : Optional.of(processIntegerNumber(limitContext, "PRINT"));
+    final OptionalInt limit = (limitContext == null)
+        ? OptionalInt.empty()
+        : OptionalInt.of(processIntegerNumber(limitContext, "LIMIT"));
 
     return new PrintTopic(
         getLocation(context),
@@ -796,11 +797,11 @@ public class AstBuilder extends SqlBaseBaseVisitor<Node> {
     );
   }
 
-  private Integer processIntegerNumber(final NumberContext number, final String context) {
+  private int processIntegerNumber(final NumberContext number, final String context) {
     if (number instanceof SqlBaseParser.IntegerLiteralContext) {
       return ((IntegerLiteral) visitIntegerLiteral((IntegerLiteralContext) number)).getValue();
     }
-    throw new KsqlException("Interval value must be integer in for command: '" + context);
+    throw new KsqlException("Value must be integer in for command: " + context);
   }
 
   @Override

--- a/ksql-parser/src/main/java/io/confluent/ksql/parser/AstBuilder.java
+++ b/ksql-parser/src/main/java/io/confluent/ksql/parser/AstBuilder.java
@@ -761,30 +761,35 @@ public class AstBuilder extends SqlBaseBaseVisitor<Node> {
 
   @Override
   public Node visitPrintTopic(final SqlBaseParser.PrintTopicContext context) {
-    final boolean fromBeginning = context.FROM() != null;
+    final boolean fromBeginning = context.printClause().FROM() != null;
 
-    QualifiedName topicName = null;
+    final QualifiedName topicName;
     if (context.STRING() != null) {
       topicName = QualifiedName.of(unquote(context.STRING().getText(), "'"));
     } else {
       topicName = getQualifiedName(context.qualifiedName());
     }
-    if (context.number() == null) {
+
+    final Optional<String> limit = getTextIfPresent(context.printClause().limit);
+
+    if (context.printClause().number() == null) {
       return new PrintTopic(
           getLocation(context),
           topicName,
           fromBeginning,
-          Optional.empty()
+          Optional.empty(),
+          limit
       );
-    } else if (context.number() instanceof SqlBaseParser.IntegerLiteralContext) {
+    } else if (context.printClause().number() instanceof SqlBaseParser.IntegerLiteralContext) {
       final SqlBaseParser.IntegerLiteralContext integerLiteralContext =
-          (SqlBaseParser.IntegerLiteralContext) context.number();
+          (SqlBaseParser.IntegerLiteralContext) context.printClause().number();
       final IntegerLiteral literal = (IntegerLiteral) visitIntegerLiteral(integerLiteralContext);
       return new PrintTopic(
           getLocation(context),
           topicName,
           fromBeginning,
-          Optional.of(literal.getValue())
+          Optional.of(literal.getValue()),
+          limit
       );
     } else {
       throw new KsqlException("Interval value should be integer in 'PRINT' command!");

--- a/ksql-parser/src/main/java/io/confluent/ksql/parser/SqlFormatter.java
+++ b/ksql-parser/src/main/java/io/confluent/ksql/parser/SqlFormatter.java
@@ -117,7 +117,7 @@ public final class SqlFormatter {
       processRelation(node.getQueryBody(), indent);
 
       if (node.getLimit().isPresent()) {
-        append(indent, "LIMIT " + node.getLimit().get())
+        append(indent, "LIMIT " + node.getLimit().getAsInt())
                 .append('\n');
       }
 
@@ -155,7 +155,7 @@ public final class SqlFormatter {
       }
 
       if (node.getLimit().isPresent()) {
-        append(indent, "LIMIT " + node.getLimit().get())
+        append(indent, "LIMIT " + node.getLimit().getAsInt())
                 .append('\n');
       }
       return null;

--- a/ksql-parser/src/main/java/io/confluent/ksql/parser/tree/PrintTopic.java
+++ b/ksql-parser/src/main/java/io/confluent/ksql/parser/tree/PrintTopic.java
@@ -20,7 +20,6 @@ import static java.util.Objects.requireNonNull;
 import java.util.Objects;
 import java.util.Optional;
 import java.util.OptionalInt;
-import org.apache.commons.lang3.StringUtils;
 
 public class PrintTopic extends Statement {
 
@@ -35,9 +34,9 @@ public class PrintTopic extends Statement {
       final QualifiedName topic,
       final boolean fromBeginning,
       final Optional<Integer> intervalValue,
-      final Optional<String> limit
+      final Optional<Integer> limitValue
   ) {
-    this(Optional.of(location), topic, fromBeginning, intervalValue, limit);
+    this(Optional.of(location), topic, fromBeginning, intervalValue, limitValue);
   }
 
   private PrintTopic(
@@ -45,15 +44,13 @@ public class PrintTopic extends Statement {
       final QualifiedName topic,
       final boolean fromBeginning,
       final Optional<Integer> intervalValue,
-      final Optional<String> limit
+      final Optional<Integer> limit
   ) {
     super(location);
     this.topic = requireNonNull(topic, "table is null");
     this.fromBeginning = fromBeginning;
     this.intervalValue = intervalValue.orElse(1);
-    this.limit = limit.filter(StringUtils::isNumeric)
-        .map(Integer::parseInt)
-        .orElse(null);
+    this.limit = limit.orElse(null);
   }
 
   public QualifiedName getTopic() {

--- a/ksql-parser/src/main/java/io/confluent/ksql/parser/tree/PrintTopic.java
+++ b/ksql-parser/src/main/java/io/confluent/ksql/parser/tree/PrintTopic.java
@@ -19,33 +19,41 @@ import static java.util.Objects.requireNonNull;
 
 import java.util.Objects;
 import java.util.Optional;
+import java.util.OptionalInt;
+import org.apache.commons.lang3.StringUtils;
 
 public class PrintTopic extends Statement {
 
   private final QualifiedName topic;
   private final boolean fromBeginning;
   private final int intervalValue;
+  private final Integer limit;
 
 
   public PrintTopic(
       final NodeLocation location,
       final QualifiedName topic,
       final boolean fromBeginning,
-      final Optional<Integer> intervalValue
+      final Optional<Integer> intervalValue,
+      final Optional<String> limit
   ) {
-    this(Optional.of(location), topic, fromBeginning, intervalValue);
+    this(Optional.of(location), topic, fromBeginning, intervalValue, limit);
   }
 
   private PrintTopic(
       final Optional<NodeLocation> location,
       final QualifiedName topic,
       final boolean fromBeginning,
-      final Optional<Integer> intervalValue
+      final Optional<Integer> intervalValue,
+      final Optional<String> limit
   ) {
     super(location);
     this.topic = requireNonNull(topic, "table is null");
     this.fromBeginning = fromBeginning;
     this.intervalValue = intervalValue.orElse(1);
+    this.limit = limit.filter(StringUtils::isNumeric)
+        .map(Integer::parseInt)
+        .orElse(null);
   }
 
   public QualifiedName getTopic() {
@@ -60,6 +68,10 @@ public class PrintTopic extends Statement {
     return intervalValue;
   }
 
+  public OptionalInt getLimit() {
+    return (limit == null) ? OptionalInt.empty() : OptionalInt.of(limit);
+  }
+
   @Override
   public boolean equals(final Object o) {
     if (this == o) {
@@ -71,12 +83,13 @@ public class PrintTopic extends Statement {
     final PrintTopic that = (PrintTopic) o;
     return getFromBeginning() == that.getFromBeginning()
         && Objects.equals(getTopic(), that.getTopic())
-        && getIntervalValue() == that.getIntervalValue();
+        && getIntervalValue() == that.getIntervalValue()
+        && Objects.equals(getLimit(), that.getLimit());
   }
 
   @Override
   public int hashCode() {
-    return Objects.hash(getTopic(), getFromBeginning(), getIntervalValue());
+    return Objects.hash(getTopic(), getFromBeginning(), getIntervalValue(), getLimit());
   }
 
   @Override

--- a/ksql-parser/src/main/java/io/confluent/ksql/parser/tree/PrintTopic.java
+++ b/ksql-parser/src/main/java/io/confluent/ksql/parser/tree/PrintTopic.java
@@ -26,15 +26,15 @@ public class PrintTopic extends Statement {
   private final QualifiedName topic;
   private final boolean fromBeginning;
   private final int intervalValue;
-  private final Integer limit;
+  private final OptionalInt limit;
 
 
   public PrintTopic(
       final NodeLocation location,
       final QualifiedName topic,
       final boolean fromBeginning,
-      final Optional<Integer> intervalValue,
-      final Optional<Integer> limitValue
+      final OptionalInt intervalValue,
+      final OptionalInt limitValue
   ) {
     this(Optional.of(location), topic, fromBeginning, intervalValue, limitValue);
   }
@@ -43,14 +43,14 @@ public class PrintTopic extends Statement {
       final Optional<NodeLocation> location,
       final QualifiedName topic,
       final boolean fromBeginning,
-      final Optional<Integer> intervalValue,
-      final Optional<Integer> limit
+      final OptionalInt intervalValue,
+      final OptionalInt limit
   ) {
     super(location);
     this.topic = requireNonNull(topic, "table is null");
     this.fromBeginning = fromBeginning;
     this.intervalValue = intervalValue.orElse(1);
-    this.limit = limit.orElse(null);
+    this.limit = limit;
   }
 
   public QualifiedName getTopic() {
@@ -66,7 +66,7 @@ public class PrintTopic extends Statement {
   }
 
   public OptionalInt getLimit() {
-    return (limit == null) ? OptionalInt.empty() : OptionalInt.of(limit);
+    return limit;
   }
 
   @Override
@@ -78,15 +78,15 @@ public class PrintTopic extends Statement {
       return false;
     }
     final PrintTopic that = (PrintTopic) o;
-    return getFromBeginning() == that.getFromBeginning()
-        && Objects.equals(getTopic(), that.getTopic())
-        && getIntervalValue() == that.getIntervalValue()
-        && Objects.equals(getLimit(), that.getLimit());
+    return fromBeginning == that.fromBeginning
+        && Objects.equals(topic, that.topic)
+        && intervalValue == that.intervalValue
+        && Objects.equals(limit, that.limit);
   }
 
   @Override
   public int hashCode() {
-    return Objects.hash(getTopic(), getFromBeginning(), getIntervalValue(), getLimit());
+    return Objects.hash(topic, fromBeginning, intervalValue, limit);
   }
 
   @Override

--- a/ksql-parser/src/main/java/io/confluent/ksql/parser/tree/Query.java
+++ b/ksql-parser/src/main/java/io/confluent/ksql/parser/tree/Query.java
@@ -24,25 +24,25 @@ public class Query
     extends Statement {
 
   private final QueryBody queryBody;
-  private final Optional<String> limit;
+  private final Optional<Integer> limit;
 
   public Query(
       final QueryBody queryBody,
-      final Optional<String> limit) {
+      final Optional<Integer> limit) {
     this(Optional.empty(), queryBody, limit);
   }
 
   public Query(
       final NodeLocation location,
       final QueryBody queryBody,
-      final Optional<String> limit) {
+      final Optional<Integer> limit) {
     this(Optional.of(location), queryBody, limit);
   }
 
   private Query(
       final Optional<NodeLocation> location,
       final QueryBody queryBody,
-      final Optional<String> limit) {
+      final Optional<Integer> limit) {
     super(location);
     requireNonNull(queryBody, "queryBody is null");
     requireNonNull(limit, "limit is null");
@@ -55,7 +55,7 @@ public class Query
     return queryBody;
   }
 
-  public Optional<String> getLimit() {
+  public Optional<Integer> getLimit() {
     return limit;
   }
 

--- a/ksql-parser/src/main/java/io/confluent/ksql/parser/tree/Query.java
+++ b/ksql-parser/src/main/java/io/confluent/ksql/parser/tree/Query.java
@@ -19,30 +19,31 @@ import static java.util.Objects.requireNonNull;
 
 import java.util.Objects;
 import java.util.Optional;
+import java.util.OptionalInt;
 
 public class Query
     extends Statement {
 
   private final QueryBody queryBody;
-  private final Optional<Integer> limit;
+  private final OptionalInt limit;
 
   public Query(
       final QueryBody queryBody,
-      final Optional<Integer> limit) {
+      final OptionalInt limit) {
     this(Optional.empty(), queryBody, limit);
   }
 
   public Query(
       final NodeLocation location,
       final QueryBody queryBody,
-      final Optional<Integer> limit) {
+      final OptionalInt limit) {
     this(Optional.of(location), queryBody, limit);
   }
 
   private Query(
       final Optional<NodeLocation> location,
       final QueryBody queryBody,
-      final Optional<Integer> limit) {
+      final OptionalInt limit) {
     super(location);
     requireNonNull(queryBody, "queryBody is null");
     requireNonNull(limit, "limit is null");
@@ -55,7 +56,7 @@ public class Query
     return queryBody;
   }
 
-  public Optional<Integer> getLimit() {
+  public OptionalInt getLimit() {
     return limit;
   }
 
@@ -68,7 +69,7 @@ public class Query
   public String toString() {
     return toStringHelper(this)
         .add("queryBody", queryBody)
-        .add("limit", limit.orElse(null))
+        .add("limit", limit)
         .omitNullValues()
         .toString();
   }

--- a/ksql-parser/src/main/java/io/confluent/ksql/parser/tree/QuerySpecification.java
+++ b/ksql-parser/src/main/java/io/confluent/ksql/parser/tree/QuerySpecification.java
@@ -19,6 +19,7 @@ import static java.util.Objects.requireNonNull;
 
 import java.util.Objects;
 import java.util.Optional;
+import java.util.OptionalInt;
 
 public class QuerySpecification
     extends QueryBody {
@@ -31,7 +32,7 @@ public class QuerySpecification
   private final Optional<Expression> where;
   private final Optional<GroupBy> groupBy;
   private final Optional<Expression> having;
-  private final Optional<Integer> limit;
+  private final OptionalInt limit;
 
   public QuerySpecification(
       final Select select,
@@ -42,7 +43,7 @@ public class QuerySpecification
       final Optional<Expression> where,
       final Optional<GroupBy> groupBy,
       final Optional<Expression> having,
-      final Optional<Integer> limit) {
+      final OptionalInt limit) {
     this(Optional.empty(), select, into, shouldCreateInto, from, windowExpression, where, groupBy,
          having, limit);
   }
@@ -57,7 +58,7 @@ public class QuerySpecification
       final Optional<Expression> where,
       final Optional<GroupBy> groupBy,
       final Optional<Expression> having,
-      final Optional<Integer> limit) {
+      final OptionalInt limit) {
     this(Optional.of(location), select, into, shouldCreateInto, from, windowExpression, where,
          groupBy,
          having, limit);
@@ -73,7 +74,7 @@ public class QuerySpecification
       final Optional<Expression> where,
       final Optional<GroupBy> groupBy,
       final Optional<Expression> having,
-      final Optional<Integer> limit) {
+      final OptionalInt limit) {
     super(location);
     requireNonNull(select, "select is null");
     requireNonNull(into, "into is null");
@@ -127,7 +128,7 @@ public class QuerySpecification
     return having;
   }
 
-  public Optional<Integer> getLimit() {
+  public OptionalInt getLimit() {
     return limit;
   }
 
@@ -145,7 +146,7 @@ public class QuerySpecification
         .add("where", where.orElse(null))
         .add("groupBy", groupBy)
         .add("having", having.orElse(null))
-        .add("limit", limit.orElse(null))
+        .add("limit", limit)
         .toString();
   }
 

--- a/ksql-parser/src/main/java/io/confluent/ksql/parser/tree/QuerySpecification.java
+++ b/ksql-parser/src/main/java/io/confluent/ksql/parser/tree/QuerySpecification.java
@@ -31,7 +31,7 @@ public class QuerySpecification
   private final Optional<Expression> where;
   private final Optional<GroupBy> groupBy;
   private final Optional<Expression> having;
-  private final Optional<String> limit;
+  private final Optional<Integer> limit;
 
   public QuerySpecification(
       final Select select,
@@ -42,7 +42,7 @@ public class QuerySpecification
       final Optional<Expression> where,
       final Optional<GroupBy> groupBy,
       final Optional<Expression> having,
-      final Optional<String> limit) {
+      final Optional<Integer> limit) {
     this(Optional.empty(), select, into, shouldCreateInto, from, windowExpression, where, groupBy,
          having, limit);
   }
@@ -57,7 +57,7 @@ public class QuerySpecification
       final Optional<Expression> where,
       final Optional<GroupBy> groupBy,
       final Optional<Expression> having,
-      final Optional<String> limit) {
+      final Optional<Integer> limit) {
     this(Optional.of(location), select, into, shouldCreateInto, from, windowExpression, where,
          groupBy,
          having, limit);
@@ -73,7 +73,7 @@ public class QuerySpecification
       final Optional<Expression> where,
       final Optional<GroupBy> groupBy,
       final Optional<Expression> having,
-      final Optional<String> limit) {
+      final Optional<Integer> limit) {
     super(location);
     requireNonNull(select, "select is null");
     requireNonNull(into, "into is null");
@@ -127,7 +127,7 @@ public class QuerySpecification
     return having;
   }
 
-  public Optional<String> getLimit() {
+  public Optional<Integer> getLimit() {
     return limit;
   }
 

--- a/ksql-rest-app/src/main/java/io/confluent/ksql/rest/server/resources/streaming/PollingSubscription.java
+++ b/ksql-rest-app/src/main/java/io/confluent/ksql/rest/server/resources/streaming/PollingSubscription.java
@@ -92,7 +92,6 @@ public abstract class PollingSubscription<T> implements Flow.Subscription {
     }
   }
 
-
   protected void setError(final Throwable e) {
     exception = e;
     done = true;

--- a/ksql-rest-app/src/main/java/io/confluent/ksql/rest/server/resources/streaming/PrintPublisher.java
+++ b/ksql-rest-app/src/main/java/io/confluent/ksql/rest/server/resources/streaming/PrintPublisher.java
@@ -162,7 +162,7 @@ public class PrintPublisher implements Flow.Publisher<Collection<String>> {
     }
   }
 
-  private static class LimitIntervalCollection<T> extends AbstractCollection<T> {
+  private static final class LimitIntervalCollection<T> extends AbstractCollection<T> {
 
     private final Iterable<T> source;
     private final int limit;

--- a/ksql-rest-app/src/main/java/io/confluent/ksql/rest/server/resources/streaming/PrintPublisher.java
+++ b/ksql-rest-app/src/main/java/io/confluent/ksql/rest/server/resources/streaming/PrintPublisher.java
@@ -14,15 +14,25 @@
 
 package io.confluent.ksql.rest.server.resources.streaming;
 
+import com.google.common.base.Preconditions;
+import com.google.common.collect.Iterables;
+import com.google.common.collect.Iterators;
+import com.google.common.math.IntMath;
 import com.google.common.util.concurrent.ListeningScheduledExecutorService;
 import io.confluent.kafka.schemaregistry.client.SchemaRegistryClient;
+import io.confluent.ksql.parser.tree.PrintTopic;
 import io.confluent.ksql.rest.server.resources.streaming.Flow.Subscriber;
 import io.confluent.ksql.rest.server.resources.streaming.TopicStream.RecordFormatter;
+import java.math.RoundingMode;
 import java.time.Duration;
+import java.util.AbstractCollection;
 import java.util.Collection;
+import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.stream.Collectors;
+import javax.annotation.Nonnull;
 import org.apache.kafka.clients.consumer.ConsumerRecords;
 import org.apache.kafka.clients.consumer.KafkaConsumer;
 import org.apache.kafka.common.TopicPartition;
@@ -41,19 +51,19 @@ public class PrintPublisher implements Flow.Publisher<Collection<String>> {
   private final String topicName;
   private final boolean fromBeginning;
   private final Map<String, Object> consumerProperties;
+  private final PrintTopic printTopic;
 
   public PrintPublisher(
       final ListeningScheduledExecutorService exec,
       final SchemaRegistryClient schemaRegistryClient,
       final Map<String, Object> consumerProperties,
-      final String topicName,
-      final boolean fromBeginning
-  ) {
+      final PrintTopic printTopic) {
     this.exec = exec;
     this.schemaRegistryClient = schemaRegistryClient;
     this.consumerProperties = consumerProperties;
-    this.topicName = topicName;
-    this.fromBeginning = fromBeginning;
+    this.printTopic = printTopic;
+    this.topicName = printTopic.getTopic().toString();
+    this.fromBeginning = printTopic.getFromBeginning();
   }
 
   @Override
@@ -77,6 +87,8 @@ public class PrintPublisher implements Flow.Publisher<Collection<String>> {
 
     subscriber.onSubscribe(
         new PrintSubscription(
+            exec,
+            printTopic,
             subscriber,
             topicConsumer,
             new RecordFormatter(schemaRegistryClient, topicName)
@@ -84,18 +96,27 @@ public class PrintPublisher implements Flow.Publisher<Collection<String>> {
     );
   }
 
-  class PrintSubscription extends PollingSubscription<Collection<String>> {
+  static class PrintSubscription extends PollingSubscription<Collection<String>> {
 
+    private final PrintTopic printTopic;
     private final KafkaConsumer<String, Bytes> topicConsumer;
     private final RecordFormatter formatter;
+    private final String topicName;
     private boolean closed = false;
 
+    private int numPolled = 0;
+    private int numWritten = 0;
+
     PrintSubscription(
+        final ListeningScheduledExecutorService exec,
+        final PrintTopic printTopic,
         final Subscriber<Collection<String>> subscriber,
         final KafkaConsumer<String, Bytes> topicConsumer,
         final RecordFormatter formatter
     ) {
       super(exec, subscriber, null);
+      this.printTopic = printTopic;
+      this.topicName = printTopic.getTopic().toString();
       this.topicConsumer = topicConsumer;
       this.formatter = formatter;
     }
@@ -107,7 +128,24 @@ public class PrintPublisher implements Flow.Publisher<Collection<String>> {
         if (records.isEmpty()) {
           return null;
         }
-        return formatter.format(records);
+
+        final Collection<String> formatted = formatter.format(records);
+        final Collection<String> limited = new LimitIntervalCollection<>(
+            formatted,
+            printTopic.getLimit().orElse(Integer.MAX_VALUE) - numWritten,
+            printTopic.getIntervalValue(),
+            numPolled % printTopic.getIntervalValue()
+        );
+
+        numPolled += formatted.size();
+        numWritten += limited.size();
+
+        if (printTopic.getLimit().isPresent()
+            && numWritten >= printTopic.getLimit().getAsInt()) {
+          setDone();
+        }
+
+        return limited;
       } catch (final Exception e) {
         setError(e);
         return null;
@@ -121,6 +159,57 @@ public class PrintPublisher implements Flow.Publisher<Collection<String>> {
         closed = true;
         topicConsumer.close();
       }
+    }
+  }
+
+  private static class LimitIntervalCollection<T> extends AbstractCollection<T> {
+
+    private final Iterable<T> source;
+    private final int limit;
+    private final int interval;
+    private final int size;
+
+    private LimitIntervalCollection(
+        final Collection<T> source,
+        final int limit,
+        final int interval,
+        final int start) {
+      Preconditions.checkArgument(interval > 0, "interval must be greater than 0");
+      Objects.requireNonNull(source, "source");
+
+      this.source = Iterables.skip(source, start);
+      this.size = Math.min(
+          IntMath.divide(source.size() - start, interval, RoundingMode.CEILING),
+          limit);
+      this.interval = interval;
+      this.limit = limit;
+    }
+
+    @Override
+    public @Nonnull Iterator<T> iterator() {
+      return new Iterator<T>() {
+
+        final Iterator<T> it = source.iterator();
+        int remaining = limit;
+
+        @Override
+        public boolean hasNext() {
+          return remaining > 0 && it.hasNext();
+        }
+
+        @Override
+        public T next() {
+          remaining--;
+          final T next = it.next();
+          Iterators.advance(it, interval - 1);
+          return next;
+        }
+      };
+    }
+
+    @Override
+    public int size() {
+      return size;
     }
   }
 }

--- a/ksql-rest-app/src/main/java/io/confluent/ksql/rest/server/resources/streaming/StreamedQueryResource.java
+++ b/ksql-rest-app/src/main/java/io/confluent/ksql/rest/server/resources/streaming/StreamedQueryResource.java
@@ -188,7 +188,8 @@ public class StreamedQueryResource {
         topicName,
         printTopic.getIntervalValue(),
         disconnectCheckInterval,
-        printTopic.getFromBeginning()
+        printTopic.getFromBeginning(),
+        printTopic.getLimit()
     );
 
     log.info("Printing topic '{}'", topicName);

--- a/ksql-rest-app/src/main/java/io/confluent/ksql/rest/server/resources/streaming/StreamedQueryResource.java
+++ b/ksql-rest-app/src/main/java/io/confluent/ksql/rest/server/resources/streaming/StreamedQueryResource.java
@@ -185,11 +185,8 @@ public class StreamedQueryResource {
     final TopicStreamWriter topicStreamWriter = new TopicStreamWriter(
         serviceContext.getSchemaRegistryClient(),
         ksqlConfig.getKsqlStreamConfigProps(),
-        topicName,
-        printTopic.getIntervalValue(),
-        disconnectCheckInterval,
-        printTopic.getFromBeginning(),
-        printTopic.getLimit()
+        printTopic,
+        disconnectCheckInterval
     );
 
     log.info("Printing topic '{}'", topicName);

--- a/ksql-rest-app/src/main/java/io/confluent/ksql/rest/server/resources/streaming/TopicStreamWriter.java
+++ b/ksql-rest-app/src/main/java/io/confluent/ksql/rest/server/resources/streaming/TopicStreamWriter.java
@@ -112,7 +112,7 @@ public class TopicStreamWriter implements StreamingOutput {
               out.flush();
             }
 
-            if (limit.isPresent() && limit.getAsInt() >= messagesWritten) {
+            if (limit.isPresent() && messagesWritten >= limit.getAsInt()) {
               return;
             }
           }

--- a/ksql-rest-app/src/main/java/io/confluent/ksql/rest/server/resources/streaming/TopicStreamWriter.java
+++ b/ksql-rest-app/src/main/java/io/confluent/ksql/rest/server/resources/streaming/TopicStreamWriter.java
@@ -24,6 +24,7 @@ import java.time.Duration;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
+import java.util.OptionalInt;
 import java.util.stream.Collectors;
 import javax.ws.rs.core.StreamingOutput;
 import org.apache.kafka.clients.consumer.ConsumerRecords;
@@ -43,8 +44,10 @@ public class TopicStreamWriter implements StreamingOutput {
   private final KafkaConsumer<String, Bytes> topicConsumer;
   private final SchemaRegistryClient schemaRegistryClient;
   private final String topicName;
+  private final OptionalInt limit;
 
   private long messagesWritten;
+  private long messagesPolled;
 
   public TopicStreamWriter(
       final SchemaRegistryClient schemaRegistryClient,
@@ -52,35 +55,39 @@ public class TopicStreamWriter implements StreamingOutput {
       final String topicName,
       final long interval,
       final Duration disconnectCheckInterval,
-      final boolean fromBeginning
+      final boolean fromBeginning,
+      final OptionalInt limit
   ) {
+    this(
+        schemaRegistryClient,
+        createTopicConsumer(consumerProperties, topicName, fromBeginning),
+        topicName,
+        interval,
+        disconnectCheckInterval,
+        limit);
+  }
+
+
+  TopicStreamWriter(
+      final SchemaRegistryClient schemaRegistryClient,
+      final KafkaConsumer<String, Bytes> topicConsumer,
+      final String topicName,
+      final long interval,
+      final Duration disconnectCheckInterval,
+      final OptionalInt limit
+  ) {
+    this.topicConsumer = topicConsumer;
     this.schemaRegistryClient = schemaRegistryClient;
     this.topicName = topicName;
-    this.messagesWritten = 0;
-
+    this.interval = interval;
+    this.limit = limit;
     this.disconnectCheckInterval = Objects
         .requireNonNull(disconnectCheckInterval, "disconnectCheckInterval");
 
-    this.topicConsumer = new KafkaConsumer<>(
-        consumerProperties,
-        new StringDeserializer(),
-        new BytesDeserializer()
-    );
-
-    final List<TopicPartition> topicPartitions = topicConsumer.partitionsFor(topicName)
-        .stream()
-        .map(partitionInfo -> new TopicPartition(partitionInfo.topic(), partitionInfo.partition()))
-        .collect(Collectors.toList());
-    topicConsumer.assign(topicPartitions);
-
-    if (fromBeginning) {
-      topicConsumer.seekToBeginning(topicPartitions);
-    }
-
-    this.interval = interval;
+    this.messagesWritten = 0;
+    this.messagesPolled = 0;
   }
 
-  @SuppressWarnings("InfiniteLoopStatement")
   @Override
   public void write(final OutputStream out) {
     try {
@@ -99,9 +106,14 @@ public class TopicStreamWriter implements StreamingOutput {
               out.write(("Format:" + formatter.getFormat().name() + "\n")
                             .getBytes(StandardCharsets.UTF_8));
             }
-            if (messagesWritten++ % interval == 0) {
+            if (messagesPolled++ % interval == 0) {
+              messagesWritten++;
               out.write(value.getBytes(StandardCharsets.UTF_8));
               out.flush();
+            }
+
+            if (limit.isPresent() && limit.getAsInt() >= messagesWritten) {
+              return;
             }
           }
         }
@@ -124,5 +136,28 @@ public class TopicStreamWriter implements StreamingOutput {
     } catch (final IOException e) {
       log.debug("Client disconnected while attempting to write an error message");
     }
+  }
+
+  private static KafkaConsumer<String, Bytes> createTopicConsumer(
+      final Map<String, Object> consumerProperties,
+      final String topicName,
+      final boolean fromBeginning) {
+
+    final KafkaConsumer<String, Bytes> topicConsumer = new KafkaConsumer<>(
+        consumerProperties,
+        new StringDeserializer(),
+        new BytesDeserializer()
+    );
+
+    final List<TopicPartition> topicPartitions = topicConsumer.partitionsFor(topicName)
+        .stream()
+        .map(partitionInfo -> new TopicPartition(partitionInfo.topic(), partitionInfo.partition()))
+        .collect(Collectors.toList());
+    topicConsumer.assign(topicPartitions);
+
+    if (fromBeginning) {
+      topicConsumer.seekToBeginning(topicPartitions);
+    }
+    return topicConsumer;
   }
 }

--- a/ksql-rest-app/src/main/java/io/confluent/ksql/rest/server/resources/streaming/TopicStreamWriter.java
+++ b/ksql-rest-app/src/main/java/io/confluent/ksql/rest/server/resources/streaming/TopicStreamWriter.java
@@ -15,6 +15,7 @@
 package io.confluent.ksql.rest.server.resources.streaming;
 
 import io.confluent.kafka.schemaregistry.client.SchemaRegistryClient;
+import io.confluent.ksql.parser.tree.PrintTopic;
 import io.confluent.ksql.rest.server.resources.streaming.TopicStream.RecordFormatter;
 import java.io.EOFException;
 import java.io.IOException;
@@ -52,19 +53,17 @@ public class TopicStreamWriter implements StreamingOutput {
   public TopicStreamWriter(
       final SchemaRegistryClient schemaRegistryClient,
       final Map<String, Object> consumerProperties,
-      final String topicName,
-      final long interval,
-      final Duration disconnectCheckInterval,
-      final boolean fromBeginning,
-      final OptionalInt limit
+      final PrintTopic printTopic,
+      final Duration disconnectCheckInterval
   ) {
     this(
         schemaRegistryClient,
-        createTopicConsumer(consumerProperties, topicName, fromBeginning),
-        topicName,
-        interval,
+        createTopicConsumer(
+            consumerProperties, printTopic.getTopic().toString(), printTopic.getFromBeginning()),
+        printTopic.getTopic().toString(),
+        printTopic.getIntervalValue(),
         disconnectCheckInterval,
-        limit);
+        printTopic.getLimit());
   }
 
 

--- a/ksql-rest-app/src/main/java/io/confluent/ksql/rest/server/resources/streaming/WSQueryEndpoint.java
+++ b/ksql-rest-app/src/main/java/io/confluent/ksql/rest/server/resources/streaming/WSQueryEndpoint.java
@@ -281,7 +281,7 @@ public class WSQueryEndpoint {
     this.subscriber = topicSubscriber;
 
     topicPublisher.start(exec, serviceContext.getSchemaRegistryClient(),
-        ksqlConfig.getKsqlStreamConfigProps(), topicName, printTopic.getFromBeginning(),
+        ksqlConfig.getKsqlStreamConfigProps(), printTopic,
         topicSubscriber
     );
   }
@@ -313,11 +313,10 @@ public class WSQueryEndpoint {
       final ListeningScheduledExecutorService exec,
       final SchemaRegistryClient schemaRegistryClient,
       final Map<String, Object> ksqlStreamConfigProps,
-      final String topicName,
-      final boolean fromBeginning,
+      final PrintTopic printTopic,
       final WebSocketSubscriber<String> topicSubscriber
   ) {
-    new PrintPublisher(exec, schemaRegistryClient, ksqlStreamConfigProps, topicName,fromBeginning)
+    new PrintPublisher(exec, schemaRegistryClient, ksqlStreamConfigProps, printTopic)
         .subscribe(topicSubscriber);
   }
 
@@ -338,8 +337,7 @@ public class WSQueryEndpoint {
         ListeningScheduledExecutorService exec,
         SchemaRegistryClient schemaRegistryClient,
         Map<String, Object> consumerProperties,
-        String topicName,
-        boolean fromBeginning,
+        PrintTopic printTopic,
         WebSocketSubscriber<String> subscriber);
   }
 

--- a/ksql-rest-app/src/test/java/io/confluent/ksql/rest/server/computation/StatementExecutorTest.java
+++ b/ksql-rest-app/src/test/java/io/confluent/ksql/rest/server/computation/StatementExecutorTest.java
@@ -67,6 +67,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+import java.util.OptionalInt;
 import org.easymock.EasyMockSupport;
 import org.easymock.IArgumentMatcher;
 import org.hamcrest.CoreMatchers;
@@ -476,7 +477,7 @@ public class StatementExecutorTest extends EasyMockSupport {
     final QuerySpecification mockQuerySpec = mock(QuerySpecification.class);
     final Table mockRelation = mock(Table.class);
     expect(mockQuery.getQueryBody()).andStubReturn(mockQuerySpec);
-    expect(mockQuery.getLimit()).andStubReturn(Optional.empty());
+    expect(mockQuery.getLimit()).andStubReturn(OptionalInt.empty());
     expect(mockQuerySpec.getInto()).andStubReturn(mockRelation);
     expect(mockRelation.getName()).andStubReturn(QualifiedName.of(name));
     return mockQuery;

--- a/ksql-rest-app/src/test/java/io/confluent/ksql/rest/server/resources/streaming/PollingSubscriptionTest.java
+++ b/ksql-rest-app/src/test/java/io/confluent/ksql/rest/server/resources/streaming/PollingSubscriptionTest.java
@@ -25,13 +25,11 @@ import com.google.common.collect.Lists;
 import com.google.common.util.concurrent.MoreExecutors;
 import io.confluent.ksql.rest.server.resources.streaming.Flow.Subscriber;
 import io.confluent.ksql.rest.server.resources.streaming.Flow.Subscription;
-import java.util.List;
+import io.confluent.ksql.rest.server.resources.streaming.StreamingTestUtils.TestSubscriber;
 import java.util.Queue;
-import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.Executors;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.TimeUnit;
-import org.apache.kafka.connect.data.Schema;
 import org.apache.kafka.connect.data.SchemaBuilder;
 import org.junit.Test;
 
@@ -41,56 +39,6 @@ public class PollingSubscriptionTest {
   private static final ImmutableList<String> ELEMENTS = ImmutableList.of("a", "b", "c", "d", "e", "f");
   private final ScheduledExecutorService multithreadedExec = Executors.newScheduledThreadPool(8);
   final ScheduledExecutorService exec = Executors.newSingleThreadScheduledExecutor();
-
-  private static class TestSubscriber implements Subscriber<String> {
-
-    CountDownLatch done = new CountDownLatch(1);
-    Throwable error = null;
-    List<String> elements = Lists.newLinkedList();
-    Schema schema = null;
-    Subscription subscription;
-
-    @Override
-    public void onNext(final String item) {
-      if (done.getCount() == 0) {
-        throw new IllegalStateException("already done");
-      }
-      elements.add(item);
-      subscription.request(1);
-    }
-
-    @Override
-    public void onError(final Throwable e) {
-      if (done.getCount() == 0) {
-        throw new IllegalStateException("already done");
-      }
-      error = e;
-      done.countDown();
-    }
-
-    @Override
-    public void onComplete() {
-      if (done.getCount() == 0) {
-        throw new IllegalStateException("already done");
-      }
-      done.countDown();
-    }
-
-    @Override
-    public void onSchema(final Schema s) {
-      if (done.getCount() == 0) {
-        throw new IllegalStateException("already done");
-      }
-      schema = s;
-    }
-
-    @Override
-    public void onSubscribe(final Subscription subscription) {
-      this.subscription = subscription;
-      subscription.request(1);
-    }
-  }
-
 
   class TestPublisher implements Flow.Publisher<String> {
     TestPollingSubscription subscription;
@@ -141,7 +89,7 @@ public class PollingSubscriptionTest {
 
   @Test
   public void testBasicFlow() throws Exception {
-    final TestSubscriber testSubscriber = new TestSubscriber();
+    final TestSubscriber<String> testSubscriber = new TestSubscriber<>();
     final TestPublisher testPublisher = new TestPublisher();
     testPublisher.subscribe(testSubscriber);
 
@@ -156,7 +104,7 @@ public class PollingSubscriptionTest {
 
   @Test
   public void testErrorDrainsNextElement() throws Exception {
-    final TestSubscriber testSubscriber = new TestSubscriber();
+    final TestSubscriber<String> testSubscriber = new TestSubscriber<>();
     final TestPublisher testPublisher = new TestPublisher() {
       @Override
       TestPollingSubscription createSubscription(
@@ -189,7 +137,7 @@ public class PollingSubscriptionTest {
 
   @Test
   public void testMultithreaded() throws Exception {
-    final TestSubscriber testSubscriber = new TestSubscriber();
+    final TestSubscriber<String> testSubscriber = new TestSubscriber<>();
     final TestPublisher testPublisher = new TestPublisher() {
       @Override
       TestPollingSubscription createSubscription(
@@ -211,7 +159,7 @@ public class PollingSubscriptionTest {
 
   @Test
   public void testReentrantNextElement() throws Exception {
-    final TestSubscriber testSubscriber = new TestSubscriber();
+    final TestSubscriber<String> testSubscriber = new TestSubscriber<>();
     final TestPublisher testPublisher = new TestPublisher() {
       @Override
       TestPollingSubscription createSubscription(
@@ -247,7 +195,7 @@ public class PollingSubscriptionTest {
 
   @Test
   public void testEmpty() throws Exception {
-    final TestSubscriber testSubscriber = new TestSubscriber();
+    final TestSubscriber<String> testSubscriber = new TestSubscriber<>();
     final TestPublisher testPublisher = new TestPublisher() {
       @Override
       TestPollingSubscription createSubscription(
@@ -275,7 +223,7 @@ public class PollingSubscriptionTest {
 
   @Test(expected = IllegalArgumentException.class)
   public void testExpectsNEqualsOne() {
-    final TestSubscriber testSubscriber = new TestSubscriber() {
+    final TestSubscriber<String> testSubscriber = new TestSubscriber<String>() {
       @Override
       public void onSubscribe(final Subscription subscription) {
         subscription.request(2);

--- a/ksql-rest-app/src/test/java/io/confluent/ksql/rest/server/resources/streaming/PrintSubscriptionTest.java
+++ b/ksql-rest-app/src/test/java/io/confluent/ksql/rest/server/resources/streaming/PrintSubscriptionTest.java
@@ -8,6 +8,7 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.when;
 
 import com.google.common.base.Charsets;
+import com.google.common.collect.Lists;
 import com.google.common.util.concurrent.MoreExecutors;
 import io.confluent.kafka.schemaregistry.client.SchemaRegistryClient;
 import io.confluent.ksql.rest.server.resources.streaming.PrintPublisher.PrintSubscription;
@@ -62,10 +63,10 @@ public class PrintSubscriptionTest {
     Collection<String> results = subscription.poll();
 
     // Then:
-    assertThat(results, contains(
+    assertThat(results, contains(Lists.newArrayList(
         containsString("key0 , value0"),
         containsString("key1 , value1"),
-        containsString("key2 , value2")
+        containsString("key2 , value2"))
     ));
   }
 
@@ -86,9 +87,9 @@ public class PrintSubscriptionTest {
     Collection<String> results2 = subscription.poll();
 
     // Then:
-    assertThat(results, contains(
+    assertThat(results, contains(Lists.newArrayList(
         containsString("key0 , value0"),
-        containsString("key1 , value1")
+        containsString("key1 , value1"))
     ));
     assertThat(results2, empty());
   }
@@ -110,14 +111,14 @@ public class PrintSubscriptionTest {
     Collection<String> results2 = subscription.poll();
 
     // Then:
-    assertThat(results, contains(
+    assertThat(results, contains(Lists.newArrayList(
         containsString("key0 , value0"),
         containsString("key1 , value1"),
-        containsString("key2 , value2")
+        containsString("key2 , value2"))
     ));
-    assertThat(results2, contains(
+    assertThat(results2, contains(Lists.newArrayList(
         containsString("key3 , value3"),
-        containsString("key4 , value4")
+        containsString("key4 , value4"))
     ));
   }
 
@@ -138,9 +139,9 @@ public class PrintSubscriptionTest {
     Collection<String> results2 = subscription.poll();
 
     // Then:
-    assertThat(results, contains(
+    assertThat(results, contains(Lists.newArrayList(
         containsString("key0 , value0"),
-        containsString("key2 , value2")
+        containsString("key2 , value2"))
     ));
     assertThat(results2, contains(
         containsString("key4 , value4")
@@ -166,9 +167,9 @@ public class PrintSubscriptionTest {
     Collection<String> results4 = subscription.poll();
 
     // Then:
-    assertThat(results, contains(
+    assertThat(results, contains(Lists.newArrayList(
         containsString("key0 , value0"),
-        containsString("key2 , value2")
+        containsString("key2 , value2"))
     ));
     assertThat(results2, contains(
         containsString("key4 , value4")

--- a/ksql-rest-app/src/test/java/io/confluent/ksql/rest/server/resources/streaming/PrintSubscriptionTest.java
+++ b/ksql-rest-app/src/test/java/io/confluent/ksql/rest/server/resources/streaming/PrintSubscriptionTest.java
@@ -1,0 +1,183 @@
+package io.confluent.ksql.rest.server.resources.streaming;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.Matchers.empty;
+import static org.hamcrest.collection.IsIterableContainingInOrder.contains;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.when;
+
+import com.google.common.base.Charsets;
+import com.google.common.util.concurrent.MoreExecutors;
+import io.confluent.kafka.schemaregistry.client.SchemaRegistryClient;
+import io.confluent.ksql.rest.server.resources.streaming.PrintPublisher.PrintSubscription;
+import io.confluent.ksql.rest.server.resources.streaming.StreamingTestUtils.TestSubscriber;
+import io.confluent.ksql.rest.server.resources.streaming.TopicStream.RecordFormatter;
+import java.time.Duration;
+import java.util.Collection;
+import java.util.Iterator;
+import java.util.concurrent.Executors;
+import org.apache.kafka.clients.consumer.ConsumerRecords;
+import org.apache.kafka.clients.consumer.KafkaConsumer;
+import org.apache.kafka.common.utils.Bytes;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnitRunner;
+
+@RunWith(MockitoJUnitRunner.class)
+public class PrintSubscriptionTest {
+
+  @Mock public KafkaConsumer<String, Bytes> kafkaConsumer;
+  @Mock public SchemaRegistryClient schemaRegistry;
+
+  @Before
+  public void setup() {
+    final Iterator<ConsumerRecords<String, Bytes>> records = StreamingTestUtils.generate(
+        "topic",
+        i -> "key" + i,
+        i -> new Bytes(("value" + i).getBytes(Charsets.UTF_8)));
+
+    final Iterator<ConsumerRecords<String, Bytes>> partitioned =
+        StreamingTestUtils.partition(records, 3);
+
+    when(kafkaConsumer.poll(any(Duration.class)))
+        .thenAnswer(invocation -> partitioned.next());
+  }
+
+  @Test
+  public void testPrintPublisher() {
+    // Given:
+    TestSubscriber<Collection<String>> subscriber = new TestSubscriber<>();
+    PrintSubscription subscription = new PrintSubscription(
+        MoreExecutors.listeningDecorator(Executors.newScheduledThreadPool(1)),
+        StreamingTestUtils.printTopic("topic", true, null, null),
+        subscriber,
+        kafkaConsumer,
+        new RecordFormatter(schemaRegistry, "topic")
+    );
+
+    // When:
+    Collection<String> results = subscription.poll();
+
+    // Then:
+    assertThat(results, contains(
+        containsString("key0 , value0"),
+        containsString("key1 , value1"),
+        containsString("key2 , value2")
+    ));
+  }
+
+  @Test
+  public void testPrintPublisherLimit() {
+    // Given:
+    TestSubscriber<Collection<String>> subscriber = new TestSubscriber<>();
+    PrintSubscription subscription = new PrintSubscription(
+        MoreExecutors.listeningDecorator(Executors.newScheduledThreadPool(1)),
+        StreamingTestUtils.printTopic("topic", true, null, 2),
+        subscriber,
+        kafkaConsumer,
+        new RecordFormatter(schemaRegistry, "topic")
+    );
+
+    // When:
+    Collection<String> results = subscription.poll();
+    Collection<String> results2 = subscription.poll();
+
+    // Then:
+    assertThat(results, contains(
+        containsString("key0 , value0"),
+        containsString("key1 , value1")
+    ));
+    assertThat(results2, empty());
+  }
+
+  @Test
+  public void testPrintPublisherLimitTwoBatches() {
+    // Given:
+    TestSubscriber<Collection<String>> subscriber = new TestSubscriber<>();
+    PrintSubscription subscription = new PrintSubscription(
+        MoreExecutors.listeningDecorator(Executors.newScheduledThreadPool(1)),
+        StreamingTestUtils.printTopic("topic", true, null, 5),
+        subscriber,
+        kafkaConsumer,
+        new RecordFormatter(schemaRegistry, "topic")
+    );
+
+    // When:
+    Collection<String> results = subscription.poll();
+    Collection<String> results2 = subscription.poll();
+
+    // Then:
+    assertThat(results, contains(
+        containsString("key0 , value0"),
+        containsString("key1 , value1"),
+        containsString("key2 , value2")
+    ));
+    assertThat(results2, contains(
+        containsString("key3 , value3"),
+        containsString("key4 , value4")
+    ));
+  }
+
+  @Test
+  public void testPrintPublisherIntervalNoLimit() {
+    // Given:
+    TestSubscriber<Collection<String>> subscriber = new TestSubscriber<>();
+    PrintSubscription subscription = new PrintSubscription(
+        MoreExecutors.listeningDecorator(Executors.newScheduledThreadPool(1)),
+        StreamingTestUtils.printTopic("topic", true, 2, null),
+        subscriber,
+        kafkaConsumer,
+        new RecordFormatter(schemaRegistry, "topic")
+    );
+
+    // When:
+    Collection<String> results = subscription.poll();
+    Collection<String> results2 = subscription.poll();
+
+    // Then:
+    assertThat(results, contains(
+        containsString("key0 , value0"),
+        containsString("key2 , value2")
+    ));
+    assertThat(results2, contains(
+        containsString("key4 , value4")
+    ));
+  }
+
+  @Test
+  public void testPrintPublisherIntervalAndLimit() {
+    // Given:
+    TestSubscriber<Collection<String>> subscriber = new TestSubscriber<>();
+    PrintSubscription subscription = new PrintSubscription(
+        MoreExecutors.listeningDecorator(Executors.newScheduledThreadPool(1)),
+        StreamingTestUtils.printTopic("topic", true, 2, 4),
+        subscriber,
+        kafkaConsumer,
+        new RecordFormatter(schemaRegistry, "topic")
+    );
+
+    // When:
+    Collection<String> results = subscription.poll();
+    Collection<String> results2 = subscription.poll();
+    Collection<String> results3 = subscription.poll();
+    Collection<String> results4 = subscription.poll();
+
+    // Then:
+    assertThat(results, contains(
+        containsString("key0 , value0"),
+        containsString("key2 , value2")
+    ));
+    assertThat(results2, contains(
+        containsString("key4 , value4")
+    ));
+    assertThat(results3, contains(
+        containsString("key6 , value6")
+    ));
+    assertThat(results4, empty());
+  }
+
+}
+

--- a/ksql-rest-app/src/test/java/io/confluent/ksql/rest/server/resources/streaming/StreamingTestUtils.java
+++ b/ksql-rest-app/src/test/java/io/confluent/ksql/rest/server/resources/streaming/StreamingTestUtils.java
@@ -85,7 +85,7 @@ class StreamingTestUtils {
         QualifiedName.of(name),
         fromBeginning,
         Optional.ofNullable(interval),
-        Optional.ofNullable(limit == null ? null : String.valueOf(limit))
+        Optional.ofNullable(limit)
     );
   }
 

--- a/ksql-rest-app/src/test/java/io/confluent/ksql/rest/server/resources/streaming/StreamingTestUtils.java
+++ b/ksql-rest-app/src/test/java/io/confluent/ksql/rest/server/resources/streaming/StreamingTestUtils.java
@@ -29,6 +29,7 @@ import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+import java.util.OptionalInt;
 import java.util.concurrent.CountDownLatch;
 import java.util.function.Function;
 import java.util.stream.IntStream;
@@ -84,8 +85,8 @@ class StreamingTestUtils {
         new NodeLocation(0, 1),
         QualifiedName.of(name),
         fromBeginning,
-        Optional.ofNullable(interval),
-        Optional.ofNullable(limit)
+        interval == null ? OptionalInt.empty() : OptionalInt.of(interval),
+        limit == null ? OptionalInt.empty() : OptionalInt.of(limit)
     );
   }
 

--- a/ksql-rest-app/src/test/java/io/confluent/ksql/rest/server/resources/streaming/StreamingTestUtils.java
+++ b/ksql-rest-app/src/test/java/io/confluent/ksql/rest/server/resources/streaming/StreamingTestUtils.java
@@ -1,0 +1,140 @@
+/*
+ * Copyright 2019 Confluent Inc.
+ *
+ * Licensed under the Confluent Community License; you may not use this file
+ * except in compliance with the License.  You may obtain a copy of the License at
+ *
+ * http://www.confluent.io/confluent-community-license
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package io.confluent.ksql.rest.server.resources.streaming;
+
+import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.Iterators;
+import com.google.common.collect.Lists;
+import com.google.common.collect.Streams;
+import io.confluent.ksql.parser.tree.NodeLocation;
+import io.confluent.ksql.parser.tree.PrintTopic;
+import io.confluent.ksql.parser.tree.QualifiedName;
+import io.confluent.ksql.rest.server.resources.streaming.Flow.Subscriber;
+import io.confluent.ksql.rest.server.resources.streaming.Flow.Subscription;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.concurrent.CountDownLatch;
+import java.util.function.Function;
+import java.util.stream.IntStream;
+import org.apache.kafka.clients.consumer.ConsumerRecord;
+import org.apache.kafka.clients.consumer.ConsumerRecords;
+import org.apache.kafka.common.TopicPartition;
+import org.apache.kafka.common.utils.Bytes;
+import org.apache.kafka.connect.data.Schema;
+
+class StreamingTestUtils {
+
+  private StreamingTestUtils() { /* private constructor for utility class */ }
+
+  static Iterator<ConsumerRecords<String, Bytes>> generate(
+      final String topic,
+      final Function<Integer, String> keyMapper,
+      final Function<Integer, Bytes> valueMapper) {
+    return IntStream.iterate(0, i -> i + 1)
+        .mapToObj(
+            i -> new ConsumerRecord<>(topic, 0, i, keyMapper.apply(i), valueMapper.apply(i)))
+        .map(Lists::newArrayList)
+        .map(crs -> (List<ConsumerRecord<String, Bytes>>) crs)
+        .map(crs -> ImmutableMap.of(new TopicPartition("topic", 0), crs))
+        .map(map -> (Map<TopicPartition, List<ConsumerRecord<String, Bytes>>>) map)
+        .map(ConsumerRecords::new)
+        .iterator();
+  }
+
+  static Iterator<ConsumerRecords<String, Bytes>> partition(
+      final Iterator<ConsumerRecords<String, Bytes>> source,
+      final int partitions) {
+    return Streams.stream(Iterators.partition(source, partitions))
+        .map(StreamingTestUtils::combine)
+        .iterator();
+  }
+
+  private static <K, V> ConsumerRecords<K, V> combine(List<ConsumerRecords<K,V>> recordsList) {
+    final Map<TopicPartition, List<ConsumerRecord<K, V>>> recordMap = new HashMap<>();
+    for (ConsumerRecords<K, V> records : recordsList) {
+      for (TopicPartition tp : records.partitions()) {
+        recordMap.computeIfAbsent(tp, ignored -> new ArrayList<>()).addAll(records.records(tp));
+      }
+    }
+    return new ConsumerRecords<K, V>(recordMap);
+  }
+
+  static PrintTopic printTopic(
+      final String name,
+      final boolean fromBeginning,
+      final Integer interval,
+      final Integer limit) {
+    return new PrintTopic(
+        new NodeLocation(0, 1),
+        QualifiedName.of(name),
+        fromBeginning,
+        Optional.ofNullable(interval),
+        Optional.ofNullable(limit == null ? null : String.valueOf(limit))
+    );
+  }
+
+  static class TestSubscriber<T> implements Subscriber<T> {
+
+    CountDownLatch done = new CountDownLatch(1);
+    Throwable error = null;
+    List<T> elements = Lists.newLinkedList();
+    Schema schema = null;
+    Subscription subscription;
+
+    @Override
+    public void onNext(final T item) {
+      if (done.getCount() == 0) {
+        throw new IllegalStateException("already done");
+      }
+      elements.add(item);
+      subscription.request(1);
+    }
+
+    @Override
+    public void onError(final Throwable e) {
+      if (done.getCount() == 0) {
+        throw new IllegalStateException("already done");
+      }
+      error = e;
+      done.countDown();
+    }
+
+    @Override
+    public void onComplete() {
+      if (done.getCount() == 0) {
+        throw new IllegalStateException("already done");
+      }
+      done.countDown();
+    }
+
+    @Override
+    public void onSchema(final Schema s) {
+      if (done.getCount() == 0) {
+        throw new IllegalStateException("already done");
+      }
+      schema = s;
+    }
+
+    @Override
+    public void onSubscribe(final Subscription subscription) {
+      this.subscription = subscription;
+      subscription.request(1);
+    }
+  }
+}

--- a/ksql-rest-app/src/test/java/io/confluent/ksql/rest/server/resources/streaming/TopicStreamWriterTest.java
+++ b/ksql-rest-app/src/test/java/io/confluent/ksql/rest/server/resources/streaming/TopicStreamWriterTest.java
@@ -1,0 +1,121 @@
+package io.confluent.ksql.rest.server.resources.streaming;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+
+import com.google.common.base.Charsets;
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.Lists;
+import com.google.common.primitives.Ints;
+import io.confluent.kafka.schemaregistry.client.SchemaRegistryClient;
+import java.io.OutputStream;
+import java.time.Duration;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Map;
+import java.util.OptionalInt;
+import java.util.stream.IntStream;
+import org.apache.kafka.clients.consumer.ConsumerRecord;
+import org.apache.kafka.clients.consumer.ConsumerRecords;
+import org.apache.kafka.clients.consumer.KafkaConsumer;
+import org.apache.kafka.common.TopicPartition;
+import org.apache.kafka.common.utils.Bytes;
+import org.hamcrest.Matchers;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.Mockito;
+import org.mockito.junit.MockitoJUnitRunner;
+
+@RunWith(MockitoJUnitRunner.class)
+public class TopicStreamWriterTest {
+
+  @Mock public KafkaConsumer<String, Bytes> kafkaConsumer;
+  @Mock public SchemaRegistryClient schemaRegistry;
+
+  @Before
+  public void setup() {
+    final Iterator<ConsumerRecords<String, Bytes>> records = IntStream.iterate(0, i -> i + 1)
+        .mapToObj(i -> new ConsumerRecord<>(
+            "topic", 0, i, String.valueOf(i), new Bytes(Ints.toByteArray(i))))
+        .map(Lists::newArrayList)
+        .map(crs -> (List<ConsumerRecord<String, Bytes>>) crs)
+        .map(crs -> ImmutableMap.of(new TopicPartition("topic", 0), crs))
+        .map(map -> (Map<TopicPartition, List<ConsumerRecord<String, Bytes>>>) map)
+        .map(ConsumerRecords::new)
+        .iterator();
+
+    Mockito.when(kafkaConsumer.poll(Mockito.any(Duration.class)))
+        .thenAnswer(invocation -> records.next());
+  }
+
+  @Test
+  public void testIntervalOneAndLimitTwo() {
+    final TopicStreamWriter writer = new TopicStreamWriter(
+        schemaRegistry,
+        kafkaConsumer,
+        "topic",
+        1,
+        Duration.ZERO,
+        OptionalInt.of(2)
+    );
+
+    final List<String> expected = ImmutableList.of(
+        "Format:STRING",
+        "\\x00\\x00\\x00\\x00",
+        "\\x00\\x00\\x00\\x01"
+    );
+
+    ValidatingOutputStream out = new ValidatingOutputStream(expected);
+    writer.write(out);
+    out.assertNoMore();
+  }
+
+  @Test
+  public void testIntervalTwoAndLimitTwo() {
+    final TopicStreamWriter writer = new TopicStreamWriter(
+        schemaRegistry,
+        kafkaConsumer,
+        "topic",
+        2,
+        Duration.ZERO,
+        OptionalInt.of(2)
+    );
+
+    final List<String> expected = ImmutableList.of(
+        "Format:STRING",
+        "\\x00\\x00\\x00\\x00",
+        "\\x00\\x00\\x00\\x02"
+    );
+
+    ValidatingOutputStream out = new ValidatingOutputStream(expected);
+    writer.write(out);
+    out.assertNoMore();
+  }
+
+  private static class ValidatingOutputStream extends OutputStream {
+
+    private final List<String> expected;
+    private int numWrites = 0;
+
+    ValidatingOutputStream(List<String> expected) {
+      this.expected = expected;
+    }
+
+    @Override public void write(final int b) { /* not called*/ }
+
+    @Override
+    public void write(final byte[] b) {
+      assertThat(numWrites, Matchers.lessThanOrEqualTo(expected.size()));
+      assertThat(
+          new String(b, Charsets.UTF_8),
+          Matchers.containsString(expected.get(numWrites++)));
+    }
+
+    void assertNoMore() {
+      assertThat(numWrites, Matchers.equalTo(expected.size() - 1));
+    }
+  }
+
+}

--- a/ksql-rest-app/src/test/java/io/confluent/ksql/rest/server/resources/streaming/TopicStreamWriterTest.java
+++ b/ksql-rest-app/src/test/java/io/confluent/ksql/rest/server/resources/streaming/TopicStreamWriterTest.java
@@ -53,16 +53,10 @@ public class TopicStreamWriterTest {
 
   @Before
   public void setup() {
-    final Iterator<ConsumerRecords<String, Bytes>> records = IntStream.iterate(0, i -> i + 1)
-        .mapToObj(i -> new ConsumerRecord<>(
-            "topic", 0, i, "key" + i, new Bytes(("value" + i).getBytes(Charsets.UTF_8))))
-        .map(Lists::newArrayList)
-        .map(crs -> (List<ConsumerRecord<String, Bytes>>) crs)
-        .map(crs -> ImmutableMap.of(new TopicPartition("topic", 0), crs))
-        .map(map -> (Map<TopicPartition, List<ConsumerRecord<String, Bytes>>>) map)
-        .map(ConsumerRecords::new)
-        .iterator();
-
+    final Iterator<ConsumerRecords<String, Bytes>> records = StreamingTestUtils.generate(
+        "topic",
+        i -> "key" + i,
+        i -> new Bytes(("value" + i).getBytes(Charsets.UTF_8)));
     when(kafkaConsumer.poll(any(Duration.class)))
         .thenAnswer(invocation -> records.next());
   }

--- a/ksql-rest-app/src/test/java/io/confluent/ksql/rest/server/resources/streaming/TopicStreamWriterTest.java
+++ b/ksql-rest-app/src/test/java/io/confluent/ksql/rest/server/resources/streaming/TopicStreamWriterTest.java
@@ -50,6 +50,7 @@ public class TopicStreamWriterTest {
 
   @Mock public KafkaConsumer<String, Bytes> kafkaConsumer;
   @Mock public SchemaRegistryClient schemaRegistry;
+  private ValidatingOutputStream out;
 
   @Before
   public void setup() {
@@ -59,6 +60,7 @@ public class TopicStreamWriterTest {
         i -> new Bytes(("value" + i).getBytes(Charsets.UTF_8)));
     when(kafkaConsumer.poll(any(Duration.class)))
         .thenAnswer(invocation -> records.next());
+    out = new ValidatingOutputStream();
   }
 
   @Test
@@ -74,7 +76,6 @@ public class TopicStreamWriterTest {
     );
 
     // When:
-    ValidatingOutputStream out = new ValidatingOutputStream();
     writer.write(out);
 
     // Then:

--- a/ksql-rest-app/src/test/java/io/confluent/ksql/rest/server/resources/streaming/TopicStreamWriterTest.java
+++ b/ksql-rest-app/src/test/java/io/confluent/ksql/rest/server/resources/streaming/TopicStreamWriterTest.java
@@ -117,7 +117,7 @@ public class TopicStreamWriterTest {
       recordedWrites.add(b);
     }
 
-    void assertWrites(List<String> expected) {
+    void assertWrites(final List<String> expected) {
       assertThat(recordedWrites.size(), Matchers.equalTo(expected.size()));
       for (int i = 0; i < recordedWrites.size(); i++) {
         final byte[] bytes = recordedWrites.get(i);

--- a/ksql-rest-app/src/test/java/io/confluent/ksql/rest/server/resources/streaming/WSQueryEndpointTest.java
+++ b/ksql-rest-app/src/test/java/io/confluent/ksql/rest/server/resources/streaming/WSQueryEndpointTest.java
@@ -34,9 +34,6 @@ import com.google.common.util.concurrent.ListeningScheduledExecutorService;
 import io.confluent.kafka.schemaregistry.client.SchemaRegistryClient;
 import io.confluent.ksql.KsqlEngine;
 import io.confluent.ksql.parser.KsqlParser.PreparedStatement;
-import io.confluent.ksql.parser.tree.NodeLocation;
-import io.confluent.ksql.parser.tree.PrintTopic;
-import io.confluent.ksql.parser.tree.QualifiedName;
 import io.confluent.ksql.parser.tree.Query;
 import io.confluent.ksql.parser.tree.QueryBody;
 import io.confluent.ksql.parser.tree.Statement;
@@ -322,7 +319,7 @@ public class WSQueryEndpointTest {
   @Test
   public void shouldHandlePrintTopic() {
     // Given:
-    givenRequestIs(printTopic("bob", true));
+    givenRequestIs(StreamingTestUtils.printTopic("bob", true, null, null));
     when(topicClient.isTopicExists("bob")).thenReturn(true);
     when(ksqlConfig.getKsqlStreamConfigProps()).thenReturn(ImmutableMap.of("this", "that"));
 
@@ -334,15 +331,14 @@ public class WSQueryEndpointTest {
         eq(exec),
         eq(schemaRegistryClient),
         eq(ImmutableMap.of("this", "that")),
-        eq("bob"),
-        eq(true),
+        eq(StreamingTestUtils.printTopic("bob", true, null, null)),
         any());
   }
 
   @Test
   public void shouldReturnErrorIfTopicDoesNotExist() throws Exception {
     // Given:
-    givenRequestIs(printTopic("bob", true));
+    givenRequestIs(StreamingTestUtils.printTopic("bob", true, null, null));
     when(topicClient.isTopicExists("bob")).thenReturn(false);
 
     // When:
@@ -391,16 +387,6 @@ public class WSQueryEndpointTest {
     // Then:
     verifyClosedWithReason("yikes", CloseCodes.TRY_AGAIN_LATER);
     verify(statementParser, never()).parseSingleStatement(any());
-  }
-
-  private static PrintTopic printTopic(final String name, final boolean fromBeginning) {
-    return new PrintTopic(
-        new NodeLocation(0, 1),
-        QualifiedName.of(name),
-        fromBeginning,
-        Optional.empty(),
-        Optional.empty()
-    );
   }
 
   private void givenVersions(final String... versions) {

--- a/ksql-rest-app/src/test/java/io/confluent/ksql/rest/server/resources/streaming/WSQueryEndpointTest.java
+++ b/ksql-rest-app/src/test/java/io/confluent/ksql/rest/server/resources/streaming/WSQueryEndpointTest.java
@@ -398,6 +398,7 @@ public class WSQueryEndpointTest {
         new NodeLocation(0, 1),
         QualifiedName.of(name),
         fromBeginning,
+        Optional.empty(),
         Optional.empty()
     );
   }

--- a/ksql-rest-app/src/test/java/io/confluent/ksql/rest/server/resources/streaming/WSQueryEndpointTest.java
+++ b/ksql-rest-app/src/test/java/io/confluent/ksql/rest/server/resources/streaming/WSQueryEndpointTest.java
@@ -52,7 +52,7 @@ import java.time.Duration;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
-import java.util.Optional;
+import java.util.OptionalInt;
 import java.util.concurrent.TimeoutException;
 import java.util.stream.Collectors;
 import javax.websocket.CloseReason;
@@ -128,7 +128,7 @@ public class WSQueryEndpointTest {
 
   @Before
   public void setUp() {
-    query = new Query(queryBody, Optional.empty());
+    query = new Query(queryBody, OptionalInt.empty());
 
     when(session.getId()).thenReturn("session-id");
     when(statementParser.parseSingleStatement(anyString()))

--- a/pom.xml
+++ b/pom.xml
@@ -91,6 +91,7 @@
         <airline.version>2.6.0</airline.version>
         <antlr.version>4.7</antlr.version>
         <csv.version>1.4</csv.version>
+        <lang3.version>3.3.1</lang3.version>
         <guava.version>24.0-jre</guava.version>
         <inject.version>1</inject.version>
         <janino.version>3.0.7</janino.version>
@@ -270,6 +271,12 @@
                 <groupId>org.apache.commons</groupId>
                 <artifactId>commons-csv</artifactId>
                 <version>${csv.version}</version>
+            </dependency>
+
+            <dependency>
+                <groupId>org.apache.commons</groupId>
+                <artifactId>commons-lang3</artifactId>
+                <version>${lang3.version}</version>
             </dependency>
 
             <dependency>


### PR DESCRIPTION
### Description 
See discussion on #1316 - this adds support to "early terminate" PRINT queries. This is especially helpful for starters and for demos.

Fixes #1316 

### Testing done 
- Unit Testing
- Various tests with CLI: `PRINT 'topic' FROM BEGINNING LIMIT 1`, `PRINT 'topic' FROM BEGINNING INTERVAL 2 LIMIT 2`, `PRINT 'topic' FROM BEGINNING LIMIT ALL`, (failure case) `PRINT 'topic' FROM BEGINNING LIMIT FOOBAR`

Checked through C3 that the LIMIT/INTERVAL statements work - set deubg log statement and issued the following two queries:

```
PRINT 'pageviews' FROM BEGINNING LIMIT 3;
PRINT 'pageviews' FROM BEGINNING INTERVAL 2 LIMIT 3;
```

And got the following results:
```
[2/1/19 11:55:07 AM PST, 1, {"viewtime": 1, "userid": "User_4", "pageid": "Page_73"}
, 2/1/19 11:55:07 AM PST, 11, {"viewtime": 11, "userid": "User_3", "pageid": "Page_81"}
, 2/1/19 11:55:08 AM PST, 21, {"viewtime": 21, "userid": "User_5", "pageid": "Page_10"}
], 

[2/1/19 11:55:07 AM PST, 1, {"viewtime": 1, "userid": "User_4", "pageid": "Page_73"}
, 2/1/19 11:55:08 AM PST, 21, {"viewtime": 21, "userid": "User_5", "pageid": "Page_10"}
, 2/1/19 11:55:08 AM PST, 41, {"viewtime": 41, "userid": "User_9", "pageid": "Page_69"}
]
```

### Reviewer checklist
- [ ] Ensure docs are updated if necessary. (eg. if a user visible feature is being added or changed).
- [ ] Ensure relevant issues are linked (description should include text like "Fixes #<issue number>")

