### PR TITLE
(Backport to 4.1.x) add auto-retry to ZK failures

### DIFF
--- a/ksql-engine/src/test/java/io/confluent/ksql/integration/EndToEndIntegrationTest.java
+++ b/ksql-engine/src/test/java/io/confluent/ksql/integration/EndToEndIntegrationTest.java
@@ -25,6 +25,7 @@ import io.confluent.ksql.util.PersistentQueryMetadata;
 import io.confluent.ksql.util.QueryMetadata;
 import io.confluent.ksql.util.QueuedQueryMetadata;
 import io.confluent.ksql.util.UserDataProvider;
+import kafka.zookeeper.ZooKeeperClientException;
 import org.apache.kafka.clients.admin.AdminClient;
 import org.apache.kafka.clients.consumer.ConsumerConfig;
 import org.apache.kafka.common.utils.Utils;
@@ -33,6 +34,7 @@ import org.apache.kafka.test.IntegrationTest;
 import org.apache.kafka.test.TestUtils;
 import org.junit.After;
 import org.junit.Before;
+import org.junit.Rule;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
 import org.slf4j.Logger;
@@ -71,6 +73,9 @@ public class EndToEndIntegrationTest {
 
   private final String pageViewStream = "pageviews_original";
   private final String userTable = "users_original";
+
+  @Rule
+  public Retry retry = Retry.of(3, ZooKeeperClientException.class, 3, TimeUnit.SECONDS);
 
   @Before
   public void before() throws Exception {

--- a/ksql-engine/src/test/java/io/confluent/ksql/integration/Retry.java
+++ b/ksql-engine/src/test/java/io/confluent/ksql/integration/Retry.java
@@ -1,0 +1,136 @@
+/*
+ * Copyright 2019 Confluent Inc.
+ *
+ * Licensed under the Confluent Community License (the "License"; you may not use
+ * this file except in compliance with the License. You may obtain a copy of the
+ * License at
+ *
+ * http://www.confluent.io/confluent-community-license
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package io.confluent.ksql.integration;
+
+import java.util.concurrent.TimeUnit;
+import org.junit.rules.TestRule;
+import org.junit.runner.Description;
+import org.junit.runners.model.Statement;
+
+/**
+ * The {@code Retry} rule allows you to retry a test that
+ * throws a specific exception.
+ *
+ * <h3>Usage</h3>
+ *
+ * <pre>
+ * public class SimpleRetryTest {
+ *  &#064;Rule public Retry retry = Retry.none();
+ *
+ *  private int attemptCount = 0;
+ *
+ *  &#064;Test
+ *  public void noRetries() {
+ *    // this test will fail
+ *    throw new RuntimeException();
+ *  }
+ *
+ *  &#064;Test
+ *  public void retryOnce() {
+ *    retry.when(RuntimeException.class);
+ *    retry.upTo(1);
+ *
+ *    if (attemptCount == 0) {
+ *      // test will be retried the first time, and will succeed
+ *      // (not throw an exception) the second time
+ *      attemptCount++;
+ *      throw new RuntimeException();
+ *    }
+ *  }
+ * }
+ * </pre>
+ *
+ * <p>
+ * You have to add the {@code Retry} rule to your test; this does not
+ * affect your existing tests, as by default no retries will be added.
+ * To specify your retry rule, use the three method below:
+ *
+ * <ul>
+ *   <li>{@link #upTo(int)} denotes how many retries to attempt before
+ *   considering the test failed. The default is 0, which represents
+ *   no retries (attempt only once).</li>
+ *   <li>{@link #when(Class)} denotes on which exceptions to retry. The
+ *   default is {@link Throwable}.</li>
+ *   <li>{@link #withDelay(long, TimeUnit)} denotes how long to wait
+ *   between each retry. The default is 0MS.</li>
+ * </ul>
+ * These three can be combined in any combination, though without specifying
+ * {@link #upTo(int)} the behavior is identical to not using this Rule.
+ *
+ * @see org.junit.Rule
+ */
+public class Retry implements TestRule {
+
+  public static Retry none() {
+    return new Retry();
+  }
+
+  public static Retry of(
+      final int retries,
+      final Class<? extends Throwable> exception,
+      final long delay,
+      final TimeUnit unit) {
+    final Retry retry = new Retry();
+    retry.upTo(retries);
+    retry.when(exception);
+    retry.withDelay(delay, unit);
+    return retry;
+  }
+
+  private Class<? extends Throwable> exception = Throwable.class;
+  private int maxRetries = 0;
+  private long delay = 0;
+  private TimeUnit unit = TimeUnit.MILLISECONDS;
+
+  private Retry() { }
+
+  public void when(final Class<? extends Throwable> exception) {
+    this.exception = exception;
+  }
+
+  public void upTo(final int retries) {
+    this.maxRetries = retries;
+  }
+
+  public void withDelay(final long delay, final TimeUnit unit) {
+    this.unit = unit;
+    this.delay = delay;
+  }
+
+  @Override
+  public Statement apply(final Statement base, final Description description) {
+    return new Statement() {
+      @Override
+      public void evaluate() throws Throwable {
+        int retries = 0;
+
+        while (true) {
+          try {
+            base.evaluate();
+            return;
+          } catch (final Throwable e) {
+            retries++;
+            if (!(exception.isInstance(e)) || retries > maxRetries) {
+              throw e;
+            }
+            unit.sleep(delay);
+          }
+        }
+      }
+    };
+  }
+
+}

--- a/ksql-engine/src/test/java/io/confluent/ksql/integration/StreamsSelectAndProjectIntTest.java
+++ b/ksql-engine/src/test/java/io/confluent/ksql/integration/StreamsSelectAndProjectIntTest.java
@@ -4,6 +4,9 @@ import io.confluent.ksql.GenericRow;
 import io.confluent.ksql.KsqlContext;
 import io.confluent.ksql.serde.DataSource;
 import io.confluent.ksql.util.OrderDataProvider;
+import java.util.concurrent.TimeUnit;
+import kafka.zookeeper.ZooKeeperClientException;
+import kafka.zookeeper.ZooKeeperClientTimeoutException;
 import org.apache.kafka.clients.producer.RecordMetadata;
 import org.apache.kafka.common.serialization.StringDeserializer;
 import org.apache.kafka.connect.data.Schema;
@@ -12,6 +15,7 @@ import org.hamcrest.core.IsCollectionContaining;
 import org.junit.After;
 import org.junit.Assert;
 import org.junit.Before;
+import org.junit.Rule;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
 
@@ -38,6 +42,9 @@ public class StreamsSelectAndProjectIntTest {
   private final String avroStreamName = "orders_avro";
   private OrderDataProvider dataProvider;
 
+  @Rule
+  public Retry retry = Retry.of(3, ZooKeeperClientException.class, 3, TimeUnit.SECONDS);
+
   @Before
   public void before() throws Exception {
     testHarness = new IntegrationTestHarness();
@@ -63,7 +70,9 @@ public class StreamsSelectAndProjectIntTest {
 
   @After
   public void after() throws Exception {
-    ksqlContext.close();
+    if (ksqlContext != null) {
+      ksqlContext.close();
+    }
     testHarness.stop();
   }
 

--- a/ksql-engine/src/test/java/io/confluent/ksql/integration/UdfIntTest.java
+++ b/ksql-engine/src/test/java/io/confluent/ksql/integration/UdfIntTest.java
@@ -6,12 +6,15 @@ import io.confluent.ksql.serde.DataSource;
 import io.confluent.ksql.util.ItemDataProvider;
 import io.confluent.ksql.util.OrderDataProvider;
 import io.confluent.ksql.util.SchemaUtil;
+import java.util.concurrent.TimeUnit;
+import kafka.zookeeper.ZooKeeperClientException;
 import org.apache.kafka.clients.producer.RecordMetadata;
 import org.apache.kafka.common.serialization.StringDeserializer;
 import org.apache.kafka.connect.data.Schema;
 import org.apache.kafka.test.IntegrationTest;
 import org.junit.After;
 import org.junit.Before;
+import org.junit.Rule;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
 
@@ -42,6 +45,9 @@ public class UdfIntTest {
   private OrderDataProvider orderDataProvider;
   private ItemDataProvider itemDataProvider;
   String format = DataSource.DataSourceSerDe.JSON.name();
+
+  @Rule
+  public Retry retry = Retry.of(3, ZooKeeperClientException.class, 3, TimeUnit.SECONDS);
 
   @Before
   public void before() throws Exception {
@@ -75,7 +81,9 @@ public class UdfIntTest {
 
   @After
   public void after() throws Exception {
-    ksqlContext.close();
+    if (ksqlContext != null) {
+      ksqlContext.close();
+    }
     testHarness.stop();
   }
 

--- a/ksql-engine/src/test/java/io/confluent/ksql/integration/WindowingIntTest.java
+++ b/ksql-engine/src/test/java/io/confluent/ksql/integration/WindowingIntTest.java
@@ -8,6 +8,7 @@ import io.confluent.ksql.util.KafkaTopicClientImpl;
 import io.confluent.ksql.util.OrderDataProvider;
 import io.confluent.ksql.util.QueryMetadata;
 
+import kafka.zookeeper.ZooKeeperClientException;
 import org.apache.kafka.clients.admin.AdminClient;
 import org.apache.kafka.clients.admin.Config;
 import org.apache.kafka.clients.admin.ConfigEntry;
@@ -21,6 +22,7 @@ import org.apache.kafka.test.IntegrationTest;
 import org.apache.kafka.test.TestUtils;
 import org.junit.After;
 import org.junit.Before;
+import org.junit.Rule;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
 
@@ -47,6 +49,9 @@ public class WindowingIntTest {
   private OrderDataProvider dataProvider;
   private long now;
 
+  @Rule
+  public Retry retry = Retry.of(3, ZooKeeperClientException.class, 3, TimeUnit.SECONDS);
+
   @Before
   public void before() throws Exception {
     testHarness = new IntegrationTestHarness();
@@ -69,7 +74,9 @@ public class WindowingIntTest {
 
   @After
   public void after() throws Exception {
-    ksqlContext.close();
+    if (ksqlContext != null) {
+      ksqlContext.close();
+    }
     testHarness.stop();
   }
 


### PR DESCRIPTION
see #2620  - I removed the `RetryTest` because this version of Ksql did not import mockito and other things required to run it. I don't want to spend too much time doing random backports and this is a test-only change.