### PR TITLE
fix: remove last of registered topics stuff from api / cli (MINOR)

### DIFF
--- a/docs/developer-guide/query-with-structured-data.rst
+++ b/docs/developer-guide/query-with-structured-data.rst
@@ -121,12 +121,12 @@ Your output should resemble:
 
 ::
 
-     Kafka Topic        | Registered | Partitions | Partition Replicas | Consumers | ConsumerGroups
-    ------------------------------------------------------------------------------------------------
-     _confluent-metrics | false      | 12         | 1                  | 0         | 0
-     _schemas           | false      | 1          | 1                  | 0         | 0
-     raw-topic          | false      | 1          | 1                  | 0         | 0
-    ------------------------------------------------------------------------------------------------
+     Kafka Topic        | Partitions | Partition Replicas | Consumers | ConsumerGroups
+    ----------------------------------------------------------------------------------
+     _confluent-metrics | 12         | 1                  | 0         | 0
+     _schemas           | 1          | 1                  | 0         | 0
+     raw-topic          | 1          | 1                  | 0         | 0
+    ----------------------------------------------------------------------------------
 
 Inspect ``raw-topic`` to ensure that |kcat| populated it: 
 

--- a/docs/includes/ksql-includes.rst
+++ b/docs/includes/ksql-includes.rst
@@ -126,13 +126,13 @@ Your output should resemble:
 
 ::
 
-     Kafka Topic        | Registered | Partitions | Partition Replicas | Consumers | ConsumerGroups
-    ------------------------------------------------------------------------------------------------
-     _confluent-metrics | false      | 12         | 1                  | 0         | 0
-     _schemas           | false      | 1          | 1                  | 0         | 0
-     pageviews          | false      | 1          | 1                  | 0         | 0
-     users              | false      | 1          | 1                  | 0         | 0
-    ------------------------------------------------------------------------------------------------
+     Kafka Topic        | Partitions | Partition Replicas | Consumers | ConsumerGroups
+    -----------------------------------------------------------------------------------
+     _confluent-metrics | 12         | 1                  | 0         | 0
+     _schemas           | 1          | 1                  | 0         | 0
+     pageviews          | 1          | 1                  | 0         | 0
+     users              | 1          | 1                  | 0         | 0
+    -----------------------------------------------------------------------------------
 
 Inspect the ``users`` topic by using the PRINT statement:
 

