### PR TITLE
feat: Add SHOW TOPICS EXTENDED

### DIFF
--- a/docs/developer-guide/query-with-structured-data.rst
+++ b/docs/developer-guide/query-with-structured-data.rst
@@ -121,12 +121,12 @@ Your output should resemble:
 
 ::
 
-     Kafka Topic        | Partitions | Partition Replicas | Consumers | ConsumerGroups
-    ----------------------------------------------------------------------------------
-     _confluent-metrics | 12         | 1                  | 0         | 0
-     _schemas           | 1          | 1                  | 0         | 0
-     raw-topic          | 1          | 1                  | 0         | 0
-    ----------------------------------------------------------------------------------
+     Kafka Topic        | Partitions | Partition Replicas
+    ------------------------------------------------------
+     _confluent-metrics | 12         | 1
+     _schemas           | 1          | 1
+     raw-topic          | 1          | 1
+    ------------------------------------------------------
 
 Inspect ``raw-topic`` to ensure that |kcat| populated it: 
 

--- a/docs/developer-guide/syntax-reference.rst
+++ b/docs/developer-guide/syntax-reference.rst
@@ -1338,13 +1338,14 @@ SHOW TOPICS
 
 .. code:: sql
 
-    SHOW | LIST TOPICS;
+    SHOW | LIST TOPICS [EXTENDED];
 
 **Description**
 
-List the available topics in the Kafka cluster that KSQL is configured
+SHOW TOPICS lists the available topics in the Kafka cluster that KSQL is configured
 to connect to (default setting for ``bootstrap.servers``:
-``localhost:9092``).
+``localhost:9092``). SHOW TOPICS EXTENDED also displays consumer groups and their active consumer
+counts.
 
 .. _show-streams:
 

--- a/docs/includes/ksql-includes.rst
+++ b/docs/includes/ksql-includes.rst
@@ -126,13 +126,13 @@ Your output should resemble:
 
 ::
 
-     Kafka Topic        | Partitions | Partition Replicas | Consumers | ConsumerGroups
-    -----------------------------------------------------------------------------------
-     _confluent-metrics | 12         | 1                  | 0         | 0
-     _schemas           | 1          | 1                  | 0         | 0
-     pageviews          | 1          | 1                  | 0         | 0
-     users              | 1          | 1                  | 0         | 0
-    -----------------------------------------------------------------------------------
+     Kafka Topic        | Partitions | Partition Replicas
+    ------------------------------------------------------
+     _confluent-metrics | 12         | 1
+     _schemas           | 1          | 1
+     pageviews          | 1          | 1
+     users              | 1          | 1
+    ------------------------------------------------------
 
 Inspect the ``users`` topic by using the PRINT statement:
 

--- a/docs/tutorials/basics-control-center.rst
+++ b/docs/tutorials/basics-control-center.rst
@@ -154,9 +154,7 @@ statements in KSQL Editor, just like you use them in the KSQL CLI.
          "registered": true,
          "replicaInfo": [
            1
-         ],
-         "consumerCount": 0,
-         "consumerGroupCount": 0
+         ]
        },
 
    The ``"registered": true`` indicator means that you have registered the topic

--- a/ksql-cli/src/main/java/io/confluent/ksql/cli/console/Console.java
+++ b/ksql-cli/src/main/java/io/confluent/ksql/cli/console/Console.java
@@ -49,6 +49,7 @@ import io.confluent.ksql.rest.entity.FunctionDescriptionList;
 import io.confluent.ksql.rest.entity.FunctionInfo;
 import io.confluent.ksql.rest.entity.FunctionNameList;
 import io.confluent.ksql.rest.entity.KafkaTopicsList;
+import io.confluent.ksql.rest.entity.KafkaTopicsListExtended;
 import io.confluent.ksql.rest.entity.KsqlEntity;
 import io.confluent.ksql.rest.entity.KsqlEntityList;
 import io.confluent.ksql.rest.entity.KsqlErrorMessage;
