### PR TITLE
Close ServiceContext when Session is closed

### DIFF
--- a/ksql-rest-app/src/main/java/io/confluent/ksql/rest/server/resources/streaming/WSQueryEndpoint.java
+++ b/ksql-rest-app/src/main/java/io/confluent/ksql/rest/server/resources/streaming/WSQueryEndpoint.java
@@ -91,6 +91,7 @@ public class WSQueryEndpoint {
   private final ServiceContextFactory serviceContextFactory;
 
   private WebSocketSubscriber<?> subscriber;
+  private ServiceContext serviceContext;
 
   @VisibleForTesting
   @FunctionalInterface
@@ -206,7 +207,7 @@ public class WSQueryEndpoint {
       final PreparedStatement<?> preparedStatement = parseStatement(request);
 
       final Principal principal = session.getUserPrincipal();
-      final ServiceContext serviceContext = serviceContextFactory.create(
+      serviceContext = serviceContextFactory.create(
           ksqlConfig,
           securityExtension.getKafkaClientSupplier(principal),
           securityExtension.getSchemaRegistryClientSupplier(principal));
@@ -234,6 +235,11 @@ public class WSQueryEndpoint {
     if (subscriber != null) {
       subscriber.close();
     }
+
+    if (serviceContext != null) {
+      serviceContext.close();
+    }
+
     log.debug(
         "Closing websocket session {} ({}): {}",
         session.getId(),

--- a/ksql-rest-app/src/test/java/io/confluent/ksql/rest/server/resources/streaming/WSQueryEndpointTest.java
+++ b/ksql-rest-app/src/test/java/io/confluent/ksql/rest/server/resources/streaming/WSQueryEndpointTest.java
@@ -380,6 +380,19 @@ public class WSQueryEndpointTest {
   }
 
   @Test
+  public void shouldCloseImpersonatedServiceContextOnClose() {
+    // Given:
+    givenRequestIs(query);
+
+    // When:
+    wsQueryEndpoint.onOpen(session, null);
+    wsQueryEndpoint.onClose(session, new CloseReason(CloseCodes.NO_STATUS_CODE, ""));
+
+    // Then:
+    verify(serviceContext).close();
+  }
+
+  @Test
   public void shouldReturnErrorIfTopicDoesNotExist() throws Exception {
     // Given:
     givenRequestIs(StreamingTestUtils.printTopic("bob", true, null, null));


### PR DESCRIPTION
### Description 
This PR fixes an issue with the `ServiceContext` not closed on WebSocket sessions.

When a new WS session is opened, the `onOpen` call creates a new `ServiceContext` that might contain the Session user credentials to access Kafka resources. Once the WS session is closed, this `ServiceContext` must be closed in the `onClose` method.

I learned that the whole `WSQueryEndpoint` configured in the `KsqlRestApplication#registerWebSocketEndpoints` is created every time a new Session is opened. So, it was enough to store the `ServiceContext` as a Class member scope so it can be accessed from the `onClose` method. This is similar to the `subscriber` class member variable.

### Testing done 
Update the `WSQueryEndpoint` test case.

### Reviewer checklist
- [ ] Ensure docs are updated if necessary. (eg. if a user visible feature is being added or changed).
- [ ] Ensure relevant issues are linked (description should include text like "Fixes #<issue number>")

