### PR TITLE
Add docs about upgrade compatibility

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -20,6 +20,11 @@ KSQL 5.2 includes new features, including:
     arithmetic results, functions, string concatenations and literals.
   * literals in the projection, (a.k.a the ``SELECT`` clause).
   * Multiple ``HAVING`` clauses, including the use of aggregate functions and literals.
+* Automatic compatibility management for queries in headless mode across versions. Starting with 5.2, KSQL will automatically take care
+  of ensuring query compatiblity when upgrading. This means you won't need to worry about setting properties correctly during upgrade, as
+  has been required for previous upgrades. Refer to the :ref:`architecture documentation <ksql-architecture-config-topic>` for details.
+  Note that it is still up to the user to set properties correctly before upgrading to 5.2. The :ref:`upgrade doc <upgrading-ksql>` has
+  details about the properties required to safely upgrade to 5.2.
 
 KSQL 5.2 includes bug fixes, including:
 

--- a/docs/concepts/ksql-architecture.rst
+++ b/docs/concepts/ksql-architecture.rst
@@ -153,6 +153,15 @@ In interactive mode, you can:
 * Start one or more CLIs or REST Clients and point them to a server:
   ``<path-to-confluent>/bin/ksql https://<ksql-server-ip-address>:8090``
 
+Command Topic
+-------------
+
+In interactive mode, KSQL shares statements with servers in the cluster over the
+*command topic*. The command topic stores every KSQL statement, along with some
+metadata that ensures the statements are built compatibly across KSQL restarts
+and upgrades. KSQL names the command topic ``_confluent-ksql-<service id>_command_topic``,
+where ``<service id>`` is the value in the ``ksql.service.id`` property.
+
 Headless Deployment
 ===================
 
@@ -174,6 +183,17 @@ In headless mode you can:
 * Version-control your queries and transformations as code
 * Ensure resource isolation
 * Leave resource management to dedicated systems, like Kubernetes
+
+.. _ksql-architecture-config-topic:
+
+Config Topic
+------------
+
+In headless mode, you supply KSQL statements to each server in its SQL file. However
+KSQL still needs to store some internal metadata to ensure that it builds queries
+compatibly across restarts and upgrades. KSQL stores this metadata in an internal topic
+called the *config topic*. KSQL names the config topic ``_confluent-ksql-<service id>_configs``,
+where ``<service id>`` is the value in the ``ksql.service.id`` property.
 
 Supported Operations in Headless and Interactive Modes
 ======================================================

--- a/docs/faq.rst
+++ b/docs/faq.rst
@@ -217,17 +217,21 @@ Yes. KSQL can be configured to communicate with |sr-long| over HTTPS. For more i
 Where are KSQL-related data and metadata stored?
 ================================================
 
-Metadata is stored in and built from the KSQL command topic. Each KSQL server
-has its own in-memory version of the metastore. To secure the metadata, you must
-secure the command topic.
+In interactive mode, KSQL stores metatada in and builds metadata ifrom the KSQL
+command topic. To secure the metadata, you must secure the command topic.
 
 The KSQL command topic stores all data definition language (DDL) statements:
 CREATE STREAM, CREATE TABLE, DROP STREAM, and DROP TABLE. Also, the KSQL command
 topic stores TERMINATE statements, which stop persistent queries based on
 CREATE STREAM AS SELECT (CSAS) and CREATE TABLE AS SELECT (CTAS). 
 
-Currently, data manipulation language (DML) statements, like UPDATE, INSERT,
-and DELETE, aren't available.
+Currently, data manipulation language (DML) statements, like UPDATE and DELETE
+aren't available.
+
+In headless mode, KSQL stores metadata in the config topic. The config topic stores
+the KSQL properties provided to KSQL when the application was first started. KSQL
+uses these configs to ensure that your KSQL queries are built compatibly on every
+restart of the server.
 
 ===============================================
 Which KSQL queries read or write data to Kafka?

