### PR TITLE
Rest API: support for multi-line interdependent requests.

### DIFF
--- a/ksql-rest-app/src/main/java/io/confluent/ksql/rest/entity/CommandStatusEntity.java
+++ b/ksql-rest-app/src/main/java/io/confluent/ksql/rest/entity/CommandStatusEntity.java
@@ -49,7 +49,7 @@ public class CommandStatusEntity extends KsqlEntity {
     return commandStatus;
   }
 
-  public Long getCommandSequenceNumber() {
+  public long getCommandSequenceNumber() {
     return commandSequenceNumber;
   }
 

--- a/ksql-rest-app/src/main/java/io/confluent/ksql/rest/server/resources/Errors.java
+++ b/ksql-rest-app/src/main/java/io/confluent/ksql/rest/server/resources/Errors.java
@@ -31,13 +31,16 @@ public final class Errors {
 
   static final int ERROR_CODE_BAD_REQUEST = toErrorCode(BAD_REQUEST.getStatusCode());
   static final int ERROR_CODE_BAD_STATEMENT = toErrorCode(BAD_REQUEST.getStatusCode()) + 1;
-  static final int ERROR_CODE_QUERY_ENDPOINT = toErrorCode(BAD_REQUEST.getStatusCode()) + 2;
+  private static final int ERROR_CODE_QUERY_ENDPOINT = toErrorCode(BAD_REQUEST.getStatusCode()) + 2;
 
   public static final int ERROR_CODE_UNAUTHORIZED = toErrorCode(UNAUTHORIZED.getStatusCode());
 
   public static final int ERROR_CODE_FORBIDDEN = toErrorCode(FORBIDDEN.getStatusCode());
 
   static final int ERROR_CODE_NOT_FOUND = toErrorCode(NOT_FOUND.getStatusCode());
+
+  static final int ERROR_CODE_SERVER_SHUTTING_DOWN =
+      toErrorCode(SERVICE_UNAVAILABLE.getStatusCode());
 
   public static final int ERROR_CODE_COMMAND_QUEUE_CATCHUP_TIMEOUT =
       toErrorCode(SERVICE_UNAVAILABLE.getStatusCode()) + 1;
@@ -128,10 +131,22 @@ public final class Errors {
         .build();
   }
 
-  public static Response commandQueueCatchUpTimeout(final String msg) {
+  public static Response commandQueueCatchUpTimeout(final long cmdSeqNum) {
+    final String errorMsg = "Timed out while waiting for a previous command to execute. "
+        + "command sequence number: " + cmdSeqNum;
+
     return Response
         .status(SERVICE_UNAVAILABLE)
-        .entity(new KsqlErrorMessage(ERROR_CODE_COMMAND_QUEUE_CATCHUP_TIMEOUT, msg))
+        .entity(new KsqlErrorMessage(ERROR_CODE_COMMAND_QUEUE_CATCHUP_TIMEOUT, errorMsg))
+        .build();
+  }
+
+  static Response serverShuttingDown() {
+    return Response
+        .status(SERVICE_UNAVAILABLE)
+        .entity(new KsqlErrorMessage(
+            ERROR_CODE_SERVER_SHUTTING_DOWN,
+            "The server is shutting down"))
         .build();
   }
 }

--- a/ksql-rest-app/src/main/java/io/confluent/ksql/rest/server/resources/KsqlResource.java
+++ b/ksql-rest-app/src/main/java/io/confluent/ksql/rest/server/resources/KsqlResource.java
@@ -307,7 +307,6 @@ public class KsqlResource {
     reversed.stream()
         .filter(e -> e instanceof CommandStatusEntity)
         .map(cs -> ((CommandStatusEntity) cs).getCommandSequenceNumber())
-        .filter(Objects::nonNull)
         .findFirst()
         .ifPresent(seqNum -> {
           try {

--- a/ksql-rest-app/src/main/java/io/confluent/ksql/rest/util/CommandStoreUtil.java
+++ b/ksql-rest-app/src/main/java/io/confluent/ksql/rest/util/CommandStoreUtil.java
@@ -36,12 +36,15 @@ public final class CommandStoreUtil {
     try {
       waitForCommandSequenceNumber(commandQueue, request, timeout);
     } catch (final InterruptedException e) {
-      final String errorMsg = "Interrupted while waiting for command queue to reach "
-          + "specified command sequence number in request: " + request.getKsql();
+      final long seqNum = request.getCommandSequenceNumber().orElse(-1L);
+      final String errorMsg = "Interrupted while waiting for command with the supplied "
+          + "sequence number to execute. sequence number: " + seqNum
+          + ", request: " + request.getKsql();
       throw new KsqlRestException(
           Errors.serverErrorForStatement(e, errorMsg, new KsqlEntityList()));
     } catch (final TimeoutException e) {
-      throw new KsqlRestException(Errors.commandQueueCatchUpTimeout(e.getMessage()));
+      throw new KsqlRestException(Errors.commandQueueCatchUpTimeout(
+          request.getCommandSequenceNumber().orElse(-1L)));
     }
   }
 

--- a/ksql-rest-app/src/test/java/io/confluent/ksql/rest/server/resources/KsqlResourceTest.java
+++ b/ksql-rest-app/src/test/java/io/confluent/ksql/rest/server/resources/KsqlResourceTest.java
@@ -665,7 +665,7 @@ public class KsqlResourceTest {
   }
 
   @Test
-  public void shouldWaitForLastDistributedStatementBeforeExecutingAnyNoneDistributed()
+  public void shouldWaitForLastDistributedStatementBeforeExecutingAnyNonDistributed()
       throws Exception
   {
     // Given:

--- a/ksql-rest-app/src/test/java/io/confluent/ksql/rest/server/resources/KsqlResourceTest.java
+++ b/ksql-rest-app/src/test/java/io/confluent/ksql/rest/server/resources/KsqlResourceTest.java
@@ -14,9 +14,14 @@
 
 package io.confluent.ksql.rest.server.resources;
 
+import static io.confluent.ksql.rest.entity.KsqlErrorMessageMatchers.errorCode;
 import static io.confluent.ksql.rest.entity.KsqlErrorMessageMatchers.errorMessage;
 import static io.confluent.ksql.rest.entity.KsqlStatementErrorMessageMatchers.statement;
 import static io.confluent.ksql.rest.server.computation.CommandId.Action.CREATE;
+import static io.confluent.ksql.rest.server.computation.CommandId.Action.DROP;
+import static io.confluent.ksql.rest.server.computation.CommandId.Action.EXECUTE;
+import static io.confluent.ksql.rest.server.computation.CommandId.Type.STREAM;
+import static io.confluent.ksql.rest.server.computation.CommandId.Type.TABLE;
 import static io.confluent.ksql.rest.server.computation.CommandId.Type.TOPIC;
 import static io.confluent.ksql.rest.server.resources.KsqlRestExceptionMatchers.exceptionErrorMessage;
 import static io.confluent.ksql.rest.server.resources.KsqlRestExceptionMatchers.exceptionStatementErrorMessage;
@@ -40,6 +45,7 @@ import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.ArgumentMatchers.isA;
+import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.inOrder;
 import static org.mockito.Mockito.mock;
@@ -139,6 +145,7 @@ import org.junit.runner.RunWith;
 import org.mockito.InOrder;
 import org.mockito.Mock;
 import org.mockito.junit.MockitoJUnitRunner;
+import org.mockito.stubbing.Answer;
 
 @SuppressWarnings("unchecked")
 @RunWith(MockitoJUnitRunner.class)
@@ -173,6 +180,8 @@ public class KsqlResourceTest {
   private KsqlResource ksqlResource;
   private SchemaRegistryClient schemaRegistryClient;
   private QueuedCommandStatus commandStatus;
+  private QueuedCommandStatus commandStatus1;
+  private QueuedCommandStatus commandStatus2;
   private MetaStoreImpl metaStore;
   private ServiceContext serviceContext;
 
@@ -182,6 +191,13 @@ public class KsqlResourceTest {
   public void setUp() throws IOException, RestClientException {
     commandStatus = new QueuedCommandStatus(
         0, new CommandStatusFuture(new CommandId(TOPIC, "whateva", CREATE)));
+
+    commandStatus1 = new QueuedCommandStatus(
+        1, new CommandStatusFuture(new CommandId(TABLE, "something", DROP)));
+
+    commandStatus2 = new QueuedCommandStatus(
+        2, new CommandStatusFuture(new CommandId(STREAM, "something", EXECUTE)));
+
     kafkaTopicClient = new FakeKafkaTopicClient();
     serviceContext = TestServiceContext.create(kafkaTopicClient);
     schemaRegistryClient = serviceContext.getSchemaRegistryClient();
@@ -202,7 +218,10 @@ public class KsqlResourceTest {
 
     setUpKsqlResource();
 
-    when(commandStore.enqueueCommand(any(), any(), any(), any())).thenReturn(commandStatus);
+    when(commandStore.enqueueCommand(any(), any(), any(), any()))
+        .thenReturn(commandStatus)
+        .thenReturn(commandStatus1)
+        .thenReturn(commandStatus2);
 
     streamName = KsqlIdentifierTestUtil.uniqueIdentifierName();
   }
@@ -643,6 +662,101 @@ public class KsqlResourceTest {
         eq("CREATE STREAM S AS SELECT * FROM test_stream;"), any(), any(), any());
     inOrder.verify(commandStore).enqueueCommand(
         eq("CREATE STREAM S2 AS SELECT * FROM S;"), any(), any(), any());
+  }
+
+  @Test
+  public void shouldWaitForLastDistributedStatementBeforeExecutingAnyNoneDistributed()
+      throws Exception
+  {
+    // Given:
+    final String csasSql = "CREATE STREAM S AS SELECT * FROM test_stream;";
+
+    doAnswer(executeAgainstEngine(csasSql))
+        .when(commandStore)
+        .ensureConsumedPast(
+            commandStatus1.getCommandSequenceNumber(),
+            DISTRIBUTED_COMMAND_RESPONSE_TIMEOUT
+        );
+
+    // When:
+    final List<KsqlEntity> results = makeMultipleRequest(
+        csasSql + "\n"   // <-- commandStatus
+            + "CREATE STREAM S2 AS SELECT * FROM test_stream;\n" // <-- commandStatus1
+            + "DESCRIBE S;",
+        KsqlEntity.class
+    );
+
+    // Then:
+    verify(commandStore).ensureConsumedPast(
+        commandStatus1.getCommandSequenceNumber(), DISTRIBUTED_COMMAND_RESPONSE_TIMEOUT);
+
+    assertThat(results, hasSize(3));
+    assertThat(results.get(2), is(instanceOf(SourceDescriptionEntity.class)));
+  }
+
+  @Test
+  public void shouldNotWaitOnAnyDistributedStatementsBeforeDistributingAnother() throws Exception {
+    // When:
+    makeMultipleRequest(
+        "CREATE STREAM S AS SELECT * FROM test_stream;\n"
+            + "CREATE STREAM S2 AS SELECT * FROM test_stream;",
+        KsqlEntity.class
+    );
+
+    // Then:
+    verify(commandStore, never()).ensureConsumedPast(anyLong(), any());
+  }
+
+  @Test
+  public void shouldThrowShutdownIfInterruptedWhileAwaitingPreviousCmdInMultiStatementRequest()
+      throws Exception
+  {
+    // Given:
+    doThrow(new InterruptedException("oh no!"))
+        .when(commandStore)
+        .ensureConsumedPast(anyLong(), any());
+
+    // Then:
+    expectedException.expect(KsqlRestException.class);
+    expectedException.expect(exceptionStatusCode(is(Code.SERVICE_UNAVAILABLE)));
+    expectedException
+        .expect(exceptionErrorMessage(errorMessage(is("The server is shutting down"))));
+    expectedException
+        .expect(exceptionErrorMessage(errorCode(is(Errors.ERROR_CODE_SERVER_SHUTTING_DOWN))));
+
+    // When:
+    makeMultipleRequest(
+        "CREATE STREAM S AS SELECT * FROM test_stream;\n"
+            + "DESCRIBE S;",
+        KsqlEntity.class
+    );
+  }
+
+  @Test
+  public void shouldThrowTimeoutOnTimeoutAwaitingPreviousCmdInMultiStatementRequest()
+      throws Exception
+  {
+    // Given:
+    doThrow(new TimeoutException("oh no!"))
+        .when(commandStore)
+        .ensureConsumedPast(anyLong(), any());
+
+    // Then:
+    expectedException.expect(KsqlRestException.class);
+    expectedException.expect(exceptionStatusCode(is(Code.SERVICE_UNAVAILABLE)));
+    expectedException.expect(exceptionErrorMessage(errorMessage(
+        containsString("Timed out"))));
+    expectedException.expect(exceptionErrorMessage(errorMessage(
+        containsString("sequence number: " + commandStatus.getCommandSequenceNumber()))));
+    expectedException.expect(exceptionErrorMessage(errorCode(
+        is(Errors.ERROR_CODE_COMMAND_QUEUE_CATCHUP_TIMEOUT))));
+
+    // When:
+    makeMultipleRequest(
+        "CREATE STREAM S AS SELECT * FROM test_stream;\n"
+            + "DESCRIBE S;",
+        KsqlEntity.class
+    );
   }
 
   @Test
@@ -1127,7 +1241,9 @@ public class KsqlResourceTest {
 
     // Then:
     assertThat(result.getErrorCode(), is(Errors.ERROR_CODE_COMMAND_QUEUE_CATCHUP_TIMEOUT));
-    assertThat(result.getMessage(), is("timed out!"));
+    assertThat(result.getMessage(),
+        containsString("Timed out while waiting for a previous command to execute"));
+    assertThat(result.getMessage(), containsString("command sequence number: 2"));
   }
 
   @Test
@@ -1188,6 +1304,13 @@ public class KsqlResourceTest {
 
     // When:
     ksqlResource.terminateCluster(request);
+  }
+
+  private Answer executeAgainstEngine(final String sql) {
+    return invocation -> {
+      KsqlEngineTestUtil.execute(ksqlEngine, sql, ksqlConfig, Collections.emptyMap());
+      return null;
+    };
   }
 
   @SuppressWarnings("SameParameterValue")

--- a/ksql-rest-app/src/test/java/io/confluent/ksql/rest/server/resources/StreamedQueryResourceTest.java
+++ b/ksql-rest-app/src/test/java/io/confluent/ksql/rest/server/resources/StreamedQueryResourceTest.java
@@ -218,7 +218,8 @@ public class StreamedQueryResourceTest {
     // Expect
     expectedException.expect(KsqlRestException.class);
     expectedException.expect(exceptionStatusCode(is(Code.SERVICE_UNAVAILABLE)));
-    expectedException.expect(exceptionErrorMessage(errorMessage(is("whoops"))));
+    expectedException.expect(exceptionErrorMessage(errorMessage(
+        containsString("Timed out while waiting for a previous command to execute"))));
     expectedException.expect(
         exceptionErrorMessage(errorCode(is(Errors.ERROR_CODE_COMMAND_QUEUE_CATCHUP_TIMEOUT))));
 

--- a/ksql-rest-app/src/test/java/io/confluent/ksql/rest/util/CommandStoreUtilTest.java
+++ b/ksql-rest-app/src/test/java/io/confluent/ksql/rest/util/CommandStoreUtilTest.java
@@ -19,6 +19,7 @@ import static io.confluent.ksql.rest.entity.KsqlErrorMessageMatchers.errorMessag
 import static io.confluent.ksql.rest.server.resources.KsqlRestExceptionMatchers.exceptionErrorMessage;
 import static io.confluent.ksql.rest.server.resources.KsqlRestExceptionMatchers.exceptionStatusCode;
 import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.Matchers.containsString;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.Mockito.doThrow;
@@ -88,7 +89,10 @@ public class CommandStoreUtilTest {
     // Expect:
     expectedException.expect(KsqlRestException.class);
     expectedException.expect(exceptionStatusCode(is(Code.SERVICE_UNAVAILABLE)));
-    expectedException.expect(exceptionErrorMessage(errorMessage(is("uh oh"))));
+    expectedException.expect(exceptionErrorMessage(errorMessage(
+        containsString("Timed out while waiting for a previous command to execute"))));
+    expectedException.expect(exceptionErrorMessage(errorMessage(
+        containsString("command sequence number: 2"))));
 
     // When:
     CommandStoreUtil.httpWaitForCommandSequenceNumber(commandQueue, request, TIMEOUT);


### PR DESCRIPTION
### Description 

Fixes: #2197

This PR adds support for multi-line rest requests where later non-distributed statements are dependant on former distributed statements, e.g.

```sql
CREATE STREAM S AS SELECT * FROM SOMETHING;
DESCRIBE S;
```

Here the CSAS call is distributed to the command topic and then the `DESCRIBE` call is handled by the rest api. This change ensures the CSAS statement has been processed by the main engine thread _before_ processing the `DESCRIBE` call.

### Testing done 
 Tests added and manual

### Reviewer checklist
- [ ] Ensure docs are updated if necessary. (eg. if a user visible feature is being added or changed).
- [ ] Ensure relevant issues are linked (description should include text like "Fixes #<issue number>")

