### PR TITLE
Return null for max/min if all inputs are null (Fixes #2599)

### DIFF
--- a/ksql-engine/src/main/java/io/confluent/ksql/function/udaf/BaseNumberKudaf.java
+++ b/ksql-engine/src/main/java/io/confluent/ksql/function/udaf/BaseNumberKudaf.java
@@ -1,0 +1,62 @@
+/*
+ * Copyright 2019 Confluent Inc.
+ *
+ * Licensed under the Confluent Community License (the "License"; you may not use
+ * this file except in compliance with the License. You may obtain a copy of the
+ * License at
+ *
+ * http://www.confluent.io/confluent-community-license
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package io.confluent.ksql.function.udaf;
+
+import io.confluent.ksql.function.BaseAggregateFunction;
+import java.util.Collections;
+import java.util.Objects;
+import java.util.function.BiFunction;
+import org.apache.kafka.connect.data.Schema;
+import org.apache.kafka.streams.kstream.Merger;
+
+public abstract class BaseNumberKudaf<T extends Number> extends BaseAggregateFunction<T, T> {
+
+  private final BiFunction<T, T, T> aggregatePrimitive;
+
+  public BaseNumberKudaf(
+      final String functionName,
+      final Integer argIndexInValue,
+      final Schema type,
+      final BiFunction<T, T, T> aggregatePrimitive,
+      final String description
+  ) {
+    super(functionName,
+        argIndexInValue,
+        () -> null,
+        type,
+        Collections.singletonList(type),
+        description);
+    this.aggregatePrimitive = Objects.requireNonNull(aggregatePrimitive, "aggregatePrimitive");
+  }
+
+  @Override
+  public final T aggregate(final T currentValue, final T aggregateValue) {
+    if (currentValue == null) {
+      return aggregateValue;
+    }
+
+    if (aggregateValue == null) {
+      return currentValue;
+    }
+
+    return aggregatePrimitive.apply(aggregateValue, currentValue);
+  }
+
+  @Override
+  public final Merger<String, T> getMerger() {
+    return (key, a, b) -> aggregate(a, b);
+  }
+}

--- a/ksql-engine/src/main/java/io/confluent/ksql/function/udaf/max/DoubleMaxKudaf.java
+++ b/ksql-engine/src/main/java/io/confluent/ksql/function/udaf/max/DoubleMaxKudaf.java
@@ -16,33 +16,15 @@
 package io.confluent.ksql.function.udaf.max;
 
 import io.confluent.ksql.function.AggregateFunctionArguments;
-import io.confluent.ksql.function.BaseAggregateFunction;
 import io.confluent.ksql.function.KsqlAggregateFunction;
-import java.util.Collections;
+import io.confluent.ksql.function.udaf.BaseNumberKudaf;
 import org.apache.kafka.connect.data.Schema;
-import org.apache.kafka.streams.kstream.Merger;
 
-public class DoubleMaxKudaf extends BaseAggregateFunction<Double, Double> {
+public class DoubleMaxKudaf extends BaseNumberKudaf<Double> {
 
   DoubleMaxKudaf(final String functionName, final int argIndexInValue) {
-    super(functionName, argIndexInValue, () -> Double.NEGATIVE_INFINITY,
-        Schema.OPTIONAL_FLOAT64_SCHEMA,
-        Collections.singletonList(Schema.OPTIONAL_FLOAT64_SCHEMA),
-        "Computes the maximum double value for a key."
-    );
-  }
-
-  @Override
-  public Double aggregate(final Double currentValue, final Double aggregateValue) {
-    if (currentValue == null) {
-      return aggregateValue;
-    }
-    return Math.max(currentValue, aggregateValue);
-  }
-
-  @Override
-  public Merger<String, Double> getMerger() {
-    return (aggKey, aggOne, aggTwo) -> Math.max(aggOne, aggTwo);
+    super(functionName, argIndexInValue, Schema.OPTIONAL_FLOAT64_SCHEMA, Double::max,
+        "Computes the maximum double value for a key.");
   }
 
   @Override

--- a/ksql-engine/src/main/java/io/confluent/ksql/function/udaf/max/IntegerMaxKudaf.java
+++ b/ksql-engine/src/main/java/io/confluent/ksql/function/udaf/max/IntegerMaxKudaf.java
@@ -16,32 +16,15 @@
 package io.confluent.ksql.function.udaf.max;
 
 import io.confluent.ksql.function.AggregateFunctionArguments;
-import io.confluent.ksql.function.BaseAggregateFunction;
 import io.confluent.ksql.function.KsqlAggregateFunction;
-import java.util.Collections;
+import io.confluent.ksql.function.udaf.BaseNumberKudaf;
 import org.apache.kafka.connect.data.Schema;
-import org.apache.kafka.streams.kstream.Merger;
 
-public class IntegerMaxKudaf extends BaseAggregateFunction<Integer, Integer> {
+public class IntegerMaxKudaf extends BaseNumberKudaf<Integer> {
 
   IntegerMaxKudaf(final String functionName, final int argIndexInValue) {
-    super(functionName, argIndexInValue, () -> Integer.MIN_VALUE, Schema.OPTIONAL_INT32_SCHEMA,
-        Collections.singletonList(Schema.OPTIONAL_INT32_SCHEMA),
-        "Computes the maximum integer value for a key."
-    );
-  }
-
-  @Override
-  public Integer aggregate(final Integer currentValue, final Integer aggregateValue) {
-    if (currentValue == null) {
-      return aggregateValue;
-    }
-    return Math.max(currentValue, aggregateValue);
-  }
-
-  @Override
-  public Merger<String, Integer> getMerger() {
-    return (aggKey, aggOne, aggTwo) -> Math.max(aggOne, aggTwo);
+    super(functionName, argIndexInValue, Schema.OPTIONAL_INT32_SCHEMA, Integer::max,
+        "Computes the maximum integer value for a key.");
   }
 
   @Override

--- a/ksql-engine/src/main/java/io/confluent/ksql/function/udaf/max/LongMaxKudaf.java
+++ b/ksql-engine/src/main/java/io/confluent/ksql/function/udaf/max/LongMaxKudaf.java
@@ -16,32 +16,15 @@
 package io.confluent.ksql.function.udaf.max;
 
 import io.confluent.ksql.function.AggregateFunctionArguments;
-import io.confluent.ksql.function.BaseAggregateFunction;
 import io.confluent.ksql.function.KsqlAggregateFunction;
-import java.util.Collections;
+import io.confluent.ksql.function.udaf.BaseNumberKudaf;
 import org.apache.kafka.connect.data.Schema;
-import org.apache.kafka.streams.kstream.Merger;
 
-public class LongMaxKudaf extends BaseAggregateFunction<Long, Long> {
+public class LongMaxKudaf extends BaseNumberKudaf<Long> {
 
   LongMaxKudaf(final String functionName, final int argIndexInValue) {
-    super(functionName, argIndexInValue, () -> Long.MIN_VALUE, Schema.OPTIONAL_INT64_SCHEMA,
-        Collections.singletonList(Schema.OPTIONAL_INT64_SCHEMA),
-        "Computes the maximum long value for a key."
-    );
-  }
-
-  @Override
-  public Long aggregate(final Long currentValue, final Long aggregateValue) {
-    if (currentValue == null) {
-      return aggregateValue;
-    }
-    return Math.max(currentValue, aggregateValue);
-  }
-
-  @Override
-  public Merger<String, Long> getMerger() {
-    return (aggKey, aggOne, aggTwo) -> Math.max(aggOne, aggTwo);
+    super(functionName, argIndexInValue, Schema.OPTIONAL_INT64_SCHEMA, Long::max,
+        "Computes the maximum long value for a key.");
   }
 
   @Override

--- a/ksql-engine/src/main/java/io/confluent/ksql/function/udaf/min/DoubleMinKudaf.java
+++ b/ksql-engine/src/main/java/io/confluent/ksql/function/udaf/min/DoubleMinKudaf.java
@@ -16,32 +16,15 @@
 package io.confluent.ksql.function.udaf.min;
 
 import io.confluent.ksql.function.AggregateFunctionArguments;
-import io.confluent.ksql.function.BaseAggregateFunction;
 import io.confluent.ksql.function.KsqlAggregateFunction;
-import java.util.Collections;
+import io.confluent.ksql.function.udaf.BaseNumberKudaf;
 import org.apache.kafka.connect.data.Schema;
-import org.apache.kafka.streams.kstream.Merger;
 
-public class DoubleMinKudaf extends BaseAggregateFunction<Double, Double> {
+public class DoubleMinKudaf extends BaseNumberKudaf<Double> {
 
   DoubleMinKudaf(final String functionName, final int argIndexInValue) {
-    super(functionName, argIndexInValue, () -> Double.MAX_VALUE, Schema.OPTIONAL_FLOAT64_SCHEMA,
-        Collections.singletonList(Schema.OPTIONAL_FLOAT64_SCHEMA),
-        "Computes the minimum double value by key."
-    );
-  }
-
-  @Override
-  public Double aggregate(final Double currentValue, final Double aggregateValue) {
-    if (currentValue == null) {
-      return aggregateValue;
-    }
-    return Math.min(currentValue, aggregateValue);
-  }
-
-  @Override
-  public Merger<String, Double> getMerger() {
-    return (aggKey, aggOne, aggTwo) -> Math.min(aggOne, aggTwo);
+    super(functionName, argIndexInValue, Schema.OPTIONAL_FLOAT64_SCHEMA, Double::min,
+        "Computes the minimum double value by key.");
   }
 
   @Override

--- a/ksql-engine/src/main/java/io/confluent/ksql/function/udaf/min/IntegerMinKudaf.java
+++ b/ksql-engine/src/main/java/io/confluent/ksql/function/udaf/min/IntegerMinKudaf.java
@@ -16,32 +16,15 @@
 package io.confluent.ksql.function.udaf.min;
 
 import io.confluent.ksql.function.AggregateFunctionArguments;
-import io.confluent.ksql.function.BaseAggregateFunction;
 import io.confluent.ksql.function.KsqlAggregateFunction;
-import java.util.Collections;
+import io.confluent.ksql.function.udaf.BaseNumberKudaf;
 import org.apache.kafka.connect.data.Schema;
-import org.apache.kafka.streams.kstream.Merger;
 
-public class IntegerMinKudaf extends BaseAggregateFunction<Integer, Integer> {
+public class IntegerMinKudaf extends BaseNumberKudaf<Integer> {
 
   IntegerMinKudaf(final String functionName, final int argIndexInValue) {
-    super(functionName, argIndexInValue, () -> Integer.MAX_VALUE, Schema.OPTIONAL_INT32_SCHEMA,
-        Collections.singletonList(Schema.OPTIONAL_INT32_SCHEMA),
-        "Computes the minimum integer value for a key."
-    );
-  }
-
-  @Override
-  public Integer aggregate(final Integer currentValue, final Integer aggregateValue) {
-    if (currentValue == null) {
-      return aggregateValue;
-    }
-    return Math.min(currentValue, aggregateValue);
-  }
-
-  @Override
-  public Merger<String, Integer> getMerger() {
-    return (aggKey, aggOne, aggTwo) -> Math.min(aggOne, aggTwo);
+    super(functionName, argIndexInValue, Schema.OPTIONAL_INT32_SCHEMA, Integer::min,
+        "Computes the minimum integer value for a key.");
   }
 
   @Override

--- a/ksql-engine/src/main/java/io/confluent/ksql/function/udaf/min/LongMinKudaf.java
+++ b/ksql-engine/src/main/java/io/confluent/ksql/function/udaf/min/LongMinKudaf.java
@@ -16,32 +16,15 @@
 package io.confluent.ksql.function.udaf.min;
 
 import io.confluent.ksql.function.AggregateFunctionArguments;
-import io.confluent.ksql.function.BaseAggregateFunction;
 import io.confluent.ksql.function.KsqlAggregateFunction;
-import java.util.Collections;
+import io.confluent.ksql.function.udaf.BaseNumberKudaf;
 import org.apache.kafka.connect.data.Schema;
-import org.apache.kafka.streams.kstream.Merger;
 
-public class LongMinKudaf extends BaseAggregateFunction<Long, Long> {
+public class LongMinKudaf extends BaseNumberKudaf<Long> {
 
   LongMinKudaf(final String functionName, final int argIndexInValue) {
-    super(functionName, argIndexInValue, () -> Long.MAX_VALUE, Schema.OPTIONAL_INT64_SCHEMA,
-        Collections.singletonList(Schema.OPTIONAL_INT64_SCHEMA),
-        "Computes the minimum long value for a key."
-    );
-  }
-
-  @Override
-  public Long aggregate(final Long currentValue, final Long aggregateValue) {
-    if (currentValue == null) {
-      return aggregateValue;
-    }
-    return Math.min(currentValue, aggregateValue);
-  }
-
-  @Override
-  public Merger<String, Long> getMerger() {
-    return (aggKey, aggOne, aggTwo) -> Math.min(aggOne, aggTwo);
+    super(functionName, argIndexInValue, Schema.OPTIONAL_INT64_SCHEMA, Long::min,
+        "Computes the minimum long value for a key.");
   }
 
   @Override

--- a/ksql-engine/src/test/java/io/confluent/ksql/function/udaf/max/DoubleMaxKudafTest.java
+++ b/ksql-engine/src/test/java/io/confluent/ksql/function/udaf/max/DoubleMaxKudafTest.java
@@ -31,7 +31,7 @@ public class DoubleMaxKudafTest {
   public void shouldFindCorrectMax() {
     final DoubleMaxKudaf doubleMaxKudaf = getDoubleMaxKudaf();
     final double[] values = new double[]{3.0, 5.0, 8.0, 2.2, 3.5, 4.6, 5.0};
-    double currentMax = Double.MIN_VALUE;
+    Double currentMax = null;
     for (final double i: values) {
       currentMax = doubleMaxKudaf.aggregate(i, currentMax);
     }
@@ -42,11 +42,11 @@ public class DoubleMaxKudafTest {
   public void shouldHandleNull() {
     final DoubleMaxKudaf doubleMaxKudaf = getDoubleMaxKudaf();
     final double[] values = new double[]{3.0, 5.0, 8.0, 2.2, 3.5, 4.6, 5.0};
-    double currentMax = Double.MIN_VALUE;
+    Double currentMax = null;
 
     // aggregate null before any aggregation
     currentMax = doubleMaxKudaf.aggregate(null, currentMax);
-    assertThat(Double.MIN_VALUE, equalTo(currentMax));
+    assertThat(null, equalTo(currentMax));
 
     // now send each value to aggregation and verify
     for (final double i: values) {

--- a/ksql-engine/src/test/java/io/confluent/ksql/function/udaf/max/IntegerMaxKudafTest.java
+++ b/ksql-engine/src/test/java/io/confluent/ksql/function/udaf/max/IntegerMaxKudafTest.java
@@ -42,11 +42,11 @@ public class IntegerMaxKudafTest {
   public void shouldHandleNull() {
     final IntegerMaxKudaf integerMaxKudaf = getIntegerMaxKudaf();
     final int[] values = new int[]{3, 5, 8, 2, 3, 4, 5};
-    int currentMax = Integer.MIN_VALUE;
+    Integer currentMax = null;
 
     // null before any aggregation
     currentMax = integerMaxKudaf.aggregate(null, currentMax);
-    assertThat(Integer.MIN_VALUE, equalTo(currentMax));
+    assertThat(null, equalTo(currentMax));
 
     // now send each value to aggregation and verify
     for (final int i: values) {

--- a/ksql-engine/src/test/java/io/confluent/ksql/function/udaf/max/LongMaxKudafTest.java
+++ b/ksql-engine/src/test/java/io/confluent/ksql/function/udaf/max/LongMaxKudafTest.java
@@ -42,11 +42,11 @@ public class LongMaxKudafTest {
   public void shouldHandleNull() {
     final LongMaxKudaf longMaxKudaf = getLongMaxKudaf();
     final long[] values = new long[]{3L, 5L, 8L, 2L, 3L, 4L, 5L};
-    long currentMax = Long.MIN_VALUE;
+    Long currentMax = null;
 
     // null before any aggregation
     currentMax = longMaxKudaf.aggregate(null, currentMax);
-    assertThat(Long.MIN_VALUE, equalTo(currentMax));
+    assertThat(null, equalTo(currentMax));
 
     // now send each value to aggregation and verify
     for (final long i: values) {

--- a/ksql-engine/src/test/java/io/confluent/ksql/function/udaf/min/DoubleMinKudafTest.java
+++ b/ksql-engine/src/test/java/io/confluent/ksql/function/udaf/min/DoubleMinKudafTest.java
@@ -42,11 +42,11 @@ public class DoubleMinKudafTest {
   public void shouldHandleNull() {
     final DoubleMinKudaf doubleMinKudaf = getDoubleMinKudaf();
     final double[] values = new double[]{3.0, 5.0, 8.0, 2.2, 3.5, 4.6, 5.0};
-    double currentMin = Double.MAX_VALUE;
+    Double currentMin = null;
 
     // null before any aggregation
     currentMin = doubleMinKudaf.aggregate(null, currentMin);
-    assertThat(Double.MAX_VALUE, equalTo(currentMin));
+    assertThat(null, equalTo(currentMin));
 
     // now send each value to aggregation and verify
     for (final double i: values) {

--- a/ksql-engine/src/test/java/io/confluent/ksql/function/udaf/min/IntegerMinKudafTest.java
+++ b/ksql-engine/src/test/java/io/confluent/ksql/function/udaf/min/IntegerMinKudafTest.java
@@ -42,11 +42,11 @@ public class IntegerMinKudafTest {
   public void shouldHandleNull() {
     final IntegerMinKudaf integerMinKudaf = getIntegerMinKudaf();
     final int[] values = new int[]{3, 5, 8, 2, 3, 4, 5};
-    int currentMin = Integer.MAX_VALUE;
+    Integer currentMin = null;
 
     // aggregate null before any aggregation
     currentMin = integerMinKudaf.aggregate(null, currentMin);
-    assertThat(Integer.MAX_VALUE, equalTo(currentMin));
+    assertThat(null, equalTo(currentMin));
 
     // now send each value to aggregation and verify
     for (final int i: values) {

--- a/ksql-engine/src/test/java/io/confluent/ksql/function/udaf/min/LongMinKudafTest.java
+++ b/ksql-engine/src/test/java/io/confluent/ksql/function/udaf/min/LongMinKudafTest.java
@@ -42,11 +42,11 @@ public class LongMinKudafTest {
   public void shouldHandleNull() {
     final LongMinKudaf longMinKudaf = getLongMinKudaf();
     final long[] values = new long[]{3L, 5L, 8L, 2L, 3L, 4L, 5L};
-    long currentMin = Long.MAX_VALUE;
+    Long currentMin = null;
 
     // aggregate null before any aggregation
     currentMin = longMinKudaf.aggregate(null, currentMin);
-    assertThat(Long.MAX_VALUE, equalTo(currentMin));
+    assertThat(null, equalTo(currentMin));
 
     // now send each value to aggregation and verify
     for (final long i: values) {

--- a/ksql-engine/src/test/resources/query-validation-tests/max-group-by.json
+++ b/ksql-engine/src/test/resources/query-validation-tests/max-group-by.json
@@ -34,6 +34,19 @@
       ]
     },
     {
+      "name": "max integer group by with nulls",
+      "statements": [
+        "CREATE STREAM TEST (ID bigint, VALUE integer) WITH (kafka_topic='test_topic',value_format='JSON', key='ID');",
+        "CREATE TABLE S2 as SELECT id, max(value) as MAX FROM test group by id;"
+      ],
+      "inputs": [
+        {"topic": "test_topic", "key": 1, "value": {"id":  1, "value":  null}}
+      ],
+      "outputs": [
+        {"topic": "S2", "key": 1, "value": {"ID":  1, "MAX":  null}}
+      ]
+    },
+    {
       "name": "max long group by",
       "statements": [
         "CREATE STREAM TEST (ID bigint, NAME varchar, VALUE bigint) WITH (kafka_topic='test_topic', value_format='DELIMITED', key='ID');",
@@ -56,6 +69,19 @@
         {"topic": "S2", "key": 100, "value": "100,300"},
         {"topic": "S2", "key": 0, "value": "0,9223372036854775807"},
         {"topic": "S2", "key": 0, "value": "0,9223372036854775807"}
+      ]
+    },
+    {
+      "name": "max long by with nulls",
+      "statements": [
+        "CREATE STREAM TEST (ID bigint, VALUE bigint) WITH (kafka_topic='test_topic',value_format='JSON', key='ID');",
+        "CREATE TABLE S2 as SELECT id, max(value) as MAX FROM test group by id;"
+      ],
+      "inputs": [
+        {"topic": "test_topic", "key": 1, "value": {"id":  1, "value":  null}}
+      ],
+      "outputs": [
+        {"topic": "S2", "key": 1, "value": {"ID":  1, "MAX":  null}}
       ]
     },
     {
@@ -84,6 +110,19 @@
         {"topic": "S2", "key": 100, "value": "100,300.8"},
         {"topic": "S2", "key": 0, "value": "0,2000.99"},
         {"topic": "S2", "key": 0, "value": "0,2000.99"}
+      ]
+    },
+    {
+      "name": "max double by with nulls",
+      "statements": [
+        "CREATE STREAM TEST (ID bigint, VALUE double) WITH (kafka_topic='test_topic',value_format='JSON', key='ID');",
+        "CREATE TABLE S2 as SELECT id, max(value) as MAX FROM test group by id;"
+      ],
+      "inputs": [
+        {"topic": "test_topic", "key": 1, "value": {"id":  1, "value":  null}}
+      ],
+      "outputs": [
+        {"topic": "S2", "key": 1, "value": {"ID":  1, "MAX":  null}}
       ]
     }
   ]

--- a/ksql-engine/src/test/resources/query-validation-tests/max-group-by.json
+++ b/ksql-engine/src/test/resources/query-validation-tests/max-group-by.json
@@ -40,10 +40,14 @@
         "CREATE TABLE S2 as SELECT id, max(value) as MAX FROM test group by id;"
       ],
       "inputs": [
-        {"topic": "test_topic", "key": 1, "value": {"id":  1, "value":  null}}
+        {"topic": "test_topic", "key": 1, "value": {"id":  1, "value":  null}},
+        {"topic": "test_topic", "key": 0, "value": {"id":  0, "value":  null}},
+        {"topic": "test_topic", "key": 0, "value": {"id":  0, "value":  1}}
       ],
       "outputs": [
-        {"topic": "S2", "key": 1, "value": {"ID":  1, "MAX":  null}}
+        {"topic": "S2", "key": 1, "value": {"ID":  1, "MAX":  null}},
+        {"topic": "S2", "key": 0, "value": {"ID":  0, "MAX":  null}},
+        {"topic": "S2", "key": 0, "value": {"ID":  0, "MAX":  1}}
       ]
     },
     {
@@ -78,10 +82,14 @@
         "CREATE TABLE S2 as SELECT id, max(value) as MAX FROM test group by id;"
       ],
       "inputs": [
-        {"topic": "test_topic", "key": 1, "value": {"id":  1, "value":  null}}
+        {"topic": "test_topic", "key": 1, "value": {"id":  1, "value":  null}},
+        {"topic": "test_topic", "key": 0, "value": {"id":  0, "value":  null}},
+        {"topic": "test_topic", "key": 0, "value": {"id":  0, "value":  1}}
       ],
       "outputs": [
-        {"topic": "S2", "key": 1, "value": {"ID":  1, "MAX":  null}}
+        {"topic": "S2", "key": 1, "value": {"ID":  1, "MAX":  null}},
+        {"topic": "S2", "key": 0, "value": {"ID":  0, "MAX":  null}},
+        {"topic": "S2", "key": 0, "value": {"ID":  0, "MAX":  1}}
       ]
     },
     {
@@ -119,10 +127,14 @@
         "CREATE TABLE S2 as SELECT id, max(value) as MAX FROM test group by id;"
       ],
       "inputs": [
-        {"topic": "test_topic", "key": 1, "value": {"id":  1, "value":  null}}
+        {"topic": "test_topic", "key": 1, "value": {"id":  1, "value":  null}},
+        {"topic": "test_topic", "key": 0, "value": {"id":  0, "value":  null}},
+        {"topic": "test_topic", "key": 0, "value": {"id":  0, "value":  1.0}}
       ],
       "outputs": [
-        {"topic": "S2", "key": 1, "value": {"ID":  1, "MAX":  null}}
+        {"topic": "S2", "key": 1, "value": {"ID":  1, "MAX":  null}},
+        {"topic": "S2", "key": 0, "value": {"ID":  0, "MAX":  null}},
+        {"topic": "S2", "key": 0, "value": {"ID":  0, "MAX":  1.0}}
       ]
     }
   ]

--- a/ksql-engine/src/test/resources/query-validation-tests/min-group-by.json
+++ b/ksql-engine/src/test/resources/query-validation-tests/min-group-by.json
@@ -34,6 +34,19 @@
       ]
     },
     {
+      "name": "min integer group by with nulls",
+      "statements": [
+        "CREATE STREAM TEST (ID bigint, VALUE integer) WITH (kafka_topic='test_topic',value_format='JSON', key='ID');",
+        "CREATE TABLE S2 as SELECT id, min(value) as MAX FROM test group by id;"
+      ],
+      "inputs": [
+        {"topic": "test_topic", "key": 1, "value": {"id":  1, "value":  null}}
+      ],
+      "outputs": [
+        {"topic": "S2", "key": 1, "value": {"ID":  1, "MAX":  null}}
+      ]
+    },
+    {
       "name": "min long group by",
       "statements": [
         "CREATE STREAM TEST (ID bigint, NAME varchar, VALUE bigint) WITH (kafka_topic='test_topic', value_format='DELIMITED', key='ID');",
@@ -56,6 +69,19 @@
         {"topic": "S2", "key": 100, "value": "100,6"},
         {"topic": "S2", "key": 0, "value": "0,-9223372036854775807"},
         {"topic": "S2", "key": 0, "value": "0,-9223372036854775807"}
+      ]
+    },
+    {
+      "name": "min long group by with nulls",
+      "statements": [
+        "CREATE STREAM TEST (ID bigint, VALUE bigint) WITH (kafka_topic='test_topic',value_format='JSON', key='ID');",
+        "CREATE TABLE S2 as SELECT id, min(value) as MAX FROM test group by id;"
+      ],
+      "inputs": [
+        {"topic": "test_topic", "key": 1, "value": {"id":  1, "value":  null}}
+      ],
+      "outputs": [
+        {"topic": "S2", "key": 1, "value": {"ID":  1, "MAX":  null}}
       ]
     },
     {
@@ -82,6 +108,19 @@
         {"topic": "S2", "key": 100, "value": "100,6.4"},
         {"topic": "S2", "key": 0, "value": "0,-1.7976931348623157E308"},
         {"topic": "S2", "key": 0, "value": "0,-1.7976931348623157E308"}
+      ]
+    },
+    {
+      "name": "min double group by with nulls",
+      "statements": [
+        "CREATE STREAM TEST (ID bigint, VALUE double) WITH (kafka_topic='test_topic',value_format='JSON', key='ID');",
+        "CREATE TABLE S2 as SELECT id, min(value) as MAX FROM test group by id;"
+      ],
+      "inputs": [
+        {"topic": "test_topic", "key": 1, "value": {"id":  1, "value":  null}}
+      ],
+      "outputs": [
+        {"topic": "S2", "key": 1, "value": {"ID":  1, "MAX":  null}}
       ]
     }
   ]

--- a/ksql-engine/src/test/resources/query-validation-tests/min-group-by.json
+++ b/ksql-engine/src/test/resources/query-validation-tests/min-group-by.json
@@ -40,10 +40,14 @@
         "CREATE TABLE S2 as SELECT id, min(value) as MAX FROM test group by id;"
       ],
       "inputs": [
-        {"topic": "test_topic", "key": 1, "value": {"id":  1, "value":  null}}
+        {"topic": "test_topic", "key": 1, "value": {"id":  1, "value":  null}},
+        {"topic": "test_topic", "key": 0, "value": {"id":  0, "value":  null}},
+        {"topic": "test_topic", "key": 0, "value": {"id":  0, "value":  1}}
       ],
       "outputs": [
-        {"topic": "S2", "key": 1, "value": {"ID":  1, "MAX":  null}}
+        {"topic": "S2", "key": 1, "value": {"ID":  1, "MAX":  null}},
+        {"topic": "S2", "key": 0, "value": {"ID":  0, "MAX":  null}},
+        {"topic": "S2", "key": 0, "value": {"ID":  0, "MAX":  1}}
       ]
     },
     {
@@ -78,10 +82,14 @@
         "CREATE TABLE S2 as SELECT id, min(value) as MAX FROM test group by id;"
       ],
       "inputs": [
-        {"topic": "test_topic", "key": 1, "value": {"id":  1, "value":  null}}
+        {"topic": "test_topic", "key": 1, "value": {"id":  1, "value":  null}},
+        {"topic": "test_topic", "key": 0, "value": {"id":  0, "value":  null}},
+        {"topic": "test_topic", "key": 0, "value": {"id":  0, "value":  1}}
       ],
       "outputs": [
-        {"topic": "S2", "key": 1, "value": {"ID":  1, "MAX":  null}}
+        {"topic": "S2", "key": 1, "value": {"ID":  1, "MAX":  null}},
+        {"topic": "S2", "key": 0, "value": {"ID":  0, "MAX":  null}},
+        {"topic": "S2", "key": 0, "value": {"ID":  0, "MAX":  1}}
       ]
     },
     {
@@ -117,10 +125,14 @@
         "CREATE TABLE S2 as SELECT id, min(value) as MAX FROM test group by id;"
       ],
       "inputs": [
-        {"topic": "test_topic", "key": 1, "value": {"id":  1, "value":  null}}
+        {"topic": "test_topic", "key": 1, "value": {"id":  1, "value":  null}},
+        {"topic": "test_topic", "key": 0, "value": {"id":  0, "value":  null}},
+        {"topic": "test_topic", "key": 0, "value": {"id":  0, "value":  1.0}}
       ],
       "outputs": [
-        {"topic": "S2", "key": 1, "value": {"ID":  1, "MAX":  null}}
+        {"topic": "S2", "key": 1, "value": {"ID":  1, "MAX":  null}},
+        {"topic": "S2", "key": 0, "value": {"ID":  0, "MAX":  null}},
+        {"topic": "S2", "key": 0, "value": {"ID":  0, "MAX":  1.0}}
       ]
     }
   ]


### PR DESCRIPTION
### Description 
See #2599. This PR fixes behavior around nulls in `MAX` and `MIN` UDAFs. It also slightly cleans it up by having a base class for all of them.

### Testing done 
- Unit Testing
- QTT

### Reviewer checklist
- [ ] Ensure docs are updated if necessary. (eg. if a user visible feature is being added or changed).
- [ ] Ensure relevant issues are linked (description should include text like "Fixes #<issue number>")

