### PR TITLE
Added docs for sink topic partitions and replica defaults.

### DIFF
--- a/docs/developer-guide/syntax-reference.rst
+++ b/docs/developer-guide/syntax-reference.rst
@@ -446,12 +446,18 @@ The WITH clause for the result supports the following properties:
 |                         | set, then the format of the input stream/table is used.                                              |
 +-------------------------+------------------------------------------------------------------------------------------------------+
 | PARTITIONS              | The number of partitions in the backing topic. If this property is not set, then the number          |
-|                         | of partitions is taken from the value of the ``ksql.sink.partitions`` property, which                |
-|                         | defaults to four partitions. The ``ksql.sink.partitions`` property can be set in the                 |
-|                         | properties file the KSQL server is started with, or by using the ``SET`` statement.                  |
+|                         | of partitions of the input stream/table will be used. In the Join queries the properties would       |
+|                         | come from the left hand side stream/table.                                                           |
+|                         | For KSQL 5.2 and earlier, if the property is not set, the value of the ``ksql.sink.partitions``      |
+|                         | property, which defaults to four partitions, will be used. The ``ksql.sink.partitions`` property can |
+|                         | be set in the properties file the KSQL server is started with, or by using the ``SET`` statement.    |
 +-------------------------+------------------------------------------------------------------------------------------------------+
 | REPLICAS                | The replication factor for the topic. If this property is not set, then the number of                |
-|                         | replicas of the input stream or table will be used.                                                  |
+|                         | replicas of the input stream or table will be used. In the Join queries the properties would         |
+|                         | come from the left hand side stream/table.                                                           |
+|                         | For KSQL 5.2 and earlier, if the REPLICAS is not set, the value of the ``ksql.sink.replicas``        |
+|                         | property, which defaults to one replica, will be used. The ``ksql.sink.replicas`` property can       |
+|                         | be set in the properties file the KSQL server is started with, or by using the ``SET`` statement.    |
 +-------------------------+------------------------------------------------------------------------------------------------------+
 | TIMESTAMP               | Sets a field within this stream's schema to be used as the default source of ``ROWTIME`` for         |
 |                         | any downstream queries. Downstream queries that use time-based operations, such as windowing,        |

--- a/docs/developer-guide/syntax-reference.rst
+++ b/docs/developer-guide/syntax-reference.rst
@@ -446,15 +446,15 @@ The WITH clause for the result supports the following properties:
 |                         | set, then the format of the input stream/table is used.                                              |
 +-------------------------+------------------------------------------------------------------------------------------------------+
 | PARTITIONS              | The number of partitions in the backing topic. If this property is not set, then the number          |
-|                         | of partitions of the input stream/table will be used. In the Join queries the properties would       |
-|                         | come from the left hand side stream/table.                                                           |
+|                         | of partitions of the input stream/table will be used. In join queries, the property values are taken |
+|                         | from the left-side stream or table.                                                                  |
 |                         | For KSQL 5.2 and earlier, if the property is not set, the value of the ``ksql.sink.partitions``      |
 |                         | property, which defaults to four partitions, will be used. The ``ksql.sink.partitions`` property can |
 |                         | be set in the properties file the KSQL server is started with, or by using the ``SET`` statement.    |
 +-------------------------+------------------------------------------------------------------------------------------------------+
 | REPLICAS                | The replication factor for the topic. If this property is not set, then the number of                |
-|                         | replicas of the input stream or table will be used. In the Join queries the properties would         |
-|                         | come from the left hand side stream/table.                                                           |
+|                         | replicas of the input stream or table will be used. In join queries, the property values are take    |
+|                         | from the left-side stream or table.                                                                  |
 |                         | For KSQL 5.2 and earlier, if the REPLICAS is not set, the value of the ``ksql.sink.replicas``        |
 |                         | property, which defaults to one replica, will be used. The ``ksql.sink.replicas`` property can       |
 |                         | be set in the properties file the KSQL server is started with, or by using the ``SET`` statement.    |

--- a/docs/developer-guide/syntax-reference.rst
+++ b/docs/developer-guide/syntax-reference.rst
@@ -453,7 +453,7 @@ The WITH clause for the result supports the following properties:
 |                         | be set in the properties file the KSQL server is started with, or by using the ``SET`` statement.    |
 +-------------------------+------------------------------------------------------------------------------------------------------+
 | REPLICAS                | The replication factor for the topic. If this property is not set, then the number of                |
