### PR TITLE
Minor: Update required ACLs to account for record processing log topic

### DIFF
--- a/docs/installation/server-config/security.rst
+++ b/docs/installation/server-config/security.rst
@@ -375,6 +375,11 @@ KSQL always requires the following ACLs for its internal operations and data man
 
 Where ``ksql.service.id`` can be configured in the KSQL configuration and defaults to ``default_``.
 
+If KSQL is configured to create a topic for the :ref:`record processing log<ksql_processing_log>`
+(the default configuration since KSQL version 5.2), the following ACLs are also needed:
+
+- The ``ALL`` operation on the ``TOPIC`` with ``LITERAL`` name ``<ksql.service.id>ksql_processing_log``.
+
 In addition to the general permissions above, KSQL also needs permissions to perform the actual processing of your data.
 Here, KSQL needs permissions to read data from your desired input topics and/or permissions to write data to your desired output topics:
 
@@ -422,6 +427,9 @@ Then the following commands would create the necessary ACLs in the Kafka cluster
     # Allow KSQL to manage its own internal topics and consumer groups:
     bin/kafka-acls --authorizer-properties zookeeper.connect=localhost:2181 --add --allow-principal User:KSQL1 --allow-host 198.51.100.0 --allow-host 198.51.100.1 --allow-host 198.51.100.2 --operation All --resource-pattern-type prefixed --topic _confluent-ksql-production_ --group _confluent-ksql-production_
 
+    # Allow KSQL to manage its record processing log topic, if configured:
+    bin/kafka-acls --authorizer-properties zookeeper.connect=localhost:2181 --add --allow-principal User:KSQL1 --allow-host 198.51.100.0 --allow-host 198.51.100.1 --allow-host 198.51.100.2 --operation All --topic production_ksql_processing_log
+
 .. _config-security-ksql-acl-interactive_post_ak_2_0:
 
 Interactive KSQL clusters
@@ -462,6 +470,9 @@ Then the following commands would create the necessary ACLs in the Kafka cluster
 
     # Allow KSQL to manage its own internal topics and consumer groups:
     bin/kafka-acls --authorizer-properties zookeeper.connect=localhost:2181 --add --allow-principal User:KSQL1 --allow-host 198.51.100.0 --allow-host 198.51.100.1 --allow-host 198.51.100.2 --operation All --resource-pattern-type prefixed --topic _confluent-ksql-fraud_ --group _confluent-ksql-fraud_
+
+    # Allow KSQL to manage its record processing log topic, if configured:
+    bin/kafka-acls --authorizer-properties zookeeper.connect=localhost:2181 --add --allow-principal User:KSQL1 --allow-host 198.51.100.0 --allow-host 198.51.100.1 --allow-host 198.51.100.2 --operation All --topic fraud_ksql_processing_log
 
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 |cp| versions below v5.0 (Apache Kafka < v2.0)

--- a/docs/installation/server-config/security.rst
+++ b/docs/installation/server-config/security.rst
@@ -375,8 +375,8 @@ KSQL always requires the following ACLs for its internal operations and data man
 
 Where ``ksql.service.id`` can be configured in the KSQL configuration and defaults to ``default_``.
 
-If KSQL is configured to create a topic for the :ref:`record processing log<ksql_processing_log>`
-(the default configuration since KSQL version 5.2), the following ACLs are also needed:
+If KSQL is configured to create a topic for the :ref:`record processing log <ksql_processing_log>`
+which is the default configuration since KSQL version 5.2, the following ACLs are also needed:
 
 - The ``ALL`` operation on the ``TOPIC`` with ``LITERAL`` name ``<ksql.service.id>ksql_processing_log``.
 

--- a/docs/installation/server-config/security.rst
+++ b/docs/installation/server-config/security.rst
@@ -378,7 +378,9 @@ Where ``ksql.service.id`` can be configured in the KSQL configuration and defaul
 If KSQL is configured to create a topic for the :ref:`record processing log <ksql_processing_log>`
 which is the default configuration since KSQL version 5.2, the following ACLs are also needed:
 
-- The ``ALL`` operation on the ``TOPIC`` with ``LITERAL`` name ``<ksql.service.id>ksql_processing_log``.
+- The ``ALL`` operation on the ``TOPIC`` with ``LITERAL`` name ``<ksql.logging.processing.topic.name>``.
+
+Where ``ksql.logging.processing.topic.name`` can be configured in the KSQL configuration and defaults to ``<ksql.service.id>ksql_processing_log``.
 
 In addition to the general permissions above, KSQL also needs permissions to perform the actual processing of your data.
 Here, KSQL needs permissions to read data from your desired input topics and/or permissions to write data to your desired output topics:


### PR DESCRIPTION
### Description 

With the introduction of the record processing log topic, the docs around required Kafka ACLs need to be updated. Otherwise, KSQL fails to start with the following error when ACLs are enabled:
```
[2019-03-25 18:03:11,579] ERROR Failed to start KSQL (io.confluent.ksql.rest.server.KsqlServerMain:53)
io.confluent.ksql.exception.KafkaResponseGetFailedException: Failed to guarantee existence of topic default_ksql_processing_log
    at io.confluent.ksql.services.KafkaTopicClientImpl.createTopic(KafkaTopicClientImpl.java:100)
    at io.confluent.ksql.services.KafkaTopicClient.createTopic(KafkaTopicClient.java:53)
    at io.confluent.ksql.rest.util.ProcessingLogServerUtils.maybeCreateProcessingLogTopic(ProcessingLogServerUtils.java:81)
    at io.confluent.ksql.rest.server.KsqlRestApplication.buildApplication(KsqlRestApplication.java:414)
    at io.confluent.ksql.rest.server.KsqlRestApplication.buildApplication(KsqlRestApplication.java:307)
    at io.confluent.ksql.rest.server.KsqlServerMain.createExecutable(KsqlServerMain.java:85)
    at io.confluent.ksql.rest.server.KsqlServerMain.main(KsqlServerMain.java:50)
Caused by: org.apache.kafka.common.errors.TopicAuthorizationException: Not authorized to access topics: [Topic authorization failed.]
```
This PR updates the docs accordingly.

### Testing done 

Docs-only change. Manual testing to confirm that ACLs in the current docs are insufficient, and that adding these additional ACLs work as expected.

### Reviewer checklist
- [ ] Ensure docs are updated if necessary. (eg. if a user visible feature is being added or changed).
- [ ] Ensure relevant issues are linked (description should include text like "Fixes #<issue number>")

