### PR TITLE
Improve the Rest API test

### DIFF
--- a/ksql-engine/src/test/java/io/confluent/ksql/KsqlContextTestUtil.java
+++ b/ksql-engine/src/test/java/io/confluent/ksql/KsqlContextTestUtil.java
@@ -15,6 +15,7 @@
 
 package io.confluent.ksql;
 
+import com.google.common.collect.ImmutableMap;
 import io.confluent.kafka.schemaregistry.client.SchemaRegistryClient;
 import io.confluent.ksql.engine.KsqlEngine;
 import io.confluent.ksql.function.FunctionRegistry;
@@ -82,7 +83,11 @@ public final class KsqlContextTestUtil {
       final EmbeddedSingleNodeKafkaCluster kafkaCluster,
       final Map<String, Object> additionalConfig
   ) {
-    return createKsqlConfig(kafkaCluster.bootstrapServers(), additionalConfig);
+    final ImmutableMap<String, Object> config = ImmutableMap.<String, Object>builder()
+        .putAll(kafkaCluster.getClientProperties())
+        .putAll(additionalConfig)
+        .build();
+    return createKsqlConfig(kafkaCluster.bootstrapServers(), config);
   }
 
   public static KsqlConfig createKsqlConfig(

--- a/ksql-engine/src/test/java/io/confluent/ksql/integration/IntegrationTestHarness.java
+++ b/ksql-engine/src/test/java/io/confluent/ksql/integration/IntegrationTestHarness.java
@@ -533,9 +533,7 @@ public class IntegrationTestHarness extends ExternalResource {
   }
 
   private Map<String, Object> clientConfig() {
-    final Map<String, Object> config = new HashMap<>();
-    config.put(ProducerConfig.BOOTSTRAP_SERVERS_CONFIG, kafkaCluster.bootstrapServers());
-    return config;
+    return new HashMap<>(kafkaCluster.getClientProperties());
   }
 
   private Map<String, Object> producerConfig() {
@@ -610,8 +608,13 @@ public class IntegrationTestHarness extends ExternalResource {
   public static final class Builder {
 
     private final SchemaRegistryClient schemaRegistry = new MockSchemaRegistryClient();
-    private final EmbeddedSingleNodeKafkaCluster.Builder kafkaCluster
+    private EmbeddedSingleNodeKafkaCluster.Builder kafkaCluster
         = EmbeddedSingleNodeKafkaCluster.newBuilder();
+
+    public Builder withKafkaCluster(final EmbeddedSingleNodeKafkaCluster.Builder kafkaCluster) {
+      this.kafkaCluster = Objects.requireNonNull(kafkaCluster, "kafkaCluster");
+      return this;
+    }
 
     public IntegrationTestHarness build() {
       return new IntegrationTestHarness(kafkaCluster.build(), schemaRegistry);

--- a/ksql-engine/src/test/java/io/confluent/ksql/integration/SecureIntegrationTest.java
+++ b/ksql-engine/src/test/java/io/confluent/ksql/integration/SecureIntegrationTest.java
@@ -18,6 +18,9 @@ package io.confluent.ksql.integration;
 import static io.confluent.ksql.test.util.AssertEventually.assertThatEventually;
 import static io.confluent.ksql.test.util.EmbeddedSingleNodeKafkaCluster.VALID_USER1;
 import static io.confluent.ksql.test.util.EmbeddedSingleNodeKafkaCluster.VALID_USER2;
+import static io.confluent.ksql.test.util.EmbeddedSingleNodeKafkaCluster.ops;
+import static io.confluent.ksql.test.util.EmbeddedSingleNodeKafkaCluster.prefixedResource;
+import static io.confluent.ksql.test.util.EmbeddedSingleNodeKafkaCluster.resource;
 import static io.confluent.ksql.util.KsqlConfig.KSQL_SERVICE_ID_CONFIG;
 import static org.apache.kafka.common.acl.AclOperation.ALL;
 import static org.apache.kafka.common.acl.AclOperation.CREATE;
@@ -52,13 +55,11 @@ import io.confluent.ksql.util.PersistentQueryMetadata;
 import io.confluent.ksql.util.QueryMetadata;
 import io.confluent.ksql.util.TopicConsumer;
 import io.confluent.ksql.util.TopicProducer;
-import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.atomic.AtomicInteger;
-import java.util.stream.Collectors;
 import javax.net.ssl.HostnameVerifier;
 import javax.net.ssl.HttpsURLConnection;
 import kafka.security.auth.Acl;
@@ -66,9 +67,7 @@ import org.apache.kafka.clients.admin.AdminClient;
 import org.apache.kafka.clients.consumer.ConsumerConfig;
 import org.apache.kafka.common.acl.AclOperation;
 import org.apache.kafka.common.acl.AclPermissionType;
-import org.apache.kafka.common.resource.PatternType;
 import org.apache.kafka.common.resource.ResourcePattern;
-import org.apache.kafka.common.resource.ResourceType;
 import org.apache.kafka.common.security.auth.SecurityProtocol;
 import org.apache.kafka.test.TestUtils;
 import org.junit.After;
@@ -96,7 +95,7 @@ public class SecureIntegrationTest {
           .withoutPlainListeners()
           .withSaslSslListeners()
           .withSslListeners()
-          .withAcls(SUPER_USER.username)
+          .withAclsEnabled(SUPER_USER.username)
           .build();
 
   private QueryId queryId;
@@ -253,20 +252,6 @@ public class SecureIntegrationTest {
                                     final ResourcePattern resource,
                                     final Set<AclOperation> ops) {
     SECURE_CLUSTER.addUserAcl(credentials.username, AclPermissionType.ALLOW, resource, ops);
-  }
-
-  private static Set<AclOperation> ops(final AclOperation... ops) {
-    return Arrays.stream(ops).collect(Collectors.toSet());
-  }
-
-  private static ResourcePattern resource(final ResourceType resourceType,
-                                          final String resourceName) {
-    return new ResourcePattern(resourceType, resourceName, PatternType.LITERAL);
-  }
-
-  private static ResourcePattern prefixedResource(final ResourceType resourceType,
-                                                  final String resourceName) {
-    return new ResourcePattern(resourceType, resourceName, PatternType.PREFIXED);
   }
 
   private void givenTestSetupWithConfig(final Map<String, Object> ksqlConfigs) {

--- a/ksql-rest-app/src/main/java/io/confluent/ksql/rest/entity/Versions.java
+++ b/ksql-rest-app/src/main/java/io/confluent/ksql/rest/entity/Versions.java
@@ -15,8 +15,12 @@
 
 package io.confluent.ksql.rest.entity;
 
+import javax.ws.rs.core.MediaType;
+
 public final class Versions {
   public static final String KSQL_V1_JSON = "application/vnd.ksql.v1+json";
+  public static final MediaType KSQL_V1_JSON_TYPE =
+      new MediaType("application", "vnd.ksql.v1+json");
 
   public static final String KSQL_V1_WS = "1";
   public static final String KSQL_V1_WS_PARAM = "version";

--- a/ksql-rest-app/src/main/java/io/confluent/ksql/rest/server/resources/streaming/WebSocketSubscriber.java
+++ b/ksql-rest-app/src/main/java/io/confluent/ksql/rest/server/resources/streaming/WebSocketSubscriber.java
@@ -77,7 +77,11 @@ class WebSocketSubscriber<T> implements Flow.Subscriber<Collection<T>>, AutoClos
   @Override
   public void onError(final Throwable e) {
     log.error("error in session {}", session.getId(), e);
-    SessionUtil.closeSilently(session, CloseCodes.UNEXPECTED_CONDITION, "streams exception");
+    SessionUtil.closeSilently(
+        session,
+        CloseCodes.UNEXPECTED_CONDITION,
+        "streams exception: " + e.getMessage()
+    );
   }
 
   @Override

--- a/ksql-rest-app/src/test/java/io/confluent/ksql/rest/integration/RestApiTest.java
+++ b/ksql-rest-app/src/test/java/io/confluent/ksql/rest/integration/RestApiTest.java
@@ -15,17 +15,45 @@
 
 package io.confluent.ksql.rest.integration;
 
-import static org.junit.Assert.assertEquals;
+import static io.confluent.ksql.test.util.EmbeddedSingleNodeKafkaCluster.VALID_USER1;
+import static io.confluent.ksql.test.util.EmbeddedSingleNodeKafkaCluster.VALID_USER2;
+import static io.confluent.ksql.test.util.EmbeddedSingleNodeKafkaCluster.ops;
+import static io.confluent.ksql.test.util.EmbeddedSingleNodeKafkaCluster.prefixedResource;
+import static io.confluent.ksql.test.util.EmbeddedSingleNodeKafkaCluster.resource;
+import static org.apache.kafka.common.acl.AclOperation.ALL;
+import static org.apache.kafka.common.acl.AclOperation.DESCRIBE_CONFIGS;
+import static org.apache.kafka.common.resource.ResourceType.CLUSTER;
+import static org.apache.kafka.common.resource.ResourceType.GROUP;
+import static org.apache.kafka.common.resource.ResourceType.TOPIC;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.hasSize;
+import static org.hamcrest.Matchers.is;
 
 import io.confluent.common.utils.IntegrationTest;
 import io.confluent.ksql.integration.IntegrationTestHarness;
 import io.confluent.ksql.rest.entity.Versions;
 import io.confluent.ksql.rest.server.TestKsqlRestApp;
+import io.confluent.ksql.serde.DataSource.DataSourceSerDe;
+import io.confluent.ksql.test.util.EmbeddedSingleNodeKafkaCluster;
+import io.confluent.ksql.test.util.secure.ClientTrustStore;
+import io.confluent.ksql.test.util.secure.Credentials;
+import io.confluent.ksql.test.util.secure.SecureKafkaHelper;
+import io.confluent.ksql.util.PageViewDataProvider;
+import java.util.List;
 import java.util.Optional;
+import java.util.concurrent.CopyOnWriteArrayList;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicReference;
+import javax.websocket.CloseReason.CloseCodes;
 import javax.ws.rs.client.Client;
-import javax.ws.rs.client.Invocation.Builder;
 import javax.ws.rs.core.MediaType;
-import javax.ws.rs.core.Response;
+import org.eclipse.jetty.websocket.api.Session;
+import org.eclipse.jetty.websocket.api.annotations.OnWebSocketClose;
+import org.eclipse.jetty.websocket.api.annotations.OnWebSocketError;
+import org.eclipse.jetty.websocket.api.annotations.OnWebSocketMessage;
+import org.eclipse.jetty.websocket.api.annotations.WebSocket;
+import org.eclipse.jetty.websocket.client.WebSocketClient;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.BeforeClass;
@@ -34,17 +62,51 @@ import org.junit.Test;
 import org.junit.experimental.categories.Category;
 import org.junit.rules.RuleChain;
 
-@SuppressWarnings("unchecked")
 @Category({IntegrationTest.class})
 public class RestApiTest {
 
+  private static final int HEADER = 1;  // <-- some responses include a header as the first message.
+  private static final int LIMIT = 2;
   private static final String PAGE_VIEW_TOPIC = "pageviews";
   private static final String PAGE_VIEW_STREAM = "pageviews_original";
+  private static final Credentials SUPER_USER = VALID_USER1;
+  private static final Credentials NORMAL_USER = VALID_USER2;
 
-  private static final IntegrationTestHarness TEST_HARNESS = IntegrationTestHarness.build();
+  private static final IntegrationTestHarness TEST_HARNESS = IntegrationTestHarness.builder()
+      .withKafkaCluster(
+          EmbeddedSingleNodeKafkaCluster.newBuilder()
+              .withoutPlainListeners()
+              .withSaslSslListeners()
+              .withAclsEnabled(SUPER_USER.username)
+              .withAcl(
+                  NORMAL_USER,
+                  resource(CLUSTER, "kafka-cluster"),
+                  ops(DESCRIBE_CONFIGS)
+              )
+              .withAcl(
+                  NORMAL_USER,
+                  resource(TOPIC, "_confluent-ksql-default__command_topic"),
+                  ops(ALL)
+              )
+              .withAcl(
+                  NORMAL_USER,
+                  resource(TOPIC, PAGE_VIEW_TOPIC),
+                  ops(ALL)
+              )
+              .withAcl(
+                  NORMAL_USER,
+                  prefixedResource(GROUP, "_confluent-ksql-default_transient_"),
+                  ops(ALL)
+              )
+      )
+      .build();
 
   private static final TestKsqlRestApp REST_APP = TestKsqlRestApp
       .builder(TEST_HARNESS::kafkaBootstrapServers)
+      .withProperty("security.protocol", "SASL_SSL")
+      .withProperty("sasl.mechanism", "PLAIN")
+      .withProperty("sasl.jaas.config", SecureKafkaHelper.buildJaasConfig(NORMAL_USER))
+      .withProperties(ClientTrustStore.trustStoreProps())
       .build();
 
   @ClassRule
@@ -55,6 +117,8 @@ public class RestApiTest {
   @BeforeClass
   public static void setUpClass() {
     TEST_HARNESS.ensureTopics(PAGE_VIEW_TOPIC);
+
+    TEST_HARNESS.produceRows(PAGE_VIEW_TOPIC, new PageViewDataProvider(), DataSourceSerDe.JSON);
 
     RestIntegrationTestUtil.createStreams(REST_APP, PAGE_VIEW_STREAM, PAGE_VIEW_TOPIC);
   }
@@ -70,50 +134,109 @@ public class RestApiTest {
   }
 
   @Test
-  public void shouldExecuteStreamingQueryWithV1ContentType() {
-    try (final Response response = makeStreamingRequest(
-        "SELECT * from " + PAGE_VIEW_STREAM + ";",
-        Versions.KSQL_V1_JSON,
-        Versions.KSQL_V1_JSON
-    )) {
-      assertEquals(Response.Status.OK.getStatusCode(), response.getStatus());
-    }
+  public void shouldExecuteStreamingQueryWithV1ContentType() throws Exception {
+    // When:
+    final List<String> messages = makeStreamingRequest(
+        "SELECT * from " + PAGE_VIEW_STREAM + " LIMIT " + LIMIT + ";",
+        Versions.KSQL_V1_JSON_TYPE,
+        Versions.KSQL_V1_JSON_TYPE
+    );
+
+    // Then:
+    assertThat(messages, hasSize(is(HEADER + LIMIT)));
   }
 
   @Test
-  public void shouldExecuteStreamingQueryWithJsonContentType() {
-    try (final Response response = makeStreamingRequest(
-        "SELECT * from " + PAGE_VIEW_STREAM + "; ",
-        MediaType.APPLICATION_JSON_TYPE.toString(),
-        MediaType.APPLICATION_JSON_TYPE.toString()
-    )) {
-      assertEquals(Response.Status.OK.getStatusCode(), response.getStatus());
+  public void shouldExecuteStreamingQueryWithJsonContentType() throws Exception {
+    // When:
+    final List<String> messages = makeStreamingRequest(
+        "SELECT * from " + PAGE_VIEW_STREAM + " LIMIT " + LIMIT + ";",
+        MediaType.APPLICATION_JSON_TYPE,
+        MediaType.APPLICATION_JSON_TYPE
+    );
+
+    // Then:
+    assertThat(messages, hasSize(is(HEADER + LIMIT)));
+  }
+
+  @Test
+  public void shouldPrintTopic() throws Exception {
+    // When:
+    final List<String> messages = makeStreamingRequest(
+        "PRINT '" + PAGE_VIEW_TOPIC + "' FROM BEGINNING LIMIT " + LIMIT + ";",
+        MediaType.APPLICATION_JSON_TYPE,
+        MediaType.APPLICATION_JSON_TYPE);
+
+    // Then:
+    assertThat(messages, hasSize(is(LIMIT)));
+  }
+
+  private static List<String> makeStreamingRequest(
+      final String sql,
+      final MediaType mediaType,
+      final MediaType contentType
+  ) throws Exception {
+    final WebSocketListener listener = new WebSocketListener();
+
+    final WebSocketClient wsClient = RestIntegrationTestUtil.makeWsRequest(
+        REST_APP.getWsListener(),
+        sql,
+        listener,
+        Optional.of(mediaType),
+        Optional.of(contentType),
+        Optional.of(SUPER_USER)
+    );
+
+    try {
+      return listener.awaitMessages();
+    } finally {
+      wsClient.stop();
     }
   }
 
-  private Response makeStreamingRequest(
-      final String sql,
-      final String mediaType,
-      final String contentType
-  ) {
-    return makeRequest("query", sql, mediaType, Optional.ofNullable(contentType));
-  }
+  @SuppressWarnings("unused") // Invoked via reflection
+  @WebSocket
+  public static class WebSocketListener {
 
-  private Response makeRequest(
-      final String path,
-      final String sql,
-      final String mediaType,
-      final Optional<String> contentType
-  ) {
-    Builder builder = restClient
-        .target(REST_APP.getHttpListener())
-        .path(path)
-        .request(mediaType);
+    final CountDownLatch latch = new CountDownLatch(1);
+    final AtomicReference<Throwable> error = new AtomicReference<>();
+    final List<String> messages = new CopyOnWriteArrayList<>();
 
-    if (contentType.isPresent()) {
-      builder = builder.header("Content-Type", contentType.get());
+    @OnWebSocketMessage
+    public void onMessage(final Session session, final String text) {
+      messages.add(text);
     }
 
-    return builder.post(RestIntegrationTestUtil.ksqlRequest(sql));
+    @OnWebSocketClose
+    public void onClose(final int statusCode, final String reason) {
+      if (statusCode != CloseCodes.NORMAL_CLOSURE.getCode()) {
+        error.set(new RuntimeException("non-normal close: " + reason + ", code: " + statusCode));
+      }
+      latch.countDown();
+    }
+
+    @OnWebSocketError
+    public void onError(final Throwable t) {
+      error.set(t);
+      latch.countDown();
+    }
+
+    List<String> awaitMessages() {
+      assertThat("Response received", await(), is(true));
+
+      if (error.get() != null) {
+        throw new AssertionError("Error in web socket listener:", error.get());
+      }
+
+      return messages;
+    }
+
+    private boolean await() {
+      try {
+        return latch.await(30, TimeUnit.SECONDS);
+      } catch (final Exception e) {
+        throw new AssertionError("Timed out waiting for WS response", e);
+      }
+    }
   }
 }

--- a/ksql-rest-app/src/test/java/io/confluent/ksql/rest/server/resources/streaming/WebSocketSubscriberTest.java
+++ b/ksql-rest-app/src/test/java/io/confluent/ksql/rest/server/resources/streaming/WebSocketSubscriberTest.java
@@ -154,7 +154,7 @@ public class WebSocketSubscriberTest {
     subscriber.onError(new RuntimeException("streams died"));
     subscriber.close();
 
-    assertEquals("streams exception", reason.getValue().getReasonPhrase());
+    assertEquals("streams exception: streams died", reason.getValue().getReasonPhrase());
     assertEquals(CloseCodes.UNEXPECTED_CONDITION, reason.getValue().getCloseCode());
 
     EasyMock.verify(subscription, session);

--- a/ksql-test-util/src/main/java/io/confluent/ksql/test/util/EmbeddedSingleNodeKafkaCluster.java
+++ b/ksql-test-util/src/main/java/io/confluent/ksql/test/util/EmbeddedSingleNodeKafkaCluster.java
@@ -31,6 +31,7 @@ import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Properties;
 import java.util.Set;
 import java.util.stream.Collectors;
@@ -48,7 +49,9 @@ import org.apache.kafka.clients.consumer.ConsumerConfig;
 import org.apache.kafka.common.acl.AclOperation;
 import org.apache.kafka.common.acl.AclPermissionType;
 import org.apache.kafka.common.config.SslConfigs;
+import org.apache.kafka.common.resource.PatternType;
 import org.apache.kafka.common.resource.ResourcePattern;
+import org.apache.kafka.common.resource.ResourceType;
 import org.apache.kafka.common.security.JaasUtils;
 import org.apache.kafka.common.security.auth.KafkaPrincipal;
 import org.apache.kafka.common.security.auth.SecurityProtocol;
@@ -83,22 +86,26 @@ public final class EmbeddedSingleNodeKafkaCluster extends ExternalResource {
   private final TemporaryFolder tmpFolder = new TemporaryFolder();
   private final SimpleAclAuthorizer authorizer = new SimpleAclAuthorizer();
   private final Set<kafka.security.auth.Resource> addedAcls = new HashSet<>();
+  private final Map<AclKey, Set<AclOperation>> initialAcls;
 
   private ZooKeeperEmbedded zookeeper;
   private KafkaEmbedded broker;
 
   /**
    * Creates and starts a Kafka cluster.
-   *
-   * @param brokerConfig Additional broker configuration settings.
+   *  @param brokerConfig Additional broker configuration settings.
    * @param clientConfig Additional client configuration settings.
+   * @param initialAcls a set of ACLs to set when the cluster starts.
    */
   private EmbeddedSingleNodeKafkaCluster(
       final Map<String, Object> brokerConfig,
       final Map<String, Object> clientConfig,
-      final String additionalJaasConfig) {
+      final String additionalJaasConfig,
+      final Map<AclKey, Set<AclOperation>> initialAcls
+  ) {
     this.brokerConfig.putAll(brokerConfig);
     this.clientConfig.putAll(clientConfig);
+    this.initialAcls = ImmutableMap.copyOf(initialAcls);
 
     this.previousJassConfig = System.getProperty("java.security.auth.login.config");
     this.jassConfigFile = createServerJaasConfig(additionalJaasConfig);
@@ -119,6 +126,9 @@ public final class EmbeddedSingleNodeKafkaCluster extends ExternalResource {
     broker = new KafkaEmbedded(effectiveBrokerConfigFrom());
     clientConfig.put(ConsumerConfig.BOOTSTRAP_SERVERS_CONFIG, bootstrapServers());
     authorizer.configure(ImmutableMap.of(ZKConfig.ZkConnectProp(), zookeeperConnect()));
+
+    initialAcls.forEach((key, ops) ->
+        addUserAcl(key.userName, AclPermissionType.ALLOW, key.resourcePattern, ops));
   }
 
   @Override
@@ -339,11 +349,30 @@ public final class EmbeddedSingleNodeKafkaCluster extends ExternalResource {
     Configuration.setConfiguration(null);
   }
 
+  public static Set<AclOperation> ops(final AclOperation... ops) {
+    return Arrays.stream(ops).collect(Collectors.toSet());
+  }
+
+  public static ResourcePattern resource(
+      final ResourceType resourceType,
+      final String resourceName
+  ) {
+    return new ResourcePattern(resourceType, resourceName, PatternType.LITERAL);
+  }
+
+  public static ResourcePattern prefixedResource(
+      final ResourceType resourceType,
+      final String resourceName
+  ) {
+    return new ResourcePattern(resourceType, resourceName, PatternType.PREFIXED);
+  }
+
   public static final class Builder {
 
     private final Map<String, Object> brokerConfig = new HashMap<>();
     private final Map<String, Object> clientConfig = new HashMap<>();
     private final StringBuilder additionalJaasConfig = new StringBuilder();
+    private final Map<AclKey, Set<AclOperation>> acls = new HashMap<>();
 
     Builder() {
       brokerConfig.put(KafkaConfig.AuthorizerClassNameProp(), SimpleAclAuthorizer.class.getName());
@@ -376,12 +405,23 @@ public final class EmbeddedSingleNodeKafkaCluster extends ExternalResource {
       return this;
     }
 
-    public Builder withAcls(final String... superUsers) {
+    public Builder withAclsEnabled(final String... superUsers) {
       brokerConfig.remove(SimpleAclAuthorizer.AllowEveryoneIfNoAclIsFoundProp());
       brokerConfig.put(SimpleAclAuthorizer.SuperUsersProp(),
                        Stream.concat(Arrays.stream(superUsers), Stream.of("broker"))
                            .map(s -> "User:" + s)
                            .collect(Collectors.joining(";")));
+      return this;
+    }
+
+    public Builder withAcl(
+        final Credentials credentials,
+        final ResourcePattern resource,
+        final Set<AclOperation> ops
+    ) {
+      acls.computeIfAbsent(AclKey.of(credentials.username, resource), k -> new HashSet<>())
+          .addAll(ops);
+
       return this;
     }
 
@@ -399,7 +439,7 @@ public final class EmbeddedSingleNodeKafkaCluster extends ExternalResource {
 
     public EmbeddedSingleNodeKafkaCluster build() {
       return new EmbeddedSingleNodeKafkaCluster(
-          brokerConfig, clientConfig, additionalJaasConfig.toString());
+          brokerConfig, clientConfig, additionalJaasConfig.toString(), acls);
     }
 
     private void addListenersProp(final String listenerType) {
@@ -413,6 +453,47 @@ public final class EmbeddedSingleNodeKafkaCluster extends ExternalResource {
           .filter(part -> !part.startsWith(listenerType + "://"))
           .collect(Collectors.joining(","));
       brokerConfig.put(KafkaConfig.ListenersProp(), replacement);
+    }
+  }
+
+  private static final class AclKey {
+
+    private final String userName;
+    private final ResourcePattern resourcePattern;
+
+    AclKey(final String userName, final ResourcePattern resourcePattern) {
+      this.userName = Objects.requireNonNull(userName, "userName");
+      this.resourcePattern = Objects.requireNonNull(resourcePattern, "resourcePattern");
+    }
+
+    static AclKey of(final String userName, final ResourcePattern resourcePattern) {
+      return new AclKey(userName, resourcePattern);
+    }
+
+    @Override
+    public boolean equals(final Object o) {
+      if (this == o) {
+        return true;
+      }
+      if (o == null || getClass() != o.getClass()) {
+        return false;
+      }
+      final AclKey aclKey = (AclKey) o;
+      return Objects.equals(userName, aclKey.userName)
+          && Objects.equals(resourcePattern, aclKey.resourcePattern);
+    }
+
+    @Override
+    public int hashCode() {
+      return Objects.hash(userName, resourcePattern);
+    }
+
+    @Override
+    public String toString() {
+      return "AclKey{"
+          + "userName='" + userName + '\''
+          + ", resourcePattern=" + resourcePattern
+          + '}';
     }
   }
 }


### PR DESCRIPTION
### Description 

 Improve the Rest API test to include:
 - Kafka ACLs
 - Print topic
 - Actually streaming back results of websocket requests.

To do this I had to extend some test classes to better support secure cluster and ACLs.

Also exposed more error information when things fail.

This was done as part of investigating a user's issue where they were seeing a 'not authorised to use group' error message when doing a PRINT topic where the Kafka cluster is secured by ACLs. The tests added look to prove there is no requirement for ACLs on consumer groups for the PRINT command.  Likely, the user is running into a known issue with older versions of Kafka. (See https://issues.apache.org/jira/browse/KAFKA-6774).

### Testing done 

Usual

### Reviewer checklist
- [ ] Ensure docs are updated if necessary. (eg. if a user visible feature is being added or changed).
- [ ] Ensure relevant issues are linked (description should include text like "Fixes #<issue number>")

