### PR TITLE
feat(ksql-connect): introduce ConnectClient for REST requests

### DIFF
--- a/ksql-common/src/main/java/io/confluent/ksql/util/KsqlConfig.java
+++ b/ksql-common/src/main/java/io/confluent/ksql/util/KsqlConfig.java
@@ -63,6 +63,8 @@ public class KsqlConfig extends AbstractConfig {
 
   public static final String SCHEMA_REGISTRY_URL_PROPERTY = "ksql.schema.registry.url";
 
+  public static final String CONNECT_URL_PROPERTY = "ksql.connect.registry.url";
+
   public static final String KSQL_ENABLE_UDFS = "ksql.udfs.enabled";
 
   public static final String KSQL_EXT_DIR = "ksql.extension.dir";
@@ -154,8 +156,8 @@ public class KsqlConfig extends AbstractConfig {
       "Extension for supplying custom metrics to be emitted along with "
       + "the engine's default JMX metrics";
 
-  public static final String
-      defaultSchemaRegistryUrl = "http://localhost:8081";
+  public static final String DEFAULT_SCHEMA_REGISTRY_URL = "http://localhost:8081";
+  public static final String DEFAULT_CONNECT_URL = "http://localhost:8083";
 
   public static final String KSQL_STREAMS_PREFIX = "ksql.streams.";
 
@@ -425,9 +427,15 @@ public class KsqlConfig extends AbstractConfig {
         ).define(
             SCHEMA_REGISTRY_URL_PROPERTY,
             ConfigDef.Type.STRING,
-            defaultSchemaRegistryUrl,
+            DEFAULT_SCHEMA_REGISTRY_URL,
             ConfigDef.Importance.MEDIUM,
             "The URL for the schema registry, defaults to http://localhost:8081"
+        ).define(
+            CONNECT_URL_PROPERTY,
+            ConfigDef.Type.STRING,
+            DEFAULT_CONNECT_URL,
+            Importance.MEDIUM,
+            "The URL for the connect deployment, defaults to http://localhost:8083"
         ).define(
             KSQL_ENABLE_UDFS,
             ConfigDef.Type.BOOLEAN,

--- a/ksql-engine/pom.xml
+++ b/ksql-engine/pom.xml
@@ -32,22 +32,27 @@
             <groupId>io.confluent.ksql</groupId>
             <artifactId>ksql-common</artifactId>
         </dependency>
+
         <dependency>
             <groupId>io.confluent.support</groupId>
             <artifactId>support-metrics-common</artifactId>
         </dependency>
+
         <dependency>
             <groupId>io.confluent.ksql</groupId>
             <artifactId>ksql-serde</artifactId>
         </dependency>
+
         <dependency>
             <groupId>io.confluent.ksql</groupId>
             <artifactId>ksql-parser</artifactId>
         </dependency>
+
         <dependency>
             <groupId>io.confluent.ksql</groupId>
             <artifactId>ksql-metastore</artifactId>
         </dependency>
+
         <dependency>
             <groupId>io.confluent.ksql</groupId>
             <artifactId>ksql-udf</artifactId>
@@ -79,8 +84,18 @@
         </dependency>
 
         <dependency>
+            <groupId>org.apache.httpcomponents</groupId>
+            <artifactId>fluent-hc</artifactId>
+        </dependency>
+
+        <dependency>
             <groupId>org.apache.kafka</groupId>
             <artifactId>connect-api</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>org.apache.kafka</groupId>
+            <artifactId>connect-runtime</artifactId>
         </dependency>
 
         <dependency>
@@ -129,6 +144,12 @@
             <groupId>io.confluent.avro</groupId>
             <artifactId>avro-random-generator</artifactId>
             <version>${avro.random.generator.version}</version>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>com.github.tomakehurst</groupId>
+            <artifactId>wiremock-jre8</artifactId>
             <scope>test</scope>
         </dependency>
 

--- a/ksql-engine/src/main/java/io/confluent/ksql/services/ConnectClient.java
+++ b/ksql-engine/src/main/java/io/confluent/ksql/services/ConnectClient.java
@@ -1,0 +1,72 @@
+/*
+ * Copyright 2019 Confluent Inc.
+ *
+ * Licensed under the Confluent Community License (the "License"; you may not use
+ * this file except in compliance with the License. You may obtain a copy of the
+ * License at
+ *
+ * http://www.confluent.io/confluent-community-license
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package io.confluent.ksql.services;
+
+import io.confluent.ksql.util.KsqlPreconditions;
+import java.util.Map;
+import java.util.Optional;
+import org.apache.kafka.connect.runtime.rest.entities.ConnectorInfo;
+
+/**
+ * An interface defining the common operations to communicate with
+ * a Kafka Connect cluster.
+ */
+public interface ConnectClient {
+
+  /**
+   * Creates a connector with {@code connector} as the name under the
+   * specified configuration.
+   *
+   * @param connector the name of the connector
+   * @param config    the connector configuration
+   */
+  ConnectResponse<ConnectorInfo> create(String connector, Map<String, String> config);
+
+  /**
+   * An optionally successful response. Either contains a value of type
+   * {@code <T>} or an error, which is the string representation of the
+   * response entity.
+   */
+  class ConnectResponse<T> {
+    private final Optional<T> datum;
+    private final Optional<String> error;
+
+    public static <T> ConnectResponse<T> of(final T datum) {
+      return new ConnectResponse<>(datum, null);
+    }
+
+    public static <T> ConnectResponse<T> of(final String error) {
+      return new ConnectResponse<>(null, error);
+    }
+
+    private ConnectResponse(final T datum, final String error) {
+      KsqlPreconditions.checkArgument(
+          datum != null ^ error != null,
+          "expected exactly one of datum or error to be null");
+      this.datum = Optional.ofNullable(datum);
+      this.error = Optional.ofNullable(error);
+    }
+
+    public Optional<T> datum() {
+      return datum;
+    }
+
+    public Optional<String> error() {
+      return error;
+    }
+  }
+
+}

--- a/ksql-engine/src/main/java/io/confluent/ksql/services/DefaultConnectClient.java
+++ b/ksql-engine/src/main/java/io/confluent/ksql/services/DefaultConnectClient.java
@@ -19,6 +19,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.common.collect.ImmutableMap;
 import io.confluent.ksql.json.JsonMapper;
 import io.confluent.ksql.util.KsqlException;
+import io.confluent.ksql.util.KsqlServerException;
 import java.net.URI;
 import java.net.URISyntaxException;
 import java.util.Map;
@@ -53,7 +54,8 @@ public class DefaultConnectClient implements ConnectClient {
     try {
       this.connectURI = new URI(connectURI);
     } catch (URISyntaxException e) {
-      throw new KsqlException("Could not initialize connect client.", e);
+      throw new KsqlException(
+          "Could not initialize connect client due to invalid URI: " + connectURI, e);
     }
   }
 
@@ -87,7 +89,7 @@ public class DefaultConnectClient implements ConnectClient {
 
       return connectResponse;
     } catch (final Exception e) {
-      throw new KsqlException(e);
+      throw new KsqlServerException(e);
     }
   }
 

--- a/ksql-engine/src/main/java/io/confluent/ksql/services/DefaultConnectClient.java
+++ b/ksql-engine/src/main/java/io/confluent/ksql/services/DefaultConnectClient.java
@@ -1,0 +1,111 @@
+/*
+ * Copyright 2019 Confluent Inc.
+ *
+ * Licensed under the Confluent Community License (the "License"; you may not use
+ * this file except in compliance with the License. You may obtain a copy of the
+ * License at
+ *
+ * http://www.confluent.io/confluent-community-license
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package io.confluent.ksql.services;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.google.common.collect.ImmutableMap;
+import io.confluent.ksql.json.JsonMapper;
+import io.confluent.ksql.util.KsqlException;
+import java.net.URI;
+import java.net.URISyntaxException;
+import java.util.Map;
+import java.util.Objects;
+import org.apache.http.HttpStatus;
+import org.apache.http.client.ResponseHandler;
+import org.apache.http.client.fluent.Request;
+import org.apache.http.entity.ContentType;
+import org.apache.http.util.EntityUtils;
+import org.apache.kafka.connect.runtime.rest.entities.ConnectorInfo;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * The default implementation of {@code ConnectClient}. This implementation is
+ * thread safe, and the methods are all <i>blocking</i> and are configured with
+ * default timeouts of {@value #DEFAULT_TIMEOUT_MS}ms.
+ */
+public class DefaultConnectClient implements ConnectClient {
+
+  private static final Logger LOG = LoggerFactory.getLogger(DefaultConnectClient.class);
+  private static final ObjectMapper MAPPER = JsonMapper.INSTANCE.mapper;
+
+  private static final String CONNECTORS = "/connectors";
+  private static final int DEFAULT_TIMEOUT_MS = 5_000;
+
+  private final URI connectURI;
+
+  public DefaultConnectClient(final String connectURI) {
+    Objects.requireNonNull(connectURI, "connectURI");
+
+    try {
+      this.connectURI = new URI(connectURI);
+    } catch (URISyntaxException e) {
+      throw new KsqlException("Could not initialize connect client.", e);
+    }
+  }
+
+  @Override
+  public ConnectResponse<ConnectorInfo> create(
+      final String connector,
+      final Map<String, String> config
+  ) {
+    try {
+      LOG.debug("Issuing request to Kafka Connect at URI {} with name {} and config {}",
+          connectURI,
+          connector,
+          config);
+
+      final ConnectResponse<ConnectorInfo> connectResponse = Request
+          .Post(connectURI.resolve(CONNECTORS))
+          .socketTimeout(DEFAULT_TIMEOUT_MS)
+          .connectTimeout(DEFAULT_TIMEOUT_MS)
+          .bodyString(
+              MAPPER.writeValueAsString(
+                  ImmutableMap.of(
+                      "name", connector,
+                      "config", config)),
+              ContentType.APPLICATION_JSON
+          )
+          .execute()
+          .handleResponse(createHandler(HttpStatus.SC_CREATED, ConnectorInfo.class));
+
+      connectResponse.error()
+          .ifPresent(error -> LOG.warn("Did not CREATE connector {}: {}", connector, error));
+
+      return connectResponse;
+    } catch (final Exception e) {
+      throw new KsqlException(e);
+    }
+  }
+
+  private static <T> ResponseHandler<ConnectResponse<T>> createHandler(
+      final int expectedStatus,
+      final Class<T> entityClass
+  ) {
+    return httpResponse -> {
+      if (httpResponse.getStatusLine().getStatusCode() != expectedStatus) {
+        final String entity = EntityUtils.toString(httpResponse.getEntity());
+        return ConnectResponse.of(entity);
+      }
+
+      final T info = MAPPER.readValue(
+          httpResponse.getEntity().getContent(),
+          entityClass);
+
+      return ConnectResponse.of(info);
+    };
+  }
+}

--- a/ksql-engine/src/main/java/io/confluent/ksql/services/DefaultServiceContext.java
+++ b/ksql-engine/src/main/java/io/confluent/ksql/services/DefaultServiceContext.java
@@ -35,6 +35,7 @@ public class DefaultServiceContext implements ServiceContext {
   private final KafkaTopicClient topicClient;
   private final Supplier<SchemaRegistryClient> srClientFactory;
   private final SchemaRegistryClient srClient;
+  private final ConnectClient connectClient;
 
   public static DefaultServiceContext create(final KsqlConfig ksqlConfig) {
     return create(
@@ -57,7 +58,8 @@ public class DefaultServiceContext implements ServiceContext {
         kafkaClientSupplier,
         adminClient,
         new KafkaTopicClientImpl(adminClient),
-        srClientFactory
+        srClientFactory,
+        new DefaultConnectClient(ksqlConfig.getString(KsqlConfig.CONNECT_URL_PROPERTY))
     );
   }
 
@@ -65,13 +67,15 @@ public class DefaultServiceContext implements ServiceContext {
       final KafkaClientSupplier kafkaClientSupplier,
       final AdminClient adminClient,
       final KafkaTopicClient topicClient,
-      final Supplier<SchemaRegistryClient> srClientFactory
+      final Supplier<SchemaRegistryClient> srClientFactory,
+      final ConnectClient connectClient
   ) {
     this.kafkaClientSupplier = Objects.requireNonNull(kafkaClientSupplier, "kafkaClientSupplier");
     this.adminClient = Objects.requireNonNull(adminClient, "adminClient");
     this.topicClient = Objects.requireNonNull(topicClient, "topicClient");
     this.srClientFactory = Objects.requireNonNull(srClientFactory, "srClientFactory");
     this.srClient = Objects.requireNonNull(srClientFactory.get(), "srClient");
+    this.connectClient = Objects.requireNonNull(connectClient, "connectClient");
   }
 
   @Override
@@ -97,6 +101,11 @@ public class DefaultServiceContext implements ServiceContext {
   @Override
   public Supplier<SchemaRegistryClient> getSchemaRegistryClientFactory() {
     return srClientFactory;
+  }
+
+  @Override
+  public ConnectClient getConnectClient() {
+    return connectClient;
   }
 
   @Override

--- a/ksql-engine/src/main/java/io/confluent/ksql/services/LazyServiceContext.java
+++ b/ksql-engine/src/main/java/io/confluent/ksql/services/LazyServiceContext.java
@@ -54,6 +54,11 @@ public class LazyServiceContext implements ServiceContext {
   }
 
   @Override
+  public ConnectClient getConnectClient() {
+    return serviceContextSupplier.get().getConnectClient();
+  }
+
+  @Override
   public void close() {
     serviceContextSupplier.get().close();
   }

--- a/ksql-engine/src/main/java/io/confluent/ksql/services/SandboxConnectClient.java
+++ b/ksql-engine/src/main/java/io/confluent/ksql/services/SandboxConnectClient.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright 2019 Confluent Inc.
+ *
+ * Licensed under the Confluent Community License (the "License"; you may not use
+ * this file except in compliance with the License. You may obtain a copy of the
+ * License at
+ *
+ * http://www.confluent.io/confluent-community-license
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package io.confluent.ksql.services;
+
+import static io.confluent.ksql.util.LimitedProxyBuilder.methodParams;
+
+import io.confluent.ksql.services.ConnectClient.ConnectResponse;
+import io.confluent.ksql.util.LimitedProxyBuilder;
+import java.util.Map;
+
+/**
+ * Supplies {@link ConnectClient}s to use that do not make any
+ * state changes to the external connect clusters.
+ */
+final class SandboxConnectClient {
+
+  private SandboxConnectClient() { }
+
+  public static ConnectClient createProxy() {
+    return LimitedProxyBuilder.forClass(ConnectClient.class)
+        .swallow("create", methodParams(String.class, Map.class), ConnectResponse.of("sandbox"))
+        .build();
+  }
+}

--- a/ksql-engine/src/main/java/io/confluent/ksql/services/SandboxedServiceContext.java
+++ b/ksql-engine/src/main/java/io/confluent/ksql/services/SandboxedServiceContext.java
@@ -33,6 +33,7 @@ public final class SandboxedServiceContext implements ServiceContext {
   private final KafkaTopicClient topicClient;
   private final SchemaRegistryClient srClient;
   private final KafkaClientSupplier kafkaClientSupplier;
+  private final ConnectClient connectClient;
 
   public static SandboxedServiceContext create(final ServiceContext serviceContext) {
     if (serviceContext instanceof SandboxedServiceContext) {
@@ -44,21 +45,25 @@ public final class SandboxedServiceContext implements ServiceContext {
         .createProxy(serviceContext.getTopicClient());
     final SchemaRegistryClient schemaRegistryClient =
         SandboxedSchemaRegistryClient.createProxy(serviceContext.getSchemaRegistryClient());
+    final ConnectClient connectClient = SandboxConnectClient.createProxy();
 
     return new SandboxedServiceContext(
         kafkaClientSupplier,
         kafkaTopicClient,
-        schemaRegistryClient);
+        schemaRegistryClient,
+        connectClient);
   }
 
   private SandboxedServiceContext(
       final KafkaClientSupplier kafkaClientSupplier,
       final KafkaTopicClient topicClient,
-      final SchemaRegistryClient srClient
+      final SchemaRegistryClient srClient,
+      final ConnectClient connectClient
   ) {
     this.kafkaClientSupplier = Objects.requireNonNull(kafkaClientSupplier, "kafkaClientSupplier");
     this.topicClient = Objects.requireNonNull(topicClient, "topicClient");
     this.srClient = Objects.requireNonNull(srClient, "srClient");
+    this.connectClient = Objects.requireNonNull(connectClient, "connectClient");
   }
 
   @Override
@@ -84,6 +89,11 @@ public final class SandboxedServiceContext implements ServiceContext {
   @Override
   public Supplier<SchemaRegistryClient> getSchemaRegistryClientFactory() {
     return () -> srClient;
+  }
+
+  @Override
+  public ConnectClient getConnectClient() {
+    return connectClient;
   }
 
   @Override

--- a/ksql-engine/src/main/java/io/confluent/ksql/services/ServiceContext.java
+++ b/ksql-engine/src/main/java/io/confluent/ksql/services/ServiceContext.java
@@ -84,6 +84,15 @@ public interface ServiceContext extends AutoCloseable {
    */
   Supplier<SchemaRegistryClient> getSchemaRegistryClientFactory();
 
+  /**
+   * Get the shared {@link ConnectClient} instance.
+   *
+   * <p>The default implementation is thread-safe and can be shared across threads.
+   *
+   * @return a shared {@link ConnectClient}
+   */
+  ConnectClient getConnectClient();
+
   @Override
   void close();
 }

--- a/ksql-engine/src/test/java/io/confluent/ksql/KsqlContextTestUtil.java
+++ b/ksql-engine/src/test/java/io/confluent/ksql/KsqlContextTestUtil.java
@@ -19,6 +19,7 @@ import io.confluent.kafka.schemaregistry.client.SchemaRegistryClient;
 import io.confluent.ksql.engine.KsqlEngine;
 import io.confluent.ksql.function.FunctionRegistry;
 import io.confluent.ksql.logging.processing.ProcessingLogContext;
+import io.confluent.ksql.services.DefaultConnectClient;
 import io.confluent.ksql.services.KafkaTopicClient;
 import io.confluent.ksql.services.KafkaTopicClientImpl;
 import io.confluent.ksql.services.ServiceContext;
@@ -50,7 +51,8 @@ public final class KsqlContextTestUtil {
         clientSupplier,
         adminClient,
         kafkaTopicClient,
-        () -> schemaRegistryClient
+        () -> schemaRegistryClient,
+        new DefaultConnectClient(ksqlConfig.getString(KsqlConfig.CONNECT_URL_PROPERTY))
     );
 
     final KsqlEngine engine = new KsqlEngine(

--- a/ksql-engine/src/test/java/io/confluent/ksql/services/DefaultConnectClientTest.java
+++ b/ksql-engine/src/test/java/io/confluent/ksql/services/DefaultConnectClientTest.java
@@ -1,0 +1,98 @@
+/*
+ * Copyright 2019 Confluent Inc.
+ *
+ * Licensed under the Confluent Community License (the "License"; you may not use
+ * this file except in compliance with the License. You may obtain a copy of the
+ * License at
+ *
+ * http://www.confluent.io/confluent-community-license
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package io.confluent.ksql.services;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.*;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.github.tomakehurst.wiremock.client.WireMock;
+import com.github.tomakehurst.wiremock.core.WireMockConfiguration;
+import com.github.tomakehurst.wiremock.junit.WireMockRule;
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+import io.confluent.ksql.json.JsonMapper;
+import io.confluent.ksql.metastore.model.MetaStoreMatchers.OptionalMatchers;
+import io.confluent.ksql.services.ConnectClient.ConnectResponse;
+import org.apache.http.HttpStatus;
+import org.apache.kafka.connect.runtime.rest.entities.ConnectorInfo;
+import org.apache.kafka.connect.runtime.rest.entities.ConnectorType;
+import org.apache.kafka.connect.util.ConnectorTaskId;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+
+public class DefaultConnectClientTest {
+
+  private static final ObjectMapper MAPPER = JsonMapper.INSTANCE.mapper;
+  private static final ConnectorInfo SAMPLE_INFO = new ConnectorInfo(
+      "foo",
+      ImmutableMap.of("key", "value"),
+      ImmutableList.of(new ConnectorTaskId("foo", 1)),
+      ConnectorType.SOURCE
+  );
+
+  @Rule
+  public WireMockRule wireMockRule = new WireMockRule(
+      WireMockConfiguration.wireMockConfig().dynamicPort());
+
+  private ConnectClient client;
+
+  @Before
+  public void setup() {
+    client = new DefaultConnectClient("http://localhost:" + wireMockRule.port());
+  }
+
+  @Test
+  public void testCreate() throws JsonProcessingException {
+    // Given:
+    WireMock.stubFor(
+        WireMock.post(WireMock.urlEqualTo("/connectors"))
+            .willReturn(WireMock.aResponse()
+                .withStatus(HttpStatus.SC_CREATED)
+                .withBody(MAPPER.writeValueAsString(SAMPLE_INFO)))
+    );
+
+    // When:
+    final ConnectResponse<ConnectorInfo> response =
+        client.create("foo", ImmutableMap.of());
+
+    // Then:
+    assertThat(response.datum(), OptionalMatchers.of(is(SAMPLE_INFO)));
+    assertThat("Expected no error!", !response.error().isPresent());
+  }
+
+  @Test
+  public void testCreateWithError() throws JsonProcessingException {
+    // Given:
+    WireMock.stubFor(
+        WireMock.post(WireMock.urlEqualTo("/connectors"))
+            .willReturn(WireMock.aResponse()
+                .withStatus(HttpStatus.SC_BAD_REQUEST)
+                .withBody("Oh no!"))
+    );
+
+    // When:
+    final ConnectResponse<ConnectorInfo> response =
+        client.create("foo", ImmutableMap.of());
+
+    // Then:
+    assertThat("Expected no datum!", !response.datum().isPresent());
+    assertThat(response.error(), OptionalMatchers.of(is("Oh no!")));
+  }
+
+}

--- a/ksql-engine/src/test/java/io/confluent/ksql/services/SandboxConnectClientTest.java
+++ b/ksql-engine/src/test/java/io/confluent/ksql/services/SandboxConnectClientTest.java
@@ -1,0 +1,48 @@
+/*
+ * Copyright 2019 Confluent Inc.
+ *
+ * Licensed under the Confluent Community License (the "License"; you may not use
+ * this file except in compliance with the License. You may obtain a copy of the
+ * License at
+ *
+ * http://www.confluent.io/confluent-community-license
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package io.confluent.ksql.services;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.*;
+
+import com.google.common.collect.ImmutableMap;
+import io.confluent.ksql.metastore.model.MetaStoreMatchers.OptionalMatchers;
+import io.confluent.ksql.services.ConnectClient.ConnectResponse;
+import org.apache.kafka.connect.runtime.rest.entities.ConnectorInfo;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+public class SandboxConnectClientTest {
+
+  private ConnectClient sandboxClient;
+
+  @Before
+  public void setUp() {
+    sandboxClient = SandboxConnectClient.createProxy();
+  }
+
+  @Test
+  public void shouldReturnErrorOnCreate() {
+    // When:
+    final ConnectResponse<ConnectorInfo> foo = sandboxClient.create("foo", ImmutableMap.of());
+
+    // Then:
+    assertThat(foo.error(), OptionalMatchers.of(is("sandbox")));
+    assertThat("expected no datum", !foo.datum().isPresent());
+  }
+
+}

--- a/ksql-engine/src/test/java/io/confluent/ksql/services/SandboxedServiceContextTest.java
+++ b/ksql-engine/src/test/java/io/confluent/ksql/services/SandboxedServiceContextTest.java
@@ -18,6 +18,7 @@ package io.confluent.ksql.services;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.instanceOf;
 import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.notNullValue;
 import static org.hamcrest.Matchers.sameInstance;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
@@ -55,6 +56,7 @@ public final class SandboxedServiceContextTest {
           .ignore("getKafkaClientSupplier")
           .ignore("getSchemaRegistryClient")
           .ignore("getSchemaRegistryClientFactory")
+          .ignore("getConnectClient")
           .ignore("close")
           .build();
     }
@@ -160,6 +162,15 @@ public final class SandboxedServiceContextTest {
 
       // Then:
       assertThat(factory.get(), is(sameInstance(sandboxedServiceContext.getSchemaRegistryClient())));
+    }
+
+    @Test
+    public void shouldGetSandboxedConnectClient() {
+      // When:
+      final ConnectClient client = sandboxedServiceContext.getConnectClient();
+
+      // Then:
+      assertThat("Expected proxy class", Proxy.isProxyClass(client.getClass()));
     }
 
     @Test

--- a/ksql-engine/src/test/java/io/confluent/ksql/services/TestServiceContext.java
+++ b/ksql-engine/src/test/java/io/confluent/ksql/services/TestServiceContext.java
@@ -62,7 +62,8 @@ public final class TestServiceContext {
         new FakeKafkaClientSupplier(),
         new FakeKafkaClientSupplier().getAdminClient(Collections.emptyMap()),
         topicClient,
-        srClientFactory
+        srClientFactory,
+        new DefaultConnectClient("http://localhost:8083")
     );
   }
 
@@ -78,7 +79,8 @@ public final class TestServiceContext {
         kafkaClientSupplier,
         adminClient,
         new KafkaTopicClientImpl(adminClient),
-        srClientFactory
+        srClientFactory,
+        new DefaultConnectClient(ksqlConfig.getString(KsqlConfig.CONNECT_URL_PROPERTY))
     );
   }
 
@@ -86,8 +88,9 @@ public final class TestServiceContext {
       final KafkaClientSupplier kafkaClientSupplier,
       final AdminClient adminClient,
       final KafkaTopicClient topicClient,
-      final Supplier<SchemaRegistryClient> srClientFactory
+      final Supplier<SchemaRegistryClient> srClientFactory,
+      final ConnectClient connectClient
   ) {
-    return new DefaultServiceContext(kafkaClientSupplier, adminClient, topicClient, srClientFactory);
+    return new DefaultServiceContext(kafkaClientSupplier, adminClient, topicClient, srClientFactory, connectClient);
   }
 }

--- a/ksql-rest-app/src/test/java/io/confluent/ksql/rest/server/execution/ListSourceExecutorTest.java
+++ b/ksql-rest-app/src/test/java/io/confluent/ksql/rest/server/execution/ListSourceExecutorTest.java
@@ -247,7 +247,8 @@ public class ListSourceExecutorTest {
         engine.getServiceContext().getKafkaClientSupplier(),
         engine.getServiceContext().getAdminClient(),
         spyTopicClient,
-        engine.getServiceContext().getSchemaRegistryClientFactory()
+        engine.getServiceContext().getSchemaRegistryClientFactory(),
+        engine.getServiceContext().getConnectClient()
     );
 
     // When:

--- a/ksql-rest-app/src/test/java/io/confluent/ksql/rest/server/execution/ListTopicsExecutorTest.java
+++ b/ksql-rest-app/src/test/java/io/confluent/ksql/rest/server/execution/ListTopicsExecutorTest.java
@@ -59,7 +59,8 @@ public class ListTopicsExecutorTest {
         engine.getServiceContext().getKafkaClientSupplier(),
         mockAdminClient,
         engine.getServiceContext().getTopicClient(),
-        engine.getServiceContext().getSchemaRegistryClientFactory()
+        engine.getServiceContext().getSchemaRegistryClientFactory(),
+        engine.getServiceContext().getConnectClient()
     );
 
     // When:

--- a/pom.xml
+++ b/pom.xml
@@ -88,6 +88,7 @@
     <properties>
         <apache.directory.server.version>2.0.0-M22</apache.directory.server.version>
         <apache.directory.api.version>1.0.0-M33</apache.directory.api.version>
+        <apache.httpcomponents.version>4.5.9</apache.httpcomponents.version>
         <confluent.maven.repo>http://packages.confluent.io/maven/</confluent.maven.repo>
         <exec-maven-plugin.version>1.2.1</exec-maven-plugin.version>
         <podam.version>6.0.2.RELEASE</podam.version>
@@ -107,6 +108,7 @@
         <generext.version>1.0.2</generext.version>
         <avro.random.generator.version>0.2.2</avro.random.generator.version>
         <apache.curator.version>2.9.0</apache.curator.version>
+        <wiremock.version>2.24.0</wiremock.version>
         <!--
          Temporarily pinning KSQL to old Kafka Streams snapshot until issues with breaking change
          due to state store name changes in PR https://github.com/apache/kafka/pull/6411,
@@ -317,6 +319,12 @@
             </dependency>
 
             <dependency>
+                <groupId>org.apache.httpcomponents</groupId>
+                <artifactId>fluent-hc</artifactId>
+                <version>${apache.httpcomponents.version}</version>
+            </dependency>
+
+            <dependency>
                 <groupId>org.apache.commons</groupId>
                 <artifactId>commons-lang3</artifactId>
                 <version>${lang3.version}</version>
@@ -358,6 +366,13 @@
                 <groupId>com.google.guava</groupId>
                 <artifactId>guava-testlib</artifactId>
                 <version>${guava.version}</version>
+                <scope>test</scope>
+            </dependency>
+
+            <dependency>
+                <groupId>com.github.tomakehurst</groupId>
+                <artifactId>wiremock-jre8</artifactId>
+                <version>${wiremock.version}</version>
                 <scope>test</scope>
             </dependency>
 


### PR DESCRIPTION
### Description 
This PR introduces a client that can issue requests to connect and wires it through the `ServiceContext` as well as make the necessary `pom.xml` changes. This is part 1 of a few PRs for connect integration and an effort to keep them small.

### Testing done 
Unit testing for the new components, but there isn't actually any new functionality that is introduced with this change.

### Reviewer checklist
- [ ] Ensure docs are updated if necessary. (eg. if a user visible feature is being added or changed).
- [ ] Ensure relevant issues are linked (description should include text like "Fixes #<issue number>")

