### PR TITLE
Minor: do not install/deploy benchmark module

### DIFF
--- a/ksql-benchmark/pom.xml
+++ b/ksql-benchmark/pom.xml
@@ -107,6 +107,22 @@ questions.
       </plugin>
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-deploy-plugin</artifactId>
+        <version>3.0.0-M1</version>
+        <configuration>
+          <skip>true</skip>
+        </configuration>
+      </plugin>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-install-plugin</artifactId>
+        <version>3.0.0-M1</version>
+        <configuration>
+          <skip>true</skip>
+        </configuration>
+      </plugin>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-shade-plugin</artifactId>
         <version>2.0</version>
         <executions>

--- a/ksql-benchmark/pom.xml
+++ b/ksql-benchmark/pom.xml
@@ -108,7 +108,7 @@ questions.
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-deploy-plugin</artifactId>
-        <version>3.0.0-M1</version>
+        <version>${maven.plugins.version}</version>
         <configuration>
           <skip>true</skip>
         </configuration>
@@ -116,7 +116,7 @@ questions.
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-install-plugin</artifactId>
-        <version>3.0.0-M1</version>
+        <version>${maven.plugins.version}</version>
         <configuration>
           <skip>true</skip>
         </configuration>

--- a/pom.xml
+++ b/pom.xml
@@ -100,6 +100,7 @@
         <jline.version>3.9.0</jline.version>
         <jna.version>4.4.0</jna.version>
         <jsr305.version>3.0.2</jsr305.version>
+        <maven.plugins.version>3.0.0-M1</maven.plugins.version>
         <really.executable.jar.version>1.5.0</really.executable.jar.version>
         <generext.version>1.0.2</generext.version>
         <avro.random.generator.version>0.2.2</avro.random.generator.version>


### PR DESCRIPTION
### Description 

There's no reason to ever install or deploy the ksql-benchmark module, so this PR disables those maven goals for the module accordingly.

### Testing done 

Manually verified that the benchmarks jar is no longer installed.

### Reviewer checklist
- [ ] Ensure docs are updated if necessary. (eg. if a user visible feature is being added or changed).
- [ ] Ensure relevant issues are linked (description should include text like "Fixes #<issue number>")

