### PR TITLE
Minor: Rename `KsqlType` to `SqlType`

### DIFF
--- a/ksql-engine/src/test/java/io/confluent/ksql/ddl/commands/AbstractCreateStreamCommandTest.java
+++ b/ksql-engine/src/test/java/io/confluent/ksql/ddl/commands/AbstractCreateStreamCommandTest.java
@@ -31,7 +31,7 @@ import io.confluent.ksql.parser.tree.PrimitiveType;
 import io.confluent.ksql.parser.tree.QualifiedName;
 import io.confluent.ksql.parser.tree.StringLiteral;
 import io.confluent.ksql.parser.tree.TableElement;
-import io.confluent.ksql.parser.tree.Type.KsqlType;
+import io.confluent.ksql.parser.tree.Type.SqlType;
 import io.confluent.ksql.services.KafkaTopicClient;
 import io.confluent.ksql.util.KsqlException;
 import java.util.Collections;
@@ -51,7 +51,7 @@ public class AbstractCreateStreamCommandTest {
 
   private static final String TOPIC_NAME = "some topic";
   private static final List<TableElement> SOME_ELEMENTS = ImmutableList.of(
-      new TableElement("bob", new PrimitiveType(KsqlType.STRING)));
+      new TableElement("bob", new PrimitiveType(SqlType.STRING)));
 
   @Rule
   public final ExpectedException expectedException = ExpectedException.none();

--- a/ksql-engine/src/test/java/io/confluent/ksql/ddl/commands/CommandFactoriesTest.java
+++ b/ksql-engine/src/test/java/io/confluent/ksql/ddl/commands/CommandFactoriesTest.java
@@ -36,8 +36,7 @@ import io.confluent.ksql.parser.tree.QualifiedName;
 import io.confluent.ksql.parser.tree.RegisterTopic;
 import io.confluent.ksql.parser.tree.StringLiteral;
 import io.confluent.ksql.parser.tree.TableElement;
-import io.confluent.ksql.parser.tree.Type;
-import io.confluent.ksql.parser.tree.Type.KsqlType;
+import io.confluent.ksql.parser.tree.Type.SqlType;
 import io.confluent.ksql.services.KafkaTopicClient;
 import io.confluent.ksql.services.ServiceContext;
 import io.confluent.ksql.util.KsqlException;
@@ -53,7 +52,7 @@ public class CommandFactoriesTest {
   private static final java.util.Map<String, Object> NO_PROPS = Collections.emptyMap();
   private static final String sqlExpression = "sqlExpression";
   private static final List<TableElement> SOME_ELEMENTS = ImmutableList.of(
-      new TableElement("bob", new PrimitiveType(KsqlType.STRING)));
+      new TableElement("bob", new PrimitiveType(SqlType.STRING)));
 
   private final KafkaTopicClient topicClient = EasyMock.createNiceMock(KafkaTopicClient.class);
   private final ServiceContext serviceContext = EasyMock.createNiceMock(ServiceContext.class);
@@ -207,8 +206,8 @@ public class CommandFactoriesTest {
   private static CreateTable createTable(final HashMap<String, Expression> tableProperties) {
     return new CreateTable(QualifiedName.of("foo"),
         ImmutableList.of(
-            new TableElement("COL1", new PrimitiveType(Type.KsqlType.BIGINT)),
-            new TableElement("COL2", new PrimitiveType(Type.KsqlType.STRING))),
+            new TableElement("COL1", new PrimitiveType(SqlType.BIGINT)),
+            new TableElement("COL2", new PrimitiveType(SqlType.STRING))),
         true, tableProperties);
   }
 

--- a/ksql-engine/src/test/java/io/confluent/ksql/ddl/commands/CreateStreamCommandTest.java
+++ b/ksql-engine/src/test/java/io/confluent/ksql/ddl/commands/CreateStreamCommandTest.java
@@ -33,7 +33,7 @@ import io.confluent.ksql.parser.tree.PrimitiveType;
 import io.confluent.ksql.parser.tree.QualifiedName;
 import io.confluent.ksql.parser.tree.StringLiteral;
 import io.confluent.ksql.parser.tree.TableElement;
-import io.confluent.ksql.parser.tree.Type.KsqlType;
+import io.confluent.ksql.parser.tree.Type.SqlType;
 import io.confluent.ksql.services.KafkaTopicClient;
 import io.confluent.ksql.util.KsqlException;
 import io.confluent.ksql.util.MetaStoreFixture;
@@ -55,7 +55,7 @@ import org.mockito.junit.MockitoJUnitRunner;
 public class CreateStreamCommandTest {
 
   private static final List<TableElement> SOME_ELEMENTS = ImmutableList.of(
-      new TableElement("bob", new PrimitiveType(KsqlType.STRING)));
+      new TableElement("bob", new PrimitiveType(SqlType.STRING)));
 
   @Mock
   private KafkaTopicClient topicClient;

--- a/ksql-engine/src/test/java/io/confluent/ksql/ddl/commands/CreateTableCommandTest.java
+++ b/ksql-engine/src/test/java/io/confluent/ksql/ddl/commands/CreateTableCommandTest.java
@@ -33,7 +33,7 @@ import io.confluent.ksql.parser.tree.PrimitiveType;
 import io.confluent.ksql.parser.tree.QualifiedName;
 import io.confluent.ksql.parser.tree.StringLiteral;
 import io.confluent.ksql.parser.tree.TableElement;
-import io.confluent.ksql.parser.tree.Type.KsqlType;
+import io.confluent.ksql.parser.tree.Type.SqlType;
 import io.confluent.ksql.services.KafkaTopicClient;
 import io.confluent.ksql.util.KsqlException;
 import io.confluent.ksql.util.MetaStoreFixture;
@@ -69,7 +69,7 @@ public class CreateTableCommandTest {
     givenPropertiesWith((Collections.emptyMap()));
     when(createTableStatement.getName()).thenReturn(QualifiedName.of("name"));
     when(createTableStatement.getElements()).thenReturn(ImmutableList.of(
-        new TableElement("SOME-KEY", new PrimitiveType(KsqlType.STRING))
+        new TableElement("SOME-KEY", new PrimitiveType(SqlType.STRING))
     ));
     when(topicClient.isTopicExists(any())).thenReturn(true);
   }

