### PR TITLE
Add support for varargs in UDFs (Fixes #1509)

### DIFF
--- a/docs/developer-guide/udf.rst
+++ b/docs/developer-guide/udf.rst
@@ -114,6 +114,7 @@ used to call the UDF. As can be seen this UDF can be invoked in different ways:
 - with two int parameters returning a long (BIGINT) result.
 - with two long (BIGINT) parameters returning a long (BIGINT) result.
 - with two nullable Long (BIGINT) parameters returning a nullable Long (BIGINT) result.
+- with two double parameters returning a double result.
 - with vararg double parameters returning a double result.
 
 .. code:: java
@@ -141,6 +142,11 @@ used to call the UDF. As can be seen this UDF can be invoked in different ways:
       @Udf(description = "multiply two nullable BIGINTs. If either param is null, null is returned.")
       public Long multiply(final Long v1, final Long v2) {
         return v1 == null || v2 == null ? null : v1 * v2;
+      }
+
+      @Udf(description = "multiply two non-nullable DOUBLEs.")
+      public double multiply(final double v1, final double v2) {
+        return v1 * v2;
       }
 
       @Udf(description = "multiply N non-nullable DOUBLEs.")

--- a/docs/developer-guide/udf.rst
+++ b/docs/developer-guide/udf.rst
@@ -114,7 +114,7 @@ used to call the UDF. As can be seen this UDF can be invoked in different ways:
 - with two int parameters returning a long (BIGINT) result.
 - with two long (BIGINT) parameters returning a long (BIGINT) result.
 - with two nullable Long (BIGINT) parameters returning a nullable Long (BIGINT) result.
-- with two double parameters returning a double result.
+- with vararg double parameters returning a double result.
 
 .. code:: java
 
@@ -143,9 +143,9 @@ used to call the UDF. As can be seen this UDF can be invoked in different ways:
         return v1 == null || v2 == null ? null : v1 * v2;
       }
 
-      @Udf(description = "multiply two non-nullable DOUBLEs.")
-      public double multiply(final double v1, double v2) {
-        return v1 * v2;
+      @Udf(description = "multiply N non-nullable DOUBLEs.")
+      public double multiply(final double... values) {
+        return Arrays.stream(values).reduce((a, b) -> a * b);
       }
     }
 

--- a/ksql-common/src/main/java/io/confluent/ksql/function/KsqlFunction.java
+++ b/ksql-common/src/main/java/io/confluent/ksql/function/KsqlFunction.java
@@ -15,7 +15,6 @@
 
 package io.confluent.ksql.function;
 
-import com.google.common.annotations.VisibleForTesting;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.Iterables;
 import io.confluent.ksql.function.udf.Kudf;

