### PR TITLE
Fixed the issue from case sensitivity of field names in the fnctional…

### DIFF
--- a/ksql-functional-tests/src/main/java/io/confluent/ksql/test/serde/avro/ValueSpecAvroSerdeSupplier.java
+++ b/ksql-functional-tests/src/main/java/io/confluent/ksql/test/serde/avro/ValueSpecAvroSerdeSupplier.java
@@ -27,6 +27,7 @@ import java.util.AbstractMap;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Map.Entry;
 import java.util.Objects;
 import java.util.Set;
 import java.util.stream.Collectors;
@@ -121,10 +122,13 @@ public class ValueSpecAvroSerdeSupplier implements SerdeSupplier<Object> {
           return new GenericMap(schema, map);
         case RECORD:
           final GenericRecord record = new GenericData.Record(schema);
+          final Map<String, String> caseInsensitiveFieldNames
+              = getCaseInsensitiveMap((Map<String, ?>) spec);
           for (final org.apache.avro.Schema.Field field : schema.getFields()) {
             record.put(
                 field.name(),
-                valueSpecToAvro(((Map<String, ?>) spec).get(field.name()), field.schema())
+                valueSpecToAvro(((Map<String, ?>) spec)
+                    .get(caseInsensitiveFieldNames.get(field.name().toUpperCase())), field.schema())
             );
           }
           return record;
@@ -291,4 +295,11 @@ public class ValueSpecAvroSerdeSupplier implements SerdeSupplier<Object> {
       }
     }
   }
+
+  private static Map<String, String> getCaseInsensitiveMap(final Map<String, ?> record) {
+    return record.entrySet().stream().collect(Collectors.toMap(
+        entry -> entry.getKey().toUpperCase(),
+        Entry::getKey));
+  }
+
 } 

--- a/ksql-functional-tests/src/test/java/io/confluent/ksql/test/tools/KsqlTestingToolTest.java
+++ b/ksql-functional-tests/src/test/java/io/confluent/ksql/test/tools/KsqlTestingToolTest.java
@@ -54,7 +54,7 @@ public class KsqlTestingToolTest {
   @Test
   public void shouldRunCorrectsTest() throws Exception {
     final String testFolderPath = "src/test/resources/test-runner/";
-    for (int i = 1; i <= 3; i++) {
+    for (int i = 1; i <= 4; i++) {
       outContent.reset();
       errContent.reset();
       runTestCaseAndAssertPassed(testFolderPath + "test" + i + "/statements.sql",

--- a/ksql-functional-tests/src/test/resources/test-runner/test4/input.json
+++ b/ksql-functional-tests/src/test/resources/test-runner/test4/input.json
@@ -1,0 +1,29 @@
+
+{
+  "inputs": [
+    {
+      "topic": "publication_events",
+      "key": "C.S. Lewis",
+      "value": {
+        "author": "C.S. Lewis",
+        "title": "The Silver Chair"
+      }
+    },
+    {
+      "topic": "publication_events",
+      "key": "George R. R. Martin",
+      "value": {
+        "author": "George R. R. Martin",
+        "title": "A Song of Ice and Fire"
+      }
+    },
+    {
+      "topic": "publication_events",
+      "key": "C.S. Lewis",
+      "value": {
+        "author": "C.S. Lewis",
+        "title": "Perelandra"
+      }
+    }
+  ]
+}

--- a/ksql-functional-tests/src/test/resources/test-runner/test4/output.json
+++ b/ksql-functional-tests/src/test/resources/test-runner/test4/output.json
@@ -1,0 +1,12 @@
+{
+  "outputs": [
+    {
+      "topic": "george_martin_books",
+      "key": "George R. R. Martin",
+      "value": {
+        "AUTHOR": "George R. R. Martin",
+        "TITLE": "A Song of Ice and Fire"
+      }
+    }
+  ]
+}

--- a/ksql-functional-tests/src/test/resources/test-runner/test4/statements.sql
+++ b/ksql-functional-tests/src/test/resources/test-runner/test4/statements.sql
@@ -1,0 +1,13 @@
+-- This test is courtesy of Michael Drogalis (https://gist.github.com/MichaelDrogalis)
+CREATE STREAM all_publications (author VARCHAR, title VARCHAR)
+    WITH (kafka_topic = 'publication_events',
+          partitions = 1,
+          key = 'author',
+          value_format = 'avro');
+
+CREATE STREAM george_martin
+    WITH (kafka_topic = 'george_martin_books',
+          partitions = 1) AS
+    SELECT author, title
+    FROM all_publications
+    WHERE author = 'George R. R. Martin';


### PR DESCRIPTION
… tests.
KSQL considers column names for a table/stream to be case insensitive. This PR updates the avro serializer in the FunctionalTest module to use case insensitive field names, the same way the serializers work in KSQL.