### PR TITLE
fix: default timestamp extractor override is not working

### DIFF
--- a/ksql-common/src/main/java/io/confluent/ksql/util/timestamp/MetadataTimestampExtractionPolicy.java
+++ b/ksql-common/src/main/java/io/confluent/ksql/util/timestamp/MetadataTimestampExtractionPolicy.java
@@ -17,30 +17,40 @@ package io.confluent.ksql.util.timestamp;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.google.errorprone.annotations.Immutable;
+import java.util.Objects;
 import org.apache.kafka.streams.processor.FailOnInvalidTimestamp;
 import org.apache.kafka.streams.processor.TimestampExtractor;
 
 @Immutable
 public class MetadataTimestampExtractionPolicy implements TimestampExtractionPolicy {
+  private final TimestampExtractor timestampExtractor;
 
   @JsonCreator
-  public MetadataTimestampExtractionPolicy(){}
+  public MetadataTimestampExtractionPolicy() {
+    this(new FailOnInvalidTimestamp());
+  }
+
+  public MetadataTimestampExtractionPolicy(final TimestampExtractor timestampExtractor) {
+    this.timestampExtractor = timestampExtractor;
+  }
 
   @Override
   public TimestampExtractor create(final int columnIndex) {
-    return new FailOnInvalidTimestamp();
+    return timestampExtractor;
   }
 
   @Override
   public int hashCode() {
-    return this.getClass().hashCode();
+    return Objects.hash(this.getClass(), timestampExtractor.getClass());
   }
 
   @Override
   public boolean equals(final Object other) {
-    if (this == other) {
-      return true;
+    if (!(other instanceof MetadataTimestampExtractionPolicy)) {
+      return false;
     }
-    return other instanceof MetadataTimestampExtractionPolicy;
+
+    final MetadataTimestampExtractionPolicy that = (MetadataTimestampExtractionPolicy)other;
+    return timestampExtractor.getClass() == that.timestampExtractor.getClass();
   }
 }

--- a/ksql-common/src/main/java/io/confluent/ksql/util/timestamp/TimestampExtractionPolicyFactory.java
+++ b/ksql-common/src/main/java/io/confluent/ksql/util/timestamp/TimestampExtractionPolicyFactory.java
@@ -20,7 +20,6 @@ import io.confluent.ksql.schema.ksql.KsqlSchema;
 import io.confluent.ksql.util.KsqlConfig;
 import io.confluent.ksql.util.KsqlException;
 
-import java.util.Collections;
 import java.util.Optional;
 import org.apache.kafka.connect.data.Field;
 import org.apache.kafka.connect.data.Schema;
@@ -31,19 +30,6 @@ import org.apache.kafka.streams.processor.TimestampExtractor;
 public final class TimestampExtractionPolicyFactory {
 
   private TimestampExtractionPolicyFactory() {
-  }
-
-  public static TimestampExtractionPolicy create(
-      final KsqlSchema schema,
-      final Optional<String> timestampColumnName,
-      final Optional<String> timestampFormat
-  ) {
-    return create(
-        new KsqlConfig(Collections.emptyMap()),
-        schema,
-        timestampColumnName,
-        timestampFormat
-    );
   }
 
   public static TimestampExtractionPolicy create(

--- a/ksql-common/src/test/java/io/confluent/ksql/util/timestamp/MetadataTimestampExtractionPolicyTest.java
+++ b/ksql-common/src/test/java/io/confluent/ksql/util/timestamp/MetadataTimestampExtractionPolicyTest.java
@@ -16,6 +16,7 @@
 package io.confluent.ksql.util.timestamp;
 
 import com.google.common.testing.EqualsTester;
+import org.apache.kafka.streams.processor.UsePreviousTimeOnInvalidTimestamp;
 import org.junit.Test;
 
 public class MetadataTimestampExtractionPolicyTest {
@@ -25,6 +26,10 @@ public class MetadataTimestampExtractionPolicyTest {
         .addEqualityGroup(
             new MetadataTimestampExtractionPolicy(),
             new MetadataTimestampExtractionPolicy())
+        .addEqualityGroup(
+            new MetadataTimestampExtractionPolicy(new UsePreviousTimeOnInvalidTimestamp()),
+            new MetadataTimestampExtractionPolicy(new UsePreviousTimeOnInvalidTimestamp())
+        )
         .testEquals();
   }
 }

--- a/ksql-common/src/test/java/io/confluent/ksql/util/timestamp/TimestampExtractionPolicyFactoryTest.java
+++ b/ksql-common/src/test/java/io/confluent/ksql/util/timestamp/TimestampExtractionPolicyFactoryTest.java
@@ -72,7 +72,7 @@ public class TimestampExtractionPolicyFactoryTest {
     ));
 
     // Then/When:
-    final TimestampExtractionPolicy result = TimestampExtractionPolicyFactory
+    TimestampExtractionPolicyFactory
         .create(
             ksqlConfig,
             KsqlSchema.of(schemaBuilder.build()),
@@ -90,7 +90,7 @@ public class TimestampExtractionPolicyFactoryTest {
     ));
 
     // Then/When:
-    final TimestampExtractionPolicy result = TimestampExtractionPolicyFactory
+    TimestampExtractionPolicyFactory
         .create(
             ksqlConfig,
             KsqlSchema.of(schemaBuilder.build()),

--- a/ksql-engine/src/main/java/io/confluent/ksql/ddl/commands/CommandFactories.java
+++ b/ksql-engine/src/main/java/io/confluent/ksql/ddl/commands/CommandFactories.java
@@ -29,6 +29,7 @@ import io.confluent.ksql.parser.tree.UnsetProperty;
 import io.confluent.ksql.services.ServiceContext;
 import io.confluent.ksql.util.HandlerMaps;
 import io.confluent.ksql.util.HandlerMaps.ClassHandlerMapR2;
+import io.confluent.ksql.util.KsqlConfig;
 import io.confluent.ksql.util.KsqlException;
 import java.util.Map;
 import java.util.Objects;
@@ -62,6 +63,7 @@ public class CommandFactories implements DdlCommandFactory {
   public DdlCommand create(
       final String sqlExpression,
       final DdlStatement ddlStatement,
+      final KsqlConfig ksqlConfig,
       final Map<String, Object> properties
   ) {
     return FACTORIES
@@ -75,7 +77,7 @@ public class CommandFactories implements DdlCommandFactory {
         })
         .handle(
             this,
-            new CallInfo(sqlExpression, properties),
+            new CallInfo(sqlExpression, ksqlConfig, properties),
             ddlStatement);
   }
 
@@ -90,6 +92,7 @@ public class CommandFactories implements DdlCommandFactory {
     return new CreateStreamCommand(
         callInfo.sqlExpression,
         statement,
+        callInfo.ksqlConfig,
         serviceContext.getTopicClient());
   }
 
@@ -100,6 +103,7 @@ public class CommandFactories implements DdlCommandFactory {
     return new CreateTableCommand(
         callInfo.sqlExpression,
         statement,
+        callInfo.ksqlConfig,
         serviceContext.getTopicClient());
   }
 
@@ -140,14 +144,18 @@ public class CommandFactories implements DdlCommandFactory {
   private static final class CallInfo {
 
     final String sqlExpression;
+    final KsqlConfig ksqlConfig;
     final Map<String, Object> properties;
 
     private CallInfo(
         final String sqlExpression,
+        final KsqlConfig ksqlConfig,
         final Map<String, Object> properties
     ) {
-      this.sqlExpression = sqlExpression;
-      this.properties = properties;
+      this.sqlExpression = Objects.requireNonNull(sqlExpression, "sqlExpression");
+      this.properties = Objects.requireNonNull(properties, "properties");
+      this.ksqlConfig = Objects.requireNonNull(ksqlConfig, "ksqlConfig")
+          .cloneWithPropertyOverwrite(properties);
     }
   }
 }

--- a/ksql-engine/src/main/java/io/confluent/ksql/ddl/commands/CreateSourceCommand.java
+++ b/ksql-engine/src/main/java/io/confluent/ksql/ddl/commands/CreateSourceCommand.java
@@ -94,7 +94,7 @@ abstract class CreateSourceCommand implements DdlCommand {
     final Optional<String> timestampName = properties.getTimestampName();
     final Optional<String> timestampFormat = properties.getTimestampFormat();
     this.timestampExtractionPolicy = TimestampExtractionPolicyFactory
-        .create(schema, timestampName, timestampFormat);
+        .create(ksqlConfig, schema, timestampName, timestampFormat);
 
     this.keySerdeFactory = extractKeySerde(properties);
   }

--- a/ksql-engine/src/main/java/io/confluent/ksql/ddl/commands/CreateSourceCommand.java
+++ b/ksql-engine/src/main/java/io/confluent/ksql/ddl/commands/CreateSourceCommand.java
@@ -24,6 +24,7 @@ import io.confluent.ksql.parser.tree.TableElement;
 import io.confluent.ksql.schema.ksql.KsqlSchema;
 import io.confluent.ksql.schema.ksql.LogicalSchemas;
 import io.confluent.ksql.services.KafkaTopicClient;
+import io.confluent.ksql.util.KsqlConfig;
 import io.confluent.ksql.util.KsqlException;
 import io.confluent.ksql.util.SchemaUtil;
 import io.confluent.ksql.util.StringUtil;
@@ -55,6 +56,7 @@ abstract class CreateSourceCommand implements DdlCommand {
   CreateSourceCommand(
       final String sqlExpression,
       final CreateSource statement,
+      final KsqlConfig ksqlConfig,
       final KafkaTopicClient kafkaTopicClient
   ) {
     this.sqlExpression = sqlExpression;

--- a/ksql-engine/src/main/java/io/confluent/ksql/ddl/commands/CreateStreamCommand.java
+++ b/ksql-engine/src/main/java/io/confluent/ksql/ddl/commands/CreateStreamCommand.java
@@ -19,6 +19,7 @@ import io.confluent.ksql.metastore.MutableMetaStore;
 import io.confluent.ksql.metastore.model.KsqlStream;
 import io.confluent.ksql.parser.tree.CreateStream;
 import io.confluent.ksql.services.KafkaTopicClient;
+import io.confluent.ksql.util.KsqlConfig;
 import io.confluent.ksql.util.KsqlException;
 
 public class CreateStreamCommand extends CreateSourceCommand {
@@ -26,9 +27,10 @@ public class CreateStreamCommand extends CreateSourceCommand {
   public CreateStreamCommand(
       final String sqlExpression,
       final CreateStream createStream,
+      final KsqlConfig ksqlConfig,
       final KafkaTopicClient kafkaTopicClient
   ) {
-    super(sqlExpression, createStream, kafkaTopicClient);
+    super(sqlExpression, createStream, ksqlConfig, kafkaTopicClient);
   }
 
   @Override

--- a/ksql-engine/src/main/java/io/confluent/ksql/ddl/commands/CreateTableCommand.java
+++ b/ksql-engine/src/main/java/io/confluent/ksql/ddl/commands/CreateTableCommand.java
@@ -19,6 +19,7 @@ import io.confluent.ksql.metastore.MutableMetaStore;
 import io.confluent.ksql.metastore.model.KsqlTable;
 import io.confluent.ksql.parser.tree.CreateTable;
 import io.confluent.ksql.services.KafkaTopicClient;
+import io.confluent.ksql.util.KsqlConfig;
 import io.confluent.ksql.util.KsqlException;
 
 public class CreateTableCommand extends CreateSourceCommand {
@@ -26,9 +27,10 @@ public class CreateTableCommand extends CreateSourceCommand {
   CreateTableCommand(
       final String sqlExpression,
       final CreateTable createTable,
+      final KsqlConfig ksqlConfig,
       final KafkaTopicClient kafkaTopicClient
   ) {
-    super(sqlExpression, createTable, kafkaTopicClient);
+    super(sqlExpression, createTable, ksqlConfig, kafkaTopicClient);
   }
 
   @Override

--- a/ksql-engine/src/main/java/io/confluent/ksql/ddl/commands/DdlCommandFactory.java
+++ b/ksql-engine/src/main/java/io/confluent/ksql/ddl/commands/DdlCommandFactory.java
@@ -16,12 +16,15 @@
 package io.confluent.ksql.ddl.commands;
 
 import io.confluent.ksql.parser.tree.DdlStatement;
+import io.confluent.ksql.util.KsqlConfig;
+
 import java.util.Map;
 
 public interface DdlCommandFactory {
   DdlCommand create(
       String sqlExpression,
       DdlStatement ddlStatement,
+      KsqlConfig ksqlConfig,
       Map<String, Object> properties
   );
 }

--- a/ksql-engine/src/main/java/io/confluent/ksql/engine/EngineContext.java
+++ b/ksql-engine/src/main/java/io/confluent/ksql/engine/EngineContext.java
@@ -29,6 +29,7 @@ import io.confluent.ksql.parser.tree.ExecutableDdlStatement;
 import io.confluent.ksql.query.QueryId;
 import io.confluent.ksql.services.SandboxedServiceContext;
 import io.confluent.ksql.services.ServiceContext;
+import io.confluent.ksql.util.KsqlConfig;
 import io.confluent.ksql.util.KsqlException;
 import io.confluent.ksql.util.KsqlStatementException;
 import io.confluent.ksql.util.PersistentQueryMetadata;
@@ -154,6 +155,7 @@ final class EngineContext {
   String executeDdlStatement(
       final String sqlExpression,
       final ExecutableDdlStatement statement,
+      final KsqlConfig ksqlConfig,
       final Map<String, Object> overriddenProperties
   ) {
     KsqlEngineProps.throwOnImmutableOverride(overriddenProperties);
@@ -161,6 +163,7 @@ final class EngineContext {
     final DdlCommand command = ddlCommandFactory.create(
         sqlExpression,
         statement,
+        ksqlConfig,
         overriddenProperties
     );
 

--- a/ksql-engine/src/main/java/io/confluent/ksql/engine/EngineExecutor.java
+++ b/ksql-engine/src/main/java/io/confluent/ksql/engine/EngineExecutor.java
@@ -89,6 +89,7 @@ final class EngineExecutor {
         final String msg = engineContext.executeDdlStatement(
             statement.getStatementText(),
             (ExecutableDdlStatement) statement.getStatement(),
+            ksqlConfig,
             overriddenProperties
         );
 

--- a/ksql-engine/src/main/java/io/confluent/ksql/engine/QueryEngine.java
+++ b/ksql-engine/src/main/java/io/confluent/ksql/engine/QueryEngine.java
@@ -150,6 +150,6 @@ class QueryEngine {
     final Analysis analysis = queryAnalyzer.analyze(sqlExpression, query, sink);
     final AggregateAnalysisResult aggAnalysis = queryAnalyzer.analyzeAggregate(query, analysis);
 
-    return new LogicalPlanner(analysis, aggAnalysis, metaStore).buildPlan();
+    return new LogicalPlanner(config, analysis, aggAnalysis, metaStore).buildPlan();
   }
 }

--- a/ksql-engine/src/main/java/io/confluent/ksql/planner/LogicalPlanner.java
+++ b/ksql-engine/src/main/java/io/confluent/ksql/planner/LogicalPlanner.java
@@ -36,6 +36,7 @@ import io.confluent.ksql.planner.plan.PlanNodeId;
 import io.confluent.ksql.planner.plan.ProjectNode;
 import io.confluent.ksql.schema.ksql.KsqlSchema;
 import io.confluent.ksql.util.ExpressionTypeManager;
+import io.confluent.ksql.util.KsqlConfig;
 import io.confluent.ksql.util.KsqlException;
 import io.confluent.ksql.util.Pair;
 import io.confluent.ksql.util.timestamp.TimestampExtractionPolicy;
@@ -49,15 +50,18 @@ import org.apache.kafka.connect.data.SchemaBuilder;
 public class LogicalPlanner {
   // CHECKSTYLE_RULES.ON: ClassDataAbstractionCoupling
 
+  private final KsqlConfig ksqlConfig;
   private final Analysis analysis;
   private final AggregateAnalysisResult aggregateAnalysis;
   private final FunctionRegistry functionRegistry;
 
   public LogicalPlanner(
+      final KsqlConfig ksqlConfig,
       final Analysis analysis,
       final AggregateAnalysisResult aggregateAnalysis,
       final FunctionRegistry functionRegistry
   ) {
+    this.ksqlConfig = ksqlConfig;
     this.analysis = analysis;
     this.aggregateAnalysis = aggregateAnalysis;
     this.functionRegistry = functionRegistry;
@@ -125,11 +129,12 @@ public class LogicalPlanner {
     );
   }
 
-  private static TimestampExtractionPolicy getTimestampExtractionPolicy(
+  private TimestampExtractionPolicy getTimestampExtractionPolicy(
       final KsqlSchema inputSchema,
       final Analysis analysis
   ) {
     return TimestampExtractionPolicyFactory.create(
+        ksqlConfig,
         inputSchema,
         analysis.getTimestampColumnName(),
         analysis.getTimestampFormat());

--- a/ksql-engine/src/test/java/io/confluent/ksql/ddl/commands/CreateSourceCommandTest.java
+++ b/ksql-engine/src/test/java/io/confluent/ksql/ddl/commands/CreateSourceCommandTest.java
@@ -35,6 +35,7 @@ import io.confluent.ksql.parser.tree.StringLiteral;
 import io.confluent.ksql.parser.tree.TableElement;
 import io.confluent.ksql.parser.tree.Type.SqlType;
 import io.confluent.ksql.services.KafkaTopicClient;
+import io.confluent.ksql.util.KsqlConfig;
 import io.confluent.ksql.util.KsqlException;
 import java.util.Collections;
 import java.util.HashMap;
@@ -62,12 +63,16 @@ public class CreateSourceCommandTest {
   @Mock
   private KafkaTopicClient kafkaTopicClient;
 
+  private KsqlConfig ksqlConfig;
+
   @Before
   public void setUp() {
     when(statement.getElements()).thenReturn(SOME_ELEMENTS);
     when(statement.getName()).thenReturn(QualifiedName.of("bob"));
     givenPropertiesWith(ImmutableMap.of());
     when(kafkaTopicClient.isTopicExists(any())).thenReturn(true);
+
+    ksqlConfig = new KsqlConfig(ImmutableMap.of());
   }
 
   @Test
@@ -81,7 +86,7 @@ public class CreateSourceCommandTest {
         "The statement does not define any columns.");
 
     // When:
-    new TestCmd("look mum, no columns", statement, kafkaTopicClient);
+    new TestCmd("look mum, no columns", statement, ksqlConfig, kafkaTopicClient);
   }
 
   @Test
@@ -90,7 +95,7 @@ public class CreateSourceCommandTest {
     when(statement.getElements()).thenReturn(SOME_ELEMENTS);
 
     // When:
-    new TestCmd("look mum, columns", statement, kafkaTopicClient);
+    new TestCmd("look mum, columns", statement, ksqlConfig, kafkaTopicClient);
 
     // Then: not exception thrown
   }
@@ -105,7 +110,7 @@ public class CreateSourceCommandTest {
     expectedException.expectMessage("Kafka topic does not exist: " + TOPIC_NAME);
 
     // When:
-    new TestCmd("what, no value topic?", statement, kafkaTopicClient);
+    new TestCmd("what, no value topic?", statement, ksqlConfig, kafkaTopicClient);
   }
 
   @Test
@@ -114,7 +119,7 @@ public class CreateSourceCommandTest {
     when(kafkaTopicClient.isTopicExists(TOPIC_NAME)).thenReturn(true);
 
     // When:
-    new TestCmd("what, no value topic?", statement, kafkaTopicClient);
+    new TestCmd("what, no value topic?", statement, ksqlConfig, kafkaTopicClient);
 
     // Then:
     verify(kafkaTopicClient).isTopicExists(TOPIC_NAME);
@@ -133,7 +138,7 @@ public class CreateSourceCommandTest {
             + "'WILL-NOT-FIND-ME'");
 
     // When:
-    new TestCmd("key not in schema!", statement, kafkaTopicClient);
+    new TestCmd("key not in schema!", statement, ksqlConfig, kafkaTopicClient);
   }
 
   @Test
@@ -150,7 +155,7 @@ public class CreateSourceCommandTest {
             + "'WILL-NOT-FIND-ME'");
 
     // When:
-    new TestCmd("key not in schema!", statement, kafkaTopicClient);
+    new TestCmd("key not in schema!", statement, ksqlConfig, kafkaTopicClient);
   }
 
   private static Map<String, Literal> minValidProps() {
@@ -178,9 +183,10 @@ public class CreateSourceCommandTest {
     private TestCmd(
         final String sqlExpression,
         final CreateSource statement,
+        final KsqlConfig ksqlConfig,
         final KafkaTopicClient kafkaTopicClient
     ) {
-      super(sqlExpression, statement, kafkaTopicClient);
+      super(sqlExpression, statement, ksqlConfig, kafkaTopicClient);
     }
 
     @Override

--- a/ksql-engine/src/test/java/io/confluent/ksql/ddl/commands/CreateStreamCommandTest.java
+++ b/ksql-engine/src/test/java/io/confluent/ksql/ddl/commands/CreateStreamCommandTest.java
@@ -37,6 +37,7 @@ import io.confluent.ksql.parser.tree.StringLiteral;
 import io.confluent.ksql.parser.tree.TableElement;
 import io.confluent.ksql.parser.tree.Type.SqlType;
 import io.confluent.ksql.services.KafkaTopicClient;
+import io.confluent.ksql.util.KsqlConfig;
 import io.confluent.ksql.util.KsqlException;
 import io.confluent.ksql.util.MetaStoreFixture;
 import java.util.Collections;
@@ -67,6 +68,8 @@ public class CreateStreamCommandTest {
   private KafkaTopicClient topicClient;
   @Mock
   private CreateStream createStreamStatement;
+  @Mock
+  private KsqlConfig ksqlConfig;
 
   @Rule
   public final ExpectedException expectedException = ExpectedException.none();
@@ -190,7 +193,11 @@ public class CreateStreamCommandTest {
   }
 
   private CreateStreamCommand createCmd() {
-    return new CreateStreamCommand("some sql", createStreamStatement, topicClient);
+    return new CreateStreamCommand(
+        "some sql",
+        createStreamStatement,
+        ksqlConfig,
+        topicClient);
   }
 
   private void givenPropertiesWith(final Map<String, Literal> props) {

--- a/ksql-engine/src/test/java/io/confluent/ksql/ddl/commands/CreateTableCommandTest.java
+++ b/ksql-engine/src/test/java/io/confluent/ksql/ddl/commands/CreateTableCommandTest.java
@@ -37,6 +37,7 @@ import io.confluent.ksql.parser.tree.StringLiteral;
 import io.confluent.ksql.parser.tree.TableElement;
 import io.confluent.ksql.parser.tree.Type.SqlType;
 import io.confluent.ksql.services.KafkaTopicClient;
+import io.confluent.ksql.util.KsqlConfig;
 import io.confluent.ksql.util.KsqlException;
 import io.confluent.ksql.util.MetaStoreFixture;
 import java.util.Collections;
@@ -62,6 +63,8 @@ public class CreateTableCommandTest {
   private KafkaTopicClient topicClient;
   @Mock
   private CreateTable createTableStatement;
+  @Mock
+  private KsqlConfig ksqlConfig;
 
   @Rule
   public final ExpectedException expectedException = ExpectedException.none();
@@ -188,7 +191,11 @@ public class CreateTableCommandTest {
 
 
   private CreateTableCommand createCmd() {
-    return new CreateTableCommand("some sql", createTableStatement, topicClient);
+    return new CreateTableCommand(
+        "some sql",
+        createTableStatement,
+        ksqlConfig,
+        topicClient);
   }
 
   private void givenPropertiesWith(final Map<String, Literal> props) {

--- a/ksql-engine/src/test/java/io/confluent/ksql/physical/PhysicalPlanBuilderTest.java
+++ b/ksql-engine/src/test/java/io/confluent/ksql/physical/PhysicalPlanBuilderTest.java
@@ -228,7 +228,7 @@ public class PhysicalPlanBuilderTest {
   }
 
   private QueryMetadata buildPhysicalPlan(final String query) {
-    final OutputNode logical = AnalysisTestUtil.buildLogicalPlan(query, metaStore);;
+    final OutputNode logical = AnalysisTestUtil.buildLogicalPlan(ksqlConfig, query, metaStore);;
     return physicalPlanBuilder.buildPhysicalPlan(new LogicalPlanNode(query, Optional.of(logical)));
   }
 
@@ -682,7 +682,7 @@ public class PhysicalPlanBuilderTest {
     final ProcessingLogger logger = mock(ProcessingLogger.class);
     when(processingLogContext.getLoggerFactory()).thenReturn(loggerFactory);
     final OutputNode spyNode = spy(
-        AnalysisTestUtil.buildLogicalPlan(simpleSelectFilter, metaStore));
+        AnalysisTestUtil.buildLogicalPlan(ksqlConfig, simpleSelectFilter, metaStore));
     doReturn(new QueryId("foo")).when(spyNode).getQueryId(any());
     when(loggerFactory.getLogger("foo")).thenReturn(logger);
     when(loggerFactory.getLogger(ArgumentMatchers.startsWith("foo.")))

--- a/ksql-engine/src/test/java/io/confluent/ksql/planner/LogicalPlannerTest.java
+++ b/ksql-engine/src/test/java/io/confluent/ksql/planner/LogicalPlannerTest.java
@@ -34,7 +34,10 @@ import io.confluent.ksql.planner.plan.JoinNode;
 import io.confluent.ksql.planner.plan.PlanNode;
 import io.confluent.ksql.planner.plan.ProjectNode;
 import io.confluent.ksql.testutils.AnalysisTestUtil;
+import io.confluent.ksql.util.KsqlConfig;
 import io.confluent.ksql.util.MetaStoreFixture;
+
+import java.util.Collections;
 import java.util.Optional;
 import org.apache.kafka.connect.data.Schema;
 import org.junit.Assert;
@@ -44,10 +47,12 @@ import org.junit.Test;
 public class LogicalPlannerTest {
 
   private MetaStore metaStore;
+  private KsqlConfig ksqlConfig;
 
   @Before
   public void init() {
     metaStore = MetaStoreFixture.getNewMetaStore(new InternalFunctionRegistry());
+    ksqlConfig = new KsqlConfig(Collections.emptyMap());
   }
 
   @Test
@@ -249,6 +254,6 @@ public class LogicalPlannerTest {
   }
 
   private PlanNode buildLogicalPlan(final String query) {
-    return AnalysisTestUtil.buildLogicalPlan(query, metaStore);
+    return AnalysisTestUtil.buildLogicalPlan(ksqlConfig, query, metaStore);
   }
 }

--- a/ksql-engine/src/test/java/io/confluent/ksql/planner/PlanSourceExtractorVisitorTest.java
+++ b/ksql-engine/src/test/java/io/confluent/ksql/planner/PlanSourceExtractorVisitorTest.java
@@ -22,7 +22,10 @@ import io.confluent.ksql.function.InternalFunctionRegistry;
 import io.confluent.ksql.metastore.MetaStore;
 import io.confluent.ksql.planner.plan.PlanNode;
 import io.confluent.ksql.testutils.AnalysisTestUtil;
+import io.confluent.ksql.util.KsqlConfig;
 import io.confluent.ksql.util.MetaStoreFixture;
+
+import java.util.Collections;
 import java.util.Set;
 import org.apache.kafka.common.utils.Utils;
 import org.junit.Before;
@@ -31,10 +34,12 @@ import org.junit.Test;
 public class PlanSourceExtractorVisitorTest {
 
   private MetaStore metaStore;
+  private KsqlConfig ksqlConfig;
 
   @Before
   public void init() {
     metaStore = MetaStoreFixture.getNewMetaStore(new InternalFunctionRegistry());
+    ksqlConfig = new KsqlConfig(Collections.emptyMap());
   }
 
   @Test
@@ -61,6 +66,6 @@ public class PlanSourceExtractorVisitorTest {
   }
 
   private PlanNode buildLogicalPlan(final String query) {
-    return AnalysisTestUtil.buildLogicalPlan(query, metaStore);
+    return AnalysisTestUtil.buildLogicalPlan(ksqlConfig, query, metaStore);
   }
 }

--- a/ksql-engine/src/test/java/io/confluent/ksql/planner/plan/AggregateNodeTest.java
+++ b/ksql-engine/src/test/java/io/confluent/ksql/planner/plan/AggregateNodeTest.java
@@ -395,7 +395,7 @@ public class AggregateNodeTest {
   private static AggregateNode buildAggregateNode(final String queryString) {
     final MetaStore newMetaStore = MetaStoreFixture.getNewMetaStore(new InternalFunctionRegistry());
     final KsqlBareOutputNode planNode = (KsqlBareOutputNode) AnalysisTestUtil
-        .buildLogicalPlan(queryString, newMetaStore);
+        .buildLogicalPlan(KSQL_CONFIG, queryString, newMetaStore);
 
     return (AggregateNode) planNode.getSource();
   }

--- a/ksql-engine/src/test/java/io/confluent/ksql/planner/plan/JoinNodeTest.java
+++ b/ksql-engine/src/test/java/io/confluent/ksql/planner/plan/JoinNodeTest.java
@@ -1069,7 +1069,7 @@ public class JoinNodeTest {
     final MetaStore metaStore = MetaStoreFixture.getNewMetaStore(new InternalFunctionRegistry());
 
     final KsqlBareOutputNode planNode =
-        (KsqlBareOutputNode) AnalysisTestUtil.buildLogicalPlan(queryString, metaStore);
+        (KsqlBareOutputNode) AnalysisTestUtil.buildLogicalPlan(ksqlConfig, queryString, metaStore);
 
     joinNode = (JoinNode) ((ProjectNode) planNode.getSource()).getSource();
   }

--- a/ksql-engine/src/test/java/io/confluent/ksql/planner/plan/KsqlBareOutputNodeTest.java
+++ b/ksql-engine/src/test/java/io/confluent/ksql/planner/plan/KsqlBareOutputNodeTest.java
@@ -68,6 +68,7 @@ public class KsqlBareOutputNodeTest {
   private StreamsBuilder builder;
   private final MetaStore metaStore = MetaStoreFixture.getNewMetaStore(new InternalFunctionRegistry());
   private final QueryId queryId = new QueryId("output-test");
+  private final KsqlConfig ksqlConfig = new KsqlConfig(Collections.emptyMap());
 
   @Mock
   private KsqlQueryBuilder ksqlStreamBuilder;
@@ -87,7 +88,7 @@ public class KsqlBareOutputNodeTest {
             .push(inv.getArgument(0).toString()));
 
     final KsqlBareOutputNode planNode = (KsqlBareOutputNode) AnalysisTestUtil
-        .buildLogicalPlan(SIMPLE_SELECT_WITH_FILTER, metaStore);
+        .buildLogicalPlan(ksqlConfig, SIMPLE_SELECT_WITH_FILTER, metaStore);
 
     stream = planNode.buildStream(ksqlStreamBuilder);
   }
@@ -134,7 +135,7 @@ public class KsqlBareOutputNodeTest {
     // Given:
     final KsqlBareOutputNode node
         = (KsqlBareOutputNode) AnalysisTestUtil
-        .buildLogicalPlan("select col0 from test1;", metaStore);
+        .buildLogicalPlan(ksqlConfig, "select col0 from test1;", metaStore);
     final QueryIdGenerator queryIdGenerator = mock(QueryIdGenerator.class);
 
     // When:

--- a/ksql-engine/src/test/java/io/confluent/ksql/structured/SchemaKGroupedTableTest.java
+++ b/ksql-engine/src/test/java/io/confluent/ksql/structured/SchemaKGroupedTableTest.java
@@ -111,7 +111,7 @@ public class SchemaKGroupedTableTest {
       final String query,
       final String...groupByColumns
   ) {
-    final PlanNode logicalPlan = AnalysisTestUtil.buildLogicalPlan(query, metaStore);
+    final PlanNode logicalPlan = AnalysisTestUtil.buildLogicalPlan(ksqlConfig, query, metaStore);
     final SchemaKTable<?> initialSchemaKTable = new SchemaKTable<>(
         logicalPlan.getTheSourceNode().getSchema(),
         kTable,

--- a/ksql-engine/src/test/java/io/confluent/ksql/structured/SchemaKStreamTest.java
+++ b/ksql-engine/src/test/java/io/confluent/ksql/structured/SchemaKStreamTest.java
@@ -922,7 +922,11 @@ public class SchemaKStreamTest {
   }
 
   private PlanNode givenInitialKStreamOf(final String selectQuery) {
-    final PlanNode logicalPlan = AnalysisTestUtil.buildLogicalPlan(selectQuery, metaStore);
+    final PlanNode logicalPlan = AnalysisTestUtil.buildLogicalPlan(
+        ksqlConfig,
+        selectQuery,
+        metaStore
+    );
 
     initialSchemaKStream = new SchemaKStream(
         logicalPlan.getTheSourceNode().getSchema(),

--- a/ksql-engine/src/test/java/io/confluent/ksql/structured/SchemaKTableTest.java
+++ b/ksql-engine/src/test/java/io/confluent/ksql/structured/SchemaKTableTest.java
@@ -633,7 +633,11 @@ public class SchemaKTableTest {
   }
 
   private List<SelectExpression> givenInitialKTableOf(final String selectQuery) {
-    final PlanNode logicalPlan = AnalysisTestUtil.buildLogicalPlan(selectQuery, metaStore);
+    final PlanNode logicalPlan = AnalysisTestUtil.buildLogicalPlan(
+        ksqlConfig,
+        selectQuery,
+        metaStore
+    );
 
     initialSchemaKTable = new SchemaKTable<>(
         logicalPlan.getTheSourceNode().getSchema(),
@@ -659,6 +663,6 @@ public class SchemaKTableTest {
   }
 
   private PlanNode buildLogicalPlan(final String query) {
-    return AnalysisTestUtil.buildLogicalPlan(query, metaStore);
+    return AnalysisTestUtil.buildLogicalPlan(ksqlConfig, query, metaStore);
   }
 }

--- a/ksql-engine/src/test/java/io/confluent/ksql/structured/SelectValueMapperTest.java
+++ b/ksql-engine/src/test/java/io/confluent/ksql/structured/SelectValueMapperTest.java
@@ -137,7 +137,7 @@ public class SelectValueMapperTest {
   }
 
   private SelectValueMapper givenSelectMapperFor(final String query) {
-    final PlanNode planNode = AnalysisTestUtil.buildLogicalPlan(query, metaStore);
+    final PlanNode planNode = AnalysisTestUtil.buildLogicalPlan(ksqlConfig, query, metaStore);
     final ProjectNode projectNode = (ProjectNode) planNode.getSources().get(0);
     final KsqlSchema schema = planNode.getTheSourceNode().getSchema();
     final List<SelectExpression> selectExpressions = projectNode.getProjectSelectExpressions();

--- a/ksql-engine/src/test/java/io/confluent/ksql/structured/SqlPredicateTest.java
+++ b/ksql-engine/src/test/java/io/confluent/ksql/structured/SqlPredicateTest.java
@@ -136,7 +136,11 @@ public class SqlPredicateTest {
   }
 
   private SqlPredicate givenSqlPredicateFor(final String statement) {
-    final PlanNode logicalPlan = AnalysisTestUtil.buildLogicalPlan(statement, metaStore);
+    final PlanNode logicalPlan = AnalysisTestUtil.buildLogicalPlan(
+        ksqlConfig,
+        statement,
+        metaStore
+    );
     final FilterNode filterNode = (FilterNode) logicalPlan.getSources().get(0).getSources().get(0);
     return new SqlPredicate(
         filterNode.getPredicate(),

--- a/ksql-engine/src/test/java/io/confluent/ksql/testutils/AnalysisTestUtil.java
+++ b/ksql-engine/src/test/java/io/confluent/ksql/testutils/AnalysisTestUtil.java
@@ -30,6 +30,8 @@ import io.confluent.ksql.parser.tree.Sink;
 import io.confluent.ksql.parser.tree.Statement;
 import io.confluent.ksql.planner.LogicalPlanner;
 import io.confluent.ksql.planner.plan.OutputNode;
+import io.confluent.ksql.util.KsqlConfig;
+
 import java.util.List;
 import java.util.Optional;
 
@@ -42,10 +44,15 @@ public final class AnalysisTestUtil {
     return new Analyzer(queryStr, metaStore).analysis;
   }
 
-  public static OutputNode buildLogicalPlan(final String queryStr, final MetaStore metaStore) {
+  public static OutputNode buildLogicalPlan(
+      final KsqlConfig ksqlConfig,
+      final String queryStr,
+      final MetaStore metaStore
+  ) {
     final Analyzer analyzer = new Analyzer(queryStr, metaStore);
 
     final LogicalPlanner logicalPlanner = new LogicalPlanner(
+        ksqlConfig,
         analyzer.analysis,
         analyzer.aggregateAnalys(),
         metaStore);

--- a/ksql-functional-tests/src/test/resources/query-validation-tests/timestamp-extractor.json
+++ b/ksql-functional-tests/src/test/resources/query-validation-tests/timestamp-extractor.json
@@ -1,0 +1,44 @@
+{
+  "comments": [
+    "Tests to verify override of default.timestamp.extractor on streams"
+  ],
+  "tests": [
+    {
+      "name": "KSQL default timestamp extractor",
+      "statements": [
+        "CREATE STREAM TEST (ID bigint) WITH (kafka_topic='test_topic', value_format='JSON');",
+        "CREATE STREAM TS AS SELECT id FROM test;"
+      ],
+      "inputs": [
+        {"topic": "test_topic", "value": {"ID": 1}, "timestamp": 1526075913000},
+        {"topic": "test_topic", "value": {"ID": 2}, "timestamp": 1557611913000},
+        {"topic": "test_topic", "value": {"ID": 3}, "timestamp": 1589234313000}
+      ],
+      "outputs": [
+        {"topic": "TS", "value": {"ID": 1}, "timestamp": 1526075913000},
+        {"topic": "TS", "value": {"ID": 2}, "timestamp": 1557611913000},
+        {"topic": "TS", "value": {"ID": 3}, "timestamp": 1589234313000}
+      ]
+    },
+    {
+      "name": "KSQL override timestamp extractor",
+      "statements": [
+        "CREATE STREAM TEST (ID bigint) WITH (kafka_topic='test_topic', value_format='JSON');",
+        "CREATE STREAM TS AS SELECT id FROM test;"
+      ],
+      "properties": {
+        "ksql.streams.default.timestamp.extractor": "org.apache.kafka.streams.processor.UsePreviousTimeOnInvalidTimestamp"
+      },
+      "inputs": [
+        {"topic": "test_topic", "value": {"ID": 1}, "timestamp": 1526075913000},
+        {"topic": "test_topic", "value": {"ID": 2}, "timestamp": -1},
+        {"topic": "test_topic", "value": {"ID": 3}, "timestamp": 1589234313000}
+      ],
+      "outputs": [
+        {"topic": "TS", "value": {"ID": 1}, "timestamp": 1526075913000},
+        {"topic": "TS", "value": {"ID": 2}, "timestamp": 1526075913000},
+        {"topic": "TS", "value": {"ID": 3}, "timestamp": 1589234313000}
+      ]
+    }
+  ]
+}

--- a/ksql-rest-app/src/main/java/io/confluent/ksql/rest/server/KsqlRestApplication.java
+++ b/ksql-rest-app/src/main/java/io/confluent/ksql/rest/server/KsqlRestApplication.java
@@ -286,6 +286,7 @@ public final class KsqlRestApplication extends Application<KsqlRestConfig> imple
                 .put(DdlConfig.TOPIC_NAME_PROPERTY, new StringLiteral(COMMANDS_KSQL_TOPIC_NAME))
                 .build()
         ),
+        ksqlConfig,
         serviceContext.getTopicClient()
     ));
 

--- a/ksql-rest-app/src/test/java/io/confluent/ksql/rest/entity/KsqlRequestTest.java
+++ b/ksql-rest-app/src/test/java/io/confluent/ksql/rest/entity/KsqlRequestTest.java
@@ -31,6 +31,8 @@ import java.util.Collections;
 import java.util.Map;
 import java.util.Optional;
 import org.apache.kafka.clients.consumer.ConsumerConfig;
+import org.apache.kafka.streams.StreamsConfig;
+import org.apache.kafka.streams.processor.TimestampExtractor;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ExpectedException;
@@ -42,23 +44,30 @@ public class KsqlRequestTest {
   private static final String A_JSON_REQUEST = "{"
       + "\"ksql\":\"sql\","
       + "\"streamsProperties\":{"
-      + "\"" + ConsumerConfig.AUTO_OFFSET_RESET_CONFIG + "\":\"earliest\""
+      + "\"" + ConsumerConfig.AUTO_OFFSET_RESET_CONFIG + "\":\"earliest\","
+      + "\"" + StreamsConfig.DEFAULT_TIMESTAMP_EXTRACTOR_CLASS_CONFIG + "\":\""
+                + TimestampExtractor.class.getCanonicalName() + "\""
       + "}}";
   private static final String A_JSON_REQUEST_WITH_COMMAND_NUMBER = "{"
       + "\"ksql\":\"sql\","
       + "\"streamsProperties\":{"
-      + "\"" + ConsumerConfig.AUTO_OFFSET_RESET_CONFIG + "\":\"earliest\""
+      + "\"" + ConsumerConfig.AUTO_OFFSET_RESET_CONFIG + "\":\"earliest\","
+      + "\"" + StreamsConfig.DEFAULT_TIMESTAMP_EXTRACTOR_CLASS_CONFIG + "\":\""
+                + TimestampExtractor.class.getCanonicalName() + "\""
       + "},"
       + "\"commandSequenceNumber\":2}";
   private static final String A_JSON_REQUEST_WITH_NULL_COMMAND_NUMBER = "{"
       + "\"ksql\":\"sql\","
       + "\"streamsProperties\":{"
-      + "\"" + ConsumerConfig.AUTO_OFFSET_RESET_CONFIG + "\":\"earliest\""
+      + "\"" + ConsumerConfig.AUTO_OFFSET_RESET_CONFIG + "\":\"earliest\","
+      + "\"" + StreamsConfig.DEFAULT_TIMESTAMP_EXTRACTOR_CLASS_CONFIG + "\":\""
+                + TimestampExtractor.class.getCanonicalName() + "\""
       + "},"
       + "\"commandSequenceNumber\":null}";
 
   private static final ImmutableMap<String, Object> SOME_PROPS = ImmutableMap.of(
-      ConsumerConfig.AUTO_OFFSET_RESET_CONFIG, "earliest"
+      ConsumerConfig.AUTO_OFFSET_RESET_CONFIG, "earliest",
+      StreamsConfig.DEFAULT_TIMESTAMP_EXTRACTOR_CLASS_CONFIG, TimestampExtractor.class
   );
   private static final long SOME_COMMAND_NUMBER = 2L;
 


### PR DESCRIPTION
### Description 
The use of ksql.streams.default.timestamp.extractor when creating a stream/table is not working. The new value is persisted in the command topic, but KSQL always use a default FailOnInvalidTimestamp

This patch fixes KSQL so it honors the new default specified.

### Testing done 

- Added unit tests.

- Verified a stream created with `'ksql.streams.default.timestamp.extractor'='org.apache.kafka.streams.processor.WallclockTimestampExtractor'` results in queries displaying the current Wallclock time.
- Verified a stream created with no timestamp extractor uses the default `FailedOnInvalidTimestamp`, which displays the timestamp it was used during the insertion of the row.

To test it, I had to call the REST api instead of the CLI because I couldn't make the CLI to recognize a different timestamp extractor:
```
curl -X POST http://localhost:8088/ksql -H 'content-type: application/vnd.ksql.v1+json; charset=utf-8' -d "{\"ksql\":\"create stream t1 (id int, name string) with (kafka_topic='t1', value_format='json');\", \"streamsProperties\": { \"ksql.streams.default.timestamp.extractor\": \"org.apache.kafka.streams.processor.WallclockTimestampExtractor\" }}"
```

### Reviewer checklist
- [ ] Ensure docs are updated if necessary. (eg. if a user visible feature is being added or changed).
- [ ] Ensure relevant issues are linked (description should include text like "Fixes #<issue number>")

