### PR TITLE
Revert change to switch KSQL over to use new `incrementalAlterConfigs` admin client functionality.

### DIFF
--- a/ksql-engine/src/main/java/io/confluent/ksql/services/KafkaTopicClientImpl.java
+++ b/ksql-engine/src/main/java/io/confluent/ksql/services/KafkaTopicClientImpl.java
@@ -88,6 +88,11 @@ public class KafkaTopicClientImpl implements KafkaTopicClient {
       ExecutorUtil.executeWithRetries(
           () -> adminClient.createTopics(Collections.singleton(newTopic)).all().get(),
           ExecutorUtil.RetryBehaviour.ON_RETRYABLE);
+    } catch (final InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new KafkaResponseGetFailedException(
+          "Failed to guarantee existence of topic " + topic, e);
+
     } catch (final TopicExistsException e) {
       // if the topic already exists, it is most likely because another node just created it.
       // ensure that it matches the partition count and replication factor before returning

--- a/ksql-engine/src/main/java/io/confluent/ksql/services/SandboxedAdminClient.java
+++ b/ksql-engine/src/main/java/io/confluent/ksql/services/SandboxedAdminClient.java
@@ -171,7 +171,7 @@ class SandboxedAdminClient extends AdminClient {
     throw new UnsupportedOperationException();
   }
 
-  @SuppressWarnings("deprecation")
+  @SuppressWarnings({"deprecation", "RedundantSuppression"})
   @Override
   public AlterConfigsResult alterConfigs(
       final Map<ConfigResource, Config> configs,


### PR DESCRIPTION
### Description 

Partially revert changes to switch KSQL over to use new `incrementalAlterConfigs` admin client functionality (#2737).

This new functionality is only available on new Kafka Brokers and so would unnecessarily restrict compatible KSQL - Kafka versions.

Instead, we use the new API and if its not available we fallback to the older API.

The older API has issues with race conditions and overwriting secret properties. 

### Testing done 
_Describe the testing strategy. Unit and integration tests are expected for any behavior changes._

### Reviewer checklist
- [ ] Ensure docs are updated if necessary. (eg. if a user visible feature is being added or changed).
- [ ] Ensure relevant issues are linked (description should include text like "Fixes #<issue number>")

