### PR TITLE
Include processing log topic in cluster cleanup

### DIFF
--- a/docs/developer-guide/api.rst
+++ b/docs/developer-guide/api.rst
@@ -332,7 +332,7 @@ If a CREATE, DROP, or TERMINATE statement returns a command status with state QU
 
 .. _ksql_cluster_terminate:
 
-Terminate A Cluster
+Terminate a Cluster
 -------------------
 
 If you don't need your KSQL cluster anymore, you can terminate the cluster and clean up the resources using this endpoint. To terminate a KSQL cluster, first shutdown all the servers except one.

--- a/docs/developer-guide/api.rst
+++ b/docs/developer-guide/api.rst
@@ -330,6 +330,8 @@ If a CREATE, DROP, or TERMINATE statement returns a command status with state QU
       }
 
 
+.. _ksql_cluster_terminate:
+
 Terminate A Cluster
 -------------------
 

--- a/docs/developer-guide/processing-log.rst
+++ b/docs/developer-guide/processing-log.rst
@@ -158,6 +158,8 @@ The replication factor and partition count are configurable
 using the ``ksql.processing.log.topic.replication.factor`` and ``ksql.processing.log.topic.partitions`` properties,
 respectively.
 
+If ``ksql.processing.log.topic.auto.create`` is set to ``true``, the created topic will be deleted as part of :ref:`cluster termination<ksql_cluster_terminate>`.
+
 If the ``ksql.processing.log.topic.name`` property is not specified, the processing log topic name will default to ``<ksql service id>processing_log``, where ``ksql service id`` is the value from the ``ksql.service.id`` property. This ensures each KSQL cluster gets its own processing log topic by default.
 
 If you are bringing up a new interactive mode KSQL cluster, you can configure KSQL to set up

--- a/ksql-rest-app/src/main/java/io/confluent/ksql/rest/server/KsqlRestApplication.java
+++ b/ksql-rest-app/src/main/java/io/confluent/ksql/rest/server/KsqlRestApplication.java
@@ -51,6 +51,7 @@ import io.confluent.ksql.rest.server.resources.ServerInfoResource;
 import io.confluent.ksql.rest.server.resources.StatusResource;
 import io.confluent.ksql.rest.server.resources.streaming.StreamedQueryResource;
 import io.confluent.ksql.rest.server.resources.streaming.WSQueryEndpoint;
+import io.confluent.ksql.rest.util.ClusterTerminator;
 import io.confluent.ksql.rest.util.ProcessingLogConfig;
 import io.confluent.ksql.rest.util.ProcessingLogServerUtils;
 import io.confluent.ksql.services.DefaultServiceContext;
@@ -74,9 +75,11 @@ import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
+import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
+import java.util.Optional;
 import java.util.Properties;
 import java.util.concurrent.Executors;
 import java.util.function.Function;
@@ -362,15 +365,6 @@ public final class KsqlRestApplication extends Application<KsqlRestConfig> imple
         statementParser
     );
 
-    final CommandRunner commandRunner = new CommandRunner(
-        statementExecutor,
-        commandStore,
-        ksqlConfig,
-        ksqlEngine,
-        maxStatementRetries,
-        serviceContext
-    );
-
     final RootDocument rootDocument = new RootDocument();
 
     final StatusResource statusResource = new StatusResource(statementExecutor);
@@ -400,15 +394,27 @@ public final class KsqlRestApplication extends Application<KsqlRestConfig> imple
 
     final ProcessingLogConfig processingLogConfig =
         new ProcessingLogConfig(restConfig.getOriginals());
