### PR TITLE
Release notes + default configs for processing logger

### DIFF
--- a/config/ksql-server.properties
+++ b/config/ksql-server.properties
@@ -14,3 +14,6 @@
 
 bootstrap.servers=localhost:9092
 listeners=http://localhost:8088
+ksql.processing.log.stream.auto.create=true
+ksql.processing.log.topic.auto.create=true
+#ksql.processing.log.include.rows=true

--- a/config/ksql-server.properties
+++ b/config/ksql-server.properties
@@ -14,6 +14,6 @@
 
 bootstrap.servers=localhost:9092
 listeners=http://localhost:8088
-ksql.processing.log.stream.auto.create=true
-ksql.processing.log.topic.auto.create=true
-#ksql.processing.log.include.rows=true
+ksql.logging.processing.stream.auto.create=true
+ksql.logging.processing.topic.auto.create=true
+#ksql.logging.processing.rows.include=true

--- a/config/log4j-rolling.properties
+++ b/config/log4j-rolling.properties
@@ -39,6 +39,12 @@ log4j.appender.kafka.MaxFileSize=10MB
 log4j.appender.kafka.MaxBackupIndex=5
 log4j.appender.kafka.append=true
 
+log4j.appender.kafka_appender=org.apache.kafka.log4jappender.KafkaLog4jAppender
+log4j.appender.kafka_appender.layout=io.confluent.common.logging.log4j.StructuredJsonLayout
+log4j.appender.kafka_appender.BrokerList=localhost:9092
+log4j.appender.kafka_appender.Topic=default_ksql_processing_log
+log4j.logger.processing=ERROR, kafka_appender
+
 # loggers
 log4j.logger.org.apache.kafka.streams=INFO, streams
 log4j.additivity.org.apache.kafka.streams=false
@@ -54,3 +60,6 @@ log4j.additivity.org.apache.kafka=false
 
 log4j.logger.org.I0Itec.zkclient=ERROR, kafka
 log4j.additivity.org.I0Itec.zkclient=false
+
+log4j.logger.processing=ERROR, kafka_appender
+log4j.additivity.processing=false

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -11,6 +11,9 @@ KSQL 5.2 includes new features, including:
 * Added support for read-after-write consistency: new commands don't execute until previous commands have finished executing.
   This feature is enabled by default in the CLI (`#2280 <https://github.com/confluentinc/ksql/pull/2280>`_)
   and can be implemented by the user for the REST API (:ref:`coordinate_multiple_requests`).
+* A log of record processing events to help users debug their KSQL queries. The log can be configured
+  to log to Kafka to be consumed as a KSQL stream. See :ref:`KSQL processing log <ksql_processing_log>`
+  for more details.
 
 KSQL 5.2 includes bug fixes, including:
 

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -6,9 +6,9 @@ Version 5.2.0
 
 KSQL 5.2 includes new features, including:
 
-* Added a new family of UDFs for improved handling of URIs (e.g. extracting information/decoding information), see :ref:`UDF table <functions>` for all URL functions
-* Added ``LIMIT`` keyword support for ``PRINT`` (`#1316 <https://github.com/confluentinc/ksql/issues/1316>`_)
-* Added support for read-after-write consistency: new commands don't execute until previous commands have finished executing.
+* A new family of UDFs for improved handling of URIs (e.g. extracting information/decoding information), see :ref:`UDF table <functions>` for all URL functions
+* ``LIMIT`` keyword support for ``PRINT`` (`#1316 <https://github.com/confluentinc/ksql/issues/1316>`_)
+* Support for read-after-write consistency: new commands don't execute until previous commands have finished executing.
   This feature is enabled by default in the CLI (`#2280 <https://github.com/confluentinc/ksql/pull/2280>`_)
   and can be implemented by the user for the REST API (:ref:`coordinate_multiple_requests`).
 * A log of record processing events to help users debug their KSQL queries. The log can be configured

--- a/docs/developer-guide/processing-log.rst
+++ b/docs/developer-guide/processing-log.rst
@@ -156,7 +156,7 @@ properties file:
 ::
 
     ksql.logging.processing.topic.auto.create=true
-    ksql.logging.processing.topic.name=<kafka topic>  # defaults to <ksql service id>processing_log
+    ksql.logging.processing.topic.name=<kafka topic>  # defaults to <ksql service id>ksql_processing_log
 
 The replication factor and partition count are configurable
 using the ``ksql.logging.processing.topic.replication.factor`` and ``ksql.logging.processing.topic.partitions`` properties,


### PR DESCRIPTION
Adds default configs for the processing logger that enables the log to write to kafka.
This way, when you use ksql out-of-the-box, it should just work.

Also adds a release note
