### PR TITLE
fixes #2640 CTRL+C sometimes throws a JsonEOFException from the CLI

### DIFF
--- a/ksql-rest-app/src/main/java/io/confluent/ksql/rest/client/KsqlRestClient.java
+++ b/ksql-rest-app/src/main/java/io/confluent/ksql/rest/client/KsqlRestClient.java
@@ -376,6 +376,9 @@ public class KsqlRestClient implements Closeable {
             try {
               bufferedRow = objectMapper.readValue(responseLine, StreamedRow.class);
             } catch (final IOException exception) {
+              if (closed) {
+                return false;
+              }
               throw new RuntimeException(exception);
             }
             return true;

--- a/pom.xml
+++ b/pom.xml
@@ -97,7 +97,7 @@
         <guava.version>24.0-jre</guava.version>
         <inject.version>1</inject.version>
         <janino.version>3.0.7</janino.version>
-        <jline.version>3.9.0</jline.version>
+        <jline.version>3.11.0</jline.version>
         <jna.version>4.4.0</jna.version>
         <jsr305.version>3.0.2</jsr305.version>
         <maven.plugins.version>3.0.0-M1</maven.plugins.version>


### PR DESCRIPTION
### Description 
Fixes #2640 CTRL+C sometimes throws a JsonEOFException from the CLI
Refer to : https://github.com/confluentinc/ksql/pull/2717

### Testing done 
I add some exception.printStackTrace()
https://github.com/confluentinc/ksql/blob/589a0817b99cabaf1af79ac64c93f98332ea0786/ksql-rest-app/src/main/java/io/confluent/ksql/rest/client/KsqlRestClient.java#L379


### Reviewer checklist
- [ ] Ensure docs are updated if necessary. (eg. if a user visible feature is being added or changed).
- [ ] Ensure relevant issues are linked (description should include text like "Fixes #<issue number>")

