### PR TITLE
Make the output of usage of datagen prettier

### DIFF
--- a/ksql-examples/src/main/java/io/confluent/ksql/datagen/DataGen.java
+++ b/ksql-examples/src/main/java/io/confluent/ksql/datagen/DataGen.java
@@ -86,20 +86,23 @@ public final class DataGen {
   }
 
   private static void usage() {
+    final String newLine = System.lineSeparator();
     System.err.println(
-        "usage: DataGen "
-        + "[help] "
-        + "[bootstrap-server=<kafka bootstrap server(s)> (defaults to localhost:9092)] "
+        "usage: DataGen " + newLine
+        + "[help] " + newLine
+        + "[bootstrap-server=<kafka bootstrap server(s)> (defaults to localhost:9092)] " + newLine
         + "[quickstart=<quickstart preset> (case-insensitive; one of 'orders', 'users', or "
-        + "'pageviews')] "
-        + "schema=<avro schema file> "
-        + "[schemaRegistryUrl=<url for Confluent Schema Registry> (defaults to http://localhost:8081)] "
-        + "format=<message format> (case-insensitive; one of 'avro', 'json', or 'delimited') "
-        + "topic=<kafka topic name> "
-        + "key=<name of key column> "
-        + "[iterations=<number of rows> (defaults to 1,000,000)] "
-        + "[maxInterval=<Max time in ms between rows> (defaults to 500)] "
-        + "[propertiesFile=<file specifying Kafka client properties>]"
+        + "'pageviews')] " + newLine
+        + "schema=<avro schema file> " + newLine
+        + "[schemaRegistryUrl=<url for Confluent Schema Registry> "
+        + "(defaults to http://localhost:8081)] " + newLine
+        + "format=<message format> (case-insensitive; one of 'avro', 'json', or "
+        + "'delimited') " + newLine
+        + "topic=<kafka topic name> " + newLine
+        + "key=<name of key column> " + newLine
+        + "[iterations=<number of rows> (defaults to 1,000,000)] " + newLine
+        + "[maxInterval=<Max time in ms between rows> (defaults to 500)] " + newLine
+        + "[propertiesFile=<file specifying Kafka client properties>]" + newLine
     );
   }
 


### PR DESCRIPTION
### Description 
Add some simple newlines to make the usage output for the datagen cli
more readable. The new output looks like this:
```usage: DataGen 
[help]
[bootstrap-server=<kafka bootstrap server(s)> (defaults to localhost:9092)]
[quickstart=<quickstart preset> (case-insensitive; one of 'orders', 'users', or 'pageviews')] 
schema=<avro schema file> 
[schemaRegistryUrl=<url for Confluent Schema Registry> (defaults to http://localhost:8081)]
format=<message format> (case-insensitive; one of 'avro', 'json', or 'delimited')
topic=<kafka topic name>  
key=<name of key column> 
[iterations=<number of rows> (defaults to 1,000,000)] 
[maxInterval=<Max time in ms between rows> (defaults to 500)] 
[propertiesFile=<file specifying Kafka client properties>
```

### Testing done 
_Describe the testing strategy. Unit and integration tests are expected for any behavior changes._

### Reviewer checklist
- [ ] Ensure docs are updated if necessary. (eg. if a user visible feature is being added or changed).
- [ ] Ensure relevant issues are linked (description should include text like "Fixes #<issue number>")

