### PR TITLE
fix: `COLLECT_LIST` can now be applied to tables

### DIFF
--- a/ksql-engine/src/main/java/io/confluent/ksql/function/udaf/array/CollectListUdaf.java
+++ b/ksql-engine/src/main/java/io/confluent/ksql/function/udaf/array/CollectListUdaf.java
@@ -17,7 +17,6 @@ package io.confluent.ksql.function.udaf.array;
 
 import com.google.common.collect.Lists;
 import io.confluent.ksql.function.udaf.TableUdaf;
-import io.confluent.ksql.function.udaf.Udaf;
 import io.confluent.ksql.function.udaf.UdafDescription;
 import io.confluent.ksql.function.udaf.UdafFactory;
 import java.util.List;
@@ -69,27 +68,27 @@ public final class CollectListUdaf {
   }
 
   @UdafFactory(description = "collect values of a Bigint field into a single Array")
-  public static Udaf<Long, List<Long>> createCollectListLong() {
+  public static TableUdaf<Long, List<Long>> createCollectListLong() {
     return listCollector();
   }
 
   @UdafFactory(description = "collect values of an Integer field into a single Array")
-  public static Udaf<Integer, List<Integer>> createCollectListInt() {
+  public static TableUdaf<Integer, List<Integer>> createCollectListInt() {
     return listCollector();
   }
 
   @UdafFactory(description = "collect values of a Double field into a single Array")
-  public static Udaf<Double, List<Double>> createCollectListDouble() {
+  public static TableUdaf<Double, List<Double>> createCollectListDouble() {
     return listCollector();
   }
 
   @UdafFactory(description = "collect values of a String/Varchar field into a single Array")
-  public static Udaf<String, List<String>> createCollectListString() {
+  public static TableUdaf<String, List<String>> createCollectListString() {
     return listCollector();
   }
 
   @UdafFactory(description = "collect values of a Boolean field into a single Array")
-  public static Udaf<Boolean, List<Boolean>> createCollectListBool() {
+  public static TableUdaf<Boolean, List<Boolean>> createCollectListBool() {
     return listCollector();
   }
 }

--- a/ksql-engine/src/test/java/io/confluent/ksql/function/udaf/array/CollectListUdafTest.java
+++ b/ksql-engine/src/test/java/io/confluent/ksql/function/udaf/array/CollectListUdafTest.java
@@ -20,7 +20,8 @@ import static org.hamcrest.Matchers.hasItem;
 import static org.hamcrest.Matchers.hasSize;
 import static org.hamcrest.Matchers.not;
 import static org.junit.Assert.assertThat;
-import io.confluent.ksql.function.udaf.Udaf;
+
+import io.confluent.ksql.function.udaf.TableUdaf;
 import java.util.List;
 import org.junit.Test;
 
@@ -28,7 +29,7 @@ public class CollectListUdafTest {
 
   @Test
   public void shouldCollectInts() {
-    final Udaf<Integer, List<Integer>> udaf = CollectListUdaf.createCollectListInt();
+    final TableUdaf<Integer, List<Integer>> udaf = CollectListUdaf.createCollectListInt();
     final Integer[] values = new Integer[] {3, 4, 5, 3};
     List<Integer> runningList = udaf.initialize();
     for (final Integer i : values) {
@@ -39,7 +40,7 @@ public class CollectListUdafTest {
 
   @Test
   public void shouldMergeIntLists() {
-    final Udaf<Integer, List<Integer>> udaf = CollectListUdaf.createCollectListInt();
+    final TableUdaf<Integer, List<Integer>> udaf = CollectListUdaf.createCollectListInt();
 
     List<Integer> lhs = udaf.initialize();
     final Integer[] lhsValues = new Integer[] {1, 2, null, 3};
@@ -61,7 +62,7 @@ public class CollectListUdafTest {
 
   @Test
   public void shouldRespectSizeLimit() {
-    final Udaf<Integer, List<Integer>> udaf = CollectListUdaf.createCollectListInt();
+    final TableUdaf<Integer, List<Integer>> udaf = CollectListUdaf.createCollectListInt();
     List<Integer> runningList = udaf.initialize();
     for (int i = 1; i < 2500; i++) {
       runningList = udaf.aggregate(i, runningList);

--- a/ksql-engine/src/test/resources/query-validation-tests/collect-list.json
+++ b/ksql-engine/src/test/resources/query-validation-tests/collect-list.json
@@ -116,18 +116,18 @@
         "CREATE TABLE S2 as SELECT id, collect_list(value) as collected FROM test group by id;"
       ],
       "inputs": [
-        {"topic": "test_topic", "key": 0, "value": {"ID": 0, "VALUE": 0}},
-        {"topic": "test_topic", "key": 0, "value": {"ID": 0, "VALUE": 100}},
-        {"topic": "test_topic", "key": 100, "value": {"ID": 100, "VALUE": 500}},
-        {"topic": "test_topic", "key": 100, "value": {"ID": 100, "VALUE": 100}}
+        {"topic": "test_topic", "key": 0, "value": {"ID": 0, "VALUE": 0}, "timestamp": 0},
+        {"topic": "test_topic", "key": 0, "value": {"ID": 0, "VALUE": 100}, "timestamp": 0},
+        {"topic": "test_topic", "key": 100, "value": {"ID": 100, "VALUE": 500}, "timestamp": 0},
+        {"topic": "test_topic", "key": 100, "value": {"ID": 100, "VALUE": 100}, "timestamp": 0}
       ],
       "outputs": [
-        {"topic": "S2", "key": 0, "value": {"ID": 0, "COLLECTED": [0]}},
-        {"topic": "S2", "key": 0, "value": {"ID": 0, "COLLECTED": []}},
-        {"topic": "S2", "key": 0, "value": {"ID": 0, "COLLECTED": [100]}},
-        {"topic": "S2", "key": 100, "value": {"ID": 100, "COLLECTED": [500]}},
-        {"topic": "S2", "key": 100, "value": {"ID": 100, "COLLECTED": []}},
-        {"topic": "S2", "key": 100, "value": {"ID": 100, "COLLECTED": [100]}}
+        {"topic": "S2", "key": 0, "value": {"ID": 0, "COLLECTED": [0]}, "timestamp": 0},
+        {"topic": "S2", "key": 0, "value": {"ID": 0, "COLLECTED": []}, "timestamp": 0},
+        {"topic": "S2", "key": 0, "value": {"ID": 0, "COLLECTED": [100]}, "timestamp": 0},
+        {"topic": "S2", "key": 100, "value": {"ID": 100, "COLLECTED": [500]}, "timestamp": 0},
+        {"topic": "S2", "key": 100, "value": {"ID": 100, "COLLECTED": []}, "timestamp": 0},
+        {"topic": "S2", "key": 100, "value": {"ID": 100, "COLLECTED": [100]}, "timestamp": 0}
       ]
     },
     {
@@ -138,18 +138,18 @@
         "CREATE TABLE S2 as SELECT id, collect_list(value) as collected FROM test group by id;"
       ],
       "inputs": [
-        {"topic": "test_topic", "key": 0, "value": {"ID": 0, "VALUE": 2147483648}},
-        {"topic": "test_topic", "key": 0, "value": {"ID": 0, "VALUE": 100}},
-        {"topic": "test_topic", "key": 100, "value": {"ID": 100, "VALUE": 500}},
-        {"topic": "test_topic", "key": 100, "value": {"ID": 100, "VALUE": 100}}
+        {"topic": "test_topic", "key": 0, "value": {"ID": 0, "VALUE": 2147483648}, "timestamp": 0},
+        {"topic": "test_topic", "key": 0, "value": {"ID": 0, "VALUE": 100}, "timestamp": 0},
+        {"topic": "test_topic", "key": 100, "value": {"ID": 100, "VALUE": 500}, "timestamp": 0},
+        {"topic": "test_topic", "key": 100, "value": {"ID": 100, "VALUE": 100}, "timestamp": 0}
       ],
       "outputs": [
-        {"topic": "S2", "key": 0, "value": {"ID": 0, "COLLECTED": [2147483648]}},
-        {"topic": "S2", "key": 0, "value": {"ID": 0, "COLLECTED": []}},
-        {"topic": "S2", "key": 0, "value": {"ID": 0, "COLLECTED": [100]}},
-        {"topic": "S2", "key": 100, "value": {"ID": 100, "COLLECTED": [500]}},
-        {"topic": "S2", "key": 100, "value": {"ID": 100, "COLLECTED": []}},
-        {"topic": "S2", "key": 100, "value": {"ID": 100, "COLLECTED": [100]}}
+        {"topic": "S2", "key": 0, "value": {"ID": 0, "COLLECTED": [2147483648]}, "timestamp": 0},
+        {"topic": "S2", "key": 0, "value": {"ID": 0, "COLLECTED": []}, "timestamp": 0},
+        {"topic": "S2", "key": 0, "value": {"ID": 0, "COLLECTED": [100]}, "timestamp": 0},
+        {"topic": "S2", "key": 100, "value": {"ID": 100, "COLLECTED": [500]}, "timestamp": 0},
+        {"topic": "S2", "key": 100, "value": {"ID": 100, "COLLECTED": []}, "timestamp": 0},
+        {"topic": "S2", "key": 100, "value": {"ID": 100, "COLLECTED": [100]}, "timestamp": 0}
       ]
     },
     {
@@ -160,18 +160,18 @@
         "CREATE TABLE S2 as SELECT id, collect_list(value) as collected FROM test group by id;"
       ],
       "inputs": [
-        {"topic": "test_topic", "key": 0, "value": {"ID": 0, "VALUE": 5.4}},
-        {"topic": "test_topic", "key": 0, "value": {"ID": 0, "VALUE": 100.1}},
-        {"topic": "test_topic", "key": 100, "value": {"ID": 100, "VALUE": 500.9}},
-        {"topic": "test_topic", "key": 100, "value": {"ID": 100, "VALUE": 300.8}}
+        {"topic": "test_topic", "key": 0, "value": {"ID": 0, "VALUE": 5.4}, "timestamp": 0},
+        {"topic": "test_topic", "key": 0, "value": {"ID": 0, "VALUE": 100.1}, "timestamp": 0},
+        {"topic": "test_topic", "key": 100, "value": {"ID": 100, "VALUE": 500.9}, "timestamp": 0},
+        {"topic": "test_topic", "key": 100, "value": {"ID": 100, "VALUE": 300.8}, "timestamp": 0}
       ],
       "outputs": [
-        {"topic": "S2", "key": 0, "value": {"ID": 0, "COLLECTED": [5.4]}},
-        {"topic": "S2", "key": 0, "value": {"ID": 0, "COLLECTED": []}},
-        {"topic": "S2", "key": 0, "value": {"ID": 0, "COLLECTED": [100.1]}},
-        {"topic": "S2", "key": 100, "value": {"ID": 100, "COLLECTED": [500.9]}},
-        {"topic": "S2", "key": 100, "value": {"ID": 100, "COLLECTED": []}},
-        {"topic": "S2", "key": 100, "value": {"ID": 100, "COLLECTED": [300.8]}}
+        {"topic": "S2", "key": 0, "value": {"ID": 0, "COLLECTED": [5.4]}, "timestamp": 0},
+        {"topic": "S2", "key": 0, "value": {"ID": 0, "COLLECTED": []}, "timestamp": 0},
+        {"topic": "S2", "key": 0, "value": {"ID": 0, "COLLECTED": [100.1]}, "timestamp": 0},
+        {"topic": "S2", "key": 100, "value": {"ID": 100, "COLLECTED": [500.9]}, "timestamp": 0},
+        {"topic": "S2", "key": 100, "value": {"ID": 100, "COLLECTED": []}, "timestamp": 0},
+        {"topic": "S2", "key": 100, "value": {"ID": 100, "COLLECTED": [300.8]}, "timestamp": 0}
       ]
     },
     {
@@ -182,21 +182,21 @@
         "CREATE TABLE S2 as SELECT id, collect_list(value) as collected FROM test group by id;"
       ],
       "inputs": [
-        {"topic": "test_topic", "key": 0, "value": {"ID": 0, "VALUE": "foo"}},
-        {"topic": "test_topic", "key": 100, "value": {"ID": 100, "VALUE": "baz"}},
-        {"topic": "test_topic", "key": 0, "value": {"ID": 0, "VALUE": "bar"}},
-        {"topic": "test_topic", "key": 100, "value": {"ID": 100, "VALUE": "baz"}},
-        {"topic": "test_topic", "key": 100, "value": {"ID": 100, "VALUE": "foo"}}
+        {"topic": "test_topic", "key": 0, "value": {"ID": 0, "VALUE": "foo"}, "timestamp": 0},
+        {"topic": "test_topic", "key": 100, "value": {"ID": 100, "VALUE": "baz"}, "timestamp": 0},
+        {"topic": "test_topic", "key": 0, "value": {"ID": 0, "VALUE": "bar"}, "timestamp": 0},
+        {"topic": "test_topic", "key": 100, "value": {"ID": 100, "VALUE": "baz"}, "timestamp": 0},
+        {"topic": "test_topic", "key": 100, "value": {"ID": 100, "VALUE": "foo"}, "timestamp": 0}
       ],
       "outputs": [
-        {"topic": "S2", "key": 0, "value": {"ID": 0, "COLLECTED": ["foo"]}},
-        {"topic": "S2", "key": 100, "value": {"ID": 100, "COLLECTED": ["baz"]}},
-        {"topic": "S2", "key": 0, "value": {"ID": 0, "COLLECTED": []}},
-        {"topic": "S2", "key": 0, "value": {"ID": 0, "COLLECTED": ["bar"]}},
-        {"topic": "S2", "key": 100, "value": {"ID": 100, "COLLECTED": []}},
-        {"topic": "S2", "key": 100, "value": {"ID": 100, "COLLECTED": ["baz"]}},
-        {"topic": "S2", "key": 100, "value": {"ID": 100, "COLLECTED": []}},
-        {"topic": "S2", "key": 100, "value": {"ID": 100, "COLLECTED": ["foo"]}}
+        {"topic": "S2", "key": 0, "value": {"ID": 0, "COLLECTED": ["foo"]}, "timestamp": 0},
+        {"topic": "S2", "key": 100, "value": {"ID": 100, "COLLECTED": ["baz"]}, "timestamp": 0},
+        {"topic": "S2", "key": 0, "value": {"ID": 0, "COLLECTED": []}, "timestamp": 0},
+        {"topic": "S2", "key": 0, "value": {"ID": 0, "COLLECTED": ["bar"]}, "timestamp": 0},
+        {"topic": "S2", "key": 100, "value": {"ID": 100, "COLLECTED": []}, "timestamp": 0},
+        {"topic": "S2", "key": 100, "value": {"ID": 100, "COLLECTED": ["baz"]}, "timestamp": 0},
+        {"topic": "S2", "key": 100, "value": {"ID": 100, "COLLECTED": []}, "timestamp": 0},
+        {"topic": "S2", "key": 100, "value": {"ID": 100, "COLLECTED": ["foo"]}, "timestamp": 0}
       ]
     },
     {
@@ -207,16 +207,16 @@
         "CREATE TABLE S2 as SELECT id, collect_list(value['key1']) AS collected FROM test group by id;"
       ],
       "inputs": [
-        {"topic": "test_topic", "key": 0, "value": {"id": 0, "name": "zero", "value": {"key1":true, "key2":false}}},
-        {"topic": "test_topic", "key": 0, "value": {"id": 0, "name": "zero", "value": {"key1":false, "key2":true}}},
-        {"topic": "test_topic", "key": 0, "value": {"id": 0, "name": "zero", "value": {"key1":true, "key2":true}}}
+        {"topic": "test_topic", "key": 0, "value": {"id": 0, "name": "zero", "value": {"key1":true, "key2":false}}, "timestamp": 0},
+        {"topic": "test_topic", "key": 0, "value": {"id": 0, "name": "zero", "value": {"key1":false, "key2":true}}, "timestamp": 0},
+        {"topic": "test_topic", "key": 0, "value": {"id": 0, "name": "zero", "value": {"key1":true, "key2":true}}, "timestamp": 0}
       ],
       "outputs": [
-        {"topic": "S2", "key": 0, "value": {"ID":0,"COLLECTED":[true]}},
-        {"topic": "S2", "key": 0, "value": {"ID":0,"COLLECTED":[]}},
-        {"topic": "S2", "key": 0, "value": {"ID":0,"COLLECTED":[false]}},
-        {"topic": "S2", "key": 0, "value": {"ID":0,"COLLECTED":[]}},
-        {"topic": "S2", "key": 0, "value": {"ID":0,"COLLECTED":[true]}}
+        {"topic": "S2", "key": 0, "value": {"ID":0,"COLLECTED":[true]}, "timestamp": 0},
+        {"topic": "S2", "key": 0, "value": {"ID":0,"COLLECTED":[]}, "timestamp": 0},
+        {"topic": "S2", "key": 0, "value": {"ID":0,"COLLECTED":[false]}, "timestamp": 0},
+        {"topic": "S2", "key": 0, "value": {"ID":0,"COLLECTED":[]}, "timestamp": 0},
+        {"topic": "S2", "key": 0, "value": {"ID":0,"COLLECTED":[true]}, "timestamp": 0}
       ]
     }
   ]

--- a/ksql-engine/src/test/resources/query-validation-tests/collect-list.json
+++ b/ksql-engine/src/test/resources/query-validation-tests/collect-list.json
@@ -107,6 +107,117 @@
         {"topic": "S2", "key": 0, "value": {"ID":0,"COLLECTED":[true,false]}, "timestamp": 0},
         {"topic": "S2", "key": 0, "value": {"ID":0,"COLLECTED":[true,false,true]}, "timestamp": 0}
       ]
+    },
+    {
+      "name": "collect_list int table",
+      "format": ["AVRO", "JSON"],
+      "statements": [
+        "CREATE TABLE TEST (ID bigint, VALUE integer) WITH (kafka_topic='test_topic',value_format='{FORMAT}', key='ID');",
+        "CREATE TABLE S2 as SELECT id, collect_list(value) as collected FROM test group by id;"
+      ],
+      "inputs": [
+        {"topic": "test_topic", "key": 0, "value": {"ID": 0, "VALUE": 0}},
+        {"topic": "test_topic", "key": 0, "value": {"ID": 0, "VALUE": 100}},
+        {"topic": "test_topic", "key": 100, "value": {"ID": 100, "VALUE": 500}},
+        {"topic": "test_topic", "key": 100, "value": {"ID": 100, "VALUE": 100}}
+      ],
+      "outputs": [
+        {"topic": "S2", "key": 0, "value": {"ID": 0, "COLLECTED": [0]}},
+        {"topic": "S2", "key": 0, "value": {"ID": 0, "COLLECTED": []}},
+        {"topic": "S2", "key": 0, "value": {"ID": 0, "COLLECTED": [100]}},
+        {"topic": "S2", "key": 100, "value": {"ID": 100, "COLLECTED": [500]}},
+        {"topic": "S2", "key": 100, "value": {"ID": 100, "COLLECTED": []}},
+        {"topic": "S2", "key": 100, "value": {"ID": 100, "COLLECTED": [100]}}
+      ]
+    },
+    {
+      "name": "collect_list long table",
+      "format": ["AVRO", "JSON"],
+      "statements": [
+        "CREATE TABLE TEST (ID bigint, VALUE bigint) WITH (kafka_topic='test_topic', value_format='{FORMAT}', key='ID');",
+        "CREATE TABLE S2 as SELECT id, collect_list(value) as collected FROM test group by id;"
+      ],
+      "inputs": [
+        {"topic": "test_topic", "key": 0, "value": {"ID": 0, "VALUE": 2147483648}},
+        {"topic": "test_topic", "key": 0, "value": {"ID": 0, "VALUE": 100}},
+        {"topic": "test_topic", "key": 100, "value": {"ID": 100, "VALUE": 500}},
+        {"topic": "test_topic", "key": 100, "value": {"ID": 100, "VALUE": 100}}
+      ],
+      "outputs": [
+        {"topic": "S2", "key": 0, "value": {"ID": 0, "COLLECTED": [2147483648]}},
+        {"topic": "S2", "key": 0, "value": {"ID": 0, "COLLECTED": []}},
+        {"topic": "S2", "key": 0, "value": {"ID": 0, "COLLECTED": [100]}},
+        {"topic": "S2", "key": 100, "value": {"ID": 100, "COLLECTED": [500]}},
+        {"topic": "S2", "key": 100, "value": {"ID": 100, "COLLECTED": []}},
+        {"topic": "S2", "key": 100, "value": {"ID": 100, "COLLECTED": [100]}}
+      ]
+    },
+    {
+      "name": "collect_list double table",
+      "format": ["AVRO", "JSON"],
+      "statements": [
+        "CREATE TABLE TEST (ID bigint, VALUE double) WITH (kafka_topic='test_topic', value_format='{FORMAT}', key='ID');",
+        "CREATE TABLE S2 as SELECT id, collect_list(value) as collected FROM test group by id;"
+      ],
+      "inputs": [
+        {"topic": "test_topic", "key": 0, "value": {"ID": 0, "VALUE": 5.4}},
+        {"topic": "test_topic", "key": 0, "value": {"ID": 0, "VALUE": 100.1}},
+        {"topic": "test_topic", "key": 100, "value": {"ID": 100, "VALUE": 500.9}},
+        {"topic": "test_topic", "key": 100, "value": {"ID": 100, "VALUE": 300.8}}
+      ],
+      "outputs": [
+        {"topic": "S2", "key": 0, "value": {"ID": 0, "COLLECTED": [5.4]}},
+        {"topic": "S2", "key": 0, "value": {"ID": 0, "COLLECTED": []}},
+        {"topic": "S2", "key": 0, "value": {"ID": 0, "COLLECTED": [100.1]}},
+        {"topic": "S2", "key": 100, "value": {"ID": 100, "COLLECTED": [500.9]}},
+        {"topic": "S2", "key": 100, "value": {"ID": 100, "COLLECTED": []}},
+        {"topic": "S2", "key": 100, "value": {"ID": 100, "COLLECTED": [300.8]}}
+      ]
+    },
+    {
+      "name": "collect_list string table",
+      "format": ["AVRO", "JSON"],
+      "statements": [
+        "CREATE TABLE TEST (ID bigint, VALUE varchar) WITH (kafka_topic='test_topic', value_format='{FORMAT}', key='ID');",
+        "CREATE TABLE S2 as SELECT id, collect_list(value) as collected FROM test group by id;"
+      ],
+      "inputs": [
+        {"topic": "test_topic", "key": 0, "value": {"ID": 0, "VALUE": "foo"}},
+        {"topic": "test_topic", "key": 100, "value": {"ID": 100, "VALUE": "baz"}},
+        {"topic": "test_topic", "key": 0, "value": {"ID": 0, "VALUE": "bar"}},
+        {"topic": "test_topic", "key": 100, "value": {"ID": 100, "VALUE": "baz"}},
+        {"topic": "test_topic", "key": 100, "value": {"ID": 100, "VALUE": "foo"}}
+      ],
+      "outputs": [
+        {"topic": "S2", "key": 0, "value": {"ID": 0, "COLLECTED": ["foo"]}},
+        {"topic": "S2", "key": 100, "value": {"ID": 100, "COLLECTED": ["baz"]}},
+        {"topic": "S2", "key": 0, "value": {"ID": 0, "COLLECTED": []}},
+        {"topic": "S2", "key": 0, "value": {"ID": 0, "COLLECTED": ["bar"]}},
+        {"topic": "S2", "key": 100, "value": {"ID": 100, "COLLECTED": []}},
+        {"topic": "S2", "key": 100, "value": {"ID": 100, "COLLECTED": ["baz"]}},
+        {"topic": "S2", "key": 100, "value": {"ID": 100, "COLLECTED": []}},
+        {"topic": "S2", "key": 100, "value": {"ID": 100, "COLLECTED": ["foo"]}}
+      ]
+    },
+    {
+      "name": "collect_list bool map table",
+      "format": ["JSON"],
+      "statements": [
+        "CREATE TABLE TEST (ID bigint, NAME varchar, VALUE map<varchar, boolean>) WITH (kafka_topic='test_topic', value_format='{FORMAT}', key='ID');",
+        "CREATE TABLE S2 as SELECT id, collect_list(value['key1']) AS collected FROM test group by id;"
+      ],
+      "inputs": [
+        {"topic": "test_topic", "key": 0, "value": {"id": 0, "name": "zero", "value": {"key1":true, "key2":false}}},
+        {"topic": "test_topic", "key": 0, "value": {"id": 0, "name": "zero", "value": {"key1":false, "key2":true}}},
+        {"topic": "test_topic", "key": 0, "value": {"id": 0, "name": "zero", "value": {"key1":true, "key2":true}}}
+      ],
+      "outputs": [
+        {"topic": "S2", "key": 0, "value": {"ID":0,"COLLECTED":[true]}},
+        {"topic": "S2", "key": 0, "value": {"ID":0,"COLLECTED":[]}},
+        {"topic": "S2", "key": 0, "value": {"ID":0,"COLLECTED":[false]}},
+        {"topic": "S2", "key": 0, "value": {"ID":0,"COLLECTED":[]}},
+        {"topic": "S2", "key": 0, "value": {"ID":0,"COLLECTED":[true]}}
+      ]
     }
   ]
 }


### PR DESCRIPTION
### Description 

Same as https://github.com/confluentinc/ksql/pull/3093, but retargeted at an earlier branch.

(The only difference between these diffs and the ones in https://github.com/confluentinc/ksql/pull/3093 are that the old query translation test framework (used in 5.1) required all messages to have timestamps. I will remove these timestamps from 5.2 and later via a manual merge after this PR is submitted.)

### Testing done 

Updated unit tests and added query translation tests.

### Reviewer checklist
- [ ] Ensure docs are updated if necessary. (eg. if a user visible feature is being added or changed).
- [ ] Ensure relevant issues are linked (description should include text like "Fixes #<issue number>")

