### PR TITLE
Minor: Simplify `RestIntegrationTestUtil`

### DIFF
--- a/ksql-rest-app/src/test/java/io/confluent/ksql/rest/integration/ClusterTerminationTest.java
+++ b/ksql-rest-app/src/test/java/io/confluent/ksql/rest/integration/ClusterTerminationTest.java
@@ -22,7 +22,6 @@ import com.google.common.collect.ImmutableList;
 import io.confluent.common.utils.IntegrationTest;
 import io.confluent.ksql.integration.IntegrationTestHarness;
 import io.confluent.ksql.integration.Retry;
-import io.confluent.ksql.rest.client.KsqlRestClient;
 import io.confluent.ksql.rest.entity.ClusterTerminateRequest;
 import io.confluent.ksql.rest.server.TestKsqlRestApp;
 import io.confluent.ksql.services.ServiceContext;
@@ -38,8 +37,6 @@ import kafka.zookeeper.ZooKeeperClientException;
 import org.glassfish.hk2.api.Factory;
 import org.glassfish.hk2.utilities.binding.AbstractBinder;
 import org.glassfish.jersey.process.internal.RequestScoped;
-import org.junit.After;
-import org.junit.Before;
 import org.junit.BeforeClass;
 import org.junit.ClassRule;
 import org.junit.Test;
