### PR TITLE
fix: drop describe topic functionality (MINOR)

### DIFF
--- a/ksql-cli/src/test/java/io/confluent/ksql/cli/CliTest.java
+++ b/ksql-cli/src/test/java/io/confluent/ksql/cli/CliTest.java
@@ -451,12 +451,6 @@ public class CliTest {
   }
 
   @Test
-  public void testDescribe() {
-    assertRunCommand("describe topic " + COMMANDS_KSQL_TOPIC_NAME,
-        isRow(COMMANDS_KSQL_TOPIC_NAME, commandTopicName, "JSON"));
-  }
-
-  @Test
   public void shouldPrintCorrectSchemaForDescribeStream() {
     assertRunCommand(
         "describe " + orderDataProvider.kstreamName(),

--- a/ksql-parser/src/main/antlr4/io/confluent/ksql/parser/SqlBase.g4
+++ b/ksql-parser/src/main/antlr4/io/confluent/ksql/parser/SqlBase.g4
@@ -38,7 +38,7 @@ statement
     | (LIST | SHOW) STREAMS EXTENDED?                                       #listStreams
     | (LIST | SHOW) TABLES EXTENDED?                                        #listTables
     | (LIST | SHOW) FUNCTIONS                                               #listFunctions
-    | DESCRIBE EXTENDED? (qualifiedName | TOPIC qualifiedName)              #showColumns
+    | DESCRIBE EXTENDED? qualifiedName                                      #showColumns
     | DESCRIBE FUNCTION qualifiedName                                       #describeFunction
     | PRINT (qualifiedName | STRING) printClause                            #printTopic
     | (LIST | SHOW) QUERIES EXTENDED?                                       #listQueries

--- a/ksql-parser/src/main/java/io/confluent/ksql/parser/AstBuilder.java
+++ b/ksql-parser/src/main/java/io/confluent/ksql/parser/AstBuilder.java
@@ -574,7 +574,6 @@ public class AstBuilder {
       return new ShowColumns(
           getLocation(context),
           ParserUtil.getQualifiedName(context.qualifiedName()),
-          context.TOPIC() != null,
           context.EXTENDED() != null
       );
     }

--- a/ksql-parser/src/main/java/io/confluent/ksql/parser/tree/ShowColumns.java
+++ b/ksql-parser/src/main/java/io/confluent/ksql/parser/tree/ShowColumns.java
@@ -25,31 +25,24 @@ import java.util.Optional;
 public class ShowColumns extends Statement {
 
   private final QualifiedName table;
-  private final boolean isTopic;
   private final boolean isExtended;
 
-  public ShowColumns(final QualifiedName table, final boolean isTopic, final boolean isExtended) {
-    this(Optional.empty(), table, isTopic, isExtended);
+  public ShowColumns(final QualifiedName table, final boolean isExtended) {
+    this(Optional.empty(), table, isExtended);
   }
 
   public ShowColumns(
       final Optional<NodeLocation> location,
       final QualifiedName table,
-      final boolean isTopic,
       final boolean isExtended
   ) {
     super(location);
     this.table = requireNonNull(table, "table");
-    this.isTopic = isTopic;
     this.isExtended = isExtended;
   }
 
   public QualifiedName getTable() {
     return table;
-  }
-
-  public boolean isTopic() {
-    return isTopic;
   }
 
   public boolean isExtended() {
@@ -70,21 +63,19 @@ public class ShowColumns extends Statement {
       return false;
     }
     final ShowColumns that = (ShowColumns) o;
-    return isTopic == that.isTopic
-        && isExtended == that.isExtended
+    return isExtended == that.isExtended
         && Objects.equals(table, that.table);
   }
 
   @Override
   public int hashCode() {
-    return Objects.hash(table, isTopic, isExtended);
+    return Objects.hash(table, isExtended);
   }
 
   @Override
   public String toString() {
     return "ShowColumns{"
         + "table=" + table
-        + ", isTopic=" + isTopic
         + ", isExtended=" + isExtended
         + '}';
   }

--- a/ksql-parser/src/test/java/io/confluent/ksql/parser/tree/ShowColumnsTest.java
+++ b/ksql-parser/src/test/java/io/confluent/ksql/parser/tree/ShowColumnsTest.java
@@ -42,10 +42,7 @@ public class ShowColumnsTest {
         .addEqualityGroup(
             new ShowColumns(QualifiedName.of("diff"), false)
         )
-        .addEqualityGroup(
-            new ShowColumns(SOME_NAME, false)
-        )
-        .addEqualityGroup(
+       .addEqualityGroup(
             new ShowColumns(SOME_NAME, true)
         )
         .testEquals();

--- a/ksql-parser/src/test/java/io/confluent/ksql/parser/tree/ShowColumnsTest.java
+++ b/ksql-parser/src/test/java/io/confluent/ksql/parser/tree/ShowColumnsTest.java
@@ -34,19 +34,19 @@ public class ShowColumnsTest {
     new EqualsTester()
         .addEqualityGroup(
             // Note: At the moment location does not take part in equality testing
-            new ShowColumns(SOME_NAME, true, false),
-            new ShowColumns(SOME_NAME, true, false),
-            new ShowColumns(Optional.of(SOME_LOCATION), SOME_NAME, true, false),
-            new ShowColumns(Optional.of(OTHER_LOCATION), SOME_NAME, true, false)
+            new ShowColumns(SOME_NAME, false),
+            new ShowColumns(SOME_NAME, false),
+            new ShowColumns(Optional.of(SOME_LOCATION), SOME_NAME, false),
+            new ShowColumns(Optional.of(OTHER_LOCATION), SOME_NAME, false)
         )
         .addEqualityGroup(
-            new ShowColumns(QualifiedName.of("diff"), true, false)
+            new ShowColumns(QualifiedName.of("diff"), false)
         )
         .addEqualityGroup(
-            new ShowColumns(SOME_NAME, false, false)
+            new ShowColumns(SOME_NAME, false)
         )
         .addEqualityGroup(
-            new ShowColumns(SOME_NAME, true, true)
+            new ShowColumns(SOME_NAME, true)
         )
         .testEquals();
   }

--- a/ksql-rest-app/src/main/java/io/confluent/ksql/rest/server/execution/ListSourceExecutor.java
+++ b/ksql-rest-app/src/main/java/io/confluent/ksql/rest/server/execution/ListSourceExecutor.java
@@ -19,7 +19,6 @@ import io.confluent.ksql.KsqlExecutionContext;
 import io.confluent.ksql.metastore.model.DataSource;
 import io.confluent.ksql.metastore.model.KsqlStream;
 import io.confluent.ksql.metastore.model.KsqlTable;
-import io.confluent.ksql.metastore.model.KsqlTopic;
 import io.confluent.ksql.parser.tree.ListStreams;
 import io.confluent.ksql.parser.tree.ListTables;
 import io.confluent.ksql.parser.tree.ShowColumns;
@@ -32,11 +31,9 @@ import io.confluent.ksql.rest.entity.SourceDescriptionList;
 import io.confluent.ksql.rest.entity.SourceInfo;
 import io.confluent.ksql.rest.entity.StreamsList;
 import io.confluent.ksql.rest.entity.TablesList;
-import io.confluent.ksql.rest.entity.TopicDescription;
 import io.confluent.ksql.rest.server.KsqlRestApplication;
 import io.confluent.ksql.services.ServiceContext;
 import io.confluent.ksql.statement.ConfiguredStatement;
-import io.confluent.ksql.util.KsqlException;
 import io.confluent.ksql.util.KsqlStatementException;
 import io.confluent.ksql.util.PersistentQueryMetadata;
 import java.util.List;
@@ -103,24 +100,6 @@ public final class ListSourceExecutor {
       final ServiceContext serviceContext
   ) {
     final ShowColumns showColumns = statement.getStatement();
-    if (showColumns.isTopic()) {
-      final String name = showColumns.getTable().getSuffix();
-      final KsqlTopic ksqlTopic = executionContext.getMetaStore().getTopic(name);
-      if (ksqlTopic == null) {
-        throw new KsqlException(String.format(
-            "Could not find Topic '%s' in the Metastore",
-            name
-        ));
-      }
-      return Optional.of(new TopicDescription(
-          statement.getStatementText(),
-          name,
-          ksqlTopic.getKafkaTopicName(),
-          ksqlTopic.getValueSerdeFactory().getFormat().toString(),
-          null
-      ));
-    }
-
     return Optional.of(new SourceDescriptionEntity(
         statement.getStatementText(),
         describeSource(


### PR DESCRIPTION
### Description 

In the CLI you can still do:

```
DESCRIBE TOPIC foo;
```

Which will only work if `foo` is a registered topic.

Registered topic functionality has been removed, but this functionality was missed - let's remove it. 

Also see related #3068

### Testing done 

`mvn test`.

### Reviewer checklist
- [ ] Ensure docs are updated if necessary. (eg. if a user visible feature is being added or changed).
- [ ] Ensure relevant issues are linked (description should include text like "Fixes #<issue number>")

