### PR TITLE
refactor: improve reserve words handling

### DIFF
--- a/ksql-common/src/main/java/io/confluent/ksql/function/UdfIndex.java
+++ b/ksql-common/src/main/java/io/confluent/ksql/function/UdfIndex.java
@@ -86,6 +86,8 @@ public class UdfIndex<T extends IndexedFunction> {
   // the best candidate (e.g. foo(null, int) matches B, C and E).
 
   private static final Logger LOG = LoggerFactory.getLogger(UdfIndex.class);
+  private static final SqlSchemaFormatter FORMATTER =
+      new SqlSchemaFormatter(word -> false);
 
   private final String udfName;
   private final Node root = new Node();
@@ -177,7 +179,7 @@ public class UdfIndex<T extends IndexedFunction> {
     final String sqlParamTypes = paramTypes.stream()
         .map(schema -> schema == null
             ? null
-            : SqlSchemaFormatter.DEFAULT.format(schema))
+            : FORMATTER.format(schema))
         .collect(Collectors.joining(", ", "[", "]"));
 
     return new KsqlException("Function '" + udfName
@@ -318,7 +320,7 @@ public class UdfIndex<T extends IndexedFunction> {
 
     @Override
     public String toString() {
-      return SqlSchemaFormatter.DEFAULT.format(schema) + (isVararg ? "(VARARG)" : "");
+      return FORMATTER.format(schema) + (isVararg ? "(VARARG)" : "");
     }
   }
 

--- a/ksql-common/src/main/java/io/confluent/ksql/schema/ksql/FormatOptions.java
+++ b/ksql-common/src/main/java/io/confluent/ksql/schema/ksql/FormatOptions.java
@@ -1,0 +1,59 @@
+/*
+ * Copyright 2019 Confluent Inc.
+ *
+ * Licensed under the Confluent Community License (the "License"); you may not use
+ * this file except in compliance with the License.  You may obtain a copy of the
+ * License at
+ *
+ * http://www.confluent.io/confluent-community-license
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package io.confluent.ksql.schema.ksql;
+
+import static java.util.Objects.requireNonNull;
+
+import java.util.function.Predicate;
+
+public final class FormatOptions {
+
+  private final Predicate<String> reservedWordPredicate;
+
+  public static FormatOptions none() {
+    return new FormatOptions(word -> true);
+  }
+
+  /**
+   * Construct instance.
+   *
+   <p>The {@code reservedWordPredicate} allows code that lives in the common module
+   * to be wired up to the set of reserved words defined in the parser module. Wire this up to
+   * {@code ParserUtil::isReservedWord}.
+   *
+   * <p>If using this type in a module that does <i>not</i> have access to the parser, then the
+   * <i>safest</i> option is to pass in predicate that always returns true, which will always
+   * escape field names by wrapping them in back quotes.
+   *
+   * <p>Where the predicate returns {@code true} a field name will be escaped by enclosing in
+   * quotes. NB: this also makes the field name case-sensitive. So care must be taken to ensure
+   * field names have the correct case.
+   *
+   * @param reservedWordPredicate predicate to test if a word is a reserved in SQL syntax.
+   * @return instance of {@code FormatOptions}.
+   */
+  public static FormatOptions of(final Predicate<String> reservedWordPredicate) {
+    return new FormatOptions(reservedWordPredicate);
+  }
+
+  private FormatOptions(final Predicate<String> fieldNameEscaper) {
+    this.reservedWordPredicate = requireNonNull(fieldNameEscaper, "reservedWordPredicate");
+  }
+
+  public boolean isReservedWord(final String word) {
+    return reservedWordPredicate.test(word);
+  }
+}

--- a/ksql-common/src/main/java/io/confluent/ksql/schema/ksql/FormatOptions.java
+++ b/ksql-common/src/main/java/io/confluent/ksql/schema/ksql/FormatOptions.java
@@ -30,7 +30,7 @@ public final class FormatOptions {
   /**
    * Construct instance.
    *
-   <p>The {@code reservedWordPredicate} allows code that lives in the common module
+   * <p>The {@code reservedWordPredicate} allows code that lives in the common module
    * to be wired up to the set of reserved words defined in the parser module. Wire this up to
    * {@code ParserUtil::isReservedWord}.
    *

--- a/ksql-common/src/main/java/io/confluent/ksql/schema/ksql/LogicalSchema.java
+++ b/ksql-common/src/main/java/io/confluent/ksql/schema/ksql/LogicalSchema.java
@@ -58,8 +58,6 @@ import org.apache.kafka.connect.data.SchemaBuilder;
 @Immutable
 public final class LogicalSchema {
 
-  private static final SqlSchemaFormatter FORMATTER = new SqlSchemaFormatter(Option.AS_COLUMN_LIST);
-
   private static final Schema METADATA_SCHEMA = SchemaBuilder
       .struct()
       .field(SchemaUtil.ROWTIME_NAME, Schema.OPTIONAL_INT64_SCHEMA)
@@ -322,7 +320,14 @@ public final class LogicalSchema {
 
   @Override
   public String toString() {
-    return "[" + FORMATTER.format(valueSchema) + "]";
+    return toString(FormatOptions.none());
+  }
+
+  public String toString(final FormatOptions formatOptions) {
+    final SqlSchemaFormatter formatter = new SqlSchemaFormatter(
+        formatOptions::isReservedWord, Option.AS_COLUMN_LIST);
+
+    return "[" + formatter.format(valueSchema) + "]";
   }
 
   private Set<String> metaFieldNames() {

--- a/ksql-common/src/main/java/io/confluent/ksql/schema/ksql/PersistenceSchema.java
+++ b/ksql-common/src/main/java/io/confluent/ksql/schema/ksql/PersistenceSchema.java
@@ -17,6 +17,7 @@ package io.confluent.ksql.schema.ksql;
 
 import com.google.errorprone.annotations.Immutable;
 import io.confluent.ksql.schema.connect.SqlSchemaFormatter;
+import io.confluent.ksql.schema.connect.SqlSchemaFormatter.Option;
 import java.util.Objects;
 import org.apache.kafka.connect.data.ConnectSchema;
 
@@ -33,6 +34,9 @@ import org.apache.kafka.connect.data.ConnectSchema;
  */
 @Immutable
 public final class PersistenceSchema {
+
+  private static final SqlSchemaFormatter FORMATTER =
+      new SqlSchemaFormatter(word -> false, Option.APPEND_NOT_NULL);
 
   private final ConnectSchema connectSchema;
 
@@ -67,6 +71,6 @@ public final class PersistenceSchema {
 
   @Override
   public String toString() {
-    return "Persistence{" + SqlSchemaFormatter.STRICT.format(connectSchema) + '}';
+    return "Persistence{" + FORMATTER.format(connectSchema) + '}';
   }
 }

--- a/ksql-common/src/test/java/io/confluent/ksql/schema/connect/SqlSchemaFormatterTest.java
+++ b/ksql-common/src/test/java/io/confluent/ksql/schema/connect/SqlSchemaFormatterTest.java
@@ -18,79 +18,88 @@ package io.confluent.ksql.schema.connect;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
 
-import com.google.common.collect.ImmutableSet;
 import io.confluent.ksql.schema.connect.SqlSchemaFormatter.Option;
 import io.confluent.ksql.util.DecimalUtil;
+import java.util.function.Predicate;
 import org.apache.kafka.connect.data.Schema;
 import org.apache.kafka.connect.data.SchemaBuilder;
 import org.junit.Test;
 
 public class SqlSchemaFormatterTest {
 
+  private static final Predicate<String> DO_NOT_ESCAPE_COLUMN_NAMES = word -> false;
+
+  private static final SqlSchemaFormatter DEFAULT =
+      new SqlSchemaFormatter(DO_NOT_ESCAPE_COLUMN_NAMES);
+
+  private static final SqlSchemaFormatter STRICT =
+      new SqlSchemaFormatter(DO_NOT_ESCAPE_COLUMN_NAMES, Option.APPEND_NOT_NULL);
+
+
   @Test
   public void shouldFormatBoolean() {
-    assertThat(SqlSchemaFormatter.DEFAULT.format(Schema.BOOLEAN_SCHEMA), is("BOOLEAN"));
-    assertThat(SqlSchemaFormatter.STRICT.format(Schema.BOOLEAN_SCHEMA), is("BOOLEAN NOT NULL"));
+    assertThat(DEFAULT.format(Schema.BOOLEAN_SCHEMA), is("BOOLEAN"));
+    assertThat(STRICT.format(Schema.BOOLEAN_SCHEMA), is("BOOLEAN NOT NULL"));
   }
 
   @Test
   public void shouldFormatOptionalBoolean() {
-    assertThat(SqlSchemaFormatter.DEFAULT.format(Schema.OPTIONAL_BOOLEAN_SCHEMA), is("BOOLEAN"));
-    assertThat(SqlSchemaFormatter.STRICT.format(Schema.OPTIONAL_BOOLEAN_SCHEMA), is("BOOLEAN"));
+    assertThat(DEFAULT.format(Schema.OPTIONAL_BOOLEAN_SCHEMA), is("BOOLEAN"));
+    assertThat(STRICT.format(Schema.OPTIONAL_BOOLEAN_SCHEMA), is("BOOLEAN"));
   }
 
   @Test
   public void shouldFormatInt() {
-    assertThat(SqlSchemaFormatter.DEFAULT.format(Schema.INT32_SCHEMA), is("INT"));
-    assertThat(SqlSchemaFormatter.STRICT.format(Schema.INT32_SCHEMA), is("INT NOT NULL"));
+    assertThat(DEFAULT.format(Schema.INT32_SCHEMA), is("INT"));
+    assertThat(STRICT.format(Schema.INT32_SCHEMA), is("INT NOT NULL"));
   }
 
   @Test
   public void shouldFormatOptionalInt() {
-    assertThat(SqlSchemaFormatter.DEFAULT.format(Schema.OPTIONAL_INT32_SCHEMA), is("INT"));
-    assertThat(SqlSchemaFormatter.STRICT.format(Schema.OPTIONAL_INT32_SCHEMA), is("INT"));
+    assertThat(DEFAULT.format(Schema.OPTIONAL_INT32_SCHEMA), is("INT"));
+    assertThat(STRICT.format(Schema.OPTIONAL_INT32_SCHEMA), is("INT"));
   }
 
   @Test
   public void shouldFormatBigint() {
-    assertThat(SqlSchemaFormatter.DEFAULT.format(Schema.INT64_SCHEMA), is("BIGINT"));
-    assertThat(SqlSchemaFormatter.STRICT.format(Schema.INT64_SCHEMA), is("BIGINT NOT NULL"));
+    assertThat(DEFAULT.format(Schema.INT64_SCHEMA), is("BIGINT"));
+    assertThat(STRICT.format(Schema.INT64_SCHEMA), is("BIGINT NOT NULL"));
   }
 
   @Test
   public void shouldFormatOptionalBigint() {
-    assertThat(SqlSchemaFormatter.DEFAULT.format(Schema.OPTIONAL_INT64_SCHEMA), is("BIGINT"));
-    assertThat(SqlSchemaFormatter.STRICT.format(Schema.OPTIONAL_INT64_SCHEMA), is("BIGINT"));
+    assertThat(DEFAULT.format(Schema.OPTIONAL_INT64_SCHEMA), is("BIGINT"));
+    assertThat(STRICT.format(Schema.OPTIONAL_INT64_SCHEMA), is("BIGINT"));
   }
 
   @Test
   public void shouldFormatDouble() {
-    assertThat(SqlSchemaFormatter.DEFAULT.format(Schema.FLOAT64_SCHEMA), is("DOUBLE"));
-    assertThat(SqlSchemaFormatter.STRICT.format(Schema.FLOAT64_SCHEMA), is("DOUBLE NOT NULL"));
+    assertThat(DEFAULT.format(Schema.FLOAT64_SCHEMA), is("DOUBLE"));
+    assertThat(STRICT.format(Schema.FLOAT64_SCHEMA), is("DOUBLE NOT NULL"));
   }
 
   @Test
   public void shouldFormatOptionalDouble() {
-    assertThat(SqlSchemaFormatter.DEFAULT.format(Schema.OPTIONAL_FLOAT64_SCHEMA), is("DOUBLE"));
-    assertThat(SqlSchemaFormatter.STRICT.format(Schema.OPTIONAL_FLOAT64_SCHEMA), is("DOUBLE"));
+    assertThat(DEFAULT.format(Schema.OPTIONAL_FLOAT64_SCHEMA), is("DOUBLE"));
+    assertThat(STRICT.format(Schema.OPTIONAL_FLOAT64_SCHEMA), is("DOUBLE"));
   }
 
   @Test
   public void shouldFormatString() {
-    assertThat(SqlSchemaFormatter.DEFAULT.format(Schema.STRING_SCHEMA), is("VARCHAR"));
-    assertThat(SqlSchemaFormatter.STRICT.format(Schema.STRING_SCHEMA), is("VARCHAR NOT NULL"));
+    assertThat(DEFAULT.format(Schema.STRING_SCHEMA), is("VARCHAR"));
+    assertThat(STRICT.format(Schema.STRING_SCHEMA), is("VARCHAR NOT NULL"));
   }
 
   @Test
   public void shouldFormatOptionalString() {
-    assertThat(SqlSchemaFormatter.DEFAULT.format(Schema.OPTIONAL_STRING_SCHEMA), is("VARCHAR"));
-    assertThat(SqlSchemaFormatter.STRICT.format(Schema.OPTIONAL_STRING_SCHEMA), is("VARCHAR"));
+    assertThat(DEFAULT.format(Schema.OPTIONAL_STRING_SCHEMA), is("VARCHAR"));
+    assertThat(STRICT.format(Schema.OPTIONAL_STRING_SCHEMA), is("VARCHAR"));
   }
 
   @Test
   public void shouldFormatDecimal() {
-    assertThat(SqlSchemaFormatter.DEFAULT.format(DecimalUtil.builder(2, 1).build()), is("DECIMAL(2, 1)"));
-    assertThat(SqlSchemaFormatter.STRICT.format(DecimalUtil.builder(2, 1).build()), is("DECIMAL(2, 1)"));
+    assertThat(DEFAULT.format(DecimalUtil.builder(2, 1).build()), is("DECIMAL(2, 1)"));
+    assertThat(STRICT.format(DecimalUtil.builder(2, 1).build()), is("DECIMAL(2, 1)"));
   }
 
   @Test
@@ -101,9 +110,9 @@ public class SqlSchemaFormatterTest {
         .build();
 
     // Then:
-    assertThat(SqlSchemaFormatter.DEFAULT.format(schema),
+    assertThat(DEFAULT.format(schema),
         is("ARRAY<DOUBLE>"));
-    assertThat(SqlSchemaFormatter.STRICT.format(schema),
+    assertThat(STRICT.format(schema),
         is("ARRAY<DOUBLE NOT NULL> NOT NULL"));
   }
 
@@ -116,9 +125,9 @@ public class SqlSchemaFormatterTest {
         .build();
 
     // Then:
-    assertThat(SqlSchemaFormatter.DEFAULT.format(schema),
+    assertThat(DEFAULT.format(schema),
         is("ARRAY<DOUBLE>"));
-    assertThat(SqlSchemaFormatter.STRICT.format(schema),
+    assertThat(STRICT.format(schema),
         is("ARRAY<DOUBLE>"));
   }
 
@@ -130,10 +139,10 @@ public class SqlSchemaFormatterTest {
         .build();
 
     // Then:
-    assertThat(SqlSchemaFormatter.DEFAULT.format(schema),
+    assertThat(DEFAULT.format(schema),
         is("MAP<VARCHAR, DOUBLE>"));
 
-    assertThat(SqlSchemaFormatter.STRICT.format(schema),
+    assertThat(STRICT.format(schema),
         is("MAP<VARCHAR NOT NULL, DOUBLE NOT NULL> NOT NULL"));
   }
 
@@ -146,8 +155,8 @@ public class SqlSchemaFormatterTest {
         .build();
 
     // Then:
-    assertThat(SqlSchemaFormatter.DEFAULT.format(schema), is("MAP<VARCHAR, DOUBLE>"));
-    assertThat(SqlSchemaFormatter.STRICT.format(schema), is("MAP<VARCHAR, DOUBLE>"));
+    assertThat(DEFAULT.format(schema), is("MAP<VARCHAR, DOUBLE>"));
+    assertThat(STRICT.format(schema), is("MAP<VARCHAR, DOUBLE>"));
   }
 
   @Test
@@ -164,14 +173,14 @@ public class SqlSchemaFormatterTest {
         .build();
 
     // Then:
-    assertThat(SqlSchemaFormatter.DEFAULT.format(structSchema), is(
+    assertThat(DEFAULT.format(structSchema), is(
         "STRUCT<"
             + "COL1 VARCHAR, "
             + "COL4 ARRAY<DOUBLE>, "
             + "COL5 MAP<VARCHAR, DOUBLE>"
             + ">"));
 
-    assertThat(SqlSchemaFormatter.STRICT.format(structSchema), is(
+    assertThat(STRICT.format(structSchema), is(
         "STRUCT<"
             + "COL1 VARCHAR NOT NULL, "
             + "COL4 ARRAY<DOUBLE NOT NULL> NOT NULL, "
@@ -189,12 +198,15 @@ public class SqlSchemaFormatterTest {
             .field("COL3", Schema.STRING_SCHEMA)
             .build())
         .build();
-    final SqlSchemaFormatter formatter = new SqlSchemaFormatter(ImmutableSet.of("COL1", "COL2", "COL3"));
+
+    final Predicate<String> escaper = name -> !name.equalsIgnoreCase("COL1");
+
+    final SqlSchemaFormatter formatter = new SqlSchemaFormatter(escaper);
 
     // Then:
     assertThat(formatter.format(structSchema), is(
         "STRUCT<"
-            + "`COL1` VARCHAR, "
+            + "COL1 VARCHAR, "
             + "`COL2` STRUCT<`COL3` VARCHAR>"
             + ">"));
   }
@@ -216,14 +228,14 @@ public class SqlSchemaFormatterTest {
         .build();
 
     // Then:
-    assertThat(SqlSchemaFormatter.DEFAULT.format(structSchema), is(
+    assertThat(DEFAULT.format(structSchema), is(
         "STRUCT<"
             + "COL1 VARCHAR, "
             + "COL4 ARRAY<DOUBLE>, "
             + "COL5 MAP<VARCHAR, DOUBLE>"
             + ">"));
 
-    assertThat(SqlSchemaFormatter.STRICT.format(structSchema), is(
+    assertThat(STRICT.format(structSchema), is(
         "STRUCT<"
             + "COL1 VARCHAR, "
             + "COL4 ARRAY<DOUBLE>, "
@@ -248,6 +260,7 @@ public class SqlSchemaFormatterTest {
         .build();
 
     final SqlSchemaFormatter formatter = new SqlSchemaFormatter(
+        DO_NOT_ESCAPE_COLUMN_NAMES,
         Option.AS_COLUMN_LIST,
         Option.APPEND_NOT_NULL
     );
@@ -278,6 +291,7 @@ public class SqlSchemaFormatterTest {
         .build();
 
     final SqlSchemaFormatter formatter = new SqlSchemaFormatter(
+        DO_NOT_ESCAPE_COLUMN_NAMES,
         Option.AS_COLUMN_LIST,
         Option.APPEND_NOT_NULL
     );

--- a/ksql-common/src/test/java/io/confluent/ksql/schema/ksql/LogicalSchemaTest.java
+++ b/ksql-common/src/test/java/io/confluent/ksql/schema/ksql/LogicalSchemaTest.java
@@ -574,14 +574,43 @@ public class LogicalSchemaTest {
     // Then:
     assertThat(s, is(
         "["
-            + "f0 BOOLEAN, "
-            + "f1 INT, "
-            + "f2 BIGINT, "
-            + "f4 DOUBLE, "
-            + "f5 VARCHAR, "
-            + "f6 STRUCT<a BIGINT>, "
-            + "f7 ARRAY<VARCHAR>, "
-            + "f8 MAP<VARCHAR, VARCHAR>"
+            + "`f0` BOOLEAN, "
+            + "`f1` INT, "
+            + "`f2` BIGINT, "
+            + "`f4` DOUBLE, "
+            + "`f5` VARCHAR, "
+            + "`f6` STRUCT<`a` BIGINT>, "
+            + "`f7` ARRAY<VARCHAR>, "
+            + "`f8` MAP<VARCHAR, VARCHAR>"
+            + "]"));
+  }
+
+  @Test
+  public void shouldConvertSchemaToStringWithReservedWords() {
+    // Given:
+    final LogicalSchema schema = LogicalSchema.of(
+        SchemaBuilder.struct()
+            .field("f0", SchemaBuilder.OPTIONAL_BOOLEAN_SCHEMA)
+            .field("f1", SchemaBuilder
+                .struct()
+                .field("f0", Schema.OPTIONAL_INT64_SCHEMA)
+                .field("f1", Schema.OPTIONAL_INT64_SCHEMA)
+                .optional()
+                .build())
+            .build()
+    );
+
+    final FormatOptions formatOptions =
+        FormatOptions.of(word -> word.equalsIgnoreCase("f0"));
+
+    // When:
+    final String s = schema.toString(formatOptions);
+
+    // Then:
+    assertThat(s, is(
+        "["
+            + "`f0` BOOLEAN, "
+            + "f1 STRUCT<`f0` BIGINT, f1 BIGINT>"
             + "]"));
   }
 
@@ -600,7 +629,7 @@ public class LogicalSchemaTest {
     // Then:
     assertThat(s, is(
         "["
-            + "t.f0 BOOLEAN"
+            + "`t.f0` BOOLEAN"
             + "]"));
   }
 

--- a/ksql-engine/src/main/java/io/confluent/ksql/physical/QuerySchemas.java
+++ b/ksql-engine/src/main/java/io/confluent/ksql/physical/QuerySchemas.java
@@ -19,6 +19,7 @@ import com.google.common.annotations.VisibleForTesting;
 import com.google.errorprone.annotations.Immutable;
 import io.confluent.ksql.schema.connect.SchemaFormatter;
 import io.confluent.ksql.schema.connect.SqlSchemaFormatter;
+import io.confluent.ksql.schema.connect.SqlSchemaFormatter.Option;
 import io.confluent.ksql.schema.ksql.PersistenceSchema;
 import java.util.LinkedHashMap;
 import java.util.Objects;
@@ -38,11 +39,14 @@ import java.util.stream.Collectors;
 @Immutable
 public final class QuerySchemas {
 
+  private static final SqlSchemaFormatter FORMATTER =
+      new SqlSchemaFormatter(word -> false, Option.APPEND_NOT_NULL);
+
   private final LinkedHashMap<String, PersistenceSchema> schemas;
   private final SchemaFormatter schemaFormatter;
 
   public static QuerySchemas of(final LinkedHashMap<String, PersistenceSchema> schemas) {
-    return new QuerySchemas(schemas, SqlSchemaFormatter.STRICT);
+    return new QuerySchemas(schemas, FORMATTER);
   }
 
   @VisibleForTesting

--- a/ksql-engine/src/main/java/io/confluent/ksql/schema/ksql/inference/DefaultSchemaInjector.java
+++ b/ksql-engine/src/main/java/io/confluent/ksql/schema/ksql/inference/DefaultSchemaInjector.java
@@ -52,7 +52,7 @@ import org.apache.kafka.connect.data.Schema;
 public class DefaultSchemaInjector implements Injector {
 
   private static final SqlSchemaFormatter FORMATTER = new SqlSchemaFormatter(
-      ParserUtil::isReservedWord, Option.AS_COLUMN_LIST);
+      ParserUtil::isReservedIdentifier, Option.AS_COLUMN_LIST);
 
   private final TopicSchemaSupplier schemaSupplier;
 

--- a/ksql-engine/src/main/java/io/confluent/ksql/schema/ksql/inference/DefaultSchemaInjector.java
+++ b/ksql-engine/src/main/java/io/confluent/ksql/schema/ksql/inference/DefaultSchemaInjector.java
@@ -52,7 +52,7 @@ import org.apache.kafka.connect.data.Schema;
 public class DefaultSchemaInjector implements Injector {
 
   private static final SqlSchemaFormatter FORMATTER = new SqlSchemaFormatter(
-      ParserUtil.RESERVED_WORDS, Option.AS_COLUMN_LIST);
+      ParserUtil::isReservedWord, Option.AS_COLUMN_LIST);
 
   private final TopicSchemaSupplier schemaSupplier;
 

--- a/ksql-engine/src/main/java/io/confluent/ksql/structured/SchemaKStream.java
+++ b/ksql-engine/src/main/java/io/confluent/ksql/structured/SchemaKStream.java
@@ -28,11 +28,13 @@ import io.confluent.ksql.metastore.model.KeyField;
 import io.confluent.ksql.parser.tree.DereferenceExpression;
 import io.confluent.ksql.parser.tree.Expression;
 import io.confluent.ksql.parser.tree.QualifiedNameReference;
+import io.confluent.ksql.schema.ksql.FormatOptions;
 import io.confluent.ksql.schema.ksql.LogicalSchema;
 import io.confluent.ksql.streams.StreamsFactories;
 import io.confluent.ksql.streams.StreamsUtil;
 import io.confluent.ksql.util.ExpressionMetadata;
 import io.confluent.ksql.util.KsqlConfig;
+import io.confluent.ksql.util.ParserUtil;
 import io.confluent.ksql.util.QueryLoggerUtil;
 import io.confluent.ksql.util.SchemaUtil;
 import io.confluent.ksql.util.SelectExpression;
@@ -62,6 +64,8 @@ import org.apache.kafka.streams.kstream.WindowedSerdes;
 @SuppressWarnings("OptionalUsedAsFieldOrParameterType")
 public class SchemaKStream<K> {
   // CHECKSTYLE_RULES.ON: ClassDataAbstractionCoupling
+
+  private static final FormatOptions FORMAT_OPTIONS = FormatOptions.of(ParserUtil::isReservedWord);
 
   public enum Type { SOURCE, PROJECT, FILTER, AGGREGATE, SINK, REKEY, JOIN }
 
@@ -697,7 +701,7 @@ public class SchemaKStream<K> {
     stringBuilder.append(indent)
         .append(" > [ ")
         .append(type).append(" ] | Schema: ")
-        .append(schema)
+        .append(schema.toString(FORMAT_OPTIONS))
         .append(" | Logger: ").append(QueryLoggerUtil.queryLoggerName(queryContext))
         .append("\n");
     for (final SchemaKStream schemaKStream : sourceSchemaKStreams) {

--- a/ksql-engine/src/main/java/io/confluent/ksql/structured/SchemaKStream.java
+++ b/ksql-engine/src/main/java/io/confluent/ksql/structured/SchemaKStream.java
@@ -65,7 +65,8 @@ import org.apache.kafka.streams.kstream.WindowedSerdes;
 public class SchemaKStream<K> {
   // CHECKSTYLE_RULES.ON: ClassDataAbstractionCoupling
 
-  private static final FormatOptions FORMAT_OPTIONS = FormatOptions.of(ParserUtil::isReservedWord);
+  private static final FormatOptions FORMAT_OPTIONS =
+      FormatOptions.of(ParserUtil::isReservedIdentifier);
 
   public enum Type { SOURCE, PROJECT, FILTER, AGGREGATE, SINK, REKEY, JOIN }
 

--- a/ksql-engine/src/test/java/io/confluent/ksql/physical/PhysicalPlanBuilderTest.java
+++ b/ksql-engine/src/test/java/io/confluent/ksql/physical/PhysicalPlanBuilderTest.java
@@ -398,9 +398,9 @@ public class PhysicalPlanBuilderTest {
     expectedException.expect(KsqlStatementException.class);
     expectedException.expect(rawMessage(is(
         "Incompatible schema between results and sink. Result schema is "
-            + "[COL0 BIGINT, COL1 VARCHAR, COL2 DOUBLE], "
+            + "[`COL0` BIGINT, `COL1` VARCHAR, `COL2` DOUBLE], "
             + "but the sink schema is "
-            + "[COL0 BIGINT, COL1 VARCHAR].")));
+            + "[`COL0` BIGINT, `COL1` VARCHAR].")));
 
     // When:
     execute(CREATE_STREAM_TEST1 + csasQuery + insertIntoQuery);

--- a/ksql-engine/src/test/java/io/confluent/ksql/schema/ksql/inference/DefaultSchemaInjectorFunctionalTest.java
+++ b/ksql-engine/src/test/java/io/confluent/ksql/schema/ksql/inference/DefaultSchemaInjectorFunctionalTest.java
@@ -35,6 +35,7 @@ import io.confluent.ksql.statement.ConfiguredStatement;
 import io.confluent.ksql.util.DecimalUtil;
 import io.confluent.ksql.util.KsqlConfig;
 import io.confluent.ksql.util.KsqlException;
+import io.confluent.ksql.util.ParserUtil;
 import org.apache.kafka.connect.data.Schema;
 import org.apache.kafka.connect.data.SchemaBuilder;
 import org.junit.Assert;
@@ -48,6 +49,9 @@ import org.mockito.junit.MockitoJUnitRunner;
 
 @RunWith(MockitoJUnitRunner.class)
 public class DefaultSchemaInjectorFunctionalTest {
+
+  private static final SqlSchemaFormatter FORMATTER =
+      new SqlSchemaFormatter(ParserUtil::isReservedWord);
 
   @Rule
   public final ExpectedException expectedException = ExpectedException.none();
@@ -523,8 +527,8 @@ public class DefaultSchemaInjectorFunctionalTest {
 
     final Schema actual = getSchemaForDdlStatement((CreateSource) withSchema);
 
-    Assert.assertThat(new SqlSchemaFormatter().format(actual),
-        equalTo(new SqlSchemaFormatter().format(expectedKqlSchema)));
+    Assert.assertThat(FORMATTER.format(actual),
+        equalTo(FORMATTER.format(expectedKqlSchema)));
     Assert.assertThat(actual, equalTo(expectedKqlSchema));
   }
 

--- a/ksql-engine/src/test/java/io/confluent/ksql/schema/ksql/inference/DefaultSchemaInjectorFunctionalTest.java
+++ b/ksql-engine/src/test/java/io/confluent/ksql/schema/ksql/inference/DefaultSchemaInjectorFunctionalTest.java
@@ -51,7 +51,7 @@ import org.mockito.junit.MockitoJUnitRunner;
 public class DefaultSchemaInjectorFunctionalTest {
 
   private static final SqlSchemaFormatter FORMATTER =
-      new SqlSchemaFormatter(ParserUtil::isReservedWord);
+      new SqlSchemaFormatter(ParserUtil::isReservedIdentifier);
 
   @Rule
   public final ExpectedException expectedException = ExpectedException.none();

--- a/ksql-parser/src/main/java/io/confluent/ksql/parser/ExpressionFormatter.java
+++ b/ksql-parser/src/main/java/io/confluent/ksql/parser/ExpressionFormatter.java
@@ -105,7 +105,7 @@ public final class ExpressionFormatter {
     protected String visitStruct(final Struct node, final Boolean unmangleNames) {
       return "STRUCT<" + Joiner.on(", ").join(node.getFields().stream()
           .map((child) ->
-              ParserUtil.escapeIfLiteral(child.getName())
+              ParserUtil.escapeIfReservedWord(child.getName())
                   + " " + process(child.getType(), unmangleNames))
           .collect(toList())) + ">";
     }

--- a/ksql-parser/src/main/java/io/confluent/ksql/parser/ExpressionFormatter.java
+++ b/ksql-parser/src/main/java/io/confluent/ksql/parser/ExpressionFormatter.java
@@ -105,7 +105,7 @@ public final class ExpressionFormatter {
     protected String visitStruct(final Struct node, final Boolean unmangleNames) {
       return "STRUCT<" + Joiner.on(", ").join(node.getFields().stream()
           .map((child) ->
-              ParserUtil.escapeIfReservedWord(child.getName())
+              ParserUtil.escapeIfReservedIdentifier(child.getName())
                   + " " + process(child.getType(), unmangleNames))
           .collect(toList())) + ">";
     }

--- a/ksql-parser/src/main/java/io/confluent/ksql/parser/SqlFormatter.java
+++ b/ksql-parser/src/main/java/io/confluent/ksql/parser/SqlFormatter.java
@@ -429,7 +429,7 @@ public final class SqlFormatter {
     }
 
     private static String formatTableElement(final TableElement e) {
-      return ParserUtil.escapeIfLiteral(e.getName())
+      return ParserUtil.escapeIfReservedWord(e.getName())
           + " "
           + e.getType();
     }

--- a/ksql-parser/src/main/java/io/confluent/ksql/parser/SqlFormatter.java
+++ b/ksql-parser/src/main/java/io/confluent/ksql/parser/SqlFormatter.java
@@ -429,7 +429,7 @@ public final class SqlFormatter {
     }
 
     private static String formatTableElement(final TableElement e) {
-      return ParserUtil.escapeIfReservedWord(e.getName())
+      return ParserUtil.escapeIfReservedIdentifier(e.getName())
           + " "
           + e.getType();
     }

--- a/ksql-parser/src/main/java/io/confluent/ksql/util/ParserUtil.java
+++ b/ksql-parser/src/main/java/io/confluent/ksql/util/ParserUtil.java
@@ -20,11 +20,14 @@ import static java.util.Objects.requireNonNull;
 import static java.util.stream.Collectors.toList;
 
 import com.google.common.collect.ImmutableSet;
+import io.confluent.ksql.parser.DefaultKsqlParser;
+import io.confluent.ksql.parser.KsqlParser;
 import io.confluent.ksql.parser.ParsingException;
 import io.confluent.ksql.parser.SqlBaseLexer;
 import io.confluent.ksql.parser.SqlBaseParser;
 import io.confluent.ksql.parser.SqlBaseParser.IntegerLiteralContext;
 import io.confluent.ksql.parser.SqlBaseParser.NumberContext;
+import io.confluent.ksql.parser.exception.ParseFailedException;
 import io.confluent.ksql.parser.tree.DoubleLiteral;
 import io.confluent.ksql.parser.tree.IntegerLiteral;
 import io.confluent.ksql.parser.tree.Literal;
@@ -35,6 +38,7 @@ import java.util.List;
 import java.util.Objects;
 import java.util.Optional;
 import java.util.Set;
+import java.util.function.Predicate;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 import org.antlr.v4.runtime.ParserRuleContext;
@@ -46,22 +50,39 @@ public final class ParserUtil {
   private ParserUtil() {
   }
 
-  private static final Set<String> RESERVED_WORDS = ImmutableSet.copyOf(
-      IntStream.range(0, SqlBaseLexer.VOCABULARY.getMaxTokenType())
-          .mapToObj(SqlBaseLexer.VOCABULARY::getLiteralName)
-          .filter(Objects::nonNull)
-          // literals start and end with ' - remove them
-          .map(l -> l.substring(1, l.length() - 1))
-          .map(String::toUpperCase)
-          .collect(Collectors.toSet())
-  );
+  private static final Set<String> RESERVED_WORDS;
 
-  public static boolean isReservedWord(final String name) {
+  static {
+    final KsqlParser parser = new DefaultKsqlParser();
+
+    final Predicate<String> isReservedWord = columnName -> {
+      try {
+        parser.parse(
+            "CREATE STREAM x (" + columnName + " INT) "
+                + "WITH(KAFKA_TOPIC='x', VALUE_FORMAT='JSON');");
+        return false;
+      } catch (final ParseFailedException e) {
+        return true;
+      }
+    };
+
+    final Set<String> reserved = IntStream.range(0, SqlBaseLexer.VOCABULARY.getMaxTokenType())
+        .mapToObj(SqlBaseLexer.VOCABULARY::getLiteralName)
+        .filter(Objects::nonNull)
+        .map(l -> l.substring(1, l.length() - 1)) // literals start and end with ' - remove them
+        .map(String::toUpperCase)
+        .filter(isReservedWord)
+        .collect(Collectors.toSet());
+
+    RESERVED_WORDS = ImmutableSet.copyOf(reserved);
+  }
+
+  public static boolean isReservedIdentifier(final String name) {
     return RESERVED_WORDS.contains(name.toUpperCase());
   }
 
-  public static String escapeIfReservedWord(final String name) {
-    return isReservedWord(name) ? "`" + name + "`" : name;
+  public static String escapeIfReservedIdentifier(final String name) {
+    return isReservedIdentifier(name) ? "`" + name + "`" : name;
   }
 
   public static String getIdentifierText(final SqlBaseParser.IdentifierContext context) {

--- a/ksql-parser/src/main/java/io/confluent/ksql/util/ParserUtil.java
+++ b/ksql-parser/src/main/java/io/confluent/ksql/util/ParserUtil.java
@@ -40,31 +40,13 @@ import java.util.stream.IntStream;
 import org.antlr.v4.runtime.ParserRuleContext;
 import org.antlr.v4.runtime.Token;
 import org.antlr.v4.runtime.tree.TerminalNode;
-import org.apache.commons.lang3.ObjectUtils;
 
 public final class ParserUtil {
-
-  public static final Set<String> RESERVED_WORDS;
-
-  static {
-    final ImmutableSet.Builder<String> reservedWords = new ImmutableSet.Builder<>();
-    for (int i = 1; i < SqlBaseParser.VOCABULARY.getMaxTokenType(); i++) {
-      final String name = ObjectUtils.firstNonNull(
-          SqlBaseParser.VOCABULARY.getLiteralName(i),
-          SqlBaseParser.VOCABULARY.getSymbolicName(i)
-      );
-      if (name == null) {
-        throw new IllegalStateException("Did not expect to unknown word in vocab at index " + i);
-      }
-      reservedWords.add(StringUtil.cleanQuotes(name));
-    }
-    RESERVED_WORDS = reservedWords.build();
-  }
 
   private ParserUtil() {
   }
 
-  private static final Set<String> LITERALS_SET = ImmutableSet.copyOf(
+  private static final Set<String> RESERVED_WORDS = ImmutableSet.copyOf(
       IntStream.range(0, SqlBaseLexer.VOCABULARY.getMaxTokenType())
           .mapToObj(SqlBaseLexer.VOCABULARY::getLiteralName)
           .filter(Objects::nonNull)
@@ -74,8 +56,12 @@ public final class ParserUtil {
           .collect(Collectors.toSet())
   );
 
-  public static String escapeIfLiteral(final String name) {
-    return LITERALS_SET.contains(name.toUpperCase()) ? "`" + name + "`" : name;
+  public static boolean isReservedWord(final String name) {
+    return RESERVED_WORDS.contains(name.toUpperCase());
+  }
+
+  public static String escapeIfReservedWord(final String name) {
+    return isReservedWord(name) ? "`" + name + "`" : name;
   }
 
   public static String getIdentifierText(final SqlBaseParser.IdentifierContext context) {

--- a/ksql-parser/src/test/java/io/confluent/ksql/parser/util/ParserUtilTest.java
+++ b/ksql-parser/src/test/java/io/confluent/ksql/parser/util/ParserUtilTest.java
@@ -16,6 +16,7 @@
 package io.confluent.ksql.parser.util;
 
 import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.is;
 import static org.junit.Assert.assertThat;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
@@ -94,6 +95,17 @@ public class ParserUtilTest {
 
     // When:
     ParserUtil.parseDecimalLiteral(decimalLiteralContext);
+  }
+
+  @Test
+  public void shouldHaveReservedLiteralInReservedSet() {
+    assertThat(ParserUtil.isReservedIdentifier("FROM"), is(true));
+  }
+
+  @Test
+  public void shouldExcludeNonReservedLiteralsFromReservedSet() {
+    // i.e. those in the "nonReserved" rule in SqlBase.g4
+    assertThat(ParserUtil.isReservedIdentifier("SHOW"), is(false));
   }
 
   private static void mockLocation(final ParserRuleContext ctx, final int line, final int col) {

--- a/ksql-parser/src/test/java/io/confluent/ksql/parser/util/ParserUtilTest.java
+++ b/ksql-parser/src/test/java/io/confluent/ksql/parser/util/ParserUtilTest.java
@@ -49,12 +49,12 @@ public class ParserUtilTest {
 
   @Test
   public void shouldEscapeStringIfLiteral() {
-    assertThat(ParserUtil.escapeIfLiteral("END"), equalTo("`END`"));
+    assertThat(ParserUtil.escapeIfReservedWord("END"), equalTo("`END`"));
   }
 
   @Test
   public void shouldNotEscapeStringIfNotLiteral() {
-    assertThat(ParserUtil.escapeIfLiteral("NOT_A_LITERAL"), equalTo("NOT_A_LITERAL"));
+    assertThat(ParserUtil.escapeIfReservedWord("NOT_A_LITERAL"), equalTo("NOT_A_LITERAL"));
   }
 
   @Test

--- a/ksql-parser/src/test/java/io/confluent/ksql/parser/util/ParserUtilTest.java
+++ b/ksql-parser/src/test/java/io/confluent/ksql/parser/util/ParserUtilTest.java
@@ -49,12 +49,12 @@ public class ParserUtilTest {
 
   @Test
   public void shouldEscapeStringIfLiteral() {
-    assertThat(ParserUtil.escapeIfReservedWord("END"), equalTo("`END`"));
+    assertThat(ParserUtil.escapeIfReservedIdentifier("END"), equalTo("`END`"));
   }
 
   @Test
   public void shouldNotEscapeStringIfNotLiteral() {
-    assertThat(ParserUtil.escapeIfReservedWord("NOT_A_LITERAL"), equalTo("NOT_A_LITERAL"));
+    assertThat(ParserUtil.escapeIfReservedIdentifier("NOT_A_LITERAL"), equalTo("NOT_A_LITERAL"));
   }
 
   @Test

--- a/ksql-rest-app/src/main/java/io/confluent/ksql/rest/server/execution/DescribeFunctionExecutor.java
+++ b/ksql-rest-app/src/main/java/io/confluent/ksql/rest/server/execution/DescribeFunctionExecutor.java
@@ -28,12 +28,16 @@ import io.confluent.ksql.rest.entity.KsqlEntity;
 import io.confluent.ksql.schema.connect.SqlSchemaFormatter;
 import io.confluent.ksql.services.ServiceContext;
 import io.confluent.ksql.statement.ConfiguredStatement;
+import io.confluent.ksql.util.ParserUtil;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
 import org.apache.kafka.connect.data.Schema;
 
 public final class DescribeFunctionExecutor {
+
+  private static final SqlSchemaFormatter FORMATTER =
+      new SqlSchemaFormatter(ParserUtil::isReservedWord);
 
   private DescribeFunctionExecutor() { }
 
@@ -113,11 +117,11 @@ public final class DescribeFunctionExecutor {
     for (int i = 0; i < argTypes.size(); i++) {
       final Schema s = argTypes.get(i);
       final boolean isVariadic = variadic && i == (argTypes.size() - 1);
-      final String sqlType = SqlSchemaFormatter.DEFAULT.format(isVariadic ? s.valueSchema() : s);
+      final String sqlType = FORMATTER.format(isVariadic ? s.valueSchema() : s);
       args.add(new ArgumentInfo(s.name(), sqlType, s.doc(), isVariadic));
     }
 
-    final String returnType = SqlSchemaFormatter.DEFAULT.format(returnTypeSchema);
+    final String returnType = FORMATTER.format(returnTypeSchema);
 
     return new FunctionInfo(args, returnType, description);
   }

--- a/ksql-rest-app/src/main/java/io/confluent/ksql/rest/server/execution/DescribeFunctionExecutor.java
+++ b/ksql-rest-app/src/main/java/io/confluent/ksql/rest/server/execution/DescribeFunctionExecutor.java
@@ -37,7 +37,7 @@ import org.apache.kafka.connect.data.Schema;
 public final class DescribeFunctionExecutor {
 
   private static final SqlSchemaFormatter FORMATTER =
-      new SqlSchemaFormatter(ParserUtil::isReservedWord);
+      new SqlSchemaFormatter(ParserUtil::isReservedIdentifier);
 
   private DescribeFunctionExecutor() { }
 

--- a/ksql-rest-app/src/main/java/io/confluent/ksql/rest/util/ProcessingLogServerUtils.java
+++ b/ksql-rest-app/src/main/java/io/confluent/ksql/rest/util/ProcessingLogServerUtils.java
@@ -28,6 +28,7 @@ import io.confluent.ksql.schema.connect.SqlSchemaFormatter;
 import io.confluent.ksql.schema.connect.SqlSchemaFormatter.Option;
 import io.confluent.ksql.services.KafkaTopicClient;
 import io.confluent.ksql.util.KsqlConfig;
+import io.confluent.ksql.util.ParserUtil;
 import java.util.Optional;
 import org.apache.kafka.connect.data.Schema;
 import org.apache.kafka.connect.data.SchemaAndValue;
@@ -38,7 +39,7 @@ public final class ProcessingLogServerUtils {
 
   private static final Logger LOGGER = LoggerFactory.getLogger(ProcessingLogServerUtils.class);
   private static final SqlSchemaFormatter FORMATTER =
-      new SqlSchemaFormatter(word -> false, Option.AS_COLUMN_LIST);
+      new SqlSchemaFormatter(ParserUtil::isReservedIdentifier, Option.AS_COLUMN_LIST);
 
   private ProcessingLogServerUtils() {
   }

--- a/ksql-rest-app/src/main/java/io/confluent/ksql/rest/util/ProcessingLogServerUtils.java
+++ b/ksql-rest-app/src/main/java/io/confluent/ksql/rest/util/ProcessingLogServerUtils.java
@@ -37,6 +37,8 @@ import org.slf4j.LoggerFactory;
 public final class ProcessingLogServerUtils {
 
   private static final Logger LOGGER = LoggerFactory.getLogger(ProcessingLogServerUtils.class);
+  private static final SqlSchemaFormatter FORMATTER =
+      new SqlSchemaFormatter(word -> false, Option.AS_COLUMN_LIST);
 
   private ProcessingLogServerUtils() {
   }
@@ -100,7 +102,7 @@ public final class ProcessingLogServerUtils {
   ) {
     final Schema schema = getMessageSchema();
 
-    final String elements = new SqlSchemaFormatter(Option.AS_COLUMN_LIST).format(schema);
+    final String elements = FORMATTER.format(schema);
 
     final String createStreamSql = "CREATE STREAM " + name
         + " (" + elements + ")"

--- a/ksql-serde/src/main/java/io/confluent/ksql/serde/json/KsqlJsonDeserializer.java
+++ b/ksql-serde/src/main/java/io/confluent/ksql/serde/json/KsqlJsonDeserializer.java
@@ -43,6 +43,7 @@ import org.slf4j.LoggerFactory;
 public class KsqlJsonDeserializer implements Deserializer<Object> {
 
   private static final Logger LOG = LoggerFactory.getLogger(KsqlJsonDeserializer.class);
+  private static final SqlSchemaFormatter FORMATTER = new SqlSchemaFormatter(word -> false);
 
   private static final Map<Schema.Type, Function<JsonValueContext, Object>> HANDLERS = ImmutableMap
       .<Schema.Type, Function<JsonValueContext, Object>>builder()
@@ -215,7 +216,7 @@ public class KsqlJsonDeserializer implements Deserializer<Object> {
   ) {
     throw JsonSerdeUtils.invalidConversionException(
         value,
-        SqlSchemaFormatter.DEFAULT.format(schema)
+        FORMATTER.format(schema)
     );
   }
 


### PR DESCRIPTION
### Description 

While working in the area I noticed `ParserUtil` has two sets of the parsers reserved words. Let's remove one.  The only difference between the two is that one includes just literals and the other literals and symbols.  AFAICT symbols are never reserved words. Symbols are things like: `DIGIT_IDENTIFIER` and `QUOTED_IDENTIFIER`. 

`SqlSchemaFormatter` takes an optional set of reserved words.  `ParserUtil` now exposes a function to check if a word is reserved or not. So I've refactored the formatter to take a predicate.  While doing so I've removed the default constructor and static instances, which didn't take the set of reserved words, and just assumed none were reserved. This is a potentially dangerous assumption, that could lead to bugs. Hence removing this and creating instances where needed in the code. Some of these instances continue to assume there are no reserved words. Fixing these is outside the scope of this change, but can at least now be fixed one-by-one.

The second commit takes this one step more.  The `SqlBase.g4` antlr file defines a `nonReserved` rule that makes some of the literals used in the rules valid identifiers, e.g. `TIME`.  Previously, the code would treat these as reserved.  Unfortunately, there is no way to easy way to get this set of literals out of `nonReserved` in Java code.  So I've changed `ParserUtil` to filter the set of reserved words, removing any that don't result in a parsing error when they are used as an identifier.

### Testing done 

`mvn test`.

### Reviewer checklist
- [ ] Ensure docs are updated if necessary. (eg. if a user visible feature is being added or changed).
- [ ] Ensure relevant issues are linked (description should include text like "Fixes #<issue number>")

