### PR TITLE
refactor: AggregateAnalyzer/ExpressionTypeManager impl ExpressionVisitor

### DIFF
--- a/ksql-engine/src/main/java/io/confluent/ksql/analyzer/AggregateAnalyzer.java
+++ b/ksql-engine/src/main/java/io/confluent/ksql/analyzer/AggregateAnalyzer.java
@@ -17,10 +17,10 @@ package io.confluent.ksql.analyzer;
 
 import com.google.common.collect.ImmutableList;
 import io.confluent.ksql.function.FunctionRegistry;
-import io.confluent.ksql.parser.DefaultTraversalVisitor;
 import io.confluent.ksql.parser.tree.DereferenceExpression;
 import io.confluent.ksql.parser.tree.Expression;
 import io.confluent.ksql.parser.tree.FunctionCall;
+import io.confluent.ksql.parser.tree.TraversalExpressionVisitor;
 import io.confluent.ksql.util.KsqlException;
 import java.util.HashSet;
 import java.util.Objects;
@@ -81,7 +81,7 @@ class AggregateAnalyzer {
     visitor.process(expression, null);
   }
 
-  private final class AggregateVisitor extends DefaultTraversalVisitor<Void, Void> {
+  private final class AggregateVisitor extends TraversalExpressionVisitor<Void> {
 
     private final BiConsumer<Optional<String>, DereferenceExpression> dereferenceCollector;
     private Optional<String> aggFunctionName = Optional.empty();
@@ -134,5 +134,7 @@ class AggregateAnalyzer {
       aggregateAnalysis.addRequiredColumn(node);
       return null;
     }
+
+
   }
 }

--- a/ksql-engine/src/main/java/io/confluent/ksql/util/ExpressionTypeManager.java
+++ b/ksql-engine/src/main/java/io/confluent/ksql/util/ExpressionTypeManager.java
@@ -20,27 +20,37 @@ import io.confluent.ksql.function.KsqlAggregateFunction;
 import io.confluent.ksql.function.KsqlFunctionException;
 import io.confluent.ksql.function.UdfFactory;
 import io.confluent.ksql.function.udf.structfieldextractor.FetchFieldFromStruct;
+import io.confluent.ksql.parser.VisitorUtil;
 import io.confluent.ksql.parser.tree.ArithmeticBinaryExpression;
+import io.confluent.ksql.parser.tree.ArithmeticUnaryExpression;
 import io.confluent.ksql.parser.tree.BetweenPredicate;
 import io.confluent.ksql.parser.tree.BooleanLiteral;
 import io.confluent.ksql.parser.tree.Cast;
 import io.confluent.ksql.parser.tree.ComparisonExpression;
-import io.confluent.ksql.parser.tree.DefaultAstVisitor;
+import io.confluent.ksql.parser.tree.DecimalLiteral;
 import io.confluent.ksql.parser.tree.DereferenceExpression;
 import io.confluent.ksql.parser.tree.DoubleLiteral;
 import io.confluent.ksql.parser.tree.Expression;
+import io.confluent.ksql.parser.tree.ExpressionVisitor;
 import io.confluent.ksql.parser.tree.FunctionCall;
+import io.confluent.ksql.parser.tree.InListExpression;
+import io.confluent.ksql.parser.tree.InPredicate;
 import io.confluent.ksql.parser.tree.IntegerLiteral;
 import io.confluent.ksql.parser.tree.IsNotNullPredicate;
 import io.confluent.ksql.parser.tree.IsNullPredicate;
 import io.confluent.ksql.parser.tree.LikePredicate;
+import io.confluent.ksql.parser.tree.LogicalBinaryExpression;
 import io.confluent.ksql.parser.tree.LongLiteral;
 import io.confluent.ksql.parser.tree.NotExpression;
 import io.confluent.ksql.parser.tree.NullLiteral;
 import io.confluent.ksql.parser.tree.QualifiedNameReference;
 import io.confluent.ksql.parser.tree.SearchedCaseExpression;
+import io.confluent.ksql.parser.tree.SimpleCaseExpression;
 import io.confluent.ksql.parser.tree.StringLiteral;
 import io.confluent.ksql.parser.tree.SubscriptExpression;
+import io.confluent.ksql.parser.tree.TimeLiteral;
+import io.confluent.ksql.parser.tree.TimestampLiteral;
+import io.confluent.ksql.parser.tree.Type;
 import io.confluent.ksql.parser.tree.WhenClause;
 import io.confluent.ksql.schema.Operator;
 import io.confluent.ksql.schema.ksql.Field;
@@ -53,8 +63,7 @@ import java.util.List;
 import java.util.Objects;
 import org.apache.kafka.connect.data.Schema;
 
