### PR TITLE
Test JSON top-level maps and add documentation about serialization formats

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -28,9 +28,9 @@ KSQL 5.3.0 includes new features, including:
 
 * KSQL now supports deserializing records where the value is:
 
-  #. A primitive, e.g. a ``STRING``, ``INT``, ``DOUBLE`` etc, in Avro, Json and Delimited formats.
-  #. An array, for both Avro and Json formats.
-  #. A map, for both Avro and Json formats.
+  #. A primitive, e.g. a ``STRING``, ``INT``, ``DOUBLE`` etc, in Avro, JSON and Delimited formats.
+  #. An array, for both Avro and JSON formats.
+  #. A map, for both Avro and JSON formats.
 
 
 KSQL 5.3.0 includes bug fixes, including:

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -30,7 +30,7 @@ KSQL 5.3.0 includes new features, including:
 
   #. A primitive, e.g. a ``STRING``, ``INT``, ``DOUBLE`` etc, in Avro, Json and Delimited formats.
   #. An array, for both Avro and Json formats.
-  #. A map, for Avro formats.
+  #. A map, for both Avro and Json formats.
 
 
 KSQL 5.3.0 includes bug fixes, including:

--- a/docs/developer-guide/index.rst
+++ b/docs/developer-guide/index.rst
@@ -20,6 +20,7 @@ These topics show how to develop KSQL applications for |cp|.
     implement-a-udf
     partition-data
     syntax-reference
+    serialization
     api
     udf
     processing-log

--- a/docs/developer-guide/serialization.rst
+++ b/docs/developer-guide/serialization.rst
@@ -18,7 +18,7 @@ DELIMITED
 
 The ``DELIMITED`` format supports comma separated values.
 
-The serialized object should be a Kafka serialized string, which will be split into columns.
+The serialized object should be a Kafka-serialized string, which will be split into columns.
 
 For example, given a KSQL statement such as:
 
@@ -26,11 +26,11 @@ For example, given a KSQL statement such as:
 
     CREATE STREAM x (ID BIGINT, NAME STRING, AGE INT) WITH (VALUE_FORMAT='DELIMITED', ...);
 
-Then KSQL would split a value of ``120, bob, 49`` into the three fields with ``ID`` of ``120``,
+KSQL splits a value of ``120, bob, 49`` into the three fields with ``ID`` of ``120``,
 ``NAME`` of ``bob`` and ``AGE`` of ``49``.
 
-This data format supports all KSQL data types except ``ARRAY``, ``MAP`` and ``STRUCT``. See
-:ref:`data-types` for more details.
+This data format supports all KSQL :ref:`data types <data-types>` except ``ARRAY``, ``MAP`` and
+``STRUCT``.
 
 .. _json_format
 
@@ -40,11 +40,11 @@ JSON
 
 The ``JSON`` format supports JSON values.
 
-The JSON format supports all of KSQL's data types. (See :ref:`data-types` for details). Though,
-as JSON itself does not support a map type, KSQL serializes ``MAP``s as JSON objects.  Because of
-this the JSON format can only support ``MAP``s with ``STRING`` keys.
+The JSON format supports all of KSQL's ref:`data types <data-types>`. As JSON does not itself
+support a map type, KSQL serializes ``MAP``s as JSON objects.  Because of this the JSON format can
+only support ``MAP`` objects that have ``STRING`` keys.
 
-The serialized object should be a Kafka serialized string containing a valid JSON value. The foramt
+The serialized object should be a Kafka-serialized string containing a valid JSON value. The foramt
 supports JSON objects and top-level primitives, arrays and maps. See below for more info.
 
 JSON Objects
@@ -68,13 +68,13 @@ And a JSON value of:
          "age": "49"
        }
 
-KSQL would deserialize the JSON object's fields into the corresponding field of the stream.
+KSQL deserializes the JSON object's fields into the corresponding fields of the stream.
 
 Top-level Primitives
 --------------------
 
-The JSON format supports reading top-level JSON primitives. KSQL can only do so if the target
-schema contains only a single field of a compatible type.
+The JSON format supports reading top-level JSON primitives, but can if the target schema contains
+a single field of a compatible type.
 
 For example, given a KSQL statement with only a single field in the value schema:
 
@@ -88,22 +88,22 @@ And a JSON value of:
 
        10
 
-KSQL would deserialize the JSON primitive ``10`` into the ``ID`` field of the stream.
+KSQL deserializes the JSON primitive ``10`` into the ``ID`` field of the stream.
 
-However, if the value schema contained multiple fields, for example:
+However, if the value schema contains multiple fields, for example:
 
 .. code:: sql
 
     CREATE STREAM x (ID BIGINT, NAME STRING) WITH (VALUE_FORMAT='JSON', ...);
 
-Deserialization would fail as it is ambiguous as to which field the primitive value should be
+Deserialization fails, because it's ambiguous as to which field the primitive value should be
 deserialized into.
 
 Top-level Arrays
 ----------------
 
-The JSON format supports reading top-level JSON arrays. KSQL can only do so if the target schema
-contains only a single field of a compatible type.
+The JSON format supports reading top-level JSON arrays, but only if the target schema contains a
+single field of a compatible type.
 
 For example, given a KSQL statement with only a single array field in the value schema:
 
@@ -120,27 +120,27 @@ And a JSON value of:
           "EMEA"
        ]
 
-KSQL would deserialize the JSON array into the ``REGIONS`` field of the stream.
+KSQL deserializes the JSON array into the ``REGIONS`` field of the stream.
 
-However, if the value schema contained multiple fields, for example:
+However, if the value schema contains multiple fields, for example:
 
 .. code:: sql
 
     CREATE STREAM x (REGIONS ARRAY<STRING>, NAME STRING) WITH (VALUE_FORMAT='JSON', ...);
 
-Deserialization would fail as it is ambiguous as to which field the primitive value should be
+Deserialization fails, because it's ambiguous as to which field the primitive value should be
 deserialized into.
 
 Top-level Maps
 --------------
 
-.. tip:: Care must be take when deserializing JSON objects into a single ``MAP`` field to ensure
-         the name of the field within the KSQL statement never clashes with any of the keys within
-         the map.  Any clash can lead to undesirable deserialization artifacts as KSQL will
-         treat the value as a normal JSON object, not as a map.
+.. tip:: When you deserialize JSON objects into a single ``MAP`` field, ensure the name of the
+         field within the KSQL statement doesn't conflict with any of the keys in the map.
+         Any conflict can lead to undesirable deserialization artifacts because KSQL treats the
+         value as a normal JSON object, not as a map.
 
-The JSON format supports reading a JSON object as a ``MAP``. KSQL can only do so if the target
-schema contains only a single field of a compatible type.
+The JSON format supports reading a JSON object as a ``MAP``, but only if the target schema contains
+a single field of a compatible type.
 
 For example, given a KSQL statement with only a single map field in the value schema:
 
@@ -158,18 +158,18 @@ And a JSON value of:
           "userId": "peter"
        }
 
-KSQL would deserialize the JSON map into the ``PROPS`` field of the stream.
+KSQL deserializes the JSON map into the ``PROPS`` field of the stream.
 
