### PR TITLE
feat(ksql-connect): poll connect-configs and auto register sources

### DIFF
--- a/config/ksql-server.properties
+++ b/config/ksql-server.properties
@@ -47,6 +47,7 @@ ksql.logging.processing.stream.auto.create=true
 
 # The set of Kafka brokers to bootstrap Kafka cluster information from:
 bootstrap.servers=localhost:9092
+ksql.connect.polling.enable=true
 
 # Uncomment and complete the following to enable KSQL's integration to the Confluent Schema Registry:
 #ksql.schema.registry.url=?

--- a/ksql-common/src/main/java/io/confluent/ksql/properties/with/CreateConfigs.java
+++ b/ksql-common/src/main/java/io/confluent/ksql/properties/with/CreateConfigs.java
@@ -31,6 +31,7 @@ public final class CreateConfigs {
   public static final String WINDOW_TYPE_PROPERTY = "WINDOW_TYPE";
   public static final String WINDOW_SIZE_PROPERTY = "WINDOW_SIZE";
   public static final String AVRO_SCHEMA_ID = "AVRO_SCHEMA_ID";
+  public static final String SOURCE_CONNECTOR = "SOURCE_CONNECTOR";
 
   private static final ConfigDef CONFIG_DEF = new ConfigDef()
       .define(
@@ -64,6 +65,14 @@ public final class CreateConfigs {
           null,
           Importance.LOW,
           "Undocumented feature"
+      ).define(
+          SOURCE_CONNECTOR,
+          Type.STRING,
+          null,
+          Importance.LOW,
+          "Indicates that this source was created by a connector with the given name. This "
+              + "is useful for understanding which sources map to which connectors and will "
+              + "be automatically populated for connectors."
       );
 
   static {

--- a/ksql-common/src/main/java/io/confluent/ksql/util/KsqlConfig.java
+++ b/ksql-common/src/main/java/io/confluent/ksql/util/KsqlConfig.java
@@ -65,6 +65,10 @@ public class KsqlConfig extends AbstractConfig {
 
   public static final String CONNECT_URL_PROPERTY = "ksql.connect.registry.url";
 
+  public static final String CONNECT_POLLING_DISABLE_PROPERTY = "ksql.connect.polling.disable";
+
+  public static final String CONNECT_CONFIGS_TOPIC_PROPERTY = "ksql.connect.configs.topic";
+
   public static final String KSQL_ENABLE_UDFS = "ksql.udfs.enabled";
 
   public static final String KSQL_EXT_DIR = "ksql.extension.dir";
@@ -158,6 +162,7 @@ public class KsqlConfig extends AbstractConfig {
 
   public static final String DEFAULT_SCHEMA_REGISTRY_URL = "http://localhost:8081";
   public static final String DEFAULT_CONNECT_URL = "http://localhost:8083";
+  public static final String DEFAULT_CONNECT_CONFIGS_TOPIC = "connect-configs";
 
   public static final String KSQL_STREAMS_PREFIX = "ksql.streams.";
 
@@ -390,6 +395,7 @@ public class KsqlConfig extends AbstractConfig {
     return generation == ConfigGeneration.CURRENT ? CURRENT_DEF : LEGACY_DEF;
   }
 
+  // CHECKSTYLE_RULES.OFF: MethodLength
   private static ConfigDef buildConfigDef(final ConfigGeneration generation) {
     final ConfigDef configDef = new ConfigDef()
         .define(
@@ -439,6 +445,19 @@ public class KsqlConfig extends AbstractConfig {
             DEFAULT_CONNECT_URL,
             Importance.MEDIUM,
             "The URL for the connect deployment, defaults to http://localhost:8083"
+        ).define(
+            CONNECT_POLLING_DISABLE_PROPERTY,
+            Type.BOOLEAN,
+            true,
+            Importance.LOW,
+            "A value of true for this configuration will disable automatically importing sources "
+            + "from connectors into KSQL."
+        ).define(
+            CONNECT_CONFIGS_TOPIC_PROPERTY ,
+            ConfigDef.Type.STRING,
+            DEFAULT_CONNECT_CONFIGS_TOPIC,
+            Importance.LOW,
+            "The name for the connect configuration topic, defaults to 'connect-configs'"
         ).define(
             KSQL_ENABLE_UDFS,
             ConfigDef.Type.BOOLEAN,
@@ -539,6 +558,7 @@ public class KsqlConfig extends AbstractConfig {
     }
     return configDef;
   }
+  // CHECKSTYLE_RULES.ON: MethodLength
 
   private static final class ConfigValue {
     final ConfigItem configItem;

--- a/ksql-common/src/main/java/io/confluent/ksql/util/KsqlConfig.java
+++ b/ksql-common/src/main/java/io/confluent/ksql/util/KsqlConfig.java
@@ -65,7 +65,7 @@ public class KsqlConfig extends AbstractConfig {
 
   public static final String CONNECT_URL_PROPERTY = "ksql.connect.registry.url";
 
-  public static final String CONNECT_POLLING_DISABLE_PROPERTY = "ksql.connect.polling.disable";
+  public static final String CONNECT_POLLING_ENABLE_PROPERTY = "ksql.connect.polling.enable";
 
   public static final String CONNECT_CONFIGS_TOPIC_PROPERTY = "ksql.connect.configs.topic";
 
@@ -446,11 +446,11 @@ public class KsqlConfig extends AbstractConfig {
             Importance.MEDIUM,
             "The URL for the connect deployment, defaults to http://localhost:8083"
         ).define(
-            CONNECT_POLLING_DISABLE_PROPERTY,
+            CONNECT_POLLING_ENABLE_PROPERTY,
             Type.BOOLEAN,
-            true,
+            false,
             Importance.LOW,
-            "A value of true for this configuration will disable automatically importing sources "
+            "A value of false for this configuration will disable automatically importing sources "
             + "from connectors into KSQL."
         ).define(
             CONNECT_CONFIGS_TOPIC_PROPERTY ,

--- a/ksql-engine/src/main/java/io/confluent/ksql/connect/ConnectConfigService.java
+++ b/ksql-engine/src/main/java/io/confluent/ksql/connect/ConnectConfigService.java
@@ -1,0 +1,185 @@
+/*
+ * Copyright 2019 Confluent Inc.
+ *
+ * Licensed under the Confluent Community License (the "License"; you may not use
+ * this file except in compliance with the License. You may obtain a copy of the
+ * License at
+ *
+ * http://www.confluent.io/confluent-community-license
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package io.confluent.ksql.connect;
+
+import com.google.common.annotations.VisibleForTesting;
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.Sets;
+import com.google.common.util.concurrent.AbstractExecutionThreadService;
+import com.google.common.util.concurrent.MoreExecutors;
+import io.confluent.ksql.util.KsqlConfig;
+import java.time.Duration;
+import java.util.HashSet;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Optional;
+import java.util.Set;
+import java.util.function.Function;
+import org.apache.kafka.clients.consumer.ConsumerConfig;
+import org.apache.kafka.clients.consumer.ConsumerRecord;
+import org.apache.kafka.clients.consumer.ConsumerRecords;
+import org.apache.kafka.clients.consumer.KafkaConsumer;
+import org.apache.kafka.common.TopicPartition;
+import org.apache.kafka.common.errors.WakeupException;
+import org.apache.kafka.common.serialization.ByteArrayDeserializer;
+import org.apache.kafka.common.serialization.StringDeserializer;
+import org.apache.kafka.connect.errors.DataException;
+import org.apache.kafka.connect.json.JsonConverter;
+import org.apache.kafka.connect.json.JsonConverterConfig;
+import org.apache.kafka.connect.storage.ConverterConfig;
+import org.apache.kafka.connect.storage.ConverterType;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * The {@code ConnectConfigService} listens to the connect configuration topic,
+ * which outputs messages whenever a new connector (or connector task) is started
+ * in Connect. These messages contain information that is then passed to a
+ * {@link ConnectPollingService} to digest and register with KSQL.
+ *
+ * <p>On startup, this service reads the connect configuration topic from the
+ * beginning to make sure that it reconstructs the necessary state.</p>
+ */
+class ConnectConfigService extends AbstractExecutionThreadService {
+
+  private static final Logger LOG = LoggerFactory.getLogger(ConnectConfigService.class);
+  private static final long POLL_TIMEOUT_S = 60;
+
+  private final KsqlConfig ksqlConfig;
+  private final String configsTopic;
+  private final ConnectPollingService pollingService;
+  private final JsonConverter converter;
+  private final Function<Map<String, Object>, KafkaConsumer<String, byte[]>> consumerFactory;
+  private final Function<Map<String, String>, Optional<Connector>> connectorFactory;
+
+  private Set<Connector> connectors = new HashSet<>();
+
+  // not final because constructing a consumer is expensive and should be
+  // done in startUp()
+  private KafkaConsumer<String, byte[]> consumer;
+
+  ConnectConfigService(
+      final KsqlConfig ksqlConfig,
+      final ConnectPollingService pollingService
+  ) {
+    this(ksqlConfig, pollingService, Connectors::fromConnectConfig , KafkaConsumer::new);
+  }
+
+  @VisibleForTesting
+  ConnectConfigService(
+      final KsqlConfig ksqlConfig,
+      final ConnectPollingService pollingService,
+      final Function<Map<String, String>, Optional<Connector>> connectorFactory,
+      final Function<Map<String, Object>, KafkaConsumer<String, byte[]>> consumerFactory
+  ) {
+    this.ksqlConfig = Objects.requireNonNull(ksqlConfig, "ksqlConfig");
+    this.pollingService = Objects.requireNonNull(pollingService, "pollingService");
+    this.connectorFactory = Objects.requireNonNull(connectorFactory, "connectorFactory");
+    this.consumerFactory = Objects.requireNonNull(consumerFactory, "consumerFactory");
+    this.configsTopic = ksqlConfig.getString(KsqlConfig.CONNECT_CONFIGS_TOPIC_PROPERTY);
+
+    this.converter = new JsonConverter();
+
+    addListener(new Listener() {
+      @Override
+      public void failed(final State from, final Throwable failure) {
+        LOG.error("ConnectConfigService failed due to: ", failure);
+      }
+    }, MoreExecutors.directExecutor());
+  }
+
+  @Override
+  protected void startUp() {
+    final Map<String, Object> consumerConfigs = ImmutableMap.<String, Object>builder()
+        .putAll(ksqlConfig.getProducerClientConfigProps())
+        // don't create the config topic if it doesn't exist - this is also necessary
+        // for some integration tests to pass
+        .put(ConsumerConfig.ALLOW_AUTO_CREATE_TOPICS_CONFIG, false)
+        .put(ConsumerConfig.KEY_DESERIALIZER_CLASS_CONFIG, StringDeserializer.class)
+        .put(ConsumerConfig.VALUE_DESERIALIZER_CLASS_CONFIG, ByteArrayDeserializer.class)
+        .build();
+
+    consumer = consumerFactory.apply(consumerConfigs);
+    consumer.assign(ImmutableList.of(new TopicPartition(configsTopic, 0)));
+    consumer.seekToBeginning(ImmutableList.of());
+
+    converter.configure(ImmutableMap.of(
+        ConverterConfig.TYPE_CONFIG, ConverterType.VALUE.getName(),
+        JsonConverterConfig.SCHEMAS_ENABLE_CONFIG, false));
+  }
+
+  @Override
+  protected void run() {
+    while (isRunning()) {
+      final ConsumerRecords<String, byte[]> records;
+      try {
+        records = consumer.poll(Duration.ofSeconds(POLL_TIMEOUT_S));
+        LOG.debug("Polled {} records from connect config topic", records.count());
+      } catch (final WakeupException e) {
+        if (isRunning()) {
+          throw e;
+        }
+        return;
+      }
+
+      final Set<Connector> connectors = new HashSet<>();
+      for (final ConsumerRecord<String, byte[]> record : records) {
+        try {
+          extractConnector(
+              converter.toConnectData(configsTopic, record.value()).value()
+          ).ifPresent(connectors::add);
+        } catch (final DataException e) {
+          LOG.warn("Failed to read connector configuration for connector {}", record.key(), e);
+        }
+      }
+
+      if (!connectors.isEmpty()) {
+        connectors.forEach(pollingService::addConnector);
+        if (!Sets.symmetricDifference(this.connectors, connectors).isEmpty()) {
+          LOG.info("Registered the following connectors: {}", connectors);
+          this.connectors = connectors;
+          pollingService.runOneIteration();
+        }
+      }
+    }
+  }
+
+  @SuppressWarnings("unchecked")
+  private Optional<Connector> extractConnector(final Object value) {
+    final Map<String, Object> asMap = (Map<String, Object>) value;
+    final Map<String, String> properties = (Map<String, String>) asMap.get("properties");
+    if (properties != null) {
+      return connectorFactory.apply(properties);
+    }
+
+    return Optional.empty();
+  }
+
+  @Override
+  protected void shutDown() {
+    // this is called in the same thread as run() as it is not thread-safe
+    consumer.close();
+    LOG.info("ConnectConfigService is down.");
+  }
+
+  @Override
+  protected void triggerShutdown() {
+    // this is called on a different thread from run() since it is thread-safe
+    LOG.info("Shutting down ConnectConfigService.");
+    consumer.wakeup();
+  }
+}

--- a/ksql-engine/src/main/java/io/confluent/ksql/connect/ConnectConfigService.java
+++ b/ksql-engine/src/main/java/io/confluent/ksql/connect/ConnectConfigService.java
@@ -160,10 +160,12 @@ class ConnectConfigService extends AbstractExecutionThreadService {
 
   @SuppressWarnings("unchecked")
   private Optional<Connector> extractConnector(final Object value) {
-    final Map<String, Object> asMap = (Map<String, Object>) value;
-    final Map<String, String> properties = (Map<String, String>) asMap.get("properties");
-    if (properties != null) {
-      return connectorFactory.apply(properties);
+    if (value != null) {
+      final Map<String, Object> asMap = (Map<String, Object>) value;
+      final Map<String, String> properties = (Map<String, String>) asMap.get("properties");
+      if (properties != null) {
+        return connectorFactory.apply(properties);
+      }
     }
 
     return Optional.empty();

--- a/ksql-engine/src/main/java/io/confluent/ksql/connect/ConnectPollingService.java
+++ b/ksql-engine/src/main/java/io/confluent/ksql/connect/ConnectPollingService.java
@@ -53,7 +53,7 @@ import org.slf4j.LoggerFactory;
  * registry.</p>
  */
 @ThreadSafe
-class ConnectPollingService extends AbstractScheduledService {
+final class ConnectPollingService extends AbstractScheduledService {
 
   private static final Logger LOG = LoggerFactory.getLogger(ConnectPollingService.class);
   private static final int INTERVAL_S = 30;

--- a/ksql-engine/src/main/java/io/confluent/ksql/connect/ConnectPollingService.java
+++ b/ksql-engine/src/main/java/io/confluent/ksql/connect/ConnectPollingService.java
@@ -1,0 +1,158 @@
+/*
+ * Copyright 2019 Confluent Inc.
+ *
+ * Licensed under the Confluent Community License (the "License"; you may not use
+ * this file except in compliance with the License. You may obtain a copy of the
+ * License at
+ *
+ * http://www.confluent.io/confluent-community-license
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package io.confluent.ksql.connect;
+
+import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.ImmutableMap.Builder;
+import com.google.common.collect.ImmutableSet;
+import com.google.common.util.concurrent.AbstractScheduledService;
+import io.confluent.ksql.KsqlExecutionContext;
+import io.confluent.ksql.metastore.model.DataSource.DataSourceType;
+import io.confluent.ksql.parser.properties.with.CreateSourceProperties;
+import io.confluent.ksql.parser.tree.CreateSource;
+import io.confluent.ksql.parser.tree.CreateStream;
+import io.confluent.ksql.parser.tree.CreateTable;
+import io.confluent.ksql.parser.tree.Literal;
+import io.confluent.ksql.parser.tree.QualifiedName;
+import io.confluent.ksql.parser.tree.StringLiteral;
+import io.confluent.ksql.parser.tree.TableElements;
+import io.confluent.ksql.properties.with.CommonCreateConfigs;
+import io.confluent.ksql.properties.with.CreateConfigs;
+import io.confluent.ksql.util.KsqlConstants;
+import java.util.Objects;
+import java.util.Optional;
+import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.TimeUnit;
+import java.util.function.Consumer;
+import javax.annotation.concurrent.ThreadSafe;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * The {@code ConnectPollingService} will maintain a list of {@link Connector}s
+ * and for each one it will poll kafka and schema registry to see if any topics
+ * created by that connector are eligible for automatic registry with KSQL on
+ * a regular basis.
+ *
+ * <p>Ideally, Connect would implement a metadata topic where it publishes all
+ * this information on a push basis, so we don't need to poll kafka or schema
+ * registry.</p>
+ */
+@ThreadSafe
+class ConnectPollingService extends AbstractScheduledService {
+
+  private static final Logger LOG = LoggerFactory.getLogger(ConnectPollingService.class);
+  private static final int INTERVAL_S = 30;
+
+  private final KsqlExecutionContext executionContext;
+  private final Consumer<CreateSource> sourceCallback;
+
+  private Set<Connector> connectors;
+
+  ConnectPollingService(
+      final KsqlExecutionContext executionContext,
+      final Consumer<CreateSource> sourceCallback
+  ) {
+    this.executionContext = Objects.requireNonNull(executionContext, "executionContext");
+    this.sourceCallback = Objects.requireNonNull(sourceCallback, "sourceCallback");
+    this.connectors = ConcurrentHashMap.newKeySet();
+  }
+
+  /**
+   * Add this connector to the set of connectors that are polled by this
+   * {@code ConnectPollingService}. Next time an iteration is scheduled in
+   * {@value #INTERVAL_S} seconds, the connector will be included in the topic
+   * scan.
+   *
+   * @param connector a connector to register
+   */
+  void addConnector(final Connector connector) {
+    connectors.add(connector);
+  }
+
+  @Override
+  protected void runOneIteration() {
+    if (connectors.isEmpty()) {
+      // avoid making external calls if unnecessary
+      return;
+    }
+
+    try {
+      final Set<String> topics = executionContext.getServiceContext()
+          .getAdminClient()
+          .listTopics()
+          .names()
+          .get(10, TimeUnit.SECONDS);
+
+      final Set<String> subjects = ImmutableSet.copyOf(
+          executionContext.getServiceContext()
+              .getSchemaRegistryClient()
+              .getAllSubjects()
+      );
+
+      for (final String topic : topics) {
+        final Optional<Connector> maybeConnector = connectors
+            .stream()
+            .filter(candidate -> candidate.matches(topic))
+            .findFirst();
+        maybeConnector.ifPresent(connector -> handleTopic(topic, subjects, connector));
+      }
+    } catch (final Exception e) {
+      LOG.error("Could not resolve connect sources. Trying again in {} seconds.", INTERVAL_S, e);
+    }
+  }
+
+  private void handleTopic(
+      final String topic,
+      final Set<String> subjects,
+      final Connector connector
+  ) {
+    final String valueSubject = topic + KsqlConstants.SCHEMA_REGISTRY_VALUE_SUFFIX;
+    if (subjects.contains(valueSubject)) {
+      final String name = connector.getName();
+      final String source = connector.mapToSource(topic).toUpperCase();
+
+      // if the meta store already contains the source, don't send the extra command
+      // onto the command topic
+      if (executionContext.getMetaStore().getSource(source) == null) {
+        LOG.info("Auto-Registering topic {} from connector {} as source {}",
+            topic, connector.getName(), source);
+        final Builder<String, Literal> builder = ImmutableMap.<String, Literal>builder()
+            .put(CommonCreateConfigs.KAFKA_TOPIC_NAME_PROPERTY, new StringLiteral(topic))
+            .put(CommonCreateConfigs.VALUE_FORMAT_PROPERTY, new StringLiteral("AVRO"))
+            .put(CreateConfigs.SOURCE_CONNECTOR, new StringLiteral(name));
+
+        connector.getKeyField().ifPresent(
+            key -> builder.put(CreateConfigs.KEY_NAME_PROPERTY, new StringLiteral(key))
+        );
+
+        final CreateSourceProperties properties = CreateSourceProperties.from(builder.build());
+        final CreateSource createSource =
+            connector.getSourceType() == (DataSourceType.KSTREAM)
+                ? new CreateStream(QualifiedName.of(source), TableElements.of(), true, properties)
+                : new CreateTable(QualifiedName.of(source), TableElements.of(), true, properties);
+
+        sourceCallback.accept(createSource);
+      }
+    }
+  }
+
+  @Override
+  protected Scheduler scheduler() {
+    return Scheduler.newFixedRateSchedule(0, INTERVAL_S, TimeUnit.SECONDS);
+  }
+}

--- a/ksql-engine/src/main/java/io/confluent/ksql/connect/Connector.java
+++ b/ksql-engine/src/main/java/io/confluent/ksql/connect/Connector.java
@@ -1,0 +1,97 @@
+/*
+ * Copyright 2019 Confluent Inc.
+ *
+ * Licensed under the Confluent Community License (the "License"; you may not use
+ * this file except in compliance with the License. You may obtain a copy of the
+ * License at
+ *
+ * http://www.confluent.io/confluent-community-license
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package io.confluent.ksql.connect;
+
+import com.google.errorprone.annotations.Immutable;
+import io.confluent.ksql.metastore.model.DataSource.DataSourceType;
+import java.util.Objects;
+import java.util.Optional;
+import java.util.function.Function;
+import java.util.function.Predicate;
+
+/**
+ * A model for a connector, which contains various information that
+ * helps map topics to KSQL sources.
+ */
+@Immutable
+class Connector {
+
+  private final String name;
+  private final Predicate<String> isTopicMatch;
+  private final Function<String, String> getSourceName;
+  private final DataSourceType sourceType;
+  private final Optional<String> keyField;
+
+  Connector(
+      final String name,
+      final Predicate<String> isTopicMatch,
+      final Function<String, String> getSourceName,
+      final DataSourceType sourceType,
+      final String keyField) {
+    this.name = Objects.requireNonNull(name, "name");
+    this.isTopicMatch = Objects.requireNonNull(isTopicMatch, "isTopicMatch");
+    this.getSourceName = Objects.requireNonNull(getSourceName, "getSourceName");
+    this.sourceType = Objects.requireNonNull(sourceType, "sourceType");
+    this.keyField = Optional.ofNullable(keyField);
+  }
+
+  String getName() {
+    return name;
+  }
+
+  boolean matches(final String topic) {
+    return isTopicMatch.test(topic);
+  }
+
+  String mapToSource(final String topic) {
+    return getSourceName.apply(topic);
+  }
+
+  DataSourceType getSourceType() {
+    return sourceType;
+  }
+
+  public Optional<String> getKeyField() {
+    return keyField;
+  }
+
+  @Override
+  public boolean equals(final Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    final Connector that = (Connector) o;
+    return Objects.equals(name, that.name)
+        && sourceType == that.sourceType
+        && Objects.equals(keyField, that.keyField);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(name, sourceType, keyField);
+  }
+
+  @Override
+  public String toString() {
+    return "Connector{" + "name='" + name + '\''
+        + ", sourceType=" + sourceType
+        + ", keyField=" + keyField
+        + '}';
+  }
+}

--- a/ksql-engine/src/main/java/io/confluent/ksql/connect/Connectors.java
+++ b/ksql-engine/src/main/java/io/confluent/ksql/connect/Connectors.java
@@ -1,0 +1,89 @@
+/*
+ * Copyright 2019 Confluent Inc.
+ *
+ * Licensed under the Confluent Community License (the "License"; you may not use
+ * this file except in compliance with the License. You may obtain a copy of the
+ * License at
+ *
+ * http://www.confluent.io/confluent-community-license
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package io.confluent.ksql.connect;
+
+import com.google.common.base.Splitter;
+import io.confluent.ksql.metastore.model.DataSource.DataSourceType;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+
+final class Connectors {
+
+  static final String CONNECTOR_CLASS = "connector.class";
+  static final String JDBC_SOURCE_CLASS = "io.confluent.connect.jdbc.JdbcSourceConnector";
+
+  private Connectors() { }
+
+  @SuppressWarnings("SwitchStatementWithTooFewBranches") // will soon expand to more
+  static Optional<Connector> fromConnectConfig(final Map<String, String> properties) {
+    final String clazz = properties.get(CONNECTOR_CLASS);
+    if (clazz == null) {
+      return  Optional.empty();
+    }
+
+    switch (clazz) {
+      case JDBC_SOURCE_CLASS: return Optional.of(jdbc(properties));
+      default:                return Optional.empty();
+    }
+  }
+
+  private static Connector jdbc(final Map<String, String> properties) {
+    final String name = properties.get("name");
+    final String prefix = properties.get("topic.prefix");
+
+    return new Connector(
+        name,
+        topic -> topic.startsWith(prefix),
+        topic -> clean(name + "_" + topic.substring(prefix.length())),
+        DataSourceType.KTABLE,
+        extractKeyNameFromSMT(properties).orElse(null)
+    );
+  }
+
+  /**
+   * JDBC connector does not necessarily have an easy way to define the key field (or the primary
+   * column in the database). Most configurations of JDBC, therefore, will specify an extract field
+   * transform to determine the key of the table - the built in one in connect is ExtractField$Key,
+   * though it is not necessary that the connect is configured with this Single Message Transform.
+   * If it is not configured such, we will not be able to determine the key and the user will need
+   * to manually import the connector.
+   *
+   * <p>This is pretty hacky, and we need to figure out a better long-term way to determine the key
+   * column from a connector.</p>
+   */
+  private static Optional<String> extractKeyNameFromSMT(final Map<String, String> properties) {
+    final String transformsString = properties.get("transforms");
+    if (transformsString == null) {
+      return Optional.empty();
+    }
+
+    final List<String> transforms = Splitter.on(',').splitToList(transformsString);
+    for (String transform : transforms) {
+      final String transformType = properties.get("transforms." + transform + ".type");
+      if (transformType != null && transformType.contains("ExtractField$Key")) {
+        return Optional.ofNullable(properties.get("transforms." + transform + ".field"));
+      }
+    }
+
+    return Optional.empty();
+  }
+
+  private static String clean(final String name) {
+    return name.replace('-', '_').replace('.', '_');
+  }
+
+}

--- a/ksql-engine/src/main/java/io/confluent/ksql/connect/Connectors.java
+++ b/ksql-engine/src/main/java/io/confluent/ksql/connect/Connectors.java
@@ -20,24 +20,32 @@ import io.confluent.ksql.metastore.model.DataSource.DataSourceType;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+import org.apache.kafka.connect.runtime.rest.entities.ConnectorInfo;
 
 final class Connectors {
 
   static final String CONNECTOR_CLASS = "connector.class";
   static final String JDBC_SOURCE_CLASS = "io.confluent.connect.jdbc.JdbcSourceConnector";
 
-  private Connectors() { }
+  private Connectors() {
+  }
+
+  static Optional<Connector> fromConnectInfo(final ConnectorInfo connectorInfo) {
+    return fromConnectInfo(connectorInfo.config());
+  }
 
   @SuppressWarnings("SwitchStatementWithTooFewBranches") // will soon expand to more
-  static Optional<Connector> fromConnectConfig(final Map<String, String> properties) {
+  static Optional<Connector> fromConnectInfo(final Map<String, String> properties) {
     final String clazz = properties.get(CONNECTOR_CLASS);
     if (clazz == null) {
-      return  Optional.empty();
+      return Optional.empty();
     }
 
     switch (clazz) {
-      case JDBC_SOURCE_CLASS: return Optional.of(jdbc(properties));
-      default:                return Optional.empty();
+      case JDBC_SOURCE_CLASS:
+        return Optional.of(jdbc(properties));
+      default:
+        return Optional.empty();
     }
   }
 

--- a/ksql-engine/src/main/java/io/confluent/ksql/connect/KsqlConnect.java
+++ b/ksql-engine/src/main/java/io/confluent/ksql/connect/KsqlConnect.java
@@ -1,0 +1,76 @@
+/*
+ * Copyright 2019 Confluent Inc.
+ *
+ * Licensed under the Confluent Community License (the "License"; you may not use
+ * this file except in compliance with the License. You may obtain a copy of the
+ * License at
+ *
+ * http://www.confluent.io/confluent-community-license
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package io.confluent.ksql.connect;
+
+import com.google.common.annotations.VisibleForTesting;
+import io.confluent.ksql.KsqlExecutionContext;
+import io.confluent.ksql.parser.tree.CreateSource;
+import io.confluent.ksql.util.KsqlConfig;
+import java.io.Closeable;
+import java.util.Objects;
+import java.util.function.Consumer;
+
+/**
+ * A simple wrapper around {@link ConnectPollingService} and {@link ConnectConfigService}
+ * to make lifecycle management a little easier.
+ */
+public class KsqlConnect implements Closeable {
+
+  private final ConnectPollingService connectPollingService;
+  private final ConnectConfigService configService;
+  private final boolean enabled;
+
+  public KsqlConnect(
+      final KsqlExecutionContext executionContext,
+      final KsqlConfig ksqlConfig,
+      final Consumer<CreateSource> sourceCallback
+  ) {
+    connectPollingService = new ConnectPollingService(executionContext, sourceCallback);
+    configService = new ConnectConfigService(ksqlConfig, connectPollingService);
+    enabled = !ksqlConfig.getBoolean(KsqlConfig.CONNECT_POLLING_DISABLE_PROPERTY);
+  }
+
+  @VisibleForTesting
+  KsqlConnect(
+      final ConnectPollingService connectPollingService,
+      final ConnectConfigService connectConfigService
+  ) {
+    this.connectPollingService = Objects
+        .requireNonNull(connectPollingService, "connectPollingService");
+    this.configService = Objects
+        .requireNonNull(connectConfigService, "connectConfigService");
+    enabled = true;
+  }
+
+  /**
+   * Asynchronously starts the KSQL-Connect integration components - does not
+   * wait for them to startup before returning.
+   */
+  public void startAsync() {
+    if (enabled) {
+      connectPollingService.startAsync();
+      configService.startAsync();
+    }
+  }
+
+  @Override
+  public void close() {
+    if (enabled) {
+      configService.stopAsync().awaitTerminated();
+      connectPollingService.stopAsync().awaitTerminated();
+    }
+  }
+}

--- a/ksql-engine/src/main/java/io/confluent/ksql/connect/KsqlConnect.java
+++ b/ksql-engine/src/main/java/io/confluent/ksql/connect/KsqlConnect.java
@@ -43,7 +43,8 @@ public class KsqlConnect implements Closeable {
       final Consumer<CreateSource> sourceCallback
   ) {
     connectPollingService = new ConnectPollingService(executionContext, sourceCallback);
-    configService = new ConnectConfigService(ksqlConfig, connectPollingService);
+    configService = new ConnectConfigService(
+        ksqlConfig, executionContext.getServiceContext().getConnectClient(), connectPollingService);
     enabled = ksqlConfig.getBoolean(KsqlConfig.CONNECT_POLLING_ENABLE_PROPERTY);
   }
 

--- a/ksql-engine/src/main/java/io/confluent/ksql/connect/KsqlConnect.java
+++ b/ksql-engine/src/main/java/io/confluent/ksql/connect/KsqlConnect.java
@@ -40,7 +40,7 @@ public class KsqlConnect implements Closeable {
   ) {
     connectPollingService = new ConnectPollingService(executionContext, sourceCallback);
     configService = new ConnectConfigService(ksqlConfig, connectPollingService);
-    enabled = !ksqlConfig.getBoolean(KsqlConfig.CONNECT_POLLING_DISABLE_PROPERTY);
+    enabled = ksqlConfig.getBoolean(KsqlConfig.CONNECT_POLLING_ENABLE_PROPERTY);
   }
 
   @VisibleForTesting

--- a/ksql-engine/src/main/java/io/confluent/ksql/connect/KsqlConnect.java
+++ b/ksql-engine/src/main/java/io/confluent/ksql/connect/KsqlConnect.java
@@ -22,12 +22,16 @@ import io.confluent.ksql.util.KsqlConfig;
 import java.io.Closeable;
 import java.util.Objects;
 import java.util.function.Consumer;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  * A simple wrapper around {@link ConnectPollingService} and {@link ConnectConfigService}
  * to make lifecycle management a little easier.
  */
 public class KsqlConnect implements Closeable {
+
+  private static final Logger LOG = LoggerFactory.getLogger(KsqlConnect.class);
 
   private final ConnectPollingService connectPollingService;
   private final ConnectConfigService configService;
@@ -63,6 +67,9 @@ public class KsqlConnect implements Closeable {
     if (enabled) {
       connectPollingService.startAsync();
       configService.startAsync();
+    } else {
+      LOG.info("Connect integration is disabled, turn on by setting "
+          + KsqlConfig.CONNECT_POLLING_ENABLE_PROPERTY);
     }
   }
 

--- a/ksql-engine/src/main/java/io/confluent/ksql/schema/ksql/inference/TopicSchemaSupplier.java
+++ b/ksql-engine/src/main/java/io/confluent/ksql/schema/ksql/inference/TopicSchemaSupplier.java
@@ -69,5 +69,13 @@ public interface TopicSchemaSupplier {
     static SchemaResult failure(final Exception cause) {
       return new SchemaResult(Optional.empty(), Optional.of(cause));
     }
+
+    public Optional<SchemaAndId> getSchemaAndId() {
+      return schemaAndId;
+    }
+
+    public Optional<Exception> getFailureReason() {
+      return failureReason;
+    }
   }
 }

--- a/ksql-engine/src/main/java/io/confluent/ksql/services/ConnectClient.java
+++ b/ksql-engine/src/main/java/io/confluent/ksql/services/ConnectClient.java
@@ -16,6 +16,7 @@
 package io.confluent.ksql.services;
 
 import io.confluent.ksql.util.KsqlPreconditions;
+import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import org.apache.kafka.connect.runtime.rest.entities.ConnectorInfo;
@@ -25,6 +26,20 @@ import org.apache.kafka.connect.runtime.rest.entities.ConnectorInfo;
  * a Kafka Connect cluster.
  */
 public interface ConnectClient {
+
+  /**
+   * List all of the connectors available in this connect cluster.
+   *
+   * @return a list of connector names
+   */
+  ConnectResponse<List<String>> connectors();
+
+  /**
+   * Gets the configuration for a specified connector.
+   *
+   * @param connector the name of the connector
+   */
+  ConnectResponse<ConnectorInfo> describe(String connector);
 
   /**
    * Creates a connector with {@code connector} as the name under the

--- a/ksql-engine/src/main/java/io/confluent/ksql/services/SandboxConnectClient.java
+++ b/ksql-engine/src/main/java/io/confluent/ksql/services/SandboxConnectClient.java
@@ -17,6 +17,7 @@ package io.confluent.ksql.services;
 
 import static io.confluent.ksql.util.LimitedProxyBuilder.methodParams;
 
+import com.google.common.collect.ImmutableList;
 import io.confluent.ksql.services.ConnectClient.ConnectResponse;
 import io.confluent.ksql.util.LimitedProxyBuilder;
 import java.util.Map;
@@ -32,6 +33,8 @@ final class SandboxConnectClient {
   public static ConnectClient createProxy() {
     return LimitedProxyBuilder.forClass(ConnectClient.class)
         .swallow("create", methodParams(String.class, Map.class), ConnectResponse.of("sandbox"))
+        .swallow("describe", methodParams(String.class), ConnectResponse.of(ImmutableList.of()))
+        .swallow("connectors", methodParams(), ConnectResponse.of(ImmutableList.of()))
         .build();
   }
 }

--- a/ksql-engine/src/test/java/io/confluent/ksql/connect/ConnectConfigServiceTest.java
+++ b/ksql-engine/src/test/java/io/confluent/ksql/connect/ConnectConfigServiceTest.java
@@ -83,6 +83,7 @@ public class ConnectConfigServiceTest {
   public void shouldWakeupConsumerBeforeShuttingDown() {
     // Given:
     setupConfigService();
+    givenConnector("ignored", ImmutableMap.of());
     configService.startAsync().awaitRunning();
 
     // When:

--- a/ksql-engine/src/test/java/io/confluent/ksql/connect/ConnectConfigServiceTest.java
+++ b/ksql-engine/src/test/java/io/confluent/ksql/connect/ConnectConfigServiceTest.java
@@ -1,0 +1,128 @@
+/*
+ * Copyright 2019 Confluent Inc.
+ *
+ * Licensed under the Confluent Community License (the "License"; you may not use
+ * this file except in compliance with the License. You may obtain a copy of the
+ * License at
+ *
+ * http://www.confluent.io/confluent-community-license
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package io.confluent.ksql.connect;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.inOrder;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+import io.confluent.ksql.util.KsqlConfig;
+import java.util.Map;
+import java.util.Optional;
+import java.util.concurrent.CountDownLatch;
+import org.apache.kafka.clients.consumer.ConsumerRecord;
+import org.apache.kafka.clients.consumer.ConsumerRecords;
+import org.apache.kafka.clients.consumer.KafkaConsumer;
+import org.apache.kafka.common.TopicPartition;
+import org.apache.kafka.common.errors.WakeupException;
+import org.apache.kafka.connect.json.JsonConverter;
+import org.apache.kafka.connect.json.JsonConverterConfig;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.InOrder;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnitRunner;
+
+@RunWith(MockitoJUnitRunner.class)
+public class ConnectConfigServiceTest {
+
+  @Mock
+  private KafkaConsumer<String, byte[]> consumer;
+  @Mock
+  private ConnectPollingService pollingService;
+  @Mock
+  private Connector connector;
+
+  private ConnectConfigService configService;
+
+  @Test(timeout = 30_000L)
+  public void shouldCreateConnectorFromConfig() throws InterruptedException {
+    // Given:
+    final Map<String, String> config = ImmutableMap.of();
+    givenRecord(config);
+
+    final CountDownLatch awaitIteration = new CountDownLatch(1);
+    doAnswer(invocationOnMock -> {
+      awaitIteration.countDown();
+      return null;
+    }).when(pollingService).runOneIteration();
+    setupConfigService();
+
+    // When:
+    configService.startAsync().awaitRunning();
+
+    // Then:
+    awaitIteration.await();
+    verify(pollingService).addConnector(connector);
+    configService.stopAsync().awaitTerminated();
+  }
+
+  @Test(timeout = 30_000L)
+  public void shouldWakeupConsumerBeforeShuttingDown() {
+    // Given:
+    final CountDownLatch awaitWakeup = new CountDownLatch(1);
+    when(consumer.poll(any())).thenAnswer(invocationOnMock -> {
+      awaitWakeup.await();
+      throw new WakeupException();
+    });
+    doAnswer(invocation -> {
+      awaitWakeup.countDown();
+      return null;
+    }).when(consumer).wakeup();
+    setupConfigService();
+    configService.startAsync().awaitRunning();
+
+    // When:
+    configService.stopAsync().awaitTerminated();
+
+    // Then:
+    final InOrder inOrder = inOrder(consumer);
+    inOrder.verify(consumer).poll(any());
+    inOrder.verify(consumer).wakeup();
+    inOrder.verify(consumer).close();
+    inOrder.verifyNoMoreInteractions();
+  }
+
+  private void givenRecord(final Map<String, String> properties) {
+    final JsonConverter converter = new JsonConverter();
+    converter.configure(ImmutableMap.of(
+        "converter.type", "value",
+        JsonConverterConfig.SCHEMAS_ENABLE_CONFIG, false));
+
+    final byte[] mapAsBytes = converter
+        .fromConnectData("topic", null, ImmutableMap.of("properties", properties));
+    when(consumer.poll(any()))
+        .thenReturn(new ConsumerRecords<>(
+            ImmutableMap.of(
+                new TopicPartition("topic", 0),
+                ImmutableList.of(new ConsumerRecord<>("topic", 0, 0L, "connector", mapAsBytes)))))
+        .thenReturn(new ConsumerRecords<>(
+            ImmutableMap.of()));
+  }
+
+  private void setupConfigService() {
+    configService = new ConnectConfigService(
+        new KsqlConfig(ImmutableMap.of()),
+        pollingService,
+        props -> Optional.of(connector),
+        props -> consumer);
+  }
+
+}

--- a/ksql-engine/src/test/java/io/confluent/ksql/connect/ConnectConfigServiceTest.java
+++ b/ksql-engine/src/test/java/io/confluent/ksql/connect/ConnectConfigServiceTest.java
@@ -252,10 +252,10 @@ public class ConnectConfigServiceTest {
   private void givenNoMoreRecords(final OngoingStubbing<?> stubbing, final CountDownLatch noMoreLatch) {
     final CountDownLatch awaitWakeup = new CountDownLatch(1);
     stubbing.thenAnswer(invocationOnMock -> {
-          noMoreLatch.countDown();
-          awaitWakeup.await(30, TimeUnit.SECONDS);
-          throw new WakeupException();
-        });
+      noMoreLatch.countDown();
+      awaitWakeup.await();
+      throw new WakeupException();
+    });
 
     doAnswer(invocation -> {
       awaitWakeup.countDown();

--- a/ksql-engine/src/test/java/io/confluent/ksql/connect/ConnectPollingServiceTest.java
+++ b/ksql-engine/src/test/java/io/confluent/ksql/connect/ConnectPollingServiceTest.java
@@ -1,0 +1,199 @@
+/*
+ * Copyright 2019 Confluent Inc.
+ *
+ * Licensed under the Confluent Community License (the "License"; you may not use
+ * this file except in compliance with the License. You may obtain a copy of the
+ * License at
+ *
+ * http://www.confluent.io/confluent-community-license
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package io.confluent.ksql.connect;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.nullValue;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verifyZeroInteractions;
+import static org.mockito.Mockito.when;
+
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+import io.confluent.kafka.schemaregistry.client.SchemaRegistryClient;
+import io.confluent.ksql.KsqlExecutionContext;
+import io.confluent.ksql.function.FunctionRegistry;
+import io.confluent.ksql.metastore.MutableMetaStore;
+import io.confluent.ksql.metastore.model.DataSource;
+import io.confluent.ksql.metastore.model.DataSource.DataSourceType;
+import io.confluent.ksql.parser.SqlFormatter;
+import io.confluent.ksql.parser.tree.CreateSource;
+import io.confluent.ksql.services.ServiceContext;
+import io.confluent.ksql.util.KsqlConstants;
+import io.confluent.ksql.util.MetaStoreFixture;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.Objects;
+import java.util.Set;
+import java.util.function.Consumer;
+import org.apache.kafka.clients.admin.MockAdminClient;
+import org.apache.kafka.common.Node;
+import org.apache.kafka.common.TopicPartitionInfo;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnitRunner;
+
+@RunWith(MockitoJUnitRunner.class)
+public class ConnectPollingServiceTest {
+
+  private final Node node = new Node(1, "localhost", 1234);
+
+  @Mock
+  private FunctionRegistry functionRegistry;
+  @Mock
+  private KsqlExecutionContext executionContext;
+  @Mock
+  private ServiceContext serviceContext;
+  @Mock
+  private SchemaRegistryClient schemaRegistryClient;
+
+  private MockAdminClient adminClient;
+  private ConnectPollingService pollingService;
+  private Set<String> subjects;
+  private MutableMetaStore metaStore;
+
+  @Before
+  public void setUp() throws Exception {
+    adminClient = new MockAdminClient(Collections.singletonList(node), node);
+    subjects = new HashSet<>();
+    metaStore = MetaStoreFixture.getNewMetaStore(functionRegistry);
+
+    when(executionContext.getMetaStore()).thenReturn(metaStore);
+    when(executionContext.getServiceContext()).thenReturn(serviceContext);
+
+    when(serviceContext.getAdminClient()).thenReturn(adminClient);
+    when(serviceContext.getSchemaRegistryClient()).thenReturn(schemaRegistryClient);
+
+    when(schemaRegistryClient.getAllSubjects()).thenReturn(subjects);
+  }
+
+  @Test
+  public void shouldCreateSourceFromConnector() {
+    // Given:
+    final CreateSource[] ref = new CreateSource[]{null};
+    givenTopic("foo");
+    givenSubject("foo");
+    givenPollingService(cs -> ref[0] = cs);
+    givenConnector("foo");
+
+    // When:
+    pollingService.runOneIteration();
+
+    // Then:
+    assertThat(
+        SqlFormatter.formatSql(ref[0]),
+        is("CREATE TABLE IF NOT EXISTS FOO "
+            + "WITH ("
+            + "KAFKA_TOPIC='foo', "
+            + "KEY='key', "
+            + "SOURCE_CONNECTOR='connector', "
+            + "VALUE_FORMAT='AVRO');"));
+  }
+
+  @Test
+  public void shouldNotCreateSourceFromConnectorWithoutTopicMatch() {
+    // Given:
+    final CreateSource[] ref = new CreateSource[]{null};
+    givenTopic("foo");
+    givenSubject("foo");
+    givenPollingService(cs -> ref[0] = cs);
+    givenConnector("bar");
+
+    // When:
+    pollingService.runOneIteration();
+
+    // Then:
+    assertThat(ref[0], nullValue());
+  }
+
+  @Test
+  public void shouldNotCreateSourceFromConnectorWithoutSubjectMatch() {
+    // Given:
+    final CreateSource[] ref = new CreateSource[]{null};
+    givenTopic("foo");
+    givenPollingService(cs -> ref[0] = cs);
+    givenConnector("foo");
+
+    // When:
+    pollingService.runOneIteration();
+
+    // Then:
+    assertThat(ref[0], nullValue());
+  }
+
+  @Test
+  public void shouldNotCreateSourceForAlreadyRegisteredSource() {
+    // Given:
+    final CreateSource[] ref = new CreateSource[]{null};
+    givenTopic("foo");
+    givenSubject("foo");
+    givenPollingService(cs -> ref[0] = cs);
+    givenConnector("foo");
+
+    final DataSource<?> source = mock(DataSource.class);
+    when(source.getName()).thenReturn("FOO");
+    metaStore.putSource(source);
+
+    // When:
+    pollingService.runOneIteration();
+
+    // Then:
+    assertThat(ref[0], nullValue());
+  }
+
+  @Test
+  public void shouldNotPollIfNoRegisteredConnectors() {
+    givenPollingService(foo -> {});
+
+    // When:
+    pollingService.runOneIteration();
+
+    // Then:
+    verifyZeroInteractions(serviceContext);
+  }
+
+  private void givenTopic(final String topicName) {
+    adminClient.addTopic(
+        false,
+        topicName,
+        ImmutableList.of(
+            new TopicPartitionInfo(0, node, ImmutableList.of(), ImmutableList.of())),
+        ImmutableMap.of());
+  }
+
+  private void givenPollingService(final Consumer<CreateSource> callback) {
+    pollingService = new ConnectPollingService(executionContext, callback);
+  }
+
+  private void givenConnector(final String topic) {
+    pollingService.addConnector(
+        new Connector(
+            "connector",
+            foo -> Objects.equals(foo, topic),
+            foo -> topic,
+            DataSourceType.KTABLE,
+            "key"
+    ));
+  }
+
+  private void givenSubject(final String topicName) {
+    subjects.add(topicName + KsqlConstants.SCHEMA_REGISTRY_VALUE_SUFFIX);
+  }
+
+}

--- a/ksql-engine/src/test/java/io/confluent/ksql/connect/ConnectorTest.java
+++ b/ksql-engine/src/test/java/io/confluent/ksql/connect/ConnectorTest.java
@@ -1,0 +1,41 @@
+/*
+ * Copyright 2019 Confluent Inc.
+ *
+ * Licensed under the Confluent Community License (the "License"; you may not use
+ * this file except in compliance with the License. You may obtain a copy of the
+ * License at
+ *
+ * http://www.confluent.io/confluent-community-license
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package io.confluent.ksql.connect;
+
+import com.google.common.testing.EqualsTester;
+import io.confluent.ksql.metastore.model.DataSource.DataSourceType;
+import org.junit.Test;
+
+public class ConnectorTest {
+
+  @Test
+  public void shouldImplementHashAndEquals() {
+    new EqualsTester()
+        .addEqualityGroup(
+            new Connector("foo", foo -> true, foo -> foo, DataSourceType.KTABLE, "key"),
+            new Connector("foo", foo -> false, foo -> foo, DataSourceType.KTABLE, "key"),
+            new Connector("foo", foo -> false, foo -> foo, DataSourceType.KTABLE, "key")
+        ).addEqualityGroup(
+            new Connector("bar", foo -> true, foo -> foo, DataSourceType.KTABLE, "key")
+        ).addEqualityGroup(
+            new Connector("foo", foo -> true, foo -> foo, DataSourceType.KTABLE, "key2")
+        ).addEqualityGroup(
+            new Connector("foo", foo -> true, foo -> foo, DataSourceType.KSTREAM, "key")
+        )
+        .testEquals();
+  }
+
+}

--- a/ksql-engine/src/test/java/io/confluent/ksql/connect/ConnectorsTest.java
+++ b/ksql-engine/src/test/java/io/confluent/ksql/connect/ConnectorsTest.java
@@ -35,7 +35,7 @@ public class ConnectorsTest {
     );
 
     // When:
-    final Optional<Connector> maybeConnector = Connectors.fromConnectConfig(config);
+    final Optional<Connector> maybeConnector = Connectors.fromConnectInfo(config);
 
     // Then:
     assertThat("expected no connector", !maybeConnector.isPresent());
@@ -50,7 +50,7 @@ public class ConnectorsTest {
     );
 
     // When:
-    final Optional<Connector> maybeConnector = Connectors.fromConnectConfig(config);
+    final Optional<Connector> maybeConnector = Connectors.fromConnectInfo(config);
 
     // Then:
     final Connector expected = new Connector(
@@ -72,7 +72,7 @@ public class ConnectorsTest {
     );
 
     // When:
-    final Optional<Connector> maybeConnector = Connectors.fromConnectConfig(config);
+    final Optional<Connector> maybeConnector = Connectors.fromConnectInfo(config);
 
     // Then:
     assertThat(
@@ -90,7 +90,7 @@ public class ConnectorsTest {
     );
 
     // When:
-    final Optional<Connector> maybeConnector = Connectors.fromConnectConfig(config);
+    final Optional<Connector> maybeConnector = Connectors.fromConnectInfo(config);
 
     // Then:
     assertThat(
@@ -110,7 +110,7 @@ public class ConnectorsTest {
     );
 
     // When:
-    final Optional<Connector> maybeConnector = Connectors.fromConnectConfig(config);
+    final Optional<Connector> maybeConnector = Connectors.fromConnectInfo(config);
 
     // Then:
     final Connector expected = new Connector(

--- a/ksql-engine/src/test/java/io/confluent/ksql/connect/ConnectorsTest.java
+++ b/ksql-engine/src/test/java/io/confluent/ksql/connect/ConnectorsTest.java
@@ -1,0 +1,125 @@
+/*
+ * Copyright 2019 Confluent Inc.
+ *
+ * Licensed under the Confluent Community License (the "License"; you may not use
+ * this file except in compliance with the License. You may obtain a copy of the
+ * License at
+ *
+ * http://www.confluent.io/confluent-community-license
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package io.confluent.ksql.connect;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+
+import com.google.common.collect.ImmutableMap;
+import io.confluent.ksql.metastore.model.DataSource.DataSourceType;
+import io.confluent.ksql.metastore.model.MetaStoreMatchers.OptionalMatchers;
+import java.util.Map;
+import java.util.Optional;
+import org.junit.Test;
+
+public class ConnectorsTest {
+
+  @Test
+  public void shouldNotCreateConnectorForUnknown() {
+    // Given:
+    final Map<String, String> config = ImmutableMap.of(
+        Connectors.CONNECTOR_CLASS, "foobar"
+    );
+
+    // When:
+    final Optional<Connector> maybeConnector = Connectors.fromConnectConfig(config);
+
+    // Then:
+    assertThat("expected no connector", !maybeConnector.isPresent());
+  }
+
+  @Test
+  public void shouldCreateJdbcConnectorWithValidConfigs() {
+    // Given:
+    final Map<String, String> config = ImmutableMap.of(
+        Connectors.CONNECTOR_CLASS, Connectors.JDBC_SOURCE_CLASS,
+        "name", "foo"
+    );
+
+    // When:
+    final Optional<Connector> maybeConnector = Connectors.fromConnectConfig(config);
+
+    // Then:
+    final Connector expected = new Connector(
+        "foo",
+        foo -> true,
+        foo -> foo,
+        DataSourceType.KTABLE,
+        null);
+    assertThat(maybeConnector, OptionalMatchers.of(is(expected)));
+  }
+
+  @Test
+  public void shouldCreateJdbcConnectorWithValidPrefixTest() {
+    // Given:
+    final Map<String, String> config = ImmutableMap.of(
+        Connectors.CONNECTOR_CLASS, Connectors.JDBC_SOURCE_CLASS,
+        "name", "foo",
+        "topic.prefix", "foo-"
+    );
+
+    // When:
+    final Optional<Connector> maybeConnector = Connectors.fromConnectConfig(config);
+
+    // Then:
+    assertThat(
+        "expected match",
+        maybeConnector.map(connector -> connector.matches("foo-bar")).orElse(false));
+  }
+
+  @Test
+  public void shouldCreateJdbcConnectorWithValidMapToSource() {
+    // Given:
+    final Map<String, String> config = ImmutableMap.of(
+        Connectors.CONNECTOR_CLASS, Connectors.JDBC_SOURCE_CLASS,
+        "name", "name",
+        "topic.prefix", "foo-"
+    );
+
+    // When:
+    final Optional<Connector> maybeConnector = Connectors.fromConnectConfig(config);
+
+    // Then:
+    assertThat(
+        maybeConnector.map(connector -> connector.mapToSource("foo-bar")).orElse(null),
+        is("name_bar"));
+  }
+
+  @Test
+  public void shouldCreateJdbcConnectorWithValidConfigsAndSMT() {
+    // Given:
+    final Map<String, String> config = ImmutableMap.of(
+        Connectors.CONNECTOR_CLASS, Connectors.JDBC_SOURCE_CLASS,
+        "name", "foo",
+        "transforms", "foobar,createKey",
+        "transforms.createKey.type", "org.apache.kafka.connect.transforms.ExtractField$Key",
+        "transforms.createKey.field", "key"
+    );
+
+    // When:
+    final Optional<Connector> maybeConnector = Connectors.fromConnectConfig(config);
+
+    // Then:
+    final Connector expected = new Connector(
+        "foo",
+        foo -> true,
+        foo -> foo,
+        DataSourceType.KTABLE,
+        "key");
+    assertThat(maybeConnector, OptionalMatchers.of(is(expected)));
+  }
+
+}

--- a/ksql-engine/src/test/java/io/confluent/ksql/connect/KsqlConnectTest.java
+++ b/ksql-engine/src/test/java/io/confluent/ksql/connect/KsqlConnectTest.java
@@ -1,0 +1,73 @@
+/*
+ * Copyright 2019 Confluent Inc.
+ *
+ * Licensed under the Confluent Community License (the "License"; you may not use
+ * this file except in compliance with the License. You may obtain a copy of the
+ * License at
+ *
+ * http://www.confluent.io/confluent-community-license
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package io.confluent.ksql.connect;
+
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoMoreInteractions;
+import static org.mockito.Mockito.when;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnitRunner;
+
+@RunWith(MockitoJUnitRunner.class)
+public class KsqlConnectTest {
+
+  @Mock
+  private ConnectPollingService pollingService;
+  @Mock
+  private ConnectConfigService configService;
+
+  private KsqlConnect ksqlConnect;
+
+  @Before
+  public void setUp() {
+    ksqlConnect = new KsqlConnect(pollingService, configService);
+
+    when(pollingService.startAsync()).thenReturn(pollingService);
+    when(pollingService.stopAsync()).thenReturn(pollingService);
+
+    when(configService.startAsync()).thenReturn(configService);
+    when(configService.stopAsync()).thenReturn(configService);
+  }
+
+  @Test
+  public void shouldStartBothSubServicesAsynchronously() {
+    // When:
+    ksqlConnect.startAsync();
+
+    // Then:
+    verify(pollingService).startAsync();
+    verify(configService).startAsync();
+
+    verifyNoMoreInteractions(pollingService, configService);
+  }
+
+  @Test
+  public void shouldStopBothSubServicesSynchronously() {
+    // When:
+    ksqlConnect.close();
+
+    // Then:
+    verify(configService).stopAsync();
+    verify(pollingService).stopAsync();
+    verify(configService).awaitTerminated();
+    verify(pollingService).awaitTerminated();
+  }
+
+}

--- a/ksql-rest-app/src/test/java/io/confluent/ksql/rest/server/KsqlRestApplicationTest.java
+++ b/ksql-rest-app/src/test/java/io/confluent/ksql/rest/server/KsqlRestApplicationTest.java
@@ -32,6 +32,7 @@ import static org.mockito.hamcrest.MockitoHamcrest.argThat;
 
 import com.google.common.collect.ImmutableList;
 import io.confluent.ksql.KsqlExecutionContext;
+import io.confluent.ksql.connect.KsqlConnect;
 import io.confluent.ksql.engine.KsqlEngine;
 import io.confluent.ksql.logging.processing.ProcessingLogConfig;
 import io.confluent.ksql.logging.processing.ProcessingLogContext;
@@ -120,6 +121,8 @@ public class KsqlRestApplicationTest {
   @Mock
   private KsqlServerPrecondition precondition2;
   @Mock
+  private KsqlConnect ksqlConnect;
+  @Mock
   private ParsedStatement parsedStatement;
   @Mock
   private PreparedStatement<?> preparedStatement;
@@ -173,8 +176,8 @@ public class KsqlRestApplicationTest {
         securityExtension,
         serverState,
         processingLogContext,
-        ImmutableList.of(precondition1, precondition2)
-    );
+        ImmutableList.of(precondition1, precondition2),
+        ksqlConnect);
   }
 
   @Test
@@ -193,6 +196,15 @@ public class KsqlRestApplicationTest {
 
     // Then:
     verify(securityExtension).close();
+  }
+
+  @Test
+  public void shouldCloseKsqlConnect() {
+    // When:
+    app.stop();
+
+    // Then:
+    verify(ksqlConnect).close();
   }
 
   @Test


### PR DESCRIPTION
## Description 
This PR implements the most bare-bones mechanism to automatically import tables created from a JDBC connector. It should be noted that this PR is *incremental* and is the minimum chunk that I felt I could implement and put out in a single PR. See the Future Work section for upcoming PRs. Because of this, there are lots of limitations - BUT if you look at the testing done section it makes for a pretty 💣 💥  demo! What's left makes it much more robust.

## Design

There are two main services introduced:
- `ConnectConfigService` is in charge of listening to the `connect-configs` topic (value configurable) and polling /connectors endpoint, extracting "known" connector configurations, passing them to the `ConnectPollingService`. As of now, only JDBC source connector is a known connector.
- `ConnectPollingService` is a scheduled service that runs every so often, scanning all kafka topics and seeing if any of them could have been created by a connector that was passed in by `ConnectConfigService`. If it does, it issues a `CREATE TABLE` request to the KSQL endpoint.

```
                  +-----------------------------------------+
                  |        KSQL                             |       +---------+
                  |                           +------------------>  | Kafka   |
                  |                           |             |       +---------+
                  |               +-----------+-----------+ |
                  |        +------+ ConnectPollingService | |
                  |        |      +--------+--+-----------+ |
                  |        |               ^  |             |       +---------+
                  |        |               |  +------------------>  | SR      |
+---------+       |        v               |                |       +---------+
|         |       | +------+--+   +--------+------------+   |
|  >cli   +-------->+  /ksql  |   | ConnectConfigService|   |
|         |       | +---+-----+   +----+---+------------+   |
+---------+       |     |              |   ^                |
                  |     |              |   |                |
                  |     |              |   |                |
                  +-----------------------------------------+
                        |              |   |
                 +------v-------+<-----+   |
                 |              |          |
                 |   connect    | +--------+--------+
                 |              | | connect configs |
                 +--------------+ +-----------------+
```

The diagram above describes the flow of creating a connector and having it automatically imported into KSQL (including what was implemented in #3149 

Beyond that, the following classes were changed:
- configs were added for (1) disabling this feature and (2) specifying the kafka topic for `connect-configs`
- the `KsqlConnect` class simply wraps the two classes describes above into one easy to pass around component
- the `Connector` class models information specific to each connectors (e.g. the `topic.prefix` config for JDBC connector) and `Connectors` helps create those
- `CreateConfigs` (WITH clause) now accepts metadata describing which connector created the source. This is not used as of this PR but it was straightforward enough removing it was annoying.

### Distributed System Concerns

Since multiple servers will be running this at the same time, we make sure that only one is in charge by having them all share a group.id when reading from `connect-configs`. If a server becomes the one assigned to read from `connect-configs`, it will reconstruct the entire state by calling `/connectors` and reading data from connect.

### Security Concerns

cc @spena - since this is asynchronous, the KSQL principal will be the one who creates the table from the connect topic. Do you have any suggestions here with regards to the ksql security model? 

### Future Work

- We need to add support for dropping these sources. As of this design, even if you `DROP <SOURCE>`, it will be re-created the next time `ConnectPollingService` runs
- Work needs to be done in connect to expose a metadata topic to replace the `connect-configs` topic. When we do that `ConnectPollingService` can be removed.
- We need to add `DESCRIBE` functionality to connectors, which will leverage the `WITH` clause change in this PR. This will be in the returned response for `CREATE SOURCE CONNECTOR` for improved usability
- We will add `AWAIT <SOURCE>` so that users can wait until a certain stream is imported into KSQL
- Full integration system tests for this and documentation of end-to-end connect integration
- Simplify JDBC configuration for SMTs

## Testing done 

- Unit tests mocking out most major components
- End to end manual testing:

```
ksql> CREATE SOURCE CONNECTOR `jdbc-connector` WITH("connector.class"='io.confluent.connect.jdbc.JdbcSourceConnector',"tasks.max"='1',"connection.url"='jdbc:postgresql://localhost:5432/almog.gavra',"mode"='bulk',"topic.prefix"='jdbc-',"transforms"='createKey,extractString',"transforms.createKey.type"= 'org.apache.kafka.connect.transforms.ValueToKey', "transforms.createKey.fields"='username',"transforms.extractString.type"='org.apache.kafka.connect.transforms.ExtractField$Key',"transforms.extractString.field"='username', "key.converter"='org.apache.kafka.connect.storage.StringConverter');

 Message
----------------------------------
 Created connector jdbc-connector
----------------------------------

ksql> SHOW TABLES;

 Table Name           | Kafka Topic | Format | Windowed
--------------------------------------------------------
 JDBC_CONNECTOR_USERS | jdbc-users  | AVRO   | false
--------------------------------------------------------
```

## Reviewer checklist
- [ ] Ensure docs are updated if necessary. (eg. if a user visible feature is being added or changed).
- [ ] Ensure relevant issues are linked (description should include text like "Fixes #<issue number>")

