### PR TITLE
Output metrics in structured fashion

### DIFF
--- a/docs/developer-guide/syntax-reference.rst
+++ b/docs/developer-guide/syntax-reference.rst
@@ -599,7 +599,7 @@ Extended descriptions provide the following metrics for the topic backing the so
 * last-message: The time that the last message was produced to or consumed from the topic by the server
 * failed-messages-per-sec: The number of failures during message consumption (for example, deserialization failures) per second on the server
 * consumer-failed-messages: The total number of failures during message consumption on the server
-* last-failed: The time that the last failure occured when a message was consumed from the topic by the server
+* last-failed: The time that the last failure occurred when a message was consumed from the topic by the server
 
 Example of describing a table:
 

--- a/ksql-cli/src/main/java/io/confluent/ksql/cli/console/Console.java
+++ b/ksql-cli/src/main/java/io/confluent/ksql/cli/console/Console.java
@@ -508,13 +508,17 @@ public class Console implements Closeable {
 
     printWriteQueries(source);
 
-    writer().println(String.format(
-        "%n%-20s%n%s",
-        "Local runtime statistics",
-        "------------------------"
-    ));
-    writer().println(source.getStatistics());
-    writer().println(source.getErrorStats());
+    if (source.getMetrics() != null) {
+      writer().println(source.getMetrics().format());
+    } else {
+      writer().println(String.format(
+          "%n%-20s%n%s",
+          "Local runtime statistics",
+          "------------------------"
+      ));
+      writer().println(source.getStatistics());
+      writer().println(source.getErrorStats());
+    }
     writer().println(String.format(
         "(%s)",
         "Statistics of the local KSQL server interaction with the Kafka topic "

--- a/ksql-cli/src/main/java/io/confluent/ksql/cli/console/Console.java
+++ b/ksql-cli/src/main/java/io/confluent/ksql/cli/console/Console.java
@@ -63,6 +63,7 @@ import io.confluent.ksql.rest.entity.StreamedRow;
 import io.confluent.ksql.rest.entity.StreamsList;
 import io.confluent.ksql.rest.entity.TablesList;
 import io.confluent.ksql.rest.entity.TopicDescription;
+import io.confluent.ksql.rest.util.ClientMetricUtils;
 import io.confluent.ksql.util.CmdLineUtil;
 import io.confluent.ksql.util.HandlerMaps;
 import io.confluent.ksql.util.HandlerMaps.ClassHandlerMap1;
@@ -509,7 +510,7 @@ public class Console implements Closeable {
     printWriteQueries(source);
 
     if (source.getMetrics() != null) {
-      writer().println(source.getMetrics().format());
+      writer().println(ClientMetricUtils.format(source.getMetrics()));
     } else {
       writer().println(String.format(
           "%n%-20s%n%s",

--- a/ksql-cli/src/test/java/io/confluent/ksql/cli/console/ConsoleTest.java
+++ b/ksql-cli/src/test/java/io/confluent/ksql/cli/console/ConsoleTest.java
@@ -44,6 +44,8 @@ import io.confluent.ksql.rest.entity.KafkaTopicsList;
 import io.confluent.ksql.rest.entity.KsqlEntityList;
 import io.confluent.ksql.rest.entity.KsqlTopicInfo;
 import io.confluent.ksql.rest.entity.KsqlTopicsList;
+import io.confluent.ksql.rest.entity.Metric;
+import io.confluent.ksql.rest.entity.Metrics;
 import io.confluent.ksql.rest.entity.PropertiesList;
 import io.confluent.ksql.rest.entity.Queries;
 import io.confluent.ksql.rest.entity.RunningQuery;
@@ -151,7 +153,10 @@ public class ConsoleTest {
               new SourceDescription(
                   "TestSource", Collections.emptyList(), Collections.emptyList(), buildTestSchema(i),
                   DataSource.DataSourceType.KTABLE.getKqlType(), "key", "2000-01-01", "stats",
-                  "errors", false, "avro", "kadka-topic", 1, 1)),
+                  "errors",
+                  new Metrics(ImmutableList.of(new Metric("stat", 1.0d, 123, false)),
+                              ImmutableList.of(new Metric("stat", 1.0d, 123, true))),
+                  false, "avro", "kadka-topic", 1, 1)),
           new TopicDescription("e", "TestTopic", "TestKafkaTopic", "AVRO", "schemaString"),
           new StreamsList("e", ImmutableList.of(new SourceInfo.Stream("TestStream", "TestTopic", "AVRO"))),
           new TablesList("e", ImmutableList.of(new SourceInfo.Table("TestTable", "TestTopic", "JSON", false))),
@@ -171,7 +176,10 @@ public class ConsoleTest {
             new SourceDescription(
                 "TestSource", Collections.emptyList(), Collections.emptyList(),
                 buildTestSchema(2), DataSource.DataSourceType.KTABLE.getKqlType(),
-                "key", "2000-01-01", "stats", "errors", true, "avro", "kadka-topic",
+                "key", "2000-01-01", "stats", "errors",
+                new Metrics(ImmutableList.of(new Metric("stat", 1.0d, 123, false)),
+                            ImmutableList.of(new Metric("stat", 1.0d, 123, true))),
+                true, "avro", "kadka-topic",
                 2, 1))));
 
     console.printKsqlEntityList(entityList);

--- a/ksql-common/src/main/java/io/confluent/ksql/metrics/MetricCollectors.java
+++ b/ksql-common/src/main/java/io/confluent/ksql/metrics/MetricCollectors.java
@@ -93,19 +93,15 @@ public final class MetricCollectors {
     collectorMap.remove(id);
   }
 
-  static Map<String, TopicSensors.Stat> getStatsFor(
-      final String topic, final boolean isError) {
+  public static Map<String, TopicSensors.Stat> getStatsFor(
+      final String topic,
+      final boolean isError
+  ) {
     return getAggregateMetrics(
         collectorMap.values().stream()
             .flatMap(c -> c.stats(topic.toLowerCase(), isError).stream())
             .collect(Collectors.toList())
     );
-  }
-
-  public static String getAndFormatStatsFor(final String topic, final boolean isError) {
-    return format(
-        getStatsFor(topic, isError).values(),
-        isError ? "last-failed" : "last-message");
   }
 
   static Map<String, TopicSensors.Stat> getAggregateMetrics(
@@ -120,19 +116,6 @@ public final class MetricCollectors {
       results.get(stat.name()).aggregate(stat.getValue());
     });
     return results;
-  }
-
-  private static String format(
-      final Collection<TopicSensors.Stat> stats,
-      final String lastEventTimestampMsg) {
-    final StringBuilder results = new StringBuilder();
-    stats.forEach(stat -> results.append(stat.formatted()).append(" "));
-    if (stats.size() > 0) {
-      results
-          .append(String.format("%16s: ", lastEventTimestampMsg))
-          .append(String.format("%9s", stats.iterator().next().timestamp()));
-    }
-    return results.toString();
   }
 
   public static Collection<Double> currentConsumptionRateByQuery() {

--- a/ksql-common/src/main/java/io/confluent/ksql/metrics/TopicSensors.java
+++ b/ksql-common/src/main/java/io/confluent/ksql/metrics/TopicSensors.java
@@ -28,7 +28,7 @@ import org.apache.kafka.common.metrics.Metrics;
 import org.apache.kafka.common.metrics.Sensor;
 import org.apache.kafka.common.metrics.stats.Rate;
 
-class TopicSensors<R> {
+public class TopicSensors<R> {
 
   private final String topic;
   private final List<SensorMetric<R>> sensors;
@@ -69,7 +69,7 @@ class TopicSensors<R> {
         .collect(Collectors.toList());
   }
 
-  static class Stat {
+  public static class Stat {
 
     private final String name;
     private double value;

--- a/ksql-rest-app/src/main/java/io/confluent/ksql/rest/entity/Metric.java
+++ b/ksql-rest-app/src/main/java/io/confluent/ksql/rest/entity/Metric.java
@@ -18,7 +18,7 @@ import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonTypeName;
-import com.google.common.math.DoubleMath;
+import java.util.Objects;
 
 @JsonIgnoreProperties(ignoreUnknown = true)
 @JsonTypeName("metric")
@@ -35,7 +35,7 @@ public class Metric {
       @JsonProperty("value") final double value,
       @JsonProperty("timestamp") final long timestamp,
       @JsonProperty("isError") final boolean isError) {
-    this.name = name;
+    this.name = Objects.requireNonNull(name, "name");
     this.value = value;
     this.timestamp = timestamp;
     this.isError = isError;
@@ -55,12 +55,6 @@ public class Metric {
 
   public boolean isError() {
     return isError;
-  }
-
-  public String formatted() {
-    return (DoubleMath.isMathematicalInteger(value))
-        ? String.format("%16s:%10.0f", name, value)
-        : String.format("%16s:%10.2f", name, value);
   }
 
   @Override

--- a/ksql-rest-app/src/main/java/io/confluent/ksql/rest/entity/Metric.java
+++ b/ksql-rest-app/src/main/java/io/confluent/ksql/rest/entity/Metric.java
@@ -1,0 +1,74 @@
+/*
+ * Copyright 2019 Confluent Inc.
+ *
+ * Licensed under the Confluent Community License; you may not use this file
+ * except in compliance with the License.  You may obtain a copy of the License at
+ *
+ * http://www.confluent.io/confluent-community-license
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package io.confluent.ksql.rest.entity;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonTypeName;
+import com.google.common.math.DoubleMath;
+
+@JsonIgnoreProperties(ignoreUnknown = true)
+@JsonTypeName("metric")
+public class Metric {
+
+  private final String name;
+  private final double value;
+  private final long timestamp;
+  private final boolean isError;
+
+  @JsonCreator
+  public Metric(
+      @JsonProperty("name") final String name,
+      @JsonProperty("value") final double value,
+      @JsonProperty("timestamp") final long timestamp,
+      @JsonProperty("isError") final boolean isError) {
+    this.name = name;
+    this.value = value;
+    this.timestamp = timestamp;
+    this.isError = isError;
+  }
+
+  public String getName() {
+    return name;
+  }
+
+  public double getValue() {
+    return value;
+  }
+
+  public long getTimestamp() {
+    return timestamp;
+  }
+
+  public boolean isError() {
+    return isError;
+  }
+
+  public String formatted() {
+    return (DoubleMath.isMathematicalInteger(value))
+        ? String.format("%16s:%10.0f", name, value)
+        : String.format("%16s:%10.2f", name, value);
+  }
+
+  @Override
+  public String toString() {
+    return "Metric{" + "name='" + name + '\''
+        + ", value=" + value
+        + ", timestamp=" + timestamp
+        + ", isError=" + isError
+        + '}';
+  }
+}

--- a/ksql-rest-app/src/main/java/io/confluent/ksql/rest/entity/Metrics.java
+++ b/ksql-rest-app/src/main/java/io/confluent/ksql/rest/entity/Metrics.java
@@ -18,23 +18,12 @@ import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonTypeName;
-import com.google.common.collect.Iterables;
 import java.util.Collection;
-import java.util.stream.Collectors;
-import org.apache.commons.lang3.StringUtils;
+import java.util.Objects;
 
 @JsonIgnoreProperties(ignoreUnknown = true)
 @JsonTypeName("metrics")
 public class Metrics {
-
-  private static final String TABLE_HEADER = String.format(
-      "|%s|%s|%s|%s|",
-      StringUtils.center("metric", 40),
-      StringUtils.center("value", 14),
-      StringUtils.center("timestamp", 14),
-      StringUtils.center("error", 7));
-  private static final String TABLE_CONTENT_FORMAT = "|%-40s|%14.6e|%14d|%7s|";
-  private static final String TABLE_ROW = "|" + StringUtils.repeat('-', 78) + "|";
 
   private final Collection<Metric> metrics;
   private final Collection<Metric> errorMetrics;
@@ -44,8 +33,8 @@ public class Metrics {
       @JsonProperty("metrics") final Collection<Metric> metrics,
       @JsonProperty("errorMetrics") final Collection<Metric> errorMetrics
   ) {
-    this.metrics = metrics;
-    this.errorMetrics = errorMetrics;
+    this.metrics = Objects.requireNonNull(metrics, "metrics");
+    this.errorMetrics = Objects.requireNonNull(errorMetrics, "errorMetrics");
   }
 
   public Collection<Metric> getMetrics() {
@@ -56,55 +45,10 @@ public class Metrics {
     return errorMetrics;
   }
 
-  String formatted(final boolean errors) {
-    final Collection<Metric> metrics = errors ? this.errorMetrics : this.metrics;
-
-    final String lastEventTimestampMessage;
-    if (!metrics.isEmpty()) {
-      lastEventTimestampMessage =
-          String.format(" %16s: ", errors ? "last-failed" : "last-message")
-              + String.format("%9s", metrics.iterator().next());
-    } else {
-      lastEventTimestampMessage = "";
-    }
-
-    return metrics.stream().map(Metric::formatted).collect(Collectors.joining(" "))
-        + lastEventTimestampMessage ;
-  }
-
-  public String format() {
-    final StringBuilder table = new StringBuilder();
-
-    table.append(TABLE_ROW);
-    table.append(System.lineSeparator());
-    table.append(TABLE_HEADER);
-    table.append(System.lineSeparator());
-    table.append(TABLE_ROW);
-    table.append(System.lineSeparator());
-
-    for (final Metric metric : Iterables.concat(metrics, errorMetrics)) {
-      table.append(String.format(
-          TABLE_CONTENT_FORMAT,
-          metric.getName(),
-          metric.getValue(),
-          metric.getTimestamp(),
-          StringUtils.center(metric.isError() ? "x" : "", 7)));
-      table.append(System.lineSeparator());
-    }
-
-    if (metrics.isEmpty() && errorMetrics.isEmpty()) {
-      table.append("|");
-      table.append(StringUtils.center("No Metrics Available", 78));
-      table.append("|");
-      table.append(System.lineSeparator());
-    }
-
-    table.append(TABLE_ROW);
-    return table.toString();
-  }
-
   @Override
   public String toString() {
-    return format();
+    return "Metrics{" + "metrics=" + metrics
+        + ", errorMetrics=" + errorMetrics
+        + '}';
   }
 }

--- a/ksql-rest-app/src/main/java/io/confluent/ksql/rest/entity/Metrics.java
+++ b/ksql-rest-app/src/main/java/io/confluent/ksql/rest/entity/Metrics.java
@@ -1,0 +1,110 @@
+/*
+ * Copyright 2019 Confluent Inc.
+ *
+ * Licensed under the Confluent Community License; you may not use this file
+ * except in compliance with the License.  You may obtain a copy of the License at
+ *
+ * http://www.confluent.io/confluent-community-license
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package io.confluent.ksql.rest.entity;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonTypeName;
+import com.google.common.collect.Iterables;
+import java.util.Collection;
+import java.util.stream.Collectors;
+import org.apache.commons.lang3.StringUtils;
+
+@JsonIgnoreProperties(ignoreUnknown = true)
+@JsonTypeName("metrics")
+public class Metrics {
+
+  private static final String TABLE_HEADER = String.format(
+      "|%s|%s|%s|%s|",
+      StringUtils.center("metric", 40),
+      StringUtils.center("value", 14),
+      StringUtils.center("timestamp", 14),
+      StringUtils.center("error", 7));
+  private static final String TABLE_CONTENT_FORMAT = "|%-40s|%14.6e|%14d|%7s|";
+  private static final String TABLE_ROW = "|" + StringUtils.repeat('-', 78) + "|";
+
+  private final Collection<Metric> metrics;
+  private final Collection<Metric> errorMetrics;
+
+  @JsonCreator
+  public Metrics(
+      @JsonProperty("metrics") final Collection<Metric> metrics,
+      @JsonProperty("errorMetrics") final Collection<Metric> errorMetrics
+  ) {
+    this.metrics = metrics;
+    this.errorMetrics = errorMetrics;
+  }
+
+  public Collection<Metric> getMetrics() {
+    return metrics;
+  }
+
+  public Collection<Metric> getErrorMetrics() {
+    return errorMetrics;
+  }
+
+  String formatted(final boolean errors) {
+    final Collection<Metric> metrics = errors ? this.errorMetrics : this.metrics;
+
+    final String lastEventTimestampMessage;
+    if (!metrics.isEmpty()) {
+      lastEventTimestampMessage =
+          String.format(" %16s: ", errors ? "last-failed" : "last-message")
+              + String.format("%9s", metrics.iterator().next());
+    } else {
+      lastEventTimestampMessage = "";
+    }
+
+    return metrics.stream().map(Metric::formatted).collect(Collectors.joining(" "))
+        + lastEventTimestampMessage ;
+  }
+
+  public String format() {
+    final StringBuilder table = new StringBuilder();
+
+    table.append(TABLE_ROW);
+    table.append(System.lineSeparator());
+    table.append(TABLE_HEADER);
+    table.append(System.lineSeparator());
+    table.append(TABLE_ROW);
+    table.append(System.lineSeparator());
+
+    for (final Metric metric : Iterables.concat(metrics, errorMetrics)) {
+      table.append(String.format(
+          TABLE_CONTENT_FORMAT,
+          metric.getName(),
+          metric.getValue(),
+          metric.getTimestamp(),
+          StringUtils.center(metric.isError() ? "x" : "", 7)));
+      table.append(System.lineSeparator());
+    }
+
+    if (metrics.isEmpty() && errorMetrics.isEmpty()) {
+      table.append("|");
+      table.append(StringUtils.center("No Metrics Available", 78));
+      table.append("|");
+      table.append(System.lineSeparator());
+    }
+
+    table.append(TABLE_ROW);
+    return table.toString();
+  }
+
+  @Override
+  public String toString() {
+    return format();
+  }
+}

--- a/ksql-rest-app/src/main/java/io/confluent/ksql/rest/entity/SourceDescription.java
+++ b/ksql-rest-app/src/main/java/io/confluent/ksql/rest/entity/SourceDescription.java
@@ -21,6 +21,7 @@ import com.fasterxml.jackson.annotation.JsonSubTypes;
 import com.fasterxml.jackson.annotation.JsonTypeName;
 import io.confluent.ksql.metastore.StructuredDataSource;
 import io.confluent.ksql.metrics.MetricCollectors;
+import io.confluent.ksql.rest.util.ClientMetricUtils;
 import io.confluent.ksql.rest.util.EntityUtil;
 import io.confluent.ksql.services.KafkaTopicClient;
 import io.confluent.ksql.util.timestamp.TimestampExtractionPolicy;
@@ -123,8 +124,8 @@ public class SourceDescription {
         Optional.ofNullable(dataSource.getKeyField()).map(Field::name).orElse(""),
         Optional.ofNullable(dataSource.getTimestampExtractionPolicy())
             .map(TimestampExtractionPolicy::timestampField).orElse(""),
-        metrics.formatted(false),
-        metrics.formatted(true),
+        ClientMetricUtils.format(metrics.getMetrics(), false),
+        ClientMetricUtils.format(metrics.getErrorMetrics(), true),
         metrics,
         extended,
         format,

--- a/ksql-rest-app/src/main/java/io/confluent/ksql/rest/entity/SourceDescription.java
+++ b/ksql-rest-app/src/main/java/io/confluent/ksql/rest/entity/SourceDescription.java
@@ -75,18 +75,20 @@ public class SourceDescription {
   ) {
     // CHECKSTYLE_RULES.ON: ParameterNumberCheck
     this.name = name;
-    this.readQueries = Collections.unmodifiableList(readQueries);
-    this.writeQueries = Collections.unmodifiableList(writeQueries);
-    this.fields = Collections.unmodifiableList(fields);
-    this.type = type;
-    this.key = key;
-    this.timestamp = timestamp;
-    this.statistics = statistics;
-    this.errorStats = errorStats;
-    this.metrics = metrics;
+    this.readQueries = Collections.unmodifiableList(
+        Objects.requireNonNull(readQueries, "readQueries"));
+    this.writeQueries = Collections.unmodifiableList(
+        Objects.requireNonNull(writeQueries, "writeQueries"));
+    this.fields = Collections.unmodifiableList(Objects.requireNonNull(fields, "fields"));
+    this.type = Objects.requireNonNull(type, "type");
+    this.key = Objects.requireNonNull(key);
+    this.timestamp = Objects.requireNonNull(timestamp, "timestamp");
+    this.statistics = Objects.requireNonNull(statistics, "statistics");
+    this.errorStats = Objects.requireNonNull(errorStats, "errorStats");
+    this.metrics = Objects.requireNonNull(metrics, "metrics");
     this.extended = extended;
-    this.format = format;
-    this.topic = topic;
+    this.format = Objects.requireNonNull(format, "format");
+    this.topic = Objects.requireNonNull(topic, "topic");
     this.partitions = partitions;
     this.replication = replication;
   }

--- a/ksql-rest-app/src/main/java/io/confluent/ksql/rest/server/resources/KsqlResource.java
+++ b/ksql-rest-app/src/main/java/io/confluent/ksql/rest/server/resources/KsqlResource.java
@@ -650,7 +650,7 @@ public class KsqlResource {
       ));
     }
 
-    return new SourceDescription(
+    return SourceDescription.of(
         dataSource,
         extended,
         dataSource.getKsqlTopic().getKsqlTopicSerDe().getSerDe().name(),

--- a/ksql-rest-app/src/main/java/io/confluent/ksql/rest/util/ClientMetricUtils.java
+++ b/ksql-rest-app/src/main/java/io/confluent/ksql/rest/util/ClientMetricUtils.java
@@ -1,0 +1,93 @@
+/*
+ * Copyright 2019 Confluent Inc.
+ *
+ * Licensed under the Confluent Community License; you may not use this file
+ * except in compliance with the License.  You may obtain a copy of the License at
+ *
+ * http://www.confluent.io/confluent-community-license
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package io.confluent.ksql.rest.util;
+
+import com.google.common.collect.Iterables;
+import com.google.common.math.DoubleMath;
+import io.confluent.ksql.rest.entity.Metric;
+import io.confluent.ksql.rest.entity.Metrics;
+import java.util.Collection;
+import java.util.stream.Collectors;
+import org.apache.commons.lang3.StringUtils;
+
+/**
+ * Contains <i>client</i> side utility methods for handling {@link Metric}
+ * and {@link Metrics}.
+ */
+public final class ClientMetricUtils {
+
+  private static final String TABLE_HEADER = String.format(
+      "|%s|%s|%s|%s|",
+      StringUtils.center("metric", 40),
+      StringUtils.center("value", 14),
+      StringUtils.center("timestamp", 14),
+      StringUtils.center("error", 7));
+  private static final String TABLE_CONTENT_FORMAT = "|%-40s|%14.6e|%14d|%7s|";
+  private static final String TABLE_ROW = "|" + StringUtils.repeat('-', 78) + "|";
+
+  private ClientMetricUtils() { }
+
+  public static String format(final Metrics metrics) {
+    final StringBuilder table = new StringBuilder();
+
+    table.append(TABLE_ROW);
+    table.append(System.lineSeparator());
+    table.append(TABLE_HEADER);
+    table.append(System.lineSeparator());
+    table.append(TABLE_ROW);
+    table.append(System.lineSeparator());
+
+    for (final Metric metric : Iterables.concat(metrics.getMetrics(), metrics.getErrorMetrics())) {
+      table.append(String.format(
+          TABLE_CONTENT_FORMAT,
+          metric.getName(),
+          metric.getValue(),
+          metric.getTimestamp(),
+          StringUtils.center(metric.isError() ? "x" : "", 7)));
+      table.append(System.lineSeparator());
+    }
+
+    if (metrics.getMetrics().isEmpty() && metrics.getErrorMetrics().isEmpty()) {
+      table.append("|");
+      table.append(StringUtils.center("No Metrics Available", 78));
+      table.append("|");
+      table.append(System.lineSeparator());
+    }
+
+    table.append(TABLE_ROW);
+    return table.toString();
+  }
+
+  public static String format(final Collection<Metric> metrics, final boolean errors) {
+    final String lastEventTimestampMessage;
+    if (!metrics.isEmpty()) {
+      lastEventTimestampMessage =
+          String.format(" %16s: ", errors ? "last-failed" : "last-message")
+              + String.format("%9s", metrics.iterator().next());
+    } else {
+      lastEventTimestampMessage = "";
+    }
+
+    return metrics.stream().map(ClientMetricUtils::format).collect(Collectors.joining(" "))
+        + lastEventTimestampMessage ;
+  }
+
+  private static String format(Metric metric) {
+    return (DoubleMath.isMathematicalInteger(metric.getValue()))
+        ? String.format("%16s:%10.0f", metric.getName(), metric.getValue())
+        : String.format("%16s:%10.2f", metric.getName(), metric.getValue());
+  }
+
+}

--- a/ksql-rest-app/src/test/java/io/confluent/ksql/rest/entity/SourceDescriptionTest.java
+++ b/ksql-rest-app/src/test/java/io/confluent/ksql/rest/entity/SourceDescriptionTest.java
@@ -17,7 +17,10 @@ package io.confluent.ksql.rest.entity;
 import static org.hamcrest.CoreMatchers.containsString;
 import static org.junit.Assert.assertThat;
 
+import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.Maps;
+import com.google.common.math.DoubleMath;
 import io.confluent.ksql.metastore.KsqlStream;
 import io.confluent.ksql.metastore.KsqlTopic;
 import io.confluent.ksql.metastore.StructuredDataSource;
@@ -27,6 +30,8 @@ import io.confluent.ksql.serde.json.KsqlJsonTopicSerDe;
 import io.confluent.ksql.util.timestamp.MetadataTimestampExtractionPolicy;
 import java.util.Arrays;
 import java.util.Collections;
+import java.util.Map;
+import java.util.Objects;
 import org.apache.kafka.clients.consumer.ConsumerConfig;
 import org.apache.kafka.clients.consumer.ConsumerRecord;
 import org.apache.kafka.clients.consumer.ConsumerRecords;
@@ -35,6 +40,9 @@ import org.apache.kafka.common.record.TimestampType;
 import org.apache.kafka.common.serialization.Serdes;
 import org.apache.kafka.connect.data.Schema;
 import org.apache.kafka.connect.data.SchemaBuilder;
+import org.hamcrest.Description;
+import org.hamcrest.Matcher;
+import org.hamcrest.TypeSafeMatcher;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
@@ -90,7 +98,7 @@ public class SourceDescriptionTest {
     StreamsErrorCollector.recordError(APP_ID, kafkaTopicName);
 
     // When
-    final SourceDescription sourceDescription = new SourceDescription(
+    final SourceDescription sourceDescription = SourceDescription.of(
         dataSource,
         true,
         "json",
@@ -105,5 +113,81 @@ public class SourceDescriptionTest {
     assertThat(
         sourceDescription.getErrorStats(),
         containsString(StreamsErrorCollector.CONSUMER_FAILED_MESSAGES));
+  }
+
+  @Test
+  public void shouldReturnStructuredMetricsBasedOnKafkaTopic() {
+    // Given:
+    final String kafkaTopicName = "kafka";
+    final StructuredDataSource dataSource = buildDataSource(kafkaTopicName);
+    consumerCollector.onConsume(buildRecords(kafkaTopicName));
+    StreamsErrorCollector.recordError(APP_ID, kafkaTopicName);
+
+    // When
+    final SourceDescription sourceDescription = SourceDescription.of(
+        dataSource,
+        true,
+        "json",
+        Collections.emptyList(),
+        Collections.emptyList(),
+        null);
+
+    // Then:
+    System.out.println(sourceDescription.getMetrics());
+    assertThat(sourceDescription.getMetrics(), matchesMetrics(
+        new Metrics(
+            ImmutableList.of(
+                new Metric(ConsumerCollector.CONSUMER_MESSAGES_PER_SEC, 0d, 0L, false),
+                new Metric(ConsumerCollector.CONSUMER_TOTAL_MESSAGES, 1d, 0L, false),
+                new Metric(ConsumerCollector.CONSUMER_TOTAL_BYTES, 20d, 0L, false)
+            ),
+            ImmutableList.of(
+                new Metric(StreamsErrorCollector.CONSUMER_FAILED_MESSAGES_PER_SEC, 0d, 0L, false),
+                new Metric(StreamsErrorCollector.CONSUMER_FAILED_MESSAGES, 1d, 0L, false)
+            )
+        )
+    ));
+  }
+
+  private Matcher<Metrics> matchesMetrics(Metrics expected) {
+    return new TypeSafeMatcher<Metrics>() {
+
+      @Override
+      protected boolean matchesSafely(final Metrics actual) {
+        final Map<String, Metric> expectedStat =
+            Maps.uniqueIndex(expected.getMetrics(), Metric::getName);
+        final Map<String, Metric> actualStat =
+            Maps.uniqueIndex(actual.getMetrics(), Metric::getName);
+
+        final boolean statsMatch = expectedStat.entrySet()
+            .stream()
+            .map(metric -> matches(metric.getValue(), actualStat.get(metric.getKey())))
+            .reduce(Boolean::logicalAnd)
+            .orElse(expectedStat.isEmpty() && actualStat.isEmpty());
+
+        final Map<String, Metric> expectedErrors =
+            Maps.uniqueIndex(expected.getErrorMetrics(), Metric::getName);
+        final Map<String, Metric> actualErrors =
+            Maps.uniqueIndex(actual.getErrorMetrics(), Metric::getName);
+
+        final boolean errorsMatch = expectedErrors.entrySet()
+            .stream()
+            .map(metric -> matches(metric.getValue(), actualErrors.get(metric.getKey())))
+            .reduce(Boolean::logicalAnd)
+            .orElse(expectedStat.isEmpty() && actualStat.isEmpty());
+
+        return statsMatch && errorsMatch;
+      }
+
+      private boolean matches(final Metric actual, final Metric expected) {
+        return Objects.equals(expected.getName(), actual.getName())
+            && DoubleMath.fuzzyCompare(expected.getValue(), expected.getValue(), .1) == 0;
+      }
+
+      @Override
+      public void describeTo(final Description description) {
+        description.appendText(expected.format());
+      }
+    };
   }
 }

--- a/ksql-rest-app/src/test/java/io/confluent/ksql/rest/entity/SourceDescriptionTest.java
+++ b/ksql-rest-app/src/test/java/io/confluent/ksql/rest/entity/SourceDescriptionTest.java
@@ -186,7 +186,7 @@ public class SourceDescriptionTest {
 
       @Override
       public void describeTo(final Description description) {
-        description.appendText(expected.format());
+        description.appendText(expected.toString());
       }
     };
   }

--- a/ksql-rest-app/src/test/java/io/confluent/ksql/rest/server/resources/KsqlResourceTest.java
+++ b/ksql-rest-app/src/test/java/io/confluent/ksql/rest/server/resources/KsqlResourceTest.java
@@ -304,11 +304,11 @@ public class KsqlResourceTest {
 
     // Then:
     assertThat(descriptionList.getSourceDescriptions(), containsInAnyOrder(
-        new SourceDescription(
+        SourceDescription.of(
             ksqlEngine.getMetaStore().getSource("TEST_STREAM"),
             true, "JSON", Collections.emptyList(), Collections.emptyList(),
             kafkaTopicClient),
-        new SourceDescription(
+        SourceDescription.of(
             ksqlEngine.getMetaStore().getSource("new_stream"),
             true, "JSON", Collections.emptyList(), Collections.emptyList(),
             kafkaTopicClient)));
@@ -331,11 +331,11 @@ public class KsqlResourceTest {
 
     // Then:
     assertThat(descriptionList.getSourceDescriptions(), containsInAnyOrder(
-        new SourceDescription(
+        SourceDescription.of(
             ksqlEngine.getMetaStore().getSource("TEST_TABLE"),
             true, "JSON", Collections.emptyList(), Collections.emptyList(),
             kafkaTopicClient),
-        new SourceDescription(
+        SourceDescription.of(
             ksqlEngine.getMetaStore().getSource("new_table"),
             true, "JSON", Collections.emptyList(), Collections.emptyList(),
             kafkaTopicClient)));
@@ -374,7 +374,7 @@ public class KsqlResourceTest {
         "DESCRIBE DESCRIBED_STREAM;", SourceDescriptionEntity.class);
 
     // Then:
-    final SourceDescription expectedDescription = new SourceDescription(
+    final SourceDescription expectedDescription = SourceDescription.of(
         ksqlEngine.getMetaStore().getSource("DESCRIBED_STREAM"), false, "JSON",
         Collections.singletonList(queries.get(1)), Collections.singletonList(queries.get(0)), null);
 


### PR DESCRIPTION
### Description 
In order for machines to better handle the output of our `DESCRIBE EXTENDED` functionality, this PR changes the output structure of the statistics from native string to a `Metrics` object.

To maintain backwards compatibility, we introduce a new field into `SourceDescription`: `metrics` and leave the old fields.

Some reviewing notes:
- `Metric` is just a jackson JSON compatible version of `Stat`

The new formatted metrics:
```
|------------------------------------------------------------------------------|
|                 metric                 |    value     |  timestamp   | error |
|------------------------------------------------------------------------------|
|consumer-messages-per-sec               |  1.009979e-02| 1550086992023|       |
|consumer-total-bytes                    |  2.000000e+01| 1550086992023|       |
|consumer-total-messages                 |  1.000000e+00| 1550086992023|       |
|consumer-failed-messages                |  1.000000e+00| 1550086992030|   x   |
|consumer-failed-messages-per-sec        |  1.010040e-02| 1550086992030|   x   |
|------------------------------------------------------------------------------|
```

### Testing done 
- Existing unit test coverage
- C3 querying the new server shows the results properly
- {New, Old} x {Server, CLI} compatibility testing

### Reviewer checklist
- [ ] Ensure docs are updated if necessary. (eg. if a user visible feature is being added or changed).
- [ ] Ensure relevant issues are linked (description should include text like "Fixes #<issue number>")

