### PR TITLE
Minor: Add liveness indicator metric

### DIFF
--- a/ksql-engine/src/main/java/io/confluent/ksql/internal/KsqlEngineMetrics.java
+++ b/ksql-engine/src/main/java/io/confluent/ksql/internal/KsqlEngineMetrics.java
@@ -76,6 +76,7 @@ public class KsqlEngineMetrics implements Closeable {
 
     this.metrics = metrics;
 
+    configureLivenessIndicator(metrics);
     configureNumActiveQueries(metrics);
     configureNumPersistentQueries(metrics);
     this.messagesIn = configureMessagesIn(metrics);
@@ -229,6 +230,28 @@ public class KsqlEngineMetrics implements Closeable {
     final String description = "Number of inactive queries";
     final Sensor sensor = createSensor(metrics, metricName, description, Value::new);
     return sensor;
+  }
+
+  private void configureLivenessIndicator(final Metrics metrics) {
+    final String metricName = "liveness-indicator";
+    final String description =
+        "A metric with constant value 1 indicating the server is up and emitting metrics";
+    createSensor(
+        metrics,
+        metricName,
+        description,
+        () -> new MeasurableStat() {
+          @Override
+          public double measure(final MetricConfig metricConfig, final long l) {
+            return 1;
+          }
+
+          @Override
+          public void record(final MetricConfig metricConfig, final double v, final long l) {
+            // Nothing to record
+          }
+        }
+    );
   }
 
   private Sensor configureMessageConsumptionByQuerySensor(final Metrics metrics) {

--- a/ksql-engine/src/test/java/io/confluent/ksql/internal/KsqlEngineMetricsTest.java
+++ b/ksql-engine/src/test/java/io/confluent/ksql/internal/KsqlEngineMetricsTest.java
@@ -103,6 +103,15 @@ public class KsqlEngineMetricsTest {
   }
 
   @Test
+  public void shouldRecordLivenessIndicator() {
+    final double value = getMetricValue("liveness-indicator");
+    final double legacyValue = getMetricValueLegacy("liveness-indicator");
+
+    assertThat(value, equalTo(1.0));
+    assertThat(legacyValue, equalTo(1.0));
+  }
+
+  @Test
   public void shouldRecordNumberOfActiveQueries() {
     when(ksqlEngine.numberOfLiveQueries()).thenReturn(3);
 


### PR DESCRIPTION
### Description 

Adds a new metric `liveness-indicator` that always has value 1. As the name suggests, the new metric simply indicates the KSQL engine is up and emitting metrics. 

### Testing done 

Added unit test.

### Reviewer checklist
- [ ] Ensure docs are updated if necessary. (eg. if a user visible feature is being added or changed).
- [ ] Ensure relevant issues are linked (description should include text like "Fixes #<issue number>")

