### PR TITLE
docs: call out that service id should end in separator char

### DIFF
--- a/docs/concepts/ksql-architecture.rst
+++ b/docs/concepts/ksql-architecture.rst
@@ -163,8 +163,11 @@ Command Topic
 In interactive mode, KSQL shares statements with servers in the cluster over the
 *command topic*. The command topic stores every KSQL statement, along with some
 metadata that ensures the statements are built compatibly across KSQL restarts
-and upgrades. KSQL names the command topic ``_confluent-ksql-<service id>_command_topic``,
+and upgrades. KSQL names the command topic ``_confluent-ksql-<service id>command_topic``,
 where ``<service id>`` is the value in the ``ksql.service.id`` property.
+
+By convention, the ``ksql.service.id`` property should end with a separator character of some form,
+for example a dash or underscore, as this makes the topic name easier to read.
 
 .. _ksql-server-headless-deployment:
 

--- a/docs/installation/server-config/config-reference.rst
+++ b/docs/installation/server-config/config-reference.rst
@@ -201,6 +201,9 @@ By default, the service ID of KSQL servers is ``default_``. The service ID is al
 the prefix for the internal topics created by KSQL. Using the default value ``ksql.service.id``, the KSQL internal topics
 will be prefixed as ``_confluent-ksql-default_`` (e.g. ``_command_topic`` becomes ``_confluent-ksql-default__command_topic``).
 
+By convention, the ``ksql.service.id`` property should end with a separator character of some form,
+for example a dash or underscore, as this makes the internal topic names easier to read.
+
 .. _ksql-internal-topic-replicas:
 
 ----------------------------

--- a/ksql-common/src/main/java/io/confluent/ksql/util/KsqlConfig.java
+++ b/ksql-common/src/main/java/io/confluent/ksql/util/KsqlConfig.java
@@ -384,6 +384,9 @@ public class KsqlConfig extends AbstractConfig {
             KSQL_SERVICE_ID_DEFAULT,
             ConfigDef.Importance.MEDIUM,
             "Indicates the ID of the ksql service. It will be used as prefix for "
+                + "all implicitly named resources created by this instance in Kafka. "
+                + "By convention, the id should end in a seperator character of some form, e.g. "
+                + "a dash or underscore, as this makes identifiers easier to read."
         )
         .define(
             KSQL_TRANSIENT_QUERY_NAME_PREFIX_CONFIG,


### PR DESCRIPTION
### Description 

Doc change to call out that the service id should ideally end in a `-` or `_` to make reading the internal topic names easier.

Prompted by https://github.com/confluentinc/ksql/pull/3085

### Testing done 

doc only change.

### Reviewer checklist
- [ ] Ensure docs are updated if necessary. (eg. if a user visible feature is being added or changed).
- [ ] Ensure relevant issues are linked (description should include text like "Fixes #<issue number>")