-public class ExpressionTypeManager
-    extends DefaultAstVisitor<Expression, ExpressionTypeManager.ExpressionTypeContext> {
+public class ExpressionTypeManager {
 
   private static final SqlToConnectTypeConverter SQL_TO_CONNECT_SCHEMA_CONVERTER =
       SchemaConverters.sqlToConnectConverter();
@@ -72,12 +81,11 @@ public class ExpressionTypeManager
 
   public Schema getExpressionSchema(final Expression expression) {
     final ExpressionTypeContext expressionTypeContext = new ExpressionTypeContext();
-    process(expression, expressionTypeContext);
+    new Visitor().process(expression, expressionTypeContext);
     return expressionTypeContext.getSchema();
   }
 
   static class ExpressionTypeContext {
-
     private Schema schema;
 
     public Schema getSchema() {
@@ -89,251 +97,337 @@ public class ExpressionTypeManager
     }
   }
 
-  // TODO(rohan): make the below an internal class
-  @Override
-  public Expression visitArithmeticBinary(final ArithmeticBinaryExpression node,
-      final ExpressionTypeContext expressionTypeContext) {
-    process(node.getLeft(), expressionTypeContext);
-    final Schema leftType = expressionTypeContext.getSchema();
-    process(node.getRight(), expressionTypeContext);
-    final Schema rightType = expressionTypeContext.getSchema();
-    expressionTypeContext.setSchema(resolveArithmeticType(leftType, rightType, node.getOperator()));
-    return null;
-  }
-
-  @Override
-  public Expression visitNotExpression(
-      final NotExpression node, final ExpressionTypeContext expressionTypeContext) {
-    expressionTypeContext.setSchema(Schema.OPTIONAL_BOOLEAN_SCHEMA);
-    return null;
-  }
-
-  @Override
-  public Expression visitCast(
-      final Cast node,
-      final ExpressionTypeContext expressionTypeContext
-  ) {
-    final SqlType sqlType = node.getType().getSqlType();
-    if (!sqlType.supportsCast()) {
-      throw new KsqlFunctionException("Only casts to primitive types or decimals "
-          + "are supported: " + sqlType);
-    }
-
-    final Schema castType = SchemaConverters
-        .sqlToConnectConverter()
-        .toConnectSchema(sqlType);
-
-    expressionTypeContext.setSchema(castType);
-    return null;
-  }
-
-  @Override
-  public Expression visitComparisonExpression(
-      final ComparisonExpression node, final ExpressionTypeContext expressionTypeContext) {
-    process(node.getLeft(), expressionTypeContext);
-    final Schema leftSchema = expressionTypeContext.getSchema();
-    process(node.getRight(), expressionTypeContext);
-    final Schema rightSchema = expressionTypeContext.getSchema();
-    ComparisonUtil.isValidComparison(leftSchema, node.getType(), rightSchema);
-    expressionTypeContext.setSchema(Schema.OPTIONAL_BOOLEAN_SCHEMA);
-    return null;
-  }
-
-  @Override
-  public Expression visitBetweenPredicate(final BetweenPredicate node,
-      final ExpressionTypeContext context) {
-    context.setSchema(Schema.OPTIONAL_BOOLEAN_SCHEMA);
-    return null;
-  }
-
-  @Override
-  public Expression visitQualifiedNameReference(
-      final QualifiedNameReference node,
-      final ExpressionTypeContext expressionTypeContext
-  ) {
-    final Field schemaField = schema.findValueField(node.getName().getSuffix())
-        .orElseThrow(() ->
-            new KsqlException(String.format("Invalid Expression %s.", node.toString())));
-
-    final Schema schema = SQL_TO_CONNECT_SCHEMA_CONVERTER.toConnectSchema(schemaField.type());
-    expressionTypeContext.setSchema(schema);
-    return null;
-  }
-
-  @Override
-  public Expression visitDereferenceExpression(
-      final DereferenceExpression node,
-      final ExpressionTypeContext expressionTypeContext
-  ) {
-    final Field schemaField = schema.findValueField(node.toString())
-        .orElseThrow(() ->
-            new KsqlException(String.format("Invalid Expression %s.", node.toString())));
-
-    final Schema schema = SQL_TO_CONNECT_SCHEMA_CONVERTER.toConnectSchema(schemaField.type());
-    expressionTypeContext.setSchema(schema);
-    return null;
-  }
-
-  @Override
-  public Expression visitStringLiteral(final StringLiteral node,
-      final ExpressionTypeContext expressionTypeContext) {
-    expressionTypeContext.setSchema(Schema.OPTIONAL_STRING_SCHEMA);
-    return null;
-  }
-
-  @Override
-  public Expression visitBooleanLiteral(final BooleanLiteral node,
-      final ExpressionTypeContext expressionTypeContext) {
-    expressionTypeContext.setSchema(Schema.OPTIONAL_BOOLEAN_SCHEMA);
-    return null;
-  }
-
-  @Override
-  public Expression visitLongLiteral(final LongLiteral node,
-      final ExpressionTypeContext expressionTypeContext) {
-    expressionTypeContext.setSchema(Schema.OPTIONAL_INT64_SCHEMA);
-    return null;
-  }
-
-  @Override
-  public Expression visitIntegerLiteral(final IntegerLiteral node,
-      final ExpressionTypeContext expressionTypeContext) {
-    expressionTypeContext.setSchema(Schema.OPTIONAL_INT32_SCHEMA);
-    return null;
-  }
-
-  @Override
-  public Expression visitDoubleLiteral(final DoubleLiteral node,
-      final ExpressionTypeContext expressionTypeContext) {
-    expressionTypeContext.setSchema(Schema.OPTIONAL_FLOAT64_SCHEMA);
-    return null;
-  }
-
-  @Override
-  public Expression visitNullLiteral(final NullLiteral node,
-      final ExpressionTypeContext context) {
-    context.setSchema(null);
-    return null;
-  }
-
-  @Override
-  public Expression visitLikePredicate(final LikePredicate node,
-      final ExpressionTypeContext expressionTypeContext) {
-    expressionTypeContext.setSchema(Schema.OPTIONAL_BOOLEAN_SCHEMA);
-    return null;
-  }
-
-  @Override
-  public Expression visitIsNotNullPredicate(final IsNotNullPredicate node,
-      final ExpressionTypeContext expressionTypeContext) {
-    expressionTypeContext.setSchema(Schema.OPTIONAL_BOOLEAN_SCHEMA);
-    return null;
-  }
-
-  @Override
-  public Expression visitIsNullPredicate(final IsNullPredicate node,
-      final ExpressionTypeContext expressionTypeContext) {
-    expressionTypeContext.setSchema(Schema.OPTIONAL_BOOLEAN_SCHEMA);
-    return null;
-  }
-
-  @Override
-  public Expression visitSearchedCaseExpression(
-      final SearchedCaseExpression node,
-      final ExpressionTypeContext expressionTypeContext) {
-    validateSearchedCaseExpression(node);
-    process(node.getWhenClauses().get(0).getResult(), expressionTypeContext);
-    return null;
-  }
-
-  @Override
-  public Expression visitSubscriptExpression(
-      final SubscriptExpression node,
-      final ExpressionTypeContext expressionTypeContext
-  ) {
-    process(node.getBase(), expressionTypeContext);
-    final Schema arrayMapSchema = expressionTypeContext.getSchema();
-    expressionTypeContext.setSchema(arrayMapSchema.valueSchema());
-    return null;
-  }
-
-  @Override
-  public Expression visitFunctionCall(
-      final FunctionCall node,
-      final ExpressionTypeContext expressionTypeContext) {
-
-    if (functionRegistry.isAggregate(node.getName().getSuffix())) {
-      final Schema schema = node.getArguments().isEmpty()
-          ? FunctionRegistry.DEFAULT_FUNCTION_ARG_SCHEMA
-          : getExpressionSchema(node.getArguments().get(0));
-
-      final KsqlAggregateFunction aggFunc = functionRegistry
-          .getAggregate(node.getName().getSuffix(), schema);
-
-      expressionTypeContext.setSchema(aggFunc.getReturnType());
+  private class Visitor implements ExpressionVisitor<Void, ExpressionTypeContext> {
+    @Override
+    public Void visitArithmeticBinary(final ArithmeticBinaryExpression node,
+        final ExpressionTypeContext expressionTypeContext) {
+      process(node.getLeft(), expressionTypeContext);
+      final Schema leftType = expressionTypeContext.getSchema();
+      process(node.getRight(), expressionTypeContext);
+      final Schema rightType = expressionTypeContext.getSchema();
+      expressionTypeContext
+          .setSchema(resolveArithmeticType(leftType, rightType, node.getOperator()));
       return null;
     }
-    if (node.getName().getSuffix().equalsIgnoreCase(FetchFieldFromStruct.FUNCTION_NAME)) {
-      process(node.getArguments().get(0), expressionTypeContext);
-      final Schema firstArgSchema = expressionTypeContext.getSchema();
-      final String fieldName = ((StringLiteral) node.getArguments().get(1)).getValue();
-      if (firstArgSchema.field(fieldName) == null) {
-        throw new KsqlException(String.format("Could not find field %s in %s.",
-            fieldName,
-            node.getArguments().get(0).toString()));
-      }
-      final Schema returnSchema = firstArgSchema.field(fieldName).schema();
-      expressionTypeContext.setSchema(returnSchema);
-    } else {
-      final UdfFactory udfFactory = functionRegistry.getUdfFactory(node.getName().getSuffix());
-      final List<Schema> argTypes = new ArrayList<>();
-      for (final Expression expression : node.getArguments()) {
-        process(expression, expressionTypeContext);
-        argTypes.add(expressionTypeContext.getSchema());
-      }
-      final Schema returnType = udfFactory.getFunction(argTypes)
-          .getReturnType(argTypes);
-      expressionTypeContext.setSchema(returnType);
+
+    @Override
+    public Void visitArithmeticUnary(
+        final ArithmeticUnaryExpression node,
+        final ExpressionTypeContext context
+    ) {
+      process(node.getValue(), context);
+      return null;
     }
-    return null;
-  }
 
-  private static Schema resolveArithmeticType(
-      final Schema leftSchema,
-      final Schema rightSchema,
-      final Operator operator) {
-    return SchemaUtil.resolveBinaryOperatorResultType(leftSchema, rightSchema, operator);
-  }
-
-  private void validateSearchedCaseExpression(final SearchedCaseExpression searchedCaseExpression) {
-    final Schema firstResultSchema = getExpressionSchema(
-        searchedCaseExpression.getWhenClauses().get(0).getResult());
-    searchedCaseExpression.getWhenClauses()
-        .forEach(whenClause -> validateWhenClause(whenClause, firstResultSchema));
-    searchedCaseExpression.getDefaultValue()
-        .map(this::getExpressionSchema)
-        .filter(defaultSchema -> !firstResultSchema.equals(defaultSchema))
-        .ifPresent(badSchema -> {
-          throw new KsqlException("Invalid Case expression."
-              + " Schema for the default clause should be the same as schema for THEN clauses."
-              + " Result scheme: " + firstResultSchema + "."
-              + " Schema for default expression is " + badSchema);
-        });
-  }
-
-  private void validateWhenClause(final WhenClause whenClause, final Schema expectedResultSchema) {
-    final Schema operandSchema = getExpressionSchema(whenClause.getOperand());
-    if (!operandSchema.equals(Schema.OPTIONAL_BOOLEAN_SCHEMA)) {
-      throw new KsqlException("When operand schema should be boolean. Schema for ("
-          + whenClause.getOperand() + ") is " + operandSchema);
+    @Override
+    public Void visitNotExpression(
+        final NotExpression node, final ExpressionTypeContext expressionTypeContext) {
+      expressionTypeContext.setSchema(Schema.OPTIONAL_BOOLEAN_SCHEMA);
+      return null;
     }
-    final Schema resultSchema = getExpressionSchema(whenClause.getResult());
-    if (!expectedResultSchema.equals(resultSchema)) {
-      throw new KsqlException("Invalid Case expression."
-          + " Schemas for 'THEN' clauses should be the same."
-          + " Result schema: " + expectedResultSchema + "."
-          + " Schema for THEN expression '" + whenClause + "'"
-          + " is " + resultSchema);
+
+    @Override
+    public Void visitCast(
+        final Cast node,
+        final ExpressionTypeContext expressionTypeContext
+    ) {
+      final SqlType sqlType = node.getType().getSqlType();
+      if (!sqlType.supportsCast()) {
+        throw new KsqlFunctionException("Only casts to primitive types or decimals "
+            + "are supported: " + sqlType);
+      }
+
+      final Schema castType = SchemaConverters
+          .sqlToConnectConverter()
+          .toConnectSchema(sqlType);
+
+      expressionTypeContext.setSchema(castType);
+      return null;
+    }
+
+    @Override
+    public Void visitComparisonExpression(
+        final ComparisonExpression node, final ExpressionTypeContext expressionTypeContext) {
+      process(node.getLeft(), expressionTypeContext);
+      final Schema leftSchema = expressionTypeContext.getSchema();
+      process(node.getRight(), expressionTypeContext);
+      final Schema rightSchema = expressionTypeContext.getSchema();
+      ComparisonUtil.isValidComparison(leftSchema, node.getType(), rightSchema);
+      expressionTypeContext.setSchema(Schema.OPTIONAL_BOOLEAN_SCHEMA);
+      return null;
+    }
+
+    @Override
+    public Void visitBetweenPredicate(final BetweenPredicate node,
+        final ExpressionTypeContext context) {
+      context.setSchema(Schema.OPTIONAL_BOOLEAN_SCHEMA);
+      return null;
+    }
+
+    @Override
+    public Void visitQualifiedNameReference(
+        final QualifiedNameReference node,
+        final ExpressionTypeContext expressionTypeContext
+    ) {
+      final Field schemaField = schema.findValueField(node.getName().getSuffix())
+          .orElseThrow(() ->
+              new KsqlException(String.format("Invalid Expression %s.", node.toString())));
+
+      final Schema schema = SQL_TO_CONNECT_SCHEMA_CONVERTER.toConnectSchema(schemaField.type());
+      expressionTypeContext.setSchema(schema);
+      return null;
+    }
+
+    @Override
+    public Void visitDereferenceExpression(
+        final DereferenceExpression node,
+        final ExpressionTypeContext expressionTypeContext
+    ) {
+      final Field schemaField = schema.findValueField(node.toString())
+          .orElseThrow(() ->
+              new KsqlException(String.format("Invalid Expression %s.", node.toString())));
+
+      final Schema schema = SQL_TO_CONNECT_SCHEMA_CONVERTER.toConnectSchema(schemaField.type());
+      expressionTypeContext.setSchema(schema);
+      return null;
+    }
+
+    @Override
+    public Void visitStringLiteral(final StringLiteral node,
+        final ExpressionTypeContext expressionTypeContext) {
+      expressionTypeContext.setSchema(Schema.OPTIONAL_STRING_SCHEMA);
+      return null;
+    }
+
+    @Override
+    public Void visitBooleanLiteral(final BooleanLiteral node,
+        final ExpressionTypeContext expressionTypeContext) {
+      expressionTypeContext.setSchema(Schema.OPTIONAL_BOOLEAN_SCHEMA);
+      return null;
+    }
+
+    @Override
+    public Void visitLongLiteral(final LongLiteral node,
+        final ExpressionTypeContext expressionTypeContext) {
+      expressionTypeContext.setSchema(Schema.OPTIONAL_INT64_SCHEMA);
+      return null;
+    }
+
+    @Override
+    public Void visitIntegerLiteral(final IntegerLiteral node,
+        final ExpressionTypeContext expressionTypeContext) {
+      expressionTypeContext.setSchema(Schema.OPTIONAL_INT32_SCHEMA);
+      return null;
+    }
+
+    @Override
+    public Void visitDoubleLiteral(final DoubleLiteral node,
+        final ExpressionTypeContext expressionTypeContext) {
+      expressionTypeContext.setSchema(Schema.OPTIONAL_FLOAT64_SCHEMA);
+      return null;
+    }
+
+    @Override
+    public Void visitNullLiteral(final NullLiteral node,
+        final ExpressionTypeContext context) {
+      context.setSchema(null);
+      return null;
+    }
+
+    @Override
+    public Void visitLikePredicate(final LikePredicate node,
+        final ExpressionTypeContext expressionTypeContext) {
+      expressionTypeContext.setSchema(Schema.OPTIONAL_BOOLEAN_SCHEMA);
+      return null;
+    }
+
+    @Override
+    public Void visitIsNotNullPredicate(final IsNotNullPredicate node,
+        final ExpressionTypeContext expressionTypeContext) {
+      expressionTypeContext.setSchema(Schema.OPTIONAL_BOOLEAN_SCHEMA);
+      return null;
+    }
+
+    @Override
+    public Void visitIsNullPredicate(final IsNullPredicate node,
+        final ExpressionTypeContext expressionTypeContext) {
+      expressionTypeContext.setSchema(Schema.OPTIONAL_BOOLEAN_SCHEMA);
+      return null;
+    }
+
+    @Override
+    public Void visitSearchedCaseExpression(
+        final SearchedCaseExpression node,
+        final ExpressionTypeContext expressionTypeContext) {
+      validateSearchedCaseExpression(node);
+      process(node.getWhenClauses().get(0).getResult(), expressionTypeContext);
+      return null;
+    }
+
+    @Override
+    public Void visitSubscriptExpression(
+        final SubscriptExpression node,
+        final ExpressionTypeContext expressionTypeContext
+    ) {
+      process(node.getBase(), expressionTypeContext);
+      final Schema arrayMapSchema = expressionTypeContext.getSchema();
+      expressionTypeContext.setSchema(arrayMapSchema.valueSchema());
+      return null;
+    }
+
+    @Override
+    public Void visitFunctionCall(
+        final FunctionCall node,
+        final ExpressionTypeContext expressionTypeContext) {
+
+      if (functionRegistry.isAggregate(node.getName().getSuffix())) {
+        final Schema schema = node.getArguments().isEmpty()
+            ? FunctionRegistry.DEFAULT_FUNCTION_ARG_SCHEMA
+            : getExpressionSchema(node.getArguments().get(0));
+
+        final KsqlAggregateFunction aggFunc = functionRegistry
+            .getAggregate(node.getName().getSuffix(), schema);
+
+        expressionTypeContext.setSchema(aggFunc.getReturnType());
+        return null;
+      }
+      if (node.getName().getSuffix().equalsIgnoreCase(FetchFieldFromStruct.FUNCTION_NAME)) {
+        process(node.getArguments().get(0), expressionTypeContext);
+        final Schema firstArgSchema = expressionTypeContext.getSchema();
+        final String fieldName = ((StringLiteral) node.getArguments().get(1)).getValue();
+        if (firstArgSchema.field(fieldName) == null) {
+          throw new KsqlException(String.format("Could not find field %s in %s.",
+              fieldName,
+              node.getArguments().get(0).toString()));
+        }
+        final Schema returnSchema = firstArgSchema.field(fieldName).schema();
+        expressionTypeContext.setSchema(returnSchema);
+      } else {
+        final UdfFactory udfFactory = functionRegistry.getUdfFactory(node.getName().getSuffix());
+        final List<Schema> argTypes = new ArrayList<>();
+        for (final Expression expression : node.getArguments()) {
+          process(expression, expressionTypeContext);
+          argTypes.add(expressionTypeContext.getSchema());
+        }
+        final Schema returnType = udfFactory.getFunction(argTypes)
+            .getReturnType(argTypes);
+        expressionTypeContext.setSchema(returnType);
+      }
+      return null;
+    }
+
+    @Override
+    public Void visitLogicalBinaryExpression(
+        final LogicalBinaryExpression node,
+        final ExpressionTypeContext context) {
+      process(node.getLeft(), context);
+      process(node.getRight(), context);
+      return null;
+    }
+
+    @Override
+    public Void visitType(
+        final Type type,
+        final ExpressionTypeContext expressionTypeContext
+    ) {
+      throw VisitorUtil.illegalState(this, type);
+    }
+
+    @Override
+    public Void visitTimeLiteral(
+        final TimeLiteral timeLiteral,
+        final ExpressionTypeContext expressionTypeContext
+    ) {
+      throw VisitorUtil.unsupportedOperation(this, timeLiteral);
+    }
+
+    @Override
+    public Void visitTimestampLiteral(
+        final TimestampLiteral timestampLiteral,
+        final ExpressionTypeContext expressionTypeContext
+    ) {
+      throw VisitorUtil.unsupportedOperation(this, timestampLiteral);
+    }
+
+    @Override
+    public Void visitDecimalLiteral(
+        final DecimalLiteral decimalLiteral,
+        final ExpressionTypeContext expressionTypeContext
+    ) {
+      throw VisitorUtil.unsupportedOperation(this, decimalLiteral);
+    }
+
+    @Override
+    public Void visitSimpleCaseExpression(
+        final SimpleCaseExpression simpleCaseExpression,
+        final ExpressionTypeContext expressionTypeContext
+    ) {
+      throw VisitorUtil.unsupportedOperation(this, simpleCaseExpression);
+    }
+
+    @Override
+    public Void visitInListExpression(
+        final InListExpression inListExpression,
+        final ExpressionTypeContext expressionTypeContext
+    ) {
+      throw VisitorUtil.unsupportedOperation(this, inListExpression);
+    }
+
+    @Override
+    public Void visitInPredicate(
+        final InPredicate inPredicate,
+        final ExpressionTypeContext expressionTypeContext
+    ) {
+      throw VisitorUtil.unsupportedOperation(this, inPredicate);
+    }
+
+    @Override
+    public Void visitWhenClause(
+        final WhenClause whenClause,
+        final ExpressionTypeContext expressionTypeContext
+    ) {
+      throw VisitorUtil.illegalState(this, whenClause);
+    }
+
+    private Schema resolveArithmeticType(
+        final Schema leftSchema,
+        final Schema rightSchema,
+        final Operator operator) {
+      return SchemaUtil.resolveBinaryOperatorResultType(leftSchema, rightSchema, operator);
+    }
+
+    private void validateSearchedCaseExpression(
+        final SearchedCaseExpression searchedCaseExpression) {
+      final Schema firstResultSchema = getExpressionSchema(
+          searchedCaseExpression.getWhenClauses().get(0).getResult());
+      searchedCaseExpression.getWhenClauses()
+          .forEach(whenClause -> validateWhenClause(whenClause, firstResultSchema));
+      searchedCaseExpression.getDefaultValue()
+          .map(ExpressionTypeManager.this::getExpressionSchema)
+          .filter(defaultSchema -> !firstResultSchema.equals(defaultSchema))
+          .ifPresent(badSchema -> {
+            throw new KsqlException("Invalid Case expression."
+                + " Schema for the default clause should be the same as schema for THEN clauses."
+                + " Result scheme: " + firstResultSchema + "."
+                + " Schema for default expression is " + badSchema);
+          });
+    }
+
+    private void validateWhenClause(final WhenClause whenClause,
+        final Schema expectedResultSchema) {
+      final Schema operandSchema = getExpressionSchema(whenClause.getOperand());
+      if (!operandSchema.equals(Schema.OPTIONAL_BOOLEAN_SCHEMA)) {
+        throw new KsqlException("When operand schema should be boolean. Schema for ("
+            + whenClause.getOperand() + ") is " + operandSchema);
+      }
+      final Schema resultSchema = getExpressionSchema(whenClause.getResult());
+      if (!expectedResultSchema.equals(resultSchema)) {
+        throw new KsqlException("Invalid Case expression."
+            + " Schemas for 'THEN' clauses should be the same."
+            + " Result schema: " + expectedResultSchema + "."
+            + " Schema for THEN expression '" + whenClause + "'"
+            + " is " + resultSchema);
+      }
     }
   }
 }

--- a/ksql-engine/src/test/java/io/confluent/ksql/testutils/ExpressionParseTestUtil.java
+++ b/ksql-engine/src/test/java/io/confluent/ksql/testutils/ExpressionParseTestUtil.java
@@ -1,0 +1,25 @@
+package io.confluent.ksql.testutils;
+
+import io.confluent.ksql.metastore.MetaStore;
+import io.confluent.ksql.parser.DefaultKsqlParser;
+import io.confluent.ksql.parser.KsqlParser;
+import io.confluent.ksql.parser.KsqlParser.ParsedStatement;
+import io.confluent.ksql.parser.KsqlParser.PreparedStatement;
+import io.confluent.ksql.parser.tree.Expression;
+import io.confluent.ksql.parser.tree.Query;
+import io.confluent.ksql.parser.tree.SingleColumn;
+
+public final class ExpressionParseTestUtil {
+  public static Expression parseExpression(final String asText, final MetaStore metaStore) {
+    final KsqlParser parser = new DefaultKsqlParser();
+    final String ksql = String.format("SELECT %s FROM test1;", asText);
+
+    final ParsedStatement parsedStatement = parser.parse(ksql).get(0);
+    final PreparedStatement preparedStatement = parser.prepare(parsedStatement, metaStore);
+    final SingleColumn singleColumn = (SingleColumn) ((Query)preparedStatement.getStatement())
+        .getSelect()
+        .getSelectItems()
+        .get(0);
+    return singleColumn.getExpression();
+  }
+}

--- a/ksql-engine/src/test/java/io/confluent/ksql/util/ExpressionTypeManagerTest.java
+++ b/ksql-engine/src/test/java/io/confluent/ksql/util/ExpressionTypeManagerTest.java
@@ -23,9 +23,11 @@ import io.confluent.ksql.analyzer.Analysis;
 import io.confluent.ksql.function.FunctionRegistry;
 import io.confluent.ksql.function.TestFunctionRegistry;
 import io.confluent.ksql.metastore.MetaStore;
+import io.confluent.ksql.parser.tree.Expression;
 import io.confluent.ksql.schema.ksql.LogicalSchema;
 import io.confluent.ksql.schema.ksql.SchemaConverters;
 import io.confluent.ksql.schema.ksql.types.SqlType;
+import io.confluent.ksql.testutils.ExpressionParseTestUtil;
 import org.apache.kafka.connect.data.Schema;
 import org.apache.kafka.connect.data.SchemaBuilder;
 import org.junit.Assert;
@@ -129,7 +131,6 @@ public class ExpressionTypeManagerTest {
 
     // When:
     expressionTypeManager.getExpressionSchema(analysis.getSelectExpressions().get(0));
-
   }
 
   @Test
@@ -321,6 +322,64 @@ public class ExpressionTypeManagerTest {
 
     // When:
     ordersExpressionTypeManager.getExpressionSchema(analysis.getSelectExpressions().get(0));
+  }
 
+  @Test
+  public void shouldThrowOnTimeLiteral() {
+    final Expression expression = ExpressionParseTestUtil.parseExpression(
+        "TIME '00:00:00'",
+        metaStore
+    );
+
+    // Then:
+    expectedException.expect(UnsupportedOperationException.class);
+
+    // When:
+    ordersExpressionTypeManager.getExpressionSchema(expression);
+  }
+
+  @Test
+  public void shouldThrowOnTimestampLiteral() {
+    final Expression expression = ExpressionParseTestUtil.parseExpression(
+        "TIMESTAMP '00:00:00'",
+        metaStore
+    );
+
+    // Then:
+    expectedException.expect(UnsupportedOperationException.class);
+
+    // When:
+    ordersExpressionTypeManager.getExpressionSchema(expression);
+  }
+
+  @Test
+  public void shouldThrowOnIn() {
+    final Expression expression = ExpressionParseTestUtil.parseExpression(
+        "orderunits IN (1,2,3)",
+        metaStore
+    );
+
+    // Then:
+    expectedException.expect(UnsupportedOperationException.class);
+
+    // When:
+    ordersExpressionTypeManager.getExpressionSchema(expression);
+  }
+
+  @Test
+  public void shouldThrowOnSimpleCase() {
+    final Expression expression = ExpressionParseTestUtil.parseExpression(
+        "CASE orderunits "
+            + "WHEN 10 THEN 'ten' "
+            + "WHEN 100 THEN 'one hundred' "
+            + "END",
+        metaStore
+    );
+
+    // Then:
+    expectedException.expect(UnsupportedOperationException.class);
+
+    // When:
+    ordersExpressionTypeManager.getExpressionSchema(expression);
   }
 }

--- a/ksql-parser/src/main/java/io/confluent/ksql/parser/VisitorUtil.java
+++ b/ksql-parser/src/main/java/io/confluent/ksql/parser/VisitorUtil.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright 2019 Confluent Inc.
+ *
+ * Licensed under the Confluent Community License (the "License"); you may not use
+ * this file except in compliance with the License.  You may obtain a copy of the
+ * License at
+ *
+ * http://www.confluent.io/confluent-community-license
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package io.confluent.ksql.parser;
+
+public final class VisitorUtil {
+  private VisitorUtil() {
+  }
+
+  public static RuntimeException unsupportedOperation(
+      final Object visitor,
+      final Object obj) {
+    return new UnsupportedOperationException(
+        String.format(
+            "not yet implemented: %s.visit%s",
+            visitor.getClass().getName(),
+            obj.getClass().getSimpleName()
+        )
+    );
+  }
+
+  public static RuntimeException illegalState(
+      final Object visitor,
+      final Object obj) {
+    return new IllegalStateException(
+        String.format(
+            "Type %s should never be visited by %s",
+            obj.getClass(),
+            visitor.getClass()));
+  }
+}

--- a/ksql-parser/src/main/java/io/confluent/ksql/parser/tree/ExpressionVisitor.java
+++ b/ksql-parser/src/main/java/io/confluent/ksql/parser/tree/ExpressionVisitor.java
@@ -79,4 +79,5 @@ public interface ExpressionVisitor<R, C> {
   R visitType(Type exp, @Nullable C context);
 
   R visitWhenClause(WhenClause exp, @Nullable C context);
+
 }

--- a/ksql-parser/src/main/java/io/confluent/ksql/parser/tree/TraversalExpressionVisitor.java
+++ b/ksql-parser/src/main/java/io/confluent/ksql/parser/tree/TraversalExpressionVisitor.java
@@ -1,0 +1,204 @@
+/*
+ * Copyright 2019 Confluent Inc.
+ *
+ * Licensed under the Confluent Community License (the "License"); you may not use
+ * this file except in compliance with the License.  You may obtain a copy of the
+ * License at
+ *
+ * http://www.confluent.io/confluent-community-license
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package io.confluent.ksql.parser.tree;
+
+/**
+ * TraversalExpressionVisitor provides an abstract base class for implementations of
+ * ExpressionVisitor, which by default traverses the expression tree.
+ *
+ * @param <C> The type of the context object passed through the visitor.
+ */
+public abstract class TraversalExpressionVisitor<C> implements ExpressionVisitor<Void, C> {
+  @Override
+  public Void visitCast(final Cast node, final C context) {
+    return process(node.getExpression(), context);
+  }
+
+  @Override
+  public Void visitArithmeticBinary(final ArithmeticBinaryExpression node, final C context) {
+    process(node.getLeft(), context);
+    process(node.getRight(), context);
+    return null;
+  }
+
+  @Override
+  public Void visitBetweenPredicate(final BetweenPredicate node, final C context) {
+    process(node.getValue(), context);
+    process(node.getMin(), context);
+    process(node.getMax(), context);
+    return null;
+  }
+
+  @Override
+  public Void visitSubscriptExpression(final SubscriptExpression node, final C context) {
+    process(node.getBase(), context);
+    process(node.getIndex(), context);
+    return null;
+  }
+
+  @Override
+  public Void visitComparisonExpression(final ComparisonExpression node, final C context) {
+    process(node.getLeft(), context);
+    process(node.getRight(), context);
+    return null;
+  }
+
+  @Override
+  public Void visitWhenClause(final WhenClause node, final C context) {
+    process(node.getOperand(), context);
+    process(node.getResult(), context);
+    return null;
+  }
+
+  @Override
+  public Void visitInPredicate(final InPredicate node, final C context) {
+    process(node.getValue(), context);
+    process(node.getValueList(), context);
+    return null;
+  }
+
+  @Override
+  public Void visitFunctionCall(final FunctionCall node, final C context) {
+    for (final Expression argument : node.getArguments()) {
+      process(argument, context);
+    }
+    return null;
+  }
+
+  @Override
+  public Void visitDereferenceExpression(final DereferenceExpression node, final C context) {
+    process(node.getBase(), context);
+    return null;
+  }
+
+  @Override
+  public Void visitSimpleCaseExpression(final SimpleCaseExpression node, final C context) {
+    process(node.getOperand(), context);
+    for (final WhenClause clause : node.getWhenClauses()) {
+      process(clause, context);
+    }
+    node.getDefaultValue()
+        .ifPresent(value -> process(value, context));
+    return null;
+  }
+
+  @Override
+  public Void visitInListExpression(final InListExpression node, final C context) {
+    for (final Expression value : node.getValues()) {
+      process(value, context);
+    }
+    return null;
+  }
+
+  @Override
+  public Void visitArithmeticUnary(final ArithmeticUnaryExpression node, final C context) {
+    return process(node.getValue(), context);
+  }
+
+  @Override
+  public Void visitNotExpression(final NotExpression node, final C context) {
+    return process(node.getValue(), context);
+  }
+
+  @Override
+  public Void visitSearchedCaseExpression(final SearchedCaseExpression node, final C context) {
+    for (final WhenClause clause : node.getWhenClauses()) {
+      process(clause, context);
+    }
+    node.getDefaultValue()
+        .ifPresent(value -> process(value, context));
+    return null;
+  }
+
+  @Override
+  public Void visitLikePredicate(final LikePredicate node, final C context) {
+    process(node.getValue(), context);
+    process(node.getPattern(), context);
+    return null;
+  }
+
+  @Override
+  public Void visitIsNotNullPredicate(final IsNotNullPredicate node, final C context) {
+    return process(node.getValue(), context);
+  }
+
+  @Override
+  public Void visitIsNullPredicate(final IsNullPredicate node, final C context) {
+    return process(node.getValue(), context);
+  }
+
+  @Override
+  public Void visitLogicalBinaryExpression(final LogicalBinaryExpression node, final C context) {
+    process(node.getLeft(), context);
+    process(node.getRight(), context);
+    return null;
+  }
+
+  @Override
+  public Void visitDoubleLiteral(final DoubleLiteral node, final C context) {
+    return null;
+  }
+
+  @Override
+  public Void visitDecimalLiteral(final DecimalLiteral node, final C context) {
+    return null;
+  }
+
+  @Override
+  public Void visitTimeLiteral(final TimeLiteral node, final C context) {
+    return null;
+  }
+
+  @Override
+  public Void visitTimestampLiteral(final TimestampLiteral node, final C context) {
+    return null;
+  }
+
+  @Override
+  public Void visitStringLiteral(final StringLiteral node, final C context) {
+    return null;
+  }
+
+  @Override
+  public Void visitBooleanLiteral(final BooleanLiteral node, final C context) {
+    return null;
+  }
+
+  @Override
+  public Void visitQualifiedNameReference(final QualifiedNameReference node, final C context) {
+    return null;
+  }
+
+  @Override
+  public Void visitNullLiteral(final NullLiteral node, final C context) {
+    return null;
+  }
+
+  @Override
+  public Void visitLongLiteral(final LongLiteral node, final C context) {
+    return null;
+  }
+
+  @Override
+  public Void visitIntegerLiteral(final IntegerLiteral node, final C context) {
+    return null;
+  }
+
+  @Override
+  public Void visitType(final Type node, final C context) {
+    return null;
+  }
+}


### PR DESCRIPTION
This patch refactors AggregateAnalyzer and ExpressionTypeManager to implement
ExpressionVisitor. ExpressionTypeManager implements ExpressionVisitor directly,
and now has impls for unsupported expressions (which throw). AggregateAnalyzer
implements ExpressionVisitor by inheriting from TraversalExpressionVisitor, an
abstract base which implements a traversal of the expression tree by default.