### PR TITLE
fix: Remove delete.topic.enable check

### DIFF
--- a/ksql-engine/src/main/java/io/confluent/ksql/services/KafkaTopicClientImpl.java
+++ b/ksql-engine/src/main/java/io/confluent/ksql/services/KafkaTopicClientImpl.java
@@ -15,7 +15,6 @@
 
 package io.confluent.ksql.services;
 
-import com.google.common.base.Suppliers;
 import com.google.common.collect.Lists;
 import io.confluent.ksql.exception.KafkaResponseGetFailedException;
 import io.confluent.ksql.topic.TopicProperties;
@@ -31,7 +30,6 @@ import java.util.Objects;
 import java.util.Set;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeUnit;
-import java.util.function.Supplier;
 import java.util.stream.Collectors;
 import javax.annotation.concurrent.ThreadSafe;
 import org.apache.kafka.clients.admin.AdminClient;
@@ -61,17 +59,8 @@ public class KafkaTopicClientImpl implements KafkaTopicClient {
   private static final Logger LOG = LoggerFactory.getLogger(KafkaTopicClient.class);
 
   private static final String DEFAULT_REPLICATION_PROP = "default.replication.factor";
-  private static final String DELETE_TOPIC_ENABLE = "delete.topic.enable";
 
   private final AdminClient adminClient;
-
-  // This supplier solves two issues:
-  // 1. Avoids the constructor to check for the topic.delete.enable unnecessary. The AdminClient
-  //    might not have access to this config, and it would fail for every Ksql command if it does
-  //    the check initially.
-  // 2. It is a memoize supplier. Once this is call, the subsequent calls will return the cached
-  //    value.
-  private final Supplier<Boolean> isTopicDeleteEnabledSupplier;
 
   /**
    * Construct a topic client from an existing admin client.
@@ -80,7 +69,6 @@ public class KafkaTopicClientImpl implements KafkaTopicClient {
    */
   public KafkaTopicClientImpl(final AdminClient adminClient) {
     this.adminClient = Objects.requireNonNull(adminClient, "adminClient");
-    this.isTopicDeleteEnabledSupplier = Suppliers.memoize(this::isTopicDeleteEnabled);
   }
 
   @Override
@@ -249,10 +237,7 @@ public class KafkaTopicClientImpl implements KafkaTopicClient {
     if (topicsToDelete.isEmpty()) {
       return;
     }
-    if (!isTopicDeleteEnabledSupplier.get()) {
-      LOG.info("Cannot delete topics since '" + DELETE_TOPIC_ENABLE + "' is false. ");
-      return;
-    }
+
     final DeleteTopicsResult deleteTopicsResult = adminClient.deleteTopics(topicsToDelete);
     final Map<String, KafkaFuture<Void>> results = deleteTopicsResult.values();
     final List<String> failList = Lists.newArrayList();
@@ -271,10 +256,6 @@ public class KafkaTopicClientImpl implements KafkaTopicClient {
 
   @Override
   public void deleteInternalTopics(final String applicationId) {
-    if (!isTopicDeleteEnabledSupplier.get()) {
-      LOG.warn("Cannot delete topics since '" + DELETE_TOPIC_ENABLE + "' is false. ");
-      return;
-    }
     try {
       final Set<String> topicNames = listTopicNames();
       final List<String> internalTopics = Lists.newArrayList();
@@ -290,18 +271,6 @@ public class KafkaTopicClientImpl implements KafkaTopicClient {
       LOG.error("Exception while trying to clean up internal topics for application id: {}.",
           applicationId, e
       );
-    }
-  }
-
-  private boolean isTopicDeleteEnabled() {
-    try {
-      final ConfigEntry configEntry = getConfig().get(DELETE_TOPIC_ENABLE);
-      // default to true if there is no entry
-      return configEntry == null || Boolean.valueOf(configEntry.value());
-    } catch (final Exception e) {
-      LOG.error("Failed to initialize TopicClient: {}", e.getMessage());
-      throw new KafkaResponseGetFailedException(
-          "Could not fetch broker information. KSQL cannot initialize", e);
     }
   }
 

--- a/ksql-engine/src/main/java/io/confluent/ksql/services/KafkaTopicClientImpl.java
+++ b/ksql-engine/src/main/java/io/confluent/ksql/services/KafkaTopicClientImpl.java
@@ -259,7 +259,6 @@ public class KafkaTopicClientImpl implements KafkaTopicClient {
           // If TopicDeletionDisabledException is detected, we throw the exception immediately
           // instead of going through the rest of the topics to delete.
           // It is now up to the caller to ignore this exception.
-          LOG.info("Cannot delete topics since '" + DELETE_TOPIC_ENABLE + "' is false. ");
           throw new TopicDeletionDisabledException("Topic deletion is disabled. "
               + "To delete the topic, you must set '" + DELETE_TOPIC_ENABLE + "' to true in "
               + "the Kafka cluster configuration.");
@@ -287,15 +286,13 @@ public class KafkaTopicClientImpl implements KafkaTopicClient {
       if (!internalTopics.isEmpty()) {
         deleteTopics(internalTopics);
       }
+    } catch (final TopicDeletionDisabledException e) {
+      // Ignore TopicDeletionDisabledException should not be logged as an error
+      LOG.info("Did not delete any topics: ", e.getMessage());
     } catch (final Exception e) {
-      // An exception due to TopicDeletionDisabledException should not be logged as an error, just
-      // info level should be enough. However, the deleteTopics() method already logged it for us,
-      // so we can skip it.
-      if (!(e instanceof TopicDeletionDisabledException)) {
-        LOG.error("Exception while trying to clean up internal topics for application id: {}.",
-            applicationId, e
-        );
-      }
+      LOG.error("Exception while trying to clean up internal topics for application id: {}.",
+          applicationId, e
+      );
     }
   }
 

--- a/ksql-engine/src/main/java/io/confluent/ksql/services/KafkaTopicClientImpl.java
+++ b/ksql-engine/src/main/java/io/confluent/ksql/services/KafkaTopicClientImpl.java
@@ -265,6 +265,7 @@ public class KafkaTopicClientImpl implements KafkaTopicClient {
               + "the Kafka cluster configuration.");
         }
 
+        LOG.error(String.format("Could not delete topic '%s'", entry.getKey()), e);
         failList.add(entry.getKey());
       }
     }

--- a/ksql-engine/src/main/java/io/confluent/ksql/topic/TopicDeleteInjector.java
+++ b/ksql-engine/src/main/java/io/confluent/ksql/topic/TopicDeleteInjector.java
@@ -30,6 +30,7 @@ import io.confluent.ksql.services.KafkaTopicClient;
 import io.confluent.ksql.services.ServiceContext;
 import io.confluent.ksql.statement.ConfiguredStatement;
 import io.confluent.ksql.statement.Injector;
+import io.confluent.ksql.util.ExecutorUtil;
 import io.confluent.ksql.util.KsqlConstants;
 import io.confluent.ksql.util.KsqlException;
 import java.util.Objects;
@@ -91,7 +92,9 @@ public class TopicDeleteInjector implements Injector {
 
     if (source != null) {
       try {
-        topicClient.deleteTopics(ImmutableList.of(source.getKafkaTopicName()));
+        ExecutorUtil.executeWithRetries(
+            () -> topicClient.deleteTopics(ImmutableList.of(source.getKafkaTopicName())),
+            ExecutorUtil.RetryBehaviour.ALWAYS);
       } catch (Exception e) {
         throw new KsqlException("Could not delete the corresponding kafka topic: "
             + source.getKafkaTopicName(), e);

--- a/ksql-engine/src/main/java/io/confluent/ksql/topic/TopicDeleteInjector.java
+++ b/ksql-engine/src/main/java/io/confluent/ksql/topic/TopicDeleteInjector.java
@@ -30,8 +30,6 @@ import io.confluent.ksql.services.KafkaTopicClient;
 import io.confluent.ksql.services.ServiceContext;
 import io.confluent.ksql.statement.ConfiguredStatement;
 import io.confluent.ksql.statement.Injector;
-import io.confluent.ksql.util.ExecutorUtil;
-import io.confluent.ksql.util.ExecutorUtil.RetryBehaviour;
 import io.confluent.ksql.util.KsqlConstants;
 import io.confluent.ksql.util.KsqlException;
 import java.util.Objects;
@@ -93,9 +91,7 @@ public class TopicDeleteInjector implements Injector {
 
     if (source != null) {
       try {
-        ExecutorUtil.executeWithRetries(
-            () -> topicClient.deleteTopics(ImmutableList.of(source.getKafkaTopicName())),
-            RetryBehaviour.ALWAYS);
+        topicClient.deleteTopics(ImmutableList.of(source.getKafkaTopicName()));
       } catch (Exception e) {
         throw new KsqlException("Could not delete the corresponding kafka topic: "
             + source.getKafkaTopicName(), e);

--- a/ksql-rest-app/src/main/java/io/confluent/ksql/rest/util/ClusterTerminator.java
+++ b/ksql-rest-app/src/main/java/io/confluent/ksql/rest/util/ClusterTerminator.java
@@ -99,14 +99,12 @@ public class ClusterTerminator {
           () -> serviceContext.getTopicClient().deleteTopics(
               filterNonExistingTopics(topicsToBeDeleted)),
           ExecutorUtil.RetryBehaviour.ALWAYS);
+    } catch (final TopicDeletionDisabledException e) {
+      // Ignore TopicDeletionDisabledException when a Cluster termination is requested.
+      LOGGER.info("Did not delete any topics: ", e.getMessage());
     } catch (final Exception e) {
-      // An exception due to TopicDeletionDisabledException should be ignored when a Cluster
-      // termination is requested. The deleteTopics already logs an INFO message. We can skip
-      // logging it here.
-      if (!(e instanceof TopicDeletionDisabledException)) {
-        throw new KsqlException(
-            "Exception while deleting topics: " + StringUtils.join(topicsToBeDeleted, ", "));
-      }
+      throw new KsqlException(
+          "Exception while deleting topics: " + StringUtils.join(topicsToBeDeleted, ", "));
     }
   }
 

--- a/ksql-rest-app/src/test/java/io/confluent/ksql/rest/util/ClusterTerminatorTest.java
+++ b/ksql-rest-app/src/test/java/io/confluent/ksql/rest/util/ClusterTerminatorTest.java
@@ -55,6 +55,8 @@ import java.util.Map;
 import java.util.Set;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
+
+import org.apache.kafka.common.errors.TopicDeletionDisabledException;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
@@ -372,6 +374,21 @@ public class ClusterTerminatorTest {
     // When:
     clusterTerminator.terminateCluster(Collections.emptyList());
 
+  }
+
+  @Test
+  public void shouldNotThrowOnTopicDeletionDisabledException() throws Exception {
+    // Given:
+    givenTopicsExistInKafka("K_Foo");
+    givenSinkTopicsExistInMetastore(Format.AVRO,"K_Foo");
+    givenSchemasForTopicsExistInSchemaRegistry("K_Foo");
+    doThrow(TopicDeletionDisabledException.class).when(kafkaTopicClient).deleteTopics(any());
+
+    // When:
+    clusterTerminator.terminateCluster(ImmutableList.of("K_Foo"));
+
+    // Then:
+    verifySchemaDeletedForTopics("K_Foo");
   }
 
   @Test


### PR DESCRIPTION
### Description 
The `delete.topic.enable` configuration check done during the `DROP STREAM DELETE TOPIC` command is unnecessary. This check is hiding the real error if a user cannot delete the topic when dropping the stream. Actually, the drop stream delete topic does not fail if the flag is set to False.

To fix the problem, I removed the `delete.topic.enable` check, and rely on the `TopicDeletionDisableException` thrown when attempting to delete the topic. For `DROP STREAM DELETE TOPIC`, an error will be displayed in the console about the delete.topic.enable. 

For Cluster termination, the exception is ignored, and let KSQL continue with the cluster termination and cleanup of any other internal state.

### Testing done 
Added a few test cases to validate the changes.
Verify the `DROP STREAM DELETE TOPIC` works as expected with and without the `delete.topic.enable` configuration.
```
ksql> drop stream t1 delete topic;
Could not delete the corresponding kafka topic: t1
Caused by: Topic deletion is disabled. To delete the topic, you must set
	'delete.topic.enable' to true in the Kafka cluster configuration.
```

### Reviewer checklist
- [ ] Ensure docs are updated if necessary. (eg. if a user visible feature is being added or changed).
- [ ] Ensure relevant issues are linked (description should include text like "Fixes #<issue number>")

