### PR TITLE
Switch KSQL over from using the Connect `Schema` type to represent schemas to `KsqlSchema`

### DIFF
--- a/ksql-cli/src/test/java/io/confluent/ksql/cli/CliTest.java
+++ b/ksql-cli/src/test/java/io/confluent/ksql/cli/CliTest.java
@@ -58,6 +58,7 @@ import io.confluent.ksql.rest.server.KsqlRestConfig;
 import io.confluent.ksql.rest.server.TestKsqlRestApp;
 import io.confluent.ksql.rest.server.computation.CommandId;
 import io.confluent.ksql.rest.server.resources.Errors;
+import io.confluent.ksql.schema.ksql.KsqlSchema;
 import io.confluent.ksql.test.util.EmbeddedSingleNodeKafkaCluster;
 import io.confluent.ksql.test.util.KsqlIdentifierTestUtil;
 import io.confluent.ksql.util.KsqlConfig;
@@ -314,7 +315,11 @@ public class CliTest {
     );
   }
 
-  private void testCreateStreamAsSelect(String selectQuery, final Schema resultSchema, final Map<String, GenericRow> expectedResults) {
+  private void testCreateStreamAsSelect(
+      String selectQuery,
+      final KsqlSchema resultSchema,
+      final Map<String, GenericRow> expectedResults
+  ) {
     if (!selectQuery.endsWith(";")) {
       selectQuery += ";";
     }
@@ -550,11 +555,11 @@ public class CliTest {
             80.0,
             new Double[]{1100.0, 1110.99, 970.0})));
 
-    final Schema resultSchema = SchemaBuilder.struct()
+    final KsqlSchema resultSchema = KsqlSchema.of(SchemaBuilder.struct()
         .field("ITEMID", SchemaBuilder.OPTIONAL_STRING_SCHEMA)
         .field("ORDERUNITS", SchemaBuilder.OPTIONAL_FLOAT64_SCHEMA)
         .field("PRICEARRAY", SchemaBuilder.array(SchemaBuilder.OPTIONAL_FLOAT64_SCHEMA).optional().build())
-        .build();
+        .build());
 
     testCreateStreamAsSelect(
         "SELECT ITEMID, ORDERUNITS, PRICEARRAY FROM " + orderDataProvider.kstreamName(),
@@ -615,14 +620,14 @@ public class CliTest {
         orderDataProvider.kstreamName()
     );
 
-    final Schema sourceSchema = orderDataProvider.schema();
-    final Schema resultSchema = SchemaBuilder.struct()
+    final Schema sourceSchema = orderDataProvider.schema().getSchema();
+    final KsqlSchema resultSchema = KsqlSchema.of(SchemaBuilder.struct()
         .field("ITEMID", sourceSchema.field("ITEMID").schema())
         .field("COL1", sourceSchema.field("ORDERUNITS").schema())
         .field("COL2", sourceSchema.field("PRICEARRAY").schema().valueSchema())
         .field("COL3", sourceSchema.field("KEYVALUEMAP").schema().valueSchema())
         .field("COL4", SchemaBuilder.OPTIONAL_BOOLEAN_SCHEMA)
-        .build();
+        .build());
 
     final Map<String, GenericRow> expectedResults = new HashMap<>();
     expectedResults.put("8", new GenericRow(ImmutableList.of("ITEM_8", 800.0, 1110.0, 12.0, true)));

--- a/ksql-cli/src/test/java/io/confluent/ksql/cli/console/ConsoleTest.java
+++ b/ksql-cli/src/test/java/io/confluent/ksql/cli/console/ConsoleTest.java
@@ -58,6 +58,7 @@ import io.confluent.ksql.rest.entity.TablesList;
 import io.confluent.ksql.rest.entity.TopicDescription;
 import io.confluent.ksql.rest.server.computation.CommandId;
 import io.confluent.ksql.rest.util.EntityUtil;
+import io.confluent.ksql.schema.ksql.KsqlSchema;
 import io.confluent.ksql.schema.ksql.LogicalSchemas;
 import io.confluent.ksql.serde.Format;
 import java.io.IOException;
@@ -388,6 +389,6 @@ public class ConsoleTest {
     for (int i = 0; i < size; i++) {
       dataSourceBuilder.field("f_" + i, LogicalSchemas.STRING);
     }
-    return EntityUtil.buildSourceSchemaEntity(dataSourceBuilder.build());
+    return EntityUtil.buildSourceSchemaEntity(KsqlSchema.of(dataSourceBuilder.build()));
   }
 }

--- a/ksql-common/src/main/java/io/confluent/ksql/schema/ksql/KsqlSchema.java
+++ b/ksql-common/src/main/java/io/confluent/ksql/schema/ksql/KsqlSchema.java
@@ -15,16 +15,29 @@
 
 package io.confluent.ksql.schema.ksql;
 
-import static java.util.Objects.requireNonNull;
-
+import com.google.common.collect.ImmutableMap;
 import com.google.errorprone.annotations.Immutable;
+import io.confluent.ksql.util.KsqlException;
+import io.confluent.ksql.util.SchemaUtil;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Optional;
+import java.util.OptionalInt;
+import java.util.Set;
+import java.util.function.Consumer;
+import java.util.stream.Collectors;
 import org.apache.kafka.connect.data.ConnectSchema;
+import org.apache.kafka.connect.data.Field;
 import org.apache.kafka.connect.data.Schema;
+import org.apache.kafka.connect.data.Schema.Type;
+import org.apache.kafka.connect.data.SchemaBuilder;
 
 /**
  * Immutable KSQL logical schema.
  *
- * <p>KSQL's logical schema uses the Connect {@link org.apache.kafka.connect.data.Schema}
+ * <p>KSQL's logical schema internal uses the Connect {@link org.apache.kafka.connect.data.Schema}
  * interface. The interface has two main implementations: a mutable {@link
  * org.apache.kafka.connect.data.SchemaBuilder} and an immutable {@link
  * org.apache.kafka.connect.data.ConnectSchema}.
@@ -40,39 +53,251 @@ import org.apache.kafka.connect.data.Schema;
 @Immutable
 public final class KsqlSchema {
 
-  private final Schema schema;
+  private static final Consumer<Schema> NO_ADDITIONAL_VALIDATION = schema -> {
+  };
+
+  private static final Map<Type, Consumer<Schema>> VALIDATORS =
+      ImmutableMap.<Type, Consumer<Schema>>builder()
+          .put(Type.BOOLEAN, NO_ADDITIONAL_VALIDATION)
+          .put(Type.INT32, NO_ADDITIONAL_VALIDATION)
+          .put(Type.INT64, NO_ADDITIONAL_VALIDATION)
+          .put(Type.FLOAT64, NO_ADDITIONAL_VALIDATION)
+          .put(Type.STRING, NO_ADDITIONAL_VALIDATION)
+          .put(Type.ARRAY, KsqlSchema::validateArray)
+          .put(Type.MAP, KsqlSchema::validateMap)
+          .put(Type.STRUCT, KsqlSchema::validateStruct)
+          .build();
+
+  private final ConnectSchema schema;
 
   public static KsqlSchema of(final Schema schema) {
     return new KsqlSchema(schema);
   }
 
   private KsqlSchema(final Schema schema) {
-    this.schema = requireNonNull(schema, "schema").schema();
-    throwIfMutable(this.schema);
+    this.schema = validate(Objects.requireNonNull(schema, "schema"), true);
   }
 
   public Schema getSchema() {
     return schema;
   }
 
-  private static void throwIfMutable(final Schema schema) {
+  public List<Field> fields() {
+    return schema.fields();
+  }
+
+  public KsqlSchema withAlias(final String alias) {
+    final SchemaBuilder newSchema = SchemaBuilder
+        .struct()
+        .name(schema.name());
+
+    for (final Field field : schema.fields()) {
+      final String aliased = SchemaUtil.buildAliasedFieldName(alias, field.name());
+      newSchema.field(aliased, field.schema());
+    }
+
+    return KsqlSchema.of(newSchema.build());
+  }
+
+  /**
+   * Add implicit fields to the schema.
+   *
+   * <p>Implicit fields are:
+   * <ol>
+   * <li>{@link SchemaUtil#ROWTIME_NAME}</li>
+   * <li>{@link SchemaUtil#ROWKEY_NAME}</li>
+   * </ol>
+   *
+   * <p>If the implicit fields already exist, the function returns the same schema.
+   *
+   * <p><b>NOTE:</b> the function does NOT take any aliases in the fields into account
+   *
+   * @return the new schema with the (unaliased) implicit fields added.
+   */
+  public KsqlSchema withImplicitFields() {
+    final SchemaBuilder schemaBuilder = SchemaBuilder.struct();
+    schemaBuilder.field(SchemaUtil.ROWTIME_NAME, Schema.OPTIONAL_INT64_SCHEMA);
+    schemaBuilder.field(SchemaUtil.ROWKEY_NAME, Schema.OPTIONAL_STRING_SCHEMA);
+    for (final Field field : ((Schema) schema).fields()) {
+      if (!field.name().equals(SchemaUtil.ROWKEY_NAME)
+          && !field.name().equals(SchemaUtil.ROWTIME_NAME)) {
+        schemaBuilder.field(field.name(), field.schema());
+      }
+    }
+    return KsqlSchema.of(schemaBuilder.build());
+  }
+
+  /**
+   * Remove implicit fields to the schema.
+   *
+   * <p>Implicit fields are:
+   * <ol>
+   * <li>{@link SchemaUtil#ROWTIME_NAME}</li>
+   * <li>{@link SchemaUtil#ROWKEY_NAME}</li>
+   * </ol>
+   *
+   * <p><b>NOTE:</b> the function DOES take any aliases in the fields into account.
+   *
+   * <p><b>NOTE:</b> the function also removes aliasing from any other fields.
+   *
+   * @return the new schema with the implicit fields removed and any aliasing removed.
+   */
+  public KsqlSchema withoutImplicitFields() {
+    final SchemaBuilder schemaBuilder = SchemaBuilder.struct();
+    for (final Field field : getSchema().fields()) {
+      String fieldName = field.name();
+      fieldName = fieldName.substring(fieldName.indexOf(SchemaUtil.FIELD_NAME_DELIMITER) + 1);
+      if (!fieldName.equalsIgnoreCase(SchemaUtil.ROWTIME_NAME)
+          && !fieldName.equalsIgnoreCase(SchemaUtil.ROWKEY_NAME)) {
+        schemaBuilder.field(fieldName, field.schema());
+      }
+    }
+    return KsqlSchema.of(schemaBuilder.build());
+  }
+
+  public Set<Integer> implicitColumnIndexes() {
+    final Set<Integer> indexSet = new HashSet<>();
+    for (int i = 0; i < ((Schema) schema).fields().size(); i++) {
+      final Field field = ((Schema) schema).fields().get(i);
+      if (field.name().equalsIgnoreCase(SchemaUtil.ROWTIME_NAME)
+          || field.name().equalsIgnoreCase(SchemaUtil.ROWKEY_NAME)) {
+        indexSet.add(i);
+      }
+    }
+    return indexSet;
+  }
+
+  public Optional<Field> findField(final String fieldName) {
+    return schema.fields()
+        .stream()
+        .filter(f -> SchemaUtil.matchFieldName(f, fieldName))
+        .findFirst();
+  }
+
+  public OptionalInt findFieldIndex(final String fieldName) {
+    if (schema.fields() == null) {
+      return OptionalInt.empty();
+    }
+
+    for (int i = 0; i < schema.fields().size(); i++) {
+      final Field field = schema.fields().get(i);
+      final int dotIndex = field.name().indexOf(SchemaUtil.FIELD_NAME_DELIMITER);
+      if (dotIndex == -1) {
+        if (field.name().equals(fieldName)) {
+          return OptionalInt.of(i);
+        }
+      } else {
+        if (dotIndex < fieldName.length()) {
+          final String fieldNameWithDot =
+              fieldName.substring(0, dotIndex)
+                  + SchemaUtil.FIELD_NAME_DELIMITER
+                  + fieldName.substring(dotIndex + 1);
+          if (field.name().equals(fieldNameWithDot)) {
+            return OptionalInt.of(i);
+          }
+        }
+      }
+
+    }
+    return OptionalInt.empty();
+  }
+
+  /**
+   * Simpliar to {@link #findFieldIndex(String)}, except requires an exact match.
+   *
+   * @param fieldName the exact name of the field.
+   * @return the name of the field.
+   */
+  public int fieldIndex(final String fieldName) {
+    for (int i = 0; i < schema.fields().size(); i++) {
+      final Field field = schema.fields().get(i);
+      if (field.name().equals(fieldName)) {
+        return i;
+      }
+    }
+
+    throw new KsqlException("Could not find field in schema."
+        + " field: " + fieldName
+        + " schema: " + schema
+    );
+  }
+
+  @Override
+  public boolean equals(final Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    final KsqlSchema that = (KsqlSchema) o;
+    return schemasAreEqual(schema, that.schema);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(schema);
+  }
+
+  @Override
+  public String toString() {
+    return schema.fields().stream()
+        .map(field -> field.name() + " : " + SchemaUtil.getSqlTypeName(field.schema()))
+        .collect(Collectors.joining(", ", "[", "]"));
+  }
+
+  private static ConnectSchema validate(final Schema schema, final boolean topLevel) {
+    if (topLevel && schema.type() != Type.STRUCT) {
+      throw new IllegalArgumentException("Top level schema must be STRUCT. schema: " + schema);
+    }
+
     if (!(schema instanceof ConnectSchema)) {
       throw new IllegalArgumentException("Mutable schema found: " + schema);
     }
 
-    switch (schema.type()) {
-      case STRUCT:
-        schema.fields().forEach(field -> throwIfMutable(field.schema()));
-        break;
-      case MAP:
-        throwIfMutable(schema.keySchema());
-        throwIfMutable(schema.valueSchema());
-        break;
-      case ARRAY:
-        throwIfMutable(schema.valueSchema());
-        break;
-      default:
-        break;
+    final Consumer<Schema> validator = VALIDATORS.get(schema.type());
+    if (validator == null) {
+      throw new IllegalArgumentException("Unsupported schema type: " + schema);
+    }
+
+    validator.accept(schema);
+    return (ConnectSchema) schema;
+  }
+
+  private static void validateArray(final Schema schema) {
+    validate(schema.valueSchema(), false);
+  }
+
+  private static void validateMap(final Schema schema) {
+    if (schema.keySchema().type() != Type.STRING) {
+      throw new IllegalArgumentException("MAP only supports STRING keys");
+    }
+
+    validate(schema.keySchema(), false);
+    validate(schema.valueSchema(), false);
+  }
+
+  private static void validateStruct(final Schema schema) {
+    for (int idx = 0; idx != schema.fields().size(); ++idx) {
+      final Field field = schema.fields().get(idx);
+      validate(field.schema(), false);
     }
   }
+
+  private static boolean schemasAreEqual(final Schema schema1, final Schema schema2) {
+    if (schema1.fields().size() != schema2.fields().size()) {
+      return false;
+    }
+
+    for (int i = 0; i < schema1.fields().size(); i++) {
+      final Field f1 = schema1.fields().get(i);
+      final Field f2 = schema2.fields().get(i);
+      if (!f1.equals(f2)) {
+        return false;
+      }
+    }
+
+    return true;
+  }
 }
+

--- a/ksql-common/src/main/java/io/confluent/ksql/util/timestamp/TimestampExtractionPolicyFactory.java
+++ b/ksql-common/src/main/java/io/confluent/ksql/util/timestamp/TimestampExtractionPolicyFactory.java
@@ -16,8 +16,8 @@
 package io.confluent.ksql.util.timestamp;
 
 import io.confluent.ksql.ddl.DdlConfig;
+import io.confluent.ksql.schema.ksql.KsqlSchema;
 import io.confluent.ksql.util.KsqlException;
-import io.confluent.ksql.util.SchemaUtil;
 import io.confluent.ksql.util.StringUtil;
 import org.apache.kafka.connect.data.Field;
 import org.apache.kafka.connect.data.Schema;
