### PR TITLE
Minor: update JsonMapper to ignore unknown fields

### DIFF
--- a/ksql-cli/src/main/java/io/confluent/ksql/cli/console/Console.java
+++ b/ksql-cli/src/main/java/io/confluent/ksql/cli/console/Console.java
@@ -17,7 +17,6 @@ package io.confluent.ksql.cli.console;
 
 import static io.confluent.ksql.util.CmdLineUtil.splitByUnquotedWhitespace;
 
-import com.fasterxml.jackson.core.JsonGenerator;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.Maps;
@@ -38,6 +37,7 @@ import io.confluent.ksql.cli.console.table.builder.StreamsListTableBuilder;
 import io.confluent.ksql.cli.console.table.builder.TableBuilder;
 import io.confluent.ksql.cli.console.table.builder.TablesListTableBuilder;
 import io.confluent.ksql.cli.console.table.builder.TopicDescriptionTableBuilder;
+import io.confluent.ksql.json.JsonMapper;
 import io.confluent.ksql.rest.entity.ArgumentInfo;
 import io.confluent.ksql.rest.entity.CommandStatusEntity;
 import io.confluent.ksql.rest.entity.ExecutionPlan;
@@ -190,7 +190,7 @@ public class Console implements Closeable {
     this.terminal = Objects.requireNonNull(terminal, "terminal");
     this.rowCaptor = Objects.requireNonNull(rowCaptor, "rowCaptor");
     this.cliSpecificCommands = Maps.newLinkedHashMap();
-    this.objectMapper = new ObjectMapper().disable(JsonGenerator.Feature.AUTO_CLOSE_TARGET);
+    this.objectMapper = JsonMapper.INSTANCE.mapper;
   }
 
   public PrintWriter writer() {

--- a/ksql-common/src/test/java/io/confluent/ksql/json/JsonMapperTest.java
+++ b/ksql-common/src/test/java/io/confluent/ksql/json/JsonMapperTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018 Confluent Inc.
+ * Copyright 2019 Confluent Inc.
  *
  * Licensed under the Confluent Community License (the "License"); you may not use
  * this file except in compliance with the License.  You may obtain a copy of the
@@ -15,20 +15,25 @@
 
 package io.confluent.ksql.json;
 
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.MatcherAssert.assertThat;
+
 import com.fasterxml.jackson.core.JsonGenerator;
 import com.fasterxml.jackson.databind.DeserializationFeature;
 import com.fasterxml.jackson.databind.ObjectMapper;
-import com.fasterxml.jackson.datatype.jdk8.Jdk8Module;
+import org.junit.Test;
 
-public enum JsonMapper {
-  INSTANCE;
+public class JsonMapperTest {
 
-  public final ObjectMapper mapper =
-      new ObjectMapper().disable(JsonGenerator.Feature.AUTO_CLOSE_TARGET);
+  private static final ObjectMapper OBJECT_MAPPER = JsonMapper.INSTANCE.mapper;
 
-  JsonMapper() {
-    mapper.registerModule(new Jdk8Module());
-    mapper.registerModule(new StructSerializationModule());
-    mapper.disable(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES);
+  @Test
+  public void shouldNotAutoCloseTarget() {
+    assertThat(OBJECT_MAPPER.isEnabled(JsonGenerator.Feature.AUTO_CLOSE_TARGET), is(false));
+  }
+
+  @Test
+  public void shouldIgnoreUnknownProperties() {
+    assertThat(OBJECT_MAPPER.isEnabled(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES), is(false));
   }
 }

--- a/ksql-engine/src/main/java/io/confluent/ksql/function/udf/json/JsonExtractStringKudf.java
+++ b/ksql-engine/src/main/java/io/confluent/ksql/function/udf/json/JsonExtractStringKudf.java
@@ -16,20 +16,20 @@
 package io.confluent.ksql.function.udf.json;
 
 import com.fasterxml.jackson.databind.JsonNode;
-import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.ObjectReader;
 import com.fasterxml.jackson.databind.node.ArrayNode;
 import com.google.common.collect.ImmutableList;
 import io.confluent.ksql.function.KsqlFunctionException;
 import io.confluent.ksql.function.UdfUtil;
 import io.confluent.ksql.function.udf.Kudf;
+import io.confluent.ksql.json.JsonMapper;
 import io.confluent.ksql.util.KsqlException;
 import io.confluent.ksql.util.json.JsonPathTokenizer;
 import java.io.IOException;
 import java.util.List;
 
 public class JsonExtractStringKudf implements Kudf {
-  private static final ObjectReader OBJECT_READER = new ObjectMapper().reader();
+  private static final ObjectReader OBJECT_READER = JsonMapper.INSTANCE.mapper.reader();
   public static final String NAME = "EXTRACTJSONFIELD";
 
   private List<String> tokens = null;

--- a/ksql-engine/src/test/java/io/confluent/ksql/EndToEndEngineTestUtil.java
+++ b/ksql-engine/src/test/java/io/confluent/ksql/EndToEndEngineTestUtil.java
@@ -286,7 +286,7 @@ final class EndToEndEngineTestUtil {
         return null;
       }
       try {
-        return new ObjectMapper().readValue(data, Map.class);
+        return OBJECT_MAPPER.readValue(data, Map.class);
       } catch (final Exception e) {
         throw new RuntimeException(e);
       }
@@ -308,7 +308,7 @@ final class EndToEndEngineTestUtil {
         return null;
       }
       try {
-        return new ObjectMapper().writeValueAsBytes(spec);
+        return OBJECT_MAPPER.writeValueAsBytes(spec);
       } catch (final Exception e) {
         throw new RuntimeException(e);
       }
@@ -714,7 +714,7 @@ final class EndToEndEngineTestUtil {
       final String topologyDir,
       final List<TestCase> testCases) {
 
-    final ObjectWriter objectWriter = new ObjectMapper().writerWithDefaultPrettyPrinter();
+    final ObjectWriter objectWriter = OBJECT_MAPPER.writerWithDefaultPrettyPrinter();
 
     testCases.forEach(testCase -> {
       final KsqlConfig ksqlConfig = new KsqlConfig(baseConfig())
@@ -837,7 +837,7 @@ final class EndToEndEngineTestUtil {
 
   static Map<String, TopologyAndConfigs> loadExpectedTopologies(final String dir) {
     final HashMap<String, TopologyAndConfigs> expectedTopologyAndConfigs = new HashMap<>();
-    final ObjectReader objectReader = new ObjectMapper().readerFor(Map.class);
+    final ObjectReader objectReader = OBJECT_MAPPER.readerFor(Map.class);
     final List<String> topologyFiles = findExpectedTopologyFiles(dir);
     topologyFiles.forEach(fileName -> {
       final TopologyAndConfigs topologyAndConfigs = readTopologyFile(dir + "/" + fileName, objectReader);

--- a/ksql-rest-app/src/main/java/io/confluent/ksql/rest/client/KsqlRestClient.java
+++ b/ksql-rest-app/src/main/java/io/confluent/ksql/rest/client/KsqlRestClient.java
@@ -17,7 +17,6 @@ package io.confluent.ksql.rest.client;
 
 import com.fasterxml.jackson.databind.DeserializationFeature;
 import com.fasterxml.jackson.databind.ObjectMapper;
-import com.fasterxml.jackson.datatype.jdk8.Jdk8Module;
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.collect.ImmutableList;
 import io.confluent.ksql.json.JsonMapper;
@@ -307,7 +306,7 @@ public class KsqlRestClient implements Closeable {
     private QueryStream(final Response response) {
       this.response = response;
 
-      this.objectMapper = new ObjectMapper();
+      this.objectMapper = JsonMapper.INSTANCE.mapper;
       this.isr = new InputStreamReader(
           (InputStream) response.getEntity(),
           StandardCharsets.UTF_8
@@ -427,10 +426,8 @@ public class KsqlRestClient implements Closeable {
       final SslClientConfigurer sslClientConfigurer,
       final Map<String, String> props
   ) {
-    final ObjectMapper objectMapper = JsonMapper.INSTANCE.mapper;
-    objectMapper.configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false);
+    final ObjectMapper objectMapper = JsonMapper.INSTANCE.mapper.copy();
     objectMapper.configure(DeserializationFeature.FAIL_ON_NULL_FOR_PRIMITIVES, false);
-    objectMapper.registerModule(new Jdk8Module());
     final JacksonMessageBodyProvider jsonProvider = new JacksonMessageBodyProvider(objectMapper);
 
     try {

--- a/ksql-rest-app/src/test/java/io/confluent/ksql/rest/entity/CommandStatusEntityTest.java
+++ b/ksql-rest-app/src/test/java/io/confluent/ksql/rest/entity/CommandStatusEntityTest.java
@@ -20,6 +20,7 @@ import static org.hamcrest.MatcherAssert.assertThat;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
+import io.confluent.ksql.json.JsonMapper;
 import io.confluent.ksql.rest.server.computation.CommandId;
 import org.junit.Rule;
 import org.junit.Test;
@@ -27,7 +28,7 @@ import org.junit.rules.ExpectedException;
 
 @SuppressFBWarnings("NP_NULL_PARAM_DEREF_NONVIRTUAL")
 public class CommandStatusEntityTest {
-  private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper();
+  private static final ObjectMapper OBJECT_MAPPER = JsonMapper.INSTANCE.mapper;
 
   private static final String JSON_ENTITY = "{"
       + "\"@type\":\"currentStatus\","

--- a/ksql-rest-app/src/test/java/io/confluent/ksql/rest/entity/FunctionInfoTest.java
+++ b/ksql-rest-app/src/test/java/io/confluent/ksql/rest/entity/FunctionInfoTest.java
@@ -23,6 +23,7 @@ import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.common.collect.ImmutableList;
+import io.confluent.ksql.json.JsonMapper;
 import java.util.Collections;
 import java.util.List;
 import java.util.Objects;
@@ -30,7 +31,7 @@ import org.junit.Test;
 
 @SuppressWarnings("SameParameterValue")
 public class FunctionInfoTest {
-  private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper();
+  private static final ObjectMapper OBJECT_MAPPER = JsonMapper.INSTANCE.mapper;
   private static final FunctionInfo FUNC_INFO = new FunctionInfo(
       ImmutableList.of(
           new ArgumentInfo("arg0", "VARCHAR", "first arg", false),

--- a/ksql-rest-app/src/test/java/io/confluent/ksql/rest/entity/KsqlRequestTest.java
+++ b/ksql-rest-app/src/test/java/io/confluent/ksql/rest/entity/KsqlRequestTest.java
@@ -22,17 +22,15 @@ import static org.hamcrest.Matchers.hasItem;
 import static org.hamcrest.Matchers.is;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
-import com.fasterxml.jackson.datatype.jdk8.Jdk8Module;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.testing.EqualsTester;
-import io.confluent.ksql.util.KsqlConfig;
+import io.confluent.ksql.json.JsonMapper;
 import io.confluent.ksql.util.KsqlException;
 import java.io.IOException;
 import java.util.Collections;
 import java.util.Map;
 import java.util.Optional;
 import org.apache.kafka.clients.consumer.ConsumerConfig;
-import org.junit.BeforeClass;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ExpectedException;
@@ -40,7 +38,7 @@ import org.junit.rules.ExpectedException;
 @SuppressWarnings("SameParameterValue")
 public class KsqlRequestTest {
 
-  private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper();
+  private static final ObjectMapper OBJECT_MAPPER = JsonMapper.INSTANCE.mapper;
   private static final String A_JSON_REQUEST = "{"
       + "\"ksql\":\"sql\","
       + "\"streamsProperties\":{"
@@ -67,11 +65,6 @@ public class KsqlRequestTest {
   private static final KsqlRequest A_REQUEST = new KsqlRequest("sql", SOME_PROPS, null);
   private static final KsqlRequest A_REQUEST_WITH_COMMAND_NUMBER =
       new KsqlRequest("sql", SOME_PROPS, SOME_COMMAND_NUMBER);
-
-  @BeforeClass
-  public static void setUpClass() {
-    OBJECT_MAPPER.registerModule(new Jdk8Module());
-  }
 
   @Rule
   public final ExpectedException expectedException = ExpectedException.none();

--- a/ksql-rest-app/src/test/java/io/confluent/ksql/rest/entity/SchemaDescriptionFormatTest.java
+++ b/ksql-rest-app/src/test/java/io/confluent/ksql/rest/entity/SchemaDescriptionFormatTest.java
@@ -20,7 +20,6 @@ import static org.junit.Assert.assertThat;
 
 import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.ObjectMapper;
-import com.fasterxml.jackson.datatype.jdk8.Jdk8Module;
 import io.confluent.ksql.json.JsonMapper;
 import java.io.IOException;
 import java.util.List;
@@ -28,11 +27,6 @@ import java.util.Optional;
 import org.junit.Test;
 
 public class SchemaDescriptionFormatTest {
-  private ObjectMapper newObjectMapper() {
-    final ObjectMapper objectMapper = JsonMapper.INSTANCE.mapper;
-    objectMapper.registerModule(new Jdk8Module());
-    return objectMapper;
-  }
 
   private void shouldSerializeCorrectly(final String descriptionString,
                                         final List<FieldInfo> deserialized) throws IOException {

--- a/ksql-rest-app/src/test/java/io/confluent/ksql/rest/server/TestKsqlRestApp.java
+++ b/ksql-rest-app/src/test/java/io/confluent/ksql/rest/server/TestKsqlRestApp.java
@@ -17,10 +17,10 @@ package io.confluent.ksql.rest.server;
 
 import static org.easymock.EasyMock.niceMock;
 
+import com.fasterxml.jackson.core.JsonGenerator;
 import com.fasterxml.jackson.databind.DeserializationFeature;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.datatype.jdk8.Jdk8Module;
-import io.confluent.ksql.json.JsonMapper;
 import io.confluent.ksql.rest.client.KsqlRestClient;
 import io.confluent.ksql.rest.client.RestResponse;
 import io.confluent.ksql.rest.entity.EntityQueryId;
@@ -173,7 +173,8 @@ public class TestKsqlRestApp extends ExternalResource {
   }
 
   public static Client buildClient() {
-    final ObjectMapper objectMapper = JsonMapper.INSTANCE.mapper;
+    final ObjectMapper objectMapper =
+        new ObjectMapper().disable(JsonGenerator.Feature.AUTO_CLOSE_TARGET);
     objectMapper.configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, true);
     objectMapper.configure(DeserializationFeature.FAIL_ON_NULL_FOR_PRIMITIVES, true);
     objectMapper.registerModule(new Jdk8Module());

--- a/ksql-rest-app/src/test/java/io/confluent/ksql/rest/server/TestKsqlRestApp.java
+++ b/ksql-rest-app/src/test/java/io/confluent/ksql/rest/server/TestKsqlRestApp.java
@@ -17,10 +17,10 @@ package io.confluent.ksql.rest.server;
 
 import static org.easymock.EasyMock.niceMock;
 
-import com.fasterxml.jackson.core.JsonGenerator;
 import com.fasterxml.jackson.databind.DeserializationFeature;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.datatype.jdk8.Jdk8Module;
+import io.confluent.ksql.json.JsonMapper;
 import io.confluent.ksql.rest.client.KsqlRestClient;
 import io.confluent.ksql.rest.client.RestResponse;
 import io.confluent.ksql.rest.entity.EntityQueryId;
@@ -173,8 +173,7 @@ public class TestKsqlRestApp extends ExternalResource {
   }
 
   public static Client buildClient() {
-    final ObjectMapper objectMapper =
-        new ObjectMapper().disable(JsonGenerator.Feature.AUTO_CLOSE_TARGET);
+    final ObjectMapper objectMapper = JsonMapper.INSTANCE.mapper.copy();
     objectMapper.configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, true);
     objectMapper.configure(DeserializationFeature.FAIL_ON_NULL_FOR_PRIMITIVES, true);
     objectMapper.registerModule(new Jdk8Module());

--- a/ksql-rest-app/src/test/java/io/confluent/ksql/rest/server/resources/streaming/WSQueryEndpointTest.java
+++ b/ksql-rest-app/src/test/java/io/confluent/ksql/rest/server/resources/streaming/WSQueryEndpointTest.java
@@ -28,13 +28,13 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
-import com.fasterxml.jackson.datatype.jdk8.Jdk8Module;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableMap.Builder;
 import com.google.common.util.concurrent.ListeningScheduledExecutorService;
 import io.confluent.kafka.schemaregistry.client.SchemaRegistryClient;
 import io.confluent.ksql.engine.KsqlEngine;
+import io.confluent.ksql.json.JsonMapper;
 import io.confluent.ksql.parser.KsqlParser.PreparedStatement;
 import io.confluent.ksql.parser.tree.Query;
 import io.confluent.ksql.parser.tree.Relation;
@@ -65,7 +65,6 @@ import javax.websocket.CloseReason.CloseCodes;
 import javax.websocket.Session;
 import org.apache.kafka.clients.consumer.ConsumerConfig;
 import org.junit.Before;
-import org.junit.BeforeClass;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.ArgumentCaptor;
@@ -77,7 +76,7 @@ import org.mockito.junit.MockitoJUnitRunner;
 @RunWith(MockitoJUnitRunner.class)
 public class WSQueryEndpointTest {
 
-  private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper();
+  private static final ObjectMapper OBJECT_MAPPER = JsonMapper.INSTANCE.mapper;
 
   private static final KsqlRequest VALID_REQUEST = new KsqlRequest("test-sql",
       ImmutableMap.of(ConsumerConfig.AUTO_OFFSET_RESET_CONFIG, "earliest"), null);
@@ -123,11 +122,6 @@ public class WSQueryEndpointTest {
   private ArgumentCaptor<CloseReason> closeReasonCaptor;
   private Query query;
   private WSQueryEndpoint wsQueryEndpoint;
-
-  @BeforeClass
-  public static void setUpClass() {
-    OBJECT_MAPPER.registerModule(new Jdk8Module());
-  }
 
   @Before
   public void setUp() {


### PR DESCRIPTION
### Description 

This PR:

- updates JsonMapper to ignore unknown fields, so that even if the `@JsonIgnoreProperties(ignoreUnknown = true)` is forgotten/missed on certain types, we still have forward compatibility when new fields are introduced. This change is motivated by https://github.com/confluentinc/ksql/issues/2685.
- cleans up references to JsonMapper: non-test code should use JsonMapper rather than creating new ObjectMappers, and should not reconfigure the JsonMapper.

I've chosen not to remove existing `@JsonIgnoreProperties(ignoreUnknown = true)` annotations from types despite these annotations no longer being needed with this change, for the sake of being explicit. If folks prefer they be removed I'm happy to do so.

### Testing done 

Added small unit test for JsonMapper. Existing tests continue to pass.

### Reviewer checklist
- [ ] Ensure docs are updated if necessary. (eg. if a user visible feature is being added or changed).
- [ ] Ensure relevant issues are linked (description should include text like "Fixes #<issue number>")

