### PR TITLE
Support more date formats (Fixes #2499)

### DIFF
--- a/ksql-common/src/test/java/io/confluent/ksql/util/timestamp/StringTimestampExtractorTest.java
+++ b/ksql-common/src/test/java/io/confluent/ksql/util/timestamp/StringTimestampExtractorTest.java
@@ -51,7 +51,6 @@ public class StringTimestampExtractorTest {
   }
 
 
-  @SuppressWarnings("unchecked")
   @Test(expected = NullPointerException.class)
   public void shouldThrowOnNullFormat() {
     new StringTimestampExtractor(null, -1);

--- a/ksql-common/src/test/java/io/confluent/ksql/util/timestamp/StringToTimestampParserTest.java
+++ b/ksql-common/src/test/java/io/confluent/ksql/util/timestamp/StringToTimestampParserTest.java
@@ -57,16 +57,40 @@ public class StringToTimestampParserTest {
   }
 
   @Test
-  public void shouldParseFullLocalDate() {
+  public void shouldParseFullLocalDateWithPartialSeconds() {
     // Given
-    final String format = "yyyy-MM-dd HH:mm";
-    final String timestamp = "1605-11-05 10:10";
+    final String format = "yyyy-MM-dd HH:mm:ss:SSS";
+    final String timestamp = "1605-11-05 10:10:10:010";
 
     // When
     ZonedDateTime ts = new StringToTimestampParser(format).parseZoned(timestamp, ZID);
 
     // Then
-    assertThat(ts, is(sameInstant(FIFTH_OF_NOVEMBER.withHour(10).withMinute(10))));
+    assertThat(ts, is(sameInstant(FIFTH_OF_NOVEMBER
+        .withHour(10)
+        .withMinute(10)
+        .withSecond(10)
+        .withNano(10_000_000))));
+  }
+
+  @Test
+  public void shouldParseFullLocalDateWithNanoSeconds() {
+    // Given
+    final String format = "yyyy-MM-dd HH:mm:ss:nnnnnnnnn";
+    // Note that there is an issue when resolving nanoseconds that occur below the
+    // micro-second granularity. Since this is a private API (the only one exposed
+    // converts it to millis) we can safely ignore it.
+    final String timestamp = "1605-11-05 10:10:10:001000000";
+
+    // When
+    ZonedDateTime ts = new StringToTimestampParser(format).parseZoned(timestamp, ZID);
+
+    // Then
+    assertThat(ts, is(sameInstant(FIFTH_OF_NOVEMBER
+        .withHour(10)
+        .withMinute(10)
+        .withSecond(10)
+        .withNano(1_000_000))));
   }
 
   @Test
@@ -98,8 +122,10 @@ public class StringToTimestampParserTest {
   @Test
   public void shouldParseFullLocalDateWithTimeZone() {
     // Given
-    final String format = "yyyy-MM-dd HH O";
-    final String timestamp = "1605-11-05 10 GMT+3";
+    // NOTE: a trailing space is required due to JDK bug, fixed in JDK 9b116
+    // https://bugs.openjdk.java.net/browse/JDK-8154050
+    final String format = "yyyy-MM-dd HH O ";
+    final String timestamp = "1605-11-05 10 GMT+3 ";
 
     // When
     ZonedDateTime ts = new StringToTimestampParser(format).parseZoned(timestamp, IGNORED);

--- a/ksql-common/src/test/java/io/confluent/ksql/util/timestamp/StringToTimestampParserTest.java
+++ b/ksql-common/src/test/java/io/confluent/ksql/util/timestamp/StringToTimestampParserTest.java
@@ -1,0 +1,197 @@
+package io.confluent.ksql.util.timestamp;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.equalTo;
+
+import java.sql.Timestamp;
+import java.time.LocalDateTime;
+import java.time.ZoneId;
+import java.time.ZonedDateTime;
+import org.junit.Test;
+
+public class StringToTimestampParserTest {
+
+  @Test
+  public void shouldParseFullTimestamp() {
+    // Given:
+    final StringToTimestampParser parser = new StringToTimestampParser("yyyy/MM/dd:HH");
+
+    // When:
+    final long ts = parser.parse("1605/11/05:12");
+
+    // Then:
+    assertThat(ts, equalTo(toMillis(LocalDateTime.of(1605, 11, 5, 12, 0))));
+  }
+
+  @Test
+  public void shouldParseFullTimestampWithMinutes() {
+    // Given:
+    final StringToTimestampParser parser = new StringToTimestampParser("yyyy/MM/dd HH:mm");
+
+    // When:
+    final long ts = parser.parse("1605/11/05 12:10");
+
+    // Then:
+    assertThat(ts, equalTo(toMillis(LocalDateTime.of(1605, 11, 5, 12, 10))));
+  }
+
+  @Test
+  public void shouldParseWithOptionalElements() {
+    // Given:
+    final StringToTimestampParser parser = new StringToTimestampParser("yyyy/MM/dd HH[:mm]");
+
+    // When:
+    final long ts = parser.parse("1605/11/05 12");
+
+    // Then:
+    assertThat(ts, equalTo(toMillis(LocalDateTime.of(1605, 11, 5, 12, 0))));
+  }
+
+  @Test
+  public void shouldParseWithOptionalDefaultedFields() {
+    // Given:
+    final StringToTimestampParser parser = new StringToTimestampParser("yyyy/MM[/dd]");
+
+    // When:
+    final long ts = parser.parse("1605/11/05");
+
+    // Then:
+    assertThat(ts, equalTo(toMillis(LocalDateTime.of(1605, 11, 5, 0, 0))));
+  }
+
+  @Test
+  public void shouldParseClockHourOfDay() {
+    // Given:
+    final StringToTimestampParser parser = new StringToTimestampParser("yyyy/MM/dd[ k]");
+
+    // When:
+    final long ts = parser.parse("1605/11/01 2");
+
+    // Then:
+    assertThat(ts, equalTo(toMillis(LocalDateTime.of(1605, 11, 1, 2, 0))));
+  }
+
+  @Test
+  public void shouldParseWithTimeZone() {
+    // Given:
+    final StringToTimestampParser parser = new StringToTimestampParser("yyyy/MM/dd HH z");
+
+    // When:
+    final long ts = parser.parse("1605/11/01 12 UTC");
+
+    // Then:
+    assertThat(ts, equalTo(
+        toMillis(ZonedDateTime.of(1605, 11, 1, 12, 0, 0, 0, ZoneId.of("UTC"))
+            .withZoneSameInstant(ZoneId.systemDefault())
+            .toLocalDateTime())));
+  }
+
+  @Test
+  public void shouldResolveDefaultsWithNoFormat() {
+    // Given:
+    final StringToTimestampParser parser = new StringToTimestampParser("");
+
+    // When:
+    final long ts = parser.parse("");
+
+    // Then:
+    assertThat(ts, equalTo(toMillis(LocalDateTime.of(1970, 1, 1, 0, 0))));
+  }
+
+  @Test
+  public void shouldResolveDefaultsWithPartialFormat() {
+    // Given:
+    final StringToTimestampParser parser = new StringToTimestampParser("yyyy");
+
+    // When:
+    final long ts = parser.parse("2010");
+
+    // Then:
+    assertThat(ts, equalTo(toMillis(LocalDateTime.of(2010, 1, 1, 0, 0))));
+  }
+
+  @Test
+  public void shouldResolveDefaultsWithGapFormat() {
+    // Given:
+    final StringToTimestampParser parser = new StringToTimestampParser("yyyy-dd");
+
+    // When:
+    final long ts = parser.parse("2010-10");
+
+    // Then:
+    assertThat(ts, equalTo(toMillis(LocalDateTime.of(2010, 1, 10, 0, 0))));
+  }
+
+  @Test
+  public void shouldAllowDayOfYear() {
+    // Given:
+    final StringToTimestampParser parser = new StringToTimestampParser("yyyy-DDD");
+
+    // When:
+    final int fifthOfNovember = LocalDateTime.of(1605, 11, 5, 0, 0).getDayOfYear();
+    final long ts = parser.parse(String.format("%d-%3d", 1605, fifthOfNovember));
+
+    // Then:
+    assertThat(ts, equalTo(toMillis(LocalDateTime.of(1605, 11, 5, 0, 0))));
+  }
+
+  @Test
+  public void shouldResolveDefaultsForOptionalFields() {
+    // Given:
+    final StringToTimestampParser parser = new StringToTimestampParser("yyyy/MM[/dd]");
+
+    // When:
+    final long ts = parser.parse("1605/11");
+
+    // Then:
+    assertThat(ts, equalTo(toMillis(LocalDateTime.of(1605, 11, 1, 0, 0))));
+  }
+
+  @Test
+  public void shouldResolveDefaultsForClockHourOfDay() {
+    // Given:
+    final StringToTimestampParser parser = new StringToTimestampParser("yyyy/MM/dd[ k]");
+
+    // When:
+    final long ts = parser.parse("1605/11/01");
+
+    // Then:
+    assertThat(ts, equalTo(toMillis(LocalDateTime.of(1605, 11, 1, 0, 0))));
+  }
+
+
+  @Test
+  public void shouldResolveDefaultsWithTimeZone() {
+    // Given:
+    final StringToTimestampParser parser = new StringToTimestampParser("yyyy/MM/dd[ HH] z");
+
+    // When:
+    final long ts = parser.parse("1605/11/01 UTC", ZoneId.of("UTC"));
+
+    // Then:
+    assertThat(ts, equalTo(
+        toMillis(ZonedDateTime.of(1605, 11, 1, 0, 0, 0, 0, ZoneId.of("UTC"))
+            .withZoneSameInstant(ZoneId.systemDefault())
+            .toLocalDateTime())));
+  }
+
+  @Test
+  public void shouldResolveDefaultsWithOptionalTimeZone() {
+    // Given:
+    final StringToTimestampParser parser = new StringToTimestampParser("yyyy/MM/dd[ HH][ z]");
+
+    // When:
+    final long ts = parser.parse("1605/11/01 10");
+
+    // Then:
+    assertThat(ts, equalTo(
+        toMillis(ZonedDateTime.of(1605, 11, 1, 10, 0, 0, 0, ZoneId.systemDefault())
+            .withZoneSameInstant(ZoneId.systemDefault())
+            .toLocalDateTime())));
+  }
+
+  private long toMillis(LocalDateTime time) {
+    return Timestamp.valueOf(time).getTime();
+  }
+
+}

--- a/ksql-engine/src/test/java/io/confluent/ksql/function/udf/datetime/StringToTimestampTest.java
+++ b/ksql-engine/src/test/java/io/confluent/ksql/function/udf/datetime/StringToTimestampTest.java
@@ -21,6 +21,7 @@ import static org.junit.Assert.assertThat;
 import io.confluent.ksql.function.KsqlFunctionException;
 import java.text.ParseException;
 import java.text.SimpleDateFormat;
+import java.util.TimeZone;
 import java.util.stream.IntStream;
 import org.junit.Assert;
 import org.junit.Before;
@@ -152,6 +153,7 @@ public class StringToTimestampTest {
     assertLikeSimpleDateFormat("2021-12-01 12 -0700", "yyyy-MM-dd HH X");
     assertLikeSimpleDateFormat("2021-12-01", "yyyy-MM-dd");
     assertLikeSimpleDateFormat("2021-12-01 PST", "yyyy-MM-dd z");
+    assertLikeSimpleDateFormat("2021-12-01 UTC", "yyyy-MM-dd z");
     assertLikeSimpleDateFormat("2021-12", "yyyy-MM");
     assertLikeSimpleDateFormat("2021", "yyyy");
     assertLikeSimpleDateFormat("12", "MM");

--- a/ksql-engine/src/test/java/io/confluent/ksql/function/udf/datetime/StringToTimestampTest.java
+++ b/ksql-engine/src/test/java/io/confluent/ksql/function/udf/datetime/StringToTimestampTest.java
@@ -21,7 +21,6 @@ import static org.junit.Assert.assertThat;
 import io.confluent.ksql.function.KsqlFunctionException;
 import java.text.ParseException;
 import java.text.SimpleDateFormat;
-import java.util.TimeZone;
 import java.util.stream.IntStream;
 import org.junit.Assert;
 import org.junit.Before;


### PR DESCRIPTION
### Description 
See #2499 for full description of the problem - when we use `parseDefaulting`, java's time modules force that ChronoField to be used (it doesn't know how to resolve defaults between `DAY_OF_YEAR` and `DAY_OF_MONTH`).

This PR reverses the approach (see [this stack overflow discussion](https://stackoverflow.com/questions/49812003/java-time-datetimeformatter-parsing-with-flexible-fallback-values)) by first constructing a time unit with defaults and then filing in anything that was parsed from the format instead of trying to "parse best" from an incomplete timestamp string.

Previously was #2520 

### Testing done 
- Unit tests

### Reviewer checklist
- [ ] Ensure docs are updated if necessary. (eg. if a user visible feature is being added or changed).
- [ ] Ensure relevant issues are linked (description should include text like "Fixes #<issue number>")

