### PR TITLE
Upcast checks should use SQL schema.

### DIFF
--- a/ksql-common/src/main/java/io/confluent/ksql/util/SchemaUtil.java
+++ b/ksql-common/src/main/java/io/confluent/ksql/util/SchemaUtil.java
@@ -31,9 +31,7 @@ import java.lang.reflect.Type;
 import java.util.List;
 import java.util.Map;
 import java.util.NavigableMap;
-import java.util.Optional;
 import java.util.Set;
-import java.util.function.Function;
 import java.util.function.Supplier;
 import org.apache.avro.SchemaBuilder.FieldAssembler;
 import org.apache.kafka.connect.data.Field;
@@ -76,14 +74,6 @@ public final class SchemaUtil {
           Schema.Type.FLOAT32,
           Schema.Type.FLOAT64
       );
-
-  private static final Map<Schema.Type, Function<Number, Number>> UPCASTER =
-      ImmutableMap.<Schema.Type, Function<Number, Number>>builder()
-          .put(Schema.Type.INT32, Number::intValue)
-          .put(Schema.Type.INT64, Number::longValue)
-          .put(Schema.Type.FLOAT32, Number::floatValue)
-          .put(Schema.Type.FLOAT64, Number::doubleValue)
-          .build();
 
   private static final Set<Schema.Type> ARITHMETIC_TYPES =
       ImmutableSet.copyOf(ARITHMETIC_TYPES_LIST);
