### PR TITLE
Comparison support for DECIMAL type

### DIFF
--- a/ksql-common/src/main/java/io/confluent/ksql/util/SchemaUtil.java
+++ b/ksql-common/src/main/java/io/confluent/ksql/util/SchemaUtil.java
@@ -341,6 +341,10 @@ public final class SchemaUtil {
     return ARITHMETIC_TYPES.contains(type);
   }
 
+  public static boolean isNumber(final Schema schema) {
+    return isNumber(schema.type()) || DecimalUtil.isDecimal(schema);
+  }
+
   public static Schema ensureOptional(final Schema schema) {
     final SchemaBuilder builder;
     switch (schema.type()) {

--- a/ksql-common/src/test/java/io/confluent/ksql/util/SchemaUtilTest.java
+++ b/ksql-common/src/test/java/io/confluent/ksql/util/SchemaUtilTest.java
@@ -850,6 +850,11 @@ public class SchemaUtilTest {
   }
 
   @Test
+  public void shouldPassIsNumberForDecimal() {
+    assertThat(SchemaUtil.isNumber(DecimalUtil.builder(2, 1)), is(true));
+  }
+
+  @Test
   public void shouldFailIsNumberForBoolean() {
     assertThat(SchemaUtil.isNumber(Schema.Type.BOOLEAN), is(false));
     assertThat(SchemaUtil.isNumber(Schema.OPTIONAL_BOOLEAN_SCHEMA), is(false));

--- a/ksql-common/src/test/java/io/confluent/ksql/util/SchemaUtilTest.java
+++ b/ksql-common/src/test/java/io/confluent/ksql/util/SchemaUtilTest.java
@@ -831,26 +831,36 @@ public class SchemaUtilTest {
   @Test
   public void shouldPassIsNumberForInt() {
     assertThat(SchemaUtil.isNumber(Schema.Type.INT32), is(true));
+    assertThat(SchemaUtil.isNumber(Schema.OPTIONAL_INT32_SCHEMA), is(true));
+    assertThat(SchemaUtil.isNumber(Schema.INT32_SCHEMA), is(true));
   }
 
   @Test
   public void shouldPassIsNumberForBigint() {
     assertThat(SchemaUtil.isNumber(Schema.Type.INT64), is(true));
+    assertThat(SchemaUtil.isNumber(Schema.OPTIONAL_INT64_SCHEMA), is(true));
+    assertThat(SchemaUtil.isNumber(Schema.INT64_SCHEMA), is(true));
   }
 
   @Test
   public void shouldPassIsNumberForDouble() {
     assertThat(SchemaUtil.isNumber(Schema.Type.FLOAT64), is(true));
+    assertThat(SchemaUtil.isNumber(Schema.OPTIONAL_FLOAT64_SCHEMA), is(true));
+    assertThat(SchemaUtil.isNumber(Schema.FLOAT64_SCHEMA), is(true));
   }
 
   @Test
   public void shouldFailIsNumberForBoolean() {
     assertThat(SchemaUtil.isNumber(Schema.Type.BOOLEAN), is(false));
+    assertThat(SchemaUtil.isNumber(Schema.OPTIONAL_BOOLEAN_SCHEMA), is(false));
+    assertThat(SchemaUtil.isNumber(Schema.BOOLEAN_SCHEMA), is(false));
   }
 
   @Test
   public void shouldFailIsNumberForString() {
     assertThat(SchemaUtil.isNumber(Schema.Type.STRING), is(false));
+    assertThat(SchemaUtil.isNumber(Schema.OPTIONAL_STRING_SCHEMA), is(false));
+    assertThat(SchemaUtil.isNumber(Schema.STRING_SCHEMA), is(false));
   }
 
   @Test

--- a/ksql-engine/src/main/java/io/confluent/ksql/util/ComparisonUtil.java
+++ b/ksql-engine/src/main/java/io/confluent/ksql/util/ComparisonUtil.java
@@ -39,11 +39,13 @@ final class ComparisonUtil {
     }
 
     if (left.type() == Type.BOOLEAN && right.type() == Type.BOOLEAN) {
-      return operator == ComparisonExpression.Type.EQUAL
-          || operator == ComparisonExpression.Type.NOT_EQUAL;
+      if (operator == ComparisonExpression.Type.EQUAL
+          || operator == ComparisonExpression.Type.NOT_EQUAL) {
+        return true;
+      }
     }
 
-    throw new KsqlException("Operator " + operator + " cannot be used to compare " + left
-        + " and " + right);
+    throw new KsqlException("Operator " + operator + " cannot be used to compare " + left.type()
+        + " and " + right.type());
   }
 }

--- a/ksql-engine/src/main/java/io/confluent/ksql/util/ComparisonUtil.java
+++ b/ksql-engine/src/main/java/io/confluent/ksql/util/ComparisonUtil.java
@@ -16,6 +16,7 @@
 package io.confluent.ksql.util;
 
 import io.confluent.ksql.parser.tree.ComparisonExpression;
+import io.confluent.ksql.schema.ksql.SchemaConverters;
 import org.apache.kafka.connect.data.Schema;
 import org.apache.kafka.connect.data.Schema.Type;
 
@@ -45,7 +46,10 @@ final class ComparisonUtil {
       }
     }
 
-    throw new KsqlException("Operator " + operator + " cannot be used to compare " + left.type()
-        + " and " + right.type());
+    throw new KsqlException("Operator " + operator + " cannot be used to compare "
+        + SchemaConverters.logicalToSqlConverter().toSqlType(left)
+        + " and "
+        + SchemaConverters.logicalToSqlConverter().toSqlType(right)
+    );
   }
 }

