### PR TITLE
Minor: Refactor `EntityUtil` to make use of new `SchemaWalker`

### DIFF
--- a/ksql-common/src/main/java/io/confluent/ksql/schema/connect/SchemaWalker.java
+++ b/ksql-common/src/main/java/io/confluent/ksql/schema/connect/SchemaWalker.java
@@ -29,8 +29,8 @@ import org.apache.kafka.connect.data.Schema.Type;
  */
 public final class SchemaWalker {
 
-  private static final Map<Type, BiFunction<Visitor<?>, Schema, Object>> HANDLER =
-      ImmutableMap.<Type, BiFunction<Visitor<?>, Schema, Object>>builder()
+  private static final Map<Type, BiFunction<Visitor<?, ?>, Schema, Object>> HANDLER =
+      ImmutableMap.<Type, BiFunction<Visitor<?, ?>, Schema, Object>>builder()
           .put(Type.BOOLEAN, Visitor::visitBoolean)
           .put(Type.INT8, Visitor::visitInt8)
           .put(Type.INT16, Visitor::visitInt16)
@@ -48,95 +48,95 @@ public final class SchemaWalker {
   private SchemaWalker() {
   }
 
-  public interface Visitor<T> {
+  public interface Visitor<S, F> {
 
-    default T visitSchema(Schema schema) {
+    default S visitSchema(Schema schema) {
       throw new UnsupportedOperationException("Unsupported schema type: " + schema);
     }
 
-    default T visitPrimitive(Schema schema) {
+    default S visitPrimitive(Schema schema) {
       return visitSchema(schema);
     }
 
-    default T visitBoolean(Schema schema) {
+    default S visitBoolean(Schema schema) {
       return visitPrimitive(schema);
     }
 
-    default T visitInt8(Schema schema) {
+    default S visitInt8(Schema schema) {
       return visitPrimitive(schema);
     }
 
-    default T visitInt16(Schema schema) {
+    default S visitInt16(Schema schema) {
       return visitPrimitive(schema);
     }
 
-    default T visitInt32(Schema schema) {
+    default S visitInt32(Schema schema) {
       return visitPrimitive(schema);
     }
 
-    default T visitInt64(Schema schema) {
+    default S visitInt64(Schema schema) {
       return visitPrimitive(schema);
     }
 
-    default T visitFloat32(Schema schema) {
+    default S visitFloat32(Schema schema) {
       return visitPrimitive(schema);
     }
 
-    default T visitFloat64(Schema schema) {
+    default S visitFloat64(Schema schema) {
       return visitPrimitive(schema);
     }
 
-    default T visitString(Schema schema) {
+    default S visitString(Schema schema) {
       return visitPrimitive(schema);
     }
 
-    default T visitBytes(Schema schema) {
+    default S visitBytes(Schema schema) {
       return visitSchema(schema);
     }
 
-    default T visitArray(Schema schema, T element) {
+    default S visitArray(Schema schema, S element) {
       return visitSchema(schema);
     }
 
-    default T visitMap(Schema schema, T key, T value) {
+    default S visitMap(Schema schema, S key, S value) {
       return visitSchema(schema);
     }
 
-    default T visitStruct(Schema schema, List<? extends T> fields) {
+    default S visitStruct(Schema schema, List<? extends F> fields) {
       return visitSchema(schema);
     }
 
-    default T visitField(Field field, T type) {
+    default F visitField(Field field, S type) {
       return null;
     }
   }
 
   @SuppressWarnings("unchecked")
-  public static <T> T visit(final Schema schema, final Visitor<T> visitor) {
-    final BiFunction<Visitor<?>, Schema, Object> handler = HANDLER.get(schema.type());
+  public static <S, F> S visit(final Schema schema, final Visitor<S, F> visitor) {
+    final BiFunction<Visitor<?, ?>, Schema, Object> handler = HANDLER.get(schema.type());
     if (handler == null) {
       throw new UnsupportedOperationException("Unsupported schema type: " + schema.type());
     }
 
-    return (T) handler.apply(visitor, schema);
+    return (S) handler.apply(visitor, schema);
   }
 
-  private static <T> T visitArray(final Visitor<T> visitor, final Schema schema) {
-    final T element = visit(schema.valueSchema(), visitor);
+  private static <S, F> S visitArray(final Visitor<S, F> visitor, final Schema schema) {
+    final S element = visit(schema.valueSchema(), visitor);
     return visitor.visitArray(schema, element);
   }
 
-  private static <T> T visitMap(final Visitor<T> visitor, final Schema schema) {
-    final T key = visit(schema.keySchema(), visitor);
-    final T value = visit(schema.valueSchema(), visitor);
+  private static <S, F> S visitMap(final Visitor<S, F> visitor, final Schema schema) {
+    final S key = visit(schema.keySchema(), visitor);
+    final S value = visit(schema.valueSchema(), visitor);
     return visitor.visitMap(schema, key, value);
   }
 
-  private static <T> T visitStruct(final Visitor<T> visitor, final Schema schema) {
-    final List<T> fields = schema.fields().stream()
+  private static <S, F> S visitStruct(final Visitor<S, F> visitor, final Schema schema) {
+    final List<F> fields = schema.fields().stream()
         .map(field -> visitor.visitField(
             field,
-            SchemaWalker.<T>visit(field.schema(), visitor))
+            SchemaWalker.<S, F>visit(field.schema(), visitor))
         )
         .collect(Collectors.toList());
 

--- a/ksql-rest-app/src/main/java/io/confluent/ksql/rest/entity/SchemaInfo.java
+++ b/ksql-rest-app/src/main/java/io/confluent/ksql/rest/entity/SchemaInfo.java
@@ -18,6 +18,7 @@ package io.confluent.ksql.rest.entity;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
+import com.google.common.collect.ImmutableList;
 import io.confluent.ksql.schema.SqlType;
 import java.util.List;
 import java.util.Objects;
@@ -33,11 +34,13 @@ public class SchemaInfo {
   @JsonCreator
   public SchemaInfo(
       @JsonProperty("type") final SqlType type,
-      @JsonProperty("fields") final List<FieldInfo> fields,
+      @JsonProperty("fields") final List<? extends FieldInfo> fields,
       @JsonProperty("memberSchema") final SchemaInfo memberSchema) {
     Objects.requireNonNull(type);
     this.type = type;
-    this.fields = fields;
+    this.fields = fields == null
+        ? null
+        : ImmutableList.copyOf(fields);
     this.memberSchema = memberSchema;
   }
 

--- a/ksql-rest-app/src/main/java/io/confluent/ksql/rest/util/EntityUtil.java
+++ b/ksql-rest-app/src/main/java/io/confluent/ksql/rest/util/EntityUtil.java
@@ -15,72 +15,70 @@
 
 package io.confluent.ksql.rest.util;
 
-import avro.shaded.com.google.common.collect.ImmutableMap;
 import io.confluent.ksql.rest.entity.FieldInfo;
 import io.confluent.ksql.rest.entity.SchemaInfo;
 import io.confluent.ksql.schema.SqlType;
+import io.confluent.ksql.schema.connect.SchemaWalker;
 import io.confluent.ksql.schema.ksql.KsqlSchema;
 import java.util.List;
-import java.util.Map;
-import java.util.stream.Collectors;
+import org.apache.kafka.connect.data.Field;
 import org.apache.kafka.connect.data.Schema;
 
 public final class EntityUtil {
-  private static final Map<Schema.Type, SqlType>
-      SCHEMA_TYPE_TO_SCHEMA_INFO_TYPE =
-      ImmutableMap.<Schema.Type, SqlType>builder()
-          .put(Schema.Type.INT32, SqlType.INTEGER)
-          .put(Schema.Type.INT64, SqlType.BIGINT)
-          .put(Schema.Type.FLOAT32, SqlType.DOUBLE)
-          .put(Schema.Type.FLOAT64, SqlType.DOUBLE)
-          .put(Schema.Type.BOOLEAN, SqlType.BOOLEAN)
-          .put(Schema.Type.STRING, SqlType.STRING)
-          .put(Schema.Type.ARRAY, SqlType.ARRAY)
-          .put(Schema.Type.MAP, SqlType.MAP)
-          .put(Schema.Type.STRUCT, SqlType.STRUCT)
-          .build();
 
   private EntityUtil() {
   }
 
   public static List<FieldInfo> buildSourceSchemaEntity(final KsqlSchema schema) {
-    return buildSchemaEntity(schema.getSchema()).getFields()
+    return SchemaWalker.visit(schema.getSchema(), new Converter())
+        .getFields()
         .orElseThrow(() -> new RuntimeException("Root schema should contain fields"));
   }
 
-  private static SchemaInfo buildSchemaEntity(final Schema schema) {
-    final SqlType sqlType = getSqlType(schema);
+  private static final class Converter implements SchemaWalker.Visitor<SchemaInfo, FieldInfo> {
 
-    switch (schema.type()) {
-      case ARRAY:
-      case MAP:
-        return new SchemaInfo(
-            sqlType,
-            null,
-            buildSchemaEntity(schema.valueSchema())
-        );
-      case STRUCT:
-        return new SchemaInfo(
-            sqlType,
-            schema.fields()
-                .stream()
-                .map(
-                    f -> new FieldInfo(f.name(), buildSchemaEntity(f.schema())))
-                .collect(Collectors.toList()),
-            null
-        );
-      default:
-        return new SchemaInfo(sqlType, null, null);
-    }
-  }
-
-  private static SqlType getSqlType(final Schema schema) {
-    final SqlType type = SCHEMA_TYPE_TO_SCHEMA_INFO_TYPE.get(schema.type());
-    if (type == null) {
-      throw new RuntimeException(String.format("Invalid type in schema: %s.",
-          schema.type().getName()));
+    public SchemaInfo visitSchema(final Schema schema) {
+      throw new IllegalArgumentException("Invalid type in schema: " + schema.type());
     }
 
-    return type;
+    public SchemaInfo visitBoolean(final Schema schema) {
+      return primitive(SqlType.BOOLEAN);
+    }
+
+    public SchemaInfo visitInt32(final Schema schema) {
+      return primitive(SqlType.INTEGER);
+    }
+
+    public SchemaInfo visitInt64(final Schema schema) {
+      return primitive(SqlType.BIGINT);
+    }
+
+    public SchemaInfo visitFloat64(final Schema schema) {
+      return primitive(SqlType.DOUBLE);
+    }
+
+    public SchemaInfo visitString(final Schema schema) {
+      return primitive(SqlType.STRING);
+    }
+
+    public SchemaInfo visitArray(final Schema schema, final SchemaInfo element) {
+      return new SchemaInfo(SqlType.ARRAY, null, element);
+    }
+
+    public SchemaInfo visitMap(final Schema schema, final SchemaInfo key, final SchemaInfo value) {
+      return new SchemaInfo(SqlType.MAP, null, value);
+    }
+
+    public SchemaInfo visitStruct(final Schema schema, final List<? extends FieldInfo> fields) {
+      return new SchemaInfo(SqlType.STRUCT, fields, null);
+    }
+
+    public FieldInfo visitField(final Field field, final SchemaInfo type) {
+      return new FieldInfo(field.name(), type);
+    }
+
+    private static SchemaInfo primitive(final SqlType type) {
+      return new SchemaInfo(type, null, null);
+    }
   }
 }

--- a/ksql-serde/src/main/java/io/confluent/ksql/serde/avro/AvroDataTranslator.java
+++ b/ksql-serde/src/main/java/io/confluent/ksql/serde/avro/AvroDataTranslator.java
@@ -210,7 +210,7 @@ public class AvroDataTranslator implements DataTranslator {
 
   private static Schema throwOnInvalidSchema(final Schema schema) {
 
-    class SchemaValidator implements Visitor<Void> {
+    class SchemaValidator implements Visitor<Void, Void> {
 
       @Override
       public Void visitMap(final Schema schema, final Void key, final Void value) {

--- a/ksql-serde/src/main/java/io/confluent/ksql/serde/json/JsonSerdeUtils.java
+++ b/ksql-serde/src/main/java/io/confluent/ksql/serde/json/JsonSerdeUtils.java
@@ -29,7 +29,7 @@ final class JsonSerdeUtils {
 
   static PersistenceSchema validateSchema(final PersistenceSchema schema) {
 
-    class SchemaValidator implements Visitor<Void> {
+    class SchemaValidator implements Visitor<Void, Void> {
 
       @Override
       public Void visitMap(final Schema schema, final Void key, final Void value) {


### PR DESCRIPTION
### Description 

Refactor `EntityUtil` to make use of new `SchemaWalker`.

This involved a small enhancement to `SchemaWalker` to allow it to return a different type for fields, which will make sense in a lot of cases.

### Testing done 

`mvn test`.

### Reviewer checklist
- [ ] Ensure docs are updated if necessary. (eg. if a user visible feature is being added or changed).
- [ ] Ensure relevant issues are linked (description should include text like "Fixes #<issue number>")

