### PR TITLE
feat(rest server): add warnings when listing fails with kafka error

### DIFF
--- a/docs/developer-guide/api.rst
+++ b/docs/developer-guide/api.rst
@@ -117,9 +117,16 @@ statements use the ``/query`` endpoint.
 
    The response JSON is an array of result objects. The result object contents depend on the statement that it is returning results for. The following sections detail the contents of the result objects by statement.
 
-   **CREATE, DROP, TERMINATE**
+   **Common Fields**
+   The following fields are common to all responses.
 
    :>json string statementText: The KSQL statement whose result is being returned.
+   :>json array  warnings: A list of warnings about conditions that may be unexpected by the user, b
+ut don't result in failure to execute the statement.
+   :>json string warnings[i].message: A message detailing the condition being warned on.
+
+   **CREATE, DROP, TERMINATE**
+
    :>json string commandId: A string that identifies the requested operation. You can use this ID to poll the result of the operation using the status endpoint.
    :>json string commandStatus.status: One of QUEUED, PARSING, EXECUTING, TERMINATED, SUCCESS, or ERROR.
    :>json string commandStatus.message: Detailed message regarding the status of the execution statement.
@@ -127,7 +134,6 @@ statements use the ``/query`` endpoint.
 
    **LIST STREAMS, SHOW STREAMS**
 
-   :>json string statementText: The KSQL statement whose result is being returned.
    :>json array  streams: List of streams.
    :>json string streams[i].name: The name of the stream.
    :>json string streams[i].topic: The topic backing the stream.
@@ -135,7 +141,6 @@ statements use the ``/query`` endpoint.
 
    **LIST TABLES, SHOW TABLES**
 
-   :>json string statementText: The KSQL statement whose result is being returned.
    :>json array  tables: List of tables.
    :>json string tables[i].name: The name of the table.
    :>json string tables[i].topic: The topic backing the table.
@@ -143,7 +148,6 @@ statements use the ``/query`` endpoint.
 
    **LIST QUERIES, SHOW QUERIES**
 
-   :>json string statementText: The KSQL statement whose result is being returned.
    :>json array  queries: List of queries.
    :>json string queries[i].queryString: The text of the statement that started the query.
    :>json string queries[i].sinks: The streams and tables being written to by the query.
@@ -151,13 +155,11 @@ statements use the ``/query`` endpoint.
 
    **LIST PROPERTIES, SHOW PROPERTIES**
 
-   :>json string statementText: The KSQL statement whose result is being returned.
    :>json map    properties: The KSQL server query properties.
    :>json string properties[``property-name``]: The value of the property named by ``property-name``.
 
    **DESCRIBE**
 
-   :>json string  statementText: The KSQL statement whose result is being returned.
    :>json string  sourceDescription.name: The name of the stream or table.
    :>json array   sourceDescription.readQueries: The queries reading from the stream or table.
    :>json array   sourceDescription.writeQueries: The queries writing into the stream or table
@@ -180,7 +182,6 @@ statements use the ``/query`` endpoint.
 
    **EXPLAIN**
 
-   :>json string statementText: The KSQL statement whose result is being returned.
    :>json string queryDescription.statementText: The KSQL statement for which the query being explained is running.
    :>json array  queryDescription.fields: A list of field objects that describes each field in the query output.
    :>json string queryDescription.fields[i].name: The name of the field.

--- a/ksql-cli/src/main/java/io/confluent/ksql/cli/console/Console.java
+++ b/ksql-cli/src/main/java/io/confluent/ksql/cli/console/Console.java
@@ -51,6 +51,7 @@ import io.confluent.ksql.rest.entity.KsqlEntityList;
 import io.confluent.ksql.rest.entity.KsqlErrorMessage;
 import io.confluent.ksql.rest.entity.KsqlStatementErrorMessage;
 import io.confluent.ksql.rest.entity.KsqlTopicsList;
+import io.confluent.ksql.rest.entity.KsqlWarning;
 import io.confluent.ksql.rest.entity.PropertiesList;
 import io.confluent.ksql.rest.entity.Queries;
 import io.confluent.ksql.rest.entity.QueryDescription;
