### PR TITLE
Minor: fix error in SSL config docs.

### DIFF
--- a/docs/installation/server-config/security.rst
+++ b/docs/installation/server-config/security.rst
@@ -46,7 +46,7 @@ settings:
 
 ::
 
-    ssl.client.auth=required
+    ssl.client.auth=true
     ssl.truststore.location=/var/private/ssl/ksql.server.truststore.jks
     ssl.truststore.password=zzzz
 


### PR DESCRIPTION
### Description 

The newly-added docs around configuring KSQL for HTTPS mention setting `ssl.client.auth=required` for configuring mutual auth, but [the config is a boolean](https://github.com/confluentinc/rest-utils/blob/fa71eb6dee284530fb9b27b703e16063aa73d9b3/core/src/main/java/io/confluent/rest/RestConfig.java#L411) so it should be `ssl.client.auth=true` instead.

Specifically, setting `ssl.client.auth=required` results in
```
io.confluent.common.config.ConfigException: Invalid value required for configuration ssl.client.auth: Expected value to be either true or false
    at io.confluent.common.config.ConfigDef.parseType(ConfigDef.java:286)
    at io.confluent.common.config.ConfigDef.parse(ConfigDef.java:249)
    at io.confluent.common.config.AbstractConfig.<init>(AbstractConfig.java:78)
    at io.confluent.rest.RestConfig.<init>(RestConfig.java:494)
    at io.confluent.ksql.rest.server.KsqlRestConfig.<init>(KsqlRestConfig.java:92)
    at io.confluent.ksql.rest.server.KsqlServerMain.createExecutable(KsqlServerMain.java:84)
    at io.confluent.ksql.rest.server.KsqlServerMain.main(KsqlServerMain.java:50)
```

### Testing done 

Docs-only change. Manual verification that setting `ssl.client.auth=true` functions as expected.

### Reviewer checklist
- [ ] Ensure docs are updated if necessary. (eg. if a user visible feature is being added or changed).
- [ ] Ensure relevant issues are linked (description should include text like "Fixes #<issue number>")

