### PR TITLE
Minor: bump docker quickstart image versions

### DIFF
--- a/docs/tutorials/docker-compose.yml
+++ b/docs/tutorials/docker-compose.yml
@@ -2,13 +2,13 @@
 version: '2'
 services:
   zookeeper:
-    image: "confluentinc/cp-zookeeper:5.0.0"
+    image: "confluentinc/cp-zookeeper:5.1.0"
     environment:
       ZOOKEEPER_CLIENT_PORT: 32181
       ZOOKEEPER_TICK_TIME: 2000
 
   kafka:
-    image: "confluentinc/cp-enterprise-kafka:5.0.0"
+    image: "confluentinc/cp-enterprise-kafka:5.1.0"
     ports:
       - '39092:39092'
     depends_on:
@@ -30,7 +30,7 @@ services:
       CONFLUENT_SUPPORT_CUSTOMER_ID: 'anonymous'
 
   schema-registry:
-    image: "confluentinc/cp-schema-registry:5.0.0"
+    image: "confluentinc/cp-schema-registry:5.1.0"
     depends_on:
       - zookeeper
       - kafka
@@ -39,7 +39,7 @@ services:
       SCHEMA_REGISTRY_KAFKASTORE_CONNECTION_URL: zookeeper:32181
 
   ksql-server:
-    image: "confluentinc/cp-ksql-server:5.0.0"
+    image: "confluentinc/cp-ksql-server:5.1.0"
     depends_on:
       - kafka
       - schema-registry


### PR DESCRIPTION
### Description 

Image versions in the KSQL docker quickstart haven't been bumped since 5.0.0. As identified in https://github.com/confluentinc/ksql/issues/2685, this is breaking the docker quickstart since 5.2 due to an incompatibility between the 5.2 CLI and the 5.0 server (root cause investigation still underway). In the meantime, this PR fixes the quickstart by bumping the server version, and also bumps dependency versions too.

This PR is targeted at 5.1.0-post. I will update the versions for each branch as the PR is merged forward.

Fixes https://github.com/confluentinc/ksql/issues/2685

### Testing done 

Manual verification that the quickstart still works with 5.1.0 and 5.2.1.

### Reviewer checklist
- [ ] Ensure docs are updated if necessary. (eg. if a user visible feature is being added or changed).
- [ ] Ensure relevant issues are linked (description should include text like "Fixes #<issue number>")

