### PR TITLE
Remove core dependency added for support metrics workaround

### DIFF
--- a/ksql-engine/pom.xml
+++ b/ksql-engine/pom.xml
@@ -36,14 +36,6 @@
             <groupId>io.confluent.support</groupId>
             <artifactId>support-metrics-common</artifactId>
         </dependency>
-
-        <!-- We use `BaseMetricsReporter` in support-metrics-common that depends on classes from the
-        kafka core jar. We can remove this once `BaseMetricsReporter` is fixed not to do that. -->
-        <dependency>
-            <groupId>org.apache.kafka</groupId>
-            <artifactId>kafka_${kafka.scala.version}</artifactId>
-        </dependency>
-
         <dependency>
             <groupId>io.confluent.ksql</groupId>
             <artifactId>ksql-serde</artifactId>

--- a/ksql-version-metrics-client/pom.xml
+++ b/ksql-version-metrics-client/pom.xml
@@ -34,13 +34,6 @@
             <artifactId>support-metrics-common</artifactId>
         </dependency>
 
-        <!-- We use `BaseMetricsReporter` in support-metrics-common that depends on classes from the
-        kafka core jar. We can remove this once `BaseMetricsReporter` is fixed not to do that. -->
-        <dependency>
-            <groupId>org.apache.kafka</groupId>
-            <artifactId>kafka_${kafka.scala.version}</artifactId>
-        </dependency>
-
         <dependency>
             <groupId>io.confluent.ksql</groupId>
             <artifactId>ksql-common</artifactId>

--- a/ksql-version-metrics-client/src/main/java/io/confluent/ksql/version/metrics/KsqlVersionChecker.java
+++ b/ksql-version-metrics-client/src/main/java/io/confluent/ksql/version/metrics/KsqlVersionChecker.java
@@ -50,6 +50,9 @@ public class KsqlVersionChecker extends BaseMetricsReporter {
     this.metricsCollector = new BasicCollector(moduleType, activenessStatusSupplier);
   }
 
+  // This is used when collecting metrics in a kafka topic. Since KSQL isn't aware of ZK, we are
+  // returning null here to disable KafkaSubmitter and also turning off topic metrics collection in
+  // KsqlVersionCheckerConfig.
   @Override
   protected Submitter createKafkaSubmitter(final String supportTopic) {
     return null;

--- a/ksql-version-metrics-client/src/main/java/io/confluent/ksql/version/metrics/KsqlVersionChecker.java
+++ b/ksql-version-metrics-client/src/main/java/io/confluent/ksql/version/metrics/KsqlVersionChecker.java
@@ -20,8 +20,7 @@ import io.confluent.ksql.version.metrics.collector.KsqlModuleType;
 import io.confluent.support.metrics.BaseMetricsReporter;
 import io.confluent.support.metrics.BaseSupportConfig;
 import io.confluent.support.metrics.common.Collector;
-import io.confluent.support.metrics.common.kafka.KafkaUtilities;
-import io.confluent.support.metrics.common.kafka.ZkClientProvider;
+import io.confluent.support.metrics.submitters.Submitter;
 import java.util.Objects;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.function.Supplier;
@@ -42,7 +41,6 @@ public class KsqlVersionChecker extends BaseMetricsReporter {
         "KsqlVersionCheckerAgent",
         true,
         ksqlVersionCheckerConfig,
-        new KafkaUtilities(),
         new KsqlVersionCheckerResponseHandler(),
         enableSettlingTime
     );
@@ -53,11 +51,13 @@ public class KsqlVersionChecker extends BaseMetricsReporter {
   }
 
   @Override
-  protected ZkClientProvider zkClientProvider() {
-    //This is used when collecting metrics in a kafka topic. Since KSQL isn't aware of ZK, we are
-    // returning null here and also turning off topic metrics collection in
-    // KsqlVersionCheckerConfig.
+  protected Submitter createKafkaSubmitter(final String supportTopic) {
     return null;
+  }
+
+  @Override
+  protected boolean kafkaSubmitterReady(final String supportTopic) {
+    return false;
   }
 
   @Override


### PR DESCRIPTION
### Description 
BaseMetricsReporter in support-metrics-common is being updated to avoid dependency on core in components like KSQL which don't use ZK. This PR reflect the changes to the base class.

### Testing done 
Manual testing of KSQL startup without core jars.

### Reviewer checklist
- [ ] Ensure docs are updated if necessary. (eg. if a user visible feature is being added or changed).
- [ ] Ensure relevant issues are linked (description should include text like "Fixes #<issue number>")

