### PR TITLE
Adds a name to map schemas (#2504)

### DIFF
--- a/ksql-common/src/main/java/io/confluent/ksql/util/KsqlConfig.java
+++ b/ksql-common/src/main/java/io/confluent/ksql/util/KsqlConfig.java
@@ -85,6 +85,9 @@ public class KsqlConfig extends AbstractConfig implements Cloneable {
       + "'CREATE STREAM S AS ...' will create a topic 'thing-S', where as the statement "
       + "'CREATE STREAM S WITH(KAFKA_TOPIC = 'foo') AS ...' will create a topic 'foo'.";
 
+  public static final String KSQL_USE_NAMED_AVRO_MAPS = "ksql.avro.maps.named";
+  private static final String KSQL_USE_NAMED_AVRO_MAPS_DOC = "";
+
   public static final String
       defaultSchemaRegistryUrl = "http://localhost:8081";
 
@@ -113,7 +116,16 @@ public class KsqlConfig extends AbstractConfig implements Cloneable {
               ConfigDef.Importance.MEDIUM,
               "Suffix for state store names in Tables. For instance if the suffix is "
                   + "_ksql_statestore the state "
-                  + "store name would be ksql_query_1_ksql_statestore _ksql_statestore "));
+                  + "store name would be ksql_query_1_ksql_statestore _ksql_statestore "),
+          new CompatibiltyBreakingConfigDef(
+              KSQL_USE_NAMED_AVRO_MAPS,
+              ConfigDef.Type.BOOLEAN,
+              false,
+              false,
+              ConfigDef.Importance.LOW,
+              KSQL_USE_NAMED_AVRO_MAPS_DOC
+          )
+  );
 
   private static class CompatibiltyBreakingConfigDef {
     private final String name;

--- a/ksql-engine/src/test/resources/query-validation-tests/multiple-avro-maps.json
+++ b/ksql-engine/src/test/resources/query-validation-tests/multiple-avro-maps.json
@@ -1,0 +1,25 @@
+{
+  "comments": [
+    "You can specify multiple statements per test case, i.e., to set up the various streams needed",
+    "for joins etc, but currently only the final topology will be verified. This should be enough",
+    "for most tests as we can simulate the outputs from previous stages into the final stage. If we",
+    "take a modular approach to testing we can still verify that it all works correctly, i.e, if we",
+    "verify the output of a select or aggregate is correct, we can use simulated output to feed into",
+    "a join or another aggregate."
+  ],
+  "tests": [
+    {
+      "name": "project multiple avro maps",
+      "statements": [
+        "CREATE STREAM TEST (M1 MAP<STRING, INT>, M2 MAP<STRING, STRING>) WITH (kafka_topic='test_topic', value_format='AVRO');",
+        "CREATE STREAM SINK as SELECT * FROM test;"
+      ],
+      "inputs": [
+        {"topic": "test_topic", "key": 0, "value": {"M1": {"K1": 123}, "M2": {"K2": "FOO"}}, "timestamp": 0}
+      ],
+      "outputs": [
+        {"topic": "SINK", "key": 0, "value": {"M1": {"K1": 123}, "M2": {"K2": "FOO"}}, "timestamp": 0}
+      ]
+    }
+  ]
+}

--- a/ksql-serde/src/main/java/io/confluent/ksql/serde/avro/AvroDataTranslator.java
+++ b/ksql-serde/src/main/java/io/confluent/ksql/serde/avro/AvroDataTranslator.java
@@ -38,10 +38,11 @@ public class AvroDataTranslator implements DataTranslator {
   private final Schema ksqlSchema;
   private final Schema avroCompatibleSchema;
 
-  public AvroDataTranslator(final Schema ksqlSchema) {
+  public AvroDataTranslator(final Schema ksqlSchema, final boolean useNamedMaps) {
     this.ksqlSchema = ksqlSchema;
     this.avroCompatibleSchema = buildAvroCompatibleSchema(
         ksqlSchema,
+        useNamedMaps,
         new TypeNameGenerator());
     this.innerTranslator = new ConnectDataTranslator(avroCompatibleSchema);
   }
@@ -99,15 +100,17 @@ public class AvroDataTranslator implements DataTranslator {
     }
   }
 
-  private String avroCompatibleFieldName(final Field field) {
+  private static String avroCompatibleFieldName(final Field field) {
     // Currently the only incompatible field names expected are fully qualified
     // column identifiers. Once quoted identifier support is introduced we will
     // need to implement something more generic here.
     return field.name().replace(".", "_");
   }
 
-  private Schema buildAvroCompatibleSchema(final Schema schema,
-                                           final TypeNameGenerator typeNameGenerator) {
+  private static Schema buildAvroCompatibleSchema(
+      final Schema schema,
+      final boolean useNamedMaps,
+      final TypeNameGenerator typeNameGenerator) {
     final SchemaBuilder schemaBuilder;
     switch (schema.type()) {
       default:
@@ -120,19 +123,26 @@ public class AvroDataTranslator implements DataTranslator {
         for (final Field f : schema.fields()) {
           schemaBuilder.field(
               avroCompatibleFieldName(f),
-              buildAvroCompatibleSchema(f.schema(), typeNameGenerator.with(f.name())));
+              buildAvroCompatibleSchema(
+                  f.schema(), useNamedMaps, typeNameGenerator.with(f.name())));
         }
         break;
       case ARRAY:
         schemaBuilder = SchemaBuilder.array(
-            buildAvroCompatibleSchema(schema.valueSchema(), typeNameGenerator));
+            buildAvroCompatibleSchema(
+                schema.valueSchema(), useNamedMaps, typeNameGenerator));
         break;
       case MAP:
-        schemaBuilder = SchemaBuilder.map(
+        final SchemaBuilder mapSchemaBuilder = SchemaBuilder.map(
             buildAvroCompatibleSchema(schema.keySchema(),
+                useNamedMaps,
                 typeNameGenerator.with(TypeNameGenerator.MAP_KEY_NAME)),
             buildAvroCompatibleSchema(schema.valueSchema(),
-                typeNameGenerator.with(TypeNameGenerator.MAP_VALUE_NAME)));
+                useNamedMaps,
+                typeNameGenerator.with(TypeNameGenerator.MAP_VALUE_NAME))
+        );
+        schemaBuilder = useNamedMaps
+          ? mapSchemaBuilder.name(typeNameGenerator.name()) : mapSchemaBuilder;
         break;
     }
     if (schema.isOptional()) {

--- a/ksql-serde/src/main/java/io/confluent/ksql/serde/avro/KsqlAvroTopicSerDe.java
+++ b/ksql-serde/src/main/java/io/confluent/ksql/serde/avro/KsqlAvroTopicSerDe.java
@@ -71,12 +71,19 @@ public class KsqlAvroTopicSerDe extends KsqlTopicSerDe {
         ? schemaMaybeWithSource : SchemaUtil.getSchemaWithNoAlias(schemaMaybeWithSource);
     final Serializer<GenericRow> genericRowSerializer = new ThreadLocalSerializer(
         () -> new KsqlConnectSerializer(
-            new AvroDataTranslator(schema),
+            new AvroDataTranslator(
+                schema,
+                ksqlConfig.getBoolean(KsqlConfig.KSQL_USE_NAMED_AVRO_MAPS)
+            ),
             getAvroConverter(schemaRegistryClientFactory.get(), ksqlConfig)));
     final Deserializer<GenericRow> genericRowDeserializer = new ThreadLocalDeserializer(
         () -> new KsqlConnectDeserializer(
             getAvroConverter(schemaRegistryClientFactory.get(), ksqlConfig),
-            new AvroDataTranslator(schema))
+            new AvroDataTranslator(
+                schema,
+                ksqlConfig.getBoolean(KsqlConfig.KSQL_USE_NAMED_AVRO_MAPS)
+            )
+        )
     );
     return Serdes.serdeFrom(genericRowSerializer, genericRowDeserializer);
   }

--- a/ksql-serde/src/test/java/io/confluent/ksql/serde/avro/AvroDataTranslatorTest.java
+++ b/ksql-serde/src/test/java/io/confluent/ksql/serde/avro/AvroDataTranslatorTest.java
@@ -22,7 +22,9 @@ public class AvroDataTranslatorTest {
         .optional()
         .build();
 
-    final AvroDataTranslator dataTranslator = new AvroDataTranslator(schema);
+    final AvroDataTranslator dataTranslator = new AvroDataTranslator(
+        schema,
+        true);
     final GenericRow ksqlRow = new GenericRow(ImmutableList.of(123));
     final Struct struct = dataTranslator.toConnectRow(ksqlRow);
 
@@ -72,7 +74,9 @@ public class AvroDataTranslatorTest {
     final Struct structInnerStruct = new Struct(structInner)
         .put("STRUCT_INNER", "foo");
 
-    final AvroDataTranslator dataTranslator = new AvroDataTranslator(schema);
+    final AvroDataTranslator dataTranslator = new AvroDataTranslator(
+        schema,
+        true);
     final GenericRow ksqlRow = new GenericRow(
         ImmutableList.of(arrayInnerStruct),
         ImmutableMap.of("bar", mapInnerStruct),
@@ -136,7 +140,9 @@ public class AvroDataTranslatorTest {
         .optional()
         .build();
 
-    final AvroDataTranslator dataTranslator = new AvroDataTranslator(schema);
+    final AvroDataTranslator dataTranslator = new AvroDataTranslator(
+        schema,
+        true);
     final GenericRow ksqlRow = new GenericRow(Collections.singletonList(null));
     final Struct struct = dataTranslator.toConnectRow(ksqlRow);
 
@@ -153,7 +159,9 @@ public class AvroDataTranslatorTest {
         .optional()
         .build();
 
-    final AvroDataTranslator dataTranslator = new AvroDataTranslator(schema);
+    final AvroDataTranslator dataTranslator = new AvroDataTranslator(
+        schema,
+        true);
     final GenericRow ksqlRow = new GenericRow(Collections.singletonList(123L));
     final Struct struct = dataTranslator.toConnectRow(ksqlRow);
 

--- a/ksql-serde/src/test/java/io/confluent/ksql/serde/avro/KsqlGenericRowAvroSerializerTest.java
+++ b/ksql-serde/src/test/java/io/confluent/ksql/serde/avro/KsqlGenericRowAvroSerializerTest.java
@@ -21,6 +21,7 @@ import static org.junit.Assert.assertThat;
 
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
+import io.confluent.connect.avro.AvroData;
 import io.confluent.kafka.schemaregistry.client.MockSchemaRegistryClient;
 import io.confluent.kafka.schemaregistry.client.SchemaRegistryClient;
 import io.confluent.kafka.serializers.KafkaAvroDeserializer;
@@ -34,7 +35,9 @@ import java.util.List;
 import java.util.Map;
 import org.apache.avro.generic.GenericData;
 import org.apache.avro.generic.GenericRecord;
+import org.apache.avro.generic.GenericRecordBuilder;
 import org.apache.avro.util.Utf8;
+import org.apache.kafka.common.serialization.Deserializer;
 import org.apache.kafka.common.serialization.Serde;
 import org.apache.kafka.common.serialization.Serializer;
 import org.apache.kafka.connect.data.Schema;
@@ -42,11 +45,14 @@ import org.apache.kafka.connect.data.SchemaBuilder;
 import org.apache.kafka.connect.data.Struct;
 import org.apache.kafka.connect.errors.DataException;
 import org.junit.Assert;
+import org.junit.Before;
 import org.junit.Test;
 
+@SuppressWarnings("unchecked")
 public class KsqlGenericRowAvroSerializerTest {
+  private final SchemaRegistryClient schemaRegistryClient = new MockSchemaRegistryClient();
 
-  final Schema schema = SchemaBuilder.struct()
+  private Schema schema = SchemaBuilder.struct()
         .field("ordertime".toUpperCase(), Schema.OPTIONAL_INT64_SCHEMA)
         .field("orderid".toUpperCase(), Schema.OPTIONAL_INT64_SCHEMA)
         .field("itemid".toUpperCase(), Schema.OPTIONAL_STRING_SCHEMA)
@@ -61,17 +67,31 @@ public class KsqlGenericRowAvroSerializerTest {
                 Schema.OPTIONAL_FLOAT64_SCHEMA).optional().build())
         .optional()
         .build();
+  private KsqlConfig ksqlConfig = new KsqlConfig(
+      ImmutableMap.of(KsqlConfig.KSQL_USE_NAMED_AVRO_MAPS, true)
+  );
+  private Serializer<GenericRow> serializer;
+  private Deserializer<GenericRow> deserializer;
+
+  @Before
+  public void setup() {
+    resetSerde();
+  }
+
+  private void resetSerde() {
+    final Serde<GenericRow> serde =
+        new KsqlAvroTopicSerDe().getGenericRowSerde(
+            schema,
+            ksqlConfig,
+            false,
+            () -> schemaRegistryClient
+        );
+    serializer = serde.serializer();
+    deserializer = serde.deserializer();
+  }
 
   @Test
   public void shouldSerializeRowCorrectly() {
-    final SchemaRegistryClient schemaRegistryClient = new MockSchemaRegistryClient();
-
-    final Serializer<GenericRow> serializer =
-        new KsqlAvroTopicSerDe().getGenericRowSerde(
-            schema, new KsqlConfig(Collections.emptyMap()), false,
-            () -> schemaRegistryClient
-        ).serializer();
-
     final List columns = Arrays.asList(
         1511897796092L, 1L, "item_1", 10.0, Arrays.asList(100.0),
         Collections.singletonMap("key1", 100.0));
@@ -100,16 +120,8 @@ public class KsqlGenericRowAvroSerializerTest {
 
   }
 
-
   @Test
   public void shouldSerializeRowWithNullCorrectly() {
-    final SchemaRegistryClient schemaRegistryClient = new MockSchemaRegistryClient();
-    final Serializer<GenericRow> serializer =
-        new KsqlAvroTopicSerDe().getGenericRowSerde(
-            schema, new KsqlConfig(Collections.emptyMap()), false,
-            () -> schemaRegistryClient
-        ).serializer();
-
     final List columns = Arrays.asList(
         1511897796092L, 1L, null, 10.0, Arrays.asList(100.0),
         Collections.singletonMap("key1", 100.0));
@@ -142,29 +154,14 @@ public class KsqlGenericRowAvroSerializerTest {
   @Test
   @SuppressWarnings("unchecked")
   public void shouldSerializeRowWithNullValues() {
-    final SchemaRegistryClient schemaRegistryClient = new MockSchemaRegistryClient();
-    final Serializer<GenericRow> serializer =
-        new KsqlAvroTopicSerDe().getGenericRowSerde(
-            schema, new KsqlConfig(Collections.emptyMap()), false,
-            () -> schemaRegistryClient
-        ).serializer();
-
     final List columns = Arrays.asList(1511897796092L, 1L, "item_1", 10.0, null, null);
 
     final GenericRow genericRow = new GenericRow(columns);
     serializer.serialize("t1", genericRow);
-
   }
 
   @Test
   public void shouldFailForIncompatibleType() {
-    final SchemaRegistryClient schemaRegistryClient = new MockSchemaRegistryClient();
-    final Serializer<GenericRow> serializer =
-        new KsqlAvroTopicSerDe().getGenericRowSerde(
-            schema, new KsqlConfig(Collections.emptyMap()), false,
-            () -> schemaRegistryClient
-        ).serializer();
-
     final List columns = Arrays.asList(
         1511897796092L, 1L, "item_1", "10.0", Arrays.asList((Double)100.0),
         Collections.singletonMap("key1", 100.0));
@@ -187,24 +184,19 @@ public class KsqlGenericRowAvroSerializerTest {
                                             final Object ksqlValue,
                                             final org.apache.avro.Schema avroSchema,
                                             final Object avroValue) {
-    final Schema ksqlRecordSchema = SchemaBuilder.struct()
+    // Given:
+    schema = SchemaBuilder.struct()
         .field("field0", ksqlSchema)
         .build();
-
+    resetSerde();
     final GenericRow ksqlRecord = new GenericRow(ImmutableList.of(ksqlValue));
 
-    final SchemaRegistryClient schemaRegistryClient = new MockSchemaRegistryClient();
-    final Serde<GenericRow> serde =
-        new KsqlAvroTopicSerDe().getGenericRowSerde(
-            ksqlRecordSchema, new KsqlConfig(Collections.emptyMap()), false,
-            () -> schemaRegistryClient
-        );
+    // When:
+    final byte[] bytes = serializer.serialize("topic", ksqlRecord);
 
-    final byte[] bytes = serde.serializer().serialize("topic", ksqlRecord);
-
+    // Then:
     final KafkaAvroDeserializer deserializer = new KafkaAvroDeserializer(schemaRegistryClient);
     final GenericRecord avroRecord = (GenericRecord) deserializer.deserialize("topic", bytes);
-
     assertThat(avroRecord.getSchema().getNamespace(), equalTo(KsqlConstants.AVRO_SCHEMA_NAMESPACE));
     assertThat(avroRecord.getSchema().getName(), equalTo(KsqlConstants.AVRO_SCHEMA_NAME));
     assertThat(avroRecord.getSchema().getFields().size(), equalTo(1));
@@ -216,8 +208,7 @@ public class KsqlGenericRowAvroSerializerTest {
         equalTo(org.apache.avro.Schema.create(org.apache.avro.Schema.Type.NULL)));
     assertThat(field.schema().getTypes().get(1), equalTo(avroSchema));
     assertThat(avroRecord.get("field0"), equalTo(avroValue));
-
-    final GenericRow deserializedKsqlRecord = serde.deserializer().deserialize("topic", bytes);
+    final GenericRow deserializedKsqlRecord = this.deserializer.deserialize("topic", bytes);
     assertThat(deserializedKsqlRecord, equalTo(ksqlRecord));
   }
 
@@ -277,11 +268,62 @@ public class KsqlGenericRowAvroSerializerTest {
     );
   }
 
+  private org.apache.avro.Schema mapEntrySchema(
+      final String name,
+      final org.apache.avro.Schema valueSchema) {
+    return org.apache.avro.SchemaBuilder.record(name)
+        .namespace("io.confluent.ksql.avro_schemas")
+        .prop("connect.internal.type", "MapEntry")
+        .fields()
+        .name("key")
+        .type().unionOf().nullType().and().stringType().endUnion()
+        .nullDefault()
+        .name("value")
+        .type(valueSchema).withDefault(null)
+        .endRecord();
+  }
+
+  private org.apache.avro.Schema mapEntrySchema(final String name) {
+    return mapEntrySchema(
+        name,
+        org.apache.avro.SchemaBuilder.unionOf().nullType().and().longType().endUnion());
+  }
+
+  private org.apache.avro.Schema mapSchema(final org.apache.avro.Schema entrySchema) {
+    return org.apache.avro.SchemaBuilder.array().items(entrySchema);
+  }
+
+  private void shouldSerializeMap(final org.apache.avro.Schema avroSchema) {
+    // Given;
+    final Map<String, Long> value = ImmutableMap.of("foo", 123L);
+    final List<GenericRecord> avroValue = new LinkedList<>();
+    for (final Map.Entry<String, Long> entry : value.entrySet()) {
+      final GenericRecord record = new GenericData.Record(avroSchema.getElementType());
+      record.put("key", entry.getKey());
+      record.put("value", entry.getValue());
+      avroValue.add(record);
+    }
+
+    // Then:
+    shouldSerializeTypeCorrectly(
+        SchemaBuilder.map(Schema.OPTIONAL_STRING_SCHEMA, Schema.OPTIONAL_INT64_SCHEMA)
+            .optional()
+            .build(),
+        value,
+        avroSchema,
+        avroValue);
+  }
+
   @Test
-  public void shouldSerializeMap() {
-    final org.apache.avro.Schema entrySchema
-        = org.apache.avro.SchemaBuilder.record("MapEntry")
-        .namespace("io.confluent.connect.avro")
+  public void shouldSerializeMapWithName() {
+    final org.apache.avro.Schema avroSchema = mapSchema(
+        mapEntrySchema(KsqlConstants.AVRO_SCHEMA_NAMESPACE + ".KsqlDataSourceSchema_field0"));
+    shouldSerializeMap(avroSchema);
+  }
+
+  private org.apache.avro.Schema legacyMapEntrySchema() {
+    final String name = AvroData.NAMESPACE + "." + AvroData.MAP_ENTRY_TYPE_NAME;
+    return org.apache.avro.SchemaBuilder.record(name)
         .fields()
         .name("key")
         .type().unionOf().nullType().and().stringType().endUnion()
@@ -290,23 +332,62 @@ public class KsqlGenericRowAvroSerializerTest {
         .type().unionOf().nullType().and().longType().endUnion()
         .nullDefault()
         .endRecord();
-    final org.apache.avro.Schema avroSchema
-        = org.apache.avro.SchemaBuilder.array().items(entrySchema);
-    final Map<String, Long> value = ImmutableMap.of("foo", 123L);
-    final List<GenericRecord> avroValue = new LinkedList<>();
-    for (final Map.Entry<String, Long> entry : value.entrySet()) {
-      final GenericRecord record = new GenericData.Record(entrySchema);
-      record.put("key", entry.getKey());
-      record.put("value", entry.getValue());
-      avroValue.add(record);
-    }
-    shouldSerializeTypeCorrectly(
-        SchemaBuilder.map(Schema.OPTIONAL_STRING_SCHEMA, Schema.OPTIONAL_INT64_SCHEMA)
-            .optional()
-            .build(),
-        value,
-        avroSchema,
-        avroValue);
+  }
+
+  @Test
+  public void shouldSerializeMapWithoutNameIfDisabled() {
+    ksqlConfig = new KsqlConfig(
+        Collections.singletonMap(KsqlConfig.KSQL_USE_NAMED_AVRO_MAPS, false));
+    final org.apache.avro.Schema avroSchema = mapSchema(legacyMapEntrySchema());
+    shouldSerializeMap(avroSchema);
+  }
+
+  @Test
+  public void shouldSerializeMultipleMaps() {
+    final org.apache.avro.Schema avroInnerSchema0
+        = mapEntrySchema(
+            KsqlConstants.AVRO_SCHEMA_NAMESPACE + ".KsqlDataSourceSchema_field0_inner0");
+    final org.apache.avro.Schema avroInnerSchema1 =
+        mapEntrySchema(
+            KsqlConstants.AVRO_SCHEMA_NAMESPACE + ".KsqlDataSourceSchema_field0_inner1",
+            org.apache.avro.SchemaBuilder.unionOf().nullType().and().stringType().endUnion());
+    final org.apache.avro.Schema avroSchema =
+        org.apache.avro.SchemaBuilder.record("KsqlDataSourceSchema_field0")
+            .namespace("io.confluent.ksql.avro_schemas")
+            .fields()
+            .name("inner0").type().unionOf().nullType().and().array()
+            .items(avroInnerSchema0).endUnion().nullDefault()
+            .name("inner1").type().unionOf().nullType().and().array()
+            .items(avroInnerSchema1).endUnion().nullDefault()
+            .endRecord();
+
+    final Schema ksqlSchema = SchemaBuilder.struct()
+        .field(
+            "inner0",
+            SchemaBuilder.map(
+                Schema.OPTIONAL_STRING_SCHEMA,
+                Schema.OPTIONAL_INT64_SCHEMA).optional().build())
+        .field("inner1",
+            SchemaBuilder.map(
+                Schema.OPTIONAL_STRING_SCHEMA,
+                Schema.OPTIONAL_STRING_SCHEMA).optional().build())
+        .optional()
+        .build();
+
+    final Struct value = new Struct(ksqlSchema)
+        .put("inner0", ImmutableMap.of("foo", 123L))
+        .put("inner1", ImmutableMap.of("bar", "baz"));
+
+    final List<GenericRecord> avroInner0 = Collections.singletonList(
+        new GenericRecordBuilder(avroInnerSchema0).set("key", "foo").set("value", 123L).build());
+    final List<GenericRecord> avroInner1 = Collections.singletonList(
+        new GenericRecordBuilder(avroInnerSchema1).set("key", "bar").set("value", "baz").build());
+    final GenericRecord avroValue = new GenericRecordBuilder(avroSchema)
+        .set("inner0", avroInner0)
+        .set("inner1", avroInner1)
+        .build();
+
+    shouldSerializeTypeCorrectly(ksqlSchema, value, avroSchema, avroValue);
   }
 
   @Test
@@ -344,10 +425,11 @@ public class KsqlGenericRowAvroSerializerTest {
 
     final GenericRow ksqlRecord = new GenericRow(ImmutableList.of(123));
 
-    final SchemaRegistryClient schemaRegistryClient = new MockSchemaRegistryClient();
     final Serde<GenericRow> serde =
         new KsqlAvroTopicSerDe().getGenericRowSerde(
-            ksqlRecordSchema, new KsqlConfig(Collections.emptyMap()), false,
+            ksqlRecordSchema,
+            new KsqlConfig(Collections.emptyMap()),
+            false,
             () -> schemaRegistryClient
         );
 
@@ -371,10 +453,11 @@ public class KsqlGenericRowAvroSerializerTest {
 
     final GenericRow ksqlRecord = new GenericRow(ImmutableList.of(123));
 
-    final SchemaRegistryClient schemaRegistryClient = new MockSchemaRegistryClient();
     final Serde<GenericRow> serde =
         new KsqlAvroTopicSerDe().getGenericRowSerde(
-            ksqlRecordSchema, new KsqlConfig(Collections.emptyMap()), true,
+            ksqlRecordSchema,
+            new KsqlConfig(Collections.emptyMap()),
+            true,
             () -> schemaRegistryClient
         );
 


### PR DESCRIPTION
This patch adds names to map schemas when serializing avro. Internally,
the avro converter will use this name to name the map entry type. This
fixes the issue where, when a schema has multiple maps with different
types, avro errors out because the same name is used for different
map entry record schemas

This is a backport of #2504 . The main difference here is that we're
setting the current default of the compatibility-breaking config change
to false. This way users don't break compatibility when upgrading headless
mode across bugfix releases. If a user needs the fix then they can set the
config explicitly in their properties file.

### Testing done 
- Unit tests for avro serde
- QTT

### Reviewer checklist
- [ ] Ensure docs are updated if necessary. (eg. if a user visible feature is being added or changed).
- [ ] Ensure relevant issues are linked (description should include text like "Fixes #<issue number>")

