### PR TITLE
Introduce Syntax & Executor for InsertValues

### DIFF
--- a/ksql-common/src/main/java/io/confluent/ksql/logging/processing/NoopProcessingLogContext.java
+++ b/ksql-common/src/main/java/io/confluent/ksql/logging/processing/NoopProcessingLogContext.java
@@ -1,0 +1,56 @@
+/*
+ * Copyright 2019 Confluent Inc.
+ *
+ * Licensed under the Confluent Community License (the "License"; you may not use
+ * this file except in compliance with the License. You may obtain a copy of the
+ * License at
+ *
+ * http://www.confluent.io/confluent-community-license
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package io.confluent.ksql.logging.processing;
+
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+import java.util.Collection;
+
+/**
+ * An implementation of {@code ProcessingLogContext} that does nothing.
+ */
+public final class NoopProcessingLogContext implements ProcessingLogContext {
+
+  private static final ProcessingLogConfig NOOP_CONFIG = new ProcessingLogConfig(ImmutableMap.of());
+
+  private static final ProcessingLogger NOOP_LOGGER = msgFactory -> { };
+
+  private static final ProcessingLoggerFactory NOOP_FACTORY = new ProcessingLoggerFactory() {
+    @Override
+    public ProcessingLogger getLogger(final String name) {
+      return NOOP_LOGGER;
+    }
+
+    @Override
+    public Collection<String> getLoggers() {
+      return ImmutableList.of();
+    }
+  };
+
+  public static final ProcessingLogContext INSTANCE = new NoopProcessingLogContext();
+
+  private NoopProcessingLogContext() { }
+
+  @Override
+  public ProcessingLogConfig getConfig() {
+    return NOOP_CONFIG;
+  }
+
+  @Override
+  public ProcessingLoggerFactory getLoggerFactory() {
+    return NOOP_FACTORY;
+  }
+}

--- a/ksql-common/src/main/java/io/confluent/ksql/util/KsqlConfig.java
+++ b/ksql-common/src/main/java/io/confluent/ksql/util/KsqlConfig.java
@@ -31,6 +31,7 @@ import java.util.Set;
 import java.util.stream.Collectors;
 import org.apache.kafka.clients.admin.AdminClientConfig;
 import org.apache.kafka.clients.consumer.ConsumerConfig;
+import org.apache.kafka.clients.producer.ProducerConfig;
 import org.apache.kafka.common.config.AbstractConfig;
 import org.apache.kafka.common.config.ConfigDef;
 import org.apache.kafka.common.config.ConfigDef.Importance;
@@ -536,11 +537,18 @@ public class KsqlConfig extends AbstractConfig {
   }
 
   public Map<String, Object> getKsqlAdminClientConfigProps() {
+    return getConfigsFor(AdminClientConfig.configNames());
+  }
+
+  public Map<String, Object> getProducerClientConfigProps() {
+    return getConfigsFor(ProducerConfig.configNames());
+  }
+
+  private Map<String, Object> getConfigsFor(final Set<String> configs) {
     final Map<String, Object> props = new HashMap<>();
     ksqlStreamConfigProps.values().stream()
-        .filter(configValue -> AdminClientConfig.configNames().contains(configValue.key))
-        .forEach(
-            configValue -> props.put(configValue.key, configValue.value));
+        .filter(configValue -> configs.contains(configValue.key))
+        .forEach(configValue -> props.put(configValue.key, configValue.value));
     return Collections.unmodifiableMap(props);
   }
 

--- a/ksql-common/src/test/java/io/confluent/ksql/util/KsqlConfigTest.java
+++ b/ksql-common/src/test/java/io/confluent/ksql/util/KsqlConfigTest.java
@@ -23,6 +23,8 @@ import static org.hamcrest.CoreMatchers.nullValue;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.contains;
 import static org.hamcrest.Matchers.empty;
+import static org.hamcrest.Matchers.hasEntry;
+import static org.hamcrest.Matchers.hasKey;
 
 import com.google.common.collect.ImmutableMap;
 import io.confluent.ksql.errors.LogMetricAndContinueExceptionHandler;
@@ -573,6 +575,22 @@ public class KsqlConfigTest {
     assertThat(
         merged.getKsqlStreamConfigProps().get(StreamsConfig.TOPOLOGY_OPTIMIZATION),
         equalTo(StreamsConfig.NO_OPTIMIZATION));
+  }
+
+  @Test
+  public void shouldFilterProducerConfigs() {
+    // Given:
+    final Map<String, Object> configs = new HashMap<>();
+    configs.put(ProducerConfig.ACKS_CONFIG, "all");
+    configs.put(ProducerConfig.CLIENT_ID_CONFIG, null);
+    configs.put("not.a.config", "123");
+
+    final KsqlConfig ksqlConfig = new KsqlConfig(configs);
+
+    // When:
+    assertThat(ksqlConfig.getProducerClientConfigProps(), hasEntry(ProducerConfig.ACKS_CONFIG, "all"));
+    assertThat(ksqlConfig.getProducerClientConfigProps(), hasEntry(ProducerConfig.CLIENT_ID_CONFIG, null));
+    assertThat(ksqlConfig.getProducerClientConfigProps(), not(hasKey("not.a.config")));
   }
 
   @Test

--- a/ksql-engine/src/main/java/io/confluent/ksql/services/SandboxedProducer.java
+++ b/ksql-engine/src/main/java/io/confluent/ksql/services/SandboxedProducer.java
@@ -18,6 +18,7 @@ package io.confluent.ksql.services;
 import static io.confluent.ksql.util.LimitedProxyBuilder.anyParams;
 
 import io.confluent.ksql.util.LimitedProxyBuilder;
