### PR TITLE
Create a SchemaRegistryClient using the injected REST context properties

### DIFF
--- a/ksql-engine/src/main/java/io/confluent/ksql/schema/registry/KsqlSchemaRegistryClientFactory.java
+++ b/ksql-engine/src/main/java/io/confluent/ksql/schema/registry/KsqlSchemaRegistryClientFactory.java
@@ -34,7 +34,7 @@ public class KsqlSchemaRegistryClientFactory {
   private final Supplier<RestService> serviceSupplier;
   private final Map<String, Object> schemaRegistryClientConfigs;
   private final SchemaRegistryClientFactory schemaRegistryClientFactory;
-  private final Map<String, String> schemaRegistryHttpHeaders;
+  private final Map<String, String> httpHeaders;
 
   interface SchemaRegistryClientFactory {
     CachedSchemaRegistryClient create(RestService service,
@@ -63,7 +63,7 @@ public class KsqlSchemaRegistryClientFactory {
                                   final Supplier<RestService> serviceSupplier,
                                   final SslFactory sslFactory,
                                   final SchemaRegistryClientFactory schemaRegistryClientFactory,
-                                  final Map<String, String> schemaRegistryHttpHeaders) {
+                                  final Map<String, String> httpHeaders) {
     this.sslFactory = sslFactory;
     this.serviceSupplier = serviceSupplier;
     this.schemaRegistryClientConfigs = config.originalsWithPrefix(
@@ -73,7 +73,7 @@ public class KsqlSchemaRegistryClientFactory {
         .configure(config.valuesWithPrefixOverride(KsqlConfig.KSQL_SCHEMA_REGISTRY_PREFIX));
 
     this.schemaRegistryClientFactory = schemaRegistryClientFactory;
-    this.schemaRegistryHttpHeaders = schemaRegistryHttpHeaders;
+    this.httpHeaders = httpHeaders;
   }
 
   public SchemaRegistryClient get() {
@@ -87,7 +87,7 @@ public class KsqlSchemaRegistryClientFactory {
         restService,
         1000,
         schemaRegistryClientConfigs,
-        schemaRegistryHttpHeaders
+        httpHeaders
     );
   }
 }

--- a/ksql-engine/src/main/java/io/confluent/ksql/services/DefaultServiceContext.java
+++ b/ksql-engine/src/main/java/io/confluent/ksql/services/DefaultServiceContext.java
@@ -18,6 +18,7 @@ package io.confluent.ksql.services;
 import io.confluent.kafka.schemaregistry.client.SchemaRegistryClient;
 import io.confluent.ksql.schema.registry.KsqlSchemaRegistryClientFactory;
 import io.confluent.ksql.util.KsqlConfig;
+import java.util.Collections;
 import java.util.Objects;
 import java.util.function.Supplier;
 import org.apache.kafka.clients.admin.AdminClient;
@@ -36,12 +37,17 @@ public class DefaultServiceContext implements ServiceContext {
   private final SchemaRegistryClient srClient;
 
   public static DefaultServiceContext create(final KsqlConfig ksqlConfig) {
-    return create(ksqlConfig, new DefaultKafkaClientSupplier());
+    return create(
+        ksqlConfig,
+        new DefaultKafkaClientSupplier(),
+        new KsqlSchemaRegistryClientFactory(ksqlConfig, Collections.emptyMap())::get
+    );
   }
 
   public static DefaultServiceContext create(
       final KsqlConfig ksqlConfig,
-      final KafkaClientSupplier kafkaClientSupplier
+      final KafkaClientSupplier kafkaClientSupplier,
+      final Supplier<SchemaRegistryClient> srClientFactory
   ) {
     final AdminClient adminClient = kafkaClientSupplier.getAdminClient(
         ksqlConfig.getKsqlAdminClientConfigProps()
@@ -51,7 +57,7 @@ public class DefaultServiceContext implements ServiceContext {
         kafkaClientSupplier,
         adminClient,
         new KafkaTopicClientImpl(adminClient),
-        new KsqlSchemaRegistryClientFactory(ksqlConfig)::get
+        srClientFactory
     );
   }
 

--- a/ksql-engine/src/test/java/io/confluent/ksql/schema/registry/KsqlSchemaRegistryClientFactoryTest.java
+++ b/ksql-engine/src/test/java/io/confluent/ksql/schema/registry/KsqlSchemaRegistryClientFactoryTest.java
@@ -64,7 +64,7 @@ public class KsqlSchemaRegistryClientFactoryTest {
 
   @Before
   public void setUp() {
-    when(srClientFactory.create(any(), anyInt(), any()))
+    when(srClientFactory.create(any(), anyInt(), any(), any()))
         .thenReturn(mock(CachedSchemaRegistryClient.class));
 
     when(restServiceSupplier.get()).thenReturn(restService);
@@ -86,7 +86,7 @@ public class KsqlSchemaRegistryClientFactoryTest {
     // When:
     final SchemaRegistryClient client =
         new KsqlSchemaRegistryClientFactory(config, restServiceSupplier, sslFactory,
-            srClientFactory).get();
+            srClientFactory, Collections.emptyMap()).get();
 
     // Then:
     assertThat(client, is(notNullValue()));
@@ -107,7 +107,7 @@ public class KsqlSchemaRegistryClientFactoryTest {
     // When:
     final SchemaRegistryClient client =
         new KsqlSchemaRegistryClientFactory(config, restServiceSupplier, sslFactory,
-            srClientFactory).get();
+            srClientFactory, Collections.emptyMap()).get();
 
     // Then:
     assertThat(client, is(notNullValue()));
@@ -128,7 +128,7 @@ public class KsqlSchemaRegistryClientFactoryTest {
     // When:
     final SchemaRegistryClient client =
         new KsqlSchemaRegistryClientFactory(config, restServiceSupplier, sslFactory,
-            srClientFactory).get();
+            srClientFactory, Collections.emptyMap()).get();
 
 
     // Then:
@@ -153,10 +153,10 @@ public class KsqlSchemaRegistryClientFactoryTest {
 
     // When:
     new KsqlSchemaRegistryClientFactory(
-        config, restServiceSupplier, sslFactory, srClientFactory).get();
+        config, restServiceSupplier, sslFactory, srClientFactory, Collections.emptyMap()).get();
 
     // Then:
-    srClientFactory.create(same(restService), anyInt(), eq(expectedConfigs));
+    srClientFactory.create(same(restService), anyInt(), eq(expectedConfigs), any());
   }
 
   private static Map<String, Object> defaultConfigs() {

--- a/ksql-rest-app/src/main/java/io/confluent/ksql/rest/server/context/KsqlRestContext.java
+++ b/ksql-rest-app/src/main/java/io/confluent/ksql/rest/server/context/KsqlRestContext.java
@@ -54,15 +54,27 @@ public class KsqlRestContext {
     requestContext.setProperty(KSQL_REST_CONTEXT_PROPERTY, restContext);
   }
 
-  private final ImmutableMap<String, Object> restContextProperties;
+  private final ImmutableMap<String, Object> kafkaClientSupplierProperties;
+  private final ImmutableMap<String, String> schemaRegistryClientHttpHeaders;
 
-  public KsqlRestContext(final Map<String, Object> restContextProperties) {
-    this.restContextProperties = ImmutableMap.copyOf(
-        Objects.requireNonNull(restContextProperties, "restContextProperties")
+  public KsqlRestContext(
+      final Map<String, Object> kafkaClientSupplierProperties,
+      final Map<String, String> schemaRegistryHttpHeaders
+  ) {
+    this.kafkaClientSupplierProperties = ImmutableMap.copyOf(
+        Objects.requireNonNull(kafkaClientSupplierProperties, "kafkaClientSupplierProperties")
+    );
+
+    this.schemaRegistryClientHttpHeaders = ImmutableMap.copyOf(
+        Objects.requireNonNull(schemaRegistryHttpHeaders, "schemaRegistryClientHttpHeaders")
     );
   }
 
-  public Map<String, Object> getRestContextProperties() {
-    return restContextProperties;
+  public Map<String, Object> getKafkaClientSupplierProperties() {
+    return kafkaClientSupplierProperties;
+  }
+
+  public Map<String, String> getSchemaRegistryClientHttpHeaders() {
+    return schemaRegistryClientHttpHeaders;
   }
 }

--- a/ksql-rest-app/src/main/java/io/confluent/ksql/rest/server/context/KsqlRestServiceContextFactory.java
+++ b/ksql-rest-app/src/main/java/io/confluent/ksql/rest/server/context/KsqlRestServiceContextFactory.java
@@ -15,12 +15,15 @@
 
 package io.confluent.ksql.rest.server.context;
 
+import io.confluent.kafka.schemaregistry.client.SchemaRegistryClient;
+import io.confluent.ksql.schema.registry.KsqlSchemaRegistryClientFactory;
 import io.confluent.ksql.services.DefaultServiceContext;
 import io.confluent.ksql.services.ServiceContext;
 import io.confluent.ksql.util.KsqlConfig;
 
 import java.util.Objects;
 import java.util.Optional;
+import java.util.function.Supplier;
 import javax.inject.Inject;
 import javax.ws.rs.container.ContainerRequestContext;
 
@@ -48,18 +51,29 @@ public class KsqlRestServiceContextFactory implements Factory<ServiceContext> {
 
   @Override
   public ServiceContext provide() {
-    return DefaultServiceContext.create(ksqlConfig, getKafkaClientSupplier());
-  }
-
-  private KafkaClientSupplier getKafkaClientSupplier() {
     if (ksqlRestContext.isPresent()) {
-      return new ConfiguredKafkaClientSupplier(
-          new DefaultKafkaClientSupplier(),
-          ksqlRestContext.get().getRestContextProperties()
+      return DefaultServiceContext.create(
+          ksqlConfig,
+          getKafkaClientSupplier(),
+          getSchemaRegistryClientSupplier()
       );
     }
 
-    return new DefaultKafkaClientSupplier();
+    return DefaultServiceContext.create(ksqlConfig);
+  }
+
+  private KafkaClientSupplier getKafkaClientSupplier() {
+    return new ConfiguredKafkaClientSupplier(
+        new DefaultKafkaClientSupplier(),
+        ksqlRestContext.get().getKafkaClientSupplierProperties()
+    );
+  }
+
+  private Supplier<SchemaRegistryClient> getSchemaRegistryClientSupplier() {
+    return new KsqlSchemaRegistryClientFactory(
+        ksqlConfig,
+        ksqlRestContext.get().getSchemaRegistryClientHttpHeaders()
+    )::get;
   }
 
   @Override


### PR DESCRIPTION
### Description 
As part of the work that injects a user context credentials into KSQL for impersonation, this PR injects the context to create an impersonated `SchemaRegistryClient`. This is done by passing the HTTP headers to the `SchemaRegistryClientFactory` from the `KsqlRestServiceContextFactory` class.

An impersonated `SchemaRegistryClient` will access the AVRO schema with the current REST user credentials. If denied, then KSQL throws the error coming from the SR client.

A follow-up PR will be next that provides better error messages and pass the impersonated SR client to the right code places.

### Testing done 
Regression testing by running current tests.
Local functional tests that infer a stream schema with authorized and unauthorized users.

### Reviewer checklist
- [ ] Ensure docs are updated if necessary. (eg. if a user visible feature is being added or changed).
- [ ] Ensure relevant issues are linked (description should include text like "Fixes #<issue number>")

