### PR TITLE
Minor: Correct tests to ensure sources have correct schemas

### DIFF
--- a/ksql-engine/src/main/java/io/confluent/ksql/structured/SchemaKStream.java
+++ b/ksql-engine/src/main/java/io/confluent/ksql/structured/SchemaKStream.java
@@ -566,6 +566,12 @@ public class SchemaKStream<K> {
   }
 
   private Object extractColumn(final Field newKeyField, final GenericRow value) {
+    if (value.getColumns().size() != schema.fields().size()) {
+      throw new IllegalStateException("Field count mismatch. "
+          + "Schema fields: " + schema
+          + ", row:" + value);
+    }
+
     return value
         .getColumns()
         .get(schema.fieldIndex(newKeyField.name()).orElseThrow(IllegalStateException::new));

--- a/ksql-engine/src/test/java/io/confluent/ksql/analyzer/AnalyzerTest.java
+++ b/ksql-engine/src/test/java/io/confluent/ksql/analyzer/AnalyzerTest.java
@@ -17,11 +17,9 @@ package io.confluent.ksql.analyzer;
 
 import static io.confluent.ksql.testutils.AnalysisTestUtil.analyzeQuery;
 import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.Matchers.contains;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.not;
 import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
@@ -35,8 +33,6 @@ import io.confluent.ksql.ddl.DdlConfig;
 import io.confluent.ksql.function.InternalFunctionRegistry;
 import io.confluent.ksql.metastore.MetaStore;
 import io.confluent.ksql.metastore.MutableMetaStore;
-import io.confluent.ksql.metastore.SerdeFactory;
-import io.confluent.ksql.metastore.model.DataSource;
 import io.confluent.ksql.metastore.model.KeyField;
 import io.confluent.ksql.metastore.model.KsqlStream;
 import io.confluent.ksql.metastore.model.KsqlTopic;
@@ -113,11 +109,6 @@ public class AnalyzerTest {
         serdeOptiponsSupplier
     );
 
-    final KsqlTopic sinkTopic = mock(KsqlTopic.class);
-    final DataSource<?> sinkSource = mock(DataSource.class);
-    when(sinkSource.getKsqlTopic()).thenReturn(sinkTopic);
-    final SerdeFactory<?> keySerdeFactory = mock(SerdeFactory.class);
-    when(sinkSource.getKeySerdeFactory()).thenReturn((SerdeFactory)keySerdeFactory);
     when(sink.getName()).thenReturn("TEST0");
 
     query = parseSingle("Select COL0, COL1 from TEST1;");
@@ -383,7 +374,7 @@ public class AnalyzerTest {
     final KsqlStream<?> ksqlStream = new KsqlStream<>(
             "create stream s0 with(KAFKA_TOPIC='s0', VALUE_AVRO_SCHEMA_FULL_NAME='org.ac.s1', VALUE_FORMAT='avro');",
             "S0",
-            LogicalSchema.of(schema),
+            LogicalSchema.of(schema).withImplicitFields(),
         SerdeOption.none(),
             KeyField.of("FIELD1", schema.field("FIELD1")),
             new MetadataTimestampExtractionPolicy(),

--- a/ksql-engine/src/test/java/io/confluent/ksql/analyzer/QueryAnalyzerTest.java
+++ b/ksql-engine/src/test/java/io/confluent/ksql/analyzer/QueryAnalyzerTest.java
@@ -371,8 +371,8 @@ public class QueryAnalyzerTest {
     expectedException.expect(KsqlException.class);
     expectedException.expectMessage(containsString(
         "Non-aggregate SELECT expression(s) not part of GROUP BY: "
-            + "[ORDERS.ORDERTIME, ORDERS.ORDERUNITS, ORDERS.MAPCOL, ORDERS.ORDERID, "
-            + "ORDERS.ITEMINFO, ORDERS.ARRAYCOL, ORDERS.ADDRESS]"
+            + "[ORDERS.ORDERTIME, ORDERS.ROWTIME, ORDERS.ROWKEY, ORDERS.ORDERUNITS, ORDERS.MAPCOL, "
+            + "ORDERS.ORDERID, ORDERS.ITEMINFO, ORDERS.ARRAYCOL, ORDERS.ADDRESS]"
     ));
 
     // When:
@@ -383,7 +383,7 @@ public class QueryAnalyzerTest {
   public void shouldHandleSelectStarWithCorrectGroupBy() {
     // Given:
     final Query query = givenQuery("select *, count() from orders group by "
-        + "ITEMID, ORDERTIME, ORDERUNITS, MAPCOL, ORDERID, ITEMINFO, ARRAYCOL, ADDRESS;");
+        + "ROWTIME, ROWKEY, ITEMID, ORDERTIME, ORDERUNITS, MAPCOL, ORDERID, ITEMINFO, ARRAYCOL, ADDRESS;");
 
     final Analysis analysis = queryAnalyzer.analyze("sqlExpression", query, Optional.empty());
 
@@ -393,8 +393,9 @@ public class QueryAnalyzerTest {
     // Then:
     assertThat(aggregateAnalysis.getNonAggregateSelectExpressions().keySet(), containsInAnyOrder(
         dereferenceExpressions(
-            "ORDERS.ITEMID", "ORDERS.ORDERTIME", "ORDERS.ORDERUNITS", "ORDERS.MAPCOL",
-            "ORDERS.ORDERID", "ORDERS.ITEMINFO", "ORDERS.ARRAYCOL", "ORDERS.ADDRESS")
+            "ORDERS.ROWTIME", "ORDERS.ROWKEY", "ORDERS.ITEMID", "ORDERS.ORDERTIME",
+            "ORDERS.ORDERUNITS", "ORDERS.MAPCOL", "ORDERS.ORDERID", "ORDERS.ITEMINFO",
+            "ORDERS.ARRAYCOL", "ORDERS.ADDRESS")
     ));
   }
 

--- a/ksql-engine/src/test/java/io/confluent/ksql/codegen/CodeGenRunnerTest.java
+++ b/ksql-engine/src/test/java/io/confluent/ksql/codegen/CodeGenRunnerTest.java
@@ -154,6 +154,8 @@ public class CodeGenRunnerTest {
             .build();
 
         final Schema metaStoreSchema = SchemaBuilder.struct()
+            .field("ROWTIME", SchemaBuilder.OPTIONAL_INT64_SCHEMA)
+            .field("ROWKEY", SchemaBuilder.OPTIONAL_STRING_SCHEMA)
             .field("COL0", SchemaBuilder.OPTIONAL_INT64_SCHEMA)
             .field("COL1", SchemaBuilder.OPTIONAL_STRING_SCHEMA)
             .field("COL2", SchemaBuilder.OPTIONAL_STRING_SCHEMA)

--- a/ksql-engine/src/test/java/io/confluent/ksql/engine/AuthorizationTopicAccessValidatorTest.java
+++ b/ksql-engine/src/test/java/io/confluent/ksql/engine/AuthorizationTopicAccessValidatorTest.java
@@ -52,6 +52,8 @@ import org.mockito.junit.MockitoJUnitRunner;
 public class AuthorizationTopicAccessValidatorTest {
   private static final LogicalSchema SCHEMA = LogicalSchema.of(SchemaBuilder
       .struct()
+      .field("ROWTIME", Schema.OPTIONAL_INT64_SCHEMA)
+      .field("ROWKEY", Schema.OPTIONAL_STRING_SCHEMA)
       .field("F1", Schema.OPTIONAL_STRING_SCHEMA)
       .build());
 

--- a/ksql-engine/src/test/java/io/confluent/ksql/integration/StreamsSelectAndProjectIntTest.java
+++ b/ksql-engine/src/test/java/io/confluent/ksql/integration/StreamsSelectAndProjectIntTest.java
@@ -21,6 +21,7 @@ import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
 
+import com.google.common.collect.ImmutableList;
 import io.confluent.common.utils.IntegrationTest;
 import io.confluent.ksql.GenericRow;
 import io.confluent.ksql.metastore.model.DataSource;
@@ -38,7 +39,6 @@ import java.util.concurrent.TimeUnit;
 import kafka.zookeeper.ZooKeeperClientException;
 import org.apache.kafka.clients.consumer.ConsumerRecord;
 import org.apache.kafka.clients.producer.RecordMetadata;
-import org.junit.Assert;
 import org.junit.Before;
 import org.junit.ClassRule;
 import org.junit.Rule;
@@ -244,7 +244,7 @@ public class StreamsSelectAndProjectIntTest {
 
     assertThat(results.get(0).key(), is("8"));
     assertThat(results.get(0).value(), is(new GenericRow(
-        Arrays.asList(null, null, "8", recordMetadataMap.get("8").timestamp(), "ITEM_8"))));
+        ImmutableList.of("8", recordMetadataMap.get("8").timestamp(), "ITEM_8"))));
   }
 
   private void testSelectProject(
@@ -261,8 +261,7 @@ public class StreamsSelectAndProjectIntTest {
         getResultSchema());
 
     final GenericRow value = results.get(0).value();
-    // skip over first to values (rowKey, rowTime)
-    Assert.assertEquals( "ITEM_1", value.getColumns().get(2));
+    assertThat(value.getColumns().get(0), is("ITEM_1"));
   }
 
 
@@ -281,8 +280,7 @@ public class StreamsSelectAndProjectIntTest {
         getResultSchema());
 
     final GenericRow value = results.get(0).value();
-    // skip over first to values (rowKey, rowTime)
-    Assert.assertEquals( "ITEM_1", value.getColumns().get(2).toString());
+    assertThat(value.getColumns().get(0), is("ITEM_1"));
   }
 
   private void testSelectStar(
@@ -330,8 +328,7 @@ public class StreamsSelectAndProjectIntTest {
         getResultSchema());
 
     final GenericRow value = results.get(0).value();
-    // skip over first to values (rowKey, rowTime)
-    Assert.assertEquals( "ITEM_1", value.getColumns().get(2).toString());
+    assertThat(value.getColumns().get(0), is("ITEM_1"));
   }
 
   @Test
@@ -349,8 +346,7 @@ public class StreamsSelectAndProjectIntTest {
         getResultSchema());
 
     final GenericRow value = results.get(0).value();
-    // skip over first to values (rowKey, rowTime)
-    Assert.assertEquals( "ITEM_1", value.getColumns().get(2).toString());
+    assertThat(value.getColumns().get(0), is("ITEM_1"));
   }
 
   @Test
@@ -419,7 +415,7 @@ public class StreamsSelectAndProjectIntTest {
         .getSource(resultStream.toUpperCase());
 
     return PhysicalSchema.from(
-        source.getSchema(),
+        source.getSchema().withoutImplicitFields(),
         source.getSerdeOptions()
     );
   }

--- a/ksql-engine/src/test/java/io/confluent/ksql/physical/PhysicalPlanBuilderTest.java
+++ b/ksql-engine/src/test/java/io/confluent/ksql/physical/PhysicalPlanBuilderTest.java
@@ -334,12 +334,12 @@ public class PhysicalPlanBuilderTest {
         "\t\t\t\t > [ PROJECT ] | Schema: [KSQL_INTERNAL_COL_0 BIGINT, "
             + "KSQL_INTERNAL_COL_1 DOUBLE] |"));
     assertThat(lines[3], startsWith(
-        "\t\t\t\t\t\t > [ FILTER ] | Schema: [TEST1.ROWTIME BIGINT, TEST1.ROWKEY BIGINT, "
+        "\t\t\t\t\t\t > [ FILTER ] | Schema: [TEST1.ROWTIME BIGINT, TEST1.ROWKEY VARCHAR, "
             + "TEST1.COL0 BIGINT, TEST1.COL1 VARCHAR, TEST1.COL2 VARCHAR, "
             + "TEST1.COL3 DOUBLE, TEST1.COL4 ARRAY<DOUBLE>, "
             + "TEST1.COL5 MAP<VARCHAR, DOUBLE>] |"));
     assertThat(lines[4], startsWith(
-        "\t\t\t\t\t\t\t\t > [ SOURCE ] | Schema: [TEST1.ROWTIME BIGINT, TEST1.ROWKEY BIGINT, "
+        "\t\t\t\t\t\t\t\t > [ SOURCE ] | Schema: [TEST1.ROWTIME BIGINT, TEST1.ROWKEY VARCHAR, "
             + "TEST1.COL0 BIGINT, TEST1.COL1 VARCHAR, TEST1.COL2 VARCHAR, "
             + "TEST1.COL3 DOUBLE, TEST1.COL4 ARRAY<DOUBLE>, "
             + "TEST1.COL5 MAP<VARCHAR, DOUBLE>] |"));