+import java.util.concurrent.CompletableFuture;
 import org.apache.kafka.clients.producer.Producer;
 
 /**
@@ -32,6 +33,7 @@ final class SandboxedProducer<K, V> {
 
   static <K, V> Producer<K, V> createProxy() {
     return LimitedProxyBuilder.forClass(Producer.class)
+        .swallow("send", anyParams(), CompletableFuture.completedFuture(null))
         .swallow("close", anyParams())
         .build();
   }

--- a/ksql-engine/src/main/java/io/confluent/ksql/structured/SchemaKStream.java
+++ b/ksql-engine/src/main/java/io/confluent/ksql/structured/SchemaKStream.java
@@ -537,7 +537,7 @@ public class SchemaKStream<K> {
         .selectKey((key, value) -> extractColumn(proposedKey, value).toString())
         .mapValues((key, row) -> {
           if (updateRowKey) {
-            row.getColumns().set(SchemaUtil.ROWKEY_NAME_INDEX, key);
+            row.getColumns().set(SchemaUtil.ROWKEY_INDEX, key);
           }
           return row;
         });

--- a/ksql-engine/src/test/java/io/confluent/ksql/services/SandboxedProducerTest.java
+++ b/ksql-engine/src/test/java/io/confluent/ksql/services/SandboxedProducerTest.java
@@ -21,7 +21,9 @@ import java.time.Duration;
 import java.util.Collection;
 import java.util.Objects;
 import java.util.concurrent.TimeUnit;
+import org.apache.kafka.clients.producer.Callback;
 import org.apache.kafka.clients.producer.Producer;
+import org.apache.kafka.clients.producer.ProducerRecord;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.experimental.runners.Enclosed;
@@ -40,6 +42,8 @@ public final class SandboxedProducerTest {
     @Parameterized.Parameters(name = "{0}")
     public static Collection<TestCase<Producer>> getMethodsToTest() {
       return TestMethods.builder(Producer.class)
+          .ignore("send", ProducerRecord.class)
+          .ignore("send", ProducerRecord.class, Callback.class)
           .ignore("close")
           .ignore("close", long.class, TimeUnit.class)
           .ignore("close", Duration.class)

--- a/ksql-metastore/src/main/java/io/confluent/ksql/metastore/model/KsqlStream.java
+++ b/ksql-metastore/src/main/java/io/confluent/ksql/metastore/model/KsqlStream.java
@@ -46,14 +46,14 @@ public class KsqlStream<K> extends StructuredDataSource<K> {
     );
   }
 
+  @Override
+  public String toString() {
+    return getClass().getSimpleName() + " name:" + getName();
+  }
+
   public boolean hasWindowedKey() {
     final Serde<K> keySerde = getKeySerdeFactory().create();
     return keySerde instanceof WindowedSerdes.SessionWindowedSerde
         || keySerde instanceof WindowedSerdes.TimeWindowedSerde;
-  }
-
-  @Override
-  public String toString() {
-    return getClass().getSimpleName() + " name:" + getName();
   }
 }

--- a/ksql-metastore/src/main/java/io/confluent/ksql/metastore/model/KsqlTable.java
+++ b/ksql-metastore/src/main/java/io/confluent/ksql/metastore/model/KsqlTable.java
@@ -46,14 +46,14 @@ public class KsqlTable<K> extends StructuredDataSource<K> {
     );
   }
 
+  @Override
+  public String toString() {
+    return getClass().getSimpleName() + " name:" + getName();
+  }
+
   public boolean isWindowed() {
     final Serde<K> keySerde = getKeySerdeFactory().create();
     return keySerde instanceof WindowedSerdes.SessionWindowedSerde
         || keySerde instanceof WindowedSerdes.TimeWindowedSerde;
-  }
-
-  @Override
-  public String toString() {
-    return getClass().getSimpleName() + " name:" + getName();
   }
 }

--- a/ksql-parser/src/main/antlr4/io/confluent/ksql/parser/SqlBase.g4
+++ b/ksql-parser/src/main/antlr4/io/confluent/ksql/parser/SqlBase.g4
@@ -60,6 +60,7 @@ statement
     | CREATE TABLE (IF NOT EXISTS)? qualifiedName
             (WITH tableProperties)? AS query                                #createTableAs
     | INSERT INTO qualifiedName query (PARTITION BY identifier)?            #insertInto
+    | INSERT INTO qualifiedName (columns)? VALUES values                    #insertValues
     | DROP TOPIC (IF EXISTS)? qualifiedName                                 #dropTopic
     | DROP STREAM (IF EXISTS)? qualifiedName (DELETE TOPIC)?                #dropStream
     | DROP TABLE (IF EXISTS)? qualifiedName  (DELETE TOPIC)?                #dropTable
@@ -144,6 +145,10 @@ groupingExpressions
     | expression
     ;
 
+values
+    : '(' (literal (',' literal)*)? ')'
+    ;
+
 /*
  * Dropped `namedQuery` as we don't support them.
  */
@@ -186,7 +191,7 @@ aliasedRelation
     : relationPrimary (AS? identifier)?
     ;
 
-columnAliases
+columns
     : '(' identifier (',' identifier)* ')'
     ;
 

--- a/ksql-parser/src/main/java/io/confluent/ksql/parser/SqlFormatter.java
+++ b/ksql-parser/src/main/java/io/confluent/ksql/parser/SqlFormatter.java
@@ -34,6 +34,7 @@ import io.confluent.ksql.parser.tree.DropTable;
 import io.confluent.ksql.parser.tree.Explain;
 import io.confluent.ksql.parser.tree.Expression;
 import io.confluent.ksql.parser.tree.InsertInto;
+import io.confluent.ksql.parser.tree.InsertValues;
 import io.confluent.ksql.parser.tree.Join;
 import io.confluent.ksql.parser.tree.JoinCriteria;
 import io.confluent.ksql.parser.tree.JoinOn;
@@ -373,8 +374,6 @@ public final class SqlFormatter {
       return null;
     }
 
