### PR TITLE
fix: ensure topology generator test runs in build (MINOR)

### DIFF
--- a/ksql-functional-tests/src/test/java/io/confluent/ksql/test/EndToEndEngineTestUtil.java
+++ b/ksql-functional-tests/src/test/java/io/confluent/ksql/test/EndToEndEngineTestUtil.java
@@ -268,7 +268,9 @@ final class EndToEndEngineTestUtil {
   }
 
   static String formatQueryName(final String originalQueryName) {
-    return originalQueryName.replaceAll(" - (AVRO|JSON)$", "").replaceAll("\\s", "_");
+    return originalQueryName
+        .replaceAll(" - (AVRO|JSON)$", "")
+        .replaceAll("\\s|/", "_");
   }
 
   static Map<String, TopologyAndConfigs> loadExpectedTopologies(final String dir) {

--- a/ksql-functional-tests/src/test/java/io/confluent/ksql/test/TopologyFileGenerator.java
+++ b/ksql-functional-tests/src/test/java/io/confluent/ksql/test/TopologyFileGenerator.java
@@ -17,7 +17,6 @@ package io.confluent.ksql.test;
 
 import io.confluent.ksql.test.tools.TestCase;
 import java.io.File;
-import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
@@ -25,14 +24,10 @@ import java.util.List;
 import java.util.stream.Collectors;
 import javax.xml.parsers.DocumentBuilder;
 import javax.xml.parsers.DocumentBuilderFactory;
-import javax.xml.parsers.ParserConfigurationException;
 import org.apache.kafka.test.IntegrationTest;
-import org.apache.kafka.test.TestUtils;
-import org.junit.Test;
 import org.junit.experimental.categories.Category;
 import org.w3c.dom.Document;
 import org.w3c.dom.NodeList;
-import org.xml.sax.SAXException;
 
 /**
  * This class is used to generate the topology files to ensure safe
@@ -56,15 +51,11 @@ public final class TopologyFileGenerator {
 
     private static final String BASE_DIRECTORY = "src/test/resources/expected_topology/";
 
-    public static void main(final String[] args) throws Exception {
-        generateTopologies(findBaseDir());
+    private TopologyFileGenerator() {
     }
 
-    @Test
-    public void shouldGenerateTopologies() throws Exception {
-        final File tmp = TestUtils.tempDirectory();
-        tmp.deleteOnExit();
-        generateTopologies(tmp.toPath());
+    public static void main(final String[] args) throws Exception {
+        generateTopologies(findBaseDir());
     }
 
     static Path findBaseDir() {
@@ -81,7 +72,7 @@ public final class TopologyFileGenerator {
             + "root of the ksql-functional-tests module");
     }
 
-    private static void generateTopologies(final Path base) throws Exception {
+    static void generateTopologies(final Path base) throws Exception {
         final String formattedVersion = getFormattedVersionFromPomFile();
         final Path generatedTopologyPath = base.resolve(formattedVersion);
 
@@ -105,7 +96,7 @@ public final class TopologyFileGenerator {
             .collect(Collectors.toList());
     }
 
-    private static String getFormattedVersionFromPomFile() throws IOException, ParserConfigurationException, SAXException {
+    private static String getFormattedVersionFromPomFile() throws Exception {
         final File pomFile = new File("pom.xml");
         final DocumentBuilderFactory documentBuilderFactory = DocumentBuilderFactory.newInstance();
         final DocumentBuilder documentBuilder = documentBuilderFactory.newDocumentBuilder();

--- a/ksql-functional-tests/src/test/java/io/confluent/ksql/test/TopologyFileGeneratorTest.java
+++ b/ksql-functional-tests/src/test/java/io/confluent/ksql/test/TopologyFileGeneratorTest.java
@@ -1,0 +1,38 @@
+/*
+ * Copyright 2019 Confluent Inc.
+ *
+ * Licensed under the Confluent Community License (the "License"); you may not use
+ * this file except in compliance with the License.  You may obtain a copy of the
+ * License at
+ *
+ * http://www.confluent.io/confluent-community-license
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package io.confluent.ksql.test;
+
+import org.apache.kafka.test.IntegrationTest;
+import org.junit.ClassRule;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.junit.rules.TemporaryFolder;
+
+/**
+ * Do not combine this with `TopologyFileGenerator` as mvn will ignore the tests as the class
+ * does not end in `Test`.
+ */
+@Category(IntegrationTest.class)
+public final class TopologyFileGeneratorTest {
+
+    @ClassRule
+    public static final TemporaryFolder TMP = new TemporaryFolder();
+
+    @Test
+    public void shouldGenerateTopologies() throws Exception {
+        TopologyFileGenerator.generateTopologies(TMP.newFolder().toPath());
+    }
+}


### PR DESCRIPTION
### Description 

Because the class name does not end in `Test` mvn surefire ignore it. So lets move the test into a test file.

This highlights we've got test cases with `/` in their name, which when used in a path, results in a `DirectoryDoesNotExist` exception, so let's replace the `\` with a `_`.

### Testing done 

Test only change.

### Reviewer checklist
- [ ] Ensure docs are updated if necessary. (eg. if a user visible feature is being added or changed).
- [ ] Ensure relevant issues are linked (description should include text like "Fixes #<issue number>")

