### PR TITLE
Minor: Correct docs for configuring basic HTTP auth

### DIFF
--- a/docs/installation/server-config/security.rst
+++ b/docs/installation/server-config/security.rst
@@ -38,13 +38,19 @@ Use the following settings to configure the KSQL server to require authenticatio
     authentication.method=BASIC
     authentication.roles=some-ksql-cluster-id
     authentication.realm=KsqlServer-Props
-    java.security.auth.login.config=/path/to/the/jaas_config.file
 
 The ``authentication.roles`` config defines a comma separated list of user roles. To be authorized
 to use the KSQL server an authenticated user must belong to at least one of these roles.
 
 The ``authentication.realm`` config must match a section within ``jaas_config.file``, which
-defines how the server authenticates users, for example:
+defines how the server authenticates users, and should be passed as a JVM option during server start:
+
+.. code:: bash
+
+    $ export KSQL_OPTS=-Djava.security.auth.login.config=/path/to/the/jaas_config.file
+    $ <path-to-confluent>/bin/ksql-server-start <path-to-confluent>/etc/ksql/ksql-server.properties
+
+An example ``jaas_config.file`` is:
 
 ::
 

--- a/docs/installation/server-config/security.rst
+++ b/docs/installation/server-config/security.rst
@@ -43,7 +43,7 @@ The ``authentication.roles`` config defines a comma separated list of user roles
 to use the KSQL server an authenticated user must belong to at least one of these roles.
 
 The ``authentication.realm`` config must match a section within ``jaas_config.file``, which
-defines how the server authenticates users, and should be passed as a JVM option during server start:
+defines how the server authenticates users and should be passed as a JVM option during server start:
 
 .. code:: bash
 


### PR DESCRIPTION
### Description 

The docs for configuring basic HTTP auth for KSQL recommend specifying the JAAS file location as a parameter in the server config, but this doesn't work since [we exclude configs prefixed with `java.`](https://github.com/confluentinc/ksql/blob/5.1.x/ksql-rest-app/src/main/java/io/confluent/ksql/rest/server/ServerOptions.java#L39) when loading server configs. This PR updates the docs to recommend passing the JAAS file location as a JVM parameter instead, which does work.

I've targeted `5.1.x` as the docs for configuring basic auth were only introduced in 5.1 (i.e., they're not present on `5.0.x`), but I'm unfamiliar with how our `-post` branches work. Perhaps this correction should target one of the 5.1 `-post` branches instead? cc @JimGalasyn 

### Testing done 

Docs-only change. Manually tested both the current recommendation to verify it doesn't work, and the new recommendation to verify it does work, on 5.1 and 5.2.

### Reviewer checklist
- [ ] Ensure docs are updated if necessary. (eg. if a user visible feature is being added or changed).
- [ ] Ensure relevant issues are linked (description should include text like "Fixes #<issue number>")

