### PR TITLE
Don't do unnecessary rebuild of sink topic serde for avro

### DIFF
--- a/ksql-engine/src/main/java/io/confluent/ksql/analyzer/Analyzer.java
+++ b/ksql-engine/src/main/java/io/confluent/ksql/analyzer/Analyzer.java
@@ -189,7 +189,6 @@ public class Analyzer extends DefaultTraversalVisitor<Node, AnalysisContext> {
         getKeySerde(intoStructuredDataSource)
     );
     analysis.setInto(intoKsqlStream, doCreateInto);
-
   }
 
   private static Serde<?> getKeySerde(final StructuredDataSource intoStructuredDataSource) {
@@ -638,9 +637,10 @@ public class Analyzer extends DefaultTraversalVisitor<Node, AnalysisContext> {
       analysis.getIntoProperties().put(DdlConfig.AVRO_SCHEMA_FILE, avroSchemaFilePath);
 
       final Expression avroSchemaFullName =
-              node.getProperties().get(DdlConfig.VALUE_AVRO_SCHEMA_FULL_NAME);
+          node.getProperties().get(DdlConfig.VALUE_AVRO_SCHEMA_FULL_NAME);
       analysis.getIntoProperties().put(
-              DdlConfig.VALUE_AVRO_SCHEMA_FULL_NAME, avroSchemaFullName != null
+          DdlConfig.VALUE_AVRO_SCHEMA_FULL_NAME,
+          avroSchemaFullName != null
               ? avroSchemaFullName : KsqlConstants.DEFAULT_AVRO_SCHEMA_FULL_NAME);
     } else if (node.getProperties().containsKey(DdlConfig.VALUE_AVRO_SCHEMA_FULL_NAME)) {
       throw new KsqlException(

--- a/ksql-engine/src/test/resources/query-validation-tests/insert-into.json
+++ b/ksql-engine/src/test/resources/query-validation-tests/insert-into.json
@@ -1,0 +1,30 @@
+{
+  "comments": [
+    "You can specify multiple statements per test case, i.e., to set up the various streams needed",
+    "for joins etc, but currently only the final topology will be verified. This should be enough",
+    "for most tests as we can simulate the outputs from previous stages into the final stage. If we",
+    "take a modular approach to testing we can still verify that it all works correctly, i.e, if we",
+    "verify the output of a select or aggregate is correct, we can use simulated output to feed into",
+    "a join or another aggregate."
+  ],
+  "tests": [
+    {
+      "name": "convert formats",
+      "statements": [
+        "CREATE STREAM SOURCE (A bigint, B varchar) WITH (kafka_topic='source', value_format='JSON');",
+        "CREATE STREAM SINK (A bigint, B varchar) WITH (kafka_topic='sink', value_format='AVRO');",
+        "INSERT INTO SINK SELECT * FROM SOURCE;"
+      ],
+      "inputs": [
+        {"topic": "source", "key": 0, "value": {"A": 123, "B": "falcon"}, "timestamp": 0},
+        {"topic": "source", "key": 0, "value": {"A": 456, "B": "giraffe"}, "timestamp": 0},
+        {"topic": "source", "key": 0, "value": {"A": 789, "B": "turtle"}, "timestamp": 0}
+      ],
+      "outputs": [
+        {"topic": "sink", "key": 0, "value": {"A": 123, "B": "falcon"}, "timestamp": 0},
+        {"topic": "sink", "key": 0, "value": {"A": 456, "B": "giraffe"}, "timestamp": 0},
+        {"topic": "sink", "key": 0, "value": {"A": 789, "B": "turtle"}, "timestamp": 0}
+      ]
+    }
+  ]
+}

--- a/ksql-engine/src/test/resources/query-validation-tests/insert-into.json
+++ b/ksql-engine/src/test/resources/query-validation-tests/insert-into.json
@@ -1,18 +1,28 @@
 {
-  "comments": [
-    "You can specify multiple statements per test case, i.e., to set up the various streams needed",
-    "for joins etc, but currently only the final topology will be verified. This should be enough",
-    "for most tests as we can simulate the outputs from previous stages into the final stage. If we",
-    "take a modular approach to testing we can still verify that it all works correctly, i.e, if we",
-    "verify the output of a select or aggregate is correct, we can use simulated output to feed into",
-    "a join or another aggregate."
-  ],
   "tests": [
     {
-      "name": "convert formats",
+      "name": "convert formats: JSON to AVRO",
       "statements": [
         "CREATE STREAM SOURCE (A bigint, B varchar) WITH (kafka_topic='source', value_format='JSON');",
         "CREATE STREAM SINK (A bigint, B varchar) WITH (kafka_topic='sink', value_format='AVRO');",
+        "INSERT INTO SINK SELECT * FROM SOURCE;"
+      ],
+      "inputs": [
+        {"topic": "source", "key": 0, "value": {"A": 123, "B": "falcon"}, "timestamp": 0},
+        {"topic": "source", "key": 0, "value": {"A": 456, "B": "giraffe"}, "timestamp": 0},
+        {"topic": "source", "key": 0, "value": {"A": 789, "B": "turtle"}, "timestamp": 0}
+      ],
+      "outputs": [
+        {"topic": "sink", "key": 0, "value": {"A": 123, "B": "falcon"}, "timestamp": 0},
+        {"topic": "sink", "key": 0, "value": {"A": 456, "B": "giraffe"}, "timestamp": 0},
+        {"topic": "sink", "key": 0, "value": {"A": 789, "B": "turtle"}, "timestamp": 0}
+      ]
+    },
+    {
+      "name": "convert formats: AVRO to JSON",
+      "statements": [
+        "CREATE STREAM SOURCE (A bigint, B varchar) WITH (kafka_topic='source', value_format='AVRO');",
+        "CREATE STREAM SINK (A bigint, B varchar) WITH (kafka_topic='sink', value_format='JSON');",
         "INSERT INTO SINK SELECT * FROM SOURCE;"
       ],
       "inputs": [


### PR DESCRIPTION
### Description
For some reason KsqlStructuredDataOutputNode is rebuilding the sink topic serde
for queries that write avro. There is no reason to do this, and in the case of
INSERT INTO from a json source actuall results in an NPE, because the schema name
isn't set in the properties. Instead of doing this rebuild, we should just use
the serde the analyzer computed for us.

### Testing done 
Unit test and QVT
