### PR TITLE
Disable WADL

### DIFF
--- a/ksql-rest-app/src/main/java/io/confluent/ksql/rest/server/KsqlRestApplication.java
+++ b/ksql-rest-app/src/main/java/io/confluent/ksql/rest/server/KsqlRestApplication.java
@@ -245,6 +245,7 @@ public final class KsqlRestApplication extends Application<KsqlRestConfig> imple
 
     // Don't want to buffer rows when streaming JSON in a request to the query resource
     config.property(ServerProperties.OUTBOUND_CONTENT_LENGTH_BUFFER, 0);
+    config.property(ServerProperties.WADL_FEATURE_DISABLE, true);
   }
 
   @Override


### PR DESCRIPTION
### Description 
Disable WADL since we don't have the jaxb runtime. A good reminder about inheritance
being freaking evil. This is fixed in rest-util's Application, but we override this method.