### PR TITLE
fix some issues with INSERT INTO

### DIFF
--- a/ksql-common/src/main/java/io/confluent/ksql/util/SchemaUtil.java
+++ b/ksql-common/src/main/java/io/confluent/ksql/util/SchemaUtil.java
@@ -367,6 +367,10 @@ public final class SchemaUtil {
         .build();
   }
 
+  public static boolean canUpCast(final Schema.Type expected, final Schema.Type actual) {
+    return ARITHMETIC_TYPE_ORDERING.max(expected, actual) == expected;
+  }
+
   private static SchemaBuilder handleParametrizedType(final Type type) {
     if (type instanceof ParameterizedType) {
       final ParameterizedType parameterizedType = (ParameterizedType) type;

--- a/ksql-common/src/main/java/io/confluent/ksql/util/SchemaUtil.java
+++ b/ksql-common/src/main/java/io/confluent/ksql/util/SchemaUtil.java
@@ -31,6 +31,7 @@ import java.lang.reflect.Type;
 import java.util.List;
 import java.util.Map;
 import java.util.NavigableMap;
+import java.util.Optional;
 import java.util.Set;
 import java.util.function.Function;
 import java.util.function.Supplier;
@@ -77,6 +78,14 @@ public final class SchemaUtil {
           Schema.Type.FLOAT32,
           Schema.Type.FLOAT64
       );
+
+  private static final Map<Schema.Type, Function<Number, Number>> UPCASTER =
+      ImmutableMap.<Schema.Type, Function<Number, Number>>builder()
+          .put(Schema.Type.INT32, Number::intValue)
+          .put(Schema.Type.INT64, Number::longValue)
+          .put(Schema.Type.FLOAT32, Number::floatValue)
+          .put(Schema.Type.FLOAT64, Number::doubleValue)
+          .build();
 
   private static final Set<Schema.Type> ARITHMETIC_TYPES =
       ImmutableSet.copyOf(ARITHMETIC_TYPES_LIST);
@@ -367,8 +376,18 @@ public final class SchemaUtil {
         .build();
   }
 
-  public static boolean canUpCast(final Schema.Type expected, final Schema.Type actual) {
+  private static boolean canUpCast(final Schema.Type expected, final Schema.Type actual) {
     return ARITHMETIC_TYPE_ORDERING.max(expected, actual) == expected;
+  }
+
+  public static Optional<Number> maybeUpCast(
+      final Schema.Type expected,
+      final Schema.Type actual,
+      final Object value
+  ) {
+    return value instanceof Number && isNumber(actual) && canUpCast(expected, actual)
+        ? Optional.of(UPCASTER.get(expected).apply((Number) value))
+        : Optional.empty();
   }
 
   private static SchemaBuilder handleParametrizedType(final Type type) {

--- a/ksql-common/src/test/java/io/confluent/ksql/util/SchemaUtilTest.java
+++ b/ksql-common/src/test/java/io/confluent/ksql/util/SchemaUtilTest.java
@@ -15,6 +15,8 @@
 
 package io.confluent.ksql.util;
 
+import static java.util.Optional.empty;
+import static java.util.Optional.of;
 import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.CoreMatchers.nullValue;
@@ -753,6 +755,66 @@ public class SchemaUtilTest {
         .optional()
         .build()
     ));
+  }
+
+  @Test
+  public void shouldUpCastInt() {
+    // Given:
+    final int val = 1;
+
+    // Then:
+    assertThat(SchemaUtil.maybeUpCast(Schema.Type.INT64, Schema.Type.INT32, val), is(of(1L)));
+    assertThat(SchemaUtil.maybeUpCast(Schema.Type.FLOAT32, Schema.Type.INT32, val), is(of(1f)));
+    assertThat(SchemaUtil.maybeUpCast(Schema.Type.FLOAT64, Schema.Type.INT32, val), is(of(1d)));
+  }
+
+  @Test
+  public void shouldUpCastLong() {
+    // Given:
+    final long val = 1L;
+
+    // Then:
+    assertThat(SchemaUtil.maybeUpCast(Schema.Type.FLOAT32, Schema.Type.INT64, val), is(of(1f)));
+    assertThat(SchemaUtil.maybeUpCast(Schema.Type.FLOAT64, Schema.Type.INT64, val), is(of(1d)));
+  }
+
+  @Test
+  public void shouldUpCastFloat() {
+    // Given:
+    final float val = 1f;
+
+    // Then:
+    assertThat(SchemaUtil.maybeUpCast(Schema.Type.FLOAT64, Schema.Type.FLOAT32, val), is(of(1d)));
+  }
+
+  @Test
+  public void shouldNotDownCastLong() {
+    // Given:
+    final long val = 1L;
+
+    // Expect:
+    assertThat(SchemaUtil.maybeUpCast(Schema.Type.INT32, Schema.Type.INT64, val), is(empty()));
+  }
+
+  @Test
+  public void shouldNotDownCastFloat() {
+    // Given:
+    final float val = 1f;
+
+    // Expect:
+    assertThat(SchemaUtil.maybeUpCast(Schema.Type.INT64, Schema.Type.FLOAT32, val), is(empty()));
+    assertThat(SchemaUtil.maybeUpCast(Schema.Type.INT32, Schema.Type.FLOAT32, val), is(empty()));
+  }
+
+  @Test
+  public void shouldNotDownCastDouble() {
+    // Given:
+    final double val = 1d;
+
+    // Expect:
+    assertThat(SchemaUtil.maybeUpCast(Schema.Type.FLOAT32, Schema.Type.FLOAT64, val), is(empty()));
+    assertThat(SchemaUtil.maybeUpCast(Schema.Type.INT64, Schema.Type.FLOAT64, val), is(empty()));
+    assertThat(SchemaUtil.maybeUpCast(Schema.Type.INT32, Schema.Type.FLOAT64, val), is(empty()));
   }
 
   // Following methods not invoked but used to test conversion from Type -> Schema

--- a/ksql-engine/src/main/java/io/confluent/ksql/services/SandboxedSchemaRegistryClient.java
+++ b/ksql-engine/src/main/java/io/confluent/ksql/services/SandboxedSchemaRegistryClient.java
@@ -15,6 +15,7 @@
 
 package io.confluent.ksql.services;
 
+import static io.confluent.ksql.util.LimitedProxyBuilder.anyParams;
 import static io.confluent.ksql.util.LimitedProxyBuilder.methodParams;
 
 import io.confluent.kafka.schemaregistry.client.SchemaRegistryClient;
@@ -37,6 +38,7 @@ final class SandboxedSchemaRegistryClient {
     Objects.requireNonNull(delegate, "delegate");
 
     return LimitedProxyBuilder.forClass(SchemaRegistryClient.class)
+        .swallow("register", anyParams(), 123)
         .forward("getLatestSchemaMetadata", methodParams(String.class), delegate)
         .forward("testCompatibility",
             methodParams(String.class, Schema.class), delegate)

--- a/ksql-engine/src/test/java/io/confluent/ksql/services/SandboxedSchemaRegistryClientTest.java
+++ b/ksql-engine/src/test/java/io/confluent/ksql/services/SandboxedSchemaRegistryClientTest.java
@@ -48,6 +48,8 @@ public final class SandboxedSchemaRegistryClientTest {
     @Parameterized.Parameters(name = "{0}")
     public static Collection<TestCase<SchemaRegistryClient>> getMethodsToTest() {
       return TestMethods.builder(SchemaRegistryClient.class)
+          .ignore("register", String.class, Schema.class)
+          .ignore("register", String.class, Schema.class, int.class, int.class)
           .ignore("getLatestSchemaMetadata", String.class)
           .ignore("testCompatibility", String.class, Schema.class)
           .ignore("deleteSubject", String.class)

--- a/ksql-rest-app/src/main/java/io/confluent/ksql/rest/server/KsqlRestApplication.java
+++ b/ksql-rest-app/src/main/java/io/confluent/ksql/rest/server/KsqlRestApplication.java
@@ -96,6 +96,7 @@ import javax.ws.rs.core.Configurable;
 import org.apache.kafka.common.errors.UnsupportedVersionException;
 import org.eclipse.jetty.server.ServerConnector;
 import org.eclipse.jetty.websocket.jsr356.server.ServerContainer;
+import org.glassfish.hk2.utilities.Binder;
 import org.glassfish.jersey.server.ServerProperties;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -120,6 +121,7 @@ public final class KsqlRestApplication extends Application<KsqlRestConfig> imple
   private final ServerInfo serverInfo;
   private final VersionCheckerAgent versionCheckerAgent;
   private final ServiceContext serviceContext;
+  private final Function<KsqlConfig, Binder> serviceContextBinder;
 
   public static String getCommandsStreamName() {
     return COMMANDS_STREAM_NAME;
@@ -138,8 +140,8 @@ public final class KsqlRestApplication extends Application<KsqlRestConfig> imple
       final StatusResource statusResource,
       final StreamedQueryResource streamedQueryResource,
       final KsqlResource ksqlResource,
-      final VersionCheckerAgent versionCheckerAgent
-  ) {
+      final VersionCheckerAgent versionCheckerAgent,
+      final Function<KsqlConfig, Binder> serviceContextBinder) {
     super(config);
     this.serviceContext = Objects.requireNonNull(serviceContext, "serviceContext");
     this.ksqlConfig = Objects.requireNonNull(ksqlConfig, "ksqlConfig");
@@ -154,6 +156,7 @@ public final class KsqlRestApplication extends Application<KsqlRestConfig> imple
 
     this.versionCheckerAgent =
         Objects.requireNonNull(versionCheckerAgent, "versionCheckerAgent");
+    this.serviceContextBinder = serviceContextBinder;
     this.serverInfo = new ServerInfo(
         Version.getVersion(),
         getKafkaClusterId(serviceContext),
@@ -242,7 +245,7 @@ public final class KsqlRestApplication extends Application<KsqlRestConfig> imple
         new JacksonMessageBodyProvider(JsonMapper.INSTANCE.mapper);
     config.register(jsonProvider);
     config.register(JsonParseExceptionMapper.class);
-    config.register(new KsqlRestServiceContextBinder(ksqlConfig));
+    config.register(serviceContextBinder.apply(ksqlConfig));
 
     // Don't want to buffer rows when streaming JSON in a request to the query resource
     config.property(ServerProperties.OUTBOUND_CONTENT_LENGTH_BUFFER, 0);
@@ -304,14 +307,20 @@ public final class KsqlRestApplication extends Application<KsqlRestConfig> imple
     final KsqlConfig ksqlConfig = new KsqlConfig(restConfig.getKsqlConfigProperties());
     final ServiceContext serviceContext = DefaultServiceContext.create(ksqlConfig);
 
-    return buildApplication(restConfig, versionCheckerFactory, maxStatementRetries, serviceContext);
+    return buildApplication(
+        restConfig,
+        versionCheckerFactory,
+        maxStatementRetries,
+        serviceContext,
+        KsqlRestServiceContextBinder::new);
   }
 
   static KsqlRestApplication buildApplication(
       final KsqlRestConfig restConfig,
       final Function<Supplier<Boolean>, VersionCheckerAgent> versionCheckerFactory,
       final int maxStatementRetries,
-      final ServiceContext serviceContext
+      final ServiceContext serviceContext,
+      final Function<KsqlConfig, Binder> serviceContextBinder
   ) {
     final String ksqlInstallDir = restConfig.getString(KsqlRestConfig.INSTALL_DIR_CONFIG);
 
@@ -443,7 +452,8 @@ public final class KsqlRestApplication extends Application<KsqlRestConfig> imple
         statusResource,
         streamedQueryResource,
         ksqlResource,
-        versionChecker
+        versionChecker,
+        serviceContextBinder
     );
   }
 

--- a/ksql-rest-app/src/main/java/io/confluent/ksql/rest/server/execution/InsertValuesExecutor.java
+++ b/ksql-rest-app/src/main/java/io/confluent/ksql/rest/server/execution/InsertValuesExecutor.java
@@ -16,7 +16,6 @@
 package io.confluent.ksql.rest.server.execution;
 
 import com.google.common.annotations.VisibleForTesting;
-import com.google.common.collect.ImmutableMap;
 import io.confluent.ksql.GenericRow;
 import io.confluent.ksql.KsqlExecutionContext;
 import io.confluent.ksql.logging.processing.NoopProcessingLogContext;
@@ -41,7 +40,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
-import java.util.function.Function;
 import java.util.function.LongSupplier;
 import java.util.stream.Collectors;
 import org.apache.kafka.clients.producer.Producer;

--- a/ksql-rest-app/src/test/java/io/confluent/ksql/rest/server/KsqlRestApplicationTest.java
+++ b/ksql-rest-app/src/test/java/io/confluent/ksql/rest/server/KsqlRestApplicationTest.java
@@ -18,7 +18,6 @@ package io.confluent.ksql.rest.server;
 import static io.confluent.ksql.parser.ParserMatchers.configured;
 import static org.hamcrest.Matchers.equalTo;
 import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoMoreInteractions;
@@ -32,6 +31,7 @@ import io.confluent.ksql.parser.KsqlParser.PreparedStatement;
 import io.confluent.ksql.rest.server.computation.CommandQueue;
 import io.confluent.ksql.rest.server.computation.CommandRunner;
 import io.confluent.ksql.rest.server.computation.QueuedCommandStatus;
+import io.confluent.ksql.rest.server.context.KsqlRestServiceContextBinder;
 import io.confluent.ksql.rest.server.resources.KsqlResource;
 import io.confluent.ksql.rest.server.resources.RootDocument;
 import io.confluent.ksql.rest.server.resources.StatusResource;
@@ -115,7 +115,8 @@ public class KsqlRestApplicationTest {
         statusResource,
         streamedQueryResource,
         ksqlResource,
-        versionCheckerAgent
+        versionCheckerAgent,
+        KsqlRestServiceContextBinder::new
     );
   }
 

--- a/ksql-rest-app/src/test/java/io/confluent/ksql/rest/server/TestKsqlRestApp.java
+++ b/ksql-rest-app/src/test/java/io/confluent/ksql/rest/server/TestKsqlRestApp.java
@@ -82,7 +82,7 @@ public class TestKsqlRestApp extends ExternalResource {
   private final Map<String, ?> baseConfig;
   private final Supplier<String> bootstrapServers;
   private final Supplier<ServiceContext> serviceContext;
-  private final Function<KsqlConfig, Binder> serviceContextBinder;
+  private final Function<KsqlConfig, Binder> serviceContextBinderFactory;
   private final List<URL> listeners = new ArrayList<>();
   private KsqlRestApplication restServer;
 
@@ -90,13 +90,13 @@ public class TestKsqlRestApp extends ExternalResource {
       final Supplier<String> bootstrapServers,
       final Map<String, Object> additionalProps,
       final Supplier<ServiceContext> serviceContext,
-      final Function<KsqlConfig, Binder> serviceContextBinder) {
+      final Function<KsqlConfig, Binder> serviceContextBinderFactory) {
 
     this.baseConfig = buildBaseConfig(additionalProps);
     this.bootstrapServers = Objects.requireNonNull(bootstrapServers, "bootstrapServers");
     this.serviceContext = Objects.requireNonNull(serviceContext, "serviceContext");
-    this.serviceContextBinder = Objects
-        .requireNonNull(serviceContextBinder, "serviceContextBinder");
+    this.serviceContextBinderFactory = Objects
+        .requireNonNull(serviceContextBinderFactory, "serviceContextBinderFactory");
   }
 
   public List<URL> getListeners() {
@@ -204,7 +204,7 @@ public class TestKsqlRestApp extends ExternalResource {
           (booleanSupplier) -> niceMock(VersionCheckerAgent.class),
           3,
           serviceContext.get(),
-          serviceContextBinder
+          serviceContextBinderFactory
       );
     } catch (final Exception e) {
       throw new RuntimeException("Failed to initialise", e);

--- a/ksql-rest-app/src/test/java/io/confluent/ksql/rest/server/TestKsqlRestApp.java
+++ b/ksql-rest-app/src/test/java/io/confluent/ksql/rest/server/TestKsqlRestApp.java
@@ -31,6 +31,7 @@ import io.confluent.ksql.rest.entity.RunningQuery;
 import io.confluent.ksql.rest.entity.SourceInfo;
 import io.confluent.ksql.rest.entity.StreamsList;
 import io.confluent.ksql.rest.entity.TablesList;
+import io.confluent.ksql.rest.server.context.KsqlRestServiceContextBinder;
 import io.confluent.ksql.services.DefaultServiceContext;
 import io.confluent.ksql.services.ServiceContext;
 import io.confluent.ksql.test.util.EmbeddedSingleNodeKafkaCluster;
@@ -49,12 +50,14 @@ import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Set;
+import java.util.function.Function;
 import java.util.function.Supplier;
 import java.util.stream.Collectors;
 import javax.ws.rs.client.Client;
 import javax.ws.rs.client.ClientBuilder;
 import org.apache.kafka.clients.consumer.ConsumerConfig;
 import org.eclipse.jetty.websocket.api.util.WSURI;
+import org.glassfish.hk2.utilities.Binder;
 import org.junit.rules.ExternalResource;
 
 /**
@@ -79,17 +82,21 @@ public class TestKsqlRestApp extends ExternalResource {
   private final Map<String, ?> baseConfig;
   private final Supplier<String> bootstrapServers;
   private final Supplier<ServiceContext> serviceContext;
+  private final Function<KsqlConfig, Binder> serviceContextBinder;
   private final List<URL> listeners = new ArrayList<>();
   private KsqlRestApplication restServer;
 
   private TestKsqlRestApp(
       final Supplier<String> bootstrapServers,
       final Map<String, Object> additionalProps,
-      final Supplier<ServiceContext> serviceContext) {
+      final Supplier<ServiceContext> serviceContext,
+      final Function<KsqlConfig, Binder> serviceContextBinder) {
 
     this.baseConfig = buildBaseConfig(additionalProps);
     this.bootstrapServers = Objects.requireNonNull(bootstrapServers, "bootstrapServers");
     this.serviceContext = Objects.requireNonNull(serviceContext, "serviceContext");
+    this.serviceContextBinder = Objects
+        .requireNonNull(serviceContextBinder, "serviceContextBinder");
   }
 
   public List<URL> getListeners() {
@@ -196,7 +203,8 @@ public class TestKsqlRestApp extends ExternalResource {
           buildConfig(bootstrapServers, baseConfig),
           (booleanSupplier) -> niceMock(VersionCheckerAgent.class),
           3,
-          serviceContext.get()
+          serviceContext.get(),
+          serviceContextBinder
       );
     } catch (final Exception e) {
       throw new RuntimeException("Failed to initialise", e);
@@ -364,6 +372,7 @@ public class TestKsqlRestApp extends ExternalResource {
     private final Map<String, Object> additionalProps = new HashMap<>();
 
     private Supplier<ServiceContext> serviceContext;
+    private Function<KsqlConfig, Binder> serviceContextBinder = KsqlRestServiceContextBinder::new;
 
     private Builder(final Supplier<String> bootstrapServers) {
       this.bootstrapServers = Objects.requireNonNull(bootstrapServers, "bootstrapServers");
@@ -388,8 +397,17 @@ public class TestKsqlRestApp extends ExternalResource {
       return this;
     }
 
+    public Builder withServiceContextBinder(final Function<KsqlConfig, Binder> binder) {
+      serviceContextBinder = binder;
+      return this;
+    }
+
     public TestKsqlRestApp build() {
-      return new TestKsqlRestApp(bootstrapServers, additionalProps, serviceContext);
+      return new TestKsqlRestApp(
+          bootstrapServers,
+          additionalProps,
+          serviceContext,
+          serviceContextBinder);
     }
   }
 }


### PR DESCRIPTION
### Description 
1. Fix issue with AVRO during validation where the sandbox client was failing to register
2. Bring back upcasting because otherwise we can't type Long literals (timestamp will parse to int). These follow implicit conversion rules in SQL SERVER: https://docs.microsoft.com/en-us/sql/t-sql/data-types/media/lrdatahd.png?view=sql-server-2017 
3. Inject a Binder into the TestKsqlResource so that we can make sure we use the correct ServiceContext for each request

### Testing done 

- New integration tests, unit tests
- Manual testing

```
ksql> create stream p4 (author varchar, title varchar) with (kafka_topic='publications', key='author', value_format='avro', partitions=2);

 Message
----------------
 Stream created
ksql> insert into p4 (author, title) values ('C.S. Lewis', 'The Silver Chair');
ksql> SELECT * FROM P4;
1556832213821 | C.S. Lewis | C.S. Lewis | The Silver Chair
```

### Reviewer checklist
- [ ] Ensure docs are updated if necessary. (eg. if a user visible feature is being added or changed).
- [ ] Ensure relevant issues are linked (description should include text like "Fixes #<issue number>")

