### PR TITLE
Docs around null handling for unwrapped single-field schemas.

### DIFF
--- a/docs/developer-guide/serialization.rst
+++ b/docs/developer-guide/serialization.rst
@@ -149,7 +149,7 @@ For more information, see :ref:`ksql-persistence-wrap-single-values`.
 
 A ``null`` value in a table's topic is treated as a tombstone, which indicates that a row has been
 removed. If a table's source topic has an unwrapped single-field key schema and the value is
-``null``, it be treated as a tombstone, resulting in any previous value for the key being removed
+``null``, it's treated as a tombstone, resulting in any previous value for the key being removed
 from the table.
 
 A ``null`` key or value in a stream's topic will be ignored when the stream is part of a join.

--- a/docs/developer-guide/serialization.rst
+++ b/docs/developer-guide/serialization.rst
@@ -147,7 +147,7 @@ For more information, see :ref:`ksql-persistence-wrap-single-values`.
 .. important:: KSQL treats ``null` keys and values as a special case. We recommended avoiding
                unwrapped single-field schemas if the field can have a ``null`` value.
 
-A ``null`` value in a table's topic is treated as a tombstone, used to indicate a row has been
+A ``null`` value in a table's topic is treated as a tombstone, which indicates that a row has been
 removed. If a table's source topic has an unwrapped single-field key schema and the value is
 ``null``, it be treated as a tombstone, resulting in any previous value for the key being removed
 from the table.

--- a/docs/developer-guide/serialization.rst
+++ b/docs/developer-guide/serialization.rst
@@ -144,7 +144,7 @@ If a statement doesn't set the value wrapping explicitly, KSQL uses the system
 default, defined by ``ksql.persistence.wrap.single.values``. You can change the system default.
 For more information, see :ref:`ksql-persistence-wrap-single-values`.
 
-.. important:: KSQL treats ``null` keys and values as a special case. It is recommended that
+.. important:: KSQL treats ``null` keys and values as a special case. We recommended avoiding
                unwrapped single-field schemas are avoided if the field can have a ``null`` value.
 
 A ``null`` value in a table's topic is treated as a tombstone, used to indicate a row has been

--- a/docs/developer-guide/serialization.rst
+++ b/docs/developer-guide/serialization.rst
@@ -154,7 +154,7 @@ from the table.
 
 A ``null`` key or value in a stream's topic is ignored when the stream is part of a join.
 A ``null`` key in a table's topic is treated as a tombstone, and a ``null`` value is
-ignored, when the table is part of a join,
+ignored when the table is part of a join.
 
 Care should be taken when dealing with unwrapped single-field schemas to ensure any ``null`` key or
 value has the desired result.

--- a/docs/developer-guide/serialization.rst
+++ b/docs/developer-guide/serialization.rst
@@ -83,7 +83,7 @@ For more information, see :ref:`ksql-persistence-wrap-single-values`.
 .. important:: KSQL treats ``null` keys and values as a special case. We recommend avoiding
                unwrapped single-field schemas if the field can have a ``null`` value.
 
-A ``null`` value in a table's topic is treated as a tombstone, used to indicate a row has been
+A ``null`` value in a table's topic is treated as a tombstone, which indicates that a row has been
 removed. If a table's source topic has an unwrapped single-field key schema and the value is
 ``null``, it's treated as a tombstone, resulting in any previous value for the key being removed
 from the table.

--- a/docs/developer-guide/serialization.rst
+++ b/docs/developer-guide/serialization.rst
@@ -88,7 +88,7 @@ removed. If a table's source topic has an unwrapped single-field key schema and 
 ``null``, it be treated as a tombstone, resulting in any previous value for the key being removed
 from the table.
 
-A ``null`` key or value in a stream's topic will be ignored when the stream is part of a join.
+A ``null`` key or value in a stream's topic is ignored when the stream is part of a join.
 A ``null`` key in a table's topic will be treated as a tombstone and a ``null` value will be
 ignored, when the table is part of a join,
 

--- a/docs/developer-guide/serialization.rst
+++ b/docs/developer-guide/serialization.rst
@@ -85,7 +85,7 @@ For more information, see :ref:`ksql-persistence-wrap-single-values`.
 
 A ``null`` value in a table's topic is treated as a tombstone, used to indicate a row has been
 removed. If a table's source topic has an unwrapped single-field key schema and the value is
