### PR TITLE
chore: Fix merge revert

### DIFF
--- a/docs/developer-guide/serialization.rst
+++ b/docs/developer-guide/serialization.rst
@@ -190,7 +190,7 @@ Single-field serialization examples
     -- results in an error as the value schema is multi-field
     CREATE STREAM BAD_SINK WITH(WRAP_SINGLE_VALUE=true) AS SELECT ID, COST FROM S;
 
-.. _ksql_formats
+.. _ksql_formats:
 
 =======
 Formats
@@ -203,7 +203,7 @@ KSQL currently supports three serialization formats:
 *. ``AVRO`` supports AVRO serialized values. See :ref:`avro_format` below.
 *. ``KAFKA`` supports primitives serialized using the standard Kafka serializers. See :ref:`kafka_format` below.
 
-.. _delimited_format
+.. _delimited_format:
 
 ---------
 DELIMITED
@@ -225,7 +225,7 @@ KSQL splits a value of ``120, bob, 49`` into the three fields with ``ID`` of ``1
 This data format supports all KSQL :ref:`data types <data-types>` except ``ARRAY``, ``MAP`` and
 ``STRUCT``.
 
-.. _json_format
+.. _json_format:
 
 ----
 JSON
@@ -298,7 +298,7 @@ Field Name Case Sensitivity
 The format is case-insensitive when matching a KSQL field name with a JSON document's property name.
 The first case-insensitive match is used.
 
-.. _avro_format
+.. _avro_format:
 
 ----
 Avro

--- a/ksql-rest-app/src/main/java/io/confluent/ksql/rest/server/KsqlRestApplication.java
+++ b/ksql-rest-app/src/main/java/io/confluent/ksql/rest/server/KsqlRestApplication.java
@@ -36,6 +36,7 @@ import io.confluent.ksql.logging.processing.ProcessingLogConfig;
 import io.confluent.ksql.logging.processing.ProcessingLogContext;
 import io.confluent.ksql.parser.KsqlParser.ParsedStatement;
 import io.confluent.ksql.parser.KsqlParser.PreparedStatement;
+import io.confluent.ksql.rest.entity.KsqlErrorMessage;
 import io.confluent.ksql.rest.server.computation.CommandQueue;
 import io.confluent.ksql.rest.server.computation.CommandRunner;
 import io.confluent.ksql.rest.server.computation.CommandStore;
