### PR TITLE
fix: misplaced commas when formatting CTAS statements

### DIFF
--- a/ksql-parser/src/main/java/io/confluent/ksql/parser/SqlFormatter.java
+++ b/ksql-parser/src/main/java/io/confluent/ksql/parser/SqlFormatter.java
@@ -74,8 +74,7 @@ public final class SqlFormatter {
     return StringUtils.stripEnd(builder.toString(), "\n");
   }
 
-  private static final class Formatter
-          extends AstVisitor<Void, Integer> {
+  private static final class Formatter extends AstVisitor<Void, Integer> {
 
     private final StringBuilder builder;
     private final boolean unmangledNames;
@@ -147,9 +146,9 @@ public final class SqlFormatter {
       if (selectItems.size() > 1) {
         boolean first = true;
         for (final SelectItem item : selectItems) {
-          builder.append("\n")
-                  .append(indentString(indent))
-                  .append(first ? "  " : ", ");
+          builder.append(first ? "" : ",")
+                 .append("\n  ")
+                 .append(indentString(indent));
 
           process(item, indent);
           first = false;

--- a/ksql-parser/src/test/java/io/confluent/ksql/parser/SqlFormatterTest.java
+++ b/ksql-parser/src/test/java/io/confluent/ksql/parser/SqlFormatterTest.java
@@ -324,8 +324,8 @@ public class SqlFormatterTest {
         .getStatement();
     assertThat(SqlFormatter.formatSql(statement),
         equalTo("CREATE STREAM S AS SELECT\n"
-            + "  *\n"
-            + ", ADDRESS.ADDRESS \"CITY\"\n"
+            + "  *,\n"
+            + "  ADDRESS.ADDRESS \"CITY\"\n"
             + "FROM ADDRESS ADDRESS"));
   }
 
@@ -337,8 +337,8 @@ public class SqlFormatterTest {
         .getStatement();
     assertThat(SqlFormatter.formatSql(statement),
         equalTo("CREATE STREAM S AS SELECT\n"
-            + "  ADDRESS.*\n"
-            + ", ITEMID.*\n"
+            + "  ADDRESS.*,\n"
+            + "  ITEMID.*\n"
             + "FROM ADDRESS ADDRESS\n"
             + "INNER JOIN ITEMID ITEMID ON ((ADDRESS.ADDRESS = ITEMID.ADDRESS->ADDRESS))"));
   }
@@ -351,8 +351,8 @@ public class SqlFormatterTest {
         .getStatement();
     assertThat(SqlFormatter.formatSql(statement),
         equalTo("CREATE STREAM S AS SELECT\n"
-            + "  ADDRESS.*\n"
-            + ", ITEMID.ORDERTIME \"ORDERTIME\"\n"
+            + "  ADDRESS.*,\n"
+            + "  ITEMID.ORDERTIME \"ORDERTIME\"\n"
             + "FROM ADDRESS ADDRESS\n"
             + "INNER JOIN ITEMID ITEMID ON ((ADDRESS.ADDRESS = ITEMID.ADDRESS->ADDRESS))"));
   }
@@ -364,8 +364,8 @@ public class SqlFormatterTest {
         .getStatement();
     assertThat(SqlFormatter.formatSql(statement),
         equalTo("CREATE STREAM S AS SELECT\n"
-            + "  ADDRESS.ADDRESS \"ONE\"\n"
-            + ", ADDRESS.ADDRESS \"TWO\"\n"
+            + "  ADDRESS.ADDRESS \"ONE\",\n"
+            + "  ADDRESS.ADDRESS \"TWO\"\n"
             + "FROM ADDRESS ADDRESS"));
   }
 
@@ -532,8 +532,8 @@ public class SqlFormatterTest {
     final String result = SqlFormatter.formatSql(statement);
 
     assertThat(result, is("CREATE STREAM S AS SELECT\n"
-        + "  ORDERS.ITEMID \"ITEMID\"\n"
-        + ", COUNT(*) \"KSQL_COL_1\"\n"
+        + "  ORDERS.ITEMID \"ITEMID\",\n"
+        + "  COUNT(*) \"KSQL_COL_1\"\n"
         + "FROM ORDERS ORDERS\n"
         + "WINDOW TUMBLING ( SIZE 7 DAYS ) \n"
         + "GROUP BY ORDERS.ITEMID"));
@@ -549,8 +549,8 @@ public class SqlFormatterTest {
     final String result = SqlFormatter.formatSql(statement);
 
     assertThat(result, is("CREATE STREAM S AS SELECT\n"
-        + "  ORDERS.ITEMID \"ITEMID\"\n"
-        + ", COUNT(*) \"KSQL_COL_1\"\n"
+        + "  ORDERS.ITEMID \"ITEMID\",\n"
+        + "  COUNT(*) \"KSQL_COL_1\"\n"
         + "FROM ORDERS ORDERS\n"
         + "WINDOW HOPPING ( SIZE 20 SECONDS , ADVANCE BY 5 SECONDS ) \n"
         + "GROUP BY ORDERS.ITEMID"));
@@ -566,8 +566,8 @@ public class SqlFormatterTest {
     final String result = SqlFormatter.formatSql(statement);
 
     assertThat(result, is("CREATE STREAM S AS SELECT\n"
-        + "  ORDERS.ITEMID \"ITEMID\"\n"
-        + ", COUNT(*) \"KSQL_COL_1\"\n"
+        + "  ORDERS.ITEMID \"ITEMID\",\n"
+        + "  COUNT(*) \"KSQL_COL_1\"\n"
         + "FROM ORDERS ORDERS\n"
         + "WINDOW SESSION ( 15 MINUTES ) \n"
         + "GROUP BY ORDERS.ITEMID"));


### PR DESCRIPTION
  - commas now placed after each projection field on same line
  - fixed unit tests to reflect new format

### Description 
_Fixes #3014, to place commas on the same line as the field_

### Testing done 
_Fixed unit tests and also verified on ksql commandline and confluent UI locally._

### Reviewer checklist
- [ ] Ensure docs are updated if necessary. (eg. if a user visible feature is being added or changed).
- [ ] Ensure relevant issues are linked (description should include text like "Fixes #<issue number>")