@@ -88,8 +85,6 @@ public class ClusterTerminationTest {
       .around(TEST_HARNESS)
       .around(REST_APP);
 
-  private KsqlRestClient restClient;
-
   @BeforeClass
   public static void setUpClass() {
     TEST_HARNESS.ensureTopics(PAGE_VIEW_TOPIC);
@@ -97,22 +92,11 @@ public class ClusterTerminationTest {
     RestIntegrationTestUtil.createStreams(REST_APP, PAGE_VIEW_STREAM, PAGE_VIEW_TOPIC);
   }
 
-  @Before
-  public void setUp() {
-    restClient = REST_APP.buildKsqlClient();
-  }
-
-  @After
-  public void cleanUp() {
-    restClient.close();
-  }
-
   @Test
   public void shouldCleanUpSinkTopicsAndSchemasDuringClusterTermination() throws Exception {
     // Given:
     RestIntegrationTestUtil.makeKsqlRequest(
         REST_APP,
-        restClient,
         "CREATE STREAM " + SINK_STREAM
             + " WITH (kafka_topic='" + SINK_TOPIC + "',value_format='avro')"
             + " AS SELECT * FROM " + PAGE_VIEW_STREAM + ";"

--- a/ksql-rest-app/src/test/java/io/confluent/ksql/rest/integration/KsqlResourceFunctionalTest.java
+++ b/ksql-rest-app/src/test/java/io/confluent/ksql/rest/integration/KsqlResourceFunctionalTest.java
@@ -27,7 +27,6 @@ import io.confluent.common.utils.IntegrationTest;
 import io.confluent.ksql.GenericRow;
 import io.confluent.ksql.integration.IntegrationTestHarness;
 import io.confluent.ksql.integration.Retry;
-import io.confluent.ksql.rest.client.KsqlRestClient;
 import io.confluent.ksql.rest.entity.CommandStatus.Status;
 import io.confluent.ksql.rest.entity.CommandStatusEntity;
 import io.confluent.ksql.rest.entity.KsqlEntity;
@@ -101,7 +100,6 @@ public class KsqlResourceFunctionalTest {
       .around(TEST_HARNESS)
       .around(REST_APP);
 
-  private KsqlRestClient restClient;
   private String source;
 
   @BeforeClass
@@ -113,8 +111,6 @@ public class KsqlResourceFunctionalTest {
 
   @Before
   public void setUp() {
-    restClient = REST_APP.buildKsqlClient();
-
     source = KsqlIdentifierTestUtil.uniqueIdentifierName("source");
 
     RestIntegrationTestUtil.createStreams(REST_APP, source, PAGE_VIEW_TOPIC);
@@ -125,7 +121,6 @@ public class KsqlResourceFunctionalTest {
     NEXT_QUERY_ID.addAndGet(REST_APP.getPersistentQueries().size());
     REST_APP.closePersistentQueries();
     REST_APP.dropSourcesExcept(PAGE_VIEW_STREAM);
-    restClient.close();
   }
 
   @Test
@@ -267,7 +262,7 @@ public class KsqlResourceFunctionalTest {
             is(Status.SUCCESS)));
   }
 
-  private List<KsqlEntity> makeKsqlRequest(final String sql) {
-    return RestIntegrationTestUtil.makeKsqlRequest(REST_APP, restClient, sql);
+  private static List<KsqlEntity> makeKsqlRequest(final String sql) {
+    return RestIntegrationTestUtil.makeKsqlRequest(REST_APP, sql);
   }
 }

--- a/ksql-rest-app/src/test/java/io/confluent/ksql/rest/integration/RestApiTest.java
+++ b/ksql-rest-app/src/test/java/io/confluent/ksql/rest/integration/RestApiTest.java
@@ -47,7 +47,6 @@ import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicReference;
 import javax.websocket.CloseReason.CloseCodes;
-import javax.ws.rs.client.Client;
 import javax.ws.rs.core.MediaType;
 import org.eclipse.jetty.websocket.api.Session;
 import org.eclipse.jetty.websocket.api.annotations.OnWebSocketClose;
@@ -55,8 +54,6 @@ import org.eclipse.jetty.websocket.api.annotations.OnWebSocketError;
 import org.eclipse.jetty.websocket.api.annotations.OnWebSocketMessage;
 import org.eclipse.jetty.websocket.api.annotations.WebSocket;
 import org.eclipse.jetty.websocket.client.WebSocketClient;
-import org.junit.After;
-import org.junit.Before;
 import org.junit.BeforeClass;
 import org.junit.ClassRule;
 import org.junit.Test;
@@ -123,8 +120,6 @@ public class RestApiTest {
   @ClassRule
   public static final RuleChain CHAIN = RuleChain.outerRule(TEST_HARNESS).around(REST_APP);
 
-  private Client restClient;
-
   @BeforeClass
   public static void setUpClass() {
     TEST_HARNESS.ensureTopics(PAGE_VIEW_TOPIC);
@@ -132,16 +127,6 @@ public class RestApiTest {
     TEST_HARNESS.produceRows(PAGE_VIEW_TOPIC, new PageViewDataProvider(), Format.JSON);
 
     RestIntegrationTestUtil.createStreams(REST_APP, PAGE_VIEW_STREAM, PAGE_VIEW_TOPIC);
-  }
-
-  @Before
-  public void setUp() {
-    restClient = TestKsqlRestApp.buildClient();
-  }
-
-  @After
-  public void cleanUp() {
-    restClient.close();
   }
 
   @Test
@@ -188,14 +173,12 @@ public class RestApiTest {
       // Given:
       RestIntegrationTestUtil.makeKsqlRequest(
           REST_APP,
-          REST_APP.buildKsqlClient(),
           "CREATE STREAM X AS SELECT * FROM " + PAGE_VIEW_STREAM + ";");
       assertThat("Expected topic X to be created", serviceContext.getTopicClient().isTopicExists("X"));
 
       // When:
       RestIntegrationTestUtil.makeKsqlRequest(
           REST_APP,
-          REST_APP.buildKsqlClient(),
           "TERMINATE QUERY CSAS_X_0; DROP STREAM X DELETE TOPIC;");
 
       // Then:

--- a/ksql-rest-app/src/test/java/io/confluent/ksql/rest/integration/RestIntegrationTestUtil.java
+++ b/ksql-rest-app/src/test/java/io/confluent/ksql/rest/integration/RestIntegrationTestUtil.java
@@ -47,12 +47,14 @@ final class RestIntegrationTestUtil {
   private RestIntegrationTestUtil() {
   }
 
-  static List<KsqlEntity> makeKsqlRequest(final TestKsqlRestApp restApp, final KsqlRestClient restClient, final String sql) {
-    final RestResponse<KsqlEntityList> res = restClient.makeKsqlRequest(sql);
+  static List<KsqlEntity> makeKsqlRequest(final TestKsqlRestApp restApp, final String sql) {
+    try (final KsqlRestClient restClient = restApp.buildKsqlClient()) {
+      final RestResponse<KsqlEntityList> res = restClient.makeKsqlRequest(sql);
 
-    throwOnError(res);
+      throwOnError(res);
 
-    return awaitResults(restApp, res.getResponse());
+      return awaitResults(restApp, res.getResponse());
+    }
   }
 
   static void createStreams(final TestKsqlRestApp restApp, final String streamName, final String topicName) {


### PR DESCRIPTION
### Description 

Small PR to simplify the use of `RestIntegrationTestUtil` by creating the client inside the test.

This doesn't change the run time of the test and makes the tests cleaner.

### Testing done 

Test only change.


### Reviewer checklist
- [ ] Ensure docs are updated if necessary. (eg. if a user visible feature is being added or changed).
- [ ] Ensure relevant issues are linked (description should include text like "Fixes #<issue number>")

