### PR TITLE
Minor: clarify operations supported in headless mode

### DIFF
--- a/docs/concepts/ksql-architecture.rst
+++ b/docs/concepts/ksql-architecture.rst
@@ -189,7 +189,9 @@ interactive deployments.
 +----------------------------------------------------+-------------------+---------------------+
 | Explain a query, including runtime stats (EXPLAIN) | Supported         | Not Supported       |
 +----------------------------------------------------+-------------------+---------------------+
-| CREATE and DROP a stream or table                  | Supported         | Supported           |
+| CREATE a stream or table                           | Supported         | Supported           |
++----------------------------------------------------+-------------------+---------------------+
+| DROP a stream or table                             | Supported         | Not Supported       |
 +----------------------------------------------------+-------------------+---------------------+
 | List existing streams and tables (SHOW STREAMS,    | Supported         | Not Supported       |
 | SHOW TABLES)                                       |                   |                     |
@@ -208,7 +210,7 @@ interactive deployments.
 +----------------------------------------------------+-------------------+---------------------+
 | Show results of a query (SELECT)                   | Supported         | Not Supported       |
 +----------------------------------------------------+-------------------+---------------------+
-| Start and stop a query                             | Supported         | Supported           |
+| TERMINATE a query                                  | Supported         | Not Supported       |
 +----------------------------------------------------+-------------------+---------------------+
 | Start and stop a KSQL Server instance              | Not with KSQL API | Not with KSQL API   |
 +----------------------------------------------------+-------------------+---------------------+


### PR DESCRIPTION
### Description 

The current table of supported KSQL operations in our docs says "CREATE and DROP a stream or table" and "Start and stop a query" are both supported in headless mode, but this is misleading since headless mode doesn't support `TERMINATE` or `DROP` statements. This PR updates the table to clarify this.

### Testing done 

Docs-only change.

### Reviewer checklist
- [ ] Ensure docs are updated if necessary. (eg. if a user visible feature is being added or changed).
- [ ] Ensure relevant issues are linked (description should include text like "Fixes #<issue number>")

