### PR TITLE
Minor: Add test covering a join that selects all fields from both sides of join

### DIFF
--- a/ksql-engine/src/test/resources/expected_topology/5_3_0_pre/joins_-_stream_stream_inner_join_all_fields
+++ b/ksql-engine/src/test/resources/expected_topology/5_3_0_pre/joins_-_stream_stream_inner_join_all_fields
@@ -1,0 +1,80 @@
+{
+  "ksql.extension.dir" : "ext",
+  "ksql.streams.cache.max.bytes.buffering" : "0",
+  "ksql.transient.prefix" : "transient_",
+  "ksql.named.internal.topics" : "on",
+  "ksql.windowed.session.key.legacy" : "false",
+  "ksql.schema.registry.url" : "http://localhost:8081",
+  "ksql.streams.default.deserialization.exception.handler" : "io.confluent.ksql.errors.LogMetricAndContinueExceptionHandler",
+  "ksql.output.topic.name.prefix" : "",
+  "ksql.streams.auto.offset.reset" : "earliest",
+  "ksql.sink.partitions" : null,
+  "ksql.avro.maps.named" : "true",
+  "ksql.service.id" : "some.ksql.service.id",
+  "ksql.streams.state.dir" : "/var/folders/2d/3pt97ylj3zngd51bwl91bl3r0000gp/T/kafka-3907136236469218310",
+  "ksql.internal.topic.replicas" : "1",
+  "ksql.streams.default.production.exception.handler" : "io.confluent.ksql.errors.ProductionExceptionHandlerUtil$LogAndFailProductionExceptionHandler",
+  "ksql.streams.bootstrap.servers" : "localhost:0",
+  "ksql.streams.commit.interval.ms" : "2000",
+  "ksql.streams.auto.commit.interval.ms" : "0",
+  "ksql.sink.replicas" : null,
+  "ksql.streams.topology.optimization" : "all",
+  "ksql.streams.num.stream.threads" : "4",
+  "ksql.udfs.enabled" : "true",
+  "ksql.udf.enable.security.manager" : "true",
+  "ksql.functions.substring.legacy.args" : "false",
+  "ksql.streams.application.id" : "some.ksql.service.id",
+  "ksql.sink.window.change.log.additional.retention" : "1000000",
+  "ksql.udf.collect.metrics" : "false",
+  "ksql.persistent.prefix" : "query_",
+  "ksql.query.persistent.active.limit" : "2147483647"
+}
+CONFIGS_END
+CSAS_INNER_JOIN_0.KafkaTopic_Left.source = struct<ID optional<int64>,NAME optional<string>>
+CSAS_INNER_JOIN_0.KafkaTopic_Right.source = struct<ID optional<int64>,F1 optional<string>>
+CSAS_INNER_JOIN_0.Join.left = struct<ROWTIME optional<int64>,ROWKEY optional<string>,ID optional<int64>,NAME optional<string>>
+CSAS_INNER_JOIN_0.Join.right = struct<ROWTIME optional<int64>,ROWKEY optional<string>,ID optional<int64>,F1 optional<string>>
+CSAS_INNER_JOIN_0.INNER_JOIN = struct<TT_ROWTIME optional<int64>,TT_ROWKEY optional<string>,TT_ID optional<int64>,TT_NAME optional<string>,T_ROWTIME optional<int64>,T_ROWKEY optional<string>,T_ID optional<int64>,T_F1 optional<string>>
+SCHEMAS_END
+Topologies:
+   Sub-topology: 0
+    Source: KSTREAM-SOURCE-0000000000 (topics: [left_topic])
+      --> KSTREAM-MAPVALUES-0000000001
+    Source: KSTREAM-SOURCE-0000000003 (topics: [right_topic])
+      --> KSTREAM-MAPVALUES-0000000004
+    Processor: KSTREAM-MAPVALUES-0000000001 (stores: [])
+      --> KSTREAM-TRANSFORMVALUES-0000000002
+      <-- KSTREAM-SOURCE-0000000000
+    Processor: KSTREAM-MAPVALUES-0000000004 (stores: [])
+      --> KSTREAM-TRANSFORMVALUES-0000000005
+      <-- KSTREAM-SOURCE-0000000003
+    Processor: KSTREAM-TRANSFORMVALUES-0000000002 (stores: [])
+      --> KSTREAM-WINDOWED-0000000006
+      <-- KSTREAM-MAPVALUES-0000000001
+    Processor: KSTREAM-TRANSFORMVALUES-0000000005 (stores: [])
+      --> KSTREAM-WINDOWED-0000000007
+      <-- KSTREAM-MAPVALUES-0000000004
+    Processor: KSTREAM-WINDOWED-0000000006 (stores: [KSTREAM-JOINTHIS-0000000008-store])
+      --> KSTREAM-JOINTHIS-0000000008
+      <-- KSTREAM-TRANSFORMVALUES-0000000002
+    Processor: KSTREAM-WINDOWED-0000000007 (stores: [KSTREAM-JOINOTHER-0000000009-store])
+      --> KSTREAM-JOINOTHER-0000000009
+      <-- KSTREAM-TRANSFORMVALUES-0000000005
+    Processor: KSTREAM-JOINOTHER-0000000009 (stores: [KSTREAM-JOINTHIS-0000000008-store])
+      --> KSTREAM-MERGE-0000000010
+      <-- KSTREAM-WINDOWED-0000000007
+    Processor: KSTREAM-JOINTHIS-0000000008 (stores: [KSTREAM-JOINOTHER-0000000009-store])
+      --> KSTREAM-MERGE-0000000010
+      <-- KSTREAM-WINDOWED-0000000006
+    Processor: KSTREAM-MERGE-0000000010 (stores: [])
+      --> KSTREAM-MAPVALUES-0000000011
+      <-- KSTREAM-JOINTHIS-0000000008, KSTREAM-JOINOTHER-0000000009
+    Processor: KSTREAM-MAPVALUES-0000000011 (stores: [])
+      --> KSTREAM-MAPVALUES-0000000012
+      <-- KSTREAM-MERGE-0000000010
+    Processor: KSTREAM-MAPVALUES-0000000012 (stores: [])
+      --> KSTREAM-SINK-0000000013
+      <-- KSTREAM-MAPVALUES-0000000011
+    Sink: KSTREAM-SINK-0000000013 (topic: INNER_JOIN)
+      <-- KSTREAM-MAPVALUES-0000000012
+

