### PR TITLE
Minor: Drop unnecessary `cloneWithDoCreateInto`

### DIFF
--- a/ksql-engine/src/main/java/io/confluent/ksql/physical/PhysicalPlanBuilder.java
+++ b/ksql-engine/src/main/java/io/confluent/ksql/physical/PhysicalPlanBuilder.java
@@ -151,11 +151,9 @@ public class PhysicalPlanBuilder {
 
     } else if (outputNode instanceof KsqlStructuredDataOutputNode) {
 
-      KsqlStructuredDataOutputNode ksqlStructuredDataOutputNode =
+      final KsqlStructuredDataOutputNode ksqlStructuredDataOutputNode =
           (KsqlStructuredDataOutputNode) outputNode;
-      ksqlStructuredDataOutputNode = ksqlStructuredDataOutputNode.cloneWithDoCreateInto(
-          ((KsqlStructuredDataOutputNode) logicalPlanNode.getNode()).isDoCreateInto()
-      );
+
       return buildPlanForStructuredOutputNode(
           logicalPlanNode.getStatementText(),
           resultStream,

--- a/ksql-engine/src/main/java/io/confluent/ksql/planner/plan/KsqlStructuredDataOutputNode.java
+++ b/ksql-engine/src/main/java/io/confluent/ksql/planner/plan/KsqlStructuredDataOutputNode.java
@@ -318,21 +318,6 @@ public class KsqlStructuredDataOutputNode extends OutputNode {
     return ksqlTopic.getKsqlTopicSerDe();
   }
 
-  public KsqlStructuredDataOutputNode cloneWithDoCreateInto(final boolean newDoCreateInto) {
-    return new KsqlStructuredDataOutputNode(
-        getId(),
-        getSource(),
-        getSchema(),
-        getTimestampExtractionPolicy(),
-        getKeyField(),
-        getKsqlTopic(),
-        getKafkaTopicName(),
-        outputProperties,
-        getLimit(),
-        newDoCreateInto
-    );
-  }
-
   private static class SourceTopicProperties {
 
     private final int partitions;


### PR DESCRIPTION
### Description 

There's a call to `KsqlStructuredDataOutputNode.cloneWithDoCreateInto` in `PhysicalPlanBuilder` that looks to serve no purpose. I've looked back at where this flag comes from and everything looks like it should always do the right thing already.  This may be because of some of my earlier refactors.

Hence this PR drops the unnecessary call and removes the method.

### Testing done 
Ran the usual tests.

### Reviewer checklist
- [ ] Ensure docs are updated if necessary. (eg. if a user visible feature is being added or changed).
- [ ] Ensure relevant issues are linked (description should include text like "Fixes #<issue number>")