--- a/ksql-common/src/main/java/io/confluent/ksql/function/KsqlFunction.java
+++ b/ksql-common/src/main/java/io/confluent/ksql/function/KsqlFunction.java
@@ -51,18 +51,7 @@ public final class KsqlFunction {
       final Schema returnType,
       final List<Schema> arguments,
       final String functionName,
-      final Class<? extends Kudf> kudfClass) {
-    return createBuiltInVarargs(
-        returnType, arguments, functionName, kudfClass, false);
-  }
-
-  @VisibleForTesting
-  static KsqlFunction createBuiltInVarargs(
-      final Schema returnType,
-      final List<Schema> arguments,
-      final String functionName,
-      final Class<? extends Kudf> kudfClass,
-      final boolean isVarArgs
+      final Class<? extends Kudf> kudfClass
   ) {
     final Function<KsqlConfig, Kudf> udfFactory = ksqlConfig -> {
       try {
@@ -74,7 +63,7 @@ public final class KsqlFunction {
     };
 
     return create(
-        returnType, arguments, functionName, kudfClass, udfFactory, "", INTERNAL_PATH, isVarArgs);
+        returnType, arguments, functionName, kudfClass, udfFactory, "", INTERNAL_PATH, false);
   }
 
   /**
@@ -179,7 +168,7 @@ public final class KsqlFunction {
         && Objects.equals(functionName, that.functionName)
         && Objects.equals(kudfClass, that.kudfClass)
         && Objects.equals(pathLoadedFrom, that.pathLoadedFrom)
-        && (isVarArgs == ((KsqlFunction) o).isVarArgs);
+        && (isVarArgs == that.isVarArgs);
   }
 
   @Override

--- a/ksql-common/src/main/java/io/confluent/ksql/function/UdfFactory.java
+++ b/ksql-common/src/main/java/io/confluent/ksql/function/UdfFactory.java
@@ -18,52 +18,32 @@ package io.confluent.ksql.function;
 import io.confluent.ksql.function.udf.Kudf;
 import io.confluent.ksql.function.udf.UdfMetadata;
 import io.confluent.ksql.util.KsqlException;
-import io.confluent.ksql.util.SchemaUtil;
-import java.util.LinkedHashMap;
 import java.util.List;
-import java.util.Map;
 import java.util.Objects;
 import java.util.function.Consumer;
-import java.util.stream.Collectors;
-import java.util.stream.IntStream;
 import org.apache.kafka.connect.data.Schema;
 
 public class UdfFactory {
   private final UdfMetadata metadata;
   private final Class<? extends Kudf> udfClass;
-  private final Map<List<FunctionParameter>, KsqlFunction> functions = new LinkedHashMap<>();
-
+  private final UdfIndex udfIndex;
 
   UdfFactory(final Class<? extends Kudf> udfClass,
              final UdfMetadata metadata) {
     this.udfClass = Objects.requireNonNull(udfClass, "udfClass can't be null");
     this.metadata = Objects.requireNonNull(metadata, "metadata can't be null");
-  }
-
-  public UdfFactory copy() {
-    final UdfFactory udf = new UdfFactory(udfClass, metadata);
-    udf.functions.putAll(functions);
-    return udf;
+    this.udfIndex = new UdfIndex(metadata);
   }
 
   void addFunction(final KsqlFunction ksqlFunction) {
-    final List<FunctionParameter> paramTypes
-        = mapToFunctionParameter(ksqlFunction.getArguments());
-
-    checkCompatible(ksqlFunction, paramTypes);
-    functions.put(paramTypes, ksqlFunction);
+    checkCompatible(ksqlFunction);
+    udfIndex.addFunction(ksqlFunction);
   }
 
-  private void checkCompatible(final KsqlFunction ksqlFunction,
-                               final List<FunctionParameter> paramTypes) {
+  private void checkCompatible(final KsqlFunction ksqlFunction) {
     if (udfClass != ksqlFunction.getKudfClass()) {
       throw new KsqlException("Can't add function " + ksqlFunction
           + " as a function with the same name exists in a different " + udfClass);
-    }
-    if (functions.containsKey(paramTypes)) {
-      throw new KsqlException("Can't add function " + ksqlFunction
-          + " as a function with the same name and argument types already exists "
-          + functions.get(paramTypes));
     }
     if (!ksqlFunction.getPathLoadedFrom().equals(metadata.getPath())) {
       throw new KsqlException("Can't add function " + ksqlFunction
@@ -89,7 +69,7 @@ public class UdfFactory {
   }
 
   public void eachFunction(final Consumer<KsqlFunction> consumer) {
-    functions.values().forEach(consumer);
+    udfIndex.values().forEach(consumer);
   }
 
   public boolean isInternal() {
@@ -110,101 +90,11 @@ public class UdfFactory {
     return "UdfFactory{"
         + "metadata=" + metadata
         + ", udfClass=" + udfClass
-        + ", functions=" + functions
+        + ", udfIndex=" + udfIndex
         + '}';
   }
 
   public KsqlFunction getFunction(final List<Schema> paramTypes) {
-    final List<FunctionParameter> params = mapToFunctionParameter(paramTypes);
-    final KsqlFunction function = functions.get(params);
-    if (function != null) {
-      return function;
-    }
-
-    if (paramTypes.stream().anyMatch(Objects::isNull)) {
-      return functions.entrySet()
-          .stream()
-          .filter(entry -> checkParamsMatch(entry.getKey(), paramTypes))
-          .map(Map.Entry::getValue)
-          .findFirst()
-          .orElseThrow(() -> createNoMatchingFunctionException(paramTypes));
-    }
-
-    throw createNoMatchingFunctionException(paramTypes);
-  }
-
-  private KsqlException createNoMatchingFunctionException(final List<Schema> paramTypes) {
-    final String sqlParamTypes = paramTypes.stream()
-        .map(schema -> schema == null
-            ? null
-            : SchemaUtil.getSchemaTypeAsSqlType(schema.type()))
-        .collect(Collectors.joining(", ", "[", "]"));
-
-    return new KsqlException("Function '" + metadata.getName()
-                            + "' does not accept parameters of types:" + sqlParamTypes);
-  }
-
-  private static boolean checkParamsMatch(final List<FunctionParameter> functionArgTypes,
-                                          final List<Schema> suppliedParamTypes) {
-    if (functionArgTypes.size() != suppliedParamTypes.size()) {
-      return false;
-    }
-
-    return IntStream.range(0, suppliedParamTypes.size())
-        .boxed()
-        .allMatch(idx -> functionArgTypes.get(idx).matches(suppliedParamTypes.get(idx)));
-  }
-
-  private List<FunctionParameter> mapToFunctionParameter(final List<Schema> params) {
-    return params
-        .stream()
-        .map(schema -> schema == null
-            ? new FunctionParameter(null, false)
-            : new FunctionParameter(schema.type(), schema.isOptional()))
-        .collect(Collectors.toList());
-  }
-
-  private static final class FunctionParameter {
-    private final Schema.Type type;
-    private final boolean isOptional;
-
-    private FunctionParameter(final Schema.Type type, final boolean isOptional) {
-      this.type = type;
-      this.isOptional = isOptional;
-    }
-
-    @Override
-    public boolean equals(final Object o) {
-      if (this == o) {
-        return true;
-      }
-      if (o == null || getClass() != o.getClass()) {
-        return false;
-      }
-      final FunctionParameter that = (FunctionParameter) o;
-      // isOptional is excluded from equals and hashCode so that
-      // primitive types will match their boxed counterparts. i.e,
-      // primitive types are not optional, i.e., they don't accept null.
-      return type == that.type;
-    }
-
-    @Override
-    public int hashCode() {
-      // isOptional is excluded from equals and hashCode so that
-      // primitive types will match their boxed counterparts. i.e,
-      // primitive types are not optional, i.e., they don't accept null.
-      return Objects.hash(type);
-    }
-
-    boolean isOptional() {
-      return isOptional;
-    }
-
-    public boolean matches(final Schema schema) {
-      if (schema == null) {
-        return isOptional;
-      }
-      return type.equals(schema.type());
-    }
+    return udfIndex.getFunction(paramTypes);
   }
 }

--- a/ksql-common/src/main/java/io/confluent/ksql/function/UdfFactory.java
+++ b/ksql-common/src/main/java/io/confluent/ksql/function/UdfFactory.java
@@ -32,7 +32,7 @@ public class UdfFactory {
              final UdfMetadata metadata) {
     this.udfClass = Objects.requireNonNull(udfClass, "udfClass can't be null");
     this.metadata = Objects.requireNonNull(metadata, "metadata can't be null");
-    this.udfIndex = new UdfIndex(metadata);
+    this.udfIndex = new UdfIndex(metadata.getName());
   }
 
   void addFunction(final KsqlFunction ksqlFunction) {

--- a/ksql-common/src/main/java/io/confluent/ksql/function/UdfIndex.java
+++ b/ksql-common/src/main/java/io/confluent/ksql/function/UdfIndex.java
@@ -256,7 +256,10 @@ public class UdfIndex {
                 Objects.equals(a.keySchema(), b.keySchema())
                     && Objects.equals(a.valueSchema(), b.valueSchema()))
             .put(Type.ARRAY, (a, b) -> Objects.equals(a.valueSchema(), b.valueSchema()))
-            .put(Type.STRUCT, (a, b) -> Objects.equals(a.fields(), b.fields()))
+            .put(Type.STRUCT, (a, b) ->
+                a.fields().isEmpty()
+                || b.fields().isEmpty()
+                || Objects.equals(a.fields(), b.fields()))
             .build();
 
     private final Schema schema;

--- a/ksql-common/src/main/java/io/confluent/ksql/function/UdfIndex.java
+++ b/ksql-common/src/main/java/io/confluent/ksql/function/UdfIndex.java
@@ -1,0 +1,293 @@
+/*
+ * Copyright 2019 Confluent Inc.
+ *
+ * Licensed under the Confluent Community License (the "License"; you may not use
+ * this file except in compliance with the License. You may obtain a copy of the
+ * License at
+ *
+ * http://www.confluent.io/confluent-community-license
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package io.confluent.ksql.function;
+
+import com.google.common.annotations.VisibleForTesting;
+import com.google.common.collect.Iterables;
+import io.confluent.ksql.function.udf.UdfMetadata;
+import io.confluent.ksql.util.KsqlException;
+import io.confluent.ksql.util.SchemaUtil;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Comparator;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Map.Entry;
+import java.util.Objects;
+import java.util.stream.Collectors;
+import org.apache.commons.lang3.StringUtils;
+import org.apache.kafka.connect.data.Schema;
+import org.apache.kafka.connect.data.SchemaBuilder;
+
+/**
+ * An index of all method signatures associated with a UDF. This index
+ * supports lookups based on method signatures, defined by a list of
+ * nullable {@link Schema}.
+ *
+ * <p>Resolving a method signature takes the following precedence rules:
+ * <ul>
+ *   <li>If only one exact method exists, return it</li>
+ *   <li>If a method exists such that all non-null {@code Schema} in the
+ *       parameters match, and all other parameters are optional, return
+ *       that method</li>
+ *   <li>If two methods exist that match given the above rules, and one
+ *       does not have variable arguments (e.g. {@code String...}, return
+ *       that one.</li>
+ *   <li>If two methods exist that match given the above rules, and both
+ *       have variable arguments, return the method with the more non-variable
+ *       arguments.</li>
+ *   <li>If two methods exist that match only null values, return the one
+ *       that was added first.</li>
+ * </ul>
+ */
+public class UdfIndex {
+  // this class is implemented as a custom Trie data structure that resolves
+  // the rules described above. the Trie is built so that each node in the
+  // trie references a single possible parameter in the signature. take for
+  // example the following method signatures:
+  //
+  // A: void foo(String a)
+  // B: void foo(String a, Integer b)
+  // C: void foo(String a, Integer... ints)
+  // D: void foo(Integer a)
+  // E: void foo(Integer... ints)
+  //
+  // The final constructed trie would look like:
+  //
+  //                 Ø -> E
+  //               /   \
+  //    A <-- String   Integer -> D
+  //         /            \
+  // B <-- Integer      Integer (VARARG) -> E
+  //        /
+  // C <-- Integer (VARARG)
+  //
+  // To resolve a query against the trie, this class simply traverses down each
+  // matching path of the trie until it exhausts the input List<Schema>. The
+  // final node that it reaches will contain the method that is returned. If
+  // multiple methods are returned, the rules described above are used to select
+  // the best candidate (e.g. foo(null, int) matches both B and E).
+
+  private final UdfMetadata metadata;
+  private final Node root = new Node();
+  private final Map<List<Schema>, KsqlFunction> allFunctions;
+
+  UdfIndex(final UdfMetadata metadata) {
+    this.metadata = metadata;
+    allFunctions = new HashMap<>();
+  }
+
+  void addFunction(final KsqlFunction function) {
+    final List<Schema> arguments = function.getArguments();
+    if (allFunctions.put(function.getArguments(), function) != null) {
+      throw new KsqlException(
+          "Can't add function "
+              + function
+              + " as a function with the same name and argument type already exists "
+              + allFunctions.get(arguments)
+      );
+    }
+
+    final int order = allFunctions.size();
+
+    Node curr = root;
+    Node parent = curr;
+    for (final Schema arg : arguments) {
+      final FunctionParameter param = new FunctionParameter(arg, false);
+      parent = curr;
+      curr = curr.children.computeIfAbsent(param, ignored -> new Node());
+    }
+
+    if (function.isVarArgs()) {
+      // first add the function to the parent to address the
+      // case of empty varargs
+      parent.update(function, order);
+
+      // then add a new child node with the parameter value type
+      // and add this function to that node
+      final Schema varargSchema = Iterables.getLast(function.getArguments());
+      final FunctionParameter vararg = new FunctionParameter(varargSchema, true);
+      final Node leaf = parent.children.computeIfAbsent(vararg, ignored -> new Node());
+      leaf.update(function, order);
+
+      // add a self referential loop for varargs so that we can
+      // add as many of the same param at the end and still retrieve
+      // this node
+      leaf.children.putIfAbsent(vararg, leaf);
+    }
+
+    curr.update(function, order);
+  }
+
+  KsqlFunction getFunction(final List<Schema> parameters) {
+    final List<Node> candidates = new ArrayList<>();
+    getCandidates(parameters, 0, root, candidates);
+
+    return candidates
+        .stream()
+        .max(Node::compare)
+        .map(node -> node.value)
+        .orElseThrow(() -> createNoMatchingFunctionException(parameters));
+  }
+
+  private void getCandidates(
+      final List<Schema> parameters,
+      final int paramIndex,
+      final Node current,
+      final List<Node> candidates
+  ) {
+    if (paramIndex == parameters.size()) {
+      if (current.value != null) {
+        candidates.add(current);
+      }
+      return;
+    }
+
+    current.children
+        .entrySet()
+        .stream()
+        .filter(entry -> entry.getKey().matches(parameters.get(paramIndex)))
+        .map(Entry::getValue)
+        .forEach(node -> getCandidates(parameters, paramIndex + 1, node, candidates));
+  }
+
+  private KsqlException createNoMatchingFunctionException(final List<Schema> paramTypes) {
+    final String sqlParamTypes = paramTypes.stream()
+        .map(schema -> schema == null
+            ? null
+            : SchemaUtil.getSchemaTypeAsSqlType(schema.type()))
+        .collect(Collectors.joining(", ", "[", "]"));
+
+    return new KsqlException("Function '" + metadata.getName()
+        + "' does not accept parameters of types:" + sqlParamTypes);
+  }
+
+  public Collection<KsqlFunction> values() {
+    return allFunctions.values();
+  }
+
+  @SuppressWarnings("unused")
+  @VisibleForTesting
+  String describe() {
+    final StringBuilder sb = new StringBuilder();
+    sb.append("-ROOT\n");
+    root.describe(sb, 1);
+    return sb.toString();
+  }
+
+  private static final class Node {
+
+    private static final Comparator<KsqlFunction> COMPARE_FUNCTIONS =
+        Comparator.nullsFirst(
+            Comparator
+                .<KsqlFunction, Integer>comparing(fun -> fun.isVarArgs() ? 0 : 1)
+                .thenComparing(fun -> fun.getArguments().size())
+        );
+
+    private final Map<FunctionParameter, Node> children;
+    private KsqlFunction value;
+    private int order = 0;
+
+    private Node() {
+      this.children = new HashMap<>();
+      this.value = null;
+    }
+
+    private void update(final KsqlFunction function, final int order) {
+      if (COMPARE_FUNCTIONS.compare(function, value) > 0) {
+        value = function;
+        this.order = order;
+      }
+    }
+
+    private void describe(final StringBuilder builder, final int indent) {
+      for (final Entry<FunctionParameter, Node> child : children.entrySet()) {
+        if (child.getValue() != this) {
+          builder.append(StringUtils.repeat(' ', indent * 2))
+              .append('-')
+              .append(child.getKey())
+              .append(": ")
+              .append(child.getValue())
+              .append('\n');
+          child.getValue().describe(builder, indent + 1);
+        }
+      }
+    }
+
+    @Override
+    public String toString() {
+      return value != null ? value.getFunctionName() : "EMPTY";
+    }
+
+    public static int compare(final Node a, final Node b) {
+      final int compare = COMPARE_FUNCTIONS.compare(a.value, b.value);
+      return compare == 0 ? -(a.order - b.order) : compare;
+    }
+  }
+
+  private static final class FunctionParameter  {
+    private final Schema schema;
+    private final boolean isOptional;
+    private final boolean isVararg;
+
+    private FunctionParameter(final Schema schema, final boolean isVararg) {
+      this.schema = (schema instanceof SchemaBuilder) ? ((SchemaBuilder) schema).build() : schema;
+      this.isOptional = schema.isOptional();
+      this.isVararg = isVararg;
+    }
+
+    @Override
+    public boolean equals(final Object o) {
+      if (this == o) {
+        return true;
+      }
+      if (o == null || getClass() != o.getClass()) {
+        return false;
+      }
+      final FunctionParameter that = (FunctionParameter) o;
+      // isOptional is excluded from equals and hashCode so that
+      // primitive types will match their boxed counterparts. i.e,
+      // primitive types are not optional, i.e., they don't accept null.
+      return schema == that.schema && isVararg == that.isVararg;
+    }
+
+    @Override
+    public int hashCode() {
+      // isOptional is excluded from equals and hashCode so that
+      // primitive types will match their boxed counterparts. i.e,
+      // primitive types are not optional, i.e., they don't accept null.
+      return Objects.hash(schema, isVararg);
+    }
+
+    public boolean matches(final Schema schema) {
+      if (schema == null) {
+        return isOptional || (isVararg && this.schema.valueSchema().isOptional());
+      } else if (isVararg) {
+        return this.schema.valueSchema().type().equals(schema.type());
+      } else {
+        return this.schema.type().equals(schema.type());
+      }
+    }
+
+    @Override
+    public String toString() {
+      return SchemaUtil.getSqlTypeName(isVararg ? schema.valueSchema() : schema)
+          + (isVararg ? "(VARARG)" : "");
+    }
+  }
+
+}

--- a/ksql-common/src/main/java/io/confluent/ksql/util/SchemaUtil.java
+++ b/ksql-common/src/main/java/io/confluent/ksql/util/SchemaUtil.java
@@ -443,6 +443,9 @@ public final class SchemaUtil {
         return SchemaBuilder.array(getSchemaFromType(
             parameterizedType.getActualTypeArguments()[0]));
       }
+    } else if (type instanceof Class && ((Class) type).isArray()) {
+      // handle var args
+      return SchemaBuilder.array(getSchemaFromType(((Class) type).getComponentType()));
     }
     throw new KsqlException("Type is not supported: " + type);
   }

