### PR TITLE
fix: Create the streams state directory if it does not exist.

### DIFF
--- a/ksql-rest-app/src/main/java/io/confluent/ksql/rest/server/KsqlServerMain.java
+++ b/ksql-rest-app/src/main/java/io/confluent/ksql/rest/server/KsqlServerMain.java
@@ -112,7 +112,7 @@ public class KsqlServerMain {
   @VisibleForTesting
   static void enforceStreamStateDirAvailability(final File streamsStateDir) {
     if (!streamsStateDir.exists()) {
-      final boolean mkDirSuccess = streamsStateDir.mkdir();
+      final boolean mkDirSuccess = streamsStateDir.mkdirs();
       if (!mkDirSuccess) {
         throw new KsqlServerException("Could not create the kafka streams state directory: "
             + streamsStateDir.getPath()
@@ -134,7 +134,7 @@ public class KsqlServerMain {
           + "' config in the properties file."
       );
     }
-    if (!streamsStateDir.canWrite()) {
+    if (!streamsStateDir.canWrite() || !streamsStateDir.canExecute()) {
       throw new KsqlServerException("The kafka streams state directory is not writable "
           + "for KSQL server: "
           + streamsStateDir.getPath()

--- a/ksql-rest-app/src/main/java/io/confluent/ksql/rest/server/KsqlServerMain.java
+++ b/ksql-rest-app/src/main/java/io/confluent/ksql/rest/server/KsqlServerMain.java
@@ -50,10 +50,10 @@ public class KsqlServerMain {
       );
 
       final String installDir = properties.getOrDefault("ksql.server.install.dir", "");
-      final String streamsStateDirPath = properties.getOrDefault(
-          KsqlConfig.KSQL_STREAMS_PREFIX + StreamsConfig.STATE_DIR_CONFIG,
-          StreamsConfig.configDef().defaultValues()
-              .get(StreamsConfig.STATE_DIR_CONFIG).toString());
+      final KsqlConfig ksqlConfig = new KsqlConfig(properties);
+      final String streamsStateDirPath = ksqlConfig.getKsqlStreamConfigProps().getOrDefault(
+          StreamsConfig.STATE_DIR_CONFIG,
+          StreamsConfig.configDef().defaultValues().get(StreamsConfig.STATE_DIR_CONFIG)).toString();
       enforceStreamStateDirAvailability(new File(streamsStateDirPath));
       final Optional<String> queriesFile = serverOptions.getQueriesFile(properties);
       final Executable executable = createExecutable(properties, queriesFile, installDir);

--- a/ksql-rest-app/src/main/java/io/confluent/ksql/rest/server/KsqlServerMain.java
+++ b/ksql-rest-app/src/main/java/io/confluent/ksql/rest/server/KsqlServerMain.java
@@ -111,19 +111,37 @@ public class KsqlServerMain {
 
   @VisibleForTesting
   static void enforceStreamStateDirAvailability(final File streamsStateDir) {
-    if (!streamsStateDir.exists() || !streamsStateDir.isDirectory()) {
-      throw new KsqlServerException("The kafka streams state directory does not exist: "
-          + streamsStateDir.getPath()
-          + "\n Make sure the directory exists and is writable for KSQL server."
+    if (!streamsStateDir.exists()) {
+      final boolean mkDirSuccess = streamsStateDir.mkdir();
+      if (!mkDirSuccess) {
+        throw new KsqlServerException("Could not create the kafka streams state directory: "
+            + streamsStateDir.getPath()
+            + "\n Make sure the directory exists and is writable for KSQL server "
+            + "\n or its parend directory is writbale by KSQL server"
+            + "\n or change it to a writable directory by setting '"
+            + KsqlConfig.KSQL_STREAMS_PREFIX + StreamsConfig.STATE_DIR_CONFIG
+            + "' config in the properties file."
+        );
+      }
+    }
+    if (!streamsStateDir.isDirectory()) {
+      throw new KsqlServerException(streamsStateDir.getPath()
+          + " is not a directory."
+          + "\n Make sure the directory exists and is writable for KSQL server "
+          + "\n or its parend directory is writbale by KSQL server"
+          + "\n or change it to a writable directory by setting '"
+          + KsqlConfig.KSQL_STREAMS_PREFIX + StreamsConfig.STATE_DIR_CONFIG
+          + "' config in the properties file."
       );
     }
     if (!streamsStateDir.canWrite()) {
       throw new KsqlServerException("The kafka streams state directory is not writable "
           + "for KSQL server: "
           + streamsStateDir.getPath()
-          + "\n Make sure KSQL server has write access to this directory or change it to a writable"
-          + " one by setting `" + KsqlConfig.KSQL_STREAMS_PREFIX + StreamsConfig.STATE_DIR_CONFIG
-          + "` config in the properties file."
+          + "\n Make sure the directory exists and is writable for KSQL server "
+          + "\n or change it to a writable directory by setting '"
+          + KsqlConfig.KSQL_STREAMS_PREFIX + StreamsConfig.STATE_DIR_CONFIG
+          + "' config in the properties file."
       );
     }
   }

--- a/ksql-rest-app/src/test/java/io/confluent/ksql/rest/server/KsqlServerMainTest.java
+++ b/ksql-rest-app/src/test/java/io/confluent/ksql/rest/server/KsqlServerMainTest.java
@@ -49,9 +49,10 @@ public class KsqlServerMainTest {
   public void setUp() {
     main = new KsqlServerMain(executable);
     when(mockStreamsStateDir.exists()).thenReturn(true);
-    when(mockStreamsStateDir.mkdir()).thenReturn(true);
+    when(mockStreamsStateDir.mkdirs()).thenReturn(true);
     when(mockStreamsStateDir.isDirectory()).thenReturn(true);
     when(mockStreamsStateDir.canWrite()).thenReturn(true);
+    when(mockStreamsStateDir.canExecute()).thenReturn(true);
     when(mockStreamsStateDir.getPath()).thenReturn("/var/lib/kafka-streams");
   }
 
@@ -95,7 +96,7 @@ public class KsqlServerMainTest {
   public void shouldFailIfStreamsStateDirectoryCannotBeCreated() {
     // Given:
     when(mockStreamsStateDir.exists()).thenReturn(false);
-    when(mockStreamsStateDir.mkdir()).thenReturn(false);
+    when(mockStreamsStateDir.mkdirs()).thenReturn(false);
 
     expectedException.expect(KsqlServerException.class);
     expectedException.expectMessage(
@@ -131,6 +132,21 @@ public class KsqlServerMainTest {
   public void shouldFailIfStreamsStateDirectoryIsNotWritable() {
     // Given:
     when(mockStreamsStateDir.canWrite()).thenReturn(false);
+
+    expectedException.expect(KsqlServerException.class);
+    expectedException.expectMessage(
+        "The kafka streams state directory is not writable for KSQL server: /var/lib/kafka-streams\n"
+            + " Make sure the directory exists and is writable for KSQL server \n"
+            + " or change it to a writable directory by setting 'ksql.streams.state.dir' config in the properties file.");
+
+    // When:
+    KsqlServerMain.enforceStreamStateDirAvailability(mockStreamsStateDir);
+  }
+
+  @Test
+  public void shouldFailIfStreamsStateDirectoryIsNotExacutable() {
+    // Given:
+    when(mockStreamsStateDir.canExecute()).thenReturn(false);
 
     expectedException.expect(KsqlServerException.class);
     expectedException.expectMessage(


### PR DESCRIPTION
Currently KSQL server fails if the streams state directory does not exist. With this PR, KSQL server will try to create the folder if it does not exist.
Some of the error messages were also improved.
Unit tests were updated.