### PR TITLE
Fix the build: KStreams has changed the timestamp on tombstones

### DIFF
--- a/ksql-functional-tests/src/test/resources/query-validation-tests/session-windows.json
+++ b/ksql-functional-tests/src/test/resources/query-validation-tests/session-windows.json
@@ -17,10 +17,10 @@
       ],
       "outputs": [
         {"topic": "S2", "key": 0, "value": "0,0", "timestamp": 0, "window": {"start": 0, "end": 0, "type": "session"}},
-        {"topic": "S2", "key": 0, "value": null, "timestamp": 10000, "window": {"start": 0, "end": 0, "type": "session"}},
+        {"topic": "S2", "key": 0, "value": null, "timestamp": 0, "window": {"start": 0, "end": 0, "type": "session"}},
         {"topic": "S2", "key": 0, "value": "0,5", "timestamp": 10000, "window": {"start": 0, "end": 10000, "type": "session"}},
         {"topic": "S2", "key": 1, "value": "1,100", "timestamp": 10000, "window": {"start": 10000, "end": 10000, "type": "session"}},
-        {"topic": "S2", "key": 1, "value": null, "timestamp": 40000, "window": {"start": 10000, "end": 10000, "type": "session"}},
+        {"topic": "S2", "key": 1, "value": null, "timestamp": 10000, "window": {"start": 10000, "end": 10000, "type": "session"}},
         {"topic": "S2", "key": 1, "value": "1,200", "timestamp": 40000, "window": {"start": 10000, "end": 40000, "type": "session"}}
       ],
       "properties": {
@@ -35,14 +35,14 @@
       ],
       "inputs": [
         {"topic": "test_topic", "key": 0, "value": "0,0", "timestamp": 10, "window": {"start": 10, "end": 10, "type": "session"}},
-        {"topic": "test_topic", "key": 0, "value": null, "timestamp": 10000, "window": {"start": 10, "end": 10, "type": "session"}},
+        {"topic": "test_topic", "key": 0, "value": null, "timestamp": 10, "window": {"start": 10, "end": 10, "type": "session"}},
         {"topic": "test_topic", "key": 0, "value": "0,5", "timestamp": 10000, "window": {"start": 10, "end": 10000, "type": "session"}},
         {"topic": "test_topic", "key": 1, "value": "1,100", "timestamp": 10000, "window": {"start": 800, "end": 10000, "type": "session"}},
         {"topic": "test_topic", "key": 1, "value": "1,200", "timestamp": 40000, "window": {"start": 800, "end": 40000, "type": "session"}}
       ],
       "outputs": [
         {"topic": "S2", "key": 0, "value": "0,0,0 : Window{start=10 end=10}", "timestamp": 10, "window": {"start": 10, "end": 10, "type": "session"}},
-        {"topic": "S2", "key": 0, "value": null, "timestamp": 10000, "window": {"start": 10, "end": 10, "type": "session"}},
+        {"topic": "S2", "key": 0, "value": null, "timestamp": 10, "window": {"start": 10, "end": 10, "type": "session"}},
         {"topic": "S2", "key": 0, "value": "0,5,0 : Window{start=10 end=10000}", "timestamp": 10000, "window": {"start": 10, "end": 10000, "type": "session"}},
         {"topic": "S2", "key": 1, "value": "1,100,1 : Window{start=800 end=10000}", "timestamp": 10000, "window": {"start": 800, "end": 10000, "type": "session"}},
         {"topic": "S2", "key": 1, "value": "1,200,1 : Window{start=800 end=40000}", "timestamp": 40000, "window": {"start": 800, "end": 40000, "type": "session"}}
@@ -56,14 +56,14 @@
       ],
       "inputs": [
         {"topic": "test_topic", "key": 0, "value": "0,0", "timestamp": 0, "window": {"start": 0, "end": 0, "type": "session"}},
-        {"topic": "test_topic", "key": 0, "value": null, "timestamp": 10000, "window": {"start": 0, "end": 0, "type": "session"}},
+        {"topic": "test_topic", "key": 0, "value": null, "timestamp": 0, "window": {"start": 0, "end": 0, "type": "session"}},
         {"topic": "test_topic", "key": 0, "value": "0,5", "timestamp": 10000, "window": {"start": 0, "end": 10000, "type": "session"}},
         {"topic": "test_topic", "key": 1, "value": "1,100", "timestamp": 10000, "window": {"start": 10000, "end": 10000, "type": "session"}},
         {"topic": "test_topic", "key": 1, "value": "1,200", "timestamp": 40000, "window": {"start": 10000, "end": 40000, "type": "session"}}
       ],
       "outputs": [
         {"topic": "S2", "key": 0, "value": "0,0,0 : Window{start=0 end=0}", "timestamp": 0, "window": {"start": 0, "end": 0, "type": "session"}},
-        {"topic": "S2", "key": 0, "value": null, "timestamp": 10000, "window": {"start": 0, "end": 0, "type": "session"}},
+        {"topic": "S2", "key": 0, "value": null, "timestamp": 0, "window": {"start": 0, "end": 0, "type": "session"}},
         {"topic": "S2", "key": 0, "value": "0,5,0 : Window{start=0 end=10000}", "timestamp": 10000, "window": {"start": 0, "end": 10000, "type": "session"}},
         {"topic": "S2", "key": 1, "value": "1,100,1 : Window{start=10000 end=10000}", "timestamp": 10000, "window": {"start": 10000, "end": 10000, "type": "session"}},
         {"topic": "S2", "key": 1, "value": "1,200,1 : Window{start=10000 end=40000}", "timestamp": 40000, "window": {"start": 10000, "end": 40000, "type": "session"}}
@@ -91,10 +91,10 @@
       ],
       "outputs": [
         {"topic": "S2", "key": 0, "value": "0,0", "timestamp": 0, "window": {"start": 0, "end": 30000, "type": "time"}},
-        {"topic": "S2", "key": 0, "value": null, "timestamp": 10000, "window": {"start": 0, "end": 30000, "type": "time"}},
+        {"topic": "S2", "key": 0, "value": null, "timestamp": 0, "window": {"start": 0, "end": 30000, "type": "time"}},
         {"topic": "S2", "key": 0, "value": "0,5", "timestamp": 10000, "window": {"start": 0, "end": 40000, "type": "time"}},
         {"topic": "S2", "key": 1, "value": "1,100", "timestamp": 10000, "window": {"start": 10000, "end": 40000, "type": "time"}},
-        {"topic": "S2", "key": 1, "value": null, "timestamp": 40000, "window": {"start": 10000, "end": 40000, "type": "time"}},
+        {"topic": "S2", "key": 1, "value": null, "timestamp": 10000, "window": {"start": 10000, "end": 40000, "type": "time"}},
         {"topic": "S2", "key": 1, "value": "1,200", "timestamp": 40000, "window": {"start": 10000, "end": 70000, "type": "time"}}
       ]
     },
