### PR TITLE
Decrease Kafka Controller socket timeout in tests.

### DIFF
--- a/ksql-test-util/src/main/java/io/confluent/ksql/test/util/EmbeddedSingleNodeKafkaCluster.java
+++ b/ksql-test-util/src/main/java/io/confluent/ksql/test/util/EmbeddedSingleNodeKafkaCluster.java
@@ -282,10 +282,18 @@ public final class EmbeddedSingleNodeKafkaCluster extends ExternalResource {
     final Properties effectiveConfig = new Properties();
     effectiveConfig.putAll(brokerConfig);
     effectiveConfig.put(KafkaConfig.ZkConnectProp(), zookeeper.connectString());
+    // Allow tests to delete topics:
     effectiveConfig.put(KafkaConfig.DeleteTopicEnableProp(), true);
+    // Do not clean logs from under the tests or waste resources doing so:
     effectiveConfig.put(KafkaConfig.LogCleanerEnableProp(), false);
+    // Only single node, so only single RF on offset topic partitions:
     effectiveConfig.put(KafkaConfig.OffsetsTopicReplicationFactorProp(), (short) 1);
+    // Tests do not need large numbers of offset topic partitions:
+    effectiveConfig.put(KafkaConfig.OffsetsTopicPartitionsProp(), "2");
+    // Shutdown quick:
     effectiveConfig.put(KafkaConfig.ControlledShutdownEnableProp(), false);
+    // Explicitly set to be less that the default 30 second timeout of KSQL functional tests
+    effectiveConfig.put(KafkaConfig.ControllerSocketTimeoutMsProp(), 20_000);
     return effectiveConfig;
   }
 


### PR DESCRIPTION
### Description 

We occasionally see tests failing due to the Kafka Controller thread losing connection to the broker.  The default timeout on the socket is 30 seconds. The default timeout on tests is 30 seconds.  This PR drops the socket timeout to 20 seconds in order to give tests timeout to detect the dead connection and recover _before_ the test times out.

### Testing done 
None functional change.

### Reviewer checklist
- [ ] Ensure docs are updated if necessary. (eg. if a user visible feature is being added or changed).
- [ ] Ensure relevant issues are linked (description should include text like "Fixes #<issue number>")

