### PR TITLE
Use a KsqlSecurityExtension to register REST endpoints authorization

### DIFF
--- a/ksql-common/src/main/java/io/confluent/ksql/util/KsqlConfig.java
+++ b/ksql-common/src/main/java/io/confluent/ksql/util/KsqlConfig.java
@@ -155,6 +155,11 @@ public class KsqlConfig extends AbstractConfig {
 
   public static final String DEFAULT_EXT_DIR = "ext";
 
+  public static final String KSQL_SECURITY_EXTENSION_CLASS = "ksql.security.extension.class";
+  public static final String KSQL_SECURITY_EXTENSION_DEFAULT = null;
+  public static final String KSQL_SECURITY_EXTENSION_DOC = "A KSQL security extension class that "
+      + "provides authorization to KSQL servers.";
+
   public static final Collection<CompatibilityBreakingConfigDef> COMPATIBLY_BREAKING_CONFIG_DEFS
       = ImmutableList.of(
           new CompatibilityBreakingConfigDef(
@@ -463,6 +468,12 @@ public class KsqlConfig extends AbstractConfig {
             true,
             ConfigDef.Importance.LOW,
             "Enable the INSERT INTO ... VALUES functionality."
+        ).define(
+            KSQL_SECURITY_EXTENSION_CLASS,
+            Type.CLASS,
+            KSQL_SECURITY_EXTENSION_DEFAULT,
+            ConfigDef.Importance.LOW,
+            KSQL_SECURITY_EXTENSION_DOC
         )
         .withClientSslSupport();
     for (final CompatibilityBreakingConfigDef compatibilityBreakingConfigDef

--- a/ksql-rest-app/src/main/java/io/confluent/ksql/rest/server/security/KsqlDefaultSecurityExtension.java
+++ b/ksql-rest-app/src/main/java/io/confluent/ksql/rest/server/security/KsqlDefaultSecurityExtension.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018 Confluent Inc.
+ * Copyright 2019 Confluent Inc.
  *
  * Licensed under the Confluent Community License (the "License"); you may not use
  * this file except in compliance with the License.  You may obtain a copy of the

--- a/ksql-rest-app/src/main/java/io/confluent/ksql/rest/server/security/KsqlDefaultSecurityExtension.java
+++ b/ksql-rest-app/src/main/java/io/confluent/ksql/rest/server/security/KsqlDefaultSecurityExtension.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright 2018 Confluent Inc.
+ *
+ * Licensed under the Confluent Community License (the "License"); you may not use
+ * this file except in compliance with the License.  You may obtain a copy of the
+ * License at
+ *
+ * http://www.confluent.io/confluent-community-license
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package io.confluent.ksql.rest.server.security;
+
+import io.confluent.ksql.util.KsqlConfig;
+import io.confluent.ksql.util.KsqlException;
+
+import javax.ws.rs.core.Configurable;
+
+/**
+ * This is the default security extension for KSQL. For now, this class is just a dummy
+ * implementation of the {@link KsqlSecurityExtension} interface.
+ */
+public class KsqlDefaultSecurityExtension implements KsqlSecurityExtension {
+  @Override
+  public void initialize(final KsqlConfig config) throws KsqlException {
+  }
+
+  @Override
+  public void registerRestEndpoints(final Configurable<?> configurable) {
+  }
+
+  @Override
+  public void close() {
+  }
+}

--- a/ksql-rest-app/src/main/java/io/confluent/ksql/rest/server/security/KsqlSecurityExtension.java
+++ b/ksql-rest-app/src/main/java/io/confluent/ksql/rest/server/security/KsqlSecurityExtension.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018 Confluent Inc.
+ * Copyright 2019 Confluent Inc.
  *
  * Licensed under the Confluent Community License (the "License"); you may not use
  * this file except in compliance with the License.  You may obtain a copy of the

--- a/ksql-rest-app/src/main/java/io/confluent/ksql/rest/server/security/KsqlSecurityExtension.java
+++ b/ksql-rest-app/src/main/java/io/confluent/ksql/rest/server/security/KsqlSecurityExtension.java
@@ -1,0 +1,58 @@
+/*
+ * Copyright 2018 Confluent Inc.
+ *
+ * Licensed under the Confluent Community License (the "License"); you may not use
+ * this file except in compliance with the License.  You may obtain a copy of the
+ * License at
+ *
+ * http://www.confluent.io/confluent-community-license
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package io.confluent.ksql.rest.server.security;
+
+import io.confluent.ksql.util.KsqlConfig;
+import io.confluent.ksql.util.KsqlException;
+
+import javax.ws.rs.core.Configurable;
+
+/**
+ * This interface provides a security extension (or plugin) to the KSQL server in order to
+ * protect the access to REST, Websockets, and other internal KSQL resources.
+ * </p>
+ * The type of security details provided is left to the implementation class. This class is
+ * called only at specific registration points to let the implementation know when to register
+ * a specific security plugin.
+ */
+public interface KsqlSecurityExtension extends AutoCloseable {
+  /**
+   * Initializes the security extension. This is called in case the implementation requires
+   * to initializes internal objects prior to registering necessary endpoints.
+   *
+   * @param config The KSQL configuration containing security required configs.
+   * @throws KsqlException If an error occurs while initializing the security extension.
+   */
+  void initialize(KsqlConfig config) throws KsqlException;
+
+  /**
+   * Registers the security extension for the KSQL REST endpoints.
+   *
+   * @param configurable The {@link Configurable} object where to register the security plugins.
+   * @throws KsqlException If an error occurs while registering the REST security plugin.
+   */
+  void registerRestEndpoints(Configurable<?> configurable) throws KsqlException;
+
+  /**
+   * Closes the current security extension. This is called in case the implementation requires
+   * to clean any security data in memory, files, and/or close connections to external security
+   * services.
+   *
+   * @throws KsqlException If an error occurs while closing the security extension.
+   */
+  @Override
+  void close() throws KsqlException;
+}


### PR DESCRIPTION
### Description 
This PR adds a `KsqlSecurityExtension` interface and a configuration that can be used to provide a security context to the `KsqlRestApplication`.

The configuration name is `ksql.security.extension.class` and accepts an implementation of `KsqlSecurityExtension`. This extension is initialized and REST endpoints registered when the `KsqlRestApplication.configureBaseApplication()` method is called when the server is started.

There is no default security for KSQL. Only a dummy implementation that is used internally to provide basic functionality to the `KsqlRestApplication`.

### Testing done 
Unit tests that verify `KsqlRestApplication` is initializing, registering, and closing the security extension.
I have my implementation that was called during my local functional tests.

### Reviewer checklist
- [ ] Ensure docs are updated if necessary. (eg. if a user visible feature is being added or changed).
- [ ] Ensure relevant issues are linked (description should include text like "Fixes #<issue number>")

