### PR TITLE
Escape quotes in string literals

### DIFF
--- a/ksql-engine/src/main/java/io/confluent/ksql/codegen/SqlToJavaVisitor.java
+++ b/ksql-engine/src/main/java/io/confluent/ksql/codegen/SqlToJavaVisitor.java
@@ -63,6 +63,7 @@ import java.util.List;
 import java.util.Optional;
 import java.util.function.Supplier;
 import java.util.stream.Collectors;
+import org.apache.commons.lang3.StringEscapeUtils;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.commons.lang3.text.StrSubstitutor;
 import org.apache.kafka.connect.data.Field;
@@ -146,7 +147,7 @@ public class SqlToJavaVisitor {
         final Void context
     ) {
       return new Pair<>(
-          "\"" + node.getValue().replace("\"", "\\\"") + "\"",
+          "\"" + StringEscapeUtils.escapeJava(node.getValue()) + "\"",
           Schema.OPTIONAL_STRING_SCHEMA);
     }
 

--- a/ksql-engine/src/main/java/io/confluent/ksql/codegen/SqlToJavaVisitor.java
+++ b/ksql-engine/src/main/java/io/confluent/ksql/codegen/SqlToJavaVisitor.java
@@ -145,7 +145,9 @@ public class SqlToJavaVisitor {
         final StringLiteral node,
         final Void context
     ) {
-      return new Pair<>("\"" + node.getValue() + "\"", Schema.OPTIONAL_STRING_SCHEMA);
+      return new Pair<>(
+          "\"" + node.getValue().replace("\"", "\\\"") + "\"",
+          Schema.OPTIONAL_STRING_SCHEMA);
     }
 
     @Override

--- a/ksql-engine/src/main/java/io/confluent/ksql/streams/JoinedFactory.java
+++ b/ksql-engine/src/main/java/io/confluent/ksql/streams/JoinedFactory.java
@@ -17,6 +17,7 @@ package io.confluent.ksql.streams;
 
 import io.confluent.ksql.util.KsqlConfig;
 import org.apache.kafka.common.serialization.Serde;
+import org.apache.kafka.streams.kstream.JoinWindows;
 import org.apache.kafka.streams.kstream.Joined;
 
 public interface JoinedFactory {

--- a/ksql-engine/src/main/java/io/confluent/ksql/streams/JoinedFactory.java
+++ b/ksql-engine/src/main/java/io/confluent/ksql/streams/JoinedFactory.java
@@ -17,7 +17,6 @@ package io.confluent.ksql.streams;
 
 import io.confluent.ksql.util.KsqlConfig;
 import org.apache.kafka.common.serialization.Serde;
-import org.apache.kafka.streams.kstream.JoinWindows;
 import org.apache.kafka.streams.kstream.Joined;
 
 public interface JoinedFactory {

--- a/ksql-engine/src/test/java/io/confluent/ksql/codegen/CodeGenRunnerTest.java
+++ b/ksql-engine/src/test/java/io/confluent/ksql/codegen/CodeGenRunnerTest.java
@@ -555,6 +555,18 @@ public class CodeGenRunnerTest {
     }
 
     @Test
+    public void shouldHandleStringLiteralWithCharactersThatMustBeEscaped() {
+        // Given:
+        final String query = "SELECT CONCAT(CONCAT('\\\"', 'foo'), '\\\"') FROM CODEGEN_TEST;";
+
+        // When:
+        final List<Object> columns = executeExpression(query, Collections.emptyMap());
+
+        // Then:
+        assertThat(columns, contains("\\\"foo\\\""));
+    }
+
+    @Test
     public void shouldHandleMathUdfs() {
         // Given:
         final String query =

--- a/ksql-engine/src/test/java/io/confluent/ksql/codegen/SqlToJavaVisitorTest.java
+++ b/ksql-engine/src/test/java/io/confluent/ksql/codegen/SqlToJavaVisitorTest.java
@@ -143,6 +143,16 @@ public class SqlToJavaVisitorTest {
   }
 
   @Test
+  public void shouldEscapeQuotesInStringLiteral() {
+    final Analysis analysis = analyzeQuery(
+        "SELECT '\"foo\"' FROM test1;", metaStore);
+
+    final String javaExpression = sqlToJavaVisitor
+        .process(analysis.getSelectExpressions().get(0));
+    assertThat(javaExpression, equalTo("\"\\\"foo\\\"\""));
+  }
+
+  @Test
   public void shouldGenerateCorrectCodeForComparisonWithNegativeNumbers() {
     final Analysis analysis = analyzeQuery(
         "SELECT * FROM test1 WHERE col3 > -10.0;", metaStore);

--- a/ksql-engine/src/test/java/io/confluent/ksql/codegen/SqlToJavaVisitorTest.java
+++ b/ksql-engine/src/test/java/io/confluent/ksql/codegen/SqlToJavaVisitorTest.java
@@ -153,6 +153,15 @@ public class SqlToJavaVisitorTest {
   }
 
   @Test
+  public void shouldEscapeQuotesInStringLiteralQuote() {
+    final Analysis analysis = analyzeQuery(
+        "SELECT '\\\"' FROM test1;", metaStore);
+    final String javaExpression = sqlToJavaVisitor
+        .process(analysis.getSelectExpressions().get(0));
+    assertThat(javaExpression, equalTo("\"\\\\\\\"\""));
+  }
+
+  @Test
   public void shouldGenerateCorrectCodeForComparisonWithNegativeNumbers() {
     final Analysis analysis = analyzeQuery(
         "SELECT * FROM test1 WHERE col3 > -10.0;", metaStore);

--- a/ksql-engine/src/test/resources/query-validation-tests/project-filter.json
+++ b/ksql-engine/src/test/resources/query-validation-tests/project-filter.json
@@ -24,6 +24,19 @@
       ]
     },
     {
+      "name": "project string with embedded code",
+      "statements": [
+        "CREATE STREAM TEST (ID bigint) WITH (kafka_topic='test_topic', value_format='DELIMITED', key='ID');",
+        "CREATE STREAM S1 as SELECT '\" + new java.util.function.Supplier<String>(){public String get() {return \"boom\";}}.get() + \"' as x  FROM test;"
+      ],
+      "inputs": [
+        {"topic": "test_topic", "key": 0, "value": "0"}
+      ],
+      "outputs": [
+        {"topic": "S1", "key": 0, "value": "\"\"\" + new java.util.function.Supplier<String>(){public String get() {return \"\"boom\"\";}}.get() + \"\"\""}
+      ]
+    },
+    {
       "name": "Json Map filter",
       "statements": [
         "CREATE STREAM TEST (ID bigint, THING MAP<VARCHAR, VARCHAR>) WITH (kafka_topic='test_topic', value_format='JSON');",


### PR DESCRIPTION
### Description 

This patch changes SqlToJavaVisitor to escape quotes in string literals. This
protects code gen against java code injection attacks. The patch also includes
a query-validation-test that demonstrates how one might inject java code

### Testing done 
unit test + qvt

### Reviewer checklist
- [ ] Ensure docs are updated if necessary. (eg. if a user visible feature is being added or changed).
- [ ] Ensure relevant issues are linked (description should include text like "Fixes #<issue number>")

