### PR TITLE
Refactor code to void check-style CyclomaticComplexity rules

### DIFF
--- a/ksql-common/src/main/java/io/confluent/ksql/util/SchemaUtil.java
+++ b/ksql-common/src/main/java/io/confluent/ksql/util/SchemaUtil.java
@@ -84,7 +84,7 @@ public final class SchemaUtil {
           .put(Schema.Type.FLOAT64, Schema.OPTIONAL_FLOAT64_SCHEMA)
           .build();
 
-  private static final ImmutableMap<String, String> TYPE_MAP =
+  private static final ImmutableMap<String, String> SCHEMA_TYPE_NAME_TO_SQL_TYPE =
       new ImmutableMap.Builder<String, String>()
           .put("STRING", "VARCHAR(STRING)")
           .put("INT64", "BIGINT")
@@ -205,7 +205,7 @@ public final class SchemaUtil {
   }
 
   public static String getSchemaTypeAsSqlType(final Schema.Type type) {
-    final String sqlType = TYPE_MAP.get(type.name());
+    final String sqlType = SCHEMA_TYPE_NAME_TO_SQL_TYPE.get(type.name());
     if (sqlType == null) {
       throw new IllegalArgumentException("Unknown schema type: " + type);
     }

--- a/ksql-common/src/main/java/io/confluent/ksql/util/SchemaUtil.java
+++ b/ksql-common/src/main/java/io/confluent/ksql/util/SchemaUtil.java
@@ -96,16 +96,16 @@ public final class SchemaUtil {
           .put("STRUCT", "STRUCT")
           .build();
 
-  private static final Map<Schema.Type, Function<Schema, Type>> SCHEMA_TYPE_TO_JAVA_TYPE =
-      ImmutableMap.<Schema.Type, Function<Schema, Type>>builder()
-          .put(Schema.Type.STRING, s -> String.class)
-          .put(Schema.Type.BOOLEAN, s -> Boolean.class)
-          .put(Schema.Type.INT32, s -> Integer.class)
-          .put(Schema.Type.INT64, s -> Long.class)
-          .put(Schema.Type.FLOAT64, s -> Double.class)
-          .put(Schema.Type.ARRAY, s -> List.class)
-          .put(Schema.Type.MAP, s -> Map.class)
-          .put(Schema.Type.STRUCT, s -> Struct.class)
+  private static final Map<Schema.Type, Class> SCHEMA_TYPE_TO_JAVA_TYPE =
+      ImmutableMap.<Schema.Type, Class>builder()
+          .put(Schema.Type.STRING, String.class)
+          .put(Schema.Type.BOOLEAN, Boolean.class)
+          .put(Schema.Type.INT32, Integer.class)
+          .put(Schema.Type.INT64, Long.class)
+          .put(Schema.Type.FLOAT64, Double.class)
+          .put(Schema.Type.ARRAY, List.class)
+          .put(Schema.Type.MAP, Map.class)
+          .put(Schema.Type.STRUCT, Struct.class)
           .build();
 
   private static Map<Schema.Type, Function<Schema, String>> SCHEMA_TYPE_TO_SQL_TYPE =
@@ -137,12 +137,12 @@ public final class SchemaUtil {
   }
 
   public static Class<?> getJavaType(final Schema schema) {
-    final Function<Schema, Type> handler = SCHEMA_TYPE_TO_JAVA_TYPE.get(schema.type());
-    if (handler == null) {
+    final Class typeClazz = SCHEMA_TYPE_TO_JAVA_TYPE.get(schema.type());
+    if (typeClazz == null) {
       throw new KsqlException("Type is not supported: " + schema.type());
     }
 
-    return (Class) handler.apply(schema);
+    return typeClazz;
   }
 
   public static Schema getSchemaFromType(final Type type) {

--- a/ksql-common/src/main/java/io/confluent/ksql/util/SchemaUtil.java
+++ b/ksql-common/src/main/java/io/confluent/ksql/util/SchemaUtil.java
@@ -32,6 +32,7 @@ import java.util.Map;
 import java.util.NavigableMap;
 import java.util.Optional;
 import java.util.Set;
+import java.util.function.Function;
 import java.util.function.Supplier;
 import java.util.stream.Collectors;
 import org.apache.avro.SchemaBuilder.FieldAssembler;
@@ -83,30 +84,65 @@ public final class SchemaUtil {
           .put(Schema.Type.FLOAT64, Schema.OPTIONAL_FLOAT64_SCHEMA)
           .build();
 
+  private static final ImmutableMap<String, String> TYPE_MAP =
+      new ImmutableMap.Builder<String, String>()
+          .put("STRING", "VARCHAR(STRING)")
+          .put("INT64", "BIGINT")
+          .put("INT32", "INTEGER")
+          .put("FLOAT64", "DOUBLE")
+          .put("BOOLEAN", "BOOLEAN")
+          .put("ARRAY", "ARRAY")
+          .put("MAP", "MAP")
+          .put("STRUCT", "STRUCT")
+          .build();
+
+  private static final Map<Schema.Type, Function<Schema, Type>> SCHEMA_TYPE_TO_JAVA_TYPE =
+      ImmutableMap.<Schema.Type, Function<Schema, Type>>builder()
+          .put(Schema.Type.STRING, s -> String.class)
+          .put(Schema.Type.BOOLEAN, s -> Boolean.class)
+          .put(Schema.Type.INT32, s -> Integer.class)
+          .put(Schema.Type.INT64, s -> Long.class)
+          .put(Schema.Type.FLOAT64, s -> Double.class)
+          .put(Schema.Type.ARRAY, s -> List.class)
+          .put(Schema.Type.MAP, s -> Map.class)
+          .put(Schema.Type.STRUCT, s -> Struct.class)
+          .build();
+
+  private static Map<Schema.Type, Function<Schema, String>> SCHEMA_TYPE_TO_SQL_TYPE =
+      ImmutableMap.<Schema.Type, Function<Schema, String>>builder()
+          .put(Schema.Type.INT32, s -> "INT")
+          .put(Schema.Type.INT64, s -> "BIGINT")
+          .put(Schema.Type.FLOAT32, s -> "DOUBLE")
+          .put(Schema.Type.FLOAT64, s -> "DOUBLE")
+          .put(Schema.Type.BOOLEAN, s -> "BOOLEAN")
+          .put(Schema.Type.STRING, s -> "VARCHAR")
+          .put(Schema.Type.ARRAY, s ->
+              "ARRAY<" + getSqlTypeName(s.valueSchema()) + ">")
+          .put(Schema.Type.MAP, s ->
+              "MAP<" + getSqlTypeName(s.keySchema()) + "," + getSqlTypeName(s.valueSchema()) + ">")
+          .put(Schema.Type.STRUCT, s -> getStructString(s))
+          .build();
+
+  private static final ImmutableMap<Schema.Type, String> SCHEMA_TYPE_TO_CAST_STRING =
+      new ImmutableMap.Builder<Schema.Type, String>()
+          .put(Schema.Type.INT32, "(Integer)")
+          .put(Schema.Type.INT64, "(Long)")
+          .put(Schema.Type.FLOAT64, "(Double)")
+          .put(Schema.Type.STRING, "(String)")
+          .put(Schema.Type.BOOLEAN, "(Boolean)")
+          .build();
+
+
   private SchemaUtil() {
   }
 
   public static Class<?> getJavaType(final Schema schema) {
-    switch (schema.type()) {
-      case STRING:
-        return String.class;
-      case BOOLEAN:
-        return Boolean.class;
-      case INT32:
-        return Integer.class;
-      case INT64:
-        return Long.class;
-      case FLOAT64:
-        return Double.class;
-      case ARRAY:
-        return List.class;
-      case MAP:
-        return Map.class;
-      case STRUCT:
-        return Struct.class;
-      default:
-        throw new KsqlException("Type is not supported: " + schema.type());
+    final Function<Schema, Type> handler = SCHEMA_TYPE_TO_JAVA_TYPE.get(schema.type());
+    if (handler == null) {
+      throw new KsqlException("Type is not supported: " + schema.type());
     }
+
+    return (Class) handler.apply(schema);
   }
 
   public static Schema getSchemaFromType(final Type type) {
@@ -168,18 +204,6 @@ public final class SchemaUtil {
     return newSchema.build();
   }
 
-  private static final ImmutableMap<String, String> TYPE_MAP =
-      new ImmutableMap.Builder<String, String>()
-          .put("STRING", "VARCHAR(STRING)")
-          .put("INT64", "BIGINT")
-          .put("INT32", "INTEGER")
-          .put("FLOAT64", "DOUBLE")
-          .put("BOOLEAN", "BOOLEAN")
-          .put("ARRAY", "ARRAY")
-          .put("MAP", "MAP")
-          .put("STRUCT", "STRUCT")
-          .build();
-
   public static String getSchemaTypeAsSqlType(final Schema.Type type) {
     final String sqlType = TYPE_MAP.get(type.name());
     if (sqlType == null) {
@@ -190,21 +214,13 @@ public final class SchemaUtil {
   }
 
   public static String getJavaCastString(final Schema schema) {
-    switch (schema.type()) {
-      case INT32:
-        return "(Integer)";
-      case INT64:
-        return "(Long)";
-      case FLOAT64:
-        return "(Double)";
-      case STRING:
-        return "(String)";
-      case BOOLEAN:
-        return "(Boolean)";
-      default:
-        //TODO: Add complex types later!
-        return "";
+    final String castString = SCHEMA_TYPE_TO_CAST_STRING.get(schema.type());
+    if (castString == null) {
+      //TODO: Add complex or other types later!
+      return "";
     }
+
+    return castString;
   }
 
   public static Schema addImplicitRowTimeRowKeyToSchema(final Schema schema) {
@@ -252,31 +268,12 @@ public final class SchemaUtil {
   }
 
   public static String getSqlTypeName(final Schema schema) {
-    switch (schema.type()) {
-      case INT32:
-        return "INT";
-      case INT64:
-        return "BIGINT";
-      case FLOAT32:
-      case FLOAT64:
-        return "DOUBLE";
-      case BOOLEAN:
-        return "BOOLEAN";
-      case STRING:
-        return "VARCHAR";
-      case ARRAY:
-        return "ARRAY<" + getSqlTypeName(schema.valueSchema()) + ">";
-      case MAP:
-        return "MAP<"
-            + getSqlTypeName(schema.keySchema())
-            + ","
-            + getSqlTypeName(schema.valueSchema())
-            + ">";
-      case STRUCT:
-        return getStructString(schema);
-      default:
-        throw new KsqlException(String.format("Invalid type in schema: %s.", schema.toString()));
+    final Function<Schema, String> handler = SCHEMA_TYPE_TO_SQL_TYPE.get(schema.type());
+    if (handler == null) {
+      throw new KsqlException(String.format("Invalid type in schema: %s.", schema.toString()));
     }
+
+    return handler.apply(schema);
   }
 
   private static String getStructString(final Schema schema) {

--- a/ksql-parser/src/main/java/io/confluent/ksql/parser/tree/PrimitiveType.java
+++ b/ksql-parser/src/main/java/io/confluent/ksql/parser/tree/PrimitiveType.java
@@ -24,13 +24,15 @@ import java.util.Optional;
 @Immutable
 public final class PrimitiveType extends Type {
 
-  private static final ImmutableMap<SqlType, PrimitiveType> TYPES = ImmutableMap.of(
-      SqlType.BOOLEAN, new PrimitiveType(SqlType.BOOLEAN),
-      SqlType.INTEGER, new PrimitiveType(SqlType.INTEGER),
-      SqlType.BIGINT, new PrimitiveType(SqlType.BIGINT),
-      SqlType.DOUBLE, new PrimitiveType(SqlType.DOUBLE),
-      SqlType.STRING, new PrimitiveType(SqlType.STRING)
-  );
+  private static final ImmutableMap<SqlType, PrimitiveType> TYPES =
+      ImmutableMap.<SqlType, PrimitiveType>builder()
+      .put(SqlType.BOOLEAN, new PrimitiveType(SqlType.BOOLEAN))
+      .put(SqlType.INTEGER, new PrimitiveType(SqlType.INTEGER))
+      .put(SqlType.BIGINT,  new PrimitiveType(SqlType.BIGINT))
+      .put(SqlType.DOUBLE,  new PrimitiveType(SqlType.DOUBLE))
+      .put(SqlType.STRING,  new PrimitiveType(SqlType.STRING))
+      .build();
+
 
   public static PrimitiveType of(final String typeName) {
     switch (typeName.toUpperCase()) {

--- a/ksql-rest-app/src/main/java/io/confluent/ksql/rest/util/EntityUtil.java
+++ b/ksql-rest-app/src/main/java/io/confluent/ksql/rest/util/EntityUtil.java
@@ -20,23 +20,22 @@ import io.confluent.ksql.rest.entity.FieldInfo;
 import io.confluent.ksql.rest.entity.SchemaInfo;
 import java.util.List;
 import java.util.Map;
-import java.util.function.Function;
 import java.util.stream.Collectors;
 import org.apache.kafka.connect.data.Schema;
 
 public final class EntityUtil {
-  private static final Map<Schema.Type, Function<Schema, SchemaInfo.Type>>
+  private static final Map<Schema.Type, SchemaInfo.Type>
       SCHEMA_TYPE_TO_SCHEMA_INFO_TYPE =
-      ImmutableMap.<Schema.Type, Function<Schema, SchemaInfo.Type>>builder()
-          .put(Schema.Type.INT32, s -> SchemaInfo.Type.INTEGER)
-          .put(Schema.Type.INT64, s -> SchemaInfo.Type.BIGINT)
-          .put(Schema.Type.FLOAT32, s -> SchemaInfo.Type.DOUBLE)
-          .put(Schema.Type.FLOAT64, s -> SchemaInfo.Type.DOUBLE)
-          .put(Schema.Type.BOOLEAN, s -> SchemaInfo.Type.BOOLEAN)
-          .put(Schema.Type.STRING, s -> SchemaInfo.Type.STRING)
-          .put(Schema.Type.ARRAY, s -> SchemaInfo.Type.ARRAY)
-          .put(Schema.Type.MAP, s -> SchemaInfo.Type.MAP)
-          .put(Schema.Type.STRUCT, s -> SchemaInfo.Type.STRUCT)
+      ImmutableMap.<Schema.Type, SchemaInfo.Type>builder()
+          .put(Schema.Type.INT32, SchemaInfo.Type.INTEGER)
+          .put(Schema.Type.INT64, SchemaInfo.Type.BIGINT)
+          .put(Schema.Type.FLOAT32, SchemaInfo.Type.DOUBLE)
+          .put(Schema.Type.FLOAT64, SchemaInfo.Type.DOUBLE)
+          .put(Schema.Type.BOOLEAN, SchemaInfo.Type.BOOLEAN)
+          .put(Schema.Type.STRING, SchemaInfo.Type.STRING)
+          .put(Schema.Type.ARRAY, SchemaInfo.Type.ARRAY)
+          .put(Schema.Type.MAP, SchemaInfo.Type.MAP)
+          .put(Schema.Type.STRUCT, SchemaInfo.Type.STRUCT)
           .build();
 
   private EntityUtil() {
@@ -72,13 +71,12 @@ public final class EntityUtil {
   }
 
   private static SchemaInfo.Type getSchemaTypeString(final Schema schema) {
-    final Function<Schema, SchemaInfo.Type> handler =
-        SCHEMA_TYPE_TO_SCHEMA_INFO_TYPE.get(schema.type());
-    if (handler == null) {
+    final SchemaInfo.Type type = SCHEMA_TYPE_TO_SCHEMA_INFO_TYPE.get(schema.type());
+    if (type == null) {
       throw new RuntimeException(String.format("Invalid type in schema: %s.",
           schema.type().getName()));
     }
 
-    return handler.apply(schema);
+    return type;
   }
 }


### PR DESCRIPTION
### Description 
This refactor is needed to avoid disabling check-style CyclomaticComplexity rules in a future patch for decimal types (#842).

It only moves methods that have several if/case conditions into static variables that map those if/case conditions into a result.

### Testing done 
No new tests are necessary. Current unit tests verify these changes.

### Reviewer checklist
- [ ] Ensure docs are updated if necessary. (eg. if a user visible feature is being added or changed).
- [ ] Ensure relevant issues are linked (description should include text like "Fixes #<issue number>")

