### PR TITLE
refactor: switch cluster terminator off metastore get all ksql topics (MINOR)

### DIFF
--- a/ksql-engine/src/test/java/io/confluent/ksql/integration/IntegrationTestHarness.java
+++ b/ksql-engine/src/test/java/io/confluent/ksql/integration/IntegrationTestHarness.java
@@ -122,6 +122,12 @@ public class IntegrationTestHarness extends ExternalResource {
     return new ContextBuilder();
   }
 
+  public boolean topicExists(final String topicName) {
+    final KafkaTopicClient topicClient = serviceContext.get().getTopicClient();
+
+    return topicClient.isTopicExists(topicName);
+  }
+
   /**
    * Ensure topics with the given {@code topicNames} exist.
    *

--- a/ksql-rest-app/src/main/java/io/confluent/ksql/rest/util/ClusterTerminator.java
+++ b/ksql-rest-app/src/main/java/io/confluent/ksql/rest/util/ClusterTerminator.java
@@ -18,6 +18,7 @@ package io.confluent.ksql.rest.util;
 import com.google.common.collect.ImmutableList;
 import io.confluent.ksql.engine.KsqlEngine;
 import io.confluent.ksql.metastore.MetaStore;
+import io.confluent.ksql.metastore.model.DataSource;
 import io.confluent.ksql.metastore.model.KsqlTopic;
 import io.confluent.ksql.schema.registry.SchemaRegistryUtil;
 import io.confluent.ksql.serde.Format;
@@ -80,7 +81,8 @@ public class ClusterTerminator {
         .collect(Collectors.toList());
 
     final MetaStore metaStore = ksqlEngine.getMetaStore();
-    final List<String> toDelete = metaStore.getAllKsqlTopics().values().stream()
+    final List<String> toDelete = metaStore.getAllDataSources().values().stream()
+        .map(DataSource::getKsqlTopic)
         .filter(KsqlTopic::isKsqlSink)
         .map(KsqlTopic::getKafkaTopicName)
         .filter(topicName -> topicShouldBeDeleted(topicName, patterns))

--- a/ksql-rest-app/src/test/java/io/confluent/ksql/rest/integration/ClusterTerminationTest.java
+++ b/ksql-rest-app/src/test/java/io/confluent/ksql/rest/integration/ClusterTerminationTest.java
@@ -16,6 +16,7 @@
 package io.confluent.ksql.rest.integration;
 
 import static io.confluent.ksql.serde.Format.JSON;
+import static org.hamcrest.Matchers.is;
 import static org.junit.Assert.assertEquals;
 
 import com.google.common.collect.ImmutableList;
@@ -37,6 +38,7 @@ import kafka.zookeeper.ZooKeeperClientException;
 import org.glassfish.hk2.api.Factory;
 import org.glassfish.hk2.utilities.binding.AbstractBinder;
 import org.glassfish.jersey.process.internal.RequestScoped;
+import org.hamcrest.MatcherAssert;
 import org.junit.BeforeClass;
 import org.junit.ClassRule;
 import org.junit.Test;
@@ -116,6 +118,12 @@ public class ClusterTerminationTest {
     TEST_HARNESS.waitForTopicsToBeAbsent(SINK_TOPIC);
 
     TEST_HARNESS.waitForSubjectToBeAbsent(SINK_TOPIC + KsqlConstants.SCHEMA_REGISTRY_VALUE_SUFFIX);
+
+    MatcherAssert.assertThat(
+        "Should not delete non-sink topics",
+        TEST_HARNESS.topicExists(PAGE_VIEW_TOPIC),
+        is(true)
+    );
   }
 
   private static void terminateCluster(final List<String> deleteTopicList) {


### PR DESCRIPTION
### Description 
Part of the work to remove this functionality from the metastore

### Testing done 
`mvn test`

### Reviewer checklist
- [ ] Ensure docs are updated if necessary. (eg. if a user visible feature is being added or changed).
- [ ] Ensure relevant issues are linked (description should include text like "Fixes #<issue number>")

