### PR TITLE
Remove validation and dependency on metastore from CommandIDAssigner

### DIFF
--- a/ksql-engine/src/main/java/io/confluent/ksql/ddl/commands/AbstractCreateStreamCommand.java
+++ b/ksql-engine/src/main/java/io/confluent/ksql/ddl/commands/AbstractCreateStreamCommand.java
@@ -147,12 +147,12 @@ abstract class AbstractCreateStreamCommand implements DdlCommand {
   void checkMetaData(final MetaStore metaStore, final String sourceName, final String topicName) {
     // TODO: move the check to the runtime since it accesses metaStore
     if (metaStore.getSource(sourceName) != null) {
-      throw new KsqlException(String.format("Source %s already exists.", sourceName));
+      throw new KsqlException(String.format("Source already exists: %s", sourceName));
     }
 
     if (metaStore.getTopic(topicName) == null) {
       throw new KsqlException(
-          String.format("The corresponding topic, %s, does not exist.", topicName));
+          String.format("The corresponding topic does not exist: %s", topicName));
     }
   }
 

--- a/ksql-rest-app/src/main/java/io/confluent/ksql/rest/server/KsqlRestApplication.java
+++ b/ksql-rest-app/src/main/java/io/confluent/ksql/rest/server/KsqlRestApplication.java
@@ -42,7 +42,6 @@ import io.confluent.ksql.parser.tree.Type;
 import io.confluent.ksql.processing.log.ProcessingLogConfig;
 import io.confluent.ksql.processing.log.ProcessingLogContext;
 import io.confluent.ksql.rest.entity.ServerInfo;
-import io.confluent.ksql.rest.server.computation.CommandIdAssigner;
 import io.confluent.ksql.rest.server.computation.CommandQueue;
 import io.confluent.ksql.rest.server.computation.CommandRunner;
 import io.confluent.ksql.rest.server.computation.CommandStore;