--- a/ksql-engine/src/test/resources/query-validation-tests/joins.json
+++ b/ksql-engine/src/test/resources/query-validation-tests/joins.json
@@ -1,12 +1,4 @@
 {
-  "comments": [
-    "You can specify multiple statements per test case, i.e., to set up the various streams needed",
-    "for joins etc, but currently only the final topology will be verified. This should be enough",
-    "for most tests as we can simulate the outputs from previous stages into the final stage. If we",
-    "take a modular approach to testing we can still verify that it all works correctly, i.e, if we",
-    "verify the output of a select or aggregate is correct, we can use simulated output to feed into",
-    "a join or another aggregate."
-  ],
   "tests": [
     {
       "name": "stream stream left join",
@@ -158,6 +150,38 @@
         {"topic": "INNER_JOIN", "key": 0, "value": {"T_ID": 0, "T_F1": "blah", "T_F2": 50, "T_ROWKEY": "0", "T_ROWTIME": 10000, "NAME": "zero"}, "timestamp": 10000},
         {"topic": "INNER_JOIN", "key": 0, "value": {"T_ID": 0, "T_F1": "blah", "T_F2": 50, "T_ROWKEY": "0", "T_ROWTIME": 10000, "NAME": "foo"}, "timestamp": 13000},
         {"topic": "INNER_JOIN", "key": 0, "value": {"T_ID": 0, "T_F1": "a", "T_F2": 10, "T_ROWKEY": "0", "T_ROWTIME": 15000, "NAME": "foo"}, "timestamp": 15000}
+      ]
+    },
+    {
+      "name": "stream stream inner join all fields",
+      "format": ["AVRO", "JSON"],
+      "statements": [
+        "CREATE STREAM TEST (ID bigint, NAME varchar) WITH (kafka_topic='left_topic', value_format='{FORMAT}', key='ID');",
+        "CREATE STREAM TEST_STREAM (ID bigint, F1 varchar) WITH (kafka_topic='right_topic', value_format='{FORMAT}', key='ID');",
+        "CREATE STREAM INNER_JOIN as SELECT * FROM test tt inner join TEST_STREAM t WITHIN 11 SECONDS ON t.id = tt.id;"
+      ],
+      "inputs": [
+        {"topic": "left_topic", "key": 0, "value": {"ID": 0, "NAME": "zero"}, "timestamp": 0},
+        {"topic": "right_topic", "key": 0, "value": {"ID": 0, "F1": "blah"}, "timestamp": 10000},
+        {"topic": "left_topic", "key": 10, "value": {"ID": 10, "NAME": "100"}, "timestamp": 11000},
+        {"topic": "left_topic", "key": 0, "value": {"ID": 0, "NAME": "foo"}, "timestamp": 13000},
+        {"topic": "right_topic", "key": 0, "value": {"ID": 0, "F1": "a"}, "timestamp": 15000},
+        {"topic": "right_topic", "key": 100, "value": {"ID": 100, "F1": "newblah"}, "timestamp": 16000},
+        {"topic": "left_topic", "key": 90, "value": {"ID": 90, "NAME": "ninety"}, "timestamp": 17000},
+        {"topic": "left_topic", "key": 0, "value": {"ID": 0, "NAME": "bar"}, "timestamp": 30000}
+      ],
+      "outputs": [
+        {"topic": "_confluent-ksql-some.ksql.service.idquery_CSAS_INNER_JOIN_0-KSTREAM-JOINTHIS-0000000008-store-changelog", "key": "0\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0001", "value": {"ROWTIME": 0, "ROWKEY": "0", "ID": 0, "NAME": "zero"}, "timestamp": 0},
+        {"topic": "_confluent-ksql-some.ksql.service.idquery_CSAS_INNER_JOIN_0-KSTREAM-JOINOTHER-0000000009-store-changelog", "key": "0\u0000\u0000\u0000\u0000\u0000\u0000'\u0010\u0000\u0000\u0000\u0001", "value": {"ROWTIME": 10000, "ROWKEY": "0", "ID": 0, "F1": "blah"}, "timestamp": 10000},
+        {"topic": "_confluent-ksql-some.ksql.service.idquery_CSAS_INNER_JOIN_0-KSTREAM-JOINTHIS-0000000008-store-changelog", "key": "10\u0000\u0000\u0000\u0000\u0000\u0000*�\u0000\u0000\u0000\u0002", "value": {"ROWTIME": 11000, "ROWKEY": "10", "ID": 10, "NAME": "100"}, "timestamp": 11000},
+        {"topic": "_confluent-ksql-some.ksql.service.idquery_CSAS_INNER_JOIN_0-KSTREAM-JOINTHIS-0000000008-store-changelog", "key": "0\u0000\u0000\u0000\u0000\u0000\u00002�\u0000\u0000\u0000\u0003", "value": {"ROWTIME": 13000, "ROWKEY": "0", "ID": 0, "NAME": "foo"}, "timestamp": 13000},
+        {"topic": "_confluent-ksql-some.ksql.service.idquery_CSAS_INNER_JOIN_0-KSTREAM-JOINOTHER-0000000009-store-changelog", "key": "0\u0000\u0000\u0000\u0000\u0000\u0000:�\u0000\u0000\u0000\u0002", "value": {"ROWTIME": 15000, "ROWKEY": "0", "ID": 0, "F1": "a"}, "timestamp": 15000},
+        {"topic": "_confluent-ksql-some.ksql.service.idquery_CSAS_INNER_JOIN_0-KSTREAM-JOINOTHER-0000000009-store-changelog", "key": "100\u0000\u0000\u0000\u0000\u0000\u0000>�\u0000\u0000\u0000\u0003", "value": {"ROWTIME": 16000, "ROWKEY": "100", "ID": 100, "F1": "newblah"}, "timestamp": 16000},
+        {"topic": "_confluent-ksql-some.ksql.service.idquery_CSAS_INNER_JOIN_0-KSTREAM-JOINTHIS-0000000008-store-changelog", "key": "90\u0000\u0000\u0000\u0000\u0000\u0000Bh\u0000\u0000\u0000\u0004", "value": {"ROWTIME": 17000, "ROWKEY": "90", "ID": 90, "NAME": "ninety"}, "timestamp": 17000},
+        {"topic": "_confluent-ksql-some.ksql.service.idquery_CSAS_INNER_JOIN_0-KSTREAM-JOINTHIS-0000000008-store-changelog", "key": "0\u0000\u0000\u0000\u0000\u0000\u0000u0\u0000\u0000\u0000\u0005", "value": {"ROWTIME": 30000, "ROWKEY": "0", "ID": 0, "NAME": "bar"}, "timestamp": 30000},
+        {"topic": "INNER_JOIN", "key": 0, "value": {"T_ID": 0, "T_F1": "blah", "T_ROWKEY": "0", "T_ROWTIME": 10000, "TT_ID": 0, "TT_NAME": "zero", "TT_ROWKEY": "0", "TT_ROWTIME": 0}, "timestamp": 10000},
+        {"topic": "INNER_JOIN", "key": 0, "value": {"T_ID": 0, "T_F1": "blah", "T_ROWKEY": "0", "T_ROWTIME": 10000, "TT_ID": 0, "TT_NAME": "foo", "TT_ROWKEY": "0", "TT_ROWTIME": 13000}, "timestamp": 13000},
+        {"topic": "INNER_JOIN", "key": 0, "value": {"T_ID": 0, "T_F1": "a", "T_ROWKEY": "0", "T_ROWTIME": 15000, "TT_ID": 0, "TT_NAME": "foo", "TT_ROWKEY": "0", "TT_ROWTIME": 13000}, "timestamp": 15000}
       ]
     },
     {


### PR DESCRIPTION
### Description 

New test to cover hole in current testing - test for join with `SELECT *` i.e. pulling in all fields from both sides of the join.

### Testing done 
Test only change.

### Reviewer checklist
- [ ] Ensure docs are updated if necessary. (eg. if a user visible feature is being added or changed).
- [ ] Ensure relevant issues are linked (description should include text like "Fixes #<issue number>")

