### PR TITLE
Minor: Have `Analyzer` create and track `DataSourceNode` 

### DIFF
--- a/ksql-engine/src/main/java/io/confluent/ksql/analyzer/Analyzer.java
+++ b/ksql-engine/src/main/java/io/confluent/ksql/analyzer/Analyzer.java
@@ -61,7 +61,6 @@ import io.confluent.ksql.serde.SerdeOption;
 import io.confluent.ksql.serde.SerdeOptions;
 import io.confluent.ksql.util.KsqlConstants;
 import io.confluent.ksql.util.KsqlException;
-import io.confluent.ksql.util.Pair;
 import io.confluent.ksql.util.SchemaUtil;
 import io.confluent.ksql.util.StringUtil;
 import java.util.List;
@@ -248,7 +247,7 @@ class Analyzer {
         return Format.of(StringUtil.cleanQuotes(serdeProperty.toString()));
       }
 
-      final DataSource<?> leftSource = analysis.getFromDataSource(0).left;
+      final DataSource<?> leftSource = analysis.getFromDataSource(0).getDataSource();
       return leftSource.getKsqlTopic().getValueSerdeFactory().getFormat();
     }
 
@@ -342,7 +341,7 @@ class Analyzer {
 
       final LogicalSchema schema = isJoinSchema
           ? analysis.getJoin().getSchema()
-          : analysis.getFromDataSources().get(0).getLeft().getSchema();
+          : analysis.getFromDataSource(0).getSchema().withoutAlias();
 
       final ExpressionAnalyzer expressionAnalyzer = new ExpressionAnalyzer(schema, isJoinSchema);
 
@@ -386,13 +385,13 @@ class Analyzer {
       final ComparisonExpression comparisonExpression = (ComparisonExpression) joinOn
           .getExpression();
 
-      final Field leftJoinField = getJoinField(
+      final String leftJoinField = getJoinFieldName(
           comparisonExpression,
           leftAlias,
           leftDataSource.getSchema()
       );
 
-      final Field rightJoinField = getJoinField(
+      final String rightJoinField = getJoinFieldName(
           comparisonExpression,
           rightAlias,
           rightDataSource.getSchema()
@@ -419,8 +418,8 @@ class Analyzer {
           joinType,
           leftSourceNode,
           rightSourceNode,
-          leftJoinField.name(),
-          rightJoinField.name(),
+          leftJoinField,
+          rightJoinField,
           leftAlias,
           rightAlias,
           node.getWithinExpression().orElse(null),
@@ -450,12 +449,12 @@ class Analyzer {
       return joinType;
     }
 
-    private Field getJoinField(
+    private String getJoinFieldName(
         final ComparisonExpression comparisonExpression,
         final String sourceAlias,
         final LogicalSchema sourceSchema
     ) {
-      Optional<Field> joinField = getJoinFieldFromExpr(
+      Optional<String> joinField = getJoinFieldFromExpr(
           comparisonExpression.getLeft(),
           sourceAlias,
           sourceSchema
@@ -479,7 +478,7 @@ class Analyzer {
           ));
     }
 
-    private Optional<Field> getJoinFieldFromExpr(
+    private Optional<String> getJoinFieldFromExpr(
         final Expression expression,
         final String sourceAlias,
         final LogicalSchema sourceSchema
@@ -505,28 +504,31 @@ class Analyzer {
       return Optional.empty();
     }
 
-    private Optional<Field> getJoinFieldFromSource(
+    private Optional<String> getJoinFieldFromSource(
         final String fieldName,
         final String sourceAlias,
         final LogicalSchema sourceSchema
     ) {
       return sourceSchema.findField(fieldName)
-          .map(field -> SchemaUtil.buildAliasedField(sourceAlias, field));
+          .map(field -> SchemaUtil.buildAliasedFieldName(sourceAlias, field.name()));
     }
 
     @Override
     protected Node visitAliasedRelation(final AliasedRelation node, final Void context) {
       final String structuredDataSourceName = ((Table) node.getRelation()).getName().getSuffix();
-      if (metaStore.getSource(structuredDataSourceName) == null) {
+
+      final DataSource<?> source = metaStore.getSource(structuredDataSourceName);
+      if (source == null) {
         throw new KsqlException(structuredDataSourceName + " does not exist.");
       }
 
-      final Pair<DataSource<?>, String> fromDataSource =
-          new Pair<>(
-              metaStore.getSource(structuredDataSourceName),
-              node.getAlias()
-          );
-      analysis.addDataSource(fromDataSource);
+      final DataSourceNode sourceNode = new DataSourceNode(
+          new PlanNodeId("KsqlTopic"),
+          source,
+          node.getAlias()
+      );
+
+      analysis.addDataSource(sourceNode);
       return node;
     }
 
@@ -550,20 +552,19 @@ class Analyzer {
                 .orElse("");
 
             if (!prefix.equals(join.getRightAlias())) {
-              final LogicalSchema schema = join.getLeft().getSchema().withoutAlias();
+              final LogicalSchema schema = join.getLeft().getSchema();
               addSelectItems(location, schema, join.getLeftAlias(), join.getLeftAlias() + "_");
             }
 
             if (!prefix.equals(join.getLeftAlias())) {
-              final LogicalSchema schema = join.getRight().getSchema().withoutAlias();
+              final LogicalSchema schema = join.getRight().getSchema();
               addSelectItems(location, schema, join.getRightAlias(), join.getRightAlias() + "_");
             }
           } else {
-            final Pair<DataSource<?>, String> sourceTuple = analysis.getFromDataSources().get(0);
-            final String sourceAlias = sourceTuple.getRight();
-            final LogicalSchema schema = sourceTuple.getLeft().getSchema();
+            final DataSourceNode source = analysis.getFromDataSource(0);
+            final LogicalSchema schema = source.getSchema();
 
-            addSelectItems(location, schema, sourceAlias, "");
+            addSelectItems(location, schema, source.getAlias(), "");
           }
         } else if (selectItem instanceof SingleColumn) {
           final SingleColumn column = (SingleColumn) selectItem;
@@ -614,7 +615,7 @@ class Analyzer {
         final String sourceAlias,
         final String aliasPrefix
     ) {
-      for (final Field field : schema.fields()) {
+      for (final Field field : schema.withoutAlias().fields()) {
 
         final QualifiedName name = QualifiedName.of(sourceAlias);
 

--- a/ksql-engine/src/main/java/io/confluent/ksql/analyzer/ExpressionAnalyzer.java
+++ b/ksql-engine/src/main/java/io/confluent/ksql/analyzer/ExpressionAnalyzer.java
@@ -31,7 +31,6 @@ import io.confluent.ksql.parser.tree.QualifiedNameReference;
 import io.confluent.ksql.schema.ksql.LogicalSchema;
 import java.util.Objects;
 import java.util.Optional;
-import org.apache.kafka.connect.data.Field;
 
 
 class ExpressionAnalyzer {
@@ -116,7 +115,7 @@ class ExpressionAnalyzer {
       if (isJoinSchema) {
         columnName = node.toString();
       }
-      final Optional<Field> schemaField = schema.findField(columnName);
+      final Optional<?> schemaField = schema.findField(columnName);
       if (!schemaField.isPresent()) {
         throw new RuntimeException(
             String.format("Column %s cannot be resolved.", columnName));
@@ -136,7 +135,7 @@ class ExpressionAnalyzer {
         final QualifiedNameReference node,
         final Object context) {
       final String columnName = node.getName().getSuffix();
-      final Optional<Field> schemaField = schema.findField(columnName);
+      final Optional<?> schemaField = schema.findField(columnName);
       if (!schemaField.isPresent()) {
         throw new RuntimeException(
             String.format("Column %s cannot be resolved.", columnName));

--- a/ksql-engine/src/main/java/io/confluent/ksql/planner/plan/DataSourceNode.java
+++ b/ksql-engine/src/main/java/io/confluent/ksql/planner/plan/DataSourceNode.java
@@ -90,6 +90,7 @@ public class DataSourceNode
   private static final String REDUCE_OP_NAME = "reduce";
 
   private final DataSource<?> dataSource;
+  private final String alias;
   private final LogicalSchema schema;
   private final KeyField keyField;
   private final Function<KsqlConfig, MaterializedFactory> materializedFactorySupplier;
@@ -111,6 +112,7 @@ public class DataSourceNode
   ) {
     super(id, dataSource.getDataSourceType());
     this.dataSource = requireNonNull(dataSource, "dataSource");
+    this.alias = requireNonNull(alias, "alias");
     this.schema = dataSource.getSchema()
       .withAlias(alias);
 
@@ -141,6 +143,10 @@ public class DataSourceNode
 
   public DataSource<?> getDataSource() {
     return dataSource;
+  }
+
+  public String getAlias() {
+    return alias;
   }
 
   @Override

--- a/ksql-engine/src/test/java/io/confluent/ksql/analyzer/AnalyzerTest.java
+++ b/ksql-engine/src/test/java/io/confluent/ksql/analyzer/AnalyzerTest.java
@@ -17,11 +17,9 @@ package io.confluent.ksql.analyzer;
 
 import static io.confluent.ksql.testutils.AnalysisTestUtil.analyzeQuery;
 import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.Matchers.contains;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.not;
 import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
@@ -35,8 +33,6 @@ import io.confluent.ksql.ddl.DdlConfig;
 import io.confluent.ksql.function.InternalFunctionRegistry;
 import io.confluent.ksql.metastore.MetaStore;
 import io.confluent.ksql.metastore.MutableMetaStore;
-import io.confluent.ksql.metastore.SerdeFactory;
-import io.confluent.ksql.metastore.model.DataSource;
 import io.confluent.ksql.metastore.model.KeyField;
 import io.confluent.ksql.metastore.model.KsqlStream;
 import io.confluent.ksql.metastore.model.KsqlTopic;
@@ -113,11 +109,6 @@ public class AnalyzerTest {
         serdeOptiponsSupplier
     );
 
-    final KsqlTopic sinkTopic = mock(KsqlTopic.class);
-    final DataSource<?> sinkSource = mock(DataSource.class);
-    when(sinkSource.getKsqlTopic()).thenReturn(sinkTopic);
-    final SerdeFactory<?> keySerdeFactory = mock(SerdeFactory.class);
-    when(sinkSource.getKeySerdeFactory()).thenReturn((SerdeFactory)keySerdeFactory);
     when(sink.getName()).thenReturn("TEST0");
 
     query = parseSingle("Select COL0, COL1 from TEST1;");
@@ -128,11 +119,10 @@ public class AnalyzerTest {
     final String simpleQuery = "SELECT col0, col2, col3 FROM test1 WHERE col0 > 100;";
     final Analysis analysis = analyzeQuery(simpleQuery, jsonMetaStore);
     Assert.assertNotNull("INTO is null", analysis.getInto());
-    Assert.assertNotNull("FROM is null", analysis.getFromDataSources());
     Assert.assertNotNull("SELECT is null", analysis.getSelectExpressions());
     Assert.assertNotNull("SELECT alias is null", analysis.getSelectExpressionAlias());
     Assert.assertTrue("FROM was not analyzed correctly.",
-                      analysis.getFromDataSources().get(0).getLeft().getName()
+        analysis.getFromDataSource(0).getDataSource().getName()
                           .equalsIgnoreCase("test1"));
     Assert.assertEquals(analysis.getSelectExpressions().size(),
         analysis.getSelectExpressionAlias().size());
@@ -233,11 +223,10 @@ public class AnalyzerTest {
     final Analysis analysis = analyzeQuery(queryStr, jsonMetaStore);
 
     Assert.assertNotNull("INTO is null", analysis.getInto());
-    Assert.assertNotNull("FROM is null", analysis.getFromDataSources());
     Assert.assertNotNull("SELECT is null", analysis.getSelectExpressions());
     Assert.assertNotNull("SELECT aliacs is null", analysis.getSelectExpressionAlias());
     Assert.assertTrue("FROM was not analyzed correctly.",
-                      analysis.getFromDataSources().get(0).getLeft().getName()
+        analysis.getFromDataSource(0).getDataSource().getName()
                           .equalsIgnoreCase("test1"));
 
     final String
@@ -264,11 +253,10 @@ public class AnalyzerTest {
     final Analysis analysis = analyzeQuery(queryStr, jsonMetaStore);
 
     Assert.assertNotNull("INTO is null", analysis.getInto());
-    Assert.assertNotNull("FROM is null", analysis.getFromDataSources());
     Assert.assertNotNull("SELECT is null", analysis.getSelectExpressions());
     Assert.assertNotNull("SELECT aliacs is null", analysis.getSelectExpressionAlias());
     Assert.assertTrue("FROM was not analyzed correctly.",
-            analysis.getFromDataSources().get(0).getLeft().getName()
+        analysis.getFromDataSource(0).getDataSource().getName()
                     .equalsIgnoreCase("test1"));
 
     final String

--- a/ksql-engine/src/test/java/io/confluent/ksql/analyzer/QueryAnalyzerTest.java
+++ b/ksql-engine/src/test/java/io/confluent/ksql/analyzer/QueryAnalyzerTest.java
@@ -23,7 +23,6 @@ import static org.hamcrest.Matchers.contains;
 import static org.hamcrest.Matchers.containsInAnyOrder;
 import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.hasItem;
-import static org.hamcrest.Matchers.hasSize;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.not;
 import static org.junit.Assert.assertTrue;
@@ -47,12 +46,12 @@ import io.confluent.ksql.parser.tree.QualifiedName;
 import io.confluent.ksql.parser.tree.QualifiedNameReference;
 import io.confluent.ksql.parser.tree.Query;
 import io.confluent.ksql.parser.tree.Sink;
+import io.confluent.ksql.planner.plan.DataSourceNode;
 import io.confluent.ksql.planner.plan.JoinNode;
 import io.confluent.ksql.serde.Format;
 import io.confluent.ksql.serde.SerdeOption;
 import io.confluent.ksql.util.KsqlException;
 import io.confluent.ksql.util.MetaStoreFixture;
-import io.confluent.ksql.util.Pair;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.Optional;
@@ -88,11 +87,11 @@ public class QueryAnalyzerTest {
     final Analysis analysis = queryAnalyzer.analyze("sqlExpression", query, Optional.empty());
 
     // Then:
-    final Pair<DataSource<?>, String> fromDataSource = analysis.getFromDataSource(0);
+    final DataSourceNode fromDataSource = analysis.getFromDataSource(0);
     assertThat(analysis.getSelectExpressions(), equalTo(Collections.singletonList(ORDER_ID)));
-    assertThat(analysis.getFromDataSources().size(), equalTo(1));
-    assertThat(fromDataSource.left, instanceOf(KsqlStream.class));
-    assertThat(fromDataSource.right, equalTo("ORDERS"));
+    assertThat(analysis.getFromDataSourceCount(), is(1));
+    assertThat(fromDataSource.getDataSource(), instanceOf(KsqlStream.class));
+    assertThat(fromDataSource.getAlias(), equalTo("ORDERS"));
   }
 
   @Test
@@ -110,11 +109,11 @@ public class QueryAnalyzerTest {
     assertThat(analysis.getSelectExpressions(), contains(new DereferenceExpression(
         new QualifiedNameReference(QualifiedName.of("TEST1")), "COL1")));
 
-    assertThat(analysis.getFromDataSources(), hasSize(1));
+    assertThat(analysis.getFromDataSourceCount(), is(1));
 
-    final Pair<DataSource<?>, String> fromDataSource = analysis.getFromDataSource(0);
-    assertThat(fromDataSource.left, instanceOf(KsqlStream.class));
-    assertThat(fromDataSource.right, equalTo("TEST1"));
+    final DataSourceNode fromDataSource = analysis.getFromDataSource(0);
+    assertThat(fromDataSource.getDataSource(), instanceOf(KsqlStream.class));
+    assertThat(fromDataSource.getAlias(), equalTo("TEST1"));
     assertThat(analysis.getInto().get().getName(), is("S"));
   }
 
@@ -133,11 +132,11 @@ public class QueryAnalyzerTest {
     assertThat(analysis.getSelectExpressions(), contains(new DereferenceExpression(
         new QualifiedNameReference(QualifiedName.of("TEST2")), "COL1")));
 
-    assertThat(analysis.getFromDataSources(), hasSize(1));
+    assertThat(analysis.getFromDataSourceCount(), is(1));
 
-    final Pair<DataSource<?>, String> fromDataSource = analysis.getFromDataSource(0);
-    assertThat(fromDataSource.left, instanceOf(KsqlTable.class));
-    assertThat(fromDataSource.right, equalTo("TEST2"));
+    final DataSourceNode fromDataSource = analysis.getFromDataSource(0);
+    assertThat(fromDataSource.getDataSource(), instanceOf(KsqlTable.class));
+    assertThat(fromDataSource.getAlias(), equalTo("TEST2"));
     assertThat(analysis.getInto().get().getName(), is("T"));
   }
 
@@ -156,11 +155,11 @@ public class QueryAnalyzerTest {
     assertThat(analysis.getSelectExpressions(), contains(new DereferenceExpression(
         new QualifiedNameReference(QualifiedName.of("TEST1")), "COL1")));
 
-    assertThat(analysis.getFromDataSources(), hasSize(1));
+    assertThat(analysis.getFromDataSourceCount(), is(1));
 
-    final Pair<DataSource<?>, String> fromDataSource = analysis.getFromDataSource(0);
-    assertThat(fromDataSource.left, instanceOf(KsqlStream.class));
-    assertThat(fromDataSource.right, equalTo("TEST1"));
+    final DataSourceNode fromDataSource = analysis.getFromDataSource(0);
+    assertThat(fromDataSource.getDataSource(), instanceOf(KsqlStream.class));
+    assertThat(fromDataSource.getAlias(), equalTo("TEST1"));
     assertThat(analysis.getInto(), is(not(Optional.empty())));
     final Into into = analysis.getInto().get();
     final DataSource<?> test0 = metaStore.getSource("TEST0");

--- a/ksql-parser/src/main/java/io/confluent/ksql/util/DataSourceExtractor.java
+++ b/ksql-parser/src/main/java/io/confluent/ksql/util/DataSourceExtractor.java
@@ -17,6 +17,7 @@ package io.confluent.ksql.util;
 
 import static java.util.Objects.requireNonNull;
 
+import com.google.common.collect.Sets;
 import io.confluent.ksql.metastore.MetaStore;
 import io.confluent.ksql.metastore.model.DataSource;
 import io.confluent.ksql.parser.SqlBaseBaseVisitor;
@@ -26,6 +27,7 @@ import io.confluent.ksql.parser.tree.Node;
 import io.confluent.ksql.parser.tree.NodeLocation;
 import io.confluent.ksql.parser.tree.Table;
 import io.confluent.ksql.schema.ksql.LogicalSchema;
+import java.util.Collections;
 import java.util.HashSet;
 import java.util.Objects;
 import java.util.Optional;
@@ -33,14 +35,10 @@ import java.util.Set;
 import org.antlr.v4.runtime.ParserRuleContext;
 import org.antlr.v4.runtime.Token;
 import org.antlr.v4.runtime.tree.ParseTree;
-import org.apache.kafka.connect.data.Field;
 
 public class DataSourceExtractor {
 
   private final MetaStore metaStore;
-
-  private LogicalSchema joinLeftSchema;
-  private LogicalSchema joinRightSchema;
 
   private String fromAlias;
   private String fromName;
@@ -62,17 +60,7 @@ public class DataSourceExtractor {
   public void extractDataSources(final ParseTree node) {
     new Visitor().visit(node);
 
-    if (joinLeftSchema != null) {
-      for (final Field field : joinLeftSchema.fields()) {
-        leftFieldNames.add(field.name());
-      }
-      for (final Field field : joinRightSchema.fields()) {
-        rightFieldNames.add(field.name());
-        if (leftFieldNames.contains(field.name())) {
-          commonFieldNames.add(field.name());
-        }
-      }
-    }
+    commonFieldNames.addAll(Sets.intersection(leftFieldNames, rightFieldNames));
   }
 
   public String getFromAlias() {
@@ -88,15 +76,15 @@ public class DataSourceExtractor {
   }
 
   public Set<String> getCommonFieldNames() {
-    return commonFieldNames;
+    return Collections.unmodifiableSet(commonFieldNames);
   }
 
   public Set<String> getLeftFieldNames() {
-    return leftFieldNames;
+    return Collections.unmodifiableSet(leftFieldNames);
   }
 
   public Set<String> getRightFieldNames() {
-    return rightFieldNames;
+    return Collections.unmodifiableSet(rightFieldNames);
   }
 
   public String getFromName() {
@@ -179,7 +167,7 @@ public class DataSourceExtractor {
         throw new KsqlException(((Table) left.getRelation()).getName().getSuffix() + " does not "
             + "exist.");
       }
-      joinLeftSchema = leftDataSource.getSchema();
+      addFieldNames(leftDataSource.getSchema(), leftFieldNames);
 
       final AliasedRelation right = (AliasedRelation) visit(context.right);
       rightAlias = right.getAlias();
@@ -191,7 +179,7 @@ public class DataSourceExtractor {
         throw new KsqlException(((Table) right.getRelation()).getName().getSuffix() + " does not "
             + "exist.");
       }
-      joinRightSchema = rightDataSource.getSchema();
+      addFieldNames(rightDataSource.getSchema(), rightFieldNames);
 
       return null;
     }
@@ -205,5 +193,9 @@ public class DataSourceExtractor {
   private static Optional<NodeLocation> getLocation(final Token token) {
     requireNonNull(token, "token is null");
     return Optional.of(new NodeLocation(token.getLine(), token.getCharPositionInLine()));
+  }
+
+  private static void addFieldNames(final LogicalSchema schema, final Set<String> collection) {
+    schema.fields().forEach(field -> collection.add(field.name()));
   }
 }


### PR DESCRIPTION
### Description 

Minor PR in prep for later PR to clean up implicits in schemas.

This PR moves all `DataSourceNode` creation into `Analyzer` and has the `Analysis` track `DataSourceNode`s rather than `StructuredDataSource`s.

This has the benefit that both the node's and the source's schema are available to the `Analyzer` and others, stopping them having to replicate the operations the node does to the source's schema, i.e. removes code duplication.

The `Analyzer` already created the `DataSourceNode`s for any join, now it does so for non-joins too.

The PR also simplifies `DataSourceExtractor`.

### Testing done 

`mvn test`

### Reviewer checklist
- [ ] Ensure docs are updated if necessary. (eg. if a user visible feature is being added or changed).
- [ ] Ensure relevant issues are linked (description should include text like "Fixes #<issue number>")