-However, if the value schema contained multiple fields, for example:
+However, if the value schema contains multiple fields, for example:
 
 .. code:: sql
 
     CREATE STREAM x (PROPS MAP<STRING, STRING>, NAME STRING) WITH (VALUE_FORMAT='JSON', ...);
 
-Deserialization would fail as it is ambiguous as to which field the primitive value should be
+Deserialization fails, because it's ambiguous as to which field the primitive value should be
 deserialized into.
 
-A further potential ambiguity exists when working with top-level maps should any of the keys of the
+A further potential ambiguity exists when working with top-level maps, when any of the keys of the
 value match the name of the singular field in the target schema.
 
 For example, given:
@@ -190,10 +190,11 @@ And a JSON value of:
           "userId": "peter"
        }
 
-It is now ambiguous to KSQL as to how to deserialize the value: top level map or object? KSQL will
-deserialize the value as JSON object, meaning ``PROPS`` will be populated with an entry ``x -> y``
-only.  Such ambiguity can be avoided by ensuring the name of the field using in the KSQL statement
-never clashes with a property name within the json object.
+Deserializing the value is ambiguous: does KSQL deserialize to a top-level map or object? KSQL
+deserializes the value as a JSON object, meaning ``PROPS`` is populated with an entry ``x -> y``
+only.  Avoid this kind of ambiguity by ensuring the name of the field using in the KSQL statement
+never clashes with a property name within the json object, or that the target schema contains more
+than a single field.
 
 .. _avro_format
 
@@ -201,11 +202,11 @@ never clashes with a property name within the json object.
 Avro
 ----
 
-The ``AVRO`` format supports Avro binary serialized records and top-level primitives, arrays and
-maps.
+The ``AVRO`` format supports Avro binary serialized of all of KSQL's ref:`data types <data-types>`
+including records and top-level primitives, arrays and maps.
 
 The format requires KSQL to be configured to store and retrieve the Avro schemas from the |sr-long|.
-See :ref:`install_ksql-avro-schema` for more info.
+For more information, see :ref:`install_ksql-avro-schema`.
 
 ------------
 Avro Records
@@ -219,7 +220,7 @@ For example, given a KSQL statement such as:
 
     CREATE STREAM x (ID BIGINT, NAME STRING, AGE INT) WITH (VALUE_FORMAT='JSON', ...);
 
-And a Avro record serialized with the schema:
+And an Avro record serialized with the schema:
 
 .. code:: json
 
@@ -234,14 +235,14 @@ And a Avro record serialized with the schema:
          ]
        }
 
-KSQL would deserialize the Avro record's fields into the corresponding field of the stream.
+KSQL deserializes the Avro record's fields into the corresponding fields of the stream.
 
 -------------------------------------
 Top-level primitives, arrays and maps
 -------------------------------------
 
-The Avro format supports reading top-level primitives, arrays and maps. KSQL can only do so if the
-target schema contains only a single field of a compatible type.
+The Avro format supports reading top-level primitives, arrays and maps, but only if the target
+schema contains a single field of a compatible type.
 
 For example, given a KSQL statement with only a single field in the value schema:
 
@@ -249,7 +250,7 @@ For example, given a KSQL statement with only a single field in the value schema
 
     CREATE STREAM x (ID BIGINT) WITH (VALUE_FORMAT='JSON', ...);
 
-And a Avro value serialized with the schema:
+And an Avro value serialized with the schema:
 
 .. code:: json
 
@@ -259,11 +260,11 @@ And a Avro value serialized with the schema:
 
 KSQL can deserialize the values into the ``ID`` field of the stream.
 
-However, if the value schema contained multiple fields, for example:
+However, if the value schema contains multiple fields, for example:
 
 .. code:: sql
 
     CREATE STREAM x (ID BIGINT, NAME STRING) WITH (VALUE_FORMAT='JSON', ...);
 
-Deserialization would fail as it is ambiguous as to which field the primitive value should be
+Deserialization fails, because it's ambiguous as to which field the primitive value should be
 deserialized into.

