### PR TITLE
Disable NPathComplexity for newer checkstyle compatibility on older branches

### DIFF
--- a/checkstyle/suppressions.xml
+++ b/checkstyle/suppressions.xml
@@ -14,7 +14,7 @@
     <suppress files="(PersistentQueryMetadata|SourceDescription|JoinNode).java"
               checks="ParameterNumber"/>
     <suppress files="(Console|Main|Generator|KsqlResource).java" checks="JavaNCSSCheck"/>
-    <suppress files="Generator.java" checks="NPathComplexity"/>
+    <suppress files="(Generator|DataGen).java" checks="NPathComplexity"/>
     <suppress files="(ExpressionTreeRewriter|AstBuilder|KsqlParser|SchemaKTable).java"
               checks="ClassDataAbstractionCouplingCheck"/>
     <suppress


### PR DESCRIPTION
This allows older branches to pass checkstyle with updated versions. It's not meant to be merged up through subsequent branches, but rather is the temporary way out since multiple refactors were performed in newer branches to clean this up.