### PR TITLE
Minor: Move serde option manipulation into one place.

### DIFF
--- a/ksql-engine/src/main/java/io/confluent/ksql/analyzer/Analyzer.java
+++ b/ksql-engine/src/main/java/io/confluent/ksql/analyzer/Analyzer.java
@@ -18,6 +18,7 @@ package io.confluent.ksql.analyzer;
 import static java.lang.String.format;
 import static java.util.Objects.requireNonNull;
 
+import com.google.common.annotations.VisibleForTesting;
 import com.google.common.collect.ImmutableSet;
 import io.confluent.ksql.analyzer.Analysis.Into;
 import io.confluent.ksql.ddl.DdlConfig;
@@ -25,7 +26,6 @@ import io.confluent.ksql.metastore.MetaStore;
 import io.confluent.ksql.metastore.model.DataSource;
 import io.confluent.ksql.metastore.model.KsqlTopic;
 import io.confluent.ksql.parser.DefaultTraversalVisitor;
-import io.confluent.ksql.parser.LiteralUtil;
 import io.confluent.ksql.parser.tree.AliasedRelation;
 import io.confluent.ksql.parser.tree.AllColumns;
 import io.confluent.ksql.parser.tree.Cast;
@@ -57,16 +57,17 @@ import io.confluent.ksql.serde.KsqlSerdeFactories;
 import io.confluent.ksql.serde.KsqlSerdeFactory;
 import io.confluent.ksql.serde.SerdeFactories;
 import io.confluent.ksql.serde.SerdeOption;
+import io.confluent.ksql.serde.SerdeOptions;
 import io.confluent.ksql.util.KsqlConstants;
 import io.confluent.ksql.util.KsqlException;
 import io.confluent.ksql.util.Pair;
 import io.confluent.ksql.util.SchemaUtil;
 import io.confluent.ksql.util.StringUtil;
+import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
 import java.util.Set;
-import java.util.function.Predicate;
 import org.apache.kafka.common.serialization.Serdes;
 import org.apache.kafka.connect.data.Field;
 
