### PR TITLE
Fix bug to allow setting only one legacy sink property

### DIFF
--- a/ksql-engine/src/main/java/io/confluent/ksql/planner/plan/KsqlStructuredDataOutputNode.java
+++ b/ksql-engine/src/main/java/io/confluent/ksql/planner/plan/KsqlStructuredDataOutputNode.java
@@ -32,6 +32,7 @@ import io.confluent.ksql.structured.QueryContext;
 import io.confluent.ksql.structured.SchemaKStream;
 import io.confluent.ksql.structured.SchemaKTable;
 import io.confluent.ksql.util.KsqlConfig;
+import io.confluent.ksql.util.KsqlConstants;
 import io.confluent.ksql.util.KsqlException;
 import io.confluent.ksql.util.QueryIdGenerator;
 import io.confluent.ksql.util.QueryLoggerUtil;
@@ -292,10 +293,12 @@ public class KsqlStructuredDataOutputNode extends OutputNode {
   ) {
     final int partitions = (Integer) sinkProperties.getOrDefault(
         KsqlConfig.SINK_NUMBER_OF_PARTITIONS_PROPERTY,
-        ksqlConfig.getInt(KsqlConfig.SINK_NUMBER_OF_PARTITIONS_PROPERTY));
+        Optional.ofNullable(ksqlConfig.getInt(KsqlConfig.SINK_NUMBER_OF_PARTITIONS_PROPERTY))
+            .orElse(KsqlConstants.legacyDefaultSinkPartitionCount));
     final short replicas = (Short) sinkProperties.getOrDefault(
         KsqlConfig.SINK_NUMBER_OF_REPLICAS_PROPERTY,
-        ksqlConfig.getShort(KsqlConfig.SINK_NUMBER_OF_REPLICAS_PROPERTY));
+        Optional.ofNullable(ksqlConfig.getShort(KsqlConfig.SINK_NUMBER_OF_REPLICAS_PROPERTY))
+            .orElse(KsqlConstants.legacyDefaultSinkReplicaCount));
     return new SourceTopicProperties(partitions, replicas);
   }
 