--- a/ksql-engine/src/main/java/io/confluent/ksql/util/ComparisonUtil.java
+++ b/ksql-engine/src/main/java/io/confluent/ksql/util/ComparisonUtil.java
@@ -47,9 +47,9 @@ final class ComparisonUtil {
     }
 
     throw new KsqlException("Operator " + operator + " cannot be used to compare "
-        + SchemaConverters.logicalToSqlConverter().toSqlType(left)
+        + SchemaConverters.logicalToSqlConverter().toSqlType(left).getSqlType()
         + " and "
-        + SchemaConverters.logicalToSqlConverter().toSqlType(right)
+        + SchemaConverters.logicalToSqlConverter().toSqlType(right).getSqlType()
     );
   }
 }

--- a/ksql-engine/src/main/java/io/confluent/ksql/util/ExpressionTypeManager.java
+++ b/ksql-engine/src/main/java/io/confluent/ksql/util/ExpressionTypeManager.java
@@ -126,7 +126,7 @@ public class ExpressionTypeManager
     final Schema leftSchema = expressionTypeContext.getSchema();
     process(node.getRight(), expressionTypeContext);
     final Schema rightSchema = expressionTypeContext.getSchema();
-    ComparisonUtil.isValidComparison(leftSchema.type(), node.getType(), rightSchema.type());
+    ComparisonUtil.isValidComparison(leftSchema, node.getType(), rightSchema);
     expressionTypeContext.setSchema(Schema.OPTIONAL_BOOLEAN_SCHEMA);
     return null;
   }

