### PR TITLE
Preserve '*' when formatting a 'SELECT *' statement

### DIFF
--- a/ksql-parser/src/main/java/io/confluent/ksql/parser/SqlFormatter.java
+++ b/ksql-parser/src/main/java/io/confluent/ksql/parser/SqlFormatter.java
@@ -169,7 +169,7 @@ public final class SqlFormatter {
           .stream()
           .map(item ->
               (item instanceof SingleColumn)
-                  ? ((SingleColumn) item).getSource().map(SelectItem.class::cast).orElse(item)
+                  ? ((SingleColumn) item).getAllColumns().map(SelectItem.class::cast).orElse(item)
                   : item)
           .distinct()
           .collect(Collectors.toList());

--- a/ksql-parser/src/main/java/io/confluent/ksql/parser/SqlFormatter.java
+++ b/ksql-parser/src/main/java/io/confluent/ksql/parser/SqlFormatter.java
@@ -66,6 +66,8 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 import java.util.regex.Pattern;
+import java.util.stream.Collectors;
+import org.apache.commons.lang3.StringUtils;
 
 public final class SqlFormatter {
 
@@ -76,15 +78,13 @@ public final class SqlFormatter {
   }
 
   public static String formatSql(final Node root) {
-    final StringBuilder builder = new StringBuilder();
-    new Formatter(builder, true).process(root, 0);
-    return builder.toString();
+    return formatSql(root, true);
   }
 
   public static String formatSql(final Node root, final boolean unmangleNames) {
     final StringBuilder builder = new StringBuilder();
     new Formatter(builder, unmangleNames).process(root, 0);
-    return builder.toString();
+    return StringUtils.stripEnd(builder.toString(), "\n");
   }
 
   private static final class Formatter
@@ -131,9 +131,6 @@ public final class SqlFormatter {
       append(indent, "FROM ");
       processRelation(node.getFrom(), indent);
       builder.append('\n');
-      append(indent, "  ");
-
-      builder.append('\n');
 
       if (node.getWhere().isPresent()) {
         append(indent, "WHERE " + ExpressionFormatter.formatExpression(node.getWhere().get()))
@@ -168,9 +165,18 @@ public final class SqlFormatter {
         builder.append(" DISTINCT");
       }
 
-      if (node.getSelectItems().size() > 1) {
+      final List<SelectItem> selectItems = node.getSelectItems()
+          .stream()
+          .map(item ->
+              (item instanceof SingleColumn)
+                  ? ((SingleColumn) item).getSource().map(SelectItem.class::cast).orElse(item)
+                  : item)
+          .distinct()
+          .collect(Collectors.toList());
+
+      if (selectItems.size() > 1) {
         boolean first = true;
-        for (final SelectItem item : node.getSelectItems()) {
+        for (final SelectItem item : selectItems) {
           builder.append("\n")
                   .append(indentString(indent))
                   .append(first ? "  " : ", ");
@@ -180,7 +186,7 @@ public final class SqlFormatter {
         }
       } else {
         builder.append(' ');
-        process(getOnlyElement(node.getSelectItems()), indent);
+        process(getOnlyElement(selectItems), indent);
       }
 
       builder.append('\n');

--- a/ksql-parser/src/main/java/io/confluent/ksql/parser/rewrite/StatementRewriter.java
+++ b/ksql-parser/src/main/java/io/confluent/ksql/parser/rewrite/StatementRewriter.java
@@ -549,19 +549,7 @@ public class StatementRewriter extends DefaultAstVisitor<Node, Object> {
   }
 
   protected Node visitSingleColumn(final SingleColumn node, final Object context) {
-    // use an if/else block here (instead of isPresent.map(...).orElse(...)) so only one object
-    // gets instantiated (issue #1784)
-    if (node.getLocation().isPresent()) {
-      return new SingleColumn(node.getLocation().get(),
-          (Expression) process(node.getExpression(), context),
-          node.getAlias()
-      );
-    } else {
-      return new SingleColumn(
-          (Expression) process(node.getExpression(), context),
-          node.getAlias()
-      );
-    }
+    return node.copyWithExpression((Expression) process(node.getExpression(), context));
   }
 
   protected Node visitAllColumns(final AllColumns node, final Object context) {

--- a/ksql-parser/src/main/java/io/confluent/ksql/parser/tree/SingleColumn.java
+++ b/ksql-parser/src/main/java/io/confluent/ksql/parser/tree/SingleColumn.java
@@ -24,7 +24,7 @@ import java.util.Optional;
 public class SingleColumn
     extends SelectItem {
 
-  private final Optional<AllColumns> source;
+  private final Optional<AllColumns> allColumns;
   private final Optional<String> alias;
   private final Expression expression;
 
@@ -45,23 +45,26 @@ public class SingleColumn
     this(Optional.of(location), expression, alias, Optional.empty());
   }
 
-  public SingleColumn(final Expression expression, final String alias, final AllColumns source) {
-    this(Optional.empty(), expression, Optional.of(alias), Optional.of(source));
+  public SingleColumn(
+      final Expression expression,
+      final String alias,
+      final AllColumns allColumns) {
+    this(Optional.empty(), expression, Optional.of(alias), Optional.of(allColumns));
   }
 
   private SingleColumn(final SingleColumn other, final Expression expression) {
-    this(other.getLocation(), expression, other.alias, other.source);
+    this(other.getLocation(), expression, other.alias, other.allColumns);
   }
 
   private SingleColumn(
       final Optional<NodeLocation> location,
       final Expression expression,
       final Optional<String> alias,
-      final Optional<AllColumns> source) {
+      final Optional<AllColumns> allColumns) {
     super(location);
     requireNonNull(expression, "expression is null");
     requireNonNull(alias, "alias is null");
-    requireNonNull(source, "source is null");
+    requireNonNull(allColumns, "allColumns is null");
 
     alias.ifPresent(name -> {
       checkForReservedToken(expression, name, SchemaUtil.ROWTIME_NAME);
@@ -70,7 +73,7 @@ public class SingleColumn
 
     this.expression = expression;
     this.alias = alias;
-    this.source = source;
+    this.allColumns = allColumns;
   }
 
   public SingleColumn copyWithExpression(final Expression expression) {
@@ -96,8 +99,13 @@ public class SingleColumn
     return expression;
   }
 
-  public Optional<AllColumns> getSource() {
-    return source;
+  /**
+   * @return a reference to an {@code AllColumns} if this single column
+   *         was expanded as part of a {@code SELECT *} Expression, otherwise
+   *         returns an empty optional
+   */
+  public Optional<AllColumns> getAllColumns() {
+    return allColumns;
   }
 
   @Override
@@ -111,17 +119,17 @@ public class SingleColumn
     final SingleColumn other = (SingleColumn) obj;
     return Objects.equals(this.alias, other.alias)
         && Objects.equals(this.expression, other.expression)
-        && Objects.equals(this.source, other.source);
+        && Objects.equals(this.allColumns, other.allColumns);
   }
 
   @Override
   public int hashCode() {
-    return Objects.hash(source, alias, expression);
+    return Objects.hash(allColumns, alias, expression);
   }
 
   @Override
   public String toString() {
-    return "SingleColumn{" + "source=" + source
+    return "SingleColumn{" + "allColumns=" + allColumns
         + ", alias=" + alias
         + ", expression=" + expression
         + '}';

--- a/ksql-parser/src/main/java/io/confluent/ksql/parser/tree/SingleColumn.java
+++ b/ksql-parser/src/main/java/io/confluent/ksql/parser/tree/SingleColumn.java
@@ -24,31 +24,44 @@ import java.util.Optional;
 public class SingleColumn
     extends SelectItem {
 
+  private final Optional<AllColumns> source;
   private final Optional<String> alias;
   private final Expression expression;
 
   public SingleColumn(final Expression expression) {
-    this(Optional.empty(), expression, Optional.empty());
+    this(Optional.empty(), expression, Optional.empty(), Optional.empty());
   }
 
   public SingleColumn(final Expression expression, final Optional<String> alias) {
-    this(Optional.empty(), expression, alias);
+    this(Optional.empty(), expression, alias, Optional.empty());
   }
 
   public SingleColumn(final Expression expression, final String alias) {
-    this(Optional.empty(), expression, Optional.of(alias));
+    this(Optional.empty(), expression, Optional.of(alias), Optional.empty());
   }
 
   public SingleColumn(
       final NodeLocation location, final Expression expression, final Optional<String> alias) {
-    this(Optional.of(location), expression, alias);
+    this(Optional.of(location), expression, alias, Optional.empty());
   }
 
-  private SingleColumn(final Optional<NodeLocation> location, final Expression expression,
-                       final Optional<String> alias) {
+  public SingleColumn(final Expression expression, final String alias, final AllColumns source) {
+    this(Optional.empty(), expression, Optional.of(alias), Optional.of(source));
+  }
+
+  private SingleColumn(final SingleColumn other, final Expression expression) {
+    this(other.getLocation(), expression, other.alias, other.source);
+  }
+
+  private SingleColumn(
+      final Optional<NodeLocation> location,
+      final Expression expression,
+      final Optional<String> alias,
+      final Optional<AllColumns> source) {
     super(location);
     requireNonNull(expression, "expression is null");
     requireNonNull(alias, "alias is null");
+    requireNonNull(source, "source is null");
 
     alias.ifPresent(name -> {
       checkForReservedToken(expression, name, SchemaUtil.ROWTIME_NAME);
@@ -57,6 +70,11 @@ public class SingleColumn
 
     this.expression = expression;
     this.alias = alias;
+    this.source = source;
+  }
+
+  public SingleColumn copyWithExpression(final Expression expression) {
+    return new SingleColumn(this, expression);
   }
 
   private void checkForReservedToken(
@@ -78,6 +96,10 @@ public class SingleColumn
     return expression;
   }
 
+  public Optional<AllColumns> getSource() {
+    return source;
+  }
+
   @Override
   public boolean equals(final Object obj) {
     if (this == obj) {
@@ -87,22 +109,22 @@ public class SingleColumn
       return false;
     }
     final SingleColumn other = (SingleColumn) obj;
-    return Objects.equals(this.alias, other.alias) && Objects
-        .equals(this.expression, other.expression);
+    return Objects.equals(this.alias, other.alias)
+        && Objects.equals(this.expression, other.expression)
+        && Objects.equals(this.source, other.source);
   }
 
   @Override
   public int hashCode() {
-    return Objects.hash(alias, expression);
+    return Objects.hash(source, alias, expression);
   }
 
   @Override
   public String toString() {
-    if (alias.isPresent()) {
-      return expression.toString() + " " + alias.get();
-    }
-
-    return expression.toString();
+    return "SingleColumn{" + "source=" + source
+        + ", alias=" + alias
+        + ", expression=" + expression
+        + '}';
   }
 
   @Override

--- a/ksql-parser/src/test/java/io/confluent/ksql/parser/KsqlParserTest.java
+++ b/ksql-parser/src/test/java/io/confluent/ksql/parser/KsqlParserTest.java
@@ -1300,7 +1300,7 @@ public class KsqlParserTest {
         SingleColumn column = (SingleColumn) item;
         return Objects.equals(column.getExpression().toString(), expression)
             && Objects.equals(column.getAlias().orElse(null), alias)
-            && Objects.equals(column.getSource().isPresent(), false);
+            && Objects.equals(column.getAllColumns().isPresent(), false);
       }
 
       @Override


### PR DESCRIPTION
### Description 
Consider stream `X` with fields `A` and `B`. Previously, the following semantics would hold:
```java
// Statement statement = resolve("SELECT * FROM X");
print(SqlFormatter.formatSql(statement));
> SELECT X.ROWTIME "ROWTIME", X.ROWKEY "ROWKEY", X.A "A", X.B "B" FROM X X;
```

The new behavior replaces all of the select items that came from a `*` with `*`, for example:
```java
// Statement statement = resolve("SELECT *, A AS ONE FROM X");
print(SqlFormatter.formatSql(statement));
> SELECT *, X.A "ONE" FROM X X;
```

### Motivation
In order to support #2436, we need to make sure that `SELECT *` statements do not expand to include ROWKEY/ROWTIME. Fixing the root cause of this behavior is tricky and perhaps backwards incompatible (see discussion https://github.com/confluentinc/ksql/pull/2436#discussion_r257433312), so in the meantime I propose the behavior in this PR, which I think is good independent of that PR.

### Testing done 
New unit tests.

### Reviewer checklist
- [ ] Ensure docs are updated if necessary. (eg. if a user visible feature is being added or changed).
- [ ] Ensure relevant issues are linked (description should include text like "Fixes #<issue number>")