@@ -367,8 +366,7 @@ public final class KsqlRestApplication extends Application<KsqlRestConfig> imple
     final CommandStore commandStore = new CommandStore(
         commandTopic,
         restConfig.getCommandConsumerProperties(),
-        restConfig.getCommandProducerProperties(),
-        new CommandIdAssigner(ksqlEngine.getMetaStore()));
+        restConfig.getCommandProducerProperties());
 
     final StatementExecutor statementExecutor = new StatementExecutor(
         ksqlConfig,

--- a/ksql-rest-app/src/main/java/io/confluent/ksql/rest/server/computation/CommandIdAssigner.java
+++ b/ksql-rest-app/src/main/java/io/confluent/ksql/rest/server/computation/CommandIdAssigner.java
@@ -14,7 +14,7 @@
 
 package io.confluent.ksql.rest.server.computation;
 
-import io.confluent.ksql.metastore.MetaStore;
+import com.google.common.collect.ImmutableMap;
 import io.confluent.ksql.parser.tree.CreateStream;
 import io.confluent.ksql.parser.tree.CreateStreamAsSelect;
 import io.confluent.ksql.parser.tree.CreateTable;
@@ -30,7 +30,6 @@ import io.confluent.ksql.parser.tree.TerminateQuery;
 import io.confluent.ksql.rest.server.computation.CommandId.Action;
 import io.confluent.ksql.rest.server.computation.CommandId.Type;
 import io.confluent.ksql.rest.util.TerminateCluster;
-import java.util.HashMap;
 import java.util.Map;
 
 public class CommandIdAssigner {
@@ -39,38 +38,38 @@ public class CommandIdAssigner {
     CommandId apply(Statement command);
   }
 
-  private final MetaStore metaStore;
-  private final Map<Class<? extends Statement>, CommandIdSupplier> suppliers = new HashMap<>();
+  private static final Map<Class<? extends Statement>, CommandIdSupplier> SUPPLIERS =
+      ImmutableMap.<Class<? extends Statement>, CommandIdSupplier>builder()
+          .put(RegisterTopic.class,
+            command -> getTopicCommandId((RegisterTopic) command))
+          .put(CreateStream.class,
+            command -> getTopicStreamCommandId((CreateStream) command))
+          .put(CreateTable.class,
+            command -> getTopicTableCommandId((CreateTable) command))
+          .put(CreateStreamAsSelect.class,
+            command -> getSelectStreamCommandId((CreateStreamAsSelect) command))
+          .put(CreateTableAsSelect.class,
+            command -> getSelectTableCommandId((CreateTableAsSelect) command))
+          .put(InsertInto.class,
+            command -> getInsertIntoCommandId((InsertInto) command))
+          .put(TerminateQuery.class,
+            command -> getTerminateCommandId((TerminateQuery) command))
+          .put(DropTopic.class,
+            command -> getDropTopicCommandId((DropTopic) command))
+          .put(DropStream.class,
+            command -> getDropStreamCommandId((DropStream) command))
+          .put(DropTable.class,
+            command -> getDropTableCommandId((DropTable) command))
+          .put(RunScript.class,
+            command -> new CommandId(CommandId.Type.STREAM, "RunScript", CommandId.Action.EXECUTE))
+          .put(TerminateCluster.class,
+            command -> new CommandId(Type.CLUSTER, "TerminateCluster", Action.TERMINATE))
+          .build();
 
-  public CommandIdAssigner(final MetaStore metaStore) {
-    this.metaStore = metaStore;
-    suppliers.put(RegisterTopic.class,
-        command -> getTopicCommandId((RegisterTopic) command));
-    suppliers.put(CreateStream.class,
-        command -> getTopicStreamCommandId((CreateStream) command));
-    suppliers.put(CreateTable.class,
-        command -> getTopicTableCommandId((CreateTable) command));
-    suppliers.put(CreateStreamAsSelect.class,
-        command -> getSelectStreamCommandId((CreateStreamAsSelect) command));
-    suppliers.put(CreateTableAsSelect.class,
-        command -> getSelectTableCommandId((CreateTableAsSelect) command));
-    suppliers.put(InsertInto.class, command -> getInsertIntoCommandId((InsertInto) command));
-    suppliers.put(TerminateQuery.class,
-        command -> getTerminateCommandId((TerminateQuery) command));
-    suppliers.put(DropTopic.class,
-        command -> getDropTopicCommandId((DropTopic) command));
-    suppliers.put(DropStream.class,
-        command -> getDropStreamCommandId((DropStream) command));
-    suppliers.put(DropTable.class,
-        command -> getDropTableCommandId((DropTable) command));
-    suppliers.put(RunScript.class,
-        command -> new CommandId(CommandId.Type.STREAM, "RunScript", CommandId.Action.EXECUTE));
-    suppliers.put(TerminateCluster.class,
-        command -> new CommandId(Type.CLUSTER, "TerminateCluster", Action.TERMINATE));
-  }
+  public CommandIdAssigner() { }
 
   public CommandId getCommandId(final Statement command) {
-    final CommandIdSupplier supplier = suppliers.get(command.getClass());
+    final CommandIdSupplier supplier = SUPPLIERS.get(command.getClass());
     if (supplier == null) {
       throw new RuntimeException(String.format(
           "Cannot assign command ID to statement of type %s",
@@ -80,27 +79,25 @@ public class CommandIdAssigner {
     return supplier.apply(command);
   }
 
-  private CommandId getTopicCommandId(final RegisterTopic registerTopic) {
+  private static CommandId getTopicCommandId(final RegisterTopic registerTopic) {
     final String topicName = registerTopic.getName().toString();
-    if (metaStore.getAllKsqlTopics().containsKey(topicName)) {
-      throw new RuntimeException(String.format("Topic %s already exists", topicName));
-    }
     return new CommandId(CommandId.Type.TOPIC, topicName, CommandId.Action.CREATE);
   }
 
-  private CommandId getTopicStreamCommandId(final CreateStream createStream) {
+  private static CommandId getTopicStreamCommandId(final CreateStream createStream) {
     return getStreamCommandId(createStream.getName().toString());
   }
 
-  private CommandId getSelectStreamCommandId(final CreateStreamAsSelect createStreamAsSelect) {
+  private static CommandId getSelectStreamCommandId(
+      final CreateStreamAsSelect createStreamAsSelect) {
     return getStreamCommandId(createStreamAsSelect.getName().toString());
   }
 
-  private CommandId getTopicTableCommandId(final CreateTable createTable) {
+  private static CommandId getTopicTableCommandId(final CreateTable createTable) {
     return getTableCommandId(createTable.getName().toString());
   }
 
-  private CommandId getSelectTableCommandId(final CreateTableAsSelect createTableAsSelect) {
+  private static CommandId getSelectTableCommandId(final CreateTableAsSelect createTableAsSelect) {
     return getTableCommandId(createTableAsSelect.getName().toString());
   }
 
@@ -141,18 +138,15 @@ public class CommandIdAssigner {
     );
   }
 
-  private CommandId getStreamCommandId(final String streamName) {
+  private static CommandId getStreamCommandId(final String streamName) {
     return getSourceCommandId(CommandId.Type.STREAM, streamName);
   }
 
-  private CommandId getTableCommandId(final String tableName) {
+  private static CommandId getTableCommandId(final String tableName) {
     return getSourceCommandId(CommandId.Type.TABLE, tableName);
   }
 
-  private CommandId getSourceCommandId(final CommandId.Type type, final String sourceName) {
-    if (metaStore.getAllStructuredDataSources().containsKey(sourceName)) {
-      throw new RuntimeException(String.format("Source %s already exists", sourceName));
-    }
+  private static CommandId getSourceCommandId(final CommandId.Type type, final String sourceName) {
     return new CommandId(type, sourceName, CommandId.Action.CREATE);
   }
 }

--- a/ksql-rest-app/src/main/java/io/confluent/ksql/rest/server/computation/CommandQueue.java
+++ b/ksql-rest-app/src/main/java/io/confluent/ksql/rest/server/computation/CommandQueue.java
@@ -22,22 +22,69 @@ import java.util.List;
 import java.util.Map;
 import java.util.concurrent.TimeoutException;
 
+/**
+ * Represents a queue of {@link Command}s that must be distributed to all
+ * KSQL servers for execution. This queue should be persistent to failure
+ * of individual servers, and servers must be able to recover (i.e. build
+ * their meta store state) using <i>exclusively</i> data stored within.
+ */
 public interface CommandQueue extends Closeable {
+
+  /**
+   * Enqueues a command onto the command topic. After this method returns,
+   * it is guaranteed that the command has been persisted, without regard
+   * for the {@link io.confluent.ksql.rest.entity.CommandStatus CommandStatus}.
+   *
+   * @param statementString     The string of the statement to be distributed
+   * @param statement           The statement to be distributed
+   * @param ksqlConfig          The application-scoped configurations
+   * @param overwriteProperties Any command-specific Streams properties to use.
+   *
+   * @return an asynchronous tracker that can be used to determine the current
+   *         state of the command
+   */
   QueuedCommandStatus enqueueCommand(
       PreparedStatement<?> statement,
       KsqlConfig ksqlConfig,
       Map<String, Object> overwriteProperties
   );
 
+  /**
+   * Polls the Queue for any commands that have been enqueued since the last
+   * invocation to this method, blocking until there is data to return. If
+   * between invocations to this method, {@link #getRestoreCommands()} is
+   * invoked, this command will begin where the results of that call ended.
+   *
+   * @return a list of commands that have been enqueued since the last call
+   * @apiNote this method may block
+   */
   List<QueuedCommand> getNewCommands();
 
+  /**
+   * Seeks to the earliest point in history available in the command queue
+   * and returns all commands between then and the end of the queue.
+   *
+   * @return the entire command list history
+   * @apiNote this method may block
+   */
   List<QueuedCommand> getRestoreCommands();
 
+  /**
+   * @param seqNum  the required minimum sequence number to wait for
+   * @param timeout throws {@link TimeoutException} if it takes longer that
+   *                {@code timeout} to get to {@code seqNum}
+   */
   void ensureConsumedPast(long seqNum, Duration timeout)
       throws InterruptedException, TimeoutException;
 
+  /**
+   * @return whether or not there are any enqueued commands
+   */
   boolean isEmpty();
 
+  /**
+   * Closes the queue so that no more reads or writes will be accepted.
+   */
   @Override
   void close();
 }

--- a/ksql-rest-app/src/main/java/io/confluent/ksql/rest/server/computation/CommandStore.java
+++ b/ksql-rest-app/src/main/java/io/confluent/ksql/rest/server/computation/CommandStore.java
@@ -50,12 +50,11 @@ public class CommandStore implements CommandQueue, Closeable {
   public CommandStore(
       final String commandTopicName,
       final Map<String, Object> kafkaConsumerProperties,
-      final Map<String, Object> kafkaProducerProperties,
-      final CommandIdAssigner commandIdAssigner
+      final Map<String, Object> kafkaProducerProperties
   ) {
     this(
         new CommandTopic(commandTopicName, kafkaConsumerProperties, kafkaProducerProperties),
-        commandIdAssigner,
+        new CommandIdAssigner(),
         new SequenceNumberFutureStore());
   }
 

--- a/ksql-rest-app/src/test/java/io/confluent/ksql/rest/server/computation/CommandStoreTest.java
+++ b/ksql-rest-app/src/test/java/io/confluent/ksql/rest/server/computation/CommandStoreTest.java
@@ -124,7 +124,6 @@ public class CommandStoreTest {
   public void shouldFailEnqueueIfCommandWithSameIdRegistered() {
     // Given:
     when(commandIdAssigner.getCommandId(any())).thenReturn(commandId);
-
     commandStore.enqueueCommand(preparedStatement, KSQL_CONFIG, OVERRIDE_PROPERTIES);
 
     expectedException.expect(IllegalStateException.class);

--- a/ksql-rest-app/src/test/java/io/confluent/ksql/rest/server/computation/RecoveryTest.java
+++ b/ksql-rest-app/src/test/java/io/confluent/ksql/rest/server/computation/RecoveryTest.java
@@ -98,9 +98,8 @@ public class RecoveryTest {
     private int offset;
 
     FakeCommandQueue(
-        final CommandIdAssigner commandIdAssigner,
         final List<QueuedCommand> commandLog) {
-      this.commandIdAssigner = commandIdAssigner;
+      this.commandIdAssigner = new CommandIdAssigner();
       this.commandLog = commandLog;
     }
 
@@ -154,17 +153,13 @@ public class RecoveryTest {
   private class KsqlServer {
     final KsqlEngine ksqlEngine;
     final KsqlResource ksqlResource;
-    final CommandIdAssigner commandIdAssigner;
     final FakeCommandQueue fakeCommandQueue;
     final StatementExecutor statementExecutor;
     final CommandRunner commandRunner;
 
     KsqlServer(final List<QueuedCommand> commandLog) {
       this.ksqlEngine = createKsqlEngine();
-      this.commandIdAssigner = new CommandIdAssigner(ksqlEngine.getMetaStore());
-      this.fakeCommandQueue = new FakeCommandQueue(
-          new CommandIdAssigner(ksqlEngine.getMetaStore()),
-          commandLog);
+      this.fakeCommandQueue = new FakeCommandQueue(commandLog);
       this.ksqlResource = new KsqlResource(
           ksqlConfig,
           ksqlEngine,

--- a/ksql-rest-app/src/test/java/io/confluent/ksql/rest/server/resources/KsqlResourceTest.java
+++ b/ksql-rest-app/src/test/java/io/confluent/ksql/rest/server/resources/KsqlResourceTest.java
@@ -1455,7 +1455,7 @@ public class KsqlResourceTest {
     expectedException.expect(exceptionErrorMessage(
         errorMessage(containsString(
             "Cannot add the new data source. Another data source with the "
-                + "same name already exists: KsqlStream name:SINK"))));
+                + "same name already exists: KsqlTable name:SINK"))));
 
     // When:
     final String createSql =


### PR DESCRIPTION
### Description 
Three minor changes contained in this patch:

1. Remove validation from CommandIDAssigner since it doesn't really make sense to have it there and this validation was already being done in various other places.
2. Add tests to ensure removed code didn't affect functionality (and increased coverage)
3. Added javadoc to `CommandQueue` interface

### Testing done 
Added new unit tests

### Reviewer checklist
- [ ] Ensure docs are updated if necessary. (eg. if a user visible feature is being added or changed).
- [ ] Ensure relevant issues are linked (description should include text like "Fixes #<issue number>")

