### PR TITLE
Remove the hack to standarize expected topologies.

### DIFF
--- a/docs/capacity-planning.rst
+++ b/docs/capacity-planning.rst
@@ -122,14 +122,14 @@ Some queries require that the input stream be repartitioned so that all messages
               --> KSTREAM-FILTER-0000000004
               <-- KSTREAM-TRANSFORMVALUES-0000000002
             Processor: KSTREAM-FILTER-0000000004 (stores: [])
-              --> KSTREAM-KEY-SELECT-0000000005
+              --> Aggregate-groupby
               <-- KSTREAM-MAPVALUES-0000000003
-            Processor: KSTREAM-KEY-SELECT-0000000005 (stores: [])
+            Processor: Aggregate-groupby (stores: [])
               --> KSTREAM-FILTER-0000000009
               <-- KSTREAM-FILTER-0000000004
             Processor: KSTREAM-FILTER-0000000009 (stores: [])
               --> KSTREAM-SINK-0000000008
-              <-- KSTREAM-KEY-SELECT-0000000005
+              <-- Aggregate-groupby
             Sink: KSTREAM-SINK-0000000008 (topic: KSTREAM-AGGREGATE-STATE-STORE-0000000006-repartition)
               <-- KSTREAM-FILTER-0000000009
         

--- a/ksql-functional-tests/src/main/java/io/confluent/ksql/test/tools/TestCase.java
+++ b/ksql-functional-tests/src/main/java/io/confluent/ksql/test/tools/TestCase.java
@@ -40,8 +40,6 @@ import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
 import java.util.Set;
-import java.util.concurrent.atomic.AtomicInteger;
-import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 import org.apache.kafka.clients.consumer.ConsumerRecord;
 import org.apache.kafka.clients.producer.ProducerRecord;
