### PR TITLE
Make SUM UDAF handle undos of null values.

### DIFF
--- a/ksql-engine/src/main/java/io/confluent/ksql/function/udaf/sum/DoubleSumKudaf.java
+++ b/ksql-engine/src/main/java/io/confluent/ksql/function/udaf/sum/DoubleSumKudaf.java
@@ -35,11 +35,19 @@ public class DoubleSumKudaf
   }
 
   @Override
-  public Double aggregate(final Double currentValue, final Double aggregateValue) {
-    if (currentValue == null) {
+  public Double aggregate(final Double valueToAdd, final Double aggregateValue) {
+    if (valueToAdd == null) {
       return aggregateValue;
     }
-    return currentValue + aggregateValue;
+    return aggregateValue + valueToAdd;
+  }
+
+  @Override
+  public Double undo(final Double valueToUndo, final Double aggregateValue) {
+    if (valueToUndo == null) {
+      return aggregateValue;
+    }
+    return aggregateValue - valueToUndo;
   }
 
   @Override
@@ -48,15 +56,8 @@ public class DoubleSumKudaf
   }
 
   @Override
-  public Double undo(final Double valueToUndo, final Double aggregateValue) {
-    return aggregateValue - valueToUndo;
-  }
-
-  @Override
   public KsqlAggregateFunction<Double, Double> getInstance(
       final AggregateFunctionArguments aggregateFunctionArguments) {
     return new DoubleSumKudaf(functionName, aggregateFunctionArguments.udafIndex());
   }
-
-
 }

--- a/ksql-engine/src/main/java/io/confluent/ksql/function/udaf/sum/IntegerSumKudaf.java
+++ b/ksql-engine/src/main/java/io/confluent/ksql/function/udaf/sum/IntegerSumKudaf.java
@@ -35,15 +35,18 @@ public class IntegerSumKudaf
   }
 
   @Override
-  public Integer aggregate(final Integer currentValue, final Integer aggregateValue) {
-    if (currentValue == null) {
+  public Integer aggregate(final Integer valueToAdd, final Integer aggregateValue) {
+    if (valueToAdd == null) {
       return aggregateValue;
     }
-    return currentValue + aggregateValue;
+    return aggregateValue + valueToAdd;
   }
 
   @Override
   public Integer undo(final Integer valueToUndo, final Integer aggregateValue) {
+    if (valueToUndo == null) {
+      return aggregateValue;
+    }
     return aggregateValue - valueToUndo;
   }
 

--- a/ksql-engine/src/main/java/io/confluent/ksql/function/udaf/sum/LongSumKudaf.java
+++ b/ksql-engine/src/main/java/io/confluent/ksql/function/udaf/sum/LongSumKudaf.java
@@ -33,21 +33,24 @@ public class LongSumKudaf
   }
 
   @Override
-  public Long aggregate(final Long currentValue, final Long aggregateValue) {
-    if (currentValue == null) {
+  public Long aggregate(final Long valueToAdd, final Long aggregateValue) {
+    if (valueToAdd == null) {
       return aggregateValue;
     }
-    return currentValue + aggregateValue;
+    return aggregateValue + valueToAdd;
+  }
+
+  @Override
+  public Long undo(final Long valueToUndo, final Long aggregateValue) {
+    if (valueToUndo == null) {
+      return aggregateValue;
+    }
+    return aggregateValue - valueToUndo;
   }
 
   @Override
   public Merger<String, Long> getMerger() {
     return (aggKey, aggOne, aggTwo) -> aggOne + aggTwo;
-  }
-
-  @Override
-  public Long undo(final Long valueToUndo, final Long aggregateValue) {
-    return aggregateValue - valueToUndo;
   }
 
   @Override

--- a/ksql-engine/src/test/java/io/confluent/ksql/function/udaf/sum/BaseSumKudafTest.java
+++ b/ksql-engine/src/test/java/io/confluent/ksql/function/udaf/sum/BaseSumKudafTest.java
@@ -43,7 +43,7 @@ public abstract class BaseSumKudafTest<
     for (final T i : values) {
       currentVal = sumKudaf.aggregate(i, currentVal);
     }
-    assertThat(tGenerator.fromInt(30), equalTo(currentVal));
+    assertThat(currentVal, equalTo(tGenerator.fromInt(30)));
   }
 
   @Test
@@ -56,7 +56,7 @@ public abstract class BaseSumKudafTest<
     for (final T i : values) {
       currentVal = sumKudaf.aggregate(i, currentVal);
     }
-    assertThat(tGenerator.fromInt(25), equalTo(currentVal));
+    assertThat(currentVal, equalTo(tGenerator.fromInt(25)));
   }
 
   @Test
@@ -69,7 +69,20 @@ public abstract class BaseSumKudafTest<
     for (final T i: values) {
       currentVal = sumKudaf.undo(i, currentVal);
     }
-    assertThat(tGenerator.fromInt(0), equalTo(currentVal));
+    assertThat(currentVal, equalTo(tGenerator.fromInt(0)));
+  }
+
+  @Test
+  public void shouldHandleNullsInUndo() {
+    final TGenerator<T> tGenerator = getTGenerator();
+    final AT sumKudaf = getSumKudaf();
+    T currentVal = tGenerator.fromInt(30);
+    final List<T> values = Stream.of(3, null, 8, 2, 3, 4, 5)
+        .map(tGenerator::fromInt).collect(Collectors.toList());
+    for (final T i: values) {
+      currentVal = sumKudaf.undo(i, currentVal);
+    }
+    assertThat(currentVal, equalTo(tGenerator.fromInt(5)));
   }
 
   @Test

