### PR TITLE
Fix the way Key Fields are calculated, stored & used.

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -11,7 +11,7 @@ KSQL 5.3.0 includes new features, including:
   the ``WITH`` clause.
   The improved handling may eliminate unnecessary repartition steps in certain queries.
   Please note that preexisting persistent queries, e.g. those created via ``CREATE TABLE AS SELECT ...`` or
-  ``CREATE STREAM AS SELECT ...`` or ``INSET INTO ...``, will continue to have the unnecessary repartition step.
+  ``CREATE STREAM AS SELECT ...`` or ``INSERT INTO ...``, will continue to have the unnecessary repartition step.
   This is required to avoid the potential for data loss should this step be dropped.
   See `#2280 <https://github.com/confluentinc/ksql/pull/2636>`_ for more info.
 

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -1,6 +1,21 @@
 Changelog
 =========
 
+Version 5.3.0
+-------------
+
+KSQL 5.3.0 includes new features, including:
+
+* Improved handling of ``KEY`` fields. The ``KEY`` field is an optional copy of the Kafka record's key held
+  within the record's value. Users can supply the name of the field that holds the copy of the key within
+  the ``WITH`` clause.
+  The improved handling may eliminate unnecessary repartition steps in certain queries.
+  Please note that preexisting persistent queries, e.g. those created via ``CREATE TABLE AS SELECT ...`` or
+  ``CREATE STREAM AS SELECT ...`` or ``INSET INTO ...``, will continue to have the unnecessary repartition step.
+  This is required to avoid the potential for data loss should this step be dropped.
+  See `#2280 <https://github.com/confluentinc/ksql/pull/2636>`_ for more info.
+
+
 Version 5.2.0
 -------------
 

--- a/ksql-common/src/main/java/io/confluent/ksql/util/KsqlConfig.java
+++ b/ksql-common/src/main/java/io/confluent/ksql/util/KsqlConfig.java
@@ -136,6 +136,8 @@ public class KsqlConfig extends AbstractConfig {
   public static final String KSQL_USE_NAMED_AVRO_MAPS = "ksql.avro.maps.named";
   private static final String KSQL_USE_NAMED_AVRO_MAPS_DOC = "";
 
+  public static final String KSQL_USE_LEGACY_KEY_FIELD = "ksql.query.fields.key.legacy";
+
   public static final String
       defaultSchemaRegistryUrl = "http://localhost:8081";
 
@@ -211,6 +213,17 @@ public class KsqlConfig extends AbstractConfig {
               true,
               ConfigDef.Importance.LOW,
               KSQL_USE_NAMED_AVRO_MAPS_DOC
+          ),
+          new CompatibilityBreakingConfigDef(
+              KSQL_USE_LEGACY_KEY_FIELD,
+              ConfigDef.Type.BOOLEAN,
+              true,
+              false,
+              ConfigDef.Importance.LOW,
+              "Determines if the legacy key field is used when building queries. "
+                  + "This setting is automatically applied for persistent queries started by "
+                  + "older versions of KSQL. "
+                  + "This setting should not be set manually."
           )
   );
 

--- a/ksql-common/src/test/java/io/confluent/ksql/util/SchemaUtilTest.java
+++ b/ksql-common/src/test/java/io/confluent/ksql/util/SchemaUtilTest.java
@@ -702,6 +702,48 @@ public class SchemaUtilTest {
     assertThat(SchemaUtil.isNumber(Schema.Type.STRING), is(false));
   }
 
+  @Test
+  public void shouldBuildAliasedFieldName() {
+    // When:
+    final String result = SchemaUtil.buildAliasedFieldName("SomeAlias", "SomeFieldName");
+
+    // Then:
+    assertThat(result, is("SomeAlias.SomeFieldName"));
+  }
+
+  @Test
+  public void shouldBuildAliasedFieldNameThatIsAlreadyAliased() {
+    // When:
+    final String result = SchemaUtil.buildAliasedFieldName("SomeAlias", "SomeAlias.SomeFieldName");
+
+    // Then:
+    assertThat(result, is("SomeAlias.SomeFieldName"));
+  }
+
+  @Test
+  public void shouldBuildAliasedField() {
+    // Given:
+    final Field field = new Field("col0", 1, Schema.INT64_SCHEMA);
+
+    // When:
+    final Field result = SchemaUtil
+        .buildAliasedField("TheAlias", field);
+
+    // Then:
+    assertThat(result, is(new Field("TheAlias.col0", 1, Schema.INT64_SCHEMA)));
+  }
+
+  @Test
+  public void shouldBuildAliasedFieldThatIsAlreadyAliased() {
+    // Given:
+    final Field field = new Field("TheAlias.col0", 1, Schema.INT64_SCHEMA);
+
+    // When:
+    final Field result = SchemaUtil.buildAliasedField("TheAlias", field);
+
+    // Then:
+    assertThat(result, is(field));
+  }
 
   // Following methods not invoked but used to test conversion from Type -> Schema
   @SuppressWarnings("unused")

