### PR TITLE
Allow BIGINT and INT types in Math UDF (abs, round, floor, ceil)

### DIFF
--- a/ksql-engine/src/main/java/io/confluent/ksql/function/InternalFunctionRegistry.java
+++ b/ksql-engine/src/main/java/io/confluent/ksql/function/InternalFunctionRegistry.java
@@ -25,11 +25,7 @@ import io.confluent.ksql.function.udf.UdfMetadata;
 import io.confluent.ksql.function.udf.geo.GeoDistanceKudf;
 import io.confluent.ksql.function.udf.json.ArrayContainsKudf;
 import io.confluent.ksql.function.udf.json.JsonExtractStringKudf;
-import io.confluent.ksql.function.udf.math.AbsKudf;
-import io.confluent.ksql.function.udf.math.CeilKudf;
-import io.confluent.ksql.function.udf.math.FloorKudf;
 import io.confluent.ksql.function.udf.math.RandomKudf;
-import io.confluent.ksql.function.udf.math.RoundKudf;
 import io.confluent.ksql.function.udf.string.ConcatKudf;
 import io.confluent.ksql.function.udf.string.IfNullKudf;
 import io.confluent.ksql.function.udf.string.LCaseKudf;
@@ -221,36 +217,6 @@ public class InternalFunctionRegistry implements MutableFunctionRegistry {
     }
 
     private void addMathFunctions() {
-
-      addBuiltInFunction(KsqlFunction.createLegacyBuiltIn(
-          Schema.OPTIONAL_FLOAT64_SCHEMA,
-          ImmutableList.of(Schema.OPTIONAL_FLOAT64_SCHEMA),
-          AbsKudf.NAME,
-          AbsKudf.class));
-
-      addBuiltInFunction(KsqlFunction.createLegacyBuiltIn(
-          Schema.OPTIONAL_FLOAT64_SCHEMA,
-          Collections.singletonList(Schema.OPTIONAL_INT64_SCHEMA),
-          AbsKudf.NAME,
-          AbsKudf.class));
-
-      addBuiltInFunction(KsqlFunction.createLegacyBuiltIn(
-          Schema.OPTIONAL_FLOAT64_SCHEMA,
-          Collections.singletonList(Schema.OPTIONAL_FLOAT64_SCHEMA),
-          "CEIL",
-          CeilKudf.class));
-
-      addBuiltInFunction(KsqlFunction.createLegacyBuiltIn(
-          Schema.OPTIONAL_FLOAT64_SCHEMA,
-          Collections.singletonList(Schema.OPTIONAL_FLOAT64_SCHEMA),
-          "FLOOR",
-          FloorKudf.class));
-
-      addBuiltInFunction(KsqlFunction.createLegacyBuiltIn(
-          Schema.OPTIONAL_INT64_SCHEMA,
-          Collections.singletonList(Schema.OPTIONAL_FLOAT64_SCHEMA),
-          "ROUND",
-          RoundKudf.class));
 
       addBuiltInFunction(KsqlFunction.createLegacyBuiltIn(
           Schema.OPTIONAL_FLOAT64_SCHEMA,

--- a/ksql-engine/src/main/java/io/confluent/ksql/function/udf/math/AbsKudf.java
+++ b/ksql-engine/src/main/java/io/confluent/ksql/function/udf/math/AbsKudf.java
@@ -14,18 +14,45 @@
 
 package io.confluent.ksql.function.udf.math;
 
-import io.confluent.ksql.function.UdfUtil;
-import io.confluent.ksql.function.udf.Kudf;
+import io.confluent.ksql.function.udf.Udf;
+import io.confluent.ksql.function.udf.UdfDescription;
+import io.confluent.ksql.function.udf.UdfParameter;
 
-public class AbsKudf implements Kudf {
+@UdfDescription(name = AbsKudf.NAME, version = "Confluent",
+    description = "Returns the absolute value of a number.")
+public class AbsKudf {
   public static final String NAME = "ABS";
 
-  @Override
-  public Object evaluate(final Object... args) {
-    UdfUtil.ensureCorrectArgs(NAME, args, Number.class);
-    if (args[0] == null) {
+  @Udf(description = "Returns the absolute value of a number.")
+  public Integer abs(
+      @UdfParameter(description = "A number whose absolute value is to be retrieved.")
+      final Integer n) {
+    if (n == null) {
       return null;
     }
-    return Math.abs(((Number) args[0]).doubleValue());
+
+    return Math.abs(n);
+  }
+
+  @Udf(description = "Returns the absolute value of a number.")
+  public Long abs(
+      @UdfParameter(description = "A number whose absolute value is to be retrieved.")
+      final Long n) {
+    if (n == null) {
+      return null;
+    }
+
+    return Math.abs(n);
+  }
+
+  @Udf(description = "Returns the absolute value of a number.")
+  public Double abs(
+      @UdfParameter(description = "A number whose absolute value is to be retrieved.")
+      final Double n) {
+    if (n == null) {
+      return null;
+    }
+
+    return Math.abs(n);
   }
 }

--- a/ksql-engine/src/main/java/io/confluent/ksql/function/udf/math/CeilKudf.java
+++ b/ksql-engine/src/main/java/io/confluent/ksql/function/udf/math/CeilKudf.java
@@ -14,16 +14,42 @@
 
 package io.confluent.ksql.function.udf.math;
 
-import io.confluent.ksql.function.KsqlFunctionException;
-import io.confluent.ksql.function.udf.Kudf;
+import io.confluent.ksql.function.udf.Udf;
+import io.confluent.ksql.function.udf.UdfDescription;
+import io.confluent.ksql.function.udf.UdfParameter;
 
-public class CeilKudf implements Kudf {
+@UdfDescription(name = CeilKudf.NAME, version = "Confluent",
+    description = "Returns the ceiling of a value.")
+public class CeilKudf {
+  static final String NAME = "CEIL";
 
-  @Override
-  public Object evaluate(final Object... args) {
-    if (args.length != 1) {
-      throw new KsqlFunctionException("Ceil udf should have one input argument.");
+  @Udf(description = "Returns the ceiling of a value.")
+  public Integer ceil(@UdfParameter(description = "A value.")
+      final Integer n) {
+    if (n == null) {
+      return null;
     }
-    return Math.ceil((Double) args[0]);
+
+    return (int) Math.ceil(n.doubleValue());
+  }
+
+  @Udf(description = "Returns the ceiling of a value.")
+  public Long ceil(@UdfParameter(description = "A value.")
+                      final Long n) {
+    if (n == null) {
+      return null;
+    }
+
+    return (long) Math.ceil(n.doubleValue());
+  }
+
+  @Udf(description = "Returns the ceiling of a value.")
+  public Double ceil(@UdfParameter(description = "A value.")
+                      final Double n) {
+    if (n == null) {
+      return null;
+    }
+
+    return Math.ceil(n.doubleValue());
   }
 }

--- a/ksql-engine/src/main/java/io/confluent/ksql/function/udf/math/FloorKudf.java
+++ b/ksql-engine/src/main/java/io/confluent/ksql/function/udf/math/FloorKudf.java
@@ -14,16 +14,45 @@
 
 package io.confluent.ksql.function.udf.math;
 
-import io.confluent.ksql.function.KsqlFunctionException;
-import io.confluent.ksql.function.udf.Kudf;
+import io.confluent.ksql.function.udf.Udf;
+import io.confluent.ksql.function.udf.UdfDescription;
+import io.confluent.ksql.function.udf.UdfParameter;
 
-public class FloorKudf implements Kudf {
+@UdfDescription(name = FloorKudf.NAME, version = "Confluent",
+    description = "Returns the floor of a value.")
+public class FloorKudf {
+  static final String NAME = "FLOOR";
 
-  @Override
-  public Object evaluate(final Object... args) {
-    if (args.length != 1) {
-      throw new KsqlFunctionException("Floor udf should have one input argument.");
+  @Udf(description = "Returns the floor of a value.")
+  public Integer floor(
+      @UdfParameter(description = "A value.")
+      final Integer n) {
+    if (n == null) {
+      return null;
     }
-    return Math.floor((Double) args[0]);
+
+    return (int) Math.floor(n.doubleValue());
+  }
+
+  @Udf(description = "Returns the floor of a value.")
+  public Long floor(
+      @UdfParameter(description = "A value.")
+      final Long n) {
+    if (n == null) {
+      return null;
+    }
+
+    return (long) Math.floor(n.doubleValue());
+  }
+
+  @Udf(description = "Returns the floor of a value.")
+  public Double floor(
+      @UdfParameter(description = "A value.")
+      final Double n) {
+    if (n == null) {
+      return null;
+    }
+
+    return Math.floor(n);
   }
 }

--- a/ksql-engine/src/main/java/io/confluent/ksql/function/udf/math/RoundKudf.java
+++ b/ksql-engine/src/main/java/io/confluent/ksql/function/udf/math/RoundKudf.java
@@ -14,16 +14,45 @@
 
 package io.confluent.ksql.function.udf.math;
 
-import io.confluent.ksql.function.KsqlFunctionException;
-import io.confluent.ksql.function.udf.Kudf;
+import io.confluent.ksql.function.udf.Udf;
+import io.confluent.ksql.function.udf.UdfDescription;
+import io.confluent.ksql.function.udf.UdfParameter;
 
-public class RoundKudf implements Kudf {
+@UdfDescription(name = RoundKudf.NAME, version = "Confluent",
+    description = "Round a value to the nearest BIGINT value.")
+public class RoundKudf {
+  static final String NAME = "ROUND";
 
-  @Override
-  public Object evaluate(final Object... args) {
-    if (args.length != 1) {
-      throw new KsqlFunctionException("Len udf should have one input argument.");
+  @Udf(description = "Round a value to the nearest BIGINT value.")
+  public Long round(
+      @UdfParameter(description = "A number which will be rounded up.")
+      final Integer n) {
+    if (n == null) {
+      return null;
     }
-    return Math.round((Double) args[0]);
+
+    return Math.round(n.doubleValue());
+  }
+
+  @Udf(description = "Round a value to the nearest BIGINT value.")
+  public Long round(
+      @UdfParameter(description = "A number which will be rounded up.")
+      final Long n) {
+    if (n == null) {
+      return null;
+    }
+
+    return Math.round(n.doubleValue());
+  }
+
+  @Udf(description = "Round a value to the nearest BIGINT value.")
+  public Long round(
+      @UdfParameter(description = "A number which will be rounded up.")
+      final Double n) {
+    if (n == null) {
+      return null;
+    }
+
+    return Math.round(n);
   }
 }

--- a/ksql-engine/src/test/java/io/confluent/ksql/function/udf/math/CeilKudfTest.java
+++ b/ksql-engine/src/test/java/io/confluent/ksql/function/udf/math/CeilKudfTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018 Confluent Inc.
+ * Copyright 2019 Confluent Inc.
  *
  * Licensed under the Confluent Community License; you may not use this file
  * except in compliance with the License.  You may obtain a copy of the License at
@@ -14,44 +14,43 @@
 
 package io.confluent.ksql.function.udf.math;
 
+import org.junit.Before;
+import org.junit.Test;
+
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.nullValue;
 import static org.junit.Assert.assertThat;
 
-import org.junit.Before;
-import org.junit.Test;
-
-public class AbsKudfTest {
-
-  private AbsKudf udf;
+public class CeilKudfTest {
+  private CeilKudf udf;
 
   @Before
   public void setUp() {
-    udf = new AbsKudf();
+    udf = new CeilKudf();
   }
 
   @Test
   public void shouldReturnNullWhenArgNull() {
-    assertThat(udf.abs((Integer)null), is(nullValue()));
-    assertThat(udf.abs((Long)null), is(nullValue()));
-    assertThat(udf.abs((Double)null), is(nullValue()));
+    assertThat(udf.ceil((Integer)null), is(nullValue()));
+    assertThat(udf.ceil((Long)null), is(nullValue()));
+    assertThat(udf.ceil((Double)null), is(nullValue()));
   }
 
   @Test
   public void shouldAcceptDoubleValues() {
-    assertThat(udf.abs(-1.234), is(1.234));
-    assertThat(udf.abs(5567.0), is(5567.0));
+    assertThat(udf.ceil(-1.234), is(-1.0));
+    assertThat(udf.ceil(7.59), is(8.0));
   }
 
   @Test
   public void shouldAcceptIntegerValues() {
-    assertThat(udf.abs(-1), is(1));
-    assertThat(udf.abs(1), is(1));
+    assertThat(udf.ceil(-1), is(-1));
+    assertThat(udf.ceil(1), is(1));
   }
 
   @Test
   public void shouldAcceptLongValues() {
-    assertThat(udf.abs(-1L), is(1L));
-    assertThat(udf.abs(1L), is(1L));
+    assertThat(udf.ceil(-1L), is(-1L));
+    assertThat(udf.ceil(1L), is(1L));
   }
 }

--- a/ksql-engine/src/test/java/io/confluent/ksql/function/udf/math/FloorKudfTest.java
+++ b/ksql-engine/src/test/java/io/confluent/ksql/function/udf/math/FloorKudfTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018 Confluent Inc.
+ * Copyright 2019 Confluent Inc.
  *
  * Licensed under the Confluent Community License; you may not use this file
  * except in compliance with the License.  You may obtain a copy of the License at
@@ -21,37 +21,36 @@ import static org.junit.Assert.assertThat;
 import org.junit.Before;
 import org.junit.Test;
 
-public class AbsKudfTest {
-
-  private AbsKudf udf;
+public class FloorKudfTest {
+  private FloorKudf udf;
 
   @Before
   public void setUp() {
-    udf = new AbsKudf();
+    udf = new FloorKudf();
   }
 
   @Test
   public void shouldReturnNullWhenArgNull() {
-    assertThat(udf.abs((Integer)null), is(nullValue()));
-    assertThat(udf.abs((Long)null), is(nullValue()));
-    assertThat(udf.abs((Double)null), is(nullValue()));
+    assertThat(udf.floor((Integer)null), is(nullValue()));
+    assertThat(udf.floor((Long)null), is(nullValue()));
+    assertThat(udf.floor((Double)null), is(nullValue()));
   }
 
   @Test
   public void shouldAcceptDoubleValues() {
-    assertThat(udf.abs(-1.234), is(1.234));
-    assertThat(udf.abs(5567.0), is(5567.0));
+    assertThat(udf.floor(-1.234), is(-2.0));
+    assertThat(udf.floor(7.59), is(7.0));
   }
 
   @Test
   public void shouldAcceptIntegerValues() {
-    assertThat(udf.abs(-1), is(1));
-    assertThat(udf.abs(1), is(1));
+    assertThat(udf.floor(-1), is(-1));
+    assertThat(udf.floor(1), is(1));
   }
 
   @Test
   public void shouldAcceptLongValues() {
-    assertThat(udf.abs(-1L), is(1L));
-    assertThat(udf.abs(1L), is(1L));
+    assertThat(udf.floor(-1L), is(-1L));
+    assertThat(udf.floor(1L), is(1L));
   }
 }

--- a/ksql-engine/src/test/java/io/confluent/ksql/function/udf/math/RoundKudfTest.java
+++ b/ksql-engine/src/test/java/io/confluent/ksql/function/udf/math/RoundKudfTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018 Confluent Inc.
+ * Copyright 2019 Confluent Inc.
  *
  * Licensed under the Confluent Community License; you may not use this file
  * except in compliance with the License.  You may obtain a copy of the License at
@@ -21,37 +21,36 @@ import static org.junit.Assert.assertThat;
 import org.junit.Before;
 import org.junit.Test;
 
-public class AbsKudfTest {
-
-  private AbsKudf udf;
+public class RoundKudfTest {
+  private RoundKudf udf;
 
   @Before
   public void setUp() {
-    udf = new AbsKudf();
+    udf = new RoundKudf();
   }
 
   @Test
   public void shouldReturnNullWhenArgNull() {
-    assertThat(udf.abs((Integer)null), is(nullValue()));
-    assertThat(udf.abs((Long)null), is(nullValue()));
-    assertThat(udf.abs((Double)null), is(nullValue()));
+    assertThat(udf.round((Integer)null), is(nullValue()));
+    assertThat(udf.round((Long)null), is(nullValue()));
+    assertThat(udf.round((Double)null), is(nullValue()));
   }
 
   @Test
   public void shouldAcceptDoubleValues() {
-    assertThat(udf.abs(-1.234), is(1.234));
-    assertThat(udf.abs(5567.0), is(5567.0));
+    assertThat(udf.round(-1.234), is(-1L));
+    assertThat(udf.round(7.59), is(8L));
   }
 
   @Test
   public void shouldAcceptIntegerValues() {
-    assertThat(udf.abs(-1), is(1));
-    assertThat(udf.abs(1), is(1));
+    assertThat(udf.round(-1), is(-1L));
+    assertThat(udf.round(1), is(1L));
   }
 
   @Test
   public void shouldAcceptLongValues() {
-    assertThat(udf.abs(-1L), is(1L));
-    assertThat(udf.abs(1L), is(1L));
+    assertThat(udf.round(-1L), is(-1L));
+    assertThat(udf.round(1L), is(1L));
   }
 }

--- a/ksql-engine/src/test/resources/query-validation-tests/abs.json
+++ b/ksql-engine/src/test/resources/query-validation-tests/abs.json
@@ -1,0 +1,24 @@
+{
+  "comments": [
+    "Tests covering the use of the ABS function."
+  ],
+  "tests": [
+    {
+      "name": "returns the absolute value of an integer, a bigint, and a double",
+      "statements": [
+        "CREATE STREAM TEST (a INT, b BIGINT, c DOUBLE) WITH (kafka_topic='test_topic', value_format='JSON');",
+        "CREATE STREAM OUTPUT AS SELECT ABS(a) as A, ABS(b) as B, ABS(c) as C FROM TEST;"
+      ],
+      "inputs": [
+        {"topic": "test_topic", "key": 1, "value": {"a": 1, "b": 1, "c":  1.0}, "timestamp": 0},
+        {"topic": "test_topic", "key": 2, "value": {"a": -1, "b": -1, "c":  -1.0}, "timestamp": 0},
+        {"topic": "test_topic", "key": 3, "value": {"a": null, "b": null, "c":  null}, "timestamp": 0}
+      ],
+      "outputs": [
+        {"topic": "OUTPUT", "key": 1, "value": {"A": 1, "B": 1, "C":  1.0}, "timestamp": 0},
+        {"topic": "OUTPUT", "key": 2, "value": {"A": 1, "B": 1, "C":  1.0}, "timestamp": 0},
+        {"topic": "OUTPUT", "key": 3, "value": {"A": null, "B": null, "C": null}, "timestamp": 0}
+      ]
+    }
+  ]
+}

--- a/ksql-engine/src/test/resources/query-validation-tests/ceil.json
+++ b/ksql-engine/src/test/resources/query-validation-tests/ceil.json
@@ -1,0 +1,24 @@
+{
+  "comments": [
+    "Tests covering the use of the CEIL function."
+  ],
+  "tests": [
+    {
+      "name": "returns the ceil number of an integer, a bigint, and a double",
+      "statements": [
+        "CREATE STREAM TEST (a INT, b BIGINT, c DOUBLE) WITH (kafka_topic='test_topic', value_format='JSON');",
+        "CREATE STREAM OUTPUT AS SELECT CEIL(a) as A, CEIL(b) as B, CEIL(c) as C FROM TEST;"
+      ],
+      "inputs": [
+        {"topic": "test_topic", "key": 1, "value": {"a": 1, "b": 1, "c":  1.9}, "timestamp": 0},
+        {"topic": "test_topic", "key": 2, "value": {"a": -1, "b": -1, "c":  -1.9}, "timestamp": 0},
+        {"topic": "test_topic", "key": 3, "value": {"a": null, "b": null, "c":  null}, "timestamp": 0}
+      ],
+      "outputs": [
+        {"topic": "OUTPUT", "key": 1, "value": {"A": 1, "B": 1, "C":  2.0}, "timestamp": 0},
+        {"topic": "OUTPUT", "key": 2, "value": {"A": -1, "B": -1, "C":  -1.0}, "timestamp": 0},
+        {"topic": "OUTPUT", "key": 3, "value": {"A": null, "B": null, "C": null}, "timestamp": 0}
+      ]
+    }
+  ]
+}

--- a/ksql-engine/src/test/resources/query-validation-tests/floor.json
+++ b/ksql-engine/src/test/resources/query-validation-tests/floor.json
@@ -1,0 +1,24 @@
+{
+  "comments": [
+    "Tests covering the use of the FLOOR function."
+  ],
+  "tests": [
+    {
+      "name": "returns the floor number of an integer, a bigint, and a double",
+      "statements": [
+        "CREATE STREAM TEST (a INT, b BIGINT, c DOUBLE) WITH (kafka_topic='test_topic', value_format='JSON');",
+        "CREATE STREAM OUTPUT AS SELECT FLOOR(a) as A, FLOOR(b) as B, FLOOR(c) as C FROM TEST;"
+      ],
+      "inputs": [
+        {"topic": "test_topic", "key": 1, "value": {"a": 1, "b": 1, "c":  1.9}, "timestamp": 0},
+        {"topic": "test_topic", "key": 2, "value": {"a": -1, "b": -1, "c":  -1.9}, "timestamp": 0},
+        {"topic": "test_topic", "key": 3, "value": {"a": null, "b": null, "c":  null}, "timestamp": 0}
+      ],
+      "outputs": [
+        {"topic": "OUTPUT", "key": 1, "value": {"A": 1, "B": 1, "C":  1.0}, "timestamp": 0},
+        {"topic": "OUTPUT", "key": 2, "value": {"A": -1, "B": -1, "C":  -2.0}, "timestamp": 0},
+        {"topic": "OUTPUT", "key": 3, "value": {"A": null, "B": null, "C": null}, "timestamp": 0}
+      ]
+    }
+  ]
+}

--- a/ksql-engine/src/test/resources/query-validation-tests/round.json
+++ b/ksql-engine/src/test/resources/query-validation-tests/round.json
@@ -1,0 +1,24 @@
+{
+  "comments": [
+    "Tests covering the use of the ROUND function."
+  ],
+  "tests": [
+    {
+      "name": "returns the rounding number of an integer, a bigint, and a double",
+      "statements": [
+        "CREATE STREAM TEST (a INT, b BIGINT, c DOUBLE) WITH (kafka_topic='test_topic', value_format='JSON');",
+        "CREATE STREAM OUTPUT AS SELECT ROUND(a) as A, ROUND(b) as B, ROUND(c) as C FROM TEST;"
+      ],
+      "inputs": [
+        {"topic": "test_topic", "key": 1, "value": {"a": 1, "b": 1, "c":  1.0}, "timestamp": 0},
+        {"topic": "test_topic", "key": 2, "value": {"a": -1, "b": -1, "c":  -1.0}, "timestamp": 0},
+        {"topic": "test_topic", "key": 3, "value": {"a": null, "b": null, "c":  null}, "timestamp": 0}
+      ],
+      "outputs": [
+        {"topic": "OUTPUT", "key": 1, "value": {"A": 1, "B": 1, "C":  1}, "timestamp": 0},
+        {"topic": "OUTPUT", "key": 2, "value": {"A": -1, "B": -1, "C":  -1}, "timestamp": 0},
+        {"topic": "OUTPUT", "key": 3, "value": {"A": null, "B": null, "C": null}, "timestamp": 0}
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
Fixes #306

### Description 
All SQL databases support integers and floating-point numbers in these common math functions (ABS, ROUND, FLOOR, CEIL). To allow different numeric types, this patch moves the mentioned UDF to the UDF pluggable framework and overload methods to support int, long, and double.

### Testing done 
Added unit tests for all UDF to verify numeric and doubles are supported.
Added Query tests for all UDF to verify numeric and doubles are supported.

### Reviewer checklist
- [ ] Ensure docs are updated if necessary. (eg. if a user visible feature is being added or changed).
- [ ] Ensure relevant issues are linked (description should include text like "Fixes #<issue number>")