-``null``, it be treated as a tombstone, resulting in any previous value for the key being removed
+``null``, it's treated as a tombstone, resulting in any previous value for the key being removed
 from the table.
 
 A ``null`` key or value in a stream's topic is ignored when the stream is part of a join.

--- a/docs/developer-guide/serialization.rst
+++ b/docs/developer-guide/serialization.rst
@@ -80,6 +80,21 @@ If a statement doesn't set the value wrapping explicitly, KSQL uses the system
 default, defined by ``ksql.persistence.wrap.single.values``. You can change the system default.
 For more information, see :ref:`ksql-persistence-wrap-single-values`.
 
+.. important:: KSQL treats ``null` keys and values as a special case. It is recommended that
+               unwrapped single-field schemas are avoided if the field can have a ``null`` value.
+
+A ``null`` value in a table's topic is treated as a tombstone, used to indicate a row has been
+removed. If a table's source topic has an unwrapped single-field key schema and the value is
+``null``, it be treated as a tombstone, resulting in any previous value for the key being removed
+from the table.
+
+A ``null`` key or value in a stream's topic will be ignored when the stream is part of a join.
+A ``null`` key in a table's topic will be treated as a tombstone and a ``null` value will be
+ignored, when the table is part of a join,
+
+Care should be taken when dealing with unwrapped single-field schemas to ensure any ``null`` key or
+value has the desired result.
+
 Controlling serialization of single fields
 ==========================================
 
@@ -128,6 +143,21 @@ For example,
 If a statement doesn't set the value wrapping explicitly, KSQL uses the system
 default, defined by ``ksql.persistence.wrap.single.values``. You can change the system default.
 For more information, see :ref:`ksql-persistence-wrap-single-values`.
+
+.. important:: KSQL treats ``null` keys and values as a special case. It is recommended that
+               unwrapped single-field schemas are avoided if the field can have a ``null`` value.
+
+A ``null`` value in a table's topic is treated as a tombstone, used to indicate a row has been
+removed. If a table's source topic has an unwrapped single-field key schema and the value is
+``null``, it be treated as a tombstone, resulting in any previous value for the key being removed
+from the table.
+
+A ``null`` key or value in a stream's topic will be ignored when the stream is part of a join.
+A ``null`` key in a table's topic will be treated as a tombstone and a ``null` value will be
+ignored, when the table is part of a join,
+
+Care should be taken when dealing with unwrapped single-field schemas to ensure any ``null`` key or
+value has the desired result.
 
 Single-field serialization examples
 ===================================

--- a/docs/developer-guide/serialization.rst
+++ b/docs/developer-guide/serialization.rst
@@ -89,7 +89,7 @@ removed. If a table's source topic has an unwrapped single-field key schema and 
 from the table.
 
 A ``null`` key or value in a stream's topic is ignored when the stream is part of a join.
-A ``null`` key in a table's topic will be treated as a tombstone and a ``null` value will be
+A ``null`` key in a table's topic is treated as a tombstone, and a ``null`` value is
 ignored, when the table is part of a join,
 
 Care should be taken when dealing with unwrapped single-field schemas to ensure any ``null`` key or

--- a/docs/developer-guide/serialization.rst
+++ b/docs/developer-guide/serialization.rst
@@ -90,7 +90,7 @@ from the table.
 
 A ``null`` key or value in a stream's topic is ignored when the stream is part of a join.
 A ``null`` key in a table's topic is treated as a tombstone, and a ``null`` value is
-ignored, when the table is part of a join,
+ignored when the table is part of a join.
 
 Care should be taken when dealing with unwrapped single-field schemas to ensure any ``null`` key or
 value has the desired result.