--- a/ksql-engine/src/test/java/io/confluent/ksql/schema/inference/DefaultSchemaInjectorTest.java
+++ b/ksql-engine/src/test/java/io/confluent/ksql/schema/inference/DefaultSchemaInjectorTest.java
@@ -31,9 +31,7 @@ import static org.mockito.Mockito.when;
 
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
-import io.confluent.ksql.metastore.MetaStore;
 import io.confluent.ksql.parser.KsqlParser.PreparedStatement;
-import io.confluent.ksql.parser.KsqlParserTestUtil;
 import io.confluent.ksql.parser.tree.AbstractStreamCreateStatement;
 import io.confluent.ksql.parser.tree.CreateStream;
 import io.confluent.ksql.parser.tree.CreateTable;
@@ -43,8 +41,7 @@ import io.confluent.ksql.parser.tree.QualifiedName;
 import io.confluent.ksql.parser.tree.Statement;
 import io.confluent.ksql.parser.tree.StringLiteral;
 import io.confluent.ksql.parser.tree.TableElement;
-import io.confluent.ksql.parser.tree.Type;
-import io.confluent.ksql.parser.tree.Type.KsqlType;
+import io.confluent.ksql.parser.tree.Type.SqlType;
 import io.confluent.ksql.schema.inference.TopicSchemaSupplier.SchemaResult;
 import io.confluent.ksql.util.KsqlException;
 import io.confluent.ksql.util.KsqlStatementException;
@@ -68,7 +65,7 @@ import org.mockito.junit.MockitoJUnitRunner;
 public class DefaultSchemaInjectorTest {
 
   private static final List<TableElement> SOME_ELEMENTS = ImmutableList.of(
-      new TableElement("bob", new PrimitiveType(KsqlType.STRING)));
+      new TableElement("bob", new PrimitiveType(SqlType.STRING)));
   private static final Map<String, Expression> UNSUPPORTED_PROPS = ImmutableMap.of(
       "VALUE_FORMAT", new StringLiteral("json")
   );
@@ -104,18 +101,18 @@ public class DefaultSchemaInjectorTest {
 
   private static final List<TableElement> EXPECTED_KSQL_SCHEMA = ImmutableList
       .<TableElement>builder()
-      .add(new TableElement("INTFIELD", new PrimitiveType(Type.KsqlType.INTEGER)))
-      .add(new TableElement("BIGINTFIELD", new PrimitiveType(KsqlType.BIGINT)))
-      .add(new TableElement("FLOATFIELD", new PrimitiveType(KsqlType.DOUBLE)))
-      .add(new TableElement("DOUBLEFIELD", new PrimitiveType(KsqlType.DOUBLE)))
-      .add(new TableElement("STRINGFIELD", new PrimitiveType(KsqlType.STRING)))
-      .add(new TableElement("BOOLEANFIELD", new PrimitiveType(KsqlType.BOOLEAN)))
+      .add(new TableElement("INTFIELD", new PrimitiveType(SqlType.INTEGER)))
+      .add(new TableElement("BIGINTFIELD", new PrimitiveType(SqlType.BIGINT)))
+      .add(new TableElement("FLOATFIELD", new PrimitiveType(SqlType.DOUBLE)))
+      .add(new TableElement("DOUBLEFIELD", new PrimitiveType(SqlType.DOUBLE)))
+      .add(new TableElement("STRINGFIELD", new PrimitiveType(SqlType.STRING)))
+      .add(new TableElement("BOOLEANFIELD", new PrimitiveType(SqlType.BOOLEAN)))
       .add(new TableElement("ARRAYFIELD", new io.confluent.ksql.parser.tree.Array(
-          new PrimitiveType(KsqlType.INTEGER))))
+          new PrimitiveType(SqlType.INTEGER))))
       .add(new TableElement("MAPFIELD", new io.confluent.ksql.parser.tree.Map(
-          new PrimitiveType(KsqlType.BIGINT))))
+          new PrimitiveType(SqlType.BIGINT))))
       .add(new TableElement("STRUCTFIELD", new io.confluent.ksql.parser.tree.Struct(
-          ImmutableList.of(new Pair<>("s0", new PrimitiveType(KsqlType.BIGINT))))))
+          ImmutableList.of(new Pair<>("s0", new PrimitiveType(SqlType.BIGINT))))))
       .build();
   private static final int SCHEMA_ID = 5;
 

--- a/ksql-parser/src/main/java/io/confluent/ksql/parser/ExpressionFormatter.java
+++ b/ksql-parser/src/main/java/io/confluent/ksql/parser/ExpressionFormatter.java
@@ -72,7 +72,6 @@ import io.confluent.ksql.parser.tree.Window;
 import io.confluent.ksql.parser.tree.WindowFrame;
 import io.confluent.ksql.util.KsqlConstants;
 import io.confluent.ksql.util.ParserUtil;
