### PR TITLE
Fix the build by temporarily pinning kstreams version

### DIFF
--- a/ksql-engine/pom.xml
+++ b/ksql-engine/pom.xml
@@ -84,11 +84,6 @@
         </dependency>
 
         <dependency>
-            <groupId>org.apache.kafka</groupId>
-            <artifactId>kafka-streams</artifactId>
-        </dependency>
-
-        <dependency>
             <groupId>org.codehaus.janino</groupId>
             <artifactId>janino</artifactId>
         </dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -113,6 +113,17 @@
             <!-- Cross-submodule dependencies -->
 
             <dependency>
+                <groupId>org.apache.kafka</groupId>
+                <artifactId>kafka-streams</artifactId>
+                <!--
+                 Temporarily pinning KSQL to old Kafka snapshot until issues with breaking change
+                 due to state store name changes in PR https://github.com/apache/kafka/pull/6411,
+                 (part of KIP-307), is fixed.
+                -->
+                <version>5.4.0-ccs-20190531.005406-27</version>
+            </dependency>
+
+            <dependency>
                 <groupId>io.confluent.ksql</groupId>
                 <artifactId>ksql-common</artifactId>
                 <version>${project.version}</version>


### PR DESCRIPTION
### Description 

Upstream changes in KS have broken our build. These look to be compatibility breaking changes.  They are looking into it.  For now, we pin the version.

Issue to review: #2915

### Testing done 

`mvn test`

### Reviewer checklist
- [ ] Ensure docs are updated if necessary. (eg. if a user visible feature is being added or changed).
- [ ] Ensure relevant issues are linked (description should include text like "Fixes #<issue number>")

