### PR TITLE
add delimiter between serviceId and metricName

### DIFF
--- a/ksql-engine/src/main/java/io/confluent/ksql/internal/KsqlEngineMetrics.java
+++ b/ksql-engine/src/main/java/io/confluent/ksql/internal/KsqlEngineMetrics.java
@@ -83,7 +83,8 @@ public class KsqlEngineMetrics implements Closeable {
       final Map<String, String> customMetricsTags,
       final Optional<KsqlMetricsExtension> metricsExtension) {
     this.ksqlEngine = ksqlEngine;
-    this.ksqlServiceId = KsqlConstants.KSQL_INTERNAL_TOPIC_PREFIX + ksqlEngine.getServiceId();
+    this.ksqlServiceId = KsqlConstants.KSQL_INTERNAL_TOPIC_PREFIX
+            + addDelimiterIfNotExists(ksqlEngine.getServiceId());
     this.sensors = new ArrayList<>();
     this.countMetrics = new ArrayList<>();
     this.metricGroupName = metricGroupPrefix + "-query-stats";
@@ -285,14 +286,14 @@ public class KsqlEngineMetrics implements Closeable {
     // legacy
     sensor.add(
         metrics.metricName(
-            ksqlServiceId + "-" + metric.name(),
+            ksqlServiceId + metric.name(),
             metricGroupName, metric.description()),
         metric.statSupplier().get());
     // new
     sensor.add(
         metrics.metricName(
             metric.name(),
-            ksqlServiceId + "-" + metricGroupName,
+            ksqlServiceId + metricGroupName,
             metric.description(),
             customMetricsTags),
         metric.statSupplier().get());
@@ -334,7 +335,7 @@ public class KsqlEngineMetrics implements Closeable {
     final String name = state + "-queries";
     // legacy
     configureGaugeForState(
-        ksqlServiceId + "-" + metricGroupName + "-" + name,
+        ksqlServiceId + metricGroupName + "-" + name,
         metricGroupName,
         Collections.emptyMap(),
         state
@@ -342,7 +343,7 @@ public class KsqlEngineMetrics implements Closeable {
     // new
     configureGaugeForState(
         name,
-        ksqlServiceId + "-" + metricGroupName,
+        ksqlServiceId + metricGroupName,
         customMetricsTags,
         state
     );
@@ -375,5 +376,12 @@ public class KsqlEngineMetrics implements Closeable {
     public Gauge<Long> getCount() {
       return count;
     }
+  }
+
+  private String addDelimiterIfNotExists(final String serviceId) {
+    if (!serviceId.endsWith("_")) {
+      return serviceId + "-";
+    }
+    return serviceId;
   }
 }

--- a/ksql-engine/src/main/java/io/confluent/ksql/internal/KsqlEngineMetrics.java
+++ b/ksql-engine/src/main/java/io/confluent/ksql/internal/KsqlEngineMetrics.java
@@ -284,13 +284,15 @@ public class KsqlEngineMetrics implements Closeable {
       final KsqlMetric metric) {
     // legacy
     sensor.add(
-        metrics.metricName(ksqlServiceId + metric.name(), metricGroupName, metric.description()),
+        metrics.metricName(
+            ksqlServiceId + "-" + metric.name(),
+            metricGroupName, metric.description()),
         metric.statSupplier().get());
     // new
     sensor.add(
         metrics.metricName(
             metric.name(),
-            ksqlServiceId + metricGroupName,
+            ksqlServiceId + "-" + metricGroupName,
             metric.description(),
             customMetricsTags),
         metric.statSupplier().get());
@@ -332,7 +334,7 @@ public class KsqlEngineMetrics implements Closeable {
     final String name = state + "-queries";
     // legacy
     configureGaugeForState(
-        ksqlServiceId + metricGroupName + "-" + name,
+        ksqlServiceId + "-" + metricGroupName + "-" + name,
         metricGroupName,
         Collections.emptyMap(),
         state
@@ -340,7 +342,7 @@ public class KsqlEngineMetrics implements Closeable {
     // new
     configureGaugeForState(
         name,
-        ksqlServiceId + metricGroupName,
+        ksqlServiceId + "-" + metricGroupName,
         customMetricsTags,
         state
     );

--- a/ksql-engine/src/test/java/io/confluent/ksql/internal/KsqlEngineMetricsTest.java
+++ b/ksql-engine/src/test/java/io/confluent/ksql/internal/KsqlEngineMetricsTest.java
@@ -66,7 +66,7 @@ public class KsqlEngineMetricsTest {
   private static final String METRIC_GROUP = "testGroup";
   private KsqlEngineMetrics engineMetrics;
   private static final String KSQL_SERVICE_ID = "test-ksql-service-id";
-  private static final String metricNamePrefix = KsqlConstants.KSQL_INTERNAL_TOPIC_PREFIX + KSQL_SERVICE_ID;
+  private static final String metricNamePrefix = KsqlConstants.KSQL_INTERNAL_TOPIC_PREFIX + KSQL_SERVICE_ID + "-";
   private static final Map<String, String> CUSTOM_TAGS = ImmutableMap.of("tag1", "value1", "tag2", "value2");
 
   @Mock


### PR DESCRIPTION
### Description 
I want a delimiter exists between service Id and metric name, so metric is more readable.
for example `myserviceidavg-message-> myserviceid-avg-message`
In order to fix https://github.com/confluentinc/ksql/issues/3084

### Testing done 
add "-" in metricNamePrefix at the end, in order to pass KsqlEngineMetricsTest
 
### Reviewer checklist
- [ ] Ensure docs are updated if necessary. (eg. if a user visible feature is being added or changed).
- [ ] Ensure relevant issues are linked (description should include text like "Fixes #<issue number>")