--- a/docs/developer-guide/serialization.rst
+++ b/docs/developer-guide/serialization.rst
@@ -1,0 +1,269 @@
+.. _ksql_serialization:
+
+KSQL Serialization
+==================
+
+KSQL currently supports three serialization formats:
+
+*. ``DELIMITED`` supports comma separated values. See :ref:`delimited_format` below.
+*. ``JSON`` supports JSON values. See :ref:`json_format` below.
+*. ``AVRO`` supports AVRO serialized values. See :ref:`avro_format` below.
+
+
+.. _delimited_format
+
+---------
+DELIMITED
+---------
+
+The ``DELIMITED`` format supports comma separated values.
+
+The serialized object should be a Kafka serialized string, which will be split into columns.
+
+For example, given a KSQL statement such as:
+
+.. code:: sql
+
+    CREATE STREAM x (ID BIGINT, NAME STRING, AGE INT) WITH (VALUE_FORMAT='DELIMITED', ...);
+
+Then KSQL would split a value of ``120, bob, 49`` into the three fields with ``ID`` of ``120``,
+``NAME`` of ``bob`` and ``AGE`` of ``49``.
+
+This data format supports all KSQL data types except ``ARRAY``, ``MAP`` and ``STRUCT``. See
+:ref:`data-types` for more details.
+
+.. _json_format
+
+----
+JSON
+----
+
+The ``JSON`` format supports JSON values.
+
+The JSON format supports all of KSQL's data types. (See :ref:`data-types` for details). Though,
+as JSON itself does not support a map type, KSQL serializes ``MAP``s as JSON objects.  Because of
+this the JSON format can only support ``MAP``s with ``STRING`` keys.
+
+The serialized object should be a Kafka serialized string containing a valid JSON value. The foramt
+supports JSON objects and top-level primitives, arrays and maps. See below for more info.
+
+JSON Objects
+------------
+
+Values that are JSON objects are probably the most common.
+
+For example, given a KSQL statement such as:
+
+.. code:: sql
+
+    CREATE STREAM x (ID BIGINT, NAME STRING, AGE INT) WITH (VALUE_FORMAT='JSON', ...);
+
+And a JSON value of:
+
+.. code:: json
+
+       {
+         "id": 120,
+         "name": "bob",
+         "age": "49"
+       }
+
+KSQL would deserialize the JSON object's fields into the corresponding field of the stream.
+
+Top-level Primitives
+--------------------
+
+The JSON format supports reading top-level JSON primitives. KSQL can only do so if the target
+schema contains only a single field of a compatible type.
+
+For example, given a KSQL statement with only a single field in the value schema:
+
+.. code:: sql
+
+    CREATE STREAM x (ID BIGINT) WITH (VALUE_FORMAT='JSON', ...);
+
+And a JSON value of:
+
+.. code:: json
+
+       10
+
+KSQL would deserialize the JSON primitive ``10`` into the ``ID`` field of the stream.
+
+However, if the value schema contained multiple fields, for example:
+
+.. code:: sql
+
+    CREATE STREAM x (ID BIGINT, NAME STRING) WITH (VALUE_FORMAT='JSON', ...);
+
+Deserialization would fail as it is ambiguous as to which field the primitive value should be
+deserialized into.
+
+Top-level Arrays
+----------------
+
+The JSON format supports reading top-level JSON arrays. KSQL can only do so if the target schema
+contains only a single field of a compatible type.
+
+For example, given a KSQL statement with only a single array field in the value schema:
+
+.. code:: sql
+
+    CREATE STREAM x (REGIONS ARRAY<STRING>) WITH (VALUE_FORMAT='JSON', ...);
+
+And a JSON value of:
+
+.. code:: json
+
+       [
+          "US",
+          "EMEA"
+       ]
+
+KSQL would deserialize the JSON array into the ``REGIONS`` field of the stream.
+
+However, if the value schema contained multiple fields, for example:
+
+.. code:: sql
+
+    CREATE STREAM x (REGIONS ARRAY<STRING>, NAME STRING) WITH (VALUE_FORMAT='JSON', ...);
+
+Deserialization would fail as it is ambiguous as to which field the primitive value should be
+deserialized into.
+
+Top-level Maps
+--------------
+
+.. tip:: Care must be take when deserializing JSON objects into a single ``MAP`` field to ensure
+         the name of the field within the KSQL statement never clashes with any of the keys within
+         the map.  Any clash can lead to undesirable deserialization artifacts as KSQL will
+         treat the value as a normal JSON object, not as a map.
+
+The JSON format supports reading a JSON object as a ``MAP``. KSQL can only do so if the target
+schema contains only a single field of a compatible type.
+
+For example, given a KSQL statement with only a single map field in the value schema:
+
+.. code:: sql
+
+    CREATE STREAM x (PROPS MAP<STRING, STRING>) WITH (VALUE_FORMAT='JSON', ...);
+
+And a JSON value of:
+
+.. code:: json
+
+       {
+          "nodeCount": 10,
+          "region": "us-12",
+          "userId": "peter"
+       }
+
+KSQL would deserialize the JSON map into the ``PROPS`` field of the stream.
+
+However, if the value schema contained multiple fields, for example:
+
+.. code:: sql
+
+    CREATE STREAM x (PROPS MAP<STRING, STRING>, NAME STRING) WITH (VALUE_FORMAT='JSON', ...);
+
+Deserialization would fail as it is ambiguous as to which field the primitive value should be
+deserialized into.
+
+A further potential ambiguity exists when working with top-level maps should any of the keys of the
+value match the name of the singular field in the target schema.
+
+For example, given:
+
+.. code:: sql
+
+    CREATE STREAM x (PROPS MAP<STRING, STRING>) WITH (VALUE_FORMAT='JSON', ...);
+
+And a JSON value of:
+
+.. code:: json
+
+       {
+          "props": {
+             "x": "y"
+          },
+          "region": "us-12",
+          "userId": "peter"
+       }
+
+It is now ambiguous to KSQL as to how to deserialize the value: top level map or object? KSQL will
+deserialize the value as JSON object, meaning ``PROPS`` will be populated with an entry ``x -> y``
+only.  Such ambiguity can be avoided by ensuring the name of the field using in the KSQL statement
+never clashes with a property name within the json object.
+
+.. _avro_format
+
+----
+Avro
+----
+
+The ``AVRO`` format supports Avro binary serialized records and top-level primitives, arrays and
+maps.
+
+The format requires KSQL to be configured to store and retrieve the Avro schemas from the |sr-long|.
+See :ref:`install_ksql-avro-schema` for more info.
+
+------------
+Avro Records
+------------
+
+Avro records can be deserialized into matching KSQL schemas.
+
+For example, given a KSQL statement such as:
+
+.. code:: sql
+
+    CREATE STREAM x (ID BIGINT, NAME STRING, AGE INT) WITH (VALUE_FORMAT='JSON', ...);
+
+And a Avro record serialized with the schema:
+
+.. code:: json
+
+       {
+         "type": "record",
+         "namespace": "com.acme",
+         "name": "UserDetails",
+         "fields": [
+           { "name": "id", "type": "long" },
+           { "name": "name", "type": "string" }
+           { "name": "age", "type": "int" }
+         ]
+       }
+
+KSQL would deserialize the Avro record's fields into the corresponding field of the stream.
+
+-------------------------------------
+Top-level primitives, arrays and maps
+-------------------------------------
+
+The Avro format supports reading top-level primitives, arrays and maps. KSQL can only do so if the
+target schema contains only a single field of a compatible type.
+
+For example, given a KSQL statement with only a single field in the value schema:
+
+.. code:: sql
+
+    CREATE STREAM x (ID BIGINT) WITH (VALUE_FORMAT='JSON', ...);
+
+And a Avro value serialized with the schema:
+
+.. code:: json
+
+       {
+         { "type": "long" }
+       }
+
+KSQL can deserialize the values into the ``ID`` field of the stream.
+
+However, if the value schema contained multiple fields, for example:
+
+.. code:: sql
+
+    CREATE STREAM x (ID BIGINT, NAME STRING) WITH (VALUE_FORMAT='JSON', ...);
+
+Deserialization would fail as it is ambiguous as to which field the primitive value should be
+deserialized into.

--- a/docs/developer-guide/syntax-reference.rst
+++ b/docs/developer-guide/syntax-reference.rst
@@ -234,18 +234,89 @@ RUN SCRIPT can also be used from the command line, for instance when writing she
 For more information, see :ref:`running-ksql-command-line`.
 
 
+.. _data-types:
+
+===============
+KSQL data types
+===============
+
+KSQL supports the following data types:
+
+Primitive Types
+---------------
+
+KSQL supports the following primitive data types:
+
+-  ``BOOLEAN``
+-  ``INTEGER``
+-  ``BIGINT``
+-  ``DOUBLE``
+-  ``VARCHAR`` (or ``STRING``)
+
+
+Array
+-----
+
+``ARRAY<ElementType>``
+
+Note: the ``DELIMITED`` format does not support arrays.
+
+KSQL supports fields that are arrays of another type. The array must have homogeneous elements i.e.
+all the elements must be of the same type. The element type can be any valid KSQL type.
+
+Arrays can be defined within a ``CREATE TABLE`` or ``CREATE STREAM`` statement using the syntax
+``ARRAY<ElementType>``, for example ``ARRAY<INT>`` will define an array of integers.
+
+The elements of an array are zero-indexed and can be accessed using the ``[]`` operator passing in
+the index, for example ``SOME_ARRAY[0]`` will retrieve the first element from the array.
+See :ref:`operators` for more details.
+
+Map
+---
+
+``MAP<KeyType, ValueType>``
+
+Note: the ``DELIMITED`` format does not support maps.
+
+KSQL supports fields that are maps. A map has a key and value type. The map must have homogeneous
+key and values i.e. all the keys must be of the same type and all the values must be also be of the
+same type. Currently only ``STRING`` keys are supported. The value type can be any valid KSQL type.
+
+Maps can be defined within a ``CREATE TABLE`` or ``CREATE STREAM`` statement using the syntax
+``MAP<KeyType, ValueType>``, for example ``MAP<STRING, INT>`` will define a map of string keys to
+integer values.
+
+The values in a map can be accessed using the ``[]`` operator passing on the key, for example
+``SOME_MAP['cost']`` will return the value from the map for the entry with key ``cost``, or ``null``
+if no such entry exists. See :ref:`operators` for more details.
+
+Struct
+------
+
+``STRUCT<FieldName FieldType, ...>``
+
+Note: the ``DELIMITED`` format does not support structs.
+
+KSQL supports fields that are structs. A struct represents stongly typed structured data. A struct
+is an ordered collection of named fields that have a specific type. The field types can be any valid
+KSQL type.
+
+Maps can be defined within a ``CREATE TABLE`` or ``CREATE STREAM`` statement using the syntax
+``STRUCT<FieldName FieldType, ...>``, for example ``STRUCT<ID BIGINT, NAME STRING, AGE INT>`` will
+define a struct with three fields, with the supplied name and type.
+
+The fields of a struct can be accessed using the ``->`` operator, for example ``SOME_STRUCT->ID``
+will return the value of the structs ``ID`` field. See :ref:`operators` for more details.
+
+
 ===============
 KSQL statements
 ===============
 
 .. tip::
 
