### PR TITLE
fix: filter null entries before creating KafkaConfigStore

### DIFF
--- a/ksql-rest-app/src/main/java/io/confluent/ksql/rest/server/computation/KafkaConfigStore.java
+++ b/ksql-rest-app/src/main/java/io/confluent/ksql/rest/server/computation/KafkaConfigStore.java
@@ -26,6 +26,7 @@ import java.time.temporal.ChronoUnit;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
+import java.util.Map.Entry;
 import java.util.Objects;
 import java.util.Optional;
 import java.util.function.Supplier;
@@ -116,7 +117,11 @@ public class KafkaConfigStore implements ConfigStore {
     KsqlProperties(
         @JsonProperty("ksqlProperties") final Map<String, String> ksqlProperties) {
       this.ksqlProperties = ksqlProperties == null
-          ? Collections.emptyMap() : ImmutableMap.copyOf(ksqlProperties);
+          ? Collections.emptyMap()
+          : ksqlProperties.entrySet()
+              .stream()
+              .filter(kv -> kv.getValue() != null)
+              .collect(ImmutableMap.toImmutableMap(Entry::getKey, Entry::getValue));
     }
 
     public Map<String, String> getKsqlProperties() {

--- a/ksql-rest-app/src/test/java/io/confluent/ksql/rest/server/computation/KafkaConfigStoreTest.java
+++ b/ksql-rest-app/src/test/java/io/confluent/ksql/rest/server/computation/KafkaConfigStoreTest.java
@@ -72,13 +72,13 @@ public class KafkaConfigStoreTest {
       ImmutableMap.of(KsqlConfig.KSQL_PERSISTENT_QUERY_NAME_PREFIX_CONFIG, "bad"));
 
   private final KsqlProperties properties = new KsqlProperties(
-      filterNullValues(currentConfig.getAllConfigPropsWithSecretsObfuscated())
+      currentConfig.getAllConfigPropsWithSecretsObfuscated()
   );
   private final KsqlProperties savedProperties = new KsqlProperties(
-      filterNullValues(savedConfig.getAllConfigPropsWithSecretsObfuscated())
+      savedConfig.getAllConfigPropsWithSecretsObfuscated()
   );
   private final KsqlProperties badProperties = new KsqlProperties(
-      filterNullValues(badConfig.getAllConfigPropsWithSecretsObfuscated())
+      badConfig.getAllConfigPropsWithSecretsObfuscated()
   );
 
   private final TopicPartition topicPartition = new TopicPartition(TOPIC_NAME, 0);
@@ -107,7 +107,6 @@ public class KafkaConfigStoreTest {
   private InOrder inOrder;
 
   @Before
-  @SuppressWarnings("unchecked")
   public void setUp() {
     when(producerSupplier.get()).thenReturn(producer);
     when(consumerSupplier.get()).thenReturn(consumerBefore).thenReturn(consumerAfter);


### PR DESCRIPTION
### Description 
Our standalone module goes through `KafkaConfigStore`, which in turn uses `ImmutableMap`. The `ImmutableMap` requires all values in a map to be non-null. Since we added a few configurations with `null` defaults - we need to filter them out here.

### Testing done 
Updated tests to remove the `filterNullEntries` and manually spun up KSQL standalone.

### Reviewer checklist
- [ ] Ensure docs are updated if necessary. (eg. if a user visible feature is being added or changed).
- [ ] Ensure relevant issues are linked (description should include text like "Fixes #<issue number>")

