### PR TITLE
refactor: allow for more specific error messages to be sent when the server is unavailable

### DIFF
--- a/ksql-rest-app/src/main/java/io/confluent/ksql/rest/server/KsqlRestApplication.java
+++ b/ksql-rest-app/src/main/java/io/confluent/ksql/rest/server/KsqlRestApplication.java
@@ -46,6 +46,7 @@ import io.confluent.ksql.parser.tree.RegisterTopic;
 import io.confluent.ksql.parser.tree.StringLiteral;
 import io.confluent.ksql.parser.tree.TableElement;
 import io.confluent.ksql.parser.tree.Type.SqlType;
+import io.confluent.ksql.rest.entity.KsqlErrorMessage;
 import io.confluent.ksql.rest.server.computation.CommandQueue;
 import io.confluent.ksql.rest.server.computation.CommandRunner;
 import io.confluent.ksql.rest.server.computation.CommandStore;
@@ -224,13 +225,13 @@ public final class KsqlRestApplication extends Application<KsqlRestConfig> imple
 
   private void checkPreconditions() {
     for (final KsqlServerPrecondition precondition : preconditions) {
-      final Optional<String> error = precondition.checkPrecondition(
+      final Optional<KsqlErrorMessage> error = precondition.checkPrecondition(
           config,
           serviceContext
       );
       if (error.isPresent()) {
         serverState.setInitializingReason(error.get());
-        throw new KsqlFailedPrecondition(error.get());
+        throw new KsqlFailedPrecondition(error.get().toString());
       }
     }
   }

--- a/ksql-rest-app/src/main/java/io/confluent/ksql/rest/server/KsqlServerPrecondition.java
+++ b/ksql-rest-app/src/main/java/io/confluent/ksql/rest/server/KsqlServerPrecondition.java
@@ -15,7 +15,9 @@
 
 package io.confluent.ksql.rest.server;
 
+import io.confluent.ksql.rest.entity.KsqlErrorMessage;
 import io.confluent.ksql.services.ServiceContext;
+
 import java.util.Optional;
 
 public interface KsqlServerPrecondition {
@@ -24,10 +26,10 @@ public interface KsqlServerPrecondition {
    *
    * @param config The KSQL server config
    * @param serviceContext The KSQL server context for accessing external serivces
-   * @return Optional.empty() if precondition check passes, non-empty reason string if the
+   * @return Optional.empty() if precondition check passes, non-empty KsqlErrorMessage object if the
    *         check does not pass.
    */
-  Optional<String> checkPrecondition(
+  Optional<KsqlErrorMessage> checkPrecondition(
       KsqlRestConfig config,
       ServiceContext serviceContext
   );

--- a/ksql-rest-app/src/main/java/io/confluent/ksql/rest/server/resources/Errors.java
+++ b/ksql-rest-app/src/main/java/io/confluent/ksql/rest/server/resources/Errors.java
@@ -154,10 +154,10 @@ public final class Errors {
         .build();
   }
 
-  public static Response serverNotReady(final String reason) {
+  public static Response serverNotReady(final KsqlErrorMessage error) {
     return Response
         .status(SERVICE_UNAVAILABLE)
-        .entity(new KsqlErrorMessage(ERROR_CODE_SERVER_NOT_READY, reason))
+        .entity(error)
         .build();
   }
 }

--- a/ksql-rest-app/src/main/java/io/confluent/ksql/rest/server/state/ServerState.java
+++ b/ksql-rest-app/src/main/java/io/confluent/ksql/rest/server/state/ServerState.java
@@ -15,6 +15,7 @@
 
 package io.confluent.ksql.rest.server.state;
 
+import io.confluent.ksql.rest.entity.KsqlErrorMessage;
 import io.confluent.ksql.rest.server.resources.Errors;
 import java.util.Optional;
 import java.util.concurrent.atomic.AtomicReference;
@@ -35,23 +36,28 @@ public class ServerState {
     TERMINATING
   }
 
-  private static final class StateWithReason {
+  private static final class StateWithErrorMessage {
     final State state;
-    final String reason;
+    final KsqlErrorMessage errorMessage;
 
-    private StateWithReason(final State state, final String reason) {
+    private StateWithErrorMessage(final State state, final KsqlErrorMessage error) {
       this.state = state;
-      this.reason = reason;
+      this.errorMessage = error;
     }
 
-    private StateWithReason(final State state) {
+    private StateWithErrorMessage(final State state) {
       this.state = state;
-      this.reason = null;
+      this.errorMessage = null;
     }
   }
 
-  private final AtomicReference<StateWithReason> state = new AtomicReference<>(
-      new StateWithReason(State.INITIALIZING, "KSQL is not yet ready to serve requests.")
+  private final AtomicReference<StateWithErrorMessage> state = new AtomicReference<>(
+      new StateWithErrorMessage(State.INITIALIZING,
+              new KsqlErrorMessage(
+                      Errors.ERROR_CODE_SERVER_NOT_READY,
+                      "KSQL is not yet ready to serve requests."
+              )
+      )
   );
 
   /**
@@ -61,28 +67,29 @@ public class ServerState {
   }
 
   /**
-   * Set a reason string explaining why the server is still in the INITIALIZING state.
-   * This reason string will be used to add context to the API error indicating that the server
-   * is not yet ready to serve requests.
+   * Set a KsqlErrorMessage object containing a reason string explaining why the server
+   * is still in the INITIALIZING state and an error code. This reason string and corresponding
+   * error code will be used to add context to the API error indicating that the server is not
+   * yet ready to serve requests.
    *
-   * @param initializingReason The reason string indicating why the server is still initializing.
+   * @param error KsqlErrorMessage object containing the error code and the error string.
    */
-  public void setInitializingReason(final String initializingReason) {
-    this.state.set(new StateWithReason(State.INITIALIZING, initializingReason));
+  public void setInitializingReason(final KsqlErrorMessage error) {
+    this.state.set(new StateWithErrorMessage(State.INITIALIZING, error));
   }
 
   /**
    * Sets the server state to READY.
    */
   public void setReady() {
-    this.state.set(new StateWithReason(State.READY));
+    this.state.set(new StateWithErrorMessage(State.READY));
   }
 
   /**
    * Sets the server state to TERMINATING.
    */
   public void setTerminating() {
-    this.state.set(new StateWithReason(State.TERMINATING));
+    this.state.set(new StateWithErrorMessage(State.TERMINATING));
   }
 
   /**
@@ -93,10 +100,10 @@ public class ServerState {
    *         to be returned back to the user.
    */
   public Optional<Response> checkReady() {
-    final StateWithReason state = this.state.get();
+    final StateWithErrorMessage state = this.state.get();
     switch (state.state) {
       case INITIALIZING:
-        return Optional.of(Errors.serverNotReady(state.reason));
+        return Optional.of(Errors.serverNotReady(state.errorMessage));
       case TERMINATING:
         return Optional.of(Errors.serverShuttingDown());
       default:

--- a/ksql-rest-app/src/test/java/io/confluent/ksql/rest/server/KsqlRestApplicationTest.java
+++ b/ksql-rest-app/src/test/java/io/confluent/ksql/rest/server/KsqlRestApplicationTest.java
@@ -37,6 +37,7 @@ import io.confluent.ksql.logging.processing.ProcessingLogConfig;
 import io.confluent.ksql.logging.processing.ProcessingLogContext;
 import io.confluent.ksql.parser.KsqlParser.PreparedStatement;
 import io.confluent.ksql.parser.tree.CreateSource;
+import io.confluent.ksql.rest.entity.KsqlErrorMessage;
 import io.confluent.ksql.rest.server.computation.CommandRunner;
 import io.confluent.ksql.rest.server.computation.CommandStore;
 import io.confluent.ksql.rest.server.computation.QueuedCommandStatus;
@@ -326,9 +327,11 @@ public class KsqlRestApplicationTest {
   @Test
   public void shouldNotInitializeUntilPreconditionsChecked() {
     // Given:
-    final Queue<String> errors = new LinkedList<>();
-    errors.add("error1");
-    errors.add("error2");
+    KsqlErrorMessage error1 = new KsqlErrorMessage(50000, "error1");
+    KsqlErrorMessage error2 = new KsqlErrorMessage(50000, "error2");
+    final Queue<KsqlErrorMessage> errors = new LinkedList<>();
+    errors.add(error1);
+    errors.add(error2);
     when(precondition2.checkPrecondition(any(), any())).then(a -> {
       verifyZeroInteractions(serviceContext);
       return Optional.ofNullable(errors.isEmpty() ? null : errors.remove());
@@ -341,10 +344,10 @@ public class KsqlRestApplicationTest {
     final InOrder inOrder = Mockito.inOrder(precondition1, precondition2, serverState);
     inOrder.verify(precondition1).checkPrecondition(restConfig, serviceContext);
     inOrder.verify(precondition2).checkPrecondition(restConfig, serviceContext);
-    inOrder.verify(serverState).setInitializingReason("error1");
+    inOrder.verify(serverState).setInitializingReason(error1);
     inOrder.verify(precondition1).checkPrecondition(restConfig, serviceContext);
     inOrder.verify(precondition2).checkPrecondition(restConfig, serviceContext);
-    inOrder.verify(serverState).setInitializingReason("error2");
+    inOrder.verify(serverState).setInitializingReason(error2);
     inOrder.verify(precondition1).checkPrecondition(restConfig, serviceContext);
     inOrder.verify(precondition2).checkPrecondition(restConfig, serviceContext);
   }

--- a/ksql-rest-app/src/test/java/io/confluent/ksql/rest/server/state/ServerStateTest.java
+++ b/ksql-rest-app/src/test/java/io/confluent/ksql/rest/server/state/ServerStateTest.java
@@ -19,6 +19,7 @@ import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.is;
 import static org.junit.Assert.assertThat;
 
+import io.confluent.ksql.rest.entity.KsqlErrorMessage;
 import io.confluent.ksql.rest.server.resources.Errors;
 import java.util.Optional;
 import javax.ws.rs.core.Response;
@@ -30,7 +31,8 @@ public class ServerStateTest {
   @Test
   public void shouldReturnErrorWhenInitializing() {
     // Given:
-    serverState.setInitializingReason("bad stuff is happening");
+    KsqlErrorMessage error = new KsqlErrorMessage(12345, "bad stuff is happening");
+    serverState.setInitializingReason(error);
 
     // When:
     final Optional<Response> result = serverState.checkReady();
@@ -38,7 +40,7 @@ public class ServerStateTest {
     // Then:
     assertThat(result.isPresent(), is(true));
     final Response response = result.get();
-    final Response expected = Errors.serverNotReady("bad stuff is happening");
+    final Response expected = Errors.serverNotReady(error);
     assertThat(response.getStatus(), equalTo(expected.getStatus()));
     assertThat(response.getEntity(), equalTo(expected.getEntity()));
   }


### PR DESCRIPTION
### Description 
Instead of only receiving an error string from precondition checks, receives a KsqlErrorMessage object that can be directly passed along to anyone who checks serverState while it's in State.Initializing

### Testing done 
Fixed unit tests that broke and ran them to verify they passed
mvn clean install
Tested in CPD
### Reviewer checklist
- [ ] Ensure docs are updated if necessary. (eg. if a user visible feature is being added or changed).
- [ ] Ensure relevant issues are linked (description should include text like "Fixes #<issue number>")

