### PR TITLE
Wrap timestamps in ROWTIME expressions with STRINGTOTIMESTAMP

### DIFF
--- a/docs/developer-guide/syntax-reference.rst
+++ b/docs/developer-guide/syntax-reference.rst
@@ -1153,16 +1153,19 @@ Example:
       WHERE ROWTIME >= 1510923225000
         AND ROWTIME <= 1510923228000;
 
-When writing logical expressions using `ROWTIME`, ISO-8061 formatted datestrings can also be used to represent dates.
+When writing logical expressions using ``ROWTIME``, ISO-8601 formatted datestrings can also be used to represent dates.
 For example, the above query is equivalent to the following:
 
 .. code:: sql
+
     SELECT * FROM pageviews
           WHERE ROWTIME >= '2017-11-17 04:53:45'
             AND ROWTIME <= '2017-11-17 04:53:48';
 
-If the datestring is inexact, the rest of the timestamp is assumed to be 0.
-For example, `ROWTIME = `2019-07-30 11:00` is equivalent to `ROWTIME = `2019-07-30 11:00:00`.
+If the datestring is inexact, the rest of the timestamp is assumed to be padded with 0's.
+For example, ``ROWTIME = '2019-07-30 11:00'`` is equivalent to ``ROWTIME = '2019-07-30 11:00:00.0000'``.
+
+Note that the timestamps are interperted in the UTC timezone.
 
 A ``LIMIT`` can be used to limit the number of rows returned. Once the limit is reached the query will terminate.
 

--- a/docs/developer-guide/syntax-reference.rst
+++ b/docs/developer-guide/syntax-reference.rst
@@ -1153,6 +1153,19 @@ Example:
       WHERE ROWTIME >= 1510923225000
         AND ROWTIME <= 1510923228000;
 
+When writing logical expressions using `ROWTIME`, ISO-8061 formatted datestrings can also be used to represent dates.
+For example, the above query is equivalent to the following:
+
+.. code:: sql
+    SELECT * FROM pageviews
+          WHERE ROWTIME >= '2017-11-17 04:53:45'
+            AND ROWTIME <= '2017-11-17 04:53:48';
+
+If the datestring is inexact, the `ROWTIME` will match the timestamp down to the smallest temporal term specified.
+For example, `ROWTIME = `2019-07-30` will return true for all timestamps from July 30, 2019,
+and `ROWTIME = 2019-07-30 11:00` will return true for all timestamps between `2019-07-30 11:00:00`
+and `2019-07-30 11:00:59`.
+
 A ``LIMIT`` can be used to limit the number of rows returned. Once the limit is reached the query will terminate.
 
 Example:

--- a/docs/developer-guide/syntax-reference.rst
+++ b/docs/developer-guide/syntax-reference.rst
@@ -1159,13 +1159,14 @@ For example, the above query is equivalent to the following:
 .. code:: sql
 
     SELECT * FROM pageviews
-          WHERE ROWTIME >= '2017-11-17 04:53:45'
-            AND ROWTIME <= '2017-11-17 04:53:48';
+          WHERE ROWTIME >= '2017-11-17T04:53:45'
+            AND ROWTIME <= '2017-11-17T04:53:48';
 
 If the datestring is inexact, the rest of the timestamp is assumed to be padded with 0's.
-For example, ``ROWTIME = '2019-07-30 11:00'`` is equivalent to ``ROWTIME = '2019-07-30 11:00:00.0000'``.
+For example, ``ROWTIME = '2019-07-30T11:00'`` is equivalent to ``ROWTIME = '2019-07-30T11:00:00.0000'``.
 
-Note that the timestamps are interperted in the UTC timezone.
+Timezones can be specified within the datestring. For example, `2017-11-17T04:53:45-0330` is in the Newfoundland time
+zone. If no timezone is specified within the datestring, then timestamps are interperted in the UTC timezone.
 
 A ``LIMIT`` can be used to limit the number of rows returned. Once the limit is reached the query will terminate.
 

--- a/docs/developer-guide/syntax-reference.rst
+++ b/docs/developer-guide/syntax-reference.rst
@@ -1161,10 +1161,8 @@ For example, the above query is equivalent to the following:
           WHERE ROWTIME >= '2017-11-17 04:53:45'
             AND ROWTIME <= '2017-11-17 04:53:48';
 
-If the datestring is inexact, the `ROWTIME` will match the timestamp down to the smallest temporal term specified.
-For example, `ROWTIME = `2019-07-30` will return true for all timestamps from July 30, 2019,
-and `ROWTIME = 2019-07-30 11:00` will return true for all timestamps between `2019-07-30 11:00:00`
-and `2019-07-30 11:00:59`.
+If the datestring is inexact, the rest of the timestamp is assumed to be 0.
+For example, `ROWTIME = `2019-07-30 11:00` is equivalent to `ROWTIME = `2019-07-30 11:00:00`.
 
 A ``LIMIT`` can be used to limit the number of rows returned. Once the limit is reached the query will terminate.
 

