### PR TITLE
fix: dummy placeholder class in ksql-execution

### DIFF
--- a/ksql-execution/src/main/java/io/confluent/ksql/execution/expression/tree/Placeholder.java
+++ b/ksql-execution/src/main/java/io/confluent/ksql/execution/expression/tree/Placeholder.java
@@ -1,0 +1,20 @@
+/*
+ * Copyright 2018 Confluent Inc.
+ *
+ * Licensed under the Confluent Community License (the "License"); you may not use
+ * this file except in compliance with the License.  You may obtain a copy of the
+ * License at
+ *
+ * http://www.confluent.io/confluent-community-license
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package io.confluent.ksql.execution.expression.tree;
+
+class Placeholder {
+
+}


### PR DESCRIPTION
This patch adds a dummy placeholder class to ksql-execution. For some reason,
when the jar is empty maven complains about the jar being replaced when its built
by multiple maven targets (e.g. `mvn package install`). This will be cleaned up when
we start moving code into this project.