### PR TITLE
refactor: switch create source properties over to config def

### DIFF
--- a/ksql-common/src/main/java/io/confluent/ksql/configdef/ConfigValidators.java
+++ b/ksql-common/src/main/java/io/confluent/ksql/configdef/ConfigValidators.java
@@ -1,0 +1,71 @@
+/*
+ * Copyright 2019 Confluent Inc.
+ *
+ * Licensed under the Confluent Community License (the "License"); you may not use
+ * this file except in compliance with the License.  You may obtain a copy of the
+ * License at
+ *
+ * http://www.confluent.io/confluent-community-license
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package io.confluent.ksql.configdef;
+
+import static java.util.Objects.requireNonNull;
+
+import java.util.Arrays;
+import java.util.EnumSet;
+import java.util.List;
+import java.util.stream.Collectors;
+import org.apache.kafka.common.config.ConfigDef.Validator;
+import org.apache.kafka.common.config.ConfigException;
+
+/**
+ * Custom {@link org.apache.kafka.common.config.ConfigDef.Validator}s
+ */
+public final class ConfigValidators {
+
+  private ConfigValidators() {
+  }
+
+  public static <T extends Enum<T>> Validator enumValues(final Class<T> enumClass) {
+    final String[] validValues = EnumSet.allOf(enumClass)
+        .stream()
+        .map(Object::toString)
+        .toArray(String[]::new);
+
+    return ValidCaseInsensitiveString.in(validValues);
+  }
+
+  public static final class ValidCaseInsensitiveString implements Validator {
+
+    private final List<String> validStrings;
+
+    private ValidCaseInsensitiveString(final String... validStrings) {
+      this.validStrings = Arrays.stream(requireNonNull(validStrings, "validStrings"))
+          .map(v -> v == null ? null : v.toUpperCase())
+          .collect(Collectors.toList());
+    }
+
+    public static ValidCaseInsensitiveString in(final String... validStrings) {
+      return new ValidCaseInsensitiveString(validStrings);
+    }
+
+    @Override
+    public void ensureValid(final String name, final Object value) {
+      final String s = (String) value;
+      if (!validStrings.contains(s == null ? null : s.toUpperCase())) {
+        throw new ConfigException(name, value, "String must be one of: "
+            + String.join(", ", validStrings));
+      }
+    }
+
+    public String toString() {
+      return "[" + String.join(", ", validStrings) + "]";
+    }
+  }
+}