--- a/docs/installation/upgrading.rst
+++ b/docs/installation/upgrading.rst
@@ -47,7 +47,7 @@ Upgrading from KSQL 5.0.0 and below to KSQL 5.1
 
     * The KSQL engine metrics are now prefixed with the ``ksql.service.id``. If you have been using any metric monitoring
       tool you need to update your metric names.
-      For instance, assuming ``ksql.service.id`` is set to ``default``, ``messages-produced-per-sec`` will be changed to ``_confluent-ksql-default_messages-consumed-per-sec``.
+      For instance, assuming ``ksql.service.id`` is set to ``default_``, ``messages-produced-per-sec`` will be changed to ``_confluent-ksql-default_messages-consumed-per-sec``.
 
 * Configuration:
 

--- a/docs/installation/upgrading.rst
+++ b/docs/installation/upgrading.rst
@@ -27,6 +27,32 @@ Upgrading from KSQL 5.1 to KSQL 5.2
           release.
           Instead, include the contents of the script in the main body of your request.
 
+* Configuration:
+
+    * When upgrading your headless (non-interactive) mode application from version 5.0.0 and below, you must include the configs specified in the :ref:`5.1 upgrade instructions <5-1-upgrade>`.
+    * When upgrading your headless (non-interactive) mode application, you must include the following properties in your properties file:
+
+::
+
+    ksql.windowed.session.key.legacy=true
+    ksql.named.internal.topics=off
+    ksql.streams.topology.optimization=none
+
+.. _5-1-upgrade:
+
+Upgrading from KSQL 5.0.0 and below to KSQL 5.1
+-----------------------------------------------
+
+* KSQL server:
+
+    * The KSQL engine metrics are now prefixed with the ``ksql.service.id``. If you have been using any metric monitoring
+      tool you need to update your metric names.
+      For instance, assuming ``ksql.service.id`` is set to ``default``, ``messages-produced-per-sec`` will be changed to ``_confluent-ksql-default_messages-consumed-per-sec``.
+
+* Configuration:
+
+    * When upgrading your headless (non-interactive) mode application, you must either update your queries to use the new SUBSTRING indexing semantics, or set ``ksql.functions.substring.legacy.args`` to ``true``. If possible, we recommend that you update your queries accordingly, instead of enabling this configuration setting. Refer to the SUBSTRING documentation in the :ref:`function <functions>` guide for details on how to do so. Note that this is NOT required for interactive mode KSQL.
+
 Upgrading from KSQL 0.x (Developer Preview) to KSQL 4.1
 -------------------------------------------------------
 
@@ -59,16 +85,3 @@ Notable changes in 4.1:
 * Configuration: Advanced KSQL users can configure the Kafka Streams and Kafka producer/consumer client settings used
   by KSQL.  This is achieved by using prefixes for the respective configuration settings.
   See :ref:`ksql-param-reference` as well as :ref:`ksql-server-config` and :ref:`install_cli-config` for details.
-
-Upgrading from KSQL 5.0.0 and below to KSQL 5.1
------------------------------------------------
-
-* KSQL server:
-
-    * The KSQL engine metrics are now prefixed with the ``ksql.service.id``. If you have been using any metric monitoring
-      tool you need to update your metric names.
-      For instance, assuming ``ksql.service.id`` is set to ``default``, ``messages-produced-per-sec`` will be changed to ``_confluent-ksql-default_messages-consumed-per-sec``.
-
-* Configuration:
-
-    * When upgrading your headless (non-interactive) mode application, you must either update your queries to use the new SUBSTRING indexing semantics, or set ``ksql.functions.substring.legacy.args`` to ``true``. If possible, we recommend that you update your queries accordingly, instead of enabling this configuration setting. Refer to the SUBSTRING documentation in the :ref:`function <functions>` guide for details on how to do so. Note that this is NOT required for interactive mode KSQL.


### PR DESCRIPTION
This patch adds documentation about upgrade compatibility:
- Release notes that raise the new compatibility config topic for headless mode
- Upgrade docs that specify the properties that must be set for headless mode when
  upgrading. Note that docs for the individual configs are omitted since they really
  should just be internal properties