### PR TITLE
refactor: datagen to use main format enum (Minor)

### DIFF
--- a/ksql-examples/src/main/java/io/confluent/ksql/datagen/DataGen.java
+++ b/ksql-examples/src/main/java/io/confluent/ksql/datagen/DataGen.java
@@ -17,6 +17,7 @@ package io.confluent.ksql.datagen;
 
 import com.google.common.collect.ImmutableMap;
 import io.confluent.avro.random.generator.Generator;
+import io.confluent.ksql.serde.Format;
 import io.confluent.ksql.util.KsqlConfig;
 import java.io.FileInputStream;
 import java.io.IOException;
@@ -106,8 +107,6 @@ public final class DataGen {
   }
 
   static class Arguments {
-
-    public enum Format { AVRO, JSON, DELIMITED }
 
     private final boolean help;
     private final String bootstrapServer;

--- a/ksql-examples/src/main/java/io/confluent/ksql/datagen/ProducerFactory.java
+++ b/ksql-examples/src/main/java/io/confluent/ksql/datagen/ProducerFactory.java
@@ -15,7 +15,7 @@
 
 package io.confluent.ksql.datagen;
 
-import io.confluent.ksql.datagen.DataGen.Arguments.Format;
+import io.confluent.ksql.serde.Format;
 import io.confluent.ksql.util.KsqlConfig;
 import java.util.Properties;
 


### PR DESCRIPTION
### Description 
Data Gen to use main `Format` enum rather than its own...

### Testing done 

`mvn test` and started datagen.

### Reviewer checklist
- [ ] Ensure docs are updated if necessary. (eg. if a user visible feature is being added or changed).
- [ ] Ensure relevant issues are linked (description should include text like "Fixes #<issue number>")

