### PR TITLE
feat: Enforce availability of the streams state directory.

### DIFF
--- a/ksql-rest-app/src/main/java/io/confluent/ksql/rest/server/KsqlServerMain.java
+++ b/ksql-rest-app/src/main/java/io/confluent/ksql/rest/server/KsqlServerMain.java
@@ -50,8 +50,9 @@ public class KsqlServerMain {
       );
 
       final String installDir = properties.getOrDefault("ksql.server.install.dir", "");
-      final String streamsStateDirPath = StreamsConfig.configDef().defaultValues()
-          .get(StreamsConfig.STATE_DIR_CONFIG).toString();
+      final String streamsStateDirPath = properties.getOrDefault("ksql.streams.state.dir",
+          StreamsConfig.configDef().defaultValues()
+              .get(StreamsConfig.STATE_DIR_CONFIG).toString());
       enforceStreamStateDirAvailability(new File(streamsStateDirPath));
       final Optional<String> queriesFile = serverOptions.getQueriesFile(properties);
       final Executable executable = createExecutable(properties, queriesFile, installDir);

--- a/ksql-rest-app/src/main/java/io/confluent/ksql/rest/server/KsqlServerMain.java
+++ b/ksql-rest-app/src/main/java/io/confluent/ksql/rest/server/KsqlServerMain.java
@@ -50,7 +50,8 @@ public class KsqlServerMain {
       );
 
       final String installDir = properties.getOrDefault("ksql.server.install.dir", "");
