### PR TITLE
INSERT VALUES support for DECIMAL type

### DIFF
--- a/ksql-parser/src/main/java/io/confluent/ksql/schema/ksql/SqlValueCoercer.java
+++ b/ksql-parser/src/main/java/io/confluent/ksql/schema/ksql/SqlValueCoercer.java
@@ -16,6 +16,7 @@
 package io.confluent.ksql.schema.ksql;
 
 import java.util.Optional;
+import org.apache.kafka.connect.data.Schema;
 
 /**
  * Coerces values to {@link SqlType SQL types}.
@@ -28,9 +29,9 @@ public interface SqlValueCoercer {
    * <p>Complex SQL types are not supported, (yet).
    *
    * @param value the value to try to coerce.
-   * @param targetSqlType the target SQL type.
+   * @param targetSchema the target SQL type.
    * @param <T> target Java type
    * @return the coerced value if the value could be coerced, {@link Optional#empty()} otherwise.
    */
-  <T> Optional<T> coerce(Object value, SqlType targetSqlType);
+  <T> Optional<T> coerce(Object value, Schema targetSchema);
 }

--- a/ksql-parser/src/test/java/io/confluent/ksql/schema/ksql/DefaultSqlValueCoercerTest.java
+++ b/ksql-parser/src/test/java/io/confluent/ksql/schema/ksql/DefaultSqlValueCoercerTest.java
@@ -28,11 +28,16 @@ import org.apache.kafka.connect.data.Schema;
 import org.apache.kafka.connect.data.SchemaBuilder;
 import org.apache.kafka.connect.data.Struct;
 import org.junit.Before;
+import org.junit.Rule;
 import org.junit.Test;
+import org.junit.rules.ExpectedException;
 
 public class DefaultSqlValueCoercerTest {
 
   private DefaultSqlValueCoercer coercer;
+
+  @Rule
+  public final ExpectedException expectedException = ExpectedException.none();
 
   @Before
   public void setUp() {
@@ -133,5 +138,18 @@ public class DefaultSqlValueCoercerTest {
 
     // Expect:
     assertThat(coercer.coerce(val, DecimalUtil.builder(2, 1)), is(Optional.of(new BigDecimal("1.0"))));
+  }
+
+  @Test
+  public void shouldThrowIfInvalidCoercionString() {
+    // Given:
+    final String val = "hello";
+
+    // Expect;
+    expectedException.expect(KsqlException.class);
+    expectedException.expectMessage("Cannot coerce value to DECIMAL: hello");
+
+    // When:
+    coercer.coerce(val, DecimalUtil.builder(2, 1));
   }
 }

--- a/ksql-rest-app/src/main/java/io/confluent/ksql/rest/server/execution/InsertValuesExecutor.java
+++ b/ksql-rest-app/src/main/java/io/confluent/ksql/rest/server/execution/InsertValuesExecutor.java
@@ -34,6 +34,7 @@ import io.confluent.ksql.rest.entity.KsqlEntity;
 import io.confluent.ksql.schema.ksql.DefaultSqlValueCoercer;
 import io.confluent.ksql.schema.ksql.LogicalSchema;
 import io.confluent.ksql.schema.ksql.PhysicalSchema;
+import io.confluent.ksql.schema.ksql.SchemaConverters;
 import io.confluent.ksql.schema.ksql.SqlValueCoercer;
 import io.confluent.ksql.serde.GenericRowSerDe;
 import io.confluent.ksql.services.ServiceContext;
@@ -325,7 +326,9 @@ public class InsertValuesExecutor {
       return defaultSqlValueCoercer.coerce(value, fieldSchema)
           .orElseThrow(
               () -> new KsqlException(
-                  "Expected type " + fieldSchema.type() + " for field " + fieldName
+                  "Expected type "
+                      + SchemaConverters.logicalToSqlConverter().toSqlType(fieldSchema)
+                      + " for field " + fieldName
                       + " but got " + value));
     }
   }

--- a/ksql-rest-app/src/main/java/io/confluent/ksql/rest/server/execution/InsertValuesExecutor.java
+++ b/ksql-rest-app/src/main/java/io/confluent/ksql/rest/server/execution/InsertValuesExecutor.java
@@ -325,7 +325,7 @@ public class InsertValuesExecutor {
       return defaultSqlValueCoercer.coerce(value, fieldSchema)
           .orElseThrow(
               () -> new KsqlException(
-                  "Expected type " + fieldSchema + " for field " + fieldName
+                  "Expected type " + fieldSchema.type() + " for field " + fieldName
                       + " but got " + value));
     }
   }

