### PR TITLE
fix: authorization filter is logging incorrect username

### DIFF
--- a/ksql-rest-app/src/main/java/io/confluent/ksql/rest/server/filters/KsqlAuthorizationFilter.java
+++ b/ksql-rest-app/src/main/java/io/confluent/ksql/rest/server/filters/KsqlAuthorizationFilter.java
@@ -47,7 +47,8 @@ public class KsqlAuthorizationFilter implements ContainerRequestFilter  {
     try {
       authorizationProvider.checkEndpointAccess(user, method, path);
     } catch (final Throwable t) {
-      log.warn(String.format("User:%s is denied access to \"%s %s\"", user, method, path), t);
+      log.warn(String.format("User:%s is denied access to \"%s %s\"",
+          user.getName(), method, path), t);
       requestContext.abortWith(Errors.accessDenied(t.getMessage()));
     }
   }

--- a/ksql-rest-app/src/main/java/io/confluent/ksql/rest/server/resources/streaming/WSQueryEndpoint.java
+++ b/ksql-rest-app/src/main/java/io/confluent/ksql/rest/server/resources/streaming/WSQueryEndpoint.java
@@ -277,7 +277,7 @@ public class WSQueryEndpoint {
             provider.checkEndpointAccess(user, method, path);
           } catch (final Throwable t) {
             log.warn(String.format("User:%s is denied access to Websocket "
-                + "%s endpoint", user, path), t);
+                + "%s endpoint", user.getName(), path), t);
             throw new KsqlException(t);
           }
         }


### PR DESCRIPTION
### Description 
Fix a logging issue in the Authorization filter which was displaying the `Principal` object instead of the user name.

### Testing done 
_Describe the testing strategy. Unit and integration tests are expected for any behavior changes._

### Reviewer checklist
- [ ] Ensure docs are updated if necessary. (eg. if a user visible feature is being added or changed).
- [ ] Ensure relevant issues are linked (description should include text like "Fixes #<issue number>")

