### PR TITLE
Add ksql-benchmark README (baseline results and how to run)

### DIFF
--- a/ksql-benchmark/README.md
+++ b/ksql-benchmark/README.md
@@ -58,7 +58,7 @@ java -jar ./target/benchmarks.jar -h
 
 ### Benchmark results
 
-The following results were obtained from 10 runs of `SerdeBenchmark.java` on a different
+The following results were obtained from 10 runs of `SerdeBenchmark.java` on different
 r5.xlarge EC2 instances, for KSQL code as of the 5.2 release (compiled and run with Java 11),
 using the default benchmark parameters.
 
@@ -74,5 +74,7 @@ using the default benchmark parameters.
 |  serialize  |        Avro         |   metrics   |     9.904        |   0.300                                |
 
 Time per operation is quite consistent from run to run, and from iteration to iteration within runs.
+(The cross-instance variance was found to be greater than the run-to-run variance on a single
+instance for many of the benchmarks.)
 Don't be surprised if running on your laptop produces better results than those reported here for
 an r5.xlarge EC2 instance, since that is consistently the case.

--- a/ksql-benchmark/README.md
+++ b/ksql-benchmark/README.md
@@ -1,0 +1,78 @@
+# KSQL JMH Microbenchmarks
+
+This module is for JMH micro-benchmarking of pieces of the KSQL code.
+
+## `SerdeBenchmark.java`
+
+For example, `SerdeBenchmark.java`
+benchmarks the performance of the Avro and JSON serdes used by KSQL, since the serdes have been
+shown to be a performance bottleneck in the past. The benchmarks use the schema files found in
+`src/main/resources/schemas`. A serialization and deserialization benchmark is run for each schema
+(e.g., `impressions` or `metrics`) and each serialization format (Avro or JSON).  
+
+### How to run
+
+The benchmarks can be run either from `SerdeBenchmark.java` directly through IntelliJ, or via the
+command line as follows, after building the module to produce `target/benchmarks.jar`:
+
+```
+java -jar ./target/benchmarks.jar
+```
+
+### Running a subset of benchmarks
+
+To run only a subset of the benchmarks, you can specify parameters to run with. For example,
+to run only Avro benchmarks:
+```
+java -jar ./target/benchmarks.jar -p serializationFormat=Avro
+```
+
+Or to run only JSON (serialization and deserialization) benchmarks using the `metrics` schema:
+```
+java -jar ./target/benchmarks.jar -p serializationFormat=JSON -p schemaName=metrics
+```
+
+Or to run only the deserialization benchmarks on both the `impressions` and `metrics` schemas:
+```
+java -jar ./target/benchmarks.jar SerdeBenchmark.deserialize -p schemaName=impressions,metrics
+```
+
+### Running with non-default parameters
+
+JMH parameters of interest may include the number of forks to use (`-f`), the number of warmup and
+measurement iterations (`-wi` and `-i`, respectively), the duration of each iteration
+(`-w` and `-r` for warmup and measurement iterations, respectively, with units of seconds),
+and the number of threads (`-t`).
+By default, `SerdeBenchmark.java` is set up to run with 3 forks, 3 warmup iterations, 3 measurement
+iterations, 10 seconds per iteration, and 4 threads.
+
+As an example, to run benchmarks with 8 threads and only a single fork:
+```
+java -jar ./target/benchmarks.jar -t 8 -f 1
+```
+
+The full list of JMH command line options can be viewed with:
+```
+java -jar ./target/benchmarks.jar -h
+```
+
+### Benchmark results
+
+The following results were obtained from 20 runs of `SerdeBenchmark.java` on an
+r5.xlarge EC2 instance, for KSQL code as of the 5.2 release (compiled and run with Java 11),
+using the default benchmark parameters.
+
+|  Benchmark  | serializationFormat | schemaName  | time per op (us) | standard deviation across 20 runs (us) |
+|:-----------:|:-------------------:|:-----------:|:----------------:|:--------------------------------------:|
+| deserialize |        JSON         | impressions |     2.840        |   0.070                                |
+| deserialize |        Avro         | impressions |     4.748        |   0.062                                |
+| deserialize |        JSON         |   metrics   |     16.309       |   0.162                                |
+| deserialize |        Avro         |   metrics   |     17.423       |   1.045                                |
+|  serialize  |        JSON         | impressions |     1.782        |   0.071                                |
+|  serialize  |        Avro         | impressions |     2.848        |   0.172                                |
+|  serialize  |        JSON         |   metrics   |     6.620        |   0.149                                |
+|  serialize  |        Avro         |   metrics   |     10.056       |   0.099                                |
+
+Time per operation is quite consistent from run to run, and from iteration to iteration within runs.
+Don't be surprised if running on your laptop produces better results than those reported here for
+an r5.xlarge EC2 instance, since that is consistently the case.

--- a/ksql-benchmark/README.md
+++ b/ksql-benchmark/README.md
@@ -58,20 +58,20 @@ java -jar ./target/benchmarks.jar -h
 
 ### Benchmark results
 
-The following results were obtained from 20 runs of `SerdeBenchmark.java` on an
-r5.xlarge EC2 instance, for KSQL code as of the 5.2 release (compiled and run with Java 11),
+The following results were obtained from 10 runs of `SerdeBenchmark.java` on a different
+r5.xlarge EC2 instances, for KSQL code as of the 5.2 release (compiled and run with Java 11),
 using the default benchmark parameters.
 