-|                         | replicas of the input stream or table will be used. In join queries, the property values are take    |
+|                         | replicas of the input stream or table will be used. In join queries, the property values are taken   |
 |                         | from the left-side stream or table.                                                                  |
 |                         | For KSQL 5.2 and earlier, if the REPLICAS is not set, the value of the ``ksql.sink.replicas``        |
 |                         | property, which defaults to one replica, will be used. The ``ksql.sink.replicas`` property can       |
@@ -533,12 +533,18 @@ The WITH clause supports the following properties:
 |                         | set, then the format of the input stream or table is used.                                           |
 +-------------------------+------------------------------------------------------------------------------------------------------+
 | PARTITIONS              | The number of partitions in the backing topic. If this property is not set, then the number          |
-|                         | of partitions is taken from the value of the ``ksql.sink.partitions`` property, which                |
-|                         | defaults to four partitions. The ``ksql.sink.partitions`` property can be set in the                 |
-|                         | properties file the KSQL server is started with, or by using the ``SET`` statement.                  |
+|                         | of partitions of the input stream/table will be used. In join queries, the property values are taken |
+|                         | from the left-side stream or table.                                                                  |
+|                         | For KSQL 5.2 and earlier, if the property is not set, the value of the ``ksql.sink.partitions``      |
+|                         | property, which defaults to four partitions, will be used. The ``ksql.sink.partitions`` property can |
+|                         | be set in the properties file the KSQL server is started with, or by using the ``SET`` statement.    |
 +-------------------------+------------------------------------------------------------------------------------------------------+
 | REPLICAS                | The replication factor for the topic. If this property is not set, then the number of                |
-|                         | replicas of the input stream or table will be used.                                                  |
+|                         | replicas of the input stream or table will be used. In join queries, the property values are taken   |
+|                         | from the left-side stream or table.                                                                  |
+|                         | For KSQL 5.2 and earlier, if the REPLICAS is not set, the value of the ``ksql.sink.replicas``        |
+|                         | property, which defaults to one replica, will be used. The ``ksql.sink.replicas`` property can       |
+|                         | be set in the properties file the KSQL server is started with, or by using the ``SET`` statement.    |
 +-------------------------+------------------------------------------------------------------------------------------------------+
 | TIMESTAMP               | Sets a field within this tables's schema to be used as the default source of ``ROWTIME`` for         |
 |                         | any downstream queries. Downstream queries that use time-based operations, such as windowing,        |

--- a/docs/installation/cli-config.rst
+++ b/docs/installation/cli-config.rst
@@ -26,8 +26,7 @@ Here are some common KSQL CLI properties that you can customize:
 - :ref:`ksql.streams.auto.offset.reset <ksql-auto-offset-reset>`
 - :ref:`ksql.streams.cache.max.bytes.buffering <streams_developer-guide_optional-configs>`
 - :ref:`ksql.streams.num.stream.threads <streams_developer-guide_optional-configs>`
-- :ref:`ksql.sink.partitions <ksql-sink-partitions>`
-- :ref:`ksql.sink.replicas <ksql-sink-replicas>`
+
 
 
 