@@ -130,7 +131,11 @@ public class Console implements Closeable {
           .put(TablesList.class,
               tablePrinter(TablesList.class, TablesListTableBuilder::new))
           .put(KafkaTopicsList.class,
-              tablePrinter(KafkaTopicsList.class, KafkaTopicsListTableBuilder::new))
+              tablePrinter(KafkaTopicsList.class, KafkaTopicsListTableBuilder.SimpleBuilder::new))
+          .put(KafkaTopicsListExtended.class,
+              tablePrinter(
+                  KafkaTopicsListExtended.class,
+                  KafkaTopicsListTableBuilder.ExtendedBuilder::new))
           .put(ExecutionPlan.class,
               tablePrinter(ExecutionPlan.class, ExecutionPlanTableBuilder::new))
           .put(FunctionNameList.class,

--- a/ksql-cli/src/main/java/io/confluent/ksql/cli/console/table/builder/KafkaTopicsListTableBuilder.java
+++ b/ksql-cli/src/main/java/io/confluent/ksql/cli/console/table/builder/KafkaTopicsListTableBuilder.java
@@ -19,33 +19,57 @@ import com.google.common.collect.ImmutableList;
 import io.confluent.ksql.cli.console.table.Table;
 import io.confluent.ksql.cli.console.table.Table.Builder;
 import io.confluent.ksql.rest.entity.KafkaTopicsList;
+import io.confluent.ksql.rest.entity.KafkaTopicsListExtended;
 import io.confluent.ksql.util.StringUtil;
 import java.util.List;
 import java.util.stream.Stream;
 
-public class KafkaTopicsListTableBuilder implements TableBuilder<KafkaTopicsList> {
+public class KafkaTopicsListTableBuilder {
 
-  private static final List<String> HEADERS = ImmutableList.of(
-      "Kafka Topic",
-      "Partitions",
-      "Partition Replicas",
-      "Consumers",
-      "ConsumerGroups");
+  public static class SimpleBuilder implements TableBuilder<KafkaTopicsList> {
+    private static final List<String> HEADERS = ImmutableList.of(
+        "Kafka Topic",
+        "Partitions",
+        "Partition Replicas");
 
-  @Override
-  public Table buildTable(final KafkaTopicsList entity) {
-    final Stream<List<String>> rows = entity.getTopics().stream()
-        .map(t -> ImmutableList.of(
-            t.getName(),
-            Integer.toString(t.getReplicaInfo().size()),
-            getTopicReplicaInfo(t.getReplicaInfo()),
-            Integer.toString(t.getConsumerCount()),
-            Integer.toString(t.getConsumerGroupCount())));
+    @Override
+    public Table buildTable(final KafkaTopicsList entity) {
+      final Stream<List<String>> rows = entity.getTopics().stream()
+          .map(t -> ImmutableList.of(
+              t.getName(),
+              Integer.toString(t.getReplicaInfo().size()),
+              getTopicReplicaInfo(t.getReplicaInfo())));
 
-    return new Builder()
-        .withColumnHeaders(HEADERS)
-        .withRows(rows)
-        .build();
+      return new Builder()
+          .withColumnHeaders(HEADERS)
+          .withRows(rows)
+          .build();
+    }
+  }
+
+  public static class ExtendedBuilder implements TableBuilder<KafkaTopicsListExtended> {
+    private static final List<String> HEADERS = ImmutableList.of(
+        "Kafka Topic",
+        "Partitions",
+        "Partition Replicas",
+        "Consumers",
+        "ConsumerGroups");
+
+    @Override
+    public Table buildTable(final KafkaTopicsListExtended entity) {
+      final Stream<List<String>> rows = entity.getTopics().stream()
+          .map(t -> ImmutableList.of(
+              t.getName(),
+              Integer.toString(t.getReplicaInfo().size()),
+              getTopicReplicaInfo(t.getReplicaInfo()),
+              Integer.toString(t.getConsumerCount()),
+              Integer.toString(t.getConsumerGroupCount())));
+
+      return new Builder()
+          .withColumnHeaders(HEADERS)
+          .withRows(rows)
+          .build();
+    }
   }
 
   /**

--- a/ksql-cli/src/test/java/io/confluent/ksql/cli/CliTest.java
+++ b/ksql-cli/src/test/java/io/confluent/ksql/cli/CliTest.java
@@ -355,9 +355,17 @@ public class CliTest {
 
   @Test
   public void shouldPrintResultsForListOrShowCommands() {
-
     assertRunListCommand(
         "topics",
+        hasRow(
+            equalTo(orderDataProvider.topicName()),
+            equalTo("1"),
+            equalTo("1")
+        )
+    );
+
+    assertRunListCommand(
+        "topics extended",
         hasRow(
             equalTo(orderDataProvider.topicName()),
             equalTo("1"),

--- a/ksql-parser/src/main/antlr4/io/confluent/ksql/parser/SqlBase.g4
+++ b/ksql-parser/src/main/antlr4/io/confluent/ksql/parser/SqlBase.g4
@@ -34,7 +34,7 @@ singleExpression
 statement
     : query                                                                 #querystatement
     | (LIST | SHOW) PROPERTIES                                              #listProperties
-    | (LIST | SHOW) TOPICS                                                  #listTopics
+    | (LIST | SHOW) TOPICS EXTENDED?                                        #listTopics
     | (LIST | SHOW) STREAMS EXTENDED?                                       #listStreams
     | (LIST | SHOW) TABLES EXTENDED?                                        #listTables
     | (LIST | SHOW) FUNCTIONS                                               #listFunctions

--- a/ksql-parser/src/main/java/io/confluent/ksql/parser/AstBuilder.java
+++ b/ksql-parser/src/main/java/io/confluent/ksql/parser/AstBuilder.java
@@ -571,7 +571,7 @@ public class AstBuilder {
 
     @Override
     public Node visitListTopics(final SqlBaseParser.ListTopicsContext context) {
-      return new ListTopics(getLocation(context));
+      return new ListTopics(getLocation(context), context.EXTENDED() != null);
     }
 
     @Override

--- a/ksql-parser/src/main/java/io/confluent/ksql/parser/tree/ListTopics.java
+++ b/ksql-parser/src/main/java/io/confluent/ksql/parser/tree/ListTopics.java
@@ -22,27 +22,38 @@ import java.util.Optional;
 
 public class ListTopics extends Statement {
 
-  public ListTopics(final Optional<NodeLocation> location) {
+  private final boolean showExtended;
+
+  public ListTopics(final Optional<NodeLocation> location, final boolean showExtended) {
     super(location);
+    this.showExtended = showExtended;
+  }
+
+  public boolean getShowExtended() {
+    return showExtended;
+  }
+
+  @Override
+  public boolean equals(final Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    final ListTopics that = (ListTopics) o;
+    return showExtended == that.showExtended;
   }
 
   @Override
   public int hashCode() {
-    return Objects.hash(getClass());
-  }
-
-  @Override
-  public boolean equals(final Object obj) {
-    if (this == obj) {
-      return true;
-    }
-
-    return obj != null && obj.getClass().equals(getClass());
+    return Objects.hash(showExtended);
   }
 
   @Override
   public String toString() {
     return toStringHelper(this)
+        .add("showExtended", showExtended)
         .toString();
   }
 }

--- a/ksql-parser/src/test/java/io/confluent/ksql/parser/KsqlParserTest.java
+++ b/ksql-parser/src/test/java/io/confluent/ksql/parser/KsqlParserTest.java
@@ -619,11 +619,17 @@ public class KsqlParserTest {
 
   @Test
   public void testShowTopics() {
+    // Given:
     final String simpleQuery = "SHOW TOPICS;";
+
+    // When:
     final Statement statement = KsqlParserTestUtil.buildSingleAst(simpleQuery, metaStore).getStatement();
-    Assert.assertTrue(statement instanceof ListTopics);
     final ListTopics listTopics = (ListTopics) statement;
-    Assert.assertTrue(listTopics.toString().equalsIgnoreCase("ListTopics{}"));
+
+    // Then:
+    Assert.assertTrue(statement instanceof ListTopics);
+    Assert.assertThat(listTopics.toString(), is("ListTopics{showExtended=false}"));
+    Assert.assertThat(listTopics.getShowExtended(), is(false));
   }
 
   @Test
@@ -759,6 +765,21 @@ public class KsqlParserTest {
     Assert.assertThat(statement, instanceOf(ListStreams.class));
     final ListStreams listStreams = (ListStreams)statement;
     Assert.assertThat(listStreams.getShowExtended(), is(true));
+  }
+
+  @Test
+  public void shouldSetShowDescriptionsForShowTopicsDescriptions() {
+    // Given:
+    final String statementString = "SHOW TOPICS EXTENDED;";
+
+    // When:
+    final Statement statement = KsqlParserTestUtil.buildSingleAst(statementString, metaStore)
+        .getStatement();
+
+    // Then:
+    Assert.assertThat(statement, instanceOf(ListTopics.class));
+    final ListTopics listTopics = (ListTopics)statement;
+    Assert.assertThat(listTopics.getShowExtended(), is(true));
   }
 
   @Test

--- a/ksql-parser/src/test/java/io/confluent/ksql/parser/tree/ListTopicsTest.java
+++ b/ksql-parser/src/test/java/io/confluent/ksql/parser/tree/ListTopicsTest.java
@@ -26,11 +26,15 @@ public class ListTopicsTest {
 
   @Test
   public void shouldImplementHashCodeAndEqualsProperty() {
+    // Note: At the moment location does not take part in equality testing
     new EqualsTester()
         .addEqualityGroup(
-            // Note: At the moment location does not take part in equality testing
-            new ListTopics(Optional.of(SOME_LOCATION)),
-            new ListTopics(Optional.of(OTHER_LOCATION))
+            new ListTopics(Optional.of(SOME_LOCATION), true),
+            new ListTopics(Optional.of(OTHER_LOCATION), true)
+        )
+        .addEqualityGroup(
+            new ListTopics(Optional.of(SOME_LOCATION), false),
+            new ListTopics(Optional.of(OTHER_LOCATION), false)
         )
         .testEquals();
   }

--- a/ksql-rest-app/src/main/java/io/confluent/ksql/rest/entity/KafkaTopicInfoExtended.java
+++ b/ksql-rest-app/src/main/java/io/confluent/ksql/rest/entity/KafkaTopicInfoExtended.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018 Confluent Inc.
+ * Copyright 2019 Confluent Inc.
  *
  * Licensed under the Confluent Community License (the "License"); you may not use
  * this file except in compliance with the License.  You may obtain a copy of the
@@ -24,18 +24,24 @@ import java.util.Objects;
 
 @JsonIgnoreProperties(ignoreUnknown = true)
 @JsonSubTypes({})
-public class KafkaTopicInfo {
+public class KafkaTopicInfoExtended {
 
   private final String name;
   private final List<Integer> replicaInfo;
+  private final int consumerGroupCount;
+  private final int consumerCount;
 
   @JsonCreator
-  public KafkaTopicInfo(
+  public KafkaTopicInfoExtended(
       @JsonProperty("name") final String name,
-      @JsonProperty("replicaInfo") final List<Integer> replicaInfo
+      @JsonProperty("replicaInfo") final List<Integer> replicaInfo,
+      @JsonProperty("consumerCount") final int consumerCount,
+      @JsonProperty("consumerGroupCount") final int consumerGroupCount
   ) {
     this.name = name;
     this.replicaInfo = replicaInfo;
+    this.consumerGroupCount = consumerGroupCount;
+    this.consumerCount = consumerCount;
   }
 
   public String getName() {
@@ -46,6 +52,14 @@ public class KafkaTopicInfo {
     return replicaInfo;
   }
 
+  public int getConsumerCount() {
+    return consumerCount;
+  }
+
+  public int getConsumerGroupCount() {
+    return consumerGroupCount;
+  }
+
   @Override
   public boolean equals(final Object o) {
     if (this == o) {
@@ -54,7 +68,7 @@ public class KafkaTopicInfo {
     if (o == null || getClass() != o.getClass()) {
       return false;
     }
-    final KafkaTopicInfo that = (KafkaTopicInfo) o;
+    final KafkaTopicInfoExtended that = (KafkaTopicInfoExtended) o;
     return Objects.equals(name, that.name);
   }
 

--- a/ksql-rest-app/src/main/java/io/confluent/ksql/rest/entity/KafkaTopicsList.java
+++ b/ksql-rest-app/src/main/java/io/confluent/ksql/rest/entity/KafkaTopicsList.java
@@ -19,24 +19,10 @@ import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.google.common.base.Preconditions;
-import io.confluent.ksql.util.KafkaConsumerGroupClient;
-import io.confluent.ksql.util.KafkaConsumerGroupClientImpl;
-import io.confluent.ksql.util.KsqlConfig;
-import io.confluent.ksql.util.KsqlConstants;
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.Collection;
-import java.util.HashMap;
-import java.util.HashSet;
 import java.util.List;
-import java.util.Map;
 import java.util.Objects;
-import java.util.Set;
-import java.util.TreeMap;
-import java.util.concurrent.atomic.AtomicInteger;
-import java.util.stream.Collectors;
-import org.apache.kafka.clients.admin.TopicDescription;
-import org.apache.kafka.common.TopicPartition;
 
 @JsonIgnoreProperties(ignoreUnknown = true)
 public class KafkaTopicsList extends KsqlEntity {
@@ -73,88 +59,4 @@ public class KafkaTopicsList extends KsqlEntity {
   public int hashCode() {
     return Objects.hash(getTopics());
   }
-
-  public static KafkaTopicsList build(
-      final String statementText,
-      final Map<String, TopicDescription> kafkaTopicDescriptions,
-      final KsqlConfig ksqlConfig,
-      final KafkaConsumerGroupClient consumerGroupClient
-  ) {
-    final List<KafkaTopicInfo> kafkaTopicInfoList = new ArrayList<>();
-    final Map<String, TopicDescription> filteredDescriptions = new TreeMap<>(
-        filterKsqlInternalTopics(kafkaTopicDescriptions, ksqlConfig));
-
-    final Map<String, List<Integer>> topicConsumersAndGroupCount = getTopicConsumerAndGroupCounts(
-        consumerGroupClient);
-
-    for (final TopicDescription desp : filteredDescriptions.values()) {
-      kafkaTopicInfoList.add(new KafkaTopicInfo(
-          desp.name(),
-          desp.partitions()
-              .stream().map(partition -> partition.replicas().size()).collect(Collectors.toList()),
-          topicConsumersAndGroupCount.getOrDefault(desp.name(), Arrays.asList(0, 0)).get(0),
-          topicConsumersAndGroupCount.getOrDefault(desp.name(), Arrays.asList(0, 0)).get(1)
-      ));
-    }
-    return new KafkaTopicsList(statementText, kafkaTopicInfoList);
-  }
-
-  /**
-   * @return all topics with their associated consumerCount and consumerGroupCount
-   */
-  private static Map<String, List<Integer>> getTopicConsumerAndGroupCounts(
-      final KafkaConsumerGroupClient consumerGroupClient
-  ) {
-
-    final List<String> consumerGroups = consumerGroupClient.listGroups();
-
-    final Map<String, AtomicInteger> topicConsumerCount = new HashMap<>();
-    final Map<String, Set<String>> topicConsumerGroupCount = new HashMap<>();
-
-    for (final String group : consumerGroups) {
-      final Collection<KafkaConsumerGroupClientImpl.ConsumerSummary> consumerSummaryList =
-          consumerGroupClient.describeConsumerGroup(group).consumers();
-
-      for (final KafkaConsumerGroupClientImpl.ConsumerSummary summary : consumerSummaryList) {
-
-        for (final TopicPartition topicPartition : summary.partitions()) {
-          topicConsumerCount
-              .computeIfAbsent(topicPartition.topic(), k -> new AtomicInteger())
-              .incrementAndGet();
-          topicConsumerGroupCount
-              .computeIfAbsent(topicPartition.topic(), k -> new HashSet<>()).add(group);
-        }
-      }
-    }
-    final HashMap<String, List<Integer>> results = new HashMap<>();
-    topicConsumerCount.forEach(
-        (k, v) -> {
-          results.computeIfAbsent(k, v1 -> new ArrayList<>()).add(v.intValue());
-          results.get(k).add(topicConsumerGroupCount.get(k).size());
-        }
-    );
-
-    return results;
-  }
-
-  private static Map<String, TopicDescription> filterKsqlInternalTopics(
-      final Map<String, TopicDescription> kafkaTopicDescriptions, final KsqlConfig ksqlConfig
-  ) {
-    final Map<String, TopicDescription> filteredKafkaTopics = new HashMap<>();
-    final String serviceId = KsqlConstants.KSQL_INTERNAL_TOPIC_PREFIX
-                       + ksqlConfig.getString(KsqlConfig.KSQL_SERVICE_ID_CONFIG);
-    final String persistentQueryPrefix = ksqlConfig.getString(
-        KsqlConfig.KSQL_PERSISTENT_QUERY_NAME_PREFIX_CONFIG);
-    final String transientQueryPrefix = ksqlConfig.getString(
-        KsqlConfig.KSQL_TRANSIENT_QUERY_NAME_PREFIX_CONFIG);
-
-    for (final Map.Entry<String, TopicDescription> entry : kafkaTopicDescriptions.entrySet()) {
-      if (!entry.getKey().startsWith(serviceId + persistentQueryPrefix)
-          && !entry.getKey().startsWith(serviceId + transientQueryPrefix)) {
-        filteredKafkaTopics.put(entry.getKey().toLowerCase(), entry.getValue());
-      }
-    }
-    return filteredKafkaTopics;
-  }
-
 }

--- a/ksql-rest-app/src/main/java/io/confluent/ksql/rest/entity/KafkaTopicsListExtended.java
+++ b/ksql-rest-app/src/main/java/io/confluent/ksql/rest/entity/KafkaTopicsListExtended.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018 Confluent Inc.
+ * Copyright 2019 Confluent Inc.
  *
  * Licensed under the Confluent Community License (the "License"); you may not use
  * this file except in compliance with the License.  You may obtain a copy of the
@@ -18,32 +18,29 @@ package io.confluent.ksql.rest.entity;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
-import com.fasterxml.jackson.annotation.JsonSubTypes;
+import com.google.common.base.Preconditions;
+import java.util.ArrayList;
+import java.util.Collection;
 import java.util.List;
 import java.util.Objects;
 
 @JsonIgnoreProperties(ignoreUnknown = true)
-@JsonSubTypes({})
-public class KafkaTopicInfo {
+public class KafkaTopicsListExtended extends KsqlEntity {
 
-  private final String name;
-  private final List<Integer> replicaInfo;
+  private final Collection<KafkaTopicInfoExtended> topics;
 
   @JsonCreator
-  public KafkaTopicInfo(
-      @JsonProperty("name") final String name,
-      @JsonProperty("replicaInfo") final List<Integer> replicaInfo
+  public KafkaTopicsListExtended(
+      @JsonProperty("statementText") final String statementText,
+      @JsonProperty("topics") final Collection<KafkaTopicInfoExtended> topics
   ) {
-    this.name = name;
-    this.replicaInfo = replicaInfo;
+    super(statementText);
+    Preconditions.checkNotNull(topics, "topics field must not be null");
+    this.topics = topics;
   }
 
-  public String getName() {
-    return name;
-  }
-
-  public List<Integer> getReplicaInfo() {
-    return replicaInfo;
+  public List<KafkaTopicInfoExtended> getTopics() {
+    return new ArrayList<>(topics);
   }
 
   @Override
@@ -51,15 +48,15 @@ public class KafkaTopicInfo {
     if (this == o) {
       return true;
     }
-    if (o == null || getClass() != o.getClass()) {
+    if (!(o instanceof KafkaTopicsListExtended)) {
       return false;
     }
-    final KafkaTopicInfo that = (KafkaTopicInfo) o;
-    return Objects.equals(name, that.name);
+    final KafkaTopicsListExtended that = (KafkaTopicsListExtended) o;
+    return Objects.equals(getTopics(), that.getTopics());
   }
 
   @Override
   public int hashCode() {
-    return Objects.hash(name);
+    return Objects.hash(getTopics());
   }
 }

--- a/ksql-rest-app/src/main/java/io/confluent/ksql/rest/entity/KsqlEntity.java
+++ b/ksql-rest-app/src/main/java/io/confluent/ksql/rest/entity/KsqlEntity.java
@@ -37,6 +37,7 @@ import java.util.List;
     @JsonSubTypes.Type(value = StreamsList.class, name = "streams"),
     @JsonSubTypes.Type(value = TablesList.class, name = "tables"),
     @JsonSubTypes.Type(value = KafkaTopicsList.class, name = "kafka_topics"),
+    @JsonSubTypes.Type(value = KafkaTopicsListExtended.class, name = "kafka_topics_extended"),
     @JsonSubTypes.Type(value = ExecutionPlan.class, name = "executionPlan"),
     @JsonSubTypes.Type(value = SourceDescriptionList.class, name = "source_descriptions"),
     @JsonSubTypes.Type(value = QueryDescriptionList.class, name = "query_descriptions"),

--- a/ksql-rest-app/src/main/java/io/confluent/ksql/rest/server/execution/ListTopicsExecutor.java
+++ b/ksql-rest-app/src/main/java/io/confluent/ksql/rest/server/execution/ListTopicsExecutor.java
@@ -17,18 +17,39 @@ package io.confluent.ksql.rest.server.execution;
 
 import io.confluent.ksql.KsqlExecutionContext;
 import io.confluent.ksql.parser.tree.ListTopics;
+import io.confluent.ksql.rest.entity.KafkaTopicInfo;
+import io.confluent.ksql.rest.entity.KafkaTopicInfoExtended;
 import io.confluent.ksql.rest.entity.KafkaTopicsList;
+import io.confluent.ksql.rest.entity.KafkaTopicsListExtended;
 import io.confluent.ksql.rest.entity.KsqlEntity;
 import io.confluent.ksql.services.KafkaTopicClient;
 import io.confluent.ksql.services.ServiceContext;
 import io.confluent.ksql.statement.ConfiguredStatement;
 import io.confluent.ksql.util.KafkaConsumerGroupClient;
+import io.confluent.ksql.util.KafkaConsumerGroupClient.ConsumerSummary;
 import io.confluent.ksql.util.KafkaConsumerGroupClientImpl;
+import io.confluent.ksql.util.KsqlConfig;
+import io.confluent.ksql.util.KsqlConstants;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
 import java.util.Optional;
+import java.util.Set;
+import java.util.TreeMap;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.stream.Collectors;
+import org.apache.kafka.clients.admin.TopicDescription;
+import org.apache.kafka.common.TopicPartition;
 
 public final class ListTopicsExecutor {
 
-  private ListTopicsExecutor() { }
+  private ListTopicsExecutor() {
+
+  }
 
   public static Optional<KsqlEntity> execute(
       final ConfiguredStatement<ListTopics> statement,
@@ -36,14 +57,114 @@ public final class ListTopicsExecutor {
       final ServiceContext serviceContext
   ) {
     final KafkaTopicClient client = serviceContext.getTopicClient();
-    final KafkaConsumerGroupClient kafkaConsumerGroupClient
-        = new KafkaConsumerGroupClientImpl(serviceContext.getAdminClient());
 
-    return Optional.of(KafkaTopicsList.build(
-        statement.getStatementText(),
-        client.describeTopics(client.listNonInternalTopicNames()),
-        statement.getConfig(),
-        kafkaConsumerGroupClient
-    ));
+    final Map<String, TopicDescription> kafkaTopicDescriptions
+        = client.describeTopics(client.listNonInternalTopicNames());
+
+    final Map<String, TopicDescription> filteredDescriptions = new TreeMap<>(
+        filterKsqlInternalTopics(kafkaTopicDescriptions, statement.getConfig()));
+
+    if (statement.getStatement().getShowExtended()) {
+      final KafkaConsumerGroupClient consumerGroupClient
+          = new KafkaConsumerGroupClientImpl(serviceContext.getAdminClient());
+      final Map<String, List<Integer>> topicConsumersAndGroupCount
+          = getTopicConsumerAndGroupCounts(consumerGroupClient);
+
+      final List<KafkaTopicInfoExtended> topicInfoExtendedList = filteredDescriptions.values()
+          .stream().map(desc ->
+              topicDescriptionToTopicInfoExtended(desc, topicConsumersAndGroupCount))
+          .collect(Collectors.toList());
+
+      return Optional.of(
+          new KafkaTopicsListExtended(statement.getStatementText(), topicInfoExtendedList));
+    } else {
+      final List<KafkaTopicInfo> topicInfoList = filteredDescriptions.values()
+          .stream().map(desc -> topicDescriptionToTopicInfo(desc))
+          .collect(Collectors.toList());
+
+      return Optional.of(new KafkaTopicsList(statement.getStatementText(), topicInfoList));
+    }
+  }
+
+  private static KafkaTopicInfo topicDescriptionToTopicInfo(final TopicDescription description) {
+    return new KafkaTopicInfo(
+        description.name(),
+        description.partitions()
+            .stream().map(partition -> partition.replicas().size()).collect(Collectors.toList()));
+  }
+
+  private static KafkaTopicInfoExtended topicDescriptionToTopicInfoExtended(
+      final TopicDescription topicDescription,
+      final Map<String, List<Integer>> topicConsumersAndGroupCount
+  ) {
+
+    final List<Integer> consumerAndGroupCount = topicConsumersAndGroupCount
+        .getOrDefault(topicDescription.name(), Arrays.asList(0, 0));
+
+    return new KafkaTopicInfoExtended(
+        topicDescription.name(),
+        topicDescription.partitions()
+            .stream().map(partition -> partition.replicas().size()).collect(Collectors.toList()),
+        consumerAndGroupCount.get(0),
+        consumerAndGroupCount.get(1));
+  }
+
+  private static Map<String, TopicDescription> filterKsqlInternalTopics(
+      final Map<String, TopicDescription> kafkaTopicDescriptions,
+      final KsqlConfig ksqlConfig
+  ) {
+    final Map<String, TopicDescription> filteredKafkaTopics = new HashMap<>();
+    final String serviceId = KsqlConstants.KSQL_INTERNAL_TOPIC_PREFIX
+        + ksqlConfig.getString(KsqlConfig.KSQL_SERVICE_ID_CONFIG);
+    final String persistentQueryPrefix = ksqlConfig.getString(
+        KsqlConfig.KSQL_PERSISTENT_QUERY_NAME_PREFIX_CONFIG);
+    final String transientQueryPrefix = ksqlConfig.getString(
+        KsqlConfig.KSQL_TRANSIENT_QUERY_NAME_PREFIX_CONFIG);
+
+    for (final Map.Entry<String, TopicDescription> entry : kafkaTopicDescriptions.entrySet()) {
+      if (!entry.getKey().startsWith(serviceId + persistentQueryPrefix)
+          && !entry.getKey().startsWith(serviceId + transientQueryPrefix)) {
+        filteredKafkaTopics.put(entry.getKey().toLowerCase(), entry.getValue());
+      }
+    }
+    return filteredKafkaTopics;
+  }
+
+  /**
+   * @return all topics with their associated consumerCount and consumerGroupCount
+   */
+  private static Map<String, List<Integer>> getTopicConsumerAndGroupCounts(
+      final KafkaConsumerGroupClient consumerGroupClient
+  ) {
+
+    final List<String> consumerGroups = consumerGroupClient.listGroups();
+
+    final Map<String, AtomicInteger> topicConsumerCount = new HashMap<>();
+    final Map<String, Set<String>> topicConsumerGroupCount = new HashMap<>();
+
+    for (final String group : consumerGroups) {
+      final Collection<ConsumerSummary> consumerSummaryList =
+          consumerGroupClient.describeConsumerGroup(group).consumers();
+
+      for (final KafkaConsumerGroupClientImpl.ConsumerSummary summary : consumerSummaryList) {
+
+        for (final TopicPartition topicPartition : summary.partitions()) {
+          topicConsumerCount
+              .computeIfAbsent(topicPartition.topic(), k -> new AtomicInteger())
+              .incrementAndGet();
+          topicConsumerGroupCount
+              .computeIfAbsent(topicPartition.topic(), k -> new HashSet<>()).add(group);
+        }
+      }
+    }
+    final HashMap<String, List<Integer>> results = new HashMap<>();
+    topicConsumerCount.forEach(
+        (k, v) -> {
+          results.computeIfAbsent(k, v1 -> new ArrayList<>()).add(v.intValue());
+          results.get(k).add(topicConsumerGroupCount.get(k).size());
+        }
+    );
+
+    return results;
   }
 }

--- a/ksql-rest-app/src/test/java/io/confluent/ksql/rest/entity/KafkaTopicsListExtendedTest.java
+++ b/ksql-rest-app/src/test/java/io/confluent/ksql/rest/entity/KafkaTopicsListExtendedTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018 Confluent Inc.
+ * Copyright 2019 Confluent Inc.
  *
  * Licensed under the Confluent Community License (the "License"); you may not use
  * this file except in compliance with the License.  You may obtain a copy of the
@@ -21,32 +21,34 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.common.collect.ImmutableList;
 import io.confluent.ksql.json.JsonMapper;
 import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.junit.MockitoJUnitRunner;
 
-public class KafkaTopicsListTest {
+@RunWith(MockitoJUnitRunner.class)
+public class KafkaTopicsListExtendedTest {
 
   @Test
   public void testSerde() throws Exception {
     // Given:
     final ObjectMapper mapper = JsonMapper.INSTANCE.mapper;
-    final KafkaTopicsList expected = new KafkaTopicsList(
-        "SHOW TOPICS;",
-        ImmutableList.of(new KafkaTopicInfo("thetopic", ImmutableList.of(1, 2, 3)))
+    final KafkaTopicsListExtended expected = new KafkaTopicsListExtended(
+        "SHOW TOPICS EXTENDED;",
+        ImmutableList.of(new KafkaTopicInfoExtended("thetopic", ImmutableList.of(1, 2, 3), 42, 12))
     );
 
     // When:
     final String json = mapper.writeValueAsString(expected);
-    final KafkaTopicsList actual = mapper.readValue(json, KafkaTopicsList.class);
+    final KafkaTopicsListExtended actual = mapper.readValue(json, KafkaTopicsListExtended.class);
 
     // Then:
     assertEquals(
         "{"
-            + "\"@type\":\"kafka_topics\","
-            + "\"statementText\":\"SHOW TOPICS;\","
+            + "\"@type\":\"kafka_topics_extended\","
+            + "\"statementText\":\"SHOW TOPICS EXTENDED;\","
             + "\"topics\":["
-            + "{\"name\":\"thetopic\",\"replicaInfo\":[1,2,3]}"
+            + "{\"name\":\"thetopic\",\"replicaInfo\":[1,2,3],\"consumerCount\":42,\"consumerGroupCount\":12}"
             + "],\"warnings\":[]}",
         json);
-
     assertEquals(expected, actual);
   }
 }

--- a/ksql-rest-app/src/test/java/io/confluent/ksql/rest/server/execution/ListTopicsExecutorTest.java
+++ b/ksql-rest-app/src/test/java/io/confluent/ksql/rest/server/execution/ListTopicsExecutorTest.java
@@ -22,7 +22,9 @@ import static org.mockito.Mockito.when;
 
 import com.google.common.collect.ImmutableList;
 import io.confluent.ksql.rest.entity.KafkaTopicInfo;
+import io.confluent.ksql.rest.entity.KafkaTopicInfoExtended;
 import io.confluent.ksql.rest.entity.KafkaTopicsList;
+import io.confluent.ksql.rest.entity.KafkaTopicsListExtended;
 import io.confluent.ksql.rest.server.TemporaryEngine;
 import io.confluent.ksql.services.ServiceContext;
 import io.confluent.ksql.services.TestServiceContext;
@@ -48,12 +50,6 @@ public class ListTopicsExecutorTest {
     engine.givenKafkaTopic("topic2");
 
     final AdminClient mockAdminClient = mock(AdminClient.class);
-    final ListConsumerGroupsResult result = mock(ListConsumerGroupsResult.class);
-    final KafkaFutureImpl<Collection<ConsumerGroupListing>> groups = new KafkaFutureImpl<>();
-
-    when(result.all()).thenReturn(groups);
-    when(mockAdminClient.listConsumerGroups()).thenReturn(result);
-    groups.complete(ImmutableList.of());
 
     final ServiceContext serviceContext = TestServiceContext.create(
         engine.getServiceContext().getKafkaClientSupplier(),
@@ -73,8 +69,45 @@ public class ListTopicsExecutorTest {
 
     // Then:
     assertThat(topicsList.getTopics(), containsInAnyOrder(
-        new KafkaTopicInfo("topic1", ImmutableList.of(1), 0, 0),
-        new KafkaTopicInfo("topic2", ImmutableList.of(1), 0, 0)
+        new KafkaTopicInfo("topic1", ImmutableList.of(1)),
+        new KafkaTopicInfo("topic2", ImmutableList.of(1))
+    ));
+  }
+
+  @Test
+  public void shouldListKafkaTopicsExtended() {
+    // Given:
+    engine.givenKafkaTopic("topic1");
+    engine.givenKafkaTopic("topic2");
+
+    final AdminClient mockAdminClient = mock(AdminClient.class);
+    final ListConsumerGroupsResult result = mock(ListConsumerGroupsResult.class);
+    final KafkaFutureImpl<Collection<ConsumerGroupListing>> groups = new KafkaFutureImpl<>();
+
+    when(result.all()).thenReturn(groups);
+    when(mockAdminClient.listConsumerGroups()).thenReturn(result);
+    groups.complete(ImmutableList.of());
+
+    final ServiceContext serviceContext = TestServiceContext.create(
+        engine.getServiceContext().getKafkaClientSupplier(),
+        mockAdminClient,
+        engine.getServiceContext().getTopicClient(),
+        engine.getServiceContext().getSchemaRegistryClientFactory(),
+        engine.getServiceContext().getConnectClient()
+    );
+
+    // When:
+    final KafkaTopicsListExtended topicsList =
+        (KafkaTopicsListExtended) CustomExecutors.LIST_TOPICS.execute(
+            engine.configure("LIST TOPICS EXTENDED;"),
+            engine.getEngine(),
+            serviceContext
+        ).orElseThrow(IllegalStateException::new);
+
+    // Then:
+    assertThat(topicsList.getTopics(), containsInAnyOrder(
+        new KafkaTopicInfoExtended("topic1", ImmutableList.of(1), 0, 0),
+        new KafkaTopicInfoExtended("topic2", ImmutableList.of(1), 0, 0)
     ));
   }
 


### PR DESCRIPTION
Fixes #1268

BREAKING CHANGE: "SHOW TOPICS" no longer includes the "Consumers" and
"ConsumerGroups" columns. You can use "SHOW TOPICS EXTENDED" to get the
output previous emitted from "SHOW TOPICS". See below for examples.

This change splits "SHOW TOPICS" into two commands:

1. "SHOW TOPICS EXTENDED", which shows what was previously shown by
"SHOW TOPICS". Sample output:

```
    ksql> show topics extended;

     Kafka Topic                                                                                   | Partitions | Partition Replicas | Consumers | ConsumerGroups
    --------------------------------------------------------------------------------------------------------------------------------------------------------------
     _confluent-command                                                                            | 1          | 1                  | 1         | 1
     _confluent-controlcenter-5-3-0-1-actual-group-consumption-rekey                               | 1          | 1                  | 1         | 1
```

2. "SHOW TOPICS", which now no longer queries consumer groups and their
active consumers. Sample output:

```
    ksql> show topics;

     Kafka Topic                                                                                   | Partitions | Partition Replicas
    ---------------------------------------------------------------------------------------------------------------------------------
     _confluent-command                                                                            | 1          | 1
     _confluent-controlcenter-5-3-0-1-actual-group-consumption-rekey                               | 1          | 1
```

This changeset primarily involved renaming KafkaTopicXXX classes to
KafkaTopicXXXExtended and then trimming out the consumer group info from
the original KafkaTopicXXX classes.