### PR TITLE
fix: Update version checker to use new dependencies

### DIFF
--- a/ksql-rest-app/src/test/java/io/confluent/ksql/rest/server/resources/KsqlResourceTest.java
+++ b/ksql-rest-app/src/test/java/io/confluent/ksql/rest/server/resources/KsqlResourceTest.java
@@ -1344,8 +1344,7 @@ public class KsqlResourceTest {
     final PropertiesList props = makeSingleRequest("list properties;", PropertiesList.class);
 
     // Then:
-    assertThat(props.getDefaultProperties(),
-        hasItem(KsqlConfig.KSQL_STREAMS_PREFIX + StreamsConfig.STATE_DIR_CONFIG));
+    assertThat(props.getDefaultProperties(), hasItem(KsqlConfig.KSQL_SERVICE_ID_CONFIG));
   }
 
   @Test

--- a/ksql-rest-app/src/test/java/io/confluent/ksql/rest/server/resources/KsqlResourceTest.java
+++ b/ksql-rest-app/src/test/java/io/confluent/ksql/rest/server/resources/KsqlResourceTest.java
@@ -1337,14 +1337,15 @@ public class KsqlResourceTest {
   public void shouldListDefaultKsqlProperty() {
     // Given:
     givenKsqlConfigWith(ImmutableMap.<String, Object>builder()
-        .put(StreamsConfig.STATE_DIR_CONFIG, "/var/lib/kafka-streams")
+        .put(StreamsConfig.STATE_DIR_CONFIG, "/tmp/kafka-streams")
         .build());
 
     // When:
     final PropertiesList props = makeSingleRequest("list properties;", PropertiesList.class);
 
     // Then:
-    assertThat(props.getDefaultProperties(), hasItem(KsqlConfig.KSQL_SERVICE_ID_CONFIG));
+    assertThat(props.getDefaultProperties(),
+               hasItem(KsqlConfig.KSQL_STREAMS_PREFIX + StreamsConfig.STATE_DIR_CONFIG));
   }
 
   @Test

--- a/ksql-version-metrics-client/pom.xml
+++ b/ksql-version-metrics-client/pom.xml
@@ -44,6 +44,11 @@
             <artifactId>jackson-databind</artifactId>
         </dependency>
 
+        <dependency>
+            <groupId>io.confluent.ksql</groupId>
+            <artifactId>ksql-engine</artifactId>
+        </dependency>
+
         <!-- Required for running tests -->
 
         <dependency>

--- a/ksql-version-metrics-client/src/main/java/io/confluent/ksql/version/metrics/collector/BasicCollector.java
+++ b/ksql-version-metrics-client/src/main/java/io/confluent/ksql/version/metrics/collector/BasicCollector.java
@@ -15,14 +15,13 @@
 
 package io.confluent.ksql.version.metrics.collector;
 
+import io.confluent.ksql.util.Version;
 import io.confluent.ksql.version.metrics.KsqlVersionMetrics;
 import io.confluent.support.metrics.common.Collector;
 import java.time.Clock;
 import java.util.Objects;
 import java.util.concurrent.TimeUnit;
 import java.util.function.Supplier;
-
-import org.apache.kafka.common.utils.AppInfoParser;
 
 
 public class BasicCollector extends Collector {
@@ -52,14 +51,10 @@ public class BasicCollector extends Collector {
   public KsqlVersionMetrics collectMetrics() {
     final KsqlVersionMetrics metricsRecord = new KsqlVersionMetrics();
     metricsRecord.setTimestamp(TimeUnit.MILLISECONDS.toSeconds(clock.millis()));
-    metricsRecord.setConfluentPlatformVersion(cpVersion(AppInfoParser.getVersion()));
+    metricsRecord.setConfluentPlatformVersion(Version.getVersion());
     metricsRecord.setKsqlComponentType(moduleType.name());
     metricsRecord.setIsActive(activenessSupplier.get());
     return metricsRecord;
   }
 
-  // Visible for Testing
-  public static String cpVersion(final String kafkaVersion) {
-    return kafkaVersion.replace("-ce", "").replace("-ccs", "");
-  }
 }

--- a/ksql-version-metrics-client/src/main/java/io/confluent/ksql/version/metrics/collector/BasicCollector.java
+++ b/ksql-version-metrics-client/src/main/java/io/confluent/ksql/version/metrics/collector/BasicCollector.java
@@ -17,11 +17,13 @@ package io.confluent.ksql.version.metrics.collector;
 
 import io.confluent.ksql.version.metrics.KsqlVersionMetrics;
 import io.confluent.support.metrics.common.Collector;
-import io.confluent.support.metrics.common.Version;
 import java.time.Clock;
 import java.util.Objects;
 import java.util.concurrent.TimeUnit;
 import java.util.function.Supplier;
+
+import org.apache.kafka.common.utils.AppInfoParser;
+
 
 public class BasicCollector extends Collector {
 
@@ -50,9 +52,14 @@ public class BasicCollector extends Collector {
   public KsqlVersionMetrics collectMetrics() {
     final KsqlVersionMetrics metricsRecord = new KsqlVersionMetrics();
     metricsRecord.setTimestamp(TimeUnit.MILLISECONDS.toSeconds(clock.millis()));
-    metricsRecord.setConfluentPlatformVersion(Version.getVersion());
+    metricsRecord.setConfluentPlatformVersion(cpVersion(AppInfoParser.getVersion()));
     metricsRecord.setKsqlComponentType(moduleType.name());
     metricsRecord.setIsActive(activenessSupplier.get());
     return metricsRecord;
+  }
+
+  // Visible for Testing
+  public static String cpVersion(final String kafkaVersion) {
+    return kafkaVersion.replace("-ce", "").replace("-ccs", "");
   }
 }

--- a/ksql-version-metrics-client/src/main/java/io/confluent/ksql/version/metrics/collector/BasicCollector.java
+++ b/ksql-version-metrics-client/src/main/java/io/confluent/ksql/version/metrics/collector/BasicCollector.java
@@ -23,7 +23,6 @@ import java.util.Objects;
 import java.util.concurrent.TimeUnit;
 import java.util.function.Supplier;
 
-
 public class BasicCollector extends Collector {
 
   private final KsqlModuleType moduleType;
@@ -56,5 +55,4 @@ public class BasicCollector extends Collector {
     metricsRecord.setIsActive(activenessSupplier.get());
     return metricsRecord;
   }
-
 }

--- a/ksql-version-metrics-client/src/test/java/io/confluent/ksql/version/metrics/collector/BasicCollectorTest.java
+++ b/ksql-version-metrics-client/src/test/java/io/confluent/ksql/version/metrics/collector/BasicCollectorTest.java
@@ -20,10 +20,11 @@ import static org.junit.Assert.assertThat;
 import static org.mockito.Mockito.when;
 
 import io.confluent.ksql.version.metrics.KsqlVersionMetrics;
-import io.confluent.support.metrics.common.Version;
 import java.time.Clock;
 import java.util.concurrent.TimeUnit;
 import java.util.function.Supplier;
+
+import org.apache.kafka.common.utils.AppInfoParser;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -97,7 +98,8 @@ public class BasicCollectorTest {
     final KsqlVersionMetrics metrics = basicCollector.collectMetrics();
 
     // Then:
-    assertThat(metrics.getConfluentPlatformVersion(), is(Version.getVersion()));
+    assertThat(metrics.getConfluentPlatformVersion(),
+               is(BasicCollector.cpVersion(AppInfoParser.getVersion())));
   }
 
   @Test

--- a/ksql-version-metrics-client/src/test/java/io/confluent/ksql/version/metrics/collector/BasicCollectorTest.java
+++ b/ksql-version-metrics-client/src/test/java/io/confluent/ksql/version/metrics/collector/BasicCollectorTest.java
@@ -19,6 +19,7 @@ import static org.hamcrest.Matchers.is;
 import static org.junit.Assert.assertThat;
 import static org.mockito.Mockito.when;
 
+import io.confluent.ksql.util.Version;
 import io.confluent.ksql.version.metrics.KsqlVersionMetrics;
 import java.time.Clock;
 import java.util.concurrent.TimeUnit;
@@ -98,8 +99,8 @@ public class BasicCollectorTest {
     final KsqlVersionMetrics metrics = basicCollector.collectMetrics();
 
     // Then:
-    assertThat(metrics.getConfluentPlatformVersion(),
-               is(BasicCollector.cpVersion(AppInfoParser.getVersion())));
+    assertThat(metrics.getConfluentPlatformVersion(), is(Version.getVersion()));
+    System.out.println(Version.getVersion());
   }
 
   @Test

--- a/ksql-version-metrics-client/src/test/java/io/confluent/ksql/version/metrics/collector/BasicCollectorTest.java
+++ b/ksql-version-metrics-client/src/test/java/io/confluent/ksql/version/metrics/collector/BasicCollectorTest.java
@@ -25,7 +25,6 @@ import java.time.Clock;
 import java.util.concurrent.TimeUnit;
 import java.util.function.Supplier;
 
-import org.apache.kafka.common.utils.AppInfoParser;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -100,7 +99,6 @@ public class BasicCollectorTest {
 
     // Then:
     assertThat(metrics.getConfluentPlatformVersion(), is(Version.getVersion()));
-    System.out.println(Version.getVersion());
   }
 
   @Test


### PR DESCRIPTION
### Description 
Use local version checker and change a test case to fix the build. 

Also had to change the kafka streams state directory back to `/tmp/kafka-streams` in the `KsqlResourceTest.shouldListDefaultKsqlProperty`, since that is the new default upstream.

### Testing done 
Build passes

### Reviewer checklist
- [ ] Ensure docs are updated if necessary. (eg. if a user visible feature is being added or changed).
- [ ] Ensure relevant issues are linked (description should include text like "Fixes #<issue number>")