@@ -321,20 +311,6 @@ public final class SchemaUtil {
     return builder
         .optional()
         .build();
-  }
-
-  private static boolean canUpCast(final Schema.Type expected, final Schema.Type actual) {
-    return ARITHMETIC_TYPE_ORDERING.max(expected, actual) == expected;
-  }
-
-  public static Optional<Number> maybeUpCast(
-      final Schema.Type expected,
-      final Schema.Type actual,
-      final Object value
-  ) {
-    return value instanceof Number && isNumber(actual) && canUpCast(expected, actual)
-        ? Optional.of(UPCASTER.get(expected).apply((Number) value))
-        : Optional.empty();
   }
 
   private static SchemaBuilder handleParametrizedType(final Type type) {

--- a/ksql-common/src/test/java/io/confluent/ksql/schema/ksql/SqlTypeTest.java
+++ b/ksql-common/src/test/java/io/confluent/ksql/schema/ksql/SqlTypeTest.java
@@ -1,0 +1,86 @@
+/*
+ * Copyright 2019 Confluent Inc.
+ *
+ * Licensed under the Confluent Community License (the "License"); you may not use
+ * this file except in compliance with the License.  You may obtain a copy of the
+ * License at
+ *
+ * http://www.confluent.io/confluent-community-license
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package io.confluent.ksql.schema.ksql;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+
+import com.google.common.collect.ImmutableSet;
+import java.util.Arrays;
+import java.util.Set;
+import java.util.stream.Stream;
+import org.junit.Test;
+
+public class SqlTypeTest {
+
+  private static final Set<SqlType> NUMBER_TYPES =
+      ImmutableSet.of(SqlType.INTEGER, SqlType.BIGINT, SqlType.DOUBLE);
+
+  @Test
+  public void shouldNotBeNumber() {
+    nonNumberTypes().forEach(sqlType ->
+        assertThat(sqlType + " should not be number", sqlType.isNumber(), is(false)));
+  }
+
+  @Test
+  public void shouldBeNumber() {
+    numberTypes().forEach(sqlType ->
+        assertThat(sqlType + " should be number", sqlType.isNumber(), is(true)));
+  }
+
+  @Test
+  public void shouldNotUpCastIfNotNumber() {
+    nonNumberTypes().forEach(sqlType ->
+        assertThat(sqlType + " should not upcast", sqlType.canUpCast(sqlType), is(false)));
+  }
+
+  @Test
+  public void shouldUpCastToSelfIfNumber() {
+    numberTypes().forEach(sqlType ->
+        assertThat(sqlType + " should upcast to self", sqlType.canUpCast(sqlType), is(true)));
+  }
+
+  @Test
+  public void shouldUpCastInt() {
+    assertThat(SqlType.INTEGER.canUpCast(SqlType.BIGINT), is(true));
+    assertThat(SqlType.INTEGER.canUpCast(SqlType.DOUBLE), is(true));
+  }
+
+  @Test
+  public void shouldUpCastBigInt() {
+    assertThat(SqlType.BIGINT.canUpCast(SqlType.DOUBLE), is(true));
+  }
+
+  @Test
+  public void shouldNotDownCastBigInt() {
+    assertThat(SqlType.BIGINT.canUpCast(SqlType.INTEGER), is(false));
+  }
+
+  @Test
+  public void shouldNotDownCastDouble() {
+    assertThat(SqlType.DOUBLE.canUpCast(SqlType.INTEGER), is(false));
+    assertThat(SqlType.DOUBLE.canUpCast(SqlType.BIGINT), is(false));
+  }
+
+  private static Stream<SqlType> numberTypes() {
+    return NUMBER_TYPES.stream();
+  }
+
+  private static Stream<SqlType> nonNumberTypes() {
+    return Arrays.stream(SqlType.values())
+        .filter(sqlType -> !NUMBER_TYPES.contains(sqlType));
+  }
+}

--- a/ksql-common/src/test/java/io/confluent/ksql/util/SchemaUtilTest.java
+++ b/ksql-common/src/test/java/io/confluent/ksql/util/SchemaUtilTest.java
@@ -786,66 +786,6 @@ public class SchemaUtilTest {
     ));
   }
 
-  @Test
-  public void shouldUpCastInt() {
-    // Given:
-    final int val = 1;
-
-    // Then:
-    assertThat(SchemaUtil.maybeUpCast(Schema.Type.INT64, Schema.Type.INT32, val), is(of(1L)));
-    assertThat(SchemaUtil.maybeUpCast(Schema.Type.FLOAT32, Schema.Type.INT32, val), is(of(1f)));
-    assertThat(SchemaUtil.maybeUpCast(Schema.Type.FLOAT64, Schema.Type.INT32, val), is(of(1d)));
-  }
-
-  @Test
-  public void shouldUpCastLong() {
-    // Given:
-    final long val = 1L;
-
-    // Then:
-    assertThat(SchemaUtil.maybeUpCast(Schema.Type.FLOAT32, Schema.Type.INT64, val), is(of(1f)));
-    assertThat(SchemaUtil.maybeUpCast(Schema.Type.FLOAT64, Schema.Type.INT64, val), is(of(1d)));
-  }
-
-  @Test
-  public void shouldUpCastFloat() {
-    // Given:
-    final float val = 1f;
-
-    // Then:
-    assertThat(SchemaUtil.maybeUpCast(Schema.Type.FLOAT64, Schema.Type.FLOAT32, val), is(of(1d)));
-  }
-
-  @Test
-  public void shouldNotDownCastLong() {
-    // Given:
-    final long val = 1L;
-
-    // Expect:
-    assertThat(SchemaUtil.maybeUpCast(Schema.Type.INT32, Schema.Type.INT64, val), is(empty()));
-  }
-
-  @Test
-  public void shouldNotDownCastFloat() {
-    // Given:
-    final float val = 1f;
-
-    // Expect:
-    assertThat(SchemaUtil.maybeUpCast(Schema.Type.INT64, Schema.Type.FLOAT32, val), is(empty()));
-    assertThat(SchemaUtil.maybeUpCast(Schema.Type.INT32, Schema.Type.FLOAT32, val), is(empty()));
-  }
-
-  @Test
-  public void shouldNotDownCastDouble() {
-    // Given:
-    final double val = 1d;
-
-    // Expect:
-    assertThat(SchemaUtil.maybeUpCast(Schema.Type.FLOAT32, Schema.Type.FLOAT64, val), is(empty()));
-    assertThat(SchemaUtil.maybeUpCast(Schema.Type.INT64, Schema.Type.FLOAT64, val), is(empty()));
-    assertThat(SchemaUtil.maybeUpCast(Schema.Type.INT32, Schema.Type.FLOAT64, val), is(empty()));
-  }
-
   // Following methods not invoked but used to test conversion from Type -> Schema
   @SuppressWarnings("unused")
   private void mapType(final Map<String, Integer> map) {

--- a/ksql-engine/src/main/java/io/confluent/ksql/codegen/SqlToJavaVisitor.java
+++ b/ksql-engine/src/main/java/io/confluent/ksql/codegen/SqlToJavaVisitor.java
@@ -366,7 +366,7 @@ public class SqlToJavaVisitor {
         throw new KsqlFunctionException("Only casts to primitive types are supported: " + sqlType);
       }
 
-      final Schema returnType = SchemaConverters.fromSqlTypeConverter().fromSqlType(sqlType);
+      final Schema returnType = SchemaConverters.sqlToLogicalConverter().fromSqlType(sqlType);
       final Schema rightSchema = expr.getRight();
       if (returnType.equals(rightSchema) || rightSchema == null) {
         return new Pair<>(expr.getLeft(), returnType);

--- a/ksql-engine/src/main/java/io/confluent/ksql/ddl/commands/CreateSourceCommand.java
+++ b/ksql-engine/src/main/java/io/confluent/ksql/ddl/commands/CreateSourceCommand.java
@@ -141,7 +141,7 @@ abstract class CreateSourceCommand implements DdlCommand {
       }
       tableSchema = tableSchema.field(
           tableElement.getName(),
-          SchemaConverters.fromSqlTypeConverter().fromSqlType(tableElement.getType())
+          SchemaConverters.sqlToLogicalConverter().fromSqlType(tableElement.getType())
       );
     }
 

--- a/ksql-engine/src/main/java/io/confluent/ksql/function/UdfCompiler.java
+++ b/ksql-engine/src/main/java/io/confluent/ksql/function/UdfCompiler.java
@@ -149,14 +149,13 @@ public class UdfCompiler {
 
       final Schema argSchema = paramSchema.isEmpty()
           ? SchemaUtil.getSchemaFromType(valueAndAggregateTypes.left)
-          : SchemaConverters.fromSqlTypeConverter()
+          : SchemaConverters.sqlToLogicalConverter()
               .fromSqlType(TypeContextUtil.getType(paramSchema));
-
       final List<Schema> args = Collections.singletonList(argSchema);
 
       final Schema returnValue = returnSchema.isEmpty()
           ? SchemaUtil.ensureOptional(SchemaUtil.getSchemaFromType(valueAndAggregateTypes.right))
-          : SchemaConverters.fromSqlTypeConverter()
+          : SchemaConverters.sqlToLogicalConverter()
               .fromSqlType(TypeContextUtil.getType(returnSchema));
 
       return evaluator.apply(args, returnValue, metrics);

--- a/ksql-engine/src/main/java/io/confluent/ksql/function/UdfLoader.java
+++ b/ksql-engine/src/main/java/io/confluent/ksql/function/UdfLoader.java
@@ -276,7 +276,7 @@ public class UdfLoader {
 
       final String doc = annotation.map(UdfParameter::description).orElse("");
       if (annotation.isPresent() && !annotation.get().schema().isEmpty()) {
-        return SchemaConverters.fromSqlTypeConverter()
+        return SchemaConverters.sqlToLogicalConverter()
             .fromSqlType(
                 TypeContextUtil.getType(annotation.get().schema()),
                 name,
@@ -374,7 +374,7 @@ public class UdfLoader {
       final Schema returnType = udfAnnotation.schema().isEmpty()
           ? SchemaUtil.getSchemaFromType(method.getGenericReturnType())
           : SchemaConverters
-              .fromSqlTypeConverter()
+              .sqlToLogicalConverter()
               .fromSqlType(TypeContextUtil.getType(udfAnnotation.schema()));
 
       return SchemaUtil.ensureOptional(returnType);

--- a/ksql-engine/src/main/java/io/confluent/ksql/schema/ksql/inference/DefaultSchemaInjector.java
+++ b/ksql-engine/src/main/java/io/confluent/ksql/schema/ksql/inference/DefaultSchemaInjector.java
@@ -139,7 +139,7 @@ public class DefaultSchemaInjector implements Injector {
   ) {
     try {
       // throws exception if invalid
-      SchemaConverters.toSqlTypeConverter().toSqlType(schema);
+      SchemaConverters.logicalToSqlConverter().toSqlType(schema);
       return SchemaParser.parse(FORMATTER.format(schema));
     } catch (final Exception e) {
       throw new KsqlStatementException(

--- a/ksql-engine/src/main/java/io/confluent/ksql/util/ExpressionTypeManager.java
+++ b/ksql-engine/src/main/java/io/confluent/ksql/util/ExpressionTypeManager.java
@@ -113,7 +113,7 @@ public class ExpressionTypeManager
       throw new KsqlFunctionException("Only casts to primitive types are supported: " + sqlType);
     }
 
-    final Schema castType = SchemaConverters.fromSqlTypeConverter().fromSqlType(sqlType);
+    final Schema castType = SchemaConverters.sqlToLogicalConverter().fromSqlType(sqlType);
     expressionTypeContext.setSchema(castType);
     return null;
   }

--- a/ksql-engine/src/test/java/io/confluent/ksql/schema/ksql/inference/DefaultSchemaInjectorFunctionalTest.java
+++ b/ksql-engine/src/test/java/io/confluent/ksql/schema/ksql/inference/DefaultSchemaInjectorFunctionalTest.java
@@ -515,7 +515,7 @@ public class DefaultSchemaInjectorFunctionalTest {
     for (final TableElement tableElement : statement.getElements()) {
       builder.field(
           tableElement.getName(),
-          SchemaConverters.fromSqlTypeConverter().fromSqlType(tableElement.getType())
+          SchemaConverters.sqlToLogicalConverter().fromSqlType(tableElement.getType())
       );
     }
     return builder.build();

--- a/ksql-functional-tests/src/main/java/io/confluent/ksql/test/model/FieldNode.java
+++ b/ksql-functional-tests/src/main/java/io/confluent/ksql/test/model/FieldNode.java
@@ -27,7 +27,7 @@ import com.fasterxml.jackson.databind.deser.std.StdDeserializer;
 import io.confluent.ksql.metastore.model.MetaStoreMatchers.FieldMatchers;
 import io.confluent.ksql.parser.tree.PrimitiveType;
 import io.confluent.ksql.schema.ksql.SchemaConverters;
-import io.confluent.ksql.schema.ksql.SchemaConverters.SqlTypeToLogicalConverter;
+import io.confluent.ksql.schema.ksql.SchemaConverters.SqlToLogicalTypeConverter;
 import io.confluent.ksql.test.tools.DataSourceMatchers.OptionalMatchers;
 import io.confluent.ksql.test.tools.exceptions.InvalidFieldException;
 import io.confluent.ksql.test.tools.exceptions.MissingFieldException;
@@ -83,8 +83,8 @@ final class FieldNode {
   private static final class ConnectSchemaDeserializer
       extends StdDeserializer<Optional<ConnectSchema>> {
 
-    private final SqlTypeToLogicalConverter sqlTypeToLogicalConverter =
-        SchemaConverters.fromSqlTypeConverter();
+    private final SqlToLogicalTypeConverter sqlTypeToLogicalConverter =
+        SchemaConverters.sqlToLogicalConverter();
 
     ConnectSchemaDeserializer() {
       super(ConnectSchema.class);

--- a/ksql-functional-tests/src/main/java/io/confluent/ksql/test/model/SourceNode.java
+++ b/ksql-functional-tests/src/main/java/io/confluent/ksql/test/model/SourceNode.java
@@ -108,7 +108,7 @@ class SourceNode {
   private static Optional<Schema> parseSchema(final String schema) {
     return Optional.ofNullable(schema)
         .map(TypeContextUtil::getType)
-        .map(SchemaConverters.fromSqlTypeConverter()::fromSqlType)
+        .map(SchemaConverters.sqlToLogicalConverter()::fromSqlType)
         .map(SourceNode::makeTopLevelStructNoneOptional);
   }
 

--- a/ksql-functional-tests/src/main/java/io/confluent/ksql/test/model/TestCaseNode.java
+++ b/ksql-functional-tests/src/main/java/io/confluent/ksql/test/model/TestCaseNode.java
@@ -254,7 +254,7 @@ public class TestCaseNode {
         final SchemaBuilder schemaBuilder = SchemaBuilder.struct();
         statement.getElements().forEach(e -> schemaBuilder.field(
             e.getName(),
-            SchemaConverters.fromSqlTypeConverter().fromSqlType(e.getType()))
+            SchemaConverters.sqlToLogicalConverter().fromSqlType(e.getType()))
         );
         avroSchema = Optional.of(new AvroData(1)
             .fromConnectSchema(addNames(schemaBuilder.build())));

--- a/ksql-functional-tests/src/main/java/io/confluent/ksql/test/serde/KeyFieldDeserializer.java
+++ b/ksql-functional-tests/src/main/java/io/confluent/ksql/test/serde/KeyFieldDeserializer.java
@@ -81,7 +81,7 @@ public class KeyFieldDeserializer extends StdDeserializer<KeyFieldNode> {
     try {
       return Optional.ofNullable(valueSchema)
           .map(TypeContextUtil::getType)
-          .map(SchemaConverters.fromSqlTypeConverter()::fromSqlType);
+          .map(SchemaConverters.sqlToLogicalConverter()::fromSqlType);
     } catch (final Exception e) {
       throw new InvalidFieldException("legacySchema", "Failed to parse: " + valueSchema, e);
     }

--- a/ksql-parser/src/main/java/io/confluent/ksql/parser/tree/TableElement.java
+++ b/ksql-parser/src/main/java/io/confluent/ksql/parser/tree/TableElement.java
@@ -91,7 +91,7 @@ public final class TableElement extends Node {
 
   public static List<TableElement> fromSchema(final Schema schema) {
     final LogicalToSqlTypeConverter toSqlTypeConverter = SchemaConverters
-        .toSqlTypeConverter();
+        .logicalToSqlConverter();
 
     return schema.fields().stream()
         .map(f -> new TableElement(

--- a/ksql-parser/src/main/java/io/confluent/ksql/schema/ksql/DefaultSqlValueCoercer.java
+++ b/ksql-parser/src/main/java/io/confluent/ksql/schema/ksql/DefaultSqlValueCoercer.java
@@ -29,18 +29,24 @@ public final class DefaultSqlValueCoercer implements SqlValueCoercer {
           .put(SqlType.DOUBLE, Number::doubleValue)
           .build();
 
-  public Optional<Object> coerce(final Object value, final SqlType targetSqlType) {
+  public <T> Optional<T> coerce(final Object value, final SqlType targetSqlType) {
     final SqlType valueSqlType = SchemaConverters.javaToSqlConverter()
         .toSqlType(value.getClass());
 
     if (valueSqlType.equals(targetSqlType)) {
-      return Optional.of(value);
+      return optional(value);
     }
 
     if (!(value instanceof Number) || !valueSqlType.canUpCast(targetSqlType)) {
       return Optional.empty();
     }
 
-    return Optional.of(UPCASTER.get(targetSqlType).apply((Number) value));
+    final Number result = UPCASTER.get(targetSqlType).apply((Number) value);
+    return optional(result);
+  }
+
+  @SuppressWarnings("unchecked")
+  private static <T> Optional<T> optional(final Object value) {
+    return Optional.of((T)value);
   }
 }

--- a/ksql-parser/src/main/java/io/confluent/ksql/schema/ksql/DefaultSqlValueCoercer.java
+++ b/ksql-parser/src/main/java/io/confluent/ksql/schema/ksql/DefaultSqlValueCoercer.java
@@ -1,0 +1,46 @@
+/*
+ * Copyright 2019 Confluent Inc.
+ *
+ * Licensed under the Confluent Community License (the "License"); you may not use
+ * this file except in compliance with the License.  You may obtain a copy of the
+ * License at
+ *
+ * http://www.confluent.io/confluent-community-license
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package io.confluent.ksql.schema.ksql;
+
+import com.google.common.collect.ImmutableMap;
+import java.util.Map;
+import java.util.Optional;
+import java.util.function.Function;
+
+public final class DefaultSqlValueCoercer implements SqlValueCoercer {
+
+  private static final Map<SqlType, Function<Number, Number>> UPCASTER =
+      ImmutableMap.<SqlType, Function<Number, Number>>builder()
+          .put(SqlType.INTEGER, Number::intValue)
+          .put(SqlType.BIGINT, Number::longValue)
+          .put(SqlType.DOUBLE, Number::doubleValue)
+          .build();
+
+  public Optional<Object> coerce(final Object value, final SqlType targetSqlType) {
+    final SqlType valueSqlType = SchemaConverters.javaToSqlConverter()
+        .toSqlType(value.getClass());
+
+    if (valueSqlType.equals(targetSqlType)) {
+      return Optional.of(value);
+    }
+
+    if (!(value instanceof Number) || !valueSqlType.canUpCast(targetSqlType)) {
+      return Optional.empty();
+    }
+
+    return Optional.of(UPCASTER.get(targetSqlType).apply((Number) value));
+  }
+}

--- a/ksql-parser/src/main/java/io/confluent/ksql/schema/ksql/SchemaConverters.java
+++ b/ksql-parser/src/main/java/io/confluent/ksql/schema/ksql/SchemaConverters.java
@@ -60,8 +60,14 @@ public final class SchemaConverters {
   public static final Schema DOUBLE = Schema.OPTIONAL_FLOAT64_SCHEMA;
   public static final Schema STRING = Schema.OPTIONAL_STRING_SCHEMA;
 
-  private static final LogicalToSqlTypeConverter TO_SQL_CONVERTER = new ToSqlTypeConverter();
-  private static final SqlTypeToLogicalConverter FROM_SQL_CONVERTER = new FromSqlTypeConverter();
+  private static final LogicalToSqlTypeConverter LOGICAL_TO_SQL_CONVERTER =
+      new LogicalToSqlConverter();
+
+  private static final SqlToLogicalTypeConverter SQL_TO_LOGICAL_CONVERTER =
+      new LogicalFromSqlConverter();
+
+  private static final JavaToSqlTypeConverter JAVA_TO_SQL_CONVERTER =
+      new JavaToSqlConverter();
 
   private SchemaConverters() {
   }
@@ -76,7 +82,7 @@ public final class SchemaConverters {
     Type toSqlType(Schema schema);
   }
 
-  public interface SqlTypeToLogicalConverter {
+  public interface SqlToLogicalTypeConverter {
 
     /**
      * @see #fromSqlType(Type, String, String)
@@ -94,15 +100,32 @@ public final class SchemaConverters {
     Schema fromSqlType(Type sqlType, String name, String doc);
   }
 
-  public static LogicalToSqlTypeConverter toSqlTypeConverter() {
-    return TO_SQL_CONVERTER;
+  public interface JavaToSqlTypeConverter {
+
+    /**
+     * Convert the supplied {@code javaType} to its corresponding SQL type.
+     *
+     * <p/>Structured types are not supported
+     *
+     * @param javaType the java type to convert.
+     * @return the sql type.
+     */
+    SqlType toSqlType(Class<?> javaType);
   }
 
