### PR TITLE
PRINT does not deserialize a DELIMITED topic with one integer column

### DIFF
--- a/ksql-rest-app/src/main/java/io/confluent/ksql/rest/server/resources/streaming/TopicStream.java
+++ b/ksql-rest-app/src/main/java/io/confluent/ksql/rest/server/resources/streaming/TopicStream.java
@@ -152,7 +152,13 @@ public final class TopicStream {
           final KafkaAvroDeserializer avroDeserializer,
           final DateFormat dateFormat) {
         try {
-          JsonMapper.INSTANCE.mapper.readTree(record.value().toString());
+          final JsonNode jsonNode = JsonMapper.INSTANCE.mapper.readTree(record.value().toString());
+
+          // If the JsonNode is not structured like 'key:value', then do not use JSON to print
+          // this value
+          if (!(jsonNode instanceof ObjectNode)) {
+            return Optional.empty();
+          }
 
           return Optional.of(createFormatter());
         } catch (final Throwable t) {

--- a/ksql-rest-app/src/test/java/io/confluent/ksql/rest/server/resources/streaming/TopicStreamTest.java
+++ b/ksql-rest-app/src/test/java/io/confluent/ksql/rest/server/resources/streaming/TopicStreamTest.java
@@ -125,6 +125,20 @@ public class TopicStreamTest {
   }
 
   @Test
+  public void shouldMatchStringFormatWithOneColumnValues() {
+    // Given:
+    replay(schemaRegistryClient);
+
+    final String stringValue = "v1";
+
+    // When:
+    final Result result = getFormatter(stringValue);
+
+    // Then:
+    assertThat(result.format, is(Format.STRING));
+  }
+
+  @Test
   public void shouldFilterNullValues() {
     replay(schemaRegistryClient);
 


### PR DESCRIPTION
Fixes #2639

### Description 
This fixes the issue when a topic has one single value with one column.
```
# echo "1000" | kafkacat -b localhost:9092 -t t1 -P

ksql> print 't1' from BEGINNING;
com.fasterxml.jackson.databind.node.IntNode cannot be cast to com.fasterxml.jackson.databind.node.ObjectNode
```

The issue is that `PRINT` was selecting a JSON format to display the above value (which is a valid JSON value), however, the `PRINT` format was expecting to use an `ObjectNode` which expects a `key:value` format.

The fix is easy. Just to prevent using JSON if the value is not an `ObjectNode`. It will fall back to the STRING format instead.

### Testing done 
Add a test to `TopicStreamTest`
Manually verified in KSQL CLI
```
ksql> print 't1' from BEGINNING;
Format:STRING
4/12/19 9:55:55 AM CDT , NULL , 1000
```

### Reviewer checklist
- [ ] Ensure docs are updated if necessary. (eg. if a user visible feature is being added or changed).
- [ ] Ensure relevant issues are linked (description should include text like "Fixes #<issue number>")

