### PR TITLE
refactor: separate expression tree nodes into a separate tree from ast

### DIFF
--- a/ksql-engine/src/main/java/io/confluent/ksql/analyzer/AggregateAnalyzer.java
+++ b/ksql-engine/src/main/java/io/confluent/ksql/analyzer/AggregateAnalyzer.java
@@ -21,7 +21,6 @@ import io.confluent.ksql.parser.DefaultTraversalVisitor;
 import io.confluent.ksql.parser.tree.DereferenceExpression;
 import io.confluent.ksql.parser.tree.Expression;
 import io.confluent.ksql.parser.tree.FunctionCall;
-import io.confluent.ksql.parser.tree.Node;
 import io.confluent.ksql.util.KsqlException;
 import java.util.HashSet;
 import java.util.Objects;
@@ -82,7 +81,7 @@ class AggregateAnalyzer {
     visitor.process(expression, null);
   }
 
-  private final class AggregateVisitor extends DefaultTraversalVisitor<Node, Void> {
+  private final class AggregateVisitor extends DefaultTraversalVisitor<Void, Void> {
 
     private final BiConsumer<Optional<String>, DereferenceExpression> dereferenceCollector;
     private Optional<String> aggFunctionName = Optional.empty();
@@ -96,7 +95,7 @@ class AggregateAnalyzer {
     }
 
     @Override
-    protected Node visitFunctionCall(final FunctionCall node, final Void context) {
+    public Void visitFunctionCall(final FunctionCall node, final Void context) {
       final String functionName = node.getName().getSuffix();
       final boolean aggregateFunc = functionRegistry.isAggregate(functionName);
 
@@ -117,17 +116,17 @@ class AggregateAnalyzer {
         aggregateAnalysis.addAggFunction(functionCall);
       }
 
-      final Node result = super.visitFunctionCall(functionCall, context);
+      super.visitFunctionCall(functionCall, context);
 
       if (aggregateFunc) {
         aggFunctionName = Optional.empty();
       }
 
-      return result;
+      return null;
     }
 
     @Override
-    protected Node visitDereferenceExpression(
+    public Void visitDereferenceExpression(
         final DereferenceExpression node,
         final Void context
     ) {

--- a/ksql-engine/src/main/java/io/confluent/ksql/analyzer/ExpressionAnalyzer.java
+++ b/ksql-engine/src/main/java/io/confluent/ksql/analyzer/ExpressionAnalyzer.java
@@ -69,19 +69,19 @@ class ExpressionAnalyzer {
 
   private class Visitor extends AstVisitor<Object, Object> {
 
-    protected Object visitLikePredicate(final LikePredicate node, final Object context) {
+    public Object visitLikePredicate(final LikePredicate node, final Object context) {
       process(node.getValue(), null);
       return null;
     }
 
-    protected Object visitFunctionCall(final FunctionCall node, final Object context) {
+    public Object visitFunctionCall(final FunctionCall node, final Object context) {
       for (final Expression argExpr : node.getArguments()) {
         process(argExpr, null);
       }
       return null;
     }
 
-    protected Object visitArithmeticBinary(
+    public Object visitArithmeticBinary(
         final ArithmeticBinaryExpression node,
         final Object context) {
       process(node.getLeft(), null);
@@ -89,15 +89,15 @@ class ExpressionAnalyzer {
       return null;
     }
 
-    protected Object visitIsNotNullPredicate(final IsNotNullPredicate node, final Object context) {
+    public Object visitIsNotNullPredicate(final IsNotNullPredicate node, final Object context) {
       return process(node.getValue(), context);
     }
 
-    protected Object visitIsNullPredicate(final IsNullPredicate node, final Object context) {
+    public Object visitIsNullPredicate(final IsNullPredicate node, final Object context) {
       return process(node.getValue(), context);
     }
 
-    protected Object visitLogicalBinaryExpression(
+    public Object visitLogicalBinaryExpression(
         final LogicalBinaryExpression node,
         final Object context) {
       process(node.getLeft(), null);
@@ -106,7 +106,7 @@ class ExpressionAnalyzer {
     }
 
     @Override
-    protected Object visitComparisonExpression(
+    public Object visitComparisonExpression(
         final ComparisonExpression node,
         final Object context) {
       process(node.getLeft(), null);
@@ -115,18 +115,18 @@ class ExpressionAnalyzer {
     }
 
     @Override
-    protected Object visitNotExpression(final NotExpression node, final Object context) {
+    public Object visitNotExpression(final NotExpression node, final Object context) {
       return process(node.getValue(), null);
     }
 
     @Override
-    protected Object visitCast(final Cast node, final Object context) {
+    public Object visitCast(final Cast node, final Object context) {
       process(node.getExpression(), context);
       return null;
     }
 
     @Override
-    protected Object visitDereferenceExpression(
+    public Object visitDereferenceExpression(
         final DereferenceExpression node,
         final Object context
     ) {
@@ -139,7 +139,7 @@ class ExpressionAnalyzer {
     }
 
     @Override
-    protected Object visitQualifiedNameReference(
+    public Object visitQualifiedNameReference(
         final QualifiedNameReference node,
         final Object context
     ) {

--- a/ksql-engine/src/main/java/io/confluent/ksql/codegen/CodeGenRunner.java
+++ b/ksql-engine/src/main/java/io/confluent/ksql/codegen/CodeGenRunner.java
@@ -183,12 +183,12 @@ public class CodeGenRunner {
           ksqlConfig));
     }
 
-    protected Object visitLikePredicate(final LikePredicate node, final Object context) {
+    public Object visitLikePredicate(final LikePredicate node, final Object context) {
       process(node.getValue(), null);
       return null;
     }
 
-    protected Object visitFunctionCall(final FunctionCall node, final Object context) {
+    public Object visitFunctionCall(final FunctionCall node, final Object context) {
       final int functionNumber = functionCounter++;
       final List<Schema> argumentTypes = new ArrayList<>();
       final String functionName = node.getName().getSuffix();
@@ -208,7 +208,7 @@ public class CodeGenRunner {
       return null;
     }
 
-    protected Object visitArithmeticBinary(
+    public Object visitArithmeticBinary(
         final ArithmeticBinaryExpression node,
         final Object context) {
       process(node.getLeft(), null);
@@ -216,22 +216,22 @@ public class CodeGenRunner {
       return null;
     }
 
-    protected Object visitArithmeticUnary(
+    public Object visitArithmeticUnary(
         final ArithmeticUnaryExpression node,
         final Object context) {
       process(node.getValue(), null);
       return null;
     }
 
-    protected Object visitIsNotNullPredicate(final IsNotNullPredicate node, final Object context) {
+    public Object visitIsNotNullPredicate(final IsNotNullPredicate node, final Object context) {
       return process(node.getValue(), context);
     }
 
-    protected Object visitIsNullPredicate(final IsNullPredicate node, final Object context) {
+    public Object visitIsNullPredicate(final IsNullPredicate node, final Object context) {
       return process(node.getValue(), context);
     }
 
-    protected Object visitLogicalBinaryExpression(
+    public Object visitLogicalBinaryExpression(
         final LogicalBinaryExpression node,
         final Object context) {
       process(node.getLeft(), null);
@@ -240,7 +240,7 @@ public class CodeGenRunner {
     }
 
     @Override
-    protected Object visitComparisonExpression(
+    public Object visitComparisonExpression(
         final ComparisonExpression node,
         final Object context) {
       process(node.getLeft(), null);
@@ -249,7 +249,7 @@ public class CodeGenRunner {
     }
 
     @Override
-    protected Object visitBetweenPredicate(final BetweenPredicate node, final Object context) {
+    public Object visitBetweenPredicate(final BetweenPredicate node, final Object context) {
       process(node.getValue(), null);
       process(node.getMax(), null);
       process(node.getMin(), null);
@@ -257,12 +257,12 @@ public class CodeGenRunner {
     }
 
     @Override
-    protected Object visitNotExpression(final NotExpression node, final Object context) {
+    public Object visitNotExpression(final NotExpression node, final Object context) {
       return process(node.getValue(), null);
     }
 
     @Override
-    protected Object visitDereferenceExpression(
+    public Object visitDereferenceExpression(
         final DereferenceExpression node,
         final Object context
     ) {
@@ -271,7 +271,7 @@ public class CodeGenRunner {
     }
 
     @Override
-    protected Object visitSearchedCaseExpression(
+    public Object visitSearchedCaseExpression(
         final SearchedCaseExpression node,
         final Object context) {
       node.getWhenClauses().forEach(
@@ -285,13 +285,13 @@ public class CodeGenRunner {
     }
 
     @Override
-    protected Object visitCast(final Cast node, final Object context) {
+    public Object visitCast(final Cast node, final Object context) {
       process(node.getExpression(), context);
       return null;
     }
 
     @Override
-    protected Object visitSubscriptExpression(
+    public Object visitSubscriptExpression(
         final SubscriptExpression node,
         final Object context
     ) {
@@ -307,7 +307,7 @@ public class CodeGenRunner {
     }
 
     @Override
-    protected Object visitQualifiedNameReference(
+    public Object visitQualifiedNameReference(
         final QualifiedNameReference node,
         final Object context
     ) {

--- a/ksql-engine/src/main/java/io/confluent/ksql/codegen/SqlToJavaVisitor.java
+++ b/ksql-engine/src/main/java/io/confluent/ksql/codegen/SqlToJavaVisitor.java
@@ -28,6 +28,7 @@ import io.confluent.ksql.function.udf.structfieldextractor.FetchFieldFromStruct;
 import io.confluent.ksql.parser.tree.AllColumns;
 import io.confluent.ksql.parser.tree.ArithmeticBinaryExpression;
 import io.confluent.ksql.parser.tree.ArithmeticUnaryExpression;
+import io.confluent.ksql.parser.tree.AstNode;
 import io.confluent.ksql.parser.tree.AstVisitor;
 import io.confluent.ksql.parser.tree.BetweenPredicate;
 import io.confluent.ksql.parser.tree.BooleanLiteral;
@@ -43,7 +44,6 @@ import io.confluent.ksql.parser.tree.IsNullPredicate;
 import io.confluent.ksql.parser.tree.LikePredicate;
 import io.confluent.ksql.parser.tree.LogicalBinaryExpression;
 import io.confluent.ksql.parser.tree.LongLiteral;
-import io.confluent.ksql.parser.tree.Node;
 import io.confluent.ksql.parser.tree.NotExpression;
 import io.confluent.ksql.parser.tree.NullLiteral;
 import io.confluent.ksql.parser.tree.QualifiedName;
@@ -152,7 +152,7 @@ public class SqlToJavaVisitor {
     }
 
     @Override
-    protected Pair<String, Schema> visitNode(final Node node, final Void context) {
+    protected Pair<String, Schema> visitNode(final AstNode node, final Void context) {
       throw new UnsupportedOperationException();
     }
 
@@ -171,7 +171,7 @@ public class SqlToJavaVisitor {
     }
 
     @Override
-    protected Pair<String, Schema> visitBooleanLiteral(
+    public Pair<String, Schema> visitBooleanLiteral(
         final BooleanLiteral node,
         final Void context
     ) {
@@ -179,7 +179,7 @@ public class SqlToJavaVisitor {
     }
 
     @Override
-    protected Pair<String, Schema> visitStringLiteral(
+    public Pair<String, Schema> visitStringLiteral(
         final StringLiteral node,
         final Void context
     ) {
@@ -189,19 +189,19 @@ public class SqlToJavaVisitor {
     }
 
     @Override
-    protected Pair<String, Schema> visitDoubleLiteral(
+    public Pair<String, Schema> visitDoubleLiteral(
         final DoubleLiteral node, final Void context) {
       return new Pair<>(Double.toString(node.getValue()), Schema.OPTIONAL_FLOAT64_SCHEMA);
     }
 
     @Override
-    protected Pair<String, Schema> visitNullLiteral(
+    public Pair<String, Schema> visitNullLiteral(
         final NullLiteral node, final Void context) {
       return new Pair<>("null", null);
     }
 
     @Override
-    protected Pair<String, Schema> visitQualifiedNameReference(
+    public Pair<String, Schema> visitQualifiedNameReference(
         final QualifiedNameReference node,
         final Void context
     ) {
@@ -215,7 +215,7 @@ public class SqlToJavaVisitor {
     }
 
     @Override
-    protected Pair<String, Schema> visitDereferenceExpression(
+    public Pair<String, Schema> visitDereferenceExpression(
         final DereferenceExpression node,
         final Void context
     ) {
@@ -236,7 +236,7 @@ public class SqlToJavaVisitor {
       return Joiner.on('.').join(parts);
     }
 
-    protected Pair<String, Schema> visitLongLiteral(
+    public Pair<String, Schema> visitLongLiteral(
         final LongLiteral node,
         final Void context
     ) {
@@ -244,7 +244,7 @@ public class SqlToJavaVisitor {
     }
 
     @Override
-    protected Pair<String, Schema> visitIntegerLiteral(
+    public Pair<String, Schema> visitIntegerLiteral(
         final IntegerLiteral node,
         final Void context
     ) {
@@ -252,7 +252,7 @@ public class SqlToJavaVisitor {
     }
 
     @Override
-    protected Pair<String, Schema> visitFunctionCall(
+    public Pair<String, Schema> visitFunctionCall(
         final FunctionCall node,
         final Void context) {
       final String functionName = node.getName().getSuffix();
@@ -283,7 +283,7 @@ public class SqlToJavaVisitor {
     }
 
     @Override
-    protected Pair<String, Schema> visitLogicalBinaryExpression(
+    public Pair<String, Schema> visitLogicalBinaryExpression(
         final LogicalBinaryExpression node,
         final Void context
     ) {
@@ -306,7 +306,7 @@ public class SqlToJavaVisitor {
     }
 
     @Override
-    protected Pair<String, Schema> visitNotExpression(
+    public Pair<String, Schema> visitNotExpression(
         final NotExpression node, final Void context) {
       final String exprString = process(node.getValue(), context).getLeft();
       return new Pair<>("(!" + exprString + ")", Schema.OPTIONAL_BOOLEAN_SCHEMA);
@@ -394,7 +394,7 @@ public class SqlToJavaVisitor {
     }
 
     @Override
-    protected Pair<String, Schema> visitComparisonExpression(
+    public Pair<String, Schema> visitComparisonExpression(
         final ComparisonExpression node,
         final Void context
     ) {
@@ -428,13 +428,13 @@ public class SqlToJavaVisitor {
     }
 
     @Override
-    protected Pair<String, Schema> visitCast(final Cast node, final Void context) {
+    public Pair<String, Schema> visitCast(final Cast node, final Void context) {
       final Pair<String, Schema> expr = process(node.getExpression(), context);
       return CastVisitor.getCast(expr, node.getType().getSqlType());
     }
 
     @Override
-    protected Pair<String, Schema> visitIsNullPredicate(
+    public Pair<String, Schema> visitIsNullPredicate(
         final IsNullPredicate node,
         final Void context
     ) {
@@ -443,7 +443,7 @@ public class SqlToJavaVisitor {
     }
 
     @Override
-    protected Pair<String, Schema> visitIsNotNullPredicate(
+    public Pair<String, Schema> visitIsNotNullPredicate(
         final IsNotNullPredicate node,
         final Void context
     ) {
@@ -452,7 +452,7 @@ public class SqlToJavaVisitor {
     }
 
     @Override
-    protected Pair<String, Schema> visitArithmeticUnary(
+    public Pair<String, Schema> visitArithmeticUnary(
         final ArithmeticUnaryExpression node,
         final Void context
     ) {
@@ -497,7 +497,7 @@ public class SqlToJavaVisitor {
     }
 
     @Override
-    protected Pair<String, Schema> visitArithmeticBinary(
+    public Pair<String, Schema> visitArithmeticBinary(
         final ArithmeticBinaryExpression node,
         final Void context
     ) {
@@ -548,7 +548,7 @@ public class SqlToJavaVisitor {
     }
 
     @Override
-    protected Pair<String, Schema> visitSearchedCaseExpression(
+    public Pair<String, Schema> visitSearchedCaseExpression(
         final SearchedCaseExpression node,
         final Void context) {
       final String functionClassName = SearchedCaseFunction.class.getSimpleName();
@@ -592,7 +592,7 @@ public class SqlToJavaVisitor {
     }
 
     @Override
-    protected Pair<String, Schema> visitLikePredicate(
+    public Pair<String, Schema> visitLikePredicate(
         final LikePredicate node,
         final Void context
     ) {
@@ -646,7 +646,7 @@ public class SqlToJavaVisitor {
     }
 
     @Override
-    protected Pair<String, Schema> visitSubscriptExpression(
+    public Pair<String, Schema> visitSubscriptExpression(
         final SubscriptExpression node,
         final Void context
     ) {
@@ -685,7 +685,7 @@ public class SqlToJavaVisitor {
     }
 
     @Override
-    protected Pair<String, Schema> visitBetweenPredicate(
+    public Pair<String, Schema> visitBetweenPredicate(
         final BetweenPredicate node,
         final Void context
     ) {

--- a/ksql-engine/src/main/java/io/confluent/ksql/engine/InsertValuesExecutor.java
+++ b/ksql-engine/src/main/java/io/confluent/ksql/engine/InsertValuesExecutor.java
@@ -24,11 +24,11 @@ import io.confluent.ksql.metastore.model.DataSource;
 import io.confluent.ksql.metastore.model.KeyField;
 import io.confluent.ksql.metastore.model.KsqlStream;
 import io.confluent.ksql.metastore.model.KsqlTable;
+import io.confluent.ksql.parser.tree.AstNode;
 import io.confluent.ksql.parser.tree.AstVisitor;
 import io.confluent.ksql.parser.tree.Expression;
 import io.confluent.ksql.parser.tree.InsertValues;
 import io.confluent.ksql.parser.tree.Literal;
-import io.confluent.ksql.parser.tree.Node;
 import io.confluent.ksql.parser.tree.NullLiteral;
 import io.confluent.ksql.schema.ksql.DefaultSqlValueCoercer;
 import io.confluent.ksql.schema.ksql.Field;
@@ -355,7 +355,7 @@ public class InsertValuesExecutor {
     }
 
     @Override
-    protected String visitNode(final Node node, final Void context) {
+    protected String visitNode(final AstNode node, final Void context) {
       throw new KsqlException(
           "Only Literals are supported for INSERT INTO. Got: " + node + " for field " + fieldName);
     }

--- a/ksql-engine/src/main/java/io/confluent/ksql/topic/SourceTopicsExtractor.java
+++ b/ksql-engine/src/main/java/io/confluent/ksql/topic/SourceTopicsExtractor.java
@@ -19,8 +19,8 @@ import io.confluent.ksql.metastore.MetaStore;
 import io.confluent.ksql.metastore.model.DataSource;
 import io.confluent.ksql.parser.DefaultTraversalVisitor;
 import io.confluent.ksql.parser.tree.AliasedRelation;
+import io.confluent.ksql.parser.tree.AstNode;
 import io.confluent.ksql.parser.tree.Join;
-import io.confluent.ksql.parser.tree.Node;
 import io.confluent.ksql.parser.tree.Table;
 import io.confluent.ksql.util.KsqlException;
 import java.util.HashSet;
@@ -29,7 +29,7 @@ import java.util.Set;
 /**
  * Helper class that extracts all source topics from a query node.
  */
-public class SourceTopicsExtractor extends DefaultTraversalVisitor<Node, Void> {
+public class SourceTopicsExtractor extends DefaultTraversalVisitor<AstNode, Void> {
   private final Set<String> sourceTopics = new HashSet<>();
   private final MetaStore metaStore;
 
@@ -48,14 +48,14 @@ public class SourceTopicsExtractor extends DefaultTraversalVisitor<Node, Void> {
   }
 
   @Override
-  protected Node visitJoin(final Join node, final Void context) {
+  protected AstNode visitJoin(final Join node, final Void context) {
     process(node.getLeft(), context);
     process(node.getRight(), context);
     return null;
   }
 
   @Override
-  protected Node visitAliasedRelation(final AliasedRelation node, final Void context) {
+  protected AstNode visitAliasedRelation(final AliasedRelation node, final Void context) {
     final String structuredDataSourceName = ((Table) node.getRelation()).getName().getSuffix();
     final DataSource<?> source = metaStore.getSource(structuredDataSourceName);
     if (source == null) {

--- a/ksql-engine/src/main/java/io/confluent/ksql/util/ExpressionTypeManager.java
+++ b/ksql-engine/src/main/java/io/confluent/ksql/util/ExpressionTypeManager.java
@@ -89,8 +89,9 @@ public class ExpressionTypeManager
     }
   }
 
+  // TODO(rohan): make the below an internal class
   @Override
-  protected Expression visitArithmeticBinary(final ArithmeticBinaryExpression node,
+  public Expression visitArithmeticBinary(final ArithmeticBinaryExpression node,
       final ExpressionTypeContext expressionTypeContext) {
     process(node.getLeft(), expressionTypeContext);
     final Schema leftType = expressionTypeContext.getSchema();
@@ -101,14 +102,14 @@ public class ExpressionTypeManager
   }
 
   @Override
-  protected Expression visitNotExpression(
+  public Expression visitNotExpression(
       final NotExpression node, final ExpressionTypeContext expressionTypeContext) {
     expressionTypeContext.setSchema(Schema.OPTIONAL_BOOLEAN_SCHEMA);
     return null;
   }
 
   @Override
-  protected Expression visitCast(
+  public Expression visitCast(
       final Cast node,
       final ExpressionTypeContext expressionTypeContext
   ) {
@@ -127,7 +128,7 @@ public class ExpressionTypeManager
   }
 
   @Override
-  protected Expression visitComparisonExpression(
+  public Expression visitComparisonExpression(
       final ComparisonExpression node, final ExpressionTypeContext expressionTypeContext) {
     process(node.getLeft(), expressionTypeContext);
     final Schema leftSchema = expressionTypeContext.getSchema();
@@ -139,14 +140,14 @@ public class ExpressionTypeManager
   }
 
   @Override
-  protected Expression visitBetweenPredicate(final BetweenPredicate node,
+  public Expression visitBetweenPredicate(final BetweenPredicate node,
       final ExpressionTypeContext context) {
     context.setSchema(Schema.OPTIONAL_BOOLEAN_SCHEMA);
     return null;
   }
 
   @Override
-  protected Expression visitQualifiedNameReference(
+  public Expression visitQualifiedNameReference(
       final QualifiedNameReference node,
       final ExpressionTypeContext expressionTypeContext
   ) {
@@ -160,7 +161,7 @@ public class ExpressionTypeManager
   }
 
   @Override
-  protected Expression visitDereferenceExpression(
+  public Expression visitDereferenceExpression(
       final DereferenceExpression node,
       final ExpressionTypeContext expressionTypeContext
   ) {
@@ -174,70 +175,70 @@ public class ExpressionTypeManager
   }
 
   @Override
-  protected Expression visitStringLiteral(final StringLiteral node,
+  public Expression visitStringLiteral(final StringLiteral node,
       final ExpressionTypeContext expressionTypeContext) {
     expressionTypeContext.setSchema(Schema.OPTIONAL_STRING_SCHEMA);
     return null;
   }
 
   @Override
-  protected Expression visitBooleanLiteral(final BooleanLiteral node,
+  public Expression visitBooleanLiteral(final BooleanLiteral node,
       final ExpressionTypeContext expressionTypeContext) {
     expressionTypeContext.setSchema(Schema.OPTIONAL_BOOLEAN_SCHEMA);
     return null;
   }
 
   @Override
-  protected Expression visitLongLiteral(final LongLiteral node,
+  public Expression visitLongLiteral(final LongLiteral node,
       final ExpressionTypeContext expressionTypeContext) {
     expressionTypeContext.setSchema(Schema.OPTIONAL_INT64_SCHEMA);
     return null;
   }
 
   @Override
-  protected Expression visitIntegerLiteral(final IntegerLiteral node,
+  public Expression visitIntegerLiteral(final IntegerLiteral node,
       final ExpressionTypeContext expressionTypeContext) {
     expressionTypeContext.setSchema(Schema.OPTIONAL_INT32_SCHEMA);
     return null;
   }
 
   @Override
-  protected Expression visitDoubleLiteral(final DoubleLiteral node,
+  public Expression visitDoubleLiteral(final DoubleLiteral node,
       final ExpressionTypeContext expressionTypeContext) {
     expressionTypeContext.setSchema(Schema.OPTIONAL_FLOAT64_SCHEMA);
     return null;
   }
 
   @Override
-  protected Expression visitNullLiteral(final NullLiteral node,
+  public Expression visitNullLiteral(final NullLiteral node,
       final ExpressionTypeContext context) {
     context.setSchema(null);
     return null;
   }
 
   @Override
-  protected Expression visitLikePredicate(final LikePredicate node,
+  public Expression visitLikePredicate(final LikePredicate node,
       final ExpressionTypeContext expressionTypeContext) {
     expressionTypeContext.setSchema(Schema.OPTIONAL_BOOLEAN_SCHEMA);
     return null;
   }
 
   @Override
-  protected Expression visitIsNotNullPredicate(final IsNotNullPredicate node,
+  public Expression visitIsNotNullPredicate(final IsNotNullPredicate node,
       final ExpressionTypeContext expressionTypeContext) {
     expressionTypeContext.setSchema(Schema.OPTIONAL_BOOLEAN_SCHEMA);
     return null;
   }
 
   @Override
-  protected Expression visitIsNullPredicate(final IsNullPredicate node,
+  public Expression visitIsNullPredicate(final IsNullPredicate node,
       final ExpressionTypeContext expressionTypeContext) {
     expressionTypeContext.setSchema(Schema.OPTIONAL_BOOLEAN_SCHEMA);
     return null;
   }
 
   @Override
-  protected Expression visitSearchedCaseExpression(
+  public Expression visitSearchedCaseExpression(
       final SearchedCaseExpression node,
       final ExpressionTypeContext expressionTypeContext) {
     validateSearchedCaseExpression(node);
@@ -246,7 +247,7 @@ public class ExpressionTypeManager
   }
 
   @Override
-  protected Expression visitSubscriptExpression(
+  public Expression visitSubscriptExpression(
       final SubscriptExpression node,
       final ExpressionTypeContext expressionTypeContext
   ) {
@@ -257,7 +258,7 @@ public class ExpressionTypeManager
   }
 
   @Override
-  protected Expression visitFunctionCall(
+  public Expression visitFunctionCall(
       final FunctionCall node,
       final ExpressionTypeContext expressionTypeContext) {
 

--- a/ksql-engine/src/test/java/io/confluent/ksql/analyzer/AnalyzerTest.java
+++ b/ksql-engine/src/test/java/io/confluent/ksql/analyzer/AnalyzerTest.java
@@ -38,12 +38,14 @@ import io.confluent.ksql.metastore.MutableMetaStore;
 import io.confluent.ksql.metastore.model.KeyField;
 import io.confluent.ksql.metastore.model.KsqlStream;
 import io.confluent.ksql.metastore.model.KsqlTopic;
+import io.confluent.ksql.parser.ExpressionFormatter;
 import io.confluent.ksql.parser.KsqlParser.PreparedStatement;
 import io.confluent.ksql.parser.KsqlParserTestUtil;
 import io.confluent.ksql.parser.SqlFormatter;
 import io.confluent.ksql.parser.properties.with.CreateSourceAsProperties;
 import io.confluent.ksql.parser.tree.BooleanLiteral;
 import io.confluent.ksql.parser.tree.CreateStreamAsSelect;
+import io.confluent.ksql.parser.tree.Expression;
 import io.confluent.ksql.parser.tree.Literal;
 import io.confluent.ksql.parser.tree.Query;
 import io.confluent.ksql.parser.tree.Sink;
@@ -139,22 +141,22 @@ public class AnalyzerTest {
         analysis.getSelectExpressionAlias().size());
     final String
         sqlStr =
-        SqlFormatter.formatSql(analysis.getWhereExpression()).replace("\n", " ");
+        ExpressionFormatter.formatExpression(analysis.getWhereExpression()).replace("\n", " ");
     Assert.assertTrue(sqlStr.equalsIgnoreCase("(TEST1.COL0 > 100)"));
 
     final String
         select1 =
-        SqlFormatter.formatSql(analysis.getSelectExpressions().get(0))
+        ExpressionFormatter.formatExpression(analysis.getSelectExpressions().get(0))
             .replace("\n", " ");
     Assert.assertTrue(select1.equalsIgnoreCase("TEST1.COL0"));
     final String
         select2 =
-        SqlFormatter.formatSql(analysis.getSelectExpressions().get(1))
+        ExpressionFormatter.formatExpression(analysis.getSelectExpressions().get(1))
             .replace("\n", " ");
     Assert.assertTrue(select2.equalsIgnoreCase("TEST1.COL2"));
     final String
         select3 =
-        SqlFormatter.formatSql(analysis.getSelectExpressions().get(2))
+        ExpressionFormatter.formatExpression(analysis.getSelectExpressions().get(2))
             .replace("\n", " ");
     Assert.assertTrue(select3.equalsIgnoreCase("TEST1.COL3"));
 
@@ -184,7 +186,7 @@ public class AnalyzerTest {
     assertThat(analysis.getJoin().get().getRightJoinField(), is("T2.COL1"));
 
     final List<String> selects = analysis.getSelectExpressions().stream()
-        .map(SqlFormatter::formatSql)
+        .map(ExpressionFormatter::formatExpression)
         .collect(Collectors.toList());
 
     assertThat(selects, contains("T1.COL1", "T2.COL1", "T2.COL4", "T1.COL5", "T2.COL2"));
@@ -221,17 +223,17 @@ public class AnalyzerTest {
 
     final String
         select1 =
-        SqlFormatter.formatSql(analysis.getSelectExpressions().get(0))
+        ExpressionFormatter.formatExpression(analysis.getSelectExpressions().get(0))
             .replace("\n", " ");
     Assert.assertTrue(select1.equalsIgnoreCase("(TEST1.COL0 = 10)"));
     final String
         select2 =
-        SqlFormatter.formatSql(analysis.getSelectExpressions().get(1))
+        ExpressionFormatter.formatExpression(analysis.getSelectExpressions().get(1))
             .replace("\n", " ");
     Assert.assertTrue(select2.equalsIgnoreCase("TEST1.COL2"));
     final String
         select3 =
-        SqlFormatter.formatSql(analysis.getSelectExpressions().get(2))
+        ExpressionFormatter.formatExpression(analysis.getSelectExpressions().get(2))
             .replace("\n", " ");
     Assert.assertTrue(select3.equalsIgnoreCase("(TEST1.COL3 > TEST1.COL1)"));
   }
@@ -250,17 +252,17 @@ public class AnalyzerTest {
 
     final String
             select1 =
-        SqlFormatter.formatSql(analysis.getSelectExpressions().get(0))
+        ExpressionFormatter.formatExpression(analysis.getSelectExpressions().get(0))
                     .replace("\n", " ");
     Assert.assertTrue(select1.equalsIgnoreCase("(TEST1.COL0 = 10)"));
     final String
             select2 =
-        SqlFormatter.formatSql(analysis.getSelectExpressions().get(1))
+        ExpressionFormatter.formatExpression(analysis.getSelectExpressions().get(1))
                     .replace("\n", " ");
     Assert.assertTrue(select2.equalsIgnoreCase("TEST1.COL2"));
     final String
             select3 =
-        SqlFormatter.formatSql(analysis.getSelectExpressions().get(2))
+        ExpressionFormatter.formatExpression(analysis.getSelectExpressions().get(2))
                     .replace("\n", " ");
     Assert.assertTrue(select3.equalsIgnoreCase("(TEST1.COL3 > TEST1.COL1)"));
     Assert.assertTrue("testFilterAnalysis failed.", analysis.getWhereExpression().toString().equalsIgnoreCase("(TEST1.COL0 > 20)"));

--- a/ksql-parser/src/main/java/io/confluent/ksql/parser/DefaultTraversalVisitor.java
+++ b/ksql-parser/src/main/java/io/confluent/ksql/parser/DefaultTraversalVisitor.java
@@ -60,12 +60,12 @@ public abstract class DefaultTraversalVisitor<R, C>
   }
 
   @Override
-  protected R visitCast(final Cast node, final C context) {
+  public R visitCast(final Cast node, final C context) {
     return process(node.getExpression(), context);
   }
 
   @Override
-  protected R visitArithmeticBinary(final ArithmeticBinaryExpression node, final C context) {
+  public R visitArithmeticBinary(final ArithmeticBinaryExpression node, final C context) {
     process(node.getLeft(), context);
     process(node.getRight(), context);
 
@@ -73,7 +73,7 @@ public abstract class DefaultTraversalVisitor<R, C>
   }
 
   @Override
-  protected R visitBetweenPredicate(final BetweenPredicate node, final C context) {
+  public R visitBetweenPredicate(final BetweenPredicate node, final C context) {
     process(node.getValue(), context);
     process(node.getMin(), context);
     process(node.getMax(), context);
@@ -82,7 +82,7 @@ public abstract class DefaultTraversalVisitor<R, C>
   }
 
   @Override
-  protected R visitSubscriptExpression(final SubscriptExpression node, final C context) {
+  public R visitSubscriptExpression(final SubscriptExpression node, final C context) {
     process(node.getBase(), context);
     process(node.getIndex(), context);
 
@@ -90,7 +90,7 @@ public abstract class DefaultTraversalVisitor<R, C>
   }
 
   @Override
-  protected R visitComparisonExpression(final ComparisonExpression node, final C context) {
+  public R visitComparisonExpression(final ComparisonExpression node, final C context) {
     process(node.getLeft(), context);
     process(node.getRight(), context);
 
@@ -131,7 +131,7 @@ public abstract class DefaultTraversalVisitor<R, C>
   }
 
   @Override
-  protected R visitWhenClause(final WhenClause node, final C context) {
+  public R visitWhenClause(final WhenClause node, final C context) {
     process(node.getOperand(), context);
     process(node.getResult(), context);
 
@@ -139,7 +139,7 @@ public abstract class DefaultTraversalVisitor<R, C>
   }
 
   @Override
-  protected R visitInPredicate(final InPredicate node, final C context) {
+  public R visitInPredicate(final InPredicate node, final C context) {
     process(node.getValue(), context);
     process(node.getValueList(), context);
 
@@ -147,7 +147,7 @@ public abstract class DefaultTraversalVisitor<R, C>
   }
 
   @Override
-  protected R visitFunctionCall(final FunctionCall node, final C context) {
+  public R visitFunctionCall(final FunctionCall node, final C context) {
     for (final Expression argument : node.getArguments()) {
       process(argument, context);
     }
@@ -156,13 +156,13 @@ public abstract class DefaultTraversalVisitor<R, C>
   }
 
   @Override
-  protected R visitDereferenceExpression(final DereferenceExpression node, final C context) {
+  public R visitDereferenceExpression(final DereferenceExpression node, final C context) {
     process(node.getBase(), context);
     return null;
   }
 
   @Override
-  protected R visitSimpleCaseExpression(final SimpleCaseExpression node, final C context) {
+  public R visitSimpleCaseExpression(final SimpleCaseExpression node, final C context) {
     process(node.getOperand(), context);
     for (final WhenClause clause : node.getWhenClauses()) {
       process(clause, context);
@@ -175,7 +175,7 @@ public abstract class DefaultTraversalVisitor<R, C>
   }
 
   @Override
-  protected R visitInListExpression(final InListExpression node, final C context) {
+  public R visitInListExpression(final InListExpression node, final C context) {
     for (final Expression value : node.getValues()) {
       process(value, context);
     }
@@ -184,17 +184,17 @@ public abstract class DefaultTraversalVisitor<R, C>
   }
 
   @Override
-  protected R visitArithmeticUnary(final ArithmeticUnaryExpression node, final C context) {
+  public R visitArithmeticUnary(final ArithmeticUnaryExpression node, final C context) {
     return process(node.getValue(), context);
   }
 
   @Override
-  protected R visitNotExpression(final NotExpression node, final C context) {
+  public R visitNotExpression(final NotExpression node, final C context) {
     return process(node.getValue(), context);
   }
 
   @Override
-  protected R visitSearchedCaseExpression(final SearchedCaseExpression node, final C context) {
+  public R visitSearchedCaseExpression(final SearchedCaseExpression node, final C context) {
     for (final WhenClause clause : node.getWhenClauses()) {
       process(clause, context);
     }
@@ -205,24 +205,24 @@ public abstract class DefaultTraversalVisitor<R, C>
   }
 
   @Override
-  protected R visitLikePredicate(final LikePredicate node, final C context) {
+  public R visitLikePredicate(final LikePredicate node, final C context) {
     process(node.getValue(), context);
     process(node.getPattern(), context);
     return null;
   }
 
   @Override
-  protected R visitIsNotNullPredicate(final IsNotNullPredicate node, final C context) {
+  public R visitIsNotNullPredicate(final IsNotNullPredicate node, final C context) {
     return process(node.getValue(), context);
   }
 
   @Override
-  protected R visitIsNullPredicate(final IsNullPredicate node, final C context) {
+  public R visitIsNullPredicate(final IsNullPredicate node, final C context) {
     return process(node.getValue(), context);
   }
 
   @Override
-  protected R visitLogicalBinaryExpression(final LogicalBinaryExpression node, final C context) {
+  public R visitLogicalBinaryExpression(final LogicalBinaryExpression node, final C context) {
     process(node.getLeft(), context);
     process(node.getRight(), context);
 

--- a/ksql-parser/src/main/java/io/confluent/ksql/parser/SqlFormatter.java
+++ b/ksql-parser/src/main/java/io/confluent/ksql/parser/SqlFormatter.java
@@ -21,6 +21,7 @@ import static com.google.common.collect.Iterables.getOnlyElement;
 import com.google.common.base.Strings;
 import io.confluent.ksql.parser.tree.AliasedRelation;
 import io.confluent.ksql.parser.tree.AllColumns;
+import io.confluent.ksql.parser.tree.AstNode;
 import io.confluent.ksql.parser.tree.AstVisitor;
 import io.confluent.ksql.parser.tree.CreateAsSelect;
 import io.confluent.ksql.parser.tree.CreateSource;
@@ -39,7 +40,6 @@ import io.confluent.ksql.parser.tree.Join;
 import io.confluent.ksql.parser.tree.JoinCriteria;
 import io.confluent.ksql.parser.tree.JoinOn;
 import io.confluent.ksql.parser.tree.ListFunctions;
-import io.confluent.ksql.parser.tree.Node;
 import io.confluent.ksql.parser.tree.Query;
 import io.confluent.ksql.parser.tree.Relation;
 import io.confluent.ksql.parser.tree.Select;
@@ -64,11 +64,11 @@ public final class SqlFormatter {
   private SqlFormatter() {
   }
 
-  public static String formatSql(final Node root) {
+  public static String formatSql(final AstNode root) {
     return formatSql(root, true);
   }
 
-  public static String formatSql(final Node root, final boolean unmangleNames) {
+  public static String formatSql(final AstNode root, final boolean unmangleNames) {
     final StringBuilder builder = new StringBuilder();
     new Formatter(builder, unmangleNames).process(root, 0);
     return StringUtils.stripEnd(builder.toString(), "\n");
@@ -85,7 +85,7 @@ public final class SqlFormatter {
     }
 
     @Override
-    protected Void visitNode(final Node node, final Integer indent) {
+    protected Void visitNode(final AstNode node, final Integer indent) {
       throw new UnsupportedOperationException("not yet implemented: " + node);
     }
 
@@ -316,7 +316,7 @@ public final class SqlFormatter {
       builder.append(
           node.getValues()
               .stream()
-              .map(SqlFormatter::formatSql)
+              .map(exp -> ExpressionFormatter.formatExpression(exp, unmangledNames))
               .collect(Collectors.joining(", ")));
       builder.append(")");
 

--- a/ksql-parser/src/main/java/io/confluent/ksql/parser/rewrite/StatementRewriteForStruct.java
+++ b/ksql-parser/src/main/java/io/confluent/ksql/parser/rewrite/StatementRewriteForStruct.java
@@ -19,7 +19,6 @@ import com.google.common.collect.ImmutableList;
 import io.confluent.ksql.parser.tree.DereferenceExpression;
 import io.confluent.ksql.parser.tree.Expression;
 import io.confluent.ksql.parser.tree.FunctionCall;
-import io.confluent.ksql.parser.tree.Node;
 import io.confluent.ksql.parser.tree.QualifiedName;
 import io.confluent.ksql.parser.tree.QualifiedNameReference;
 import io.confluent.ksql.parser.tree.Query;
@@ -45,11 +44,10 @@ public class StatementRewriteForStruct {
         || statement instanceof QueryContainer;
   }
 
-
   private static class RewriteWithStructFieldExtractors extends StatementRewriter {
 
     @Override
-    protected Node visitDereferenceExpression(
+    public Expression visitDereferenceExpression(
         final DereferenceExpression node,
         final Object context
     ) {

--- a/ksql-parser/src/main/java/io/confluent/ksql/parser/rewrite/StatementRewriter.java
+++ b/ksql-parser/src/main/java/io/confluent/ksql/parser/rewrite/StatementRewriter.java
@@ -19,6 +19,7 @@ import io.confluent.ksql.parser.tree.AliasedRelation;
 import io.confluent.ksql.parser.tree.AllColumns;
 import io.confluent.ksql.parser.tree.ArithmeticBinaryExpression;
 import io.confluent.ksql.parser.tree.ArithmeticUnaryExpression;
+import io.confluent.ksql.parser.tree.AstNode;
 import io.confluent.ksql.parser.tree.BetweenPredicate;
 import io.confluent.ksql.parser.tree.Cast;
 import io.confluent.ksql.parser.tree.ComparisonExpression;
@@ -70,7 +71,7 @@ import java.util.stream.Collectors;
 
 /**
  * This class will create a new AST given the input AST. The new AST is exactly the clone of
- * the imput one. If you want to rewrite a query by changing the AST you can inherit from this
+ * the input one. If you want to rewrite a query by changing the AST you can inherit from this
  * class and implemet the changes for the nodes you need. The newly generated tree will include
  * your changes and the rest of the tree will remain the same.
  *
@@ -82,11 +83,11 @@ import java.util.stream.Collectors;
 public class StatementRewriter extends DefaultAstVisitor<Node, Object> {
   // CHECKSTYLE_RULES.ON: ClassDataAbstractionCoupling
 
-  protected Node visitExpression(final Expression node, final Object context) {
+  protected Expression visitExpression(final Expression node, final Object context) {
     return node;
   }
 
-  protected Node visitArithmeticBinary(
+  public Expression visitArithmeticBinary(
       final ArithmeticBinaryExpression node,
       final Object context
   ) {
@@ -100,7 +101,7 @@ public class StatementRewriter extends DefaultAstVisitor<Node, Object> {
         rewrittenRight);
   }
 
-  protected Node visitBetweenPredicate(final BetweenPredicate node, final Object context) {
+  public Expression visitBetweenPredicate(final BetweenPredicate node, final Object context) {
     return new BetweenPredicate(
         node.getLocation(),
         (Expression) process(node.getValue(), context),
@@ -108,7 +109,9 @@ public class StatementRewriter extends DefaultAstVisitor<Node, Object> {
         (Expression) process(node.getMax(), context));
   }
 
-  protected Node visitComparisonExpression(final ComparisonExpression node, final Object context) {
+  public Expression visitComparisonExpression(
+      final ComparisonExpression node,
+      final Object context) {
     return new ComparisonExpression(
         node.getLocation(),
         node.getType(),
@@ -116,7 +119,7 @@ public class StatementRewriter extends DefaultAstVisitor<Node, Object> {
         (Expression) process(node.getRight(), context));
   }
 
-  protected Node visitStatements(final Statements node, final Object context) {
+  protected AstNode visitStatements(final Statements node, final Object context) {
     final List<Statement> rewrittenStatements = node.getStatements()
         .stream()
         .map(s -> (Statement) process(s, context))
@@ -157,7 +160,7 @@ public class StatementRewriter extends DefaultAstVisitor<Node, Object> {
     );
   }
 
-  protected Node visitSelect(final Select node, final Object context) {
+  protected AstNode visitSelect(final Select node, final Object context) {
     final List<SelectItem> rewrittenItems = node.getSelectItems()
         .stream()
         .map(selectItem -> (SelectItem) process(selectItem, context))
@@ -169,7 +172,7 @@ public class StatementRewriter extends DefaultAstVisitor<Node, Object> {
     );
   }
 
-  protected Node visitWhenClause(final WhenClause node, final Object context) {
+  public Expression visitWhenClause(final WhenClause node, final Object context) {
     return new WhenClause(
         node.getLocation(),
         (Expression) process(node.getOperand(), context),
@@ -177,7 +180,7 @@ public class StatementRewriter extends DefaultAstVisitor<Node, Object> {
     );
   }
 
-  protected Node visitInPredicate(final InPredicate node, final Object context) {
+  public Expression visitInPredicate(final InPredicate node, final Object context) {
     return new InPredicate(
         node.getLocation(),
         (Expression) process(node.getValue(), context),
@@ -185,7 +188,7 @@ public class StatementRewriter extends DefaultAstVisitor<Node, Object> {
     );
   }
 
-  protected Node visitFunctionCall(final FunctionCall node, final Object context) {
+  public Expression visitFunctionCall(final FunctionCall node, final Object context) {
     final List<Expression> rewrittenArgs = node.getArguments()
         .stream()
         .map(arg -> (Expression) process(arg, context))
@@ -198,7 +201,9 @@ public class StatementRewriter extends DefaultAstVisitor<Node, Object> {
     );
   }
 
-  protected Node visitSimpleCaseExpression(final SimpleCaseExpression node, final Object context) {
+  public Expression visitSimpleCaseExpression(
+      final SimpleCaseExpression node,
+      final Object context) {
     final Expression operand = (Expression) process(node.getOperand(), context);
 
     final List<WhenClause> when = node.getWhenClauses().stream()
@@ -216,7 +221,7 @@ public class StatementRewriter extends DefaultAstVisitor<Node, Object> {
       );
   }
 
-  protected Node visitInListExpression(final InListExpression node, final Object context) {
+  public Expression visitInListExpression(final InListExpression node, final Object context) {
     final List<Expression> rewrittenExpressions = node.getValues().stream()
         .map(value -> (Expression) process(value, context))
         .collect(Collectors.toList());
@@ -224,14 +229,14 @@ public class StatementRewriter extends DefaultAstVisitor<Node, Object> {
     return new InListExpression(node.getLocation(), rewrittenExpressions);
   }
 
-  protected Node visitQualifiedNameReference(
+  public Expression visitQualifiedNameReference(
       final QualifiedNameReference node,
       final Object context
   ) {
     return node;
   }
 
-  protected Node visitDereferenceExpression(
+  public Expression visitDereferenceExpression(
       final DereferenceExpression node,
       final Object context
   ) {
@@ -242,11 +247,13 @@ public class StatementRewriter extends DefaultAstVisitor<Node, Object> {
     );
   }
 
-  protected Node visitLiteral(final Literal node, final Object context) {
+  public Expression visitLiteral(final Literal node, final Object context) {
     return node;
   }
 
-  protected Node visitArithmeticUnary(final ArithmeticUnaryExpression node, final Object context) {
+  public Expression visitArithmeticUnary(
+      final ArithmeticUnaryExpression node,
+      final Object context) {
     final Expression rewrittenExpression = (Expression) process(node.getValue(), context);
 
     return new ArithmeticUnaryExpression(
@@ -256,22 +263,22 @@ public class StatementRewriter extends DefaultAstVisitor<Node, Object> {
     );
   }
 
-  protected Node visitNotExpression(final NotExpression node, final Object context) {
+  public Expression visitNotExpression(final NotExpression node, final Object context) {
     return new NotExpression(
         node.getLocation(),
         (Expression) process(node.getValue(), context)
     );
   }
 
-  protected Node visitSingleColumn(final SingleColumn node, final Object context) {
+  protected AstNode visitSingleColumn(final SingleColumn node, final Object context) {
     return node.copyWithExpression((Expression) process(node.getExpression(), context));
   }
 
-  protected Node visitAllColumns(final AllColumns node, final Object context) {
+  protected AstNode visitAllColumns(final AllColumns node, final Object context) {
     return node;
   }
 
-  protected Node visitSearchedCaseExpression(
+  public Expression visitSearchedCaseExpression(
       final SearchedCaseExpression node,
       final Object context
   ) {
@@ -289,7 +296,7 @@ public class StatementRewriter extends DefaultAstVisitor<Node, Object> {
     );
   }
 
-  protected Node visitLikePredicate(final LikePredicate node, final Object context) {
+  public Expression visitLikePredicate(final LikePredicate node, final Object context) {
     return new LikePredicate(
         node.getLocation(),
         (Expression) process(node.getValue(), context),
@@ -297,21 +304,23 @@ public class StatementRewriter extends DefaultAstVisitor<Node, Object> {
       );
   }
 
-  protected Node visitIsNotNullPredicate(final IsNotNullPredicate node, final Object context) {
+  public Expression visitIsNotNullPredicate(final IsNotNullPredicate node, final Object context) {
     return new IsNotNullPredicate(
         node.getLocation(),
         (Expression) process(node.getValue(), context)
     );
   }
 
-  protected Node visitIsNullPredicate(final IsNullPredicate node, final Object context) {
+  public Expression visitIsNullPredicate(final IsNullPredicate node, final Object context) {
     return new IsNullPredicate(
         node.getLocation(),
         (Expression) process(node.getValue(), context)
     );
   }
 
-  protected Node visitSubscriptExpression(final SubscriptExpression node, final Object context) {
+  public Expression visitSubscriptExpression(
+      final SubscriptExpression node,
+      final Object context) {
     return new SubscriptExpression(
         node.getLocation(),
         (Expression) process(node.getBase(), context),
@@ -319,7 +328,7 @@ public class StatementRewriter extends DefaultAstVisitor<Node, Object> {
     );
   }
 
-  protected Node visitLogicalBinaryExpression(
+  public Expression visitLogicalBinaryExpression(
       final LogicalBinaryExpression node,
       final Object context
   ) {
@@ -331,11 +340,11 @@ public class StatementRewriter extends DefaultAstVisitor<Node, Object> {
     );
   }
 
-  protected Node visitTable(final Table node, final Object context) {
+  protected AstNode visitTable(final Table node, final Object context) {
     return node;
   }
 
-  protected Node visitAliasedRelation(final AliasedRelation node, final Object context) {
+  protected AstNode visitAliasedRelation(final AliasedRelation node, final Object context) {
     final Relation rewrittenRelation = (Relation) process(node.getRelation(), context);
 
     return new AliasedRelation(
@@ -344,7 +353,7 @@ public class StatementRewriter extends DefaultAstVisitor<Node, Object> {
         node.getAlias());
   }
 
-  protected Node visitJoin(final Join node, final Object context) {
+  protected AstNode visitJoin(final Join node, final Object context) {
     final Relation rewrittenLeft = (Relation) process(node.getLeft(), context);
     final Relation rewrittenRight = (Relation) process(node.getRight(), context);
     final Optional<WithinExpression> rewrittenWithin = node.getWithinExpression()
@@ -360,31 +369,33 @@ public class StatementRewriter extends DefaultAstVisitor<Node, Object> {
   }
 
   @Override
-  protected Node visitWithinExpression(final WithinExpression node, final Object context) {
+  protected AstNode visitWithinExpression(final WithinExpression node, final Object context) {
     return node;
   }
 
-  protected Node visitCast(final Cast node, final Object context) {
+  public Expression visitCast(final Cast node, final Object context) {
     final Expression expression = (Expression) process(node.getExpression(), context);
     return new Cast(node.getLocation(), expression, node.getType());
   }
 
-  protected Node visitWindowExpression(final WindowExpression node, final Object context) {
+  protected AstNode visitWindowExpression(final WindowExpression node, final Object context) {
     return new WindowExpression(
           node.getLocation(),
           node.getWindowName(),
           (KsqlWindowExpression) process(node.getKsqlWindowExpression(), context));
   }
 
-  protected Node visitKsqlWindowExpression(final KsqlWindowExpression node, final Object context) {
+  protected AstNode visitKsqlWindowExpression(
+      final KsqlWindowExpression node,
+      final Object context) {
     return node;
   }
 
-  protected Node visitTableElement(final TableElement node, final Object context) {
+  protected AstNode visitTableElement(final TableElement node, final Object context) {
     return node;
   }
 
-  protected Node visitCreateStream(final CreateStream node, final Object context) {
+  protected AstNode visitCreateStream(final CreateStream node, final Object context) {
     final List<TableElement> rewrittenElements = node.getElements().stream()
         .map(tableElement -> (TableElement) process(tableElement, context))
         .collect(Collectors.toList());
@@ -392,7 +403,9 @@ public class StatementRewriter extends DefaultAstVisitor<Node, Object> {
     return node.copyWith(TableElements.of(rewrittenElements), node.getProperties());
   }
 
-  protected Node visitCreateStreamAsSelect(final CreateStreamAsSelect node, final Object context) {
+  protected AstNode visitCreateStreamAsSelect(
+      final CreateStreamAsSelect node,
+      final Object context) {
     final Optional<Expression> partitionBy = node.getPartitionByColumn()
         .map(exp -> (Expression) process(exp,context));
 
@@ -406,7 +419,7 @@ public class StatementRewriter extends DefaultAstVisitor<Node, Object> {
     );
   }
 
-  protected Node visitCreateTable(final CreateTable node, final Object context) {
+  protected AstNode visitCreateTable(final CreateTable node, final Object context) {
     final List<TableElement> rewrittenElements = node.getElements().stream()
         .map(tableElement -> (TableElement) process(tableElement, context))
         .collect(Collectors.toList());
@@ -414,7 +427,9 @@ public class StatementRewriter extends DefaultAstVisitor<Node, Object> {
     return node.copyWith(TableElements.of(rewrittenElements), node.getProperties());
   }
 
-  protected Node visitCreateTableAsSelect(final CreateTableAsSelect node, final Object context) {
+  protected AstNode visitCreateTableAsSelect(
+      final CreateTableAsSelect node,
+      final Object context) {
     return new CreateTableAsSelect(
         node.getLocation(),
         node.getName(),
@@ -424,7 +439,7 @@ public class StatementRewriter extends DefaultAstVisitor<Node, Object> {
     );
   }
 
-  protected Node visitInsertInto(final InsertInto node, final Object context) {
+  protected AstNode visitInsertInto(final InsertInto node, final Object context) {
     final Optional<Expression> rewrittenPartitionBy = node.getPartitionByColumn()
         .map(exp -> (Expression) process(exp, context));
 
@@ -435,11 +450,11 @@ public class StatementRewriter extends DefaultAstVisitor<Node, Object> {
         rewrittenPartitionBy);
   }
 
-  protected Node visitDropTable(final DropTable node, final Object context) {
+  protected AstNode visitDropTable(final DropTable node, final Object context) {
     return node;
   }
 
-  protected Node visitGroupBy(final GroupBy node, final Object context) {
+  protected AstNode visitGroupBy(final GroupBy node, final Object context) {
     final List<GroupingElement> rewrittenGroupings = node.getGroupingElements().stream()
         .map(groupingElement -> (GroupingElement) process(groupingElement, context))
         .collect(Collectors.toList());
@@ -447,7 +462,7 @@ public class StatementRewriter extends DefaultAstVisitor<Node, Object> {
     return new GroupBy(node.getLocation(), rewrittenGroupings);
   }
 
-  protected Node visitSimpleGroupBy(final SimpleGroupBy node, final Object context) {
+  protected AstNode visitSimpleGroupBy(final SimpleGroupBy node, final Object context) {
     final List<Expression> columns = node.getColumns().stream()
         .map(ce -> (Expression) process(ce, context))
         .collect(Collectors.toList());

--- a/ksql-parser/src/main/java/io/confluent/ksql/parser/tree/ArithmeticBinaryExpression.java
+++ b/ksql-parser/src/main/java/io/confluent/ksql/parser/tree/ArithmeticBinaryExpression.java
@@ -60,7 +60,7 @@ public class ArithmeticBinaryExpression extends Expression {
   }
 
   @Override
-  public <R, C> R accept(final AstVisitor<R, C> visitor, final C context) {
+  public <R, C> R accept(final ExpressionVisitor<R, C> visitor, final C context) {
     return visitor.visitArithmeticBinary(this, context);
   }
 

--- a/ksql-parser/src/main/java/io/confluent/ksql/parser/tree/ArithmeticUnaryExpression.java
+++ b/ksql-parser/src/main/java/io/confluent/ksql/parser/tree/ArithmeticUnaryExpression.java
@@ -65,7 +65,7 @@ public class ArithmeticUnaryExpression extends Expression {
   }
 
   @Override
-  public <R, C> R accept(final AstVisitor<R, C> visitor, final C context) {
+  public <R, C> R accept(final ExpressionVisitor<R, C> visitor, final C context) {
     return visitor.visitArithmeticUnary(this, context);
   }
 

--- a/ksql-parser/src/main/java/io/confluent/ksql/parser/tree/AstNode.java
+++ b/ksql-parser/src/main/java/io/confluent/ksql/parser/tree/AstNode.java
@@ -19,14 +19,14 @@ import com.google.errorprone.annotations.Immutable;
 import java.util.Optional;
 
 @Immutable
-public abstract class Relation extends AstNode {
+public abstract class AstNode extends Node {
 
-  protected Relation(final Optional<NodeLocation> location) {
+  protected AstNode(final Optional<NodeLocation> location) {
     super(location);
   }
 
-  @Override
-  public <R, C> R accept(final AstVisitor<R, C> visitor, final C context) {
-    return visitor.visitRelation(this, context);
-  }
+  /**
+   * Accessible for {@link AstVisitor}, use {@link AstVisitor#process(AstNode, Object)} instead.
+   */
+  protected abstract <R, C> R accept(AstVisitor<R, C> visitor, C context);
 }

--- a/ksql-parser/src/main/java/io/confluent/ksql/parser/tree/AstVisitor.java
+++ b/ksql-parser/src/main/java/io/confluent/ksql/parser/tree/AstVisitor.java
@@ -17,30 +17,30 @@ package io.confluent.ksql.parser.tree;
 
 import javax.annotation.Nullable;
 
-public abstract class AstVisitor<R, C> {
+public abstract class AstVisitor<R, C> implements ExpressionVisitor<R, C> {
 
-  public R process(final Node node, @Nullable final C context) {
+  public R process(final AstNode node, @Nullable final C context) {
     return node.accept(this, context);
   }
 
-  protected R visitNode(final Node node, final C context) {
+  protected R visitNode(final AstNode node, final C context) {
     return null;
   }
 
   protected R visitExpression(final Expression node, final C context) {
-    return visitNode(node, context);
+    return null;
   }
 
-  protected R visitArithmeticBinary(final ArithmeticBinaryExpression node, final C context) {
+  public R visitArithmeticBinary(final ArithmeticBinaryExpression node, final C context) {
     return visitExpression(node, context);
   }
 
-  protected R visitBetweenPredicate(final BetweenPredicate node, final C context) {
+  public R visitBetweenPredicate(final BetweenPredicate node, final C context) {
     return visitExpression(node, context);
   }
 
 
-  protected R visitComparisonExpression(final ComparisonExpression node, final C context) {
+  public R visitComparisonExpression(final ComparisonExpression node, final C context) {
     return visitExpression(node, context);
   }
 
@@ -48,11 +48,11 @@ public abstract class AstVisitor<R, C> {
     return visitExpression(node, context);
   }
 
-  protected R visitDoubleLiteral(final DoubleLiteral node, final C context) {
+  public R visitDoubleLiteral(final DoubleLiteral node, final C context) {
     return visitLiteral(node, context);
   }
 
-  protected R visitDecimalLiteral(final DecimalLiteral node, final C context) {
+  public R visitDecimalLiteral(final DecimalLiteral node, final C context) {
     return visitLiteral(node, context);
   }
 
@@ -80,7 +80,7 @@ public abstract class AstVisitor<R, C> {
     return visitStatement(node, context);
   }
 
-  protected R visitTimeLiteral(final TimeLiteral node, final C context) {
+  public R visitTimeLiteral(final TimeLiteral node, final C context) {
     return visitLiteral(node, context);
   }
 
@@ -92,55 +92,55 @@ public abstract class AstVisitor<R, C> {
     return visitNode(node, context);
   }
 
-  protected R visitTimestampLiteral(final TimestampLiteral node, final C context) {
+  public R visitTimestampLiteral(final TimestampLiteral node, final C context) {
     return visitLiteral(node, context);
   }
 
-  protected R visitWhenClause(final WhenClause node, final C context) {
+  public R visitWhenClause(final WhenClause node, final C context) {
     return visitExpression(node, context);
   }
 
-  protected R visitInPredicate(final InPredicate node, final C context) {
+  public R visitInPredicate(final InPredicate node, final C context) {
     return visitExpression(node, context);
   }
 
-  protected R visitFunctionCall(final FunctionCall node, final C context) {
+  public R visitFunctionCall(final FunctionCall node, final C context) {
     return visitExpression(node, context);
   }
 
-  protected R visitSimpleCaseExpression(final SimpleCaseExpression node, final C context) {
+  public R visitSimpleCaseExpression(final SimpleCaseExpression node, final C context) {
     return visitExpression(node, context);
   }
 
-  protected R visitStringLiteral(final StringLiteral node, final C context) {
+  public R visitStringLiteral(final StringLiteral node, final C context) {
     return visitLiteral(node, context);
   }
 
-  protected R visitBooleanLiteral(final BooleanLiteral node, final C context) {
+  public R visitBooleanLiteral(final BooleanLiteral node, final C context) {
     return visitLiteral(node, context);
   }
 
-  protected R visitInListExpression(final InListExpression node, final C context) {
+  public R visitInListExpression(final InListExpression node, final C context) {
     return visitExpression(node, context);
   }
 
-  protected R visitQualifiedNameReference(final QualifiedNameReference node, final C context) {
+  public R visitQualifiedNameReference(final QualifiedNameReference node, final C context) {
     return visitExpression(node, context);
   }
 
-  protected R visitDereferenceExpression(final DereferenceExpression node, final C context) {
+  public R visitDereferenceExpression(final DereferenceExpression node, final C context) {
     return visitExpression(node, context);
   }
 
-  protected R visitNullLiteral(final NullLiteral node, final C context) {
+  public R visitNullLiteral(final NullLiteral node, final C context) {
     return visitLiteral(node, context);
   }
 
-  protected R visitArithmeticUnary(final ArithmeticUnaryExpression node, final C context) {
+  public R visitArithmeticUnary(final ArithmeticUnaryExpression node, final C context) {
     return visitExpression(node, context);
   }
 
-  protected R visitNotExpression(final NotExpression node, final C context) {
+  public R visitNotExpression(final NotExpression node, final C context) {
     return visitExpression(node, context);
   }
 
@@ -156,35 +156,35 @@ public abstract class AstVisitor<R, C> {
     return visitSelectItem(node, context);
   }
 
-  protected R visitSearchedCaseExpression(final SearchedCaseExpression node, final C context) {
+  public R visitSearchedCaseExpression(final SearchedCaseExpression node, final C context) {
     return visitExpression(node, context);
   }
 
-  protected R visitLikePredicate(final LikePredicate node, final C context) {
+  public R visitLikePredicate(final LikePredicate node, final C context) {
     return visitExpression(node, context);
   }
 
-  protected R visitIsNotNullPredicate(final IsNotNullPredicate node, final C context) {
+  public R visitIsNotNullPredicate(final IsNotNullPredicate node, final C context) {
     return visitExpression(node, context);
   }
 
-  protected R visitIsNullPredicate(final IsNullPredicate node, final C context) {
+  public R visitIsNullPredicate(final IsNullPredicate node, final C context) {
     return visitExpression(node, context);
   }
 
-  protected R visitSubscriptExpression(final SubscriptExpression node, final C context) {
+  public R visitSubscriptExpression(final SubscriptExpression node, final C context) {
     return visitExpression(node, context);
   }
 
-  protected R visitLongLiteral(final LongLiteral node, final C context) {
+  public R visitLongLiteral(final LongLiteral node, final C context) {
     return visitLiteral(node, context);
   }
 
-  protected R visitIntegerLiteral(final IntegerLiteral node, final C context) {
+  public R visitIntegerLiteral(final IntegerLiteral node, final C context) {
     return visitLiteral(node, context);
   }
 
-  protected R visitLogicalBinaryExpression(final LogicalBinaryExpression node, final C context) {
+  public R visitLogicalBinaryExpression(final LogicalBinaryExpression node, final C context) {
     return visitExpression(node, context);
   }
 
@@ -192,8 +192,8 @@ public abstract class AstVisitor<R, C> {
     return visitRelation(node, context);
   }
 
-  protected R visitType(final Type node, final C context) {
-    return visitNode(node, context);
+  public R visitType(final Type node, final C context) {
+    return visitExpression(node, context);
   }
 
   protected R visitAliasedRelation(final AliasedRelation node, final C context) {
@@ -208,7 +208,7 @@ public abstract class AstVisitor<R, C> {
     return visitNode(node, context);
   }
 
-  protected R visitCast(final Cast node, final C context) {
+  public R visitCast(final Cast node, final C context) {
     return visitExpression(node, context);
   }
 

--- a/ksql-parser/src/main/java/io/confluent/ksql/parser/tree/BetweenPredicate.java
+++ b/ksql-parser/src/main/java/io/confluent/ksql/parser/tree/BetweenPredicate.java
@@ -61,7 +61,7 @@ public class BetweenPredicate extends Expression {
   }
 
   @Override
-  public <R, C> R accept(final AstVisitor<R, C> visitor, final C context) {
+  public <R, C> R accept(final ExpressionVisitor<R, C> visitor, final C context) {
     return visitor.visitBetweenPredicate(this, context);
   }
 

--- a/ksql-parser/src/main/java/io/confluent/ksql/parser/tree/BooleanLiteral.java
+++ b/ksql-parser/src/main/java/io/confluent/ksql/parser/tree/BooleanLiteral.java
@@ -51,7 +51,7 @@ public class BooleanLiteral extends Literal {
   }
 
   @Override
-  public <R, C> R accept(final AstVisitor<R, C> visitor, final C context) {
+  public <R, C> R accept(final ExpressionVisitor<R, C> visitor, final C context) {
     return visitor.visitBooleanLiteral(this, context);
   }
 

--- a/ksql-parser/src/main/java/io/confluent/ksql/parser/tree/Cast.java
+++ b/ksql-parser/src/main/java/io/confluent/ksql/parser/tree/Cast.java
@@ -53,7 +53,7 @@ public final class Cast extends Expression {
   }
 
   @Override
-  public <R, C> R accept(final AstVisitor<R, C> visitor, final C context) {
+  public <R, C> R accept(final ExpressionVisitor<R, C> visitor, final C context) {
     return visitor.visitCast(this, context);
   }
 

--- a/ksql-parser/src/main/java/io/confluent/ksql/parser/tree/ComparisonExpression.java
+++ b/ksql-parser/src/main/java/io/confluent/ksql/parser/tree/ComparisonExpression.java
@@ -121,7 +121,7 @@ public class ComparisonExpression extends Expression {
   }
 
   @Override
-  public <R, C> R accept(final AstVisitor<R, C> visitor, final C context) {
+  public <R, C> R accept(final ExpressionVisitor<R, C> visitor, final C context) {
     return visitor.visitComparisonExpression(this, context);
   }
 

--- a/ksql-parser/src/main/java/io/confluent/ksql/parser/tree/DecimalLiteral.java
+++ b/ksql-parser/src/main/java/io/confluent/ksql/parser/tree/DecimalLiteral.java
@@ -41,7 +41,7 @@ public class DecimalLiteral extends Literal {
   }
 
   @Override
-  public <R, C> R accept(final AstVisitor<R, C> visitor, final C context) {
+  public <R, C> R accept(final ExpressionVisitor<R, C> visitor, final C context) {
     return visitor.visitDecimalLiteral(this, context);
   }
 

--- a/ksql-parser/src/main/java/io/confluent/ksql/parser/tree/DefaultAstVisitor.java
+++ b/ksql-parser/src/main/java/io/confluent/ksql/parser/tree/DefaultAstVisitor.java
@@ -20,29 +20,29 @@ import javax.annotation.Nullable;
 public abstract class DefaultAstVisitor<R, C>
     extends AstVisitor<R, C> {
 
-  public R process(final Node node, @Nullable final C context) {
+  public R process(final AstNode node, @Nullable final C context) {
     return node.accept(this, context);
   }
 
-  protected R visitNode(final Node node, final C context) {
+  protected R visitNode(final AstNode node, final C context) {
     return null;
   }
 
   protected R visitExpression(final Expression node, final C context) {
-    return visitNode(node, context);
+    return null;
   }
 
-  protected R visitArithmeticBinary(final ArithmeticBinaryExpression node, final C context) {
+  public R visitArithmeticBinary(final ArithmeticBinaryExpression node, final C context) {
     process(node.getLeft(), context);
     process(node.getRight(), context);
     return visitExpression(node, context);
   }
 
-  protected R visitBetweenPredicate(final BetweenPredicate node, final C context) {
+  public R visitBetweenPredicate(final BetweenPredicate node, final C context) {
     return visitExpression(node, context);
   }
 
-  protected R visitComparisonExpression(final ComparisonExpression node, final C context) {
+  public R visitComparisonExpression(final ComparisonExpression node, final C context) {
     process(node.getLeft(), context);
     process(node.getRight(), context);
     return visitExpression(node, context);
@@ -52,11 +52,11 @@ public abstract class DefaultAstVisitor<R, C>
     return visitExpression(node, context);
   }
 
-  protected R visitDoubleLiteral(final DoubleLiteral node, final C context) {
+  public R visitDoubleLiteral(final DoubleLiteral node, final C context) {
     return visitLiteral(node, context);
   }
 
-  protected R visitDecimalLiteral(final DecimalLiteral node, final C context) {
+  public R visitDecimalLiteral(final DecimalLiteral node, final C context) {
     return visitLiteral(node, context);
   }
 
@@ -84,7 +84,7 @@ public abstract class DefaultAstVisitor<R, C>
     return visitStatement(node, context);
   }
 
-  protected R visitTimeLiteral(final TimeLiteral node, final C context) {
+  public R visitTimeLiteral(final TimeLiteral node, final C context) {
     return visitLiteral(node, context);
   }
 
@@ -96,56 +96,56 @@ public abstract class DefaultAstVisitor<R, C>
     return visitNode(node, context);
   }
 
-  protected R visitTimestampLiteral(final TimestampLiteral node, final C context) {
+  public R visitTimestampLiteral(final TimestampLiteral node, final C context) {
     return visitLiteral(node, context);
   }
 
-  protected R visitWhenClause(final WhenClause node, final C context) {
+  public R visitWhenClause(final WhenClause node, final C context) {
     return visitExpression(node, context);
   }
 
-  protected R visitInPredicate(final InPredicate node, final C context) {
+  public R visitInPredicate(final InPredicate node, final C context) {
     return visitExpression(node, context);
   }
 
-  protected R visitFunctionCall(final FunctionCall node, final C context) {
+  public R visitFunctionCall(final FunctionCall node, final C context) {
     return visitExpression(node, context);
   }
 
-  protected R visitSimpleCaseExpression(final SimpleCaseExpression node, final C context) {
+  public R visitSimpleCaseExpression(final SimpleCaseExpression node, final C context) {
     return visitExpression(node, context);
   }
 
-  protected R visitStringLiteral(final StringLiteral node, final C context) {
+  public R visitStringLiteral(final StringLiteral node, final C context) {
     return visitLiteral(node, context);
   }
 
-  protected R visitBooleanLiteral(final BooleanLiteral node, final C context) {
+  public R visitBooleanLiteral(final BooleanLiteral node, final C context) {
     return visitLiteral(node, context);
   }
 
-  protected R visitInListExpression(final InListExpression node, final C context) {
+  public R visitInListExpression(final InListExpression node, final C context) {
     return visitExpression(node, context);
   }
 
-  protected R visitQualifiedNameReference(final QualifiedNameReference node, final C context) {
+  public R visitQualifiedNameReference(final QualifiedNameReference node, final C context) {
     return visitExpression(node, context);
   }
 
-  protected R visitDereferenceExpression(final DereferenceExpression node, final C context) {
+  public R visitDereferenceExpression(final DereferenceExpression node, final C context) {
     return visitExpression(node, context);
   }
 
-  protected R visitNullLiteral(final NullLiteral node, final C context) {
+  public R visitNullLiteral(final NullLiteral node, final C context) {
     return visitLiteral(node, context);
   }
 
-  protected R visitArithmeticUnary(final ArithmeticUnaryExpression node, final C context) {
+  public R visitArithmeticUnary(final ArithmeticUnaryExpression node, final C context) {
     process(node.getValue(), context);
     return visitExpression(node, context);
   }
 
-  protected R visitNotExpression(final NotExpression node, final C context) {
+  public R visitNotExpression(final NotExpression node, final C context) {
     return visitExpression(node, context);
   }
 
@@ -162,32 +162,32 @@ public abstract class DefaultAstVisitor<R, C>
     return visitSelectItem(node, context);
   }
 
-  protected R visitSearchedCaseExpression(final SearchedCaseExpression node, final C context) {
+  public R visitSearchedCaseExpression(final SearchedCaseExpression node, final C context) {
     return visitExpression(node, context);
   }
 
-  protected R visitLikePredicate(final LikePredicate node, final C context) {
+  public R visitLikePredicate(final LikePredicate node, final C context) {
     process(node.getValue(), context);
     return visitExpression(node, context);
   }
 
-  protected R visitIsNotNullPredicate(final IsNotNullPredicate node, final C context) {
+  public R visitIsNotNullPredicate(final IsNotNullPredicate node, final C context) {
     return visitExpression(node, context);
   }
 
-  protected R visitIsNullPredicate(final IsNullPredicate node, final C context) {
+  public R visitIsNullPredicate(final IsNullPredicate node, final C context) {
     return visitExpression(node, context);
   }
 
-  protected R visitSubscriptExpression(final SubscriptExpression node, final C context) {
+  public R visitSubscriptExpression(final SubscriptExpression node, final C context) {
     return visitExpression(node, context);
   }
 
-  protected R visitLongLiteral(final LongLiteral node, final C context) {
+  public R visitLongLiteral(final LongLiteral node, final C context) {
     return visitLiteral(node, context);
   }
 
-  protected R visitLogicalBinaryExpression(final LogicalBinaryExpression node, final C context) {
+  public R visitLogicalBinaryExpression(final LogicalBinaryExpression node, final C context) {
     process(node.getLeft(), context);
     process(node.getRight(), context);
     return visitExpression(node, context);
@@ -205,7 +205,7 @@ public abstract class DefaultAstVisitor<R, C>
     return visitRelation(node, context);
   }
 
-  protected R visitCast(final Cast node, final C context) {
+  public R visitCast(final Cast node, final C context) {
     return visitExpression(node, context);
   }
 

--- a/ksql-parser/src/main/java/io/confluent/ksql/parser/tree/DereferenceExpression.java
+++ b/ksql-parser/src/main/java/io/confluent/ksql/parser/tree/DereferenceExpression.java
@@ -47,7 +47,7 @@ public class DereferenceExpression extends Expression {
   }
 
   @Override
-  public <R, C> R accept(final AstVisitor<R, C> visitor, final C context) {
+  public <R, C> R accept(final ExpressionVisitor<R, C> visitor, final C context) {
     return visitor.visitDereferenceExpression(this, context);
   }
 

--- a/ksql-parser/src/main/java/io/confluent/ksql/parser/tree/DoubleLiteral.java
+++ b/ksql-parser/src/main/java/io/confluent/ksql/parser/tree/DoubleLiteral.java
@@ -38,7 +38,7 @@ public class DoubleLiteral extends Literal {
   }
 
   @Override
-  public <R, C> R accept(final AstVisitor<R, C> visitor, final C context) {
+  public <R, C> R accept(final ExpressionVisitor<R, C> visitor, final C context) {
     return visitor.visitDoubleLiteral(this, context);
   }
 

--- a/ksql-parser/src/main/java/io/confluent/ksql/parser/tree/Expression.java
+++ b/ksql-parser/src/main/java/io/confluent/ksql/parser/tree/Expression.java
@@ -30,13 +30,7 @@ public abstract class Expression extends Node {
     super(location);
   }
 
-  /**
-   * Accessible for {@link AstVisitor}, use {@link AstVisitor#process(Node, Object)} instead.
-   */
-  @Override
-  protected <R, C> R accept(final AstVisitor<R, C> visitor, final C context) {
-    return visitor.visitExpression(this, context);
-  }
+  protected abstract <R, C> R accept(ExpressionVisitor<R, C> visitor, C context);
 
   @Override
   public final String toString() {

--- a/ksql-parser/src/main/java/io/confluent/ksql/parser/tree/ExpressionTreeRewriter.java
+++ b/ksql-parser/src/main/java/io/confluent/ksql/parser/tree/ExpressionTreeRewriter.java
@@ -34,7 +34,7 @@ public final class ExpressionTreeRewriter<C> {
   }
 
 
-  public ExpressionTreeRewriter(final ExpressionRewriter<C> rewriter) {
+  private ExpressionTreeRewriter(final ExpressionRewriter<C> rewriter) {
     this.rewriter = rewriter;
     this.visitor = new RewritingVisitor();
   }
@@ -50,7 +50,7 @@ public final class ExpressionTreeRewriter<C> {
     // CHECKSTYLE_RULES.ON: ClassDataAbstractionCoupling
 
     @Override
-    protected Expression visitExpression(final Expression node, final Context<C> context) {
+    public Expression visitExpression(final Expression node, final Context<C> context) {
       if (!context.isDefaultRewrite()) {
         final Expression
             result =
@@ -66,7 +66,7 @@ public final class ExpressionTreeRewriter<C> {
     }
 
     @Override
-    protected Expression visitType(final Type node, final Context<C> context) {
+    public Expression visitType(final Type node, final Context<C> context) {
       if (!(node.getSqlType() instanceof SqlStruct)) {
         return node;
       }
@@ -84,7 +84,7 @@ public final class ExpressionTreeRewriter<C> {
     }
 
     @Override
-    protected Expression visitArithmeticUnary(
+    public Expression visitArithmeticUnary(
         final ArithmeticUnaryExpression node,
         final Context<C> context) {
       if (!context.isDefaultRewrite()) {
@@ -128,7 +128,7 @@ public final class ExpressionTreeRewriter<C> {
     }
 
     @Override
-    protected Expression visitSubscriptExpression(
+    public Expression visitSubscriptExpression(
         final SubscriptExpression node,
         final Context<C> context) {
       if (!context.isDefaultRewrite()) {
@@ -174,7 +174,7 @@ public final class ExpressionTreeRewriter<C> {
     }
 
     @Override
-    protected Expression visitBetweenPredicate(
+    public Expression visitBetweenPredicate(
         final BetweenPredicate node,
         final Context<C> context) {
       if (!context.isDefaultRewrite()) {
@@ -241,7 +241,7 @@ public final class ExpressionTreeRewriter<C> {
     }
 
     @Override
-    protected Expression visitIsNullPredicate(
+    public Expression visitIsNullPredicate(
         final IsNullPredicate node,
         final Context<C> context) {
       if (!context.isDefaultRewrite()) {
@@ -263,7 +263,7 @@ public final class ExpressionTreeRewriter<C> {
     }
 
     @Override
-    protected Expression visitIsNotNullPredicate(
+    public Expression visitIsNotNullPredicate(
         final IsNotNullPredicate node,
         final Context<C> context) {
       if (!context.isDefaultRewrite()) {
@@ -285,7 +285,7 @@ public final class ExpressionTreeRewriter<C> {
     }
 
     @Override
-    protected Expression visitSearchedCaseExpression(final SearchedCaseExpression node,
+    public Expression visitSearchedCaseExpression(final SearchedCaseExpression node,
                                                      final Context<C> context) {
       if (!context.isDefaultRewrite()) {
         final Expression
@@ -314,7 +314,7 @@ public final class ExpressionTreeRewriter<C> {
     }
 
     @Override
-    protected Expression visitSimpleCaseExpression(
+    public Expression visitSimpleCaseExpression(
         final SimpleCaseExpression node,
         final Context<C> context) {
       if (!context.isDefaultRewrite()) {
@@ -346,7 +346,7 @@ public final class ExpressionTreeRewriter<C> {
     }
 
     @Override
-    protected Expression visitWhenClause(final WhenClause node, final Context<C> context) {
+    public Expression visitWhenClause(final WhenClause node, final Context<C> context) {
       if (!context.isDefaultRewrite()) {
         final Expression
             result =
@@ -430,7 +430,7 @@ public final class ExpressionTreeRewriter<C> {
     }
 
     @Override
-    protected Expression visitInListExpression(
+    public Expression visitInListExpression(
         final InListExpression node,
         final Context<C> context) {
       if (!context.isDefaultRewrite()) {

--- a/ksql-parser/src/main/java/io/confluent/ksql/parser/tree/ExpressionVisitor.java
+++ b/ksql-parser/src/main/java/io/confluent/ksql/parser/tree/ExpressionVisitor.java
@@ -1,0 +1,82 @@
+/*
+ * Copyright 2019 Confluent Inc.
+ *
+ * Licensed under the Confluent Community License (the "License"); you may not use
+ * this file except in compliance with the License.  You may obtain a copy of the
+ * License at
+ *
+ * http://www.confluent.io/confluent-community-license
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package io.confluent.ksql.parser.tree;
+
+import javax.annotation.Nullable;
+
+public interface ExpressionVisitor<R, C> {
+  default R process(final Expression node, @Nullable final C context) {
+    return node.accept(this, context);
+  }
+
+  R visitArithmeticBinary(ArithmeticBinaryExpression exp, @Nullable C context);
+
+  R visitArithmeticUnary(ArithmeticUnaryExpression exp, @Nullable C context);
+
+  R visitBetweenPredicate(BetweenPredicate exp, @Nullable C context);
+
+  R visitBooleanLiteral(BooleanLiteral exp, @Nullable C context);
+
+  R visitCast(Cast exp, @Nullable C context);
+
+  R visitComparisonExpression(ComparisonExpression exp, @Nullable C context);
+
+  R visitDecimalLiteral(DecimalLiteral exp, @Nullable C context);
+
+  R visitDereferenceExpression(DereferenceExpression exp, @Nullable C context);
+
+  R visitDoubleLiteral(DoubleLiteral exp, @Nullable C context);
+
+  R visitFunctionCall(FunctionCall exp, @Nullable C context);
+
+  R visitInListExpression(InListExpression exp, @Nullable C context);
+
+  R visitInPredicate(InPredicate exp, @Nullable C context);
+
+  R visitIntegerLiteral(IntegerLiteral exp, @Nullable C context);
+
+  R visitIsNotNullPredicate(IsNotNullPredicate exp, @Nullable C context);
+
+  R visitIsNullPredicate(IsNullPredicate exp, @Nullable C context);
+
+  R visitLikePredicate(LikePredicate exp, @Nullable C context);
+
+  R visitLogicalBinaryExpression(LogicalBinaryExpression exp, @Nullable C context);
+
+  R visitLongLiteral(LongLiteral exp, @Nullable C context);
+
+  R visitNotExpression(NotExpression exp, @Nullable C context);
+
+  R visitNullLiteral(NullLiteral exp, @Nullable C context);
+
+  R visitQualifiedNameReference(QualifiedNameReference exp, @Nullable C context);
+
+  R visitSearchedCaseExpression(SearchedCaseExpression exp, @Nullable C context);
+
+  R visitSimpleCaseExpression(SimpleCaseExpression exp, @Nullable C context);
+
+  R visitStringLiteral(StringLiteral exp, @Nullable C context);
+
+  R visitSubscriptExpression(SubscriptExpression exp, @Nullable C context);
+
+  R visitTimeLiteral(TimeLiteral exp, @Nullable C context);
+
+  R visitTimestampLiteral(TimestampLiteral exp, @Nullable C context);
+
+  R visitType(Type exp, @Nullable C context);
+
+  R visitWhenClause(WhenClause exp, @Nullable C context);
+}

--- a/ksql-parser/src/main/java/io/confluent/ksql/parser/tree/FunctionCall.java
+++ b/ksql-parser/src/main/java/io/confluent/ksql/parser/tree/FunctionCall.java
@@ -55,7 +55,7 @@ public class FunctionCall extends Expression {
   }
 
   @Override
-  public <R, C> R accept(final AstVisitor<R, C> visitor, final C context) {
+  public <R, C> R accept(final ExpressionVisitor<R, C> visitor, final C context) {
     return visitor.visitFunctionCall(this, context);
   }
 

--- a/ksql-parser/src/main/java/io/confluent/ksql/parser/tree/GroupBy.java
+++ b/ksql-parser/src/main/java/io/confluent/ksql/parser/tree/GroupBy.java
@@ -25,7 +25,7 @@ import java.util.Objects;
 import java.util.Optional;
 
 @Immutable
-public class GroupBy extends Node {
+public class GroupBy extends AstNode {
 
   private final ImmutableList<GroupingElement> groupingElements;
 

--- a/ksql-parser/src/main/java/io/confluent/ksql/parser/tree/GroupingElement.java
+++ b/ksql-parser/src/main/java/io/confluent/ksql/parser/tree/GroupingElement.java
@@ -21,7 +21,7 @@ import java.util.Optional;
 import java.util.Set;
 
 @Immutable
-public abstract class GroupingElement extends Node {
+public abstract class GroupingElement extends AstNode {
 
   GroupingElement(final Optional<NodeLocation> location) {
     super(location);

--- a/ksql-parser/src/main/java/io/confluent/ksql/parser/tree/InListExpression.java
+++ b/ksql-parser/src/main/java/io/confluent/ksql/parser/tree/InListExpression.java
@@ -49,7 +49,7 @@ public class InListExpression extends Expression {
   }
 
   @Override
-  public <R, C> R accept(final AstVisitor<R, C> visitor, final C context) {
+  public <R, C> R accept(final ExpressionVisitor<R, C> visitor, final C context) {
     return visitor.visitInListExpression(this, context);
   }
 

--- a/ksql-parser/src/main/java/io/confluent/ksql/parser/tree/InPredicate.java
+++ b/ksql-parser/src/main/java/io/confluent/ksql/parser/tree/InPredicate.java
@@ -53,7 +53,7 @@ public class InPredicate extends Expression {
   }
 
   @Override
-  public <R, C> R accept(final AstVisitor<R, C> visitor, final C context) {
+  public <R, C> R accept(final ExpressionVisitor<R, C> visitor, final C context) {
     return visitor.visitInPredicate(this, context);
   }
 

--- a/ksql-parser/src/main/java/io/confluent/ksql/parser/tree/IntegerLiteral.java
+++ b/ksql-parser/src/main/java/io/confluent/ksql/parser/tree/IntegerLiteral.java
@@ -39,7 +39,7 @@ public class IntegerLiteral extends Literal {
   }
 
   @Override
-  public <R, C> R accept(final AstVisitor<R, C> visitor, final C context) {
+  public <R, C> R accept(final ExpressionVisitor<R, C> visitor, final C context) {
     return visitor.visitIntegerLiteral(this, context);
   }
 

--- a/ksql-parser/src/main/java/io/confluent/ksql/parser/tree/IsNotNullPredicate.java
+++ b/ksql-parser/src/main/java/io/confluent/ksql/parser/tree/IsNotNullPredicate.java
@@ -43,7 +43,7 @@ public class IsNotNullPredicate extends Expression {
   }
 
   @Override
-  public <R, C> R accept(final AstVisitor<R, C> visitor, final C context) {
+  public <R, C> R accept(final ExpressionVisitor<R, C> visitor, final C context) {
     return visitor.visitIsNotNullPredicate(this, context);
   }
 

--- a/ksql-parser/src/main/java/io/confluent/ksql/parser/tree/IsNullPredicate.java
+++ b/ksql-parser/src/main/java/io/confluent/ksql/parser/tree/IsNullPredicate.java
@@ -40,7 +40,7 @@ public class IsNullPredicate extends Expression {
   }
 
   @Override
-  public <R, C> R accept(final AstVisitor<R, C> visitor, final C context) {
+  public <R, C> R accept(final ExpressionVisitor<R, C> visitor, final C context) {
     return visitor.visitIsNullPredicate(this, context);
   }
 

--- a/ksql-parser/src/main/java/io/confluent/ksql/parser/tree/KsqlWindowExpression.java
+++ b/ksql-parser/src/main/java/io/confluent/ksql/parser/tree/KsqlWindowExpression.java
@@ -27,7 +27,7 @@ import org.apache.kafka.streams.kstream.Materialized;
 import org.apache.kafka.streams.kstream.Windowed;
 
 @Immutable
-public abstract class KsqlWindowExpression extends Node {
+public abstract class KsqlWindowExpression extends AstNode {
 
   KsqlWindowExpression(final Optional<NodeLocation> location) {
     super(location);

--- a/ksql-parser/src/main/java/io/confluent/ksql/parser/tree/LikePredicate.java
+++ b/ksql-parser/src/main/java/io/confluent/ksql/parser/tree/LikePredicate.java
@@ -53,7 +53,7 @@ public class LikePredicate extends Expression {
   }
 
   @Override
-  public <R, C> R accept(final AstVisitor<R, C> visitor, final C context) {
+  public <R, C> R accept(final ExpressionVisitor<R, C> visitor, final C context) {
     return visitor.visitLikePredicate(this, context);
   }
 

--- a/ksql-parser/src/main/java/io/confluent/ksql/parser/tree/Literal.java
+++ b/ksql-parser/src/main/java/io/confluent/ksql/parser/tree/Literal.java
@@ -25,10 +25,5 @@ public abstract class Literal extends Expression {
     super(location);
   }
 
-  @Override
-  public <R, C> R accept(final AstVisitor<R, C> visitor, final C context) {
-    return visitor.visitLiteral(this, context);
-  }
-
   public abstract Object getValue();
 }

--- a/ksql-parser/src/main/java/io/confluent/ksql/parser/tree/LogicalBinaryExpression.java
+++ b/ksql-parser/src/main/java/io/confluent/ksql/parser/tree/LogicalBinaryExpression.java
@@ -65,7 +65,7 @@ public class LogicalBinaryExpression extends Expression {
   }
 
   @Override
-  public <R, C> R accept(final AstVisitor<R, C> visitor, final C context) {
+  public <R, C> R accept(final ExpressionVisitor<R, C> visitor, final C context) {
     return visitor.visitLogicalBinaryExpression(this, context);
   }
 

--- a/ksql-parser/src/main/java/io/confluent/ksql/parser/tree/LongLiteral.java
+++ b/ksql-parser/src/main/java/io/confluent/ksql/parser/tree/LongLiteral.java
@@ -38,7 +38,7 @@ public class LongLiteral extends Literal {
   }
 
   @Override
-  public <R, C> R accept(final AstVisitor<R, C> visitor, final C context) {
+  public <R, C> R accept(final ExpressionVisitor<R, C> visitor, final C context) {
     return visitor.visitLongLiteral(this, context);
   }
 

--- a/ksql-parser/src/main/java/io/confluent/ksql/parser/tree/Node.java
+++ b/ksql-parser/src/main/java/io/confluent/ksql/parser/tree/Node.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018 Confluent Inc.
+ * Copyright 2019 Confluent Inc.
  *
  * Licensed under the Confluent Community License (the "License"); you may not use
  * this file except in compliance with the License.  You may obtain a copy of the
@@ -22,18 +22,10 @@ import java.util.Optional;
 
 @Immutable
 public abstract class Node {
-
   private final Optional<NodeLocation> location;
 
   protected Node(final Optional<NodeLocation> location) {
     this.location = requireNonNull(location, "location");
-  }
-
-  /**
-   * Accessible for {@link AstVisitor}, use {@link AstVisitor#process(Node, Object)} instead.
-   */
-  protected <R, C> R accept(final AstVisitor<R, C> visitor, final C context) {
-    return visitor.visitNode(this, context);
   }
 
   public Optional<NodeLocation> getLocation() {

--- a/ksql-parser/src/main/java/io/confluent/ksql/parser/tree/NotExpression.java
+++ b/ksql-parser/src/main/java/io/confluent/ksql/parser/tree/NotExpression.java
@@ -40,7 +40,7 @@ public class NotExpression extends Expression {
   }
 
   @Override
-  public <R, C> R accept(final AstVisitor<R, C> visitor, final C context) {
+  public <R, C> R accept(final ExpressionVisitor<R, C> visitor, final C context) {
     return visitor.visitNotExpression(this, context);
   }
 

--- a/ksql-parser/src/main/java/io/confluent/ksql/parser/tree/NullLiteral.java
+++ b/ksql-parser/src/main/java/io/confluent/ksql/parser/tree/NullLiteral.java
@@ -30,7 +30,7 @@ public class NullLiteral extends Literal {
   }
 
   @Override
-  public <R, C> R accept(final AstVisitor<R, C> visitor, final C context) {
+  public <R, C> R accept(final ExpressionVisitor<R, C> visitor, final C context) {
     return visitor.visitNullLiteral(this, context);
   }
 

--- a/ksql-parser/src/main/java/io/confluent/ksql/parser/tree/QualifiedNameReference.java
+++ b/ksql-parser/src/main/java/io/confluent/ksql/parser/tree/QualifiedNameReference.java
@@ -44,7 +44,7 @@ public class QualifiedNameReference extends Expression {
   }
 
   @Override
-  public <R, C> R accept(final AstVisitor<R, C> visitor, final C context) {
+  public <R, C> R accept(final ExpressionVisitor<R, C> visitor, final C context) {
     return visitor.visitQualifiedNameReference(this, context);
   }
 

--- a/ksql-parser/src/main/java/io/confluent/ksql/parser/tree/SearchedCaseExpression.java
+++ b/ksql-parser/src/main/java/io/confluent/ksql/parser/tree/SearchedCaseExpression.java
@@ -55,7 +55,7 @@ public class SearchedCaseExpression extends Expression {
   }
 
   @Override
-  public <R, C> R accept(final AstVisitor<R, C> visitor, final C context) {
+  public <R, C> R accept(final ExpressionVisitor<R, C> visitor, final C context) {
     return visitor.visitSearchedCaseExpression(this, context);
   }
 

--- a/ksql-parser/src/main/java/io/confluent/ksql/parser/tree/Select.java
+++ b/ksql-parser/src/main/java/io/confluent/ksql/parser/tree/Select.java
@@ -25,7 +25,7 @@ import java.util.Objects;
 import java.util.Optional;
 
 @Immutable
-public class Select extends Node {
+public class Select extends AstNode {
 
   private final ImmutableList<SelectItem> selectItems;
 

--- a/ksql-parser/src/main/java/io/confluent/ksql/parser/tree/SelectItem.java
+++ b/ksql-parser/src/main/java/io/confluent/ksql/parser/tree/SelectItem.java
@@ -19,7 +19,7 @@ import com.google.errorprone.annotations.Immutable;
 import java.util.Optional;
 
 @Immutable
-public abstract class SelectItem extends Node {
+public abstract class SelectItem extends AstNode {
 
   protected SelectItem(final Optional<NodeLocation> location) {
     super(location);

--- a/ksql-parser/src/main/java/io/confluent/ksql/parser/tree/SimpleCaseExpression.java
+++ b/ksql-parser/src/main/java/io/confluent/ksql/parser/tree/SimpleCaseExpression.java
@@ -63,7 +63,7 @@ public class SimpleCaseExpression extends Expression {
   }
 
   @Override
-  public <R, C> R accept(final AstVisitor<R, C> visitor, final C context) {
+  public <R, C> R accept(final ExpressionVisitor<R, C> visitor, final C context) {
     return visitor.visitSimpleCaseExpression(this, context);
   }
 

--- a/ksql-parser/src/main/java/io/confluent/ksql/parser/tree/Statement.java
+++ b/ksql-parser/src/main/java/io/confluent/ksql/parser/tree/Statement.java
@@ -22,7 +22,7 @@ import java.util.Optional;
  * A {@code Statement} represents the parsed AST version of a single SQL statement.
  */
 @Immutable
-public abstract class Statement extends Node {
+public abstract class Statement extends AstNode {
 
   protected Statement(final Optional<NodeLocation> location) {
     super(location);

--- a/ksql-parser/src/main/java/io/confluent/ksql/parser/tree/Statements.java
+++ b/ksql-parser/src/main/java/io/confluent/ksql/parser/tree/Statements.java
@@ -25,7 +25,7 @@ import java.util.Objects;
 import java.util.Optional;
 
 @Immutable
-public class Statements extends Node {
+public class Statements extends AstNode {
 
   private final ImmutableList<Statement> statements;
 

--- a/ksql-parser/src/main/java/io/confluent/ksql/parser/tree/StringLiteral.java
+++ b/ksql-parser/src/main/java/io/confluent/ksql/parser/tree/StringLiteral.java
@@ -40,7 +40,7 @@ public class StringLiteral extends Literal {
   }
 
   @Override
-  public <R, C> R accept(final AstVisitor<R, C> visitor, final C context) {
+  public <R, C> R accept(final ExpressionVisitor<R, C> visitor, final C context) {
     return visitor.visitStringLiteral(this, context);
   }
 

--- a/ksql-parser/src/main/java/io/confluent/ksql/parser/tree/SubscriptExpression.java
+++ b/ksql-parser/src/main/java/io/confluent/ksql/parser/tree/SubscriptExpression.java
@@ -45,7 +45,7 @@ public class SubscriptExpression extends Expression {
   }
 
   @Override
-  public <R, C> R accept(final AstVisitor<R, C> visitor, final C context) {
+  public <R, C> R accept(final ExpressionVisitor<R, C> visitor, final C context) {
     return visitor.visitSubscriptExpression(this, context);
   }
 

--- a/ksql-parser/src/main/java/io/confluent/ksql/parser/tree/TableElement.java
+++ b/ksql-parser/src/main/java/io/confluent/ksql/parser/tree/TableElement.java
@@ -28,7 +28,7 @@ import java.util.Optional;
  * An element in the schema of a table or stream.
  */
 @Immutable
-public final class TableElement extends Node {
+public final class TableElement extends AstNode {
 
   public enum Namespace {
     KEY,

--- a/ksql-parser/src/main/java/io/confluent/ksql/parser/tree/TimeLiteral.java
+++ b/ksql-parser/src/main/java/io/confluent/ksql/parser/tree/TimeLiteral.java
@@ -41,7 +41,7 @@ public class TimeLiteral extends Literal {
   }
 
   @Override
-  public <R, C> R accept(final AstVisitor<R, C> visitor, final C context) {
+  public <R, C> R accept(final ExpressionVisitor<R, C> visitor, final C context) {
     return visitor.visitTimeLiteral(this, context);
   }
 

--- a/ksql-parser/src/main/java/io/confluent/ksql/parser/tree/TimestampLiteral.java
+++ b/ksql-parser/src/main/java/io/confluent/ksql/parser/tree/TimestampLiteral.java
@@ -41,7 +41,7 @@ public class TimestampLiteral extends Literal {
   }
 
   @Override
-  public <R, C> R accept(final AstVisitor<R, C> visitor, final C context) {
+  public <R, C> R accept(final ExpressionVisitor<R, C> visitor, final C context) {
     return visitor.visitTimestampLiteral(this, context);
   }
 

--- a/ksql-parser/src/main/java/io/confluent/ksql/parser/tree/Type.java
+++ b/ksql-parser/src/main/java/io/confluent/ksql/parser/tree/Type.java
@@ -41,7 +41,7 @@ public final class Type extends Expression {
   }
 
   @Override
-  public <R, C> R accept(final AstVisitor<R, C> visitor, final C context) {
+  public <R, C> R accept(final ExpressionVisitor<R, C> visitor, final C context) {
     return visitor.visitType(this, context);
   }
 

--- a/ksql-parser/src/main/java/io/confluent/ksql/parser/tree/WhenClause.java
+++ b/ksql-parser/src/main/java/io/confluent/ksql/parser/tree/WhenClause.java
@@ -50,7 +50,7 @@ public class WhenClause extends Expression {
   }
 
   @Override
-  public <R, C> R accept(final AstVisitor<R, C> visitor, final C context) {
+  public <R, C> R accept(final ExpressionVisitor<R, C> visitor, final C context) {
     return visitor.visitWhenClause(this, context);
   }
 

--- a/ksql-parser/src/main/java/io/confluent/ksql/parser/tree/WindowExpression.java
+++ b/ksql-parser/src/main/java/io/confluent/ksql/parser/tree/WindowExpression.java
@@ -23,7 +23,7 @@ import java.util.Optional;
 import java.util.concurrent.TimeUnit;
 
 @Immutable
-public class WindowExpression extends Node {
+public class WindowExpression extends AstNode {
 
   private final String windowName;
   private final KsqlWindowExpression ksqlWindowExpression;

--- a/ksql-parser/src/main/java/io/confluent/ksql/parser/tree/WithinExpression.java
+++ b/ksql-parser/src/main/java/io/confluent/ksql/parser/tree/WithinExpression.java
@@ -25,7 +25,7 @@ import java.util.concurrent.TimeUnit;
 import org.apache.kafka.streams.kstream.JoinWindows;
 
 @Immutable
-public class WithinExpression extends Node {
+public class WithinExpression extends AstNode {
 
   private final long before;
   private final long after;

--- a/ksql-parser/src/main/java/io/confluent/ksql/util/DataSourceExtractor.java
+++ b/ksql-parser/src/main/java/io/confluent/ksql/util/DataSourceExtractor.java
@@ -23,7 +23,7 @@ import io.confluent.ksql.metastore.model.DataSource;
 import io.confluent.ksql.parser.SqlBaseBaseVisitor;
 import io.confluent.ksql.parser.SqlBaseParser;
 import io.confluent.ksql.parser.tree.AliasedRelation;
-import io.confluent.ksql.parser.tree.Node;
+import io.confluent.ksql.parser.tree.AstNode;
 import io.confluent.ksql.parser.tree.NodeLocation;
 import io.confluent.ksql.parser.tree.Table;
 import io.confluent.ksql.schema.ksql.LogicalSchema;
@@ -103,21 +103,21 @@ public class DataSourceExtractor {
     return isJoin;
   }
 
-  private final class Visitor extends SqlBaseBaseVisitor<Node> {
+  private final class Visitor extends SqlBaseBaseVisitor<AstNode> {
 
     @Override
-    public Node visitQuery(final SqlBaseParser.QueryContext ctx) {
+    public AstNode visitQuery(final SqlBaseParser.QueryContext ctx) {
       visit(ctx.from);
       return visitChildren(ctx);
     }
 
     @Override
-    public Node visitTableName(final SqlBaseParser.TableNameContext context) {
+    public AstNode visitTableName(final SqlBaseParser.TableNameContext context) {
       return new Table(getLocation(context), ParserUtil.getQualifiedName(context.qualifiedName()));
     }
 
     @Override
-    public Node visitAliasedRelation(final SqlBaseParser.AliasedRelationContext context) {
+    public AstNode visitAliasedRelation(final SqlBaseParser.AliasedRelationContext context) {
       final Table table = (Table) visit(context.relationPrimary());
 
       final String alias;
@@ -155,7 +155,7 @@ public class DataSourceExtractor {
     }
 
     @Override
-    public Node visitJoinRelation(final SqlBaseParser.JoinRelationContext context) {
+    public AstNode visitJoinRelation(final SqlBaseParser.JoinRelationContext context) {
       isJoin = true;
       final AliasedRelation left = (AliasedRelation) visit(context.left);
       leftAlias = left.getAlias();

--- a/ksql-parser/src/test/java/io/confluent/ksql/parser/rewrite/StatementRewriterTest.java
+++ b/ksql-parser/src/test/java/io/confluent/ksql/parser/rewrite/StatementRewriterTest.java
@@ -34,7 +34,7 @@ import io.confluent.ksql.parser.tree.CreateStreamAsSelect;
 import io.confluent.ksql.parser.tree.CreateTable;
 import io.confluent.ksql.parser.tree.InsertInto;
 import io.confluent.ksql.parser.tree.Join;
-import io.confluent.ksql.parser.tree.Node;
+import io.confluent.ksql.parser.tree.AstNode;
 import io.confluent.ksql.parser.tree.Query;
 import io.confluent.ksql.parser.tree.SingleColumn;
 import io.confluent.ksql.parser.tree.Statement;
@@ -248,7 +248,7 @@ public class StatementRewriterTest {
     final Query original = parse("SELECT * FROM test1 t1;");
 
     // When:
-    final Node rewrittenStatement = statementRewriter.process(original, null);
+    final AstNode rewrittenStatement = (AstNode) statementRewriter.process(original, null);
 
     // Then:
     assertThat(rewrittenStatement, is(instanceOf(Query.class)));
@@ -265,7 +265,7 @@ public class StatementRewriterTest {
             + "WHERE t2.col2 = 'test';");
 
     // When:
-    final Node rewrittenStatement = statementRewriter.process(original, null);
+    final AstNode rewrittenStatement = (AstNode) statementRewriter.process(original, null);
 
     // Then:
     assertThat(rewrittenStatement, instanceOf(Query.class));

--- a/ksql-parser/src/test/java/io/confluent/ksql/parser/tree/ParserModelTest.java
+++ b/ksql-parser/src/test/java/io/confluent/ksql/parser/tree/ParserModelTest.java
@@ -91,7 +91,7 @@ public class ParserModelTest {
   @Parameterized.Parameters(name = "{0}")
   public static Collection<Class<?>> data() {
     return ClassFinder.getClasses(FunctionCall.class.getPackage().getName()).stream()
-        .filter(Node.class::isAssignableFrom)
+        .filter(AstNode.class::isAssignableFrom)
         .collect(Collectors.toList());
   }
 


### PR DESCRIPTION
### Description 

This patch moves the nodes in our expression tree into a separate parse
tree. This is a first step towards moving the code that deals with
expressions into ksql-execution (see https://github.com/confluentinc/ksql/pull/3125),
so that the serialized execution plan nodes can refer to expressions (e.g. for a select).

Both AST and Expression node have a common parent Node class, which now
just contains a NodeLocation, and abstract hashcode/equals methods.

The Expression tree now has its own visitor interface, called
ExpressionVisitor. This patch also migrates ExpressionFormatter to
implement this interface.

Note that this is just the first of multiple steps to get these decoupled, with the goal
for this PR being to separate the two trees. I'm deferring the following to later PRs:
    - Actually moving the expression classes into ksql-execution (this pollutes the diff).
    - We have lots of AstVisitor implementations that only operate on expressions
       (e.g. codegen, expression type manager, insert-into analyzer). Migrating these
       to implement ExpressionVisitor is deferred to a later PR.
    - The current patch has AstVisitor implement ExpressionVisitor. These should be
       decoupled into separate visitors (and all made private inner classes (see below)),
       and explicitly composed where needed.
    - ExpressionVisitor is an interface, which means that all the visit methods are public,
       but that's fine since  the final implementation should always be a private inner class
       so that the interface can be restricted appropriately for the given visitor use case.
       Migrating AstVisitor (and cleaning up the weird inheritance hierarchy) to follow a
       similar pattern is also deferred.
       
### Testing done 
This is purely a refactor, so no new tests have been added.
