### PR TITLE
Parse should fail in WITH properties aren't literals.

### DIFF
--- a/ksql-engine/src/main/java/io/confluent/ksql/ddl/commands/AbstractCreateStreamCommand.java
+++ b/ksql-engine/src/main/java/io/confluent/ksql/ddl/commands/AbstractCreateStreamCommand.java
@@ -21,7 +21,7 @@ import io.confluent.ksql.metastore.MetaStore;
 import io.confluent.ksql.metastore.SerdeFactory;
 import io.confluent.ksql.metastore.model.KeyField;
 import io.confluent.ksql.parser.tree.AbstractStreamCreateStatement;
-import io.confluent.ksql.parser.tree.Expression;
+import io.confluent.ksql.parser.tree.Literal;
 import io.confluent.ksql.parser.tree.StringLiteral;
 import io.confluent.ksql.parser.tree.TableElement;
 import io.confluent.ksql.schema.ksql.LogicalSchemas;
@@ -74,7 +74,7 @@ abstract class AbstractCreateStreamCommand implements DdlCommand {
     this.sourceName = statement.getName().getSuffix();
     this.kafkaTopicClient = kafkaTopicClient;
 
-    final Map<String, Expression> properties = statement.getProperties();
+    final Map<String, Literal> properties = statement.getProperties();
     validateWithClause(properties.keySet());
 
     if (properties.containsKey(DdlConfig.TOPIC_NAME_PROPERTY)
@@ -119,8 +119,7 @@ abstract class AbstractCreateStreamCommand implements DdlCommand {
     this.keySerdeFactory = extractKeySerde(properties);
   }
 
-  private static void checkTopicNameNotNull(final Map<String, Expression> properties) {
-    // TODO: move the check to grammar
+  private static void checkTopicNameNotNull(final Map<String, ?> properties) {
     if (properties.get(DdlConfig.TOPIC_NAME_PROPERTY) == null) {
       throw new KsqlException("Topic name should be set in WITH clause.");
     }
@@ -167,9 +166,9 @@ abstract class AbstractCreateStreamCommand implements DdlCommand {
   }
 
   private RegisterTopicCommand registerTopicFirst(
-      final Map<String, Expression> properties
+      final Map<String, Literal> properties
   ) {
-    final Expression topicNameExp = properties.get(DdlConfig.KAFKA_TOPIC_NAME_PROPERTY);
+    final Literal topicNameExp = properties.get(DdlConfig.KAFKA_TOPIC_NAME_PROPERTY);
 
     if (topicNameExp == null) {
       throw new KsqlException("Corresponding Kafka topic ("
@@ -206,7 +205,7 @@ abstract class AbstractCreateStreamCommand implements DdlCommand {
   }
 
   private static SerdeFactory<?> extractKeySerde(
-      final Map<String, Expression> properties
+      final Map<String, Literal> properties
   ) {
     final String windowType = StringUtil.cleanQuotes(properties
         .getOrDefault(DdlConfig.WINDOW_TYPE_PROPERTY, new StringLiteral(""))

--- a/ksql-engine/src/main/java/io/confluent/ksql/ddl/commands/CreateTableCommand.java
+++ b/ksql-engine/src/main/java/io/confluent/ksql/ddl/commands/CreateTableCommand.java
@@ -19,7 +19,6 @@ import io.confluent.ksql.ddl.DdlConfig;
 import io.confluent.ksql.metastore.MutableMetaStore;
 import io.confluent.ksql.metastore.model.KsqlTable;
 import io.confluent.ksql.parser.tree.CreateTable;
-import io.confluent.ksql.parser.tree.Expression;
 import io.confluent.ksql.services.KafkaTopicClient;
 import io.confluent.ksql.util.KsqlException;
 import io.confluent.ksql.util.SchemaUtil;
@@ -34,7 +33,7 @@ public class CreateTableCommand extends AbstractCreateStreamCommand {
   ) {
     super(sqlExpression, createTable, kafkaTopicClient);
 
-    final Map<String, Expression> properties = createTable.getProperties();
+    final Map<String, ?> properties = createTable.getProperties();
 
     if (!properties.containsKey(DdlConfig.KEY_NAME_PROPERTY)) {
       throw new KsqlException(

--- a/ksql-engine/src/main/java/io/confluent/ksql/schema/inference/DefaultSchemaInjector.java
+++ b/ksql-engine/src/main/java/io/confluent/ksql/schema/inference/DefaultSchemaInjector.java
@@ -183,7 +183,7 @@ public class DefaultSchemaInjector implements Injector {
     final List<TableElement> elements = buildElements(schema.schema, preparedStatement);
 
     final AbstractStreamCreateStatement statement = preparedStatement.getStatement();
-    final Map<String, Expression> properties = new HashMap<>(statement.getProperties());
+    final Map<String, Literal> properties = new HashMap<>(statement.getProperties());
     properties
         .putIfAbsent(KsqlConstants.AVRO_SCHEMA_ID, new StringLiteral(String.valueOf(schema.id)));
 

--- a/ksql-engine/src/main/java/io/confluent/ksql/topic/DefaultTopicInjector.java
+++ b/ksql-engine/src/main/java/io/confluent/ksql/topic/DefaultTopicInjector.java
@@ -26,9 +26,9 @@ import io.confluent.ksql.parser.SqlFormatter;
 import io.confluent.ksql.parser.tree.AliasedRelation;
 import io.confluent.ksql.parser.tree.CreateAsSelect;
 import io.confluent.ksql.parser.tree.CreateTableAsSelect;
-import io.confluent.ksql.parser.tree.Expression;
 import io.confluent.ksql.parser.tree.IntegerLiteral;
 import io.confluent.ksql.parser.tree.Join;
+import io.confluent.ksql.parser.tree.Literal;
 import io.confluent.ksql.parser.tree.Node;
 import io.confluent.ksql.parser.tree.Statement;
 import io.confluent.ksql.parser.tree.StringLiteral;
@@ -112,7 +112,7 @@ public class DefaultTopicInjector implements Injector {
         : Collections.emptyMap();
     topicClient.createTopic(info.getTopicName(), info.getPartitions(), info.getReplicas(), config);
 
-    final Map<String, Expression> props = new HashMap<>(cas.getStatement().getProperties());
+    final Map<String, Literal> props = new HashMap<>(cas.getStatement().getProperties());
     props.put(DdlConfig.KAFKA_TOPIC_NAME_PROPERTY, new StringLiteral(info.getTopicName()));
     props.put(KsqlConstants.SINK_NUMBER_OF_REPLICAS, new IntegerLiteral(info.getReplicas()));
     props.put(KsqlConstants.SINK_NUMBER_OF_PARTITIONS, new IntegerLiteral(info.getPartitions()));

--- a/ksql-engine/src/main/java/io/confluent/ksql/topic/TopicProperties.java
+++ b/ksql-engine/src/main/java/io/confluent/ksql/topic/TopicProperties.java
@@ -19,6 +19,7 @@ import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Suppliers;
 import io.confluent.ksql.ddl.DdlConfig;
 import io.confluent.ksql.parser.tree.Expression;
+import io.confluent.ksql.parser.tree.Literal;
 import io.confluent.ksql.util.KsqlConfig;
 import io.confluent.ksql.util.KsqlConstants;
 import io.confluent.ksql.util.KsqlException;
@@ -106,7 +107,7 @@ public final class TopicProperties {
       return this;
     }
 
-    public Builder withWithClause(final Map<String, Expression> withClause) {
+    public Builder withWithClause(final Map<String, Literal> withClause) {
       final Expression nameExpression = withClause.get(DdlConfig.KAFKA_TOPIC_NAME_PROPERTY);
       final String name = nameExpression == null
           ? null

--- a/ksql-engine/src/test/java/io/confluent/ksql/QueryTranslationTest.java
+++ b/ksql-engine/src/test/java/io/confluent/ksql/QueryTranslationTest.java
@@ -68,7 +68,7 @@ import io.confluent.ksql.parser.KsqlParser.ParsedStatement;
 import io.confluent.ksql.parser.KsqlParser.PreparedStatement;
 import io.confluent.ksql.parser.SqlBaseParser;
 import io.confluent.ksql.parser.tree.AbstractStreamCreateStatement;
-import io.confluent.ksql.parser.tree.Expression;
+import io.confluent.ksql.parser.tree.Literal;
 import io.confluent.ksql.schema.ksql.LogicalSchemas;
 import io.confluent.ksql.schema.ksql.TypeContextUtil;
 import io.confluent.ksql.serde.DataSource;
@@ -247,7 +247,7 @@ public class QueryTranslationTest {
       final AbstractStreamCreateStatement statement = (AbstractStreamCreateStatement) stmt
           .getStatement();
 
-      final Map<String, Expression> properties = statement.getProperties();
+      final Map<String, Literal> properties = statement.getProperties();
       final String topicName
           = StringUtil.cleanQuotes(properties.get(DdlConfig.KAFKA_TOPIC_NAME_PROPERTY).toString());
       final String format

--- a/ksql-engine/src/test/java/io/confluent/ksql/ddl/commands/AbstractCreateStreamCommandTest.java
+++ b/ksql-engine/src/test/java/io/confluent/ksql/ddl/commands/AbstractCreateStreamCommandTest.java
@@ -27,6 +27,7 @@ import io.confluent.ksql.ddl.DdlConfig;
 import io.confluent.ksql.metastore.MutableMetaStore;
 import io.confluent.ksql.parser.tree.AbstractStreamCreateStatement;
 import io.confluent.ksql.parser.tree.Expression;
+import io.confluent.ksql.parser.tree.Literal;
 import io.confluent.ksql.parser.tree.PrimitiveType;
 import io.confluent.ksql.parser.tree.QualifiedName;
 import io.confluent.ksql.parser.tree.StringLiteral;
@@ -146,15 +147,15 @@ public class AbstractCreateStreamCommandTest {
     verify(kafkaTopicClient).isTopicExists(TOPIC_NAME);
   }
 
-  private static Map<String, Expression> minValidProps() {
+  private static Map<String, Literal> minValidProps() {
     return ImmutableMap.of(
         DdlConfig.VALUE_FORMAT_PROPERTY, new StringLiteral("json"),
         DdlConfig.KAFKA_TOPIC_NAME_PROPERTY, new StringLiteral(TOPIC_NAME)
     );
   }
 
-  private static Map<String, Expression> propsWithout(final String name) {
-    final HashMap<String, Expression> props = new HashMap<>(minValidProps());
+  private static Map<String, Literal> propsWithout(final String name) {
+    final HashMap<String, Literal> props = new HashMap<>(minValidProps());
     final Expression removed = props.remove(name);
     assertThat("invalid test", removed, is(notNullValue()));
     return ImmutableMap.copyOf(props);

--- a/ksql-engine/src/test/java/io/confluent/ksql/ddl/commands/CommandFactoriesTest.java
+++ b/ksql-engine/src/test/java/io/confluent/ksql/ddl/commands/CommandFactoriesTest.java
@@ -30,7 +30,7 @@ import io.confluent.ksql.parser.tree.DropStream;
 import io.confluent.ksql.parser.tree.DropTable;
 import io.confluent.ksql.parser.tree.DropTopic;
 import io.confluent.ksql.parser.tree.ExecutableDdlStatement;
-import io.confluent.ksql.parser.tree.Expression;
+import io.confluent.ksql.parser.tree.Literal;
 import io.confluent.ksql.parser.tree.PrimitiveType;
 import io.confluent.ksql.parser.tree.QualifiedName;
 import io.confluent.ksql.parser.tree.RegisterTopic;
@@ -57,7 +57,7 @@ public class CommandFactoriesTest {
   private final KafkaTopicClient topicClient = EasyMock.createNiceMock(KafkaTopicClient.class);
   private final ServiceContext serviceContext = EasyMock.createNiceMock(ServiceContext.class);
   private final CommandFactories commandFactories = new CommandFactories(serviceContext);
-  private final HashMap<String, Expression> properties = new HashMap<>();
+  private final HashMap<String, Literal> properties = new HashMap<>();
 
 
   @Before
@@ -97,7 +97,7 @@ public class CommandFactoriesTest {
 
   @Test
   public void shouldCreateCommandForCreateTable() {
-    final HashMap<String, Expression> tableProperties = validTableProps();
+    final HashMap<String, Literal> tableProperties = validTableProps();
 
     final DdlCommand result = commandFactories
         .create(sqlExpression, createTable(tableProperties),
@@ -108,7 +108,7 @@ public class CommandFactoriesTest {
 
   @Test
   public void shouldFailCreateTableIfKeyNameIsIncorrect() {
-    final HashMap<String, Expression> tableProperties = validTableProps();
+    final HashMap<String, Literal> tableProperties = validTableProps();
     tableProperties.put(DdlConfig.KEY_NAME_PROPERTY, new StringLiteral("COL3"));
 
     try {
@@ -124,7 +124,7 @@ public class CommandFactoriesTest {
 
   @Test
   public void shouldFailCreateTableIfTimestampColumnNameIsIncorrect() {
-    final HashMap<String, Expression> tableProperties = validTableProps();
+    final HashMap<String, Literal> tableProperties = validTableProps();
     tableProperties.put(DdlConfig.TIMESTAMP_NAME_PROPERTY, new StringLiteral("COL3"));
 
     try {
@@ -138,7 +138,7 @@ public class CommandFactoriesTest {
 
   @Test
   public void shouldFailCreateTableIfKeyIsNotProvided() {
-    final HashMap<String, Expression> tableProperties = validTableProps();
+    final HashMap<String, Literal> tableProperties = validTableProps();
     tableProperties.remove(DdlConfig.KEY_NAME_PROPERTY);
 
     try {
@@ -151,7 +151,7 @@ public class CommandFactoriesTest {
 
   @Test
   public void shouldFailCreateTableIfTopicNotExist() {
-    final HashMap<String, Expression> tableProperties = validTableProps();
+    final HashMap<String, Literal> tableProperties = validTableProps();
 
     givenTopicsDoNotExist();
 
@@ -197,13 +197,13 @@ public class CommandFactoriesTest {
         NO_PROPS);
   }
 
-  private HashMap<String, Expression> validTableProps() {
-    final HashMap<String, Expression> tableProperties = new HashMap<>(properties);
+  private HashMap<String, Literal> validTableProps() {
+    final HashMap<String, Literal> tableProperties = new HashMap<>(properties);
     tableProperties.put(DdlConfig.KEY_NAME_PROPERTY, new StringLiteral("COL1"));
     return tableProperties;
   }
 
-  private static CreateTable createTable(final HashMap<String, Expression> tableProperties) {
+  private static CreateTable createTable(final HashMap<String, Literal> tableProperties) {
     return new CreateTable(QualifiedName.of("foo"),
         ImmutableList.of(
             new TableElement("COL1", PrimitiveType.of(SqlType.BIGINT)),

--- a/ksql-engine/src/test/java/io/confluent/ksql/ddl/commands/CreateStreamCommandTest.java
+++ b/ksql-engine/src/test/java/io/confluent/ksql/ddl/commands/CreateStreamCommandTest.java
@@ -28,7 +28,7 @@ import io.confluent.ksql.function.InternalFunctionRegistry;
 import io.confluent.ksql.metastore.MutableMetaStore;
 import io.confluent.ksql.parser.tree.BooleanLiteral;
 import io.confluent.ksql.parser.tree.CreateStream;
-import io.confluent.ksql.parser.tree.Expression;
+import io.confluent.ksql.parser.tree.Literal;
 import io.confluent.ksql.parser.tree.PrimitiveType;
 import io.confluent.ksql.parser.tree.QualifiedName;
 import io.confluent.ksql.parser.tree.StringLiteral;
@@ -189,8 +189,8 @@ public class CreateStreamCommandTest {
     return new CreateStreamCommand("some sql", createStreamStatement, topicClient);
   }
 
-  private void givenPropertiesWith(final Map<String, Expression> props) {
-    final Map<String, Expression> allProps = new HashMap<>(props);
+  private void givenPropertiesWith(final Map<String, Literal> props) {
+    final Map<String, Literal> allProps = new HashMap<>(props);
     allProps.putIfAbsent(DdlConfig.VALUE_FORMAT_PROPERTY, new StringLiteral("Json"));
     allProps.putIfAbsent(DdlConfig.KAFKA_TOPIC_NAME_PROPERTY, new StringLiteral("some-topic"));
     when(createStreamStatement.getProperties()).thenReturn(allProps);

--- a/ksql-engine/src/test/java/io/confluent/ksql/ddl/commands/CreateTableCommandTest.java
+++ b/ksql-engine/src/test/java/io/confluent/ksql/ddl/commands/CreateTableCommandTest.java
@@ -28,7 +28,7 @@ import io.confluent.ksql.function.InternalFunctionRegistry;
 import io.confluent.ksql.metastore.MutableMetaStore;
 import io.confluent.ksql.parser.tree.BooleanLiteral;
 import io.confluent.ksql.parser.tree.CreateTable;
-import io.confluent.ksql.parser.tree.Expression;
+import io.confluent.ksql.parser.tree.Literal;
 import io.confluent.ksql.parser.tree.PrimitiveType;
 import io.confluent.ksql.parser.tree.QualifiedName;
 import io.confluent.ksql.parser.tree.StringLiteral;
@@ -187,8 +187,8 @@ public class CreateTableCommandTest {
     return new CreateTableCommand("some sql", createTableStatement, topicClient);
   }
 
-  private void givenPropertiesWith(final Map<String, Expression> props) {
-    final Map<String, Expression> allProps = new HashMap<>(props);
+  private void givenPropertiesWith(final Map<String, Literal> props) {
+    final Map<String, Literal> allProps = new HashMap<>(props);
     allProps.putIfAbsent(DdlConfig.VALUE_FORMAT_PROPERTY, new StringLiteral("Json"));
     allProps.putIfAbsent(DdlConfig.KAFKA_TOPIC_NAME_PROPERTY, new StringLiteral("some-topic"));
     allProps.putIfAbsent(DdlConfig.KEY_NAME_PROPERTY, new StringLiteral("some-key"));

--- a/ksql-engine/src/test/java/io/confluent/ksql/ddl/commands/RegisterTopicCommandTest.java
+++ b/ksql-engine/src/test/java/io/confluent/ksql/ddl/commands/RegisterTopicCommandTest.java
@@ -20,7 +20,7 @@ import com.google.common.collect.ImmutableMap;
 import io.confluent.ksql.ddl.DdlConfig;
 import io.confluent.ksql.function.InternalFunctionRegistry;
 import io.confluent.ksql.metastore.MutableMetaStore;
-import io.confluent.ksql.parser.tree.Expression;
+import io.confluent.ksql.parser.tree.Literal;
 import io.confluent.ksql.parser.tree.QualifiedName;
 import io.confluent.ksql.parser.tree.RegisterTopic;
 import io.confluent.ksql.parser.tree.StringLiteral;
@@ -67,14 +67,14 @@ public class RegisterTopicCommandTest {
         return new RegisterTopicCommand(registerTopicStatement);
     }
 
-    private static Map<String, Expression> propsWith(final Map<String, Expression> props) {
-        Map<String, Expression> valid = new HashMap<>(props);
+    private static Map<String, Literal> propsWith(final Map<String, Literal> props) {
+        Map<String, Literal> valid = new HashMap<>(props);
         valid.putIfAbsent(DdlConfig.VALUE_FORMAT_PROPERTY, new StringLiteral("Json"));
         valid.putIfAbsent(DdlConfig.KAFKA_TOPIC_NAME_PROPERTY, new StringLiteral("some-topic"));
         return valid;
     }
 
-    private void givenProperties(final Map<String, Expression> props) {
+    private void givenProperties(final Map<String, Literal> props) {
         EasyMock.expect(registerTopicStatement.getProperties()).andReturn(props).anyTimes();
         EasyMock.expect(registerTopicStatement.getName()).andReturn(QualifiedName.of("name")).anyTimes();
         EasyMock.replay(registerTopicStatement);

--- a/ksql-engine/src/test/java/io/confluent/ksql/schema/inference/DefaultSchemaInjectorTest.java
+++ b/ksql-engine/src/test/java/io/confluent/ksql/schema/inference/DefaultSchemaInjectorTest.java
@@ -35,7 +35,7 @@ import io.confluent.ksql.parser.KsqlParser.PreparedStatement;
 import io.confluent.ksql.parser.tree.AbstractStreamCreateStatement;
 import io.confluent.ksql.parser.tree.CreateStream;
 import io.confluent.ksql.parser.tree.CreateTable;
-import io.confluent.ksql.parser.tree.Expression;
+import io.confluent.ksql.parser.tree.Literal;
 import io.confluent.ksql.parser.tree.PrimitiveType;
 import io.confluent.ksql.parser.tree.QualifiedName;
 import io.confluent.ksql.parser.tree.Statement;
@@ -67,11 +67,11 @@ public class DefaultSchemaInjectorTest {
 
   private static final List<TableElement> SOME_ELEMENTS = ImmutableList.of(
       new TableElement("bob", PrimitiveType.of(SqlType.STRING)));
-  private static final Map<String, Expression> UNSUPPORTED_PROPS = ImmutableMap.of(
+  private static final Map<String, Literal> UNSUPPORTED_PROPS = ImmutableMap.of(
       "VALUE_FORMAT", new StringLiteral("json")
   );
   private static final String KAFKA_TOPIC = "some-topic";
-  private static final Map<String, Expression> SUPPORTED_PROPS = ImmutableMap.of(
+  private static final Map<String, Literal> SUPPORTED_PROPS = ImmutableMap.of(
       "VALUE_FORMAT", new StringLiteral("avro"),
       "KAFKA_TOPIC", new StringLiteral(KAFKA_TOPIC)
   );
@@ -461,17 +461,17 @@ public class DefaultSchemaInjectorTest {
   }
 
   @SuppressWarnings("SameParameterValue")
-  private static Map<String, Expression> supportedPropsWith(
+  private static Map<String, Literal> supportedPropsWith(
       final String property,
       final String value
   ) {
-    final HashMap<String, Expression> props = new HashMap<>(SUPPORTED_PROPS);
+    final HashMap<String, Literal> props = new HashMap<>(SUPPORTED_PROPS);
     props.put(property, new StringLiteral(value));
     return props;
   }
 
-  private static Map<String, Expression> supportedPropsWithout(final String property) {
-    final HashMap<String, Expression> props = new HashMap<>(SUPPORTED_PROPS);
+  private static Map<String, Literal> supportedPropsWithout(final String property) {
+    final HashMap<String, Literal> props = new HashMap<>(SUPPORTED_PROPS);
     assertThat("Invalid test", props.remove(property), is(notNullValue()));
     return props;
   }

--- a/ksql-engine/src/test/java/io/confluent/ksql/topic/TopicPropertiesTest.java
+++ b/ksql-engine/src/test/java/io/confluent/ksql/topic/TopicPropertiesTest.java
@@ -15,7 +15,19 @@
 
 package io.confluent.ksql.topic;
 
-import static io.confluent.ksql.topic.TopicPropertiesTest.Inject.*;
+import static io.confluent.ksql.topic.TopicPropertiesTest.Inject.KSQL_CONFIG;
+import static io.confluent.ksql.topic.TopicPropertiesTest.Inject.KSQL_CONFIG_P;
+import static io.confluent.ksql.topic.TopicPropertiesTest.Inject.KSQL_CONFIG_R;
+import static io.confluent.ksql.topic.TopicPropertiesTest.Inject.NO_CONFIG;
+import static io.confluent.ksql.topic.TopicPropertiesTest.Inject.NO_OVERRIDES;
+import static io.confluent.ksql.topic.TopicPropertiesTest.Inject.NO_WITH;
+import static io.confluent.ksql.topic.TopicPropertiesTest.Inject.OVERRIDES;
+import static io.confluent.ksql.topic.TopicPropertiesTest.Inject.OVERRIDES_P;
+import static io.confluent.ksql.topic.TopicPropertiesTest.Inject.OVERRIDES_R;
+import static io.confluent.ksql.topic.TopicPropertiesTest.Inject.SOURCE;
+import static io.confluent.ksql.topic.TopicPropertiesTest.Inject.WITH;
+import static io.confluent.ksql.topic.TopicPropertiesTest.Inject.WITH_P;
+import static io.confluent.ksql.topic.TopicPropertiesTest.Inject.WITH_R;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.equalTo;
 import static org.mockito.Mockito.mock;
@@ -25,8 +37,8 @@ import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.Lists;
 import io.confluent.ksql.ddl.DdlConfig;
-import io.confluent.ksql.parser.tree.Expression;
 import io.confluent.ksql.parser.tree.IntegerLiteral;
+import io.confluent.ksql.parser.tree.Literal;
 import io.confluent.ksql.parser.tree.StringLiteral;
 import io.confluent.ksql.util.KsqlConfig;
 import io.confluent.ksql.util.KsqlConstants;
@@ -69,7 +81,7 @@ public class TopicPropertiesTest {
     @Test
     public void shouldUseNameFromWithClause() {
       // Given:
-      final Map<String, Expression> withClause = ImmutableMap.of(
+      final Map<String, Literal> withClause = ImmutableMap.of(
           DdlConfig.KAFKA_TOPIC_NAME_PROPERTY, new StringLiteral("name")
       );
 
@@ -86,7 +98,7 @@ public class TopicPropertiesTest {
     @Test
     public void shouldUseNameFromWithClauseWhenNameIsAlsoPresent() {
       // Given:
-      final Map<String, Expression> withClause = ImmutableMap.of(
+      final Map<String, Literal> withClause = ImmutableMap.of(
           DdlConfig.KAFKA_TOPIC_NAME_PROPERTY, new StringLiteral("name")
       );
 
@@ -177,7 +189,7 @@ public class TopicPropertiesTest {
     @Test
     public void shouldNotMakeRemoteCallIfUnnecessary() {
       // Given:
-      final Map<String, Expression> withClause = ImmutableMap.of(
+      final Map<String, Literal> withClause = ImmutableMap.of(
           DdlConfig.KAFKA_TOPIC_NAME_PROPERTY, new StringLiteral("name"),
           KsqlConstants.SINK_NUMBER_OF_PARTITIONS, new IntegerLiteral(1),
           KsqlConstants.SINK_NUMBER_OF_REPLICAS, new IntegerLiteral(1)
@@ -328,8 +340,8 @@ public class TopicPropertiesTest {
     public Inject expectedReplicas;
 
     private KsqlConfig ksqlConfig = new KsqlConfig(new HashMap<>());
-    private Map<String, Object> propertyOverrides = new HashMap<>();
-    private Map<String, Expression> withClause = new HashMap<>();
+    private final Map<String, Object> propertyOverrides = new HashMap<>();
+    private final Map<String, Literal> withClause = new HashMap<>();
 
     @Test
     public void shouldInferCorrectPartitionsAndReplicas() {

--- a/ksql-parser/src/main/antlr4/io/confluent/ksql/parser/SqlBase.g4
+++ b/ksql-parser/src/main/antlr4/io/confluent/ksql/parser/SqlBase.g4
@@ -86,7 +86,7 @@ tableProperties
     ;
 
 tableProperty
-    : identifier EQ expression
+    : identifier EQ literal
     ;
 
 printClause
@@ -231,11 +231,8 @@ valueExpression
     ;
 
 primaryExpression
-    : NULL                                                                           #nullLiteral
+    : literal                                                                        #literalExpression
     | identifier STRING                                                              #typeConstructor
-    | number                                                                         #numericLiteral
-    | booleanValue                                                                   #booleanLiteral
-    | STRING                                                                         #stringLiteral
     | qualifiedName '(' ASTERISK ')'                              		               #functionCall
     | qualifiedName '(' (expression (',' expression)*)? ')' 						             #functionCall
     | CASE valueExpression whenClause+ (ELSE elseExpression=expression)? END         #simpleCase
@@ -296,6 +293,13 @@ identifier
 number
     : DECIMAL_VALUE  #decimalLiteral
     | INTEGER_VALUE  #integerLiteral
+    ;
+
+literal
+    : NULL                                                                           #nullLiteral
+    | number                                                                         #numericLiteral
+    | booleanValue                                                                   #booleanLiteral
+    | STRING                                                                         #stringLiteral
     ;
 
 nonReserved

--- a/ksql-parser/src/main/java/io/confluent/ksql/parser/AstBuilder.java
+++ b/ksql-parser/src/main/java/io/confluent/ksql/parser/AstBuilder.java
@@ -188,10 +188,10 @@ public class AstBuilder {
       return visit(context.expression());
     }
 
-    private Map<String, Expression> processTableProperties(
+    private Map<String, Literal> processTableProperties(
         final TablePropertiesContext tablePropertiesContext
     ) {
-      final ImmutableMap.Builder<String, Expression> properties = ImmutableMap.builder();
+      final ImmutableMap.Builder<String, Literal> properties = ImmutableMap.builder();
       if (tablePropertiesContext != null) {
         for (final TablePropertyContext prop : tablePropertiesContext.tableProperty()) {
           properties.put(

--- a/ksql-parser/src/main/java/io/confluent/ksql/parser/AstBuilder.java
+++ b/ksql-parser/src/main/java/io/confluent/ksql/parser/AstBuilder.java
@@ -72,6 +72,7 @@ import io.confluent.ksql.parser.tree.ListRegisteredTopics;
 import io.confluent.ksql.parser.tree.ListStreams;
 import io.confluent.ksql.parser.tree.ListTables;
 import io.confluent.ksql.parser.tree.ListTopics;
+import io.confluent.ksql.parser.tree.Literal;
 import io.confluent.ksql.parser.tree.LogicalBinaryExpression;
 import io.confluent.ksql.parser.tree.LongLiteral;
 import io.confluent.ksql.parser.tree.Node;
@@ -195,7 +196,7 @@ public class AstBuilder {
         for (final TablePropertyContext prop : tablePropertiesContext.tableProperty()) {
           properties.put(
               ParserUtil.getIdentifierText(prop.identifier()),
-              (Expression) visit(prop.expression())
+              (Literal) visit(prop.literal())
           );
         }
       }

--- a/ksql-parser/src/main/java/io/confluent/ksql/parser/rewrite/StatementRewriter.java
+++ b/ksql-parser/src/main/java/io/confluent/ksql/parser/rewrite/StatementRewriter.java
@@ -397,13 +397,13 @@ public class StatementRewriter extends DefaultAstVisitor<Node, Object> {
         .map(tableElement -> (TableElement) process(tableElement, context))
         .collect(Collectors.toList());
 
-    final Map<String, Expression> rewrittenProps = node
+    final Map<String, Literal> rewrittenProps = node
         .getProperties()
         .entrySet()
         .stream()
         .collect(Collectors.toMap(
             Entry::getKey,
-            e -> (Expression) process(e.getValue(), context)
+            e -> (Literal) process(e.getValue(), context)
         ));
 
     return node.copyWith(rewrittenElements, rewrittenProps);
@@ -418,7 +418,7 @@ public class StatementRewriter extends DefaultAstVisitor<Node, Object> {
         node.getProperties().entrySet().stream()
             .collect(Collectors.toMap(
                 Map.Entry::getKey,
-                e -> (Expression) process(e.getValue(), context)
+                e -> (Literal) process(e.getValue(), context)
             )),
         node.getPartitionByColumn().isPresent()
             ? Optional.ofNullable(
@@ -433,13 +433,13 @@ public class StatementRewriter extends DefaultAstVisitor<Node, Object> {
         .map(tableElement -> (TableElement) process(tableElement, context))
         .collect(Collectors.toList());
 
-    final Map<String, Expression> rewrittenProps = node
+    final Map<String, Literal> rewrittenProps = node
         .getProperties()
         .entrySet()
         .stream()
         .collect(Collectors.toMap(
             Entry::getKey,
-            e -> (Expression) process(e.getValue(), context)
+            e -> (Literal) process(e.getValue(), context)
         ));
 
     return node.copyWith(rewrittenElements, rewrittenProps);
@@ -453,7 +453,7 @@ public class StatementRewriter extends DefaultAstVisitor<Node, Object> {
         node.getProperties().entrySet().stream()
             .collect(Collectors.toMap(
                 Entry::getKey,
-                e -> (Expression) process(e.getValue(), context)
+                e -> (Literal) process(e.getValue(), context)
             )));
   }
 

--- a/ksql-parser/src/main/java/io/confluent/ksql/parser/tree/AbstractStreamCreateStatement.java
+++ b/ksql-parser/src/main/java/io/confluent/ksql/parser/tree/AbstractStreamCreateStatement.java
@@ -31,14 +31,14 @@ public abstract class AbstractStreamCreateStatement extends Statement {
   private final QualifiedName name;
   private final ImmutableList<TableElement> elements;
   private final boolean notExists;
-  private final ImmutableMap<String, Expression> properties;
+  private final ImmutableMap<String, Literal> properties;
 
   AbstractStreamCreateStatement(
       final Optional<NodeLocation> location,
       final QualifiedName name,
       final List<TableElement> elements,
       final boolean notExists,
-      final Map<String, Expression> properties
+      final Map<String, Literal> properties
   ) {
     super(location);
     this.name = requireNonNull(name, "name");
@@ -47,7 +47,7 @@ public abstract class AbstractStreamCreateStatement extends Statement {
     this.properties = ImmutableMap.copyOf(requireNonNull(properties, "properties"));
   }
 
-  public Map<String, Expression> getProperties() {
+  public Map<String, Literal> getProperties() {
     return properties;
   }
 
@@ -65,7 +65,7 @@ public abstract class AbstractStreamCreateStatement extends Statement {
 
   public abstract AbstractStreamCreateStatement copyWith(
       List<TableElement> elements,
-      Map<String, Expression> properties);
+      Map<String, Literal> properties);
 
   @Override
   public int hashCode() {

--- a/ksql-parser/src/main/java/io/confluent/ksql/parser/tree/CreateAsSelect.java
+++ b/ksql-parser/src/main/java/io/confluent/ksql/parser/tree/CreateAsSelect.java
@@ -27,7 +27,7 @@ public abstract class CreateAsSelect extends Statement implements QueryContainer
   private final QualifiedName name;
   private final Query query;
   private final boolean notExists;
-  private final ImmutableMap<String, Expression> properties;
+  private final ImmutableMap<String, Literal> properties;
   private final Optional<Expression> partitionByColumn;
 
   CreateAsSelect(
@@ -35,7 +35,7 @@ public abstract class CreateAsSelect extends Statement implements QueryContainer
       final QualifiedName name,
       final Query query,
       final boolean notExists,
-      final Map<String, Expression> properties,
+      final Map<String, Literal> properties,
       final Optional<Expression> partitionByColumn) {
     super(location);
     this.name = requireNonNull(name, "name is null");
@@ -48,7 +48,7 @@ public abstract class CreateAsSelect extends Statement implements QueryContainer
 
   CreateAsSelect(
       final CreateAsSelect other,
-      final Map<String, Expression> properties) {
+      final Map<String, Literal> properties) {
     this(
         other.getLocation(),
         other.name,
@@ -58,7 +58,7 @@ public abstract class CreateAsSelect extends Statement implements QueryContainer
         other.partitionByColumn);
   }
 
-  public abstract CreateAsSelect copyWith(Map<String, Expression> properties);
+  public abstract CreateAsSelect copyWith(Map<String, Literal> properties);
 
   public QualifiedName getName() {
     return name;
@@ -73,7 +73,7 @@ public abstract class CreateAsSelect extends Statement implements QueryContainer
     return notExists;
   }
 
-  public Map<String, Expression> getProperties() {
+  public Map<String, Literal> getProperties() {
     return properties;
   }
 

--- a/ksql-parser/src/main/java/io/confluent/ksql/parser/tree/CreateStream.java
+++ b/ksql-parser/src/main/java/io/confluent/ksql/parser/tree/CreateStream.java
@@ -29,7 +29,7 @@ public class CreateStream extends AbstractStreamCreateStatement implements Execu
       final QualifiedName name,
       final List<TableElement> elements,
       final boolean notExists,
-      final Map<String, Expression> properties
+      final Map<String, Literal> properties
   ) {
     this(Optional.empty(), name, elements, notExists, properties);
   }
@@ -39,7 +39,7 @@ public class CreateStream extends AbstractStreamCreateStatement implements Execu
       final QualifiedName name,
       final List<TableElement> elements,
       final boolean notExists,
-      final Map<String, Expression> properties
+      final Map<String, Literal> properties
   ) {
     super(location, name, elements, notExists, properties);
   }
@@ -47,7 +47,7 @@ public class CreateStream extends AbstractStreamCreateStatement implements Execu
   @Override
   public AbstractStreamCreateStatement copyWith(
       final List<TableElement> elements,
-      final Map<String, Expression> properties
+      final Map<String, Literal> properties
   ) {
     return new CreateStream(
         getLocation(),

--- a/ksql-parser/src/main/java/io/confluent/ksql/parser/tree/CreateStreamAsSelect.java
+++ b/ksql-parser/src/main/java/io/confluent/ksql/parser/tree/CreateStreamAsSelect.java
@@ -28,7 +28,7 @@ public class CreateStreamAsSelect extends CreateAsSelect {
       final QualifiedName name,
       final Query query,
       final boolean notExists,
-      final Map<String, Expression> properties,
+      final Map<String, Literal> properties,
       final Optional<Expression> partitionByColumn
   ) {
     this(Optional.empty(), name, query, notExists, properties, partitionByColumn);
@@ -39,14 +39,14 @@ public class CreateStreamAsSelect extends CreateAsSelect {
       final QualifiedName name,
       final Query query,
       final boolean notExists,
-      final Map<String, Expression> properties,
+      final Map<String, Literal> properties,
       final Optional<Expression> partitionByColumn) {
     super(location, name, query, notExists, properties, partitionByColumn);
   }
 
   private CreateStreamAsSelect(
       final CreateStreamAsSelect other,
-      final Map<String, Expression> properties
+      final Map<String, Literal> properties
   ) {
     super(other, properties);
   }
@@ -59,13 +59,13 @@ public class CreateStreamAsSelect extends CreateAsSelect {
             .put(DdlConfig.PARTITION_BY_PROPERTY, exp)
             .build()
         )
-        .orElse(getProperties());
+        .orElseGet(() -> ImmutableMap.copyOf(getProperties()));
 
     return Sink.of(getName().getSuffix(), true, sinkProperties);
   }
 
   @Override
-  public CreateAsSelect copyWith(final Map<String, Expression> properties) {
+  public CreateAsSelect copyWith(final Map<String, Literal> properties) {
     return new CreateStreamAsSelect(this, properties);
   }
 

--- a/ksql-parser/src/main/java/io/confluent/ksql/parser/tree/CreateTable.java
+++ b/ksql-parser/src/main/java/io/confluent/ksql/parser/tree/CreateTable.java
@@ -29,7 +29,7 @@ public class CreateTable extends AbstractStreamCreateStatement implements Execut
       final QualifiedName name,
       final List<TableElement> elements,
       final boolean notExists,
-      final Map<String, Expression> properties
+      final Map<String, Literal> properties
   ) {
     this(Optional.empty(), name, elements, notExists, properties);
   }
@@ -39,7 +39,7 @@ public class CreateTable extends AbstractStreamCreateStatement implements Execut
       final QualifiedName name,
       final List<TableElement> elements,
       final boolean notExists,
-      final Map<String, Expression> properties
+      final Map<String, Literal> properties
   ) {
     super(location, name, elements, notExists, properties);
   }
@@ -47,7 +47,7 @@ public class CreateTable extends AbstractStreamCreateStatement implements Execut
   @Override
   public AbstractStreamCreateStatement copyWith(
       final List<TableElement> elements,
-      final Map<String, Expression> properties
+      final Map<String, Literal> properties
   ) {
     return new CreateTable(
         getLocation(),

--- a/ksql-parser/src/main/java/io/confluent/ksql/parser/tree/CreateTableAsSelect.java
+++ b/ksql-parser/src/main/java/io/confluent/ksql/parser/tree/CreateTableAsSelect.java
@@ -15,6 +15,7 @@
 
 package io.confluent.ksql.parser.tree;
 
+import com.google.common.collect.ImmutableMap;
 import com.google.errorprone.annotations.Immutable;
 import java.util.Map;
 import java.util.Optional;
@@ -26,7 +27,7 @@ public class CreateTableAsSelect extends CreateAsSelect {
       final QualifiedName name,
       final Query query,
       final boolean notExists,
-      final Map<String, Expression> properties
+      final Map<String, Literal> properties
   ) {
     this(Optional.empty(), name, query, notExists, properties);
   }
@@ -36,20 +37,20 @@ public class CreateTableAsSelect extends CreateAsSelect {
       final QualifiedName name,
       final Query query,
       final boolean notExists,
-      final Map<String, Expression> properties
+      final Map<String, Literal> properties
   ) {
     super(location, name, query, notExists, properties, Optional.empty());
   }
 
   private CreateTableAsSelect(
       final CreateTableAsSelect other,
-      final Map<String, Expression> properties
+      final Map<String, Literal> properties
   ) {
     super(other, properties);
   }
 
   @Override
-  public CreateAsSelect copyWith(final Map<String, Expression> properties) {
+  public CreateAsSelect copyWith(final Map<String, Literal> properties) {
     return new CreateTableAsSelect(this, properties);
   }
 
@@ -60,7 +61,7 @@ public class CreateTableAsSelect extends CreateAsSelect {
 
   @Override
   public Sink getSink() {
-    return Sink.of(getName().getSuffix(), true, getProperties());
+    return Sink.of(getName().getSuffix(), true, ImmutableMap.copyOf(getProperties()));
   }
 
   @Override

--- a/ksql-parser/src/main/java/io/confluent/ksql/parser/tree/RegisterTopic.java
+++ b/ksql-parser/src/main/java/io/confluent/ksql/parser/tree/RegisterTopic.java
@@ -29,12 +29,12 @@ public class RegisterTopic extends Statement implements ExecutableDdlStatement {
 
   private final QualifiedName name;
   private final boolean notExists;
-  private final ImmutableMap<String, Expression> properties;
+  private final ImmutableMap<String, Literal> properties;
 
   public RegisterTopic(
       final QualifiedName name,
       final boolean notExists,
-      final Map<String, Expression> properties
+      final Map<String, Literal> properties
   ) {
     this(Optional.empty(), name, notExists, properties);
   }
@@ -43,7 +43,7 @@ public class RegisterTopic extends Statement implements ExecutableDdlStatement {
       final Optional<NodeLocation> location,
       final QualifiedName name,
       final boolean notExists,
-      final Map<String, Expression> properties
+      final Map<String, Literal> properties
   ) {
     super(location);
     this.name = requireNonNull(name, "name");
@@ -59,7 +59,7 @@ public class RegisterTopic extends Statement implements ExecutableDdlStatement {
     return notExists;
   }
 
-  public Map<String, Expression> getProperties() {
+  public Map<String, Literal> getProperties() {
     return properties;
   }
 

--- a/ksql-parser/src/test/java/io/confluent/ksql/parser/KsqlParserTest.java
+++ b/ksql-parser/src/test/java/io/confluent/ksql/parser/KsqlParserTest.java
@@ -74,7 +74,6 @@ import io.confluent.ksql.util.MetaStoreFixture;
 import io.confluent.ksql.util.timestamp.MetadataTimestampExtractionPolicy;
 import java.util.List;
 import java.util.Objects;
-import java.util.Optional;
 import java.util.concurrent.TimeUnit;
 import org.apache.kafka.common.serialization.Serdes;
 import org.apache.kafka.connect.data.Schema;
@@ -1203,6 +1202,17 @@ public class KsqlParserTest {
     // Then:
     final SearchedCaseExpression searchedCaseExpression = getSearchedCaseExpressionFromCsas(statement);
     assertThat(searchedCaseExpression.getDefaultValue().isPresent(), equalTo(false));
+  }
+
+  // https://github.com/confluentinc/ksql/issues/2287
+  @Test
+  public void shouldThrowHelpfulErrorMessageIfKeyFieldNotQuoted() {
+    // Then:
+    expectedException.expect(ParseFailedException.class);
+    expectedException.expectMessage("mismatched input 'ID'");
+
+    // When:
+    KsqlParserTestUtil.buildSingleAst("CREATE STREAM S (ID INT) WITH (KEY=ID);", metaStore);
   }
 
   private static SearchedCaseExpression getSearchedCaseExpressionFromCsas(final Statement statement) {

--- a/ksql-parser/src/test/java/io/confluent/ksql/parser/tree/CreateStreamAsSelectTest.java
+++ b/ksql-parser/src/test/java/io/confluent/ksql/parser/tree/CreateStreamAsSelectTest.java
@@ -29,7 +29,7 @@ public class CreateStreamAsSelectTest {
   public static final NodeLocation SOME_LOCATION = new NodeLocation(0, 0);
   public static final NodeLocation OTHER_LOCATION = new NodeLocation(1, 0);
   private static final QualifiedName SOME_NAME = QualifiedName.of("bob");
-  private static final Map<String, Expression> SOME_PROPS = ImmutableMap.of(
+  private static final Map<String, Literal> SOME_PROPS = ImmutableMap.of(
       "key", new StringLiteral("value")
   );
   private static final Query SOME_QUERY = mock(Query.class);

--- a/ksql-parser/src/test/java/io/confluent/ksql/parser/tree/CreateStreamTest.java
+++ b/ksql-parser/src/test/java/io/confluent/ksql/parser/tree/CreateStreamTest.java
@@ -32,7 +32,7 @@ public class CreateStreamTest {
   private static final List<TableElement> SOME_ELEMENTS = ImmutableList.of(
       new TableElement("Bob", PrimitiveType.of(SqlType.STRING))
   );
-  private static final Map<String, Expression> SOME_PROPS = ImmutableMap.of(
+  private static final Map<String, Literal> SOME_PROPS = ImmutableMap.of(
       "key", new StringLiteral("value")
   );
 

--- a/ksql-parser/src/test/java/io/confluent/ksql/parser/tree/CreateTableAsSelectTest.java
+++ b/ksql-parser/src/test/java/io/confluent/ksql/parser/tree/CreateTableAsSelectTest.java
@@ -29,7 +29,7 @@ public class CreateTableAsSelectTest {
   public static final NodeLocation SOME_LOCATION = new NodeLocation(0, 0);
   public static final NodeLocation OTHER_LOCATION = new NodeLocation(1, 0);
   private static final QualifiedName SOME_NAME = QualifiedName.of("bob");
-  private static final Map<String, Expression> SOME_PROPS = ImmutableMap.of(
+  private static final Map<String, Literal> SOME_PROPS = ImmutableMap.of(
       "key", new StringLiteral("value")
   );
   private static final Query SOME_QUERY = mock(Query.class);

--- a/ksql-parser/src/test/java/io/confluent/ksql/parser/tree/CreateTableTest.java
+++ b/ksql-parser/src/test/java/io/confluent/ksql/parser/tree/CreateTableTest.java
@@ -32,7 +32,7 @@ public class CreateTableTest {
   private static final List<TableElement> SOME_ELEMENTS = ImmutableList.of(
       new TableElement("Bob", PrimitiveType.of(SqlType.STRING))
   );
-  private static final Map<String, Expression> SOME_PROPS = ImmutableMap.of(
+  private static final Map<String, Literal> SOME_PROPS = ImmutableMap.of(
       "key", new StringLiteral("value")
   );
 

--- a/ksql-rest-app/src/main/java/io/confluent/ksql/rest/server/KsqlRestApplication.java
+++ b/ksql-rest-app/src/main/java/io/confluent/ksql/rest/server/KsqlRestApplication.java
@@ -33,7 +33,7 @@ import io.confluent.ksql.logging.processing.ProcessingLogConfig;
 import io.confluent.ksql.logging.processing.ProcessingLogContext;
 import io.confluent.ksql.parser.KsqlParser.PreparedStatement;
 import io.confluent.ksql.parser.tree.CreateStream;
-import io.confluent.ksql.parser.tree.Expression;
+import io.confluent.ksql.parser.tree.Literal;
 import io.confluent.ksql.parser.tree.PrimitiveType;
 import io.confluent.ksql.parser.tree.QualifiedName;
 import io.confluent.ksql.parser.tree.RegisterTopic;
@@ -339,7 +339,7 @@ public final class KsqlRestApplication extends Application<KsqlRestConfig> imple
         ksqlConfig, KsqlRestConfig.COMMAND_TOPIC_SUFFIX);
     KsqlInternalTopicUtils.ensureTopic(commandTopic, ksqlConfig, serviceContext.getTopicClient());
 
-    final Map<String, Expression> commandTopicProperties = new HashMap<>();
+    final Map<String, Literal> commandTopicProperties = new HashMap<>();
     commandTopicProperties.put(
         DdlConfig.VALUE_FORMAT_PROPERTY,
         new StringLiteral("json")

--- a/ksql-rest-app/src/test/java/io/confluent/ksql/rest/server/StandaloneExecutorTest.java
+++ b/ksql-rest-app/src/test/java/io/confluent/ksql/rest/server/StandaloneExecutorTest.java
@@ -34,7 +34,6 @@ import static org.mockito.hamcrest.MockitoHamcrest.argThat;
 
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
-import io.confluent.kafka.schemaregistry.client.SchemaRegistryClient;
 import io.confluent.ksql.KsqlExecutionContext;
 import io.confluent.ksql.KsqlExecutionContext.ExecuteResult;
 import io.confluent.ksql.engine.KsqlEngine;
@@ -49,8 +48,8 @@ import io.confluent.ksql.parser.tree.CreateStreamAsSelect;
 import io.confluent.ksql.parser.tree.CreateTable;
 import io.confluent.ksql.parser.tree.CreateTableAsSelect;
 import io.confluent.ksql.parser.tree.DropStream;
-import io.confluent.ksql.parser.tree.Expression;
 import io.confluent.ksql.parser.tree.InsertInto;
+import io.confluent.ksql.parser.tree.Literal;
 import io.confluent.ksql.parser.tree.PrimitiveType;
 import io.confluent.ksql.parser.tree.QualifiedName;
 import io.confluent.ksql.parser.tree.Query;
@@ -113,11 +112,11 @@ public class StandaloneExecutorTest {
 
   private static final QualifiedName SOME_NAME = QualifiedName.of("Bob");
 
-  private static final ImmutableMap<String, Expression> JSON_PROPS = ImmutableMap
+  private static final ImmutableMap<String, Literal> JSON_PROPS = ImmutableMap
       .of("VALUE_FORMAT", new StringLiteral("json"));
 
   private static final String SOME_TOPIC = "some-topic";
-  private static final ImmutableMap<String, Expression> AVRO_PROPS = ImmutableMap.of(
+  private static final ImmutableMap<String, Literal> AVRO_PROPS = ImmutableMap.of(
       "VALUE_FORMAT", new StringLiteral("avro"),
       "KAFKA_TOPIC", new StringLiteral(SOME_TOPIC));
 
@@ -147,9 +146,6 @@ public class StandaloneExecutorTest {
 
   private final static ParsedStatement PARSED_STMT_1 = ParsedStatement
       .of("sql 1", mock(SingleStatementContext.class));
-
-  private static final ParsedStatement PARSED_CSAS = ParsedStatement
-      .of("CSAS", mock(SingleStatementContext.class));
 
   private final static PreparedStatement<?> PREPARED_STMT_0 = PreparedStatement
       .of("sql 0", CREATE_STREAM);
@@ -218,8 +214,6 @@ public class StandaloneExecutorTest {
   private ServiceContext serviceContext;
   @Mock
   private KafkaTopicClient kafkaTopicClient;
-  @Mock
-  private SchemaRegistryClient srClient;
   @Mock
   private BiFunction<KsqlExecutionContext, ServiceContext, Injector> injectorFactory;
   @Mock


### PR DESCRIPTION
### Description 

Fixes: #2287

If user's forget to quote string literals in the `WITH` clause the error message is less than helpful:

```
ksql> CREATE TABLE accounts (ac_key BIGINT, username VARCHAR, company VARCHAR, created_date VARCHAR) \
>        WITH (KEY=ac_key, KAFKA_TOPIC = 'accounts', VALUE_FORMAT = 'json');
name is null
```

This is because the parser is treating the `ac_key` as a column reference. The underlying issue was a `null` being passed when creating a `QualifiedName`, which is invalid. Hence `name is null`.  Fixing this specific issue in the java code may still leave other code paths with similar issues.

At the moment the syntax allows a property to be set to any `Expression`. ASAIK all properties set within the WITH clause are literals and that's highly likely to remain the case.  So this PR changes the parsing rules to only accept literals as WITH property values.  (We can always change this in the future if we need to).

While the new error message isn't amazing, the parser now rejects the above SQL statement:

```
ksql> CREATE TABLE accounts (ac_key BIGINT, username VARCHAR, company VARCHAR, created_date VARCHAR) \
>        WITH (KEY=ac_key, KAFKA_TOPIC = 'accounts', VALUE_FORMAT = 'json');
line 1:36: mismatched input 'ac_key' expecting {'NULL', 'TRUE', 'FALSE', STRING, INTEGER_VALUE, DECIMAL_VALUE}
```

#### Reviewing notes:

1. First commit makes the main code / logic change.
2. Second commit just ripples the change from `Map<String, Expression>` to `Map<String, Literal>` down the code.

### Testing done 
Suitable unit tests added.

### Reviewer checklist
- [ ] Ensure docs are updated if necessary. (eg. if a user visible feature is being added or changed).
- [ ] Ensure relevant issues are linked (description should include text like "Fixes #<issue number>")

