### PR TITLE
Minor: Remove unused Jackson annotations from query logical model

### DIFF
--- a/ksql-engine/src/main/java/io/confluent/ksql/planner/plan/AggregateNode.java
+++ b/ksql-engine/src/main/java/io/confluent/ksql/planner/plan/AggregateNode.java
@@ -18,8 +18,6 @@ package io.confluent.ksql.planner.plan;
 import static io.confluent.ksql.metastore.model.DataSource.DataSourceType;
 import static java.util.Objects.requireNonNull;
 
-import com.fasterxml.jackson.annotation.JsonCreator;
-import com.fasterxml.jackson.annotation.JsonProperty;
 import com.google.common.collect.ImmutableList;
 import io.confluent.ksql.GenericRow;
 import io.confluent.ksql.function.AggregateFunctionArguments;
@@ -86,19 +84,18 @@ public class AggregateNode extends PlanNode {
   private final Expression havingExpressions;
 
   // CHECKSTYLE_RULES.OFF: ParameterNumberCheck
-  @JsonCreator
   public AggregateNode(
-      @JsonProperty("id") final PlanNodeId id,
-      @JsonProperty("source") final PlanNode source,
-      @JsonProperty("schema") final KsqlSchema schema,
-      @JsonProperty("keyField") final Optional<String> keyFieldName,
-      @JsonProperty("groupby") final List<Expression> groupByExpressions,
-      @JsonProperty("window") final WindowExpression windowExpression,
-      @JsonProperty("aggregateFunctionArguments") final List<Expression> aggregateFunctionArguments,
-      @JsonProperty("functionList") final List<FunctionCall> functionList,
-      @JsonProperty("requiredColumnList") final List<DereferenceExpression> requiredColumns,
-      @JsonProperty("finalSelectExpressions") final List<Expression> finalSelectExpressions,
-      @JsonProperty("havingExpressions") final Expression havingExpressions
+      final PlanNodeId id,
+      final PlanNode source,
+      final KsqlSchema schema,
+      final Optional<String> keyFieldName,
+      final List<Expression> groupByExpressions,
+      final WindowExpression windowExpression,
+      final List<Expression> aggregateFunctionArguments,
+      final List<FunctionCall> functionList,
+      final List<DereferenceExpression> requiredColumns,
+      final List<Expression> finalSelectExpressions,
+      final Expression havingExpressions
   ) {
     // CHECKSTYLE_RULES.ON: ParameterNumberCheck
     super(id, DataSourceType.KTABLE);

--- a/ksql-engine/src/main/java/io/confluent/ksql/planner/plan/DataSourceNode.java
+++ b/ksql-engine/src/main/java/io/confluent/ksql/planner/plan/DataSourceNode.java
@@ -17,8 +17,6 @@ package io.confluent.ksql.planner.plan;
 
 import static java.util.Objects.requireNonNull;
 
-import com.fasterxml.jackson.annotation.JsonCreator;
-import com.fasterxml.jackson.annotation.JsonProperty;
 import com.google.common.annotations.VisibleForTesting;
 import io.confluent.ksql.GenericRow;
 import io.confluent.ksql.metastore.model.DataSource;
@@ -94,11 +92,10 @@ public class DataSourceNode
   private final KeyField keyField;
   private final Function<KsqlConfig, MaterializedFactory> materializedFactorySupplier;
 
-  @JsonCreator
   public DataSourceNode(
-      @JsonProperty("id") final PlanNodeId id,
-      @JsonProperty("dataSource") final DataSource<?> dataSource,
-      @JsonProperty("alias") final String alias
+      final PlanNodeId id,
+      final DataSource<?> dataSource,
+      final String alias
   ) {
     this(id, dataSource, alias, MaterializedFactory::create);
   }

--- a/ksql-engine/src/main/java/io/confluent/ksql/planner/plan/FilterNode.java
+++ b/ksql-engine/src/main/java/io/confluent/ksql/planner/plan/FilterNode.java
@@ -15,8 +15,6 @@
 
 package io.confluent.ksql.planner.plan;
 
-import com.fasterxml.jackson.annotation.JsonCreator;
-import com.fasterxml.jackson.annotation.JsonProperty;
 import com.google.common.collect.ImmutableList;
 import io.confluent.ksql.metastore.model.KeyField;
 import io.confluent.ksql.parser.tree.Expression;
@@ -34,17 +32,17 @@ public class FilterNode extends PlanNode {
   private final PlanNode source;
   private final Expression predicate;
 
-  @JsonCreator
-  public FilterNode(@JsonProperty("id") final PlanNodeId id,
-                    @JsonProperty("source") final PlanNode source,
-                    @JsonProperty("predicate") final Expression predicate) {
+  public FilterNode(
+      final PlanNodeId id,
+      final PlanNode source,
+      final Expression predicate
+  ) {
     super(id, source.getNodeOutputType());
 
     this.source = Objects.requireNonNull(source, "source");
     this.predicate = Objects.requireNonNull(predicate, "predicate");
   }
 
-  @JsonProperty("predicate")
   public Expression getPredicate() {
     return predicate;
   }
@@ -64,7 +62,6 @@ public class FilterNode extends PlanNode {
     return ImmutableList.of(source);
   }
 
-  @JsonProperty("source")
   public PlanNode getSource() {
     return source;
   }

--- a/ksql-engine/src/main/java/io/confluent/ksql/planner/plan/JoinNode.java
+++ b/ksql-engine/src/main/java/io/confluent/ksql/planner/plan/JoinNode.java
@@ -15,7 +15,6 @@
 
 package io.confluent.ksql.planner.plan;
 
-import com.fasterxml.jackson.annotation.JsonProperty;
 import com.google.common.collect.ImmutableMap;
 import io.confluent.ksql.GenericRow;
 import io.confluent.ksql.metastore.model.DataSource;
@@ -70,17 +69,17 @@ public class JoinNode extends PlanNode {
 
   // CHECKSTYLE_RULES.OFF: ParameterNumberCheck
   public JoinNode(
-      @JsonProperty("id") final PlanNodeId id,
-      @JsonProperty("type") final JoinType joinType,
-      @JsonProperty("left") final PlanNode left,
-      @JsonProperty("right") final PlanNode right,
-      @JsonProperty("leftJoinFieldName") final String leftJoinFieldName,
-      @JsonProperty("rightJoinFieldName") final String rightJoinFieldName,
-      @JsonProperty("leftAlias") final String leftAlias,
-      @JsonProperty("rightAlias") final String rightAlias,
-      @JsonProperty("within") final WithinExpression withinExpression,
-      @JsonProperty("leftType") final DataSourceType leftType,
-      @JsonProperty("rightType") final DataSourceType rightType
+      final PlanNodeId id,
+      final JoinType joinType,
+      final PlanNode left,
+      final PlanNode right,
+      final String leftJoinFieldName,
+      final String rightJoinFieldName,
+      final String leftAlias,
+      final String rightAlias,
+      final WithinExpression withinExpression,
+      final DataSourceType leftType,
+      final DataSourceType rightType
   ) {
     // CHECKSTYLE_RULES.ON: ParameterNumberCheck
     super(id, (leftType == DataSourceType.KTABLE && rightType == DataSourceType.KTABLE)

--- a/ksql-engine/src/main/java/io/confluent/ksql/planner/plan/KsqlBareOutputNode.java
+++ b/ksql-engine/src/main/java/io/confluent/ksql/planner/plan/KsqlBareOutputNode.java
@@ -15,8 +15,6 @@
 
 package io.confluent.ksql.planner.plan;
 
-import com.fasterxml.jackson.annotation.JsonCreator;
-import com.fasterxml.jackson.annotation.JsonProperty;
 import io.confluent.ksql.metastore.model.KeyField;
 import io.confluent.ksql.physical.KsqlQueryBuilder;
 import io.confluent.ksql.query.QueryId;
@@ -33,13 +31,12 @@ public class KsqlBareOutputNode extends OutputNode {
 
   private final KeyField keyField;
 
-  @JsonCreator
   public KsqlBareOutputNode(
-      @JsonProperty("id") final PlanNodeId id,
-      @JsonProperty("source") final PlanNode source,
-      @JsonProperty("schema") final KsqlSchema schema,
-      @JsonProperty("limit") final Optional<Integer> limit,
-      @JsonProperty("timestampExtraction") final TimestampExtractionPolicy extractionPolicy
+      final PlanNodeId id,
+      final PlanNode source,
+      final KsqlSchema schema,
+      final Optional<Integer> limit,
+      final TimestampExtractionPolicy extractionPolicy
   ) {
     super(id, source, schema, limit, extractionPolicy);
     this.keyField = KeyField.of(source.getKeyField().name(), Optional.empty())

--- a/ksql-engine/src/main/java/io/confluent/ksql/planner/plan/KsqlStructuredDataOutputNode.java
+++ b/ksql-engine/src/main/java/io/confluent/ksql/planner/plan/KsqlStructuredDataOutputNode.java
@@ -17,8 +17,6 @@ package io.confluent.ksql.planner.plan;
 
 import static io.confluent.ksql.metastore.model.DataSource.DataSourceType;
 
-import com.fasterxml.jackson.annotation.JsonCreator;
-import com.fasterxml.jackson.annotation.JsonProperty;
 import io.confluent.ksql.GenericRow;
 import io.confluent.ksql.function.FunctionRegistry;
 import io.confluent.ksql.metastore.model.KeyField;
@@ -47,18 +45,17 @@ public class KsqlStructuredDataOutputNode extends OutputNode {
   private final boolean doCreateInto;
   private final boolean selectKeyRequired;
 
-  @JsonCreator
   public KsqlStructuredDataOutputNode(
-      @JsonProperty("id") final PlanNodeId id,
-      @JsonProperty("source") final PlanNode source,
-      @JsonProperty("schema") final KsqlSchema schema,
-      @JsonProperty("timestamp") final TimestampExtractionPolicy timestampExtractionPolicy,
-      @JsonProperty("key") final KeyField keyField,
-      @JsonProperty("ksqlTopic") final KsqlTopic ksqlTopic,
-      @JsonProperty("topicName") final String kafkaTopicName,
-      @JsonProperty("selectKeyRequired") final boolean selectKeyRequired,
-      @JsonProperty("limit") final Optional<Integer> limit,
-      @JsonProperty("doCreateInto") final boolean doCreateInto
+      final PlanNodeId id,
+      final PlanNode source,
+      final KsqlSchema schema,
+      final TimestampExtractionPolicy timestampExtractionPolicy,
+      final KeyField keyField,
+      final KsqlTopic ksqlTopic,
+      final String kafkaTopicName,
+      final boolean selectKeyRequired,
+      final Optional<Integer> limit,
+      final boolean doCreateInto
   ) {
     super(id, source, schema, limit, timestampExtractionPolicy);
     this.kafkaTopicName = Objects.requireNonNull(kafkaTopicName, "kafkaTopicName");

--- a/ksql-engine/src/main/java/io/confluent/ksql/planner/plan/OutputNode.java
+++ b/ksql-engine/src/main/java/io/confluent/ksql/planner/plan/OutputNode.java
@@ -17,8 +17,6 @@ package io.confluent.ksql.planner.plan;
 
 import static java.util.Objects.requireNonNull;
 
-import com.fasterxml.jackson.annotation.JsonCreator;
-import com.fasterxml.jackson.annotation.JsonProperty;
 import com.google.common.collect.ImmutableList;
 import io.confluent.ksql.query.QueryId;
 import io.confluent.ksql.schema.ksql.KsqlSchema;
@@ -39,13 +37,12 @@ public abstract class OutputNode
   private final Optional<Integer> limit;
   private final TimestampExtractionPolicy timestampExtractionPolicy;
 
-  @JsonCreator
   protected OutputNode(
-      @JsonProperty("id") final PlanNodeId id,
-      @JsonProperty("source") final PlanNode source,
-      @JsonProperty("schema") final KsqlSchema schema,
-      @JsonProperty("limit") final Optional<Integer> limit,
-      @JsonProperty("timestamp_policy") final TimestampExtractionPolicy timestampExtractionPolicy
+      final PlanNodeId id,
+      final PlanNode source,
+      final KsqlSchema schema,
+      final Optional<Integer> limit,
+      final TimestampExtractionPolicy timestampExtractionPolicy
   ) {
     super(id, source.getNodeOutputType());
 
@@ -70,7 +67,6 @@ public abstract class OutputNode
     return limit;
   }
 
-  @JsonProperty
   public PlanNode getSource() {
     return source;
   }

--- a/ksql-engine/src/main/java/io/confluent/ksql/planner/plan/PlanNode.java
+++ b/ksql-engine/src/main/java/io/confluent/ksql/planner/plan/PlanNode.java
@@ -17,7 +17,6 @@ package io.confluent.ksql.planner.plan;
 
 import static java.util.Objects.requireNonNull;
 
-import com.fasterxml.jackson.annotation.JsonProperty;
 import io.confluent.ksql.metastore.model.DataSource.DataSourceType;
 import io.confluent.ksql.metastore.model.KeyField;
 import io.confluent.ksql.physical.KsqlQueryBuilder;
@@ -39,7 +38,6 @@ public abstract class PlanNode {
     this.nodeOutputType = nodeOutputType;
   }
 
-  @JsonProperty("id")
   public PlanNodeId getId() {
     return id;
   }

--- a/ksql-engine/src/main/java/io/confluent/ksql/planner/plan/PlanNodeId.java
+++ b/ksql-engine/src/main/java/io/confluent/ksql/planner/plan/PlanNodeId.java
@@ -17,8 +17,6 @@ package io.confluent.ksql.planner.plan;
 
 import static java.util.Objects.requireNonNull;
 
-import com.fasterxml.jackson.annotation.JsonCreator;
-import com.fasterxml.jackson.annotation.JsonValue;
 import javax.annotation.concurrent.Immutable;
 
 @Immutable
@@ -26,14 +24,12 @@ public class PlanNodeId {
 
   private final String id;
 
-  @JsonCreator
   public PlanNodeId(final String id) {
     requireNonNull(id, "id is null");
     this.id = id;
   }
 
   @Override
-  @JsonValue
   public String toString() {
     return id;
   }

--- a/ksql-engine/src/main/java/io/confluent/ksql/planner/plan/ProjectNode.java
+++ b/ksql-engine/src/main/java/io/confluent/ksql/planner/plan/ProjectNode.java
@@ -17,8 +17,6 @@ package io.confluent.ksql.planner.plan;
 
 import static java.util.Objects.requireNonNull;
 
-import com.fasterxml.jackson.annotation.JsonCreator;
-import com.fasterxml.jackson.annotation.JsonProperty;
 import com.google.common.collect.ImmutableList;
 import io.confluent.ksql.metastore.model.KeyField;
 import io.confluent.ksql.parser.tree.Expression;
@@ -41,13 +39,12 @@ public class ProjectNode extends PlanNode {
   private final List<Expression> projectExpressions;
   private final KeyField keyField;
 
-  @JsonCreator
   public ProjectNode(
-      @JsonProperty("id") final PlanNodeId id,
-      @JsonProperty("source") final PlanNode source,
-      @JsonProperty("schema") final KsqlSchema schema,
-      @JsonProperty("key") final Optional<String> keyFieldName,
-      @JsonProperty("projectExpressions") final List<Expression> projectExpressions
+      final PlanNodeId id,
+      final PlanNode source,
+      final KsqlSchema schema,
+      final Optional<String> keyFieldName,
+      final List<Expression> projectExpressions
   ) {
     super(id, source.getNodeOutputType());
 
@@ -70,7 +67,6 @@ public class ProjectNode extends PlanNode {
     return ImmutableList.of(source);
   }
 
-  @JsonProperty
   public PlanNode getSource() {
     return source;
   }


### PR DESCRIPTION
### Description 

The nodes of the logical query model are annotated with Jackson `@JsonProperty` and other such annotations.  These, as far as I can tell, are not used anywhere by the code.  There are also no tests to test things (de)serialize to/from JSON, and PRs regularly change constructor parameters, etc.

The annotations are just noise and cause confusion, e.g. people worried about changing constructor args for fear of breaking JSON compatibility.

Hence, this PR removes them.

### Testing done 

All tests pass.

### Reviewer checklist
- [ ] Ensure docs are updated if necessary. (eg. if a user visible feature is being added or changed).
- [ ] Ensure relevant issues are linked (description should include text like "Fixes #<issue number>")