@@ -443,14 +443,14 @@ public class PhysicalPlanBuilderTest {
     final String planText = queries.get(1).getExecutionPlan();
     final String[] lines = planText.split("\n");
     assertThat(lines.length, equalTo(3));
-    assertThat(lines[0], containsString("> [ SINK ] | "
-        + "Schema: [ROWTIME BIGINT, ROWKEY VARCHAR, COL0 INT]"));
+    assertThat(lines[0], containsString(
+        "> [ SINK ] | Schema: [ROWTIME BIGINT, ROWKEY VARCHAR, COL0 INT]"));
 
-    assertThat(lines[1], containsString("> [ PROJECT ] | "
-        + "Schema: [ROWTIME BIGINT, ROWKEY VARCHAR, COL0 INT]"));
+    assertThat(lines[1], containsString(
+        "> [ PROJECT ] | Schema: [ROWTIME BIGINT, ROWKEY VARCHAR, COL0 INT]"));
 
-    assertThat(lines[2], containsString("> [ SOURCE ] | "
-        + "Schema: [TEST1.ROWTIME BIGINT, TEST1.ROWKEY VARCHAR, TEST1.COL0 INT]"));
+    assertThat(lines[2], containsString(
+        "> [ SOURCE ] | Schema: [TEST1.ROWTIME BIGINT, TEST1.ROWKEY VARCHAR, TEST1.COL0 INT]"));
   }
 
   @Test

--- a/ksql-engine/src/test/java/io/confluent/ksql/planner/plan/DataSourceNodeTest.java
+++ b/ksql-engine/src/test/java/io/confluent/ksql/planner/plan/DataSourceNodeTest.java
@@ -51,6 +51,7 @@ import io.confluent.ksql.structured.SchemaKStream;
 import io.confluent.ksql.structured.SchemaKTable;
 import io.confluent.ksql.util.KsqlConfig;
 import io.confluent.ksql.util.QueryLoggerUtil;
+import io.confluent.ksql.util.SchemaUtil;
 import io.confluent.ksql.util.timestamp.LongColumnTimestampExtractionPolicy;
 import io.confluent.ksql.util.timestamp.TimestampExtractionPolicy;
 import java.util.Arrays;