@@ -28,7 +28,7 @@ public final class TimestampExtractionPolicyFactory {
   }
 
   public static TimestampExtractionPolicy create(
-      final Schema schema,
+      final KsqlSchema schema,
       final String timestampColumnName,
       final String timestampFormat) {
     if (timestampColumnName == null) {
@@ -36,8 +36,7 @@ public final class TimestampExtractionPolicyFactory {
     }
 
     final String fieldName = StringUtil.cleanQuotes(timestampColumnName.toUpperCase());
-    final Field timestampField = SchemaUtil.getFieldByName(schema,
-        fieldName)
+    final Field timestampField = schema.findField(fieldName)
         .orElseThrow(() -> new KsqlException(
             "The TIMESTAMP column set in the WITH clause does not exist in the schema: '"
                 + fieldName + "'"));

--- a/ksql-common/src/test/java/io/confluent/ksql/schema/ksql/KsqlSchemaTest.java
+++ b/ksql-common/src/test/java/io/confluent/ksql/schema/ksql/KsqlSchemaTest.java
@@ -16,64 +16,552 @@
 package io.confluent.ksql.schema.ksql;
 
 import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.Matchers.instanceOf;
+import static org.hamcrest.Matchers.containsInAnyOrder;
+import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.Matchers.empty;
+import static org.hamcrest.Matchers.hasSize;
 import static org.hamcrest.Matchers.is;
-import static org.hamcrest.Matchers.sameInstance;
+import static org.junit.Assert.fail;
 
-import org.apache.kafka.connect.data.ConnectSchema;
+import com.google.common.testing.EqualsTester;
+import io.confluent.ksql.util.SchemaUtil;
+import java.util.Optional;
+import java.util.OptionalInt;
+import java.util.Set;
+import java.util.stream.Stream;
+import org.apache.kafka.connect.data.Field;
 import org.apache.kafka.connect.data.Schema;
+import org.apache.kafka.connect.data.Schema.Type;
 import org.apache.kafka.connect.data.SchemaBuilder;
+import org.junit.Ignore;
+import org.junit.Rule;
 import org.junit.Test;
+import org.junit.rules.ExpectedException;
 
 public class KsqlSchemaTest {
 
   private static final Schema IMMUTABLE_SCHEMA = Schema.OPTIONAL_STRING_SCHEMA;
-  private static final SchemaBuilder MUTABLE_SCHEMA = SchemaBuilder.int32();
+  private static final SchemaBuilder MUTABLE_SCHEMA = SchemaBuilder.struct()
+      .optional()
+      .field("f0", Schema.OPTIONAL_INT64_SCHEMA);
+
+  private static final Schema SOME_CONNECT_SCHEMA = SchemaBuilder.struct()
+      .field("f0", SchemaBuilder.OPTIONAL_STRING_SCHEMA)
+      .field("f1", SchemaBuilder.OPTIONAL_INT64_SCHEMA)
+      .build();
+
+  private static final Schema ALIASED_CONNECT_SCHEMA = SchemaBuilder.struct()
+      .field("bob.f0", SchemaBuilder.OPTIONAL_STRING_SCHEMA)
+      .field("bob.f1", SchemaBuilder.OPTIONAL_INT64_SCHEMA)
+      .build();
+
+  private static final KsqlSchema SOME_SCHEMA = KsqlSchema.of(SOME_CONNECT_SCHEMA);
+  private static final KsqlSchema ALIASED_SCHEMA = KsqlSchema.of(ALIASED_CONNECT_SCHEMA);
+
+  @Rule
+  public final ExpectedException expectedException = ExpectedException.none();
 
   @Test
-  public void shouldDoNothingToImmutableSchema() {
-    assertThat(KsqlSchema.of(IMMUTABLE_SCHEMA).getSchema(), is(sameInstance(IMMUTABLE_SCHEMA)));
+  public void shouldImplementEqualsProperly() {
+    new EqualsTester()
+        .addEqualityGroup(
+            KsqlSchema.of(SOME_CONNECT_SCHEMA), KsqlSchema.of(SOME_CONNECT_SCHEMA)
+        ).addEqualityGroup(
+        KsqlSchema.of(ALIASED_CONNECT_SCHEMA)
+    )
+        .testEquals();
   }
 
   @Test
-  public void shouldBuildMutableSchemaIntoImmutableSchema() {
-    assertThat(KsqlSchema.of(MUTABLE_SCHEMA).getSchema(), is(instanceOf(ConnectSchema.class)));
+  public void shouldThrowOnNoneSqlTypes() {
+    Stream.of(
+        Schema.OPTIONAL_INT8_SCHEMA,
+        Schema.OPTIONAL_INT16_SCHEMA,
+        Schema.OPTIONAL_FLOAT32_SCHEMA,
+        Schema.OPTIONAL_BYTES_SCHEMA
+
+    ).forEach(schema -> {
+      try {
+        KsqlSchema.of(SchemaBuilder.struct().field("test", schema).build());
+        fail();
+      } catch (final IllegalArgumentException e) {
+        assertThat(schema.toString(), e.getMessage(), containsString("Unsupported schema type"));
+      }
+    });
   }
 
-  @Test(expected = IllegalArgumentException.class)
+  @Test
   public void shouldThrowOnMutableStructFields() {
+    // Then:
+    expectedException.expect(IllegalArgumentException.class);
+    expectedException.expectMessage("Mutable schema found");
+
+    // When:
     KsqlSchema.of(nested(
         SchemaBuilder.struct()
             .field("fieldWithMutableSchema", MUTABLE_SCHEMA)
+            .optional()
             .build()
     ));
   }
 
-  @Test(expected = IllegalArgumentException.class)
+  @Test
   public void shouldThrowOnMutableMapKeys() {
+    // Then:
+    expectedException.expect(IllegalArgumentException.class);
+    expectedException.expectMessage("Mutable schema found");
+
+    // When:
     KsqlSchema.of(nested(
-        SchemaBuilder.array(
-            SchemaBuilder.map(MUTABLE_SCHEMA, IMMUTABLE_SCHEMA).build()
-        ).build()
+        SchemaBuilder.map(new SchemaBuilder(Type.STRING).optional(), IMMUTABLE_SCHEMA)
+            .optional()
+            .build()
     ));
   }
 
-  @Test(expected = IllegalArgumentException.class)
+  @Test
   public void shouldThrowOnMutableMapValues() {
+    // Then:
+    expectedException.expect(IllegalArgumentException.class);
+    expectedException.expectMessage("Mutable schema found");
+
+    // When:
     KsqlSchema.of(nested(
-        SchemaBuilder.map(IMMUTABLE_SCHEMA, MUTABLE_SCHEMA).build()
+        SchemaBuilder.map(IMMUTABLE_SCHEMA, MUTABLE_SCHEMA)
+            .optional()
+            .build()
     ));
   }
 
-  @Test(expected = IllegalArgumentException.class)
+  @Test
   public void shouldThrowOnMutableArrayElements() {
+    // Then:
+    expectedException.expect(IllegalArgumentException.class);
+    expectedException.expectMessage("Mutable schema found");
+
+    // When:
     KsqlSchema.of(nested(
-        SchemaBuilder.array(MUTABLE_SCHEMA).build()
+        SchemaBuilder.array(MUTABLE_SCHEMA)
+            .optional()
+            .build()
     ));
+  }
+
+  @Ignore // Currently ignored as UDFs can result in non-optional schema fields.
+  @Test
+  public void shouldThrowOnNoneOptionalMapKeys() {
+    // Then:
+    expectedException.expect(IllegalArgumentException.class);
+    expectedException.expectMessage("Non-optional field found");
+
+    // When:
+    KsqlSchema.of(nested(
+        SchemaBuilder.map(IMMUTABLE_SCHEMA, IMMUTABLE_SCHEMA)
+            .build()
+    ));
+  }
+
+  @Ignore // Currently ignored as UDFs can result in non-optional schema fields.
+  @Test
+  public void shouldThrowOnNoneOptionalMapValues() {
+    // Then:
+    expectedException.expect(IllegalArgumentException.class);
+    expectedException.expectMessage("Non-optional field found");
+
+    // When:
+    KsqlSchema.of(nested(
+        SchemaBuilder.map(IMMUTABLE_SCHEMA, IMMUTABLE_SCHEMA).build()
+    ));
+  }
+
+  @Ignore // Currently ignored as UDFs can result in non-optional schema fields.
+  @Test
+  public void shouldThrowOnNoneOptionalElements() {
+    // Then:
+    expectedException.expect(IllegalArgumentException.class);
+    expectedException.expectMessage("Non-optional field found");
+
+    // When:
+    KsqlSchema.of(nested(
+        SchemaBuilder.array(IMMUTABLE_SCHEMA).build()
+    ));
+  }
+
+  @Test
+  public void shouldNotThrowIfTopLevelNotOptional() {
+    // Given:
+    final Schema schema = SchemaBuilder.struct()
+        .field("f0", Schema.OPTIONAL_INT64_SCHEMA)
+        .build();
+
+    // When:
+    KsqlSchema.of(schema);
+
+    // Then: did not throw.
+  }
+
+  @Test
+  public void shouldThrowOnNoneStringMapLey() {
+    // Then:
+    expectedException.expect(IllegalArgumentException.class);
+    expectedException.expectMessage("MAP only supports STRING keys");
+
+    // When:
+    KsqlSchema.of(nested(
+        SchemaBuilder.map(Schema.OPTIONAL_INT64_SCHEMA, IMMUTABLE_SCHEMA)
+            .optional()
+            .build()
+    ));
+  }
+
+  @Test
+  public void shouldBuildSchemaWithAlias() {
+    // When:
+    final KsqlSchema result = SOME_SCHEMA.withAlias("bob");
+
+    // Then:
+    assertThat(result, is(ALIASED_SCHEMA));
+  }
+
+  @Test
+  public void shouldCopySchemaIfSchemaAlreadyAliased() {
+    // When:
+    final KsqlSchema result = ALIASED_SCHEMA.withAlias("bob");
+
+    // Then:
+    assertThat(result, is(ALIASED_SCHEMA));
+  }
+
+  @Test
+  public void shouldOnlyAddAliasToTopLevelFields() {
+    // Given:
+    final KsqlSchema schema = KsqlSchema.of(
+        SchemaBuilder.struct()
+            .field("f0", SchemaBuilder.OPTIONAL_STRING_SCHEMA)
+            .field("f1", SchemaBuilder.struct()
+                .field("nested", Schema.OPTIONAL_INT64_SCHEMA)
+                .optional()
+                .build())
+            .build()
+    );
+
+    // When:
+    final KsqlSchema result = schema.withAlias("bob");
+
+    // Then:
+    assertThat(result, is(KsqlSchema.of(SchemaBuilder.struct()
+        .field("bob.f0", SchemaBuilder.OPTIONAL_STRING_SCHEMA)
+        .field("bob.f1", SchemaBuilder
+            .struct()
+            .field("nested", Schema.OPTIONAL_INT64_SCHEMA)
+            .optional()
+            .build())
+        .build())));
+  }
+
+  @Test
+  public void shouldGetFieldByName() {
+    // When:
+    final Optional<Field> result = SOME_SCHEMA.findField("f0");
+
+    // Then:
+    assertThat(result, is(Optional.of(SOME_CONNECT_SCHEMA.field("f0"))));
+  }
+
+  @Test
+  public void shouldGetFieldByAliasedName() {
+    // When:
+    final Optional<Field> result = SOME_SCHEMA.findField("SomeAlias.f0");
+
+    // Then:
+    assertThat(result, is(Optional.of(SOME_CONNECT_SCHEMA.field("f0"))));
+  }
+
+  @Test
+  public void shouldNotGetFieldByNameIfWrongCase() {
+    // When:
+    final Optional<Field> result = SOME_SCHEMA.findField("F0");
+
+    // Then:
+    assertThat(result, is(Optional.empty()));
+  }
+
+  @Test
+  public void shouldNotGetFieldByNameIfFieldIsAliasedAndNameIsNot() {
+    // When:
+    final Optional<Field> result = ALIASED_SCHEMA.findField("f0");
+
+    // Then:
+    assertThat(result, is(Optional.empty()));
+  }
+
+  @Test
+  public void shouldGetFieldByNameIfBothFieldAndNameAreAliased() {
+    // When:
+    final Optional<Field> result = ALIASED_SCHEMA.findField("bob.f0");
+
+    // Then:
+    assertThat(result, is(Optional.of(ALIASED_CONNECT_SCHEMA.field("bob.f0"))));
+  }
+
+  @Test
+  public void shouldGetFieldIndex() {
+    assertThat(SOME_SCHEMA.findFieldIndex("f0"), is(OptionalInt.of(0)));
+    assertThat(SOME_SCHEMA.findFieldIndex("f1"), is(OptionalInt.of(1)));
+  }
+
+  @Test
+  public void shouldReturnMinusOneForIndexIfFieldNotFound() {
+    assertThat(SOME_SCHEMA.findFieldIndex("wontfindme"), is(OptionalInt.empty()));
+  }
+
+  @Test
+  public void shouldNotFindFieldIfDifferentCase() {
+    assertThat(SOME_SCHEMA.findFieldIndex("F0"), is(OptionalInt.empty()));
+  }
+
+  @Test
+  public void shouldGetAliasedFieldIndex() {
+    assertThat(ALIASED_SCHEMA.findFieldIndex("bob.f1"), is(OptionalInt.of(1)));
+  }
+
+  @Test
+  public void shouldNotFindUnaliasedFieldIndexInAliasedSchema() {
+    assertThat(ALIASED_SCHEMA.findFieldIndex("f1"), is(OptionalInt.empty()));
+  }
+
+  @Test
+  public void shouldNotFindAliasedFieldIndexInUnaliasedSchema() {
+    assertThat(SOME_SCHEMA.findFieldIndex("bob.f1"), is(OptionalInt.empty()));
+  }
+
+  @Test
+  public void shouldExposeFields() {
+    assertThat(SOME_SCHEMA.fields(), is(SOME_CONNECT_SCHEMA.fields()));
+  }
+
+  @Test
+  public void shouldConvertSchemaToString() {
+    // Given:
+    final KsqlSchema schema = KsqlSchema.of(
+        SchemaBuilder.struct()
+            .field("f0", SchemaBuilder.OPTIONAL_BOOLEAN_SCHEMA)
+            .field("f1", SchemaBuilder.OPTIONAL_INT32_SCHEMA)
+            .field("f2", SchemaBuilder.OPTIONAL_INT64_SCHEMA)
+            .field("f4", SchemaBuilder.OPTIONAL_FLOAT64_SCHEMA)
+            .field("f5", SchemaBuilder.OPTIONAL_STRING_SCHEMA)
+            .field("f6", SchemaBuilder
+                .struct()
+                .field("a", Schema.OPTIONAL_INT64_SCHEMA)
+                .optional()
+                .build())
+            .field("f7", SchemaBuilder
+                .array(
+                    SchemaBuilder.OPTIONAL_STRING_SCHEMA
+                )
+                .optional()
+                .build())
+            .field("f8", SchemaBuilder
+                .map(
+                    SchemaBuilder.OPTIONAL_STRING_SCHEMA,
+                    SchemaBuilder.OPTIONAL_STRING_SCHEMA
+                )
+                .optional()
+                .build())
+            .build()
+    );
+
+    // When:
+    final String s = schema.toString();
+
+    // Then:
+    assertThat(s, is(
+        "["
+            + "f0 : BOOLEAN, "
+            + "f1 : INT, "
+            + "f2 : BIGINT, "
+            + "f4 : DOUBLE, "
+            + "f5 : VARCHAR, "
+            + "f6 : STRUCT<a BIGINT>, "
+            + "f7 : ARRAY<VARCHAR>, "
+            + "f8 : MAP<VARCHAR,VARCHAR>"
+            + "]"));
+  }
+
+  @Test
+  public void shouldAddImplicitColumns() {
+    // When:
+    final KsqlSchema result = KsqlSchema.of(SOME_CONNECT_SCHEMA).withImplicitFields();
+
+    // Then:
+    assertThat(result.fields(), hasSize(SOME_CONNECT_SCHEMA.fields().size() + 2));
+    assertThat(result.fields().get(0).name(), is(SchemaUtil.ROWTIME_NAME));
+    assertThat(result.fields().get(0).index(), is(0));
+    assertThat(result.fields().get(0).schema(), is(Schema.OPTIONAL_INT64_SCHEMA));
+    assertThat(result.fields().get(1).name(), is(SchemaUtil.ROWKEY_NAME));
+    assertThat(result.fields().get(1).index(), is(1));
+    assertThat(result.fields().get(1).schema(), is(Schema.OPTIONAL_STRING_SCHEMA));
+  }
+
+  @Test
+  public void shouldAddImplicitColumnsOnlyOnce() {
+    // Given:
+    final KsqlSchema ksqlSchema = KsqlSchema.of(SOME_CONNECT_SCHEMA)
+        .withImplicitFields();
+
+    // When:
+    final KsqlSchema result = ksqlSchema.withImplicitFields();
+
+    // Then:
+    assertThat(result, is(ksqlSchema));
+  }
+
+  @Test
+  public void shouldRemoveOtherImplicitsWhenAddingImplicit() {
+    // Given:
+    final KsqlSchema ksqlSchema = KsqlSchema.of(SchemaBuilder.struct()
+        .field("f0", Schema.OPTIONAL_INT64_SCHEMA)
+        .field(SchemaUtil.ROWKEY_NAME, Schema.OPTIONAL_FLOAT64_SCHEMA)
+        .field("f1", Schema.OPTIONAL_INT64_SCHEMA)
+        .field(SchemaUtil.ROWTIME_NAME, Schema.OPTIONAL_FLOAT64_SCHEMA)
+        .build()
+    );
+
+    // When:
+    final KsqlSchema result = ksqlSchema.withImplicitFields();
+
+    // Then:
+    assertThat(result, is(KsqlSchema.of(SchemaBuilder.struct()
+        .field(SchemaUtil.ROWTIME_NAME, Schema.OPTIONAL_INT64_SCHEMA)
+        .field(SchemaUtil.ROWKEY_NAME, Schema.OPTIONAL_STRING_SCHEMA)
+        .field("f0", Schema.OPTIONAL_INT64_SCHEMA)
+        .field("f1", Schema.OPTIONAL_INT64_SCHEMA)
+        .build()
+    )));
+  }
+
+  @Test
+  public void shouldRemoveImplicitFields() {
+    // Given:
+    final KsqlSchema schema = KsqlSchema.of(SchemaBuilder.struct()
+        .field(SchemaUtil.ROWTIME_NAME, Schema.OPTIONAL_INT64_SCHEMA)
+        .field(SchemaUtil.ROWKEY_NAME, Schema.OPTIONAL_STRING_SCHEMA)
+        .field("f0", Schema.OPTIONAL_INT64_SCHEMA)
+        .field("f1", Schema.OPTIONAL_INT64_SCHEMA)
+        .build()
+    );
+
+    // When
+    final KsqlSchema result = schema.withoutImplicitFields();
+
+    // Then:
+    assertThat(result, is(KsqlSchema.of(SchemaBuilder.struct()
+        .field("f0", Schema.OPTIONAL_INT64_SCHEMA)
+        .field("f1", Schema.OPTIONAL_INT64_SCHEMA)
+        .build()
+    )));
+  }
+
+  @Test
+  public void shouldRemoveImplicitFieldsWhereEverTheyAre() {
+    // Given:
+    final KsqlSchema schema = KsqlSchema.of(SchemaBuilder.struct()
+        .field("f0", Schema.OPTIONAL_INT64_SCHEMA)
+        .field(SchemaUtil.ROWKEY_NAME, Schema.OPTIONAL_STRING_SCHEMA)
+        .field("f1", Schema.OPTIONAL_INT64_SCHEMA)
+        .field(SchemaUtil.ROWTIME_NAME, Schema.OPTIONAL_INT64_SCHEMA)
+        .build()
+    );
+
+    // When
+    final KsqlSchema result = schema.withoutImplicitFields();
+
+    // Then:
+    assertThat(result, is(KsqlSchema.of(SchemaBuilder.struct()
+        .field("f0", Schema.OPTIONAL_INT64_SCHEMA)
+        .field("f1", Schema.OPTIONAL_INT64_SCHEMA)
+        .build()
+    )));
+  }
+
+  @Test
+  public void shouldRemoveImplicitFieldsEvenIfAliased() {
+    // Given:
+    final KsqlSchema schema = KsqlSchema.of(SchemaBuilder.struct()
+        .field("bob.f0", Schema.OPTIONAL_INT64_SCHEMA)
+        .field("bob." + SchemaUtil.ROWKEY_NAME, Schema.OPTIONAL_STRING_SCHEMA)
+        .field("bob.f1", Schema.OPTIONAL_INT64_SCHEMA)
+        .field("bob." + SchemaUtil.ROWTIME_NAME, Schema.OPTIONAL_INT64_SCHEMA)
+        .build()
+    );
+
+    // When
+    final KsqlSchema result = schema.withoutImplicitFields();
+
+    // Then:
+    assertThat(result, is(KsqlSchema.of(SchemaBuilder.struct()
+        .field("f0", Schema.OPTIONAL_INT64_SCHEMA)
+        .field("f1", Schema.OPTIONAL_INT64_SCHEMA)
+        .build()
+    )));
+  }
+
+  @Test
+  public void shouldGetImplicitColumnIndexes() {
+    // Given:
+    final KsqlSchema schema = KsqlSchema.of(SchemaBuilder.struct()
+        .field("f0", Schema.OPTIONAL_INT64_SCHEMA)
+        .field(SchemaUtil.ROWKEY_NAME, Schema.OPTIONAL_STRING_SCHEMA)
+        .field("f1", Schema.OPTIONAL_INT64_SCHEMA)
+        .field(SchemaUtil.ROWTIME_NAME, Schema.OPTIONAL_INT64_SCHEMA)
+        .build()
+    );
+
+    // When
+    final Set<Integer> result = schema.implicitColumnIndexes();
+
+    // Then:
+    assertThat(result, containsInAnyOrder(1, 3));
+  }
+
+  @Test
+  public void shouldGetNoImplicitColumnIndexesIfImplicitColumnsAsAliased() {
+    // Given:
+    final KsqlSchema schema = KsqlSchema.of(SchemaBuilder.struct()
+        .field("bob.f0", Schema.OPTIONAL_INT64_SCHEMA)
+        .field("bob." + SchemaUtil.ROWKEY_NAME, Schema.OPTIONAL_STRING_SCHEMA)
+        .field("bob.f1", Schema.OPTIONAL_INT64_SCHEMA)
+        .field("bob." + SchemaUtil.ROWTIME_NAME, Schema.OPTIONAL_INT64_SCHEMA)
+        .build()
+    );
+
+    // When
+    final Set<Integer> result = schema.implicitColumnIndexes();
+
+    // Then:
+    assertThat(result, is(empty()));
+  }
+
+  @Test
+  public void shouldGetNoImplicitColumnIndexesIfNoImplicitColumns() {
+    // Given:
+    final KsqlSchema schema = KsqlSchema.of(SchemaBuilder.struct()
+        .field("f0", Schema.OPTIONAL_INT64_SCHEMA)
+        .field("f1", Schema.OPTIONAL_INT64_SCHEMA)
+        .build()
+    );
+
+    // When
+    final Set<Integer> result = schema.implicitColumnIndexes();
+
+    // Then:
+    assertThat(result, is(empty()));
   }
 
   private static Schema nested(final Schema schema) {
     // Nest the schema under test within another layer of schema to ensure checks are deep:
-    return SchemaBuilder.array(schema).build();
+    return SchemaBuilder.struct()
+        .field("f0", schema)
+        .build();
   }
 }

--- a/ksql-common/src/test/java/io/confluent/ksql/util/SchemaTestUtil.java
+++ b/ksql-common/src/test/java/io/confluent/ksql/util/SchemaTestUtil.java
@@ -22,6 +22,8 @@ import org.apache.kafka.connect.data.SchemaBuilder;
 
 public final class SchemaTestUtil {
 
+  private SchemaTestUtil() {}
+
   /**
    * Remove the alias when reading/writing from outside
    */

--- a/ksql-common/src/test/java/io/confluent/ksql/util/SchemaUtilTest.java
+++ b/ksql-common/src/test/java/io/confluent/ksql/util/SchemaUtilTest.java
@@ -18,15 +18,12 @@ package io.confluent.ksql.util;
 import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.CoreMatchers.nullValue;
-import static org.hamcrest.CoreMatchers.sameInstance;
 import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.Matchers.hasSize;
 import static org.hamcrest.Matchers.notNullValue;
 
 import java.lang.reflect.Type;
 import java.util.List;
 import java.util.Map;
-import java.util.Optional;
 import org.apache.kafka.connect.data.Field;
 import org.apache.kafka.connect.data.Schema;
 import org.apache.kafka.connect.data.SchemaBuilder;
@@ -414,47 +411,6 @@ public class SchemaUtilTest {
   }
 
   @Test
-  public void shouldGetTheCorrectFieldName() {
-    final Optional<Field> field = SchemaUtil.getFieldByName(schema, "orderid".toUpperCase());
-    Assert.assertTrue(field.isPresent());
-    assertThat(field.get().schema(), sameInstance(Schema.OPTIONAL_INT64_SCHEMA));
-    assertThat("", field.get().name().toLowerCase(), equalTo("orderid"));
-
-    final Optional<Field> field1 = SchemaUtil.getFieldByName(schema, "orderid");
-    Assert.assertFalse(field1.isPresent());
-  }
-
-  @Test
-  public void shouldGetTheCorrectFieldIndex() {
-    final int index1 = SchemaUtil.getFieldIndexByName(schema, "orderid".toUpperCase());
-    final int index2 = SchemaUtil.getFieldIndexByName(schema, "itemid".toUpperCase());
-    final int index3 = SchemaUtil.getFieldIndexByName(schema, "mapcol".toUpperCase());
-
-    assertThat("Incorrect index.", index1, equalTo(1));
-    assertThat("Incorrect index.", index2, equalTo(2));
-    assertThat("Incorrect index.", index3, equalTo(5));
-
-  }
-
-  @Test
-  public void shouldHandleInvalidFieldIndexCorrectly() {
-    final int index = SchemaUtil.getFieldIndexByName(schema, "mapcol1".toUpperCase());
-    assertThat("Incorrect index.", index, equalTo(-1));
-  }
-
-  @Test
-  public void shouldBuildTheCorrectSchemaWithAlias() {
-    final String alias = "Hello";
-    final Schema schemaWithAlias = SchemaUtil.buildSchemaWithAlias(schema, alias);
-    assertThat(schemaWithAlias.fields(), hasSize(schema.fields().size()));
-    for (int i = 0; i < schemaWithAlias.fields().size(); i++) {
-      final Field fieldWithAlias = schemaWithAlias.fields().get(i);
-      final Field field = schema.fields().get(i);
-      assertThat(fieldWithAlias.name(), equalTo(alias + "." + field.name()));
-    }
-  }
-
-  @Test
   public void shouldGetTheCorrectJavaCastClass() {
     assertThat("Incorrect class.", SchemaUtil.getJavaCastString(Schema.OPTIONAL_BOOLEAN_SCHEMA),
         equalTo("(Boolean)"));
@@ -468,44 +424,7 @@ public class SchemaUtilTest {
         equalTo("(String)"));
   }
 
-  @Test
-  public void shouldAddAndRemoveImplicitColumns() {
-    // Given:
-    final int initialFieldCount = schema.fields().size();
 
-    // When:
-    final Schema withImplicit = SchemaUtil.addImplicitRowTimeRowKeyToSchema(schema);
-
-    // Then:
-    assertThat("Invalid field count.", withImplicit.fields(), hasSize(initialFieldCount + 2));
-    assertThat("Field name should be ROWTIME.", withImplicit.fields().get(0).name(),
-        equalTo(SchemaUtil.ROWTIME_NAME));
-    assertThat("Field name should ne ROWKEY.", withImplicit.fields().get(1).name(),
-        equalTo(SchemaUtil.ROWKEY_NAME));
-
-    // When:
-    final Schema withoutImplicit = SchemaUtil.removeImplicitRowTimeRowKeyFromSchema(withImplicit);
-
-    // Then:
-    assertThat("Invalid field count.", withoutImplicit.fields(), hasSize(initialFieldCount));
-    assertThat("Invalid field name.", withoutImplicit.fields().get(0).name(), equalTo("ORDERTIME"));
-    assertThat("Invalid field name.", withoutImplicit.fields().get(1).name(), equalTo("ORDERID"));
-  }
-
-  @Test
-  public void shouldGetTheSchemaDefString() {
-    final String schemaDef = SchemaUtil.getSchemaDefinitionString(schema);
-    assertThat("Invalid schema def.", schemaDef, equalTo("[ORDERTIME : BIGINT, "
-        + "ORDERID : BIGINT, "
-        + "ITEMID : VARCHAR, "
-        + "ORDERUNITS : DOUBLE, "
-        + "ARRAYCOL : ARRAY<DOUBLE>, "
-        + "MAPCOL : MAP<VARCHAR,DOUBLE>, "
-        + "RAW_STRUCT : STRUCT<f0 BIGINT, f1 BOOLEAN>, "
-        + "ARRAY_OF_STRUCTS : ARRAY<STRUCT<f0 BIGINT, f1 BOOLEAN>>, "
-        + "MAP-OF-STRUCTS : MAP<VARCHAR,STRUCT<f0 BIGINT, f1 BOOLEAN>>, "
-        + "NESTED.STRUCTS : STRUCT<s0 STRUCT<f0 BIGINT, f1 BOOLEAN>, s1 STRUCT<ss0 STRUCT<f0 BIGINT, f1 BOOLEAN>>>]"));
-  }
 
   @Test
   public void shouldGetCorrectSqlType() {

--- a/ksql-common/src/test/java/io/confluent/ksql/util/timestamp/TimestampExtractionPolicyFactoryTest.java
+++ b/ksql-common/src/test/java/io/confluent/ksql/util/timestamp/TimestampExtractionPolicyFactoryTest.java
@@ -19,6 +19,7 @@ import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.core.IsInstanceOf.instanceOf;
 
+import io.confluent.ksql.schema.ksql.KsqlSchema;
 import io.confluent.ksql.util.KsqlException;
 import org.apache.kafka.connect.data.Schema;
 import org.apache.kafka.connect.data.SchemaBuilder;
@@ -32,68 +33,95 @@ public class TimestampExtractionPolicyFactoryTest {
 
   @Test
   public void shouldCreateMetadataPolicyWhenTimestampFieldNotProvided() {
-    assertThat(TimestampExtractionPolicyFactory.create(schemaBuilder.build(), null, null),
-        instanceOf(MetadataTimestampExtractionPolicy.class));
+    // When:
+    final TimestampExtractionPolicy result = TimestampExtractionPolicyFactory
+        .create(KsqlSchema.of(schemaBuilder.build()), null, null);
+
+    // Then:
+    assertThat(result, instanceOf(MetadataTimestampExtractionPolicy.class));
   }
 
   @Test
   public void shouldCreateLongTimestampPolicyWhenTimestampFieldIsOfTypeLong() {
+    // Given:
     final String timestamp = "timestamp";
     final Schema schema = schemaBuilder
         .field(timestamp.toUpperCase(), Schema.OPTIONAL_INT64_SCHEMA)
         .build();
-    final TimestampExtractionPolicy extractionPolicy
-        = TimestampExtractionPolicyFactory.create(schema, timestamp, null);
-    assertThat(extractionPolicy, instanceOf(LongColumnTimestampExtractionPolicy.class));
-    assertThat(extractionPolicy.timestampField(), equalTo(timestamp.toUpperCase()));
+
+    // When:
+    final TimestampExtractionPolicy result = TimestampExtractionPolicyFactory
+        .create(KsqlSchema.of(schema), timestamp, null);
+
+    // Then:
+    assertThat(result, instanceOf(LongColumnTimestampExtractionPolicy.class));
+    assertThat(result.timestampField(), equalTo(timestamp.toUpperCase()));
   }
 
   @Test(expected = KsqlException.class)
   public void shouldFailIfCantFindTimestampField() {
-    TimestampExtractionPolicyFactory.create(schemaBuilder.build(), "whateva", null);
+    TimestampExtractionPolicyFactory
+        .create(KsqlSchema.of(schemaBuilder.build()), "whateva", null);
   }
 
   @Test
   public void shouldCreateStringTimestampPolicyWhenTimestampFieldIsStringTypeAndFormatProvided() {
+    // Given:
     final String field = "my_string_field";
     final Schema schema = schemaBuilder
         .field(field.toUpperCase(), Schema.OPTIONAL_STRING_SCHEMA)
         .build();
-    final TimestampExtractionPolicy extractionPolicy
-        = TimestampExtractionPolicyFactory.create(schema, field, "yyyy-MM-DD");
-    assertThat(extractionPolicy, instanceOf(StringTimestampExtractionPolicy.class));
-    assertThat(extractionPolicy.timestampField(), equalTo(field.toUpperCase()));
+
+    // When:
+    final TimestampExtractionPolicy result = TimestampExtractionPolicyFactory
+        .create(KsqlSchema.of(schema), field, "yyyy-MM-DD");
+
+    // Then:
+    assertThat(result, instanceOf(StringTimestampExtractionPolicy.class));
+    assertThat(result.timestampField(), equalTo(field.toUpperCase()));
   }
 
   @Test(expected = KsqlException.class)
   public void shouldFailIfStringTimestampTypeAndFormatNotSupplied() {
+    // Given:
     final String field = "my_string_field";
     final Schema schema = schemaBuilder
         .field(field.toUpperCase(), Schema.OPTIONAL_STRING_SCHEMA)
         .build();
 
-    TimestampExtractionPolicyFactory.create(schema, field, null);
+    // When:
+    TimestampExtractionPolicyFactory
+        .create(KsqlSchema.of(schema), field, null);
   }
 
   @Test
   public void shouldSupportFieldsWithQuotedStrings() {
+    // Given:
     final String field = "my_string_field";
     final Schema schema = schemaBuilder
         .field(field.toUpperCase(), Schema.OPTIONAL_STRING_SCHEMA)
         .build();
-    final TimestampExtractionPolicy extractionPolicy
-        = TimestampExtractionPolicyFactory.create(schema, "'"+ field+ "'", "'yyyy-MM-DD'");
-    assertThat(extractionPolicy, instanceOf(StringTimestampExtractionPolicy.class));
-    assertThat(extractionPolicy.timestampField(), equalTo(field.toUpperCase()));
+
+    // When:
+    final TimestampExtractionPolicy result = TimestampExtractionPolicyFactory
+        .create(KsqlSchema.of(schema), "'" + field + "'", "'yyyy-MM-DD'");
+
+    // Then:
+    assertThat(result, instanceOf(StringTimestampExtractionPolicy.class));
+    assertThat(result.timestampField(), equalTo(field.toUpperCase()));
   }
 
   @Test(expected = KsqlException.class)
   public void shouldThrowIfTimestampFieldTypeIsNotLongOrString() {
+    // Given:
     final String field = "blah";
     final Schema schema = schemaBuilder
         .field(field.toUpperCase(), Schema.OPTIONAL_FLOAT64_SCHEMA)
         .build();
-    TimestampExtractionPolicyFactory.create(schema, "'"+ field+ "'", null);
+
+    // When:
+    TimestampExtractionPolicyFactory
+        .create(KsqlSchema.of(schema), "'" + field + "'", null);
   }
 
 }

--- a/ksql-engine/src/main/java/io/confluent/ksql/analyzer/Analyzer.java
+++ b/ksql-engine/src/main/java/io/confluent/ksql/analyzer/Analyzer.java
@@ -46,6 +46,7 @@ import io.confluent.ksql.parser.tree.WindowExpression;
 import io.confluent.ksql.planner.plan.DataSourceNode;
 import io.confluent.ksql.planner.plan.JoinNode;
 import io.confluent.ksql.planner.plan.PlanNodeId;
+import io.confluent.ksql.schema.ksql.KsqlSchema;
 import io.confluent.ksql.serde.Format;
 import io.confluent.ksql.serde.KsqlTopicSerDe;
 import io.confluent.ksql.serde.avro.KsqlAvroTopicSerDe;
@@ -66,7 +67,6 @@ import java.util.Optional;
 import java.util.Set;
 import org.apache.kafka.common.serialization.Serdes;
 import org.apache.kafka.connect.data.Field;
-import org.apache.kafka.connect.data.Schema;
 
 // CHECKSTYLE_RULES.OFF: ClassDataAbstractionCoupling
 class Analyzer {
@@ -348,7 +348,7 @@ class Analyzer {
     }
 
     private void analyzeExpressions() {
-      Schema schema = analysis.getFromDataSources().get(0).getLeft().getSchema();
+      KsqlSchema schema = analysis.getFromDataSources().get(0).getLeft().getSchema();
       boolean isJoinSchema = false;
       if (analysis.getJoin() != null) {
         schema = analysis.getJoin().getSchema();
@@ -464,7 +464,7 @@ class Analyzer {
     private Field getJoinField(
         final ComparisonExpression comparisonExpression,
         final String sourceAlias,
-        final Schema sourceSchema
+        final KsqlSchema sourceSchema
     ) {
       Optional<Field> joinField = getJoinFieldFromExpr(
           comparisonExpression.getLeft(),
@@ -493,7 +493,7 @@ class Analyzer {
     private Optional<Field> getJoinFieldFromExpr(
         final Expression expression,
         final String sourceAlias,
-        final Schema sourceSchema
+        final KsqlSchema sourceSchema
     ) {
       if (expression instanceof DereferenceExpression) {
         final DereferenceExpression dereferenceExpr = (DereferenceExpression) expression;
@@ -519,9 +519,9 @@ class Analyzer {
     private Optional<Field> getJoinFieldFromSource(
         final String fieldName,
         final String sourceAlias,
-        final Schema sourceSchema
+        final KsqlSchema sourceSchema
     ) {
-      return SchemaUtil.getFieldByName(sourceSchema, fieldName)
+      return sourceSchema.findField(fieldName)
           .map(field -> SchemaUtil.buildAliasedField(sourceAlias, field));
     }
 

--- a/ksql-engine/src/main/java/io/confluent/ksql/analyzer/ExpressionAnalyzer.java
+++ b/ksql-engine/src/main/java/io/confluent/ksql/analyzer/ExpressionAnalyzer.java
@@ -28,18 +28,19 @@ import io.confluent.ksql.parser.tree.LikePredicate;
 import io.confluent.ksql.parser.tree.LogicalBinaryExpression;
 import io.confluent.ksql.parser.tree.NotExpression;
 import io.confluent.ksql.parser.tree.QualifiedNameReference;
-import io.confluent.ksql.util.SchemaUtil;
+import io.confluent.ksql.schema.ksql.KsqlSchema;
+import java.util.Objects;
 import java.util.Optional;
 import org.apache.kafka.connect.data.Field;
-import org.apache.kafka.connect.data.Schema;
 
 
-public class ExpressionAnalyzer {
-  private final Schema schema;
+class ExpressionAnalyzer {
+
+  private final KsqlSchema schema;
   private final boolean isJoinSchema;
 
-  ExpressionAnalyzer(final Schema schema, final boolean isJoinSchema) {
-    this.schema = schema;
+  ExpressionAnalyzer(final KsqlSchema schema, final boolean isJoinSchema) {
+    this.schema = Objects.requireNonNull(schema, "schema");
     this.isJoinSchema = isJoinSchema;
   }
 
@@ -51,10 +52,10 @@ public class ExpressionAnalyzer {
   private class Visitor
       extends AstVisitor<Object, Object> {
 
-    final Schema schema;
+    private final KsqlSchema schema;
 
-    Visitor(final Schema schema) {
-      this.schema = schema;
+    Visitor(final KsqlSchema schema) {
+      this.schema = Objects.requireNonNull(schema, "schema");
     }
 
     protected Object visitLikePredicate(final LikePredicate node, final Object context) {
@@ -115,7 +116,7 @@ public class ExpressionAnalyzer {
       if (isJoinSchema) {
         columnName = node.toString();
       }
-      final Optional<Field> schemaField = SchemaUtil.getFieldByName(schema, columnName);
+      final Optional<Field> schemaField = schema.findField(columnName);
       if (!schemaField.isPresent()) {
         throw new RuntimeException(
             String.format("Column %s cannot be resolved.", columnName));
@@ -135,7 +136,7 @@ public class ExpressionAnalyzer {
         final QualifiedNameReference node,
         final Object context) {
       final String columnName = node.getName().getSuffix();
-      final Optional<Field> schemaField = SchemaUtil.getFieldByName(schema, columnName);
+      final Optional<Field> schemaField = schema.findField(columnName);
       if (!schemaField.isPresent()) {
         throw new RuntimeException(
             String.format("Column %s cannot be resolved.", columnName));

--- a/ksql-engine/src/main/java/io/confluent/ksql/ddl/commands/CreateStreamCommand.java
+++ b/ksql-engine/src/main/java/io/confluent/ksql/ddl/commands/CreateStreamCommand.java
@@ -20,7 +20,6 @@ import io.confluent.ksql.metastore.model.KsqlStream;
 import io.confluent.ksql.parser.tree.CreateStream;
 import io.confluent.ksql.services.KafkaTopicClient;
 import io.confluent.ksql.util.KsqlException;
-import io.confluent.ksql.util.SchemaUtil;
 
 public class CreateStreamCommand extends AbstractCreateStreamCommand {
 
@@ -48,7 +47,7 @@ public class CreateStreamCommand extends AbstractCreateStreamCommand {
     final KsqlStream ksqlStream = new KsqlStream<>(
         sqlExpression,
         sourceName,
-        SchemaUtil.addImplicitRowTimeRowKeyToSchema(schema),
+        schema.withImplicitFields(),
         keyField,
         timestampExtractionPolicy,
         metaStore.getTopic(topicName),

--- a/ksql-engine/src/main/java/io/confluent/ksql/ddl/commands/CreateTableCommand.java
+++ b/ksql-engine/src/main/java/io/confluent/ksql/ddl/commands/CreateTableCommand.java
@@ -20,7 +20,6 @@ import io.confluent.ksql.metastore.model.KsqlTable;
 import io.confluent.ksql.parser.tree.CreateTable;
 import io.confluent.ksql.services.KafkaTopicClient;
 import io.confluent.ksql.util.KsqlException;
-import io.confluent.ksql.util.SchemaUtil;
 
 public class CreateTableCommand extends AbstractCreateStreamCommand {
 
@@ -48,7 +47,7 @@ public class CreateTableCommand extends AbstractCreateStreamCommand {
     final KsqlTable ksqlTable = new KsqlTable<>(
         sqlExpression,
         sourceName,
-        SchemaUtil.addImplicitRowTimeRowKeyToSchema(schema),
+        schema.withImplicitFields(),
         keyField,
         timestampExtractionPolicy,
         metaStore.getTopic(topicName),

--- a/ksql-engine/src/main/java/io/confluent/ksql/planner/plan/FilterNode.java
+++ b/ksql-engine/src/main/java/io/confluent/ksql/planner/plan/FilterNode.java
@@ -21,12 +21,12 @@ import com.google.common.collect.ImmutableList;
 import io.confluent.ksql.metastore.model.KeyField;
 import io.confluent.ksql.parser.tree.Expression;
 import io.confluent.ksql.physical.KsqlQueryBuilder;
+import io.confluent.ksql.schema.ksql.KsqlSchema;
 import io.confluent.ksql.services.KafkaTopicClient;
 import io.confluent.ksql.structured.SchemaKStream;
 import java.util.List;
 import java.util.Objects;
 import javax.annotation.concurrent.Immutable;
-import org.apache.kafka.connect.data.Schema;
 
 @Immutable
 public class FilterNode extends PlanNode {
@@ -50,7 +50,7 @@ public class FilterNode extends PlanNode {
   }
 
   @Override
-  public Schema getSchema() {
+  public KsqlSchema getSchema() {
     return source.getSchema();
   }
 

--- a/ksql-engine/src/main/java/io/confluent/ksql/planner/plan/KsqlBareOutputNode.java
+++ b/ksql-engine/src/main/java/io/confluent/ksql/planner/plan/KsqlBareOutputNode.java
@@ -20,13 +20,13 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import io.confluent.ksql.metastore.model.KeyField;
 import io.confluent.ksql.physical.KsqlQueryBuilder;
 import io.confluent.ksql.query.QueryId;
+import io.confluent.ksql.schema.ksql.KsqlSchema;
 import io.confluent.ksql.structured.QueuedSchemaKStream;
 import io.confluent.ksql.structured.SchemaKStream;
 import io.confluent.ksql.util.QueryIdGenerator;
 import io.confluent.ksql.util.timestamp.TimestampExtractionPolicy;
 import java.util.Optional;
 import java.util.concurrent.ThreadLocalRandom;
-import org.apache.kafka.connect.data.Schema;
 
 @SuppressWarnings("OptionalUsedAsFieldOrParameterType")
 public class KsqlBareOutputNode extends OutputNode {
@@ -37,7 +37,7 @@ public class KsqlBareOutputNode extends OutputNode {
   public KsqlBareOutputNode(
       @JsonProperty("id") final PlanNodeId id,
       @JsonProperty("source") final PlanNode source,
-      @JsonProperty("schema") final Schema schema,
+      @JsonProperty("schema") final KsqlSchema schema,
       @JsonProperty("limit") final Optional<Integer> limit,
       @JsonProperty("timestampExtraction") final TimestampExtractionPolicy extractionPolicy
   ) {

--- a/ksql-engine/src/main/java/io/confluent/ksql/planner/plan/OutputNode.java
+++ b/ksql-engine/src/main/java/io/confluent/ksql/planner/plan/OutputNode.java
@@ -21,13 +21,13 @@ import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.google.common.collect.ImmutableList;
 import io.confluent.ksql.query.QueryId;
+import io.confluent.ksql.schema.ksql.KsqlSchema;
 import io.confluent.ksql.services.KafkaTopicClient;
 import io.confluent.ksql.util.QueryIdGenerator;
 import io.confluent.ksql.util.timestamp.TimestampExtractionPolicy;
 import java.util.List;
 import java.util.Optional;
 import javax.annotation.concurrent.Immutable;
-import org.apache.kafka.connect.data.Schema;
 
 @SuppressWarnings("OptionalUsedAsFieldOrParameterType")
 @Immutable
@@ -35,7 +35,7 @@ public abstract class OutputNode
     extends PlanNode {
 
   private final PlanNode source;
-  private final Schema schema;
+  private final KsqlSchema schema;
   private final Optional<Integer> limit;
   private final TimestampExtractionPolicy timestampExtractionPolicy;
 
@@ -43,7 +43,7 @@ public abstract class OutputNode
   protected OutputNode(
       @JsonProperty("id") final PlanNodeId id,
       @JsonProperty("source") final PlanNode source,
-      @JsonProperty("schema") final Schema schema,
+      @JsonProperty("schema") final KsqlSchema schema,
       @JsonProperty("limit") final Optional<Integer> limit,
       @JsonProperty("timestamp_policy") final TimestampExtractionPolicy timestampExtractionPolicy
   ) {
@@ -57,8 +57,8 @@ public abstract class OutputNode
   }
 
   @Override
-  public Schema getSchema() {
-    return this.schema;
+  public KsqlSchema getSchema() {
+    return schema;
   }
 
   @Override

--- a/ksql-engine/src/main/java/io/confluent/ksql/planner/plan/PlanNode.java
+++ b/ksql-engine/src/main/java/io/confluent/ksql/planner/plan/PlanNode.java
@@ -21,10 +21,10 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import io.confluent.ksql.metastore.model.DataSource.DataSourceType;
 import io.confluent.ksql.metastore.model.KeyField;
 import io.confluent.ksql.physical.KsqlQueryBuilder;
+import io.confluent.ksql.schema.ksql.KsqlSchema;
 import io.confluent.ksql.services.KafkaTopicClient;
 import io.confluent.ksql.structured.SchemaKStream;
 import java.util.List;
-import org.apache.kafka.connect.data.Schema;
 
 
 public abstract class PlanNode {
@@ -48,7 +48,7 @@ public abstract class PlanNode {
     return nodeOutputType;
   }
 
-  public abstract Schema getSchema();
+  public abstract KsqlSchema getSchema();
 
   public abstract KeyField getKeyField();
 

--- a/ksql-engine/src/main/java/io/confluent/ksql/planner/plan/ProjectNode.java
+++ b/ksql-engine/src/main/java/io/confluent/ksql/planner/plan/ProjectNode.java
@@ -23,6 +23,7 @@ import com.google.common.collect.ImmutableList;
 import io.confluent.ksql.metastore.model.KeyField;
 import io.confluent.ksql.parser.tree.Expression;
 import io.confluent.ksql.physical.KsqlQueryBuilder;
+import io.confluent.ksql.schema.ksql.KsqlSchema;
 import io.confluent.ksql.services.KafkaTopicClient;
 import io.confluent.ksql.structured.SchemaKStream;
 import io.confluent.ksql.util.KsqlException;
@@ -31,13 +32,12 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
 import javax.annotation.concurrent.Immutable;
-import org.apache.kafka.connect.data.Schema;
 
 @Immutable
 public class ProjectNode extends PlanNode {
 
   private final PlanNode source;
-  private final Schema schema;
+  private final KsqlSchema schema;
   private final List<Expression> projectExpressions;
   private final KeyField keyField;
 
@@ -45,7 +45,7 @@ public class ProjectNode extends PlanNode {
   public ProjectNode(
       @JsonProperty("id") final PlanNodeId id,
       @JsonProperty("source") final PlanNode source,
-      @JsonProperty("schema") final Schema schema,
+      @JsonProperty("schema") final KsqlSchema schema,
       @JsonProperty("key") final Optional<String> keyFieldName,
       @JsonProperty("projectExpressions") final List<Expression> projectExpressions
   ) {
@@ -76,7 +76,7 @@ public class ProjectNode extends PlanNode {
   }
 
   @Override
-  public Schema getSchema() {
+  public KsqlSchema getSchema() {
     return schema;
   }
 

--- a/ksql-engine/src/main/java/io/confluent/ksql/structured/QueuedSchemaKStream.java
+++ b/ksql-engine/src/main/java/io/confluent/ksql/structured/QueuedSchemaKStream.java
@@ -19,11 +19,11 @@ import io.confluent.ksql.GenericRow;
 import io.confluent.ksql.logging.processing.ProcessingLogContext;
 import io.confluent.ksql.metastore.model.KeyField;
 import io.confluent.ksql.parser.tree.Expression;
+import io.confluent.ksql.schema.ksql.KsqlSchema;
 import io.confluent.ksql.util.SelectExpression;
 import java.util.List;
 import java.util.Set;
 import org.apache.kafka.common.serialization.Serde;
-import org.apache.kafka.connect.data.Schema;
 
 public class QueuedSchemaKStream<K> extends SchemaKStream<K> {
 
@@ -72,7 +72,7 @@ public class QueuedSchemaKStream<K> extends SchemaKStream<K> {
   @Override
   public SchemaKStream<K> leftJoin(
       final SchemaKTable<K> schemaKTable,
-      final Schema joinSchema,
+      final KsqlSchema joinSchema,
       final KeyField keyField,
       final Serde<GenericRow> joinSerde,
       final QueryContext.Stacker contextStacker

--- a/ksql-engine/src/main/java/io/confluent/ksql/structured/SchemaKGroupedStream.java
+++ b/ksql-engine/src/main/java/io/confluent/ksql/structured/SchemaKGroupedStream.java
@@ -25,6 +25,7 @@ import io.confluent.ksql.metastore.SerdeFactory;
 import io.confluent.ksql.metastore.model.KeyField;
 import io.confluent.ksql.parser.tree.KsqlWindowExpression;
 import io.confluent.ksql.parser.tree.WindowExpression;
+import io.confluent.ksql.schema.ksql.KsqlSchema;
 import io.confluent.ksql.streams.MaterializedFactory;
 import io.confluent.ksql.streams.StreamsUtil;
 import io.confluent.ksql.util.KsqlConfig;
@@ -34,7 +35,6 @@ import java.util.Objects;
 import org.apache.kafka.common.serialization.Serde;
 import org.apache.kafka.common.serialization.Serdes;
 import org.apache.kafka.common.utils.Bytes;
-import org.apache.kafka.connect.data.Schema;
 import org.apache.kafka.streams.kstream.Initializer;
 import org.apache.kafka.streams.kstream.KGroupedStream;
 import org.apache.kafka.streams.kstream.KTable;
@@ -46,7 +46,7 @@ import org.apache.kafka.streams.state.WindowStore;
 
 public class SchemaKGroupedStream {
 
-  final Schema schema;
+  final KsqlSchema schema;
   final KGroupedStream kgroupedStream;
   final KeyField keyField;
   final List<SchemaKStream> sourceSchemaKStreams;
@@ -55,7 +55,7 @@ public class SchemaKGroupedStream {
   final MaterializedFactory materializedFactory;
 
   SchemaKGroupedStream(
-      final Schema schema,
+      final KsqlSchema schema,
       final KGroupedStream kgroupedStream,
       final KeyField keyField,
       final List<SchemaKStream> sourceSchemaKStreams,
@@ -74,7 +74,7 @@ public class SchemaKGroupedStream {
   }
 
   SchemaKGroupedStream(
-      final Schema schema,
+      final KsqlSchema schema,
       final KGroupedStream kgroupedStream,
       final KeyField keyField,
       final List<SchemaKStream> sourceSchemaKStreams,

--- a/ksql-engine/src/main/java/io/confluent/ksql/structured/SchemaKGroupedTable.java
+++ b/ksql-engine/src/main/java/io/confluent/ksql/structured/SchemaKGroupedTable.java
@@ -23,6 +23,7 @@ import io.confluent.ksql.function.udaf.KudafAggregator;
 import io.confluent.ksql.function.udaf.KudafUndoAggregator;
 import io.confluent.ksql.metastore.model.KeyField;
 import io.confluent.ksql.parser.tree.WindowExpression;
+import io.confluent.ksql.schema.ksql.KsqlSchema;
 import io.confluent.ksql.streams.MaterializedFactory;
 import io.confluent.ksql.streams.StreamsUtil;
 import io.confluent.ksql.util.KsqlConfig;
@@ -33,7 +34,6 @@ import java.util.Objects;
 import java.util.stream.Collectors;
 import org.apache.kafka.common.serialization.Serde;
 import org.apache.kafka.common.serialization.Serdes;
-import org.apache.kafka.connect.data.Schema;
 import org.apache.kafka.streams.kstream.Initializer;
 import org.apache.kafka.streams.kstream.KGroupedTable;
 import org.apache.kafka.streams.kstream.KTable;
@@ -43,7 +43,7 @@ public class SchemaKGroupedTable extends SchemaKGroupedStream {
   private final KGroupedTable kgroupedTable;
 
   SchemaKGroupedTable(
-      final Schema schema,
+      final KsqlSchema schema,
       final KGroupedTable kgroupedTable,
       final KeyField keyField,
       final List<SchemaKStream> sourceSchemaKStreams,
@@ -61,7 +61,7 @@ public class SchemaKGroupedTable extends SchemaKGroupedStream {
   }
 
   SchemaKGroupedTable(
-      final Schema schema,
+      final KsqlSchema schema,
       final KGroupedTable kgroupedTable,
       final KeyField keyField,
       final List<SchemaKStream> sourceSchemaKStreams,

--- a/ksql-engine/src/main/java/io/confluent/ksql/structured/SchemaKTable.java
+++ b/ksql-engine/src/main/java/io/confluent/ksql/structured/SchemaKTable.java
@@ -22,11 +22,11 @@ import io.confluent.ksql.logging.processing.ProcessingLogContext;
 import io.confluent.ksql.metastore.SerdeFactory;
 import io.confluent.ksql.metastore.model.KeyField;
 import io.confluent.ksql.parser.tree.Expression;
+import io.confluent.ksql.schema.ksql.KsqlSchema;
 import io.confluent.ksql.streams.StreamsFactories;
 import io.confluent.ksql.streams.StreamsUtil;
 import io.confluent.ksql.util.KsqlConfig;
 import io.confluent.ksql.util.QueryLoggerUtil;
-import io.confluent.ksql.util.SchemaUtil;
 import io.confluent.ksql.util.SelectExpression;
 import java.util.ArrayList;
 import java.util.Collections;
@@ -49,7 +49,7 @@ public class SchemaKTable<K> extends SchemaKStream<K> {
   private final KTable<K, GenericRow> ktable;
 
   public SchemaKTable(
-      final Schema schema,
+      final KsqlSchema schema,
       final KTable<K, GenericRow> ktable,
       final KeyField keyField,
       final List<SchemaKStream> sourceSchemaKStreams,
@@ -74,7 +74,7 @@ public class SchemaKTable<K> extends SchemaKStream<K> {
   }
 
   SchemaKTable(
-      final Schema schema,
+      final KsqlSchema schema,
       final KTable<K, GenericRow> ktable,
       final KeyField keyField,
       final List<SchemaKStream> sourceSchemaKStreams,
@@ -209,7 +209,7 @@ public class SchemaKTable<K> extends SchemaKStream<K> {
     final Field legacyKeyField = new Field(
         groupBy.aggregateKeyName, -1, Schema.OPTIONAL_STRING_SCHEMA);
 
-    final Optional<String> newKeyField = SchemaUtil.getFieldByName(schema, groupBy.aggregateKeyName)
+    final Optional<String> newKeyField = schema.findField(groupBy.aggregateKeyName)
         .map(Field::name);
 
     return new SchemaKGroupedTable(
@@ -224,7 +224,7 @@ public class SchemaKTable<K> extends SchemaKStream<K> {
   @SuppressWarnings("unchecked")
   public SchemaKTable<K> join(
       final SchemaKTable<K> schemaKTable,
-      final Schema joinSchema,
+      final KsqlSchema joinSchema,
       final KeyField keyField,
       final QueryContext.Stacker contextStacker
   ) {
@@ -249,7 +249,7 @@ public class SchemaKTable<K> extends SchemaKStream<K> {
   @SuppressWarnings("unchecked")
   public SchemaKTable<K> leftJoin(
       final SchemaKTable<K> schemaKTable,
-      final Schema joinSchema,
+      final KsqlSchema joinSchema,
       final KeyField keyField,
       final QueryContext.Stacker contextStacker
   ) {
@@ -275,7 +275,7 @@ public class SchemaKTable<K> extends SchemaKStream<K> {
   @SuppressWarnings("unchecked")
   public SchemaKTable<K> outerJoin(
       final SchemaKTable<K> schemaKTable,
-      final Schema joinSchema,
+      final KsqlSchema joinSchema,
       final KeyField keyField,
       final QueryContext.Stacker contextStacker
   ) {

--- a/ksql-engine/src/main/java/io/confluent/ksql/structured/SqlPredicate.java
+++ b/ksql-engine/src/main/java/io/confluent/ksql/structured/SqlPredicate.java
@@ -15,6 +15,8 @@
 
 package io.confluent.ksql.structured;
 
+import static java.util.Objects.requireNonNull;
+
 import io.confluent.ksql.GenericRow;
 import io.confluent.ksql.codegen.CodeGenRunner;
 import io.confluent.ksql.codegen.SqlToJavaVisitor;
@@ -22,24 +24,23 @@ import io.confluent.ksql.function.FunctionRegistry;
 import io.confluent.ksql.function.udf.Kudf;
 import io.confluent.ksql.logging.processing.ProcessingLogger;
 import io.confluent.ksql.parser.tree.Expression;
+import io.confluent.ksql.schema.ksql.KsqlSchema;
 import io.confluent.ksql.util.EngineProcessingLogMessageFactory;
 import io.confluent.ksql.util.ExpressionMetadata;
 import io.confluent.ksql.util.GenericRowValueTypeEnforcer;
 import io.confluent.ksql.util.KsqlConfig;
 import io.confluent.ksql.util.KsqlException;
-import io.confluent.ksql.util.SchemaUtil;
 import java.util.List;
-import java.util.Objects;
 import java.util.Set;
-import org.apache.kafka.connect.data.Schema;
 import org.apache.kafka.streams.kstream.Predicate;
 import org.apache.kafka.streams.kstream.Windowed;
 import org.codehaus.commons.compiler.CompilerFactoryFactory;
 import org.codehaus.commons.compiler.IExpressionEvaluator;
 
-public class SqlPredicate {
+class SqlPredicate {
+
   private final Expression filterExpression;
-  private final Schema schema;
+  private final KsqlSchema schema;
   private final IExpressionEvaluator ee;
   private final int[] columnIndexes;
   private final boolean isWindowedKey;
@@ -50,19 +51,19 @@ public class SqlPredicate {
 
   SqlPredicate(
       final Expression filterExpression,
-      final Schema schema,
+      final KsqlSchema schema,
       final boolean isWindowedKey,
       final KsqlConfig ksqlConfig,
       final FunctionRegistry functionRegistry,
       final ProcessingLogger processingLogger
   ) {
-    this.filterExpression = filterExpression;
-    this.schema = schema;
+    this.filterExpression = requireNonNull(filterExpression, "filterExpression");
+    this.schema = requireNonNull(schema, "schema");
     this.genericRowValueTypeEnforcer = new GenericRowValueTypeEnforcer(schema);
     this.isWindowedKey = isWindowedKey;
-    this.functionRegistry = functionRegistry;
-    this.ksqlConfig = Objects.requireNonNull(ksqlConfig, "ksqlConfig");
-    this.processingLogger = Objects.requireNonNull(processingLogger);
+    this.functionRegistry = requireNonNull(functionRegistry, "functionRegistry");
+    this.ksqlConfig = requireNonNull(ksqlConfig, "ksqlConfig");
+    this.processingLogger = requireNonNull(processingLogger);
 
     final CodeGenRunner codeGenRunner = new CodeGenRunner(schema, ksqlConfig, functionRegistry);
     final Set<CodeGenRunner.ParameterType> parameters
@@ -75,7 +76,7 @@ public class SqlPredicate {
     for (final CodeGenRunner.ParameterType param : parameters) {
       parameterNames[index] = param.getName();
       parameterTypes[index] = param.getType();
-      columnIndexes[index] = SchemaUtil.getFieldIndexByName(schema, param.getName());
+      columnIndexes[index] = schema.findFieldIndex(param.getName()).orElse(-1);
       index++;
     }
 
@@ -188,12 +189,8 @@ public class SqlPredicate {
     );
   }
 
-  public Expression getFilterExpression() {
+  Expression getFilterExpression() {
     return filterExpression;
-  }
-
-  public Schema getSchema() {
-    return schema;
   }
 
   // visible for testing

--- a/ksql-engine/src/main/java/io/confluent/ksql/util/AvroUtil.java
+++ b/ksql-engine/src/main/java/io/confluent/ksql/util/AvroUtil.java
@@ -35,7 +35,7 @@ public final class AvroUtil {
     }
 
     final org.apache.avro.Schema avroSchema = SchemaUtil.buildAvroSchema(
-        persistentQueryMetadata.getResultSchema(),
+        persistentQueryMetadata.getResultSchema().getSchema(),
         persistentQueryMetadata.getResultTopic().getKsqlTopicName()
     );
 

--- a/ksql-engine/src/main/java/io/confluent/ksql/util/GenericRowValueTypeEnforcer.java
+++ b/ksql-engine/src/main/java/io/confluent/ksql/util/GenericRowValueTypeEnforcer.java
@@ -17,10 +17,10 @@ package io.confluent.ksql.util;
 
 import com.google.common.collect.ImmutableMap;
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
+import io.confluent.ksql.schema.ksql.KsqlSchema;
 import java.util.List;
 import java.util.Map;
 import java.util.function.Function;
-
 import org.apache.kafka.connect.data.Field;
 import org.apache.kafka.connect.data.Schema;
 
@@ -30,17 +30,17 @@ public class GenericRowValueTypeEnforcer {
 
   private static final Map<Schema.Type, Function<Object, Object>> SCHEMA_TYPE_TO_ENFORCE =
       ImmutableMap.<Schema.Type, Function<Object, Object>>builder()
-          .put(Schema.Type.INT32, v -> enforceInteger(v))
-          .put(Schema.Type.INT64, v -> enforceLong(v))
-          .put(Schema.Type.FLOAT64, v -> enforceDouble(v))
-          .put(Schema.Type.STRING, v -> enforceString(v))
-          .put(Schema.Type.BOOLEAN, v -> enforceBoolean(v))
+          .put(Schema.Type.INT32, GenericRowValueTypeEnforcer::enforceInteger)
+          .put(Schema.Type.INT64, GenericRowValueTypeEnforcer::enforceLong)
+          .put(Schema.Type.FLOAT64, GenericRowValueTypeEnforcer::enforceDouble)
+          .put(Schema.Type.STRING, GenericRowValueTypeEnforcer::enforceString)
+          .put(Schema.Type.BOOLEAN, GenericRowValueTypeEnforcer::enforceBoolean)
           .put(Schema.Type.ARRAY, v -> v)
           .put(Schema.Type.MAP, v -> v)
           .put(Schema.Type.STRUCT, v -> v)
           .build();
 
-  public GenericRowValueTypeEnforcer(final Schema schema) {
+  public GenericRowValueTypeEnforcer(final KsqlSchema schema) {
     this.fields = schema.fields();
   }
 
@@ -49,7 +49,7 @@ public class GenericRowValueTypeEnforcer {
     return enforceFieldType(field.schema(), value);
   }
 
-  private Object enforceFieldType(final Schema schema, final Object value) {
+  private static Object enforceFieldType(final Schema schema, final Object value) {
     final Function<Object, Object> handler = SCHEMA_TYPE_TO_ENFORCE.get(schema.type());
     if (handler == null) {
       throw new KsqlException("Type is not supported: " + schema);
@@ -71,7 +71,7 @@ public class GenericRowValueTypeEnforcer {
       return ((Short) value).doubleValue();
     } else if (value instanceof Byte) {
       return ((Byte) value).doubleValue();
-    } else if (value instanceof String || value instanceof CharSequence) {
+    } else if (value instanceof CharSequence) {
       return Double.parseDouble(value.toString());
     } else if (value == null) {
       return null;
@@ -91,7 +91,7 @@ public class GenericRowValueTypeEnforcer {
       return ((Short) value).longValue();
     } else if (value instanceof Byte) {
       return ((Byte) value).longValue();
-    } else if (value instanceof String || value instanceof CharSequence) {
+    } else if (value instanceof CharSequence) {
       return Long.parseLong(value.toString());
     } else if (value == null) {
       return null;
@@ -112,7 +112,7 @@ public class GenericRowValueTypeEnforcer {
       return ((Short) value).intValue();
     } else if (value instanceof Byte) {
       return ((Byte) value).intValue();
-    } else if (value instanceof String || value instanceof CharSequence) {
+    } else if (value instanceof CharSequence) {
       return Integer.parseInt(value.toString());
     } else if (value == null) {
       return null;
@@ -122,7 +122,7 @@ public class GenericRowValueTypeEnforcer {
   }
 
   private static String enforceString(final Object value) {
-    if (value instanceof String || value instanceof CharSequence) {
+    if (value instanceof CharSequence) {
       return value.toString();
     } else if (value == null) {
       return null;

--- a/ksql-engine/src/main/java/io/confluent/ksql/util/PersistentQueryMetadata.java
+++ b/ksql-engine/src/main/java/io/confluent/ksql/util/PersistentQueryMetadata.java
@@ -20,12 +20,12 @@ import io.confluent.ksql.metastore.model.DataSource.DataSourceType;
 import io.confluent.ksql.metastore.model.KsqlTopic;
 import io.confluent.ksql.physical.QuerySchemas;
 import io.confluent.ksql.query.QueryId;
+import io.confluent.ksql.schema.ksql.KsqlSchema;
 import io.confluent.ksql.serde.Format;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Set;
 import java.util.function.Consumer;
-import org.apache.kafka.connect.data.Schema;
 import org.apache.kafka.streams.KafkaStreams;
 import org.apache.kafka.streams.Topology;
 
@@ -43,7 +43,7 @@ public class PersistentQueryMetadata extends QueryMetadata {
   public PersistentQueryMetadata(
       final String statementString,
       final KafkaStreams kafkaStreams,
-      final Schema resultSchema,
+      final KsqlSchema resultSchema,
       final Set<String> sourceNames,
       final String sinkName,
       final String executionPlan,

--- a/ksql-engine/src/main/java/io/confluent/ksql/util/QueryMetadata.java
+++ b/ksql-engine/src/main/java/io/confluent/ksql/util/QueryMetadata.java
@@ -18,13 +18,13 @@ package io.confluent.ksql.util;
 import com.google.common.collect.ImmutableMap;
 import io.confluent.ksql.internal.QueryStateListener;
 import io.confluent.ksql.metastore.model.DataSource.DataSourceType;
+import io.confluent.ksql.schema.ksql.KsqlSchema;
 import java.lang.Thread.UncaughtExceptionHandler;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
 import java.util.Set;
 import java.util.function.Consumer;
-import org.apache.kafka.connect.data.Schema;
 import org.apache.kafka.streams.KafkaStreams;
 import org.apache.kafka.streams.Topology;
 import org.slf4j.Logger;
@@ -44,7 +44,7 @@ public class QueryMetadata {
   private final Map<String, Object> overriddenProperties;
   private final Consumer<QueryMetadata> closeCallback;
   private final Set<String> sourceNames;
-  private final Schema schema;
+  private final KsqlSchema schema;
 
   private Optional<QueryStateListener> queryStateListener = Optional.empty();
   private boolean everStarted = false;
@@ -53,7 +53,7 @@ public class QueryMetadata {
   protected QueryMetadata(
       final String statementString,
       final KafkaStreams kafkaStreams,
-      final Schema schema,
+      final KsqlSchema schema,
       final Set<String> sourceNames,
       final String executionPlan,
       final DataSourceType dataSourceType,
@@ -136,7 +136,7 @@ public class QueryMetadata {
     return streamsProperties;
   }
 
-  public Schema getResultSchema() {
+  public KsqlSchema getResultSchema() {
     return schema;
   }
 

--- a/ksql-engine/src/main/java/io/confluent/ksql/util/QueuedQueryMetadata.java
+++ b/ksql-engine/src/main/java/io/confluent/ksql/util/QueuedQueryMetadata.java
@@ -18,13 +18,13 @@ package io.confluent.ksql.util;
 import io.confluent.ksql.GenericRow;
 import io.confluent.ksql.metastore.model.DataSource.DataSourceType;
 import io.confluent.ksql.physical.LimitHandler;
+import io.confluent.ksql.schema.ksql.KsqlSchema;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Set;
 import java.util.concurrent.BlockingQueue;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.function.Consumer;
-import org.apache.kafka.connect.data.Schema;
 import org.apache.kafka.streams.KafkaStreams;
 import org.apache.kafka.streams.KeyValue;
 import org.apache.kafka.streams.Topology;
@@ -42,7 +42,7 @@ public class QueuedQueryMetadata extends QueryMetadata {
   public QueuedQueryMetadata(
       final String statementString,
       final KafkaStreams kafkaStreams,
-      final Schema resultSchema,
+      final KsqlSchema resultSchema,
       final Set<String> sourceNames,
       final Consumer<LimitHandler> limitHandlerSetter,
       final String executionPlan,

--- a/ksql-engine/src/test/java/io/confluent/ksql/analyzer/AnalyzerTest.java
+++ b/ksql-engine/src/test/java/io/confluent/ksql/analyzer/AnalyzerTest.java
@@ -35,6 +35,7 @@ import io.confluent.ksql.parser.tree.CreateStreamAsSelect;
 import io.confluent.ksql.parser.tree.Query;
 import io.confluent.ksql.parser.tree.Statement;
 import io.confluent.ksql.planner.plan.JoinNode;
+import io.confluent.ksql.schema.ksql.KsqlSchema;
 import io.confluent.ksql.serde.avro.KsqlAvroTopicSerDe;
 import io.confluent.ksql.serde.json.KsqlJsonTopicSerDe;
 import io.confluent.ksql.util.KsqlConstants;
@@ -130,8 +131,8 @@ public class AnalyzerTest {
     Assert.assertEquals(analysis.getSelectExpressions().size(),
         analysis.getSelectExpressionAlias().size());
 
-    assertThat(analysis.getJoin().getLeftKeyFieldName(), is("T1.COL1"));
-    assertThat(analysis.getJoin().getRightKeyFieldName(), is("T2.COL1"));
+    assertThat(analysis.getJoin().getLeftJoinFieldName(), is("T1.COL1"));
+    assertThat(analysis.getJoin().getRightJoinFieldName(), is("T2.COL1"));
 
     final String
         select1 =
@@ -170,8 +171,8 @@ public class AnalyzerTest {
         .getJoin();
 
     // Then:
-    assertThat(join.getLeftKeyFieldName(), is("T1.ROWKEY"));
-    assertThat(join.getRightKeyFieldName(), is("T2.ROWKEY"));
+    assertThat(join.getLeftJoinFieldName(), is("T1.ROWKEY"));
+    assertThat(join.getRightJoinFieldName(), is("T2.ROWKEY"));
   }
 
   @Test
@@ -320,13 +321,13 @@ public class AnalyzerTest {
     final SchemaBuilder schemaBuilder = SchemaBuilder.struct();
     final Schema schema = schemaBuilder
             .name("org.ac.s1")
-            .field("FIELD1", Schema.INT64_SCHEMA)
+            .field("FIELD1", Schema.OPTIONAL_INT64_SCHEMA)
             .build();
 
     final KsqlStream<?> ksqlStream = new KsqlStream<>(
             "create stream s0 with(KAFKA_TOPIC='s0', VALUE_AVRO_SCHEMA_FULL_NAME='org.ac.s1', VALUE_FORMAT='avro');",
             "S0",
-            schema,
+            KsqlSchema.of(schema),
             KeyField.of("FIELD1", schema.field("FIELD1")),
             new MetadataTimestampExtractionPolicy(),
             ksqlTopic,

--- a/ksql-engine/src/test/java/io/confluent/ksql/analyzer/QueryAnalyzerTest.java
+++ b/ksql-engine/src/test/java/io/confluent/ksql/analyzer/QueryAnalyzerTest.java
@@ -356,8 +356,8 @@ public class QueryAnalyzerTest {
     // Then:
     final JoinNode join = analysis.getJoin();
     assertTrue(join.isLeftJoin());
-    assertThat(join.getLeftKeyFieldName(), is("TEST1.COL1"));
-    assertThat(join.getRightKeyFieldName(), is("TEST2.COL2"));
+    assertThat(join.getLeftJoinFieldName(), is("TEST1.COL1"));
+    assertThat(join.getRightJoinFieldName(), is("TEST2.COL2"));
   }
 
   @Test

--- a/ksql-engine/src/test/java/io/confluent/ksql/codegen/CodeGenRunnerTest.java
+++ b/ksql-engine/src/test/java/io/confluent/ksql/codegen/CodeGenRunnerTest.java
@@ -43,6 +43,7 @@ import io.confluent.ksql.metastore.model.KeyField;
 import io.confluent.ksql.metastore.model.KsqlStream;
 import io.confluent.ksql.metastore.model.KsqlTopic;
 import io.confluent.ksql.parser.tree.Expression;
+import io.confluent.ksql.schema.ksql.KsqlSchema;
 import io.confluent.ksql.serde.json.KsqlJsonTopicSerDe;
 import io.confluent.ksql.util.ExpressionMetadata;
 import io.confluent.ksql.util.KsqlConfig;
@@ -54,7 +55,6 @@ import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
-import java.util.Optional;
 import java.util.stream.Collectors;
 import org.apache.kafka.common.serialization.Serdes;
 import org.apache.kafka.connect.data.Schema;
@@ -128,7 +128,7 @@ public class CodeGenRunnerTest {
         // load substring function
         UdfLoaderUtil.load(functionRegistry);
 
-        final Schema arraySchema = SchemaBuilder.array(Schema.STRING_SCHEMA).optional().build();
+        final Schema arraySchema = SchemaBuilder.array(Schema.OPTIONAL_STRING_SCHEMA).optional().build();
 
 
         final Schema schema = SchemaBuilder.struct()
@@ -149,7 +149,9 @@ public class CodeGenRunnerTest {
                    SchemaBuilder.map(SchemaBuilder.OPTIONAL_STRING_SCHEMA, SchemaBuilder.OPTIONAL_INT32_SCHEMA).optional().build())
             .field("CODEGEN_TEST.COL13", SchemaBuilder.array(SchemaBuilder.OPTIONAL_STRING_SCHEMA).optional().build())
             .field("CODEGEN_TEST.COL14", SchemaBuilder.array(arraySchema).optional().build())
-            .field("CODEGEN_TEST.COL15", STRUCT_SCHEMA);
+            .field("CODEGEN_TEST.COL15", STRUCT_SCHEMA)
+            .build();
+
         final Schema metaStoreSchema = SchemaBuilder.struct()
             .field("COL0", SchemaBuilder.OPTIONAL_INT64_SCHEMA)
             .field("COL1", SchemaBuilder.OPTIONAL_STRING_SCHEMA)
@@ -168,7 +170,9 @@ public class CodeGenRunnerTest {
                 SchemaBuilder.map(SchemaBuilder.OPTIONAL_STRING_SCHEMA, SchemaBuilder.OPTIONAL_INT32_SCHEMA).optional().build())
             .field("COL13", SchemaBuilder.array(SchemaBuilder.OPTIONAL_STRING_SCHEMA).optional().build())
             .field("CODEGEN_TEST.COL14", SchemaBuilder.array(arraySchema).optional().build())
-            .field("COL15", STRUCT_SCHEMA);
+            .field("COL15", STRUCT_SCHEMA)
+            .build();
+
         final KsqlTopic ksqlTopic = new KsqlTopic(
             "CODEGEN_TEST",
             "codegen_test",
@@ -176,13 +180,13 @@ public class CodeGenRunnerTest {
         final KsqlStream ksqlStream = new KsqlStream<>(
             "sqlexpression",
             "CODEGEN_TEST",
-            metaStoreSchema,
+            KsqlSchema.of(metaStoreSchema),
             KeyField.of("COL0", metaStoreSchema.field("COL0")),
             new MetadataTimestampExtractionPolicy(),
             ksqlTopic,Serdes::String);
         metaStore.putTopic(ksqlTopic);
         metaStore.putSource(ksqlStream);
-        codeGenRunner = new CodeGenRunner(schema, ksqlConfig, functionRegistry);
+        codeGenRunner = new CodeGenRunner(KsqlSchema.of(schema), ksqlConfig, functionRegistry);
     }
 
     @Test

--- a/ksql-engine/src/test/java/io/confluent/ksql/codegen/SqlToJavaVisitorTest.java
+++ b/ksql-engine/src/test/java/io/confluent/ksql/codegen/SqlToJavaVisitorTest.java
@@ -24,6 +24,7 @@ import io.confluent.ksql.analyzer.Analysis;
 import io.confluent.ksql.function.TestFunctionRegistry;
 import io.confluent.ksql.metastore.MetaStore;
 import io.confluent.ksql.parser.tree.Expression;
+import io.confluent.ksql.schema.ksql.KsqlSchema;
 import io.confluent.ksql.util.MetaStoreFixture;
 import org.apache.kafka.connect.data.Schema;
 import org.apache.kafka.connect.data.SchemaBuilder;
@@ -63,7 +64,7 @@ public class SqlToJavaVisitorTest {
         .field("TEST1.COL7", SchemaBuilder.OPTIONAL_INT32_SCHEMA)
         .build();
 
-    sqlToJavaVisitor = new SqlToJavaVisitor(schema, TestFunctionRegistry.INSTANCE.get());
+    sqlToJavaVisitor = new SqlToJavaVisitor(KsqlSchema.of(schema), TestFunctionRegistry.INSTANCE.get());
   }
 
   @Test

--- a/ksql-engine/src/test/java/io/confluent/ksql/integration/JoinIntTest.java
+++ b/ksql-engine/src/test/java/io/confluent/ksql/integration/JoinIntTest.java
@@ -20,6 +20,7 @@ import static io.confluent.ksql.serde.Format.JSON;
 
 import io.confluent.common.utils.IntegrationTest;
 import io.confluent.ksql.GenericRow;
+import io.confluent.ksql.schema.ksql.KsqlSchema;
 import io.confluent.ksql.serde.Format;
 import io.confluent.ksql.test.util.TopicTestUtil;
 import io.confluent.ksql.util.ItemDataProvider;
@@ -30,7 +31,6 @@ import java.util.HashMap;
 import java.util.Map;
 import java.util.concurrent.TimeUnit;
 import kafka.zookeeper.ZooKeeperClientException;
-import org.apache.kafka.connect.data.Schema;
 import org.apache.kafka.test.TestUtils;
 import org.junit.Before;
 import org.junit.ClassRule;
@@ -104,7 +104,8 @@ public class JoinIntTest {
 
     ksqlContext.sql(queryString);
 
-    final Schema resultSchema = ksqlContext.getMetaStore().getSource(testStreamName).getSchema();
+    final KsqlSchema resultSchema = ksqlContext.getMetaStore().getSource(testStreamName)
+        .getSchema();
 
     final Map<String, GenericRow> expectedResults =
         Collections.singletonMap("ITEM_1",
@@ -172,7 +173,8 @@ public class JoinIntTest {
     ksqlContext.sql(csasQueryString);
     ksqlContext.sql(insertQueryString);
 
-    final Schema resultSchema = ksqlContext.getMetaStore().getSource(testStreamName).getSchema();
+    final KsqlSchema resultSchema = ksqlContext.getMetaStore().getSource(testStreamName)
+        .getSchema();
 
     final Map<String, GenericRow> expectedResults = Collections.singletonMap("ITEM_1", new GenericRow(Arrays.asList(null, null, "ORDER_1", "ITEM_1", 10.0, "home cinema")));
 
@@ -235,7 +237,7 @@ public class JoinIntTest {
     ksqlContext.sql(queryString);
 
     final String outputStream = "OUTPUT";
-    final Schema resultSchema = ksqlContext.getMetaStore().getSource(outputStream).getSchema();
+    final KsqlSchema resultSchema = ksqlContext.getMetaStore().getSource(outputStream).getSchema();
 
     final Map<String, GenericRow> expectedResults =
         Collections.singletonMap("ITEM_1",

--- a/ksql-engine/src/test/java/io/confluent/ksql/integration/UdfIntTest.java
+++ b/ksql-engine/src/test/java/io/confluent/ksql/integration/UdfIntTest.java
@@ -27,11 +27,11 @@ import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import io.confluent.common.utils.IntegrationTest;
 import io.confluent.ksql.GenericRow;
+import io.confluent.ksql.schema.ksql.KsqlSchema;
 import io.confluent.ksql.serde.Format;
 import io.confluent.ksql.test.util.KsqlIdentifierTestUtil;
 import io.confluent.ksql.util.ItemDataProvider;
 import io.confluent.ksql.util.OrderDataProvider;
-import io.confluent.ksql.util.SchemaUtil;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
@@ -39,7 +39,6 @@ import java.util.Map;
 import java.util.concurrent.TimeUnit;
 import kafka.zookeeper.ZooKeeperClientException;
 import org.apache.kafka.clients.producer.RecordMetadata;
-import org.apache.kafka.connect.data.Schema;
 import org.junit.Assume;
 import org.junit.Before;
 import org.junit.BeforeClass;
@@ -248,8 +247,12 @@ public class UdfIntTest {
   }
 
   private Map<String, GenericRow> consumeOutputMessages() {
-    final Schema resultSchema = SchemaUtil.removeImplicitRowTimeRowKeyFromSchema(
-        ksqlContext.getMetaStore().getSource(resultStreamName).getSchema());
+
+    final KsqlSchema resultSchema = ksqlContext
+        .getMetaStore()
+        .getSource(resultStreamName)
+        .getSchema()
+        .withoutImplicitFields();
 
     return TEST_HARNESS.verifyAvailableUniqueRows(
         resultStreamName,

--- a/ksql-engine/src/test/java/io/confluent/ksql/integration/WindowingIntTest.java
+++ b/ksql-engine/src/test/java/io/confluent/ksql/integration/WindowingIntTest.java
@@ -27,6 +27,7 @@ import static org.hamcrest.Matchers.is;
 import com.google.common.collect.ImmutableMap;
 import io.confluent.common.utils.IntegrationTest;
 import io.confluent.ksql.GenericRow;
+import io.confluent.ksql.schema.ksql.KsqlSchema;
 import io.confluent.ksql.services.KafkaTopicClient;
 import io.confluent.ksql.services.KafkaTopicClient.TopicCleanupPolicy;
 import io.confluent.ksql.test.util.KsqlIdentifierTestUtil;
@@ -41,7 +42,6 @@ import java.util.concurrent.TimeUnit;
 import kafka.zookeeper.ZooKeeperClientException;
 import org.apache.kafka.common.serialization.Deserializer;
 import org.apache.kafka.common.serialization.StringDeserializer;
-import org.apache.kafka.connect.data.Schema;
 import org.apache.kafka.streams.kstream.SessionWindowedDeserializer;
 import org.apache.kafka.streams.kstream.TimeWindowedDeserializer;
 import org.apache.kafka.streams.kstream.Windowed;
@@ -87,7 +87,7 @@ public class WindowingIntTest {
   private String sourceTopicName;
   private String resultStream0;
   private String resultStream1;
-  private Schema resultSchema;
+  private KsqlSchema resultSchema;
   private Set<String> preExistingTopics;
   private KafkaTopicClient topicClient;
 

--- a/ksql-engine/src/test/java/io/confluent/ksql/physical/PhysicalPlanBuilderTest.java
+++ b/ksql-engine/src/test/java/io/confluent/ksql/physical/PhysicalPlanBuilderTest.java
@@ -51,6 +51,7 @@ import io.confluent.ksql.planner.LogicalPlanNode;
 import io.confluent.ksql.planner.plan.OutputNode;
 import io.confluent.ksql.planner.plan.PlanTestUtil;
 import io.confluent.ksql.query.QueryId;
+import io.confluent.ksql.schema.ksql.KsqlSchema;
 import io.confluent.ksql.serde.Format;
 import io.confluent.ksql.services.FakeKafkaTopicClient;
 import io.confluent.ksql.services.KafkaTopicClient;
@@ -253,13 +254,13 @@ public class PhysicalPlanBuilderTest {
     final QueryMetadata queryMetadata = buildPhysicalPlan(simpleSelectFilter);
 
     // Then:
-    assertThat(queryMetadata.getResultSchema(), is(
+    assertThat(queryMetadata.getResultSchema(), is(KsqlSchema.of(
         SchemaBuilder.struct()
             .field("COL0", Schema.OPTIONAL_INT64_SCHEMA)
             .field("COL2", Schema.OPTIONAL_STRING_SCHEMA)
             .field("COL3", Schema.OPTIONAL_FLOAT64_SCHEMA)
             .build()
-    ));
+    )));
   }
 
   @Test
@@ -269,7 +270,7 @@ public class PhysicalPlanBuilderTest {
         "CREATE STREAM FOO AS " + simpleSelectFilter);
 
     // Then:
-    assertThat(queryMetadata.getResultSchema(), is(
+    assertThat(queryMetadata.getResultSchema(), is(KsqlSchema.of(
         SchemaBuilder.struct()
             .field("ROWTIME", Schema.OPTIONAL_INT64_SCHEMA)
             .field("ROWKEY", Schema.OPTIONAL_STRING_SCHEMA)
@@ -277,7 +278,7 @@ public class PhysicalPlanBuilderTest {
             .field("COL2", Schema.OPTIONAL_STRING_SCHEMA)
             .field("COL3", Schema.OPTIONAL_FLOAT64_SCHEMA)
             .build()
-    ));
+    )));
   }
 
   @Test
@@ -744,7 +745,7 @@ public class PhysicalPlanBuilderTest {
     givenKafkaTopicsExist("test1");
     final List<QueryMetadata> queryMetadataList = execute(
         CREATE_STREAM_TEST1 + csasQuery + insertIntoQuery);
-    final Schema resultSchema = queryMetadataList.get(0).getResultSchema();
+    final KsqlSchema resultSchema = queryMetadataList.get(0).getResultSchema();
     resultSchema.fields().forEach(
         field -> Assert.assertTrue(field.schema().isOptional())
     );

--- a/ksql-engine/src/test/java/io/confluent/ksql/planner/plan/DataSourceNodeTest.java
+++ b/ksql-engine/src/test/java/io/confluent/ksql/planner/plan/DataSourceNodeTest.java
@@ -32,12 +32,14 @@ import static org.mockito.Mockito.when;
 
 import com.google.common.collect.ImmutableSet;
 import io.confluent.ksql.GenericRow;
+import io.confluent.ksql.function.FunctionRegistry;
 import io.confluent.ksql.metastore.model.KeyField;
 import io.confluent.ksql.metastore.model.KsqlStream;
 import io.confluent.ksql.metastore.model.KsqlTable;
 import io.confluent.ksql.metastore.model.KsqlTopic;
 import io.confluent.ksql.physical.KsqlQueryBuilder;
 import io.confluent.ksql.query.QueryId;
+import io.confluent.ksql.schema.ksql.KsqlSchema;
 import io.confluent.ksql.serde.KsqlTopicSerDe;
 import io.confluent.ksql.serde.json.KsqlJsonTopicSerDe;
 import io.confluent.ksql.streams.MaterializedFactory;
@@ -89,19 +91,19 @@ public class DataSourceNodeTest {
   private final KsqlConfig realConfig = new KsqlConfig(Collections.emptyMap());
   private SchemaKStream realStream;
   private StreamsBuilder realBuilder;
-  private final Schema realSchema = SchemaBuilder.struct()
+  private final KsqlSchema realSchema = KsqlSchema.of(SchemaBuilder.struct()
       .field("field1", Schema.OPTIONAL_STRING_SCHEMA)
       .field("field2", Schema.OPTIONAL_STRING_SCHEMA)
       .field("field3", Schema.OPTIONAL_STRING_SCHEMA)
       .field(TIMESTAMP_FIELD, Schema.OPTIONAL_INT64_SCHEMA)
       .field("key", Schema.OPTIONAL_STRING_SCHEMA)
-      .build();
+      .build());
 
   private final KsqlStream<String> SOME_SOURCE = new KsqlStream<>(
       "sqlExpression",
       "datasource",
       realSchema,
-      KeyField.of("key", realSchema.field("key")),
+      KeyField.of("key", realSchema.getSchema().field("key")),
       new LongColumnTimestampExtractionPolicy("timestamp"),
       new KsqlTopic("topic", "topic",
           new KsqlJsonTopicSerDe(), false), Serdes::String);
@@ -144,6 +146,8 @@ public class DataSourceNodeTest {
   private Materialized materialized;
   @Mock
   private KsqlQueryBuilder ksqlStreamBuilder;
+  @Mock
+  private FunctionRegistry functionRegistry;
   @Captor
   private ArgumentCaptor<QueryContext> queryContextCaptor;
 
@@ -157,6 +161,8 @@ public class DataSourceNodeTest {
     when(ksqlStreamBuilder.buildNodeContext(any())).thenAnswer(inv ->
         new QueryContext.Stacker(queryId)
             .push(inv.getArgument(0).toString()));
+    when(ksqlStreamBuilder.buildGenericRowSerde(any(), any(), any())).thenReturn(rowSerde);
+    when(ksqlStreamBuilder.getFunctionRegistry()).thenReturn(functionRegistry);
 
     realStream = node.buildStream(ksqlStreamBuilder);
 
@@ -167,7 +173,6 @@ public class DataSourceNodeTest {
     when(tableSource.getTimestampExtractionPolicy()).thenReturn(timestampExtractionPolicy);
     when(ksqlTopic.getKafkaTopicName()).thenReturn("topic");
     when(ksqlTopic.getKsqlTopicSerDe()).thenReturn(topicSerDe);
-    when(ksqlStreamBuilder.buildGenericRowSerde(any(), any(), any())).thenReturn(rowSerde);
     when(timestampExtractionPolicy.timestampField()).thenReturn(TIMESTAMP_FIELD);
     when(timestampExtractionPolicy.create(anyInt())).thenReturn(timestampExtractor);
     when(kStream.transformValues(any(ValueTransformerSupplier.class))).thenReturn(kStream);
@@ -257,7 +262,7 @@ public class DataSourceNodeTest {
   public void shouldBuildSchemaKTableWhenKTableSource() {
     final KsqlTable<String> table = new KsqlTable<>("sqlExpression", "datasource",
         realSchema,
-        KeyField.of("field1", realSchema.field("field1")),
+        KeyField.of("field1", realSchema.getSchema().field("field1")),
         new LongColumnTimestampExtractionPolicy("timestamp"),
         new KsqlTopic("topic2", "topic2",
             new KsqlJsonTopicSerDe(), false),
@@ -276,7 +281,7 @@ public class DataSourceNodeTest {
   public void shouldTransformKStreamToKTableCorrectly() {
     final KsqlTable<String> table = new KsqlTable<>("sqlExpression", "datasource",
         realSchema,
-        KeyField.of("field1", realSchema.field("field1")),
+        KeyField.of("field1", realSchema.getSchema().field("field1")),
         new LongColumnTimestampExtractionPolicy("timestamp"),
         new KsqlTopic("topic2", "topic2",
             new KsqlJsonTopicSerDe(), false),
@@ -324,17 +329,17 @@ public class DataSourceNodeTest {
     final String sourceName = SOME_SOURCE.getName();
 
     // When:
-    final Schema schema = node.getSchema();
+    final KsqlSchema schema = node.getSchema();
 
     // Then:
     assertThat(schema, is(
-        SchemaBuilder.struct()
+        KsqlSchema.of(SchemaBuilder.struct()
             .field(sourceName + ".field1", Schema.OPTIONAL_STRING_SCHEMA)
             .field(sourceName + ".field2", Schema.OPTIONAL_STRING_SCHEMA)
             .field(sourceName + ".field3", Schema.OPTIONAL_STRING_SCHEMA)
             .field(sourceName + "." + TIMESTAMP_FIELD, Schema.OPTIONAL_INT64_SCHEMA)
             .field(sourceName + ".key", Schema.OPTIONAL_STRING_SCHEMA)
-            .build()));
+            .build())));
   }
 
   @SuppressWarnings("unchecked")
@@ -343,7 +348,7 @@ public class DataSourceNodeTest {
     when(streamsBuilder.stream(anyString(), any())).thenReturn((KStream)kStream);
     when(tableSource.getSchema()).thenReturn(realSchema);
     when(tableSource.getKeyField())
-        .thenReturn(KeyField.of("field1", realSchema.field("field1")));
+        .thenReturn(KeyField.of("field1", realSchema.getSchema().field("field1")));
 
     return new DataSourceNode(
         realNodeId,

--- a/ksql-engine/src/test/java/io/confluent/ksql/planner/plan/KsqlBareOutputNodeTest.java
+++ b/ksql-engine/src/test/java/io/confluent/ksql/planner/plan/KsqlBareOutputNodeTest.java
@@ -19,24 +19,26 @@ import static io.confluent.ksql.planner.plan.PlanTestUtil.verifyProcessorNode;
 import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.CoreMatchers.instanceOf;
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.contains;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verifyNoMoreInteractions;
 import static org.mockito.Mockito.when;
 
 import com.google.common.collect.ImmutableSet;
+import io.confluent.ksql.function.FunctionRegistry;
 import io.confluent.ksql.function.InternalFunctionRegistry;
 import io.confluent.ksql.logging.processing.ProcessingLogContext;
 import io.confluent.ksql.metastore.MetaStore;
 import io.confluent.ksql.physical.KsqlQueryBuilder;
 import io.confluent.ksql.query.QueryId;
+import io.confluent.ksql.schema.ksql.KsqlSchema;
 import io.confluent.ksql.structured.QueryContext;
 import io.confluent.ksql.structured.SchemaKStream;
 import io.confluent.ksql.testutils.AnalysisTestUtil;
 import io.confluent.ksql.util.KsqlConfig;
 import io.confluent.ksql.util.MetaStoreFixture;
 import io.confluent.ksql.util.QueryIdGenerator;
-import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 import java.util.Set;
@@ -69,6 +71,8 @@ public class KsqlBareOutputNodeTest {
 
   @Mock
   private KsqlQueryBuilder ksqlStreamBuilder;
+  @Mock
+  private FunctionRegistry functionRegistry;
 
   @Before
   public void before() {
@@ -77,6 +81,7 @@ public class KsqlBareOutputNodeTest {
     when(ksqlStreamBuilder.getKsqlConfig()).thenReturn(new KsqlConfig(Collections.emptyMap()));
     when(ksqlStreamBuilder.getStreamsBuilder()).thenReturn(builder);
     when(ksqlStreamBuilder.getProcessingLogContext()).thenReturn(ProcessingLogContext.create());
+    when(ksqlStreamBuilder.getFunctionRegistry()).thenReturn(functionRegistry);
     when(ksqlStreamBuilder.buildNodeContext(any())).thenAnswer(inv ->
         new QueryContext.Stacker(queryId)
             .push(inv.getArgument(0).toString()));
@@ -117,10 +122,11 @@ public class KsqlBareOutputNodeTest {
 
   @Test
   public void shouldCreateCorrectSchema() {
-    final Schema schema = stream.getSchema();
-    assertThat(schema.fields(), equalTo(Arrays.asList(new Field("COL0", 0, Schema.OPTIONAL_INT64_SCHEMA),
+    final KsqlSchema schema = stream.getSchema();
+    assertThat(schema.fields(), contains(
+        new Field("COL0", 0, Schema.OPTIONAL_INT64_SCHEMA),
         new Field("COL2", 1, Schema.OPTIONAL_STRING_SCHEMA),
-        new Field("COL3", 2, Schema.OPTIONAL_FLOAT64_SCHEMA))));
+        new Field("COL3", 2, Schema.OPTIONAL_FLOAT64_SCHEMA)));
   }
 
   @Test

--- a/ksql-engine/src/test/java/io/confluent/ksql/planner/plan/KsqlStructuredDataOutputNodeTest.java
+++ b/ksql-engine/src/test/java/io/confluent/ksql/planner/plan/KsqlStructuredDataOutputNodeTest.java
@@ -34,6 +34,7 @@ import static org.mockito.Mockito.when;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
 import io.confluent.ksql.ddl.DdlConfig;
+import io.confluent.ksql.function.FunctionRegistry;
 import io.confluent.ksql.metastore.SerdeFactory;
 import io.confluent.ksql.metastore.model.KeyField;
 import io.confluent.ksql.metastore.model.KsqlStream;
@@ -41,6 +42,7 @@ import io.confluent.ksql.metastore.model.KsqlTable;
 import io.confluent.ksql.metastore.model.KsqlTopic;
 import io.confluent.ksql.physical.KsqlQueryBuilder;
 import io.confluent.ksql.query.QueryId;
+import io.confluent.ksql.schema.ksql.KsqlSchema;
 import io.confluent.ksql.serde.KsqlTopicSerDe;
 import io.confluent.ksql.serde.avro.KsqlAvroTopicSerDe;
 import io.confluent.ksql.serde.json.KsqlJsonTopicSerDe;
@@ -91,17 +93,17 @@ public class KsqlStructuredDataOutputNodeTest {
   @Rule
   public final ExpectedException expectedException = ExpectedException.none();
 
-  private final Schema schema = SchemaBuilder.struct()
+  private final KsqlSchema schema = KsqlSchema.of(SchemaBuilder.struct()
       .field("field1", Schema.OPTIONAL_STRING_SCHEMA)
       .field("field2", Schema.OPTIONAL_STRING_SCHEMA)
       .field("field3", Schema.OPTIONAL_STRING_SCHEMA)
       .field("timestamp", Schema.OPTIONAL_INT64_SCHEMA)
       .field("key", Schema.OPTIONAL_STRING_SCHEMA)
-      .build();
+      .build());
 
   private final KsqlStream dataSource = new KsqlStream<>("sqlExpression", "datasource",
       schema,
-      KeyField.of("key", schema.field("key")),
+      KeyField.of("key", schema.getSchema().field("key")),
       new LongColumnTimestampExtractionPolicy("timestamp"),
       new KsqlTopic(SOURCE_TOPIC_NAME, SOURCE_KAFKA_TOPIC_NAME,
           new KsqlJsonTopicSerDe(), false), Serdes::String);
@@ -121,6 +123,8 @@ public class KsqlStructuredDataOutputNodeTest {
   private QueryIdGenerator queryIdGenerator;
   @Mock
   private KsqlQueryBuilder ksqlStreamBuilder;
+  @Mock
+  private FunctionRegistry functionRegistry;
   @Captor
   private ArgumentCaptor<QueryContext> queryContextCaptor;
 
@@ -135,6 +139,7 @@ public class KsqlStructuredDataOutputNodeTest {
 
     when(ksqlStreamBuilder.getKsqlConfig()).thenReturn(ksqlConfig);
     when(ksqlStreamBuilder.getStreamsBuilder()).thenReturn(builder);
+    when(ksqlStreamBuilder.getFunctionRegistry()).thenReturn(functionRegistry);
     when(ksqlStreamBuilder.buildNodeContext(any())).thenAnswer(inv ->
         new QueryContext.Stacker(QUERY_ID)
             .push(inv.getArgument(0).toString()));
@@ -148,7 +153,7 @@ public class KsqlStructuredDataOutputNodeTest {
         sourceNode,
         schema,
         new LongColumnTimestampExtractionPolicy("timestamp"),
-        KeyField.of("key", schema.field("key")),
+        KeyField.of("key", schema.getSchema().field("key")),
         new KsqlTopic(SINK_TOPIC_NAME, SINK_KAFKA_TOPIC_NAME, serde, true),
         SINK_KAFKA_TOPIC_NAME,
         props,
@@ -159,7 +164,7 @@ public class KsqlStructuredDataOutputNodeTest {
   @Test(expected = IllegalArgumentException.class)
   public void shouldThrowIfKeyFieldDoesNotMatchPartitionBy() {
     // Given
-    final KeyField keyField = KeyField.of("key", schema.field("key"));
+    final KeyField keyField = KeyField.of("key", schema.getSchema().field("key"));
     final ImmutableMap<String, Object> of = ImmutableMap.of(
         DdlConfig.PARTITION_BY_PROPERTY, "field1"
     );
@@ -191,7 +196,7 @@ public class KsqlStructuredDataOutputNodeTest {
         sourceNode,
         schema,
         new LongColumnTimestampExtractionPolicy("timestamp"),
-        KeyField.of("key", schema.field("key")),
+        KeyField.of("key", schema.getSchema().field("key")),
         new KsqlTopic(SINK_TOPIC_NAME, SINK_KAFKA_TOPIC_NAME, new KsqlJsonTopicSerDe(), true),
         SINK_KAFKA_TOPIC_NAME,
         of,
@@ -276,7 +281,7 @@ public class KsqlStructuredDataOutputNodeTest {
     assertThat(stream.getKeyField().name(), is(Optional.of("key")));
     assertThat(stream.getKeyField().legacy(),
         is(Optional.of(new Field("key", 4, Schema.OPTIONAL_STRING_SCHEMA))));
-    assertThat(stream.getSchema().fields(), equalTo(schema.fields()));
+    assertThat(stream.getSchema().fields(), equalTo(schema.getSchema().fields()));
   }
 
   @Test
@@ -343,7 +348,7 @@ public class KsqlStructuredDataOutputNodeTest {
         sourceNode,
         schema,
         new LongColumnTimestampExtractionPolicy("timestamp"),
-        KeyField.of("key", schema.field("key")),
+        KeyField.of("key", schema.getSchema().field("key")),
         mockTopic(topicSerde),
         "output",
         Collections.emptyMap(),
@@ -356,7 +361,7 @@ public class KsqlStructuredDataOutputNodeTest {
     // Then:
     verify(ksqlStreamBuilder).buildGenericRowSerde(
         eq(topicSerde),
-        eq(schema),
+        eq(schema.getSchema()),
         queryContextCaptor.capture()
     );
 
@@ -373,7 +378,7 @@ public class KsqlStructuredDataOutputNodeTest {
     final KsqlTable<K> dataSource = new KsqlTable<>(
         "sqlExpression", "datasource",
         schema,
-        KeyField.of("key", schema.field("key")),
+        KeyField.of("key", schema.getSchema().field("key")),
         new MetadataTimestampExtractionPolicy(),
         new KsqlTopic(SOURCE_TOPIC_NAME, SOURCE_KAFKA_TOPIC_NAME, new KsqlJsonTopicSerDe(), false),
         keySerdeFatory);
@@ -388,7 +393,7 @@ public class KsqlStructuredDataOutputNodeTest {
         tableSourceNode,
         schema,
         new MetadataTimestampExtractionPolicy(),
-        KeyField.of("key", schema.field("key")),
+        KeyField.of("key", schema.getSchema().field("key")),
         new KsqlTopic(SINK_TOPIC_NAME, SINK_KAFKA_TOPIC_NAME, new KsqlJsonTopicSerDe(), true),
         SINK_KAFKA_TOPIC_NAME,
         props,

--- a/ksql-engine/src/test/java/io/confluent/ksql/planner/plan/ProjectNodeTest.java
+++ b/ksql-engine/src/test/java/io/confluent/ksql/planner/plan/ProjectNodeTest.java
@@ -31,6 +31,7 @@ import io.confluent.ksql.metastore.model.DataSource.DataSourceType;
 import io.confluent.ksql.metastore.model.KeyField;
 import io.confluent.ksql.parser.tree.BooleanLiteral;
 import io.confluent.ksql.physical.KsqlQueryBuilder;
+import io.confluent.ksql.schema.ksql.KsqlSchema;
 import io.confluent.ksql.structured.QueryContext.Stacker;
 import io.confluent.ksql.structured.SchemaKStream;
 import io.confluent.ksql.util.KsqlException;
@@ -53,10 +54,10 @@ public class ProjectNodeTest {
   private static final BooleanLiteral TRUE_EXPRESSION = new BooleanLiteral("true");
   private static final BooleanLiteral FALSE_EXPRESSION = new BooleanLiteral("false");
   private static final String KEY_FIELD_NAME = "field1";
-  private static final Schema SCHEMA = SchemaBuilder.struct()
+  private static final KsqlSchema SCHEMA = KsqlSchema.of(SchemaBuilder.struct()
       .field("field1", Schema.OPTIONAL_STRING_SCHEMA)
       .field("field2", Schema.OPTIONAL_STRING_SCHEMA)
-      .build();
+      .build());
   private static final KeyField SOURCE_KEY_FIELD = KeyField
       .of("source-key", new Field("legacy-source-key", 1, Schema.STRING_SCHEMA));
 

--- a/ksql-engine/src/test/java/io/confluent/ksql/structured/KsqlValueJoinerTest.java
+++ b/ksql-engine/src/test/java/io/confluent/ksql/structured/KsqlValueJoinerTest.java
@@ -18,17 +18,17 @@ package io.confluent.ksql.structured;
 import static org.junit.Assert.assertEquals;
 
 import io.confluent.ksql.GenericRow;
+import io.confluent.ksql.schema.ksql.KsqlSchema;
 import java.util.Arrays;
 import java.util.List;
-import org.apache.kafka.connect.data.Schema;
 import org.apache.kafka.connect.data.SchemaBuilder;
 import org.junit.Before;
 import org.junit.Test;
 
 public class KsqlValueJoinerTest {
 
-  private Schema leftSchema;
-  private Schema rightSchema;
+  private KsqlSchema leftSchema;
+  private KsqlSchema rightSchema;
   private GenericRow leftRow;
   private GenericRow rightRow;
 
@@ -38,8 +38,8 @@ public class KsqlValueJoinerTest {
         .field("col0", SchemaBuilder.OPTIONAL_INT64_SCHEMA)
         .field("col1", SchemaBuilder.OPTIONAL_STRING_SCHEMA);
 
-    leftSchema = schemaBuilder.build();
-    rightSchema = schemaBuilder.build();
+    leftSchema = KsqlSchema.of(schemaBuilder.build());
+    rightSchema = KsqlSchema.of(schemaBuilder.build());
 
     leftRow = new GenericRow(Arrays.asList(12L, "foobar"));
     rightRow = new GenericRow(Arrays.asList(20L, "baz"));

--- a/ksql-engine/src/test/java/io/confluent/ksql/structured/SchemaKGroupedStreamTest.java
+++ b/ksql-engine/src/test/java/io/confluent/ksql/structured/SchemaKGroupedStreamTest.java
@@ -36,17 +36,15 @@ import io.confluent.ksql.metastore.model.KeyField;
 import io.confluent.ksql.parser.tree.KsqlWindowExpression;
 import io.confluent.ksql.parser.tree.WindowExpression;
 import io.confluent.ksql.query.QueryId;
+import io.confluent.ksql.schema.ksql.KsqlSchema;
 import io.confluent.ksql.streams.MaterializedFactory;
 import io.confluent.ksql.streams.StreamsUtil;
 import io.confluent.ksql.util.KsqlConfig;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
-import java.util.Optional;
 import org.apache.kafka.common.serialization.Serde;
 import org.apache.kafka.common.serialization.Serdes;
-import org.apache.kafka.connect.data.Field;
-import org.apache.kafka.connect.data.Schema;
 import org.apache.kafka.streams.kstream.Initializer;
 import org.apache.kafka.streams.kstream.KGroupedStream;
 import org.apache.kafka.streams.kstream.KTable;
@@ -65,7 +63,7 @@ import org.mockito.junit.MockitoRule;
 @SuppressWarnings("unchecked")
 public class SchemaKGroupedStreamTest {
   @Mock
-  private Schema schema;
+  private KsqlSchema schema;
   @Mock
   private KGroupedStream groupedStream;
   @Mock

--- a/ksql-engine/src/test/java/io/confluent/ksql/structured/SelectValueMapperTest.java
+++ b/ksql-engine/src/test/java/io/confluent/ksql/structured/SelectValueMapperTest.java
@@ -31,6 +31,7 @@ import io.confluent.ksql.logging.processing.ProcessingLogger;
 import io.confluent.ksql.metastore.MetaStore;
 import io.confluent.ksql.planner.plan.PlanNode;
 import io.confluent.ksql.planner.plan.ProjectNode;
+import io.confluent.ksql.schema.ksql.KsqlSchema;
 import io.confluent.ksql.testutils.AnalysisTestUtil;
 import io.confluent.ksql.util.ExpressionMetadata;
 import io.confluent.ksql.util.KsqlConfig;
@@ -42,7 +43,6 @@ import java.util.Collections;
 import java.util.List;
 import java.util.function.Function;
 import java.util.stream.Collectors;
-import org.apache.kafka.connect.data.Schema;
 import org.apache.kafka.connect.data.SchemaAndValue;
 import org.apache.kafka.connect.data.Struct;
 import org.junit.Rule;
@@ -139,7 +139,7 @@ public class SelectValueMapperTest {
   private SelectValueMapper givenSelectMapperFor(final String query) {
     final PlanNode planNode = AnalysisTestUtil.buildLogicalPlan(query, metaStore);
     final ProjectNode projectNode = (ProjectNode) planNode.getSources().get(0);
-    final Schema schema = planNode.getTheSourceNode().getSchema();
+    final KsqlSchema schema = planNode.getTheSourceNode().getSchema();
     final List<SelectExpression> selectExpressions = projectNode.getProjectSelectExpressions();
     final List<ExpressionMetadata> metadata = createExpressionMetadata(selectExpressions, schema);
     final List<String> selectFieldNames = selectExpressions.stream()
@@ -154,7 +154,7 @@ public class SelectValueMapperTest {
 
   private List<ExpressionMetadata> createExpressionMetadata(
       final List<SelectExpression> selectExpressions,
-      final Schema schema
+      final KsqlSchema schema
   ) {
     try {
       final CodeGenRunner codeGenRunner = new CodeGenRunner(

--- a/ksql-engine/src/test/java/io/confluent/ksql/topic/TopicCreateInjectorTest.java
+++ b/ksql-engine/src/test/java/io/confluent/ksql/topic/TopicCreateInjectorTest.java
@@ -39,20 +39,16 @@ import io.confluent.ksql.parser.KsqlParser.PreparedStatement;
 import io.confluent.ksql.parser.tree.CreateAsSelect;
 import io.confluent.ksql.parser.tree.IntegerLiteral;
 import io.confluent.ksql.parser.tree.StringLiteral;
+import io.confluent.ksql.schema.ksql.KsqlSchema;
 import io.confluent.ksql.serde.json.KsqlJsonTopicSerDe;
-import io.confluent.ksql.services.FakeKafkaTopicClient;
-import io.confluent.ksql.services.FakeKafkaTopicClient.FakeTopic;
 import io.confluent.ksql.services.KafkaTopicClient;
-import io.confluent.ksql.services.KafkaTopicClient.TopicCleanupPolicy;
 import io.confluent.ksql.statement.ConfiguredStatement;
 import io.confluent.ksql.util.KsqlConfig;
 import io.confluent.ksql.util.KsqlConstants;
 import io.confluent.ksql.util.timestamp.MetadataTimestampExtractionPolicy;
 import java.util.HashMap;
 import java.util.Map;
-import java.util.Optional;
 import java.util.function.Supplier;
-import kafka.server.KafkaConfig;
 import org.apache.kafka.clients.admin.TopicDescription;
 import org.apache.kafka.common.config.TopicConfig;
 import org.apache.kafka.common.serialization.Serdes;
@@ -69,10 +65,10 @@ import org.mockito.junit.MockitoJUnitRunner;
 @RunWith(MockitoJUnitRunner.class)
 public class TopicCreateInjectorTest {
 
-  private static final Schema SCHEMA = SchemaBuilder
+  private static final KsqlSchema SCHEMA = KsqlSchema.of(SchemaBuilder
       .struct()
       .field("F1", Schema.OPTIONAL_STRING_SCHEMA)
-      .build();
+      .build());
 
   @Mock
   private TopicProperties.Builder builder;

--- a/ksql-engine/src/test/java/io/confluent/ksql/util/AvroUtilTest.java
+++ b/ksql-engine/src/test/java/io/confluent/ksql/util/AvroUtilTest.java
@@ -28,11 +28,11 @@ import io.confluent.connect.avro.AvroDataConfig;
 import io.confluent.kafka.schemaregistry.client.SchemaRegistryClient;
 import io.confluent.kafka.schemaregistry.client.rest.exceptions.RestClientException;
 import io.confluent.ksql.metastore.model.KsqlTopic;
+import io.confluent.ksql.schema.ksql.KsqlSchema;
 import io.confluent.ksql.serde.avro.KsqlAvroTopicSerDe;
 import io.confluent.ksql.serde.connect.ConnectSchemaTranslator;
 import java.io.IOException;
 import java.util.Collections;
-import org.apache.kafka.connect.data.Schema;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
@@ -58,7 +58,7 @@ public class AvroUtilTest {
       + " ]"
       + "}";
 
-  private static final Schema RESULT_SCHEMA = toKsqlSchema(AVRO_SCHEMA_STRING);
+  private static final KsqlSchema RESULT_SCHEMA = toKsqlSchema(AVRO_SCHEMA_STRING);
 
   private static final KsqlTopic RESULT_TOPIC =
       new KsqlTopic("registered-name", "actual-name", new KsqlAvroTopicSerDe(KsqlConstants.DEFAULT_AVRO_SCHEMA_FULL_NAME), false);
@@ -97,7 +97,7 @@ public class AvroUtilTest {
     when(persistentQuery.getResultSchema()).thenReturn(RESULT_SCHEMA);
 
     final org.apache.avro.Schema expectedAvroSchema = SchemaUtil
-        .buildAvroSchema(RESULT_SCHEMA, RESULT_TOPIC.getKsqlTopicName());
+        .buildAvroSchema(RESULT_SCHEMA.getSchema(), RESULT_TOPIC.getKsqlTopicName());
 
     // When:
     AvroUtil.isValidSchemaEvolution(persistentQuery, srClient);
@@ -171,10 +171,11 @@ public class AvroUtilTest {
     AvroUtil.isValidSchemaEvolution(persistentQuery, srClient);
   }
 
-  private static Schema toKsqlSchema(final String avroSchemaString) {
+  private static KsqlSchema toKsqlSchema(final String avroSchemaString) {
     final org.apache.avro.Schema avroSchema =
         new org.apache.avro.Schema.Parser().parse(avroSchemaString);
     final AvroData avroData = new AvroData(new AvroDataConfig(Collections.emptyMap()));
-    return new ConnectSchemaTranslator().toKsqlSchema(avroData.toConnectSchema(avroSchema));
+    return KsqlSchema.of(new ConnectSchemaTranslator()
+        .toKsqlSchema(avroData.toConnectSchema(avroSchema)));
   }
 }

--- a/ksql-engine/src/test/java/io/confluent/ksql/util/GenericRowValueTypeEnforcerTest.java
+++ b/ksql-engine/src/test/java/io/confluent/ksql/util/GenericRowValueTypeEnforcerTest.java
@@ -33,13 +33,15 @@ public class GenericRowValueTypeEnforcerTest {
 
   @Test
   public void testEnforceBoolean() {
-    final SchemaBuilder schemaBuilder = SchemaBuilder.struct()
-        .field("boolean", Schema.OPTIONAL_BOOLEAN_SCHEMA);
+    final KsqlSchema schema = KsqlSchema.of(SchemaBuilder.struct()
+        .field("boolean", Schema.OPTIONAL_BOOLEAN_SCHEMA)
+        .build());
+    
     final GenericRowValueTypeEnforcer genericRowValueTypeEnforcer =
-        new GenericRowValueTypeEnforcer(KsqlSchema.of(schemaBuilder.build()));
+        new GenericRowValueTypeEnforcer(schema);
 
     try {
-      genericRowValueTypeEnforcer.enforceFieldType(0, schemaBuilder);
+      genericRowValueTypeEnforcer.enforceFieldType(0, schema);
       fail("Expecting exception: KsqlException");
     } catch (final KsqlException e) {
       assertEquals(GenericRowValueTypeEnforcer.class.getName(),
@@ -49,40 +51,48 @@ public class GenericRowValueTypeEnforcerTest {
 
   @Test
   public void testEnforceBooleanReturningBooleanWhereBooleanValueIsFalse() {
-    final SchemaBuilder schemaBuilder = SchemaBuilder.struct()
-        .field("boolean", Schema.OPTIONAL_BOOLEAN_SCHEMA);
+    final KsqlSchema schema = KsqlSchema.of(SchemaBuilder.struct()
+        .field("boolean", Schema.OPTIONAL_BOOLEAN_SCHEMA)
+        .build());
+
     final GenericRowValueTypeEnforcer genericRowValueTypeEnforcer =
-        new GenericRowValueTypeEnforcer(KsqlSchema.of(schemaBuilder.build()));
+        new GenericRowValueTypeEnforcer(schema);
 
     assertEquals(Boolean.FALSE, genericRowValueTypeEnforcer.enforceFieldType(0, "0x"));
   }
 
   @Test
   public void testEnforceBooleanReturningBooleanWhereBooleanValueIsTrue() {
-    final SchemaBuilder schemaBuilder = SchemaBuilder.struct()
-        .field("boolean", Schema.OPTIONAL_BOOLEAN_SCHEMA);
+    final KsqlSchema schema = KsqlSchema.of(SchemaBuilder.struct()
+        .field("boolean", Schema.OPTIONAL_BOOLEAN_SCHEMA)
+        .build());
+
     final GenericRowValueTypeEnforcer genericRowValueTypeEnforcer =
-        new GenericRowValueTypeEnforcer(KsqlSchema.of(schemaBuilder.build()));
+        new GenericRowValueTypeEnforcer(schema);
 
     assertEquals(Boolean.TRUE, genericRowValueTypeEnforcer.enforceFieldType(0, true));
   }
 
   @Test
   public void testEnforceBooleanReturningNull() {
-    final SchemaBuilder schemaBuilder = SchemaBuilder.struct()
-        .field("boolean", Schema.OPTIONAL_BOOLEAN_SCHEMA);
+    final KsqlSchema schema = KsqlSchema.of(SchemaBuilder.struct()
+        .field("boolean", Schema.OPTIONAL_BOOLEAN_SCHEMA)
+        .build());
+
     final GenericRowValueTypeEnforcer genericRowValueTypeEnforcer =
-        new GenericRowValueTypeEnforcer(KsqlSchema.of(schemaBuilder.build()));
+        new GenericRowValueTypeEnforcer(schema);
 
     assertNull(genericRowValueTypeEnforcer.enforceFieldType(0, null));
   }
 
   @Test
   public void testEnforceString() {
-    final SchemaBuilder schemaBuilder = SchemaBuilder.struct()
-        .field("string", Schema.OPTIONAL_STRING_SCHEMA);
+    final KsqlSchema schema = KsqlSchema.of(SchemaBuilder.struct()
+        .field("string", Schema.OPTIONAL_STRING_SCHEMA)
+        .build());
+
     final GenericRowValueTypeEnforcer genericRowValueTypeEnforcer =
-        new GenericRowValueTypeEnforcer(KsqlSchema.of(schemaBuilder.build()));
+        new GenericRowValueTypeEnforcer(schema);
 
     try {
       genericRowValueTypeEnforcer.enforceFieldType(0, 0.0);
@@ -95,23 +105,27 @@ public class GenericRowValueTypeEnforcerTest {
 
   @Test
   public void testEnforceStringReturningNull() {
-    final SchemaBuilder schemaBuilder = SchemaBuilder.struct()
-        .field("string", Schema.OPTIONAL_STRING_SCHEMA);
+    final KsqlSchema schema = KsqlSchema.of(SchemaBuilder.struct()
+        .field("string", Schema.OPTIONAL_STRING_SCHEMA)
+        .build());
+
     final GenericRowValueTypeEnforcer genericRowValueTypeEnforcer =
-        new GenericRowValueTypeEnforcer(KsqlSchema.of(schemaBuilder.build()));
+        new GenericRowValueTypeEnforcer(schema);
 
     assertNull(genericRowValueTypeEnforcer.enforceFieldType(0, null));
   }
 
   @Test
   public void testEnforceInteger() {
-    final SchemaBuilder schemaBuilder = SchemaBuilder.struct()
-        .field("int", Schema.OPTIONAL_INT32_SCHEMA);
+    final KsqlSchema schema = KsqlSchema.of(SchemaBuilder.struct()
+        .field("int", Schema.OPTIONAL_INT32_SCHEMA)
+        .build());
+
     final GenericRowValueTypeEnforcer genericRowValueTypeEnforcer =
-        new GenericRowValueTypeEnforcer(KsqlSchema.of(schemaBuilder.build()));
+        new GenericRowValueTypeEnforcer(schema);
 
     try {
-      genericRowValueTypeEnforcer.enforceFieldType(0, schemaBuilder);
+      genericRowValueTypeEnforcer.enforceFieldType(0, schema);
       fail("Expecting exception: KsqlException");
     } catch (final KsqlException e) {
       assertEquals(GenericRowValueTypeEnforcer.class.getName(),
@@ -121,10 +135,12 @@ public class GenericRowValueTypeEnforcerTest {
 
   @Test
   public void testEnforceIntegerThrowsNumberFormatExceptionOnInvalidCharSequence() {
-    final SchemaBuilder schemaBuilder = SchemaBuilder.struct()
-        .field("int", Schema.OPTIONAL_INT32_SCHEMA);
+    final KsqlSchema schema = KsqlSchema.of(SchemaBuilder.struct()
+        .field("int", Schema.OPTIONAL_INT32_SCHEMA)
+        .build());
+
     final GenericRowValueTypeEnforcer genericRowValueTypeEnforcer =
-        new GenericRowValueTypeEnforcer(KsqlSchema.of(schemaBuilder.build()));
+        new GenericRowValueTypeEnforcer(schema);
 
     try {
       genericRowValueTypeEnforcer.enforceFieldType(0, new StringBuilder("Not A number"));
@@ -136,10 +152,12 @@ public class GenericRowValueTypeEnforcerTest {
 
   @Test
   public void testEnforceIntegerThrowsNumberFormatExceptionOnInvalidString() {
-    final SchemaBuilder schemaBuilder = SchemaBuilder.struct()
-        .field("int", Schema.OPTIONAL_INT32_SCHEMA);
+    final KsqlSchema schema = KsqlSchema.of(SchemaBuilder.struct()
+        .field("int", Schema.OPTIONAL_INT32_SCHEMA)
+        .build());
+
     final GenericRowValueTypeEnforcer genericRowValueTypeEnforcer =
-        new GenericRowValueTypeEnforcer(KsqlSchema.of(schemaBuilder.build()));
+        new GenericRowValueTypeEnforcer(schema);
 
     try {
       genericRowValueTypeEnforcer.enforceFieldType(0, "Wzhq'Rrv?s=O");
@@ -151,70 +169,84 @@ public class GenericRowValueTypeEnforcerTest {
 
   @Test
   public void testEnforceIntegerOnValidCharSequence() {
-    final SchemaBuilder schemaBuilder = SchemaBuilder.struct()
-        .field("int", Schema.OPTIONAL_INT32_SCHEMA);
+    final KsqlSchema schema = KsqlSchema.of(SchemaBuilder.struct()
+        .field("int", Schema.OPTIONAL_INT32_SCHEMA)
+        .build());
+
     final GenericRowValueTypeEnforcer genericRowValueTypeEnforcer =
-        new GenericRowValueTypeEnforcer(KsqlSchema.of(schemaBuilder.build()));
+        new GenericRowValueTypeEnforcer(schema);
 
     assertEquals(55, genericRowValueTypeEnforcer.enforceFieldType(0, new StringBuilder("55")));
   }
 
   @Test
   public void testEnforceIntegerOnValidString() {
-    final SchemaBuilder schemaBuilder = SchemaBuilder.struct()
-        .field("int", Schema.OPTIONAL_INT32_SCHEMA);
+    final KsqlSchema schema = KsqlSchema.of(SchemaBuilder.struct()
+        .field("int", Schema.OPTIONAL_INT32_SCHEMA)
+        .build());
+
     final GenericRowValueTypeEnforcer genericRowValueTypeEnforcer =
-        new GenericRowValueTypeEnforcer(KsqlSchema.of(schemaBuilder.build()));
+        new GenericRowValueTypeEnforcer(schema);
 
     assertEquals(-55, genericRowValueTypeEnforcer.enforceFieldType(0, "-55"));
   }
 
   @Test
   public void testEnforceIntegerAndEnforceIntegerOne() {
-    final SchemaBuilder schemaBuilder = SchemaBuilder.struct()
-        .field("int", Schema.OPTIONAL_INT32_SCHEMA);
+    final KsqlSchema schema = KsqlSchema.of(SchemaBuilder.struct()
+        .field("int", Schema.OPTIONAL_INT32_SCHEMA)
+        .build());
+
     final GenericRowValueTypeEnforcer genericRowValueTypeEnforcer =
-        new GenericRowValueTypeEnforcer(KsqlSchema.of(schemaBuilder.build()));
+        new GenericRowValueTypeEnforcer(schema);
 
     assertEquals(55, genericRowValueTypeEnforcer.enforceFieldType(0, 55));
   }
 
   @Test
   public void testEnforceIntegerAndEnforceIntegerThree() {
-    final SchemaBuilder schemaBuilder = SchemaBuilder.struct()
-        .field("int", Schema.OPTIONAL_INT32_SCHEMA);
+    final KsqlSchema schema = KsqlSchema.of(SchemaBuilder.struct()
+        .field("int", Schema.OPTIONAL_INT32_SCHEMA)
+        .build());
+
     final GenericRowValueTypeEnforcer genericRowValueTypeEnforcer =
-        new GenericRowValueTypeEnforcer(KsqlSchema.of(schemaBuilder.build()));
+        new GenericRowValueTypeEnforcer(schema);
 
     assertEquals(361, genericRowValueTypeEnforcer.enforceFieldType(0, 361L));
   }
 
   @Test
   public void testEnforceIntegerAndEnforceIntegerFour() {
-    final SchemaBuilder schemaBuilder = SchemaBuilder.struct()
-        .field("int", Schema.OPTIONAL_INT32_SCHEMA);
+    final KsqlSchema schema = KsqlSchema.of(SchemaBuilder.struct()
+        .field("int", Schema.OPTIONAL_INT32_SCHEMA)
+        .build());
+
     final GenericRowValueTypeEnforcer genericRowValueTypeEnforcer =
-        new GenericRowValueTypeEnforcer(KsqlSchema.of(schemaBuilder.build()));
+        new GenericRowValueTypeEnforcer(schema);
 
     assertEquals(1, genericRowValueTypeEnforcer.enforceFieldType(0, 1));
   }
 
   @Test
   public void testEnforceIntegerReturningNull() {
-    final SchemaBuilder schemaBuilder = SchemaBuilder.struct()
-        .field("int", Schema.OPTIONAL_INT32_SCHEMA);
+    final KsqlSchema schema = KsqlSchema.of(SchemaBuilder.struct()
+        .field("int", Schema.OPTIONAL_INT32_SCHEMA)
+        .build());
+
     final GenericRowValueTypeEnforcer genericRowValueTypeEnforcer =
-        new GenericRowValueTypeEnforcer(KsqlSchema.of(schemaBuilder.build()));
+        new GenericRowValueTypeEnforcer(schema);
 
     assertNull(genericRowValueTypeEnforcer.enforceFieldType(0, null));
   }
 
   @Test
   public void testEnforceLong() {
-    final SchemaBuilder schemaBuilder = SchemaBuilder.struct()
-        .field("long", Schema.OPTIONAL_INT64_SCHEMA);
+    final KsqlSchema schema = KsqlSchema.of(SchemaBuilder.struct()
+        .field("long", Schema.OPTIONAL_INT64_SCHEMA)
+        .build());
+
     final GenericRowValueTypeEnforcer genericRowValueTypeEnforcer =
-        new GenericRowValueTypeEnforcer(KsqlSchema.of(schemaBuilder.build()));
+        new GenericRowValueTypeEnforcer(schema);
 
     try {
       genericRowValueTypeEnforcer.enforceFieldType(0, Boolean.FALSE);
@@ -227,10 +259,12 @@ public class GenericRowValueTypeEnforcerTest {
 
   @Test
   public void testEnforceLongThrowsNumberFormatExceptionOnInvalidCharSequence() {
-    final SchemaBuilder schemaBuilder = SchemaBuilder.struct()
-        .field("long", Schema.OPTIONAL_INT64_SCHEMA);
+    final KsqlSchema schema = KsqlSchema.of(SchemaBuilder.struct()
+        .field("long", Schema.OPTIONAL_INT64_SCHEMA)
+        .build());
+
     final GenericRowValueTypeEnforcer genericRowValueTypeEnforcer =
-        new GenericRowValueTypeEnforcer(KsqlSchema.of(schemaBuilder.build()));
+        new GenericRowValueTypeEnforcer(schema);
 
     try {
       genericRowValueTypeEnforcer.enforceFieldType(0, new StringBuilder("Not a Long"));
@@ -242,10 +276,12 @@ public class GenericRowValueTypeEnforcerTest {
 
   @Test
   public void testEnforceLongThrowsNumberFormatExceptionOnInvalidString() {
-    final SchemaBuilder schemaBuilder = SchemaBuilder.struct()
-        .field("long", Schema.OPTIONAL_INT64_SCHEMA);
+    final KsqlSchema schema = KsqlSchema.of(SchemaBuilder.struct()
+        .field("long", Schema.OPTIONAL_INT64_SCHEMA)
+        .build());
+
     final GenericRowValueTypeEnforcer genericRowValueTypeEnforcer =
-        new GenericRowValueTypeEnforcer(KsqlSchema.of(schemaBuilder.build()));
+        new GenericRowValueTypeEnforcer(schema);
 
     try {
       genericRowValueTypeEnforcer.enforceFieldType(0, "-drbetk");
@@ -257,70 +293,84 @@ public class GenericRowValueTypeEnforcerTest {
 
   @Test
   public void testEnforceLongOnValidCharSequence() {
-    final SchemaBuilder schemaBuilder = SchemaBuilder.struct()
-        .field("long", Schema.OPTIONAL_INT64_SCHEMA);
+    final KsqlSchema schema = KsqlSchema.of(SchemaBuilder.struct()
+        .field("long", Schema.OPTIONAL_INT64_SCHEMA)
+        .build());
+
     final GenericRowValueTypeEnforcer genericRowValueTypeEnforcer =
-        new GenericRowValueTypeEnforcer(KsqlSchema.of(schemaBuilder.build()));
+        new GenericRowValueTypeEnforcer(schema);
 
     assertEquals(123L, genericRowValueTypeEnforcer.enforceFieldType(0, new StringBuilder("123")));
   }
 
   @Test
   public void testEnforceLongOnValidString() {
-    final SchemaBuilder schemaBuilder = SchemaBuilder.struct()
-        .field("long", Schema.OPTIONAL_INT64_SCHEMA);
+    final KsqlSchema schema = KsqlSchema.of(SchemaBuilder.struct()
+        .field("long", Schema.OPTIONAL_INT64_SCHEMA)
+        .build());
+
     final GenericRowValueTypeEnforcer genericRowValueTypeEnforcer =
-        new GenericRowValueTypeEnforcer(KsqlSchema.of(schemaBuilder.build()));
+        new GenericRowValueTypeEnforcer(schema);
 
     assertEquals(-123L, genericRowValueTypeEnforcer.enforceFieldType(0, "-123"));
   }
 
   @Test
   public void testEnforceLongAndEnforceLongOne() {
-    final SchemaBuilder schemaBuilder = SchemaBuilder.struct()
-        .field("long", Schema.OPTIONAL_INT64_SCHEMA);
+    final KsqlSchema schema = KsqlSchema.of(SchemaBuilder.struct()
+        .field("long", Schema.OPTIONAL_INT64_SCHEMA)
+        .build());
+
     final GenericRowValueTypeEnforcer genericRowValueTypeEnforcer =
-        new GenericRowValueTypeEnforcer(KsqlSchema.of(schemaBuilder.build()));
+        new GenericRowValueTypeEnforcer(schema);
 
     assertEquals(0L, genericRowValueTypeEnforcer.enforceFieldType(0, 0));
   }
 
   @Test
   public void testEnforceLongReturningLongWhereByteValueIsNegative() {
-    final SchemaBuilder schemaBuilder = SchemaBuilder.struct()
-        .field("long", Schema.OPTIONAL_INT64_SCHEMA);
+    final KsqlSchema schema = KsqlSchema.of(SchemaBuilder.struct()
+        .field("long", Schema.OPTIONAL_INT64_SCHEMA)
+        .build());
+
     final GenericRowValueTypeEnforcer genericRowValueTypeEnforcer =
-        new GenericRowValueTypeEnforcer(KsqlSchema.of(schemaBuilder.build()));
+        new GenericRowValueTypeEnforcer(schema);
 
     assertEquals(-2315L, genericRowValueTypeEnforcer.enforceFieldType(0, -2315));
   }
 
   @Test
   public void testEnforceLongReturningLongWhereShortValueIsNegative() {
-    final SchemaBuilder schemaBuilder = SchemaBuilder.struct()
-        .field("long", Schema.OPTIONAL_INT64_SCHEMA);
+    final KsqlSchema schema = KsqlSchema.of(SchemaBuilder.struct()
+        .field("long", Schema.OPTIONAL_INT64_SCHEMA)
+        .build());
+
     final GenericRowValueTypeEnforcer genericRowValueTypeEnforcer =
-        new GenericRowValueTypeEnforcer(KsqlSchema.of(schemaBuilder.build()));
+        new GenericRowValueTypeEnforcer(schema);
 
     assertEquals(-446L, genericRowValueTypeEnforcer.enforceFieldType(0, -446.28F));
   }
 
   @Test
   public void testEnforceLongReturningNull() {
-    final SchemaBuilder schemaBuilder = SchemaBuilder.struct()
-        .field("long", Schema.OPTIONAL_INT64_SCHEMA);
+    final KsqlSchema schema = KsqlSchema.of(SchemaBuilder.struct()
+        .field("long", Schema.OPTIONAL_INT64_SCHEMA)
+        .build());
+
     final GenericRowValueTypeEnforcer genericRowValueTypeEnforcer =
-        new GenericRowValueTypeEnforcer(KsqlSchema.of(schemaBuilder.build()));
+        new GenericRowValueTypeEnforcer(schema);
 
     assertNull(genericRowValueTypeEnforcer.enforceFieldType(0, null));
   }
 
   @Test
   public void testEnforceDouble() {
-    final SchemaBuilder schemaBuilder = SchemaBuilder.struct()
-        .field("double", Schema.OPTIONAL_FLOAT64_SCHEMA);
+    final KsqlSchema schema = KsqlSchema.of(SchemaBuilder.struct()
+        .field("double", Schema.OPTIONAL_FLOAT64_SCHEMA)
+        .build());
+
     final GenericRowValueTypeEnforcer genericRowValueTypeEnforcer =
-        new GenericRowValueTypeEnforcer(KsqlSchema.of(schemaBuilder.build()));
+        new GenericRowValueTypeEnforcer(schema);
     final Object object = new Object();
 
     try {
@@ -334,100 +384,120 @@ public class GenericRowValueTypeEnforcerTest {
 
   @Test(expected = NumberFormatException.class)
   public void testEnforceDoubleThrowsNumberFormatExceptionOnInvalidCharSequence() {
-    final SchemaBuilder schemaBuilder = SchemaBuilder.struct()
-        .field("double", Schema.OPTIONAL_FLOAT64_SCHEMA);
+    final KsqlSchema schema = KsqlSchema.of(SchemaBuilder.struct()
+        .field("double", Schema.OPTIONAL_FLOAT64_SCHEMA)
+        .build());
+
     final GenericRowValueTypeEnforcer genericRowValueTypeEnforcer =
-        new GenericRowValueTypeEnforcer(KsqlSchema.of(schemaBuilder.build()));
+        new GenericRowValueTypeEnforcer(schema);
 
     genericRowValueTypeEnforcer.enforceFieldType(0, new StringBuilder("not a double"));
   }
 
   @Test(expected = NumberFormatException.class)
   public void testEnforceDoubleThrowsNumberFormatExceptionOnInvalidString() {
-    final SchemaBuilder schemaBuilder = SchemaBuilder.struct()
-        .field("double", Schema.OPTIONAL_FLOAT64_SCHEMA);
+    final KsqlSchema schema = KsqlSchema.of(SchemaBuilder.struct()
+        .field("double", Schema.OPTIONAL_FLOAT64_SCHEMA)
+        .build());
+
     final GenericRowValueTypeEnforcer genericRowValueTypeEnforcer =
-        new GenericRowValueTypeEnforcer(KsqlSchema.of(schemaBuilder.build()));
+        new GenericRowValueTypeEnforcer(schema);
 
     genericRowValueTypeEnforcer.enforceFieldType(0, "not a double");
   }
 
   @Test
   public void testEnforceDoubleOnValidCharSequence() {
-    final SchemaBuilder schemaBuilder = SchemaBuilder.struct()
-        .field("double", Schema.OPTIONAL_FLOAT64_SCHEMA);
+    final KsqlSchema schema = KsqlSchema.of(SchemaBuilder.struct()
+        .field("double", Schema.OPTIONAL_FLOAT64_SCHEMA)
+        .build());
+
     final GenericRowValueTypeEnforcer genericRowValueTypeEnforcer =
-        new GenericRowValueTypeEnforcer(KsqlSchema.of(schemaBuilder.build()));
+        new GenericRowValueTypeEnforcer(schema);
 
     assertEquals(1.0, genericRowValueTypeEnforcer.enforceFieldType(0, new StringBuilder("1.0")));
   }
 
   @Test
   public void testEnforceDoubleOnValidString() {
-    final SchemaBuilder schemaBuilder = SchemaBuilder.struct()
-        .field("double", Schema.OPTIONAL_FLOAT64_SCHEMA);
+    final KsqlSchema schema = KsqlSchema.of(SchemaBuilder.struct()
+        .field("double", Schema.OPTIONAL_FLOAT64_SCHEMA)
+        .build());
+
     final GenericRowValueTypeEnforcer genericRowValueTypeEnforcer =
-        new GenericRowValueTypeEnforcer(KsqlSchema.of(schemaBuilder.build()));
+        new GenericRowValueTypeEnforcer(schema);
 
     assertEquals(-1.0, genericRowValueTypeEnforcer.enforceFieldType(0, "-1.0"));
   }
 
   @Test
   public void testEnforceDoubleAndEnforceDoubleOne() {
-    final SchemaBuilder schemaBuilder = SchemaBuilder.struct()
-        .field("double", Schema.OPTIONAL_FLOAT64_SCHEMA);
+    final KsqlSchema schema = KsqlSchema.of(SchemaBuilder.struct()
+        .field("double", Schema.OPTIONAL_FLOAT64_SCHEMA)
+        .build());
+
     final GenericRowValueTypeEnforcer genericRowValueTypeEnforcer =
-        new GenericRowValueTypeEnforcer(KsqlSchema.of(schemaBuilder.build()));
+        new GenericRowValueTypeEnforcer(schema);
 
     assertEquals(0.0, genericRowValueTypeEnforcer.enforceFieldType(0, 0));
   }
 
   @Test
   public void testEnforceDoubleReturningDoubleWhereByteValueIsNegative() {
-    final SchemaBuilder schemaBuilder = SchemaBuilder.struct()
-        .field("double", Schema.OPTIONAL_FLOAT64_SCHEMA);
+    final KsqlSchema schema = KsqlSchema.of(SchemaBuilder.struct()
+        .field("double", Schema.OPTIONAL_FLOAT64_SCHEMA)
+        .build());
+
     final GenericRowValueTypeEnforcer genericRowValueTypeEnforcer =
-        new GenericRowValueTypeEnforcer(KsqlSchema.of(schemaBuilder.build()));
+        new GenericRowValueTypeEnforcer(schema);
 
     assertEquals((-1.0), genericRowValueTypeEnforcer.enforceFieldType(0, -1));
   }
 
   @Test
   public void testEnforceDoubleAndEnforceDoubleTwo() {
-    final SchemaBuilder schemaBuilder = SchemaBuilder.struct()
-        .field("double", Schema.OPTIONAL_FLOAT64_SCHEMA);
+    final KsqlSchema schema = KsqlSchema.of(SchemaBuilder.struct()
+        .field("double", Schema.OPTIONAL_FLOAT64_SCHEMA)
+        .build());
+
     final GenericRowValueTypeEnforcer genericRowValueTypeEnforcer =
-        new GenericRowValueTypeEnforcer(KsqlSchema.of(schemaBuilder.build()));
+        new GenericRowValueTypeEnforcer(schema);
 
     assertEquals(0.0, genericRowValueTypeEnforcer.enforceFieldType(0, 0.0F));
   }
 
   @Test
   public void testEnforceDoubleReturningDoubleWhereShortValueIsPositive() {
-    final SchemaBuilder schemaBuilder = SchemaBuilder.struct()
-        .field("double", Schema.OPTIONAL_FLOAT64_SCHEMA);
+    final KsqlSchema schema = KsqlSchema.of(SchemaBuilder.struct()
+        .field("double", Schema.OPTIONAL_FLOAT64_SCHEMA)
+        .build());
+
     final GenericRowValueTypeEnforcer genericRowValueTypeEnforcer =
-        new GenericRowValueTypeEnforcer(KsqlSchema.of(schemaBuilder.build()));
+        new GenericRowValueTypeEnforcer(schema);
 
     assertEquals(366.0, genericRowValueTypeEnforcer.enforceFieldType(0, 366L));
   }
 
   @Test
   public void testEnforceDoubleReturningDoubleWhereShortValueIsNegative() {
-    final SchemaBuilder schemaBuilder = SchemaBuilder.struct()
-        .field("double", Schema.OPTIONAL_FLOAT64_SCHEMA);
+    final KsqlSchema schema = KsqlSchema.of(SchemaBuilder.struct()
+        .field("double", Schema.OPTIONAL_FLOAT64_SCHEMA)
+        .build());
+
     final GenericRowValueTypeEnforcer genericRowValueTypeEnforcer =
-        new GenericRowValueTypeEnforcer(KsqlSchema.of(schemaBuilder.build()));
+        new GenericRowValueTypeEnforcer(schema);
 
     assertEquals(-433.0, genericRowValueTypeEnforcer.enforceFieldType(0, -433));
   }
 
   @Test
   public void testEnforceDoubleReturningNull() {
-    final SchemaBuilder schemaBuilder = SchemaBuilder.struct()
-        .field("double", Schema.OPTIONAL_FLOAT64_SCHEMA);
+    final KsqlSchema schema = KsqlSchema.of(SchemaBuilder.struct()
+        .field("double", Schema.OPTIONAL_FLOAT64_SCHEMA)
+        .build());
+
     final GenericRowValueTypeEnforcer genericRowValueTypeEnforcer =
-        new GenericRowValueTypeEnforcer(KsqlSchema.of(schemaBuilder.build()));
+        new GenericRowValueTypeEnforcer(schema);
 
     assertNull(genericRowValueTypeEnforcer.enforceFieldType(0, null));
   }

--- a/ksql-engine/src/test/java/io/confluent/ksql/util/GenericRowValueTypeEnforcerTest.java
+++ b/ksql-engine/src/test/java/io/confluent/ksql/util/GenericRowValueTypeEnforcerTest.java
@@ -19,6 +19,8 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.fail;
 
+import io.confluent.ksql.schema.ksql.KsqlSchema;
+import org.apache.kafka.connect.data.Schema;
 import org.apache.kafka.connect.data.SchemaBuilder;
 import org.junit.Test;
 
@@ -31,9 +33,10 @@ public class GenericRowValueTypeEnforcerTest {
 
   @Test
   public void testEnforceBoolean() {
-    final SchemaBuilder schemaBuilder = SchemaBuilder.struct().field("boolean", SchemaBuilder.bool());
+    final SchemaBuilder schemaBuilder = SchemaBuilder.struct()
+        .field("boolean", Schema.OPTIONAL_BOOLEAN_SCHEMA);
     final GenericRowValueTypeEnforcer genericRowValueTypeEnforcer =
-        new GenericRowValueTypeEnforcer(schemaBuilder);
+        new GenericRowValueTypeEnforcer(KsqlSchema.of(schemaBuilder.build()));
 
     try {
       genericRowValueTypeEnforcer.enforceFieldType(0, schemaBuilder);
@@ -46,36 +49,40 @@ public class GenericRowValueTypeEnforcerTest {
 
   @Test
   public void testEnforceBooleanReturningBooleanWhereBooleanValueIsFalse() {
-    final SchemaBuilder schemaBuilder = SchemaBuilder.struct().field("boolean", SchemaBuilder.bool());
+    final SchemaBuilder schemaBuilder = SchemaBuilder.struct()
+        .field("boolean", Schema.OPTIONAL_BOOLEAN_SCHEMA);
     final GenericRowValueTypeEnforcer genericRowValueTypeEnforcer =
-        new GenericRowValueTypeEnforcer(schemaBuilder);
+        new GenericRowValueTypeEnforcer(KsqlSchema.of(schemaBuilder.build()));
 
     assertEquals(Boolean.FALSE, genericRowValueTypeEnforcer.enforceFieldType(0, "0x"));
   }
 
   @Test
   public void testEnforceBooleanReturningBooleanWhereBooleanValueIsTrue() {
-    final SchemaBuilder schemaBuilder = SchemaBuilder.struct().field("boolean", SchemaBuilder.bool());
+    final SchemaBuilder schemaBuilder = SchemaBuilder.struct()
+        .field("boolean", Schema.OPTIONAL_BOOLEAN_SCHEMA);
     final GenericRowValueTypeEnforcer genericRowValueTypeEnforcer =
-        new GenericRowValueTypeEnforcer(schemaBuilder);
+        new GenericRowValueTypeEnforcer(KsqlSchema.of(schemaBuilder.build()));
 
     assertEquals(Boolean.TRUE, genericRowValueTypeEnforcer.enforceFieldType(0, true));
   }
 
   @Test
   public void testEnforceBooleanReturningNull() {
-    final SchemaBuilder schemaBuilder = SchemaBuilder.struct().field("boolean", SchemaBuilder.bool());
+    final SchemaBuilder schemaBuilder = SchemaBuilder.struct()
+        .field("boolean", Schema.OPTIONAL_BOOLEAN_SCHEMA);
     final GenericRowValueTypeEnforcer genericRowValueTypeEnforcer =
-        new GenericRowValueTypeEnforcer(schemaBuilder);
+        new GenericRowValueTypeEnforcer(KsqlSchema.of(schemaBuilder.build()));
 
     assertNull(genericRowValueTypeEnforcer.enforceFieldType(0, null));
   }
 
   @Test
   public void testEnforceString() {
-    final SchemaBuilder schemaBuilder = SchemaBuilder.struct().field("string", SchemaBuilder.string());
+    final SchemaBuilder schemaBuilder = SchemaBuilder.struct()
+        .field("string", Schema.OPTIONAL_STRING_SCHEMA);
     final GenericRowValueTypeEnforcer genericRowValueTypeEnforcer =
-        new GenericRowValueTypeEnforcer(schemaBuilder);
+        new GenericRowValueTypeEnforcer(KsqlSchema.of(schemaBuilder.build()));
 
     try {
       genericRowValueTypeEnforcer.enforceFieldType(0, 0.0);
@@ -88,18 +95,20 @@ public class GenericRowValueTypeEnforcerTest {
 
   @Test
   public void testEnforceStringReturningNull() {
-    final SchemaBuilder schemaBuilder = SchemaBuilder.struct().field("string", SchemaBuilder.string());
+    final SchemaBuilder schemaBuilder = SchemaBuilder.struct()
+        .field("string", Schema.OPTIONAL_STRING_SCHEMA);
     final GenericRowValueTypeEnforcer genericRowValueTypeEnforcer =
-        new GenericRowValueTypeEnforcer(schemaBuilder);
+        new GenericRowValueTypeEnforcer(KsqlSchema.of(schemaBuilder.build()));
 
     assertNull(genericRowValueTypeEnforcer.enforceFieldType(0, null));
   }
 
   @Test
   public void testEnforceInteger() {
-    final SchemaBuilder schemaBuilder = SchemaBuilder.struct().field("int", SchemaBuilder.int32());
+    final SchemaBuilder schemaBuilder = SchemaBuilder.struct()
+        .field("int", Schema.OPTIONAL_INT32_SCHEMA);
     final GenericRowValueTypeEnforcer genericRowValueTypeEnforcer =
-        new GenericRowValueTypeEnforcer(schemaBuilder);
+        new GenericRowValueTypeEnforcer(KsqlSchema.of(schemaBuilder.build()));
 
     try {
       genericRowValueTypeEnforcer.enforceFieldType(0, schemaBuilder);
@@ -112,9 +121,10 @@ public class GenericRowValueTypeEnforcerTest {
 
   @Test
   public void testEnforceIntegerThrowsNumberFormatExceptionOnInvalidCharSequence() {
-    final SchemaBuilder schemaBuilder = SchemaBuilder.struct().field("int", SchemaBuilder.int32());
+    final SchemaBuilder schemaBuilder = SchemaBuilder.struct()
+        .field("int", Schema.OPTIONAL_INT32_SCHEMA);
     final GenericRowValueTypeEnforcer genericRowValueTypeEnforcer =
-        new GenericRowValueTypeEnforcer(schemaBuilder);
+        new GenericRowValueTypeEnforcer(KsqlSchema.of(schemaBuilder.build()));
 
     try {
       genericRowValueTypeEnforcer.enforceFieldType(0, new StringBuilder("Not A number"));
@@ -126,9 +136,10 @@ public class GenericRowValueTypeEnforcerTest {
 
   @Test
   public void testEnforceIntegerThrowsNumberFormatExceptionOnInvalidString() {
-    final SchemaBuilder schemaBuilder = SchemaBuilder.struct().field("int", SchemaBuilder.int32());
+    final SchemaBuilder schemaBuilder = SchemaBuilder.struct()
+        .field("int", Schema.OPTIONAL_INT32_SCHEMA);
     final GenericRowValueTypeEnforcer genericRowValueTypeEnforcer =
-        new GenericRowValueTypeEnforcer(schemaBuilder);
+        new GenericRowValueTypeEnforcer(KsqlSchema.of(schemaBuilder.build()));
 
     try {
       genericRowValueTypeEnforcer.enforceFieldType(0, "Wzhq'Rrv?s=O");
@@ -140,63 +151,70 @@ public class GenericRowValueTypeEnforcerTest {
 
   @Test
   public void testEnforceIntegerOnValidCharSequence() {
-    final SchemaBuilder schemaBuilder = SchemaBuilder.struct().field("int", SchemaBuilder.int32());
+    final SchemaBuilder schemaBuilder = SchemaBuilder.struct()
+        .field("int", Schema.OPTIONAL_INT32_SCHEMA);
     final GenericRowValueTypeEnforcer genericRowValueTypeEnforcer =
-        new GenericRowValueTypeEnforcer(schemaBuilder);
+        new GenericRowValueTypeEnforcer(KsqlSchema.of(schemaBuilder.build()));
 
     assertEquals(55, genericRowValueTypeEnforcer.enforceFieldType(0, new StringBuilder("55")));
   }
 
   @Test
   public void testEnforceIntegerOnValidString() {
-    final SchemaBuilder schemaBuilder = SchemaBuilder.struct().field("int", SchemaBuilder.int32());
+    final SchemaBuilder schemaBuilder = SchemaBuilder.struct()
+        .field("int", Schema.OPTIONAL_INT32_SCHEMA);
     final GenericRowValueTypeEnforcer genericRowValueTypeEnforcer =
-        new GenericRowValueTypeEnforcer(schemaBuilder);
+        new GenericRowValueTypeEnforcer(KsqlSchema.of(schemaBuilder.build()));
 
     assertEquals(-55, genericRowValueTypeEnforcer.enforceFieldType(0, "-55"));
   }
 
   @Test
   public void testEnforceIntegerAndEnforceIntegerOne() {
-    final SchemaBuilder schemaBuilder = SchemaBuilder.struct().field("int", SchemaBuilder.int32());
+    final SchemaBuilder schemaBuilder = SchemaBuilder.struct()
+        .field("int", Schema.OPTIONAL_INT32_SCHEMA);
     final GenericRowValueTypeEnforcer genericRowValueTypeEnforcer =
-        new GenericRowValueTypeEnforcer(schemaBuilder);
+        new GenericRowValueTypeEnforcer(KsqlSchema.of(schemaBuilder.build()));
 
     assertEquals(55, genericRowValueTypeEnforcer.enforceFieldType(0, 55));
   }
 
   @Test
   public void testEnforceIntegerAndEnforceIntegerThree() {
-    final SchemaBuilder schemaBuilder = SchemaBuilder.struct().field("int", SchemaBuilder.int32());
+    final SchemaBuilder schemaBuilder = SchemaBuilder.struct()
+        .field("int", Schema.OPTIONAL_INT32_SCHEMA);
     final GenericRowValueTypeEnforcer genericRowValueTypeEnforcer =
-        new GenericRowValueTypeEnforcer(schemaBuilder);
+        new GenericRowValueTypeEnforcer(KsqlSchema.of(schemaBuilder.build()));
 
     assertEquals(361, genericRowValueTypeEnforcer.enforceFieldType(0, 361L));
   }
 
   @Test
   public void testEnforceIntegerAndEnforceIntegerFour() {
-    final SchemaBuilder schemaBuilder = SchemaBuilder.struct().field("int", SchemaBuilder.int32());
+    final SchemaBuilder schemaBuilder = SchemaBuilder.struct()
+        .field("int", Schema.OPTIONAL_INT32_SCHEMA);
     final GenericRowValueTypeEnforcer genericRowValueTypeEnforcer =
-        new GenericRowValueTypeEnforcer(schemaBuilder);
+        new GenericRowValueTypeEnforcer(KsqlSchema.of(schemaBuilder.build()));
 
     assertEquals(1, genericRowValueTypeEnforcer.enforceFieldType(0, 1));
   }
 
   @Test
   public void testEnforceIntegerReturningNull() {
-    final SchemaBuilder schemaBuilder = SchemaBuilder.struct().field("int", SchemaBuilder.int32());
+    final SchemaBuilder schemaBuilder = SchemaBuilder.struct()
+        .field("int", Schema.OPTIONAL_INT32_SCHEMA);
     final GenericRowValueTypeEnforcer genericRowValueTypeEnforcer =
-        new GenericRowValueTypeEnforcer(schemaBuilder);
+        new GenericRowValueTypeEnforcer(KsqlSchema.of(schemaBuilder.build()));
 
     assertNull(genericRowValueTypeEnforcer.enforceFieldType(0, null));
   }
 
   @Test
   public void testEnforceLong() {
-    final SchemaBuilder schemaBuilder = SchemaBuilder.struct().field("long", SchemaBuilder.int64());
+    final SchemaBuilder schemaBuilder = SchemaBuilder.struct()
+        .field("long", Schema.OPTIONAL_INT64_SCHEMA);
     final GenericRowValueTypeEnforcer genericRowValueTypeEnforcer =
-        new GenericRowValueTypeEnforcer(schemaBuilder);
+        new GenericRowValueTypeEnforcer(KsqlSchema.of(schemaBuilder.build()));
 
     try {
       genericRowValueTypeEnforcer.enforceFieldType(0, Boolean.FALSE);
@@ -209,9 +227,10 @@ public class GenericRowValueTypeEnforcerTest {
 
   @Test
   public void testEnforceLongThrowsNumberFormatExceptionOnInvalidCharSequence() {
-    final SchemaBuilder schemaBuilder = SchemaBuilder.struct().field("long", SchemaBuilder.int64());
+    final SchemaBuilder schemaBuilder = SchemaBuilder.struct()
+        .field("long", Schema.OPTIONAL_INT64_SCHEMA);
     final GenericRowValueTypeEnforcer genericRowValueTypeEnforcer =
-        new GenericRowValueTypeEnforcer(schemaBuilder);
+        new GenericRowValueTypeEnforcer(KsqlSchema.of(schemaBuilder.build()));
 
     try {
       genericRowValueTypeEnforcer.enforceFieldType(0, new StringBuilder("Not a Long"));
@@ -223,9 +242,10 @@ public class GenericRowValueTypeEnforcerTest {
 
   @Test
   public void testEnforceLongThrowsNumberFormatExceptionOnInvalidString() {
-    final SchemaBuilder schemaBuilder = SchemaBuilder.struct().field("long", SchemaBuilder.int64());
+    final SchemaBuilder schemaBuilder = SchemaBuilder.struct()
+        .field("long", Schema.OPTIONAL_INT64_SCHEMA);
     final GenericRowValueTypeEnforcer genericRowValueTypeEnforcer =
-        new GenericRowValueTypeEnforcer(schemaBuilder);
+        new GenericRowValueTypeEnforcer(KsqlSchema.of(schemaBuilder.build()));
 
     try {
       genericRowValueTypeEnforcer.enforceFieldType(0, "-drbetk");
@@ -237,63 +257,70 @@ public class GenericRowValueTypeEnforcerTest {
 
   @Test
   public void testEnforceLongOnValidCharSequence() {
-    final SchemaBuilder schemaBuilder = SchemaBuilder.struct().field("long", SchemaBuilder.int64());
+    final SchemaBuilder schemaBuilder = SchemaBuilder.struct()
+        .field("long", Schema.OPTIONAL_INT64_SCHEMA);
     final GenericRowValueTypeEnforcer genericRowValueTypeEnforcer =
-        new GenericRowValueTypeEnforcer(schemaBuilder);
+        new GenericRowValueTypeEnforcer(KsqlSchema.of(schemaBuilder.build()));
 
     assertEquals(123L, genericRowValueTypeEnforcer.enforceFieldType(0, new StringBuilder("123")));
   }
 
   @Test
   public void testEnforceLongOnValidString() {
-    final SchemaBuilder schemaBuilder = SchemaBuilder.struct().field("long", SchemaBuilder.int64());
+    final SchemaBuilder schemaBuilder = SchemaBuilder.struct()
+        .field("long", Schema.OPTIONAL_INT64_SCHEMA);
     final GenericRowValueTypeEnforcer genericRowValueTypeEnforcer =
-        new GenericRowValueTypeEnforcer(schemaBuilder);
+        new GenericRowValueTypeEnforcer(KsqlSchema.of(schemaBuilder.build()));
 
     assertEquals(-123L, genericRowValueTypeEnforcer.enforceFieldType(0, "-123"));
   }
 
   @Test
   public void testEnforceLongAndEnforceLongOne() {
-    final SchemaBuilder schemaBuilder = SchemaBuilder.struct().field("long", SchemaBuilder.int64());
+    final SchemaBuilder schemaBuilder = SchemaBuilder.struct()
+        .field("long", Schema.OPTIONAL_INT64_SCHEMA);
     final GenericRowValueTypeEnforcer genericRowValueTypeEnforcer =
-        new GenericRowValueTypeEnforcer(schemaBuilder);
+        new GenericRowValueTypeEnforcer(KsqlSchema.of(schemaBuilder.build()));
 
     assertEquals(0L, genericRowValueTypeEnforcer.enforceFieldType(0, 0));
   }
 
   @Test
   public void testEnforceLongReturningLongWhereByteValueIsNegative() {
-    final SchemaBuilder schemaBuilder = SchemaBuilder.struct().field("long", SchemaBuilder.int64());
+    final SchemaBuilder schemaBuilder = SchemaBuilder.struct()
+        .field("long", Schema.OPTIONAL_INT64_SCHEMA);
     final GenericRowValueTypeEnforcer genericRowValueTypeEnforcer =
-        new GenericRowValueTypeEnforcer(schemaBuilder);
+        new GenericRowValueTypeEnforcer(KsqlSchema.of(schemaBuilder.build()));
 
     assertEquals(-2315L, genericRowValueTypeEnforcer.enforceFieldType(0, -2315));
   }
 
   @Test
   public void testEnforceLongReturningLongWhereShortValueIsNegative() {
-    final SchemaBuilder schemaBuilder = SchemaBuilder.struct().field("long", SchemaBuilder.int64());
+    final SchemaBuilder schemaBuilder = SchemaBuilder.struct()
+        .field("long", Schema.OPTIONAL_INT64_SCHEMA);
     final GenericRowValueTypeEnforcer genericRowValueTypeEnforcer =
-        new GenericRowValueTypeEnforcer(schemaBuilder);
+        new GenericRowValueTypeEnforcer(KsqlSchema.of(schemaBuilder.build()));
 
     assertEquals(-446L, genericRowValueTypeEnforcer.enforceFieldType(0, -446.28F));
   }
 
   @Test
   public void testEnforceLongReturningNull() {
-    final SchemaBuilder schemaBuilder = SchemaBuilder.struct().field("long", SchemaBuilder.int64());
+    final SchemaBuilder schemaBuilder = SchemaBuilder.struct()
+        .field("long", Schema.OPTIONAL_INT64_SCHEMA);
     final GenericRowValueTypeEnforcer genericRowValueTypeEnforcer =
-        new GenericRowValueTypeEnforcer(schemaBuilder);
+        new GenericRowValueTypeEnforcer(KsqlSchema.of(schemaBuilder.build()));
 
     assertNull(genericRowValueTypeEnforcer.enforceFieldType(0, null));
   }
 
   @Test
   public void testEnforceDouble() {
-    final SchemaBuilder schemaBuilder = SchemaBuilder.struct().field("double", SchemaBuilder.float64());
+    final SchemaBuilder schemaBuilder = SchemaBuilder.struct()
+        .field("double", Schema.OPTIONAL_FLOAT64_SCHEMA);
     final GenericRowValueTypeEnforcer genericRowValueTypeEnforcer =
-        new GenericRowValueTypeEnforcer(schemaBuilder);
+        new GenericRowValueTypeEnforcer(KsqlSchema.of(schemaBuilder.build()));
     final Object object = new Object();
 
     try {
@@ -307,90 +334,100 @@ public class GenericRowValueTypeEnforcerTest {
 
   @Test(expected = NumberFormatException.class)
   public void testEnforceDoubleThrowsNumberFormatExceptionOnInvalidCharSequence() {
-    final SchemaBuilder schemaBuilder = SchemaBuilder.struct().field("double", SchemaBuilder.float64());
+    final SchemaBuilder schemaBuilder = SchemaBuilder.struct()
+        .field("double", Schema.OPTIONAL_FLOAT64_SCHEMA);
     final GenericRowValueTypeEnforcer genericRowValueTypeEnforcer =
-        new GenericRowValueTypeEnforcer(schemaBuilder);
+        new GenericRowValueTypeEnforcer(KsqlSchema.of(schemaBuilder.build()));
 
     genericRowValueTypeEnforcer.enforceFieldType(0, new StringBuilder("not a double"));
   }
 
   @Test(expected = NumberFormatException.class)
   public void testEnforceDoubleThrowsNumberFormatExceptionOnInvalidString() {
-    final SchemaBuilder schemaBuilder = SchemaBuilder.struct().field("double", SchemaBuilder.float64());
+    final SchemaBuilder schemaBuilder = SchemaBuilder.struct()
+        .field("double", Schema.OPTIONAL_FLOAT64_SCHEMA);
     final GenericRowValueTypeEnforcer genericRowValueTypeEnforcer =
-        new GenericRowValueTypeEnforcer(schemaBuilder);
+        new GenericRowValueTypeEnforcer(KsqlSchema.of(schemaBuilder.build()));
 
     genericRowValueTypeEnforcer.enforceFieldType(0, "not a double");
   }
 
   @Test
   public void testEnforceDoubleOnValidCharSequence() {
-    final SchemaBuilder schemaBuilder = SchemaBuilder.struct().field("double", SchemaBuilder.float64());
+    final SchemaBuilder schemaBuilder = SchemaBuilder.struct()
+        .field("double", Schema.OPTIONAL_FLOAT64_SCHEMA);
     final GenericRowValueTypeEnforcer genericRowValueTypeEnforcer =
-        new GenericRowValueTypeEnforcer(schemaBuilder);
+        new GenericRowValueTypeEnforcer(KsqlSchema.of(schemaBuilder.build()));
 
     assertEquals(1.0, genericRowValueTypeEnforcer.enforceFieldType(0, new StringBuilder("1.0")));
   }
 
   @Test
   public void testEnforceDoubleOnValidString() {
-    final SchemaBuilder schemaBuilder = SchemaBuilder.struct().field("double", SchemaBuilder.float64());
+    final SchemaBuilder schemaBuilder = SchemaBuilder.struct()
+        .field("double", Schema.OPTIONAL_FLOAT64_SCHEMA);
     final GenericRowValueTypeEnforcer genericRowValueTypeEnforcer =
-        new GenericRowValueTypeEnforcer(schemaBuilder);
+        new GenericRowValueTypeEnforcer(KsqlSchema.of(schemaBuilder.build()));
 
     assertEquals(-1.0, genericRowValueTypeEnforcer.enforceFieldType(0, "-1.0"));
   }
 
   @Test
   public void testEnforceDoubleAndEnforceDoubleOne() {
-    final SchemaBuilder schemaBuilder = SchemaBuilder.struct().field("double", SchemaBuilder.float64());
+    final SchemaBuilder schemaBuilder = SchemaBuilder.struct()
+        .field("double", Schema.OPTIONAL_FLOAT64_SCHEMA);
     final GenericRowValueTypeEnforcer genericRowValueTypeEnforcer =
-        new GenericRowValueTypeEnforcer(schemaBuilder);
+        new GenericRowValueTypeEnforcer(KsqlSchema.of(schemaBuilder.build()));
 
     assertEquals(0.0, genericRowValueTypeEnforcer.enforceFieldType(0, 0));
   }
 
   @Test
   public void testEnforceDoubleReturningDoubleWhereByteValueIsNegative() {
-    final SchemaBuilder schemaBuilder = SchemaBuilder.struct().field("double", SchemaBuilder.float64());
+    final SchemaBuilder schemaBuilder = SchemaBuilder.struct()
+        .field("double", Schema.OPTIONAL_FLOAT64_SCHEMA);
     final GenericRowValueTypeEnforcer genericRowValueTypeEnforcer =
-        new GenericRowValueTypeEnforcer(schemaBuilder);
+        new GenericRowValueTypeEnforcer(KsqlSchema.of(schemaBuilder.build()));
 
     assertEquals((-1.0), genericRowValueTypeEnforcer.enforceFieldType(0, -1));
   }
 
   @Test
   public void testEnforceDoubleAndEnforceDoubleTwo() {
-    final SchemaBuilder schemaBuilder = SchemaBuilder.struct().field("double", SchemaBuilder.float64());
+    final SchemaBuilder schemaBuilder = SchemaBuilder.struct()
+        .field("double", Schema.OPTIONAL_FLOAT64_SCHEMA);
     final GenericRowValueTypeEnforcer genericRowValueTypeEnforcer =
-        new GenericRowValueTypeEnforcer(schemaBuilder);
+        new GenericRowValueTypeEnforcer(KsqlSchema.of(schemaBuilder.build()));
 
     assertEquals(0.0, genericRowValueTypeEnforcer.enforceFieldType(0, 0.0F));
   }
 
   @Test
   public void testEnforceDoubleReturningDoubleWhereShortValueIsPositive() {
-    final SchemaBuilder schemaBuilder = SchemaBuilder.struct().field("double", SchemaBuilder.float64());
+    final SchemaBuilder schemaBuilder = SchemaBuilder.struct()
+        .field("double", Schema.OPTIONAL_FLOAT64_SCHEMA);
     final GenericRowValueTypeEnforcer genericRowValueTypeEnforcer =
-        new GenericRowValueTypeEnforcer(schemaBuilder);
+        new GenericRowValueTypeEnforcer(KsqlSchema.of(schemaBuilder.build()));
 
     assertEquals(366.0, genericRowValueTypeEnforcer.enforceFieldType(0, 366L));
   }
 
   @Test
   public void testEnforceDoubleReturningDoubleWhereShortValueIsNegative() {
-    final SchemaBuilder schemaBuilder = SchemaBuilder.struct().field("double", SchemaBuilder.float64());
+    final SchemaBuilder schemaBuilder = SchemaBuilder.struct()
+        .field("double", Schema.OPTIONAL_FLOAT64_SCHEMA);
     final GenericRowValueTypeEnforcer genericRowValueTypeEnforcer =
-        new GenericRowValueTypeEnforcer(schemaBuilder);
+        new GenericRowValueTypeEnforcer(KsqlSchema.of(schemaBuilder.build()));
 
     assertEquals(-433.0, genericRowValueTypeEnforcer.enforceFieldType(0, -433));
   }
 
   @Test
   public void testEnforceDoubleReturningNull() {
-    final SchemaBuilder schemaBuilder = SchemaBuilder.struct().field("double", SchemaBuilder.float64());
+    final SchemaBuilder schemaBuilder = SchemaBuilder.struct()
+        .field("double", Schema.OPTIONAL_FLOAT64_SCHEMA);
     final GenericRowValueTypeEnforcer genericRowValueTypeEnforcer =
-        new GenericRowValueTypeEnforcer(schemaBuilder);
+        new GenericRowValueTypeEnforcer(KsqlSchema.of(schemaBuilder.build()));
 
     assertNull(genericRowValueTypeEnforcer.enforceFieldType(0, null));
   }

--- a/ksql-engine/src/test/java/io/confluent/ksql/util/ItemDataProvider.java
+++ b/ksql-engine/src/test/java/io/confluent/ksql/util/ItemDataProvider.java
@@ -16,10 +16,10 @@
 package io.confluent.ksql.util;
 
 import io.confluent.ksql.GenericRow;
+import io.confluent.ksql.schema.ksql.KsqlSchema;
 import java.util.Arrays;
 import java.util.HashMap;
 import java.util.Map;
-import org.apache.kafka.connect.data.Schema;
 import org.apache.kafka.connect.data.SchemaBuilder;
 
 public class ItemDataProvider extends TestDataProvider {
@@ -32,9 +32,10 @@ public class ItemDataProvider extends TestDataProvider {
 
   private static final String key = "ID";
 
-  private static final Schema schema = SchemaBuilder.struct()
+  private static final KsqlSchema schema = KsqlSchema.of(SchemaBuilder.struct()
       .field("ID", SchemaBuilder.OPTIONAL_STRING_SCHEMA)
-      .field("DESCRIPTION", SchemaBuilder.OPTIONAL_STRING_SCHEMA).build();
+      .field("DESCRIPTION", SchemaBuilder.OPTIONAL_STRING_SCHEMA)
+      .build());
 
   private static final Map<String, GenericRow> data = buildData();
 

--- a/ksql-engine/src/test/java/io/confluent/ksql/util/OrderDataProvider.java
+++ b/ksql-engine/src/test/java/io/confluent/ksql/util/OrderDataProvider.java
@@ -16,6 +16,7 @@
 package io.confluent.ksql.util;
 
 import io.confluent.ksql.GenericRow;
+import io.confluent.ksql.schema.ksql.KsqlSchema;
 import java.util.Arrays;
 import java.util.HashMap;
 import java.util.Map;
@@ -32,14 +33,22 @@ public class OrderDataProvider extends TestDataProvider {
 
   private static final String key = "ORDERTIME";
 
-  private static final Schema schema = SchemaBuilder.struct()
+  private static final KsqlSchema schema = KsqlSchema.of(SchemaBuilder.struct()
       .field("ORDERTIME", SchemaBuilder.OPTIONAL_INT64_SCHEMA)
       .field("ORDERID", SchemaBuilder.OPTIONAL_STRING_SCHEMA)
       .field("ITEMID", SchemaBuilder.OPTIONAL_STRING_SCHEMA)
       .field("ORDERUNITS", SchemaBuilder.OPTIONAL_FLOAT64_SCHEMA)
       .field("TIMESTAMP", Schema.OPTIONAL_STRING_SCHEMA)
-      .field("PRICEARRAY", SchemaBuilder.array(SchemaBuilder.OPTIONAL_FLOAT64_SCHEMA).optional().build())
-      .field("KEYVALUEMAP", SchemaBuilder.map(SchemaBuilder.OPTIONAL_STRING_SCHEMA, SchemaBuilder.OPTIONAL_FLOAT64_SCHEMA)).optional().build();
+      .field("PRICEARRAY", SchemaBuilder
+          .array(SchemaBuilder.OPTIONAL_FLOAT64_SCHEMA)
+          .optional()
+          .build())
+      .field("KEYVALUEMAP", SchemaBuilder
+          .map(SchemaBuilder.OPTIONAL_STRING_SCHEMA, SchemaBuilder.OPTIONAL_FLOAT64_SCHEMA)
+          .optional()
+          .build())
+      .optional()
+      .build());
 
   private static final Map<String, GenericRow> data = buildData();
 

--- a/ksql-engine/src/test/java/io/confluent/ksql/util/PageViewDataProvider.java
+++ b/ksql-engine/src/test/java/io/confluent/ksql/util/PageViewDataProvider.java
@@ -15,10 +15,10 @@
 package io.confluent.ksql.util;
 
 import io.confluent.ksql.GenericRow;
+import io.confluent.ksql.schema.ksql.KsqlSchema;
 import java.util.Arrays;
 import java.util.HashMap;
 import java.util.Map;
-import org.apache.kafka.connect.data.Schema;
 import org.apache.kafka.connect.data.SchemaBuilder;
 
 public class PageViewDataProvider extends TestDataProvider {
@@ -30,10 +30,11 @@ public class PageViewDataProvider extends TestDataProvider {
 
   private static final String key = "PAGEID";
 
-  private static final Schema schema = SchemaBuilder.struct()
+  private static final KsqlSchema schema = KsqlSchema.of(SchemaBuilder.struct()
       .field("VIEWTIME", SchemaBuilder.OPTIONAL_INT64_SCHEMA)
       .field("USERID", SchemaBuilder.OPTIONAL_STRING_SCHEMA)
-      .field("PAGEID", SchemaBuilder.OPTIONAL_STRING_SCHEMA).build();
+      .field("PAGEID", SchemaBuilder.OPTIONAL_STRING_SCHEMA)
+      .build());
 
   private static final Map<String, GenericRow> data = buildData();
 

--- a/ksql-engine/src/test/java/io/confluent/ksql/util/QueryMetadataTest.java
+++ b/ksql-engine/src/test/java/io/confluent/ksql/util/QueryMetadataTest.java
@@ -28,7 +28,6 @@ import io.confluent.ksql.schema.ksql.KsqlSchema;
 import java.util.Collections;
 import java.util.Set;
 import java.util.function.Consumer;
-import org.apache.kafka.connect.data.Schema;
 import org.apache.kafka.connect.data.SchemaBuilder;
 import org.apache.kafka.streams.KafkaStreams;
 import org.apache.kafka.streams.KafkaStreams.State;
@@ -44,9 +43,9 @@ import org.mockito.junit.MockitoJUnitRunner;
 public class QueryMetadataTest {
 
   private static final String QUERY_APPLICATION_ID = "Query1";
-  private static final Schema SOME_SCHEMA = SchemaBuilder.struct()
+  private static final KsqlSchema SOME_SCHEMA = KsqlSchema.of(SchemaBuilder.struct()
       .field("f0", SchemaBuilder.OPTIONAL_STRING_SCHEMA)
-      .build();
+      .build());
   private static final Set<String> SOME_SOURCES = ImmutableSet.of("s1", "s2");
 
   @Mock
@@ -64,7 +63,7 @@ public class QueryMetadataTest {
     query = new QueryMetadata(
         "foo",
         kafkaStreams,
-        KsqlSchema.of(SOME_SCHEMA),
+        SOME_SCHEMA,
         SOME_SOURCES,
         "bar",
         DataSourceType.KSTREAM,

--- a/ksql-engine/src/test/java/io/confluent/ksql/util/QueryMetadataTest.java
+++ b/ksql-engine/src/test/java/io/confluent/ksql/util/QueryMetadataTest.java
@@ -24,7 +24,7 @@ import static org.mockito.Mockito.when;
 
 import com.google.common.collect.ImmutableSet;
 import io.confluent.ksql.internal.QueryStateListener;
-import io.confluent.ksql.planner.plan.OutputNode;
+import io.confluent.ksql.schema.ksql.KsqlSchema;
 import java.util.Collections;
 import java.util.Set;
 import java.util.function.Consumer;
@@ -44,11 +44,11 @@ import org.mockito.junit.MockitoJUnitRunner;
 public class QueryMetadataTest {
 
   private static final String QUERY_APPLICATION_ID = "Query1";
-  private static final Schema SOME_SCHEMA = SchemaBuilder.OPTIONAL_STRING_SCHEMA;
+  private static final Schema SOME_SCHEMA = SchemaBuilder.struct()
+      .field("f0", SchemaBuilder.OPTIONAL_STRING_SCHEMA)
+      .build();
   private static final Set<String> SOME_SOURCES = ImmutableSet.of("s1", "s2");
 
-  @Mock
-  private OutputNode outputNode;
   @Mock
   private Topology topoplogy;
   @Mock
@@ -64,7 +64,7 @@ public class QueryMetadataTest {
     query = new QueryMetadata(
         "foo",
         kafkaStreams,
-        SOME_SCHEMA,
+        KsqlSchema.of(SOME_SCHEMA),
         SOME_SOURCES,
         "bar",
         DataSourceType.KSTREAM,

--- a/ksql-engine/src/test/java/io/confluent/ksql/util/TestDataProvider.java
+++ b/ksql-engine/src/test/java/io/confluent/ksql/util/TestDataProvider.java
@@ -16,15 +16,15 @@
 package io.confluent.ksql.util;
 
 import io.confluent.ksql.GenericRow;
+import io.confluent.ksql.schema.ksql.KsqlSchema;
 import java.util.Map;
 import java.util.Objects;
-import org.apache.kafka.connect.data.Schema;
 
 public abstract class TestDataProvider {
   private final String topicName;
   private final String ksqlSchemaString;
   private final String key;
-  private final Schema schema;
+  private final KsqlSchema schema;
   private final Map<String, GenericRow> data;
   private final String kstreamName;
 
@@ -32,7 +32,7 @@ public abstract class TestDataProvider {
       final String namePrefix,
       final String ksqlSchemaString,
       final String key,
-      final Schema schema,
+      final KsqlSchema schema,
       final Map<String, GenericRow> data
   ) {
     this.topicName = Objects.requireNonNull(namePrefix, "namePrefix") + "_TOPIC";
@@ -55,7 +55,7 @@ public abstract class TestDataProvider {
     return key;
   }
 
-  public Schema schema() {
+  public KsqlSchema schema() {
     return schema;
   }
 

--- a/ksql-engine/src/test/java/io/confluent/ksql/util/TopicConsumer.java
+++ b/ksql-engine/src/test/java/io/confluent/ksql/util/TopicConsumer.java
@@ -21,6 +21,7 @@ import static org.hamcrest.Matchers.hasSize;
 
 import io.confluent.ksql.GenericRow;
 import io.confluent.ksql.logging.processing.ProcessingLogContext;
+import io.confluent.ksql.schema.ksql.KsqlSchema;
 import io.confluent.ksql.serde.json.KsqlJsonDeserializer;
 import io.confluent.ksql.test.util.EmbeddedSingleNodeKafkaCluster;
 import java.time.Duration;
@@ -34,7 +35,6 @@ import org.apache.kafka.clients.consumer.ConsumerRecord;
 import org.apache.kafka.clients.consumer.KafkaConsumer;
 import org.apache.kafka.common.serialization.ByteArrayDeserializer;
 import org.apache.kafka.common.serialization.Deserializer;
-import org.apache.kafka.connect.data.Schema;
 import org.hamcrest.Matcher;
 
 public class TopicConsumer {
@@ -49,10 +49,12 @@ public class TopicConsumer {
     this.cluster = cluster;
   }
 
-  public <K, V> Map<K, V> readResults(final String topic,
-                                      final Matcher<Integer> expectedNumMessages,
-                                      final Deserializer<V> valueDeserializer,
-                                      final Deserializer<K> keyDeserializer) {
+  public <K, V> Map<K, V> readResults(
+      final String topic,
+      final Matcher<Integer> expectedNumMessages,
+      final Deserializer<V> valueDeserializer,
+      final Deserializer<K> keyDeserializer
+  ) {
     final Map<K, V> result = new HashMap<>();
 
     final Properties consumerConfig = new Properties();
@@ -84,15 +86,17 @@ public class TopicConsumer {
     return result;
   }
 
-  public <K> Map<K, GenericRow> readResults(final String topic,
-                                            final Schema schema,
-                                            final int expectedNumMessages,
-                                            final Deserializer<K> keyDeserializer) {
+  public <K> Map<K, GenericRow> readResults(
+      final String topic,
+      final KsqlSchema schema,
+      final int expectedNumMessages,
+      final Deserializer<K> keyDeserializer
+  ) {
     return readResults(
         topic,
         greaterThanOrEqualTo(expectedNumMessages),
         new KsqlJsonDeserializer(
-            schema,
+            schema.getSchema(),
             processingLogContext.getLoggerFactory().getLogger("consumer")),
         keyDeserializer
     );

--- a/ksql-engine/src/test/java/io/confluent/ksql/util/TopicProducer.java
+++ b/ksql-engine/src/test/java/io/confluent/ksql/util/TopicProducer.java
@@ -16,6 +16,7 @@
 package io.confluent.ksql.util;
 
 import io.confluent.ksql.GenericRow;
+import io.confluent.ksql.schema.ksql.KsqlSchema;
 import io.confluent.ksql.serde.json.KsqlJsonSerializer;
 import io.confluent.ksql.test.util.EmbeddedSingleNodeKafkaCluster;
 import java.util.HashMap;
@@ -30,7 +31,6 @@ import org.apache.kafka.clients.producer.ProducerConfig;
 import org.apache.kafka.clients.producer.ProducerRecord;
 import org.apache.kafka.clients.producer.RecordMetadata;
 import org.apache.kafka.common.serialization.StringSerializer;
-import org.apache.kafka.connect.data.Schema;
 
 public class TopicProducer {
 
@@ -58,11 +58,14 @@ public class TopicProducer {
    * @throws TimeoutException
    * @throws ExecutionException
    */
-  public Map<String, RecordMetadata> produceInputData(final String topicName, final Map<String, GenericRow> recordsToPublish, final Schema schema)
-      throws InterruptedException, TimeoutException, ExecutionException {
+  public Map<String, RecordMetadata> produceInputData(
+      final String topicName,
+      final Map<String, GenericRow> recordsToPublish,
+      final KsqlSchema schema
+  ) throws InterruptedException, TimeoutException, ExecutionException {
 
     final KafkaProducer<String, GenericRow> producer =
-        new KafkaProducer<>(producerConfig, new StringSerializer(), new KsqlJsonSerializer(schema));
+        new KafkaProducer<>(producerConfig, new StringSerializer(), new KsqlJsonSerializer(schema.getSchema()));
 
     final Map<String, RecordMetadata> result = new HashMap<>();
     for (final Map.Entry<String, GenericRow> recordEntry : recordsToPublish.entrySet()) {

--- a/ksql-engine/src/test/java/io/confluent/ksql/util/UserDataProvider.java
+++ b/ksql-engine/src/test/java/io/confluent/ksql/util/UserDataProvider.java
@@ -15,10 +15,10 @@
 package io.confluent.ksql.util;
 
 import io.confluent.ksql.GenericRow;
+import io.confluent.ksql.schema.ksql.KsqlSchema;
 import java.util.Arrays;
 import java.util.HashMap;
 import java.util.Map;
-import org.apache.kafka.connect.data.Schema;
 import org.apache.kafka.connect.data.SchemaBuilder;
 
 public class UserDataProvider extends TestDataProvider {
@@ -28,11 +28,12 @@ public class UserDataProvider extends TestDataProvider {
 
   private static final String key = "USERID";
 
-  private static final Schema schema = SchemaBuilder.struct()
+  private static final KsqlSchema schema = KsqlSchema.of(SchemaBuilder.struct()
       .field("REGISTERTIME", SchemaBuilder.OPTIONAL_INT64_SCHEMA)
       .field("GENDER", SchemaBuilder.OPTIONAL_STRING_SCHEMA)
       .field("REGIONID", SchemaBuilder.OPTIONAL_STRING_SCHEMA)
-      .field("USERID", SchemaBuilder.OPTIONAL_STRING_SCHEMA).build();
+      .field("USERID", SchemaBuilder.OPTIONAL_STRING_SCHEMA)
+      .build());
 
   private static final Map<String, GenericRow> data = buildData();
 

--- a/ksql-metastore/src/main/java/io/confluent/ksql/metastore/model/DataSource.java
+++ b/ksql-metastore/src/main/java/io/confluent/ksql/metastore/model/DataSource.java
@@ -16,9 +16,9 @@
 package io.confluent.ksql.metastore.model;
 
 import io.confluent.ksql.metastore.SerdeFactory;
+import io.confluent.ksql.schema.ksql.KsqlSchema;
 import io.confluent.ksql.serde.KsqlTopicSerDe;
 import io.confluent.ksql.util.timestamp.TimestampExtractionPolicy;
-import org.apache.kafka.connect.data.Schema;
 
 public interface DataSource<K> {
 
@@ -48,9 +48,9 @@ public interface DataSource<K> {
   DataSourceType getDataSourceType();
 
   /**
-   * @return the value schema of the source.
+   * @return the schema of the source.
    */
-  Schema getSchema();
+  KsqlSchema getSchema();
 
   /**
    * @return the key field of the source.

--- a/ksql-metastore/src/main/java/io/confluent/ksql/metastore/model/KeyField.java
+++ b/ksql-metastore/src/main/java/io/confluent/ksql/metastore/model/KeyField.java
@@ -16,12 +16,12 @@
 package io.confluent.ksql.metastore.model;
 
 import com.google.errorprone.annotations.Immutable;
+import io.confluent.ksql.schema.ksql.KsqlSchema;
 import io.confluent.ksql.util.KsqlConfig;
 import io.confluent.ksql.util.SchemaUtil;
 import java.util.Objects;
 import java.util.Optional;
 import org.apache.kafka.connect.data.Field;
-import org.apache.kafka.connect.data.Schema;
 
 /**
  * Pojo that holds the details of a source's key field.
@@ -78,7 +78,7 @@ public final class KeyField {
    * @return self, to allow fluid syntax.
    * @throws IllegalArgumentException if the key is not within the supplied schema.
    */
-  public KeyField validateKeyExistsIn(final Schema schema) {
+  public KeyField validateKeyExistsIn(final KsqlSchema schema) {
     resolveKey(schema);
     return this;
   }
@@ -107,7 +107,7 @@ public final class KeyField {
    * @return the resolved key field, or {@link Optional#empty()} if no key field is set.
    * @throws IllegalArgumentException if new key field is required but not available in the schema.
    */
-  public Optional<Field> resolve(final Schema schema, final KsqlConfig ksqlConfig) {
+  public Optional<Field> resolve(final KsqlSchema schema, final KsqlConfig ksqlConfig) {
     if (shouldUseLegacy(ksqlConfig)) {
       return legacyKeyField;
     }
@@ -205,10 +205,9 @@ public final class KeyField {
         + '}';
   }
 
-  private Optional<Field> resolveKey(final Schema schema) {
+  private Optional<Field> resolveKey(final KsqlSchema schema) {
     return keyField
-        .map(fieldName -> SchemaUtil
-            .getFieldByName(schema, fieldName)
+        .map(fieldName -> schema.findField(fieldName)
             .orElseThrow(() -> new IllegalArgumentException(
                 "Invalid key field, not found in schema: " + fieldName)));
   }

--- a/ksql-metastore/src/main/java/io/confluent/ksql/metastore/model/KsqlStream.java
+++ b/ksql-metastore/src/main/java/io/confluent/ksql/metastore/model/KsqlStream.java
@@ -17,9 +17,9 @@ package io.confluent.ksql.metastore.model;
 
 import com.google.errorprone.annotations.Immutable;
 import io.confluent.ksql.metastore.SerdeFactory;
+import io.confluent.ksql.schema.ksql.KsqlSchema;
 import io.confluent.ksql.util.timestamp.TimestampExtractionPolicy;
 import org.apache.kafka.common.serialization.Serde;
-import org.apache.kafka.connect.data.Schema;
 import org.apache.kafka.streams.kstream.WindowedSerdes;
 
 @Immutable
@@ -28,7 +28,7 @@ public class KsqlStream<K> extends StructuredDataSource<K> {
   public KsqlStream(
       final String sqlExpression,
       final String datasourceName,
-      final Schema schema,
+      final KsqlSchema schema,
       final KeyField keyField,
       final TimestampExtractionPolicy timestampExtractionPolicy,
       final KsqlTopic ksqlTopic,

--- a/ksql-metastore/src/main/java/io/confluent/ksql/metastore/model/KsqlTable.java
+++ b/ksql-metastore/src/main/java/io/confluent/ksql/metastore/model/KsqlTable.java
@@ -17,9 +17,9 @@ package io.confluent.ksql.metastore.model;
 
 import com.google.errorprone.annotations.Immutable;
 import io.confluent.ksql.metastore.SerdeFactory;
+import io.confluent.ksql.schema.ksql.KsqlSchema;
 import io.confluent.ksql.util.timestamp.TimestampExtractionPolicy;
 import org.apache.kafka.common.serialization.Serde;
-import org.apache.kafka.connect.data.Schema;
 import org.apache.kafka.streams.kstream.WindowedSerdes;
 
 @Immutable
@@ -28,7 +28,7 @@ public class KsqlTable<K> extends StructuredDataSource<K> {
   public KsqlTable(
       final String sqlExpression,
       final String datasourceName,
-      final Schema schema,
+      final KsqlSchema schema,
       final KeyField keyField,
       final TimestampExtractionPolicy timestampExtractionPolicy,
       final KsqlTopic ksqlTopic,

--- a/ksql-metastore/src/main/java/io/confluent/ksql/metastore/model/StructuredDataSource.java
+++ b/ksql-metastore/src/main/java/io/confluent/ksql/metastore/model/StructuredDataSource.java
@@ -22,7 +22,6 @@ import io.confluent.ksql.metastore.SerdeFactory;
 import io.confluent.ksql.schema.ksql.KsqlSchema;
 import io.confluent.ksql.serde.KsqlTopicSerDe;
 import io.confluent.ksql.util.timestamp.TimestampExtractionPolicy;
-import org.apache.kafka.connect.data.Schema;
 
 @Immutable
 abstract class StructuredDataSource<K> implements DataSource<K> {
@@ -39,7 +38,7 @@ abstract class StructuredDataSource<K> implements DataSource<K> {
   StructuredDataSource(
       final String sqlExpression,
       final String dataSourceName,
-      final Schema schema,
+      final KsqlSchema schema,
       final KeyField keyField,
       final TimestampExtractionPolicy tsExtractionPolicy,
       final DataSourceType dataSourceType,
@@ -48,7 +47,7 @@ abstract class StructuredDataSource<K> implements DataSource<K> {
   ) {
     this.sqlExpression = requireNonNull(sqlExpression, "sqlExpression");
     this.dataSourceName = requireNonNull(dataSourceName, "dataSourceName");
-    this.schema = KsqlSchema.of(schema);
+    this.schema = requireNonNull(schema, "schema");
     this.keyField = requireNonNull(keyField, "keyField")
         .validateKeyExistsIn(schema);
     this.timestampExtractionPolicy = requireNonNull(tsExtractionPolicy, "tsExtractionPolicy");
@@ -68,8 +67,8 @@ abstract class StructuredDataSource<K> implements DataSource<K> {
   }
 
   @Override
-  public Schema getSchema() {
-    return schema.getSchema();
+  public KsqlSchema getSchema() {
+    return schema;
   }
 
   @Override

--- a/ksql-metastore/src/test/java/io/confluent/ksql/metastore/model/KeyFieldTest.java
+++ b/ksql-metastore/src/test/java/io/confluent/ksql/metastore/model/KeyFieldTest.java
@@ -20,6 +20,7 @@ import static org.hamcrest.Matchers.is;
 
 import com.google.common.collect.ImmutableMap;
 import com.google.common.testing.EqualsTester;
+import io.confluent.ksql.schema.ksql.KsqlSchema;
 import io.confluent.ksql.util.KsqlConfig;
 import java.util.Optional;
 import org.apache.kafka.connect.data.Field;
@@ -31,10 +32,12 @@ import org.junit.rules.ExpectedException;
 
 public class KeyFieldTest {
 
-  private static final Schema SCHEMA = SchemaBuilder.struct()
+  private static final KsqlSchema SCHEMA = KsqlSchema.of(
+      SchemaBuilder.struct()
       .field("field0", Schema.OPTIONAL_STRING_SCHEMA)
-      .field("field1", Schema.OPTIONAL_BYTES_SCHEMA)
-      .build();
+      .field("field1", Schema.OPTIONAL_INT64_SCHEMA)
+          .build()
+  );
 
   private static final KsqlConfig LEGACY_CONFIG = new KsqlConfig(
       ImmutableMap.of(KsqlConfig.KSQL_USE_LEGACY_KEY_FIELD, true)

--- a/ksql-metastore/src/test/java/io/confluent/ksql/metastore/model/MetaStoreMatchers.java
+++ b/ksql-metastore/src/test/java/io/confluent/ksql/metastore/model/MetaStoreMatchers.java
@@ -59,7 +59,7 @@ public final class MetaStoreMatchers {
         (schemaMatcher, "source with value schema", "value schema") {
       @Override
       protected Schema featureValueOf(final DataSource<?> actual) {
-        return actual.getSchema();
+        return actual.getSchema().getSchema();
       }
     };
   }

--- a/ksql-metastore/src/test/java/io/confluent/ksql/metastore/model/MetaStoreModelTest.java
+++ b/ksql-metastore/src/test/java/io/confluent/ksql/metastore/model/MetaStoreModelTest.java
@@ -32,6 +32,7 @@ import java.lang.reflect.Modifier;
 import java.util.Collection;
 import java.util.Optional;
 import org.apache.kafka.connect.data.Schema;
+import org.apache.kafka.connect.data.SchemaBuilder;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
@@ -50,6 +51,11 @@ public class MetaStoreModelTest {
       .put(org.apache.kafka.connect.data.Field.class,
           new org.apache.kafka.connect.data.Field("bob", 1, Schema.OPTIONAL_STRING_SCHEMA))
       .put(KeyField.class, KeyField.of(Optional.empty(), Optional.empty()))
+      .put(KsqlSchema.class, KsqlSchema.of(SchemaBuilder
+          .struct()
+          .optional()
+          .field("f0", Schema.OPTIONAL_INT64_SCHEMA)
+          .build()))
       .build();
 
   private final Class<?> modelClass;

--- a/ksql-metastore/src/test/java/io/confluent/ksql/metastore/model/StructuredDataSourceTest.java
+++ b/ksql-metastore/src/test/java/io/confluent/ksql/metastore/model/StructuredDataSourceTest.java
@@ -18,6 +18,7 @@ package io.confluent.ksql.metastore.model;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 
+import io.confluent.ksql.schema.ksql.KsqlSchema;
 import io.confluent.ksql.util.timestamp.TimestampExtractionPolicy;
 import org.apache.kafka.common.serialization.Serdes;
 import org.apache.kafka.connect.data.Schema;
@@ -30,9 +31,11 @@ import org.mockito.junit.MockitoJUnitRunner;
 @RunWith(MockitoJUnitRunner.class)
 public class StructuredDataSourceTest {
 
-  private static final Schema SOME_SCHEMA = SchemaBuilder.struct()
+  private static final KsqlSchema SOME_SCHEMA = KsqlSchema.of(
+      SchemaBuilder.struct()
       .field("f0", Schema.OPTIONAL_INT64_SCHEMA)
-      .build();
+          .build()
+  );
 
   @Mock
   public KeyField keyField;
@@ -55,7 +58,7 @@ public class StructuredDataSourceTest {
   private static final class TestStructuredDataSource extends StructuredDataSource<String> {
 
     private TestStructuredDataSource(
-        final Schema schema,
+        final KsqlSchema schema,
         final KeyField keyField
     ) {
       super(

--- a/ksql-metastore/src/test/java/io/confluent/ksql/util/MetaStoreFixture.java
+++ b/ksql-metastore/src/test/java/io/confluent/ksql/util/MetaStoreFixture.java
@@ -22,6 +22,7 @@ import io.confluent.ksql.metastore.model.KeyField;
 import io.confluent.ksql.metastore.model.KsqlStream;
 import io.confluent.ksql.metastore.model.KsqlTable;
 import io.confluent.ksql.metastore.model.KsqlTopic;
+import io.confluent.ksql.schema.ksql.KsqlSchema;
 import io.confluent.ksql.serde.KsqlTopicSerDe;
 import io.confluent.ksql.serde.json.KsqlJsonTopicSerDe;
 import io.confluent.ksql.util.timestamp.MetadataTimestampExtractionPolicy;
@@ -65,7 +66,7 @@ public final class MetaStoreFixture {
     final KsqlStream<?> ksqlStream0 = new KsqlStream<>(
         "sqlexpression",
         "TEST0",
-        test1Schema,
+        KsqlSchema.of(test1Schema),
         KeyField.of("COL0", test1Schema.field("COL0")),
         timestampExtractionPolicy,
         ksqlTopic0,
@@ -80,7 +81,7 @@ public final class MetaStoreFixture {
 
     final KsqlStream<?> ksqlStream1 = new KsqlStream<>("sqlexpression",
         "TEST1",
-        test1Schema,
+        KsqlSchema.of(test1Schema),
         KeyField.of("COL0", test1Schema.field("COL0")),
         timestampExtractionPolicy,
         ksqlTopic1,
@@ -105,7 +106,7 @@ public final class MetaStoreFixture {
     final KsqlTable<String> ksqlTable = new KsqlTable<>(
         "sqlexpression",
         "TEST2",
-        test2Schema,
+        KsqlSchema.of(test2Schema),
         KeyField.of("COL0", test2Schema.field("COL0")),
         timestampExtractionPolicy,
         ksqlTopic2,
@@ -138,7 +139,7 @@ public final class MetaStoreFixture {
         .field("ORDERID", Schema.OPTIONAL_INT64_SCHEMA)
         .field("ITEMID", Schema.OPTIONAL_STRING_SCHEMA)
         .field("ITEMINFO", itemInfoSchema)
-        .field("ORDERUNITS", Schema.INT32_SCHEMA)
+        .field("ORDERUNITS", Schema.OPTIONAL_INT32_SCHEMA)
         .field("ARRAYCOL",SchemaBuilder.array(Schema.OPTIONAL_FLOAT64_SCHEMA).optional().build())
         .field("MAPCOL", SchemaBuilder.map(Schema.OPTIONAL_STRING_SCHEMA, Schema.OPTIONAL_FLOAT64_SCHEMA).optional().build())
         .field("ADDRESS", addressSchema)
@@ -151,7 +152,7 @@ public final class MetaStoreFixture {
     final KsqlStream<?> ksqlStreamOrders = new KsqlStream<>(
         "sqlexpression",
         "ORDERS",
-        ordersSchema,
+        KsqlSchema.of(ordersSchema),
         KeyField.of("ORDERTIME", ordersSchema.field("ORDERTIME")),
         timestampExtractionPolicy,
         ksqlTopicOrders,
@@ -160,7 +161,7 @@ public final class MetaStoreFixture {
     metaStore.putTopic(ksqlTopicOrders);
     metaStore.putSource(ksqlStreamOrders);
 
-    final Schema schemaBuilderTestTable3 = SchemaBuilder.struct()
+    final Schema testTable3 = SchemaBuilder.struct()
         .field("ROWTIME", Schema.OPTIONAL_INT64_SCHEMA)
         .field("ROWKEY", Schema.OPTIONAL_INT64_SCHEMA)
         .field("COL0", Schema.OPTIONAL_INT64_SCHEMA)
@@ -176,8 +177,8 @@ public final class MetaStoreFixture {
     final KsqlTable<String> ksqlTable3 = new KsqlTable<>(
         "sqlexpression",
         "TEST3",
-        schemaBuilderTestTable3,
-        KeyField.of("COL0", schemaBuilderTestTable3.field("COL0")),
+        KsqlSchema.of(testTable3),
+        KeyField.of("COL0", testTable3.field("COL0")),
         timestampExtractionPolicy,
         ksqlTopic3,
         Serdes::String);
@@ -186,8 +187,8 @@ public final class MetaStoreFixture {
     metaStore.putSource(ksqlTable3);
 
     final Schema nestedArrayStructMapSchema = SchemaBuilder.struct()
-        .field("ARRAYCOL", SchemaBuilder.array(itemInfoSchema).build())
-        .field("MAPCOL", SchemaBuilder.map(Schema.OPTIONAL_STRING_SCHEMA, itemInfoSchema).build())
+        .field("ARRAYCOL", SchemaBuilder.array(itemInfoSchema).optional().build())
+        .field("MAPCOL", SchemaBuilder.map(Schema.OPTIONAL_STRING_SCHEMA, itemInfoSchema).optional().build())
         .field("NESTED_ORDER_COL", ordersSchema)
         .field("ITEM", itemInfoSchema)
         .optional().build();
@@ -199,7 +200,7 @@ public final class MetaStoreFixture {
     final KsqlStream<?> nestedArrayStructMapOrders = new KsqlStream<>(
         "sqlexpression",
         "NESTED_STREAM",
-        nestedArrayStructMapSchema,
+        KsqlSchema.of(nestedArrayStructMapSchema),
         KeyField.of(Optional.empty(), Optional.empty()),
         timestampExtractionPolicy,
         nestedArrayStructMapTopic,
@@ -214,7 +215,7 @@ public final class MetaStoreFixture {
     final KsqlStream<?> ksqlStream4 = new KsqlStream<>(
         "sqlexpression4",
         "TEST4",
-        test1Schema,
+        KsqlSchema.of(test1Schema),
         KeyField.of(Optional.empty(), Optional.empty()),
         timestampExtractionPolicy,
         ksqlTopic4,

--- a/ksql-parser/src/main/java/io/confluent/ksql/util/DataSourceExtractor.java
+++ b/ksql-parser/src/main/java/io/confluent/ksql/util/DataSourceExtractor.java
@@ -25,6 +25,7 @@ import io.confluent.ksql.parser.tree.AliasedRelation;
 import io.confluent.ksql.parser.tree.Node;
 import io.confluent.ksql.parser.tree.NodeLocation;
 import io.confluent.ksql.parser.tree.Table;
+import io.confluent.ksql.schema.ksql.KsqlSchema;
 import java.util.HashSet;
 import java.util.Objects;
 import java.util.Optional;
@@ -33,14 +34,13 @@ import org.antlr.v4.runtime.ParserRuleContext;
 import org.antlr.v4.runtime.Token;
 import org.antlr.v4.runtime.tree.ParseTree;
 import org.apache.kafka.connect.data.Field;
-import org.apache.kafka.connect.data.Schema;
 
 public class DataSourceExtractor {
 
   private final MetaStore metaStore;
 
-  private Schema joinLeftSchema;
-  private Schema joinRightSchema;
+  private KsqlSchema joinLeftSchema;
+  private KsqlSchema joinRightSchema;
 
   private String fromAlias;
   private String fromName;

--- a/ksql-parser/src/test/java/io/confluent/ksql/parser/KsqlParserTest.java
+++ b/ksql-parser/src/test/java/io/confluent/ksql/parser/KsqlParserTest.java
@@ -68,6 +68,7 @@ import io.confluent.ksql.parser.tree.Statement;
 import io.confluent.ksql.parser.tree.Struct;
 import io.confluent.ksql.parser.tree.Type.SqlType;
 import io.confluent.ksql.parser.tree.WithinExpression;
+import io.confluent.ksql.schema.ksql.KsqlSchema;
 import io.confluent.ksql.serde.json.KsqlJsonTopicSerDe;
 import io.confluent.ksql.util.KsqlException;
 import io.confluent.ksql.util.MetaStoreFixture;
@@ -116,20 +117,26 @@ public class KsqlParserTest {
         .optional().build();
 
     final Schema itemInfoSchema = SchemaBuilder.struct()
-        .field("ITEMID", Schema.INT64_SCHEMA)
-        .field("NAME", Schema.STRING_SCHEMA)
+        .field("ITEMID", Schema.OPTIONAL_INT64_SCHEMA)
+        .field("NAME", Schema.OPTIONAL_STRING_SCHEMA)
         .field("CATEGORY", categorySchema)
         .optional().build();
 
     final SchemaBuilder schemaBuilder = SchemaBuilder.struct();
     final Schema schemaBuilderOrders = schemaBuilder
-        .field("ORDERTIME", Schema.INT64_SCHEMA)
+        .field("ORDERTIME", Schema.OPTIONAL_INT64_SCHEMA)
         .field("ORDERID", Schema.OPTIONAL_INT64_SCHEMA)
         .field("ITEMID", Schema.OPTIONAL_STRING_SCHEMA)
         .field("ITEMINFO", itemInfoSchema)
-        .field("ORDERUNITS", Schema.INT32_SCHEMA)
-        .field("ARRAYCOL",SchemaBuilder.array(Schema.FLOAT64_SCHEMA).optional().build())
-        .field("MAPCOL", SchemaBuilder.map(Schema.STRING_SCHEMA, Schema.FLOAT64_SCHEMA).optional().build())
+        .field("ORDERUNITS", Schema.OPTIONAL_INT32_SCHEMA)
+        .field("ARRAYCOL",SchemaBuilder
+            .array(Schema.OPTIONAL_FLOAT64_SCHEMA)
+            .optional()
+            .build())
+        .field("MAPCOL", SchemaBuilder
+            .map(Schema.OPTIONAL_STRING_SCHEMA, Schema.OPTIONAL_FLOAT64_SCHEMA)
+            .optional()
+            .build())
         .field("ADDRESS", addressSchema)
         .build();
 
@@ -140,7 +147,7 @@ public class KsqlParserTest {
     final KsqlStream ksqlStreamOrders = new KsqlStream<>(
         "sqlexpression",
         "ADDRESS",
-        schemaBuilderOrders,
+        KsqlSchema.of(schemaBuilderOrders),
         KeyField.of("ORDERTIME", schemaBuilderOrders.field("ORDERTIME")),
         new MetadataTimestampExtractionPolicy(),
         ksqlTopicOrders,
@@ -155,7 +162,7 @@ public class KsqlParserTest {
     final KsqlTable<String> ksqlTableOrders = new KsqlTable<>(
         "sqlexpression",
         "ITEMID",
-        itemInfoSchema,
+        KsqlSchema.of(itemInfoSchema),
         KeyField.of("ITEMID", itemInfoSchema.field("ITEMID")),
         new MetadataTimestampExtractionPolicy(),
         ksqlTopicItems,

--- a/ksql-parser/src/test/java/io/confluent/ksql/parser/SqlFormatterTest.java
+++ b/ksql-parser/src/test/java/io/confluent/ksql/parser/SqlFormatterTest.java
@@ -49,6 +49,7 @@ import io.confluent.ksql.parser.tree.Table;
 import io.confluent.ksql.parser.tree.TableElement;
 import io.confluent.ksql.parser.tree.Type.SqlType;
 import io.confluent.ksql.parser.tree.WithinExpression;
+import io.confluent.ksql.schema.ksql.KsqlSchema;
 import io.confluent.ksql.serde.json.KsqlJsonTopicSerDe;
 import io.confluent.ksql.util.MetaStoreFixture;
 import io.confluent.ksql.util.timestamp.MetadataTimestampExtractionPolicy;
@@ -90,20 +91,26 @@ public class SqlFormatterTest {
       .optional().build();
 
   private static final Schema itemInfoSchema = SchemaBuilder.struct()
-      .field("ITEMID", Schema.INT64_SCHEMA)
-      .field("NAME", Schema.STRING_SCHEMA)
+      .field("ITEMID", Schema.OPTIONAL_INT64_SCHEMA)
+      .field("NAME", Schema.OPTIONAL_STRING_SCHEMA)
       .field("CATEGORY", categorySchema)
       .optional().build();
 
   private static final SchemaBuilder schemaBuilder = SchemaBuilder.struct();
   private static final Schema schemaBuilderOrders = schemaBuilder
-      .field("ORDERTIME", Schema.INT64_SCHEMA)
+      .field("ORDERTIME", Schema.OPTIONAL_INT64_SCHEMA)
       .field("ORDERID", Schema.OPTIONAL_INT64_SCHEMA)
       .field("ITEMID", Schema.OPTIONAL_STRING_SCHEMA)
       .field("ITEMINFO", itemInfoSchema)
-      .field("ORDERUNITS", Schema.INT32_SCHEMA)
-      .field("ARRAYCOL",SchemaBuilder.array(Schema.FLOAT64_SCHEMA).optional().build())
-      .field("MAPCOL", SchemaBuilder.map(Schema.STRING_SCHEMA, Schema.FLOAT64_SCHEMA).optional().build())
+      .field("ORDERUNITS", Schema.OPTIONAL_INT32_SCHEMA)
+      .field("ARRAYCOL",SchemaBuilder
+          .array(Schema.OPTIONAL_FLOAT64_SCHEMA)
+          .optional()
+          .build())
+      .field("MAPCOL", SchemaBuilder
+          .map(Schema.OPTIONAL_STRING_SCHEMA, Schema.OPTIONAL_FLOAT64_SCHEMA)
+          .optional()
+          .build())
       .field("ADDRESS", addressSchema)
       .build();
 
@@ -128,7 +135,7 @@ public class SqlFormatterTest {
     final KsqlStream ksqlStreamOrders = new KsqlStream<>(
         "sqlexpression",
         "ADDRESS",
-        schemaBuilderOrders,
+        KsqlSchema.of(schemaBuilderOrders),
         KeyField.of("ORDERTIME", schemaBuilderOrders.field("ORDERTIME")),
         new MetadataTimestampExtractionPolicy(),
         ksqlTopicOrders,
@@ -143,7 +150,7 @@ public class SqlFormatterTest {
     final KsqlTable<String> ksqlTableOrders = new KsqlTable<>(
         "sqlexpression",
         "ITEMID",
-        itemInfoSchema,
+        KsqlSchema.of(itemInfoSchema),
         KeyField.of("ITEMID", itemInfoSchema.field("ITEMID")),
         new MetadataTimestampExtractionPolicy(),
         ksqlTopicItems,

--- a/ksql-rest-app/src/main/java/io/confluent/ksql/rest/server/execution/InsertValuesExecutor.java
+++ b/ksql-rest-app/src/main/java/io/confluent/ksql/rest/server/execution/InsertValuesExecutor.java
@@ -139,7 +139,7 @@ public class InsertValuesExecutor {
     final Map<String, Object> values = new HashMap<>();
     for (int i = 0; i < columns.size(); i++) {
       final String column = columns.get(i);
-      final Schema columnSchema = dataSource.getSchema().field(column).schema();
+      final Schema columnSchema = dataSource.getSchema().getSchema().field(column).schema();
       final Expression valueExp = insertValues.getValues().get(i);
 
       values.put(column, new ExpressionResolver(columnSchema, column).process(valueExp, null));
@@ -202,7 +202,7 @@ public class InsertValuesExecutor {
   ) {
     final Serde<GenericRow> rowSerde = dataSource.getKsqlTopicSerde()
         .getGenericRowSerde(
-            dataSource.getSchema(),
+            dataSource.getSchema().getSchema(),
             config,
             serviceContext.getSchemaRegistryClientFactory(),
             "",

--- a/ksql-rest-app/src/main/java/io/confluent/ksql/rest/server/resources/streaming/Flow.java
+++ b/ksql-rest-app/src/main/java/io/confluent/ksql/rest/server/resources/streaming/Flow.java
@@ -15,7 +15,7 @@
 
 package io.confluent.ksql.rest.server.resources.streaming;
 
-import org.apache.kafka.connect.data.Schema;
+import io.confluent.ksql.schema.ksql.KsqlSchema;
 
 /**
  * Flow constructs borrowed from Java 9
@@ -38,7 +38,7 @@ public class Flow {
      * to describe the message format, in case the stream has a schema
      * @param schema schema for upcoming messages
      */
-    void onSchema(Schema schema);
+    void onSchema(KsqlSchema schema);
 
     void onSubscribe(Subscription subscription);
   }

--- a/ksql-rest-app/src/main/java/io/confluent/ksql/rest/server/resources/streaming/PollingSubscription.java
+++ b/ksql-rest-app/src/main/java/io/confluent/ksql/rest/server/resources/streaming/PollingSubscription.java
@@ -43,7 +43,7 @@ public abstract class PollingSubscription<T> implements Flow.Subscription {
   ) {
     this.exec = Objects.requireNonNull(exec, "exec");
     this.subscriber = Objects.requireNonNull(subscriber, "subscriber");
-    this.schema = Objects.requireNonNull(schema, "schema");
+    this.schema = schema;
   }
 
   @Override

--- a/ksql-rest-app/src/main/java/io/confluent/ksql/rest/server/resources/streaming/PollingSubscription.java
+++ b/ksql-rest-app/src/main/java/io/confluent/ksql/rest/server/resources/streaming/PollingSubscription.java
@@ -18,8 +18,9 @@ package io.confluent.ksql.rest.server.resources.streaming;
 import com.google.common.base.Preconditions;
 import com.google.common.util.concurrent.ListenableFuture;
 import com.google.common.util.concurrent.ListeningScheduledExecutorService;
+import io.confluent.ksql.schema.ksql.KsqlSchema;
+import java.util.Objects;
 import java.util.concurrent.TimeUnit;
-import org.apache.kafka.connect.data.Schema;
 
 public abstract class PollingSubscription<T> implements Flow.Subscription {
 
@@ -27,7 +28,7 @@ public abstract class PollingSubscription<T> implements Flow.Subscription {
 
   private final Flow.Subscriber<T> subscriber;
   private final ListeningScheduledExecutorService exec;
-  private final Schema schema;
+  private final KsqlSchema schema;
 
   private boolean needsSchema = true;
   private volatile boolean done = false;
@@ -38,11 +39,11 @@ public abstract class PollingSubscription<T> implements Flow.Subscription {
   public PollingSubscription(
       final ListeningScheduledExecutorService exec,
       final Flow.Subscriber<T> subscriber,
-      final Schema schema
+      final KsqlSchema schema
   ) {
-    this.exec = exec;
-    this.subscriber = subscriber;
-    this.schema = schema;
+    this.exec = Objects.requireNonNull(exec, "exec");
+    this.subscriber = Objects.requireNonNull(subscriber, "subscriber");
+    this.schema = Objects.requireNonNull(schema, "schema");
   }
 
   @Override

--- a/ksql-rest-app/src/main/java/io/confluent/ksql/rest/server/resources/streaming/WebSocketSubscriber.java
+++ b/ksql-rest-app/src/main/java/io/confluent/ksql/rest/server/resources/streaming/WebSocketSubscriber.java
@@ -18,11 +18,11 @@ package io.confluent.ksql.rest.server.resources.streaming;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import io.confluent.ksql.rest.util.EntityUtil;
+import io.confluent.ksql.schema.ksql.KsqlSchema;
 import java.io.IOException;
 import java.util.Collection;
 import javax.websocket.CloseReason.CloseCodes;
 import javax.websocket.Session;
-import org.apache.kafka.connect.data.Schema;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -90,7 +90,7 @@ class WebSocketSubscriber<T> implements Flow.Subscriber<Collection<T>>, AutoClos
   }
 
   @Override
-  public void onSchema(final Schema schema) {
+  public void onSchema(final KsqlSchema schema) {
     try {
       session.getBasicRemote().sendText(
           mapper.writeValueAsString(EntityUtil.buildSourceSchemaEntity(schema))

--- a/ksql-rest-app/src/main/java/io/confluent/ksql/rest/util/EntityUtil.java
+++ b/ksql-rest-app/src/main/java/io/confluent/ksql/rest/util/EntityUtil.java
@@ -18,6 +18,7 @@ package io.confluent.ksql.rest.util;
 import avro.shaded.com.google.common.collect.ImmutableMap;
 import io.confluent.ksql.rest.entity.FieldInfo;
 import io.confluent.ksql.rest.entity.SchemaInfo;
+import io.confluent.ksql.schema.ksql.KsqlSchema;
 import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
@@ -41,8 +42,8 @@ public final class EntityUtil {
   private EntityUtil() {
   }
 
-  public static List<FieldInfo> buildSourceSchemaEntity(final Schema schema) {
-    return buildSchemaEntity(schema).getFields()
+  public static List<FieldInfo> buildSourceSchemaEntity(final KsqlSchema schema) {
+    return buildSchemaEntity(schema.getSchema()).getFields()
         .orElseThrow(() -> new RuntimeException("Root schema should contain fields"));
   }
 

--- a/ksql-rest-app/src/test/java/io/confluent/ksql/rest/entity/QueryDescriptionTest.java
+++ b/ksql-rest-app/src/test/java/io/confluent/ksql/rest/entity/QueryDescriptionTest.java
@@ -29,6 +29,7 @@ import io.confluent.ksql.physical.LimitHandler;
 import io.confluent.ksql.physical.QuerySchemas;
 import io.confluent.ksql.query.QueryId;
 import io.confluent.ksql.rest.entity.SchemaInfo.Type;
+import io.confluent.ksql.schema.ksql.KsqlSchema;
 import io.confluent.ksql.serde.json.KsqlJsonTopicSerDe;
 import io.confluent.ksql.util.PersistentQueryMetadata;
 import io.confluent.ksql.util.QueryMetadata;
@@ -42,7 +43,6 @@ import java.util.Map;
 import java.util.concurrent.LinkedBlockingQueue;
 import java.util.function.Consumer;
 import org.apache.kafka.common.serialization.Serdes;
-import org.apache.kafka.connect.data.Schema;
 import org.apache.kafka.connect.data.SchemaBuilder;
 import org.apache.kafka.streams.KafkaStreams;
 import org.apache.kafka.streams.Topology;
@@ -56,11 +56,11 @@ import org.mockito.junit.MockitoJUnitRunner;
 @RunWith(MockitoJUnitRunner.class)
 public class QueryDescriptionTest {
 
-  private static final Schema SCHEMA =
+  private static final KsqlSchema SCHEMA = KsqlSchema.of(
       SchemaBuilder.struct()
           .field("field1", SchemaBuilder.int32().build())
           .field("field2", SchemaBuilder.string().build())
-          .build();
+          .build());
 
   private static final List<FieldInfo> EXPECTED_FIELDS = Arrays.asList(
       new FieldInfo("field1", new SchemaInfo(Type.INTEGER, null, null)),

--- a/ksql-rest-app/src/test/java/io/confluent/ksql/rest/entity/SourceDescriptionTest.java
+++ b/ksql-rest-app/src/test/java/io/confluent/ksql/rest/entity/SourceDescriptionTest.java
@@ -25,6 +25,7 @@ import io.confluent.ksql.metastore.model.KsqlStream;
 import io.confluent.ksql.metastore.model.KsqlTopic;
 import io.confluent.ksql.metrics.ConsumerCollector;
 import io.confluent.ksql.metrics.StreamsErrorCollector;
+import io.confluent.ksql.schema.ksql.KsqlSchema;
 import io.confluent.ksql.serde.json.KsqlJsonTopicSerDe;
 import io.confluent.ksql.util.timestamp.MetadataTimestampExtractionPolicy;
 import java.util.Arrays;
@@ -61,9 +62,9 @@ public class SourceDescriptionTest {
   }
 
   private DataSource<?> buildDataSource(final String kafkaTopicName) {
-    final Schema schema = SchemaBuilder.struct()
+    final KsqlSchema schema = KsqlSchema.of(SchemaBuilder.struct()
         .field("field0", Schema.OPTIONAL_INT32_SCHEMA)
-        .build();
+        .build());
     final KsqlTopic topic = new KsqlTopic("internal", kafkaTopicName, new KsqlJsonTopicSerDe(), true);
     return new KsqlStream<>(
         "query", "stream", schema,

--- a/ksql-rest-app/src/test/java/io/confluent/ksql/rest/server/StandaloneExecutorFunctionalTest.java
+++ b/ksql-rest-app/src/test/java/io/confluent/ksql/rest/server/StandaloneExecutorFunctionalTest.java
@@ -23,6 +23,7 @@ import com.google.common.collect.ImmutableMap;
 import io.confluent.common.utils.IntegrationTest;
 import io.confluent.ksql.integration.IntegrationTestHarness;
 import io.confluent.ksql.rest.server.computation.ConfigStore;
+import io.confluent.ksql.schema.ksql.KsqlSchema;
 import io.confluent.ksql.services.ServiceContext;
 import io.confluent.ksql.services.TestServiceContext;
 import io.confluent.ksql.test.util.KsqlIdentifierTestUtil;
@@ -69,7 +70,7 @@ public class StandaloneExecutorFunctionalTest {
   private static final String AVRO_TOPIC = "avro-topic";
   private static final String JSON_TOPIC = "json-topic";
   private static int DATA_SIZE;
-  private static Schema DATA_SCHEMA;
+  private static KsqlSchema DATA_SCHEMA;
 
   @Mock
   private VersionCheckerAgent versionChecker;
@@ -278,9 +279,9 @@ public class StandaloneExecutorFunctionalTest {
   }
 
   private static void givenIncompatibleSchemaExists(final String topicName) {
-    final Schema incompatible = SchemaBuilder.struct()
+    final KsqlSchema incompatible = KsqlSchema.of(SchemaBuilder.struct()
         .field("ORDERID", Schema.INT64_SCHEMA)
-        .build();
+        .build());
 
     TEST_HARNESS.ensureSchema(topicName, incompatible);
   }

--- a/ksql-rest-app/src/test/java/io/confluent/ksql/rest/server/TemporaryEngine.java
+++ b/ksql-rest-app/src/test/java/io/confluent/ksql/rest/server/TemporaryEngine.java
@@ -32,6 +32,7 @@ import io.confluent.ksql.metastore.model.KsqlTable;
 import io.confluent.ksql.metastore.model.KsqlTopic;
 import io.confluent.ksql.parser.DefaultKsqlParser;
 import io.confluent.ksql.query.QueryId;
+import io.confluent.ksql.schema.ksql.KsqlSchema;
 import io.confluent.ksql.serde.json.KsqlJsonTopicSerDe;
 import io.confluent.ksql.services.FakeKafkaTopicClient;
 import io.confluent.ksql.services.ServiceContext;
@@ -52,8 +53,9 @@ import org.junit.rules.ExternalResource;
 
 public class TemporaryEngine extends ExternalResource {
 
-  public static final Schema SCHEMA =
-      SchemaBuilder.struct().field("val", Schema.OPTIONAL_STRING_SCHEMA).build();
+  public static final KsqlSchema SCHEMA = KsqlSchema.of(SchemaBuilder.struct()
+      .field("val", Schema.OPTIONAL_STRING_SCHEMA)
+      .build());
 
   private MutableMetaStore metaStore;
 
@@ -96,14 +98,14 @@ public class TemporaryEngine extends ExternalResource {
         source =
             new KsqlStream<>(
                 "statement", name, SCHEMA,
-                KeyField.of("val", SCHEMA.field("val")),
+                KeyField.of("val", SCHEMA.getSchema().field("val")),
                 new MetadataTimestampExtractionPolicy(), topic, Serdes::String);
         break;
       case KTABLE:
         source =
             new KsqlTable<>(
                 "statement", name, SCHEMA,
-                KeyField.of("val", SCHEMA.field("val")),
+                KeyField.of("val", SCHEMA.getSchema().field("val")),
                 new MetadataTimestampExtractionPolicy(), topic, Serdes::String);
         break;
       default:
@@ -134,7 +136,7 @@ public class TemporaryEngine extends ExternalResource {
   }
 
   @SuppressWarnings("SameParameterValue")
-  public PersistentQueryMetadata givenPersistentQuery(final String id) {
+  public static PersistentQueryMetadata givenPersistentQuery(final String id) {
     final PersistentQueryMetadata metadata = mock(PersistentQueryMetadata.class);
     when(metadata.getQueryId()).thenReturn(new QueryId(id));
     when(metadata.getSinkNames()).thenReturn(ImmutableSet.of(id));

--- a/ksql-rest-app/src/test/java/io/confluent/ksql/rest/server/computation/RecoveryTest.java
+++ b/ksql-rest-app/src/test/java/io/confluent/ksql/rest/server/computation/RecoveryTest.java
@@ -42,6 +42,7 @@ import io.confluent.ksql.rest.server.resources.KsqlResource;
 import io.confluent.ksql.rest.util.ClusterTerminator;
 import io.confluent.ksql.schema.inference.DefaultSchemaInjector;
 import io.confluent.ksql.schema.inference.SchemaRegistryTopicSchemaSupplier;
+import io.confluent.ksql.schema.ksql.KsqlSchema;
 import io.confluent.ksql.serde.KsqlTopicSerDe;
 import io.confluent.ksql.services.FakeKafkaTopicClient;
 import io.confluent.ksql.services.ServiceContext;
@@ -65,7 +66,6 @@ import java.util.Optional;
 import java.util.Set;
 import java.util.stream.Collectors;
 import javax.ws.rs.core.Response;
-import org.apache.kafka.connect.data.Schema;
 import org.hamcrest.Description;
 import org.hamcrest.Matcher;
 import org.hamcrest.TypeSafeDiagnosingMatcher;
@@ -276,7 +276,7 @@ public class RecoveryTest {
     final DataSource<?> source;
     final Matcher<DataSource.DataSourceType> typeMatcher;
     final Matcher<String> nameMatcher;
-    final Matcher<Schema> schemaMatcher;
+    final Matcher<KsqlSchema> schemaMatcher;
     final Matcher<String> sqlMatcher;
     final Matcher<TimestampExtractionPolicy> extractionPolicyMatcher;
     final Matcher<KsqlTopic> topicMatcher;
@@ -408,7 +408,7 @@ public class RecoveryTest {
       extends TypeSafeDiagnosingMatcher<PersistentQueryMetadata> {
     private final Matcher<Set<String>> sourcesNamesMatcher;
     private final Matcher<Set<String>> sinkNamesMatcher;
-    private final Matcher<Schema> resultSchemaMatcher;
+    private final Matcher<KsqlSchema> resultSchemaMatcher;
     private final Matcher<String> sqlMatcher;
     private final Matcher<String> stateMatcher;
 

--- a/ksql-rest-app/src/test/java/io/confluent/ksql/rest/server/execution/ExplainExecutorTest.java
+++ b/ksql-rest-app/src/test/java/io/confluent/ksql/rest/server/execution/ExplainExecutorTest.java
@@ -48,7 +48,7 @@ public class ExplainExecutorTest {
   public void shouldExplainQueryId() {
     // Given:
     final ConfiguredStatement<?> explain = engine.configure("EXPLAIN id;");
-    final PersistentQueryMetadata metadata = engine.givenPersistentQuery("id");
+    final PersistentQueryMetadata metadata = TemporaryEngine.givenPersistentQuery("id");
 
     KsqlEngine engine = mock(KsqlEngine.class);
     when(engine.getPersistentQuery(metadata.getQueryId())).thenReturn(Optional.of(metadata));

--- a/ksql-rest-app/src/test/java/io/confluent/ksql/rest/server/execution/InsertValuesExecutorTest.java
+++ b/ksql-rest-app/src/test/java/io/confluent/ksql/rest/server/execution/InsertValuesExecutorTest.java
@@ -43,6 +43,7 @@ import io.confluent.ksql.parser.tree.QualifiedName;
 import io.confluent.ksql.parser.tree.StringLiteral;
 import io.confluent.ksql.parser.tree.Struct;
 import io.confluent.ksql.parser.tree.Type.SqlType;
+import io.confluent.ksql.schema.ksql.KsqlSchema;
 import io.confluent.ksql.serde.KsqlTopicSerDe;
 import io.confluent.ksql.services.ServiceContext;
 import io.confluent.ksql.statement.ConfiguredStatement;
@@ -72,21 +73,21 @@ import org.mockito.junit.MockitoJUnitRunner;
 @RunWith(MockitoJUnitRunner.class)
 public class InsertValuesExecutorTest {
 
-  private static final Schema SCHEMA = SchemaBuilder.struct()
+  private static final KsqlSchema SCHEMA = KsqlSchema.of(SchemaBuilder.struct()
       .field("ROWTIME", Schema.OPTIONAL_INT64_SCHEMA)
       .field("ROWKEY", Schema.OPTIONAL_INT64_SCHEMA)
       .field("COL0", Schema.OPTIONAL_INT64_SCHEMA)
       .field("COL1", Schema.OPTIONAL_STRING_SCHEMA)
-      .build();
+      .build());
 
-  private static final Schema STRICT_SCHEMA = SchemaBuilder.struct()
+  private static final KsqlSchema STRICT_SCHEMA = KsqlSchema.of(SchemaBuilder.struct()
       .field("ROWTIME", Schema.INT64_SCHEMA)
       .field("ROWKEY", Schema.INT64_SCHEMA)
       .field("COL0", Schema.OPTIONAL_INT64_SCHEMA)
       .field("COL1", Schema.STRING_SCHEMA)
-      .build();
+      .build());
 
-  private static final Schema BIG_SCHEMA = SchemaBuilder.struct()
+  private static final KsqlSchema BIG_SCHEMA = KsqlSchema.of(SchemaBuilder.struct()
       .field("ROWTIME", Schema.OPTIONAL_INT64_SCHEMA)
       .field("ROWKEY", Schema.OPTIONAL_INT64_SCHEMA)
       .field("INT", Schema.OPTIONAL_INT32_SCHEMA)
@@ -94,7 +95,7 @@ public class InsertValuesExecutorTest {
       .field("DOUBLE", Schema.OPTIONAL_FLOAT64_SCHEMA)
       .field("BOOLEAN", Schema.OPTIONAL_BOOLEAN_SCHEMA)
       .field("VARCHAR", Schema.OPTIONAL_STRING_SCHEMA)
-      .build();
+      .build());
 
   private static final byte[] KEY = new byte[]{1};
   private static final byte[] VALUE = new byte[]{2};
@@ -482,13 +483,13 @@ public class InsertValuesExecutorTest {
     );
   }
 
-  private void givenDataSourceWithSchema(final Schema schema) {
+  private void givenDataSourceWithSchema(final KsqlSchema schema) {
     final KsqlTopic topic = new KsqlTopic("TOPIC", TOPIC_NAME, topicSerDe, false);
     final DataSource<?> dataSource = new KsqlStream<>(
         "",
         "TOPIC",
         schema,
-        KeyField.of(Optional.of("COL0"), Optional.of(schema.field("COL0"))),
+        KeyField.of(Optional.of("COL0"), Optional.of(schema.getSchema().field("COL0"))),
         new MetadataTimestampExtractionPolicy(),
         topic,
         () -> keySerDe

--- a/ksql-rest-app/src/test/java/io/confluent/ksql/rest/server/execution/ListQueriesExecutorTest.java
+++ b/ksql-rest-app/src/test/java/io/confluent/ksql/rest/server/execution/ListQueriesExecutorTest.java
@@ -23,7 +23,6 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
 import com.google.common.collect.ImmutableList;
-import com.google.common.collect.ImmutableMap;
 import io.confluent.ksql.engine.KsqlEngine;
 import io.confluent.ksql.rest.entity.EntityQueryId;
 import io.confluent.ksql.rest.entity.Queries;
@@ -59,7 +58,7 @@ public class ListQueriesExecutorTest {
   public void shouldListQueriesBasic() {
     // Given
     final ConfiguredStatement<?> showQueries = engine.configure("SHOW QUERIES;");
-    final PersistentQueryMetadata metadata = engine.givenPersistentQuery("id");
+    final PersistentQueryMetadata metadata = TemporaryEngine.givenPersistentQuery("id");
 
     final KsqlEngine engine = mock(KsqlEngine.class);
     when(engine.getPersistentQueries()).thenReturn(ImmutableList.of(metadata));
@@ -82,7 +81,7 @@ public class ListQueriesExecutorTest {
   public void shouldListQueriesExtended() {
     // Given
     final ConfiguredStatement<?> showQueries = engine.configure("SHOW QUERIES EXTENDED;");
-    final PersistentQueryMetadata metadata = engine.givenPersistentQuery("id");
+    final PersistentQueryMetadata metadata = TemporaryEngine.givenPersistentQuery("id");
 
     final KsqlEngine engine = mock(KsqlEngine.class);
     when(engine.getPersistentQueries()).thenReturn(ImmutableList.of(metadata));

--- a/ksql-rest-app/src/test/java/io/confluent/ksql/rest/server/resources/KsqlResourceTest.java
+++ b/ksql-rest-app/src/test/java/io/confluent/ksql/rest/server/resources/KsqlResourceTest.java
@@ -114,6 +114,7 @@ import io.confluent.ksql.rest.server.computation.CommandStore;
 import io.confluent.ksql.rest.server.computation.QueuedCommandStatus;
 import io.confluent.ksql.rest.util.EntityUtil;
 import io.confluent.ksql.rest.util.TerminateCluster;
+import io.confluent.ksql.schema.ksql.KsqlSchema;
 import io.confluent.ksql.serde.json.KsqlJsonTopicSerDe;
 import io.confluent.ksql.services.FakeKafkaTopicClient;
 import io.confluent.ksql.services.SandboxedServiceContext;
@@ -177,8 +178,9 @@ public class KsqlResourceTest {
       "CREATE STREAM S AS SELECT * FROM test_stream;",
       ImmutableMap.of(ConsumerConfig.AUTO_OFFSET_RESET_CONFIG, "earliest"),
       0L);
-  private static final Schema SINGLE_FIELD_SCHEMA = SchemaBuilder.struct()
-      .field("val", Schema.OPTIONAL_STRING_SCHEMA);
+  private static final KsqlSchema SINGLE_FIELD_SCHEMA = KsqlSchema.of(SchemaBuilder.struct()
+      .field("val", Schema.OPTIONAL_STRING_SCHEMA)
+      .build());
 
   private static final ClusterTerminateRequest VALID_TERMINATE_REQUEST =
       new ClusterTerminateRequest(ImmutableList.of("Foo"));
@@ -216,6 +218,10 @@ public class KsqlResourceTest {
       ImmutableMap.of(),
       new KsqlConfig(getDefaultKsqlConfig())
   );
+
+  private static final KsqlSchema SOME_SCHEMA = KsqlSchema.of(SchemaBuilder.struct()
+      .field("f1", Schema.OPTIONAL_STRING_SCHEMA)
+      .build());
 
   @Rule
   public final ExpectedException expectedException = ExpectedException.none();
@@ -372,9 +378,10 @@ public class KsqlResourceTest {
   @Test
   public void shouldShowStreamsExtended() {
     // Given:
-    final Schema schema = SchemaBuilder.struct()
+    final KsqlSchema schema = KsqlSchema.of(SchemaBuilder.struct()
         .field("FIELD1", Schema.OPTIONAL_BOOLEAN_SCHEMA)
-        .field("FIELD2", Schema.OPTIONAL_STRING_SCHEMA);
+        .field("FIELD2", Schema.OPTIONAL_STRING_SCHEMA)
+        .build());
 
     givenSource(
         DataSourceType.KSTREAM, "new_stream", "new_topic",
@@ -399,9 +406,10 @@ public class KsqlResourceTest {
   @Test
   public void shouldShowTablesExtended() {
     // Given:
-    final Schema schema = SchemaBuilder.struct()
+    final KsqlSchema schema = KsqlSchema.of(SchemaBuilder.struct()
         .field("FIELD1", Schema.OPTIONAL_BOOLEAN_SCHEMA)
-        .field("FIELD2", Schema.OPTIONAL_STRING_SCHEMA);
+        .field("FIELD2", Schema.OPTIONAL_STRING_SCHEMA)
+        .build());
 
     givenSource(
         DataSourceType.KTABLE, "new_table", "new_topic",
@@ -686,9 +694,8 @@ public class KsqlResourceTest {
   @Test
   public void shouldSupportTopicInferenceInVerification() {
     // Given:
-    final Schema schema = SchemaBuilder.struct().field("f1", Schema.OPTIONAL_STRING_SCHEMA).build();
     givenMockEngine();
-    givenSource(DataSourceType.KSTREAM, "ORDERS1", "ORDERS1", "ORDERS1", schema);
+    givenSource(DataSourceType.KSTREAM, "ORDERS1", "ORDERS1", "ORDERS1", SOME_SCHEMA);
 
     final String sql = "CREATE STREAM orders2 AS SELECT * FROM orders1;";
     final String sqlWithTopic = "CREATE STREAM orders2 WITH(kafka_topic='orders2') AS SELECT * FROM orders1;";
@@ -712,9 +719,8 @@ public class KsqlResourceTest {
   @Test
   public void shouldSupportTopicInferenceInExecution() {
     // Given:
-    final Schema schema = SchemaBuilder.struct().field("f1", Schema.OPTIONAL_STRING_SCHEMA).build();
     givenMockEngine();
-    givenSource(DataSourceType.KSTREAM, "ORDERS1", "ORDERS1", "ORDERS1", schema);
+    givenSource(DataSourceType.KSTREAM, "ORDERS1", "ORDERS1", "ORDERS1", SOME_SCHEMA);
 
     final String sql = "CREATE STREAM orders2 AS SELECT * FROM orders1;";
     final String sqlWithTopic = "CREATE STREAM orders2 WITH(kafka_topic='orders2') AS SELECT * FROM orders1;";
@@ -737,8 +743,7 @@ public class KsqlResourceTest {
   @Test
   public void shouldFailWhenTopicInferenceFailsDuringValidate() {
     // Given:
-    final Schema schema = SchemaBuilder.struct().field("f1", Schema.OPTIONAL_STRING_SCHEMA).build();
-    givenSource(DataSourceType.KSTREAM, "ORDERS1", "ORDERS1", "ORDERS1", schema);
+    givenSource(DataSourceType.KSTREAM, "ORDERS1", "ORDERS1", "ORDERS1", SOME_SCHEMA);
     when(sandboxTopicInjector.inject(any()))
         .thenThrow(new KsqlStatementException("boom", "sql"));
 
@@ -755,8 +760,7 @@ public class KsqlResourceTest {
   @Test
   public void shouldFailWhenTopicInferenceFailsDuringExecute() {
     // Given:
-    final Schema schema = SchemaBuilder.struct().field("f1", Schema.OPTIONAL_STRING_SCHEMA).build();
-    givenSource(DataSourceType.KSTREAM, "ORDERS1", "ORDERS1", "ORDERS1", schema);
+    givenSource(DataSourceType.KSTREAM, "ORDERS1", "ORDERS1", "ORDERS1", SOME_SCHEMA);
 
     when(topicInjector.inject(any()))
         .thenThrow(new KsqlStatementException("boom", "some-sql"));
@@ -1917,11 +1921,13 @@ public class KsqlResourceTest {
   }
 
   private void addTestTopicAndSources() {
-    final Schema schema1 = SchemaBuilder.struct().field("S1_F1", Schema.OPTIONAL_BOOLEAN_SCHEMA);
+    final KsqlSchema schema1 = KsqlSchema.of(
+        SchemaBuilder.struct().field("S1_F1", Schema.OPTIONAL_BOOLEAN_SCHEMA));
     givenSource(
         DataSourceType.KTABLE,
         "TEST_TABLE", "KAFKA_TOPIC_1", "KSQL_TOPIC_1", schema1);
-    final Schema schema2 = SchemaBuilder.struct().field("S2_F1", Schema.OPTIONAL_STRING_SCHEMA);
+    final KsqlSchema schema2 = KsqlSchema.of(
+        SchemaBuilder.struct().field("S2_F1", Schema.OPTIONAL_STRING_SCHEMA));
     givenSource(
         DataSourceType.KSTREAM,
         "TEST_STREAM", "KAFKA_TOPIC_2", "KSQL_TOPIC_2", schema2);
@@ -1933,7 +1939,7 @@ public class KsqlResourceTest {
       final String sourceName,
       final String topicName,
       final String ksqlTopicName,
-      final Schema schema
+      final KsqlSchema schema
   ) {
     if (metaStore.getTopic(ksqlTopicName) != null) {
       return;

--- a/ksql-rest-app/src/test/java/io/confluent/ksql/rest/server/resources/KsqlResourceTest.java
+++ b/ksql-rest-app/src/test/java/io/confluent/ksql/rest/server/resources/KsqlResourceTest.java
@@ -1921,13 +1921,18 @@ public class KsqlResourceTest {
   }
 
   private void addTestTopicAndSources() {
-    final KsqlSchema schema1 = KsqlSchema.of(
-        SchemaBuilder.struct().field("S1_F1", Schema.OPTIONAL_BOOLEAN_SCHEMA));
+    final KsqlSchema schema1 = KsqlSchema.of(SchemaBuilder.struct()
+            .field("S1_F1", Schema.OPTIONAL_BOOLEAN_SCHEMA)
+            .build());
+
     givenSource(
         DataSourceType.KTABLE,
         "TEST_TABLE", "KAFKA_TOPIC_1", "KSQL_TOPIC_1", schema1);
-    final KsqlSchema schema2 = KsqlSchema.of(
-        SchemaBuilder.struct().field("S2_F1", Schema.OPTIONAL_STRING_SCHEMA));
+
+    final KsqlSchema schema2 = KsqlSchema.of(SchemaBuilder.struct()
+        .field("S2_F1", Schema.OPTIONAL_STRING_SCHEMA)
+        .build());
+
     givenSource(
         DataSourceType.KSTREAM,
         "TEST_STREAM", "KAFKA_TOPIC_2", "KSQL_TOPIC_2", schema2);

--- a/ksql-rest-app/src/test/java/io/confluent/ksql/rest/server/resources/StreamedQueryResourceTest.java
+++ b/ksql-rest-app/src/test/java/io/confluent/ksql/rest/server/resources/StreamedQueryResourceTest.java
@@ -53,6 +53,7 @@ import io.confluent.ksql.rest.entity.StreamedRow;
 import io.confluent.ksql.rest.server.StatementParser;
 import io.confluent.ksql.rest.server.computation.CommandQueue;
 import io.confluent.ksql.rest.server.resources.streaming.StreamedQueryResource;
+import io.confluent.ksql.schema.ksql.KsqlSchema;
 import io.confluent.ksql.services.KafkaTopicClient;
 import io.confluent.ksql.services.ServiceContext;
 import io.confluent.ksql.statement.ConfiguredStatement;
@@ -76,7 +77,6 @@ import java.util.function.Consumer;
 import javax.ws.rs.core.Response;
 import javax.ws.rs.core.Response.Status;
 import javax.ws.rs.core.StreamingOutput;
-import org.apache.kafka.connect.data.Schema;
 import org.apache.kafka.connect.data.SchemaBuilder;
 import org.apache.kafka.streams.KafkaStreams;
 import org.apache.kafka.streams.KeyValue;
@@ -97,9 +97,9 @@ public class StreamedQueryResourceTest {
 
   private static final Duration DISCONNECT_CHECK_INTERVAL = Duration.ofMillis(1000);
   private static final Duration COMMAND_QUEUE_CATCHUP_TIMOEUT = Duration.ofMillis(1000);
-  private static final Schema SOME_SCHEMA = SchemaBuilder.struct()
+  private static final KsqlSchema SOME_SCHEMA = KsqlSchema.of(SchemaBuilder.struct()
       .field("f1", SchemaBuilder.OPTIONAL_INT32_SCHEMA)
-      .build();
+      .build());
 
   @Rule
   public final ExpectedException expectedException = ExpectedException.none();

--- a/ksql-rest-app/src/test/java/io/confluent/ksql/rest/server/resources/streaming/PollingSubscriptionTest.java
+++ b/ksql-rest-app/src/test/java/io/confluent/ksql/rest/server/resources/streaming/PollingSubscriptionTest.java
@@ -27,10 +27,12 @@ import com.google.common.util.concurrent.MoreExecutors;
 import io.confluent.ksql.rest.server.resources.streaming.Flow.Subscriber;
 import io.confluent.ksql.rest.server.resources.streaming.Flow.Subscription;
 import io.confluent.ksql.rest.server.resources.streaming.StreamingTestUtils.TestSubscriber;
+import io.confluent.ksql.schema.ksql.KsqlSchema;
 import java.util.Queue;
 import java.util.concurrent.Executors;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.TimeUnit;
+import org.apache.kafka.connect.data.Schema;
 import org.apache.kafka.connect.data.SchemaBuilder;
 import org.junit.Test;
 
@@ -59,12 +61,17 @@ public class PollingSubscriptionTest {
     boolean closed;
     Queue<String> queue = Lists.newLinkedList(ELEMENTS);
 
-    public TestPollingSubscription(
-        final Subscriber<String> subscriber, final ScheduledExecutorService exec) {
+    TestPollingSubscription(
+        final Subscriber<String> subscriber,
+        final ScheduledExecutorService exec
+    ) {
       super(
           MoreExecutors.listeningDecorator(exec),
           subscriber,
-          SchemaBuilder.OPTIONAL_STRING_SCHEMA
+          KsqlSchema.of(SchemaBuilder
+              .struct()
+              .field("f0", Schema.OPTIONAL_STRING_SCHEMA)
+              .build())
       );
     }
 

--- a/ksql-rest-app/src/test/java/io/confluent/ksql/rest/server/resources/streaming/QueryStreamWriterTest.java
+++ b/ksql-rest-app/src/test/java/io/confluent/ksql/rest/server/resources/streaming/QueryStreamWriterTest.java
@@ -32,6 +32,7 @@ import io.confluent.ksql.GenericRow;
 import io.confluent.ksql.engine.KsqlEngine;
 import io.confluent.ksql.json.JsonMapper;
 import io.confluent.ksql.physical.LimitHandler;
+import io.confluent.ksql.schema.ksql.KsqlSchema;
 import io.confluent.ksql.util.KsqlException;
 import io.confluent.ksql.util.QueuedQueryMetadata;
 import java.io.ByteArrayOutputStream;
@@ -91,7 +92,9 @@ public class QueryStreamWriterTest {
     drainCapture = newCapture();
     limitHandlerCapture = newCapture();
 
-    final Schema schema = SchemaBuilder.struct().field("col1", Schema.OPTIONAL_STRING_SCHEMA).build();
+    final KsqlSchema schema = KsqlSchema.of(SchemaBuilder.struct()
+        .field("col1", Schema.OPTIONAL_STRING_SCHEMA)
+        .build());
 
     final KafkaStreams kStreams = niceMock(KafkaStreams.class);
 

--- a/ksql-rest-app/src/test/java/io/confluent/ksql/rest/server/resources/streaming/StreamingTestUtils.java
+++ b/ksql-rest-app/src/test/java/io/confluent/ksql/rest/server/resources/streaming/StreamingTestUtils.java
@@ -23,6 +23,7 @@ import io.confluent.ksql.parser.tree.PrintTopic;
 import io.confluent.ksql.parser.tree.QualifiedName;
 import io.confluent.ksql.rest.server.resources.streaming.Flow.Subscriber;
 import io.confluent.ksql.rest.server.resources.streaming.Flow.Subscription;
+import io.confluent.ksql.schema.ksql.KsqlSchema;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.Iterator;
@@ -37,7 +38,6 @@ import org.apache.kafka.clients.consumer.ConsumerRecord;
 import org.apache.kafka.clients.consumer.ConsumerRecords;
 import org.apache.kafka.common.TopicPartition;
 import org.apache.kafka.common.utils.Bytes;
-import org.apache.kafka.connect.data.Schema;
 
 class StreamingTestUtils {
 
@@ -95,7 +95,7 @@ class StreamingTestUtils {
     CountDownLatch done = new CountDownLatch(1);
     Throwable error = null;
     List<T> elements = Lists.newLinkedList();
-    Schema schema = null;
+    KsqlSchema schema = null;
     Subscription subscription;
 
     @Override
@@ -125,7 +125,7 @@ class StreamingTestUtils {
     }
 
     @Override
-    public void onSchema(final Schema s) {
+    public void onSchema(final KsqlSchema s) {
       if (done.getCount() == 0) {
         throw new IllegalStateException("already done");
       }

--- a/ksql-rest-app/src/test/java/io/confluent/ksql/rest/server/resources/streaming/WebSocketSubscriberTest.java
+++ b/ksql-rest-app/src/test/java/io/confluent/ksql/rest/server/resources/streaming/WebSocketSubscriberTest.java
@@ -120,8 +120,8 @@ public class WebSocketSubscriberTest {
     EasyMock.replay(subscription, session, basic);
 
     subscriber.onSchema(KsqlSchema.of(SchemaBuilder.struct()
-        .field("currency", Schema.STRING_SCHEMA)
-        .field("amount", Schema.OPTIONAL_FLOAT32_SCHEMA)
+        .field("currency", Schema.OPTIONAL_STRING_SCHEMA)
+        .field("amount", Schema.OPTIONAL_FLOAT64_SCHEMA)
         .build()));
 
     subscriber.close();

--- a/ksql-rest-app/src/test/java/io/confluent/ksql/rest/server/resources/streaming/WebSocketSubscriberTest.java
+++ b/ksql-rest-app/src/test/java/io/confluent/ksql/rest/server/resources/streaming/WebSocketSubscriberTest.java
@@ -22,6 +22,7 @@ import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import io.confluent.ksql.json.JsonMapper;
 import io.confluent.ksql.rest.server.resources.streaming.Flow.Subscription;
+import io.confluent.ksql.schema.ksql.KsqlSchema;
 import java.io.IOException;
 import java.util.Map;
 import javax.websocket.CloseReason;
@@ -118,11 +119,11 @@ public class WebSocketSubscriberTest {
 
     EasyMock.replay(subscription, session, basic);
 
-    subscriber.onSchema(SchemaBuilder
-                            .struct()
+    subscriber.onSchema(KsqlSchema.of(SchemaBuilder.struct()
         .field("currency", Schema.STRING_SCHEMA)
         .field("amount", Schema.OPTIONAL_FLOAT32_SCHEMA)
-                            .build());
+        .build()));
+
     subscriber.close();
 
     assertEquals(

--- a/ksql-rest-app/src/test/java/io/confluent/ksql/rest/server/validation/RequestValidatorTest.java
+++ b/ksql-rest-app/src/test/java/io/confluent/ksql/rest/server/validation/RequestValidatorTest.java
@@ -41,6 +41,7 @@ import io.confluent.ksql.parser.tree.CreateStream;
 import io.confluent.ksql.parser.tree.Explain;
 import io.confluent.ksql.parser.tree.SetProperty;
 import io.confluent.ksql.parser.tree.Statement;
+import io.confluent.ksql.schema.ksql.KsqlSchema;
 import io.confluent.ksql.services.SandboxedServiceContext;
 import io.confluent.ksql.services.ServiceContext;
 import io.confluent.ksql.services.TestServiceContext;
@@ -67,8 +68,10 @@ import org.mockito.junit.MockitoJUnitRunner;
 @RunWith(MockitoJUnitRunner.class)
 public class RequestValidatorTest {
 
-  private static final Schema SCHEMA =
-      SchemaBuilder.struct().field("val", Schema.OPTIONAL_STRING_SCHEMA).build();
+  private static final KsqlSchema SCHEMA = KsqlSchema.of(SchemaBuilder
+      .struct()
+      .field("val", Schema.OPTIONAL_STRING_SCHEMA)
+      .build());
 
   @Rule
   public ExpectedException expectedException = ExpectedException.none();

--- a/ksql-rest-app/src/test/java/io/confluent/ksql/rest/server/validation/TerminateQueryValidatorTest.java
+++ b/ksql-rest-app/src/test/java/io/confluent/ksql/rest/server/validation/TerminateQueryValidatorTest.java
@@ -61,7 +61,7 @@ public class TerminateQueryValidatorTest {
   @Test
   public void shouldValidateKnownQueryId() {
     // Given:
-    final PersistentQueryMetadata metadata = engine.givenPersistentQuery("id");
+    final PersistentQueryMetadata metadata = TemporaryEngine.givenPersistentQuery("id");
     final KsqlEngine mockEngine = mock(KsqlEngine.class);
     when(mockEngine.getPersistentQuery(any())).thenReturn(Optional.ofNullable(metadata));
 

--- a/ksql-rest-app/src/test/java/io/confluent/ksql/rest/util/EntityUtilTest.java
+++ b/ksql-rest-app/src/test/java/io/confluent/ksql/rest/util/EntityUtilTest.java
@@ -75,7 +75,9 @@ public class EntityUtilTest {
     // Given:
     final KsqlSchema schema = KsqlSchema.of(SchemaBuilder
         .struct()
-        .field("field", SchemaBuilder.map(Schema.STRING_SCHEMA, Schema.INT32_SCHEMA))
+        .field("field", SchemaBuilder
+            .map(Schema.OPTIONAL_STRING_SCHEMA, Schema.OPTIONAL_INT32_SCHEMA)
+            .build())
         .build());
 
     // When:
@@ -94,7 +96,9 @@ public class EntityUtilTest {
     // Given:
     final KsqlSchema schema = KsqlSchema.of(SchemaBuilder
         .struct()
-        .field("field", SchemaBuilder.array(SchemaBuilder.INT64_SCHEMA))
+        .field("field", SchemaBuilder
+            .array(SchemaBuilder.OPTIONAL_INT64_SCHEMA)
+            .build())
         .build());
 
     // When:

--- a/ksql-rest-app/src/test/java/io/confluent/ksql/rest/util/EntityUtilTest.java
+++ b/ksql-rest-app/src/test/java/io/confluent/ksql/rest/util/EntityUtilTest.java
@@ -19,6 +19,7 @@ import static org.hamcrest.CoreMatchers.equalTo;
 import static org.junit.Assert.assertThat;
 
 import io.confluent.ksql.rest.entity.FieldInfo;
+import io.confluent.ksql.schema.ksql.KsqlSchema;
 import java.util.List;
 import java.util.Optional;
 import org.apache.kafka.connect.data.Schema;
@@ -26,12 +27,14 @@ import org.apache.kafka.connect.data.SchemaBuilder;
 import org.junit.Test;
 
 public class EntityUtilTest {
-  private void shouldBuildCorrectPrimitiveField(final Schema primitiveSchema,
-                                                final String schemaName) {
-    final Schema schema = SchemaBuilder
+  private static void shouldBuildCorrectPrimitiveField(
+      final Schema primitiveSchema,
+      final String schemaName
+  ) {
+    final KsqlSchema schema = KsqlSchema.of(SchemaBuilder
         .struct()
         .field("field", primitiveSchema)
-        .build();
+        .build());
 
     final List<FieldInfo> entity = EntityUtil.buildSourceSchemaEntity(schema);
 
@@ -69,13 +72,16 @@ public class EntityUtilTest {
 
   @Test
   public void shouldBuildCorrectMapField() {
-    final Schema schema = SchemaBuilder
+    // Given:
+    final KsqlSchema schema = KsqlSchema.of(SchemaBuilder
         .struct()
         .field("field", SchemaBuilder.map(Schema.STRING_SCHEMA, Schema.INT32_SCHEMA))
-        .build();
+        .build());
 
+    // When:
     final List<FieldInfo> entity = EntityUtil.buildSourceSchemaEntity(schema);
 
+    // Then:
     assertThat(entity.size(), equalTo(1));
     assertThat(entity.get(0).getName(), equalTo("field"));
     assertThat(entity.get(0).getSchema().getTypeName(), equalTo("MAP"));
@@ -85,13 +91,16 @@ public class EntityUtilTest {
 
   @Test
   public void shouldBuildCorrectArrayField() {
-    final Schema schema = SchemaBuilder
+    // Given:
+    final KsqlSchema schema = KsqlSchema.of(SchemaBuilder
         .struct()
         .field("field", SchemaBuilder.array(SchemaBuilder.INT64_SCHEMA))
-        .build();
+        .build());
 
+    // When:
     final List<FieldInfo> entity = EntityUtil.buildSourceSchemaEntity(schema);
 
+    // Then:
     assertThat(entity.size(), equalTo(1));
     assertThat(entity.get(0).getName(), equalTo("field"));
     assertThat(entity.get(0).getSchema().getTypeName(), equalTo("ARRAY"));
@@ -101,7 +110,8 @@ public class EntityUtilTest {
 
   @Test
   public void shouldBuildCorrectStructField() {
-    final Schema schema = SchemaBuilder
+    // Given:
+    final KsqlSchema schema = KsqlSchema.of(SchemaBuilder
         .struct()
         .field(
             "field",
@@ -109,11 +119,12 @@ public class EntityUtilTest {
                 struct()
                 .field("innerField", Schema.STRING_SCHEMA)
                 .build())
-        .build();
+        .build());
 
-
+    // When:
     final List<FieldInfo> entity = EntityUtil.buildSourceSchemaEntity(schema);
 
+    // Then:
     assertThat(entity.size(), equalTo(1));
     assertThat(entity.get(0).getName(), equalTo("field"));
     assertThat(entity.get(0).getSchema().getTypeName(), equalTo("STRUCT"));
@@ -125,15 +136,17 @@ public class EntityUtilTest {
 
   @Test
   public void shouldBuildMiltipleFieldsCorrectly() {
-    final Schema schema = SchemaBuilder
+    // Given:
+    final KsqlSchema schema = KsqlSchema.of(SchemaBuilder
         .struct()
         .field("field1", Schema.INT32_SCHEMA)
         .field("field2", Schema.INT64_SCHEMA)
-        .build();
+        .build());
 
-
+    // When:
     final List<FieldInfo> entity = EntityUtil.buildSourceSchemaEntity(schema);
 
+    // Then:
     assertThat(entity.size(), equalTo(2));
     assertThat(entity.get(0).getName(), equalTo("field1"));
     assertThat(entity.get(0).getSchema().getTypeName(), equalTo("INTEGER"));

--- a/ksql-rest-app/src/test/java/io/confluent/ksql/rest/util/ProcessingLogServerUtilsTest.java
+++ b/ksql-rest-app/src/test/java/io/confluent/ksql/rest/util/ProcessingLogServerUtilsTest.java
@@ -50,7 +50,6 @@ import java.util.List;
 import java.util.Optional;
 import org.apache.kafka.connect.data.Field;
 import org.apache.kafka.connect.data.Schema;
-import org.apache.kafka.connect.data.Schema.Type;
 import org.junit.After;
 import org.junit.Rule;
 import org.junit.Test;
@@ -155,7 +154,6 @@ public class ProcessingLogServerUtilsTest {
     final Schema expected = ProcessingLogServerUtils.getMessageSchema();
     assertThat(stream.getKsqlTopicSerde(), instanceOf(KsqlJsonTopicSerDe.class));
     assertThat(stream.getKsqlTopic().getKafkaTopicName(), equalTo(topicName));
-    assertThat(stream.getSchema().type(), equalTo(Type.STRUCT));
     assertThat(
         stream.getSchema().fields().stream().map(Field::name).collect(toList()),
         equalTo(
@@ -172,7 +170,7 @@ public class ProcessingLogServerUtilsTest {
     expected.fields().forEach(
         f -> assertLogSchema(
             f.schema(),
-            stream.getSchema().field(f.name().toUpperCase()).schema(),
+            stream.getSchema().getSchema().field(f.name().toUpperCase()).schema(),
             ImmutableList.of(f.name())));
   }
 


### PR DESCRIPTION
### Description 

A preparatory PR for the structured keys work (#824) that switch KSQL over from internally passing around and storing schemas using the Connect `Schema` type to a KSQL specific `KsqlSchema`.

Some places, e.g. serde classes, still use the `Schema` type as they are dealing specifically with the _value_ only so don't need the key.

Internally, `KsqlSchema` still uses the Connect `Schema` type.  Later it will be enhanced to have the key schema as well. 

The PR tries to minimise code change as this is already a wide reaching PR.  The main changes are:

1. Switch KSQL from using `Schema` to `KsqlSchema` in most places in the code.
1. Moved code from `SchemaUtil` into `KsqlSchema` where it made sense. Note: this PR does not attempt to fix bugs or refactor the implementation of this methods.  That will come later.
1. A sneaky rename of two params to `JoinNode` that got missed on a previous PR.

### Testing done 

Lots more tests added around the `SchemaUtil` code that now lives in `KsqlSchema`.

### Reviewer checklist
- [ ] Ensure docs are updated if necessary. (eg. if a user visible feature is being added or changed).
- [ ] Ensure relevant issues are linked (description should include text like "Fixes #<issue number>")