-    ProcessingLogServerUtils.maybeCreateProcessingLogTopic(
-        serviceContext.getTopicClient(),
-        processingLogConfig,
-        ksqlConfig);
+    final Optional<String> processingLogTopic =
+        ProcessingLogServerUtils.maybeCreateProcessingLogTopic(
+            serviceContext.getTopicClient(),
+            processingLogConfig,
+            ksqlConfig);
     maybeCreateProcessingLogStream(
         processingLogConfig,
         ksqlConfig,
         ksqlEngine,
         commandStore
+    );
+
+    final List<String> managedTopics = new LinkedList<>();
+    managedTopics.add(commandTopic);
+    processingLogTopic.ifPresent(managedTopics::add);
+    final CommandRunner commandRunner = new CommandRunner(
+        statementExecutor,
+        commandStore,
+        ksqlEngine,
+        maxStatementRetries,
+        new ClusterTerminator(ksqlConfig, ksqlEngine, serviceContext, managedTopics)
     );
 
     commandRunner.processPriorCommands();

--- a/ksql-rest-app/src/main/java/io/confluent/ksql/rest/server/computation/CommandRunner.java
+++ b/ksql-rest-app/src/main/java/io/confluent/ksql/rest/server/computation/CommandRunner.java
@@ -18,8 +18,6 @@ import io.confluent.ksql.KsqlEngine;
 import io.confluent.ksql.rest.entity.ClusterTerminateRequest;
 import io.confluent.ksql.rest.util.ClusterTerminator;
 import io.confluent.ksql.rest.util.TerminateCluster;
-import io.confluent.ksql.services.ServiceContext;
-import io.confluent.ksql.util.KsqlConfig;
 import io.confluent.ksql.util.PersistentQueryMetadata;
 import io.confluent.ksql.util.RetryUtil;
 import java.io.Closeable;
