### PR TITLE
CreateStream/Table will now create topics if they do not exist

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -19,6 +19,13 @@ KSQL 5.3.0 includes new features, including:
   This is required to avoid the potential for data loss should this step be dropped.
   See `Github issue #2636 <https://github.com/confluentinc/ksql/pull/2636>`_ for more info.
 
+* ``INSERT INTO ... VALUES`` is now supported, with standard SQL syntax to insert rows to existing
+  KSQL streams/tables. To disable this functionality, set ``ksql.insert.into.values.enabled`` to
+  ``false`` in the server properties.
+
+* ``CREATE STREAM`` and ``CREATE TABLE`` will now allow you to create the topic if it is missing.
+  To do this, specify the ``PARTITIONS`` and optionally ``REPLICAS`` in the ``WITH`` clause.
+
 
 KSQL 5.3.0 includes bug fixes, including:
 

--- a/docs/developer-guide/syntax-reference.rst
+++ b/docs/developer-guide/syntax-reference.rst
@@ -295,7 +295,7 @@ The WITH clause supports the following properties:
 |                         | ``JSON``, ``DELIMITED`` (comma-separated value), and ``AVRO``.                             |
 +-------------------------+--------------------------------------------------------------------------------------------+
 | PARTITIONS              | The number of partitions in the backing topic. This property must be set if creating a     |
-|                         | SOURCE without an existing topic (the command will fail if the topic does not exist).      |
+|                         | STREAM without an existing topic (the command will fail if the topic does not exist).      |
 +-------------------------+--------------------------------------------------------------------------------------------+
 | REPLICAS                | The number of replicas in the backing topic. If this property is not set but PARTITIONS is |
 |                         | set, then the default Kafka cluster configuration for replicas will be used for creating a |
@@ -402,7 +402,7 @@ The WITH clause supports the following properties:
 |                         | ``JSON``, ``DELIMITED`` (comma-separated value), and ``AVRO``.                             |
 +-------------------------+--------------------------------------------------------------------------------------------+
 | PARTITIONS              | The number of partitions in the backing topic. This property must be set if creating a     |
-|                         | SOURCE without an existing topic (the command will fail if the topic does not exist).      |
+|                         | TABLE without an existing topic (the command will fail if the topic does not exist).       |
 +-------------------------+--------------------------------------------------------------------------------------------+
 | REPLICAS                | The number of replicas in the backing topic. If this property is not set but PARTITIONS is |
 |                         | set, then the default Kafka cluster configuration for replicas will be used for creating a |
@@ -681,13 +681,14 @@ INSERT VALUES
 
 Produce a row into an existing stream or table and its underlying topic based on
 explicitly specified values. The first ``column_name`` of every schema is ``ROWKEY``, which
-defines the corresponding kafka key - if the source specifies a ``key`` and that column is present
-in the column names for this insert statement, the values are expected to match, otherwise the
-value will be duplicated into the value (or conversely from the value into the ``ROWKEY``).
+defines the corresponding Kafka key. If the source specifies a ``key`` and that column is present
+in the column names for this INSERT statement then that value and the ``ROWKEY`` value are expected
+to match, otherwise the value from ``ROWKEY`` will be copied into the value of the key column (or
+conversely from the key column into the ``ROWKEY`` column).
 
-Any column not explicitly given a value is set to ``null`` (KSQL does not yet support DEFAULT
-values).  If no columns are specified, a value for every column is expected in the same order as
-the schema with ``ROWKEY`` as the first column. If columns are specified, the order does not matter.
+Any column not explicitly given a value is set to ``null``.  If no columns are specified, a value
+for every column is expected in the same order as the schema with ``ROWKEY`` as the first column.
+If columns are specified, the order does not matter.
 
 .. note:: ``ROWTIME`` may be specified as an explicit column, but is not required when omitting the
   column specifications.
@@ -710,6 +711,7 @@ For example, the statements below would all be valid for a source with schema
       INSERT INTO foo (KEY_COL) VALUES ("key");
 
 The values will serialize using the ``value_format`` specified in the original `CREATE` statement.
+The key will always be serialized as a String.
 
 
 DESCRIBE

--- a/docs/developer-guide/syntax-reference.rst
+++ b/docs/developer-guide/syntax-reference.rst
@@ -287,10 +287,19 @@ The WITH clause supports the following properties:
 +-------------------------+--------------------------------------------------------------------------------------------+
 | Property                | Description                                                                                |
 +=========================+============================================================================================+
-| KAFKA_TOPIC (required)  | The name of the Kafka topic that backs this stream. The topic must already exist in Kafka. |
+| KAFKA_TOPIC (required)  | The name of the Kafka topic that backs this source. The topic must either already exist in |
+|                         | Kafka, or PARTITIONS must be specified to create the topic. Command will fail if the topic |
+|                         | exists with different partition/replica counts.                                            |
 +-------------------------+--------------------------------------------------------------------------------------------+
 | VALUE_FORMAT (required) | Specifies the serialization format of the message value in the topic. Supported formats:   |
 |                         | ``JSON``, ``DELIMITED`` (comma-separated value), and ``AVRO``.                             |
++-------------------------+--------------------------------------------------------------------------------------------+
+| PARTITIONS              | The number of partitions in the backing topic. This property must be set if creating a     |
+|                         | SOURCE without an existing topic (the command will fail if the topic does not exist).      |
++-------------------------+--------------------------------------------------------------------------------------------+
+| REPLICAS                | The number of replicas in the backing topic. If this property is not set but PARTITIONS is |
+|                         | set, then the default Kafka cluster configuration for replicas will be used for creating a |
+|                         | new topic.                                                                                 |
 +-------------------------+--------------------------------------------------------------------------------------------+
 | KEY                     | Optimization hint: If the Kafka message key is also present as a field/column in the Kafka |
 |                         | message value, you may set this property to associate the corresponding field/column with  |
@@ -377,17 +386,27 @@ KSQL adds the implicit columns ``ROWTIME`` and ``ROWKEY`` to every
 stream and table, which represent the corresponding Kafka message
 timestamp and message key, respectively. The timestamp has milliseconds accuracy.
 
-When creating a table from a Kafka topic, KSQL requries the message key to be a ``VARCHAR`` aka ``STRING``. If the message key is not of this type follow the instructions in :ref:`ksql_key_requirements`.
+When creating a table from a Kafka topic, KSQL requries the message key to be a ``VARCHAR`` aka ``STRING``. If the message
+key is not of this type follow the instructions in :ref:`ksql_key_requirements`.
 
 The WITH clause supports the following properties:
 
 +-------------------------+--------------------------------------------------------------------------------------------+
 | Property                | Description                                                                                |
 +=========================+============================================================================================+
-| KAFKA_TOPIC (required)  | The name of the Kafka topic that backs this table. The topic must already exist in Kafka.  |
+| KAFKA_TOPIC (required)  | The name of the Kafka topic that backs this source. The topic must either already exist in |
+|                         | Kafka, or PARTITIONS must be specified to create the topic. Command will fail if the topic |
+|                         | exists with different partition/replica counts.                                            |
 +-------------------------+--------------------------------------------------------------------------------------------+
 | VALUE_FORMAT (required) | Specifies the serialization format of message values in the topic. Supported formats:      |
 |                         | ``JSON``, ``DELIMITED`` (comma-separated value), and ``AVRO``.                             |
++-------------------------+--------------------------------------------------------------------------------------------+
+| PARTITIONS              | The number of partitions in the backing topic. This property must be set if creating a     |
+|                         | SOURCE without an existing topic (the command will fail if the topic does not exist).      |
++-------------------------+--------------------------------------------------------------------------------------------+
+| REPLICAS                | The number of replicas in the backing topic. If this property is not set but PARTITIONS is |
+|                         | set, then the default Kafka cluster configuration for replicas will be used for creating a |
+|                         | new topic.                                                                                 |
 +-------------------------+--------------------------------------------------------------------------------------------+
 | KEY                     | Optimization hint: If the Kafka message key is also present as a field/column in the Kafka |
 |                         | message value, you may set this property to associate the corresponding field/column with  |
@@ -646,6 +665,52 @@ stream_name and from_item must both refer to a Stream. Tables are not supported.
 Records written into the stream are not timestamp-ordered with respect to other queries.
 Therefore, the topic partitions of the output stream may contain out-of-order records even
 if the source stream for the query is ordered by timestamp.
+
+
+INSERT VALUES
+-----------
+
+**Synopsis**
+
+.. code:: sql
+
+    INSERT INTO <stream_name|table_name> [(column_name [, ...]])]
+      VALUES (value [,...]);
+
+**Description**
+
+Produce a row into an existing stream or table and its underlying topic based on
+explicitly specified values. The first ``column_name`` of every schema is ``ROWKEY``, which
+defines the corresponding kafka key - if the source specifies a ``key`` and that column is present
+in the column names for this insert statement, the values are expected to match, otherwise the
+value will be duplicated into the value (or conversely from the value into the ``ROWKEY``).
+
+Any column not explicitly given a value is set to ``null`` (KSQL does not yet support DEFAULT
+values).  If no columns are specified, a value for every column is expected in the same order as
+the schema with ``ROWKEY`` as the first column. If columns are specified, the order does not matter.
+
+.. note:: ``ROWTIME`` may be specified as an explicit column, but is not required when omitting the
+  column specifications.
+
+For example, the statements below would all be valid for a source with schema
+``<KEY_COL VARCHAR, COL_A VARCHAR>`` with ``KEY=KEY_COL``:
+
+  .. code:: sql
+
+      // inserts (1234, "key", "key", "A")
+      INSERT INTO foo (ROWTIME, ROWKEY, KEY_COL, COL_A) VALUES (1234, "key", "key", "A");
+
+      // inserts (current_time(), "key", "key", "A")
+      INSERT INTO foo VALUES ("key", "key", "A");
+
+      // inserts (current_time(), "key", "key", "A")
+      INSERT INTO foo (KEY_COL, COL_A) VALUES ("key", "A");
+
+      // inserts (current_time(), "key", "key", null)
+      INSERT INTO foo (KEY_COL) VALUES ("key");
+
+The values will serialize using the ``value_format`` specified in the original `CREATE` statement.
+
 
 DESCRIBE
 --------