-    -  KSQL statements must be terminated with a semicolon (``;``).
-    -  Multi-line statements:
-
-       -  In the CLI you must use a backslash (``\``) to indicate
-          continuation of a statement on the next line.
-       -  Do not use ``\`` for multi-line statements in ``.sql`` files.
+    - KSQL statements must be terminated with a semicolon (``;``).
+    - Statements can be spread over multiple lines.
     - The hyphen character, ``-``, isn't supported in names for streams, tables,
       topics, and columns.
     - Don't use quotes around stream names or table names when you CREATE them.
@@ -264,21 +335,8 @@ CREATE STREAM
 
 **Description**
 
-Create a new stream with the specified columns and properties.
-
-The supported column data types are:
-
--  ``BOOLEAN``
--  ``INTEGER``
--  ``BIGINT``
--  ``DOUBLE``
--  ``VARCHAR`` (or ``STRING``)
--  ``ARRAY<ArrayType>`` (JSON and AVRO only. Index starts from 0)
--  ``MAP<VARCHAR, ValueType>`` (JSON and AVRO only)
--  ``STRUCT<FieldName FieldType, ...>`` (JSON and AVRO only) The STRUCT type requires you to specify a list of fields.
-   For each field you must specify the field name (FieldName) and field type (FieldType). The field type can be any of
-   the supported KSQL types, including the complex types ``MAP``, ``ARRAY``, and ``STRUCT``. ``STRUCT`` fields can be
-   accessed in expressions using the struct dereference (``->``) operator. See :ref:`operators` for more details.
+Create a new stream with the specified columns and properties. Columns can be any of KSQLs supported
+data types. See :ref:`data-types` for more details.
 
 KSQL adds the implicit columns ``ROWTIME`` and ``ROWKEY`` to every
 stream and table, which represent the corresponding Kafka message
@@ -295,6 +353,7 @@ The WITH clause supports the following properties:
 +-------------------------+--------------------------------------------------------------------------------------------+
 | VALUE_FORMAT (required) | Specifies the serialization format of the message value in the topic. Supported formats:   |
 |                         | ``JSON``, ``DELIMITED`` (comma-separated value), and ``AVRO``.                             |
+|                         | See :ref:`ksql_serialization` for more details.                                                 |
 +-------------------------+--------------------------------------------------------------------------------------------+
 | PARTITIONS              | The number of partitions in the backing topic. This property must be set if creating a     |
 |                         | STREAM without an existing topic (the command will fail if the topic does not exist).      |
@@ -368,21 +427,8 @@ CREATE TABLE
 
 **Description**
 
-Create a new table with the specified columns and properties.
-
-The supported column data types are:
-
--  ``BOOLEAN``
--  ``INTEGER``
--  ``BIGINT``
--  ``DOUBLE``
--  ``VARCHAR`` (or ``STRING``)
--  ``ARRAY<ArrayType>`` (JSON and AVRO only. Index starts from 0)
--  ``MAP<VARCHAR, ValueType>`` (JSON and AVRO only)
--  ``STRUCT<FieldName FieldType, ...>`` (JSON and AVRO only) The STRUCT type requires you to specify a list of fields.
-   For each field you must specify the field name (FieldName) and field type (FieldType). The field type can be any of
-   the supported KSQL types, including the complex types ``MAP``, ``ARRAY``, and ``STRUCT``. ``STRUCT`` fields can be
-   accessed in expressions using the struct dereference (``->``) operator. See :ref:`operators` for more details.
+Create a new table with the specified columns and properties.Columns can be any of KSQLs supported
+data types. See :ref:`data-types` for more details.
 
 KSQL adds the implicit columns ``ROWTIME`` and ``ROWKEY`` to every
 stream and table, which represent the corresponding Kafka message
@@ -402,6 +448,7 @@ The WITH clause supports the following properties:
 +-------------------------+--------------------------------------------------------------------------------------------+
 | VALUE_FORMAT (required) | Specifies the serialization format of message values in the topic. Supported formats:      |
 |                         | ``JSON``, ``DELIMITED`` (comma-separated value), and ``AVRO``.                             |
+|                         | See :ref:`ksql_serialization` for more details.                                                 |
 +-------------------------+--------------------------------------------------------------------------------------------+
 | PARTITIONS              | The number of partitions in the backing topic. This property must be set if creating a     |
 |                         | TABLE without an existing topic (the command will fail if the topic does not exist).       |

--- a/docs/developer-guide/syntax-reference.rst
+++ b/docs/developer-guide/syntax-reference.rst
@@ -248,7 +248,7 @@ Primitive Types
 KSQL supports the following primitive data types:
 
 -  ``BOOLEAN``
--  ``INTEGER``
+-  ``INTEGER`` or [``INT``]
 -  ``BIGINT``
 -  ``DOUBLE``
 -  ``VARCHAR`` (or ``STRING``)

--- a/docs/developer-guide/syntax-reference.rst
+++ b/docs/developer-guide/syntax-reference.rst
@@ -259,54 +259,53 @@ Array
 
 ``ARRAY<ElementType>``
 
-Note: the ``DELIMITED`` format does not support arrays.
+.. note:: The ``DELIMITED`` format doesn't support arrays.
 
-KSQL supports fields that are arrays of another type. The array must have homogeneous elements i.e.
-all the elements must be of the same type. The element type can be any valid KSQL type.
+KSQL supports fields that are arrays of another type. All the elements in the array must be of the
+same type. The element type can be any valid KSQL type.
 
-Arrays can be defined within a ``CREATE TABLE`` or ``CREATE STREAM`` statement using the syntax
-``ARRAY<ElementType>``, for example ``ARRAY<INT>`` will define an array of integers.
+You can define arrays within a ``CREATE TABLE`` or ``CREATE STREAM`` statement by using the syntax
+``ARRAY<ElementType>``. For example, ``ARRAY<INT>`` defines an array of integers.
 
-The elements of an array are zero-indexed and can be accessed using the ``[]`` operator passing in
-the index, for example ``SOME_ARRAY[0]`` will retrieve the first element from the array.
-See :ref:`operators` for more details.
+The elements of an array are zero-indexed and can be accessed by using the ``[]`` operator passing
+in the index. For example, ``SOME_ARRAY[0]`` retrieves the first element from the array.
+For more information, see :ref:`operators`.
 
 Map
 ---
 
 ``MAP<KeyType, ValueType>``
 
