### PR TITLE
Minor: Speed up tests by _not_ executing queries twice.

### DIFF
--- a/ksql-engine/src/test/java/io/confluent/ksql/engine/KsqlEngineTestUtil.java
+++ b/ksql-engine/src/test/java/io/confluent/ksql/engine/KsqlEngineTestUtil.java
@@ -91,10 +91,6 @@ public final class KsqlEngineTestUtil {
         .map(SchemaRegistryTopicSchemaSupplier::new)
         .map(DefaultSchemaInjector::new);
 
-    final KsqlExecutionContext sandbox = engine.createSandbox();
-    statements
-        .forEach(stmt -> execute(sandbox, stmt, ksqlConfig, overriddenProperties, schemaInjector));
-
     return statements.stream()
         .map(stmt -> execute(engine, stmt, ksqlConfig, overriddenProperties, schemaInjector))
         .map(ExecuteResult::getQuery)


### PR DESCRIPTION
### Description 

The `QueryTranslationTest` and many others make use of `KsqlEngineTestUtil` to run queries and execute statements.  This test class currently follows the pattern used by the rest-api of building a sandbox, executing statements and, if they pass that, executing them on the engine for real.

This is test code, there is no real benefit from first validating the statements in a sandbox. It's just eating up time in our tests.  22% of time when running the QTT is taken up by executing in the sandbox!

This PR drops the validation step from `KsqlEngineTestUtil`, speeding up QTT and other tests.

### Testing done 

Test only change.

### Reviewer checklist
- [ ] Ensure docs are updated if necessary. (eg. if a user visible feature is being added or changed).
- [ ] Ensure relevant issues are linked (description should include text like "Fixes #<issue number>")

