### PR TITLE
MINOR: When an error other than a parse exception print the stacktrace

### DIFF
--- a/ksql-examples/src/main/java/io/confluent/ksql/datagen/DataGen.java
+++ b/ksql-examples/src/main/java/io/confluent/ksql/datagen/DataGen.java
@@ -43,7 +43,7 @@ public final class DataGen {
       usage();
       System.exit(1);
     } catch (final Exception e) {
-      System.err.println(e.getMessage());
+      e.printStackTrace();
       System.exit(1);
     }
   }


### PR DESCRIPTION
### Description 
When using the DataGen tool if there is an exception beyond an `ArgumentParseException`,  the `DataGen#main` method prints only the exception message.  It would be more helpful in solving the issue to print the stacktrace to the console.

### Testing done 
Reproduced an error and observed stacktrace on console

### Reviewer checklist
- [ ] Ensure docs are updated if necessary. (eg. if a user visible feature is being added or changed).
- [ ] Ensure relevant issues are linked (description should include text like "Fixes #<issue number>")