### PR TITLE
Fix late/missed review comments/feedback from processing logger prs

### DIFF
--- a/docs/developer-guide/processing-log.rst
+++ b/docs/developer-guide/processing-log.rst
@@ -127,10 +127,11 @@ log entries as JSON:
 
 ::
 
-    log4j.appender.kafka=org.apache.kafka.log4jappender.KafkaLog4jAppender
-    log4j.appender.kafka.layout=io.confluent.common.logging.log4j.StructuredJsonLayout
-    log4j.appender.kafka.BrokerList=<list of kafka brokers>
-    log4j.appender.kafka.Topic=<kafka topic>
+    log4j.appender.kafka_appender=org.apache.kafka.log4jappender.KafkaLog4jAppender
+    log4j.appender.kafka_appender.layout=io.confluent.common.logging.log4j.StructuredJsonLayout
+    log4j.appender.kafka_appender.BrokerList=<list of kafka brokers>
+    log4j.appender.kafka_appender.Topic=<kafka topic>
+    log4j.logger.processing=ERROR, kafka_appender
 
 The ``list of kafka brokers`` setting is a comma-separated list of brokers in the Kafka cluster, and
 ``kafka topic`` is the name of the Kafka topic to log to.
@@ -140,19 +141,21 @@ properties file:
 
 ::
 
-    ksql.processing.log.topic.auto.create=on
-    ksql.processing.log.topic.name=<kafka topic>  # defaults to processing_log
+    ksql.processing.log.topic.auto.create=true
+    ksql.processing.log.topic.name=<kafka topic>  # defaults to <ksql service id>processing_log
 
 The replication factor and partition count are configurable
 using the ``ksql.processing.log.topic.replication.factor`` and ``ksql.processing.log.topic.partitions`` properties,
 respectively.
+
+If the ``ksql.processing.log.topic.name`` property is not specified, the processing log topic name will default to ``<ksql service id>processing_log``, where ``ksql service id`` is the value from the ``ksql.service.id`` property. This ensures each KSQL cluster gets its own processing log topic by default.
 
 If you are bringing up a new interactive mode KSQL cluster, you can configure KSQL to set up
 a log stream automatically by including the following in your KSQL properties file:
 
 ::
 
-    ksql.processing.log.stream.auto.create=on
+    ksql.processing.log.stream.auto.create=true
     ksql.processing.log.stream.name=<stream name>  # defaults to PROCESSING_LOG
 
 When you start KSQL, you should see the stream in your list of streams:

--- a/ksql-rest-app/src/main/java/io/confluent/ksql/rest/server/StandaloneExecutor.java
+++ b/ksql-rest-app/src/main/java/io/confluent/ksql/rest/server/StandaloneExecutor.java
@@ -114,8 +114,7 @@ public class StandaloneExecutor implements Executable {
           serviceContext.getTopicClient(),
           processingLogConfig,
           ksqlConfig);