--- a/ksql-common/src/main/java/io/confluent/ksql/util/SchemaUtil.java
+++ b/ksql-common/src/main/java/io/confluent/ksql/util/SchemaUtil.java
@@ -443,9 +443,9 @@ public final class SchemaUtil {
         return SchemaBuilder.array(getSchemaFromType(
             parameterizedType.getActualTypeArguments()[0]));
       }
-    } else if (type instanceof Class && ((Class) type).isArray()) {
+    } else if (type instanceof Class && ((Class<?>) type).isArray()) {
       // handle var args
-      return SchemaBuilder.array(getSchemaFromType(((Class) type).getComponentType()));
+      return SchemaBuilder.array(getSchemaFromType(((Class<?>) type).getComponentType()));
     }
     throw new KsqlException("Type is not supported: " + type);
   }

--- a/ksql-common/src/test/java/io/confluent/ksql/function/UdfFactoryTest.java
+++ b/ksql-common/src/test/java/io/confluent/ksql/function/UdfFactoryTest.java
@@ -15,20 +15,12 @@
 
 package io.confluent.ksql.function;
 
-import static org.hamcrest.CoreMatchers.equalTo;
-import static org.hamcrest.CoreMatchers.is;
-import static org.hamcrest.CoreMatchers.sameInstance;
-import static org.hamcrest.MatcherAssert.assertThat;
-
 import com.google.common.collect.ImmutableList;
 import io.confluent.ksql.function.udf.Kudf;
 import io.confluent.ksql.function.udf.UdfMetadata;
