### PR TITLE
5.2 keyfield tests

### DIFF
--- a/ksql-engine/src/test/java/io/confluent/ksql/EndToEndEngineTestUtil.java
+++ b/ksql-engine/src/test/java/io/confluent/ksql/EndToEndEngineTestUtil.java
@@ -19,6 +19,8 @@ import static org.hamcrest.CoreMatchers.allOf;
 import static org.hamcrest.CoreMatchers.containsString;
 import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.CoreMatchers.instanceOf;
+import static org.hamcrest.Matchers.anything;
+import static org.hamcrest.Matchers.hasItems;
 import static org.hamcrest.Matchers.is;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertThat;
@@ -42,8 +44,10 @@ import io.confluent.kafka.serializers.KafkaAvroSerializer;
 import io.confluent.ksql.EndToEndEngineTestUtil.WindowData.Type;
 import io.confluent.ksql.function.InternalFunctionRegistry;
 import io.confluent.ksql.function.UdfLoaderUtil;
+import io.confluent.ksql.metastore.MetaStore;
 import io.confluent.ksql.metastore.MetaStoreImpl;
 import io.confluent.ksql.metastore.MutableMetaStore;
+import io.confluent.ksql.metastore.StructuredDataSource;
 import io.confluent.ksql.services.ServiceContext;
 import io.confluent.ksql.services.TestServiceContext;
 import io.confluent.ksql.util.KsqlConfig;
@@ -476,24 +480,6 @@ final class EndToEndEngineTestUtil {
     }
   }
 
-  static class JsonTestCase {
-    private final Path testPath;
-    private final JsonNode node;
-
-    JsonTestCase(final Path testPath, final JsonNode node) {
-      this.testPath = testPath;
-      this.node = node;
-    }
-
-    Path getTestPath() {
-      return testPath;
-    }
-
-    public JsonNode getNode() {
-      return node;
-    }
-  }
-
   static class TestCase {
 
     private final Path testPath;
@@ -507,6 +493,7 @@ final class EndToEndEngineTestUtil {
     private String generatedTopology;
     private String expectedTopology;
     private Map<String, String> persistedProperties;
+    private final PostConditions postConditions;
 
     public String getName() {
       return name;
@@ -520,7 +507,9 @@ final class EndToEndEngineTestUtil {
         final List<Record> inputRecords,
         final List<Record> outputRecords,
         final List<String> statements,
-        final ExpectedException expectedException) {
+        final ExpectedException expectedException,
+        final PostConditions postConditions
+    ) {
       this.topics = topics;
       this.inputRecords = inputRecords;
       this.outputRecords = outputRecords;
@@ -529,6 +518,7 @@ final class EndToEndEngineTestUtil {
       this.properties = ImmutableMap.copyOf(properties);
       this.statements = statements;
       this.expectedException = expectedException;
+      this.postConditions = Objects.requireNonNull(postConditions, "postConditions");
     }
 
     TestCase copyWithName(String newName) {
@@ -540,7 +530,8 @@ final class EndToEndEngineTestUtil {
           inputRecords,
           outputRecords,
           statements,
-          expectedException);
+          expectedException,
+          postConditions);
       copy.setGeneratedTopology(generatedTopology);
       copy.setExpectedTopology(expectedTopology);
       copy.setPersistedProperties(persistedProperties);
@@ -637,6 +628,10 @@ final class EndToEndEngineTestUtil {
       }
     }
 
+    void verifyMetastore(final MetaStore metaStore) {
+      postConditions.verify(metaStore);
+    }
+
     boolean isAnyExceptionExpected() {
       return !expectedException.matchers.isEmpty();
     }
@@ -653,6 +648,35 @@ final class EndToEndEngineTestUtil {
       } else {
         throw e;
       }
+    }
+  }
+
+  @SuppressWarnings("unchecked")
+  static class PostConditions {
+
+    static final PostConditions NONE = new PostConditions(hasItems(anything()));
+
+    final Matcher<Iterable<StructuredDataSource>> sourcesMatcher;
+
+    PostConditions(
+        final Matcher<Iterable<StructuredDataSource>> sourcesMatcher
+    ) {
+      this.sourcesMatcher = Objects.requireNonNull(sourcesMatcher, "sourcesMatcher");
+    }
+
+    public void verify(final MetaStore metaStore) {
+      final Collection<StructuredDataSource> values = metaStore
+          .getAllStructuredDataSources()
+          .values();
+
+      final String text = values.stream()
+          .map(s -> s.getDataSourceType() + ":" + s.getName()
+              + ", key:" + s.getKeyField()
+              + ", value:" + s.getSchema())
+          .collect(Collectors.joining(System.lineSeparator()));
+
+      assertThat("metastore sources after the statements have run:"
+          + System.lineSeparator() + text, values, sourcesMatcher);
     }
   }
 
@@ -954,6 +978,7 @@ final class EndToEndEngineTestUtil {
       assertEquals(testCase.expectedTopology, testCase.generatedTopology);
       testCase.processInput(testDriver, serviceContext.getSchemaRegistryClient());
       testCase.verifyOutput(testDriver, serviceContext.getSchemaRegistryClient());
+      testCase.verifyMetastore(ksqlEngine.getMetaStore());
     } catch (final RuntimeException e) {
       testCase.handleException(e);
     }
@@ -1099,6 +1124,7 @@ final class EndToEndEngineTestUtil {
     }
   }
 
+  @SuppressWarnings("UnstableApiUsage")
   static String buildTestName(
       final Path testPath,
       final String testName,
@@ -1120,22 +1146,6 @@ final class EndToEndEngineTestUtil {
       return Optional.of(parser.parse(schemaString));
     } catch (final Exception e) {
       throw new InvalidFieldException("schema", "failed to parse", e);
-    }
-  }
-
-  @SuppressWarnings("unchecked")
-  static Class<? extends Throwable> parseThrowable(
-      final String className,
-      final String fieldName
-  ) {
-    try {
-      final Class<?> theClass = Class.forName(className);
-      if (!Throwable.class.isAssignableFrom(theClass)) {
-        throw new InvalidFieldException(fieldName, "Type was not a Throwable");
-      }
-      return (Class<? extends Throwable>) theClass;
-    } catch (final ClassNotFoundException e) {
-      throw new InvalidFieldException(fieldName, "Type was not found", e);
     }
   }
 

--- a/ksql-engine/src/test/java/io/confluent/ksql/EndToEndEngineTestUtil.java
+++ b/ksql-engine/src/test/java/io/confluent/ksql/EndToEndEngineTestUtil.java
@@ -870,10 +870,7 @@ final class EndToEndEngineTestUtil {
       final Class<TF> testFileType
   ) {
     return getTestPaths(dir, files).stream()
-        .flatMap(testPath -> {
-          final TF testFile = loadTest(testPath, testFileType);
-          return testFile.buildTests(testPath);
-        });
+        .flatMap(testPath -> buildTests(testPath, testFileType));
   }
 
   /**
@@ -888,12 +885,17 @@ final class EndToEndEngineTestUtil {
     }
   }
 
-  private static <T> T loadTest(final Path testPath, final Class<T> testFileType) {
+  private static <TF extends TestFile<T>, T> Stream<T> buildTests(
+      final Path testPath,
+      final Class<TF> testFileType
+  ) {
     try (InputStream stream = EndToEndEngineTestUtil.class
         .getClassLoader()
-        .getResourceAsStream(testPath.toString())) {
-      return OBJECT_MAPPER.readValue(stream, testFileType);
-    } catch (IOException e) {
+        .getResourceAsStream(testPath.toString())
+    ) {
+      final TF testFile = OBJECT_MAPPER.readValue(stream, testFileType);
+      return testFile.buildTests(testPath);
+    } catch (Exception e) {
       throw new RuntimeException("Unable to load test at path " + testPath, e);
     }
   }

--- a/ksql-engine/src/test/java/io/confluent/ksql/EndToEndEngineTestUtil.java
+++ b/ksql-engine/src/test/java/io/confluent/ksql/EndToEndEngineTestUtil.java
@@ -14,6 +14,7 @@
  */
 package io.confluent.ksql;
 
+import static java.util.Objects.requireNonNull;
 import static org.hamcrest.CoreMatchers.allOf;
 import static org.hamcrest.CoreMatchers.containsString;
 import static org.hamcrest.CoreMatchers.equalTo;
@@ -24,10 +25,12 @@ import static org.junit.Assert.assertThat;
 import static org.junit.Assert.fail;
 import static org.junit.matchers.JUnitMatchers.isThrowable;
 
+import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.ObjectReader;
 import com.fasterxml.jackson.databind.ObjectWriter;
+import com.fasterxml.jackson.databind.node.NullNode;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.Maps;
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
@@ -48,6 +51,7 @@ import io.confluent.ksql.util.KsqlConstants;
 import io.confluent.ksql.util.QueryMetadata;
 import java.io.BufferedReader;
 import java.io.IOException;
+import java.io.InputStream;
 import java.io.InputStreamReader;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
@@ -64,11 +68,8 @@ import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
 import java.util.Properties;
-import java.util.Spliterator;
-import java.util.Spliterators;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
-import java.util.stream.StreamSupport;
 import org.apache.avro.generic.GenericData;
 import org.apache.avro.generic.GenericRecord;
 import org.apache.kafka.clients.consumer.ConsumerConfig;