--- a/docs/developer-guide/serialization.rst
+++ b/docs/developer-guide/serialization.rst
@@ -145,7 +145,7 @@ default, defined by ``ksql.persistence.wrap.single.values``. You can change the 
 For more information, see :ref:`ksql-persistence-wrap-single-values`.
 
 .. important:: KSQL treats ``null` keys and values as a special case. We recommended avoiding
-               unwrapped single-field schemas are avoided if the field can have a ``null`` value.
+               unwrapped single-field schemas if the field can have a ``null`` value.
 
 A ``null`` value in a table's topic is treated as a tombstone, used to indicate a row has been
 removed. If a table's source topic has an unwrapped single-field key schema and the value is

--- a/docs/developer-guide/serialization.rst
+++ b/docs/developer-guide/serialization.rst
@@ -92,7 +92,7 @@ A ``null`` key or value in a stream's topic is ignored when the stream is part o
 A ``null`` key in a table's topic is treated as a tombstone, and a ``null`` value is
 ignored when the table is part of a join.
 
-Care should be taken when dealing with unwrapped single-field schemas to ensure any ``null`` key or
+When you have an unwrapped single-field schema, ensure that any ``null`` key or
 value has the desired result.
 
 Controlling serialization of single fields

--- a/docs/developer-guide/serialization.rst
+++ b/docs/developer-guide/serialization.rst
@@ -153,7 +153,7 @@ removed. If a table's source topic has an unwrapped single-field key schema and 
 from the table.
 
 A ``null`` key or value in a stream's topic is ignored when the stream is part of a join.
-A ``null`` key in a table's topic will be treated as a tombstone and a ``null` value will be
+A ``null`` key in a table's topic is treated as a tombstone, and a ``null`` value is
 ignored, when the table is part of a join,
 
 Care should be taken when dealing with unwrapped single-field schemas to ensure any ``null`` key or

--- a/docs/developer-guide/serialization.rst
+++ b/docs/developer-guide/serialization.rst
@@ -89,7 +89,7 @@ removed. If a table's source topic has an unwrapped single-field key schema and 
 from the table.
 
 A ``null`` key or value in a stream's topic is ignored when the stream is part of a join.
-A ``null`` key in a table's topic is treated as a tombstone, and a ``null`` value is
+A ``null`` value in a table's topic is treated as a tombstone, and a ``null`` key is
 ignored when the table is part of a join.
 
 When you have an unwrapped single-field schema, ensure that any ``null`` key or
@@ -153,7 +153,7 @@ removed. If a table's source topic has an unwrapped single-field key schema and 
 from the table.
 
 A ``null`` key or value in a stream's topic is ignored when the stream is part of a join.
-A ``null`` key in a table's topic is treated as a tombstone, and a ``null`` value is
+A ``null`` value in a table's topic is treated as a tombstone, and a ``null`` key is
 ignored when the table is part of a join.
 
 When you have an unwrapped single-field schema, ensure that any ``null`` key or

--- a/docs/developer-guide/serialization.rst
+++ b/docs/developer-guide/serialization.rst
@@ -81,7 +81,7 @@ default, defined by ``ksql.persistence.wrap.single.values``. You can change the 
 For more information, see :ref:`ksql-persistence-wrap-single-values`.
 
 .. important:: KSQL treats ``null` keys and values as a special case. We recommend avoiding
-               unwrapped single-field schemas are avoided if the field can have a ``null`` value.
+               unwrapped single-field schemas if the field can have a ``null`` value.
 
 A ``null`` value in a table's topic is treated as a tombstone, used to indicate a row has been
 removed. If a table's source topic has an unwrapped single-field key schema and the value is

--- a/docs/developer-guide/serialization.rst
+++ b/docs/developer-guide/serialization.rst
@@ -80,7 +80,7 @@ If a statement doesn't set the value wrapping explicitly, KSQL uses the system
 default, defined by ``ksql.persistence.wrap.single.values``. You can change the system default.
 For more information, see :ref:`ksql-persistence-wrap-single-values`.
 
-.. important:: KSQL treats ``null` keys and values as a special case. It is recommended that
+.. important:: KSQL treats ``null` keys and values as a special case. We recommend avoiding
                unwrapped single-field schemas are avoided if the field can have a ``null`` value.
 
 A ``null`` value in a table's topic is treated as a tombstone, used to indicate a row has been

--- a/docs/developer-guide/serialization.rst
+++ b/docs/developer-guide/serialization.rst
@@ -156,7 +156,7 @@ A ``null`` key or value in a stream's topic is ignored when the stream is part o
 A ``null`` key in a table's topic is treated as a tombstone, and a ``null`` value is
 ignored when the table is part of a join.
 
-Care should be taken when dealing with unwrapped single-field schemas to ensure any ``null`` key or
+When you have an unwrapped single-field schema, ensure that any ``null`` key or
 value has the desired result.
 
 Single-field serialization examples

--- a/docs/developer-guide/serialization.rst
+++ b/docs/developer-guide/serialization.rst
@@ -152,7 +152,7 @@ removed. If a table's source topic has an unwrapped single-field key schema and 
 ``null``, it's treated as a tombstone, resulting in any previous value for the key being removed
 from the table.
 
-A ``null`` key or value in a stream's topic will be ignored when the stream is part of a join.
+A ``null`` key or value in a stream's topic is ignored when the stream is part of a join.
 A ``null`` key in a table's topic will be treated as a tombstone and a ``null` value will be
 ignored, when the table is part of a join,
 

