### PR TITLE
Minor: fix typo in finding server log4j properties file

### DIFF
--- a/bin/ksql-server-start
+++ b/bin/ksql-server-start
@@ -15,7 +15,7 @@ base_dir=$( cd "$( dirname "${BASH_SOURCE[0]}" )/.." && pwd )
 : "${KSQL_CONFIG_DIR:="$base_dir/config"}"
 
 : "${KSQL_LOG4J_OPTS:=""}"
-if [ -z "$KSQL_LOG4J_OPTS" ] && [ -e "$KSQL_CONFIG_DIR/log4j-silent.properties" ]; then
+if [ -z "$KSQL_LOG4J_OPTS" ] && [ -e "$KSQL_CONFIG_DIR/log4j-rolling.properties" ]; then
   export KSQL_LOG4J_OPTS="-Dlog4j.configuration=file:$KSQL_CONFIG_DIR/log4j-rolling.properties"
 fi
 


### PR DESCRIPTION
### Description 

The server's log4j properties file is `log4j-rolling.properties`, so that's the file we should check existence for, not `log4j-silent.properties` (which is for datagen).

### Testing done 

File is still found correctly.

### Reviewer checklist
- [ ] Ensure docs are updated if necessary. (eg. if a user visible feature is being added or changed).
- [ ] Ensure relevant issues are linked (description should include text like "Fixes #<issue number>")

