### PR TITLE
Minor: refactor AggregateFunctionFactory for future decimal support

### DIFF
--- a/ksql-engine/src/main/java/io/confluent/ksql/function/UdafAggregateFunctionFactory.java
+++ b/ksql-engine/src/main/java/io/confluent/ksql/function/UdafAggregateFunctionFactory.java
@@ -28,7 +28,7 @@ public class UdafAggregateFunctionFactory extends AggregateFunctionFactory {
       final UdfMetadata metadata,
       final List<KsqlAggregateFunction<?, ?>> functionList
   ) {
-    super(metadata, functionList);
+    super(metadata);
     udfIndex = new UdfIndex<>(metadata.getName());
     functionList.forEach(udfIndex::addFunction);
   }
@@ -43,5 +43,13 @@ public class UdafAggregateFunctionFactory extends AggregateFunctionFactory {
           .collect(Collectors.joining(",")));
     }
     return ksqlAggregateFunction;
+  }
+
+  @Override
+  public List<List<Schema>> supportedArgs() {
+    return udfIndex.values()
+        .stream()
+        .map(KsqlAggregateFunction::getArguments)
+        .collect(Collectors.toList());
   }
 }

--- a/ksql-engine/src/main/java/io/confluent/ksql/function/udaf/count/CountAggFunctionFactory.java
+++ b/ksql-engine/src/main/java/io/confluent/ksql/function/udaf/count/CountAggFunctionFactory.java
@@ -15,9 +15,9 @@
 
 package io.confluent.ksql.function.udaf.count;
 
+import com.google.common.collect.ImmutableList;
 import io.confluent.ksql.function.AggregateFunctionFactory;
 import io.confluent.ksql.function.KsqlAggregateFunction;
-import java.util.Collections;
 import java.util.List;
 import org.apache.kafka.connect.data.Schema;
 
@@ -25,11 +25,17 @@ public class CountAggFunctionFactory extends AggregateFunctionFactory {
   private static final String FUNCTION_NAME = "COUNT";
 
   public CountAggFunctionFactory() {
-    super(FUNCTION_NAME, Collections.singletonList(new CountKudaf(FUNCTION_NAME, -1)));
+    super(FUNCTION_NAME);
   }
 
   @Override
   public KsqlAggregateFunction getProperAggregateFunction(final List<Schema> argTypeList) {
-    return getAggregateFunctionList().get(0);
+    return new CountKudaf(FUNCTION_NAME, -1);
+  }
+
+  @Override
+  public List<List<Schema>> supportedArgs() {
+    // anything is a supported type
+    return ImmutableList.of(ImmutableList.of());
   }
 }

--- a/ksql-engine/src/main/java/io/confluent/ksql/function/udaf/min/MinAggFunctionFactory.java
+++ b/ksql-engine/src/main/java/io/confluent/ksql/function/udaf/min/MinAggFunctionFactory.java
@@ -18,7 +18,7 @@ package io.confluent.ksql.function.udaf.min;
 import io.confluent.ksql.function.AggregateFunctionFactory;
 import io.confluent.ksql.function.KsqlAggregateFunction;
 import io.confluent.ksql.util.KsqlException;
-import java.util.Arrays;
+import io.confluent.ksql.util.KsqlPreconditions;
 import java.util.List;
 import org.apache.kafka.connect.data.Schema;
 
