### PR TITLE
Support date formats that do not use our ChronoFields (Fixes #2499)

### DIFF
--- a/ksql-common/src/main/java/io/confluent/ksql/util/timestamp/StringToTimestampParser.java
+++ b/ksql-common/src/main/java/io/confluent/ksql/util/timestamp/StringToTimestampParser.java
@@ -40,8 +40,6 @@ import org.slf4j.LoggerFactory;
 @SuppressWarnings("UnstableApiUsage")
 public class StringToTimestampParser {
 
-  private static final Logger LOG = LoggerFactory.getLogger(StringToTimestampParser.class);
-
   private static final Multimap<TemporalUnit, ChronoField> CHRONO_UNIT_TO_FIELDS;
 
   static {
@@ -84,9 +82,6 @@ public class StringToTimestampParser {
             (ChronoUnit) chronoField.getRangeUnit()));
       }
     }
-
-    LOG.debug("Supported range for pattern {} is: {}", pattern, supportedRange);
-    System.out.println("Supported range: " + supportedRange);
 
     setDefault(formatBuilder, now, ChronoUnit.YEARS, ChronoField.YEAR_OF_ERA, 1970, supportedRange);
     setDefault(formatBuilder, now, ChronoUnit.MONTHS, ChronoField.MONTH_OF_YEAR, 1, supportedRange);

--- a/ksql-common/src/main/java/io/confluent/ksql/util/timestamp/StringToTimestampParser.java
+++ b/ksql-common/src/main/java/io/confluent/ksql/util/timestamp/StringToTimestampParser.java
@@ -15,27 +15,85 @@
 
 package io.confluent.ksql.util.timestamp;
 
+import com.google.common.collect.ImmutableMultimap;
+import com.google.common.collect.Multimap;
+import com.google.common.collect.Range;
+import com.google.common.collect.RangeSet;
+import com.google.common.collect.TreeRangeSet;
 import io.confluent.ksql.util.KsqlException;
 import java.sql.Timestamp;
+import java.text.ParsePosition;
 import java.time.LocalDateTime;
 import java.time.ZoneId;
 import java.time.ZonedDateTime;
 import java.time.format.DateTimeFormatter;
 import java.time.format.DateTimeFormatterBuilder;
 import java.time.temporal.ChronoField;
+import java.time.temporal.ChronoUnit;
 import java.time.temporal.TemporalAccessor;
