### PR TITLE
Introduce Injectors enum to group together common Injector chains

### DIFF
--- a/ksql-engine/src/main/java/io/confluent/ksql/KsqlContext.java
+++ b/ksql-engine/src/main/java/io/confluent/ksql/KsqlContext.java
@@ -26,15 +26,11 @@ import io.confluent.ksql.metastore.MetaStore;
 import io.confluent.ksql.parser.KsqlParser.ParsedStatement;
 import io.confluent.ksql.parser.KsqlParser.PreparedStatement;
 import io.confluent.ksql.query.QueryId;
-import io.confluent.ksql.schema.inference.DefaultSchemaInjector;
-import io.confluent.ksql.schema.inference.SchemaRegistryTopicSchemaSupplier;
 import io.confluent.ksql.services.DefaultServiceContext;
 import io.confluent.ksql.services.ServiceContext;
 import io.confluent.ksql.statement.ConfiguredStatement;
 import io.confluent.ksql.statement.Injector;
-import io.confluent.ksql.statement.InjectorChain;
-import io.confluent.ksql.topic.TopicCreateInjector;
-import io.confluent.ksql.topic.TopicDeleteInjector;
+import io.confluent.ksql.statement.Injectors;
 import io.confluent.ksql.util.KsqlConfig;
 import io.confluent.ksql.util.PersistentQueryMetadata;
 import io.confluent.ksql.util.QueryMetadata;
@@ -81,11 +77,7 @@ public class KsqlContext {
         serviceContext,
         ksqlConfig,
         engine,
-        (ec, sc) -> InjectorChain.of(
-            new DefaultSchemaInjector(
-                new SchemaRegistryTopicSchemaSupplier(sc.getSchemaRegistryClient())),
-            new TopicCreateInjector(ec),
-            new TopicDeleteInjector(ec))
+        Injectors.DEFAULT
     );
   }
 