--- a/ksql-engine/src/test/java/io/confluent/ksql/EndToEndEngineTestUtil.java
+++ b/ksql-engine/src/test/java/io/confluent/ksql/EndToEndEngineTestUtil.java
@@ -324,17 +324,20 @@ final class EndToEndEngineTestUtil {
     private final Optional<org.apache.avro.Schema> schema;
     private final SerdeSupplier serdeSupplier;
     private final int numPartitions;
+    private final short numReplicas;
 
     Topic(
         final String name,
         final Optional<org.apache.avro.Schema> schema,
         final SerdeSupplier serdeSupplier,
-        final int numPartitions
+        final int numPartitions,
+        final short numReplicas
     ) {
       this.name = Objects.requireNonNull(name, "name");
       this.schema = Objects.requireNonNull(schema, "schema");
       this.serdeSupplier = Objects.requireNonNull(serdeSupplier, "serdeSupplier");
       this.numPartitions = numPartitions;
+      this.numReplicas = numReplicas;
     }
 
     String getName() {
@@ -615,7 +618,7 @@ final class EndToEndEngineTestUtil {
 
     void initializeTopics(final ServiceContext serviceContext) {
       for (final Topic topic : topics) {
-        serviceContext.getTopicClient().createTopic(topic.getName(), topic.numPartitions, (short) 1);
+        serviceContext.getTopicClient().createTopic(topic.getName(), topic.numPartitions, topic.numReplicas);
 
         topic.getSchema()
             .ifPresent(schema -> {

--- a/ksql-engine/src/test/java/io/confluent/ksql/QueryTranslationTest.java
+++ b/ksql-engine/src/test/java/io/confluent/ksql/QueryTranslationTest.java
@@ -272,7 +272,7 @@ public class QueryTranslationTest {
     msgTopics.stream()
         .filter(topicName -> !topicsMap.containsKey(topicName))
         .forEach(topicName -> topicsMap
-            .put(topicName, (new Topic(topicName, Optional.empty(), defaultSerdeSupplier, 4))));
+            .put(topicName, (new Topic(topicName, Optional.empty(), defaultSerdeSupplier, 4, (short) 1))));
 
     return topicsMap;
   }
@@ -419,7 +419,12 @@ public class QueryTranslationTest {
       } else {
         avroSchema = Optional.empty();
       }
-      return new Topic(topicName, avroSchema, getSerdeSupplier(format), KsqlConstants.legacyDefaultSinkPartitionCount);
+      return new Topic(
+          topicName,
+          avroSchema,
+          getSerdeSupplier(format),
+          KsqlConstants.legacyDefaultSinkPartitionCount,
+          KsqlConstants.legacyDefaultSinkReplicaCount);
     };
 
     try {
@@ -460,8 +465,11 @@ public class QueryTranslationTest {
     final int numPartitions = node.has("partitions")
         ? node.get("partitions").intValue()
         : 1;
+    final short numReplicas = node.has("replicas")
+        ? node.get("replicas").shortValue()
+        : 1;
 
-    return new Topic(node.get("name").asText(), schema, serdeSupplier, numPartitions);
+    return new Topic(node.get("name").asText(), schema, serdeSupplier, numPartitions, numReplicas);
   }
 
   private static Record createRecordFromNode(

--- a/ksql-engine/src/test/java/io/confluent/ksql/SchemaTranslationTest.java
+++ b/ksql-engine/src/test/java/io/confluent/ksql/SchemaTranslationTest.java
@@ -156,15 +156,15 @@ public class SchemaTranslationTest {
 
     final Topic srcTopic;
     final Topic outputTopic
-        = new Topic(OUTPUT_TOPIC_NAME, Optional.empty(), new ValueSpecAvroSerdeSupplier(), 1);
+        = new Topic(OUTPUT_TOPIC_NAME, Optional.empty(), new ValueSpecAvroSerdeSupplier(), 1, (short) 1);
     final List<Record> inputRecords;
     final List<Record> outputRecords;
     if (node.has("input_records")) {
-      srcTopic = new Topic(TOPIC_NAME, Optional.of(avroSchema), new ValueSpecAvroSerdeSupplier(), 1);
+      srcTopic = new Topic(TOPIC_NAME, Optional.of(avroSchema), new ValueSpecAvroSerdeSupplier(), 1, (short) 1);
       inputRecords = loadRecords(srcTopic, node.get("input_records"));
       outputRecords = loadRecords(outputTopic, node.get("output_records"));
     } else {
-      srcTopic = new Topic(TOPIC_NAME, Optional.of(avroSchema), new AvroSerdeSupplier(), 1);
+      srcTopic = new Topic(TOPIC_NAME, Optional.of(avroSchema), new AvroSerdeSupplier(), 1, (short) 1);
       inputRecords = generateInputRecords(srcTopic, avroSchema);
       outputRecords = getOutputRecords(outputTopic, inputRecords, avroSchema);
     }

--- a/ksql-engine/src/test/resources/query-validation-tests/sink-partitions-replicas.json
+++ b/ksql-engine/src/test/resources/query-validation-tests/sink-partitions-replicas.json
@@ -52,6 +52,60 @@
       },
       "inputs": [{"topic": "input", "value": {"c1": 4}}],
       "outputs": [{"topic": "S", "value": {"C1": 4}}]
+    },
+    {
+      "name": "legacy default sink properties with only partitions set",
+      "statements": [
+        "CREATE STREAM TEST WITH (kafka_topic='input', value_format='AVRO');",
+        "CREATE STREAM S as SELECT * FROM test;"
+      ],
+      "topics": [
+        {
+          "name": "input",
+          "schema": {"name": "blah", "type": "record", "fields": [{"name": "c1", "type": "int"}]},
+          "format": "AVRO",
+          "partitions": 5,
+          "replicas" : 3
+        },
+        {
+          "name": "S",
+          "format": "AVRO",
+          "partitions": 3,
+          "replicas" : 1
+        }
+      ],
+      "properties": {
+        "ksql.sink.partitions": "3"
+      },
+      "inputs": [{"topic": "input", "value": {"c1": 4}}],
+      "outputs": [{"topic": "S", "value": {"C1": 4}}]
+    },
+    {
+      "name": "legacy default sink properties with only replicas set",
+      "statements": [
+        "CREATE STREAM TEST WITH (kafka_topic='input', value_format='AVRO');",
+        "CREATE STREAM S as SELECT * FROM test;"
+      ],
+      "topics": [
+        {
+          "name": "input",
+          "schema": {"name": "blah", "type": "record", "fields": [{"name": "c1", "type": "int"}]},
+          "format": "AVRO",
+          "partitions": 5,
+          "replicas" : 2
+        },
+        {
+          "name": "S",
+          "format": "AVRO",
+          "partitions": 4,
+          "replicas" : 3
+        }
+      ],
+      "properties": {
+        "ksql.sink.replicas": "3"
+      },
+      "inputs": [{"topic": "input", "value": {"c1": 4}}],
+      "outputs": [{"topic": "S", "value": {"C1": 4}}]
     }
   ]
 }


### PR DESCRIPTION
### Description 

Currently, if a user has either `ksql.sink.replicas` or `ksql.sink.partitions` set **but not both**, any CSAS/CTAS statement they run (without specifying `PARTITIONS` or `REPLICAS` in the `WITH` clause) results in a `NullPointerException` in `KsqlStructuredDataOutputNode#getSinkTopicPropertiesLegacyWay()`. This is a bug in backwards-compatibility if we plan to continue supporting the config properties `ksql.sink.replicas` and `ksql.sink.partitions`. If we don't plan to continue supporting them, we need to document this breakage in our upgrade notes, and also update our [recommended configurations for using KSQL with CCloud Kafka clusters](https://docs.confluent.io/current/cloud/connect/ksql-cloud-config.html) since currently those configurations cause CSAS/CTAS statements to fail.

This patch fixes the bug to provide full legacy support for `ksql.sink.replicas` and `ksql.sink.partitions`.

### Testing done 

Added unit tests and query translation tests.

### Reviewer checklist
- [ ] Ensure docs are updated if necessary. (eg. if a user visible feature is being added or changed).
- [ ] Ensure relevant issues are linked (description should include text like "Fixes #<issue number>")

