### PR TITLE
build: remove `npm install` from `mvn package`

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -118,7 +118,9 @@ Examples that could make sense for KSQL include "parser", "analyzer", "rest serv
 "cli", "processing log", and "metrics", to name a few.
 
 The optional body and footer are for specifying additional information, such as linking to issues fixed by the commit
-or drawing attention to breaking changes.
+or drawing attention to [breaking changes](#breaking-changes).
+
+##### Breaking changes
 
 A commit is a "breaking change" if users should expect different behavior from an existing workflow
 as a result of the change. Examples of breaking changes include deprecation of existing configs or APIs,
@@ -141,6 +143,14 @@ Breaking changes must be called out in commit messages, PR descriptions, and upg
 
  * [Upgrade notes][https://github.com/confluentinc/ksql/blob/master/docs/installation/upgrading.rst]
    should also be updated as part of the same PR.
+
+##### Commitlint
+
+This project has [commitlint][https://github.com/conventional-changelog/commitlint] configured
+to ensure that commit messages are of the expected format.
+To enable commitlint, run either `mvn clean package -DskipTests` (to build KSQL locally) or
+`npm install` (if you already have `npm` installed).
+Once enabled, commitlint will reject commits with improperly formatted commit messages.
 
 ### GitHub Workflow
 
@@ -216,7 +226,10 @@ Breaking changes must be called out in commit messages, PR descriptions, and upg
 
    - Give your pull-request a meaningful title that conforms to the Conventional Commits specification
      as described [above](#commit-messages) for commit messages.
-   - In the description, explain your changes and the problem they are solving.
+     You'll know your title is properly formatted once the `Semantic Pull Request` GitHub check
+     transitions from a status of "pending" to "passed".
+   - In the description, explain your changes and the problem they are solving. Be sure to also call out
+     any breaking changes as described [above](#breaking-changes).
 
 9. Addressing code review comments
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -148,8 +148,7 @@ Breaking changes must be called out in commit messages, PR descriptions, and upg
 
 This project has [commitlint][https://github.com/conventional-changelog/commitlint] configured
 to ensure that commit messages are of the expected format.
-To enable commitlint, run either `mvn clean package -DskipTests` (to build KSQL locally) or
-`npm install` (if you already have `npm` installed).
+To enable commitlint, simply run `npm install` (requires [`npm`][https://www.npmjs.com/get-npm]).
 Once enabled, commitlint will reject commits with improperly formatted commit messages.
 
 ### GitHub Workflow

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -148,7 +148,8 @@ Breaking changes must be called out in commit messages, PR descriptions, and upg
 
 This project has [commitlint][https://github.com/conventional-changelog/commitlint] configured
 to ensure that commit messages are of the expected format.
-To enable commitlint, simply run `npm install` (requires [`npm`][https://www.npmjs.com/get-npm]).
+To enable commitlint, simply run `npm install` from the root directory of the KSQL repo
+(after [installing `npm`][https://www.npmjs.com/get-npm].)
 Once enabled, commitlint will reject commits with improperly formatted commit messages.
 
 ### GitHub Workflow

--- a/pom.xml
+++ b/pom.xml
@@ -93,7 +93,6 @@
         <airline.version>2.6.0</airline.version>
         <antlr.version>4.7</antlr.version>
         <csv.version>1.4</csv.version>
-        <frontend.maven.plugin.version>1.6</frontend.maven.plugin.version>
         <lang3.version>3.3.1</lang3.version>
         <guava.version>24.0-jre</guava.version>
         <inject.version>1</inject.version>
@@ -102,7 +101,6 @@
         <jna.version>4.4.0</jna.version>
         <jsr305.version>3.0.2</jsr305.version>
         <maven.plugins.version>3.0.0-M1</maven.plugins.version>
-        <node.version>v10.12.0</node.version>
         <really.executable.jar.version>1.5.0</really.executable.jar.version>
         <generext.version>1.0.2</generext.version>
         <avro.random.generator.version>0.2.2</avro.random.generator.version>
@@ -415,30 +413,6 @@
                         </goals>
                     </execution>
                 </executions>
-            </plugin>
-
-            <plugin>
-                <groupId>com.github.eirslett</groupId>
-                <artifactId>frontend-maven-plugin</artifactId>
-                <version>${frontend.maven.plugin.version}</version>
-                <inherited>false</inherited>
-                <executions>
-                    <execution>
-                        <id>install node and npm</id>
-                        <goals>
-                            <goal>install-node-and-npm</goal>
-                        </goals>
-                    </execution>
-                    <execution>
-                        <id>npm install</id>
-                        <goals>
-                            <goal>npm</goal>
-                        </goals>
-                    </execution>
-                </executions>
-                <configuration>
-                    <nodeVersion>${node.version}</nodeVersion>
-                </configuration>
             </plugin>
         </plugins>
     </build>


### PR DESCRIPTION
### Description 

Following up on https://github.com/confluentinc/ksql/pull/3008/, this PR does two things:

- removes `npm install` from our Maven build, since I couldn't find a way to get Husky to use the local npm installed by maven-frontend-plugin. To enable commitlint, users should have `npm` and run `npm install` from the KSQL root directory, rather than relying on `mvn package`.
- adds a section on commitlint to CONTRIBUTING.md.

### Testing done 

`mvn clean package` and manual testing of commitlint.

### Reviewer checklist
- [ ] Ensure docs are updated if necessary. (eg. if a user visible feature is being added or changed).
- [ ] Ensure relevant issues are linked (description should include text like "Fixes #<issue number>")

