### PR TITLE
fix: drop succeeds even if missing topic or schema

### DIFF
--- a/ksql-engine/src/main/java/io/confluent/ksql/exception/KafkaDeleteTopicsException.java
+++ b/ksql-engine/src/main/java/io/confluent/ksql/exception/KafkaDeleteTopicsException.java
@@ -1,0 +1,35 @@
+/*
+ * Copyright 2018 Confluent Inc.
+ *
+ * Licensed under the Confluent Community License (the "License"); you may not use
+ * this file except in compliance with the License.  You may obtain a copy of the
+ * License at
+ *
+ * http://www.confluent.io/confluent-community-license
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package io.confluent.ksql.exception;
+
+import java.util.List;
+import javafx.util.Pair;
+
+public class KafkaDeleteTopicsException extends KafkaTopicClientException {
+  private final List<Pair<String, Throwable>> exceptionList;
+
+  public KafkaDeleteTopicsException(
+          final String message,
+          final List<Pair<String, Throwable>> failList) {
+    super(message);
+    exceptionList = failList;
+  }
+
+  public final List<Pair<String, Throwable>> getExceptionList() {
+    return exceptionList;
+  }
+
+}

--- a/ksql-engine/src/main/java/io/confluent/ksql/services/KafkaTopicClientImpl.java
+++ b/ksql-engine/src/main/java/io/confluent/ksql/services/KafkaTopicClientImpl.java
@@ -16,6 +16,7 @@
 package io.confluent.ksql.services;
 
 import com.google.common.collect.Lists;
+import io.confluent.ksql.exception.KafkaDeleteTopicsException;
 import io.confluent.ksql.exception.KafkaResponseGetFailedException;
 import io.confluent.ksql.topic.TopicProperties;
 import io.confluent.ksql.util.ExecutorUtil;
@@ -31,7 +32,9 @@ import java.util.Set;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeUnit;
 import java.util.stream.Collectors;
+import javafx.util.Pair;
 import javax.annotation.concurrent.ThreadSafe;
+
 import org.apache.commons.lang3.exception.ExceptionUtils;
 import org.apache.kafka.clients.admin.AdminClient;
 import org.apache.kafka.clients.admin.AlterConfigOp;
@@ -46,6 +49,7 @@ import org.apache.kafka.common.config.ConfigResource;
 import org.apache.kafka.common.config.TopicConfig;
 import org.apache.kafka.common.errors.TopicDeletionDisabledException;
 import org.apache.kafka.common.errors.TopicExistsException;
+import org.apache.kafka.common.errors.UnknownTopicOrPartitionException;
 import org.apache.kafka.common.errors.UnsupportedVersionException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -244,7 +248,7 @@ public class KafkaTopicClientImpl implements KafkaTopicClient {
     final DeleteTopicsResult deleteTopicsResult = adminClient.deleteTopics(topicsToDelete);
     final Map<String, KafkaFuture<Void>> results = deleteTopicsResult.values();
     final List<String> failList = Lists.newArrayList();
-
+    final List<Pair<String, Throwable>> exceptionList = Lists.newArrayList();
     for (final Map.Entry<String, KafkaFuture<Void>> entry : results.entrySet()) {
       try {
         entry.getValue().get(30, TimeUnit.SECONDS);
@@ -255,14 +259,17 @@ public class KafkaTopicClientImpl implements KafkaTopicClient {
           throw new TopicDeletionDisabledException("Topic deletion is disabled. "
               + "To delete the topic, you must set '" + DELETE_TOPIC_ENABLE + "' to true in "
               + "the Kafka broker configuration.");
+        } else if (!(rootCause instanceof UnknownTopicOrPartitionException)) {
+          LOG.error(String.format("Could not delete topic '%s'", entry.getKey()), e);
+          failList.add(entry.getKey());
+          exceptionList.add(new Pair<>(entry.getKey(), rootCause));
         }
-
-        LOG.error(String.format("Could not delete topic '%s'", entry.getKey()), e);
-        failList.add(entry.getKey());
       }
     }
+
     if (!failList.isEmpty()) {
-      throw new KsqlException("Failed to clean up topics: " + String.join(",", failList));
+      throw new KafkaDeleteTopicsException("Failed to clean up topics: "
+              + String.join(",", failList), exceptionList);
     }
   }
 

--- a/ksql-engine/src/main/java/io/confluent/ksql/topic/TopicDeleteInjector.java
+++ b/ksql-engine/src/main/java/io/confluent/ksql/topic/TopicDeleteInjector.java
@@ -17,7 +17,9 @@ package io.confluent.ksql.topic;
 
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.collect.ImmutableList;
+
 import io.confluent.kafka.schemaregistry.client.SchemaRegistryClient;
+import io.confluent.kafka.schemaregistry.client.rest.exceptions.RestClientException;
 import io.confluent.ksql.KsqlExecutionContext;
 import io.confluent.ksql.metastore.MetaStore;
 import io.confluent.ksql.metastore.model.DataSource;
@@ -33,6 +35,7 @@ import io.confluent.ksql.statement.Injector;
 import io.confluent.ksql.util.ExecutorUtil;
 import io.confluent.ksql.util.KsqlConstants;
 import io.confluent.ksql.util.KsqlException;
+
 import java.util.Map;
 import java.util.Objects;
 import java.util.stream.Collectors;
@@ -52,6 +55,8 @@ public class TopicDeleteInjector implements Injector {
   private final MetaStore metastore;
   private final KafkaTopicClient topicClient;
   private final SchemaRegistryClient schemaRegistryClient;
+
+  private static final int SUBJECT_NOT_FOUND_ERROR_CODE = 40401;
 
   public TopicDeleteInjector(
       final KsqlExecutionContext executionContext,
@@ -99,19 +104,18 @@ public class TopicDeleteInjector implements Injector {
             () -> topicClient.deleteTopics(ImmutableList.of(source.getKafkaTopicName())),
             ExecutorUtil.RetryBehaviour.ALWAYS);
       } catch (Exception e) {
-        throw new KsqlException("Could not delete the corresponding kafka topic: "
-            + source.getKafkaTopicName(), e);
+        throw new RuntimeException("Could not delete the corresponding kafka topic: "
+                + sourceName, e);
       }
 
-      if (source.getValueSerdeFactory().getFormat() == Format.AVRO) {
-        try {
+      try {
+        if (source.getValueSerdeFactory().getFormat() == Format.AVRO) {
           SchemaRegistryUtil.deleteSubjectWithRetries(
-              schemaRegistryClient,
-              source.getKafkaTopicName() + KsqlConstants.SCHEMA_REGISTRY_VALUE_SUFFIX);
-        } catch (final Exception e) {
-          throw new KsqlException("Could not clean up the schema registry for topic: "
-              + source.getKafkaTopicName(), e);
+                  schemaRegistryClient,
+                  source.getKafkaTopicName() + KsqlConstants.SCHEMA_REGISTRY_VALUE_SUFFIX);
         }
+      } catch (final Exception e) {
+        checkSchemaError(e, source.getKafkaTopicName());
       }
     } else if (dropStatement.getIfExists()) {
       throw new KsqlException("Could not find source to delete topic for: " + statement);
@@ -121,6 +125,14 @@ public class TopicDeleteInjector implements Injector {
     final String withoutDeleteText = SqlFormatter.formatSql(withoutDelete) + ";";
 
     return statement.withStatement(withoutDeleteText, withoutDelete);
+  }
+
+  private void checkSchemaError(final Exception error, final String sourceName) {
+    if (!(error instanceof RestClientException
+            && ((RestClientException) error).getErrorCode() == SUBJECT_NOT_FOUND_ERROR_CODE)) {
+      throw new RuntimeException("Could not clean up the schema registry for topic: "
+              + sourceName, error);
+    }
   }
 
   private void checkTopicRefs(final DataSource<?> source) {
@@ -133,7 +145,7 @@ public class TopicDeleteInjector implements Injector {
         .filter(name -> !sourceName.equals(name))
         .collect(Collectors.joining(", "));
     if (!using.isEmpty()) {
-      throw new KsqlException(
+      throw new RuntimeException(
           String.format(
               "Refusing to delete topic. Found other data sources (%s) using topic %s",
               using,


### PR DESCRIPTION
### Description 
https://github.com/confluentinc/ksql/issues/3048

Added new exception class that can store corresponding error messages that can occur while trying to delete a topic.
Wrote some helper functions in TopicDeleteInjector in order to reduce cyclomatic complexity.
### Testing done 
Unit tests
`mvn clean install`
Testing using KSQL CLI
Deleting subjects with schema registry and using kafka-topics to delete topics.

### Reviewer checklist
- [ ] Ensure docs are updated if necessary. (eg. if a user visible feature is being added or changed).
- [ ] Ensure relevant issues are linked (description should include text like "Fixes #<issue number>")

