### PR TITLE
Adds a name to map schemas

### DIFF
--- a/ksql-common/src/main/java/io/confluent/ksql/util/KsqlConfig.java
+++ b/ksql-common/src/main/java/io/confluent/ksql/util/KsqlConfig.java
@@ -137,6 +137,9 @@ public class KsqlConfig extends AbstractConfig implements Cloneable {
       KSQL_USE_NAMED_INTERNAL_TOPICS_ON, KSQL_USE_NAMED_INTERNAL_TOPICS_OFF
   );
 
+  public static final String KSQL_USE_NAMED_AVRO_MAPS = "ksql.avro.maps.named";
+  private static final String KSQL_USE_NAMED_AVRO_MAPS_DOC = "";
+
   public static final String
       defaultSchemaRegistryUrl = "http://localhost:8081";
 
@@ -213,6 +216,14 @@ public class KsqlConfig extends AbstractConfig implements Cloneable {
               "The default number of replicas for the topics created by KSQL "
                   + "in 5.1 and earlier versions."
                   + "This property should not be set for 5.2 and later versions."
+          ),
+          new CompatibilityBreakingConfigDef(
+              KSQL_USE_NAMED_AVRO_MAPS,
+              ConfigDef.Type.BOOLEAN,
+              false,
+              true,
+              ConfigDef.Importance.LOW,
+              KSQL_USE_NAMED_AVRO_MAPS_DOC
           )
   );
 

