### PR TITLE
Minor: update JsonMapper to ignore unknown fields (5.0.x)

### DIFF
--- a/ksql-cli/src/main/java/io/confluent/ksql/cli/console/Console.java
+++ b/ksql-cli/src/main/java/io/confluent/ksql/cli/console/Console.java
@@ -16,7 +16,6 @@
 
 package io.confluent.ksql.cli.console;
 
-import com.fasterxml.jackson.core.JsonGenerator;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import io.confluent.ksql.GenericRow;
 import io.confluent.ksql.rest.client.KsqlRestClient;
@@ -48,6 +47,7 @@ import io.confluent.ksql.rest.entity.StreamedRow;
 import io.confluent.ksql.rest.entity.StreamsList;
 import io.confluent.ksql.rest.entity.TablesList;
 import io.confluent.ksql.rest.entity.TopicDescription;
+import io.confluent.ksql.rest.util.JsonMapper;
 import io.confluent.ksql.util.CliUtils;
 import io.confluent.ksql.util.StringUtil;
 import java.io.Closeable;
@@ -94,7 +94,7 @@ public abstract class Console implements Closeable {
 
     this.cliSpecificCommands = new LinkedHashMap<>();
 
-    this.objectMapper = new ObjectMapper().disable(JsonGenerator.Feature.AUTO_CLOSE_TARGET);
+    this.objectMapper = JsonMapper.INSTANCE.mapper;
 
     registerDefaultCommands();
   }

--- a/ksql-cli/src/main/java/io/confluent/ksql/util/CliUtils.java
+++ b/ksql-cli/src/main/java/io/confluent/ksql/util/CliUtils.java
@@ -23,6 +23,7 @@ import io.confluent.ksql.parser.AstBuilder;
 import io.confluent.ksql.parser.SqlBaseParser;
 import io.confluent.ksql.parser.tree.RegisterTopic;
 import io.confluent.ksql.rest.entity.PropertiesList;
+import io.confluent.ksql.rest.util.JsonMapper;
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
@@ -65,7 +66,7 @@ public class CliUtils {
   public String getAvroSchema(final String schemaFilePath) {
     try {
       final byte[] jsonData = Files.readAllBytes(Paths.get(schemaFilePath));
-      final ObjectMapper objectMapper = new ObjectMapper();
+      final ObjectMapper objectMapper = JsonMapper.INSTANCE.mapper;
       final JsonNode root = objectMapper.readTree(jsonData);
       return root.toString();
     } catch (final JsonParseException e) {

--- a/ksql-rest-app/src/main/java/io/confluent/ksql/rest/client/KsqlRestClient.java
+++ b/ksql-rest-app/src/main/java/io/confluent/ksql/rest/client/KsqlRestClient.java
@@ -18,7 +18,6 @@ package io.confluent.ksql.rest.client;
 
 import com.fasterxml.jackson.databind.DeserializationFeature;
 import com.fasterxml.jackson.databind.ObjectMapper;
-import com.fasterxml.jackson.datatype.jdk8.Jdk8Module;
 import com.google.common.collect.Maps;
 import io.confluent.ksql.rest.client.exception.KsqlRestClientException;
 import io.confluent.ksql.rest.entity.CommandStatus;
@@ -223,7 +222,7 @@ public class KsqlRestClient implements Closeable, AutoCloseable {
     public QueryStream(final Response response) {
       this.response = response;
 
-      this.objectMapper = new ObjectMapper();
+      this.objectMapper = JsonMapper.INSTANCE.mapper;
       final InputStreamReader isr = new InputStreamReader(
           (InputStream) response.getEntity(),
           StandardCharsets.UTF_8
@@ -351,10 +350,8 @@ public class KsqlRestClient implements Closeable, AutoCloseable {
   }
 
   private static Client buildClient() {
-    final ObjectMapper objectMapper = JsonMapper.INSTANCE.mapper;
-    objectMapper.configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false);
+    final ObjectMapper objectMapper = JsonMapper.INSTANCE.mapper.copy();
     objectMapper.configure(DeserializationFeature.FAIL_ON_NULL_FOR_PRIMITIVES, false);
-    objectMapper.registerModule(new Jdk8Module());
     final JacksonMessageBodyProvider jsonProvider = new JacksonMessageBodyProvider(objectMapper);
     return ClientBuilder.newBuilder().register(jsonProvider).build();
   }

--- a/ksql-rest-app/src/main/java/io/confluent/ksql/rest/util/JsonMapper.java
+++ b/ksql-rest-app/src/main/java/io/confluent/ksql/rest/util/JsonMapper.java
@@ -17,6 +17,7 @@
 package io.confluent.ksql.rest.util;
 
 import com.fasterxml.jackson.core.JsonGenerator;
+import com.fasterxml.jackson.databind.DeserializationFeature;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.datatype.jdk8.Jdk8Module;
 
@@ -29,5 +30,6 @@ public enum JsonMapper {
   JsonMapper() {
     mapper.registerModule(new Jdk8Module());
     mapper.registerModule(new StructSerializationModule());
+    mapper.disable(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES);
   }
 }


### PR DESCRIPTION
### Description 

This is a backport of https://github.com/confluentinc/ksql/pull/2704 to 5.0.x, which is needed in order for 5.0 servers to be compatible with 5.2+ CLI versions. (See https://github.com/confluentinc/ksql/issues/2685 as example motivation.)

### Testing done 

Manual verification that the 5.0 server with this change is now compatible with the 5.2 CLI. Existing tests continue to pass. I chose not to backport unit tests from https://github.com/confluentinc/ksql/pull/2704 since active development no longer happens on 5.0.x, but am happy to do so if others think this is desirable.

### Reviewer checklist
- [ ] Ensure docs are updated if necessary. (eg. if a user visible feature is being added or changed).
- [ ] Ensure relevant issues are linked (description should include text like "Fixes #<issue number>")

