### PR TITLE
Whiteliste configs for set/unset commands.

### DIFF
--- a/docs/developer-guide/syntax-reference.rst
+++ b/docs/developer-guide/syntax-reference.rst
@@ -1124,6 +1124,34 @@ SHOW PROPERTIES
 List the :ref:`configuration settings <ksql-param-reference>` that are
 currently in effect.
 
+SET/UNSET property
+------------------
+**Synopsis**
+
+.. code:: sql
+
+    SET 'auto.offset.reset' = 'earliest';
+
+Set or unset the session properties in the CLI. The session properties that have been set will be sent to the server along with the subsequent KSQL statements.
+The properties that are set using these commands are session properties, meaning they will be only available in the current CLI session.
+The following are the properties that can be configured with SET/UNSET commands from release 5.2 and above:
+
++---------------------------------------------------+--------------------------------------------------------------------------------------------+
+| Property                                          | Description                                                                                |
++===================================================+============================================================================================+
+| ksql.sink.window.change.log.additional.retention  | The default window change log additional retention time. This is a streams config value    |
+|                                                   | which will be added to a windows maintainMs to ensure data is not deleted from the log     |
+|                                                   | prematurely. Allows for clock drift. The default is 1 day.                                 |
++---------------------------------------------------+--------------------------------------------------------------------------------------------+
+| ksql.streams.commit.interval.ms                   | The frequency with which to save the position (offsets in source topics) of tasks.         |
+|                                                   | The default is 30000 milliseconds (at-least-once) / 100 milliseconds (exactly-once).       |
++---------------------------------------------------+--------------------------------------------------------------------------------------------+
+| auto.offset.reset                                 | Configure the KSQL queries to read the source topics from earliest or latest offset.       |
+|                                                   | The default in KSQL is 'latest'.                                                           |
++---------------------------------------------------+--------------------------------------------------------------------------------------------+
+
+
+
 .. _ksql-terminate:
 
 TERMINATE

--- a/docs/developer-guide/syntax-reference.rst
+++ b/docs/developer-guide/syntax-reference.rst
@@ -1130,7 +1130,8 @@ SET/UNSET property
 
 .. code:: sql
 
-    [SET/UNSET] 'property_name' = 'property_value';
+    [SET] 'property_name' = 'property_value';
+    [UNSET] 'property_name';
 
 **Description**
 

--- a/docs/developer-guide/syntax-reference.rst
+++ b/docs/developer-guide/syntax-reference.rst
@@ -1152,6 +1152,7 @@ The following are the properties that can be configured with SET/UNSET commands 
 |                                                   | The default in KSQL is ``latest``.                                                         |
 +---------------------------------------------------+--------------------------------------------------------------------------------------------+
 | group.id                                          | A unique string that identifies the consumer group this consumer belongs to.               |
+|                                                   | This can be set for PRINT TOPIC command when ACLs are enabled in Kafka.                                                               |
 |                                                   | The default in KSQL is ````.                                                               |
 +---------------------------------------------------+--------------------------------------------------------------------------------------------+
 

--- a/docs/developer-guide/syntax-reference.rst
+++ b/docs/developer-guide/syntax-reference.rst
@@ -1130,7 +1130,9 @@ SET/UNSET property
 
 .. code:: sql
 
-    SET 'auto.offset.reset' = 'earliest';
+    [SET/UNSET] 'property_name' = 'property_value';
+
+**Description**
 
 Set or unset the session properties in the CLI. The session properties that have been set will be sent to the server along with the subsequent KSQL statements.
 The properties that are set using these commands are session properties, meaning they will be only available in the current CLI session.
@@ -1147,9 +1149,11 @@ The following are the properties that can be configured with SET/UNSET commands 
 |                                                   | The default is 30000 milliseconds (at-least-once) / 100 milliseconds (exactly-once).       |
 +---------------------------------------------------+--------------------------------------------------------------------------------------------+
 | auto.offset.reset                                 | Configure the KSQL queries to read the source topics from earliest or latest offset.       |
-|                                                   | The default in KSQL is 'latest'.                                                           |
+|                                                   | The default in KSQL is ``latest``.                                                         |
 +---------------------------------------------------+--------------------------------------------------------------------------------------------+
-
+| group.id                                          | A unique string that identifies the consumer group this consumer belongs to.               |
+|                                                   | The default in KSQL is ````.                                                               |
++---------------------------------------------------+--------------------------------------------------------------------------------------------+
 
 
 .. _ksql-terminate:

