### PR TITLE
feat(cli): print column names when issuing transient select

### DIFF
--- a/ksql-cli/src/main/java/io/confluent/ksql/cli/Cli.java
+++ b/ksql-cli/src/main/java/io/confluent/ksql/cli/Cli.java
@@ -32,8 +32,10 @@ import io.confluent.ksql.rest.client.KsqlRestClient.QueryStream;
 import io.confluent.ksql.rest.client.RestResponse;
 import io.confluent.ksql.rest.entity.CommandStatus;
 import io.confluent.ksql.rest.entity.CommandStatusEntity;
+import io.confluent.ksql.rest.entity.FieldInfo;
 import io.confluent.ksql.rest.entity.KsqlEntity;
 import io.confluent.ksql.rest.entity.KsqlEntityList;
+import io.confluent.ksql.rest.entity.QueryDescriptionEntity;
 import io.confluent.ksql.rest.entity.StreamedRow;
 import io.confluent.ksql.rest.server.resources.Errors;
 import io.confluent.ksql.util.ErrorMessageUtil;
@@ -323,6 +325,17 @@ public class Cli implements KsqlRequestExecutor, Closeable {
 
   @SuppressWarnings("try")
   private void handleStreamedQuery(final String query) throws IOException {
+    final RestResponse<KsqlEntityList> explainResponse = restClient
+        .makeKsqlRequest("EXPLAIN " + query);
+    if (!explainResponse.isSuccessful()) {
+      terminal.printErrorMessage(explainResponse.getErrorMessage());
+      return;
+    } else {
+      final QueryDescriptionEntity description =
+          (QueryDescriptionEntity) explainResponse.getResponse().get(0);
+      final List<FieldInfo> fields = description.getQueryDescription().getFields();
+      terminal.printRowHeader(fields);
+    }
 
     final RestResponse<KsqlRestClient.QueryStream> queryResponse =
         makeKsqlRequest(query, restClient::makeQueryRequest);

--- a/ksql-cli/src/main/java/io/confluent/ksql/cli/console/Console.java
+++ b/ksql-cli/src/main/java/io/confluent/ksql/cli/console/Console.java
@@ -331,6 +331,26 @@ public class Console implements Closeable {
     }
   }
 
+  public void printRowHeader(final List<FieldInfo> fields) throws IOException {
+    switch (outputFormat) {
+      case JSON:
+        printAsJson(fields);
+        break;
+      case TABULAR:
+        final String header = fields.stream()
+            .map(FieldInfo::getName)
+            .collect(Collectors.joining(" | "));
+        writer().println(header);
+        writer().println(StringUtils.repeat('-', header.length()));
+        break;
+      default:
+        throw new RuntimeException(String.format(
+            "Unexpected output format: '%s'",
+            outputFormat.name()
+        ));
+    }
+  }
+
   public void registerCliSpecificCommand(final CliSpecificCommand cliSpecificCommand) {
     cliSpecificCommands.put(cliSpecificCommand.getName().toLowerCase(), cliSpecificCommand);
   }

--- a/ksql-cli/src/test/java/io/confluent/ksql/cli/console/ConsoleTest.java
+++ b/ksql-cli/src/test/java/io/confluent/ksql/cli/console/ConsoleTest.java
@@ -48,6 +48,7 @@ import io.confluent.ksql.rest.entity.KsqlTopicsList;
 import io.confluent.ksql.rest.entity.PropertiesList;
 import io.confluent.ksql.rest.entity.Queries;
 import io.confluent.ksql.rest.entity.RunningQuery;
+import io.confluent.ksql.rest.entity.SchemaInfo;
 import io.confluent.ksql.rest.entity.SourceDescription;
 import io.confluent.ksql.rest.entity.SourceDescriptionEntity;
 import io.confluent.ksql.rest.entity.SourceInfo;
@@ -58,6 +59,7 @@ import io.confluent.ksql.rest.entity.TopicDescription;
 import io.confluent.ksql.rest.server.computation.CommandId;
 import io.confluent.ksql.rest.util.EntityUtil;
 import io.confluent.ksql.schema.ksql.LogicalSchema;
+import io.confluent.ksql.schema.ksql.SqlType;
 import io.confluent.ksql.serde.Format;
 import java.io.IOException;
 import java.util.ArrayList;
@@ -110,6 +112,23 @@ public class ConsoleTest {
   public void testPrintGenericStreamedRow() throws IOException {
     final StreamedRow row = StreamedRow.row(new GenericRow(ImmutableList.of("col_1", "col_2")));
     console.printStreamedRow(row);
+  }
+
+  @Test
+  public void testPrintRowHeader() throws IOException {
+    // Given:
+    final List<FieldInfo> header = ImmutableList.of(
+        new FieldInfo("col_1", new SchemaInfo(SqlType.STRING, null, null)),
+        new FieldInfo("col_2", new SchemaInfo(SqlType.INTEGER, null, null))
+    );
+
+    // When:
+    console.printRowHeader(header);
+
+    // Then:
+    if (console.getOutputFormat() == OutputFormat.TABULAR) {
+      assertThat(terminal.getOutputString(), is("col_1 | col_2\n-------------\n"));
+    }
   }
 
   @Test


### PR DESCRIPTION
### Description 
Add the column names to the output of transient queries to improve the CLI usability. This first makes a request to `EXPLAIN` to get the column names, and then proceeds as it used to.

NOTE: there is an open bug #3039 that makes this functionality look bad, but that bug needs to be fixed anyway since it affects lots of things.

### Testing done 
Unit testing and end-to-end:
```
ksql> SELECT * FROM FOO;
ROWTIME | ROWKEY | ROWTIME | ROWKEY | ID
----------------------------------------
1562021756897 | a | 1
```

### Reviewer checklist
- [ ] Ensure docs are updated if necessary. (eg. if a user visible feature is being added or changed).
- [ ] Ensure relevant issues are linked (description should include text like "Fixes #<issue number>")

