### PR TITLE
Expose QueryID in CSAS/CTAS/INSERT response (Fixes #2895)

### DIFF
--- a/ksql-rest-app/src/main/java/io/confluent/ksql/rest/server/computation/StatementExecutor.java
+++ b/ksql-rest-app/src/main/java/io/confluent/ksql/rest/server/computation/StatementExecutor.java
@@ -190,12 +190,13 @@ public class StatementExecutor {
     if (statement.getStatement() instanceof ExecutableDdlStatement) {
       successMessage = executeDdlStatement(statement, command);
     } else if (statement.getStatement() instanceof CreateAsSelect) {
-      startQuery(statement, command, mode);
+      final PersistentQueryMetadata query = startQuery(statement, command, mode);
       successMessage = statement.getStatement() instanceof CreateTableAsSelect
           ? "Table created and running" : "Stream created and running";
+      successMessage += " with id: " + query.getQueryId();
     } else if (statement.getStatement() instanceof InsertInto) {
-      startQuery(statement, command, mode);
-      successMessage = "Insert Into query is running.";
+      final PersistentQueryMetadata query = startQuery(statement, command, mode);
+      successMessage = "Insert Into query is running with id: " + query.getQueryId() + " .";
     } else if (statement.getStatement() instanceof TerminateQuery) {
       terminateQuery((PreparedStatement<TerminateQuery>) statement);
       successMessage = "Query terminated.";
@@ -271,7 +272,7 @@ public class StatementExecutor {
     }
   }
 
-  private void startQuery(
+  private PersistentQueryMetadata startQuery(
       final PreparedStatement<?> statement,
       final Command command,
       final Mode mode
@@ -301,6 +302,7 @@ public class StatementExecutor {
     if (mode == Mode.EXECUTE) {
       persistentQueryMd.start();
     }
+    return persistentQueryMd;
   }
 
   private KsqlConfig buildMergedConfig(final Command command) {

--- a/ksql-rest-app/src/main/java/io/confluent/ksql/rest/server/computation/StatementExecutor.java
+++ b/ksql-rest-app/src/main/java/io/confluent/ksql/rest/server/computation/StatementExecutor.java
@@ -193,7 +193,7 @@ public class StatementExecutor {
       final PersistentQueryMetadata query = startQuery(statement, command, mode);
       successMessage = statement.getStatement() instanceof CreateTableAsSelect
           ? "Table created and running" : "Stream created and running";
-      successMessage += " with query ID: " + query.getQueryId();
+      successMessage += ". Created by query with query ID: " + query.getQueryId();
     } else if (statement.getStatement() instanceof InsertInto) {
       final PersistentQueryMetadata query = startQuery(statement, command, mode);
       successMessage = "Insert Into query is running with query ID: " + query.getQueryId();

--- a/ksql-rest-app/src/main/java/io/confluent/ksql/rest/server/computation/StatementExecutor.java
+++ b/ksql-rest-app/src/main/java/io/confluent/ksql/rest/server/computation/StatementExecutor.java
@@ -193,10 +193,10 @@ public class StatementExecutor {
       final PersistentQueryMetadata query = startQuery(statement, command, mode);
       successMessage = statement.getStatement() instanceof CreateTableAsSelect
           ? "Table created and running" : "Stream created and running";
-      successMessage += " with id: " + query.getQueryId();
+      successMessage += " with query ID: " + query.getQueryId();
     } else if (statement.getStatement() instanceof InsertInto) {
       final PersistentQueryMetadata query = startQuery(statement, command, mode);
-      successMessage = "Insert Into query is running with id: " + query.getQueryId() + " .";
+      successMessage = "Insert Into query is running with query ID: " + query.getQueryId();
     } else if (statement.getStatement() instanceof TerminateQuery) {
       terminateQuery((PreparedStatement<TerminateQuery>) statement);
       successMessage = "Query terminated.";

--- a/ksql-rest-app/src/test/java/io/confluent/ksql/rest/server/computation/StatementExecutorTest.java
+++ b/ksql-rest-app/src/test/java/io/confluent/ksql/rest/server/computation/StatementExecutorTest.java
@@ -85,7 +85,6 @@ import org.junit.ClassRule;
 import org.junit.Test;
 import org.junit.rules.RuleChain;
 
-@SuppressWarnings("ConstantConditions")
 public class StatementExecutorTest extends EasyMockSupport {
 
   private static final Map<String, String> PRE_VERSION_5_NULL_ORIGINAL_PROPS = null;
@@ -330,6 +329,7 @@ public class StatementExecutorTest extends EasyMockSupport {
     assertThat(statusStore.get(topicCommandId).getStatus(), equalTo(CommandStatus.Status.SUCCESS));
     assertThat(statusStore.get(csCommandId).getStatus(), equalTo(CommandStatus.Status.SUCCESS));
     assertThat(statusStore.get(csasCommandId).getStatus(), equalTo(CommandStatus.Status.SUCCESS));
+    assertThat(statusStore.get(csasCommandId).getMessage(), equalTo("Stream created and running with id: CSAS_USER1PV_0"));
     assertThat(statusStore.get(ctasCommandId).getStatus(), equalTo(CommandStatus.Status.ERROR));
     assertThat(statusStore.get(terminateCmdId).getStatus(), equalTo(CommandStatus.Status.SUCCESS));
   }

--- a/ksql-rest-app/src/test/java/io/confluent/ksql/rest/server/computation/StatementExecutorTest.java
+++ b/ksql-rest-app/src/test/java/io/confluent/ksql/rest/server/computation/StatementExecutorTest.java
@@ -329,7 +329,7 @@ public class StatementExecutorTest extends EasyMockSupport {
     assertThat(statusStore.get(topicCommandId).getStatus(), equalTo(CommandStatus.Status.SUCCESS));
     assertThat(statusStore.get(csCommandId).getStatus(), equalTo(CommandStatus.Status.SUCCESS));
     assertThat(statusStore.get(csasCommandId).getStatus(), equalTo(CommandStatus.Status.SUCCESS));
-    assertThat(statusStore.get(csasCommandId).getMessage(), equalTo("Stream created and running with id: CSAS_USER1PV_0"));
+    assertThat(statusStore.get(csasCommandId).getMessage(), equalTo("Stream created and running with query ID: CSAS_USER1PV_0"));
     assertThat(statusStore.get(ctasCommandId).getStatus(), equalTo(CommandStatus.Status.ERROR));
     assertThat(statusStore.get(terminateCmdId).getStatus(), equalTo(CommandStatus.Status.SUCCESS));
   }

--- a/ksql-rest-app/src/test/java/io/confluent/ksql/rest/server/computation/StatementExecutorTest.java
+++ b/ksql-rest-app/src/test/java/io/confluent/ksql/rest/server/computation/StatementExecutorTest.java
@@ -329,7 +329,8 @@ public class StatementExecutorTest extends EasyMockSupport {
     assertThat(statusStore.get(topicCommandId).getStatus(), equalTo(CommandStatus.Status.SUCCESS));
     assertThat(statusStore.get(csCommandId).getStatus(), equalTo(CommandStatus.Status.SUCCESS));
     assertThat(statusStore.get(csasCommandId).getStatus(), equalTo(CommandStatus.Status.SUCCESS));
-    assertThat(statusStore.get(csasCommandId).getMessage(), equalTo("Stream created and running with query ID: CSAS_USER1PV_0"));
+    assertThat(statusStore.get(csasCommandId).getMessage(),
+        equalTo("Stream created and running. Created by query with query ID: CSAS_USER1PV_0"));
     assertThat(statusStore.get(ctasCommandId).getStatus(), equalTo(CommandStatus.Status.ERROR));
     assertThat(statusStore.get(terminateCmdId).getStatus(), equalTo(CommandStatus.Status.SUCCESS));
   }


### PR DESCRIPTION
NOTE: https://github.com/confluentinc/ksql/pull/2896 is included in this PR, but that will be merged soon, look only at the last commit (bc545ec)

### Description 
See #2895 - this will make it easier to terminate queries without following up with a SHOW QUERIES. 

### Testing done 
`mvn clean install` and local testing:
```
ksql> create stream s1 (author varchar, title varchar) with (kafka_topic='publications', key='author', value_format='json', partitions=1);

 Message
----------------
 Stream created
----------------
ksql> create stream s2 as select * from s1;

 Message
-----------------------------------------------
 Stream created and running with id: CSAS_S2_0
-----------------------------------------------
```

### Future Work

Note that there are still more improvements to be done that are out of scope for this PR:
- it is possible that the server is slow and it times out, in which case the queryID will not be present since it is created on the server, in that case the response will be:
```
 Message
---------------------
 Executing statement
---------------------
```
- this does not make it programmatically easy to extract this information since that requires developing a more structured API

### Reviewer checklist
- [ ] Ensure docs are updated if necessary. (eg. if a user visible feature is being added or changed).
- [ ] Ensure relevant issues are linked (description should include text like "Fixes #<issue number>")

