### PR TITLE
Add extension for custom metrics

### DIFF
--- a/ksql-common/src/main/java/io/confluent/ksql/util/KsqlConfig.java
+++ b/ksql-common/src/main/java/io/confluent/ksql/util/KsqlConfig.java
@@ -149,6 +149,11 @@ public class KsqlConfig extends AbstractConfig {
       "A list of tags to be included with emitted JMX metrics, formatted as a string of key:value "
       + "pairs separated by commas. For example, 'key1:value1,key2:value2'.";
 
+  public static final String KSQL_CUSTOM_METRICS_EXTENSION = "ksql.metrics.extension";
+  private static final String KSQL_CUSTOM_METRICS_EXTENSION_DOC =
+      "Extension for supplying custom metrics to be emitted along with "
+      + "the engine's default JMX metrics";
+
   public static final String
       defaultSchemaRegistryUrl = "http://localhost:8081";
 
@@ -482,6 +487,12 @@ public class KsqlConfig extends AbstractConfig {
             "",
             ConfigDef.Importance.LOW,
             KSQL_CUSTOM_METRICS_TAGS_DOC
+        ).define(
+            KSQL_CUSTOM_METRICS_EXTENSION,
+            ConfigDef.Type.CLASS,
+            null,
+            ConfigDef.Importance.LOW,
+            KSQL_CUSTOM_METRICS_EXTENSION_DOC
         )
         .withClientSslSupport();
     for (final CompatibilityBreakingConfigDef compatibilityBreakingConfigDef

--- a/ksql-engine/src/main/java/io/confluent/ksql/ServiceInfo.java
+++ b/ksql-engine/src/main/java/io/confluent/ksql/ServiceInfo.java
@@ -15,14 +15,17 @@
 
 package io.confluent.ksql;
 
+import io.confluent.ksql.internal.KsqlMetricsExtension;
 import io.confluent.ksql.util.KsqlConfig;
 import java.util.Map;
 import java.util.Objects;
+import java.util.Optional;
 
 public final class ServiceInfo {
 
   private final String serviceId;
   private final Map<String, String> customMetricsTags;
+  private final Optional<KsqlMetricsExtension> metricsExtension;
 
   /**
    * Create an object to be passed from the KSQL context down to the KSQL engine.
@@ -33,16 +36,23 @@ public final class ServiceInfo {
     final String serviceId = ksqlConfig.getString(KsqlConfig.KSQL_SERVICE_ID_CONFIG);
     final Map<String, String> customMetricsTags =
         ksqlConfig.getStringAsMap(KsqlConfig.KSQL_CUSTOM_METRICS_TAGS);
+    final Optional<KsqlMetricsExtension> metricsExtension = Optional.ofNullable(
+        ksqlConfig.getConfiguredInstance(
+            KsqlConfig.KSQL_CUSTOM_METRICS_EXTENSION,
+            KsqlMetricsExtension.class
+        ));
 
-    return new ServiceInfo(serviceId, customMetricsTags);
+    return new ServiceInfo(serviceId, customMetricsTags, metricsExtension);
   }
 
   private ServiceInfo(
       final String serviceId,
-      final Map<String, String> customMetricsTags
+      final Map<String, String> customMetricsTags,
+      final Optional<KsqlMetricsExtension> metricsExtension
   ) {
     this.serviceId = Objects.requireNonNull(serviceId, "serviceId");
     this.customMetricsTags = Objects.requireNonNull(customMetricsTags, "customMetricsTags");
+    this.metricsExtension = Objects.requireNonNull(metricsExtension, "metricsExtension");
   }
 
   public String serviceId() {
@@ -51,5 +61,9 @@ public final class ServiceInfo {
 
   public Map<String, String> customMetricsTags() {
     return customMetricsTags;
+  }
+
+  public Optional<KsqlMetricsExtension> metricsExtension() {
+    return metricsExtension;
   }
 }

--- a/ksql-engine/src/main/java/io/confluent/ksql/engine/KsqlEngine.java
+++ b/ksql-engine/src/main/java/io/confluent/ksql/engine/KsqlEngine.java
@@ -74,7 +74,8 @@ public class KsqlEngine implements KsqlExecutionContext, Closeable {
         processingLogContext,
         serviceInfo.serviceId(),
         new MetaStoreImpl(functionRegistry),
-        (engine) -> new KsqlEngineMetrics(engine, serviceInfo.customMetricsTags()));
+        (engine) -> new KsqlEngineMetrics(
+            engine, serviceInfo.customMetricsTags(), serviceInfo.metricsExtension()));
   }
 
   KsqlEngine(

--- a/ksql-engine/src/main/java/io/confluent/ksql/internal/KsqlMetric.java
+++ b/ksql-engine/src/main/java/io/confluent/ksql/internal/KsqlMetric.java
@@ -1,10 +1,25 @@
+/*
+ * Copyright 2019 Confluent Inc.
+ *
+ * Licensed under the Confluent Community License (the "License"); you may not use
+ * this file except in compliance with the License.  You may obtain a copy of the
+ * License at
+ *
+ * http://www.confluent.io/confluent-community-license
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
 package io.confluent.ksql.internal;
 
 import java.util.Objects;
 import java.util.function.Supplier;
 import org.apache.kafka.common.metrics.MeasurableStat;
 
-public class KsqlMetric {
+public final class KsqlMetric {
   private String name;
   private String description;
   private Supplier<MeasurableStat> statSupplier;

--- a/ksql-engine/src/main/java/io/confluent/ksql/internal/KsqlMetric.java
+++ b/ksql-engine/src/main/java/io/confluent/ksql/internal/KsqlMetric.java
@@ -20,9 +20,9 @@ import java.util.function.Supplier;
 import org.apache.kafka.common.metrics.MeasurableStat;
 
 public final class KsqlMetric {
-  private String name;
-  private String description;
-  private Supplier<MeasurableStat> statSupplier;
+  private final String name;
+  private final String description;
+  private final Supplier<MeasurableStat> statSupplier;
 
   public static KsqlMetric of(
       final String name,

--- a/ksql-engine/src/main/java/io/confluent/ksql/internal/KsqlMetric.java
+++ b/ksql-engine/src/main/java/io/confluent/ksql/internal/KsqlMetric.java
@@ -1,0 +1,39 @@
+package io.confluent.ksql.internal;
+
+import java.util.Objects;
+import java.util.function.Supplier;
+import org.apache.kafka.common.metrics.MeasurableStat;
+
+public class KsqlMetric {
+  private String name;
+  private String description;
+  private Supplier<MeasurableStat> statSupplier;
+
+  public static KsqlMetric of(
+      final String name,
+      final String description,
+      final Supplier<MeasurableStat> statSupplier) {
+    return new KsqlMetric(name, description, statSupplier);
+  }
+
+  private KsqlMetric(
+      final String name,
+      final String description,
+      final Supplier<MeasurableStat> statSupplier) {
+    this.name = Objects.requireNonNull(name, "name cannot be null");
+    this.description = Objects.requireNonNull(description, "description cannot be null");
+    this.statSupplier = Objects.requireNonNull(statSupplier, "statSupplier cannot be null");
+  }
+
+  public String name() {
+    return name;
+  }
+
+  public String description() {
+    return description;
+  }
+
+  public Supplier<MeasurableStat> statSupplier() {
+    return statSupplier;
+  }
+}

--- a/ksql-engine/src/main/java/io/confluent/ksql/internal/KsqlMetricsExtension.java
+++ b/ksql-engine/src/main/java/io/confluent/ksql/internal/KsqlMetricsExtension.java
@@ -17,10 +17,7 @@ package io.confluent.ksql.internal;
 
 import java.util.List;
 import java.util.Map;
-import java.util.Objects;
-import java.util.function.Supplier;
 import org.apache.kafka.common.Configurable;
-import org.apache.kafka.common.metrics.MeasurableStat;
 
 /**
  * This interface provides a way for users to provide custom metrics that will be emitted alongside
@@ -36,32 +33,5 @@ public interface KsqlMetricsExtension extends Configurable {
    *
    * @return list of metrics
    */
-  List<Metric> getCustomMetrics();
-
-  class Metric {
-    private String name;
-    private String description;
-    private Supplier<MeasurableStat> statSupplier;
-
-    public Metric(
-        final String name,
-        final String description,
-        final Supplier<MeasurableStat> statSupplier) {
-      this.name = Objects.requireNonNull(name, "name cannot be null");
-      this.description = Objects.requireNonNull(description, "description cannot be null");
-      this.statSupplier = Objects.requireNonNull(statSupplier, "statSupplier cannot be null");
-    }
-
-    public String name() {
-      return name;
-    }
-
-    public String description() {
-      return description;
-    }
-
-    public Supplier<MeasurableStat> statSupplier() {
-      return statSupplier;
-    }
-  }
+  List<KsqlMetric> getCustomMetrics();
 }

--- a/ksql-engine/src/main/java/io/confluent/ksql/internal/KsqlMetricsExtension.java
+++ b/ksql-engine/src/main/java/io/confluent/ksql/internal/KsqlMetricsExtension.java
@@ -1,0 +1,67 @@
+/*
+ * Copyright 2019 Confluent Inc.
+ *
+ * Licensed under the Confluent Community License (the "License"); you may not use
+ * this file except in compliance with the License.  You may obtain a copy of the
+ * License at
+ *
+ * http://www.confluent.io/confluent-community-license
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package io.confluent.ksql.internal;
+
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.function.Supplier;
+import org.apache.kafka.common.Configurable;
+import org.apache.kafka.common.metrics.MeasurableStat;
+
+/**
+ * This interface provides a way for users to provide custom metrics that will be emitted alongside
+ * the default KSQL engine JMX metrics.
+ */
+public interface KsqlMetricsExtension extends Configurable {
+
+  @Override
+  void configure(Map<String, ?> config);
+
+  /**
+   * Returns custom metrics to be emitted alongside the default KSQL engine JMX metrics.
+   *
+   * @return list of metrics
+   */
+  List<Metric> getCustomMetrics();
+
+  class Metric {
+    private String name;
+    private String description;
+    private Supplier<MeasurableStat> statSupplier;
+
+    public Metric(
+        final String name,
+        final String description,
+        final Supplier<MeasurableStat> statSupplier) {
+      this.name = Objects.requireNonNull(name, "name cannot be null");
+      this.description = Objects.requireNonNull(description, "description cannot be null");
+      this.statSupplier = Objects.requireNonNull(statSupplier, "statSupplier cannot be null");
+    }
+
+    public String name() {
+      return name;
+    }
+
+    public String description() {
+      return description;
+    }
+
+    public Supplier<MeasurableStat> statSupplier() {
+      return statSupplier;
+    }
+  }
+}

--- a/ksql-engine/src/test/java/io/confluent/ksql/engine/KsqlEngineTestUtil.java
+++ b/ksql-engine/src/test/java/io/confluent/ksql/engine/KsqlEngineTestUtil.java
@@ -50,7 +50,7 @@ public final class KsqlEngineTestUtil {
         ProcessingLogContext.create(),
         "test_instance_",
         metaStore,
-        (engine) -> new KsqlEngineMetrics(engine, Collections.emptyMap())
+        (engine) -> new KsqlEngineMetrics(engine, Collections.emptyMap(), Optional.empty())
     );
   }
 

--- a/ksql-engine/src/test/java/io/confluent/ksql/internal/KsqlEngineMetricsTest.java
+++ b/ksql-engine/src/test/java/io/confluent/ksql/internal/KsqlEngineMetricsTest.java
@@ -25,6 +25,7 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
+import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import io.confluent.ksql.engine.KsqlEngine;
 import io.confluent.ksql.metrics.ConsumerCollector;
@@ -37,12 +38,16 @@ import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
+import java.util.function.Supplier;
 import org.apache.kafka.clients.consumer.ConsumerConfig;
 import org.apache.kafka.clients.consumer.ConsumerRecord;
 import org.apache.kafka.clients.consumer.ConsumerRecords;
 import org.apache.kafka.clients.producer.ProducerConfig;
 import org.apache.kafka.clients.producer.ProducerRecord;
 import org.apache.kafka.common.TopicPartition;
+import org.apache.kafka.common.metrics.MeasurableStat;
+import org.apache.kafka.common.metrics.MetricConfig;
 import org.apache.kafka.common.metrics.Metrics;
 import org.apache.kafka.common.record.TimestampType;
 import org.apache.kafka.streams.KafkaStreams;
@@ -75,7 +80,12 @@ public class KsqlEngineMetricsTest {
     when(ksqlEngine.getServiceId()).thenReturn(KSQL_SERVICE_ID);
     when(query1.getQueryApplicationId()).thenReturn("app-1");
 
-    engineMetrics = new KsqlEngineMetrics(METRIC_GROUP, ksqlEngine, MetricCollectors.getMetrics(), CUSTOM_TAGS);
+    engineMetrics = new KsqlEngineMetrics(
+        METRIC_GROUP,
+        ksqlEngine,
+        MetricCollectors.getMetrics(),
+        CUSTOM_TAGS,
+        Optional.of(new TestKsqlMetricsExtension()));
   }
 
   @After
@@ -251,6 +261,15 @@ public class KsqlEngineMetricsTest {
   }
 
   @Test
+  public void shouldRecordCustomMetric() {
+    final double value = getMetricValue("my-custom-metric");
+    final double legacyValue = getMetricValueLegacy("my-custom-metric");
+
+    assertThat(value, equalTo(123.0));
+    assertThat(legacyValue, equalTo(123.0));
+  }
+
+  @Test
   public void shouldRegisterQueries() {
     // When:
     engineMetrics.registerQuery(query1);
@@ -334,5 +353,31 @@ public class KsqlEngineMetricsTest {
       }
       return queryMetadataList;
     };
+  }
+
+  private static class TestKsqlMetricsExtension implements KsqlMetricsExtension {
+
+    @Override
+    public void configure(Map<String, ?> config) {
+    }
+
+    @Override
+    public List<Metric> getCustomMetrics() {
+      final String name = "my-custom-metric";
+      final String description = "";
+      final Supplier<MeasurableStat> statSupplier =
+          () -> new MeasurableStat() {
+            @Override
+            public double measure(final MetricConfig metricConfig, final long l) {
+              return 123;
+            }
+
+            @Override
+            public void record(final MetricConfig metricConfig, final double v, final long l) {
+              // Nothing to record
+            }
+          };
+      return ImmutableList.of(new Metric(name, description, statSupplier));
+    }
   }
 }