--- a/ksql-engine/src/main/java/io/confluent/ksql/function/udf/datetime/StringToTimestamp.java
+++ b/ksql-engine/src/main/java/io/confluent/ksql/function/udf/datetime/StringToTimestamp.java
@@ -24,6 +24,7 @@ import io.confluent.ksql.function.udf.UdfDescription;
 import io.confluent.ksql.function.udf.UdfParameter;
 import io.confluent.ksql.util.KsqlConstants;
 import io.confluent.ksql.util.timestamp.StringToTimestampParser;
+
 import java.time.ZoneId;
 import java.util.concurrent.ExecutionException;
 

--- a/ksql-functional-tests/src/test/resources/query-validation-tests/rowtime.json
+++ b/ksql-functional-tests/src/test/resources/query-validation-tests/rowtime.json
@@ -1,0 +1,101 @@
+{
+  "comments": [
+    "Tests covering filters using ROWTIME"
+  ],
+  "tests": [
+    {
+      "name": "test ROWTIME",
+      "statements": [
+        "CREATE STREAM TEST (source int) WITH (kafka_topic='test_topic', value_format='JSON');",
+        "CREATE STREAM OUTPUT AS SELECT source AS THING FROM TEST WHERE ROWTIME>'2018-01-01T00:00:00';"
+      ],
+      "inputs": [
+        {"topic": "test_topic", "key": 0, "value": {"source": null}, "timestamp": 0},
+        {"topic": "test_topic", "key": 1, "value": {"source": 1}, "timestamp": 0},
+        {"topic": "test_topic", "key": 2, "value": {"source": 2}, "timestamp": 1546300808000},
+        {"topic": "test_topic", "key": 3, "value": {"source": 3}, "timestamp": 1546300800000},
+        {"topic": "test_topic", "key": 4, "value": {"source": 4}, "timestamp": 0},
+        {"topic": "test_topic", "key": 5, "value": {"source": 5}, "timestamp": 0}
+      ],
+      "outputs": [
+        {"topic": "OUTPUT", "key": 2, "value": {"THING": 2}, "timestamp": 1546300808000},
+        {"topic": "OUTPUT", "key": 3, "value": {"THING": 3}, "timestamp": 1546300800000}
+      ]
+    },
+    {
+      "name": "test ROWTIME with BETWEEN",
+      "statements": [
+        "CREATE STREAM TEST (source int) WITH (kafka_topic='test_topic', value_format='JSON');",
+        "CREATE STREAM OUTPUT AS SELECT source AS THING FROM TEST WHERE ROWTIME BETWEEN '2018-01-01T00:00:00' AND '2019-12-31T23:59:59';"
+      ],
+      "inputs": [
+        {"topic": "test_topic", "key": 0, "value": {"source": null}, "timestamp": 0},
+        {"topic": "test_topic", "key": 1, "value": {"source": 1}, "timestamp": 1546300808000},
+        {"topic": "test_topic", "key": 2, "value": {"source": 2}, "timestamp": 0},
+        {"topic": "test_topic", "key": 3, "value": {"source": 3}, "timestamp": 1536307808000},
+        {"topic": "test_topic", "key": 4, "value": {"source": 4}, "timestamp": 0},
+        {"topic": "test_topic", "key": 5, "value": {"source": 5}, "timestamp": 1600000000000}
+      ],
+      "outputs": [
+        {"topic": "OUTPUT", "key": 1, "value": {"THING": 1}, "timestamp": 1546300808000},
+        {"topic": "OUTPUT", "key": 3, "value": {"THING": 3}, "timestamp": 1536307808000}
+      ]
+    },
+    {
+      "name": "test ROWTIME with timezone",
+      "statements": [
+        "CREATE STREAM TEST (source int) WITH (kafka_topic='test_topic', value_format='JSON');",
+        "CREATE STREAM OUTPUT AS SELECT source AS THING FROM TEST WHERE ROWTIME > '2019-01-01T00:00:00+0445';"
+      ],
+      "inputs": [
+        {"topic": "test_topic", "key": 0, "value": {"source": null}, "timestamp": 0},
+        {"topic": "test_topic", "key": 1, "value": {"source": 1}, "timestamp": 1546300800000},
+        {"topic": "test_topic", "key": 2, "value": {"source": 2}, "timestamp": 0},
+        {"topic": "test_topic", "key": 3, "value": {"source": 3}, "timestamp": 0},
+        {"topic": "test_topic", "key": 4, "value": {"source": 4}, "timestamp": 0},
+        {"topic": "test_topic", "key": 5, "value": {"source": 5}, "timestamp": 1600000000000}
+      ],
+      "outputs": [
+        {"topic": "OUTPUT", "key": 1, "value": {"THING": 1}, "timestamp": 1546300800000},
+        {"topic": "OUTPUT", "key": 5, "value": {"THING": 5}, "timestamp": 1600000000000}
+      ]
+    },
+    {
+      "name": "test ROWTIME with AND",
+      "statements": [
+        "CREATE STREAM TEST (source int) WITH (kafka_topic='test_topic', value_format='JSON');",
+        "CREATE STREAM OUTPUT AS SELECT source AS THING FROM TEST WHERE ROWTIME >= '2019-01-01T00:00:00' AND SOURCE=5;"
+      ],
+      "inputs": [
+        {"topic": "test_topic", "key": 0, "value": {"source": null}, "timestamp": 0},
+        {"topic": "test_topic", "key": 1, "value": {"source": 1}, "timestamp": 1546300800000},
+        {"topic": "test_topic", "key": 2, "value": {"source": 2}, "timestamp": 0},
+        {"topic": "test_topic", "key": 3, "value": {"source": 3}, "timestamp": 0},
+        {"topic": "test_topic", "key": 4, "value": {"source": 4}, "timestamp": 0},
+        {"topic": "test_topic", "key": 5, "value": {"source": 5}, "timestamp": 1600000000000}
+      ],
+      "outputs": [
+        {"topic": "OUTPUT", "key": 5, "value": {"THING": 5}, "timestamp": 1600000000000}
+      ]
+    },
+    {
+      "name": "test ROWTIME with inexact timestring",
+      "statements": [
+        "CREATE STREAM TEST (source int) WITH (kafka_topic='test_topic', value_format='JSON');",
+        "CREATE STREAM OUTPUT AS SELECT source AS THING FROM TEST WHERE ROWTIME >= '2018';"
+      ],
+      "inputs": [
+        {"topic": "test_topic", "key": 0, "value": {"source": null}, "timestamp": 0},
+        {"topic": "test_topic", "key": 1, "value": {"source": 1}, "timestamp": 1546300800000},
+        {"topic": "test_topic", "key": 2, "value": {"source": 2}, "timestamp": 0},
+        {"topic": "test_topic", "key": 3, "value": {"source": 3}, "timestamp": 0},
+        {"topic": "test_topic", "key": 4, "value": {"source": 4}, "timestamp": 0},
+        {"topic": "test_topic", "key": 5, "value": {"source": 5}, "timestamp": 1600000000000}
+      ],
+      "outputs": [
+        {"topic": "OUTPUT", "key": 1, "value": {"THING": 1}, "timestamp": 1546300800000},
+        {"topic": "OUTPUT", "key": 5, "value": {"THING": 5}, "timestamp": 1600000000000}
+      ]
+    }
+  ]
+}

