### PR TITLE
docs: fix quotes in INSERT VALUES examples

### DIFF
--- a/docs/developer-guide/syntax-reference.rst
+++ b/docs/developer-guide/syntax-reference.rst
@@ -755,18 +755,18 @@ For example, the statements below would all be valid for a source with schema
   .. code:: sql
 
       // inserts (1234, "key", "key", "A")
-      INSERT INTO foo (ROWTIME, ROWKEY, KEY_COL, COL_A) VALUES (1234, "key", "key", "A");
+      INSERT INTO foo (ROWTIME, ROWKEY, KEY_COL, COL_A) VALUES (1234, 'key', 'key', 'A');
 
       // inserts (current_time(), "key", "key", "A")
-      INSERT INTO foo VALUES ("key", "key", "A");
+      INSERT INTO foo VALUES ('key', 'key', 'A');
 
       // inserts (current_time(), "key", "key", "A")
-      INSERT INTO foo (KEY_COL, COL_A) VALUES ("key", "A");
+      INSERT INTO foo (KEY_COL, COL_A) VALUES ('key', 'A');
 
       // inserts (current_time(), "key", "key", null)
-      INSERT INTO foo (KEY_COL) VALUES ("key");
+      INSERT INTO foo (KEY_COL) VALUES ('key');
 
-The values will serialize using the ``value_format`` specified in the original `CREATE` statement.
+The values will serialize using the ``value_format`` specified in the original ``CREATE`` statement.
 The key will always be serialized as a String.
 
 .. _ksql-syntax-describe:


### PR DESCRIPTION
### Description 

The docs for `INSERT VALUES` currently suggest using double-quotes around string literals but this results in a parsing error:
```
ksql> INSERT INTO foo (col1, col2) VALUES ("test", "test2");
line 1:38: mismatched input '"test"' expecting {')', 'NULL', 'TRUE', 'FALSE', STRING, INTEGER_VALUE, DECIMAL_VALUE}
Statement: INSERT INTO foo (col1, col2) VALUES ("test", "test2");
Caused by: line 1:38: mismatched input '"test"' expecting {')', 'NULL', 'TRUE',
	'FALSE', STRING, INTEGER_VALUE, DECIMAL_VALUE}
Caused by: org.antlr.v4.runtime.InputMismatchException
```

Single-quotes is the way to go:
```
ksql> INSERT INTO foo (col1, col2) VALUES ('test', 'test2');
```

This PR updates the docs accordingly.

### Testing done 

None, docs-only change.

### Reviewer checklist
- [ ] Ensure docs are updated if necessary. (eg. if a user visible feature is being added or changed).
- [ ] Ensure relevant issues are linked (description should include text like "Fixes #<issue number>")