@@ -129,13 +130,13 @@ final class EndToEndEngineTestUtil {
         assertThat("type mismatch at " + path, o2, instanceOf(Map.class));
         assertThat("keyset mismatch at " + path, ((Map) o1).keySet(), equalTo(((Map)o2).keySet()));
         for (final Object k : ((Map) o1).keySet()) {
-          compare(((Map) o1).get(k), ((Map) o2).get(k), path + "." + String.valueOf(k));
+          compare(((Map) o1).get(k), ((Map) o2).get(k), path + "." + k);
         }
       } else if (o1 instanceof List) {
         assertThat("type mismatch at " + path, o2, instanceOf(List.class));
         assertThat("list size mismatch at " + path, ((List) o1).size(), equalTo(((List)o2).size()));
         for (int i = 0; i < ((List) o1).size(); i++) {
-          compare(((List) o1).get(i), ((List) o2).get(i), path + "." + String.valueOf(i));
+          compare(((List) o1).get(i), ((List) o2).get(i), path + "." + i);
         }
       } else {
         assertThat("type mismatch at " + path, o1.getClass(), equalTo(o2.getClass()));
@@ -322,17 +323,20 @@ final class EndToEndEngineTestUtil {
     private final Optional<org.apache.avro.Schema> schema;
     private final SerdeSupplier serdeSupplier;
     private final int numPartitions;
+    private final int replicas;
 
     Topic(
         final String name,
         final Optional<org.apache.avro.Schema> schema,
         final SerdeSupplier serdeSupplier,
-        final int numPartitions
+        final int numPartitions,
+        final int replicas
     ) {
-      this.name = Objects.requireNonNull(name, "name");
-      this.schema = Objects.requireNonNull(schema, "schema");
-      this.serdeSupplier = Objects.requireNonNull(serdeSupplier, "serdeSupplier");
+      this.name = requireNonNull(name, "name");
+      this.schema = requireNonNull(schema, "schema");
+      this.serdeSupplier = requireNonNull(serdeSupplier, "serdeSupplier");
       this.numPartitions = numPartitions;
+      this.replicas = replicas;
     }
 
     String getName() {
@@ -359,14 +363,19 @@ final class EndToEndEngineTestUtil {
   static class WindowData {
 
     enum Type {SESSION, TIME}
-    private final long start;
-    private final long end;
-    private final Type type;
 
-    WindowData(final long start, final long end, final String type) {
+    final long start;
+    final long end;
+    final Type type;
+
+    WindowData(
+        @JsonProperty("start") final long start,
+        @JsonProperty("end") final long end,
+        @JsonProperty("type") final String type
+    ) {
       this.start = start;
       this.end = end;
-      this.type = Type.valueOf(Objects.requireNonNull(type, "type").toUpperCase());
+      this.type = Type.valueOf(requireNonNull(type, "type").toUpperCase());
     }
 
     public long size() {
@@ -486,6 +495,7 @@ final class EndToEndEngineTestUtil {
   }
 
   static class TestCase {
+
     private final Path testPath;
     private final String name;
     private final Map<String, Object> properties;
@@ -613,7 +623,7 @@ final class EndToEndEngineTestUtil {
 
     void initializeTopics(final ServiceContext serviceContext) {
       for (final Topic topic : topics) {
-        serviceContext.getTopicClient().createTopic(topic.getName(), topic.numPartitions, (short) 1);
+        serviceContext.getTopicClient().createTopic(topic.getName(), topic.numPartitions, (short) topic.replicas);
 
         topic.getSchema()
             .ifPresent(schema -> {
@@ -849,18 +859,20 @@ final class EndToEndEngineTestUtil {
     return Arrays.asList(ksqlTestFiles.split(","));
   }
 
-  static Stream<JsonTestCase> findTestCases(final Path dir, final List<String> files) {
-    final ClassLoader classLoader = EndToEndEngineTestUtil.class.getClassLoader();
+  interface TestFile<TestType> {
 
+    Stream<TestType> buildTests(final Path testPath);
+  }
+
+  static <TF extends TestFile<T>, T> Stream<T> findTestCases(
+      final Path dir,
+      final List<String> files,
+      final Class<TF> testFileType
+  ) {
     return getTestPaths(dir, files).stream()
         .flatMap(testPath -> {
-          final JsonNode rootNode = loadTest(classLoader, testPath);
-
-          final Spliterator<JsonNode> tests = Spliterators.spliteratorUnknownSize(
-              rootNode.findValue("tests").elements(), Spliterator.ORDERED);
-
-          return StreamSupport.stream(tests, false)
-              .map(jsonNode -> new JsonTestCase(testPath, jsonNode));
+          final TF testFile = loadTest(testPath, testFileType);
+          return testFile.buildTests(testPath);
         });
   }
 
@@ -876,9 +888,11 @@ final class EndToEndEngineTestUtil {
     }
   }
 
-  private static JsonNode loadTest(final ClassLoader classLoader, final Path testPath) {
-    try {
-      return OBJECT_MAPPER.readTree(classLoader.getResourceAsStream(testPath.toString()));
+  private static <T> T loadTest(final Path testPath, final Class<T> testFileType) {
+    try (InputStream stream = EndToEndEngineTestUtil.class
+        .getClassLoader()
+        .getResourceAsStream(testPath.toString())) {
+      return OBJECT_MAPPER.readValue(stream, testFileType);
     } catch (IOException e) {
       throw new RuntimeException("Unable to load test at path " + testPath, e);
     }
@@ -1080,6 +1094,71 @@ final class EndToEndEngineTestUtil {
     TopologyAndConfigs(final String topology, final Map<String, String> configs) {
       this.topology = topology;
       this.configs = configs;
+    }
+  }
+
+  static String buildTestName(
+      final Path testPath,
+      final String testName,
+      final String postfix
+  ) {
+    final String fileName = com.google.common.io.Files.getNameWithoutExtension(testPath.toString());
+    final String pf = postfix.isEmpty() ? "" : " - " + postfix;
+    return fileName + " - " + testName + pf;
+  }
+
+  static Optional<org.apache.avro.Schema> buildAvroSchema(final JsonNode schema) {
+    if (schema instanceof NullNode) {
+      return Optional.empty();
+    }
+
+    try {
+      final String schemaString = OBJECT_MAPPER.writeValueAsString(schema);
+      final org.apache.avro.Schema.Parser parser = new org.apache.avro.Schema.Parser();
+      return Optional.of(parser.parse(schemaString));
+    } catch (final Exception e) {
+      throw new InvalidFieldException("schema", "failed to parse", e);
+    }
+  }
+
+  @SuppressWarnings("unchecked")
+  static Class<? extends Throwable> parseThrowable(
+      final String className,
+      final String fieldName
+  ) {
+    try {
+      final Class<?> theClass = Class.forName(className);
+      if (!Throwable.class.isAssignableFrom(theClass)) {
+        throw new InvalidFieldException(fieldName, "Type was not a Throwable");
+      }
+      return (Class<? extends Throwable>) theClass;
+    } catch (final ClassNotFoundException e) {
+      throw new InvalidFieldException(fieldName, "Type was not found", e);
+    }
+  }
+
+  static final class MissingFieldException extends RuntimeException {
+
+    MissingFieldException(final String fieldName) {
+      super("test must define '" + fieldName + "' field");
+    }
+  }
+
+  static final class InvalidFieldException extends RuntimeException {
+
+    InvalidFieldException(
+        final String fieldName,
+        final String reason
+    ) {
+      super(fieldName + ": " + reason);
+    }
+
+    InvalidFieldException(
+        final String fieldName,
+        final String reason,
+        final Throwable cause
+    ) {
+      super(fieldName + ": " + reason, cause);
     }
   }
 }

--- a/ksql-engine/src/test/java/io/confluent/ksql/QueryTranslationTest.java
+++ b/ksql-engine/src/test/java/io/confluent/ksql/QueryTranslationTest.java
@@ -30,8 +30,8 @@ import static io.confluent.ksql.EndToEndEngineTestUtil.loadExpectedTopologies;
 import static io.confluent.ksql.util.KsqlExceptionMatcher.statementText;
 import static java.util.Objects.requireNonNull;
 import static org.hamcrest.Matchers.allOf;
+import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.hasItems;
-import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.nullValue;
 
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
@@ -502,7 +502,7 @@ public class QueryTranslationTest {
 
             if (KsqlStatementException.class.isAssignableFrom(type)) {
               // Ensure exception contains last statement, otherwise the test case is invalid:
-              expectedException.expect(statementText(is(lastStatement)));
+              expectedException.expect(statementText(containsString(lastStatement)));
             }
           });
 

--- a/ksql-engine/src/test/java/io/confluent/ksql/QueryTranslationTest.java
+++ b/ksql-engine/src/test/java/io/confluent/ksql/QueryTranslationTest.java
@@ -29,12 +29,20 @@ import static io.confluent.ksql.EndToEndEngineTestUtil.formatQueryName;
 import static io.confluent.ksql.EndToEndEngineTestUtil.loadExpectedTopologies;
 import static io.confluent.ksql.util.KsqlExceptionMatcher.statementText;
 import static java.util.Objects.requireNonNull;
+import static org.hamcrest.Matchers.allOf;
+import static org.hamcrest.Matchers.hasItems;
 import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.nullValue;
 
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.core.JsonParser;
+import com.fasterxml.jackson.databind.DeserializationContext;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import com.fasterxml.jackson.databind.deser.std.StdDeserializer;
+import com.fasterxml.jackson.databind.node.NullNode;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.Iterables;
@@ -42,13 +50,19 @@ import com.google.common.collect.Streams;
 import io.confluent.connect.avro.AvroData;
 import io.confluent.ksql.EndToEndEngineTestUtil.InvalidFieldException;
 import io.confluent.ksql.EndToEndEngineTestUtil.MissingFieldException;
+import io.confluent.ksql.EndToEndEngineTestUtil.PostConditions;
 import io.confluent.ksql.EndToEndEngineTestUtil.TestCase;
 import io.confluent.ksql.EndToEndEngineTestUtil.TestFile;
 import io.confluent.ksql.EndToEndEngineTestUtil.TopologyAndConfigs;
 import io.confluent.ksql.EndToEndEngineTestUtil.WindowData;
 import io.confluent.ksql.ddl.DdlConfig;
 import io.confluent.ksql.function.InternalFunctionRegistry;
+import io.confluent.ksql.metastore.KsqlStream;
+import io.confluent.ksql.metastore.KsqlTable;
 import io.confluent.ksql.metastore.MetaStoreImpl;
+import io.confluent.ksql.metastore.StructuredDataSource;
+import io.confluent.ksql.metastore.StructuredDataSourceMatchers;
+import io.confluent.ksql.metastore.StructuredDataSourceMatchers.FieldMatchers;
 import io.confluent.ksql.parser.DefaultKsqlParser;
 import io.confluent.ksql.parser.KsqlParser;
 import io.confluent.ksql.parser.KsqlParser.ParsedStatement;
@@ -57,6 +71,7 @@ import io.confluent.ksql.parser.SqlBaseParser;
 import io.confluent.ksql.parser.exception.ParseFailedException;
 import io.confluent.ksql.parser.tree.AbstractStreamCreateStatement;
 import io.confluent.ksql.parser.tree.Expression;
+import io.confluent.ksql.parser.tree.PrimitiveType;
 import io.confluent.ksql.serde.DataSource;
 import io.confluent.ksql.util.KsqlStatementException;
 import io.confluent.ksql.util.StringUtil;
@@ -76,9 +91,12 @@ import java.util.function.Function;
 import java.util.function.Predicate;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
+import org.apache.kafka.connect.data.ConnectSchema;
 import org.apache.kafka.connect.data.Field;
 import org.apache.kafka.connect.data.Schema;
 import org.apache.kafka.connect.data.SchemaBuilder;
+import org.hamcrest.Matcher;
+import org.hamcrest.core.IsInstanceOf;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
@@ -106,7 +124,7 @@ public class QueryTranslationTest {
    */
   @SuppressWarnings("unused")
   public QueryTranslationTest(final String name, final TestCase testCase) {
-    this.testCase = Objects.requireNonNull(testCase, "testCase");
+    this.testCase = requireNonNull(testCase, "testCase");
   }
 
   @Test
@@ -305,6 +323,7 @@ public class QueryTranslationTest {
     }
   }
 
+  @SuppressWarnings("UnstableApiUsage")
   @JsonIgnoreProperties(ignoreUnknown = true)
   static class TestCaseNode {
 
@@ -316,6 +335,7 @@ public class QueryTranslationTest {
     private final List<String> statements;
     private final Map<String, Object> properties;
     private final Optional<ExpectedExceptionNode> expectedException;
+    private final Optional<PostConditionsNode> postConditions;
 
     TestCaseNode(
         @JsonProperty("name") final String name,
@@ -325,7 +345,8 @@ public class QueryTranslationTest {
         @JsonProperty("topics") final List<TopicNode> topics,
         @JsonProperty("statements") final List<String> statements,
         @JsonProperty("properties") final Map<String, Object> properties,
-        @JsonProperty("expectedException") ExpectedExceptionNode expectedException
+        @JsonProperty("expectedException") final ExpectedExceptionNode expectedException,
+        @JsonProperty("post") final PostConditionsNode postConditions
     ) {
       this.name = name == null ? "" : name;
       this.formats = formats == null ? ImmutableList.of() : ImmutableList.copyOf(formats);
@@ -335,6 +356,7 @@ public class QueryTranslationTest {
       this.topics = topics == null ? ImmutableList.of() : ImmutableList.copyOf(topics);
       this.properties = properties == null ? ImmutableMap.of() : ImmutableMap.copyOf(properties);
       this.expectedException = Optional.ofNullable(expectedException);
+      this.postConditions = Optional.ofNullable(postConditions);
 
       if (this.name.isEmpty()) {
         throw new MissingFieldException("name");
@@ -383,6 +405,10 @@ public class QueryTranslationTest {
             .map(node -> node.build(topics))
             .collect(Collectors.toList());
 
+        final PostConditions post = postConditions
+            .map(PostConditionsNode::build)
+            .orElse(PostConditions.NONE);
+
         return new TestCase(
             testPath,
             testName,
@@ -391,7 +417,8 @@ public class QueryTranslationTest {
             inputRecords,
             outputRecords,
             statements,
-            ee.orElseGet(ExpectedException::none)
+            ee.orElseGet(ExpectedException::none),
+            post
         );
       } catch (final Exception e) {
         throw new AssertionError(testName + ": Invalid test. " + e.getMessage(), e);
@@ -469,7 +496,7 @@ public class QueryTranslationTest {
       final ExpectedException expectedException = ExpectedException.none();
 
       type
-          .map(t -> EndToEndEngineTestUtil.parseThrowable(t, "expectedException.type"))
+          .map(ExpectedExceptionNode::parseThrowable)
           .ifPresent(type -> {
             expectedException.expect(type);
 
@@ -481,6 +508,19 @@ public class QueryTranslationTest {
 
       message.ifPresent(expectedException::expectMessage);
       return expectedException;
+    }
+
+    @SuppressWarnings("unchecked")
+    static Class<? extends Throwable> parseThrowable(final String className) {
+      try {
+        final Class<?> theClass = Class.forName(className);
+        if (!Throwable.class.isAssignableFrom(theClass)) {
+          throw new InvalidFieldException("expectedException.type", "Type was not a Throwable");
+        }
+        return (Class<? extends Throwable>) theClass;
+      } catch (final ClassNotFoundException e) {
+        throw new InvalidFieldException("expectedException.type", "Type was not found", e);
+      }
     }
   }
 
@@ -579,6 +619,227 @@ public class QueryTranslationTest {
       } catch (final IOException e) {
         throw new InvalidFieldException("value", "failed to parse", e);
       }
+    }
+  }
+
+  @JsonIgnoreProperties(ignoreUnknown = true)
+  static class PostConditionsNode {
+
+    private final List<SourceNode> sources;
+
+    PostConditionsNode(@JsonProperty("sources") final List<SourceNode> sources) {
+      this.sources = sources == null ? ImmutableList.of() : ImmutableList.copyOf(sources);
+    }
+
+    @SuppressWarnings("unchecked")
+    PostConditions build() {
+      final Matcher<StructuredDataSource>[] matchers = sources.stream()
+          .map(SourceNode::build)
+          .toArray(Matcher[]::new);
+
+      final Matcher<Iterable<StructuredDataSource>> sourcesMatcher = hasItems(matchers);
+      return new PostConditions(sourcesMatcher);
+    }
+  }
+
+  static class SourceNodeDeserializer extends StdDeserializer<SourceNode> {
+
+    public SourceNodeDeserializer() {
+      super(SourceNode.class);
+    }
+
+    @Override
+    public SourceNode deserialize(
+        final JsonParser jp,
+        final DeserializationContext ctxt
+    ) throws IOException {
+
+      final JsonNode node = jp.getCodec().readTree(jp);
+
+      final String name = buildString("name", node, jp);
+      final String type = buildString("type", node, jp);
+      final Optional<FieldNode> keyField = buildKeyField(node, jp);
+
+      return new SourceNode(name, type, keyField);
+    }
+
+    private static String buildString(
+        final String name,
+        final JsonNode node,
+        final JsonParser jp
+    ) throws IOException {
+      return node.get(name).traverse(jp.getCodec()).readValueAs(String.class);
+    }
+
+    private static Optional<FieldNode> buildKeyField(
+        final JsonNode node,
+        final JsonParser jp
+    ) throws IOException {
+      if (!node.has("keyField")) {
+        return Optional.empty();
+      }
+
+      final JsonNode keyField = node.get("keyField");
+      if (keyField instanceof NullNode) {
+        return Optional.of(FieldNode.NULL);
+      }
+
+      return Optional.of(keyField.traverse(jp.getCodec()).readValueAs(FieldNode.class));
+    }
+  }
+
+  @JsonDeserialize(using = SourceNodeDeserializer.class)
+  static class SourceNode {
+
+    private final String name;
+    private final Optional<Class<? extends StructuredDataSource>> type;
+    private final Optional<FieldNode> keyField;
+
+    SourceNode(
+        @JsonProperty("name") final String name,
+        @JsonProperty("type") final String type,
+        @JsonProperty("keyField") final Optional<FieldNode> keyField
+    ) {
+      this.name = name == null ? "" : name;
+      this.keyField = keyField;
+      this.type = Optional.ofNullable(type)
+          .map(String::toUpperCase)
+          .map(SourceNode::toType);
+
+      if (this.name.isEmpty()) {
+        throw new InvalidFieldException("name", "empty or missing");
+      }
+    }
+
+    @SuppressWarnings("unchecked")
+    Matcher<? super StructuredDataSource> build() {
+      if (name.isEmpty()) {
+        throw new InvalidFieldException("name", "missing or empty");
+      }
+
+      final Matcher<StructuredDataSource> nameMatcher = StructuredDataSourceMatchers.hasName(name);
+
+      final Matcher<Object> typeMatcher = type
+          .map(IsInstanceOf::instanceOf)
+          .orElse(null);
+
+      final Matcher<StructuredDataSource> keyFieldMatcher = keyField
+          .map(FieldNode::build)
+          .map(StructuredDataSourceMatchers::hasKeyField)
+          .orElse(null);
+
+      final Matcher[] matchers = Stream.of(nameMatcher, typeMatcher, keyFieldMatcher)
+          .filter(Objects::nonNull)
+          .toArray(Matcher[]::new);
+
+      return allOf(matchers);
+    }
+
+    private static Class<? extends StructuredDataSource> toType(final String type) {
+      switch (type) {
+        case "STREAM":
+          return KsqlStream.class;
+
+        case "TABLE":
+          return KsqlTable.class;
+
+        default:
+          throw new InvalidFieldException("type", "must be either STREAM or TABLE");
+      }
+    }
+  }
+
+  static class FieldNode {
+
+    static final FieldNode NULL = new FieldNode("explicitly set to NULL", Optional.empty());
+
+    private final String name;
+    private final Optional<ConnectSchema> schema;
+
+    FieldNode(
+        @JsonProperty("name") final String name,
+
+        @JsonProperty("schema")
+        @JsonDeserialize(using = ConnectSchemaDeserializer.class) final Optional<ConnectSchema> schema
+    ) {
+      this.name = name == null ? "" : name;
+      this.schema = Objects.requireNonNull(schema, "schema");
+
+      if (this.name.isEmpty()) {
+        throw new InvalidFieldException("name", "empty or missing");
+      }
+    }
+
+    @SuppressWarnings("unchecked")
+    Matcher<Field> build() {
+      if (this == NULL) {
+        return nullValue(Field.class);
+      }
+
+      final Matcher<Field> nameMatcher = FieldMatchers.hasName(name);
+
+      final Matcher<Field> schemaMatcher = schema
+          .map(FieldMatchers::hasSchema)
+          .orElse(null);
+
+      final Matcher[] matchers = Stream.of(nameMatcher, schemaMatcher)
+          .filter(Objects::nonNull)
+          .toArray(Matcher[]::new);
+
+      return allOf(matchers);
+    }
+  }
+
+  static class ConnectSchemaDeserializer extends StdDeserializer<Optional<ConnectSchema>> {
+
+    public ConnectSchemaDeserializer() {
+      super(ConnectSchema.class);
+    }
+
+    @Override
+    public Optional<ConnectSchema> deserialize(
+        final JsonParser jp,
+        final DeserializationContext ctxt
+    ) throws IOException {
+
+      final JsonNode node = jp.getCodec().readTree(jp);
+
+      final String type = buildString("type", node, jp);
+      if (type == null) {
+        throw new MissingFieldException("type");
+      }
+
+      try {
+        final PrimitiveType sqlType = PrimitiveType.getPrimitiveType(type.toUpperCase());
+
+        return Optional.of((ConnectSchema) TypeUtil.getTypeSchema(sqlType));
+      } catch (final Exception e) {
+        throw new InvalidFieldException("type", "only primitive types supported", e);
+      }
+    }
+
+    private static String buildString(
+        final String name,
+        final JsonNode node,
+        final JsonParser jp
+    ) throws IOException {
+      return node.get(name).traverse(jp.getCodec()).readValueAs(String.class);
+    }
+
+    private static Optional<FieldNode> buildKeyField(
+        final JsonNode node,
+        final JsonParser jp
+    ) throws IOException {
+      if (!node.has("keyField")) {
+        return Optional.empty();
+      }
+
+      final JsonNode keyField = node.get("keyField");
+      if (keyField instanceof NullNode) {
+        return Optional.of(FieldNode.NULL);
+      }
+
+      return Optional.of(keyField.traverse(jp.getCodec()).readValueAs(FieldNode.class));
     }
   }
 }

--- a/ksql-engine/src/test/java/io/confluent/ksql/QueryTranslationTest.java
+++ b/ksql-engine/src/test/java/io/confluent/ksql/QueryTranslationTest.java
@@ -22,20 +22,28 @@ import static io.confluent.ksql.EndToEndEngineTestUtil.StringSerdeSupplier;
 import static io.confluent.ksql.EndToEndEngineTestUtil.Topic;
 import static io.confluent.ksql.EndToEndEngineTestUtil.ValueSpecAvroSerdeSupplier;
 import static io.confluent.ksql.EndToEndEngineTestUtil.ValueSpecJsonSerdeSupplier;
+import static io.confluent.ksql.EndToEndEngineTestUtil.buildTestName;
 import static io.confluent.ksql.EndToEndEngineTestUtil.findExpectedTopologyDirectories;
 import static io.confluent.ksql.EndToEndEngineTestUtil.formatQueryName;
 import static io.confluent.ksql.EndToEndEngineTestUtil.loadExpectedTopologies;
 import static io.confluent.ksql.util.KsqlExceptionMatcher.statementText;
+import static java.util.Objects.requireNonNull;
 import static org.hamcrest.Matchers.is;
 
-import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.NullNode;
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.Iterables;
-import com.google.common.io.Files;
+import com.google.common.collect.Streams;
 import io.confluent.connect.avro.AvroData;
-import io.confluent.ksql.EndToEndEngineTestUtil.JsonTestCase;
+import io.confluent.ksql.EndToEndEngineTestUtil.InvalidFieldException;
+import io.confluent.ksql.EndToEndEngineTestUtil.MissingFieldException;
 import io.confluent.ksql.EndToEndEngineTestUtil.TestCase;
+import io.confluent.ksql.EndToEndEngineTestUtil.TestFile;
 import io.confluent.ksql.EndToEndEngineTestUtil.TopologyAndConfigs;
 import io.confluent.ksql.EndToEndEngineTestUtil.WindowData;
 import io.confluent.ksql.ddl.DdlConfig;
@@ -59,20 +67,15 @@ import java.nio.file.Paths;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.HashMap;
-import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
-import java.util.Set;
-import java.util.Spliterator;
-import java.util.Spliterators;
 import java.util.UUID;
 import java.util.function.Function;
 import java.util.function.Predicate;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
-import java.util.stream.StreamSupport;
 import org.apache.kafka.connect.data.Field;
 import org.apache.kafka.connect.data.Schema;
 import org.apache.kafka.connect.data.SchemaBuilder;
@@ -88,6 +91,7 @@ import org.junit.runners.Parameterized;
  */
 @RunWith(Parameterized.class)
 public class QueryTranslationTest {
+
   private static final ObjectMapper objectMapper = new ObjectMapper();
   private static final Path QUERY_VALIDATION_TEST_DIR = Paths.get("query-validation-tests");
   private static final String TOPOLOGY_CHECKS_DIR = "expected_topology/";
@@ -112,11 +116,9 @@ public class QueryTranslationTest {
 
   @Parameterized.Parameters(name = "{0}")
   public static Collection<Object[]> data() {
-    final List<TopologiesAndVersion> expectedTopologies = loadTopologiesAndVersions();
     return buildTestCases()
-          .flatMap(q -> buildVersionedTestCases(q, expectedTopologies))
-          .map(testCase -> new Object[]{testCase.getName(), testCase})
-          .collect(Collectors.toCollection(ArrayList::new));
+        .map(testCase -> new Object[]{testCase.getName(), testCase})
+        .collect(Collectors.toCollection(ArrayList::new));
   }
 
   private static List<TopologiesAndVersion> loadTopologiesAndVersions() {
@@ -161,190 +163,13 @@ public class QueryTranslationTest {
 
   static Stream<TestCase> buildTestCases() {
     final List<String> testFiles = EndToEndEngineTestUtil.getTestFilesParam();
+    final List<TopologiesAndVersion> expectedTopologies = loadTopologiesAndVersions();
 
-    return EndToEndEngineTestUtil.findTestCases(QUERY_VALIDATION_TEST_DIR, testFiles)
-        .flatMap(test -> {
-          final JsonNode formatsNode = test.getNode().get("format");
-          if (formatsNode == null) {
-            return Stream.of(createTest(test, ""));
-          }
-
-          final Spliterator<JsonNode> formats = Spliterators.spliteratorUnknownSize(
-              formatsNode.iterator(), Spliterator.ORDERED);
-
-          return StreamSupport.stream(formats, false)
-              .map(format -> createTest(test, format.asText()));
-        });
-  }
-
-  private static TestCase createTest(final JsonTestCase test, final String format) {
-    final String testName = buildTestName(test, format);
-
-    try {
-      final JsonNode testCase = test.getNode();
-
-      final Map<String, Object> properties = getTestCaseProperties(testCase);
-
-      final List<String> statements = getTestCaseStatements(testCase, format);
-
-      final Optional<ExpectedException> expectedException =
-          getTestCaseExpectedException(testCase, Iterables.getLast(statements));
-
-      final Map<String, Topic> topics =
-          getTestCaseTopics(testCase, statements, expectedException.isPresent());
-
-      final List<Record> inputs = getTestCaseTopicMessages(testCase, topics, "inputs");
-
-      final List<Record> outputs = getTestCaseTopicMessages(testCase, topics, "outputs");
-
-      if (inputs.isEmpty() && !expectedException.isPresent()) {
-        throw new InvalidFieldException("inputs", "is empty and 'expectedException' is not defind");
-      }
-
-      return new TestCase(
-          test.getTestPath(),
-          testName,
-          properties,
-          topics.values(),
-          inputs,
-          outputs,
-          statements,
-          expectedException.orElseGet(ExpectedException::none)
-      );
-    } catch (final Exception e) {
-      throw new AssertionError(testName + ": Invalid test. " + e.getMessage(), e);
-    }
-  }
-
-  private static List<Record> getTestCaseTopicMessages(
-      final JsonNode testCase,
-      final Map<String, Topic> topics,
-      final String fieldName
-  ) {
-    final List<Record> messages = new ArrayList<>();
-    getOptionalJsonField(testCase, fieldName)
-        .ifPresent(node -> node.elements().forEachRemaining(
-            message -> messages.add(
-                createRecordFromNode(topics, message, fieldName + "[]"))));
-
-    return messages;
-  }
-
-  private static Map<String, Topic> getTestCaseTopics(
-      final JsonNode testCase,
-      final List<String> statements,
-      final boolean expectsException
-  ) {
-    final Map<String, Topic> topicsMap = new HashMap<>();
-
-    // Add all topics from topic nodes to the map
-    getOptionalJsonField(testCase, "topics")
-        .ifPresent(topicsNode -> topicsNode.forEach(
-            topicNode -> {
-              final Topic topic = createTopicFromNode(topicNode);
-              topicsMap.put(topic.getName(), createTopicFromNode(topicNode));
-            }
-        ));
-
-    // Infer topics if not added already
-    statements.stream()
-        .map(QueryTranslationTest::createTopicFromStatement)
-        .filter(Objects::nonNull)
-        .forEach(
-            topic -> topicsMap.putIfAbsent(topic.getName(), topic)
-        );
-
-    if (topicsMap.isEmpty()) {
-      if (expectsException) {
-        return topicsMap;
-      }
-      throw new InvalidFieldException("statements/topics", "The test does not define any topics");
-    }
-
-    final SerdeSupplier defaultSerdeSupplier =
-        topicsMap.values().iterator().next().getSerdeSupplier();
-
-    // Get topics from inputs field:
-    final Set<String> msgTopics = getTestCaseMessageTopicNames(testCase, "inputs");
-    msgTopics.addAll(getTestCaseMessageTopicNames(testCase, "outputs"));
-
-    msgTopics.stream()
-        .filter(topicName -> !topicsMap.containsKey(topicName))
-        .forEach(topicName -> topicsMap
-            .put(topicName, (new Topic(topicName, Optional.empty(), defaultSerdeSupplier, 4))));
-
-    return topicsMap;
-  }
-
-  private static Set<String> getTestCaseMessageTopicNames(
-      final JsonNode testCase,
-      final String fieldName
-  ) {
-    final Set<String> allTopics = new HashSet<>();
-
-    getOptionalJsonField(testCase, fieldName)
-        .ifPresent(messages -> messages.elements().forEachRemaining(
-            message -> allTopics
-                .add(getRequiredJsonField(message, "topic", fieldName + "[]").asText())));
-
-    return allTopics;
-  }
-
-  private static List<String> getTestCaseStatements(final JsonNode testCase, final String format) {
-    final List<String> statements = new ArrayList<>();
-    getRequiredJsonField(testCase, "statements").elements()
-        .forEachRemaining(
-            statement -> statements.add(statement.asText().replace("{FORMAT}", format)));
-    return statements;
-  }
-
-  private static Map<String, Object> getTestCaseProperties(final JsonNode testCase) {
-    final Map<String, Object> properties = new HashMap<>();
-    getOptionalJsonField(testCase, "properties")
-        .ifPresent(propNode -> propNode.fields().forEachRemaining(
-            property -> properties.put(property.getKey(), property.getValue().asText())));
-
-    return properties;
-  }
-
-  private static Optional<ExpectedException> getTestCaseExpectedException(
-      final JsonNode testCase,
-      final String lastStatement
-  ) {
-    return getOptionalJsonField(testCase, "expectedException")
-        .map(eeNode -> {
-          final ExpectedException expectedException = ExpectedException.none();
-
-          getOptionalJsonField(eeNode, "type")
-              .map(JsonNode::asText)
-              .map(QueryTranslationTest::parseThrowable)
-              .ifPresent(type -> {
-                expectedException.expect(type);
-
-                if (type.equals(KsqlStatementException.class)) {
-                  // Ensure exception contains last statement, otherwise the test case is invalid:
-                  expectedException.expect(statementText(is(lastStatement)));
-                }
-              });
-
-          getOptionalJsonField(eeNode, "message")
-              .ifPresent(msg -> expectedException.expectMessage(msg.asText()));
-
-          return expectedException;
-        });
-  }
-
-  private static String buildTestName(final JsonTestCase testCase, final String format) {
-    try {
-      final String fileName = Files.getNameWithoutExtension(testCase.getTestPath().toString());
-      final String testName = getRequiredJsonField(testCase.getNode(), "name").asText();
-      final String formatPostFix = format.isEmpty() ? "" : " - " + format;
-
-      return fileName + " - " + testName + formatPostFix;
-    } catch (final MissingFieldException e) {
-      throw new AssertionError(
-          "Test file contains an invalid test case: " + testCase.getTestPath(), e);
-    }
+    return EndToEndEngineTestUtil.findTestCases(
+        QUERY_VALIDATION_TEST_DIR,
+        testFiles,
+        QttTestFile.class)
+        .flatMap(q -> buildVersionedTestCases(q, expectedTopologies));
   }
 
   private static SerdeSupplier getSerdeSupplier(final String format) {
@@ -354,8 +179,11 @@ public class QueryTranslationTest {
       case DataSource.JSON_SERDE_NAME:
         return new ValueSpecJsonSerdeSupplier();
       case DataSource.DELIMITED_SERDE_NAME:
-      default:
         return new StringSerdeSupplier();
+      default:
+        throw new InvalidFieldException("format", format.isEmpty()
+            ? "missing or empty"
+            : "unknown value: " + format);
     }
   }
 
@@ -417,7 +245,7 @@ public class QueryTranslationTest {
       } else {
         avroSchema = Optional.empty();
       }
-      return new Topic(topicName, avroSchema, getSerdeSupplier(format), 1);
+      return new Topic(topicName, avroSchema, getSerdeSupplier(format), 1, 1);
     };
 
     try {
@@ -439,148 +267,6 @@ public class QueryTranslationTest {
     }
   }
 
-  private static Topic createTopicFromNode(final JsonNode node) {
-    final Optional<org.apache.avro.Schema> schema;
-    if (node.has("schema")) {
-      try {
-        final String schemaString = objectMapper.writeValueAsString(node.get("schema"));
-        final org.apache.avro.Schema.Parser parser = new org.apache.avro.Schema.Parser();
-        schema = Optional.of(parser.parse(schemaString));
-      } catch (final JsonProcessingException e) {
-        throw new RuntimeException(e);
-      }
-    } else {
-      schema = Optional.empty();
-    }
-
-    final SerdeSupplier serdeSupplier = getSerdeSupplier(node.get("format").asText());
-
-    final int numPartitions = node.has("partitions")
-        ? node.get("partitions").intValue()
-        : 1;
-
-    return new Topic(node.get("name").asText(), schema, serdeSupplier, numPartitions);
-  }
-
-  private static Record createRecordFromNode(
-      final Map<String, Topic> topics,
-      final JsonNode node,
-      final String scope
-  ) {
-    final String topicName = getRequiredJsonField(node, "topic", scope).asText();
-
-    final String key = getOptionalJsonField(node, "key")
-        .map(JsonNode::asText)
-        .orElse("");
-
-    final Object topicValue;
-    if (node.findValue("value").asText().equals("null")) {
-      topicValue = null;
-    } else if (topics.get(topicName).getSerdeSupplier() instanceof StringSerdeSupplier) {
-      topicValue = node.findValue("value").asText();
-    } else {
-      try {
-        topicValue = objectMapper.readValue(
-            objectMapper.writeValueAsString(node.findValue("value")), Object.class);
-      } catch (final IOException e) {
-        throw new RuntimeException(e);
-      }
-    }
-
-    final long timestamp = getOptionalJsonField(node, "timestamp")
-        .map(JsonNode::asLong)
-        .orElse(0L);
-
-    final WindowData window = createWindowIfExists(node);
-
-
-    return new Record(
-        topics.get(topicName),
-        key,
-        topicValue,
-        timestamp,
-        window
-    );
-  }
-
-  private static WindowData createWindowIfExists(final JsonNode node) {
-    final JsonNode windowNode = node.findValue("window");
-    if (windowNode == null) {
-      return null;
-    }
-
-    return new WindowData(
-        windowNode.findValue("start").asLong(),
-        windowNode.findValue("end").asLong(),
-        windowNode.findValue("type").asText());
-  }
-
-  @SuppressWarnings("unchecked")
-  private static Class<? extends Throwable> parseThrowable(final String className) {
-    try {
-      final Class<?> theClass = Class.forName(className);
-      if (!Throwable.class.isAssignableFrom(theClass)) {
-        throw new InvalidFieldException("expectedException.type", "Type was not a Throwable");
-        }
-        return (Class<? extends Throwable>) theClass;
-    } catch (final ClassNotFoundException e) {
-      throw new InvalidFieldException("expectedException.type", "Type was not found", e);
-    }
-  }
-
-  private static JsonNode getRequiredJsonField(
-      final JsonNode query,
-      final String fieldName
-  ) {
-    return getRequiredJsonField(query, fieldName, "");
-  }
-
-  private static JsonNode getRequiredJsonField(
-      final JsonNode query,
-      final String fieldName,
-      final String scope
-  ) {
-    if (!query.has(fieldName)) {
-      throw new MissingFieldException(scope + "." + fieldName);
-    }
-    return query.findValue(fieldName);
-  }
-
-  private static Optional<JsonNode> getOptionalJsonField(
-      final JsonNode node,
-      final String fieldName
-  ) {
-    if (node.hasNonNull(fieldName)) {
-      return Optional.of(node.findValue(fieldName));
-    }
-    return Optional.empty();
-  }
-
-  private static final class MissingFieldException extends RuntimeException {
-
-    private MissingFieldException(final String fieldName) {
-      super("test it must define '" + fieldName + "' field");
-    }
-  }
-
-  private static final class InvalidFieldException extends RuntimeException {
-
-    private InvalidFieldException(
-        final String fieldName,
-        final String reason
-    ) {
-      super("'" + fieldName + "': " + reason);
-    }
-
-    private InvalidFieldException(
-        final String fieldName,
-        final String reason,
-        final Throwable cause
-    ) {
-      super(fieldName + ": " + reason, cause);
-    }
-  }
-
   private static class TopologiesAndVersion {
 
     private final String version;
@@ -599,4 +285,319 @@ public class QueryTranslationTest {
       return topologies.get(name);
     }
   }
+
+  @JsonIgnoreProperties(ignoreUnknown = true)
+  static class QttTestFile implements TestFile<TestCase> {
+
+    private final List<TestCaseNode> tests;
+
+    QttTestFile(@JsonProperty("tests") final List<TestCaseNode> tests) {
+      this.tests = ImmutableList.copyOf(requireNonNull(tests, "tests collection missing"));
+    }
+
+    @Override
+    public Stream<TestCase> buildTests(final Path testPath) {
+      if (tests.isEmpty()) {
+        throw new IllegalArgumentException(testPath + ": test file did not contain any tests");
+      }
+
+      try {
+        return tests.stream().flatMap(node -> node.buildTests(testPath));
+      } catch (final Exception e) {
+        throw new IllegalArgumentException(testPath + ": " + e.getMessage(), e);
+      }
+    }
+  }
+
+  static final class ExpectedExceptionNode {
+
+    private final Optional<String> type;
+    private final Optional<String> message;
+
+    ExpectedExceptionNode(
+        @JsonProperty("type") final String type,
+        @JsonProperty("message") final String message
+    ) {
+      this.type = Optional.ofNullable(type);
+      this.message = Optional.ofNullable(message);
+    }
+
+    ExpectedException build(final String lastStatement) {
+      if (!type.isPresent() && !message.isPresent()) {
+        throw new MissingFieldException("expectedException.type or expectedException.message");
+      }
+
+      final ExpectedException expectedException = ExpectedException.none();
+
+      type
+          .map(t -> EndToEndEngineTestUtil.parseThrowable(t, "expectedException.type"))
+          .ifPresent(type -> {
+            expectedException.expect(type);
+
+            if (KsqlStatementException.class.isAssignableFrom(type)) {
+              // Ensure exception contains last statement, otherwise the test case is invalid:
+              expectedException.expect(statementText(is(lastStatement)));
+            }
+          });
+
+      message.ifPresent(expectedException::expectMessage);
+      return expectedException;
+    }
+  }
+
+  @JsonIgnoreProperties(ignoreUnknown = true)
+  static class TestCaseNode {
+
+    private final String name;
+    private final List<String> formats;
+    private final List<RecordNode> inputs;
+    private final List<RecordNode> outputs;
+    private final List<TopicNode> topics;
+    private final List<String> statements;
+    private final Map<String, Object> properties;
+    private final Optional<ExpectedExceptionNode> expectedException;
+
+    TestCaseNode(
+        @JsonProperty("name") final String name,
+        @JsonProperty("format") final List<String> formats,
+        @JsonProperty("inputs") final List<RecordNode> inputs,
+        @JsonProperty("outputs") final List<RecordNode> outputs,
+        @JsonProperty("topics") final List<TopicNode> topics,
+        @JsonProperty("statements") final List<String> statements,
+        @JsonProperty("properties") final Map<String, Object> properties,
+        @JsonProperty("expectedException") ExpectedExceptionNode expectedException
+    ) {
+      this.name = name == null ? "" : name;
+      this.formats = formats == null ? ImmutableList.of() : ImmutableList.copyOf(formats);
+      this.statements = statements == null ? ImmutableList.of() : ImmutableList.copyOf(statements);
+      this.inputs = inputs == null ? ImmutableList.of() : ImmutableList.copyOf(inputs);
+      this.outputs = outputs == null ? ImmutableList.of() : ImmutableList.copyOf(outputs);
+      this.topics = topics == null ? ImmutableList.of() : ImmutableList.copyOf(topics);
+      this.properties = properties == null ? ImmutableMap.of() : ImmutableMap.copyOf(properties);
+      this.expectedException = Optional.ofNullable(expectedException);
+    }
+
+    Stream<TestCase> buildTests(final Path testPath) {
+      if (name.isEmpty()) {
+        throw new MissingFieldException("name");
+      }
+
+      try {
+        if (statements.isEmpty()) {
+          throw new InvalidFieldException("statements", "was empty");
+        }
+
+        if (inputs.isEmpty() != outputs.isEmpty()) {
+          throw new InvalidFieldException("inputs and outputs",
+              "either both, or neither, field should be set");
+        }
+
+        if (!inputs.isEmpty() && expectedException.isPresent()) {
+          throw new InvalidFieldException("inputs and expectedException",
+              "can not both be set");
+        }
+
+        return formats.isEmpty()
+            ? Stream.of(createTest("", testPath))
+            : formats.stream().map(format -> createTest(format, testPath));
+      } catch (final Exception e) {
+        throw new IllegalArgumentException("test '" + name + "': " + e.getMessage(), e);
+      }
+    }
+
+    private TestCase createTest(final String format, final Path testPath) {
+      final String testName = buildTestName(testPath, name, format);
+
+      try {
+        final List<String> statements = buildStatements(format);
+
+        final Optional<ExpectedException> ee = buildExpectedException(statements);
+
+        final Map<String, Topic> topics = getTestCaseTopics(statements, ee.isPresent());
+
+        final List<Record> inputRecords = inputs.stream()
+            .map(node -> node.build(topics))
+            .collect(Collectors.toList());
+
+        final List<Record> outputRecords = outputs.stream()
+            .map(node -> node.build(topics))
+            .collect(Collectors.toList());
+
+        return new TestCase(
+            testPath,
+            testName,
+            properties,
+            topics.values(),
+            inputRecords,
+            outputRecords,
+            statements,
+            ee.orElseGet(ExpectedException::none)
+        );
+      } catch (final Exception e) {
+        throw new AssertionError(testName + ": Invalid test. " + e.getMessage(), e);
+      }
+    }
+
+    private Optional<ExpectedException> buildExpectedException(final List<String> statements) {
+      return this.expectedException
+          .map(ee -> ee.build(Iterables.getLast(statements)));
+    }
+
+    private List<String> buildStatements(final String format) {
+      return statements.stream()
+          .map(stmt -> stmt.replace("{FORMAT}", format))
+          .collect(Collectors.toList());
+    }
+
+    private Map<String, Topic> getTestCaseTopics(
+        final List<String> statements,
+        final boolean expectsException
+    ) {
+      final Map<String, Topic> allTopics = new HashMap<>();
+
+      // Add all topics from topic nodes to the map:
+      topics.stream()
+          .map(TopicNode::build)
+          .forEach(topic -> allTopics.put(topic.getName(), topic));
+
+      // Infer topics if not added already:
+      statements.stream()
+          .map(QueryTranslationTest::createTopicFromStatement)
+          .filter(Objects::nonNull)
+          .forEach(
+              topic -> allTopics.putIfAbsent(topic.getName(), topic)
+          );
+
+      if (allTopics.isEmpty()) {
+        if (expectsException) {
+          return ImmutableMap.of();
+        }
+        throw new InvalidFieldException("statements/topics", "The test does not define any topics");
+      }
+
+      final SerdeSupplier defaultSerdeSupplier =
+          allTopics.values().iterator().next().getSerdeSupplier();
+
+      // Get topics from inputs and outputs fields:
+      Streams.concat(inputs.stream(), outputs.stream())
+          .map(RecordNode::topicName)
+          .map(topicName -> new Topic(topicName, Optional.empty(), defaultSerdeSupplier, 4, 1))
+          .forEach(topic -> allTopics.putIfAbsent(topic.getName(), topic));
+
+      return allTopics;
+    }
+  }
+
+  static class TopicNode {
+
+    private final String name;
+    private final String format;
+    private final int numPartitions;
+    private final JsonNode schema;
+    private final int replicas;
+
+    TopicNode(
+        @JsonProperty("name") final String name,
+        @JsonProperty("schema") final JsonNode schema,
+        @JsonProperty("format") final String format,
+        @JsonProperty("partitions") final Integer numPartitions,
+        @JsonProperty("replicas") final Integer replicas
+    ) {
+      this.name = name == null ? "" : name;
+      this.schema = requireNonNull(schema, "schema");
+      this.format = format == null ? "" : format;
+      this.numPartitions = numPartitions == null ? 1 : numPartitions;
+      this.replicas = replicas == null ? 1 : replicas;
+    }
+
+    Topic build() {
+      if (name.isEmpty()) {
+        throw new InvalidFieldException("name", "empty or missing");
+      }
+
+      return new Topic(
+          name,
+          buildAvroSchema(),
+          getSerdeSupplier(format),
+          numPartitions,
+          replicas
+      );
+    }
+
+    private Optional<org.apache.avro.Schema> buildAvroSchema() {
+      if (schema instanceof NullNode) {
+        return Optional.empty();
+      }
+
+      try {
+        final String schemaString = objectMapper.writeValueAsString(schema);
+        final org.apache.avro.Schema.Parser parser = new org.apache.avro.Schema.Parser();
+        return Optional.of(parser.parse(schemaString));
+      } catch (final Exception e) {
+        throw new InvalidFieldException("schema", "failed to parse", e);
+      }
+    }
+  }
+
+  static class RecordNode {
+
+    private final String topicName;
+    private final String key;
+    private final JsonNode value;
+    private final long timestamp;
+    private final Optional<WindowData> window;
+
+    RecordNode(
+        @JsonProperty("topic") final String topicName,
+        @JsonProperty("key") final String key,
+        @JsonProperty("value") final JsonNode value,
+        @JsonProperty("timestamp") final Long timestamp,
+        @JsonProperty("window") final WindowData window
+    ) {
+      this.topicName = topicName == null ? "" : topicName;
+      this.key = key == null ? "" : key;
+      this.value = requireNonNull(value, "value");
+      this.timestamp = timestamp == null ? 0L : timestamp;
+      this.window = Optional.ofNullable(window);
+    }
+
+    public String topicName() {
+      if (topicName.isEmpty()) {
+        throw new MissingFieldException("topic");
+      }
+
+      return topicName;
+    }
+
+    private Record build(final Map<String, Topic> topics) {
+      final Topic topic = topics.get(topicName());
+
+      final Object topicValue = buildValue(topic);
+
+      return new Record(
+          topic,
+          key,
+          topicValue,
+          timestamp,
+          window.orElse(null)
+      );
+    }
+
+    private Object buildValue(final Topic topic) {
+      if (value.asText().equals("null")) {
+        return null;
+      }
+
+      if (topic.getSerdeSupplier() instanceof StringSerdeSupplier) {
+        return value.asText();
+      }
+
+      try {
+        return objectMapper.readValue(objectMapper.writeValueAsString(value), Object.class);
+      } catch (final IOException e) {
+        throw new InvalidFieldException("value", "failed to parse", e);
+      }
+    }
+  }
 }
+

--- a/ksql-engine/src/test/java/io/confluent/ksql/SchemaTranslationTest.java
+++ b/ksql-engine/src/test/java/io/confluent/ksql/SchemaTranslationTest.java
@@ -32,6 +32,7 @@ import com.fasterxml.jackson.databind.JsonNode;
 import com.google.common.collect.ImmutableList;
 import io.confluent.avro.random.generator.Generator;
 import io.confluent.ksql.EndToEndEngineTestUtil.MissingFieldException;
+import io.confluent.ksql.EndToEndEngineTestUtil.PostConditions;
 import io.confluent.ksql.EndToEndEngineTestUtil.TestFile;
 import java.nio.file.Path;
 import java.nio.file.Paths;
@@ -187,7 +188,9 @@ public class SchemaTranslationTest {
             inputRecords,
             outputRecords,
             ImmutableList.of(DDL_STATEMENT, csasStatement),
-            EndToEndEngineTestUtil.ExpectedException.none()));
+            EndToEndEngineTestUtil.ExpectedException.none(),
+            PostConditions.NONE
+        ));
       } catch (final Exception e) {
         throw new AssertionError(testName + ": Invalid test. " + e.getMessage(), e);
       }

--- a/ksql-engine/src/test/java/io/confluent/ksql/SchemaTranslationTest.java
+++ b/ksql-engine/src/test/java/io/confluent/ksql/SchemaTranslationTest.java
@@ -21,28 +21,28 @@ import static io.confluent.ksql.EndToEndEngineTestUtil.TestCase;
 import static io.confluent.ksql.EndToEndEngineTestUtil.Topic;
 import static io.confluent.ksql.EndToEndEngineTestUtil.ValueSpecAvroSerdeSupplier;
 import static io.confluent.ksql.EndToEndEngineTestUtil.avroToValueSpec;
+import static io.confluent.ksql.EndToEndEngineTestUtil.buildAvroSchema;
+import static io.confluent.ksql.EndToEndEngineTestUtil.buildTestName;
 import static io.confluent.ksql.EndToEndEngineTestUtil.findTestCases;
+import static java.util.Objects.requireNonNull;
 
-import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.databind.JsonNode;
-import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.common.collect.ImmutableList;
-import com.google.common.io.Files;
 import io.confluent.avro.random.generator.Generator;
-import io.confluent.ksql.EndToEndEngineTestUtil.JsonTestCase;
-import java.io.IOException;
+import io.confluent.ksql.EndToEndEngineTestUtil.MissingFieldException;
+import io.confluent.ksql.EndToEndEngineTestUtil.TestFile;
 import java.nio.file.Path;
 import java.nio.file.Paths;
-import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
-import java.util.LinkedList;
 import java.util.List;
-import java.util.Map;
 import java.util.Optional;
 import java.util.Random;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
+import java.util.stream.Stream;
 import org.apache.avro.Schema;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -51,12 +51,16 @@ import org.junit.runners.Parameterized;
 
 @RunWith(Parameterized.class)
 public class SchemaTranslationTest {
-  private static final ObjectMapper objectMapper = new ObjectMapper();
+
   private static final Path SCHEMA_VALIDATION_TEST_DIR = Paths.get("schema-validation-tests");
   private static final String TOPIC_NAME = "TEST_INPUT";
   private static final String OUTPUT_TOPIC_NAME = "TEST_OUTPUT";
+  private static final String DDL_STATEMENT = "CREATE STREAM " + TOPIC_NAME
+      + " WITH (KAFKA_TOPIC='" + TOPIC_NAME + "', VALUE_FORMAT='AVRO');";
 
   private final TestCase testCase;
+  private static final Topic OUTPUT_TOPIC = new Topic(OUTPUT_TOPIC_NAME, Optional.empty(),
+      new ValueSpecAvroSerdeSupplier(), 4, 1);
 
   @SuppressWarnings("unused")
   public SchemaTranslationTest(final String name, final TestCase testCase) {
@@ -72,13 +76,11 @@ public class SchemaTranslationTest {
   public static Collection<Object[]> data() {
     final List<String> testFiles = EndToEndEngineTestUtil.getTestFilesParam();
 
-    return findTestCases(SCHEMA_VALIDATION_TEST_DIR, testFiles)
-        .map(SchemaTranslationTest::loadTest)
-        .map(q -> new Object[]{q.getName(), q})
+    return findTestCases(SCHEMA_VALIDATION_TEST_DIR, testFiles, SttTestFile.class)
+        .map(test -> new Object[]{test.getName(), test})
         .collect(Collectors.toList());
   }
 
-  @SuppressWarnings("unchecked")
   private static List<Record> generateInputRecords(
       final Topic topic, final org.apache.avro.Schema avroSchema) {
     final Generator generator = new Generator(avroSchema, new Random());
@@ -93,7 +95,6 @@ public class SchemaTranslationTest {
     ).collect(Collectors.toList());
   }
 
-  @SuppressWarnings("unchecked")
   private static List<Record> getOutputRecords(
       final Topic topic, final List<Record> inputRecords,
       final org.apache.avro.Schema avroSchema) {
@@ -110,87 +111,87 @@ public class SchemaTranslationTest {
 
   }
 
-  private static Object loadRecordSpec(final JsonNode node) {
-    try {
-      return objectMapper.readValue(
-          objectMapper.writeValueAsString(node), Map.class);
-    } catch (final IOException e) {
-      throw new RuntimeException(e);
+  @JsonIgnoreProperties(ignoreUnknown = true)
+  static class SttTestFile implements TestFile<TestCase> {
+
+    private final List<TestCaseNode> tests;
+
+    SttTestFile(@JsonProperty("tests") final List<TestCaseNode> tests) {
+      this.tests = ImmutableList.copyOf(requireNonNull(tests, "tests collection missing"));
+    }
+
+    @Override
+    public Stream<TestCase> buildTests(final Path testPath) {
+      if (tests.isEmpty()) {
+        throw new IllegalArgumentException(testPath + ": test file did not contain any tests");
+      }
+
+      try {
+        return tests.stream().flatMap(node -> node.buildTests(testPath));
+      } catch (final Exception e) {
+        throw new IllegalArgumentException(testPath + ": " + e.getMessage(), e);
+      }
     }
   }
 
-  @SuppressWarnings("unchecked")
-  private static List<Record> loadRecords(final Topic topic, final JsonNode node) {
-    final List<Record> records = new LinkedList<>();
-    node.forEach(
-        child -> records.add(
-            new Record(
-                topic,
-                "test-key",
-                loadRecordSpec(child),
-                0,
-                null
-            )
-        )
-    );
-    return records;
-  }
+  @JsonIgnoreProperties(ignoreUnknown = true)
+  static class TestCaseNode {
 
-  private static TestCase loadTest(final JsonTestCase testCase) {
-    final JsonNode node = testCase.getNode();
+    private final String name;
+    private final JsonNode schema;
 
-    final String name = Files.getNameWithoutExtension(testCase.getTestPath().toString())
-        + " - "
-        + node.get("name").asText();
-
-    final JsonNode schemaNode = node.get("schema");
-    final String schemaString;
-    try {
-      schemaString = new ObjectMapper().writeValueAsString(schemaNode);
-    } catch (final JsonProcessingException e) {
-      throw new RuntimeException(e);
+    TestCaseNode(
+        @JsonProperty("name") final String name,
+        @JsonProperty("schema") final JsonNode schema
+    ) {
+      this.name = name == null ? "" : name;
+      this.schema = requireNonNull(schema, "schema");
     }
 
-    final org.apache.avro.Schema.Parser parser = new org.apache.avro.Schema.Parser();
-    final org.apache.avro.Schema avroSchema = parser.parse(schemaString);
+    Stream<TestCase> buildTests(final Path testPath) {
+      if (name.isEmpty()) {
+        throw new MissingFieldException("name");
+      }
 
-    final Topic srcTopic;
-    final Topic outputTopic
-        = new Topic(OUTPUT_TOPIC_NAME, Optional.empty(), new ValueSpecAvroSerdeSupplier(), 4);
-    final List<Record> inputRecords;
-    final List<Record> outputRecords;
-    if (node.has("input_records")) {
-      srcTopic = new Topic(TOPIC_NAME, Optional.of(avroSchema), new ValueSpecAvroSerdeSupplier(), 1);
-      inputRecords = loadRecords(srcTopic, node.get("input_records"));
-      outputRecords = loadRecords(outputTopic, node.get("output_records"));
-    } else {
-      srcTopic = new Topic(TOPIC_NAME, Optional.of(avroSchema), new AvroSerdeSupplier(), 1);
-      inputRecords = generateInputRecords(srcTopic, avroSchema);
-      outputRecords = getOutputRecords(outputTopic, inputRecords, avroSchema);
-    }
+      final String testName = buildTestName(testPath, name, "");
 
-    final String ddlStatement =
-        String.format(
-            "CREATE STREAM %s WITH (KAFKA_TOPIC='%s', VALUE_FORMAT='AVRO');",
-            TOPIC_NAME, TOPIC_NAME);
-    final String csasStatement = avroSchema.getFields()
-        .stream()
-        .map(Schema.Field::name)
-        .collect(
-            Collectors.joining(
-                ", ",
-                "CREATE STREAM " + OUTPUT_TOPIC_NAME + " AS SELECT ",
-                " FROM " + TOPIC_NAME + ";")
+      try {
+        final Schema avroSchema = buildAvroSchema(schema)
+            .orElseThrow(() -> new MissingFieldException("schema"));
+
+        final Topic srcTopic = new Topic(
+            TOPIC_NAME,
+            Optional.of(avroSchema),
+            new AvroSerdeSupplier(),
+            1,
+            1
         );
 
-    return new TestCase(
-        testCase.getTestPath(),
-        name,
-        Collections.emptyMap(),
-        ImmutableList.of(srcTopic, outputTopic),
-        inputRecords,
-        outputRecords,
-        Arrays.asList(ddlStatement, csasStatement),
-        EndToEndEngineTestUtil.ExpectedException.none());
+        final List<Record> inputRecords = generateInputRecords(srcTopic, avroSchema);
+        final List<Record> outputRecords = getOutputRecords(OUTPUT_TOPIC, inputRecords, avroSchema);
+
+        final String csasStatement = avroSchema.getFields()
+            .stream()
+            .map(Schema.Field::name)
+            .collect(
+                Collectors.joining(
+                    ", ",
+                    "CREATE STREAM " + OUTPUT_TOPIC_NAME + " AS SELECT ",
+                    " FROM " + TOPIC_NAME + ";")
+            );
+
+        return Stream.of(new TestCase(
+            testPath,
+            name,
+            Collections.emptyMap(),
+            ImmutableList.of(srcTopic, OUTPUT_TOPIC),
+            inputRecords,
+            outputRecords,
+            ImmutableList.of(DDL_STATEMENT, csasStatement),
+            EndToEndEngineTestUtil.ExpectedException.none()));
+      } catch (final Exception e) {
+        throw new AssertionError(testName + ": Invalid test. " + e.getMessage(), e);
+      }
+    }
   }
 }

--- a/ksql-engine/src/test/java/io/confluent/ksql/util/AvroSchemaInferenceTest.java
+++ b/ksql-engine/src/test/java/io/confluent/ksql/util/AvroSchemaInferenceTest.java
@@ -441,7 +441,7 @@ public class AvroSchemaInferenceTest {
         .endRecord();
     final SchemaBuilder ksqlStreamSchemaBuilder = SchemaBuilder.struct();
     if (ksqlSchema != null) {
-      ksqlStreamSchemaBuilder.field("FIELD0", ksqlSchema).build();
+      ksqlStreamSchemaBuilder.field("FIELD0", ksqlSchema);
     }
     shouldInferSchema(avroStreamSchema, ksqlStreamSchemaBuilder.build());
   }

--- a/ksql-engine/src/test/resources/query-validation-tests/elements.json
+++ b/ksql-engine/src/test/resources/query-validation-tests/elements.json
@@ -105,9 +105,7 @@
           "format": "AVRO",
           "partitions": 4
         }
-      ],
-      "inputs": [{"topic": "input", "value": {"c1": 4}}],
-      "outputs": [{"topic": "S", "value": {"C1": 4}}]
+      ]
     }
   ]
 }

--- a/ksql-engine/src/test/resources/query-validation-tests/key-field.json
+++ b/ksql-engine/src/test/resources/query-validation-tests/key-field.json
@@ -1,0 +1,658 @@
+{
+  "comments": [
+    "Tests covering handling of key-fields.",
+    "The 'key-field' is an optional field within the value that matches the key",
+    "",
+    "There are four main dimensions to this test suite:",
+    " - source type:",
+    "   - stream",
+    "   - table",
+    " - source key:",
+    "   - initially null",
+    "   - initially set",
+    " - explicit changing of key:",
+    "   - no key change",
+    "   - partition by (same key)",
+    "   - partition by (different key)",
+    "   - group by (same key)",
+    "   - group by (different key)",
+    " - key present in target value schema:",
+    "   - key in value",
+    "   - key not in value",
+    " - aliasing of the key field in the value schema",
+    "   - no aliasing",
+    "   - aliased key field",
+    "",
+    "Not all combinations are valid, e.g. can not have an alias is there is no key.",
+    "",
+    "issue: this is currently an inconsistency between how GROUP BY's and PARTITION BY's handling of aliases:",
+    " - PARTITION BY requires the target name, (i.e. the alias), failing if the source field name is used.",
+    " - GROUP BY requires the source field name, failing if the target field name, (i.e. the alias), is used."
+  ],
+  "tests": [
+    {
+      "name": "stream | initially null | no key change | - | -",
+      "statements": [
+        "CREATE STREAM INPUT (foo INT, bar INT) WITH (kafka_topic='input_topic', value_format='JSON');",
+        "CREATE STREAM OUTPUT AS SELECT * FROM INPUT;"
+      ],
+      "inputs": [
+        {"topic": "input_topic", "value": {"foo": 1, "bar": 2}}
+      ],
+      "outputs": [
+        {"topic": "OUTPUT", "value": {"FOO":1, "BAR": 2}}
+      ],
+      "post": {
+        "sources": [
+          {"name": "OUTPUT", "type": "stream", "keyField": null}
+        ]
+      }
+    },
+    {
+      "name": "stream | initially null | partition by (-) | key in value | no aliasing",
+      "statements": [
+        "CREATE STREAM INPUT (foo INT, bar INT) WITH (kafka_topic='input_topic', value_format='JSON');",
+        "CREATE STREAM OUTPUT AS SELECT * FROM INPUT PARTITION BY foo;"
+      ],
+      "inputs": [
+        {"topic": "input_topic", "value": {"foo": 1, "bar": 2}}
+      ],
+      "outputs": [
+        {"topic": "OUTPUT", "key": "1", "value": {"FOO":1, "BAR": 2}}
+      ],
+      "post": {
+        "issues": ["key field of OUTPUT has INCORRECT type: Should be 'STRING'."],
+        "sources": [
+          {"name": "OUTPUT", "type": "stream", "keyField": {"name": "FOO", "schema": {"type": "INT"}}}
+        ]
+      }
+    },
+    {
+      "name": "stream | initially null | partition by (-) | key in value | aliasing",
+      "statements": [
+        "CREATE STREAM INPUT (foo INT, bar INT) WITH (kafka_topic='input_topic', value_format='JSON');",
+        "CREATE STREAM OUTPUT AS SELECT foo AS ALIASED, bar FROM INPUT PARTITION BY ALIASED;"
+      ],
+      "inputs": [
+        {"topic": "input_topic", "value": {"foo": 1, "bar": 2}}
+      ],
+      "outputs": [
+        {"topic": "OUTPUT", "key": "1", "value": {"ALIASED":1, "BAR": 2}}
+      ],
+      "post": {
+        "issues": ["key field of OUTPUT has INCORRECT type: Should be 'STRING'."],
+        "sources": [
+          {"name": "OUTPUT", "type": "stream", "keyField": {"name": "ALIASED", "schema": {"type": "INT"}}}
+        ]
+      }
+    },
+    {
+      "name": "stream | initially null | partition by (-) | key not in value | -",
+      "statements": [
+        "CREATE STREAM INPUT (foo INT, bar INT) WITH (kafka_topic='input_topic', value_format='JSON');",
+        "CREATE STREAM OUTPUT AS SELECT bar FROM INPUT PARTITION BY foo;"
+      ],
+      "expectedException": {
+        "type": "io.confluent.ksql.util.KsqlStatementException",
+        "message": "Column FOO does not exist in the result schema. Error in Partition By clause."
+      }
+    },
+    {
+      "name": "stream | initially null | group by (-) | key in value | no aliasing",
+      "statements": [
+        "CREATE STREAM INPUT (foo INT, bar INT) WITH (kafka_topic='input_topic', value_format='JSON');",
+        "CREATE TABLE OUTPUT AS SELECT foo, COUNT(*) FROM INPUT GROUP BY foo;"
+      ],
+      "inputs": [
+        {"topic": "input_topic", "value": {"foo": 1, "bar": 2}}
+      ],
+      "outputs": [
+        {"topic": "OUTPUT", "key": "1", "value": {"FOO":1, "KSQL_COL_1": 1}}
+      ],
+      "post": {
+        "issues": ["key field of output has INCORRECT name: should be 'FOO'."],
+        "sources": [
+          {"name": "OUTPUT", "type": "table", "keyField": {"name": "KSQL_INTERNAL_COL_0", "schema": {"type": "STRING"}}}
+        ]
+      }
+    },
+    {
+      "name": "stream | initially null | group by (-) | key in value | aliasing",
+      "statements": [
+        "CREATE STREAM INPUT (foo INT, bar INT) WITH (kafka_topic='input_topic', value_format='JSON');",
+        "CREATE TABLE OUTPUT AS SELECT foo AS Aliased, COUNT(*) FROM INPUT GROUP BY foo;"
+      ],
+      "inputs": [
+        {"topic": "input_topic", "value": {"foo": 1, "bar": 2}}
+      ],
+      "outputs": [
+        {"topic": "OUTPUT", "key": "1", "value": {"ALIASED":1, "KSQL_COL_1": 1}}
+      ],
+      "post": {
+        "issues": ["key field of output has INCORRECT name: should be 'ALIASED'."],
+        "sources": [
+          {"name": "OUTPUT", "type": "table", "keyField": {"name": "KSQL_INTERNAL_COL_0", "schema": {"type": "STRING"}}}
+        ]
+      }
+    },
+    {
+      "name": "stream | initially null | group by (-) | key not in value | -",
+      "statements": [
+        "CREATE STREAM INPUT (foo INT, bar INT) WITH (kafka_topic='input_topic', value_format='JSON');",
+        "CREATE TABLE OUTPUT AS SELECT COUNT(*) FROM INPUT GROUP BY foo;"
+      ],
+      "inputs": [
+        {"topic": "input_topic", "value": {"foo": 1, "bar": 2}}
+      ],
+      "outputs": [
+        {"topic": "OUTPUT", "key": "1", "value": {"KSQL_COL_0": 1}}
+      ],
+      "post": {
+        "issues": ["key field of output has INCORRECT name: should be 'ALIASED'."],
+        "sources": [
+          {"name": "OUTPUT", "type": "table", "keyField": {"name": "KSQL_INTERNAL_COL_1", "schema": {"type": "STRING"}}}
+        ]
+      }
+    },
+    {
+      "name": "stream | initially set | no key change | key in value | no aliasing",
+      "statements": [
+        "CREATE STREAM INPUT (foo INT, bar INT) WITH (kafka_topic='input_topic', key='foo', value_format='JSON');",
+        "CREATE STREAM OUTPUT AS SELECT * FROM INPUT;"
+      ],
+      "inputs": [
+        {"topic": "input_topic", "value": {"foo": 1, "bar": 2}}
+      ],
+      "outputs": [
+        {"topic": "OUTPUT", "value": {"FOO":1, "BAR": 2}}
+      ],
+      "post": {
+        "issues": ["key field of output has INCORRECT type: should be 'STRING'."],
+        "sources": [
+          {"name": "OUTPUT", "type": "stream", "keyField": {"name": "FOO", "schema": {"type": "INT"}}}
+        ]
+      }
+    },
+    {
+      "name": "stream | initially set | no key change | key in value | aliasing",
+      "statements": [
+        "CREATE STREAM INPUT (foo INT, bar INT) WITH (kafka_topic='input_topic', key='foo', value_format='JSON');",
+        "CREATE STREAM OUTPUT AS SELECT foo as aliased, bar FROM INPUT;"
+      ],
+      "inputs": [
+        {"topic": "input_topic", "value": {"foo": 1, "bar": 2}}
+      ],
+      "outputs": [
+        {"topic": "OUTPUT", "value": {"ALIASED":1, "BAR": 2}}
+      ],
+      "post": {
+        "issues": [
+          "key field of output has INCORRECT name: should be 'ALIASED'.",
+          "key field of output has INCORRECT type: should be 'STRING'."
+          ],
+        "sources": [
+          {"name": "OUTPUT", "type": "stream", "keyField": {"name": "FOO", "schema": {"type": "INT"}}}
+        ]
+      }
+    },
+    {
+      "name": "stream | initially set | no key change | key not in value | -",
+      "statements": [
+        "CREATE STREAM INPUT (foo INT, bar INT) WITH (kafka_topic='input_topic', key='foo', value_format='JSON');",
+        "CREATE STREAM OUTPUT AS SELECT bar FROM INPUT;"
+      ],
+      "inputs": [
+        {"topic": "input_topic", "value": {"foo": 1, "bar": 2}}
+      ],
+      "outputs": [
+        {"topic": "OUTPUT", "value": {"BAR": 2}}
+      ],
+      "post": {
+        "issues": ["key field of output INCORRECT: should be null."],
+        "sources": [
+          {"name": "OUTPUT", "type": "stream", "keyField": {"name": "FOO", "schema": {"type": "INT"}}}
+        ]
+      }
+    },
+    {
+      "name": "stream | initially set | partition by (same) | key in value | no aliasing",
+      "statements": [
+        "CREATE STREAM INPUT (foo INT, bar INT) WITH (kafka_topic='input_topic', key='foo', value_format='JSON');",
+        "CREATE STREAM OUTPUT AS SELECT * FROM INPUT PARTITION BY foo;"
+      ],
+      "inputs": [
+        {"topic": "input_topic", "key": "1", "value": {"foo": 1, "bar": 2}}
+      ],
+      "outputs": [
+        {"topic": "OUTPUT", "key":"1", "value": {"FOO":1, "BAR": 2}}
+      ],
+      "post": {
+        "issues": ["key field of output has INCORRECT type: should be 'STRING'."],
+        "sources": [
+          {"name": "OUTPUT", "type": "stream", "keyField": {"name": "FOO", "schema": {"type": "INT"}}}
+        ]
+      }
+    },
+    {
+      "name": "stream | initially set | partition by (same) | key in value | aliasing",
+      "statements": [
+        "CREATE STREAM INPUT (foo INT, bar INT) WITH (kafka_topic='input_topic', key='foo', value_format='JSON');",
+        "CREATE STREAM OUTPUT AS SELECT foo AS aliased, bar FROM INPUT PARTITION BY aliased;"
+      ],
+      "inputs": [
+        {"topic": "input_topic", "key": "1", "value": {"foo": 1, "bar": 2}}
+      ],
+      "outputs": [
+        {"topic": "OUTPUT", "key":"1", "value": {"ALIASED":1, "BAR": 2}}
+      ],
+      "post": {
+        "issues": ["key field of output has INCORRECT type: should be 'STRING'."],
+        "sources": [
+          {"name": "OUTPUT", "type": "stream", "keyField": {"name": "ALIASED", "schema": {"type": "INT"}}}
+        ]
+      }
+    },
+    {
+      "name": "stream | initially set | partition by (same) | key not in value | -",
+      "statements": [
+        "CREATE STREAM INPUT (foo INT, bar INT) WITH (kafka_topic='input_topic', key='foo', value_format='JSON');",
+        "CREATE STREAM OUTPUT AS SELECT bar FROM INPUT PARTITION BY foo;"
+      ],
+      "expectedException": {
+        "type": "io.confluent.ksql.util.KsqlStatementException",
+        "message": "Column FOO does not exist in the result schema. Error in Partition By clause."
+      }
+    },
+    {
+      "name": "stream | initially set | partition by (different) | key in value | no aliasing",
+      "statements": [
+        "CREATE STREAM INPUT (foo INT, bar INT) WITH (kafka_topic='input_topic', key='foo', value_format='JSON');",
+        "CREATE STREAM OUTPUT AS SELECT * FROM INPUT PARTITION BY bar;"
+      ],
+      "inputs": [
+        {"topic": "input_topic", "key": "1", "value": {"foo": 1, "bar": 2}}
+      ],
+      "outputs": [
+        {"topic": "OUTPUT", "key":"2", "value": {"FOO": 1, "BAR": 2}}
+      ],
+      "post": {
+        "issues": ["key field of output has INCORRECT type: should be 'STRING'."],
+        "sources": [
+          {"name": "OUTPUT", "type": "stream", "keyField": {"name": "BAR", "schema": {"type": "INT"}}}
+        ]
+      }
+    },
+    {
+      "name": "stream | initially set | partition by (different) | key in value | aliasing",
+      "statements": [
+        "CREATE STREAM INPUT (foo INT, bar INT) WITH (kafka_topic='input_topic', key='foo', value_format='JSON');",
+        "CREATE STREAM OUTPUT AS SELECT foo, bar AS aliased FROM INPUT PARTITION BY aliased;"
+      ],
+      "inputs": [
+        {"topic": "input_topic", "key": "1", "value": {"foo": 1, "bar": 2}}
+      ],
+      "outputs": [
+        {"topic": "OUTPUT", "key":"2", "value": {"FOO": 1, "ALIASED": 2}}
+      ],
+      "post": {
+        "issues": ["key field of output has INCORRECT type: should be 'STRING'."],
+        "sources": [
+          {"name": "OUTPUT", "type": "stream", "keyField": {"name": "ALIASED", "schema": {"type": "INT"}}}
+        ]
+      }
+    },
+    {
+      "name": "stream | initially set | partition by (different) | key not in value | -",
+      "statements": [
+        "CREATE STREAM INPUT (foo INT, bar INT) WITH (kafka_topic='input_topic', key='foo', value_format='JSON');",
+        "CREATE STREAM OUTPUT AS SELECT foo FROM INPUT PARTITION BY bar;"
+      ],
+      "expectedException": {
+        "type": "io.confluent.ksql.util.KsqlStatementException",
+        "message": "Column BAR does not exist in the result schema. Error in Partition By clause."
+      }
+    },
+    {
+      "name": "stream | initially set | group by (same) | key in value | no aliasing",
+      "statements": [
+        "CREATE STREAM INPUT (foo INT, bar INT) WITH (kafka_topic='input_topic', key='foo', value_format='JSON');",
+        "CREATE TABLE OUTPUT AS SELECT foo, COUNT(*) FROM INPUT GROUP BY foo;"
+      ],
+      "inputs": [
+        {"topic": "input_topic", "key": "1", "value": {"foo": 1, "bar": 2}}
+      ],
+      "outputs": [
+        {"topic": "OUTPUT", "key":"1", "value": {"FOO":1, "KSQL_COL_1": 1}}
+      ],
+      "post": {
+        "issues": ["key field of output has INCORRECT type: should be 'STRING'."],
+        "sources": [
+          {"name": "OUTPUT", "type": "table", "keyField": {"name": "FOO", "schema": {"type": "INT"}}}
+        ]
+      }
+    },
+    {
+      "name": "stream | initially set | group by (same) | key in value | aliasing",
+      "statements": [
+        "CREATE STREAM INPUT (foo INT, bar INT) WITH (kafka_topic='input_topic', key='foo', value_format='JSON');",
+        "CREATE TABLE OUTPUT AS SELECT foo AS aliased, COUNT(*) FROM INPUT GROUP BY foo;"
+      ],
+      "inputs": [
+        {"topic": "input_topic", "key": "1", "value": {"foo": 1, "bar": 2}}
+      ],
+      "outputs": [
+        {"topic": "OUTPUT", "key":"1", "value": {"ALIASED":1, "KSQL_COL_1": 1}}
+      ],
+      "post": {
+        "issues": ["key field of output has INCORRECT type: should be 'STRING'."],
+        "sources": [
+          {"name": "OUTPUT", "type": "table", "keyField": {"name": "ALIASED", "schema": {"type": "INT"}}}
+        ]
+      }
+    },
+    {
+      "name": "stream | initially set | group by (same) | key not in value | -",
+      "statements": [
+        "CREATE STREAM INPUT (foo INT, bar INT) WITH (kafka_topic='input_topic', key='foo', value_format='JSON');",
+        "CREATE TABLE OUTPUT AS SELECT COUNT(*) FROM INPUT GROUP BY foo;"
+      ],
+      "inputs": [
+        {"topic": "input_topic", "key": "1", "value": {"foo": 1, "bar": 2}}
+      ],
+      "outputs": [
+        {"topic": "OUTPUT", "key":"1", "value": {"KSQL_COL_0": 1}}
+      ],
+      "post": {
+        "sources": [
+          {"name": "OUTPUT", "type": "table", "keyField": null}
+        ]
+      }
+    },
+    {
+      "name": "stream | initially set | group by (different) | key in value | no aliasing",
+      "statements": [
+        "CREATE STREAM INPUT (foo INT, bar INT) WITH (kafka_topic='input_topic', key='foo', value_format='JSON');",
+        "CREATE TABLE OUTPUT AS SELECT bar, COUNT(*) FROM INPUT GROUP BY bar;"
+      ],
+      "inputs": [
+        {"topic": "input_topic", "key": "1", "value": {"foo": 1, "bar": 2}}
+      ],
+      "outputs": [
+        {"topic": "OUTPUT", "key":"2", "value": {"BAR":2, "KSQL_COL_1": 1}}
+      ],
+      "post": {
+        "issues": ["key field of output has INCORRECT name: should be 'BAR'."],
+        "sources": [
+          {"name": "OUTPUT", "type": "table", "keyField": {"name": "KSQL_INTERNAL_COL_0", "schema": {"type": "STRING"}}}
+        ]
+      }
+    },
+    {
+      "name": "stream | initially set | group by (different) | key in value | aliasing",
+      "statements": [
+        "CREATE STREAM INPUT (foo INT, bar INT) WITH (kafka_topic='input_topic', key='foo', value_format='JSON');",
+        "CREATE TABLE OUTPUT AS SELECT bar AS aliased, COUNT(*) FROM INPUT GROUP BY bar;"
+      ],
+      "inputs": [
+        {"topic": "input_topic", "key": "1", "value": {"foo": 1, "bar": 2}}
+      ],
+      "outputs": [
+        {"topic": "OUTPUT", "key":"2", "value": {"ALIASED":2, "KSQL_COL_1": 1}}
+      ],
+      "post": {
+        "issues": ["key field of output has INCORRECT name: should be 'ALIASED'."],
+        "sources": [
+          {"name": "OUTPUT", "type": "table", "keyField": {"name": "KSQL_INTERNAL_COL_0", "schema": {"type": "STRING"}}}
+        ]
+      }
+    },
+    {
+      "name": "stream | initially set | group by (different) | key not in value | -",
+      "statements": [
+        "CREATE STREAM INPUT (foo INT, bar INT) WITH (kafka_topic='input_topic', key='foo', value_format='JSON');",
+        "CREATE TABLE OUTPUT AS SELECT COUNT(*) FROM INPUT GROUP BY bar;"
+      ],
+      "inputs": [
+        {"topic": "input_topic", "key": "1", "value": {"foo": 1, "bar": 2}}
+      ],
+      "outputs": [
+        {"topic": "OUTPUT", "key":"2", "value": {"KSQL_COL_0": 1}}
+      ],
+      "post": {
+        "issues": ["key field of output INCORRECT: should be null."],
+        "sources": [
+          {"name": "OUTPUT", "type": "table", "keyField": {"name": "KSQL_INTERNAL_COL_1", "schema": {"type": "STRING"}}}
+        ]
+      }
+    },
+    {
+      "name": "table | initially null | no key change | - | -",
+      "statements": [
+        "CREATE TABLE INPUT (foo INT, bar INT) WITH (kafka_topic='input_topic', key='foo', value_format='JSON');",
+        "CREATE TABLE INTERMEDIATE AS SELECT bar FROM INPUT;",
+        "CREATE TABLE OUTPUT AS SELECT * FROM INTERMEDIATE;"
+      ],
+      "inputs": [
+        {"topic": "INTERMEDIATE", "key": "x", "value": {"bar": 1}}
+      ],
+      "outputs": [
+        {"topic": "OUTPUT", "key": "x", "value": {"BAR": 1}}
+      ],
+      "post": {
+        "sources": [
+          {"name": "OUTPUT", "type": "table", "keyField": null}
+        ]
+      }
+    },
+    {
+      "name": "table | initially null | group by (-) | key in value | no aliasing",
+      "statements": [
+        "CREATE TABLE INPUT (foo INT, bar INT) WITH (kafka_topic='input_topic', key='foo', value_format='JSON');",
+        "CREATE TABLE INTERMEDIATE AS SELECT * FROM INPUT;",
+        "CREATE TABLE OUTPUT AS SELECT foo, COUNT(*) FROM INTERMEDIATE GROUP BY foo;"
+      ],
+      "inputs": [
+        {"topic": "INTERMEDIATE", "key": "x", "value": {"foo": 1, "bar": 2}}
+      ],
+      "outputs": [
+        {"topic": "OUTPUT", "key": "1", "value": {"FOO": 1, "KSQL_COL_1": 1}}
+      ],
+      "post": {
+        "issues": ["key field of output has INCORRECT name: should be 'FOO'."],
+        "sources": [
+          {"name": "OUTPUT", "type": "table", "keyField": {"name": "KSQL_INTERNAL_COL_0", "schema": {"type": "STRING"}}}
+        ]
+      }
+    },
+    {
+      "name": "table | initially null | group by (-) | key in value | aliasing",
+      "statements": [
+        "CREATE TABLE INPUT (foo INT, bar INT) WITH (kafka_topic='input_topic', key='foo', value_format='JSON');",
+        "CREATE TABLE INTERMEDIATE AS SELECT * FROM INPUT;",
+        "CREATE TABLE OUTPUT AS SELECT foo AS aliased, COUNT(*) FROM INTERMEDIATE GROUP BY foo;"
+      ],
+      "inputs": [
+        {"topic": "INTERMEDIATE", "key": "x", "value": {"foo": 1, "bar": 2}}
+      ],
+      "outputs": [
+        {"topic": "OUTPUT", "key": "1", "value": {"ALIASED": 1, "KSQL_COL_1": 1}}
+      ],
+      "post": {
+        "issues": ["key field of output has INCORRECT name: should be 'FOO'."],
+        "sources": [
+          {"name": "OUTPUT", "type": "table", "keyField": {"name": "KSQL_INTERNAL_COL_0", "schema": {"type": "STRING"}}}
+        ]
+      }
+    },
+    {
+      "name": "table | initially set | no key change | key in value | no aliasing",
+      "statements": [
+        "CREATE TABLE INPUT (foo INT, bar INT) WITH (kafka_topic='input_topic', key='foo', value_format='JSON');",
+        "CREATE TABLE OUTPUT AS SELECT * FROM INPUT;"
+      ],
+      "inputs": [
+        {"topic": "input_topic", "key": "1", "value": {"foo": 1, "bar": 2}}
+      ],
+      "outputs": [
+        {"topic": "OUTPUT", "key": "1", "value": {"FOO": 1, "BAR": 2}}
+      ],
+      "post": {
+        "issues": ["key field of output has INCORRECT type: should be 'STRING'."],
+        "sources": [
+          {"name": "OUTPUT", "type": "table", "keyField": {"name": "FOO", "schema": {"type": "INT"}}}
+        ]
+      }
+    },
+    {
+      "name": "table | initially set | no key change | key in value | aliasing",
+      "statements": [
+        "CREATE TABLE INPUT (foo INT, bar INT) WITH (kafka_topic='input_topic', key='foo', value_format='JSON');",
+        "CREATE TABLE OUTPUT AS SELECT foo AS aliased, bar FROM INPUT;"
+      ],
+      "inputs": [
+        {"topic": "input_topic", "key": "1", "value": {"foo": 1, "bar": 2}}
+      ],
+      "outputs": [
+        {"topic": "OUTPUT", "key": "1", "value": {"ALIASED": 1, "BAR": 2}}
+      ],
+      "post": {
+        "issues": ["key field of output has INCORRECT type: should be 'STRING'."],
+        "sources": [
+          {"name": "OUTPUT", "type": "table", "keyField": {"name": "ALIASED", "schema": {"type": "INT"}}}
+        ]
+      }
+    },
+    {
+      "name": "table | initially set | no key change | key not in value | -",
+      "statements": [
+        "CREATE TABLE INPUT (foo INT, bar INT) WITH (kafka_topic='input_topic', key='foo', value_format='JSON');",
+        "CREATE TABLE OUTPUT AS SELECT bar FROM INPUT;"
+      ],
+      "inputs": [
+        {"topic": "input_topic", "key": "1", "value": {"foo": 1, "bar": 2}}
+      ],
+      "outputs": [
+        {"topic": "OUTPUT", "key": "1", "value": {"BAR": 2}}
+      ],
+      "post": {
+        "sources": [
+          {"name": "OUTPUT", "type": "table", "keyField": null}
+        ]
+      }
+    },
+    {
+      "name": "table | initially set | group by (same) | key in value | no aliasing",
+      "statements": [
+        "CREATE TABLE INPUT (foo INT, bar INT) WITH (kafka_topic='input_topic', key='foo', value_format='JSON');",
+        "CREATE TABLE OUTPUT AS SELECT foo, COUNT(*) FROM INPUT GROUP BY foo;"
+      ],
+      "inputs": [
+        {"topic": "input_topic", "key": "1", "value": {"foo": 1, "bar": 2}}
+      ],
+      "outputs": [
+        {"topic": "OUTPUT", "key": "1", "value": {"FOO": 1, "KSQL_COL_1":  1}}
+      ],
+      "post": {
+        "issues": ["key field of output has INCORRECT name: should be 'FOO'."],
+        "sources": [
+          {"name": "OUTPUT", "type": "table", "keyField": {"name": "KSQL_INTERNAL_COL_0", "schema": {"type": "STRING"}}}
+        ]
+      }
+    },
+    {
+      "name": "table | initially set | group by (same) | key in value | aliasing",
+      "statements": [
+        "CREATE TABLE INPUT (foo INT, bar INT) WITH (kafka_topic='input_topic', key='foo', value_format='JSON');",
+        "CREATE TABLE OUTPUT AS SELECT foo AS aliased, COUNT(*) FROM INPUT GROUP BY foo;"
+      ],
+      "inputs": [
+        {"topic": "input_topic", "key": "1", "value": {"foo": 1, "bar": 2}}
+      ],
+      "outputs": [
+        {"topic": "OUTPUT", "key": "1", "value": {"ALIASED": 1, "KSQL_COL_1":  1}}
+      ],
+      "post": {
+        "issues": ["key field of output has INCORRECT name: should be 'ALIASED'."],
+        "sources": [
+          {"name": "OUTPUT", "type": "table", "keyField": {"name": "KSQL_INTERNAL_COL_0", "schema": {"type": "STRING"}}}
+        ]
+      }
+    },
+    {
+      "name": "table | initially set | group by (same) | key not in value | -",
+      "statements": [
+        "CREATE TABLE INPUT (foo INT, bar INT) WITH (kafka_topic='input_topic', key='foo', value_format='JSON');",
+        "CREATE TABLE OUTPUT AS SELECT COUNT(*) FROM INPUT GROUP BY foo;"
+      ],
+      "inputs": [
+        {"topic": "input_topic", "key": "1", "value": {"foo": 1, "bar": 2}}
+      ],
+      "outputs": [
+        {"topic": "OUTPUT", "key": "1", "value": {"KSQL_COL_0":  1}}
+      ],
+      "post": {
+        "issues": ["key field of output INCORRECT: should be null."],
+        "sources": [
+          {"name": "OUTPUT", "type": "table", "keyField": {"name": "KSQL_INTERNAL_COL_1", "schema": {"type": "STRING"}}}
+        ]
+      }
+    },
+    {
+      "name": "table | initially set | group by (different) | key in value | no aliasing",
+      "statements": [
+        "CREATE TABLE INPUT (foo INT, bar INT) WITH (kafka_topic='input_topic', key='foo', value_format='JSON');",
+        "CREATE TABLE OUTPUT AS SELECT bar, COUNT(*) FROM INPUT GROUP BY bar;"
+      ],
+      "inputs": [
+        {"topic": "input_topic", "key": "1", "value": {"foo": 1, "bar": 2}}
+      ],
+      "outputs": [
+        {"topic": "OUTPUT", "key": "2", "value": {"BAR": 2, "KSQL_COL_1":  1}}
+      ],
+      "post": {
+        "issues": ["key field of output has INCORRECT name: should be 'BAR'."],
+        "sources": [
+          {"name": "OUTPUT", "type": "table", "keyField": {"name": "KSQL_INTERNAL_COL_0", "schema": {"type": "STRING"}}}
+        ]
+      }
+    },
+    {
+      "name": "table | initially set | group by (different) | key in value | aliasing",
+      "statements": [
+        "CREATE TABLE INPUT (foo INT, bar INT) WITH (kafka_topic='input_topic', key='foo', value_format='JSON');",
+        "CREATE TABLE OUTPUT AS SELECT bar AS aliased, COUNT(*) FROM INPUT GROUP BY bar;"
+      ],
+      "inputs": [
+        {"topic": "input_topic", "key": "1", "value": {"foo": 1, "bar": 2}}
+      ],
+      "outputs": [
+        {"topic": "OUTPUT", "key": "2", "value": {"ALIASED": 2, "KSQL_COL_1":  1}}
+      ],
+      "post": {
+        "issues": ["key field of output has INCORRECT name: should be 'ALIASED'."],
+        "sources": [
+          {"name": "OUTPUT", "type": "table", "keyField": {"name": "KSQL_INTERNAL_COL_0", "schema": {"type": "STRING"}}}
+        ]
+      }
+    },
+    {
+      "name": "table | initially set | group by (different) | key not in value | -",
+      "statements": [
+        "CREATE TABLE INPUT (foo INT, bar INT) WITH (kafka_topic='input_topic', key='foo', value_format='JSON');",
+        "CREATE TABLE OUTPUT AS SELECT COUNT(*) FROM INPUT GROUP BY bar;"
+      ],
+      "inputs": [
+        {"topic": "input_topic", "key": "1", "value": {"foo": 1, "bar": 2}}
+      ],
+      "outputs": [
+        {"topic": "OUTPUT", "key": "2", "value": {"KSQL_COL_0":  1}}
+      ],
+      "post": {
+        "issues": ["key field of output INCORRECT: should be null."],
+        "sources": [
+          {"name": "OUTPUT", "type": "table", "keyField": {"name": "KSQL_INTERNAL_COL_1", "schema": {"type": "STRING"}}}
+        ]
+      }
+    }
+  ]
+}

--- a/ksql-engine/src/test/resources/query-validation-tests/key-field.json
+++ b/ksql-engine/src/test/resources/query-validation-tests/key-field.json
@@ -61,8 +61,9 @@
         {"topic": "OUTPUT", "key": "1", "value": {"FOO":1, "BAR": 2}}
       ],
       "post": {
-        "issues": ["key field of OUTPUT has INCORRECT type: Should be 'STRING'."],
+        "issues": ["key field of OUTPUT has INCORRECT type: should be 'STRING'."],
         "sources": [
+          {"name": "INPUT", "type": "stream", "keyField": null},
           {"name": "OUTPUT", "type": "stream", "keyField": {"name": "FOO", "schema": {"type": "INT"}}}
         ]
       }
@@ -80,8 +81,9 @@
         {"topic": "OUTPUT", "key": "1", "value": {"ALIASED":1, "BAR": 2}}
       ],
       "post": {
-        "issues": ["key field of OUTPUT has INCORRECT type: Should be 'STRING'."],
+        "issues": ["key field of OUTPUT has INCORRECT type: should be 'STRING'."],
         "sources": [
+          {"name": "INPUT", "type": "stream", "keyField": null},
           {"name": "OUTPUT", "type": "stream", "keyField": {"name": "ALIASED", "schema": {"type": "INT"}}}
         ]
       }
@@ -112,6 +114,7 @@
       "post": {
         "issues": ["key field of output has INCORRECT name: should be 'FOO'."],
         "sources": [
+          {"name": "INPUT", "type": "stream", "keyField": null},
           {"name": "OUTPUT", "type": "table", "keyField": {"name": "KSQL_INTERNAL_COL_0", "schema": {"type": "STRING"}}}
         ]
       }
@@ -131,6 +134,7 @@
       "post": {
         "issues": ["key field of output has INCORRECT name: should be 'ALIASED'."],
         "sources": [
+          {"name": "INPUT", "type": "stream", "keyField": null},
           {"name": "OUTPUT", "type": "table", "keyField": {"name": "KSQL_INTERNAL_COL_0", "schema": {"type": "STRING"}}}
         ]
       }
@@ -150,6 +154,7 @@
       "post": {
         "issues": ["key field of output has INCORRECT name: should be 'ALIASED'."],
         "sources": [
+          {"name": "INPUT", "type": "stream", "keyField": null},
           {"name": "OUTPUT", "type": "table", "keyField": {"name": "KSQL_INTERNAL_COL_1", "schema": {"type": "STRING"}}}
         ]
       }
@@ -167,8 +172,12 @@
         {"topic": "OUTPUT", "value": {"FOO":1, "BAR": 2}}
       ],
       "post": {
-        "issues": ["key field of output has INCORRECT type: should be 'STRING'."],
+        "issues": [
+          "key field of input has INCORRECT type: should be 'STRING'.",
+          "key field of output has INCORRECT type: should be 'STRING'."
+        ],
         "sources": [
+          {"name": "INPUT", "type": "stream", "keyField": {"name": "FOO", "schema": {"type": "INT"}}},
           {"name": "OUTPUT", "type": "stream", "keyField": {"name": "FOO", "schema": {"type": "INT"}}}
         ]
       }
@@ -187,10 +196,12 @@
       ],
       "post": {
         "issues": [
+          "key field of input has INCORRECT type: should be 'STRING'.",
           "key field of output has INCORRECT name: should be 'ALIASED'.",
           "key field of output has INCORRECT type: should be 'STRING'."
           ],
         "sources": [
+          {"name": "INPUT", "type": "stream", "keyField": {"name": "FOO", "schema": {"type": "INT"}}},
           {"name": "OUTPUT", "type": "stream", "keyField": {"name": "FOO", "schema": {"type": "INT"}}}
         ]
       }
@@ -208,8 +219,12 @@
         {"topic": "OUTPUT", "value": {"BAR": 2}}
       ],
       "post": {
-        "issues": ["key field of output INCORRECT: should be null."],
+        "issues": [
+          "key field of input has INCORRECT type: should be 'STRING'.",
+          "key field of output INCORRECT: should be null."
+        ],
         "sources": [
+          {"name": "INPUT", "type": "stream", "keyField": {"name": "FOO", "schema": {"type": "INT"}}},
           {"name": "OUTPUT", "type": "stream", "keyField": {"name": "FOO", "schema": {"type": "INT"}}}
         ]
       }
@@ -227,8 +242,12 @@
         {"topic": "OUTPUT", "key":"1", "value": {"FOO":1, "BAR": 2}}
       ],
       "post": {
-        "issues": ["key field of output has INCORRECT type: should be 'STRING'."],
+        "issues": [
+          "key field of input has INCORRECT type: should be 'STRING'.",
+          "key field of output has INCORRECT type: should be 'STRING'."
+        ],
         "sources": [
+          {"name": "INPUT", "type": "stream", "keyField": {"name": "FOO", "schema": {"type": "INT"}}},
           {"name": "OUTPUT", "type": "stream", "keyField": {"name": "FOO", "schema": {"type": "INT"}}}
         ]
       }
@@ -246,8 +265,12 @@
         {"topic": "OUTPUT", "key":"1", "value": {"ALIASED":1, "BAR": 2}}
       ],
       "post": {
-        "issues": ["key field of output has INCORRECT type: should be 'STRING'."],
+        "issues": [
+          "key field of input has INCORRECT type: should be 'STRING'.",
+          "key field of output has INCORRECT type: should be 'STRING'."
+        ],
         "sources": [
+          {"name": "INPUT", "type": "stream", "keyField": {"name": "FOO", "schema": {"type": "INT"}}},
           {"name": "OUTPUT", "type": "stream", "keyField": {"name": "ALIASED", "schema": {"type": "INT"}}}
         ]
       }
@@ -276,8 +299,12 @@
         {"topic": "OUTPUT", "key":"2", "value": {"FOO": 1, "BAR": 2}}
       ],
       "post": {
-        "issues": ["key field of output has INCORRECT type: should be 'STRING'."],
+        "issues": [
+          "key field of input has INCORRECT type: should be 'STRING'.",
+          "key field of output has INCORRECT type: should be 'STRING'."
+        ],
         "sources": [
+          {"name": "INPUT", "type": "stream", "keyField": {"name": "FOO", "schema": {"type": "INT"}}},
           {"name": "OUTPUT", "type": "stream", "keyField": {"name": "BAR", "schema": {"type": "INT"}}}
         ]
       }
@@ -295,8 +322,12 @@
         {"topic": "OUTPUT", "key":"2", "value": {"FOO": 1, "ALIASED": 2}}
       ],
       "post": {
-        "issues": ["key field of output has INCORRECT type: should be 'STRING'."],
+        "issues": [
+          "key field of input has INCORRECT type: should be 'STRING'.",
+          "key field of output has INCORRECT type: should be 'STRING'."
+        ],
         "sources": [
+          {"name": "INPUT", "type": "stream", "keyField": {"name": "FOO", "schema": {"type": "INT"}}},
           {"name": "OUTPUT", "type": "stream", "keyField": {"name": "ALIASED", "schema": {"type": "INT"}}}
         ]
       }
@@ -325,8 +356,12 @@
         {"topic": "OUTPUT", "key":"1", "value": {"FOO":1, "KSQL_COL_1": 1}}
       ],
       "post": {
-        "issues": ["key field of output has INCORRECT type: should be 'STRING'."],
+        "issues": [
+          "key field of input has INCORRECT type: should be 'STRING'.",
+          "key field of output has INCORRECT type: should be 'STRING'."
+        ],
         "sources": [
+          {"name": "INPUT", "type": "stream", "keyField": {"name": "FOO", "schema": {"type": "INT"}}},
           {"name": "OUTPUT", "type": "table", "keyField": {"name": "FOO", "schema": {"type": "INT"}}}
         ]
       }
@@ -344,8 +379,12 @@
         {"topic": "OUTPUT", "key":"1", "value": {"ALIASED":1, "KSQL_COL_1": 1}}
       ],
       "post": {
-        "issues": ["key field of output has INCORRECT type: should be 'STRING'."],
+        "issues": [
+          "key field of input has INCORRECT type: should be 'STRING'.",
+          "key field of output has INCORRECT type: should be 'STRING'."
+        ],
         "sources": [
+          {"name": "INPUT", "type": "stream", "keyField": {"name": "FOO", "schema": {"type": "INT"}}},
           {"name": "OUTPUT", "type": "table", "keyField": {"name": "ALIASED", "schema": {"type": "INT"}}}
         ]
       }
@@ -497,8 +536,12 @@
         {"topic": "OUTPUT", "key": "1", "value": {"FOO": 1, "BAR": 2}}
       ],
       "post": {
-        "issues": ["key field of output has INCORRECT type: should be 'STRING'."],
+        "issues": [
+          "key field of input has INCORRECT type: should be 'STRING'.",
+          "key field of output has INCORRECT type: should be 'STRING'."
+        ],
         "sources": [
+          {"name": "INPUT", "type": "table", "keyField": {"name": "FOO", "schema": {"type": "INT"}}},
           {"name": "OUTPUT", "type": "table", "keyField": {"name": "FOO", "schema": {"type": "INT"}}}
         ]
       }
@@ -516,8 +559,12 @@
         {"topic": "OUTPUT", "key": "1", "value": {"ALIASED": 1, "BAR": 2}}
       ],
       "post": {
-        "issues": ["key field of output has INCORRECT type: should be 'STRING'."],
+        "issues": [
+          "key field of input has INCORRECT type: should be 'STRING'.",
+          "key field of output has INCORRECT type: should be 'STRING'."
+        ],
         "sources": [
+          {"name": "INPUT", "type": "table", "keyField": {"name": "FOO", "schema": {"type": "INT"}}},
           {"name": "OUTPUT", "type": "table", "keyField": {"name": "ALIASED", "schema": {"type": "INT"}}}
         ]
       }

--- a/ksql-engine/src/test/resources/query-validation-tests/key-field.json
+++ b/ksql-engine/src/test/resources/query-validation-tests/key-field.json
@@ -25,9 +25,10 @@
     "",
     "Not all combinations are valid, e.g. can not have an alias is there is no key.",
     "",
-    "issue: this is currently an inconsistency between how GROUP BY's and PARTITION BY's handling of aliases:",
-    " - PARTITION BY requires the target name, (i.e. the alias), failing if the source field name is used.",
-    " - GROUP BY requires the source field name, failing if the target field name, (i.e. the alias), is used."
+    "issues:",
+    " There is currently an inconsistency between how GROUP BY's and PARTITION BY's handling of aliases:",
+    "  - PARTITION BY requires the target name, (i.e. the alias), failing if the source field name is used.",
+    "  - GROUP BY requires the source field name, failing if the target field name, (i.e. the alias), is used."
   ],
   "tests": [
     {
@@ -110,7 +111,10 @@
         {"topic": "OUTPUT", "key": "1", "value": {"FOO":1, "KSQL_COL_1": 1}}
       ],
       "post": {
-        "issues": ["key field of output has INCORRECT name: should be 'FOO'."],
+        "issues": [
+          "key field of output has INCORRECT name: should be 'FOO'.",
+          "key field of output has INCORRECT type: should be 'INT"
+        ],
         "sources": [
           {"name": "INPUT", "type": "stream", "keyField": null},
           {"name": "OUTPUT", "type": "table", "keyField": {"name": "KSQL_INTERNAL_COL_0", "schema": {"type": "STRING"}}}
@@ -130,7 +134,10 @@
         {"topic": "OUTPUT", "key": "1", "value": {"ALIASED":1, "KSQL_COL_1": 1}}
       ],
       "post": {
-        "issues": ["key field of output has INCORRECT name: should be 'ALIASED'."],
+        "issues": [
+          "key field of output has INCORRECT name: should be 'ALIASED'.",
+          "key field of output has INCORRECT type: should be 'INT'."
+        ],
         "sources": [
           {"name": "INPUT", "type": "stream", "keyField": null},
           {"name": "OUTPUT", "type": "table", "keyField": {"name": "KSQL_INTERNAL_COL_0", "schema": {"type": "STRING"}}}
@@ -150,7 +157,10 @@
         {"topic": "OUTPUT", "key": "1", "value": {"KSQL_COL_0": 1}}
       ],
       "post": {
-        "issues": ["key field of output has INCORRECT name: should be 'ALIASED'."],
+        "issues": [
+          "key field of output has INCORRECT name: should be 'ALIASED'.",
+          "key field of output has INCORRECT type: should be 'INT'."
+        ],
         "sources": [
           {"name": "INPUT", "type": "stream", "keyField": null},
           {"name": "OUTPUT", "type": "table", "keyField": {"name": "KSQL_INTERNAL_COL_1", "schema": {"type": "STRING"}}}
@@ -387,7 +397,10 @@
         {"topic": "OUTPUT", "key":"2", "value": {"BAR":2, "KSQL_COL_1": 1}}
       ],
       "post": {
-        "issues": ["key field of output has INCORRECT name: should be 'BAR'."],
+        "issues": [
+          "key field of output has INCORRECT name: should be 'BAR'.",
+          "key field of output has INCORRECT type: should be 'INT'."
+        ],
         "sources": [
           {"name": "OUTPUT", "type": "table", "keyField": {"name": "KSQL_INTERNAL_COL_0", "schema": {"type": "STRING"}}}
         ]
@@ -406,7 +419,10 @@
         {"topic": "OUTPUT", "key":"2", "value": {"ALIASED":2, "KSQL_COL_1": 1}}
       ],
       "post": {
-        "issues": ["key field of output has INCORRECT name: should be 'ALIASED'."],
+        "issues": [
+          "key field of output has INCORRECT name: should be 'ALIASED'.",
+          "key field of output has INCORRECT type: should be 'INT'."
+        ],
         "sources": [
           {"name": "OUTPUT", "type": "table", "keyField": {"name": "KSQL_INTERNAL_COL_0", "schema": {"type": "STRING"}}}
         ]
@@ -464,7 +480,9 @@
         {"topic": "OUTPUT", "key": "1", "value": {"FOO": 1, "KSQL_COL_1": 1}}
       ],
       "post": {
-        "issues": ["key field of output has INCORRECT name: should be 'FOO'."],
+        "issues": [
+          "key field of output has INCORRECT name: should be 'FOO'.",
+          "key field of output has INCORRECT type: should be 'INT'."],
         "sources": [
           {"name": "OUTPUT", "type": "table", "keyField": {"name": "KSQL_INTERNAL_COL_0", "schema": {"type": "STRING"}}}
         ]
@@ -484,7 +502,10 @@
         {"topic": "OUTPUT", "key": "1", "value": {"ALIASED": 1, "KSQL_COL_1": 1}}
       ],
       "post": {
-        "issues": ["key field of output has INCORRECT name: should be 'FOO'."],
+        "issues": [
+          "key field of output has INCORRECT name: should be 'FOO'.",
+          "key field of output has INCORRECT type: should be 'INT'."
+        ],
         "sources": [
           {"name": "OUTPUT", "type": "table", "keyField": {"name": "KSQL_INTERNAL_COL_0", "schema": {"type": "STRING"}}}
         ]
@@ -559,7 +580,10 @@
         {"topic": "OUTPUT", "key": "1", "value": {"FOO": 1, "KSQL_COL_1":  1}}
       ],
       "post": {
-        "issues": ["key field of output has INCORRECT name: should be 'FOO'."],
+        "issues": [
+          "key field of output has INCORRECT name: should be 'FOO'.",
+          "key field of output has INCORRECT type: should be 'INT'."
+        ],
         "sources": [
           {"name": "OUTPUT", "type": "table", "keyField": {"name": "KSQL_INTERNAL_COL_0", "schema": {"type": "STRING"}}}
         ]
@@ -578,7 +602,10 @@
         {"topic": "OUTPUT", "key": "1", "value": {"ALIASED": 1, "KSQL_COL_1":  1}}
       ],
       "post": {
-        "issues": ["key field of output has INCORRECT name: should be 'ALIASED'."],
+        "issues": [
+          "key field of output has INCORRECT name: should be 'ALIASED'.",
+          "key field of output has INCORRECT type: should be 'INT'."
+        ],
         "sources": [
           {"name": "OUTPUT", "type": "table", "keyField": {"name": "KSQL_INTERNAL_COL_0", "schema": {"type": "STRING"}}}
         ]
@@ -616,7 +643,10 @@
         {"topic": "OUTPUT", "key": "2", "value": {"BAR": 2, "KSQL_COL_1":  1}}
       ],
       "post": {
-        "issues": ["key field of output has INCORRECT name: should be 'BAR'."],
+        "issues": [
+          "key field of output has INCORRECT name: should be 'BAR'.",
+          "key field of output has INCORRECT type: should be 'INT'."
+        ],
         "sources": [
           {"name": "OUTPUT", "type": "table", "keyField": {"name": "KSQL_INTERNAL_COL_0", "schema": {"type": "STRING"}}}
         ]
@@ -635,7 +665,10 @@
         {"topic": "OUTPUT", "key": "2", "value": {"ALIASED": 2, "KSQL_COL_1":  1}}
       ],
       "post": {
-        "issues": ["key field of output has INCORRECT name: should be 'ALIASED'."],
+        "issues": [
+          "key field of output has INCORRECT name: should be 'ALIASED'.",
+          "key field of output has INCORRECT type: should be 'INT'."
+        ],
         "sources": [
           {"name": "OUTPUT", "type": "table", "keyField": {"name": "KSQL_INTERNAL_COL_0", "schema": {"type": "STRING"}}}
         ]

--- a/ksql-engine/src/test/resources/query-validation-tests/key-field.json
+++ b/ksql-engine/src/test/resources/query-validation-tests/key-field.json
@@ -3,7 +3,7 @@
     "Tests covering handling of key-fields.",
     "The 'key-field' is an optional field within the value that matches the key",
     "",
-    "There are four main dimensions to this test suite:",
+    "There are several main dimensions to this test suite:",
     " - source type:",
     "   - stream",
     "   - table",
@@ -23,7 +23,7 @@
     "   - no aliasing",
     "   - aliased key field",
     "",
-    "Not all combinations are valid, e.g. can not have an alias is there is no key.",
+    "Not all combinations are valid, e.g. can not have an alias if there is no key.",
     "",
     "issues:",
     " There is currently an inconsistency between how GROUP BY's and PARTITION BY's handling of aliases:",
@@ -690,6 +690,98 @@
         "issues": ["key field of output INCORRECT: should be null."],
         "sources": [
           {"name": "OUTPUT", "type": "table", "keyField": {"name": "KSQL_INTERNAL_COL_1", "schema": {"type": "STRING"}}}
+        ]
+      }
+    },
+    {
+      "name": "stream | initially set | partition by expression | key in value | no aliasing",
+      "statements": [
+        "CREATE STREAM INPUT (foo INT, bar INT) WITH (kafka_topic='input_topic', key='foo', value_format='JSON');",
+        "CREATE STREAM OUTPUT AS SELECT foo + bar FROM INPUT PARTITION BY foo + bar;"
+      ],
+      "comment": [
+        "This test is present so that it fails if/when we support PARTITION BY on multiple fields.",
+        "If/when we do, this test will fail to remind us to add tests to cover keyFields for new functionality"],
+      "expectedException": {
+        "type": "io.confluent.ksql.util.KsqlStatementException",
+        "message": "line 2:70: mismatched input '+' expecting ';'"
+      }
+    },
+    {
+      "name": "stream | initially set | partition by multiple | key in value | no aliasing",
+      "statements": [
+        "CREATE STREAM INPUT (foo INT, bar INT) WITH (kafka_topic='input_topic', key='foo', value_format='JSON');",
+        "CREATE STREAM OUTPUT AS SELECT * FROM INPUT PARTITION BY foo, bar;"
+      ],
+      "comment": [
+        "This test is present so that it fails if/when we support PARTITION BY on multiple fields.",
+        "If/when we do, this test will fail to remind us to add tests to cover keyFields for new functionality"],
+      "expectedException": {
+        "type": "io.confluent.ksql.util.KsqlStatementException",
+        "message": "line 2:61: mismatched input ',' expecting ';'"
+      }
+    },
+    {
+      "name": "stream | initially set | group by multiple | key in value | no aliasing",
+      "statements": [
+        "CREATE STREAM INPUT (foo INT, bar INT) WITH (kafka_topic='input_topic', key='foo', value_format='JSON');",
+        "CREATE TABLE OUTPUT AS SELECT foo, bar, COUNT(*) FROM INPUT GROUP BY bar, foo;"
+      ],
+      "inputs": [
+        {"topic": "input_topic", "key": "1", "value": {"foo": 1, "bar": 2}}
+      ],
+      "outputs": [
+        {"topic": "OUTPUT", "key":"2|+|1", "value": {"FOO": 1, "BAR": 2, "KSQL_COL_2": 1}}
+      ],
+      "post": {
+        "issues": ["key field of output is INCORRECT: should be null."],
+        "sources": [
+          {"name": "OUTPUT", "type": "table", "keyField": {"name": "KSQL_INTERNAL_COL_1|+|KSQL_INTERNAL_COL_0", "schema": {"type": "STRING"}}}
+        ]
+      }
+    },
+    {
+      "name": "stream | initially set | group by expression | key in value | no aliasing",
+      "statements": [
+        "CREATE STREAM INPUT (foo INT, bar INT) WITH (kafka_topic='input_topic', key='foo', value_format='JSON');",
+        "CREATE TABLE OUTPUT AS SELECT foo + bar, COUNT(*) FROM INPUT GROUP BY foo + bar;"
+      ],
+      "inputs": [
+        {"topic": "input_topic", "key": "1", "value": {"foo": 1, "bar": 2}}
+      ],
+      "outputs": [
+        {"topic": "OUTPUT", "key":"3", "value": {"KSQL_COL_0": 3, "KSQL_COL_1": 1}}
+      ],
+      "post": {
+        "issues": [
+          "key field of output has INCORRECT name: should be 'KSQL_COL_0'.",
+          "key field of output has INCORRECT type: should be 'INT"
+        ],
+        "sources": [
+          {"name": "OUTPUT", "type": "table", "keyField": {"name": "(KSQL_INTERNAL_COL_0 + KSQL_INTERNAL_COL_1)", "schema": {"type": "STRING"}}}
+        ]
+      }
+    },
+    {
+      "name": "stream | initially null | group by (-) | key in value | no aliasing | with cast",
+      "statements": [
+        "CREATE STREAM INPUT (foo INT, bar INT) WITH (kafka_topic='input_topic', value_format='JSON');",
+        "CREATE TABLE OUTPUT AS SELECT cast(foo as INT), COUNT(*) FROM INPUT GROUP BY cast(foo as INT);"
+      ],
+      "inputs": [
+        {"topic": "input_topic", "value": {"foo": 1, "bar": 2}}
+      ],
+      "outputs": [
+        {"topic": "OUTPUT", "key": "1", "value": {"KSQL_COL_0":1, "KSQL_COL_1": 1}}
+      ],
+      "post": {
+        "issues": [
+          "key field of output has INCORRECT name: should be 'KSQL_COL_0'.",
+          "key field of output has INCORRECT type: should be 'INT"
+        ],
+        "sources": [
+          {"name": "INPUT", "type": "stream", "keyField": null},
+          {"name": "OUTPUT", "type": "table", "keyField": {"name": "CAST(KSQL_INTERNAL_COL_0 AS INTEGER)", "schema": {"type": "STRING"}}}
         ]
       }
     }

--- a/ksql-engine/src/test/resources/query-validation-tests/key-field.json
+++ b/ksql-engine/src/test/resources/query-validation-tests/key-field.json
@@ -61,7 +61,6 @@
         {"topic": "OUTPUT", "key": "1", "value": {"FOO":1, "BAR": 2}}
       ],
       "post": {
-        "issues": ["key field of OUTPUT has INCORRECT type: should be 'STRING'."],
         "sources": [
           {"name": "INPUT", "type": "stream", "keyField": null},
           {"name": "OUTPUT", "type": "stream", "keyField": {"name": "FOO", "schema": {"type": "INT"}}}
@@ -81,7 +80,6 @@
         {"topic": "OUTPUT", "key": "1", "value": {"ALIASED":1, "BAR": 2}}
       ],
       "post": {
-        "issues": ["key field of OUTPUT has INCORRECT type: should be 'STRING'."],
         "sources": [
           {"name": "INPUT", "type": "stream", "keyField": null},
           {"name": "OUTPUT", "type": "stream", "keyField": {"name": "ALIASED", "schema": {"type": "INT"}}}
@@ -172,10 +170,6 @@
         {"topic": "OUTPUT", "value": {"FOO":1, "BAR": 2}}
       ],
       "post": {
-        "issues": [
-          "key field of input has INCORRECT type: should be 'STRING'.",
-          "key field of output has INCORRECT type: should be 'STRING'."
-        ],
         "sources": [
           {"name": "INPUT", "type": "stream", "keyField": {"name": "FOO", "schema": {"type": "INT"}}},
           {"name": "OUTPUT", "type": "stream", "keyField": {"name": "FOO", "schema": {"type": "INT"}}}
@@ -196,9 +190,7 @@
       ],
       "post": {
         "issues": [
-          "key field of input has INCORRECT type: should be 'STRING'.",
-          "key field of output has INCORRECT name: should be 'ALIASED'.",
-          "key field of output has INCORRECT type: should be 'STRING'."
+          "key field of output has INCORRECT name: should be 'ALIASED'."
           ],
         "sources": [
           {"name": "INPUT", "type": "stream", "keyField": {"name": "FOO", "schema": {"type": "INT"}}},
@@ -220,7 +212,6 @@
       ],
       "post": {
         "issues": [
-          "key field of input has INCORRECT type: should be 'STRING'.",
           "key field of output INCORRECT: should be null."
         ],
         "sources": [
@@ -242,10 +233,6 @@
         {"topic": "OUTPUT", "key":"1", "value": {"FOO":1, "BAR": 2}}
       ],
       "post": {
-        "issues": [
-          "key field of input has INCORRECT type: should be 'STRING'.",
-          "key field of output has INCORRECT type: should be 'STRING'."
-        ],
         "sources": [
           {"name": "INPUT", "type": "stream", "keyField": {"name": "FOO", "schema": {"type": "INT"}}},
           {"name": "OUTPUT", "type": "stream", "keyField": {"name": "FOO", "schema": {"type": "INT"}}}
@@ -265,10 +252,6 @@
         {"topic": "OUTPUT", "key":"1", "value": {"ALIASED":1, "BAR": 2}}
       ],
       "post": {
-        "issues": [
-          "key field of input has INCORRECT type: should be 'STRING'.",
-          "key field of output has INCORRECT type: should be 'STRING'."
-        ],
         "sources": [
           {"name": "INPUT", "type": "stream", "keyField": {"name": "FOO", "schema": {"type": "INT"}}},
           {"name": "OUTPUT", "type": "stream", "keyField": {"name": "ALIASED", "schema": {"type": "INT"}}}
@@ -299,10 +282,6 @@
         {"topic": "OUTPUT", "key":"2", "value": {"FOO": 1, "BAR": 2}}
       ],
       "post": {
-        "issues": [
-          "key field of input has INCORRECT type: should be 'STRING'.",
-          "key field of output has INCORRECT type: should be 'STRING'."
-        ],
         "sources": [
           {"name": "INPUT", "type": "stream", "keyField": {"name": "FOO", "schema": {"type": "INT"}}},
           {"name": "OUTPUT", "type": "stream", "keyField": {"name": "BAR", "schema": {"type": "INT"}}}
@@ -322,10 +301,6 @@
         {"topic": "OUTPUT", "key":"2", "value": {"FOO": 1, "ALIASED": 2}}
       ],
       "post": {
-        "issues": [
-          "key field of input has INCORRECT type: should be 'STRING'.",
-          "key field of output has INCORRECT type: should be 'STRING'."
-        ],
         "sources": [
           {"name": "INPUT", "type": "stream", "keyField": {"name": "FOO", "schema": {"type": "INT"}}},
           {"name": "OUTPUT", "type": "stream", "keyField": {"name": "ALIASED", "schema": {"type": "INT"}}}
@@ -356,10 +331,6 @@
         {"topic": "OUTPUT", "key":"1", "value": {"FOO":1, "KSQL_COL_1": 1}}
       ],
       "post": {
-        "issues": [
-          "key field of input has INCORRECT type: should be 'STRING'.",
-          "key field of output has INCORRECT type: should be 'STRING'."
-        ],
         "sources": [
           {"name": "INPUT", "type": "stream", "keyField": {"name": "FOO", "schema": {"type": "INT"}}},
           {"name": "OUTPUT", "type": "table", "keyField": {"name": "FOO", "schema": {"type": "INT"}}}
@@ -379,10 +350,6 @@
         {"topic": "OUTPUT", "key":"1", "value": {"ALIASED":1, "KSQL_COL_1": 1}}
       ],
       "post": {
-        "issues": [
-          "key field of input has INCORRECT type: should be 'STRING'.",
-          "key field of output has INCORRECT type: should be 'STRING'."
-        ],
         "sources": [
           {"name": "INPUT", "type": "stream", "keyField": {"name": "FOO", "schema": {"type": "INT"}}},
           {"name": "OUTPUT", "type": "table", "keyField": {"name": "ALIASED", "schema": {"type": "INT"}}}
@@ -536,10 +503,6 @@
         {"topic": "OUTPUT", "key": "1", "value": {"FOO": 1, "BAR": 2}}
       ],
       "post": {
-        "issues": [
-          "key field of input has INCORRECT type: should be 'STRING'.",
-          "key field of output has INCORRECT type: should be 'STRING'."
-        ],
         "sources": [
           {"name": "INPUT", "type": "table", "keyField": {"name": "FOO", "schema": {"type": "INT"}}},
           {"name": "OUTPUT", "type": "table", "keyField": {"name": "FOO", "schema": {"type": "INT"}}}
@@ -559,10 +522,6 @@
         {"topic": "OUTPUT", "key": "1", "value": {"ALIASED": 1, "BAR": 2}}
       ],
       "post": {
-        "issues": [
-          "key field of input has INCORRECT type: should be 'STRING'.",
-          "key field of output has INCORRECT type: should be 'STRING'."
-        ],
         "sources": [
           {"name": "INPUT", "type": "table", "keyField": {"name": "FOO", "schema": {"type": "INT"}}},
           {"name": "OUTPUT", "type": "table", "keyField": {"name": "ALIASED", "schema": {"type": "INT"}}}

--- a/ksql-metastore/src/test/java/io/confluent/ksql/metastore/StructuredDataSourceMatchers.java
+++ b/ksql-metastore/src/test/java/io/confluent/ksql/metastore/StructuredDataSourceMatchers.java
@@ -1,0 +1,79 @@
+/*
+ * Copyright 2019 Confluent Inc.
+ *
+ * Licensed under the Confluent Community License (the "License"); you may not use
+ * this file except in compliance with the License.  You may obtain a copy of the
+ * License at
+ *
+ * http://www.confluent.io/confluent-community-license
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package io.confluent.ksql.metastore;
+
+import static org.hamcrest.Matchers.is;
+
+import org.apache.kafka.connect.data.Field;
+import org.apache.kafka.connect.data.Schema;
+import org.hamcrest.FeatureMatcher;
+import org.hamcrest.Matcher;
+
+public final class StructuredDataSourceMatchers {
+
+  private StructuredDataSourceMatchers() {
+  }
+
+  public static Matcher<StructuredDataSource> hasName(final String name) {
+    return new FeatureMatcher<StructuredDataSource, String>
+        (is(name), "source with name", "name") {
+      @Override
+      protected String featureValueOf(final StructuredDataSource actual) {
+        return actual.getName();
+      }
+    };
+  }
+
+  public static Matcher<StructuredDataSource> hasKeyField(final String keyFieldName) {
+    return hasKeyField(FieldMatchers.hasName(keyFieldName));
+  }
+
+  public static Matcher<StructuredDataSource> hasKeyField(final Matcher<Field> fieldMatcher) {
+    return new FeatureMatcher<StructuredDataSource, Field>
+        (fieldMatcher, "source with key field", "key field") {
+      @Override
+      protected Field featureValueOf(final StructuredDataSource actual) {
+        return actual.getKeyField();
+      }
+    };
+  }
+
+  public static final class FieldMatchers {
+
+    private FieldMatchers() {
+    }
+
+    public static Matcher<Field> hasName(final String name) {
+      return new FeatureMatcher<Field, String>
+          (is(name), "field with name", "name") {
+        @Override
+        protected String featureValueOf(final Field actual) {
+          return actual.name();
+        }
+      };
+    }
+
+    public static Matcher<Field> hasSchema(final Schema schema) {
+      return new FeatureMatcher<Field, Schema>
+          (is(schema), "field with schema", "schema") {
+        @Override
+        protected Schema featureValueOf(final Field actual) {
+          return actual.schema();
+        }
+      };
+    }
+  }
+}


### PR DESCRIPTION
### Description 

Add the changes to QTT and STT and the new keyField tests added in this PR: https://github.com/confluentinc/ksql/pull/2574 to the 5.2 branch.

This will mean we'll get 'expected topology' files for these tests for the 5.2 branch, which will be useful for detecting breaking changes in the structured key work.

### Testing done 
_Describe the testing strategy. Unit and integration tests are expected for any behavior changes._

### Reviewer checklist
- [ ] Ensure docs are updated if necessary. (eg. if a user visible feature is being added or changed).
- [ ] Ensure relevant issues are linked (description should include text like "Fixes #<issue number>")

