### PR TITLE
add @Sandbox annotation to ensure that some calls are sandboxed

### DIFF
--- a/ksql-engine/src/main/java/io/confluent/ksql/engine/SandboxedExecutionContext.java
+++ b/ksql-engine/src/main/java/io/confluent/ksql/engine/SandboxedExecutionContext.java
@@ -24,6 +24,7 @@ import io.confluent.ksql.query.QueryId;
 import io.confluent.ksql.services.ServiceContext;
 import io.confluent.ksql.statement.ConfiguredStatement;
 import io.confluent.ksql.util.PersistentQueryMetadata;
+import io.confluent.ksql.util.Sandbox;
 import java.util.List;
 import java.util.Optional;
 
@@ -31,6 +32,7 @@ import java.util.Optional;
  * An execution context that can execute statements without changing the core engine's state
  * or the state of external services.
  */
+@Sandbox
 final class SandboxedExecutionContext implements KsqlExecutionContext {
 
   private final EngineContext engineContext;

--- a/ksql-engine/src/main/java/io/confluent/ksql/services/SandboxedServiceContext.java
+++ b/ksql-engine/src/main/java/io/confluent/ksql/services/SandboxedServiceContext.java
@@ -16,6 +16,7 @@
 package io.confluent.ksql.services;
 
 import io.confluent.kafka.schemaregistry.client.SchemaRegistryClient;
+import io.confluent.ksql.util.Sandbox;
 import java.util.Objects;
 import java.util.function.Supplier;
 import org.apache.kafka.clients.admin.AdminClient;
@@ -26,6 +27,7 @@ import org.apache.kafka.streams.KafkaClientSupplier;
  *
  * <p>The service clients within will not make changes to the external services they connect to.
  */
+@Sandbox
 public final class SandboxedServiceContext implements ServiceContext {
 
   private final KafkaTopicClient topicClient;

--- a/ksql-engine/src/main/java/io/confluent/ksql/util/Sandbox.java
+++ b/ksql-engine/src/main/java/io/confluent/ksql/util/Sandbox.java
@@ -1,0 +1,31 @@
+/*
+ * Copyright 2019 Confluent Inc.
+ *
+ * Licensed under the Confluent Community License (the "License"; you may not use
+ * this file except in compliance with the License. You may obtain a copy of the
+ * License at
+ *
+ * http://www.confluent.io/confluent-community-license
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package io.confluent.ksql.util;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/**
+ * Indicates that the target class is a Sandbox, and any invocations on this
+ * instance will not affect the core engine state.
+ *
+ * @see SandboxUtil
+ */
+@Target(ElementType.TYPE)
+@Retention(RetentionPolicy.RUNTIME)
+public @interface Sandbox { }

--- a/ksql-engine/src/main/java/io/confluent/ksql/util/SandboxUtil.java
+++ b/ksql-engine/src/main/java/io/confluent/ksql/util/SandboxUtil.java
@@ -15,8 +15,6 @@
 
 package io.confluent.ksql.util;
 
-import javax.annotation.Nonnull;
-
 public final class SandboxUtil {
 
   private SandboxUtil() { }
@@ -28,7 +26,7 @@ public final class SandboxUtil {
    * @throws IllegalArgumentException if {@code object} is not an instance of a class that
    *                                  is annotated with {@link Sandbox}
    */
-  public static <T> T requireSandbox(@Nonnull final T object) {
+  public static <T> T requireSandbox(final T object) {
     if (object.getClass().isAnnotationPresent(Sandbox.class)) {
       return object;
     }

--- a/ksql-engine/src/main/java/io/confluent/ksql/util/SandboxUtil.java
+++ b/ksql-engine/src/main/java/io/confluent/ksql/util/SandboxUtil.java
@@ -1,0 +1,38 @@
+/*
+ * Copyright 2019 Confluent Inc.
+ *
+ * Licensed under the Confluent Community License (the "License"; you may not use
+ * this file except in compliance with the License. You may obtain a copy of the
+ * License at
+ *
+ * http://www.confluent.io/confluent-community-license
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package io.confluent.ksql.util;
+
+import javax.annotation.Nonnull;
+
+public final class SandboxUtil {
+
+  private SandboxUtil() { }
+
+  /**
+   * @param object the object to check
+   * @return the object that was passed in
+   *
+   * @throws IllegalArgumentException if {@code object} is not an instance of a class that
+   *                                  is annotated with {@link Sandbox}
+   */
+  public static <T> T requireSandbox(@Nonnull final T object) {
+    if (object.getClass().isAnnotationPresent(Sandbox.class)) {
+      return object;
+    }
+    throw new IllegalArgumentException("Expected sandbox but got: " + object.getClass());
+  }
+
+}

--- a/ksql-rest-app/src/main/java/io/confluent/ksql/rest/server/validation/RequestValidator.java
+++ b/ksql-rest-app/src/main/java/io/confluent/ksql/rest/server/validation/RequestValidator.java
@@ -15,6 +15,7 @@
 
 package io.confluent.ksql.rest.server.validation;
 
+import static io.confluent.ksql.util.SandboxUtil.requireSandbox;
 import static java.util.Objects.requireNonNull;
 
 import io.confluent.ksql.KsqlExecutionContext;
@@ -79,7 +80,7 @@ public class RequestValidator {
     this.schemaInjectorFactory = requireNonNull(schemaInjectorFactory, "schemaInjector");
     this.topicInjectorFactory = requireNonNull(topicInjectorFactory, "topicInjectorFactory");
     this.snapshotSupplier = requireNonNull(snapshotSupplier, "snapshotSupplier");
-    this.serviceContext = requireNonNull(serviceContext, "serviceContext");
+    this.serviceContext = requireSandbox(requireNonNull(serviceContext, "serviceContext"));
     this.ksqlConfig = requireNonNull(ksqlConfig, "ksqlConfig");
   }
 
@@ -103,7 +104,7 @@ public class RequestValidator {
       final String sql
   ) {
     validateOverriddenConfigProperties(propertyOverrides);
-    final KsqlExecutionContext ctx = snapshotSupplier.get();
+    final KsqlExecutionContext ctx = requireSandbox(snapshotSupplier.get());
     final Injector schemaInjector = schemaInjectorFactory.apply(serviceContext);
     final Injector topicInjector = topicInjectorFactory.apply(ctx);
 

--- a/ksql-rest-app/src/test/java/io/confluent/ksql/rest/server/resources/KsqlResourceTest.java
+++ b/ksql-rest-app/src/test/java/io/confluent/ksql/rest/server/resources/KsqlResourceTest.java
@@ -127,6 +127,7 @@ import io.confluent.ksql.util.KsqlException;
 import io.confluent.ksql.util.KsqlStatementException;
 import io.confluent.ksql.util.PersistentQueryMetadata;
 import io.confluent.ksql.util.QueryMetadata;
+import io.confluent.ksql.util.Sandbox;
 import io.confluent.ksql.util.timestamp.MetadataTimestampExtractionPolicy;
 import io.confluent.ksql.version.metrics.ActivenessRegistrar;
 import io.confluent.rest.RestConfig;
@@ -223,7 +224,7 @@ public class KsqlResourceTest {
   private KsqlEngine realEngine;
   private KsqlEngine ksqlEngine;
   @Mock
-  private KsqlExecutionContext sandbox;
+  private SandboxEngine sandbox;
   @Mock
   private CommandStore commandStore;
   @Mock
@@ -1999,4 +2000,7 @@ public class KsqlResourceTest {
     when(queries.size()).thenReturn(value);
     when(sandbox.getPersistentQueries()).thenReturn(queries);
   }
+
+  @Sandbox
+  private interface SandboxEngine extends KsqlExecutionContext { }
 }


### PR DESCRIPTION
### Description 
Adds an annotation `@Sandbox` which will allow us to check to make sure that we are getting Sandbox clients at certain call sites - specifically the validation work on the rest server.

This addresses @rodesai's comment on #2634.

### Testing done 
- Unit testing

### Reviewer checklist
- [ ] Ensure docs are updated if necessary. (eg. if a user visible feature is being added or changed).
- [ ] Ensure relevant issues are linked (description should include text like "Fixes #<issue number>")