--- a/ksql-engine/src/test/java/io/confluent/ksql/internal/KsqlEngineMetricsTest.java
+++ b/ksql-engine/src/test/java/io/confluent/ksql/internal/KsqlEngineMetricsTest.java
@@ -362,7 +362,7 @@ public class KsqlEngineMetricsTest {
     }
 
     @Override
-    public List<Metric> getCustomMetrics() {
+    public List<KsqlMetric> getCustomMetrics() {
       final String name = "my-custom-metric";
       final String description = "";
       final Supplier<MeasurableStat> statSupplier =
@@ -377,7 +377,7 @@ public class KsqlEngineMetricsTest {
               // Nothing to record
             }
           };
-      return ImmutableList.of(new Metric(name, description, statSupplier));
+      return ImmutableList.of(KsqlMetric.of(name, description, statSupplier));
     }
   }
 }


### PR DESCRIPTION
### Description 

Introduces a new interface `KsqlMetricsExtension` for users to specify custom metrics to be emitted alongside the default engine JMX metrics. Users may point the `ksql.metrics.extension` config at their custom implementation in order to emit custom metrics.

### Testing done 

Manual + unit tests.

### Reviewer checklist
- [ ] Ensure docs are updated if necessary. (eg. if a user visible feature is being added or changed).
- [ ] Ensure relevant issues are linked (description should include text like "Fixes #<issue number>")