+import java.time.temporal.TemporalUnit;
+import java.util.Locale;
+import java.util.Optional;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
+@SuppressWarnings("UnstableApiUsage")
 public class StringToTimestampParser {
+
+  private static final Logger LOG = LoggerFactory.getLogger(StringToTimestampParser.class);
+
+  private static final Multimap<TemporalUnit, ChronoField> CHRONO_UNIT_TO_FIELDS;
+
+  static {
+    ImmutableMultimap.Builder<TemporalUnit, ChronoField> unitBuilder = ImmutableMultimap.builder();
+    for (ChronoField field : ChronoField.values())  {
+      unitBuilder.put(field.getBaseUnit(), field);
+    }
+    CHRONO_UNIT_TO_FIELDS = unitBuilder.build();
+  }
+
   private final DateTimeFormatter formatter;
 
   public StringToTimestampParser(final String pattern) {
-    formatter = new DateTimeFormatterBuilder()
-        .appendPattern(pattern)
-        .parseDefaulting(ChronoField.YEAR_OF_ERA, 1970)
-        .parseDefaulting(ChronoField.MONTH_OF_YEAR, 1)
-        .parseDefaulting(ChronoField.DAY_OF_MONTH, 1)
-        .parseDefaulting(ChronoField.HOUR_OF_DAY, 0)
-        .toFormatter();
+    final DateTimeFormatter ofPattern = DateTimeFormatter.ofPattern(pattern, Locale.ROOT);
+
+    // Java APIs don't let you access which TemporalFields are supported directly
+    // from a DateTimeFormatter. Instead, we format LocalDateTime.now() using the
+    // pattern and parse it again into a TemporalAccessor - which allows us sneak
+    // a look into which temporal units are supported. Using parseUnresolved means
+    // that it won't expand the format into all supported inferred types (see
+    // documentation)
+    final String sample = ofPattern.format(LocalDateTime.now());
+    final TemporalAccessor now = ofPattern.parseUnresolved(sample, new ParsePosition(0));
+    final DateTimeFormatterBuilder formatBuilder = new DateTimeFormatterBuilder()
+        .appendPattern(pattern);
+
+    // We need to fill in defaults for any chrono field that is not supported that
+    // has a base unit greater than or equal to ChronoUnit.HOURS. Some fields can
+    // span multiple time units - for example, DAY_OF_YEAR spans (DAY, YEAR] which
+    // makes it exclusive with MONTH_OF_YEAR (which spans (MONTH, YEAR)). Constructing
+    // a range of what the format supports allows us to fill in the blanks
+    final RangeSet<ChronoUnit> supportedRange = TreeRangeSet.create();
+    for (ChronoField chronoField : ChronoField.values()) {
+      if (now.isSupported(chronoField)) {
+        // we chose closedOpen because we do not want to set defaults for the base limit
+        // but do want to set it for the range. For example, DAY_OF_YEAR should preclude
+        // us from setting defaults for DAY or MONTH, but we still set default for YEAR
+        supportedRange.add(Range.closedOpen(
+            (ChronoUnit) chronoField.getBaseUnit(),
+            (ChronoUnit) chronoField.getRangeUnit()));
+      }
+    }
+
+    LOG.debug("Supported range for pattern {} is: {}", pattern, supportedRange);
+    System.out.println("Supported range: " + supportedRange);
+
+    setDefault(formatBuilder, now, ChronoUnit.YEARS, ChronoField.YEAR_OF_ERA, 1970, supportedRange);
+    setDefault(formatBuilder, now, ChronoUnit.MONTHS, ChronoField.MONTH_OF_YEAR, 1, supportedRange);
+    setDefault(formatBuilder, now, ChronoUnit.DAYS, ChronoField.DAY_OF_MONTH, 1, supportedRange);
+    setDefault(formatBuilder, now, ChronoUnit.HOURS, ChronoField.HOUR_OF_DAY, 0, supportedRange);
+
+    formatter = formatBuilder.toFormatter();
   }
 
   public long parse(final String text) {
@@ -62,6 +120,28 @@ public class StringToTimestampParser {
         .withZoneSameInstant(ZoneId.systemDefault())
         .toLocalDateTime();
     return Timestamp.valueOf(dateTime).getTime();
+  }
+
+  private void setDefault(
+      final DateTimeFormatterBuilder formatterBuilder,
+      final TemporalAccessor sample,
+      final ChronoUnit chronoUnit,
+      final ChronoField defaultField,
+      final int defaultValue,
+      final RangeSet<ChronoUnit> supportedRange) {
+    if (supportedRange == null || !supportedRange.contains(chronoUnit)) {
+      // if it is not within the supported range, we can safely use
+      // the default field
+      formatterBuilder.parseDefaulting(defaultField, defaultValue);
+    } else {
+      final Optional<ChronoField> defaultingField = CHRONO_UNIT_TO_FIELDS.get(chronoUnit)
+          .stream()
+          .filter(sample::isSupported)
+          .findFirst();
+
+      defaultingField.ifPresent(
+          chronoField -> formatterBuilder.parseDefaulting(chronoField, defaultValue));
+    }
   }
 
 }

--- a/ksql-common/src/test/java/io/confluent/ksql/util/timestamp/StringTimestampExtractorTest.java
+++ b/ksql-common/src/test/java/io/confluent/ksql/util/timestamp/StringTimestampExtractorTest.java
@@ -51,7 +51,6 @@ public class StringTimestampExtractorTest {
   }
 
 
-  @SuppressWarnings("unchecked")
   @Test(expected = NullPointerException.class)
   public void shouldThrowOnNullFormat() {
     new StringTimestampExtractor(null, -1);

--- a/ksql-common/src/test/java/io/confluent/ksql/util/timestamp/StringToTimestampParserTest.java
+++ b/ksql-common/src/test/java/io/confluent/ksql/util/timestamp/StringToTimestampParserTest.java
@@ -1,0 +1,149 @@
+package io.confluent.ksql.util.timestamp;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.equalTo;
+
+import java.sql.Timestamp;
+import java.time.LocalDateTime;
+import org.junit.Test;
+
+public class StringToTimestampParserTest {
+
+  @Test
+  public void shouldParseFullTimestamp() {
+    // Given:
+    final StringToTimestampParser parser = new StringToTimestampParser("yyyy/MM/dd:HH");
+
+    // When:
+    final long ts = parser.parse("1605/11/05:12");
+
+    // Then:
+    assertThat(ts, equalTo(toMillis(LocalDateTime.of(1605, 11, 5, 12, 0))));
+  }
+
+  @Test
+  public void shouldParseFullTimestampWithMinutes() {
+    // Given:
+    final StringToTimestampParser parser = new StringToTimestampParser("yyyy/MM/dd HH:mm");
+
+    // When:
+    final long ts = parser.parse("1605/11/05 12:10");
+
+    // Then:
+    assertThat(ts, equalTo(toMillis(LocalDateTime.of(1605, 11, 5, 12, 10))));
+  }
+
+  @Test
+  public void shouldParseWithOptionalElements() {
+    // Given:
+    final StringToTimestampParser parser = new StringToTimestampParser("yyyy/MM/dd HH[:mm]");
+
+    // When:
+    final long ts = parser.parse("1605/11/05 12");
+
+    // Then:
+    assertThat(ts, equalTo(toMillis(LocalDateTime.of(1605, 11, 5, 12, 0))));
+  }
+
+  @Test
+  public void shouldParseWithOptionalDefaultedFields() {
+    // Given:
+    final StringToTimestampParser parser = new StringToTimestampParser("yyyy/MM[/dd]");
+
+    // When:
+    final long ts = parser.parse("1605/11/05");
+
+    // Then:
+    assertThat(ts, equalTo(toMillis(LocalDateTime.of(1605, 11, 5, 0, 0))));
+  }
+
+  @Test
+  public void shouldParseClockHourOfDay() {
+    // Given:
+    final StringToTimestampParser parser = new StringToTimestampParser("yyyy/MM/dd[ k]");
+
+    // When:
+    final long ts = parser.parse("1605/11/01 2");
+
+    // Then:
+    assertThat(ts, equalTo(toMillis(LocalDateTime.of(1605, 11, 1, 2, 0))));
+  }
+
+  @Test
+  public void shouldResolveDefaultsWithNoFormat() {
+    // Given:
+    final StringToTimestampParser parser = new StringToTimestampParser("");
+
+    // When:
+    final long ts = parser.parse("");
+
+    // Then:
+    assertThat(ts, equalTo(toMillis(LocalDateTime.of(1970, 1, 1, 0, 0))));
+  }
+
+  @Test
+  public void shouldResolveDefaultsWithPartialFormat() {
+    // Given:
+    final StringToTimestampParser parser = new StringToTimestampParser("yyyy");
+
+    // When:
+    final long ts = parser.parse("2010");
+
+    // Then:
+    assertThat(ts, equalTo(toMillis(LocalDateTime.of(2010, 1, 1, 0, 0))));
+  }
+
+  @Test
+  public void shouldResolveDefaultsWithGapFormat() {
+    // Given:
+    final StringToTimestampParser parser = new StringToTimestampParser("yyyy-dd");
+
+    // When:
+    final long ts = parser.parse("2010-10");
+
+    // Then:
+    assertThat(ts, equalTo(toMillis(LocalDateTime.of(2010, 1, 10, 0, 0))));
+  }
+
+  @Test
+  public void shouldNotResolveDefaultsForConflictingFormats() {
+    // Given:
+    final StringToTimestampParser parser = new StringToTimestampParser("yyyy-DDD");
+
+    // When:
+    final int fifthOfNovember = LocalDateTime.of(1605, 11, 5, 0, 0).getDayOfYear();
+    final long ts = parser.parse(String.format("%d-%3d", 1605, fifthOfNovember));
+
+    // Then:
+    assertThat(ts, equalTo(toMillis(LocalDateTime.of(1605, 11, 5, 0, 0))));
+  }
+
+  @Test
+  public void shouldResolveDefaultsForOptionalFields() {
+    // Given:
+    final StringToTimestampParser parser = new StringToTimestampParser("yyyy/MM[/dd]");
+
+    // When:
+    final long ts = parser.parse("1605/11");
+
+    // Then:
+    assertThat(ts, equalTo(toMillis(LocalDateTime.of(1605, 11, 1, 0, 0))));
+  }
+
+  @Test
+  public void shouldResolveDefaultsForClockHourOfDay() {
+    // Given:
+    final StringToTimestampParser parser = new StringToTimestampParser("yyyy/MM/dd[ k]");
+
+    // When:
+    final long ts = parser.parse("1605/11/01");
+
+    // Then:
+    assertThat(ts, equalTo(toMillis(LocalDateTime.of(1605, 11, 1, 0, 0))));
+  }
+
+  private long toMillis(LocalDateTime time) {
+    return Timestamp.valueOf(time).getTime();
+  }
+
+}


### PR DESCRIPTION
**Happy to take suggestions from anyone about a better way to do this, but I scoured the internet looking for a good way and couldn't find any...** See: https://stackoverflow.com/questions/49812003/java-time-datetimeformatter-parsing-with-flexible-fallback-values

### Description 

See #2499, which has an excellent description of the problem. Essentially if you specify a time unit that is within the same ChronoUnit range as one of our defaults but a different ChronoField, the java time parser doesn't know what to do with it.

This fix, which admittedly is rather ugly, fixes the issue by attempting to "understand" which fields are supported by the given format. To do this, it partially parses `LocalDateTime#now` and checks which fields are supported.

My confidence that this works for _everything_ is not high, but it seems to be better than the original code without obvious regressions.

### Testing done 
- Extensive unit testing

### Reviewer checklist
- [ ] Ensure docs are updated if necessary. (eg. if a user visible feature is being added or changed).
- [ ] Ensure relevant issues are linked (description should include text like "Fixes #<issue number>")