-import io.confluent.ksql.util.KsqlException;
-import java.util.Arrays;
 import java.util.Collections;
 import org.apache.kafka.common.KafkaException;
 import org.apache.kafka.connect.data.Schema;
-import org.apache.kafka.connect.data.SchemaBuilder;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ExpectedException;

--- a/ksql-common/src/test/java/io/confluent/ksql/function/UdfIndexTest.java
+++ b/ksql-common/src/test/java/io/confluent/ksql/function/UdfIndexTest.java
@@ -24,6 +24,10 @@ public class UdfIndexTest {
   private static final Schema STRING_VARARGS = SchemaBuilder.array(Schema.OPTIONAL_STRING_SCHEMA);
   private static final Schema STRING = Schema.OPTIONAL_STRING_SCHEMA;
   private static final Schema INT = Schema.OPTIONAL_INT32_SCHEMA;
+  private static final Schema STRUCT1 = SchemaBuilder.struct().field("a", STRING).build();
+  private static final Schema STRUCT2 = SchemaBuilder.struct().field("b", INT).build();
+  private static final Schema MAP1 = SchemaBuilder.map(STRING, STRING).build();
+  private static final Schema MAP2 = SchemaBuilder.map(STRING, INT).build();
 
   private static final String EXPECTED = "expected";
 
@@ -95,6 +99,24 @@ public class UdfIndexTest {
             new Schema[]{STRING, STRING},
             true
         },
+        new Object[]{
+            "shouldChooseCorrectStruct",
+            new KsqlFunction[]{
+                function("other", false, STRUCT2),
+                function(EXPECTED, false, STRUCT1),
+            },
+            new Schema[]{STRUCT1},
+            true
+        },
+        new Object[]{
+            "shouldChooseCorrectMap",
+            new KsqlFunction[]{
+                function("other", false, MAP2),
+                function(EXPECTED, false, MAP1),
+            },
+            new Schema[]{MAP1},
+            true
+        },
 
         // vararg tests
         new Object[]{
@@ -119,6 +141,14 @@ public class UdfIndexTest {
                 function(EXPECTED, true, STRING_VARARGS)
             },
             new Schema[]{STRING, STRING},
+            true
+        },
+        new Object[]{
+            "shouldFindVarargWithStruct",
+            new KsqlFunction[]{
+                function(EXPECTED, true, SchemaBuilder.array(STRUCT1).build()),
+            },
+            new Schema[]{STRUCT1, STRUCT1},
             true
         },
         new Object[]{
@@ -308,6 +338,14 @@ public class UdfIndexTest {
                 function("one", false, STRING)
             },
             new Schema[]{STRING, null},
+            false
+        },
+        new Object[]{
+            "shouldNotMatchVarargDifferentStructs",
+            new KsqlFunction[]{
+                function("one", true, SchemaBuilder.array(STRUCT1).build()),
+            },
+            new Schema[]{STRUCT1, STRUCT2},
             false
         }
     );