-
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Set;
@@ -100,7 +99,7 @@ public final class ExpressionFormatter {
 
     @Override
     protected String visitPrimitiveType(final PrimitiveType node, final Boolean unmangleNames) {
-      return node.getKsqlType().toString();
+      return node.getSqlType().toString();
     }
 
     @Override

--- a/ksql-parser/src/main/java/io/confluent/ksql/parser/tree/Array.java
+++ b/ksql-parser/src/main/java/io/confluent/ksql/parser/tree/Array.java
@@ -33,7 +33,7 @@ public class Array extends Type {
   }
 
   private Array(final Optional<NodeLocation> location, final Type itemType) {
-    super(location, KsqlType.ARRAY);
+    super(location, SqlType.ARRAY);
     requireNonNull(itemType, "itemType is null");
     this.itemType = itemType;
   }

--- a/ksql-parser/src/main/java/io/confluent/ksql/parser/tree/Map.java
+++ b/ksql-parser/src/main/java/io/confluent/ksql/parser/tree/Map.java
@@ -33,7 +33,7 @@ public class Map extends Type {
   }
 
   private Map(final Optional<NodeLocation> location, final Type valueType) {
-    super(location, KsqlType.MAP);
+    super(location, SqlType.MAP);
     requireNonNull(valueType, "itemType is null");
     this.valueType = valueType;
   }

--- a/ksql-parser/src/main/java/io/confluent/ksql/parser/tree/PrimitiveType.java
+++ b/ksql-parser/src/main/java/io/confluent/ksql/parser/tree/PrimitiveType.java
@@ -23,36 +23,36 @@ import java.util.Optional;
 
 public class PrimitiveType extends Type {
 
-  final KsqlType ksqlType;
+  final SqlType sqlType;
 
-  public PrimitiveType(final KsqlType ksqlType) {
-    this(Optional.empty(), ksqlType);
+  public PrimitiveType(final SqlType sqlType) {
+    this(Optional.empty(), sqlType);
   }
 
-  public PrimitiveType(final NodeLocation location, final KsqlType ksqlType) {
-    this(Optional.of(location), ksqlType);
+  public PrimitiveType(final NodeLocation location, final SqlType sqlType) {
+    this(Optional.of(location), sqlType);
   }
 
-  private PrimitiveType(final Optional<NodeLocation> location, final KsqlType ksqlType) {
-    super(location, ksqlType);
-    requireNonNull(ksqlType, "ksqlType is null");
-    this.ksqlType = ksqlType;
+  private PrimitiveType(final Optional<NodeLocation> location, final SqlType sqlType) {
+    super(location, sqlType);
+    requireNonNull(sqlType, "sqlType is null");
+    this.sqlType = sqlType;
   }
 
   public static PrimitiveType getPrimitiveType(final String typeName) {
     switch (typeName) {
       case "BOOLEAN":
-        return new PrimitiveType(Type.KsqlType.BOOLEAN);
+        return new PrimitiveType(SqlType.BOOLEAN);
       case "INT":
       case "INTEGER":
-        return new PrimitiveType(Type.KsqlType.INTEGER);
+        return new PrimitiveType(SqlType.INTEGER);
       case "BIGINT":
-        return new PrimitiveType(Type.KsqlType.BIGINT);
+        return new PrimitiveType(SqlType.BIGINT);
       case "DOUBLE":
-        return new PrimitiveType(Type.KsqlType.DOUBLE);
+        return new PrimitiveType(SqlType.DOUBLE);
       case "VARCHAR":
       case "STRING":
-        return new PrimitiveType(Type.KsqlType.STRING);
+        return new PrimitiveType(SqlType.STRING);
       default:
         throw new KsqlException("Invalid primitive column type: " + typeName);
     }
@@ -64,19 +64,19 @@ public class PrimitiveType extends Type {
   }
 
   @Override
-  public KsqlType getKsqlType() {
-    return ksqlType;
+  public SqlType getSqlType() {
+    return sqlType;
   }
 
   @Override
   public int hashCode() {
-    return Objects.hashCode(ksqlType);
+    return Objects.hashCode(sqlType);
   }
 
   @Override
   public boolean equals(final Object obj) {
     if (obj instanceof PrimitiveType) {
-      return ((PrimitiveType) obj).getKsqlType() == ksqlType;
+      return ((PrimitiveType) obj).getSqlType() == sqlType;
     }
     return false;
   }

--- a/ksql-parser/src/main/java/io/confluent/ksql/parser/tree/Struct.java
+++ b/ksql-parser/src/main/java/io/confluent/ksql/parser/tree/Struct.java
@@ -37,7 +37,7 @@ public final class Struct
   }
 
   private Struct(final Optional<NodeLocation> location, final List<Pair<String, Type>> items) {
-    super(location, KsqlType.STRUCT);
+    super(location, SqlType.STRUCT);
     requireNonNull(items, "items is null");
     this.items = ImmutableList.copyOf(items);
   }

--- a/ksql-parser/src/main/java/io/confluent/ksql/parser/tree/Type.java
+++ b/ksql-parser/src/main/java/io/confluent/ksql/parser/tree/Type.java
@@ -22,27 +22,27 @@ import java.util.Optional;
 public abstract class Type extends Expression {
 
 
-  public enum KsqlType {
+  public enum SqlType {
     BOOLEAN, INTEGER, BIGINT, DOUBLE, STRING, ARRAY, MAP, STRUCT
   }
 
-  final KsqlType ksqlType;
+  final SqlType sqlType;
 
-  public Type(final KsqlType ksqlType) {
-    this(Optional.empty(), ksqlType);
+  public Type(final SqlType sqlType) {
+    this(Optional.empty(), sqlType);
   }
 
-  public Type(final NodeLocation location, final KsqlType ksqlType) {
-    this(Optional.of(location), ksqlType);
+  public Type(final NodeLocation location, final SqlType sqlType) {
+    this(Optional.of(location), sqlType);
   }
 
-  protected Type(final Optional<NodeLocation> location, final KsqlType ksqlType) {
+  protected Type(final Optional<NodeLocation> location, final SqlType sqlType) {
     super(location);
-    requireNonNull(ksqlType, "ksqlType is null");
-    this.ksqlType = ksqlType;
+    requireNonNull(sqlType, "sqlType is null");
+    this.sqlType = sqlType;
   }
 
-  public KsqlType getKsqlType() {
-    return ksqlType;
+  public SqlType getSqlType() {
+    return sqlType;
   }
 }

--- a/ksql-parser/src/main/java/io/confluent/ksql/util/TypeUtil.java
+++ b/ksql-parser/src/main/java/io/confluent/ksql/util/TypeUtil.java
@@ -21,6 +21,7 @@ import io.confluent.ksql.parser.tree.PrimitiveType;
 import io.confluent.ksql.parser.tree.Struct;
 import io.confluent.ksql.parser.tree.TableElement;
 import io.confluent.ksql.parser.tree.Type;
+import io.confluent.ksql.parser.tree.Type.SqlType;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
@@ -34,12 +35,12 @@ public final class TypeUtil {
 
   private static final Map<Schema.Type, Function<Schema, Type>> KSQL_TYPES = ImmutableMap
       .<Schema.Type, Function<Schema, Type>>builder()
-      .put(Schema.Type.INT32, s -> new PrimitiveType(Type.KsqlType.INTEGER))
-      .put(Schema.Type.INT64, s -> new PrimitiveType(Type.KsqlType.BIGINT))
-      .put(Schema.Type.FLOAT32, s -> new PrimitiveType(Type.KsqlType.DOUBLE))
-      .put(Schema.Type.FLOAT64, s -> new PrimitiveType(Type.KsqlType.DOUBLE))
-      .put(Schema.Type.BOOLEAN, s -> new PrimitiveType(Type.KsqlType.BOOLEAN))
-      .put(Schema.Type.STRING, s -> new PrimitiveType(Type.KsqlType.STRING))
+      .put(Schema.Type.INT32, s -> new PrimitiveType(SqlType.INTEGER))
+      .put(Schema.Type.INT64, s -> new PrimitiveType(SqlType.BIGINT))
+      .put(Schema.Type.FLOAT32, s -> new PrimitiveType(SqlType.DOUBLE))
+      .put(Schema.Type.FLOAT64, s -> new PrimitiveType(SqlType.DOUBLE))
+      .put(Schema.Type.BOOLEAN, s -> new PrimitiveType(SqlType.BOOLEAN))
+      .put(Schema.Type.STRING, s -> new PrimitiveType(SqlType.STRING))
       .put(Schema.Type.ARRAY, TypeUtil::toKsqlArray)
       .put(Schema.Type.MAP, TypeUtil::toKsqlMap)
       .put(Schema.Type.STRUCT, TypeUtil::toKsqlStruct)
@@ -84,7 +85,7 @@ public final class TypeUtil {
   }
 
   public static Schema getTypeSchema(final Type ksqlType) {
-    switch (ksqlType.getKsqlType()) {
+    switch (ksqlType.getSqlType()) {
       case BOOLEAN:
         return Schema.OPTIONAL_BOOLEAN_SCHEMA;
       case INTEGER:

--- a/ksql-parser/src/test/java/io/confluent/ksql/parser/ExpressionFormatterTest.java
+++ b/ksql-parser/src/test/java/io/confluent/ksql/parser/ExpressionFormatterTest.java
@@ -59,7 +59,7 @@ import io.confluent.ksql.parser.tree.SymbolReference;
 import io.confluent.ksql.parser.tree.TimeLiteral;
 import io.confluent.ksql.parser.tree.TimestampLiteral;
 import io.confluent.ksql.parser.tree.TumblingWindowExpression;
-import io.confluent.ksql.parser.tree.Type;
+import io.confluent.ksql.parser.tree.Type.SqlType;
 import io.confluent.ksql.parser.tree.WhenClause;
 import io.confluent.ksql.parser.tree.Window;
 import io.confluent.ksql.parser.tree.WindowExpression;
@@ -347,8 +347,8 @@ public class ExpressionFormatterTest {
     final Struct struct
         = new Struct(
             ImmutableList.of(
-                new Pair<>("field1", new PrimitiveType(Type.KsqlType.INTEGER)),
-                new Pair<>("field2", new PrimitiveType(Type.KsqlType.STRING))
+                new Pair<>("field1", new PrimitiveType(SqlType.INTEGER)),
+                new Pair<>("field2", new PrimitiveType(SqlType.STRING))
             ));
     assertThat(
         ExpressionFormatter.formatExpression(struct),
@@ -360,7 +360,7 @@ public class ExpressionFormatterTest {
     final Struct struct
         = new Struct(
         ImmutableList.of(
-            new Pair<>("END", new PrimitiveType(Type.KsqlType.INTEGER))
+            new Pair<>("END", new PrimitiveType(SqlType.INTEGER))
         ));
     assertThat(
         ExpressionFormatter.formatExpression(struct),
@@ -369,13 +369,13 @@ public class ExpressionFormatterTest {
 
   @Test
   public void shouldFormatMap() {
-    final Map map = new Map(new PrimitiveType(Type.KsqlType.BIGINT));
+    final Map map = new Map(new PrimitiveType(SqlType.BIGINT));
     assertThat(ExpressionFormatter.formatExpression(map), equalTo("MAP<VARCHAR, BIGINT>"));
   }
 
   @Test
   public void shouldFormatArray() {
-    final Array array = new Array(new PrimitiveType(Type.KsqlType.BOOLEAN));
+    final Array array = new Array(new PrimitiveType(SqlType.BOOLEAN));
     assertThat(ExpressionFormatter.formatExpression(array), equalTo("ARRAY<BOOLEAN>"));
   }
 }

--- a/ksql-parser/src/test/java/io/confluent/ksql/parser/KsqlParserTest.java
+++ b/ksql-parser/src/test/java/io/confluent/ksql/parser/KsqlParserTest.java
@@ -65,7 +65,7 @@ import io.confluent.ksql.parser.tree.SetProperty;
 import io.confluent.ksql.parser.tree.SingleColumn;
 import io.confluent.ksql.parser.tree.Statement;
 import io.confluent.ksql.parser.tree.Struct;
-import io.confluent.ksql.parser.tree.Type;
+import io.confluent.ksql.parser.tree.Type.SqlType;
 import io.confluent.ksql.parser.tree.WithinExpression;
 import io.confluent.ksql.serde.json.KsqlJsonTopicSerDe;
 import io.confluent.ksql.util.KsqlException;
@@ -547,10 +547,10 @@ public class KsqlParserTest {
     assertThat(createStream.getName().toString().toUpperCase(), equalTo("ORDERS"));
     assertThat(createStream.getElements().size(), equalTo(7));
     assertThat(createStream.getElements().get(0).getName().toString().toLowerCase(), equalTo("ordertime"));
-    assertThat(createStream.getElements().get(6).getType().getKsqlType(), equalTo(Type.KsqlType.STRUCT));
+    assertThat(createStream.getElements().get(6).getType().getSqlType(), equalTo(SqlType.STRUCT));
     final Struct struct = (Struct) createStream.getElements().get(6).getType();
     assertThat(struct.getItems().size(), equalTo(5));
-    assertThat(struct.getItems().get(0).getRight().getKsqlType(), equalTo(Type.KsqlType.STRING));
+    assertThat(struct.getItems().get(0).getRight().getSqlType(), equalTo(SqlType.STRING));
     assertThat(createStream.getProperties().get(DdlConfig.TOPIC_NAME_PROPERTY).toString().toLowerCase(),
                equalTo("'orders_topic'"));
   }

--- a/ksql-parser/src/test/java/io/confluent/ksql/parser/SqlFormatterTest.java
+++ b/ksql-parser/src/test/java/io/confluent/ksql/parser/SqlFormatterTest.java
@@ -41,7 +41,7 @@ import io.confluent.ksql.parser.tree.Statement;
 import io.confluent.ksql.parser.tree.StringLiteral;
 import io.confluent.ksql.parser.tree.Table;
 import io.confluent.ksql.parser.tree.TableElement;
-import io.confluent.ksql.parser.tree.Type;
+import io.confluent.ksql.parser.tree.Type.SqlType;
 import io.confluent.ksql.parser.tree.WithinExpression;
 import io.confluent.ksql.serde.json.KsqlJsonTopicSerDe;
 import io.confluent.ksql.util.MetaStoreFixture;
@@ -150,9 +150,9 @@ public class SqlFormatterTest {
   public void testFormatSql() {
 
     final ArrayList<TableElement> tableElements = new ArrayList<>();
-    tableElements.add(new TableElement("GROUP", new PrimitiveType(Type.KsqlType.STRING)));
-    tableElements.add(new TableElement("NOLIT", new PrimitiveType(Type.KsqlType.STRING)));
-    tableElements.add(new TableElement("Having", new PrimitiveType(Type.KsqlType.STRING)));
+    tableElements.add(new TableElement("GROUP", new PrimitiveType(SqlType.STRING)));
+    tableElements.add(new TableElement("NOLIT", new PrimitiveType(SqlType.STRING)));
+    tableElements.add(new TableElement("Having", new PrimitiveType(SqlType.STRING)));
 
     final CreateStream createStream = new CreateStream(
         QualifiedName.of("TEST"),

--- a/ksql-parser/src/test/java/io/confluent/ksql/parser/rewrite/StatementRewriterTest.java
+++ b/ksql-parser/src/test/java/io/confluent/ksql/parser/rewrite/StatementRewriterTest.java
@@ -37,7 +37,7 @@ import io.confluent.ksql.parser.tree.QuerySpecification;
 import io.confluent.ksql.parser.tree.SingleColumn;
 import io.confluent.ksql.parser.tree.Statement;
 import io.confluent.ksql.parser.tree.Struct;
-import io.confluent.ksql.parser.tree.Type;
+import io.confluent.ksql.parser.tree.Type.SqlType;
 import io.confluent.ksql.util.MetaStoreFixture;
 import org.junit.Assert;
 import org.junit.Before;
@@ -361,10 +361,10 @@ public class StatementRewriterTest {
     assertThat(createStream.getName().toString().toUpperCase(), equalTo("ORDERS"));
     assertThat(createStream.getElements().size(), equalTo(7));
     assertThat(createStream.getElements().get(0).getName().toLowerCase(), equalTo("ordertime"));
-    assertThat(createStream.getElements().get(6).getType().getKsqlType(), equalTo(Type.KsqlType.STRUCT));
+    assertThat(createStream.getElements().get(6).getType().getSqlType(), equalTo(SqlType.STRUCT));
     final Struct struct = (Struct) createStream.getElements().get(6).getType();
     assertThat(struct.getItems().size(), equalTo(5));
-    assertThat(struct.getItems().get(0).getRight().getKsqlType(), equalTo(Type.KsqlType.STRING));
+    assertThat(struct.getItems().get(0).getRight().getSqlType(), equalTo(SqlType.STRING));
     assertThat(createStream.getProperties().get(DdlConfig.TOPIC_NAME_PROPERTY).toString().toLowerCase(),
         equalTo("'orders_topic'"));
   }

--- a/ksql-parser/src/test/java/io/confluent/ksql/parser/util/TypeUtilTest.java
+++ b/ksql-parser/src/test/java/io/confluent/ksql/parser/util/TypeUtilTest.java
@@ -24,6 +24,7 @@ import io.confluent.ksql.parser.tree.Map;
 import io.confluent.ksql.parser.tree.PrimitiveType;
 import io.confluent.ksql.parser.tree.Struct;
 import io.confluent.ksql.parser.tree.Type;
+import io.confluent.ksql.parser.tree.Type.SqlType;
 import io.confluent.ksql.util.KsqlException;
 import io.confluent.ksql.util.Pair;
 import io.confluent.ksql.util.TypeUtil;
@@ -42,19 +43,19 @@ public class TypeUtilTest {
   @Test
   public void shouldGetCorrectPrimitiveKsqlType() {
     final Type type0 = TypeUtil.getKsqlType(Schema.OPTIONAL_BOOLEAN_SCHEMA);
-    assertThat(type0.getKsqlType(), equalTo(Type.KsqlType.BOOLEAN));
+    assertThat(type0.getSqlType(), equalTo(SqlType.BOOLEAN));
 
     final Type type1 = TypeUtil.getKsqlType(Schema.OPTIONAL_INT32_SCHEMA);
-    assertThat(type1.getKsqlType(), equalTo(Type.KsqlType.INTEGER));
+    assertThat(type1.getSqlType(), equalTo(SqlType.INTEGER));
 
     final Type type2 = TypeUtil.getKsqlType(Schema.OPTIONAL_FLOAT64_SCHEMA);
-    assertThat(type2.getKsqlType(), equalTo(Type.KsqlType.DOUBLE));
+    assertThat(type2.getSqlType(), equalTo(SqlType.DOUBLE));
 
     final Type type3 = TypeUtil.getKsqlType(Schema.OPTIONAL_STRING_SCHEMA);
-    assertThat(type3.getKsqlType(), equalTo(Type.KsqlType.STRING));
+    assertThat(type3.getSqlType(), equalTo(SqlType.STRING));
 
     final Type type4 = TypeUtil.getKsqlType(Schema.OPTIONAL_INT64_SCHEMA);
-    assertThat(type4.getKsqlType(), equalTo(Type.KsqlType.BIGINT));
+    assertThat(type4.getSqlType(), equalTo(SqlType.BIGINT));
   }
 
   @Test
@@ -62,9 +63,9 @@ public class TypeUtilTest {
 
     final Schema arraySchema = SchemaBuilder.array(Schema.OPTIONAL_FLOAT64_SCHEMA).optional().build();
     final Type type = TypeUtil.getKsqlType(arraySchema);
-    assertThat(type.getKsqlType(), equalTo(Type.KsqlType.ARRAY));
+    assertThat(type.getSqlType(), equalTo(SqlType.ARRAY));
     assertThat(type, instanceOf(Array.class));
-    assertThat(((Array) type).getItemType().getKsqlType(), equalTo(Type.KsqlType.DOUBLE));
+    assertThat(((Array) type).getItemType().getSqlType(), equalTo(SqlType.DOUBLE));
   }
 
   @Test
@@ -72,9 +73,9 @@ public class TypeUtilTest {
 
     final Schema mapSchema = SchemaBuilder.map(Schema.OPTIONAL_STRING_SCHEMA, Schema.OPTIONAL_FLOAT64_SCHEMA).optional().build();
     final Type type = TypeUtil.getKsqlType(mapSchema);
-    assertThat(type.getKsqlType(), equalTo(Type.KsqlType.MAP));
+    assertThat(type.getSqlType(), equalTo(SqlType.MAP));
     assertThat(type, instanceOf(Map.class));
-    assertThat(((Map) type).getValueType().getKsqlType(), equalTo(Type.KsqlType.DOUBLE));
+    assertThat(((Map) type).getValueType().getSqlType(), equalTo(SqlType.DOUBLE));
   }
 
   @Test
@@ -97,15 +98,15 @@ public class TypeUtilTest {
 
     final Schema arraySchema = SchemaBuilder.array(Schema.OPTIONAL_FLOAT64_SCHEMA).optional().build();
     final Type type4 = TypeUtil.getKsqlType(arraySchema);
-    assertThat(type4.getKsqlType(), equalTo(Type.KsqlType.ARRAY));
+    assertThat(type4.getSqlType(), equalTo(SqlType.ARRAY));
     assertThat(type4, instanceOf(Array.class));
-    assertThat(((Array) type4).getItemType().getKsqlType(), equalTo(Type.KsqlType.DOUBLE));
+    assertThat(((Array) type4).getItemType().getSqlType(), equalTo(SqlType.DOUBLE));
 
     final Schema mapSchema = SchemaBuilder.map(Schema.OPTIONAL_STRING_SCHEMA, Schema.OPTIONAL_FLOAT64_SCHEMA).optional().build();
     final Type type5 = TypeUtil.getKsqlType(mapSchema);
-    assertThat(type5.getKsqlType(), equalTo(Type.KsqlType.MAP));
+    assertThat(type5.getSqlType(), equalTo(SqlType.MAP));
     assertThat(type5, instanceOf(Map.class));
-    assertThat(((Map) type5).getValueType().getKsqlType(), equalTo(Type.KsqlType.DOUBLE));
+    assertThat(((Map) type5).getValueType().getSqlType(), equalTo(SqlType.DOUBLE));
 
     final Schema structSchema1 = SchemaBuilder.struct()
         .field("COL1", Schema.OPTIONAL_FLOAT64_SCHEMA)
@@ -115,16 +116,16 @@ public class TypeUtilTest {
         .field("COL5", mapSchema)
         .optional().build();
     final Type type6 = TypeUtil.getKsqlType(structSchema1);
-    assertThat(type6.getKsqlType(), equalTo(Type.KsqlType.STRUCT));
+    assertThat(type6.getSqlType(), equalTo(SqlType.STRUCT));
     assertThat(type6, instanceOf(Struct.class));
-    assertThat(((Struct) type6).getItems().get(0).getRight().getKsqlType(), equalTo(Type.KsqlType.DOUBLE));
-    assertThat(((Struct) type6).getItems().get(1).getRight().getKsqlType(), equalTo(Type.KsqlType
+    assertThat(((Struct) type6).getItems().get(0).getRight().getSqlType(), equalTo(SqlType.DOUBLE));
+    assertThat(((Struct) type6).getItems().get(1).getRight().getSqlType(), equalTo(SqlType
                                                                                         .STRING));
-    assertThat(((Struct) type6).getItems().get(2).getRight().getKsqlType(), equalTo(Type.KsqlType
+    assertThat(((Struct) type6).getItems().get(2).getRight().getSqlType(), equalTo(SqlType
                                                                                         .BOOLEAN));
-    assertThat(((Struct) type6).getItems().get(3).getRight().getKsqlType(), equalTo(Type.KsqlType
+    assertThat(((Struct) type6).getItems().get(3).getRight().getSqlType(), equalTo(SqlType
                                                                                         .ARRAY));
-    assertThat(((Struct) type6).getItems().get(4).getRight().getKsqlType(), equalTo(Type.KsqlType
+    assertThat(((Struct) type6).getItems().get(4).getRight().getSqlType(), equalTo(SqlType
                                                                                         .MAP));
 
     final Schema structSchema2 = SchemaBuilder.struct()
@@ -136,18 +137,18 @@ public class TypeUtilTest {
         .field("COL6", structSchema1)
         .build();
     final Type type7 = TypeUtil.getKsqlType(structSchema2);
-    assertThat(type6.getKsqlType(), equalTo(Type.KsqlType.STRUCT));
+    assertThat(type6.getSqlType(), equalTo(SqlType.STRUCT));
     assertThat(type7, instanceOf(Struct.class));
-    assertThat(((Struct) type7).getItems().get(0).getRight().getKsqlType(), equalTo(Type.KsqlType.DOUBLE));
-    assertThat(((Struct) type7).getItems().get(1).getRight().getKsqlType(), equalTo(Type.KsqlType
+    assertThat(((Struct) type7).getItems().get(0).getRight().getSqlType(), equalTo(SqlType.DOUBLE));
+    assertThat(((Struct) type7).getItems().get(1).getRight().getSqlType(), equalTo(SqlType
                                                                                         .STRING));
-    assertThat(((Struct) type7).getItems().get(2).getRight().getKsqlType(), equalTo(Type.KsqlType
+    assertThat(((Struct) type7).getItems().get(2).getRight().getSqlType(), equalTo(SqlType
                                                                                         .BOOLEAN));
-    assertThat(((Struct) type7).getItems().get(3).getRight().getKsqlType(), equalTo(Type.KsqlType
+    assertThat(((Struct) type7).getItems().get(3).getRight().getSqlType(), equalTo(SqlType
                                                                                         .ARRAY));
-    assertThat(((Struct) type7).getItems().get(4).getRight().getKsqlType(), equalTo(Type.KsqlType
+    assertThat(((Struct) type7).getItems().get(4).getRight().getSqlType(), equalTo(SqlType
                                                                                         .MAP));
-    assertThat(((Struct) type7).getItems().get(5).getRight().getKsqlType(), equalTo(Type.KsqlType
+    assertThat(((Struct) type7).getItems().get(5).getRight().getSqlType(), equalTo(SqlType
                                                                                         .STRUCT));
 
 
@@ -156,22 +157,22 @@ public class TypeUtilTest {
   @Test
   public void shouldGetCorrectPrimitiveSchema() {
 
-    final Schema schema1 = TypeUtil.getTypeSchema(new PrimitiveType(Type.KsqlType.BIGINT));
+    final Schema schema1 = TypeUtil.getTypeSchema(new PrimitiveType(SqlType.BIGINT));
     assertThat(schema1, equalTo(Schema.OPTIONAL_INT64_SCHEMA));
 
-    final Schema schema2 = TypeUtil.getTypeSchema(new PrimitiveType(Type.KsqlType.BOOLEAN));
+    final Schema schema2 = TypeUtil.getTypeSchema(new PrimitiveType(SqlType.BOOLEAN));
     assertThat(schema2, equalTo(Schema.OPTIONAL_BOOLEAN_SCHEMA));
 
-    final Schema schema3 = TypeUtil.getTypeSchema(new PrimitiveType(Type.KsqlType.INTEGER));
+    final Schema schema3 = TypeUtil.getTypeSchema(new PrimitiveType(SqlType.INTEGER));
     assertThat(schema3, equalTo(Schema.OPTIONAL_INT32_SCHEMA));
 
-    final Schema schema4 = TypeUtil.getTypeSchema(new PrimitiveType(Type.KsqlType.DOUBLE));
+    final Schema schema4 = TypeUtil.getTypeSchema(new PrimitiveType(SqlType.DOUBLE));
     assertThat(schema4, equalTo(Schema.OPTIONAL_FLOAT64_SCHEMA));
 
-    final Schema schema5 = TypeUtil.getTypeSchema(new PrimitiveType(Type.KsqlType.STRING));
+    final Schema schema5 = TypeUtil.getTypeSchema(new PrimitiveType(SqlType.STRING));
     assertThat(schema5, equalTo(Schema.OPTIONAL_STRING_SCHEMA));
 
-    final Schema schema6 = TypeUtil.getTypeSchema(new PrimitiveType(Type.KsqlType.BIGINT));
+    final Schema schema6 = TypeUtil.getTypeSchema(new PrimitiveType(SqlType.BIGINT));
     assertThat(schema6, equalTo(Schema.OPTIONAL_INT64_SCHEMA));
 
   }
@@ -179,7 +180,7 @@ public class TypeUtilTest {
   @Test
   public void shouldGetCorrectArraySchema() {
 
-    final Schema schema = TypeUtil.getTypeSchema(new Array(new PrimitiveType(Type.KsqlType.STRING)));
+    final Schema schema = TypeUtil.getTypeSchema(new Array(new PrimitiveType(SqlType.STRING)));
     assertThat(schema.type(), equalTo(Schema.Type.ARRAY));
     assertThat(schema.valueSchema().type(), equalTo(Schema.Type.STRING));
   }
@@ -187,7 +188,7 @@ public class TypeUtilTest {
   @Test
   public void shouldGetCorrectMapSchema() {
 
-    final Schema schema = TypeUtil.getTypeSchema(new Map(new PrimitiveType(Type.KsqlType.DOUBLE)));
+    final Schema schema = TypeUtil.getTypeSchema(new Map(new PrimitiveType(SqlType.DOUBLE)));
     assertThat(schema.type(), equalTo(Schema.Type.MAP));
     assertThat(schema.valueSchema().type(), equalTo(Schema.Type.FLOAT64));
   }
@@ -196,17 +197,17 @@ public class TypeUtilTest {
   public void shouldGetCorrectSchema() {
 
     final Struct internalStruct = new Struct(Arrays.asList(
-        new Pair<>("COL1", new PrimitiveType(Type.KsqlType.STRING)),
-        new Pair<>("COL2", new PrimitiveType(Type.KsqlType.BIGINT)),
-        new Pair<>("COL3", new PrimitiveType(Type.KsqlType.BOOLEAN))
+        new Pair<>("COL1", new PrimitiveType(SqlType.STRING)),
+        new Pair<>("COL2", new PrimitiveType(SqlType.BIGINT)),
+        new Pair<>("COL3", new PrimitiveType(SqlType.BOOLEAN))
     ));
 
     final Struct struct = new Struct(Arrays.asList(
-        new Pair<>("COL1", new PrimitiveType(Type.KsqlType.STRING)),
-        new Pair<>("COL2", new PrimitiveType(Type.KsqlType.BIGINT)),
-        new Pair<>("COL3", new PrimitiveType(Type.KsqlType.BOOLEAN)),
-        new Pair<>("COL4", new Array(new PrimitiveType(Type.KsqlType.STRING))),
-        new Pair<>("COL5", new Map(new PrimitiveType(Type.KsqlType.DOUBLE))),
+        new Pair<>("COL1", new PrimitiveType(SqlType.STRING)),
+        new Pair<>("COL2", new PrimitiveType(SqlType.BIGINT)),
+        new Pair<>("COL3", new PrimitiveType(SqlType.BOOLEAN)),
+        new Pair<>("COL4", new Array(new PrimitiveType(SqlType.STRING))),
+        new Pair<>("COL5", new Map(new PrimitiveType(SqlType.DOUBLE))),
         new Pair<>("COL6", internalStruct)
     ));
 

--- a/ksql-rest-app/src/main/java/io/confluent/ksql/rest/server/KsqlRestApplication.java
+++ b/ksql-rest-app/src/main/java/io/confluent/ksql/rest/server/KsqlRestApplication.java
@@ -39,7 +39,7 @@ import io.confluent.ksql.parser.tree.QualifiedName;
 import io.confluent.ksql.parser.tree.RegisterTopic;
 import io.confluent.ksql.parser.tree.StringLiteral;
 import io.confluent.ksql.parser.tree.TableElement;
-import io.confluent.ksql.parser.tree.Type;
+import io.confluent.ksql.parser.tree.Type.SqlType;
 import io.confluent.ksql.rest.entity.ServerInfo;
 import io.confluent.ksql.rest.server.computation.CommandQueue;
 import io.confluent.ksql.rest.server.computation.CommandRunner;
@@ -350,7 +350,7 @@ public final class KsqlRestApplication extends Application<KsqlRestConfig> imple
             QualifiedName.of(COMMANDS_STREAM_NAME),
             Collections.singletonList(new TableElement(
                 "STATEMENT",
-                new PrimitiveType(Type.KsqlType.STRING)
+                new PrimitiveType(SqlType.STRING)
             )),
             false,
             Collections.singletonMap(

--- a/ksql-rest-app/src/test/java/io/confluent/ksql/rest/server/StandaloneExecutorTest.java
+++ b/ksql-rest-app/src/test/java/io/confluent/ksql/rest/server/StandaloneExecutorTest.java
@@ -53,7 +53,7 @@ import io.confluent.ksql.parser.tree.Query;
 import io.confluent.ksql.parser.tree.SetProperty;
 import io.confluent.ksql.parser.tree.StringLiteral;
 import io.confluent.ksql.parser.tree.TableElement;
-import io.confluent.ksql.parser.tree.Type.KsqlType;
+import io.confluent.ksql.parser.tree.Type.SqlType;
 import io.confluent.ksql.parser.tree.UnsetProperty;
 import io.confluent.ksql.schema.inference.SchemaInjector;
 import io.confluent.ksql.services.KafkaTopicClient;
@@ -100,7 +100,7 @@ public class StandaloneExecutorTest {
   private static final KsqlConfig ksqlConfig = new KsqlConfig(emptyMap());
 
   private static final List<TableElement> SOME_ELEMENTS = ImmutableList.of(
-      new TableElement("bob", new PrimitiveType(KsqlType.STRING)));
+      new TableElement("bob", new PrimitiveType(SqlType.STRING)));
 
   private static final QualifiedName SOME_NAME = QualifiedName.of("Bob");
 

--- a/ksql-rest-app/src/test/java/io/confluent/ksql/rest/server/resources/KsqlResourceTest.java
+++ b/ksql-rest-app/src/test/java/io/confluent/ksql/rest/server/resources/KsqlResourceTest.java
@@ -76,7 +76,7 @@ import io.confluent.ksql.parser.tree.QualifiedName;
 import io.confluent.ksql.parser.tree.StringLiteral;
 import io.confluent.ksql.parser.tree.TableElement;
 import io.confluent.ksql.parser.tree.TerminateQuery;
-import io.confluent.ksql.parser.tree.Type.KsqlType;
+import io.confluent.ksql.parser.tree.Type.SqlType;
 import io.confluent.ksql.rest.entity.ClusterTerminateRequest;
 import io.confluent.ksql.rest.entity.CommandStatus;
 import io.confluent.ksql.rest.entity.CommandStatusEntity;
@@ -176,7 +176,7 @@ public class KsqlResourceTest {
   private static final ClusterTerminateRequest VALID_TERMINATE_REQUEST =
       new ClusterTerminateRequest(ImmutableList.of("Foo"));
   private static final List<TableElement> SOME_ELEMENTS = ImmutableList.of(
-      new TableElement("f0", new PrimitiveType(KsqlType.STRING))
+      new TableElement("f0", new PrimitiveType(SqlType.STRING))
   );
   private static final PreparedStatement<CreateStream> STMT_0_WITH_SCHEMA = PreparedStatement.of(
       "sql with schema",


### PR DESCRIPTION
### Description 

This PR is nothing more than a rename of the `KsqlType` enum to `SqlType`.  Why? Because the enum is a list of the SQL types we support, and so should IMHO have a name to match.

KSQL has three main type systems:
 - SQL, e.g. `INT` `BIGINT`, `DOUBLE`, `MAP`, etc.
 - Logical, corresponding `Schema` mappings for the above type, with all fields optional.
 - Schemas relating to serialization, e.g. the Connect schema, Avro schema, etc.

Historically, the lines and naming between these type systems was pretty blurred in the code, and I think this simple rename helps clarify these are specifically SQL types and not some other KSQL type.

Are you convinced? :D

### Testing done 
Well, it compiles...

### Reviewer checklist
- [ ] Ensure docs are updated if necessary. (eg. if a user visible feature is being added or changed).
- [ ] Ensure relevant issues are linked (description should include text like "Fixes #<issue number>")