--- a/ksql-engine/src/main/java/io/confluent/ksql/analyzer/Analyzer.java
+++ b/ksql-engine/src/main/java/io/confluent/ksql/analyzer/Analyzer.java
@@ -424,14 +424,16 @@ class Analyzer {
           new StructuredDataSourceNode(
               new PlanNodeId("KafkaTopic_Left"),
               leftDataSource,
-              leftDataSource.getSchema()
+              leftDataSource.getSchema(),
+              leftDataSource.getKeyField()
           );
       final StructuredDataSourceNode
           rightSourceKafkaTopicNode =
           new StructuredDataSourceNode(
               new PlanNodeId("KafkaTopic_Right"),
               rightDataSource,
-              rightDataSource.getSchema()
+              rightDataSource.getSchema(),
+              rightDataSource.getKeyField()
           );
 
       final JoinNode joinNode =

--- a/ksql-engine/src/main/java/io/confluent/ksql/ddl/commands/AbstractCreateStreamCommand.java
+++ b/ksql-engine/src/main/java/io/confluent/ksql/ddl/commands/AbstractCreateStreamCommand.java
@@ -35,7 +35,6 @@ import io.confluent.ksql.util.timestamp.TimestampExtractionPolicyFactory;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
-import java.util.Optional;
 import java.util.Set;
 import org.apache.kafka.common.serialization.Serdes;
 import org.apache.kafka.connect.data.Field;
@@ -104,7 +103,7 @@ abstract class AbstractCreateStreamCommand implements DdlCommand {
 
       this.keyField = KeyField.of(keyFieldName, keyField);
     } else {
-      this.keyField = KeyField.of(Optional.empty(), Optional.empty());
+      this.keyField = KeyField.none();
     }
 
     final String timestampName = properties.containsKey(DdlConfig.TIMESTAMP_NAME_PROPERTY)

--- a/ksql-engine/src/main/java/io/confluent/ksql/ddl/commands/CreateStreamCommand.java
+++ b/ksql-engine/src/main/java/io/confluent/ksql/ddl/commands/CreateStreamCommand.java
@@ -21,7 +21,6 @@ import io.confluent.ksql.parser.tree.CreateStream;
 import io.confluent.ksql.services.KafkaTopicClient;
 import io.confluent.ksql.util.KsqlException;
 import io.confluent.ksql.util.SchemaUtil;
-import java.util.Optional;
 
 public class CreateStreamCommand extends AbstractCreateStreamCommand {
 
@@ -45,12 +44,12 @@ public class CreateStreamCommand extends AbstractCreateStreamCommand {
       }
     }
     checkMetaData(metaStore, sourceName, topicName);
+
     final KsqlStream ksqlStream = new KsqlStream<>(
         sqlExpression,
         sourceName,
         SchemaUtil.addImplicitRowTimeRowKeyToSchema(schema),
-        (keyColumnName.length() == 0)
-          ? Optional.empty() : SchemaUtil.getFieldByName(schema, keyColumnName),
+        keyField,
         timestampExtractionPolicy,
         metaStore.getTopic(topicName),
         keySerdeFactory

--- a/ksql-engine/src/main/java/io/confluent/ksql/ddl/commands/CreateTableCommand.java
+++ b/ksql-engine/src/main/java/io/confluent/ksql/ddl/commands/CreateTableCommand.java
@@ -24,7 +24,6 @@ import io.confluent.ksql.services.KafkaTopicClient;
 import io.confluent.ksql.util.KsqlException;
 import io.confluent.ksql.util.SchemaUtil;
 import java.util.Map;
-import java.util.Optional;
 
 public class CreateTableCommand extends AbstractCreateStreamCommand {
 
@@ -60,8 +59,7 @@ public class CreateTableCommand extends AbstractCreateStreamCommand {
         sqlExpression,
         sourceName,
         SchemaUtil.addImplicitRowTimeRowKeyToSchema(schema),
-        (keyColumnName.isEmpty())
-          ? Optional.empty() : SchemaUtil.getFieldByName(schema, keyColumnName),
+        keyField,
         timestampExtractionPolicy,
         metaStore.getTopic(topicName),
         keySerdeFactory

--- a/ksql-engine/src/main/java/io/confluent/ksql/engine/EngineContext.java
+++ b/ksql-engine/src/main/java/io/confluent/ksql/engine/EngineContext.java
@@ -110,10 +110,6 @@ final class EngineContext {
     return sandBox;
   }
 
-  int numberOfPersistentQueries() {
-    return persistentQueries.size();
-  }
-
   Optional<PersistentQueryMetadata> getPersistentQuery(final QueryId queryId) {
     return Optional.ofNullable(persistentQueries.get(queryId));
   }

--- a/ksql-engine/src/main/java/io/confluent/ksql/physical/PhysicalPlanBuilder.java
+++ b/ksql-engine/src/main/java/io/confluent/ksql/physical/PhysicalPlanBuilder.java
@@ -332,7 +332,10 @@ public class PhysicalPlanBuilder {
           SchemaUtil.getSchemaDefinitionString(existingSchema)));
     }
 
-    enforceKeyEquivalence(existing.getKeyField(), sinkDataSource.getKeyField());
+    enforceKeyEquivalence(
+        existing.getKeyField().resolve(existing.getSchema(), ksqlConfig),
+        sinkDataSource.getKeyField().resolve(sinkDataSource.getSchema(), ksqlConfig)
+    );
   }
 
   private static String getQueryApplicationId(

--- a/ksql-engine/src/main/java/io/confluent/ksql/planner/LogicalPlanner.java
+++ b/ksql-engine/src/main/java/io/confluent/ksql/planner/LogicalPlanner.java
@@ -230,7 +230,6 @@ public class LogicalPlanner {
       throw new RuntimeException("Data source is not supported yet.");
     }
 
-    // Todo(ac): Next steps move this INTO StructuredDataSourceNode
     final Schema fromSchema = SchemaUtil.buildSchemaWithAlias(
         dataSource.left.getSchema(),
         dataSource.right

--- a/ksql-engine/src/main/java/io/confluent/ksql/planner/LogicalPlanner.java
+++ b/ksql-engine/src/main/java/io/confluent/ksql/planner/LogicalPlanner.java
@@ -20,9 +20,11 @@ import io.confluent.ksql.analyzer.Analysis;
 import io.confluent.ksql.analyzer.Analysis.Into;
 import io.confluent.ksql.ddl.DdlConfig;
 import io.confluent.ksql.function.FunctionRegistry;
+import io.confluent.ksql.metastore.model.KeyField;
 import io.confluent.ksql.metastore.model.KsqlStream;
 import io.confluent.ksql.metastore.model.KsqlTable;
 import io.confluent.ksql.metastore.model.StructuredDataSource;
+import io.confluent.ksql.parser.tree.DereferenceExpression;
 import io.confluent.ksql.parser.tree.Expression;
 import io.confluent.ksql.planner.plan.AggregateNode;
 import io.confluent.ksql.planner.plan.FilterNode;
@@ -35,11 +37,14 @@ import io.confluent.ksql.planner.plan.ProjectNode;
 import io.confluent.ksql.planner.plan.StructuredDataSourceNode;
 import io.confluent.ksql.util.ExpressionTypeManager;
 import io.confluent.ksql.util.KsqlConstants;
+import io.confluent.ksql.util.KsqlException;
 import io.confluent.ksql.util.Pair;
 import io.confluent.ksql.util.SchemaUtil;
 import io.confluent.ksql.util.timestamp.TimestampExtractionPolicy;
 import io.confluent.ksql.util.timestamp.TimestampExtractionPolicyFactory;
 import java.util.Map;
+import java.util.Optional;
+import org.apache.kafka.connect.data.Field;
 import org.apache.kafka.connect.data.Schema;
 import org.apache.kafka.connect.data.SchemaBuilder;
 
@@ -72,20 +77,16 @@ public class LogicalPlanner {
       currentNode = buildFilterNode(currentNode);
     }
     if (!analysis.getGroupByExpressions().isEmpty()) {
-      currentNode = buildAggregateNode(currentNode.getSchema(), currentNode);
+      currentNode = buildAggregateNode(currentNode);
     } else {
-      currentNode = buildProjectNode(currentNode.getSchema(), currentNode);
+      currentNode = buildProjectNode(currentNode);
     }
 
-    return buildOutputNode(
-        currentNode.getSchema(),
-        currentNode);
+    return buildOutputNode(currentNode);
   }
 
-  private OutputNode buildOutputNode(
-      final Schema inputSchema,
-      final PlanNode sourcePlanNode
-  ) {
+  private OutputNode buildOutputNode(final PlanNode sourcePlanNode) {
+    final Schema inputSchema = sourcePlanNode.getSchema();
     final Map<String, Object> intoProperties = analysis.getIntoProperties();
     final TimestampExtractionPolicy extractionPolicy =
         getTimestampExtractionPolicy(inputSchema, intoProperties);
@@ -102,12 +103,26 @@ public class LogicalPlanner {
 
     final Into intoDataSource = analysis.getInto().get();
 
+    final Optional<Field> partitionByField = Optional
+        .ofNullable(intoProperties.get(DdlConfig.PARTITION_BY_PROPERTY))
+        .map(Object::toString)
+        .map(keyName -> SchemaUtil.getFieldByName(inputSchema, keyName)
+            .orElseThrow(() -> new KsqlException(
+                "Column " + keyName + " does not exist in the result schema. "
+                    + "Error in Partition By clause.")
+            ));
+
+    final KeyField keyField = partitionByField
+        .map(Field::name)
+        .map(newKeyField -> sourcePlanNode.getKeyField().withName(newKeyField))
+        .orElse(sourcePlanNode.getKeyField());
+
     return new KsqlStructuredDataOutputNode(
         new PlanNodeId(intoDataSource.getName()),
         sourcePlanNode,
         inputSchema,
         extractionPolicy,
-        sourcePlanNode.getKeyField(),
+        keyField,
         intoDataSource.getKsqlTopic(),
         intoDataSource.getKsqlTopic().getKafkaTopicName(),
         intoProperties,
@@ -126,15 +141,18 @@ public class LogicalPlanner {
         (String) intoProperties.get(DdlConfig.TIMESTAMP_FORMAT_PROPERTY));
   }
 
-  private AggregateNode buildAggregateNode(
-      final Schema inputSchema,
-      final PlanNode sourcePlanNode
-  ) {
-    SchemaBuilder aggregateSchema = SchemaBuilder.struct();
+  private AggregateNode buildAggregateNode(final PlanNode sourcePlanNode) {
     final ExpressionTypeManager expressionTypeManager = new ExpressionTypeManager(
-        inputSchema,
+        sourcePlanNode.getSchema(),
         functionRegistry
     );
+
+    final Expression groupBy = analysis.getGroupByExpressions().size() == 1
+        ? analysis.getGroupByExpressions().get(0)
+        : null;
+
+    Optional<String> keyField = Optional.empty();
+    SchemaBuilder aggregateSchema = SchemaBuilder.struct();
     for (int i = 0; i < analysis.getSelectExpressions().size(); i++) {
       final Expression expression = analysis.getSelectExpressions().get(i);
       final String alias = analysis.getSelectExpressionAlias().get(i);
@@ -142,12 +160,17 @@ public class LogicalPlanner {
       final Schema expressionType = expressionTypeManager.getExpressionSchema(expression);
 
       aggregateSchema = aggregateSchema.field(alias, expressionType);
+
+      if (expression.equals(groupBy)) {
+        keyField = Optional.of(alias);
+      }
     }
 
     return new AggregateNode(
         new PlanNodeId("Aggregate"),
         sourcePlanNode,
         aggregateSchema,
+        keyField,
         analysis.getGroupByExpressions(),
         analysis.getWindowExpression(),
         aggregateAnalysis.getAggregateFunctionArguments(),
@@ -158,26 +181,38 @@ public class LogicalPlanner {
     );
   }
 
-  private ProjectNode buildProjectNode(final Schema inputSchema, final PlanNode sourcePlanNode) {
-    SchemaBuilder projectionSchema = SchemaBuilder.struct();
+  private ProjectNode buildProjectNode(final PlanNode sourcePlanNode) {
     final ExpressionTypeManager expressionTypeManager = new ExpressionTypeManager(
-        inputSchema,
+        sourcePlanNode.getSchema(),
         functionRegistry
     );
+
+    final String sourceKeyFieldName = sourcePlanNode
+        .getKeyField()
+        .name()
+        .orElse(null);
+
+    Optional<String> keyFieldName = Optional.empty();
+    final SchemaBuilder projectionSchema = SchemaBuilder.struct();
     for (int i = 0; i < analysis.getSelectExpressions().size(); i++) {
       final Expression expression = analysis.getSelectExpressions().get(i);
       final String alias = analysis.getSelectExpressionAlias().get(i);
 
       final Schema expressionType = expressionTypeManager.getExpressionSchema(expression);
 
-      projectionSchema = projectionSchema.field(alias, expressionType);
+      projectionSchema.field(alias, expressionType);
 
+      if (expression instanceof DereferenceExpression
+          && expression.toString().equals(sourceKeyFieldName)) {
+        keyFieldName = Optional.of(alias);
+      }
     }
 
     return new ProjectNode(
         new PlanNodeId("Project"),
         sourcePlanNode,
         projectionSchema,
+        keyFieldName,
         analysis.getSelectExpressions()
     );
   }
@@ -191,15 +226,24 @@ public class LogicalPlanner {
   private StructuredDataSourceNode buildSourceNode() {
 
     final Pair<StructuredDataSource, String> dataSource = analysis.getFromDataSource(0);
+    if (!(dataSource.left instanceof KsqlStream) && !(dataSource.left instanceof KsqlTable)) {
+      throw new RuntimeException("Data source is not supported yet.");
+    }
+
+    // Todo(ac): Next steps move this INTO StructuredDataSourceNode
     final Schema fromSchema = SchemaUtil.buildSchemaWithAlias(
         dataSource.left.getSchema(),
         dataSource.right
     );
 
-    if (dataSource.left instanceof KsqlStream || dataSource.left instanceof KsqlTable) {
-      return new StructuredDataSourceNode(new PlanNodeId("KsqlTopic"), dataSource.left, fromSchema);
-    }
-    throw new RuntimeException("Data source is not supported yet.");
-  }
+    final Optional<String> newKeyName = dataSource.left.getKeyField().name()
+        .map(name -> SchemaUtil.buildAliasedFieldName(dataSource.right, name));
 
+    return new StructuredDataSourceNode(
+        new PlanNodeId("KsqlTopic"),
+        dataSource.left,
+        fromSchema,
+        KeyField.of(newKeyName, dataSource.left.getKeyField().legacy())
+    );
+  }
 }

--- a/ksql-engine/src/main/java/io/confluent/ksql/planner/plan/AggregateNode.java
+++ b/ksql-engine/src/main/java/io/confluent/ksql/planner/plan/AggregateNode.java
@@ -465,8 +465,6 @@ public class AggregateNode extends PlanNode {
     private Expression resolveToInternal(final Expression exp) {
       final String name = expressionToInternalColumnNameMap.get(exp.toString());
       if (name != null) {
-        // Todo(ac): If we switch this to DereferenceExpression we fix
-        //   https://github.com/confluentinc/ksql/issues/1695
         return new QualifiedNameReference(exp.getLocation(), QualifiedName.of(name));
       }
 

--- a/ksql-engine/src/main/java/io/confluent/ksql/planner/plan/FilterNode.java
+++ b/ksql-engine/src/main/java/io/confluent/ksql/planner/plan/FilterNode.java
@@ -18,14 +18,14 @@ package io.confluent.ksql.planner.plan;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.google.common.collect.ImmutableList;
+import io.confluent.ksql.metastore.model.KeyField;
 import io.confluent.ksql.parser.tree.Expression;
 import io.confluent.ksql.physical.KsqlQueryBuilder;
 import io.confluent.ksql.services.KafkaTopicClient;
 import io.confluent.ksql.structured.SchemaKStream;
 import java.util.List;
-import java.util.Optional;
+import java.util.Objects;
 import javax.annotation.concurrent.Immutable;
-import org.apache.kafka.connect.data.Field;
 import org.apache.kafka.connect.data.Schema;
 
 @Immutable
@@ -33,7 +33,6 @@ public class FilterNode extends PlanNode {
 
   private final PlanNode source;
   private final Expression predicate;
-  private final Schema schema;
 
   @JsonCreator
   public FilterNode(@JsonProperty("id") final PlanNodeId id,
@@ -41,9 +40,8 @@ public class FilterNode extends PlanNode {
                     @JsonProperty("predicate") final Expression predicate) {
     super(id, source.getNodeOutputType());
 
-    this.source = source;
-    this.schema = source.getSchema();
-    this.predicate = predicate;
+    this.source = Objects.requireNonNull(source, "source");
+    this.predicate = Objects.requireNonNull(predicate, "predicate");
   }
 
   @JsonProperty("predicate")
@@ -53,11 +51,11 @@ public class FilterNode extends PlanNode {
 
   @Override
   public Schema getSchema() {
-    return this.schema;
+    return source.getSchema();
   }
 
   @Override
-  public Optional<Field> getKeyField() {
+  public KeyField getKeyField() {
     return source.getKeyField();
   }
 

--- a/ksql-engine/src/main/java/io/confluent/ksql/planner/plan/JoinNode.java
+++ b/ksql-engine/src/main/java/io/confluent/ksql/planner/plan/JoinNode.java
@@ -98,10 +98,10 @@ public class JoinNode extends PlanNode {
     this.leftType = leftType;
     this.rightType = rightType;
 
-    final String keyFieldName = leftAlias + "." + leftKeyFieldName;
+    final String keyFieldName = SchemaUtil.buildAliasedFieldName(leftAlias, leftKeyFieldName);
     this.keyField = Optional.ofNullable(schema.field(keyFieldName))
         .map(legacy -> KeyField.of(keyFieldName, legacy))
-        .orElseGet(() -> KeyField.of(Optional.empty(), Optional.empty()))
+        .orElseGet(KeyField::none)
         .validateKeyExistsIn(schema);
   }
 

--- a/ksql-engine/src/main/java/io/confluent/ksql/planner/plan/JoinNode.java
+++ b/ksql-engine/src/main/java/io/confluent/ksql/planner/plan/JoinNode.java
@@ -98,7 +98,6 @@ public class JoinNode extends PlanNode {
     this.leftType = leftType;
     this.rightType = rightType;
 
-    // Todo(ac): Pass keyfield in, as per others?
     final String keyFieldName = leftAlias + "." + leftKeyFieldName;
     this.keyField = Optional.ofNullable(schema.field(keyFieldName))
         .map(legacy -> KeyField.of(keyFieldName, legacy))

--- a/ksql-engine/src/main/java/io/confluent/ksql/planner/plan/KsqlBareOutputNode.java
+++ b/ksql-engine/src/main/java/io/confluent/ksql/planner/plan/KsqlBareOutputNode.java
@@ -17,6 +17,7 @@ package io.confluent.ksql.planner.plan;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
+import io.confluent.ksql.metastore.model.KeyField;
 import io.confluent.ksql.physical.KsqlQueryBuilder;
 import io.confluent.ksql.query.QueryId;
 import io.confluent.ksql.structured.QueuedSchemaKStream;
@@ -25,20 +26,24 @@ import io.confluent.ksql.util.QueryIdGenerator;
 import io.confluent.ksql.util.timestamp.TimestampExtractionPolicy;
 import java.util.Optional;
 import java.util.concurrent.ThreadLocalRandom;
-import org.apache.kafka.connect.data.Field;
 import org.apache.kafka.connect.data.Schema;
 
 @SuppressWarnings("OptionalUsedAsFieldOrParameterType")
 public class KsqlBareOutputNode extends OutputNode {
 
+  private final KeyField keyField;
+
   @JsonCreator
-  public KsqlBareOutputNode(@JsonProperty("id") final PlanNodeId id,
-                            @JsonProperty("source") final PlanNode source,
-                            @JsonProperty("schema") final Schema schema,
-                            @JsonProperty("limit") final Optional<Integer> limit,
-                            @JsonProperty("timestampExtraction")
-                              final TimestampExtractionPolicy extractionPolicy) {
+  public KsqlBareOutputNode(
+      @JsonProperty("id") final PlanNodeId id,
+      @JsonProperty("source") final PlanNode source,
+      @JsonProperty("schema") final Schema schema,
+      @JsonProperty("limit") final Optional<Integer> limit,
+      @JsonProperty("timestampExtraction") final TimestampExtractionPolicy extractionPolicy
+  ) {
     super(id, source, schema, limit, extractionPolicy);
+    this.keyField = KeyField.of(source.getKeyField().name(), Optional.empty())
+        .validateKeyExistsIn(schema);
   }
 
   @Override
@@ -47,8 +52,8 @@ public class KsqlBareOutputNode extends OutputNode {
   }
 
   @Override
-  public Optional<Field> getKeyField() {
-    return Optional.empty();
+  public KeyField getKeyField() {
+    return keyField;
   }
 
   @Override

--- a/ksql-engine/src/main/java/io/confluent/ksql/planner/plan/KsqlStructuredDataOutputNode.java
+++ b/ksql-engine/src/main/java/io/confluent/ksql/planner/plan/KsqlStructuredDataOutputNode.java
@@ -73,16 +73,14 @@ public class KsqlStructuredDataOutputNode extends OutputNode {
     this.outputProperties = Objects.requireNonNull(outputProperties, "outputProperties");
     this.doCreateInto = doCreateInto;
 
-    getPartitionByField(schema)
-        .filter(partitionByField -> keyField.name()
-            .map(kf -> !partitionByField.name().equals(kf))
-            .orElse(false))
-        .ifPresent(partitionByField -> {
-          throw new IllegalArgumentException(
-              "keyField does not match partition by field. "
-                  + "keyField: " + keyField.name() + ", "
-                  + "partitionByField:" + partitionByField);
-        });
+    final Optional<Field> partitionBy = getPartitionByField(schema);
+    if (partitionBy.isPresent()
+        && !partitionBy.get().name().equals(keyField.name().orElse(null))) {
+      throw new IllegalArgumentException(
+          "keyField does not match partition by field. "
+              + "keyField: " + keyField.name() + ", "
+              + "partitionByField:" + partitionBy.get());
+    }
   }
 
   public String getKafkaTopicName() {

--- a/ksql-engine/src/main/java/io/confluent/ksql/planner/plan/KsqlStructuredDataOutputNode.java
+++ b/ksql-engine/src/main/java/io/confluent/ksql/planner/plan/KsqlStructuredDataOutputNode.java
@@ -20,6 +20,7 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import io.confluent.ksql.GenericRow;
 import io.confluent.ksql.ddl.DdlConfig;
 import io.confluent.ksql.function.FunctionRegistry;
+import io.confluent.ksql.metastore.model.KeyField;
 import io.confluent.ksql.metastore.model.KsqlTopic;
 import io.confluent.ksql.physical.KsqlQueryBuilder;
 import io.confluent.ksql.query.QueryId;
@@ -47,7 +48,7 @@ import org.apache.kafka.connect.data.Schema;
 public class KsqlStructuredDataOutputNode extends OutputNode {
   private final String kafkaTopicName;
   private final KsqlTopic ksqlTopic;
-  private final Optional<Field> keyField;
+  private final KeyField keyField;
   private final boolean doCreateInto;
   private final Map<String, Object> outputProperties;
 
@@ -57,18 +58,31 @@ public class KsqlStructuredDataOutputNode extends OutputNode {
       @JsonProperty("source") final PlanNode source,
       @JsonProperty("schema") final Schema schema,
       @JsonProperty("timestamp") final TimestampExtractionPolicy timestampExtractionPolicy,
-      @JsonProperty("key") final Optional<Field> keyField,
+      @JsonProperty("key") final KeyField keyField,
       @JsonProperty("ksqlTopic") final KsqlTopic ksqlTopic,
       @JsonProperty("topicName") final String kafkaTopicName,
       @JsonProperty("outputProperties") final Map<String, Object> outputProperties,
       @JsonProperty("limit") final Optional<Integer> limit,
-      @JsonProperty("doCreateInto") final boolean doCreateInto) {
+      @JsonProperty("doCreateInto") final boolean doCreateInto
+  ) {
     super(id, source, schema, limit, timestampExtractionPolicy);
-    this.kafkaTopicName = kafkaTopicName;
-    this.keyField = Objects.requireNonNull(keyField, "keyField");
-    this.ksqlTopic = ksqlTopic;
-    this.outputProperties = outputProperties;
+    this.kafkaTopicName = Objects.requireNonNull(kafkaTopicName, "kafkaTopicName");
+    this.keyField = Objects.requireNonNull(keyField, "keyField")
+        .validateKeyExistsIn(schema);
+    this.ksqlTopic = Objects.requireNonNull(ksqlTopic, "ksqlTopic");
+    this.outputProperties = Objects.requireNonNull(outputProperties, "outputProperties");
     this.doCreateInto = doCreateInto;
+
+    getPartitionByField(schema)
+        .filter(partitionByField -> keyField.name()
+            .map(kf -> !partitionByField.name().equals(kf))
+            .orElse(false))
+        .ifPresent(partitionByField -> {
+          throw new IllegalArgumentException(
+              "keyField does not match partition by field. "
+                  + "keyField: " + keyField.name() + ", "
+                  + "partitionByField:" + partitionByField);
+        });
   }
 
   public String getKafkaTopicName() {
@@ -92,7 +106,7 @@ public class KsqlStructuredDataOutputNode extends OutputNode {
   }
 
   @Override
-  public Optional<Field> getKeyField() {
+  public KeyField getKeyField() {
     return keyField;
   }
 
@@ -104,7 +118,7 @@ public class KsqlStructuredDataOutputNode extends OutputNode {
     final QueryContext.Stacker contextStacker = builder.buildNodeContext(getId());
 
     final Set<Integer> rowkeyIndexes = SchemaUtil.getRowTimeRowKeyIndexes(getSchema());
-    final Builder outputNodeBuilder = Builder.from(this);
+    final Builder outputNodeBuilder = new Builder(this);
     final Schema schema = SchemaUtil.removeImplicitRowTimeRowKeyFromSchema(getSchema());
     outputNodeBuilder.withSchema(schema);
 
@@ -117,7 +131,6 @@ public class KsqlStructuredDataOutputNode extends OutputNode {
         outputNodeBuilder,
         builder.getKsqlConfig(),
         builder.getFunctionRegistry(),
-        outputProperties,
         contextStacker
     );
 
@@ -151,7 +164,6 @@ public class KsqlStructuredDataOutputNode extends OutputNode {
       final KsqlStructuredDataOutputNode.Builder outputNodeBuilder,
       final KsqlConfig ksqlConfig,
       final FunctionRegistry functionRegistry,
-      final Map<String, Object> outputProperties,
       final QueryContext.Stacker contextStacker
   ) {
 
@@ -159,10 +171,15 @@ public class KsqlStructuredDataOutputNode extends OutputNode {
       return schemaKStream;
     }
 
+    final KeyField resultKeyField = KeyField.of(
+        schemaKStream.getKeyField().name(),
+        getKeyField().legacy()
+    );
+
     final SchemaKStream result = new SchemaKStream(
         getSchema(),
         schemaKStream.getKstream(),
-        this.getKeyField(),
+        resultKeyField,
         Collections.singletonList(schemaKStream),
         schemaKStream.getKeySerdeFactory(),
         SchemaKStream.Type.SINK,
@@ -171,20 +188,24 @@ public class KsqlStructuredDataOutputNode extends OutputNode {
         contextStacker.getQueryContext()
     );
 
-    if (outputProperties.containsKey(DdlConfig.PARTITION_BY_PROPERTY)) {
-      final String keyFieldName = outputProperties.get(DdlConfig.PARTITION_BY_PROPERTY).toString();
-      final Field keyField = SchemaUtil.getFieldByName(
-          result.getSchema(), keyFieldName)
-          .orElseThrow(() -> new KsqlException(String.format(
-              "Column %s does not exist in the result schema."
-                  + " Error in Partition By clause.",
-              keyFieldName
-          )));
-
-      outputNodeBuilder.withKeyField(Optional.of(keyField));
-      return result.selectKey(keyField, false, contextStacker);
+    final Optional<Field> partitionByField = getPartitionByField(result.getSchema());
+    if (!partitionByField.isPresent()) {
+      return result;
     }
-    return result;
+
+    final Field field = partitionByField.get();
+    outputNodeBuilder.withKeyFields(Optional.of(field.name()), Optional.of(field));
+    return result.selectKey(field, false, contextStacker);
+  }
+
+  private Optional<Field> getPartitionByField(final Schema schema) {
+    return Optional.ofNullable(outputProperties.get(DdlConfig.PARTITION_BY_PROPERTY))
+        .map(Object::toString)
+        .map(keyName -> SchemaUtil.getFieldByName(schema, keyName)
+            .orElseThrow(() -> new KsqlException(
+                "Column " + keyName + " does not exist in the result schema. "
+                    + "Error in Partition By clause.")
+            ));
   }
 
   private void addAvroSchemaToResultTopic(final Builder builder) {
@@ -208,60 +229,32 @@ public class KsqlStructuredDataOutputNode extends OutputNode {
     return ksqlTopic.getKsqlTopicSerDe();
   }
 
-  public static class Builder {
+  private static class Builder {
 
-    private PlanNodeId id;
-    private PlanNode source;
+    private final KsqlStructuredDataOutputNode original;
     private Schema schema;
-    private TimestampExtractionPolicy timestampExtractionPolicy;
-    private Optional<Field> keyField;
+    private KeyField keyField;
     private KsqlTopic ksqlTopic;
-    private String kafkaTopicName;
-    private Map<String, Object> outputProperties;
-    private Optional<Integer> limit;
-    private boolean doCreateInto;
+
+    Builder(final KsqlStructuredDataOutputNode original) {
+      this.original = Objects.requireNonNull(original, "original");
+      this.schema = original.getSchema();
+      this.keyField = original.keyField;
+      this.ksqlTopic = original.ksqlTopic;
+    }
 
     public KsqlStructuredDataOutputNode build() {
       return new KsqlStructuredDataOutputNode(
-          id,
-          source,
+          original.getId(),
+          original.getSource(),
           schema,
-          timestampExtractionPolicy,
+          original.getTimestampExtractionPolicy(),
           keyField,
           ksqlTopic,
-          kafkaTopicName,
-          outputProperties,
-          limit,
-          doCreateInto);
-    }
-
-    public static Builder from(final KsqlStructuredDataOutputNode original) {
-      return new Builder()
-          .withId(original.getId())
-          .withSource(original.getSource())
-          .withSchema(original.getSchema())
-          .withTimestampExtractionPolicy(original.getTimestampExtractionPolicy())
-          .withKeyField(original.getKeyField())
-          .withKsqlTopic(original.getKsqlTopic())
-          .withKafkaTopicName(original.getKafkaTopicName())
-          .withOutputProperties(original.outputProperties)
-          .withLimit(original.getLimit())
-          .withDoCreateInto(original.isDoCreateInto());
-    }
-
-    Builder withLimit(final Optional<Integer> limit) {
-      this.limit = limit;
-      return this;
-    }
-
-    Builder withOutputProperties(final Map<String, Object> outputProperties) {
-      this.outputProperties = outputProperties;
-      return this;
-    }
-
-    Builder withKafkaTopicName(final String kafkaTopicName) {
-      this.kafkaTopicName = kafkaTopicName;
-      return this;
+          original.kafkaTopicName,
+          original.outputProperties,
+          original.getLimit(),
+          original.isDoCreateInto());
     }
 
     Builder withKsqlTopic(final KsqlTopic ksqlTopic) {
@@ -269,13 +262,11 @@ public class KsqlStructuredDataOutputNode extends OutputNode {
       return this;
     }
 
-    Builder withKeyField(final Optional<Field> keyField) {
-      this.keyField = keyField;
-      return this;
-    }
-
-    Builder withTimestampExtractionPolicy(final TimestampExtractionPolicy extractionPolicy) {
-      this.timestampExtractionPolicy = extractionPolicy;
+    Builder withKeyFields(
+        final Optional<String> keyFieldName,
+        final Optional<Field> legacyKeyField
+    ) {
+      this.keyField = KeyField.of(keyFieldName, legacyKeyField);
       return this;
     }
 
@@ -283,21 +274,5 @@ public class KsqlStructuredDataOutputNode extends OutputNode {
       this.schema = schema;
       return this;
     }
-
-    Builder withSource(final PlanNode source) {
-      this.source = source;
-      return this;
-    }
-
-    Builder withId(final PlanNodeId id) {
-      this.id = id;
-      return this;
-    }
-
-    Builder withDoCreateInto(final boolean doCreateInto) {
-      this.doCreateInto = doCreateInto;
-      return this;
-    }
-
   }
 }

--- a/ksql-engine/src/main/java/io/confluent/ksql/planner/plan/OutputNode.java
+++ b/ksql-engine/src/main/java/io/confluent/ksql/planner/plan/OutputNode.java
@@ -45,16 +45,15 @@ public abstract class OutputNode
       @JsonProperty("source") final PlanNode source,
       @JsonProperty("schema") final Schema schema,
       @JsonProperty("limit") final Optional<Integer> limit,
-      @JsonProperty("timestamp_policy") final TimestampExtractionPolicy timestampExtractionPolicy) {
+      @JsonProperty("timestamp_policy") final TimestampExtractionPolicy timestampExtractionPolicy
+  ) {
     super(id, source.getNodeOutputType());
-    requireNonNull(source, "source is null");
-    requireNonNull(schema, "schema is null");
-    requireNonNull(timestampExtractionPolicy, "timestampExtractionPolicy is null");
 
-    this.source = source;
-    this.schema = schema;
-    this.limit = limit;
-    this.timestampExtractionPolicy = timestampExtractionPolicy;
+    this.source = requireNonNull(source, "source");
+    this.schema = requireNonNull(schema, "schema");
+    this.limit = requireNonNull(limit, "limit");
+    this.timestampExtractionPolicy =
+        requireNonNull(timestampExtractionPolicy, "timestampExtractionPolicy");
   }
 
   @Override

--- a/ksql-engine/src/main/java/io/confluent/ksql/planner/plan/PlanNode.java
+++ b/ksql-engine/src/main/java/io/confluent/ksql/planner/plan/PlanNode.java
@@ -18,13 +18,12 @@ package io.confluent.ksql.planner.plan;
 import static java.util.Objects.requireNonNull;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
+import io.confluent.ksql.metastore.model.KeyField;
 import io.confluent.ksql.physical.KsqlQueryBuilder;
 import io.confluent.ksql.serde.DataSource.DataSourceType;
 import io.confluent.ksql.services.KafkaTopicClient;
 import io.confluent.ksql.structured.SchemaKStream;
 import java.util.List;
-import java.util.Optional;
-import org.apache.kafka.connect.data.Field;
 import org.apache.kafka.connect.data.Schema;
 
 
@@ -51,7 +50,7 @@ public abstract class PlanNode {
 
   public abstract Schema getSchema();
 
-  public abstract Optional<Field> getKeyField();
+  public abstract KeyField getKeyField();
 
   public abstract List<PlanNode> getSources();
 

--- a/ksql-engine/src/main/java/io/confluent/ksql/planner/plan/ProjectNode.java
+++ b/ksql-engine/src/main/java/io/confluent/ksql/planner/plan/ProjectNode.java
@@ -15,9 +15,12 @@
 
 package io.confluent.ksql.planner.plan;
 
+import static java.util.Objects.requireNonNull;
+
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.google.common.collect.ImmutableList;
+import io.confluent.ksql.metastore.model.KeyField;
 import io.confluent.ksql.parser.tree.Expression;
 import io.confluent.ksql.physical.KsqlQueryBuilder;
 import io.confluent.ksql.services.KafkaTopicClient;
@@ -26,30 +29,36 @@ import io.confluent.ksql.util.KsqlException;
 import io.confluent.ksql.util.SelectExpression;
 import java.util.ArrayList;
 import java.util.List;
-import java.util.Objects;
 import java.util.Optional;
 import javax.annotation.concurrent.Immutable;
-import org.apache.kafka.connect.data.Field;
 import org.apache.kafka.connect.data.Schema;
 
 @Immutable
-public class ProjectNode
-    extends PlanNode {
+public class ProjectNode extends PlanNode {
+
   private final PlanNode source;
   private final Schema schema;
   private final List<Expression> projectExpressions;
+  private final KeyField keyField;
 
   @JsonCreator
-  public ProjectNode(@JsonProperty("id") final PlanNodeId id,
-                     @JsonProperty("source") final PlanNode source,
-                     @JsonProperty("schema") final Schema schema,
-                     @JsonProperty("projectExpressions")
-                       final List<Expression> projectExpressions) {
+  public ProjectNode(
+      @JsonProperty("id") final PlanNodeId id,
+      @JsonProperty("source") final PlanNode source,
+      @JsonProperty("schema") final Schema schema,
+      @JsonProperty("key") final Optional<String> keyFieldName,
+      @JsonProperty("projectExpressions") final List<Expression> projectExpressions
+  ) {
     super(id, source.getNodeOutputType());
 
-    this.source = Objects.requireNonNull(source, "source");
-    this.schema = Objects.requireNonNull(schema, "schema");
-    this.projectExpressions = Objects.requireNonNull(projectExpressions, "projectExpressions");
+    this.source = requireNonNull(source, "source");
+    this.schema = requireNonNull(schema, "schema");
+    this.projectExpressions = requireNonNull(projectExpressions, "projectExpressions");
+    this.keyField = KeyField.of(
+        requireNonNull(keyFieldName, "keyFieldName"),
+        source.getKeyField().legacy())
+        .validateKeyExistsIn(schema);
+    // Todo(ac): add tests for all validateKeyExistsIn
 
     if (schema.fields().size() != projectExpressions.size()) {
       throw new KsqlException("Error in projection. Schema fields and expression list are not "
@@ -78,8 +87,8 @@ public class ProjectNode
   }
 
   @Override
-  public Optional<Field> getKeyField() {
-    return source.getKeyField();
+  public KeyField getKeyField() {
+    return keyField;
   }
 
   public List<SelectExpression> getProjectSelectExpressions() {

--- a/ksql-engine/src/main/java/io/confluent/ksql/planner/plan/ProjectNode.java
+++ b/ksql-engine/src/main/java/io/confluent/ksql/planner/plan/ProjectNode.java
@@ -58,7 +58,6 @@ public class ProjectNode extends PlanNode {
         requireNonNull(keyFieldName, "keyFieldName"),
         source.getKeyField().legacy())
         .validateKeyExistsIn(schema);
-    // Todo(ac): add tests for all validateKeyExistsIn
 
     if (schema.fields().size() != projectExpressions.size()) {
       throw new KsqlException("Error in projection. Schema fields and expression list are not "

--- a/ksql-engine/src/main/java/io/confluent/ksql/structured/SchemaKGroupedStream.java
+++ b/ksql-engine/src/main/java/io/confluent/ksql/structured/SchemaKGroupedStream.java
@@ -22,6 +22,7 @@ import io.confluent.ksql.function.UdafAggregator;
 import io.confluent.ksql.function.udaf.KudafAggregator;
 import io.confluent.ksql.function.udaf.window.WindowSelectMapper;
 import io.confluent.ksql.metastore.SerdeFactory;
+import io.confluent.ksql.metastore.model.KeyField;
 import io.confluent.ksql.parser.tree.KsqlWindowExpression;
 import io.confluent.ksql.parser.tree.WindowExpression;
 import io.confluent.ksql.streams.MaterializedFactory;
@@ -30,11 +31,9 @@ import io.confluent.ksql.util.KsqlConfig;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
-import java.util.Optional;
 import org.apache.kafka.common.serialization.Serde;
 import org.apache.kafka.common.serialization.Serdes;
 import org.apache.kafka.common.utils.Bytes;
-import org.apache.kafka.connect.data.Field;
 import org.apache.kafka.connect.data.Schema;
 import org.apache.kafka.streams.kstream.Initializer;
 import org.apache.kafka.streams.kstream.KGroupedStream;
@@ -49,7 +48,7 @@ public class SchemaKGroupedStream {
 
   final Schema schema;
   final KGroupedStream kgroupedStream;
-  final Optional<Field> keyField;
+  final KeyField keyField;
   final List<SchemaKStream> sourceSchemaKStreams;
   final KsqlConfig ksqlConfig;
   final FunctionRegistry functionRegistry;
@@ -58,7 +57,7 @@ public class SchemaKGroupedStream {
   SchemaKGroupedStream(
       final Schema schema,
       final KGroupedStream kgroupedStream,
-      final Optional<Field> keyField,
+      final KeyField keyField,
       final List<SchemaKStream> sourceSchemaKStreams,
       final KsqlConfig ksqlConfig,
       final FunctionRegistry functionRegistry
@@ -77,7 +76,7 @@ public class SchemaKGroupedStream {
   SchemaKGroupedStream(
       final Schema schema,
       final KGroupedStream kgroupedStream,
-      final Optional<Field> keyField,
+      final KeyField keyField,
       final List<SchemaKStream> sourceSchemaKStreams,
       final KsqlConfig ksqlConfig,
       final FunctionRegistry functionRegistry,
@@ -92,7 +91,7 @@ public class SchemaKGroupedStream {
     this.materializedFactory = materializedFactory;
   }
 
-  public Optional<Field> getKeyField() {
+  public KeyField getKeyField() {
     return keyField;
   }
 

--- a/ksql-engine/src/main/java/io/confluent/ksql/structured/SchemaKGroupedTable.java
+++ b/ksql-engine/src/main/java/io/confluent/ksql/structured/SchemaKGroupedTable.java
@@ -21,6 +21,7 @@ import io.confluent.ksql.function.KsqlAggregateFunction;
 import io.confluent.ksql.function.TableAggregationFunction;
 import io.confluent.ksql.function.udaf.KudafAggregator;
 import io.confluent.ksql.function.udaf.KudafUndoAggregator;
+import io.confluent.ksql.metastore.model.KeyField;
 import io.confluent.ksql.parser.tree.WindowExpression;
 import io.confluent.ksql.streams.MaterializedFactory;
 import io.confluent.ksql.streams.StreamsUtil;
@@ -29,11 +30,9 @@ import io.confluent.ksql.util.KsqlException;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
-import java.util.Optional;
 import java.util.stream.Collectors;
 import org.apache.kafka.common.serialization.Serde;
 import org.apache.kafka.common.serialization.Serdes;
-import org.apache.kafka.connect.data.Field;
 import org.apache.kafka.connect.data.Schema;
 import org.apache.kafka.streams.kstream.Initializer;
 import org.apache.kafka.streams.kstream.KGroupedTable;
@@ -46,7 +45,7 @@ public class SchemaKGroupedTable extends SchemaKGroupedStream {
   SchemaKGroupedTable(
       final Schema schema,
       final KGroupedTable kgroupedTable,
-      final Optional<Field> keyField,
+      final KeyField keyField,
       final List<SchemaKStream> sourceSchemaKStreams,
       final KsqlConfig ksqlConfig,
       final FunctionRegistry functionRegistry
@@ -64,7 +63,7 @@ public class SchemaKGroupedTable extends SchemaKGroupedStream {
   SchemaKGroupedTable(
       final Schema schema,
       final KGroupedTable kgroupedTable,
-      final Optional<Field> keyField,
+      final KeyField keyField,
       final List<SchemaKStream> sourceSchemaKStreams,
       final KsqlConfig ksqlConfig,
       final FunctionRegistry functionRegistry,

--- a/ksql-engine/src/main/java/io/confluent/ksql/structured/SchemaKStream.java
+++ b/ksql-engine/src/main/java/io/confluent/ksql/structured/SchemaKStream.java
@@ -272,7 +272,6 @@ public class SchemaKStream<K> {
       return Optional.empty();
     }
 
-    // Todo(ac): Roll these two into one?
     private Optional<Field> findLegacyKeyField(final List<SelectExpression> selectExpressions) {
       if (!getKeyField().legacy().isPresent()) {
         return Optional.empty();
@@ -366,7 +365,6 @@ public class SchemaKStream<K> {
                 StreamsUtil.buildOpName(contextStacker.getQueryContext()))
         );
 
-    // Todo(ac): Must join be in value schema?
     return new SchemaKStream<>(
         joinSchema,
         joinedKStream,
@@ -402,7 +400,6 @@ public class SchemaKStream<K> {
                     StreamsUtil.buildOpName(contextStacker.getQueryContext()))
             );
 
-    // Todo(ac): must join key be in value?
     return new SchemaKStream<>(
         joinSchema,
         joinStream,
@@ -435,7 +432,6 @@ public class SchemaKStream<K> {
                 StreamsUtil.buildOpName(contextStacker.getQueryContext()))
         );
 
-    // Todo(ac): must join key be in value?
     return new SchemaKStream<>(
         joinSchema,
         joinedKStream,
@@ -470,7 +466,6 @@ public class SchemaKStream<K> {
                     StreamsUtil.buildOpName(contextStacker.getQueryContext()))
             );
 
-    // Todo(ac): must join key be in value?
     return new SchemaKStream<>(
         joinSchema,
         joinStream,
@@ -504,7 +499,6 @@ public class SchemaKStream<K> {
                 StreamsUtil.buildOpName(contextStacker.getQueryContext()))
         );
 
-    // Todo(ac): must join key be in value?
     return new SchemaKStream<>(
         joinSchema,
         joinStream,
@@ -525,7 +519,6 @@ public class SchemaKStream<K> {
       final boolean updateRowKey,
       final QueryContext.Stacker contextStacker
   ) {
-    // Todo(ac): apurva's bug: https://github.com/confluentinc/ksql/issues/2525
     final boolean namesMatch = keyField.resolve(schema, ksqlConfig)
         .map(Field::name)
         .map(name -> name.equals(newKeyField.name()))

--- a/ksql-engine/src/main/java/io/confluent/ksql/structured/SchemaKStream.java
+++ b/ksql-engine/src/main/java/io/confluent/ksql/structured/SchemaKStream.java
@@ -528,7 +528,7 @@ public class SchemaKStream<K> {
       return new SchemaKStream<>(
           schema,
           kstream,
-          KeyField.of(Optional.of(newKeyField.name()), Optional.of(newKeyField)),
+          KeyField.of(newKeyField.name(), newKeyField),
           sourceSchemaKStreams,
           keySerdeFactory,
           type,
@@ -552,7 +552,7 @@ public class SchemaKStream<K> {
     return new SchemaKStream<>(
         schema,
         keyedKStream,
-        KeyField.of(Optional.of(newKeyField.name()), Optional.of(newKeyField)),
+        KeyField.of(newKeyField.name(), newKeyField),
         Collections.singletonList(this),
         Serdes::String,
         Type.REKEY,

--- a/ksql-engine/src/main/java/io/confluent/ksql/structured/SchemaKTable.java
+++ b/ksql-engine/src/main/java/io/confluent/ksql/structured/SchemaKTable.java
@@ -20,11 +20,13 @@ import io.confluent.ksql.GenericRow;
 import io.confluent.ksql.function.FunctionRegistry;
 import io.confluent.ksql.logging.processing.ProcessingLogContext;
 import io.confluent.ksql.metastore.SerdeFactory;
+import io.confluent.ksql.metastore.model.KeyField;
 import io.confluent.ksql.parser.tree.Expression;
 import io.confluent.ksql.streams.StreamsFactories;
 import io.confluent.ksql.streams.StreamsUtil;
 import io.confluent.ksql.util.KsqlConfig;
 import io.confluent.ksql.util.QueryLoggerUtil;
+import io.confluent.ksql.util.SchemaUtil;
 import io.confluent.ksql.util.SelectExpression;
 import java.util.ArrayList;
 import java.util.Collections;
@@ -49,7 +51,7 @@ public class SchemaKTable<K> extends SchemaKStream<K> {
   public SchemaKTable(
       final Schema schema,
       final KTable<K, GenericRow> ktable,
-      final Optional<Field> keyField,
+      final KeyField keyField,
       final List<SchemaKStream> sourceSchemaKStreams,
       final SerdeFactory<K> keySerdeFactory,
       final Type type,
@@ -74,7 +76,7 @@ public class SchemaKTable<K> extends SchemaKStream<K> {
   SchemaKTable(
       final Schema schema,
       final KTable<K, GenericRow> ktable,
-      final Optional<Field> keyField,
+      final KeyField keyField,
       final List<SchemaKStream> sourceSchemaKStreams,
       final SerdeFactory<K> keySerdeFactory,
       final Type type,
@@ -98,7 +100,6 @@ public class SchemaKTable<K> extends SchemaKStream<K> {
     this.ktable = ktable;
   }
 
-  @SuppressWarnings("unchecked")
   @Override
   public SchemaKTable<K> into(
       final String kafkaTopicName,
@@ -205,12 +206,16 @@ public class SchemaKTable<K> extends SchemaKStream<K> {
                     contextStacker.getQueryContext()), Serdes.String(), valSerde)
         );
 
-    final Field newKeyField = new Field(
+    final Field legacyKeyField = new Field(
         groupBy.aggregateKeyName, -1, Schema.OPTIONAL_STRING_SCHEMA);
+
+    final Optional<String> newKeyField = SchemaUtil.getFieldByName(schema, groupBy.aggregateKeyName)
+        .map(Field::name);
+
     return new SchemaKGroupedTable(
         schema,
         kgroupedTable,
-        Optional.of(newKeyField),
+        KeyField.of(newKeyField, Optional.of(legacyKeyField)),
         Collections.singletonList(this),
         ksqlConfig,
         functionRegistry);
@@ -228,10 +233,11 @@ public class SchemaKTable<K> extends SchemaKStream<K> {
         new KsqlValueJoiner(this.getSchema(), schemaKTable.getSchema())
     );
 
+    // Todo(ac): Must join be in value schema?
     return new SchemaKTable<>(
         joinSchema,
         joinedKTable,
-        Optional.of(joinKey),
+        KeyField.of(joinKey.name(), joinKey),
         ImmutableList.of(this, schemaKTable),
         keySerdeFactory,
         Type.JOIN,
@@ -254,10 +260,11 @@ public class SchemaKTable<K> extends SchemaKStream<K> {
             new KsqlValueJoiner(this.getSchema(), schemaKTable.getSchema())
         );
 
+    // Todo(ac): Must join be in value schema?
     return new SchemaKTable<>(
         joinSchema,
         joinedKTable,
-        Optional.of(joinKey),
+        KeyField.of(joinKey.name(), joinKey),
         ImmutableList.of(this, schemaKTable),
         keySerdeFactory,
         Type.JOIN,
@@ -280,10 +287,11 @@ public class SchemaKTable<K> extends SchemaKStream<K> {
             new KsqlValueJoiner(this.getSchema(), schemaKTable.getSchema())
         );
 
+    // Todo(ac): Must join be in value schema?
     return new SchemaKTable<>(
         joinSchema,
         joinedKTable,
-        Optional.of(joinKey),
+        KeyField.of(joinKey.name(), joinKey),
         ImmutableList.of(this, schemaKTable),
         keySerdeFactory,
         Type.JOIN,

--- a/ksql-engine/src/main/java/io/confluent/ksql/structured/SchemaKTable.java
+++ b/ksql-engine/src/main/java/io/confluent/ksql/structured/SchemaKTable.java
@@ -233,7 +233,6 @@ public class SchemaKTable<K> extends SchemaKStream<K> {
         new KsqlValueJoiner(this.getSchema(), schemaKTable.getSchema())
     );
 
-    // Todo(ac): Must join be in value schema?
     return new SchemaKTable<>(
         joinSchema,
         joinedKTable,
@@ -260,7 +259,6 @@ public class SchemaKTable<K> extends SchemaKStream<K> {
             new KsqlValueJoiner(this.getSchema(), schemaKTable.getSchema())
         );
 
-    // Todo(ac): Must join be in value schema?
     return new SchemaKTable<>(
         joinSchema,
         joinedKTable,
@@ -287,7 +285,6 @@ public class SchemaKTable<K> extends SchemaKStream<K> {
             new KsqlValueJoiner(this.getSchema(), schemaKTable.getSchema())
         );
 
-    // Todo(ac): Must join be in value schema?
     return new SchemaKTable<>(
         joinSchema,
         joinedKTable,

--- a/ksql-engine/src/test/java/io/confluent/ksql/EndToEndEngineTestUtil.java
+++ b/ksql-engine/src/test/java/io/confluent/ksql/EndToEndEngineTestUtil.java
@@ -1062,6 +1062,9 @@ final class EndToEndEngineTestUtil {
       testCase.verifyMetastore(ksqlEngine.getMetaStore());
     } catch (final RuntimeException e) {
       testCase.handleException(e);
+    } catch (final AssertionError e) {
+      throw new AssertionError("test: " + testCase.getName() + System.lineSeparator()
+          + e.getMessage(), e);
     }
   }
 

--- a/ksql-engine/src/test/java/io/confluent/ksql/QueryTranslationTest.java
+++ b/ksql-engine/src/test/java/io/confluent/ksql/QueryTranslationTest.java
@@ -916,5 +916,3 @@ public class QueryTranslationTest {
     }
   }
 }
-
-// Todo(ac): Release / upgrade notes

--- a/ksql-engine/src/test/java/io/confluent/ksql/analyzer/AnalyzerTest.java
+++ b/ksql-engine/src/test/java/io/confluent/ksql/analyzer/AnalyzerTest.java
@@ -25,6 +25,7 @@ import io.confluent.ksql.ddl.DdlConfig;
 import io.confluent.ksql.function.InternalFunctionRegistry;
 import io.confluent.ksql.metastore.MetaStore;
 import io.confluent.ksql.metastore.MutableMetaStore;
+import io.confluent.ksql.metastore.model.KeyField;
 import io.confluent.ksql.metastore.model.KsqlStream;
 import io.confluent.ksql.metastore.model.KsqlTopic;
 import io.confluent.ksql.parser.KsqlParser.PreparedStatement;
@@ -312,7 +313,7 @@ public class AnalyzerTest {
             "create stream s0 with(KAFKA_TOPIC='s0', VALUE_AVRO_SCHEMA_FULL_NAME='org.ac.s1', VALUE_FORMAT='avro');",
             "S0",
             schema,
-            Optional.of(schema.field("FIELD1")),
+            KeyField.of("FIELD1", schema.field("FIELD1")),
             new MetadataTimestampExtractionPolicy(),
             ksqlTopic,
             Serdes::String);

--- a/ksql-engine/src/test/java/io/confluent/ksql/codegen/CodeGenRunnerTest.java
+++ b/ksql-engine/src/test/java/io/confluent/ksql/codegen/CodeGenRunnerTest.java
@@ -39,6 +39,7 @@ import io.confluent.ksql.function.MutableFunctionRegistry;
 import io.confluent.ksql.function.UdfLoaderUtil;
 import io.confluent.ksql.function.udf.Kudf;
 import io.confluent.ksql.metastore.MutableMetaStore;
+import io.confluent.ksql.metastore.model.KeyField;
 import io.confluent.ksql.metastore.model.KsqlStream;
 import io.confluent.ksql.metastore.model.KsqlTopic;
 import io.confluent.ksql.parser.tree.Expression;
@@ -168,7 +169,7 @@ public class CodeGenRunnerTest {
             "sqlexpression",
             "CODEGEN_TEST",
             metaStoreSchema,
-            Optional.of(metaStoreSchema.field("COL0")),
+            KeyField.of("COL0", metaStoreSchema.field("COL0")),
             new MetadataTimestampExtractionPolicy(),
             ksqlTopic,Serdes::String);
         metaStore.putTopic(ksqlTopic);

--- a/ksql-engine/src/test/java/io/confluent/ksql/engine/KsqlEngineTest.java
+++ b/ksql-engine/src/test/java/io/confluent/ksql/engine/KsqlEngineTest.java
@@ -134,12 +134,6 @@ public class KsqlEngineTest {
     );
 
     sandbox = ksqlEngine.createSandbox();
-    doReturn(new TopicDescription("test1", true, Collections.singletonList(mock(TopicPartitionInfo.class))))
-        .when(topicClient).describeTopic("test1");
-    doReturn(new TopicDescription("test2", true, Collections.singletonList(mock(TopicPartitionInfo.class))))
-        .when(topicClient).describeTopic("test2");
-    doReturn(new TopicDescription("orders_topic", true, Collections.singletonList(mock(TopicPartitionInfo.class))))
-        .when(topicClient).describeTopic("orders_topic");
   }
 
   @After

--- a/ksql-engine/src/test/java/io/confluent/ksql/planner/LogicalPlannerTest.java
+++ b/ksql-engine/src/test/java/io/confluent/ksql/planner/LogicalPlannerTest.java
@@ -15,15 +15,17 @@
 
 package io.confluent.ksql.planner;
 
-import static io.confluent.ksql.metastore.model.StructuredDataSourceMatchers.FieldMatchers.hasName;
+import static io.confluent.ksql.metastore.model.MetaStoreMatchers.FieldMatchers.hasName;
 import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.CoreMatchers.instanceOf;
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
 
 import io.confluent.ksql.function.InternalFunctionRegistry;
 import io.confluent.ksql.metastore.MetaStore;
 import io.confluent.ksql.metastore.model.StructuredDataSource;
-import io.confluent.ksql.metastore.model.StructuredDataSourceMatchers.OptionalMatchers;
+import io.confluent.ksql.metastore.model.MetaStoreMatchers.FieldMatchers;
+import io.confluent.ksql.metastore.model.MetaStoreMatchers.OptionalMatchers;
 import io.confluent.ksql.planner.plan.AggregateNode;
 import io.confluent.ksql.planner.plan.FilterNode;
 import io.confluent.ksql.planner.plan.JoinNode;
@@ -34,6 +36,7 @@ import io.confluent.ksql.serde.DataSource;
 import io.confluent.ksql.serde.DataSource.DataSourceType;
 import io.confluent.ksql.testutils.AnalysisTestUtil;
 import io.confluent.ksql.util.MetaStoreFixture;
+import java.util.Optional;
 import org.apache.kafka.connect.data.Schema;
 import org.junit.Assert;
 import org.junit.Before;
@@ -105,7 +108,8 @@ public class LogicalPlannerTest {
     assertThat(logicalPlan.getSources().get(0), instanceOf(ProjectNode.class));
     final ProjectNode projectNode = (ProjectNode) logicalPlan.getSources().get(0);
 
-    assertThat(projectNode.getKeyField(), OptionalMatchers.of(hasName("T1.COL1")));
+    assertThat(projectNode.getKeyField().name(), is(Optional.of("T1_COL1")));
+    assertThat(projectNode.getKeyField().legacy(), OptionalMatchers.of(hasName("T1.COL1")));
     assertThat(projectNode.getSchema().fields().size(), equalTo(5));
 
     assertThat(projectNode.getSources().get(0), instanceOf(FilterNode.class));
@@ -116,7 +120,6 @@ public class LogicalPlannerTest {
     final JoinNode joinNode = (JoinNode) filterNode.getSources().get(0);
     assertThat(joinNode.getSources().get(0), instanceOf(StructuredDataSourceNode.class));
     assertThat(joinNode.getSources().get(1), instanceOf(StructuredDataSourceNode.class));
-
   }
 
   @Test
@@ -226,6 +229,24 @@ public class LogicalPlannerTest {
     final String simpleQuery = "SELECT * FROM TEST2 INNER JOIN TEST3 ON TEST2.COL0=TEST3.COL0;";
     final PlanNode logicalPlan = buildLogicalPlan(simpleQuery);
     assertThat(logicalPlan.getNodeOutputType(), equalTo(DataSourceType.KTABLE));
+  }
+
+  @Test
+  public void shouldUpdateKeyToReflectProjectionAlias() {
+    // Given:
+    final String simpleQuery = "SELECT COL0 AS NEW_KEY FROM TEST2;";
+
+    // When:
+    final PlanNode logicalPlan = buildLogicalPlan(simpleQuery);
+
+    // Then:
+    assertThat(logicalPlan.getKeyField().name(), is(Optional.of("NEW_KEY")));
+    assertThat(logicalPlan.getKeyField().legacy(), is(Optional.empty()));
+
+    final PlanNode source = logicalPlan.getSources().get(0);
+    assertThat(source.getKeyField().name(), is(Optional.of("NEW_KEY")));
+    assertThat(source.getKeyField().legacy(),
+        is(OptionalMatchers.of(FieldMatchers.hasName("COL0"))));
   }
 
   private PlanNode buildLogicalPlan(final String query) {

--- a/ksql-engine/src/test/java/io/confluent/ksql/planner/plan/AggregateNodeTest.java
+++ b/ksql-engine/src/test/java/io/confluent/ksql/planner/plan/AggregateNodeTest.java
@@ -15,7 +15,7 @@
 
 package io.confluent.ksql.planner.plan;
 
-import static io.confluent.ksql.metastore.model.StructuredDataSourceMatchers.FieldMatchers.hasName;
+import static io.confluent.ksql.metastore.model.MetaStoreMatchers.FieldMatchers.hasName;
 import static io.confluent.ksql.planner.plan.PlanTestUtil.MAPVALUES_NODE;
 import static io.confluent.ksql.planner.plan.PlanTestUtil.SOURCE_NODE;
 import static io.confluent.ksql.planner.plan.PlanTestUtil.getNodeByName;
@@ -44,7 +44,7 @@ import io.confluent.ksql.function.FunctionRegistry;
 import io.confluent.ksql.function.InternalFunctionRegistry;
 import io.confluent.ksql.logging.processing.ProcessingLogContext;
 import io.confluent.ksql.metastore.MetaStore;
-import io.confluent.ksql.metastore.model.StructuredDataSourceMatchers.OptionalMatchers;
+import io.confluent.ksql.metastore.model.MetaStoreMatchers.OptionalMatchers;
 import io.confluent.ksql.physical.KsqlQueryBuilder;
 import io.confluent.ksql.query.QueryId;
 import io.confluent.ksql.structured.QueryContext;
@@ -356,7 +356,8 @@ public class AggregateNodeTest {
         + "GROUP BY UCASE(col1);");
 
     // Then:
-    assertThat(stream.getKeyField(), OptionalMatchers.of(hasName("UCASE(KSQL_INTERNAL_COL_0)")));
+    assertThat(stream.getKeyField().name(), is(Optional.empty()));
+    assertThat(stream.getKeyField().legacy(), OptionalMatchers.of(hasName("UCASE(KSQL_INTERNAL_COL_0)")));
   }
 
   @Test
@@ -366,7 +367,8 @@ public class AggregateNodeTest {
         + "GROUP BY col0 + 10;");
 
     // Then:
-    assertThat(stream.getKeyField(), OptionalMatchers.of(hasName("(KSQL_INTERNAL_COL_0 + 10)")));
+    assertThat(stream.getKeyField().name(), is(Optional.empty()));
+    assertThat(stream.getKeyField().legacy(), OptionalMatchers.of(hasName("(KSQL_INTERNAL_COL_0 + 10)")));
   }
 
   private SchemaKStream buildQuery(final String queryString) {

--- a/ksql-engine/src/test/java/io/confluent/ksql/planner/plan/JoinNodeTest.java
+++ b/ksql-engine/src/test/java/io/confluent/ksql/planner/plan/JoinNodeTest.java
@@ -30,6 +30,7 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
 import com.google.common.collect.ImmutableList;
@@ -40,6 +41,7 @@ import io.confluent.ksql.GenericRow;
 import io.confluent.ksql.function.InternalFunctionRegistry;
 import io.confluent.ksql.logging.processing.ProcessingLogContext;
 import io.confluent.ksql.metastore.MetaStore;
+import io.confluent.ksql.metastore.model.KeyField;
 import io.confluent.ksql.metastore.model.KsqlTopic;
 import io.confluent.ksql.metastore.model.StructuredDataSource;
 import io.confluent.ksql.parser.tree.WithinExpression;
@@ -151,7 +153,9 @@ public class JoinNodeTest {
     EasyMock.expect(mockKsqlConfig.cloneWithPropertyOverwrite(
         Collections.singletonMap(ConsumerConfig.AUTO_OFFSET_RESET_CONFIG, "earliest")))
         .andStubReturn(mockKsqlConfigClonedWithOffsetReset);
-    EasyMock.expect(rightSchemaKTable.getKeyField()).andReturn(Optional.empty()).anyTimes();
+    EasyMock.expect(rightSchemaKTable.getKeyField())
+        .andReturn(KeyField.of(Optional.empty(), Optional.empty()))
+        .anyTimes();
 
     EasyMock.replay(serviceContext, mockKsqlConfig);
 
@@ -970,7 +974,8 @@ public class JoinNodeTest {
   @SuppressWarnings("unchecked")
   private void setupTable(final StructuredDataSourceNode node, final SchemaKTable table,
                           final Schema schema, final int partitions) {
-    expect(node.getSchema()).andReturn(schema);
+    expect(node.getSchema()).andReturn(schema).anyTimes();
+    expect(table.getSchema()).andReturn(schema).anyTimes();
     expect(node.getPartitions(mockKafkaTopicClient)).andReturn(partitions);
 
     expect(node.buildStream(ksqlStreamBuilder)).andReturn(table);
@@ -1005,16 +1010,16 @@ public class JoinNodeTest {
       final SchemaKStream stream,
       final Schema schema,
       final int partitions) {
-    expect(node.getSchema()).andReturn(schema);
+    expect(node.getSchema()).andReturn(schema).anyTimes();
     expect(node.getPartitions(mockKafkaTopicClient)).andReturn(partitions);
     expectBuildStream(node, contextStacker, stream, schema);
   }
 
   private static void expectKeyField(final SchemaKStream stream, final String keyFieldName) {
     final Field field = niceMock(Field.class);
-    expect(stream.getKeyField()).andStubReturn(Optional.of(field));
     expect(field.name()).andStubReturn(keyFieldName);
     replay(field);
+    expect(stream.getKeyField()).andStubReturn(KeyField.of(keyFieldName, field));
   }
 
   private Schema joinSchema() {
@@ -1046,7 +1051,6 @@ public class JoinNodeTest {
     expect(ksqlTopic.getKsqlTopicSerDe()).andReturn(ksqlTopicSerde);
 
     final Serde<GenericRow> serde = niceMock(Serde.class);
-    expect(node.getSchema()).andReturn(schema);
     expect(ksqlTopicSerde.getGenericRowSerde(
         schema,
         ksqlConfig,

--- a/ksql-engine/src/test/java/io/confluent/ksql/planner/plan/JoinNodeTest.java
+++ b/ksql-engine/src/test/java/io/confluent/ksql/planner/plan/JoinNodeTest.java
@@ -154,7 +154,7 @@ public class JoinNodeTest {
         Collections.singletonMap(ConsumerConfig.AUTO_OFFSET_RESET_CONFIG, "earliest")))
         .andStubReturn(mockKsqlConfigClonedWithOffsetReset);
     EasyMock.expect(rightSchemaKTable.getKeyField())
-        .andReturn(KeyField.of(Optional.empty(), Optional.empty()))
+        .andReturn(KeyField.none())
         .anyTimes();
 
     EasyMock.replay(serviceContext, mockKsqlConfig);

--- a/ksql-engine/src/test/java/io/confluent/ksql/planner/plan/StructuredDataSourceNodeTest.java
+++ b/ksql-engine/src/test/java/io/confluent/ksql/planner/plan/StructuredDataSourceNodeTest.java
@@ -265,7 +265,7 @@ public class StructuredDataSourceNodeTest {
     final KeyField actual = stream.getKeyField();
 
     // Then:
-    assertThat(actual, is(sameInstance(keyField)));
+    assertThat(actual, is(keyField));
   }
 
   @Test

--- a/ksql-engine/src/test/java/io/confluent/ksql/structured/SchemaKGroupedStreamTest.java
+++ b/ksql-engine/src/test/java/io/confluent/ksql/structured/SchemaKGroupedStreamTest.java
@@ -32,6 +32,7 @@ import com.google.common.collect.ImmutableMap;
 import io.confluent.ksql.GenericRow;
 import io.confluent.ksql.function.FunctionRegistry;
 import io.confluent.ksql.function.KsqlAggregateFunction;
+import io.confluent.ksql.metastore.model.KeyField;
 import io.confluent.ksql.parser.tree.KsqlWindowExpression;
 import io.confluent.ksql.parser.tree.WindowExpression;
 import io.confluent.ksql.query.QueryId;
@@ -68,7 +69,7 @@ public class SchemaKGroupedStreamTest {
   @Mock
   private KGroupedStream groupedStream;
   @Mock
-  private Optional<Field> keyField;
+  private KeyField keyField;
   @Mock
   private List<SchemaKStream> sourceStreams;
   @Mock

--- a/ksql-engine/src/test/java/io/confluent/ksql/structured/SchemaKGroupedTableTest.java
+++ b/ksql-engine/src/test/java/io/confluent/ksql/structured/SchemaKGroupedTableTest.java
@@ -32,6 +32,7 @@ import io.confluent.ksql.function.KsqlAggregateFunction;
 import io.confluent.ksql.function.udaf.KudafInitializer;
 import io.confluent.ksql.logging.processing.ProcessingLogContext;
 import io.confluent.ksql.metastore.MetaStore;
+import io.confluent.ksql.metastore.model.KeyField;
 import io.confluent.ksql.metastore.model.KsqlTable;
 import io.confluent.ksql.parser.tree.DereferenceExpression;
 import io.confluent.ksql.parser.tree.Expression;
@@ -113,7 +114,7 @@ public class SchemaKGroupedTableTest {
     final SchemaKTable<?> initialSchemaKTable = new SchemaKTable<>(
         logicalPlan.getTheSourceNode().getSchema(),
         kTable,
-        ksqlTable.getKeyField(),
+        logicalPlan.getTheSourceNode().getKeyField(),
         new ArrayList<>(),
         Serdes::String,
         SchemaKStream.Type.SOURCE,
@@ -205,7 +206,7 @@ public class SchemaKGroupedTableTest {
     return new SchemaKGroupedTable(
         schema,
         kGroupedTable,
-        Optional.of(schema.fields().get(0)),
+        KeyField.of(schema.fields().get(0).name(), schema.fields().get(0)),
         Collections.emptyList(),
         ksqlConfig,
         functionRegistry,

--- a/ksql-engine/src/test/java/io/confluent/ksql/structured/SchemaKStreamTest.java
+++ b/ksql-engine/src/test/java/io/confluent/ksql/structured/SchemaKStreamTest.java
@@ -321,8 +321,7 @@ public class SchemaKStreamTest {
         .select(selectExpressions, childContextStacker, processingLogContext);
 
     // Then:
-    assertThat(result.getKeyField(),
-        is(KeyField.of(Optional.empty(), Optional.empty())));
+    assertThat(result.getKeyField(), is(KeyField.none()));
   }
 
   @Test
@@ -337,7 +336,7 @@ public class SchemaKStreamTest {
         .select(selectExpressions, childContextStacker, processingLogContext);
 
     // Then:
-    assertThat(result.getKeyField(), is(KeyField.of(Optional.empty(), Optional.empty())));
+    assertThat(result.getKeyField(), is(KeyField.none()));
   }
 
   @Test

--- a/ksql-engine/src/test/java/io/confluent/ksql/structured/SchemaKTableTest.java
+++ b/ksql-engine/src/test/java/io/confluent/ksql/structured/SchemaKTableTest.java
@@ -580,8 +580,7 @@ public class SchemaKTableTest {
         .select(selectExpressions, childContextStacker, processingLogContext);
 
     // Then:
-    MatcherAssert.assertThat(result.getKeyField(),
-        is(KeyField.of(Optional.empty(), Optional.empty())));
+    MatcherAssert.assertThat(result.getKeyField(), is(KeyField.none()));
   }
 
   @Test
@@ -595,7 +594,7 @@ public class SchemaKTableTest {
         .select(selectExpressions, childContextStacker, processingLogContext);
 
     // Then:
-    MatcherAssert.assertThat(result.getKeyField(), is(KeyField.of(Optional.empty(), Optional.empty())));
+    MatcherAssert.assertThat(result.getKeyField(), is(KeyField.none()));
   }
 
   @Test

--- a/ksql-engine/src/test/java/io/confluent/ksql/structured/SchemaKTableTest.java
+++ b/ksql-engine/src/test/java/io/confluent/ksql/structured/SchemaKTableTest.java
@@ -25,14 +25,17 @@ import static org.easymock.EasyMock.same;
 import static org.easymock.EasyMock.verify;
 import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.CoreMatchers.instanceOf;
+import static org.hamcrest.Matchers.is;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertThat;
 
+import com.google.common.collect.ImmutableList;
 import io.confluent.kafka.schemaregistry.client.MockSchemaRegistryClient;
 import io.confluent.ksql.GenericRow;
 import io.confluent.ksql.function.InternalFunctionRegistry;
 import io.confluent.ksql.logging.processing.ProcessingLogContext;
 import io.confluent.ksql.metastore.MetaStore;
+import io.confluent.ksql.metastore.model.KeyField;
 import io.confluent.ksql.metastore.model.KsqlTable;
 import io.confluent.ksql.metastore.model.KsqlTopic;
 import io.confluent.ksql.parser.tree.DereferenceExpression;
@@ -56,6 +59,7 @@ import io.confluent.ksql.util.KsqlConfig;
 import io.confluent.ksql.util.MetaStoreFixture;
 import io.confluent.ksql.util.SchemaTestUtil;
 import io.confluent.ksql.util.SchemaUtil;
+import io.confluent.ksql.util.SelectExpression;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
@@ -76,12 +80,15 @@ import org.apache.kafka.streams.kstream.KeyValueMapper;
 import org.apache.kafka.streams.kstream.Predicate;
 import org.easymock.Capture;
 import org.easymock.EasyMock;
+import org.hamcrest.MatcherAssert;
+import org.hamcrest.Matchers;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
 
 @SuppressWarnings("unchecked")
 public class SchemaKTableTest {
+
   private final KsqlConfig ksqlConfig = new KsqlConfig(Collections.emptyMap());
   private final MetaStore metaStore = MetaStoreFixture.getNewMetaStore(new InternalFunctionRegistry());
   private final GroupedFactory groupedFactory = mock(GroupedFactory.class);
@@ -101,6 +108,11 @@ public class SchemaKTableTest {
   private final QueryContext parentContext = queryContext.push("parent").getQueryContext();
   private final QueryContext.Stacker childContextStacker = queryContext.push("child");
   private final ProcessingLogContext processingLogContext = ProcessingLogContext.create();
+  private Serde<GenericRow> rowSerde;
+  private static final Expression TEST_2_COL_1 = new DereferenceExpression(
+      new QualifiedNameReference(QualifiedName.of("TEST2")), "COL1");
+  private static final Expression TEST_2_COL_2 = new DereferenceExpression(
+      new QualifiedNameReference(QualifiedName.of("TEST2")), "COL2");
 
   @Before
   public void init() {
@@ -125,14 +137,14 @@ public class SchemaKTableTest {
   }
 
   private SchemaKTable buildSchemaKTable(
-      final KsqlTable<?> ksqlTable,
       final Schema schema,
+      final KeyField keyField,
       final KTable kTable,
       final GroupedFactory groupedFactory) {
     return new SchemaKTable(
         schema,
         kTable,
-        ksqlTable.getKeyField(),
+        keyField,
         new ArrayList<>(),
         Serdes::String,
         Type.SOURCE,
@@ -148,17 +160,26 @@ public class SchemaKTableTest {
   private SchemaKTable buildSchemaKTable(
       final KsqlTable ksqlTable,
       final KTable kTable,
-      final GroupedFactory groupedFactory) {
+      final GroupedFactory groupedFactory
+  ) {
+    final Schema schema = SchemaUtil
+        .buildSchemaWithAlias(ksqlTable.getSchema(), ksqlTable.getName());
+
+    final Optional<String> newKeyName = ksqlTable.getKeyField().name()
+        .map(name -> SchemaUtil.buildAliasedFieldName(ksqlTable.getName(), name));
+
+    final KeyField keyFieldWithAlias = KeyField.of(newKeyName, ksqlTable.getKeyField().legacy());
+
     return buildSchemaKTable(
-        ksqlTable,
-        SchemaUtil.buildSchemaWithAlias(ksqlTable.getSchema(), ksqlTable.getName()),
+        schema,
+        keyFieldWithAlias,
         kTable,
         groupedFactory);
   }
 
   private SchemaKTable buildSchemaKTableForJoin(final KsqlTable ksqlTable, final KTable kTable) {
     return buildSchemaKTable(
-        ksqlTable, ksqlTable.getSchema(), kTable, GroupedFactory.create(ksqlConfig));
+        ksqlTable.getSchema(), ksqlTable.getKeyField(), kTable, GroupedFactory.create(ksqlConfig));
   }
 
   private Serde<GenericRow> getRowSerde(final KsqlTopic topic, final Schema schema) {
@@ -179,7 +200,7 @@ public class SchemaKTableTest {
     initialSchemaKTable = new SchemaKTable<>(
         logicalPlan.getTheSourceNode().getSchema(),
         kTable,
-        ksqlTable.getKeyField(),
+        logicalPlan.getTheSourceNode().getKeyField(),
         new ArrayList<>(),
         Serdes::String,
         SchemaKStream.Type.SOURCE,
@@ -218,7 +239,7 @@ public class SchemaKTableTest {
     initialSchemaKTable = new SchemaKTable<>(
         logicalPlan.getTheSourceNode().getSchema(),
         kTable,
-        ksqlTable.getKeyField(),
+        logicalPlan.getTheSourceNode().getKeyField(),
         new ArrayList<>(),
         Serdes::String,
         SchemaKStream.Type.SOURCE,
@@ -260,7 +281,7 @@ public class SchemaKTableTest {
     initialSchemaKTable = new SchemaKTable<>(
         logicalPlan.getTheSourceNode().getSchema(),
         kTable,
-        ksqlTable.getKeyField(),
+        logicalPlan.getTheSourceNode().getKeyField(),
         new ArrayList<>(),
         Serdes::String,
         SchemaKStream.Type.SOURCE,
@@ -303,7 +324,7 @@ public class SchemaKTableTest {
     initialSchemaKTable = new SchemaKTable<>(
         logicalPlan.getTheSourceNode().getSchema(),
         kTable,
-        ksqlTable.getKeyField(),
+        logicalPlan.getTheSourceNode().getKeyField(),
         new ArrayList<>(),
         Serdes::String,
         SchemaKStream.Type.SOURCE,
@@ -311,10 +332,6 @@ public class SchemaKTableTest {
         functionRegistry,
         parentContext);
 
-    final Expression col1Expression = new DereferenceExpression(
-        new QualifiedNameReference(QualifiedName.of("TEST2")), "COL1");
-    final Expression col2Expression = new DereferenceExpression(
-        new QualifiedNameReference(QualifiedName.of("TEST2")), "COL2");
     final KsqlTopicSerDe ksqlTopicSerDe = new KsqlJsonTopicSerDe();
     final Serde<GenericRow> rowSerde = ksqlTopicSerDe.getGenericRowSerde(
         SchemaTestUtil.getSchemaWithNoAlias(initialSchemaKTable.getSchema()),
@@ -322,14 +339,16 @@ public class SchemaKTableTest {
         () -> null,
         "test",
         processingLogContext);
-    final List<Expression> groupByExpressions = Arrays.asList(col2Expression, col1Expression);
+    final List<Expression> groupByExpressions = Arrays.asList(TEST_2_COL_2, TEST_2_COL_1);
     final SchemaKGroupedStream groupedSchemaKTable = initialSchemaKTable.groupBy(
         rowSerde,
         groupByExpressions,
         childContextStacker);
 
     assertThat(groupedSchemaKTable, instanceOf(SchemaKGroupedTable.class));
-    assertThat(groupedSchemaKTable.getKeyField().get().name(), equalTo("TEST2.COL2|+|TEST2.COL1"));
+    assertThat(groupedSchemaKTable.getKeyField().name(), is(Optional.empty()));
+    assertThat(groupedSchemaKTable.getKeyField().legacy().map(Field::name),
+        is(Optional.of("TEST2.COL2|+|TEST2.COL1")));
   }
 
   @Test
@@ -346,9 +365,8 @@ public class SchemaKTableTest {
     final KGroupedTable groupedTable = mock(KGroupedTable.class);
     expect(mockKTable.groupBy(anyObject(), same(grouped))).andReturn(groupedTable);
     replay(groupedFactory, mockKTable);
-    final Expression col1Expression = new DereferenceExpression(
-        new QualifiedNameReference(QualifiedName.of(ksqlTable.getName())), "COL1");
-    final List<Expression> groupByExpressions = Collections.singletonList(col1Expression);
+
+    final List<Expression> groupByExpressions = Collections.singletonList(TEST_2_COL_1);
     final SchemaKTable schemaKTable = buildSchemaKTable(ksqlTable, mockKTable, groupedFactory);
 
     // When:
@@ -377,7 +395,7 @@ public class SchemaKTableTest {
     initialSchemaKTable = new SchemaKTable<>(
         logicalPlan.getTheSourceNode().getSchema(),
         mockKTable,
-        ksqlTable.getKeyField(),
+        logicalPlan.getTheSourceNode().getKeyField(),
         new ArrayList<>(),
         Serdes::String,
         SchemaKStream.Type.SOURCE,
@@ -385,12 +403,7 @@ public class SchemaKTableTest {
         functionRegistry,
         parentContext);
 
-    // Given a grouping expression comprising COL1 and COL2
-    final Expression col1Expression = new DereferenceExpression(
-        new QualifiedNameReference(QualifiedName.of("TEST2")), "COL1");
-    final Expression col2Expression = new DereferenceExpression(
-        new QualifiedNameReference(QualifiedName.of("TEST2")), "COL2");
-    final List<Expression> groupByExpressions = Arrays.asList(col2Expression, col1Expression);
+    final List<Expression> groupByExpressions = Arrays.asList(TEST_2_COL_2, TEST_2_COL_1);
     final Serde<GenericRow> rowSerde = new KsqlJsonTopicSerDe().getGenericRowSerde(
         SchemaTestUtil.getSchemaWithNoAlias(initialSchemaKTable.getSchema()),
         null,
@@ -432,7 +445,7 @@ public class SchemaKTableTest {
     assertThat(joinedKStream, instanceOf(SchemaKTable.class));
     assertEquals(SchemaKStream.Type.JOIN, joinedKStream.type);
     assertEquals(joinSchema, joinedKStream.schema);
-    assertEquals(Optional.of(joinSchema.fields().get(0)), joinedKStream.keyField);
+    assertEquals(Optional.of(joinSchema.fields().get(0).name()), joinedKStream.keyField.name());
     assertEquals(Arrays.asList(firstSchemaKTable, secondSchemaKTable),
                  joinedKStream.sourceSchemaKStreams);
   }
@@ -454,7 +467,7 @@ public class SchemaKTableTest {
     assertThat(joinedKStream, instanceOf(SchemaKTable.class));
     assertEquals(SchemaKStream.Type.JOIN, joinedKStream.type);
     assertEquals(joinSchema, joinedKStream.schema);
-    assertEquals(Optional.of(joinSchema.fields().get(0)), joinedKStream.keyField);
+    assertEquals(Optional.of(joinSchema.fields().get(0).name()), joinedKStream.keyField.name());
     assertEquals(Arrays.asList(firstSchemaKTable, secondSchemaKTable),
                  joinedKStream.sourceSchemaKStreams);
   }
@@ -476,10 +489,128 @@ public class SchemaKTableTest {
     assertThat(joinedKStream, instanceOf(SchemaKTable.class));
     assertEquals(SchemaKStream.Type.JOIN, joinedKStream.type);
     assertEquals(joinSchema, joinedKStream.schema);
-    assertEquals(Optional.of(joinSchema.fields().get(0)), joinedKStream.keyField);
+    assertEquals(Optional.of(joinSchema.fields().get(0).name()), joinedKStream.keyField.name());
     assertEquals(Arrays.asList(firstSchemaKTable, secondSchemaKTable),
                  joinedKStream.sourceSchemaKStreams);
 
+  }
+
+  @Test
+  public void shouldUpdateKeyIfRenamed() {
+    // Given:
+    final List<SelectExpression> selectExpressions = givenInitialKTableOf(
+        "SELECT col0 as NEWKEY, col2, col3 FROM test1;");
+
+    // When:
+    final SchemaKStream result = initialSchemaKTable
+        .select(selectExpressions, childContextStacker, processingLogContext);
+
+    MatcherAssert.assertThat(result.getKeyField(),
+        is(KeyField.of("NEWKEY", new Field("NEWKEY", 0, Schema.OPTIONAL_INT64_SCHEMA))));
+  }
+
+  @Test
+  public void shouldUpdateKeyIfRenamedViaFullyQualifiedName() {
+    // Given:
+    final List<SelectExpression> selectExpressions = givenInitialKTableOf(
+        "SELECT test1.col0 as NEWKEY, col2, col3 FROM test1;");
+
+    // When:
+    final SchemaKStream result = initialSchemaKTable
+        .select(selectExpressions, childContextStacker, processingLogContext);
+
+    // Then:
+    MatcherAssert.assertThat(result.getKeyField(),
+        is(KeyField.of("NEWKEY", new Field("NEWKEY", 0, Schema.OPTIONAL_INT64_SCHEMA))));
+  }
+
+  @Test
+  public void shouldUpdateKeyIfRenamedAndSourceIsAliased() {
+    // Given:
+    final List<SelectExpression> selectExpressions = givenInitialKTableOf(
+        "SELECT t.col0 as NEWKEY, col2, col3 FROM test1 t;");
+
+    // When:
+    final SchemaKStream result = initialSchemaKTable
+        .select(selectExpressions, childContextStacker, processingLogContext);
+
+    // Then:
+    MatcherAssert.assertThat(result.getKeyField(),
+        is(KeyField.of("NEWKEY", new Field("NEWKEY", 0, Schema.OPTIONAL_INT64_SCHEMA))));
+  }
+
+  @Test
+  public void shouldPreserveKeyOnSelectStar() {
+    // Given:
+    final List<SelectExpression> selectExpressions = givenInitialKTableOf(
+        "SELECT * FROM test1;");
+
+    // When:
+    final SchemaKStream result = initialSchemaKTable
+        .select(selectExpressions, childContextStacker, processingLogContext);
+
+    // Then:
+    MatcherAssert.assertThat(result.getKeyField(),
+        is(KeyField.of(Optional.of("COL0"), initialSchemaKTable.keyField.legacy())));
+  }
+
+  @Test
+  public void shouldUpdateKeyIfMovedToDifferentIndex() {
+    // Given:
+    final List<SelectExpression> selectExpressions = givenInitialKTableOf(
+        "SELECT col2, col0, col3 FROM test1;");
+
+    // When:
+    final SchemaKStream result = initialSchemaKTable
+        .select(selectExpressions, childContextStacker, processingLogContext);
+
+    // Then:
+    MatcherAssert.assertThat(result.getKeyField(),
+        Matchers.equalTo(KeyField.of("COL0", new Field("COL0", 1, Schema.OPTIONAL_INT64_SCHEMA))));
+  }
+
+  @Test
+  public void shouldDropKeyIfNotSelected() {
+    // Given:
+    final List<SelectExpression> selectExpressions = givenInitialKTableOf(
+        "SELECT col2, col3 FROM test1;");
+
+    // When:
+    final SchemaKStream result = initialSchemaKTable
+        .select(selectExpressions, childContextStacker, processingLogContext);
+
+    // Then:
+    MatcherAssert.assertThat(result.getKeyField(),
+        is(KeyField.of(Optional.empty(), Optional.empty())));
+  }
+
+  @Test
+  public void shouldHandleSourceWithoutKey() {
+    // Given:
+    final List<SelectExpression> selectExpressions = givenInitialKTableOf(
+        "SELECT * FROM test4;");
+
+    // When:
+    final SchemaKStream result = initialSchemaKTable
+        .select(selectExpressions, childContextStacker, processingLogContext);
+
+    // Then:
+    MatcherAssert.assertThat(result.getKeyField(), is(KeyField.of(Optional.empty(), Optional.empty())));
+  }
+
+  @Test
+  public void shouldSetKeyOnGroupBySingleExpressionThatIsInProjection() {
+    // Given:
+    givenInitialKTableOf("SELECT * FROM test2;");
+    final List<Expression> groupByExprs =  ImmutableList.of(TEST_2_COL_1);
+
+    // When:
+    final SchemaKGroupedStream result = initialSchemaKTable
+        .groupBy(rowSerde, groupByExprs, childContextStacker);
+
+    // Then:
+    MatcherAssert.assertThat(result.getKeyField(),
+        is(KeyField.of("TEST2.COL1", new Field("TEST2.COL1", -1, Schema.OPTIONAL_STRING_SCHEMA))));
   }
 
   private static Schema getJoinSchema(final Schema leftSchema, final Schema rightSchema) {
@@ -496,6 +627,31 @@ public class SchemaKTableTest {
       schemaBuilder.field(fieldName, field.schema());
     }
     return schemaBuilder.build();
+  }
+
+  private List<SelectExpression> givenInitialKTableOf(final String selectQuery) {
+    final PlanNode logicalPlan = AnalysisTestUtil.buildLogicalPlan(selectQuery, metaStore);
+
+    initialSchemaKTable = new SchemaKTable<>(
+        logicalPlan.getTheSourceNode().getSchema(),
+        kTable,
+        logicalPlan.getTheSourceNode().getKeyField(),
+        new ArrayList<>(),
+        Serdes::String,
+        SchemaKStream.Type.SOURCE,
+        ksqlConfig,
+        functionRegistry,
+        parentContext);
+
+    rowSerde = new KsqlJsonTopicSerDe().getGenericRowSerde(
+        SchemaTestUtil.getSchemaWithNoAlias(initialSchemaKTable.getSchema()),
+        null,
+        () -> null,
+        "test",
+        processingLogContext);
+
+    final ProjectNode projectNode = (ProjectNode) logicalPlan.getSources().get(0);
+    return projectNode.getProjectSelectExpressions();
   }
 
   private PlanNode buildLogicalPlan(final String query) {

--- a/ksql-engine/src/test/java/io/confluent/ksql/topic/DefaultTopicInjectorTest.java
+++ b/ksql-engine/src/test/java/io/confluent/ksql/topic/DefaultTopicInjectorTest.java
@@ -30,6 +30,7 @@ import io.confluent.ksql.ddl.DdlConfig;
 import io.confluent.ksql.function.InternalFunctionRegistry;
 import io.confluent.ksql.metastore.MetaStoreImpl;
 import io.confluent.ksql.metastore.MutableMetaStore;
+import io.confluent.ksql.metastore.model.KeyField;
 import io.confluent.ksql.metastore.model.KsqlStream;
 import io.confluent.ksql.metastore.model.KsqlTopic;
 import io.confluent.ksql.parser.DefaultKsqlParser;
@@ -102,7 +103,7 @@ public class DefaultTopicInjectorTest {
         "",
         "SOURCE",
         SCHEMA,
-        Optional.empty(),
+        KeyField.of(Optional.empty(), Optional.empty()),
         new MetadataTimestampExtractionPolicy(),
         sourceTopic,
         Serdes::String);
@@ -114,7 +115,7 @@ public class DefaultTopicInjectorTest {
         "",
         "J_SOURCE",
         SCHEMA,
-        Optional.empty(),
+        KeyField.of(Optional.empty(), Optional.empty()),
         new MetadataTimestampExtractionPolicy(),
         joinTopic,
         Serdes::String);

--- a/ksql-engine/src/test/java/io/confluent/ksql/topic/DefaultTopicInjectorTest.java
+++ b/ksql-engine/src/test/java/io/confluent/ksql/topic/DefaultTopicInjectorTest.java
@@ -103,7 +103,7 @@ public class DefaultTopicInjectorTest {
         "",
         "SOURCE",
         SCHEMA,
-        KeyField.of(Optional.empty(), Optional.empty()),
+        KeyField.none(),
         new MetadataTimestampExtractionPolicy(),
         sourceTopic,
         Serdes::String);
@@ -115,7 +115,7 @@ public class DefaultTopicInjectorTest {
         "",
         "J_SOURCE",
         SCHEMA,
-        KeyField.of(Optional.empty(), Optional.empty()),
+        KeyField.none(),
         new MetadataTimestampExtractionPolicy(),
         joinTopic,
         Serdes::String);

--- a/ksql-engine/src/test/resources/query-validation-tests/README.md
+++ b/ksql-engine/src/test/resources/query-validation-tests/README.md
@@ -234,12 +234,7 @@ A post condition can define the list of sources that must exist in the metastore
   "name": "S1",
   "type": "table",
   "keyField": {"name": "FOO", "legacyName": "KSQL_INTERNAL_COL_0", "legacySchema": {"type": "STRING"}},
-  "valueSchema": {"type": "STRUCT", "fields": [
-    {"name": "ROWTIME", "schema": {"type": "BIGINT"}},
-    {"name": "ROWKEY", "schema": {"type": "STRING"}},
-    {"name": "FOO", "schema": {"type": "INT"}},
-    {"name": "KSQL_COL_1", "schema": {"type": "BIGINT"}}
-  ]}
+  "valueSchema": "STRUCT<ROWTIME BIGINT, ROWKEY STRING, FOO INT, KSQL_COL_1 BIGINT>"
 }
 ```
 
@@ -250,7 +245,7 @@ Each source can define the following attributes:
 | name        | (Required) The name of the source. |
 | type        | (Required) Specifies if the source is a STREAM or TABLE. |
 | keyField    | (Optional) Specifies the keyField for the source. (See below for details of key field) |
-| valueSchema | (Optional) Specifies the value schema for the source. |
+| valueSchema | (Optional) Specifies the value SQL schema for the source. |
 
 ##### Key Fields
 
@@ -260,7 +255,7 @@ Key field nodes can define the following attributes:
 |-------------|:------------|
 | name        | (Optional) The name of the key field. If present, but set to `null`, the name of the key field is expected to not be set. If not supplied, the name of the key field will not be checked. |
 | legacyName  | (Optional) The legacy name of the key field. If present, but set to `null`, the legacy name of the key field is expected to not be set. If not supplied, the legacy name of the key field will not be checked. |
-| legacySchema| (Optional) The legacy schema of the key field. If present, but set to `null`, the legacy schema of the key field is expected to not be set. If not supplied, the legacy schema of the key field will not be checked. |
+| legacySchema| (Optional) The legacy SQL schema of the key field. If present, but set to `null`, the legacy schema of the key field is expected to not be set. If not supplied, the legacy schema of the key field will not be checked. |
 
 A test case can not test the value of the the key field by not including a keyField node in the source:
 

--- a/ksql-engine/src/test/resources/query-validation-tests/joins.json
+++ b/ksql-engine/src/test/resources/query-validation-tests/joins.json
@@ -36,11 +36,8 @@
         {"topic": "LEFT_OUTER_JOIN", "key": 0, "value": {"T_ID": 0, "NAME": "bar", "VALUE": 99, "F1": null, "F2": null}, "timestamp": 30000}
       ],
       "post": {
-        "issues": [
-          "key field has incorrect name - should be T_ID"
-        ],
         "sources": [
-          {"name": "LEFT_OUTER_JOIN", "type": "stream", "keyField": {"name": "T.ID", "schema": {"type": "BIGINT"}}}
+          {"name": "LEFT_OUTER_JOIN", "type": "stream", "keyField": {"name": "T_ID", "legacyName": "T.ID", "legacySchema": {"type": "BIGINT"}}}
         ]
       }
     },
@@ -49,7 +46,7 @@
       "comments": [
         "The purpose of this test is to capture the topology of a downstream query of the above test case",
         "and test the key fields of the entities added to the metastore, to ensure backwards compatibility is maintained",
-        "In this case, the code used to incorrectly set the keyField to 'T.ID' rather than the correct 'T_ID'",
+        "In this case, the code previously incorrectly set the keyField to 'T.ID' rather than the correct 'T_ID'",
         "This would result in an unnecessary repartition step being added to the DOWNSTREAM query.",
         "New versions of the code must not remove this unnecessary step for existing queries, as that would break backwards compatibility"
       ],
@@ -59,14 +56,17 @@
         "CREATE STREAM LEFT_OUTER_JOIN as SELECT t.id, name, value, f1, f2 FROM test t left join TEST_STREAM tt WITHIN 11 seconds ON t.id = tt.id;",
         "CREATE STREAM DOWNSTREAM as SELECT T_ID FROM LEFT_OUTER_JOIN PARTITION BY T_ID;"
       ],
+      "properties": {
+        "ksql.query.fields.key.legacy": "true"
+      },
       "inputs": [
       ],
       "outputs": [
       ],
       "post": {
         "sources": [
-          {"name": "LEFT_OUTER_JOIN", "type": "stream", "keyField": {"name": "T.ID", "schema": {"type": "BIGINT"}}},
-          {"name": "DOWNSTREAM", "type": "stream", "keyField": {"name": "T_ID", "schema": {"type": "BIGINT"}}}
+          {"name": "LEFT_OUTER_JOIN", "type": "stream", "keyField": {"name": "T_ID", "legacyName": "T.ID", "legacySchema": {"type": "BIGINT"}}},
+          {"name": "DOWNSTREAM", "type": "stream", "keyField": {"name": "T_ID", "legacyName": "T_ID", "legacySchema": {"type": "BIGINT"}}}
         ]
       }
     },
@@ -114,11 +114,8 @@
         {"topic": "LEFT_OUTER_JOIN", "key": 0, "value": {"T_ID": 0, "NAME": "bar", "VALUE": 99, "F1": null, "F2": null}, "timestamp": 30000}
       ],
       "post": {
-        "issues": [
-          "key field has incorrect name - should be T_ID"
-        ],
         "sources": [
-          {"name": "LEFT_OUTER_JOIN", "type": "stream", "keyField": {"name": "T.ID", "schema": {"type": "BIGINT"}}}
+          {"name": "LEFT_OUTER_JOIN", "type": "stream", "keyField": {"name": "T_ID", "legacyName": "T.ID", "legacySchema": {"type": "BIGINT"}}}
         ]
       }
     },
@@ -127,7 +124,7 @@
       "comments": [
         "The purpose of this test is to capture the topology of a downstream query of the above test case",
         "and test the key fields of the entities added to the metastore, to ensure backwards compatibility is maintained",
-        "In this case, the code used to incorrectly set the keyField to 'T.ID' rather than the correct 'T_ID'",
+        "In this case, the code previously incorrectly set the keyField to 'T.ID' rather than the correct 'T_ID'",
         "This would result in an unnecessary repartition step being added to the DOWNSTREAM query.",
         "New versions of the code must not remove this unnecessary step for existing queries, as that would break backwards compatibility"
       ],
@@ -137,18 +134,17 @@
         "CREATE STREAM LEFT_OUTER_JOIN as SELECT t.id, name, value, f1, f2 FROM test t left join TEST_STREAM tt WITHIN 11 seconds ON t.id = tt.id;",
         "CREATE TABLE DOWNSTREAM as SELECT T_ID, COUNT() FROM LEFT_OUTER_JOIN GROUP BY T_ID;"
       ],
+      "properties": {
+        "ksql.query.fields.key.legacy": "true"
+      },
       "inputs": [
       ],
       "outputs": [
       ],
       "post": {
-        "issues": [
-          "key field has incorrect name - should be T_ID",
-          "key field has incorrect schema - should be BIGINT"
-        ],
         "sources": [
-          {"name": "LEFT_OUTER_JOIN", "type": "stream", "keyField": {"name": "T.ID", "schema": {"type": "BIGINT"}}},
-          {"name": "DOWNSTREAM", "type": "table", "keyField": {"name": "KSQL_INTERNAL_COL_0", "schema": {"type": "STRING"}}}
+          {"name": "LEFT_OUTER_JOIN", "type": "stream", "keyField": {"name": "T_ID", "legacyName": "T.ID", "legacySchema": {"type": "BIGINT"}}},
+          {"name": "DOWNSTREAM", "type": "table", "keyField": {"name": "T_ID", "legacyName": "KSQL_INTERNAL_COL_0", "legacySchema": {"type": "STRING"}}}
         ]
       }
     },
@@ -176,11 +172,8 @@
         {"topic": "INNER_JOIN", "key": 0, "value": {"T_ID": 0, "NAME": "foo", "VALUE": 100, "F1": "a", "F2": 10}, "timestamp": 15000}
       ],
       "post": {
-        "issues": [
-          "key field has incorrect name - should be T_ID"
-        ],
         "sources": [
-          {"name": "INNER_JOIN", "type": "stream", "keyField": {"name": "T.ID", "schema": {"type": "BIGINT"}}}
+          {"name": "INNER_JOIN", "type": "stream", "keyField": {"name": "T_ID", "legacyName": "T.ID", "legacySchema": {"type": "BIGINT"}}}
         ]
       }
     },
@@ -189,7 +182,7 @@
       "comments": [
         "The purpose of this test is to capture the topology of a downstream query of the above test case",
         "and test the key fields of the entities added to the metastore, to ensure backwards compatibility is maintained",
-        "In this case, the code used to incorrectly set the keyField to 'T.ID' rather than the correct 'T_ID'",
+        "In this case, the code previously incorrectly set the keyField to 'T.ID' rather than the correct 'T_ID'",
         "This would result in an unnecessary repartition step being added to the DOWNSTREAM query.",
         "New versions of the code must not remove this unnecessary step for existing queries, as that would break backwards compatibility"
       ],
@@ -199,14 +192,17 @@
         "CREATE STREAM INNER_JOIN as SELECT t.id, name, value, f1, f2 FROM test t join TEST_STREAM tt WITHIN 11 SECONDS ON t.id = tt.id;",
         "CREATE STREAM DOWNSTREAM AS SELECT T_ID FROM INNER_JOIN;"
       ],
+      "properties": {
+        "ksql.query.fields.key.legacy": "true"
+      },
       "inputs": [
       ],
       "outputs": [
       ],
       "post": {
         "sources": [
-          {"name": "INNER_JOIN", "type": "stream", "keyField": {"name": "T.ID", "schema": {"type": "BIGINT"}}},
-          {"name": "DOWNSTREAM", "type": "stream", "keyField": {"name": "T.ID", "schema": {"type": "BIGINT"}}}
+          {"name": "INNER_JOIN", "type": "stream", "keyField": {"name": "T_ID", "legacyName": "T.ID", "legacySchema": {"type": "BIGINT"}}},
+          {"name": "DOWNSTREAM", "type": "stream", "keyField": {"name": "T_ID", "legacyName": "T.ID", "legacySchema": {"type": "BIGINT"}}}
         ]
       }
     },
@@ -396,7 +392,7 @@
       ],
       "post": {
         "sources": [
-          {"name": "LEFT_OUTER_JOIN", "type": "table", "keyField": {"name": "T_ID", "schema": {"type": "BIGINT"}}}
+          {"name": "LEFT_OUTER_JOIN", "type": "table", "keyField": {"name": "T_ID", "legacyName": "T_ID", "legacySchema": {"type": "BIGINT"}}}
         ]
       }
     },
@@ -426,7 +422,7 @@
       ],
       "post": {
         "sources": [
-          {"name": "INNER_JOIN", "type": "table", "keyField": {"name": "T_ID", "schema": {"type": "BIGINT"}}}
+          {"name": "INNER_JOIN", "type": "table", "keyField": {"name": "T_ID", "legacyName": "T_ID", "legacySchema": {"type": "BIGINT"}}}
         ]
       }
     },
@@ -458,7 +454,7 @@
       ],
       "post": {
         "sources": [
-          {"name": "OUTER_JOIN", "type": "table", "keyField": {"name": "T_ID", "schema": {"type": "BIGINT"}}}
+          {"name": "OUTER_JOIN", "type": "table", "keyField": {"name": "T_ID", "legacyName": "T_ID", "legacySchema": {"type": "BIGINT"}}}
         ]
       }
     },
@@ -486,11 +482,8 @@
         {"topic": "LEFT_JOIN", "key": 90, "value": {"T_ID": 90, "NAME": "ninety", "VALUE": 90, "F1": null, "F2": null}, "timestamp": 15000}
       ],
       "post": {
-        "issues": [
-          "key field has incorrect name - should be T_ID"
-        ],
         "sources": [
-          {"name": "LEFT_JOIN", "type": "stream", "keyField": {"name": "T.ID", "schema": {"type": "BIGINT"}}}
+          {"name": "LEFT_JOIN", "type": "stream", "keyField": {"name": "T_ID", "legacyName": "T.ID", "legacySchema": {"type": "BIGINT"}}}
         ]
       }
     },
@@ -517,11 +510,8 @@
         {"topic": "INNER_JOIN", "key": 0, "value": {"T_ID": 0, "NAME": "bar", "VALUE": 99, "F1": "a", "F2": 10}, "timestamp": 15000}
       ],
       "post": {
-        "issues": [
-          "key field has incorrect name - should be T_ID"
-        ],
         "sources": [
-          {"name": "INNER_JOIN", "type": "stream", "keyField": {"name": "T.ID", "schema": {"type": "BIGINT"}}}
+          {"name": "INNER_JOIN", "type": "stream", "keyField": {"name": "T_ID", "legacyName": "T.ID", "legacySchema": {"type": "BIGINT"}}}
         ]
       }
     },
@@ -553,7 +543,7 @@
           "key field has incorrect type - should be BIGINT"
         ],
         "sources": [
-          {"name": "INNER_JOIN", "type": "stream", "keyField": {"name": "T.ROWKEY", "schema": {"type": "STRING"}}}
+          {"name": "INNER_JOIN", "type": "stream", "keyField": {"name": null, "legacyName": "T.ROWKEY", "legacySchema": {"type": "STRING"}}}
         ]
       }
     },
@@ -562,7 +552,7 @@
       "comments": [
         "The purpose of this test is to capture the topology of a downstream query of the above test case",
         "and test the key fields of the entities added to the metastore, to ensure backwards compatibility is maintained",
-        "In this case, the code used to incorrectly set the keyField to 'T.ROWKEY' rather than the correct 'T_ID'",
+        "In this case, the code previously incorrectly set the keyField to 'T.ROWKEY' rather than the correct 'T_ID'",
         "This would result in an unnecessary repartition step being added to the DOWNSTREAM query.",
         "New versions of the code must not remove this unnecessary step for existing queries, as that would break backwards compatibility"
       ],
@@ -572,14 +562,17 @@
         "CREATE STREAM INNER_JOIN as SELECT t.id AS ID, name, value, f1, f2 FROM test t join test_table tt on t.ROWKEY = tt.ROWKEY;",
         "CREATE STREAM DOWNSTREAM AS SELECT ID FROM INNER_JOIN PARTITION BY ID;"
       ],
+      "properties": {
+        "ksql.query.fields.key.legacy": "true"
+      },
       "inputs": [
       ],
       "outputs": [
       ],
       "post": {
         "sources": [
-          {"name": "INNER_JOIN", "type": "stream", "keyField": {"name": "T.ROWKEY", "schema": {"type": "STRING"}}},
-          {"name": "DOWNSTREAM", "type": "stream", "keyField": {"name": "ID", "schema": {"type": "BIGINT"}}}
+          {"name": "INNER_JOIN", "type": "stream", "keyField": {"name": null, "legacyName": "T.ROWKEY", "legacySchema": {"type": "STRING"}}},
+          {"name": "DOWNSTREAM", "type": "stream", "keyField": {"name": "ID", "legacyName": "ID", "legacySchema": {"type": "BIGINT"}}}
         ]
       }
     },
@@ -638,7 +631,7 @@
       ],
       "post": {
         "sources": [
-          {"name": "OUTPUT", "type": "table", "keyField": {"name": "T_ID", "schema": {"type": "BIGINT"}}}
+          {"name": "OUTPUT", "type": "table", "keyField": {"name": "T_ID", "legacyName": "T_ID", "legacySchema": {"type": "BIGINT"}}}
         ]
       }
     }

--- a/ksql-engine/src/test/resources/query-validation-tests/joins.json
+++ b/ksql-engine/src/test/resources/query-validation-tests/joins.json
@@ -37,7 +37,7 @@
       ],
       "post": {
         "sources": [
-          {"name": "LEFT_OUTER_JOIN", "type": "stream", "keyField": {"name": "T_ID", "legacyName": "T.ID", "legacySchema": {"type": "BIGINT"}}}
+          {"name": "LEFT_OUTER_JOIN", "type": "stream", "keyField": {"name": "T_ID", "legacyName": "T.ID", "legacySchema": "BIGINT"}}
         ]
       }
     },
@@ -65,8 +65,8 @@
       ],
       "post": {
         "sources": [
-          {"name": "LEFT_OUTER_JOIN", "type": "stream", "keyField": {"name": "T_ID", "legacyName": "T.ID", "legacySchema": {"type": "BIGINT"}}},
-          {"name": "DOWNSTREAM", "type": "stream", "keyField": {"name": "T_ID", "legacyName": "T_ID", "legacySchema": {"type": "BIGINT"}}}
+          {"name": "LEFT_OUTER_JOIN", "type": "stream", "keyField": {"name": "T_ID", "legacyName": "T.ID", "legacySchema": "BIGINT"}},
+          {"name": "DOWNSTREAM", "type": "stream", "keyField": {"name": "T_ID", "legacyName": "T_ID", "legacySchema": "BIGINT"}}
         ]
       }
     },
@@ -115,7 +115,7 @@
       ],
       "post": {
         "sources": [
-          {"name": "LEFT_OUTER_JOIN", "type": "stream", "keyField": {"name": "T_ID", "legacyName": "T.ID", "legacySchema": {"type": "BIGINT"}}}
+          {"name": "LEFT_OUTER_JOIN", "type": "stream", "keyField": {"name": "T_ID", "legacyName": "T.ID", "legacySchema": "BIGINT"}}
         ]
       }
     },
@@ -143,8 +143,8 @@
       ],
       "post": {
         "sources": [
-          {"name": "LEFT_OUTER_JOIN", "type": "stream", "keyField": {"name": "T_ID", "legacyName": "T.ID", "legacySchema": {"type": "BIGINT"}}},
-          {"name": "DOWNSTREAM", "type": "table", "keyField": {"name": "T_ID", "legacyName": "KSQL_INTERNAL_COL_0", "legacySchema": {"type": "STRING"}}}
+          {"name": "LEFT_OUTER_JOIN", "type": "stream", "keyField": {"name": "T_ID", "legacyName": "T.ID", "legacySchema": "BIGINT"}},
+          {"name": "DOWNSTREAM", "type": "table", "keyField": {"name": "T_ID", "legacyName": "KSQL_INTERNAL_COL_0", "legacySchema": "STRING"}}
         ]
       }
     },
@@ -173,7 +173,7 @@
       ],
       "post": {
         "sources": [
-          {"name": "INNER_JOIN", "type": "stream", "keyField": {"name": "T_ID", "legacyName": "T.ID", "legacySchema": {"type": "BIGINT"}}}
+          {"name": "INNER_JOIN", "type": "stream", "keyField": {"name": "T_ID", "legacyName": "T.ID", "legacySchema": "BIGINT"}}
         ]
       }
     },
@@ -201,8 +201,8 @@
       ],
       "post": {
         "sources": [
-          {"name": "INNER_JOIN", "type": "stream", "keyField": {"name": "T_ID", "legacyName": "T.ID", "legacySchema": {"type": "BIGINT"}}},
-          {"name": "DOWNSTREAM", "type": "stream", "keyField": {"name": "T_ID", "legacyName": "T.ID", "legacySchema": {"type": "BIGINT"}}}
+          {"name": "INNER_JOIN", "type": "stream", "keyField": {"name": "T_ID", "legacyName": "T.ID", "legacySchema": "BIGINT"}},
+          {"name": "DOWNSTREAM", "type": "stream", "keyField": {"name": "T_ID", "legacyName": "T.ID", "legacySchema": "BIGINT"}}
         ]
       }
     },
@@ -392,7 +392,7 @@
       ],
       "post": {
         "sources": [
-          {"name": "LEFT_OUTER_JOIN", "type": "table", "keyField": {"name": "T_ID", "legacyName": "T_ID", "legacySchema": {"type": "BIGINT"}}}
+          {"name": "LEFT_OUTER_JOIN", "type": "table", "keyField": {"name": "T_ID", "legacyName": "T_ID", "legacySchema": "BIGINT"}}
         ]
       }
     },
@@ -422,7 +422,7 @@
       ],
       "post": {
         "sources": [
-          {"name": "INNER_JOIN", "type": "table", "keyField": {"name": "T_ID", "legacyName": "T_ID", "legacySchema": {"type": "BIGINT"}}}
+          {"name": "INNER_JOIN", "type": "table", "keyField": {"name": "T_ID", "legacyName": "T_ID", "legacySchema": "BIGINT"}}
         ]
       }
     },
@@ -454,7 +454,7 @@
       ],
       "post": {
         "sources": [
-          {"name": "OUTER_JOIN", "type": "table", "keyField": {"name": "T_ID", "legacyName": "T_ID", "legacySchema": {"type": "BIGINT"}}}
+          {"name": "OUTER_JOIN", "type": "table", "keyField": {"name": "T_ID", "legacyName": "T_ID", "legacySchema": "BIGINT"}}
         ]
       }
     },
@@ -483,7 +483,7 @@
       ],
       "post": {
         "sources": [
-          {"name": "LEFT_JOIN", "type": "stream", "keyField": {"name": "T_ID", "legacyName": "T.ID", "legacySchema": {"type": "BIGINT"}}}
+          {"name": "LEFT_JOIN", "type": "stream", "keyField": {"name": "T_ID", "legacyName": "T.ID", "legacySchema": "BIGINT"}}
         ]
       }
     },
@@ -511,7 +511,7 @@
       ],
       "post": {
         "sources": [
-          {"name": "INNER_JOIN", "type": "stream", "keyField": {"name": "T_ID", "legacyName": "T.ID", "legacySchema": {"type": "BIGINT"}}}
+          {"name": "INNER_JOIN", "type": "stream", "keyField": {"name": "T_ID", "legacyName": "T.ID", "legacySchema": "BIGINT"}}
         ]
       }
     },
@@ -543,7 +543,7 @@
           "key field has incorrect type - should be BIGINT"
         ],
         "sources": [
-          {"name": "INNER_JOIN", "type": "stream", "keyField": {"name": null, "legacyName": "T.ROWKEY", "legacySchema": {"type": "STRING"}}}
+          {"name": "INNER_JOIN", "type": "stream", "keyField": {"name": null, "legacyName": "T.ROWKEY", "legacySchema": "STRING"}}
         ]
       }
     },
@@ -571,8 +571,8 @@
       ],
       "post": {
         "sources": [
-          {"name": "INNER_JOIN", "type": "stream", "keyField": {"name": null, "legacyName": "T.ROWKEY", "legacySchema": {"type": "STRING"}}},
-          {"name": "DOWNSTREAM", "type": "stream", "keyField": {"name": "ID", "legacyName": "ID", "legacySchema": {"type": "BIGINT"}}}
+          {"name": "INNER_JOIN", "type": "stream", "keyField": {"name": null, "legacyName": "T.ROWKEY", "legacySchema": "STRING"}},
+          {"name": "DOWNSTREAM", "type": "stream", "keyField": {"name": "ID", "legacyName": "ID", "legacySchema": "BIGINT"}}
         ]
       }
     },
@@ -631,7 +631,38 @@
       ],
       "post": {
         "sources": [
-          {"name": "OUTPUT", "type": "table", "keyField": {"name": "T_ID", "legacyName": "T_ID", "legacySchema": {"type": "BIGINT"}}}
+          {"name": "OUTPUT", "type": "table", "keyField": {"name": "T_ID", "legacyName": "T_ID", "legacySchema": "BIGINT"}}
+        ]
+      }
+    },
+    {
+      "name": "stream stream inner join with right side key field in projection",
+      "statements": [
+        "CREATE STREAM TEST (ID bigint, NAME varchar, VALUE bigint) WITH (kafka_topic='left_topic', value_format='JSON', key='ID');",
+        "CREATE STREAM TEST_STREAM (ID bigint, F1 varchar, F2 bigint) WITH (kafka_topic='right_topic', value_format='JSON', key='ID');",
+        "CREATE STREAM INNER_JOIN as SELECT tt.id, name, value, f1, f2 FROM test t join TEST_STREAM tt WITHIN 11 SECONDS ON t.id = tt.id;"
+      ],
+      "inputs": [
+        {"topic": "left_topic", "key": 0, "value": {"ID": 0, "NAME": "zero", "VALUE": 0}, "timestamp": 0},
+        {"topic": "right_topic", "key": 0, "value": {"ID": 0, "F1": "blah", "F2": 50}, "timestamp": 10000},
+        {"topic": "left_topic", "key": 10, "value": {"ID": 10, "NAME": "100", "VALUE": 5}, "timestamp": 11000},
+        {"topic": "left_topic", "key": 0, "value": {"ID": 0, "NAME": "foo", "VALUE": 100}, "timestamp": 13000},
+        {"topic": "right_topic", "key": 0, "value": {"ID": 0, "F1": "a", "F2": 10}, "timestamp": 15000},
+        {"topic": "right_topic", "key": 100, "value": {"ID": 100, "F1": "newblah", "F2": 150}, "timestamp": 16000},
+        {"topic": "left_topic", "key": 90, "value": {"ID": 90, "NAME": "ninety", "VALUE": 90}, "timestamp": 17000},
+        {"topic": "left_topic", "key": 0, "value": {"ID": 0, "NAME": "bar", "VALUE": 99}, "timestamp": 30000}
+      ],
+      "outputs": [
+        {"topic": "INNER_JOIN", "key": 0, "value": {"TT_ID": 0, "NAME": "zero", "VALUE": 0, "F1": "blah", "F2": 50}, "timestamp": 10000},
+        {"topic": "INNER_JOIN", "key": 0, "value": {"TT_ID": 0, "NAME": "foo", "VALUE": 100, "F1": "blah", "F2": 50}, "timestamp": 13000},
+        {"topic": "INNER_JOIN", "key": 0, "value": {"TT_ID": 0, "NAME": "foo", "VALUE": 100, "F1": "a", "F2": 10}, "timestamp": 15000}
+      ],
+      "post": {
+        "issues": [
+          "key field has incorrect name - should be TT_ID"
+        ],
+        "sources": [
+          {"name": "INNER_JOIN", "type": "stream", "keyField": {"name": null, "legacyName": "T.ID", "legacySchema": "BIGINT"}}
         ]
       }
     }

--- a/ksql-engine/src/test/resources/query-validation-tests/joins.json
+++ b/ksql-engine/src/test/resources/query-validation-tests/joins.json
@@ -610,6 +610,37 @@
         {"topic": "INNER_JOIN_2", "key": 0, "value": {"T_ID": 0, "NAME": "X", "F1": "yo dawg", "F3": "I heard you like joins"}, "timestamp": 10000},
         {"topic": "INNER_JOIN_2", "key": 100, "value": {"T_ID": 100, "NAME": "X", "F1": "KSQL has table-table joins", "F3": "so now you can join your join"}, "timestamp": 20000}
       ]
+    },
+    {
+      "name": "table table join with where clause",
+      "statements": [
+        "CREATE TABLE TEST (ID bigint, NAME varchar, VALUE bigint) WITH (kafka_topic='left_topic', value_format='JSON', key='ID');",
+        "CREATE TABLE TEST_TABLE (ID bigint, F1 varchar, F2 bigint) WITH (kafka_topic='right_topic', value_format='JSON', key='ID');",
+        "CREATE TABLE OUTPUT as SELECT t.id, name, tt.f1, f2 FROM test t JOIN test_table tt ON t.id = tt.id WHERE t.value > 10 AND tt.f2 > 5;"
+      ],
+      "inputs": [
+        {"topic": "left_topic", "key": 0, "value": {"ID": 0, "NAME": "zero", "VALUE": 0}, "timestamp": 0},
+        {"topic": "right_topic", "key": 0, "value": {"ID": 0, "F1": "blah", "F2": 4}, "timestamp": 10000},
+        {"topic": "left_topic", "key": 0, "value": {"ID": 0, "NAME": "foo", "VALUE": 100}, "timestamp": 13000},
+        {"topic": "right_topic", "key": 0, "value": {"ID": 0, "F1": "a", "F2": 10}, "timestamp": 15000},
+        {"topic": "left_topic", "key": 0, "value": {"ID": 0, "NAME": "bar", "VALUE": 99}, "timestamp": 16000},
+        {"topic": "left_topic", "key": 90, "value": {"ID": 90, "NAME": "ninety", "VALUE": 90}, "timestamp": 17000},
+        {"topic": "right_topic", "key": 90, "value": {"ID": 0, "F1": "b", "F2": 10}, "timestamp": 18000},
+        {"topic": "right_topic", "key": 90, "value": null, "timestamp": 19000}
+      ],
+      "outputs": [
+        {"topic": "OUTPUT", "key": 0, "value": null, "timestamp": 10000},
+        {"topic": "OUTPUT", "key": 0, "value": null, "timestamp": 13000},
+        {"topic": "OUTPUT", "key": 0, "value": {"T_ID": 0, "NAME": "foo", "F1": "a", "F2": 10}, "timestamp": 15000},
+        {"topic": "OUTPUT", "key": 0, "value": {"T_ID": 0, "NAME": "bar", "F1": "a", "F2": 10}, "timestamp": 16000},
+        {"topic": "OUTPUT", "key": 90, "value": {"T_ID": 90, "NAME": "ninety", "F1": "b", "F2": 10}, "timestamp": 18000},
+        {"topic": "OUTPUT", "key": 90, "value": null, "timestamp": 19000}
+      ],
+      "post": {
+        "sources": [
+          {"name": "OUTPUT", "type": "table", "keyField": {"name": "T_ID", "schema": {"type": "BIGINT"}}}
+        ]
+      }
     }
   ]
 }

--- a/ksql-engine/src/test/resources/query-validation-tests/key-field.json
+++ b/ksql-engine/src/test/resources/query-validation-tests/key-field.json
@@ -23,48 +23,26 @@
     "   - no aliasing",
     "   - aliased key field",
     "",
-    "Not all combinations are valid, e.g. can not have an alias if there is no key.",
+    "Note: Not all combinations are valid, e.g. can not have an alias if there is no key.",
+    "Note: There are some tests in joins.json that also test key fields are correctly set",
     "",
     "issues:",
     "",
-    " 1: key field in metastore for OUTPUT contains internal column names e.g. 'KSQL_INTERNAL_COL0' or 'CAST(KSQL_INTERNAL_COL_0 AS INTEGER)'",
-    "    - fix implications: fixing would mean downstream queries might avoid an unnecessary repartition step",
-    "      (fix is NOT backwards compatible by default)",
-    "",
-    " 2: key field in metastore for OUTPUT either matches INPUT or contains internal column names, but should be null",
-    "    - fix implications: fixing would not effect downstream queries as the key field is not available in the value schema either before or after the fix",
-    "      (fix IS backwards compatible by default)",
-    "",
-    " 3: key field in metastore has wrong type (STRING)",
-    "    - fix implications: ",
-    "      Currently, OUTPUT can be joined to sources that have a matching (incorrect) key type, which should not be possible.",
-    "      (fix is NOT backwards compatible by default, though could argue maintaining backwards compatibility here is wrong)",
-    "      Currently, OUTPUT would fail to join to anything with matching (correct) key type, which should be possible.",
-    "      (fix IS backwards compatible)",
-    "",
-    " 4: key field in metastore has not picked up the aliasing of the key field in the project, i.e. key field matches source, but should be alias",
-    "    - fix implications:",
-    "      If the projection has no fields that match the source key field then the implications are the same as issue #1",
-    "      If the projection has a field that duplicates the name of the source key field then additionally:",
-    "      Downstrean queries that PARTITION BY or GROUP BY the duplicate field name would not work correctly as no repartition would happen",
-    "      (fix is backwards compatible as it fixes broken functionality)",
-    "      Downstream queries that PARTITION BY or GROUP BY the new alias would stop introducing unnecessary repartition step",
-    "      (fix is NOT backwards compatible by default)",
-    "",
-    " Additionally, there is currently an inconsistency between how GROUP BY's and PARTITION BY's handling of aliases:",
+    " - there is currently an inconsistency between how GROUP BY's and PARTITION BY's handling of aliases:",
     "  - PARTITION BY requires the target name, (i.e. the alias), failing if the source field name is used.",
     "  - GROUP BY requires the source field name, failing if the target field name, (i.e. the alias), is used.",
+    "   see https://github.com/confluentinc/ksql/issues/2701",
     "",
-    "Each test case follows the pattern of defining:",
+    "Most test cases follows the pattern of defining:",
     " INPUT - the initial source",
     " OUTPUT - a source built from INPUT using the dimensions in the title of the test",
     " DOWNSTREAM - an optional source built from OUTPUT. This is necessary as the key fields this test file covers affect downstream queries too.",
     "",
-    "Some tests may need intermediate sources to get to the required state.",
+    "Some tests may need intermediate sources to get to the required state. (Which is generally a source table where the key field is not set)",
     "",
-    "The main point of the tests to to:",
-    "  a: test the post conditions in the metastore, i.e. that sources of the correct type and params are registered",
-    "  b: test the topology of the output or downstream queries"
+    "The main point of the tests to:",
+    "  a: test the post conditions in the metastore, i.e. that sources with the correct state are registered.",
+    "  b: test the topology of the output or downstream queries."
   ],
   "tests": [
     {
@@ -81,7 +59,7 @@
       ],
       "post": {
         "sources": [
-          {"name": "OUTPUT", "type": "stream", "keyField": null}
+          {"name": "OUTPUT", "type": "stream", "keyField": {"name": null, "legacyName": null}}
         ]
       }
     },
@@ -99,8 +77,8 @@
       ],
       "post": {
         "sources": [
-          {"name": "INPUT", "type": "stream", "keyField": null},
-          {"name": "OUTPUT", "type": "stream", "keyField": {"name": "FOO", "schema": {"type": "INT"}}}
+          {"name": "INPUT", "type": "stream", "keyField": {"name": null, "legacyName": null}},
+          {"name": "OUTPUT", "type": "stream", "keyField": {"name": "FOO", "legacyName": "FOO", "legacySchema": {"type": "INT"}}}
         ]
       }
     },
@@ -118,8 +96,8 @@
       ],
       "post": {
         "sources": [
-          {"name": "INPUT", "type": "stream", "keyField": null},
-          {"name": "OUTPUT", "type": "stream", "keyField": {"name": "ALIASED", "schema": {"type": "INT"}}}
+          {"name": "INPUT", "type": "stream", "keyField": {"name": null, "legacyName": null}},
+          {"name": "OUTPUT", "type": "stream", "keyField": {"name": "ALIASED", "legacyName": "ALIASED", "legacySchema": {"type": "INT"}}}
         ]
       }
     },
@@ -147,23 +125,39 @@
         {"topic": "OUTPUT", "key": "1", "value": {"FOO":1, "KSQL_COL_1": 1}}
       ],
       "post": {
-        "issues": [
-          "key field of output has INCORRECT name: should be 'FOO' - (see Issue #1 above)",
-          "key field of output has INCORRECT type: should be 'INT' - (see Issue #3 above)"
-        ],
         "sources": [
-          {"name": "INPUT", "type": "stream", "keyField": null},
-          {"name": "OUTPUT", "type": "table", "keyField": {"name": "KSQL_INTERNAL_COL_0", "schema": {"type": "STRING"}}}
+          {"name": "INPUT", "type": "stream", "keyField": {"name": null, "legacyName": null}},
+          {
+            "name": "OUTPUT",
+            "type": "table",
+            "keyField": {"name": "FOO", "legacyName": "KSQL_INTERNAL_COL_0", "legacySchema": {"type": "STRING"}},
+            "valueSchema": {"type": "STRUCT", "fields": [
+              {"name": "ROWTIME", "schema": {"type": "BIGINT"}},
+              {"name": "ROWKEY", "schema": {"type": "STRING"}},
+              {"name": "FOO", "schema": {"type": "INT"}},
+              {"name": "KSQL_COL_1", "schema": {"type": "BIGINT"}}
+            ]}
+          }
         ]
       }
     },
     {
       "name": "stream | initially null | group by (-) | key in value | no aliasing | legacy downstream query",
+      "comments": [
+        "The purpose of this test is to capture the topology of a downstream query of the above test case",
+        "and test the key fields of the entities added to the metastore, to ensure backwards compatibility is maintained",
+        "In this case, the code previously incorrectly set the keyField to 'KSQL_INTERNAL_COL_0' rather than the correct 'FOO'",
+        "This would result in an unnecessary repartition step being added to the DOWNSTREAM query.",
+        "New versions of the code must not remove this unnecessary step for existing queries, as that would break backwards compatibility"
+      ],
       "statements": [
         "CREATE STREAM INPUT (foo INT, bar INT) WITH (kafka_topic='input_topic', value_format='JSON');",
         "CREATE TABLE OUTPUT AS SELECT foo, COUNT(*) FROM INPUT GROUP BY foo;",
         "CREATE TABLE DOWNSTREAM AS SELECT foo, COUNT(*) FROM OUTPUT GROUP BY foo;"
       ],
+      "properties": {
+        "ksql.query.fields.key.legacy": "true"
+      },
       "inputs": [
         {"topic": "OUTPUT", "key": "1", "value": {"FOO":1, "KSQL_COL_1": 1}}
       ],
@@ -172,7 +166,7 @@
       ],
       "post": {
         "sources": [
-          {"name": "DOWNSTREAM", "type": "table", "keyField": {"name": "KSQL_INTERNAL_COL_0", "schema": {"type": "STRING"}}}
+          {"name": "DOWNSTREAM", "type": "table", "keyField": {"name": "FOO", "legacyName": "KSQL_INTERNAL_COL_0", "legacySchema": {"type": "STRING"}}}
         ]
       }
     },
@@ -189,23 +183,29 @@
         {"topic": "OUTPUT", "key": "1", "value": {"ALIASED":1, "KSQL_COL_1": 1}}
       ],
       "post": {
-        "issues": [
-          "key field of output has INCORRECT name: should be 'ALIASED' - (see Issue #1 above)",
-          "key field of output has INCORRECT type: should be 'INT' - (see Issue #3 above)"
-        ],
         "sources": [
-          {"name": "INPUT", "type": "stream", "keyField": null},
-          {"name": "OUTPUT", "type": "table", "keyField": {"name": "KSQL_INTERNAL_COL_0", "schema": {"type": "STRING"}}}
+          {"name": "INPUT", "type": "stream", "keyField": {"name": null, "legacyName": null}},
+          {"name": "OUTPUT", "type": "table", "keyField": {"name": "ALIASED", "legacyName": "KSQL_INTERNAL_COL_0", "legacySchema": {"type": "STRING"}}}
         ]
       }
     },
     {
       "name": "stream | initially null | group by (-) | key in value | aliasing | legacy downstream query",
+      "comments": [
+        "The purpose of this test is to capture the topology of a downstream query of the above test case",
+        "and test the key fields of the entities added to the metastore, to ensure backwards compatibility is maintained",
+        "In this case, the code previously incorrectly set the keyField to 'KSQL_INTERNAL_COL_0' rather than the correct 'ALIASED'",
+        "This would result in an unnecessary repartition step being added to the DOWNSTREAM query.",
+        "New versions of the code must not remove this unnecessary step for existing queries, as that would break backwards compatibility"
+      ],
       "statements": [
         "CREATE STREAM INPUT (foo INT, bar INT) WITH (kafka_topic='input_topic', value_format='JSON');",
         "CREATE TABLE OUTPUT AS SELECT foo AS Aliased, COUNT(*) FROM INPUT GROUP BY foo;",
         "CREATE TABLE DOWNSTREAM AS SELECT Aliased, COUNT(*) FROM OUTPUT GROUP BY Aliased;"
       ],
+      "properties": {
+        "ksql.query.fields.key.legacy": "true"
+      },
       "inputs": [
         {"topic": "OUTPUT", "key": "1", "value": {"ALIASED":1, "KSQL_COL_1": 1}}
       ],
@@ -214,7 +214,7 @@
       ],
       "post": {
         "sources": [
-           {"name": "DOWNSTREAM", "type": "table", "keyField": {"name": "KSQL_INTERNAL_COL_0", "schema": {"type": "STRING"}}}
+           {"name": "DOWNSTREAM", "type": "table", "keyField": {"name": "ALIASED", "legacyName": "KSQL_INTERNAL_COL_0", "legacySchema": {"type": "STRING"}}}
         ]
       }
     },
@@ -231,22 +231,28 @@
         {"topic": "OUTPUT", "key": "1", "value": {"KSQL_COL_0": 1}}
       ],
       "post": {
-        "issues": [
-          "key field of output INCORRECT: should be null - (see Issue #2 above)"
-        ],
         "sources": [
-          {"name": "INPUT", "type": "stream", "keyField": null},
-          {"name": "OUTPUT", "type": "table", "keyField": {"name": "KSQL_INTERNAL_COL_1", "schema": {"type": "STRING"}}}
+          {"name": "INPUT", "type": "stream", "keyField": {"name": null, "legacyName": null}},
+          {"name": "OUTPUT", "type": "table", "keyField": {"name": null, "legacyName": "KSQL_INTERNAL_COL_1", "legacySchema": {"type": "STRING"}}}
         ]
       }
     },
     {
       "name": "stream | initially null | group by (-) | key not in value | - | legacy downstream query",
+      "comments": [
+        "The purpose of this test is to capture the topology of a downstream query of the above test case",
+        "and test the key fields of the entities added to the metastore, to ensure backwards compatibility is maintained",
+        "In this case, the code previously incorrectly set the keyField to 'KSQL_INTERNAL_COL_1' rather than the correct 'null'",
+        "This would not really create any problems, but its good to ensure things remain consistent."
+      ],
       "statements": [
         "CREATE STREAM INPUT (foo INT, bar INT) WITH (kafka_topic='input_topic', value_format='JSON');",
         "CREATE TABLE OUTPUT AS SELECT COUNT(*) FROM INPUT GROUP BY foo;",
         "CREATE TABLE DOWNSTREAM AS SELECT COUNT(*) FROM OUTPUT GROUP BY ROWKEY;"
       ],
+      "properties": {
+        "ksql.query.fields.key.legacy": "true"
+      },
       "inputs": [
         {"topic": "OUTPUT", "key": "1", "value": {"KSQL_COL_0": 1}}
       ],
@@ -255,7 +261,7 @@
       ],
       "post": {
         "sources": [
-          {"name": "DOWNSTREAM", "type": "table", "keyField": {"name": "KSQL_INTERNAL_COL_1", "schema": {"type": "STRING"}}}
+          {"name": "DOWNSTREAM", "type": "table", "keyField": {"name": null, "legacyName": "KSQL_INTERNAL_COL_1", "legacySchema": {"type": "STRING"}}}
         ]
       }
     },
@@ -273,8 +279,8 @@
       ],
       "post": {
         "sources": [
-          {"name": "INPUT", "type": "stream", "keyField": {"name": "FOO", "schema": {"type": "INT"}}},
-          {"name": "OUTPUT", "type": "stream", "keyField": {"name": "FOO", "schema": {"type": "INT"}}}
+          {"name": "INPUT", "type": "stream", "keyField": {"name": "FOO", "legacyName": "FOO", "legacySchema": {"type": "INT"}}},
+          {"name": "OUTPUT", "type": "stream", "keyField": {"name": "FOO", "legacyName": "FOO", "legacySchema": {"type": "INT"}}}
         ]
       }
     },
@@ -291,22 +297,29 @@
         {"topic": "OUTPUT", "value": {"ALIASED":1, "BAR": 2}}
       ],
       "post": {
-        "issues": [
-          "key field of output has INCORRECT name: should be 'ALIASED' - (see Issue #4 above)"
-        ],
         "sources": [
-          {"name": "INPUT", "type": "stream", "keyField": {"name": "FOO", "schema": {"type": "INT"}}},
-          {"name": "OUTPUT", "type": "stream", "keyField": {"name": "FOO", "schema": {"type": "INT"}}}
+          {"name": "INPUT", "type": "stream", "keyField": {"name": "FOO", "legacyName": "FOO", "legacySchema": {"type": "INT"}}},
+          {"name": "OUTPUT", "type": "stream", "keyField": {"name": "ALIASED", "legacyName": "FOO", "legacySchema": {"type": "INT"}}}
         ]
       }
     },
     {
       "name": "stream | initially set | no key change | key in value | aliasing | legacy downstream query",
+      "comments": [
+        "The purpose of this test is to capture the topology of a downstream query of the above test case",
+        "and test the key fields of the entities added to the metastore, to ensure backwards compatibility is maintained",
+        "In this case, the code previously incorrectly set the keyField to 'FOO' rather than the correct 'ALIASED'",
+        "This would result in an unnecessary repartition step being added to the DOWNSTREAM query.",
+        "New versions of the code must not remove this unnecessary step for existing queries, as that would break backwards compatibility"
+      ],
       "statements": [
         "CREATE STREAM INPUT (foo INT, bar INT) WITH (kafka_topic='input_topic', key='foo', value_format='JSON');",
         "CREATE STREAM OUTPUT AS SELECT foo as aliased, bar FROM INPUT;",
         "CREATE STREAM DOWNSTREAM AS SELECT Aliased, bar FROM OUTPUT PARTITION BY Aliased;"
       ],
+      "properties": {
+        "ksql.query.fields.key.legacy": "true"
+      },
       "inputs": [
         {"topic": "OUTPUT", "key": "1", "value": {"ALIASED":1, "BAR": 2}}
       ],
@@ -315,7 +328,8 @@
       ],
       "post": {
         "sources": [
-         {"name": "DOWNSTREAM", "type": "stream", "keyField": {"name": "ALIASED", "schema": {"type": "INT"}}}
+          {"name": "OUTPUT", "type": "stream", "keyField": {"name": "ALIASED", "legacyName": "FOO", "legacySchema": {"type": "INT"}}},
+         {"name": "DOWNSTREAM", "type": "stream", "keyField": {"name": "ALIASED", "legacyName": "ALIASED", "legacySchema": {"type": "INT"}}}
         ]
       }
     },
@@ -332,22 +346,29 @@
         {"topic": "OUTPUT", "value": {"ALIASED":1, "FOO": 2}}
       ],
       "post": {
-        "issues": [
-          "key field of output has INCORRECT name: should be 'ALIASED' - (see Issue #4 above)"
-        ],
         "sources": [
-          {"name": "INPUT", "type": "stream", "keyField": {"name": "FOO", "schema": {"type": "INT"}}},
-          {"name": "OUTPUT", "type": "stream", "keyField": {"name": "FOO", "schema": {"type": "INT"}}}
+          {"name": "INPUT", "type": "stream", "keyField": {"name": "FOO", "legacyName": "FOO", "legacySchema": {"type": "INT"}}},
+          {"name": "OUTPUT", "type": "stream", "keyField": {"name": "ALIASED", "legacyName": "FOO", "legacySchema": {"type": "INT"}}}
         ]
       }
     },
     {
       "name": "stream | initially set | no key change | key in value | aliasing + duplicate | legacy downstream query | no key change",
+      "comments": [
+        "The purpose of this test is to capture the topology of a downstream query of the above test case",
+        "and test the key fields of the entities added to the metastore, to ensure backwards compatibility is maintained",
+        "In this case, the code previously incorrectly set the keyField to 'FOO' rather than the correct 'ALIASED'",
+        "This would result in an unnecessary repartition step being added to the DOWNSTREAM query.",
+        "New versions of the code must not remove this unnecessary step for existing queries, as that would break backwards compatibility"
+      ],
       "statements": [
         "CREATE STREAM INPUT (foo INT, bar INT) WITH (kafka_topic='input_topic', key='foo', value_format='JSON');",
         "CREATE STREAM OUTPUT AS SELECT foo as aliased, bar as foo FROM INPUT;",
         "CREATE STREAM DOWNSTREAM AS SELECT aliased, foo FROM OUTPUT PARTITION BY aliased;"
       ],
+      "properties": {
+        "ksql.query.fields.key.legacy": "true"
+      },
       "inputs": [
         {"topic": "OUTPUT", "key": "1" ,"value": {"ALIASED":1, "FOO": 2}}
       ],
@@ -356,12 +377,45 @@
       ],
       "post": {
         "sources": [
-           {"name": "DOWNSTREAM", "type": "stream", "keyField": {"name": "ALIASED", "schema": {"type": "INT"}}}
+          {"name": "OUTPUT", "type": "stream", "keyField": {"name": "ALIASED", "legacyName": "FOO", "legacySchema": {"type": "INT"}}},
+          {"name": "DOWNSTREAM", "type": "stream", "keyField": {"name": "ALIASED", "legacyName": "ALIASED", "legacySchema": {"type": "INT"}}}
         ]
       }
     },
     {
       "name": "stream | initially set | no key change | key in value | aliasing + duplicate | legacy downstream query | key change",
+      "comments": [
+        "The purpose of this test is to capture the topology of a downstream query of the above test case",
+        "and test the key fields of the entities added to the metastore, to ensure backwards compatibility is maintained",
+        "In this case, the code previously incorrectly set the keyField to 'FOO' rather than the correct 'ALIASED'",
+        "This would result in an unnecessary repartition step being added to the DOWNSTREAM query.",
+        "New versions of the code must not remove this unnecessary step for existing queries, as that would break backwards compatibility",
+        "Note: PARTITION BY takes the target name, i.e. the name of the field in the output schema.",
+        "So in the test below the 'PARTITION BY foo' in the final SELECT should be set the key to FOO."
+      ],
+      "statements": [
+        "CREATE STREAM INPUT (foo INT, bar INT) WITH (kafka_topic='input_topic', key='foo', value_format='JSON');",
+        "CREATE STREAM OUTPUT AS SELECT foo as aliased, bar as foo FROM INPUT;",
+        "CREATE STREAM DOWNSTREAM AS SELECT aliased, foo FROM OUTPUT PARTITION BY foo;"
+      ],
+      "properties": {
+        "ksql.query.fields.key.legacy": "true"
+      },
+      "inputs": [
+        {"topic": "OUTPUT", "key": "1" ,"value": {"ALIASED":1, "FOO": 2}}
+      ],
+      "outputs": [
+        {"topic": "DOWNSTREAM", "key": "1", "value": {"ALIASED":1, "FOO": 2}}
+      ],
+      "post": {
+        "sources": [
+          {"name": "OUTPUT", "type": "stream", "keyField": {"name": "ALIASED", "legacyName": "FOO", "legacySchema": {"type": "INT"}}},
+          {"name": "DOWNSTREAM", "type": "stream", "keyField": {"name": "FOO", "legacyName": "FOO", "legacySchema": {"type": "INT"}}}
+        ]
+      }
+    },
+    {
+      "name": "stream | initially set | no key change | key in value | aliasing + duplicate | downstream query | key change",
       "statements": [
         "CREATE STREAM INPUT (foo INT, bar INT) WITH (kafka_topic='input_topic', key='foo', value_format='JSON');",
         "CREATE STREAM OUTPUT AS SELECT foo as aliased, bar as foo FROM INPUT;",
@@ -371,11 +425,11 @@
         {"topic": "OUTPUT", "key": "1" ,"value": {"ALIASED":1, "FOO": 2}}
       ],
       "outputs": [
-        {"topic": "DOWNSTREAM", "key": "1", "value": {"ALIASED":1, "FOO": 2}}
+        {"topic": "DOWNSTREAM", "key": "2", "value": {"ALIASED":1, "FOO": 2}}
       ],
       "post": {
         "sources": [
-          {"name": "DOWNSTREAM", "type": "stream", "keyField": {"name": "FOO", "schema": {"type": "INT"}}}
+          {"name": "DOWNSTREAM", "type": "stream", "keyField": {"name": "FOO", "legacyName": "FOO", "legacySchema": {"type": "INT"}}}
         ]
       }
     },
@@ -392,22 +446,28 @@
         {"topic": "OUTPUT", "value": {"BAR": 2}}
       ],
       "post": {
-        "issues": [
-          "key field of output INCORRECT: should be null - (see Issue #2 above)"
-        ],
         "sources": [
-          {"name": "INPUT", "type": "stream", "keyField": {"name": "FOO", "schema": {"type": "INT"}}},
-          {"name": "OUTPUT", "type": "stream", "keyField": {"name": "FOO", "schema": {"type": "INT"}}}
+          {"name": "INPUT", "type": "stream", "keyField": {"name": "FOO", "legacyName": "FOO", "legacySchema": {"type": "INT"}}},
+          {"name": "OUTPUT", "type": "stream", "keyField": {"name": null, "legacyName": "FOO", "legacySchema": {"type": "INT"}}}
         ]
       }
     },
     {
       "name": "stream | initially set | no key change | key not in value | - | legacy downstream query",
+      "comments": [
+        "The purpose of this test is to capture the topology of a downstream query of the above test case",
+        "and test the key fields of the entities added to the metastore, to ensure backwards compatibility is maintained",
+        "In this case, the code previously incorrectly set the keyField to 'FOO' rather than the correct 'null'",
+        "This would not really create any problems, but its good to ensure things remain consistent."
+      ],
       "statements": [
         "CREATE STREAM INPUT (foo INT, bar INT) WITH (kafka_topic='input_topic', key='foo', value_format='JSON');",
         "CREATE STREAM OUTPUT AS SELECT bar FROM INPUT;",
-        "CREATE STREAM DOWNSTREAM AS SELECT bar as FOO FROM OUTPUT PARTITION BY foo;"
+        "CREATE STREAM DOWNSTREAM AS SELECT bar as FOO FROM OUTPUT PARTITION BY FOO;"
       ],
+      "properties": {
+        "ksql.query.fields.key.legacy": "true"
+      },
       "inputs": [
         {"topic": "OUTPUT", "key": "-", "value": {"BAR": 2}}
       ],
@@ -416,7 +476,8 @@
       ],
       "post": {
        "sources": [
-           {"name": "DOWNSTREAM", "type": "stream", "keyField": {"name": "FOO", "schema": {"type": "INT"}}}
+         {"name": "OUTPUT", "type": "stream", "keyField": {"name": null, "legacyName": "FOO", "legacySchema": {"type": "INT"}}},
+           {"name": "DOWNSTREAM", "type": "stream", "keyField": {"name": "FOO", "legacyName": "FOO", "legacySchema": {"type": "INT"}}}
         ]
       }
     },
@@ -434,13 +495,35 @@
       ],
       "post": {
         "sources": [
-          {"name": "INPUT", "type": "stream", "keyField": {"name": "FOO", "schema": {"type": "INT"}}},
-          {"name": "OUTPUT", "type": "stream", "keyField": {"name": "FOO", "schema": {"type": "INT"}}}
+          {"name": "INPUT", "type": "stream", "keyField": {"name": "FOO", "legacyName": "FOO", "legacySchema": {"type": "INT"}}},
+          {"name": "OUTPUT", "type": "stream", "keyField": {"name": "FOO", "legacyName": "FOO", "legacySchema": {"type": "INT"}}}
         ]
       }
     },
     {
       "name": "stream | initially set | partition by (same) | key in value | aliasing",
+      "statements": [
+        "CREATE STREAM INPUT (foo INT, bar INT) WITH (kafka_topic='input_topic', key='foo', value_format='JSON');",
+        "CREATE STREAM OUTPUT AS SELECT foo AS aliased, bar FROM INPUT PARTITION BY aliased;"
+      ],
+      "properties": {
+        "ksql.query.fields.key.legacy": "true"
+      },
+      "inputs": [
+        {"topic": "input_topic", "key": "1", "value": {"foo": 1, "bar": 2}}
+      ],
+      "outputs": [
+        {"topic": "OUTPUT", "key":"1", "value": {"ALIASED":1, "BAR": 2}}
+      ],
+      "post": {
+        "sources": [
+          {"name": "INPUT", "type": "stream", "keyField": {"name": "FOO", "legacyName": "FOO", "legacySchema": {"type": "INT"}}},
+          {"name": "OUTPUT", "type": "stream", "keyField": {"name": "ALIASED", "legacyName": "ALIASED", "legacySchema": {"type": "INT"}}}
+        ]
+      }
+    },
+    {
+      "name": "stream | initially set | partition by (same) | key in value | aliasing | non-legacy",
       "statements": [
         "CREATE STREAM INPUT (foo INT, bar INT) WITH (kafka_topic='input_topic', key='foo', value_format='JSON');",
         "CREATE STREAM OUTPUT AS SELECT foo AS aliased, bar FROM INPUT PARTITION BY aliased;"
@@ -453,8 +536,8 @@
       ],
       "post": {
         "sources": [
-          {"name": "INPUT", "type": "stream", "keyField": {"name": "FOO", "schema": {"type": "INT"}}},
-          {"name": "OUTPUT", "type": "stream", "keyField": {"name": "ALIASED", "schema": {"type": "INT"}}}
+          {"name": "INPUT", "type": "stream", "keyField": {"name": "FOO"}},
+          {"name": "OUTPUT", "type": "stream", "keyField": {"name": "ALIASED"}}
         ]
       }
     },
@@ -483,8 +566,8 @@
       ],
       "post": {
         "sources": [
-          {"name": "INPUT", "type": "stream", "keyField": {"name": "FOO", "schema": {"type": "INT"}}},
-          {"name": "OUTPUT", "type": "stream", "keyField": {"name": "BAR", "schema": {"type": "INT"}}}
+          {"name": "INPUT", "type": "stream", "keyField": {"name": "FOO", "legacyName": "FOO", "legacySchema": {"type": "INT"}}},
+          {"name": "OUTPUT", "type": "stream", "keyField": {"name": "BAR", "legacyName": "BAR", "legacySchema": {"type": "INT"}}}
         ]
       }
     },
@@ -502,8 +585,8 @@
       ],
       "post": {
         "sources": [
-          {"name": "INPUT", "type": "stream", "keyField": {"name": "FOO", "schema": {"type": "INT"}}},
-          {"name": "OUTPUT", "type": "stream", "keyField": {"name": "ALIASED", "schema": {"type": "INT"}}}
+          {"name": "INPUT", "type": "stream", "keyField": {"name": "FOO", "legacyName": "FOO", "legacySchema": {"type": "INT"}}},
+          {"name": "OUTPUT", "type": "stream", "keyField": {"name": "ALIASED", "legacyName": "ALIASED", "legacySchema": {"type": "INT"}}}
         ]
       }
     },
@@ -532,8 +615,8 @@
       ],
       "post": {
         "sources": [
-          {"name": "INPUT", "type": "stream", "keyField": {"name": "FOO", "schema": {"type": "INT"}}},
-          {"name": "OUTPUT", "type": "table", "keyField": {"name": "FOO", "schema": {"type": "INT"}}}
+          {"name": "INPUT", "type": "stream", "keyField": {"name": "FOO", "legacyName": "FOO", "legacySchema": {"type": "INT"}}},
+          {"name": "OUTPUT", "type": "table", "keyField": {"name": "FOO", "legacyName": "FOO", "legacySchema": {"type": "INT"}}}
         ]
       }
     },
@@ -551,8 +634,8 @@
       ],
       "post": {
         "sources": [
-          {"name": "INPUT", "type": "stream", "keyField": {"name": "FOO", "schema": {"type": "INT"}}},
-          {"name": "OUTPUT", "type": "table", "keyField": {"name": "ALIASED", "schema": {"type": "INT"}}}
+          {"name": "INPUT", "type": "stream", "keyField": {"name": "FOO", "legacyName": "FOO", "legacySchema": {"type": "INT"}}},
+          {"name": "OUTPUT", "type": "table", "keyField": {"name": "ALIASED", "legacyName": "ALIASED", "legacySchema": {"type": "INT"}}}
         ]
       }
     },
@@ -570,7 +653,7 @@
       ],
       "post": {
         "sources": [
-          {"name": "OUTPUT", "type": "table", "keyField": null}
+          {"name": "OUTPUT", "type": "table", "keyField": {"name": null, "legacyName": null}}
         ]
       }
     },
@@ -587,22 +670,28 @@
         {"topic": "OUTPUT", "key":"2", "value": {"BAR":2, "KSQL_COL_1": 1}}
       ],
       "post": {
-        "issues": [
-          "key field of output has INCORRECT name: should be 'BAR' - (see Issue #1 above)",
-          "key field of output has INCORRECT type: should be 'INT' - (see Issue #3 above)"
-        ],
         "sources": [
-          {"name": "OUTPUT", "type": "table", "keyField": {"name": "KSQL_INTERNAL_COL_0", "schema": {"type": "STRING"}}}
+          {"name": "OUTPUT", "type": "table", "keyField": {"name": "BAR", "legacyName": "KSQL_INTERNAL_COL_0", "legacySchema": {"type": "STRING"}}}
         ]
       }
     },
     {
       "name": "stream | initially set | group by (different) | key in value | no aliasing | legacy downstream query",
+      "comments": [
+        "The purpose of this test is to capture the topology of a downstream query of the above test case",
+        "and test the key fields of the entities added to the metastore, to ensure backwards compatibility is maintained",
+        "In this case, the code previously incorrectly set the keyField to 'KSQL_INTERNAL_COL_0' rather than the correct 'BAR'",
+        "This would result in an unnecessary repartition step being added to the DOWNSTREAM query.",
+        "New versions of the code must not remove this unnecessary step for existing queries, as that would break backwards compatibility"
+      ],
       "statements": [
         "CREATE STREAM INPUT (foo INT, bar INT) WITH (kafka_topic='input_topic', key='foo', value_format='JSON');",
         "CREATE TABLE OUTPUT AS SELECT bar, COUNT(*) FROM INPUT GROUP BY bar;",
         "CREATE TABLE DOWNSTREAM AS SELECT bar, COUNT(*) FROM OUTPUT GROUP BY bar;"
       ],
+      "properties": {
+        "ksql.query.fields.key.legacy": "true"
+      },
       "inputs": [
         {"topic": "OUTPUT", "key":"2", "value": {"BAR":2, "KSQL_COL_1": 1}}
       ],
@@ -611,7 +700,8 @@
       ],
       "post": {
         "sources": [
-          {"name": "DOWNSTREAM", "type": "table", "keyField": {"name": "KSQL_INTERNAL_COL_0", "schema": {"type": "STRING"}}}
+          {"name": "OUTPUT", "type": "table", "keyField": {"name": "BAR", "legacyName": "KSQL_INTERNAL_COL_0", "legacySchema": {"type": "STRING"}}},
+          {"name": "DOWNSTREAM", "type": "table", "keyField": {"name": "BAR", "legacyName": "KSQL_INTERNAL_COL_0", "legacySchema": {"type": "STRING"}}}
         ]
       }
     },
@@ -628,22 +718,28 @@
         {"topic": "OUTPUT", "key":"2", "value": {"ALIASED":2, "KSQL_COL_1": 1}}
       ],
       "post": {
-        "issues": [
-          "key field of output has INCORRECT name: should be 'ALIASED' - (see Issue #1 above)",
-          "key field of output has INCORRECT type: should be 'INT' - (see Issue #3 above)"
-        ],
         "sources": [
-          {"name": "OUTPUT", "type": "table", "keyField": {"name": "KSQL_INTERNAL_COL_0", "schema": {"type": "STRING"}}}
+          {"name": "OUTPUT", "type": "table", "keyField": {"name": "ALIASED", "legacyName": "KSQL_INTERNAL_COL_0", "legacySchema": {"type": "STRING"}}}
         ]
       }
     },
     {
       "name": "stream | initially set | group by (different) | key in value | aliasing | legacy downstream query",
+      "comments": [
+        "The purpose of this test is to capture the topology of a downstream query of the above test case",
+        "and test the key fields of the entities added to the metastore, to ensure backwards compatibility is maintained",
+        "In this case, the code previously incorrectly set the keyField to 'KSQL_INTERNAL_COL_0' rather than the correct 'ALIASED'",
+        "This would result in an unnecessary repartition step being added to the DOWNSTREAM query.",
+        "New versions of the code must not remove this unnecessary step for existing queries, as that would break backwards compatibility"
+      ],
       "statements": [
         "CREATE STREAM INPUT (foo INT, bar INT) WITH (kafka_topic='input_topic', key='foo', value_format='JSON');",
         "CREATE TABLE OUTPUT AS SELECT bar AS aliased, COUNT(*) FROM INPUT GROUP BY bar;",
         "CREATE TABLE DOWNSTREAM AS SELECT aliased, COUNT(*) FROM OUTPUT GROUP BY aliased;"
       ],
+      "properties": {
+        "ksql.query.fields.key.legacy": "true"
+      },
       "inputs": [
         {"topic": "OUTPUT", "key":"2", "value": {"ALIASED":2, "KSQL_COL_1": 1}}
       ],
@@ -652,7 +748,8 @@
       ],
       "post": {
         "sources": [
-          {"name": "DOWNSTREAM", "type": "table", "keyField": {"name": "KSQL_INTERNAL_COL_0", "schema": {"type": "STRING"}}}
+          {"name": "OUTPUT", "type": "table", "keyField": {"name": "ALIASED", "legacyName": "KSQL_INTERNAL_COL_0", "legacySchema": {"type": "STRING"}}},
+          {"name": "DOWNSTREAM", "type": "table", "keyField": {"name": "ALIASED", "legacyName": "KSQL_INTERNAL_COL_0", "legacySchema": {"type": "STRING"}}}
         ]
       }
     },
@@ -669,19 +766,27 @@
         {"topic": "OUTPUT", "key":"2", "value": {"KSQL_COL_0": 1}}
       ],
       "post": {
-        "issues": ["key field of output INCORRECT: should be null - (see Issue #2 above)"],
         "sources": [
-          {"name": "OUTPUT", "type": "table", "keyField": {"name": "KSQL_INTERNAL_COL_1", "schema": {"type": "STRING"}}}
+          {"name": "OUTPUT", "type": "table", "keyField": {"name": null, "legacyName": "KSQL_INTERNAL_COL_1", "legacySchema": {"type": "STRING"}}}
         ]
       }
     },
     {
       "name": "stream | initially set | group by (different) | key not in value | - | legacy downstream query",
+      "comments": [
+        "The purpose of this test is to capture the topology of a downstream query of the above test case",
+        "and test the key fields of the entities added to the metastore, to ensure backwards compatibility is maintained",
+        "In this case, the code previously incorrectly set the keyField to 'KSQL_INTERNAL_COL_1' rather than the correct 'null'",
+        "This would not really create any problems, but its good to ensure things remain consistent."
+      ],
       "statements": [
         "CREATE STREAM INPUT (foo INT, bar INT) WITH (kafka_topic='input_topic', key='foo', value_format='JSON');",
         "CREATE TABLE OUTPUT AS SELECT COUNT(*) FROM INPUT GROUP BY bar;",
         "CREATE TABLE DOWNSTREAM AS SELECT COUNT(*) FROM OUTPUT GROUP BY ROWKEY;"
       ],
+      "properties": {
+        "ksql.query.fields.key.legacy": "true"
+      },
       "inputs": [
         {"topic": "OUTPUT", "key":"2", "value": {"KSQL_COL_0": 1}}
       ],
@@ -690,7 +795,7 @@
       ],
       "post": {
         "sources": [
-          {"name": "DOWNSTREAM", "type": "table", "keyField": {"name": "KSQL_INTERNAL_COL_1", "schema": {"type": "STRING"}}}
+          {"name": "DOWNSTREAM", "type": "table", "keyField": {"name": null, "legacyName": "KSQL_INTERNAL_COL_1", "legacySchema": {"type": "STRING"}}}
         ]
       }
     },
@@ -712,8 +817,8 @@
       ],
       "post": {
         "sources": [
-          {"name": "INTERMEDIATE", "type": "table", "keyField": null},
-          {"name": "OUTPUT", "type": "table", "keyField": null}
+          {"name": "INTERMEDIATE", "type": "table", "keyField": {"name": null, "legacyName": null}},
+          {"name": "OUTPUT", "type": "table", "keyField": {"name": null, "legacyName": null}}
         ]
       }
     },
@@ -734,19 +839,20 @@
         {"topic": "OUTPUT", "key": "1", "value": {"FOO": 1, "KSQL_COL_1": 1}}
       ],
       "post": {
-        "issues": [
-          "key field of output has INCORRECT name: should be 'FOO' - (see Issue #1 above)",
-          "key field of output has INCORRECT type: should be 'INT' - (see Issue #3 above)"
-        ],
         "sources": [
-          {"name": "INTERMEDIATE", "type": "table", "keyField": null},
-          {"name": "OUTPUT", "type": "table", "keyField": {"name": "KSQL_INTERNAL_COL_0", "schema": {"type": "STRING"}}}
+          {"name": "INTERMEDIATE", "type": "table", "keyField": {"name": null, "legacyName": null}},
+          {"name": "OUTPUT", "type": "table", "keyField": {"name": "FOO", "legacyName": "KSQL_INTERNAL_COL_0", "legacySchema": {"type": "STRING"}}}
         ]
       }
     },
     {
       "name": "table | initially null | group by (-) | key in value | no aliasing | legacy downstream query",
       "comments": [
+        "The purpose of this test is to capture the topology of a downstream query of the above test case",
+        "and test the key fields of the entities added to the metastore, to ensure backwards compatibility is maintained",
+        "In this case, the code previously incorrectly set the keyField to 'KSQL_INTERNAL_COL_0' rather than the correct 'FOO'",
+        "This would result in an unnecessary repartition step being added to the DOWNSTREAM query.",
+        "New versions of the code must not remove this unnecessary step for existing queries, as that would break backwards compatibility",
         "Note: The INTERMEDIATE table is there to create a source where the key field is set to null"
       ],
       "statements": [
@@ -755,6 +861,9 @@
         "CREATE TABLE OUTPUT AS SELECT foo, COUNT(*) FROM INTERMEDIATE GROUP BY foo;",
         "CREATE TABLE DOWNSTREAM AS SELECT foo, COUNT(*) FROM OUTPUT GROUP BY foo;"
       ],
+      "properties": {
+        "ksql.query.fields.key.legacy": "true"
+      },
       "inputs": [
         {"topic": "OUTPUT", "key": "1", "value": {"FOO": 1, "KSQL_COL_1": 1}}
       ],
@@ -763,15 +872,16 @@
       ],
       "post": {
         "sources": [
-           {"name": "INTERMEDIATE", "type": "table", "keyField": null},
-           {"name": "DOWNSTREAM", "type": "table", "keyField": {"name": "KSQL_INTERNAL_COL_0", "schema": {"type": "STRING"}}}
+          {"name": "OUTPUT", "type": "table", "keyField": {"name": "FOO", "legacyName": "KSQL_INTERNAL_COL_0", "legacySchema": {"type": "STRING"}}},
+          {"name": "DOWNSTREAM", "type": "table", "keyField": {"name": "FOO", "legacyName": "KSQL_INTERNAL_COL_0", "legacySchema": {"type": "STRING"}}}
         ]
       }
     },
     {
       "name": "table | initially null | group by (-) | key in value | aliasing",
       "comments": [
-        "Note: The INTERMEDIATE table is there to create a source where the key field is set to null"
+        "Note: The INTERMEDIATE table is there to create a source where the key field is set to null",
+        "note: GROUP BY takes the name of the field from the source schema."
       ],
       "statements": [
         "CREATE TABLE INPUT (foo INT, bar INT) WITH (kafka_topic='input_topic', key='bar', value_format='JSON');",
@@ -785,19 +895,20 @@
         {"topic": "OUTPUT", "key": "1", "value": {"ALIASED": 1, "KSQL_COL_1": 1}}
       ],
       "post": {
-        "issues": [
-          "key field of output has INCORRECT name: should be 'FOO' - (see Issue #1 above)",
-          "key field of output has INCORRECT type: should be 'INT' - (see Issue #3 above)"
-        ],
         "sources": [
-          {"name": "INTERMEDIATE", "type": "table", "keyField": null},
-          {"name": "OUTPUT", "type": "table", "keyField": {"name": "KSQL_INTERNAL_COL_0", "schema": {"type": "STRING"}}}
+          {"name": "INTERMEDIATE", "type": "table", "keyField": {"name": null, "legacyName": null}},
+          {"name": "OUTPUT", "type": "table", "keyField": {"name": "ALIASED", "legacyName": "KSQL_INTERNAL_COL_0", "legacySchema": {"type": "STRING"}}}
         ]
       }
     },
     {
       "name": "table | initially null | group by (-) | key in value | aliasing | legacy downstream query",
       "comments": [
+        "The purpose of this test is to capture the topology of a downstream query of the above test case",
+        "and test the key fields of the entities added to the metastore, to ensure backwards compatibility is maintained",
+        "In this case, the code previously incorrectly set the keyField to 'KSQL_INTERNAL_COL_0' rather than the correct 'ALIASED'",
+        "This would result in an unnecessary repartition step being added to the DOWNSTREAM query.",
+        "New versions of the code must not remove this unnecessary step for existing queries, as that would break backwards compatibility",
         "Note: The INTERMEDIATE table is there to create a source where the key field is set to null"
       ],
       "statements": [
@@ -806,6 +917,9 @@
         "CREATE TABLE OUTPUT AS SELECT foo AS aliased, COUNT(*) FROM INTERMEDIATE GROUP BY foo;",
         "CREATE TABLE DOWNSTREAM AS SELECT aliased, COUNT(*) FROM OUTPUT GROUP BY aliased;"
       ],
+      "properties": {
+        "ksql.query.fields.key.legacy": "true"
+      },
       "inputs": [
         {"topic": "OUTPUT", "key": "1", "value": {"ALIASED": 1, "KSQL_COL_1": 1}}
       ],
@@ -814,8 +928,8 @@
       ],
       "post": {
         "sources": [
-          {"name": "INTERMEDIATE", "type": "table", "keyField": null},
-          {"name": "DOWNSTREAM", "type": "table", "keyField": {"name": "KSQL_INTERNAL_COL_0", "schema": {"type": "STRING"}}}
+          {"name": "OUTPUT", "type": "table", "keyField": {"name": "ALIASED", "legacyName": "KSQL_INTERNAL_COL_0", "legacySchema": {"type": "STRING"}}},
+          {"name": "DOWNSTREAM", "type": "table", "keyField": {"name": "ALIASED", "legacyName": "KSQL_INTERNAL_COL_0", "legacySchema": {"type": "STRING"}}}
         ]
       }
     },
@@ -833,8 +947,8 @@
       ],
       "post": {
         "sources": [
-          {"name": "INPUT", "type": "table", "keyField": {"name": "FOO", "schema": {"type": "INT"}}},
-          {"name": "OUTPUT", "type": "table", "keyField": {"name": "FOO", "schema": {"type": "INT"}}}
+          {"name": "INPUT", "type": "table", "keyField": {"name": "FOO", "legacyName": "FOO", "legacySchema": {"type": "INT"}}},
+          {"name": "OUTPUT", "type": "table", "keyField": {"name": "FOO", "legacyName": "FOO", "legacySchema": {"type": "INT"}}}
         ]
       }
     },
@@ -852,8 +966,8 @@
       ],
       "post": {
         "sources": [
-          {"name": "INPUT", "type": "table", "keyField": {"name": "FOO", "schema": {"type": "INT"}}},
-          {"name": "OUTPUT", "type": "table", "keyField": {"name": "ALIASED", "schema": {"type": "INT"}}}
+          {"name": "INPUT", "type": "table", "keyField": {"name": "FOO", "legacyName": "FOO", "legacySchema": {"type": "INT"}}},
+          {"name": "OUTPUT", "type": "table", "keyField": {"name": "ALIASED", "legacyName": "ALIASED", "legacySchema": {"type": "INT"}}}
         ]
       }
     },
@@ -871,7 +985,7 @@
       ],
       "post": {
         "sources": [
-          {"name": "OUTPUT", "type": "table", "keyField": null}
+          {"name": "OUTPUT", "type": "table", "keyField": {"name": null, "legacyName": null}}
         ]
       }
     },
@@ -888,22 +1002,28 @@
         {"topic": "OUTPUT", "key": "1", "value": {"FOO": 1, "KSQL_COL_1":  1}}
       ],
       "post": {
-        "issues": [
-          "key field of output has INCORRECT name: should be 'FOO' - (see Issue #1 above)",
-          "key field of output has INCORRECT type: should be 'INT' - (see Issue #3 above)"
-        ],
         "sources": [
-          {"name": "OUTPUT", "type": "table", "keyField": {"name": "KSQL_INTERNAL_COL_0", "schema": {"type": "STRING"}}}
+          {"name": "OUTPUT", "type": "table", "keyField": {"name": "FOO", "legacyName": "KSQL_INTERNAL_COL_0", "legacySchema": {"type": "STRING"}}}
         ]
       }
     },
     {
       "name": "table | initially set | group by (same) | key in value | no aliasing | legacy downstream query",
+      "comments": [
+        "The purpose of this test is to capture the topology of a downstream query of the above test case",
+        "and test the key fields of the entities added to the metastore, to ensure backwards compatibility is maintained",
+        "In this case, the code previously incorrectly set the keyField to 'KSQL_INTERNAL_COL_0' rather than the correct 'FOO'",
+        "This would result in an unnecessary repartition step being added to the DOWNSTREAM query.",
+        "New versions of the code must not remove this unnecessary step for existing queries, as that would break backwards compatibility"
+      ],
       "statements": [
         "CREATE TABLE INPUT (foo INT, bar INT) WITH (kafka_topic='input_topic', key='foo', value_format='JSON');",
         "CREATE TABLE OUTPUT AS SELECT foo, COUNT(*) FROM INPUT GROUP BY foo;",
         "CREATE TABLE DOWNSTREAM AS SELECT foo, COUNT(*) FROM OUTPUT GROUP BY foo;"
       ],
+      "properties": {
+        "ksql.query.fields.key.legacy": "true"
+      },
       "inputs": [
         {"topic": "OUTPUT", "key": "1", "value": {"FOO": 1, "KSQL_COL_1":  1}}
       ],
@@ -912,7 +1032,8 @@
       ],
       "post": {
         "sources": [
-          {"name": "DOWNSTREAM", "type": "table", "keyField": {"name": "KSQL_INTERNAL_COL_0", "schema": {"type": "STRING"}}}
+          {"name": "OUTPUT", "type": "table", "keyField": {"name": "FOO", "legacyName": "KSQL_INTERNAL_COL_0", "legacySchema": {"type": "STRING"}}},
+          {"name": "DOWNSTREAM", "type": "table", "keyField": {"name": "FOO", "legacyName": "KSQL_INTERNAL_COL_0", "legacySchema": {"type": "STRING"}}}
         ]
       }
     },
@@ -929,22 +1050,28 @@
         {"topic": "OUTPUT", "key": "1", "value": {"ALIASED": 1, "KSQL_COL_1":  1}}
       ],
       "post": {
-        "issues": [
-          "key field of output has INCORRECT name: should be 'ALIASED' - (see Issue #1 above)",
-          "key field of output has INCORRECT type: should be 'INT' - (see Issue #3 above)"
-        ],
         "sources": [
-          {"name": "OUTPUT", "type": "table", "keyField": {"name": "KSQL_INTERNAL_COL_0", "schema": {"type": "STRING"}}}
+          {"name": "OUTPUT", "type": "table", "keyField": {"name": "ALIASED", "legacyName": "KSQL_INTERNAL_COL_0", "legacySchema": {"type": "STRING"}}}
         ]
       }
     },
     {
       "name": "table | initially set | group by (same) | key in value | aliasing | legacy downstream query",
+      "comments": [
+        "The purpose of this test is to capture the topology of a downstream query of the above test case",
+        "and test the key fields of the entities added to the metastore, to ensure backwards compatibility is maintained",
+        "In this case, the code previously incorrectly set the keyField to 'KSQL_INTERNAL_COL_0' rather than the correct 'ALIASED'",
+        "This would result in an unnecessary repartition step being added to the DOWNSTREAM query.",
+        "New versions of the code must not remove this unnecessary step for existing queries, as that would break backwards compatibility"
+      ],
       "statements": [
         "CREATE TABLE INPUT (foo INT, bar INT) WITH (kafka_topic='input_topic', key='foo', value_format='JSON');",
         "CREATE TABLE OUTPUT AS SELECT foo AS aliased, COUNT(*) FROM INPUT GROUP BY foo;",
         "CREATE TABLE DOWNSTREAM AS SELECT aliased, COUNT(*) FROM OUTPUT GROUP BY aliased;"
       ],
+      "properties": {
+        "ksql.query.fields.key.legacy": "true"
+      },
       "inputs": [
         {"topic": "OUTPUT", "key": "1", "value": {"ALIASED": 1, "KSQL_COL_1":  1}}
       ],
@@ -953,7 +1080,8 @@
       ],
       "post": {
         "sources": [
-          {"name": "DOWNSTREAM", "type": "table", "keyField": {"name": "KSQL_INTERNAL_COL_0", "schema": {"type": "STRING"}}}
+          {"name": "OUTPUT", "type": "table", "keyField": {"name": "ALIASED", "legacyName": "KSQL_INTERNAL_COL_0", "legacySchema": {"type": "STRING"}}},
+          {"name": "DOWNSTREAM", "type": "table", "keyField": {"name": "ALIASED", "legacyName": "KSQL_INTERNAL_COL_0", "legacySchema": {"type": "STRING"}}}
         ]
       }
     },
@@ -970,19 +1098,27 @@
         {"topic": "OUTPUT", "key": "1", "value": {"KSQL_COL_0":  1}}
       ],
       "post": {
-        "issues": ["key field of output INCORRECT: should be null - (see Issue #2 above)"],
         "sources": [
-          {"name": "OUTPUT", "type": "table", "keyField": {"name": "KSQL_INTERNAL_COL_1", "schema": {"type": "STRING"}}}
+          {"name": "OUTPUT", "type": "table", "keyField": {"name": null, "legacyName": "KSQL_INTERNAL_COL_1", "legacySchema": {"type": "STRING"}}}
         ]
       }
     },
     {
       "name": "table | initially set | group by (same) | key not in value | - | legacy downstream query",
+      "comments": [
+        "The purpose of this test is to capture the topology of a downstream query of the above test case",
+        "and test the key fields of the entities added to the metastore, to ensure backwards compatibility is maintained",
+        "In this case, the code previously incorrectly set the keyField to 'KSQL_INTERNAL_COL_0' rather than the correct 'null'",
+        "This would not really create any problems, but its good to ensure things remain consistent."
+      ],
       "statements": [
         "CREATE TABLE INPUT (foo INT, bar INT) WITH (kafka_topic='input_topic', key='foo', value_format='JSON');",
         "CREATE TABLE OUTPUT AS SELECT COUNT(*) FROM INPUT GROUP BY foo;",
         "CREATE TABLE DOWNSTREAM AS SELECT COUNT(*) FROM OUTPUT GROUP BY ROWKEY;"
       ],
+      "properties": {
+        "ksql.query.fields.key.legacy": "true"
+      },
       "inputs": [
         {"topic": "OUTPUT", "key": "1", "value": {"KSQL_COL_0":  1}}
       ],
@@ -991,7 +1127,8 @@
       ],
       "post": {
         "sources": [
-          {"name": "DOWNSTREAM", "type": "table", "keyField": {"name": "KSQL_INTERNAL_COL_1", "schema": {"type": "STRING"}}}
+          {"name": "OUTPUT", "type": "table", "keyField": {"name": null, "legacyName": "KSQL_INTERNAL_COL_1", "legacySchema": {"type": "STRING"}}},
+          {"name": "DOWNSTREAM", "type": "table", "keyField": {"name": null, "legacyName": "KSQL_INTERNAL_COL_1", "legacySchema": {"type": "STRING"}}}
         ]
       }
     },
@@ -1008,22 +1145,28 @@
         {"topic": "OUTPUT", "key": "2", "value": {"BAR": 2, "KSQL_COL_1":  1}}
       ],
       "post": {
-        "issues": [
-          "key field of output has INCORRECT name: should be 'BAR' - (see Issue #1 above)",
-          "key field of output has INCORRECT type: should be 'INT' - (see Issue #3 above)"
-        ],
         "sources": [
-          {"name": "OUTPUT", "type": "table", "keyField": {"name": "KSQL_INTERNAL_COL_0", "schema": {"type": "STRING"}}}
+          {"name": "OUTPUT", "type": "table", "keyField": {"name": "BAR", "legacyName": "KSQL_INTERNAL_COL_0", "legacySchema": {"type": "STRING"}}}
         ]
       }
     },
     {
       "name": "table | initially set | group by (different) | key in value | no aliasing | legacy downstream query",
+      "comments": [
+        "The purpose of this test is to capture the topology of a downstream query of the above test case",
+        "and test the key fields of the entities added to the metastore, to ensure backwards compatibility is maintained",
+        "In this case, the code previously incorrectly set the keyField to 'KSQL_INTERNAL_COL_0' rather than the correct 'BAR'",
+        "This would result in an unnecessary repartition step being added to the DOWNSTREAM query.",
+        "New versions of the code must not remove this unnecessary step for existing queries, as that would break backwards compatibility"
+      ],
       "statements": [
         "CREATE TABLE INPUT (foo INT, bar INT) WITH (kafka_topic='input_topic', key='foo', value_format='JSON');",
         "CREATE TABLE OUTPUT AS SELECT bar, COUNT(*) FROM INPUT GROUP BY bar;",
         "CREATE TABLE DOWNSTREAM AS SELECT bar, COUNT(*) FROM OUTPUT GROUP BY bar;"
       ],
+      "properties": {
+        "ksql.query.fields.key.legacy": "true"
+      },
       "inputs": [
         {"topic": "OUTPUT", "key": "2", "value": {"BAR": 2, "KSQL_COL_1":  1}}
       ],
@@ -1032,7 +1175,8 @@
       ],
       "post": {
         "sources": [
-          {"name": "DOWNSTREAM", "type": "table", "keyField": {"name": "KSQL_INTERNAL_COL_0", "schema": {"type": "STRING"}}}
+          {"name": "OUTPUT", "type": "table", "keyField": {"name": "BAR", "legacyName": "KSQL_INTERNAL_COL_0", "legacySchema": {"type": "STRING"}}},
+          {"name": "DOWNSTREAM", "type": "table", "keyField": {"name": "BAR", "legacyName": "KSQL_INTERNAL_COL_0", "legacySchema": {"type": "STRING"}}}
         ]
       }
     },
@@ -1049,22 +1193,28 @@
         {"topic": "OUTPUT", "key": "2", "value": {"ALIASED": 2, "KSQL_COL_1":  1}}
       ],
       "post": {
-        "issues": [
-          "key field of output has INCORRECT name: should be 'ALIASED' - (see Issue #1 above)",
-          "key field of output has INCORRECT type: should be 'INT' - (see Issue #3 above)"
-        ],
         "sources": [
-          {"name": "OUTPUT", "type": "table", "keyField": {"name": "KSQL_INTERNAL_COL_0", "schema": {"type": "STRING"}}}
+          {"name": "OUTPUT", "type": "table", "keyField": {"name": "ALIASED", "legacyName": "KSQL_INTERNAL_COL_0", "legacySchema": {"type": "STRING"}}}
         ]
       }
     },
     {
       "name": "table | initially set | group by (different) | key in value | aliasing | legacy downstream query",
+      "comments": [
+        "The purpose of this test is to capture the topology of a downstream query of the above test case",
+        "and test the key fields of the entities added to the metastore, to ensure backwards compatibility is maintained",
+        "In this case, the code previously incorrectly set the keyField to 'KSQL_INTERNAL_COL_0' rather than the correct 'ALIASED'",
+        "This would result in an unnecessary repartition step being added to the DOWNSTREAM query.",
+        "New versions of the code must not remove this unnecessary step for existing queries, as that would break backwards compatibility"
+      ],
       "statements": [
         "CREATE TABLE INPUT (foo INT, bar INT) WITH (kafka_topic='input_topic', key='foo', value_format='JSON');",
         "CREATE TABLE OUTPUT AS SELECT bar AS aliased, COUNT(*) FROM INPUT GROUP BY bar;",
         "CREATE TABLE DOWNSTREAM AS SELECT aliased, COUNT(*) FROM OUTPUT GROUP BY Aliased;"
       ],
+      "properties": {
+        "ksql.query.fields.key.legacy": "true"
+      },
       "inputs": [
         {"topic": "OUTPUT", "key": "2", "value": {"ALIASED": 2, "KSQL_COL_1":  1}}
       ],
@@ -1073,7 +1223,8 @@
       ],
       "post": {
         "sources": [
-          {"name": "DOWNSTREAM", "type": "table", "keyField": {"name": "KSQL_INTERNAL_COL_0", "schema": {"type": "STRING"}}}
+          {"name": "OUTPUT", "type": "table", "keyField": {"name": "ALIASED", "legacyName": "KSQL_INTERNAL_COL_0", "legacySchema": {"type": "STRING"}}},
+          {"name": "DOWNSTREAM", "type": "table", "keyField": {"name": "ALIASED", "legacyName": "KSQL_INTERNAL_COL_0", "legacySchema": {"type": "STRING"}}}
         ]
       }
     },
@@ -1090,19 +1241,27 @@
         {"topic": "OUTPUT", "key": "2", "value": {"KSQL_COL_0":  1}}
       ],
       "post": {
-        "issues": ["key field of output INCORRECT: should be null - (see Issue #2 above)"],
         "sources": [
-          {"name": "OUTPUT", "type": "table", "keyField": {"name": "KSQL_INTERNAL_COL_1", "schema": {"type": "STRING"}}}
+          {"name": "OUTPUT", "type": "table", "keyField": {"name": null, "legacyName": "KSQL_INTERNAL_COL_1", "legacySchema": {"type": "STRING"}}}
         ]
       }
     },
     {
       "name": "table | initially set | group by (different) | key not in value | - | legacy downstream query",
+      "comments": [
+        "The purpose of this test is to capture the topology of a downstream query of the above test case",
+        "and test the key fields of the entities added to the metastore, to ensure backwards compatibility is maintained",
+        "In this case, the code previously incorrectly set the keyField to 'KSQL_INTERNAL_COL_1' rather than the correct 'null'",
+        "This would not really create any problems, but its good to ensure things remain consistent."
+      ],
       "statements": [
         "CREATE TABLE INPUT (foo INT, bar INT) WITH (kafka_topic='input_topic', key='foo', value_format='JSON');",
         "CREATE TABLE OUTPUT AS SELECT COUNT(*) FROM INPUT GROUP BY bar;",
         "CREATE TABLE DOWNSTREAM AS SELECT COUNT(*) FROM OUTPUT GROUP BY ROWKEY;"
       ],
+      "properties": {
+        "ksql.query.fields.key.legacy": "true"
+      },
       "inputs": [
         {"topic": "OUTPUT", "key": "2", "value": {"KSQL_COL_0":  1}}
       ],
@@ -1111,7 +1270,7 @@
       ],
       "post": {
         "sources": [
-          {"name": "OUTPUT", "type": "table", "keyField": {"name": "KSQL_INTERNAL_COL_1", "schema": {"type": "STRING"}}}
+          {"name": "OUTPUT", "type": "table", "keyField": {"name": null, "legacyName": "KSQL_INTERNAL_COL_1", "legacySchema": {"type": "STRING"}}}
         ]
       }
     },
@@ -1156,19 +1315,27 @@
         {"topic": "OUTPUT", "key":"2|+|1", "value": {"FOO": 1, "BAR": 2, "KSQL_COL_2": 1}}
       ],
       "post": {
-        "issues": ["key field of output is INCORRECT: should be null - (see Issue #2 above)"],
         "sources": [
-          {"name": "OUTPUT", "type": "table", "keyField": {"name": "KSQL_INTERNAL_COL_1|+|KSQL_INTERNAL_COL_0", "schema": {"type": "STRING"}}}
+          {"name": "OUTPUT", "type": "table", "keyField": {"name": null, "legacyName": "KSQL_INTERNAL_COL_1|+|KSQL_INTERNAL_COL_0", "legacySchema": {"type": "STRING"}}}
         ]
       }
     },
     {
       "name": "stream | initially set | group by multiple | key in value | no aliasing | legacy downstream query",
+      "comments": [
+        "The purpose of this test is to capture the topology of a downstream query of the above test case",
+        "and test the key fields of the entities added to the metastore, to ensure backwards compatibility is maintained",
+        "In this case, the code previously incorrectly set the keyField to 'KSQL_INTERNAL_COL_1|+|KSQL_INTERNAL_COL_0' rather than the correct 'null'",
+        "This would not really create any problems, but its good to ensure things remain consistent."
+      ],
       "statements": [
         "CREATE STREAM INPUT (foo INT, bar INT) WITH (kafka_topic='input_topic', key='foo', value_format='JSON');",
         "CREATE TABLE OUTPUT AS SELECT foo, bar, COUNT(*) FROM INPUT GROUP BY bar, foo;",
         "CREATE TABLE DOWNSTREAM AS SELECT COUNT(*) FROM OUTPUT GROUP BY ROWKEY;"
       ],
+      "properties": {
+        "ksql.query.fields.key.legacy": "true"
+      },
       "inputs": [
         {"topic": "OUTPUT", "key":"2|+|1", "value": {"FOO": 1, "BAR": 2, "KSQL_COL_2": 1}}
       ],
@@ -1177,7 +1344,7 @@
       ],
       "post": {
         "sources": [
-          {"name": "OUTPUT", "type": "table", "keyField": {"name": "KSQL_INTERNAL_COL_1|+|KSQL_INTERNAL_COL_0", "schema": {"type": "STRING"}}}
+          {"name": "OUTPUT", "type": "table", "keyField": {"name": null, "legacyName": "KSQL_INTERNAL_COL_1|+|KSQL_INTERNAL_COL_0", "legacySchema": {"type": "STRING"}}}
         ]
       }
     },
@@ -1195,21 +1362,29 @@
       ],
       "post": {
         "issues": [
-          "key field of output has INCORRECT name: should be 'KSQL_COL_0' - (see Issue #1 above)",
-          "key field of output has INCORRECT type: should be 'INT' - (see Issue #3 above)"
+          "key field of output has INCORRECT name: should be 'KSQL_COL_0'"
         ],
         "sources": [
-          {"name": "OUTPUT", "type": "table", "keyField": {"name": "(KSQL_INTERNAL_COL_0 + KSQL_INTERNAL_COL_1)", "schema": {"type": "STRING"}}}
+          {"name": "OUTPUT", "type": "table", "keyField": {"name": null, "legacyName": "(KSQL_INTERNAL_COL_0 + KSQL_INTERNAL_COL_1)", "legacySchema": {"type": "STRING"}}}
         ]
       }
     },
     {
       "name": "stream | initially set | group by expression | key in value | no aliasing | legacy downstream query",
+      "comments": [
+        "The purpose of this test is to capture the topology of a downstream query of the above test case",
+        "and test the key fields of the entities added to the metastore, to ensure backwards compatibility is maintained",
+        "In this case, the code previously incorrectly set the keyField to 'KSQL_INTERNAL_COL_1' rather than the correct 'null'",
+        "This would not really create any problems, but its good to ensure things remain consistent."
+      ],
       "statements": [
         "CREATE STREAM INPUT (foo INT, bar INT) WITH (kafka_topic='input_topic', key='foo', value_format='JSON');",
         "CREATE TABLE OUTPUT AS SELECT foo + bar, COUNT(*) FROM INPUT GROUP BY foo + bar;",
         "CREATE TABLE DOWNSTREAM AS SELECT COUNT(*) FROM OUTPUT GROUP BY ROWKEY;"
       ],
+      "properties": {
+        "ksql.query.fields.key.legacy": "true"
+      },
       "inputs": [
         {"topic": "OUTPUT", "key":"3", "value": {"KSQL_COL_0": 3, "KSQL_COL_1": 1}}
       ],
@@ -1217,8 +1392,11 @@
         {"topic": "DOWNSTREAM", "key":"3", "value": {"KSQL_COL_0": 1}}
       ],
       "post": {
+        "issues": [
+          "key field of output has INCORRECT name: should be 'KSQL_COL_0'"
+        ],
         "sources": [
-          {"name": "DOWNSTREAM", "type": "table", "keyField": {"name": "KSQL_INTERNAL_COL_1", "schema": {"type": "STRING"}}}
+          {"name": "DOWNSTREAM", "type": "table", "keyField": {"name": null, "legacyName": "KSQL_INTERNAL_COL_1", "legacySchema": {"type": "STRING"}}}
         ]
       }
     },
@@ -1228,6 +1406,7 @@
         "CREATE STREAM INPUT (foo INT, bar INT) WITH (kafka_topic='input_topic', value_format='JSON');",
         "CREATE TABLE OUTPUT AS SELECT cast(foo as INT), COUNT(*) FROM INPUT GROUP BY cast(foo as INT);"
       ],
+      "issues:": "this is a duplicate of `group by expression` and should be removed",
       "inputs": [
         {"topic": "input_topic", "value": {"foo": 1, "bar": 2}}
       ],
@@ -1236,22 +1415,31 @@
       ],
       "post": {
         "issues": [
-          "key field of output has INCORRECT name: should be 'KSQL_COL_0' - (see Issue #1 above)",
-          "key field of output has INCORRECT type: should be 'INT' - (see Issue #3 above)"
+          "key field of output has INCORRECT name: should be 'KSQL_COL_0'"
         ],
         "sources": [
-          {"name": "INPUT", "type": "stream", "keyField": null},
-          {"name": "OUTPUT", "type": "table", "keyField": {"name": "CAST(KSQL_INTERNAL_COL_0 AS INTEGER)", "schema": {"type": "STRING"}}}
+          {"name": "INPUT", "type": "stream", "keyField": {"name": null, "legacyName": null}},
+          {"name": "OUTPUT", "type": "table", "keyField": {"name": null, "legacyName": "CAST(KSQL_INTERNAL_COL_0 AS INTEGER)", "legacySchema": {"type": "STRING"}}}
         ]
       }
     },
     {
       "name": "stream | initially null | group by (-) | key in value | no aliasing | with cast | legacy downstream query",
+      "comments": [
+        "The purpose of this test is to capture the topology of a downstream query of the above test case",
+        "and test the key fields of the entities added to the metastore, to ensure backwards compatibility is maintained",
+        "In this case, the code previously incorrectly set the keyField to 'KSQL_INTERNAL_COL_1' rather than the correct 'null'",
+        "This would not really create any problems, but its good to ensure things remain consistent."
+      ],
       "statements": [
         "CREATE STREAM INPUT (foo INT, bar INT) WITH (kafka_topic='input_topic', value_format='JSON');",
         "CREATE TABLE OUTPUT AS SELECT cast(foo as INT), COUNT(*) FROM INPUT GROUP BY cast(foo as INT);",
         "CREATE TABLE DOWNSTREAM AS SELECT COUNT(*) FROM OUTPUT GROUP BY ROWKEY;"
       ],
+      "issues:": "this is a duplicate of `group by expression` and should be removed",
+      "properties": {
+        "ksql.query.fields.key.legacy": "true"
+      },
       "inputs": [
         {"topic": "OUTPUT", "key": "1", "value": {"KSQL_COL_0":1, "KSQL_COL_1": 1}}
       ],
@@ -1259,8 +1447,11 @@
         {"topic": "DOWNSTREAM", "key": "1", "value": {"KSQL_COL_0":1}}
       ],
       "post": {
+        "issues": [
+          "key field of output has INCORRECT name: should be 'KSQL_COL_0'"
+        ],
         "sources": [
-          {"name": "DOWNSTREAM", "type": "table", "keyField": {"name": "KSQL_INTERNAL_COL_1", "schema": {"type": "STRING"}}}
+          {"name": "DOWNSTREAM", "type": "table", "keyField": {"name": null, "legacyName": "KSQL_INTERNAL_COL_1", "legacySchema": {"type": "STRING"}}}
         ]
       }
     },
@@ -1278,7 +1469,7 @@
       ],
       "post": {
         "sources": [
-          {"name": "OUTPUT", "type": "stream", "keyField": {"name": "FOO", "schema": {"type": "INT"}}}
+          {"name": "OUTPUT", "type": "stream", "keyField": {"name": "FOO", "legacyName": "FOO", "legacySchema": {"type": "INT"}}}
         ]
       }
     },
@@ -1295,11 +1486,44 @@
         {"topic": "OUTPUT", "value": {"BOO": 1}}
       ],
       "post": {
-        "issues": [
-          "source key field name incorrect - should be 'BOO'"
-        ],
         "sources": [
-          {"name": "OUTPUT", "type": "stream", "keyField": {"name": "FOO", "schema": {"type": "INT"}}}
+          {"name": "OUTPUT", "type": "stream", "keyField": {"name": "BOO", "legacyName": "FOO", "legacySchema": {"type": "INT"}}}
+        ]
+      }
+    },
+    {
+      "name": "using source alias in projection",
+      "statements": [
+        "CREATE STREAM INPUT (foo INT, bar INT) WITH (kafka_topic='input_topic', key='foo', value_format='JSON');",
+        "CREATE STREAM OUTPUT AS SELECT i.foo FROM INPUT i WHERE bar < 10;"
+      ],
+      "inputs": [
+        {"topic": "input_topic", "value": {"foo": 1, "bar": 2}}
+      ],
+      "outputs": [
+        {"topic": "OUTPUT", "value": {"FOO": 1}}
+      ],
+      "post": {
+        "sources": [
+          {"name": "OUTPUT", "type": "stream", "keyField": {"name": "FOO", "legacyName": "FOO", "legacySchema": {"type": "INT"}}}
+        ]
+      }
+    },
+    {
+      "name": "using full source name in projection",
+      "statements": [
+        "CREATE STREAM INPUT (foo INT, bar INT) WITH (kafka_topic='input_topic', key='foo', value_format='JSON');",
+        "CREATE STREAM OUTPUT AS SELECT input.foo FROM INPUT WHERE bar < 10;"
+      ],
+      "inputs": [
+        {"topic": "input_topic", "value": {"foo": 1, "bar": 2}}
+      ],
+      "outputs": [
+        {"topic": "OUTPUT", "value": {"FOO": 1}}
+      ],
+      "post": {
+        "sources": [
+          {"name": "OUTPUT", "type": "stream", "keyField": {"name": "FOO", "legacyName": "FOO", "legacySchema": {"type": "INT"}}}
         ]
       }
     }

--- a/ksql-engine/src/test/resources/query-validation-tests/key-field.json
+++ b/ksql-engine/src/test/resources/query-validation-tests/key-field.json
@@ -1263,6 +1263,45 @@
           {"name": "DOWNSTREAM", "type": "table", "keyField": {"name": "KSQL_INTERNAL_COL_1", "schema": {"type": "STRING"}}}
         ]
       }
+    },
+    {
+      "name": "where clause",
+      "statements": [
+        "CREATE STREAM INPUT (foo INT, bar INT) WITH (kafka_topic='input_topic', key='foo', value_format='JSON');",
+        "CREATE STREAM OUTPUT AS SELECT foo FROM INPUT WHERE bar < 10;"
+      ],
+      "inputs": [
+        {"topic": "input_topic", "value": {"foo": 1, "bar": 2}}
+      ],
+      "outputs": [
+        {"topic": "OUTPUT", "value": {"FOO": 1}}
+      ],
+      "post": {
+        "sources": [
+          {"name": "OUTPUT", "type": "stream", "keyField": {"name": "FOO", "schema": {"type": "INT"}}}
+        ]
+      }
+    },
+    {
+      "name": "where clause with alias",
+      "statements": [
+        "CREATE STREAM INPUT (foo INT, bar INT) WITH (kafka_topic='input_topic', key='foo', value_format='JSON');",
+        "CREATE STREAM OUTPUT AS SELECT foo as boo FROM INPUT WHERE bar < 10;"
+      ],
+      "inputs": [
+        {"topic": "input_topic", "value": {"foo": 1, "bar": 2}}
+      ],
+      "outputs": [
+        {"topic": "OUTPUT", "value": {"BOO": 1}}
+      ],
+      "post": {
+        "issues": [
+          "source key field name incorrect - should be 'BOO'"
+        ],
+        "sources": [
+          {"name": "OUTPUT", "type": "stream", "keyField": {"name": "FOO", "schema": {"type": "INT"}}}
+        ]
+      }
     }
   ]
 }

--- a/ksql-engine/src/test/resources/query-validation-tests/key-field.json
+++ b/ksql-engine/src/test/resources/query-validation-tests/key-field.json
@@ -78,7 +78,7 @@
       "post": {
         "sources": [
           {"name": "INPUT", "type": "stream", "keyField": {"name": null, "legacyName": null}},
-          {"name": "OUTPUT", "type": "stream", "keyField": {"name": "FOO", "legacyName": "FOO", "legacySchema": {"type": "INT"}}}
+          {"name": "OUTPUT", "type": "stream", "keyField": {"name": "FOO", "legacyName": "FOO", "legacySchema": "INT"}}
         ]
       }
     },
@@ -97,7 +97,7 @@
       "post": {
         "sources": [
           {"name": "INPUT", "type": "stream", "keyField": {"name": null, "legacyName": null}},
-          {"name": "OUTPUT", "type": "stream", "keyField": {"name": "ALIASED", "legacyName": "ALIASED", "legacySchema": {"type": "INT"}}}
+          {"name": "OUTPUT", "type": "stream", "keyField": {"name": "ALIASED", "legacyName": "ALIASED", "legacySchema": "INT"}}
         ]
       }
     },
@@ -130,13 +130,8 @@
           {
             "name": "OUTPUT",
             "type": "table",
-            "keyField": {"name": "FOO", "legacyName": "KSQL_INTERNAL_COL_0", "legacySchema": {"type": "STRING"}},
-            "valueSchema": {"type": "STRUCT", "fields": [
-              {"name": "ROWTIME", "schema": {"type": "BIGINT"}},
-              {"name": "ROWKEY", "schema": {"type": "STRING"}},
-              {"name": "FOO", "schema": {"type": "INT"}},
-              {"name": "KSQL_COL_1", "schema": {"type": "BIGINT"}}
-            ]}
+            "keyField": {"name": "FOO", "legacyName": "KSQL_INTERNAL_COL_0", "legacySchema": "STRING"},
+            "valueSchema": "STRUCT<ROWTIME BIGINT, ROWKEY STRING, FOO INT, KSQL_COL_1 BIGINT>"
           }
         ]
       }
@@ -166,7 +161,7 @@
       ],
       "post": {
         "sources": [
-          {"name": "DOWNSTREAM", "type": "table", "keyField": {"name": "FOO", "legacyName": "KSQL_INTERNAL_COL_0", "legacySchema": {"type": "STRING"}}}
+          {"name": "DOWNSTREAM", "type": "table", "keyField": {"name": "FOO", "legacyName": "KSQL_INTERNAL_COL_0", "legacySchema": "STRING"}}
         ]
       }
     },
@@ -185,7 +180,7 @@
       "post": {
         "sources": [
           {"name": "INPUT", "type": "stream", "keyField": {"name": null, "legacyName": null}},
-          {"name": "OUTPUT", "type": "table", "keyField": {"name": "ALIASED", "legacyName": "KSQL_INTERNAL_COL_0", "legacySchema": {"type": "STRING"}}}
+          {"name": "OUTPUT", "type": "table", "keyField": {"name": "ALIASED", "legacyName": "KSQL_INTERNAL_COL_0", "legacySchema": "STRING"}}
         ]
       }
     },
@@ -214,7 +209,7 @@
       ],
       "post": {
         "sources": [
-           {"name": "DOWNSTREAM", "type": "table", "keyField": {"name": "ALIASED", "legacyName": "KSQL_INTERNAL_COL_0", "legacySchema": {"type": "STRING"}}}
+           {"name": "DOWNSTREAM", "type": "table", "keyField": {"name": "ALIASED", "legacyName": "KSQL_INTERNAL_COL_0", "legacySchema": "STRING"}}
         ]
       }
     },
@@ -233,7 +228,7 @@
       "post": {
         "sources": [
           {"name": "INPUT", "type": "stream", "keyField": {"name": null, "legacyName": null}},
-          {"name": "OUTPUT", "type": "table", "keyField": {"name": null, "legacyName": "KSQL_INTERNAL_COL_1", "legacySchema": {"type": "STRING"}}}
+          {"name": "OUTPUT", "type": "table", "keyField": {"name": null, "legacyName": "KSQL_INTERNAL_COL_1", "legacySchema": "STRING"}}
         ]
       }
     },
@@ -261,7 +256,7 @@
       ],
       "post": {
         "sources": [
-          {"name": "DOWNSTREAM", "type": "table", "keyField": {"name": null, "legacyName": "KSQL_INTERNAL_COL_1", "legacySchema": {"type": "STRING"}}}
+          {"name": "DOWNSTREAM", "type": "table", "keyField": {"name": null, "legacyName": "KSQL_INTERNAL_COL_1", "legacySchema": "STRING"}}
         ]
       }
     },
@@ -279,8 +274,8 @@
       ],
       "post": {
         "sources": [
-          {"name": "INPUT", "type": "stream", "keyField": {"name": "FOO", "legacyName": "FOO", "legacySchema": {"type": "INT"}}},
-          {"name": "OUTPUT", "type": "stream", "keyField": {"name": "FOO", "legacyName": "FOO", "legacySchema": {"type": "INT"}}}
+          {"name": "INPUT", "type": "stream", "keyField": {"name": "FOO", "legacyName": "FOO", "legacySchema": "INT"}},
+          {"name": "OUTPUT", "type": "stream", "keyField": {"name": "FOO", "legacyName": "FOO", "legacySchema": "INT"}}
         ]
       }
     },
@@ -298,8 +293,8 @@
       ],
       "post": {
         "sources": [
-          {"name": "INPUT", "type": "stream", "keyField": {"name": "FOO", "legacyName": "FOO", "legacySchema": {"type": "INT"}}},
-          {"name": "OUTPUT", "type": "stream", "keyField": {"name": "ALIASED", "legacyName": "FOO", "legacySchema": {"type": "INT"}}}
+          {"name": "INPUT", "type": "stream", "keyField": {"name": "FOO", "legacyName": "FOO", "legacySchema": "INT"}},
+          {"name": "OUTPUT", "type": "stream", "keyField": {"name": "ALIASED", "legacyName": "FOO", "legacySchema": "INT"}}
         ]
       }
     },
@@ -328,8 +323,8 @@
       ],
       "post": {
         "sources": [
-          {"name": "OUTPUT", "type": "stream", "keyField": {"name": "ALIASED", "legacyName": "FOO", "legacySchema": {"type": "INT"}}},
-         {"name": "DOWNSTREAM", "type": "stream", "keyField": {"name": "ALIASED", "legacyName": "ALIASED", "legacySchema": {"type": "INT"}}}
+          {"name": "OUTPUT", "type": "stream", "keyField": {"name": "ALIASED", "legacyName": "FOO", "legacySchema": "INT"}},
+         {"name": "DOWNSTREAM", "type": "stream", "keyField": {"name": "ALIASED", "legacyName": "ALIASED", "legacySchema": "INT"}}
         ]
       }
     },
@@ -347,8 +342,8 @@
       ],
       "post": {
         "sources": [
-          {"name": "INPUT", "type": "stream", "keyField": {"name": "FOO", "legacyName": "FOO", "legacySchema": {"type": "INT"}}},
-          {"name": "OUTPUT", "type": "stream", "keyField": {"name": "ALIASED", "legacyName": "FOO", "legacySchema": {"type": "INT"}}}
+          {"name": "INPUT", "type": "stream", "keyField": {"name": "FOO", "legacyName": "FOO", "legacySchema": "INT"}},
+          {"name": "OUTPUT", "type": "stream", "keyField": {"name": "ALIASED", "legacyName": "FOO", "legacySchema": "INT"}}
         ]
       }
     },
@@ -377,8 +372,8 @@
       ],
       "post": {
         "sources": [
-          {"name": "OUTPUT", "type": "stream", "keyField": {"name": "ALIASED", "legacyName": "FOO", "legacySchema": {"type": "INT"}}},
-          {"name": "DOWNSTREAM", "type": "stream", "keyField": {"name": "ALIASED", "legacyName": "ALIASED", "legacySchema": {"type": "INT"}}}
+          {"name": "OUTPUT", "type": "stream", "keyField": {"name": "ALIASED", "legacyName": "FOO", "legacySchema": "INT"}},
+          {"name": "DOWNSTREAM", "type": "stream", "keyField": {"name": "ALIASED", "legacyName": "ALIASED", "legacySchema": "INT"}}
         ]
       }
     },
@@ -409,8 +404,8 @@
       ],
       "post": {
         "sources": [
-          {"name": "OUTPUT", "type": "stream", "keyField": {"name": "ALIASED", "legacyName": "FOO", "legacySchema": {"type": "INT"}}},
-          {"name": "DOWNSTREAM", "type": "stream", "keyField": {"name": "FOO", "legacyName": "FOO", "legacySchema": {"type": "INT"}}}
+          {"name": "OUTPUT", "type": "stream", "keyField": {"name": "ALIASED", "legacyName": "FOO", "legacySchema": "INT"}},
+          {"name": "DOWNSTREAM", "type": "stream", "keyField": {"name": "FOO", "legacyName": "FOO", "legacySchema": "INT"}}
         ]
       }
     },
@@ -429,7 +424,7 @@
       ],
       "post": {
         "sources": [
-          {"name": "DOWNSTREAM", "type": "stream", "keyField": {"name": "FOO", "legacyName": "FOO", "legacySchema": {"type": "INT"}}}
+          {"name": "DOWNSTREAM", "type": "stream", "keyField": {"name": "FOO", "legacyName": "FOO", "legacySchema": "INT"}}
         ]
       }
     },
@@ -447,8 +442,8 @@
       ],
       "post": {
         "sources": [
-          {"name": "INPUT", "type": "stream", "keyField": {"name": "FOO", "legacyName": "FOO", "legacySchema": {"type": "INT"}}},
-          {"name": "OUTPUT", "type": "stream", "keyField": {"name": null, "legacyName": "FOO", "legacySchema": {"type": "INT"}}}
+          {"name": "INPUT", "type": "stream", "keyField": {"name": "FOO", "legacyName": "FOO", "legacySchema": "INT"}},
+          {"name": "OUTPUT", "type": "stream", "keyField": {"name": null, "legacyName": "FOO", "legacySchema": "INT"}}
         ]
       }
     },
@@ -476,8 +471,8 @@
       ],
       "post": {
        "sources": [
-         {"name": "OUTPUT", "type": "stream", "keyField": {"name": null, "legacyName": "FOO", "legacySchema": {"type": "INT"}}},
-           {"name": "DOWNSTREAM", "type": "stream", "keyField": {"name": "FOO", "legacyName": "FOO", "legacySchema": {"type": "INT"}}}
+         {"name": "OUTPUT", "type": "stream", "keyField": {"name": null, "legacyName": "FOO", "legacySchema": "INT"}},
+           {"name": "DOWNSTREAM", "type": "stream", "keyField": {"name": "FOO", "legacyName": "FOO", "legacySchema": "INT"}}
         ]
       }
     },
@@ -495,8 +490,8 @@
       ],
       "post": {
         "sources": [
-          {"name": "INPUT", "type": "stream", "keyField": {"name": "FOO", "legacyName": "FOO", "legacySchema": {"type": "INT"}}},
-          {"name": "OUTPUT", "type": "stream", "keyField": {"name": "FOO", "legacyName": "FOO", "legacySchema": {"type": "INT"}}}
+          {"name": "INPUT", "type": "stream", "keyField": {"name": "FOO", "legacyName": "FOO", "legacySchema": "INT"}},
+          {"name": "OUTPUT", "type": "stream", "keyField": {"name": "FOO", "legacyName": "FOO", "legacySchema": "INT"}}
         ]
       }
     },
@@ -517,8 +512,8 @@
       ],
       "post": {
         "sources": [
-          {"name": "INPUT", "type": "stream", "keyField": {"name": "FOO", "legacyName": "FOO", "legacySchema": {"type": "INT"}}},
-          {"name": "OUTPUT", "type": "stream", "keyField": {"name": "ALIASED", "legacyName": "ALIASED", "legacySchema": {"type": "INT"}}}
+          {"name": "INPUT", "type": "stream", "keyField": {"name": "FOO", "legacyName": "FOO", "legacySchema": "INT"}},
+          {"name": "OUTPUT", "type": "stream", "keyField": {"name": "ALIASED", "legacyName": "ALIASED", "legacySchema": "INT"}}
         ]
       }
     },
@@ -566,8 +561,8 @@
       ],
       "post": {
         "sources": [
-          {"name": "INPUT", "type": "stream", "keyField": {"name": "FOO", "legacyName": "FOO", "legacySchema": {"type": "INT"}}},
-          {"name": "OUTPUT", "type": "stream", "keyField": {"name": "BAR", "legacyName": "BAR", "legacySchema": {"type": "INT"}}}
+          {"name": "INPUT", "type": "stream", "keyField": {"name": "FOO", "legacyName": "FOO", "legacySchema": "INT"}},
+          {"name": "OUTPUT", "type": "stream", "keyField": {"name": "BAR", "legacyName": "BAR", "legacySchema": "INT"}}
         ]
       }
     },
@@ -585,8 +580,8 @@
       ],
       "post": {
         "sources": [
-          {"name": "INPUT", "type": "stream", "keyField": {"name": "FOO", "legacyName": "FOO", "legacySchema": {"type": "INT"}}},
-          {"name": "OUTPUT", "type": "stream", "keyField": {"name": "ALIASED", "legacyName": "ALIASED", "legacySchema": {"type": "INT"}}}
+          {"name": "INPUT", "type": "stream", "keyField": {"name": "FOO", "legacyName": "FOO", "legacySchema": "INT"}},
+          {"name": "OUTPUT", "type": "stream", "keyField": {"name": "ALIASED", "legacyName": "ALIASED", "legacySchema": "INT"}}
         ]
       }
     },
@@ -615,8 +610,8 @@
       ],
       "post": {
         "sources": [
-          {"name": "INPUT", "type": "stream", "keyField": {"name": "FOO", "legacyName": "FOO", "legacySchema": {"type": "INT"}}},
-          {"name": "OUTPUT", "type": "table", "keyField": {"name": "FOO", "legacyName": "FOO", "legacySchema": {"type": "INT"}}}
+          {"name": "INPUT", "type": "stream", "keyField": {"name": "FOO", "legacyName": "FOO", "legacySchema": "INT"}},
+          {"name": "OUTPUT", "type": "table", "keyField": {"name": "FOO", "legacyName": "FOO", "legacySchema": "INT"}}
         ]
       }
     },
@@ -634,8 +629,8 @@
       ],
       "post": {
         "sources": [
-          {"name": "INPUT", "type": "stream", "keyField": {"name": "FOO", "legacyName": "FOO", "legacySchema": {"type": "INT"}}},
-          {"name": "OUTPUT", "type": "table", "keyField": {"name": "ALIASED", "legacyName": "ALIASED", "legacySchema": {"type": "INT"}}}
+          {"name": "INPUT", "type": "stream", "keyField": {"name": "FOO", "legacyName": "FOO", "legacySchema": "INT"}},
+          {"name": "OUTPUT", "type": "table", "keyField": {"name": "ALIASED", "legacyName": "ALIASED", "legacySchema": "INT"}}
         ]
       }
     },
@@ -671,7 +666,7 @@
       ],
       "post": {
         "sources": [
-          {"name": "OUTPUT", "type": "table", "keyField": {"name": "BAR", "legacyName": "KSQL_INTERNAL_COL_0", "legacySchema": {"type": "STRING"}}}
+          {"name": "OUTPUT", "type": "table", "keyField": {"name": "BAR", "legacyName": "KSQL_INTERNAL_COL_0", "legacySchema": "STRING"}}
         ]
       }
     },
@@ -700,8 +695,8 @@
       ],
       "post": {
         "sources": [
-          {"name": "OUTPUT", "type": "table", "keyField": {"name": "BAR", "legacyName": "KSQL_INTERNAL_COL_0", "legacySchema": {"type": "STRING"}}},
-          {"name": "DOWNSTREAM", "type": "table", "keyField": {"name": "BAR", "legacyName": "KSQL_INTERNAL_COL_0", "legacySchema": {"type": "STRING"}}}
+          {"name": "OUTPUT", "type": "table", "keyField": {"name": "BAR", "legacyName": "KSQL_INTERNAL_COL_0", "legacySchema": "STRING"}},
+          {"name": "DOWNSTREAM", "type": "table", "keyField": {"name": "BAR", "legacyName": "KSQL_INTERNAL_COL_0", "legacySchema": "STRING"}}
         ]
       }
     },
@@ -719,7 +714,7 @@
       ],
       "post": {
         "sources": [
-          {"name": "OUTPUT", "type": "table", "keyField": {"name": "ALIASED", "legacyName": "KSQL_INTERNAL_COL_0", "legacySchema": {"type": "STRING"}}}
+          {"name": "OUTPUT", "type": "table", "keyField": {"name": "ALIASED", "legacyName": "KSQL_INTERNAL_COL_0", "legacySchema": "STRING"}}
         ]
       }
     },
@@ -748,8 +743,8 @@
       ],
       "post": {
         "sources": [
-          {"name": "OUTPUT", "type": "table", "keyField": {"name": "ALIASED", "legacyName": "KSQL_INTERNAL_COL_0", "legacySchema": {"type": "STRING"}}},
-          {"name": "DOWNSTREAM", "type": "table", "keyField": {"name": "ALIASED", "legacyName": "KSQL_INTERNAL_COL_0", "legacySchema": {"type": "STRING"}}}
+          {"name": "OUTPUT", "type": "table", "keyField": {"name": "ALIASED", "legacyName": "KSQL_INTERNAL_COL_0", "legacySchema": "STRING"}},
+          {"name": "DOWNSTREAM", "type": "table", "keyField": {"name": "ALIASED", "legacyName": "KSQL_INTERNAL_COL_0", "legacySchema": "STRING"}}
         ]
       }
     },
@@ -767,7 +762,7 @@
       ],
       "post": {
         "sources": [
-          {"name": "OUTPUT", "type": "table", "keyField": {"name": null, "legacyName": "KSQL_INTERNAL_COL_1", "legacySchema": {"type": "STRING"}}}
+          {"name": "OUTPUT", "type": "table", "keyField": {"name": null, "legacyName": "KSQL_INTERNAL_COL_1", "legacySchema": "STRING"}}
         ]
       }
     },
@@ -795,7 +790,7 @@
       ],
       "post": {
         "sources": [
-          {"name": "DOWNSTREAM", "type": "table", "keyField": {"name": null, "legacyName": "KSQL_INTERNAL_COL_1", "legacySchema": {"type": "STRING"}}}
+          {"name": "DOWNSTREAM", "type": "table", "keyField": {"name": null, "legacyName": "KSQL_INTERNAL_COL_1", "legacySchema": "STRING"}}
         ]
       }
     },
@@ -841,7 +836,7 @@
       "post": {
         "sources": [
           {"name": "INTERMEDIATE", "type": "table", "keyField": {"name": null, "legacyName": null}},
-          {"name": "OUTPUT", "type": "table", "keyField": {"name": "FOO", "legacyName": "KSQL_INTERNAL_COL_0", "legacySchema": {"type": "STRING"}}}
+          {"name": "OUTPUT", "type": "table", "keyField": {"name": "FOO", "legacyName": "KSQL_INTERNAL_COL_0", "legacySchema": "STRING"}}
         ]
       }
     },
@@ -872,8 +867,8 @@
       ],
       "post": {
         "sources": [
-          {"name": "OUTPUT", "type": "table", "keyField": {"name": "FOO", "legacyName": "KSQL_INTERNAL_COL_0", "legacySchema": {"type": "STRING"}}},
-          {"name": "DOWNSTREAM", "type": "table", "keyField": {"name": "FOO", "legacyName": "KSQL_INTERNAL_COL_0", "legacySchema": {"type": "STRING"}}}
+          {"name": "OUTPUT", "type": "table", "keyField": {"name": "FOO", "legacyName": "KSQL_INTERNAL_COL_0", "legacySchema": "STRING"}},
+          {"name": "DOWNSTREAM", "type": "table", "keyField": {"name": "FOO", "legacyName": "KSQL_INTERNAL_COL_0", "legacySchema": "STRING"}}
         ]
       }
     },
@@ -897,7 +892,7 @@
       "post": {
         "sources": [
           {"name": "INTERMEDIATE", "type": "table", "keyField": {"name": null, "legacyName": null}},
-          {"name": "OUTPUT", "type": "table", "keyField": {"name": "ALIASED", "legacyName": "KSQL_INTERNAL_COL_0", "legacySchema": {"type": "STRING"}}}
+          {"name": "OUTPUT", "type": "table", "keyField": {"name": "ALIASED", "legacyName": "KSQL_INTERNAL_COL_0", "legacySchema": "STRING"}}
         ]
       }
     },
@@ -928,8 +923,8 @@
       ],
       "post": {
         "sources": [
-          {"name": "OUTPUT", "type": "table", "keyField": {"name": "ALIASED", "legacyName": "KSQL_INTERNAL_COL_0", "legacySchema": {"type": "STRING"}}},
-          {"name": "DOWNSTREAM", "type": "table", "keyField": {"name": "ALIASED", "legacyName": "KSQL_INTERNAL_COL_0", "legacySchema": {"type": "STRING"}}}
+          {"name": "OUTPUT", "type": "table", "keyField": {"name": "ALIASED", "legacyName": "KSQL_INTERNAL_COL_0", "legacySchema": "STRING"}},
+          {"name": "DOWNSTREAM", "type": "table", "keyField": {"name": "ALIASED", "legacyName": "KSQL_INTERNAL_COL_0", "legacySchema": "STRING"}}
         ]
       }
     },
@@ -947,8 +942,8 @@
       ],
       "post": {
         "sources": [
-          {"name": "INPUT", "type": "table", "keyField": {"name": "FOO", "legacyName": "FOO", "legacySchema": {"type": "INT"}}},
-          {"name": "OUTPUT", "type": "table", "keyField": {"name": "FOO", "legacyName": "FOO", "legacySchema": {"type": "INT"}}}
+          {"name": "INPUT", "type": "table", "keyField": {"name": "FOO", "legacyName": "FOO", "legacySchema": "INT"}},
+          {"name": "OUTPUT", "type": "table", "keyField": {"name": "FOO", "legacyName": "FOO", "legacySchema": "INT"}}
         ]
       }
     },
@@ -966,8 +961,8 @@
       ],
       "post": {
         "sources": [
-          {"name": "INPUT", "type": "table", "keyField": {"name": "FOO", "legacyName": "FOO", "legacySchema": {"type": "INT"}}},
-          {"name": "OUTPUT", "type": "table", "keyField": {"name": "ALIASED", "legacyName": "ALIASED", "legacySchema": {"type": "INT"}}}
+          {"name": "INPUT", "type": "table", "keyField": {"name": "FOO", "legacyName": "FOO", "legacySchema": "INT"}},
+          {"name": "OUTPUT", "type": "table", "keyField": {"name": "ALIASED", "legacyName": "ALIASED", "legacySchema": "INT"}}
         ]
       }
     },
@@ -1003,7 +998,7 @@
       ],
       "post": {
         "sources": [
-          {"name": "OUTPUT", "type": "table", "keyField": {"name": "FOO", "legacyName": "KSQL_INTERNAL_COL_0", "legacySchema": {"type": "STRING"}}}
+          {"name": "OUTPUT", "type": "table", "keyField": {"name": "FOO", "legacyName": "KSQL_INTERNAL_COL_0", "legacySchema": "STRING"}}
         ]
       }
     },
@@ -1032,8 +1027,8 @@
       ],
       "post": {
         "sources": [
-          {"name": "OUTPUT", "type": "table", "keyField": {"name": "FOO", "legacyName": "KSQL_INTERNAL_COL_0", "legacySchema": {"type": "STRING"}}},
-          {"name": "DOWNSTREAM", "type": "table", "keyField": {"name": "FOO", "legacyName": "KSQL_INTERNAL_COL_0", "legacySchema": {"type": "STRING"}}}
+          {"name": "OUTPUT", "type": "table", "keyField": {"name": "FOO", "legacyName": "KSQL_INTERNAL_COL_0", "legacySchema": "STRING"}},
+          {"name": "DOWNSTREAM", "type": "table", "keyField": {"name": "FOO", "legacyName": "KSQL_INTERNAL_COL_0", "legacySchema": "STRING"}}
         ]
       }
     },
@@ -1051,7 +1046,7 @@
       ],
       "post": {
         "sources": [
-          {"name": "OUTPUT", "type": "table", "keyField": {"name": "ALIASED", "legacyName": "KSQL_INTERNAL_COL_0", "legacySchema": {"type": "STRING"}}}
+          {"name": "OUTPUT", "type": "table", "keyField": {"name": "ALIASED", "legacyName": "KSQL_INTERNAL_COL_0", "legacySchema": "STRING"}}
         ]
       }
     },
@@ -1080,8 +1075,8 @@
       ],
       "post": {
         "sources": [
-          {"name": "OUTPUT", "type": "table", "keyField": {"name": "ALIASED", "legacyName": "KSQL_INTERNAL_COL_0", "legacySchema": {"type": "STRING"}}},
-          {"name": "DOWNSTREAM", "type": "table", "keyField": {"name": "ALIASED", "legacyName": "KSQL_INTERNAL_COL_0", "legacySchema": {"type": "STRING"}}}
+          {"name": "OUTPUT", "type": "table", "keyField": {"name": "ALIASED", "legacyName": "KSQL_INTERNAL_COL_0", "legacySchema": "STRING"}},
+          {"name": "DOWNSTREAM", "type": "table", "keyField": {"name": "ALIASED", "legacyName": "KSQL_INTERNAL_COL_0", "legacySchema": "STRING"}}
         ]
       }
     },
@@ -1099,7 +1094,7 @@
       ],
       "post": {
         "sources": [
-          {"name": "OUTPUT", "type": "table", "keyField": {"name": null, "legacyName": "KSQL_INTERNAL_COL_1", "legacySchema": {"type": "STRING"}}}
+          {"name": "OUTPUT", "type": "table", "keyField": {"name": null, "legacyName": "KSQL_INTERNAL_COL_1", "legacySchema": "STRING"}}
         ]
       }
     },
@@ -1127,8 +1122,8 @@
       ],
       "post": {
         "sources": [
-          {"name": "OUTPUT", "type": "table", "keyField": {"name": null, "legacyName": "KSQL_INTERNAL_COL_1", "legacySchema": {"type": "STRING"}}},
-          {"name": "DOWNSTREAM", "type": "table", "keyField": {"name": null, "legacyName": "KSQL_INTERNAL_COL_1", "legacySchema": {"type": "STRING"}}}
+          {"name": "OUTPUT", "type": "table", "keyField": {"name": null, "legacyName": "KSQL_INTERNAL_COL_1", "legacySchema": "STRING"}},
+          {"name": "DOWNSTREAM", "type": "table", "keyField": {"name": null, "legacyName": "KSQL_INTERNAL_COL_1", "legacySchema": "STRING"}}
         ]
       }
     },
@@ -1146,7 +1141,7 @@
       ],
       "post": {
         "sources": [
-          {"name": "OUTPUT", "type": "table", "keyField": {"name": "BAR", "legacyName": "KSQL_INTERNAL_COL_0", "legacySchema": {"type": "STRING"}}}
+          {"name": "OUTPUT", "type": "table", "keyField": {"name": "BAR", "legacyName": "KSQL_INTERNAL_COL_0", "legacySchema": "STRING"}}
         ]
       }
     },
@@ -1175,8 +1170,8 @@
       ],
       "post": {
         "sources": [
-          {"name": "OUTPUT", "type": "table", "keyField": {"name": "BAR", "legacyName": "KSQL_INTERNAL_COL_0", "legacySchema": {"type": "STRING"}}},
-          {"name": "DOWNSTREAM", "type": "table", "keyField": {"name": "BAR", "legacyName": "KSQL_INTERNAL_COL_0", "legacySchema": {"type": "STRING"}}}
+          {"name": "OUTPUT", "type": "table", "keyField": {"name": "BAR", "legacyName": "KSQL_INTERNAL_COL_0", "legacySchema": "STRING"}},
+          {"name": "DOWNSTREAM", "type": "table", "keyField": {"name": "BAR", "legacyName": "KSQL_INTERNAL_COL_0", "legacySchema": "STRING"}}
         ]
       }
     },
@@ -1194,7 +1189,7 @@
       ],
       "post": {
         "sources": [
-          {"name": "OUTPUT", "type": "table", "keyField": {"name": "ALIASED", "legacyName": "KSQL_INTERNAL_COL_0", "legacySchema": {"type": "STRING"}}}
+          {"name": "OUTPUT", "type": "table", "keyField": {"name": "ALIASED", "legacyName": "KSQL_INTERNAL_COL_0", "legacySchema": "STRING"}}
         ]
       }
     },
@@ -1223,8 +1218,8 @@
       ],
       "post": {
         "sources": [
-          {"name": "OUTPUT", "type": "table", "keyField": {"name": "ALIASED", "legacyName": "KSQL_INTERNAL_COL_0", "legacySchema": {"type": "STRING"}}},
-          {"name": "DOWNSTREAM", "type": "table", "keyField": {"name": "ALIASED", "legacyName": "KSQL_INTERNAL_COL_0", "legacySchema": {"type": "STRING"}}}
+          {"name": "OUTPUT", "type": "table", "keyField": {"name": "ALIASED", "legacyName": "KSQL_INTERNAL_COL_0", "legacySchema": "STRING"}},
+          {"name": "DOWNSTREAM", "type": "table", "keyField": {"name": "ALIASED", "legacyName": "KSQL_INTERNAL_COL_0", "legacySchema": "STRING"}}
         ]
       }
     },
@@ -1242,7 +1237,7 @@
       ],
       "post": {
         "sources": [
-          {"name": "OUTPUT", "type": "table", "keyField": {"name": null, "legacyName": "KSQL_INTERNAL_COL_1", "legacySchema": {"type": "STRING"}}}
+          {"name": "OUTPUT", "type": "table", "keyField": {"name": null, "legacyName": "KSQL_INTERNAL_COL_1", "legacySchema": "STRING"}}
         ]
       }
     },
@@ -1270,7 +1265,7 @@
       ],
       "post": {
         "sources": [
-          {"name": "OUTPUT", "type": "table", "keyField": {"name": null, "legacyName": "KSQL_INTERNAL_COL_1", "legacySchema": {"type": "STRING"}}}
+          {"name": "OUTPUT", "type": "table", "keyField": {"name": null, "legacyName": "KSQL_INTERNAL_COL_1", "legacySchema": "STRING"}}
         ]
       }
     },
@@ -1316,7 +1311,7 @@
       ],
       "post": {
         "sources": [
-          {"name": "OUTPUT", "type": "table", "keyField": {"name": null, "legacyName": "KSQL_INTERNAL_COL_1|+|KSQL_INTERNAL_COL_0", "legacySchema": {"type": "STRING"}}}
+          {"name": "OUTPUT", "type": "table", "keyField": {"name": null, "legacyName": "KSQL_INTERNAL_COL_1|+|KSQL_INTERNAL_COL_0", "legacySchema": "STRING"}}
         ]
       }
     },
@@ -1344,7 +1339,7 @@
       ],
       "post": {
         "sources": [
-          {"name": "OUTPUT", "type": "table", "keyField": {"name": null, "legacyName": "KSQL_INTERNAL_COL_1|+|KSQL_INTERNAL_COL_0", "legacySchema": {"type": "STRING"}}}
+          {"name": "OUTPUT", "type": "table", "keyField": {"name": null, "legacyName": "KSQL_INTERNAL_COL_1|+|KSQL_INTERNAL_COL_0", "legacySchema": "STRING"}}
         ]
       }
     },
@@ -1365,7 +1360,7 @@
           "key field of output has INCORRECT name: should be 'KSQL_COL_0'"
         ],
         "sources": [
-          {"name": "OUTPUT", "type": "table", "keyField": {"name": null, "legacyName": "(KSQL_INTERNAL_COL_0 + KSQL_INTERNAL_COL_1)", "legacySchema": {"type": "STRING"}}}
+          {"name": "OUTPUT", "type": "table", "keyField": {"name": null, "legacyName": "(KSQL_INTERNAL_COL_0 + KSQL_INTERNAL_COL_1)", "legacySchema": "STRING"}}
         ]
       }
     },
@@ -1396,7 +1391,7 @@
           "key field of output has INCORRECT name: should be 'KSQL_COL_0'"
         ],
         "sources": [
-          {"name": "DOWNSTREAM", "type": "table", "keyField": {"name": null, "legacyName": "KSQL_INTERNAL_COL_1", "legacySchema": {"type": "STRING"}}}
+          {"name": "DOWNSTREAM", "type": "table", "keyField": {"name": null, "legacyName": "KSQL_INTERNAL_COL_1", "legacySchema": "STRING"}}
         ]
       }
     },
@@ -1419,7 +1414,7 @@
         ],
         "sources": [
           {"name": "INPUT", "type": "stream", "keyField": {"name": null, "legacyName": null}},
-          {"name": "OUTPUT", "type": "table", "keyField": {"name": null, "legacyName": "CAST(KSQL_INTERNAL_COL_0 AS INTEGER)", "legacySchema": {"type": "STRING"}}}
+          {"name": "OUTPUT", "type": "table", "keyField": {"name": null, "legacyName": "CAST(KSQL_INTERNAL_COL_0 AS INTEGER)", "legacySchema": "STRING"}}
         ]
       }
     },
@@ -1451,7 +1446,7 @@
           "key field of output has INCORRECT name: should be 'KSQL_COL_0'"
         ],
         "sources": [
-          {"name": "DOWNSTREAM", "type": "table", "keyField": {"name": null, "legacyName": "KSQL_INTERNAL_COL_1", "legacySchema": {"type": "STRING"}}}
+          {"name": "DOWNSTREAM", "type": "table", "keyField": {"name": null, "legacyName": "KSQL_INTERNAL_COL_1", "legacySchema": "STRING"}}
         ]
       }
     },
@@ -1469,7 +1464,7 @@
       ],
       "post": {
         "sources": [
-          {"name": "OUTPUT", "type": "stream", "keyField": {"name": "FOO", "legacyName": "FOO", "legacySchema": {"type": "INT"}}}
+          {"name": "OUTPUT", "type": "stream", "keyField": {"name": "FOO", "legacyName": "FOO", "legacySchema": "INT"}}
         ]
       }
     },
@@ -1487,7 +1482,7 @@
       ],
       "post": {
         "sources": [
-          {"name": "OUTPUT", "type": "stream", "keyField": {"name": "BOO", "legacyName": "FOO", "legacySchema": {"type": "INT"}}}
+          {"name": "OUTPUT", "type": "stream", "keyField": {"name": "BOO", "legacyName": "FOO", "legacySchema": "INT"}}
         ]
       }
     },
@@ -1505,7 +1500,7 @@
       ],
       "post": {
         "sources": [
-          {"name": "OUTPUT", "type": "stream", "keyField": {"name": "FOO", "legacyName": "FOO", "legacySchema": {"type": "INT"}}}
+          {"name": "OUTPUT", "type": "stream", "keyField": {"name": "FOO", "legacyName": "FOO", "legacySchema": "INT"}}
         ]
       }
     },
@@ -1523,7 +1518,7 @@
       ],
       "post": {
         "sources": [
-          {"name": "OUTPUT", "type": "stream", "keyField": {"name": "FOO", "legacyName": "FOO", "legacySchema": {"type": "INT"}}}
+          {"name": "OUTPUT", "type": "stream", "keyField": {"name": "FOO", "legacyName": "FOO", "legacySchema": "INT"}}
         ]
       }
     }

--- a/ksql-engine/src/test/resources/query-validation-tests/key-field.json
+++ b/ksql-engine/src/test/resources/query-validation-tests/key-field.json
@@ -1396,61 +1396,6 @@
       }
     },
     {
-      "name": "stream | initially null | group by (-) | key in value | no aliasing | with cast",
-      "statements": [
-        "CREATE STREAM INPUT (foo INT, bar INT) WITH (kafka_topic='input_topic', value_format='JSON');",
-        "CREATE TABLE OUTPUT AS SELECT cast(foo as INT), COUNT(*) FROM INPUT GROUP BY cast(foo as INT);"
-      ],
-      "issues:": "this is a duplicate of `group by expression` and should be removed",
-      "inputs": [
-        {"topic": "input_topic", "value": {"foo": 1, "bar": 2}}
-      ],
-      "outputs": [
-        {"topic": "OUTPUT", "key": "1", "value": {"KSQL_COL_0":1, "KSQL_COL_1": 1}}
-      ],
-      "post": {
-        "issues": [
-          "key field of output has INCORRECT name: should be 'KSQL_COL_0'"
-        ],
-        "sources": [
-          {"name": "INPUT", "type": "stream", "keyField": {"name": null, "legacyName": null}},
-          {"name": "OUTPUT", "type": "table", "keyField": {"name": null, "legacyName": "CAST(KSQL_INTERNAL_COL_0 AS INTEGER)", "legacySchema": "STRING"}}
-        ]
-      }
-    },
-    {
-      "name": "stream | initially null | group by (-) | key in value | no aliasing | with cast | legacy downstream query",
-      "comments": [
-        "The purpose of this test is to capture the topology of a downstream query of the above test case",
-        "and test the key fields of the entities added to the metastore, to ensure backwards compatibility is maintained",
-        "In this case, the code previously incorrectly set the keyField to 'KSQL_INTERNAL_COL_1' rather than the correct 'null'",
-        "This would not really create any problems, but its good to ensure things remain consistent."
-      ],
-      "statements": [
-        "CREATE STREAM INPUT (foo INT, bar INT) WITH (kafka_topic='input_topic', value_format='JSON');",
-        "CREATE TABLE OUTPUT AS SELECT cast(foo as INT), COUNT(*) FROM INPUT GROUP BY cast(foo as INT);",
-        "CREATE TABLE DOWNSTREAM AS SELECT COUNT(*) FROM OUTPUT GROUP BY ROWKEY;"
-      ],
-      "issues:": "this is a duplicate of `group by expression` and should be removed",
-      "properties": {
-        "ksql.query.fields.key.legacy": "true"
-      },
-      "inputs": [
-        {"topic": "OUTPUT", "key": "1", "value": {"KSQL_COL_0":1, "KSQL_COL_1": 1}}
-      ],
-      "outputs": [
-        {"topic": "DOWNSTREAM", "key": "1", "value": {"KSQL_COL_0":1}}
-      ],
-      "post": {
-        "issues": [
-          "key field of output has INCORRECT name: should be 'KSQL_COL_0'"
-        ],
-        "sources": [
-          {"name": "DOWNSTREAM", "type": "table", "keyField": {"name": null, "legacyName": "KSQL_INTERNAL_COL_1", "legacySchema": "STRING"}}
-        ]
-      }
-    },
-    {
       "name": "where clause",
       "statements": [
         "CREATE STREAM INPUT (foo INT, bar INT) WITH (kafka_topic='input_topic', key='foo', value_format='JSON');",

--- a/ksql-metastore/src/main/java/io/confluent/ksql/metastore/model/KeyField.java
+++ b/ksql-metastore/src/main/java/io/confluent/ksql/metastore/model/KeyField.java
@@ -73,7 +73,6 @@ public final class KeyField {
    * @throws IllegalArgumentException if the key is not within the supplied schema.
    */
   public KeyField validateKeyExistsIn(final Schema schema) {
-    // Todo(ac): once we drop the builder in KsqlStructuredDataNode this can go:
     if (!keyField
         .filter(name -> !name.equalsIgnoreCase(SchemaUtil.ROWKEY_NAME))
         .isPresent()) {

--- a/ksql-metastore/src/main/java/io/confluent/ksql/metastore/model/KeyField.java
+++ b/ksql-metastore/src/main/java/io/confluent/ksql/metastore/model/KeyField.java
@@ -41,7 +41,7 @@ import org.apache.kafka.connect.data.Schema;
  * allows these later queries to benefit from the improved logical.
  *
  * <p>This Pojo holds both the legacy and latest key field details. The legacy field is a complete
- * {@link Field}, where as the latest is just the key field name, which can be lookup up in the
+ * {@link Field}, where as the latest is just the key field name, which can be looked up in the
  * associated schema.
  *
  * @see <a href="https://github.com/confluentinc/ksql/issues/2636">Github issue 2636</a>
@@ -49,8 +49,14 @@ import org.apache.kafka.connect.data.Schema;
 @Immutable
 public final class KeyField {
 
+  private static final KeyField NONE = KeyField.of(Optional.empty(), Optional.empty());
+
   private final Optional<String> keyField;
   private final Optional<Field> legacyKeyField;
+
+  public static KeyField none() {
+    return NONE;
+  }
 
   public static KeyField of(final String keyField, final Field legacyKeyField) {
     return new KeyField(Optional.of(keyField), Optional.of(legacyKeyField));
@@ -66,16 +72,14 @@ public final class KeyField {
   }
 
   /**
-   * Validate the new key field is contained within the supplied {@code schema}.
+   * Validate the new key field, if set, is contained within the supplied {@code schema}.
    *
    * @param schema the associated schema that the key should be present in.
    * @return self, to allow fluid syntax.
    * @throws IllegalArgumentException if the key is not within the supplied schema.
    */
   public KeyField validateKeyExistsIn(final Schema schema) {
-    if (!keyField
-        .filter(name -> !name.equalsIgnoreCase(SchemaUtil.ROWKEY_NAME))
-        .isPresent()) {
+    if (keyField.isPresent() && keyField.get().equalsIgnoreCase(SchemaUtil.ROWKEY_NAME)) {
       return this;
     }
 
@@ -111,9 +115,10 @@ public final class KeyField {
     if (o == null || getClass() != o.getClass()) {
       return false;
     }
-    final KeyField keyField1 = (KeyField) o;
-    return Objects.equals(keyField, keyField1.keyField)
-        && Objects.equals(legacyKeyField, keyField1.legacyKeyField);
+
+    final KeyField that = (KeyField) o;
+    return Objects.equals(keyField, that.keyField)
+        && Objects.equals(legacyKeyField, that.legacyKeyField);
   }
 
   @Override

--- a/ksql-metastore/src/main/java/io/confluent/ksql/metastore/model/KeyField.java
+++ b/ksql-metastore/src/main/java/io/confluent/ksql/metastore/model/KeyField.java
@@ -1,0 +1,139 @@
+/*
+ * Copyright 2019 Confluent Inc.
+ *
+ * Licensed under the Confluent Community License (the "License"); you may not use
+ * this file except in compliance with the License.  You may obtain a copy of the
+ * License at
+ *
+ * http://www.confluent.io/confluent-community-license
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package io.confluent.ksql.metastore.model;
+
+import com.google.errorprone.annotations.Immutable;
+import io.confluent.ksql.util.KsqlConfig;
+import io.confluent.ksql.util.SchemaUtil;
+import java.util.Objects;
+import java.util.Optional;
+import org.apache.kafka.connect.data.Field;
+import org.apache.kafka.connect.data.Schema;
+
+/**
+ * Pojo that holds the details of a source's key field.
+ *
+ * <p>In KSQL versions 5.2.x and earlier the key field of sources stored in the metastore was not
+ * always accurate. The inaccurate key field is used in downstream queries.
+ *
+ * <p>To maintain backwards compatibility for persistent queries started on these earlier it is
+ * unfortunately necessary to track both the corrected and legacy key fields of sources, and to use
+ * these when building queries, resolving to the correct key depending on the version of KSQL the
+ * query was started on.
+ *
+ * <p>Downstream queries started on earlier versions of KSQL should use the legacy key field. This
+ * ensures the logical and topology remain backwards compatible
+ *
+ * <p>Downstream queries started on later versions of KSQL should use the corrected key field. This
+ * allows these later queries to benefit from the improved logical.
+ *
+ * <p>This Pojo holds both the legacy and latest key field details. The legacy field is a complete
+ * {@link Field}, where as the latest is just the key field name, which can be lookup up in the
+ * associated schema.
+ *
+ * @see <a href="https://github.com/confluentinc/ksql/issues/2636">Github issue 2636</a>
+ */
+@Immutable
+public final class KeyField {
+
+  private final Optional<String> keyField;
+  private final Optional<Field> legacyKeyField;
+
+  public static KeyField of(final String keyField, final Field legacyKeyField) {
+    return new KeyField(Optional.of(keyField), Optional.of(legacyKeyField));
+  }
+
+  public static KeyField of(final Optional<String> keyField, final Optional<Field> legacyKeyField) {
+    return new KeyField(keyField, legacyKeyField);
+  }
+
+  private KeyField(final Optional<String> keyField, final Optional<Field> legacyKeyField) {
+    this.keyField = Objects.requireNonNull(keyField, "keyField");
+    this.legacyKeyField = Objects.requireNonNull(legacyKeyField, "legacyKeyField");
+  }
+
+  /**
+   * Validate the new key field is contained within the supplied {@code schema}.
+   *
+   * @param schema the associated schema that the key should be present in.
+   * @return self, to allow fluid syntax.
+   * @throws IllegalArgumentException if the key is not within the supplied schema.
+   */
+  public KeyField validateKeyExistsIn(final Schema schema) {
+    // Todo(ac): once we drop the builder in KsqlStructuredDataNode this can go:
+    if (!keyField
+        .filter(name -> !name.equalsIgnoreCase(SchemaUtil.ROWKEY_NAME))
+        .isPresent()) {
+      return this;
+    }
+
+    resolveKey(schema);
+    return this;
+  }
+
+  public Optional<String> name() {
+    return keyField;
+  }
+
+  public Optional<Field> legacy() {
+    return legacyKeyField;
+  }
+
+  public Optional<Field> resolve(final Schema schema, final KsqlConfig ksqlConfig) {
+    if (ksqlConfig.getBoolean(KsqlConfig.KSQL_USE_LEGACY_KEY_FIELD)) {
+      return legacyKeyField;
+    }
+
+    return resolveKey(schema);
+  }
+
+  public KeyField withName(final String newName) {
+    return KeyField.of(Optional.of(newName), legacyKeyField);
+  }
+
+  @Override
+  public boolean equals(final Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    final KeyField keyField1 = (KeyField) o;
+    return Objects.equals(keyField, keyField1.keyField)
+        && Objects.equals(legacyKeyField, keyField1.legacyKeyField);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(keyField, legacyKeyField);
+  }
+
+  @Override
+  public String toString() {
+    return "KeyField{"
+        + "keyField='" + keyField + '\''
+        + ", legacyKeyField=" + legacyKeyField
+        + '}';
+  }
+
+  private Optional<Field> resolveKey(final Schema schema) {
+    return keyField
+        .map(fieldName -> SchemaUtil
+            .getFieldByName(schema, fieldName)
+            .orElseThrow(() -> new IllegalArgumentException("Invalid key field: " + fieldName)));
+  }
+}

--- a/ksql-metastore/src/main/java/io/confluent/ksql/metastore/model/KsqlStream.java
+++ b/ksql-metastore/src/main/java/io/confluent/ksql/metastore/model/KsqlStream.java
@@ -18,9 +18,7 @@ package io.confluent.ksql.metastore.model;
 import com.google.errorprone.annotations.Immutable;
 import io.confluent.ksql.metastore.SerdeFactory;
 import io.confluent.ksql.util.timestamp.TimestampExtractionPolicy;
-import java.util.Optional;
 import org.apache.kafka.common.serialization.Serde;
-import org.apache.kafka.connect.data.Field;
 import org.apache.kafka.connect.data.Schema;
 import org.apache.kafka.streams.kstream.WindowedSerdes;
 
@@ -31,7 +29,7 @@ public class KsqlStream<K> extends StructuredDataSource<K> {
       final String sqlExpression,
       final String datasourceName,
       final Schema schema,
-      final Optional<Field> keyField,
+      final KeyField keyField,
       final TimestampExtractionPolicy timestampExtractionPolicy,
       final KsqlTopic ksqlTopic,
       final SerdeFactory<K> keySerde

--- a/ksql-metastore/src/main/java/io/confluent/ksql/metastore/model/KsqlTable.java
+++ b/ksql-metastore/src/main/java/io/confluent/ksql/metastore/model/KsqlTable.java
@@ -18,9 +18,7 @@ package io.confluent.ksql.metastore.model;
 import com.google.errorprone.annotations.Immutable;
 import io.confluent.ksql.metastore.SerdeFactory;
 import io.confluent.ksql.util.timestamp.TimestampExtractionPolicy;
-import java.util.Optional;
 import org.apache.kafka.common.serialization.Serde;
-import org.apache.kafka.connect.data.Field;
 import org.apache.kafka.connect.data.Schema;
 import org.apache.kafka.streams.kstream.WindowedSerdes;
 
@@ -31,7 +29,7 @@ public class KsqlTable<K> extends StructuredDataSource<K> {
       final String sqlExpression,
       final String datasourceName,
       final Schema schema,
-      final Optional<Field> keyField,
+      final KeyField keyField,
       final TimestampExtractionPolicy timestampExtractionPolicy,
       final KsqlTopic ksqlTopic,
       final SerdeFactory<K> keySerde

--- a/ksql-metastore/src/main/java/io/confluent/ksql/metastore/model/StructuredDataSource.java
+++ b/ksql-metastore/src/main/java/io/confluent/ksql/metastore/model/StructuredDataSource.java
@@ -23,8 +23,6 @@ import io.confluent.ksql.schema.ksql.KsqlSchema;
 import io.confluent.ksql.serde.DataSource;
 import io.confluent.ksql.serde.KsqlTopicSerDe;
 import io.confluent.ksql.util.timestamp.TimestampExtractionPolicy;
-import java.util.Optional;
-import org.apache.kafka.connect.data.Field;
 import org.apache.kafka.connect.data.Schema;
 
 @Immutable
@@ -33,7 +31,7 @@ public abstract class StructuredDataSource<K> implements DataSource {
   private final String dataSourceName;
   private final DataSourceType dataSourceType;
   private final KsqlSchema schema;
-  private final Optional<Field> keyField;
+  private final KeyField keyField;
   private final TimestampExtractionPolicy timestampExtractionPolicy;
   private final SerdeFactory<K> keySerde;
   private final KsqlTopic ksqlTopic;
@@ -43,7 +41,7 @@ public abstract class StructuredDataSource<K> implements DataSource {
       final String sqlExpression,
       final String dataSourceName,
       final Schema schema,
-      final Optional<Field> keyField,
+      final KeyField keyField,
       final TimestampExtractionPolicy tsExtractionPolicy,
       final DataSourceType dataSourceType,
       final KsqlTopic ksqlTopic,
@@ -52,7 +50,8 @@ public abstract class StructuredDataSource<K> implements DataSource {
     this.sqlExpression = requireNonNull(sqlExpression, "sqlExpression");
     this.dataSourceName = requireNonNull(dataSourceName, "dataSourceName");
     this.schema = KsqlSchema.of(schema);
-    this.keyField = requireNonNull(keyField, "keyField");
+    this.keyField = requireNonNull(keyField, "keyField")
+        .validateKeyExistsIn(schema);
     this.timestampExtractionPolicy = requireNonNull(tsExtractionPolicy, "tsExtractionPolicy");
     this.dataSourceType = requireNonNull(dataSourceType, "dataSourceType");
     this.ksqlTopic = requireNonNull(ksqlTopic, "ksqlTopic");
@@ -73,7 +72,7 @@ public abstract class StructuredDataSource<K> implements DataSource {
     return schema.getSchema();
   }
 
-  public Optional<Field> getKeyField() {
+  public KeyField getKeyField() {
     return keyField;
   }
 

--- a/ksql-metastore/src/test/java/io/confluent/ksql/metastore/StructuredDataSourceTest.java
+++ b/ksql-metastore/src/test/java/io/confluent/ksql/metastore/StructuredDataSourceTest.java
@@ -1,0 +1,75 @@
+/*
+ * Copyright 2019 Confluent Inc.
+ *
+ * Licensed under the Confluent Community License (the "License"); you may not use
+ * this file except in compliance with the License.  You may obtain a copy of the
+ * License at
+ *
+ * http://www.confluent.io/confluent-community-license
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package io.confluent.ksql.metastore;
+
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+
+import io.confluent.ksql.metastore.model.KeyField;
+import io.confluent.ksql.metastore.model.KsqlTopic;
+import io.confluent.ksql.metastore.model.StructuredDataSource;
+import io.confluent.ksql.util.timestamp.TimestampExtractionPolicy;
+import org.apache.kafka.common.serialization.Serdes;
+import org.apache.kafka.connect.data.Schema;
+import org.apache.kafka.connect.data.SchemaBuilder;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnitRunner;
+
+@RunWith(MockitoJUnitRunner.class)
+public class StructuredDataSourceTest {
+
+  private static final Schema SOME_SCHEMA = SchemaBuilder.struct()
+      .field("f0", Schema.OPTIONAL_INT64_SCHEMA)
+      .build();
+
+  @Mock
+  public KeyField keyField;
+
+  @Test
+  public void shouldValidateKeyFieldIsInSchema() {
+    // When:
+    new TestStructuredDataSource(
+        SOME_SCHEMA,
+        keyField
+    );
+
+    // Then (no exception):
+    verify(keyField).validateKeyExistsIn(SOME_SCHEMA);
+  }
+
+  /**
+   * Test class to allow the abstract base class to be instantiated.
+   */
+  private static final class TestStructuredDataSource extends StructuredDataSource<String> {
+
+    private TestStructuredDataSource(
+        final Schema schema,
+        final KeyField keyField
+    ) {
+      super(
+          "some SQL",
+          "some name",
+          schema,
+          keyField,
+          mock(TimestampExtractionPolicy.class),
+          DataSourceType.KSTREAM,
+          mock(KsqlTopic.class),
+          Serdes::String);
+    }
+  }
+}

--- a/ksql-metastore/src/test/java/io/confluent/ksql/metastore/model/KeyFieldTest.java
+++ b/ksql-metastore/src/test/java/io/confluent/ksql/metastore/model/KeyFieldTest.java
@@ -1,0 +1,227 @@
+/*
+ * Copyright 2019 Confluent Inc.
+ *
+ * Licensed under the Confluent Community License (the "License"); you may not use
+ * this file except in compliance with the License.  You may obtain a copy of the
+ * License at
+ *
+ * http://www.confluent.io/confluent-community-license
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package io.confluent.ksql.metastore.model;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+
+import com.google.common.collect.ImmutableMap;
+import com.google.common.testing.EqualsTester;
+import io.confluent.ksql.util.KsqlConfig;
+import java.util.Optional;
+import org.apache.kafka.connect.data.Field;
+import org.apache.kafka.connect.data.Schema;
+import org.apache.kafka.connect.data.SchemaBuilder;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+
+public class KeyFieldTest {
+
+  private static final Schema SCHEMA = SchemaBuilder.struct()
+      .field("field0", Schema.OPTIONAL_STRING_SCHEMA)
+      .field("field1", Schema.OPTIONAL_BYTES_SCHEMA)
+      .build();
+
+  private static final KsqlConfig LEGACY_CONFIG = new KsqlConfig(
+      ImmutableMap.of(KsqlConfig.KSQL_USE_LEGACY_KEY_FIELD, true)
+  );
+
+  private static final KsqlConfig LATEST_CONFIG = new KsqlConfig(
+      ImmutableMap.of()
+  );
+
+  private static final Field RANDOM_FIELD =
+      new Field("won't find me anywhere", 0, Schema.OPTIONAL_STRING_SCHEMA);
+
+  private static final Field SCHEMA_FIELD = SCHEMA.fields().get(0);
+
+  @Rule
+  public final ExpectedException expectedException = ExpectedException.none();
+
+  @Test
+  public void shouldImplementHashCodeAndEqualsProperly() {
+    final Optional<String> keyField = Optional.of("key");
+    final Optional<Field> legacy = Optional.of(SCHEMA.fields().get(0));
+
+    new EqualsTester()
+        .addEqualityGroup(KeyField.of(keyField, legacy), KeyField.of(keyField, legacy))
+        .addEqualityGroup(KeyField.of(Optional.empty(), legacy))
+        .addEqualityGroup(KeyField.of(keyField, Optional.empty()))
+        .testEquals();
+  }
+
+  @Test
+  public void shouldHandleLegacyEmpty() {
+    // When:
+    final KeyField keyField = KeyField.of(Optional.of("something"), Optional.empty());
+
+    // Then:
+    assertThat(keyField.name(), is(Optional.of("something")));
+    assertThat(keyField.legacy(), is(Optional.empty()));
+  }
+
+  @Test
+  public void shouldHandleNewEmpty() {
+    // When:
+    final KeyField keyField = KeyField.of(Optional.empty(), Optional.of(RANDOM_FIELD));
+
+    // Then:
+    assertThat(keyField.name(), is(Optional.empty()));
+    assertThat(keyField.legacy(), is(Optional.of(RANDOM_FIELD)));
+  }
+
+  @Test
+  public void shouldHandleBothEmpty() {
+    // When:
+    final KeyField keyField = KeyField.of(Optional.empty(), Optional.empty());
+
+    // Then:
+    assertThat(keyField.name(), is(Optional.empty()));
+    assertThat(keyField.legacy(), is(Optional.empty()));
+  }
+
+  @Test
+  public void shouldNotThrowOnValidateIfKeyInSchema() {
+    // Given:
+    final KeyField keyField = KeyField.of(Optional.of("field0"), Optional.empty());
+
+    // When:
+    keyField.validateKeyExistsIn(SCHEMA);
+
+    // Then: did not throw.
+  }
+
+  @Test
+  public void shouldNotThrowOnValidateIfKeyIsRowKey() {
+    // Given:
+    final KeyField keyField = KeyField.of(Optional.of("ROWKEY"), Optional.empty());
+
+    // When:
+    keyField.validateKeyExistsIn(SCHEMA);
+
+    // Then: did not throw.
+  }
+
+  @Test
+  public void shouldThrowOnValidateIfKeyNotInSchema() {
+    // Given:
+    final KeyField keyField = KeyField.of(Optional.of("????"), Optional.empty());
+
+    // Then:
+    expectedException.expect(IllegalArgumentException.class);
+    expectedException.expectMessage("Invalid key field: ????");
+
+    // When:
+    keyField.validateKeyExistsIn(SCHEMA);
+  }
+
+  @Test
+  public void shouldNotThrowOnValidateIfKeyNotInSchema() {
+    // Given:
+    final KeyField keyField = KeyField.of(Optional.empty(), Optional.of(RANDOM_FIELD));
+
+    // When:
+    keyField.validateKeyExistsIn(SCHEMA);
+
+    // Then: did not throw.
+  }
+
+  @Test
+  public void shouldThrowOnResolveIfSchemaDoesNotContainNewKeyField() {
+    // Given:
+    final KeyField keyField = KeyField.of(Optional.of("not found"), Optional.empty());
+
+    // Then:
+    expectedException.expect(IllegalArgumentException.class);
+
+    // When:
+    keyField.resolve(SCHEMA, LATEST_CONFIG);
+  }
+
+  @Test
+  public void shouldNotThrowOnResolveIfSchemaDoesNotContainsLegacyKeyField() {
+    // Given:
+    final KeyField keyField = KeyField.of(Optional.empty(), Optional.of(RANDOM_FIELD));
+
+    // When:
+    final Optional<Field> resolved = keyField.resolve(SCHEMA, LEGACY_CONFIG);
+
+    // Then:
+    assertThat(resolved, is(Optional.of(RANDOM_FIELD)));
+  }
+
+  @Test
+  public void shouldResolveToNewKeyField() {
+    // Given:
+    final KeyField keyField = KeyField.of(Optional.of(SCHEMA_FIELD.name()), Optional.empty());
+
+    // When:
+    final Optional<Field> resolved = keyField.resolve(SCHEMA, LATEST_CONFIG);
+
+    // Then:
+    assertThat(resolved, is(Optional.of(SCHEMA_FIELD)));
+  }
+
+  @Test
+  public void shouldResolveToLegacyKeyField() {
+    // Given:
+    final KeyField keyField = KeyField.of(Optional.empty(), Optional.of(SCHEMA_FIELD));
+
+    // When:
+    final Optional<Field> resolved = keyField.resolve(SCHEMA, LEGACY_CONFIG);
+
+    // Then:
+    assertThat(resolved, is(Optional.of(SCHEMA_FIELD)));
+  }
+
+  @Test
+  public void shouldResolveToEmptyNewKeyField() {
+    // Given:
+    final KeyField keyField = KeyField.of(Optional.empty(), Optional.of(SCHEMA_FIELD));
+
+    // When:
+    final Optional<Field> resolved = keyField.resolve(SCHEMA, LATEST_CONFIG);
+
+    // Then:
+    assertThat(resolved, is(Optional.empty()));
+  }
+
+  @Test
+  public void shouldResolveToEmptyLegacyKeyField() {
+    // Given:
+    final KeyField keyField = KeyField.of(Optional.of("something"), Optional.empty());
+
+    // When:
+    final Optional<Field> resolved = keyField.resolve(SCHEMA, LEGACY_CONFIG);
+
+    // Then:
+    assertThat(resolved, is(Optional.empty()));
+  }
+
+  @Test
+  public void shouldBuildNewWithNewName() {
+    // Given:
+    final KeyField keyField = KeyField.of(Optional.of("something"), Optional.empty());
+
+    // When:
+    final KeyField result = keyField.withName("new-name");
+
+    // Then:
+    assertThat(keyField.name(), is(Optional.of("something")));
+    assertThat(result, is(KeyField.of(Optional.of("new-name"), Optional.empty())));
+  }
+}

--- a/ksql-metastore/src/test/java/io/confluent/ksql/metastore/model/MetaStoreMatchers.java
+++ b/ksql-metastore/src/test/java/io/confluent/ksql/metastore/model/MetaStoreMatchers.java
@@ -25,9 +25,9 @@ import org.hamcrest.FeatureMatcher;
 import org.hamcrest.Matcher;
 import org.hamcrest.TypeSafeDiagnosingMatcher;
 
-public final class StructuredDataSourceMatchers {
+public final class MetaStoreMatchers {
 
-  private StructuredDataSourceMatchers() {
+  private MetaStoreMatchers() {
   }
 
   public static Matcher<StructuredDataSource<?>> hasName(final String name) {
@@ -40,20 +40,64 @@ public final class StructuredDataSourceMatchers {
     };
   }
 
-  public static Matcher<StructuredDataSource<?>> hasKeyField(final String keyFieldName) {
-    return hasKeyField(OptionalMatchers.of(FieldMatchers.hasName(keyFieldName)));
-  }
-
   public static Matcher<StructuredDataSource<?>> hasKeyField(
-      final Matcher<Optional<Field>> fieldMatcher
+      final Matcher<KeyField> fieldMatcher
   ) {
-    return new FeatureMatcher<StructuredDataSource<?>, Optional<Field>>
+    return new FeatureMatcher<StructuredDataSource<?>, KeyField>
         (fieldMatcher, "source with key field", "key field") {
       @Override
-      protected Optional<Field> featureValueOf(final StructuredDataSource<?> actual) {
+      protected KeyField featureValueOf(final StructuredDataSource<?> actual) {
         return actual.getKeyField();
       }
     };
+  }
+
+  public static Matcher<StructuredDataSource<?>> hasValueSchema(
+      final Matcher<Schema> schemaMatcher
+  ) {
+    return new FeatureMatcher<StructuredDataSource<?>, Schema>
+        (schemaMatcher, "source with value schema", "value schema") {
+      @Override
+      protected Schema featureValueOf(final StructuredDataSource<?> actual) {
+        return actual.getSchema();
+      }
+    };
+  }
+
+  public static final class KeyFieldMatchers {
+
+    private KeyFieldMatchers() {
+    }
+
+    public static Matcher<KeyField> hasName(final Optional<String> name) {
+      return new FeatureMatcher<KeyField, Optional<String>>
+          (is(name), "field with name", "name") {
+        @Override
+        protected Optional<String> featureValueOf(final KeyField actual) {
+          return actual.name();
+        }
+      };
+    }
+
+    public static Matcher<KeyField> hasLegacyName(final Optional<String> name) {
+      return new FeatureMatcher<KeyField, Optional<String>>
+          (is(name), "field with legacy name", "legacy name") {
+        @Override
+        protected Optional<String> featureValueOf(final KeyField actual) {
+          return actual.legacy().map(Field::name);
+        }
+      };
+    }
+
+    public static Matcher<KeyField> hasLegacySchema(final Optional<? extends Schema> schema) {
+      return new FeatureMatcher<KeyField, Optional<Schema>>
+          (is(schema), "field with legacy schema", "legacy schema") {
+        @Override
+        protected Optional<Schema> featureValueOf(final KeyField actual) {
+          return actual.legacy().map(Field::schema);
+        }
+      };
+    }
   }
 
   public static final class FieldMatchers {

--- a/ksql-metastore/src/test/java/io/confluent/ksql/metastore/model/MetaStoreModelTest.java
+++ b/ksql-metastore/src/test/java/io/confluent/ksql/metastore/model/MetaStoreModelTest.java
@@ -30,6 +30,7 @@ import io.confluent.ksql.test.util.ClassFinder;
 import io.confluent.ksql.test.util.ImmutableTester;
 import java.lang.reflect.Modifier;
 import java.util.Collection;
+import java.util.Optional;
 import org.apache.kafka.connect.data.Schema;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -48,6 +49,7 @@ public class MetaStoreModelTest {
           new KsqlTopic("bob", "bob", new KsqlJsonTopicSerDe(), false))
       .put(org.apache.kafka.connect.data.Field.class,
           new org.apache.kafka.connect.data.Field("bob", 1, Schema.OPTIONAL_STRING_SCHEMA))
+      .put(KeyField.class, KeyField.of(Optional.empty(), Optional.empty()))
       .build();
 
   private final Class<?> modelClass;

--- a/ksql-metastore/src/test/java/io/confluent/ksql/util/MetaStoreFixture.java
+++ b/ksql-metastore/src/test/java/io/confluent/ksql/util/MetaStoreFixture.java
@@ -18,6 +18,7 @@ package io.confluent.ksql.util;
 import io.confluent.ksql.function.FunctionRegistry;
 import io.confluent.ksql.metastore.MetaStoreImpl;
 import io.confluent.ksql.metastore.MutableMetaStore;
+import io.confluent.ksql.metastore.model.KeyField;
 import io.confluent.ksql.metastore.model.KsqlStream;
 import io.confluent.ksql.metastore.model.KsqlTable;
 import io.confluent.ksql.metastore.model.KsqlTopic;
@@ -65,7 +66,7 @@ public final class MetaStoreFixture {
         "sqlexpression",
         "TEST0",
         test1Schema,
-        Optional.of(test1Schema.field("COL0")),
+        KeyField.of("COL0", test1Schema.field("COL0")),
         timestampExtractionPolicy,
         ksqlTopic0,
         Serdes::String);
@@ -80,7 +81,7 @@ public final class MetaStoreFixture {
     final KsqlStream<?> ksqlStream1 = new KsqlStream<>("sqlexpression",
         "TEST1",
         test1Schema,
-        Optional.of(test1Schema.field("COL0")),
+        KeyField.of("COL0", test1Schema.field("COL0")),
         timestampExtractionPolicy,
         ksqlTopic1,
         Serdes::String);
@@ -105,7 +106,7 @@ public final class MetaStoreFixture {
         "sqlexpression",
         "TEST2",
         test2Schema,
-        Optional.ofNullable(test2Schema.field("COL0")),
+        KeyField.of("COL0", test2Schema.field("COL0")),
         timestampExtractionPolicy,
         ksqlTopic2,
         Serdes::String);
@@ -151,7 +152,7 @@ public final class MetaStoreFixture {
         "sqlexpression",
         "ORDERS",
         ordersSchema,
-        Optional.of(ordersSchema.field("ORDERTIME")),
+        KeyField.of("ORDERTIME", ordersSchema.field("ORDERTIME")),
         timestampExtractionPolicy,
         ksqlTopicOrders,
         Serdes::String);
@@ -176,7 +177,7 @@ public final class MetaStoreFixture {
         "sqlexpression",
         "TEST3",
         schemaBuilderTestTable3,
-        Optional.ofNullable(schemaBuilderTestTable3.field("COL0")),
+        KeyField.of("COL0", schemaBuilderTestTable3.field("COL0")),
         timestampExtractionPolicy,
         ksqlTopic3,
         Serdes::String);
@@ -199,13 +200,28 @@ public final class MetaStoreFixture {
         "sqlexpression",
         "NESTED_STREAM",
         nestedArrayStructMapSchema,
-        Optional.empty(),
+        KeyField.of(Optional.empty(), Optional.empty()),
         timestampExtractionPolicy,
         nestedArrayStructMapTopic,
         Serdes::String);
 
     metaStore.putTopic(nestedArrayStructMapTopic);
     metaStore.putSource(nestedArrayStructMapOrders);
+
+    final KsqlTopic ksqlTopic4 =
+        new KsqlTopic("TEST4", "test4", serde.get(), false);
+
+    final KsqlStream<?> ksqlStream4 = new KsqlStream<>(
+        "sqlexpression4",
+        "TEST4",
+        test1Schema,
+        KeyField.of(Optional.empty(), Optional.empty()),
+        timestampExtractionPolicy,
+        ksqlTopic4,
+        Serdes::String);
+
+    metaStore.putTopic(ksqlTopic4);
+    metaStore.putSource(ksqlStream4);
 
     return metaStore;
   }

--- a/ksql-parser/src/test/java/io/confluent/ksql/parser/KsqlParserTest.java
+++ b/ksql-parser/src/test/java/io/confluent/ksql/parser/KsqlParserTest.java
@@ -32,6 +32,7 @@ import static org.mockito.Mockito.mock;
 import io.confluent.ksql.ddl.DdlConfig;
 import io.confluent.ksql.function.FunctionRegistry;
 import io.confluent.ksql.metastore.MutableMetaStore;
+import io.confluent.ksql.metastore.model.KeyField;
 import io.confluent.ksql.metastore.model.KsqlStream;
 import io.confluent.ksql.metastore.model.KsqlTable;
 import io.confluent.ksql.metastore.model.KsqlTopic;
@@ -141,7 +142,7 @@ public class KsqlParserTest {
         "sqlexpression",
         "ADDRESS",
         schemaBuilderOrders,
-        Optional.of(schemaBuilderOrders.field("ORDERTIME")),
+        KeyField.of("ORDERTIME", schemaBuilderOrders.field("ORDERTIME")),
         new MetadataTimestampExtractionPolicy(),
         ksqlTopicOrders,
         Serdes::String);
@@ -156,7 +157,7 @@ public class KsqlParserTest {
         "sqlexpression",
         "ITEMID",
         itemInfoSchema,
-        Optional.ofNullable(itemInfoSchema.field("ITEMID")),
+        KeyField.of("ITEMID", itemInfoSchema.field("ITEMID")),
         new MetadataTimestampExtractionPolicy(),
         ksqlTopicItems,
         Serdes::String);

--- a/ksql-parser/src/test/java/io/confluent/ksql/parser/SqlFormatterTest.java
+++ b/ksql-parser/src/test/java/io/confluent/ksql/parser/SqlFormatterTest.java
@@ -27,6 +27,7 @@ import static org.mockito.Mockito.mock;
 import io.confluent.ksql.ddl.DdlConfig;
 import io.confluent.ksql.function.FunctionRegistry;
 import io.confluent.ksql.metastore.MutableMetaStore;
+import io.confluent.ksql.metastore.model.KeyField;
 import io.confluent.ksql.metastore.model.KsqlStream;
 import io.confluent.ksql.metastore.model.KsqlTable;
 import io.confluent.ksql.metastore.model.KsqlTopic;
@@ -120,7 +121,7 @@ public class SqlFormatterTest {
         "sqlexpression",
         "ADDRESS",
         schemaBuilderOrders,
-        Optional.of(schemaBuilderOrders.field("ORDERTIME")),
+        KeyField.of("ORDERTIME", schemaBuilderOrders.field("ORDERTIME")),
         new MetadataTimestampExtractionPolicy(),
         ksqlTopicOrders,
         Serdes::String);
@@ -135,7 +136,7 @@ public class SqlFormatterTest {
         "sqlexpression",
         "ITEMID",
         itemInfoSchema,
-        Optional.ofNullable(itemInfoSchema.field("ITEMID")),
+        KeyField.of("ITEMID", itemInfoSchema.field("ITEMID")),
         new MetadataTimestampExtractionPolicy(),
         ksqlTopicItems,
         Serdes::String);

--- a/ksql-rest-app/src/main/java/io/confluent/ksql/rest/entity/SourceDescription.java
+++ b/ksql-rest-app/src/main/java/io/confluent/ksql/rest/entity/SourceDescription.java
@@ -29,7 +29,6 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Objects;
 import java.util.Optional;
-import org.apache.kafka.connect.data.Field;
 
 @JsonIgnoreProperties(ignoreUnknown = true)
 @JsonTypeName("description")
@@ -100,7 +99,7 @@ public class SourceDescription {
         writeQueries,
         EntityUtil.buildSourceSchemaEntity(dataSource.getSchema()),
         dataSource.getDataSourceType().getKqlType(),
-        dataSource.getKeyField().map(Field::name).orElse(""),
+        dataSource.getKeyField().name().orElse(""),
         Optional.ofNullable(dataSource.getTimestampExtractionPolicy())
             .map(TimestampExtractionPolicy::timestampField).orElse(""),
         (extended

--- a/ksql-rest-app/src/test/java/io/confluent/ksql/rest/entity/QueryDescriptionTest.java
+++ b/ksql-rest-app/src/test/java/io/confluent/ksql/rest/entity/QueryDescriptionTest.java
@@ -21,6 +21,7 @@ import static org.junit.Assert.assertThat;
 import static org.mockito.Mockito.when;
 
 import com.google.common.collect.ImmutableSet;
+import io.confluent.ksql.metastore.model.KeyField;
 import io.confluent.ksql.metastore.model.KsqlStream;
 import io.confluent.ksql.metastore.model.KsqlTopic;
 import io.confluent.ksql.physical.LimitHandler;
@@ -122,7 +123,8 @@ public class QueryDescriptionTest {
     // Given:
     final KsqlTopic sinkTopic = new KsqlTopic("fake_sink", "fake_sink", new KsqlJsonTopicSerDe(), true);
     final KsqlStream<?> fakeSink = new KsqlStream<>(
-        STATEMENT, "fake_sink", SCHEMA, Optional.of(SCHEMA.fields().get(0)),
+        STATEMENT, "fake_sink", SCHEMA,
+        KeyField.of(SCHEMA.fields().get(0).name(), SCHEMA.fields().get(0)),
         new MetadataTimestampExtractionPolicy(), sinkTopic, Serdes::String);
 
     final PersistentQueryMetadata queryMetadata = new PersistentQueryMetadata(

--- a/ksql-rest-app/src/test/java/io/confluent/ksql/rest/entity/SourceDescriptionTest.java
+++ b/ksql-rest-app/src/test/java/io/confluent/ksql/rest/entity/SourceDescriptionTest.java
@@ -19,6 +19,7 @@ import static org.hamcrest.CoreMatchers.containsString;
 import static org.junit.Assert.assertThat;
 
 import com.google.common.collect.ImmutableMap;
+import io.confluent.ksql.metastore.model.KeyField;
 import io.confluent.ksql.metastore.model.KsqlStream;
 import io.confluent.ksql.metastore.model.KsqlTopic;
 import io.confluent.ksql.metastore.model.StructuredDataSource;
@@ -28,7 +29,6 @@ import io.confluent.ksql.serde.json.KsqlJsonTopicSerDe;
 import io.confluent.ksql.util.timestamp.MetadataTimestampExtractionPolicy;
 import java.util.Arrays;
 import java.util.Collections;
-import java.util.Optional;
 import org.apache.kafka.clients.consumer.ConsumerConfig;
 import org.apache.kafka.clients.consumer.ConsumerRecord;
 import org.apache.kafka.clients.consumer.ConsumerRecords;
@@ -66,7 +66,8 @@ public class SourceDescriptionTest {
         .build();
     final KsqlTopic topic = new KsqlTopic("internal", kafkaTopicName, new KsqlJsonTopicSerDe(), true);
     return new KsqlStream<>(
-        "query", "stream", schema, Optional.of(schema.fields().get(0)),
+        "query", "stream", schema,
+        KeyField.of(schema.fields().get(0).name(), schema.fields().get(0)),
         new MetadataTimestampExtractionPolicy(), topic, Serdes::String);
   }
 

--- a/ksql-rest-app/src/test/java/io/confluent/ksql/rest/server/TemporaryEngine.java
+++ b/ksql-rest-app/src/test/java/io/confluent/ksql/rest/server/TemporaryEngine.java
@@ -18,19 +18,18 @@ package io.confluent.ksql.rest.server;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
-import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
 import io.confluent.ksql.engine.KsqlEngine;
 import io.confluent.ksql.engine.KsqlEngineTestUtil;
 import io.confluent.ksql.function.InternalFunctionRegistry;
 import io.confluent.ksql.metastore.MetaStoreImpl;
 import io.confluent.ksql.metastore.MutableMetaStore;
+import io.confluent.ksql.metastore.model.KeyField;
 import io.confluent.ksql.metastore.model.KsqlStream;
 import io.confluent.ksql.metastore.model.KsqlTable;
 import io.confluent.ksql.metastore.model.KsqlTopic;
 import io.confluent.ksql.metastore.model.StructuredDataSource;
 import io.confluent.ksql.parser.DefaultKsqlParser;
-import io.confluent.ksql.parser.KsqlParser.PreparedStatement;
 import io.confluent.ksql.query.QueryId;
 import io.confluent.ksql.serde.DataSource;
 import io.confluent.ksql.serde.json.KsqlJsonTopicSerDe;
@@ -45,7 +44,6 @@ import io.confluent.rest.RestConfig;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
-import java.util.Optional;
 import org.apache.kafka.clients.consumer.ConsumerConfig;
 import org.apache.kafka.common.serialization.Serdes;
 import org.apache.kafka.connect.data.Schema;
@@ -97,13 +95,15 @@ public class TemporaryEngine extends ExternalResource {
       case KSTREAM:
         source =
             new KsqlStream<>(
-                "statement", name, SCHEMA, Optional.of(SCHEMA.field("val")),
+                "statement", name, SCHEMA,
+                KeyField.of("val", SCHEMA.field("val")),
                 new MetadataTimestampExtractionPolicy(), topic, Serdes::String);
         break;
       case KTABLE:
         source =
             new KsqlTable<>(
-                "statement", name, SCHEMA, Optional.of(SCHEMA.field("val")),
+                "statement", name, SCHEMA,
+                KeyField.of("val", SCHEMA.field("val")),
                 new MetadataTimestampExtractionPolicy(), topic, Serdes::String);
         break;
       case KTOPIC:

--- a/ksql-rest-app/src/test/java/io/confluent/ksql/rest/server/resources/KsqlResourceTest.java
+++ b/ksql-rest-app/src/test/java/io/confluent/ksql/rest/server/resources/KsqlResourceTest.java
@@ -66,6 +66,7 @@ import io.confluent.ksql.engine.KsqlEngine;
 import io.confluent.ksql.engine.KsqlEngineTestUtil;
 import io.confluent.ksql.function.InternalFunctionRegistry;
 import io.confluent.ksql.metastore.MetaStoreImpl;
+import io.confluent.ksql.metastore.model.KeyField;
 import io.confluent.ksql.metastore.model.KsqlStream;
 import io.confluent.ksql.metastore.model.KsqlTable;
 import io.confluent.ksql.metastore.model.KsqlTopic;
@@ -1938,13 +1939,15 @@ public class KsqlResourceTest {
     if (type == DataSource.DataSourceType.KSTREAM) {
       metaStore.putSource(
           new KsqlStream<>(
-              "statementText", sourceName, schema, Optional.of(schema.fields().get(0)),
+              "statementText", sourceName, schema,
+              KeyField.of(schema.fields().get(0).name(), schema.fields().get(0)),
               new MetadataTimestampExtractionPolicy(), ksqlTopic, Serdes::String));
     }
     if (type == DataSource.DataSourceType.KTABLE) {
       metaStore.putSource(
           new KsqlTable<>(
-              "statementText", sourceName, schema, Optional.of(schema.fields().get(0)),
+              "statementText", sourceName, schema,
+              KeyField.of(schema.fields().get(0).name(), schema.fields().get(0)),
               new MetadataTimestampExtractionPolicy(), ksqlTopic, Serdes::String));
     }
   }


### PR DESCRIPTION
### Description 

Looks to address many issues in #2636

Users can (optionally) supply a hint to KSQL that there is a field in the value schema that contains the same data as the key,  e.g.

```SQL
CREATE STREAM FOO (ID INT, NAME STRING, ...) WITH (KEY='ID', ...);
```

Note: `TABLE`s currently _require_ the `KEY` to be provided, but this will go away soon.

KSQL stored this key field as part of the source in the `MetaStore` and allows KSQL to avoid unnecessary repartition steps in downstream queries should a user choose to `JOIN`, `PARTITION BY` or `GROUP BY` the key field. e.g. 

```SQL
-- no repartition necessary as the data is already keyed by ID:
CREATE TABLE T AS SELECT STRING FROM FOO GROUP BY ID;
```

Source created via `CSAS`, `CTAS` and `INSERT INTO` statements can also have key fields set, but the existing logic to determine what this should be set to is flawed. I've previously added tests in `key-fields.json` and `joins.json` to cover different scenarios of how key fields are calculated and to highlight existing issues. See the 'issues' nodes in the current files.

Miscalculation of the key field can result in unnecessary repartition steps being added to topologies, increasing latency, complexity and storage costs.

This PR looks to address the majority of issues pertaining to key field handling.  There are still two issues remaining, which I will cover in follow up PRs:
 - key field not set when `GROUP BY ROWKEY`
 - key field not set when `GROUP BY` multiple fields, where a matching column exists in the projection.

The PR introduces a `KeyField` class that tracks both the new key and the legacy key. The tracking of the legacy key is required to ensure pre-existing downstream queries continue to have the unnecessary repartition step. Removing this step in existing queries would likely result in data loss.

To help understand the need for `KeyField` consider the case where the stream `OUTPUT` currently has an incorrect key field calculated by KSQL: it should be `COL0`, but is actually `KSQL_INTERNAL_COL_0` in the metastore.  This means a downstream query, such as the one below, will have an unnecessary repartition step in its topology:

```SQL
-- Because the key field of OUTPUT is not set to COL0 this query will contain a repartition step:
CREATE TABLE DOWNSTREAM AS SELECT COL0, COUNT() FROM OUTPUT GROUP BY COL0;
```

If `OUTPUT` and `DOWNSTREAM` existing in the command topic prior to upgrading KSQL, then KSQL must continue to run the `DOWNSTREAM` query with the additional repartition step if it is to avoid data loss, (e.g. from unprocessed records left in the repartition topic).  This means KSQL must use to old, broken, key field logic when handling `DOWNSTREAM`.

However, if after the upgrade, the user creates another query that uses `OUTPUT`, such as the one below, then we don't want this new query to pay the cost of the unnecessary repartition step:

```SQL
-- We want this new query to avoid the unnecessary repartition step, so it needs the correct key field for OUTPUT:
CREATE TABLE NEW_DOWNSTREAM AS SELECT COL0, COUNT() FROM OUTPUT GROUP BY COL0;
```

To achieve this, KSQL must compute and store both the legacy, (potentially wrong), key field _and_ the new key field. It must then know which of these two key fields to use when building a query. 

When building a query / topology KSQL will determine which of the two key fields to use by looking for a new `CompatibilityBreakingConfig` called `ksql.query.fields.key.legacy`. This shouldn't be set by users.  New statements will be persisted to the command topic with this property set to `false`, where as old statements won't have it set, so it will default to `true`.

To help track down issues, and to fail quickly should any get reintroduced again, I've made use of the new `KeyField.validateKeyExistsIn` method within the constructors of the node types that the `LogicalPlanner` uses.  This ensures any class that is instantiated with a key field actually has the field in its value schema.

#### How to review...

1. First off, take a look at the tests in `key-fields.json` and joins.json`, especially those previously marked with `"issues"` nodes.   This will help you understand the issues.  Note: the `post.sources` node contains the sources the test should check are in the metastore _post_ the statements running and the state the sources should be in, i.e. the keyField they should have.
1. Next have a look at the `KeyField` class. You'll see it has a legacy `Field` and a new `String` field name.  The non-legacy value is not a `Field` as this is unnecessary. They field can be obtained from the schema by the name.   The `KeyField` class also has a `resolve` method, which takes the schema and config and will return the `Field` to use. This will either be the `legacyField` or the field from the supplied `schema`, depending on the value of `ksql.query.fields.key.legacy`.
1. You're now ready to look at the rest of the code. Personally, I'd start with `CT` / `CS` commands, so that's `CreateTableCommand` and `CreateStreamCommand` and then work through the node types in the logical planner. But you can tackle it what every way you want.



### Testing done 
Lots of QTT tests were added before to ensure 

### Reviewer checklist
- [ ] Ensure docs are updated if necessary. (eg. if a user visible feature is being added or changed).
- [ ] Ensure relevant issues are linked (description should include text like "Fixes #<issue number>")

