### PR TITLE
refactor: Move logical plan node creation into the LogicalPlanner (MINOR)

### DIFF
--- a/ksql-common/src/main/java/io/confluent/ksql/util/SchemaUtil.java
+++ b/ksql-common/src/main/java/io/confluent/ksql/util/SchemaUtil.java
@@ -33,6 +33,7 @@ import java.math.BigDecimal;
 import java.util.List;
 import java.util.Map;
 import java.util.NavigableMap;
+import java.util.Optional;
 import java.util.Set;
 import java.util.function.Supplier;
 import org.apache.avro.LogicalTypes;
@@ -271,6 +272,15 @@ public final class SchemaUtil {
     }
 
     return fieldName.substring(idx + 1);
+  }
+
+  public static Optional<String> getFieldNameAlias(final String fieldName) {
+    final int idx = fieldName.indexOf(FIELD_NAME_DELIMITER);
+    if (idx < 0) {
+      return Optional.empty();
+    }
+
+    return Optional.of(fieldName.substring(0, idx));
   }
 
   public static Schema resolveBinaryOperatorResultType(

--- a/ksql-common/src/test/java/io/confluent/ksql/util/SchemaUtilTest.java
+++ b/ksql-common/src/test/java/io/confluent/ksql/util/SchemaUtilTest.java
@@ -28,6 +28,7 @@ import java.lang.reflect.Type;
 import java.math.BigDecimal;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import org.apache.kafka.connect.data.ConnectSchema;
 import org.apache.kafka.connect.data.Field;
 import org.apache.kafka.connect.data.Schema;
@@ -539,6 +540,16 @@ public class SchemaUtilTest {
 
     // Then:
     assertThat(result, is("some-field-name"));
+  }
+
+  @Test
+  public void shouldReturnNoAlias() {
+    assertThat(SchemaUtil.getFieldNameAlias("not-aliased"), is(Optional.empty()));
+  }
+
+  @Test
+  public void shouldReturnAlias() {
+    assertThat(SchemaUtil.getFieldNameAlias("is.aliased"), is(Optional.of("is")));
   }
 
   @Test

--- a/ksql-engine/src/main/java/io/confluent/ksql/analyzer/Analysis.java
+++ b/ksql-engine/src/main/java/io/confluent/ksql/analyzer/Analysis.java
@@ -33,14 +33,17 @@ import io.confluent.ksql.parser.tree.WindowExpression;
 import io.confluent.ksql.parser.tree.WithinExpression;
 import io.confluent.ksql.planner.plan.JoinNode;
 import io.confluent.ksql.planner.plan.JoinNode.JoinType;
+import io.confluent.ksql.schema.ksql.LogicalSchema;
 import io.confluent.ksql.serde.SerdeOption;
 import io.confluent.ksql.util.SchemaUtil;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
 import java.util.OptionalInt;
 import java.util.Set;
+import java.util.stream.Collectors;
 
 public class Analysis {
 
@@ -162,6 +165,16 @@ public class Analysis {
 
   public List<AliasedDataSource> getFromDataSources() {
     return ImmutableList.copyOf(fromDataSources);
+  }
+
+  public SourceSchemas getFromSourceSchemas() {
+    final Map<String, LogicalSchema> schemaBySource = fromDataSources.stream()
+        .collect(Collectors.toMap(
+            AliasedDataSource::getAlias,
+            s -> s.getDataSource().getSchema()
+        ));
+
+    return new SourceSchemas(schemaBySource);
   }
 
   void addDataSource(final String alias, final DataSource<?> dataSource) {

--- a/ksql-engine/src/main/java/io/confluent/ksql/analyzer/Analysis.java
+++ b/ksql-engine/src/main/java/io/confluent/ksql/analyzer/Analysis.java
@@ -21,18 +21,23 @@ import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSet;
 import com.google.errorprone.annotations.Immutable;
 import io.confluent.ksql.metastore.SerdeFactory;
+import io.confluent.ksql.metastore.model.DataSource;
+import io.confluent.ksql.metastore.model.KsqlStream;
+import io.confluent.ksql.metastore.model.KsqlTable;
 import io.confluent.ksql.metastore.model.KsqlTopic;
 import io.confluent.ksql.parser.tree.DereferenceExpression;
 import io.confluent.ksql.parser.tree.Expression;
 import io.confluent.ksql.parser.tree.QualifiedName;
 import io.confluent.ksql.parser.tree.QualifiedNameReference;
 import io.confluent.ksql.parser.tree.WindowExpression;
-import io.confluent.ksql.planner.plan.DataSourceNode;
+import io.confluent.ksql.parser.tree.WithinExpression;
 import io.confluent.ksql.planner.plan.JoinNode;
+import io.confluent.ksql.planner.plan.JoinNode.JoinType;
 import io.confluent.ksql.serde.SerdeOption;
 import io.confluent.ksql.util.SchemaUtil;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Objects;
 import java.util.Optional;
 import java.util.OptionalInt;
 import java.util.Set;
@@ -40,8 +45,8 @@ import java.util.Set;
 public class Analysis {
 
   private Optional<Into> into = Optional.empty();
-  private final List<DataSourceNode> fromDataSources = new ArrayList<>();
-  private JoinNode join;
+  private final List<AliasedDataSource> fromDataSources = new ArrayList<>();
+  private Optional<JoinInfo> joinInfo = Optional.empty();
   private Expression whereExpression = null;
   private final List<Expression> selectExpressions = new ArrayList<>();
   private final List<String> selectExpressionAlias = new ArrayList<>();
@@ -83,14 +88,6 @@ public class Analysis {
     return selectExpressionAlias;
   }
 
-  public JoinNode getJoin() {
-    return join;
-  }
-
-  public void setJoin(final JoinNode join) {
-    this.join = join;
-  }
-
   public List<Expression> getGroupByExpressions() {
     return ImmutableList.copyOf(groupByExpressions);
   }
@@ -103,15 +100,15 @@ public class Analysis {
     return windowExpression;
   }
 
-  public void setWindowExpression(final WindowExpression windowExpression) {
+  void setWindowExpression(final WindowExpression windowExpression) {
     this.windowExpression = windowExpression;
   }
 
-  public Expression getHavingExpression() {
+  Expression getHavingExpression() {
     return havingExpression;
   }
 
-  public void setHavingExpression(final Expression havingExpression) {
+  void setHavingExpression(final Expression havingExpression) {
     this.havingExpression = havingExpression;
   }
 
@@ -119,7 +116,7 @@ public class Analysis {
     return timestampColumnName;
   }
 
-  public void setTimestampColumnName(final String columnName) {
+  void setTimestampColumnName(final String columnName) {
     timestampColumnName = Optional.of(columnName);
   }
 
@@ -127,7 +124,7 @@ public class Analysis {
     return timestampFormat;
   }
 
-  public void setTimestampFormat(final String format) {
+  void setTimestampFormat(final String format) {
     timestampFormat = Optional.of(format);
   }
 
@@ -135,7 +132,7 @@ public class Analysis {
     return partitionBy;
   }
 
-  public void setPartitionBy(final String partitionBy) {
+  void setPartitionBy(final String partitionBy) {
     this.partitionBy = Optional.of(partitionBy);
   }
 
@@ -143,27 +140,40 @@ public class Analysis {
     return limitClause;
   }
 
-  public void setLimitClause(final int limitClause) {
+  void setLimitClause(final int limitClause) {
     this.limitClause = OptionalInt.of(limitClause);
   }
 
-  public DataSourceNode getFromDataSource(final int index) {
-    return fromDataSources.get(index);
+  void setJoin(final JoinInfo joinInfo) {
+    if (fromDataSources.size() <= 1) {
+      throw new IllegalStateException("Join info can only be supplied for joins");
+    }
+
+    this.joinInfo = Optional.of(joinInfo);
   }
 
-  int getFromDataSourceCount() {
-    return fromDataSources.size();
+  public Optional<JoinInfo> getJoin() {
+    return joinInfo;
   }
 
-  void addDataSource(final DataSourceNode dataSourceNode) {
-    fromDataSources.add(dataSourceNode);
+  public boolean isJoin() {
+    return joinInfo.isPresent();
+  }
+
+  public List<AliasedDataSource> getFromDataSources() {
+    return ImmutableList.copyOf(fromDataSources);
+  }
+
+  void addDataSource(final String alias, final DataSource<?> dataSource) {
+    if (!(dataSource instanceof KsqlStream) && !(dataSource instanceof KsqlTable)) {
+      throw new IllegalArgumentException("Data source type not supported yet: " + dataSource);
+    }
+
+    fromDataSources.add(new AliasedDataSource(alias, dataSource));
   }
 
   DereferenceExpression getDefaultArgument() {
-    final String base = join == null
-        ? fromDataSources.get(0).getAlias()
-        : join.getLeftAlias();
-
+    final String base = fromDataSources.get(0).getAlias();
     final Expression baseExpression = new QualifiedNameReference(QualifiedName.of(base));
     return new DereferenceExpression(baseExpression, SchemaUtil.ROWTIME_NAME);
   }
@@ -227,6 +237,79 @@ public class Analysis {
 
     public SerdeFactory<?> getKeySerdeFactory() {
       return keySerdeFactory;
+    }
+  }
+
+  @Immutable
+  public static final class AliasedDataSource {
+
+    private final String alias;
+    private final DataSource<?> dataSource;
+
+    AliasedDataSource(
+        final String alias,
+        final DataSource<?> dataSource
+    ) {
+      this.alias = Objects.requireNonNull(alias, "alias");
+      this.dataSource = Objects.requireNonNull(dataSource, "dataSource");
+
+      if (alias.trim().isEmpty()) {
+        throw new IllegalArgumentException("Alias or name can not be empty: '" + alias + "'");
+      }
+    }
+
+    public String getAlias() {
+      return alias;
+    }
+
+    public DataSource<?> getDataSource() {
+      return dataSource;
+    }
+  }
+
+  @Immutable
+  public static final class JoinInfo {
+
+    private final String leftJoinField;
+    private final String rightJoinField;
+    private final JoinNode.JoinType type;
+    private final Optional<WithinExpression> withinExpression;
+
+    JoinInfo(
+        final String leftJoinField,
+        final String rightJoinField,
+        final JoinType type,
+        final Optional<WithinExpression> withinExpression
+
+    ) {
+      this.leftJoinField =  Objects.requireNonNull(leftJoinField, "leftJoinField");
+      this.rightJoinField =  Objects.requireNonNull(rightJoinField, "rightJoinField");
+      this.type = Objects.requireNonNull(type, "type");
+      this.withinExpression = Objects.requireNonNull(withinExpression, "withinExpression");
+
+      if (leftJoinField.trim().isEmpty()) {
+        throw new IllegalArgumentException("left join field name can not be empty");
+      }
+
+      if (rightJoinField.trim().isEmpty()) {
+        throw new IllegalArgumentException("right join field name can not be empty");
+      }
+    }
+
+    public String getLeftJoinField() {
+      return leftJoinField;
+    }
+
+    public String getRightJoinField() {
+      return rightJoinField;
+    }
+
+    public JoinType getType() {
+      return type;
+    }
+
+    public Optional<WithinExpression> getWithinExpression() {
+      return withinExpression;
     }
   }
 }

--- a/ksql-engine/src/main/java/io/confluent/ksql/analyzer/Analyzer.java
+++ b/ksql-engine/src/main/java/io/confluent/ksql/analyzer/Analyzer.java
@@ -338,7 +338,7 @@ class Analyzer {
     private void throwOnUnknownColumnReference() {
 
       final ExpressionAnalyzer expressionAnalyzer =
-          new ExpressionAnalyzer(analysis.getFromDataSources());
+          new ExpressionAnalyzer(analysis.getFromSourceSchemas());
 
       for (final Expression selectExpression : analysis.getSelectExpressions()) {
         expressionAnalyzer.analyzeExpression(selectExpression);

--- a/ksql-engine/src/main/java/io/confluent/ksql/analyzer/Analyzer.java
+++ b/ksql-engine/src/main/java/io/confluent/ksql/analyzer/Analyzer.java
@@ -15,12 +15,13 @@
 
 package io.confluent.ksql.analyzer;
 
-import static java.lang.String.format;
 import static java.util.Objects.requireNonNull;
 
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.collect.ImmutableSet;
+import io.confluent.ksql.analyzer.Analysis.AliasedDataSource;
 import io.confluent.ksql.analyzer.Analysis.Into;
+import io.confluent.ksql.analyzer.Analysis.JoinInfo;
 import io.confluent.ksql.ddl.DdlConfig;
 import io.confluent.ksql.metastore.MetaStore;
 import io.confluent.ksql.metastore.model.DataSource;
@@ -49,9 +50,7 @@ import io.confluent.ksql.parser.tree.Sink;
 import io.confluent.ksql.parser.tree.StringLiteral;
 import io.confluent.ksql.parser.tree.Table;
 import io.confluent.ksql.parser.tree.WindowExpression;
-import io.confluent.ksql.planner.plan.DataSourceNode;
 import io.confluent.ksql.planner.plan.JoinNode;
-import io.confluent.ksql.planner.plan.PlanNodeId;
 import io.confluent.ksql.schema.ksql.LogicalSchema;
 import io.confluent.ksql.serde.Format;
 import io.confluent.ksql.serde.KsqlSerdeFactories;
@@ -247,7 +246,7 @@ class Analyzer {
         return Format.of(StringUtil.cleanQuotes(serdeProperty.toString()));
       }
 
-      final DataSource<?> leftSource = analysis.getFromDataSource(0).getDataSource();
+      final DataSource<?> leftSource = analysis.getFromDataSources().get(0).getDataSource();
       return leftSource.getKsqlTopic().getValueSerdeFactory().getFormat();
     }
 
@@ -331,29 +330,28 @@ class Analyzer {
       node.getHaving().ifPresent(this::analyzeHaving);
       node.getLimit().ifPresent(analysis::setLimitClause);
 
-      analyzeExpressions();
+      throwOnUnknownColumnReference();
 
       return null;
     }
 
-    private void analyzeExpressions() {
-      final boolean isJoinSchema = analysis.getJoin() != null;
+    private void throwOnUnknownColumnReference() {
 
-      final LogicalSchema schema = isJoinSchema
-          ? analysis.getJoin().getSchema()
-          : analysis.getFromDataSource(0).getSchema().withoutAlias();
-
-      final ExpressionAnalyzer expressionAnalyzer = new ExpressionAnalyzer(schema, isJoinSchema);
+      final ExpressionAnalyzer expressionAnalyzer =
+          new ExpressionAnalyzer(analysis.getFromDataSources());
 
       for (final Expression selectExpression : analysis.getSelectExpressions()) {
         expressionAnalyzer.analyzeExpression(selectExpression);
       }
+
       if (analysis.getWhereExpression() != null) {
         expressionAnalyzer.analyzeExpression(analysis.getWhereExpression());
       }
+
       for (final Expression expression : analysis.getGroupByExpressions()) {
         expressionAnalyzer.analyzeExpression(expression);
       }
+
       if (analysis.getHavingExpression() != null) {
         expressionAnalyzer.analyzeExpression(analysis.getHavingExpression());
       }
@@ -361,73 +359,41 @@ class Analyzer {
 
     @Override
     protected Node visitJoin(final Join node, final Void context) {
-      final AliasedRelation left = (AliasedRelation) process(node.getLeft(), context);
-      final AliasedRelation right = (AliasedRelation) process(node.getRight(), context);
-
-      final String leftSideName = ((Table) left.getRelation()).getName().getSuffix();
-      final DataSource<?> leftDataSource = metaStore.getSource(leftSideName);
-      if (leftDataSource == null) {
-        throw new KsqlException(format("Resource %s does not exist.", leftSideName));
-      }
-
-      final String rightSideName = ((Table) right.getRelation()).getName().getSuffix();
-      final DataSource<?> rightDataSource = metaStore.getSource(rightSideName);
-      if (rightDataSource == null) {
-        throw new KsqlException(format("Resource %s does not exist.", rightSideName));
-      }
-
-      final String leftAlias = left.getAlias();
-      final String rightAlias = right.getAlias();
+      process(node.getLeft(), context);
+      process(node.getRight(), context);
 
       final JoinNode.JoinType joinType = getJoinType(node);
+
+      final AliasedDataSource left = analysis.getFromDataSources().get(0);
+      final AliasedDataSource right = analysis.getFromDataSources().get(1);
 
       final JoinOn joinOn = (JoinOn) node.getCriteria();
       final ComparisonExpression comparisonExpression = (ComparisonExpression) joinOn
           .getExpression();
 
-      final String leftJoinField = getJoinFieldName(
-          comparisonExpression,
-          leftAlias,
-          leftDataSource.getSchema()
-      );
-
-      final String rightJoinField = getJoinFieldName(
-          comparisonExpression,
-          rightAlias,
-          rightDataSource.getSchema()
-      );
-
       if (comparisonExpression.getType() != ComparisonExpression.Type.EQUAL) {
         throw new KsqlException("Only equality join criteria is supported.");
       }
 
-      final DataSourceNode leftSourceNode = new DataSourceNode(
-          new PlanNodeId("KafkaTopic_Left"),
-          leftDataSource,
-          leftAlias
+      final String leftJoinField = getJoinFieldName(
+          comparisonExpression,
+          left.getAlias(),
+          left.getDataSource().getSchema()
       );
 
-      final DataSourceNode rightSourceNode = new DataSourceNode(
-          new PlanNodeId("KafkaTopic_Right"),
-          rightDataSource,
-          rightAlias
+      final String rightJoinField = getJoinFieldName(
+          comparisonExpression,
+          right.getAlias(),
+          right.getDataSource().getSchema()
       );
 
-      final JoinNode joinNode = new JoinNode(
-          new PlanNodeId("Join"),
-          joinType,
-          leftSourceNode,
-          rightSourceNode,
+      analysis.setJoin(new JoinInfo(
           leftJoinField,
           rightJoinField,
-          leftAlias,
-          rightAlias,
-          node.getWithinExpression().orElse(null),
-          leftDataSource.getDataSourceType(),
-          rightDataSource.getDataSourceType()
-      );
+          joinType,
+          node.getWithinExpression()
+      ));
 
-      analysis.setJoin(joinNode);
       return null;
     }
 
@@ -522,13 +488,7 @@ class Analyzer {
         throw new KsqlException(structuredDataSourceName + " does not exist.");
       }
 
-      final DataSourceNode sourceNode = new DataSourceNode(
-          new PlanNodeId("KsqlTopic"),
-          source,
-          node.getAlias()
-      );
-
-      analysis.addDataSource(sourceNode);
+      analysis.addDataSource(node.getAlias(), source);
       return node;
     }
 
@@ -541,31 +501,7 @@ class Analyzer {
     protected Node visitSelect(final Select node, final Void context) {
       for (final SelectItem selectItem : node.getSelectItems()) {
         if (selectItem instanceof AllColumns) {
-          // expand * and T.*
-          final AllColumns allColumns = (AllColumns) selectItem;
-          final Optional<NodeLocation> location = allColumns.getLocation();
-
-          final JoinNode join = analysis.getJoin();
-          if (join != null) {
-            final String prefix = allColumns.getPrefix()
-                .map(QualifiedName::toString)
-                .orElse("");
-
-            if (!prefix.equals(join.getRightAlias())) {
-              final LogicalSchema schema = join.getLeft().getSchema();
-              addSelectItems(location, schema, join.getLeftAlias(), join.getLeftAlias() + "_");
-            }
-
-            if (!prefix.equals(join.getLeftAlias())) {
-              final LogicalSchema schema = join.getRight().getSchema();
-              addSelectItems(location, schema, join.getRightAlias(), join.getRightAlias() + "_");
-            }
-          } else {
-            final DataSourceNode source = analysis.getFromDataSource(0);
-            final LogicalSchema schema = source.getSchema();
-
-            addSelectItems(location, schema, source.getAlias(), "");
-          }
+          visitSelectStar((AllColumns) selectItem);
         } else if (selectItem instanceof SingleColumn) {
           final SingleColumn column = (SingleColumn) selectItem;
           analysis.addSelectItem(column.getExpression(), column.getAlias());
@@ -609,24 +545,37 @@ class Analyzer {
       analysis.setHavingExpression((Expression) node);
     }
 
-    private void addSelectItems(
-        final Optional<NodeLocation> location,
-        final LogicalSchema schema,
-        final String sourceAlias,
-        final String aliasPrefix
-    ) {
-      for (final Field field : schema.withoutAlias().valueFields()) {
+    private void visitSelectStar(final AllColumns allColumns) {
 
-        final QualifiedName name = QualifiedName.of(sourceAlias);
+      final Optional<NodeLocation> location = allColumns.getLocation();
+
+      final String prefix = allColumns.getPrefix()
+          .map(QualifiedName::toString)
+          .orElse("");
+
+      for (final AliasedDataSource source : analysis.getFromDataSources()) {
+
+        if (!prefix.isEmpty() && !prefix.equals(source.getAlias())) {
+          continue;
+        }
+
+        final QualifiedName name = QualifiedName.of(source.getAlias());
 
         final QualifiedNameReference nameRef = new QualifiedNameReference(location, name);
 
-        final DereferenceExpression selectItem =
-            new DereferenceExpression(location, nameRef, field.name());
+        final String aliasPrefix = analysis.isJoin()
+            ? source.getAlias() + "_"
+            : "";
 
-        final String alias = aliasPrefix + field.name();
+        for (final Field field : source.getDataSource().getSchema().fields()) {
 
-        analysis.addSelectItem(selectItem, alias);
+          final DereferenceExpression selectItem =
+              new DereferenceExpression(location, nameRef, field.name());
+
+          final String alias = aliasPrefix + field.name();
+
+          analysis.addSelectItem(selectItem, alias);
+        }
       }
     }
   }

--- a/ksql-engine/src/main/java/io/confluent/ksql/analyzer/ExpressionAnalyzer.java
+++ b/ksql-engine/src/main/java/io/confluent/ksql/analyzer/ExpressionAnalyzer.java
@@ -29,8 +29,10 @@ import io.confluent.ksql.parser.tree.LogicalBinaryExpression;
 import io.confluent.ksql.parser.tree.NotExpression;
 import io.confluent.ksql.parser.tree.QualifiedNameReference;
 import io.confluent.ksql.util.KsqlException;
+import io.confluent.ksql.util.SchemaUtil;
 import java.util.Objects;
 import java.util.Set;
+import java.util.stream.Collectors;
 
 /**
  * Searches through the AST for any column references and throws if they are unknown fields.
@@ -55,8 +57,13 @@ class ExpressionAnalyzer {
     }
 
     if (sourcesWithField.size() > 1) {
+      final String possibilities = sourcesWithField.stream()
+          .sorted()
+          .map(source -> SchemaUtil.buildAliasedFieldName(source, columnName))
+          .collect(Collectors.joining(","));
+
       throw new KsqlException("Field '" + columnName + "' is ambiguous. "
-          + "Could be any of: " + sourcesWithField);
+          + "Could be any of: " + possibilities);
     }
   }
 

--- a/ksql-engine/src/main/java/io/confluent/ksql/analyzer/SourceSchemas.java
+++ b/ksql-engine/src/main/java/io/confluent/ksql/analyzer/SourceSchemas.java
@@ -1,0 +1,80 @@
+/*
+ * Copyright 2019 Confluent Inc.
+ *
+ * Licensed under the Confluent Community License (the "License"); you may not use
+ * this file except in compliance with the License.  You may obtain a copy of the
+ * License at
+ *
+ * http://www.confluent.io/confluent-community-license
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package io.confluent.ksql.analyzer;
+
+import static java.util.Objects.requireNonNull;
+
+import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.ImmutableSet;
+import io.confluent.ksql.schema.ksql.LogicalSchema;
+import io.confluent.ksql.util.SchemaUtil;
+import java.util.Map;
+import java.util.Map.Entry;
+import java.util.Optional;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+/**
+ * Helper for finding fields in the schemas of one or more aliased sources.
+ */
+final class SourceSchemas {
+
+  private final Map<String, LogicalSchema> sourceSchemas;
+
+  SourceSchemas(final Map<String, LogicalSchema> sourceSchemas) {
+    this.sourceSchemas = ImmutableMap.copyOf(requireNonNull(sourceSchemas, "sourceSchemas"));
+
+    if (sourceSchemas.isEmpty()) {
+      throw new IllegalArgumentException("Must supply at least one schema");
+    }
+  }
+
+  /**
+   * Find the name of any sources containing the supplied {@code fieldName}.
+   *
+   * <p>The supplied name can be prefixed with a source name. In which case, only that specific
+   * source is checked. If not prefix is present, all sources are checked.
+   *
+   * @param fieldName the field name to search for. Can be prefixed by source name.
+   * @return the set of source names or aliases which contain the supplied {@code fieldName}.
+   */
+  Set<String> sourcesWithField(final String fieldName) {
+
+    final Optional<String> maybeSourceName = SchemaUtil.getFieldNameAlias(fieldName);
+    if (!maybeSourceName.isPresent()) {
+      return sourceSchemas.entrySet().stream()
+          .filter(e -> e.getValue().findField(fieldName).isPresent())
+          .map(Entry::getKey)
+          .collect(Collectors.toSet());
+    }
+
+    final String sourceName = maybeSourceName.get();
+    final String baseFieldName = SchemaUtil.getFieldNameWithNoAlias(fieldName);
+
+    final LogicalSchema sourceSchema = sourceSchemas.get(sourceName);
+    if (sourceSchema == null) {
+      return ImmutableSet.of();
+    }
+
+    return sourceSchema.findField(baseFieldName).isPresent()
+        ? ImmutableSet.of(sourceName)
+        : ImmutableSet.of();
+  }
+
+  public boolean isJoin() {
+    return sourceSchemas.size() > 1;
+  }
+}

--- a/ksql-engine/src/main/java/io/confluent/ksql/planner/LogicalPlanner.java
+++ b/ksql-engine/src/main/java/io/confluent/ksql/planner/LogicalPlanner.java
@@ -17,13 +17,17 @@ package io.confluent.ksql.planner;
 
 import io.confluent.ksql.analyzer.AggregateAnalysisResult;
 import io.confluent.ksql.analyzer.Analysis;
+import io.confluent.ksql.analyzer.Analysis.AliasedDataSource;
 import io.confluent.ksql.analyzer.Analysis.Into;
+import io.confluent.ksql.analyzer.Analysis.JoinInfo;
 import io.confluent.ksql.function.FunctionRegistry;
 import io.confluent.ksql.metastore.model.KeyField;
 import io.confluent.ksql.parser.tree.DereferenceExpression;
 import io.confluent.ksql.parser.tree.Expression;
 import io.confluent.ksql.planner.plan.AggregateNode;
+import io.confluent.ksql.planner.plan.DataSourceNode;
 import io.confluent.ksql.planner.plan.FilterNode;
+import io.confluent.ksql.planner.plan.JoinNode;
 import io.confluent.ksql.planner.plan.KsqlBareOutputNode;
 import io.confluent.ksql.planner.plan.KsqlStructuredDataOutputNode;
 import io.confluent.ksql.planner.plan.OutputNode;
@@ -36,6 +40,7 @@ import io.confluent.ksql.util.KsqlException;
 import io.confluent.ksql.util.SchemaUtil;
 import io.confluent.ksql.util.timestamp.TimestampExtractionPolicy;
 import io.confluent.ksql.util.timestamp.TimestampExtractionPolicyFactory;
+import java.util.List;
 import java.util.Optional;
 import org.apache.kafka.connect.data.Field;
 import org.apache.kafka.connect.data.Schema;
@@ -60,15 +65,12 @@ public class LogicalPlanner {
   }
 
   public OutputNode buildPlan() {
-    PlanNode currentNode;
-    if (analysis.getJoin() != null) {
-      currentNode = analysis.getJoin();
-    } else {
-      currentNode = analysis.getFromDataSource(0);
-    }
+    PlanNode currentNode = buildSourceNode();
+
     if (analysis.getWhereExpression() != null) {
       currentNode = buildFilterNode(currentNode);
     }
+
     if (!analysis.getGroupByExpressions().isEmpty()) {
       currentNode = buildAggregateNode(currentNode);
     } else {
@@ -213,5 +215,57 @@ public class LogicalPlanner {
 
     final Expression filterExpression = analysis.getWhereExpression();
     return new FilterNode(new PlanNodeId("Filter"), sourcePlanNode, filterExpression);
+  }
+
+  private PlanNode buildSourceNode() {
+
+    final List<AliasedDataSource> sources = analysis.getFromDataSources();
+
+    final Optional<JoinInfo> joinInfo = analysis.getJoin();
+    if (!joinInfo.isPresent()) {
+      return buildNonJoinNode(sources);
+    }
+
+    if (sources.size() != 2) {
+      throw new IllegalStateException("Expected 2 sources. Got " + sources.size());
+    }
+
+    final AliasedDataSource left = sources.get(0);
+    final AliasedDataSource right = sources.get(1);
+
+    final DataSourceNode leftSourceNode = new DataSourceNode(
+        new PlanNodeId("KafkaTopic_Left"),
+        left.getDataSource(),
+        left.getAlias()
+    );
+
+    final DataSourceNode rightSourceNode = new DataSourceNode(
+        new PlanNodeId("KafkaTopic_Right"),
+        right.getDataSource(),
+        right.getAlias()
+    );
+
+    return new JoinNode(
+        new PlanNodeId("Join"),
+        joinInfo.get().getType(),
+        leftSourceNode,
+        rightSourceNode,
+        joinInfo.get().getLeftJoinField(),
+        joinInfo.get().getRightJoinField(),
+        joinInfo.get().getWithinExpression()
+    );
+  }
+
+  private DataSourceNode buildNonJoinNode(final List<AliasedDataSource> sources) {
+    if (sources.size() != 1) {
+      throw new IllegalStateException("Expected only 1 source, got: " + sources.size());
+    }
+
+    final AliasedDataSource dataSource = analysis.getFromDataSources().get(0);
+    return new DataSourceNode(
+        new PlanNodeId("KsqlTopic"),
+        dataSource.getDataSource(),
+        dataSource.getAlias()
+    );
   }
 }

--- a/ksql-engine/src/main/java/io/confluent/ksql/planner/plan/JoinNode.java
+++ b/ksql-engine/src/main/java/io/confluent/ksql/planner/plan/JoinNode.java
@@ -62,14 +62,8 @@ public class JoinNode extends PlanNode {
   private final String leftJoinFieldName;
   private final String rightJoinFieldName;
   private final KeyField keyField;
+  private final Optional<WithinExpression> withinExpression;
 
-  private final String leftAlias;
-  private final String rightAlias;
-  private final WithinExpression withinExpression;
-  private final DataSourceType leftType;
-  private final DataSourceType rightType;
-
-  // CHECKSTYLE_RULES.OFF: ParameterNumberCheck
   public JoinNode(
       final PlanNodeId id,
       final JoinType joinType,
@@ -77,27 +71,16 @@ public class JoinNode extends PlanNode {
       final DataSourceNode right,
       final String leftJoinFieldName,
       final String rightJoinFieldName,
-      final String leftAlias,
-      final String rightAlias,
-      final WithinExpression withinExpression,
-      final DataSourceType leftType,
-      final DataSourceType rightType
+      final Optional<WithinExpression> withinExpression
   ) {
-    // CHECKSTYLE_RULES.ON: ParameterNumberCheck
-    super(id, (leftType == DataSourceType.KTABLE && rightType == DataSourceType.KTABLE)
-        ? DataSourceType.KTABLE
-        : DataSourceType.KSTREAM);
+    super(id, calculateSinkType(left, right));
     this.joinType = joinType;
     this.left = Objects.requireNonNull(left, "left");
     this.right = Objects.requireNonNull(right, "right");
     this.schema = buildSchema(left, right);
     this.leftJoinFieldName = Objects.requireNonNull(leftJoinFieldName, "leftJoinFieldName");
     this.rightJoinFieldName = Objects.requireNonNull(rightJoinFieldName, "rightJoinFieldName");
-    this.leftAlias = Objects.requireNonNull(leftAlias, "leftAlias");
-    this.rightAlias = Objects.requireNonNull(rightAlias, rightAlias);
-    this.withinExpression = withinExpression;
-    this.leftType = Objects.requireNonNull(leftType, "leftType");
-    this.rightType = Objects.requireNonNull(rightType, "rightType");
+    this.withinExpression = Objects.requireNonNull(withinExpression, "withinExpression");
 
     final Field leftKeyField = validateFieldInSchema(leftJoinFieldName, left.getSchema());
     validateFieldInSchema(rightJoinFieldName, right.getSchema());
@@ -150,30 +133,6 @@ public class JoinNode extends PlanNode {
     return right;
   }
 
-  public String getLeftJoinFieldName() {
-    return leftJoinFieldName;
-  }
-
-  public String getRightJoinFieldName() {
-    return rightJoinFieldName;
-  }
-
-  public String getLeftAlias() {
-    return leftAlias;
-  }
-
-  public String getRightAlias() {
-    return rightAlias;
-  }
-
-  JoinType getJoinType() {
-    return joinType;
-  }
-
-  public boolean isLeftJoin() {
-    return joinType == JoinType.LEFT;
-  }
-
   @Override
   public SchemaKStream<?> buildStream(final KsqlQueryBuilder builder) {
 
@@ -184,7 +143,7 @@ public class JoinNode extends PlanNode {
         this,
         builder.buildNodeContext(getId()));
 
-    return joinerFactory.getJoiner(leftType, rightType).join();
+    return joinerFactory.getJoiner(left.getDataSourceType(), right.getDataSourceType()).join();
   }
 
   @Override
@@ -401,7 +360,7 @@ public class JoinNode extends PlanNode {
 
     @Override
     public SchemaKStream<K> join() {
-      if (joinNode.withinExpression == null) {
+      if (!joinNode.withinExpression.isPresent()) {
         throw new KsqlException("Stream-Stream joins must have a WITHIN clause specified. None was "
             + "provided. To learn about how to specify a WITHIN clause with a "
             + "stream-stream join, please visit: https://docs.confluent"
@@ -410,18 +369,18 @@ public class JoinNode extends PlanNode {
       }
 
       final SchemaKStream<K> leftStream = buildStream(
-          joinNode.getLeft(), joinNode.getLeftJoinFieldName());
+          joinNode.getLeft(), joinNode.leftJoinFieldName);
 
       final SchemaKStream<K> rightStream = buildStream(
-          joinNode.getRight(), joinNode.getRightJoinFieldName());
+          joinNode.getRight(), joinNode.rightJoinFieldName);
 
       switch (joinNode.joinType) {
         case LEFT:
           return leftStream.leftJoin(
               rightStream,
               joinNode.schema,
-              getJoinedKeyField(joinNode.leftAlias, leftStream.getKeyField()),
-              joinNode.withinExpression.joinWindow(),
+              getJoinedKeyField(joinNode.left.getAlias(), leftStream.getKeyField()),
+              joinNode.withinExpression.get().joinWindow(),
               getSerDeForSource(joinNode.left, contextStacker.push(LEFT_SERDE_CONTEXT_NAME)),
               getSerDeForSource(joinNode.right, contextStacker.push(RIGHT_SERDE_CONTEXT_NAME)),
               contextStacker);
@@ -429,8 +388,8 @@ public class JoinNode extends PlanNode {
           return leftStream.outerJoin(
               rightStream,
               joinNode.schema,
-              getOuterJoinedKeyField(joinNode.leftAlias, leftStream.getKeyField()),
-              joinNode.withinExpression.joinWindow(),
+              getOuterJoinedKeyField(joinNode.left.getAlias(), leftStream.getKeyField()),
+              joinNode.withinExpression.get().joinWindow(),
               getSerDeForSource(joinNode.left, contextStacker.push(LEFT_SERDE_CONTEXT_NAME)),
               getSerDeForSource(joinNode.right, contextStacker.push(RIGHT_SERDE_CONTEXT_NAME)),
               contextStacker);
@@ -438,8 +397,8 @@ public class JoinNode extends PlanNode {
           return leftStream.join(
               rightStream,
               joinNode.schema,
-              getJoinedKeyField(joinNode.leftAlias, leftStream.getKeyField()),
-              joinNode.withinExpression.joinWindow(),
+              getJoinedKeyField(joinNode.left.getAlias(), leftStream.getKeyField()),
+              joinNode.withinExpression.get().joinWindow(),
               getSerDeForSource(joinNode.left, contextStacker.push(LEFT_SERDE_CONTEXT_NAME)),
               getSerDeForSource(joinNode.right, contextStacker.push(RIGHT_SERDE_CONTEXT_NAME)),
               contextStacker);
@@ -461,24 +420,24 @@ public class JoinNode extends PlanNode {
 
     @Override
     public SchemaKStream<K> join() {
-      if (joinNode.withinExpression != null) {
+      if (joinNode.withinExpression.isPresent()) {
         throw new KsqlException("A window definition was provided for a Stream-Table join. These "
             + "joins are not windowed. Please drop the window definition (ie."
             + " the WITHIN clause) and try to execute your join again.");
       }
 
       final SchemaKTable<K> rightTable = buildTable(
-          joinNode.getRight(), joinNode.getRightJoinFieldName(), joinNode.getRightAlias());
+          joinNode.getRight(), joinNode.rightJoinFieldName, joinNode.right.getAlias());
 
       final SchemaKStream<K> leftStream = buildStream(
-          joinNode.getLeft(), joinNode.getLeftJoinFieldName());
+          joinNode.getLeft(), joinNode.leftJoinFieldName);
 
       switch (joinNode.joinType) {
         case LEFT:
           return leftStream.leftJoin(
               rightTable,
               joinNode.schema,
-              getJoinedKeyField(joinNode.leftAlias, leftStream.getKeyField()),
+              getJoinedKeyField(joinNode.left.getAlias(), leftStream.getKeyField()),
               getSerDeForSource(joinNode.left, contextStacker.push(LEFT_SERDE_CONTEXT_NAME)),
               contextStacker);
 
@@ -486,7 +445,7 @@ public class JoinNode extends PlanNode {
           return leftStream.join(
               rightTable,
               joinNode.schema,
-              getJoinedKeyField(joinNode.leftAlias, leftStream.getKeyField()),
+              getJoinedKeyField(joinNode.left.getAlias(), leftStream.getKeyField()),
               getSerDeForSource(joinNode.left, contextStacker.push(LEFT_SERDE_CONTEXT_NAME)),
               contextStacker);
         case OUTER:
@@ -510,7 +469,7 @@ public class JoinNode extends PlanNode {
 
     @Override
     public SchemaKTable<K> join() {
-      if (joinNode.withinExpression != null) {
+      if (joinNode.withinExpression.isPresent()) {
         throw new KsqlException("A window definition was provided for a Table-Table join. These "
             + "joins are not windowed. Please drop the window definition "
             + "(i.e. the WITHIN clause) and try to execute your Table-Table "
@@ -518,32 +477,43 @@ public class JoinNode extends PlanNode {
       }
 
       final SchemaKTable<K> leftTable = buildTable(
-          joinNode.getLeft(), joinNode.getLeftJoinFieldName(), joinNode.getLeftAlias());
+          joinNode.getLeft(), joinNode.leftJoinFieldName, joinNode.left.getAlias());
       final SchemaKTable<K> rightTable = buildTable(
-          joinNode.getRight(), joinNode.getRightJoinFieldName(), joinNode.getRightAlias());
+          joinNode.getRight(), joinNode.rightJoinFieldName, joinNode.right.getAlias());
 
       switch (joinNode.joinType) {
         case LEFT:
           return leftTable.leftJoin(
               rightTable,
               joinNode.schema,
-              getJoinedKeyField(joinNode.leftAlias, leftTable.getKeyField()),
+              getJoinedKeyField(joinNode.left.getAlias(), leftTable.getKeyField()),
               contextStacker);
         case INNER:
           return leftTable.join(
               rightTable,
               joinNode.schema,
-              getJoinedKeyField(joinNode.leftAlias, leftTable.getKeyField()),
+              getJoinedKeyField(joinNode.left.getAlias(), leftTable.getKeyField()),
               contextStacker);
         case OUTER:
           return leftTable.outerJoin(
               rightTable,
               joinNode.schema,
-              getOuterJoinedKeyField(joinNode.leftAlias, leftTable.getKeyField()),
+              getOuterJoinedKeyField(joinNode.left.getAlias(), leftTable.getKeyField()),
               contextStacker);
         default:
           throw new KsqlException("Invalid join type encountered: " + joinNode.joinType);
       }
     }
+  }
+
+  private static DataSourceType calculateSinkType(
+      final DataSourceNode left,
+      final DataSourceNode right
+  ) {
+    final DataSourceType leftType = left.getDataSourceType();
+    final DataSourceType rightType = right.getDataSourceType();
+    return leftType == DataSourceType.KTABLE && rightType == DataSourceType.KTABLE
+        ? DataSourceType.KTABLE
+        : DataSourceType.KSTREAM;
   }
 }

--- a/ksql-engine/src/test/java/io/confluent/ksql/analyzer/AnalyzerTest.java
+++ b/ksql-engine/src/test/java/io/confluent/ksql/analyzer/AnalyzerTest.java
@@ -17,6 +17,8 @@ package io.confluent.ksql.analyzer;
 
 import static io.confluent.ksql.testutils.AnalysisTestUtil.analyzeQuery;
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.contains;
+import static org.hamcrest.Matchers.hasSize;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.not;
 import static org.mockito.ArgumentMatchers.any;
@@ -28,6 +30,7 @@ import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Iterables;
 import io.confluent.ksql.analyzer.Analysis.Into;
+import io.confluent.ksql.analyzer.Analysis.JoinInfo;
 import io.confluent.ksql.analyzer.Analyzer.SerdeOptionsSupplier;
 import io.confluent.ksql.ddl.DdlConfig;
 import io.confluent.ksql.function.InternalFunctionRegistry;
@@ -45,7 +48,7 @@ import io.confluent.ksql.parser.tree.Query;
 import io.confluent.ksql.parser.tree.Sink;
 import io.confluent.ksql.parser.tree.Statement;
 import io.confluent.ksql.parser.tree.StringLiteral;
-import io.confluent.ksql.planner.plan.JoinNode;
+import io.confluent.ksql.planner.plan.JoinNode.JoinType;
 import io.confluent.ksql.schema.ksql.LogicalSchema;
 import io.confluent.ksql.serde.Format;
 import io.confluent.ksql.serde.SerdeFactories;
@@ -121,7 +124,7 @@ public class AnalyzerTest {
     Assert.assertNotNull("SELECT is null", analysis.getSelectExpressions());
     Assert.assertNotNull("SELECT alias is null", analysis.getSelectExpressionAlias());
     Assert.assertTrue("FROM was not analyzed correctly.",
-        analysis.getFromDataSource(0).getDataSource().getName()
+        analysis.getFromDataSources().get(0).getDataSource().getName()
                           .equalsIgnoreCase("test1"));
     Assert.assertEquals(analysis.getSelectExpressions().size(),
         analysis.getSelectExpressionAlias().size());
@@ -153,67 +156,46 @@ public class AnalyzerTest {
 
   @Test
   public void testSimpleLeftJoinAnalysis() {
-    final String
-        simpleQuery =
-        "SELECT t1.col1, t2.col1, t2.col4, col5, t2.col2 FROM test1 t1 LEFT JOIN test2 t2 ON "
-        + "t1.col1 = t2.col1;";
-    final Analysis analysis = analyzeQuery(simpleQuery, jsonMetaStore);
-    Assert.assertNotNull("INTO is null", analysis.getInto());
-    final JoinNode join = analysis.getJoin();
-    Assert.assertNotNull("JOIN is null", join);
+    // When:
+    final Analysis analysis = analyzeQuery(
+        "SELECT t1.col1, t2.col1, t2.col4, col5, t2.col2 "
+            + "FROM test1 t1 LEFT JOIN test2 t2 "
+            + "ON t1.col1 = t2.col1;", jsonMetaStore);
 
-    Assert.assertNotNull("SELECT is null", analysis.getSelectExpressions());
-    Assert.assertNotNull("SELECT aliacs is null", analysis.getSelectExpressionAlias());
-    Assert.assertTrue("JOIN left hand side was not analyzed correctly.",
-                      analysis.getJoin().getLeftAlias().equalsIgnoreCase("t1"));
-    Assert.assertTrue("JOIN right hand side was not analyzed correctly.",
-                      analysis.getJoin().getRightAlias().equalsIgnoreCase("t2"));
+    // Then:
+    assertThat(analysis.getFromDataSources(), hasSize(2));
+    assertThat(analysis.getFromDataSources().get(0).getAlias(), is("T1"));
+    assertThat(analysis.getFromDataSources().get(1).getAlias(), is("T2"));
 
-    Assert.assertEquals(analysis.getSelectExpressions().size(),
-        analysis.getSelectExpressionAlias().size());
+    assertThat(analysis.getSelectExpressions().size(),
+        is(analysis.getSelectExpressionAlias().size()));
 
-    assertThat(analysis.getJoin().getLeftJoinFieldName(), is("T1.COL1"));
-    assertThat(analysis.getJoin().getRightJoinFieldName(), is("T2.COL1"));
+    assertThat(analysis.getJoin(), is(not(Optional.empty())));
+    assertThat(analysis.getJoin().get().getLeftJoinField(), is("T1.COL1"));
+    assertThat(analysis.getJoin().get().getRightJoinField(), is("T2.COL1"));
 
-    final String
-        select1 =
-        SqlFormatter.formatSql(analysis.getSelectExpressions().get(0))
-            .replace("\n", " ");
-    Assert.assertTrue(select1.equalsIgnoreCase("T1.COL1"));
-    final String
-        select2 =
-        SqlFormatter.formatSql(analysis.getSelectExpressions().get(1))
-            .replace("\n", " ");
-    Assert.assertTrue(select2.equalsIgnoreCase("T2.COL1"));
-    final String
-        select3 =
-        SqlFormatter.formatSql(analysis.getSelectExpressions().get(2))
-            .replace("\n", " ");
-    final String
-        select4 =
-        SqlFormatter.formatSql(analysis.getSelectExpressions().get(3))
-            .replace("\n", " ");
-    Assert.assertTrue(select3.equalsIgnoreCase("T2.COL4"));
-    Assert.assertTrue(select4.equalsIgnoreCase("T1.COL5"));
+    final List<String> selects = analysis.getSelectExpressions().stream()
+        .map(SqlFormatter::formatSql)
+        .collect(Collectors.toList());
 
-    Assert.assertTrue(analysis.getSelectExpressionAlias().get(0).equalsIgnoreCase("T1_COL1"));
-    Assert.assertTrue(analysis.getSelectExpressionAlias().get(1).equalsIgnoreCase("T2_COL1"));
-    Assert.assertTrue(analysis.getSelectExpressionAlias().get(2).equalsIgnoreCase("T2_COL4"));
-    Assert.assertTrue(analysis.getSelectExpressionAlias().get(3).equalsIgnoreCase("COL5"));
-    Assert.assertTrue(analysis.getSelectExpressionAlias().get(4).equalsIgnoreCase("T2_COL2"));
+    assertThat(selects, contains("T1.COL1", "T2.COL1", "T2.COL4", "T1.COL5", "T2.COL2"));
+    assertThat(analysis.getSelectExpressionAlias(),
+        contains("T1_COL1", "T2_COL1", "T2_COL4", "COL5", "T2_COL2"));
   }
 
   @Test
   public void shouldHandleJoinOnRowKey() {
     // When:
-    final JoinNode join = analyzeQuery(
+    final Optional<JoinInfo> join = analyzeQuery(
         "SELECT * FROM test1 t1 LEFT JOIN test2 t2 ON t1.ROWKEY = t2.ROWKEY;",
         jsonMetaStore)
         .getJoin();
 
     // Then:
-    assertThat(join.getLeftJoinFieldName(), is("T1.ROWKEY"));
-    assertThat(join.getRightJoinFieldName(), is("T2.ROWKEY"));
+    assertThat(join, is(not(Optional.empty())));
+    assertThat(join.get().getType(), is(JoinType.LEFT));
+    assertThat(join.get().getLeftJoinField(), is("T1.ROWKEY"));
+    assertThat(join.get().getRightJoinField(), is("T2.ROWKEY"));
   }
 
   @Test
@@ -225,7 +207,7 @@ public class AnalyzerTest {
     Assert.assertNotNull("SELECT is null", analysis.getSelectExpressions());
     Assert.assertNotNull("SELECT aliacs is null", analysis.getSelectExpressionAlias());
     Assert.assertTrue("FROM was not analyzed correctly.",
-        analysis.getFromDataSource(0).getDataSource().getName()
+        analysis.getFromDataSources().get(0).getDataSource().getName()
                           .equalsIgnoreCase("test1"));
 
     final String
@@ -243,7 +225,6 @@ public class AnalyzerTest {
         SqlFormatter.formatSql(analysis.getSelectExpressions().get(2))
             .replace("\n", " ");
     Assert.assertTrue(select3.equalsIgnoreCase("(TEST1.COL3 > TEST1.COL1)"));
-
   }
 
   @Test
@@ -255,7 +236,7 @@ public class AnalyzerTest {
     Assert.assertNotNull("SELECT is null", analysis.getSelectExpressions());
     Assert.assertNotNull("SELECT aliacs is null", analysis.getSelectExpressionAlias());
     Assert.assertTrue("FROM was not analyzed correctly.",
-        analysis.getFromDataSource(0).getDataSource().getName()
+        analysis.getFromDataSources().get(0).getDataSource().getName()
                     .equalsIgnoreCase("test1"));
 
     final String

--- a/ksql-engine/src/test/java/io/confluent/ksql/analyzer/SourceSchemasTest.java
+++ b/ksql-engine/src/test/java/io/confluent/ksql/analyzer/SourceSchemasTest.java
@@ -59,7 +59,7 @@ public class SourceSchemasTest {
   }
 
   @Test
-  public void shouldNotBeJoinIfSingleSchemas() {
+  public void shouldNotBeJoinIfSingleSchema() {
     // When:
     sourceSchemas = new SourceSchemas(ImmutableMap.of(ALIAS_1, SCHEMA_1));
 

--- a/ksql-engine/src/test/java/io/confluent/ksql/analyzer/SourceSchemasTest.java
+++ b/ksql-engine/src/test/java/io/confluent/ksql/analyzer/SourceSchemasTest.java
@@ -87,6 +87,11 @@ public class SourceSchemasTest {
   }
 
   @Test
+  public void shouldFindUnqualifiedUniqueField() {
+    assertThat(sourceSchemas.sourcesWithField("F1"), contains(ALIAS_1));
+  }
+
+  @Test
   public void shouldFindQualifiedUniqueField() {
     assertThat(sourceSchemas.sourcesWithField(ALIAS_2 + ".F2"), contains(ALIAS_2));
   }
@@ -102,5 +107,4 @@ public class SourceSchemasTest {
     assertThat(sourceSchemas.sourcesWithField(ALIAS_1 + "." + COMMON_FIELD_NAME),
         contains(ALIAS_1));
   }
-
 }

--- a/ksql-engine/src/test/java/io/confluent/ksql/analyzer/SourceSchemasTest.java
+++ b/ksql-engine/src/test/java/io/confluent/ksql/analyzer/SourceSchemasTest.java
@@ -1,0 +1,106 @@
+/*
+ * Copyright 2019 Confluent Inc.
+ *
+ * Licensed under the Confluent Community License (the "License"); you may not use
+ * this file except in compliance with the License.  You may obtain a copy of the
+ * License at
+ *
+ * http://www.confluent.io/confluent-community-license
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package io.confluent.ksql.analyzer;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.contains;
+import static org.hamcrest.Matchers.containsInAnyOrder;
+import static org.hamcrest.Matchers.empty;
+import static org.hamcrest.Matchers.is;
+
+import com.google.common.collect.ImmutableMap;
+import io.confluent.ksql.schema.ksql.LogicalSchema;
+import org.apache.kafka.connect.data.Schema;
+import org.apache.kafka.connect.data.SchemaBuilder;
+import org.junit.Before;
+import org.junit.Test;
+
+public class SourceSchemasTest {
+
+  private static final String ALIAS_1 = "S1";
+  private static final String ALIAS_2 = "S2";
+  private static final String COMMON_FIELD_NAME = "F0";
+
+  private static final LogicalSchema SCHEMA_1 = LogicalSchema.of(SchemaBuilder.struct()
+      .field(COMMON_FIELD_NAME, Schema.OPTIONAL_STRING_SCHEMA)
+      .field("F1", Schema.OPTIONAL_STRING_SCHEMA)
+      .build()
+  );
+
+  private static final LogicalSchema SCHEMA_2 = LogicalSchema.of(SchemaBuilder.struct()
+      .field(COMMON_FIELD_NAME, Schema.OPTIONAL_STRING_SCHEMA)
+      .field("F2", Schema.OPTIONAL_STRING_SCHEMA)
+      .build()
+  );
+
+  private SourceSchemas sourceSchemas;
+
+  @Before
+  public void setUp() {
+    sourceSchemas = new SourceSchemas(ImmutableMap.of(ALIAS_1, SCHEMA_1, ALIAS_2, SCHEMA_2));
+  }
+
+  @Test(expected = IllegalArgumentException.class)
+  public void shouldThrowOnNoSchemas() {
+    new SourceSchemas(ImmutableMap.of());
+  }
+
+  @Test
+  public void shouldNotBeJoinIfSingleSchemas() {
+    // When:
+    sourceSchemas = new SourceSchemas(ImmutableMap.of(ALIAS_1, SCHEMA_1));
+
+    // Then:
+    assertThat(sourceSchemas.isJoin(), is(false));
+  }
+
+  @Test
+  public void shouldBeJoinIfMultipleSchemas() {
+    // When:
+    sourceSchemas = new SourceSchemas(ImmutableMap.of(ALIAS_1, SCHEMA_1, ALIAS_2, SCHEMA_2));
+
+    // Then:
+    assertThat(sourceSchemas.isJoin(), is(true));
+  }
+
+  @Test
+  public void shouldFindNoField() {
+    assertThat(sourceSchemas.sourcesWithField("unknown"), is(empty()));
+  }
+
+  @Test
+  public void shouldFindNoQualifiedField() {
+    assertThat(sourceSchemas.sourcesWithField(ALIAS_1 + ".F2"), is(empty()));
+  }
+
+  @Test
+  public void shouldFieldUnqualifiedUniqueField() {
+    assertThat(sourceSchemas.sourcesWithField(ALIAS_2 + ".F2"), contains(ALIAS_2));
+  }
+
+  @Test
+  public void shouldFieldUnqualifiedCommonField() {
+    assertThat(sourceSchemas.sourcesWithField(COMMON_FIELD_NAME),
+        containsInAnyOrder(ALIAS_1, ALIAS_2));
+  }
+
+  @Test
+  public void shouldFindQualifiedFieldOnlyInThatSource() {
+    assertThat(sourceSchemas.sourcesWithField(ALIAS_1 + "." + COMMON_FIELD_NAME),
+        contains(ALIAS_1));
+  }
+
+}

--- a/ksql-engine/src/test/java/io/confluent/ksql/analyzer/SourceSchemasTest.java
+++ b/ksql-engine/src/test/java/io/confluent/ksql/analyzer/SourceSchemasTest.java
@@ -87,7 +87,7 @@ public class SourceSchemasTest {
   }
 
   @Test
-  public void shouldFieldUnqualifiedUniqueField() {
+  public void shouldFindQualifiedUniqueField() {
     assertThat(sourceSchemas.sourcesWithField(ALIAS_2 + ".F2"), contains(ALIAS_2));
   }
 

--- a/ksql-engine/src/test/java/io/confluent/ksql/analyzer/SourceSchemasTest.java
+++ b/ksql-engine/src/test/java/io/confluent/ksql/analyzer/SourceSchemasTest.java
@@ -92,7 +92,7 @@ public class SourceSchemasTest {
   }
 
   @Test
-  public void shouldFieldUnqualifiedCommonField() {
+  public void shouldFindUnqualifiedCommonField() {
     assertThat(sourceSchemas.sourcesWithField(COMMON_FIELD_NAME),
         containsInAnyOrder(ALIAS_1, ALIAS_2));
   }

--- a/ksql-engine/src/test/java/io/confluent/ksql/codegen/CodeGenRunnerTest.java
+++ b/ksql-engine/src/test/java/io/confluent/ksql/codegen/CodeGenRunnerTest.java
@@ -170,7 +170,7 @@ public class CodeGenRunnerTest {
             .field("COL12",
                 SchemaBuilder.map(SchemaBuilder.OPTIONAL_STRING_SCHEMA, SchemaBuilder.OPTIONAL_INT32_SCHEMA).optional().build())
             .field("COL13", SchemaBuilder.array(SchemaBuilder.OPTIONAL_STRING_SCHEMA).optional().build())
-            .field("CODEGEN_TEST.COL14", SchemaBuilder.array(arraySchema).optional().build())
+            .field("COL14", SchemaBuilder.array(arraySchema).optional().build())
             .field("COL15", STRUCT_SCHEMA)
             .build();
 
@@ -924,9 +924,9 @@ public class CodeGenRunnerTest {
         return evalBetweenClause(simpleQuery, col, val);
     }
 
-    private boolean evalNotBetweenClauseObject(final int col, final Object val, final String min, final String max) {
+    private void evalNotBetweenClauseObject(final int col, final Object val, final String min, final String max) {
         final String simpleQuery = String.format("SELECT * FROM CODEGEN_TEST WHERE col%d NOT BETWEEN %s AND %s;", col, min, max);
-        return evalBetweenClause(simpleQuery, col, val);
+        evalBetweenClause(simpleQuery, col, val);
     }
 
     private boolean evalBetweenClause(final String simpleQuery, final int col, final Object val) {
@@ -943,7 +943,7 @@ public class CodeGenRunnerTest {
         return (Boolean)result0;
     }
 
-    private GenericRow buildRow(final Map<Integer, Object> overrides) {
+    private static GenericRow buildRow(final Map<Integer, Object> overrides) {
         final List<Object> columns = new ArrayList<>(ONE_ROW);
         overrides.forEach(columns::set);
         return genericRow(columns);

--- a/ksql-functional-tests/src/test/resources/query-validation-tests/elements.json
+++ b/ksql-functional-tests/src/test/resources/query-validation-tests/elements.json
@@ -156,6 +156,112 @@
       ],
       "inputs": [{"topic": "input", "value": {"F0": 4}, "timestamp": 10}],
       "outputs": [{"topic": "OUTPUT", "key": 10, "value": {"COUNT": 1}, "timestamp": 10}]
+    },
+    {
+      "name": "non-join qualified select star",
+      "statements": [
+        "CREATE STREAM INPUT (F0 INT) WITH (kafka_topic='input', value_format='JSON');",
+        "CREATE STREAM OUTPUT as SELECT i.* FROM INPUT i;"
+      ],
+      "inputs": [{"topic": "input", "value": {"F0": 4}}],
+      "outputs": [{"topic": "OUTPUT", "value": {"F0": 4}}]
+    },
+    {
+      "name": "non-join select star with unknown qualifier",
+      "statements": [
+        "CREATE STREAM INPUT (F0 INT) WITH (kafka_topic='input', value_format='JSON');",
+        "CREATE STREAM OUTPUT as SELECT unknown.* FROM INPUT i;"
+      ],
+      "expectedException": {
+        "type": "io.confluent.ksql.util.KsqlException",
+        "message": "'UNKNOWN' is not a valid stream/table name or alias."
+      }
+    },
+    {
+      "name": "join qualified select star left",
+      "statements": [
+        "CREATE STREAM INPUT_1 (F0 INT) WITH (kafka_topic='input_1', value_format='JSON');",
+        "CREATE STREAM INPUT_2 (F0 INT) WITH (kafka_topic='input_2', value_format='JSON');",
+        "CREATE STREAM OUTPUT as SELECT i1.* FROM INPUT_1 i1 JOIN INPUT_2 i2 WITHIN 10 SECONDS ON i1.ROWKEY = i2.ROWKEY;"
+      ],
+      "inputs": [
+        {"topic": "input_1", "key": 1, "value": {"F0": 4}, "timestamp": 10},
+        {"topic": "input_2", "key": 1, "value": {"F0": 4}, "timestamp": 11}
+      ],
+      "outputs": [{"topic": "OUTPUT", "key": 1, "value": {"I1_ROWTIME": 10, "I1_ROWKEY": "1", "I1_F0": 4}, "timestamp": 11}]
+    },
+    {
+      "name": "join qualified select star right",
+      "statements": [
+        "CREATE STREAM INPUT_1 (F0 INT) WITH (kafka_topic='input_1', value_format='JSON');",
+        "CREATE STREAM INPUT_2 (F0 INT) WITH (kafka_topic='input_2', value_format='JSON');",
+        "CREATE STREAM OUTPUT as SELECT i2.* FROM INPUT_1 i1 JOIN INPUT_2 i2 WITHIN 10 SECONDS ON i1.ROWKEY = i2.ROWKEY;"
+      ],
+      "inputs": [
+        {"topic": "input_1", "key": 1, "value": {"F0": 4}, "timestamp": 10},
+        {"topic": "input_2", "key": 1, "value": {"F0": 4}, "timestamp": 11}
+      ],
+      "outputs": [{"topic": "OUTPUT", "key": 1, "value": {"I2_ROWTIME": 11, "I2_ROWKEY": "1", "I2_F0": 4}, "timestamp": 11}]
+    },
+    {
+      "name": "join qualified select star",
+      "statements": [
+        "CREATE STREAM INPUT_1 (F0 INT) WITH (kafka_topic='input_1', value_format='JSON');",
+        "CREATE STREAM INPUT_2 (F0 INT) WITH (kafka_topic='input_2', value_format='JSON');",
+        "CREATE STREAM OUTPUT as SELECT * FROM INPUT_1 i1 JOIN INPUT_2 i2 WITHIN 10 SECONDS ON i1.ROWKEY = i2.ROWKEY;"
+      ],
+      "inputs": [
+        {"topic": "input_1", "key": 1, "value": {"F0": 4}, "timestamp": 10},
+        {"topic": "input_2", "key": 1, "value": {"F0": 4}, "timestamp": 11}
+      ],
+      "outputs": [{"topic": "OUTPUT", "key": 1, "value": {"I1_ROWTIME": 10, "I1_ROWKEY": "1", "I1_F0": 4, "I2_ROWTIME": 11, "I2_ROWKEY": "1", "I2_F0": 4}, "timestamp": 11}]
+    },
+    {
+      "name": "join unknown qualified select star",
+      "statements": [
+        "CREATE STREAM INPUT_1 (F0 INT) WITH (kafka_topic='input_1', value_format='JSON');",
+        "CREATE STREAM INPUT_2 (F0 INT) WITH (kafka_topic='input_2', value_format='JSON');",
+        "CREATE STREAM OUTPUT as SELECT unknown.* FROM INPUT_1 i1 JOIN INPUT_2 i2 WITHIN 10 SECONDS ON i1.ROWKEY = i2.ROWKEY;"
+      ],
+      "expectedException": {
+        "type": "io.confluent.ksql.util.KsqlException",
+        "message": "'UNKNOWN' is not a valid stream/table name or alias."
+      }
+    },
+    {
+      "name": "non-join unknown field",
+      "statements": [
+        "CREATE STREAM INPUT (F0 INT) WITH (kafka_topic='input', value_format='JSON');",
+        "CREATE STREAM OUTPUT as SELECT unknown FROM INPUT;"
+      ],
+      "expectedException": {
+        "type": "io.confluent.ksql.util.KsqlException",
+        "message": "Field 'UNKNOWN' cannot be resolved."
+      }
+    },
+    {
+      "name": "join unknown field",
+      "statements": [
+        "CREATE STREAM INPUT_1 (F0 INT) WITH (kafka_topic='input_1', value_format='JSON');",
+        "CREATE STREAM INPUT_2 (F0 INT) WITH (kafka_topic='input_2', value_format='JSON');",
+        "CREATE STREAM OUTPUT as SELECT unknown FROM INPUT_1 i1 JOIN INPUT_2 i2 WITHIN 10 SECONDS ON i1.ROWKEY = i2.ROWKEY;"
+      ],
+      "expectedException": {
+        "type": "io.confluent.ksql.util.KsqlException",
+        "message": "Field 'UNKNOWN' cannot be resolved."
+      }
+    },
+    {
+      "name": "join ambiguous field",
+      "statements": [
+        "CREATE STREAM INPUT_1 (F0 INT) WITH (kafka_topic='input_1', value_format='JSON');",
+        "CREATE STREAM INPUT_2 (F0 INT) WITH (kafka_topic='input_2', value_format='JSON');",
+        "CREATE STREAM OUTPUT as SELECT F0 FROM INPUT_1 i1 JOIN INPUT_2 i2 WITHIN 10 SECONDS ON i1.ROWKEY = i2.ROWKEY;"
+      ],
+      "expectedException": {
+        "type": "io.confluent.ksql.util.KsqlException",
+        "message": "Field 'F0' is ambiguous."
+      }
     }
   ]
 }

--- a/ksql-functional-tests/src/test/resources/query-validation-tests/elements.json
+++ b/ksql-functional-tests/src/test/resources/query-validation-tests/elements.json
@@ -204,7 +204,7 @@
       "outputs": [{"topic": "OUTPUT", "key": 1, "value": {"I2_ROWTIME": 11, "I2_ROWKEY": "1", "I2_F0": 4}, "timestamp": 11}]
     },
     {
-      "name": "join qualified select star",
+      "name": "join unqualified select star",
       "statements": [
         "CREATE STREAM INPUT_1 (F0 INT) WITH (kafka_topic='input_1', value_format='JSON');",
         "CREATE STREAM INPUT_2 (F0 INT) WITH (kafka_topic='input_2', value_format='JSON');",

--- a/ksql-parser/src/main/java/io/confluent/ksql/parser/AstBuilder.java
+++ b/ksql-parser/src/main/java/io/confluent/ksql/parser/AstBuilder.java
@@ -912,7 +912,7 @@ public class AstBuilder {
 
       if (dataSourceExtractor.isJoin()) {
         if (dataSourceExtractor.getCommonFieldNames().contains(columnName)) {
-          throw new KsqlException("Field " + columnName + " is ambiguous.");
+          throw new KsqlException("Field '" + columnName + "' is ambiguous.");
         }
 
         if (dataSourceExtractor.getLeftFieldNames().contains(columnName)) {
@@ -935,7 +935,7 @@ public class AstBuilder {
 
         throw new InvalidColumnReferenceException(
             columnLocation,
-            "Field " + columnName + " is ambiguous."
+            "Field '" + columnName + "' cannot be resolved."
         );
       }
 
@@ -1167,7 +1167,7 @@ public class AstBuilder {
       }
     }
 
-    private OptionalInt getLimit(final LimitClauseContext limitContext) {
+    private static OptionalInt getLimit(final LimitClauseContext limitContext) {
       return limitContext == null
           ? OptionalInt.empty()
           : OptionalInt.of(processIntegerNumber(limitContext.number(), "LIMIT"));


### PR DESCRIPTION
### Description 

As was requested in a[ previous PR by @hjafarpour,](https://github.com/confluentinc/ksql/pull/2962#pullrequestreview-249045767) this PR looks to move the creation of `JoinNode` and `DataSourceNode` out of the `Analyzer` and into the `LogicalPlanner`. The `LogicalPlanner` is now responsible for creating all logical node types.

Main changes:
* Rather than creating the `JoinNode` the `Analyzer` now builds a `JoinInfo`, which is stored in `Analysis`. `LogicalPlanner` uses this info to build the `JoinNode`.
* Rather than creating the `DataSourceNode` the `Analyzer` now stores a `AliasedDataSource` in `Analysis`. `LogicalPlanner` uses this info to build the `DataSourceNode`(s).
* `Analyzer` resolves all the columns in a `SELECT *`  using the schemas of all the source(s) involved, rather than using the schemas of the source logical nodes.
* The `Analyzer` now passes the list of sources to `ExpressionAnalyzer`, rather than building what it thinks should be the resulting schema of the first node in the logical plan, (i.e. either `JoinNode` or `DataSourceNode`).  The job of `ExpressionAnalyzer` is to find column references that can't be resolved.  I've beefed up this functionality with a view to removing the same functionality from the parser at some point.
* I've simplified `JoinNode`s constructor parameters: the aliases and datasource type are available from the supplied `DataSourceNode`, so no need to pass them separately.
* I've removed some getters from `JoinNode` as the only callers where in `JoinNode` itself or its test.

### Testing done 

Added a few additional QTT tests to ensure error messages are sensible. 

Removed some tests that either tested getters that weren't needed, (e.g. in `JoinNode`) or duplicated other tests, (e.g. in `QueryAnalyzerTest`, which has the same test in `AnalyzerTest`).

`mvn test`.

### Reviewer checklist
- [ ] Ensure docs are updated if necessary. (eg. if a user visible feature is being added or changed).
- [ ] Ensure relevant issues are linked (description should include text like "Fixes #<issue number>")