@@ -26,21 +26,32 @@ public class MinAggFunctionFactory extends AggregateFunctionFactory {
   private static final String FUNCTION_NAME = "MIN";
 
   public MinAggFunctionFactory() {
-    super(
-        FUNCTION_NAME,
-        Arrays.asList(
-            new DoubleMinKudaf(FUNCTION_NAME, -1), new LongMinKudaf(FUNCTION_NAME, -1),
-            new IntegerMinKudaf(FUNCTION_NAME, -1)));
+    super(FUNCTION_NAME);
   }
 
   @Override
   public KsqlAggregateFunction getProperAggregateFunction(final List<Schema> argTypeList) {
-    for (final KsqlAggregateFunction<?, ?> ksqlAggregateFunction : getAggregateFunctionList()) {
-      if (ksqlAggregateFunction.hasSameArgTypes(argTypeList)) {
-        return ksqlAggregateFunction;
-      }
+    KsqlPreconditions.checkArgument(
+        argTypeList.size() == 1,
+        "expected exactly one argument to aggregate MAX function");
+
+    final Schema argSchema = argTypeList.get(0);
+    switch (argSchema.type()) {
+      case INT32:
+        return new IntegerMinKudaf(FUNCTION_NAME, -1);
+      case INT64:
+        return new LongMinKudaf(FUNCTION_NAME, -1);
+      case FLOAT64:
+        return new DoubleMinKudaf(FUNCTION_NAME, -1);
+      default:
+        throw new KsqlException("No Max aggregate function with " + argTypeList.get(0) + " "
+            + " argument type exists!");
+
     }
-    throw new KsqlException("No Max aggregate function with " + argTypeList.get(0) + " "
-                            + " argument type exists!");
+  }
+
+  @Override
+  public List<List<Schema>> supportedArgs() {
+    return NUMERICAL_ARGS;
   }
 }

--- a/ksql-engine/src/main/java/io/confluent/ksql/function/udaf/sum/SumAggFunctionFactory.java
+++ b/ksql-engine/src/main/java/io/confluent/ksql/function/udaf/sum/SumAggFunctionFactory.java
@@ -18,7 +18,7 @@ package io.confluent.ksql.function.udaf.sum;
 import io.confluent.ksql.function.AggregateFunctionFactory;
 import io.confluent.ksql.function.KsqlAggregateFunction;
 import io.confluent.ksql.util.KsqlException;
-import java.util.Arrays;
+import io.confluent.ksql.util.KsqlPreconditions;
 import java.util.List;
 import org.apache.kafka.connect.data.Schema;
 
@@ -26,23 +26,33 @@ public class SumAggFunctionFactory extends AggregateFunctionFactory {
   private static final String FUNCTION_NAME = "SUM";
 
   public SumAggFunctionFactory() {
-    super(
-        FUNCTION_NAME,
-        Arrays.asList(
-            new DoubleSumKudaf(FUNCTION_NAME, -1), new LongSumKudaf(FUNCTION_NAME, -1),
-            new IntegerSumKudaf(FUNCTION_NAME,-1)));
+    super(FUNCTION_NAME);
   }
 
   @Override
   public KsqlAggregateFunction getProperAggregateFunction(final List<Schema> argTypeList) {
-    // For now we only support aggregate functions with one arg.
-    for (final KsqlAggregateFunction<?, ?> ksqlAggregateFunction : getAggregateFunctionList()) {
-      if (ksqlAggregateFunction.hasSameArgTypes(argTypeList)) {
-        return ksqlAggregateFunction;
-      }
+    KsqlPreconditions.checkArgument(
+        argTypeList.size() == 1,
+        "expected exactly one argument to aggregate MAX function");
+
+    final Schema argSchema = argTypeList.get(0);
+    switch (argSchema.type()) {
+      case INT32:
+        return new IntegerSumKudaf(FUNCTION_NAME, -1);
+      case INT64:
+        return new LongSumKudaf(FUNCTION_NAME, -1);
+      case FLOAT64:
+        return new DoubleSumKudaf(FUNCTION_NAME, -1);
+      default:
+        throw new KsqlException("No Max aggregate function with " + argTypeList.get(0) + " "
+            + " argument type exists!");
+
     }
-    throw new KsqlException("No SUM aggregate function with " + argTypeList.get(0) + " "
-                           + " argument type exists!");
+  }
+
+  @Override
+  public List<List<Schema>> supportedArgs() {
+    return NUMERICAL_ARGS;
   }
 
 }

--- a/ksql-engine/src/main/java/io/confluent/ksql/function/udaf/topk/TopKAggregateFunctionFactory.java
+++ b/ksql-engine/src/main/java/io/confluent/ksql/function/udaf/topk/TopKAggregateFunctionFactory.java
@@ -15,10 +15,10 @@
 
 package io.confluent.ksql.function.udaf.topk;
 
+import com.google.common.collect.ImmutableList;
 import io.confluent.ksql.function.AggregateFunctionFactory;
 import io.confluent.ksql.function.KsqlAggregateFunction;
 import io.confluent.ksql.util.KsqlException;
-import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 import org.apache.kafka.connect.data.Schema;
@@ -28,46 +28,22 @@ public class TopKAggregateFunctionFactory extends AggregateFunctionFactory {
   private static final String NAME = "TOPK";
   private final int topKSize;
 
+  private static final List<List<Schema>> SUPPORTED_TYPES = ImmutableList
+      .<List<Schema>>builder()
+      .add(ImmutableList.of(Schema.OPTIONAL_INT32_SCHEMA))
+      .add(ImmutableList.of(Schema.OPTIONAL_INT64_SCHEMA))
+      .add(ImmutableList.of(Schema.OPTIONAL_FLOAT64_SCHEMA))
+      .add(ImmutableList.of(Schema.OPTIONAL_STRING_SCHEMA))
+      .build();
+
   public TopKAggregateFunctionFactory() {
-    super(NAME, createFunctions());
+    super(NAME);
     this.topKSize = 0;
   }
 
   TopKAggregateFunctionFactory(final int topKSize) {
-    super(NAME, Collections.emptyList());
+    super(NAME);
     this.topKSize = topKSize;
-  }
-
-  // Just used to populate the function registry with info on the available functions
-  private static List<KsqlAggregateFunction<?,?>> createFunctions() {
-    return Arrays.asList(new TopkKudaf<>(
-            NAME,
-            -1,
-            0,
-            SchemaBuilder.array(Schema.OPTIONAL_INT32_SCHEMA).optional().build(),
-            Collections.singletonList(Schema.OPTIONAL_INT32_SCHEMA),
-            Integer.class),
-        new TopkKudaf<>(
-            NAME,
-            -1,
-            0,
-            SchemaBuilder.array(Schema.OPTIONAL_INT64_SCHEMA).optional().build(),
-            Collections.singletonList(Schema.OPTIONAL_INT64_SCHEMA),
-            Long.class),
-        new TopkKudaf<>(
-            NAME,
-            -1,
-            0,
-            SchemaBuilder.array(Schema.OPTIONAL_FLOAT64_SCHEMA).optional().build(),
-            Collections.singletonList(Schema.OPTIONAL_FLOAT64_SCHEMA),
-            Double.class),
-        new TopkKudaf<>(
-            NAME,
-            -1,
-            0,
-            SchemaBuilder.array(Schema.OPTIONAL_STRING_SCHEMA).optional().build(),
-            Collections.singletonList(Schema.OPTIONAL_STRING_SCHEMA),
-            String.class));
   }
 
   @Override
@@ -113,5 +89,10 @@ public class TopKAggregateFunctionFactory extends AggregateFunctionFactory {
         throw new KsqlException("No TOPK aggregate function with " + argumentType.get(0)
                                 + " argument type exists!");
     }
+  }
+
+  @Override
+  public List<List<Schema>> supportedArgs() {
+    return SUPPORTED_TYPES;
   }
 }

--- a/ksql-engine/src/main/java/io/confluent/ksql/function/udaf/topkdistinct/TopkDistinctAggFunctionFactory.java
+++ b/ksql-engine/src/main/java/io/confluent/ksql/function/udaf/topkdistinct/TopkDistinctAggFunctionFactory.java
@@ -15,6 +15,7 @@
 
 package io.confluent.ksql.function.udaf.topkdistinct;
 
+import com.google.common.collect.ImmutableList;
 import io.confluent.ksql.function.AggregateFunctionFactory;
 import io.confluent.ksql.function.KsqlAggregateFunction;
 import io.confluent.ksql.util.KsqlException;
@@ -29,9 +30,20 @@ public class TopkDistinctAggFunctionFactory extends AggregateFunctionFactory {
   private static final String NAME = "TOPKDISTINCT";
   private final Map<Schema.Type, KsqlAggregateFunction<?, ?>> functions = new HashMap<>();
 
+
+  private static final List<List<Schema>> SUPPORTED_TYPES = ImmutableList
+      .<List<Schema>>builder()
+      .add(ImmutableList.of(Schema.OPTIONAL_INT32_SCHEMA))
+      .add(ImmutableList.of(Schema.OPTIONAL_INT64_SCHEMA))
+      .add(ImmutableList.of(Schema.OPTIONAL_FLOAT64_SCHEMA))
+      .add(ImmutableList.of(Schema.OPTIONAL_STRING_SCHEMA))
+      .build();
+
   public TopkDistinctAggFunctionFactory() {
-    super(NAME, createDescriptionFunctions());
-    eachFunction(func -> functions.put(((TopkDistinctKudaf)func).getOutputSchema().type(), func));
+    super(NAME);
+    for (KsqlAggregateFunction<?, ?> func : createDescriptionFunctions()) {
+      functions.put(((TopkDistinctKudaf) func).getOutputSchema().type(), func);
+    }
   }
 
   private static List<KsqlAggregateFunction<?, ?>> createDescriptionFunctions() {
@@ -59,5 +71,10 @@ public class TopkDistinctAggFunctionFactory extends AggregateFunctionFactory {
           + " argument type exists!");
     }
     return function;
+  }
+
+  @Override
+  public List<List<Schema>> supportedArgs() {
+    return SUPPORTED_TYPES;
   }
 }

