### PR TITLE
KSQL-2261: Replace 'Apache Kafka' literals with token

### DIFF
--- a/docs/capacity-planning.rst
+++ b/docs/capacity-planning.rst
@@ -4,7 +4,7 @@
 KSQL Capacity Planning
 ======================
 
-KSQL is a simple and powerful tool for building streaming applications on top of Kafka. This guide helps you plan for provisioning your KSQL deployment and answers these questions:
+KSQL is a simple and powerful tool for building streaming applications on top of |ak|. This guide helps you plan for provisioning your KSQL deployment and answers these questions:
 
 - What server specification should I use to run KSQL?
 - Approximately how many KSQL server nodes do I need?

--- a/docs/faq.rst
+++ b/docs/faq.rst
@@ -7,7 +7,7 @@ Frequently Asked Questions
 What are the benefits of KSQL?
 ==============================
 
-KSQL allows you to query, read, write, and process data in Apache Kafka
+KSQL allows you to query, read, write, and process data in |ak|
 in real-time and at scale using intuitive SQL-like syntax. KSQL does not
 require proficiency with a programming language such as Java or Scala,
 and you don’t have to install a separate processing cluster technology.

--- a/docs/includes/ksql-supported-versions.rst
+++ b/docs/includes/ksql-supported-versions.rst
@@ -1,4 +1,4 @@
-You can use KSQL with compatible |cp| and Apache Kafka versions.
+You can use KSQL with compatible |cp| and |ak| versions.
 
 ==================== ================
 KSQL version         4.1

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -6,7 +6,7 @@ KSQL
 What Is KSQL?
 -------------
 
-KSQL is the streaming SQL engine for Apache Kafka®. It provides an easy-to-use yet powerful interactive SQL
+KSQL is the streaming SQL engine for |ak|. It provides an easy-to-use yet powerful interactive SQL
 interface for stream processing on Kafka, without the need to write code in a programming language such as Java or
 Python. KSQL is scalable, elastic, fault-tolerant, and real-time. It supports a wide range of streaming operations,
 including data filtering, transformations, aggregations, joins, windowing, and sessionization.

--- a/docs/installation/check-ksql-server-health.rst
+++ b/docs/installation/check-ksql-server-health.rst
@@ -39,7 +39,7 @@ Check a KSQL Server by using the REST API
 
 The KSQL REST API supports a "server info" request, which you access with a URL
 like ``http://<ksql-server-url>/info``. The ``/info`` endpoint returns the
-KSQL Server version, the Kafka cluster ID, and the service ID of the KSQL Server.
+KSQL Server version, the |ak| cluster ID, and the service ID of the KSQL Server.
 For more information, see :ref:`ksql-rest-api`.
 
 .. code:: bash

--- a/docs/installation/installing.rst
+++ b/docs/installation/installing.rst
@@ -8,7 +8,7 @@ Installing KSQL
 KSQL is a component of |cp| and the KSQL binaries are located at `https://www.confluent.io/download/ <https://www.confluent.io/download/>`_
 as a part of the |cp| bundle.
 
-KSQL must have access to a running Kafka cluster, which can be in your data center, in a public cloud, |ccloud|, etc.
+KSQL must have access to a running |ak| cluster, which can be in your data center, in a public cloud, |ccloud|, etc.
 
 Docker support
     You can deploy KSQL in Docker, however the current release does not yet ship with ready-to-use KSQL Docker images for

--- a/docs/installation/server-config/avro-schema.rst
+++ b/docs/installation/server-config/avro-schema.rst
@@ -10,7 +10,7 @@ manually define columns and data types in KSQL and from manual interaction with 
 Supported functionality
 ***********************
 
-KSQL currently supports Avro data in the Kafka message values.
+KSQL currently supports Avro data in the |ak| message values.
 
 The following functionality is not supported yet:
 

--- a/docs/installation/server-config/config-reference.rst
+++ b/docs/installation/server-config/config-reference.rst
@@ -20,7 +20,7 @@ These configurations control how Kafka Streams executes queries. These configura
 ksql.streams.auto.offset.reset
 ------------------------------
 
-Determines what to do when there is no initial offset in Kafka or if the current offset does not exist on the server. The
+Determines what to do when there is no initial offset in |ak| or if the current offset does not exist on the server. The
 default value in KSQL is ``latest``, which means all Kafka topics are read from the latest available offset. For example,
 to change it to earliest by using the KSQL command line:
 

--- a/docs/installation/server-config/security.rst
+++ b/docs/installation/server-config/security.rst
@@ -3,7 +3,7 @@
 Configuring Security for KSQL
 =============================
 
-KSQL supports many of the security features of both Apache Kafka and the |sr|.
+KSQL supports many of the security features of both |ak| and the |sr|.
 
 - KSQL supports Apache Kafka security features such as :ref:`SSL for encryption <kafka_ssl_encryption>`,
   :ref:`SASL for authentication <kafka_sasl_auth>`, and :ref:`authorization with ACLs <kafka_authorization>`.

--- a/docs/operations.rst
+++ b/docs/operations.rst
@@ -106,7 +106,7 @@ currently supported in KSQL.
 ------------------------------------------
 KSQL doesn’t clean up its internal topics?
 ------------------------------------------
