### PR TITLE
refactor: add VisitParentExpressionVisitor

### DIFF
--- a/ksql-engine/src/main/java/io/confluent/ksql/analyzer/ExpressionAnalyzer.java
+++ b/ksql-engine/src/main/java/io/confluent/ksql/analyzer/ExpressionAnalyzer.java
@@ -16,7 +16,6 @@
 package io.confluent.ksql.analyzer;
 
 import io.confluent.ksql.parser.tree.ArithmeticBinaryExpression;
-import io.confluent.ksql.parser.tree.AstVisitor;
 import io.confluent.ksql.parser.tree.Cast;
 import io.confluent.ksql.parser.tree.ComparisonExpression;
 import io.confluent.ksql.parser.tree.DereferenceExpression;
@@ -28,6 +27,7 @@ import io.confluent.ksql.parser.tree.LikePredicate;
 import io.confluent.ksql.parser.tree.LogicalBinaryExpression;
 import io.confluent.ksql.parser.tree.NotExpression;
 import io.confluent.ksql.parser.tree.QualifiedNameReference;
+import io.confluent.ksql.parser.tree.VisitParentExpressionVisitor;
 import io.confluent.ksql.util.KsqlException;
 import io.confluent.ksql.util.SchemaUtil;
 import java.util.Objects;
@@ -67,7 +67,7 @@ class ExpressionAnalyzer {
     }
   }
 