--- a/ksql-common/src/test/java/io/confluent/ksql/configdef/ConfigValidatorsTest.java
+++ b/ksql-common/src/test/java/io/confluent/ksql/configdef/ConfigValidatorsTest.java
@@ -1,0 +1,117 @@
+/*
+ * Copyright 2019 Confluent Inc.
+ *
+ * Licensed under the Confluent Community License (the "License"); you may not use
+ * this file except in compliance with the License.  You may obtain a copy of the
+ * License at
+ *
+ * http://www.confluent.io/confluent-community-license
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package io.confluent.ksql.configdef;
+
+import org.apache.kafka.common.config.ConfigDef.Validator;
+import org.apache.kafka.common.config.ConfigException;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+
+public class ConfigValidatorsTest {
+
+  @Rule
+  public final ExpectedException expectedException = ExpectedException.none();
+
+  @Test
+  public void shouldFailIfValueNoInEnum() {
+    // Given:
+    final Validator validator = ConfigValidators.enumValues(TestEnum.class);
+
+    // Then:
+    expectedException.expect(ConfigException.class);
+    expectedException.expectMessage("String must be one of: FOO, BAR");
+
+    // When:
+    validator.ensureValid("propName", "NotValid");
+  }
+
+  @Test
+  public void shouldNotThrowIfAValidEnumValue() {
+    // Given:
+    final Validator validator = ConfigValidators.enumValues(TestEnum.class);
+
+    // When:
+    validator.ensureValid("propName", TestEnum.FOO.toString());
+
+    // Then: did not throw
+  }
+
+  @Test
+  public void shouldNotThrowIfAValidEnumValueInDifferentCase() {
+    // Given:
+    final Validator validator = ConfigValidators.enumValues(TestEnum.class);
+
+    // When:
+    validator.ensureValid("propName", TestEnum.FOO.toString().toLowerCase());
+
+    // Then: did not throw
+  }
+
+  @Test
+  public void shouldNotThrowifMatchForCaseInsensitiveString() {
+    // Given:
+    final Validator validator = ConfigValidators.ValidCaseInsensitiveString.in("a", "B");
+
+    // When:
+    validator.ensureValid("propName", "A");
+
+    // Then: did not throw
+  }
+
+  @Test
+  public void shouldThrowIfNoMatchForCaseInsensitiveString() {
+    // Given:
+    final Validator validator = ConfigValidators.ValidCaseInsensitiveString.in("a", "B");
+
+    // Then:
+    expectedException.expect(ConfigException.class);
+    expectedException.expectMessage("Invalid value c for configuration propName: "
+        + "String must be one of: A, B");
+
+    // When:
+    validator.ensureValid("propName", "c");
+  }
+
+  @Test
+  public void shouldNotThrowIfMatchForCaseInsensitiveStringIncludesNull() {
+    // Given:
+    final Validator validator = ConfigValidators.ValidCaseInsensitiveString.in("a", "B", null);
+
+    // When:
+    validator.ensureValid("propName", null);
+
+    // Then: did not throw
+  }
+
+  @Test
+  public void shouldThrowIfNoMatchForCaseInsensitiveStringNull() {
+    // Given:
+    final Validator validator = ConfigValidators.ValidCaseInsensitiveString.in("a", "B");
+
+    // Then:
+    expectedException.expect(ConfigException.class);
+    expectedException.expectMessage("Invalid value null for configuration propName: "
+        + "String must be one of: A, B");
+
+    // When:
+    validator.ensureValid("propName", null);
+  }
+
+  private enum TestEnum {
+    FOO, BAR
+  }
+}

--- a/ksql-engine/src/test/java/io/confluent/ksql/ddl/commands/CreateSourceCommandTest.java
+++ b/ksql-engine/src/test/java/io/confluent/ksql/ddl/commands/CreateSourceCommandTest.java
@@ -23,6 +23,7 @@ import static org.mockito.Mockito.when;
 
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import io.confluent.ksql.ddl.DdlConfig;
 import io.confluent.ksql.ddl.commands.CreateSourceCommand.SerdeOptionsSupplier;
 import io.confluent.ksql.metastore.MutableMetaStore;
@@ -172,6 +173,7 @@ public class CreateSourceCommandTest {
     );
   }
 
+  @SuppressFBWarnings("RV_RETURN_VALUE_IGNORED_NO_SIDE_EFFECT")
   @Test
   public void shouldNotThrowIfTopicDoesExist() {
     // Given:
@@ -318,7 +320,7 @@ public class CreateSourceCommandTest {
   private void givenPropertiesWith(final Map<String, Literal> additionalProps) {
     final Map<String, Literal> allProps = new HashMap<>(minValidProps());
     allProps.putAll(additionalProps);
-    when(statement.getProperties()).thenReturn(new CreateSourceProperties(allProps));
+    when(statement.getProperties()).thenReturn(CreateSourceProperties.from(allProps));
   }
 
   private static final class TestCmd extends CreateSourceCommand {

--- a/ksql-engine/src/test/java/io/confluent/ksql/ddl/commands/CreateStreamCommandTest.java
+++ b/ksql-engine/src/test/java/io/confluent/ksql/ddl/commands/CreateStreamCommandTest.java
@@ -204,6 +204,6 @@ public class CreateStreamCommandTest {
     final Map<String, Literal> allProps = new HashMap<>(props);
     allProps.putIfAbsent(DdlConfig.VALUE_FORMAT_PROPERTY, new StringLiteral("Json"));
     allProps.putIfAbsent(DdlConfig.KAFKA_TOPIC_NAME_PROPERTY, new StringLiteral("some-topic"));
-    when(createStreamStatement.getProperties()).thenReturn(new CreateSourceProperties(allProps));
+    when(createStreamStatement.getProperties()).thenReturn(CreateSourceProperties.from(allProps));
   }
 }

--- a/ksql-engine/src/test/java/io/confluent/ksql/ddl/commands/CreateTableCommandTest.java
+++ b/ksql-engine/src/test/java/io/confluent/ksql/ddl/commands/CreateTableCommandTest.java
@@ -202,6 +202,6 @@ public class CreateTableCommandTest {
     final Map<String, Literal> allProps = new HashMap<>(props);
     allProps.putIfAbsent(DdlConfig.VALUE_FORMAT_PROPERTY, new StringLiteral("Json"));
     allProps.putIfAbsent(DdlConfig.KAFKA_TOPIC_NAME_PROPERTY, new StringLiteral("some-topic"));
-    when(createTableStatement.getProperties()).thenReturn(new CreateSourceProperties(allProps));
+    when(createTableStatement.getProperties()).thenReturn(CreateSourceProperties.from(allProps));
   }
 }

--- a/ksql-engine/src/test/java/io/confluent/ksql/engine/KsqlEngineTest.java
+++ b/ksql-engine/src/test/java/io/confluent/ksql/engine/KsqlEngineTest.java
@@ -752,7 +752,7 @@ public class KsqlEngineTest {
         Assert.fail();
       } catch (final KsqlStatementException e) {
         assertThat(e.getMessage(), containsString(
-            "Corresponding Kafka topic (KAFKA_TOPIC) should be set in WITH clause."));
+            "Missing required property \"KAFKA_TOPIC\" which has no default value."));
       }
     }
   }
@@ -777,7 +777,7 @@ public class KsqlEngineTest {
         Assert.fail();
       } catch (final KsqlStatementException e) {
         assertThat(e.getMessage(), containsString(
-            "Topic format(VALUE_FORMAT) should be set in WITH clause."));
+            "Missing required property \"VALUE_FORMAT\" which has no default value."));
       }
     }
   }

--- a/ksql-engine/src/test/java/io/confluent/ksql/schema/ksql/inference/DefaultSchemaInjectorTest.java
+++ b/ksql-engine/src/test/java/io/confluent/ksql/schema/ksql/inference/DefaultSchemaInjectorTest.java
@@ -142,8 +142,8 @@ public class DefaultSchemaInjectorTest {
     when(cs.getName()).thenReturn(QualifiedName.of("cs"));
     when(ct.getName()).thenReturn(QualifiedName.of("ct"));
 
-    when(cs.getProperties()).thenReturn(new CreateSourceProperties(SUPPORTED_PROPS));
-    when(ct.getProperties()).thenReturn(new CreateSourceProperties(SUPPORTED_PROPS));
+    when(cs.getProperties()).thenReturn(CreateSourceProperties.from(SUPPORTED_PROPS));
+    when(ct.getProperties()).thenReturn(CreateSourceProperties.from(SUPPORTED_PROPS));
 
     when(cs.copyWith(any(), any())).thenAnswer(inv -> setupCopy(inv, cs, mock(CreateStream.class)));
     when(ct.copyWith(any(), any())).thenAnswer(inv -> setupCopy(inv, ct, mock(CreateTable.class)));
@@ -203,7 +203,7 @@ public class DefaultSchemaInjectorTest {
   @Test
   public void shouldReturnStatementUnchangedIfCsFormatDoesNotSupportInference() {
     // Given:
-    when(cs.getProperties()).thenReturn(new CreateSourceProperties(UNSUPPORTED_PROPS));
+    when(cs.getProperties()).thenReturn(CreateSourceProperties.from(UNSUPPORTED_PROPS));
 
     // When:
     final ConfiguredStatement<?> result = injector.inject(csStatement);
@@ -215,7 +215,7 @@ public class DefaultSchemaInjectorTest {
   @Test
   public void shouldReturnStatementUnchangedIfCtFormatDoesNotSupportInference() {
     // Given:
-    when(ct.getProperties()).thenReturn(new CreateSourceProperties(UNSUPPORTED_PROPS));
+    when(ct.getProperties()).thenReturn(CreateSourceProperties.from(UNSUPPORTED_PROPS));
 
     // When:
     final ConfiguredStatement<?> result = injector.inject(ctStatement);
@@ -285,7 +285,7 @@ public class DefaultSchemaInjectorTest {
             + "MAPFIELD MAP<VARCHAR, BIGINT>, "
             + "STRUCTFIELD STRUCT<S0 BIGINT>, "
             + "DECIMALFIELD DECIMAL(4, 2)) "
-            + "WITH (VALUE_FORMAT='avro', KAFKA_TOPIC='some-topic', AVRO_SCHEMA_ID='5');"
+            + "WITH (AVRO_SCHEMA_ID=5, KAFKA_TOPIC='some-topic', VALUE_FORMAT='avro');"
     ));
   }
 
@@ -310,7 +310,7 @@ public class DefaultSchemaInjectorTest {
             + "MAPFIELD MAP<VARCHAR, BIGINT>, "
             + "STRUCTFIELD STRUCT<S0 BIGINT>, "
             + "DECIMALFIELD DECIMAL(4, 2)) "
-            + "WITH (VALUE_FORMAT='avro', KAFKA_TOPIC='some-topic', AVRO_SCHEMA_ID='5');"
+            + "WITH (AVRO_SCHEMA_ID=5, KAFKA_TOPIC='some-topic', VALUE_FORMAT='avro');"
     ));
   }
 
@@ -337,7 +337,7 @@ public class DefaultSchemaInjectorTest {
             + "MAPFIELD MAP<VARCHAR, BIGINT>, "
             + "STRUCTFIELD STRUCT<S0 BIGINT>, "
             + "DECIMALFIELD DECIMAL(4, 2)) "
-            + "WITH (VALUE_FORMAT='avro', KAFKA_TOPIC='some-topic', AVRO_SCHEMA_ID='42');"
+            + "WITH (AVRO_SCHEMA_ID='42', KAFKA_TOPIC='some-topic', VALUE_FORMAT='avro');"
     ));
   }
 
@@ -364,7 +364,7 @@ public class DefaultSchemaInjectorTest {
             + "MAPFIELD MAP<VARCHAR, BIGINT>, "
             + "STRUCTFIELD STRUCT<S0 BIGINT>, "
             + "DECIMALFIELD DECIMAL(4, 2)) "
-            + "WITH (VALUE_FORMAT='avro', KAFKA_TOPIC='some-topic', AVRO_SCHEMA_ID='42');"
+            + "WITH (AVRO_SCHEMA_ID='42', KAFKA_TOPIC='some-topic', VALUE_FORMAT='avro');"
     ));
   }
 
@@ -380,7 +380,7 @@ public class DefaultSchemaInjectorTest {
     // Then:
     assertThat(result.getStatement().getProperties().getAvroSchemaId().get(), is(SCHEMA_ID));
 
-    assertThat(result.getStatementText(), containsString("AVRO_SCHEMA_ID='5'"));
+    assertThat(result.getStatementText(), containsString("AVRO_SCHEMA_ID=5"));
   }
 
   @Test
@@ -473,13 +473,13 @@ public class DefaultSchemaInjectorTest {
   ) {
     final HashMap<String, Literal> props = new HashMap<>(SUPPORTED_PROPS);
     props.put(property, new StringLiteral(value));
-    return new CreateSourceProperties(props);
+    return CreateSourceProperties.from(props);
   }
 
   private static CreateSourceProperties supportedPropsWithout(final String property) {
     final HashMap<String, Literal> props = new HashMap<>(SUPPORTED_PROPS);
     assertThat("Invalid test", props.remove(property), is(notNullValue()));
-    return new CreateSourceProperties(props);
+    return CreateSourceProperties.from(props);
   }
 
   private static Object setupCopy(

--- a/ksql-engine/src/test/java/io/confluent/ksql/topic/TopicCreateInjectorTest.java
+++ b/ksql-engine/src/test/java/io/confluent/ksql/topic/TopicCreateInjectorTest.java
@@ -466,7 +466,7 @@ public class TopicCreateInjectorTest {
             + "stream/table please re-run the statement providing the required 'PARTITIONS' "
             + "configuration in the WITH clause (and optionally 'REPLICAS'). For example: "
             + "CREATE STREAM FOO (FOO STRING) "
-            + "WITH (VALUE_FORMAT='avro', KAFKA_TOPIC='doesntexist', PARTITIONS=2, REPLICAS=1);");
+            + "WITH (KAFKA_TOPIC='doesntexist', PARTITIONS=2, REPLICAS=1, VALUE_FORMAT='avro');");
 
     // When:
     injector.inject(statement, builder);

--- a/ksql-parser/src/main/java/io/confluent/ksql/parser/tree/CreateSourceProperties.java
+++ b/ksql-parser/src/main/java/io/confluent/ksql/parser/tree/CreateSourceProperties.java
@@ -15,23 +15,33 @@
 
 package io.confluent.ksql.parser.tree;
 
+import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
-import com.google.common.collect.ImmutableSet;
+import com.google.common.collect.Sets;
+import com.google.common.collect.Sets.SetView;
 import com.google.errorprone.annotations.Immutable;
+import io.confluent.ksql.configdef.ConfigValidators;
+import io.confluent.ksql.configdef.ConfigValidators.ValidCaseInsensitiveString;
 import io.confluent.ksql.ddl.DdlConfig;
 import io.confluent.ksql.metastore.SerdeFactory;
 import io.confluent.ksql.serde.Format;
 import io.confluent.ksql.util.KsqlConstants;
 import io.confluent.ksql.util.KsqlException;
-import io.confluent.ksql.util.StringUtil;
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
 import java.util.Objects;
 import java.util.Optional;
 import java.util.Set;
-import java.util.function.Function;
 import java.util.stream.Collectors;
-import java.util.stream.Stream;
+import org.apache.kafka.common.config.AbstractConfig;
+import org.apache.kafka.common.config.ConfigDef;
+import org.apache.kafka.common.config.ConfigDef.Importance;
+import org.apache.kafka.common.config.ConfigDef.NonEmptyString;
+import org.apache.kafka.common.config.ConfigException;
 import org.apache.kafka.streams.kstream.Windowed;
 import org.apache.kafka.streams.kstream.WindowedSerdes;
 
@@ -39,21 +49,125 @@ import org.apache.kafka.streams.kstream.WindowedSerdes;
  * Performs validation of a CREATE statement's WITH clause.
  */
 @Immutable
