### PR TITLE
Minor: default to true when delete.topic.enable is not returned with broker configs

### DIFF
--- a/ksql-engine/src/main/java/io/confluent/ksql/services/KafkaTopicClientImpl.java
+++ b/ksql-engine/src/main/java/io/confluent/ksql/services/KafkaTopicClientImpl.java
@@ -30,7 +30,6 @@ import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeUnit;
 import java.util.stream.Collectors;
 import javax.annotation.concurrent.ThreadSafe;
-import kafka.server.Defaults;
 import org.apache.kafka.clients.admin.AdminClient;
 import org.apache.kafka.clients.admin.Config;
 import org.apache.kafka.clients.admin.ConfigEntry;
@@ -274,7 +273,9 @@ public class KafkaTopicClientImpl implements KafkaTopicClient {
           .filter(configEntry -> configEntry.name().equalsIgnoreCase("delete.topic.enable"))
           .findFirst()
           .map(configEntry -> configEntry.value().equalsIgnoreCase("true"))
-          .orElse(Defaults.DeleteTopicEnable());
+          // if the broker does not provide the config value, default to true in an attempt
+          // to clean up topics
+          .orElse(true);
 
     } catch (final Exception e) {
       log.error("Failed to initialize TopicClient: {}", e.getMessage());

--- a/ksql-engine/src/main/java/io/confluent/ksql/services/KafkaTopicClientImpl.java
+++ b/ksql-engine/src/main/java/io/confluent/ksql/services/KafkaTopicClientImpl.java
@@ -261,8 +261,6 @@ public class KafkaTopicClientImpl implements KafkaTopicClient {
           String.valueOf(nodes.iterator().next().id())
       );
 
-      ;
-
       final Map<ConfigResource, Config> config = ExecutorUtil.executeWithRetries(
           () -> adminClient.describeConfigs(Collections.singleton(resource)).all().get(),
           ExecutorUtil.RetryBehaviour.ON_RETRYABLE);

--- a/ksql-engine/src/test/java/io/confluent/ksql/services/KafkaTopicClientImplTest.java
+++ b/ksql-engine/src/test/java/io/confluent/ksql/services/KafkaTopicClientImplTest.java
@@ -43,7 +43,6 @@ import java.util.Objects;
 import java.util.Set;
 import java.util.concurrent.ExecutionException;
 import java.util.stream.Collectors;
-import kafka.server.Defaults;
 import org.apache.kafka.clients.admin.AdminClient;
 import org.apache.kafka.clients.admin.AlterConfigsResult;
 import org.apache.kafka.clients.admin.Config;
@@ -248,9 +247,9 @@ public class KafkaTopicClientImplTest {
   }
 
   @Test
-  public void shouldDeleteTopicsIfDeleteTopicEnableExplicitlyTrue() {
+  public void shouldDeleteTopicsIfDeleteTopicEnableTrue() {
     // Given:
-    givenDeleteTopicEnableExplicitlyTrue();
+    givenDeleteTopicEnableTrue();
     expect(adminClient.deleteTopics(anyObject())).andReturn(getDeleteTopicsResult());
     replay(adminClient);
     final KafkaTopicClient kafkaTopicClient = new KafkaTopicClientImpl(adminClient);
@@ -263,11 +262,9 @@ public class KafkaTopicClientImplTest {
   }
 
   @Test
-  public void shouldDeleteTopicsIfDeleteTopicEnableNotExplicitlySet() {
-    assertThat(Defaults.DeleteTopicEnable(), equalTo(true));
-
+  public void shouldDeleteTopicsIfBrokerDoesNotReturnValueForDeleteTopicEnable() {
     // Given:
-    givenDeleteTopicEnableNotExplicitlySet();
+    givenDeleteTopicEnableNotReturnedByBroker();
     expect(adminClient.deleteTopics(anyObject())).andReturn(getDeleteTopicsResult());
     replay(adminClient);
     final KafkaTopicClient kafkaTopicClient = new KafkaTopicClientImpl(adminClient);
@@ -280,9 +277,9 @@ public class KafkaTopicClientImplTest {
   }
 
   @Test
-  public void shouldNotDeleteTopicIfDeleteTopicEnableExplicitlyFalse() {
+  public void shouldNotDeleteTopicIfDeleteTopicEnableFalse() {
     // Given:
-    givenDeleteTopicEnableExplicitlyFalse();
+    givenDeleteTopicEnableFalse();
     replay(adminClient);
     final KafkaTopicClient kafkaTopicClient = new KafkaTopicClientImpl(adminClient);
 
@@ -538,7 +535,7 @@ public class KafkaTopicClientImplTest {
     return Collections.singleton(new ConfigResource(ConfigResource.Type.BROKER, node.idString()));
   }
 
-  private void givenDeleteTopicEnableExplicitlyTrue() {
+  private void givenDeleteTopicEnableTrue() {
     reset(adminClient);
     expect(adminClient.describeCluster()).andReturn(describeClusterResult());
 
@@ -547,7 +544,7 @@ public class KafkaTopicClientImplTest {
         .andReturn(describeBrokerResult(Collections.singletonList(configEntryDeleteEnable)));
   }
 
-  private void givenDeleteTopicEnableExplicitlyFalse() {
+  private void givenDeleteTopicEnableFalse() {
     reset(adminClient);
     expect(adminClient.describeCluster()).andReturn(describeClusterResult());
 
@@ -556,7 +553,7 @@ public class KafkaTopicClientImplTest {
         .andReturn(describeBrokerResult(Collections.singletonList(configEntryDeleteEnable)));
   }
 
-  private void givenDeleteTopicEnableNotExplicitlySet() {
+  private void givenDeleteTopicEnableNotReturnedByBroker() {
     reset(adminClient);
     expect(adminClient.describeCluster()).andReturn(describeClusterResult());
     expect(adminClient.describeConfigs(describeBrokerRequest()))

--- a/ksql-engine/src/test/java/io/confluent/ksql/services/KafkaTopicClientImplTest.java
+++ b/ksql-engine/src/test/java/io/confluent/ksql/services/KafkaTopicClientImplTest.java
@@ -21,6 +21,7 @@ import static org.easymock.EasyMock.expectLastCall;
 import static org.easymock.EasyMock.mock;
 import static org.easymock.EasyMock.niceMock;
 import static org.easymock.EasyMock.replay;
+import static org.easymock.EasyMock.reset;
 import static org.easymock.EasyMock.verify;
 import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.MatcherAssert.assertThat;
@@ -31,7 +32,6 @@ import com.google.common.collect.ImmutableMap;
 import io.confluent.ksql.exception.KafkaResponseGetFailedException;
 import io.confluent.ksql.exception.KafkaTopicExistsException;
 import io.confluent.ksql.util.KsqlConstants;
-import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
@@ -43,6 +43,7 @@ import java.util.Objects;
 import java.util.Set;
 import java.util.concurrent.ExecutionException;
 import java.util.stream.Collectors;
+import kafka.server.Defaults;
 import org.apache.kafka.clients.admin.AdminClient;
 import org.apache.kafka.clients.admin.AlterConfigsResult;
 import org.apache.kafka.clients.admin.Config;
@@ -101,7 +102,7 @@ public class KafkaTopicClientImplTest {
     node = new Node(1, "host", 9092);
     expect(adminClient.describeCluster()).andReturn(describeClusterResult());
     expect(adminClient.describeConfigs(describeBrokerRequest()))
-        .andReturn(describeBrokerResult());
+        .andReturn(describeBrokerResult(Collections.emptyList()));
   }
 
   @Test
@@ -243,6 +244,52 @@ public class KafkaTopicClientImplTest {
                                          KsqlConstants.KSQL_INTERNAL_TOPIC_PREFIX,
                                          "default_query_CTAS_USERS_BY_CITY");
     kafkaTopicClient.deleteInternalTopics(applicationId);
+    verify(adminClient);
+  }
+
+  @Test
+  public void shouldDeleteTopicsIfDeleteTopicEnableExplicitlyTrue() {
+    // Given:
+    givenDeleteTopicEnableExplicitlyTrue();
+    expect(adminClient.deleteTopics(anyObject())).andReturn(getDeleteTopicsResult());
+    replay(adminClient);
+    final KafkaTopicClient kafkaTopicClient = new KafkaTopicClientImpl(adminClient);
+
+    // When:
+    kafkaTopicClient.deleteTopics(Collections.singletonList(topicName2));
+
+    // Then:
+    verify(adminClient);
+  }
+
+  @Test
+  public void shouldDeleteTopicsIfDeleteTopicEnableNotExplicitlySet() {
+    assertThat(Defaults.DeleteTopicEnable(), equalTo(true));
+
+    // Given:
+    givenDeleteTopicEnableNotExplicitlySet();
+    expect(adminClient.deleteTopics(anyObject())).andReturn(getDeleteTopicsResult());
+    replay(adminClient);
+    final KafkaTopicClient kafkaTopicClient = new KafkaTopicClientImpl(adminClient);
+
+    // When:
+    kafkaTopicClient.deleteTopics(Collections.singletonList(topicName2));
+
+    // Then:
+    verify(adminClient);
+  }
+
+  @Test
+  public void shouldNotDeleteTopicIfDeleteTopicEnableExplicitlyFalse() {
+    // Given:
+    givenDeleteTopicEnableExplicitlyFalse();
+    replay(adminClient);
+    final KafkaTopicClient kafkaTopicClient = new KafkaTopicClientImpl(adminClient);
+
+    // When:
+    kafkaTopicClient.deleteTopics(Collections.singletonList(topicName2));
+
+    // Then:
     verify(adminClient);
   }
 
@@ -491,13 +538,35 @@ public class KafkaTopicClientImplTest {
     return Collections.singleton(new ConfigResource(ConfigResource.Type.BROKER, node.idString()));
   }
 
-  private DescribeConfigsResult describeBrokerResult() {
-    final DescribeConfigsResult describeConfigsResult = mock(DescribeConfigsResult.class);
+  private void givenDeleteTopicEnableExplicitlyTrue() {
+    reset(adminClient);
+    expect(adminClient.describeCluster()).andReturn(describeClusterResult());
+
     final ConfigEntry configEntryDeleteEnable = new ConfigEntry("delete.topic.enable", "true");
-    final List<ConfigEntry> configEntries = new ArrayList<>();
-    configEntries.add(configEntryDeleteEnable);
+    expect(adminClient.describeConfigs(describeBrokerRequest()))
+        .andReturn(describeBrokerResult(Collections.singletonList(configEntryDeleteEnable)));
+  }
+
+  private void givenDeleteTopicEnableExplicitlyFalse() {
+    reset(adminClient);
+    expect(adminClient.describeCluster()).andReturn(describeClusterResult());
+
+    final ConfigEntry configEntryDeleteEnable = new ConfigEntry("delete.topic.enable", "false");
+    expect(adminClient.describeConfigs(describeBrokerRequest()))
+        .andReturn(describeBrokerResult(Collections.singletonList(configEntryDeleteEnable)));
+  }
+
+  private void givenDeleteTopicEnableNotExplicitlySet() {
+    reset(adminClient);
+    expect(adminClient.describeCluster()).andReturn(describeClusterResult());
+    expect(adminClient.describeConfigs(describeBrokerRequest()))
+        .andReturn(describeBrokerResult(Collections.emptyList()));
+  }
+
+  private DescribeConfigsResult describeBrokerResult(final List<ConfigEntry> brokerConfigs) {
+    final DescribeConfigsResult describeConfigsResult = mock(DescribeConfigsResult.class);
     final Map<ConfigResource, Config> config = ImmutableMap.of(
-        new ConfigResource(ConfigResource.Type.BROKER, node.idString()), new Config(configEntries));
+        new ConfigResource(ConfigResource.Type.BROKER, node.idString()), new Config(brokerConfigs));
     expect(describeConfigsResult.all()).andReturn(KafkaFuture.completedFuture(config));
     replay(describeConfigsResult);
     return describeConfigsResult;


### PR DESCRIPTION
### Description 

Currently, the way KSQL determines the value of `delete.topic.enable` for a given Kafka cluster is by getting a list of broker configs and returning whether there exists a config called `delete.topic.enable` with value `true`. This means if `delete.topic.enable` isn't included the list of configs returned by the broker, KSQL will not try to delete topics. However, it's better that KSQL make an attempt to delete topics in this case, especially since the default value of `delete.topic.enable` for brokers is true.

This PR updates KSQL to use the config value if `delete.topic.enable` is present in the list of broker configs, otherwise `true` (the default value of the config).

### Testing done 

Unit tests and manual.

### Reviewer checklist
- [ ] Ensure docs are updated if necessary. (eg. if a user visible feature is being added or changed).
- [ ] Ensure relevant issues are linked (description should include text like "Fixes #<issue number>")