-  private class Visitor extends AstVisitor<Object, Object> {
+  private class Visitor extends VisitParentExpressionVisitor<Object, Object> {
 
     public Object visitLikePredicate(final LikePredicate node, final Object context) {
       process(node.getValue(), null);

--- a/ksql-engine/src/main/java/io/confluent/ksql/codegen/CodeGenRunner.java
+++ b/ksql-engine/src/main/java/io/confluent/ksql/codegen/CodeGenRunner.java
@@ -21,7 +21,6 @@ import io.confluent.ksql.function.UdfFactory;
 import io.confluent.ksql.function.udf.Kudf;
 import io.confluent.ksql.parser.tree.ArithmeticBinaryExpression;
 import io.confluent.ksql.parser.tree.ArithmeticUnaryExpression;
-import io.confluent.ksql.parser.tree.AstVisitor;
 import io.confluent.ksql.parser.tree.BetweenPredicate;
 import io.confluent.ksql.parser.tree.Cast;
 import io.confluent.ksql.parser.tree.ComparisonExpression;
@@ -36,6 +35,7 @@ import io.confluent.ksql.parser.tree.NotExpression;
 import io.confluent.ksql.parser.tree.QualifiedNameReference;
 import io.confluent.ksql.parser.tree.SearchedCaseExpression;
 import io.confluent.ksql.parser.tree.SubscriptExpression;
+import io.confluent.ksql.parser.tree.VisitParentExpressionVisitor;
 import io.confluent.ksql.schema.ksql.Field;
 import io.confluent.ksql.schema.ksql.LogicalSchema;
 import io.confluent.ksql.schema.ksql.SchemaConverters;
@@ -150,7 +150,7 @@ public class CodeGenRunner {
     }
   }
 
-  private static final class Visitor extends AstVisitor<Object, Object> {
+  private static final class Visitor extends VisitParentExpressionVisitor<Object, Object> {
 
     private static final SqlToJavaTypeConverter converter = SchemaConverters.sqlToJavaConverter();
 

--- a/ksql-engine/src/main/java/io/confluent/ksql/engine/InsertValuesExecutor.java
+++ b/ksql-engine/src/main/java/io/confluent/ksql/engine/InsertValuesExecutor.java
@@ -24,12 +24,11 @@ import io.confluent.ksql.metastore.model.DataSource;
 import io.confluent.ksql.metastore.model.KeyField;
 import io.confluent.ksql.metastore.model.KsqlStream;
 import io.confluent.ksql.metastore.model.KsqlTable;
-import io.confluent.ksql.parser.tree.AstNode;
-import io.confluent.ksql.parser.tree.AstVisitor;
 import io.confluent.ksql.parser.tree.Expression;
 import io.confluent.ksql.parser.tree.InsertValues;
 import io.confluent.ksql.parser.tree.Literal;
 import io.confluent.ksql.parser.tree.NullLiteral;
+import io.confluent.ksql.parser.tree.VisitParentExpressionVisitor;
 import io.confluent.ksql.schema.ksql.DefaultSqlValueCoercer;
 import io.confluent.ksql.schema.ksql.Field;
 import io.confluent.ksql.schema.ksql.LogicalSchema;
@@ -343,7 +342,7 @@ public class InsertValuesExecutor {
     }
   }
 
-  private static class ExpressionResolver extends AstVisitor<Object, Void> {
+  private static class ExpressionResolver extends VisitParentExpressionVisitor<Object, Void> {
 
     private final SqlType fieldType;
     private final String fieldName;
@@ -355,9 +354,10 @@ public class InsertValuesExecutor {
     }
 
     @Override
-    protected String visitNode(final AstNode node, final Void context) {
+    protected String visitExpression(final Expression expression, final Void context) {
       throw new KsqlException(
-          "Only Literals are supported for INSERT INTO. Got: " + node + " for field " + fieldName);
+          "Only Literals are supported for INSERT INTO. Got: "
+              + expression + " for field " + fieldName);
     }
 
     @Override

--- a/ksql-parser/src/main/java/io/confluent/ksql/parser/tree/ExpressionTreeRewriter.java
+++ b/ksql-parser/src/main/java/io/confluent/ksql/parser/tree/ExpressionTreeRewriter.java
@@ -26,7 +26,7 @@ import java.util.stream.Collectors;
 public final class ExpressionTreeRewriter<C> {
 
   private final ExpressionRewriter<C> rewriter;
-  private final AstVisitor<Expression, Context<C>> visitor;
+  private final ExpressionVisitor<Expression, Context<C>> visitor;
 
   public static <C, T extends Expression> T rewriteWith(
       final ExpressionRewriter<C> rewriter, final T node) {
@@ -46,7 +46,7 @@ public final class ExpressionTreeRewriter<C> {
 
   // CHECKSTYLE_RULES.OFF: ClassDataAbstractionCoupling
   private class RewritingVisitor
-      extends AstVisitor<Expression, Context<C>> {
+      extends VisitParentExpressionVisitor<Expression, Context<C>> {
     // CHECKSTYLE_RULES.ON: ClassDataAbstractionCoupling
 
     @Override

--- a/ksql-parser/src/main/java/io/confluent/ksql/parser/tree/VisitParentExpressionVisitor.java
+++ b/ksql-parser/src/main/java/io/confluent/ksql/parser/tree/VisitParentExpressionVisitor.java
@@ -1,0 +1,182 @@
+/*
+ * Copyright 2019 Confluent Inc.
+ *
+ * Licensed under the Confluent Community License (the "License"); you may not use
+ * this file except in compliance with the License.  You may obtain a copy of the
+ * License at
+ *
+ * http://www.confluent.io/confluent-community-license
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package io.confluent.ksql.parser.tree;
+
+/**
+ * VisitParentExpressionVisitor is meant to be a base class for an ExpressionVisitor implementation
+ * that by default, implements each visit[NodeType] call by calling a delegate visit impl for that
+ * type's parent. This is useful for implementing visit behaviour that is common to all nodes of
+ * a given type. For example, a visitor may be interested in the recording the type of any literal,
+ * and so can provide an implementation for visitLiteral rather than implementing
+ * visitIntegerLiteral, visitBooleanLiteral, and so on.
+ *
+ * @param <R> The type of the result returned by the visitor
+ * @param <C> The type of the context object passed through calls to visit[NodeType]
+ */
+public abstract class VisitParentExpressionVisitor<R, C> implements ExpressionVisitor<R, C> {
+  protected R visitExpression(final Expression node, final C context) {
+    return null;
+  }
+
+  @Override
+  public R visitArithmeticBinary(final ArithmeticBinaryExpression node, final C context) {
+    return visitExpression(node, context);
+  }
+
+  @Override
+  public R visitBetweenPredicate(final BetweenPredicate node, final C context) {
+    return visitExpression(node, context);
+  }
+
+  @Override
+  public R visitComparisonExpression(final ComparisonExpression node, final C context) {
+    return visitExpression(node, context);
+  }
+
+  protected R visitLiteral(final Literal node, final C context) {
+    return visitExpression(node, context);
+  }
+
+  @Override
+  public R visitDoubleLiteral(final DoubleLiteral node, final C context) {
+    return visitLiteral(node, context);
+  }
+
+  @Override
+  public R visitDecimalLiteral(final DecimalLiteral node, final C context) {
+    return visitLiteral(node, context);
+  }
+
+  @Override
+  public R visitTimeLiteral(final TimeLiteral node, final C context) {
+    return visitLiteral(node, context);
+  }
+
+  @Override
+  public R visitTimestampLiteral(final TimestampLiteral node, final C context) {
+    return visitLiteral(node, context);
+  }
+
+  @Override
+  public R visitWhenClause(final WhenClause node, final C context) {
+    return visitExpression(node, context);
+  }
+
+  @Override
+  public R visitInPredicate(final InPredicate node, final C context) {
+    return visitExpression(node, context);
+  }
+
+  @Override
+  public R visitFunctionCall(final FunctionCall node, final C context) {
+    return visitExpression(node, context);
+  }
+
+  @Override
+  public R visitSimpleCaseExpression(final SimpleCaseExpression node, final C context) {
+    return visitExpression(node, context);
+  }
+
+  @Override
+  public R visitStringLiteral(final StringLiteral node, final C context) {
+    return visitLiteral(node, context);
+  }
+
+  @Override
+  public R visitBooleanLiteral(final BooleanLiteral node, final C context) {
+    return visitLiteral(node, context);
+  }
+
+  @Override
+  public R visitInListExpression(final InListExpression node, final C context) {
+    return visitExpression(node, context);
+  }
+
+  @Override
+  public R visitQualifiedNameReference(final QualifiedNameReference node, final C context) {
+    return visitExpression(node, context);
+  }
+
+  @Override
+  public R visitDereferenceExpression(final DereferenceExpression node, final C context) {
+    return visitExpression(node, context);
+  }
+
+  @Override
+  public R visitNullLiteral(final NullLiteral node, final C context) {
+    return visitLiteral(node, context);
+  }
+
+  @Override
+  public R visitArithmeticUnary(final ArithmeticUnaryExpression node, final C context) {
+    return visitExpression(node, context);
+  }
+
+  @Override
+  public R visitNotExpression(final NotExpression node, final C context) {
+    return visitExpression(node, context);
+  }
+
+  @Override
+  public R visitSearchedCaseExpression(final SearchedCaseExpression node, final C context) {
+    return visitExpression(node, context);
+  }
+
+  @Override
+  public R visitLikePredicate(final LikePredicate node, final C context) {
+    return visitExpression(node, context);
+  }
+
+  @Override
+  public R visitIsNotNullPredicate(final IsNotNullPredicate node, final C context) {
+    return visitExpression(node, context);
+  }
+
+  @Override
+  public R visitIsNullPredicate(final IsNullPredicate node, final C context) {
+    return visitExpression(node, context);
+  }
+
+  @Override
+  public R visitSubscriptExpression(final SubscriptExpression node, final C context) {
+    return visitExpression(node, context);
+  }
+
+  @Override
+  public R visitLongLiteral(final LongLiteral node, final C context) {
+    return visitLiteral(node, context);
+  }
+
+  @Override
+  public R visitIntegerLiteral(final IntegerLiteral node, final C context) {
+    return visitLiteral(node, context);
+  }
+
+  @Override
+  public R visitLogicalBinaryExpression(final LogicalBinaryExpression node, final C context) {
+    return visitExpression(node, context);
+  }
+
+  @Override
+  public R visitType(final Type node, final C context) {
+    return visitExpression(node, context);
+  }
+
+  @Override
+  public R visitCast(final Cast node, final C context) {
+    return visitExpression(node, context);
+  }
+}

--- a/ksql-parser/src/main/java/io/confluent/ksql/parser/tree/VisitParentExpressionVisitor.java
+++ b/ksql-parser/src/main/java/io/confluent/ksql/parser/tree/VisitParentExpressionVisitor.java
@@ -19,7 +19,7 @@ package io.confluent.ksql.parser.tree;
  * VisitParentExpressionVisitor is meant to be a base class for an ExpressionVisitor implementation
  * that by default, implements each visit[NodeType] call by calling a delegate visit impl for that
  * type's parent. This is useful for implementing visit behaviour that is common to all nodes of
- * a given type. For example, a visitor may be interested in the recording the type of any literal,
+ * a given type. For example, a visitor may be interested in recording the type of any literal,
  * and so can provide an implementation for visitLiteral rather than implementing
  * visitIntegerLiteral, visitBooleanLiteral, and so on.
  *


### PR DESCRIPTION
This patch adds an abstract base visitor for ExpressionVisitor, called
VisitParentExpressionVisitor, which provides a default implementation of
each visit call that just delegates to a visit to the parent type. E.g.
visitBooleanLiteral calls visitLiteral calls visitExpression. This is
basically what the existing AstVisitor does for the AST. This patch also
migrates the expression-only visitors that inherit from AstVisitor to
VisitParentExpressionVisitor

### Testing done 
Just a refactor, so no new tests.