--- a/ksql-cli/src/test/java/io/confluent/ksql/cli/CliTest.java
+++ b/ksql-cli/src/test/java/io/confluent/ksql/cli/CliTest.java
@@ -454,29 +454,7 @@ public class CliTest {
   @Test
   public void testPropertySetUnset() {
     assertRunCommand("set 'auto.offset.reset' = 'latest'", is(EMPTY_RESULT));
-    assertRunCommand("set 'application.id' = 'Test_App'", is(EMPTY_RESULT));
-    assertRunCommand("set 'producer.batch.size' = '16384'", is(EMPTY_RESULT));
-    assertRunCommand("set 'max.request.size' = '1048576'", is(EMPTY_RESULT));
-    assertRunCommand("set 'consumer.max.poll.records' = '500'", is(EMPTY_RESULT));
-    assertRunCommand("set 'enable.auto.commit' = 'true'", is(EMPTY_RESULT));
-    assertRunCommand("set 'ksql.streams.application.id' = 'Test_App'", is(EMPTY_RESULT));
-    assertRunCommand("set 'ksql.streams.producer.batch.size' = '16384'", is(EMPTY_RESULT));
-    assertRunCommand("set 'ksql.streams.max.request.size' = '1048576'", is(EMPTY_RESULT));
-    assertRunCommand("set 'ksql.streams.consumer.max.poll.records' = '500'", is(EMPTY_RESULT));
-    assertRunCommand("set 'ksql.streams.enable.auto.commit' = 'true'", is(EMPTY_RESULT));
-    assertRunCommand("set 'ksql.service.id' = 'assertPrint'", is(EMPTY_RESULT));
-
-    assertRunCommand("unset 'application.id'", is(EMPTY_RESULT));
-    assertRunCommand("unset 'producer.batch.size'", is(EMPTY_RESULT));
-    assertRunCommand("unset 'max.request.size'", is(EMPTY_RESULT));
-    assertRunCommand("unset 'consumer.max.poll.records'", is(EMPTY_RESULT));
-    assertRunCommand("unset 'enable.auto.commit'", is(EMPTY_RESULT));
-    assertRunCommand("unset 'ksql.streams.application.id'", is(EMPTY_RESULT));
-    assertRunCommand("unset 'ksql.streams.producer.batch.size'", is(EMPTY_RESULT));
-    assertRunCommand("unset 'ksql.streams.max.request.size'", is(EMPTY_RESULT));
-    assertRunCommand("unset 'ksql.streams.consumer.max.poll.records'", is(EMPTY_RESULT));
-    assertRunCommand("unset 'ksql.streams.enable.auto.commit'", is(EMPTY_RESULT));
-    assertRunCommand("unset 'ksql.service.id'", is(EMPTY_RESULT));
+    
 
     final TestResult.Builder builder = new TestResult.Builder();
     builder.addRows(startUpConfigs());

--- a/ksql-rest-app/src/main/java/io/confluent/ksql/rest/client/properties/LocalPropertyValidator.java
+++ b/ksql-rest-app/src/main/java/io/confluent/ksql/rest/client/properties/LocalPropertyValidator.java
@@ -19,6 +19,7 @@ import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
 import io.confluent.ksql.config.PropertyValidator;
 import io.confluent.ksql.util.KsqlConfig;
+import io.confluent.ksql.util.KsqlConstants;
 import java.util.Map;
 import java.util.Set;
 import java.util.function.Consumer;
@@ -37,6 +38,7 @@ class LocalPropertyValidator implements PropertyValidator {
       .add(KsqlConfig.SINK_WINDOW_CHANGE_LOG_ADDITIONAL_RETENTION_MS_PROPERTY)
       .add(StreamsConfig.COMMIT_INTERVAL_MS_CONFIG)
       .add(ConsumerConfig.AUTO_OFFSET_RESET_CONFIG)
+      .add(KsqlConstants.LEGACY_RUN_SCRIPT_STATEMENTS_CONTENT)
       .build();
 
   private static final Map<String, Consumer<Object>> HANDLERS =

--- a/ksql-rest-app/src/main/java/io/confluent/ksql/rest/client/properties/LocalPropertyValidator.java
+++ b/ksql-rest-app/src/main/java/io/confluent/ksql/rest/client/properties/LocalPropertyValidator.java
@@ -30,11 +30,10 @@ import org.apache.kafka.streams.StreamsConfig;
  * This class adds additional validation of properties on top of that provided by the
  * {@code ConfigDef} instances.
  */
-class LocalPropertyValidator implements PropertyValidator {
+public class LocalPropertyValidator implements PropertyValidator {
 
   // Only these config properties can be configured using SET/UNSET commands.
-  // Package private for testing.
-  static final Set<String> CONFIG_PROPERTY_WHITELIST = ImmutableSet.<String>builder()
+  public static final Set<String> CONFIG_PROPERTY_WHITELIST = ImmutableSet.<String>builder()
       .add(KsqlConfig.SINK_WINDOW_CHANGE_LOG_ADDITIONAL_RETENTION_MS_PROPERTY)
       .add(StreamsConfig.COMMIT_INTERVAL_MS_CONFIG)
       .add(ConsumerConfig.AUTO_OFFSET_RESET_CONFIG)

--- a/ksql-rest-app/src/main/java/io/confluent/ksql/rest/client/properties/LocalPropertyValidator.java
+++ b/ksql-rest-app/src/main/java/io/confluent/ksql/rest/client/properties/LocalPropertyValidator.java
@@ -39,6 +39,7 @@ class LocalPropertyValidator implements PropertyValidator {
       .add(StreamsConfig.COMMIT_INTERVAL_MS_CONFIG)
       .add(ConsumerConfig.AUTO_OFFSET_RESET_CONFIG)
       .add(KsqlConstants.LEGACY_RUN_SCRIPT_STATEMENTS_CONTENT)
+      .add(ConsumerConfig.GROUP_ID_CONFIG)
       .build();
 
   private static final Map<String, Consumer<Object>> HANDLERS =

--- a/ksql-rest-app/src/main/java/io/confluent/ksql/rest/client/properties/LocalPropertyValidator.java
+++ b/ksql-rest-app/src/main/java/io/confluent/ksql/rest/client/properties/LocalPropertyValidator.java
@@ -18,11 +18,8 @@ package io.confluent.ksql.rest.client.properties;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
 import io.confluent.ksql.config.PropertyValidator;
-import io.confluent.ksql.engine.KsqlEngineProps;
 import io.confluent.ksql.util.KsqlConfig;
-import java.util.Collection;
 import java.util.Map;
-import java.util.Objects;
 import java.util.Set;
 import java.util.function.Consumer;
 import org.apache.kafka.clients.consumer.ConsumerConfig;
@@ -35,7 +32,8 @@ import org.apache.kafka.streams.StreamsConfig;
 class LocalPropertyValidator implements PropertyValidator {
 
   // Only these config properties can be configured using SET/UNSET commands.
-  private static final Set<String> CONFIG_PROPERTY_WHITELIST = ImmutableSet.<String>builder()
+  // Package private for testing.
+  static final Set<String> CONFIG_PROPERTY_WHITELIST = ImmutableSet.<String>builder()
       .add(KsqlConfig.SINK_WINDOW_CHANGE_LOG_ADDITIONAL_RETENTION_MS_PROPERTY)
       .add(StreamsConfig.COMMIT_INTERVAL_MS_CONFIG)
       .add(ConsumerConfig.AUTO_OFFSET_RESET_CONFIG)

--- a/ksql-rest-app/src/main/java/io/confluent/ksql/rest/server/validation/PropertyValidator.java
+++ b/ksql-rest-app/src/main/java/io/confluent/ksql/rest/server/validation/PropertyValidator.java
@@ -22,6 +22,7 @@ import io.confluent.ksql.config.KsqlConfigResolver;
 import io.confluent.ksql.parser.KsqlParser.PreparedStatement;
 import io.confluent.ksql.parser.tree.SetProperty;
 import io.confluent.ksql.parser.tree.UnsetProperty;
+import io.confluent.ksql.rest.client.properties.LocalPropertyValidator;
 import io.confluent.ksql.services.ServiceContext;
 import io.confluent.ksql.util.KsqlConfig;
 import io.confluent.ksql.util.KsqlStatementException;
@@ -40,7 +41,7 @@ public final class PropertyValidator {
       final Map<String, Object> propertyOverrides
   ) {
     final SetProperty setProperty = (SetProperty) statement.getStatement();
-    throwIfUnknownProperty(
+    throwIfInvalidProperty(
         setProperty.getPropertyName(),
         statement.getStatementText()
     );
@@ -66,17 +67,17 @@ public final class PropertyValidator {
       final Map<String, Object> propertyOverrides
   ) {
     final UnsetProperty unsetProperty = (UnsetProperty) statement.getStatement();
-    throwIfUnknownProperty(
+    throwIfInvalidProperty(
         unsetProperty.getPropertyName(),
         statement.getStatementText()
     );
     context.execute(statement, ksqlConfig, propertyOverrides);
   }
 
-  private static void throwIfUnknownProperty(final String propertyName, final String text) {
-    new KsqlConfigResolver().resolve(propertyName, false).orElseThrow(
-        () -> new KsqlStatementException("Unknown property: " + propertyName, text)
-    );
+  private static void throwIfInvalidProperty(final String propertyName, final String text) {
+    if (!LocalPropertyValidator.CONFIG_PROPERTY_WHITELIST.contains(propertyName)) {
+      throw new KsqlStatementException("Unknown property: " + propertyName, text);
+    }
   }
 
 }

--- a/ksql-rest-app/src/main/java/io/confluent/ksql/rest/server/validation/PropertyValidator.java
+++ b/ksql-rest-app/src/main/java/io/confluent/ksql/rest/server/validation/PropertyValidator.java
@@ -18,7 +18,6 @@ package io.confluent.ksql.rest.server.validation;
 import com.google.common.collect.ImmutableMap;
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import io.confluent.ksql.KsqlExecutionContext;
-import io.confluent.ksql.config.KsqlConfigResolver;
 import io.confluent.ksql.parser.KsqlParser.PreparedStatement;
 import io.confluent.ksql.parser.tree.SetProperty;
 import io.confluent.ksql.parser.tree.UnsetProperty;

--- a/ksql-rest-app/src/main/java/io/confluent/ksql/rest/server/validation/RequestValidator.java
+++ b/ksql-rest-app/src/main/java/io/confluent/ksql/rest/server/validation/RequestValidator.java
@@ -172,15 +172,16 @@ public class RequestValidator {
     return validate(executionContext.parse(sql), propertyOverrides, sql);
   }
 
-  private static void validateOverriddenConfigProperties(final Map<String, Object> propertyOverrides) {
-    propertyOverrides.keySet().forEach(propertyName ->
-        {
-          if (!LocalPropertyValidator.CONFIG_PROPERTY_WHITELIST.contains(propertyName)) {
-            throw new KsqlException("Invalid config property: " + propertyName);
-          }
-        }
-    );
-
+  private static void validateOverriddenConfigProperties(
+      final Map<String, Object> propertyOverrides
+  ) {
+    propertyOverrides.keySet()
+        .forEach(
+            propertyName -> {
+              if (!LocalPropertyValidator.CONFIG_PROPERTY_WHITELIST.contains(propertyName)) {
+                throw new KsqlException("Invalid config property: " + propertyName);
+              }
+            });
   }
 
 }

--- a/ksql-rest-app/src/main/java/io/confluent/ksql/rest/server/validation/RequestValidator.java
+++ b/ksql-rest-app/src/main/java/io/confluent/ksql/rest/server/validation/RequestValidator.java
@@ -23,6 +23,7 @@ import io.confluent.ksql.parser.tree.CreateAsSelect;
 import io.confluent.ksql.parser.tree.InsertInto;
 import io.confluent.ksql.parser.tree.RunScript;
 import io.confluent.ksql.parser.tree.Statement;
+import io.confluent.ksql.rest.client.properties.LocalPropertyValidator;
 import io.confluent.ksql.rest.util.QueryCapacityUtil;
 import io.confluent.ksql.schema.inference.SchemaInjector;
 import io.confluent.ksql.services.ServiceContext;
@@ -95,6 +96,7 @@ public class RequestValidator {
       final Map<String, Object> propertyOverrides,
       final String sql
   ) {
+    validateOverriddenConfigProperties(propertyOverrides);
     final KsqlExecutionContext ctx = snapshotSupplier.get();
     final SchemaInjector injector = schemaInjectorFactory.apply(serviceContext);
 
@@ -168,6 +170,17 @@ public class RequestValidator {
         + "statement: " + statement.getStatementText());
 
     return validate(executionContext.parse(sql), propertyOverrides, sql);
+  }
+
+  private static void validateOverriddenConfigProperties(final Map<String, Object> propertyOverrides) {
+    propertyOverrides.keySet().forEach(propertyName ->
+        {
+          if (!LocalPropertyValidator.CONFIG_PROPERTY_WHITELIST.contains(propertyName)) {
+            throw new KsqlException("Invalid config property: " + propertyName);
+          }
+        }
+    );
+
   }
 
 }

--- a/ksql-rest-app/src/test/java/io/confluent/ksql/rest/client/properties/LocalPropertiesTest.java
+++ b/ksql-rest-app/src/test/java/io/confluent/ksql/rest/client/properties/LocalPropertiesTest.java
@@ -184,41 +184,9 @@ public class LocalPropertiesTest {
     realProps.set(StreamsConfig.CONSUMER_PREFIX + "some.unknown.prop", "some.value");
   }
 
-  @Test
-  public void shouldAllowKnownConsumerPropertyToBeSet() {
-    realProps.set(ConsumerConfig.FETCH_MIN_BYTES_CONFIG, "100");
-  }
-
-  @Test
-  public void shouldAllowKnownPrefixedConsumerPropertyToBeSet() {
-    realProps.set(StreamsConfig.CONSUMER_PREFIX + ConsumerConfig.FETCH_MIN_BYTES_CONFIG, "100");
-  }
-
-  @Test
-  public void shouldAllowKnownKsqlPrefixedConsumerPropertyToBeSet() {
-    realProps.set(KsqlConfig.KSQL_STREAMS_PREFIX + StreamsConfig.CONSUMER_PREFIX
-        + ConsumerConfig.FETCH_MIN_BYTES_CONFIG, "100");
-  }
-
   @Test(expected = IllegalArgumentException.class)
   public void shouldNotAllowUnknownProducerPropertyToBeSet() {
     realProps.set(StreamsConfig.PRODUCER_PREFIX + "some.unknown.prop", "some.value");
-  }
-
-  @Test
-  public void shouldAllowKnownProducerPropertyToBeSet() {
-    realProps.set(ProducerConfig.BUFFER_MEMORY_CONFIG, "100");
-  }
-
-  @Test
-  public void shouldAllowKnownKsqlPrefixedProducerPropertyToBeSet() {
-    realProps.set(KsqlConfig.KSQL_STREAMS_PREFIX + StreamsConfig.PRODUCER_PREFIX
-        + ProducerConfig.BUFFER_MEMORY_CONFIG, "100");
-  }
-
-  @Test
-  public void shouldAllowKnownPrefixedProducerPropertyToBeSet() {
-    realProps.set(StreamsConfig.PRODUCER_PREFIX + ProducerConfig.BUFFER_MEMORY_CONFIG, "100");
   }
 
   @Test(expected = IllegalArgumentException.class)
@@ -226,28 +194,9 @@ public class LocalPropertiesTest {
     realProps.set(KsqlConfig.KSQL_STREAMS_PREFIX + "some.unknown.prop", "some.value");
   }
 
-  @Test
-  public void shouldAllowKnownStreamsConfigToBeSet() {
-    realProps.set(StreamsConfig.NUM_STREAM_THREADS_CONFIG, "2");
-  }
-
-  @Test
-  public void shouldAllowKnownPrefixedStreamsConfigToBeSet() {
-    realProps.set(KsqlConfig.KSQL_STREAMS_PREFIX + StreamsConfig.NUM_STREAM_THREADS_CONFIG, "2");
-  }
-
   @Test(expected = IllegalArgumentException.class)
   public void shouldNotAllowUnknownKsqlConfigToBeSet() {
     realProps.set(KsqlConfig.KSQL_CONFIG_PROPERTY_PREFIX + "some.unknown.prop", "some.value");
   }
 
-  @Test
-  public void shouldAllowKnownUdfConfigToBeSet() {
-    realProps.set(KsqlConfig.KSQL_FUNCTIONS_SUBSTRING_LEGACY_ARGS_CONFIG, "true");
-  }
-
-  @Test
-  public void shouldAllowUnknownUdfConfigToBeSet() {
-    realProps.set(KsqlConfig.KSQL_FUNCTIONS_PROPERTY_PREFIX + "some_udf.some.prop", "some thing");
-  }
 }

--- a/ksql-rest-app/src/test/java/io/confluent/ksql/rest/client/properties/LocalPropertyValidatorTest.java
+++ b/ksql-rest-app/src/test/java/io/confluent/ksql/rest/client/properties/LocalPropertyValidatorTest.java
@@ -15,8 +15,6 @@
 
 package io.confluent.ksql.rest.client.properties;
 
-import com.google.common.collect.ImmutableList;
-import java.util.Collection;
 import org.apache.kafka.clients.consumer.ConsumerConfig;
 import org.junit.Before;
 import org.junit.Rule;
@@ -24,9 +22,6 @@ import org.junit.Test;
 import org.junit.rules.ExpectedException;
 
 public class LocalPropertyValidatorTest {
-
-  private static final Collection<String> IMMUTABLE_PROPS =
-      ImmutableList.of("immutable-1", "immutable-2");
 
   @Rule
   public final ExpectedException expectedException = ExpectedException.none();
@@ -50,7 +45,6 @@ public class LocalPropertyValidatorTest {
   public void shouldNotThrowOnConfigurableProp() {
     LocalPropertyValidator
         .CONFIG_PROPERTY_WHITELIST
-        .stream()
         .forEach(s -> validator.validate(s, "anything"));
   }
 

--- a/ksql-rest-app/src/test/java/io/confluent/ksql/rest/client/properties/LocalPropertyValidatorTest.java
+++ b/ksql-rest-app/src/test/java/io/confluent/ksql/rest/client/properties/LocalPropertyValidatorTest.java
@@ -35,7 +35,7 @@ public class LocalPropertyValidatorTest {
 
   @Before
   public void setUp() {
-    validator = new LocalPropertyValidator(IMMUTABLE_PROPS);
+    validator = new LocalPropertyValidator();
   }
 
   @Test

--- a/ksql-rest-app/src/test/java/io/confluent/ksql/rest/client/properties/LocalPropertyValidatorTest.java
+++ b/ksql-rest-app/src/test/java/io/confluent/ksql/rest/client/properties/LocalPropertyValidatorTest.java
@@ -39,16 +39,19 @@ public class LocalPropertyValidatorTest {
   }
 
   @Test
-  public void shouldThrowOnImmutableProp() {
+  public void shouldThrowOnNonConfigurableProp() {
     expectedException.expect(IllegalArgumentException.class);
-    expectedException.expectMessage("Cannot override property 'immutable-2'");
+    expectedException.expectMessage("Cannot override property 'foo'");
 
-    validator.validate("immutable-2", "anything");
+    validator.validate("foo", "anything");
   }
 
   @Test
-  public void shouldNotThrowOnMutableProp() {
-    validator.validate("mutable-1", "anything");
+  public void shouldNotThrowOnConfigurableProp() {
+    LocalPropertyValidator
+        .CONFIG_PROPERTY_WHITELIST
+        .stream()
+        .forEach(s -> validator.validate(s, "anything"));
   }
 
   @Test

--- a/ksql-rest-app/src/test/java/io/confluent/ksql/rest/entity/KsqlRequestTest.java
+++ b/ksql-rest-app/src/test/java/io/confluent/ksql/rest/entity/KsqlRequestTest.java
@@ -15,13 +15,11 @@
 
 package io.confluent.ksql.rest.entity;
 
-import static io.confluent.ksql.util.KsqlConfig.KSQL_TRANSIENT_QUERY_NAME_PREFIX_CONFIG;
-import static io.confluent.ksql.util.KsqlConfig.SINK_NUMBER_OF_REPLICAS_PROPERTY;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.hasItem;
 import static org.hamcrest.Matchers.is;
-import static org.hamcrest.Matchers.nullValue;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.datatype.jdk8.Jdk8Module;
@@ -33,6 +31,7 @@ import java.io.IOException;
 import java.util.Collections;
 import java.util.Map;
 import java.util.Optional;
+import org.apache.kafka.clients.consumer.ConsumerConfig;
 import org.junit.BeforeClass;
 import org.junit.Rule;
 import org.junit.Test;
@@ -45,23 +44,23 @@ public class KsqlRequestTest {
   private static final String A_JSON_REQUEST = "{"
       + "\"ksql\":\"sql\","
       + "\"streamsProperties\":{"
-      + "\"" + KsqlConfig.KSQL_SERVICE_ID_CONFIG + "\":\"some-service-id\""
+      + "\"" + ConsumerConfig.AUTO_OFFSET_RESET_CONFIG + "\":\"earliest\""
       + "}}";
   private static final String A_JSON_REQUEST_WITH_COMMAND_NUMBER = "{"
       + "\"ksql\":\"sql\","
       + "\"streamsProperties\":{"
-      + "\"" + KsqlConfig.KSQL_SERVICE_ID_CONFIG + "\":\"some-service-id\""
+      + "\"" + ConsumerConfig.AUTO_OFFSET_RESET_CONFIG + "\":\"earliest\""
       + "},"
       + "\"commandSequenceNumber\":2}";
   private static final String A_JSON_REQUEST_WITH_NULL_COMMAND_NUMBER = "{"
       + "\"ksql\":\"sql\","
       + "\"streamsProperties\":{"
-      + "\"" + KsqlConfig.KSQL_SERVICE_ID_CONFIG + "\":\"some-service-id\""
+      + "\"" + ConsumerConfig.AUTO_OFFSET_RESET_CONFIG + "\":\"earliest\""
       + "},"
       + "\"commandSequenceNumber\":null}";
 
   private static final ImmutableMap<String, Object> SOME_PROPS = ImmutableMap.of(
-      KsqlConfig.KSQL_SERVICE_ID_CONFIG, "some-service-id"
+      ConsumerConfig.AUTO_OFFSET_RESET_CONFIG, "earliest"
   );
   private static final long SOME_COMMAND_NUMBER = 2L;
 
@@ -155,14 +154,14 @@ public class KsqlRequestTest {
     final String jsonRequest = "{"
         + "\"ksql\":\"sql\","
         + "\"streamsProperties\":{"
-        + "\"" + KsqlConfig.SINK_NUMBER_OF_REPLICAS_PROPERTY + "\":2"
+        + "\"" + ConsumerConfig.AUTO_OFFSET_RESET_CONFIG + "\":\"earliest\""
         + "}}";
 
     // When:
     final KsqlRequest request = deserialize(jsonRequest);
 
     // Then:
-    assertThat(request.getStreamsProperties().get(SINK_NUMBER_OF_REPLICAS_PROPERTY), is((short)2));
+    assertThat(request.getStreamsProperties().get(ConsumerConfig.AUTO_OFFSET_RESET_CONFIG), equalTo("earliest"));
   }
 
   @Test
@@ -171,12 +170,12 @@ public class KsqlRequestTest {
     final KsqlRequest request = new KsqlRequest(
         "sql",
         ImmutableMap.of(
-            SINK_NUMBER_OF_REPLICAS_PROPERTY, "not-parsable"
+            ConsumerConfig.AUTO_OFFSET_RESET_CONFIG, "not-parsable"
         ),
         null);
 
     expectedException.expect(KsqlException.class);
-    expectedException.expectMessage(containsString(SINK_NUMBER_OF_REPLICAS_PROPERTY));
+    expectedException.expectMessage(containsString(ConsumerConfig.AUTO_OFFSET_RESET_CONFIG));
     expectedException.expectMessage(containsString("not-parsable"));
 
     // When:
@@ -189,7 +188,7 @@ public class KsqlRequestTest {
     final KsqlRequest request = new KsqlRequest(
         "sql",
         Collections.singletonMap(
-            KSQL_TRANSIENT_QUERY_NAME_PREFIX_CONFIG, null
+            ConsumerConfig.AUTO_OFFSET_RESET_CONFIG, "earliest"
         ),
         null);
 
@@ -197,8 +196,8 @@ public class KsqlRequestTest {
     final Map<String, Object> props = request.getStreamsProperties();
 
     // Then:
-    assertThat(props.keySet(), hasItem(KSQL_TRANSIENT_QUERY_NAME_PREFIX_CONFIG));
-    assertThat(props.get(KSQL_TRANSIENT_QUERY_NAME_PREFIX_CONFIG), is(nullValue()));
+    assertThat(props.keySet(), hasItem(ConsumerConfig.AUTO_OFFSET_RESET_CONFIG));
+    assertThat(props.get(ConsumerConfig.AUTO_OFFSET_RESET_CONFIG), is("earliest"));
   }
 
   private static String serialize(final KsqlRequest request) {

--- a/ksql-rest-app/src/test/java/io/confluent/ksql/rest/server/resources/KsqlResourceTest.java
+++ b/ksql-rest-app/src/test/java/io/confluent/ksql/rest/server/resources/KsqlResourceTest.java
@@ -169,7 +169,7 @@ public class KsqlResourceTest {
   private static final Duration DISTRIBUTED_COMMAND_RESPONSE_TIMEOUT = Duration.ofMillis(1000);
   private static final KsqlRequest VALID_EXECUTABLE_REQUEST = new KsqlRequest(
       "CREATE STREAM S AS SELECT * FROM test_stream;",
-      ImmutableMap.of(KsqlConfig.KSQL_WINDOWED_SESSION_KEY_LEGACY_CONFIG, true),
+      ImmutableMap.of(ConsumerConfig.AUTO_OFFSET_RESET_CONFIG, "earliest"),
       0L);
   private static final Schema SINGLE_FIELD_SCHEMA = SchemaBuilder.struct()
       .field("val", Schema.OPTIONAL_STRING_SCHEMA);
@@ -1089,12 +1089,12 @@ public class KsqlResourceTest {
     // Given:
     final String csas = "CREATE STREAM " + streamName + " AS SELECT * FROM test_stream;";
     final Map<String, Object> localOverrides = ImmutableMap.of(
-        KsqlConfig.SINK_NUMBER_OF_REPLICAS_PROPERTY, "2"
+        ConsumerConfig.AUTO_OFFSET_RESET_CONFIG, "earliest"
     );
 
     // When:
     final CommandStatusEntity result = makeSingleRequest(
-        new KsqlRequest("UNSET '" + KsqlConfig.SINK_NUMBER_OF_REPLICAS_PROPERTY + "';\n"
+        new KsqlRequest("UNSET '" + ConsumerConfig.AUTO_OFFSET_RESET_CONFIG + "';\n"
             + csas, localOverrides, null),
         CommandStatusEntity.class);
 

--- a/ksql-rest-app/src/test/java/io/confluent/ksql/rest/server/resources/KsqlResourceTest.java
+++ b/ksql-rest-app/src/test/java/io/confluent/ksql/rest/server/resources/KsqlResourceTest.java
@@ -894,8 +894,8 @@ public class KsqlResourceTest {
         "LIST FUNCTIONS;",
         "DESCRIBE FUNCTION LCASE;",
         "LIST PROPERTIES;",
-        "SET '" + KsqlConfig.KSQL_SERVICE_ID_CONFIG + "'='FOO';",
-        "UNSET '" + KsqlConfig.KSQL_SERVICE_ID_CONFIG + "';"
+        "SET '" + ConsumerConfig.AUTO_OFFSET_RESET_CONFIG + "'='earliest';",
+        "UNSET '" + ConsumerConfig.AUTO_OFFSET_RESET_CONFIG + "';"
     );
 
     for (final String statement : blackListed) {
@@ -1146,7 +1146,7 @@ public class KsqlResourceTest {
 
     // When:
     final List<CommandStatusEntity> results = makeMultipleRequest(
-        "SET '" + KsqlConfig.KSQL_ENABLE_UDFS + "' = 'false';\n"
+        "SET '" + ConsumerConfig.AUTO_OFFSET_RESET_CONFIG + "' = 'earliest';\n"
             + csas,
         CommandStatusEntity.class);
 
@@ -1154,7 +1154,7 @@ public class KsqlResourceTest {
     verify(commandStore).enqueueCommand(
         argThat(is(preparedStatementText(csas))),
         any(),
-        eq(ImmutableMap.of(KsqlConfig.KSQL_ENABLE_UDFS, "false")));
+        eq(ImmutableMap.of(ConsumerConfig.AUTO_OFFSET_RESET_CONFIG, "earliest")));
 
     assertThat(results, hasSize(1));
     assertThat(results.get(0).getStatementText(), is(csas));
@@ -1177,15 +1177,15 @@ public class KsqlResourceTest {
   public void shouldFailSetPropertyOnInvalidPropertyValue() {
     // When:
     final KsqlErrorMessage response = makeFailingRequest(
-        "SET '" + KsqlConfig.SINK_NUMBER_OF_REPLICAS_PROPERTY + "' = 'invalid value';",
+        "SET '" + ConsumerConfig.AUTO_OFFSET_RESET_CONFIG + "' = 'invalid value';",
         Code.BAD_REQUEST);
 
     // Then:
     assertThat(response, instanceOf(KsqlStatementErrorMessage.class));
     assertThat(response.getErrorCode(), is(Errors.ERROR_CODE_BAD_STATEMENT));
     assertThat(response.getMessage(),
-        containsString("Invalid value invalid value for configuration ksql.sink.replicas: "
-            + "Not a number of type SHORT"));
+        containsString("Invalid value invalid value for configuration auto.offset.reset: "
+            + "String must be one of: latest, earliest, none"));
   }
 
   @Test
@@ -1230,7 +1230,7 @@ public class KsqlResourceTest {
     final String csas = "CREATE STREAM " + streamName + " AS SELECT * FROM test_stream;";
 
     makeMultipleRequest(
-        "SET '" + KsqlConfig.SINK_NUMBER_OF_REPLICAS_PROPERTY + "' = '2';", KsqlEntity.class);
+        "SET '" + ConsumerConfig.AUTO_OFFSET_RESET_CONFIG + "' = 'earliest';", KsqlEntity.class);
 
     // When:
     makeSingleRequest(csas, KsqlEntity.class);

--- a/ksql-rest-app/src/test/java/io/confluent/ksql/rest/server/resources/streaming/WSQueryEndpointTest.java
+++ b/ksql-rest-app/src/test/java/io/confluent/ksql/rest/server/resources/streaming/WSQueryEndpointTest.java
@@ -62,6 +62,7 @@ import java.util.stream.Collectors;
 import javax.websocket.CloseReason;
 import javax.websocket.CloseReason.CloseCodes;
 import javax.websocket.Session;
+import org.apache.kafka.clients.consumer.ConsumerConfig;
 import org.junit.Before;
 import org.junit.BeforeClass;
 import org.junit.Test;
@@ -78,7 +79,7 @@ public class WSQueryEndpointTest {
   private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper();
 
   private static final KsqlRequest VALID_REQUEST = new KsqlRequest("test-sql",
-      ImmutableMap.of(KsqlConfig.KSQL_SERVICE_ID_CONFIG, "test-id"), null);
+      ImmutableMap.of(ConsumerConfig.AUTO_OFFSET_RESET_CONFIG, "earliest"), null);
 
   private static final KsqlRequest ANOTHER_REQUEST = new KsqlRequest("other-sql",
       ImmutableMap.of(), null);
@@ -86,7 +87,7 @@ public class WSQueryEndpointTest {
   private static final long SEQUENCE_NUMBER = 2L;
   private static final KsqlRequest REQUEST_WITHOUT_SEQUENCE_NUMBER = VALID_REQUEST;
   private static final KsqlRequest REQUEST_WITH_SEQUENCE_NUMBER = new KsqlRequest("test-sql",
-      ImmutableMap.of(KsqlConfig.KSQL_SERVICE_ID_CONFIG, "test-id"), SEQUENCE_NUMBER);
+      ImmutableMap.of(ConsumerConfig.AUTO_OFFSET_RESET_CONFIG, "earliest"), SEQUENCE_NUMBER);
 
   private static final String VALID_VERSION = Versions.KSQL_V1_WS;
   private static final String[] NO_VERSION_PROPERTY = null;

--- a/ksql-rest-app/src/test/java/io/confluent/ksql/rest/server/validation/PropertyValidatorTest.java
+++ b/ksql-rest-app/src/test/java/io/confluent/ksql/rest/server/validation/PropertyValidatorTest.java
@@ -23,6 +23,7 @@ import io.confluent.ksql.util.KsqlConfig;
 import io.confluent.ksql.util.KsqlStatementException;
 import java.util.HashMap;
 import java.util.Optional;
+import org.apache.kafka.clients.consumer.ConsumerConfig;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ExpectedException;
@@ -58,8 +59,8 @@ public class PropertyValidatorTest {
     // No exception when:
     CustomValidators.SET_PROPERTY.validate(
         PreparedStatement.of(
-            "SET '" + KsqlConfig.SINK_NUMBER_OF_REPLICAS_PROPERTY + "' = '1';",
-            new SetProperty(Optional.empty(), KsqlConfig.SINK_NUMBER_OF_REPLICAS_PROPERTY, "1")),
+            "SET '" + ConsumerConfig.AUTO_OFFSET_RESET_CONFIG + "' = 'earliest';",
+            new SetProperty(Optional.empty(), ConsumerConfig.AUTO_OFFSET_RESET_CONFIG, "earliest")),
         engine.getEngine(),
         engine.getServiceContext(),
         engine.getKsqlConfig(),
@@ -77,8 +78,8 @@ public class PropertyValidatorTest {
     // When:
     CustomValidators.SET_PROPERTY.validate(
         PreparedStatement.of(
-            "SET '" + KsqlConfig.SINK_NUMBER_OF_REPLICAS_PROPERTY + "' = 'invalid';",
-            new SetProperty(Optional.empty(), KsqlConfig.SINK_NUMBER_OF_REPLICAS_PROPERTY, "invalid")),
+            "SET '" + ConsumerConfig.AUTO_OFFSET_RESET_CONFIG + "' = 'invalid';",
+            new SetProperty(Optional.empty(), ConsumerConfig.AUTO_OFFSET_RESET_CONFIG, "invalid")),
         engine.getEngine(),
         engine.getServiceContext(),
         engine.getKsqlConfig(),
@@ -109,8 +110,8 @@ public class PropertyValidatorTest {
     // No exception when:
     CustomValidators.UNSET_PROPERTY.validate(
         PreparedStatement.of(
-            "UNSET '" + KsqlConfig.SINK_NUMBER_OF_REPLICAS_PROPERTY + "';",
-            new UnsetProperty(Optional.empty(), KsqlConfig.SINK_NUMBER_OF_REPLICAS_PROPERTY)),
+            "UNSET '" + ConsumerConfig.AUTO_OFFSET_RESET_CONFIG + "';",
+            new UnsetProperty(Optional.empty(), ConsumerConfig.AUTO_OFFSET_RESET_CONFIG)),
         engine.getEngine(),
         engine.getServiceContext(),
         engine.getKsqlConfig(),

--- a/ksql-rest-app/src/test/java/io/confluent/ksql/rest/server/validation/RequestValidatorTest.java
+++ b/ksql-rest-app/src/test/java/io/confluent/ksql/rest/server/validation/RequestValidatorTest.java
@@ -49,6 +49,7 @@ import io.confluent.ksql.util.KsqlException;
 import io.confluent.ksql.util.KsqlStatementException;
 import java.util.List;
 import java.util.Map;
+import org.apache.kafka.clients.consumer.ConsumerConfig;
 import org.apache.kafka.connect.data.Schema;
 import org.apache.kafka.connect.data.SchemaBuilder;
 import org.junit.Before;
@@ -247,6 +248,56 @@ public class RequestValidatorTest {
         any()
     );
   }
+
+
+  @Test
+  public void shouldThrowIfInvalidOverriddenProperty() {
+    // Given:
+    final Map<String, Object> props = ImmutableMap.of(
+        "invalid.property", "foo");
+    givenRequestValidator(
+        ImmutableMap.of(CreateStream.class, statementValidator)
+    );
+    final List<ParsedStatement> statements =
+        givenParsed(
+            "CREATE STREAM a WITH (kafka_topic='a', value_format='json');"
+        );
+
+    // Expect:
+    expectedException.expect(KsqlException.class);
+    expectedException.expectMessage("Invalid config property: invalid.property");
+
+    // When:
+    validator.validate(statements, props, "sql");
+  }
+
+  @Test
+  public void shouldValidateForValidOverriddenProperty() {
+    // Given:
+    final Map<String, Object> props = ImmutableMap.of(
+        ConsumerConfig.AUTO_OFFSET_RESET_CONFIG, "earliest");
+    givenRequestValidator(
+        ImmutableMap.of(CreateStream.class, statementValidator)
+    );
+    final List<ParsedStatement> statements =
+        givenParsed(
+            "CREATE STREAM a WITH (kafka_topic='a', value_format='json');"
+        );
+
+    // When:
+    validator.validate(statements, props, "sql");
+
+    // Then:
+    verify(statementValidator, times(1)).validate(
+        argThat(is(preparedStatement(instanceOf(CreateStream.class)))),
+        eq(executionContext),
+        any(),
+        eq(ksqlConfig),
+        any()
+    );
+
+  }
+
 
   private List<ParsedStatement> givenParsed(final String sql) {
     return new DefaultKsqlParser().parse(sql);


### PR DESCRIPTION
This patch changes the behavior for SET/UNSET command so only the properties in a predefined whitelist can be configured using these commands and the command would fail user tries to config any other property.
Currently user can run these command with many properties that should not be configurable by users. For instance, user should not be able to issue the following command:

```
ksql> set 'ksql.service.id` = 'foo';
```
Currently we have only 4 configurable session properties, but we can add more in this PR if reviewers have convincing suggestion! :) 
So as of now the properties that user can set/unset from client are the following:

- ksql.sink.window.change.log.additional.retention

- ksql.streams.commit.interval.ms

- auto.offset.reset  

- group.id  

Any other property that is used in SET/UNSET command or is sent to the REST API as part of properties will result in failure of the command/request.  

Since we store all the config properties for each query along with that query, this won't have any effect on the existing queries and therefore no backward compatibility issue in the interactive mode.
In the headless mode, user can easily update the query file by removing invalid set/unset commands.


### Testing done 
Related tests were updated.

### Reviewer checklist
- [ ] Ensure docs are updated if necessary. (eg. if a user visible feature is being added or changed).
- [ ] Ensure relevant issues are linked (description should include text like "Fixes #<issue number>")