-Make sure that your Kafka cluster is configured with ``delete.topic.enable=true``. For more information, see :cp-javadoc:`deleteTopics|clients/javadocs/org/apache/kafka/clients/admin/AdminClient.html`.
+Make sure that your |ak| cluster is configured with ``delete.topic.enable=true``. For more information, see :cp-javadoc:`deleteTopics|clients/javadocs/org/apache/kafka/clients/admin/AdminClient.html`.
 
 ----------------------------------------
 KSQL CLI doesn’t connect to KSQL server? 

--- a/docs/quickstart.rst
+++ b/docs/quickstart.rst
@@ -6,7 +6,7 @@ KSQL Quick Start
 
 |cp| Quick Start
     The :ref:`quickstart` is the easiest way to get you up and running with |cp| and KSQL. It will demonstrate a simple
-    workflow with topic management, monitoring, and using KSQL to write streaming queries against data in Kafka.
+    workflow with topic management, monitoring, and using KSQL to write streaming queries against data in |ak|.
 
 KSQL Tutorials and Examples
     The :ref:`KSQL tutorials and examples <ksql_tutorials>` page provides introductory and advanced KSQL usage scenarios

--- a/docs/syntax-reference.rst
+++ b/docs/syntax-reference.rst
@@ -19,7 +19,7 @@ Stream
 
 A stream is an unbounded sequence of structured data (“facts”). For example, we could have a stream of financial transactions
 such as “Alice sent $100 to Bob, then Charlie sent $50 to Bob”. Facts in a stream are immutable, which means new facts can
-be inserted to a stream, but existing facts can never be updated or deleted. Streams can be created from a Kafka topic or
+be inserted to a stream, but existing facts can never be updated or deleted. Streams can be created from an |ak| topic or
 derived from an existing stream. A stream’s underlying data is durably stored (persisted) within a Kafka topic on the Kafka
 brokers.
 

--- a/docs/troubleshoot-ksql.rst
+++ b/docs/troubleshoot-ksql.rst
@@ -31,8 +31,8 @@ Next, follow this checklist to diagnose why your query returns no results:
 * Does the data match the query predicate?
 * Are deserialization errors occurring while reading the data?
 
-Check the stream's underlying Kafka topic
-=========================================
+Check the stream's underlying |ak| topic
+========================================
 
 Use the DESCRIBE EXTENDED statement to verify the source topic for the stream.
 For example, if you have a ``pageviews`` stream on a Kafka topic named

--- a/docs/tutorials/basics-docker.rst
+++ b/docs/tutorials/basics-docker.rst
@@ -1,7 +1,7 @@
 .. _ksql_quickstart-docker:
 
-Writing Streaming Queries Against Kafka Using KSQL (Docker)
-===========================================================
+Writing Streaming Queries Against |ak| Using KSQL (Docker)
+==========================================================
 
 This tutorial demonstrates a simple workflow using KSQL to write streaming queries against messages in Kafka in a Docker
 environment.

--- a/docs/tutorials/basics-local.rst
+++ b/docs/tutorials/basics-local.rst
@@ -1,6 +1,6 @@
 .. _ksql_quickstart-local:
 
-Writing Streaming Queries Against Kafka Using KSQL (Local)
+Writing Streaming Queries Against |ak| Using KSQL (Local)
 ==========================================================
 
 This tutorial demonstrates a simple workflow using KSQL to write streaming queries against messages in Kafka.

--- a/docs/tutorials/examples.rst
+++ b/docs/tutorials/examples.rst
@@ -9,7 +9,7 @@ Creating streams
 ----------------
 
 Prerequisite:
-    The corresponding Kafka topics must already exist in your Kafka cluster.
+    The corresponding Kafka topics must already exist in your |ak| cluster.
 
 Create a stream with three columns on the Kafka topic that is named ``pageviews``.
 

--- a/docs/tutorials/generate-custom-test-data.rst
+++ b/docs/tutorials/generate-custom-test-data.rst
@@ -15,7 +15,7 @@ Also, you can generate data from a few simple, predefined schemas.
 **Prerequisites:** 
 
 - :ref:`Confluent Platform <installation>` is installed and running.
-  This installation includes a Kafka broker, KSQL, |c3-short|, |zk|,
+  This installation includes an |ak| broker, KSQL, |c3-short|, |zk|,
   Schema Registry, REST Proxy, and Kafka Connect.
 - Java: Minimum version 1.8. Install Oracle Java JRE or JDK >= 1.8 on your
   local machine.

--- a/docs/tutorials/index.rst
+++ b/docs/tutorials/index.rst
@@ -15,7 +15,7 @@ KSQL Tutorials and Examples
 KSQL Basics
 ***********
 
-This tutorial demonstrates a simple workflow using KSQL to write streaming queries against messages in Kafka.
+This tutorial demonstrates a simple workflow using KSQL to write streaming queries against messages in |ak|.
 
 Get started with these instructions:
 


### PR DESCRIPTION
For the first use of "Kafka" on a page, per new [Naming Guidelines](https://www.confluent.io/apache-guidelines#naming_guidelines).