-
-
     private static String formatName(final String name) {
       if (NAME_PATTERN.matcher(name).matches()) {
         return name;
@@ -395,6 +394,29 @@ public final class SqlFormatter {
     @Override
     protected Void visitDropStream(final DropStream node, final Integer context) {
       visitDrop(node, "STREAM");
+      return null;
+    }
+
+    @Override
+    protected Void visitInsertValues(final InsertValues node, final Integer context) {
+      builder.append("INSERT INTO ");
+      builder.append(node.getTarget());
+      builder.append(" ");
+
+      if (!node.getColumns().isEmpty()) {
+        builder.append(node.getColumns().stream().collect(Collectors.joining(", ", "(", ") ")));
+      }
+
+      builder.append("VALUES ");
+
+      builder.append("(");
+      builder.append(
+          node.getValues()
+              .stream()
+              .map(SqlFormatter::formatSql)
+              .collect(Collectors.joining(", ")));
+      builder.append(")");
+
       return null;
     }
 

--- a/ksql-parser/src/main/java/io/confluent/ksql/parser/tree/AstVisitor.java
+++ b/ksql-parser/src/main/java/io/confluent/ksql/parser/tree/AstVisitor.java
@@ -272,6 +272,10 @@ public abstract class AstVisitor<R, C> {
     return visitStatement(node, context);
   }
 
+  protected R visitInsertValues(final InsertValues node, final C context) {
+    return visitStatement(node, context);
+  }
+
   protected R visitDropTopic(final DropTopic node, final C context) {
     return visitStatement(node, context);
   }

--- a/ksql-parser/src/main/java/io/confluent/ksql/parser/tree/InsertValues.java
+++ b/ksql-parser/src/main/java/io/confluent/ksql/parser/tree/InsertValues.java
@@ -1,0 +1,105 @@
+/*
+ * Copyright 2019 Confluent Inc.
+ *
+ * Licensed under the Confluent Community License (the "License"; you may not use
+ * this file except in compliance with the License. You may obtain a copy of the
+ * License at
+ *
+ * http://www.confluent.io/confluent-community-license
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package io.confluent.ksql.parser.tree;
+
+import com.google.common.collect.ImmutableList;
+import com.google.errorprone.annotations.Immutable;
+import io.confluent.ksql.util.KsqlException;
+import java.util.List;
+import java.util.Objects;
+import java.util.Optional;
+
+@Immutable
+public class InsertValues extends Statement {
+
+  private final QualifiedName target;
+  private final ImmutableList<String> columns;
+  private final ImmutableList<Expression> values;
+
+  public InsertValues(
+      final QualifiedName target,
+      final List<String> columns,
+      final List<Expression> values
+  ) {
+    this(Optional.empty(), target, columns, values);
+  }
+
+  public InsertValues(
+      final Optional<NodeLocation> location,
+      final QualifiedName target,
+      final List<String> columns,
+      final List<Expression> values
+  ) {
+    super(location);
+    this.target = Objects.requireNonNull(target, "target");
+    this.columns = ImmutableList.copyOf(Objects.requireNonNull(columns, "columns"));
+    this.values = ImmutableList.copyOf(Objects.requireNonNull(values, "values"));
+
+    if (values.isEmpty()) {
+      throw new KsqlException("Expected some values for INSERT INTO statement.");
+    }
+
+    if (!columns.isEmpty() && columns.size() != values.size()) {
+      throw new KsqlException(
+          "Expected number columns and values to match: " + columns + ", " + values);
+    }
+  }
+
+  public QualifiedName getTarget() {
+    return target;
+  }
+
+  public List<String> getColumns() {
+    return columns;
+  }
+
+  public List<Expression> getValues() {
+    return values;
+  }
+
+  @Override
+  public <R, C> R accept(final AstVisitor<R, C> visitor, final C context) {
+    return visitor.visitInsertValues(this, context);
+  }
+
+  @Override
+  public boolean equals(final Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    final InsertValues that = (InsertValues) o;
+    return Objects.equals(target, that.target)
+        && Objects.equals(columns, that.columns)
+        && Objects.equals(values, that.values);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(target, columns, values);
+  }
+
+  @Override
+  public String toString() {
+    return "InsertValues{"
+        + "target=" + target
+        + ", columns=" + columns
+        + ", values=" + values
+        + '}';
+  }
+}

--- a/ksql-parser/src/test/java/io/confluent/ksql/parser/tree/InsertValuesTest.java
+++ b/ksql-parser/src/test/java/io/confluent/ksql/parser/tree/InsertValuesTest.java
@@ -1,0 +1,71 @@
+/*
+ * Copyright 2019 Confluent Inc.
+ *
+ * Licensed under the Confluent Community License (the "License"; you may not use
+ * this file except in compliance with the License. You may obtain a copy of the
+ * License at
+ *
+ * http://www.confluent.io/confluent-community-license
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package io.confluent.ksql.parser.tree;
+
+import com.google.common.collect.ImmutableList;
+import com.google.common.testing.EqualsTester;
+import io.confluent.ksql.util.KsqlException;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+
+public class InsertValuesTest {
+
+  @Rule
+  public final ExpectedException expectedException = ExpectedException.none();
+
+  @Test
+  public void shouldImplementEqualsHashcode() {
+    new EqualsTester()
+        .addEqualityGroup(
+            new InsertValues(QualifiedName.of("a"), ImmutableList.of(), ImmutableList.of(new NullLiteral())),
+            new InsertValues(QualifiedName.of("a"), ImmutableList.of(), ImmutableList.of(new NullLiteral())))
+        .addEqualityGroup(new InsertValues(
+            QualifiedName.of("diff"), ImmutableList.of(), ImmutableList.of(new StringLiteral("b"))))
+        .addEqualityGroup(new InsertValues(
+            QualifiedName.of("a"), ImmutableList.of("diff"), ImmutableList.of(new StringLiteral("b"))))
+        .addEqualityGroup(new InsertValues(
+            QualifiedName.of("a"), ImmutableList.of(), ImmutableList.of(new StringLiteral("diff"))))
+        .testEquals();
+  }
+
+  @Test
+  public void shouldThrowIfEmptyValues() {
+    // Expect:
+    expectedException.expect(KsqlException.class);
+    expectedException.expectMessage("Expected some values for INSERT INTO statement");
+
+    // When:
+    new InsertValues(
+        QualifiedName.of("a"),
+        ImmutableList.of("col1"),
+        ImmutableList.of());
+  }
+
+  @Test
+  public void shouldThrowIfNonEmptyColumnsValuesDoNotMatch() {
+    // Expect:
+    expectedException.expect(KsqlException.class);
+    expectedException.expectMessage("Expected number columns and values to match");
+
+    // When:
+    new InsertValues(
+        QualifiedName.of("a"),
+        ImmutableList.of("col1"),
+        ImmutableList.of(new StringLiteral("val1"), new StringLiteral("val2")));
+  }
+
+}

--- a/ksql-rest-app/src/main/java/io/confluent/ksql/rest/server/execution/CustomExecutors.java
+++ b/ksql-rest-app/src/main/java/io/confluent/ksql/rest/server/execution/CustomExecutors.java
@@ -19,6 +19,7 @@ import com.google.common.collect.ImmutableMap;
 import io.confluent.ksql.KsqlExecutionContext;
 import io.confluent.ksql.parser.tree.DescribeFunction;
 import io.confluent.ksql.parser.tree.Explain;
+import io.confluent.ksql.parser.tree.InsertValues;
 import io.confluent.ksql.parser.tree.ListFunctions;
 import io.confluent.ksql.parser.tree.ListProperties;
 import io.confluent.ksql.parser.tree.ListQueries;
@@ -60,7 +61,8 @@ public enum CustomExecutors {
   EXPLAIN(Explain.class, ExplainExecutor::execute),
   DESCRIBE_FUNCTION(DescribeFunction.class, DescribeFunctionExecutor::execute),
   SET_PROPERTY(SetProperty.class, PropertyExecutor::set),
-  UNSET_PROPERTY(UnsetProperty.class, PropertyExecutor::unset);
+  UNSET_PROPERTY(UnsetProperty.class, PropertyExecutor::unset),
+  INSERT_VALUES(InsertValues.class, new InsertValuesExecutor()::execute);
 
   public static final Map<Class<? extends Statement>, StatementExecutor<?>> EXECUTOR_MAP =
       ImmutableMap.copyOf(

--- a/ksql-rest-app/src/main/java/io/confluent/ksql/rest/server/execution/InsertValuesExecutor.java
+++ b/ksql-rest-app/src/main/java/io/confluent/ksql/rest/server/execution/InsertValuesExecutor.java
@@ -1,0 +1,251 @@
+/*
+ * Copyright 2019 Confluent Inc.
+ *
+ * Licensed under the Confluent Community License (the "License"; you may not use
+ * this file except in compliance with the License. You may obtain a copy of the
+ * License at
+ *
+ * http://www.confluent.io/confluent-community-license
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package io.confluent.ksql.rest.server.execution;
+
+import com.google.common.annotations.VisibleForTesting;
+import io.confluent.ksql.GenericRow;
+import io.confluent.ksql.KsqlExecutionContext;
+import io.confluent.ksql.logging.processing.NoopProcessingLogContext;
+import io.confluent.ksql.metastore.model.DataSource;
+import io.confluent.ksql.metastore.model.KsqlStream;
+import io.confluent.ksql.metastore.model.KsqlTable;
+import io.confluent.ksql.parser.tree.AstVisitor;
+import io.confluent.ksql.parser.tree.Expression;
+import io.confluent.ksql.parser.tree.InsertValues;
+import io.confluent.ksql.parser.tree.Literal;
+import io.confluent.ksql.parser.tree.Node;
+import io.confluent.ksql.parser.tree.NullLiteral;
+import io.confluent.ksql.rest.entity.KsqlEntity;
+import io.confluent.ksql.services.ServiceContext;
+import io.confluent.ksql.statement.ConfiguredStatement;
+import io.confluent.ksql.util.KsqlConfig;
+import io.confluent.ksql.util.KsqlException;
+import io.confluent.ksql.util.SchemaUtil;
+import java.time.Duration;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Optional;
+import java.util.function.LongSupplier;
+import java.util.stream.Collectors;
+import org.apache.kafka.clients.producer.Producer;
+import org.apache.kafka.clients.producer.ProducerRecord;
+import org.apache.kafka.common.serialization.Serde;
+import org.apache.kafka.connect.data.Field;
+import org.apache.kafka.connect.data.Schema;
+import org.apache.kafka.connect.data.Schema.Type;
+
+public class InsertValuesExecutor {
+
+  private static final long MAX_SEND_TIMEOUT_SECONDS = 5;
+
+  private final LongSupplier clock;
+
+  public InsertValuesExecutor() {
+    this(System::currentTimeMillis);
+  }
+
+  @VisibleForTesting
+  InsertValuesExecutor(final LongSupplier clock) {
+    this.clock = Objects.requireNonNull(clock, "clock");
+  }
+
+  public Optional<KsqlEntity> execute(
+      final ConfiguredStatement<InsertValues> statement,
+      final KsqlExecutionContext executionContext,
+      final ServiceContext serviceContext
+  ) {
+    final InsertValues insertValues = statement.getStatement();
+    final DataSource<?> dataSource = executionContext
+        .getMetaStore()
+        .getSource(insertValues.getTarget().getSuffix());
+
+    if (dataSource == null) {
+      throw new KsqlException("Cannot insert values into an unknown stream/table: "
+          + insertValues.getTarget().getSuffix());
+    }
+
+    if (dataSource instanceof KsqlTable && ((KsqlTable<?>) dataSource).isWindowed()
+        || dataSource instanceof KsqlStream && ((KsqlStream<?>) dataSource).hasWindowedKey()) {
+      throw new KsqlException("Cannot insert values into windowed stream/table!");
+    }
+
+    final KsqlConfig config = statement.getConfig()
+        .cloneWithPropertyOverwrite(statement.getOverrides());
+
+    final GenericRow row = extractRow(insertValues, dataSource);
+    final byte[] key = serializeKey(row.getColumnValue(SchemaUtil.ROWKEY_INDEX), dataSource);
+    final byte[] value = serializeRow(row, dataSource, config, serviceContext);
+
+    final String topicName = dataSource.getKafkaTopicName();
+
+    // for now, just create a new producer each time
+    final Producer<byte[], byte[]> producer = serviceContext
+        .getKafkaClientSupplier()
+        .getProducer(config.getProducerClientConfigProps());
+
+    producer.send(
+        new ProducerRecord<>(
+            topicName,
+            null,
+            row.getColumnValue(SchemaUtil.ROWTIME_INDEX),
+            key,
+            value
+        )
+    );
+
+    producer.close(Duration.ofSeconds(MAX_SEND_TIMEOUT_SECONDS));
+
+    return Optional.empty();
+  }
+
+  private GenericRow extractRow(
+      final InsertValues insertValues,
+      final DataSource<?> dataSource
+  ) {
+    final Optional<String> keyField = dataSource.getKeyField().name();
+
+    final List<String> columns = insertValues.getColumns().isEmpty()
+        ? dataSource.getSchema()
+          .fields()
+          .stream()
+          .map(Field::name)
+          .filter(name -> !SchemaUtil.ROWTIME_NAME.equals(name))
+          .collect(Collectors.toList())
+        : insertValues.getColumns();
+
+    if (columns.size() != insertValues.getValues().size()) {
+      // this will only happen if insertValues.getColumns() is empty, otherwise
+      // the columns/values are verified by the InsertValues constructor
+      throw new KsqlException(
+          "Expected a value for each column. Expected Columns: " + columns
+              + ". Got " + insertValues.getValues());
+    }
+
+    final Map<String, Object> values = new HashMap<>();
+    for (int i = 0; i < columns.size(); i++) {
+      final String column = columns.get(i);
+      final Schema columnSchema = dataSource.getSchema().field(column).schema();
+      final Expression valueExp = insertValues.getValues().get(i);
+
+      values.put(column, new ExpressionResolver(columnSchema, column).process(valueExp, null));
+    }
+
+    if (keyField.isPresent()) {
+      final String key = keyField.get();
+      final Object keyValue = values.get(key);
+      final Object rowKeyValue = values.get(SchemaUtil.ROWKEY_NAME);
+
+      if (keyValue != null ^ rowKeyValue != null) {
+        values.putIfAbsent(key, rowKeyValue);
+        values.putIfAbsent(SchemaUtil.ROWKEY_NAME, keyValue);
+      } else if (!Objects.equals(keyValue, rowKeyValue)) {
+        throw new KsqlException(
+            String.format(
+                "Expected ROWKEY and %s to match but got %s and %s respectively.",
+                key, rowKeyValue, keyValue));
+      }
+    }
+
+    values.putIfAbsent(SchemaUtil.ROWTIME_NAME, clock.getAsLong());
+
+    for (Field field : dataSource.getSchema().fields()) {
+      if (!field.schema().isOptional() && values.getOrDefault(field.name(), null) == null) {
+        throw new KsqlException("Got null value for nonnull field: " + field);
+      }
+    }
+
+    return new GenericRow(
+        dataSource.getSchema()
+            .fields()
+            .stream()
+            .map(Field::name)
+            .map(values::get)
+            .collect(Collectors.toList())
+    );
+  }
+
+  @SuppressWarnings("unchecked") // we know that key is String
+  private byte[] serializeKey(final Object keyValue, final DataSource<?> dataSource) {
+    if (keyValue == null) {
+      return null;
+    }
+
+    try {
+      return ((Serde<String>) dataSource.getKeySerdeFactory().create())
+          .serializer()
+          .serialize(dataSource.getKafkaTopicName(), keyValue.toString());
+    } catch (final Exception e) {
+      throw new KsqlException("Could not serialize key: " + keyValue, e);
+    }
+  }
+
+  private byte[] serializeRow(
+      final GenericRow row,
+      final DataSource<?> dataSource,
+      final KsqlConfig config,
+      final ServiceContext serviceContext
+  ) {
+    final Serde<GenericRow> rowSerde = dataSource.getKsqlTopicSerde()
+        .getGenericRowSerde(
+            dataSource.getSchema(),
+            config,
+            serviceContext.getSchemaRegistryClientFactory(),
+            "",
+            NoopProcessingLogContext.INSTANCE);
+    try {
+      return rowSerde.serializer().serialize(dataSource.getKafkaTopicName(), row);
+    } catch (final Exception e) {
+      throw new KsqlException("Could not serialize row: " + row, e);
+    }
+  }
+
+  private static class ExpressionResolver extends AstVisitor<Object, Void> {
+
+    private final Schema schema;
+    private final String field;
+
+    ExpressionResolver(final Schema schema, final String field) {
+      this.schema = Objects.requireNonNull(schema, "schema");
+      this.field = Objects.requireNonNull(field, "field");
+    }
+
+    @Override
+    protected String visitNode(final Node node, final Void context) {
+      throw new KsqlException(
+          "Only Literals are supported for INSERT INTO. Got: " + node + " for field " + field);
+    }
+
+    @Override
+    protected Object visitLiteral(final Literal node, final Void context) {
+      final Object value = node.getValue();
+      if (node instanceof NullLiteral || value == null) {
+        return null;
+      }
+
+      final Type valueType = SchemaUtil.getSchemaFromType(value.getClass()).type();
+      if (valueType.equals(schema.type())) {
+        return value;
+      }
+
+      throw new KsqlException(
+          "Expected type " + schema.type() + " for field " + field
+              + " but got " + value + "(" + valueType + ")");
+    }
+  }
+
+}

--- a/ksql-rest-app/src/main/java/io/confluent/ksql/rest/server/validation/CustomValidators.java
+++ b/ksql-rest-app/src/main/java/io/confluent/ksql/rest/server/validation/CustomValidators.java
@@ -19,6 +19,7 @@ import com.google.common.collect.ImmutableMap;
 import io.confluent.ksql.KsqlExecutionContext;
 import io.confluent.ksql.parser.tree.DescribeFunction;
 import io.confluent.ksql.parser.tree.Explain;
+import io.confluent.ksql.parser.tree.InsertValues;
 import io.confluent.ksql.parser.tree.ListFunctions;
 import io.confluent.ksql.parser.tree.ListProperties;
 import io.confluent.ksql.parser.tree.ListQueries;
@@ -35,6 +36,7 @@ import io.confluent.ksql.parser.tree.TerminateQuery;
 import io.confluent.ksql.parser.tree.UnsetProperty;
 import io.confluent.ksql.rest.server.execution.DescribeFunctionExecutor;
 import io.confluent.ksql.rest.server.execution.ExplainExecutor;
+import io.confluent.ksql.rest.server.execution.InsertValuesExecutor;
 import io.confluent.ksql.rest.server.execution.ListSourceExecutor;
 import io.confluent.ksql.services.ServiceContext;
 import io.confluent.ksql.statement.ConfiguredStatement;
@@ -63,6 +65,7 @@ public enum CustomValidators {
   LIST_FUNCTIONS(ListFunctions.class, StatementValidator.NO_VALIDATION),
   LIST_QUERIES(ListQueries.class, StatementValidator.NO_VALIDATION),
   LIST_PROPERTIES(ListProperties.class, StatementValidator.NO_VALIDATION),
+  INSERT_VALUES(InsertValues.class, new InsertValuesExecutor()::execute),
 
   SHOW_COLUMNS(ShowColumns.class, ListSourceExecutor::columns),
   EXPLAIN(Explain.class, ExplainExecutor::execute),

--- a/ksql-rest-app/src/test/java/io/confluent/ksql/rest/server/execution/InsertValuesExecutorTest.java
+++ b/ksql-rest-app/src/test/java/io/confluent/ksql/rest/server/execution/InsertValuesExecutorTest.java
@@ -1,0 +1,503 @@
+/*
+ * Copyright 2019 Confluent Inc.
+ *
+ * Licensed under the Confluent Community License (the "License"; you may not use
+ * this file except in compliance with the License. You may obtain a copy of the
+ * License at
+ *
+ * http://www.confluent.io/confluent-community-license
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package io.confluent.ksql.rest.server.execution;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+import io.confluent.ksql.GenericRow;
+import io.confluent.ksql.engine.KsqlEngine;
+import io.confluent.ksql.function.TestFunctionRegistry;
+import io.confluent.ksql.metastore.MetaStoreImpl;
+import io.confluent.ksql.metastore.model.DataSource;
+import io.confluent.ksql.metastore.model.KeyField;
+import io.confluent.ksql.metastore.model.KsqlStream;
+import io.confluent.ksql.metastore.model.KsqlTopic;
+import io.confluent.ksql.parser.KsqlParser.PreparedStatement;
+import io.confluent.ksql.parser.tree.BooleanLiteral;
+import io.confluent.ksql.parser.tree.DoubleLiteral;
+import io.confluent.ksql.parser.tree.Expression;
+import io.confluent.ksql.parser.tree.InsertValues;
+import io.confluent.ksql.parser.tree.IntegerLiteral;
+import io.confluent.ksql.parser.tree.LongLiteral;
+import io.confluent.ksql.parser.tree.NullLiteral;
+import io.confluent.ksql.parser.tree.PrimitiveType;
+import io.confluent.ksql.parser.tree.QualifiedName;
+import io.confluent.ksql.parser.tree.StringLiteral;
+import io.confluent.ksql.parser.tree.Struct;
+import io.confluent.ksql.parser.tree.Type.SqlType;
+import io.confluent.ksql.serde.KsqlTopicSerDe;
+import io.confluent.ksql.services.ServiceContext;
+import io.confluent.ksql.statement.ConfiguredStatement;
+import io.confluent.ksql.util.KsqlConfig;
+import io.confluent.ksql.util.KsqlException;
+import io.confluent.ksql.util.timestamp.MetadataTimestampExtractionPolicy;
+import java.util.List;
+import java.util.Optional;
+import java.util.stream.Collectors;
+import org.apache.kafka.clients.producer.KafkaProducer;
+import org.apache.kafka.clients.producer.ProducerRecord;
+import org.apache.kafka.common.errors.SerializationException;
+import org.apache.kafka.common.serialization.Serde;
+import org.apache.kafka.common.serialization.Serializer;
+import org.apache.kafka.connect.data.Field;
+import org.apache.kafka.connect.data.Schema;
+import org.apache.kafka.connect.data.SchemaBuilder;
+import org.apache.kafka.streams.KafkaClientSupplier;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnitRunner;
+
+@RunWith(MockitoJUnitRunner.class)
+public class InsertValuesExecutorTest {
+
+  private static final Schema SCHEMA = SchemaBuilder.struct()
+      .field("ROWTIME", Schema.OPTIONAL_INT64_SCHEMA)
+      .field("ROWKEY", Schema.OPTIONAL_INT64_SCHEMA)
+      .field("COL0", Schema.OPTIONAL_INT64_SCHEMA)
+      .field("COL1", Schema.OPTIONAL_STRING_SCHEMA)
+      .build();
+
+  private static final Schema STRICT_SCHEMA = SchemaBuilder.struct()
+      .field("ROWTIME", Schema.INT64_SCHEMA)
+      .field("ROWKEY", Schema.INT64_SCHEMA)
+      .field("COL0", Schema.OPTIONAL_INT64_SCHEMA)
+      .field("COL1", Schema.STRING_SCHEMA)
+      .build();
+
+  private static final Schema BIG_SCHEMA = SchemaBuilder.struct()
+      .field("ROWTIME", Schema.OPTIONAL_INT64_SCHEMA)
+      .field("ROWKEY", Schema.OPTIONAL_INT64_SCHEMA)
+      .field("INT", Schema.OPTIONAL_INT32_SCHEMA)
+      .field("COL0", Schema.OPTIONAL_INT64_SCHEMA) // named COL0 for auto-ROWKEY
+      .field("DOUBLE", Schema.OPTIONAL_FLOAT64_SCHEMA)
+      .field("BOOLEAN", Schema.OPTIONAL_BOOLEAN_SCHEMA)
+      .field("VARCHAR", Schema.OPTIONAL_STRING_SCHEMA)
+      .build();
+
+  private static final byte[] KEY = new byte[]{1};
+  private static final byte[] VALUE = new byte[]{2};
+
+  private static final String TOPIC_NAME = "topic";
+
+  @Rule
+  public final ExpectedException expectedException = ExpectedException.none();
+
+  @Mock
+  private KsqlEngine engine;
+  @Mock
+  private KsqlTopicSerDe topicSerDe;
+  @Mock
+  private Serde<String> keySerDe;
+  @Mock
+  private Serializer<String> keySerializer;
+  @Mock
+  private Serde<GenericRow> rowSerDe;
+  @Mock
+  private Serializer<GenericRow> rowSerializer;
+  @Mock
+  private ServiceContext serviceContext;
+  @Mock
+  private KafkaProducer<byte[], byte[]> producer;
+
+  @Before
+  public void setup() {
+    when(topicSerDe.getGenericRowSerde(any(), any(), any(), any(), any())).thenReturn(rowSerDe);
+
+    when(keySerDe.serializer()).thenReturn(keySerializer);
+    when(rowSerDe.serializer()).thenReturn(rowSerializer);
+
+    when(keySerializer.serialize(any(), any())).thenReturn(KEY);
+    when(rowSerializer.serialize(any(), any())).thenReturn(VALUE);
+
+    final KafkaClientSupplier kafkaClientSupplier = mock(KafkaClientSupplier.class);
+    when(kafkaClientSupplier.getProducer(any())).thenReturn(producer);
+
+    when(serviceContext.getKafkaClientSupplier()).thenReturn(kafkaClientSupplier);
+
+    givenDataSourceWithSchema(SCHEMA);
+  }
+
+  @Test
+  public void shouldHandleFullRow() {
+    // Given:
+    final ConfiguredStatement<InsertValues> statement = givenInsertValues(
+        SCHEMA.fields().stream().map(Field::name).collect(Collectors.toList()),
+        ImmutableList.of(
+            new LongLiteral(1L),
+            new LongLiteral(2L),
+            new LongLiteral(2L),
+            new StringLiteral("str"))
+    );
+
+    // When:
+    new InsertValuesExecutor(() -> -1L).execute(statement, engine, serviceContext);
+
+    // Then:
+    verify(rowSerializer).serialize(TOPIC_NAME, new GenericRow(1L, 2L, 2L, "str"));
+    verify(producer).send(new ProducerRecord<>(TOPIC_NAME, null, 1L, KEY, VALUE));
+  }
+
+  @Test
+  public void shouldFillInRowtime() {
+    // Given:
+    final ConfiguredStatement<InsertValues> statement = givenInsertValues(
+        ImmutableList.of("ROWKEY", "COL0", "COL1"),
+        ImmutableList.of(
+            new LongLiteral(2L),
+            new LongLiteral(2L),
+            new StringLiteral("str"))
+    );
+
+    // When:
+    new InsertValuesExecutor(() -> 1L).execute(statement, engine, serviceContext);
+
+    // Then:
+    verify(rowSerializer).serialize(TOPIC_NAME, new GenericRow(1L, 2L, 2L, "str"));
+    verify(producer).send(new ProducerRecord<>(TOPIC_NAME, null, 1L, KEY, VALUE));
+  }
+
+  @Test
+  public void shouldFillInRowKeyFromSpecifiedKey() {
+    // Given:
+    final ConfiguredStatement<InsertValues> statement = givenInsertValues(
+        ImmutableList.of("COL0", "COL1"),
+        ImmutableList.of(
+            new LongLiteral(2L),
+            new StringLiteral("str"))
+    );
+
+    // When:
+    new InsertValuesExecutor(() -> 1L).execute(statement, engine, serviceContext);
+
+    // Then:
+    verify(rowSerializer).serialize(TOPIC_NAME, new GenericRow(1L, 2L, 2L, "str"));
+    verify(producer).send(new ProducerRecord<>(TOPIC_NAME, null, 1L, KEY, VALUE));
+  }
+
+  @Test
+  public void shouldFillInFullRowWithNoSchema() {
+    // Given:
+    final ConfiguredStatement<InsertValues> statement = givenInsertValues(
+        ImmutableList.of(),
+        ImmutableList.of(
+            new LongLiteral(2L),
+            new LongLiteral(2L),
+            new StringLiteral("str"))
+    );
+
+    // When:
+    new InsertValuesExecutor(() -> 1L).execute(statement, engine, serviceContext);
+
+    // Then:
+    verify(rowSerializer).serialize(TOPIC_NAME, new GenericRow(1L, 2L, 2L, "str"));
+    verify(producer).send(new ProducerRecord<>(TOPIC_NAME, null, 1L, KEY, VALUE));
+  }
+
+  @Test
+  public void shouldFillInMissingColumnsWithNulls() {
+    // Given:
+    final ConfiguredStatement<InsertValues> statement = givenInsertValues(
+        ImmutableList.of("ROWKEY", "COL0"),
+        ImmutableList.of(
+            new LongLiteral(2L),
+            new LongLiteral(2L))
+    );
+
+    // When:
+    new InsertValuesExecutor(() -> 1L).execute(statement, engine, serviceContext);
+
+    // Then:
+    verify(rowSerializer).serialize(TOPIC_NAME, new GenericRow(1L, 2L, 2L, null));
+    verify(producer).send(new ProducerRecord<>(TOPIC_NAME, null, 1L, KEY, VALUE));
+  }
+
+  @Test
+  public void shouldFillInKeyFromRowKey() {
+    // Given:
+    final ConfiguredStatement<InsertValues> statement = givenInsertValues(
+        ImmutableList.of("ROWKEY", "COL1"),
+        ImmutableList.of(
+            new LongLiteral(2L),
+            new StringLiteral("str"))
+    );
+
+    // When:
+    new InsertValuesExecutor(() -> 1L).execute(statement, engine, serviceContext);
+
+    // Then:
+    verify(rowSerializer).serialize(TOPIC_NAME, new GenericRow(1L, 2L, 2L, "str"));
+    verify(producer).send(new ProducerRecord<>(TOPIC_NAME, null, 1L, KEY, VALUE));
+  }
+
+  @Test
+  public void shouldHandleOutOfOrderSchema() {
+    // Given:
+    final ConfiguredStatement<InsertValues> statement = givenInsertValues(
+        ImmutableList.of("COL1", "COL0"),
+        ImmutableList.of(
+            new StringLiteral("str"),
+            new LongLiteral(2L))
+    );
+
+    // When:
+    new InsertValuesExecutor(() -> 1L).execute(statement, engine, serviceContext);
+
+    // Then:
+    verify(rowSerializer).serialize(TOPIC_NAME, new GenericRow(1L, 2L, 2L, "str"));
+    verify(producer).send(new ProducerRecord<>(TOPIC_NAME, null, 1L, KEY, VALUE));
+  }
+
+  @Test
+  public void shouldHandleAllSortsOfLiterals() {
+    // Given:
+    final ConfiguredStatement<InsertValues> statement = givenInsertValues(
+        ImmutableList.of("COL1", "COL0"),
+        ImmutableList.of(
+            new StringLiteral("str"),
+            new LongLiteral(2L))
+    );
+
+    // When:
+    new InsertValuesExecutor(() -> 1L).execute(statement, engine, serviceContext);
+
+    // Then:
+    verify(rowSerializer).serialize(TOPIC_NAME, new GenericRow(1L, 2L, 2L, "str"));
+    verify(producer).send(new ProducerRecord<>(TOPIC_NAME, null, 1L, KEY, VALUE));
+  }
+
+  @Test
+  public void shouldHandleNullKey() {
+    // Given:
+    givenDataSourceWithSchema(BIG_SCHEMA);
+    final ConfiguredStatement<InsertValues> statement = givenInsertValues(
+        BIG_SCHEMA.fields().stream().map(Field::name).collect(Collectors.toList()),
+        ImmutableList.of(
+            new LongLiteral(1L),
+            new LongLiteral(2L),
+            new IntegerLiteral(0),
+            new LongLiteral(2),
+            new DoubleLiteral("3.0"),
+            new BooleanLiteral("TRUE"),
+            new StringLiteral("str"))
+    );
+
+    // When:
+    new InsertValuesExecutor(() -> 1L).execute(statement, engine, serviceContext);
+
+    // Then:
+    verify(rowSerializer).serialize(TOPIC_NAME, new GenericRow(1L, 2L, 0, 2L, 3.0, true, "str"));
+    verify(producer).send(new ProducerRecord<>(TOPIC_NAME, null, 1L, KEY, VALUE));
+  }
+
+  @Test
+  public void shouldThrowOnSerializingKeyError() {
+    // Given:
+    final ConfiguredStatement<InsertValues> statement = givenInsertValues(
+        SCHEMA.fields().stream().map(Field::name).collect(Collectors.toList()),
+        ImmutableList.of(
+            new LongLiteral(1L),
+            new LongLiteral(2L),
+            new LongLiteral(2L),
+            new StringLiteral("str"))
+    );
+    when(keySerializer.serialize(any(), any())).thenThrow(new SerializationException("Jibberish!"));
+
+    // Expect:
+    expectedException.expect(KsqlException.class);
+    expectedException.expectMessage("Could not serialize key");
+
+    // When:
+    new InsertValuesExecutor(() -> -1L).execute(statement, engine, serviceContext);
+  }
+
+  @Test
+  public void shouldThrowOnSerializingValueError() {
+    // Given:
+    final ConfiguredStatement<InsertValues> statement = givenInsertValues(
+        SCHEMA.fields().stream().map(Field::name).collect(Collectors.toList()),
+        ImmutableList.of(
+            new LongLiteral(1L),
+            new LongLiteral(2L),
+            new LongLiteral(2L),
+            new StringLiteral("str"))
+    );
+    when(rowSerializer.serialize(any(), any())).thenThrow(new SerializationException("Jibberish!"));
+
+    // Expect:
+    expectedException.expect(KsqlException.class);
+    expectedException.expectMessage("Could not serialize row");
+
+    // When:
+    new InsertValuesExecutor(() -> -1L).execute(statement, engine, serviceContext);
+  }
+
+  @Test
+  public void shouldThrowIfRowKeyAndKeyDoNotMatch() {
+    // Given:
+    final ConfiguredStatement<InsertValues> statement = givenInsertValues(
+        ImmutableList.of("ROWKEY", "COL0"),
+        ImmutableList.of(
+            new LongLiteral(1L),
+            new LongLiteral(2L))
+    );
+
+    // Expect:
+    expectedException.expect(KsqlException.class);
+    expectedException.expectMessage("Expected ROWKEY and COL0 to match");
+
+    // When:
+    new InsertValuesExecutor(() -> 1L).execute(statement, engine, serviceContext);
+  }
+
+  @Test
+  public void shouldThrowIfNotEnoughValuesSuppliedWithNoSchema() {
+    // Given:
+    final ConfiguredStatement<InsertValues> statement = givenInsertValues(
+        ImmutableList.of(),
+        ImmutableList.of(
+            new LongLiteral(1L))
+    );
+
+    // Expect:
+    expectedException.expect(KsqlException.class);
+    expectedException.expectMessage("Expected a value for each column");
+
+    // When:
+    new InsertValuesExecutor(() -> 1L).execute(statement, engine, serviceContext);
+  }
+
+  @Test
+  public void shouldThrowIfNullForStrictSchema() {
+    // Given:
+    givenDataSourceWithSchema(STRICT_SCHEMA);
+
+    final ConfiguredStatement<InsertValues> statement = givenInsertValues(
+        ImmutableList.of("ROWKEY"),
+        ImmutableList.of(
+            new NullLiteral()
+        )
+    );
+
+    // Expect:
+    expectedException.expect(KsqlException.class);
+    expectedException.expectMessage("Got null value for nonnull field: ");
+
+    // When:
+    new InsertValuesExecutor(() -> 1L).execute(statement, engine, serviceContext);
+  }
+
+  @Test
+  public void shouldThrowIfNullForStrictSchemaForNonExplicitFields() {
+    // Given:
+    givenDataSourceWithSchema(STRICT_SCHEMA);
+
+    final ConfiguredStatement<InsertValues> statement = givenInsertValues(
+        ImmutableList.of("ROWKEY"),
+        ImmutableList.of(
+            new LongLiteral(123)
+        )
+    );
+
+    // Expect:
+    expectedException.expect(KsqlException.class);
+    expectedException.expectMessage("Got null value for nonnull field: ");
+
+    // When:
+    new InsertValuesExecutor(() -> 1L).execute(statement, engine, serviceContext);
+  }
+
+  @Test
+  public void shouldThrowIfNonLiteral() {
+    // Given:
+    givenDataSourceWithSchema(STRICT_SCHEMA);
+
+    final ConfiguredStatement<InsertValues> statement = givenInsertValues(
+        ImmutableList.of("ROWKEY"),
+        ImmutableList.of(
+            Struct.builder().addField("foo", PrimitiveType.of(SqlType.BIGINT)).build()
+        )
+    );
+
+    // Expect:
+    expectedException.expect(KsqlException.class);
+    expectedException.expectMessage(
+        "Only Literals are supported for INSERT INTO. Got: STRUCT<foo BIGINT> for field ROWKEY");
+
+    // When:
+    new InsertValuesExecutor(() -> 1L).execute(statement, engine, serviceContext);
+  }
+
+  @Test
+  public void shouldThrowIfIncompatibleTypes() {
+    // Given:
+    givenDataSourceWithSchema(STRICT_SCHEMA);
+
+    final ConfiguredStatement<InsertValues> statement = givenInsertValues(
+        ImmutableList.of("ROWKEY"),
+        ImmutableList.of(
+            new StringLiteral("1.1")
+        )
+    );
+
+    // Expect:
+    expectedException.expect(KsqlException.class);
+    expectedException.expectMessage("Expected type INT64 for field");
+
+    // When:
+    new InsertValuesExecutor(() -> 1L).execute(statement, engine, serviceContext);
+  }
+
+  private ConfiguredStatement<InsertValues> givenInsertValues(
+      final List<String> columns,
+      final List<Expression> values
+  ) {
+    return ConfiguredStatement.of(
+        PreparedStatement.of(
+            "",
+            new InsertValues(QualifiedName.of("TOPIC"), columns, values)),
+        ImmutableMap.of(),
+        new KsqlConfig(ImmutableMap.of())
+    );
+  }
+
+  private void givenDataSourceWithSchema(final Schema schema) {
+    final KsqlTopic topic = new KsqlTopic("TOPIC", TOPIC_NAME, topicSerDe, false);
+    final DataSource<?> dataSource = new KsqlStream<>(
+        "",
+        "TOPIC",
+        schema,
+        KeyField.of(Optional.of("COL0"), Optional.of(schema.field("COL0"))),
+        new MetadataTimestampExtractionPolicy(),
+        topic,
+        () -> keySerDe
+    );
+
+    final MetaStoreImpl metaStore = new MetaStoreImpl(TestFunctionRegistry.INSTANCE.get());
+    metaStore.putSource(dataSource);
+
+    when(engine.getMetaStore()).thenReturn(metaStore);
+  }
+
+}


### PR DESCRIPTION
### Progression 
This is the first of a few PRs that implement #2693 (Insert Values), which is split across the following 4 PRs:

1. **Introduce syntax and basic functionality for insert values**
2. Introduce new semantics for `CREATE STREAM`/`CREATE TABLE`
3. Documentation PR (leaving for the end so that nobody uses it until it is more complete)

If those 3 PRs are done before 5.3, we can add more functionality (like non-literal support for `INSERT VALUES`)

### Description

This PR contains the following changes:
- `INSERT INTO ... VALUES` syntax in `SqlBase.g4` and corresponding parsing/formatting code
- `InsertValuesExecutor` to produce data into the underlying topics
- Some helpful methods in `SchemaUtil`

### Testing done 
- Unit testing

Local Testing:
```sql
ksql> SELECT * FROM PAGEVIEWS;
1556037848196 | 1 | Page_23 | 1556037847931 | User_9
^CQuery terminated

ksql> INSERT INTO PAGEVIEWS VALUES ('1', 'Page_19', 123, 'Almog');

ksql> INSERT INTO PAGEVIEWS (ROWKEY, USERID) VALUES ('2', 'Almog');

ksql> INSERT INTO PAGEVIEWS (ROWKEY) VALUES ('2', 'Almog');
Failed to prepare statement: Expected number columns and values to match: [ROWKEY], ['2', 'Almog']

ksql> INSERT INTO PAGEVIEWS VALUES ('2', 'Almog');
Expected a value for each column. Expected Columns: [ROWKEY, PAGEID, VIEWTIME, USERID]. Got ['2', 'Almog']

ksql> SELECT * FROM PAGEVIEWS;
1556037848196 | 1 | Page_23 | 1556037847931 | User_9
1556038380373 | 1 | Page_19 | 123 | Almog
1556038448271 | 2 | null | null | Almog
^CQuery terminated
```

### Reviewer checklist
- [ ] Ensure docs are updated if necessary. (eg. if a user visible feature is being added or changed).
- [ ] Ensure relevant issues are linked (description should include text like "Fixes #<issue number>")