@@ -383,6 +384,14 @@ public class Console implements Closeable {
     }
     
     handler.handle(this, entity);
+
+    printWarnings(entity);
+  }
+
+  private void printWarnings(final KsqlEntity entity) {
+    for (final KsqlWarning warning : entity.getWarnings()) {
+      writer().println("WARNING: " + warning.getMessage());
+    }
   }
 
   @SuppressWarnings("ConstantConditions")

--- a/ksql-rest-app/src/main/java/io/confluent/ksql/rest/entity/KsqlEntity.java
+++ b/ksql-rest-app/src/main/java/io/confluent/ksql/rest/entity/KsqlEntity.java
@@ -18,6 +18,9 @@ package io.confluent.ksql.rest.entity;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonSubTypes;
 import com.fasterxml.jackson.annotation.JsonTypeInfo;
+import com.google.common.collect.ImmutableList;
+import java.util.Collections;
+import java.util.List;
 
 @JsonIgnoreProperties(ignoreUnknown = true)
 @JsonTypeInfo(
@@ -43,12 +46,22 @@ import com.fasterxml.jackson.annotation.JsonTypeInfo;
 })
 public abstract class KsqlEntity {
   private final String statementText;
+  private final List<KsqlWarning> warnings;
 
   public KsqlEntity(final String statementText) {
+    this(statementText, Collections.emptyList());
+  }
+
+  public KsqlEntity(final String statementText, final List<KsqlWarning> warnings) {
     this.statementText = statementText;
+    this.warnings = warnings == null ? Collections.emptyList() : ImmutableList.copyOf(warnings);
   }
 
   public String getStatementText() {
     return statementText;
+  }
+
+  public List<KsqlWarning> getWarnings() {
+    return warnings;
   }
 }

--- a/ksql-rest-app/src/main/java/io/confluent/ksql/rest/entity/KsqlWarning.java
+++ b/ksql-rest-app/src/main/java/io/confluent/ksql/rest/entity/KsqlWarning.java
@@ -18,24 +18,26 @@ package io.confluent.ksql.rest.entity;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
-import java.util.List;
+import com.google.errorprone.annotations.Immutable;
 import java.util.Objects;
 
+@Immutable
 @JsonIgnoreProperties(ignoreUnknown = true)