--- a/ksql-rest-app/src/test/java/io/confluent/ksql/rest/server/execution/InsertValuesExecutorTest.java
+++ b/ksql-rest-app/src/test/java/io/confluent/ksql/rest/server/execution/InsertValuesExecutorTest.java
@@ -44,9 +44,12 @@ import io.confluent.ksql.serde.KsqlSerdeFactory;
 import io.confluent.ksql.serde.SerdeOption;
 import io.confluent.ksql.services.ServiceContext;
 import io.confluent.ksql.statement.ConfiguredStatement;
+import io.confluent.ksql.util.DecimalUtil;
 import io.confluent.ksql.util.KsqlConfig;
 import io.confluent.ksql.util.KsqlException;
 import io.confluent.ksql.util.timestamp.MetadataTimestampExtractionPolicy;
+import java.math.BigDecimal;
+import java.math.MathContext;
 import java.util.List;
 import java.util.Optional;
 import java.util.Set;
@@ -96,6 +99,7 @@ public class InsertValuesExecutorTest {
       .field("DOUBLE", Schema.OPTIONAL_FLOAT64_SCHEMA)
       .field("BOOLEAN", Schema.OPTIONAL_BOOLEAN_SCHEMA)
       .field("VARCHAR", Schema.OPTIONAL_STRING_SCHEMA)
+      .field("DECIMAL", DecimalUtil.builder(2, 1).build())
       .build());
 
   private static final byte[] KEY = new byte[]{1};
@@ -387,7 +391,8 @@ public class InsertValuesExecutorTest {
             new LongLiteral(2),
             new DoubleLiteral("3.0"),
             new BooleanLiteral("TRUE"),
-            new StringLiteral("str"))
+            new StringLiteral("str"),
+            new StringLiteral("1.2"))
     );
 
     // When:
@@ -403,6 +408,7 @@ public class InsertValuesExecutorTest {
         .put("DOUBLE", 3.0)
         .put("BOOLEAN", true)
         .put("VARCHAR", "str")
+        .put("DECIMAL", new BigDecimal(1.2, new MathContext(2)))
     );
 
     verify(producer).send(new ProducerRecord<>(TOPIC_NAME, null, 1L, KEY, VALUE));

--- a/ksql-rest-app/src/test/java/io/confluent/ksql/rest/server/execution/InsertValuesExecutorTest.java
+++ b/ksql-rest-app/src/test/java/io/confluent/ksql/rest/server/execution/InsertValuesExecutorTest.java
@@ -554,7 +554,7 @@ public class InsertValuesExecutorTest {
 
     // Expect:
     expectedException.expect(KsqlException.class);
-    expectedException.expectMessage("Expected type Schema{INT32} for field");
+    expectedException.expectMessage("Expected type INTEGER for field");
 
     // When:
     new InsertValuesExecutor(() -> 1L).execute(statement, engine, serviceContext);

--- a/ksql-rest-app/src/test/java/io/confluent/ksql/rest/server/execution/InsertValuesExecutorTest.java
+++ b/ksql-rest-app/src/test/java/io/confluent/ksql/rest/server/execution/InsertValuesExecutorTest.java
@@ -554,7 +554,7 @@ public class InsertValuesExecutorTest {
 
     // Expect:
     expectedException.expect(KsqlException.class);
-    expectedException.expectMessage("Expected type INTEGER for field");
+    expectedException.expectMessage("Expected type Schema{INT32} for field");
 
     // When:
     new InsertValuesExecutor(() -> 1L).execute(statement, engine, serviceContext);


### PR DESCRIPTION
### Description 

Adds support to insert into for DECIMAL types.

### Testing done 

Unit testing and CLI testing

```sql
ksql> create stream s2 (ticker varchar, value decimal(4,2)) with (kafka_topic='s2', value_format='avro', partitions=1);

 Message
----------------
 Stream created
----------------

ksql> insert into s2 values ('msft', 'msft', 12.23);
ksql> insert into s2 values ('cnfl', 'cnfl', '22.33');
ksql> insert into s2 values ('cnfl', 'cnfl', 22);

ksql> SELECT * FROM S2;
1560458488849 | msft | msft | 12.23
1560458504014 | cnfl | cnfl | 22.33
1560458649743 | cnfl | cnfl | 22.0
^CQuery terminated
```

### Reviewer checklist
- [ ] Ensure docs are updated if necessary. (eg. if a user visible feature is being added or changed).
- [ ] Ensure relevant issues are linked (description should include text like "Fixes #<issue number>")

