### PR TITLE
System generated names do not check for conflicts #2401

### DIFF
--- a/ksql-engine/src/test/java/io/confluent/ksql/physical/PhysicalPlanBuilderTest.java
+++ b/ksql-engine/src/test/java/io/confluent/ksql/physical/PhysicalPlanBuilderTest.java
@@ -210,7 +210,7 @@ public class PhysicalPlanBuilderTest {
     final String planText = metadata.getExecutionPlan();
     final String[] lines = planText.split("\n");
     assertThat(lines[0], startsWith(
-        " > [ SINK ] | Schema: [COL0 : BIGINT, KSQL_COL_1 : DOUBLE, KSQL_COL_2 : BIGINT] |"));
+        " > [ SINK ] | Schema: [COL0 : BIGINT, KSQL_TEST1_COL_1 : DOUBLE, KSQL_TEST1_COL_2 : BIGINT] |"));
     assertThat(lines[1], startsWith(
         "\t\t > [ AGGREGATE ] | Schema: [KSQL_INTERNAL_COL_0 : BIGINT, "
             + "KSQL_INTERNAL_COL_1 : DOUBLE, KSQL_AGG_VARIABLE_0 : DOUBLE, "

--- a/ksql-engine/src/test/java/io/confluent/ksql/planner/plan/AggregateNodeTest.java
+++ b/ksql-engine/src/test/java/io/confluent/ksql/planner/plan/AggregateNodeTest.java
@@ -218,8 +218,8 @@ public class AggregateNodeTest {
     // Then:
     assertThat(stream.getSchema().fields(), contains(
         new Field("COL0", 0, Schema.OPTIONAL_INT64_SCHEMA),
-        new Field("KSQL_COL_1", 1, Schema.OPTIONAL_FLOAT64_SCHEMA),
-        new Field("KSQL_COL_2", 2, Schema.OPTIONAL_INT64_SCHEMA)));
+        new Field("KSQL_TEST1_COL_1", 1, Schema.OPTIONAL_FLOAT64_SCHEMA),
+        new Field("KSQL_TEST1_COL_2", 2, Schema.OPTIONAL_INT64_SCHEMA)));
   }
 
   @Test

