### PR TITLE
PRINT now respects auto.offset.reset in CLI (fixes #791)

### DIFF
--- a/ksql-rest-app/src/main/java/io/confluent/ksql/rest/server/resources/streaming/StreamedQueryResource.java
+++ b/ksql-rest-app/src/main/java/io/confluent/ksql/rest/server/resources/streaming/StreamedQueryResource.java
@@ -132,7 +132,9 @@ public class StreamedQueryResource {
       }
 
       if (statement.getStatement() instanceof PrintTopic) {
-        return handlePrintTopic(request, (PreparedStatement<PrintTopic>) statement);
+        return handlePrintTopic(
+            request.getStreamsProperties(),
+            (PreparedStatement<PrintTopic>) statement);
       }
 
       return Errors.badRequest(String.format(
@@ -169,7 +171,7 @@ public class StreamedQueryResource {
   }
 
   private Response handlePrintTopic(
-      final KsqlRequest request,
+      final Map<String, Object> streamProperties,
       final PreparedStatement<PrintTopic> statement
   ) {
     final PrintTopic printTopic = statement.getStatement();
@@ -189,7 +191,7 @@ public class StreamedQueryResource {
 
     final Map<String, Object> propertiesWithOverrides =
         new HashMap<>(ksqlConfig.getKsqlStreamConfigProps());
-    propertiesWithOverrides.putAll(request.getStreamsProperties());
+    propertiesWithOverrides.putAll(streamProperties);
 
     final TopicStreamWriter topicStreamWriter = new TopicStreamWriter(
         serviceContext.getSchemaRegistryClient(),

--- a/ksql-rest-app/src/main/java/io/confluent/ksql/rest/server/resources/streaming/StreamedQueryResource.java
+++ b/ksql-rest-app/src/main/java/io/confluent/ksql/rest/server/resources/streaming/StreamedQueryResource.java
@@ -36,6 +36,7 @@ import io.confluent.ksql.util.QueryMetadata;
 import io.confluent.ksql.util.QueuedQueryMetadata;
 import io.confluent.ksql.version.metrics.ActivenessRegistrar;
 import java.time.Duration;
+import java.util.HashMap;
 import java.util.Map;
 import java.util.Objects;
 import javax.ws.rs.Consumes;
@@ -131,7 +132,7 @@ public class StreamedQueryResource {
       }
 
       if (statement.getStatement() instanceof PrintTopic) {
-        return handlePrintTopic((PreparedStatement<PrintTopic>) statement);
+        return handlePrintTopic(request, (PreparedStatement<PrintTopic>) statement);
       }
 
       return Errors.badRequest(String.format(
@@ -167,7 +168,10 @@ public class StreamedQueryResource {
     return Response.ok().entity(queryStreamWriter).build();
   }
 
-  private Response handlePrintTopic(final PreparedStatement<PrintTopic> statement) {
+  private Response handlePrintTopic(
+      final KsqlRequest request,
+      final PreparedStatement<PrintTopic> statement
+  ) {
     final PrintTopic printTopic = statement.getStatement();
     final String topicName = printTopic.getTopic().toString();
 
@@ -183,9 +187,13 @@ public class StreamedQueryResource {
               topicName)));
     }
 
+    final Map<String, Object> propertiesWithOverrides =
+        new HashMap<>(ksqlConfig.getKsqlStreamConfigProps());
+    propertiesWithOverrides.putAll(request.getStreamsProperties());
+
     final TopicStreamWriter topicStreamWriter = new TopicStreamWriter(
         serviceContext.getSchemaRegistryClient(),
-        ksqlConfig.getKsqlStreamConfigProps(),
+        propertiesWithOverrides,
         printTopic,
         disconnectCheckInterval
     );


### PR DESCRIPTION
### Description 
There was inconsistent behavior with PRINT TOPIC. Now if you `SET 'auto.offset.reset'='earliest'`, the command will show the topics from the beginning! Full behavior described in #791.

### Testing done 
- Local testing - the below was done without producing anything to the topic

```
                  ===========================================
                  =        _  __ _____  ____  _             =
                  =       | |/ // ____|/ __ \| |            =
                  =       | ' /| (___ | |  | | |            =
                  =       |  <  \___ \| |  | | |            =
                  =       | . \ ____) | |__| | |____        =
                  =       |_|\_\_____/ \___\_\______|       =
                  =                                         =
                  =  Streaming SQL Engine for Apache Kafka® =
                  ===========================================

Copyright 2017-2018 Confluent Inc.

CLI v5.3.0-SNAPSHOT, Server v5.3.0-SNAPSHOT located at http://localhost:8088

Having trouble? Type 'help' (case-insensitive) for a rundown of how things work!

ksql> PRINT 'user_topic_json';
^CTopic printing ceased
ksql> SET 'auto.offset.reset' = 'earliest';
Successfully changed local property 'auto.offset.reset' to 'earliest'. Use the UNSET command to revert your change.
ksql> PRINT 'user_topic_json' LIMIT 3;
Format:JSON
{"ROWTIME":1551918748665,"ROWKEY":"User_2","registertime":1491774580508,"userid":"User_2","regionid":"Region_2","gender":"OTHER"}
{"ROWTIME":1551918748697,"ROWKEY":"User_4","registertime":1510919697947,"userid":"User_4","regionid":"Region_5","gender":"FEMALE"}
{"ROWTIME":1551918749465,"ROWKEY":"User_4","registertime":1509819999068,"userid":"User_4","regionid":"Region_9","gender":"OTHER"}
ksql>
```

### Reviewer checklist
- [ ] Ensure docs are updated if necessary. (eg. if a user visible feature is being added or changed).
- [ ] Ensure relevant issues are linked (description should include text like "Fixes #<issue number>")