--- a/ksql-engine/src/test/java/io/confluent/ksql/codegen/SqlToJavaVisitorTest.java
+++ b/ksql-engine/src/test/java/io/confluent/ksql/codegen/SqlToJavaVisitorTest.java
@@ -71,6 +71,7 @@ public class SqlToJavaVisitorTest {
         .field("TEST1.COL6", addressSchema)
         .field("TEST1.COL7", SchemaBuilder.OPTIONAL_INT32_SCHEMA)
         .field("TEST1.COL8", DecimalUtil.builder(2, 1).build())
+        .field("TEST1.COL9", DecimalUtil.builder(2, 1).build())
         .build();
 
     sqlToJavaVisitor = new SqlToJavaVisitor(LogicalSchema.of(schema), TestFunctionRegistry.INSTANCE.get());
@@ -339,14 +340,14 @@ public class SqlToJavaVisitorTest {
     final ComparisonExpression compExp = new ComparisonExpression(
         Type.EQUAL,
         new QualifiedNameReference(QualifiedName.of("TEST1.COL8")),
-        new QualifiedNameReference(QualifiedName.of("TEST1.COL8"))
+        new QualifiedNameReference(QualifiedName.of("TEST1.COL9"))
     );
 
     // When:
     final String java = sqlToJavaVisitor.process(compExp);
 
     // Then:
-    assertThat(java, containsString("(TEST1_COL8.compareTo(TEST1_COL8) == 0))"));
+    assertThat(java, containsString("(TEST1_COL8.compareTo(TEST1_COL9) == 0))"));
   }
 
   @Test
@@ -355,14 +356,14 @@ public class SqlToJavaVisitorTest {
     final ComparisonExpression compExp = new ComparisonExpression(
         Type.GREATER_THAN,
         new QualifiedNameReference(QualifiedName.of("TEST1.COL8")),
-        new QualifiedNameReference(QualifiedName.of("TEST1.COL8"))
+        new QualifiedNameReference(QualifiedName.of("TEST1.COL9"))
     );
 
     // When:
     final String java = sqlToJavaVisitor.process(compExp);
 
     // Then:
-    assertThat(java, containsString("(TEST1_COL8.compareTo(TEST1_COL8) > 0))"));
+    assertThat(java, containsString("(TEST1_COL8.compareTo(TEST1_COL9) > 0))"));
   }
 
   @Test
@@ -371,14 +372,14 @@ public class SqlToJavaVisitorTest {
     final ComparisonExpression compExp = new ComparisonExpression(
         Type.GREATER_THAN_OR_EQUAL,
         new QualifiedNameReference(QualifiedName.of("TEST1.COL8")),
-        new QualifiedNameReference(QualifiedName.of("TEST1.COL8"))
+        new QualifiedNameReference(QualifiedName.of("TEST1.COL9"))
     );
 
     // When:
     final String java = sqlToJavaVisitor.process(compExp);
 
     // Then:
-    assertThat(java, containsString("(TEST1_COL8.compareTo(TEST1_COL8) >= 0))"));
+    assertThat(java, containsString("(TEST1_COL8.compareTo(TEST1_COL9) >= 0))"));
   }
 
   @Test
@@ -387,14 +388,14 @@ public class SqlToJavaVisitorTest {
     final ComparisonExpression compExp = new ComparisonExpression(
         Type.LESS_THAN,
         new QualifiedNameReference(QualifiedName.of("TEST1.COL8")),
-        new QualifiedNameReference(QualifiedName.of("TEST1.COL8"))
+        new QualifiedNameReference(QualifiedName.of("TEST1.COL9"))
     );
 
     // When:
     final String java = sqlToJavaVisitor.process(compExp);
 
     // Then:
-    assertThat(java, containsString("(TEST1_COL8.compareTo(TEST1_COL8) < 0))"));
+    assertThat(java, containsString("(TEST1_COL8.compareTo(TEST1_COL9) < 0))"));
   }
 
   @Test
@@ -403,14 +404,14 @@ public class SqlToJavaVisitorTest {
     final ComparisonExpression compExp = new ComparisonExpression(
         Type.LESS_THAN_OR_EQUAL,
         new QualifiedNameReference(QualifiedName.of("TEST1.COL8")),
-        new QualifiedNameReference(QualifiedName.of("TEST1.COL8"))
+        new QualifiedNameReference(QualifiedName.of("TEST1.COL9"))
     );
 
     // When:
     final String java = sqlToJavaVisitor.process(compExp);
 
     // Then:
-    assertThat(java, containsString("(TEST1_COL8.compareTo(TEST1_COL8) <= 0))"));
+    assertThat(java, containsString("(TEST1_COL8.compareTo(TEST1_COL9) <= 0))"));
   }
 
   @Test
@@ -419,14 +420,14 @@ public class SqlToJavaVisitorTest {
     final ComparisonExpression compExp = new ComparisonExpression(
         Type.IS_DISTINCT_FROM,
         new QualifiedNameReference(QualifiedName.of("TEST1.COL8")),
-        new QualifiedNameReference(QualifiedName.of("TEST1.COL8"))
+        new QualifiedNameReference(QualifiedName.of("TEST1.COL9"))
     );
 
     // When:
     final String java = sqlToJavaVisitor.process(compExp);
 
     // Then:
-    assertThat(java, containsString("(TEST1_COL8.compareTo(TEST1_COL8) != 0))"));
+    assertThat(java, containsString("(TEST1_COL8.compareTo(TEST1_COL9) != 0))"));
   }
 
   @Test

--- a/ksql-engine/src/test/java/io/confluent/ksql/codegen/SqlToJavaVisitorTest.java
+++ b/ksql-engine/src/test/java/io/confluent/ksql/codegen/SqlToJavaVisitorTest.java
@@ -16,6 +16,7 @@
 package io.confluent.ksql.codegen;
 
 import static io.confluent.ksql.testutils.AnalysisTestUtil.analyzeQuery;
+import static org.hamcrest.CoreMatchers.containsString;
 import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
@@ -24,6 +25,8 @@ import io.confluent.ksql.analyzer.Analysis;
 import io.confluent.ksql.function.TestFunctionRegistry;
 import io.confluent.ksql.metastore.MetaStore;
 import io.confluent.ksql.parser.tree.ArithmeticBinaryExpression;
+import io.confluent.ksql.parser.tree.ComparisonExpression;
+import io.confluent.ksql.parser.tree.ComparisonExpression.Type;
 import io.confluent.ksql.parser.tree.Expression;
 import io.confluent.ksql.parser.tree.QualifiedName;
 import io.confluent.ksql.parser.tree.QualifiedNameReference;
@@ -328,6 +331,134 @@ public class SqlToJavaVisitorTest {
 
     // Then:
     assertThat(java, is("(TEST1_COL8.remainder(TEST1_COL8, new MathContext(2, RoundingMode.UNNECESSARY)).setScale(1))"));
+  }
+
+  @Test
+  public void shouldGenerateCorrectCodeForDecimalDecimalEQ() {
+    // Given:
+    final ComparisonExpression compExp = new ComparisonExpression(
+        Type.EQUAL,
+        new QualifiedNameReference(QualifiedName.of("TEST1.COL8")),
+        new QualifiedNameReference(QualifiedName.of("TEST1.COL8"))
+    );
+
+    // When:
+    final String java = sqlToJavaVisitor.process(compExp);
+
+    // Then:
+    assertThat(java, containsString("(TEST1_COL8.compareTo(TEST1_COL8) == 0))"));
+  }
+
+  @Test
+  public void shouldGenerateCorrectCodeForDecimalDecimalGT() {
+    // Given:
+    final ComparisonExpression compExp = new ComparisonExpression(
+        Type.GREATER_THAN,
+        new QualifiedNameReference(QualifiedName.of("TEST1.COL8")),
+        new QualifiedNameReference(QualifiedName.of("TEST1.COL8"))
+    );
+
+    // When:
+    final String java = sqlToJavaVisitor.process(compExp);
+
+    // Then:
+    assertThat(java, containsString("(TEST1_COL8.compareTo(TEST1_COL8) > 0))"));
+  }
+
+  @Test
+  public void shouldGenerateCorrectCodeForDecimalDecimalGEQ() {
+    // Given:
+    final ComparisonExpression compExp = new ComparisonExpression(
+        Type.GREATER_THAN_OR_EQUAL,
+        new QualifiedNameReference(QualifiedName.of("TEST1.COL8")),
+        new QualifiedNameReference(QualifiedName.of("TEST1.COL8"))
+    );
+
+    // When:
+    final String java = sqlToJavaVisitor.process(compExp);
+
+    // Then:
+    assertThat(java, containsString("(TEST1_COL8.compareTo(TEST1_COL8) >= 0))"));
+  }
+
+  @Test
+  public void shouldGenerateCorrectCodeForDecimalDecimalLT() {
+    // Given:
+    final ComparisonExpression compExp = new ComparisonExpression(
+        Type.LESS_THAN,
+        new QualifiedNameReference(QualifiedName.of("TEST1.COL8")),
+        new QualifiedNameReference(QualifiedName.of("TEST1.COL8"))
+    );
+
+    // When:
+    final String java = sqlToJavaVisitor.process(compExp);
+
+    // Then:
+    assertThat(java, containsString("(TEST1_COL8.compareTo(TEST1_COL8) < 0))"));
+  }
+
+  @Test
+  public void shouldGenerateCorrectCodeForDecimalDecimalLEQ() {
+    // Given:
+    final ComparisonExpression compExp = new ComparisonExpression(
+        Type.LESS_THAN_OR_EQUAL,
+        new QualifiedNameReference(QualifiedName.of("TEST1.COL8")),
+        new QualifiedNameReference(QualifiedName.of("TEST1.COL8"))
+    );
+
+    // When:
+    final String java = sqlToJavaVisitor.process(compExp);
+
+    // Then:
+    assertThat(java, containsString("(TEST1_COL8.compareTo(TEST1_COL8) <= 0))"));
+  }
+
+  @Test
+  public void shouldGenerateCorrectCodeForDecimalDecimalIsDistinct() {
+    // Given:
+    final ComparisonExpression compExp = new ComparisonExpression(
+        Type.IS_DISTINCT_FROM,
+        new QualifiedNameReference(QualifiedName.of("TEST1.COL8")),
+        new QualifiedNameReference(QualifiedName.of("TEST1.COL8"))
+    );
+
+    // When:
+    final String java = sqlToJavaVisitor.process(compExp);
+
+    // Then:
+    assertThat(java, containsString("(TEST1_COL8.compareTo(TEST1_COL8) != 0))"));
+  }
+
+  @Test
+  public void shouldGenerateCorrectCodeForDecimalDoubleEQ() {
+    // Given:
+    final ComparisonExpression compExp = new ComparisonExpression(
+        Type.EQUAL,
+        new QualifiedNameReference(QualifiedName.of("TEST1.COL8")),
+        new QualifiedNameReference(QualifiedName.of("TEST1.COL3"))
+    );
+
+    // When:
+    final String java = sqlToJavaVisitor.process(compExp);
+
+    // Then:
+    assertThat(java, containsString("(TEST1_COL8.compareTo(new BigDecimal(TEST1_COL3)) == 0))"));
+  }
+
+  @Test
+  public void shouldGenerateCorrectCodeForDoubleDecimalEQ() {
+    // Given:
+    final ComparisonExpression compExp = new ComparisonExpression(
+        Type.EQUAL,
+        new QualifiedNameReference(QualifiedName.of("TEST1.COL3")),
+        new QualifiedNameReference(QualifiedName.of("TEST1.COL8"))
+    );
+
+    // When:
+    final String java = sqlToJavaVisitor.process(compExp);
+
+    // Then:
+    assertThat(java, containsString("(new BigDecimal(TEST1_COL3).compareTo(TEST1_COL8) == 0))"));
   }
 
   @Test

--- a/ksql-engine/src/test/java/io/confluent/ksql/util/ComparisonUtilTest.java
+++ b/ksql-engine/src/test/java/io/confluent/ksql/util/ComparisonUtilTest.java
@@ -21,9 +21,9 @@ import static org.hamcrest.MatcherAssert.assertThat;
 
 import com.google.common.collect.ImmutableList;
 import io.confluent.ksql.parser.tree.ComparisonExpression;
+import io.confluent.ksql.schema.ksql.SqlType;
 import java.util.List;
 import org.apache.kafka.connect.data.Schema;
-import org.apache.kafka.connect.data.Schema.Type;
 import org.apache.kafka.connect.data.SchemaBuilder;
 import org.junit.Rule;
 import org.junit.Test;
@@ -43,9 +43,9 @@ public class ComparisonUtilTest {
       SchemaBuilder.struct().field("foo", Schema.OPTIONAL_INT64_SCHEMA).build()
   );
 
-  private static final String[] SCHEMA_TO_SQL_NAME = new String[] {
-      "BOOLEAN", "INTEGER", "BIGINT", "DOUBLE", "DECIMAL(4, 2)",
-      "STRING", "ARRAY<INTEGER>", "MAP<VARCHAR, STRING>", "STRUCT<foo BIGINT>"
+  private static final SqlType[] SCHEMA_TO_SQL_NAME = new SqlType[] {
+      SqlType.BOOLEAN, SqlType.INTEGER, SqlType.BIGINT, SqlType.DOUBLE,
+      SqlType.DECIMAL, SqlType.STRING, SqlType.ARRAY, SqlType.MAP, SqlType.STRUCT
   };
 
   private static final List<List<Boolean>> expectedResults = ImmutableList.of(

--- a/ksql-engine/src/test/java/io/confluent/ksql/util/ComparisonUtilTest.java
+++ b/ksql-engine/src/test/java/io/confluent/ksql/util/ComparisonUtilTest.java
@@ -23,24 +23,34 @@ import io.confluent.ksql.parser.tree.ComparisonExpression;
 import java.util.List;
 import org.apache.kafka.connect.data.Schema;
 import org.apache.kafka.connect.data.Schema.Type;
+import org.apache.kafka.connect.data.SchemaBuilder;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ExpectedException;
 
 public class ComparisonUtilTest {
 
-  private static final List<Type> typesTable = ImmutableList.of(
-      Schema.Type.BOOLEAN, Schema.Type.INT32, Schema.Type.INT64, Schema.Type.FLOAT64, Schema.Type.STRING, Schema.Type.ARRAY, Schema.Type.MAP, Schema.Type.STRUCT
+  private static final List<Schema> typesTable = ImmutableList.of(
+      Schema.OPTIONAL_BOOLEAN_SCHEMA,
+      Schema.OPTIONAL_INT32_SCHEMA,
+      Schema.OPTIONAL_INT64_SCHEMA,
+      Schema.OPTIONAL_FLOAT64_SCHEMA,
+      DecimalUtil.builder(4, 2).build(),
+      Schema.OPTIONAL_STRING_SCHEMA,
+      SchemaBuilder.array(Schema.OPTIONAL_INT32_SCHEMA).build(),
+      SchemaBuilder.map(Schema.OPTIONAL_STRING_SCHEMA, Schema.OPTIONAL_STRING_SCHEMA).build(),
+      SchemaBuilder.struct().field("foo", Schema.OPTIONAL_INT64_SCHEMA).build()
   );
   private static final List<List<Boolean>> expectedResults = ImmutableList.of(
-      ImmutableList.of(true, false, false, false, false, false, false, false), // Boolean
-      ImmutableList.of(false, true, true, true, false, false, false, false), // Int
-      ImmutableList.of(false, true, true, true, false, false, false, false), // BigInt
-      ImmutableList.of(false, true, true, true, false, false, false, false), // Double
-      ImmutableList.of(false, false, false, false, true, false, false, false),  // String
-      ImmutableList.of(false, false, false, false, false, false, false, false), // Array
-      ImmutableList.of(false, false, false, false, false, false, false, false), // Map
-      ImmutableList.of(false, false, false, false, false, false, false, false) // Struct
+      ImmutableList.of(true, false, false, false, false, false, false, false, false), // Boolean
+      ImmutableList.of(false, true, true, true, true, false, false, false, false), // Int
+      ImmutableList.of(false, true, true, true, true, false, false, false, false), // BigInt
+      ImmutableList.of(false, true, true, true, true, false, false, false, false), // Double
+      ImmutableList.of(false, true, true, true, true, false, false, false, false),  // Decimal
+      ImmutableList.of(false, false, false, false, false, true, false, false, false),  // String
+      ImmutableList.of(false, false, false, false, false, false, false, false, false), // Array
+      ImmutableList.of(false, false, false, false, false, false, false, false, false), // Map
+      ImmutableList.of(false, false, false, false, false, false, false, false, false) // Struct
   );
 
   @Rule
@@ -51,8 +61,8 @@ public class ComparisonUtilTest {
     // When:
     int i = 0;
     int j = 0;
-    for (final Schema.Type leftType: typesTable) {
-      for (final Schema.Type rightType: typesTable) {
+    for (final Schema leftType: typesTable) {
+      for (final Schema rightType: typesTable) {
         if (expectedResults.get(i).get(j)) {
           assertThat(
               ComparisonUtil.isValidComparison(leftType, ComparisonExpression.Type.EQUAL, rightType)
@@ -74,8 +84,8 @@ public class ComparisonUtilTest {
     // When:
     int i = 0;
     int j = 0;
-    for (final Schema.Type leftType: typesTable) {
-      for (final Schema.Type rightType: typesTable) {
+    for (final Schema leftType: typesTable) {
+      for (final Schema rightType: typesTable) {
         if (!expectedResults.get(i).get(j)) {
           ComparisonUtil.isValidComparison(leftType, ComparisonExpression.Type.EQUAL, rightType);
         }

--- a/ksql-engine/src/test/java/io/confluent/ksql/util/ExpressionTypeManagerTest.java
+++ b/ksql-engine/src/test/java/io/confluent/ksql/util/ExpressionTypeManagerTest.java
@@ -94,7 +94,7 @@ public class ExpressionTypeManagerTest {
     final String simpleQuery = "SELECT col1 > 10 FROM test1;";
     final Analysis analysis = analyzeQuery(simpleQuery, metaStore);
     expectedException.expect(KsqlException.class);
-    expectedException.expectMessage("Operator GREATER_THAN cannot be used to compare STRING and INT32");
+    expectedException.expectMessage("Operator GREATER_THAN cannot be used to compare STRING and INTEGER");
 
     // When:
     expressionTypeManager.getExpressionSchema(analysis.getSelectExpressions().get(0));

--- a/ksql-functional-tests/src/test/resources/query-validation-tests/decimal.json
+++ b/ksql-functional-tests/src/test/resources/query-validation-tests/decimal.json
@@ -145,6 +145,183 @@
         {"topic": "TEST2", "key": 0, "value": {"RESULT": "0.10"}},
         {"topic": "TEST2", "key": 0, "value": {"RESULT": null}}
       ]
+    },
+    {
+      "name": "equal - decimal decimal",
+      "statements": [
+        "CREATE STREAM TEST (a DECIMAL(4,2), b DECIMAL(4,2)) WITH (kafka_topic='test', value_format='AVRO');",
+        "CREATE STREAM TEST2 AS SELECT (a = b) AS RESULT FROM TEST;"
+      ],
+      "inputs": [
+        {"topic": "test", "key": 0, "value": {"A": "10.01", "B":  "10.01"}},
+        {"topic": "test", "key": 0, "value": {"A": "10.01", "B":  "12.01"}},
+        {"topic": "test", "key": 0, "value": {"A": null, "B":  "10.01"}},
+        {"topic": "test", "key": 0, "value": {"A": null, "B":  null}}
+      ],
+      "outputs": [
+        {"topic": "TEST2", "key": 0, "value": {"RESULT": true}},
+        {"topic": "TEST2", "key": 0, "value": {"RESULT": false}},
+        {"topic": "TEST2", "key": 0, "value": {"RESULT": false}},
+        {"topic": "TEST2", "key": 0, "value": {"RESULT": false}}
+      ]
+    },
+    {
+      "name": "not equal - decimal decimal",
+      "statements": [
+        "CREATE STREAM TEST (a DECIMAL(4,2), b DECIMAL(4,2)) WITH (kafka_topic='test', value_format='AVRO');",
+        "CREATE STREAM TEST2 AS SELECT (a <> b) AS RESULT FROM TEST;"
+      ],
+      "inputs": [
+        {"topic": "test", "key": 0, "value": {"A": "10.01", "B":  "10.01"}},
+        {"topic": "test", "key": 0, "value": {"A": "10.01", "B":  "12.01"}},
+        {"topic": "test", "key": 0, "value": {"A": null, "B":  "10.01"}},
+        {"topic": "test", "key": 0, "value": {"A": null, "B":  null}}
+      ],
+      "outputs": [
+        {"topic": "TEST2", "key": 0, "value": {"RESULT": false}},
+        {"topic": "TEST2", "key": 0, "value": {"RESULT": true}},
+        {"topic": "TEST2", "key": 0, "value": {"RESULT": false}},
+        {"topic": "TEST2", "key": 0, "value": {"RESULT": false}}
+      ]
+    },
+    {
+      "name": "is distinct - decimal decimal",
+      "statements": [
+        "CREATE STREAM TEST (a DECIMAL(4,2), b DECIMAL(4,2)) WITH (kafka_topic='test', value_format='AVRO');",
+        "CREATE STREAM TEST2 AS SELECT (a IS DISTINCT FROM b) AS RESULT FROM TEST;"
+      ],
+      "inputs": [
+        {"topic": "test", "key": 0, "value": {"A": "10.01", "B":  "10.01"}},
+        {"topic": "test", "key": 0, "value": {"A": "10.01", "B":  "12.01"}},
+        {"topic": "test", "key": 0, "value": {"A": null, "B":  "10.01"}},
+        {"topic": "test", "key": 0, "value": {"A": null, "B":  null}}
+      ],
+      "outputs": [
+        {"topic": "TEST2", "key": 0, "value": {"RESULT": false}},
+        {"topic": "TEST2", "key": 0, "value": {"RESULT": true}},
+        {"topic": "TEST2", "key": 0, "value": {"RESULT": true}},
+        {"topic": "TEST2", "key": 0, "value": {"RESULT": false}}
+      ]
+    },
+    {
+      "name": "less than - decimal decimal",
+      "statements": [
+        "CREATE STREAM TEST (a DECIMAL(4,2), b DECIMAL(4,2)) WITH (kafka_topic='test', value_format='AVRO');",
+        "CREATE STREAM TEST2 AS SELECT (a < b) AS RESULT FROM TEST;"
+      ],
+      "inputs": [
+        {"topic": "test", "key": 0, "value": {"A": "10.01", "B":  "10.01"}},
+        {"topic": "test", "key": 0, "value": {"A": "10.01", "B":  "12.01"}},
+        {"topic": "test", "key": 0, "value": {"A": null, "B":  "10.01"}},
+        {"topic": "test", "key": 0, "value": {"A": null, "B":  null}}
+      ],
+      "outputs": [
+        {"topic": "TEST2", "key": 0, "value": {"RESULT": false}},
+        {"topic": "TEST2", "key": 0, "value": {"RESULT": true}},
+        {"topic": "TEST2", "key": 0, "value": {"RESULT": false}},
+        {"topic": "TEST2", "key": 0, "value": {"RESULT": false}}
+      ]
+    },
+    {
+      "name": "less than - decimal decimal differing scale",
+      "statements": [
+        "CREATE STREAM TEST (a DECIMAL(4,2), b DECIMAL(5,3)) WITH (kafka_topic='test', value_format='AVRO');",
+        "CREATE STREAM TEST2 AS SELECT (a < b) AS RESULT FROM TEST;"
+      ],
+      "inputs": [
+        {"topic": "test", "key": 0, "value": {"A": "10.01", "B":  "10.010"}},
+        {"topic": "test", "key": 0, "value": {"A": "10.01", "B":  "10.012"}},
+        {"topic": "test", "key": 0, "value": {"A": null, "B":  "10.010"}},
+        {"topic": "test", "key": 0, "value": {"A": null, "B":  null}}
+      ],
+      "outputs": [
+        {"topic": "TEST2", "key": 0, "value": {"RESULT": false}},
+        {"topic": "TEST2", "key": 0, "value": {"RESULT": true}},
+        {"topic": "TEST2", "key": 0, "value": {"RESULT": false}},
+        {"topic": "TEST2", "key": 0, "value": {"RESULT": false}}
+      ]
+    },
+    {
+      "name": "LEQ - decimal decimal",
+      "statements": [
+        "CREATE STREAM TEST (a DECIMAL(4,2), b DECIMAL(4,2)) WITH (kafka_topic='test', value_format='AVRO');",
+        "CREATE STREAM TEST2 AS SELECT (a <= b) AS RESULT FROM TEST;"
+      ],
+      "inputs": [
+        {"topic": "test", "key": 0, "value": {"A": "10.01", "B":  "03.01"}},
+        {"topic": "test", "key": 0, "value": {"A": "10.01", "B":  "10.01"}},
+        {"topic": "test", "key": 0, "value": {"A": "10.01", "B":  "12.01"}},
+        {"topic": "test", "key": 0, "value": {"A": null, "B":  "10.01"}},
+        {"topic": "test", "key": 0, "value": {"A": null, "B":  null}}
+      ],
+      "outputs": [
+        {"topic": "TEST2", "key": 0, "value": {"RESULT": false}},
+        {"topic": "TEST2", "key": 0, "value": {"RESULT": true}},
+        {"topic": "TEST2", "key": 0, "value": {"RESULT": true}},
+        {"topic": "TEST2", "key": 0, "value": {"RESULT": false}},
+        {"topic": "TEST2", "key": 0, "value": {"RESULT": false}}
+      ]
+    },
+    {
+      "name": "GEQ - decimal decimal",
+      "statements": [
+        "CREATE STREAM TEST (a DECIMAL(4,2), b DECIMAL(4,2)) WITH (kafka_topic='test', value_format='AVRO');",
+        "CREATE STREAM TEST2 AS SELECT (a >= b) AS RESULT FROM TEST;"
+      ],
+      "inputs": [
+        {"topic": "test", "key": 0, "value": {"A": "10.01", "B":  "03.01"}},
+        {"topic": "test", "key": 0, "value": {"A": "10.01", "B":  "10.01"}},
+        {"topic": "test", "key": 0, "value": {"A": "10.01", "B":  "12.01"}},
+        {"topic": "test", "key": 0, "value": {"A": null, "B":  "10.01"}},
+        {"topic": "test", "key": 0, "value": {"A": null, "B":  null}}
+      ],
+      "outputs": [
+        {"topic": "TEST2", "key": 0, "value": {"RESULT": true}},
+        {"topic": "TEST2", "key": 0, "value": {"RESULT": true}},
+        {"topic": "TEST2", "key": 0, "value": {"RESULT": false}},
+        {"topic": "TEST2", "key": 0, "value": {"RESULT": false}},
+        {"topic": "TEST2", "key": 0, "value": {"RESULT": false}}
+      ]
+    },
+    {
+      "name": "greater than - decimal decimal",
+      "statements": [
+        "CREATE STREAM TEST (a DECIMAL(4,2), b DECIMAL(4,2)) WITH (kafka_topic='test', value_format='AVRO');",
+        "CREATE STREAM TEST2 AS SELECT (a >= b) AS RESULT FROM TEST;"
+      ],
+      "inputs": [
+        {"topic": "test", "key": 0, "value": {"A": "10.01", "B":  "03.01"}},
+        {"topic": "test", "key": 0, "value": {"A": "10.01", "B":  "10.01"}},
+        {"topic": "test", "key": 0, "value": {"A": "10.01", "B":  "12.01"}},
+        {"topic": "test", "key": 0, "value": {"A": null, "B":  "10.01"}},
+        {"topic": "test", "key": 0, "value": {"A": null, "B":  null}}
+      ],
+      "outputs": [
+        {"topic": "TEST2", "key": 0, "value": {"RESULT": true}},
+        {"topic": "TEST2", "key": 0, "value": {"RESULT": false}},
+        {"topic": "TEST2", "key": 0, "value": {"RESULT": false}},
+        {"topic": "TEST2", "key": 0, "value": {"RESULT": false}},
+        {"topic": "TEST2", "key": 0, "value": {"RESULT": false}}
+      ]
+    },
+    {
+      "name": "less than - decimal int",
+      "statements": [
+        "CREATE STREAM TEST (a DECIMAL(4,2), b INTEGER) WITH (kafka_topic='test', value_format='AVRO');",
+        "CREATE STREAM TEST2 AS SELECT (a < b) AS RESULT FROM TEST;"
+      ],
+      "inputs": [
+        {"topic": "test", "key": 0, "value": {"A": "10.01", "B":  1}},
+        {"topic": "test", "key": 0, "value": {"A": "10.01", "B":  12}},
+        {"topic": "test", "key": 0, "value": {"A": null, "B":  12}},
+        {"topic": "test", "key": 0, "value": {"A": null, "B":  null}}
+      ],
+      "outputs": [
+        {"topic": "TEST2", "key": 0, "value": {"RESULT": false}},
+        {"topic": "TEST2", "key": 0, "value": {"RESULT": true}},
+        {"topic": "TEST2", "key": 0, "value": {"RESULT": false}},
+        {"topic": "TEST2", "key": 0, "value": {"RESULT": false}}
+      ]
     }
   ]
 }

--- a/ksql-functional-tests/src/test/resources/query-validation-tests/decimal.json
+++ b/ksql-functional-tests/src/test/resources/query-validation-tests/decimal.json
@@ -287,7 +287,7 @@
       "name": "greater than - decimal decimal",
       "statements": [
         "CREATE STREAM TEST (a DECIMAL(4,2), b DECIMAL(4,2)) WITH (kafka_topic='test', value_format='AVRO');",
-        "CREATE STREAM TEST2 AS SELECT (a >= b) AS RESULT FROM TEST;"
+        "CREATE STREAM TEST2 AS SELECT (a > b) AS RESULT FROM TEST;"
       ],
       "inputs": [
         {"topic": "test", "key": 0, "value": {"A": "10.01", "B":  "03.01"}},


### PR DESCRIPTION
### Description 
Support comparisons (`<,<=,=,<>,>=,>` and `IS DISTINCT FROM`) between DECIMALs and other numeric types.

### Testing done 

- new QTT and unit tests

### Reviewer checklist
- [ ] Ensure docs are updated if necessary. (eg. if a user visible feature is being added or changed).
- [ ] Ensure relevant issues are linked (description should include text like "Fixes #<issue number>")