-Note: the ``DELIMITED`` format does not support maps.
+.. note:: The ``DELIMITED`` format doesn't support maps.
 
-KSQL supports fields that are maps. A map has a key and value type. The map must have homogeneous
-key and values i.e. all the keys must be of the same type and all the values must be also be of the
-same type. Currently only ``STRING`` keys are supported. The value type can be any valid KSQL type.
+KSQL supports fields that are maps. A map has a key and value type. All of the keys must be of the
+same type, and all of the values must be also be of the same type. Currently only ``STRING`` keys are supported. The value type can be any valid KSQL type.
 
-Maps can be defined within a ``CREATE TABLE`` or ``CREATE STREAM`` statement using the syntax
-``MAP<KeyType, ValueType>``, for example ``MAP<STRING, INT>`` will define a map of string keys to
+You can define maps within a ``CREATE TABLE`` or ``CREATE STREAM`` statement by using the syntax
+``MAP<KeyType, ValueType>``. For example, ``MAP<STRING, INT>`` defines a map with string keys and
 integer values.
 
-The values in a map can be accessed using the ``[]`` operator passing on the key, for example
-``SOME_MAP['cost']`` will return the value from the map for the entry with key ``cost``, or ``null``
-if no such entry exists. See :ref:`operators` for more details.
+Access the values of a map by using the ``[]`` operator and passing in the key. For example,
+``SOME_MAP['cost']`` retrieves the value for the entry with key ``cost``, or ``null``
+For more information, see :ref:`operators`.
 
 Struct
 ------
 
 ``STRUCT<FieldName FieldType, ...>``
 
-Note: the ``DELIMITED`` format does not support structs.
+.. note:: The ``DELIMITED`` format doesn't support structs.
 
-KSQL supports fields that are structs. A struct represents stongly typed structured data. A struct
+KSQL supports fields that are structs. A struct represents strongly typed structured data. A struct
 is an ordered collection of named fields that have a specific type. The field types can be any valid
 KSQL type.
 
-Maps can be defined within a ``CREATE TABLE`` or ``CREATE STREAM`` statement using the syntax
-``STRUCT<FieldName FieldType, ...>``, for example ``STRUCT<ID BIGINT, NAME STRING, AGE INT>`` will
-define a struct with three fields, with the supplied name and type.
+You can define a structs within a ``CREATE TABLE`` or ``CREATE STREAM`` statement by using the syntax
+``STRUCT<FieldName FieldType, ...>``. For example, ``STRUCT<ID BIGINT, NAME STRING, AGE INT>``
+defines a struct with three fields, with the supplied name and type.
 
-The fields of a struct can be accessed using the ``->`` operator, for example ``SOME_STRUCT->ID``
-will return the value of the structs ``ID`` field. See :ref:`operators` for more details.
+Access the fields of a struct by using the ``->`` operator. For example, ``SOME_STRUCT->ID``
+retrieves the value of the struct's ``ID`` field. For more information, see :ref:`operators`.
 
 
 ===============
@@ -335,8 +334,8 @@ CREATE STREAM
 
 **Description**
 
-Create a new stream with the specified columns and properties. Columns can be any of KSQLs supported
-data types. See :ref:`data-types` for more details.
+Create a new stream with the specified columns and properties. Columns can be any of the
+:ref:`data types <data-types>` supported by KSQL.
 
 KSQL adds the implicit columns ``ROWTIME`` and ``ROWKEY`` to every
 stream and table, which represent the corresponding Kafka message
@@ -353,7 +352,7 @@ The WITH clause supports the following properties:
 +-------------------------+--------------------------------------------------------------------------------------------+
 | VALUE_FORMAT (required) | Specifies the serialization format of the message value in the topic. Supported formats:   |
 |                         | ``JSON``, ``DELIMITED`` (comma-separated value), and ``AVRO``.                             |
-|                         | See :ref:`ksql_serialization` for more details.                                                 |
+|                         | For more information, see :ref:`ksql_serialization`.                                       |
 +-------------------------+--------------------------------------------------------------------------------------------+
 | PARTITIONS              | The number of partitions in the backing topic. This property must be set if creating a     |
 |                         | STREAM without an existing topic (the command will fail if the topic does not exist).      |
@@ -427,8 +426,8 @@ CREATE TABLE
 
 **Description**
 
-Create a new table with the specified columns and properties.Columns can be any of KSQLs supported
-data types. See :ref:`data-types` for more details.
+Create a new table with the specified columns and properties. Columns can be any of the
+:ref:`data types <data-types>` supported by KSQL.
 
 KSQL adds the implicit columns ``ROWTIME`` and ``ROWKEY`` to every
 stream and table, which represent the corresponding Kafka message
@@ -448,7 +447,7 @@ The WITH clause supports the following properties:
 +-------------------------+--------------------------------------------------------------------------------------------+
 | VALUE_FORMAT (required) | Specifies the serialization format of message values in the topic. Supported formats:      |
 |                         | ``JSON``, ``DELIMITED`` (comma-separated value), and ``AVRO``.                             |
-|                         | See :ref:`ksql_serialization` for more details.                                                 |
+|                         | For more information, see :ref:`ksql_serialization`.                                       |
 +-------------------------+--------------------------------------------------------------------------------------------+
 | PARTITIONS              | The number of partitions in the backing topic. This property must be set if creating a     |
 |                         | TABLE without an existing topic (the command will fail if the topic does not exist).       |
@@ -464,7 +463,7 @@ The WITH clause supports the following properties:
 |                         | when performing aggregations and joins.                                                    |
 |                         | You can only use this if the key format in kafka is ``VARCHAR`` or ``STRING``. Do not use  |
 |                         | this hint if the message key format in kafka is AVRO or JSON.                              |
-|                         | See :ref:`ksql_key_requirements` for more information.                                     |
+|                         | For more information, see :ref:`ksql_key_requirements`.                                    |
 +-------------------------+--------------------------------------------------------------------------------------------+
 | TIMESTAMP               | By default, the implicit ``ROWTIME`` column is the timestamp of the message in the Kafka   |
 |                         | topic. The TIMESTAMP property can be used to override ``ROWTIME`` with the contents of the |
@@ -597,7 +596,7 @@ The WITH clause for the result supports the following properties:
     :start-after: Avro_note_start
     :end-before: Avro_note_end
 
-Note: The ``KEY`` property is not supported – use PARTITION BY instead.
+.. note:: The ``KEY`` property is not supported – use PARTITION BY instead.
 
 .. _create-table-as-select:
 

--- a/docs/faq.rst
+++ b/docs/faq.rst
@@ -75,6 +75,8 @@ KSQL currently supports formats:
 -  Avro message values are supported. Avro keys are not yet supported. Requires |sr| and ``ksql.schema.registry.url`` in the
    KSQL server configuration file. For more information, see :ref:`install_ksql-avro-schema`.
 
+See :ref:`data-types` for more details.
+
 ====================================
 Is KSQL fully compliant to ANSI SQL?
 ====================================