--- a/docs/developer-guide/syntax-reference.rst
+++ b/docs/developer-guide/syntax-reference.rst
@@ -396,7 +396,7 @@ The WITH clause supports the following properties:
 |                         | :ref:`ksql_single_field_wrapping`.                                                         |
 |                         |                                                                                            |
 |                         | Note: Supplying this property for formats that do not support wrapping, for example        |
-|                         | `DELIMITED`, or when the value schema has multiple fields, will result in an error.        |
+|                         | ``DELIMITED``, or when the value schema has multiple fields, will result in an error.      |
 +-------------------------+--------------------------------------------------------------------------------------------+
 | WINDOW_TYPE             | By default, the topic is assumed to contain non-windowed data. If the data is windowed,    |
 |                         | i.e. was created using KSQL using a query that contains a ``WINDOW`` clause, then the      |

--- a/docs/developer-guide/syntax-reference.rst
+++ b/docs/developer-guide/syntax-reference.rst
@@ -511,7 +511,7 @@ The WITH clause supports the following properties:
 |                         | :ref:`ksql_single_field_wrapping`.                                                         |
 |                         |                                                                                            |
 |                         | Note: Supplying this property for formats that do not support wrapping, for example        |
-|                         | `DELIMITED`, or when the value schema has multiple fields, will result in an error.        |
+|                         | ``DELIMITED``, or when the value schema has multiple fields, will result in an error.      |
 +-------------------------+--------------------------------------------------------------------------------------------+
 | WINDOW_TYPE             | By default, the topic is assumed to contain non-windowed data. If the data is windowed,    |
 |                         | i.e. was created using KSQL using a query that contains a ``WINDOW`` clause, then the      |

--- a/docs/developer-guide/syntax-reference.rst
+++ b/docs/developer-guide/syntax-reference.rst
@@ -391,11 +391,12 @@ The WITH clause supports the following properties:
 |                         | If not supplied, the system default, defined by :ref:`ksql-persistence-wrap-single-values` |
 |                         | and defaulting to ``true```, is used.                                                      |
 |                         |                                                                                            |
-|                         | Note: Supplying this property for formats that do not support wrapping, for example        |
-|                         | `DELIMITED`, will result in an error                                                       |
+|                         | Note: ``null`` values have special meaning in KSQL. Care should be taken when dealing with |
+|                         | single-field schemas where the value can be ``null`. For more information, see             |
+|                         | :ref:`ksql_single_field_wrapping`.                                                         |
 |                         |                                                                                            |
-|                         | Note: Supplying this property when the value schema has multiple fields will result in an  |
-|                         | error.                                                                                     |
+|                         | Note: Supplying this property for formats that do not support wrapping, for example        |
+|                         | `DELIMITED`, or when the value schema has multiple fields, will result in an error.        |
 +-------------------------+--------------------------------------------------------------------------------------------+
 | WINDOW_TYPE             | By default, the topic is assumed to contain non-windowed data. If the data is windowed,    |
 |                         | i.e. was created using KSQL using a query that contains a ``WINDOW`` clause, then the      |
@@ -505,11 +506,12 @@ The WITH clause supports the following properties:
 |                         | If not supplied, the system default, defined by :ref:`ksql-persistence-wrap-single-values` |
 |                         | and defaulting to ``true```, is used.                                                      |
 |                         |                                                                                            |
-|                         | Note: Supplying this property for formats that do not support wrapping, for example        |
-|                         | `DELIMITED`, will result in an error                                                       |
+|                         | Note: ``null`` values have special meaning in KSQL. Care should be taken when dealing with |
+|                         | single-field schemas where the value can be ``null`. For more information, see             |
+|                         | :ref:`ksql_single_field_wrapping`.                                                         |
 |                         |                                                                                            |
-|                         | Note: Supplying this property when the value schema has multiple fields will result in an  |
-|                         | error.                                                                                     |
+|                         | Note: Supplying this property for formats that do not support wrapping, for example        |
+|                         | `DELIMITED`, or when the value schema has multiple fields, will result in an error.        |
 +-------------------------+--------------------------------------------------------------------------------------------+
 | WINDOW_TYPE             | By default, the topic is assumed to contain non-windowed data. If the data is windowed,    |
 |                         | i.e. was created using KSQL using a query that contains a ``WINDOW`` clause, then the      |
