### PR TITLE
Minor: QTT should not upper case map keys

### DIFF
--- a/ksql-functional-tests/src/main/java/io/confluent/ksql/test/model/RecordNode.java
+++ b/ksql-functional-tests/src/main/java/io/confluent/ksql/test/model/RecordNode.java
@@ -26,9 +26,7 @@ import io.confluent.ksql.test.tools.Topic;
 import io.confluent.ksql.test.tools.exceptions.InvalidFieldException;
 import io.confluent.ksql.test.tools.exceptions.MissingFieldException;
 import java.io.IOException;
-import java.util.HashMap;
 import java.util.Map;
-import java.util.Map.Entry;
 import java.util.Optional;
 
 public class RecordNode {
@@ -67,16 +65,7 @@ public class RecordNode {
   public Record build(final Map<String, Topic> topics) {
     final Topic topic = topics.get(topicName());
 
-    Object topicValue = buildValue(topic);
-
-    if (topicValue instanceof Map) {
-      final Map<String, Object> map = (Map<String, Object>) topicValue;
-      final Map<String, Object> uppercaseMap = new HashMap<>();
-      for (final Entry<String, Object> entry: map.entrySet()) {
-        uppercaseMap.put(entry.getKey().toUpperCase(), entry.getValue());
-      }
-      topicValue = uppercaseMap;
-    }
+    final Object topicValue = buildValue(topic);
 
     return new Record(
         topic,

--- a/ksql-functional-tests/src/test/java/io/confluent/ksql/test/tools/command/TestOptionsParserTest.java
+++ b/ksql-functional-tests/src/test/java/io/confluent/ksql/test/tools/command/TestOptionsParserTest.java
@@ -51,7 +51,7 @@ public class TestOptionsParserTest {
     System.setOut(new PrintStream(outContent, true, "UTF-8"));
 
     // When:
-    final TestOptions testOptions = TestOptionsParser.parse(new String[]{"-h"}, TestOptions.class);
+    TestOptionsParser.parse(new String[]{"-h"}, TestOptions.class);
 
     // Then:
     System.setOut(System.out);

--- a/ksql-functional-tests/src/test/resources/query-validation-tests/elements.json
+++ b/ksql-functional-tests/src/test/resources/query-validation-tests/elements.json
@@ -29,7 +29,7 @@
       "topics": [
         {
           "name": "input",
-          "schema": {"name": "blah", "type": "record", "fields": [{"name": "C1", "type": "int"}]},
+          "schema": {"name": "blah", "type": "record", "fields": [{"name": "c1", "type": "int"}]},
           "format": "AVRO"
         },
         {
@@ -50,7 +50,7 @@
       "topics": [
         {
           "name": "input",
-          "schema": {"name": "blah", "type": "record", "fields": [{"name": "C1", "type": "int"}]},
+          "schema": {"name": "blah", "type": "record", "fields": [{"name": "c1", "type": "int"}]},
           "format": "AVRO"
         },
         {
@@ -71,7 +71,7 @@
       "topics": [
         {
           "name": "input",
-          "schema": {"name": "blah", "type": "record", "fields": [{"name": "C1", "type": "int"}]},
+          "schema": {"name": "blah", "type": "record", "fields": [{"name": "c1", "type": "int"}]},
           "format": "AVRO"
         },
         {

--- a/ksql-functional-tests/src/test/resources/query-validation-tests/sink-partitions-replicas.json
+++ b/ksql-functional-tests/src/test/resources/query-validation-tests/sink-partitions-replicas.json
@@ -10,7 +10,7 @@
       "topics": [
         {
           "name": "input",
-          "schema": {"name": "blah", "type": "record", "fields": [{"name": "C1", "type": "int"}]},
+          "schema": {"name": "blah", "type": "record", "fields": [{"name": "c1", "type": "int"}]},
           "format": "AVRO",
           "partitions": 5,
           "replicas" : 3
@@ -34,7 +34,7 @@
       "topics": [
         {
           "name": "input",
-          "schema": {"name": "blah", "type": "record", "fields": [{"name": "C1", "type": "int"}]},
+          "schema": {"name": "blah", "type": "record", "fields": [{"name": "c1", "type": "int"}]},
           "format": "AVRO",
           "partitions": 5,
           "replicas" : 3


### PR DESCRIPTION
### Description 

There's a bit of code the the functional tests module that takes the JSON input records in the QTT tests and, if the input value is a `Map`, converts the map keys to upper-case.

It should not be doing this - input data should be left as is.  KSQL will upper-case the field names when deserializing. But the source data in our tests should support being any case. By upper-casing the source data being published to Kafka we could hiding issues with case-sensitivity in our code.  To put this another way - the source data our users will be passing to KSQL will include lower/mixed cased field names, so our test cases should cover the same!

This will become even more important when we support unwrapped map values. (Hence the PR).  With unwrapped map values the keys are NOT fields. With the current test code the test itself will convert a map of `{"a" -> 1, "b" -> 2}` to `{"A" -> 1, "B" -> 2}` before producing the test data to Kafka - causing test cases to fail.

### Testing done 

Test only change.

### Reviewer checklist
- [ ] Ensure docs are updated if necessary. (eg. if a user visible feature is being added or changed).
- [ ] Ensure relevant issues are linked (description should include text like "Fixes #<issue number>")

