### PR TITLE
feat(ksql-connect): wiring for creating connectors

### DIFF
--- a/ksql-cli/src/main/java/io/confluent/ksql/cli/console/Console.java
+++ b/ksql-cli/src/main/java/io/confluent/ksql/cli/console/Console.java
@@ -27,6 +27,8 @@ import io.confluent.ksql.cli.console.cmd.CliSpecificCommand;
 import io.confluent.ksql.cli.console.table.Table;
 import io.confluent.ksql.cli.console.table.Table.Builder;
 import io.confluent.ksql.cli.console.table.builder.CommandStatusTableBuilder;
+import io.confluent.ksql.cli.console.table.builder.ConnectorInfoTableBuilder;
+import io.confluent.ksql.cli.console.table.builder.ErrorEntityTableBuilder;
 import io.confluent.ksql.cli.console.table.builder.ExecutionPlanTableBuilder;
 import io.confluent.ksql.cli.console.table.builder.FunctionNameListTableBuilder;
 import io.confluent.ksql.cli.console.table.builder.KafkaTopicsListTableBuilder;
@@ -39,6 +41,8 @@ import io.confluent.ksql.cli.console.table.builder.TopicDescriptionTableBuilder;
 import io.confluent.ksql.json.JsonMapper;
 import io.confluent.ksql.rest.entity.ArgumentInfo;
 import io.confluent.ksql.rest.entity.CommandStatusEntity;
+import io.confluent.ksql.rest.entity.ConnectorInfoEntity;
+import io.confluent.ksql.rest.entity.ErrorEntity;
 import io.confluent.ksql.rest.entity.ExecutionPlan;
 import io.confluent.ksql.rest.entity.FieldInfo;
 import io.confluent.ksql.rest.entity.FunctionDescriptionList;
@@ -133,6 +137,10 @@ public class Console implements Closeable {
               tablePrinter(FunctionNameList.class, FunctionNameListTableBuilder::new))
           .put(FunctionDescriptionList.class,
               Console::printFunctionDescription)