--- a/ksql-functional-tests/src/main/java/io/confluent/ksql/test/serde/json/ValueSpecJsonSerdeSupplier.java
+++ b/ksql-functional-tests/src/main/java/io/confluent/ksql/test/serde/json/ValueSpecJsonSerdeSupplier.java
@@ -15,14 +15,25 @@
 
 package io.confluent.ksql.test.serde.json;
 
+import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.ArrayNode;
+import com.fasterxml.jackson.databind.node.JsonNodeFactory;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+import com.google.common.collect.ImmutableList;
 import io.confluent.kafka.schemaregistry.client.SchemaRegistryClient;
 import io.confluent.ksql.test.serde.SerdeSupplier;
+import java.util.Collection;
+import java.util.List;
 import java.util.Map;
+import java.util.Objects;
+import java.util.function.Function;
+import java.util.stream.Collectors;
 import org.apache.kafka.common.serialization.Deserializer;
 import org.apache.kafka.common.serialization.Serializer;
 
 public class ValueSpecJsonSerdeSupplier implements SerdeSupplier<Object> {
+
   @Override
   public Serializer<Object> getSerializer(final SchemaRegistryClient schemaRegistryClient) {
     return new ValueSpecJsonSerializer();
@@ -48,7 +59,8 @@ public class ValueSpecJsonSerdeSupplier implements SerdeSupplier<Object> {
         return null;
       }
       try {
-        return new ObjectMapper().writeValueAsBytes(spec);
+        final Object toSerialize = Converter.toJsonNode(spec);
+        return new ObjectMapper().writeValueAsBytes(toSerialize);
       } catch (final Exception e) {
         throw new RuntimeException(e);
       }
@@ -74,6 +86,94 @@ public class ValueSpecJsonSerdeSupplier implements SerdeSupplier<Object> {
       } catch (final Exception e) {
         throw new RuntimeException(e);
       }
+    }
+  }
+
+  private static final class Converter<T> {
+
+    private static final List<Converter<?>> CONVERTORS = ImmutableList.of(
+        Converter.converter(Boolean.class, JsonNodeFactory.instance::booleanNode),
+        Converter.converter(Integer.class, JsonNodeFactory.instance::numberNode),
+        Converter.converter(Long.class, JsonNodeFactory.instance::numberNode),
+        Converter.converter(Float.class, JsonNodeFactory.instance::numberNode),
+        Converter.converter(Double.class, JsonNodeFactory.instance::numberNode),
+        Converter.converter(String.class, JsonNodeFactory.instance::textNode),
+        Converter.converter(Collection.class, Converter::handleCollection),
+        Converter.converter(Map.class, Converter::handleMap)
+    );
+
+    private final Class<T> type;
+    private final Function<T, JsonNode> mapper;
+
+    static JsonNode toJsonNode(final Object obj) {
+      if (obj == null) {
+        return JsonNodeFactory.instance.nullNode();
+      }
+
+      final List<Converter<?>> candidates = CONVERTORS.stream()
+          .filter(c -> c.handles(obj))
+          .collect(Collectors.toList());
+
+      if (candidates.isEmpty()) {
+        throw new UnsupportedOperationException("Test framework does not current handle " + obj);
+      }
+
+      if (candidates.size() > 1) {
+        throw new RuntimeException("Ambiguous handling of " + obj);
+      }
+
+      return candidates.get(0).convert(obj);
+    }
+
+    private boolean handles(final Object obj) {
+      return type.isAssignableFrom(obj.getClass());
+    }
+
+    private static <T> Converter<T> converter(
+        final Class<T> type,
+        final Function<T, JsonNode> mapper
+    ) {
+      return new Converter<>(type, mapper);
+    }
+
+    private Converter(
+        final Class<T> type,
+        final Function<T, JsonNode> mapper
+    ) {
+      this.type = Objects.requireNonNull(type, "type");
+      this.mapper = Objects.requireNonNull(mapper, "mapper");
+    }
+
+    private JsonNode convert(final Object o) {
+      final T cast = type.cast(o);
+      return mapper.apply(cast);
+    }
+
+    private static JsonNode handleCollection(final Collection<?> collection) {
+      final ArrayNode list = JsonNodeFactory.instance.arrayNode();
+      for (Object element : collection) {
+        list.add(toJsonNode(element));
+      }
+      return list;
+    }
+
+    private static JsonNode handleMap(final Map<?, ?> map) {
+      final ObjectNode node = JsonNodeFactory.instance.objectNode();
+
+      if (map.isEmpty()) {
+        return node;
+      }
+
+      map.forEach((k, v) -> {
+        if (!(k instanceof String)) {
+          throw new UnsupportedOperationException(
+              "Test framework does not yet support maps with non-string keys");
+        }
+
+        node.set((String) k, toJsonNode(v));
+      });
+
+      return node;
     }
   }
 