--- a/ksql-common/src/test/java/io/confluent/ksql/function/UdfIndexTest.java
+++ b/ksql-common/src/test/java/io/confluent/ksql/function/UdfIndexTest.java
@@ -1,0 +1,358 @@
+package io.confluent.ksql.function;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.equalTo;
+
+import io.confluent.ksql.function.udf.Kudf;
+import io.confluent.ksql.function.udf.UdfMetadata;
+import io.confluent.ksql.util.KsqlException;
+import java.util.Arrays;
+import org.apache.kafka.connect.data.Schema;
+import org.apache.kafka.connect.data.SchemaBuilder;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+import org.junit.runners.Parameterized.Parameter;
+import org.junit.runners.Parameterized.Parameters;
+
+@RunWith(Parameterized.class)
+public class UdfIndexTest {
+
+  private static final Schema STRING_VARARGS = SchemaBuilder.array(Schema.OPTIONAL_STRING_SCHEMA);
+  private static final Schema STRING = Schema.OPTIONAL_STRING_SCHEMA;
+  private static final Schema INT = Schema.OPTIONAL_INT32_SCHEMA;
+
+  private static final String EXPECTED = "expected";
+
+  private UdfIndex udfIndex;
+
+  @Before
+  public void setUp() {
+    udfIndex = new UdfIndex(new UdfMetadata("name", "description", "confluent", "1", "", false));
+  }
+
+  @Rule public ExpectedException expectedException = ExpectedException.none();
+
+  @Parameter(0) public String name;
+  @Parameter(1) public KsqlFunction[] functions;
+  @Parameter(2) public Schema[] parameter;
+  @Parameter(3) public boolean shouldFind;
+
+  @Parameters(name="{0}")
+  public static Iterable<Object[]> data() {
+    return Arrays.asList(
+        // non-vararg tests
+        new Object[]{
+            "shouldFindNoArgs",
+            new KsqlFunction[]{
+                function(EXPECTED, false)
+            },
+            new Schema[]{},
+            true
+        },
+        new Object[]{
+            "shouldFindOneArg",
+            new KsqlFunction[]{
+                function(EXPECTED, false, STRING)
+            },
+            new Schema[]{STRING},
+            true
+        },
+        new Object[]{
+            "shouldFindTwoDifferentArgs",
+            new KsqlFunction[]{
+                function(EXPECTED, false, STRING, INT)
+            },
+            new Schema[]{STRING, INT},
+            true
+        },
+        new Object[]{
+            "shouldFindTwoSameArgs",
+            new KsqlFunction[]{
+                function(EXPECTED, false, STRING, STRING)
+            },
+            new Schema[]{STRING, STRING},
+            true
+        },
+        new Object[]{
+            "shouldFindOneArgConflict",
+            new KsqlFunction[]{
+                function(EXPECTED, false, STRING),
+                function("other", false, INT)
+            },
+            new Schema[]{STRING},
+            true
+        },
+        new Object[]{
+            "shouldFindTwoArgSameFirstConflict",
+            new KsqlFunction[]{
+                function(EXPECTED, false, STRING, STRING),
+                function("other", false, STRING, INT)
+            },
+            new Schema[]{STRING, STRING},
+            true
+        },
+
+        // vararg tests
+        new Object[]{
+            "shouldFindVarargsEmpty",
+            new KsqlFunction[]{
+                function(EXPECTED, true, STRING_VARARGS)
+            },
+            new Schema[]{},
+            true
+        },
+        new Object[]{
+            "shouldFindVarargsOne",
+            new KsqlFunction[]{
+                function(EXPECTED, true, STRING_VARARGS)
+            },
+            new Schema[]{STRING},
+            true
+        },
+        new Object[]{
+            "shouldFindVarargsTwo",
+            new KsqlFunction[]{
+                function(EXPECTED, true, STRING_VARARGS)
+            },
+            new Schema[]{STRING, STRING},
+            true
+        },
+        new Object[]{
+            "shouldFindVarargWithList",
+            new KsqlFunction[]{
+                function(EXPECTED, true, STRING_VARARGS),
+            },
+            new Schema[]{STRING_VARARGS},
+            true
+        },
+
+        // precedence tests
+        new Object[]{
+            "shouldChooseSpecificOverVarArgs",
+            new KsqlFunction[]{
+                function(EXPECTED, false, STRING),
+                function("other", true, STRING_VARARGS)
+            },
+            new Schema[]{STRING},
+            true
+        },
+        new Object[]{
+            "shouldChooseSpecificOverMultipleVarArgs",
+            new KsqlFunction[]{
+                function(EXPECTED, false, STRING),
+                function("other", true, STRING_VARARGS),
+                function("other1", true, STRING, STRING_VARARGS)
+            },
+            new Schema[]{STRING},
+            true
+        },
+        new Object[]{
+            "shouldChooseVarArgsIfSpecificDoesntMatch",
+            new KsqlFunction[]{
+                function("other", false, STRING),
+                function(EXPECTED, true, STRING_VARARGS)
+            },
+            new Schema[]{STRING, STRING},
+            true
+        },
+
+        // null value tests
+        new Object[]{
+            "shouldFindNonVarargWithNullValues",
+            new KsqlFunction[]{
+                function(EXPECTED, false, STRING),
+            },
+            new Schema[]{null},
+            true
+        },
+        new Object[]{
+            "shouldFindNonVarargWithPartialNullValues",
+            new KsqlFunction[]{
+                function(EXPECTED, false, STRING, STRING),
+            },
+            new Schema[]{null, STRING},
+            true
+        },
+        new Object[]{
+            "shouldChooseFirstAddedWithNullValues",
+            new KsqlFunction[]{
+                function(EXPECTED, false, STRING),
+                function("other", false, INT),
+            },
+            new Schema[]{null},
+            true
+        },
+        new Object[]{
+            "shouldFindVarargWithNullValues",
+            new KsqlFunction[]{
+                function(EXPECTED, true, STRING_VARARGS),
+            },
+            new Schema[]{null},
+            true
+        },
+        new Object[]{
+            "shouldFindVarargWithSomeNullValues",
+            new KsqlFunction[]{
+                function(EXPECTED, true, STRING_VARARGS),
+            },
+            new Schema[]{null, STRING, null},
+            true
+        },
+        new Object[]{
+            "shouldChooseNonVarargWithNullValues",
+            new KsqlFunction[]{
+                function(EXPECTED, false, STRING),
+                function("other", true, STRING_VARARGS)
+            },
+            new Schema[]{null},
+            true
+        },
+        new Object[]{
+            "shouldChooseNonVarargWithNullValuesOfDifferingSchemas",
+            new KsqlFunction[]{
+                function(EXPECTED, false, STRING, INT),
+                function("other", true, STRING_VARARGS),
+            },
+            new Schema[]{null, null},
+            true
+        },
+        new Object[]{
+            "shouldChooseNonVarargWithNullValuesOfSameSchemas",
+            new KsqlFunction[]{
+                function(EXPECTED, false, STRING, STRING),
+                function("other", true, STRING_VARARGS),
+            },
+            new Schema[]{null, null},
+            true
+        },
+        new Object[]{
+            "shouldChooseNonVarargWithNullValuesOfPartialNulls",
+            new KsqlFunction[]{
+                function(EXPECTED, false, STRING, INT),
+                function("other", true, STRING_VARARGS),
+            },
+            new Schema[]{STRING, null},
+            true
+        },
+        new Object[]{
+            "shouldChooseCorrectlyInComplicatedTopology",
+            new KsqlFunction[]{
+                function(EXPECTED, false, STRING, INT, STRING, INT),
+                function("one", true, STRING_VARARGS),
+                function("two", true, STRING, STRING_VARARGS),
+                function("three", true, STRING, INT, STRING_VARARGS),
+                function("four", true, STRING, INT, STRING, INT, STRING_VARARGS),
+                function("five", true, INT , INT, STRING, INT, STRING_VARARGS)
+            },
+            new Schema[]{STRING, INT, null, INT},
+            true
+        },
+
+        // failure tests
+        new Object[]{
+            "shouldNotMatchIfParamLengthDiffers",
+            new KsqlFunction[]{
+                function("one", false, STRING)
+            },
+            new Schema[]{STRING, STRING},
+            false
+        },
+        new Object[]{
+            "shouldNotMatchIfNoneFound",
+            new KsqlFunction[]{
+                function("one", false, STRING)
+            },
+            new Schema[]{INT},
+            false
+        },
+        new Object[]{
+            "shouldNotMatchIfNullAndPrimitive",
+            new KsqlFunction[]{
+                function("one", false, Schema.INT32_SCHEMA)
+            },
+            new Schema[]{null},
+            false
+        },
+        new Object[]{
+            "shouldNotMatchIfNullAndPrimitiveVararg",
+            new KsqlFunction[]{
+                function("one", true, SchemaBuilder.array(Schema.INT32_SCHEMA))
+            },
+            new Schema[]{null},
+            false
+        },
+        new Object[]{
+            "shouldNotMatchIfNoneFoundWithNull",
+            new KsqlFunction[]{
+                function("one", false, STRING, INT)
+            },
+            new Schema[]{INT, null},
+            false
+        },
+        new Object[]{
+            "shouldNotChooseSpecificWhenTrickyVarArgLoop",
+            new KsqlFunction[]{
+                function("one", false, STRING, INT),
+                function("two", true, STRING_VARARGS)
+            },
+            new Schema[]{STRING, INT, STRING},
+            false
+        },
+        new Object[]{
+            "shouldNotMatchWhenNullTypeInArgsIfParamLengthDiffers",
+            new KsqlFunction[]{
+                function("one", false, STRING)
+            },
+            new Schema[]{STRING, null},
+            false
+        }
+    );
+  }
+
+  @Test
+  public void test() {
+    // Given:
+    Arrays.stream(functions).forEach(udfIndex::addFunction);
+
+    // Expect:
+    if (!shouldFind) {
+      expectedException.expect(KsqlException.class);
+      expectedException.expectMessage("Function 'name' does not accept parameters");
+    }
+
+    // When:
+    final KsqlFunction fun = udfIndex.getFunction(Arrays.asList(parameter));
+
+    // Then:
+    if (shouldFind) {
+      assertThat(fun.getFunctionName(), equalTo(EXPECTED));
+    }
+  }
+
+  private static KsqlFunction function(
+      final String name,
+      final boolean isVarArgs,
+      final Schema... args
+  ) {
+    return KsqlFunction.createBuiltInVarargs(
+        Schema.OPTIONAL_STRING_SCHEMA,
+        Arrays.asList(args),
+        name,
+        MyUdf.class,
+        isVarArgs
+    );
+  }
+
+  private static final class MyUdf implements Kudf {
+    @Override
+    public Object evaluate(final Object... args) {
+      return null;
+    }
+  }
+
+
+}

