### PR TITLE
KSQL-2422: Ensure command line schema registry URL is passed

### DIFF
--- a/ksql-examples/src/main/java/io/confluent/ksql/datagen/DataGen.java
+++ b/ksql-examples/src/main/java/io/confluent/ksql/datagen/DataGen.java
@@ -17,6 +17,8 @@ package io.confluent.ksql.datagen;
 
 import com.google.common.collect.ImmutableMap;
 import io.confluent.avro.random.generator.Generator;
+import io.confluent.ksql.util.KsqlConfig;
+
 import java.io.FileInputStream;
 import java.io.IOException;
 import java.io.InputStream;
@@ -72,10 +74,11 @@ public final class DataGen {
     );
   }
 
-  private static Properties getProperties(final Arguments arguments) throws IOException {
+  static Properties getProperties(final Arguments arguments) throws IOException {
     final Properties props = new Properties();
     props.put("bootstrap.servers", arguments.bootstrapServer);
     props.put("client.id", "KSQLDataGenProducer");
+    props.put(KsqlConfig.SCHEMA_REGISTRY_URL_PROPERTY, arguments.schemaRegistryUrl);
 
     if (arguments.propertiesFile != null) {
       props.load(arguments.propertiesFile);

--- a/ksql-examples/src/test/java/io/confluent/ksql/datagen/DataGenTest.java
+++ b/ksql-examples/src/test/java/io/confluent/ksql/datagen/DataGenTest.java
@@ -15,11 +15,17 @@
 
 package io.confluent.ksql.datagen;
 
+import static org.hamcrest.CoreMatchers.equalTo;
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.containsString;
 
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ExpectedException;
+
+import java.util.Properties;
+
+import io.confluent.ksql.util.KsqlConfig;
 
 public class DataGenTest {
   @Rule
@@ -61,5 +67,13 @@ public class DataGenTest {
         "quickstart=wtf",
         "format=avro",
         "topic=foo");
+  }
+
+  @Test
+  public void shouldPassSchemaRegistryUrl() throws Exception {
+    DataGen.Arguments args = new DataGen.Arguments(
+        false, "bootstrap", null, null, "topic", "key", 0, 0L, "srUrl", null);
+    Properties props = DataGen.getProperties(args);
+    assertThat(props.getProperty(KsqlConfig.SCHEMA_REGISTRY_URL_PROPERTY), equalTo("srUrl"));
   }
 }


### PR DESCRIPTION
Ensure command line schema registry URL is passed.

This is a regression caused by https://github.com/confluentinc/ksql/pull/2584