### PR TITLE
fix: add ksql-functional-tests to the ksql package

### DIFF
--- a/ksql-package/pom.xml
+++ b/ksql-package/pom.xml
@@ -74,6 +74,12 @@
             <artifactId>ksql-examples</artifactId>
         </dependency>
 
+        <dependency>
+            <groupId>io.confluent.ksql</groupId>
+            <artifactId>ksql-functional-tests</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+
       <!-- Required for running tests -->
 
       <dependency>


### PR DESCRIPTION
### Description 
The KSQL testing tool wasn't added to the `ksql-package` module, which meant that it will not be in the tarball, or rpms, or debs. This patch adds it.

### Testing done 
`ksql-functional-tests.jar` now exists in the built package, where previously it did not. 
```
amehta-macbook-pro-3:ksql-package-5.4.0-SNAPSHOT-package apurva$ find . -name "*functional*"
./share/java/ksql/ksql-functional-tests-5.4.0-SNAPSHOT.jar
amehta-macbook-pro-3:ksql-package-5.4.0-SNAPSHOT-package apurva$ pwd
/Users/apurva/workspace/confluent/ksql/ksql-package/target/ksql-package-5.4.0-SNAPSHOT-package
amehta-macbook-pro-3:ksql-package-5.4.0-SNAPSHOT-package apurva$
```
### Reviewer checklist
- [ ] Ensure docs are updated if necessary. (eg. if a user visible feature is being added or changed).
- [ ] Ensure relevant issues are linked (description should include text like "Fixes #<issue number>")

