### PR TITLE
Support related TERMINATE and DROP in single parse request.

### DIFF
--- a/ksql-engine/src/main/java/io/confluent/ksql/KsqlEngine.java
+++ b/ksql-engine/src/main/java/io/confluent/ksql/KsqlEngine.java
@@ -50,6 +50,7 @@ import io.confluent.ksql.parser.tree.QuerySpecification;
 import io.confluent.ksql.parser.tree.SetProperty;
 import io.confluent.ksql.parser.tree.StringLiteral;
 import io.confluent.ksql.parser.tree.Table;
+import io.confluent.ksql.parser.tree.TerminateQuery;
 import io.confluent.ksql.parser.tree.UnsetProperty;
 import io.confluent.ksql.planner.LogicalPlanNode;
 import io.confluent.ksql.query.QueryId;
@@ -509,6 +510,8 @@ public class KsqlEngine implements KsqlExecutionContext, Closeable {
           validateInsertIntoStatement((PreparedStatement<InsertInto>) statement);
         } else if (statement.getStatement() instanceof ExecutableDdlStatement) {
           postProcessDdlStatement(statement);
+        } else if (statement.getStatement() instanceof TerminateQuery) {
+          postProcessTerminateStatement((TerminateQuery)statement.getStatement());
         }
       } catch (final KsqlStatementException e) {
         throw e;
@@ -564,6 +567,10 @@ public class KsqlEngine implements KsqlExecutionContext, Closeable {
           false);
 
       engineContext.ddlCommandExec.execute(ddlCmd);
+    }
+
+    private void postProcessTerminateStatement(final TerminateQuery statement) {
+      engineContext.metaStore.removePersistentQuery(statement.getQueryId().getId());
     }
   }
 

--- a/ksql-engine/src/test/java/io/confluent/ksql/KsqlEngineTest.java
+++ b/ksql-engine/src/test/java/io/confluent/ksql/KsqlEngineTest.java
@@ -92,7 +92,7 @@ import org.junit.runner.RunWith;
 import org.mockito.Spy;
 import org.mockito.junit.MockitoJUnitRunner;
 
-@SuppressWarnings("ConstantConditions")
+@SuppressWarnings({"ConstantConditions", "SameParameterValue"})
 @RunWith(MockitoJUnitRunner.class)
 public class KsqlEngineTest {
 
@@ -1021,6 +1021,19 @@ public class KsqlEngineTest {
         is(instanceOf(ReadonlyMetaStore.class)));
   }
 
+  @Test
+  public void shouldBeAbleToParseTerminateAndDrop() {
+    // Given:
+    givenSqlAlreadyExecuted("CREATE STREAM FOO AS SELECT * FROM TEST1;");
+
+    // When:
+    ksqlEngine.parseStatements(
+        "TERMINATE CSAS_FOO_0;"
+        + "DROP STREAM FOO;");
+
+    // Then: did not throw.
+  }
+
   private void givenTopicsExist(final String... topics) {
     givenTopicsExist(1, topics);
   }
@@ -1051,6 +1064,12 @@ public class KsqlEngineTest {
       final PreparedStatement<?> statement
   ) {
     ksqlEngine.execute(statement, KSQL_CONFIG, new HashMap<>());
+    sandbox = ksqlEngine.createSandbox();
+  }
+
+  private void givenSqlAlreadyExecuted(final String sql) {
+    ksqlEngine.parseStatements(sql)
+        .forEach(stmt -> ksqlEngine.execute(stmt, KSQL_CONFIG, new HashMap<>()));
     sandbox = ksqlEngine.createSandbox();
   }
 }


### PR DESCRIPTION
### Description 
Fixes: #2420 

Without this PR calling `KsqlEngine.parseStatements(sql)` will throw if the `sql` contains a TERMINATE statement that _should_ terminate any queries required by a later `DROP STREAM` statement.

This PR fixes this.

### Testing done 
Manual and added tests.

### Reviewer checklist
- [ ] Ensure docs are updated if necessary. (eg. if a user visible feature is being added or changed).
- [ ] Ensure relevant issues are linked (description should include text like "Fixes #<issue number>")

