### PR TITLE
feat: add config for enabling topic access validator

### DIFF
--- a/ksql-common/src/main/java/io/confluent/ksql/util/KsqlConfig.java
+++ b/ksql-common/src/main/java/io/confluent/ksql/util/KsqlConfig.java
@@ -168,6 +168,18 @@ public class KsqlConfig extends AbstractConfig {
   public static final String KSQL_SECURITY_EXTENSION_DOC = "A KSQL security extension class that "
       + "provides authorization to KSQL servers.";
 
+  public static final String KSQL_ENABLE_TOPIC_ACCESS_VALIDATOR = "ksql.access.validator.enable";
+  public static final String KSQL_ACCESS_VALIDATOR_ON = "on";
+  public static final String KSQL_ACCESS_VALIDATOR_OFF = "off";
+  public static final String KSQL_ACCESS_VALIDATOR_AUTO = "auto";
+  public static final String KSQL_ACCESS_VALIDATOR_DOC =
+      "Config to enable/disable the topic access validator, which checks that KSQL can access "
+          + "the involved topics before committing to execute a statement. Possible values are "
+          + "\"on\", \"off\", and \"auto\". Setting to \"on\" enables the validator. Setting to "
+          + "\"off\" disables the validator. If set to \"auto\", KSQL will attempt to discover "
+          + "whether the Kafka cluster supports the required API, and enables the validator if "
+          + "it does.";
+
   public static final Collection<CompatibilityBreakingConfigDef> COMPATIBLY_BREAKING_CONFIG_DEFS
       = ImmutableList.of(
           new CompatibilityBreakingConfigDef(
@@ -470,6 +482,17 @@ public class KsqlConfig extends AbstractConfig {
             null,
             ConfigDef.Importance.LOW,
             KSQL_CUSTOM_METRICS_EXTENSION_DOC
+        ).define(
+            KSQL_ENABLE_TOPIC_ACCESS_VALIDATOR,
+            Type.STRING,
+            KSQL_ACCESS_VALIDATOR_AUTO,
+            ValidString.in(
+                KSQL_ACCESS_VALIDATOR_ON,
+                KSQL_ACCESS_VALIDATOR_OFF,
+                KSQL_ACCESS_VALIDATOR_AUTO
+            ),
+            ConfigDef.Importance.LOW,
+            KSQL_ACCESS_VALIDATOR_DOC
         )
         .withClientSslSupport();
     for (final CompatibilityBreakingConfigDef compatibilityBreakingConfigDef

--- a/ksql-rest-app/src/main/java/io/confluent/ksql/rest/server/KsqlRestApplication.java
+++ b/ksql-rest-app/src/main/java/io/confluent/ksql/rest/server/KsqlRestApplication.java
@@ -395,7 +395,7 @@ public final class KsqlRestApplication extends Application<KsqlRestConfig> imple
 
       final StatementParser statementParser = new StatementParser(ksqlEngine);
       final TopicAccessValidator topicAccessValidator =
-          TopicAccessValidatorFactory.create(serviceContext, ksqlEngine.getMetaStore());
+          TopicAccessValidatorFactory.create(ksqlConfig, serviceContext);
 
       container.addEndpoint(
           ServerEndpointConfig.Builder
@@ -500,7 +500,7 @@ public final class KsqlRestApplication extends Application<KsqlRestConfig> imple
     final KsqlSecurityExtension securityExtension = loadSecurityExtension(ksqlConfig);
 
     final TopicAccessValidator topicAccessValidator =
-        TopicAccessValidatorFactory.create(serviceContext, ksqlEngine.getMetaStore());
+        TopicAccessValidatorFactory.create(ksqlConfig, serviceContext);
 
     final StreamedQueryResource streamedQueryResource = new StreamedQueryResource(
         ksqlConfig,


### PR DESCRIPTION
Adds a config called ksql.access.validator.enable for enabling the
topic access validator. The possible values for this config are "on",
"off", and "auto". "on" is used to enable the validator, "off"
is used to disable it, and "auto" can be set to have ksql query kafka
properties to auto-discover whether or not the validator can be used (
this is the behaviour before this patch, and is the current default
value for this setting). This config is useful for enabling the validator
when using ksql against multi-tenant kafka, where ksql will not have
access to the broker's configs.

This patch also switches the topic validator factory test to use mockito
for mocking, instead of easymock.