### PR TITLE
fixes #2726 Setting prefixed properties through CLI breaks future req…

### DIFF
--- a/ksql-cli/src/test/java/io/confluent/ksql/cli/CliTest.java
+++ b/ksql-cli/src/test/java/io/confluent/ksql/cli/CliTest.java
@@ -469,6 +469,16 @@ public class CliTest {
   }
 
   @Test
+  public void testPrefixedPropertySet() {
+    assertRunCommand("set 'ksql.streams.auto.offset.reset' = 'latest'", is(EMPTY_RESULT));
+
+
+    final TestResult.Builder builder = new TestResult.Builder();
+    builder.addRows(startUpConfigs());
+    assertRunListCommand("properties", hasItems(builder.build()));
+  }
+
+  @Test
   public void testDescribe() {
     assertRunCommand("describe topic " + COMMANDS_KSQL_TOPIC_NAME,
         contains(new TestResult(COMMANDS_KSQL_TOPIC_NAME, commandTopicName, "JSON")));

--- a/ksql-rest-app/src/main/java/io/confluent/ksql/rest/client/properties/LocalPropertyValidator.java
+++ b/ksql-rest-app/src/main/java/io/confluent/ksql/rest/client/properties/LocalPropertyValidator.java
@@ -37,6 +37,7 @@ public class LocalPropertyValidator implements PropertyValidator {
       .add(KsqlConfig.SINK_WINDOW_CHANGE_LOG_ADDITIONAL_RETENTION_MS_PROPERTY)
       .add(StreamsConfig.COMMIT_INTERVAL_MS_CONFIG)
       .add(ConsumerConfig.AUTO_OFFSET_RESET_CONFIG)
+      .add(KsqlConfig.KSQL_STREAMS_PREFIX.concat(ConsumerConfig.AUTO_OFFSET_RESET_CONFIG))
       .add(KsqlConstants.LEGACY_RUN_SCRIPT_STATEMENTS_CONTENT)
       .add(ConsumerConfig.GROUP_ID_CONFIG)
       .build();


### PR DESCRIPTION
…uests

### Description 

Fixes #2726 Setting prefixed properties through CLI breaks future requests

### Testing done 
Unit test has been add  
https://github.com/ouertani/ksql/blob/539bcee1ab30e631de341d1da9475fa37a1245de/ksql-cli/src/test/java/io/confluent/ksql/cli/CliTest.java#L471

### Reviewer checklist
- [ ] Ensure docs are updated if necessary. (eg. if a user visible feature is being added or changed).
- [X] Ensure relevant issues are linked (description should include text like "Fixes #<issue number>")

