### PR TITLE
Using the correct props for the version checker in the headless mode.

### DIFF
--- a/ksql-rest-app/src/main/java/io/confluent/ksql/rest/server/StandaloneExecutor.java
+++ b/ksql-rest-app/src/main/java/io/confluent/ksql/rest/server/StandaloneExecutor.java
@@ -109,7 +109,7 @@ public class StandaloneExecutor implements Executable {
       processesQueryFile(readQueriesFile(queriesFile));
       showWelcomeMessage();
       final Properties properties = new Properties();
-      properties.putAll(configProperties);
+      ksqlConfig.originals().forEach((key, value) -> properties.put(key, value.toString()));
       versionCheckerAgent.start(KsqlModuleType.SERVER, properties);
     } catch (final Exception e) {
       log.error("Failed to start KSQL Server with query file: " + queriesFile, e);

--- a/ksql-rest-app/src/test/java/io/confluent/ksql/rest/server/StandaloneExecutorTest.java
+++ b/ksql-rest-app/src/test/java/io/confluent/ksql/rest/server/StandaloneExecutorTest.java
@@ -195,6 +195,7 @@ public class StandaloneExecutorTest {
     // When:
     standaloneExecutor.start();
 
+    // Then:
     verify(versionCheckerAgent).start(eq(KsqlModuleType.SERVER), captor.capture());
     assertThat(captor.getValue().getProperty("confluent.support.metrics.enable"), equalTo("false"));
     standaloneExecutor.stop();

--- a/ksql-rest-app/src/test/java/io/confluent/ksql/rest/server/StandaloneExecutorTest.java
+++ b/ksql-rest-app/src/test/java/io/confluent/ksql/rest/server/StandaloneExecutorTest.java
@@ -17,6 +17,8 @@ package io.confluent.ksql.rest.server;
 
 import static java.util.Collections.emptyList;
 import static java.util.Collections.emptyMap;
+import static org.hamcrest.CoreMatchers.equalTo;
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.Assert.fail;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyInt;
@@ -66,6 +68,7 @@ import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
+import java.util.Properties;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 import org.apache.kafka.test.TestUtils;
@@ -74,6 +77,7 @@ import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ExpectedException;
 import org.junit.runner.RunWith;
+import org.mockito.ArgumentCaptor;
 import org.mockito.InOrder;
 import org.mockito.Mock;
 import org.mockito.junit.MockitoJUnitRunner;
@@ -133,6 +137,7 @@ public class StandaloneExecutorTest {
   private Path queriesFile;
   private StandaloneExecutor standaloneExecutor;
 
+
   @Before
   public void before() throws IOException {
     queriesFile = Paths.get(TestUtils.tempFile().getPath());
@@ -171,6 +176,29 @@ public class StandaloneExecutorTest {
     standaloneExecutor.start();
 
     verify(versionCheckerAgent).start(eq(KsqlModuleType.SERVER), any());
+  }
+
+  @Test
+  public void shouldStartTheVersionCheckerAgentWithCorrectProperties() throws InterruptedException {
+    // Given:
+    final ArgumentCaptor<Properties> captor = ArgumentCaptor.forClass(Properties.class);
+    final StandaloneExecutor standaloneExecutor = new StandaloneExecutor(
+        serviceContext,
+        processingLogConfig,
+        new KsqlConfig(ImmutableMap.of("confluent.support.metrics.enable", false)),
+        ksqlEngine,
+        queriesFile.toString(),
+        udfLoader,
+        false,
+        versionCheckerAgent);
+
+    // When:
+    standaloneExecutor.start();
+
+    verify(versionCheckerAgent).start(eq(KsqlModuleType.SERVER), captor.capture());
+    assertThat(captor.getValue().getProperty("confluent.support.metrics.enable"), equalTo("false"));
+    standaloneExecutor.stop();
+    standaloneExecutor.join();
   }
 
   @Test


### PR DESCRIPTION
The version checker agent in the headless mode was picking the empty properties. This PR corrects this bug along with adding a test for it.
This will be merged after #2947 