--- a/ksql-engine/src/main/java/io/confluent/ksql/function/UdfTemplate.java
+++ b/ksql-engine/src/main/java/io/confluent/ksql/function/UdfTemplate.java
@@ -81,7 +81,13 @@ public final class UdfTemplate {
     }
 
     if (clazz.isArray()) {
-      return fromArray(arg, clazz, index);
+      try {
+        return fromArray(arg, clazz);
+      } catch (Exception e) {
+        throw new KsqlFunctionException(
+            String.format("Couldn't coerce array argument \"args[%d]\" to type %s", index, clazz)
+        );
+      }
     }
 
     // using boxed type is safe: long.class and Long.class are both of type Class<Long>
@@ -114,8 +120,8 @@ public final class UdfTemplate {
   @SuppressWarnings("unchecked")
   private static <T> T fromArray(
       final Object args,
-      final Class<? extends T> arrayType,
-      final int index) {
+      final Class<? extends T> arrayType
+  ) {
     if (!args.getClass().isArray()) {
       throw new KsqlFunctionException(
           String.format("Cannot coerce non-array object %s to %s", args, arrayType));
@@ -125,7 +131,7 @@ public final class UdfTemplate {
     final Class<?> componentType = arrayType.getComponentType();
     final Object val = Array.newInstance(componentType, length);
     for (int i = 0; i < length; i++) {
-      Array.set(val, i, coerce(Array.get(args, i), componentType, index));
+      Array.set(val, i, coerce(Array.get(args, i), componentType, i));
     }
     return (T) val;
   }

--- a/ksql-engine/src/main/java/io/confluent/ksql/function/UdfTemplate.java
+++ b/ksql-engine/src/main/java/io/confluent/ksql/function/UdfTemplate.java
@@ -17,6 +17,7 @@ package io.confluent.ksql.function;
 
 import com.google.common.primitives.Primitives;
 import com.squareup.javapoet.CodeBlock;
+import java.lang.reflect.Array;
 import java.lang.reflect.Method;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
@@ -62,6 +63,14 @@ public final class UdfTemplate {
       final Class<? extends T> clazz,
       final int index) {
     final Object arg = args[index];
+    return coerce(arg, clazz, index);
+  }
+
+  public static <T> T coerce(
+      final Object arg,
+      final Class<? extends T> clazz,
+      final int index
+  ) {
     if (arg == null) {
       if (clazz.isPrimitive()) {
         throw new KsqlFunctionException(
@@ -71,14 +80,16 @@ public final class UdfTemplate {
       return null;
     }
 
+    if (clazz.isArray()) {
+      return fromArray(arg, clazz, index);
+    }
+
     // using boxed type is safe: long.class and Long.class are both of type Class<Long>
     // and this is a no-op for non-primitives
     final Class<? extends T> boxedType = Primitives.wrap(clazz);
     if (boxedType.isAssignableFrom(arg.getClass())) {
       return boxedType.cast(arg);
-    }
-
-    if (arg instanceof String) {
+    } else if (arg instanceof String) {
       try {
         return fromString((String) arg, clazz);
       } catch (Exception e) {
@@ -86,9 +97,7 @@ public final class UdfTemplate {
             String.format("Couldn't coerce string argument '\"args[%d]\"' to type %s",
                           index, clazz));
       }
-    }
-
-    if (arg instanceof Number) {
+    } else if (arg instanceof Number) {
       try {
         return fromNumber((Number) arg, boxedType);
       } catch (Exception e) {
@@ -96,10 +105,29 @@ public final class UdfTemplate {
             String.format("Couldn't coerce numeric argument '\"args[%d]:(%s) %s\"' to type %s",
                           index, arg.getClass(), arg, clazz));
       }
+    } else {
+      throw new KsqlFunctionException(
+          String.format("Impossible to coerce (%s) %s into %s", arg.getClass(), arg, clazz));
+    }
+  }
+
+  @SuppressWarnings("unchecked")
+  private static <T> T fromArray(
+      final Object args,
+      final Class<? extends T> arrayType,
+      final int index) {
+    if (!args.getClass().isArray()) {
+      throw new KsqlFunctionException(
+          String.format("Cannot coerce non-array object %s to %s", args, arrayType));
     }
 
-    throw new KsqlFunctionException(
-        String.format("Impossible to coerce (%s) %s into %s", arg.getClass(), arg, clazz));
+    final int length = Array.getLength(args);
+    final Class<?> componentType = arrayType.getComponentType();
+    final Object val = Array.newInstance(componentType, length);
+    for (int i = 0; i < length; i++) {
+      Array.set(val, i, coerce(Array.get(args, i), componentType, index));
+    }
+    return (T) val;
   }
 
   private static <T> T fromNumber(final Number arg, final Class<? extends T> boxedType) {

--- a/ksql-engine/src/main/java/io/confluent/ksql/function/udf/PluggableUdf.java
+++ b/ksql-engine/src/main/java/io/confluent/ksql/function/udf/PluggableUdf.java
@@ -17,6 +17,8 @@ package io.confluent.ksql.function.udf;
 
 import io.confluent.ksql.function.UdfInvoker;
 import io.confluent.ksql.security.ExtensionSecurityManager;
+import java.lang.reflect.Method;
+import java.util.Arrays;
 import java.util.Objects;
 
 /**
@@ -29,20 +31,40 @@ public class PluggableUdf implements Kudf {
 
   private final UdfInvoker udf;
   private final Object actualUdf;
+  private final Method method;
 
-  public PluggableUdf(final UdfInvoker udfInvoker,
-                      final Object actualUdf) {
-    this.udf = Objects.requireNonNull(udfInvoker, "udfInvoker can't be null");
-    this.actualUdf = Objects.requireNonNull(actualUdf, "actualUdf can't be null");
+  public PluggableUdf(
+      final UdfInvoker udfInvoker,
+      final Object actualUdf,
+      final Method method
+  ) {
+    this.udf = Objects.requireNonNull(udfInvoker, "udfInvoker");
+    this.actualUdf = Objects.requireNonNull(actualUdf, "actualUdf");
+    this.method = Objects.requireNonNull(method, "method");
   }
 
   @Override
   public Object evaluate(final Object... args) {
     try {
       ExtensionSecurityManager.INSTANCE.pushInUdf();
-      return udf.eval(actualUdf, args);
+      return udf.eval(actualUdf, extractArgs(args));
     } finally {
       ExtensionSecurityManager.INSTANCE.popOutUdf();
     }
+  }
+
+  private Object[] extractArgs(final Object... source) {
+    if (!method.isVarArgs()) {
+      return source;
+    }
+
+    final Object[] args = new Object[method.getParameterCount()];
+    System.arraycopy(source, 0, args, 0, method.getParameterCount() - 1);
+
+    final int start = method.getParameterCount() - 1;
+    final Object[] varargs = Arrays.copyOfRange(source, start, source.length);
+    args[start] = varargs;
+
+    return args;
   }
 }

--- a/ksql-engine/src/test/java/io/confluent/ksql/codegen/CodeGenRunnerTest.java
+++ b/ksql-engine/src/test/java/io/confluent/ksql/codegen/CodeGenRunnerTest.java
@@ -787,6 +787,17 @@ public class CodeGenRunnerTest {
     }
 
     @Test
+    public void shouldHandleFunctionWithVarargs() {
+        final String query =
+            "SELECT test_udf(col0, col0, col0, col0, col0) FROM codegen_test;";
+
+        final Map<Integer, Object> inputValues = ImmutableMap.of(0, 0);
+        final List<Object> columns = executeExpression(query, inputValues);
+        // test
+        assertThat(columns, equalTo(Collections.singletonList("doStuffLongVarargs")));
+    }
+
+    @Test
     public void shouldChoseFunctionWithCorrectNumberOfArgsWhenNullArgument() {
         final String query =
             "SELECT test_udf(col0, col0, NULL) FROM codegen_test;";

--- a/ksql-engine/src/test/java/io/confluent/ksql/function/UdfTemplateTest.java
+++ b/ksql-engine/src/test/java/io/confluent/ksql/function/UdfTemplateTest.java
@@ -197,7 +197,7 @@ public class UdfTemplateTest {
 
     // Expect:
     expectedException.expect(KsqlFunctionException.class);
-    expectedException.expectMessage("Cannot coerce non-array");
+    expectedException.expectMessage("Couldn't coerce array");
 
     // When:
     UdfTemplate.coerce(args, Object[].class, 0);

--- a/ksql-engine/src/test/java/io/confluent/ksql/function/UdfTemplateTest.java
+++ b/ksql-engine/src/test/java/io/confluent/ksql/function/UdfTemplateTest.java
@@ -5,6 +5,8 @@ import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.nullValue;
 
+import com.google.common.primitives.Primitives;
+import java.lang.reflect.Array;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
@@ -19,7 +21,6 @@ public class UdfTemplateTest {
   @Rule
   public final ExpectedException expectedException = ExpectedException.none();
 
-  @SuppressWarnings("ConstantConditions")
   @Test
   public void testCoerceNumbers() {
     // Given:
@@ -70,6 +71,7 @@ public class UdfTemplateTest {
     assertThat(UdfTemplate.coerce(args, Boolean.class, 0), nullValue());
     assertThat(UdfTemplate.coerce(args, Map.class, 0), nullValue());
     assertThat(UdfTemplate.coerce(args, List.class, 0), nullValue());
+    assertThat(UdfTemplate.coerce(args, Object[].class, 0), nullValue());
   }
 
   @Test
@@ -94,6 +96,111 @@ public class UdfTemplateTest {
     assertThat(UdfTemplate.coerce(args, List.class, 0), equalTo(new ArrayList<>()));
     assertThat(UdfTemplate.coerce(args, Map.class, 1), equalTo(new HashMap<>()));
     assertThat(UdfTemplate.coerce(args, String.class, 2), equalTo(""));
+  }
+
+  @Test
+  public void shouldCoerceNullArray() {
+    // Given:
+    Object[] args = new Object[]{null};
+
+    // Then:
+    assertThat(UdfTemplate.coerce(args, Object[].class, 0), equalTo(null));
+  }
+
+  @Test
+  public void shouldCoercePrimitiveArrays() {
+    // Given:
+    Object[] args = new Object[]{
+        new int[]{1},
+        new byte[]{1},
+        new short[]{1},
+        new float[]{1f},
+        new double[]{1d},
+        new boolean[]{true}
+    };
+
+    // Then:
+    for (int i = 0; i < args.length; i++) {
+      assertThat(UdfTemplate.coerce(args, args[i].getClass(), i), equalTo(args[i]));
+    }
+  }
+
+  @Test
+  public void shouldCoerceBoxedArrays() {
+    // Given:
+    Object[] args = new Object[]{
+        new Integer[]{1},
+        new Byte[]{1},
+        new Short[]{1},
+        new Float[]{1f},
+        new Double[]{1d},
+        new Boolean[]{true}
+    };
+
+    // Then:
+    for (int i = 0; i < args.length; i++) {
+      assertThat(UdfTemplate.coerce(args, args[i].getClass(), i), equalTo(args[i]));
+    }
+  }
+
+  @Test
+  public void shouldCoercePrimitiveArrayToBoxed() {
+    // Given:
+    Object[] args = new Object[]{
+        new int[]{1},
+        new byte[]{1},
+        new short[]{1},
+        new float[]{1f},
+        new double[]{1d},
+        new boolean[]{true}
+    };
+
+    // Then:
+    for (int i = 0; i < args.length; i++) {
+      final Class<?> boxed = Primitives.wrap(args[i].getClass().getComponentType());
+      final Class<?> boxedArray = Array.newInstance(boxed, 0).getClass();
+      assertThat(UdfTemplate.coerce(args, boxedArray, i), equalTo(args[i]));
+    }
+  }
+
+  @Test
+  public void shouldCoerceNumberConversionArray() {
+    // Given:
+    Object[] args = new Object[]{new int[]{1}};
+
+    // Then:
+    assertThat(UdfTemplate.coerce(args, double[].class, 0), equalTo(new double[]{1}));
+  }
+
+  @Test
+  public void shouldCoerceArrayOfLists() {
+    // Given:
+    Object[] args = new Object[]{new List[]{new ArrayList()}};
+
+    // Then:
+    assertThat(UdfTemplate.coerce(args, List[].class, 0), equalTo(new List[]{new ArrayList<>()}));
+  }
+
+  @Test
+  public void shouldCoerceArrayOfMaps() {
+    // Given:
+    Object[] args = new Object[]{new Map[]{new HashMap<>()}};
+
+    // Then:
+    assertThat(UdfTemplate.coerce(args, Map[].class, 0), equalTo(new Map[]{new HashMap<>()}));
+  }
+
+  @Test
+  public void shouldNotCoerceNonArrayToArray() {
+    // Given:
+    Object[] args = new Object[]{"not an array"};
+
+    // Expect:
+    expectedException.expect(KsqlFunctionException.class);
+    expectedException.expectMessage("Cannot coerce non-array");
+
+    // When:
+    UdfTemplate.coerce(args, Object[].class, 0);
   }
 
   @Test

--- a/ksql-engine/src/test/java/io/confluent/ksql/function/udf/TestUdf.java
+++ b/ksql-engine/src/test/java/io/confluent/ksql/function/udf/TestUdf.java
@@ -33,4 +33,9 @@ public class TestUdf {
   public String doStuffLongLongString(final long arg1, final long arg2, final String arg3) {
     return "doStuffLongLongString";
   }
+
+  @Udf(description = "returns method name")
+  public String doStuffLongVarargs(final long... longs) {
+    return "doStuffLongVarargs";
+  }
 }

--- a/ksql-engine/src/test/java/io/confluent/ksql/security/ExtensionSecurityManagerTest.java
+++ b/ksql-engine/src/test/java/io/confluent/ksql/security/ExtensionSecurityManagerTest.java
@@ -61,22 +61,29 @@ public class ExtensionSecurityManagerTest {
   }
 
   @Test(expected = SecurityException.class)
-  public void shouldNotAllowExecWhenPluggableUDF() {
-    new PluggableUdf((thiz,args) -> {
-      try {
-        return Runtime.getRuntime().exec("cmd");
-      } catch (IOException e) {
-        return null;
-      }
-    }, new Object()).evaluate();
+  public void shouldNotAllowExecWhenPluggableUDF() throws NoSuchMethodException {
+    new PluggableUdf(
+        (thiz,args) -> exec(),
+        new Object(),
+        ExtensionSecurityManagerTest.class.getMethod("exec"))
+        .evaluate();
+  }
+
+  @SuppressWarnings("WeakerAccess")
+  public static Process exec() {
+    try {
+      return Runtime.getRuntime().exec("cmd");
+    } catch (IOException e) {
+      return null;
+    }
   }
 
   @Test(expected = SecurityException.class)
-  public void shouldNotAllowExitWhenPluggableUDF() {
+  public void shouldNotAllowExitWhenPluggableUDF() throws NoSuchMethodException {
     new PluggableUdf((thiz,args) -> {
       System.exit(1);
       return null;
-    }, new Object()).evaluate();
+    }, new Object(), System.class.getMethod("exit", int.class)).evaluate();
   }
   
 }


### PR DESCRIPTION
### Description 
As part of #2503, this add supports for defining UDFs with variable arguments. To accomplish this there were three main changes:
* Ability for `UdfFactory` to resolve conflicts between vararg and non-vararg functions. This is done in a new class called `UdfIndex` (Implementation is described inline)
* Our coercion mechanism in `UdfTemplate` needs to be able to coerce arrays
* `SchemaUtil` needs to support parameterized array types

### TODOs
* (See below) Move built-in UDFs that use varargs (e.g. `Concat`) to the new UDF style
* Update DescribeFunction to show information on whether or not a function is varargs

### Testing done 
- Unit tests
- Moving `ConcatKudf` to new annotation based Udfs and adding QTT tests to cover (since lots of test files will be affected, I will commit this in a follow-up PR)

### Reviewer checklist
- [ ] Ensure docs are updated if necessary. (eg. if a user visible feature is being added or changed).
- [ ] Ensure relevant issues are linked (description should include text like "Fixes #<issue number>")