--- a/ksql-functional-tests/src/test/resources/query-validation-tests/schemas.json
+++ b/ksql-functional-tests/src/test/resources/query-validation-tests/schemas.json
@@ -4,6 +4,20 @@
   ],
   "tests": [
     {
+      "name": "top level primitive - value - DELIMITED",
+      "comments": "DELIMITED supports top level primitives by default",
+      "statements": [
+        "CREATE STREAM INPUT (foo INT) WITH (kafka_topic='input_topic', value_format='DELIMITED');",
+        "CREATE STREAM OUTPUT AS SELECT * FROM INPUT;"
+      ],
+      "inputs": [
+        {"topic": "input_topic", "value": "10"}
+      ],
+      "outputs": [
+        {"topic": "OUTPUT", "value": "10"}
+      ]
+    },
+    {
       "name": "top level primitive - value",
       "format": ["JSON", "AVRO"],
       "statements": [
@@ -44,6 +58,17 @@
       "outputs": [
         {"topic": "OUTPUT", "value": {"FOO": "10"}}
       ]
+    },
+    {
+      "name": "top level array - value - DELIMITED",
+      "statements": [
+        "CREATE STREAM INPUT (foo ARRAY<STRING>) WITH (kafka_topic='input_topic', value_format='DELIMITED');",
+        "CREATE STREAM OUTPUT AS SELECT * FROM INPUT;"
+      ],
+      "expectedException": {
+        "type": "io.confluent.ksql.util.KsqlStatementException",
+        "message": "DELIMITED does not support complex type: ARRAY, field: FOO"
+      }
     },
     {
       "name": "top level array - value",
@@ -91,20 +116,23 @@
       ]
     },
     {
-      "name": "top level map - value - AVRO",
-      "comments": [
-        "Note: top level maps are not supported in JSON, as it has no map type,",
-        "and DELIMITED, as it does not support complex types",
-        "Note: Because JSON does not support maps and this test case is written in Json, the test",
-        "asserts the output schema is indeed a map, and not a record, by seeding the schema",
-        "registry with a map schema. The test would fail with a schema evolution error if the OUTPUT",
-        "schema had a record field as opposed to an map"
+      "name": "top level map - value - DELIMITED",
+      "statements": [
+        "CREATE STREAM INPUT (foo MAP<STRING, INT>) WITH (kafka_topic='input_topic', value_format='DELIMITED');",
+        "CREATE STREAM OUTPUT AS SELECT * FROM INPUT;"
       ],
+      "expectedException": {
+        "type": "io.confluent.ksql.util.KsqlStatementException",
+        "message": "DELIMITED does not support complex type: MAP, field: FOO"
+      }
+    },
+    {
+      "name": "top level map - value - AVRO",
       "statements": [
         "CREATE STREAM INPUT (foo MAP<STRING, INT>) WITH (kafka_topic='input_topic', value_format='AVRO');",
         "CREATE STREAM OUTPUT AS SELECT * FROM INPUT;"
-      ],
-      "topics": [
+       ],
+       "topics": [
         {
           "name": "input_topic",
           "schema": {"type": "map", "values": "int"},
@@ -115,14 +143,14 @@
           "schema": {"name": "blah", "type": "record", "fields": [{"name": "FOO", "type": {"type": "map", "values": "int"}}]},
           "format": "AVRO"
         }
-      ],
-      "inputs": [
+       ],
+       "inputs": [
         {"topic": "input_topic", "value": {"a": 1, "b": 2, "c": 3}}
-      ],
-      "outputs": [
+       ],
+       "outputs": [
         {"topic": "OUTPUT", "value": {"FOO": {"a": 1, "b": 2, "c": 3}}}
-      ],
-      "post": {
+       ],
+       "post": {
         "sources": [
           {
             "name": "INPUT",
@@ -130,18 +158,32 @@
             "valueSchema": "STRUCT<ROWTIME BIGINT, ROWKEY STRING, FOO MAP<STRING, INT>>"
           }
         ]
-      }
+       }
+    },
+    {
+       "name": "top level map - value - JSON",
+       "statements": [
+          "CREATE STREAM INPUT (foo MAP<STRING, INT>) WITH (kafka_topic='input_topic', value_format='JSON');",
+          "CREATE STREAM OUTPUT AS SELECT * FROM INPUT;"
+        ],
+        "inputs": [
+          {"topic": "input_topic", "value": {"a": 1, "b": 2, "c": 3}}
+        ],
+        "outputs": [
+          {"topic": "OUTPUT", "value": {"FOO": {"a": 1, "b": 2, "c": 3}}}
+        ],
+        "post": {
+          "sources": [
+            {
+              "name": "INPUT",
+              "type": "stream",
+              "valueSchema": "STRUCT<ROWTIME BIGINT, ROWKEY STRING, FOO MAP<STRING, INT>>"
+            }
+          ]
+        }
     },
     {
       "name": "coerce top level map - value - AVRO",
-      "comments": [
-        "Note: top level maps are not supported in JSON, as it has no map type,",
-        "and DELIMITED, as it does not support complex types",
-        "Note: Because JSON does not support maps and this test case is written in Json, the test",
-        "asserts the output schema is indeed a map, and not a record, by seeding the schema",
-        "registry with a map schema. The test would fail with a schema evolution error if the OUTPUT",
-        "schema had a record field as opposed to an map"
-      ],
       "statements": [
         "CREATE STREAM INPUT (foo MAP<STRING, STRING>) WITH (kafka_topic='input_topic', value_format='AVRO');",
         "CREATE STREAM OUTPUT AS SELECT * FROM INPUT;"

--- a/ksql-serde/src/main/java/io/confluent/ksql/serde/json/KsqlJsonDeserializer.java
+++ b/ksql-serde/src/main/java/io/confluent/ksql/serde/json/KsqlJsonDeserializer.java
@@ -125,8 +125,8 @@ public class KsqlJsonDeserializer implements Deserializer<Struct> {
    * <p>The deserializer supports deserializing top-level unnamed primitives, arrays and maps if
    * the target schema only contains a single field of the required type, e.g. the value '10' can be
    * deserialized into a schema containing a single numeric field. Likewise, the value '[1,2]' can
-   * deserialized into a schema containing a single array field. The same is true of maps, but maps
-   * can be ambiguous.
+   * be deserialized into a schema containing a single array field. The same is true of maps, but
+   * maps can be ambiguous.
    *
    * <p>There is ambiguity when handling top level maps due to the fact that JSON does not have a
    * map type, so KSQL persists maps as JSON objects.  JSON objects are also used to represent KSQL

--- a/ksql-serde/src/main/java/io/confluent/ksql/serde/json/KsqlJsonDeserializer.java
+++ b/ksql-serde/src/main/java/io/confluent/ksql/serde/json/KsqlJsonDeserializer.java
@@ -92,8 +92,8 @@ public class KsqlJsonDeserializer implements Deserializer<Struct> {
   }
 
   @SuppressWarnings("unchecked")
-  private Struct deserialize(final byte[] rowJsonBytes) {
-    final SchemaAndValue schemaAndValue = jsonConverter.toConnectData("topic", rowJsonBytes);
+  private Struct deserialize(final byte[] bytes) {
+    final SchemaAndValue schemaAndValue = jsonConverter.toConnectData("topic", bytes);
     final Object value = schemaAndValue.value();
     if (value == null) {
       return null;

--- a/ksql-serde/src/main/java/io/confluent/ksql/serde/util/SerdeUtils.java
+++ b/ksql-serde/src/main/java/io/confluent/ksql/serde/util/SerdeUtils.java
@@ -16,9 +16,14 @@
 package io.confluent.ksql.serde.util;
 
 import io.confluent.ksql.util.KsqlException;
+import java.util.Collection;
+import java.util.Map;
 import java.util.Objects;
+import org.apache.kafka.connect.data.Field;
+import org.apache.kafka.connect.data.Schema;
 
 public final class SerdeUtils {
+
   public static final String DESERIALIZER_LOGGER_NAME = "deserializer";
 
   private SerdeUtils() {
@@ -86,5 +91,81 @@ public final class SerdeUtils {
       }
     }
     throw new IllegalArgumentException("This Object doesn't represent a double");
+  }
+
+  public static boolean isCoercible(final Object object, final Schema targetSchema) {
+    Objects.requireNonNull(object, "object");
+
+    switch (targetSchema.type()) {
+      case BOOLEAN:
+        return object instanceof Boolean;
+      case INT32:
+      case INT64:
+      case FLOAT64:
+        return object instanceof Number || object instanceof String;
+      case STRING:
+        return true;
+      case ARRAY:
+        return isArrayCoercible(object, targetSchema);
+      case MAP:
+        return isMapCoercible(object, targetSchema);
+      case STRUCT:
+        return isStrictCoercible(object, targetSchema);
+      default:
+        throw new UnsupportedOperationException("Unsupported type: " + targetSchema.type());
+    }
+  }
+
+  private static boolean isArrayCoercible(final Object object, final Schema targetSchema) {
+    if (!(object instanceof Collection)) {
+      return false;
+    }
+
+    for (final Object element : ((Collection<?>) object)) {
+      if (!isCoercible(element, targetSchema.valueSchema())) {
+        return false;
+      }
+    }
+    return true;
+  }
+
+  private static boolean isMapCoercible(final Object object, final Schema targetSchema) {
+    if (!(object instanceof Map)) {
+      return false;
+    }
+
+    for (final Map.Entry<?, ?> e : ((Map<?, ?>) object).entrySet()) {
+      if (!isCoercible(e.getKey(), targetSchema.keySchema())) {
+        return false;
+      }
+
+      if (!isCoercible(e.getValue(), targetSchema.valueSchema())) {
+        return false;
+      }
+    }
+    return true;
+  }
+
+  private static boolean isStrictCoercible(final Object object, final Schema targetSchema) {
+    if (!(object instanceof Map)) {
+      return false;
+    }
+
+    for (final Map.Entry<?, ?> e : ((Map<?, ?>) object).entrySet()) {
+      final String fieldName = e.getKey().toString();
+      final Field field = targetSchema.fields().stream()
+          .filter(f -> f.name().equalsIgnoreCase(fieldName))
+          .findFirst()
+          .orElse(null);
+
+      if (field == null) {
+        return false;
+      }
+
+      if (!isCoercible(e.getValue(), field.schema())) {
+        return false;
+      }
+    }
+    return true;
   }
 }

--- a/ksql-serde/src/main/java/io/confluent/ksql/serde/util/SerdeUtils.java
+++ b/ksql-serde/src/main/java/io/confluent/ksql/serde/util/SerdeUtils.java
@@ -17,6 +17,7 @@ package io.confluent.ksql.serde.util;
 
 import io.confluent.ksql.util.KsqlException;
 import java.util.Collection;
+import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import org.apache.kafka.connect.data.Field;
@@ -94,7 +95,9 @@ public final class SerdeUtils {
   }
 
   public static boolean isCoercible(final Object object, final Schema targetSchema) {
-    Objects.requireNonNull(object, "object");
+    if (object == null) {
+      return true;
+    }
 
     switch (targetSchema.type()) {
       case BOOLEAN:
@@ -102,58 +105,65 @@ public final class SerdeUtils {
       case INT32:
       case INT64:
       case FLOAT64:
-        return object instanceof Number || object instanceof String;
+        return isCoercibleToNumber(object);
       case STRING:
         return true;
       case ARRAY:
-        return isArrayCoercible(object, targetSchema);
+        return isCoercibleToArray(object, targetSchema.valueSchema());
       case MAP:
-        return isMapCoercible(object, targetSchema);
+        return isCoercibleToMap(object, targetSchema.keySchema(), targetSchema.valueSchema());
       case STRUCT:
-        return isStrictCoercible(object, targetSchema);
+        return isCoercibleToStruct(object, targetSchema.fields());
       default:
         throw new UnsupportedOperationException("Unsupported type: " + targetSchema.type());
     }
   }
 
-  private static boolean isArrayCoercible(final Object object, final Schema targetSchema) {
+  private static boolean isCoercibleToNumber(final Object object) {
+    return object instanceof Number || object instanceof String;
+  }
+
+  private static boolean isCoercibleToArray(final Object object, final Schema valueSchema) {
     if (!(object instanceof Collection)) {
       return false;
     }
 
     for (final Object element : ((Collection<?>) object)) {
-      if (!isCoercible(element, targetSchema.valueSchema())) {
+      if (!isCoercible(element, valueSchema)) {
         return false;
       }
     }
     return true;
   }
 
-  private static boolean isMapCoercible(final Object object, final Schema targetSchema) {
+  private static boolean isCoercibleToMap(
+      final Object object,
+      final Schema keySchema,
+      final Schema valueSchema) {
     if (!(object instanceof Map)) {
       return false;
     }
 
     for (final Map.Entry<?, ?> e : ((Map<?, ?>) object).entrySet()) {
-      if (!isCoercible(e.getKey(), targetSchema.keySchema())) {
+      if (!isCoercible(e.getKey(), keySchema)) {
         return false;
       }
 
-      if (!isCoercible(e.getValue(), targetSchema.valueSchema())) {
+      if (!isCoercible(e.getValue(), valueSchema)) {
         return false;
       }
     }
     return true;
   }
 
-  private static boolean isStrictCoercible(final Object object, final Schema targetSchema) {
+  private static boolean isCoercibleToStruct(final Object object, final List<Field> fields) {
     if (!(object instanceof Map)) {
       return false;
     }
 
     for (final Map.Entry<?, ?> e : ((Map<?, ?>) object).entrySet()) {
       final String fieldName = e.getKey().toString();
-      final Field field = targetSchema.fields().stream()
+      final Field field = fields.stream()
           .filter(f -> f.name().equalsIgnoreCase(fieldName))
           .findFirst()
           .orElse(null);

--- a/ksql-serde/src/test/java/io/confluent/ksql/serde/util/SerdeUtilsTest.java
+++ b/ksql-serde/src/test/java/io/confluent/ksql/serde/util/SerdeUtilsTest.java
@@ -146,9 +146,9 @@ public class SerdeUtilsTest {
     SerdeUtils.isCoercible(ImmutableList.of(1), Schema.OPTIONAL_INT8_SCHEMA);
   }
 
-  @Test(expected = NullPointerException.class)
-  public void shouldThrowOnNullObject() {
-    SerdeUtils.isCoercible(null, Schema.OPTIONAL_FLOAT64_SCHEMA);
+  @Test
+  public void shouldAssumeNullsAreAlwaysCoercible() {
+    assertThat(SerdeUtils.isCoercible(null, Schema.OPTIONAL_FLOAT64_SCHEMA), is(true));
   }
 
   @Test


### PR DESCRIPTION
### Description 

Following on from #2793, I've added tests to cover how KSQL handles schemas with only a single MAP field in them with the JSON format.

#2793 say KSQL able to deserialize JSON and AVRO messages where the value was not a JSON Object or Avro Record, but a top-level primitive or array, or in the case of Avro, map.

As JSON does not support a map type directly there handling is more tricky and has some ambiguity.  KSQL already serializes `MAP` columns as JSON objects, and hence can deserialize a JSON object into a `MAP` column.

If the schema of a stream or table only contains a single `MAP` column, e.g.

```sql
CREATE TABLE FOO (BAR MAP<STRING, INT>) WITH (FORMAT='JSON', ...);
```

Then there is potential for KSQL to deserialize a JSON object directly into the map field `BAR`, e.g. if it encounters a value:

```json
   {
      "a": 1, 
      "b": 2
   }
```

It will populate this into `BAR`.  This is all grand and inline with the other formats and top-level primitives and arrays.  The ambiguity arises when the json object contains a field with the same name and type as the field in the KSQL statement:

```json
  {
      "a": 1, 
      "b": 2,
       "bar": {"c", 3}
   }
```

What should KSQL do here? Deserialize it as a JSON object, populating `BAR` with `{c->3}`, or as a top-level map, populating `BAR` with `{"a": 1, "b": 2, "bar": {"c", 3}}`?

In this PR it takes the first approach: if a field with a matching name exists it treats the value as a JSON object, not a map.  This is backwards compatible. I've also clearly documented this ambiguity and how to avoid it.

### Testing done 

Tests added.

### Reviewer checklist
- [ ] Ensure docs are updated if necessary. (eg. if a user visible feature is being added or changed).
- [ ] Ensure relevant issues are linked (description should include text like "Fixes #<issue number>")

