### PR TITLE
Remove the need for a builder in `KsqlStructuredDataOutputNode`

### DIFF
--- a/ksql-engine/src/main/java/io/confluent/ksql/physical/PhysicalPlanBuilder.java
+++ b/ksql-engine/src/main/java/io/confluent/ksql/physical/PhysicalPlanBuilder.java
@@ -283,7 +283,7 @@ public class PhysicalPlanBuilder {
     return new PersistentQueryMetadata(
         sqlExpression,
         streams,
-        outputNode.getSchema(),
+        sinkSchema,
         getSourceNames(outputNode),
         sinkDataSource.getName(),
         schemaKStream.getExecutionPlan(""),

--- a/ksql-engine/src/main/java/io/confluent/ksql/planner/LogicalPlanner.java
+++ b/ksql-engine/src/main/java/io/confluent/ksql/planner/LogicalPlanner.java
@@ -211,7 +211,7 @@ public class LogicalPlanner {
     return new ProjectNode(
         new PlanNodeId("Project"),
         sourcePlanNode,
-        projectionSchema,
+        projectionSchema.build(),
         keyFieldName,
         analysis.getSelectExpressions()
     );

--- a/ksql-engine/src/main/java/io/confluent/ksql/planner/plan/KsqlStructuredDataOutputNode.java
+++ b/ksql-engine/src/main/java/io/confluent/ksql/planner/plan/KsqlStructuredDataOutputNode.java
@@ -114,12 +114,10 @@ public class KsqlStructuredDataOutputNode extends OutputNode {
     final QueryContext.Stacker contextStacker = builder.buildNodeContext(getId());
 
     final Set<Integer> rowkeyIndexes = SchemaUtil.getRowTimeRowKeyIndexes(getSchema());
-    final Builder outputNodeBuilder = new Builder(this);
     final Schema schema = SchemaUtil.removeImplicitRowTimeRowKeyFromSchema(getSchema());
 
     final SchemaKStream<?> result = createOutputStream(
         schemaKStream,
-        outputNodeBuilder,
         builder.getKsqlConfig(),
         builder.getFunctionRegistry(),
         contextStacker
@@ -139,14 +137,13 @@ public class KsqlStructuredDataOutputNode extends OutputNode {
         rowkeyIndexes
     );
 
-    result.setOutputNode(outputNodeBuilder.build());
+    result.setOutputNode(this);
     return result;
   }
 
   @SuppressWarnings("unchecked")
   private SchemaKStream<?> createOutputStream(
       final SchemaKStream schemaKStream,
-      final KsqlStructuredDataOutputNode.Builder outputNodeBuilder,
       final KsqlConfig ksqlConfig,
       final FunctionRegistry functionRegistry,
       final QueryContext.Stacker contextStacker
@@ -179,7 +176,6 @@ public class KsqlStructuredDataOutputNode extends OutputNode {
     }
 
     final Field field = partitionByField.get();
-    outputNodeBuilder.withKeyFields(Optional.of(field.name()), Optional.of(field));
     return result.selectKey(field, false, contextStacker);
   }
 
@@ -195,38 +191,5 @@ public class KsqlStructuredDataOutputNode extends OutputNode {
 
   public KsqlTopic getKsqlTopic() {
     return ksqlTopic;
-  }
-
-  public static class Builder {
-
-    private final KsqlStructuredDataOutputNode original;
-    private KeyField keyField;
-
-    Builder(final KsqlStructuredDataOutputNode original) {
-      this.original = Objects.requireNonNull(original, "original");
-      this.keyField = original.keyField;
-    }
-
-    public KsqlStructuredDataOutputNode build() {
-      return new KsqlStructuredDataOutputNode(
-          original.getId(),
-          original.getSource(),
-          original.getSchema(),
-          original.getTimestampExtractionPolicy(),
-          keyField,
-          original.ksqlTopic,
-          original.kafkaTopicName,
-          original.outputProperties,
-          original.getLimit(),
-          original.isDoCreateInto());
-    }
-
-    Builder withKeyFields(
-        final Optional<String> keyFieldName,
-        final Optional<Field> legacyKeyField
-    ) {
-      this.keyField = KeyField.of(keyFieldName, legacyKeyField);
-      return this;
-    }
   }
 }

--- a/ksql-engine/src/test/java/io/confluent/ksql/planner/plan/KsqlStructuredDataOutputNodeTest.java
+++ b/ksql-engine/src/test/java/io/confluent/ksql/planner/plan/KsqlStructuredDataOutputNodeTest.java
@@ -252,13 +252,11 @@ public class KsqlStructuredDataOutputNodeTest {
 
     // Then:
     final List<Field> expected = Arrays.asList(
-        new Field("ROWTIME", 0, Schema.OPTIONAL_INT64_SCHEMA),
-        new Field("ROWKEY", 1, Schema.OPTIONAL_STRING_SCHEMA),
-        new Field("field1", 2, Schema.OPTIONAL_STRING_SCHEMA),
-        new Field("field2", 3, Schema.OPTIONAL_STRING_SCHEMA),
-        new Field("field3", 4, Schema.OPTIONAL_STRING_SCHEMA),
-        new Field("timestamp", 5, Schema.OPTIONAL_INT64_SCHEMA),
-        new Field("key", 6, Schema.OPTIONAL_STRING_SCHEMA));
+        new Field("field1", 0, Schema.OPTIONAL_STRING_SCHEMA),
+        new Field("field2", 1, Schema.OPTIONAL_STRING_SCHEMA),
+        new Field("field3", 2, Schema.OPTIONAL_STRING_SCHEMA),
+        new Field("timestamp", 3, Schema.OPTIONAL_INT64_SCHEMA),
+        new Field("key", 4, Schema.OPTIONAL_STRING_SCHEMA));
     final List<Field> fields = stream.outputNode().getSchema().fields();
     assertThat(fields, equalTo(expected));
   }

--- a/ksql-metastore/src/main/java/io/confluent/ksql/metastore/model/KeyField.java
+++ b/ksql-metastore/src/main/java/io/confluent/ksql/metastore/model/KeyField.java
@@ -79,10 +79,6 @@ public final class KeyField {
    * @throws IllegalArgumentException if the key is not within the supplied schema.
    */
   public KeyField validateKeyExistsIn(final Schema schema) {
-    if (keyField.isPresent() && keyField.get().equalsIgnoreCase(SchemaUtil.ROWKEY_NAME)) {
-      return this;
-    }
-
     resolveKey(schema);
     return this;
   }

--- a/ksql-metastore/src/test/java/io/confluent/ksql/metastore/model/KeyFieldTest.java
+++ b/ksql-metastore/src/test/java/io/confluent/ksql/metastore/model/KeyFieldTest.java
@@ -106,17 +106,6 @@ public class KeyFieldTest {
   }
 
   @Test
-  public void shouldNotThrowOnValidateIfKeyIsRowKey() {
-    // Given:
-    final KeyField keyField = KeyField.of(Optional.of("ROWKEY"), Optional.empty());
-
-    // When:
-    keyField.validateKeyExistsIn(SCHEMA);
-
-    // Then: did not throw.
-  }
-
-  @Test
   public void shouldThrowOnValidateIfKeyNotInSchema() {
     // Given:
     final KeyField keyField = KeyField.of(Optional.of("????"), Optional.empty());


### PR DESCRIPTION
### Description 

In the current code the `LogicalPlanner` creates an immutable `KsqlStructuredDataOutputNode` when building persistent queries. When the `PhysicalPlanBuilder` calls `buildStream` on the node it uses a builder to create another copy of itself and tweak its parameters, creating a slightly different `KsqlStructuredDataOutputNode` to associate with the return value.

No other node follows this pattern. This complicates both `KsqlStructuredDataOutputNode` and other parts of the code. So... this PR does away with the builder from `KsqlStructuredDataOutputNode`.

### Testing done 
Added unit tests to ensure the schema doesn't change in the resulting `QueryMetadata`.

### Reviewer checklist
- [ ] Ensure docs are updated if necessary. (eg. if a user visible feature is being added or changed).
- [ ] Ensure relevant issues are linked (description should include text like "Fixes #<issue number>")

