### PR TITLE
test(qtt): add test coverage in QTT for the SqlSchemaFormatter

### DIFF
--- a/ksql-engine/src/test/java/io/confluent/ksql/engine/KsqlEngineTest.java
+++ b/ksql-engine/src/test/java/io/confluent/ksql/engine/KsqlEngineTest.java
@@ -231,8 +231,8 @@ public class KsqlEngineTest {
 
     // Then:
     assertThat(queries, hasSize(2));
-    assertThat(queries.get(0).getStatementString(), containsString("create stream foo as"));
-    assertThat(queries.get(1).getStatementString(), containsString("create stream bar as"));
+    assertThat(queries.get(0).getStatementString(), containsString("CREATE STREAM FOO"));
+    assertThat(queries.get(1).getStatementString(), containsString("CREATE STREAM BAR"));
   }
 
   @Test(expected = ParseFailedException.class)

--- a/ksql-engine/src/test/java/io/confluent/ksql/engine/KsqlEngineTestUtil.java
+++ b/ksql-engine/src/test/java/io/confluent/ksql/engine/KsqlEngineTestUtil.java
@@ -115,8 +115,10 @@ public final class KsqlEngineTestUtil {
         schemaInjector
             .map(injector -> injector.inject(configured))
             .orElse((ConfiguredStatement) configured);
+    final ConfiguredStatement<?> reformatted =
+        new SqlFormatInjector(executionContext).inject(withSchema);
     try {
-      return executionContext.execute(new SqlFormatInjector(executionContext).inject(withSchema));
+      return executionContext.execute(reformatted);
     } catch (final KsqlStatementException e) {
       // use the original statement text in the exception so that tests
       // can easily check that the failed statement is the input statement

--- a/ksql-engine/src/test/java/io/confluent/ksql/engine/SqlFormatInjector.java
+++ b/ksql-engine/src/test/java/io/confluent/ksql/engine/SqlFormatInjector.java
@@ -1,0 +1,51 @@
+/*
+ * Copyright 2019 Confluent Inc.
+ *
+ * Licensed under the Confluent Community License (the "License"; you may not use
+ * this file except in compliance with the License. You may obtain a copy of the
+ * License at
+ *
+ * http://www.confluent.io/confluent-community-license
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package io.confluent.ksql.engine;
+
+import io.confluent.ksql.KsqlExecutionContext;
+import io.confluent.ksql.parser.KsqlParser.PreparedStatement;
+import io.confluent.ksql.parser.SqlFormatter;
+import io.confluent.ksql.parser.tree.Statement;
+import io.confluent.ksql.statement.ConfiguredStatement;
+import io.confluent.ksql.statement.Injector;
+import java.util.Objects;
+
+public class SqlFormatInjector implements Injector {
+
+  private final KsqlExecutionContext executionContext;
+
+  public SqlFormatInjector(final KsqlExecutionContext executionContext) {
+    this.executionContext = Objects.requireNonNull(executionContext, "executionContext");
+  }
+
+  @SuppressWarnings("unchecked")
+  @Override
+  public <T extends Statement> ConfiguredStatement<T> inject(
+      final ConfiguredStatement<T> statement
+  ) {
+    try {
+      final Statement node = statement.getStatement();
+      final String sql = SqlFormatter.formatSql(node);
+      final String sqlWithSemiColon = sql.endsWith(";") ? sql : sql + ";";
+      final PreparedStatement<?> prepare = executionContext
+          .prepare(executionContext.parse(sqlWithSemiColon).get(0));
+
+      return statement.withStatement(sql, (T) prepare.getStatement());
+    } catch (final Exception e) {
+      return statement;
+    }
+  }
+}


### PR DESCRIPTION
### Description 
#3027 discovered some pretty bad holes in our QTT tests - namely our production environment executes a query _after_ it was formatted, but QTT tests execute the pre-formatted query. This change is a stop-gap bandaid that makes sure that all of our tests that go through the EndToEndExecutionUtil will use the formatted query.

### Testing done 
- ran all the tests. the windowed QTT tests failed before applying #3027 but succeeded afterwards.

### Reviewer checklist
- [ ] Ensure docs are updated if necessary. (eg. if a user visible feature is being added or changed).
- [ ] Ensure relevant issues are linked (description should include text like "Fixes #<issue number>")

