### PR TITLE
Basic Decimal Support for KSQL (Avro, Delimited & Math)

### DIFF
--- a/ksql-common/src/main/java/io/confluent/ksql/schema/Operator.java
+++ b/ksql-common/src/main/java/io/confluent/ksql/schema/Operator.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright 2019 Confluent Inc.
+ *
+ * Licensed under the Confluent Community License (the "License"; you may not use
+ * this file except in compliance with the License. You may obtain a copy of the
+ * License at
+ *
+ * http://www.confluent.io/confluent-community-license
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package io.confluent.ksql.schema;
+
+public enum Operator {
+  ADD("+"),
+  SUBTRACT("-"),
+  MULTIPLY("*"),
+  DIVIDE("/"),
+  MODULUS("%");
+
+  private final String symbol;
+
+  Operator(final String symbol) {
+    this.symbol = symbol;
+  }
+
+  public String getSymbol() {
+    return symbol;
+  }
+}

--- a/ksql-common/src/main/java/io/confluent/ksql/schema/connect/SqlSchemaFormatter.java
+++ b/ksql-common/src/main/java/io/confluent/ksql/schema/connect/SqlSchemaFormatter.java
@@ -16,6 +16,7 @@
 package io.confluent.ksql.schema.connect;
 
 import com.google.common.collect.ImmutableSet;
+import io.confluent.ksql.util.DecimalUtil;
 import io.confluent.ksql.util.KsqlException;
 import java.util.EnumSet;
 import java.util.List;
@@ -126,6 +127,14 @@ public class SqlSchemaFormatter implements SchemaFormatter {
 
     public String visitString(final Schema schema) {
       return "VARCHAR";
+    }
+
+    @Override
+    public String visitBytes(final Schema schema) {
+      DecimalUtil.requireDecimal(schema);
+      return "DECIMAL("
+          + DecimalUtil.precision(schema) + ", "
+          + DecimalUtil.scale(schema) + ")";
     }
 
     public String visitArray(final Schema schema, final String element) {

--- a/ksql-common/src/main/java/io/confluent/ksql/schema/ksql/LogicalSchema.java
+++ b/ksql-common/src/main/java/io/confluent/ksql/schema/ksql/LogicalSchema.java
@@ -20,6 +20,7 @@ import com.google.common.collect.ImmutableSet;
 import com.google.errorprone.annotations.Immutable;
 import io.confluent.ksql.schema.connect.SqlSchemaFormatter;
 import io.confluent.ksql.schema.connect.SqlSchemaFormatter.Option;
+import io.confluent.ksql.util.DecimalUtil;
 import io.confluent.ksql.util.SchemaUtil;
 import java.util.List;
 import java.util.Map;
@@ -74,6 +75,7 @@ public final class LogicalSchema {
           .put(Type.ARRAY, LogicalSchema::validateArray)
           .put(Type.MAP, LogicalSchema::validateMap)
           .put(Type.STRUCT, LogicalSchema::validateStruct)
+          .put(Type.BYTES, DecimalUtil::requireDecimal)
           .build();
 
   private final ConnectSchema schema;

--- a/ksql-common/src/main/java/io/confluent/ksql/schema/ksql/SqlType.java
+++ b/ksql-common/src/main/java/io/confluent/ksql/schema/ksql/SqlType.java
@@ -19,9 +19,10 @@ package io.confluent.ksql.schema.ksql;
  * The SQL types supported by KSQL.
  */
 public enum SqlType {
-  BOOLEAN, INTEGER, BIGINT, DOUBLE, STRING, ARRAY, MAP, STRUCT;
+  BOOLEAN, INTEGER, BIGINT, DOUBLE, DECIMAL, STRING, ARRAY, MAP, STRUCT;
 
   public boolean isNumber() {
+    // for now, conversions between DECIMAL and other numeric types is not supported
     return this == INTEGER || this == BIGINT || this == DOUBLE;
   }
 

--- a/ksql-common/src/main/java/io/confluent/ksql/util/DecimalUtil.java
+++ b/ksql-common/src/main/java/io/confluent/ksql/util/DecimalUtil.java
@@ -1,0 +1,153 @@
+/*
+ * Copyright 2019 Confluent Inc.
+ *
+ * Licensed under the Confluent Community License (the "License"; you may not use
+ * this file except in compliance with the License. You may obtain a copy of the
+ * License at
+ *
+ * http://www.confluent.io/confluent-community-license
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package io.confluent.ksql.util;
+
+import java.math.BigDecimal;
+import java.math.RoundingMode;
+import org.apache.kafka.connect.data.Decimal;
+import org.apache.kafka.connect.data.Schema;
+import org.apache.kafka.connect.data.Schema.Type;
+import org.apache.kafka.connect.data.SchemaBuilder;
+import org.apache.kafka.connect.errors.DataException;
+
+public final class DecimalUtil {
+
+  private static final String PRECISION_FIELD = "connect.decimal.precision";
+
+  private DecimalUtil() { }
+
+  /**
+   * @param schema the schema to test
+   * @return whether or not the schema in question represents a decimal
+   */
+  public static boolean isDecimal(final Schema schema) {
+    return schema.type() == Type.BYTES
+        && Decimal.LOGICAL_NAME.equals(schema.name());
+  }
+
+  /**
+   * @param schema the schema to test
+   * @throws KsqlException if the schema does not match {@link #isDecimal(Schema)}
+   */
+  public static void requireDecimal(final Schema schema) {
+    KsqlPreconditions.checkArgument(
+        isDecimal(schema),
+        String.format("Expected schema of type DECIMAL but got a schema of type %s and name %s",
+            schema.type(),
+            schema.name()));
+  }
+
+  /**
+   * Returns a builder with a copy of the input schema.
+   *
+   * @param schema the input schema
+   * @return a builder copy of the input schema, if it is a decimal schema
+   */
+  public static SchemaBuilder builder(final Schema schema) {
+    requireDecimal(schema);
+    return builder(precision(schema), scale(schema));
+  }
+
+  public static SchemaBuilder builder(final int precision, final int scale) {
+    validateParameters(precision, scale);
+    return org.apache.kafka.connect.data.Decimal
+        .builder(scale)
+        .optional()
+        .parameter(PRECISION_FIELD, Integer.toString(precision));
+  }
+
+  /**
+   * @param schema the schema
+   * @return the scale for the schema
+   */
+  public static int scale(final Schema schema) {
+    requireDecimal(schema);
+    final String scaleString = schema.parameters()
+        .get(org.apache.kafka.connect.data.Decimal.SCALE_FIELD);
+    if (scaleString == null) {
+      throw new DataException("Invalid Decimal schema: scale parameter not found.");
+    }
+
+    try {
+      return Integer.parseInt(scaleString);
+    } catch (NumberFormatException e) {
+      throw new DataException("Invalid scale parameter found in Decimal schema: ", e);
+    }
+  }
+
+  /**
+   * @param schema the schema
+   * @return the precision for the schema
+   */
+  public static int precision(final Schema schema) {
+    requireDecimal(schema);
+    final String scaleString = schema.parameters().get(PRECISION_FIELD);
+    if (scaleString == null) {
+      throw new DataException("Invalid Decimal schema: precision parameter not found.");
+    }
+
+    try {
+      return Integer.parseInt(scaleString);
+    } catch (NumberFormatException e) {
+      throw new DataException("Invalid precision parameter found in Decimal schema: ", e);
+    }
+  }
+
+  /**
+   * @param value  a decimal value
+   * @param schema the schema that it should fit within
+   * @return the decimal value if it fits
+   * @throws KsqlException if the value does not fit
+   */
+  public static BigDecimal ensureFit(final BigDecimal value, final Schema schema) {
+    if (value == null) {
+      return null;
+    }
+
+    final int precision = precision(schema);
+    final int scale = scale(schema);
+
+    validateParameters(precision(schema), scale(schema));
+
+    final int leftDigits = value.precision() - value.scale();
+    final int fitLeftDigits = precision - scale;
+    KsqlPreconditions.checkArgument(leftDigits <= fitLeftDigits,
+        String.format("Cannot fit decimal '%s' into DECIMAL(%d, %d) as it would truncate left "
+            + "digits to %d.", value.toPlainString(), precision, scale, fitLeftDigits));
+
+    // we only support exact decimal conversions for now - in the future, we can
+    // encode the rounding mode in the decimal type
+    try {
+      return value.setScale(scale, RoundingMode.UNNECESSARY);
+    } catch (final ArithmeticException e) {
+      throw new KsqlException(
+          String.format(
+              "Cannot fit decimal '%s' into DECIMAL(%d, %d) without rounding.",
+              value.toPlainString(),
+              precision,
+              scale));
+    }
+  }
+
+  private static void validateParameters(final int precision, final int scale) {
+    KsqlPreconditions.checkArgument(precision > 0,
+        String.format("DECIMAL precision must be >= 1: DECIMAL(%d,%d)", precision, scale));
+    KsqlPreconditions.checkArgument(scale >= 0,
+        String.format("DECIMAL scale must be >= 0: DECIMAL(%d,%d)", precision, scale));
+    KsqlPreconditions.checkArgument(precision >= scale,
+        String.format("DECIMAL precision must be >= scale: DECIMAL(%d,%d)", precision, scale));
+  }
+}

--- a/ksql-common/src/main/java/io/confluent/ksql/util/KsqlPreconditions.java
+++ b/ksql-common/src/main/java/io/confluent/ksql/util/KsqlPreconditions.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright 2019 Confluent Inc.
+ *
+ * Licensed under the Confluent Community License (the "License"; you may not use
+ * this file except in compliance with the License. You may obtain a copy of the
+ * License at
+ *
+ * http://www.confluent.io/confluent-community-license
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package io.confluent.ksql.util;
+
+public final class KsqlPreconditions {
+
+  private KsqlPreconditions() { }
+
+  /**
+   * Ensures the truth of an expression involving one or more parameters to the calling method.
+   *
+   * @param expression a boolean expression
+   * @throws KsqlException if {@code expression} is false
+   */
+  public static void checkArgument(final boolean expression, final String message) {
+    if (!expression) {
+      throw new KsqlException(message);
+    }
+  }
+
+}

--- a/ksql-common/src/test/java/io/confluent/ksql/schema/connect/SqlSchemaFormatterTest.java
+++ b/ksql-common/src/test/java/io/confluent/ksql/schema/connect/SqlSchemaFormatterTest.java
@@ -20,6 +20,8 @@ import static org.hamcrest.Matchers.is;
 
 import com.google.common.collect.ImmutableSet;
 import io.confluent.ksql.schema.connect.SqlSchemaFormatter.Option;
+import io.confluent.ksql.util.DecimalUtil;
+import org.apache.kafka.connect.data.Decimal;
 import org.apache.kafka.connect.data.Schema;
 import org.apache.kafka.connect.data.SchemaBuilder;
 import org.junit.Test;
@@ -84,6 +86,12 @@ public class SqlSchemaFormatterTest {
   public void shouldFormatOptionalString() {
     assertThat(SqlSchemaFormatter.DEFAULT.format(Schema.OPTIONAL_STRING_SCHEMA), is("VARCHAR"));
     assertThat(SqlSchemaFormatter.STRICT.format(Schema.OPTIONAL_STRING_SCHEMA), is("VARCHAR"));
+  }
+
+  @Test
+  public void shouldFormatDecimal() {
+    assertThat(SqlSchemaFormatter.DEFAULT.format(DecimalUtil.builder(2, 1).build()), is("DECIMAL(2, 1)"));
+    assertThat(SqlSchemaFormatter.STRICT.format(DecimalUtil.builder(2, 1).build()), is("DECIMAL(2, 1)"));
   }
 
   @Test

--- a/ksql-common/src/test/java/io/confluent/ksql/schema/ksql/LogicalSchemaTest.java
+++ b/ksql-common/src/test/java/io/confluent/ksql/schema/ksql/LogicalSchemaTest.java
@@ -26,11 +26,13 @@ import static org.hamcrest.Matchers.is;
 import static org.junit.Assert.fail;
 
 import com.google.common.testing.EqualsTester;
+import io.confluent.ksql.util.KsqlException;
 import io.confluent.ksql.util.SchemaUtil;
 import java.util.Optional;
 import java.util.OptionalInt;
 import java.util.Set;
 import java.util.stream.Stream;
+import org.apache.kafka.connect.data.Decimal;
 import org.apache.kafka.connect.data.Field;
 import org.apache.kafka.connect.data.Schema;
 import org.apache.kafka.connect.data.Schema.Type;
@@ -86,9 +88,7 @@ public class LogicalSchemaTest {
     Stream.of(
         Schema.OPTIONAL_INT8_SCHEMA,
         Schema.OPTIONAL_INT16_SCHEMA,
-        Schema.OPTIONAL_FLOAT32_SCHEMA,
-        Schema.OPTIONAL_BYTES_SCHEMA
-
+        Schema.OPTIONAL_FLOAT32_SCHEMA
     ).forEach(schema -> {
       try {
         LogicalSchema.of(SchemaBuilder.struct().field("test", schema).build());
@@ -228,6 +228,16 @@ public class LogicalSchemaTest {
             .optional()
             .build()
     ));
+  }
+
+  @Test
+  public void shouldThrowOnNonDecimalBytes() {
+    // Then:
+    expectedException.expect(KsqlException.class);
+    expectedException.expectMessage("Expected schema of type DECIMAL but got a schema of type BYTES and name foobar");
+
+    // When:
+    LogicalSchema.of(nested(SchemaBuilder.bytes().name("foobar").optional().build()));
   }
 
   @Test

--- a/ksql-common/src/test/java/io/confluent/ksql/util/DecimalUtilTest.java
+++ b/ksql-common/src/test/java/io/confluent/ksql/util/DecimalUtilTest.java
@@ -1,0 +1,138 @@
+/*
+ * Copyright 2019 Confluent Inc.
+ *
+ * Licensed under the Confluent Community License (the "License"; you may not use
+ * this file except in compliance with the License. You may obtain a copy of the
+ * License at
+ *
+ * http://www.confluent.io/confluent-community-license
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package io.confluent.ksql.util;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+
+import java.math.BigDecimal;
+import org.apache.kafka.connect.data.Decimal;
+import org.apache.kafka.connect.data.Schema;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+
+public class DecimalUtilTest {
+
+  private static final Schema DECIMAL_SCHEMA = DecimalUtil.builder(2, 1).build();
+
+  @Rule
+  public final ExpectedException expectedException = ExpectedException.none();
+
+  @Test
+  public void shouldBuildCorrectSchema() {
+    // Then:
+    assertThat(DECIMAL_SCHEMA, is(Decimal.builder(1).parameter("connect.decimal.precision", "2").optional().build()));
+  }
+
+  @Test
+  public void shouldCopyBuilder() {
+    // When:
+    final Schema copy = DecimalUtil.builder(DECIMAL_SCHEMA).build();
+
+    // Then:
+    assertThat(copy, is(DECIMAL_SCHEMA));
+  }
+
+  @Test
+  public void shouldCheckWhetherSchemaIsDecimal() {
+    // Then:
+    assertThat("Expected DECIMAL_SCHEMA to be isDecimal", DecimalUtil.isDecimal(DECIMAL_SCHEMA));
+  }
+
+  @Test
+  public void shouldNotCheckSchemaForNonDecimals() {
+    // Given:
+    final Schema notDecimal = Schema.OPTIONAL_STRING_SCHEMA;
+
+    // Then:
+    assertThat("String should not be decimal schema", !DecimalUtil.isDecimal(notDecimal));
+  }
+
+  @Test
+  public void shouldExtractScaleFromDecimalSchema() {
+    // When:
+    final int scale = DecimalUtil.scale(DECIMAL_SCHEMA);
+
+    // Then:
+    assertThat(scale, is(1));
+  }
+
+  @Test
+  public void shouldExtractPrecisionFromDecimalSchema() {
+    // When:
+    final int scale = DecimalUtil.precision(DECIMAL_SCHEMA);
+
+    // Then:
+    assertThat(scale, is(2));
+  }
+
+  @Test
+  public void shouldEnsureFitIfExactMatch() {
+    // No Exception When:
+    DecimalUtil.ensureFit(new BigDecimal("1.2"), DECIMAL_SCHEMA);
+  }
+
+  @Test
+  public void shouldFailIfBuilderWithZeroPrecision() {
+    // Expect:
+    expectedException.expect(KsqlException.class);
+    expectedException.expectMessage("DECIMAL precision must be >= 1");
+
+    // When:
+    DecimalUtil.builder(0, 0);
+  }
+
+  @Test
+  public void shouldFailIfBuilderWithNegativeScale() {
+    // Expect:
+    expectedException.expect(KsqlException.class);
+    expectedException.expectMessage("DECIMAL scale must be >= 0");
+
+    // When:
+    DecimalUtil.builder(1, -1);
+  }
+
+  @Test
+  public void shouldFailIfBuilderWithScaleGTPrecision() {
+    // Expect:
+    expectedException.expect(KsqlException.class);
+    expectedException.expectMessage("DECIMAL precision must be >= scale");
+
+    // When:
+    DecimalUtil.builder(1, 2);
+  }
+
+  @Test
+  public void shouldFailFitIfNotExactMatchMoreDigits() {
+    // Expect:
+    expectedException.expect(KsqlException.class);
+    expectedException.expectMessage("Cannot fit decimal '12' into DECIMAL(2, 1)");
+
+    // When:
+    DecimalUtil.ensureFit(new BigDecimal("12"), DECIMAL_SCHEMA);
+  }
+
+  @Test
+  public void shouldFailFitIfTruncationNecessary() {
+    // Expect:
+    expectedException.expect(KsqlException.class);
+    expectedException.expectMessage("Cannot fit decimal '1.23' into DECIMAL(2, 1) without rounding.");
+
+    // When:
+    DecimalUtil.ensureFit(new BigDecimal("1.23"), DECIMAL_SCHEMA);
+  }
+}

--- a/ksql-common/src/test/java/io/confluent/ksql/util/SchemaUtilTest.java
+++ b/ksql-common/src/test/java/io/confluent/ksql/util/SchemaUtilTest.java
@@ -24,7 +24,10 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.notNullValue;
 
 import io.confluent.ksql.schema.ksql.PersistenceSchema;
+import com.google.common.collect.ImmutableMap;
+import io.confluent.ksql.schema.Operator;
 import java.lang.reflect.Type;
+import java.math.BigDecimal;
 import java.util.List;
 import java.util.Map;
 import org.apache.kafka.connect.data.ConnectSchema;
@@ -115,6 +118,12 @@ public class SchemaUtilTest {
         SchemaBuilder.map(Schema.OPTIONAL_STRING_SCHEMA, Schema.OPTIONAL_FLOAT64_SCHEMA).optional()
             .build());
     assertThat(mapClazz, equalTo(Map.class));
+  }
+
+  @Test
+  public void shouldGetCorrectJavaClassForBytes() {
+    final Class<?> decClazz = SchemaUtil.getJavaType(DecimalUtil.builder(2, 1).build());
+    assertThat(decClazz, equalTo(BigDecimal.class));
   }
 
   @Test
@@ -429,7 +438,6 @@ public class SchemaUtilTest {
 
   @Test
   public void shouldFailForCorrectJavaType() {
-
     try {
       SchemaUtil.getJavaType(Schema.BYTES_SCHEMA);
       Assert.fail();
@@ -538,45 +546,190 @@ public class SchemaUtilTest {
   @Test
   public void shouldResolveIntAndLongSchemaToLong() {
     assertThat(
-        SchemaUtil.resolveBinaryOperatorResultType(Schema.Type.INT64, Schema.Type.INT32).type(),
+        SchemaUtil.resolveBinaryOperatorResultType(Schema.INT64_SCHEMA, Schema.INT32_SCHEMA, Operator.ADD).type(),
         equalTo(Schema.Type.INT64));
   }
 
   @Test
   public void shouldResolveIntAndIntSchemaToInt() {
     assertThat(
-        SchemaUtil.resolveBinaryOperatorResultType(Schema.Type.INT32, Schema.Type.INT32).type(),
+        SchemaUtil.resolveBinaryOperatorResultType(Schema.INT32_SCHEMA, Schema.INT32_SCHEMA, Operator.ADD).type(),
         equalTo(Schema.Type.INT32));
   }
 
   @Test
   public void shouldResolveFloat64AndAnyNumberTypeToFloat() {
     assertThat(
-        SchemaUtil.resolveBinaryOperatorResultType(Schema.Type.INT32, Schema.Type.FLOAT64).type(),
+        SchemaUtil.resolveBinaryOperatorResultType(Schema.INT32_SCHEMA, Schema.FLOAT64_SCHEMA, Operator.ADD).type(),
         equalTo(Schema.Type.FLOAT64));
     assertThat(
-        SchemaUtil.resolveBinaryOperatorResultType(Schema.Type.FLOAT64, Schema.Type.INT64).type(),
+        SchemaUtil.resolveBinaryOperatorResultType(Schema.FLOAT64_SCHEMA, Schema.OPTIONAL_INT64_SCHEMA, Operator.ADD).type(),
         equalTo(Schema.Type.FLOAT64));
     assertThat(
-        SchemaUtil.resolveBinaryOperatorResultType(Schema.Type.FLOAT32, Schema.Type.FLOAT64).type(),
+        SchemaUtil.resolveBinaryOperatorResultType(Schema.FLOAT32_SCHEMA, Schema.FLOAT64_SCHEMA, Operator.ADD).type(),
         equalTo(Schema.Type.FLOAT64));
+  }
+
+  @Test
+  public void shouldResolveDecimalAddition() {
+    final Map<Pair<PrecisionScale, PrecisionScale>, PrecisionScale> inputToExpected =
+        ImmutableMap.<Pair<PrecisionScale, PrecisionScale>, PrecisionScale>builder()
+            .put(Pair.of(PrecisionScale.of(2, 1), PrecisionScale.of(2, 1)), PrecisionScale.of(3, 1))
+            .put(Pair.of(PrecisionScale.of(2, 1), PrecisionScale.of(2, 2)), PrecisionScale.of(4, 2))
+            .put(Pair.of(PrecisionScale.of(2, 2), PrecisionScale.of(2, 1)), PrecisionScale.of(4, 2))
+            .put(Pair.of(PrecisionScale.of(2, 1), PrecisionScale.of(3, 2)), PrecisionScale.of(4, 2))
+            .put(Pair.of(PrecisionScale.of(3, 2), PrecisionScale.of(2, 1)), PrecisionScale.of(4, 2))
+            .build();
+
+    inputToExpected.forEach((in, out) -> {
+      // Given:
+      final Schema d1 = DecimalUtil.builder(in.left.precision, in.left.scale).build();
+      final Schema d2 = DecimalUtil.builder(in.right.precision, in.right.scale).build();
+
+      // When:
+      final Schema result = SchemaUtil.resolveBinaryOperatorResultType(d1, d2, Operator.ADD);
+
+      // Then:
+      assertThat(String.format("precision: %s", in), DecimalUtil.precision(result), is(out.precision));
+      assertThat(String.format("scale: %s", in), DecimalUtil.scale(result), is(out.scale));
+    });
+  }
+
+  @Test
+  public void shouldResolveDecimalSubtraction() {
+    final Map<Pair<PrecisionScale, PrecisionScale>, PrecisionScale> inputToExpected =
+        ImmutableMap.<Pair<PrecisionScale, PrecisionScale>, PrecisionScale>builder()
+            .put(Pair.of(PrecisionScale.of(2, 1), PrecisionScale.of(2, 1)), PrecisionScale.of(3, 1))
+            .put(Pair.of(PrecisionScale.of(2, 1), PrecisionScale.of(2, 2)), PrecisionScale.of(4, 2))
+            .put(Pair.of(PrecisionScale.of(2, 2), PrecisionScale.of(2, 1)), PrecisionScale.of(4, 2))
+            .put(Pair.of(PrecisionScale.of(2, 1), PrecisionScale.of(3, 2)), PrecisionScale.of(4, 2))
+            .put(Pair.of(PrecisionScale.of(3, 2), PrecisionScale.of(2, 1)), PrecisionScale.of(4, 2))
+            .build();
+
+    inputToExpected.forEach((in, out) -> {
+      // Given:
+      final Schema d1 = DecimalUtil.builder(in.left.precision, in.left.scale).build();
+      final Schema d2 = DecimalUtil.builder(in.right.precision, in.right.scale).build();
+
+      // When:
+      final Schema result = SchemaUtil.resolveBinaryOperatorResultType(d1, d2, Operator.SUBTRACT);
+
+      // Then:
+      assertThat(String.format("precision: %s", in), DecimalUtil.precision(result), is(out.precision));
+      assertThat(String.format("scale: %s", in), DecimalUtil.scale(result), is(out.scale));
+    });
+  }
+
+  @Test
+  public void shouldResolveDecimalMultiply() {
+    final Map<Pair<PrecisionScale, PrecisionScale>, PrecisionScale> inputToExpected =
+        ImmutableMap.<Pair<PrecisionScale, PrecisionScale>, PrecisionScale>builder()
+            .put(Pair.of(PrecisionScale.of(2, 1), PrecisionScale.of(2, 1)), PrecisionScale.of(5, 2))
+            .put(Pair.of(PrecisionScale.of(2, 1), PrecisionScale.of(2, 2)), PrecisionScale.of(5, 3))
+            .put(Pair.of(PrecisionScale.of(2, 2), PrecisionScale.of(2, 1)), PrecisionScale.of(5, 3))
+            .put(Pair.of(PrecisionScale.of(3, 2), PrecisionScale.of(2, 1)), PrecisionScale.of(6, 3))
+            .build();
+
+    inputToExpected.forEach((in, out) -> {
+      // Given:
+      final Schema d1 = DecimalUtil.builder(in.left.precision, in.left.scale).build();
+      final Schema d2 = DecimalUtil.builder(in.right.precision, in.right.scale).build();
+
+      // When:
+      final Schema result = SchemaUtil.resolveBinaryOperatorResultType(d1, d2, Operator.MULTIPLY);
+
+      // Then:
+      assertThat(String.format("precision: %s", in), DecimalUtil.precision(result), is(out.precision));
+      assertThat(String.format("scale: %s", in), DecimalUtil.scale(result), is(out.scale));
+    });
+  }
+
+  @Test
+  public void shouldResolveDecimalDivide() {
+    final Map<Pair<PrecisionScale, PrecisionScale>, PrecisionScale> inputToExpected =
+        ImmutableMap.<Pair<PrecisionScale, PrecisionScale>, PrecisionScale>builder()
+            .put(Pair.of(PrecisionScale.of(2, 1), PrecisionScale.of(2, 1)), PrecisionScale.of(8, 6))
+            .put(Pair.of(PrecisionScale.of(2, 1), PrecisionScale.of(2, 2)), PrecisionScale.of(9, 6))
+            .put(Pair.of(PrecisionScale.of(2, 2), PrecisionScale.of(2, 1)), PrecisionScale.of(7, 6))
+            .put(Pair.of(PrecisionScale.of(3, 3), PrecisionScale.of(3, 3)), PrecisionScale.of(10, 7))
+            .put(Pair.of(PrecisionScale.of(3, 3), PrecisionScale.of(3, 2)), PrecisionScale.of(9, 7))
+            .build();
+
+    inputToExpected.forEach((in, out) -> {
+      // Given:
+      final Schema d1 = DecimalUtil.builder(in.left.precision, in.left.scale).build();
+      final Schema d2 = DecimalUtil.builder(in.right.precision, in.right.scale).build();
+
+      // When:
+      final Schema result = SchemaUtil.resolveBinaryOperatorResultType(d1, d2, Operator.DIVIDE);
+
+      // Then:
+      assertThat(String.format("precision: %s", in), DecimalUtil.precision(result), is(out.precision));
+      assertThat(String.format("scale: %s", in), DecimalUtil.scale(result), is(out.scale));
+    });
+  }
+
+  @Test
+  public void shouldResolveDecimalMod() {
+    final Map<Pair<PrecisionScale, PrecisionScale>, PrecisionScale> inputToExpected =
+        ImmutableMap.<Pair<PrecisionScale, PrecisionScale>, PrecisionScale>builder()
+            .put(Pair.of(PrecisionScale.of(2, 1), PrecisionScale.of(2, 1)), PrecisionScale.of(2, 1))
+            .put(Pair.of(PrecisionScale.of(2, 2), PrecisionScale.of(2, 1)), PrecisionScale.of(2, 2))
+            .put(Pair.of(PrecisionScale.of(2, 1), PrecisionScale.of(2, 2)), PrecisionScale.of(2, 2))
+            .put(Pair.of(PrecisionScale.of(3, 1), PrecisionScale.of(2, 2)), PrecisionScale.of(2, 2))
+            .build();
+
+    inputToExpected.forEach((in, out) -> {
+      // Given:
+      final Schema d1 = DecimalUtil.builder(in.left.precision, in.left.scale).build();
+      final Schema d2 = DecimalUtil.builder(in.right.precision, in.right.scale).build();
+
+      // When:
+      final Schema result = SchemaUtil.resolveBinaryOperatorResultType(d1, d2, Operator.MODULUS);
+
+      // Then:
+      assertThat(String.format("precision: %s", in), DecimalUtil.precision(result), is(out.precision));
+      assertThat(String.format("scale: %s", in), DecimalUtil.scale(result), is(out.scale));
+    });
+  }
+
+  private static class PrecisionScale {
+    final int precision;
+    final int scale;
+
+    static PrecisionScale of(final int precision, final int scale) {
+      return new PrecisionScale(precision, scale);
+    }
+
+    private PrecisionScale(final int precision, final int scale) {
+      this.precision = precision;
+      this.scale = scale;
+    }
+
+    @Override
+    public String toString() {
+      return "PrecisionScale{"
+          + "precision=" + precision
+          + ", scale=" + scale
+          + '}';
+    }
   }
 
   @Test
   public void shouldResolveStringAndStringToString() {
     assertThat(
-        SchemaUtil.resolveBinaryOperatorResultType(Schema.Type.STRING, Schema.Type.STRING).type(),
+        SchemaUtil.resolveBinaryOperatorResultType(Schema.STRING_SCHEMA, Schema.STRING_SCHEMA, Operator.ADD).type(),
         equalTo(Schema.Type.STRING));
   }
 
   @Test(expected = KsqlException.class)
   public void shouldThrowExceptionWhenResolvingStringWithAnythingElse() {
-    SchemaUtil.resolveBinaryOperatorResultType(Schema.Type.STRING, Schema.Type.FLOAT64);
+    SchemaUtil.resolveBinaryOperatorResultType(Schema.STRING_SCHEMA, Schema.FLOAT64_SCHEMA, Operator.ADD);
   }
 
   @Test(expected = KsqlException.class)
   public void shouldThrowExceptionWhenResolvingUnkonwnType() {
-    SchemaUtil.resolveBinaryOperatorResultType(Schema.Type.BOOLEAN, Schema.Type.FLOAT64);
+    SchemaUtil.resolveBinaryOperatorResultType(Schema.BOOLEAN_SCHEMA, Schema.FLOAT64_SCHEMA, Operator.ADD);
   }
 
   @Test

--- a/ksql-engine/src/main/java/io/confluent/ksql/util/ExpressionTypeManager.java
+++ b/ksql-engine/src/main/java/io/confluent/ksql/util/ExpressionTypeManager.java
@@ -44,6 +44,7 @@ import io.confluent.ksql.parser.tree.StringLiteral;
 import io.confluent.ksql.parser.tree.SubscriptExpression;
 import io.confluent.ksql.parser.tree.Type;
 import io.confluent.ksql.parser.tree.WhenClause;
+import io.confluent.ksql.schema.Operator;
 import io.confluent.ksql.schema.ksql.LogicalSchema;
 import io.confluent.ksql.schema.ksql.SchemaConverters;
 import java.util.ArrayList;
@@ -92,7 +93,7 @@ public class ExpressionTypeManager
     final Schema leftType = expressionTypeContext.getSchema();
     process(node.getRight(), expressionTypeContext);
     final Schema rightType = expressionTypeContext.getSchema();
-    expressionTypeContext.setSchema(resolveArithmeticType(leftType, rightType));
+    expressionTypeContext.setSchema(resolveArithmeticType(leftType, rightType, node.getOperator()));
     return null;
   }
 
@@ -289,9 +290,11 @@ public class ExpressionTypeManager
     return null;
   }
 
-  private static Schema resolveArithmeticType(final Schema leftSchema,
-                                              final Schema rightSchema) {
-    return SchemaUtil.resolveBinaryOperatorResultType(leftSchema.type(), rightSchema.type());
+  private static Schema resolveArithmeticType(
+      final Schema leftSchema,
+      final Schema rightSchema,
+      final Operator operator) {
+    return SchemaUtil.resolveBinaryOperatorResultType(leftSchema, rightSchema, operator);
   }
 
   private void validateSearchedCaseExpression(final SearchedCaseExpression searchedCaseExpression) {

--- a/ksql-engine/src/main/java/io/confluent/ksql/util/GenericRowValueTypeEnforcer.java
+++ b/ksql-engine/src/main/java/io/confluent/ksql/util/GenericRowValueTypeEnforcer.java
@@ -35,6 +35,7 @@ public class GenericRowValueTypeEnforcer {
           .put(Schema.Type.FLOAT64, GenericRowValueTypeEnforcer::enforceDouble)
           .put(Schema.Type.STRING, GenericRowValueTypeEnforcer::enforceString)
           .put(Schema.Type.BOOLEAN, GenericRowValueTypeEnforcer::enforceBoolean)
+          .put(Schema.Type.BYTES, v -> v)
           .put(Schema.Type.ARRAY, v -> v)
           .put(Schema.Type.MAP, v -> v)
           .put(Schema.Type.STRUCT, v -> v)

--- a/ksql-engine/src/test/java/io/confluent/ksql/codegen/SqlToJavaVisitorTest.java
+++ b/ksql-engine/src/test/java/io/confluent/ksql/codegen/SqlToJavaVisitorTest.java
@@ -23,8 +23,14 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import io.confluent.ksql.analyzer.Analysis;
 import io.confluent.ksql.function.TestFunctionRegistry;
 import io.confluent.ksql.metastore.MetaStore;
+import io.confluent.ksql.parser.tree.ArithmeticBinaryExpression;
+import io.confluent.ksql.parser.tree.DereferenceExpression;
 import io.confluent.ksql.parser.tree.Expression;
+import io.confluent.ksql.parser.tree.QualifiedName;
+import io.confluent.ksql.parser.tree.QualifiedNameReference;
+import io.confluent.ksql.schema.Operator;
 import io.confluent.ksql.schema.ksql.LogicalSchema;
+import io.confluent.ksql.util.DecimalUtil;
 import io.confluent.ksql.util.MetaStoreFixture;
 import org.apache.kafka.connect.data.Schema;
 import org.apache.kafka.connect.data.SchemaBuilder;
@@ -62,6 +68,7 @@ public class SqlToJavaVisitorTest {
         .field("TEST1.COL5", SchemaBuilder.map(Schema.OPTIONAL_STRING_SCHEMA, Schema.OPTIONAL_FLOAT64_SCHEMA).optional().build())
         .field("TEST1.COL6", addressSchema)
         .field("TEST1.COL7", SchemaBuilder.OPTIONAL_INT32_SCHEMA)
+        .field("TEST1.COL8", DecimalUtil.builder(2, 1).build())
         .build();
 
     sqlToJavaVisitor = new SqlToJavaVisitor(LogicalSchema.of(schema), TestFunctionRegistry.INSTANCE.get());
@@ -245,18 +252,83 @@ public class SqlToJavaVisitorTest {
   }
 
   @Test
-  public void shouldThrowOnDecimal() {
+  public void shouldGenerateCorrectCodeForDecimalAdd() {
     // Given:
-    final Analysis analysis = analyzeQuery(
-        "SELECT DECIMAL 'something' FROM test1;", metaStore);
-
-    final Expression decimal = analysis.getSelectExpressions().get(0);
-
-    // Then:
-    expectedException.expect(UnsupportedOperationException.class);
+    final ArithmeticBinaryExpression binExp = new ArithmeticBinaryExpression(
+        Operator.ADD,
+        new QualifiedNameReference(QualifiedName.of("TEST1.COL8")),
+        new QualifiedNameReference(QualifiedName.of("TEST1.COL8"))
+    );
 
     // When:
-    sqlToJavaVisitor.process(decimal);
+    final String java = sqlToJavaVisitor.process(binExp);
+
+    // Then:
+    assertThat(java, is("(TEST1_COL8.add(TEST1_COL8, new MathContext(3, RoundingMode.UNNECESSARY)).setScale(1))"));
+  }
+
+  @Test
+  public void shouldGenerateCorrectCodeForDecimalSubtract() {
+    // Given:
+    final ArithmeticBinaryExpression binExp = new ArithmeticBinaryExpression(
+        Operator.SUBTRACT,
+        new QualifiedNameReference(QualifiedName.of("TEST1.COL8")),
+        new QualifiedNameReference(QualifiedName.of("TEST1.COL8"))
+    );
+
+    // When:
+    final String java = sqlToJavaVisitor.process(binExp);
+
+    // Then:
+    assertThat(java, is("(TEST1_COL8.subtract(TEST1_COL8, new MathContext(3, RoundingMode.UNNECESSARY)).setScale(1))"));
+  }
+
+  @Test
+  public void shouldGenerateCorrectCodeForDecimalMultiply() {
+    // Given:
+    final ArithmeticBinaryExpression binExp = new ArithmeticBinaryExpression(
+        Operator.MULTIPLY,
+        new QualifiedNameReference(QualifiedName.of("TEST1.COL8")),
+        new QualifiedNameReference(QualifiedName.of("TEST1.COL8"))
+    );
+
+    // When:
+    final String java = sqlToJavaVisitor.process(binExp);
+
+    // Then:
+    assertThat(java, is("(TEST1_COL8.multiply(TEST1_COL8, new MathContext(5, RoundingMode.UNNECESSARY)).setScale(2))"));
+  }
+
+  @Test
+  public void shouldGenerateCorrectCodeForDecimalDivide() {
+    // Given:
+    final ArithmeticBinaryExpression binExp = new ArithmeticBinaryExpression(
+        Operator.DIVIDE,
+        new QualifiedNameReference(QualifiedName.of("TEST1.COL8")),
+        new QualifiedNameReference(QualifiedName.of("TEST1.COL8"))
+    );
+
+    // When:
+    final String java = sqlToJavaVisitor.process(binExp);
+
+    // Then:
+    assertThat(java, is("(TEST1_COL8.divide(TEST1_COL8, new MathContext(8, RoundingMode.UNNECESSARY)).setScale(6))"));
+  }
+
+  @Test
+  public void shouldGenerateCorrectCodeForDecimalMod() {
+    // Given:
+    final ArithmeticBinaryExpression binExp = new ArithmeticBinaryExpression(
+        Operator.MODULUS,
+        new QualifiedNameReference(QualifiedName.of("TEST1.COL8")),
+        new QualifiedNameReference(QualifiedName.of("TEST1.COL8"))
+    );
+
+    // When:
+    final String java = sqlToJavaVisitor.process(binExp);
+
+    // Then:
+    assertThat(java, is("(TEST1_COL8.remainder(TEST1_COL8, new MathContext(2, RoundingMode.UNNECESSARY)).setScale(1))"));
   }
 
   @Test

--- a/ksql-engine/src/test/java/io/confluent/ksql/schema/ksql/inference/DefaultSchemaInjectorFunctionalTest.java
+++ b/ksql-engine/src/test/java/io/confluent/ksql/schema/ksql/inference/DefaultSchemaInjectorFunctionalTest.java
@@ -32,6 +32,7 @@ import io.confluent.ksql.parser.tree.TableElement;
 import io.confluent.ksql.schema.connect.SqlSchemaFormatter;
 import io.confluent.ksql.schema.ksql.SchemaConverters;
 import io.confluent.ksql.statement.ConfiguredStatement;
+import io.confluent.ksql.util.DecimalUtil;
 import io.confluent.ksql.util.KsqlConfig;
 import io.confluent.ksql.util.KsqlException;
 import org.apache.kafka.connect.data.Schema;
@@ -50,6 +51,15 @@ public class DefaultSchemaInjectorFunctionalTest {
 
   @Rule
   public final ExpectedException expectedException = ExpectedException.none();
+
+  private static final org.apache.avro.Schema DECIMAL_SCHEMA =
+      parseAvroSchema(
+          "{"
+              + "\"type\": \"bytes\","
+              + "\"logicalType\": \"decimal\","
+              + "\"precision\": 4,"
+              + "\"scale\": 2"
+              + "}");
 
   @Mock
   private SchemaRegistryClient srClient;
@@ -107,6 +117,14 @@ public class DefaultSchemaInjectorFunctionalTest {
     shouldInferType(
         org.apache.avro.SchemaBuilder.builder().doubleType(),
         Schema.OPTIONAL_FLOAT64_SCHEMA
+    );
+  }
+
+  @Test
+  public void shouldInferDecimalAsDecimal() {
+    shouldInferType(
+        DECIMAL_SCHEMA,
+        DecimalUtil.builder(4, 2).build()
     );
   }
 
@@ -519,5 +537,9 @@ public class DefaultSchemaInjectorFunctionalTest {
       );
     }
     return builder.build();
+  }
+
+  private static org.apache.avro.Schema parseAvroSchema(final String avroSchema) {
+    return new org.apache.avro.Schema.Parser().parse(avroSchema);
   }
 }

--- a/ksql-engine/src/test/java/io/confluent/ksql/schema/ksql/inference/DefaultSchemaInjectorTest.java
+++ b/ksql-engine/src/test/java/io/confluent/ksql/schema/ksql/inference/DefaultSchemaInjectorTest.java
@@ -45,6 +45,7 @@ import io.confluent.ksql.parser.tree.TableElement;
 import io.confluent.ksql.schema.ksql.SqlType;
 import io.confluent.ksql.schema.ksql.inference.TopicSchemaSupplier.SchemaResult;
 import io.confluent.ksql.statement.ConfiguredStatement;
+import io.confluent.ksql.util.DecimalUtil;
 import io.confluent.ksql.util.KsqlConfig;
 import io.confluent.ksql.util.KsqlException;
 import io.confluent.ksql.util.KsqlStatementException;
@@ -99,6 +100,7 @@ public class DefaultSchemaInjectorTest {
           .map(Schema.OPTIONAL_STRING_SCHEMA, Schema.OPTIONAL_INT64_SCHEMA))
       .field("structField", SchemaBuilder.struct()
           .field("s0", Schema.OPTIONAL_INT64_SCHEMA).build())
+      .field("decimalField", DecimalUtil.builder(4, 2).build())
       .build();
 
   private static final List<TableElement> EXPECTED_KSQL_SCHEMA = ImmutableList
@@ -115,6 +117,7 @@ public class DefaultSchemaInjectorTest {
       .add(new TableElement("STRUCTFIELD", io.confluent.ksql.parser.tree.Struct.builder()
           .addField("S0", PrimitiveType.of(SqlType.BIGINT))
           .build()))
+      .add(new TableElement("DECIMALFIELD", io.confluent.ksql.parser.tree.Decimal.of(4, 2)))
       .build();
   private static final int SCHEMA_ID = 5;
 
@@ -277,7 +280,8 @@ public class DefaultSchemaInjectorTest {
             + "BOOLEANFIELD BOOLEAN, "
             + "ARRAYFIELD ARRAY<INTEGER>, "
             + "MAPFIELD MAP<VARCHAR, BIGINT>, "
-            + "STRUCTFIELD STRUCT<S0 BIGINT>) "
+            + "STRUCTFIELD STRUCT<S0 BIGINT>, "
+            + "DECIMALFIELD DECIMAL(4, 2)) "
             + "WITH (VALUE_FORMAT='avro', KAFKA_TOPIC='some-topic', AVRO_SCHEMA_ID='5');"
     ));
   }
@@ -301,7 +305,8 @@ public class DefaultSchemaInjectorTest {
             + "BOOLEANFIELD BOOLEAN, "
             + "ARRAYFIELD ARRAY<INTEGER>, "
             + "MAPFIELD MAP<VARCHAR, BIGINT>, "
-            + "STRUCTFIELD STRUCT<S0 BIGINT>) "
+            + "STRUCTFIELD STRUCT<S0 BIGINT>, "
+            + "DECIMALFIELD DECIMAL(4, 2)) "
             + "WITH (VALUE_FORMAT='avro', KAFKA_TOPIC='some-topic', AVRO_SCHEMA_ID='5');"
     ));
   }
@@ -327,7 +332,8 @@ public class DefaultSchemaInjectorTest {
             + "BOOLEANFIELD BOOLEAN, "
             + "ARRAYFIELD ARRAY<INTEGER>, "
             + "MAPFIELD MAP<VARCHAR, BIGINT>, "
-            + "STRUCTFIELD STRUCT<S0 BIGINT>) "
+            + "STRUCTFIELD STRUCT<S0 BIGINT>, "
+            + "DECIMALFIELD DECIMAL(4, 2)) "
             + "WITH (VALUE_FORMAT='avro', KAFKA_TOPIC='some-topic', AVRO_SCHEMA_ID='42');"
     ));
   }
@@ -353,7 +359,8 @@ public class DefaultSchemaInjectorTest {
             + "BOOLEANFIELD BOOLEAN, "
             + "ARRAYFIELD ARRAY<INTEGER>, "
             + "MAPFIELD MAP<VARCHAR, BIGINT>, "
-            + "STRUCTFIELD STRUCT<S0 BIGINT>) "
+            + "STRUCTFIELD STRUCT<S0 BIGINT>, "
+            + "DECIMALFIELD DECIMAL(4, 2)) "
             + "WITH (VALUE_FORMAT='avro', KAFKA_TOPIC='some-topic', AVRO_SCHEMA_ID='42');"
     ));
   }

--- a/ksql-functional-tests/src/main/java/io/confluent/ksql/test/model/TestCaseNode.java
+++ b/ksql-functional-tests/src/main/java/io/confluent/ksql/test/model/TestCaseNode.java
@@ -44,6 +44,7 @@ import io.confluent.ksql.test.tools.exceptions.InvalidFieldException;
 import io.confluent.ksql.test.tools.exceptions.KsqlExpectedException;
 import io.confluent.ksql.test.tools.exceptions.MissingFieldException;
 import io.confluent.ksql.test.utils.SerdeUtil;
+import io.confluent.ksql.util.DecimalUtil;
 import io.confluent.ksql.util.KsqlConstants;
 import java.nio.file.Path;
 import java.util.HashMap;
@@ -304,6 +305,10 @@ public class TestCaseNode {
   private static Schema addNames(final Schema schema) {
     final SchemaBuilder builder;
     switch (schema.type()) {
+      case BYTES:
+        DecimalUtil.requireDecimal(schema);
+        builder = DecimalUtil.builder(schema);
+        break;
       case ARRAY:
         builder = SchemaBuilder.array(addNames(schema.valueSchema()));
         break;

--- a/ksql-functional-tests/src/test/resources/query-validation-tests/decimal.json
+++ b/ksql-functional-tests/src/test/resources/query-validation-tests/decimal.json
@@ -1,0 +1,150 @@
+{
+  "comments": ["tests for decimal functionality"],
+  "tests": [
+    {
+      "name": "DELIMITED in/out",
+      "statements": [
+        "CREATE STREAM TEST (dec DECIMAL(7,5)) WITH (kafka_topic='test', value_format='DELIMITED');",
+        "CREATE STREAM TEST2 AS SELECT * FROM TEST;"
+      ],
+      "inputs": [
+        {"topic": "test", "key": 0, "value": "10.12345"}
+      ],
+      "outputs": [
+        {"topic": "TEST2", "key": 0, "value": "10.12345"}
+      ]
+    },
+    {
+      "name": "AVRO in/out",
+      "statements": [
+        "CREATE STREAM TEST (dec DECIMAL(7,5)) WITH (kafka_topic='test', value_format='AVRO');",
+        "CREATE STREAM TEST2 AS SELECT * FROM TEST;"
+      ],
+      "inputs": [
+        {"topic": "test", "key": 0, "value": {"DEC": "10.12345"}}
+      ],
+      "outputs": [
+        {"topic": "TEST2", "key": 0, "value": {"DEC": "10.12345"}}
+      ]
+    }, {
+      "name": "JSON in/out",
+      "comments": [
+        "JSON does not support DECIMAL yet - the integration with Connect would make it require",
+        "using awkward HEX strings to encode the bytes."
+      ],
+      "statements": [
+        "CREATE STREAM TEST (dec DECIMAL(7,5)) WITH (kafka_topic='test', value_format='JSON');",
+        "CREATE STREAM TEST2 AS SELECT * FROM TEST;"
+      ],
+      "inputs": [
+        {"topic": "test", "key": 0, "value": {"DEC": "10.12345"}}
+      ],
+      "outputs": [
+      ]
+    },
+    {
+      "name": "addition",
+      "statements": [
+        "CREATE STREAM TEST (a DECIMAL(4,2), b DECIMAL(4,2)) WITH (kafka_topic='test', value_format='AVRO');",
+        "CREATE STREAM TEST2 AS SELECT (a + b) AS RESULT FROM TEST;"
+      ],
+      "inputs": [
+        {"topic": "test", "key": 0, "value": {"A": "10.01", "B":  "5.10"}},
+        {"topic": "test", "key": 0, "value": {"A": "10.01", "B":  "-5.00"}},
+        {"topic": "test", "key": 0, "value": {"A": "10.01", "B":  "0.00"}}
+      ],
+      "outputs": [
+        {"topic": "TEST2", "key": 0, "value": {"RESULT": "15.11"}},
+        {"topic": "TEST2", "key": 0, "value": {"RESULT": "5.01"}},
+        {"topic": "TEST2", "key": 0, "value": {"RESULT": "10.01"}}
+      ]
+    },
+    {
+      "name": "addition 3 columns",
+      "statements": [
+        "CREATE STREAM TEST (a DECIMAL(4,2), b DECIMAL(4,2)) WITH (kafka_topic='test', value_format='AVRO');",
+        "CREATE STREAM TEST2 AS SELECT (a + a + b) AS RESULT FROM TEST;"
+      ],
+      "inputs": [
+        {"topic": "test", "key": 0, "value": {"A": "10.01", "B":  "5.10"}}
+      ],
+      "outputs": [
+        {"topic": "TEST2", "key": 0, "value": {"RESULT": "25.12"}}
+      ]
+    },
+    {
+      "name": "subtraction",
+      "statements": [
+        "CREATE STREAM TEST (a DECIMAL(4,2), b DECIMAL(4,2)) WITH (kafka_topic='test', value_format='AVRO');",
+        "CREATE STREAM TEST2 AS SELECT (a - b) AS RESULT FROM TEST;"
+      ],
+      "inputs": [
+        {"topic": "test", "key": 0, "value": {"A": "10.10", "B":  "5.10"}},
+        {"topic": "test", "key": 0, "value": {"A": "10.10", "B":  "-5.00"}},
+        {"topic": "test", "key": 0, "value": {"A": "10.10", "B":  "0.00"}}
+      ],
+      "outputs": [
+        {"topic": "TEST2", "key": 0, "value": {"RESULT": "05.00"}},
+        {"topic": "TEST2", "key": 0, "value": {"RESULT": "15.10"}},
+        {"topic": "TEST2", "key": 0, "value": {"RESULT": "10.10"}}
+      ]
+    },
+    {
+      "name": "multiplication",
+      "statements": [
+        "CREATE STREAM TEST (a DECIMAL(4,2), b DECIMAL(4,2)) WITH (kafka_topic='test', value_format='AVRO');",
+        "CREATE STREAM TEST2 AS SELECT (a * b) AS RESULT FROM TEST;"
+      ],
+      "inputs": [
+        {"topic": "test", "key": 0, "value": {"A": "10.10", "B":  "02.00"}},
+        {"topic": "test", "key": 0, "value": {"A": "10.10", "B":  "-02.00"}},
+        {"topic": "test", "key": 0, "value": {"A": "10.10", "B":  "00.00"}}
+      ],
+      "outputs": [
+        {"topic": "TEST2", "key": 0, "value": {"RESULT": "20.2000"}},
+        {"topic": "TEST2", "key": 0, "value": {"RESULT": "-20.2000"}},
+        {"topic": "TEST2", "key": 0, "value": {"RESULT": "00.0000"}}
+      ]
+    },
+    {
+      "name": "division",
+      "statements": [
+        "CREATE STREAM TEST (a DECIMAL(4,2), b DECIMAL(4,2)) WITH (kafka_topic='test', value_format='AVRO');",
+        "CREATE STREAM TEST2 AS SELECT (a / b) AS RESULT FROM TEST;"
+      ],
+      "comments": [
+        "The last record causes division by zero, the error is logged and a null value is output"
+      ],
+      "inputs": [
+        {"topic": "test", "key": 0, "value": {"A": "10.10", "B":  "02.00"}},
+        {"topic": "test", "key": 0, "value": {"A": "10.10", "B":  "-02.00"}},
+        {"topic": "test", "key": 0, "value": {"A": "10.10", "B":  "00.00"}}
+      ],
+      "outputs": [
+        {"topic": "TEST2", "key": 0, "value": {"RESULT": "005.0500000"}},
+        {"topic": "TEST2", "key": 0, "value": {"RESULT": "-005.0500000"}},
+        {"topic": "TEST2", "key": 0, "value": {"RESULT": null}}
+      ]
+    },
+    {
+      "name": "mod",
+      "statements": [
+        "CREATE STREAM TEST (a DECIMAL(4,2), b DECIMAL(4,2)) WITH (kafka_topic='test', value_format='AVRO');",
+        "CREATE STREAM TEST2 AS SELECT (a % b) AS RESULT FROM TEST;"
+      ],
+      "comments": [
+        "The last record causes modulo by zero, the error is logged and a null value is output"
+      ],
+      "inputs": [
+        {"topic": "test", "key": 0, "value": {"A": "10.10", "B":  "02.00"}},
+        {"topic": "test", "key": 0, "value": {"A": "10.10", "B":  "-02.00"}},
+        {"topic": "test", "key": 0, "value": {"A": "10.10", "B":  "00.00"}}
+      ],
+      "outputs": [
+        {"topic": "TEST2", "key": 0, "value": {"RESULT": "0.10"}},
+        {"topic": "TEST2", "key": 0, "value": {"RESULT": "0.10"}},
+        {"topic": "TEST2", "key": 0, "value": {"RESULT": null}}
+      ]
+    }
+  ]
+}

--- a/ksql-parser/src/main/antlr4/io/confluent/ksql/parser/SqlBase.g4
+++ b/ksql-parser/src/main/antlr4/io/confluent/ksql/parser/SqlBase.g4
@@ -272,6 +272,7 @@ type
     | ARRAY '<' type '>'
     | MAP '<' type ',' type '>'
     | STRUCT '<' identifier type (',' identifier type)* '>'
+    | DECIMAL '(' number ',' number ')'
     | baseType ('(' typeParameter (',' typeParameter)* ')')?
     ;
 
@@ -430,6 +431,7 @@ BEGINNING: 'BEGINNING';
 UNSET: 'UNSET';
 RUN: 'RUN';
 SCRIPT: 'SCRIPT';
+DECIMAL: 'DECIMAL';
 
 IF: 'IF';
 

--- a/ksql-parser/src/main/java/io/confluent/ksql/parser/ExpressionFormatter.java
+++ b/ksql-parser/src/main/java/io/confluent/ksql/parser/ExpressionFormatter.java
@@ -29,6 +29,7 @@ import io.confluent.ksql.parser.tree.BetweenPredicate;
 import io.confluent.ksql.parser.tree.BooleanLiteral;
 import io.confluent.ksql.parser.tree.Cast;
 import io.confluent.ksql.parser.tree.ComparisonExpression;
+import io.confluent.ksql.parser.tree.Decimal;
 import io.confluent.ksql.parser.tree.DecimalLiteral;
 import io.confluent.ksql.parser.tree.DereferenceExpression;
 import io.confluent.ksql.parser.tree.DoubleLiteral;
@@ -107,6 +108,11 @@ public final class ExpressionFormatter {
               ParserUtil.escapeIfLiteral(child.getName())
                   + " " + process(child.getType(), unmangleNames))
           .collect(toList())) + ">";
+    }
+
+    @Override
+    protected String visitDecimal(final Decimal node, final Boolean context) {
+      return String.format("DECIMAL(%d, %d)", node.getPrecision(), node.getScale());
     }
 
     @Override
@@ -265,7 +271,7 @@ public final class ExpressionFormatter {
     protected String visitArithmeticBinary(
         final ArithmeticBinaryExpression node,
         final Boolean unmangleNames) {
-      return formatBinaryExpression(node.getType().getValue(), node.getLeft(), node.getRight(),
+      return formatBinaryExpression(node.getOperator().getSymbol(), node.getLeft(), node.getRight(),
               unmangleNames);
     }
 

--- a/ksql-parser/src/main/java/io/confluent/ksql/parser/rewrite/StatementRewriter.java
+++ b/ksql-parser/src/main/java/io/confluent/ksql/parser/rewrite/StatementRewriter.java
@@ -97,7 +97,7 @@ public class StatementRewriter extends DefaultAstVisitor<Node, Object> {
 
     return new ArithmeticBinaryExpression(
         node.getLocation(),
-        node.getType(),
+        node.getOperator(),
         rewrittenLeft,
         rewrittenRight);
   }

--- a/ksql-parser/src/main/java/io/confluent/ksql/parser/tree/ArithmeticBinaryExpression.java
+++ b/ksql-parser/src/main/java/io/confluent/ksql/parser/tree/ArithmeticBinaryExpression.java
@@ -23,16 +23,16 @@ import java.util.Optional;
 @Immutable
 public class ArithmeticBinaryExpression extends Expression {
 
-  private final Operator type;
+  private final Operator operator;
   private final Expression left;
   private final Expression right;
 
   public ArithmeticBinaryExpression(
-      final Operator type,
+      final Operator operator,
       final Expression left,
       final Expression right
   ) {
-    this(Optional.empty(), type, left, right);
+    this(Optional.empty(), operator, left, right);
   }
 
   public ArithmeticBinaryExpression(
@@ -42,13 +42,13 @@ public class ArithmeticBinaryExpression extends Expression {
       final Expression right
   ) {
     super(location);
-    this.type = Objects.requireNonNull(operator, "type");
+    this.operator = Objects.requireNonNull(operator, "operator");
     this.left = Objects.requireNonNull(left, "left");
     this.right = Objects.requireNonNull(right, "right");
   }
 
   public Operator getOperator() {
-    return type;
+    return operator;
   }
 
   public Expression getLeft() {
@@ -74,13 +74,13 @@ public class ArithmeticBinaryExpression extends Expression {
     }
 
     final ArithmeticBinaryExpression that = (ArithmeticBinaryExpression) o;
-    return (type == that.type)
+    return (operator == that.operator)
            && Objects.equals(left, that.left)
            && Objects.equals(right, that.right);
   }
 
   @Override
   public int hashCode() {
-    return Objects.hash(type, left, right);
+    return Objects.hash(operator, left, right);
   }
 }

--- a/ksql-parser/src/main/java/io/confluent/ksql/parser/tree/ArithmeticBinaryExpression.java
+++ b/ksql-parser/src/main/java/io/confluent/ksql/parser/tree/ArithmeticBinaryExpression.java
@@ -16,35 +16,19 @@
 package io.confluent.ksql.parser.tree;
 
 import com.google.errorprone.annotations.Immutable;
+import io.confluent.ksql.schema.Operator;
 import java.util.Objects;
 import java.util.Optional;
 
 @Immutable
 public class ArithmeticBinaryExpression extends Expression {
 
-  public enum Type {
-    ADD("+"),
-    SUBTRACT("-"),
-    MULTIPLY("*"),
-    DIVIDE("/"),
-    MODULUS("%");
-    private final String value;
-
-    Type(final String value) {
-      this.value = value;
-    }
-
-    public String getValue() {
-      return value;
-    }
-  }
-
-  private final Type type;
+  private final Operator type;
   private final Expression left;
   private final Expression right;
 
   public ArithmeticBinaryExpression(
-      final Type type,
+      final Operator type,
       final Expression left,
       final Expression right
   ) {
@@ -53,17 +37,17 @@ public class ArithmeticBinaryExpression extends Expression {
 
   public ArithmeticBinaryExpression(
       final Optional<NodeLocation> location,
-      final Type type,
+      final Operator operator,
       final Expression left,
       final Expression right
   ) {
     super(location);
-    this.type = Objects.requireNonNull(type, "type");
+    this.type = Objects.requireNonNull(operator, "type");
     this.left = Objects.requireNonNull(left, "left");
     this.right = Objects.requireNonNull(right, "right");
   }
 
-  public Type getType() {
+  public Operator getOperator() {
     return type;
   }
 

--- a/ksql-parser/src/main/java/io/confluent/ksql/parser/tree/AstVisitor.java
+++ b/ksql-parser/src/main/java/io/confluent/ksql/parser/tree/AstVisitor.java
@@ -208,6 +208,11 @@ public abstract class AstVisitor<R, C> {
     return visitNode(node, context);
   }
 
+
+  protected R visitDecimal(final Decimal node, final C context) {
+    return visitNode(node, context);
+  }
+
   protected R visitAliasedRelation(final AliasedRelation node, final C context) {
     return visitRelation(node, context);
   }

--- a/ksql-parser/src/main/java/io/confluent/ksql/parser/tree/Decimal.java
+++ b/ksql-parser/src/main/java/io/confluent/ksql/parser/tree/Decimal.java
@@ -1,0 +1,75 @@
+/*
+ * Copyright 2019 Confluent Inc.
+ *
+ * Licensed under the Confluent Community License (the "License"; you may not use
+ * this file except in compliance with the License. You may obtain a copy of the
+ * License at
+ *
+ * http://www.confluent.io/confluent-community-license
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package io.confluent.ksql.parser.tree;
+
+import com.google.errorprone.annotations.Immutable;
+import io.confluent.ksql.schema.ksql.SqlType;
+import io.confluent.ksql.util.DecimalUtil;
+import java.util.Objects;
+import java.util.Optional;
+import org.apache.kafka.connect.data.Schema;
+
+@Immutable
+public final class Decimal extends Type {
+
+  private final int precision;
+  private final int scale;
+
+  public static Decimal of(final int precision, final int scale) {
+    return new Decimal(precision, scale);
+  }
+
+  public static Decimal of(final Schema schema) {
+    return new Decimal(DecimalUtil.precision(schema), DecimalUtil.scale(schema));
+  }
+
+  private Decimal(final int precision, final int scale) {
+    super(Optional.empty(), SqlType.DECIMAL);
+    this.precision = precision;
+    this.scale = scale;
+  }
+
+  public int getPrecision() {
+    return precision;
+  }
+
+  public int getScale() {
+    return scale;
+  }
+
+  @Override
+  public <R, C> R accept(final AstVisitor<R, C> visitor, final C context) {
+    return visitor.visitDecimal(this, context);
+  }
+
+  @Override
+  public boolean equals(final Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    final Decimal that = (Decimal) o;
+    return precision == that.precision
+        && scale == that.scale;
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(precision, scale);
+  }
+}

--- a/ksql-parser/src/main/java/io/confluent/ksql/parser/tree/ExpressionTreeRewriter.java
+++ b/ksql-parser/src/main/java/io/confluent/ksql/parser/tree/ExpressionTreeRewriter.java
@@ -119,7 +119,7 @@ public final class ExpressionTreeRewriter<C> {
       final Expression right = rewrite(node.getRight(), context.get());
 
       if (left != node.getLeft() || right != node.getRight()) {
-        return new ArithmeticBinaryExpression(node.getLocation(), node.getType(), left, right);
+        return new ArithmeticBinaryExpression(node.getLocation(), node.getOperator(), left, right);
       }
 
       return node;

--- a/ksql-parser/src/main/java/io/confluent/ksql/schema/ksql/TypeContextUtil.java
+++ b/ksql-parser/src/main/java/io/confluent/ksql/schema/ksql/TypeContextUtil.java
@@ -42,6 +42,13 @@ public final class TypeContextUtil {
       return PrimitiveType.of(baseTypeToString(type.baseType()));
     }
 
+    if (type.DECIMAL() != null) {
+      return io.confluent.ksql.parser.tree.Decimal.of(
+          ParserUtil.processIntegerNumber(type.number(0), "DECIMAL(PRECISION)"),
+          ParserUtil.processIntegerNumber(type.number(1), "DECIMAL(SCALE)")
+      );
+    }
+
     if (type.ARRAY() != null) {
       return io.confluent.ksql.parser.tree.Array.of(getType(type.type(0)));
     }

--- a/ksql-parser/src/test/java/io/confluent/ksql/parser/ExpressionFormatterTest.java
+++ b/ksql-parser/src/test/java/io/confluent/ksql/parser/ExpressionFormatterTest.java
@@ -20,6 +20,7 @@ import static org.junit.Assert.assertThat;
 
 import com.google.common.collect.ImmutableList;
 import io.confluent.ksql.parser.tree.ArithmeticBinaryExpression;
+import io.confluent.ksql.schema.Operator;
 import io.confluent.ksql.parser.tree.ArithmeticUnaryExpression;
 import io.confluent.ksql.parser.tree.Array;
 import io.confluent.ksql.parser.tree.BetweenPredicate;
@@ -181,7 +182,7 @@ public class ExpressionFormatterTest {
 
   @Test
   public void shouldFormatArithmeticBinary() {
-    assertThat(ExpressionFormatter.formatExpression(new ArithmeticBinaryExpression(ArithmeticBinaryExpression.Type.ADD,
+    assertThat(ExpressionFormatter.formatExpression(new ArithmeticBinaryExpression(Operator.ADD,
             new LongLiteral(1), new LongLiteral(2))),
         equalTo("(1 + 2)"));
   }

--- a/ksql-parser/src/test/java/io/confluent/ksql/parser/tree/ArithmeticBinaryExpressionTest.java
+++ b/ksql-parser/src/test/java/io/confluent/ksql/parser/tree/ArithmeticBinaryExpressionTest.java
@@ -15,8 +15,8 @@
 
 package io.confluent.ksql.parser.tree;
 
-import static io.confluent.ksql.parser.tree.ArithmeticBinaryExpression.Type.ADD;
-import static io.confluent.ksql.parser.tree.ArithmeticBinaryExpression.Type.DIVIDE;
+import static io.confluent.ksql.schema.Operator.ADD;
+import static io.confluent.ksql.schema.Operator.DIVIDE;
 import static org.mockito.Mockito.mock;
 
 import com.google.common.testing.EqualsTester;

--- a/ksql-parser/src/test/java/io/confluent/ksql/schema/ksql/SchemaConvertersTest.java
+++ b/ksql-parser/src/test/java/io/confluent/ksql/schema/ksql/SchemaConvertersTest.java
@@ -23,10 +23,12 @@ import com.google.common.collect.ImmutableBiMap;
 import com.google.common.collect.ImmutableSet;
 import io.confluent.ksql.parser.tree.PrimitiveType;
 import io.confluent.ksql.parser.tree.Type;
+import io.confluent.ksql.util.DecimalUtil;
 import io.confluent.ksql.util.KsqlException;
 import java.util.Map.Entry;
 import java.util.Set;
 import java.util.stream.Collectors;
+import org.apache.kafka.connect.data.Decimal;
 import org.apache.kafka.connect.data.Schema;
 import org.apache.kafka.connect.data.SchemaBuilder;
 import org.junit.Rule;
@@ -49,6 +51,7 @@ public class SchemaConvertersTest {
       .put(PrimitiveType.of(SqlType.STRING), LOGICAL_STRING_SCHEMA)
       .put(io.confluent.ksql.parser.tree.Array.of(PrimitiveType.of(SqlType.INTEGER)),
           SchemaBuilder.array(SchemaConverters.INTEGER).optional().build())
+      .put(io.confluent.ksql.parser.tree.Decimal.of(2, 1), DecimalUtil.builder(2, 1).build())
       .put(io.confluent.ksql.parser.tree.Map.of(PrimitiveType.of(SqlType.INTEGER)),
           SchemaBuilder.map(SchemaConverters.STRING, SchemaConverters.INTEGER).optional().build())
       .put(io.confluent.ksql.parser.tree.Struct.builder()
@@ -107,8 +110,11 @@ public class SchemaConvertersTest {
 
   @Test
   public void shouldGetSqlTypeForEveryLogicalType() {
-    SQL_TO_LOGICAL.inverse().forEach((logical, sqlType) ->
-        assertThat(SchemaConverters.logicalToSqlConverter().toSqlType(logical), is(sqlType)));
+    SQL_TO_LOGICAL.inverse().forEach((logical, sqlType) -> {
+      if (!(sqlType instanceof io.confluent.ksql.parser.tree.Decimal)) {
+        assertThat(SchemaConverters.logicalToSqlConverter().toSqlType(logical), is(sqlType));
+      }
+    });
   }
 
   @Test

--- a/ksql-parser/src/test/java/io/confluent/ksql/schema/ksql/TypeContextUtilTest.java
+++ b/ksql-parser/src/test/java/io/confluent/ksql/schema/ksql/TypeContextUtilTest.java
@@ -4,6 +4,7 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
 
 import io.confluent.ksql.parser.tree.Array;
+import io.confluent.ksql.parser.tree.Decimal;
 import io.confluent.ksql.parser.tree.Map;
 import io.confluent.ksql.parser.tree.PrimitiveType;
 import io.confluent.ksql.parser.tree.Struct;
@@ -28,6 +29,18 @@ public class TypeContextUtilTest {
 
     // Then:
     assertThat(type, is(PrimitiveType.of(SqlType.STRING)));
+  }
+
+  @Test
+  public void shouldGetTypeFromDecimal() {
+    // Given:
+    final String schemaString = "DECIMAL(1, 2)";
+
+    // When:
+    final Type type = TypeContextUtil.getType(schemaString);
+
+    // Then:
+    assertThat(type, is(Decimal.of(1, 2)));
   }
 
   @Test
@@ -101,6 +114,33 @@ public class TypeContextUtilTest {
     // Expect:
     expectedException.expect(KsqlException.class);
     expectedException.expectMessage("Unknown primitive type: SHAKESPEARE");
+
+    // When:
+    TypeContextUtil.getType(schemaString);
+  }
+
+  @Test
+  public void shouldThrowOnNonIntegerPrecision() {
+    // Given:
+    final String schemaString = "DECIMAL(.1, 1)";
+
+    // Expect:
+    expectedException.expect(KsqlException.class);
+    expectedException.expectMessage("Value must be integer for command: DECIMAL(PRECISION)");
+
+    // When:
+    TypeContextUtil.getType(schemaString);
+  }
+
+
+  @Test
+  public void shouldThrowOnNonIntegerScale() {
+    // Given:
+    final String schemaString = "DECIMAL(1, 1.1)";
+
+    // Expect:
+    expectedException.expect(KsqlException.class);
+    expectedException.expectMessage("Value must be integer for command: DECIMAL(SCALE)");
 
     // When:
     TypeContextUtil.getType(schemaString);

--- a/ksql-serde/src/main/java/io/confluent/ksql/serde/avro/AvroDataTranslator.java
+++ b/ksql-serde/src/main/java/io/confluent/ksql/serde/avro/AvroDataTranslator.java
@@ -17,12 +17,14 @@ package io.confluent.ksql.serde.avro;
 
 import static java.util.Objects.requireNonNull;
 
+import com.google.common.base.Preconditions;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.Iterables;
 import io.confluent.ksql.schema.connect.SchemaWalker;
 import io.confluent.ksql.schema.connect.SchemaWalker.Visitor;
 import io.confluent.ksql.serde.connect.ConnectDataTranslator;
 import io.confluent.ksql.serde.connect.DataTranslator;
+import io.confluent.ksql.util.DecimalUtil;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashMap;
@@ -266,6 +268,14 @@ public class AvroDataTranslator implements DataTranslator {
         if (schema.keySchema().type() != Type.STRING) {
           throw new IllegalArgumentException("Avro only supports MAPs with STRING keys");
         }
+        return null;
+      }
+
+      @Override
+      public Void visitBytes(final Schema schema) {
+        Preconditions.checkArgument(
+            DecimalUtil.isDecimal(schema),
+            "Avro only supports DECIMAL for BYTES type.");
         return null;
       }
 

--- a/ksql-serde/src/main/java/io/confluent/ksql/serde/connect/ConnectSchemaTranslator.java
+++ b/ksql-serde/src/main/java/io/confluent/ksql/serde/connect/ConnectSchemaTranslator.java
@@ -16,6 +16,7 @@
 package io.confluent.ksql.serde.connect;
 
 import com.google.common.collect.ImmutableMap;
+import io.confluent.ksql.util.DecimalUtil;
 import io.confluent.ksql.util.KsqlException;
 import java.util.Map;
 import java.util.function.Function;
@@ -39,6 +40,7 @@ public class ConnectSchemaTranslator {
       .put(Type.FLOAT64, s -> Schema.OPTIONAL_FLOAT64_SCHEMA)
       .put(Type.STRING, s -> Schema.OPTIONAL_STRING_SCHEMA)
       .put(Type.BOOLEAN, s -> Schema.OPTIONAL_BOOLEAN_SCHEMA)
+      .put(Type.BYTES, ConnectSchemaTranslator::toKsqlBytesSchema)
       .put(Type.ARRAY, ConnectSchemaTranslator::toKsqlArraySchema)
       .put(Type.MAP, ConnectSchemaTranslator::toKsqlMapSchema)
       .put(Type.STRUCT, ConnectSchemaTranslator::toKsqlStructSchema)
@@ -85,6 +87,13 @@ public class ConnectSchemaTranslator {
       default:
         throw new UnsupportedTypeException("Unsupported type for map key: " + type.getName());
     }
+  }
+
+  private static Schema toKsqlBytesSchema(final Schema schema) {
+    if (DecimalUtil.isDecimal(schema)) {
+      return schema;
+    }
+    throw new UnsupportedTypeException("BYTES type must be DECIMAL schema.");
   }
 
   private static Schema toKsqlMapSchema(final Schema schema) {

--- a/ksql-serde/src/main/java/io/confluent/ksql/serde/delimited/KsqlDelimitedSerializer.java
+++ b/ksql-serde/src/main/java/io/confluent/ksql/serde/delimited/KsqlDelimitedSerializer.java
@@ -15,8 +15,10 @@
 
 package io.confluent.ksql.serde.delimited;
 
+import io.confluent.ksql.util.DecimalUtil;
 import io.confluent.ksql.util.KsqlException;
 import java.io.StringWriter;
+import java.math.BigDecimal;
 import java.nio.charset.StandardCharsets;
 import java.util.Iterator;
 import java.util.Map;
@@ -80,6 +82,9 @@ public class KsqlDelimitedSerializer implements Serializer<Object> {
     public Object next() {
       final Field field = fieldIt.next();
       throwOnUnsupportedType(field.schema());
+      if (DecimalUtil.isDecimal(field.schema())) {
+        return ((BigDecimal) data.get(field)).toPlainString();
+      }
       return data.get(field);
     }
 

--- a/ksql-serde/src/test/java/io/confluent/ksql/serde/avro/KsqlAvroDeserializerTest.java
+++ b/ksql-serde/src/test/java/io/confluent/ksql/serde/avro/KsqlAvroDeserializerTest.java
@@ -1539,8 +1539,11 @@ public class KsqlAvroDeserializerTest {
       case BYTES:
         KsqlPreconditions.checkArgument(
             value instanceof BigDecimal, "expected BigDecimal BYTES value");
+        final BigDecimal decimal = (BigDecimal) value;
         return new DecimalConversion().toBytes(
-            (BigDecimal) value, avroSchema, LogicalTypes.decimal(4, 2)).array();
+            decimal,
+            avroSchema,
+            LogicalTypes.decimal(decimal.precision(), decimal.scale())).array();
       case RECORD:
         return givenAvroRecord(schema, (Map<String, ?>) value);
       case ARRAY:

--- a/ksql-serde/src/test/java/io/confluent/ksql/serde/avro/KsqlAvroSerializerTest.java
+++ b/ksql-serde/src/test/java/io/confluent/ksql/serde/avro/KsqlAvroSerializerTest.java
@@ -825,13 +825,13 @@ public class KsqlAvroSerializerTest {
   public void shouldSerializeDecimalField() {
     final BigDecimal value = new BigDecimal("12.34");
     final ByteBuffer bytes = new DecimalConversion().toBytes(
-            new BigDecimal("12.34"),
+            value,
             DECIMAL_SCHEMA,
             LogicalTypes.decimal(4, 2));
 
     shouldSerializeFieldTypeCorrectly(
         DecimalUtil.builder(4, 2).build(),
-        new BigDecimal("12.34"),
+        value,
         DECIMAL_SCHEMA,
         bytes
     );

--- a/ksql-serde/src/test/java/io/confluent/ksql/serde/json/KsqlJsonSerializerTest.java
+++ b/ksql-serde/src/test/java/io/confluent/ksql/serde/json/KsqlJsonSerializerTest.java
@@ -30,6 +30,7 @@ import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import io.confluent.ksql.schema.ksql.PersistenceSchema;
 import java.io.IOException;
+import java.math.BigDecimal;
 import java.nio.charset.StandardCharsets;
 import java.util.Arrays;
 import java.util.Collections;
@@ -38,6 +39,7 @@ import java.util.Map;
 import org.apache.commons.lang3.exception.ExceptionUtils;
 import org.apache.kafka.common.errors.SerializationException;
 import org.apache.kafka.connect.data.ConnectSchema;
+import org.apache.kafka.connect.data.Decimal;
 import org.apache.kafka.connect.data.Schema;
 import org.apache.kafka.connect.data.SchemaBuilder;
 import org.apache.kafka.connect.data.Struct;
@@ -62,6 +64,7 @@ public class KsqlJsonSerializerTest {
   private static final String ORDERUNITS = "ORDERUNITS";
   private static final String ARRAYCOL = "ARRAYCOL";
   private static final String MAPCOL = "MAPCOL";
+  private static final String DECIMALCOL = "DECIMALCOL";
 
   private static final Schema ORDER_SCHEMA = SchemaBuilder.struct()
       .field(ORDERTIME, Schema.OPTIONAL_INT64_SCHEMA)
@@ -76,6 +79,7 @@ public class KsqlJsonSerializerTest {
           .map(Schema.OPTIONAL_STRING_SCHEMA, Schema.OPTIONAL_FLOAT64_SCHEMA)
           .optional()
           .build())
+      .field(DECIMALCOL, Decimal.builder(5).optional().build())
       .build();
 
   private static final Schema ADDRESS_SCHEMA = SchemaBuilder.struct()
@@ -147,7 +151,8 @@ public class KsqlJsonSerializerTest {
         .put(ITEMID, "item_1")
         .put(ORDERUNITS, 10.0)
         .put(ARRAYCOL, Collections.singletonList(100.0))
-        .put(MAPCOL, Collections.singletonMap("key1", 100.0));
+        .put(MAPCOL, Collections.singletonMap("key1", 100.0))
+        .put(DECIMALCOL, new BigDecimal("1.12345"));
 
     // When:
     final byte[] bytes = serializer.serialize(SOME_TOPIC, struct);
@@ -160,7 +165,8 @@ public class KsqlJsonSerializerTest {
             + "\"ITEMID\":\"item_1\","
             + "\"ORDERUNITS\":10.0,"
             + "\"ARRAYCOL\":[100.0],"
-            + "\"MAPCOL\":{\"key1\":100.0}"
+            + "\"MAPCOL\":{\"key1\":100.0},"
+            + "\"DECIMALCOL\":\"AbbZ\""
             + "}"));
   }
 
@@ -488,7 +494,8 @@ public class KsqlJsonSerializerTest {
         .put(ITEMID, "item_1")
         .put(ORDERUNITS, 10.0)
         .put(ARRAYCOL, null)
-        .put(MAPCOL, null);
+        .put(MAPCOL, null)
+        .put(DECIMALCOL, null);
 
     // When:
     final byte[] bytes = serializer.serialize(SOME_TOPIC, struct);
@@ -501,7 +508,8 @@ public class KsqlJsonSerializerTest {
             + "\"ITEMID\":\"item_1\","
             + "\"ORDERUNITS\":10.0,"
             + "\"ARRAYCOL\":null,"
-            + "\"MAPCOL\":null"
+            + "\"MAPCOL\":null,"
+            + "\"DECIMALCOL\":null"
             + "}"));
   }
 


### PR DESCRIPTION
### Description 
This change adds _basic_ support for the `DECIMAL(precision, scale)` datatype to KSQL in a limited fashion. 

**NOTE: I kept this PR as one instead of splitting it up because I think having the full context might actually make it easier to review (and it's big, but not huge). If reviewers prefer, I can split it up based on the steps outlined below.**

I recommend reviewing it with the following guidelines:
1. Parsing decimals:
   1. `SqlBase.g4` accepts `DECIMAL(scale, precision)` in the syntax
   1. `SqlType` now has a new enumeration: `DECIMAL`
   1. `Decimal.java` is the parser tree representation of a decimal. It extends `Type`
   1. `SqlSchemaFormatter` formats decimals
   1. `AstBuilder` 
   1. Minor refactors moving things around from `AstBuilder` to `ParserUtil` so that `TypeContextUtil` can handle decimal types
1. Serialization and deserialization classes for decimal type all have very minor changes to support decimal:
   1. `ConnectDataTranslator`
   1. `AvroDataTranslator`
   1. `KsqlDelimitedSerializer` and `KsqlDelimitedDeserializer`
1. Changes to support decimal math:
   1. `SchemaUtil` resolves the precision/scale of decimal math based on [transact-SQL](https://docs.microsoft.com/en-us/sql/t-sql/data-types/precision-scale-and-length-transact-sql?view=sql-server-2017)
   1. `SqlToJavaVisitor` overloads the `+,-,*,/,%` operators to use their corresponding methods in the `BigDecimal` java class
1. Some testing changes so that our JSON QTT format can accept decimal strings and turn them into the corresponding serialization type
   1. `ValueSpecAvroSerdeSupplier`
   1. `ValueSpec` can compare strings with BigDecimal

That's basically it folk! Let me know if you have any questions 😄 

### Future Work
- Documentation. I will have a dedicated PR just for documentation around decimals.
- `INSERT VALUES` support. This can be a pretty trivial follow-up since it reuses most logic that's already there.
- `UDF` support. This should be very basic type checking.
- `JSON` support. This is complicated because it requires making changes to Kafka Connect. We had three options: (1) implement JSON deserialization ourselves and be incompatible with connect (2) use hex strings instead of decimal strings to represent decimals and be compatible with connect, (3) change connect to accept decimal strings and delay implementation of JSON. I figured (3) is the best option.
- Rounding. As of this PR, if the data does not fit _exactly_ into the scale and precision that is desired, the value will be ignored. In a followup PR I will introduce a new syntax for `DECIMAL(precision, scale, ROUNDING_MODE)` which will allow users to specify the rounding mode.
- Arithmetic with other numerical types and literals
- Boolean comparators with decimals/other numerical types

### Testing done 
- Unit & QTT Tests

### Reviewer checklist
- [ ] Ensure docs are updated if necessary. (eg. if a user visible feature is being added or changed).
- [ ] Ensure relevant issues are linked (description should include text like "Fixes #<issue number>")

