### PR TITLE
Rename `topicName` to `ksqlTopicName` in KsqlTopic class.

### DIFF
--- a/ksql-engine/src/main/java/io/confluent/ksql/ddl/commands/DropSourceCommand.java
+++ b/ksql-engine/src/main/java/io/confluent/ksql/ddl/commands/DropSourceCommand.java
@@ -71,7 +71,7 @@ public class DropSourceCommand implements DdlCommand {
       ));
     }
     final DropTopicCommand dropTopicCommand =
-        new DropTopicCommand(dataSource.getTopicName());
+        new DropTopicCommand(dataSource.getKsqlTopicName());
     metaStore.deleteSource(sourceName);
     dropTopicCommand.run(metaStore);
 

--- a/ksql-engine/src/main/java/io/confluent/ksql/planner/plan/StructuredDataSourceNode.java
+++ b/ksql-engine/src/main/java/io/confluent/ksql/planner/plan/StructuredDataSourceNode.java
@@ -120,7 +120,7 @@ public class StructuredDataSourceNode
   }
 
   public String getTopicName() {
-    return structuredDataSource.getTopicName();
+    return structuredDataSource.getKsqlTopicName();
   }
 
   @Override

--- a/ksql-engine/src/test/java/io/confluent/ksql/analyzer/AnalyzerTest.java
+++ b/ksql-engine/src/test/java/io/confluent/ksql/analyzer/AnalyzerTest.java
@@ -237,7 +237,7 @@ public class AnalyzerTest {
     Assert.assertNotNull("INTO is null", analysis.getInto());
     final StructuredDataSource structuredDataSource = analysis.getInto();
     final KsqlTopic createdKsqlTopic = structuredDataSource.getKsqlTopic();
-    assertThat(createdKsqlTopic.getTopicName(), is("FOO"));
+    assertThat(createdKsqlTopic.getKsqlTopicName(), is("FOO"));
     assertThat(createdKsqlTopic.getKafkaTopicName(), is("TEST_TOPIC1"));
   }
 

--- a/ksql-engine/src/test/java/io/confluent/ksql/planner/plan/KsqlStructuredDataOutputNodeTest.java
+++ b/ksql-engine/src/test/java/io/confluent/ksql/planner/plan/KsqlStructuredDataOutputNodeTest.java
@@ -439,7 +439,7 @@ public class KsqlStructuredDataOutputNodeTest {
   private static KsqlTopic mockTopic(final KsqlTopicSerDe topicSerde) {
     final KsqlTopic ksqlTopic = mock(KsqlTopic.class);
     when(ksqlTopic.getKafkaTopicName()).thenReturn("output");
-    when(ksqlTopic.getTopicName()).thenReturn("output");
+    when(ksqlTopic.getKsqlTopicName()).thenReturn("output");
     when(ksqlTopic.getKsqlTopicSerDe()).thenReturn(topicSerde);
     return ksqlTopic;
   }

--- a/ksql-metastore/src/main/java/io/confluent/ksql/metastore/KsqlTopic.java
+++ b/ksql-metastore/src/main/java/io/confluent/ksql/metastore/KsqlTopic.java
@@ -20,17 +20,17 @@ import io.confluent.ksql.serde.KsqlTopicSerDe;
 
 public class KsqlTopic implements DataSource {
 
-  private final String topicName;
+  private final String ksqlTopicName;
   private final String kafkaTopicName;
   private final KsqlTopicSerDe ksqlTopicSerDe;
   private final boolean isKsqlSink;
 
   public KsqlTopic(
-      final String topicName,
+      final String ksqlTopicName,
       final String kafkaTopicName,
       final KsqlTopicSerDe ksqlTopicSerDe,
       final boolean isKsqlSink) {
-    this.topicName = topicName;
+    this.ksqlTopicName = ksqlTopicName;
     this.kafkaTopicName = kafkaTopicName;
     this.ksqlTopicSerDe = ksqlTopicSerDe;
     this.isKsqlSink = isKsqlSink;
@@ -44,8 +44,8 @@ public class KsqlTopic implements DataSource {
     return kafkaTopicName;
   }
 
-  public String getTopicName() {
-    return topicName;
+  public String getKsqlTopicName() {
+    return ksqlTopicName;
   }
 
   public boolean isKsqlSink() {
@@ -54,7 +54,7 @@ public class KsqlTopic implements DataSource {
 
   @Override
   public String getName() {
-    return topicName;
+    return ksqlTopicName;
   }
 
   @Override

--- a/ksql-metastore/src/main/java/io/confluent/ksql/metastore/MetaStoreImpl.java
+++ b/ksql-metastore/src/main/java/io/confluent/ksql/metastore/MetaStoreImpl.java
@@ -83,8 +83,8 @@ public final class MetaStoreImpl implements MutableMetaStore {
   public Optional<StructuredDataSource> getSourceForTopic(final String ksqlTopicName) {
     return dataSources.values()
         .stream()
-        .filter(p -> p.source.getTopicName() != null
-            && p.source.getTopicName().equals(ksqlTopicName))
+        .filter(p -> p.source.getKsqlTopicName() != null
+            && p.source.getKsqlTopicName().equals(ksqlTopicName))
         .map(sourceInfo -> sourceInfo.source)
         .findFirst();
   }

--- a/ksql-metastore/src/main/java/io/confluent/ksql/metastore/StructuredDataSource.java
+++ b/ksql-metastore/src/main/java/io/confluent/ksql/metastore/StructuredDataSource.java
@@ -93,7 +93,7 @@ public abstract class StructuredDataSource implements DataSource {
       TimestampExtractionPolicy policy);
 
   public String getTopicName() {
-    return ksqlTopic.getTopicName();
+    return ksqlTopic.getKsqlTopicName();
   }
 
   public String getKafkaTopicName() {

--- a/ksql-metastore/src/main/java/io/confluent/ksql/metastore/StructuredDataSource.java
+++ b/ksql-metastore/src/main/java/io/confluent/ksql/metastore/StructuredDataSource.java
@@ -92,7 +92,7 @@ public abstract class StructuredDataSource implements DataSource {
   public abstract StructuredDataSource cloneWithTimeExtractionPolicy(
       TimestampExtractionPolicy policy);
 
-  public String getTopicName() {
+  public String getKsqlTopicName() {
     return ksqlTopic.getKsqlTopicName();
   }
 

--- a/ksql-rest-app/src/main/java/io/confluent/ksql/rest/entity/KsqlTopicInfo.java
+++ b/ksql-rest-app/src/main/java/io/confluent/ksql/rest/entity/KsqlTopicInfo.java
@@ -43,7 +43,7 @@ public class KsqlTopicInfo {
 
   public KsqlTopicInfo(final KsqlTopic ksqlTopic) {
     this(
-        ksqlTopic.getTopicName(),
+        ksqlTopic.getKsqlTopicName(),
         ksqlTopic.getKafkaTopicName(),
         ksqlTopic.getKsqlTopicSerDe().getSerDe()
     );


### PR DESCRIPTION
KsqlTopic had a fields called 'topicName` which referred to the name of `KsqlTopic` object and another field, `kafkaTopicName` which refers to the name of the kafka topic associated with this KsqlTopic. `topicName` has cause mistakes and was used instead of kafkaTopicName before. This change clarifies the `topicName` field name indicating that it is not `kafkaTopicName`!