--- a/ksql-engine/src/test/java/io/confluent/ksql/function/InternalFunctionRegistryTest.java
+++ b/ksql-engine/src/test/java/io/confluent/ksql/function/InternalFunctionRegistryTest.java
@@ -28,6 +28,7 @@ import static org.junit.Assert.assertTrue;
 import static org.mockito.Mockito.when;
 
 import com.google.common.collect.Collections2;
+import com.google.common.collect.ImmutableList;
 import io.confluent.ksql.function.udf.Kudf;
 import io.confluent.ksql.util.KsqlException;
 import java.util.Arrays;
@@ -230,7 +231,7 @@ public class InternalFunctionRegistryTest {
   @Test
   public void shouldAddAggregateFunction() {
     functionRegistry.addAggregateFunctionFactory(
-        new AggregateFunctionFactory("my_aggregate", Collections.emptyList()) {
+        new AggregateFunctionFactory("my_aggregate") {
           @Override
           public KsqlAggregateFunction getProperAggregateFunction(final List<Schema> argTypeList) {
             return new KsqlAggregateFunction() {
@@ -284,6 +285,11 @@ public class InternalFunctionRegistryTest {
                 return null;
               }
             };
+          }
+
+          @Override
+          public List<List<Schema>> supportedArgs() {
+            return ImmutableList.of();
           }
         });
     assertThat(functionRegistry.getAggregate("my_aggregate", Schema.OPTIONAL_INT32_SCHEMA), not(nullValue()));


### PR DESCRIPTION
### Description 
This change delays creating a `KsqlAggregateFunction` until `getProperAggregateFunction` is called. This is necessary because when I introduce the corresponding Decimal Aggregate Functions, I need to know the argument schema when I create it. 

### Testing done 
- No functionality changes, passes `mvn clean install`

### Reviewer checklist
- [ ] Ensure docs are updated if necessary. (eg. if a user visible feature is being added or changed).
- [ ] Ensure relevant issues are linked (description should include text like "Fixes #<issue number>")