@@ -215,13 +216,13 @@ public final class KsqlRestApplication extends Application<KsqlRestConfig> imple
 
   private void checkPreconditions() {
     for (final KsqlServerPrecondition precondition : preconditions) {
-      final Optional<String> error = precondition.checkPrecondition(
+      final Optional<KsqlErrorMessage> error = precondition.checkPrecondition(
           config,
           serviceContext
       );
       if (error.isPresent()) {
         serverState.setInitializingReason(error.get());
-        throw new KsqlFailedPrecondition(error.get());
+        throw new KsqlFailedPrecondition(error.get().toString());
       }
     }
   }

--- a/ksql-rest-app/src/main/java/io/confluent/ksql/rest/server/KsqlServerPrecondition.java
+++ b/ksql-rest-app/src/main/java/io/confluent/ksql/rest/server/KsqlServerPrecondition.java
@@ -15,7 +15,9 @@
 
 package io.confluent.ksql.rest.server;
 
+import io.confluent.ksql.rest.entity.KsqlErrorMessage;
 import io.confluent.ksql.services.ServiceContext;
+
 import java.util.Optional;
 
 public interface KsqlServerPrecondition {
@@ -24,10 +26,10 @@ public interface KsqlServerPrecondition {
    *
    * @param config The KSQL server config
    * @param serviceContext The KSQL server context for accessing external serivces
-   * @return Optional.empty() if precondition check passes, non-empty reason string if the
+   * @return Optional.empty() if precondition check passes, non-empty KsqlErrorMessage object if the
    *         check does not pass.
    */
-  Optional<String> checkPrecondition(
+  Optional<KsqlErrorMessage> checkPrecondition(
       KsqlRestConfig config,
       ServiceContext serviceContext
   );

--- a/ksql-rest-app/src/main/java/io/confluent/ksql/rest/server/resources/Errors.java
+++ b/ksql-rest-app/src/main/java/io/confluent/ksql/rest/server/resources/Errors.java
@@ -164,10 +164,10 @@ public final class Errors {
         .build();
   }
 
-  public static Response serverNotReady(final String reason) {
+  public static Response serverNotReady(final KsqlErrorMessage error) {
     return Response
         .status(SERVICE_UNAVAILABLE)
-        .entity(new KsqlErrorMessage(ERROR_CODE_SERVER_NOT_READY, reason))
+        .entity(error)
         .build();
   }
 }

--- a/ksql-rest-app/src/main/java/io/confluent/ksql/rest/server/state/ServerState.java
+++ b/ksql-rest-app/src/main/java/io/confluent/ksql/rest/server/state/ServerState.java
@@ -15,6 +15,7 @@
 
 package io.confluent.ksql.rest.server.state;
 
+import io.confluent.ksql.rest.entity.KsqlErrorMessage;
 import io.confluent.ksql.rest.server.resources.Errors;
 import java.util.Optional;
 import java.util.concurrent.atomic.AtomicReference;
@@ -35,23 +36,28 @@ public class ServerState {
     TERMINATING
   }
 
-  private static final class StateWithReason {
+  private static final class StateWithErrorMessage {
     final State state;
-    final String reason;
+    final KsqlErrorMessage errorMessage;
 
-    private StateWithReason(final State state, final String reason) {
+    private StateWithErrorMessage(final State state, final KsqlErrorMessage error) {
       this.state = state;
-      this.reason = reason;
+      this.errorMessage = error;
     }
 
-    private StateWithReason(final State state) {
+    private StateWithErrorMessage(final State state) {
       this.state = state;
-      this.reason = null;
+      this.errorMessage = null;
     }
   }
 
-  private final AtomicReference<StateWithReason> state = new AtomicReference<>(
-      new StateWithReason(State.INITIALIZING, "KSQL is not yet ready to serve requests.")
+  private final AtomicReference<StateWithErrorMessage> state = new AtomicReference<>(
+      new StateWithErrorMessage(State.INITIALIZING,
+              new KsqlErrorMessage(
+                      Errors.ERROR_CODE_SERVER_NOT_READY,
+                      "KSQL is not yet ready to serve requests."
+              )
+      )
   );
 
   /**
@@ -61,28 +67,29 @@ public class ServerState {
   }
 
   /**
-   * Set a reason string explaining why the server is still in the INITIALIZING state.
-   * This reason string will be used to add context to the API error indicating that the server
-   * is not yet ready to serve requests.
+   * Set a KsqlErrorMessage object containing a reason string explaining why the server
+   * is still in the INITIALIZING state and an error code. This reason string and corresponding
+   * error code will be used to add context to the API error indicating that the server is not
+   * yet ready to serve requests.
    *
-   * @param initializingReason The reason string indicating why the server is still initializing.
+   * @param error KsqlErrorMessage object containing the error code and the error string.
    */
-  public void setInitializingReason(final String initializingReason) {
-    this.state.set(new StateWithReason(State.INITIALIZING, initializingReason));
+  public void setInitializingReason(final KsqlErrorMessage error) {
+    this.state.set(new StateWithErrorMessage(State.INITIALIZING, error));
   }
 
   /**
    * Sets the server state to READY.
    */
   public void setReady() {
-    this.state.set(new StateWithReason(State.READY));
+    this.state.set(new StateWithErrorMessage(State.READY));
   }
 
   /**
    * Sets the server state to TERMINATING.
    */
   public void setTerminating() {
-    this.state.set(new StateWithReason(State.TERMINATING));
+    this.state.set(new StateWithErrorMessage(State.TERMINATING));
   }
 
   /**
@@ -93,10 +100,10 @@ public class ServerState {
    *         to be returned back to the user.
    */
   public Optional<Response> checkReady() {
-    final StateWithReason state = this.state.get();
+    final StateWithErrorMessage state = this.state.get();
     switch (state.state) {
       case INITIALIZING:
-        return Optional.of(Errors.serverNotReady(state.reason));
+        return Optional.of(Errors.serverNotReady(state.errorMessage));
       case TERMINATING:
         return Optional.of(Errors.serverShuttingDown());
       default:

--- a/ksql-rest-app/src/test/java/io/confluent/ksql/rest/server/KsqlRestApplicationTest.java
+++ b/ksql-rest-app/src/test/java/io/confluent/ksql/rest/server/KsqlRestApplicationTest.java
@@ -37,6 +37,7 @@ import io.confluent.ksql.logging.processing.ProcessingLogConfig;
 import io.confluent.ksql.logging.processing.ProcessingLogContext;
 import io.confluent.ksql.parser.KsqlParser.ParsedStatement;
 import io.confluent.ksql.parser.KsqlParser.PreparedStatement;
+import io.confluent.ksql.rest.entity.KsqlErrorMessage;
 import io.confluent.ksql.rest.server.computation.CommandRunner;
 import io.confluent.ksql.rest.server.computation.CommandStore;
 import io.confluent.ksql.rest.server.computation.QueuedCommandStatus;
@@ -345,9 +346,11 @@ public class KsqlRestApplicationTest {
   @Test
   public void shouldNotInitializeUntilPreconditionsChecked() {
     // Given:
-    final Queue<String> errors = new LinkedList<>();
-    errors.add("error1");
-    errors.add("error2");
+    KsqlErrorMessage error1 = new KsqlErrorMessage(50000, "error1");
+    KsqlErrorMessage error2 = new KsqlErrorMessage(50000, "error2");
+    final Queue<KsqlErrorMessage> errors = new LinkedList<>();
+    errors.add(error1);
+    errors.add(error2);
     when(precondition2.checkPrecondition(any(), any())).then(a -> {
       verifyZeroInteractions(serviceContext);
       return Optional.ofNullable(errors.isEmpty() ? null : errors.remove());
@@ -360,10 +363,10 @@ public class KsqlRestApplicationTest {
     final InOrder inOrder = Mockito.inOrder(precondition1, precondition2, serverState);
     inOrder.verify(precondition1).checkPrecondition(restConfig, serviceContext);
     inOrder.verify(precondition2).checkPrecondition(restConfig, serviceContext);
-    inOrder.verify(serverState).setInitializingReason("error1");
+    inOrder.verify(serverState).setInitializingReason(error1);
     inOrder.verify(precondition1).checkPrecondition(restConfig, serviceContext);
     inOrder.verify(precondition2).checkPrecondition(restConfig, serviceContext);
-    inOrder.verify(serverState).setInitializingReason("error2");
+    inOrder.verify(serverState).setInitializingReason(error2);
     inOrder.verify(precondition1).checkPrecondition(restConfig, serviceContext);
     inOrder.verify(precondition2).checkPrecondition(restConfig, serviceContext);
   }

--- a/ksql-rest-app/src/test/java/io/confluent/ksql/rest/server/state/ServerStateTest.java
+++ b/ksql-rest-app/src/test/java/io/confluent/ksql/rest/server/state/ServerStateTest.java
@@ -19,6 +19,7 @@ import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.is;
 import static org.junit.Assert.assertThat;
 
+import io.confluent.ksql.rest.entity.KsqlErrorMessage;
 import io.confluent.ksql.rest.server.resources.Errors;
 import java.util.Optional;
 import javax.ws.rs.core.Response;
@@ -30,7 +31,8 @@ public class ServerStateTest {
   @Test
   public void shouldReturnErrorWhenInitializing() {
     // Given:
-    serverState.setInitializingReason("bad stuff is happening");
+    KsqlErrorMessage error = new KsqlErrorMessage(12345, "bad stuff is happening");
+    serverState.setInitializingReason(error);
 
     // When:
     final Optional<Response> result = serverState.checkReady();
@@ -38,7 +40,7 @@ public class ServerStateTest {
     // Then:
     assertThat(result.isPresent(), is(true));
     final Response response = result.get();
-    final Response expected = Errors.serverNotReady("bad stuff is happening");
+    final Response expected = Errors.serverNotReady(error);
     assertThat(response.getStatus(), equalTo(expected.getStatus()));
     assertThat(response.getEntity(), equalTo(expected.getEntity()));
   }


### PR DESCRIPTION
### Description 
tldr: messed up a pint merge from 5.3.x to master, so reverted the merge, but now pint won't be able to pick up on the changes involved in that merge now. This manually applies the two changes from that merge to master.

Original merge:https://github.com/confluentinc/ksql/commit/b1d424189dcaed362c9aa8c2ed2b065b7dda749c
Revert: https://github.com/confluentinc/ksql/commit/4cfafa5d5c8892b07ead780d1e56bb47e1331794

Changes:
https://github.com/confluentinc/ksql/commit/2b8725ec976d295e9318fb7aafbae9324e8b8677
https://github.com/confluentinc/ksql/commit/828418e647d2cf760a995e0a6a5fb64bf1474d4a

### Testing done 
mvn clean install
### Reviewer checklist
- [ ] Ensure docs are updated if necessary. (eg. if a user visible feature is being added or changed).
- [ ] Ensure relevant issues are linked (description should include text like "Fixes #<issue number>")