--- a/ksql-cli/src/main/java/io/confluent/ksql/cli/console/table/builder/KafkaTopicsListTableBuilder.java
+++ b/ksql-cli/src/main/java/io/confluent/ksql/cli/console/table/builder/KafkaTopicsListTableBuilder.java
@@ -27,7 +27,6 @@ public class KafkaTopicsListTableBuilder implements TableBuilder<KafkaTopicsList
 
   private static final List<String> HEADERS = ImmutableList.of(
       "Kafka Topic",
-      "Registered",
       "Partitions",
       "Partition Replicas",
       "Consumers",
@@ -38,7 +37,6 @@ public class KafkaTopicsListTableBuilder implements TableBuilder<KafkaTopicsList
     final Stream<List<String>> rows = entity.getTopics().stream()
         .map(t -> ImmutableList.of(
             t.getName(),
-            Boolean.toString(t.getRegistered()),
             Integer.toString(t.getReplicaInfo().size()),
             getTopicReplicaInfo(t.getReplicaInfo()),
             Integer.toString(t.getConsumerCount()),

--- a/ksql-cli/src/test/java/io/confluent/ksql/cli/CliTest.java
+++ b/ksql-cli/src/test/java/io/confluent/ksql/cli/CliTest.java
@@ -364,7 +364,6 @@ public class CliTest {
         "topics",
         hasRow(
             equalTo(orderDataProvider.topicName()),
-            equalTo("true"),
             equalTo("1"),
             equalTo("1"),
             any(String.class),

--- a/ksql-rest-app/src/main/java/io/confluent/ksql/rest/entity/KafkaTopicInfo.java
+++ b/ksql-rest-app/src/main/java/io/confluent/ksql/rest/entity/KafkaTopicInfo.java
@@ -27,7 +27,6 @@ import java.util.Objects;
 public class KafkaTopicInfo {
 
   private final String name;
-  private final boolean registered;
   private final List<Integer> replicaInfo;
   private final int consumerGroupCount;
   private final int consumerCount;
@@ -35,13 +34,11 @@ public class KafkaTopicInfo {
   @JsonCreator
   public KafkaTopicInfo(
       @JsonProperty("name") final String name,
-      @JsonProperty("registered") final boolean registered,
       @JsonProperty("replicaInfo") final List<Integer> replicaInfo,
       @JsonProperty("consumerCount") final int consumerCount,
       @JsonProperty("consumerGroupCount") final int consumerGroupCount
   ) {
     this.name = name;
-    this.registered = registered;
     this.replicaInfo = replicaInfo;
     this.consumerGroupCount = consumerGroupCount;
     this.consumerCount = consumerCount;
@@ -49,10 +46,6 @@ public class KafkaTopicInfo {
 
   public String getName() {
     return name;
-  }
-
-  public boolean getRegistered() {
-    return registered;
   }
 
   public List<Integer> getReplicaInfo() {

--- a/ksql-rest-app/src/main/java/io/confluent/ksql/rest/server/execution/ListTopicsExecutor.java
+++ b/ksql-rest-app/src/main/java/io/confluent/ksql/rest/server/execution/ListTopicsExecutor.java
@@ -41,11 +41,9 @@ public final class ListTopicsExecutor {
 
     return Optional.of(KafkaTopicsList.build(
         statement.getStatementText(),
-        executionContext.getMetaStore().getAllKsqlTopics().values(),
         client.describeTopics(client.listNonInternalTopicNames()),
         statement.getConfig(),
         kafkaConsumerGroupClient
     ));
   }
-
 }

--- a/ksql-rest-app/src/test/java/io/confluent/ksql/rest/entity/KafkaTopicsListTest.java
+++ b/ksql-rest-app/src/test/java/io/confluent/ksql/rest/entity/KafkaTopicsListTest.java
@@ -53,9 +53,6 @@ public class KafkaTopicsListTest {
     topicDescriptions.put("test-topic", new TopicDescription("test-topic", false, Collections.singletonList(topicPartitionInfo)));
 
 
-    /**
-     * Return POJO for consumerGroupClient
-     */
     final TopicPartition topicPartition = new TopicPartition("test-topic", 1);
     final KafkaConsumerGroupClientImpl.ConsumerSummary consumerSummary = new KafkaConsumerGroupClientImpl.ConsumerSummary("consumer-id");
     consumerSummary.addPartition(topicPartition);
@@ -70,11 +67,7 @@ public class KafkaTopicsListTest {
     expect(consumerGroupClient.describeConsumerGroup("test-topic")).andReturn(consumerGroupSummary);
     replay(consumerGroupClient);
 
-    /**
-     * Test
-     */
-
-    final KafkaTopicsList topicsList = KafkaTopicsList.build("statement test", ksqlTopics, topicDescriptions, new KsqlConfig(Collections.EMPTY_MAP), consumerGroupClient);
+    final KafkaTopicsList topicsList = KafkaTopicsList.build("statement test", topicDescriptions, new KsqlConfig(Collections.EMPTY_MAP), consumerGroupClient);
 
     assertThat(topicsList.getTopics().size(), equalTo(1));
     final KafkaTopicInfo first = topicsList.getTopics().iterator().next();
@@ -89,7 +82,7 @@ public class KafkaTopicsListTest {
     final ObjectMapper mapper = JsonMapper.INSTANCE.mapper;
     final KafkaTopicsList expected = new KafkaTopicsList(
         "SHOW TOPICS;",
-        ImmutableList.of(new KafkaTopicInfo("thetopic", true, ImmutableList.of(1, 2, 3), 42, 12))
+        ImmutableList.of(new KafkaTopicInfo("thetopic", ImmutableList.of(1, 2, 3), 42, 12))
     );
     final String json = mapper.writeValueAsString(expected);
     assertEquals(

--- a/ksql-rest-app/src/test/java/io/confluent/ksql/rest/entity/KafkaTopicsListTest.java
+++ b/ksql-rest-app/src/test/java/io/confluent/ksql/rest/entity/KafkaTopicsListTest.java
@@ -25,11 +25,9 @@ import static org.junit.Assert.assertEquals;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.common.collect.ImmutableList;
 import io.confluent.ksql.json.JsonMapper;
-import io.confluent.ksql.metastore.model.KsqlTopic;
 import io.confluent.ksql.util.KafkaConsumerGroupClient;
 import io.confluent.ksql.util.KafkaConsumerGroupClientImpl;
 import io.confluent.ksql.util.KsqlConfig;
-import java.util.Collection;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
@@ -45,7 +43,6 @@ public class KafkaTopicsListTest {
   @Test
   public void shouldBuildValidTopicList() {
 
-    final Collection<KsqlTopic> ksqlTopics = Collections.emptyList();
     // represent the full list of topics
     final Map<String, TopicDescription> topicDescriptions = new HashMap<>();
     final TopicPartitionInfo topicPartitionInfo = new TopicPartitionInfo(1, new Node(1, "", 8088),
@@ -86,10 +83,12 @@ public class KafkaTopicsListTest {
     );
     final String json = mapper.writeValueAsString(expected);
     assertEquals(
-        "{\"@type\":\"kafka_topics\",\"statementText\":\"SHOW TOPICS;\"," +
-        "\"topics\":[{\"name\":\"thetopic\",\"registered\":true," +
-        "\"replicaInfo\":[1,2,3],\"consumerCount\":42," +
-        "\"consumerGroupCount\":12}]}",
+        "{"
+            + "\"@type\":\"kafka_topics\","
+            + "\"statementText\":\"SHOW TOPICS;\","
+            + "\"topics\":["
+            + "{\"name\":\"thetopic\",\"replicaInfo\":[1,2,3],\"consumerCount\":42,\"consumerGroupCount\":12}"
+            + "]}",
         json);
 
     final KafkaTopicsList actual = mapper.readValue(json, KafkaTopicsList.class);

--- a/ksql-rest-app/src/test/java/io/confluent/ksql/rest/server/execution/ListTopicsExecutorTest.java
+++ b/ksql-rest-app/src/test/java/io/confluent/ksql/rest/server/execution/ListTopicsExecutorTest.java
@@ -72,8 +72,8 @@ public class ListTopicsExecutorTest {
 
     // Then:
     assertThat(topicsList.getTopics(), containsInAnyOrder(
-        new KafkaTopicInfo("topic1", true, ImmutableList.of(1), 0, 0),
-        new KafkaTopicInfo("topic2", false, ImmutableList.of(1), 0, 0)
+        new KafkaTopicInfo("topic1", ImmutableList.of(1), 0, 0),
+        new KafkaTopicInfo("topic2", ImmutableList.of(1), 0, 0)
     ));
   }
 

--- a/ksql-rest-app/src/test/java/io/confluent/ksql/rest/server/resources/KsqlResourceTest.java
+++ b/ksql-rest-app/src/test/java/io/confluent/ksql/rest/server/resources/KsqlResourceTest.java
@@ -1553,7 +1553,7 @@ public class KsqlResourceTest {
   public void shouldNeverEnqueueIfErrorIsThrown() {
     // Given:
     givenMockEngine();
-    when(ksqlEngine.getMetaStore()).thenThrow(new KsqlException("Fail"));
+    when(ksqlEngine.parse(anyString())).thenThrow(new KsqlException("Fail"));
 
     // When:
     makeFailingRequest(


### PR DESCRIPTION
### Description 

We've already removed `REGSITER TOPIC` and `DELETE TOPIC` syntax, but the
CLI still reports if a topic is registered or not.  Let's tidy this up.

This PR removes the `Registered` column from the `show topics` command as there is not 'registered topic' functionality any more.

Also see related #3072

### Testing done 

`mvn test`.

### Reviewer checklist
- [ ] Ensure docs are updated if necessary. (eg. if a user visible feature is being added or changed).
- [ ] Ensure relevant issues are linked (description should include text like "Fixes #<issue number>")