--- a/docs/installation/server-config/config-reference.rst
+++ b/docs/installation/server-config/config-reference.rst
@@ -160,18 +160,20 @@ will be prefixed as ``_confluent-ksql-default_`` (e.g. ``_command_topic`` become
 .. _ksql-sink-partitions:
 
 --------------------
-ksql.sink.partitions
+ksql.sink.partitions (Depricated)
 --------------------
 
 The default number of partitions for the topics created by KSQL. The default is four.
+This property has been depricated since 5.3 release. For more info see :ref:`KSQL Syntax Reference <ksql_syntax_reference>`.
 
 .. _ksql-sink-replicas:
 
 ------------------
-ksql.sink.replicas
+ksql.sink.replicas (Depricated)
 ------------------
 
 The default number of replicas for the topics created by KSQL. The default is one.
+This property has been depricated since 5.3 release. For more info see :ref:`KSQL Syntax Reference <ksql_syntax_reference>`.
 
 ------------------------------------
 ksql.functions.substring.legacy.args

--- a/docs/installation/server-config/config-reference.rst
+++ b/docs/installation/server-config/config-reference.rst
@@ -160,20 +160,20 @@ will be prefixed as ``_confluent-ksql-default_`` (e.g. ``_command_topic`` become
 .. _ksql-sink-partitions:
 
 --------------------
-ksql.sink.partitions (Depricated)
+ksql.sink.partitions (Deprecated)
 --------------------
 
 The default number of partitions for the topics created by KSQL. The default is four.
-This property has been depricated since 5.3 release. For more info see :ref:`KSQL Syntax Reference <ksql_syntax_reference>`.
+This property has been deprecated since 5.3 release. For more info see the WITH clause properties in :ref:`CREATE STREAM AS SELECT <create-stream-as-select>` and :ref:`CREATE TABLE AS SELECT <create-table-as-select>`.
 
 .. _ksql-sink-replicas:
 
 ------------------
-ksql.sink.replicas (Depricated)
+ksql.sink.replicas (Deprecated)
 ------------------
 
 The default number of replicas for the topics created by KSQL. The default is one.
-This property has been depricated since 5.3 release. For more info see :ref:`KSQL Syntax Reference <ksql_syntax_reference>`.
+This property has been deprecated since 5.3 release. For more info see the WITH clause properties in :ref:`CREATE STREAM AS SELECT <create-stream-as-select>` and :ref:`CREATE TABLE AS SELECT <create-table-as-select>`.
 
 ------------------------------------
 ksql.functions.substring.legacy.args

--- a/docs/installation/upgrading.rst
+++ b/docs/installation/upgrading.rst
@@ -6,6 +6,16 @@ Upgrading KSQL
 Upgrade one KSQL server at a time (i.e. rolling restart). The remaining KSQL servers should have sufficient spare
 capacity to take over temporarily for unavailable, restarting servers.
 
+Upgrading from KSQL 5.2 to KSQL 5.3
+-----------------------------------
+
+Notable changes in 5.3:
+
+* Configuration:
+
+    * ksql.sink.partitions and ksql.sink.replicas are deprecated. All new queries will use the source topic partition count and replica count for the sink topic instead unless partitions and replicas are set in the WITH clause.
+
+
 Upgrading from KSQL 5.1 to KSQL 5.2
 -----------------------------------
 

--- a/docs/installation/upgrading.rst
+++ b/docs/installation/upgrading.rst
@@ -13,7 +13,7 @@ Notable changes in 5.3:
 
 * Configuration:
 
-    * ksql.sink.partitions and ksql.sink.replicas are deprecated. All new queries will use the source topic partition count and replica count for the sink topic instead unless partitions and replicas are set in the WITH clause.
+    * ``ksql.sink.partitions`` and ``ksql.sink.replicas`` are deprecated. All new queries will use the source topic partition count and replica count for the sink topic instead unless partitions and replicas are set in the WITH clause.
 
 
 Upgrading from KSQL 5.1 to KSQL 5.2

--- a/ksql-common/src/main/java/io/confluent/ksql/util/KsqlConfig.java
+++ b/ksql-common/src/main/java/io/confluent/ksql/util/KsqlConfig.java
@@ -205,8 +205,8 @@ public class KsqlConfig extends AbstractConfig implements Cloneable {
               null,
               Importance.LOW,
               "The legacy default number of partitions for the topics created by KSQL"
-                  + "in 5.1 and earlier versions."
-                  + "This property should not be set for 5.2 and later versions."),
+                  + "in 5.2 and earlier versions."
+                  + "This property should not be set for 5.3 and later versions."),
           new CompatibilityBreakingConfigDef(
               SINK_NUMBER_OF_REPLICAS_PROPERTY,
               ConfigDef.Type.SHORT,
@@ -214,8 +214,8 @@ public class KsqlConfig extends AbstractConfig implements Cloneable {
               null,
               ConfigDef.Importance.LOW,
               "The default number of replicas for the topics created by KSQL "
-                  + "in 5.1 and earlier versions."
-                  + "This property should not be set for 5.2 and later versions."
+                  + "in 5.2 and earlier versions."
+                  + "This property should not be set for 5.3 and later versions."
           ),
           new CompatibilityBreakingConfigDef(
               KSQL_USE_NAMED_AVRO_MAPS,


### PR DESCRIPTION
Docs update for the default partition and replica count for sink topics in queries.