@@ -97,6 +98,8 @@ public class DataSourceNodeTest {
   private SchemaKStream realStream;
   private StreamsBuilder realBuilder;
   private final LogicalSchema realSchema = LogicalSchema.of(SchemaBuilder.struct()
+      .field("ROWTIME", Schema.OPTIONAL_INT64_SCHEMA)
+      .field("ROWKEY", Schema.OPTIONAL_STRING_SCHEMA)
       .field("field1", Schema.OPTIONAL_STRING_SCHEMA)
       .field("field2", Schema.OPTIONAL_STRING_SCHEMA)
       .field("field3", Schema.OPTIONAL_STRING_SCHEMA)
@@ -365,6 +368,8 @@ public class DataSourceNodeTest {
     // Then:
     assertThat(schema, is(
         LogicalSchema.of(SchemaBuilder.struct()
+            .field(sourceName + "." + SchemaUtil.ROWTIME_NAME, Schema.OPTIONAL_INT64_SCHEMA)
+            .field(sourceName + "." + SchemaUtil.ROWKEY_NAME, Schema.OPTIONAL_STRING_SCHEMA)
             .field(sourceName + ".field1", Schema.OPTIONAL_STRING_SCHEMA)
             .field(sourceName + ".field2", Schema.OPTIONAL_STRING_SCHEMA)
             .field(sourceName + ".field3", Schema.OPTIONAL_STRING_SCHEMA)
@@ -378,7 +383,8 @@ public class DataSourceNodeTest {
     // Given:
     final DataSourceNode node = nodeWithMockTableSource();
 
-    final PhysicalSchema expected = PhysicalSchema.from(realSchema, serdeOptions);
+    final PhysicalSchema expected = PhysicalSchema
+        .from(realSchema.withoutImplicitFields(), serdeOptions);
 
     // When:
     node.buildStream(ksqlStreamBuilder);

--- a/ksql-engine/src/test/java/io/confluent/ksql/planner/plan/JoinNodeTest.java
+++ b/ksql-engine/src/test/java/io/confluent/ksql/planner/plan/JoinNodeTest.java
@@ -61,7 +61,6 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Optional;
-import java.util.Set;
 import java.util.concurrent.TimeUnit;
 import java.util.function.Predicate;
 import java.util.stream.Collectors;
@@ -89,24 +88,33 @@ import org.mockito.junit.MockitoJUnitRunner;
 @RunWith(MockitoJUnitRunner.class)
 public class JoinNodeTest {
 
+  private static final LogicalSchema LEFT_SCHEMA = LogicalSchema.of(SchemaBuilder
+      .struct()
+      .field("C0", SchemaBuilder.OPTIONAL_INT64_SCHEMA)
+      .field("L1", SchemaBuilder.OPTIONAL_STRING_SCHEMA)
+      .build()).withImplicitFields();
+
+  private static final LogicalSchema RIGHT_SCHEMA = LogicalSchema.of(SchemaBuilder
+      .struct()
+      .field("C0", SchemaBuilder.OPTIONAL_INT64_SCHEMA)
+      .field("R1", SchemaBuilder.OPTIONAL_STRING_SCHEMA)
+      .build()).withImplicitFields();
+
+  private static final String LEFT_ALIAS = "left";
+  private static final String RIGHT_ALIAS = "right";
+
+  private static final LogicalSchema JOIN_SCHEMA = joinSchema();
+
   private static final Optional<String> NO_KEY_FIELD = Optional.empty();
   private final KsqlConfig ksqlConfig = new KsqlConfig(new HashMap<>());
   private StreamsBuilder builder;
-  private SchemaKStream stream;
   private JoinNode joinNode;
 
   @Mock
   private KafkaTopicClient mockKafkaTopicClient;
 
-  private static final String leftAlias = "left";
-  private static final String rightAlias = "right";
-
-  private final LogicalSchema leftSchema = createSchema(leftAlias);
-  private final LogicalSchema rightSchema = createSchema(rightAlias);
-  private final LogicalSchema joinSchema = joinSchema();
-
-  private static final String LEFT_JOIN_FIELD_NAME = leftAlias + ".COL0";
-  private static final String RIGHT_JOIN_FIELD_NAME = rightAlias + ".COL1";
+  private static final String LEFT_JOIN_FIELD_NAME = LEFT_ALIAS + ".C0";
+  private static final String RIGHT_JOIN_FIELD_NAME = RIGHT_ALIAS + ".R1";
   private static final KeyField leftJoinField = KeyField
       .of(LEFT_JOIN_FIELD_NAME, new Field(LEFT_JOIN_FIELD_NAME, 1, Schema.OPTIONAL_STRING_SCHEMA));
   private static final KeyField rightJoinField = KeyField
@@ -162,8 +170,11 @@ public class JoinNodeTest {
         new QueryContext.Stacker(queryId)
             .push(inv.getArgument(0).toString()));
 
-    when(left.getSchema()).thenReturn(leftSchema);
-    when(right.getSchema()).thenReturn(rightSchema);
+    when(leftSource.getSchema()).thenReturn(LEFT_SCHEMA);
+    when(rightSource.getSchema()).thenReturn(RIGHT_SCHEMA);
+
+    when(left.getSchema()).thenReturn(LEFT_SCHEMA.withAlias(LEFT_ALIAS));
+    when(right.getSchema()).thenReturn(RIGHT_SCHEMA.withAlias(RIGHT_ALIAS));
 
     when(left.getPartitions(mockKafkaTopicClient)).thenReturn(2);
     when(right.getPartitions(mockKafkaTopicClient)).thenReturn(2);
@@ -190,8 +201,8 @@ public class JoinNodeTest {
         right,
         "won't find me",
         RIGHT_JOIN_FIELD_NAME,
-        leftAlias,
-        rightAlias,
+        LEFT_ALIAS,
+        RIGHT_ALIAS,
         null,
         DataSource.DataSourceType.KSTREAM,
         DataSource.DataSourceType.KSTREAM);
@@ -211,8 +222,8 @@ public class JoinNodeTest {
         right,
         LEFT_JOIN_FIELD_NAME,
         "won't find me",
-        leftAlias,
-        rightAlias,
+        LEFT_ALIAS,
+        RIGHT_ALIAS,
         null,
         DataSource.DataSourceType.KSTREAM,
         DataSource.DataSourceType.KSTREAM);
@@ -228,8 +239,8 @@ public class JoinNodeTest {
         right,
         LEFT_JOIN_FIELD_NAME,
         RIGHT_JOIN_FIELD_NAME,
-        leftAlias,
-        rightAlias,
+        LEFT_ALIAS,
+        RIGHT_ALIAS,
         null,
         DataSourceType.KSTREAM,
         DataSourceType.KSTREAM);
@@ -248,8 +259,8 @@ public class JoinNodeTest {
         right,
         LEFT_JOIN_FIELD_NAME,
         RIGHT_JOIN_FIELD_NAME,
-        leftAlias,
-        rightAlias,
+        LEFT_ALIAS,
+        RIGHT_ALIAS,
         null,
         DataSourceType.KSTREAM,
         DataSourceType.KSTREAM);
@@ -269,15 +280,15 @@ public class JoinNodeTest {
         right,
         LEFT_JOIN_FIELD_NAME,
         RIGHT_JOIN_FIELD_NAME,
-        leftAlias,
-        rightAlias,
+        LEFT_ALIAS,
+        RIGHT_ALIAS,
         null,
         DataSourceType.KSTREAM,
         DataSourceType.KSTREAM);
 
     // Then:
-    assertThat(joinNode.getLeftAlias(), is(leftAlias));
-    assertThat(joinNode.getRightAlias(), is(rightAlias));
+    assertThat(joinNode.getLeftAlias(), is(LEFT_ALIAS));
+    assertThat(joinNode.getRightAlias(), is(RIGHT_ALIAS));
   }
 
   @Test
@@ -290,8 +301,8 @@ public class JoinNodeTest {
         right,
         LEFT_JOIN_FIELD_NAME,
         RIGHT_JOIN_FIELD_NAME,
-        leftAlias,
-        rightAlias,
+        LEFT_ALIAS,
+        RIGHT_ALIAS,
         null,
         DataSourceType.KSTREAM,
         DataSourceType.KSTREAM);
@@ -368,29 +379,10 @@ public class JoinNodeTest {
   }
 
   @Test
-  public void shouldHaveAllFieldsFromJoinedInputs() {
-    setupTopicClientExpectations(1, 1);
-    buildJoin();
-    final MetaStore metaStore = MetaStoreFixture.getNewMetaStore(new InternalFunctionRegistry());
-    final DataSource<?> source1
-        = metaStore.getSource("TEST1");
-    final DataSource<?> source2 = metaStore.getSource("TEST2");
-    final Set<String> expected = source1.getSchema()
-        .fields().stream()
-        .map(field -> "T1." + field.name()).collect(Collectors.toSet());
-
-    expected.addAll(source2.getSchema().fields().stream().map(field -> "T2." + field.name())
-        .collect(Collectors.toSet()));
-    final Set<String> fields = stream.getSchema().fields().stream().map(Field::name)
-        .collect(Collectors.toSet());
-    assertThat(fields, equalTo(expected));
-  }
-
-  @Test
   public void shouldPerformStreamToStreamLeftJoin() {
     // Given:
-    setupStream(left, leftSchemaKStream, leftSchema);
-    setupStream(right, rightSchemaKStream, rightSchema);
+    setupStream(left, leftSchemaKStream);
+    setupStream(right, rightSchemaKStream);
 
     final JoinNode joinNode = new JoinNode(
         nodeId,
@@ -399,8 +391,8 @@ public class JoinNodeTest {
         right,
         LEFT_JOIN_FIELD_NAME,
         RIGHT_JOIN_FIELD_NAME,
-        leftAlias,
-        rightAlias,
+        LEFT_ALIAS,
+        RIGHT_ALIAS,
         WITHIN_EXPRESSION,
         DataSourceType.KSTREAM,
         DataSourceType.KSTREAM);
@@ -411,7 +403,7 @@ public class JoinNodeTest {
     // Then:
     verify(leftSchemaKStream).leftJoin(
         eq(rightSchemaKStream),
-        eq(joinSchema),
+        eq(JOIN_SCHEMA),
         eq(leftJoinField),
         eq(WITHIN_EXPRESSION.joinWindow()),
         any(),
@@ -422,8 +414,8 @@ public class JoinNodeTest {
   @Test
   public void shouldPerformStreamToStreamInnerJoin() {
     // Given:
-    setupStream(left, leftSchemaKStream, leftSchema);
-    setupStream(right, rightSchemaKStream, rightSchema);
+    setupStream(left, leftSchemaKStream);
+    setupStream(right, rightSchemaKStream);
 
     final JoinNode joinNode = new JoinNode(
         nodeId,
@@ -432,8 +424,8 @@ public class JoinNodeTest {
         right,
         LEFT_JOIN_FIELD_NAME,
         RIGHT_JOIN_FIELD_NAME,
-        leftAlias,
-        rightAlias,
+        LEFT_ALIAS,
+        RIGHT_ALIAS,
         WITHIN_EXPRESSION,
         DataSourceType.KSTREAM,
         DataSourceType.KSTREAM);
@@ -444,7 +436,7 @@ public class JoinNodeTest {
     // Then:
     verify(leftSchemaKStream).join(
         eq(rightSchemaKStream),
-        eq(joinSchema),
+        eq(JOIN_SCHEMA),
         eq(leftJoinField),
         eq(WITHIN_EXPRESSION.joinWindow()),
         any(),
@@ -455,8 +447,8 @@ public class JoinNodeTest {
   @Test
   public void shouldPerformStreamToStreamOuterJoin() {
     // Given:
-    setupStream(left, leftSchemaKStream, leftSchema);
-    setupStream(right, rightSchemaKStream, rightSchema);
+    setupStream(left, leftSchemaKStream);
+    setupStream(right, rightSchemaKStream);
 
     final JoinNode joinNode = new JoinNode(
         nodeId,
@@ -465,8 +457,8 @@ public class JoinNodeTest {
         right,
         LEFT_JOIN_FIELD_NAME,
         RIGHT_JOIN_FIELD_NAME,
-        leftAlias,
-        rightAlias,
+        LEFT_ALIAS,
+        RIGHT_ALIAS,
         WITHIN_EXPRESSION,
         DataSourceType.KSTREAM,
         DataSourceType.KSTREAM);
@@ -477,7 +469,7 @@ public class JoinNodeTest {
     // Then:
     verify(leftSchemaKStream).outerJoin(
         eq(rightSchemaKStream),
-        eq(joinSchema),
+        eq(JOIN_SCHEMA),
         eq(leftJoinField.withName(Optional.empty())),
         eq(WITHIN_EXPRESSION.joinWindow()),
         any(),
@@ -495,8 +487,8 @@ public class JoinNodeTest {
         right,
         LEFT_JOIN_FIELD_NAME,
         RIGHT_JOIN_FIELD_NAME,
-        leftAlias,
-        rightAlias,
+        LEFT_ALIAS,
+        RIGHT_ALIAS,
         null,
         DataSourceType.KSTREAM,
         DataSourceType.KSTREAM);
@@ -523,8 +515,8 @@ public class JoinNodeTest {
         right,
         LEFT_JOIN_FIELD_NAME,
         RIGHT_JOIN_FIELD_NAME,
-        leftAlias,
-        rightAlias,
+        LEFT_ALIAS,
+        RIGHT_ALIAS,
         WITHIN_EXPRESSION,
         DataSourceType.KSTREAM,
         DataSourceType.KSTREAM);
@@ -542,11 +534,11 @@ public class JoinNodeTest {
   @Test
   public void shouldFailJoinIfTableCriteriaColumnIsNotKey() {
     // Given:
-    setupStream(left, leftSchemaKStream, leftSchema);
-    setupTable(right, rightSchemaKTable, rightSchema);
+    setupStream(left, leftSchemaKStream);
+    setupTable(right, rightSchemaKTable);
 
     final String rightCriteriaColumn =
-        getNonKeyColumn(rightSchema, rightAlias, RIGHT_JOIN_FIELD_NAME);
+        getNonKeyColumn(RIGHT_SCHEMA, RIGHT_ALIAS, RIGHT_JOIN_FIELD_NAME);
 
     final JoinNode joinNode = new JoinNode(
         nodeId,
@@ -555,8 +547,8 @@ public class JoinNodeTest {
         right,
         LEFT_JOIN_FIELD_NAME,
         rightCriteriaColumn,
-        leftAlias,
-        rightAlias,
+        LEFT_ALIAS,
+        RIGHT_ALIAS,
         null,
         DataSourceType.KSTREAM,
         DataSourceType.KTABLE);
@@ -566,7 +558,7 @@ public class JoinNodeTest {
     expectedException.expectMessage(String.format(
         "Source table (%s) key column (%s) is not the column used in the join criteria (%s). "
             + "Only the table's key column or 'ROWKEY' is supported in the join criteria.",
-        rightAlias,
+        RIGHT_ALIAS,
         RIGHT_JOIN_FIELD_NAME,
         rightCriteriaColumn
     ));
@@ -578,8 +570,8 @@ public class JoinNodeTest {
   @Test
   public void shouldFailJoinIfTableHasNoKeyAndJoinFieldIsNotRowKey() {
     // Given:
-    setupStream(left, leftSchemaKStream, leftSchema);
-    setupTable(right, rightSchemaKTable, rightSchema, NO_KEY_FIELD);
+    setupStream(left, leftSchemaKStream);
+    setupTable(right, rightSchemaKTable, NO_KEY_FIELD);
 
     final JoinNode joinNode = new JoinNode(
         nodeId,
@@ -588,8 +580,8 @@ public class JoinNodeTest {
         right,
         LEFT_JOIN_FIELD_NAME,
         RIGHT_JOIN_FIELD_NAME,
-        leftAlias,
-        rightAlias,
+        LEFT_ALIAS,
+        RIGHT_ALIAS,
         null,
         DataSource.DataSourceType.KSTREAM,
         DataSource.DataSourceType.KTABLE);
@@ -597,7 +589,7 @@ public class JoinNodeTest {
     // Then:
     expectedException.expect(KsqlException.class);
     expectedException.expectMessage(
-        "Source table (" + rightAlias +") has no key column defined. "
+        "Source table (" + RIGHT_ALIAS + ") has no key column defined. "
             + "Only 'ROWKEY' is supported in the join criteria."
     );
 
@@ -608,8 +600,8 @@ public class JoinNodeTest {
   @Test
   public void shouldHandleJoinIfTableHasNoKeyAndJoinFieldIsRowKey() {
     // Given:
-    setupStream(left, leftSchemaKStream, leftSchema);
-    setupTable(right, rightSchemaKTable, rightSchema, NO_KEY_FIELD);
+    setupStream(left, leftSchemaKStream);
+    setupTable(right, rightSchemaKTable, NO_KEY_FIELD);
 
     final JoinNode joinNode = new JoinNode(
         nodeId,
@@ -618,8 +610,8 @@ public class JoinNodeTest {
         right,
         LEFT_JOIN_FIELD_NAME,
         "right.ROWKEY",
-        leftAlias,
-        rightAlias,
+        LEFT_ALIAS,
+        RIGHT_ALIAS,
         null,
         DataSource.DataSourceType.KSTREAM,
         DataSource.DataSourceType.KTABLE);
@@ -630,7 +622,7 @@ public class JoinNodeTest {
     // Then:
     verify(leftSchemaKStream).leftJoin(
         eq(rightSchemaKTable),
-        eq(joinSchema),
+        eq(JOIN_SCHEMA),
         eq(leftJoinField),
         any(),
         eq(CONTEXT_STACKER));
@@ -639,8 +631,8 @@ public class JoinNodeTest {
   @Test
   public void shouldPerformStreamToTableLeftJoin() {
     // Given:
-    setupStream(left, leftSchemaKStream, leftSchema);
-    setupTable(right, rightSchemaKTable, rightSchema);
+    setupStream(left, leftSchemaKStream);
+    setupTable(right, rightSchemaKTable);
 
     final JoinNode joinNode = new JoinNode(
         nodeId,
@@ -649,8 +641,8 @@ public class JoinNodeTest {
         right,
         LEFT_JOIN_FIELD_NAME,
         RIGHT_JOIN_FIELD_NAME,
-        leftAlias,
-        rightAlias,
+        LEFT_ALIAS,
+        RIGHT_ALIAS,
         null,
         DataSourceType.KSTREAM,
         DataSourceType.KTABLE);
@@ -661,7 +653,7 @@ public class JoinNodeTest {
     // Then:
     verify(leftSchemaKStream).leftJoin(
         eq(rightSchemaKTable),
-        eq(joinSchema),
+        eq(JOIN_SCHEMA),
         eq(leftJoinField),
         any(),
         eq(CONTEXT_STACKER));
@@ -670,8 +662,8 @@ public class JoinNodeTest {
   @Test
   public void shouldPerformStreamToTableInnerJoin() {
     // Given:
-    setupStream(left, leftSchemaKStream, leftSchema);
-    setupTable(right, rightSchemaKTable, rightSchema);
+    setupStream(left, leftSchemaKStream);
+    setupTable(right, rightSchemaKTable);
 
     final JoinNode joinNode = new JoinNode(
         nodeId,
@@ -680,8 +672,8 @@ public class JoinNodeTest {
         right,
         LEFT_JOIN_FIELD_NAME,
         RIGHT_JOIN_FIELD_NAME,
-        leftAlias,
-        rightAlias,
+        LEFT_ALIAS,
+        RIGHT_ALIAS,
         null,
         DataSourceType.KSTREAM,
         DataSourceType.KTABLE);
@@ -692,7 +684,7 @@ public class JoinNodeTest {
     // Then:
     verify(leftSchemaKStream).join(
         eq(rightSchemaKTable),
-        eq(joinSchema),
+        eq(JOIN_SCHEMA),
         eq(leftJoinField),
         any(),
         eq(CONTEXT_STACKER));
@@ -701,8 +693,8 @@ public class JoinNodeTest {
   @Test
   public void shouldNotAllowStreamToTableOuterJoin() {
     // Given:
-    setupStream(left, leftSchemaKStream, leftSchema);
-    setupTable(right, rightSchemaKTable, rightSchema);
+    setupStream(left, leftSchemaKStream);
+    setupTable(right, rightSchemaKTable);
 
     final JoinNode joinNode = new JoinNode(
         nodeId,
@@ -711,8 +703,8 @@ public class JoinNodeTest {
         right,
         LEFT_JOIN_FIELD_NAME,
         RIGHT_JOIN_FIELD_NAME,
-        leftAlias,
-        rightAlias,
+        LEFT_ALIAS,
+        RIGHT_ALIAS,
         null,
         DataSourceType.KSTREAM,
         DataSourceType.KTABLE);
@@ -739,8 +731,8 @@ public class JoinNodeTest {
         right,
         LEFT_JOIN_FIELD_NAME,
         RIGHT_JOIN_FIELD_NAME,
-        leftAlias,
-        rightAlias,
+        LEFT_ALIAS,
+        RIGHT_ALIAS,
         withinExpression,
         DataSourceType.KSTREAM,
         DataSourceType.KTABLE);
@@ -758,10 +750,11 @@ public class JoinNodeTest {
   @Test
   public void shouldFailTableTableJoinIfLeftCriteriaColumnIsNotKey() {
     // Given:
-    setupTable(left, leftSchemaKTable, leftSchema);
-    setupTable(right, rightSchemaKTable, rightSchema);
+    setupTable(left, leftSchemaKTable);
+    setupTable(right, rightSchemaKTable);
 
-    final String leftCriteriaColumn = getNonKeyColumn(leftSchema, leftAlias, LEFT_JOIN_FIELD_NAME);
+    final String leftCriteriaColumn = getNonKeyColumn(LEFT_SCHEMA, LEFT_ALIAS,
+        LEFT_JOIN_FIELD_NAME);
 
     final JoinNode joinNode = new JoinNode(
         nodeId,
@@ -770,8 +763,8 @@ public class JoinNodeTest {
         right,
         leftCriteriaColumn,
         RIGHT_JOIN_FIELD_NAME,
-        leftAlias,
-        rightAlias,
+        LEFT_ALIAS,
+        RIGHT_ALIAS,
         null,
         DataSourceType.KTABLE,
         DataSourceType.KTABLE);
@@ -781,7 +774,7 @@ public class JoinNodeTest {
     expectedException.expectMessage(String.format(
         "Source table (%s) key column (%s) is not the column used in the join criteria (%s). "
             + "Only the table's key column or 'ROWKEY' is supported in the join criteria.",
-        leftAlias,
+        LEFT_ALIAS,
         LEFT_JOIN_FIELD_NAME,
         leftCriteriaColumn
     ));
@@ -793,11 +786,11 @@ public class JoinNodeTest {
   @Test
   public void shouldFailTableTableJoinIfRightCriteriaColumnIsNotKey() {
     // Given:
-    setupTable(left, leftSchemaKTable, leftSchema);
-    setupTable(right, rightSchemaKTable, rightSchema);
+    setupTable(left, leftSchemaKTable);
+    setupTable(right, rightSchemaKTable);
 
     final String rightCriteriaColumn =
-        getNonKeyColumn(rightSchema, rightAlias, RIGHT_JOIN_FIELD_NAME);
+        getNonKeyColumn(RIGHT_SCHEMA, RIGHT_ALIAS, RIGHT_JOIN_FIELD_NAME);
 
     final JoinNode joinNode = new JoinNode(
         nodeId,
@@ -806,8 +799,8 @@ public class JoinNodeTest {
         right,
         LEFT_JOIN_FIELD_NAME,
         rightCriteriaColumn,
-        leftAlias,
-        rightAlias,
+        LEFT_ALIAS,
+        RIGHT_ALIAS,
         null,
         DataSourceType.KTABLE,
         DataSourceType.KTABLE);
@@ -817,7 +810,7 @@ public class JoinNodeTest {
     expectedException.expectMessage(String.format(
         "Source table (%s) key column (%s) is not the column used in the join criteria (%s). "
             + "Only the table's key column or 'ROWKEY' is supported in the join criteria.",
-        rightAlias,
+        RIGHT_ALIAS,
         RIGHT_JOIN_FIELD_NAME,
         rightCriteriaColumn
     ));
@@ -829,8 +822,8 @@ public class JoinNodeTest {
   @Test
   public void shouldPerformTableToTableInnerJoin() {
     // Given:
-    setupTable(left, leftSchemaKTable, leftSchema);
-    setupTable(right, rightSchemaKTable, rightSchema);
+    setupTable(left, leftSchemaKTable);
+    setupTable(right, rightSchemaKTable);
 
     final JoinNode joinNode = new JoinNode(
         nodeId,
@@ -839,8 +832,8 @@ public class JoinNodeTest {
         right,
         LEFT_JOIN_FIELD_NAME,
         RIGHT_JOIN_FIELD_NAME,
-        leftAlias,
-        rightAlias,
+        LEFT_ALIAS,
+        RIGHT_ALIAS,
         null,
         DataSourceType.KTABLE,
         DataSourceType.KTABLE);
@@ -851,7 +844,7 @@ public class JoinNodeTest {
     // Then:
     verify(leftSchemaKTable).join(
         eq(rightSchemaKTable),
-        eq(joinSchema),
+        eq(JOIN_SCHEMA),
         eq(leftJoinField),
         eq(CONTEXT_STACKER));
   }
@@ -859,8 +852,8 @@ public class JoinNodeTest {
   @Test
   public void shouldPerformTableToTableLeftJoin() {
     // Given:
-    setupTable(left, leftSchemaKTable, leftSchema);
-    setupTable(right, rightSchemaKTable, rightSchema);
+    setupTable(left, leftSchemaKTable);
+    setupTable(right, rightSchemaKTable);
 
     final JoinNode joinNode = new JoinNode(
         nodeId,
@@ -869,8 +862,8 @@ public class JoinNodeTest {
         right,
         LEFT_JOIN_FIELD_NAME,
         RIGHT_JOIN_FIELD_NAME,
-        leftAlias,
-        rightAlias,
+        LEFT_ALIAS,
+        RIGHT_ALIAS,
         null,
         DataSourceType.KTABLE,
         DataSourceType.KTABLE
@@ -882,7 +875,7 @@ public class JoinNodeTest {
     // Then:
     verify(leftSchemaKTable).leftJoin(
         eq(rightSchemaKTable),
-        eq(joinSchema),
+        eq(JOIN_SCHEMA),
         eq(leftJoinField),
         eq(CONTEXT_STACKER));
   }
@@ -890,8 +883,8 @@ public class JoinNodeTest {
   @Test
   public void shouldPerformTableToTableOuterJoin() {
     // Given:
-    setupTable(left, leftSchemaKTable, leftSchema);
-    setupTable(right, rightSchemaKTable, rightSchema);
+    setupTable(left, leftSchemaKTable);
+    setupTable(right, rightSchemaKTable);
 
     final JoinNode joinNode = new JoinNode(
         nodeId,
@@ -900,8 +893,8 @@ public class JoinNodeTest {
         right,
         LEFT_JOIN_FIELD_NAME,
         RIGHT_JOIN_FIELD_NAME,
-        leftAlias,
-        rightAlias,
+        LEFT_ALIAS,
+        RIGHT_ALIAS,
         null,
         DataSourceType.KTABLE,
         DataSourceType.KTABLE
@@ -913,7 +906,7 @@ public class JoinNodeTest {
     // Then:
     verify(leftSchemaKTable).outerJoin(
         eq(rightSchemaKTable),
-        eq(joinSchema),
+        eq(JOIN_SCHEMA),
         eq(leftJoinField.withName(Optional.empty())),
         eq(CONTEXT_STACKER));
   }
@@ -930,8 +923,8 @@ public class JoinNodeTest {
         right,
         LEFT_JOIN_FIELD_NAME,
         RIGHT_JOIN_FIELD_NAME,
-        leftAlias,
-        rightAlias,
+        LEFT_ALIAS,
+        RIGHT_ALIAS,
         withinExpression,
         DataSourceType.KTABLE,
         DataSourceType.KTABLE);
@@ -956,8 +949,8 @@ public class JoinNodeTest {
         right,
         LEFT_JOIN_FIELD_NAME,
         RIGHT_JOIN_FIELD_NAME,
-        leftAlias,
-        rightAlias,
+        LEFT_ALIAS,
+        RIGHT_ALIAS,
         null,
         DataSourceType.KTABLE,
         DataSourceType.KTABLE
@@ -966,14 +959,14 @@ public class JoinNodeTest {
     // When:
     assertThat(joinNode.getSchema(), is(LogicalSchema.of(
         SchemaBuilder.struct()
-            .field(leftAlias + ".ROWTIME", SchemaBuilder.OPTIONAL_INT64_SCHEMA)
-            .field(leftAlias + ".ROWKEY", SchemaBuilder.OPTIONAL_INT64_SCHEMA)
-            .field(leftAlias + ".COL0", SchemaBuilder.OPTIONAL_INT64_SCHEMA)
-            .field(leftAlias + ".COL1", SchemaBuilder.OPTIONAL_STRING_SCHEMA)
-            .field(rightAlias + ".ROWTIME", SchemaBuilder.OPTIONAL_INT64_SCHEMA)
-            .field(rightAlias + ".ROWKEY", SchemaBuilder.OPTIONAL_INT64_SCHEMA)
-            .field(rightAlias + ".COL0", SchemaBuilder.OPTIONAL_INT64_SCHEMA)
-            .field(rightAlias + ".COL1", SchemaBuilder.OPTIONAL_STRING_SCHEMA)
+            .field(LEFT_ALIAS + ".ROWTIME", SchemaBuilder.OPTIONAL_INT64_SCHEMA)
+            .field(LEFT_ALIAS + ".ROWKEY", SchemaBuilder.OPTIONAL_STRING_SCHEMA)
+            .field(LEFT_ALIAS + ".C0", SchemaBuilder.OPTIONAL_INT64_SCHEMA)
+            .field(LEFT_ALIAS + ".L1", SchemaBuilder.OPTIONAL_STRING_SCHEMA)
+            .field(RIGHT_ALIAS + ".ROWTIME", SchemaBuilder.OPTIONAL_INT64_SCHEMA)
+            .field(RIGHT_ALIAS + ".ROWKEY", SchemaBuilder.OPTIONAL_STRING_SCHEMA)
+            .field(RIGHT_ALIAS + ".C0", SchemaBuilder.OPTIONAL_INT64_SCHEMA)
+            .field(RIGHT_ALIAS + ".R1", SchemaBuilder.OPTIONAL_STRING_SCHEMA)
             .build()
     )));
   }
@@ -981,8 +974,8 @@ public class JoinNodeTest {
   @Test
   public void shouldSelectLeftKeyField() {
     // Given:
-    setupStream(left, leftSchemaKStream, leftSchema);
-    setupStream(right, rightSchemaKStream, rightSchema);
+    setupStream(left, leftSchemaKStream);
+    setupStream(right, rightSchemaKStream);
 
     final JoinNode joinNode = new JoinNode(
         nodeId,
@@ -991,8 +984,8 @@ public class JoinNodeTest {
         right,
         LEFT_JOIN_FIELD_NAME,
         RIGHT_JOIN_FIELD_NAME,
-        leftAlias,
-        rightAlias,
+        LEFT_ALIAS,
+        RIGHT_ALIAS,
         WITHIN_EXPRESSION,
         DataSourceType.KSTREAM,
         DataSourceType.KSTREAM
@@ -1012,8 +1005,8 @@ public class JoinNodeTest {
   @Test
   public void shouldBuildLeftRowSerde() {
     // Given:
-    setupStream(left, leftSchemaKStream, leftSchema);
-    setupStream(right, rightSchemaKStream, rightSchema);
+    setupStream(left, leftSchemaKStream);
+    setupStream(right, rightSchemaKStream);
 
     final JoinNode joinNode = new JoinNode(
         nodeId,
@@ -1022,8 +1015,8 @@ public class JoinNodeTest {
         right,
         LEFT_JOIN_FIELD_NAME,
         RIGHT_JOIN_FIELD_NAME,
-        leftAlias,
-        rightAlias,
+        LEFT_ALIAS,
+        RIGHT_ALIAS,
         WITHIN_EXPRESSION,
         DataSourceType.KSTREAM,
         DataSourceType.KSTREAM);
@@ -1033,7 +1026,9 @@ public class JoinNodeTest {
 
     // Then:
     final PhysicalSchema expected = PhysicalSchema
-        .from(leftSchema, SerdeOption.none());
+        .from(LEFT_SCHEMA
+            .withImplicitFields(),
+            SerdeOption.none());
 
     verify(ksqlStreamBuilder).buildGenericRowSerde(
         any(),
@@ -1044,8 +1039,8 @@ public class JoinNodeTest {
   @Test
   public void shouldBuildRightRowSerde() {
     // Given:
-    setupStream(left, leftSchemaKStream, leftSchema);
-    setupStream(right, rightSchemaKStream, rightSchema);
+    setupStream(left, leftSchemaKStream);
+    setupStream(right, rightSchemaKStream);
 
     final JoinNode joinNode = new JoinNode(
         nodeId,
@@ -1054,8 +1049,8 @@ public class JoinNodeTest {
         right,
         LEFT_JOIN_FIELD_NAME,
         RIGHT_JOIN_FIELD_NAME,
-        leftAlias,
-        rightAlias,
+        LEFT_ALIAS,
+        RIGHT_ALIAS,
         WITHIN_EXPRESSION,
         DataSourceType.KSTREAM,
         DataSourceType.KSTREAM);
@@ -1065,7 +1060,9 @@ public class JoinNodeTest {
 
     // Then:
     final PhysicalSchema expected = PhysicalSchema
-        .from(rightSchema, SerdeOption.none());
+        .from(RIGHT_SCHEMA
+            .withImplicitFields(),
+            SerdeOption.none());
 
     verify(ksqlStreamBuilder).buildGenericRowSerde(
         any(),
@@ -1076,8 +1073,8 @@ public class JoinNodeTest {
   @Test
   public void shouldNotUseSourceSerdeOptionsForInternalTopics() {
     // Given:
-    setupStream(left, leftSchemaKStream, leftSchema);
-    setupStream(right, rightSchemaKStream, rightSchema);
+    setupStream(left, leftSchemaKStream);
+    setupStream(right, rightSchemaKStream);
 
     final JoinNode joinNode = new JoinNode(
         nodeId,
@@ -1086,8 +1083,8 @@ public class JoinNodeTest {
         right,
         LEFT_JOIN_FIELD_NAME,
         RIGHT_JOIN_FIELD_NAME,
-        leftAlias,
-        rightAlias,
+        LEFT_ALIAS,
+        RIGHT_ALIAS,
         WITHIN_EXPRESSION,
         DataSourceType.KSTREAM,
         DataSourceType.KSTREAM);
@@ -1103,20 +1100,21 @@ public class JoinNodeTest {
   @SuppressWarnings("unchecked")
   private void setupTable(
       final DataSourceNode node,
-      final SchemaKTable table,
-      final LogicalSchema schema
+      final SchemaKTable table
   ) {
     when(node.buildStream(ksqlStreamBuilder)).thenReturn(table);
+    final LogicalSchema schema = node.getSchema();
     when(table.getSchema()).thenReturn(schema);
   }
 
   private void setupTable(
       final DataSourceNode node,
       final SchemaKTable table,
-      final LogicalSchema schema,
       final Optional<String> keyFieldName
   ) {
-    setupTable(node, table, schema);
+    setupTable(node, table);
+
+    final LogicalSchema schema = node.getSchema();
 
     final Optional<Field> keyField = keyFieldName
         .map(key -> schema.findField(key).orElseThrow(AssertionError::new));
@@ -1127,23 +1125,23 @@ public class JoinNodeTest {
   @SuppressWarnings("unchecked")
   private void setupStream(
       final DataSourceNode node,
-      final SchemaKStream stream,
-      final LogicalSchema schema
+      final SchemaKStream stream
   ) {
     when(node.buildStream(ksqlStreamBuilder)).thenReturn(stream);
+    final LogicalSchema schema = node.getSchema();
     when(stream.getSchema()).thenReturn(schema);
     when(stream.selectKey(any(), eq(true), any())).thenReturn(stream);
   }
 
   @SuppressWarnings("Duplicates")
-  private LogicalSchema joinSchema() {
+  private static LogicalSchema joinSchema() {
     final SchemaBuilder schemaBuilder = SchemaBuilder.struct();
 
-    for (final Field field : leftSchema.fields()) {
+    for (final Field field : LEFT_SCHEMA.withImplicitFields().withAlias(LEFT_ALIAS).fields()) {
       schemaBuilder.field(field.name(), field.schema());
     }
 
-    for (final Field field : rightSchema.fields()) {
+    for (final Field field : RIGHT_SCHEMA.withImplicitFields().withAlias(RIGHT_ALIAS).fields()) {
       schemaBuilder.field(field.name(), field.schema());
     }
 
@@ -1160,7 +1158,7 @@ public class JoinNodeTest {
 
   private void buildJoin(final String queryString) {
     buildJoinNode(queryString);
-    stream = joinNode.buildStream(ksqlStreamBuilder);
+    joinNode.buildStream(ksqlStreamBuilder);
   }
 
   private void buildJoinNode(final String queryString) {
@@ -1208,11 +1206,10 @@ public class JoinNodeTest {
       final String alias,
       final String keyName
   ) {
-    final String prefix = alias + ".";
     final ImmutableList<String> blackList = ImmutableList.of(
-        prefix + SchemaUtil.ROWKEY_NAME,
-        prefix + SchemaUtil.ROWTIME_NAME,
-        keyName
+        SchemaUtil.ROWKEY_NAME,
+        SchemaUtil.ROWTIME_NAME,
+        SchemaUtil.getFieldNameWithNoAlias(keyName)
     );
 
     final String column =
@@ -1220,7 +1217,7 @@ public class JoinNodeTest {
             .orElseThrow(AssertionError::new);
 
     final Field field = schema.findField(column).get();
-    return field.name();
+    return SchemaUtil.buildAliasedFieldName(alias, field.name());
   }
 
   @SuppressWarnings("unchecked")
@@ -1231,22 +1228,11 @@ public class JoinNodeTest {
   ) {
     when(dataSource.getName()).thenReturn(name);
     when(node.getDataSource()).thenReturn((DataSource)dataSource);
-    final LogicalSchema schema = node.getSchema();
-    when(dataSource.getSchema()).thenReturn(schema);
 
     final KsqlTopic ksqlTopic = mock(KsqlTopic.class);
     when(dataSource.getKsqlTopic()).thenReturn(ksqlTopic);
 
     final KsqlSerdeFactory valueSerdeFactory = mock(KsqlSerdeFactory.class);
     when(ksqlTopic.getValueSerdeFactory()).thenReturn(valueSerdeFactory);
-  }
-
-  private static LogicalSchema createSchema(final String alias) {
-    final SchemaBuilder schemaBuilder = SchemaBuilder.struct()
-        .field(alias + ".ROWTIME", SchemaBuilder.OPTIONAL_INT64_SCHEMA)
-        .field(alias + ".ROWKEY", SchemaBuilder.OPTIONAL_INT64_SCHEMA)
-        .field(alias + ".COL0", SchemaBuilder.OPTIONAL_INT64_SCHEMA)
-        .field(alias + ".COL1", SchemaBuilder.OPTIONAL_STRING_SCHEMA);
-    return LogicalSchema.of(schemaBuilder.build());
   }
 }

--- a/ksql-engine/src/test/java/io/confluent/ksql/planner/plan/KsqlStructuredDataOutputNodeTest.java
+++ b/ksql-engine/src/test/java/io/confluent/ksql/planner/plan/KsqlStructuredDataOutputNodeTest.java
@@ -91,6 +91,8 @@ public class KsqlStructuredDataOutputNodeTest {
   public final ExpectedException expectedException = ExpectedException.none();
 
   private final LogicalSchema schema = LogicalSchema.of(SchemaBuilder.struct()
+      .field("ROWTIME", Schema.OPTIONAL_INT64_SCHEMA)
+      .field("ROWKEY", Schema.OPTIONAL_STRING_SCHEMA)
       .field("field1", Schema.OPTIONAL_STRING_SCHEMA)
       .field("field2", Schema.OPTIONAL_STRING_SCHEMA)
       .field("field3", Schema.OPTIONAL_STRING_SCHEMA)
@@ -229,7 +231,7 @@ public class KsqlStructuredDataOutputNodeTest {
     // Then:
     assertThat(stream.getKeyField().name(), is(Optional.of("key")));
     assertThat(stream.getKeyField().legacy(),
-        is(Optional.of(new Field("key", 4, Schema.OPTIONAL_STRING_SCHEMA))));
+        is(Optional.of(new Field("key", 6, Schema.OPTIONAL_STRING_SCHEMA))));
     assertThat(stream.getSchema().fields(), equalTo(schema.getSchema().fields()));
   }
 
@@ -310,7 +312,9 @@ public class KsqlStructuredDataOutputNodeTest {
     outputNode.buildStream(ksqlStreamBuilder);
 
     // Then:
-    final PhysicalSchema expectedSchema = PhysicalSchema.from(schema, serdeOptions);
+    final PhysicalSchema expectedSchema = PhysicalSchema
+        .from(schema.withoutImplicitFields(), serdeOptions);
+
     verify(ksqlStreamBuilder).buildGenericRowSerde(
         eq(valueSerdeFactory),
         eq(expectedSchema),

--- a/ksql-engine/src/test/java/io/confluent/ksql/structured/SchemaKTableTest.java
+++ b/ksql-engine/src/test/java/io/confluent/ksql/structured/SchemaKTableTest.java
@@ -15,6 +15,8 @@
 
 package io.confluent.ksql.structured;
 
+import static io.confluent.ksql.metastore.model.MetaStoreMatchers.KeyFieldMatchers.hasLegacyName;
+import static io.confluent.ksql.metastore.model.MetaStoreMatchers.KeyFieldMatchers.hasLegacySchema;
 import static org.easymock.EasyMock.anyObject;
 import static org.easymock.EasyMock.capture;
 import static org.easymock.EasyMock.eq;
@@ -39,6 +41,7 @@ import io.confluent.ksql.metastore.MetaStore;
 import io.confluent.ksql.metastore.model.KeyField;
 import io.confluent.ksql.metastore.model.KsqlTable;
 import io.confluent.ksql.metastore.model.KsqlTopic;
+import io.confluent.ksql.metastore.model.MetaStoreMatchers.KeyFieldMatchers;
 import io.confluent.ksql.parser.tree.DereferenceExpression;
 import io.confluent.ksql.parser.tree.Expression;
 import io.confluent.ksql.parser.tree.QualifiedName;
@@ -301,7 +304,7 @@ public class SchemaKTableTest {
     // Then:
     assertThat(filteredSchemaKStream.getSchema().fields(), contains(
         new Field("TEST2.ROWTIME", 0, Schema.OPTIONAL_INT64_SCHEMA),
-        new Field("TEST2.ROWKEY", 1, Schema.OPTIONAL_INT64_SCHEMA),
+        new Field("TEST2.ROWKEY", 1, Schema.OPTIONAL_STRING_SCHEMA),
         new Field("TEST2.COL0", 2, Schema.OPTIONAL_INT64_SCHEMA),
         new Field("TEST2.COL1", 3, Schema.OPTIONAL_STRING_SCHEMA),
         new Field("TEST2.COL2", 4, Schema.OPTIONAL_STRING_SCHEMA),
@@ -555,8 +558,9 @@ public class SchemaKTableTest {
         .select(selectExpressions, childContextStacker, processingLogContext);
 
     // Then:
-    assertThat(result.getKeyField(),
-        is(KeyField.of(Optional.of("COL0"), initialSchemaKTable.keyField.legacy())));
+    assertThat(result.getKeyField(), KeyFieldMatchers.hasName("COL0"));
+    assertThat(result.getKeyField(), hasLegacyName(initialSchemaKTable.keyField.legacy().map(Field::name)));
+    assertThat(result.getKeyField(), hasLegacySchema(initialSchemaKTable.keyField.legacy().map(Field::schema)));
   }
 
   @Test

--- a/ksql-engine/src/test/java/io/confluent/ksql/topic/SourceTopicsExtractorTest.java
+++ b/ksql-engine/src/test/java/io/confluent/ksql/topic/SourceTopicsExtractorTest.java
@@ -53,6 +53,8 @@ import org.mockito.junit.MockitoJUnitRunner;
 public class SourceTopicsExtractorTest {
   private static final LogicalSchema SCHEMA = LogicalSchema.of(SchemaBuilder
       .struct()
+      .field("ROWTIME", Schema.OPTIONAL_INT64_SCHEMA)
+      .field("ROWKEY", Schema.OPTIONAL_STRING_SCHEMA)
       .field("F1", Schema.OPTIONAL_STRING_SCHEMA)
       .build());
 

--- a/ksql-engine/src/test/java/io/confluent/ksql/topic/TopicCreateInjectorTest.java
+++ b/ksql-engine/src/test/java/io/confluent/ksql/topic/TopicCreateInjectorTest.java
@@ -75,6 +75,8 @@ public class TopicCreateInjectorTest {
 
   private static final LogicalSchema SCHEMA = LogicalSchema.of(SchemaBuilder
       .struct()
+      .field("ROWTIME", Schema.OPTIONAL_INT64_SCHEMA)
+      .field("ROWKEY", Schema.OPTIONAL_STRING_SCHEMA)
       .field("F1", Schema.OPTIONAL_STRING_SCHEMA)
       .build());
 

--- a/ksql-metastore/src/main/java/io/confluent/ksql/metastore/model/StructuredDataSource.java
+++ b/ksql-metastore/src/main/java/io/confluent/ksql/metastore/model/StructuredDataSource.java
@@ -60,6 +60,10 @@ abstract class StructuredDataSource<K> implements DataSource<K> {
     this.ksqlTopic = requireNonNull(ksqlTopic, "ksqlTopic");
     this.keySerde = requireNonNull(keySerde, "keySerde");
     this.serdeOptions = ImmutableSet.copyOf(requireNonNull(serdeOptions, "serdeOptions"));
+
+    if (!schema.withImplicitFields().equals(schema)) {
+      throw new IllegalArgumentException();
+    }
   }
 
   @Override

--- a/ksql-metastore/src/test/java/io/confluent/ksql/metastore/model/MetaStoreMatchers.java
+++ b/ksql-metastore/src/test/java/io/confluent/ksql/metastore/model/MetaStoreMatchers.java
@@ -113,6 +113,10 @@ public final class MetaStoreMatchers {
       };
     }
 
+    public static Matcher<KeyField> hasLegacySchema(final Schema schema) {
+      return hasLegacySchema(Optional.of(schema));
+    }
+
     public static Matcher<KeyField> hasLegacySchema(final Optional<? extends Schema> schema) {
       return new FeatureMatcher<KeyField, Optional<Schema>>
           (is(schema), "field with legacy schema", "legacy schema") {

--- a/ksql-metastore/src/test/java/io/confluent/ksql/metastore/model/StructuredDataSourceTest.java
+++ b/ksql-metastore/src/test/java/io/confluent/ksql/metastore/model/StructuredDataSourceTest.java
@@ -34,7 +34,9 @@ public class StructuredDataSourceTest {
 
   private static final LogicalSchema SOME_SCHEMA = LogicalSchema.of(
       SchemaBuilder.struct()
-      .field("f0", Schema.OPTIONAL_INT64_SCHEMA)
+          .field("ROWTIME", Schema.OPTIONAL_INT64_SCHEMA)
+          .field("ROWKEY", Schema.OPTIONAL_STRING_SCHEMA)
+          .field("f0", Schema.OPTIONAL_INT64_SCHEMA)
           .build()
   );
 

--- a/ksql-metastore/src/test/java/io/confluent/ksql/util/MetaStoreFixture.java
+++ b/ksql-metastore/src/test/java/io/confluent/ksql/util/MetaStoreFixture.java
@@ -51,7 +51,7 @@ public final class MetaStoreFixture {
 
     final Schema test1Schema = SchemaBuilder.struct()
         .field("ROWTIME", Schema.OPTIONAL_INT64_SCHEMA)
-        .field("ROWKEY", Schema.OPTIONAL_INT64_SCHEMA)
+        .field("ROWKEY", Schema.OPTIONAL_STRING_SCHEMA)
         .field("COL0", Schema.OPTIONAL_INT64_SCHEMA)
         .field("COL1", Schema.OPTIONAL_STRING_SCHEMA)
         .field("COL2", Schema.OPTIONAL_STRING_SCHEMA)
@@ -67,7 +67,7 @@ public final class MetaStoreFixture {
     final KsqlStream<?> ksqlStream0 = new KsqlStream<>(
         "sqlexpression",
         "TEST0",
-        LogicalSchema.of(test1Schema),
+        LogicalSchema.of(test1Schema).withImplicitFields(),
         SerdeOption.none(),
         KeyField.of("COL0", test1Schema.field("COL0")),
         timestampExtractionPolicy,
@@ -84,7 +84,7 @@ public final class MetaStoreFixture {
 
     final KsqlStream<?> ksqlStream1 = new KsqlStream<>("sqlexpression",
         "TEST1",
-        LogicalSchema.of(test1Schema),
+        LogicalSchema.of(test1Schema).withImplicitFields(),
         SerdeOption.none(),
         KeyField.of("COL0", test1Schema.field("COL0")),
         timestampExtractionPolicy,
@@ -97,7 +97,7 @@ public final class MetaStoreFixture {
 
     final Schema test2Schema = SchemaBuilder.struct()
         .field("ROWTIME", Schema.OPTIONAL_INT64_SCHEMA)
-        .field("ROWKEY", Schema.OPTIONAL_INT64_SCHEMA)
+        .field("ROWKEY", Schema.OPTIONAL_STRING_SCHEMA)
         .field("COL0", Schema.OPTIONAL_INT64_SCHEMA)
         .field("COL1", Schema.OPTIONAL_STRING_SCHEMA)
         .field("COL2", Schema.OPTIONAL_STRING_SCHEMA)
@@ -159,7 +159,7 @@ public final class MetaStoreFixture {
     final KsqlStream<?> ksqlStreamOrders = new KsqlStream<>(
         "sqlexpression",
         "ORDERS",
-        LogicalSchema.of(ordersSchema),
+        LogicalSchema.of(ordersSchema).withImplicitFields(),
         SerdeOption.none(),
         KeyField.of("ORDERTIME", ordersSchema.field("ORDERTIME")),
         timestampExtractionPolicy,
@@ -172,7 +172,7 @@ public final class MetaStoreFixture {
 
     final Schema testTable3 = SchemaBuilder.struct()
         .field("ROWTIME", Schema.OPTIONAL_INT64_SCHEMA)
-        .field("ROWKEY", Schema.OPTIONAL_INT64_SCHEMA)
+        .field("ROWKEY", Schema.OPTIONAL_STRING_SCHEMA)
         .field("COL0", Schema.OPTIONAL_INT64_SCHEMA)
         .field("COL1", Schema.OPTIONAL_STRING_SCHEMA)
         .field("COL2", Schema.OPTIONAL_STRING_SCHEMA)
@@ -212,7 +212,7 @@ public final class MetaStoreFixture {
     final KsqlStream<?> nestedArrayStructMapOrders = new KsqlStream<>(
         "sqlexpression",
         "NESTED_STREAM",
-        LogicalSchema.of(nestedArrayStructMapSchema),
+        LogicalSchema.of(nestedArrayStructMapSchema).withImplicitFields(),
         SerdeOption.none(),
         KeyField.none(),
         timestampExtractionPolicy,

--- a/ksql-parser/src/test/java/io/confluent/ksql/parser/KsqlParserTest.java
+++ b/ksql-parser/src/test/java/io/confluent/ksql/parser/KsqlParserTest.java
@@ -69,8 +69,8 @@ import io.confluent.ksql.parser.tree.SingleColumn;
 import io.confluent.ksql.parser.tree.Statement;
 import io.confluent.ksql.parser.tree.Struct;
 import io.confluent.ksql.parser.tree.WithinExpression;
-import io.confluent.ksql.schema.ksql.SqlType;
 import io.confluent.ksql.schema.ksql.LogicalSchema;
+import io.confluent.ksql.schema.ksql.SqlType;
 import io.confluent.ksql.serde.Format;
 import io.confluent.ksql.serde.SerdeOption;
 import io.confluent.ksql.serde.json.KsqlJsonSerdeFactory;
@@ -129,6 +129,8 @@ public class KsqlParserTest {
 
     final SchemaBuilder schemaBuilder = SchemaBuilder.struct();
     final Schema schemaBuilderOrders = schemaBuilder
+        .field("ROWTIME", Schema.OPTIONAL_INT64_SCHEMA)
+        .field("ROWKEY", Schema.OPTIONAL_STRING_SCHEMA)
         .field("ORDERTIME", Schema.OPTIONAL_INT64_SCHEMA)
         .field("ORDERID", Schema.OPTIONAL_INT64_SCHEMA)
         .field("ITEMID", Schema.OPTIONAL_STRING_SCHEMA)
@@ -168,7 +170,7 @@ public class KsqlParserTest {
     final KsqlTable<String> ksqlTableOrders = new KsqlTable<>(
         "sqlexpression",
         "ITEMID",
-        LogicalSchema.of(itemInfoSchema),
+        LogicalSchema.of(itemInfoSchema).withImplicitFields(),
         SerdeOption.none(),
         KeyField.of("ITEMID", itemInfoSchema.field("ITEMID")),
         new MetadataTimestampExtractionPolicy(),

--- a/ksql-parser/src/test/java/io/confluent/ksql/parser/SqlFormatterTest.java
+++ b/ksql-parser/src/test/java/io/confluent/ksql/parser/SqlFormatterTest.java
@@ -49,8 +49,8 @@ import io.confluent.ksql.parser.tree.StringLiteral;
 import io.confluent.ksql.parser.tree.Table;
 import io.confluent.ksql.parser.tree.TableElement;
 import io.confluent.ksql.parser.tree.WithinExpression;
-import io.confluent.ksql.schema.ksql.SqlType;
 import io.confluent.ksql.schema.ksql.LogicalSchema;
+import io.confluent.ksql.schema.ksql.SqlType;
 import io.confluent.ksql.serde.SerdeOption;
 import io.confluent.ksql.serde.json.KsqlJsonSerdeFactory;
 import io.confluent.ksql.util.MetaStoreFixture;
@@ -98,8 +98,9 @@ public class SqlFormatterTest {
       .field("CATEGORY", categorySchema)
       .optional().build();
 
-  private static final SchemaBuilder schemaBuilder = SchemaBuilder.struct();
-  private static final Schema schemaBuilderOrders = schemaBuilder
+  private static final Schema schemaBuilderOrders = SchemaBuilder.struct()
+      .field("ROWTIME", Schema.OPTIONAL_INT64_SCHEMA)
+      .field("ROWKEY", Schema.OPTIONAL_STRING_SCHEMA)
       .field("ORDERTIME", Schema.OPTIONAL_INT64_SCHEMA)
       .field("ORDERID", Schema.OPTIONAL_INT64_SCHEMA)
       .field("ITEMID", Schema.OPTIONAL_STRING_SCHEMA)
@@ -154,7 +155,7 @@ public class SqlFormatterTest {
     final KsqlTable<String> ksqlTableOrders = new KsqlTable<>(
         "sqlexpression",
         "ITEMID",
-        LogicalSchema.of(itemInfoSchema),
+        LogicalSchema.of(itemInfoSchema).withImplicitFields(),
         SerdeOption.none(),
         KeyField.of("ITEMID", itemInfoSchema.field("ITEMID")),
         new MetadataTimestampExtractionPolicy(),

--- a/ksql-rest-app/src/test/java/io/confluent/ksql/rest/entity/QueryDescriptionTest.java
+++ b/ksql-rest-app/src/test/java/io/confluent/ksql/rest/entity/QueryDescriptionTest.java
@@ -28,9 +28,9 @@ import io.confluent.ksql.metastore.model.KsqlTopic;
 import io.confluent.ksql.physical.LimitHandler;
 import io.confluent.ksql.physical.QuerySchemas;
 import io.confluent.ksql.query.QueryId;
-import io.confluent.ksql.schema.ksql.SqlType;
 import io.confluent.ksql.schema.ksql.LogicalSchema;
 import io.confluent.ksql.schema.ksql.PhysicalSchema;
+import io.confluent.ksql.schema.ksql.SqlType;
 import io.confluent.ksql.serde.SerdeOption;
 import io.confluent.ksql.serde.json.KsqlJsonSerdeFactory;
 import io.confluent.ksql.util.PersistentQueryMetadata;
@@ -61,11 +61,15 @@ public class QueryDescriptionTest {
 
   private static final LogicalSchema SCHEMA = LogicalSchema.of(
       SchemaBuilder.struct()
+          .field("ROWTIME", Schema.OPTIONAL_INT64_SCHEMA)
+          .field("ROWKEY", Schema.OPTIONAL_STRING_SCHEMA)
           .field("field1", Schema.OPTIONAL_INT32_SCHEMA)
           .field("field2", Schema.OPTIONAL_STRING_SCHEMA)
           .build());
 
   private static final List<FieldInfo> EXPECTED_FIELDS = Arrays.asList(
+      new FieldInfo("ROWTIME", new SchemaInfo(SqlType.BIGINT, null, null)),
+      new FieldInfo("ROWKEY", new SchemaInfo(SqlType.STRING, null, null)),
       new FieldInfo("field1", new SchemaInfo(SqlType.INTEGER, null, null)),
       new FieldInfo("field2", new SchemaInfo(SqlType.STRING, null, null)));
 

--- a/ksql-rest-app/src/test/java/io/confluent/ksql/rest/entity/SourceDescriptionTest.java
+++ b/ksql-rest-app/src/test/java/io/confluent/ksql/rest/entity/SourceDescriptionTest.java
@@ -64,8 +64,11 @@ public class SourceDescriptionTest {
 
   private static DataSource<?> buildDataSource(final String kafkaTopicName) {
     final LogicalSchema schema = LogicalSchema.of(SchemaBuilder.struct()
+        .field("ROWTIME", Schema.OPTIONAL_INT64_SCHEMA)
+        .field("ROWKEY", Schema.OPTIONAL_STRING_SCHEMA)
         .field("field0", Schema.OPTIONAL_INT32_SCHEMA)
         .build());
+
     final KsqlTopic topic = new KsqlTopic("internal", kafkaTopicName, new KsqlJsonSerdeFactory(), true);
     return new KsqlStream<>(
         "query",

--- a/ksql-rest-app/src/test/java/io/confluent/ksql/rest/server/TemporaryEngine.java
+++ b/ksql-rest-app/src/test/java/io/confluent/ksql/rest/server/TemporaryEngine.java
@@ -49,6 +49,8 @@ import org.junit.rules.ExternalResource;
 public class TemporaryEngine extends ExternalResource {
 
   public static final LogicalSchema SCHEMA = LogicalSchema.of(SchemaBuilder.struct()
+      .field("ROWTIME", Schema.OPTIONAL_INT64_SCHEMA)
+      .field("ROWKEY", Schema.OPTIONAL_STRING_SCHEMA)
       .field("val", Schema.OPTIONAL_STRING_SCHEMA)
       .build());
 

--- a/ksql-rest-app/src/test/java/io/confluent/ksql/rest/server/execution/InsertValuesExecutorTest.java
+++ b/ksql-rest-app/src/test/java/io/confluent/ksql/rest/server/execution/InsertValuesExecutorTest.java
@@ -76,7 +76,7 @@ public class InsertValuesExecutorTest {
 
   private static final LogicalSchema SINGLE_FIELD_SCHEMA = LogicalSchema.of(SchemaBuilder.struct()
       .field("ROWTIME", Schema.OPTIONAL_INT64_SCHEMA)
-      .field("ROWKEY", Schema.OPTIONAL_INT64_SCHEMA)
+      .field("ROWKEY", Schema.OPTIONAL_STRING_SCHEMA)
       .field("COL0", Schema.OPTIONAL_STRING_SCHEMA)
       .build());
 

--- a/ksql-rest-app/src/test/java/io/confluent/ksql/rest/server/resources/KsqlResourceTest.java
+++ b/ksql-rest-app/src/test/java/io/confluent/ksql/rest/server/resources/KsqlResourceTest.java
@@ -115,8 +115,8 @@ import io.confluent.ksql.rest.server.computation.CommandStore;
 import io.confluent.ksql.rest.server.computation.QueuedCommandStatus;
 import io.confluent.ksql.rest.util.EntityUtil;
 import io.confluent.ksql.rest.util.TerminateCluster;
-import io.confluent.ksql.schema.ksql.SqlType;
 import io.confluent.ksql.schema.ksql.LogicalSchema;
+import io.confluent.ksql.schema.ksql.SqlType;
 import io.confluent.ksql.serde.SerdeOption;
 import io.confluent.ksql.serde.json.KsqlJsonSerdeFactory;
 import io.confluent.ksql.services.FakeKafkaTopicClient;
@@ -183,7 +183,7 @@ public class KsqlResourceTest {
       0L);
   private static final LogicalSchema SINGLE_FIELD_SCHEMA = LogicalSchema.of(SchemaBuilder.struct()
       .field("val", Schema.OPTIONAL_STRING_SCHEMA)
-      .build());
+      .build()).withImplicitFields();
 
   private static final ClusterTerminateRequest VALID_TERMINATE_REQUEST =
       new ClusterTerminateRequest(ImmutableList.of("Foo"));
@@ -223,6 +223,8 @@ public class KsqlResourceTest {
   );
 
   private static final LogicalSchema SOME_SCHEMA = LogicalSchema.of(SchemaBuilder.struct()
+      .field("ROWTIME", Schema.OPTIONAL_INT64_SCHEMA)
+      .field("ROWKEY", Schema.OPTIONAL_STRING_SCHEMA)
       .field("f1", Schema.OPTIONAL_STRING_SCHEMA)
       .build());
 
@@ -385,7 +387,7 @@ public class KsqlResourceTest {
     final LogicalSchema schema = LogicalSchema.of(SchemaBuilder.struct()
         .field("FIELD1", Schema.OPTIONAL_BOOLEAN_SCHEMA)
         .field("FIELD2", Schema.OPTIONAL_STRING_SCHEMA)
-        .build());
+        .build()).withImplicitFields();
 
     givenSource(
         DataSourceType.KSTREAM, "new_stream", "new_topic",
@@ -413,7 +415,7 @@ public class KsqlResourceTest {
     final LogicalSchema schema = LogicalSchema.of(SchemaBuilder.struct()
         .field("FIELD1", Schema.OPTIONAL_BOOLEAN_SCHEMA)
         .field("FIELD2", Schema.OPTIONAL_STRING_SCHEMA)
-        .build());
+        .build()).withImplicitFields();
 
     givenSource(
         DataSourceType.KTABLE, "new_table", "new_topic",
@@ -1926,7 +1928,7 @@ public class KsqlResourceTest {
   private void addTestTopicAndSources() {
     final LogicalSchema schema1 = LogicalSchema.of(SchemaBuilder.struct()
             .field("S1_F1", Schema.OPTIONAL_BOOLEAN_SCHEMA)
-            .build());
+            .build()).withImplicitFields();
 
     givenSource(
         DataSourceType.KTABLE,
@@ -1934,7 +1936,7 @@ public class KsqlResourceTest {
 
     final LogicalSchema schema2 = LogicalSchema.of(SchemaBuilder.struct()
         .field("S2_F1", Schema.OPTIONAL_STRING_SCHEMA)
-        .build());
+        .build()).withImplicitFields();
 
     givenSource(
         DataSourceType.KSTREAM,

--- a/ksql-rest-app/src/test/java/io/confluent/ksql/rest/server/validation/RequestValidatorTest.java
+++ b/ksql-rest-app/src/test/java/io/confluent/ksql/rest/server/validation/RequestValidatorTest.java
@@ -41,7 +41,6 @@ import io.confluent.ksql.parser.KsqlParser.ParsedStatement;
 import io.confluent.ksql.parser.tree.CreateStream;
 import io.confluent.ksql.parser.tree.Explain;
 import io.confluent.ksql.parser.tree.Statement;
-import io.confluent.ksql.schema.ksql.LogicalSchema;
 import io.confluent.ksql.services.SandboxedServiceContext;
 import io.confluent.ksql.services.ServiceContext;
 import io.confluent.ksql.services.TestServiceContext;
@@ -54,8 +53,6 @@ import io.confluent.ksql.util.KsqlStatementException;
 import io.confluent.ksql.util.Sandbox;
 import java.util.List;
 import java.util.Map;
-import org.apache.kafka.connect.data.Schema;
-import org.apache.kafka.connect.data.SchemaBuilder;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
@@ -67,27 +64,23 @@ import org.mockito.junit.MockitoJUnitRunner;
 @RunWith(MockitoJUnitRunner.class)
 public class RequestValidatorTest {
 
-  private static final LogicalSchema SCHEMA = LogicalSchema.of(SchemaBuilder
-      .struct()
-      .field("val", Schema.OPTIONAL_STRING_SCHEMA)
-      .build());
   private static final String SOME_STREAM_SQL = "CREATE STREAM x WITH (value_format='json', kafka_topic='x');";
 
   @Rule
   public ExpectedException expectedException = ExpectedException.none();
 
   @Mock
-  SandboxEngine ksqlEngine;
+  private SandboxEngine ksqlEngine;
   @Mock
-  KsqlConfig ksqlConfig;
+  private KsqlConfig ksqlConfig;
   @Mock
-  StatementValidator<?> statementValidator;
+  private StatementValidator<?> statementValidator;
   @Mock
-  Injector schemaInjector;
+  private Injector schemaInjector;
   @Mock
-  Injector topicInjector;
+  private Injector topicInjector;
   @Mock
-  TopicAccessValidator topicAccessValidator;
+  private TopicAccessValidator topicAccessValidator;
 
   private ServiceContext serviceContext;
   private MutableMetaStore metaStore;
@@ -112,11 +105,9 @@ public class RequestValidatorTest {
 
     final KsqlStream<?> source = mock(KsqlStream.class);
     when(source.getName()).thenReturn("SOURCE");
-    when(source.getSchema()).thenReturn(SCHEMA);
 
     final KsqlStream<?> sink = mock(KsqlStream.class);
     when(sink.getName()).thenReturn("SINK");
-    when(sink.getSchema()).thenReturn(SCHEMA);
 
     metaStore.putSource(source);
     metaStore.putSource(sink);


### PR DESCRIPTION
### Description 

Correct test cases that create sources with logical schemas that do NOT have implicit fields. Current prod code always uses schemas with implicit fields, so should the tests.

This is prep work from a later PR which will clean up implicits handling.

Note: most, if not all, of these `.withImplicits` and the addition of `ROWKEY`/`ROWTIME` to tests will be removed again in a later PR.  The purpose of this PR is to: 

1) Fix up any tests that have the wrong result due to using the wrong schema, 
2) Keep these fixes out of the main PR that is coming so its easier to review.
3) Give me a set of tests for my later PR that are using the correct schemas and correct results.

Only two none-test files are changed:
- StructuredDataSource: has a check in it to ensure instances are created with a schema with implicits in it.  This will be removed/changed/tested in a later PR.
- `SchemaKStream`: sanity check added to ensure the row passed has the same number of columns as the schema.  This is added to ensure later work doesn't break things.

### Testing done 
`mvn test`

### Reviewer checklist
- [ ] Ensure docs are updated if necessary. (eg. if a user visible feature is being added or changed).
- [ ] Ensure relevant issues are linked (description should include text like "Fixes #<issue number>")