-public class SourceDescriptionEntity extends KsqlEntity {
-  private final SourceDescription sourceDescription;
+public class KsqlWarning {
+  private final String message;
 
   @JsonCreator
-  public SourceDescriptionEntity(
-      @JsonProperty("statementText") final String statementText,
-      @JsonProperty("sourceDescription") final SourceDescription sourceDescription,
-      @JsonProperty("warnings") final List<KsqlWarning> warnings) {
-    super(statementText, warnings);
-    this.sourceDescription = sourceDescription;
+  public KsqlWarning(@JsonProperty("message") final String message) {
+    this.message = Objects.requireNonNull(message, "message");
   }
 
-  public SourceDescription getSourceDescription() {
-    return sourceDescription;
+  public String getMessage() {
+    return message;
+  }
+
+  @Override
+  public String toString() {
+    return message;
   }
 
   @Override
@@ -43,15 +45,15 @@ public class SourceDescriptionEntity extends KsqlEntity {
     if (this == o) {
       return true;
     }
-    if (!(o instanceof SourceDescriptionEntity)) {
+    if (!(o instanceof KsqlWarning)) {
       return false;
     }
-    final SourceDescriptionEntity other = (SourceDescriptionEntity)o;
-    return Objects.equals(sourceDescription, other.sourceDescription);
+    final KsqlWarning that = (KsqlWarning) o;
+    return Objects.equals(message, that.message);
   }
 
   @Override
   public int hashCode() {
-    return Objects.hash(getSourceDescription());
+    return Objects.hash(message);
   }
 }

--- a/ksql-rest-app/src/main/java/io/confluent/ksql/rest/entity/SourceDescriptionList.java
+++ b/ksql-rest-app/src/main/java/io/confluent/ksql/rest/entity/SourceDescriptionList.java
@@ -29,9 +29,10 @@ public class SourceDescriptionList extends KsqlEntity {
   @JsonCreator
   public SourceDescriptionList(
       @JsonProperty("statementText") final String statementText,
-      @JsonProperty("sourceDescriptions") final List<SourceDescription> sourceDescriptions
+      @JsonProperty("sourceDescriptions") final List<SourceDescription> sourceDescriptions,
+      @JsonProperty("warnings") final List<KsqlWarning> warnings
   ) {
-    super(statementText);
+    super(statementText, warnings);
     this.sourceDescriptions = sourceDescriptions;
   }
 

--- a/ksql-rest-app/src/main/java/io/confluent/ksql/rest/server/execution/ListSourceExecutor.java
+++ b/ksql-rest-app/src/main/java/io/confluent/ksql/rest/server/execution/ListSourceExecutor.java
@@ -16,6 +16,7 @@
 package io.confluent.ksql.rest.server.execution;
 
 import io.confluent.ksql.KsqlExecutionContext;
+import io.confluent.ksql.exception.KafkaResponseGetFailedException;
 import io.confluent.ksql.metastore.model.DataSource;
 import io.confluent.ksql.metastore.model.KsqlStream;
 import io.confluent.ksql.metastore.model.KsqlTable;
@@ -25,6 +26,7 @@ import io.confluent.ksql.parser.tree.ListTables;
 import io.confluent.ksql.parser.tree.ShowColumns;
 import io.confluent.ksql.rest.entity.EntityQueryId;
 import io.confluent.ksql.rest.entity.KsqlEntity;
+import io.confluent.ksql.rest.entity.KsqlWarning;
 import io.confluent.ksql.rest.entity.RunningQuery;
 import io.confluent.ksql.rest.entity.SourceDescription;
 import io.confluent.ksql.rest.entity.SourceDescriptionEntity;
@@ -39,16 +41,43 @@ import io.confluent.ksql.statement.ConfiguredStatement;
 import io.confluent.ksql.util.KsqlException;
 import io.confluent.ksql.util.KsqlStatementException;
 import io.confluent.ksql.util.PersistentQueryMetadata;
+import java.util.LinkedList;
 import java.util.List;
 import java.util.Optional;
 import java.util.function.Predicate;
 import java.util.stream.Collectors;
+import org.apache.kafka.common.KafkaException;
 
 // CHECKSTYLE_RULES.OFF: ClassDataAbstractionCoupling
 public final class ListSourceExecutor {
   // CHECKSTYLE_RULES.ON: ClassDataAbstractionCoupling
 
   private ListSourceExecutor() { }
+
+  private static Optional<KsqlEntity> sourceDescriptionList(
+      final ConfiguredStatement<?> statement,
+      final KsqlExecutionContext executionContext,
+      final ServiceContext serviceContext,
+      final List<? extends DataSource<?>> sources
+  ) {
+    final List<SourceDescriptionWithWarnings> descriptions = sources.stream()
+        .map(
+            s -> describeSource(
+                executionContext,
+                serviceContext,
+                s.getName(),
+                true,
+                statement.getStatementText())
+        )
+        .collect(Collectors.toList());
+    return Optional.of(
+        new SourceDescriptionList(
+            statement.getStatementText(),
+            descriptions.stream().map(d -> d.description).collect(Collectors.toList()),
+            descriptions.stream().flatMap(d -> d.warnings.stream()).collect(Collectors.toList())
+        )
+    );
+  }
 
   public static Optional<KsqlEntity> streams(
       final ConfiguredStatement<ListStreams> statement,
@@ -59,12 +88,12 @@ public final class ListSourceExecutor {
 
     final ListStreams listStreams = statement.getStatement();
     if (listStreams.getShowExtended()) {
-      return Optional.of(new SourceDescriptionList(
-          statement.getStatementText(),
-          ksqlStreams.stream()
-              .map(s -> describeSource(executionContext, serviceContext, s.getName(), true,
-                  statement.getStatementText()))
-              .collect(Collectors.toList())));
+      return sourceDescriptionList(
+          statement,
+          executionContext,
+          serviceContext,
+          ksqlStreams
+      );
     }
 
     return Optional.of(new StreamsList(
@@ -83,12 +112,12 @@ public final class ListSourceExecutor {
 
     final ListTables listTables = statement.getStatement();
     if (listTables.getShowExtended()) {
-      return Optional.of(new SourceDescriptionList(
-          statement.getStatementText(),
-          ksqlTables.stream()
-              .map(t -> describeSource(executionContext, serviceContext, t.getName(), true,
-                  statement.getStatementText()))
-              .collect(Collectors.toList())));
+      return sourceDescriptionList(
+          statement,
+          executionContext,
+          serviceContext,
+          ksqlTables
+      );
     }
     return Optional.of(new TablesList(
         statement.getStatementText(),
@@ -121,15 +150,20 @@ public final class ListSourceExecutor {
       ));
     }
 
-    return Optional.of(new SourceDescriptionEntity(
-        statement.getStatementText(),
-        describeSource(
-            executionContext,
-            serviceContext,
-            showColumns.getTable().getSuffix(),
-            showColumns.isExtended(),
-            statement.getStatementText())
-    ));
+    final SourceDescriptionWithWarnings descriptionWithWarnings = describeSource(
+        executionContext,
+        serviceContext,
+        showColumns.getTable().getSuffix(),
+        showColumns.isExtended(),
+        statement.getStatementText()
+    );
+    return Optional.of(
+        new SourceDescriptionEntity(
+            statement.getStatementText(),
+            descriptionWithWarnings.description,
+            descriptionWithWarnings.warnings
+        )
+    );
   }
 
   private static List<KsqlTable<?>> getSpecificTables(
@@ -154,7 +188,7 @@ public final class ListSourceExecutor {
         .collect(Collectors.toList());
   }
 
-  private static SourceDescription describeSource(
+  private static SourceDescriptionWithWarnings describeSource(
       final KsqlExecutionContext ksqlEngine,
       final ServiceContext serviceContext,
       final String name,
@@ -168,13 +202,28 @@ public final class ListSourceExecutor {
       ), statementText);
     }
 
-    return new SourceDescription(
-        dataSource,
-        extended,
-        dataSource.getKsqlTopic().getValueSerdeFactory().getFormat().name(),
-        getQueries(ksqlEngine, q -> q.getSourceNames().contains(dataSource.getName())),
-        getQueries(ksqlEngine, q -> q.getSinkNames().contains(dataSource.getName())),
-        serviceContext.getTopicClient()
+    Optional<org.apache.kafka.clients.admin.TopicDescription> topicDescription = Optional.empty();
+    final List<KsqlWarning> warnings = new LinkedList<>();
+    if (extended) {
+      try {
+        topicDescription = Optional.of(
+            serviceContext.getTopicClient().describeTopic(dataSource.getKafkaTopicName())
+        );
+      } catch (final KafkaException | KafkaResponseGetFailedException e) {
+        warnings.add(new KsqlWarning("Error from Kafka: " + e.getMessage()));
+      }
+    }
+
+    return new SourceDescriptionWithWarnings(
+        warnings,
+        new SourceDescription(
+            dataSource,
+            extended,
+            dataSource.getKsqlTopic().getValueSerdeFactory().getFormat().name(),
+            getQueries(ksqlEngine, q -> q.getSourceNames().contains(dataSource.getName())),
+            getQueries(ksqlEngine, q -> q.getSinkNames().contains(dataSource.getName())),
+            topicDescription
+        )
     );
   }
 
@@ -188,5 +237,17 @@ public final class ListSourceExecutor {
         .map(q -> new RunningQuery(
             q.getStatementString(), q.getSinkNames(), new EntityQueryId(q.getQueryId())))
         .collect(Collectors.toList());
+  }
+
+  private static final class SourceDescriptionWithWarnings {
+    private final List<KsqlWarning> warnings;
+    private final SourceDescription description;
+
+    private SourceDescriptionWithWarnings(
+        final List<KsqlWarning> warnings,
+        final SourceDescription description) {
+      this.warnings = warnings;
+      this.description = description;
+    }
   }
 }

--- a/ksql-rest-app/src/test/java/io/confluent/ksql/rest/entity/CommandStatusEntityTest.java
+++ b/ksql-rest-app/src/test/java/io/confluent/ksql/rest/entity/CommandStatusEntityTest.java
@@ -38,9 +38,20 @@ public class CommandStatusEntityTest {
       + "\"status\":\"SUCCESS\","
       + "\"message\":\"some success message\""
       + "},"
+      + "\"commandSequenceNumber\":2,"
+      + "\"warnings\":[]"
+      + "}";
+  private static final String JSON_ENTITY_NO_WARNINGS = "{"
+      + "\"@type\":\"currentStatus\","
+      + "\"statementText\":\"sql\","
+      + "\"commandId\":\"topic/1/create\","
+      + "\"commandStatus\":{"
+      + "\"status\":\"SUCCESS\","
+      + "\"message\":\"some success message\""
+      + "},"
       + "\"commandSequenceNumber\":2"
       + "}";
-  private static final String OLD_JSON_ENTITY = "{"
+  private static final String JSON_ENTITY_NO_CSN = "{"
       + "\"@type\":\"currentStatus\","
       + "\"statementText\":\"sql\","
       + "\"commandId\":\"topic/1/create\","
@@ -85,7 +96,7 @@ public class CommandStatusEntityTest {
   public void shouldBeAbleToDeserializeOlderServerMessage() throws Exception {
     // When:
     final CommandStatusEntity entity =
-        OBJECT_MAPPER.readValue(OLD_JSON_ENTITY, CommandStatusEntity.class);
+        OBJECT_MAPPER.readValue(JSON_ENTITY_NO_CSN, CommandStatusEntity.class);
 
     // Then:
     assertThat(entity, is(ENTITY_WITHOUT_SEQUENCE_NUMBER));

--- a/ksql-rest-app/src/test/java/io/confluent/ksql/rest/entity/KafkaTopicsListTest.java
+++ b/ksql-rest-app/src/test/java/io/confluent/ksql/rest/entity/KafkaTopicsListTest.java
@@ -96,7 +96,7 @@ public class KafkaTopicsListTest {
         "{\"@type\":\"kafka_topics\",\"statementText\":\"SHOW TOPICS;\"," +
         "\"topics\":[{\"name\":\"thetopic\",\"registered\":true," +
         "\"replicaInfo\":[1,2,3],\"consumerCount\":42," +
-        "\"consumerGroupCount\":12}]}",
+        "\"consumerGroupCount\":12}],\"warnings\":[]}",
         json);
 
     final KafkaTopicsList actual = mapper.readValue(json, KafkaTopicsList.class);

--- a/ksql-rest-app/src/test/java/io/confluent/ksql/rest/entity/KsqlTopicsListTest.java
+++ b/ksql-rest-app/src/test/java/io/confluent/ksql/rest/entity/KsqlTopicsListTest.java
@@ -35,7 +35,8 @@ public class KsqlTopicsListTest {
     final String json = mapper.writeValueAsString(expected);
     assertEquals(
         "{\"@type\":\"ksql_topics\",\"statementText\":\"SHOW TOPICS;\"," +
-        "\"topics\":[{\"name\":\"ksqltopic\",\"kafkaTopic\":\"kafkatopic\",\"format\":\"JSON\"}]}",
+        "\"topics\":[{\"name\":\"ksqltopic\",\"kafkaTopic\":\"kafkatopic\",\"format\":\"JSON\"}],"
+            + "\"warnings\":[]}",
         json);
 
     final KsqlTopicsList actual = mapper.readValue(json, KsqlTopicsList.class);

--- a/ksql-rest-app/src/test/java/io/confluent/ksql/rest/entity/SourceDescriptionTest.java
+++ b/ksql-rest-app/src/test/java/io/confluent/ksql/rest/entity/SourceDescriptionTest.java
@@ -30,6 +30,7 @@ import io.confluent.ksql.serde.json.KsqlJsonSerdeFactory;
 import io.confluent.ksql.util.timestamp.MetadataTimestampExtractionPolicy;
 import java.util.Arrays;
 import java.util.Collections;
+import java.util.Optional;
 import org.apache.kafka.clients.consumer.ConsumerConfig;
 import org.apache.kafka.clients.consumer.ConsumerRecord;
 import org.apache.kafka.clients.consumer.ConsumerRecords;
@@ -100,7 +101,7 @@ public class SourceDescriptionTest {
         "json",
         Collections.emptyList(),
         Collections.emptyList(),
-        null);
+        Optional.empty());
 
     // Then:
     assertThat(

--- a/ksql-rest-app/src/test/java/io/confluent/ksql/rest/server/execution/ListSourceExecutorTest.java
+++ b/ksql-rest-app/src/test/java/io/confluent/ksql/rest/server/execution/ListSourceExecutorTest.java
@@ -17,8 +17,14 @@ package io.confluent.ksql.rest.server.execution;
 
 import static io.confluent.ksql.metastore.model.DataSource.DataSourceType;
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.contains;
 import static org.hamcrest.Matchers.containsInAnyOrder;
 import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.instanceOf;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.verify;
 
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
@@ -30,6 +36,8 @@ import io.confluent.ksql.parser.KsqlParser.PreparedStatement;
 import io.confluent.ksql.parser.tree.QualifiedName;
 import io.confluent.ksql.parser.tree.ShowColumns;
 import io.confluent.ksql.rest.entity.EntityQueryId;
+import io.confluent.ksql.rest.entity.KsqlEntity;
+import io.confluent.ksql.rest.entity.KsqlWarning;
 import io.confluent.ksql.rest.entity.RunningQuery;
 import io.confluent.ksql.rest.entity.SourceDescription;
 import io.confluent.ksql.rest.entity.SourceDescriptionEntity;
@@ -40,9 +48,14 @@ import io.confluent.ksql.rest.entity.TablesList;
 import io.confluent.ksql.rest.entity.TopicDescription;
 import io.confluent.ksql.rest.server.TemporaryEngine;
 import io.confluent.ksql.services.KafkaTopicClient;
+import io.confluent.ksql.services.ServiceContext;
+import io.confluent.ksql.services.TestServiceContext;
 import io.confluent.ksql.statement.ConfiguredStatement;
 import io.confluent.ksql.util.KsqlException;
 import io.confluent.ksql.util.PersistentQueryMetadata;
+import java.util.Arrays;
+import java.util.Optional;
+import java.util.stream.Collectors;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ExpectedException;
@@ -96,8 +109,20 @@ public class ListSourceExecutorTest {
 
     // Then:
     assertThat(descriptionList.getSourceDescriptions(), containsInAnyOrder(
-        new SourceDescription(stream1, true, "JSON", ImmutableList.of(), ImmutableList.of(), null),
-        new SourceDescription(stream2, true, "JSON", ImmutableList.of(), ImmutableList.of(), null)
+        new SourceDescription(
+            stream1,
+            true,
+            "JSON",
+            ImmutableList.of(),
+            ImmutableList.of(),
+            Optional.empty()),
+        new SourceDescription(
+            stream2,
+            true,
+            "JSON",
+            ImmutableList.of(),
+            ImmutableList.of(),
+            Optional.empty())
     ));
   }
 
@@ -141,8 +166,22 @@ public class ListSourceExecutorTest {
     // Then:
     final KafkaTopicClient client = engine.getServiceContext().getTopicClient();
     assertThat(descriptionList.getSourceDescriptions(), containsInAnyOrder(
-        new SourceDescription(table1, true, "JSON", ImmutableList.of(), ImmutableList.of(), client),
-        new SourceDescription(table2, true, "JSON", ImmutableList.of(), ImmutableList.of(), client)
+        new SourceDescription(
+            table1,
+            true,
+            "JSON",
+            ImmutableList.of(),
+            ImmutableList.of(),
+            Optional.of(client.describeTopic(table1.getKafkaTopicName()))
+        ),
+        new SourceDescription(
+            table2,
+            true,
+            "JSON",
+            ImmutableList.of(),
+            ImmutableList.of(),
+            Optional.of(client.describeTopic(table1.getKafkaTopicName()))
+        )
     ));
   }
 
@@ -182,7 +221,7 @@ public class ListSourceExecutorTest {
                 metadata.getStatementString(),
                 metadata.getSinkNames(),
                 new EntityQueryId(metadata.getQueryId()))),
-            null)));
+            Optional.empty())));
   }
 
   @Test
@@ -217,4 +256,136 @@ public class ListSourceExecutorTest {
     );
   }
 
+  @Test
+  public void shouldNotCallTopicClientForExtendedDescription() {
+    // Given:
+    engine.givenSource(DataSourceType.KSTREAM, "stream1");
+    final KafkaTopicClient spyTopicClient = spy(engine.getServiceContext().getTopicClient());
+    final ServiceContext serviceContext = TestServiceContext.create(
+        engine.getServiceContext().getKafkaClientSupplier(),
+        engine.getServiceContext().getAdminClient(),
+        spyTopicClient,
+        engine.getServiceContext().getSchemaRegistryClientFactory()
+    );
+
+    // When:
+    CustomExecutors.LIST_STREAMS.execute(
+        engine.configure("SHOW STREAMS;"),
+        engine.getEngine(),
+        serviceContext
+    ).orElseThrow(IllegalStateException::new);
+
+    // Then:
+    verify(spyTopicClient, never()).describeTopic(anyString());
+  }
+
+  private void assertSourceListWithWarning(
+      final KsqlEntity entity,
+      final DataSource<?>... sources) {
+    assertThat(entity, instanceOf(SourceDescriptionList.class));
+    final SourceDescriptionList listing = (SourceDescriptionList) entity;
+    assertThat(
+        listing.getSourceDescriptions(),
+        containsInAnyOrder(
+            Arrays.stream(sources)
+                .map(
+                    s -> equalTo(
+                        new SourceDescription(
+                            s,
+                            true,
+                            "JSON",
+                            ImmutableList.of(),
+                            ImmutableList.of(),
+                            Optional.empty()
+                        )
+                    )
+                )
+                .collect(Collectors.toList())
+        )
+    );
+    assertThat(
+        listing.getWarnings(),
+        containsInAnyOrder(
+            Arrays.stream(sources)
+                .map(
+                    s -> equalTo(
+                        new KsqlWarning(
+                            "Error from Kafka: unknown topic: " + s.getKafkaTopicName())))
+                .collect(Collectors.toList())
+        )
+    );
+  }
+
+  @Test
+  public void shouldAddWarningsOnClientExceptionForStreamListing() {
+    // Given:
+    final KsqlStream<?> stream1 = engine.givenSource(DataSourceType.KSTREAM, "stream1");
+    final KsqlStream<?> stream2 = engine.givenSource(DataSourceType.KSTREAM, "stream2");
+    final ServiceContext serviceContext = engine.getServiceContext();
+    serviceContext.getTopicClient().deleteTopics(ImmutableList.of("stream1", "stream2"));
+
+    // When:
+    final KsqlEntity entity = CustomExecutors.LIST_STREAMS.execute(
+        engine.configure("SHOW STREAMS EXTENDED;"),
+        engine.getEngine(),
+        serviceContext
+    ).orElseThrow(IllegalStateException::new);
+
+    // Then:
+    assertSourceListWithWarning(entity, stream1, stream2);
+  }
+
+  @Test
+  public void shouldAddWarningsOnClientExceptionForTopicListing() {
+    // Given:
+    final KsqlTable<?> table1 = engine.givenSource(DataSourceType.KTABLE, "table1");
+    final KsqlTable<?> table2 = engine.givenSource(DataSourceType.KTABLE, "table2");
+    final ServiceContext serviceContext = engine.getServiceContext();
+    serviceContext.getTopicClient().deleteTopics(ImmutableList.of("table1", "table2"));
+
+    // When:
+    final KsqlEntity entity = CustomExecutors.LIST_TABLES.execute(
+        engine.configure("SHOW TABLES EXTENDED;"),
+        engine.getEngine(),
+        serviceContext
+    ).orElseThrow(IllegalStateException::new);
+
+    // Then:
+    assertSourceListWithWarning(entity, table1, table2);
+  }
+
+  @Test
+  public void shouldAddWarningOnClientExceptionForDescription() {
+    // Given:
+    final KsqlStream<?> stream1 = engine.givenSource(DataSourceType.KSTREAM, "STREAM1");
+    final ServiceContext serviceContext = engine.getServiceContext();
+    serviceContext.getTopicClient().deleteTopics(ImmutableList.of("STREAM1"));
+
+    // When:
+    final KsqlEntity entity = CustomExecutors.SHOW_COLUMNS.execute(
+        engine.configure("DESCRIBE EXTENDED STREAM1;"),
+        engine.getEngine(),
+        serviceContext
+    ).orElseThrow(IllegalStateException::new);
+
+    // Then:
+    assertThat(entity, instanceOf(SourceDescriptionEntity.class));
+    final SourceDescriptionEntity description = (SourceDescriptionEntity) entity;
+    assertThat(
+        description.getSourceDescription(),
+        equalTo(
+            new SourceDescription(
+                stream1,
+                true,
+                "JSON",
+                ImmutableList.of(),
+                ImmutableList.of(),
+                Optional.empty()
+            )
+        )
+    );
+    assertThat(
+        description.getWarnings(),
+        contains(new KsqlWarning("Error from Kafka: unknown topic: STREAM1")));
+  }
 }

--- a/ksql-rest-app/src/test/java/io/confluent/ksql/rest/server/resources/KsqlResourceTest.java
+++ b/ksql-rest-app/src/test/java/io/confluent/ksql/rest/server/resources/KsqlResourceTest.java
@@ -144,12 +144,14 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import java.util.Properties;
 import java.util.concurrent.TimeoutException;
 import java.util.function.Function;
 import java.util.stream.Collectors;
 import javax.ws.rs.core.Response;
 import org.apache.avro.Schema.Type;
+import org.apache.kafka.clients.admin.TopicDescription;
 import org.apache.kafka.clients.consumer.ConsumerConfig;
 import org.apache.kafka.clients.producer.ProducerConfig;
 import org.apache.kafka.common.serialization.Serdes;
@@ -399,11 +401,12 @@ public class KsqlResourceTest {
         new SourceDescription(
             ksqlEngine.getMetaStore().getSource("TEST_STREAM"),
             true, "JSON", Collections.emptyList(), Collections.emptyList(),
-            kafkaTopicClient),
+            Optional.of(kafkaTopicClient.describeTopic("KAFKA_TOPIC_2"))),
         new SourceDescription(
             ksqlEngine.getMetaStore().getSource("new_stream"),
             true, "JSON", Collections.emptyList(), Collections.emptyList(),
-            kafkaTopicClient)));
+            Optional.of(kafkaTopicClient.describeTopic("new_topic"))))
+    );
   }
 
   @Test
