### PR TITLE
fix: remove non-standard JavaFx usage of Pair

### DIFF
--- a/ksql-engine/src/main/java/io/confluent/ksql/exception/KafkaDeleteTopicsException.java
+++ b/ksql-engine/src/main/java/io/confluent/ksql/exception/KafkaDeleteTopicsException.java
@@ -15,8 +15,8 @@
 
 package io.confluent.ksql.exception;
 
+import io.confluent.ksql.util.Pair;
 import java.util.List;
-import javafx.util.Pair;
 
 public class KafkaDeleteTopicsException extends KafkaTopicClientException {
   private final List<Pair<String, Throwable>> exceptionList;

--- a/ksql-engine/src/main/java/io/confluent/ksql/services/KafkaTopicClientImpl.java
+++ b/ksql-engine/src/main/java/io/confluent/ksql/services/KafkaTopicClientImpl.java
@@ -23,6 +23,7 @@ import io.confluent.ksql.util.ExecutorUtil;
 import io.confluent.ksql.util.KsqlConstants;
 import io.confluent.ksql.util.KsqlException;
 import io.confluent.ksql.util.KsqlServerException;
+import io.confluent.ksql.util.Pair;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
@@ -32,7 +33,6 @@ import java.util.Set;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeUnit;
 import java.util.stream.Collectors;
-import javafx.util.Pair;
 import javax.annotation.concurrent.ThreadSafe;
 
 import org.apache.commons.lang3.exception.ExceptionUtils;


### PR DESCRIPTION
javafx is not in OpenJDK, replacing usage of JavaFx with our internal Pair class.