@@ -106,7 +106,7 @@
       ],
       "inputs": [
         {"topic": "test_topic", "key": 0, "value": "0,0", "timestamp": 0, "window": {"start": 0, "end": 0, "type": "session"}},
-        {"topic": "test_topic", "key": 0, "value": null, "timestamp": 10000, "window": {"start": 0, "end": 0, "type": "session"}},
+        {"topic": "test_topic", "key": 0, "value": null, "timestamp": 0, "window": {"start": 0, "end": 0, "type": "session"}},
         {"topic": "test_topic", "key": 0, "value": "0,5", "timestamp": 10000, "window": {"start": 0, "end": 10000, "type": "session"}},
         {"topic": "test_topic", "key": 1, "value": "1,100", "timestamp": 10000, "window": {"start": 10000, "end": 10000, "type": "session"}},
         {"topic": "test_topic", "key": 1, "value": "1,200", "timestamp": 10000, "window": {"start": 10000, "end": 10000, "type": "session"}}

--- a/ksql-functional-tests/src/test/resources/query-validation-tests/window-bounds.json
+++ b/ksql-functional-tests/src/test/resources/query-validation-tests/window-bounds.json
@@ -17,10 +17,10 @@
       ],
       "outputs": [
         {"topic": "S2", "key": 0, "value": "0,0,0", "timestamp": 0, "window": {"start": 0, "end": 0, "type": "session"}},
-        {"topic": "S2", "key": 0, "value": null, "timestamp": 10000, "window": {"start": 0, "end": 0, "type": "session"}},
+        {"topic": "S2", "key": 0, "value": null, "timestamp": 0, "window": {"start": 0, "end": 0, "type": "session"}},
         {"topic": "S2", "key": 0, "value": "0,0,10000", "timestamp": 10000, "window": {"start": 0, "end": 10000, "type": "session"}},
         {"topic": "S2", "key": 1, "value": "1,10000,10000", "timestamp": 10000, "window": {"start": 10000, "end": 10000, "type": "session"}},
-        {"topic": "S2", "key": 1, "value": null, "timestamp": 40000, "window": {"start": 10000, "end": 10000, "type": "session"}},
+        {"topic": "S2", "key": 1, "value": null, "timestamp": 10000, "window": {"start": 10000, "end": 10000, "type": "session"}},
         {"topic": "S2", "key": 1, "value": "1,10000,40000", "timestamp": 40000, "window": {"start": 10000, "end": 40000, "type": "session"}}
       ],
       "properties": {


### PR DESCRIPTION
### Description 

Change window timestamps on tombstones to be the timestamp of the last source record to update the row. This is inline with an upstream change in KStreams.

However, I'm looking for confirmation from the streams team that this is intentional. It doesn't seem correct to me...

### Testing done 
Test only change

### Reviewer checklist
- [ ] Ensure docs are updated if necessary. (eg. if a user visible feature is being added or changed).
- [ ] Ensure relevant issues are linked (description should include text like "Fixes #<issue number>")

