### PR TITLE
KSQL-2539: Add Docker env variables to KSQL config settings topic

### DIFF
--- a/docs/installation/server-config/config-reference.rst
+++ b/docs/installation/server-config/config-reference.rst
@@ -5,6 +5,15 @@ KSQL Configuration Parameter Reference
 
 Here are some common configuration properties that you can customize.
 
+.. tip::
+
+   Each property has a corresponding environment variable in the Docker image 
+   for `KSQL Server <https://hub.docker.com/r/confluentinc/cp-ksql-server/>`__.
+   The environment variable name is the name of the configuration property
+   converted to uppercase and underscores, and prepended with ``KSQL_``. For
+   example, the name of the ``ksql.service.id`` environment variable is
+   ``KSQL_KSQL_SERVICE_ID``. For more information, see :ref:`install-ksql-with-docker`. 
+
 Kafka Streams and Kafka Client Settings
 ---------------------------------------
 
@@ -30,6 +39,10 @@ to change it to earliest by using the KSQL command line:
 
 For more information, see :ref:`kafka_consumer` and the :cp-javadoc:`Javadoc|clients/javadocs/org/apache/kafka/clients/consumer/ConsumerConfig.html#AUTO_OFFSET_RESET_CONFIG`.
 
+The corresponding environment variable in the
+`KSQL Server image <https://hub.docker.com/r/confluentinc/cp-ksql-server/>`__ is
+``KSQL_KSQL_STREAMS_AUTO_OFFSET_RESET``. 
+
 .. _ksql-bootstrap-servers:
 
 ------------------------------
@@ -46,6 +59,11 @@ by using the KSQL command line:
 
 For more information, see :ref:`Streams parameter reference <streams_developer-guide_required-configs>` and the :cp-javadoc:`Javadoc|clients/javadocs/org/apache/kafka/clients/consumer/ConsumerConfig.html#BOOTSTRAP_SERVERS_CONFIG`.
 
+The corresponding environment variable in the
+`KSQL Server image <https://hub.docker.com/r/confluentinc/cp-ksql-server/>`__ is
+``KSQL_KSQL_STREAMS_BOOTSTRAP_SERVERS`` or ``KSQL_BOOTSTRAP_SERVERS``.
+For more information, see :ref:`install-ksql-with-docker`.
+
 .. _ksql-commit-interval-ms:
 
 -------------------------------
@@ -60,6 +78,10 @@ the value to ``5000`` by using the KSQL command line:
     SET 'commit.interval.ms'='5000';
 
 For more information, see the :ref:`Streams parameter reference <streams_developer-guide_optional-configs>` and the :cp-javadoc:`Javadoc|streams/javadocs/org/apache/kafka/streams/StreamsConfig.html#COMMIT_INTERVAL_MS_CONFIG`,
+
+The corresponding environment variable in the
+`KSQL Server image <https://hub.docker.com/r/confluentinc/cp-ksql-server/>`__ is
+``KSQL_KSQL_STREAMS_COMMIT_INTERVAL_MS``.
 
 .. _ksql-cache-max-bytes-buffering:
 
@@ -76,6 +98,10 @@ Here is an example to change the value to ``20000000`` by using the KSQL command
 
 For more information, see the :ref:`Streams parameter reference <streams_developer-guide_optional-configs>` and :cp-javadoc:`Javadoc|streams/javadocs/org/apache/kafka/streams/StreamsConfig.html#CACHE_MAX_BYTES_BUFFERING_CONFIG`.
 
+The corresponding environment variable in the
+`KSQL Server image <https://hub.docker.com/r/confluentinc/cp-ksql-server/>`__ is
+``KSQL_KSQL_STREAMS_CACHE_MAX_BYTES_BUFFERING``.
+
 .. _ksql-streams-num-streams-threads:
 
 -------------------------------
@@ -84,6 +110,10 @@ ksql.streams.num.stream.threads
 
 This number of stream threads in an instance of the Kafka Streams application. The stream processing code runs in these
 threads. For more information about Kafka Streams threading model, see :ref:`streams_architecture_threads`.
+
+The corresponding environment variable in the
+`KSQL Server image <https://hub.docker.com/r/confluentinc/cp-ksql-server/>`__ is
+``KSQL_KSQL_STREAMS_NUM_STREAM_THREADS``.
 
 -----------------------------
 ksql.output.topic.name.prefix
@@ -96,12 +126,15 @@ topics. For example, you might use "ksql-interactive-" to name output topics
 in a KSQL Server cluster that's deployed in interactive mode. For more information, see
 :ref:`Configuring Security for KSQL <config-security-ksql-acl-interactive_post_ak_2_0>`.
 
+The corresponding environment variable in the
+`KSQL Server image <https://hub.docker.com/r/confluentinc/cp-ksql-server/>`__ is
+``KSQL_KSQL_OUTPUT_TOPIC_NAME_PREFIX``.
+
 KSQL Query Settings
 -------------------
 
 These configurations control how KSQL executes queries. These configurations can be specified via the ``ksql-server.properties``
 file or via ``SET`` in a KSQL CLI. For example, ``ksql.service.id`` and ``ksql.persistent.prefix``.
-
 
 .. _ksql-fail-on-deserialization-error:
 