@@ -52,23 +50,6 @@ public class CommandRunner implements Runnable, Closeable {
   private final ClusterTerminator clusterTerminator;
 
   public CommandRunner(
-      final StatementExecutor statementExecutor,
-      final CommandQueue commandStore,
-      final KsqlConfig ksqlConfig,
-      final KsqlEngine ksqlEngine,
-      final int maxRetries,
-      final ServiceContext serviceContext
-  ) {
-    this(
-        statementExecutor,
-        commandStore,
-        ksqlEngine,
-        maxRetries,
-        new ClusterTerminator(ksqlConfig, ksqlEngine, serviceContext)
-    );
-  }
-
-  CommandRunner(
       final StatementExecutor statementExecutor,
       final CommandQueue commandStore,
       final KsqlEngine ksqlEngine,

--- a/ksql-rest-app/src/main/java/io/confluent/ksql/rest/util/ClusterTerminator.java
+++ b/ksql-rest-app/src/main/java/io/confluent/ksql/rest/util/ClusterTerminator.java
@@ -14,16 +14,15 @@
 
 package io.confluent.ksql.rest.util;
 
+import com.google.common.collect.ImmutableList;
 import io.confluent.ksql.KsqlEngine;
 import io.confluent.ksql.metastore.KsqlTopic;
 import io.confluent.ksql.metastore.MetaStore;
-import io.confluent.ksql.rest.server.KsqlRestConfig;
 import io.confluent.ksql.services.ServiceContext;
 import io.confluent.ksql.util.ExecutorUtil;
 import io.confluent.ksql.util.KsqlConfig;
 import io.confluent.ksql.util.KsqlException;
 import io.confluent.ksql.util.QueryMetadata;
-import java.util.Collections;
 import java.util.List;
 import java.util.Objects;
 import java.util.Set;
@@ -33,26 +32,27 @@ import org.apache.commons.lang3.StringUtils;
 
 public class ClusterTerminator {
 
-  private final KsqlConfig ksqlConfig;
   private final KsqlEngine ksqlEngine;
   private final ServiceContext serviceContext;
+  private final List<String> managedTopics;
 
   public ClusterTerminator(
       final KsqlConfig ksqlConfig,
       final KsqlEngine ksqlEngine,
-      final ServiceContext serviceContext
+      final ServiceContext serviceContext,
+      final List<String> managedTopics
   ) {
     Objects.requireNonNull(ksqlConfig, "ksqlConfig is null.");
     Objects.requireNonNull(ksqlEngine, "ksqlEngine is null.");
-    this.ksqlConfig = ksqlConfig;
     this.ksqlEngine = ksqlEngine;
     this.serviceContext = Objects.requireNonNull(serviceContext);
+    this.managedTopics = ImmutableList.copyOf(Objects.requireNonNull(managedTopics));
   }
 
   public void terminateCluster(final List<String> deleteTopicPatterns) {
     terminatePersistentQueries();
     deleteSinkTopics(deleteTopicPatterns);
-    deleteCommandTopic();
+    deleteTopics(managedTopics);
     ksqlEngine.close();
   }
 
@@ -90,12 +90,6 @@ public class ClusterTerminator {
         .anyMatch(pattern -> pattern.matcher(topicName).matches());
   }
 
-  private void deleteCommandTopic() {
-    final String ksqlServiceId = ksqlConfig.getString(KsqlConfig.KSQL_SERVICE_ID_CONFIG);
-    final String commandTopic = KsqlRestConfig.getCommandTopic(ksqlServiceId);
-    deleteTopics(Collections.singletonList(commandTopic));
-  }
-
   private void deleteTopics(final List<String> topicsToBeDeleted) {
     try {
       ExecutorUtil.executeWithRetries(
@@ -104,7 +98,7 @@ public class ClusterTerminator {
           ExecutorUtil.RetryBehaviour.ALWAYS);
     } catch (final Exception e) {
       throw new KsqlException(
-          "Exception while deleting topics: " + StringUtils.join(topicsToBeDeleted, ","));
+          "Exception while deleting topics: " + StringUtils.join(topicsToBeDeleted, ", "));
     }
   }
 }

--- a/ksql-rest-app/src/main/java/io/confluent/ksql/rest/util/ClusterTerminator.java
+++ b/ksql-rest-app/src/main/java/io/confluent/ksql/rest/util/ClusterTerminator.java
@@ -46,7 +46,7 @@ public class ClusterTerminator {
     Objects.requireNonNull(ksqlEngine, "ksqlEngine is null.");
     this.ksqlEngine = ksqlEngine;
     this.serviceContext = Objects.requireNonNull(serviceContext);
-    this.managedTopics = ImmutableList.copyOf(Objects.requireNonNull(managedTopics));
+    this.managedTopics = ImmutableList.copyOf(Objects.requireNonNull(managedTopics, "managedTopics"));
   }
 
   public void terminateCluster(final List<String> deleteTopicPatterns) {

--- a/ksql-rest-app/src/main/java/io/confluent/ksql/rest/util/ClusterTerminator.java
+++ b/ksql-rest-app/src/main/java/io/confluent/ksql/rest/util/ClusterTerminator.java
@@ -46,7 +46,8 @@ public class ClusterTerminator {
     Objects.requireNonNull(ksqlEngine, "ksqlEngine is null.");
     this.ksqlEngine = ksqlEngine;
     this.serviceContext = Objects.requireNonNull(serviceContext);
-    this.managedTopics = ImmutableList.copyOf(Objects.requireNonNull(managedTopics, "managedTopics"));
+    this.managedTopics = ImmutableList.copyOf(
+        Objects.requireNonNull(managedTopics, "managedTopics"));
   }
 
   public void terminateCluster(final List<String> deleteTopicPatterns) {

--- a/ksql-rest-app/src/main/java/io/confluent/ksql/rest/util/ProcessingLogServerUtils.java
+++ b/ksql-rest-app/src/main/java/io/confluent/ksql/rest/util/ProcessingLogServerUtils.java
@@ -27,6 +27,7 @@ import io.confluent.ksql.processing.log.ProcessingLogMessageSchema;
 import io.confluent.ksql.services.KafkaTopicClient;
 import io.confluent.ksql.util.KsqlConfig;
 import io.confluent.ksql.util.TypeUtil;
+import java.util.Optional;
 import org.apache.kafka.connect.data.Schema;
 import org.apache.kafka.connect.data.SchemaAndValue;
 import org.slf4j.Logger;
@@ -62,12 +63,12 @@ public final class ProcessingLogServerUtils {
     }
   }
 
-  public static void maybeCreateProcessingLogTopic(
+  public static Optional<String> maybeCreateProcessingLogTopic(
       final KafkaTopicClient topicClient,
       final ProcessingLogConfig config,
       final KsqlConfig ksqlConfig) {
     if (!config.getBoolean(ProcessingLogConfig.TOPIC_AUTO_CREATE)) {
-      return;
+      return Optional.empty();
     }
     final String topicName = getTopicName(config, ksqlConfig);
     final int nPartitions =
@@ -79,6 +80,7 @@ public final class ProcessingLogServerUtils {
     } catch (final KafkaTopicExistsException e) {
       LOGGER.info(String.format("Log topic %s already exists", topicName), e);
     }
+    return Optional.of(topicName);
   }
 
   public static PreparedStatement<AbstractStreamCreateStatement> processingLogStreamCreateStatement(

--- a/ksql-rest-app/src/test/java/io/confluent/ksql/rest/server/computation/RecoveryTest.java
+++ b/ksql-rest-app/src/test/java/io/confluent/ksql/rest/server/computation/RecoveryTest.java
@@ -18,6 +18,7 @@ import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.CoreMatchers.instanceOf;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.contains;
+import static org.mockito.Mockito.mock;
 
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
@@ -57,7 +58,6 @@ import java.util.Set;
 import java.util.stream.Collectors;
 import javax.ws.rs.core.Response;
 import org.apache.kafka.connect.data.Schema;
-import org.easymock.EasyMock;
 import org.hamcrest.Description;
 import org.hamcrest.Matcher;
 import org.hamcrest.TypeSafeDiagnosingMatcher;
@@ -85,8 +85,7 @@ public class RecoveryTest {
   }
 
   private KsqlEngine createKsqlEngine() {
-    final KsqlEngineMetrics engineMetrics = EasyMock.niceMock(KsqlEngineMetrics.class);
-    EasyMock.replay(engineMetrics);
+    final KsqlEngineMetrics engineMetrics = mock(KsqlEngineMetrics.class);
     return KsqlEngineTestUtil.createKsqlEngine(
         serviceContext,
         new MetaStoreImpl(new InternalFunctionRegistry()),
@@ -183,7 +182,7 @@ public class RecoveryTest {
           fakeCommandQueue,
           ksqlEngine,
           1,
-          new ClusterTerminator(ksqlConfig, ksqlEngine, serviceContext, Collections.emptyList())
+          mock(ClusterTerminator.class)
       );
     }
 

--- a/ksql-rest-app/src/test/java/io/confluent/ksql/rest/server/computation/RecoveryTest.java
+++ b/ksql-rest-app/src/test/java/io/confluent/ksql/rest/server/computation/RecoveryTest.java
@@ -36,6 +36,7 @@ import io.confluent.ksql.rest.server.StatementParser;
 import io.confluent.ksql.rest.server.computation.CommandId.Action;
 import io.confluent.ksql.rest.server.computation.CommandId.Type;
 import io.confluent.ksql.rest.server.resources.KsqlResource;
+import io.confluent.ksql.rest.util.ClusterTerminator;
 import io.confluent.ksql.serde.KsqlTopicSerDe;
 import io.confluent.ksql.services.FakeKafkaTopicClient;
 import io.confluent.ksql.services.ServiceContext;
@@ -180,10 +181,9 @@ public class RecoveryTest {
       this.commandRunner = new CommandRunner(
           statementExecutor,
           fakeCommandQueue,
-          ksqlConfig,
           ksqlEngine,
           1,
-          serviceContext
+          new ClusterTerminator(ksqlConfig, ksqlEngine, serviceContext, Collections.emptyList())
       );
     }
 

--- a/ksql-rest-app/src/test/java/io/confluent/ksql/rest/util/ClusterTerminatorTest.java
+++ b/ksql-rest-app/src/test/java/io/confluent/ksql/rest/util/ClusterTerminatorTest.java
@@ -39,6 +39,7 @@ import io.confluent.ksql.util.KsqlException;
 import io.confluent.ksql.util.PersistentQueryMetadata;
 import java.util.Collection;
 import java.util.Collections;
+import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.stream.Collectors;
@@ -56,6 +57,13 @@ import org.mockito.junit.MockitoJUnitRunner;
 
 @RunWith(MockitoJUnitRunner.class)
 public class ClusterTerminatorTest {
+  private final static String MANAGED_TOPIC_1 = "MANAGED_TOPIC_1";
+  private final static String MANAGED_TOPIC_2 = "MANAGED_TOPIC_2";
+  private final static List<String> MANAGED_TOPICS = ImmutableList.of(
+      MANAGED_TOPIC_1,
+      MANAGED_TOPIC_2
+  );
+
 
   @Mock
   private KsqlConfig ksqlConfig;
@@ -80,9 +88,12 @@ public class ClusterTerminatorTest {
   @Before
   public void setup() {
     when(serviceContext.getTopicClient()).thenReturn(kafkaTopicClient);
-    clusterTerminator = new ClusterTerminator(ksqlConfig, ksqlEngine, serviceContext);
+    clusterTerminator = new ClusterTerminator(
+        ksqlConfig,
+        ksqlEngine,
+        serviceContext,
+        MANAGED_TOPICS);
     when(ksqlEngine.getMetaStore()).thenReturn(metaStore);
-    when(ksqlConfig.getString(KsqlConfig.KSQL_SERVICE_ID_CONFIG)).thenReturn("command_topic");
     when(ksqlEngine.getPersistentQueries())
         .thenReturn(ImmutableList.of(persistentQuery0, persistentQuery1));
   }
@@ -237,9 +248,9 @@ public class ClusterTerminatorTest {
 
   @SuppressFBWarnings("RV_RETURN_VALUE_IGNORED_NO_SIDE_EFFECT")
   @Test
-  public void shouldDeleteCommandTopic() {
+  public void shouldDeleteManagedTopics() {
     // Given:
-    givenTopicsExistInKafka("_confluent-ksql-command_topic_command_topic", "topic1", "topic2");
+    givenTopicsExistInKafka(MANAGED_TOPIC_1, MANAGED_TOPIC_2);
 
     // When:
     clusterTerminator.terminateCluster(Collections.emptyList());
@@ -247,24 +258,23 @@ public class ClusterTerminatorTest {
     // Then:
     final InOrder inOrder = Mockito.inOrder(kafkaTopicClient, ksqlEngine);
     inOrder.verify(kafkaTopicClient).listTopicNames();
-    inOrder.verify(kafkaTopicClient)
-        .deleteTopics(Collections.singletonList("_confluent-ksql-command_topic_command_topic"));
+    inOrder.verify(kafkaTopicClient).deleteTopics(MANAGED_TOPICS);
   }
 
   @Test
-  public void shouldThrowIfCannotDeleteCommandTopic() {
+  public void shouldThrowIfCannotDeleteManagedTopic() {
     // Given:
-    givenTopicsExistInKafka("_confluent-ksql-command_topic_command_topic");
+    givenTopicsExistInKafka(MANAGED_TOPIC_1, MANAGED_TOPIC_2);
     doThrow(KsqlException.class)
         .doThrow(KsqlException.class)
         .doThrow(KsqlException.class)
         .doThrow(KsqlException.class)
         .doThrow(KsqlException.class)
         .when(kafkaTopicClient)
-        .deleteTopics(Collections.singletonList("_confluent-ksql-command_topic_command_topic"));
+        .deleteTopics(MANAGED_TOPICS);
     expectedException.expect(KsqlException.class);
     expectedException.expectMessage(
-        "Exception while deleting topics: _confluent-ksql-command_topic_command_topic");
+        "Exception while deleting topics: MANAGED_TOPIC_1, MANAGED_TOPIC_2");
 
     // When:
     clusterTerminator.terminateCluster(Collections.emptyList());

--- a/ksql-rest-app/src/test/java/io/confluent/ksql/rest/util/ProcessingLogServerUtilsTest.java
+++ b/ksql-rest-app/src/test/java/io/confluent/ksql/rest/util/ProcessingLogServerUtilsTest.java
@@ -18,6 +18,7 @@ import static java.util.stream.Collectors.toList;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.hasSize;
 import static org.hamcrest.Matchers.instanceOf;
+import static org.hamcrest.Matchers.is;
 import static org.junit.Assert.assertThat;
 import static org.mockito.ArgumentMatchers.anyInt;
 import static org.mockito.ArgumentMatchers.anyShort;
@@ -46,6 +47,7 @@ import io.confluent.ksql.services.TestServiceContext;
 import io.confluent.ksql.util.KsqlConfig;
 import java.util.Collections;
 import java.util.List;
+import java.util.Optional;
 import org.apache.kafka.connect.data.Field;
 import org.apache.kafka.connect.data.Schema;
 import org.apache.kafka.connect.data.Schema.Type;
@@ -231,9 +233,13 @@ public class ProcessingLogServerUtilsTest {
     );
 
     // When:
-    ProcessingLogServerUtils.maybeCreateProcessingLogTopic(spyTopicClient, config, ksqlConfig);
+    final Optional<String> createdTopic = ProcessingLogServerUtils.maybeCreateProcessingLogTopic(
+        spyTopicClient,
+        config,
+        ksqlConfig);
 
     // Then:
+    assertThat(createdTopic.isPresent(), is(false));
     verifyZeroInteractions(spyTopicClient);
   }
 
@@ -251,9 +257,14 @@ public class ProcessingLogServerUtilsTest {
   @Test
   public void shouldCreateProcessingLogTopic() {
     // When:
-    ProcessingLogServerUtils.maybeCreateProcessingLogTopic(mockTopicClient, config, ksqlConfig);
+    final Optional<String> createdTopic = ProcessingLogServerUtils.maybeCreateProcessingLogTopic(
+        mockTopicClient,
+        config,
+        ksqlConfig);
 
     // Then:
+    assertThat(createdTopic.isPresent(), is(true));
+    assertThat(createdTopic.get(), equalTo(TOPIC));
     verify(mockTopicClient).createTopic(TOPIC, PARTITIONS, REPLICAS);
   }
 
@@ -272,9 +283,14 @@ public class ProcessingLogServerUtilsTest {
     );
 
     // When:
-    ProcessingLogServerUtils.maybeCreateProcessingLogTopic(mockTopicClient, config, ksqlConfig);
+    final Optional<String> createdTopic = ProcessingLogServerUtils.maybeCreateProcessingLogTopic(
+        mockTopicClient,
+        config,
+        ksqlConfig);
 
     // Then:
+    assertThat(createdTopic.isPresent(), is(true));
+    assertThat(createdTopic.get(), equalTo(DEFAULT_TOPIC));
     verify(mockTopicClient).createTopic(DEFAULT_TOPIC, PARTITIONS, REPLICAS);
   }
 }


### PR DESCRIPTION
### Description 

Extends the cluster cleanup handler to take a list of topics managed by the ksql
cluster that must be deleted when the cluster terminates. This gets initialized to
include the command topic, as well as the processing log topic if one is configured.

### Testing done 

added a unit test

### Reviewer checklist
- [ ] Ensure docs are updated if necessary. (eg. if a user visible feature is being added or changed).
- [ ] Ensure relevant issues are linked (description should include text like "Fixes #<issue number>")