--- a/ksql-engine/src/test/java/io/confluent/ksql/structured/SchemaKStreamTest.java
+++ b/ksql-engine/src/test/java/io/confluent/ksql/structured/SchemaKStreamTest.java
@@ -288,9 +288,9 @@ public class SchemaKStreamTest {
     Assert.assertEquals(3, projectedSchemaKStream.getSchema().fields().size());
     Assert.assertSame(projectedSchemaKStream.getSchema().field("COL0"),
         projectedSchemaKStream.getSchema().fields().get(0));
-    Assert.assertSame(projectedSchemaKStream.getSchema().field("KSQL_COL_1"),
+    Assert.assertSame(projectedSchemaKStream.getSchema().field("KSQL_TEST1_COL_1"),
         projectedSchemaKStream.getSchema().fields().get(1));
-    Assert.assertSame(projectedSchemaKStream.getSchema().field("KSQL_COL_2"),
+    Assert.assertSame(projectedSchemaKStream.getSchema().field("KSQL_TEST1_COL_2"),
         projectedSchemaKStream.getSchema().fields().get(2));
 
     Assert.assertSame(projectedSchemaKStream.getSchema().field("COL0").schema().type(),

--- a/ksql-engine/src/test/java/io/confluent/ksql/structured/SchemaKTableTest.java
+++ b/ksql-engine/src/test/java/io/confluent/ksql/structured/SchemaKTableTest.java
@@ -232,10 +232,10 @@ public class SchemaKTableTest {
     Assert.assertTrue(projectedSchemaKStream.getSchema().field("COL0") ==
                       projectedSchemaKStream.getSchema().fields().get(0));
     Assert.assertTrue(projectedSchemaKStream.getSchema()
-                          .field("KSQL_COL_1") ==
+                          .field("KSQL_TEST2_COL_1") ==
                       projectedSchemaKStream.getSchema().fields().get(1));
     Assert.assertTrue(projectedSchemaKStream.getSchema()
-                          .field("KSQL_COL_2") ==
+                          .field("KSQL_TEST2_COL_2") ==
                       projectedSchemaKStream.getSchema().fields().get(2));
 
     Assert.assertTrue(projectedSchemaKStream.getSchema()

--- a/ksql-engine/src/test/java/io/confluent/ksql/structured/SelectValueMapperTest.java
+++ b/ksql-engine/src/test/java/io/confluent/ksql/structured/SelectValueMapperTest.java
@@ -130,7 +130,7 @@ public class SelectValueMapperTest {
         errorStruct.get(ProcessingLogMessageSchema.RECORD_PROCESSING_ERROR_FIELD_MESSAGE),
         equalTo(
             "Error computing expression CEIL(TEST1.COL3) "
-                + "for column KSQL_COL_3 with index 3: null")
+                + "for column KSQL_TEST1_COL_3 with index 3: null")
     );
   }
 

--- a/ksql-engine/src/test/resources/query-validation-tests/simple-struct.json
+++ b/ksql-engine/src/test/resources/query-validation-tests/simple-struct.json
@@ -591,7 +591,7 @@
           "timestamp": 0,
           "value": {
             "ITEMID": "{\"CATEGORY\":{\"ID\":2,\"NAME\":\"Food\"},\"ITEMID\":6,\"NAME\":\"Item_6\"}",
-            "KSQL_COL_1": "6"
+            "KSQL_ORDERS_COL_1": "6"
           },
           "key": 0
         },
@@ -600,7 +600,7 @@
           "timestamp": 0,
           "value": {
             "ITEMID": "{\"CATEGORY\":{\"ID\":2,\"NAME\":\"Produce\"},\"ITEMID\":6,\"NAME\":\"Item_6\"}",
-            "KSQL_COL_1": "6"
+            "KSQL_ORDERS_COL_1": "6"
           },
           "key": 100
         },
@@ -609,7 +609,7 @@
           "timestamp": 0,
           "value": {
             "ITEMID": "{\"CATEGORY\":{\"ID\":2,\"NAME\":\"Produce\"},\"ITEMID\":6,\"NAME\":\"Item_6\"}",
-            "KSQL_COL_1": "6"
+            "KSQL_ORDERS_COL_1": "6"
           },
           "key": 101
         },
@@ -618,7 +618,7 @@
           "timestamp": 0,
           "value": {
             "ITEMID": "{\"CATEGORY\":{\"ID\":1,\"NAME\":\"Food\"},\"ITEMID\":2,\"NAME\":\"Item_2\"}",
-            "KSQL_COL_1": "2"
+            "KSQL_ORDERS_COL_1": "2"
           },
           "key": 101
         },
@@ -627,7 +627,7 @@
           "timestamp": 0,
           "value": {
             "ITEMID":  "{\"CATEGORY\":{\"ID\":1,\"NAME\":\"Produce\"},\"ITEMID\":5,\"NAME\":\"Item_5\"}",
-            "KSQL_COL_1": "5"
+            "KSQL_ORDERS_COL_1": "5"
           },
           "key": 101
         }