@@ -120,6 +153,10 @@ properties file:
 
     fail.on.deserialization.error=false
 
+The corresponding environment variable in the
+`KSQL Server image <https://hub.docker.com/r/confluentinc/cp-ksql-server/>`__ is
+``KSQL_KSQL_FAIL_ON_DESERIALIZATION_ERROR``.
+
 .. _ksql-schema-registry-url:
 
 ------------------------
@@ -128,6 +165,10 @@ ksql.schema.registry.url
 
 The |sr| URL path to connect KSQL to. To communicate with |sr| over a secure
 connection, see :ref:`config-security-ksql-sr`.
+
+The corresponding environment variable in the
+`KSQL Server image <https://hub.docker.com/r/confluentinc/cp-ksql-server/>`__ is
+``KSQL_KSQL_SCHEMA_REGISTRY_URL``.
 
 .. _ksql-service-id:
 
@@ -139,6 +180,10 @@ The service ID of the KSQL server. By default, the service ID of KSQL servers is
 the prefix for the internal topics created by KSQL. Using the default value ``ksql.service.id``, the KSQL internal topics
 will be prefixed as ``_confluent-ksql-default_`` (e.g. ``_command_topic`` becomes ``_confluent-ksql-default__command_topic``).
 
+The corresponding environment variable in the
+`KSQL Server image <https://hub.docker.com/r/confluentinc/cp-ksql-server/>`__ is
+``KSQL_KSQL_SERVICE_ID``.
+
 .. _ksql-sink-partitions:
 
 --------------------
@@ -147,6 +192,10 @@ ksql.sink.partitions
 
 The default number of partitions for the topics created by KSQL. The default is four.
 
+The corresponding environment variable in the
+`KSQL Server image <https://hub.docker.com/r/confluentinc/cp-ksql-server/>`__ is
+``KSQL_KSQL_SINK_PARTITIONS``.
+
 .. _ksql-sink-replicas:
 
 ------------------
@@ -154,6 +203,10 @@ ksql.sink.replicas
 ------------------
 
 The default number of replicas for the topics created by KSQL. The default is one.
+
+The corresponding environment variable in the
+`KSQL Server image <https://hub.docker.com/r/confluentinc/cp-ksql-server/>`__ is
+``KSQL_KSQL_SINK_REPLICAS``.
 
 KSQL Server Settings
 --------------------
@@ -172,6 +225,10 @@ ksql.queries.file
 
 A file that specifies a predefined set of queries for the KSQL and KSQL server.
 For an example, see :ref:`restrict-ksql-interactive`.
+
+The corresponding environment variable in the
+`KSQL Server image <https://hub.docker.com/r/confluentinc/cp-ksql-server/>`__ is
+``KSQL_KSQL_QUERIES_FILE``.
 
 .. _ksql-listeners:
 
@@ -192,6 +249,10 @@ bind to the default interface. For example:
 
     # Bind only to localhost.
     listeners=http://localhost:8088
+
+The corresponding environment variable in the
+`KSQL Server image <https://hub.docker.com/r/confluentinc/cp-ksql-server/>`__ is
+``KSQL_LISTENERS``.
 
 .. _ksql-c3-settings:
 

--- a/docs/installation/server-config/config-reference.rst
+++ b/docs/installation/server-config/config-reference.rst
@@ -9,10 +9,11 @@ Here are some common configuration properties that you can customize.
 
    Each property has a corresponding environment variable in the Docker image 
    for `KSQL Server <https://hub.docker.com/r/confluentinc/cp-ksql-server/>`__.
-   The environment variable name is the name of the configuration property
-   converted to uppercase and underscores, and prepended with ``KSQL_``. For
-   example, the name of the ``ksql.service.id`` environment variable is
-   ``KSQL_KSQL_SERVICE_ID``. For more information, see :ref:`install-ksql-with-docker`. 
+   The environment variable name is constructed from the configuration property
+   name by converting to uppercase, replacing periods with underscores, and
+   prepending with ``KSQL_``. For example, the name of the ``ksql.service.id``
+   environment variable is ``KSQL_KSQL_SERVICE_ID``. For more information, see
+   :ref:`install-ksql-with-docker`.
 
 Kafka Streams and Kafka Client Settings
 ---------------------------------------

--- a/docs/installation/server-config/index.rst
+++ b/docs/installation/server-config/index.rst
@@ -27,6 +27,13 @@ or the ``KSQL_OPTS`` environment variable. Properties set with ``KSQL_OPTS`` tak
 KSQL configuration file. A recommended approach is to configure a common set of properties using the KSQL configuration
 file and override specific properties as needed, using the ``KSQL_OPTS`` environment variable.
 
+.. tip::
+
+   If you deploy |cp| by using Docker containers, you can specify configuration
+   parameters as environment variables to the
+   `KSQL Server image <https://hub.docker.com/r/confluentinc/cp-ksql-server/>`__.
+   For more information, see :ref:`install-ksql-with-docker`.
+
 KSQL Server Configuration File
 ------------------------------
 


### PR DESCRIPTION
This PR adds environment variables for the KSQL Server image that correspond with settings in [KSQL Configuration Parameter Reference](https://docs.confluent.io/current/ksql/docs/installation/server-config/config-reference.html). For internal ticket KSQL-2539.