@@ -427,11 +430,12 @@ public class KsqlResourceTest {
         new SourceDescription(
             ksqlEngine.getMetaStore().getSource("TEST_TABLE"),
             true, "JSON", Collections.emptyList(), Collections.emptyList(),
-            kafkaTopicClient),
+            Optional.of(kafkaTopicClient.describeTopic("KAFKA_TOPIC_1"))),
         new SourceDescription(
             ksqlEngine.getMetaStore().getSource("new_table"),
             true, "JSON", Collections.emptyList(), Collections.emptyList(),
-            kafkaTopicClient)));
+            Optional.of(kafkaTopicClient.describeTopic("new_topic"))))
+    );
   }
 
   @Test
@@ -468,8 +472,13 @@ public class KsqlResourceTest {
 
     // Then:
     final SourceDescription expectedDescription = new SourceDescription(
-        ksqlEngine.getMetaStore().getSource("DESCRIBED_STREAM"), false, "JSON",
-        Collections.singletonList(queries.get(1)), Collections.singletonList(queries.get(0)), null);
+        ksqlEngine.getMetaStore().getSource("DESCRIBED_STREAM"),
+        false,
+        "JSON",
+        Collections.singletonList(queries.get(1)),
+        Collections.singletonList(queries.get(0)),
+        Optional.empty()
+    );
 
     assertThat(description.getSourceDescription(), is(expectedDescription));
   }


### PR DESCRIPTION
This patch adds a mechanism for returning warnings in KsqlEntity for
successful api responses. This patch also adds some warnings for source
listings. Now, when a client tries to list or describe a source, and ksql
is unable to get the details of the backing topic from kafka, a result is
returned that includes 0-values for the underlying topic info (partitions,
replicas), and includes response warnings about the issue with Kafka.