-public final class CreateSourceProperties {
+public final class CreateSourceProperties extends AbstractConfig {
 
-  private static final Set<String> VALID_PROPERTIES = ImmutableSet.<String>builder()
-      .add(DdlConfig.VALUE_FORMAT_PROPERTY.toUpperCase())
-      .add(DdlConfig.KAFKA_TOPIC_NAME_PROPERTY.toUpperCase())
-      .add(DdlConfig.KEY_NAME_PROPERTY.toUpperCase())
-      .add(DdlConfig.WINDOW_TYPE_PROPERTY.toUpperCase())
-      .add(DdlConfig.TIMESTAMP_NAME_PROPERTY.toUpperCase())
-      .add(KsqlConstants.AVRO_SCHEMA_ID.toUpperCase())
-      .add(DdlConfig.TIMESTAMP_FORMAT_PROPERTY.toUpperCase())
-      .add(DdlConfig.VALUE_AVRO_SCHEMA_FULL_NAME.toUpperCase())
-      .add(KsqlConstants.SOURCE_NUMBER_OF_PARTITIONS.toUpperCase())
-      .add(KsqlConstants.SOURCE_NUMBER_OF_REPLICAS.toUpperCase())
-      .add(DdlConfig.WRAP_SINGLE_VALUE.toUpperCase())
-      .build();
+  private static final String KAFKA_TOPIC_NAME_PROPERTY = DdlConfig.KAFKA_TOPIC_NAME_PROPERTY;
+  private static final String VALUE_FORMAT_PROPERTY = DdlConfig.VALUE_FORMAT_PROPERTY;
+  private static final String KEY_NAME_PROPERTY = DdlConfig.KEY_NAME_PROPERTY;
+  private static final String TIMESTAMP_NAME_PROPERTY = DdlConfig.TIMESTAMP_NAME_PROPERTY;
+  private static final String TIMESTAMP_FORMAT_PROPERTY = DdlConfig.TIMESTAMP_FORMAT_PROPERTY;
+  private static final String WRAP_SINGLE_VALUE = DdlConfig.WRAP_SINGLE_VALUE;
+  private static final String VALUE_AVRO_SCHEMA_FULL_NAME = DdlConfig.VALUE_AVRO_SCHEMA_FULL_NAME;
+  private static final String SOURCE_NUMBER_OF_PARTITIONS =
+      KsqlConstants.SOURCE_NUMBER_OF_PARTITIONS;
+  private static final String SOURCE_NUMBER_OF_REPLICAS = KsqlConstants.SOURCE_NUMBER_OF_REPLICAS;
+  private static final String WINDOW_TYPE_PROPERTY = DdlConfig.WINDOW_TYPE_PROPERTY;
+  private static final String AVRO_SCHEMA_ID = KsqlConstants.AVRO_SCHEMA_ID;
+
+  private static final ConfigDef CONFIG_DEF = new ConfigDef()
+      .define(
+          KAFKA_TOPIC_NAME_PROPERTY,
+          ConfigDef.Type.STRING,
+          ConfigDef.NO_DEFAULT_VALUE,
+          new NonEmptyString(),
+          Importance.HIGH,
+          "The topic that stores the data of the source"
+      ).define(
+          VALUE_FORMAT_PROPERTY,
+          ConfigDef.Type.STRING,
+          ConfigDef.NO_DEFAULT_VALUE,
+          ConfigValidators.enumValues(Format.class),
+          Importance.HIGH,
+          "The format of the serialized value"
+      ).define(
+          KEY_NAME_PROPERTY,
+          ConfigDef.Type.STRING,
+          null,
+          Importance.MEDIUM,
+          "The name of a field within the Kafka record value that matches the key. "
+              + "This may be used by KSQL to avoid unnecessary repartitions."
+      ).define(
+          TIMESTAMP_NAME_PROPERTY,
+          ConfigDef.Type.STRING,
+          null,
+          Importance.MEDIUM,
+          "The name of a field within the Kafka record value that contains the "
+              + "timestamp KSQL should use inplace of the default Kafka record timestamp. "
+              + "By default, KSQL requires the timestamp to be a `BIGINT`. Alternatively, you can "
+              + "supply '" + DdlConfig.TIMESTAMP_FORMAT_PROPERTY + "' to control how the field is "
+              + "parsed"
+      ).define(
+          TIMESTAMP_FORMAT_PROPERTY,
+          ConfigDef.Type.STRING,
+          null,
+          Importance.MEDIUM,
+          "If supplied, defines the format of the '"
+              + DdlConfig.TIMESTAMP_NAME_PROPERTY + "' field. The format can be any supported by "
+              + "the Java DateTimeFormatter class"
+      ).define(
+          WRAP_SINGLE_VALUE,
+          ConfigDef.Type.BOOLEAN,
+          null,
+          Importance.LOW,
+          "Controls how values are deserialized where the value schema contains only a"
+              + " single field.  If set to true, KSQL expects the field to have been serialized as "
+              + "a named field within a record. If set to false, KSQL expects the field to have "
+              + "been serialized as an anonymous value."
+      ).define(
+          VALUE_AVRO_SCHEMA_FULL_NAME,
+          ConfigDef.Type.STRING,
+          null,
+          Importance.LOW,
+          "The fully qualified name of the Avro schema to use"
+      ).define(
+          SOURCE_NUMBER_OF_PARTITIONS,
+          ConfigDef.Type.INT,
+          null,
+          Importance.LOW,
+          "The number of partitions in the backing topic. This property must be set if "
+              + "creating a source without an existing topic (the command will fail if the topic "
+              + "does not exist)"
+      ).define(
+          SOURCE_NUMBER_OF_REPLICAS,
+          ConfigDef.Type.SHORT,
+          null,
+          Importance.LOW,
+          "The number of replicas in the backing topic. If this property is not set "
+              + "but '" + KsqlConstants.SOURCE_NUMBER_OF_PARTITIONS + "' is set, then the default "
+              + "Kafka cluster configuration for replicas will be used for creating a new topic."
+      ).define(
+          WINDOW_TYPE_PROPERTY,
+          ConfigDef.Type.STRING,
+          null,
+          ValidCaseInsensitiveString.in("SESSION", "HOPPING", "TUMBLING", null),
+          Importance.LOW,
+          "If the data is windowed, i.e. was created using KSQL using a query that "
+              + "contains a ``WINDOW`` clause, then the property can be used to provide the "
+              + "window type. Valid values are SESSION, HOPPING or TUMBLING."
+      ).define(
+          AVRO_SCHEMA_ID,
+          ConfigDef.Type.INT,
+          null,
+          Importance.LOW,
+          "Undocumented feature"
+      );
+
+  private static final Set<String> CONFIG_NAMES = CONFIG_DEF.names().stream()
+      .map(String::toUpperCase)
+      .collect(Collectors.toSet());
+
+  private static final List<String> ORDERED_CONFIG_NAMES;
+
+  private static final Set<String> SHORT_CONFIG_NAMES = CONFIG_DEF.configKeys().entrySet().stream()
+      .filter(e -> e.getValue().type() == ConfigDef.Type.SHORT)
+      .map(Entry::getKey)
+      .collect(Collectors.toSet());
+
+  static {
+    final List<String> names = new ArrayList<>(CONFIG_NAMES);
+    names.sort(Comparator.naturalOrder());
+    ORDERED_CONFIG_NAMES = ImmutableList.copyOf(names);
+  }
 
   private static final java.util.Map<String, SerdeFactory<Windowed<String>>> WINDOW_TYPES =
       ImmutableMap.of(
@@ -62,326 +176,124 @@ public final class CreateSourceProperties {
         "HOPPING", () -> WindowedSerdes.timeWindowedSerdeFrom(String.class)
       );
 
-  // required
-  private final Property<String> kafkaTopic;
-  private final Property<Format> valueFormat;
+  private final ImmutableMap<String, Literal> originalLiterals;
 
-  // optional
-  private final Property<String> key;
-  private final Property<String> windowType;
-  private final Property<String> timestampName;
-  private final Property<String> timestampFormat;
-  private final Property<String> avroSchemaName;
-  private final Property<Integer> avroSchemaId;
-  private final Property<Integer> partitions;
-  private final Property<Short> replicas;
-  private final Property<Boolean> wrapSingleValues;
+  public static CreateSourceProperties from(final Map<String, Literal> literals) {
+    throwOnUnknownProperty(literals);
 
-  public CreateSourceProperties(final Map<String, Literal> original) {
-    final Map<String, Literal> properties = original
-        .entrySet()
-        .stream()
-        .collect(Collectors.toMap(entry -> entry.getKey().toUpperCase(), Entry::getValue));
+    try {
+      return new CreateSourceProperties(literals);
+    } catch (final ConfigException e) {
+      final String message = e.getMessage().replace(
+          "configuration",
+          "property"
+      );
 
-    properties.keySet()
-        .stream()
-        .filter(cfg -> !VALID_PROPERTIES.contains(cfg))
-        .findFirst()
-        .ifPresent(config -> {
-          throw new KsqlException("Invalid config variable in the WITH clause: " + config);
-        });
-
-    valueFormat = Property.from(
-        DdlConfig.VALUE_FORMAT_PROPERTY, properties, val -> Format.of(val.toString()));
-    if (!valueFormat.isPresent()) {
-      throw new KsqlException("Topic format(VALUE_FORMAT) should be set in WITH clause.");
+      throw new KsqlException(message, e);
     }
-
-    kafkaTopic = Property.from(
-        DdlConfig.KAFKA_TOPIC_NAME_PROPERTY,
-        properties,
-        ((Function<Object, String>) Object::toString).andThen(StringUtil::cleanQuotes));
-    if (!kafkaTopic.isPresent()) {
-      throw new KsqlException(
-          "Corresponding Kafka topic (KAFKA_TOPIC) should be set in WITH clause.");
-    }
-
-    key = Property.from(DdlConfig.KEY_NAME_PROPERTY, properties);
-    timestampName = Property.from(
-        DdlConfig.TIMESTAMP_NAME_PROPERTY,
-        properties,
-        ((Function<Object, String>) Object::toString).andThen(StringUtil::cleanQuotes));
-    timestampFormat = Property.from(
-        DdlConfig.TIMESTAMP_FORMAT_PROPERTY,
-        properties,
-        ((Function<Object, String>) Object::toString).andThen(StringUtil::cleanQuotes));
-
-    windowType = Property.from(
-        DdlConfig.WINDOW_TYPE_PROPERTY,
-        properties,
-        ((Function<Object, String>) Object::toString).andThen(String::toUpperCase));
-    if (windowType.isPresent() && !WINDOW_TYPES.containsKey(windowType.value)) {
-      throw new KsqlException(
-          "WINDOW_TYPE property is not set correctly. value: " + windowType.value
-              + ", validValues; " + WINDOW_TYPES.keySet());
-    }
-
-    avroSchemaId = Property.from(
-        KsqlConstants.AVRO_SCHEMA_ID,
-        properties,
-        id -> Integer.parseInt(id.toString()));
-    avroSchemaName = Property.from(DdlConfig.VALUE_AVRO_SCHEMA_FULL_NAME, properties);
-
-    partitions = Property.from(
-        KsqlConstants.SOURCE_NUMBER_OF_PARTITIONS,
-        properties,
-        partitions -> Integer.parseInt(partitions.toString())
-    );
-
-    replicas = Property.from(
-        KsqlConstants.SOURCE_NUMBER_OF_REPLICAS,
-        properties,
-        replicas -> Short.parseShort(replicas.toString())
-    );
-
-    wrapSingleValues = Property.from(
-        DdlConfig.WRAP_SINGLE_VALUE,
-        properties,
-        v -> Boolean.parseBoolean(v.toString())
-    );
   }
 
+  private CreateSourceProperties(final Map<String, Literal> originals) {
+    super(CONFIG_DEF, toValues(Objects.requireNonNull(originals, "originals")), false);
+    this.originalLiterals = ImmutableMap.copyOf(originals.entrySet().stream()
+        .collect(Collectors.toMap(e -> e.getKey().toUpperCase(), Map.Entry::getValue)));
+  }
+
+  @Override
   public String toString() {
-    return Stream.<Property<?>>builder()
-        .add(valueFormat)
-        .add(kafkaTopic)
-        .add(key)
-        .add(timestampName)
-        .add(timestampFormat)
-        .add(windowType)
-        .add(avroSchemaId)
-        .add(avroSchemaName)
-        .add(partitions)
-        .add(replicas)
-        .add(wrapSingleValues)
-        .build()
-        .filter(Property::isPresent)
-        .map(Object::toString)
+    return ORDERED_CONFIG_NAMES.stream()
+        .filter(originalLiterals::containsKey)
+        .map(name -> name + "=" + originalLiterals.get(name))
         .collect(Collectors.joining(", "));
   }
 
-  // CHECKSTYLE_RULES.OFF: ParameterNumberCheck
-  private CreateSourceProperties(
-      final Property<String> timestampName,
-      final Property<String> windowType,
-      final Property<String> key,
-      final Property<String> kafkaTopic,
-      final Property<Format> valueFormat,
-      final Property<String> avroSchemaName,
-      final Property<Integer> avroSchemaId,
-      final Property<String> timestampFormat,
-      final Property<Integer> partitions,
-      final Property<Short> replicas,
-      final Property<Boolean> wrapSingleValues
-  ) {
-    // CHECKSTYLE_RULES.ON: ParameterNumberCheck
-    this.valueFormat = Objects.requireNonNull(valueFormat, "valueFormat");
-    this.kafkaTopic = Objects.requireNonNull(kafkaTopic, "kafkaTopic");
-    this.key = Objects.requireNonNull(key, "key");
-    this.timestampName = Objects.requireNonNull(timestampName, "timestampName");
-    this.timestampFormat = Objects.requireNonNull(timestampFormat, "timestampFormat");
-    this.windowType = Objects.requireNonNull(windowType, "windowType");
-    this.avroSchemaId = Objects.requireNonNull(avroSchemaId, "avroSchemaId");
-    this.avroSchemaName = Objects.requireNonNull(avroSchemaName, "avroSchemaName");
-    this.partitions = Objects.requireNonNull(partitions, "partitions");
-    this.replicas = Objects.requireNonNull(replicas, "replicas");
-    this.wrapSingleValues = Objects.requireNonNull(wrapSingleValues, "wrapSingleValues");
-  }
-
   public Format getValueFormat() {
-    return valueFormat.value;
+    return Format.valueOf(getString(VALUE_FORMAT_PROPERTY).toUpperCase());
   }
 
   public String getKafkaTopic() {
-    return kafkaTopic.value;
+    return getString(KAFKA_TOPIC_NAME_PROPERTY);
   }
 
   public Optional<String> getKeyField() {
-    return Optional.ofNullable(key.value);
+    return Optional.ofNullable(getString(KEY_NAME_PROPERTY));
   }
 
   public Optional<SerdeFactory<Windowed<String>>> getWindowType() {
-    return Optional.ofNullable(windowType.value).map(WINDOW_TYPES::get);
+    return Optional.ofNullable(getString(WINDOW_TYPE_PROPERTY))
+        .map(String::toUpperCase)
+        .map(WINDOW_TYPES::get);
   }
 
   public Optional<String> getTimestampName() {
-    return Optional.ofNullable(timestampName.value);
-  }
-
-  public Optional<Integer> getAvroSchemaId() {
-    return Optional.ofNullable(avroSchemaId.value);
+    return Optional.ofNullable(getString(TIMESTAMP_NAME_PROPERTY));
   }
 
   public Optional<String> getTimestampFormat() {
-    return Optional.ofNullable(timestampFormat.value);
+    return Optional.ofNullable(getString(TIMESTAMP_FORMAT_PROPERTY));
+  }
+
+  public Optional<Integer> getAvroSchemaId() {
+    return Optional.ofNullable(getInt(AVRO_SCHEMA_ID));
   }
 
   public Optional<String> getValueAvroSchemaName() {
-    return Optional.ofNullable(avroSchemaName.value);
+    return Optional.ofNullable(getString(VALUE_AVRO_SCHEMA_FULL_NAME));
   }
 
   public Optional<Integer> getPartitions() {
-    return Optional.ofNullable(partitions.value);
+    return Optional.ofNullable(getInt(SOURCE_NUMBER_OF_PARTITIONS));
   }
 
   public Optional<Short> getReplicas() {
-    return Optional.ofNullable(replicas.value);
+    return Optional.ofNullable(getShort(SOURCE_NUMBER_OF_REPLICAS));
   }
 
   public Optional<Boolean> getWrapSingleValues() {
-    return Optional.ofNullable(wrapSingleValues.value);
+    return Optional.ofNullable(getBoolean(WRAP_SINGLE_VALUE));
   }
 
   public CreateSourceProperties withSchemaId(final int id) {
-    return new CreateSourceProperties(
-        timestampName,
-        windowType,
-        key,
-        kafkaTopic,
-        valueFormat,
-        avroSchemaName,
-        new Property<>(
-            KsqlConstants.AVRO_SCHEMA_ID,
-            new StringLiteral(Integer.toString(id)),
-            ignored -> id),
-        timestampFormat,
-        partitions,
-        replicas,
-        wrapSingleValues
-    );
+    final Map<String, Literal> originals = new HashMap<>(originalLiterals);
+    originals.put(AVRO_SCHEMA_ID, new IntegerLiteral(id));
+
+    return new CreateSourceProperties(originals);
   }
 
   public CreateSourceProperties withPartitionsAndReplicas(
       final int partitions,
       final short replicas
   ) {
-    return new CreateSourceProperties(
-        timestampName,
-        windowType,
-        key,
-        kafkaTopic,
-        valueFormat,
-        avroSchemaName,
-        avroSchemaId,
-        timestampFormat,
-        new Property<>(
-            KsqlConstants.SOURCE_NUMBER_OF_PARTITIONS,
-            new IntegerLiteral(partitions),
-            ignored -> partitions),
-        new Property<>(
-            KsqlConstants.SOURCE_NUMBER_OF_REPLICAS,
-            new IntegerLiteral(replicas), ignored ->
-            replicas),
-        wrapSingleValues
-    );
+    final Map<String, Literal> originals = new HashMap<>(originalLiterals);
+    originals.put(SOURCE_NUMBER_OF_PARTITIONS, new IntegerLiteral(partitions));
+    originals.put(SOURCE_NUMBER_OF_REPLICAS, new IntegerLiteral(replicas));
+
+    return new CreateSourceProperties(originals);
   }
 
-  // CHECKSTYLE_RULES.OFF: CyclomaticComplexity
-  @Override
-  public boolean equals(final Object o) {
-    // CHECKSTYLE_RULES.ON: CyclomaticComplexity
-    if (this == o) {
-      return true;
-    }
-    if (o == null || getClass() != o.getClass()) {
-      return false;
-    }
-    final CreateSourceProperties that = (CreateSourceProperties) o;
-    return Objects.equals(kafkaTopic, that.kafkaTopic)
-        && Objects.equals(valueFormat, that.valueFormat)
-        && Objects.equals(key, that.key)
-        && Objects.equals(windowType, that.windowType)
-        && Objects.equals(timestampName, that.timestampName)
-        && Objects.equals(timestampFormat, that.timestampFormat)
-        && Objects.equals(avroSchemaName, that.avroSchemaName)
-        && Objects.equals(avroSchemaId, that.avroSchemaId)
-        && Objects.equals(partitions, that.partitions)
-        && Objects.equals(replicas, that.replicas)
-        && Objects.equals(wrapSingleValues, that.wrapSingleValues);
-  }
+  private static Map<String, Object> toValues(final Map<String, Literal> literals) {
+    final Map<String, Object> values = literals.entrySet().stream()
+        .collect(Collectors.toMap(e -> e.getKey().toUpperCase(), e -> e.getValue().getValue()));
 
-  @Override
-  public int hashCode() {
-    return Objects.hash(
-        kafkaTopic,
-        valueFormat,
-        key,
-        windowType,
-        timestampName,
-        timestampFormat,
-        avroSchemaName,
-        avroSchemaId,
-        partitions,
-        replicas,
-        wrapSingleValues
-    );
-  }
-
-  private static final class Property<T> {
-
-    private final T value;
-    private final String name;
-    private final Literal original;
-
-    private Property(final String name, final Literal literal , final Function<Object, T> extract) {
-      this.original = literal;
-      this.value = literal == null ? null : extract.apply(literal.getValue());
-      this.name = name;
-    }
-
-    public static <T> Property<T> from(
-        final String name,
-        final Map<String, Literal> literal,
-        final Function<Object, T> extract
-    ) {
-      return new Property<>(name, literal.get(name), extract);
-    }
-
-    public static Property<String> from(
-        final String name,
-        final Map<String, Literal> literal
-    ) {
-      return new Property<>(name, literal.get(name), Object::toString);
-    }
-
-    public boolean isPresent() {
-      return value != null;
-    }
-
-
-    @Override
-    public String toString() {
-      return name + "=" + original;
-    }
-
-    @Override
-    public boolean equals(final Object o) {
-      if (this == o) {
-        return true;
+    SHORT_CONFIG_NAMES.forEach(configName -> {
+      final Object rf = values.get(configName);
+      if (rf instanceof Number) {
+        values.put(configName, ((Number) rf).shortValue());
       }
-      if (o == null || getClass() != o.getClass()) {
-        return false;
-      }
-      final Property<?> that = (Property<?>) o;
-      return Objects.equals(value, that.value)
-          && Objects.equals(name, that.name)
-          && Objects.equals(original, that.original);
-    }
+    });
 
-    @Override
-    public int hashCode() {
-      return Objects.hash(value, name, original);
-    }
+    return values;
   }
 
+  private static void throwOnUnknownProperty(final Map<String, ?> originals) {
+    final Set<String> providedNames = originals.keySet().stream()
+        .map(String::toUpperCase)
+        .collect(Collectors.toSet());
+
+    final SetView<String> onlyInProvided = Sets.difference(providedNames, CONFIG_NAMES);
+    if (!onlyInProvided.isEmpty()) {
+      throw new KsqlException("Invalid config variable(s) in the WITH clause: "
+          + String.join(",", onlyInProvided));
+    }
+  }
 }

--- a/ksql-parser/src/main/java/io/confluent/ksql/parser/tree/CreateStream.java
+++ b/ksql-parser/src/main/java/io/confluent/ksql/parser/tree/CreateStream.java
@@ -40,7 +40,7 @@ public class CreateStream extends CreateSource implements ExecutableDdlStatement
       final boolean notExists,
       final Map<String, Literal> properties
   ) {
-    this(location, name, elements, notExists, new CreateSourceProperties(properties));
+    this(location, name, elements, notExists, CreateSourceProperties.from(properties));
   }
 
   private CreateStream(

--- a/ksql-parser/src/main/java/io/confluent/ksql/parser/tree/CreateTable.java
+++ b/ksql-parser/src/main/java/io/confluent/ksql/parser/tree/CreateTable.java
@@ -40,7 +40,7 @@ public class CreateTable extends CreateSource implements ExecutableDdlStatement 
       final boolean notExists,
       final Map<String, Literal> properties
   ) {
-    this(location, name, elements, notExists, new CreateSourceProperties(properties));
+    this(location, name, elements, notExists, CreateSourceProperties.from(properties));
   }
 
   private CreateTable(

--- a/ksql-parser/src/test/java/io/confluent/ksql/parser/SqlFormatterTest.java
+++ b/ksql-parser/src/test/java/io/confluent/ksql/parser/SqlFormatterTest.java
@@ -188,7 +188,7 @@ public class SqlFormatterTest {
 
     // Then:
     assertThat(sql, is("CREATE STREAM TEST (Foo STRING, Bar STRING) "
-        + "WITH (VALUE_FORMAT='JSON', KAFKA_TOPIC='topic_test', KEY='ORDERID');"));
+        + "WITH (KAFKA_TOPIC='topic_test', KEY='ORDERID', VALUE_FORMAT='JSON');"));
   }
 
   @Test
@@ -205,7 +205,7 @@ public class SqlFormatterTest {
 
     // Then:
     assertThat(sql, is("CREATE TABLE TEST (Foo STRING, Bar STRING) "
-        + "WITH (VALUE_FORMAT='JSON', KAFKA_TOPIC='topic_test', KEY='ORDERID');"));
+        + "WITH (KAFKA_TOPIC='topic_test', KEY='ORDERID', VALUE_FORMAT='JSON');"));
   }
 
   @Test

--- a/ksql-parser/src/test/java/io/confluent/ksql/parser/tree/CreateSourcePropertiesTest.java
+++ b/ksql-parser/src/test/java/io/confluent/ksql/parser/tree/CreateSourcePropertiesTest.java
@@ -16,6 +16,7 @@
 package io.confluent.ksql.parser.tree;
 
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.instanceOf;
 import static org.hamcrest.Matchers.is;
 
@@ -25,6 +26,7 @@ import io.confluent.ksql.ddl.DdlConfig;
 import io.confluent.ksql.serde.Format;
 import io.confluent.ksql.util.KsqlConstants;
 import io.confluent.ksql.util.KsqlException;
+import java.util.HashMap;
 import java.util.Optional;
 import org.apache.kafka.streams.kstream.WindowedSerdes;
 import org.junit.Rule;
@@ -34,7 +36,7 @@ import org.junit.rules.ExpectedException;
 public class CreateSourcePropertiesTest {
 
   private static final java.util.Map<String, Literal> MINIMUM_VALID_PROPS = ImmutableMap.of(
-      DdlConfig.VALUE_FORMAT_PROPERTY, new StringLiteral("AVRO"),
+      DdlConfig.VALUE_FORMAT_PROPERTY, new StringLiteral("AvRo"),
       DdlConfig.KAFKA_TOPIC_NAME_PROPERTY, new StringLiteral("foo")
   );
 
@@ -44,7 +46,7 @@ public class CreateSourcePropertiesTest {
   @Test
   public void shouldSetMinimumValidProps() {
     // When:
-    final CreateSourceProperties properties = new CreateSourceProperties(MINIMUM_VALID_PROPS);
+    final CreateSourceProperties properties = CreateSourceProperties.from(MINIMUM_VALID_PROPS);
 
     // Then:
     assertThat(properties.getKafkaTopic(), is("foo"));
@@ -54,7 +56,7 @@ public class CreateSourcePropertiesTest {
   @Test
   public void shouldReturnOptionalEmptyForMissingProps() {
     // When:
-    final CreateSourceProperties properties = new CreateSourceProperties(MINIMUM_VALID_PROPS);
+    final CreateSourceProperties properties = CreateSourceProperties.from(MINIMUM_VALID_PROPS);
 
     // Then:
     assertThat(properties.getKeyField(), is(Optional.empty()));
@@ -71,7 +73,7 @@ public class CreateSourcePropertiesTest {
   @Test
   public void shouldSetValidKey() {
     // When:
-    final CreateSourceProperties properties = new CreateSourceProperties(
+    final CreateSourceProperties properties = CreateSourceProperties.from(
         ImmutableMap.<String, Literal>builder()
             .putAll(MINIMUM_VALID_PROPS)
             .put(DdlConfig.KEY_NAME_PROPERTY, new StringLiteral("key"))
@@ -84,7 +86,7 @@ public class CreateSourcePropertiesTest {
   @Test
   public void shouldSetValidTimestampName() {
     // When:
-    final CreateSourceProperties properties = new CreateSourceProperties(
+    final CreateSourceProperties properties = CreateSourceProperties.from(
         ImmutableMap.<String, Literal>builder()
             .putAll(MINIMUM_VALID_PROPS)
             .put(DdlConfig.TIMESTAMP_NAME_PROPERTY, new StringLiteral("ts"))
@@ -97,7 +99,7 @@ public class CreateSourcePropertiesTest {
   @Test
   public void shouldSetValidTimestampFormat() {
     // When:
-    final CreateSourceProperties properties = new CreateSourceProperties(
+    final CreateSourceProperties properties = CreateSourceProperties.from(
         ImmutableMap.<String, Literal>builder()
             .putAll(MINIMUM_VALID_PROPS)
             .put(DdlConfig.TIMESTAMP_FORMAT_PROPERTY, new StringLiteral("ts"))
@@ -110,10 +112,10 @@ public class CreateSourcePropertiesTest {
   @Test
   public void shouldSetValidWindowType() {
     // When:
-    final CreateSourceProperties properties = new CreateSourceProperties(
+    final CreateSourceProperties properties = CreateSourceProperties.from(
         ImmutableMap.<String, Literal>builder()
             .putAll(MINIMUM_VALID_PROPS)
-            .put(DdlConfig.WINDOW_TYPE_PROPERTY, new StringLiteral("HOPPING"))
+            .put(DdlConfig.WINDOW_TYPE_PROPERTY, new StringLiteral("HoPPinG"))
             .build());
 
     // Then:
@@ -126,7 +128,7 @@ public class CreateSourcePropertiesTest {
   @Test
   public void shouldSetValidSchemaId() {
     // When:
-    final CreateSourceProperties properties = new CreateSourceProperties(
+    final CreateSourceProperties properties = CreateSourceProperties.from(
         ImmutableMap.<String, Literal>builder()
             .putAll(MINIMUM_VALID_PROPS)
             .put(KsqlConstants.AVRO_SCHEMA_ID, new StringLiteral("1"))
@@ -139,7 +141,7 @@ public class CreateSourcePropertiesTest {
   @Test
   public void shouldSetValidAvroSchemaName() {
     // When:
-    final CreateSourceProperties properties = new CreateSourceProperties(
+    final CreateSourceProperties properties = CreateSourceProperties.from(
         ImmutableMap.<String, Literal>builder()
             .putAll(MINIMUM_VALID_PROPS)
             .put(DdlConfig.VALUE_AVRO_SCHEMA_FULL_NAME, new StringLiteral("schema"))
@@ -152,7 +154,7 @@ public class CreateSourcePropertiesTest {
   @Test
   public void shouldCleanQuotesForStrings() {
     // When:
-    final CreateSourceProperties properties = new CreateSourceProperties(
+    final CreateSourceProperties properties = CreateSourceProperties.from(
         ImmutableMap.<String, Literal>builder()
             .putAll(MINIMUM_VALID_PROPS)
             .put(DdlConfig.VALUE_AVRO_SCHEMA_FULL_NAME, new StringLiteral("'schema'"))
@@ -163,9 +165,9 @@ public class CreateSourcePropertiesTest {
   }
 
   @Test
-  public void shouldSetReplicas() {
+  public void shouldSetReplicasFromNumber() {
     // When:
-    final CreateSourceProperties properties = new CreateSourceProperties(
+    final CreateSourceProperties properties = CreateSourceProperties.from(
         ImmutableMap.<String, Literal>builder()
             .putAll(MINIMUM_VALID_PROPS)
             .put(KsqlConstants.SOURCE_NUMBER_OF_REPLICAS, new IntegerLiteral(2))
@@ -178,7 +180,7 @@ public class CreateSourcePropertiesTest {
   @Test
   public void shouldSetPartitions() {
     // When:
-    final CreateSourceProperties properties = new CreateSourceProperties(
+    final CreateSourceProperties properties = CreateSourceProperties.from(
         ImmutableMap.<String, Literal>builder()
             .putAll(MINIMUM_VALID_PROPS)
             .put(KsqlConstants.SOURCE_NUMBER_OF_PARTITIONS, new IntegerLiteral(2))
@@ -191,7 +193,7 @@ public class CreateSourcePropertiesTest {
   @Test
   public void shouldSetWrapSingleValues() {
     // When:
-    final CreateSourceProperties properties = new CreateSourceProperties(
+    final CreateSourceProperties properties = CreateSourceProperties.from(
         ImmutableMap.<String, Literal>builder()
             .putAll(MINIMUM_VALID_PROPS)
             .put(DdlConfig.WRAP_SINGLE_VALUE, new BooleanLiteral("true"))
@@ -202,38 +204,83 @@ public class CreateSourcePropertiesTest {
   }
 
   @Test
+  public void shouldSetNumericPropertyFromStringLiteral() {
+    // When:
+    final CreateSourceProperties properties = CreateSourceProperties.from(
+        ImmutableMap.<String, Literal>builder()
+            .putAll(MINIMUM_VALID_PROPS)
+            .put(KsqlConstants.SOURCE_NUMBER_OF_REPLICAS, new StringLiteral("3"))
+            .build());
+
+    // Then:
+    assertThat(properties.getReplicas(), is(Optional.of((short) 3)));
+  }
+
+  @Test
+  public void shouldSetBooleanPropertyFromStringLiteral() {
+    // When:
+    final CreateSourceProperties properties = CreateSourceProperties.from(
+        ImmutableMap.<String, Literal>builder()
+            .putAll(MINIMUM_VALID_PROPS)
+            .put(DdlConfig.WRAP_SINGLE_VALUE, new StringLiteral("true"))
+            .build());
+
+    // Then:
+    assertThat(properties.getWrapSingleValues(), is(Optional.of(true)));
+  }
+
+  @Test
+  public void shouldHandleNonUpperCasePropNames() {
+    // When:
+    final CreateSourceProperties properties = CreateSourceProperties.from(
+        ImmutableMap.<String, Literal>builder()
+            .putAll(MINIMUM_VALID_PROPS)
+            .put(DdlConfig.WRAP_SINGLE_VALUE.toLowerCase(), new StringLiteral("false"))
+            .build());
+
+    // Then:
+    assertThat(properties.getWrapSingleValues(), is(Optional.of(false)));
+  }
+
+  @Test
   public void shouldFailIfNoKafkaTopicName() {
+    // Given:
+    final HashMap<String, Literal> props = new HashMap<>(MINIMUM_VALID_PROPS);
+    props.remove(DdlConfig.KAFKA_TOPIC_NAME_PROPERTY);
+
     // Expect:
     expectedException.expectMessage(
-        "Corresponding Kafka topic (KAFKA_TOPIC) should be set in WITH clause");
+        "Missing required property \"KAFKA_TOPIC\" which has no default value.");
     expectedException.expect(KsqlException.class);
 
     // When:
-    new CreateSourceProperties(
-        ImmutableMap.<String, Literal>builder()
-            .put(DdlConfig.VALUE_FORMAT_PROPERTY, new StringLiteral("AVRO"))
-            .build()
-    );
+    CreateSourceProperties.from(props);
   }
 
   @Test
   public void shouldFailIfNoValueFormat() {
+    // Given:
+    final HashMap<String, Literal> props = new HashMap<>(MINIMUM_VALID_PROPS);
+    props.remove(DdlConfig.VALUE_FORMAT_PROPERTY);
+
     // Expect:
-    expectedException.expectMessage("Topic format(VALUE_FORMAT) should be set in WITH clause.");
+    expectedException
+        .expectMessage("Missing required property \"VALUE_FORMAT\" which has no default value.");
     expectedException.expect(KsqlException.class);
 
     // When:
-    new CreateSourceProperties(ImmutableMap.of());
+    CreateSourceProperties.from(props);
   }
 
   @Test
   public void shouldFailIfInvalidWindowConfig() {
     // Expect:
-    expectedException.expectMessage("WINDOW_TYPE property is not set correctly");
+    expectedException.expectMessage(
+        "Invalid value bar for property WINDOW_TYPE: String must be one of: SESSION, HOPPING, TUMBLING");
     expectedException.expect(KsqlException.class);
 
     // When:
-    new CreateSourceProperties(
+    CreateSourceProperties.from(
         ImmutableMap.<String, Literal>builder()
             .putAll(MINIMUM_VALID_PROPS)
             .put(DdlConfig.WINDOW_TYPE_PROPERTY, new StringLiteral("bar"))
@@ -244,11 +291,11 @@ public class CreateSourcePropertiesTest {
   @Test
   public void shouldFailIfInvalidConfig() {
     // Expect:
-    expectedException.expectMessage("Invalid config variable in the WITH clause: FOO");
+    expectedException.expectMessage("Invalid config variable(s) in the WITH clause: FOO");
     expectedException.expect(KsqlException.class);
 
     // When:
-    new CreateSourceProperties(
+    CreateSourceProperties.from(
         ImmutableMap.<String, Literal>builder()
             .putAll(MINIMUM_VALID_PROPS)
             .put("foo", new StringLiteral("bar"))
@@ -260,14 +307,45 @@ public class CreateSourcePropertiesTest {
   public void shouldProperlyImplementEqualsAndHashCode() {
     new EqualsTester()
         .addEqualityGroup(
-            new CreateSourceProperties(MINIMUM_VALID_PROPS),
-            new CreateSourceProperties(MINIMUM_VALID_PROPS))
+            CreateSourceProperties.from(MINIMUM_VALID_PROPS),
+            CreateSourceProperties.from(MINIMUM_VALID_PROPS))
         .addEqualityGroup(
-            new CreateSourceProperties(ImmutableMap.<String, Literal>builder()
+            CreateSourceProperties.from(ImmutableMap.<String, Literal>builder()
                 .putAll(MINIMUM_VALID_PROPS)
                 .put(DdlConfig.VALUE_AVRO_SCHEMA_FULL_NAME, new StringLiteral("schema"))
                 .build()))
         .testEquals();
   }
 
+  @Test
+  public void shouldIncludeOnlyProvidedPropsInToString() {
+    // Given:
+    final CreateSourceProperties props = CreateSourceProperties
+        .from(ImmutableMap.<String, Literal>builder()
+            .putAll(MINIMUM_VALID_PROPS)
+            .put("Wrap_Single_value", new StringLiteral("True"))
+            .build());
+
+    // When:
+    final String sql = props.toString();
+
+    // Then:
+    assertThat(sql, is("KAFKA_TOPIC='foo', VALUE_FORMAT='AvRo', WRAP_SINGLE_VALUE='True'"));
+  }
+
+  @Test
+  public void shouldNotQuoteNonStringPropValues() {
+    // Given:
+    final CreateSourceProperties props = CreateSourceProperties
+        .from(ImmutableMap.<String, Literal>builder()
+            .putAll(MINIMUM_VALID_PROPS)
+            .put("Wrap_Single_value", new BooleanLiteral("true"))
+            .build());
+
+    // When:
+    final String sql = props.toString();
+
+    // Then:
+    assertThat(sql, containsString("WRAP_SINGLE_VALUE=true"));
+  }
 }

--- a/ksql-parser/src/test/java/io/confluent/ksql/parser/tree/ParserModelTest.java
+++ b/ksql-parser/src/test/java/io/confluent/ksql/parser/tree/ParserModelTest.java
@@ -34,6 +34,8 @@ import java.util.Optional;
 import java.util.OptionalInt;
 import java.util.concurrent.TimeUnit;
 import java.util.stream.Collectors;
+import org.apache.kafka.common.config.AbstractConfig;
+import org.apache.kafka.common.config.ConfigDef;
 import org.apache.kafka.streams.kstream.JoinWindows;
 import org.apache.kafka.streams.kstream.Window;
 import org.junit.Test;
@@ -95,6 +97,8 @@ public class ParserModelTest {
     new ImmutableTester()
         .withKnownImmutableType(Window.class)
         .withKnownImmutableType(JoinWindows.class)
+        .withKnownImmutableType(ConfigDef.class)
+        .withKnownImmutableType(AbstractConfig.class)
         .test(modelClass);
   }
 

--- a/ksql-rest-app/src/test/java/io/confluent/ksql/rest/server/resources/KsqlResourceTest.java
+++ b/ksql-rest-app/src/test/java/io/confluent/ksql/rest/server/resources/KsqlResourceTest.java
@@ -623,7 +623,7 @@ public class KsqlResourceTest {
     assertThat(result, is(instanceOf(KsqlStatementErrorMessage.class)));
     assertThat(result.getErrorCode(), is(Errors.ERROR_CODE_BAD_STATEMENT));
     assertThat(result.getMessage(),
-        containsString("Corresponding Kafka topic (KAFKA_TOPIC) should be set in WITH clause."));
+        containsString("Missing required property \"KAFKA_TOPIC\" which has no default value."));
     assertThat(((KsqlStatementErrorMessage) result).getStatementText(),
         is("CREATE STREAM S (foo INT) WITH(VALUE_FORMAT='JSON');"));
   }


### PR DESCRIPTION
### Description 

Switching `CreateSourceProperties` over to use ConfigDef removes a lot of code, (and hence potential bugs), and we open up the scope to be able to generate our docs off this in the future.

The main driver behind this change is that I'd like to use the same pattern for C*AS statements, and I'd like common props, e.g. `VALUE_FORMAT` to be defined in one place, which is easily possible with `ConfigDef`.

### Testing done 

suitable tests added.

### Reviewer checklist
- [ ] Ensure docs are updated if necessary. (eg. if a user visible feature is being added or changed).
- [ ] Ensure relevant issues are linked (description should include text like "Fixes #<issue number>")

