### PR TITLE
Minor: update default listener from localhost to 0.0.0.0

### DIFF
--- a/config/ksql-server.properties
+++ b/config/ksql-server.properties
@@ -17,14 +17,14 @@
 
 ### HTTP  ###
 # The URL the KSQL server will listen on:
-listeners=http://localhost:8088
+listeners=http://0.0.0.0:8088
 
 ### HTTPS ###
 # To switch KSQL over to communicating using HTTPS comment out the 'listeners' line above
 # uncomment and complete the properties below.
 # See: https://docs.confluent.io/current/ksql/docs/installation/server-config/security.html#configuring-ksql-cli-for-https
 #
-# listeners=https://localhost:8088
+# listeners=https://0.0.0.0:8088
 # ssl.keystore.location=?
 # ssl.keystore.password=?
 # ssl.key.password=?

--- a/docs/developer-guide/api.rst
+++ b/docs/developer-guide/api.rst
@@ -6,7 +6,7 @@ KSQL REST API Reference
 REST Endpoint
 ---------------------
 
-The default REST API endpoint is ``http://localhost:8088/``. 
+The default REST API endpoint is ``http://0.0.0.0:8088/``.
 
 Change the server configuration that controls the REST API endpoint by setting
 the ``listeners`` parameter in the KSQL server config file. For more info, see

--- a/docs/installation/installing.rst
+++ b/docs/installation/installing.rst
@@ -72,7 +72,7 @@ Follow these instructions to start KSQL server using the ``ksql-server-start`` s
     ::
 
         bootstrap.servers=localhost:9092
-        listeners=http://localhost:8088
+        listeners=http://0.0.0.0:8088
 
     For more information, see :ref:`ksql-server-config`.
 

--- a/docs/installation/server-config/config-reference.rst
+++ b/docs/installation/server-config/config-reference.rst
@@ -237,10 +237,10 @@ listeners
 ---------
 
 The ``listeners`` setting controls the REST API endpoint for the KSQL server.
-For more info, see :ref:`ksql-rest-api`. 
+For more info, see :ref:`ksql-rest-api`.
 
-Specify hostname as ``0.0.0.0`` to bind to all interfaces or leave it empty to
-bind to the default interface. For example:
+The default hostname is ``0.0.0.0`` which binds to all interfaces. Update this
+to a specific interface to bind only to a single interface. For example:
 
 ::
 

--- a/docs/operations.rst
+++ b/docs/operations.rst
@@ -158,7 +158,7 @@ setting:
 
 .. code:: bash
 
-    listeners=http://localhost:8088
+    listeners=http://0.0.0.0:8088
 
 For more info, see :ref:`Starting KSQL Server <start_ksql-server>`.
 

--- a/docs/troubleshoot-ksql.rst
+++ b/docs/troubleshoot-ksql.rst
@@ -170,7 +170,7 @@ setting in the file and verify it is set correctly.
 
 .. code:: text
 
-    listeners=http://localhost:8088
+    listeners=http://0.0.0.0:8088
 
 See :ref:`Starting KSQL Server <start_ksql-server>` for more information.
 

--- a/ksql-examples/src/main/resources/ksql-server.properties
+++ b/ksql-examples/src/main/resources/ksql-server.properties
@@ -21,4 +21,4 @@ command.topic.suffix=commands
 num.stream.threads=4
 commit.interval.ms=2000
 cache.max.bytes.buffering=2000000
-listeners=http://localhost:8088
+listeners=http://0.0.0.0:8088


### PR DESCRIPTION
### Description 

This PR updates the the default KSQL server config listener from localhost to 0.0.0.0, in order to prevent users from being tripped up when connecting KSQL and Confluent Control Center, even with the documentation [here](https://docs.confluent.io/current/ksql/docs/installation/server-config/integrate-ksql-with-confluent-control-center.html#when-ksql-and-c3-run-on-different-hosts). The drawback is that 0.0.0.0 is less secure than localhost, but there is precedent for defaulting to 0.0.0.0 in other components (e.g., in [Schema Registry](https://github.com/confluentinc/schema-registry/blob/87d505d7c7985da64feddadc20dcaf6b703ff503/config/schema-registry.properties#L22)) and users will need to switch away from either when working in a secure production environment anyway.

### Testing done 

Configs/docs-only change. Still works manually.

### Reviewer checklist
- [ ] Ensure docs are updated if necessary. (eg. if a user visible feature is being added or changed).
- [ ] Ensure relevant issues are linked (description should include text like "Fixes #<issue number>")