--- a/ksql-parser/src/main/java/io/confluent/ksql/parser/AstBuilder.java
+++ b/ksql-parser/src/main/java/io/confluent/ksql/parser/AstBuilder.java
@@ -671,7 +671,9 @@ public class AstBuilder extends SqlBaseBaseVisitor<Node> {
           alias = Optional.of(dereferenceExp.getFieldName());
         }
       } else {
-        alias = Optional.of("KSQL_COL_" + selectItemIndex);
+        alias = Optional.of("KSQL_"
+                + dataSourceExtractor.getFromName()
+                + "_COL_" + selectItemIndex);
       }
     } else {
       alias = Optional.of(alias.get());

--- a/ksql-parser/src/test/java/io/confluent/ksql/parser/KsqlParserTest.java
+++ b/ksql-parser/src/test/java/io/confluent/ksql/parser/KsqlParserTest.java
@@ -245,7 +245,7 @@ public class KsqlParserTest {
     Assert.assertTrue("testBinaryExpression fails", query.getQueryBody() instanceof QuerySpecification);
     final QuerySpecification querySpecification = (QuerySpecification)query.getQueryBody();
     final SingleColumn column0 = (SingleColumn)querySpecification.getSelect().getSelectItems().get(0);
-    Assert.assertTrue("testBinaryExpression fails", column0.getAlias().get().equalsIgnoreCase("KSQL_COL_0"));
+    Assert.assertTrue("testBinaryExpression fails", column0.getAlias().get().equalsIgnoreCase("KSQL_TEST1_COL_0"));
     Assert.assertTrue("testBinaryExpression fails", column0.getExpression().toString().equalsIgnoreCase("(TEST1.COL0 + 10)"));
   }
 
@@ -258,7 +258,7 @@ public class KsqlParserTest {
     Assert.assertTrue("testProjection fails", query.getQueryBody() instanceof QuerySpecification);
     final QuerySpecification querySpecification = (QuerySpecification)query.getQueryBody();
     final SingleColumn column0 = (SingleColumn)querySpecification.getSelect().getSelectItems().get(0);
-    Assert.assertTrue("testBooleanExpression fails", column0.getAlias().get().equalsIgnoreCase("KSQL_COL_0"));
+    Assert.assertTrue("testBooleanExpression fails", column0.getAlias().get().equalsIgnoreCase("KSQL_TEST1_COL_0"));
     Assert.assertTrue("testBooleanExpression fails", column0.getExpression().toString().equalsIgnoreCase("(TEST1.COL0 = 10)"));
   }
 
@@ -271,7 +271,7 @@ public class KsqlParserTest {
     Assert.assertTrue("testLiterals fails", query.getQueryBody() instanceof QuerySpecification);
     final QuerySpecification querySpecification = (QuerySpecification)query.getQueryBody();
     final SingleColumn column0 = (SingleColumn)querySpecification.getSelect().getSelectItems().get(0);
-    Assert.assertTrue("testLiterals fails", column0.getAlias().get().equalsIgnoreCase("KSQL_COL_0"));
+    Assert.assertTrue("testLiterals fails", column0.getAlias().get().equalsIgnoreCase("KSQL_TEST1_COL_0"));
     Assert.assertTrue("testLiterals fails", column0.getExpression().toString().equalsIgnoreCase("10"));
 
     final SingleColumn column1 = (SingleColumn)querySpecification.getSelect().getSelectItems().get(1);
@@ -279,19 +279,19 @@ public class KsqlParserTest {
     Assert.assertTrue("testLiterals fails", column1.getExpression().toString().equalsIgnoreCase("TEST1.COL2"));
 
     final SingleColumn column2 = (SingleColumn)querySpecification.getSelect().getSelectItems().get(2);
-    Assert.assertTrue("testLiterals fails", column2.getAlias().get().equalsIgnoreCase("KSQL_COL_2"));
+    Assert.assertTrue("testLiterals fails", column2.getAlias().get().equalsIgnoreCase("KSQL_TEST1_COL_2"));
     Assert.assertTrue("testLiterals fails", column2.getExpression().toString().equalsIgnoreCase("'test'"));
 
     final SingleColumn column3 = (SingleColumn)querySpecification.getSelect().getSelectItems().get(3);
-    Assert.assertTrue("testLiterals fails", column3.getAlias().get().equalsIgnoreCase("KSQL_COL_3"));
+    Assert.assertTrue("testLiterals fails", column3.getAlias().get().equalsIgnoreCase("KSQL_TEST1_COL_3"));
     Assert.assertTrue("testLiterals fails", column3.getExpression().toString().equalsIgnoreCase("2.5"));
 
     final SingleColumn column4 = (SingleColumn)querySpecification.getSelect().getSelectItems().get(4);
-    Assert.assertTrue("testLiterals fails", column4.getAlias().get().equalsIgnoreCase("KSQL_COL_4"));
+    Assert.assertTrue("testLiterals fails", column4.getAlias().get().equalsIgnoreCase("KSQL_TEST1_COL_4"));
     Assert.assertTrue("testLiterals fails", column4.getExpression().toString().equalsIgnoreCase("true"));
 
     final SingleColumn column5 = (SingleColumn)querySpecification.getSelect().getSelectItems().get(5);
-    Assert.assertTrue("testLiterals fails", column5.getAlias().get().equalsIgnoreCase("KSQL_COL_5"));
+    Assert.assertTrue("testLiterals fails", column5.getAlias().get().equalsIgnoreCase("KSQL_TEST1_COL_5"));
     Assert.assertTrue("testLiterals fails", column5.getExpression().toString().equalsIgnoreCase("-5"));
   }
 
@@ -305,7 +305,7 @@ public class KsqlParserTest {
     final QuerySpecification querySpecification = (QuerySpecification) query.getQueryBody();
     final SingleColumn column0
         = (SingleColumn) querySpecification.getSelect().getSelectItems().get(0);
-    assertThat(column0.getAlias().get(), equalTo("KSQL_COL_0"));
+    assertThat(column0.getAlias().get(), equalTo("KSQL_TEST1_COL_0"));
     assertThat(column0.getExpression(), instanceOf(expectedValue.getClass()));
     assertThat(column0.getExpression(), equalTo(expectedValue));
   }
@@ -332,7 +332,7 @@ public class KsqlParserTest {
     final QuerySpecification querySpecification = (QuerySpecification) query.getQueryBody();
     final SingleColumn column0
         = (SingleColumn) querySpecification.getSelect().getSelectItems().get(0);
-    assertThat(column0.getAlias().get(), equalTo("KSQL_COL_0"));
+    assertThat(column0.getAlias().get(), equalTo("KSQL_TEST1_COL_0"));
     assertThat(column0.getExpression(), instanceOf(ArithmeticUnaryExpression.class));
     final ArithmeticUnaryExpression aue = (ArithmeticUnaryExpression) column0.getExpression();
     assertThat(aue.getValue(), instanceOf(IntegerLiteral.class));
@@ -351,7 +351,7 @@ public class KsqlParserTest {
     Assert.assertTrue("testProjection fails", query.getQueryBody() instanceof QuerySpecification);
     final QuerySpecification querySpecification = (QuerySpecification)query.getQueryBody();
     final SingleColumn column0 = (SingleColumn)querySpecification.getSelect().getSelectItems().get(0);
-    Assert.assertTrue("testProjection fails", column0.getAlias().get().equalsIgnoreCase("KSQL_COL_0"));
+    Assert.assertTrue("testProjection fails", column0.getAlias().get().equalsIgnoreCase("KSQL_TEST1_COL_0"));
     Assert.assertTrue("testProjection fails", column0.getExpression().toString().equalsIgnoreCase("10"));
 
     final SingleColumn column1 = (SingleColumn)querySpecification.getSelect().getSelectItems().get(1);
@@ -359,7 +359,7 @@ public class KsqlParserTest {
     Assert.assertTrue("testProjection fails", column1.getExpression().toString().equalsIgnoreCase("TEST1.COL2"));
 
     final SingleColumn column2 = (SingleColumn)querySpecification.getSelect().getSelectItems().get(2);
-    Assert.assertTrue("testProjection fails", column2.getAlias().get().equalsIgnoreCase("KSQL_COL_2"));
+    Assert.assertTrue("testProjection fails", column2.getAlias().get().equalsIgnoreCase("KSQL_TEST1_COL_2"));
     Assert.assertTrue("testProjection fails", column2.getExpression().toString().equalsIgnoreCase("'test'"));
 
   }
@@ -491,15 +491,15 @@ public class KsqlParserTest {
     final QuerySpecification querySpecification = (QuerySpecification)query.getQueryBody();
 
     final SingleColumn column0 = (SingleColumn)querySpecification.getSelect().getSelectItems().get(0);
-    Assert.assertTrue("testProjection fails", column0.getAlias().get().equalsIgnoreCase("KSQL_COL_0"));
+    Assert.assertTrue("testProjection fails", column0.getAlias().get().equalsIgnoreCase("KSQL_TEST1_COL_0"));
     Assert.assertTrue("testProjection fails", column0.getExpression().toString().equalsIgnoreCase("LCASE(T1.COL1)"));
 
     final SingleColumn column1 = (SingleColumn)querySpecification.getSelect().getSelectItems().get(1);
-    Assert.assertTrue("testProjection fails", column1.getAlias().get().equalsIgnoreCase("KSQL_COL_1"));
+    Assert.assertTrue("testProjection fails", column1.getAlias().get().equalsIgnoreCase("KSQL_TEST1_COL_1"));
     Assert.assertTrue("testProjection fails", column1.getExpression().toString().equalsIgnoreCase("CONCAT(T1.COL2, 'hello')"));
 
     final SingleColumn column2 = (SingleColumn)querySpecification.getSelect().getSelectItems().get(2);
-    Assert.assertTrue("testProjection fails", column2.getAlias().get().equalsIgnoreCase("KSQL_COL_2"));
+    Assert.assertTrue("testProjection fails", column2.getAlias().get().equalsIgnoreCase("KSQL_TEST1_COL_2"));
     Assert.assertTrue("testProjection fails", column2.getExpression().toString().equalsIgnoreCase("FLOOR(ABS(T1.COL3))"));
   }
 

--- a/ksql-parser/src/test/java/io/confluent/ksql/parser/rewrite/StatementRewriterTest.java
+++ b/ksql-parser/src/test/java/io/confluent/ksql/parser/rewrite/StatementRewriterTest.java
@@ -131,7 +131,7 @@ public class StatementRewriterTest {
     assertThat(query.getQueryBody(), instanceOf(QuerySpecification.class));
     final QuerySpecification querySpecification = (QuerySpecification)query.getQueryBody();
     final SingleColumn column0 = (SingleColumn)querySpecification.getSelect().getSelectItems().get(0);
-    assertThat(column0.getAlias().get(), equalTo("KSQL_COL_0"));
+    assertThat(column0.getAlias().get(), equalTo("KSQL_TEST1_COL_0"));
     assertThat(column0.getExpression().toString(), equalTo("(TEST1.COL0 + 10)"));
   }
 
@@ -148,7 +148,7 @@ public class StatementRewriterTest {
     assertThat(query.getQueryBody(), instanceOf(QuerySpecification.class));
     final QuerySpecification querySpecification = (QuerySpecification)query.getQueryBody();
     final SingleColumn column0 = (SingleColumn)querySpecification.getSelect().getSelectItems().get(0);
-    assertThat(column0.getAlias().get(), equalTo("KSQL_COL_0"));
+    assertThat(column0.getAlias().get(), equalTo("KSQL_TEST1_COL_0"));
     assertThat(column0.getExpression().toString(), equalTo("(TEST1.COL0 = 10)"));
     assertThat(column0.getExpression(), instanceOf(ComparisonExpression.class));
   }
@@ -166,7 +166,7 @@ public class StatementRewriterTest {
     assertThat(query.getQueryBody(), instanceOf(QuerySpecification.class));
     final QuerySpecification querySpecification = (QuerySpecification)query.getQueryBody();
     final SingleColumn column0 = (SingleColumn)querySpecification.getSelect().getSelectItems().get(0);
-    assertThat(column0.getAlias().get(), equalTo("KSQL_COL_0"));
+    assertThat(column0.getAlias().get(), equalTo("KSQL_TEST1_COL_0"));
     assertThat(column0.getExpression().toString(), equalTo("10"));
 
     final SingleColumn column1 = (SingleColumn)querySpecification.getSelect().getSelectItems().get(1);
@@ -174,19 +174,19 @@ public class StatementRewriterTest {
     assertThat(column1.getExpression().toString(), equalTo("TEST1.COL2"));
 
     final SingleColumn column2 = (SingleColumn)querySpecification.getSelect().getSelectItems().get(2);
-    assertThat(column2.getAlias().get(), equalTo("KSQL_COL_2"));
+    assertThat(column2.getAlias().get(), equalTo("KSQL_TEST1_COL_2"));
     assertThat(column2.getExpression().toString(), equalTo("'test'"));
 
     final SingleColumn column3 = (SingleColumn)querySpecification.getSelect().getSelectItems().get(3);
-    assertThat(column3.getAlias().get(), equalTo("KSQL_COL_3"));
+    assertThat(column3.getAlias().get(), equalTo("KSQL_TEST1_COL_3"));
     assertThat(column3.getExpression().toString(), equalTo("2.5"));
 
     final SingleColumn column4 = (SingleColumn)querySpecification.getSelect().getSelectItems().get(4);
-    assertThat(column4.getAlias().get(), equalTo("KSQL_COL_4"));
+    assertThat(column4.getAlias().get(), equalTo("KSQL_TEST1_COL_4"));
     assertThat(column4.getExpression().toString(), equalTo("true"));
 
     final SingleColumn column5 = (SingleColumn)querySpecification.getSelect().getSelectItems().get(5);
-    assertThat(column5.getAlias().get(), equalTo("KSQL_COL_5"));
+    assertThat(column5.getAlias().get(), equalTo("KSQL_TEST1_COL_5"));
     assertThat(column5.getExpression().toString(), equalTo("-5"));
   }
 
@@ -204,7 +204,7 @@ public class StatementRewriterTest {
     assertThat(query.getQueryBody(), instanceOf(QuerySpecification.class));
     final QuerySpecification querySpecification = (QuerySpecification)query.getQueryBody();
     final SingleColumn column0 = (SingleColumn)querySpecification.getSelect().getSelectItems().get(0);
-    assertThat(column0.getAlias().get(), equalTo("KSQL_COL_0"));
+    assertThat(column0.getAlias().get(), equalTo("KSQL_TEST1_COL_0"));
     assertThat(column0.getExpression().toString(), equalTo("10"));
 
     final SingleColumn column1 = (SingleColumn)querySpecification.getSelect().getSelectItems().get(1);
@@ -212,7 +212,7 @@ public class StatementRewriterTest {
     assertThat(column1.getExpression().toString(), equalTo("TEST1.COL2"));
 
     final SingleColumn column2 = (SingleColumn)querySpecification.getSelect().getSelectItems().get(2);
-    assertThat(column2.getAlias().get(), equalTo("KSQL_COL_2"));
+    assertThat(column2.getAlias().get(), equalTo("KSQL_TEST1_COL_2"));
     assertThat(column2.getExpression().toString(), equalTo("'test'"));
 
   }
@@ -314,15 +314,15 @@ public class StatementRewriterTest {
     final QuerySpecification querySpecification = (QuerySpecification)query.getQueryBody();
 
     final SingleColumn column0 = (SingleColumn)querySpecification.getSelect().getSelectItems().get(0);
-    assertThat(column0.getAlias().get(), equalTo("KSQL_COL_0"));
+    assertThat(column0.getAlias().get(), equalTo("KSQL_TEST1_COL_0"));
     assertThat(column0.getExpression().toString(), equalTo("LCASE(T1.COL1)"));
 
     final SingleColumn column1 = (SingleColumn)querySpecification.getSelect().getSelectItems().get(1);
-    assertThat(column1.getAlias().get(), equalTo("KSQL_COL_1"));
+    assertThat(column1.getAlias().get(), equalTo("KSQL_TEST1_COL_1"));
     assertThat(column1.getExpression().toString(), equalTo("CONCAT(T1.COL2, 'hello')"));
 
     final SingleColumn column2 = (SingleColumn)querySpecification.getSelect().getSelectItems().get(2);
-    assertThat(column2.getAlias().get(), equalTo("KSQL_COL_2"));
+    assertThat(column2.getAlias().get(), equalTo("KSQL_TEST1_COL_2"));
     assertThat(column2.getExpression().toString(), equalTo("FLOOR(ABS(T1.COL3))"));
   }
 


### PR DESCRIPTION
### Description 
_What behavior do you want to change, why, how does your patch achieve the changes?_

Default node name will contain the source name.
"KSQL_COL_" + selectItemIndex) --> "KSQL_"
                + dataSourceExtractor.getFromName()
                + "_COL_" + selectItemIndex

https://github.com/confluentinc/ksql/issues/2401

### Testing done 
_Describe the testing strategy. Unit and integration tests are expected for any behavior changes._

### Reviewer checklist
- [ ] Ensure docs are updated if necessary. (eg. if a user visible feature is being added or changed).
- [X ] Ensure relevant issues are linked (description should include text like "Fixes #<issue number>")

