### PR TITLE
Fixing the build. (Backing out KIP-460 changes until they come through)

### DIFF
--- a/ksql-engine/src/main/java/io/confluent/ksql/services/SandboxedAdminClient.java
+++ b/ksql-engine/src/main/java/io/confluent/ksql/services/SandboxedAdminClient.java
@@ -18,7 +18,6 @@ package io.confluent.ksql.services;
 import java.time.Duration;
 import java.util.Collection;
 import java.util.Map;
-import java.util.Set;
 import org.apache.kafka.clients.admin.AdminClient;
 import org.apache.kafka.clients.admin.AlterConfigOp;
 import org.apache.kafka.clients.admin.AlterConfigsOptions;
@@ -58,8 +57,6 @@ import org.apache.kafka.clients.admin.DescribeReplicaLogDirsOptions;
 import org.apache.kafka.clients.admin.DescribeReplicaLogDirsResult;
 import org.apache.kafka.clients.admin.DescribeTopicsOptions;
 import org.apache.kafka.clients.admin.DescribeTopicsResult;
-import org.apache.kafka.clients.admin.ElectLeadersOptions;
-import org.apache.kafka.clients.admin.ElectLeadersResult;
 import org.apache.kafka.clients.admin.ExpireDelegationTokenOptions;
 import org.apache.kafka.clients.admin.ExpireDelegationTokenResult;
 import org.apache.kafka.clients.admin.ListConsumerGroupOffsetsOptions;
@@ -73,7 +70,6 @@ import org.apache.kafka.clients.admin.NewTopic;
 import org.apache.kafka.clients.admin.RecordsToDelete;
 import org.apache.kafka.clients.admin.RenewDelegationTokenOptions;
 import org.apache.kafka.clients.admin.RenewDelegationTokenResult;
-import org.apache.kafka.common.ElectionType;
 import org.apache.kafka.common.Metric;
 import org.apache.kafka.common.MetricName;
 import org.apache.kafka.common.TopicPartition;
@@ -286,15 +282,6 @@ class SandboxedAdminClient extends AdminClient {
   public org.apache.kafka.clients.admin.ElectPreferredLeadersResult electPreferredLeaders(
       final Collection<TopicPartition> partitions,
       final org.apache.kafka.clients.admin.ElectPreferredLeadersOptions options
-  ) {
-    throw new UnsupportedOperationException();
-  }
-
-  @Override
-  public ElectLeadersResult electLeaders(
-      final ElectionType electionType,
-      final Set<TopicPartition> set,
-      final ElectLeadersOptions electLeadersOptions
   ) {
     throw new UnsupportedOperationException();
   }

--- a/ksql-test-util/src/main/java/io/confluent/ksql/test/util/TestMethods.java
+++ b/ksql-test-util/src/main/java/io/confluent/ksql/test/util/TestMethods.java
@@ -34,7 +34,6 @@ import java.util.Objects;
 import java.util.Set;
 import java.util.regex.Pattern;
 import java.util.stream.Collectors;
-import org.apache.kafka.clients.admin.ElectLeadersOptions;
 
 /**
  * Find methods within a class on which to run tests.
@@ -52,7 +51,6 @@ public final class TestMethods {
       .put(String.class, "")
       .put(Duration.class, Duration.ofMillis(1))
       .put(Pattern.class, Pattern.compile(".*"))
-      .put(ElectLeadersOptions.class, new ElectLeadersOptions())
       .build();
 
   private TestMethods() {


### PR DESCRIPTION
### Description 

Back out changes made in #2896 as upstream changes made [for KIP-460](https://github.com/apache/kafka/pull/6686) are not in the Confluent Kafka snapshot.

This will need putting back in once they are.

### Testing done 

`mvn clean install -U`

### Reviewer checklist
- [ ] Ensure docs are updated if necessary. (eg. if a user visible feature is being added or changed).
- [ ] Ensure relevant issues are linked (description should include text like "Fixes #<issue number>")

