### PR TITLE
Add cause for errors logged to processing log

### DIFF
--- a/docs/developer-guide/processing-log.rst
+++ b/docs/developer-guide/processing-log.rst
@@ -212,9 +212,11 @@ You can also create the stream yourself by issuing the following DDL:
                  `TYPE` INTEGER,
                  deserializationError STRUCT<
                      errorMessage STRING,
+                     cause ARRAY<STRING>,
                      recordB64 STRING>,
                  recordProcessingError STRUCT<
                      errorMessage STRING,
+                     cause ARRAY<STRING>,
                      record STRING>,
                  productionError STRUCT<
                      errorMessage STRING>>)

--- a/ksql-common/src/main/java/io/confluent/ksql/logging/processing/ProcessingLogMessageSchema.java
+++ b/ksql-common/src/main/java/io/confluent/ksql/logging/processing/ProcessingLogMessageSchema.java
@@ -21,23 +21,30 @@ import org.apache.kafka.connect.data.SchemaBuilder;
 public final class ProcessingLogMessageSchema {
   private static final String NAMESPACE = "io.confluent.ksql.logging.processing.";
 
+  private static final Schema CAUSE_SCHEMA =
+      SchemaBuilder.array(Schema.OPTIONAL_STRING_SCHEMA).optional().build();
+
   public static final String DESERIALIZATION_ERROR_FIELD_MESSAGE = "errorMessage";
   public static final String DESERIALIZATION_ERROR_FIELD_RECORD_B64 = "recordB64";
+  public static final String DESERIALIZATION_ERROR_FIELD_CAUSE = "cause";
 
   private static final Schema DESERIALIZATION_ERROR_SCHEMA = SchemaBuilder.struct()
       .name(NAMESPACE + "DeserializationError")
       .field(DESERIALIZATION_ERROR_FIELD_MESSAGE, Schema.OPTIONAL_STRING_SCHEMA)
       .field(DESERIALIZATION_ERROR_FIELD_RECORD_B64, Schema.OPTIONAL_STRING_SCHEMA)
+      .field(DESERIALIZATION_ERROR_FIELD_CAUSE, CAUSE_SCHEMA)
       .optional()
       .build();
 
   public static final String RECORD_PROCESSING_ERROR_FIELD_MESSAGE = "errorMessage";
   public static final String RECORD_PROCESSING_ERROR_FIELD_RECORD = "record";
+  public static final String RECORD_PROCESSING_ERROR_FIELD_CAUSE = "cause";
 
   private static final Schema RECORD_PROCESSING_ERROR_SCHEMA = SchemaBuilder.struct()
       .name(NAMESPACE + "RecordProcessingError")
       .field(RECORD_PROCESSING_ERROR_FIELD_MESSAGE, Schema.OPTIONAL_STRING_SCHEMA)
       .field(RECORD_PROCESSING_ERROR_FIELD_RECORD, Schema.OPTIONAL_STRING_SCHEMA)
+      .field(RECORD_PROCESSING_ERROR_FIELD_CAUSE, CAUSE_SCHEMA)
       .optional()
       .build();
 

--- a/ksql-common/src/main/java/io/confluent/ksql/util/ErrorMessageUtil.java
+++ b/ksql-common/src/main/java/io/confluent/ksql/util/ErrorMessageUtil.java
@@ -54,6 +54,18 @@ public final class ErrorMessageUtil {
     return causeMsg.isEmpty() ? msg : msg + System.lineSeparator() + causeMsg;
   }
 
+  /**
+   * Build a list containing the error message for each throwable in the chain.
+   *
+   * @param e the top level error.
+   * @return the list of error messages.
+   */
+  public static List<String> getErrorMessages(final Throwable e) {
+    return getThrowables(e).stream()
+        .map(ErrorMessageUtil::getErrorMessage)
+        .collect(Collectors.toList());
+  }
+
   private static String getErrorMessage(final Throwable e) {
     if (e instanceof ConnectException) {
       return "Could not connect to the server.";
@@ -70,12 +82,6 @@ public final class ErrorMessageUtil {
       cause = cause.getCause();
     }
     return list;
-  }
-
-  private static List<String> getErrorMessages(final Throwable e) {
-    return getThrowables(e).stream()
-        .map(ErrorMessageUtil::getErrorMessage)
-        .collect(Collectors.toList());
   }
 
   private static void dedup(final List<String> messages) {

--- a/ksql-common/src/test/java/io/confluent/ksql/util/ErrorMessageUtilTest.java
+++ b/ksql-common/src/test/java/io/confluent/ksql/util/ErrorMessageUtilTest.java
@@ -16,9 +16,12 @@
 package io.confluent.ksql.util;
 
 import static io.confluent.ksql.util.ErrorMessageUtil.buildErrorMessage;
+import static io.confluent.ksql.util.ErrorMessageUtil.getErrorMessages;
+import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
 
+import com.google.common.collect.ImmutableList;
 import java.net.ConnectException;
 import java.sql.SQLDataException;
 import org.junit.Test;
@@ -112,6 +115,15 @@ public class ErrorMessageUtilTest {
         is("Top level" + System.lineSeparator()
            + "Caused by: Something went wrong")
     );
+  }
+
+  @Test
+  public void shouldBuildErrorMessageChain() {
+    // Given:
+    final Throwable e = new Exception("root", new Exception("cause"));
+
+    // Then:
+    assertThat(getErrorMessages(e), equalTo(ImmutableList.of("root", "cause")));
   }
 
   private static class TestException extends Exception {

--- a/ksql-engine/src/main/java/io/confluent/ksql/structured/SelectValueMapper.java
+++ b/ksql-engine/src/main/java/io/confluent/ksql/structured/SelectValueMapper.java
@@ -71,6 +71,7 @@ class SelectValueMapper implements ValueMapper<GenericRow, GenericRow> {
       processingLogger.error(
           EngineProcessingLogMessageFactory.recordProcessingError(
               errorMsg,
+              e,
               row
           )
       );

--- a/ksql-engine/src/main/java/io/confluent/ksql/structured/SqlPredicate.java
+++ b/ksql-engine/src/main/java/io/confluent/ksql/structured/SqlPredicate.java
@@ -182,6 +182,7 @@ public class SqlPredicate {
                 filterExpression,
                 e.getMessage()
             ),
+            e,
             row
         )
     );

--- a/ksql-engine/src/main/java/io/confluent/ksql/util/EngineProcessingLogMessageFactory.java
+++ b/ksql-engine/src/main/java/io/confluent/ksql/util/EngineProcessingLogMessageFactory.java
@@ -20,6 +20,7 @@ import io.confluent.ksql.json.JsonMapper;
 import io.confluent.ksql.logging.processing.ProcessingLogConfig;
 import io.confluent.ksql.logging.processing.ProcessingLogMessageSchema;
 import io.confluent.ksql.logging.processing.ProcessingLogMessageSchema.MessageType;
+import java.util.List;
 import java.util.function.Function;
 import org.apache.kafka.connect.data.SchemaAndValue;
 import org.apache.kafka.connect.data.Struct;
@@ -35,6 +36,7 @@ public final class EngineProcessingLogMessageFactory {
 
   public static Function<ProcessingLogConfig, SchemaAndValue> recordProcessingError(
       final String errorMsg,
+      final Throwable exception,
       final GenericRow record
   ) {
     return (config) -> {
@@ -46,6 +48,12 @@ public final class EngineProcessingLogMessageFactory {
       recordProcessingError.put(
           ProcessingLogMessageSchema.RECORD_PROCESSING_ERROR_FIELD_MESSAGE,
           errorMsg);
+      final List<String> cause = ErrorMessageUtil.getErrorMessages(exception);
+      cause.remove(0);
+      recordProcessingError.put(
+          ProcessingLogMessageSchema.RECORD_PROCESSING_ERROR_FIELD_CAUSE,
+          cause
+      );
       if (record == null) {
         return new SchemaAndValue(ProcessingLogMessageSchema.PROCESSING_LOG_SCHEMA, struct);
       }

--- a/ksql-engine/src/test/java/io/confluent/ksql/util/EngineProcessingLogMessageFactoryTest.java
+++ b/ksql-engine/src/test/java/io/confluent/ksql/util/EngineProcessingLogMessageFactoryTest.java
@@ -21,6 +21,8 @@ import org.junit.Test;
 public class EngineProcessingLogMessageFactoryTest {
   private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper();
   private static final String errorMsg = "error msg";
+  private static final Throwable cause = new Exception("cause1", new Exception("cause2"));
+  private static final Throwable error = new Exception(errorMsg, cause);
 
   private final ProcessingLogConfig config = new ProcessingLogConfig(
       Collections.singletonMap(ProcessingLogConfig.INCLUDE_ROWS,  true)
@@ -31,7 +33,7 @@ public class EngineProcessingLogMessageFactoryTest {
   public void shouldBuildRecordProcessingErrorCorrectly() throws IOException {
     // When:
     final SchemaAndValue msgAndSchema = EngineProcessingLogMessageFactory.recordProcessingError(
-        errorMsg, new GenericRow(123, "data")
+        errorMsg, error, new GenericRow(123, "data")
     ).apply(config);
 
     // Then:
@@ -47,6 +49,10 @@ public class EngineProcessingLogMessageFactoryTest {
         recordProcessingError.get(
             ProcessingLogMessageSchema.RECORD_PROCESSING_ERROR_FIELD_MESSAGE),
         equalTo(errorMsg));
+    assertThat(
+        recordProcessingError.get(
+            ProcessingLogMessageSchema.RECORD_PROCESSING_ERROR_FIELD_CAUSE),
+        equalTo(ErrorMessageUtil.getErrorMessages(cause)));
     final List<Object> rowAsList =
         OBJECT_MAPPER.readValue(
             recordProcessingError.getString(
@@ -60,7 +66,7 @@ public class EngineProcessingLogMessageFactoryTest {
   public void shouldBuildRecordProcessingErrorCorrectlyIfRowNull() {
     // When:
     final SchemaAndValue msgAndSchema = EngineProcessingLogMessageFactory.recordProcessingError(
-        errorMsg, null
+        errorMsg, error, null
     ).apply(config);
 
     // Then:
@@ -82,7 +88,7 @@ public class EngineProcessingLogMessageFactoryTest {
 
     // When:
     final SchemaAndValue msgAndSchema = EngineProcessingLogMessageFactory.recordProcessingError(
-        errorMsg, new GenericRow(123, "data")
+        errorMsg, error, new GenericRow(123, "data")
     ).apply(config);
 
     // Then:

--- a/ksql-serde/src/main/java/io/confluent/ksql/serde/util/SerdeProcessingLogMessageFactory.java
+++ b/ksql-serde/src/main/java/io/confluent/ksql/serde/util/SerdeProcessingLogMessageFactory.java
@@ -18,7 +18,9 @@ package io.confluent.ksql.serde.util;
 import io.confluent.ksql.logging.processing.ProcessingLogConfig;
 import io.confluent.ksql.logging.processing.ProcessingLogMessageSchema;
 import io.confluent.ksql.logging.processing.ProcessingLogMessageSchema.MessageType;
+import io.confluent.ksql.util.ErrorMessageUtil;
 import java.util.Base64;
+import java.util.List;
 import java.util.Objects;
 import java.util.Optional;
 import java.util.function.Function;
@@ -40,6 +42,12 @@ public final class SerdeProcessingLogMessageFactory {
       deserializationError.put(
           ProcessingLogMessageSchema.DESERIALIZATION_ERROR_FIELD_MESSAGE,
           exception.getMessage());
+      final List<String> cause = ErrorMessageUtil.getErrorMessages(exception);
+      cause.remove(0);
+      deserializationError.put(
+          ProcessingLogMessageSchema.DESERIALIZATION_ERROR_FIELD_CAUSE,
+          cause
+      );
       if (config.getBoolean(ProcessingLogConfig.INCLUDE_ROWS)) {
         deserializationError.put(
             ProcessingLogMessageSchema.DESERIALIZATION_ERROR_FIELD_RECORD_B64,


### PR DESCRIPTION
### Description 
Java exceptions can have a chain of causing exceptions that contain valuable
context about why an exception was thrown. KSQL has an ErrorUtils utility
class for building error messages from the cause chain. In this patch, we
add a utility function to that class which returns the cause error msg chain
as a list, and include this list in the record processing log as a new field
for deserialization and processing errors.

Fixes #2567 

### Testing done 
Unit tests
Manual tests

### Reviewer checklist
- [x] Ensure docs are updated if necessary. (eg. if a user visible feature is being added or changed).
- [x] Ensure relevant issues are linked (description should include text like "Fixes #<issue number>")

