### PR TITLE
5.2 fix for UDFs not being passed their config.

### DIFF
--- a/ksql-common/src/main/java/io/confluent/ksql/util/KsqlConfig.java
+++ b/ksql-common/src/main/java/io/confluent/ksql/util/KsqlConfig.java
@@ -591,7 +591,7 @@ public class KsqlConfig extends AbstractConfig implements Cloneable {
   }
 
   public KsqlConfig cloneWithPropertyOverwrite(final Map<String, Object> props) {
-    final Map<String, Object> cloneProps = new HashMap<>(values());
+    final Map<String, Object> cloneProps = new HashMap<>(originals());
     cloneProps.putAll(props);
     final Map<String, ConfigValue> streamConfigProps =
         buildStreamingConfig(getKsqlStreamConfigProps(), props);

--- a/ksql-common/src/test/java/io/confluent/ksql/util/KsqlConfigTest.java
+++ b/ksql-common/src/test/java/io/confluent/ksql/util/KsqlConfigTest.java
@@ -261,6 +261,51 @@ public class KsqlConfigTest {
   }
 
   @Test
+  public void shouldHaveCorrectOriginalsAfterCloneWithOverwrite() {
+    // Given:
+    final KsqlConfig initial = new KsqlConfig(ImmutableMap.of(
+        KsqlConfig.KSQL_SERVICE_ID_CONFIG, "original-id",
+        KsqlConfig.KSQL_USE_NAMED_INTERNAL_TOPICS, "on"
+    ));
+
+    // When:
+    final KsqlConfig cloned = initial.cloneWithPropertyOverwrite(ImmutableMap.of(
+        KsqlConfig.KSQL_SERVICE_ID_CONFIG, "overridden-id",
+        KsqlConfig.KSQL_PERSISTENT_QUERY_NAME_PREFIX_CONFIG, "bob"
+    ));
+
+    // Then:
+    assertThat(cloned.originals(), is(ImmutableMap.of(
+        KsqlConfig.KSQL_SERVICE_ID_CONFIG, "overridden-id",
+        KsqlConfig.KSQL_USE_NAMED_INTERNAL_TOPICS, "on",
+        KsqlConfig.KSQL_PERSISTENT_QUERY_NAME_PREFIX_CONFIG, "bob"
+    )));
+  }
+
+  @Test
+  public void shouldCloneWithUdfProperty() {
+    // Given:
+    final String functionName = "bob";
+    final String settingPrefix = KsqlConfig.KSQL_FUNCTIONS_PROPERTY_PREFIX + functionName + ".";
+
+    final KsqlConfig config = new KsqlConfig(ImmutableMap.of(
+        settingPrefix + "one", "should-be-cloned",
+        settingPrefix + "two", "should-be-overwritten"
+    ));
+
+    // When:
+    final KsqlConfig cloned = config.cloneWithPropertyOverwrite(ImmutableMap.of(
+        settingPrefix + "two", "should-be-new-value"
+    ));
+
+    // Then:
+    assertThat(cloned.getKsqlFunctionsConfigProps(functionName), is(ImmutableMap.of(
+        settingPrefix + "one", "should-be-cloned",
+        settingPrefix + "two", "should-be-new-value"
+    )));
+  }
+
+  @Test
   public void shouldCloneWithMultipleOverwrites() {
     final KsqlConfig ksqlConfig = new KsqlConfig(ImmutableMap.of(
         ConsumerConfig.AUTO_COMMIT_INTERVAL_MS_CONFIG, "123",


### PR DESCRIPTION
### Description 
Fix for #2586: UDFs not being passed their config.

PR:
- ensures UDFs get passed their configs.
- add `KsqlConfig` tests to cover cloning config with overrides
- add functional test to ensure this works end-to-end.

The issue is that the `cloneWithPropertyOverwrites` uses the `values()` of the original config, not the `originals()`.  While the former passes along _all_ the original configs, whether known or unknown, the latter call filters out any unknown config values, (causing the bug), and also includes any default values, (which aren't necessary).  The UDF config has prefixed freeform names, so would never be included in `values()`.

Looks to be a low risk change.  

I've looked for other uses of `values()` as well.  There are only two. One looks legit, and the other is unused. (I'll remove in another PR).

### Testing done 
Added unit and functional testing.

### Reviewer checklist
- [ ] Ensure docs are updated if necessary. (eg. if a user visible feature is being added or changed).
- [ ] Ensure relevant issues are linked (description should include text like "Fixes #<issue number>")

