### PR TITLE
Allow ArrayContainsKudf to search values on arrays inside a struct.

### DIFF
--- a/ksql-engine/src/main/java/io/confluent/ksql/function/udf/json/ArrayContainsKudf.java
+++ b/ksql-engine/src/main/java/io/confluent/ksql/function/udf/json/ArrayContainsKudf.java
@@ -30,7 +30,6 @@ import com.fasterxml.jackson.core.JsonParser;
 import com.fasterxml.jackson.core.JsonToken;
 import io.confluent.ksql.function.KsqlFunctionException;
 import io.confluent.ksql.function.udf.Kudf;
-import io.confluent.ksql.util.ArrayUtil;
 import io.confluent.ksql.util.KsqlException;
 import java.io.IOException;
 import java.util.Arrays;
@@ -74,8 +73,6 @@ public class ArrayContainsKudf implements Kudf {
     final Object searchValue = args[1];
     if (args[0] instanceof String) {
       return jsonStringArrayContains(searchValue, (String) args[0]);
-    } else if (args[0] instanceof Object[]) {
-      return ArrayUtil.containsValue(searchValue, (Object[]) args[0]);
     } else if (args[0] instanceof Collection) {
       return ((Collection) args[0]).contains(searchValue);
     }

--- a/ksql-engine/src/main/java/io/confluent/ksql/function/udf/json/ArrayContainsKudf.java
+++ b/ksql-engine/src/main/java/io/confluent/ksql/function/udf/json/ArrayContainsKudf.java
@@ -34,6 +34,7 @@ import io.confluent.ksql.util.ArrayUtil;
 import io.confluent.ksql.util.KsqlException;
 import java.io.IOException;
 import java.util.Arrays;
+import java.util.Collection;
 import java.util.HashMap;
 import java.util.Map;
 
@@ -48,7 +49,7 @@ public class ArrayContainsKudf implements Kudf {
   private final Map<JsonToken, Matcher> matchers = new HashMap<>();
 
 
-  ArrayContainsKudf() {
+  public ArrayContainsKudf() {
     matchers.put(JsonToken.VALUE_NULL, (parser, value) -> value == null);
     matchers.put(JsonToken.VALUE_STRING,
         (parser, value) -> parser.getText().equals(value));
@@ -75,7 +76,10 @@ public class ArrayContainsKudf implements Kudf {
       return jsonStringArrayContains(searchValue, (String) args[0]);
     } else if (args[0] instanceof Object[]) {
       return ArrayUtil.containsValue(searchValue, (Object[]) args[0]);
+    } else if (args[0] instanceof Collection) {
+      return ((Collection) args[0]).contains(searchValue);
     }
+
     throw new KsqlFunctionException("Invalid type parameters for " + Arrays.toString(args));
   }
 

--- a/ksql-engine/src/test/java/io/confluent/ksql/function/udf/json/ArrayContainsKudfTest.java
+++ b/ksql-engine/src/test/java/io/confluent/ksql/function/udf/json/ArrayContainsKudfTest.java
@@ -19,6 +19,9 @@ import static org.junit.Assert.assertEquals;
 
 import org.junit.Test;
 
+import java.util.Arrays;
+import java.util.Collections;
+
 public class ArrayContainsKudfTest
 {
     private ArrayContainsKudf jsonUdf = new ArrayContainsKudf();
@@ -128,5 +131,59 @@ public class ArrayContainsKudfTest
         assertEquals(false, jsonUdf.evaluate(new Double[]{1.0, 2.0, 3.0}, 4.0));
         assertEquals(false, jsonUdf.evaluate(new Double[]{1.0, 2.0, 3.0}, "1"));
         assertEquals(false, jsonUdf.evaluate(new Double[]{1.0, 2.0, 3.0}, "aaa"));
+    }
+
+    @Test
+    public void shouldReturnFalseOnEmptyList() {
+        assertEquals(false, jsonUdf.evaluate(Collections.emptyList(), true));
+        assertEquals(false, jsonUdf.evaluate(Collections.emptyList(), false));
+        assertEquals(false, jsonUdf.evaluate(Collections.emptyList(), null));
+        assertEquals(false, jsonUdf.evaluate(Collections.emptyList(), 1.0));
+        assertEquals(false, jsonUdf.evaluate(Collections.emptyList(), 100));
+        assertEquals(false, jsonUdf.evaluate(Collections.emptyList(), "abc"));
+        assertEquals(false, jsonUdf.evaluate(Collections.emptyList(), ""));
+    }
+
+    @Test
+    public void shouldNotFindValuesInNullListElements() {
+        assertEquals(true, jsonUdf.evaluate(Collections.singletonList(null), null));
+        assertEquals(false, jsonUdf.evaluate(Collections.singletonList(null), "null"));
+        assertEquals(false, jsonUdf.evaluate(Collections.singletonList(null), true));
+        assertEquals(false, jsonUdf.evaluate(Collections.singletonList(null), false));
+        assertEquals(false, jsonUdf.evaluate(Collections.singletonList(null), 1.0));
+        assertEquals(false, jsonUdf.evaluate(Collections.singletonList(null), 100));
+        assertEquals(false, jsonUdf.evaluate(Collections.singletonList(null), "abc"));
+        assertEquals(false, jsonUdf.evaluate(Collections.singletonList(null), ""));
+    }
+
+    @Test
+    public void shouldFindStringInList() {
+        assertEquals(true, jsonUdf.evaluate(Arrays.asList("abc", "bd", "DC"), "DC"));
+        assertEquals(false, jsonUdf.evaluate(Arrays.asList("abc", "bd", "DC"), "dc"));
+        assertEquals(false, jsonUdf.evaluate(Arrays.asList("abc", "bd", "1"), 1));
+    }
+
+    @Test
+    public void shouldFindIntegersInList() {
+        assertEquals(true, jsonUdf.evaluate(Arrays.asList(1, 2, 3), 2));
+        assertEquals(false, jsonUdf.evaluate(Arrays.asList(1, 2, 3), 0));
+        assertEquals(false, jsonUdf.evaluate(Arrays.asList(1, 2, 3), "1"));
+        assertEquals(false, jsonUdf.evaluate(Arrays.asList(1, 2, 3), "aa"));
+    }
+
+    @Test
+    public void shouldFindLongInList() {
+        assertEquals(true, jsonUdf.evaluate(Arrays.asList(1L, 2L, 3L), 2L));
+        assertEquals(false, jsonUdf.evaluate(Arrays.asList(1L, 2L, 3L), 0L));
+        assertEquals(false, jsonUdf.evaluate(Arrays.asList(1L, 2L, 3L), "1"));
+        assertEquals(false, jsonUdf.evaluate(Arrays.asList(1L, 2L, 3L), "aaa"));
+    }
+
+    @Test
+    public void shouldFindDoublesInList() {
+        assertEquals(true, jsonUdf.evaluate(Arrays.asList(1.0, 2.0, 3.0), 2.0));
+        assertEquals(false, jsonUdf.evaluate(Arrays.asList(1.0, 2.0, 3.0), 4.0));
+        assertEquals(false, jsonUdf.evaluate(Arrays.asList(1.0, 2.0, 3.0), "1"));
+        assertEquals(false, jsonUdf.evaluate(Arrays.asList(1.0, 2.0, 3.0), "aaa"));
     }
 }

--- a/ksql-engine/src/test/java/io/confluent/ksql/function/udf/json/ArrayContainsKudfTest.java
+++ b/ksql-engine/src/test/java/io/confluent/ksql/function/udf/json/ArrayContainsKudfTest.java
@@ -103,37 +103,6 @@ public class ArrayContainsKudfTest
     }
 
     @Test
-    public void shouldFindStringInAvroArray() {
-        assertEquals(true, jsonUdf.evaluate(new String[]{"abc", "bd", "DC"}, "DC"));
-        assertEquals(false, jsonUdf.evaluate(new String[]{"abc", "bd", "DC"}, "dc"));
-        assertEquals(false, jsonUdf.evaluate(new String[]{"abc", "bd", "1"}, 1));
-    }
-
-    @Test
-    public void shouldFindIntegersInAvroArray() {
-        assertEquals(true, jsonUdf.evaluate(new Integer[]{1, 2, 3}, 2));
-        assertEquals(false, jsonUdf.evaluate(new Integer[]{1, 2, 3}, 0));
-        assertEquals(false, jsonUdf.evaluate(new Integer[]{1, 2, 3}, "1"));
-        assertEquals(false, jsonUdf.evaluate(new Integer[]{1, 2, 3}, "aa"));
-    }
-
-    @Test
-    public void shouldFindLongInAvroArray() {
-        assertEquals(true, jsonUdf.evaluate(new Long[]{1L, 2L, 3L}, 2L));
-        assertEquals(false, jsonUdf.evaluate(new Long[]{1L, 2L, 3L}, 0L));
-        assertEquals(false, jsonUdf.evaluate(new Long[]{1L, 2L, 3L}, "1"));
-        assertEquals(false, jsonUdf.evaluate(new Long[]{1L, 2L, 3L}, "aaa"));
-    }
-
-    @Test
-    public void shouldFindDoublesInAvroArray() {
-        assertEquals(true, jsonUdf.evaluate(new Double[]{1.0, 2.0, 3.0}, 2.0));
-        assertEquals(false, jsonUdf.evaluate(new Double[]{1.0, 2.0, 3.0}, 4.0));
-        assertEquals(false, jsonUdf.evaluate(new Double[]{1.0, 2.0, 3.0}, "1"));
-        assertEquals(false, jsonUdf.evaluate(new Double[]{1.0, 2.0, 3.0}, "aaa"));
-    }
-
-    @Test
     public void shouldReturnFalseOnEmptyList() {
         assertEquals(false, jsonUdf.evaluate(Collections.emptyList(), true));
         assertEquals(false, jsonUdf.evaluate(Collections.emptyList(), false));

--- a/ksql-engine/src/test/resources/query-validation-tests/arraycontains.json
+++ b/ksql-engine/src/test/resources/query-validation-tests/arraycontains.json
@@ -14,8 +14,7 @@
         {"topic": "test_topic", "key": 1, "value": {"colors": ["Black"]}, "timestamp": 0},
         {"topic": "test_topic", "key": 1, "value": {"colors": ["Pink", "Yellow", "Pink"]}, "timestamp": 0},
         {"topic": "test_topic", "key": 1, "value": {"colors": ["White", "Pink"]}, "timestamp": 0},
-        {"topic": "test_topic", "key": 1, "value": {"colors": ["Pink", null]}, "timestamp": 0},
-        {"topic": "test_topic", "key": 1, "value": {"colors": null}, "timestamp": 0}
+        {"topic": "test_topic", "key": 1, "value": {"colors": ["Pink", null]}, "timestamp": 0}
       ],
       "outputs": [
         {"topic": "OUTPUT", "key": 1, "value": {"COLORS":["Pink", "Yellow", "Pink"]}, "timestamp": 0},
@@ -34,8 +33,7 @@
         {"topic": "test_topic", "key": 1, "value": {"c1":{"colors": ["Black"]}}, "timestamp": 0},
         {"topic": "test_topic", "key": 1, "value": {"c1":{"colors": ["Pink", "Yellow", "Pink"]}}, "timestamp": 0},
         {"topic": "test_topic", "key": 1, "value": {"c1":{"colors": ["White", "Pink"]}}, "timestamp": 0},
-        {"topic": "test_topic", "key": 1, "value": {"c1":{"colors": ["Pink", null]}}, "timestamp": 0},
-        {"topic": "test_topic", "key": 1, "value": {"c1":{"colors": null}}, "timestamp": 0}
+        {"topic": "test_topic", "key": 1, "value": {"c1":{"colors": ["Pink", null]}}, "timestamp": 0}
       ],
       "outputs": [
         {"topic": "OUTPUT", "key": 1, "value": {"COLORS":["Pink", "Yellow", "Pink"]}, "timestamp": 0},

--- a/ksql-engine/src/test/resources/query-validation-tests/arraycontains.json
+++ b/ksql-engine/src/test/resources/query-validation-tests/arraycontains.json
@@ -1,0 +1,47 @@
+{
+  "comments": [
+    "Tests covering the use of the ARRAYCONTAINS function."
+  ],
+  "tests": [
+    {
+      "name": "filter rows where the ARRAY column contains a specified STRING",
+      "statements": [
+        "CREATE STREAM test (colors ARRAY<STRING>) WITH (kafka_topic='test_topic', value_format='JSON');",
+        "CREATE STREAM OUTPUT AS SELECT colors FROM test WHERE ARRAYCONTAINS(colors, 'Pink');"
+      ],
+      "inputs": [
+        {"topic": "test_topic", "key": 1, "value": {"colors": ["Red", "Green"]}, "timestamp": 0},
+        {"topic": "test_topic", "key": 1, "value": {"colors": ["Black"]}, "timestamp": 0},
+        {"topic": "test_topic", "key": 1, "value": {"colors": ["Pink", "Yellow", "Pink"]}, "timestamp": 0},
+        {"topic": "test_topic", "key": 1, "value": {"colors": ["White", "Pink"]}, "timestamp": 0},
+        {"topic": "test_topic", "key": 1, "value": {"colors": ["Pink", null]}, "timestamp": 0},
+        {"topic": "test_topic", "key": 1, "value": {"colors": null}, "timestamp": 0}
+      ],
+      "outputs": [
+        {"topic": "OUTPUT", "key": 1, "value": {"COLORS":["Pink", "Yellow", "Pink"]}, "timestamp": 0},
+        {"topic": "OUTPUT", "key": 1, "value": {"COLORS":["White", "Pink"]}, "timestamp": 0},
+        {"topic": "OUTPUT", "key": 1, "value": {"COLORS":["Pink", null]}, "timestamp": 0}
+      ]
+    },
+    {
+      "name": "filter rows where the STRUCT->ARRAY column contains a specified STRING",
+      "statements": [
+        "CREATE STREAM test (c1 STRUCT<colors ARRAY<STRING>>) WITH (kafka_topic='test_topic', value_format='JSON');",
+        "CREATE STREAM OUTPUT AS SELECT c1->colors AS colors FROM test WHERE ARRAYCONTAINS(c1->colors, 'Pink');"
+      ],
+      "inputs": [
+        {"topic": "test_topic", "key": 1, "value": {"c1":{"colors": ["Red", "Green"]}}, "timestamp": 0},
+        {"topic": "test_topic", "key": 1, "value": {"c1":{"colors": ["Black"]}}, "timestamp": 0},
+        {"topic": "test_topic", "key": 1, "value": {"c1":{"colors": ["Pink", "Yellow", "Pink"]}}, "timestamp": 0},
+        {"topic": "test_topic", "key": 1, "value": {"c1":{"colors": ["White", "Pink"]}}, "timestamp": 0},
+        {"topic": "test_topic", "key": 1, "value": {"c1":{"colors": ["Pink", null]}}, "timestamp": 0},
+        {"topic": "test_topic", "key": 1, "value": {"c1":{"colors": null}}, "timestamp": 0}
+      ],
+      "outputs": [
+        {"topic": "OUTPUT", "key": 1, "value": {"COLORS":["Pink", "Yellow", "Pink"]}, "timestamp": 0},
+        {"topic": "OUTPUT", "key": 1, "value": {"COLORS":["White", "Pink"]}, "timestamp": 0},
+        {"topic": "OUTPUT", "key": 1, "value": {"COLORS":["Pink", null]}, "timestamp": 0}
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
Fixes #1960

### Description 
This fixes an issue when using ARRAYCONTAINS() with an ARRAY inside a STRUCT.

For example, this below stream with a `STRUCT<colours ARRAY<VARCHAR>>` field.
```
ksql> CREATE STREAM NESTED_ARRAY_TEST (id BIGINT, first_name VARCHAR, last_name VARCHAR, email VARCHAR, preferred STRUCT<colours ARRAY<VARCHAR>>) WITH (kafka_topic='nested_array_test', value_format='JSON');
```

If a SELECT ... ARRAYCONTAINS(PREFERRED->COLOURS,'Pink') ... is used, then the following error happens:
```
ksql> SELECT FIRST_NAME, PREFERRED->COLOURS FROM NESTED_ARRAY_TEST WHERE ARRAYCONTAINS(PREFERRED->COLOURS,'Pink');
Failed to generate code for filterExpression:ARRAYCONTAINS(FETCH_FIELD_FROM_STRUCT(NESTED_ARRAY_TEST.PREFERRED, 'COLOURS'), 'Pink') schema:org.apache.kafka.connect.data.SchemaBuilder@76ea44ac
Caused by: Failed to create instance of kudfClass class io.confluent.ksql.function.udf.json.ArrayContainsKudf for function ARRAYCONTAINS
Caused by: Class io.confluent.ksql.function.KsqlFunction can not access a member of class io.confluent.ksql.function.udf.json.ArrayContainsKudf with modifiers ""
```

The error was happening because the ArrayContainsKudf() was not public, so the class couldn't be instantiated. Also, once fixed the above error, the problem was that ArrayContainsKudf.evaluate() needs to accept a List as a parameter as well.

### Testing done 
Added tests on ArrayContainsKudfTest.

### Reviewer checklist
- [ ] Ensure docs are updated if necessary. (eg. if a user visible feature is being added or changed).
- [ ] Ensure relevant issues are linked (description should include text like "Fixes #<issue number>")

