### PR TITLE
Fix broken topology generator and add test

### DIFF
--- a/ksql-engine/src/test/java/io/confluent/ksql/TopologyFileGenerator.java
+++ b/ksql-engine/src/test/java/io/confluent/ksql/TopologyFileGenerator.java
@@ -26,9 +26,11 @@ import java.util.stream.Collectors;
 import javax.xml.parsers.DocumentBuilder;
 import javax.xml.parsers.DocumentBuilderFactory;
 import javax.xml.parsers.ParserConfigurationException;
+import org.apache.kafka.test.IntegrationTest;
 import org.apache.kafka.test.TestUtils;
 import org.junit.Ignore;
 import org.junit.Test;
+import org.junit.experimental.categories.Category;
 import org.w3c.dom.Document;
 import org.w3c.dom.NodeList;
 import org.xml.sax.SAXException;
@@ -50,6 +52,7 @@ import org.xml.sax.SAXException;
  * VERSION_NUM is the version defined in ksql-engine/pom.xml &lt;parent&gt;&lt;version&gt; element.
  *
  */
+@Category(IntegrationTest.class)
 public final class TopologyFileGenerator {
 
     private static final String BASE_DIRECTORY = "src/test/resources/expected_topology/";

--- a/ksql-engine/src/test/java/io/confluent/ksql/TopologyFileGenerator.java
+++ b/ksql-engine/src/test/java/io/confluent/ksql/TopologyFileGenerator.java
@@ -54,9 +54,8 @@ public final class TopologyFileGenerator {
 
     private static final String BASE_DIRECTORY = "src/test/resources/expected_topology/";
 
-    @Ignore // comment me out to generate the persisted topologies
-    @Test
-    public void doGenerateTopologies() throws Exception {
+    // NOTE: must be run with current directory ksql/ksql-engine (IntelliJ default is ksql)
+    public static void main(final String[] args) throws Exception {
         generateTopologies(BASE_DIRECTORY);
     }
 
@@ -67,8 +66,7 @@ public final class TopologyFileGenerator {
         generateTopologies(tmp.getAbsolutePath());
     }
 
-    private void generateTopologies(final String base) throws Exception {
-
+    private static void generateTopologies(final String base) throws Exception {
         final String formattedVersion = getFormattedVersionFromPomFile();
         final String generatedTopologyPath = base + formattedVersion;
 

--- a/ksql-engine/src/test/java/io/confluent/ksql/TopologyFileGenerator.java
+++ b/ksql-engine/src/test/java/io/confluent/ksql/TopologyFileGenerator.java
@@ -26,6 +26,9 @@ import java.util.stream.Collectors;
 import javax.xml.parsers.DocumentBuilder;
 import javax.xml.parsers.DocumentBuilderFactory;
 import javax.xml.parsers.ParserConfigurationException;
+import org.apache.kafka.test.TestUtils;
+import org.junit.Ignore;
+import org.junit.Test;
 import org.w3c.dom.Document;
 import org.w3c.dom.NodeList;
 import org.xml.sax.SAXException;
@@ -49,15 +52,25 @@ import org.xml.sax.SAXException;
  */
 public final class TopologyFileGenerator {
 
-    private static final String BASE_DIRECTORY = "ksql-engine/src/test/resources/expected_topology/";
+    private static final String BASE_DIRECTORY = "src/test/resources/expected_topology/";
 
-    private TopologyFileGenerator() {
+    @Ignore // comment me out to generate the persisted topologies
+    @Test
+    public void doGenerateTopologies() throws Exception {
+        generateTopologies(BASE_DIRECTORY);
     }
 
-    public static void main(final String[] args) throws IOException, ParserConfigurationException, SAXException {
+    @Test
+    public void shouldGenerateTopologies() throws Exception {
+        final File tmp = TestUtils.tempDirectory();
+        tmp.deleteOnExit();
+        generateTopologies(tmp.getAbsolutePath());
+    }
+
+    private void generateTopologies(final String base) throws Exception {
 
         final String formattedVersion = getFormattedVersionFromPomFile();
-        final String generatedTopologyPath = BASE_DIRECTORY + formattedVersion;
+        final String generatedTopologyPath = base + formattedVersion;
 
         System.out.println(String.format("Starting to write topology files to %s", generatedTopologyPath));
         final Path dirPath = Paths.get(generatedTopologyPath);
@@ -70,7 +83,6 @@ public final class TopologyFileGenerator {
 
         EndToEndEngineTestUtil.writeExpectedTopologyFiles(generatedTopologyPath, getTestCases());
         System.out.println(String.format("Done writing topology files to %s", dirPath));
-        System.exit(0);
     }
 
     private static List<TestCase> getTestCases() {


### PR DESCRIPTION
### Description 
#2642 caused `TopologyFileGenerator` to fail because it is not run in the same directory that can access `udf-example.jar`. This change does two things:
- changes it from a `main` method that executes using `user.dir=../target/..` to a JUnit test, which will execute in the proper test directory
- adds a test that will be run every time to make sure that future changes will not cause the generator to fail

### Testing done 
- ran the generator

### Reviewer checklist
- [ ] Ensure docs are updated if necessary. (eg. if a user visible feature is being added or changed).
- [ ] Ensure relevant issues are linked (description should include text like "Fixes #<issue number>")