--- a/ksql-common/src/main/java/io/confluent/ksql/util/KsqlConfig.java
+++ b/ksql-common/src/main/java/io/confluent/ksql/util/KsqlConfig.java
@@ -147,6 +147,8 @@ public class KsqlConfig extends AbstractConfig {
   public static final String KSQL_COLLECT_UDF_METRICS = "ksql.udf.collect.metrics";
   public static final String KSQL_UDF_SECURITY_MANAGER_ENABLED = "ksql.udf.enable.security.manager";
 
+  public static final String KSQL_INSERT_INTO_VALUES_ENABLED = "ksql.insert.into.values.enabled";
+
   public static final String DEFAULT_EXT_DIR = "ext";
 
   private static final Collection<CompatibilityBreakingConfigDef> COMPATIBLY_BREAKING_CONFIG_DEFS
@@ -395,6 +397,12 @@ public class KsqlConfig extends AbstractConfig {
             ConfigDef.Importance.LOW,
             "Enable the security manager for UDFs. Default is true and will stop UDFs from"
                + " calling System.exit or executing processes"
+        ).define(
+            KSQL_INSERT_INTO_VALUES_ENABLED,
+            Type.BOOLEAN,
+            true,
+            ConfigDef.Importance.LOW,
+            "Enable the INSERT INTO ... VALUES functionality."
         )
         .withClientSslSupport();
     for (final CompatibilityBreakingConfigDef compatibilityBreakingConfigDef

--- a/ksql-common/src/main/java/io/confluent/ksql/util/KsqlConstants.java
+++ b/ksql-common/src/main/java/io/confluent/ksql/util/KsqlConstants.java
@@ -23,8 +23,11 @@ public final class KsqlConstants {
   public static final String KSQL_INTERNAL_TOPIC_PREFIX = "_confluent-ksql-";
   public static final String CONFLUENT_INTERNAL_TOPIC_PREFIX = "__confluent";
 
-  public static final String WITH_CLAUSE_PARTITIONS = "PARTITIONS";
-  public static final String WITH_CLAUSE_REPLICAS = "REPLICAS";
+  public static final String SINK_NUMBER_OF_PARTITIONS = "PARTITIONS";
+  public static final String SOURCE_NUMBER_OF_PARTITIONS = SINK_NUMBER_OF_PARTITIONS;
+
+  public static final String SINK_NUMBER_OF_REPLICAS = "REPLICAS";
+  public static final String SOURCE_NUMBER_OF_REPLICAS = SINK_NUMBER_OF_REPLICAS;
 
   public static final String SINK_TIMESTAMP_COLUMN_NAME = "TIMESTAMP";
 

--- a/ksql-common/src/main/java/io/confluent/ksql/util/KsqlConstants.java
+++ b/ksql-common/src/main/java/io/confluent/ksql/util/KsqlConstants.java
@@ -23,8 +23,8 @@ public final class KsqlConstants {
   public static final String KSQL_INTERNAL_TOPIC_PREFIX = "_confluent-ksql-";
   public static final String CONFLUENT_INTERNAL_TOPIC_PREFIX = "__confluent";
 
-  public static final String SINK_NUMBER_OF_PARTITIONS = "PARTITIONS";
-  public static final String SINK_NUMBER_OF_REPLICAS = "REPLICAS";
+  public static final String WITH_CLAUSE_PARTITIONS = "PARTITIONS";
+  public static final String WITH_CLAUSE_REPLICAS = "REPLICAS";
 
   public static final String SINK_TIMESTAMP_COLUMN_NAME = "TIMESTAMP";
 

--- a/ksql-engine/src/main/java/io/confluent/ksql/analyzer/Analyzer.java
+++ b/ksql-engine/src/main/java/io/confluent/ksql/analyzer/Analyzer.java
@@ -136,10 +136,10 @@ class Analyzer {
       setIntoTimestampColumnAndFormat(sink);
     }
 
-    if (sink.getProperties().get(KsqlConstants.WITH_CLAUSE_PARTITIONS) != null) {
+    if (sink.getProperties().get(KsqlConstants.SINK_NUMBER_OF_PARTITIONS) != null) {
       final int numberOfPartitions =
           WithClauseUtil.parsePartitions(
-              sink.getProperties().get(KsqlConstants.WITH_CLAUSE_PARTITIONS).toString());
+              sink.getProperties().get(KsqlConstants.SINK_NUMBER_OF_PARTITIONS).toString());
 
       analysis.getIntoProperties().put(
           KsqlConfig.SINK_NUMBER_OF_PARTITIONS_PROPERTY,
@@ -147,10 +147,10 @@ class Analyzer {
       );
     }
 
-    if (sink.getProperties().get(KsqlConstants.WITH_CLAUSE_REPLICAS) != null) {
+    if (sink.getProperties().get(KsqlConstants.SINK_NUMBER_OF_REPLICAS) != null) {
       final short numberOfReplications =
           WithClauseUtil.parseReplicas(
-              sink.getProperties().get(KsqlConstants.WITH_CLAUSE_REPLICAS).toString());
+              sink.getProperties().get(KsqlConstants.SINK_NUMBER_OF_REPLICAS).toString());
       analysis.getIntoProperties()
           .put(KsqlConfig.SINK_NUMBER_OF_REPLICAS_PROPERTY, numberOfReplications);
     }
@@ -310,8 +310,8 @@ class Analyzer {
     validSet.add(DdlConfig.KAFKA_TOPIC_NAME_PROPERTY.toUpperCase());
     validSet.add(DdlConfig.PARTITION_BY_PROPERTY.toUpperCase());
     validSet.add(KsqlConstants.SINK_TIMESTAMP_COLUMN_NAME.toUpperCase());
-    validSet.add(KsqlConstants.WITH_CLAUSE_PARTITIONS.toUpperCase());
-    validSet.add(KsqlConstants.WITH_CLAUSE_REPLICAS.toUpperCase());
+    validSet.add(KsqlConstants.SINK_NUMBER_OF_PARTITIONS.toUpperCase());
+    validSet.add(KsqlConstants.SINK_NUMBER_OF_REPLICAS.toUpperCase());
     validSet.add(DdlConfig.TIMESTAMP_FORMAT_PROPERTY.toUpperCase());
     validSet.add(DdlConfig.VALUE_AVRO_SCHEMA_FULL_NAME.toUpperCase());
 

--- a/ksql-engine/src/main/java/io/confluent/ksql/analyzer/Analyzer.java
+++ b/ksql-engine/src/main/java/io/confluent/ksql/analyzer/Analyzer.java
@@ -136,10 +136,10 @@ class Analyzer {
       setIntoTimestampColumnAndFormat(sink);
     }
 
-    if (sink.getProperties().get(KsqlConstants.SINK_NUMBER_OF_PARTITIONS) != null) {
+    if (sink.getProperties().get(KsqlConstants.WITH_CLAUSE_PARTITIONS) != null) {
       final int numberOfPartitions =
           WithClauseUtil.parsePartitions(
-              sink.getProperties().get(KsqlConstants.SINK_NUMBER_OF_PARTITIONS).toString());
+              sink.getProperties().get(KsqlConstants.WITH_CLAUSE_PARTITIONS).toString());
 
       analysis.getIntoProperties().put(
           KsqlConfig.SINK_NUMBER_OF_PARTITIONS_PROPERTY,
@@ -147,10 +147,10 @@ class Analyzer {
       );
     }
 
-    if (sink.getProperties().get(KsqlConstants.SINK_NUMBER_OF_REPLICAS) != null) {
+    if (sink.getProperties().get(KsqlConstants.WITH_CLAUSE_REPLICAS) != null) {
       final short numberOfReplications =
           WithClauseUtil.parseReplicas(
-              sink.getProperties().get(KsqlConstants.SINK_NUMBER_OF_REPLICAS).toString());
+              sink.getProperties().get(KsqlConstants.WITH_CLAUSE_REPLICAS).toString());
       analysis.getIntoProperties()
           .put(KsqlConfig.SINK_NUMBER_OF_REPLICAS_PROPERTY, numberOfReplications);
     }
@@ -310,8 +310,8 @@ class Analyzer {
     validSet.add(DdlConfig.KAFKA_TOPIC_NAME_PROPERTY.toUpperCase());
     validSet.add(DdlConfig.PARTITION_BY_PROPERTY.toUpperCase());
     validSet.add(KsqlConstants.SINK_TIMESTAMP_COLUMN_NAME.toUpperCase());
-    validSet.add(KsqlConstants.SINK_NUMBER_OF_PARTITIONS.toUpperCase());
-    validSet.add(KsqlConstants.SINK_NUMBER_OF_REPLICAS.toUpperCase());
+    validSet.add(KsqlConstants.WITH_CLAUSE_PARTITIONS.toUpperCase());
+    validSet.add(KsqlConstants.WITH_CLAUSE_REPLICAS.toUpperCase());
     validSet.add(DdlConfig.TIMESTAMP_FORMAT_PROPERTY.toUpperCase());
     validSet.add(DdlConfig.VALUE_AVRO_SCHEMA_FULL_NAME.toUpperCase());
 

--- a/ksql-engine/src/main/java/io/confluent/ksql/ddl/commands/CreateSourceCommand.java
+++ b/ksql-engine/src/main/java/io/confluent/ksql/ddl/commands/CreateSourceCommand.java
@@ -188,8 +188,8 @@ abstract class CreateSourceCommand implements DdlCommand {
     final Set<String> validSet = new HashSet<>();
     validSet.add(DdlConfig.VALUE_FORMAT_PROPERTY.toUpperCase());
     validSet.add(DdlConfig.KAFKA_TOPIC_NAME_PROPERTY.toUpperCase());
-    validSet.add(KsqlConstants.WITH_CLAUSE_PARTITIONS.toUpperCase());
-    validSet.add(KsqlConstants.WITH_CLAUSE_REPLICAS.toUpperCase());
+    validSet.add(KsqlConstants.SINK_NUMBER_OF_PARTITIONS.toUpperCase());
+    validSet.add(KsqlConstants.SINK_NUMBER_OF_REPLICAS.toUpperCase());
     validSet.add(DdlConfig.KEY_NAME_PROPERTY.toUpperCase());
     validSet.add(DdlConfig.WINDOW_TYPE_PROPERTY.toUpperCase());
     validSet.add(DdlConfig.TIMESTAMP_NAME_PROPERTY.toUpperCase());

--- a/ksql-engine/src/main/java/io/confluent/ksql/ddl/commands/CreateSourceCommand.java
+++ b/ksql-engine/src/main/java/io/confluent/ksql/ddl/commands/CreateSourceCommand.java
@@ -20,7 +20,7 @@ import io.confluent.ksql.ddl.DdlConfig;
 import io.confluent.ksql.metastore.MetaStore;
 import io.confluent.ksql.metastore.SerdeFactory;
 import io.confluent.ksql.metastore.model.KeyField;
-import io.confluent.ksql.parser.tree.AbstractStreamCreateStatement;
+import io.confluent.ksql.parser.tree.CreateSource;
 import io.confluent.ksql.parser.tree.Literal;
 import io.confluent.ksql.parser.tree.StringLiteral;
 import io.confluent.ksql.parser.tree.TableElement;
@@ -47,7 +47,7 @@ import org.apache.kafka.streams.kstream.WindowedSerdes;
 /**
  * Base class of create table/stream command
  */
-abstract class AbstractCreateStreamCommand implements DdlCommand {
+abstract class CreateSourceCommand implements DdlCommand {
 
   private static final Map<String, SerdeFactory<Windowed<String>>> WINDOW_TYPES = ImmutableMap.of(
       "SESSION", () -> WindowedSerdes.sessionWindowedSerdeFrom(String.class),
@@ -65,9 +65,9 @@ abstract class AbstractCreateStreamCommand implements DdlCommand {
   final SerdeFactory<?> keySerdeFactory;
   final TimestampExtractionPolicy timestampExtractionPolicy;
 
-  AbstractCreateStreamCommand(
+  CreateSourceCommand(
       final String sqlExpression,
-      final AbstractStreamCreateStatement statement,
+      final CreateSource statement,
       final KafkaTopicClient kafkaTopicClient
   ) {
     this.sqlExpression = sqlExpression;
@@ -188,6 +188,8 @@ abstract class AbstractCreateStreamCommand implements DdlCommand {
     final Set<String> validSet = new HashSet<>();
     validSet.add(DdlConfig.VALUE_FORMAT_PROPERTY.toUpperCase());
     validSet.add(DdlConfig.KAFKA_TOPIC_NAME_PROPERTY.toUpperCase());
+    validSet.add(KsqlConstants.SINK_NUMBER_OF_PARTITIONS.toUpperCase());
+    validSet.add(KsqlConstants.SINK_NUMBER_OF_REPLICAS.toUpperCase());
     validSet.add(DdlConfig.KEY_NAME_PROPERTY.toUpperCase());
     validSet.add(DdlConfig.WINDOW_TYPE_PROPERTY.toUpperCase());
     validSet.add(DdlConfig.TIMESTAMP_NAME_PROPERTY.toUpperCase());

--- a/ksql-engine/src/main/java/io/confluent/ksql/ddl/commands/CreateSourceCommand.java
+++ b/ksql-engine/src/main/java/io/confluent/ksql/ddl/commands/CreateSourceCommand.java
@@ -188,8 +188,8 @@ abstract class CreateSourceCommand implements DdlCommand {
     final Set<String> validSet = new HashSet<>();
     validSet.add(DdlConfig.VALUE_FORMAT_PROPERTY.toUpperCase());
     validSet.add(DdlConfig.KAFKA_TOPIC_NAME_PROPERTY.toUpperCase());
-    validSet.add(KsqlConstants.SINK_NUMBER_OF_PARTITIONS.toUpperCase());
-    validSet.add(KsqlConstants.SINK_NUMBER_OF_REPLICAS.toUpperCase());
+    validSet.add(KsqlConstants.WITH_CLAUSE_PARTITIONS.toUpperCase());
+    validSet.add(KsqlConstants.WITH_CLAUSE_REPLICAS.toUpperCase());
     validSet.add(DdlConfig.KEY_NAME_PROPERTY.toUpperCase());
     validSet.add(DdlConfig.WINDOW_TYPE_PROPERTY.toUpperCase());
     validSet.add(DdlConfig.TIMESTAMP_NAME_PROPERTY.toUpperCase());

--- a/ksql-engine/src/main/java/io/confluent/ksql/ddl/commands/CreateStreamCommand.java
+++ b/ksql-engine/src/main/java/io/confluent/ksql/ddl/commands/CreateStreamCommand.java
@@ -21,7 +21,7 @@ import io.confluent.ksql.parser.tree.CreateStream;
 import io.confluent.ksql.services.KafkaTopicClient;
 import io.confluent.ksql.util.KsqlException;
 
-public class CreateStreamCommand extends AbstractCreateStreamCommand {
+public class CreateStreamCommand extends CreateSourceCommand {
 
   public CreateStreamCommand(
       final String sqlExpression,

--- a/ksql-engine/src/main/java/io/confluent/ksql/ddl/commands/CreateTableCommand.java
+++ b/ksql-engine/src/main/java/io/confluent/ksql/ddl/commands/CreateTableCommand.java
@@ -21,7 +21,7 @@ import io.confluent.ksql.parser.tree.CreateTable;
 import io.confluent.ksql.services.KafkaTopicClient;
 import io.confluent.ksql.util.KsqlException;
 
-public class CreateTableCommand extends AbstractCreateStreamCommand {
+public class CreateTableCommand extends CreateSourceCommand {
 
   CreateTableCommand(
       final String sqlExpression,

--- a/ksql-engine/src/main/java/io/confluent/ksql/services/TopicValidationUtil.java
+++ b/ksql-engine/src/main/java/io/confluent/ksql/services/TopicValidationUtil.java
@@ -16,6 +16,7 @@
 package io.confluent.ksql.services;
 
 import io.confluent.ksql.exception.KafkaTopicExistsException;
+import io.confluent.ksql.topic.TopicProperties;
 import org.apache.kafka.clients.admin.TopicDescription;
 
 final class TopicValidationUtil {
@@ -48,7 +49,9 @@ final class TopicValidationUtil {
       final int actualNumPartitions,
       final int actualNumReplicas
   ) {
-    if (actualNumPartitions != requiredNumPartition || actualNumReplicas < requiredNumReplicas) {
+    if (actualNumPartitions != requiredNumPartition
+        || (requiredNumPartition != TopicProperties.DEFAULT_REPLICAS
+        && actualNumReplicas < requiredNumReplicas)) {
       throw new KafkaTopicExistsException(String.format(
           "A Kafka topic with the name '%s' already exists, with different partition/replica "
               + "configuration than required. KSQL expects %d partitions (topic has %d), and %d "

--- a/ksql-engine/src/main/java/io/confluent/ksql/services/TopicValidationUtil.java
+++ b/ksql-engine/src/main/java/io/confluent/ksql/services/TopicValidationUtil.java
@@ -50,7 +50,7 @@ final class TopicValidationUtil {
       final int actualNumReplicas
   ) {
     if (actualNumPartitions != requiredNumPartition
-        || (requiredNumPartition != TopicProperties.DEFAULT_REPLICAS
+        || (requiredNumReplicas != TopicProperties.DEFAULT_REPLICAS
         && actualNumReplicas < requiredNumReplicas)) {
       throw new KafkaTopicExistsException(String.format(
           "A Kafka topic with the name '%s' already exists, with different partition/replica "

--- a/ksql-engine/src/main/java/io/confluent/ksql/topic/TopicCreateInjector.java
+++ b/ksql-engine/src/main/java/io/confluent/ksql/topic/TopicCreateInjector.java
@@ -114,16 +114,17 @@ public class TopicCreateInjector implements Injector {
 
     if (topicClient.isTopicExists(topicName)) {
       topicPropertiesBuilder.withSource(() -> topicClient.describeTopic(topicName));
-    } else if (!createSource.getProperties().containsKey(KsqlConstants.WITH_CLAUSE_PARTITIONS)) {
+    } else if (!createSource.getProperties()
+        .containsKey(KsqlConstants.SOURCE_NUMBER_OF_PARTITIONS)) {
       final Map<String, Literal> exampleProps = new HashMap<>(createSource.getProperties());
-      exampleProps.put(KsqlConstants.WITH_CLAUSE_PARTITIONS, new IntegerLiteral(2));
-      exampleProps.putIfAbsent(KsqlConstants.WITH_CLAUSE_REPLICAS, new IntegerLiteral(1));
+      exampleProps.put(KsqlConstants.SOURCE_NUMBER_OF_PARTITIONS, new IntegerLiteral(2));
+      exampleProps.putIfAbsent(KsqlConstants.SOURCE_NUMBER_OF_REPLICAS, new IntegerLiteral(1));
       final CreateSource example = createSource.copyWith(createSource.getElements(), exampleProps);
       throw new KsqlException(
           "Topic '" + topicName + "' does not exist. If you want to create a new topic for the "
               + "stream/table please re-run the statement providing the required '"
-              + KsqlConstants.WITH_CLAUSE_PARTITIONS + "' configuration in the WITH clause "
-              + "(and optionally '" + KsqlConstants.WITH_CLAUSE_REPLICAS + "'). For example: "
+              + KsqlConstants.SOURCE_NUMBER_OF_PARTITIONS + "' configuration in the WITH clause "
+              + "(and optionally '" + KsqlConstants.SOURCE_NUMBER_OF_REPLICAS + "'). For example: "
               + SqlFormatter.formatSql(example));
     }
 
@@ -165,8 +166,8 @@ public class TopicCreateInjector implements Injector {
 
     final Map<String, Literal> props = new HashMap<>(createAsSelect.getProperties());
     props.put(DdlConfig.KAFKA_TOPIC_NAME_PROPERTY, new StringLiteral(info.getTopicName()));
-    props.put(KsqlConstants.WITH_CLAUSE_REPLICAS, new IntegerLiteral(info.getReplicas()));
-    props.put(KsqlConstants.WITH_CLAUSE_PARTITIONS, new IntegerLiteral(info.getPartitions()));
+    props.put(KsqlConstants.SINK_NUMBER_OF_REPLICAS, new IntegerLiteral(info.getReplicas()));
+    props.put(KsqlConstants.SINK_NUMBER_OF_PARTITIONS, new IntegerLiteral(info.getPartitions()));
 
     final T withTopic = (T) createAsSelect.copyWith(props);
     final String withTopicText = SqlFormatter.formatSql(withTopic) + ";";

--- a/ksql-engine/src/main/java/io/confluent/ksql/topic/TopicCreateInjector.java
+++ b/ksql-engine/src/main/java/io/confluent/ksql/topic/TopicCreateInjector.java
@@ -88,13 +88,13 @@ public class TopicCreateInjector implements Injector {
       final TopicProperties.Builder topicPropertiesBuilder
   ) {
     if (statement.getStatement() instanceof CreateAsSelect) {
-      return (ConfiguredStatement<T>) injectCreateAsSelect(
+      return (ConfiguredStatement<T>) injectForCreateAsSelect(
           (ConfiguredStatement<? extends CreateAsSelect>) statement,
           topicPropertiesBuilder);
     }
 
     if (statement.getStatement() instanceof CreateSource) {
-      return (ConfiguredStatement<T>) injectCreateSource(
+      return (ConfiguredStatement<T>) injectForCreateSource(
           (ConfiguredStatement<? extends CreateSource>) statement,
           topicPropertiesBuilder);
     }
@@ -102,7 +102,7 @@ public class TopicCreateInjector implements Injector {
     return statement;
   }
 
-  private ConfiguredStatement<? extends CreateSource> injectCreateSource(
+  private ConfiguredStatement<? extends CreateSource> injectForCreateSource(
       final ConfiguredStatement<? extends CreateSource> statement,
       final TopicProperties.Builder topicPropertiesBuilder
   ) {
@@ -114,16 +114,16 @@ public class TopicCreateInjector implements Injector {
 
     if (topicClient.isTopicExists(topicName)) {
       topicPropertiesBuilder.withSource(() -> topicClient.describeTopic(topicName));
-    } else if (!createSource.getProperties().containsKey(KsqlConstants.SINK_NUMBER_OF_PARTITIONS)) {
+    } else if (!createSource.getProperties().containsKey(KsqlConstants.WITH_CLAUSE_PARTITIONS)) {
       final Map<String, Literal> exampleProps = new HashMap<>(createSource.getProperties());
-      exampleProps.put(KsqlConstants.SINK_NUMBER_OF_PARTITIONS, new IntegerLiteral(2));
-      exampleProps.putIfAbsent(KsqlConstants.SINK_NUMBER_OF_REPLICAS, new IntegerLiteral(1));
+      exampleProps.put(KsqlConstants.WITH_CLAUSE_PARTITIONS, new IntegerLiteral(2));
+      exampleProps.putIfAbsent(KsqlConstants.WITH_CLAUSE_REPLICAS, new IntegerLiteral(1));
       final CreateSource example = createSource.copyWith(createSource.getElements(), exampleProps);
       throw new KsqlException(
           "Topic '" + topicName + "' does not exist. If you want to create a new topic for the "
-              + "stream/table please re-run the statement providing th required '"
-              + KsqlConstants.SINK_NUMBER_OF_PARTITIONS + "' configuration in the WITH clause "
-              + "(and optionally '" + KsqlConstants.SINK_NUMBER_OF_REPLICAS + "'). For example: "
+              + "stream/table please re-run the statement providing the required '"
+              + KsqlConstants.WITH_CLAUSE_PARTITIONS + "' configuration in the WITH clause "
+              + "(and optionally '" + KsqlConstants.WITH_CLAUSE_REPLICAS + "'). For example: "
               + SqlFormatter.formatSql(example));
     }
 
@@ -137,7 +137,7 @@ public class TopicCreateInjector implements Injector {
   }
 
   @SuppressWarnings("unchecked")
-  private <T extends CreateAsSelect> ConfiguredStatement<?> injectCreateAsSelect(
+  private <T extends CreateAsSelect> ConfiguredStatement<?> injectForCreateAsSelect(
       final ConfiguredStatement<T> statement,
       final TopicProperties.Builder topicPropertiesBuilder
   ) {
@@ -165,8 +165,8 @@ public class TopicCreateInjector implements Injector {
 
     final Map<String, Literal> props = new HashMap<>(createAsSelect.getProperties());
     props.put(DdlConfig.KAFKA_TOPIC_NAME_PROPERTY, new StringLiteral(info.getTopicName()));
-    props.put(KsqlConstants.SINK_NUMBER_OF_REPLICAS, new IntegerLiteral(info.getReplicas()));
-    props.put(KsqlConstants.SINK_NUMBER_OF_PARTITIONS, new IntegerLiteral(info.getPartitions()));
+    props.put(KsqlConstants.WITH_CLAUSE_REPLICAS, new IntegerLiteral(info.getReplicas()));
+    props.put(KsqlConstants.WITH_CLAUSE_PARTITIONS, new IntegerLiteral(info.getPartitions()));
 
     final T withTopic = (T) createAsSelect.copyWith(props);
     final String withTopicText = SqlFormatter.formatSql(withTopic) + ";";

--- a/ksql-engine/src/main/java/io/confluent/ksql/topic/TopicProperties.java
+++ b/ksql-engine/src/main/java/io/confluent/ksql/topic/TopicProperties.java
@@ -187,7 +187,9 @@ public final class TopicProperties {
           .filter(Objects::nonNull)
           .findFirst()
           .orElseGet(() -> fromSource.get().partitions);
-      Objects.requireNonNull(partitions, "Was not supplied with any valid source for partitions!");
+      if (partitions == null) {
+        throw new KsqlException("Cannot create determine partitions for creating topic " + name);
+      }
 
       final Short replicas = Stream.of(
           fromWithClause.replicas,

--- a/ksql-engine/src/main/java/io/confluent/ksql/topic/TopicProperties.java
+++ b/ksql-engine/src/main/java/io/confluent/ksql/topic/TopicProperties.java
@@ -114,12 +114,12 @@ public final class TopicProperties {
           ? null
           : StringUtils.strip(nameExpression.toString(), "'");
 
-      final Expression partitionExp = withClause.get(KsqlConstants.WITH_CLAUSE_PARTITIONS);
+      final Expression partitionExp = withClause.get(KsqlConstants.SINK_NUMBER_OF_PARTITIONS);
       final Integer partitions = partitionExp == null
           ? null
           : WithClauseUtil.parsePartitions(partitionExp.toString());
 
-      final Expression replicasExp = withClause.get(KsqlConstants.WITH_CLAUSE_REPLICAS);
+      final Expression replicasExp = withClause.get(KsqlConstants.SINK_NUMBER_OF_REPLICAS);
       final Short replicas = replicasExp == null
           ? null
           : WithClauseUtil.parseReplicas(replicasExp.toString());

--- a/ksql-engine/src/main/java/io/confluent/ksql/topic/TopicProperties.java
+++ b/ksql-engine/src/main/java/io/confluent/ksql/topic/TopicProperties.java
@@ -114,12 +114,12 @@ public final class TopicProperties {
           ? null
           : StringUtils.strip(nameExpression.toString(), "'");
 
-      final Expression partitionExp = withClause.get(KsqlConstants.SINK_NUMBER_OF_PARTITIONS);
+      final Expression partitionExp = withClause.get(KsqlConstants.WITH_CLAUSE_PARTITIONS);
       final Integer partitions = partitionExp == null
           ? null
           : WithClauseUtil.parsePartitions(partitionExp.toString());
 
-      final Expression replicasExp = withClause.get(KsqlConstants.SINK_NUMBER_OF_REPLICAS);
+      final Expression replicasExp = withClause.get(KsqlConstants.WITH_CLAUSE_REPLICAS);
       final Short replicas = replicasExp == null
           ? null
           : WithClauseUtil.parseReplicas(replicasExp.toString());

--- a/ksql-engine/src/main/java/io/confluent/ksql/topic/TopicProperties.java
+++ b/ksql-engine/src/main/java/io/confluent/ksql/topic/TopicProperties.java
@@ -188,7 +188,7 @@ public final class TopicProperties {
           .findFirst()
           .orElseGet(() -> fromSource.get().partitions);
       if (partitions == null) {
-        throw new KsqlException("Cannot create determine partitions for creating topic " + name);
+        throw new KsqlException("Cannot determine partitions for creating topic " + name);
       }
 
       final Short replicas = Stream.of(

--- a/ksql-engine/src/test/java/io/confluent/ksql/QueryTranslationTest.java
+++ b/ksql-engine/src/test/java/io/confluent/ksql/QueryTranslationTest.java
@@ -67,7 +67,7 @@ import io.confluent.ksql.parser.KsqlParser;
 import io.confluent.ksql.parser.KsqlParser.ParsedStatement;
 import io.confluent.ksql.parser.KsqlParser.PreparedStatement;
 import io.confluent.ksql.parser.SqlBaseParser;
-import io.confluent.ksql.parser.tree.AbstractStreamCreateStatement;
+import io.confluent.ksql.parser.tree.CreateSource;
 import io.confluent.ksql.parser.tree.Literal;
 import io.confluent.ksql.schema.ksql.LogicalSchemas;
 import io.confluent.ksql.schema.ksql.TypeContextUtil;
@@ -242,7 +242,7 @@ public class QueryTranslationTest {
             || stmt.getStatement().statement() instanceof SqlBaseParser.CreateTableContext;
 
     final Function<PreparedStatement<?>, Topic> extractTopic = stmt -> {
-      final AbstractStreamCreateStatement statement = (AbstractStreamCreateStatement) stmt
+      final CreateSource statement = (CreateSource) stmt
           .getStatement();
 
       final Map<String, Literal> properties = statement.getProperties();

--- a/ksql-engine/src/test/java/io/confluent/ksql/ddl/commands/CreateSourceCommandTest.java
+++ b/ksql-engine/src/test/java/io/confluent/ksql/ddl/commands/CreateSourceCommandTest.java
@@ -25,7 +25,7 @@ import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import io.confluent.ksql.ddl.DdlConfig;
 import io.confluent.ksql.metastore.MutableMetaStore;
-import io.confluent.ksql.parser.tree.AbstractStreamCreateStatement;
+import io.confluent.ksql.parser.tree.CreateSource;
 import io.confluent.ksql.parser.tree.Expression;
 import io.confluent.ksql.parser.tree.Literal;
 import io.confluent.ksql.parser.tree.PrimitiveType;
@@ -48,7 +48,7 @@ import org.mockito.Mock;
 import org.mockito.junit.MockitoJUnitRunner;
 
 @RunWith(MockitoJUnitRunner.class)
-public class AbstractCreateStreamCommandTest {
+public class CreateSourceCommandTest {
 
   private static final String TOPIC_NAME = "some topic";
   private static final List<TableElement> SOME_ELEMENTS = ImmutableList.of(
@@ -57,7 +57,7 @@ public class AbstractCreateStreamCommandTest {
   @Rule
   public final ExpectedException expectedException = ExpectedException.none();
   @Mock
-  private AbstractStreamCreateStatement statement;
+  private CreateSource statement;
   @Mock
   private KafkaTopicClient kafkaTopicClient;
 
@@ -201,11 +201,11 @@ public class AbstractCreateStreamCommandTest {
     when(statement.getProperties()).thenReturn(allProps);
   }
 
-  private static final class TestCmd extends AbstractCreateStreamCommand {
+  private static final class TestCmd extends CreateSourceCommand {
 
     private TestCmd(
         final String sqlExpression,
-        final AbstractStreamCreateStatement statement,
+        final CreateSource statement,
         final KafkaTopicClient kafkaTopicClient
     ) {
       super(sqlExpression, statement, kafkaTopicClient);

--- a/ksql-engine/src/test/java/io/confluent/ksql/schema/inference/DefaultSchemaInjectorFunctionalTest.java
+++ b/ksql-engine/src/test/java/io/confluent/ksql/schema/inference/DefaultSchemaInjectorFunctionalTest.java
@@ -26,7 +26,7 @@ import io.confluent.kafka.schemaregistry.client.SchemaRegistryClient;
 import io.confluent.ksql.metastore.MetaStore;
 import io.confluent.ksql.parser.KsqlParser.PreparedStatement;
 import io.confluent.ksql.parser.KsqlParserTestUtil;
-import io.confluent.ksql.parser.tree.AbstractStreamCreateStatement;
+import io.confluent.ksql.parser.tree.CreateSource;
 import io.confluent.ksql.parser.tree.Statement;
 import io.confluent.ksql.parser.tree.TableElement;
 import io.confluent.ksql.schema.ksql.LogicalSchemas;
@@ -468,12 +468,12 @@ public class DefaultSchemaInjectorFunctionalTest {
         .buildSingleAst(inferred.getStatementText(), metaStore)
         .getStatement();
 
-    final Schema actual = getSchemaForDdlStatement((AbstractStreamCreateStatement) withSchema);
+    final Schema actual = getSchemaForDdlStatement((CreateSource) withSchema);
 
     Assert.assertThat(actual, equalTo(expectedKqlSchema));
   }
 
-  private static Schema getSchemaForDdlStatement(final AbstractStreamCreateStatement statement) {
+  private static Schema getSchemaForDdlStatement(final CreateSource statement) {
     final SchemaBuilder builder = SchemaBuilder.struct();
     for (final TableElement tableElement : statement.getElements()) {
       builder.field(

--- a/ksql-engine/src/test/java/io/confluent/ksql/schema/inference/DefaultSchemaInjectorTest.java
+++ b/ksql-engine/src/test/java/io/confluent/ksql/schema/inference/DefaultSchemaInjectorTest.java
@@ -32,7 +32,7 @@ import static org.mockito.Mockito.when;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import io.confluent.ksql.parser.KsqlParser.PreparedStatement;
-import io.confluent.ksql.parser.tree.AbstractStreamCreateStatement;
+import io.confluent.ksql.parser.tree.CreateSource;
 import io.confluent.ksql.parser.tree.CreateStream;
 import io.confluent.ksql.parser.tree.CreateTable;
 import io.confluent.ksql.parser.tree.Literal;
@@ -478,8 +478,8 @@ public class DefaultSchemaInjectorTest {
 
   private static Object setupCopy(
       final InvocationOnMock inv,
-      final AbstractStreamCreateStatement source,
-      final AbstractStreamCreateStatement mock
+      final CreateSource source,
+      final CreateSource mock
   ) {
     final QualifiedName name = source.getName();
     when(mock.getName()).thenReturn(name);

--- a/ksql-engine/src/test/java/io/confluent/ksql/services/KafkaTopicClientImplTest.java
+++ b/ksql-engine/src/test/java/io/confluent/ksql/services/KafkaTopicClientImplTest.java
@@ -74,11 +74,16 @@ import org.easymock.EasyMockRunner;
 import org.easymock.IArgumentMatcher;
 import org.easymock.Mock;
 import org.junit.Before;
+import org.junit.Rule;
 import org.junit.Test;
+import org.junit.rules.ExpectedException;
 import org.junit.runner.RunWith;
 
 @RunWith(EasyMockRunner.class)
 public class KafkaTopicClientImplTest {
+
+  @Rule
+  public final ExpectedException expectedException = ExpectedException.none();
 
   private static final String topicName1 = "topic1";
   private static final String topicName2 = "topic2";
@@ -130,8 +135,11 @@ public class KafkaTopicClientImplTest {
     verify(adminClient);
   }
 
-  @Test(expected = KafkaTopicExistsException.class)
+  @Test
   public void shouldFailCreateExistingTopic() {
+    expectedException.expect(KafkaTopicExistsException.class);
+    expectedException.expectMessage("and 2 replication factor (topic has 1)");
+
     expect(adminClient.createTopics(anyObject())).andReturn(getCreateTopicsResult());
     expect(adminClient.listTopics()).andReturn(getListTopicsResult());
     expect(adminClient.describeTopics(anyObject())).andReturn(getDescribeTopicsResult());

--- a/ksql-engine/src/test/java/io/confluent/ksql/services/KafkaTopicClientImplTest.java
+++ b/ksql-engine/src/test/java/io/confluent/ksql/services/KafkaTopicClientImplTest.java
@@ -142,6 +142,16 @@ public class KafkaTopicClientImplTest {
   }
 
   @Test
+  public void shouldNotFailIfTopicAlreadyExistsButCreateUsesDefaultReplicas() {
+    expect(adminClient.listTopics()).andReturn(getListTopicsResult());
+    expect(adminClient.describeTopics(anyObject())).andReturn(getDescribeTopicsResult());
+    replay(adminClient);
+    final KafkaTopicClient kafkaTopicClient = new KafkaTopicClientImpl(adminClient);
+    kafkaTopicClient.createTopic(topicName1, 1, (short) -1);
+    verify(adminClient);
+  }
+
+  @Test
   public void shouldNotFailIfTopicAlreadyExistsWhenCreating() {
     expect(adminClient.listTopics()).andReturn(getEmptyListTopicResult());
     expect(adminClient.createTopics(anyObject()))

--- a/ksql-engine/src/test/java/io/confluent/ksql/topic/TopicCreateInjectorTest.java
+++ b/ksql-engine/src/test/java/io/confluent/ksql/topic/TopicCreateInjectorTest.java
@@ -21,8 +21,6 @@ import static org.hamcrest.CoreMatchers.sameInstance;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.hasEntry;
 import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.anyInt;
-import static org.mockito.ArgumentMatchers.anyShort;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
@@ -340,9 +338,9 @@ public class TopicCreateInjectorTest {
     assertThat(result.getStatement().getProperties(),
         hasEntry(DdlConfig.KAFKA_TOPIC_NAME_PROPERTY, new StringLiteral("expectedName")));
     assertThat(result.getStatement().getProperties(),
-        hasEntry(KsqlConstants.SINK_NUMBER_OF_PARTITIONS, new IntegerLiteral(10)));
+        hasEntry(KsqlConstants.WITH_CLAUSE_PARTITIONS, new IntegerLiteral(10)));
     assertThat(result.getStatement().getProperties(),
-        hasEntry(KsqlConstants.SINK_NUMBER_OF_REPLICAS, new IntegerLiteral(10)));
+        hasEntry(KsqlConstants.WITH_CLAUSE_REPLICAS, new IntegerLiteral(10)));
   }
 
   @Test

--- a/ksql-engine/src/test/java/io/confluent/ksql/topic/TopicCreateInjectorTest.java
+++ b/ksql-engine/src/test/java/io/confluent/ksql/topic/TopicCreateInjectorTest.java
@@ -164,7 +164,7 @@ public class TopicCreateInjectorTest {
   @Test
   public void shouldUseNameFromCreate() {
     // Given:
-    givenStatement("CREATE STREAM x (FOO VARCHAR) WITH (kafka_topic='foo');");
+    givenStatement("CREATE STREAM x (FOO VARCHAR) WITH (kafka_topic='foo', partitions=1);");
 
     // When:
     injector.inject(statement, builder);
@@ -277,7 +277,7 @@ public class TopicCreateInjectorTest {
   }
 
   @Test
-  public void shouldNotUseSourceTopicForCreate() {
+  public void shouldNotUseSourceTopicForCreateMissingTopic() {
     // Given:
     givenStatement("CREATE STREAM x (FOO VARCHAR) WITH(kafka_topic='topic', partitions=2);");
 
@@ -286,6 +286,18 @@ public class TopicCreateInjectorTest {
 
     // Then:
     verify(builder, never()).withSource(any());
+  }
+
+  @Test
+  public void shouldUseSourceTopicForCreateMissingTopic() {
+    // Given:
+    givenStatement("CREATE STREAM x (FOO VARCHAR) WITH(kafka_topic='source', partitions=2);");
+
+    // When:
+    injector.inject(statement, builder);
+
+    // Then:
+    verify(builder).withSource(argThat(supplierThatGets(sourceDescription)));
   }
 
   @Test
@@ -403,7 +415,7 @@ public class TopicCreateInjectorTest {
   @Test
   public void shouldCreateMissingTopicWithCompactCleanupPolicyForCreateTable() {
     // Given:
-    givenStatement("CREATE TABLE foo (FOO VARCHAR) WITH (kafka_topic='topic');");
+    givenStatement("CREATE TABLE foo (FOO VARCHAR) WITH (kafka_topic='topic', partitions=1);");
     when(builder.build()).thenReturn(new TopicProperties("topic", 10, (short) 10));
 
     // When:

--- a/ksql-engine/src/test/java/io/confluent/ksql/topic/TopicCreateInjectorTest.java
+++ b/ksql-engine/src/test/java/io/confluent/ksql/topic/TopicCreateInjectorTest.java
@@ -289,7 +289,7 @@ public class TopicCreateInjectorTest {
   }
 
   @Test
-  public void shouldUseSourceTopicForCreateMissingTopic() {
+  public void shouldUseSourceTopicForCreateExistingTopic() {
     // Given:
     givenStatement("CREATE STREAM x (FOO VARCHAR) WITH(kafka_topic='source', partitions=2);");
 

--- a/ksql-engine/src/test/java/io/confluent/ksql/topic/TopicCreateInjectorTest.java
+++ b/ksql-engine/src/test/java/io/confluent/ksql/topic/TopicCreateInjectorTest.java
@@ -454,7 +454,7 @@ public class TopicCreateInjectorTest {
     expectedException.expect(KsqlException.class);
     expectedException.expectMessage(
         "Topic 'doesntexist' does not exist. If you want to create a new topic for the "
-            + "stream/table please re-run the statement providing th required 'PARTITIONS' "
+            + "stream/table please re-run the statement providing the required 'PARTITIONS' "
             + "configuration in the WITH clause (and optionally 'REPLICAS'). For example: "
             + "CREATE STREAM FOO (FOO STRING) WITH (KAFKA_TOPIC='doesntexist', REPLICAS=1"
             + ", PARTITIONS=2);");

--- a/ksql-engine/src/test/java/io/confluent/ksql/topic/TopicCreateInjectorTest.java
+++ b/ksql-engine/src/test/java/io/confluent/ksql/topic/TopicCreateInjectorTest.java
@@ -338,9 +338,9 @@ public class TopicCreateInjectorTest {
     assertThat(result.getStatement().getProperties(),
         hasEntry(DdlConfig.KAFKA_TOPIC_NAME_PROPERTY, new StringLiteral("expectedName")));
     assertThat(result.getStatement().getProperties(),
-        hasEntry(KsqlConstants.WITH_CLAUSE_PARTITIONS, new IntegerLiteral(10)));
+        hasEntry(KsqlConstants.SINK_NUMBER_OF_PARTITIONS, new IntegerLiteral(10)));
     assertThat(result.getStatement().getProperties(),
-        hasEntry(KsqlConstants.WITH_CLAUSE_REPLICAS, new IntegerLiteral(10)));
+        hasEntry(KsqlConstants.SINK_NUMBER_OF_REPLICAS, new IntegerLiteral(10)));
   }
 
   @Test

--- a/ksql-engine/src/test/java/io/confluent/ksql/topic/TopicCreateInjectorTest.java
+++ b/ksql-engine/src/test/java/io/confluent/ksql/topic/TopicCreateInjectorTest.java
@@ -21,6 +21,9 @@ import static org.hamcrest.CoreMatchers.sameInstance;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.hasEntry;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.ArgumentMatchers.anyShort;
+import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 import static org.mockito.hamcrest.MockitoHamcrest.argThat;
@@ -37,6 +40,7 @@ import io.confluent.ksql.parser.DefaultKsqlParser;
 import io.confluent.ksql.parser.KsqlParser;
 import io.confluent.ksql.parser.KsqlParser.PreparedStatement;
 import io.confluent.ksql.parser.tree.CreateAsSelect;
+import io.confluent.ksql.parser.tree.CreateSource;
 import io.confluent.ksql.parser.tree.IntegerLiteral;
 import io.confluent.ksql.parser.tree.StringLiteral;
 import io.confluent.ksql.schema.ksql.KsqlSchema;
@@ -81,7 +85,7 @@ public class TopicCreateInjectorTest {
   private MutableMetaStore metaStore;
   private TopicCreateInjector injector;
   private Map<String, Object> overrides;
-  private ConfiguredStatement<CreateAsSelect> statement;
+  private ConfiguredStatement<?> statement;
   private KsqlConfig config;
 
   @Before
@@ -118,6 +122,7 @@ public class TopicCreateInjectorTest {
     metaStore.putSource(joinSource);
 
     when(topicClient.describeTopic("source")).thenReturn(sourceDescription);
+    when(topicClient.isTopicExists("source")).thenReturn(true);
     when(builder.withName(any())).thenReturn(builder);
     when(builder.withWithClause(any())).thenReturn(builder);
     when(builder.withOverrides(any())).thenReturn(builder);
@@ -148,6 +153,18 @@ public class TopicCreateInjectorTest {
 
     // Then:
     verify(builder).withName("X");
+  }
+
+  @Test
+  public void shouldUseNameFromCreate() {
+    // Given:
+    givenStatement("CREATE STREAM x (FOO VARCHAR) WITH (kafka_topic='foo');");
+
+    // When:
+    injector.inject(statement, builder);
+
+    // Then:
+    verify(builder).withName("foo");
   }
 
   @Test
@@ -190,13 +207,37 @@ public class TopicCreateInjectorTest {
     injector.inject(statement, builder);
 
     // Then:
-    verify(builder).withWithClause(statement.getStatement().getProperties());
+    verify(builder).withWithClause(((CreateAsSelect) (statement.getStatement())).getProperties());
+  }
+
+  @Test
+  public void shouldPassThroughWithClauseToBuilderForCreate() {
+    // Given:
+    givenStatement("CREATE STREAM x (FOO VARCHAR) WITH(kafka_topic='topic', partitions=2);");
+
+    // When:
+    injector.inject(statement, builder);
+
+    // Then:
+    verify(builder).withWithClause(((CreateSource) (statement.getStatement())).getProperties());
   }
 
   @Test
   public void shouldPassThroughOverridesToBuilder() {
     // Given:
     givenStatement("CREATE STREAM x WITH (kafka_topic='topic') AS SELECT * FROM SOURCE;");
+
+    // When:
+    injector.inject(statement, builder);
+
+    // Then:
+    verify(builder).withOverrides(overrides);
+  }
+
+  @Test
+  public void shouldPassThroughOverridesToBuilderForCreate() {
+    // Given:
+    givenStatement("CREATE STREAM x (FOO VARCHAR) WITH(kafka_topic='topic', partitions=2);");
 
     // When:
     injector.inject(statement, builder);
@@ -215,6 +256,30 @@ public class TopicCreateInjectorTest {
 
     // Then:
     verify(builder).withKsqlConfig(config);
+  }
+
+  @Test
+  public void shouldPassThroughConfigToBuilderForCreate() {
+    // Given:
+    givenStatement("CREATE STREAM x (FOO VARCHAR) WITH(kafka_topic='topic', partitions=2);");
+
+    // When:
+    injector.inject(statement, builder);
+
+    // Then:
+    verify(builder).withKsqlConfig(config);
+  }
+
+  @Test
+  public void shouldNotUseSourceTopicForCreate() {
+    // Given:
+    givenStatement("CREATE STREAM x (FOO VARCHAR) WITH(kafka_topic='topic', partitions=2);");
+
+    // When:
+    injector.inject(statement, builder);
+
+    // Then:
+    verify(builder, never()).withSource(any());
   }
 
   @Test
@@ -242,6 +307,7 @@ public class TopicCreateInjectorTest {
     verify(builder).withSource(argThat(supplierThatGets(sourceDescription)));
   }
 
+  @SuppressWarnings("unchecked")
   @Test
   public void shouldBuildWithClauseWithTopicProperties() {
     // Given:
@@ -249,7 +315,8 @@ public class TopicCreateInjectorTest {
     when(builder.build()).thenReturn(new TopicProperties("expectedName", 10, (short) 10));
 
     // When:
-    final ConfiguredStatement<CreateAsSelect> result = injector.inject(statement, builder);
+    final ConfiguredStatement<CreateAsSelect> result =
+        (ConfiguredStatement<CreateAsSelect>) injector.inject(statement, builder);
 
     // Then:
     assertThat(result.getStatement().getProperties(),
@@ -293,6 +360,23 @@ public class TopicCreateInjectorTest {
   }
 
   @Test
+  public void shouldCreateMissingTopicForCreate() {
+    // Given:
+    givenStatement("CREATE STREAM x WITH (kafka_topic='topic') AS SELECT * FROM SOURCE;");
+    when(builder.build()).thenReturn(new TopicProperties("expectedName", 10, (short) 10));
+
+    // When:
+    injector.inject(statement, builder);
+
+    // Then:
+    verify(topicClient).createTopic(
+        "expectedName",
+        10,
+        (short) 10,
+        ImmutableMap.of());
+  }
+
+  @Test
   public void shouldCreateMissingTopicWithCompactCleanupPolicyForNonWindowedTables() {
     // Given:
     givenStatement("CREATE TABLE x WITH (kafka_topic='topic') "
@@ -305,6 +389,23 @@ public class TopicCreateInjectorTest {
     // Then:
     verify(topicClient).createTopic(
         "expectedName",
+        10,
+        (short) 10,
+        ImmutableMap.of(TopicConfig.CLEANUP_POLICY_CONFIG, TopicConfig.CLEANUP_POLICY_COMPACT));
+  }
+
+  @Test
+  public void shouldCreateMissingTopicWithCompactCleanupPolicyForCreateTable() {
+    // Given:
+    givenStatement("CREATE TABLE foo (FOO VARCHAR) WITH (kafka_topic='topic');");
+    when(builder.build()).thenReturn(new TopicProperties("topic", 10, (short) 10));
+
+    // When:
+    injector.inject(statement, builder);
+
+    // Then:
+    verify(topicClient).createTopic(
+        "topic",
         10,
         (short) 10,
         ImmutableMap.of(TopicConfig.CLEANUP_POLICY_CONFIG, TopicConfig.CLEANUP_POLICY_COMPACT));
@@ -328,7 +429,6 @@ public class TopicCreateInjectorTest {
         ImmutableMap.of());
   }
 
-  @SuppressWarnings("unchecked")
   private ConfiguredStatement<?> givenStatement(final String sql) {
     final PreparedStatement<?> preparedStatement =
         parser.prepare(parser.parse(sql).get(0), metaStore);
@@ -337,9 +437,7 @@ public class TopicCreateInjectorTest {
             preparedStatement,
             overrides,
             config);
-    if (preparedStatement.getStatement() instanceof CreateAsSelect) {
-      statement = (ConfiguredStatement<CreateAsSelect>) configuredStatement;
-    }
+    statement = configuredStatement;
     return configuredStatement;
   }
 

--- a/ksql-engine/src/test/java/io/confluent/ksql/topic/TopicPropertiesTest.java
+++ b/ksql-engine/src/test/java/io/confluent/ksql/topic/TopicPropertiesTest.java
@@ -161,7 +161,7 @@ public class TopicPropertiesTest {
 
       // Expect:
       expectedException.expect(KsqlException.class);
-      expectedException.expectMessage("Cannot create determine partitions for creating topic");
+      expectedException.expectMessage("Cannot determine partitions for creating topic");
 
       // When:
       new TopicProperties.Builder()

--- a/ksql-engine/src/test/java/io/confluent/ksql/topic/TopicPropertiesTest.java
+++ b/ksql-engine/src/test/java/io/confluent/ksql/topic/TopicPropertiesTest.java
@@ -160,8 +160,8 @@ public class TopicPropertiesTest {
       ));
 
       // Expect:
-      expectedException.expect(NullPointerException.class);
-      expectedException.expectMessage("Was not supplied with any valid source for partitions!");
+      expectedException.expect(KsqlException.class);
+      expectedException.expectMessage("Cannot create determine partitions for creating topic");
 
       // When:
       new TopicProperties.Builder()

--- a/ksql-engine/src/test/java/io/confluent/ksql/topic/TopicPropertiesTest.java
+++ b/ksql-engine/src/test/java/io/confluent/ksql/topic/TopicPropertiesTest.java
@@ -192,8 +192,8 @@ public class TopicPropertiesTest {
       // Given:
       final Map<String, Literal> withClause = ImmutableMap.of(
           DdlConfig.KAFKA_TOPIC_NAME_PROPERTY, new StringLiteral("name"),
-          KsqlConstants.WITH_CLAUSE_PARTITIONS, new IntegerLiteral(1),
-          KsqlConstants.WITH_CLAUSE_REPLICAS, new IntegerLiteral(1)
+          KsqlConstants.SINK_NUMBER_OF_PARTITIONS, new IntegerLiteral(1),
+          KsqlConstants.SINK_NUMBER_OF_REPLICAS, new IntegerLiteral(1)
       );
 
       // When:
@@ -368,12 +368,12 @@ public class TopicPropertiesTest {
         case WITH:
           if (inject.partitions != null) {
             withClause.put(
-                KsqlConstants.WITH_CLAUSE_PARTITIONS,
+                KsqlConstants.SINK_NUMBER_OF_PARTITIONS,
                 new IntegerLiteral(inject.partitions));
           }
           if (inject.replicas != null) {
             withClause.put(
-                KsqlConstants.WITH_CLAUSE_REPLICAS,
+                KsqlConstants.SINK_NUMBER_OF_REPLICAS,
                 new IntegerLiteral(inject.replicas));
           }
           break;

--- a/ksql-engine/src/test/java/io/confluent/ksql/topic/TopicPropertiesTest.java
+++ b/ksql-engine/src/test/java/io/confluent/ksql/topic/TopicPropertiesTest.java
@@ -192,8 +192,8 @@ public class TopicPropertiesTest {
       // Given:
       final Map<String, Literal> withClause = ImmutableMap.of(
           DdlConfig.KAFKA_TOPIC_NAME_PROPERTY, new StringLiteral("name"),
-          KsqlConstants.SINK_NUMBER_OF_PARTITIONS, new IntegerLiteral(1),
-          KsqlConstants.SINK_NUMBER_OF_REPLICAS, new IntegerLiteral(1)
+          KsqlConstants.WITH_CLAUSE_PARTITIONS, new IntegerLiteral(1),
+          KsqlConstants.WITH_CLAUSE_REPLICAS, new IntegerLiteral(1)
       );
 
       // When:
@@ -368,12 +368,12 @@ public class TopicPropertiesTest {
         case WITH:
           if (inject.partitions != null) {
             withClause.put(
-                KsqlConstants.SINK_NUMBER_OF_PARTITIONS,
+                KsqlConstants.WITH_CLAUSE_PARTITIONS,
                 new IntegerLiteral(inject.partitions));
           }
           if (inject.replicas != null) {
             withClause.put(
-                KsqlConstants.SINK_NUMBER_OF_REPLICAS,
+                KsqlConstants.WITH_CLAUSE_REPLICAS,
                 new IntegerLiteral(inject.replicas));
           }
           break;

--- a/ksql-parser/src/main/java/io/confluent/ksql/parser/tree/CreateSource.java
+++ b/ksql-parser/src/main/java/io/confluent/ksql/parser/tree/CreateSource.java
@@ -26,14 +26,14 @@ import java.util.Objects;
 import java.util.Optional;
 
 @Immutable
-public abstract class AbstractStreamCreateStatement extends Statement {
+public abstract class CreateSource extends Statement {
 
   private final QualifiedName name;
   private final ImmutableList<TableElement> elements;
   private final boolean notExists;
   private final ImmutableMap<String, Literal> properties;
 
-  AbstractStreamCreateStatement(
+  CreateSource(
       final Optional<NodeLocation> location,
       final QualifiedName name,
       final List<TableElement> elements,
@@ -63,7 +63,7 @@ public abstract class AbstractStreamCreateStatement extends Statement {
     return notExists;
   }
 
-  public abstract AbstractStreamCreateStatement copyWith(
+  public abstract CreateSource copyWith(
       List<TableElement> elements,
       Map<String, Literal> properties);
 
@@ -77,10 +77,10 @@ public abstract class AbstractStreamCreateStatement extends Statement {
     if (this == o) {
       return true;
     }
-    if (!(o instanceof AbstractStreamCreateStatement)) {
+    if (!(o instanceof CreateSource)) {
       return false;
     }
-    final AbstractStreamCreateStatement that = (AbstractStreamCreateStatement) o;
+    final CreateSource that = (CreateSource) o;
     return notExists == that.notExists
         && Objects.equals(name, that.name)
         && Objects.equals(elements, that.elements)

--- a/ksql-parser/src/main/java/io/confluent/ksql/parser/tree/CreateStream.java
+++ b/ksql-parser/src/main/java/io/confluent/ksql/parser/tree/CreateStream.java
@@ -23,7 +23,7 @@ import java.util.Map;
 import java.util.Optional;
 
 @Immutable
-public class CreateStream extends AbstractStreamCreateStatement implements ExecutableDdlStatement {
+public class CreateStream extends CreateSource implements ExecutableDdlStatement {
 
   public CreateStream(
       final QualifiedName name,
@@ -45,7 +45,7 @@ public class CreateStream extends AbstractStreamCreateStatement implements Execu
   }
 
   @Override
-  public AbstractStreamCreateStatement copyWith(
+  public CreateSource copyWith(
       final List<TableElement> elements,
       final Map<String, Literal> properties
   ) {

--- a/ksql-parser/src/main/java/io/confluent/ksql/parser/tree/CreateTable.java
+++ b/ksql-parser/src/main/java/io/confluent/ksql/parser/tree/CreateTable.java
@@ -23,7 +23,7 @@ import java.util.Map;
 import java.util.Optional;
 
 @Immutable
-public class CreateTable extends AbstractStreamCreateStatement implements ExecutableDdlStatement {
+public class CreateTable extends CreateSource implements ExecutableDdlStatement {
 
   public CreateTable(
       final QualifiedName name,
@@ -45,7 +45,7 @@ public class CreateTable extends AbstractStreamCreateStatement implements Execut
   }
 
   @Override
-  public AbstractStreamCreateStatement copyWith(
+  public CreateSource copyWith(
       final List<TableElement> elements,
       final Map<String, Literal> properties
   ) {

--- a/ksql-rest-app/src/main/java/io/confluent/ksql/rest/server/StandaloneExecutor.java
+++ b/ksql-rest-app/src/main/java/io/confluent/ksql/rest/server/StandaloneExecutor.java
@@ -22,7 +22,7 @@ import io.confluent.ksql.function.UdfLoader;
 import io.confluent.ksql.logging.processing.ProcessingLogConfig;
 import io.confluent.ksql.parser.KsqlParser.ParsedStatement;
 import io.confluent.ksql.parser.KsqlParser.PreparedStatement;
-import io.confluent.ksql.parser.tree.AbstractStreamCreateStatement;
+import io.confluent.ksql.parser.tree.CreateSource;
 import io.confluent.ksql.parser.tree.CreateStream;
 import io.confluent.ksql.parser.tree.CreateStreamAsSelect;
 import io.confluent.ksql.parser.tree.CreateTable;
@@ -305,11 +305,11 @@ public class StandaloneExecutor implements Executable {
     }
 
     private static void throwOnMissingSchema(final ConfiguredStatement<?> statement) {
-      if (!(statement.getStatement() instanceof AbstractStreamCreateStatement)) {
+      if (!(statement.getStatement() instanceof CreateSource)) {
         return;
       }
 
-      if (!((AbstractStreamCreateStatement) statement.getStatement()).getElements().isEmpty()) {
+      if (!((CreateSource) statement.getStatement()).getElements().isEmpty()) {
         return;
       }
 

--- a/ksql-rest-app/src/main/java/io/confluent/ksql/rest/server/execution/InsertValuesExecutor.java
+++ b/ksql-rest-app/src/main/java/io/confluent/ksql/rest/server/execution/InsertValuesExecutor.java
@@ -69,6 +69,11 @@ public class InsertValuesExecutor {
       final KsqlExecutionContext executionContext,
       final ServiceContext serviceContext
   ) {
+    if (!statement.getConfig().getBoolean(KsqlConfig.KSQL_INSERT_INTO_VALUES_ENABLED)) {
+      throw new KsqlException("The server has disabled INSERT INTO ... VALUES functionality. "
+          + "To enable it, restart your KSQL-server with 'ksql.insert.into.values.enabled'=true");
+    }
+
     final InsertValues insertValues = statement.getStatement();
     final DataSource<?> dataSource = executionContext
         .getMetaStore()

--- a/ksql-rest-app/src/main/java/io/confluent/ksql/rest/util/ProcessingLogServerUtils.java
+++ b/ksql-rest-app/src/main/java/io/confluent/ksql/rest/util/ProcessingLogServerUtils.java
@@ -25,7 +25,7 @@ import io.confluent.ksql.parser.DefaultKsqlParser;
 import io.confluent.ksql.parser.KsqlParser.ParsedStatement;
 import io.confluent.ksql.parser.KsqlParser.PreparedStatement;
 import io.confluent.ksql.parser.SqlFormatter;
-import io.confluent.ksql.parser.tree.AbstractStreamCreateStatement;
+import io.confluent.ksql.parser.tree.CreateSource;
 import io.confluent.ksql.parser.tree.TableElement;
 import io.confluent.ksql.services.KafkaTopicClient;
 import io.confluent.ksql.util.KsqlConfig;
@@ -108,9 +108,9 @@ public final class ProcessingLogServerUtils {
     final PreparedStatement<?> preparedStatement = parser
         .prepare(parsed, new MetaStoreImpl(new InternalFunctionRegistry()));
 
-    final AbstractStreamCreateStatement streamCreateStatement
-        = (AbstractStreamCreateStatement) preparedStatement.getStatement();
-    final AbstractStreamCreateStatement streamCreateStatementWithSchema =
+    final CreateSource streamCreateStatement
+        = (CreateSource) preparedStatement.getStatement();
+    final CreateSource streamCreateStatementWithSchema =
         streamCreateStatement.copyWith(
             TableElement.fromSchema(schema),
             streamCreateStatement.getProperties());

--- a/ksql-rest-app/src/test/java/io/confluent/ksql/rest/server/execution/InsertValuesExecutorTest.java
+++ b/ksql-rest-app/src/test/java/io/confluent/ksql/rest/server/execution/InsertValuesExecutorTest.java
@@ -470,6 +470,27 @@ public class InsertValuesExecutorTest {
     new InsertValuesExecutor(() -> 1L).execute(statement, engine, serviceContext);
   }
 
+  @Test
+  public void shouldThrowIfInsertValuesIsDisabled() {
+    // Given:
+    givenDataSourceWithSchema(STRICT_SCHEMA);
+
+    final ConfiguredStatement<InsertValues> statement = givenInsertValues(
+        ImmutableList.of("ROWKEY"),
+        ImmutableList.of(
+            new StringLiteral("1.1")
+        )
+    ).withConfig(
+        new KsqlConfig(ImmutableMap.of(KsqlConfig.KSQL_INSERT_INTO_VALUES_ENABLED, false)));
+
+    // Expect:
+    expectedException.expect(KsqlException.class);
+    expectedException.expectMessage("The server has disabled INSERT INTO ... VALUES ");
+
+    // When:
+    new InsertValuesExecutor(() -> 1L).execute(statement, engine, serviceContext);
+  }
+
   private ConfiguredStatement<InsertValues> givenInsertValues(
       final List<String> columns,
       final List<Expression> values


### PR DESCRIPTION
### Description 
This PR completes the developer testing dream: you may now optionally create topics via `CREATE STREAM/TABLE`! 

Minor Changes:
* Rename `AbstractCreateStreamStatement` to `CreateSource` because verbosity
* Use the passed in replicationFactor to validate a topic in KafkaTopicClientImpl, not the resolved one
* Added full documentation for INSERT INTO suite (more to come with examples soon!)
* Added config to enable/disable INSERT INTO functionality

### Testing done 
- Unit Tests
- The below test (`fubar` did not exist before this command):
```
ksql> CREATE STREAM fubar (FOO VARCHAR, BAR INT) WITH(kafka_topic='fubar', partitions=1, value_format='json');
ksql> INSERT INTO fubar VALUES ('key', 'foo', 123);
ksql> SELECT * FROM fubar;
1556753838733 | key | foo | 123

// test supply wrong partitions experience
ksql> CREATE STREAM fubar (FOO VARCHAR, BAR INT) WITH(kafka_topic='fubar', partitions=10, value_format='json');
A Kafka topic with the name 'fubar' already exists, with different partition/replica configuration than required. KSQL expects 10 partitions (topic has 1), and 1 replication factor (topic has 1).

// test create without partitions experience
ksql> CREATE STREAM fubar (FOO VARCHAR, BAR INT) WITH(kafka_topic='fubar2', value_format='json');
Topic 'fubar2' does not exist. If you want to create a new topic for the stream/table please re-run the statement providing th required 'PARTITIONS' configuration in the WITH clause (and optionally 'REPLICAS'). For example: CREATE STREAM FUBAR (FOO STRING, BAR INTEGER) WITH (REPLICAS=1, PARTITIONS=2, KAFKA_TOPIC='fubar2', VALUE_FORMAT='json');
```

### Reviewer checklist
- [ ] Ensure docs are updated if necessary. (eg. if a user visible feature is being added or changed).
- [ ] Ensure relevant issues are linked (description should include text like "Fixes #<issue number>")

