### PR TITLE
Add support for checking external preconditions while still serving

### DIFF
--- a/ksql-common/src/test/java/io/confluent/ksql/util/RetryUtilTest.java
+++ b/ksql-common/src/test/java/io/confluent/ksql/util/RetryUtilTest.java
@@ -15,6 +15,7 @@
 
 package io.confluent.ksql.util;
 
+import java.util.Collections;
 import java.util.function.Consumer;
 import org.junit.Test;
 import org.mockito.InOrder;
@@ -41,7 +42,7 @@ public class RetryUtilTest {
   public void shouldBackoffOnFailure() {
     doThrow(new RuntimeException("error")).when(runnable).run();
     try {
-      RetryUtil.retryWithBackoff(3, 1, 100, runnable, sleep);
+      RetryUtil.retryWithBackoff(3, 1, 100, runnable, sleep, Collections.emptyList());
       fail("retry should have thrown");
     } catch (final RuntimeException e) {
     }
@@ -57,7 +58,7 @@ public class RetryUtilTest {
   public void shouldRespectMaxWait() {
     doThrow(new RuntimeException("error")).when(runnable).run();
     try {
-      RetryUtil.retryWithBackoff(3, 1, 3, runnable, sleep);
+      RetryUtil.retryWithBackoff(3, 1, 3, runnable, sleep, Collections.emptyList());
       fail("retry should have thrown");
     } catch (final RuntimeException e) {
     }

--- a/ksql-engine/src/main/java/io/confluent/ksql/services/LazyServiceContext.java
+++ b/ksql-engine/src/main/java/io/confluent/ksql/services/LazyServiceContext.java
@@ -1,0 +1,67 @@
+/*
+ * Copyright 2019 Confluent Inc.
+ *
+ * Licensed under the Confluent Community License (the "License"); you may not use
+ * this file except in compliance with the License.  You may obtain a copy of the
+ * License at
+ *
+ * http://www.confluent.io/confluent-community-license
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package io.confluent.ksql.services;
+
+import io.confluent.kafka.schemaregistry.client.SchemaRegistryClient;
+import java.util.function.Supplier;
+import org.apache.kafka.clients.admin.AdminClient;
+import org.apache.kafka.streams.KafkaClientSupplier;
+
+public class LazyServiceContext implements ServiceContext {
+  private final Supplier<ServiceContext> serviceContextSupplier;
+  private volatile ServiceContext serviceContext = null;
+
+  public LazyServiceContext(final Supplier<ServiceContext> serviceContextSupplier) {
+    this.serviceContextSupplier = serviceContextSupplier;
+  }
+
+  private ServiceContext getServiceContext() {
+    if (this.serviceContext == null) {
+      this.serviceContext = serviceContextSupplier.get();
+    }
+    return serviceContext;
+  }
+
+  @Override
+  public AdminClient getAdminClient() {
+    return getServiceContext().getAdminClient();
+  }
+
+  @Override
+  public KafkaTopicClient getTopicClient() {
+    return getServiceContext().getTopicClient();
+  }
+
+  @Override
+  public KafkaClientSupplier getKafkaClientSupplier() {
+    return getServiceContext().getKafkaClientSupplier();
+  }
+
+  @Override
+  public SchemaRegistryClient getSchemaRegistryClient() {
+    return getServiceContext().getSchemaRegistryClient();
+  }
+
+  @Override
+  public Supplier<SchemaRegistryClient> getSchemaRegistryClientFactory() {
+    return getServiceContext().getSchemaRegistryClientFactory();
+  }
+
+  @Override
+  public void close() {
+    getServiceContext().close();
+  }
+}

--- a/ksql-rest-app/src/main/java/io/confluent/ksql/rest/server/CommandTopic.java
+++ b/ksql-rest-app/src/main/java/io/confluent/ksql/rest/server/CommandTopic.java
@@ -44,8 +44,8 @@ public class CommandTopic {
   private static final Logger log = LoggerFactory.getLogger(CommandTopic.class);
   private final TopicPartition commandTopicPartition;
 
-  private final Consumer<CommandId, Command> commandConsumer;
-  private final Producer<CommandId, Command> commandProducer;
+  private Consumer<CommandId, Command> commandConsumer = null;
+  private Producer<CommandId, Command> commandProducer = null;
   private final String commandTopicName;
 
   public CommandTopic(
@@ -76,9 +76,15 @@ public class CommandTopic {
     this.commandConsumer = Objects.requireNonNull(commandConsumer, "commandConsumer");
     this.commandProducer = Objects.requireNonNull(commandProducer, "commandProducer");
     this.commandTopicName = Objects.requireNonNull(commandTopicName, "commandTopicName");
-    commandConsumer.assign(Collections.singleton(commandTopicPartition));
   }
 
+  public String getCommandTopicName() {
+    return commandTopicName;
+  }
+
+  public void start() {
+    commandConsumer.assign(Collections.singleton(commandTopicPartition));
+  }
 
   @SuppressWarnings("unchecked")
   public RecordMetadata send(final CommandId commandId, final Command command) {

--- a/ksql-rest-app/src/main/java/io/confluent/ksql/rest/server/KsqlRestApplication.java
+++ b/ksql-rest-app/src/main/java/io/confluent/ksql/rest/server/KsqlRestApplication.java
@@ -19,6 +19,7 @@ import static io.confluent.ksql.rest.server.KsqlRestConfig.DISTRIBUTED_COMMAND_R
 
 import com.fasterxml.jackson.jaxrs.base.JsonParseExceptionMapper;
 import com.google.common.annotations.VisibleForTesting;
+import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.util.concurrent.ListeningScheduledExecutorService;
 import com.google.common.util.concurrent.MoreExecutors;
@@ -219,8 +220,9 @@ public final class KsqlRestApplication extends Application<KsqlRestConfig> imple
   }
 
   private void waitForPreconditions() {
-    final List<Predicate<Exception>> predicates = new LinkedList<>();
-    predicates.add(e -> !(e instanceof KsqlFailedPrecondition));
+    final List<Predicate<Exception>> predicates = ImmutableList.of(
+        e -> !(e instanceof KsqlFailedPrecondition)
+    );
     RetryUtil.retryWithBackoff(
         Integer.MAX_VALUE,
         1000,

--- a/ksql-rest-app/src/main/java/io/confluent/ksql/rest/server/KsqlRestApplication.java
+++ b/ksql-rest-app/src/main/java/io/confluent/ksql/rest/server/KsqlRestApplication.java
@@ -18,6 +18,8 @@ package io.confluent.ksql.rest.server;
 import static io.confluent.ksql.rest.server.KsqlRestConfig.DISTRIBUTED_COMMAND_RESPONSE_TIMEOUT_MS_CONFIG;
 
 import com.fasterxml.jackson.jaxrs.base.JsonParseExceptionMapper;
+import com.google.common.annotations.VisibleForTesting;
+import com.google.common.collect.ImmutableMap;
 import com.google.common.util.concurrent.ListeningScheduledExecutorService;
 import com.google.common.util.concurrent.MoreExecutors;
 import com.google.common.util.concurrent.ThreadFactoryBuilder;
@@ -33,14 +35,12 @@ import io.confluent.ksql.logging.processing.ProcessingLogConfig;
 import io.confluent.ksql.logging.processing.ProcessingLogContext;
 import io.confluent.ksql.parser.KsqlParser.PreparedStatement;
 import io.confluent.ksql.parser.tree.CreateStream;
-import io.confluent.ksql.parser.tree.Expression;
 import io.confluent.ksql.parser.tree.PrimitiveType;
 import io.confluent.ksql.parser.tree.QualifiedName;
 import io.confluent.ksql.parser.tree.RegisterTopic;
 import io.confluent.ksql.parser.tree.StringLiteral;
 import io.confluent.ksql.parser.tree.TableElement;
 import io.confluent.ksql.parser.tree.Type;
-import io.confluent.ksql.rest.entity.ServerInfo;
 import io.confluent.ksql.rest.server.computation.CommandIdAssigner;
 import io.confluent.ksql.rest.server.computation.CommandQueue;
 import io.confluent.ksql.rest.server.computation.CommandRunner;
@@ -53,13 +53,17 @@ import io.confluent.ksql.rest.server.resources.ServerInfoResource;
 import io.confluent.ksql.rest.server.resources.StatusResource;
 import io.confluent.ksql.rest.server.resources.streaming.StreamedQueryResource;
 import io.confluent.ksql.rest.server.resources.streaming.WSQueryEndpoint;
+import io.confluent.ksql.rest.server.state.ServerState;
+import io.confluent.ksql.rest.server.state.ServerStateDynamicBinding;
 import io.confluent.ksql.rest.util.ClusterTerminator;
 import io.confluent.ksql.rest.util.KsqlInternalTopicUtils;
 import io.confluent.ksql.rest.util.ProcessingLogServerUtils;
 import io.confluent.ksql.services.DefaultServiceContext;
+import io.confluent.ksql.services.LazyServiceContext;
 import io.confluent.ksql.services.ServiceContext;
 import io.confluent.ksql.util.KsqlConfig;
 import io.confluent.ksql.util.KsqlException;
+import io.confluent.ksql.util.RetryUtil;
 import io.confluent.ksql.util.Version;
 import io.confluent.ksql.util.WelcomeMsgUtils;
 import io.confluent.ksql.version.metrics.VersionCheckerAgent;
@@ -74,7 +78,6 @@ import java.nio.charset.StandardCharsets;
 import java.time.Duration;
 import java.util.Arrays;
 import java.util.Collections;
-import java.util.HashMap;
 import java.util.HashSet;
 import java.util.LinkedList;
 import java.util.List;
@@ -84,6 +87,7 @@ import java.util.Optional;
 import java.util.Properties;
 import java.util.concurrent.Executors;
 import java.util.function.Function;
+import java.util.function.Predicate;
 import java.util.function.Supplier;
 import java.util.stream.Collectors;
 import javax.websocket.DeploymentException;
@@ -91,7 +95,6 @@ import javax.websocket.server.ServerEndpoint;
 import javax.websocket.server.ServerEndpointConfig;
 import javax.websocket.server.ServerEndpointConfig.Configurator;
 import javax.ws.rs.core.Configurable;
-import org.apache.kafka.common.errors.UnsupportedVersionException;
 import org.eclipse.jetty.server.ServerConnector;
 import org.eclipse.jetty.websocket.jsr356.server.ServerContainer;
 import org.glassfish.jersey.server.ServerProperties;
@@ -110,15 +113,17 @@ public final class KsqlRestApplication extends Application<KsqlRestConfig> imple
   private final KsqlConfig ksqlConfig;
   private final KsqlEngine ksqlEngine;
   private final CommandRunner commandRunner;
-  private final CommandQueue commandQueue;
+  private final CommandStore commandStore;
   private final RootDocument rootDocument;
   private final StatusResource statusResource;
   private final StreamedQueryResource streamedQueryResource;
   private final KsqlResource ksqlResource;
-  private final ServerInfo serverInfo;
   private final Thread commandRunnerThread;
   private final VersionCheckerAgent versionCheckerAgent;
   private final ServiceContext serviceContext;
+  private final ServerState serverState;
+  private final ProcessingLogContext processingLogContext;
+  private final List<KsqlServerPrecondition> preconditions;
 
   public static String getCommandsStreamName() {
     return COMMANDS_STREAM_NAME;
@@ -132,12 +137,15 @@ public final class KsqlRestApplication extends Application<KsqlRestConfig> imple
       final KsqlConfig ksqlConfig,
       final KsqlRestConfig config,
       final CommandRunner commandRunner,
-      final CommandQueue commandQueue,
+      final CommandStore commandStore,
       final RootDocument rootDocument,
       final StatusResource statusResource,
       final StreamedQueryResource streamedQueryResource,
       final KsqlResource ksqlResource,
-      final VersionCheckerAgent versionCheckerAgent
+      final VersionCheckerAgent versionCheckerAgent,
+      final ServerState serverState,
+      final ProcessingLogContext processingLogContext,
+      final List<KsqlServerPrecondition> preconditions
   ) {
     super(config);
     this.serviceContext = Objects.requireNonNull(serviceContext, "serviceContext");
@@ -149,14 +157,14 @@ public final class KsqlRestApplication extends Application<KsqlRestConfig> imple
     this.streamedQueryResource =
         Objects.requireNonNull(streamedQueryResource, "streamedQueryResource");
     this.ksqlResource = Objects.requireNonNull(ksqlResource, "ksqlResource");
-    this.commandQueue = Objects.requireNonNull(commandQueue, "commandQueue");
-
+    this.commandStore = Objects.requireNonNull(commandStore, "commandStore");
+    this.serverState = Objects.requireNonNull(serverState, "serverState");
+    this.processingLogContext = Objects.requireNonNull(
+        processingLogContext,
+        "processingLogContext");
+    this.preconditions = Objects.requireNonNull(preconditions, "preconditions");
     this.versionCheckerAgent =
         Objects.requireNonNull(versionCheckerAgent, "versionCheckerAgent");
-    this.serverInfo = new ServerInfo(
-        Version.getVersion(),
-        getKafkaClusterId(serviceContext),
-        ksqlConfig.getString(KsqlConfig.KSQL_SERVICE_ID_CONFIG));
 
     this.commandRunnerThread = new Thread(commandRunner, "CommandRunner");
   }
@@ -164,24 +172,113 @@ public final class KsqlRestApplication extends Application<KsqlRestConfig> imple
   @Override
   public void setupResources(final Configurable<?> config, final KsqlRestConfig appConfig) {
     config.register(rootDocument);
-    config.register(new ServerInfoResource(serverInfo));
+    config.register(new ServerInfoResource(serviceContext, ksqlConfig));
     config.register(statusResource);
     config.register(ksqlResource);
     config.register(streamedQueryResource);
     config.register(new KsqlExceptionMapper());
+    config.register(new ServerStateDynamicBinding(serverState));
   }
 
   @Override
   public void start() throws Exception {
-    commandRunnerThread.start();
     super.start();
+    startKsql();
+    commandRunnerThread.start();
     final Properties metricsProperties = new Properties();
     metricsProperties.putAll(getConfiguration().getOriginals());
     if (versionCheckerAgent != null) {
       versionCheckerAgent.start(KsqlModuleType.SERVER, metricsProperties);
     }
-
     displayWelcomeMessage();
+  }
+
+  @VisibleForTesting
+  void startKsql() {
+    waitForPreconditions();
+    initialize();
+  }
+
+  private static final class KsqlFailedPrecondition extends RuntimeException {
+    private KsqlFailedPrecondition(final String message) {
+      super(message);
+    }
+  }
+
+  private void checkPreconditions() {
+    for (final KsqlServerPrecondition precondition : preconditions) {
+      final Optional<String> error = precondition.checkPrecondition(
+          config,
+          serviceContext
+      );
+      if (error.isPresent()) {
+        serverState.setInitializingReason(error.get());
+        throw new KsqlFailedPrecondition(error.get());
+      }
+    }
+  }
+
+  private void waitForPreconditions() {
+    final List<Predicate<Exception>> predicates = new LinkedList<>();
+    predicates.add(e -> !(e instanceof KsqlFailedPrecondition));
+    RetryUtil.retryWithBackoff(
+        Integer.MAX_VALUE,
+        1000,
+        30000,
+        this::checkPreconditions,
+        predicates
+    );
+  }
+
+  private void initialize() {
+    final String commandTopic = commandStore.getCommandTopicName();
+    KsqlInternalTopicUtils.ensureTopic(
+        commandTopic,
+        ksqlConfig,
+        serviceContext.getTopicClient()
+    );
+    commandStore.start();
+
+    ksqlEngine.getDdlCommandExec().execute(new RegisterTopicCommand(new RegisterTopic(
+        QualifiedName.of(COMMANDS_KSQL_TOPIC_NAME),
+        false,
+        ImmutableMap.of(
+            DdlConfig.VALUE_FORMAT_PROPERTY, new StringLiteral("json"),
+            DdlConfig.KAFKA_TOPIC_NAME_PROPERTY, new StringLiteral(commandTopic)
+        )
+    )));
+    ksqlEngine.getDdlCommandExec().execute(new CreateStreamCommand(
+        "statementText",
+        new CreateStream(
+            QualifiedName.of(COMMANDS_STREAM_NAME),
+            Collections.singletonList(new TableElement(
+                "STATEMENT",
+                new PrimitiveType(Type.KsqlType.STRING)
+            )),
+            false,
+            Collections.singletonMap(
+                DdlConfig.TOPIC_NAME_PROPERTY,
+                new StringLiteral(COMMANDS_KSQL_TOPIC_NAME)
+            )
+        ),
+        serviceContext.getTopicClient()
+    ));
+
+    ProcessingLogServerUtils.maybeCreateProcessingLogTopic(
+        serviceContext.getTopicClient(),
+        processingLogContext.getConfig(),
+        ksqlConfig
+    );
+    maybeCreateProcessingLogStream(
+        processingLogContext.getConfig(),
+        ksqlConfig,
+        ksqlEngine,
+        commandStore
+    );
+
+    commandRunner.processPriorCommands();
+
+    serverState.setReady();
   }
 
   @Override
@@ -281,14 +378,14 @@ public final class KsqlRestApplication extends Application<KsqlRestConfig> imple
                       statementParser,
                       ksqlEngine,
                       serviceContext,
-                      commandQueue,
+                      commandStore,
                       exec,
                       versionCheckerAgent::updateLastRequestTime,
                       Duration.ofMillis(config.getLong(
-                          KsqlRestConfig.DISTRIBUTED_COMMAND_RESPONSE_TIMEOUT_MS_CONFIG))
+                          KsqlRestConfig.DISTRIBUTED_COMMAND_RESPONSE_TIMEOUT_MS_CONFIG)),
+                      serverState
                   );
                 }
-
               })
               .build()
       );
@@ -303,8 +400,8 @@ public final class KsqlRestApplication extends Application<KsqlRestConfig> imple
       final int maxStatementRetries
   ) {
     final KsqlConfig ksqlConfig = new KsqlConfig(restConfig.getKsqlConfigProperties());
-    final ServiceContext serviceContext = DefaultServiceContext.create(ksqlConfig);
-
+    final ServiceContext serviceContext
+        = new LazyServiceContext(() -> DefaultServiceContext.create(ksqlConfig));
     return buildApplication(restConfig, versionCheckerFactory, maxStatementRetries, serviceContext);
   }
 
@@ -335,40 +432,6 @@ public final class KsqlRestApplication extends Application<KsqlRestConfig> imple
 
     final String commandTopic = KsqlInternalTopicUtils.getTopicName(
         ksqlConfig, KsqlRestConfig.COMMAND_TOPIC_SUFFIX);
-    KsqlInternalTopicUtils.ensureTopic(commandTopic, ksqlConfig, serviceContext.getTopicClient());
-
-    final Map<String, Expression> commandTopicProperties = new HashMap<>();
-    commandTopicProperties.put(
-        DdlConfig.VALUE_FORMAT_PROPERTY,
-        new StringLiteral("json")
-    );
-    commandTopicProperties.put(
-        DdlConfig.KAFKA_TOPIC_NAME_PROPERTY,
-        new StringLiteral(commandTopic)
-    );
-
-    ksqlEngine.getDdlCommandExec().execute(new RegisterTopicCommand(new RegisterTopic(
-        QualifiedName.of(COMMANDS_KSQL_TOPIC_NAME),
-        false,
-        commandTopicProperties
-    )));
-
-    ksqlEngine.getDdlCommandExec().execute(new CreateStreamCommand(
-        "statementText",
-        new CreateStream(
-            QualifiedName.of(COMMANDS_STREAM_NAME),
-            Collections.singletonList(new TableElement(
-                "STATEMENT",
-                new PrimitiveType(Type.KsqlType.STRING)
-            )),
-            false,
-            Collections.singletonMap(
-                DdlConfig.TOPIC_NAME_PROPERTY,
-                new StringLiteral(COMMANDS_KSQL_TOPIC_NAME)
-            )
-        ),
-        serviceContext.getTopicClient()
-    ));
 
     final StatementParser statementParser = new StatementParser(ksqlEngine);
 
@@ -376,7 +439,8 @@ public final class KsqlRestApplication extends Application<KsqlRestConfig> imple
         commandTopic,
         restConfig.getCommandConsumerProperties(),
         restConfig.getCommandProducerProperties(),
-        new CommandIdAssigner(ksqlEngine.getMetaStore()));
+        new CommandIdAssigner(ksqlEngine.getMetaStore())
+    );
 
     final StatementExecutor statementExecutor = new StatementExecutor(
         ksqlConfig,
@@ -387,8 +451,10 @@ public final class KsqlRestApplication extends Application<KsqlRestConfig> imple
     final RootDocument rootDocument = new RootDocument();
 
     final StatusResource statusResource = new StatusResource(statementExecutor);
-    final VersionCheckerAgent versionChecker = versionCheckerFactory
-        .apply(ksqlEngine::hasActiveQueries);
+    final VersionCheckerAgent versionChecker
+        = versionCheckerFactory.apply(ksqlEngine::hasActiveQueries);
+
+    final ServerState serverState = new ServerState();
 
     final StreamedQueryResource streamedQueryResource = new StreamedQueryResource(
         ksqlConfig,
@@ -411,30 +477,23 @@ public final class KsqlRestApplication extends Application<KsqlRestConfig> imple
         versionChecker::updateLastRequestTime
     );
 
-    final Optional<String> processingLogTopic =
-        ProcessingLogServerUtils.maybeCreateProcessingLogTopic(
-            serviceContext.getTopicClient(),
-            processingLogConfig,
-            ksqlConfig);
-    maybeCreateProcessingLogStream(
-        processingLogConfig,
-        ksqlConfig,
-        ksqlEngine,
-        commandStore
-    );
-
     final List<String> managedTopics = new LinkedList<>();
     managedTopics.add(commandTopic);
-    processingLogTopic.ifPresent(managedTopics::add);
+    if (processingLogConfig.getBoolean(ProcessingLogConfig.TOPIC_AUTO_CREATE)) {
+      managedTopics.add(ProcessingLogServerUtils.getTopicName(processingLogConfig, ksqlConfig));
+    }
     final CommandRunner commandRunner = new CommandRunner(
         statementExecutor,
         commandStore,
-        ksqlEngine,
         maxStatementRetries,
-        new ClusterTerminator(ksqlConfig, ksqlEngine, serviceContext, managedTopics)
+        new ClusterTerminator(ksqlConfig, ksqlEngine, serviceContext, managedTopics),
+        serverState
     );
 
-    commandRunner.processPriorCommands();
+    final List<KsqlServerPrecondition> preconditions = restConfig.getConfiguredInstances(
+        KsqlRestConfig.KSQL_SERVER_PRECONDITIONS,
+        KsqlServerPrecondition.class
+    );
 
     return new KsqlRestApplication(
         serviceContext,
@@ -447,22 +506,11 @@ public final class KsqlRestApplication extends Application<KsqlRestConfig> imple
         statusResource,
         streamedQueryResource,
         ksqlResource,
-        versionChecker
+        versionChecker,
+        serverState,
+        processingLogContext,
+        preconditions
     );
-  }
-
-  private static String getKafkaClusterId(final ServiceContext serviceContext) {
-    try {
-      return serviceContext.getAdminClient().describeCluster().clusterId().get();
-
-    } catch (final UnsupportedVersionException e) {
-      throw new KsqlException(
-          "The kafka brokers are incompatible with. "
-          + "KSQL requires broker versions >= 0.10.1.x"
-      );
-    } catch (final Exception e) {
-      throw new KsqlException("Failed to get Kafka cluster information", e);
-    }
   }
 
   private void displayWelcomeMessage() {

--- a/ksql-rest-app/src/main/java/io/confluent/ksql/rest/server/KsqlRestConfig.java
+++ b/ksql-rest-app/src/main/java/io/confluent/ksql/rest/server/KsqlRestConfig.java
@@ -58,6 +58,13 @@ public class KsqlRestConfig extends RestConfig {
   private static final String KSQL_WEBSOCKETS_NUM_THREADS_DOC =
       "The number of websocket threads to handle query results";
 
+  static final String KSQL_SERVER_PRECONDITIONS =
+      KSQL_CONFIG_PREFIX + "server.preconditions";
+  private static final String KSQL_SERVER_PRECONDITIONS_DOC =
+      "A comma separated list of classes implementing KsqlServerPrecondition. The KSQL server "
+      + "will not start serving requests until all preconditions are satisfied. Until that time, "
+      + "requests will return a 503 error";
+
   private static final ConfigDef CONFIG_DEF;
 
   static {
@@ -85,6 +92,12 @@ public class KsqlRestConfig extends RestConfig {
         5,
         Importance.LOW,
         KSQL_WEBSOCKETS_NUM_THREADS_DOC
+    ).define(
+        KSQL_SERVER_PRECONDITIONS,
+        Type.LIST,
+        "",
+       Importance.LOW,
+       KSQL_SERVER_PRECONDITIONS_DOC
     );
   }
 

--- a/ksql-rest-app/src/main/java/io/confluent/ksql/rest/server/KsqlServerPrecondition.java
+++ b/ksql-rest-app/src/main/java/io/confluent/ksql/rest/server/KsqlServerPrecondition.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright 2019 Confluent Inc.
+ *
+ * Licensed under the Confluent Community License (the "License"); you may not use
+ * this file except in compliance with the License.  You may obtain a copy of the
+ * License at
+ *
+ * http://www.confluent.io/confluent-community-license
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package io.confluent.ksql.rest.server;
+
+import io.confluent.ksql.services.ServiceContext;
+import java.util.Optional;
+
+public interface KsqlServerPrecondition {
+  /**
+   * Check a precondition for initializing the KSQL server.
+   *
+   * @param config The KSQL server config
+   * @param serviceContext The KSQL server context for accessing external serivces
+   * @return Optional.empty() if precondition check passes, non-empty reason string if the
+   *         check does not pass.
+   */
+  Optional<String> checkPrecondition(
+      KsqlRestConfig config,
+      ServiceContext serviceContext
+  );
+}

--- a/ksql-rest-app/src/main/java/io/confluent/ksql/rest/server/computation/CommandStore.java
+++ b/ksql-rest-app/src/main/java/io/confluent/ksql/rest/server/computation/CommandStore.java
@@ -72,6 +72,14 @@ public class CommandStore implements CommandQueue, Closeable {
         Objects.requireNonNull(sequenceNumberFutureStore, "sequenceNumberFutureStore");
   }
 
+  public String getCommandTopicName() {
+    return commandTopic.getCommandTopicName();
+  }
+
+  public void start() {
+    commandTopic.start();
+  }
+
   /**
    * Close the store, rendering it unable to read or write commands
    */

--- a/ksql-rest-app/src/main/java/io/confluent/ksql/rest/server/resources/Errors.java
+++ b/ksql-rest-app/src/main/java/io/confluent/ksql/rest/server/resources/Errors.java
@@ -46,6 +46,9 @@ public final class Errors {
   public static final int ERROR_CODE_COMMAND_QUEUE_CATCHUP_TIMEOUT =
       toErrorCode(SERVICE_UNAVAILABLE.getStatusCode()) + 1;
 
+  public static final int ERROR_CODE_SERVER_NOT_READY =
+      toErrorCode(SERVICE_UNAVAILABLE.getStatusCode()) + 2;
+
   private Errors() {
   }
 
@@ -142,12 +145,19 @@ public final class Errors {
         .build();
   }
 
-  static Response serverShuttingDown() {
+  public static Response serverShuttingDown() {
     return Response
         .status(SERVICE_UNAVAILABLE)
         .entity(new KsqlErrorMessage(
             ERROR_CODE_SERVER_SHUTTING_DOWN,
             "The server is shutting down"))
+        .build();
+  }
+
+  public static Response serverNotReady(final String reason) {
+    return Response
+        .status(SERVICE_UNAVAILABLE)
+        .entity(new KsqlErrorMessage(ERROR_CODE_SERVER_NOT_READY, reason))
         .build();
   }
 }

--- a/ksql-rest-app/src/main/java/io/confluent/ksql/rest/server/resources/KsqlResource.java
+++ b/ksql-rest-app/src/main/java/io/confluent/ksql/rest/server/resources/KsqlResource.java
@@ -230,13 +230,6 @@ public class KsqlResource {
 
   @POST
   public Response handleKsqlStatements(final KsqlRequest request) {
-    if (!ksqlEngine.isAcceptingStatements()) {
-      return Errors.serverErrorForStatement(
-          new KsqlException("The cluster has been terminated. No new request will be accepted."),
-          request.getKsql(),
-          new KsqlEntityList()
-      );
-    }
     activenessRegistrar.updateLastRequestTime();
     try {
       CommandStoreUtil.httpWaitForCommandSequenceNumber(

--- a/ksql-rest-app/src/main/java/io/confluent/ksql/rest/server/resources/ServerInfoResource.java
+++ b/ksql-rest-app/src/main/java/io/confluent/ksql/rest/server/resources/ServerInfoResource.java
@@ -15,7 +15,12 @@
 
 package io.confluent.ksql.rest.server.resources;
 
+import io.confluent.ksql.rest.entity.ServerInfo;
 import io.confluent.ksql.rest.entity.Versions;
+import io.confluent.ksql.services.ServiceContext;
+import io.confluent.ksql.util.KsqlConfig;
+import io.confluent.ksql.util.Version;
+import java.util.concurrent.TimeUnit;
 import javax.ws.rs.GET;
 import javax.ws.rs.Path;
 import javax.ws.rs.Produces;
@@ -25,15 +30,41 @@ import javax.ws.rs.core.Response;
 @Path("/info")
 @Produces({Versions.KSQL_V1_JSON, MediaType.APPLICATION_JSON})
 public class ServerInfoResource {
+  private static final long DESCRIBE_CLUSTER_TIMEOUT_SECONDS = 30;
 
-  private final io.confluent.ksql.rest.entity.ServerInfo serverInfo;
+  private final ServiceContext serviceContext;
+  private final KsqlConfig ksqlConfig;
+  private volatile io.confluent.ksql.rest.entity.ServerInfo serverInfo = null;
 
-  public ServerInfoResource(final io.confluent.ksql.rest.entity.ServerInfo serverInfo) {
-    this.serverInfo = serverInfo;
+  public ServerInfoResource(final ServiceContext serviceContext, final KsqlConfig ksqlConfig) {
+    this.serviceContext = serviceContext;
+    this.ksqlConfig = ksqlConfig;
+  }
+
+  private ServerInfo getServerInfo() {
+    if (serverInfo == null) {
+      serverInfo = new ServerInfo(
+          Version.getVersion(),
+          getKafkaClusterId(serviceContext),
+          ksqlConfig.getString(KsqlConfig.KSQL_SERVICE_ID_CONFIG)
+      );
+    }
+    return serverInfo;
+  }
+
+  private static String getKafkaClusterId(final ServiceContext serviceContext) {
+    try {
+      return serviceContext.getAdminClient()
+          .describeCluster()
+          .clusterId()
+          .get(DESCRIBE_CLUSTER_TIMEOUT_SECONDS, TimeUnit.SECONDS);
+    } catch (final Exception e) {
+      throw new RuntimeException("Failed to get Kafka cluster information", e);
+    }
   }
 
   @GET
   public Response get() {
-    return Response.ok(serverInfo).build();
+    return Response.ok(getServerInfo()).build();
   }
 }

--- a/ksql-rest-app/src/main/java/io/confluent/ksql/rest/server/resources/streaming/StreamedQueryResource.java
+++ b/ksql-rest-app/src/main/java/io/confluent/ksql/rest/server/resources/streaming/StreamedQueryResource.java
@@ -21,7 +21,6 @@ import io.confluent.ksql.json.JsonMapper;
 import io.confluent.ksql.parser.KsqlParser.PreparedStatement;
 import io.confluent.ksql.parser.tree.PrintTopic;
 import io.confluent.ksql.parser.tree.Query;
-import io.confluent.ksql.rest.entity.KsqlEntityList;
 import io.confluent.ksql.rest.entity.KsqlRequest;
 import io.confluent.ksql.rest.entity.Versions;
 import io.confluent.ksql.rest.server.StatementParser;
@@ -90,13 +89,6 @@ public class StreamedQueryResource {
 
   @POST
   public Response streamQuery(final KsqlRequest request) throws Exception {
-    if (!ksqlEngine.isAcceptingStatements()) {
-      return Errors.serverErrorForStatement(
-          new KsqlException("Cluster has been terminated."),
-          "The cluster has been terminated. No new request will be accepted.",
-          new KsqlEntityList());
-    }
-
     activenessRegistrar.updateLastRequestTime();
 
     final PreparedStatement<?> statement = parseStatement(request);

--- a/ksql-rest-app/src/main/java/io/confluent/ksql/rest/server/state/ServerState.java
+++ b/ksql-rest-app/src/main/java/io/confluent/ksql/rest/server/state/ServerState.java
@@ -17,8 +17,17 @@ package io.confluent.ksql.rest.server.state;
 
 import io.confluent.ksql.rest.server.resources.Errors;
 import java.util.Optional;
+import java.util.concurrent.atomic.AtomicReference;
 import javax.ws.rs.core.Response;
 
+/**
+ * State machine for managing the lifecycle of a KSQL Server. The machine goes through the
+ * following states:
+ *     INITIALIZING: The server is still setting up to serve requests (checking preconditons,
+ *                   initialing the engine, etc).
+ *     READY:        The server is ready to serve the KSQL API.
+ *     TERMINATING:  The server has been asked to shut down and is cleaning up state.
+ */
 public class ServerState {
   public enum State {
     INITIALIZING,
@@ -26,28 +35,68 @@ public class ServerState {
     TERMINATING
   }
 
-  private volatile State state = State.INITIALIZING;
-  private volatile String initializingReason = "KSQL is not yet ready to serve requests.";
+  private static class StateWithReason {
+    final State state;
+    final String reason;
 
+    private StateWithReason(final State state, final String reason) {
+      this.state = state;
+      this.reason = reason;
+    }
+
+    private StateWithReason(final State state) {
+      this.state = state;
+      this.reason = null;
+    }
+  }
+
+  private final AtomicReference<StateWithReason> state = new AtomicReference<>(
+      new StateWithReason(State.INITIALIZING, "KSQL is not yet ready to serve requests.")
+  );
+
+  /**
+   * Creates a new ServerState with state INITIALIZING.
+   */
   public ServerState() {
   }
 
+  /**
+   * Set a reason string explaining why the server is still in the INITIALIZING state.
+   * This reason string will be used to add context to the API error indicating that the server
+   * is not yet ready to serve requests.
+   *
+   * @param initializingReason The reason string indicating why the server is still initializing.
+   */
   public void setInitializingReason(final String initializingReason) {
-    this.initializingReason = initializingReason;
+    this.state.set(new StateWithReason(State.INITIALIZING, initializingReason));
   }
 
+  /**
+   * Sets the server state to READY.
+   */
   public void setReady() {
-    this.state = State.READY;
+    this.state.set(new StateWithReason(State.READY));
   }
 
+  /**
+   * Sets the server state to TERMINATING.
+   */
   public void setTerminating() {
-    this.state = State.TERMINATING;
+    this.state.set(new StateWithReason(State.TERMINATING));
   }
 
+  /**
+   * Checks whether the server is READY (and can therefore server requests). If it is not READY
+   * then returns an API error to be sent back to the user.
+   *
+   * @return If empty, indicates that the server is ready. Otherwise, contains an error response
+   *         to be returned back to the user.
+   */
   public Optional<Response> checkReady() {
-    switch (state) {
+    final StateWithReason state = this.state.get();
+    switch (state.state) {
       case INITIALIZING:
-        return Optional.of(Errors.serverNotReady(initializingReason));
+        return Optional.of(Errors.serverNotReady(state.reason));
       case TERMINATING:
         return Optional.of(Errors.serverShuttingDown());
       default:

--- a/ksql-rest-app/src/main/java/io/confluent/ksql/rest/server/state/ServerState.java
+++ b/ksql-rest-app/src/main/java/io/confluent/ksql/rest/server/state/ServerState.java
@@ -35,7 +35,7 @@ public class ServerState {
     TERMINATING
   }
 
-  private static class StateWithReason {
+  private static final class StateWithReason {
     final State state;
     final String reason;
 

--- a/ksql-rest-app/src/main/java/io/confluent/ksql/rest/server/state/ServerState.java
+++ b/ksql-rest-app/src/main/java/io/confluent/ksql/rest/server/state/ServerState.java
@@ -1,0 +1,57 @@
+/*
+ * Copyright 2019 Confluent Inc.
+ *
+ * Licensed under the Confluent Community License (the "License"); you may not use
+ * this file except in compliance with the License.  You may obtain a copy of the
+ * License at
+ *
+ * http://www.confluent.io/confluent-community-license
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package io.confluent.ksql.rest.server.state;
+
+import io.confluent.ksql.rest.server.resources.Errors;
+import java.util.Optional;
+import javax.ws.rs.core.Response;
+
+public class ServerState {
+  public enum State {
+    INITIALIZING,
+    READY,
+    TERMINATING
+  }
+
+  private volatile State state = State.INITIALIZING;
+  private volatile String initializingReason = "KSQL is not yet ready to serve requests.";
+
+  public ServerState() {
+  }
+
+  public void setInitializingReason(final String initializingReason) {
+    this.initializingReason = initializingReason;
+  }
+
+  public void setReady() {
+    this.state = State.READY;
+  }
+
+  public void setTerminating() {
+    this.state = State.TERMINATING;
+  }
+
+  public Optional<Response> checkReady() {
+    switch (state) {
+      case INITIALIZING:
+        return Optional.of(Errors.serverNotReady(initializingReason));
+      case TERMINATING:
+        return Optional.of(Errors.serverShuttingDown());
+      default:
+    }
+    return Optional.empty();
+  }
+}

--- a/ksql-rest-app/src/main/java/io/confluent/ksql/rest/server/state/ServerStateDynamicBinding.java
+++ b/ksql-rest-app/src/main/java/io/confluent/ksql/rest/server/state/ServerStateDynamicBinding.java
@@ -20,6 +20,9 @@ import javax.ws.rs.container.ResourceInfo;
 import javax.ws.rs.core.FeatureContext;
 import javax.ws.rs.ext.Provider;
 
+/**
+ * A javax dynamic binding for registering the server state filter with KSQL resources.
+ */
 @Provider
 public class ServerStateDynamicBinding implements DynamicFeature {
   private final ServerState state;
@@ -28,6 +31,14 @@ public class ServerStateDynamicBinding implements DynamicFeature {
     this.state = state;
   }
 
+  /**
+   * Binds ServerStateFilter with the provided filter if the filter is defined in a package
+   * with the prefix "io.confluent.ksql.rest". This ensures that resources configured as
+   * plugins can continue to function.
+   *
+   * @param resourceInfo ResourceInfo instance provided by javax.
+   * @param context FeatureContext instance provided by javax.
+   */
   @Override
   public void configure(final ResourceInfo resourceInfo, final FeatureContext context) {
     final String packageName = resourceInfo.getResourceClass().getPackage().getName();

--- a/ksql-rest-app/src/main/java/io/confluent/ksql/rest/server/state/ServerStateDynamicBinding.java
+++ b/ksql-rest-app/src/main/java/io/confluent/ksql/rest/server/state/ServerStateDynamicBinding.java
@@ -1,0 +1,38 @@
+/*
+ * Copyright 2019 Confluent Inc.
+ *
+ * Licensed under the Confluent Community License (the "License"); you may not use
+ * this file except in compliance with the License.  You may obtain a copy of the
+ * License at
+ *
+ * http://www.confluent.io/confluent-community-license
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package io.confluent.ksql.rest.server.state;
+
+import javax.ws.rs.container.DynamicFeature;
+import javax.ws.rs.container.ResourceInfo;
+import javax.ws.rs.core.FeatureContext;
+import javax.ws.rs.ext.Provider;
+
+@Provider
+public class ServerStateDynamicBinding implements DynamicFeature {
+  private final ServerState state;
+
+  public ServerStateDynamicBinding(final ServerState state) {
+    this.state = state;
+  }
+
+  @Override
+  public void configure(final ResourceInfo resourceInfo, final FeatureContext context) {
+    final String packageName = resourceInfo.getResourceClass().getPackage().getName();
+    if (packageName.startsWith("io.confluent.ksql.rest")) {
+      context.register(new ServerStateFilter(state));
+    }
+  }
+}

--- a/ksql-rest-app/src/main/java/io/confluent/ksql/rest/server/state/ServerStateFilter.java
+++ b/ksql-rest-app/src/main/java/io/confluent/ksql/rest/server/state/ServerStateFilter.java
@@ -18,6 +18,10 @@ package io.confluent.ksql.rest.server.state;
 import javax.ws.rs.container.ContainerRequestContext;
 import javax.ws.rs.container.ContainerRequestFilter;
 
+/**
+ * A javax request filter that ensures the KSQL server is in the READY state before
+ * serving requests.
+ */
 public class ServerStateFilter implements ContainerRequestFilter {
   private final ServerState state;
 
@@ -25,6 +29,13 @@ public class ServerStateFilter implements ContainerRequestFilter {
     this.state = state;
   }
 
+  /**
+   * Ensures the KSQL server is in the READY state. If not, filter will abort the passed
+   * in request context with the API error returned by the state machine.
+   *
+   * @param requestContext the ContainerRequestContext instance provided by the javax
+   *                       implementation.
+   */
   @Override
   public void filter(final ContainerRequestContext requestContext) {
     state.checkReady().ifPresent(requestContext::abortWith);

--- a/ksql-rest-app/src/main/java/io/confluent/ksql/rest/server/state/ServerStateFilter.java
+++ b/ksql-rest-app/src/main/java/io/confluent/ksql/rest/server/state/ServerStateFilter.java
@@ -1,0 +1,32 @@
+/*
+ * Copyright 2019 Confluent Inc.
+ *
+ * Licensed under the Confluent Community License (the "License"); you may not use
+ * this file except in compliance with the License.  You may obtain a copy of the
+ * License at
+ *
+ * http://www.confluent.io/confluent-community-license
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package io.confluent.ksql.rest.server.state;
+
+import javax.ws.rs.container.ContainerRequestContext;
+import javax.ws.rs.container.ContainerRequestFilter;
+
+public class ServerStateFilter implements ContainerRequestFilter {
+  private final ServerState state;
+
+  ServerStateFilter(final ServerState state) {
+    this.state = state;
+  }
+
+  @Override
+  public void filter(final ContainerRequestContext requestContext) {
+    state.checkReady().ifPresent(requestContext::abortWith);
+  }
+}

--- a/ksql-rest-app/src/main/java/io/confluent/ksql/rest/util/ProcessingLogServerUtils.java
+++ b/ksql-rest-app/src/main/java/io/confluent/ksql/rest/util/ProcessingLogServerUtils.java
@@ -50,7 +50,7 @@ public final class ProcessingLogServerUtils {
         .schema();
   }
 
-  private static String getTopicName(
+  public static String getTopicName(
       final ProcessingLogConfig config,
       final KsqlConfig ksqlConfig) {
     final String topicNameConfig = config.getString(ProcessingLogConfig.TOPIC_NAME);

--- a/ksql-rest-app/src/test/java/io/confluent/ksql/rest/server/CommandTopicTest.java
+++ b/ksql-rest-app/src/test/java/io/confluent/ksql/rest/server/CommandTopicTest.java
@@ -102,6 +102,10 @@ public class CommandTopicTest {
 
   @Test
   public void shouldAssignCorrectPartitionToConsumer() {
+    // When:
+    commandTopic.start();
+
+    // Then:
     verify(commandConsumer)
         .assign(eq(Collections.singleton(new TopicPartition(COMMAND_TOPIC_NAME, 0))));
   }

--- a/ksql-rest-app/src/test/java/io/confluent/ksql/rest/server/KsqlRestApplicationTest.java
+++ b/ksql-rest-app/src/test/java/io/confluent/ksql/rest/server/KsqlRestApplicationTest.java
@@ -16,26 +16,32 @@
 package io.confluent.ksql.rest.server;
 
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.ArgumentMatchers.anyMap;
+import static org.mockito.ArgumentMatchers.anyShort;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.verifyNoMoreInteractions;
+import static org.mockito.Mockito.verifyZeroInteractions;
 import static org.mockito.Mockito.when;
 
-import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.ImmutableList;
 import io.confluent.ksql.KsqlEngine;
 import io.confluent.ksql.KsqlExecutionContext;
+import io.confluent.ksql.ddl.commands.DdlCommandExec;
 import io.confluent.ksql.logging.processing.ProcessingLogConfig;
+import io.confluent.ksql.logging.processing.ProcessingLogContext;
 import io.confluent.ksql.parser.KsqlParser.PreparedStatement;
-import io.confluent.ksql.parser.tree.Statement;
-import io.confluent.ksql.parser.tree.AbstractStreamCreateStatement;
-import io.confluent.ksql.rest.server.computation.CommandQueue;
 import io.confluent.ksql.rest.server.computation.CommandRunner;
+import io.confluent.ksql.rest.server.computation.CommandStore;
 import io.confluent.ksql.rest.server.computation.QueuedCommandStatus;
 import io.confluent.ksql.rest.server.resources.KsqlResource;
 import io.confluent.ksql.rest.server.resources.RootDocument;
 import io.confluent.ksql.rest.server.resources.StatusResource;
 import io.confluent.ksql.rest.server.resources.streaming.StreamedQueryResource;
+import io.confluent.ksql.rest.server.state.ServerState;
 import io.confluent.ksql.rest.util.ProcessingLogServerUtils;
+import io.confluent.ksql.services.KafkaTopicClient;
 import io.confluent.ksql.services.ServiceContext;
 import io.confluent.ksql.util.FakeKafkaClientSupplier;
 import io.confluent.ksql.util.KsqlConfig;
@@ -43,16 +49,22 @@ import io.confluent.ksql.util.KsqlException;
 import io.confluent.ksql.version.metrics.VersionCheckerAgent;
 import io.confluent.rest.RestConfig;
 import java.util.Collections;
+import java.util.LinkedList;
+import java.util.Optional;
+import java.util.Queue;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
+import org.mockito.InOrder;
 import org.mockito.Mock;
+import org.mockito.Mockito;
 import org.mockito.junit.MockitoJUnitRunner;
 
 @RunWith(MockitoJUnitRunner.class)
 public class KsqlRestApplicationTest {
   private static final String LOG_STREAM_NAME = "log_stream";
   private static final String LOG_TOPIC_NAME = "log_topic";
+  private static final String CMD_TOPIC_NAME = "command_topic";
 
   private final KsqlRestConfig restConfig =
       new KsqlRestConfig(
@@ -82,26 +94,49 @@ public class KsqlRestApplicationTest {
   @Mock
   private VersionCheckerAgent versionCheckerAgent;
   @Mock
-  private CommandQueue commandQueue;
+  private CommandStore commandQueue;
   @Mock
   private QueuedCommandStatus queuedCommandStatus;
+  @Mock
+  private ProcessingLogContext processingLogContext;
+  @Mock
+  private ServerState serverState;
+  @Mock
+  private KafkaTopicClient topicClient;
+  @Mock
+  private DdlCommandExec ddlCommandExec;
+  @Mock
+  private KsqlServerPrecondition precondition1;
+  @Mock
+  private KsqlServerPrecondition precondition2;
+  private PreparedStatement logCreateStatement;
   private KsqlRestApplication app;
 
   @Before
   public void setUp() {
-    when(ksqlConfig.getString(KsqlConfig.KSQL_SERVICE_ID_CONFIG)).thenReturn("default_id_");
     when(processingLogConfig.getBoolean(ProcessingLogConfig.STREAM_AUTO_CREATE))
         .thenReturn(true);
     when(processingLogConfig.getString(ProcessingLogConfig.STREAM_NAME))
         .thenReturn(LOG_STREAM_NAME);
     when(processingLogConfig.getString(ProcessingLogConfig.TOPIC_NAME))
         .thenReturn(LOG_TOPIC_NAME);
+    when(processingLogConfig.getBoolean(ProcessingLogConfig.TOPIC_AUTO_CREATE)).thenReturn(true);
+    when(processingLogContext.getConfig()).thenReturn(processingLogConfig);
     when(ksqlEngine.createSandbox()).thenReturn(sandBox);
     when(commandQueue.isEmpty()).thenReturn(true);
     when(commandQueue.enqueueCommand(any(), any(), any()))
         .thenReturn(queuedCommandStatus);
-    when(serviceContext.getAdminClient())
-        .thenReturn(new FakeKafkaClientSupplier().getAdminClient(Collections.emptyMap()));
+    when(commandQueue.getCommandTopicName()).thenReturn(CMD_TOPIC_NAME);
+    when(serviceContext.getTopicClient()).thenReturn(topicClient);
+    when(topicClient.isTopicExists(CMD_TOPIC_NAME)).thenReturn(false);
+    when(ksqlEngine.getDdlCommandExec()).thenReturn(ddlCommandExec);
+    when(precondition1.checkPrecondition(any(), any())).thenReturn(Optional.empty());
+    when(precondition2.checkPrecondition(any(), any())).thenReturn(Optional.empty());
+
+    logCreateStatement = ProcessingLogServerUtils.processingLogStreamCreateStatement(
+        processingLogConfig,
+        ksqlConfig
+    );
 
     app = new KsqlRestApplication(
         serviceContext,
@@ -114,7 +149,10 @@ public class KsqlRestApplicationTest {
         statusResource,
         streamedQueryResource,
         ksqlResource,
-        versionCheckerAgent
+        versionCheckerAgent,
+        serverState,
+        processingLogContext,
+        ImmutableList.of(precondition1, precondition2)
     );
   }
 
@@ -130,22 +168,12 @@ public class KsqlRestApplicationTest {
   @Test
   public void shouldCreateLogStream() {
     // When:
-    KsqlRestApplication.maybeCreateProcessingLogStream(
-        processingLogConfig,
-        ksqlConfig,
-        ksqlEngine,
-        commandQueue
-    );
+    app.startKsql();
 
     // Then:
     verify(commandQueue).isEmpty();
-    final PreparedStatement<?> statement =
-        ProcessingLogServerUtils.processingLogStreamCreateStatement(
-            processingLogConfig,
-            ksqlConfig
-        );
-    verify(sandBox).execute(statement, ksqlConfig, Collections.emptyMap());
-    verify(commandQueue).enqueueCommand(statement, ksqlConfig, Collections.emptyMap());
+    verify(sandBox).execute(logCreateStatement, ksqlConfig, Collections.emptyMap());
+    verify(commandQueue).enqueueCommand(logCreateStatement, ksqlConfig, Collections.emptyMap());
   }
 
   @Test
@@ -155,15 +183,10 @@ public class KsqlRestApplicationTest {
         .thenReturn(false);
 
     // When:
-    KsqlRestApplication.maybeCreateProcessingLogStream(
-        processingLogConfig,
-        ksqlConfig,
-        ksqlEngine,
-        commandQueue
-    );
+    app.startKsql();
 
     // Then:
-    verifyNoMoreInteractions(ksqlEngine, commandQueue);
+    verify(commandQueue, never()).enqueueCommand(any(), any(), any());
   }
 
   @Test
@@ -172,12 +195,7 @@ public class KsqlRestApplicationTest {
     when(commandQueue.isEmpty()).thenReturn(false);
 
     // When:
-    KsqlRestApplication.maybeCreateProcessingLogStream(
-        processingLogConfig,
-        ksqlConfig,
-        ksqlEngine,
-        commandQueue
-    );
+    app.startKsql();
 
     // Then:
     verify(commandQueue, never()).enqueueCommand(any(), any(), any());
@@ -189,14 +207,120 @@ public class KsqlRestApplicationTest {
     when(sandBox.execute(any(), any(), any())).thenThrow(new KsqlException("error"));
 
     // When:
-    KsqlRestApplication.maybeCreateProcessingLogStream(
-        processingLogConfig,
-        ksqlConfig,
-        ksqlEngine,
-        commandQueue
-    );
+    app.startKsql();
 
     // Then:
     verify(commandQueue, never()).enqueueCommand(any(), any(), any());
+  }
+
+  @Test
+  public void shouldStartCommandStoreBeforeEnqueuingLogStream() {
+    // When:
+    app.startKsql();
+
+    // Then:
+    final InOrder inOrder = Mockito.inOrder(commandQueue);
+    inOrder.verify(commandQueue).start();
+    inOrder.verify(commandQueue).enqueueCommand(
+        logCreateStatement,
+        ksqlConfig,
+        Collections.emptyMap()
+    );
+  }
+
+  @Test
+  public void shouldCreateLogTopicBeforeEnqueuingLogStream() {
+    // When:
+    app.startKsql();
+
+    // Then:
+    final InOrder inOrder = Mockito.inOrder(topicClient, commandQueue);
+    inOrder.verify(topicClient).createTopic(eq(LOG_TOPIC_NAME), anyInt(), anyShort());
+    inOrder.verify(commandQueue).enqueueCommand(
+        logCreateStatement,
+        ksqlConfig,
+        Collections.emptyMap()
+    );
+  }
+
+  @Test
+  public void shouldInitializeCommandStoreCorrectly() {
+    // When:
+    app.startKsql();
+
+    // Then:
+    final InOrder inOrder = Mockito.inOrder(topicClient, commandQueue, commandRunner);
+    inOrder.verify(topicClient).createTopic(eq(CMD_TOPIC_NAME), anyInt(), anyShort(), anyMap());
+    inOrder.verify(commandQueue).start();
+    inOrder.verify(commandRunner).processPriorCommands();
+  }
+
+  @Test
+  public void shouldReplayCommandsBeforeSettingReady() {
+    // When:
+    app.startKsql();
+
+    // Then:
+    final InOrder inOrder = Mockito.inOrder(commandRunner, serverState);
+    inOrder.verify(commandRunner).processPriorCommands();
+    inOrder.verify(serverState).setReady();
+  }
+
+  @Test
+  public void shouldEnqueueLogStreamBeforeSettingReady() {
+    // When:
+    app.startKsql();
+
+    // Then:
+    final InOrder inOrder = Mockito.inOrder(commandQueue, serverState);
+    inOrder.verify(commandQueue).enqueueCommand(
+        logCreateStatement,
+        ksqlConfig,
+        Collections.emptyMap()
+    );
+    inOrder.verify(serverState).setReady();
+  }
+
+  @Test
+  public void shouldCheckPreconditionsBeforeUsingServiceContext() {
+    // Given:
+    when(precondition2.checkPrecondition(any(), any())).then(a -> {
+      verifyZeroInteractions(serviceContext);
+      return Optional.empty();
+    });
+
+    // When:
+    app.startKsql();
+
+    // Then:
+    final InOrder inOrder = Mockito.inOrder(precondition1, precondition2, serviceContext);
+    inOrder.verify(precondition1).checkPrecondition(restConfig, serviceContext);
+    inOrder.verify(precondition2).checkPrecondition(restConfig, serviceContext);
+  }
+
+  @Test
+  public void shouldNotInitializeUntilPreconditionsChecked() {
+    // Given:
+    final Queue<String> errors = new LinkedList<>();
+    errors.add("error1");
+    errors.add("error2");
+    when(precondition2.checkPrecondition(any(), any())).then(a -> {
+      verifyZeroInteractions(serviceContext);
+      return Optional.ofNullable(errors.isEmpty() ? null : errors.remove());
+    });
+
+    // When:
+    app.startKsql();
+
+    // Then:
+    final InOrder inOrder = Mockito.inOrder(precondition1, precondition2, serverState);
+    inOrder.verify(precondition1).checkPrecondition(restConfig, serviceContext);
+    inOrder.verify(precondition2).checkPrecondition(restConfig, serviceContext);
+    inOrder.verify(serverState).setInitializingReason("error1");
+    inOrder.verify(precondition1).checkPrecondition(restConfig, serviceContext);
+    inOrder.verify(precondition2).checkPrecondition(restConfig, serviceContext);
+    inOrder.verify(serverState).setInitializingReason("error2");
+    inOrder.verify(precondition1).checkPrecondition(restConfig, serviceContext);
+    inOrder.verify(precondition2).checkPrecondition(restConfig, serviceContext);
   }
 }

--- a/ksql-rest-app/src/test/java/io/confluent/ksql/rest/server/computation/CommandRunnerTest.java
+++ b/ksql-rest-app/src/test/java/io/confluent/ksql/rest/server/computation/CommandRunnerTest.java
@@ -30,6 +30,7 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import io.confluent.ksql.KsqlEngine;
+import io.confluent.ksql.rest.server.state.ServerState;
 import io.confluent.ksql.rest.util.ClusterTerminator;
 import io.confluent.ksql.rest.util.TerminateCluster;
 import java.util.ArrayList;
@@ -53,6 +54,8 @@ public class CommandRunnerTest {
   private KsqlEngine ksqlEngine;
   @Mock
   private ClusterTerminator clusterTerminator;
+  @Mock
+  private ServerState serverState;
 
   @Mock
   private Command command1;
@@ -84,8 +87,13 @@ public class CommandRunnerTest {
         commandId3, command3);
     when(commandStore.getRestoreCommands()).thenReturn(queuedCommandList);
     when(commandStore.getNewCommands()).thenReturn(queuedCommandList);
-    commandRunner = new CommandRunner(statementExecutor, commandStore, ksqlEngine, 1,
-        clusterTerminator);
+    commandRunner = new CommandRunner(
+        statementExecutor,
+        commandStore,
+        1,
+        clusterTerminator,
+        serverState
+    );
   }
 
   @Test
@@ -111,7 +119,7 @@ public class CommandRunnerTest {
     commandRunner.processPriorCommands();
 
     // Then:
-    verify(ksqlEngine).stopAcceptingStatements();
+    verify(serverState).setTerminating();
     verify(commandStore).close();
     verify(clusterTerminator).terminateCluster(anyList());
     verify(statementExecutor, never()).handleRestore(any());

--- a/ksql-rest-app/src/test/java/io/confluent/ksql/rest/server/computation/CommandStoreTest.java
+++ b/ksql-rest-app/src/test/java/io/confluent/ksql/rest/server/computation/CommandStoreTest.java
@@ -110,6 +110,8 @@ public class CommandStoreTest {
 
     when(commandTopic.getNewCommands(any())).thenReturn(buildRecords(commandId, command));
 
+    when(commandTopic.getCommandTopicName()).thenReturn(COMMAND_TOPIC);
+
     when(sequenceNumberFutureStore.getFutureForSequenceNumber(anyLong())).thenReturn(future);
 
     preparedStatement = PreparedStatement.of(statementText, statement);
@@ -276,6 +278,20 @@ public class CommandStoreTest {
 
     // When/Then:
     assertThat(commandStore.isEmpty(), is(true));
+  }
+
+  @Test
+  public void shouldGetCommandTopicName() {
+    assertThat(commandStore.getCommandTopicName(), equalTo(COMMAND_TOPIC));
+  }
+
+  @Test
+  public void shouldStartCommandTopicOnStart() {
+    // When:
+    commandStore.start();
+
+    // Then:
+    verify(commandTopic).start();
   }
 
   private static ConsumerRecords<CommandId, Command> buildRecords(final Object... args) {

--- a/ksql-rest-app/src/test/java/io/confluent/ksql/rest/server/computation/RecoveryTest.java
+++ b/ksql-rest-app/src/test/java/io/confluent/ksql/rest/server/computation/RecoveryTest.java
@@ -34,6 +34,7 @@ import io.confluent.ksql.metastore.StructuredDataSource;
 import io.confluent.ksql.parser.KsqlParser.PreparedStatement;
 import io.confluent.ksql.query.QueryId;
 import io.confluent.ksql.rest.entity.KsqlRequest;
+import io.confluent.ksql.rest.server.state.ServerState;
 import io.confluent.ksql.rest.server.StatementParser;
 import io.confluent.ksql.rest.server.computation.CommandId.Action;
 import io.confluent.ksql.rest.server.computation.CommandId.Type;
@@ -159,6 +160,7 @@ public class RecoveryTest {
     final FakeCommandQueue fakeCommandQueue;
     final StatementExecutor statementExecutor;
     final CommandRunner commandRunner;
+    final ServerState serverState;
 
     KsqlServer(final List<QueuedCommand> commandLog) {
       this.ksqlEngine = createKsqlEngine();
@@ -166,6 +168,8 @@ public class RecoveryTest {
       this.fakeCommandQueue = new FakeCommandQueue(
           new CommandIdAssigner(ksqlEngine.getMetaStore()),
           commandLog);
+      serverState = new ServerState();
+      serverState.setReady();
       this.ksqlResource = new KsqlResource(
           ksqlConfig,
           ksqlEngine,
@@ -181,9 +185,9 @@ public class RecoveryTest {
       this.commandRunner = new CommandRunner(
           statementExecutor,
           fakeCommandQueue,
-          ksqlEngine,
           1,
-          mock(ClusterTerminator.class)
+          mock(ClusterTerminator.class),
+          serverState
       );
     }
 

--- a/ksql-rest-app/src/test/java/io/confluent/ksql/rest/server/resources/KsqlResourceTest.java
+++ b/ksql-rest-app/src/test/java/io/confluent/ksql/rest/server/resources/KsqlResourceTest.java
@@ -1554,7 +1554,11 @@ public class KsqlResourceTest {
 
   private void setUpKsqlResource() {
     ksqlResource = new KsqlResource(
-        ksqlConfig, ksqlEngine, serviceContext, commandStore, DISTRIBUTED_COMMAND_RESPONSE_TIMEOUT,
+        ksqlConfig,
+        ksqlEngine,
+        serviceContext,
+        commandStore,
+        DISTRIBUTED_COMMAND_RESPONSE_TIMEOUT,
         activenessRegistrar);
   }
 

--- a/ksql-rest-app/src/test/java/io/confluent/ksql/rest/server/resources/ServerInfoResourceTest.java
+++ b/ksql-rest-app/src/test/java/io/confluent/ksql/rest/server/resources/ServerInfoResourceTest.java
@@ -1,0 +1,100 @@
+package io.confluent.ksql.rest.server.resources;
+
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.instanceOf;
+import static org.junit.Assert.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoMoreInteractions;
+import static org.mockito.Mockito.when;
+
+import com.google.common.collect.ImmutableMap;
+import io.confluent.ksql.rest.entity.ServerInfo;
+import io.confluent.ksql.services.ServiceContext;
+import io.confluent.ksql.util.KsqlConfig;
+import io.confluent.ksql.util.Version;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
+import javax.ws.rs.core.Response;
+import org.apache.kafka.clients.admin.AdminClient;
+import org.apache.kafka.clients.admin.DescribeClusterResult;
+import org.apache.kafka.common.KafkaFuture;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnit;
+import org.mockito.junit.MockitoRule;
+
+public class ServerInfoResourceTest {
+  private static final String KSQL_SERVICE_ID = "ksql.foo";
+  private static final String KAFKA_CLUSTER_ID = "kafka.bar";
+
+  @Mock
+  private ServiceContext serviceContext;
+  @Mock
+  private AdminClient adminClient;
+  @Mock
+  private DescribeClusterResult describeClusterResult;
+  @Mock
+  private KafkaFuture<String> future;
+
+  private ServerInfoResource serverInfoResource = null;
+
+  private final KsqlConfig ksqlConfig = new KsqlConfig(
+      ImmutableMap.of(
+        KsqlConfig.KSQL_SERVICE_ID_CONFIG, KSQL_SERVICE_ID
+      )
+  );
+
+  @Rule
+  public final MockitoRule mockitoRule = MockitoJUnit.rule();
+
+  @Before
+  public void setup() throws InterruptedException, TimeoutException, ExecutionException {
+    when(serviceContext.getAdminClient()).thenReturn(adminClient);
+    when(adminClient.describeCluster()).thenReturn(describeClusterResult);
+    when(describeClusterResult.clusterId()).thenReturn(future);
+    when(future.get(anyLong(), any())).thenReturn(KAFKA_CLUSTER_ID);
+
+    serverInfoResource = new ServerInfoResource(serviceContext, ksqlConfig);
+  }
+
+  @Test
+  public void shouldReturnServerInfo() {
+    // When:
+    final Response response = serverInfoResource.get();
+
+    // Then:
+    assertThat(response.getStatus(), equalTo(200));
+    assertThat(response.getEntity(), instanceOf(ServerInfo.class));
+    final ServerInfo serverInfo = (ServerInfo)response.getEntity();
+    assertThat(
+        serverInfo,
+        equalTo(new ServerInfo(Version.getVersion(), KAFKA_CLUSTER_ID, KSQL_SERVICE_ID))
+    );
+  }
+
+  @Test
+  public void shouldGetKafkaClusterIdWithTimeout()
+      throws InterruptedException, ExecutionException, TimeoutException{
+    // When:
+    serverInfoResource.get();
+
+    // Then:
+    verify(future).get(30, TimeUnit.SECONDS);
+  }
+
+  @Test
+  public void shouldGetKafkaClusterIdOnce() {
+    // When:
+    serverInfoResource.get();
+    serverInfoResource.get();
+
+    // Then:
+    verify(adminClient).describeCluster();
+    verifyNoMoreInteractions(adminClient);
+  }
+}

--- a/ksql-rest-app/src/test/java/io/confluent/ksql/rest/server/resources/StreamedQueryResourceTest.java
+++ b/ksql-rest-app/src/test/java/io/confluent/ksql/rest/server/resources/StreamedQueryResourceTest.java
@@ -142,25 +142,6 @@ public class StreamedQueryResourceTest {
   }
 
   @Test
-  public void shouldFailIfIsNotAcceptingStatements() throws Exception {
-    // Given:
-    final String queryString = "SELECT * FROM test_stream;";
-    reset(mockKsqlEngine);
-    expect(mockKsqlEngine.isAcceptingStatements()).andReturn(false);
-    replay(mockKsqlEngine);
-
-    // When:
-    final Response response =
-        testResource.streamQuery(new KsqlRequest(queryString, Collections.emptyMap(), null));
-
-    // Then:
-    assertThat(response.getStatus(), equalTo(Status.INTERNAL_SERVER_ERROR.getStatusCode()));
-    final KsqlErrorMessage errorMessage = (KsqlErrorMessage)response.getEntity();
-    assertThat(errorMessage.getErrorCode(), equalTo(Errors.ERROR_CODE_SERVER_ERROR));
-    assertThat(errorMessage.getMessage(), containsString("Cluster has been terminated."));
-  }
-
-  @Test
   public void shouldReturn400OnBadStatement() throws Exception {
     // Given:
     reset(mockStatementParser);

--- a/ksql-rest-app/src/test/java/io/confluent/ksql/rest/server/state/ServerStateDynamicBindingTest.java
+++ b/ksql-rest-app/src/test/java/io/confluent/ksql/rest/server/state/ServerStateDynamicBindingTest.java
@@ -1,0 +1,91 @@
+/*
+ * Copyright 2019 Confluent Inc.
+ *
+ * Licensed under the Confluent Community License (the "License"); you may not use
+ * this file except in compliance with the License.  You may obtain a copy of the
+ * License at
+ *
+ * http://www.confluent.io/confluent-community-license
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package io.confluent.ksql.rest.server.state;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyZeroInteractions;
+
+import io.confluent.ksql.rest.server.resources.KsqlResource;
+import java.lang.reflect.Method;
+import javax.ws.rs.container.ResourceInfo;
+import javax.ws.rs.core.FeatureContext;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnit;
+import org.mockito.junit.MockitoRule;
+
+public class ServerStateDynamicBindingTest {
+  @Mock
+  private FeatureContext featureContext;
+  @Mock
+  private ServerState serverState;
+  private ServerStateDynamicBinding binding;
+
+  @Before
+  public void setuo() {
+    binding = new ServerStateDynamicBinding(serverState);
+  }
+
+  @Rule
+  public final MockitoRule mockitoRule = MockitoJUnit.rule();
+
+  @Test
+  public void shouldBindFilterForKSQLResources() {
+    // Given:
+    final ResourceInfo resourceInfo = new ResourceInfo() {
+      @Override
+      public Method getResourceMethod() {
+        return null;
+      }
+
+      @Override
+      public Class<?> getResourceClass() {
+        return KsqlResource.class;
+      }
+    };
+
+    // When:
+    binding.configure(resourceInfo, featureContext);
+
+    // Then:
+    verify(featureContext).register(any(ServerStateFilter.class));
+  }
+
+  @Test
+  public void shouldNotBindFilterForPluggedResources() {
+    // Given:
+    final ResourceInfo resourceInfo = new ResourceInfo() {
+      @Override
+      public Method getResourceMethod() {
+        return null;
+      }
+
+      @Override
+      public Class<?> getResourceClass() {
+        return String.class;
+      }
+    };
+
+    // When:
+    binding.configure(resourceInfo, featureContext);
+
+    // Then:
+    verifyZeroInteractions(featureContext);
+  }
+}

--- a/ksql-rest-app/src/test/java/io/confluent/ksql/rest/server/state/ServerStateFilterTest.java
+++ b/ksql-rest-app/src/test/java/io/confluent/ksql/rest/server/state/ServerStateFilterTest.java
@@ -1,0 +1,69 @@
+/*
+ * Copyright 2019 Confluent Inc.
+ *
+ * Licensed under the Confluent Community License (the "License"); you may not use
+ * this file except in compliance with the License.  You may obtain a copy of the
+ * License at
+ *
+ * http://www.confluent.io/confluent-community-license
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package io.confluent.ksql.rest.server.state;
+
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyZeroInteractions;
+import static org.mockito.Mockito.when;
+
+import java.util.Optional;
+import javax.ws.rs.container.ContainerRequestContext;
+import javax.ws.rs.core.Response;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnit;
+import org.mockito.junit.MockitoRule;
+
+public class ServerStateFilterTest {
+  @Mock
+  private ContainerRequestContext requestContext;
+  @Mock
+  private ServerState serverState;
+  @Mock
+  private Response response;
+  private ServerStateFilter filter;
+
+  @Rule
+  public final MockitoRule mockitoRule = MockitoJUnit.rule();
+
+  @Before
+  public void setup() {
+    filter = new ServerStateFilter(serverState);
+  }
+
+  @Test
+  public void shouldAbortRequestIfStateCheckFails() {
+    // Given:
+    when(serverState.checkReady()).thenReturn(Optional.of(response));
+
+    // When:
+    filter.filter(requestContext);
+
+    // Then:
+    verify(requestContext).abortWith(response);
+  }
+
+  @Test
+  public void shouldDoNothingIfStateCheckPasses() {
+    // When:
+    filter.filter(requestContext);
+
+    // Then:
+    verifyZeroInteractions(requestContext);
+  }
+}

--- a/ksql-rest-app/src/test/java/io/confluent/ksql/rest/server/state/ServerStateTest.java
+++ b/ksql-rest-app/src/test/java/io/confluent/ksql/rest/server/state/ServerStateTest.java
@@ -1,0 +1,61 @@
+/*
+ * Copyright 2019 Confluent Inc.
+ *
+ * Licensed under the Confluent Community License (the "License"); you may not use
+ * this file except in compliance with the License.  You may obtain a copy of the
+ * License at
+ *
+ * http://www.confluent.io/confluent-community-license
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package io.confluent.ksql.rest.server.state;
+
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.is;
+import static org.junit.Assert.assertThat;
+
+import io.confluent.ksql.rest.server.resources.Errors;
+import java.util.Optional;
+import javax.ws.rs.core.Response;
+import org.junit.Test;
+
+public class ServerStateTest {
+  private final ServerState serverState = new ServerState();
+
+  @Test
+  public void shouldReturnErrorWhenInitializing() {
+    // Given:
+    serverState.setInitializingReason("bad stuff is happening");
+
+    // When:
+    final Optional<Response> result = serverState.checkReady();
+
+    // Then:
+    assertThat(result.isPresent(), is(true));
+    final Response response = result.get();
+    final Response expected = Errors.serverNotReady("bad stuff is happening");
+    assertThat(response.getStatus(), equalTo(expected.getStatus()));
+    assertThat(response.getEntity(), equalTo(expected.getEntity()));
+  }
+
+  @Test
+  public void shouldReturnErrorWhenTerminating() {
+    // Given:
+    serverState.setTerminating();
+
+    // When:
+    final Optional<Response> result = serverState.checkReady();
+
+    // Then:
+    assertThat(result.isPresent(), is(true));
+    final Response response = result.get();
+    final Response expected = Errors.serverShuttingDown();
+    assertThat(response.getStatus(), equalTo(expected.getStatus()));
+    assertThat(response.getEntity(), equalTo(expected.getEntity()));
+  }
+}


### PR DESCRIPTION
### Description 
Refactor the server setup to first create all the resources and start
accepting requests before initializing and replaying the command topic.
While the command topic is being initialized/replayed, KSQL requests
will return an error indicating that the server is initializing.

As part of this change, I've consolidated this initializing state and
the terminating state (entered when a TERMINATE request is received)
into a single state machine tracked under the package
io.confluent.ksql.rest.server.state. This package also has a request
filter that ensures that requests are only served when the server is
in READY state.

Finally, this patch adds support for checking preconditions before
initializing the server. The preconditions are provided in config
via the ksql.rest.server.preconditions property.

### Testing done 
Added unit tests
Manual tests

### Reviewer checklist
- [ ] Ensure docs are updated if necessary. (eg. if a user visible feature is being added or changed).
- [ ] Ensure relevant issues are linked (description should include text like "Fixes #<issue number>")

