### PR TITLE
fix: expose user/password command line options

### DIFF
--- a/ksql-cli/src/main/java/io/confluent/ksql/cli/Options.java
+++ b/ksql-cli/src/main/java/io/confluent/ksql/cli/Options.java
@@ -73,8 +73,7 @@ public class Options {
               + PASSWORD_SHORT_OPTION
               + "/"
               + PASSWORD_OPTION
-              + " flag",
-      hidden = true)
+              + " flag")
   private String userName;
 
   @SuppressWarnings("unused") // Accessed via reflection
@@ -86,8 +85,7 @@ public class Options {
               + USERNAME_SHORT_OPTION
               + "/"
               + USERNAME_OPTION
-              + " flag",
-      hidden = true)
+              + " flag")
   private String password;
 
   @SuppressWarnings("unused") // Accessed via reflection


### PR DESCRIPTION
### Description 
Exposes the --user/--password command-line options when executing `ksql --help`. I don't know why they were hidden if there is nothing to secure by hiding them.

### Testing done 
Verify `ksql --help` exposes the parameters:
```
> ksql --help
...
--password <password>, -p <password>
            If your KSQL server is configured for authentication, then provide
            your password here. The username must be specified separately with
            the -u/--user flag
...
--user <userName>, -u <userName>
            If your KSQL server is configured for authentication, then provide
            your user name here. The password must be specified separately with
            the -p/--password flag
...
```

### Reviewer checklist
- [ ] Ensure docs are updated if necessary. (eg. if a user visible feature is being added or changed).
- [ ] Ensure relevant issues are linked (description should include text like "Fixes #<issue number>")

