### PR TITLE
 Revert "MINOR: fix the KSQL build (#2737)" 

### DIFF
--- a/ksql-engine/src/main/java/io/confluent/ksql/services/SandboxedAdminClient.java
+++ b/ksql-engine/src/main/java/io/confluent/ksql/services/SandboxedAdminClient.java
@@ -19,7 +19,6 @@ import java.time.Duration;
 import java.util.Collection;
 import java.util.Map;
 import org.apache.kafka.clients.admin.AdminClient;
-import org.apache.kafka.clients.admin.AlterConfigOp;
 import org.apache.kafka.clients.admin.AlterConfigsOptions;
 import org.apache.kafka.clients.admin.AlterConfigsResult;
 import org.apache.kafka.clients.admin.AlterReplicaLogDirsOptions;
@@ -164,14 +163,6 @@ class SandboxedAdminClient extends AdminClient {
     throw new UnsupportedOperationException();
   }
 
-  @Override
-  public AlterConfigsResult incrementalAlterConfigs(
-      final Map<ConfigResource, Collection<AlterConfigOp>> configs,
-      final AlterConfigsOptions options) {
-    throw new UnsupportedOperationException();
-  }
-
-  @SuppressWarnings("deprecation")
   @Override
   public AlterConfigsResult alterConfigs(
       final Map<ConfigResource, Config> configs,

--- a/ksql-engine/src/test/java/io/confluent/ksql/services/KafkaTopicClientImplTest.java
+++ b/ksql-engine/src/test/java/io/confluent/ksql/services/KafkaTopicClientImplTest.java
@@ -357,7 +357,6 @@ public class KafkaTopicClientImplTest {
     verify(adminClient);
   }
 
-  @SuppressWarnings("deprecation")
   @Test
   public void shouldAddTopicConfig() {
     final Map<String, ?> overrides = ImmutableMap.of(
@@ -407,7 +406,6 @@ public class KafkaTopicClientImplTest {
     verify(adminClient);
   }
 
-  @SuppressWarnings("deprecation")
   @Test
   public void shouldRetryAddingTopicConfig() {
     final Map<String, ?> overrides = ImmutableMap.of(


### PR DESCRIPTION
This reverts commit 3c35c2a.

### Description 
There's an issue where the repo holding kafka snapshots is not up to date, which causes the code to not compile with #2737.

### Testing done 
- Local build

### Reviewer checklist
- [ ] Ensure docs are updated if necessary. (eg. if a user visible feature is being added or changed).
- [ ] Ensure relevant issues are linked (description should include text like "Fixes #<issue number>")

