### PR TITLE
Create topics with default replication factor if no replicas are specified

### DIFF
--- a/ksql-engine/src/main/java/io/confluent/ksql/services/KafkaTopicClient.java
+++ b/ksql-engine/src/main/java/io/confluent/ksql/services/KafkaTopicClient.java
@@ -60,10 +60,12 @@ public interface KafkaTopicClient {
    * {@code numPartitions} and that the replication factor is <i>at least</i>
    * {@code replicationFactor}
    *
-   * @param topic name of the topic to create
-   * @param replicationFactor the rf of the topic.
-   * @param numPartitions the partition count of the topic.
-   * @param configs any additional topic configs to use
+   * @param topic             name of the topic to create
+   * @param replicationFactor the replication factor for the new topic, or
+   *                          {@link io.confluent.ksql.topic.TopicProperties#DEFAULT_REPLICAS}
+   *                          to use the default replication of the cluster
+   * @param numPartitions     the partition count of the topic.
+   * @param configs           any additional topic configs to use
    */
   void createTopic(
       String topic,

--- a/ksql-engine/src/main/java/io/confluent/ksql/services/KafkaTopicClientImpl.java
+++ b/ksql-engine/src/main/java/io/confluent/ksql/services/KafkaTopicClientImpl.java
@@ -54,8 +54,10 @@ import org.slf4j.LoggerFactory;
 /**
  * Note: all calls make cross machine calls and are synchronous.
  */
+// CHECKSTYLE_RULES.OFF: ClassDataAbstractionCoupling
 @ThreadSafe
 public class KafkaTopicClientImpl implements KafkaTopicClient {
+  // CHECKSTYLE_RULES.ON: ClassDataAbstractionCoupling
 
   private static final Logger LOG = LoggerFactory.getLogger(KafkaTopicClient.class);
   private static final String DEFAULT_REPLICATION_PROP = KafkaConfig.DefaultReplicationFactorProp();

--- a/ksql-engine/src/main/java/io/confluent/ksql/services/KafkaTopicClientImpl.java
+++ b/ksql-engine/src/main/java/io/confluent/ksql/services/KafkaTopicClientImpl.java
@@ -283,11 +283,13 @@ public class KafkaTopicClientImpl implements KafkaTopicClient {
 
   private boolean isTopicDeleteEnabled() {
     try {
-      return getConfig().get(KafkaConfig.DeleteTopicEnableProp()).value().equalsIgnoreCase("true");
-
+      final ConfigEntry configEntry = getConfig().get(KafkaConfig.DeleteTopicEnableProp());
+      // default to true if there is no entry
+      return configEntry == null || Boolean.valueOf(configEntry.value());
     } catch (final Exception e) {
       LOG.error("Failed to initialize TopicClient: {}", e.getMessage());
-      throw new KsqlException("Could not fetch broker information. KSQL cannot initialize", e);
+      throw new KafkaResponseGetFailedException(
+          "Could not fetch broker information. KSQL cannot initialize", e);
     }
   }
 

--- a/ksql-engine/src/main/java/io/confluent/ksql/topic/TopicProperties.java
+++ b/ksql-engine/src/main/java/io/confluent/ksql/topic/TopicProperties.java
@@ -38,9 +38,10 @@ import org.apache.kafka.clients.admin.TopicDescription;
  */
 public final class TopicProperties {
 
+  public static final short DEFAULT_REPLICAS = -1;
+
   private static final String INVALID_TOPIC_NAME = ":INVALID:";
   private static final int INVALID_PARTITIONS = -1;
-  private static final short INVALID_REPLICAS = -1;
 
   private final String topicName;
   private final Integer partitions;
@@ -74,7 +75,7 @@ public final class TopicProperties {
   }
 
   public short getReplicas() {
-    return replicas == null ? INVALID_REPLICAS : replicas;
+    return replicas == null ? DEFAULT_REPLICAS : replicas;
   }
 
   /**
@@ -195,7 +196,6 @@ public final class TopicProperties {
           .filter(Objects::nonNull)
           .findFirst()
           .orElseGet(() -> fromSource.get().replicas);
-      Objects.requireNonNull(replicas, "Was not supplied with any valid source for replicas!");
 
       return new TopicProperties(name, partitions, replicas);
     }

--- a/ksql-engine/src/test/java/io/confluent/ksql/services/FakeKafkaTopicClient.java
+++ b/ksql-engine/src/test/java/io/confluent/ksql/services/FakeKafkaTopicClient.java
@@ -20,6 +20,7 @@ import static org.apache.kafka.common.config.TopicConfig.CLEANUP_POLICY_CONFIG;
 import static org.apache.kafka.common.config.TopicConfig.COMPRESSION_TYPE_CONFIG;
 
 import com.google.common.annotations.VisibleForTesting;
+import io.confluent.ksql.topic.TopicProperties;
 import io.confluent.ksql.util.KsqlConstants;
 import java.util.Collection;
 import java.util.Collections;
@@ -118,13 +119,17 @@ public class FakeKafkaTopicClient implements KafkaTopicClient {
       final short replicationFactor,
       final Map<String, ?> configs
   ) {
+    final short replicas = replicationFactor == TopicProperties.DEFAULT_REPLICAS
+        ? 1
+        : replicationFactor;
+
     final FakeTopic existing = topicMap.get(topic);
     if (existing != null) {
-      validateTopicProperties(numPartitions, replicationFactor, existing);
+      validateTopicProperties(numPartitions, replicas, existing);
       return;
     }
 
-    final FakeTopic info = createFakeTopic(topic, numPartitions, replicationFactor, configs);
+    final FakeTopic info = createFakeTopic(topic, numPartitions, replicas, configs);
     topicMap.put(topic, info);
     createdTopics.put(topic, info);
   }

--- a/ksql-engine/src/test/java/io/confluent/ksql/topic/TopicPropertiesTest.java
+++ b/ksql-engine/src/test/java/io/confluent/ksql/topic/TopicPropertiesTest.java
@@ -30,6 +30,7 @@ import static io.confluent.ksql.topic.TopicPropertiesTest.Inject.WITH_P;
 import static io.confluent.ksql.topic.TopicPropertiesTest.Inject.WITH_R;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.is;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
@@ -40,6 +41,7 @@ import io.confluent.ksql.ddl.DdlConfig;
 import io.confluent.ksql.parser.tree.IntegerLiteral;
 import io.confluent.ksql.parser.tree.Literal;
 import io.confluent.ksql.parser.tree.StringLiteral;
+import io.confluent.ksql.topic.TopicProperties.Builder;
 import io.confluent.ksql.util.KsqlConfig;
 import io.confluent.ksql.util.KsqlConstants;
 import io.confluent.ksql.util.KsqlException;
@@ -169,21 +171,20 @@ public class TopicPropertiesTest {
     }
 
     @Test
-    public void shouldFailIfNoReplicasSupplied() {
+    public void shouldDefaultIfNoReplicasSupplied() {
       // Given:
       final KsqlConfig config = new KsqlConfig(ImmutableMap.of(
           KsqlConfig.SINK_NUMBER_OF_PARTITIONS_PROPERTY, 1
       ));
 
-      // Expect:
-      expectedException.expect(NullPointerException.class);
-      expectedException.expectMessage("Was not supplied with any valid source for replicas!");
-
       // When:
-      new TopicProperties.Builder()
+      final TopicProperties properties = new Builder()
           .withName("name")
           .withKsqlConfig(config)
           .build();
+
+      // Then:
+      assertThat(properties.getReplicas(), is(TopicProperties.DEFAULT_REPLICAS));
     }
 
     @Test

--- a/ksql-engine/src/test/java/io/confluent/ksql/util/KafkaTopicClientImplIntegrationTest.java
+++ b/ksql-engine/src/test/java/io/confluent/ksql/util/KafkaTopicClientImplIntegrationTest.java
@@ -28,6 +28,7 @@ import io.confluent.ksql.integration.Retry;
 import io.confluent.ksql.services.KafkaTopicClient;
 import io.confluent.ksql.services.KafkaTopicClientImpl;
 import io.confluent.ksql.test.util.EmbeddedSingleNodeKafkaCluster;
+import io.confluent.ksql.topic.TopicProperties;
 import java.util.Collections;
 import java.util.Map;
 import java.util.Set;
@@ -201,6 +202,21 @@ public class KafkaTopicClientImplIntegrationTest {
     assertThat(topicDescription.partitions().get(0).replicas(), hasSize(1));
     final Map<String, String> configs = client.getTopicConfig(topicName);
     assertThat(configs.get(TopicConfig.COMPRESSION_TYPE_CONFIG), is("snappy"));
+  }
+
+  @Test
+  public void shouldCreateTopicWithDefaultReplicationFactor() {
+    // Given:
+    final String topicName = UUID.randomUUID().toString();
+
+    // When:
+    client.createTopic(topicName, 2, TopicProperties.DEFAULT_REPLICAS);
+
+    // Then:
+    assertThatEventually(() -> topicExists(topicName), is(true));
+    final TopicDescription topicDescription = getTopicDescription(topicName);
+    assertThat(topicDescription.partitions(), hasSize(2));
+    assertThat(topicDescription.partitions().get(0).replicas(), hasSize(1));
   }
 
   @Test


### PR DESCRIPTION
### Description 
As part of the work to support INSERT VALUES (#2693) we need to be able to create topics without supplying the replication factor for CT/CS statements. This is part one of that change, the actual creating of the topics will happen in a follow-up PR to keep things simple.

__NOTES:__ 
1. This PR allow does not change any existing behavior with regards to CTAS/CSAS because a replication factor is always supplied. 
2. I am going to follow-up with submitting a KIP to AK that will change admin client API to accept no replication factor. (https://cwiki.apache.org/confluence/display/KAFKA/KIP-464%3A+Defaults+for+AdminClient%23createTopic)

### Testing done 
- The usual works + new integration test

### Reviewer checklist
- [ ] Ensure docs are updated if necessary. (eg. if a user visible feature is being added or changed).
- [ ] Ensure relevant issues are linked (description should include text like "Fixes #<issue number>")

