### PR TITLE
Minor: clean up references to CURRENT_TOPOLOGY_VERSION

### DIFF
--- a/ksql-engine/src/test/java/io/confluent/ksql/TopologyFileGenerator.java
+++ b/ksql-engine/src/test/java/io/confluent/ksql/TopologyFileGenerator.java
@@ -48,10 +48,6 @@ import javax.xml.parsers.ParserConfigurationException;
  * ksql-engine/src/test/resources/expected_topology/VERSION_NUM directory.  Where
  * VERSION_NUM is the version defined in ksql-engine/pom.xml &lt;parent&gt;&lt;version&gt; element.
  *
- * 3. Update the CURRENT_TOPOLOGY_VERSION variable in the {@link QueryTranslationTest}
- * class with the version number for the
- * newly generated directory name so all tests run against the newly written topology files by default.
- *
  */
 public class TopologyFileGenerator {
 

--- a/ksql-engine/src/test/resources/query-validation-tests/README.md
+++ b/ksql-engine/src/test/resources/query-validation-tests/README.md
@@ -8,15 +8,15 @@ topology, executed, and verified.
 The test cases are run by the `QueryTranslationTest` test class.
 
 ## Topology comparision
-These test also validate the generated topology matches the expected topology,
+These tests also validate the generated topology matches the expected topology,
 i.e. a test will fail if the topology has changed from previous runs.
 This is needed to detect potentially non-backwards compatible changes to the generated topology.
 
 The expected topology files, and the configuration used to generated them are found in
 `src/test/resources/expected_topology/<Version Number>`
 
-By default test will compare the current generated topology against the previously released versions
-of KSQL, as identified by the `QueryTranslationTest.CURRENT_TOPOLOGY_VERSIONS` variable.
+By default, the test will check topology compatibility against all previously released versions
+of KSQL (for which expected topology files exist).
 
 ### Running a subset of tests:
 
@@ -35,12 +35,11 @@ The above commands can execute only a single test (sum.json) or multiple tests (
 
 ### Running against different previous versions:
 
-To run this test against specific previously released versions there are three options
+To run this test against specific previously released versions, set the system property
+"topology.versions" to the desired version(s). The property value should be a comma-delimited list of
+version number(s) found under the `src/test/resources/expected_topology` directory, for example, `"5.0,5.1"`.
 
-1. Manually change `QueryTranslationTest.CURRENT_TOPOLOGY_VERSIONS` to a valid comma-delimited list of
-version numbers found under the `src/test/resources/expected_topology` directory.
-
-1. Set the system property "topology.versions" to the version(s) required.
+The are two places system properties may be set:
   * Within Intellij
     1. Click Run/Edit configurations
     1. Select the QueryTranslationTest
@@ -51,7 +50,7 @@ version numbers found under the `src/test/resources/expected_topology` directory
     1. Then run `mvn test -Dtopology.versions=X -Dtest=QueryTranslationTest -pl ksql-engine`.
        Again X is a list of the versions you want to run the tests against.
 
-  Note that for both options above the version must exist
+  Note that for both options above the version(s) must exist
   under the `src/test/resources/expected_topology` directory.
 
 ### Generating new topology files


### PR DESCRIPTION
### Description 

The old QueryTranslationTest variable `CURRENT_TOPOLOGY_VERSION` was removed in https://github.com/confluentinc/ksql/pull/2335 but some docs references to it slipped through the cracks. This PR cleans up those old references.

Targeting `5.2.x` as this is a docs-only change.

### Testing done 

None, docs-only.

### Reviewer checklist
- [ ] Ensure docs are updated if necessary. (eg. if a user visible feature is being added or changed).
- [ ] Ensure relevant issues are linked (description should include text like "Fixes #<issue number>")

