### PR TITLE
support udf imports with no package (fixes #2721 targets 5.2.x)

### DIFF
--- a/ksql-engine/src/main/java/io/confluent/ksql/function/UdfCompiler.java
+++ b/ksql-engine/src/main/java/io/confluent/ksql/function/UdfCompiler.java
@@ -15,6 +15,7 @@
 
 package io.confluent.ksql.function;
 
+import com.google.common.annotations.VisibleForTesting;
 import com.google.common.collect.ImmutableSet;
 import io.confluent.ksql.function.udaf.TableUdaf;
 import io.confluent.ksql.function.udaf.Udaf;
@@ -82,7 +83,8 @@ public class UdfCompiler {
     this.metrics = Objects.requireNonNull(metrics, "metrics can't be null");
   }
 
-  UdfInvoker compile(final Method method, final ClassLoader loader) {
+  @VisibleForTesting
+  public UdfInvoker compile(final Method method, final ClassLoader loader) {
     try {
       final IScriptEvaluator scriptEvaluator = createScriptEvaluator(method,
           loader,

--- a/ksql-engine/src/main/java/io/confluent/ksql/function/UdfTemplate.java
+++ b/ksql-engine/src/main/java/io/confluent/ksql/function/UdfTemplate.java
@@ -49,8 +49,10 @@ public final class UdfTemplate {
         .mapToObj(i -> "arg" + i)
         .collect(Collectors.joining(", "));
 
-    code.addStatement("return (($T) $L).$L($L)",
-                      method.getDeclaringClass(), obj, method.getName(), args);
+    // use the canonical name instead of relying on $T because there is a bug
+    // in javapoet when trying to compile using the default package
+    code.addStatement("return (($L) $L).$L($L)",
+        method.getDeclaringClass().getCanonicalName(), obj, method.getName(), args);
 
     final String codeString = code.build().toString();
     LOG.trace("Generated code:\n" + codeString);

--- a/ksql-engine/src/main/java/io/confluent/ksql/function/UdfTemplate.java
+++ b/ksql-engine/src/main/java/io/confluent/ksql/function/UdfTemplate.java
@@ -49,8 +49,6 @@ public final class UdfTemplate {
         .mapToObj(i -> "arg" + i)
         .collect(Collectors.joining(", "));
 
-    // use the canonical name instead of relying on $T because there is a bug
-    // in javapoet when trying to compile using the default package
     code.addStatement("return (($L) $L).$L($L)",
         method.getDeclaringClass().getCanonicalName(), obj, method.getName(), args);
 

--- a/ksql-engine/src/test/java/TestUdfWithNoPackage.java
+++ b/ksql-engine/src/test/java/TestUdfWithNoPackage.java
@@ -19,14 +19,24 @@ import static org.hamcrest.CoreMatchers.is;
 import io.confluent.ksql.function.UdfCompiler;
 import io.confluent.ksql.function.UdfInvoker;
 import java.util.Optional;
+import org.junit.Before;
+import org.junit.BeforeClass;
 import org.junit.Test;
 
 public class TestUdfWithNoPackage {
 
   private final UdfCompiler udfCompiler = new UdfCompiler(Optional.empty());
 
+  @BeforeClass
+  public static void ensureTestHasNoPackage() {
+    // guard against someone accidentally refactoring and moving this test
+    // into a non-empty package
+    assertThat(TestUdfWithNoPackage.class.getPackage().getName(), is(""));
+  }
+
   @Test
   public void shouldCompileMethodsWithNoPackage() throws Exception {
+    // motivated by https://github.com/square/javapoet/pull/723
     final UdfInvoker udf = udfCompiler
         .compile(getClass().getMethod("udf"), this.getClass().getClassLoader());
 

--- a/ksql-engine/src/test/java/TestUdfWithNoPackage.java
+++ b/ksql-engine/src/test/java/TestUdfWithNoPackage.java
@@ -14,31 +14,34 @@
  */
 
 import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.CoreMatchers.nullValue;
 import static org.hamcrest.MatcherAssert.assertThat;
 
 import io.confluent.ksql.function.UdfCompiler;
 import io.confluent.ksql.function.UdfInvoker;
 import java.util.Optional;
-import org.junit.BeforeClass;
 import org.junit.Test;
 
 public class TestUdfWithNoPackage {
 
   private final UdfCompiler udfCompiler = new UdfCompiler(Optional.empty());
 
-  @BeforeClass
-  public static void ensureTestHasNoPackage() throws ClassNotFoundException {
-    // guard against someone accidentally refactoring and moving this test
-    // into a non-empty package
-    assertThat(Class.forName("TestUdfWithNoPackage").getPackage().getName(), is(""));
-  }
-
   @Test
   public void shouldCompileMethodsWithNoPackage() throws Exception {
+    // Given:
+    double version = Double.parseDouble(System.getProperty("java.specification.version"));
+    if (version < 1.9) {
+      assertThat(this.getClass().getPackage(), nullValue());
+    } else {
+      assertThat(this.getClass().getPackage().getName(), is(""));
+    }
+
+    // When:
     // motivated by https://github.com/square/javapoet/pull/723
     final UdfInvoker udf = udfCompiler
         .compile(getClass().getMethod("udf"), this.getClass().getClassLoader());
 
+    // Then:
     assertThat(udf.eval(this), is("udf"));
   }
 

--- a/ksql-engine/src/test/java/TestUdfWithNoPackage.java
+++ b/ksql-engine/src/test/java/TestUdfWithNoPackage.java
@@ -13,13 +13,12 @@
  * specific language governing permissions and limitations under the License.
  */
 
-import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.MatcherAssert.assertThat;
 
 import io.confluent.ksql.function.UdfCompiler;
 import io.confluent.ksql.function.UdfInvoker;
 import java.util.Optional;
-import org.junit.Before;
 import org.junit.BeforeClass;
 import org.junit.Test;
 
@@ -28,10 +27,10 @@ public class TestUdfWithNoPackage {
   private final UdfCompiler udfCompiler = new UdfCompiler(Optional.empty());
 
   @BeforeClass
-  public static void ensureTestHasNoPackage() {
+  public static void ensureTestHasNoPackage() throws ClassNotFoundException {
     // guard against someone accidentally refactoring and moving this test
     // into a non-empty package
-    assertThat(TestUdfWithNoPackage.class.getPackage().getName(), is(""));
+    assertThat(Class.forName("TestUdfWithNoPackage").getPackage().getName(), is(""));
   }
 
   @Test

--- a/ksql-engine/src/test/java/TestUdfWithNoPackage.java
+++ b/ksql-engine/src/test/java/TestUdfWithNoPackage.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright 2019 Confluent Inc.
+ *
+ * Licensed under the Confluent Community License (the "License"; you may not use
+ * this file except in compliance with the License. You may obtain a copy of the
+ * License at
+ *
+ * http://www.confluent.io/confluent-community-license
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.CoreMatchers.is;
+
+import io.confluent.ksql.function.UdfCompiler;
+import io.confluent.ksql.function.UdfInvoker;
+import java.util.Optional;
+import org.junit.Test;
+
+public class TestUdfWithNoPackage {
+
+  private final UdfCompiler udfCompiler = new UdfCompiler(Optional.empty());
+
+  @Test
+  public void shouldCompileMethodsWithNoPackage() throws Exception {
+    final UdfInvoker udf = udfCompiler
+        .compile(getClass().getMethod("udf"), this.getClass().getClassLoader());
+
+    assertThat(udf.eval(this), is("udf"));
+  }
+
+  public String udf() {
+    return "udf";
+  }
+
+}


### PR DESCRIPTION
### Description 
There's an issue with javapoet when it tries to resolve type names for classes in the default package (see #2721). This circumvents it by just using the canonical name directly.

NOTE: The root cause will be fixed in a future version of javapoet: https://github.com/square/javapoet/pull/723

### Testing done 
- unit testing
- ran it with a custom udf package

### Reviewer checklist
- [ ] Ensure docs are updated if necessary. (eg. if a user visible feature is being added or changed).
- [ ] Ensure relevant issues are linked (description should include text like "Fixes #<issue number>")