--- a/ksql-engine/src/main/java/io/confluent/ksql/statement/Injectors.java
+++ b/ksql-engine/src/main/java/io/confluent/ksql/statement/Injectors.java
@@ -1,0 +1,52 @@
+/*
+ * Copyright 2019 Confluent Inc.
+ *
+ * Licensed under the Confluent Community License (the "License"; you may not use
+ * this file except in compliance with the License. You may obtain a copy of the
+ * License at
+ *
+ * http://www.confluent.io/confluent-community-license
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package io.confluent.ksql.statement;
+
+import io.confluent.ksql.KsqlExecutionContext;
+import io.confluent.ksql.schema.inference.DefaultSchemaInjector;
+import io.confluent.ksql.schema.inference.SchemaRegistryTopicSchemaSupplier;
+import io.confluent.ksql.services.ServiceContext;
+import io.confluent.ksql.topic.TopicCreateInjector;
+import io.confluent.ksql.topic.TopicDeleteInjector;
+import java.util.Objects;
+import java.util.function.BiFunction;
+
+public enum Injectors implements BiFunction<KsqlExecutionContext, ServiceContext, Injector> {
+
+  NO_TOPIC_DELETE((ec, sc) -> InjectorChain.of(
+      new DefaultSchemaInjector(
+          new SchemaRegistryTopicSchemaSupplier(sc.getSchemaRegistryClient())),
+      new TopicCreateInjector(ec)
+  )),
+
+  DEFAULT((ec, sc) -> InjectorChain.of(
+      NO_TOPIC_DELETE.apply(ec, sc),
+      new TopicDeleteInjector(ec)
+  ))
+  ;
+
+  private final BiFunction<KsqlExecutionContext, ServiceContext, Injector> injectorFactory;
+
+  Injectors(final BiFunction<KsqlExecutionContext, ServiceContext, Injector> injectorFactory) {
+    this.injectorFactory = Objects.requireNonNull(injectorFactory, "injectorFactory");
+  }
+
+  @Override
+  public Injector apply(final KsqlExecutionContext executionContext,
+      final ServiceContext serviceContext) {
+    return injectorFactory.apply(executionContext, serviceContext);
+  }
+}

--- a/ksql-engine/src/test/java/io/confluent/ksql/KsqlContextTestUtil.java
+++ b/ksql-engine/src/test/java/io/confluent/ksql/KsqlContextTestUtil.java
@@ -20,16 +20,12 @@ import io.confluent.kafka.schemaregistry.client.SchemaRegistryClient;
 import io.confluent.ksql.engine.KsqlEngine;
 import io.confluent.ksql.function.FunctionRegistry;
 import io.confluent.ksql.logging.processing.ProcessingLogContext;
-import io.confluent.ksql.schema.inference.DefaultSchemaInjector;
-import io.confluent.ksql.statement.InjectorChain;
-import io.confluent.ksql.topic.TopicCreateInjector;
-import io.confluent.ksql.schema.inference.SchemaRegistryTopicSchemaSupplier;
 import io.confluent.ksql.services.KafkaTopicClient;
 import io.confluent.ksql.services.KafkaTopicClientImpl;
 import io.confluent.ksql.services.ServiceContext;
 import io.confluent.ksql.services.TestServiceContext;
+import io.confluent.ksql.statement.Injectors;
 import io.confluent.ksql.test.util.EmbeddedSingleNodeKafkaCluster;
-import io.confluent.ksql.topic.TopicDeleteInjector;
 import io.confluent.ksql.util.KsqlConfig;
 import java.util.Collections;
 import java.util.HashMap;
@@ -72,17 +68,11 @@ public final class KsqlContextTestUtil {
         ksqlConfig.getString(KsqlConfig.KSQL_SERVICE_ID_CONFIG)
     );
 
-    final DefaultSchemaInjector schemaInjector = new DefaultSchemaInjector(
-        new SchemaRegistryTopicSchemaSupplier(serviceContext.getSchemaRegistryClient()));
     return new KsqlContext(
         serviceContext,
         ksqlConfig,
         engine,
-        (ec, sc) -> InjectorChain.of(
-            schemaInjector,
-            new TopicCreateInjector(ec),
-            new TopicDeleteInjector(ec)
-        )
+        Injectors.DEFAULT
     );
   }
 

--- a/ksql-rest-app/src/main/java/io/confluent/ksql/rest/server/KsqlRestApplication.java
+++ b/ksql-rest-app/src/main/java/io/confluent/ksql/rest/server/KsqlRestApplication.java
@@ -56,14 +56,10 @@ import io.confluent.ksql.rest.server.resources.streaming.WSQueryEndpoint;
 import io.confluent.ksql.rest.util.ClusterTerminator;
 import io.confluent.ksql.rest.util.KsqlInternalTopicUtils;
 import io.confluent.ksql.rest.util.ProcessingLogServerUtils;
-import io.confluent.ksql.schema.inference.DefaultSchemaInjector;
-import io.confluent.ksql.schema.inference.SchemaRegistryTopicSchemaSupplier;
 import io.confluent.ksql.services.DefaultServiceContext;
 import io.confluent.ksql.services.ServiceContext;
 import io.confluent.ksql.statement.ConfiguredStatement;
-import io.confluent.ksql.statement.InjectorChain;
-import io.confluent.ksql.topic.TopicCreateInjector;
-import io.confluent.ksql.topic.TopicDeleteInjector;
+import io.confluent.ksql.statement.Injectors;
 import io.confluent.ksql.util.KsqlConfig;
 import io.confluent.ksql.util.KsqlException;
 import io.confluent.ksql.util.Version;
@@ -409,12 +405,7 @@ public final class KsqlRestApplication extends Application<KsqlRestConfig> imple
         commandStore,
         Duration.ofMillis(restConfig.getLong(DISTRIBUTED_COMMAND_RESPONSE_TIMEOUT_MS_CONFIG)),
         versionChecker::updateLastRequestTime,
-        (ec, sc) -> InjectorChain.of(
-            new DefaultSchemaInjector(
-                new SchemaRegistryTopicSchemaSupplier(sc.getSchemaRegistryClient())),
-            new TopicCreateInjector(ec),
-            new TopicDeleteInjector(ec)
-        ));
+        Injectors.DEFAULT);
 
     final Optional<String> processingLogTopic =
         ProcessingLogServerUtils.maybeCreateProcessingLogTopic(

--- a/ksql-rest-app/src/main/java/io/confluent/ksql/rest/server/StandaloneExecutorFactory.java
+++ b/ksql-rest-app/src/main/java/io/confluent/ksql/rest/server/StandaloneExecutorFactory.java
@@ -26,13 +26,10 @@ import io.confluent.ksql.logging.processing.ProcessingLogContext;
 import io.confluent.ksql.rest.server.computation.ConfigStore;
 import io.confluent.ksql.rest.server.computation.KafkaConfigStore;
 import io.confluent.ksql.rest.util.KsqlInternalTopicUtils;
-import io.confluent.ksql.schema.inference.DefaultSchemaInjector;
-import io.confluent.ksql.schema.inference.SchemaRegistryTopicSchemaSupplier;
 import io.confluent.ksql.services.DefaultServiceContext;
 import io.confluent.ksql.services.ServiceContext;
 import io.confluent.ksql.statement.Injector;
-import io.confluent.ksql.statement.InjectorChain;
-import io.confluent.ksql.topic.TopicCreateInjector;
+import io.confluent.ksql.statement.Injectors;
 import io.confluent.ksql.util.KsqlConfig;
 import io.confluent.ksql.version.metrics.KsqlVersionCheckerAgent;
 import io.confluent.ksql.version.metrics.VersionCheckerAgent;
@@ -131,11 +128,7 @@ public final class StandaloneExecutorFactory {
         udfLoader,
         true,
         versionChecker,
-        (ec, sc) -> InjectorChain.of(
-            new DefaultSchemaInjector(
-                new SchemaRegistryTopicSchemaSupplier(sc.getSchemaRegistryClient())),
-            new TopicCreateInjector(ec)
-        )
+        Injectors.NO_TOPIC_DELETE
     );
   }
 }

--- a/ksql-rest-app/src/test/java/io/confluent/ksql/rest/server/computation/RecoveryTest.java
+++ b/ksql-rest-app/src/test/java/io/confluent/ksql/rest/server/computation/RecoveryTest.java
@@ -40,17 +40,13 @@ import io.confluent.ksql.rest.server.computation.CommandId.Action;
 import io.confluent.ksql.rest.server.computation.CommandId.Type;
 import io.confluent.ksql.rest.server.resources.KsqlResource;
 import io.confluent.ksql.rest.util.ClusterTerminator;
-import io.confluent.ksql.schema.inference.DefaultSchemaInjector;
-import io.confluent.ksql.schema.inference.SchemaRegistryTopicSchemaSupplier;
 import io.confluent.ksql.schema.ksql.KsqlSchema;
 import io.confluent.ksql.serde.KsqlTopicSerDe;
 import io.confluent.ksql.services.FakeKafkaTopicClient;
 import io.confluent.ksql.services.ServiceContext;
 import io.confluent.ksql.services.TestServiceContext;
 import io.confluent.ksql.statement.ConfiguredStatement;
-import io.confluent.ksql.statement.InjectorChain;
-import io.confluent.ksql.topic.TopicCreateInjector;
-import io.confluent.ksql.topic.TopicDeleteInjector;
+import io.confluent.ksql.statement.Injectors;
 import io.confluent.ksql.util.KsqlConfig;
 import io.confluent.ksql.util.PersistentQueryMetadata;
 import io.confluent.ksql.util.timestamp.TimestampExtractionPolicy;
@@ -175,12 +171,7 @@ public class RecoveryTest {
           fakeCommandQueue,
           Duration.ofMillis(0),
           ()->{},
-          (ec, sc) -> InjectorChain.of(
-              new DefaultSchemaInjector(
-                  new SchemaRegistryTopicSchemaSupplier(sc.getSchemaRegistryClient())),
-              new TopicCreateInjector(ec),
-              new TopicDeleteInjector(ec)
-          ));
+          Injectors.DEFAULT);
       this.statementExecutor = new StatementExecutor(
           ksqlConfig,
           ksqlEngine,


### PR DESCRIPTION
### Description 
Porting the Injectors enum change from #2712 to its own PR so that I can expedite it and focus on just the Set/Unset reactor in the other PR.

### Testing done 
- The usual, no functional changes here

### Reviewer checklist
- [ ] Ensure docs are updated if necessary. (eg. if a user visible feature is being added or changed).
- [ ] Ensure relevant issues are linked (description should include text like "Fixes #<issue number>")