--- a/ksql-engine/src/test/resources/query-validation-tests/sum.json
+++ b/ksql-engine/src/test/resources/query-validation-tests/sum.json
@@ -1,11 +1,6 @@
 {
   "comments": [
-    "You can specify multiple statements per test case, i.e., to set up the various streams needed",
-    "for joins etc, but currently only the final topology will be verified. This should be enough",
-    "for most tests as we can simulate the outputs from previous stages into the final stage. If we",
-    "take a modular approach to testing we can still verify that it all works correctly, i.e, if we",
-    "verify the output of a select or aggregate is correct, we can use simulated output to feed into",
-    "a join or another aggregate."
+    "Test cases covering the use of the aggregate SUM function"
   ],
   "tests": [
     {
@@ -25,6 +20,34 @@
         {"topic": "S2", "key": 0, "value": "0,100"},
         {"topic": "S2", "key": 100, "value": "100,500"},
         {"topic": "S2", "key": 100, "value": "100,600"}
+      ]
+    },
+    {
+      "name": "sum int left join of table",
+      "comment": "from https://github.com/confluentinc/ksql/issues/2490",
+      "statements": [
+        "CREATE TABLE t1 (ID bigint, TOTAL integer) WITH (kafka_topic='T1', value_format='DELIMITED', key='ID');",
+        "CREATE TABLE t2 (ID bigint, TOTAL integer) WITH (kafka_topic='T2', value_format='DELIMITED', key='ID');",
+        "CREATE TABLE OUTPUT AS SELECT t1.id, SUM(t2.total) FROM T1 LEFT JOIN T2 ON (t1.id = t2.id) GROUP BY t1.id;"
+      ],
+      "inputs": [
+        {"topic": "T1", "key": 0, "value": "0,100"},
+        {"topic": "T1", "key": 1, "value": "1,101"},
+        {"topic": "T2", "key": 0, "value": "0,5"},
+        {"topic": "T2", "key": 1, "value": "1,10"},
+        {"topic": "T2", "key": 0, "value": "0,20"},
+        {"topic": "T2", "key": 0, "value": null}
+      ],
+      "outputs": [
+        {"topic": "OUTPUT", "key": 0, "value": "0,0"},
+        {"topic": "OUTPUT", "key": 1, "value": "1,0"},
+        {"topic": "OUTPUT", "key": 0, "value": "0,0"},
+        {"topic": "OUTPUT", "key": 0, "value": "0,5"},
+        {"topic": "OUTPUT", "key": 1, "value": "1,0"},
+        {"topic": "OUTPUT", "key": 1, "value": "1,10"},
+        {"topic": "OUTPUT", "key": 0, "value": "0,0"},
+        {"topic": "OUTPUT", "key": 0, "value": "0,20"},
+        {"topic": "OUTPUT", "key": 0, "value": "0,0"}
       ]
     },
     {


### PR DESCRIPTION
### Description 

Fixes #2490

UDAF `SUM()` currently throws NPE if asked to `undo` a `null` value.   

This PR primarily fixes:
- the NPE in the variants of SUM.

In addition it ensures each impl of `SUM` has:
- The `undo` function is next to the `aggregate` function for each comparison.
- consistent names for the `valueToAdd` in the `aggregate` function and the `valueToUndo` in the `undo` function.
- consistent ordering of parameters being added together in `aggregate` and `undo` functions.

### Testing done 

Added unit and JSON test.

### Reviewer checklist
- [ ] Ensure docs are updated if necessary. (eg. if a user visible feature is being added or changed).
- [ ] Ensure relevant issues are linked (description should include text like "Fixes #<issue number>")

