### PR TITLE
Parse DECIMAL types from CREATE statements

### DIFF
--- a/ksql-cli/src/main/java/io/confluent/ksql/cli/console/Console.java
+++ b/ksql-cli/src/main/java/io/confluent/ksql/cli/console/Console.java
@@ -388,8 +388,24 @@ public class Console implements Closeable {
       case STRING:
         return "VARCHAR(STRING)";
       default:
-        return schema.getType().name();
+        return formatPrimitiveType(schema);
     }
+  }
+
+  private static String formatPrimitiveType(final SchemaInfo schema) {
+    final StringBuilder sb = new StringBuilder();
+
+    // Build the schema type with parameters in parenthesis if present
+    sb.append(schema.getType().name());
+    schema.getTypeParameters().ifPresent(
+        params -> {
+          sb.append("(");
+          sb.append(String.join(",", params));
+          sb.append(")");
+        }
+    );
+
+    return sb.toString();
   }
 
   private static String formatFieldType(final FieldInfo field, final String keyField) {

--- a/ksql-common/src/main/java/io/confluent/ksql/util/DecimalUtil.java
+++ b/ksql-common/src/main/java/io/confluent/ksql/util/DecimalUtil.java
@@ -40,12 +40,10 @@ public final class DecimalUtil {
    * @return True if the schema is a valid Decimal type; False otherwise
    */
   public static boolean isDecimalSchema(final Schema schema) {
-    if (schema == null) {
-      return false;
-    }
-
     // Use the Connect Decimal name because Schema does not have a type for decimals
-    return (schema.name() != null) ? schema.name().equalsIgnoreCase(Decimal.LOGICAL_NAME) : false;
+    return (schema != null)
+        && (schema.name() != null)
+        && schema.name().equalsIgnoreCase(Decimal.LOGICAL_NAME);
   }
 
   /**
@@ -54,10 +52,10 @@ public final class DecimalUtil {
    * The precision is obtained from the 'precision' key found on the {@link Schema}
    * parameters list.
    *
-   * @param schema The schema to get the precision from
-   * @return A numeric precision value
+   * @param schema decimal schema with {@value #PRECISION_FIELD} set as a {@link Schema} parameter
+   * @return the {@code int} value of the {@value #PRECISION_FIELD} field
    */
-  public static Integer getPrecision(final Schema schema) {
+  public static int getPrecision(final Schema schema) {
     Preconditions.checkArgument(isDecimalSchema(schema),
         "Schema is not a valid Decimal schema: " + schema);
 
@@ -70,10 +68,10 @@ public final class DecimalUtil {
    * The scale is obtained from the 'scale' key found on the {@link Schema}
    * parameters list.
    *
-   * @param schema The schema to get the scale from
-   * @return A numeric scale value
+   * @param schema decimal schema with {@value #SCALE_FIELD} set as a {@link Schema} parameter
+   * @return the {@code int} value of the {@value #SCALE_FIELD} field
    */
-  public static Integer getScale(final Schema schema) {
+  public static int getScale(final Schema schema) {
     Preconditions.checkArgument(isDecimalSchema(schema),
         "Schema is not a valid Decimal schema: " + schema);
 

--- a/ksql-common/src/main/java/io/confluent/ksql/util/DecimalUtil.java
+++ b/ksql-common/src/main/java/io/confluent/ksql/util/DecimalUtil.java
@@ -1,0 +1,107 @@
+/*
+ * Copyright 2019 Confluent Inc.
+ *
+ * Licensed under the Confluent Community License (the "License"); you may not use
+ * this file except in compliance with the License.  You may obtain a copy of the
+ * License at
+ *
+ * http://www.confluent.io/confluent-community-license
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package io.confluent.ksql.util;
+
+import com.google.common.base.Preconditions;
+import org.apache.kafka.connect.data.Decimal;
+import org.apache.kafka.connect.data.Schema;
+import org.apache.kafka.connect.data.SchemaBuilder;
+
+/**
+ * Utility functions to handle Decimal types.
+ */
+public final class DecimalUtil {
+  public static final String PRECISION_FIELD = "precision";
+  public static final String SCALE_FIELD = Decimal.SCALE_FIELD;
+
+  private DecimalUtil() {
+
+  }
+
+  /**
+   * Returns true if the specified {@link Schema} is a valid Decimal schema.
+   * </p>
+   * A valid Decimal schema is based on the Connect {@link Decimal} logical name to keep a standard
+   * across Connect and KSQL decimals.
+   * @param schema The schema to check for Decimal name
+   * @return True if the schema is a valid Decimal type; False otherwise
+   */
+  public static boolean isDecimalSchema(final Schema schema) {
+    if (schema == null) {
+      return false;
+    }
+
+    // Use the Connect Decimal name because Schema does not have a type for decimals
+    return (schema.name() != null) ? schema.name().equalsIgnoreCase(Decimal.LOGICAL_NAME) : false;
+  }
+
+  /**
+   * Returns the precision of a Decimal schema.
+   * </p>
+   * The precision is obtained from the 'precision' key found on the {@link Schema}
+   * parameters list.
+   *
+   * @param schema The schema to get the precision from
+   * @return A numeric precision value
+   */
+  public static Integer getPrecision(final Schema schema) {
+    Preconditions.checkArgument(isDecimalSchema(schema),
+        "Schema is not a valid Decimal schema: " + schema);
+
+    return Integer.parseInt(schema.parameters().get(PRECISION_FIELD));
+  }
+
+  /**
+   * Returns the scale of a Decimal schema.
+   * </p>
+   * The scale is obtained from the 'scale' key found on the {@link Schema}
+   * parameters list.
+   *
+   * @param schema The schema to get the scale from
+   * @return A numeric scale value
+   */
+  public static Integer getScale(final Schema schema) {
+    Preconditions.checkArgument(isDecimalSchema(schema),
+        "Schema is not a valid Decimal schema: " + schema);
+
+    return Integer.parseInt(schema.parameters().get(SCALE_FIELD));
+  }
+
+  /**
+   * Builds a Decimal {@link Schema} type using the precision and scale values specified.
+   * </p>
+   * The schema is created by setting the {@link Decimal} logical name, and adding the
+   * precision and scale values as a {@link Schema} parameters.
+   *
+   * @param precision The precision for the Decimal schema
+   * @param scale The scale for the Decimal schema
+   * @return A valid Decimal schema
+   */
+  public static Schema schema(final int precision, final int scale) {
+    return builder(precision, scale).build();
+  }
+
+  private static SchemaBuilder builder(final int precision, final int scale) {
+    // Do not use Decimal.schema(scale). Decimal does not set the precision, the precision
+    // parameter must be set first (before scale) so that EntityUtil can obtain the list
+    // of parameters in the right order, i.e. DECIMAL(precision, scale)
+    return SchemaBuilder.bytes()
+        .name(Decimal.LOGICAL_NAME)
+        .parameter(PRECISION_FIELD, Integer.toString(precision))
+        .parameter(SCALE_FIELD, Integer.toString(scale))
+        .optional(); // KSQL only uses optional types
+  }
+}

--- a/ksql-common/src/test/java/io/confluent/ksql/util/DecimalUtilTest.java
+++ b/ksql-common/src/test/java/io/confluent/ksql/util/DecimalUtilTest.java
@@ -1,0 +1,54 @@
+/*
+ * Copyright 2019 Confluent Inc.
+ *
+ * Licensed under the Confluent Community License (the "License"); you may not use
+ * this file except in compliance with the License.  You may obtain a copy of the
+ * License at
+ *
+ * http://www.confluent.io/confluent-community-license
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package io.confluent.ksql.util;
+
+import org.apache.kafka.connect.data.SchemaBuilder;
+import org.junit.Test;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.MatcherAssert.assertThat;
+
+public class DecimalUtilTest {
+  @Test
+  public void shouldReturnOptionalDecimalSchema() {
+    final int anyValue = 1;
+
+    assertThat(DecimalUtil.schema(anyValue, anyValue).isOptional(), is(true));
+  }
+
+  @Test
+  public void shouldReturnTrueOnConnectDecimalSchema() {
+    final int anyValue = 1;
+
+    assertThat(DecimalUtil.isDecimalSchema(DecimalUtil.schema(anyValue, anyValue)), is(true));
+  }
+
+  @Test
+  public void shouldReturnFalseOnUnknownConnectDecimalSchema() {
+    assertThat(DecimalUtil.isDecimalSchema(null), is(false));
+    assertThat(DecimalUtil.isDecimalSchema(SchemaBuilder.bytes().build()), is(false));
+    assertThat(DecimalUtil.isDecimalSchema(SchemaBuilder.bytes().name("NoConnectDecimal")), is(false));
+  }
+
+  @Test
+  public void shouldReturnPrecisionAndScaleSchemaParameters() {
+    final int precision = 6;
+    final int scale = 2;
+
+    assertThat(DecimalUtil.getPrecision(DecimalUtil.schema(precision, scale)), is(precision));
+    assertThat(DecimalUtil.getScale(DecimalUtil.schema(precision, scale)), is(scale));
+  }
+}

--- a/ksql-common/src/test/java/io/confluent/ksql/util/DecimalUtilTest.java
+++ b/ksql-common/src/test/java/io/confluent/ksql/util/DecimalUtilTest.java
@@ -15,40 +15,65 @@
 
 package io.confluent.ksql.util;
 
+import org.apache.kafka.connect.data.Decimal;
+import org.apache.kafka.connect.data.Schema;
 import org.apache.kafka.connect.data.SchemaBuilder;
+import org.junit.BeforeClass;
 import org.junit.Test;
 
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
 
 public class DecimalUtilTest {
+  /* Set Decimal Schema under test */
+  private static final int TEST_PRECISION = 6;
+  private static final int TEST_SCALE = 2;
+  private static final Schema TEST_DECIMAL_SCHEMA = DecimalUtil.schema(TEST_PRECISION, TEST_SCALE);
+
   @Test
   public void shouldReturnOptionalDecimalSchema() {
-    final int anyValue = 1;
-
-    assertThat(DecimalUtil.schema(anyValue, anyValue).isOptional(), is(true));
+    assertThat(TEST_DECIMAL_SCHEMA.isOptional(), is(true));
   }
 
   @Test
   public void shouldReturnTrueOnConnectDecimalSchema() {
-    final int anyValue = 1;
-
-    assertThat(DecimalUtil.isDecimalSchema(DecimalUtil.schema(anyValue, anyValue)), is(true));
+    assertThat(DecimalUtil.isDecimalSchema(TEST_DECIMAL_SCHEMA), is(true));
   }
 
   @Test
-  public void shouldReturnFalseOnUnknownConnectDecimalSchema() {
+  public void shouldReturnPrecisionParameters() {
+    assertThat(DecimalUtil.getPrecision(TEST_DECIMAL_SCHEMA), is(TEST_PRECISION));
+  }
+
+  @Test
+  public void shouldReturnScaleParameters() {
+    assertThat(DecimalUtil.getScale(TEST_DECIMAL_SCHEMA), is(TEST_SCALE));
+  }
+
+  @Test
+  public void shouldReturnFalseOnNullSchema() {
     assertThat(DecimalUtil.isDecimalSchema(null), is(false));
+  }
+
+  @Test
+  public void shouldReturnFalseOnEmptySchemaName() {
     assertThat(DecimalUtil.isDecimalSchema(SchemaBuilder.bytes().build()), is(false));
+  }
+
+  @Test
+  public void shouldReturnFalseOnUnknownDecimalSchema() {
     assertThat(DecimalUtil.isDecimalSchema(SchemaBuilder.bytes().name("NoConnectDecimal")), is(false));
   }
 
-  @Test
-  public void shouldReturnPrecisionAndScaleSchemaParameters() {
-    final int precision = 6;
-    final int scale = 2;
+  @Test(expected = NumberFormatException.class)
+  public void shouldThrowNumberFormatExceptionIfPrecisionParameterIsNotNumeric() {
+    DecimalUtil.getPrecision(SchemaBuilder.bytes().name(Decimal.LOGICAL_NAME)
+        .parameter(DecimalUtil.PRECISION_FIELD, "1d").build());
+  }
 
-    assertThat(DecimalUtil.getPrecision(DecimalUtil.schema(precision, scale)), is(precision));
-    assertThat(DecimalUtil.getScale(DecimalUtil.schema(precision, scale)), is(scale));
+  @Test(expected = NumberFormatException.class)
+  public void shouldThrowNumberFormatExceptionIfScaleParameterIsNotNumeric() {
+    DecimalUtil.getScale(SchemaBuilder.bytes().name(Decimal.LOGICAL_NAME)
+        .parameter(DecimalUtil.SCALE_FIELD, "1d").build());
   }
 }

--- a/ksql-parser/src/main/java/io/confluent/ksql/parser/AstBuilder.java
+++ b/ksql-parser/src/main/java/io/confluent/ksql/parser/AstBuilder.java
@@ -1280,7 +1280,7 @@ public class AstBuilder extends SqlBaseBaseVisitor<Node> {
       final String baseType = baseTypeToString(type.baseType());
       final List<Integer> typeParameters = typeParametersToList(type.typeParameter());
 
-      return PrimitiveType.of(baseType, typeParameters);
+      return PrimitiveType.of(baseType, Optional.ofNullable(typeParameters));
     }
 
     if (type.ARRAY() != null) {
@@ -1323,7 +1323,10 @@ public class AstBuilder extends SqlBaseBaseVisitor<Node> {
       return null;
     }
 
-    return typeParameters.stream().map(e -> typeParameterToInteger(e)).collect(Collectors.toList());
+    return typeParameters
+        .stream()
+        .map(AstBuilder::typeParameterToInteger)
+        .collect(Collectors.toList());
   }
 
   private static Integer typeParameterToInteger(
@@ -1331,8 +1334,8 @@ public class AstBuilder extends SqlBaseBaseVisitor<Node> {
   ) {
     try {
       return Integer.parseInt(typeParameter.INTEGER_VALUE().getSymbol().getText());
-    } catch (NumberFormatException e) {
-      throw new KsqlException("Type parameter must be numeric", e);
+    } catch (final NumberFormatException e) {
+      throw new KsqlException("Type parameter must be numeric (integer)", e);
     }
   }
 

--- a/ksql-parser/src/main/java/io/confluent/ksql/parser/ExpressionFormatter.java
+++ b/ksql-parser/src/main/java/io/confluent/ksql/parser/ExpressionFormatter.java
@@ -87,7 +87,18 @@ public final class ExpressionFormatter {
 
     @Override
     protected String visitPrimitiveType(final PrimitiveType node, final Boolean unmangleNames) {
-      return node.getSqlType().toString();
+      final StringBuilder sb = new StringBuilder();
+
+      sb.append(node.getSqlType().toString());
+      node.getSqlTypeParameters().ifPresent(p -> {
+        if (p.size() > 0) {
+          sb.append("(");
+          sb.append(Joiner.on(',').join(p));
+          sb.append(")");
+        }
+      });
+
+      return sb.toString();
     }
 
     @Override

--- a/ksql-parser/src/main/java/io/confluent/ksql/parser/ExpressionFormatter.java
+++ b/ksql-parser/src/main/java/io/confluent/ksql/parser/ExpressionFormatter.java
@@ -90,7 +90,7 @@ public final class ExpressionFormatter {
       final StringBuilder sb = new StringBuilder();
 
       sb.append(node.getSqlType().toString());
-      if (node.getSqlTypeParameters().size() > 0) {
+      if (node.getSqlTypeParameters() != null && node.getSqlTypeParameters().size() > 0) {
         sb.append("(");
         sb.append(Joiner.on(',').join(node.getSqlTypeParameters()));
         sb.append(")");

--- a/ksql-parser/src/main/java/io/confluent/ksql/parser/ExpressionFormatter.java
+++ b/ksql-parser/src/main/java/io/confluent/ksql/parser/ExpressionFormatter.java
@@ -90,13 +90,11 @@ public final class ExpressionFormatter {
       final StringBuilder sb = new StringBuilder();
 
       sb.append(node.getSqlType().toString());
-      node.getSqlTypeParameters().ifPresent(p -> {
-        if (p.size() > 0) {
-          sb.append("(");
-          sb.append(Joiner.on(',').join(p));
-          sb.append(")");
-        }
-      });
+      if (node.getSqlTypeParameters().size() > 0) {
+        sb.append("(");
+        sb.append(Joiner.on(',').join(node.getSqlTypeParameters()));
+        sb.append(")");
+      }
 
       return sb.toString();
     }

--- a/ksql-parser/src/main/java/io/confluent/ksql/parser/tree/PrimitiveType.java
+++ b/ksql-parser/src/main/java/io/confluent/ksql/parser/tree/PrimitiveType.java
@@ -30,7 +30,7 @@ import javax.annotation.Nullable;
 public final class PrimitiveType extends Type {
 
   /* List of parameters for the type (i.e. DECIMAL(6,2)). */
-  final ImmutableList<Integer> typeParameters;
+  private final ImmutableList<Integer> typeParameters;
 
   private static final ImmutableMap<SqlType, Function<ImmutableList<Integer>, PrimitiveType>>
       TYPES = ImmutableMap.<SqlType, Function<ImmutableList<Integer>, PrimitiveType>>builder()
@@ -43,12 +43,12 @@ public final class PrimitiveType extends Type {
       .build();
 
   public static PrimitiveType of(final String typeName) {
-    return of(typeName, ImmutableList.of());
+    return of(typeName, Optional.empty());
   }
 
   public static PrimitiveType of(
       final String typeName,
-      @Nullable final List<Integer> typeParameters
+      @Nullable final Optional<List<Integer>> typeParameters
   ) {
     switch (typeName.toUpperCase()) {
       case "INT":
@@ -72,14 +72,11 @@ public final class PrimitiveType extends Type {
   }
 
   public static PrimitiveType of(
-      final SqlType sqlType,
-      @Nullable final List<Integer> sqlTypeParameters
+      final SqlType sqlType, final Optional<List<Integer>> sqlTypeParameters
   ) {
-    if (sqlTypeParameters == null) {
-      return function(sqlType).apply(ImmutableList.of());
-    } else {
-      return function(sqlType).apply(ImmutableList.copyOf(sqlTypeParameters));
-    }
+    return function(sqlType).apply(ImmutableList.copyOf(
+        sqlTypeParameters.orElse(ImmutableList.of())
+    ));
   }
 
   private static Function<ImmutableList<Integer>, PrimitiveType> function(final SqlType sqlType) {
@@ -116,7 +113,7 @@ public final class PrimitiveType extends Type {
       default:
         if (typeParameters.size() > 0) {
           throw new KsqlException(
-              "Primitive type does not support parameters: " + getSqlType());
+              "Type with parameters is not supported: " + getSqlType());
         }
     }
   }

--- a/ksql-parser/src/main/java/io/confluent/ksql/parser/tree/Type.java
+++ b/ksql-parser/src/main/java/io/confluent/ksql/parser/tree/Type.java
@@ -24,7 +24,7 @@ import java.util.Optional;
 public abstract class Type extends Expression {
 
   public enum SqlType {
-    BOOLEAN, INTEGER, BIGINT, DOUBLE, STRING, ARRAY, MAP, STRUCT
+    BOOLEAN, INTEGER, BIGINT, DOUBLE, STRING, DECIMAL, ARRAY, MAP, STRUCT
   }
 
   private final SqlType sqlType;

--- a/ksql-parser/src/main/java/io/confluent/ksql/schema/ksql/LogicalSchemas.java
+++ b/ksql-parser/src/main/java/io/confluent/ksql/schema/ksql/LogicalSchemas.java
@@ -26,6 +26,7 @@ import io.confluent.ksql.util.KsqlException;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import java.util.function.Function;
 import org.apache.kafka.connect.data.Schema;
 import org.apache.kafka.connect.data.SchemaBuilder;
@@ -136,8 +137,8 @@ public final class LogicalSchemas {
         final int precision = DecimalUtil.getPrecision(schema);
         final int scale = DecimalUtil.getScale(schema);
 
-        return PrimitiveType.of(Type.SqlType.DECIMAL, Arrays.asList(precision, scale));
-      } catch (NumberFormatException e) {
+        return PrimitiveType.of(Type.SqlType.DECIMAL, Optional.of(Arrays.asList(precision, scale)));
+      } catch (final Exception e) {
         throw new KsqlException("Unexpected decimal type parameters: " + schema);
       }
     }

--- a/ksql-parser/src/main/java/io/confluent/ksql/schema/ksql/LogicalSchemas.java
+++ b/ksql-parser/src/main/java/io/confluent/ksql/schema/ksql/LogicalSchemas.java
@@ -194,7 +194,7 @@ public final class LogicalSchemas {
     }
 
     private static Schema fromSqlDecimal(final PrimitiveType sqlType) {
-      final List<Integer> parameters = sqlType.getSqlTypeParameters().orElse(null);
+      final List<Integer> parameters = sqlType.getSqlTypeParameters();
       if (parameters == null || parameters.size() != 2) {
         throw new KsqlException("Unexpected decimal type parameters: " + sqlType);
       }

--- a/ksql-parser/src/test/java/io/confluent/ksql/parser/ExpressionFormatterTest.java
+++ b/ksql-parser/src/test/java/io/confluent/ksql/parser/ExpressionFormatterTest.java
@@ -52,6 +52,7 @@ import io.confluent.ksql.parser.tree.TimeLiteral;
 import io.confluent.ksql.parser.tree.TimestampLiteral;
 import io.confluent.ksql.parser.tree.Type.SqlType;
 import io.confluent.ksql.parser.tree.WhenClause;
+import java.util.Arrays;
 import java.util.Collections;
 import java.util.Optional;
 import org.junit.Test;
@@ -306,5 +307,11 @@ public class ExpressionFormatterTest {
   public void shouldFormatArray() {
     final Array array = Array.of(PrimitiveType.of(SqlType.BOOLEAN));
     assertThat(ExpressionFormatter.formatExpression(array), equalTo("ARRAY<BOOLEAN>"));
+  }
+
+  @Test
+  public void shouldFormatDecimal() {
+    final PrimitiveType decimal = PrimitiveType.of(SqlType.DECIMAL, Arrays.asList(6, 2));
+    assertThat(ExpressionFormatter.formatExpression(decimal), equalTo("DECIMAL(6,2)"));
   }
 }

--- a/ksql-parser/src/test/java/io/confluent/ksql/parser/ExpressionFormatterTest.java
+++ b/ksql-parser/src/test/java/io/confluent/ksql/parser/ExpressionFormatterTest.java
@@ -311,7 +311,10 @@ public class ExpressionFormatterTest {
 
   @Test
   public void shouldFormatDecimal() {
-    final PrimitiveType decimal = PrimitiveType.of(SqlType.DECIMAL, Arrays.asList(6, 2));
+    final PrimitiveType decimal = PrimitiveType.of(
+        SqlType.DECIMAL,
+        Optional.of(Arrays.asList(6, 2)));
+
     assertThat(ExpressionFormatter.formatExpression(decimal), equalTo("DECIMAL(6,2)"));
   }
 }

--- a/ksql-parser/src/test/java/io/confluent/ksql/parser/tree/PrimitiveTypeTest.java
+++ b/ksql-parser/src/test/java/io/confluent/ksql/parser/tree/PrimitiveTypeTest.java
@@ -26,6 +26,8 @@ import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ExpectedException;
 
+import java.util.Arrays;
+
 public class PrimitiveTypeTest {
 
   @Rule
@@ -39,6 +41,9 @@ public class PrimitiveTypeTest {
         .addEqualityGroup(PrimitiveType.of(SqlType.BIGINT), PrimitiveType.of(SqlType.BIGINT))
         .addEqualityGroup(PrimitiveType.of(SqlType.DOUBLE), PrimitiveType.of(SqlType.DOUBLE))
         .addEqualityGroup(PrimitiveType.of(SqlType.STRING), PrimitiveType.of(SqlType.STRING))
+        .addEqualityGroup(
+            PrimitiveType.of(SqlType.DECIMAL, Arrays.asList(6 ,2)),
+            PrimitiveType.of(SqlType.DECIMAL, Arrays.asList(6 ,2)))
         .addEqualityGroup(Array.of(PrimitiveType.of(SqlType.STRING)))
         .testEquals();
   }
@@ -46,6 +51,8 @@ public class PrimitiveTypeTest {
   @Test
   public void shouldReturnSqlType() {
     assertThat(PrimitiveType.of(SqlType.INTEGER).getSqlType(), is(SqlType.INTEGER));
+    assertThat(PrimitiveType.of(
+        SqlType.DECIMAL, Arrays.asList(6 ,2)).getSqlType(), is(SqlType.DECIMAL));
   }
 
   @Test
@@ -117,5 +124,15 @@ public class PrimitiveTypeTest {
         // Then:
         assertThat(PrimitiveType.of(string).getSqlType(), is(expected))
     );
+  }
+
+  @Test
+  public void shouldThrowOnIllegalDecimalParameters() {
+    // Then:
+    expectedException.expect(KsqlException.class);
+    expectedException.expectMessage("Primitive type requires 2 parameters: DECIMAL");
+
+    // When:
+    PrimitiveType.of(SqlType.DECIMAL);
   }
 }

--- a/ksql-parser/src/test/java/io/confluent/ksql/parser/tree/PrimitiveTypeTest.java
+++ b/ksql-parser/src/test/java/io/confluent/ksql/parser/tree/PrimitiveTypeTest.java
@@ -27,6 +27,7 @@ import org.junit.Test;
 import org.junit.rules.ExpectedException;
 
 import java.util.Arrays;
+import java.util.Optional;
 
 public class PrimitiveTypeTest {
 
@@ -42,8 +43,8 @@ public class PrimitiveTypeTest {
         .addEqualityGroup(PrimitiveType.of(SqlType.DOUBLE), PrimitiveType.of(SqlType.DOUBLE))
         .addEqualityGroup(PrimitiveType.of(SqlType.STRING), PrimitiveType.of(SqlType.STRING))
         .addEqualityGroup(
-            PrimitiveType.of(SqlType.DECIMAL, Arrays.asList(6 ,2)),
-            PrimitiveType.of(SqlType.DECIMAL, Arrays.asList(6 ,2)))
+            PrimitiveType.of(SqlType.DECIMAL, Optional.of(Arrays.asList(6 ,2))),
+            PrimitiveType.of(SqlType.DECIMAL, Optional.of(Arrays.asList(6 ,2))))
         .addEqualityGroup(Array.of(PrimitiveType.of(SqlType.STRING)))
         .testEquals();
   }
@@ -52,7 +53,7 @@ public class PrimitiveTypeTest {
   public void shouldReturnSqlType() {
     assertThat(PrimitiveType.of(SqlType.INTEGER).getSqlType(), is(SqlType.INTEGER));
     assertThat(PrimitiveType.of(
-        SqlType.DECIMAL, Arrays.asList(6 ,2)).getSqlType(), is(SqlType.DECIMAL));
+        SqlType.DECIMAL, Optional.of(Arrays.asList(6 ,2))).getSqlType(), is(SqlType.DECIMAL));
   }
 
   @Test
@@ -143,7 +144,7 @@ public class PrimitiveTypeTest {
     expectedException.expectMessage("DECIMAL precision must be >= 1: DECIMAL(0,0)");
 
     // When:
-    PrimitiveType.of(SqlType.DECIMAL, Arrays.asList(0, 0));
+    PrimitiveType.of(SqlType.DECIMAL, Optional.of(Arrays.asList(0, 0)));
   }
 
   @Test
@@ -153,7 +154,7 @@ public class PrimitiveTypeTest {
     expectedException.expectMessage("DECIMAL scale must be >= 0: DECIMAL(1,-1)");
 
     // When:
-    PrimitiveType.of(SqlType.DECIMAL, Arrays.asList(1, -1));
+    PrimitiveType.of(SqlType.DECIMAL, Optional.of(Arrays.asList(1, -1)));
   }
 
   @Test
@@ -163,6 +164,6 @@ public class PrimitiveTypeTest {
     expectedException.expectMessage("DECIMAL precision must be >= scale: DECIMAL(1,2)");
 
     // When:
-    PrimitiveType.of(SqlType.DECIMAL, Arrays.asList(1, 2));
+    PrimitiveType.of(SqlType.DECIMAL, Optional.of(Arrays.asList(1, 2)));
   }
 }

--- a/ksql-parser/src/test/java/io/confluent/ksql/parser/tree/PrimitiveTypeTest.java
+++ b/ksql-parser/src/test/java/io/confluent/ksql/parser/tree/PrimitiveTypeTest.java
@@ -130,9 +130,39 @@ public class PrimitiveTypeTest {
   public void shouldThrowOnIllegalDecimalParameters() {
     // Then:
     expectedException.expect(KsqlException.class);
-    expectedException.expectMessage("Primitive type requires 2 parameters: DECIMAL");
+    expectedException.expectMessage("DECIMAL type requires 2 parameters: DECIMAL");
 
     // When:
     PrimitiveType.of(SqlType.DECIMAL);
+  }
+
+  @Test
+  public void shouldThrowOnDecimalPrecisionLessThanOne() {
+    // Then:
+    expectedException.expect(KsqlException.class);
+    expectedException.expectMessage("DECIMAL precision must be >= 1: DECIMAL(0,0)");
+
+    // When:
+    PrimitiveType.of(SqlType.DECIMAL, Arrays.asList(0, 0));
+  }
+
+  @Test
+  public void shouldThrowOnDecimalScaleLessThanZero() {
+    // Then:
+    expectedException.expect(KsqlException.class);
+    expectedException.expectMessage("DECIMAL scale must be >= 0: DECIMAL(1,-1)");
+
+    // When:
+    PrimitiveType.of(SqlType.DECIMAL, Arrays.asList(1, -1));
+  }
+
+  @Test
+  public void shouldThrowOnDecimalPrecisionLessThanScale() {
+    // Then:
+    expectedException.expect(KsqlException.class);
+    expectedException.expectMessage("DECIMAL precision must be >= scale: DECIMAL(1,2)");
+
+    // When:
+    PrimitiveType.of(SqlType.DECIMAL, Arrays.asList(1, 2));
   }
 }

--- a/ksql-parser/src/test/java/io/confluent/ksql/schema/ksql/LogicalSchemasTest.java
+++ b/ksql-parser/src/test/java/io/confluent/ksql/schema/ksql/LogicalSchemasTest.java
@@ -28,6 +28,7 @@ import io.confluent.ksql.util.DecimalUtil;
 import io.confluent.ksql.util.KsqlException;
 
 import java.util.Arrays;
+import java.util.Optional;
 import java.util.Set;
 import java.util.stream.Collectors;
 import org.apache.kafka.connect.data.Schema;
@@ -56,7 +57,7 @@ public class LogicalSchemasTest {
       .put(PrimitiveType.of(SqlType.DOUBLE), LOGICAL_DOUBLE_SCHEMA)
       .put(PrimitiveType.of(SqlType.STRING), LOGICAL_STRING_SCHEMA)
       .put(PrimitiveType.of(SqlType.DECIMAL,
-          Arrays.asList(DECIMAL_PRECISION, DECIMAL_SCALE)), LOGICAL_DECIMAL_SCHEMA)
+          Optional.of(Arrays.asList(DECIMAL_PRECISION, DECIMAL_SCALE))), LOGICAL_DECIMAL_SCHEMA)
       .put(io.confluent.ksql.parser.tree.Array.of(PrimitiveType.of(SqlType.INTEGER)),
           SchemaBuilder.array(LogicalSchemas.INTEGER).optional().build())
       .put(io.confluent.ksql.parser.tree.Map.of(PrimitiveType.of(SqlType.INTEGER)),

--- a/ksql-parser/src/test/java/io/confluent/ksql/schema/ksql/LogicalSchemasTest.java
+++ b/ksql-parser/src/test/java/io/confluent/ksql/schema/ksql/LogicalSchemasTest.java
@@ -24,7 +24,10 @@ import com.google.common.collect.ImmutableSet;
 import io.confluent.ksql.parser.tree.PrimitiveType;
 import io.confluent.ksql.parser.tree.Type;
 import io.confluent.ksql.parser.tree.Type.SqlType;
+import io.confluent.ksql.util.DecimalUtil;
 import io.confluent.ksql.util.KsqlException;
+
+import java.util.Arrays;
 import java.util.Set;
 import java.util.stream.Collectors;
 import org.apache.kafka.connect.data.Schema;
@@ -35,11 +38,16 @@ import org.junit.rules.ExpectedException;
 
 public class LogicalSchemasTest {
 
+  private static final int DECIMAL_PRECISION = 6;
+  private static final int DECIMAL_SCALE = 2;
+
   private static final Schema LOGICAL_BOOLEAN_SCHEMA = SchemaBuilder.bool().optional().build();
   private static final Schema LOGICAL_INT_SCHEMA = SchemaBuilder.int32().optional().build();
   private static final Schema LOGICAL_BIGINT_SCHEMA = SchemaBuilder.int64().optional().build();
   private static final Schema LOGICAL_DOUBLE_SCHEMA = SchemaBuilder.float64().optional().build();
   private static final Schema LOGICAL_STRING_SCHEMA = SchemaBuilder.string().optional().build();
+  private static final Schema LOGICAL_DECIMAL_SCHEMA = DecimalUtil.schema(DECIMAL_PRECISION,
+                                                                          DECIMAL_SCALE);
 
   private static final BiMap<Type, Schema> SQL_TO_LOGICAL = ImmutableBiMap.<Type, Schema>builder()
       .put(PrimitiveType.of(SqlType.BOOLEAN), LOGICAL_BOOLEAN_SCHEMA)
@@ -47,6 +55,8 @@ public class LogicalSchemasTest {
       .put(PrimitiveType.of(SqlType.BIGINT), LOGICAL_BIGINT_SCHEMA)
       .put(PrimitiveType.of(SqlType.DOUBLE), LOGICAL_DOUBLE_SCHEMA)
       .put(PrimitiveType.of(SqlType.STRING), LOGICAL_STRING_SCHEMA)
+      .put(PrimitiveType.of(SqlType.DECIMAL,
+          Arrays.asList(DECIMAL_PRECISION, DECIMAL_SCALE)), LOGICAL_DECIMAL_SCHEMA)
       .put(io.confluent.ksql.parser.tree.Array.of(PrimitiveType.of(SqlType.INTEGER)),
           SchemaBuilder.array(LogicalSchemas.INTEGER).optional().build())
       .put(io.confluent.ksql.parser.tree.Map.of(PrimitiveType.of(SqlType.INTEGER)),

--- a/ksql-rest-app/src/main/java/io/confluent/ksql/rest/entity/SchemaInfo.java
+++ b/ksql-rest-app/src/main/java/io/confluent/ksql/rest/entity/SchemaInfo.java
@@ -30,6 +30,7 @@ public class SchemaInfo {
     DOUBLE,
     BOOLEAN,
     STRING,
+    DECIMAL,
     MAP,
     ARRAY,
     STRUCT
@@ -38,16 +39,19 @@ public class SchemaInfo {
   private final Type type;
   private final List<FieldInfo> fields;
   private final SchemaInfo memberSchema;
+  private final List<String> typeParameters;
 
   @JsonCreator
   public SchemaInfo(
       @JsonProperty("type") final Type type,
       @JsonProperty("fields") final List<FieldInfo> fields,
-      @JsonProperty("memberSchema") final SchemaInfo memberSchema) {
+      @JsonProperty("memberSchema") final SchemaInfo memberSchema,
+      @JsonProperty("typeParameters") final List<String> typeParameters) {
     Objects.requireNonNull(type);
     this.type = type;
     this.fields = fields;
     this.memberSchema = memberSchema;
+    this.typeParameters = typeParameters;
   }
 
   public Type getType() {
@@ -67,16 +71,21 @@ public class SchemaInfo {
     return Optional.ofNullable(memberSchema);
   }
 
+  public Optional<List<String>> getTypeParameters() {
+    return Optional.ofNullable(typeParameters);
+  }
+
   @Override
   public boolean equals(final Object other) {
     return other instanceof SchemaInfo
         && Objects.equals(type, ((SchemaInfo)other).type)
         && Objects.equals(fields, ((SchemaInfo)other).fields)
-        && Objects.equals(memberSchema, ((SchemaInfo)other).memberSchema);
+        && Objects.equals(memberSchema, ((SchemaInfo)other).memberSchema)
+        && Objects.equals(typeParameters, ((SchemaInfo)other).typeParameters);
   }
 
   @Override
   public int hashCode() {
-    return Objects.hash(type, fields, memberSchema);
+    return Objects.hash(type, fields, memberSchema, typeParameters);
   }
 }

--- a/ksql-rest-app/src/test/java/io/confluent/ksql/rest/entity/QueryDescriptionTest.java
+++ b/ksql-rest-app/src/test/java/io/confluent/ksql/rest/entity/QueryDescriptionTest.java
@@ -61,8 +61,8 @@ public class QueryDescriptionTest {
           .build();
 
   private static final List<FieldInfo> EXPECTED_FIELDS = Arrays.asList(
-      new FieldInfo("field1", new SchemaInfo(Type.INTEGER, null, null)),
-      new FieldInfo("field2", new SchemaInfo(Type.STRING, null, null)));
+      new FieldInfo("field1", new SchemaInfo(Type.INTEGER, null, null, null)),
+      new FieldInfo("field2", new SchemaInfo(Type.STRING, null, null, null)));
 
   private static final String STATEMENT = "statement";
   private static final Map<String, Object> STREAMS_PROPS = Collections.singletonMap("k1", "v1");

--- a/ksql-rest-app/src/test/java/io/confluent/ksql/rest/server/resources/streaming/WebSocketSubscriberTest.java
+++ b/ksql-rest-app/src/test/java/io/confluent/ksql/rest/server/resources/streaming/WebSocketSubscriberTest.java
@@ -128,9 +128,9 @@ public class WebSocketSubscriberTest {
     assertEquals(
         "[" +
             "{\"name\":\"currency\"," +
-            "\"schema\":{\"type\":\"STRING\",\"fields\":null,\"memberSchema\":null}}," +
+            "\"schema\":{\"type\":\"STRING\",\"fields\":null,\"memberSchema\":null,\"typeParameters\":null}}," +
             "{\"name\":\"amount\"," +
-            "\"schema\":{\"type\":\"DOUBLE\",\"fields\":null,\"memberSchema\":null}}]"
+            "\"schema\":{\"type\":\"DOUBLE\",\"fields\":null,\"memberSchema\":null,\"typeParameters\":null}}]"
         , schema.getValue());
     assertEquals("Unable to send schema", reason.getValue().getReasonPhrase());
     assertEquals(CloseCodes.PROTOCOL_ERROR, reason.getValue().getCloseCode());

--- a/ksql-rest-app/src/test/java/io/confluent/ksql/rest/util/EntityUtilTest.java
+++ b/ksql-rest-app/src/test/java/io/confluent/ksql/rest/util/EntityUtilTest.java
@@ -19,15 +19,20 @@ import static org.hamcrest.CoreMatchers.equalTo;
 import static org.junit.Assert.assertThat;
 
 import io.confluent.ksql.rest.entity.FieldInfo;
+
+import java.util.Arrays;
 import java.util.List;
 import java.util.Optional;
+
+import io.confluent.ksql.util.DecimalUtil;
 import org.apache.kafka.connect.data.Schema;
 import org.apache.kafka.connect.data.SchemaBuilder;
 import org.junit.Test;
 
 public class EntityUtilTest {
   private void shouldBuildCorrectPrimitiveField(final Schema primitiveSchema,
-                                                final String schemaName) {
+                                                final String schemaName,
+                                                final List<String> schemaParameters) {
     final Schema schema = SchemaBuilder
         .struct()
         .field("field", primitiveSchema)
@@ -40,31 +45,41 @@ public class EntityUtilTest {
     assertThat(entity.get(0).getSchema().getTypeName(), equalTo(schemaName));
     assertThat(entity.get(0).getSchema().getFields(), equalTo(Optional.empty()));
     assertThat(entity.get(0).getSchema().getMemberSchema(), equalTo(Optional.empty()));
+    assertThat(entity.get(0).getSchema().getTypeParameters(),
+        equalTo(Optional.ofNullable(schemaParameters)));
   }
 
   @Test
   public void shouldBuildCorrectIntegerField() {
-    shouldBuildCorrectPrimitiveField(Schema.INT32_SCHEMA, "INTEGER");
+    shouldBuildCorrectPrimitiveField(Schema.INT32_SCHEMA, "INTEGER", null);
   }
 
   @Test
   public void shouldBuildCorrectBigintField() {
-    shouldBuildCorrectPrimitiveField(Schema.INT64_SCHEMA, "BIGINT");
+    shouldBuildCorrectPrimitiveField(Schema.INT64_SCHEMA, "BIGINT", null);
   }
 
   @Test
   public void shouldBuildCorrectDoubleField() {
-    shouldBuildCorrectPrimitiveField(Schema.FLOAT64_SCHEMA, "DOUBLE");
+    shouldBuildCorrectPrimitiveField(Schema.FLOAT64_SCHEMA, "DOUBLE", null);
   }
 
   @Test
   public void shouldBuildCorrectStringField() {
-    shouldBuildCorrectPrimitiveField(Schema.STRING_SCHEMA, "STRING");
+    shouldBuildCorrectPrimitiveField(Schema.STRING_SCHEMA, "STRING", null);
   }
 
   @Test
   public void shouldBuildCorrectBooleanField() {
-    shouldBuildCorrectPrimitiveField(Schema.BOOLEAN_SCHEMA, "BOOLEAN");
+    shouldBuildCorrectPrimitiveField(Schema.BOOLEAN_SCHEMA, "BOOLEAN", null);
+  }
+
+  @Test
+  public void shouldBuildCorrectDecimalField() {
+    final int precision = 6;
+    final int scale = 2;
+    shouldBuildCorrectPrimitiveField(DecimalUtil.schema(precision, scale), "DECIMAL",
+        Arrays.asList(Integer.toString(precision), Integer.toString(scale)));
   }
 
   @Test

--- a/ksql-test-util/src/main/java/io/confluent/ksql/test/util/ImmutableTester.java
+++ b/ksql-test-util/src/main/java/io/confluent/ksql/test/util/ImmutableTester.java
@@ -36,6 +36,7 @@ import java.util.OptionalDouble;
 import java.util.OptionalInt;
 import java.util.OptionalLong;
 import java.util.Set;
+import java.util.function.Function;
 import java.util.function.Predicate;
 
 public final class ImmutableTester {
@@ -45,10 +46,12 @@ public final class ImmutableTester {
       .add(Class::isPrimitive)
       .add(Class::isEnum)
       .add(String.class::isAssignableFrom)
+      .add(Number.class::isAssignableFrom)
       .add(Optional.class::isAssignableFrom)
       .add(OptionalInt.class::isAssignableFrom)
       .add(OptionalLong.class::isAssignableFrom)
       .add(OptionalDouble.class::isAssignableFrom)
+      .add(Function.class::isAssignableFrom)
       .build();
 
   private final List<Predicate<Class<?>>> knownImmutables = new ArrayList<>(STD_IMMUTABLE_TYPES);


### PR DESCRIPTION
### Description 
This is part of https://github.com/confluentinc/ksql/issues/842 (DECIMAL types).

The code parses DECIMAL schema types from CREATE STREAM and CREATE TABLE statements. There is no other functionality than allowing a CREATE statement to use a DECIMAL schema and display the DECIMAL type when executing a DESCRIBE command.
```
ksql> create stream d1 (c1 decimal(6,2)) with (kafka_topic='d1', value_format='delimited');

 Message        
----------------
 Stream created 
----------------
ksql> describe d1;

Name                 : D1
 Field   | Type                      
-------------------------------------
 ROWTIME | BIGINT           (system) 
 ROWKEY  | VARCHAR(STRING)  (system) 
 C1      | DECIMAL(6,2)              
-------------------------------------
For runtime statistics and query details run: DESCRIBE EXTENDED <Stream,Table>;
ksql> 
```
A DECIMAL type requires two parameters: precision and scale. These two parameters define how a decimal type will be deserialized and presented by KSQL.

**`DECIMAL(p, s)`**

Where:
- precision (p) is an integer that represents the maximum number of digits allowed, including the digits to the left and right of the decimal point. Precision must be >= 1.
- scale (s) is an integer that represents the maximum number of digits allowed to the right of the decimal point. Scale must be >= 0 and <= Precision.

A DECIMAL type can also be specified as DEC. DEC is similar to DECIMAL as part of the SQL standard.
`create stream (c1 dec(6,2)) ...`

**How to review this PR**
Follow each commit to understand how this patch works:
1. it adds DECIMAL as part of the `PrimitiveType` class. It also makes the `PrimitiveType` accept type parameters and checks that only supported parameterized types are allowed.
2. it parses the DECIMAL type from the CREATE statements, and returns the DECIMAL schema to the REST client to be displayed on the CLI.
3. Fixes some test issues with the `ParserModelTest` that expects the `PrimitiveType` class has only immutable class variables and static methods throw NPE in case null values are used unless @Nullable is used.
4. Set some rules in the `PrimitiveType` when creating DECIMAL types (mentioned above).


### Testing done 
- Added unit tests
- Run manual tests with KSQL that checks that CREATE STREAM and CREATE TABLE can use DECIMAL types. I checked that you can use DECIMAL or DEC, and that the parameters follow the rules mentioned above. I checked that you can use DECIMAL types inside complex types.

### Reviewer checklist
- [ ] Ensure docs are updated if necessary. (eg. if a user visible feature is being added or changed).
- [ ] Ensure relevant issues are linked (description should include text like "Fixes #<issue number>")
