### PR TITLE
Don't use Scala file KafkaConfig for constants

### DIFF
--- a/ksql-engine/src/main/java/io/confluent/ksql/services/KafkaTopicClientImpl.java
+++ b/ksql-engine/src/main/java/io/confluent/ksql/services/KafkaTopicClientImpl.java
@@ -33,7 +33,6 @@ import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeUnit;
 import java.util.stream.Collectors;
 import javax.annotation.concurrent.ThreadSafe;
-import kafka.server.KafkaConfig;
 import org.apache.kafka.clients.admin.AdminClient;
 import org.apache.kafka.clients.admin.AlterConfigOp;
 import org.apache.kafka.clients.admin.Config;
@@ -60,7 +59,9 @@ public class KafkaTopicClientImpl implements KafkaTopicClient {
   // CHECKSTYLE_RULES.ON: ClassDataAbstractionCoupling
 
   private static final Logger LOG = LoggerFactory.getLogger(KafkaTopicClient.class);
-  private static final String DEFAULT_REPLICATION_PROP = KafkaConfig.DefaultReplicationFactorProp();
+
+  private static final String DEFAULT_REPLICATION_PROP = "default.replication.factor";
+  private static final String DELETE_TOPIC_ENABLE = "delete.topic.enable";
 
   private final AdminClient adminClient;
   private final boolean isDeleteTopicEnabled;
@@ -238,7 +239,7 @@ public class KafkaTopicClientImpl implements KafkaTopicClient {
       return;
     }
     if (!isDeleteTopicEnabled) {
-      LOG.info("Cannot delete topics since 'delete.topic.enable' is false. ");
+      LOG.info("Cannot delete topics since '" + DELETE_TOPIC_ENABLE + "' is false. ");
       return;
     }
     final DeleteTopicsResult deleteTopicsResult = adminClient.deleteTopics(topicsToDelete);
@@ -260,7 +261,7 @@ public class KafkaTopicClientImpl implements KafkaTopicClient {
   @Override
   public void deleteInternalTopics(final String applicationId) {
     if (!isDeleteTopicEnabled) {
-      LOG.warn("Cannot delete topics since 'delete.topic.enable' is false. ");
+      LOG.warn("Cannot delete topics since '" + DELETE_TOPIC_ENABLE + "' is false. ");
       return;
     }
     try {
@@ -283,7 +284,7 @@ public class KafkaTopicClientImpl implements KafkaTopicClient {
 
   private boolean isTopicDeleteEnabled() {
     try {
-      final ConfigEntry configEntry = getConfig().get(KafkaConfig.DeleteTopicEnableProp());
+      final ConfigEntry configEntry = getConfig().get(DELETE_TOPIC_ENABLE);
       // default to true if there is no entry
       return configEntry == null || Boolean.valueOf(configEntry.value());
     } catch (final Exception e) {


### PR DESCRIPTION
### Description 
Don't go through KafkaConfig constants... it appears to break deploying KSQL:
```
Exception in thread "main" java.lang.NoSuchMethodError: org.apache.kafka.common.config.ConfigDef.defineInternal(Ljava/lang/String;Lorg/apache/kafka/common/config/ConfigDef$Type;Ljava/lang/Object;Lorg/apache/kafka/common/config/ConfigDef$Importance;Ljava/lang/String;)Lorg/apache/kafka/common/config/ConfigDef;
	at kafka.server.KafkaConfig$.<init>(KafkaConfig.scala:1104)
	at kafka.server.KafkaConfig$.<clinit>(KafkaConfig.scala)
	at kafka.server.KafkaConfig.DeleteTopicEnableProp(KafkaConfig.scala)
	at io.confluent.ksql.services.KafkaTopicClientImpl.isTopicDeleteEnabled(KafkaTopicClientImpl.java:286)
	at io.confluent.ksql.services.KafkaTopicClientImpl.<init>(KafkaTopicClientImpl.java:75)
	at io.confluent.ksql.services.DefaultServiceContext.create(DefaultServiceContext.java:43)
	at io.confluent.ksql.rest.server.KsqlRestApplication.buildApplication(KsqlRestApplication.java:309)
	at io.confluent.ksql.rest.server.KsqlServerMain.createExecutable(KsqlServerMain.java:85)
	at io.confluent.ksql.rest.server.KsqlServerMain.main(KsqlServerMain.java:50)
```

### Testing done 
Local deploy

### Reviewer checklist
- [ ] Ensure docs are updated if necessary. (eg. if a user visible feature is being added or changed).
- [ ] Ensure relevant issues are linked (description should include text like "Fixes #<issue number>")

