### PR TITLE
fix race condition in RestApiTest shutdown: fixes flaky test in 5.0.x

### DIFF
--- a/ksql-rest-app/src/main/java/io/confluent/ksql/rest/server/KsqlRestApplication.java
+++ b/ksql-rest-app/src/main/java/io/confluent/ksql/rest/server/KsqlRestApplication.java
@@ -168,6 +168,7 @@ public class KsqlRestApplication extends Application<KsqlRestConfig> implements 
 
   @Override
   public void stop() throws Exception {
+    super.stop();
     ksqlEngine.close();
     commandRunner.close();
     try {
@@ -175,7 +176,6 @@ public class KsqlRestApplication extends Application<KsqlRestConfig> implements 
     } catch (final InterruptedException exception) {
       log.error("Interrupted while waiting for CommandRunner thread to complete", exception);
     }
-    super.stop();
   }
 
   @Override


### PR DESCRIPTION
### Description 
1. `KsqlRestApplication` is a Jetty `Server`. As part of its `stop` functionality, it waits for any opened network connections to wrap up (default wait time is one second). 
2. In `QueryStreamWriter`, we use the admin client to cleanup internal topics.
3. In `KsqlRestApplication`, we close the engine, which in turn closes the KafkaTopicClient, which in turn closes the admin client.

3 and 2 are racey. If we close the KsqlEngine before the `QueryStreamWrtier` is done whatever it is doing, it will fail with `org.apache.kafka.common.errors.TimeoutException: The AdminClient thread is not accepting new calls.`

Since we wrap that call with a retry, it will retry forever: 
```java
executeWithRetries(() -> adminClient.listTopics().names());
```

That is, until `super.stop()` is called, which will wait with some timeout for its child processes (note #1 above) to complete:
```
java.util.concurrent.TimeoutException
	at org.eclipse.jetty.util.FutureCallback.get(FutureCallback.java:128)
	at org.eclipse.jetty.util.FutureCallback.get(FutureCallback.java:30)
	at org.eclipse.jetty.server.Server.doStop(Server.java:460)
	at io.confluent.rest.Application$1.doStop(Application.java:187)
	at org.eclipse.jetty.util.component.AbstractLifeCycle.stop(AbstractLifeCycle.java:89)
	at io.confluent.rest.Application.stop(Application.java:594)
	at io.confluent.ksql.rest.server.KsqlRestApplication.stop(KsqlRestApplication.java:178)
	at io.confluent.ksql.rest.integration.RestApiTest.cleanUpClass(RestApiTest.java:139)
```

If we re-arrange the code as done in this PR, then the stop will wait with the admin client open - giving it ample time to do what it needs to do.

See: https://github.com/eclipse/jetty.project/blob/jetty-9.4.x/jetty-server/src/main/java/org/eclipse/jetty/server/Server.java#L423 for more context

### Testing done 
- Ran the test many times

### Reviewer checklist
- [ ] Ensure docs are updated if necessary. (eg. if a user visible feature is being added or changed).
- [ ] Ensure relevant issues are linked (description should include text like "Fixes #<issue number>")