-|  Benchmark  | serializationFormat | schemaName  | time per op (us) | standard deviation across 20 runs (us) |
+|  Benchmark  | serializationFormat | schemaName  | time per op (us) | standard deviation across 10 runs (us) |
 |:-----------:|:-------------------:|:-----------:|:----------------:|:--------------------------------------:|
-| deserialize |        JSON         | impressions |     2.840        |   0.070                                |
-| deserialize |        Avro         | impressions |     4.748        |   0.062                                |
-| deserialize |        JSON         |   metrics   |     16.309       |   0.162                                |
-| deserialize |        Avro         |   metrics   |     17.423       |   1.045                                |
-|  serialize  |        JSON         | impressions |     1.782        |   0.071                                |
-|  serialize  |        Avro         | impressions |     2.848        |   0.172                                |
-|  serialize  |        JSON         |   metrics   |     6.620        |   0.149                                |
-|  serialize  |        Avro         |   metrics   |     10.056       |   0.099                                |
+| deserialize |        JSON         | impressions |     2.794        |   0.059                                |
+| deserialize |        Avro         | impressions |     4.708        |   0.162                                |
+| deserialize |        JSON         |   metrics   |     16.077       |   0.501                                |
+| deserialize |        Avro         |   metrics   |     16.993       |   0.401                                |
+|  serialize  |        JSON         | impressions |     1.741        |   0.065                                |
+|  serialize  |        Avro         | impressions |     2.774        |   0.097                                |
+|  serialize  |        JSON         |   metrics   |     6.530        |   0.258                                |
+|  serialize  |        Avro         |   metrics   |     9.904        |   0.300                                |
 
 Time per operation is quite consistent from run to run, and from iteration to iteration within runs.
 Don't be surprised if running on your laptop produces better results than those reported here for

--- a/ksql-benchmark/src/main/java/io/confluent/ksql/benchmark/SerdeBenchmark.java
+++ b/ksql-benchmark/src/main/java/io/confluent/ksql/benchmark/SerdeBenchmark.java
@@ -62,7 +62,6 @@ import org.openjdk.jmh.runner.options.OptionsBuilder;
 
 /**
  *  Runs JMH microbenchmarks against KSQL serdes.
- *
  *  See `ksql-benchmark/README.md` for more info, including benchmark results
  *  and how to run the benchmarks.
  */

--- a/ksql-benchmark/src/main/java/io/confluent/ksql/benchmark/SerdeBenchmark.java
+++ b/ksql-benchmark/src/main/java/io/confluent/ksql/benchmark/SerdeBenchmark.java
@@ -44,6 +44,7 @@ import org.apache.kafka.connect.data.Field;
 import org.apache.kafka.connect.data.SchemaBuilder;
 import org.openjdk.jmh.annotations.Benchmark;
 import org.openjdk.jmh.annotations.BenchmarkMode;
+import org.openjdk.jmh.annotations.Fork;
 import org.openjdk.jmh.annotations.Level;
 import org.openjdk.jmh.annotations.Measurement;
 import org.openjdk.jmh.annotations.Mode;
@@ -61,9 +62,10 @@ import org.openjdk.jmh.runner.options.OptionsBuilder;
 
 @BenchmarkMode(Mode.AverageTime)
 @OutputTimeUnit(TimeUnit.MICROSECONDS)
-@Warmup(iterations = 5, time = 10)
-@Measurement(iterations = 5, time = 10)
+@Warmup(iterations = 3, time = 10)
+@Measurement(iterations = 3, time = 10)
 @Threads(4)
+@Fork(3)
 public class SerdeBenchmark {
 
   private static final Path SCHEMA_DIR = Paths.get("schemas");

--- a/ksql-benchmark/src/main/java/io/confluent/ksql/benchmark/SerdeBenchmark.java
+++ b/ksql-benchmark/src/main/java/io/confluent/ksql/benchmark/SerdeBenchmark.java
@@ -60,6 +60,12 @@ import org.openjdk.jmh.runner.RunnerException;
 import org.openjdk.jmh.runner.options.Options;
 import org.openjdk.jmh.runner.options.OptionsBuilder;
 
+/**
+ *  Runs JMH microbenchmarks against KSQL serdes.
+ *
+ *  See `ksql-benchmark/README.md` for more info, including benchmark results
+ *  and how to run the benchmarks.
+ */
 @BenchmarkMode(Mode.AverageTime)
 @OutputTimeUnit(TimeUnit.MICROSECONDS)
 @Warmup(iterations = 3, time = 10)


### PR DESCRIPTION
### Description 

This PR adds instructions around how to run the serde JMH benchmarks, and also records results from 20 runs on an r5.xlarge EC2 instance. This PR also adjusts some of the benchmark parameters (specifically, the number of forks and iterations) so that `SerdeBenchmark.java` now only takes 24 minutes to run.

### Testing done 

Only non-documentation change is the tweaking of benchmark parameters.

### Reviewer checklist
- [ ] Ensure docs are updated if necessary. (eg. if a user visible feature is being added or changed).
- [ ] Ensure relevant issues are linked (description should include text like "Fixes #<issue number>")

