### PR TITLE
disable CliTest in 4.1.x

### DIFF
--- a/ksql-cli/src/test/java/io/confluent/ksql/CliTest.java
+++ b/ksql-cli/src/test/java/io/confluent/ksql/CliTest.java
@@ -36,6 +36,7 @@ import org.easymock.EasyMock;
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
 import org.junit.ClassRule;
+import org.junit.Ignore;
 import org.junit.Test;
 
 import java.util.*;
@@ -50,6 +51,7 @@ import static org.hamcrest.MatcherAssert.assertThat;
 /**
  * Most tests in CliTest are end-to-end integration tests, so it may expect a long running time.
  */
+@Ignore("flaky test fixed in future KSQl versions - backport effort is too large")
 public class CliTest extends TestRunner {
 
   @ClassRule

--- a/ksql-cli/src/test/java/io/confluent/ksql/CliTest.java
+++ b/ksql-cli/src/test/java/io/confluent/ksql/CliTest.java
@@ -51,7 +51,7 @@ import static org.hamcrest.MatcherAssert.assertThat;
 /**
  * Most tests in CliTest are end-to-end integration tests, so it may expect a long running time.
  */
-@Ignore("flaky test fixed in future KSQl versions - backport effort is too large")
+@Ignore("flaky test fixed in future KSQL versions - backport effort is too large")
 public class CliTest extends TestRunner {
 
   @ClassRule


### PR DESCRIPTION
### Description 
This test was improved in later versions to be made more stable. Backporting has low ROI, so disabling the test.

### Testing done 
ran unit tests to ensure it is excluded

### Reviewer checklist
- [ ] Ensure docs are updated if necessary. (eg. if a user visible feature is being added or changed).
- [ ] Ensure relevant issues are linked (description should include text like "Fixes #<issue number>")