@@ -245,8 +243,8 @@ public class TestCase implements Test {
 
   public void verifyTopology() {
     expectedTopology.ifPresent(expected -> {
-      final String expectedTopology = standardizeTopology(expected.topology);
-      final String actualTopology = standardizeTopology(generatedTopologies.get(0));
+      final String expectedTopology = expected.topology;
+      final String actualTopology = generatedTopologies.get(0);
       assertThat("Generated topology differs from that built by previous versions of KSQL"
               + " - this likely means there is a non-backwards compatible change.\n"
               + "THIS IS BAD!",
@@ -276,49 +274,6 @@ public class TestCase implements Test {
     } else {
       throw e;
     }
-  }
-
-  /**
-   * Convert a string topology into a standard form.
-   *
-   * <p>The standardized form takes known compatible changes into account.
-   */
-  private static String standardizeTopology(final String topology) {
-    final String[] lines = topology.split(System.lineSeparator());
-    final Pattern aggGroupBy = Pattern.compile("(.*)(--> |<-- |Processor: )Aggregate-groupby(.*)");
-    final Pattern linePattern = Pattern.compile("(.*)((?:KSTREAM|KTABLE)-.+-)(\\d+)(.*)");
-
-    final StringBuilder result = new StringBuilder();
-    final AtomicInteger nodeCounter = new AtomicInteger();
-    final Map<String, String> nodeMappings = new HashMap<>();
-
-    for (String line : lines) {
-      final java.util.regex.Matcher aggGroupMatcher = aggGroupBy.matcher(line);
-      if (aggGroupMatcher.matches()) {
-        line = aggGroupMatcher.group(1)
-            + aggGroupMatcher.group(2)
-            + "KSTREAM-KEY-SELECT-99999"
-            + aggGroupMatcher.group(3);
-      }
-
-      final java.util.regex.Matcher mainMatcher = linePattern.matcher(line);
-      if (mainMatcher.matches()) {
-        final String originalNodeType = mainMatcher.group(2);
-        final Integer originalNodeNumber = Integer.valueOf(mainMatcher.group(3));
-
-        final String originalId = originalNodeType + originalNodeNumber;
-        final String standardizedId = nodeMappings
-            .computeIfAbsent(originalId, key -> originalNodeType + nodeCounter.getAndIncrement());
-
-        line = mainMatcher.group(1) + standardizedId + mainMatcher.group(4);
-      }
-
-      result
-          .append(line)
-          .append(System.lineSeparator());
-    }
-
-    return result.toString();
   }
 
   @SuppressWarnings("unchecked")

--- a/ksql-functional-tests/src/test/java/io/confluent/ksql/test/EndToEndEngineTestUtil.java
+++ b/ksql-functional-tests/src/test/java/io/confluent/ksql/test/EndToEndEngineTestUtil.java
@@ -56,7 +56,6 @@ import java.io.InputStreamReader;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
-import java.nio.file.Paths;
 import java.nio.file.StandardOpenOption;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -81,8 +80,8 @@ import org.apache.kafka.test.TestUtils;
 
 final class EndToEndEngineTestUtil {
   private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper();
-  private static final String CONFIG_END_MARKER = "CONFIGS_END";
-  private static final String SCHEMAS_END_MARKER = "SCHEMAS_END";
+  static final String CONFIG_END_MARKER = "CONFIGS_END";
+  static final String SCHEMAS_END_MARKER = "SCHEMAS_END";
 
   private static final NavigableMap<SemanticVersion, Map<String, Object>>
       COMPATIBILITY_BREAKING_CONFIGS = buildCompatibilityBreakingConfigs();
@@ -97,9 +96,9 @@ final class EndToEndEngineTestUtil {
   private EndToEndEngineTestUtil(){}
 
   static void writeExpectedTopologyFiles(
-      final String topologyDir,
-      final List<TestCase> testCases) {
-
+      final Path topologyDir,
+      final List<TestCase> testCases
+  ) {
     final ObjectWriter objectWriter = new ObjectMapper().writerWithDefaultPrettyPrinter();
 
     testCases.forEach(testCase -> {
@@ -233,12 +232,11 @@ final class EndToEndEngineTestUtil {
       final PersistentQueryMetadata query,
       final Map<String, String> configs,
       final ObjectWriter objectWriter,
-      final String topologyDir
+      final Path topologyDir
   ) {
-    final Path newTopologyDataPath = Paths.get(topologyDir);
     try {
       final String updatedQueryName = formatQueryName(queryName);
-      final Path topologyFile = Paths.get(newTopologyDataPath.toString(), updatedQueryName);
+      final Path topologyFile = topologyDir.resolve(updatedQueryName);
       final String configString = objectWriter.writeValueAsString(configs);
       final String topologyString = query.getTopology().describe().toString();
       final String schemasString = query.getSchemasDescription();

--- a/ksql-functional-tests/src/test/java/io/confluent/ksql/test/QueryTranslationTest.java
+++ b/ksql-functional-tests/src/test/java/io/confluent/ksql/test/QueryTranslationTest.java
@@ -58,7 +58,7 @@ public class QueryTranslationTest {
 
   private static final Path QUERY_VALIDATION_TEST_DIR = Paths.get("query-validation-tests");
   private static final String TOPOLOGY_CHECKS_DIR = "expected_topology/";
-  private static final String TOPOLOGY_VERSION_FILE = "__version";
+  static final String TOPOLOGY_VERSION_FILE = "__version";
   private static final Pattern TOPOLOGY_VERSION_PATTERN = Pattern.compile("(\\d+)_(\\d+)(_\\d+)?");
   private static final String TOPOLOGY_VERSIONS_DELIMITER = ",";
   private static final String TOPOLOGY_VERSIONS_PROP = "topology.versions";

--- a/ksql-functional-tests/src/test/java/io/confluent/ksql/test/TopologyFileGenerator.java
+++ b/ksql-functional-tests/src/test/java/io/confluent/ksql/test/TopologyFileGenerator.java
@@ -56,33 +56,47 @@ public final class TopologyFileGenerator {
 
     private static final String BASE_DIRECTORY = "src/test/resources/expected_topology/";
 
-    // NOTE: must be run with current directory ksql/ksql-engine (IntelliJ default is ksql)
     public static void main(final String[] args) throws Exception {
-        generateTopologies(BASE_DIRECTORY);
+        generateTopologies(findBaseDir());
     }
 
     @Test
     public void shouldGenerateTopologies() throws Exception {
         final File tmp = TestUtils.tempDirectory();
         tmp.deleteOnExit();
-        generateTopologies(tmp.getAbsolutePath());
+        generateTopologies(tmp.toPath());
     }
 
-    private static void generateTopologies(final String base) throws Exception {
+    static Path findBaseDir() {
+        Path path = Paths.get("./ksql-functional-tests");
+        if (Files.exists(path)) {
+            return path.resolve(BASE_DIRECTORY);
+        }
+        path = Paths.get("../ksql-functional-tests");
+        if (Files.exists(path)) {
+            return path.resolve(BASE_DIRECTORY);
+        }
+        throw new RuntimeException("Failed to determine location of expected topologies directory. "
+            + "App should be run with current directory either set to the root of the repo or the "
+            + "root of the ksql-functional-tests module");
+    }
+
+    private static void generateTopologies(final Path base) throws Exception {
         final String formattedVersion = getFormattedVersionFromPomFile();
-        final String generatedTopologyPath = base + formattedVersion;
+        final Path generatedTopologyPath = base.resolve(formattedVersion);
 
         System.out.println(String.format("Starting to write topology files to %s", generatedTopologyPath));
-        final Path dirPath = Paths.get(generatedTopologyPath);
 
-        if (!dirPath.toFile().exists()) {
-            Files.createDirectory(dirPath);
+        if (!generatedTopologyPath.toFile().exists()) {
+            Files.createDirectory(generatedTopologyPath);
         } else {
-            System.out.println(String.format("Directory %s already exists, this will re-generate topology files", dirPath));
+            System.out.println("Warning: Directory already exists, "
+                + "this will re-generate topology files. dir: " + generatedTopologyPath);
         }
 
         EndToEndEngineTestUtil.writeExpectedTopologyFiles(generatedTopologyPath, getTestCases());
-        System.out.println(String.format("Done writing topology files to %s", dirPath));
+        System.out
+            .println(String.format("Done writing topology files to %s", generatedTopologyPath));
     }
 
     private static List<TestCase> getTestCases() {

--- a/ksql-functional-tests/src/test/java/io/confluent/ksql/test/TopologyFileGenerator.java
+++ b/ksql-functional-tests/src/test/java/io/confluent/ksql/test/TopologyFileGenerator.java
@@ -77,7 +77,7 @@ public final class TopologyFileGenerator {
             return path.resolve(BASE_DIRECTORY);
         }
         throw new RuntimeException("Failed to determine location of expected topologies directory. "
-            + "App should be run with current directory either set to the root of the repo or the "
+            + "App should be run with current directory set to either the root of the repo or the "
             + "root of the ksql-functional-tests module");
     }
 

--- a/ksql-functional-tests/src/test/java/io/confluent/ksql/test/TopologyFileRewriter.java
+++ b/ksql-functional-tests/src/test/java/io/confluent/ksql/test/TopologyFileRewriter.java
@@ -1,0 +1,197 @@
+/*
+ * Copyright 2019 Confluent Inc.
+ *
+ * Licensed under the Confluent Community License (the "License"); you may not use
+ * this file except in compliance with the License.  You may obtain a copy of the
+ * License at
+ *
+ * http://www.confluent.io/confluent-community-license
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package io.confluent.ksql.test;
+
+import static io.confluent.ksql.test.EndToEndEngineTestUtil.CONFIG_END_MARKER;
+import static io.confluent.ksql.test.EndToEndEngineTestUtil.SCHEMAS_END_MARKER;
+import static java.nio.charset.StandardCharsets.UTF_8;
+
+import com.google.common.collect.ImmutableSet;
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.Optional;
+import java.util.Set;
+import org.apache.kafka.test.IntegrationTest;
+import org.junit.experimental.categories.Category;
+
+/**
+ * Utility to help re-write the expected topology files used by {@link QueryTranslationTest}.
+ *
+ * Occasionally, things change in the way KStreams generates topologies and we need to update the
+ * previously saved topologies to bring them back inline.  Obviously, care should be taken when
+ * doing so to ensure no backwards incompatible changes are being hidden by any changes made. *
+ */
+@Category(IntegrationTest.class)
+public final class TopologyFileRewriter {
+
+  /**
+   * Set {@code REWRITER} to an appropriate rewriter impl.
+   */
+  private static final Rewriter REWRITER = new TheRewriter();
+
+  private static final Set<String> EXCLUDE_VERSIONS = ImmutableSet.<String>builder()
+      .add("5_0")
+      .add("5_1")
+      .build();
+
+  private TopologyFileRewriter() {
+  }
+
+  public static void main(final String[] args) throws Exception {
+    final Path baseDir = TopologyFileGenerator.findBaseDir();
+
+    Files.list(baseDir)
+        .filter(Files::isDirectory)
+        .filter(TopologyFileRewriter::includedVersion)
+        .forEach(TopologyFileRewriter::rewriteToplogyDirectory);
+  }
+
+  private static boolean includedVersion(final Path path) {
+
+    final String version = getVersion(path);
+
+    return EXCLUDE_VERSIONS.stream()
+        .noneMatch(version::startsWith);
+  }
+
+  @SuppressFBWarnings("NP_NULL_ON_SOME_PATH_FROM_RETURN_VALUE")
+  private static String getVersion(final Path versionDir) {
+    try {
+      final Path versionFile = versionDir.resolve(QueryTranslationTest.TOPOLOGY_VERSION_FILE);
+      if (Files.exists(versionFile)) {
+        return new String(Files.readAllBytes(versionFile), UTF_8);
+      }
+
+      return versionDir.getFileName().toString();
+    } catch (final Exception e) {
+      throw new RuntimeException("Failed to determine version in " + versionDir, e);
+    }
+  }
+
+  private static void rewriteToplogyDirectory(final Path versionDir) {
+    try {
+
+      System.out.println("Starting to rewrite topology files in " + versionDir);
+
+      Files.list(versionDir)
+          .filter(Files::isRegularFile)
+          .filter(path -> !path.endsWith(QueryTranslationTest.TOPOLOGY_VERSION_FILE))
+          .forEach(TopologyFileRewriter::rewriteTopologyFile);
+
+      System.out.println("Done rewriting topology files in" + versionDir);
+    } catch (final Exception e) {
+      throw new RuntimeException("Failed processing version dir: " + versionDir, e);
+    }
+  }
+
+  private static void rewriteTopologyFile(final Path path) {
+    try {
+
+      final String content = new String(Files.readAllBytes(path), UTF_8);
+
+      final String rewritten = REWRITER.rewrite(path, content);
+
+      Files.write(path, rewritten.getBytes(UTF_8));
+
+      System.out.println("Rewritten topology file: " + path);
+    } catch (final Exception e) {
+      throw new RuntimeException("Failed processing topology file: " + path, e);
+    }
+  }
+
+  private static String grabContent(
+      final String contents,
+      final Optional<String> startMarker,
+      final Optional<String> endMarker
+  ) {
+    final int start = startMarker
+        .map(marker -> {
+          final int idx = contents.indexOf(marker);
+          return idx < 0 ? idx : idx + marker.length();
+        })
+        .orElse(0);
+
+    if (start < 0) {
+      throw new RuntimeException("Failed to find marker for start of section: " + startMarker);
+    }
+
+    final int end = endMarker
+        .map(contents::indexOf)
+        .orElse(contents.length());
+
+    if (end < 0) {
+      throw new RuntimeException("Failed to find marker for end of section: " + startMarker);
+    }
+
+    return contents.substring(start, end);
+  }
+
+  private interface Rewriter {
+    String rewrite(final Path path, final String contents);
+  }
+
+  private interface StructuredRewriter extends Rewriter {
+
+    default String rewriteConfig(final Path path, final String configs) {
+      return configs;
+    }
+
+    default String rewriteSchemas(final Path path, final String schemas) {
+      return schemas;
+    }
+
+    default String rewriteTopologies(final Path path, final String topologies) {
+      return topologies;
+    }
+
+    default String rewrite(final Path path, final String contents) {
+      final String newConfig = rewriteConfig(path,
+              grabContent(contents, Optional.empty(), Optional.of(CONFIG_END_MARKER)))
+              + CONFIG_END_MARKER;
+
+      final boolean hasSchemas = contents.contains(SCHEMAS_END_MARKER);
+
+      final String newSchemas = hasSchemas
+          ? rewriteSchemas(path,
+          grabContent(contents, Optional.of(CONFIG_END_MARKER), Optional.of(SCHEMAS_END_MARKER)))
+          + SCHEMAS_END_MARKER
+          : "";
+
+      final Optional<String> topologyStart = hasSchemas
+          ? Optional.of(SCHEMAS_END_MARKER)
+          : Optional.of(CONFIG_END_MARKER);
+
+      final String newTopologies = rewriteTopologies(path,
+          grabContent(contents, topologyStart, Optional.empty()));
+
+      return newConfig + newSchemas + newTopologies;
+    }
+  }
+
+  private static final class TheRewriter implements StructuredRewriter {
+
+    @Override
+    public String rewriteTopologies(final Path path, final String topologies) {
+      if (path.toString().contains("partition-by") || path.toString().contains("partition_by")) {
+        return topologies;
+      }
+
+      return topologies
+          .replaceAll("KSTREAM-KEY-SELECT-\\d+", "Aggregate-groupby");
+    }
+  }
+}

--- a/ksql-functional-tests/src/test/java/io/confluent/ksql/test/tools/TestCaseTest.java
+++ b/ksql-functional-tests/src/test/java/io/confluent/ksql/test/tools/TestCaseTest.java
@@ -210,11 +210,13 @@ public class TestCaseTest {
     final TopologyAndConfigs topologyAndConfigs = new TopologyAndConfigs(
         "Test_topology1", Optional.empty(), Optional.empty());
     testCase.setExpectedTopology(topologyAndConfigs);
+
+    // Then:
     expectedException.expect(AssertionError.class);
     expectedException.expectMessage("Generated topology differs from that built by previous versions of KSQL - this likely means there is a non-backwards compatible change.\n"
         + "THIS IS BAD!\n"
-        + "Expected: is \"Test_topology1\\n\"\n"
-        + "     but: was \"Test_topology\\n\"");
+        + "Expected: is \"Test_topology1\"\n"
+        + "     but: was \"Test_topology\"");
 
     // When:
     testCase.verifyTopology();

--- a/ksql-functional-tests/src/test/resources/expected_topology/5_2_0/count_-_count_group_by_value
+++ b/ksql-functional-tests/src/test/resources/expected_topology/5_2_0/count_-_count_group_by_value
@@ -44,14 +44,14 @@ Topologies:
       --> KSTREAM-FILTER-0000000004
       <-- KSTREAM-TRANSFORMVALUES-0000000002
     Processor: KSTREAM-FILTER-0000000004 (stores: [])
-      --> KSTREAM-KEY-SELECT-0000000005
+      --> Aggregate-groupby
       <-- KSTREAM-MAPVALUES-0000000003
-    Processor: KSTREAM-KEY-SELECT-0000000005 (stores: [])
+    Processor: Aggregate-groupby (stores: [])
       --> KSTREAM-FILTER-0000000008
       <-- KSTREAM-FILTER-0000000004
     Processor: KSTREAM-FILTER-0000000008 (stores: [])
       --> KSTREAM-SINK-0000000007
-      <-- KSTREAM-KEY-SELECT-0000000005
+      <-- Aggregate-groupby
     Sink: KSTREAM-SINK-0000000007 (topic: Aggregate-groupby-repartition)
       <-- KSTREAM-FILTER-0000000008
 

--- a/ksql-functional-tests/src/test/resources/expected_topology/5_2_0/group-by_-_ROWKEY_(stream->table)
+++ b/ksql-functional-tests/src/test/resources/expected_topology/5_2_0/group-by_-_ROWKEY_(stream->table)
@@ -44,14 +44,14 @@ Topologies:
       --> KSTREAM-FILTER-0000000004
       <-- KSTREAM-TRANSFORMVALUES-0000000002
     Processor: KSTREAM-FILTER-0000000004 (stores: [])
-      --> KSTREAM-KEY-SELECT-0000000005
+      --> Aggregate-groupby
       <-- KSTREAM-MAPVALUES-0000000003
-    Processor: KSTREAM-KEY-SELECT-0000000005 (stores: [])
+    Processor: Aggregate-groupby (stores: [])
       --> KSTREAM-FILTER-0000000008
       <-- KSTREAM-FILTER-0000000004
     Processor: KSTREAM-FILTER-0000000008 (stores: [])
       --> KSTREAM-SINK-0000000007
-      <-- KSTREAM-KEY-SELECT-0000000005
+      <-- Aggregate-groupby
     Sink: KSTREAM-SINK-0000000007 (topic: Aggregate-groupby-repartition)
       <-- KSTREAM-FILTER-0000000008
 

--- a/ksql-functional-tests/src/test/resources/expected_topology/5_2_0/group-by_-_ROWKEY_without_ROWKEY_in_projection_(stream->table)
+++ b/ksql-functional-tests/src/test/resources/expected_topology/5_2_0/group-by_-_ROWKEY_without_ROWKEY_in_projection_(stream->table)
@@ -44,14 +44,14 @@ Topologies:
       --> KSTREAM-FILTER-0000000004
       <-- KSTREAM-TRANSFORMVALUES-0000000002
     Processor: KSTREAM-FILTER-0000000004 (stores: [])
-      --> KSTREAM-KEY-SELECT-0000000005
+      --> Aggregate-groupby
       <-- KSTREAM-MAPVALUES-0000000003
-    Processor: KSTREAM-KEY-SELECT-0000000005 (stores: [])
+    Processor: Aggregate-groupby (stores: [])
       --> KSTREAM-FILTER-0000000008
       <-- KSTREAM-FILTER-0000000004
     Processor: KSTREAM-FILTER-0000000008 (stores: [])
       --> KSTREAM-SINK-0000000007
-      <-- KSTREAM-KEY-SELECT-0000000005
+      <-- Aggregate-groupby
     Sink: KSTREAM-SINK-0000000007 (topic: Aggregate-groupby-repartition)
       <-- KSTREAM-FILTER-0000000008
 

--- a/ksql-functional-tests/src/test/resources/expected_topology/5_2_0/group-by_-_UDAF_nested_in_UDF_in_select_expression_(stream->table)
+++ b/ksql-functional-tests/src/test/resources/expected_topology/5_2_0/group-by_-_UDAF_nested_in_UDF_in_select_expression_(stream->table)
@@ -44,14 +44,14 @@ Topologies:
       --> KSTREAM-FILTER-0000000004
       <-- KSTREAM-TRANSFORMVALUES-0000000002
     Processor: KSTREAM-FILTER-0000000004 (stores: [])
-      --> KSTREAM-KEY-SELECT-0000000005
+      --> Aggregate-groupby
       <-- KSTREAM-MAPVALUES-0000000003
-    Processor: KSTREAM-KEY-SELECT-0000000005 (stores: [])
+    Processor: Aggregate-groupby (stores: [])
       --> KSTREAM-FILTER-0000000008
       <-- KSTREAM-FILTER-0000000004
     Processor: KSTREAM-FILTER-0000000008 (stores: [])
       --> KSTREAM-SINK-0000000007
-      <-- KSTREAM-KEY-SELECT-0000000005
+      <-- Aggregate-groupby
     Sink: KSTREAM-SINK-0000000007 (topic: Aggregate-groupby-repartition)
       <-- KSTREAM-FILTER-0000000008
 

--- a/ksql-functional-tests/src/test/resources/expected_topology/5_2_0/group-by_-_UDF_nested_in_UDAF_in_select_expression_(stream->table)
+++ b/ksql-functional-tests/src/test/resources/expected_topology/5_2_0/group-by_-_UDF_nested_in_UDAF_in_select_expression_(stream->table)
@@ -44,14 +44,14 @@ Topologies:
       --> KSTREAM-FILTER-0000000004
       <-- KSTREAM-TRANSFORMVALUES-0000000002
     Processor: KSTREAM-FILTER-0000000004 (stores: [])
-      --> KSTREAM-KEY-SELECT-0000000005
+      --> Aggregate-groupby
       <-- KSTREAM-MAPVALUES-0000000003
-    Processor: KSTREAM-KEY-SELECT-0000000005 (stores: [])
+    Processor: Aggregate-groupby (stores: [])
       --> KSTREAM-FILTER-0000000008
       <-- KSTREAM-FILTER-0000000004
     Processor: KSTREAM-FILTER-0000000008 (stores: [])
       --> KSTREAM-SINK-0000000007
-      <-- KSTREAM-KEY-SELECT-0000000005
+      <-- Aggregate-groupby
     Sink: KSTREAM-SINK-0000000007 (topic: Aggregate-groupby-repartition)
       <-- KSTREAM-FILTER-0000000008
 

--- a/ksql-functional-tests/src/test/resources/expected_topology/5_2_0/group-by_-_arithmetic_binary_expression_with_projection_in-order_&_non-commutative_group_by_(stream->table)
+++ b/ksql-functional-tests/src/test/resources/expected_topology/5_2_0/group-by_-_arithmetic_binary_expression_with_projection_in-order_&_non-commutative_group_by_(stream->table)
@@ -44,14 +44,14 @@ Topologies:
       --> KSTREAM-FILTER-0000000004
       <-- KSTREAM-TRANSFORMVALUES-0000000002
     Processor: KSTREAM-FILTER-0000000004 (stores: [])
-      --> KSTREAM-KEY-SELECT-0000000005
+      --> Aggregate-groupby
       <-- KSTREAM-MAPVALUES-0000000003
-    Processor: KSTREAM-KEY-SELECT-0000000005 (stores: [])
+    Processor: Aggregate-groupby (stores: [])
       --> KSTREAM-FILTER-0000000008
       <-- KSTREAM-FILTER-0000000004
     Processor: KSTREAM-FILTER-0000000008 (stores: [])
       --> KSTREAM-SINK-0000000007
-      <-- KSTREAM-KEY-SELECT-0000000005
+      <-- Aggregate-groupby
     Sink: KSTREAM-SINK-0000000007 (topic: Aggregate-groupby-repartition)
       <-- KSTREAM-FILTER-0000000008
 

--- a/ksql-functional-tests/src/test/resources/expected_topology/5_2_0/group-by_-_constant_(stream->table)
+++ b/ksql-functional-tests/src/test/resources/expected_topology/5_2_0/group-by_-_constant_(stream->table)
@@ -44,14 +44,14 @@ Topologies:
       --> KSTREAM-FILTER-0000000004
       <-- KSTREAM-TRANSFORMVALUES-0000000002
     Processor: KSTREAM-FILTER-0000000004 (stores: [])
-      --> KSTREAM-KEY-SELECT-0000000005
+      --> Aggregate-groupby
       <-- KSTREAM-MAPVALUES-0000000003
-    Processor: KSTREAM-KEY-SELECT-0000000005 (stores: [])
+    Processor: Aggregate-groupby (stores: [])
       --> KSTREAM-FILTER-0000000008
       <-- KSTREAM-FILTER-0000000004
     Processor: KSTREAM-FILTER-0000000008 (stores: [])
       --> KSTREAM-SINK-0000000007
-      <-- KSTREAM-KEY-SELECT-0000000005
+      <-- Aggregate-groupby
     Sink: KSTREAM-SINK-0000000007 (topic: Aggregate-groupby-repartition)
       <-- KSTREAM-FILTER-0000000008
 

--- a/ksql-functional-tests/src/test/resources/expected_topology/5_2_0/group-by_-_field_with_field_used_in_function_in_projection_(stream->table)
+++ b/ksql-functional-tests/src/test/resources/expected_topology/5_2_0/group-by_-_field_with_field_used_in_function_in_projection_(stream->table)
@@ -44,14 +44,14 @@ Topologies:
       --> KSTREAM-FILTER-0000000004
       <-- KSTREAM-TRANSFORMVALUES-0000000002
     Processor: KSTREAM-FILTER-0000000004 (stores: [])
-      --> KSTREAM-KEY-SELECT-0000000005
+      --> Aggregate-groupby
       <-- KSTREAM-MAPVALUES-0000000003
-    Processor: KSTREAM-KEY-SELECT-0000000005 (stores: [])
+    Processor: Aggregate-groupby (stores: [])
       --> KSTREAM-FILTER-0000000008
       <-- KSTREAM-FILTER-0000000004
     Processor: KSTREAM-FILTER-0000000008 (stores: [])
       --> KSTREAM-SINK-0000000007
-      <-- KSTREAM-KEY-SELECT-0000000005
+      <-- Aggregate-groupby
     Sink: KSTREAM-SINK-0000000007 (topic: Aggregate-groupby-repartition)
       <-- KSTREAM-FILTER-0000000008
 

--- a/ksql-functional-tests/src/test/resources/expected_topology/5_2_0/group-by_-_field_with_re-key_(stream->table)
+++ b/ksql-functional-tests/src/test/resources/expected_topology/5_2_0/group-by_-_field_with_re-key_(stream->table)
@@ -44,14 +44,14 @@ Topologies:
       --> KSTREAM-FILTER-0000000004
       <-- KSTREAM-TRANSFORMVALUES-0000000002
     Processor: KSTREAM-FILTER-0000000004 (stores: [])
-      --> KSTREAM-KEY-SELECT-0000000005
+      --> Aggregate-groupby
       <-- KSTREAM-MAPVALUES-0000000003
-    Processor: KSTREAM-KEY-SELECT-0000000005 (stores: [])
+    Processor: Aggregate-groupby (stores: [])
       --> KSTREAM-FILTER-0000000008
       <-- KSTREAM-FILTER-0000000004
     Processor: KSTREAM-FILTER-0000000008 (stores: [])
       --> KSTREAM-SINK-0000000007
-      <-- KSTREAM-KEY-SELECT-0000000005
+      <-- Aggregate-groupby
     Sink: KSTREAM-SINK-0000000007 (topic: Aggregate-groupby-repartition)
       <-- KSTREAM-FILTER-0000000008
 

--- a/ksql-functional-tests/src/test/resources/expected_topology/5_2_0/group-by_-_fields_(stream->table)
+++ b/ksql-functional-tests/src/test/resources/expected_topology/5_2_0/group-by_-_fields_(stream->table)
@@ -44,14 +44,14 @@ Topologies:
       --> KSTREAM-FILTER-0000000004
       <-- KSTREAM-TRANSFORMVALUES-0000000002
     Processor: KSTREAM-FILTER-0000000004 (stores: [])
-      --> KSTREAM-KEY-SELECT-0000000005
+      --> Aggregate-groupby
       <-- KSTREAM-MAPVALUES-0000000003
-    Processor: KSTREAM-KEY-SELECT-0000000005 (stores: [])
+    Processor: Aggregate-groupby (stores: [])
       --> KSTREAM-FILTER-0000000008
       <-- KSTREAM-FILTER-0000000004
     Processor: KSTREAM-FILTER-0000000008 (stores: [])
       --> KSTREAM-SINK-0000000007
-      <-- KSTREAM-KEY-SELECT-0000000005
+      <-- Aggregate-groupby
     Sink: KSTREAM-SINK-0000000007 (topic: Aggregate-groupby-repartition)
       <-- KSTREAM-FILTER-0000000008
 

--- a/ksql-functional-tests/src/test/resources/expected_topology/5_2_0/group-by_-_function_(stream->table)
+++ b/ksql-functional-tests/src/test/resources/expected_topology/5_2_0/group-by_-_function_(stream->table)
@@ -44,14 +44,14 @@ Topologies:
       --> KSTREAM-FILTER-0000000004
       <-- KSTREAM-TRANSFORMVALUES-0000000002
     Processor: KSTREAM-FILTER-0000000004 (stores: [])
-      --> KSTREAM-KEY-SELECT-0000000005
+      --> Aggregate-groupby
       <-- KSTREAM-MAPVALUES-0000000003
-    Processor: KSTREAM-KEY-SELECT-0000000005 (stores: [])
+    Processor: Aggregate-groupby (stores: [])
       --> KSTREAM-FILTER-0000000008
       <-- KSTREAM-FILTER-0000000004
     Processor: KSTREAM-FILTER-0000000008 (stores: [])
       --> KSTREAM-SINK-0000000007
-      <-- KSTREAM-KEY-SELECT-0000000005
+      <-- Aggregate-groupby
     Sink: KSTREAM-SINK-0000000007 (topic: Aggregate-groupby-repartition)
       <-- KSTREAM-FILTER-0000000008
 

--- a/ksql-functional-tests/src/test/resources/expected_topology/5_2_0/group-by_-_json_field_(stream->table)
+++ b/ksql-functional-tests/src/test/resources/expected_topology/5_2_0/group-by_-_json_field_(stream->table)
@@ -44,14 +44,14 @@ Topologies:
       --> KSTREAM-FILTER-0000000004
       <-- KSTREAM-TRANSFORMVALUES-0000000002
     Processor: KSTREAM-FILTER-0000000004 (stores: [])
-      --> KSTREAM-KEY-SELECT-0000000005
+      --> Aggregate-groupby
       <-- KSTREAM-MAPVALUES-0000000003
-    Processor: KSTREAM-KEY-SELECT-0000000005 (stores: [])
+    Processor: Aggregate-groupby (stores: [])
       --> KSTREAM-FILTER-0000000008
       <-- KSTREAM-FILTER-0000000004
     Processor: KSTREAM-FILTER-0000000008 (stores: [])
       --> KSTREAM-SINK-0000000007
-      <-- KSTREAM-KEY-SELECT-0000000005
+      <-- Aggregate-groupby
     Sink: KSTREAM-SINK-0000000007 (topic: Aggregate-groupby-repartition)
       <-- KSTREAM-FILTER-0000000008
 

--- a/ksql-functional-tests/src/test/resources/expected_topology/5_2_0/group-by_-_missing_matching_projection_field_(stream->table)
+++ b/ksql-functional-tests/src/test/resources/expected_topology/5_2_0/group-by_-_missing_matching_projection_field_(stream->table)
@@ -44,14 +44,14 @@ Topologies:
       --> KSTREAM-FILTER-0000000004
       <-- KSTREAM-TRANSFORMVALUES-0000000002
     Processor: KSTREAM-FILTER-0000000004 (stores: [])
-      --> KSTREAM-KEY-SELECT-0000000005
+      --> Aggregate-groupby
       <-- KSTREAM-MAPVALUES-0000000003
-    Processor: KSTREAM-KEY-SELECT-0000000005 (stores: [])
+    Processor: Aggregate-groupby (stores: [])
       --> KSTREAM-FILTER-0000000008
       <-- KSTREAM-FILTER-0000000004
     Processor: KSTREAM-FILTER-0000000008 (stores: [])
       --> KSTREAM-SINK-0000000007
-      <-- KSTREAM-KEY-SELECT-0000000005
+      <-- Aggregate-groupby
     Sink: KSTREAM-SINK-0000000007 (topic: Aggregate-groupby-repartition)
       <-- KSTREAM-FILTER-0000000008
 

--- a/ksql-functional-tests/src/test/resources/expected_topology/5_2_0/group-by_-_string_concat_using_+_op_(stream->table)
+++ b/ksql-functional-tests/src/test/resources/expected_topology/5_2_0/group-by_-_string_concat_using_+_op_(stream->table)
@@ -44,14 +44,14 @@ Topologies:
       --> KSTREAM-FILTER-0000000004
       <-- KSTREAM-TRANSFORMVALUES-0000000002
     Processor: KSTREAM-FILTER-0000000004 (stores: [])
-      --> KSTREAM-KEY-SELECT-0000000005
+      --> Aggregate-groupby
       <-- KSTREAM-MAPVALUES-0000000003
-    Processor: KSTREAM-KEY-SELECT-0000000005 (stores: [])
+    Processor: Aggregate-groupby (stores: [])
       --> KSTREAM-FILTER-0000000008
       <-- KSTREAM-FILTER-0000000004
     Processor: KSTREAM-FILTER-0000000008 (stores: [])
       --> KSTREAM-SINK-0000000007
-      <-- KSTREAM-KEY-SELECT-0000000005
+      <-- Aggregate-groupby
     Sink: KSTREAM-SINK-0000000007 (topic: Aggregate-groupby-repartition)
       <-- KSTREAM-FILTER-0000000008
 

--- a/ksql-functional-tests/src/test/resources/expected_topology/5_2_0/group-by_-_with_aggregate_arithmetic_(stream->table)
+++ b/ksql-functional-tests/src/test/resources/expected_topology/5_2_0/group-by_-_with_aggregate_arithmetic_(stream->table)
@@ -44,14 +44,14 @@ Topologies:
       --> KSTREAM-FILTER-0000000004
       <-- KSTREAM-TRANSFORMVALUES-0000000002
     Processor: KSTREAM-FILTER-0000000004 (stores: [])
-      --> KSTREAM-KEY-SELECT-0000000005
+      --> Aggregate-groupby
       <-- KSTREAM-MAPVALUES-0000000003
-    Processor: KSTREAM-KEY-SELECT-0000000005 (stores: [])
+    Processor: Aggregate-groupby (stores: [])
       --> KSTREAM-FILTER-0000000008
       <-- KSTREAM-FILTER-0000000004
     Processor: KSTREAM-FILTER-0000000008 (stores: [])
       --> KSTREAM-SINK-0000000007
-      <-- KSTREAM-KEY-SELECT-0000000005
+      <-- Aggregate-groupby
     Sink: KSTREAM-SINK-0000000007 (topic: Aggregate-groupby-repartition)
       <-- KSTREAM-FILTER-0000000008
 

--- a/ksql-functional-tests/src/test/resources/expected_topology/5_2_0/group-by_-_with_aggregate_arithmetic_involving_source_field_(stream->table)
+++ b/ksql-functional-tests/src/test/resources/expected_topology/5_2_0/group-by_-_with_aggregate_arithmetic_involving_source_field_(stream->table)
@@ -44,14 +44,14 @@ Topologies:
       --> KSTREAM-FILTER-0000000004
       <-- KSTREAM-TRANSFORMVALUES-0000000002
     Processor: KSTREAM-FILTER-0000000004 (stores: [])
-      --> KSTREAM-KEY-SELECT-0000000005
+      --> Aggregate-groupby
       <-- KSTREAM-MAPVALUES-0000000003
-    Processor: KSTREAM-KEY-SELECT-0000000005 (stores: [])
+    Processor: Aggregate-groupby (stores: [])
       --> KSTREAM-FILTER-0000000008
       <-- KSTREAM-FILTER-0000000004
     Processor: KSTREAM-FILTER-0000000008 (stores: [])
       --> KSTREAM-SINK-0000000007
-      <-- KSTREAM-KEY-SELECT-0000000005
+      <-- Aggregate-groupby
     Sink: KSTREAM-SINK-0000000007 (topic: Aggregate-groupby-repartition)
       <-- KSTREAM-FILTER-0000000008
 

--- a/ksql-functional-tests/src/test/resources/expected_topology/5_2_0/group-by_-_with_constant_having_(stream-table)
+++ b/ksql-functional-tests/src/test/resources/expected_topology/5_2_0/group-by_-_with_constant_having_(stream-table)
@@ -44,14 +44,14 @@ Topologies:
       --> KSTREAM-FILTER-0000000004
       <-- KSTREAM-TRANSFORMVALUES-0000000002
     Processor: KSTREAM-FILTER-0000000004 (stores: [])
-      --> KSTREAM-KEY-SELECT-0000000005
+      --> Aggregate-groupby
       <-- KSTREAM-MAPVALUES-0000000003
-    Processor: KSTREAM-KEY-SELECT-0000000005 (stores: [])
+    Processor: Aggregate-groupby (stores: [])
       --> KSTREAM-FILTER-0000000008
       <-- KSTREAM-FILTER-0000000004
     Processor: KSTREAM-FILTER-0000000008 (stores: [])
       --> KSTREAM-SINK-0000000007
-      <-- KSTREAM-KEY-SELECT-0000000005
+      <-- Aggregate-groupby
     Sink: KSTREAM-SINK-0000000007 (topic: Aggregate-groupby-repartition)
       <-- KSTREAM-FILTER-0000000008
 

--- a/ksql-functional-tests/src/test/resources/expected_topology/5_2_0/group-by_-_with_groupings_(stream->table)
+++ b/ksql-functional-tests/src/test/resources/expected_topology/5_2_0/group-by_-_with_groupings_(stream->table)
@@ -44,14 +44,14 @@ Topologies:
       --> KSTREAM-FILTER-0000000004
       <-- KSTREAM-TRANSFORMVALUES-0000000002
     Processor: KSTREAM-FILTER-0000000004 (stores: [])
-      --> KSTREAM-KEY-SELECT-0000000005
+      --> Aggregate-groupby
       <-- KSTREAM-MAPVALUES-0000000003
-    Processor: KSTREAM-KEY-SELECT-0000000005 (stores: [])
+    Processor: Aggregate-groupby (stores: [])
       --> KSTREAM-FILTER-0000000008
       <-- KSTREAM-FILTER-0000000004
     Processor: KSTREAM-FILTER-0000000008 (stores: [])
       --> KSTREAM-SINK-0000000007
-      <-- KSTREAM-KEY-SELECT-0000000005
+      <-- Aggregate-groupby
     Sink: KSTREAM-SINK-0000000007 (topic: Aggregate-groupby-repartition)
       <-- KSTREAM-FILTER-0000000008
 

--- a/ksql-functional-tests/src/test/resources/expected_topology/5_2_0/group-by_-_with_having_expression_on_non-group-by_field_(stream->table)
+++ b/ksql-functional-tests/src/test/resources/expected_topology/5_2_0/group-by_-_with_having_expression_on_non-group-by_field_(stream->table)
@@ -44,14 +44,14 @@ Topologies:
       --> KSTREAM-FILTER-0000000004
       <-- KSTREAM-TRANSFORMVALUES-0000000002
     Processor: KSTREAM-FILTER-0000000004 (stores: [])
-      --> KSTREAM-KEY-SELECT-0000000005
+      --> Aggregate-groupby
       <-- KSTREAM-MAPVALUES-0000000003
-    Processor: KSTREAM-KEY-SELECT-0000000005 (stores: [])
+    Processor: Aggregate-groupby (stores: [])
       --> KSTREAM-FILTER-0000000008
       <-- KSTREAM-FILTER-0000000004
     Processor: KSTREAM-FILTER-0000000008 (stores: [])
       --> KSTREAM-SINK-0000000007
-      <-- KSTREAM-KEY-SELECT-0000000005
+      <-- Aggregate-groupby
     Sink: KSTREAM-SINK-0000000007 (topic: Aggregate-groupby-repartition)
       <-- KSTREAM-FILTER-0000000008
 

--- a/ksql-functional-tests/src/test/resources/expected_topology/5_2_0/group-by_-_with_multiple_having_expressions_(stream->table)
+++ b/ksql-functional-tests/src/test/resources/expected_topology/5_2_0/group-by_-_with_multiple_having_expressions_(stream->table)
@@ -44,14 +44,14 @@ Topologies:
       --> KSTREAM-FILTER-0000000004
       <-- KSTREAM-TRANSFORMVALUES-0000000002
     Processor: KSTREAM-FILTER-0000000004 (stores: [])
-      --> KSTREAM-KEY-SELECT-0000000005
+      --> Aggregate-groupby
       <-- KSTREAM-MAPVALUES-0000000003
-    Processor: KSTREAM-KEY-SELECT-0000000005 (stores: [])
+    Processor: Aggregate-groupby (stores: [])
       --> KSTREAM-FILTER-0000000008
       <-- KSTREAM-FILTER-0000000004
     Processor: KSTREAM-FILTER-0000000008 (stores: [])
       --> KSTREAM-SINK-0000000007
-      <-- KSTREAM-KEY-SELECT-0000000005
+      <-- Aggregate-groupby
     Sink: KSTREAM-SINK-0000000007 (topic: Aggregate-groupby-repartition)
       <-- KSTREAM-FILTER-0000000008
 

--- a/ksql-functional-tests/src/test/resources/expected_topology/5_2_0/key-field_-_stream_|_initially_null_|_group_by_(-)_|_key_in_value_|_aliasing
+++ b/ksql-functional-tests/src/test/resources/expected_topology/5_2_0/key-field_-_stream_|_initially_null_|_group_by_(-)_|_key_in_value_|_aliasing
@@ -44,14 +44,14 @@ Topologies:
       --> KSTREAM-FILTER-0000000004
       <-- KSTREAM-TRANSFORMVALUES-0000000002
     Processor: KSTREAM-FILTER-0000000004 (stores: [])
-      --> KSTREAM-KEY-SELECT-0000000005
+      --> Aggregate-groupby
       <-- KSTREAM-MAPVALUES-0000000003
-    Processor: KSTREAM-KEY-SELECT-0000000005 (stores: [])
+    Processor: Aggregate-groupby (stores: [])
       --> KSTREAM-FILTER-0000000008
       <-- KSTREAM-FILTER-0000000004
     Processor: KSTREAM-FILTER-0000000008 (stores: [])
       --> KSTREAM-SINK-0000000007
-      <-- KSTREAM-KEY-SELECT-0000000005
+      <-- Aggregate-groupby
     Sink: KSTREAM-SINK-0000000007 (topic: Aggregate-groupby-repartition)
       <-- KSTREAM-FILTER-0000000008
 

--- a/ksql-functional-tests/src/test/resources/expected_topology/5_2_0/key-field_-_stream_|_initially_null_|_group_by_(-)_|_key_in_value_|_no_aliasing
+++ b/ksql-functional-tests/src/test/resources/expected_topology/5_2_0/key-field_-_stream_|_initially_null_|_group_by_(-)_|_key_in_value_|_no_aliasing
@@ -44,14 +44,14 @@ Topologies:
       --> KSTREAM-FILTER-0000000004
       <-- KSTREAM-TRANSFORMVALUES-0000000002
     Processor: KSTREAM-FILTER-0000000004 (stores: [])
-      --> KSTREAM-KEY-SELECT-0000000005
+      --> Aggregate-groupby
       <-- KSTREAM-MAPVALUES-0000000003
-    Processor: KSTREAM-KEY-SELECT-0000000005 (stores: [])
+    Processor: Aggregate-groupby (stores: [])
       --> KSTREAM-FILTER-0000000008
       <-- KSTREAM-FILTER-0000000004
     Processor: KSTREAM-FILTER-0000000008 (stores: [])
       --> KSTREAM-SINK-0000000007
-      <-- KSTREAM-KEY-SELECT-0000000005
+      <-- Aggregate-groupby
     Sink: KSTREAM-SINK-0000000007 (topic: Aggregate-groupby-repartition)
       <-- KSTREAM-FILTER-0000000008
 

--- a/ksql-functional-tests/src/test/resources/expected_topology/5_2_0/key-field_-_stream_|_initially_null_|_group_by_(-)_|_key_in_value_|_no_aliasing_|_with_cast
+++ b/ksql-functional-tests/src/test/resources/expected_topology/5_2_0/key-field_-_stream_|_initially_null_|_group_by_(-)_|_key_in_value_|_no_aliasing_|_with_cast
@@ -44,14 +44,14 @@ Topologies:
       --> KSTREAM-FILTER-0000000004
       <-- KSTREAM-TRANSFORMVALUES-0000000002
     Processor: KSTREAM-FILTER-0000000004 (stores: [])
-      --> KSTREAM-KEY-SELECT-0000000005
+      --> Aggregate-groupby
       <-- KSTREAM-MAPVALUES-0000000003
-    Processor: KSTREAM-KEY-SELECT-0000000005 (stores: [])
+    Processor: Aggregate-groupby (stores: [])
       --> KSTREAM-FILTER-0000000008
       <-- KSTREAM-FILTER-0000000004
     Processor: KSTREAM-FILTER-0000000008 (stores: [])
       --> KSTREAM-SINK-0000000007
-      <-- KSTREAM-KEY-SELECT-0000000005
+      <-- Aggregate-groupby
     Sink: KSTREAM-SINK-0000000007 (topic: Aggregate-groupby-repartition)
       <-- KSTREAM-FILTER-0000000008
 

--- a/ksql-functional-tests/src/test/resources/expected_topology/5_2_0/key-field_-_stream_|_initially_null_|_group_by_(-)_|_key_not_in_value_|_-
+++ b/ksql-functional-tests/src/test/resources/expected_topology/5_2_0/key-field_-_stream_|_initially_null_|_group_by_(-)_|_key_not_in_value_|_-
@@ -44,14 +44,14 @@ Topologies:
       --> KSTREAM-FILTER-0000000004
       <-- KSTREAM-TRANSFORMVALUES-0000000002
     Processor: KSTREAM-FILTER-0000000004 (stores: [])
-      --> KSTREAM-KEY-SELECT-0000000005
+      --> Aggregate-groupby
       <-- KSTREAM-MAPVALUES-0000000003
-    Processor: KSTREAM-KEY-SELECT-0000000005 (stores: [])
+    Processor: Aggregate-groupby (stores: [])
       --> KSTREAM-FILTER-0000000008
       <-- KSTREAM-FILTER-0000000004
     Processor: KSTREAM-FILTER-0000000008 (stores: [])
       --> KSTREAM-SINK-0000000007
-      <-- KSTREAM-KEY-SELECT-0000000005
+      <-- Aggregate-groupby
     Sink: KSTREAM-SINK-0000000007 (topic: Aggregate-groupby-repartition)
       <-- KSTREAM-FILTER-0000000008
 

--- a/ksql-functional-tests/src/test/resources/expected_topology/5_2_0/key-field_-_stream_|_initially_set_|_group_by_(different)_|_key_in_value_|_aliasing
+++ b/ksql-functional-tests/src/test/resources/expected_topology/5_2_0/key-field_-_stream_|_initially_set_|_group_by_(different)_|_key_in_value_|_aliasing
@@ -44,14 +44,14 @@ Topologies:
       --> KSTREAM-FILTER-0000000004
       <-- KSTREAM-TRANSFORMVALUES-0000000002
     Processor: KSTREAM-FILTER-0000000004 (stores: [])
-      --> KSTREAM-KEY-SELECT-0000000005
+      --> Aggregate-groupby
       <-- KSTREAM-MAPVALUES-0000000003
-    Processor: KSTREAM-KEY-SELECT-0000000005 (stores: [])
+    Processor: Aggregate-groupby (stores: [])
       --> KSTREAM-FILTER-0000000008
       <-- KSTREAM-FILTER-0000000004
     Processor: KSTREAM-FILTER-0000000008 (stores: [])
       --> KSTREAM-SINK-0000000007
-      <-- KSTREAM-KEY-SELECT-0000000005
+      <-- Aggregate-groupby
     Sink: KSTREAM-SINK-0000000007 (topic: Aggregate-groupby-repartition)
       <-- KSTREAM-FILTER-0000000008
 

--- a/ksql-functional-tests/src/test/resources/expected_topology/5_2_0/key-field_-_stream_|_initially_set_|_group_by_(different)_|_key_in_value_|_no_aliasing
+++ b/ksql-functional-tests/src/test/resources/expected_topology/5_2_0/key-field_-_stream_|_initially_set_|_group_by_(different)_|_key_in_value_|_no_aliasing
@@ -44,14 +44,14 @@ Topologies:
       --> KSTREAM-FILTER-0000000004
       <-- KSTREAM-TRANSFORMVALUES-0000000002
     Processor: KSTREAM-FILTER-0000000004 (stores: [])
-      --> KSTREAM-KEY-SELECT-0000000005
+      --> Aggregate-groupby
       <-- KSTREAM-MAPVALUES-0000000003
-    Processor: KSTREAM-KEY-SELECT-0000000005 (stores: [])
+    Processor: Aggregate-groupby (stores: [])
       --> KSTREAM-FILTER-0000000008
       <-- KSTREAM-FILTER-0000000004
     Processor: KSTREAM-FILTER-0000000008 (stores: [])
       --> KSTREAM-SINK-0000000007
-      <-- KSTREAM-KEY-SELECT-0000000005
+      <-- Aggregate-groupby
     Sink: KSTREAM-SINK-0000000007 (topic: Aggregate-groupby-repartition)
       <-- KSTREAM-FILTER-0000000008
 

--- a/ksql-functional-tests/src/test/resources/expected_topology/5_2_0/key-field_-_stream_|_initially_set_|_group_by_(different)_|_key_not_in_value_|_-
+++ b/ksql-functional-tests/src/test/resources/expected_topology/5_2_0/key-field_-_stream_|_initially_set_|_group_by_(different)_|_key_not_in_value_|_-
@@ -44,14 +44,14 @@ Topologies:
       --> KSTREAM-FILTER-0000000004
       <-- KSTREAM-TRANSFORMVALUES-0000000002
     Processor: KSTREAM-FILTER-0000000004 (stores: [])
-      --> KSTREAM-KEY-SELECT-0000000005
+      --> Aggregate-groupby
       <-- KSTREAM-MAPVALUES-0000000003
-    Processor: KSTREAM-KEY-SELECT-0000000005 (stores: [])
+    Processor: Aggregate-groupby (stores: [])
       --> KSTREAM-FILTER-0000000008
       <-- KSTREAM-FILTER-0000000004
     Processor: KSTREAM-FILTER-0000000008 (stores: [])
       --> KSTREAM-SINK-0000000007
-      <-- KSTREAM-KEY-SELECT-0000000005
+      <-- Aggregate-groupby
     Sink: KSTREAM-SINK-0000000007 (topic: Aggregate-groupby-repartition)
       <-- KSTREAM-FILTER-0000000008
 

--- a/ksql-functional-tests/src/test/resources/expected_topology/5_2_0/key-field_-_stream_|_initially_set_|_group_by_expression_|_key_in_value_|_no_aliasing
+++ b/ksql-functional-tests/src/test/resources/expected_topology/5_2_0/key-field_-_stream_|_initially_set_|_group_by_expression_|_key_in_value_|_no_aliasing
@@ -44,14 +44,14 @@ Topologies:
       --> KSTREAM-FILTER-0000000004
       <-- KSTREAM-TRANSFORMVALUES-0000000002
     Processor: KSTREAM-FILTER-0000000004 (stores: [])
-      --> KSTREAM-KEY-SELECT-0000000005
+      --> Aggregate-groupby
       <-- KSTREAM-MAPVALUES-0000000003
-    Processor: KSTREAM-KEY-SELECT-0000000005 (stores: [])
+    Processor: Aggregate-groupby (stores: [])
       --> KSTREAM-FILTER-0000000008
       <-- KSTREAM-FILTER-0000000004
     Processor: KSTREAM-FILTER-0000000008 (stores: [])
       --> KSTREAM-SINK-0000000007
-      <-- KSTREAM-KEY-SELECT-0000000005
+      <-- Aggregate-groupby
     Sink: KSTREAM-SINK-0000000007 (topic: Aggregate-groupby-repartition)
       <-- KSTREAM-FILTER-0000000008
 

--- a/ksql-functional-tests/src/test/resources/expected_topology/5_2_0/key-field_-_stream_|_initially_set_|_group_by_multiple_|_key_in_value_|_no_aliasing
+++ b/ksql-functional-tests/src/test/resources/expected_topology/5_2_0/key-field_-_stream_|_initially_set_|_group_by_multiple_|_key_in_value_|_no_aliasing
@@ -44,14 +44,14 @@ Topologies:
       --> KSTREAM-FILTER-0000000004
       <-- KSTREAM-TRANSFORMVALUES-0000000002
     Processor: KSTREAM-FILTER-0000000004 (stores: [])
-      --> KSTREAM-KEY-SELECT-0000000005
+      --> Aggregate-groupby
       <-- KSTREAM-MAPVALUES-0000000003
-    Processor: KSTREAM-KEY-SELECT-0000000005 (stores: [])
+    Processor: Aggregate-groupby (stores: [])
       --> KSTREAM-FILTER-0000000008
       <-- KSTREAM-FILTER-0000000004
     Processor: KSTREAM-FILTER-0000000008 (stores: [])
       --> KSTREAM-SINK-0000000007
-      <-- KSTREAM-KEY-SELECT-0000000005
+      <-- Aggregate-groupby
     Sink: KSTREAM-SINK-0000000007 (topic: Aggregate-groupby-repartition)
       <-- KSTREAM-FILTER-0000000008
 

--- a/ksql-functional-tests/src/test/resources/expected_topology/5_2_0/session-windows_-_import_session_stream_and_group_by
+++ b/ksql-functional-tests/src/test/resources/expected_topology/5_2_0/session-windows_-_import_session_stream_and_group_by
@@ -44,14 +44,14 @@ Topologies:
       --> KSTREAM-FILTER-0000000004
       <-- KSTREAM-TRANSFORMVALUES-0000000002
     Processor: KSTREAM-FILTER-0000000004 (stores: [])
-      --> KSTREAM-KEY-SELECT-0000000005
+      --> Aggregate-groupby
       <-- KSTREAM-MAPVALUES-0000000003
-    Processor: KSTREAM-KEY-SELECT-0000000005 (stores: [])
+    Processor: Aggregate-groupby (stores: [])
       --> KSTREAM-FILTER-0000000008
       <-- KSTREAM-FILTER-0000000004
     Processor: KSTREAM-FILTER-0000000008 (stores: [])
       --> KSTREAM-SINK-0000000007
-      <-- KSTREAM-KEY-SELECT-0000000005
+      <-- Aggregate-groupby
     Sink: KSTREAM-SINK-0000000007 (topic: Aggregate-groupby-repartition)
       <-- KSTREAM-FILTER-0000000008
 

--- a/ksql-functional-tests/src/test/resources/expected_topology/5_2_0/substring_-_in_group_by
+++ b/ksql-functional-tests/src/test/resources/expected_topology/5_2_0/substring_-_in_group_by
@@ -44,14 +44,14 @@ Topologies:
       --> KSTREAM-FILTER-0000000004
       <-- KSTREAM-TRANSFORMVALUES-0000000002
     Processor: KSTREAM-FILTER-0000000004 (stores: [])
-      --> KSTREAM-KEY-SELECT-0000000005
+      --> Aggregate-groupby
       <-- KSTREAM-MAPVALUES-0000000003
-    Processor: KSTREAM-KEY-SELECT-0000000005 (stores: [])
+    Processor: Aggregate-groupby (stores: [])
       --> KSTREAM-FILTER-0000000008
       <-- KSTREAM-FILTER-0000000004
     Processor: KSTREAM-FILTER-0000000008 (stores: [])
       --> KSTREAM-SINK-0000000007
-      <-- KSTREAM-KEY-SELECT-0000000005
+      <-- Aggregate-groupby
     Sink: KSTREAM-SINK-0000000007 (topic: Aggregate-groupby-repartition)
       <-- KSTREAM-FILTER-0000000008
 

--- a/ksql-functional-tests/src/test/resources/expected_topology/5_3_0_pre/count_-_count_group_by_value
+++ b/ksql-functional-tests/src/test/resources/expected_topology/5_3_0_pre/count_-_count_group_by_value
@@ -48,14 +48,14 @@ Topologies:
       --> KSTREAM-FILTER-0000000004
       <-- KSTREAM-TRANSFORMVALUES-0000000002
     Processor: KSTREAM-FILTER-0000000004 (stores: [])
-      --> KSTREAM-KEY-SELECT-0000000005
+      --> Aggregate-groupby
       <-- KSTREAM-MAPVALUES-0000000003
-    Processor: KSTREAM-KEY-SELECT-0000000005 (stores: [])
+    Processor: Aggregate-groupby (stores: [])
       --> KSTREAM-FILTER-0000000008
       <-- KSTREAM-FILTER-0000000004
     Processor: KSTREAM-FILTER-0000000008 (stores: [])
       --> KSTREAM-SINK-0000000007
-      <-- KSTREAM-KEY-SELECT-0000000005
+      <-- Aggregate-groupby
     Sink: KSTREAM-SINK-0000000007 (topic: Aggregate-groupby-repartition)
       <-- KSTREAM-FILTER-0000000008
 

--- a/ksql-functional-tests/src/test/resources/expected_topology/5_3_0_pre/group-by_-_ROWKEY_(stream->table)
+++ b/ksql-functional-tests/src/test/resources/expected_topology/5_3_0_pre/group-by_-_ROWKEY_(stream->table)
@@ -48,14 +48,14 @@ Topologies:
       --> KSTREAM-FILTER-0000000004
       <-- KSTREAM-TRANSFORMVALUES-0000000002
     Processor: KSTREAM-FILTER-0000000004 (stores: [])
-      --> KSTREAM-KEY-SELECT-0000000005
+      --> Aggregate-groupby
       <-- KSTREAM-MAPVALUES-0000000003
-    Processor: KSTREAM-KEY-SELECT-0000000005 (stores: [])
+    Processor: Aggregate-groupby (stores: [])
       --> KSTREAM-FILTER-0000000008
       <-- KSTREAM-FILTER-0000000004
     Processor: KSTREAM-FILTER-0000000008 (stores: [])
       --> KSTREAM-SINK-0000000007
-      <-- KSTREAM-KEY-SELECT-0000000005
+      <-- Aggregate-groupby
     Sink: KSTREAM-SINK-0000000007 (topic: Aggregate-groupby-repartition)
       <-- KSTREAM-FILTER-0000000008
 

--- a/ksql-functional-tests/src/test/resources/expected_topology/5_3_0_pre/group-by_-_ROWKEY_without_ROWKEY_in_projection_(stream->table)
+++ b/ksql-functional-tests/src/test/resources/expected_topology/5_3_0_pre/group-by_-_ROWKEY_without_ROWKEY_in_projection_(stream->table)
@@ -48,14 +48,14 @@ Topologies:
       --> KSTREAM-FILTER-0000000004
       <-- KSTREAM-TRANSFORMVALUES-0000000002
     Processor: KSTREAM-FILTER-0000000004 (stores: [])
-      --> KSTREAM-KEY-SELECT-0000000005
+      --> Aggregate-groupby
       <-- KSTREAM-MAPVALUES-0000000003
-    Processor: KSTREAM-KEY-SELECT-0000000005 (stores: [])
+    Processor: Aggregate-groupby (stores: [])
       --> KSTREAM-FILTER-0000000008
       <-- KSTREAM-FILTER-0000000004
     Processor: KSTREAM-FILTER-0000000008 (stores: [])
       --> KSTREAM-SINK-0000000007
-      <-- KSTREAM-KEY-SELECT-0000000005
+      <-- Aggregate-groupby
     Sink: KSTREAM-SINK-0000000007 (topic: Aggregate-groupby-repartition)
       <-- KSTREAM-FILTER-0000000008
 

--- a/ksql-functional-tests/src/test/resources/expected_topology/5_3_0_pre/group-by_-_UDAF_nested_in_UDF_in_select_expression_(stream->table)
+++ b/ksql-functional-tests/src/test/resources/expected_topology/5_3_0_pre/group-by_-_UDAF_nested_in_UDF_in_select_expression_(stream->table)
@@ -48,14 +48,14 @@ Topologies:
       --> KSTREAM-FILTER-0000000004
       <-- KSTREAM-TRANSFORMVALUES-0000000002
     Processor: KSTREAM-FILTER-0000000004 (stores: [])
-      --> KSTREAM-KEY-SELECT-0000000005
+      --> Aggregate-groupby
       <-- KSTREAM-MAPVALUES-0000000003
-    Processor: KSTREAM-KEY-SELECT-0000000005 (stores: [])
+    Processor: Aggregate-groupby (stores: [])
       --> KSTREAM-FILTER-0000000008
       <-- KSTREAM-FILTER-0000000004
     Processor: KSTREAM-FILTER-0000000008 (stores: [])
       --> KSTREAM-SINK-0000000007
-      <-- KSTREAM-KEY-SELECT-0000000005
+      <-- Aggregate-groupby
     Sink: KSTREAM-SINK-0000000007 (topic: Aggregate-groupby-repartition)
       <-- KSTREAM-FILTER-0000000008
 

--- a/ksql-functional-tests/src/test/resources/expected_topology/5_3_0_pre/group-by_-_UDF_nested_in_UDAF_in_select_expression_(stream->table)
+++ b/ksql-functional-tests/src/test/resources/expected_topology/5_3_0_pre/group-by_-_UDF_nested_in_UDAF_in_select_expression_(stream->table)
@@ -48,14 +48,14 @@ Topologies:
       --> KSTREAM-FILTER-0000000004
       <-- KSTREAM-TRANSFORMVALUES-0000000002
     Processor: KSTREAM-FILTER-0000000004 (stores: [])
-      --> KSTREAM-KEY-SELECT-0000000005
+      --> Aggregate-groupby
       <-- KSTREAM-MAPVALUES-0000000003
-    Processor: KSTREAM-KEY-SELECT-0000000005 (stores: [])
+    Processor: Aggregate-groupby (stores: [])
       --> KSTREAM-FILTER-0000000008
       <-- KSTREAM-FILTER-0000000004
     Processor: KSTREAM-FILTER-0000000008 (stores: [])
       --> KSTREAM-SINK-0000000007
-      <-- KSTREAM-KEY-SELECT-0000000005
+      <-- Aggregate-groupby
     Sink: KSTREAM-SINK-0000000007 (topic: Aggregate-groupby-repartition)
       <-- KSTREAM-FILTER-0000000008
 

--- a/ksql-functional-tests/src/test/resources/expected_topology/5_3_0_pre/group-by_-_arithmetic_binary_expression_with_projection_in-order_&_non-commutative_group_by_(stream->table)
+++ b/ksql-functional-tests/src/test/resources/expected_topology/5_3_0_pre/group-by_-_arithmetic_binary_expression_with_projection_in-order_&_non-commutative_group_by_(stream->table)
@@ -48,14 +48,14 @@ Topologies:
       --> KSTREAM-FILTER-0000000004
       <-- KSTREAM-TRANSFORMVALUES-0000000002
     Processor: KSTREAM-FILTER-0000000004 (stores: [])
-      --> KSTREAM-KEY-SELECT-0000000005
+      --> Aggregate-groupby
       <-- KSTREAM-MAPVALUES-0000000003
-    Processor: KSTREAM-KEY-SELECT-0000000005 (stores: [])
+    Processor: Aggregate-groupby (stores: [])
       --> KSTREAM-FILTER-0000000008
       <-- KSTREAM-FILTER-0000000004
     Processor: KSTREAM-FILTER-0000000008 (stores: [])
       --> KSTREAM-SINK-0000000007
-      <-- KSTREAM-KEY-SELECT-0000000005
+      <-- Aggregate-groupby
     Sink: KSTREAM-SINK-0000000007 (topic: Aggregate-groupby-repartition)
       <-- KSTREAM-FILTER-0000000008
 

--- a/ksql-functional-tests/src/test/resources/expected_topology/5_3_0_pre/group-by_-_constant_(stream->table)
+++ b/ksql-functional-tests/src/test/resources/expected_topology/5_3_0_pre/group-by_-_constant_(stream->table)
@@ -48,14 +48,14 @@ Topologies:
       --> KSTREAM-FILTER-0000000004
       <-- KSTREAM-TRANSFORMVALUES-0000000002
     Processor: KSTREAM-FILTER-0000000004 (stores: [])
-      --> KSTREAM-KEY-SELECT-0000000005
+      --> Aggregate-groupby
       <-- KSTREAM-MAPVALUES-0000000003
-    Processor: KSTREAM-KEY-SELECT-0000000005 (stores: [])
+    Processor: Aggregate-groupby (stores: [])
       --> KSTREAM-FILTER-0000000008
       <-- KSTREAM-FILTER-0000000004
     Processor: KSTREAM-FILTER-0000000008 (stores: [])
       --> KSTREAM-SINK-0000000007
-      <-- KSTREAM-KEY-SELECT-0000000005
+      <-- Aggregate-groupby
     Sink: KSTREAM-SINK-0000000007 (topic: Aggregate-groupby-repartition)
       <-- KSTREAM-FILTER-0000000008
 

--- a/ksql-functional-tests/src/test/resources/expected_topology/5_3_0_pre/group-by_-_field_with_field_used_in_function_in_projection_(stream->table)
+++ b/ksql-functional-tests/src/test/resources/expected_topology/5_3_0_pre/group-by_-_field_with_field_used_in_function_in_projection_(stream->table)
@@ -48,14 +48,14 @@ Topologies:
       --> KSTREAM-FILTER-0000000004
       <-- KSTREAM-TRANSFORMVALUES-0000000002
     Processor: KSTREAM-FILTER-0000000004 (stores: [])
-      --> KSTREAM-KEY-SELECT-0000000005
+      --> Aggregate-groupby
       <-- KSTREAM-MAPVALUES-0000000003
-    Processor: KSTREAM-KEY-SELECT-0000000005 (stores: [])
+    Processor: Aggregate-groupby (stores: [])
       --> KSTREAM-FILTER-0000000008
       <-- KSTREAM-FILTER-0000000004
     Processor: KSTREAM-FILTER-0000000008 (stores: [])
       --> KSTREAM-SINK-0000000007
-      <-- KSTREAM-KEY-SELECT-0000000005
+      <-- Aggregate-groupby
     Sink: KSTREAM-SINK-0000000007 (topic: Aggregate-groupby-repartition)
       <-- KSTREAM-FILTER-0000000008
 

--- a/ksql-functional-tests/src/test/resources/expected_topology/5_3_0_pre/group-by_-_field_with_re-key_(stream->table)
+++ b/ksql-functional-tests/src/test/resources/expected_topology/5_3_0_pre/group-by_-_field_with_re-key_(stream->table)
@@ -48,14 +48,14 @@ Topologies:
       --> KSTREAM-FILTER-0000000004
       <-- KSTREAM-TRANSFORMVALUES-0000000002
     Processor: KSTREAM-FILTER-0000000004 (stores: [])
-      --> KSTREAM-KEY-SELECT-0000000005
+      --> Aggregate-groupby
       <-- KSTREAM-MAPVALUES-0000000003
-    Processor: KSTREAM-KEY-SELECT-0000000005 (stores: [])
+    Processor: Aggregate-groupby (stores: [])
       --> KSTREAM-FILTER-0000000008
       <-- KSTREAM-FILTER-0000000004
     Processor: KSTREAM-FILTER-0000000008 (stores: [])
       --> KSTREAM-SINK-0000000007
-      <-- KSTREAM-KEY-SELECT-0000000005
+      <-- Aggregate-groupby
     Sink: KSTREAM-SINK-0000000007 (topic: Aggregate-groupby-repartition)
       <-- KSTREAM-FILTER-0000000008
 

--- a/ksql-functional-tests/src/test/resources/expected_topology/5_3_0_pre/group-by_-_field_with_re-key_(stream->table)_-_format
+++ b/ksql-functional-tests/src/test/resources/expected_topology/5_3_0_pre/group-by_-_field_with_re-key_(stream->table)_-_format
@@ -48,14 +48,14 @@ Topologies:
       --> KSTREAM-FILTER-0000000004
       <-- KSTREAM-TRANSFORMVALUES-0000000002
     Processor: KSTREAM-FILTER-0000000004 (stores: [])
-      --> KSTREAM-KEY-SELECT-0000000005
+      --> Aggregate-groupby
       <-- KSTREAM-MAPVALUES-0000000003
-    Processor: KSTREAM-KEY-SELECT-0000000005 (stores: [])
+    Processor: Aggregate-groupby (stores: [])
       --> KSTREAM-FILTER-0000000008
       <-- KSTREAM-FILTER-0000000004
     Processor: KSTREAM-FILTER-0000000008 (stores: [])
       --> KSTREAM-SINK-0000000007
-      <-- KSTREAM-KEY-SELECT-0000000005
+      <-- Aggregate-groupby
     Sink: KSTREAM-SINK-0000000007 (topic: Aggregate-groupby-repartition)
       <-- KSTREAM-FILTER-0000000008
 

--- a/ksql-functional-tests/src/test/resources/expected_topology/5_3_0_pre/group-by_-_fields_(stream->table)
+++ b/ksql-functional-tests/src/test/resources/expected_topology/5_3_0_pre/group-by_-_fields_(stream->table)
@@ -48,14 +48,14 @@ Topologies:
       --> KSTREAM-FILTER-0000000004
       <-- KSTREAM-TRANSFORMVALUES-0000000002
     Processor: KSTREAM-FILTER-0000000004 (stores: [])
-      --> KSTREAM-KEY-SELECT-0000000005
+      --> Aggregate-groupby
       <-- KSTREAM-MAPVALUES-0000000003
-    Processor: KSTREAM-KEY-SELECT-0000000005 (stores: [])
+    Processor: Aggregate-groupby (stores: [])
       --> KSTREAM-FILTER-0000000008
       <-- KSTREAM-FILTER-0000000004
     Processor: KSTREAM-FILTER-0000000008 (stores: [])
       --> KSTREAM-SINK-0000000007
-      <-- KSTREAM-KEY-SELECT-0000000005
+      <-- Aggregate-groupby
     Sink: KSTREAM-SINK-0000000007 (topic: Aggregate-groupby-repartition)
       <-- KSTREAM-FILTER-0000000008
 

--- a/ksql-functional-tests/src/test/resources/expected_topology/5_3_0_pre/group-by_-_fields_(stream->table)_-_format
+++ b/ksql-functional-tests/src/test/resources/expected_topology/5_3_0_pre/group-by_-_fields_(stream->table)_-_format
@@ -48,14 +48,14 @@ Topologies:
       --> KSTREAM-FILTER-0000000004
       <-- KSTREAM-TRANSFORMVALUES-0000000002
     Processor: KSTREAM-FILTER-0000000004 (stores: [])
-      --> KSTREAM-KEY-SELECT-0000000005
+      --> Aggregate-groupby
       <-- KSTREAM-MAPVALUES-0000000003
-    Processor: KSTREAM-KEY-SELECT-0000000005 (stores: [])
+    Processor: Aggregate-groupby (stores: [])
       --> KSTREAM-FILTER-0000000008
       <-- KSTREAM-FILTER-0000000004
     Processor: KSTREAM-FILTER-0000000008 (stores: [])
       --> KSTREAM-SINK-0000000007
-      <-- KSTREAM-KEY-SELECT-0000000005
+      <-- Aggregate-groupby
     Sink: KSTREAM-SINK-0000000007 (topic: Aggregate-groupby-repartition)
       <-- KSTREAM-FILTER-0000000008
 

--- a/ksql-functional-tests/src/test/resources/expected_topology/5_3_0_pre/group-by_-_function_(stream->table)
+++ b/ksql-functional-tests/src/test/resources/expected_topology/5_3_0_pre/group-by_-_function_(stream->table)
@@ -48,14 +48,14 @@ Topologies:
       --> KSTREAM-FILTER-0000000004
       <-- KSTREAM-TRANSFORMVALUES-0000000002
     Processor: KSTREAM-FILTER-0000000004 (stores: [])
-      --> KSTREAM-KEY-SELECT-0000000005
+      --> Aggregate-groupby
       <-- KSTREAM-MAPVALUES-0000000003
-    Processor: KSTREAM-KEY-SELECT-0000000005 (stores: [])
+    Processor: Aggregate-groupby (stores: [])
       --> KSTREAM-FILTER-0000000008
       <-- KSTREAM-FILTER-0000000004
     Processor: KSTREAM-FILTER-0000000008 (stores: [])
       --> KSTREAM-SINK-0000000007
-      <-- KSTREAM-KEY-SELECT-0000000005
+      <-- Aggregate-groupby
     Sink: KSTREAM-SINK-0000000007 (topic: Aggregate-groupby-repartition)
       <-- KSTREAM-FILTER-0000000008
 

--- a/ksql-functional-tests/src/test/resources/expected_topology/5_3_0_pre/group-by_-_json_field_(stream->table)
+++ b/ksql-functional-tests/src/test/resources/expected_topology/5_3_0_pre/group-by_-_json_field_(stream->table)
@@ -48,14 +48,14 @@ Topologies:
       --> KSTREAM-FILTER-0000000004
       <-- KSTREAM-TRANSFORMVALUES-0000000002
     Processor: KSTREAM-FILTER-0000000004 (stores: [])
-      --> KSTREAM-KEY-SELECT-0000000005
+      --> Aggregate-groupby
       <-- KSTREAM-MAPVALUES-0000000003
-    Processor: KSTREAM-KEY-SELECT-0000000005 (stores: [])
+    Processor: Aggregate-groupby (stores: [])
       --> KSTREAM-FILTER-0000000008
       <-- KSTREAM-FILTER-0000000004
     Processor: KSTREAM-FILTER-0000000008 (stores: [])
       --> KSTREAM-SINK-0000000007
-      <-- KSTREAM-KEY-SELECT-0000000005
+      <-- Aggregate-groupby
     Sink: KSTREAM-SINK-0000000007 (topic: Aggregate-groupby-repartition)
       <-- KSTREAM-FILTER-0000000008
 

--- a/ksql-functional-tests/src/test/resources/expected_topology/5_3_0_pre/group-by_-_missing_matching_projection_field_(stream->table)
+++ b/ksql-functional-tests/src/test/resources/expected_topology/5_3_0_pre/group-by_-_missing_matching_projection_field_(stream->table)
@@ -48,14 +48,14 @@ Topologies:
       --> KSTREAM-FILTER-0000000004
       <-- KSTREAM-TRANSFORMVALUES-0000000002
     Processor: KSTREAM-FILTER-0000000004 (stores: [])
-      --> KSTREAM-KEY-SELECT-0000000005
+      --> Aggregate-groupby
       <-- KSTREAM-MAPVALUES-0000000003
-    Processor: KSTREAM-KEY-SELECT-0000000005 (stores: [])
+    Processor: Aggregate-groupby (stores: [])
       --> KSTREAM-FILTER-0000000008
       <-- KSTREAM-FILTER-0000000004
     Processor: KSTREAM-FILTER-0000000008 (stores: [])
       --> KSTREAM-SINK-0000000007
-      <-- KSTREAM-KEY-SELECT-0000000005
+      <-- Aggregate-groupby
     Sink: KSTREAM-SINK-0000000007 (topic: Aggregate-groupby-repartition)
       <-- KSTREAM-FILTER-0000000008
 

--- a/ksql-functional-tests/src/test/resources/expected_topology/5_3_0_pre/group-by_-_string_concat_using_+_op_(stream->table)
+++ b/ksql-functional-tests/src/test/resources/expected_topology/5_3_0_pre/group-by_-_string_concat_using_+_op_(stream->table)
@@ -48,14 +48,14 @@ Topologies:
       --> KSTREAM-FILTER-0000000004
       <-- KSTREAM-TRANSFORMVALUES-0000000002
     Processor: KSTREAM-FILTER-0000000004 (stores: [])
-      --> KSTREAM-KEY-SELECT-0000000005
+      --> Aggregate-groupby
       <-- KSTREAM-MAPVALUES-0000000003
-    Processor: KSTREAM-KEY-SELECT-0000000005 (stores: [])
+    Processor: Aggregate-groupby (stores: [])
       --> KSTREAM-FILTER-0000000008
       <-- KSTREAM-FILTER-0000000004
     Processor: KSTREAM-FILTER-0000000008 (stores: [])
       --> KSTREAM-SINK-0000000007
-      <-- KSTREAM-KEY-SELECT-0000000005
+      <-- Aggregate-groupby
     Sink: KSTREAM-SINK-0000000007 (topic: Aggregate-groupby-repartition)
       <-- KSTREAM-FILTER-0000000008
 

--- a/ksql-functional-tests/src/test/resources/expected_topology/5_3_0_pre/group-by_-_with_aggregate_arithmetic_(stream->table)
+++ b/ksql-functional-tests/src/test/resources/expected_topology/5_3_0_pre/group-by_-_with_aggregate_arithmetic_(stream->table)
@@ -48,14 +48,14 @@ Topologies:
       --> KSTREAM-FILTER-0000000004
       <-- KSTREAM-TRANSFORMVALUES-0000000002
     Processor: KSTREAM-FILTER-0000000004 (stores: [])
-      --> KSTREAM-KEY-SELECT-0000000005
+      --> Aggregate-groupby
       <-- KSTREAM-MAPVALUES-0000000003
-    Processor: KSTREAM-KEY-SELECT-0000000005 (stores: [])
+    Processor: Aggregate-groupby (stores: [])
       --> KSTREAM-FILTER-0000000008
       <-- KSTREAM-FILTER-0000000004
     Processor: KSTREAM-FILTER-0000000008 (stores: [])
       --> KSTREAM-SINK-0000000007
-      <-- KSTREAM-KEY-SELECT-0000000005
+      <-- Aggregate-groupby
     Sink: KSTREAM-SINK-0000000007 (topic: Aggregate-groupby-repartition)
       <-- KSTREAM-FILTER-0000000008
 

--- a/ksql-functional-tests/src/test/resources/expected_topology/5_3_0_pre/group-by_-_with_aggregate_arithmetic_involving_source_field_(stream->table)
+++ b/ksql-functional-tests/src/test/resources/expected_topology/5_3_0_pre/group-by_-_with_aggregate_arithmetic_involving_source_field_(stream->table)
@@ -48,14 +48,14 @@ Topologies:
       --> KSTREAM-FILTER-0000000004
       <-- KSTREAM-TRANSFORMVALUES-0000000002
     Processor: KSTREAM-FILTER-0000000004 (stores: [])
-      --> KSTREAM-KEY-SELECT-0000000005
+      --> Aggregate-groupby
       <-- KSTREAM-MAPVALUES-0000000003
-    Processor: KSTREAM-KEY-SELECT-0000000005 (stores: [])
+    Processor: Aggregate-groupby (stores: [])
       --> KSTREAM-FILTER-0000000008
       <-- KSTREAM-FILTER-0000000004
     Processor: KSTREAM-FILTER-0000000008 (stores: [])
       --> KSTREAM-SINK-0000000007
-      <-- KSTREAM-KEY-SELECT-0000000005
+      <-- Aggregate-groupby
     Sink: KSTREAM-SINK-0000000007 (topic: Aggregate-groupby-repartition)
       <-- KSTREAM-FILTER-0000000008
 

--- a/ksql-functional-tests/src/test/resources/expected_topology/5_3_0_pre/group-by_-_with_constant_having_(stream-table)
+++ b/ksql-functional-tests/src/test/resources/expected_topology/5_3_0_pre/group-by_-_with_constant_having_(stream-table)
@@ -48,14 +48,14 @@ Topologies:
       --> KSTREAM-FILTER-0000000004
       <-- KSTREAM-TRANSFORMVALUES-0000000002
     Processor: KSTREAM-FILTER-0000000004 (stores: [])
-      --> KSTREAM-KEY-SELECT-0000000005
+      --> Aggregate-groupby
       <-- KSTREAM-MAPVALUES-0000000003
-    Processor: KSTREAM-KEY-SELECT-0000000005 (stores: [])
+    Processor: Aggregate-groupby (stores: [])
       --> KSTREAM-FILTER-0000000008
       <-- KSTREAM-FILTER-0000000004
     Processor: KSTREAM-FILTER-0000000008 (stores: [])
       --> KSTREAM-SINK-0000000007
-      <-- KSTREAM-KEY-SELECT-0000000005
+      <-- Aggregate-groupby
     Sink: KSTREAM-SINK-0000000007 (topic: Aggregate-groupby-repartition)
       <-- KSTREAM-FILTER-0000000008
 

--- a/ksql-functional-tests/src/test/resources/expected_topology/5_3_0_pre/group-by_-_with_groupings_(stream->table)
+++ b/ksql-functional-tests/src/test/resources/expected_topology/5_3_0_pre/group-by_-_with_groupings_(stream->table)
@@ -48,14 +48,14 @@ Topologies:
       --> KSTREAM-FILTER-0000000004
       <-- KSTREAM-TRANSFORMVALUES-0000000002
     Processor: KSTREAM-FILTER-0000000004 (stores: [])
-      --> KSTREAM-KEY-SELECT-0000000005
+      --> Aggregate-groupby
       <-- KSTREAM-MAPVALUES-0000000003
-    Processor: KSTREAM-KEY-SELECT-0000000005 (stores: [])
+    Processor: Aggregate-groupby (stores: [])
       --> KSTREAM-FILTER-0000000008
       <-- KSTREAM-FILTER-0000000004
     Processor: KSTREAM-FILTER-0000000008 (stores: [])
       --> KSTREAM-SINK-0000000007
-      <-- KSTREAM-KEY-SELECT-0000000005
+      <-- Aggregate-groupby
     Sink: KSTREAM-SINK-0000000007 (topic: Aggregate-groupby-repartition)
       <-- KSTREAM-FILTER-0000000008
 

--- a/ksql-functional-tests/src/test/resources/expected_topology/5_3_0_pre/group-by_-_with_having_expression_on_non-group-by_field_(stream->table)
+++ b/ksql-functional-tests/src/test/resources/expected_topology/5_3_0_pre/group-by_-_with_having_expression_on_non-group-by_field_(stream->table)
@@ -48,14 +48,14 @@ Topologies:
       --> KSTREAM-FILTER-0000000004
       <-- KSTREAM-TRANSFORMVALUES-0000000002
     Processor: KSTREAM-FILTER-0000000004 (stores: [])
-      --> KSTREAM-KEY-SELECT-0000000005
+      --> Aggregate-groupby
       <-- KSTREAM-MAPVALUES-0000000003
-    Processor: KSTREAM-KEY-SELECT-0000000005 (stores: [])
+    Processor: Aggregate-groupby (stores: [])
       --> KSTREAM-FILTER-0000000008
       <-- KSTREAM-FILTER-0000000004
     Processor: KSTREAM-FILTER-0000000008 (stores: [])
       --> KSTREAM-SINK-0000000007
-      <-- KSTREAM-KEY-SELECT-0000000005
+      <-- Aggregate-groupby
     Sink: KSTREAM-SINK-0000000007 (topic: Aggregate-groupby-repartition)
       <-- KSTREAM-FILTER-0000000008
 

--- a/ksql-functional-tests/src/test/resources/expected_topology/5_3_0_pre/group-by_-_with_multiple_having_expressions_(stream->table)
+++ b/ksql-functional-tests/src/test/resources/expected_topology/5_3_0_pre/group-by_-_with_multiple_having_expressions_(stream->table)
@@ -48,14 +48,14 @@ Topologies:
       --> KSTREAM-FILTER-0000000004
       <-- KSTREAM-TRANSFORMVALUES-0000000002
     Processor: KSTREAM-FILTER-0000000004 (stores: [])
-      --> KSTREAM-KEY-SELECT-0000000005
+      --> Aggregate-groupby
       <-- KSTREAM-MAPVALUES-0000000003
-    Processor: KSTREAM-KEY-SELECT-0000000005 (stores: [])
+    Processor: Aggregate-groupby (stores: [])
       --> KSTREAM-FILTER-0000000008
       <-- KSTREAM-FILTER-0000000004
     Processor: KSTREAM-FILTER-0000000008 (stores: [])
       --> KSTREAM-SINK-0000000007
-      <-- KSTREAM-KEY-SELECT-0000000005
+      <-- Aggregate-groupby
     Sink: KSTREAM-SINK-0000000007 (topic: Aggregate-groupby-repartition)
       <-- KSTREAM-FILTER-0000000008
 

--- a/ksql-functional-tests/src/test/resources/expected_topology/5_3_0_pre/joins_-_stream_stream_left_join_-_rekey_-_legacy_downstream_query
+++ b/ksql-functional-tests/src/test/resources/expected_topology/5_3_0_pre/joins_-_stream_stream_left_join_-_rekey_-_legacy_downstream_query
@@ -48,14 +48,14 @@ Topologies:
       --> KSTREAM-FILTER-0000000004
       <-- KSTREAM-TRANSFORMVALUES-0000000002
     Processor: KSTREAM-FILTER-0000000004 (stores: [])
-      --> KSTREAM-KEY-SELECT-0000000005
+      --> Aggregate-groupby
       <-- KSTREAM-MAPVALUES-0000000003
-    Processor: KSTREAM-KEY-SELECT-0000000005 (stores: [])
+    Processor: Aggregate-groupby (stores: [])
       --> KSTREAM-FILTER-0000000008
       <-- KSTREAM-FILTER-0000000004
     Processor: KSTREAM-FILTER-0000000008 (stores: [])
       --> KSTREAM-SINK-0000000007
-      <-- KSTREAM-KEY-SELECT-0000000005
+      <-- Aggregate-groupby
     Sink: KSTREAM-SINK-0000000007 (topic: Aggregate-groupby-repartition)
       <-- KSTREAM-FILTER-0000000008
 

--- a/ksql-functional-tests/src/test/resources/expected_topology/5_3_0_pre/key-field_-_stream_|_initially_null_|_group_by_(-)_|_key_in_value_|_aliasing
+++ b/ksql-functional-tests/src/test/resources/expected_topology/5_3_0_pre/key-field_-_stream_|_initially_null_|_group_by_(-)_|_key_in_value_|_aliasing
@@ -48,14 +48,14 @@ Topologies:
       --> KSTREAM-FILTER-0000000004
       <-- KSTREAM-TRANSFORMVALUES-0000000002
     Processor: KSTREAM-FILTER-0000000004 (stores: [])
-      --> KSTREAM-KEY-SELECT-0000000005
+      --> Aggregate-groupby
       <-- KSTREAM-MAPVALUES-0000000003
-    Processor: KSTREAM-KEY-SELECT-0000000005 (stores: [])
+    Processor: Aggregate-groupby (stores: [])
       --> KSTREAM-FILTER-0000000008
       <-- KSTREAM-FILTER-0000000004
     Processor: KSTREAM-FILTER-0000000008 (stores: [])
       --> KSTREAM-SINK-0000000007
-      <-- KSTREAM-KEY-SELECT-0000000005
+      <-- Aggregate-groupby
     Sink: KSTREAM-SINK-0000000007 (topic: Aggregate-groupby-repartition)
       <-- KSTREAM-FILTER-0000000008
 

--- a/ksql-functional-tests/src/test/resources/expected_topology/5_3_0_pre/key-field_-_stream_|_initially_null_|_group_by_(-)_|_key_in_value_|_no_aliasing
+++ b/ksql-functional-tests/src/test/resources/expected_topology/5_3_0_pre/key-field_-_stream_|_initially_null_|_group_by_(-)_|_key_in_value_|_no_aliasing
@@ -48,14 +48,14 @@ Topologies:
       --> KSTREAM-FILTER-0000000004
       <-- KSTREAM-TRANSFORMVALUES-0000000002
     Processor: KSTREAM-FILTER-0000000004 (stores: [])
-      --> KSTREAM-KEY-SELECT-0000000005
+      --> Aggregate-groupby
       <-- KSTREAM-MAPVALUES-0000000003
-    Processor: KSTREAM-KEY-SELECT-0000000005 (stores: [])
+    Processor: Aggregate-groupby (stores: [])
       --> KSTREAM-FILTER-0000000008
       <-- KSTREAM-FILTER-0000000004
     Processor: KSTREAM-FILTER-0000000008 (stores: [])
       --> KSTREAM-SINK-0000000007
-      <-- KSTREAM-KEY-SELECT-0000000005
+      <-- Aggregate-groupby
     Sink: KSTREAM-SINK-0000000007 (topic: Aggregate-groupby-repartition)
       <-- KSTREAM-FILTER-0000000008
 

--- a/ksql-functional-tests/src/test/resources/expected_topology/5_3_0_pre/key-field_-_stream_|_initially_null_|_group_by_(-)_|_key_in_value_|_no_aliasing_|_with_cast
+++ b/ksql-functional-tests/src/test/resources/expected_topology/5_3_0_pre/key-field_-_stream_|_initially_null_|_group_by_(-)_|_key_in_value_|_no_aliasing_|_with_cast
@@ -48,14 +48,14 @@ Topologies:
       --> KSTREAM-FILTER-0000000004
       <-- KSTREAM-TRANSFORMVALUES-0000000002
     Processor: KSTREAM-FILTER-0000000004 (stores: [])
-      --> KSTREAM-KEY-SELECT-0000000005
+      --> Aggregate-groupby
       <-- KSTREAM-MAPVALUES-0000000003
-    Processor: KSTREAM-KEY-SELECT-0000000005 (stores: [])
+    Processor: Aggregate-groupby (stores: [])
       --> KSTREAM-FILTER-0000000008
       <-- KSTREAM-FILTER-0000000004
     Processor: KSTREAM-FILTER-0000000008 (stores: [])
       --> KSTREAM-SINK-0000000007
-      <-- KSTREAM-KEY-SELECT-0000000005
+      <-- Aggregate-groupby
     Sink: KSTREAM-SINK-0000000007 (topic: Aggregate-groupby-repartition)
       <-- KSTREAM-FILTER-0000000008
 

--- a/ksql-functional-tests/src/test/resources/expected_topology/5_3_0_pre/key-field_-_stream_|_initially_null_|_group_by_(-)_|_key_not_in_value_|_-
+++ b/ksql-functional-tests/src/test/resources/expected_topology/5_3_0_pre/key-field_-_stream_|_initially_null_|_group_by_(-)_|_key_not_in_value_|_-
@@ -48,14 +48,14 @@ Topologies:
       --> KSTREAM-FILTER-0000000004
       <-- KSTREAM-TRANSFORMVALUES-0000000002
     Processor: KSTREAM-FILTER-0000000004 (stores: [])
-      --> KSTREAM-KEY-SELECT-0000000005
+      --> Aggregate-groupby
       <-- KSTREAM-MAPVALUES-0000000003
-    Processor: KSTREAM-KEY-SELECT-0000000005 (stores: [])
+    Processor: Aggregate-groupby (stores: [])
       --> KSTREAM-FILTER-0000000008
       <-- KSTREAM-FILTER-0000000004
     Processor: KSTREAM-FILTER-0000000008 (stores: [])
       --> KSTREAM-SINK-0000000007
-      <-- KSTREAM-KEY-SELECT-0000000005
+      <-- Aggregate-groupby
     Sink: KSTREAM-SINK-0000000007 (topic: Aggregate-groupby-repartition)
       <-- KSTREAM-FILTER-0000000008
 

--- a/ksql-functional-tests/src/test/resources/expected_topology/5_3_0_pre/key-field_-_stream_|_initially_set_|_group_by_(different)_|_key_in_value_|_aliasing
+++ b/ksql-functional-tests/src/test/resources/expected_topology/5_3_0_pre/key-field_-_stream_|_initially_set_|_group_by_(different)_|_key_in_value_|_aliasing
@@ -48,14 +48,14 @@ Topologies:
       --> KSTREAM-FILTER-0000000004
       <-- KSTREAM-TRANSFORMVALUES-0000000002
     Processor: KSTREAM-FILTER-0000000004 (stores: [])
-      --> KSTREAM-KEY-SELECT-0000000005
+      --> Aggregate-groupby
       <-- KSTREAM-MAPVALUES-0000000003
-    Processor: KSTREAM-KEY-SELECT-0000000005 (stores: [])
+    Processor: Aggregate-groupby (stores: [])
       --> KSTREAM-FILTER-0000000008
       <-- KSTREAM-FILTER-0000000004
     Processor: KSTREAM-FILTER-0000000008 (stores: [])
       --> KSTREAM-SINK-0000000007
-      <-- KSTREAM-KEY-SELECT-0000000005
+      <-- Aggregate-groupby
     Sink: KSTREAM-SINK-0000000007 (topic: Aggregate-groupby-repartition)
       <-- KSTREAM-FILTER-0000000008
 

--- a/ksql-functional-tests/src/test/resources/expected_topology/5_3_0_pre/key-field_-_stream_|_initially_set_|_group_by_(different)_|_key_in_value_|_no_aliasing
+++ b/ksql-functional-tests/src/test/resources/expected_topology/5_3_0_pre/key-field_-_stream_|_initially_set_|_group_by_(different)_|_key_in_value_|_no_aliasing
@@ -48,14 +48,14 @@ Topologies:
       --> KSTREAM-FILTER-0000000004
       <-- KSTREAM-TRANSFORMVALUES-0000000002
     Processor: KSTREAM-FILTER-0000000004 (stores: [])
-      --> KSTREAM-KEY-SELECT-0000000005
+      --> Aggregate-groupby
       <-- KSTREAM-MAPVALUES-0000000003
-    Processor: KSTREAM-KEY-SELECT-0000000005 (stores: [])
+    Processor: Aggregate-groupby (stores: [])
       --> KSTREAM-FILTER-0000000008
       <-- KSTREAM-FILTER-0000000004
     Processor: KSTREAM-FILTER-0000000008 (stores: [])
       --> KSTREAM-SINK-0000000007
-      <-- KSTREAM-KEY-SELECT-0000000005
+      <-- Aggregate-groupby
     Sink: KSTREAM-SINK-0000000007 (topic: Aggregate-groupby-repartition)
       <-- KSTREAM-FILTER-0000000008
 

--- a/ksql-functional-tests/src/test/resources/expected_topology/5_3_0_pre/key-field_-_stream_|_initially_set_|_group_by_(different)_|_key_not_in_value_|_-
+++ b/ksql-functional-tests/src/test/resources/expected_topology/5_3_0_pre/key-field_-_stream_|_initially_set_|_group_by_(different)_|_key_not_in_value_|_-
@@ -48,14 +48,14 @@ Topologies:
       --> KSTREAM-FILTER-0000000004
       <-- KSTREAM-TRANSFORMVALUES-0000000002
     Processor: KSTREAM-FILTER-0000000004 (stores: [])
-      --> KSTREAM-KEY-SELECT-0000000005
+      --> Aggregate-groupby
       <-- KSTREAM-MAPVALUES-0000000003
-    Processor: KSTREAM-KEY-SELECT-0000000005 (stores: [])
+    Processor: Aggregate-groupby (stores: [])
       --> KSTREAM-FILTER-0000000008
       <-- KSTREAM-FILTER-0000000004
     Processor: KSTREAM-FILTER-0000000008 (stores: [])
       --> KSTREAM-SINK-0000000007
-      <-- KSTREAM-KEY-SELECT-0000000005
+      <-- Aggregate-groupby
     Sink: KSTREAM-SINK-0000000007 (topic: Aggregate-groupby-repartition)
       <-- KSTREAM-FILTER-0000000008
 

--- a/ksql-functional-tests/src/test/resources/expected_topology/5_3_0_pre/key-field_-_stream_|_initially_set_|_group_by_expression_|_key_in_value_|_no_aliasing
+++ b/ksql-functional-tests/src/test/resources/expected_topology/5_3_0_pre/key-field_-_stream_|_initially_set_|_group_by_expression_|_key_in_value_|_no_aliasing
@@ -48,14 +48,14 @@ Topologies:
       --> KSTREAM-FILTER-0000000004
       <-- KSTREAM-TRANSFORMVALUES-0000000002
     Processor: KSTREAM-FILTER-0000000004 (stores: [])
-      --> KSTREAM-KEY-SELECT-0000000005
+      --> Aggregate-groupby
       <-- KSTREAM-MAPVALUES-0000000003
-    Processor: KSTREAM-KEY-SELECT-0000000005 (stores: [])
+    Processor: Aggregate-groupby (stores: [])
       --> KSTREAM-FILTER-0000000008
       <-- KSTREAM-FILTER-0000000004
     Processor: KSTREAM-FILTER-0000000008 (stores: [])
       --> KSTREAM-SINK-0000000007
-      <-- KSTREAM-KEY-SELECT-0000000005
+      <-- Aggregate-groupby
     Sink: KSTREAM-SINK-0000000007 (topic: Aggregate-groupby-repartition)
       <-- KSTREAM-FILTER-0000000008
 

--- a/ksql-functional-tests/src/test/resources/expected_topology/5_3_0_pre/key-field_-_stream_|_initially_set_|_group_by_multiple_|_key_in_value_|_no_aliasing
+++ b/ksql-functional-tests/src/test/resources/expected_topology/5_3_0_pre/key-field_-_stream_|_initially_set_|_group_by_multiple_|_key_in_value_|_no_aliasing
@@ -48,14 +48,14 @@ Topologies:
       --> KSTREAM-FILTER-0000000004
       <-- KSTREAM-TRANSFORMVALUES-0000000002
     Processor: KSTREAM-FILTER-0000000004 (stores: [])
-      --> KSTREAM-KEY-SELECT-0000000005
+      --> Aggregate-groupby
       <-- KSTREAM-MAPVALUES-0000000003
-    Processor: KSTREAM-KEY-SELECT-0000000005 (stores: [])
+    Processor: Aggregate-groupby (stores: [])
       --> KSTREAM-FILTER-0000000008
       <-- KSTREAM-FILTER-0000000004
     Processor: KSTREAM-FILTER-0000000008 (stores: [])
       --> KSTREAM-SINK-0000000007
-      <-- KSTREAM-KEY-SELECT-0000000005
+      <-- Aggregate-groupby
     Sink: KSTREAM-SINK-0000000007 (topic: Aggregate-groupby-repartition)
       <-- KSTREAM-FILTER-0000000008
 

--- a/ksql-functional-tests/src/test/resources/expected_topology/5_3_0_pre/session-windows_-_import_session_stream_and_group_by
+++ b/ksql-functional-tests/src/test/resources/expected_topology/5_3_0_pre/session-windows_-_import_session_stream_and_group_by
@@ -48,14 +48,14 @@ Topologies:
       --> KSTREAM-FILTER-0000000004
       <-- KSTREAM-TRANSFORMVALUES-0000000002
     Processor: KSTREAM-FILTER-0000000004 (stores: [])
-      --> KSTREAM-KEY-SELECT-0000000005
+      --> Aggregate-groupby
       <-- KSTREAM-MAPVALUES-0000000003
-    Processor: KSTREAM-KEY-SELECT-0000000005 (stores: [])
+    Processor: Aggregate-groupby (stores: [])
       --> KSTREAM-FILTER-0000000008
       <-- KSTREAM-FILTER-0000000004
     Processor: KSTREAM-FILTER-0000000008 (stores: [])
       --> KSTREAM-SINK-0000000007
-      <-- KSTREAM-KEY-SELECT-0000000005
+      <-- Aggregate-groupby
     Sink: KSTREAM-SINK-0000000007 (topic: Aggregate-groupby-repartition)
       <-- KSTREAM-FILTER-0000000008
 

--- a/ksql-functional-tests/src/test/resources/expected_topology/5_3_0_pre/substring_-_in_group_by
+++ b/ksql-functional-tests/src/test/resources/expected_topology/5_3_0_pre/substring_-_in_group_by
@@ -48,14 +48,14 @@ Topologies:
       --> KSTREAM-FILTER-0000000004
       <-- KSTREAM-TRANSFORMVALUES-0000000002
     Processor: KSTREAM-FILTER-0000000004 (stores: [])
-      --> KSTREAM-KEY-SELECT-0000000005
+      --> Aggregate-groupby
       <-- KSTREAM-MAPVALUES-0000000003
-    Processor: KSTREAM-KEY-SELECT-0000000005 (stores: [])
+    Processor: Aggregate-groupby (stores: [])
       --> KSTREAM-FILTER-0000000008
       <-- KSTREAM-FILTER-0000000004
     Processor: KSTREAM-FILTER-0000000008 (stores: [])
       --> KSTREAM-SINK-0000000007
-      <-- KSTREAM-KEY-SELECT-0000000005
+      <-- Aggregate-groupby
     Sink: KSTREAM-SINK-0000000007 (topic: Aggregate-groupby-repartition)
       <-- KSTREAM-FILTER-0000000008
 


### PR DESCRIPTION
### Description 

- Remove the hack to standarize expected topologies.
- Replace with something to help re-write expected topologies when things change in KS.
- Fix up the expected topologies

Fixes: #2759

### Testing done 

Test only change.

### Reviewer checklist
- [ ] Ensure docs are updated if necessary. (eg. if a user visible feature is being added or changed).
- [ ] Ensure relevant issues are linked (description should include text like "Fixes #<issue number>")

