### PR TITLE
Added configurability for heroku

### DIFF
--- a/ksql-cli/src/test/java/io/confluent/ksql/cli/CliTest.java
+++ b/ksql-cli/src/test/java/io/confluent/ksql/cli/CliTest.java
@@ -171,7 +171,8 @@ public class CliTest {
   public static void classSetUp() throws Exception {
     restClient = new KsqlRestClient(REST_APP.getHttpListener().toString());
 
-    commandTopicName = KsqlRestConfig.getCommandTopic(KsqlConfig.KSQL_SERVICE_ID_DEFAULT);
+    commandTopicName = KsqlRestConfig.getCommandTopic(KsqlConfig.KSQL_INTERNAL_TOPIC_PREFIX_DEFAULT,
+        KsqlConfig.KSQL_SERVICE_ID_DEFAULT);
 
     orderDataProvider = new OrderDataProvider();
     CLUSTER.createTopic(orderDataProvider.topicName());

--- a/ksql-common/src/main/java/io/confluent/ksql/util/KsqlConfig.java
+++ b/ksql-common/src/main/java/io/confluent/ksql/util/KsqlConfig.java
@@ -80,6 +80,17 @@ public class KsqlConfig extends AbstractConfig {
       KSQL_SERVICE_ID_DEFAULT = "default_";
 
   public static final String
+      KSQL_INTERNAL_TOPIC_PREFIX_CONFIG = "ksql.internal.topic.name.prefix";
+  public static final String
+      KSQL_INTERNAL_TOPIC_PREFIX_DEFAULT = "_confluent-ksql-";
+
+
+  public static final String
+      KSQL_INTERNAL_TOPIC_RETENTION_CONFIG = "ksql.internal.topic.retention";
+  public static final long
+      KSQL_INTERNAL_TOPIC_RETENTION_DEFAULT = Long.MAX_VALUE;
+
+  public static final String
       KSQL_PERSISTENT_QUERY_NAME_PREFIX_CONFIG = "ksql.persistent.prefix";
   public static final String
       KSQL_PERSISTENT_QUERY_NAME_PREFIX_DEFAULT = "query_";
@@ -369,7 +380,21 @@ public class KsqlConfig extends AbstractConfig {
             ConfigDef.Type.STRING,
             KSQL_SERVICE_ID_DEFAULT,
             ConfigDef.Importance.MEDIUM,
-            "Indicates the ID of the ksql service. It will be used as prefix for "
+            "Indicate the ID of the ksql service. It will be used as prefix for "
+        )
+        .define(
+            KSQL_INTERNAL_TOPIC_PREFIX_CONFIG,
+            ConfigDef.Type.STRING,
+            KSQL_INTERNAL_TOPIC_PREFIX_DEFAULT,
+            ConfigDef.Importance.MEDIUM,
+            "Indicates the internal topic prefix of the ksql service."
+        )
+        .define(
+            KSQL_INTERNAL_TOPIC_RETENTION_CONFIG,
+            ConfigDef.Type.LONG,
+            KSQL_INTERNAL_TOPIC_RETENTION_DEFAULT,
+            ConfigDef.Importance.MEDIUM,
+            "Retention for the internal topic prefix of the ksql service."
         )
         .define(
             KSQL_TRANSIENT_QUERY_NAME_PREFIX_CONFIG,

--- a/ksql-common/src/main/java/io/confluent/ksql/util/KsqlConstants.java
+++ b/ksql-common/src/main/java/io/confluent/ksql/util/KsqlConstants.java
@@ -20,7 +20,6 @@ public final class KsqlConstants {
   private KsqlConstants() {
   }
 
-  public static final String KSQL_INTERNAL_TOPIC_PREFIX = "_confluent-ksql-";
   public static final String CONFLUENT_INTERNAL_TOPIC_PREFIX = "__confluent";
 
   public static final String SINK_NUMBER_OF_PARTITIONS = "PARTITIONS";

--- a/ksql-engine/src/main/java/io/confluent/ksql/internal/KsqlEngineMetrics.java
+++ b/ksql-engine/src/main/java/io/confluent/ksql/internal/KsqlEngineMetrics.java
@@ -17,7 +17,7 @@ package io.confluent.ksql.internal;
 
 import io.confluent.ksql.engine.KsqlEngine;
 import io.confluent.ksql.metrics.MetricCollectors;
-import io.confluent.ksql.util.KsqlConstants;
+import io.confluent.ksql.util.KsqlConfig;
 import io.confluent.ksql.util.QueryMetadata;
 import java.io.Closeable;
 import java.util.ArrayList;
@@ -69,7 +69,7 @@ public class KsqlEngineMetrics implements Closeable {
       final KsqlEngine ksqlEngine,
       final Metrics metrics) {
     this.ksqlEngine = ksqlEngine;
-    this.ksqlServiceId = KsqlConstants.KSQL_INTERNAL_TOPIC_PREFIX + ksqlEngine.getServiceId();
+    this.ksqlServiceId = KsqlConfig.KSQL_INTERNAL_TOPIC_PREFIX_DEFAULT + ksqlEngine.getServiceId();
     this.sensors = new ArrayList<>();
     this.countMetrics = new ArrayList<>();
     this.metricGroupName = metricGroupPrefix + "-query-stats";

--- a/ksql-engine/src/main/java/io/confluent/ksql/physical/PhysicalPlanBuilder.java
+++ b/ksql-engine/src/main/java/io/confluent/ksql/physical/PhysicalPlanBuilder.java
@@ -41,7 +41,6 @@ import io.confluent.ksql.structured.QueuedSchemaKStream;
 import io.confluent.ksql.structured.SchemaKStream;
 import io.confluent.ksql.structured.SchemaKTable;
 import io.confluent.ksql.util.KsqlConfig;
-import io.confluent.ksql.util.KsqlConstants;
 import io.confluent.ksql.util.KsqlException;
 import io.confluent.ksql.util.PersistentQueryMetadata;
 import io.confluent.ksql.util.QueryIdGenerator;
@@ -443,7 +442,7 @@ public class PhysicalPlanBuilder {
 
   // Package private because of test
   String getServiceId() {
-    return KsqlConstants.KSQL_INTERNAL_TOPIC_PREFIX
+    return ksqlConfig.getString(KsqlConfig.KSQL_INTERNAL_TOPIC_PREFIX_CONFIG)
            + ksqlConfig.getString(KsqlConfig.KSQL_SERVICE_ID_CONFIG);
   }
 

--- a/ksql-engine/src/main/java/io/confluent/ksql/services/DefaultServiceContext.java
+++ b/ksql-engine/src/main/java/io/confluent/ksql/services/DefaultServiceContext.java
@@ -56,7 +56,8 @@ public class DefaultServiceContext implements ServiceContext {
     return new DefaultServiceContext(
         kafkaClientSupplier,
         adminClient,
-        new KafkaTopicClientImpl(adminClient),
+        new KafkaTopicClientImpl(adminClient,
+            ksqlConfig.getString(KsqlConfig.KSQL_INTERNAL_TOPIC_PREFIX_CONFIG)),
         srClientFactory
     );
   }

--- a/ksql-engine/src/main/java/io/confluent/ksql/services/KafkaTopicClientImpl.java
+++ b/ksql-engine/src/main/java/io/confluent/ksql/services/KafkaTopicClientImpl.java
@@ -65,6 +65,8 @@ public class KafkaTopicClientImpl implements KafkaTopicClient {
 
   private final AdminClient adminClient;
 
+  private final String internalTopicPrefix;
+
   // This supplier solves two issues:
   // 1. Avoids the constructor to check for the topic.delete.enable unnecessary. The AdminClient
   //    might not have access to this config, and it would fail for every Ksql command if it does
@@ -77,10 +79,13 @@ public class KafkaTopicClientImpl implements KafkaTopicClient {
    * Construct a topic client from an existing admin client.
    *
    * @param adminClient the admin client.
+   * @param internalTopicPrefix KSQL internal topic prefix.
    */
-  public KafkaTopicClientImpl(final AdminClient adminClient) {
+  public KafkaTopicClientImpl(final AdminClient adminClient,
+      final String internalTopicPrefix) {
     this.adminClient = Objects.requireNonNull(adminClient, "adminClient");
     this.isTopicDeleteEnabledSupplier = Suppliers.memoize(this::isTopicDeleteEnabled);
+    this.internalTopicPrefix = internalTopicPrefix;
   }
 
   @Override
@@ -165,7 +170,7 @@ public class KafkaTopicClientImpl implements KafkaTopicClient {
   @Override
   public Set<String> listNonInternalTopicNames() {
     return listTopicNames().stream()
-        .filter((topic) -> !(topic.startsWith(KsqlConstants.KSQL_INTERNAL_TOPIC_PREFIX)
+        .filter((topic) -> !(topic.startsWith(internalTopicPrefix)
             || topic.startsWith(KsqlConstants.CONFLUENT_INTERNAL_TOPIC_PREFIX)))
         .collect(Collectors.toSet());
   }

--- a/ksql-engine/src/test/java/io/confluent/ksql/KsqlContextTestUtil.java
+++ b/ksql-engine/src/test/java/io/confluent/ksql/KsqlContextTestUtil.java
@@ -44,7 +44,8 @@ public final class KsqlContextTestUtil {
     final AdminClient adminClient = clientSupplier
         .getAdminClient(ksqlConfig.getKsqlAdminClientConfigProps());
 
-    final KafkaTopicClient kafkaTopicClient = new KafkaTopicClientImpl(adminClient);
+    final KafkaTopicClient kafkaTopicClient = new KafkaTopicClientImpl(adminClient,
+        KsqlConfig.KSQL_INTERNAL_TOPIC_PREFIX_DEFAULT);
 
     final ServiceContext serviceContext = TestServiceContext.create(
         clientSupplier,

--- a/ksql-engine/src/test/java/io/confluent/ksql/integration/SecureIntegrationTest.java
+++ b/ksql-engine/src/test/java/io/confluent/ksql/integration/SecureIntegrationTest.java
@@ -123,7 +123,7 @@ public class SecureIntegrationTest {
     adminClient = AdminClient
         .create(new KsqlConfig(getKsqlConfig(SUPER_USER)).getKsqlAdminClientConfigProps());
     topicClient = new KafkaTopicClientImpl(
-        adminClient);
+        adminClient, KsqlConfig.KSQL_INTERNAL_TOPIC_PREFIX_DEFAULT);
 
     produceInitData();
   }

--- a/ksql-engine/src/test/java/io/confluent/ksql/internal/KsqlEngineMetricsTest.java
+++ b/ksql-engine/src/test/java/io/confluent/ksql/internal/KsqlEngineMetricsTest.java
@@ -31,7 +31,7 @@ import io.confluent.ksql.engine.KsqlEngine;
 import io.confluent.ksql.metrics.ConsumerCollector;
 import io.confluent.ksql.metrics.MetricCollectors;
 import io.confluent.ksql.metrics.ProducerCollector;
-import io.confluent.ksql.util.KsqlConstants;
+import io.confluent.ksql.util.KsqlConfig;
 import io.confluent.ksql.util.PersistentQueryMetadata;
 import io.confluent.ksql.util.QueryMetadata;
 import java.util.ArrayList;
@@ -62,7 +62,7 @@ public class KsqlEngineMetricsTest {
   private static final String METRIC_GROUP = "testGroup";
   private KsqlEngineMetrics engineMetrics;
   private static final String KSQL_SERVICE_ID = "test-ksql-service-id";
-  private static final String metricNamePrefix = KsqlConstants.KSQL_INTERNAL_TOPIC_PREFIX + KSQL_SERVICE_ID;
+  private static final String metricNamePrefix = KsqlConfig.KSQL_INTERNAL_TOPIC_PREFIX_DEFAULT + KSQL_SERVICE_ID;
 
   @Mock
   private KsqlEngine ksqlEngine;

--- a/ksql-engine/src/test/java/io/confluent/ksql/physical/PhysicalPlanBuilderTest.java
+++ b/ksql-engine/src/test/java/io/confluent/ksql/physical/PhysicalPlanBuilderTest.java
@@ -60,7 +60,7 @@ import io.confluent.ksql.services.ServiceContext;
 import io.confluent.ksql.services.TestServiceContext;
 import io.confluent.ksql.testutils.AnalysisTestUtil;
 import io.confluent.ksql.util.KsqlConfig;
-import io.confluent.ksql.util.KsqlConstants;
+import io.confluent.ksql.util.KsqlConfig;
 import io.confluent.ksql.util.KsqlException;
 import io.confluent.ksql.util.KsqlStatementException;
 import io.confluent.ksql.util.MetaStoreFixture;
@@ -729,7 +729,7 @@ public class PhysicalPlanBuilderTest {
   @Test
   public void shouldCreateExpectedServiceId() {
     final String serviceId = physicalPlanBuilder.getServiceId();
-    assertThat(serviceId, equalTo(KsqlConstants.KSQL_INTERNAL_TOPIC_PREFIX
+    assertThat(serviceId, equalTo(KsqlConfig.KSQL_INTERNAL_TOPIC_PREFIX_DEFAULT
         + KsqlConfig.KSQL_SERVICE_ID_DEFAULT));
   }
 

--- a/ksql-engine/src/test/java/io/confluent/ksql/services/FakeKafkaTopicClient.java
+++ b/ksql-engine/src/test/java/io/confluent/ksql/services/FakeKafkaTopicClient.java
@@ -20,6 +20,7 @@ import static org.apache.kafka.common.config.TopicConfig.CLEANUP_POLICY_CONFIG;
 
 import com.google.common.collect.Sets;
 import io.confluent.ksql.topic.TopicProperties;
+import io.confluent.ksql.util.KsqlConfig;
 import io.confluent.ksql.util.KsqlConstants;
 import java.util.Collection;
 import java.util.Collections;
@@ -156,7 +157,7 @@ public class FakeKafkaTopicClient implements KafkaTopicClient {
   @Override
   public Set<String> listNonInternalTopicNames() {
     return topicMap.keySet().stream()
-        .filter((topic) -> (!topic.startsWith(KsqlConstants.KSQL_INTERNAL_TOPIC_PREFIX)
+        .filter((topic) -> (!topic.startsWith(KsqlConfig.KSQL_INTERNAL_TOPIC_PREFIX_DEFAULT)
             || !topic.startsWith(KsqlConstants.CONFLUENT_INTERNAL_TOPIC_PREFIX)))
         .collect(Collectors.toSet());
   }

--- a/ksql-engine/src/test/java/io/confluent/ksql/services/KafkaTopicClientImplTest.java
+++ b/ksql-engine/src/test/java/io/confluent/ksql/services/KafkaTopicClientImplTest.java
@@ -32,6 +32,7 @@ import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
 import io.confluent.ksql.exception.KafkaResponseGetFailedException;
 import io.confluent.ksql.exception.KafkaTopicExistsException;
+import io.confluent.ksql.util.KsqlConfig;
 import io.confluent.ksql.util.KsqlConstants;
 import java.util.Arrays;
 import java.util.Collection;
@@ -89,12 +90,12 @@ public class KafkaTopicClientImplTest {
   private static final String topicName2 = "topic2";
   private static final String topicName3 = "topic3";
   private static final String internalTopic1 = String.format("%s%s_%s",
-      KsqlConstants.KSQL_INTERNAL_TOPIC_PREFIX,
+      KsqlConfig.KSQL_INTERNAL_TOPIC_PREFIX_DEFAULT,
       "default",
       "query_CTAS_USERS_BY_CITY-KSTREAM-AGGREGATE"
           + "-STATE-STORE-0000000006-repartition");
   private static final String internalTopic2 = String.format("%s%s_%s",
-      KsqlConstants.KSQL_INTERNAL_TOPIC_PREFIX,
+      KsqlConfig.KSQL_INTERNAL_TOPIC_PREFIX_DEFAULT,
       "default",
       "query_CTAS_USERS_BY_CITY-KSTREAM-AGGREGATE"
           + "-STATE-STORE-0000000006-changelog");
@@ -116,7 +117,8 @@ public class KafkaTopicClientImplTest {
     expect(adminClient.createTopics(anyObject())).andReturn(getCreateTopicsResult());
     replay(adminClient);
 
-    final KafkaTopicClient kafkaTopicClient = new KafkaTopicClientImpl(adminClient);
+    final KafkaTopicClient kafkaTopicClient = new KafkaTopicClientImpl(adminClient,
+        KsqlConfig.KSQL_INTERNAL_TOPIC_PREFIX_DEFAULT);
     kafkaTopicClient.createTopic("test", 1, (short) 1);
     verify(adminClient);
   }
@@ -128,7 +130,8 @@ public class KafkaTopicClientImplTest {
         .andReturn(getDescribeTopicsResult());
     replay(adminClient);
 
-    final KafkaTopicClient kafkaTopicClient = new KafkaTopicClientImpl(adminClient);
+    final KafkaTopicClient kafkaTopicClient = new KafkaTopicClientImpl(adminClient,
+        KsqlConfig.KSQL_INTERNAL_TOPIC_PREFIX_DEFAULT);
     kafkaTopicClient.createTopic(topicName1, 1, (short) 1);
     verify(adminClient);
   }
@@ -146,7 +149,8 @@ public class KafkaTopicClientImplTest {
     expect(adminClient.describeTopics(anyObject(), anyObject()))
         .andReturn(getDescribeTopicsResult());
     replay(adminClient);
-    final KafkaTopicClient kafkaTopicClient = new KafkaTopicClientImpl(adminClient);
+    final KafkaTopicClient kafkaTopicClient = new KafkaTopicClientImpl(adminClient,
+        KsqlConfig.KSQL_INTERNAL_TOPIC_PREFIX_DEFAULT);
     kafkaTopicClient.createTopic(topicName1, 1, (short) 2);
     verify(adminClient);
   }
@@ -157,7 +161,8 @@ public class KafkaTopicClientImplTest {
     expect(adminClient.describeTopics(anyObject(), anyObject()))
         .andReturn(getDescribeTopicsResult());
     replay(adminClient);
-    final KafkaTopicClient kafkaTopicClient = new KafkaTopicClientImpl(adminClient);
+    final KafkaTopicClient kafkaTopicClient = new KafkaTopicClientImpl(adminClient,
+        KsqlConfig.KSQL_INTERNAL_TOPIC_PREFIX_DEFAULT);
     kafkaTopicClient.createTopic(topicName1, 1, (short) -1);
     verify(adminClient);
   }
@@ -170,7 +175,8 @@ public class KafkaTopicClientImplTest {
     expect(adminClient.describeTopics(anyObject(), anyObject()))
         .andReturn(getDescribeTopicsResult());
     replay(adminClient);
-    final KafkaTopicClient kafkaTopicClient = new KafkaTopicClientImpl(adminClient);
+    final KafkaTopicClient kafkaTopicClient = new KafkaTopicClientImpl(adminClient,
+        KsqlConfig.KSQL_INTERNAL_TOPIC_PREFIX_DEFAULT);
     kafkaTopicClient.createTopic(topicName1, 1, (short) 1);
     verify(adminClient);
   }
@@ -186,7 +192,8 @@ public class KafkaTopicClientImplTest {
     expect(adminClient.describeTopics(anyObject(), anyObject()))
         .andReturn(getDescribeTopicsResult()).once();
     replay(adminClient);
-    final KafkaTopicClient kafkaTopicClient = new KafkaTopicClientImpl(adminClient);
+    final KafkaTopicClient kafkaTopicClient = new KafkaTopicClientImpl(adminClient,
+        KsqlConfig.KSQL_INTERNAL_TOPIC_PREFIX_DEFAULT);
     kafkaTopicClient.createTopic(topicName1, 1, (short) 1);
     verify(adminClient);
   }
@@ -201,7 +208,8 @@ public class KafkaTopicClientImplTest {
         .andReturn(describeTopicReturningUnknownPartitionException())
         .andReturn(describeTopicReturningUnknownPartitionException());
     replay(adminClient);
-    final KafkaTopicClient kafkaTopicClient = new KafkaTopicClientImpl(adminClient);
+    final KafkaTopicClient kafkaTopicClient = new KafkaTopicClientImpl(adminClient,
+        KsqlConfig.KSQL_INTERNAL_TOPIC_PREFIX_DEFAULT);
     kafkaTopicClient.describeTopics(Collections.singleton(topicName1));
     verify(adminClient);
   }
@@ -211,7 +219,8 @@ public class KafkaTopicClientImplTest {
     expect(adminClient.listTopics()).andReturn(listTopicResultWithNotControllerException()).once();
     expect(adminClient.listTopics()).andReturn(getListTopicsResult());
     replay(adminClient);
-    final KafkaTopicClient kafkaTopicClient = new KafkaTopicClientImpl(adminClient);
+    final KafkaTopicClient kafkaTopicClient = new KafkaTopicClientImpl(adminClient,
+        KsqlConfig.KSQL_INTERNAL_TOPIC_PREFIX_DEFAULT);
     final Set<String> names = kafkaTopicClient.listTopicNames();
     assertThat(names, equalTo(Utils.mkSet(topicName1, topicName2, topicName3)));
     verify(adminClient);
@@ -221,7 +230,8 @@ public class KafkaTopicClientImplTest {
   public void shouldFilterInternalTopics() {
     expect(adminClient.listTopics()).andReturn(getListTopicsResultWithInternalTopics());
     replay(adminClient);
-    final KafkaTopicClient kafkaTopicClient = new KafkaTopicClientImpl(adminClient);
+    final KafkaTopicClient kafkaTopicClient = new KafkaTopicClientImpl(adminClient,
+        KsqlConfig.KSQL_INTERNAL_TOPIC_PREFIX_DEFAULT);
     final Set<String> names = kafkaTopicClient.listNonInternalTopicNames();
     assertThat(names, equalTo(Utils.mkSet(topicName1, topicName2, topicName3)));
     verify(adminClient);
@@ -231,7 +241,8 @@ public class KafkaTopicClientImplTest {
   public void shouldListTopicNames() {
     expect(adminClient.listTopics()).andReturn(getListTopicsResult());
     replay(adminClient);
-    final KafkaTopicClient kafkaTopicClient = new KafkaTopicClientImpl(adminClient);
+    final KafkaTopicClient kafkaTopicClient = new KafkaTopicClientImpl(adminClient,
+        KsqlConfig.KSQL_INTERNAL_TOPIC_PREFIX_DEFAULT);
     final Set<String> names = kafkaTopicClient.listTopicNames();
     assertThat(names, equalTo(Utils.mkSet(topicName1, topicName2, topicName3)));
     verify(adminClient);
@@ -244,7 +255,8 @@ public class KafkaTopicClientImplTest {
         .andReturn(describeBrokerResult(Collections.emptyList()));
     expect(adminClient.deleteTopics(anyObject())).andReturn(getDeleteTopicsResult());
     replay(adminClient);
-    final KafkaTopicClient kafkaTopicClient = new KafkaTopicClientImpl(adminClient);
+    final KafkaTopicClient kafkaTopicClient = new KafkaTopicClientImpl(adminClient,
+        KsqlConfig.KSQL_INTERNAL_TOPIC_PREFIX_DEFAULT);
     final List<String> topics = Collections.singletonList(topicName2);
     kafkaTopicClient.deleteTopics(topics);
     verify(adminClient);
@@ -254,7 +266,8 @@ public class KafkaTopicClientImplTest {
   public void shouldReturnIfDeleteTopicsIsEmpty() {
     // Given:
     replay(adminClient);
-    final KafkaTopicClient kafkaTopicClient = new KafkaTopicClientImpl(adminClient);
+    final KafkaTopicClient kafkaTopicClient = new KafkaTopicClientImpl(adminClient,
+        KsqlConfig.KSQL_INTERNAL_TOPIC_PREFIX_DEFAULT);
 
     // When:
     kafkaTopicClient.deleteTopics(Collections.emptyList());
@@ -271,9 +284,10 @@ public class KafkaTopicClientImplTest {
     expect(adminClient.deleteTopics(Arrays.asList(internalTopic2, internalTopic1)))
         .andReturn(getDeleteInternalTopicsResult());
     replay(adminClient);
-    final KafkaTopicClient kafkaTopicClient = new KafkaTopicClientImpl(adminClient);
+    final KafkaTopicClient kafkaTopicClient = new KafkaTopicClientImpl(adminClient,
+        KsqlConfig.KSQL_INTERNAL_TOPIC_PREFIX_DEFAULT);
     final String applicationId = String.format("%s%s",
-        KsqlConstants.KSQL_INTERNAL_TOPIC_PREFIX,
+        KsqlConfig.KSQL_INTERNAL_TOPIC_PREFIX_DEFAULT,
         "default_query_CTAS_USERS_BY_CITY");
     kafkaTopicClient.deleteInternalTopics(applicationId);
     verify(adminClient);
@@ -285,7 +299,8 @@ public class KafkaTopicClientImplTest {
     givenDeleteTopicEnableTrue();
     expect(adminClient.deleteTopics(anyObject())).andReturn(getDeleteTopicsResult());
     replay(adminClient);
-    final KafkaTopicClient kafkaTopicClient = new KafkaTopicClientImpl(adminClient);
+    final KafkaTopicClient kafkaTopicClient = new KafkaTopicClientImpl(adminClient,
+        KsqlConfig.KSQL_INTERNAL_TOPIC_PREFIX_DEFAULT);
 
     // When:
     kafkaTopicClient.deleteTopics(Collections.singletonList(topicName2));
@@ -300,7 +315,8 @@ public class KafkaTopicClientImplTest {
     givenDeleteTopicEnableNotReturnedByBroker();
     expect(adminClient.deleteTopics(anyObject())).andReturn(getDeleteTopicsResult());
     replay(adminClient);
-    final KafkaTopicClient kafkaTopicClient = new KafkaTopicClientImpl(adminClient);
+    final KafkaTopicClient kafkaTopicClient = new KafkaTopicClientImpl(adminClient,
+        KsqlConfig.KSQL_INTERNAL_TOPIC_PREFIX_DEFAULT);
 
     // When:
     kafkaTopicClient.deleteTopics(Collections.singletonList(topicName2));
@@ -314,7 +330,8 @@ public class KafkaTopicClientImplTest {
     // Given:
     givenDeleteTopicEnableFalse();
     replay(adminClient);
-    final KafkaTopicClient kafkaTopicClient = new KafkaTopicClientImpl(adminClient);
+    final KafkaTopicClient kafkaTopicClient = new KafkaTopicClientImpl(adminClient,
+        KsqlConfig.KSQL_INTERNAL_TOPIC_PREFIX_DEFAULT);
 
     // When:
     kafkaTopicClient.deleteTopics(Collections.singletonList(topicName2));
@@ -333,7 +350,8 @@ public class KafkaTopicClientImplTest {
         ));
     replay(adminClient);
 
-    final KafkaTopicClient kafkaTopicClient = new KafkaTopicClientImpl(adminClient);
+    final KafkaTopicClient kafkaTopicClient = new KafkaTopicClientImpl(adminClient,
+        KsqlConfig.KSQL_INTERNAL_TOPIC_PREFIX_DEFAULT);
     final Map<String, String> config = kafkaTopicClient.getTopicConfig("fred");
 
     assertThat(config.get(TopicConfig.RETENTION_MS_CONFIG), is("12345"));
@@ -346,7 +364,8 @@ public class KafkaTopicClientImplTest {
         .andReturn(topicConfigResponse(new RuntimeException()));
     replay(adminClient);
 
-    final KafkaTopicClient kafkaTopicClient = new KafkaTopicClientImpl(adminClient);
+    final KafkaTopicClient kafkaTopicClient = new KafkaTopicClientImpl(adminClient,
+        KsqlConfig.KSQL_INTERNAL_TOPIC_PREFIX_DEFAULT);
     final Map<String, String> config = kafkaTopicClient.getTopicConfig("fred");
 
     assertThat(config.get(TopicConfig.RETENTION_MS_CONFIG), is("12345"));
@@ -364,7 +383,8 @@ public class KafkaTopicClientImplTest {
         ));
     replay(adminClient);
 
-    final KafkaTopicClient kafkaTopicClient = new KafkaTopicClientImpl(adminClient);
+    final KafkaTopicClient kafkaTopicClient = new KafkaTopicClientImpl(adminClient,
+        KsqlConfig.KSQL_INTERNAL_TOPIC_PREFIX_DEFAULT);
     final Map<String, String> config = kafkaTopicClient.getTopicConfig("fred");
 
     assertThat(config.get(TopicConfig.RETENTION_MS_CONFIG), is("12345"));
@@ -381,7 +401,8 @@ public class KafkaTopicClientImplTest {
     expect(adminClient.createTopics(singleNewTopic(newTopic))).andReturn(getCreateTopicsResult());
     replay(adminClient);
 
-    final KafkaTopicClient kafkaTopicClient = new KafkaTopicClientImpl(adminClient);
+    final KafkaTopicClient kafkaTopicClient = new KafkaTopicClientImpl(adminClient,
+        KsqlConfig.KSQL_INTERNAL_TOPIC_PREFIX_DEFAULT);
     kafkaTopicClient.createTopic(topicName1,
         1,
         (short) 1,
@@ -411,7 +432,8 @@ public class KafkaTopicClientImplTest {
         .andReturn(alterTopicConfigResponse());
     replay(adminClient);
 
-    final KafkaTopicClient kafkaTopicClient = new KafkaTopicClientImpl(adminClient);
+    final KafkaTopicClient kafkaTopicClient = new KafkaTopicClientImpl(adminClient,
+        KsqlConfig.KSQL_INTERNAL_TOPIC_PREFIX_DEFAULT);
     kafkaTopicClient.addTopicConfig("peter", overrides);
 
     verify(adminClient);
@@ -444,7 +466,8 @@ public class KafkaTopicClientImplTest {
         .andReturn(alterTopicConfigResponse());
     replay(adminClient);
 
-    final KafkaTopicClient kafkaTopicClient = new KafkaTopicClientImpl(adminClient);
+    final KafkaTopicClient kafkaTopicClient = new KafkaTopicClientImpl(adminClient,
+        KsqlConfig.KSQL_INTERNAL_TOPIC_PREFIX_DEFAULT);
     kafkaTopicClient.addTopicConfig("peter", overrides);
 
     verify(adminClient);
@@ -465,7 +488,8 @@ public class KafkaTopicClientImplTest {
 
     replay(adminClient);
 
-    final KafkaTopicClient kafkaTopicClient = new KafkaTopicClientImpl(adminClient);
+    final KafkaTopicClient kafkaTopicClient = new KafkaTopicClientImpl(adminClient,
+        KsqlConfig.KSQL_INTERNAL_TOPIC_PREFIX_DEFAULT);
     kafkaTopicClient.addTopicConfig("peter", overrides);
 
     verify(adminClient);
@@ -489,7 +513,8 @@ public class KafkaTopicClientImplTest {
         .andReturn(alterTopicConfigResponse());
     replay(adminClient);
 
-    final KafkaTopicClient kafkaTopicClient = new KafkaTopicClientImpl(adminClient);
+    final KafkaTopicClient kafkaTopicClient = new KafkaTopicClientImpl(adminClient,
+        KsqlConfig.KSQL_INTERNAL_TOPIC_PREFIX_DEFAULT);
     kafkaTopicClient.addTopicConfig("peter", overrides);
 
     verify(adminClient);

--- a/ksql-engine/src/test/java/io/confluent/ksql/services/TestServiceContext.java
+++ b/ksql-engine/src/test/java/io/confluent/ksql/services/TestServiceContext.java
@@ -77,7 +77,7 @@ public final class TestServiceContext {
     return create(
         kafkaClientSupplier,
         adminClient,
-        new KafkaTopicClientImpl(adminClient),
+        new KafkaTopicClientImpl(adminClient, KsqlConfig.KSQL_INTERNAL_TOPIC_PREFIX_DEFAULT),
         srClientFactory
     );
   }

--- a/ksql-engine/src/test/java/io/confluent/ksql/util/KafkaTopicClientImplIntegrationTest.java
+++ b/ksql-engine/src/test/java/io/confluent/ksql/util/KafkaTopicClientImplIntegrationTest.java
@@ -76,7 +76,7 @@ public class KafkaTopicClientImplIntegrationTest {
     adminClient = AdminClient.create(ImmutableMap.of(
         AdminClientConfig.BOOTSTRAP_SERVERS_CONFIG, KAFKA.bootstrapServers()));
 
-    client = new KafkaTopicClientImpl(adminClient);
+    client = new KafkaTopicClientImpl(adminClient, KsqlConfig.KSQL_INTERNAL_TOPIC_PREFIX_DEFAULT);
 
     allowForAsyncTopicCreation();
   }

--- a/ksql-rest-app/src/main/java/io/confluent/ksql/rest/entity/KafkaTopicsList.java
+++ b/ksql-rest-app/src/main/java/io/confluent/ksql/rest/entity/KafkaTopicsList.java
@@ -23,7 +23,6 @@ import io.confluent.ksql.metastore.model.KsqlTopic;
 import io.confluent.ksql.util.KafkaConsumerGroupClient;
 import io.confluent.ksql.util.KafkaConsumerGroupClientImpl;
 import io.confluent.ksql.util.KsqlConfig;
-import io.confluent.ksql.util.KsqlConstants;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
@@ -155,7 +154,7 @@ public class KafkaTopicsList extends KsqlEntity {
       final Map<String, TopicDescription> kafkaTopicDescriptions, final KsqlConfig ksqlConfig
   ) {
     final Map<String, TopicDescription> filteredKafkaTopics = new HashMap<>();
-    final String serviceId = KsqlConstants.KSQL_INTERNAL_TOPIC_PREFIX
+    final String serviceId = ksqlConfig.getString(KsqlConfig.KSQL_INTERNAL_TOPIC_PREFIX_CONFIG)
                        + ksqlConfig.getString(KsqlConfig.KSQL_SERVICE_ID_CONFIG);
     final String persistentQueryPrefix = ksqlConfig.getString(
         KsqlConfig.KSQL_PERSISTENT_QUERY_NAME_PREFIX_CONFIG);

--- a/ksql-rest-app/src/main/java/io/confluent/ksql/rest/server/KsqlRestConfig.java
+++ b/ksql-rest-app/src/main/java/io/confluent/ksql/rest/server/KsqlRestConfig.java
@@ -15,7 +15,6 @@
 
 package io.confluent.ksql.rest.server;
 
-import io.confluent.ksql.util.KsqlConstants;
 import io.confluent.ksql.util.KsqlException;
 import io.confluent.rest.RestConfig;
 import java.util.Map;
@@ -132,10 +131,11 @@ public class KsqlRestConfig extends RestConfig {
     return getOriginals();
   }
 
-  public static String getCommandTopic(final String ksqlServiceId) {
+  public static String getCommandTopic(final String ksqlInternalTopicPrefix,
+      final String ksqlServiceId) {
     return String.format(
         "%s%s_%s",
-        KsqlConstants.KSQL_INTERNAL_TOPIC_PREFIX,
+        ksqlInternalTopicPrefix,
         ksqlServiceId,
         COMMAND_TOPIC_SUFFIX
     );

--- a/ksql-rest-app/src/test/java/io/confluent/ksql/rest/server/KsqlRestConfigTest.java
+++ b/ksql-rest-app/src/test/java/io/confluent/ksql/rest/server/KsqlRestConfigTest.java
@@ -77,8 +77,8 @@ public class KsqlRestConfigTest {
 
   @Test
   public void ensureCorrectCommandTopicName() {
-    final String commandTopicName = KsqlRestConfig.getCommandTopic("TestKSql");
+    final String commandTopicName = KsqlRestConfig.getCommandTopic("TestPrefix", "TestKSql");
     assertThat(commandTopicName,
-               equalTo("_confluent-ksql-TestKSql_" + KsqlRestConfig.COMMAND_TOPIC_SUFFIX));
+               equalTo("TestPrefixTestKSql_" + KsqlRestConfig.COMMAND_TOPIC_SUFFIX));
   }
 }


### PR DESCRIPTION
Fixes #2933 and #2934

### Description 
Added two new config flags
- `ksql.internal.topic.name.prefix`
- `ksql.internal.topic.retention`

These flags allow ksql to be run against heroku installations in [multi-tenant mode](https://devcenter.heroku.com/articles/multi-tenant-kafka-on-heroku).

### Testing done 
- Existing tests pass
- With new configuration, I was able to run 
`bin/ksql-run-class io.confluent.ksql.rest.servsqlServerMain  ksql-server.properties` 
which would fail without these code changes

### Reviewer checklist
- [ ] Ensure docs are updated if necessary. (eg. if a user visible feature is being added or changed).
- [ ] Ensure relevant issues are linked (description should include text like "Fixes #<issue number>")

