### PR TITLE
Add confluent-security to classpath to enable security plugins

### DIFF
--- a/bin/ksql-run-class
+++ b/bin/ksql-run-class
@@ -35,7 +35,7 @@ for project in ksql-engine ksql-examples ksql-rest-app ksql-cli ksql-functional-
 done
 
 # Production jars - each one is prepended so they will appear in reverse order.  KSQL jars take precedence over other stuff passed in via CLASSPATH env var
-for library in "confluent-common" "ksql-examples" "rest-utils" "ksql-engine" "ksql-rest-app" "ksql-cli" "ksql-functional-tests" "ksql" "monitoring-interceptors"; do
+for library in "confluent-common" "ksql-examples" "rest-utils" "ksql-engine" "ksql-rest-app" "ksql-cli" "ksql-functional-tests" "ksql" "monitoring-interceptors" "confluent-security/ksql"; do
   DIR="$base_dir/share/java/$library"
   if [ -d "$DIR" ]; then
     KSQL_CLASSPATH="$DIR/*:$KSQL_CLASSPATH"


### PR DESCRIPTION
Allow security plugins path to the start of the classpath to ensure that plugins and their dependencies take precedence.