@@ -638,11 +640,12 @@ The WITH clause for the result supports the following properties:
 |                         | If not supplied, the system default, defined by :ref:`ksql-persistence-wrap-single-values` and       |
 |                         | defaulting to ``true```, is used.                                                                    |
 |                         |                                                                                                      |
-|                         | Note: Supplying this property for formats that do not support wrapping, for example                  |
-|                         | `DELIMITED`, will result in an error                                                                 |
+|                         | Note: ``null`` values have special meaning in KSQL. Care should be taken when dealing with           |
+|                         | single-field schemas where the value can be ``null`. For more information, see                       |
+|                         | :ref:`ksql_single_field_wrapping`.                                                                   |
 |                         |                                                                                                      |
-|                         | Note: Supplying this property when the value schema has multiple fields will result in an            |
-|                         | error.                                                                                               |
+|                         | Note: Supplying this property for formats that do not support wrapping, for example                  |
+|                         | `DELIMITED`, or when the value schema has multiple fields, will result in an error.                  |
 +-------------------------+------------------------------------------------------------------------------------------------------+
 
 .. include:: ../includes/ksql-includes.rst
@@ -742,11 +745,12 @@ The WITH clause supports the following properties:
 |                         | If not supplied, the system default, defined by :ref:`ksql-persistence-wrap-single-values` and       |
 |                         | defaulting to ``true```, is used.                                                                    |
 |                         |                                                                                                      |
-|                         | Note: Supplying this property for formats that do not support wrapping, for example                  |
-|                         | `DELIMITED`, will result in an error                                                                 |
+|                         | Note: ``null`` values have special meaning in KSQL. Care should be taken when dealing with           |
+|                         | single-field schemas where the value can be ``null`. For more information, see                       |
+|                         | :ref:`ksql_single_field_wrapping`.                                                                   |
 |                         |                                                                                                      |
-|                         | Note: Supplying this property when the value schema has multiple fields will result in an            |
-|                         | error.                                                                                               |
+|                         | Note: Supplying this property for formats that do not support wrapping, for example                  |
+|                         | `DELIMITED`, or when the value schema has multiple fields, will result in an error.                  |
 +-------------------------+------------------------------------------------------------------------------------------------------+
 
 .. include:: ../includes/ksql-includes.rst

--- a/docs/developer-guide/syntax-reference.rst
+++ b/docs/developer-guide/syntax-reference.rst
@@ -645,7 +645,7 @@ The WITH clause for the result supports the following properties:
 |                         | :ref:`ksql_single_field_wrapping`.                                                                   |
 |                         |                                                                                                      |
 |                         | Note: Supplying this property for formats that do not support wrapping, for example                  |
-|                         | `DELIMITED`, or when the value schema has multiple fields, will result in an error.                  |
+|                         | ``DELIMITED``, or when the value schema has multiple fields, will result in an error.                |
 +-------------------------+------------------------------------------------------------------------------------------------------+
 
 .. include:: ../includes/ksql-includes.rst

--- a/docs/developer-guide/syntax-reference.rst
+++ b/docs/developer-guide/syntax-reference.rst
@@ -750,7 +750,7 @@ The WITH clause supports the following properties:
 |                         | :ref:`ksql_single_field_wrapping`.                                                                   |
 |                         |                                                                                                      |
 |                         | Note: Supplying this property for formats that do not support wrapping, for example                  |
-|                         | `DELIMITED`, or when the value schema has multiple fields, will result in an error.                  |
+|                         | ``DELIMITED``, or when the value schema has multiple fields, will result in an error.                |
 +-------------------------+------------------------------------------------------------------------------------------------------+
 
 .. include:: ../includes/ksql-includes.rst


### PR DESCRIPTION
### Description 

Following on from the discussion in the [`WRAP_SINGLE_VALUE` PR](https://github.com/confluentinc/ksql/pull/2899#issuecomment-498827407), this PR adds documentation around the `null` handling of unwrapped single values.

### Testing done 

Docs only change.

### Reviewer checklist
- [ ] Ensure docs are updated if necessary. (eg. if a user visible feature is being added or changed).
- [ ] Ensure relevant issues are linked (description should include text like "Fixes #<issue number>")