-      final String streamsStateDirPath = properties.getOrDefault("ksql.streams.state.dir",
+      final String streamsStateDirPath = properties.getOrDefault(
+          KsqlConfig.KSQL_STREAMS_PREFIX + StreamsConfig.STATE_DIR_CONFIG,
           StreamsConfig.configDef().defaultValues()
               .get(StreamsConfig.STATE_DIR_CONFIG).toString());
       enforceStreamStateDirAvailability(new File(streamsStateDirPath));

--- a/ksql-rest-app/src/test/java/io/confluent/ksql/rest/server/KsqlServerMainTest.java
+++ b/ksql-rest-app/src/test/java/io/confluent/ksql/rest/server/KsqlServerMainTest.java
@@ -48,6 +48,10 @@ public class KsqlServerMainTest {
   @Before
   public void setUp() {
     main = new KsqlServerMain(executable);
+    when(mockStreamsStateDir.exists()).thenReturn(true);
+    when(mockStreamsStateDir.isDirectory()).thenReturn(true);
+    when(mockStreamsStateDir.canWrite()).thenReturn(true);
+    when(mockStreamsStateDir.getPath()).thenReturn("/var/lib/kafka-streams");
   }
 
   @Test
@@ -90,7 +94,6 @@ public class KsqlServerMainTest {
   public void shouldFailIfStreamsStateDirectoryDoesNotExist() {
     // Given:
     when(mockStreamsStateDir.exists()).thenReturn(false);
-    when(mockStreamsStateDir.getPath()).thenReturn("/var/lib/kafka-streams");
 
     expectedException.expect(KsqlServerException.class);
     expectedException.expectMessage(
@@ -105,9 +108,7 @@ public class KsqlServerMainTest {
   @Test
   public void shouldFailIfStreamsStateDirectoryIsNotDirectory() {
     // Given:
-    when(mockStreamsStateDir.exists()).thenReturn(true);
     when(mockStreamsStateDir.exists()).thenReturn(false);
-    when(mockStreamsStateDir.getPath()).thenReturn("/var/lib/kafka-streams");
 
     expectedException.expect(KsqlServerException.class);
     expectedException.expectMessage(
@@ -121,10 +122,7 @@ public class KsqlServerMainTest {
   @Test
   public void shouldFailIfStreamsStateDirectoryIsNotWritable() {
     // Given:
-    when(mockStreamsStateDir.exists()).thenReturn(true);
-    when(mockStreamsStateDir.isDirectory()).thenReturn(true);
     when(mockStreamsStateDir.canWrite()).thenReturn(false);
-    when(mockStreamsStateDir.getPath()).thenReturn("/var/lib/kafka-streams");
 
     expectedException.expect(KsqlServerException.class);
     expectedException.expectMessage(

--- a/ksql-rest-app/src/test/java/io/confluent/ksql/rest/server/KsqlServerMainTest.java
+++ b/ksql-rest-app/src/test/java/io/confluent/ksql/rest/server/KsqlServerMainTest.java
@@ -19,12 +19,18 @@ import static org.easymock.EasyMock.expectLastCall;
 import static org.easymock.EasyMock.replay;
 import static org.easymock.EasyMock.verify;
 import static org.junit.Assert.fail;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 
+import io.confluent.ksql.util.KsqlServerException;
+import java.io.File;
 import org.easymock.EasyMockRunner;
 import org.easymock.Mock;
 import org.easymock.MockType;
 import org.junit.Before;
+import org.junit.Rule;
 import org.junit.Test;
+import org.junit.rules.ExpectedException;
 import org.junit.runner.RunWith;
 
 @RunWith(EasyMockRunner.class)
@@ -33,6 +39,11 @@ public class KsqlServerMainTest {
 
   @Mock(MockType.NICE)
   private Executable executable;
+
+  private final File mockStreamsStateDir = mock(File.class);
+
+  @Rule
+  public final ExpectedException expectedException = ExpectedException.none();
 
   @Before
   public void setUp() {
@@ -73,5 +84,56 @@ public class KsqlServerMainTest {
 
     // Then:
     verify(executable);
+  }
+
+  @Test
+  public void shouldFailIfStreamsStateDirectoryDoesNotExist() {
+    // Given:
+    when(mockStreamsStateDir.exists()).thenReturn(false);
+    when(mockStreamsStateDir.getPath()).thenReturn("/var/lib/kafka-streams");
+
+    expectedException.expect(KsqlServerException.class);
+    expectedException.expectMessage(
+        "The kafka streams state directory does not exist: /var/lib/kafka-streams\n"
+            + " Make sure the directory exists and is writable for KSQL server.");
+
+    // When:
+    KsqlServerMain.enforceStreamStateDirAvailability(mockStreamsStateDir);
+
+  }
+
+  @Test
+  public void shouldFailIfStreamsStateDirectoryIsNotDirectory() {
+    // Given:
+    when(mockStreamsStateDir.exists()).thenReturn(true);
+    when(mockStreamsStateDir.exists()).thenReturn(false);
+    when(mockStreamsStateDir.getPath()).thenReturn("/var/lib/kafka-streams");
+
+    expectedException.expect(KsqlServerException.class);
+    expectedException.expectMessage(
+        "The kafka streams state directory does not exist: /var/lib/kafka-streams\n"
+            + " Make sure the directory exists and is writable for KSQL server.");
+
+    // When:
+    KsqlServerMain.enforceStreamStateDirAvailability(mockStreamsStateDir);
+  }
+
+  @Test
+  public void shouldFailIfStreamsStateDirectoryIsNotWritable() {
+    // Given:
+    when(mockStreamsStateDir.exists()).thenReturn(true);
+    when(mockStreamsStateDir.isDirectory()).thenReturn(true);
+    when(mockStreamsStateDir.canWrite()).thenReturn(false);
+    when(mockStreamsStateDir.getPath()).thenReturn("/var/lib/kafka-streams");
+
+    expectedException.expect(KsqlServerException.class);
+    expectedException.expectMessage(
+        "The kafka streams state directory is not writable for KSQL server:"
+            + " /var/lib/kafka-streams\n"
+            + " Make sure KSQL server has write access to this directory or change it to a writable"
+            + " one by setting `ksql.streams.state.dir` config in the properties file.");
+
+    // When:
+    KsqlServerMain.enforceStreamStateDirAvailability(mockStreamsStateDir);
   }
 }


### PR DESCRIPTION
Kafka Streams needs a local folder to write state related files. The default in CP is `/var/lib/kafka-streams`. This folder should exists and KSQL server should have write access to it. 
This PR enforces this when KSQL server starts. If the folder does not exist or is not writable, the server will show appropriate message and won't start.

Unit tests were added.