--- a/ksql-parser/src/main/java/io/confluent/ksql/parser/rewrite/StatementRewriteForRowtime.java
+++ b/ksql-parser/src/main/java/io/confluent/ksql/parser/rewrite/StatementRewriteForRowtime.java
@@ -1,0 +1,107 @@
+/*
+ * Copyright 2019 Confluent Inc.
+ *
+ * Licensed under the Confluent Community License (the "License"); you may not use
+ * this file except in compliance with the License.  You may obtain a copy of the
+ * License at
+ *
+ * http://www.confluent.io/confluent-community-license
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package io.confluent.ksql.parser.rewrite;
+
+import io.confluent.ksql.parser.tree.BetweenPredicate;
+import io.confluent.ksql.parser.tree.ComparisonExpression;
+import io.confluent.ksql.parser.tree.Expression;
+import io.confluent.ksql.parser.tree.FunctionCall;
+import io.confluent.ksql.parser.tree.Node;
+import io.confluent.ksql.parser.tree.QualifiedName;
+import io.confluent.ksql.parser.tree.StringLiteral;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Objects;
+
+public class StatementRewriteForRowtime {
+  private final Expression expression;
+
+  public StatementRewriteForRowtime(final Expression expression) {
+    this.expression = Objects.requireNonNull(expression, "expression");
+  }
+
+  public static boolean requiresRewrite(final Expression expression) {
+    return expression.toString().contains("ROWTIME");
+  }
+
+  public Expression rewriteForRowtime() {
+    return (Expression) new RewriteWithTimestampTransform().process(expression, null);
+  }
+
+  private static class TimestampRewriter extends StatementRewriter {
+    private static final String PATTERN = "yyyy-MM-dd HH:mm:ss.SSS";
+
+    @Override
+    public Expression visitFunctionCall(final FunctionCall node, final Object context) {
+      return (Expression) new StatementRewriter().process(node, context);
+    }
+
+    @Override
+    public Node visitStringLiteral(final StringLiteral node, final Object context) {
+      if (!node.getValue().equals("ROWTIME")) {
+        final List<Expression> args = new ArrayList<>();
+        args.add(new StringLiteral(appendZeros(node.getValue())));
+        args.add(new StringLiteral(PATTERN));
+        return new FunctionCall(QualifiedName.of("STRINGTOTIMESTAMP"), args);
+      }
+      return node;
+    }
+
+    private String appendZeros(final String timestamp) {
+      if (timestamp.length() >= PATTERN.length()) {
+        return timestamp;
+      }
+      return timestamp + PATTERN.substring(timestamp.length()).replaceAll("[a-zA-Z]", "0");
+    }
+  }
+
+  private static class RewriteWithTimestampTransform extends StatementRewriter {
+    @Override
+    public Expression visitBetweenPredicate(final BetweenPredicate node, final Object context) {
+      if (StatementRewriteForRowtime.requiresRewrite(node)) {
+        return new BetweenPredicate(
+            node.getLocation(),
+            (Expression) new TimestampRewriter().process(node.getValue(), context),
+            (Expression) new TimestampRewriter().process(node.getMin(), context),
+            (Expression) new TimestampRewriter().process(node.getMax(), context));
+      }
+      return new BetweenPredicate(
+          node.getLocation(),
+          (Expression) process(node.getValue(), context),
+          (Expression) process(node.getMin(), context),
+          (Expression) process(node.getMax(), context));
+    }
+
+    @Override
+    public Expression visitComparisonExpression(
+        final ComparisonExpression node,
+        final Object context) {
+      if (StatementRewriteForRowtime.requiresRewrite(node)) {
+        return new ComparisonExpression(
+          node.getLocation(),
+          node.getType(),
+          (Expression) new TimestampRewriter().process(node.getLeft(), context),
+          (Expression) new TimestampRewriter().process(node.getRight(), context));
+      }
+      return new ComparisonExpression(
+          node.getLocation(),
+          node.getType(),
+          (Expression) process(node.getLeft(), context),
+          (Expression) process(node.getRight(), context));
+    }
+  }
+}

--- a/ksql-parser/src/test/java/io/confluent/ksql/parser/rewrite/StatementRewriteForRowtimeTest.java
+++ b/ksql-parser/src/test/java/io/confluent/ksql/parser/rewrite/StatementRewriteForRowtimeTest.java
@@ -1,0 +1,100 @@
+/*
+ * Copyright 2019 Confluent Inc.
+ *
+ * Licensed under the Confluent Community License (the "License"); you may not use
+ * this file except in compliance with the License.  You may obtain a copy of the
+ * License at
+ *
+ * http://www.confluent.io/confluent-community-license
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package io.confluent.ksql.parser.rewrite;
+
+import io.confluent.ksql.function.FunctionRegistry;
+import io.confluent.ksql.metastore.MetaStore;
+import io.confluent.ksql.parser.KsqlParserTestUtil;
+import io.confluent.ksql.parser.tree.*;
+import io.confluent.ksql.util.MetaStoreFixture;
+import org.junit.Before;
+import org.junit.Test;
+
+import static org.hamcrest.CoreMatchers.containsString;
+import static org.hamcrest.CoreMatchers.equalTo;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.mockito.Mockito.mock;
+
+public class StatementRewriteForRowtimeTest {
+  private MetaStore metaStore;
+
+  @Before
+  public void init() {
+    metaStore = MetaStoreFixture.getNewMetaStore(mock(FunctionRegistry.class));
+  }
+
+  @Test
+  public void shouldReplaceStringWithLong() {
+    final String query = "SELECT * FROM orders where ROWTIME > '2017-01-01 00:00:00.000';";
+    final Query statement = (Query) KsqlParserTestUtil.buildSingleAst(query, metaStore).getStatement();
+    final Expression predicate = statement.getWhere().get();
+    final Expression rewritten = new StatementRewriteForRowtime(predicate).rewriteForRowtime();
+
+    assertThat(rewritten.toString(), equalTo("(ORDERS.ROWTIME > STRINGTOTIMESTAMP('2017-01-01 00:00:00.000', 'yyyy-MM-dd HH:mm:ss.SSS'))"));
+  }
+
+  @Test
+  public void shouldHandleInexactTimestamp() {
+    final String query = "SELECT * FROM orders where ROWTIME = '2017-01-01';";
+    final Query statement = (Query) KsqlParserTestUtil.buildSingleAst(query, metaStore).getStatement();
+    final Expression predicate = statement.getWhere().get();
+    final Expression rewritten = new StatementRewriteForRowtime(predicate).rewriteForRowtime();
+
+    assertThat(rewritten.toString(), equalTo("(ORDERS.ROWTIME = STRINGTOTIMESTAMP('2017-01-01 00:00:00.000', 'yyyy-MM-dd HH:mm:ss.SSS'))"));
+  }
+
+  @Test
+  public void shouldHandleBetweenExpression() {
+    final String query = "SELECT * FROM orders where ROWTIME BETWEEN '2017-01-01' AND '2017-02-01';";
+    final Query statement = (Query) KsqlParserTestUtil.buildSingleAst(query, metaStore).getStatement();
+    final Expression predicate = statement.getWhere().get();
+    final Expression rewritten = new StatementRewriteForRowtime(predicate).rewriteForRowtime();
+
+    assertThat(rewritten.toString(), equalTo("(ORDERS.ROWTIME BETWEEN"
+        + " STRINGTOTIMESTAMP('2017-01-01 00:00:00.000', 'yyyy-MM-dd HH:mm:ss.SSS') AND"
+        + " STRINGTOTIMESTAMP('2017-02-01 00:00:00.000', 'yyyy-MM-dd HH:mm:ss.SSS'))"));
+  }
+
+  @Test
+  public void shouldNotProcessStringsInFunctions() {
+    final String query = "SELECT * FROM orders where ROWTIME = foo('bar');";
+    final Query statement = (Query) KsqlParserTestUtil.buildSingleAst(query, metaStore).getStatement();
+    final Expression predicate = statement.getWhere().get();
+    final Expression rewritten = new StatementRewriteForRowtime(predicate).rewriteForRowtime();
+
+    assertThat(rewritten.toString(), equalTo("(ORDERS.ROWTIME = FOO('bar'))"));
+  }
+
+  @Test
+  public void shouldIgnoreNonRowtimeStrings() {
+    final String query = "SELECT * FROM orders where ROWTIME > '2017-01-01' AND ROWKEY = '2017-01-01';";
+    final Query statement = (Query) KsqlParserTestUtil.buildSingleAst(query, metaStore).getStatement();
+    final Expression predicate = statement.getWhere().get();
+    final Expression rewritten = new StatementRewriteForRowtime(predicate).rewriteForRowtime();
+
+    assertThat(rewritten.toString(), equalTo("((ORDERS.ROWTIME > STRINGTOTIMESTAMP('2017-01-01 00:00:00.000', 'yyyy-MM-dd HH:mm:ss.SSS')) AND (ORDERS.ROWKEY = '2017-01-01'))"));
+  }
+
+  @Test
+  public void shouldHandleNestedExpressions() {
+    final String simpleQuery = "SELECT * FROM orders where FOO(ROWTIME + 6000) > '2017-01-01 00:00:00.000' + 35;";
+    final Query statement = (Query) KsqlParserTestUtil.buildSingleAst(simpleQuery, metaStore).getStatement();
+    final Expression predicate = statement.getWhere().get();
+    final Expression rewritten = new StatementRewriteForRowtime(predicate).rewriteForRowtime();
+
+    assertThat(rewritten.toString(), containsString("(FOO((ORDERS.ROWTIME + 6000)) > (STRINGTOTIMESTAMP('2017-01-01 00:00:00.000', 'yyyy-MM-dd HH:mm:ss.SSS') + 35))"));
+  }
+}


### PR DESCRIPTION
### Description 
Because the `ROWTIME` is stored as a Long, the user either has to pass in Long values or use  `STRINGTOTIMESTAMP` function to make queries using `ROWTIME`, for example:

`ROWTIME > STRINGTOTIMESTAMP('1970-01-01', 'yyyy-mm-dd')`
`ROWTIME BETWEEN 156469222000 AND 1564692253275`

This change wraps datestrings with `STRINGTOTIMESTAMP` so the user can directly pass datestrings for querying:

`ROWTIME > '1970-01-01'`
`ROWTIME BETWEEN '1970-01-01 08:00:00' AND ''1970-01-01 10:00:00`

### Testing done 
Wrote tests for several types of expressions.

### Reviewer checklist
- [ ] Ensure docs are updated if necessary. (eg. if a user visible feature is being added or changed).
- [ ] Ensure relevant issues are linked (description should include text like "Fixes #<issue number>")

