### PR TITLE
Pipe serviceContext down to EngineContext (Fixes #2853)

### DIFF
--- a/ksql-engine/src/main/java/io/confluent/ksql/KsqlContext.java
+++ b/ksql-engine/src/main/java/io/confluent/ksql/KsqlContext.java
@@ -112,7 +112,7 @@ public class KsqlContext {
   public List<QueryMetadata> sql(final String sql, final Map<String, Object> overriddenProperties) {
     final List<ParsedStatement> statements = ksqlEngine.parse(sql);
 
-    final KsqlExecutionContext sandbox = ksqlEngine.createSandbox();
+    final KsqlExecutionContext sandbox = ksqlEngine.createSandbox(ksqlEngine.getServiceContext());
     for (ParsedStatement stmt : statements) {
       execute(
           sandbox,

--- a/ksql-engine/src/main/java/io/confluent/ksql/KsqlExecutionContext.java
+++ b/ksql-engine/src/main/java/io/confluent/ksql/KsqlExecutionContext.java
@@ -39,7 +39,7 @@ public interface KsqlExecutionContext {
    *
    * @return a sand boxed execution context.
    */
-  KsqlExecutionContext createSandbox();
+  KsqlExecutionContext createSandbox(ServiceContext serviceContext);
 
   /**
    * @return read-only access to the context's {@link MetaStore}.

--- a/ksql-engine/src/main/java/io/confluent/ksql/engine/EngineContext.java
+++ b/ksql-engine/src/main/java/io/confluent/ksql/engine/EngineContext.java
@@ -91,15 +91,13 @@ final class EngineContext {
         onQueryCloseCallback);
   }
 
-  EngineContext createSandbox() {
+  EngineContext createSandbox(final ServiceContext serviceContext) {
     final EngineContext sandBox = EngineContext.create(
         SandboxedServiceContext.create(serviceContext),
         processingLogContext,
         metaStore.copy(),
         queryIdGenerator.copy(),
-        (serviceContext, query) -> {
-          // No-op
-        }
+        (sc, query) -> { /* No-op */ }
     );
 
     persistentQueries.forEach((queryId, query) ->

--- a/ksql-engine/src/main/java/io/confluent/ksql/engine/EngineExecutor.java
+++ b/ksql-engine/src/main/java/io/confluent/ksql/engine/EngineExecutor.java
@@ -133,8 +133,7 @@ final class EngineExecutor {
 
     if (query instanceof PersistentQueryMetadata) {
       final PersistentQueryMetadata persistentQuery = (PersistentQueryMetadata) query;
-      final SchemaRegistryClient srClient = engineContext.getServiceContext()
-          .getSchemaRegistryClient();
+      final SchemaRegistryClient srClient = serviceContext.getSchemaRegistryClient();
 
       if (!AvroUtil.isValidSchemaEvolution(persistentQuery, srClient)) {
         throw new KsqlStatementException(String.format(

--- a/ksql-engine/src/main/java/io/confluent/ksql/engine/KsqlEngine.java
+++ b/ksql-engine/src/main/java/io/confluent/ksql/engine/KsqlEngine.java
@@ -151,8 +151,8 @@ public class KsqlEngine implements KsqlExecutionContext, Closeable {
   }
 
   @Override
-  public KsqlExecutionContext createSandbox() {
-    return new SandboxedExecutionContext(primaryContext);
+  public KsqlExecutionContext createSandbox(final ServiceContext serviceContext) {
+    return new SandboxedExecutionContext(primaryContext, serviceContext);
   }
 
   @Override

--- a/ksql-engine/src/main/java/io/confluent/ksql/engine/SandboxedExecutionContext.java
+++ b/ksql-engine/src/main/java/io/confluent/ksql/engine/SandboxedExecutionContext.java
@@ -37,8 +37,11 @@ final class SandboxedExecutionContext implements KsqlExecutionContext {
 
   private final EngineContext engineContext;
 
-  SandboxedExecutionContext(final EngineContext sourceContext) {
-    this.engineContext = sourceContext.createSandbox();
+  SandboxedExecutionContext(
+      final EngineContext sourceContext,
+      final ServiceContext serviceContext
+  ) {
+    this.engineContext = sourceContext.createSandbox(serviceContext);
   }
 
   @Override
@@ -52,8 +55,8 @@ final class SandboxedExecutionContext implements KsqlExecutionContext {
   }
 
   @Override
-  public KsqlExecutionContext createSandbox() {
-    return new SandboxedExecutionContext(engineContext);
+  public KsqlExecutionContext createSandbox(final ServiceContext serviceContext) {
+    return new SandboxedExecutionContext(engineContext, serviceContext);
   }
 
   @Override

--- a/ksql-engine/src/test/java/io/confluent/ksql/KsqlContextTest.java
+++ b/ksql-engine/src/test/java/io/confluent/ksql/KsqlContextTest.java
@@ -117,7 +117,7 @@ public class KsqlContextTest {
 
     when(ksqlEngine.execute(any())).thenReturn(ExecuteResult.of("success"));
 
-    when(ksqlEngine.createSandbox()).thenReturn(sandbox);
+    when(ksqlEngine.createSandbox(any())).thenReturn(sandbox);
 
     when(sandbox.prepare(PARSED_STMT_0)).thenReturn((PreparedStatement) PREPARED_STMT_0);
     when(sandbox.prepare(PARSED_STMT_1)).thenReturn((PreparedStatement) PREPARED_STMT_1);

--- a/ksql-engine/src/test/java/io/confluent/ksql/engine/KsqlEngineTest.java
+++ b/ksql-engine/src/test/java/io/confluent/ksql/engine/KsqlEngineTest.java
@@ -128,7 +128,7 @@ public class KsqlEngineTest {
         metaStore
     );
 
-    sandbox = ksqlEngine.createSandbox();
+    sandbox = ksqlEngine.createSandbox(serviceContext);
   }
 
   @After
@@ -1056,7 +1056,7 @@ public class KsqlEngineTest {
   ) {
     ksqlEngine.execute(
         ConfiguredStatement.of(ksqlEngine.prepare(statement), new HashMap<>(), KSQL_CONFIG));
-    sandbox = ksqlEngine.createSandbox();
+    sandbox = ksqlEngine.createSandbox(serviceContext);
   }
 
   private void givenSqlAlreadyExecuted(final String sql) {
@@ -1064,6 +1064,6 @@ public class KsqlEngineTest {
         ksqlEngine.execute(
             ConfiguredStatement.of(ksqlEngine.prepare(stmt), new HashMap<>(), KSQL_CONFIG)));
 
-    sandbox = ksqlEngine.createSandbox();
+    sandbox = ksqlEngine.createSandbox(serviceContext);
   }
 }

--- a/ksql-rest-app/src/main/java/io/confluent/ksql/rest/server/KsqlRestApplication.java
+++ b/ksql-rest-app/src/main/java/io/confluent/ksql/rest/server/KsqlRestApplication.java
@@ -492,7 +492,7 @@ public final class KsqlRestApplication extends Application<KsqlRestConfig> imple
 
   private static KsqlSecurityExtension loadSecurityExtension(final KsqlConfig ksqlConfig) {
     return Optional.ofNullable(ksqlConfig.getConfiguredInstance(
-        ksqlConfig.KSQL_SECURITY_EXTENSION_CLASS,
+        KsqlConfig.KSQL_SECURITY_EXTENSION_CLASS,
         KsqlSecurityExtension.class
     )).orElse(new KsqlDefaultSecurityExtension());
   }
@@ -554,7 +554,7 @@ public final class KsqlRestApplication extends Application<KsqlRestConfig> imple
         statement, Collections.emptyMap(), ksqlConfig);
 
     try {
-      ksqlEngine.createSandbox().execute(configured.get());
+      ksqlEngine.createSandbox(ksqlEngine.getServiceContext()).execute(configured.get());
     } catch (final KsqlException e) {
       log.warn("Failed to create processing log stream", e);
       return;

--- a/ksql-rest-app/src/main/java/io/confluent/ksql/rest/server/StandaloneExecutor.java
+++ b/ksql-rest-app/src/main/java/io/confluent/ksql/rest/server/StandaloneExecutor.java
@@ -173,7 +173,7 @@ public class StandaloneExecutor implements Executable {
   }
 
   private void validateStatements(final List<ParsedStatement> statements) {
-    final KsqlExecutionContext sandboxEngine = ksqlEngine.createSandbox();
+    final KsqlExecutionContext sandboxEngine = ksqlEngine.createSandbox(serviceContext);
     final Injector injector = injectorFactory.apply(
         sandboxEngine, sandboxEngine.getServiceContext());
 

--- a/ksql-rest-app/src/main/java/io/confluent/ksql/rest/server/execution/ExplainExecutor.java
+++ b/ksql-rest-app/src/main/java/io/confluent/ksql/rest/server/execution/ExplainExecutor.java
@@ -96,7 +96,7 @@ public final class ExplainExecutor {
         explain.getStatementText().substring("EXPLAIN ".length()),
         statement);
 
-    final QueryMetadata metadata = executionContext.createSandbox()
+    final QueryMetadata metadata = executionContext.createSandbox(serviceContext)
         .execute(
             serviceContext,
             ConfiguredStatement.of(preparedStatement, explain.getOverrides(), explain.getConfig()))

--- a/ksql-rest-app/src/main/java/io/confluent/ksql/rest/server/validation/RequestValidator.java
+++ b/ksql-rest-app/src/main/java/io/confluent/ksql/rest/server/validation/RequestValidator.java
@@ -38,7 +38,7 @@ import io.confluent.ksql.util.KsqlStatementException;
 import java.util.List;
 import java.util.Map;
 import java.util.function.BiFunction;
-import java.util.function.Supplier;
+import java.util.function.Function;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -53,7 +53,7 @@ public class RequestValidator {
 
   private final Map<Class<? extends Statement>, StatementValidator<?>> customValidators;
   private final BiFunction<KsqlExecutionContext, ServiceContext, Injector> injectorFactory;
-  private final Supplier<KsqlExecutionContext> snapshotSupplier;
+  private final Function<ServiceContext, KsqlExecutionContext> snapshotSupplier;
   private final KsqlConfig ksqlConfig;
   private final TopicAccessValidator topicAccessValidator;
 
@@ -68,7 +68,7 @@ public class RequestValidator {
   public RequestValidator(
       final Map<Class<? extends Statement>, StatementValidator<?>> customValidators,
       final BiFunction<KsqlExecutionContext, ServiceContext, Injector> injectorFactory,
-      final Supplier<KsqlExecutionContext> snapshotSupplier,
+      final Function<ServiceContext, KsqlExecutionContext> snapshotSupplier,
       final KsqlConfig ksqlConfig,
       final TopicAccessValidator topicAccessValidator
   ) {
@@ -101,7 +101,7 @@ public class RequestValidator {
   ) {
     requireSandbox(serviceContext);
 
-    final KsqlExecutionContext ctx = requireSandbox(snapshotSupplier.get());
+    final KsqlExecutionContext ctx = requireSandbox(snapshotSupplier.apply(serviceContext));
     final Injector injector = injectorFactory.apply(ctx, serviceContext);
 
     int numPersistentQueries = 0;

--- a/ksql-rest-app/src/test/java/io/confluent/ksql/rest/integration/KsqlResourceFunctionalTest.java
+++ b/ksql-rest-app/src/test/java/io/confluent/ksql/rest/integration/KsqlResourceFunctionalTest.java
@@ -194,7 +194,6 @@ public class KsqlResourceFunctionalTest {
         .field("TITLE", Schema.OPTIONAL_STRING_SCHEMA)
         .build());
 
-    TEST_HARNESS.ensureTopics("books");
     TEST_HARNESS.getSchemaRegistryClient()
         .register(
             "books" + KsqlConstants.SCHEMA_REGISTRY_VALUE_SUFFIX,
@@ -207,7 +206,7 @@ public class KsqlResourceFunctionalTest {
     // When:
     final List<KsqlEntity> results = makeKsqlRequest(""
         + "CREATE STREAM books (author VARCHAR, title VARCHAR) "
-        + "WITH (kafka_topic='books', key='author', value_format='avro');"
+        + "WITH (kafka_topic='books', key='author', value_format='avro', partitions=1);"
         + " "
         + "INSERT INTO BOOKS (ROWTIME, author, title) VALUES (123, 'Metamorphosis', 'Franz Kafka');"
     );

--- a/ksql-rest-app/src/test/java/io/confluent/ksql/rest/server/KsqlRestApplicationTest.java
+++ b/ksql-rest-app/src/test/java/io/confluent/ksql/rest/server/KsqlRestApplicationTest.java
@@ -104,7 +104,7 @@ public class KsqlRestApplicationTest {
         .thenReturn(LOG_STREAM_NAME);
     when(processingLogConfig.getString(ProcessingLogConfig.TOPIC_NAME))
         .thenReturn(LOG_TOPIC_NAME);
-    when(ksqlEngine.createSandbox()).thenReturn(sandBox);
+    when(ksqlEngine.createSandbox(any())).thenReturn(sandBox);
     when(commandQueue.isEmpty()).thenReturn(true);
     when(commandQueue.enqueueCommand(any()))
         .thenReturn(queuedCommandStatus);
@@ -149,7 +149,7 @@ public class KsqlRestApplicationTest {
   @Test
   public void shouldRegisterRestSecurityExtension() {
     // Given:
-    final Configurable configurable = mock(Configurable.class);
+    final Configurable<?> configurable = mock(Configurable.class);
 
     // When:
     app.configureBaseApplication(configurable, Collections.emptyMap());

--- a/ksql-rest-app/src/test/java/io/confluent/ksql/rest/server/StandaloneExecutorTest.java
+++ b/ksql-rest-app/src/test/java/io/confluent/ksql/rest/server/StandaloneExecutorTest.java
@@ -245,7 +245,7 @@ public class StandaloneExecutorTest {
 
     when(ksqlEngine.execute(any())).thenReturn(ExecuteResult.of(persistentQuery));
 
-    when(ksqlEngine.createSandbox()).thenReturn(sandBox);
+    when(ksqlEngine.createSandbox(any())).thenReturn(sandBox);
 
     when(sandBox.prepare(PARSED_STMT_0)).thenReturn((PreparedStatement) PREPARED_STMT_0);
     when(sandBox.prepare(PARSED_STMT_1)).thenReturn((PreparedStatement) PREPARED_STMT_1);

--- a/ksql-rest-app/src/test/java/io/confluent/ksql/rest/server/execution/InsertValuesExecutorTest.java
+++ b/ksql-rest-app/src/test/java/io/confluent/ksql/rest/server/execution/InsertValuesExecutorTest.java
@@ -112,7 +112,7 @@ public class InsertValuesExecutorTest {
   @Mock
   private ServiceContext serviceContext;
   @Mock
-  private Future producerResultFuture;
+  private Future<?> producerResultFuture;
   @Mock
   private KafkaProducer<byte[], byte[]> producer;
   private Struct expectedRow;
@@ -359,7 +359,7 @@ public class InsertValuesExecutorTest {
             new StringLiteral("str"))
     );
 
-    final Future failure = mock(Future.class);
+    final Future<?> failure = mock(Future.class);
     when(failure.get()).thenThrow(ExecutionException.class);
     doReturn(failure).when(producer).send(any());
 

--- a/ksql-rest-app/src/test/java/io/confluent/ksql/rest/server/resources/KsqlResourceTest.java
+++ b/ksql-rest-app/src/test/java/io/confluent/ksql/rest/server/resources/KsqlResourceTest.java
@@ -1753,8 +1753,8 @@ public class KsqlResourceTest {
     when(ksqlEngine.prepare(any()))
         .thenAnswer(invocation -> realEngine.prepare(invocation.getArgument(0)));
     when(sandbox.prepare(any()))
-        .thenAnswer(invocation -> realEngine.createSandbox().prepare(invocation.getArgument(0)));
-    when(ksqlEngine.createSandbox()).thenReturn(sandbox);
+        .thenAnswer(invocation -> realEngine.createSandbox(serviceContext).prepare(invocation.getArgument(0)));
+    when(ksqlEngine.createSandbox(any())).thenReturn(sandbox);
     when(ksqlEngine.getMetaStore()).thenReturn(metaStore);
     when(topicInjectorFactory.apply(ksqlEngine)).thenReturn(topicInjector);
     setUpKsqlResource();

--- a/ksql-rest-app/src/test/java/io/confluent/ksql/rest/server/validation/RequestValidatorTest.java
+++ b/ksql-rest-app/src/test/java/io/confluent/ksql/rest/server/validation/RequestValidatorTest.java
@@ -334,7 +334,7 @@ public class RequestValidatorTest {
     validator = new RequestValidator(
         customValidators,
         (ec, sc) -> InjectorChain.of(schemaInjector, topicInjector),
-        () -> executionContext,
+        (sc) -> executionContext,
         ksqlConfig,
         topicAccessValidator
     );


### PR DESCRIPTION
### Description 
After 6ac8c48766ce98c49624e6f619ed64a3268f9639 the service context that is passed to the engine context does not match that which was passed to `RequestValidator`. This fixes this to make sure that it uses the right service context.

### Testing done 
- `KsqlResourceFuncitonalTest` is updated to include an end-to-end topic creation

### Reviewer checklist
- [ ] Ensure docs are updated if necessary. (eg. if a user visible feature is being added or changed).
- [ ] Ensure relevant issues are linked (description should include text like "Fixes #<issue number>")

