### PR TITLE
Minor: close websocket session on error

### DIFF
--- a/ksql-rest-app/src/main/java/io/confluent/ksql/rest/server/resources/streaming/WSQueryEndpoint.java
+++ b/ksql-rest-app/src/main/java/io/confluent/ksql/rest/server/resources/streaming/WSQueryEndpoint.java
@@ -198,6 +198,7 @@ public class WSQueryEndpoint {
   @OnError
   public void onError(final Session session, final Throwable t) {
     log.error("websocket error in session {}", session.getId(), t);
+    SessionUtil.closeSilently(session, CloseCodes.UNEXPECTED_CONDITION, t.getMessage());
   }
 
   private void validateVersion(final Session session) {

--- a/ksql-rest-app/src/test/java/io/confluent/ksql/rest/server/resources/streaming/WSQueryEndpointTest.java
+++ b/ksql-rest-app/src/test/java/io/confluent/ksql/rest/server/resources/streaming/WSQueryEndpointTest.java
@@ -390,6 +390,15 @@ public class WSQueryEndpointTest {
     verify(statementParser, never()).parseSingleStatement(any());
   }
 
+  @Test
+  public void shouldCloseSessionOnError() throws Exception {
+    // When:
+    wsQueryEndpoint.onError(session, new Throwable("ahh scary"));
+
+    // Then:
+    verifyClosedWithReason("ahh scary", CloseCodes.UNEXPECTED_CONDITION);
+  }
+
   private void givenVersions(final String... versions) {
 
     givenRequestAndVersions(


### PR DESCRIPTION
### Description 

One of our soak clusters recently encountered a series of websocket errors such as:
```
2019-05-24 21:56:55,845] ERROR websocket error in session 69 (io.confluent.ksql.rest.server.resources.streaming.WSQueryEndpoint:200)
java.util.concurrent.TimeoutException: Idle timeout expired: 300000/300000 ms
        at org.eclipse.jetty.io.IdleTimeout.checkIdleTimeout(IdleTimeout.java:166)
        at org.eclipse.jetty.io.IdleTimeout$1.run(IdleTimeout.java:50)
        at java.util.concurrent.Executors$RunnableAdapter.call(Executors.java:511)
        at java.util.concurrent.FutureTask.run(FutureTask.java:266)
        at java.util.concurrent.ScheduledThreadPoolExecutor$ScheduledFutureTask.access$201(ScheduledThreadPoolExecutor.java:180)
        at java.util.concurrent.ScheduledThreadPoolExecutor$ScheduledFutureTask.run(ScheduledThreadPoolExecutor.java:293)
        at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1149)
        at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:624)
        at java.lang.Thread.run(Thread.java:748)
```
and now thinks it's running almost 60 queries and using 780 threads, when it should be running only 4 queries (plus the occasional transient one). I think this is happening because our `onError()` method doesn't explicitly close the session, and it also doesn't happen automatically ([link](https://stackoverflow.com/questions/27731490/how-to-handle-websocket-onerror)). This PR updates `onError()` to explicitly close the session.

### Testing done 

Added unit test.

### Reviewer checklist
- [ ] Ensure docs are updated if necessary. (eg. if a user visible feature is being added or changed).
- [ ] Ensure relevant issues are linked (description should include text like "Fixes #<issue number>")

