### PR TITLE
Add explicit kafka core dependency for support metrics

### DIFF
--- a/ksql-engine/pom.xml
+++ b/ksql-engine/pom.xml
@@ -36,6 +36,14 @@
             <groupId>io.confluent.support</groupId>
             <artifactId>support-metrics-common</artifactId>
         </dependency>
+
+        <!-- We use `BaseMetricsReporter` in support-metrics-common that depends on classes from the
+        kafka core jar. We can remove this once `BaseMetricsReporter` is fixed not to do that. -->
+        <dependency>
+            <groupId>org.apache.kafka</groupId>
+            <artifactId>kafka_${kafka.scala.version}</artifactId>
+        </dependency>
+
         <dependency>
             <groupId>io.confluent.ksql</groupId>
             <artifactId>ksql-serde</artifactId>

--- a/ksql-version-metrics-client/pom.xml
+++ b/ksql-version-metrics-client/pom.xml
@@ -34,6 +34,13 @@
             <artifactId>support-metrics-common</artifactId>
         </dependency>
 
+        <!-- We use `BaseMetricsReporter` in support-metrics-common that depends on classes from the
+        kafka core jar. We can remove this once `BaseMetricsReporter` is fixed not to do that. -->
+        <dependency>
+            <groupId>org.apache.kafka</groupId>
+            <artifactId>kafka_${kafka.scala.version}</artifactId>
+        </dependency>
+
         <dependency>
             <groupId>io.confluent.ksql</groupId>
             <artifactId>ksql-common</artifactId>


### PR DESCRIPTION
### Description 
Fix ksql packaging by adding explicit kafka core jar. The error seen is:

> Exception in thread "main" java.lang.NoClassDefFoundError: kafka/admin/AdminOperationException
>     at io.confluent.ksql.version.metrics.KsqlVersionChecker.<init>(KsqlVersionChecker.java:41)
>     at io.confluent.ksql.version.metrics.KsqlVersionCheckerAgent.start(KsqlVersionCheckerAgent.java:76)
>     at io.confluent.ksql.rest.server.KsqlRestApplication.start(KsqlRestApplication.java:207)
>     at io.confluent.ksql.rest.server.KsqlServerMain.tryStartApp(KsqlServerMain.java:65)

This is as a result of https://github.com/confluentinc/kafka/commit/72ff0d2bba.

### Testing done 
Manual verification.

### Reviewer checklist
- [ ] Ensure docs are updated if necessary. (eg. if a user visible feature is being added or changed).
- [ ] Ensure relevant issues are linked (description should include text like "Fixes #<issue number>")