@@ -89,6 +90,7 @@ class Analyzer {
   private final MetaStore metaStore;
   private final String topicPrefix;
   private final SerdeFactories serdeFactories;
+  private final SerdeOptionsSupplier serdeOptionsSupplier;
   private final Set<SerdeOption> defaultSerdeOptions;
 
   /**
@@ -101,20 +103,28 @@ class Analyzer {
       final String topicPrefix,
       final Set<SerdeOption> defaultSerdeOptions
   ) {
-    this(metaStore, topicPrefix, defaultSerdeOptions, new KsqlSerdeFactories());
+    this(
+        metaStore,
+        topicPrefix,
+        defaultSerdeOptions,
+        new KsqlSerdeFactories(),
+        SerdeOptions::buildForCreateAsStatement);
   }
 
-  private Analyzer(
+  @VisibleForTesting
+  Analyzer(
       final MetaStore metaStore,
       final String topicPrefix,
       final Set<SerdeOption> defaultSerdeOptions,
-      final SerdeFactories serdeFactories
+      final SerdeFactories serdeFactories,
+      final SerdeOptionsSupplier serdeOptionsSupplier
   ) {
     this.metaStore = requireNonNull(metaStore, "metaStore");
     this.topicPrefix = requireNonNull(topicPrefix, "topicPrefix");
     this.defaultSerdeOptions = ImmutableSet
         .copyOf(requireNonNull(defaultSerdeOptions, "defaultSerdeOptions"));
     this.serdeFactories = requireNonNull(serdeFactories, "serdeFactories");
+    this.serdeOptionsSupplier = requireNonNull(serdeOptionsSupplier, "serdeOptionsSupplier");
   }
 
   /**
@@ -152,16 +162,16 @@ class Analyzer {
       sink.ifPresent(s -> analyzeNonStdOutSink(s, sqlExpression));
     }
 
-    private void setIntoProperties(final Map<String, Expression> sinkProperties) {
-      validateWithClause(sinkProperties.keySet());
+    private void setIntoProperties(final Sink sink) {
+      validateWithClause(sink.getProperties().keySet());
 
-      setIntoTopicName(sinkProperties);
+      setIntoTopicName(sink.getProperties());
 
-      setPartitionBy(sinkProperties);
+      setPartitionBy(sink.getProperties());
 
-      setIntoTimestampColumnAndFormat(sinkProperties);
+      setIntoTimestampColumnAndFormat(sink.getProperties());
 
-      setSerdeOptions(sinkProperties);
+      setSerdeOptions(sink);
     }
 
     private void setPartitionBy(final Map<String, Expression> properties) {
@@ -181,7 +191,7 @@ class Analyzer {
         final Sink sink,
         final String sqlExpression
     ) {
-      setIntoProperties(sink.getProperties());
+      setIntoProperties(sink);
 
       if (!sink.shouldCreateSink()) {
         final DataSource<?> existing = metaStore.getSource(sink.getName());
@@ -284,36 +294,17 @@ class Analyzer {
       }
     }
 
-    private void setSerdeOptions(final Map<String, Expression> properties) {
-      final boolean singleField = analysis.getSelectExpressionAlias().stream()
-          .filter(((Predicate<String>)KsqlSchema::isImplicitColumnName).negate())
-          .count() == 1;
+    private void setSerdeOptions(final Sink sink) {
+      final List<String> columnNames = analysis.getSelectExpressionAlias();
 
-      final Expression exp = properties.get(DdlConfig.WRAP_SINGLE_VALUE);
-      if (exp == null) {
-        if (singleField) {
-          analysis.setSerdeOptions(defaultSerdeOptions);
-        }
-        return;
-      }
+      final Format valueFormat = getValueFormat(sink);
 
-      if (!singleField) {
-        throw new KsqlException("'" + DdlConfig.WRAP_SINGLE_VALUE
-            + "' is only valid for single-field value schemas");
-      }
-
-      if (!(exp instanceof Literal)) {
-        throw new KsqlException(DdlConfig.WRAP_SINGLE_VALUE
-            + " set in the WITH clause must be set to a literal");
-      }
-
-      final ImmutableSet.Builder<SerdeOption> options = ImmutableSet.builder();
-
-      if (!LiteralUtil.toBoolean(((Literal) exp), DdlConfig.WRAP_SINGLE_VALUE)) {
-        options.add(SerdeOption.UNWRAP_SINGLE_VALUES);
-      }
-
-      analysis.setSerdeOptions(options.build());
+      analysis.setSerdeOptions(serdeOptionsSupplier.build(
+          columnNames,
+          sink.getProperties(),
+          valueFormat,
+          defaultSerdeOptions
+      ));
     }
 
     private void validateWithClause(final Set<String> withClauseVariables) {
@@ -627,5 +618,16 @@ class Analyzer {
     private void analyzeHaving(final Node node) {
       analysis.setHavingExpression((Expression) node);
     }
+  }
+
+  @FunctionalInterface
+  interface SerdeOptionsSupplier {
+
+    Set<SerdeOption> build(
+        List<String> columnNames,
+        Map<String, Expression> properties,
+        Format valueFormat,
+        Set<SerdeOption> singleFieldDefaults
+    );
   }
 }

--- a/ksql-engine/src/main/java/io/confluent/ksql/engine/QueryEngine.java
+++ b/ksql-engine/src/main/java/io/confluent/ksql/engine/QueryEngine.java
@@ -15,7 +15,6 @@
 
 package io.confluent.ksql.engine;
 
-import com.google.common.collect.ImmutableSet;
 import io.confluent.ksql.analyzer.AggregateAnalysisResult;
 import io.confluent.ksql.analyzer.Analysis;
 import io.confluent.ksql.analyzer.QueryAnalyzer;
@@ -31,6 +30,7 @@ import io.confluent.ksql.planner.LogicalPlanNode;
 import io.confluent.ksql.planner.LogicalPlanner;
 import io.confluent.ksql.planner.plan.OutputNode;
 import io.confluent.ksql.serde.SerdeOption;
+import io.confluent.ksql.serde.SerdeOptions;
 import io.confluent.ksql.services.ServiceContext;
 import io.confluent.ksql.statement.ConfiguredStatement;
 import io.confluent.ksql.util.KsqlConfig;
@@ -149,7 +149,7 @@ class QueryEngine {
   ) {
     final String outputPrefix = config.getString(KsqlConfig.KSQL_OUTPUT_TOPIC_NAME_PREFIX_CONFIG);
 
-    final Set<SerdeOption> defaultSerdeOptions = buildDefaultSerdeOptions(config);
+    final Set<SerdeOption> defaultSerdeOptions = SerdeOptions.buildDefaults(config);
 
     final QueryAnalyzer queryAnalyzer =
         new QueryAnalyzer(metaStore, outputPrefix, defaultSerdeOptions);
@@ -158,15 +158,5 @@ class QueryEngine {
     final AggregateAnalysisResult aggAnalysis = queryAnalyzer.analyzeAggregate(query, analysis);
 
     return new LogicalPlanner(analysis, aggAnalysis, metaStore).buildPlan();
-  }
-
-  private static Set<SerdeOption> buildDefaultSerdeOptions(final KsqlConfig config) {
-    final ImmutableSet.Builder<SerdeOption> options = ImmutableSet.builder();
-
-    if (!config.getBoolean(KsqlConfig.KSQL_WRAP_SINGLE_VALUES)) {
-      options.add(SerdeOption.UNWRAP_SINGLE_VALUES);
-    }
-
-    return ImmutableSet.copyOf(options.build());
   }
 }

--- a/ksql-engine/src/main/java/io/confluent/ksql/serde/SerdeOptions.java
+++ b/ksql-engine/src/main/java/io/confluent/ksql/serde/SerdeOptions.java
@@ -1,0 +1,147 @@
+/*
+ * Copyright 2019 Confluent Inc.
+ *
+ * Licensed under the Confluent Community License (the "License"); you may not use
+ * this file except in compliance with the License.  You may obtain a copy of the
+ * License at
+ *
+ * http://www.confluent.io/confluent-community-license
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package io.confluent.ksql.serde;
+
+import com.google.common.collect.ImmutableSet;
+import io.confluent.ksql.ddl.DdlConfig;
+import io.confluent.ksql.parser.LiteralUtil;
+import io.confluent.ksql.parser.tree.CreateSourceProperties;
+import io.confluent.ksql.parser.tree.Expression;
+import io.confluent.ksql.parser.tree.Literal;
+import io.confluent.ksql.schema.ksql.KsqlSchema;
+import io.confluent.ksql.util.KsqlConfig;
+import io.confluent.ksql.util.KsqlException;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.function.Predicate;
+
+/**
+ * Factory / Util class for building the {@link SerdeOption} sets required by the engine.
+ */
+public final class SerdeOptions {
+
+  private SerdeOptions() {
+  }
+
+  /**
+   * Build the default options to be used by statements, should not be explicitly provided.
+   *
+   * @param ksqlConfig the system config containing defaults.
+   * @return the set of default serde options.
+   */
+  public static Set<SerdeOption> buildDefaults(final KsqlConfig ksqlConfig) {
+    final ImmutableSet.Builder<SerdeOption> options = ImmutableSet.builder();
+
+    if (!ksqlConfig.getBoolean(KsqlConfig.KSQL_WRAP_SINGLE_VALUES)) {
+      options.add(SerdeOption.UNWRAP_SINGLE_VALUES);
+    }
+
+    return ImmutableSet.copyOf(options.build());
+  }
+
+  /**
+   * Build serde options for {@code `CREATE STREAM`} and {@code `CREATE TABLE`} statements.
+   *
+   * @param schema the logical schema of the create statement.
+   * @param properties the WITH clause properties of the statement.
+   * @param ksqlConfig the system config, used to retrieve defaults.
+   * @return the set of serde options the statement defines.
+   */
+  public static Set<SerdeOption> buildForCreateStatement(
+      final KsqlSchema schema,
+      final CreateSourceProperties properties,
+      final KsqlConfig ksqlConfig
+  ) {
+    final Format valueFormat = properties.getValueFormat();
+
+    final ImmutableSet.Builder<SerdeOption> options = ImmutableSet.builder();
+
+    final boolean singleValueField = schema.getSchema().fields().size() == 1;
+
+    if (properties.getWrapSingleValues().isPresent() && !singleValueField) {
+      throw new KsqlException("'" + DdlConfig.WRAP_SINGLE_VALUE + "' "
+          + "is only valid for single-field value schemas");
+    }
+
+    if (properties.getWrapSingleValues().isPresent() && !valueFormat.supportsUnwrapping()) {
+      throw new KsqlException("'" + DdlConfig.WRAP_SINGLE_VALUE + "' can not be used with format '"
+          + valueFormat + "' as it does not support wrapping");
+    }
+
+    final Set<SerdeOption> defaults = buildDefaults(ksqlConfig);
+
+    if (singleValueField && !properties.getWrapSingleValues()
+        .orElseGet(() -> !defaults.contains(SerdeOption.UNWRAP_SINGLE_VALUES))
+    ) {
+      options.add(SerdeOption.UNWRAP_SINGLE_VALUES);
+    }
+
+    return Collections.unmodifiableSet(options.build());
+  }
+
+  /**
+   * Build serde options for {@code `CREATE STREAM AS SELECT`} and {@code `CREATE TABLE AS SELECT`}
+   * statements.
+   *
+   * @param columnNames the set of column names in the schema.
+   * @param properties the WITH clause properties of the statement.
+   * @param valueFormat the format of the value.
+   * @param singleFieldDefaults the defaults for single fields.
+   * @return the set of serde options the statement defines.
+   */
+  public static Set<SerdeOption> buildForCreateAsStatement(
+      final List<String> columnNames,
+      final Map<String, Expression> properties,
+      final Format valueFormat,
+      final Set<SerdeOption> singleFieldDefaults
+  ) {
+    final boolean singleField = columnNames.stream()
+        .filter(((Predicate<String>) KsqlSchema::isImplicitColumnName).negate())
+        .count() == 1;
+
+    final Expression exp = properties.get(DdlConfig.WRAP_SINGLE_VALUE);
+    if (exp == null) {
+      return singleField && singleFieldDefaults.contains(SerdeOption.UNWRAP_SINGLE_VALUES)
+          ? SerdeOption.of(SerdeOption.UNWRAP_SINGLE_VALUES)
+          : SerdeOption.none();
+    }
+
+    if (!valueFormat.supportsUnwrapping()) {
+      throw new KsqlException("'" + DdlConfig.WRAP_SINGLE_VALUE + "' can not be used with format '"
+          + valueFormat + "' as it does not support wrapping");
+    }
+
+    if (!singleField) {
+      throw new KsqlException("'" + DdlConfig.WRAP_SINGLE_VALUE
+          + "' is only valid for single-field value schemas");
+    }
+
+    if (!(exp instanceof Literal)) {
+      throw new KsqlException(DdlConfig.WRAP_SINGLE_VALUE
+          + " set in the WITH clause must be set to a literal");
+    }
+
+    final ImmutableSet.Builder<SerdeOption> options = ImmutableSet.builder();
+
+    if (!LiteralUtil.toBoolean(((Literal) exp), DdlConfig.WRAP_SINGLE_VALUE)) {
+      options.add(SerdeOption.UNWRAP_SINGLE_VALUES);
+    }
+
+    return options.build();
+  }
+}

--- a/ksql-engine/src/test/java/io/confluent/ksql/analyzer/AnalyzerTest.java
+++ b/ksql-engine/src/test/java/io/confluent/ksql/analyzer/AnalyzerTest.java
@@ -20,14 +20,23 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.contains;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.not;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Iterables;
 import io.confluent.ksql.analyzer.Analysis.Into;
+import io.confluent.ksql.analyzer.Analyzer.SerdeOptionsSupplier;
 import io.confluent.ksql.ddl.DdlConfig;
 import io.confluent.ksql.function.InternalFunctionRegistry;
 import io.confluent.ksql.metastore.MetaStore;
 import io.confluent.ksql.metastore.MutableMetaStore;
+import io.confluent.ksql.metastore.SerdeFactory;
+import io.confluent.ksql.metastore.model.DataSource;
 import io.confluent.ksql.metastore.model.KeyField;
 import io.confluent.ksql.metastore.model.KsqlStream;
 import io.confluent.ksql.metastore.model.KsqlTopic;
@@ -35,10 +44,15 @@ import io.confluent.ksql.parser.KsqlParser.PreparedStatement;
 import io.confluent.ksql.parser.KsqlParserTestUtil;
 import io.confluent.ksql.parser.SqlFormatter;
 import io.confluent.ksql.parser.tree.CreateStreamAsSelect;
+import io.confluent.ksql.parser.tree.Expression;
 import io.confluent.ksql.parser.tree.Query;
+import io.confluent.ksql.parser.tree.Sink;
 import io.confluent.ksql.parser.tree.Statement;
+import io.confluent.ksql.parser.tree.StringLiteral;
 import io.confluent.ksql.planner.plan.JoinNode;
 import io.confluent.ksql.schema.ksql.KsqlSchema;
+import io.confluent.ksql.serde.Format;
+import io.confluent.ksql.serde.SerdeFactories;
 import io.confluent.ksql.serde.SerdeOption;
 import io.confluent.ksql.serde.avro.KsqlAvroSerdeFactory;
 import io.confluent.ksql.serde.json.KsqlJsonSerdeFactory;
@@ -47,6 +61,7 @@ import io.confluent.ksql.util.KsqlException;
 import io.confluent.ksql.util.MetaStoreFixture;
 import io.confluent.ksql.util.timestamp.MetadataTimestampExtractionPolicy;
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
 import java.util.stream.Collectors;
@@ -58,8 +73,12 @@ import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ExpectedException;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnitRunner;
 
 @SuppressWarnings("OptionalGetWithoutIsPresent")
+@RunWith(MockitoJUnitRunner.class)
 public class AnalyzerTest {
 
   private static final Set<SerdeOption> DEFAULT_SERDE_OPTIONS = SerdeOption.none();
@@ -70,10 +89,38 @@ public class AnalyzerTest {
   @Rule
   public final ExpectedException expectedException = ExpectedException.none();
 
+  @Mock
+  private SerdeFactories serdeFactories;
+  @Mock
+  private SerdeOptionsSupplier serdeOptiponsSupplier;
+  @Mock
+  private Sink sink;
+
+  private Query query;
+  private Analyzer analyzer;
+
+  @SuppressWarnings("unchecked")
   @Before
   public void init() {
     jsonMetaStore = MetaStoreFixture.getNewMetaStore(new InternalFunctionRegistry());
     avroMetaStore = MetaStoreFixture.getNewMetaStore(new InternalFunctionRegistry(), new KsqlAvroSerdeFactory(KsqlConstants.DEFAULT_AVRO_SCHEMA_FULL_NAME));
+
+    analyzer = new Analyzer(
+        jsonMetaStore,
+        "",
+        DEFAULT_SERDE_OPTIONS,
+        serdeFactories,
+        serdeOptiponsSupplier
+    );
+
+    final KsqlTopic sinkTopic = mock(KsqlTopic.class);
+    final DataSource<?> sinkSource = mock(DataSource.class);
+    when(sinkSource.getKsqlTopic()).thenReturn(sinkTopic);
+    final SerdeFactory<?> keySerdeFactory = mock(SerdeFactory.class);
+    when(sinkSource.getKeySerdeFactory()).thenReturn((SerdeFactory)keySerdeFactory);
+    when(sink.getName()).thenReturn("TEST0");
+
+    query = parseSingle("Select COL0, COL1 from TEST1;");
   }
 
   @Test
@@ -394,9 +441,11 @@ public class AnalyzerTest {
 
   @Test
   public void shouldFailIfExplicitNamespaceIsProvidedButEmpty() {
-    final String simpleQuery = "CREATE STREAM FOO WITH (VALUE_FORMAT='AVRO', VALUE_AVRO_SCHEMA_FULL_NAME='', KAFKA_TOPIC='TEST_TOPIC1') AS SELECT col0, col2, col3 FROM test1 WHERE col0 > 100;";
-    final List<Statement> statements = parse(simpleQuery, jsonMetaStore);
-    final CreateStreamAsSelect createStreamAsSelect = (CreateStreamAsSelect) statements.get(0);
+    final CreateStreamAsSelect createStreamAsSelect = parseSingle(
+        "CREATE STREAM FOO "
+            + "WITH (VALUE_FORMAT='AVRO', VALUE_AVRO_SCHEMA_FULL_NAME='', KAFKA_TOPIC='TEST_TOPIC1') "
+            + "AS SELECT col0, col2, col3 FROM test1 WHERE col0 > 100;");
+
     final Query query = createStreamAsSelect.getQuery();
 
     final Analyzer analyzer = new Analyzer(jsonMetaStore, "", DEFAULT_SERDE_OPTIONS);
@@ -408,101 +457,27 @@ public class AnalyzerTest {
   }
 
   @Test
-  public void shouldExtractExplicitUnwrappingOfSingleValue() {
+  public void shouldGetSerdeOptions() {
     // Given:
-    final CreateStreamAsSelect csas = parseSingle(
-        "CREATE STREAM FOO WITH (WRAP_SINGLE_VALUE=false) AS SELECT col0 FROM test1;");
+    final Set<SerdeOption> serdeOptions = ImmutableSet.of(SerdeOption.UNWRAP_SINGLE_VALUES);
+    when(serdeOptiponsSupplier.build(any(), any(), any(), any())).thenReturn(serdeOptions);
 
-    final Analyzer analyzer = new Analyzer(jsonMetaStore, "", SerdeOption.none());
+    final Map<String, Expression> properties =
+        ImmutableMap.of("VALUE_FORMAT", new StringLiteral("AVRO"));
+
+    when(sink.getProperties()).thenReturn(properties);
 
     // When:
-    final Analysis result = analyzer
-        .analyze("sql Exp", csas.getQuery(), Optional.of(csas.getSink()));
+    final Analysis result = analyzer.analyze("sql", query, Optional.of(sink));
 
     // Then:
-    assertThat(result.getSerdeOptions(), contains(SerdeOption.UNWRAP_SINGLE_VALUES));
-  }
+    verify(serdeOptiponsSupplier).build(
+        ImmutableList.of("COL0", "COL1"),
+        properties,
+        Format.AVRO,
+        DEFAULT_SERDE_OPTIONS);
 
-  @Test
-  public void shouldExtractExplicitWrappingOfSingleValue() {
-    // Given:
-    final CreateStreamAsSelect csas = parseSingle(
-        "CREATE STREAM FOO WITH (WRAP_SINGLE_VALUE=true) AS SELECT col0 FROM test1;");
-
-    final Analyzer analyzer = new Analyzer(jsonMetaStore, "", SerdeOption.of(SerdeOption.UNWRAP_SINGLE_VALUES));
-
-    // When:
-    final Analysis result = analyzer
-        .analyze("sql Exp", csas.getQuery(), Optional.of(csas.getSink()));
-
-    // Then:
-    assertThat(result.getSerdeOptions(), not(contains(SerdeOption.UNWRAP_SINGLE_VALUES)));
-  }
-
-  @Test
-  public void shouldDefaultToWrappedSingleValue() {
-    // Given:
-    final CreateStreamAsSelect csas = parseSingle(
-        "CREATE STREAM FOO AS SELECT col0 FROM test1;");
-
-    final Analyzer analyzer = new Analyzer(jsonMetaStore, "", DEFAULT_SERDE_OPTIONS);
-
-    // When:
-    final Analysis result = analyzer
-        .analyze("sql Exp", csas.getQuery(), Optional.of(csas.getSink()));
-
-    // Then:
-    assertThat(result.getSerdeOptions(), not(contains(SerdeOption.UNWRAP_SINGLE_VALUES)));
-  }
-
-  @Test
-  public void shouldNotSetValueWrappingByDefaultForMultField() {
-    // Given:
-    final CreateStreamAsSelect csas = parseSingle(
-        "CREATE STREAM FOO AS SELECT * FROM test1;");
-
-    final Analyzer analyzer = new Analyzer(jsonMetaStore, "", DEFAULT_SERDE_OPTIONS);
-
-    // When:
-    final Analysis result = analyzer
-        .analyze("sql Exp", csas.getQuery(), Optional.of(csas.getSink()));
-
-    // Then:
-    assertThat(result.getSerdeOptions(), is(ImmutableSet.of()));
-  }
-
-  @Test
-  public void shouldThrowIfWrapSingleValueSuppliedForMultiField() {
-    // Given:
-    final CreateStreamAsSelect csas = parseSingle(
-        "CREATE STREAM FOO WITH (WRAP_SINGLE_VALUE=true) AS SELECT * FROM test1;");
-
-    final Analyzer analyzer = new Analyzer(jsonMetaStore, "", DEFAULT_SERDE_OPTIONS);
-
-    // Then:
-    expectedException.expect(KsqlException.class);
-    expectedException.expectMessage(
-        "'WRAP_SINGLE_VALUE' is only valid for single-field value schemas");
-
-    // When:
-    analyzer.analyze("sql Exp", csas.getQuery(), Optional.of(csas.getSink()));
-  }
-
-  @Test
-  public void shouldThrowIfUnwrapSingleValueSuppliedForMultiField() {
-    // Given:
-    final CreateStreamAsSelect csas = parseSingle(
-        "CREATE STREAM FOO WITH (WRAP_SINGLE_VALUE=false) AS SELECT * FROM test1;");
-
-    final Analyzer analyzer = new Analyzer(jsonMetaStore, "", DEFAULT_SERDE_OPTIONS);
-
-    // Then:
-    expectedException.expect(KsqlException.class);
-    expectedException.expectMessage(
-        "'WRAP_SINGLE_VALUE' is only valid for single-field value schemas");
-
-    // When:
-    analyzer.analyze("sql Exp", csas.getQuery(), Optional.of(csas.getSink()));
+    assertThat(result.getSerdeOptions(), is(serdeOptions));
   }
 
   @SuppressWarnings("unchecked")

--- a/ksql-engine/src/test/java/io/confluent/ksql/serde/SerdeOptionsTest.java
+++ b/ksql-engine/src/test/java/io/confluent/ksql/serde/SerdeOptionsTest.java
@@ -1,0 +1,298 @@
+/*
+ * Copyright 2019 Confluent Inc.
+ *
+ * Licensed under the Confluent Community License (the "License"); you may not use
+ * this file except in compliance with the License.  You may obtain a copy of the
+ * License at
+ *
+ * http://www.confluent.io/confluent-community-license
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package io.confluent.ksql.serde;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.hasItem;
+import static org.hamcrest.Matchers.not;
+import static org.mockito.Mockito.when;
+
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+import io.confluent.ksql.ddl.DdlConfig;
+import io.confluent.ksql.parser.tree.BooleanLiteral;
+import io.confluent.ksql.parser.tree.CreateSourceProperties;
+import io.confluent.ksql.parser.tree.Expression;
+import io.confluent.ksql.parser.tree.StringLiteral;
+import io.confluent.ksql.schema.ksql.KsqlSchema;
+import io.confluent.ksql.util.KsqlConfig;
+import io.confluent.ksql.util.KsqlException;
+import io.confluent.ksql.util.SchemaUtil;
+import io.confluent.ksql.util.StringUtil;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
+import org.apache.kafka.connect.data.Schema;
+import org.apache.kafka.connect.data.SchemaBuilder;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnitRunner;
+
+@RunWith(MockitoJUnitRunner.class)
+public class SerdeOptionsTest {
+
+  private static final String TOPIC_NAME = "some topic";
+
+  private static final KsqlSchema SINGLE_FIELD_SCHEMA = KsqlSchema.of(SchemaBuilder
+      .struct()
+      .field("f0", Schema.OPTIONAL_INT64_SCHEMA)
+      .build());
+
+  private static final KsqlSchema MULTI_FIELD_SCHEMA = KsqlSchema.of(SchemaBuilder
+      .struct()
+      .field("f0", Schema.OPTIONAL_INT64_SCHEMA)
+      .field("f1", Schema.OPTIONAL_FLOAT64_SCHEMA)
+      .build());
+
+  private static final List<String> SINGLE_COLUMN_NAME = ImmutableList.of("bob");
+  private static final List<String> MULTI_FIELD_NAMES = ImmutableList.of("bob", "vic");
+
+  @Rule
+  public final ExpectedException expectedException = ExpectedException.none();
+
+  @Mock
+  private CreateSourceProperties withProperties;
+
+  private final Map<String, Expression> properties = new HashMap<>();
+  private final Set<SerdeOption> singleFieldDefaults = new HashSet<>();
+  private KsqlConfig ksqlConfig;
+
+  @Before
+  public void setUp() {
+    ksqlConfig = new KsqlConfig(ImmutableMap.of());
+
+    properties.clear();
+    singleFieldDefaults.clear();
+    when(withProperties.getValueFormat()).thenReturn(Format.JSON);
+  }
+
+  @Test
+  public void shouldBuildDefaultsWithWrappedSingleValuesByDefault() {
+    // Given:
+    ksqlConfig = new KsqlConfig(ImmutableMap.of(
+        KsqlConfig.KSQL_WRAP_SINGLE_VALUES, true
+    ));
+
+    // When:
+    final Set<SerdeOption> result = SerdeOptions.buildDefaults(ksqlConfig);
+
+    // Then:
+    assertThat(result, not(hasItem(SerdeOption.UNWRAP_SINGLE_VALUES)));
+  }
+
+  @Test
+  public void shouldBuildDefaultsWithWrappedSingleValuesIfConfigured() {
+    // When:
+    final Set<SerdeOption> result = SerdeOptions.buildDefaults(ksqlConfig);
+
+    // Then:
+    assertThat(result, not(hasItem(SerdeOption.UNWRAP_SINGLE_VALUES)));
+  }
+
+  @Test
+  public void shouldBuildDefaultsWithUnwrappedSingleValuesIfConfigured() {
+    // Given:
+    ksqlConfig = new KsqlConfig(ImmutableMap.of(
+        KsqlConfig.KSQL_WRAP_SINGLE_VALUES, false
+    ));
+
+    // When:
+    final Set<SerdeOption> result = SerdeOptions.buildDefaults(ksqlConfig);
+
+    // Then:
+    assertThat(result, hasItem(SerdeOption.UNWRAP_SINGLE_VALUES));
+  }
+
+  @Test
+  public void shouldGetSingleValueWrappingFromPropertiesBeforeConfigForCreateStatement() {
+    // Given:
+    ksqlConfig = new KsqlConfig(ImmutableMap.of(
+        KsqlConfig.KSQL_WRAP_SINGLE_VALUES, true
+    ));
+
+    when(withProperties.getWrapSingleValues()).thenReturn(Optional.of(false));
+
+    // When:
+    final Set<SerdeOption> result = SerdeOptions
+        .buildForCreateStatement(SINGLE_FIELD_SCHEMA, withProperties, ksqlConfig);
+
+    // Then:
+    assertThat(result, hasItem(SerdeOption.UNWRAP_SINGLE_VALUES));
+  }
+
+  @Test
+  public void shouldGetSingleValueWrappingFromConfigForCreateStatement() {
+    // Given:
+    ksqlConfig = new KsqlConfig(ImmutableMap.of(
+        KsqlConfig.KSQL_WRAP_SINGLE_VALUES, false
+    ));
+
+    // When:
+    final Set<SerdeOption> result = SerdeOptions
+        .buildForCreateStatement(SINGLE_FIELD_SCHEMA, withProperties, ksqlConfig);
+
+    // Then:
+    assertThat(result, hasItem(SerdeOption.UNWRAP_SINGLE_VALUES));
+  }
+
+  @Test
+  public void shouldSingleValueWrappingFromDefaultConfigForCreateStatement() {
+    // When:
+    final Set<SerdeOption> result = SerdeOptions
+        .buildForCreateStatement(SINGLE_FIELD_SCHEMA, withProperties, ksqlConfig);
+
+    // Then:
+    assertThat(result, not(hasItem(SerdeOption.UNWRAP_SINGLE_VALUES)));
+  }
+
+  @Test
+  public void shouldNotGetSingleValueWrappingFromConfigForMultiFieldsForCreateStatement() {
+    // Given:
+    ksqlConfig = new KsqlConfig(ImmutableMap.of(
+        KsqlConfig.KSQL_WRAP_SINGLE_VALUES, false
+    ));
+
+    // When:
+    final Set<SerdeOption> result = SerdeOptions
+        .buildForCreateStatement(MULTI_FIELD_SCHEMA, withProperties, ksqlConfig);
+
+    // Then:
+    assertThat(result, not(hasItem(SerdeOption.UNWRAP_SINGLE_VALUES)));
+  }
+
+  @Test
+  public void shouldThrowIfWrapSingleValuePresentForMultiFieldForCreateStatement() {
+    // Given:
+    when(withProperties.getWrapSingleValues()).thenReturn(Optional.of(true));
+
+    // Then:
+    expectedException.expect(KsqlException.class);
+    expectedException.expectMessage(
+        "'WRAP_SINGLE_VALUE' is only valid for single-field value schemas");
+
+    // When:
+    SerdeOptions.buildForCreateStatement(MULTI_FIELD_SCHEMA, withProperties, ksqlConfig);
+  }
+
+  @Test
+  public void shouldThrowIfWrapSingleValuePresentForDelimitedForCreateStatement() {
+    // Given:
+    when(withProperties.getValueFormat()).thenReturn(Format.DELIMITED);
+    when(withProperties.getWrapSingleValues()).thenReturn(Optional.of(false));
+
+    // Then:
+    expectedException.expect(KsqlException.class);
+    expectedException.expectMessage(
+        "'WRAP_SINGLE_VALUE' can not be used with format 'DELIMITED' as it does not support wrapping");
+
+    // When:
+    SerdeOptions.buildForCreateStatement(SINGLE_FIELD_SCHEMA, withProperties, ksqlConfig);
+  }
+
+  @Test
+  public void shouldGetSingleValueWrappingFromPropertiesBeforeDefaultsForCreateAsStatement() {
+    // Given:
+    properties.put(DdlConfig.WRAP_SINGLE_VALUE, new BooleanLiteral("true"));
+    singleFieldDefaults.add(SerdeOption.UNWRAP_SINGLE_VALUES);
+
+    // When:
+    final Set<SerdeOption> result = SerdeOptions
+        .buildForCreateAsStatement(SINGLE_COLUMN_NAME, properties, Format.AVRO, singleFieldDefaults);
+
+    // Then:
+    assertThat(result, not(hasItem(SerdeOption.UNWRAP_SINGLE_VALUES)));
+  }
+
+  @Test
+  public void shouldGetSingleValueWrappingFromDefaultsForCreateAsStatement() {
+    // Given:
+    singleFieldDefaults.add(SerdeOption.UNWRAP_SINGLE_VALUES);
+
+    // When:
+    final Set<SerdeOption> result = SerdeOptions
+        .buildForCreateAsStatement(SINGLE_COLUMN_NAME, properties, Format.JSON, singleFieldDefaults);
+
+    // Then:
+    assertThat(result, hasItem(SerdeOption.UNWRAP_SINGLE_VALUES));
+  }
+
+  @Test
+  public void shouldNotGetSingleValueWrappingFromDefaultForMultiFieldsForCreateAsStatement() {
+    // Given:
+    singleFieldDefaults.add(SerdeOption.UNWRAP_SINGLE_VALUES);
+
+    // When:
+    final Set<SerdeOption> result = SerdeOptions
+        .buildForCreateAsStatement(MULTI_FIELD_NAMES, properties, Format.AVRO, singleFieldDefaults);
+
+    // Then:
+    assertThat(result, not(hasItem(SerdeOption.UNWRAP_SINGLE_VALUES)));
+  }
+
+  @Test
+  public void shouldThrowIfWrapSingleValuePresentForMultiFieldForCreateAsStatement() {
+    // Given:
+    properties.put(DdlConfig.WRAP_SINGLE_VALUE, new BooleanLiteral("true"));
+
+    // Then:
+    expectedException.expect(KsqlException.class);
+    expectedException.expectMessage(
+        "'WRAP_SINGLE_VALUE' is only valid for single-field value schemas");
+
+    // When:
+    SerdeOptions
+        .buildForCreateAsStatement(MULTI_FIELD_NAMES, properties, Format.JSON, singleFieldDefaults);
+  }
+
+  @Test
+  public void shouldIgnoreImplicitsWhenCountingColumns() {
+    // Given:
+    properties.put(DdlConfig.WRAP_SINGLE_VALUE, new BooleanLiteral("false"));
+
+    final List<String> columnNames =
+        ImmutableList.of("Bob", SchemaUtil.ROWKEY_NAME, SchemaUtil.ROWTIME_NAME);
+
+    // When:
+    final Set<SerdeOption> result = SerdeOptions
+        .buildForCreateAsStatement(columnNames, properties, Format.AVRO, singleFieldDefaults);
+
+    // Then:
+    assertThat(result, hasItem(SerdeOption.UNWRAP_SINGLE_VALUES));
+  }
+
+  @Test
+  public void shouldThrowIfWrapSingleValuePresentForDelimitedForCreateAsStatement() {
+    // Given:
+    properties.put(DdlConfig.VALUE_FORMAT_PROPERTY, new StringLiteral(Format.DELIMITED.toString()));
+    properties.put(DdlConfig.WRAP_SINGLE_VALUE, new BooleanLiteral("true"));
+
+    // Then:
+    expectedException.expect(KsqlException.class);
+    expectedException.expectMessage(
+        "'WRAP_SINGLE_VALUE' can not be used with format 'DELIMITED' as it does not support wrapping");
+
+    // When:
+    SerdeOptions
+        .buildForCreateAsStatement(SINGLE_COLUMN_NAME, properties, Format.DELIMITED, singleFieldDefaults);
+  }
+}


### PR DESCRIPTION
### Description 

Moves the building of sets of `SerdeOption`s into one place. This has pros and cons. But I think it makes the code around SerdeOptions a little easier to understand, find and test.  The con would be that if more areas are added that need to build serde options then this class grows, as its essentially a God class.

Thoughts? Is this an improvement or not?

### Testing done 

`mvn test`

### Reviewer checklist
- [ ] Ensure docs are updated if necessary. (eg. if a user visible feature is being added or changed).
- [ ] Ensure relevant issues are linked (description should include text like "Fixes #<issue number>")