-  public static SqlTypeToLogicalConverter fromSqlTypeConverter() {
-    return FROM_SQL_CONVERTER;
+  public static LogicalToSqlTypeConverter logicalToSqlConverter() {
+    return LOGICAL_TO_SQL_CONVERTER;
   }
 
-  private static final class ToSqlTypeConverter implements LogicalToSqlTypeConverter {
+  public static SqlToLogicalTypeConverter sqlToLogicalConverter() {
+    return SQL_TO_LOGICAL_CONVERTER;
+  }
+
+  public static JavaToSqlTypeConverter javaToSqlConverter() {
+    return JAVA_TO_SQL_CONVERTER;
+  }
+
+  private static final class LogicalToSqlConverter implements LogicalToSqlTypeConverter {
 
     private static final Map<Schema.Type, Function<Schema, Type>> LOGICAL_TO_SQL = ImmutableMap
         .<Schema.Type, Function<Schema, Type>>builder()
@@ -112,9 +135,9 @@ public final class SchemaConverters {
         .put(Schema.Type.FLOAT64, s -> PrimitiveType.of(SqlType.DOUBLE))
         .put(Schema.Type.BOOLEAN, s -> PrimitiveType.of(SqlType.BOOLEAN))
         .put(Schema.Type.STRING, s -> PrimitiveType.of(SqlType.STRING))
-        .put(Schema.Type.ARRAY, ToSqlTypeConverter::toSqlArray)
-        .put(Schema.Type.MAP, ToSqlTypeConverter::toSqlMap)
-        .put(Schema.Type.STRUCT, ToSqlTypeConverter::toSqlStruct)
+        .put(Schema.Type.ARRAY, LogicalToSqlConverter::toSqlArray)
+        .put(Schema.Type.MAP, LogicalToSqlConverter::toSqlMap)
+        .put(Schema.Type.STRUCT, LogicalToSqlConverter::toSqlStruct)
         .build();
 
     @Override
@@ -152,7 +175,7 @@ public final class SchemaConverters {
     }
   }
 
-  private static final class FromSqlTypeConverter implements SqlTypeToLogicalConverter {
+  private static final class LogicalFromSqlConverter implements SqlToLogicalTypeConverter {
 
     private static final Map<SqlType, Function<Type, SchemaBuilder>> SQL_TO_LOGICAL =
         ImmutableMap.<SqlType, Function<Type, SchemaBuilder>>builder()
@@ -161,10 +184,10 @@ public final class SchemaConverters {
         .put(SqlType.INTEGER, t -> SchemaBuilder.int32().optional())
         .put(SqlType.BIGINT, t -> SchemaBuilder.int64().optional())
         .put(SqlType.DOUBLE, t -> SchemaBuilder.float64().optional())
-        .put(SqlType.ARRAY, t -> FromSqlTypeConverter.fromSqlArray((Array) t))
-        .put(SqlType.MAP, t -> FromSqlTypeConverter
+        .put(SqlType.ARRAY, t -> LogicalFromSqlConverter.fromSqlArray((Array) t))
+        .put(SqlType.MAP, t -> LogicalFromSqlConverter
             .fromSqlMap((io.confluent.ksql.parser.tree.Map) t))
-        .put(SqlType.STRUCT, t -> FromSqlTypeConverter.fromSqlStruct((Struct) t))
+        .put(SqlType.STRUCT, t -> LogicalFromSqlConverter.fromSqlStruct((Struct) t))
         .build();
 
     @Override
@@ -206,6 +229,29 @@ public final class SchemaConverters {
 
       return builder
           .optional();
+    }
+  }
+
+  private static class JavaToSqlConverter implements JavaToSqlTypeConverter {
+
+    private static final Map<java.lang.reflect.Type, SqlType> JAVA_TO_SQL
+        = ImmutableMap.<java.lang.reflect.Type, SqlType>builder()
+        .put(Boolean.class, SqlType.BOOLEAN)
+        .put(Integer.class, SqlType.INTEGER)
+        .put(Long.class, SqlType.BIGINT)
+        .put(Double.class, SqlType.DOUBLE)
+        .put(String.class, SqlType.STRING)
+        // Structured types not required yet.
+        .build();
+
+    @Override
+    public SqlType toSqlType(final Class<?> javaType) {
+      final SqlType sqlType = JAVA_TO_SQL.get(javaType);
+      if (sqlType == null) {
+        throw new KsqlException("Unexpected java type: " + javaType);
+      }
+
+      return sqlType;
     }
   }
 }

--- a/ksql-parser/src/main/java/io/confluent/ksql/schema/ksql/SqlValueCoercer.java
+++ b/ksql-parser/src/main/java/io/confluent/ksql/schema/ksql/SqlValueCoercer.java
@@ -29,7 +29,8 @@ public interface SqlValueCoercer {
    *
    * @param value the value to try to coerce.
    * @param targetSqlType the target SQL type.
+   * @param <T> target Java type
    * @return the coerced value if the value could be coerced, {@link Optional#empty()} otherwise.
    */
-  Optional<Object> coerce(Object value, SqlType targetSqlType);
+  <T> Optional<T> coerce(Object value, SqlType targetSqlType);
 }

--- a/ksql-parser/src/main/java/io/confluent/ksql/schema/ksql/SqlValueCoercer.java
+++ b/ksql-parser/src/main/java/io/confluent/ksql/schema/ksql/SqlValueCoercer.java
@@ -15,17 +15,21 @@
 
 package io.confluent.ksql.schema.ksql;
 
+import java.util.Optional;
+
 /**
- * The SQL types supported by KSQL.
+ * Coerces values to {@link SqlType SQL types}.
  */
-public enum SqlType {
-  BOOLEAN, INTEGER, BIGINT, DOUBLE, STRING, ARRAY, MAP, STRUCT;
+public interface SqlValueCoercer {
 
-  public boolean isNumber() {
-    return this == INTEGER || this == BIGINT || this == DOUBLE;
-  }
-
-  public boolean canUpCast(final SqlType to) {
-    return isNumber() && this.ordinal() <= to.ordinal();
-  }
+  /**
+   * Coerce the supplied {@code value} to the supplied {@code sqlType}.
+   *
+   * <p>Complex SQL types are not supported, (yet).
+   *
+   * @param value the value to try to coerce.
+   * @param targetSqlType the target SQL type.
+   * @return the coerced value if the value could be coerced, {@link Optional#empty()} otherwise.
+   */
+  Optional<Object> coerce(Object value, SqlType targetSqlType);
 }

--- a/ksql-parser/src/test/java/io/confluent/ksql/schema/ksql/DefaultSqlValueCoercerTest.java
+++ b/ksql-parser/src/test/java/io/confluent/ksql/schema/ksql/DefaultSqlValueCoercerTest.java
@@ -1,0 +1,114 @@
+/*
+ * Copyright 2019 Confluent Inc.
+ *
+ * Licensed under the Confluent Community License (the "License"); you may not use
+ * this file except in compliance with the License.  You may obtain a copy of the
+ * License at
+ *
+ * http://www.confluent.io/confluent-community-license
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package io.confluent.ksql.schema.ksql;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+import io.confluent.ksql.util.KsqlException;
+import java.util.Optional;
+import org.apache.kafka.connect.data.SchemaBuilder;
+import org.apache.kafka.connect.data.Struct;
+import org.junit.Before;
+import org.junit.Test;
+
+public class DefaultSqlValueCoercerTest {
+
+  private DefaultSqlValueCoercer coercer;
+
+  @Before
+  public void setUp() {
+    coercer = new DefaultSqlValueCoercer();
+  }
+
+  @Test(expected = KsqlException.class)
+  public void shouldThrowOnArray() {
+    coercer.coerce(ImmutableList.of(), SqlType.ARRAY);
+  }
+
+  @Test(expected = KsqlException.class)
+  public void shouldThrowOnMap() {
+    coercer.coerce(ImmutableMap.of(), SqlType.MAP);
+  }
+
+  @Test(expected = KsqlException.class)
+  public void shouldThrowOnStruct() {
+    coercer.coerce(new Struct(SchemaBuilder.struct()), SqlType.STRUCT);
+  }
+
+  @Test
+  public void shouldOnlyCoerceNonNumberTypesToSelf() {
+    ImmutableMap.of(
+        SqlType.BOOLEAN, true,
+        SqlType.STRING, "self"
+    ).forEach((sqlType, value) -> {
+
+      assertThat(coercer.coerce(value, sqlType), is(Optional.of(value)));
+      assertThat(coercer.coerce(value, SqlType.INTEGER), is(Optional.empty()));
+    });
+  }
+
+  @Test
+  public void shouldUpCastInt() {
+    // Given:
+    final int val = 1;
+
+    // Then:
+    assertThat(coercer.coerce(val, SqlType.INTEGER), is(Optional.of(1)));
+    assertThat(coercer.coerce(val, SqlType.BIGINT), is(Optional.of(1L)));
+    assertThat(coercer.coerce(val, SqlType.DOUBLE), is(Optional.of(1D)));
+  }
+
+  @Test
+  public void shouldUpCastBigInt() {
+    // Given:
+    final long val = 1L;
+
+    // Then:
+    assertThat(coercer.coerce(val, SqlType.BIGINT), is(Optional.of(1L)));
+    assertThat(coercer.coerce(val, SqlType.DOUBLE), is(Optional.of(1D)));
+  }
+
+  @Test
+  public void shouldUpCastDouble() {
+    // Given:
+    final double val = 1D;
+
+    // Then:
+    assertThat(coercer.coerce(val, SqlType.DOUBLE), is(Optional.of(1D)));
+  }
+
+  @Test
+  public void shouldNotDownCastLong() {
+    // Given:
+    final long val = 1L;
+
+    // Expect:
+    assertThat(coercer.coerce(val, SqlType.INTEGER), is(Optional.empty()));
+  }
+
+  @Test
+  public void shouldNotDownCastDouble() {
+    // Given:
+    final double val = 1d;
+
+    // Expect:
+    assertThat(coercer.coerce(val, SqlType.INTEGER), is(Optional.empty()));
+    assertThat(coercer.coerce(val, SqlType.BIGINT), is(Optional.empty()));
+  }
+}

--- a/ksql-parser/src/test/java/io/confluent/ksql/schema/ksql/SchemaConvertersTest.java
+++ b/ksql-parser/src/test/java/io/confluent/ksql/schema/ksql/SchemaConvertersTest.java
@@ -100,7 +100,7 @@ public class SchemaConvertersTest {
     for (Entry<Type, Schema> entry : SQL_TO_LOGICAL.entrySet()) {
       final Type sqlType = entry.getKey();
       final Schema logical = entry.getValue();
-      final Schema result = SchemaConverters.fromSqlTypeConverter().fromSqlType(sqlType);
+      final Schema result = SchemaConverters.sqlToLogicalConverter().fromSqlType(sqlType);
       assertThat(result, is(logical));
     }
   }
@@ -108,17 +108,17 @@ public class SchemaConvertersTest {
   @Test
   public void shouldGetSqlTypeForEveryLogicalType() {
     SQL_TO_LOGICAL.inverse().forEach((logical, sqlType) ->
-        assertThat(SchemaConverters.toSqlTypeConverter().toSqlType(logical), is(sqlType)));
+        assertThat(SchemaConverters.logicalToSqlConverter().toSqlType(logical), is(sqlType)));
   }
 
   @Test
   public void shouldConvertNestedComplexToSql() {
-    assertThat(SchemaConverters.toSqlTypeConverter().toSqlType(NESTED_LOGICAL_TYPE), is(NESTED_SQL_TYPE));
+    assertThat(SchemaConverters.logicalToSqlConverter().toSqlType(NESTED_LOGICAL_TYPE), is(NESTED_SQL_TYPE));
   }
 
   @Test
   public void shouldConvertNestedComplexFromSql() {
-    assertThat(SchemaConverters.fromSqlTypeConverter().fromSqlType(NESTED_SQL_TYPE), is(NESTED_LOGICAL_TYPE));
+    assertThat(SchemaConverters.sqlToLogicalConverter().fromSqlType(NESTED_SQL_TYPE), is(NESTED_LOGICAL_TYPE));
   }
 
   @Test
@@ -133,7 +133,7 @@ public class SchemaConvertersTest {
     expectedException.expectMessage("Unsupported map key type: Schema{INT64}");
 
     // When:
-    SchemaConverters.toSqlTypeConverter().toSqlType(mapSchema);
+    SchemaConverters.logicalToSqlConverter().toSqlType(mapSchema);
   }
 
   @Test
@@ -146,6 +146,41 @@ public class SchemaConvertersTest {
     expectedException.expectMessage("Unexpected logical type: Schema{INT8}");
 
     // When:
-    SchemaConverters.toSqlTypeConverter().toSqlType(unsupported);
+    SchemaConverters.logicalToSqlConverter().toSqlType(unsupported);
+  }
+
+  @Test
+  public void shouldConvertJavaBooleanToSqlBoolean() {
+    assertThat(SchemaConverters.javaToSqlConverter().toSqlType(Boolean.class), is(SqlType.BOOLEAN));
+  }
+
+  @Test
+  public void shouldConvertJavaIntegerToSqlInteger() {
+    assertThat(SchemaConverters.javaToSqlConverter().toSqlType(Integer.class), is(SqlType.INTEGER));
+  }
+
+  @Test
+  public void shouldConvertJavaLongToSqlBigInt() {
+    assertThat(SchemaConverters.javaToSqlConverter().toSqlType(Long.class), is(SqlType.BIGINT));
+  }
+
+  @Test
+  public void shouldConvertJavaDoubleToSqlDouble() {
+    assertThat(SchemaConverters.javaToSqlConverter().toSqlType(Double.class), is(SqlType.DOUBLE));
+  }
+
+  @Test
+  public void shouldConvertJavaStringToSqlString() {
+    assertThat(SchemaConverters.javaToSqlConverter().toSqlType(String.class), is(SqlType.STRING));
+  }
+
+  @Test
+  public void shouldThrowOnUnknownJavaType() {
+    // Then:
+    expectedException.expect(KsqlException.class);
+    expectedException.expectMessage("Unexpected java type: " + double.class);
+
+    // When:
+    SchemaConverters.javaToSqlConverter().toSqlType(double.class);
   }
 }

--- a/ksql-rest-app/src/main/java/io/confluent/ksql/rest/server/execution/InsertValuesExecutor.java
+++ b/ksql-rest-app/src/main/java/io/confluent/ksql/rest/server/execution/InsertValuesExecutor.java
@@ -29,7 +29,12 @@ import io.confluent.ksql.parser.tree.Literal;
 import io.confluent.ksql.parser.tree.Node;
 import io.confluent.ksql.parser.tree.NullLiteral;
 import io.confluent.ksql.rest.entity.KsqlEntity;
+import io.confluent.ksql.schema.ksql.DefaultSqlValueCoercer;
 import io.confluent.ksql.schema.ksql.PhysicalSchema;
+import io.confluent.ksql.schema.ksql.SchemaConverters;
+import io.confluent.ksql.schema.ksql.SchemaConverters.LogicalToSqlTypeConverter;
+import io.confluent.ksql.schema.ksql.SqlType;
+import io.confluent.ksql.schema.ksql.SqlValueCoercer;
 import io.confluent.ksql.serde.GenericRowSerDe;
 import io.confluent.ksql.services.ServiceContext;
 import io.confluent.ksql.statement.ConfiguredStatement;
@@ -49,9 +54,9 @@ import org.apache.kafka.clients.producer.Producer;
 import org.apache.kafka.clients.producer.ProducerRecord;
 import org.apache.kafka.clients.producer.RecordMetadata;
 import org.apache.kafka.common.serialization.Serde;
+import org.apache.kafka.connect.data.ConnectSchema;
 import org.apache.kafka.connect.data.Field;
 import org.apache.kafka.connect.data.Schema;
-import org.apache.kafka.connect.data.Schema.Type;
 
 public class InsertValuesExecutor {
 
@@ -159,13 +164,16 @@ public class InsertValuesExecutor {
               + ". Got " + insertValues.getValues());
     }
 
+    final ConnectSchema schema = dataSource.getSchema().getSchema();
+    final LogicalToSqlTypeConverter converter = SchemaConverters.logicalToSqlConverter();
     final Map<String, Object> values = new HashMap<>();
     for (int i = 0; i < columns.size(); i++) {
       final String column = columns.get(i);
-      final Schema columnSchema = dataSource.getSchema().getSchema().field(column).schema();
+      final Schema columnSchema = schema.field(column).schema();
+      final SqlType columnType = converter.toSqlType(columnSchema).getSqlType();
       final Expression valueExp = insertValues.getValues().get(i);
 
-      values.put(column, new ExpressionResolver(columnSchema, column).process(valueExp, null));
+      values.put(column, new ExpressionResolver(columnType, column).process(valueExp, null));
     }
 
     if (keyField.isPresent()) {
@@ -248,19 +256,19 @@ public class InsertValuesExecutor {
 
   private static class ExpressionResolver extends AstVisitor<Object, Void> {
 
-    private final Schema schema;
-    private final String field;
+    private final SqlType fieldType;
+    private final String fieldName;
+    private final SqlValueCoercer defaultSqlValueCoercer = new DefaultSqlValueCoercer();
 
-
-    ExpressionResolver(final Schema schema, final String field) {
-      this.schema = Objects.requireNonNull(schema, "schema");
-      this.field = Objects.requireNonNull(field, "field");
+    ExpressionResolver(final SqlType fieldType, final String fieldName) {
+      this.fieldType = Objects.requireNonNull(fieldType, "fieldType");
+      this.fieldName = Objects.requireNonNull(fieldName, "fieldName");
     }
 
     @Override
     protected String visitNode(final Node node, final Void context) {
       throw new KsqlException(
-          "Only Literals are supported for INSERT INTO. Got: " + node + " for field " + field);
+          "Only Literals are supported for INSERT INTO. Got: " + node + " for field " + fieldName);
     }
 
     @Override
@@ -270,17 +278,11 @@ public class InsertValuesExecutor {
         return null;
       }
 
-      final Type valueType = SchemaUtil.getSchemaFromType(value.getClass()).type();
-      if (valueType.equals(schema.type())) {
-        return value;
-      }
-
-      return SchemaUtil.maybeUpCast(schema.type(), valueType, value)
+      return defaultSqlValueCoercer.coerce(value, fieldType)
           .orElseThrow(
               () -> new KsqlException(
-                  "Expected type " + schema.type() + " for field " + field
-                      + " but got " + value + "(" + valueType + ")")
-      );
+                  "Expected type " + fieldType + " for field " + fieldName
+                      + " but got " + value));
     }
   }
 }

--- a/ksql-rest-app/src/test/java/io/confluent/ksql/rest/server/execution/InsertValuesExecutorTest.java
+++ b/ksql-rest-app/src/test/java/io/confluent/ksql/rest/server/execution/InsertValuesExecutorTest.java
@@ -527,7 +527,7 @@ public class InsertValuesExecutorTest {
 
     // Expect:
     expectedException.expect(KsqlException.class);
-    expectedException.expectMessage("Expected type INT32 for field");
+    expectedException.expectMessage("Expected type INTEGER for field");
 
     // When:
     new InsertValuesExecutor(() -> 1L).execute(statement, engine, serviceContext);


### PR DESCRIPTION
### Description 

The upcast checks done as part of the `INSERT VALUES` work coerce values by inspecting the  Connect schema types to see the value can be coerced / upcast.  This PR looks to change this to use our own SQL type system to work out if values can be upcast / coerced.

(Part of some back burner work to move core KSQL away from the Connect schema type, as it will not be sufficient when we have quoted identifiers).

### Testing done 

`mvn test`

### Reviewer checklist
- [ ] Ensure docs are updated if necessary. (eg. if a user visible feature is being added or changed).
- [ ] Ensure relevant issues are linked (description should include text like "Fixes #<issue number>")