-      if (processingLogConfig.getString(ProcessingLogConfig.STREAM_AUTO_CREATE)
-          .equals(ProcessingLogConfig.AUTO_CREATE_ON)) {
+      if (processingLogConfig.getBoolean(ProcessingLogConfig.STREAM_AUTO_CREATE)) {
         log.warn("processing log auto-create is enabled, but this is not supported "
             + "for headless mode.");
       }

--- a/ksql-rest-app/src/main/java/io/confluent/ksql/rest/util/ProcessingLogConfig.java
+++ b/ksql-rest-app/src/main/java/io/confluent/ksql/rest/util/ProcessingLogConfig.java
@@ -20,8 +20,6 @@ import org.apache.kafka.common.config.AbstractConfig;
 import org.apache.kafka.common.config.ConfigDef;
 import org.apache.kafka.common.config.ConfigDef.Importance;
 import org.apache.kafka.common.config.ConfigDef.Type;
-import org.apache.kafka.common.config.ConfigDef.ValidString;
-import org.apache.kafka.common.config.ConfigDef.Validator;
 
 public class ProcessingLogConfig extends AbstractConfig {
   private static final String PROPERTY_PREFIX = "processing.log.";
@@ -29,9 +27,6 @@ public class ProcessingLogConfig extends AbstractConfig {
   private static String propertyName(final String name) {
     return KsqlConfig.KSQL_CONFIG_PROPERTY_PREFIX + PROPERTY_PREFIX + name;
   }
-
-  public static final String AUTO_CREATE_ON = "on";
-  public static final String AUTO_CREATE_OFF = "off";
 
   public static final String STREAM_NAME = propertyName("stream.name");
   private static final String STREAM_NAME_DEFAULT = "KSQL_PROCESSING_LOG";
@@ -61,36 +56,30 @@ public class ProcessingLogConfig extends AbstractConfig {
 
   public static final String STREAM_AUTO_CREATE = propertyName("stream.auto.create");
   private static final String STREAM_AUTO_CREATE_DOC = String.format(
-      "Toggles automatic processing log stream creation. If set to \"%s\", and "
+      "Toggles automatic processing log stream creation. If set to true, and "
           + "running interactive mode on a new cluster, then KSQL will automatically "
           + "create a processing log stream when it starts up. The name for the stream "
           + "is the value of the \"%s\" property. The stream will be created over the topic "
           + "set in the \"%s\" property",
-      AUTO_CREATE_ON,
       STREAM_NAME,
       TOPIC_NAME);
 
   public static final String TOPIC_AUTO_CREATE = propertyName("topic.auto.create");
   private static final String TOPIC_AUTO_CREATE_DOC = String.format(
-      "Toggles automatic processing log topic creation. If set to \"%s\", then "
+      "Toggles automatic processing log topic creation. If set to true, then "
           + "KSQL will automatically try to create a processing log topic at startup. "
           + "The name of the topic is the value of the \"%s\" property. The number of "
           + "partitions is taken from the \"%s\" property , and the replication factor "
           + "is taken from the \"%s\" property",
-      AUTO_CREATE_ON,
       TOPIC_NAME,
       TOPIC_PARTITIONS,
       TOPIC_REPLICATION_FACTOR);
 
-  private static final Validator AUTO_CREATE_VALIDATOR
-      = ValidString.in(AUTO_CREATE_ON, AUTO_CREATE_OFF);
-
   private static final ConfigDef CONFIG_DEF = new ConfigDef()
       .define(
           STREAM_AUTO_CREATE,
-          Type.STRING,
-          AUTO_CREATE_OFF,
-          AUTO_CREATE_VALIDATOR,
+          Type.BOOLEAN,
+          false,
           Importance.MEDIUM,
           STREAM_AUTO_CREATE_DOC)
       .define(
@@ -101,9 +90,8 @@ public class ProcessingLogConfig extends AbstractConfig {
           STREAM_NAME_DOC)
       .define(
           TOPIC_AUTO_CREATE,
-          Type.STRING,
-          AUTO_CREATE_OFF,
-          AUTO_CREATE_VALIDATOR,
+          Type.BOOLEAN,
+          false,
           Importance.MEDIUM,
           TOPIC_AUTO_CREATE_DOC)
       .define(

--- a/ksql-rest-app/src/test/java/io/confluent/ksql/rest/server/StandaloneExecutorTest.java
+++ b/ksql-rest-app/src/test/java/io/confluent/ksql/rest/server/StandaloneExecutorTest.java
@@ -22,6 +22,7 @@ import static org.mockito.ArgumentMatchers.anyInt;
 import static org.mockito.ArgumentMatchers.anyShort;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
@@ -71,7 +72,7 @@ public class StandaloneExecutorTest {
   private static final String PROCESSING_LOG_TOPIC_NAME = "proclogtop";
   private static final ProcessingLogConfig processingLogConfig =
       new ProcessingLogConfig(ImmutableMap.of(
-          ProcessingLogConfig.TOPIC_AUTO_CREATE, ProcessingLogConfig.AUTO_CREATE_ON,
+          ProcessingLogConfig.TOPIC_AUTO_CREATE, true,
           ProcessingLogConfig.TOPIC_NAME, PROCESSING_LOG_TOPIC_NAME
       ));
   private static final KsqlConfig ksqlConfig = new KsqlConfig(emptyMap());
@@ -166,6 +167,31 @@ public class StandaloneExecutorTest {
 
     // Then
     verify(kafkaTopicClient).createTopic(eq(PROCESSING_LOG_TOPIC_NAME), anyInt(), anyShort());
+  }
+
+  @Test
+  public void shouldNotCreateProcessingLogTopicIfNotConfigured() {
+    // Given:
+    standaloneExecutor = new StandaloneExecutor(
+        serviceContext,
+        new ProcessingLogConfig(ImmutableMap.of(
+            ProcessingLogConfig.TOPIC_AUTO_CREATE, false,
+            ProcessingLogConfig.TOPIC_NAME, PROCESSING_LOG_TOPIC_NAME
+        )),
+        ksqlConfig,
+        engine,
+        queriesFile.toString(),
+        udfLoader,
+        false,
+        versionCheckerAgent
+    );
+
+    // When:
+    standaloneExecutor.start();
+
+    // Then
+    verify(kafkaTopicClient, times(0))
+        .createTopic(eq(PROCESSING_LOG_TOPIC_NAME), anyInt(), anyShort());
   }
 
   @Test


### PR DESCRIPTION
### Description 

- Fix the log4j config examples in the docs for logging to Kafka to
  use the name kafka_appender to avoid clashing with the appender we
  use for kafka libraries.
- Document how the default processing log topic name is computed
- Return a PreparedStatement from processingLogStreamCreateStatement
  instead of a String
- Switch the auto create configs to boolean
- Add a test to verify we dont create the log topic if not configured

### Testing done 
_Describe the testing strategy. Unit and integration tests are expected for any behavior changes._

### Reviewer checklist
- [ ] Ensure docs are updated if necessary. (eg. if a user visible feature is being added or changed).
- [ ] Ensure relevant issues are linked (description should include text like "Fixes #<issue number>")

