### PR TITLE
decimal math with other numbers

### DIFF
--- a/ksql-common/src/main/java/io/confluent/ksql/util/DecimalUtil.java
+++ b/ksql-common/src/main/java/io/confluent/ksql/util/DecimalUtil.java
@@ -153,6 +153,28 @@ public final class DecimalUtil {
     }
   }
 
+  /**
+   * Converts a schema to a decimal schema with set precision/scale without losing
+   * scale or precision.
+   *
+   * @param schema the schema
+   * @return the decimal schema
+   * @throws KsqlException if the schema cannot safely be converted to decimal
+   */
+  public static Schema toDecimal(final Schema schema) {
+    switch (schema.type()) {
+      case BYTES:
+        requireDecimal(schema);
+        return schema;
+      case INT32:
+        return builder(10, 0).build();
+      case INT64:
+        return builder(19, 0).build();
+      default:
+        throw new KsqlException("Cannot convert schema of type " + schema.type() + " to decimal.");
+    }
+  }
+
   public static BigDecimal cast(final long value, final int precision, final int scale) {
     validateParameters(precision, scale);
     final BigDecimal decimal = new BigDecimal(value, new MathContext(precision));

--- a/ksql-common/src/main/java/io/confluent/ksql/util/SchemaUtil.java
+++ b/ksql-common/src/main/java/io/confluent/ksql/util/SchemaUtil.java
@@ -286,8 +286,12 @@ public final class SchemaUtil {
       return Schema.OPTIONAL_STRING_SCHEMA;
     }
 
-    if (DecimalUtil.isDecimal(left) && DecimalUtil.isDecimal(right)) {
-      return resolveDecimalOperatorResultType(left, right, operator);
+    if (DecimalUtil.isDecimal(left) || DecimalUtil.isDecimal(right)) {
+      if (left.type() != Schema.Type.FLOAT64 && right.type() != Schema.Type.FLOAT64) {
+        return resolveDecimalOperatorResultType(
+            DecimalUtil.toDecimal(left), DecimalUtil.toDecimal(right), operator);
+      }
+      return Schema.OPTIONAL_FLOAT64_SCHEMA;
     }
 
     if (!TYPE_TO_SCHEMA.containsKey(left.type()) || !TYPE_TO_SCHEMA.containsKey(right.type())) {

--- a/ksql-common/src/test/java/io/confluent/ksql/util/DecimalUtilTest.java
+++ b/ksql-common/src/test/java/io/confluent/ksql/util/DecimalUtilTest.java
@@ -23,6 +23,7 @@ import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import java.math.BigDecimal;
 import org.apache.kafka.connect.data.Decimal;
 import org.apache.kafka.connect.data.Schema;
+import org.hamcrest.Matchers;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ExpectedException;
@@ -233,6 +234,46 @@ public class DecimalUtilTest {
 
     // Then:
     assertThat(decimal, is(new BigDecimal("1.2")));
+  }
+
+  @Test
+  public void shouldConvertInteger() {
+    // When:
+    final Schema decimal = DecimalUtil.toDecimal(Schema.OPTIONAL_INT32_SCHEMA);
+
+    // Then:
+    assertThat(decimal, Matchers.is(DecimalUtil.builder(10, 0).build()));
+  }
+
+  @Test
+  public void shouldConvertLong() {
+    // When:
+    final Schema decimal = DecimalUtil.toDecimal(Schema.OPTIONAL_INT64_SCHEMA);
+
+    // Then:
+    assertThat(decimal, Matchers.is(DecimalUtil.builder(19, 0).build()));
+  }
+
+  @Test
+  public void shouldConvertDecimal() {
+    // Given:
+    final Schema given = DecimalUtil.builder(2, 2);
+
+    // When:
+    final Schema decimal = DecimalUtil.toDecimal(given);
+
+    // Then:
+    assertThat(decimal, sameInstance(given));
+  }
+
+  @Test
+  public void shouldThrowIfConvertString() {
+    // Expect:
+    expectedException.expect(KsqlException.class);
+    expectedException.expectMessage("Cannot convert schema of type STRING to decimal");
+
+    // When:
+    DecimalUtil.toDecimal(Schema.OPTIONAL_STRING_SCHEMA);
   }
 
   @Test

--- a/ksql-common/src/test/java/io/confluent/ksql/util/SchemaUtilTest.java
+++ b/ksql-common/src/test/java/io/confluent/ksql/util/SchemaUtilTest.java
@@ -691,6 +691,42 @@ public class SchemaUtilTest {
     });
   }
 
+  @Test
+  public void shouldResolveDecimalLongAdd() {
+    final Map<PrecisionScale, PrecisionScale> inputToExpected =
+        ImmutableMap.<PrecisionScale, PrecisionScale>builder()
+            .put(PrecisionScale.of(2, 1), PrecisionScale.of(21, 1))
+            .put(PrecisionScale.of(3, 3), PrecisionScale.of(23, 3))
+            .put(PrecisionScale.of(23, 0), PrecisionScale.of(24, 0))
+            .build();
+
+    inputToExpected.forEach((in, out) -> {
+      // Given:
+      final Schema d1 = DecimalUtil.builder(in.precision, in.scale).build();
+      final Schema d2 = Schema.OPTIONAL_INT64_SCHEMA;
+
+      // When:
+      final Schema result = SchemaUtil.resolveBinaryOperatorResultType(d1, d2, Operator.ADD);
+
+      // Then:
+      assertThat(String.format("precision: %s", in), DecimalUtil.precision(result), is(out.precision));
+      assertThat(String.format("scale: %s", in), DecimalUtil.scale(result), is(out.scale));
+    });
+  }
+
+  @Test
+  public void shouldResolveDecimalDoubleMath() {
+    // Given:
+    final Schema d1 = DecimalUtil.builder(15, 10).build();
+    final Schema d2 = Schema.OPTIONAL_FLOAT64_SCHEMA;
+
+    // When:
+    final Schema result = SchemaUtil.resolveBinaryOperatorResultType(d1, d2, Operator.ADD);
+
+    // Then:
+    assertThat(result, is(Schema.OPTIONAL_FLOAT64_SCHEMA));
+  }
+
   private static class PrecisionScale {
     final int precision;
     final int scale;

--- a/ksql-engine/src/main/java/io/confluent/ksql/codegen/SqlToJavaVisitor.java
+++ b/ksql-engine/src/main/java/io/confluent/ksql/codegen/SqlToJavaVisitor.java
@@ -47,6 +47,7 @@ import io.confluent.ksql.parser.tree.LongLiteral;
 import io.confluent.ksql.parser.tree.Node;
 import io.confluent.ksql.parser.tree.NotExpression;
 import io.confluent.ksql.parser.tree.NullLiteral;
+import io.confluent.ksql.parser.tree.PrimitiveType;
 import io.confluent.ksql.parser.tree.QualifiedName;
 import io.confluent.ksql.parser.tree.QualifiedNameReference;
 import io.confluent.ksql.parser.tree.SearchedCaseExpression;
@@ -502,23 +503,39 @@ public class SqlToJavaVisitor {
               left.getRight(), right.getRight(), node.getOperator());
 
       if (DecimalUtil.isDecimal(schema)) {
+        final String leftExpr = CastVisitor.getCast(
+            left,
+            Decimal.of(DecimalUtil.toDecimal(left.right))).getLeft();
+        final String rightExpr = CastVisitor.getCast(
+            right,
+            Decimal.of(DecimalUtil.toDecimal(right.right))).getLeft();
+
         return new Pair<>(
             String.format(
                 "(%s.%s(%s, new MathContext(%d, RoundingMode.UNNECESSARY)).setScale(%d))",
-                left.getLeft(),
+                leftExpr,
                 DECIMAL_OPERATOR_NAME.get(node.getOperator()),
-                right.getLeft(),
+                rightExpr,
                 DecimalUtil.precision(schema),
                 DecimalUtil.scale(schema)),
             schema
         );
       } else {
+        final String leftExpr =
+            DecimalUtil.isDecimal(left.getRight())
+                ? CastVisitor.getCast(left, PrimitiveType.of(SqlType.DOUBLE)).getLeft()
+                : left.getLeft();
+        final String rightExpr =
+            DecimalUtil.isDecimal(right.getRight())
+                ? CastVisitor.getCast(right, PrimitiveType.of(SqlType.DOUBLE)).getLeft()
+                : right.getLeft();
+
         return new Pair<>(
             String.format(
                 "(%s %s %s)",
-                left.getLeft(),
+                leftExpr,
                 node.getOperator().getSymbol(),
-                right.getLeft()),
+                rightExpr),
             schema
         );
       }
@@ -824,6 +841,10 @@ public class SqlToJavaVisitor {
         final Schema returnType) {
       if (!(type instanceof Decimal)) {
         throw new KsqlException("Expected decimal type: " + type);
+      }
+
+      if (DecimalUtil.isDecimal(expr.right) && Decimal.of(expr.right).equals(type)) {
+        return expr;
       }
 
       return new Pair<>(

--- a/ksql-engine/src/test/java/io/confluent/ksql/codegen/SqlToJavaVisitorTest.java
+++ b/ksql-engine/src/test/java/io/confluent/ksql/codegen/SqlToJavaVisitorTest.java
@@ -278,6 +278,38 @@ public class SqlToJavaVisitorTest {
   }
 
   @Test
+  public void shouldGenerateCastLongToDecimalInBinaryExpression() {
+    // Given:
+    final ArithmeticBinaryExpression binExp = new ArithmeticBinaryExpression(
+        Operator.ADD,
+        new QualifiedNameReference(QualifiedName.of("TEST1.COL8")),
+        new QualifiedNameReference(QualifiedName.of("TEST1.COL0"))
+    );
+
+    // When:
+    final String java = sqlToJavaVisitor.process(binExp);
+
+    // Then:
+    assertThat(java, containsString("DecimalUtil.cast(TEST1_COL0, 19, 0)"));
+  }
+
+  @Test
+  public void shouldGenerateCastDecimalToDoubleInBinaryExpression() {
+    // Given:
+    final ArithmeticBinaryExpression binExp = new ArithmeticBinaryExpression(
+        Operator.ADD,
+        new QualifiedNameReference(QualifiedName.of("TEST1.COL8")),
+        new QualifiedNameReference(QualifiedName.of("TEST1.COL3"))
+    );
+
+    // When:
+    final String java = sqlToJavaVisitor.process(binExp);
+
+    // Then:
+    assertThat(java, containsString("(TEST1_COL8).doubleValue()"));
+  }
+
+  @Test
   public void shouldGenerateCorrectCodeForDecimalSubtract() {
     // Given:
     final ArithmeticBinaryExpression binExp = new ArithmeticBinaryExpression(
@@ -513,6 +545,21 @@ public class SqlToJavaVisitorTest {
 
     // Then:
     assertThat(java, is("(DecimalUtil.cast(TEST1_COL3, 2, 1))"));
+  }
+
+  @Test
+  public void shouldGenerateCorrectCodeForDecimalCastNoOp() {
+    // Given:
+    final Cast cast = new Cast(
+        new QualifiedNameReference(QualifiedName.of("TEST1.COL8")),
+        Decimal.of(2, 1)
+    );
+
+    // When:
+    final String java = sqlToJavaVisitor.process(cast);
+
+    // Then:
+    assertThat(java, is("TEST1_COL8"));
   }
 
   @Test

--- a/ksql-functional-tests/src/test/resources/query-validation-tests/decimal.json
+++ b/ksql-functional-tests/src/test/resources/query-validation-tests/decimal.json
@@ -74,6 +74,40 @@
       ]
     },
     {
+      "name": "addition with double",
+      "statements": [
+        "CREATE STREAM TEST (a DECIMAL(4,2), b DOUBLE) WITH (kafka_topic='test', value_format='AVRO');",
+        "CREATE STREAM TEST2 AS SELECT (a + b) AS RESULT FROM TEST;"
+      ],
+      "inputs": [
+        {"topic": "test", "key": 0, "value": {"A": "10.01", "B":  5.1}},
+        {"topic": "test", "key": 0, "value": {"A": "10.01", "B":  -5.0}},
+        {"topic": "test", "key": 0, "value": {"A": "10.01", "B":  0.0}}
+      ],
+      "outputs": [
+        {"topic": "TEST2", "key": 0, "value": {"RESULT": 15.11}},
+        {"topic": "TEST2", "key": 0, "value": {"RESULT": 5.01}},
+        {"topic": "TEST2", "key": 0, "value": {"RESULT": 10.01}}
+      ]
+    },
+    {
+      "name": "addition with int",
+      "statements": [
+        "CREATE STREAM TEST (a DECIMAL(4,2), b INT) WITH (kafka_topic='test', value_format='AVRO');",
+        "CREATE STREAM TEST2 AS SELECT (a + b) AS RESULT FROM TEST;"
+      ],
+      "inputs": [
+        {"topic": "test", "key": 0, "value": {"A": "10.01", "B": 5}},
+        {"topic": "test", "key": 0, "value": {"A": "10.01", "B": -5}},
+        {"topic": "test", "key": 0, "value": {"A": "10.01", "B": 0}}
+      ],
+      "outputs": [
+        {"topic": "TEST2", "key": 0, "value": {"RESULT": "15.01"}},
+        {"topic": "TEST2", "key": 0, "value": {"RESULT": "5.01"}},
+        {"topic": "TEST2", "key": 0, "value": {"RESULT": "10.01"}}
+      ]
+    },
+    {
       "name": "addition 3 columns",
       "statements": [
         "CREATE STREAM TEST (a DECIMAL(4,2), b DECIMAL(4,2)) WITH (kafka_topic='test', value_format='AVRO');",


### PR DESCRIPTION
### Description 

Supports math between decimals and other numbers. The implicit conversions follow Postgres:

- Decimal/Int math will convert Int to Decimal(10, 0) and then follow the decimal math conversions
- Decimal/Long math will convert Long to Decimal(19, 0) and then follow the decimal math conversions
- Decimal/Double math will convert the decimal to a floating point and then use floating point math rules

All of these operations leverage the previous casting work, this PR just introduces the constant conversions from Int/Long to decimal.

### Testing done 

- Unit testing
- QTT

### Reviewer checklist
- [ ] Ensure docs are updated if necessary. (eg. if a user visible feature is being added or changed).
- [ ] Ensure relevant issues are linked (description should include text like "Fixes #<issue number>")