--- a/ksql-engine/src/test/java/io/confluent/ksql/EndToEndEngineTestUtil.java
+++ b/ksql-engine/src/test/java/io/confluent/ksql/EndToEndEngineTestUtil.java
@@ -1026,8 +1026,8 @@ final class EndToEndEngineTestUtil {
       case ARRAY:
         if (schema.getElementType().getName().equals(AvroData.MAP_ENTRY_TYPE_NAME) ||
             Objects.equals(
-                schema.getElementType().getProp(AvroData.CONNECT_NAMED_MAP_PROP),
-                AvroData.CONNECT_NAMED_MAP_PROP_TRUE)
+                schema.getElementType().getProp(AvroData.CONNECT_INTERNAL_TYPE_NAME),
+                AvroData.MAP_ENTRY_TYPE_NAME)
             ) {
           final org.apache.avro.Schema valueSchema
               = schema.getElementType().getField("value").schema();

--- a/ksql-engine/src/test/java/io/confluent/ksql/EndToEndEngineTestUtil.java
+++ b/ksql-engine/src/test/java/io/confluent/ksql/EndToEndEngineTestUtil.java
@@ -1024,7 +1024,11 @@ final class EndToEndEngineTestUtil {
       case STRING:
         return avro.toString();
       case ARRAY:
-        if (schema.getElementType().getName().equals(AvroData.MAP_ENTRY_TYPE_NAME)) {
+        if (schema.getElementType().getName().equals(AvroData.MAP_ENTRY_TYPE_NAME) ||
+            Objects.equals(
+                schema.getElementType().getProp(AvroData.CONNECT_NAMED_MAP_PROP),
+                AvroData.CONNECT_NAMED_MAP_PROP_TRUE)
+            ) {
           final org.apache.avro.Schema valueSchema
               = schema.getElementType().getField("value").schema();
           return ((List) avro).stream().collect(

--- a/ksql-engine/src/test/resources/query-validation-tests/multiple-avro-maps.json
+++ b/ksql-engine/src/test/resources/query-validation-tests/multiple-avro-maps.json
@@ -1,0 +1,25 @@
+{
+  "comments": [
+    "You can specify multiple statements per test case, i.e., to set up the various streams needed",
+    "for joins etc, but currently only the final topology will be verified. This should be enough",
+    "for most tests as we can simulate the outputs from previous stages into the final stage. If we",
+    "take a modular approach to testing we can still verify that it all works correctly, i.e, if we",
+    "verify the output of a select or aggregate is correct, we can use simulated output to feed into",
+    "a join or another aggregate."
+  ],
+  "tests": [
+    {
+      "name": "project multiple avro maps",
+      "statements": [
+        "CREATE STREAM TEST (M1 MAP<STRING, INT>, M2 MAP<STRING, STRING>) WITH (kafka_topic='test_topic', value_format='AVRO');",
+        "CREATE STREAM SINK as SELECT * FROM test;"
+      ],
+      "inputs": [
+        {"topic": "test_topic", "key": 0, "value": {"M1": {"K1": 123}, "M2": {"K2": "FOO"}}}
+      ],
+      "outputs": [
+        {"topic": "SINK", "key": 0, "value": {"M1": {"K1": 123}, "M2": {"K2": "FOO"}}}
+      ]
+    }
+  ]
+}

--- a/ksql-serde/src/main/java/io/confluent/ksql/serde/avro/AvroDataTranslator.java
+++ b/ksql-serde/src/main/java/io/confluent/ksql/serde/avro/AvroDataTranslator.java
@@ -128,7 +128,8 @@ public class AvroDataTranslator implements DataTranslator {
             buildAvroCompatibleSchema(schema.keySchema(),
                 typeNameGenerator.with(TypeNameGenerator.MAP_KEY_NAME)),
             buildAvroCompatibleSchema(schema.valueSchema(),
-                typeNameGenerator.with(TypeNameGenerator.MAP_VALUE_NAME)));
+                typeNameGenerator.with(TypeNameGenerator.MAP_VALUE_NAME))
+        ).name(typeNameGenerator.name());
         break;
     }
     if (schema.isOptional()) {

--- a/ksql-serde/src/main/java/io/confluent/ksql/serde/avro/AvroDataTranslator.java
+++ b/ksql-serde/src/main/java/io/confluent/ksql/serde/avro/AvroDataTranslator.java
@@ -140,8 +140,8 @@ public class AvroDataTranslator implements DataTranslator {
                 useNamedMaps,
                 typeNameGenerator.with(TypeNameGenerator.MAP_VALUE_NAME))
         );
-        schemaBuilder = useNamedMaps ?
-          mapSchemaBuilder.name(typeNameGenerator.name()) : mapSchemaBuilder;
+        schemaBuilder = useNamedMaps
+          ? mapSchemaBuilder.name(typeNameGenerator.name()) : mapSchemaBuilder;
         break;
     }
     if (schema.isOptional()) {

--- a/ksql-serde/src/main/java/io/confluent/ksql/serde/avro/KsqlAvroTopicSerDe.java
+++ b/ksql-serde/src/main/java/io/confluent/ksql/serde/avro/KsqlAvroTopicSerDe.java
@@ -80,12 +80,20 @@ public class KsqlAvroTopicSerDe extends KsqlTopicSerDe {
         ? schemaMaybeWithSource : SchemaUtil.getSchemaWithNoAlias(schemaMaybeWithSource);
     final Serializer<GenericRow> genericRowSerializer = new ThreadLocalSerializer(
         () -> new KsqlConnectSerializer(
-            new AvroDataTranslator(schema, this.fullSchemaName),
+            new AvroDataTranslator(
+                schema,
+                this.fullSchemaName,
+                ksqlConfig.getBoolean(KsqlConfig.KSQL_USE_NAMED_AVRO_MAPS)
+            ),
             getAvroConverter(schemaRegistryClientFactory.get(), ksqlConfig)));
     final Deserializer<GenericRow> genericRowDeserializer = new ThreadLocalDeserializer(
         () -> new KsqlConnectDeserializer(
             getAvroConverter(schemaRegistryClientFactory.get(), ksqlConfig),
-            new AvroDataTranslator(schema, this.fullSchemaName),
+            new AvroDataTranslator(
+                schema,
+                this.fullSchemaName,
+                ksqlConfig.getBoolean(KsqlConfig.KSQL_USE_NAMED_AVRO_MAPS)
+            ),
             processingLogContext.getLoggerFactory().getLogger(
                 join(loggerNamePrefix, SerdeUtils.DESERIALIZER_LOGGER_NAME))
         )

--- a/ksql-serde/src/test/java/io/confluent/ksql/serde/avro/AvroDataTranslatorTest.java
+++ b/ksql-serde/src/test/java/io/confluent/ksql/serde/avro/AvroDataTranslatorTest.java
@@ -39,7 +39,10 @@ public class AvroDataTranslatorTest {
         .optional()
         .build();
 
-    final AvroDataTranslator dataTranslator = new AvroDataTranslator(schema, KsqlConstants.DEFAULT_AVRO_SCHEMA_FULL_NAME);
+    final AvroDataTranslator dataTranslator = new AvroDataTranslator(
+        schema,
+        KsqlConstants.DEFAULT_AVRO_SCHEMA_FULL_NAME,
+        true);
     final GenericRow ksqlRow = new GenericRow(ImmutableList.of(123));
     final Struct struct = dataTranslator.toConnectRow(ksqlRow);
 
@@ -89,7 +92,10 @@ public class AvroDataTranslatorTest {
     final Struct structInnerStruct = new Struct(structInner)
         .put("STRUCT_INNER", "foo");
 
-    final AvroDataTranslator dataTranslator = new AvroDataTranslator(schema, KsqlConstants.DEFAULT_AVRO_SCHEMA_FULL_NAME);
+    final AvroDataTranslator dataTranslator = new AvroDataTranslator(
+        schema,
+        KsqlConstants.DEFAULT_AVRO_SCHEMA_FULL_NAME,
+        true);
     final GenericRow ksqlRow = new GenericRow(
         ImmutableList.of(arrayInnerStruct),
         ImmutableMap.of("bar", mapInnerStruct),
@@ -153,7 +159,10 @@ public class AvroDataTranslatorTest {
         .optional()
         .build();
 
-    final AvroDataTranslator dataTranslator = new AvroDataTranslator(schema, KsqlConstants.DEFAULT_AVRO_SCHEMA_FULL_NAME);
+    final AvroDataTranslator dataTranslator = new AvroDataTranslator(
+        schema,
+        KsqlConstants.DEFAULT_AVRO_SCHEMA_FULL_NAME,
+        true);
     final GenericRow ksqlRow = new GenericRow(Collections.singletonList(null));
     final Struct struct = dataTranslator.toConnectRow(ksqlRow);
 
@@ -170,7 +179,10 @@ public class AvroDataTranslatorTest {
         .optional()
         .build();
 
-    final AvroDataTranslator dataTranslator = new AvroDataTranslator(schema, KsqlConstants.DEFAULT_AVRO_SCHEMA_FULL_NAME);
+    final AvroDataTranslator dataTranslator = new AvroDataTranslator(
+        schema,
+        KsqlConstants.DEFAULT_AVRO_SCHEMA_FULL_NAME,
+        true);
     final GenericRow ksqlRow = new GenericRow(Collections.singletonList(123L));
     final Struct struct = dataTranslator.toConnectRow(ksqlRow);
 
@@ -189,7 +201,7 @@ public class AvroDataTranslatorTest {
 
     String schemaFullName = "com.custom.schema";
 
-    final AvroDataTranslator dataTranslator = new AvroDataTranslator(schema, schemaFullName);
+    final AvroDataTranslator dataTranslator = new AvroDataTranslator(schema, schemaFullName, true);
     final GenericRow ksqlRow = new GenericRow(Collections.singletonList(123L));
     final Struct struct = dataTranslator.toConnectRow(ksqlRow);
 

--- a/ksql-serde/src/test/java/io/confluent/ksql/serde/avro/KsqlGenericRowAvroSerializerTest.java
+++ b/ksql-serde/src/test/java/io/confluent/ksql/serde/avro/KsqlGenericRowAvroSerializerTest.java
@@ -276,7 +276,7 @@ public class KsqlGenericRowAvroSerializerTest {
       final org.apache.avro.Schema valueSchema) {
     return org.apache.avro.SchemaBuilder.record(name)
         .namespace("io.confluent.ksql.avro_schemas")
-        .prop("connect.named.map", "true")
+        .prop("connect.internal.type", "MapEntry")
         .fields()
         .name("key")
         .type().unionOf().nullType().and().stringType().endUnion()


### PR DESCRIPTION
This patch adds names to map schemas when serializing avro. Internally,
the avro converter will use this name to name the map entry type. This
fixes the issue where, when a schema has multiple maps with different
types, avro errors out because the same name is used for different
map entry record schemas