### PR TITLE
StructuredDataSourceNode to always use fully qualified schema

### DIFF
--- a/ksql-engine/src/main/java/io/confluent/ksql/analyzer/Analyzer.java
+++ b/ksql-engine/src/main/java/io/confluent/ksql/analyzer/Analyzer.java
@@ -425,16 +425,14 @@ class Analyzer {
           new StructuredDataSourceNode(
               new PlanNodeId("KafkaTopic_Left"),
               leftDataSource,
-              leftDataSource.getSchema(),
-              leftDataSource.getKeyField()
+              leftAlias
           );
       final StructuredDataSourceNode
           rightSourceKafkaTopicNode =
           new StructuredDataSourceNode(
               new PlanNodeId("KafkaTopic_Right"),
               rightDataSource,
-              rightDataSource.getSchema(),
-              rightDataSource.getKeyField()
+              rightAlias
           );
 
       final JoinNode joinNode =

--- a/ksql-engine/src/main/java/io/confluent/ksql/planner/LogicalPlanner.java
+++ b/ksql-engine/src/main/java/io/confluent/ksql/planner/LogicalPlanner.java
@@ -230,19 +230,10 @@ public class LogicalPlanner {
       throw new RuntimeException("Data source is not supported yet.");
     }
 
-    final Schema fromSchema = SchemaUtil.buildSchemaWithAlias(
-        dataSource.left.getSchema(),
-        dataSource.right
-    );
-
-    final Optional<String> newKeyName = dataSource.left.getKeyField().name()
-        .map(name -> SchemaUtil.buildAliasedFieldName(dataSource.right, name));
-
     return new StructuredDataSourceNode(
         new PlanNodeId("KsqlTopic"),
         dataSource.left,
-        fromSchema,
-        KeyField.of(newKeyName, dataSource.left.getKeyField().legacy())
+        dataSource.right
     );
   }
 }

--- a/ksql-engine/src/main/java/io/confluent/ksql/structured/SchemaKStream.java
+++ b/ksql-engine/src/main/java/io/confluent/ksql/structured/SchemaKStream.java
@@ -519,9 +519,10 @@ public class SchemaKStream<K> {
       final boolean updateRowKey,
       final QueryContext.Stacker contextStacker
   ) {
-    final boolean namesMatch = keyField.resolve(schema, ksqlConfig)
-        .map(Field::name)
-        .map(name -> name.equals(newKeyField.name()))
+    final Optional<Field> resolved = keyField.resolve(schema, ksqlConfig);
+
+    final boolean namesMatch = resolved
+        .map(kf -> SchemaUtil.matchFieldName(kf, newKeyField.name()))
         .orElse(false);
 
     if (namesMatch) {

--- a/ksql-engine/src/test/java/io/confluent/ksql/planner/plan/KsqlStructuredDataOutputNodeTest.java
+++ b/ksql-engine/src/test/java/io/confluent/ksql/planner/plan/KsqlStructuredDataOutputNodeTest.java
@@ -105,11 +105,11 @@ public class KsqlStructuredDataOutputNodeTest {
       new LongColumnTimestampExtractionPolicy("timestamp"),
       new KsqlTopic(SOURCE_TOPIC_NAME, SOURCE_KAFKA_TOPIC_NAME,
           new KsqlJsonTopicSerDe(), false), Serdes::String);
+
   private final StructuredDataSourceNode sourceNode = new StructuredDataSourceNode(
       new PlanNodeId("0"),
       dataSource,
-      schema,
-      dataSource.getKeyField());
+      dataSource.getName());
 
   private StreamsBuilder builder;
   private KsqlStructuredDataOutputNode outputNode;
@@ -383,8 +383,7 @@ public class KsqlStructuredDataOutputNodeTest {
     final StructuredDataSourceNode tableSourceNode = new StructuredDataSourceNode(
         new PlanNodeId("0"),
         dataSource,
-        dataSource.getSchema(),
-        dataSource.getKeyField());
+        dataSource.getName());
 
     return new KsqlStructuredDataOutputNode(
         new PlanNodeId("0"),


### PR DESCRIPTION
### Description 
In the current code base the schema passed to `StructuredDataSourceNode` has fully qualified field names, i.e. the field names are prefixed with the source name, if the query is not a join, but has unqualified field names if the query is a join.

This PR looks to standardize on always using fully qualified field names for the schema in `StructuredDataSourceNode`. Consistency here makes reasoning about the code easier and will help fixing bugs such as https://github.com/confluentinc/ksql/issues/2525.

### Testing done 
QTT and added suitable unit tests.

### Reviewer checklist
- [ ] Ensure docs are updated if necessary. (eg. if a user visible feature is being added or changed).
- [ ] Ensure relevant issues are linked (description should include text like "Fixes #<issue number>")

