### PR TITLE
Create topics before executing commands

### DIFF
--- a/ksql-engine/src/main/java/io/confluent/ksql/analyzer/Analyzer.java
+++ b/ksql-engine/src/main/java/io/confluent/ksql/analyzer/Analyzer.java
@@ -139,7 +139,7 @@ class Analyzer {
     if (sink.getProperties().get(KsqlConstants.SINK_NUMBER_OF_PARTITIONS) != null) {
       final int numberOfPartitions =
           WithClauseUtil.parsePartitions(
-              sink.getProperties().get(KsqlConstants.SINK_NUMBER_OF_PARTITIONS));
+              sink.getProperties().get(KsqlConstants.SINK_NUMBER_OF_PARTITIONS).toString());
 
       analysis.getIntoProperties().put(
           KsqlConfig.SINK_NUMBER_OF_PARTITIONS_PROPERTY,
@@ -150,7 +150,7 @@ class Analyzer {
     if (sink.getProperties().get(KsqlConstants.SINK_NUMBER_OF_REPLICAS) != null) {
       final short numberOfReplications =
           WithClauseUtil.parseReplicas(
-              sink.getProperties().get(KsqlConstants.SINK_NUMBER_OF_REPLICAS));
+              sink.getProperties().get(KsqlConstants.SINK_NUMBER_OF_REPLICAS).toString());
       analysis.getIntoProperties()
           .put(KsqlConfig.SINK_NUMBER_OF_REPLICAS_PROPERTY, numberOfReplications);
     }

--- a/ksql-engine/src/main/java/io/confluent/ksql/topic/TopicProperties.java
+++ b/ksql-engine/src/main/java/io/confluent/ksql/topic/TopicProperties.java
@@ -114,11 +114,13 @@ public final class TopicProperties {
 
       final Expression partitionExp = withClause.get(KsqlConstants.SINK_NUMBER_OF_PARTITIONS);
       final Integer partitions = partitionExp == null
-          ? null : WithClauseUtil.parsePartitions(partitionExp.toString());
+          ? null
+          : WithClauseUtil.parsePartitions(partitionExp.toString());
 
       final Expression replicasExp = withClause.get(KsqlConstants.SINK_NUMBER_OF_REPLICAS);
       final Short replicas = replicasExp == null
-          ? null : WithClauseUtil.parseReplicas(replicasExp.toString());
+          ? null
+          : WithClauseUtil.parseReplicas(replicasExp.toString());
 
       fromWithClause = new TopicProperties(name, partitions, replicas);
       return this;
@@ -128,12 +130,12 @@ public final class TopicProperties {
       final Object partitionsObj = overrides.get(KsqlConfig.SINK_NUMBER_OF_PARTITIONS_PROPERTY);
       final Integer partitions = (partitionsObj instanceof Integer || partitionsObj == null)
           ? (Integer) partitionsObj
-          : WithClauseUtil.parsePartitions(partitionsObj.toString());
+          : (Integer) WithClauseUtil.parsePartitions(partitionsObj.toString());
 
       final Object replicasObj = overrides.get(KsqlConfig.SINK_NUMBER_OF_REPLICAS_PROPERTY);
       final Short replicas = (replicasObj instanceof Short || replicasObj == null)
           ? (Short) replicasObj
-          : WithClauseUtil.parseReplicas(replicasObj.toString());
+          : (Short) WithClauseUtil.parseReplicas(replicasObj.toString());
 
       fromOverrides = new TopicProperties(null, partitions, replicas);
       return this;

--- a/ksql-engine/src/main/java/io/confluent/ksql/topic/TopicProperties.java
+++ b/ksql-engine/src/main/java/io/confluent/ksql/topic/TopicProperties.java
@@ -112,20 +112,28 @@ public final class TopicProperties {
           ? null
           : StringUtils.strip(nameExpression.toString(), "'");
 
-      final Integer partitions =
-          WithClauseUtil.parsePartitions(withClause.get(KsqlConstants.SINK_NUMBER_OF_PARTITIONS));
-      final Short replicas =
-          WithClauseUtil.parseReplicas(withClause.get(KsqlConstants.SINK_NUMBER_OF_REPLICAS));
+      final Expression partitionExp = withClause.get(KsqlConstants.SINK_NUMBER_OF_PARTITIONS);
+      final Integer partitions = partitionExp == null
+          ? null : WithClauseUtil.parsePartitions(partitionExp.toString());
+
+      final Expression replicasExp = withClause.get(KsqlConstants.SINK_NUMBER_OF_REPLICAS);
+      final Short replicas = replicasExp == null
+          ? null : WithClauseUtil.parseReplicas(replicasExp.toString());
 
       fromWithClause = new TopicProperties(name, partitions, replicas);
       return this;
     }
 
     public Builder withOverrides(final Map<String, Object> overrides) {
-      final Integer partitions = (Integer) overrides.get(
-          KsqlConfig.SINK_NUMBER_OF_PARTITIONS_PROPERTY);
-      final Short replicas = (Short) overrides.get(
-          KsqlConfig.SINK_NUMBER_OF_REPLICAS_PROPERTY);
+      final Object partitionsObj = overrides.get(KsqlConfig.SINK_NUMBER_OF_PARTITIONS_PROPERTY);
+      final Integer partitions = (partitionsObj instanceof Integer || partitionsObj == null)
+          ? (Integer) partitionsObj
+          : WithClauseUtil.parsePartitions(partitionsObj.toString());
+
+      final Object replicasObj = overrides.get(KsqlConfig.SINK_NUMBER_OF_REPLICAS_PROPERTY);
+      final Short replicas = (replicasObj instanceof Short || replicasObj == null)
+          ? (Short) replicasObj
+          : WithClauseUtil.parseReplicas(replicasObj.toString());
 
       fromOverrides = new TopicProperties(null, partitions, replicas);
       return this;

--- a/ksql-engine/src/test/java/io/confluent/ksql/integration/JsonFormatTest.java
+++ b/ksql-engine/src/test/java/io/confluent/ksql/integration/JsonFormatTest.java
@@ -195,43 +195,6 @@ public class JsonFormatTest {
   }
 
   @Test
-  public void testSinkProperties() throws Exception {
-    final int resultPartitionCount = 3;
-    final String queryString = String.format("CREATE STREAM %s WITH (PARTITIONS = %d) AS SELECT * "
-            + "FROM %s;",
-        streamName, resultPartitionCount, inputStream);
-
-    executePersistentQuery(queryString);
-
-    TestUtils.waitForCondition(
-        () -> topicClient.isTopicExists(streamName),
-        "Wait for async topic creation"
-    );
-
-    assertThat(
-        topicClient.describeTopic(streamName).partitions(),
-        hasSize(3));
-    assertThat(topicClient.getTopicCleanupPolicy(streamName), equalTo(
-        KafkaTopicClient.TopicCleanupPolicy.DELETE));
-  }
-
-  @Test
-  public void testTableSinkCleanupProperty() throws Exception {
-    final String queryString = String.format("CREATE TABLE %s AS SELECT * "
-                                             + "FROM %s;",
-        streamName, usersTable);
-    executePersistentQuery(queryString);
-
-    TestUtils.waitForCondition(
-        () -> topicClient.isTopicExists(streamName),
-        "Wait for async topic creation"
-    );
-
-    assertThat(topicClient.getTopicCleanupPolicy(streamName), equalTo(
-        KafkaTopicClient.TopicCleanupPolicy.COMPACT));
-  }
-
-  @Test
   public void testJsonStreamExtractor() {
     final String queryString = String.format("CREATE STREAM %s AS SELECT EXTRACTJSONFIELD"
             + "(message, '$.log.cloud') "

--- a/ksql-engine/src/test/java/io/confluent/ksql/services/FakeKafkaTopicClient.java
+++ b/ksql-engine/src/test/java/io/confluent/ksql/services/FakeKafkaTopicClient.java
@@ -16,14 +16,17 @@
 package io.confluent.ksql.services;
 
 import static org.apache.kafka.common.config.TopicConfig.CLEANUP_POLICY_COMPACT;
+import static org.apache.kafka.common.config.TopicConfig.CLEANUP_POLICY_CONFIG;
 import static org.apache.kafka.common.config.TopicConfig.COMPRESSION_TYPE_CONFIG;
 
+import com.google.common.annotations.VisibleForTesting;
 import io.confluent.ksql.util.KsqlConstants;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Set;
 import java.util.function.Function;
 import java.util.stream.Collectors;
@@ -38,14 +41,14 @@ import org.apache.kafka.common.errors.UnknownTopicOrPartitionException;
  */
 public class FakeKafkaTopicClient implements KafkaTopicClient {
 
-  private static class FakeTopic {
+  public static class FakeTopic {
 
     private final String topicName;
     private final int numPartitions;
     private final int replicatonFactor;
     private final TopicCleanupPolicy cleanupPolicy;
 
-    private FakeTopic(final String topicName,
+    public FakeTopic(final String topicName,
         final int numPartitions,
         final int replicatonFactor,
         final TopicCleanupPolicy cleanupPolicy) {
@@ -68,6 +71,26 @@ public class FakeKafkaTopicClient implements KafkaTopicClient {
                   p -> new TopicPartitionInfo(p, node, replicas, Collections.emptyList()))
               .collect(Collectors.toList());
       return new TopicDescription(topicName, false, partitionInfoList);
+    }
+
+    @Override
+    public boolean equals(final Object o) {
+      if (this == o) {
+        return true;
+      }
+      if (o == null || getClass() != o.getClass()) {
+        return false;
+      }
+      final FakeTopic fakeTopic = (FakeTopic) o;
+      return numPartitions == fakeTopic.numPartitions
+          && replicatonFactor == fakeTopic.replicatonFactor
+          && Objects.equals(topicName, fakeTopic.topicName)
+          && cleanupPolicy == fakeTopic.cleanupPolicy;
+    }
+
+    @Override
+    public int hashCode() {
+      return Objects.hash(topicName, numPartitions, replicatonFactor, cleanupPolicy);
     }
   }
 
@@ -156,7 +179,7 @@ public class FakeKafkaTopicClient implements KafkaTopicClient {
 
   @Override
   public TopicCleanupPolicy getTopicCleanupPolicy(final String topicName) {
-    return null;
+    return topicMap.get(topicName).cleanupPolicy;
   }
 
   @Override
@@ -177,7 +200,7 @@ public class FakeKafkaTopicClient implements KafkaTopicClient {
       final Map<String, ?> configs
   ) {
     final TopicCleanupPolicy cleanUpPolicy =
-        CLEANUP_POLICY_COMPACT.equals(configs.get(COMPRESSION_TYPE_CONFIG))
+        CLEANUP_POLICY_COMPACT.equals(configs.get(CLEANUP_POLICY_CONFIG))
             ? TopicCleanupPolicy.COMPACT
             : TopicCleanupPolicy.DELETE;
 

--- a/ksql-engine/src/test/java/io/confluent/ksql/topic/DefaultTopicInjectorTest.java
+++ b/ksql-engine/src/test/java/io/confluent/ksql/topic/DefaultTopicInjectorTest.java
@@ -25,6 +25,7 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 import static org.mockito.hamcrest.MockitoHamcrest.argThat;
 
+import com.google.common.collect.ImmutableMap;
 import io.confluent.ksql.ddl.DdlConfig;
 import io.confluent.ksql.function.InternalFunctionRegistry;
 import io.confluent.ksql.metastore.MetaStoreImpl;
@@ -148,6 +149,37 @@ public class DefaultTopicInjectorTest {
 
     // Then:
     verify(builder).withName("X");
+  }
+
+  @Test
+  public void shouldGenerateNameWithCorrectPrefixFromOverrides() {
+    // Given:
+    givenStatement("CREATE STREAM x AS SELECT * FROM SOURCE;");
+    overrides.put(KsqlConfig.KSQL_OUTPUT_TOPIC_NAME_PREFIX_CONFIG, "prefix-");
+    config = new KsqlConfig(ImmutableMap.of(
+        KsqlConfig.KSQL_OUTPUT_TOPIC_NAME_PREFIX_CONFIG, "nope"
+    ));
+
+    // When:
+    injector.forStatement(statement, config, overrides, builder);
+
+    // Then:
+    verify(builder).withName("prefix-X");
+  }
+
+  @Test
+  public void shouldGenerateNameWithCorrectPrefixFromConfig() {
+    // Given:
+    givenStatement("CREATE STREAM x AS SELECT * FROM SOURCE;");
+    config = new KsqlConfig(ImmutableMap.of(
+        KsqlConfig.KSQL_OUTPUT_TOPIC_NAME_PREFIX_CONFIG, "prefix-"
+    ));
+
+    // When:
+    injector.forStatement(statement, config, overrides, builder);
+
+    // Then:
+    verify(builder).withName("prefix-X");
   }
 
   @Test

--- a/ksql-parser/src/main/java/io/confluent/ksql/util/WithClauseUtil.java
+++ b/ksql-parser/src/main/java/io/confluent/ksql/util/WithClauseUtil.java
@@ -21,7 +21,7 @@ public final class WithClauseUtil {
 
   private WithClauseUtil() { }
 
-  public static Integer parsePartitions(final String expression) {
+  public static int parsePartitions(final String expression) {
     try {
       final int partitions = Integer.parseInt(StringUtils.strip(expression, "'"));
       if (partitions <= 0) {
@@ -34,7 +34,7 @@ public final class WithClauseUtil {
     }
   }
 
-  public static Short parseReplicas(final String expression) {
+  public static short parseReplicas(final String expression) {
     try {
       final short replicas = Short.parseShort(StringUtils.strip(expression, "'"));
       if (replicas <= 0) {

--- a/ksql-parser/src/main/java/io/confluent/ksql/util/WithClauseUtil.java
+++ b/ksql-parser/src/main/java/io/confluent/ksql/util/WithClauseUtil.java
@@ -15,22 +15,15 @@
 
 package io.confluent.ksql.util;
 
-import io.confluent.ksql.parser.tree.Expression;
-import javax.annotation.Nullable;
 import org.apache.commons.lang3.StringUtils;
 
 public final class WithClauseUtil {
 
   private WithClauseUtil() { }
 
-  public static Integer parsePartitions(@Nullable final Expression expression) {
-    if (expression == null) {
-      return null;
-    }
-
-    final String expAsString = expression.toString();
+  public static Integer parsePartitions(final String expression) {
     try {
-      final int partitions = Integer.parseInt(StringUtils.strip(expAsString, "'"));
+      final int partitions = Integer.parseInt(StringUtils.strip(expression, "'"));
       if (partitions <= 0) {
         throw new KsqlException("Invalid number of partitions in WITH clause (must be positive): "
             + partitions);
@@ -41,14 +34,9 @@ public final class WithClauseUtil {
     }
   }
 
-  public static Short parseReplicas(@Nullable final Expression expression) {
-    if (expression == null) {
-      return null;
-    }
-
-    final String expAsString = expression.toString();
+  public static Short parseReplicas(final String expression) {
     try {
-      final short replicas = Short.parseShort(StringUtils.strip(expAsString, "'"));
+      final short replicas = Short.parseShort(StringUtils.strip(expression, "'"));
       if (replicas <= 0) {
         throw new KsqlException("Invalid number of replicas in WITH clause (must be positive): "
             + replicas);

--- a/ksql-parser/src/test/java/io/confluent/ksql/util/WithClauseUtilTest.java
+++ b/ksql-parser/src/test/java/io/confluent/ksql/util/WithClauseUtilTest.java
@@ -21,7 +21,7 @@ public class WithClauseUtilTest {
     final Expression expression = new IntegerLiteral(1);
 
     // When:
-    final int partitions = WithClauseUtil.parsePartitions(expression);
+    final int partitions = WithClauseUtil.parsePartitions(expression.toString());
 
     // Then:
     assertThat(partitions, equalTo(1));
@@ -33,7 +33,7 @@ public class WithClauseUtilTest {
     final Expression expression = new LongLiteral(1);
 
     // When:
-    final int partitions = WithClauseUtil.parsePartitions(expression);
+    final int partitions = WithClauseUtil.parsePartitions(expression.toString());
 
     // Then:
     assertThat(partitions, equalTo(1));
@@ -45,7 +45,7 @@ public class WithClauseUtilTest {
     final Expression expression = new StringLiteral("1");
 
     // When:
-    final int partitions = WithClauseUtil.parsePartitions(expression);
+    final int partitions = WithClauseUtil.parsePartitions(expression.toString());
 
     // Then:
     assertThat(partitions, equalTo(1));
@@ -61,7 +61,7 @@ public class WithClauseUtilTest {
     expectedException.expectMessage("Invalid number of partitions in WITH clause");
 
     // When:
-    WithClauseUtil.parsePartitions(expression);
+    WithClauseUtil.parsePartitions(expression.toString());
   }
 
   @Test
@@ -75,7 +75,7 @@ public class WithClauseUtilTest {
         "Invalid number of partitions in WITH clause");
 
     // When:
-    WithClauseUtil.parsePartitions(expression);
+    WithClauseUtil.parsePartitions(expression.toString());
   }
 
   @Test
@@ -89,7 +89,7 @@ public class WithClauseUtilTest {
         "Invalid number of partitions in WITH clause (must be positive)");
 
     // When:
-    WithClauseUtil.parsePartitions(expression);
+    WithClauseUtil.parsePartitions(expression.toString());
   }
 
   @Test
@@ -103,7 +103,7 @@ public class WithClauseUtilTest {
         "Invalid number of partitions in WITH clause (must be positive)");
 
     // When:
-    WithClauseUtil.parsePartitions(expression);
+    WithClauseUtil.parsePartitions(expression.toString());
   }
 
   @Test
@@ -117,7 +117,7 @@ public class WithClauseUtilTest {
         "Invalid number of partitions in WITH clause");
 
     // When:
-    WithClauseUtil.parsePartitions(expression);
+    WithClauseUtil.parsePartitions(expression.toString());
   }
 
   @Test
@@ -126,7 +126,7 @@ public class WithClauseUtilTest {
     final Expression expression = new IntegerLiteral(1);
 
     // When:
-    final short replicas = WithClauseUtil.parseReplicas(expression);
+    final short replicas = WithClauseUtil.parseReplicas(expression.toString());
 
     // Then:
     assertThat(replicas, equalTo((short) 1));
@@ -138,7 +138,7 @@ public class WithClauseUtilTest {
     final Expression expression = new LongLiteral(1);
 
     // When:
-    final short replicas = WithClauseUtil.parseReplicas(expression);
+    final short replicas = WithClauseUtil.parseReplicas(expression.toString());
 
     // Then:
     assertThat(replicas, equalTo((short) 1));
@@ -150,7 +150,7 @@ public class WithClauseUtilTest {
     final Expression expression = new StringLiteral("1");
 
     // When:
-    final short replicas = WithClauseUtil.parseReplicas(expression);
+    final short replicas = WithClauseUtil.parseReplicas(expression.toString());
 
     // Then:
     assertThat(replicas, equalTo((short) 1));
@@ -166,7 +166,7 @@ public class WithClauseUtilTest {
     expectedException.expectMessage("Invalid number of replicas in WITH clause");
 
     // When:
-    WithClauseUtil.parseReplicas(expression);
+    WithClauseUtil.parseReplicas(expression.toString());
   }
 
   @Test
@@ -180,7 +180,7 @@ public class WithClauseUtilTest {
         "Invalid number of replicas in WITH clause");
 
     // When:
-    WithClauseUtil.parseReplicas(expression);
+    WithClauseUtil.parseReplicas(expression.toString());
   }
 
   @Test
@@ -194,7 +194,7 @@ public class WithClauseUtilTest {
         "Invalid number of replicas in WITH clause (must be positive)");
 
     // When:
-    WithClauseUtil.parseReplicas(expression);
+    WithClauseUtil.parseReplicas(expression.toString());
   }
 
   @Test
@@ -208,7 +208,7 @@ public class WithClauseUtilTest {
         "Invalid number of replicas in WITH clause (must be positive)");
 
     // When:
-    WithClauseUtil.parseReplicas(expression);
+    WithClauseUtil.parseReplicas(expression.toString());
   }
 
   @Test
@@ -222,7 +222,7 @@ public class WithClauseUtilTest {
         "Invalid number of replicas in WITH clause");
 
     // When:
-    WithClauseUtil.parseReplicas(expression);
+    WithClauseUtil.parseReplicas(expression.toString());
   }
 
 }


### PR DESCRIPTION
### Description 
This PR refines KSQL's topic management story by moving topic creation outside of the physical plan construction. Topics are now _expected_ to already exist with the correct configuration at the time of physical plan construction. The physical plan won't fail if the topic does not exist, but the query will. This is equivalent to deleting a topic while a query is running.

### Compatibility Notes

* Any running queries will not be affected since the topic for them has already been created
* Any new queries will have the topic created for them before enqueuing the topic.
* Recovery will fail to issue a query if the topic that query outputs to was deleted. I think this is OK without introducing a config flag because it's likely an unintended consequence, and the metastore will still be properly working. NOTE that this would not affect headless mode since headless mode goes through the default topic injector.
* A failure may occur in the following (contrived) situation: Server A is upgraded and Server B is in the old version. B receives the CSAS statement, and enqueues it. Before B can then process this statement (creating the topic), A pulls the command and fails to execute it because the topic does not exist. I think this situation is unlikely enough that we can ignore it. The workaround for it is easy, create the topic manually or simply restart server A (at that point B should have already handled it and created the topic)

### Testing done 
* Unit testing
* CSAS via CLI to make sure that it still created the topic for me
* All tests that were removed were previously added into TopicPropertiesTest or DefaultTopicInjectorTest
```
ksql> SHOW TOPICS;

 Kafka Topic                 | Registered | Partitions | Partition Replicas | Consumers | ConsumerGroups
---------------------------------------------------------------------------------------------------------
 users                       | false      | 1          | 1                  | 0         | 0
---------------------------------------------------------------------------------------------------------
ksql> CREATE STREAM users (registertime bigint, userid varchar, regionid varchar, gender varchar) WITH (value_format = 'json', kafka_topic='users');

 Message
----------------
 Stream created
----------------
ksql> CREATE STREAM users2 AS SELECT * FROM users;

 Message
----------------------------
 Stream created and running
----------------------------
ksql> SHOW TOPICS;

 Kafka Topic                 | Registered | Partitions | Partition Replicas | Consumers | ConsumerGroups
---------------------------------------------------------------------------------------------------------
 users                       | true       | 1          | 1                  | 1         | 1
 USERS2                      | true       | 1          | 1                  | 0         | 0
---------------------------------------------------------------------------------------------------------
```

### Reviewer checklist
- [ ] Ensure docs are updated if necessary. (eg. if a user visible feature is being added or changed).
- [ ] Ensure relevant issues are linked (description should include text like "Fixes #<issue number>")

