### PR TITLE
Minor: remove unnecessary numberOfPersistentQueries API

### DIFF
--- a/ksql-engine/src/main/java/io/confluent/ksql/KsqlExecutionContext.java
+++ b/ksql-engine/src/main/java/io/confluent/ksql/KsqlExecutionContext.java
@@ -47,13 +47,6 @@ public interface KsqlExecutionContext {
   MetaStore getMetaStore();
 
   /**
-   * Get the number of persistent queries.
-   *
-   * @return the number of queries
-   */
-  int numberOfPersistentQueries();
-
-  /**
    * Retrieve the details of a persistent query.
    *
    * @param queryId the id of the query to retrieve.

--- a/ksql-engine/src/main/java/io/confluent/ksql/engine/KsqlEngine.java
+++ b/ksql-engine/src/main/java/io/confluent/ksql/engine/KsqlEngine.java
@@ -114,11 +114,6 @@ public class KsqlEngine implements KsqlExecutionContext, Closeable {
   }
 
   @Override
-  public int numberOfPersistentQueries() {
-    return primaryContext.numberOfPersistentQueries();
-  }
-
-  @Override
   public Optional<PersistentQueryMetadata> getPersistentQuery(final QueryId queryId) {
     return primaryContext.getPersistentQuery(queryId);
   }

--- a/ksql-engine/src/main/java/io/confluent/ksql/engine/SandboxedExecutionContext.java
+++ b/ksql-engine/src/main/java/io/confluent/ksql/engine/SandboxedExecutionContext.java
@@ -50,11 +50,6 @@ final class SandboxedExecutionContext implements KsqlExecutionContext {
   }
 
   @Override
-  public int numberOfPersistentQueries() {
-    return engineContext.numberOfPersistentQueries();
-  }
-
-  @Override
   public Optional<PersistentQueryMetadata> getPersistentQuery(final QueryId queryId) {
     return engineContext.getPersistentQuery(queryId);
   }

--- a/ksql-engine/src/main/java/io/confluent/ksql/internal/KsqlEngineMetrics.java
+++ b/ksql-engine/src/main/java/io/confluent/ksql/internal/KsqlEngineMetrics.java
@@ -216,7 +216,7 @@ public class KsqlEngineMetrics implements Closeable {
         new MeasurableStat() {
           @Override
           public double measure(final MetricConfig metricConfig, final long l) {
-            return ksqlEngine.numberOfPersistentQueries();
+            return ksqlEngine.getPersistentQueries().size();
           }
 
           @Override

--- a/ksql-engine/src/test/java/io/confluent/ksql/engine/KsqlEngineTest.java
+++ b/ksql-engine/src/test/java/io/confluent/ksql/engine/KsqlEngineTest.java
@@ -678,7 +678,7 @@ public class KsqlEngineTest {
   public void shouldRemovePersistentQueryFromEngineWhenClosed() {
     // Given:
     final int startingLiveQueries = ksqlEngine.numberOfLiveQueries();
-    final int startingPersistentQueries = ksqlEngine.numberOfPersistentQueries();
+    final int startingPersistentQueries = ksqlEngine.getPersistentQueries().size();
 
     final QueryMetadata query = KsqlEngineTestUtil.execute(ksqlEngine,
         "create stream s1 with (value_format = 'avro') as select * from test1;",
@@ -690,7 +690,7 @@ public class KsqlEngineTest {
     // Then:
     assertThat(ksqlEngine.getPersistentQuery(getQueryId(query)), is(Optional.empty()));
     assertThat(ksqlEngine.numberOfLiveQueries(), is(startingLiveQueries));
-    assertThat(ksqlEngine.numberOfPersistentQueries(), is(startingPersistentQueries));
+    assertThat(ksqlEngine.getPersistentQueries().size(), is(startingPersistentQueries));
   }
 
   @Test
@@ -1020,7 +1020,7 @@ public class KsqlEngineTest {
   public void shouldNotUpdateMetaStoreDuringTryExecute() {
     // Given:
     final int numberOfLiveQueries = ksqlEngine.numberOfLiveQueries();
-    final int numPersistentQueries = ksqlEngine.numberOfPersistentQueries();
+    final int numPersistentQueries = ksqlEngine.getPersistentQueries().size();
 
     final List<ParsedStatement> statements = parse(
         "SET 'auto.offset.reset' = 'earliest';"
@@ -1041,7 +1041,7 @@ public class KsqlEngineTest {
     assertThat(metaStore.getSource("BAR"), is(nullValue()));
     assertThat(metaStore.getSource("FOO"), is(nullValue()));
     assertThat("live", ksqlEngine.numberOfLiveQueries(), is(numberOfLiveQueries));
-    assertThat("peristent", ksqlEngine.numberOfPersistentQueries(), is(numPersistentQueries));
+    assertThat("peristent", ksqlEngine.getPersistentQueries().size(), is(numPersistentQueries));
   }
 
   @Test

--- a/ksql-engine/src/test/java/io/confluent/ksql/internal/KsqlEngineMetricsTest.java
+++ b/ksql-engine/src/test/java/io/confluent/ksql/internal/KsqlEngineMetricsTest.java
@@ -156,7 +156,7 @@ public class KsqlEngineMetricsTest {
 
   @Test
   public void shouldRecordNumberOfPersistentQueries() {
-    when(ksqlEngine.getPersistentQueries().size()).thenReturn(3);
+    when(ksqlEngine.getPersistentQueries()).then(returnQueriesInState(3, State.RUNNING));
 
     final double value = getMetricValue(engineMetrics.getMetrics(), metricNamePrefix + "num-persistent-queries");
     assertEquals(3.0, value, 0.0);

--- a/ksql-engine/src/test/java/io/confluent/ksql/internal/KsqlEngineMetricsTest.java
+++ b/ksql-engine/src/test/java/io/confluent/ksql/internal/KsqlEngineMetricsTest.java
@@ -156,7 +156,7 @@ public class KsqlEngineMetricsTest {
 
   @Test
   public void shouldRecordNumberOfPersistentQueries() {
-    when(ksqlEngine.numberOfPersistentQueries()).thenReturn(3);
+    when(ksqlEngine.getPersistentQueries().size()).thenReturn(3);
 
     final double value = getMetricValue(engineMetrics.getMetrics(), metricNamePrefix + "num-persistent-queries");
     assertEquals(3.0, value, 0.0);

--- a/ksql-rest-app/src/main/java/io/confluent/ksql/rest/util/QueryCapacityUtil.java
+++ b/ksql-rest-app/src/main/java/io/confluent/ksql/rest/util/QueryCapacityUtil.java
@@ -28,7 +28,7 @@ public final class QueryCapacityUtil {
       final KsqlConfig ksqlConfig,
       final long additionalQueries
   ) {
-    final long newTotal = executionContext.numberOfPersistentQueries() + additionalQueries;
+    final long newTotal = executionContext.getPersistentQueries().size() + additionalQueries;
     return newTotal > getQueryLimit(ksqlConfig);
   }
 
@@ -46,7 +46,7 @@ public final class QueryCapacityUtil {
                 + "Current persistent query count: %d. Configured limit: %d.",
             statementStr,
             KsqlConfig.KSQL_ACTIVE_PERSISTENT_QUERY_LIMIT_CONFIG,
-            executionContext.numberOfPersistentQueries(),
+            executionContext.getPersistentQueries().size(),
             getQueryLimit(ksqlConfig)
         )
     );

--- a/ksql-rest-app/src/test/java/io/confluent/ksql/rest/server/computation/StatementExecutorTest.java
+++ b/ksql-rest-app/src/test/java/io/confluent/ksql/rest/server/computation/StatementExecutorTest.java
@@ -240,7 +240,7 @@ public class StatementExecutorTest extends EasyMockSupport {
         CommandId.Action.CREATE);
 
     expect(mockParser.parseSingleStatement(statementText)).andReturn(csasStatement);
-    expect(mockEngine.numberOfPersistentQueries()).andReturn(0);
+    expect(mockEngine.getPersistentQueries()).andReturn(ImmutableList.of());
     expect(mockEngine.execute(csasStatement, expectedConfig, Collections.emptyMap()))
         .andReturn(ExecuteResult.of(mockQueryMetadata));
     mockQueryMetadata.start();
@@ -512,7 +512,7 @@ public class StatementExecutorTest extends EasyMockSupport {
     expect(mockParser.parseSingleStatement(statement))
         .andReturn(csas);
     expect(mockMetaStore.getSource(name)).andStubReturn(null);
-    expect(mockEngine.numberOfPersistentQueries()).andReturn(0);
+    expect(mockEngine.getPersistentQueries()).andReturn(ImmutableList.of());
     expect(mockEngine.execute(eq(csas), anyObject(), anyObject()))
         .andReturn(ExecuteResult.of(mockQuery));
     return mockQuery;
@@ -538,7 +538,7 @@ public class StatementExecutorTest extends EasyMockSupport {
         .andReturn((PreparedStatement)preparedStatement);
     expect(mockEngine.execute(eq(preparedStatement), anyObject(), anyObject()))
         .andReturn(ExecuteResult.of(mockQuery));
-    expect(mockEngine.numberOfPersistentQueries()).andReturn(0);
+    expect(mockEngine.getPersistentQueries()).andReturn(ImmutableList.of());
     return mockQuery;
   }
 

--- a/ksql-rest-app/src/test/java/io/confluent/ksql/rest/server/resources/KsqlResourceTest.java
+++ b/ksql-rest-app/src/test/java/io/confluent/ksql/rest/server/resources/KsqlResourceTest.java
@@ -1879,6 +1879,8 @@ public class KsqlResourceTest {
   }
 
   private void givenPersistentQueryCount(final int value) {
-    when(sandbox.getPersistentQueries()).thenReturn(ImmutableList.of());
+    final List<PersistentQueryMetadata> queries = mock(List.class);
+    when(queries.size()).thenReturn(value);
+    when(sandbox.getPersistentQueries()).thenReturn(queries);
   }
 }

--- a/ksql-rest-app/src/test/java/io/confluent/ksql/rest/server/resources/KsqlResourceTest.java
+++ b/ksql-rest-app/src/test/java/io/confluent/ksql/rest/server/resources/KsqlResourceTest.java
@@ -1879,6 +1879,6 @@ public class KsqlResourceTest {
   }
 
   private void givenPersistentQueryCount(final int value) {
-    when(sandbox.numberOfPersistentQueries()).thenReturn(value);
+    when(sandbox.getPersistentQueries()).thenReturn(ImmutableList.of());
   }
 }

--- a/ksql-rest-app/src/test/java/io/confluent/ksql/rest/util/QueryCapacityUtilTest.java
+++ b/ksql-rest-app/src/test/java/io/confluent/ksql/rest/util/QueryCapacityUtilTest.java
@@ -17,11 +17,14 @@ package io.confluent.ksql.rest.util;
 
 import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
 import io.confluent.ksql.engine.KsqlEngine;
 import io.confluent.ksql.util.KsqlConfig;
 import io.confluent.ksql.util.KsqlException;
+import io.confluent.ksql.util.PersistentQueryMetadata;
+import java.util.List;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ExpectedException;
@@ -105,9 +108,12 @@ public class QueryCapacityUtilTest {
         ksqlEngine, ksqlConfig, statementStr);
   }
 
+  @SuppressWarnings("unchecked")
   private void givenActivePersistentQueries(final int numQueries) {
-    when(ksqlEngine.numberOfPersistentQueries())
-        .thenReturn(numQueries);
+    final List<PersistentQueryMetadata> queries = mock(List.class);
+    when(queries.size()).thenReturn(numQueries);
+    when(ksqlEngine.getPersistentQueries())
+        .thenReturn(queries);
   }
 
   private void givenQueryLimit(final int queryLimit) {


### PR DESCRIPTION
### Description 
In #2502 I introduced `KsqlExecutionContext#getPersistentQueries` API which obviates the need for `numberOfPersistentQueries`.

### Testing done 
- Ran existing unit tests

### Reviewer checklist
- [ ] Ensure docs are updated if necessary. (eg. if a user visible feature is being added or changed).
- [ ] Ensure relevant issues are linked (description should include text like "Fixes #<issue number>")