+          .put(ConnectorInfoEntity.class,
+              tablePrinter(ConnectorInfoEntity.class, ConnectorInfoTableBuilder::new))
+          .put(ErrorEntity.class,
+              tablePrinter(ErrorEntity.class, ErrorEntityTableBuilder::new))
           .build();
 
   private static <T extends KsqlEntity> Handler1<KsqlEntity, Console> tablePrinter(

--- a/ksql-cli/src/main/java/io/confluent/ksql/cli/console/Console.java
+++ b/ksql-cli/src/main/java/io/confluent/ksql/cli/console/Console.java
@@ -41,7 +41,7 @@ import io.confluent.ksql.cli.console.table.builder.TopicDescriptionTableBuilder;
 import io.confluent.ksql.json.JsonMapper;
 import io.confluent.ksql.rest.entity.ArgumentInfo;
 import io.confluent.ksql.rest.entity.CommandStatusEntity;
-import io.confluent.ksql.rest.entity.ConnectorInfoEntity;
+import io.confluent.ksql.rest.entity.CreateConnectorEntity;
 import io.confluent.ksql.rest.entity.ErrorEntity;
 import io.confluent.ksql.rest.entity.ExecutionPlan;
 import io.confluent.ksql.rest.entity.FieldInfo;
@@ -137,8 +137,8 @@ public class Console implements Closeable {
               tablePrinter(FunctionNameList.class, FunctionNameListTableBuilder::new))
           .put(FunctionDescriptionList.class,
               Console::printFunctionDescription)
-          .put(ConnectorInfoEntity.class,
-              tablePrinter(ConnectorInfoEntity.class, ConnectorInfoTableBuilder::new))
+          .put(CreateConnectorEntity.class,
+              tablePrinter(CreateConnectorEntity.class, ConnectorInfoTableBuilder::new))
           .put(ErrorEntity.class,
               tablePrinter(ErrorEntity.class, ErrorEntityTableBuilder::new))
           .build();

--- a/ksql-cli/src/main/java/io/confluent/ksql/cli/console/table/builder/ConnectorInfoTableBuilder.java
+++ b/ksql-cli/src/main/java/io/confluent/ksql/cli/console/table/builder/ConnectorInfoTableBuilder.java
@@ -16,21 +16,15 @@
 package io.confluent.ksql.cli.console.table.builder;
 
 import io.confluent.ksql.cli.console.table.Table;
-import io.confluent.ksql.rest.entity.ConnectorInfoEntity;
-import io.confluent.ksql.rest.entity.ConnectorInfoEntity.Action;
+import io.confluent.ksql.rest.entity.CreateConnectorEntity;
 
-public class ConnectorInfoTableBuilder implements TableBuilder<ConnectorInfoEntity> {
+public class ConnectorInfoTableBuilder implements TableBuilder<CreateConnectorEntity> {
 
   @Override
-  public Table buildTable(final ConnectorInfoEntity entity) {
-    if (entity.getAction() == Action.CREATE) {
-      return new Table.Builder()
-          .withColumnHeaders("Message")
-          .withRow("Created connector " + entity.getInfo().name())
-          .build();
-    }
-
-    throw new UnsupportedOperationException("Cannot format ConnectorInfoEntity with action:"
-        + entity.getAction());
+  public Table buildTable(final CreateConnectorEntity entity) {
+    return new Table.Builder()
+        .withColumnHeaders("Message")
+        .withRow("Created connector " + entity.getInfo().name())
+        .build();
   }
 }

--- a/ksql-cli/src/main/java/io/confluent/ksql/cli/console/table/builder/ConnectorInfoTableBuilder.java
+++ b/ksql-cli/src/main/java/io/confluent/ksql/cli/console/table/builder/ConnectorInfoTableBuilder.java
@@ -1,0 +1,36 @@
+/*
+ * Copyright 2019 Confluent Inc.
+ *
+ * Licensed under the Confluent Community License (the "License"; you may not use
+ * this file except in compliance with the License. You may obtain a copy of the
+ * License at
+ *
+ * http://www.confluent.io/confluent-community-license
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package io.confluent.ksql.cli.console.table.builder;
+
+import io.confluent.ksql.cli.console.table.Table;
+import io.confluent.ksql.rest.entity.ConnectorInfoEntity;
+import io.confluent.ksql.rest.entity.ConnectorInfoEntity.Action;
+
+public class ConnectorInfoTableBuilder implements TableBuilder<ConnectorInfoEntity> {
+
+  @Override
+  public Table buildTable(final ConnectorInfoEntity entity) {
+    if (entity.getAction() == Action.CREATE) {
+      return new Table.Builder()
+          .withColumnHeaders("Message")
+          .withRow("Created connector " + entity.getInfo().name())
+          .build();
+    }
+
+    throw new UnsupportedOperationException("Cannot format ConnectorInfoEntity with action:"
+        + entity.getAction());
+  }
+}

--- a/ksql-cli/src/main/java/io/confluent/ksql/cli/console/table/builder/ErrorEntityTableBuilder.java
+++ b/ksql-cli/src/main/java/io/confluent/ksql/cli/console/table/builder/ErrorEntityTableBuilder.java
@@ -1,0 +1,30 @@
+/*
+ * Copyright 2019 Confluent Inc.
+ *
+ * Licensed under the Confluent Community License (the "License"; you may not use
+ * this file except in compliance with the License. You may obtain a copy of the
+ * License at
+ *
+ * http://www.confluent.io/confluent-community-license
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package io.confluent.ksql.cli.console.table.builder;
+
+import io.confluent.ksql.cli.console.table.Table;
+import io.confluent.ksql.rest.entity.ErrorEntity;
+
+public class ErrorEntityTableBuilder implements TableBuilder<ErrorEntity> {
+
+  @Override
+  public Table buildTable(final ErrorEntity entity) {
+    return new Table.Builder()
+        .withColumnHeaders("Error")
+        .withRow(entity.getErrorMessage())
+        .build();
+  }
+}

--- a/ksql-rest-app/src/main/java/io/confluent/ksql/rest/entity/ConnectorInfoEntity.java
+++ b/ksql-rest-app/src/main/java/io/confluent/ksql/rest/entity/ConnectorInfoEntity.java
@@ -1,0 +1,78 @@
+/*
+ * Copyright 2019 Confluent Inc.
+ *
+ * Licensed under the Confluent Community License (the "License"; you may not use
+ * this file except in compliance with the License. You may obtain a copy of the
+ * License at
+ *
+ * http://www.confluent.io/confluent-community-license
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package io.confluent.ksql.rest.entity;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import java.util.Objects;
+import org.apache.kafka.connect.runtime.rest.entities.ConnectorInfo;
+
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class ConnectorInfoEntity extends KsqlEntity {
+
+  private final ConnectorInfo info;
+  private final Action action;
+
+  @JsonCreator
+  public ConnectorInfoEntity(
+      @JsonProperty("statementText") final String statementText,
+      @JsonProperty("info") final ConnectorInfo info,
+      @JsonProperty("action") final Action action
+  ) {
+    super(statementText);
+    this.info = Objects.requireNonNull(info, "info");
+    this.action = Objects.requireNonNull(action, "action");
+  }
+
+  public ConnectorInfo getInfo() {
+    return info;
+  }
+
+  public Action getAction() {
+    return action;
+  }
+
+  @Override
+  public boolean equals(final Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+
+    final ConnectorInfoEntity that = (ConnectorInfoEntity) o;
+    return Objects.equals(info, that.info);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(info);
+  }
+
+  @Override
+  public String toString() {
+    return "ConnectorInfoEntity{"
+        + "info=" + info
+        + '}';
+  }
+
+  public enum Action {
+    CREATE,
+    DESCRIBE
+  }
+}

--- a/ksql-rest-app/src/main/java/io/confluent/ksql/rest/entity/CreateConnectorEntity.java
+++ b/ksql-rest-app/src/main/java/io/confluent/ksql/rest/entity/CreateConnectorEntity.java
@@ -22,28 +22,21 @@ import java.util.Objects;
 import org.apache.kafka.connect.runtime.rest.entities.ConnectorInfo;
 
 @JsonIgnoreProperties(ignoreUnknown = true)
-public class ConnectorInfoEntity extends KsqlEntity {
+public class CreateConnectorEntity extends KsqlEntity {
 
   private final ConnectorInfo info;
-  private final Action action;
 
   @JsonCreator
-  public ConnectorInfoEntity(
+  public CreateConnectorEntity(
       @JsonProperty("statementText") final String statementText,
-      @JsonProperty("info") final ConnectorInfo info,
-      @JsonProperty("action") final Action action
+      @JsonProperty("info") final ConnectorInfo info
   ) {
     super(statementText);
     this.info = Objects.requireNonNull(info, "info");
-    this.action = Objects.requireNonNull(action, "action");
   }
 
   public ConnectorInfo getInfo() {
     return info;
-  }
-
-  public Action getAction() {
-    return action;
   }
 
   @Override
@@ -55,7 +48,7 @@ public class ConnectorInfoEntity extends KsqlEntity {
       return false;
     }
 
-    final ConnectorInfoEntity that = (ConnectorInfoEntity) o;
+    final CreateConnectorEntity that = (CreateConnectorEntity) o;
     return Objects.equals(info, that.info);
   }
 
@@ -66,13 +59,8 @@ public class ConnectorInfoEntity extends KsqlEntity {
 
   @Override
   public String toString() {
-    return "ConnectorInfoEntity{"
+    return "CreateConnectorEntity{"
         + "info=" + info
         + '}';
-  }
-
-  public enum Action {
-    CREATE,
-    DESCRIBE
   }
 }

--- a/ksql-rest-app/src/main/java/io/confluent/ksql/rest/entity/ErrorEntity.java
+++ b/ksql-rest-app/src/main/java/io/confluent/ksql/rest/entity/ErrorEntity.java
@@ -18,9 +18,11 @@ package io.confluent.ksql.rest.entity;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
+import com.google.errorprone.annotations.Immutable;
 import java.util.Objects;
 
 @JsonIgnoreProperties(ignoreUnknown = true)
+@Immutable
 public class ErrorEntity extends KsqlEntity {
 
   private final String errorMessage;

--- a/ksql-rest-app/src/main/java/io/confluent/ksql/rest/entity/ErrorEntity.java
+++ b/ksql-rest-app/src/main/java/io/confluent/ksql/rest/entity/ErrorEntity.java
@@ -1,0 +1,65 @@
+/*
+ * Copyright 2019 Confluent Inc.
+ *
+ * Licensed under the Confluent Community License (the "License"; you may not use
+ * this file except in compliance with the License. You may obtain a copy of the
+ * License at
+ *
+ * http://www.confluent.io/confluent-community-license
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package io.confluent.ksql.rest.entity;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import java.util.Objects;
+
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class ErrorEntity extends KsqlEntity {
+
+  private final String errorMessage;
+
+  @JsonCreator
+  public ErrorEntity(
+      @JsonProperty("statementText") final String statementText,
+      @JsonProperty("errorMessage") final String errorMessage
+  ) {
+    super(statementText);
+    this.errorMessage = Objects.requireNonNull(errorMessage, "errorMessage");
+  }
+
+  public String getErrorMessage() {
+    return errorMessage;
+  }
+
+  @Override
+  public boolean equals(final Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+
+    final ErrorEntity that = (ErrorEntity) o;
+    return Objects.equals(errorMessage, that.errorMessage);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(errorMessage);
+  }
+
+  @Override
+  public String toString() {
+    return "ErrorEntity{"
+        + "errorMessage='" + errorMessage + '\''
+        + '}';
+  }
+}

--- a/ksql-rest-app/src/main/java/io/confluent/ksql/rest/entity/KsqlEntity.java
+++ b/ksql-rest-app/src/main/java/io/confluent/ksql/rest/entity/KsqlEntity.java
@@ -41,7 +41,9 @@ import java.util.List;
     @JsonSubTypes.Type(value = SourceDescriptionList.class, name = "source_descriptions"),
     @JsonSubTypes.Type(value = QueryDescriptionList.class, name = "query_descriptions"),
     @JsonSubTypes.Type(value = FunctionDescriptionList.class, name = "describe_function"),
-    @JsonSubTypes.Type(value = FunctionNameList.class, name = "function_names")
+    @JsonSubTypes.Type(value = FunctionNameList.class, name = "function_names"),
+    @JsonSubTypes.Type(value = ConnectorInfoEntity.class, name = "connector_info"),
+    @JsonSubTypes.Type(value = ErrorEntity.class, name = "error_entity")
 })
 public abstract class KsqlEntity {
   private final String statementText;

--- a/ksql-rest-app/src/main/java/io/confluent/ksql/rest/entity/KsqlEntity.java
+++ b/ksql-rest-app/src/main/java/io/confluent/ksql/rest/entity/KsqlEntity.java
@@ -42,7 +42,7 @@ import java.util.List;
     @JsonSubTypes.Type(value = QueryDescriptionList.class, name = "query_descriptions"),
     @JsonSubTypes.Type(value = FunctionDescriptionList.class, name = "describe_function"),
     @JsonSubTypes.Type(value = FunctionNameList.class, name = "function_names"),
-    @JsonSubTypes.Type(value = ConnectorInfoEntity.class, name = "connector_info"),
+    @JsonSubTypes.Type(value = CreateConnectorEntity.class, name = "connector_info"),
     @JsonSubTypes.Type(value = ErrorEntity.class, name = "error_entity")
 })
 public abstract class KsqlEntity {

--- a/ksql-rest-app/src/main/java/io/confluent/ksql/rest/server/execution/ConnectExecutor.java
+++ b/ksql-rest-app/src/main/java/io/confluent/ksql/rest/server/execution/ConnectExecutor.java
@@ -1,0 +1,61 @@
+/*
+ * Copyright 2019 Confluent Inc.
+ *
+ * Licensed under the Confluent Community License (the "License"; you may not use
+ * this file except in compliance with the License. You may obtain a copy of the
+ * License at
+ *
+ * http://www.confluent.io/confluent-community-license
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package io.confluent.ksql.rest.server.execution;
+
+import com.google.common.collect.Maps;
+import io.confluent.ksql.KsqlExecutionContext;
+import io.confluent.ksql.parser.tree.CreateConnector;
+import io.confluent.ksql.rest.entity.ConnectorInfoEntity;
+import io.confluent.ksql.rest.entity.ConnectorInfoEntity.Action;
+import io.confluent.ksql.rest.entity.ErrorEntity;
+import io.confluent.ksql.rest.entity.KsqlEntity;
+import io.confluent.ksql.services.ConnectClient;
+import io.confluent.ksql.services.ConnectClient.ConnectResponse;
+import io.confluent.ksql.services.ServiceContext;
+import io.confluent.ksql.statement.ConfiguredStatement;
+import java.util.Optional;
+import org.apache.kafka.connect.runtime.rest.entities.ConnectorInfo;
+
+public final class ConnectExecutor {
+
+  private ConnectExecutor() { }
+
+  public static Optional<KsqlEntity> execute(
+      final ConfiguredStatement<CreateConnector> statement,
+      final KsqlExecutionContext executionContext,
+      final ServiceContext serviceContext
+  ) {
+    final CreateConnector createConnector = statement.getStatement();
+    final ConnectClient client = serviceContext.getConnectClient();
+
+    final ConnectResponse<ConnectorInfo> response = client.create(
+        createConnector.getName(),
+        Maps.transformValues(createConnector.getConfig(), l -> l.getValue().toString()));
+
+    if (response.datum().isPresent()) {
+      return Optional.of(
+          new ConnectorInfoEntity(
+              statement.getStatementText(),
+              response.datum().get(),
+              Action.CREATE
+          )
+      );
+    }
+
+    return response.error()
+        .map(err -> new ErrorEntity(statement.getStatementText(), err));
+  }
+}

--- a/ksql-rest-app/src/main/java/io/confluent/ksql/rest/server/execution/ConnectExecutor.java
+++ b/ksql-rest-app/src/main/java/io/confluent/ksql/rest/server/execution/ConnectExecutor.java
@@ -18,8 +18,7 @@ package io.confluent.ksql.rest.server.execution;
 import com.google.common.collect.Maps;
 import io.confluent.ksql.KsqlExecutionContext;
 import io.confluent.ksql.parser.tree.CreateConnector;
-import io.confluent.ksql.rest.entity.ConnectorInfoEntity;
-import io.confluent.ksql.rest.entity.ConnectorInfoEntity.Action;
+import io.confluent.ksql.rest.entity.CreateConnectorEntity;
 import io.confluent.ksql.rest.entity.ErrorEntity;
 import io.confluent.ksql.rest.entity.KsqlEntity;
 import io.confluent.ksql.services.ConnectClient;
@@ -47,10 +46,9 @@ public final class ConnectExecutor {
 
     if (response.datum().isPresent()) {
       return Optional.of(
-          new ConnectorInfoEntity(
+          new CreateConnectorEntity(
               statement.getStatementText(),
-              response.datum().get(),
-              Action.CREATE
+              response.datum().get()
           )
       );
     }

--- a/ksql-rest-app/src/main/java/io/confluent/ksql/rest/server/execution/CustomExecutors.java
+++ b/ksql-rest-app/src/main/java/io/confluent/ksql/rest/server/execution/CustomExecutors.java
@@ -18,6 +18,7 @@ package io.confluent.ksql.rest.server.execution;
 import com.google.common.collect.ImmutableMap;
 import io.confluent.ksql.KsqlExecutionContext;
 import io.confluent.ksql.engine.InsertValuesExecutor;
+import io.confluent.ksql.parser.tree.CreateConnector;
 import io.confluent.ksql.parser.tree.DescribeFunction;
 import io.confluent.ksql.parser.tree.Explain;
 import io.confluent.ksql.parser.tree.InsertValues;
@@ -61,7 +62,8 @@ public enum CustomExecutors {
   DESCRIBE_FUNCTION(DescribeFunction.class, DescribeFunctionExecutor::execute),
   SET_PROPERTY(SetProperty.class, PropertyExecutor::set),
   UNSET_PROPERTY(UnsetProperty.class, PropertyExecutor::unset),
-  INSERT_VALUES(InsertValues.class, insertValuesExecutor());
+  INSERT_VALUES(InsertValues.class, insertValuesExecutor()),
+  CREATE_CONNECTOR(CreateConnector.class, ConnectExecutor::execute);
 
   public static final Map<Class<? extends Statement>, StatementExecutor<?>> EXECUTOR_MAP =
       ImmutableMap.copyOf(

--- a/ksql-rest-app/src/main/java/io/confluent/ksql/rest/server/validation/CustomValidators.java
+++ b/ksql-rest-app/src/main/java/io/confluent/ksql/rest/server/validation/CustomValidators.java
@@ -18,6 +18,7 @@ package io.confluent.ksql.rest.server.validation;
 import com.google.common.collect.ImmutableMap;
 import io.confluent.ksql.KsqlExecutionContext;
 import io.confluent.ksql.engine.InsertValuesExecutor;
+import io.confluent.ksql.parser.tree.CreateConnector;
 import io.confluent.ksql.parser.tree.DescribeFunction;
 import io.confluent.ksql.parser.tree.Explain;
 import io.confluent.ksql.parser.tree.InsertValues;
@@ -64,8 +65,9 @@ public enum CustomValidators {
   LIST_FUNCTIONS(ListFunctions.class, StatementValidator.NO_VALIDATION),
   LIST_QUERIES(ListQueries.class, StatementValidator.NO_VALIDATION),
   LIST_PROPERTIES(ListProperties.class, StatementValidator.NO_VALIDATION),
-  INSERT_VALUES(InsertValues.class, new InsertValuesExecutor()::execute),
+  CREATE_CONNECTOR(CreateConnector.class, StatementValidator.NO_VALIDATION),
 
+  INSERT_VALUES(InsertValues.class, new InsertValuesExecutor()::execute),
   SHOW_COLUMNS(ShowColumns.class, ListSourceExecutor::columns),
   EXPLAIN(Explain.class, ExplainExecutor::execute),
   DESCRIBE_FUNCTION(DescribeFunction.class, DescribeFunctionExecutor::execute),

--- a/ksql-rest-app/src/test/java/io/confluent/ksql/rest/server/execution/ConnectExecutorTest.java
+++ b/ksql-rest-app/src/test/java/io/confluent/ksql/rest/server/execution/ConnectExecutorTest.java
@@ -28,7 +28,7 @@ import io.confluent.ksql.parser.KsqlParser.PreparedStatement;
 import io.confluent.ksql.parser.tree.CreateConnector;
 import io.confluent.ksql.parser.tree.CreateConnector.Type;
 import io.confluent.ksql.parser.tree.StringLiteral;
-import io.confluent.ksql.rest.entity.ConnectorInfoEntity;
+import io.confluent.ksql.rest.entity.CreateConnectorEntity;
 import io.confluent.ksql.rest.entity.ErrorEntity;
 import io.confluent.ksql.rest.entity.KsqlEntity;
 import io.confluent.ksql.services.ConnectClient;
@@ -94,7 +94,7 @@ public class ConnectExecutorTest {
 
     // Then:
     assertThat("Expected non-empty response", entity.isPresent());
-    assertThat(entity.get(), instanceOf(ConnectorInfoEntity.class));
+    assertThat(entity.get(), instanceOf(CreateConnectorEntity.class));
   }
 
   @Test

--- a/ksql-rest-app/src/test/java/io/confluent/ksql/rest/server/execution/ConnectExecutorTest.java
+++ b/ksql-rest-app/src/test/java/io/confluent/ksql/rest/server/execution/ConnectExecutorTest.java
@@ -1,0 +1,130 @@
+/*
+ * Copyright 2019 Confluent Inc.
+ *
+ * Licensed under the Confluent Community License (the "License"; you may not use
+ * this file except in compliance with the License. You may obtain a copy of the
+ * License at
+ *
+ * http://www.confluent.io/confluent-community-license
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package io.confluent.ksql.rest.server.execution;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.instanceOf;
+import static org.mockito.ArgumentMatchers.anyMap;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+import io.confluent.ksql.parser.KsqlParser.PreparedStatement;
+import io.confluent.ksql.parser.tree.CreateConnector;
+import io.confluent.ksql.parser.tree.CreateConnector.Type;
+import io.confluent.ksql.parser.tree.StringLiteral;
+import io.confluent.ksql.rest.entity.ConnectorInfoEntity;
+import io.confluent.ksql.rest.entity.ErrorEntity;
+import io.confluent.ksql.rest.entity.KsqlEntity;
+import io.confluent.ksql.services.ConnectClient;
+import io.confluent.ksql.services.ConnectClient.ConnectResponse;
+import io.confluent.ksql.services.ServiceContext;
+import io.confluent.ksql.statement.ConfiguredStatement;
+import io.confluent.ksql.util.KsqlConfig;
+import java.util.Optional;
+import org.apache.kafka.connect.runtime.rest.entities.ConnectorInfo;
+import org.apache.kafka.connect.runtime.rest.entities.ConnectorType;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnitRunner;
+
+@RunWith(MockitoJUnitRunner.class)
+public class ConnectExecutorTest {
+
+  private static final KsqlConfig CONFIG = new KsqlConfig(ImmutableMap.of());
+
+  private static final CreateConnector CREATE_CONNECTOR = new CreateConnector(
+      "foo", ImmutableMap.of("foo", new StringLiteral("bar")), Type.SOURCE);
+
+  private static final ConfiguredStatement<CreateConnector> CREATE_CONNECTOR_CONFIGURED =
+      ConfiguredStatement.of(
+          PreparedStatement.of(
+              "CREATE SOURCE CONNECTOR foo WITH ('foo'='bar');",
+              CREATE_CONNECTOR),
+          ImmutableMap.of(),
+          CONFIG);
+
+  @Mock
+  private ServiceContext serviceContext;
+  @Mock
+  private ConnectClient connectClient;
+
+  @Before
+  public void setUp() {
+    when(serviceContext.getConnectClient()).thenReturn(connectClient);
+  }
+
+  @Test
+  public void shouldPassInCorrectArgsToConnectClient() {
+    // Given:
+    givenSuccess();
+
+    // When:
+    final Optional<KsqlEntity> entity = ConnectExecutor
+        .execute(CREATE_CONNECTOR_CONFIGURED, null, serviceContext);
+
+    // Then:
+    verify(connectClient).create("foo", ImmutableMap.of("foo", "bar"));
+  }
+
+  @Test
+  public void shouldReturnConnectorInfoEntityOnSuccess() {
+    // Given:
+    givenSuccess();
+
+    // When:
+    final Optional<KsqlEntity> entity = ConnectExecutor
+        .execute(CREATE_CONNECTOR_CONFIGURED, null, serviceContext);
+
+    // Then:
+    assertThat("Expected non-empty response", entity.isPresent());
+    assertThat(entity.get(), instanceOf(ConnectorInfoEntity.class));
+  }
+
+  @Test
+  public void shouldReturnErrorEntityOnError() {
+    // Given:
+    givenError();
+
+    // When:
+    final Optional<KsqlEntity> entity = ConnectExecutor
+        .execute(CREATE_CONNECTOR_CONFIGURED, null, serviceContext);
+
+    // Then:
+    assertThat("Expected non-empty response", entity.isPresent());
+    assertThat(entity.get(), instanceOf(ErrorEntity.class));
+  }
+
+  private void givenSuccess() {
+    when(connectClient.create(anyString(), anyMap()))
+        .thenReturn(ConnectResponse.of(
+            new ConnectorInfo(
+                "foo",
+                ImmutableMap.of(),
+                ImmutableList.of(),
+                ConnectorType.SOURCE)));
+  }
+
+  private void givenError() {
+    when(connectClient.create(anyString(), anyMap()))
+        .thenReturn(ConnectResponse.of("error!"));
+  }
+
+}

--- a/ksql-rest-app/src/test/java/io/confluent/ksql/rest/server/execution/ConnectExecutorTest.java
+++ b/ksql-rest-app/src/test/java/io/confluent/ksql/rest/server/execution/ConnectExecutorTest.java
@@ -77,8 +77,7 @@ public class ConnectExecutorTest {
     givenSuccess();
 
     // When:
-    final Optional<KsqlEntity> entity = ConnectExecutor
-        .execute(CREATE_CONNECTOR_CONFIGURED, null, serviceContext);
+    ConnectExecutor.execute(CREATE_CONNECTOR_CONFIGURED, null, serviceContext);
 
     // Then:
     verify(connectClient).create("foo", ImmutableMap.of("foo", "bar"));


### PR DESCRIPTION
### Description 
Wires in the two previous connect prs #3137 and #3139 by introducing the following classes:
- `ErrorEntity` represents an error response from an external service
- `ConnectorInfoEntity` represents a response from connect describing a connector
- `ConnectExecutor` handles a `CreateConnector` statement

### Testing done 
- Basic unit tests
- End-to-end testing

```
ksql> CREATE SOURCE CONNECTOR `jdbc-connector6` WITH("connector.class"='io.confluent.connect.jdbc.JdbcSourceConnector',"tasks.max"='1',"connection.url"='jdbc:postgresql://localhost:5432/almog.gavra',"mode"='bulk',"topic.prefix"='jdbc2-',"transforms"='createKey,extractString',"transforms.createKey.type"= 'org.apache.kafka.connect.transforms.ValueToKey', "transforms.createKey.fields"='username',"transforms.extractString.type"='org.apache.kafka.connect.transforms.ExtractField$Key',"transforms.extractString.field"='username', "key.converter"='org.apache.kafka.connect.storage.StringConverter');

 Message
-----------------------------------
 Created connector jdbc-connector6
-----------------------------------

ksql> CREATE SOURCE CONNECTOR `jdbc-connector6` WITH("connector.class"='io.confluent.connect.jdbc.JdbcSourceConnector',"tasks.max"='1',"connection.url"='jdbc:postgresql://localhost:5432/almog.gavra',"mode"='bulk',"topic.prefix"='jdbc2-',"transforms"='createKey,extractString',"transforms.createKey.type"= 'org.apache.kafka.connect.transforms.ValueToKey', "transforms.createKey.fields"='username',"transforms.extractString.type"='org.apache.kafka.connect.transforms.ExtractField$Key',"transforms.extractString.field"='username', "key.converter"='org.apache.kafka.connect.storage.StringConverter');

 Error
-------------------------------------------------------------------------
 {"error_code":409,"message":"Connector jdbc-connector6 already exists"}
-------------------------------------------------------------------------
```

### TODO:

- [ ] Documentation. I will add full documentation at the end of the connect MVP deliverable so that it doesn't feel like a "partial" implementation.

### Reviewer checklist
- [ ] Ensure docs are updated if necessary. (eg. if a user visible feature is being added or changed).
- [ ] Ensure relevant issues are linked (description should include text like "Fixes #<issue number>")

