### PR TITLE
fix: incorrect SR authorization message is displayed

### DIFF
--- a/ksql-common/src/main/java/io/confluent/ksql/links/DocumentationLinks.java
+++ b/ksql-common/src/main/java/io/confluent/ksql/links/DocumentationLinks.java
@@ -45,6 +45,9 @@ public final class DocumentationLinks {
   public static final String SR_REST_GETSUBJECTS_DOC_URL = SCHEMA_REGISTRY_API_DOC_URL
       + "#get--subjects";
 
+  public static final String SCHEMA_REGISTRY_SECURITY_DOC_URL = SCHEMA_REGISTRY_DOCS_ROOT_URL
+      + "security.html";
+
   private DocumentationLinks() {
   }
 }

--- a/ksql-engine/src/main/java/io/confluent/ksql/engine/InsertValuesExecutor.java
+++ b/ksql-engine/src/main/java/io/confluent/ksql/engine/InsertValuesExecutor.java
@@ -363,7 +363,7 @@ public class InsertValuesExecutor {
                   topicName + KsqlConstants.SCHEMA_REGISTRY_VALUE_SUFFIX
               ));
             default:
-              throw new KsqlException("Could not serialize row: " + row, e);
+              break;
           }
         }
       }

--- a/ksql-engine/src/main/java/io/confluent/ksql/engine/InsertValuesExecutor.java
+++ b/ksql-engine/src/main/java/io/confluent/ksql/engine/InsertValuesExecutor.java
@@ -17,6 +17,7 @@ package io.confluent.ksql.engine;
 
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.collect.Streams;
+import io.confluent.kafka.schemaregistry.client.rest.exceptions.RestClientException;
 import io.confluent.ksql.GenericRow;
 import io.confluent.ksql.KsqlExecutionContext;
 import io.confluent.ksql.logging.processing.NoopProcessingLogContext;
@@ -33,6 +34,7 @@ import io.confluent.ksql.schema.ksql.LogicalSchema;
 import io.confluent.ksql.schema.ksql.PhysicalSchema;
 import io.confluent.ksql.schema.ksql.SqlValueCoercer;
 import io.confluent.ksql.schema.ksql.types.SqlType;
+import io.confluent.ksql.serde.Format;
 import io.confluent.ksql.serde.GenericKeySerDe;
 import io.confluent.ksql.serde.GenericRowSerDe;
 import io.confluent.ksql.serde.KeySerdeFactory;
@@ -40,6 +42,7 @@ import io.confluent.ksql.serde.ValueSerdeFactory;
 import io.confluent.ksql.services.ServiceContext;
 import io.confluent.ksql.statement.ConfiguredStatement;
 import io.confluent.ksql.util.KsqlConfig;
+import io.confluent.ksql.util.KsqlConstants;
 import io.confluent.ksql.util.KsqlException;
 import io.confluent.ksql.util.SchemaUtil;
 import java.time.Duration;
@@ -52,6 +55,8 @@ import java.util.concurrent.ExecutionException;
 import java.util.concurrent.Future;
 import java.util.function.LongSupplier;
 import java.util.stream.Collectors;
+import org.apache.commons.lang3.exception.ExceptionUtils;
+import org.apache.http.HttpStatus;
 import org.apache.kafka.clients.producer.Producer;
 import org.apache.kafka.clients.producer.ProducerRecord;
 import org.apache.kafka.clients.producer.RecordMetadata;
@@ -142,21 +147,21 @@ public class InsertValuesExecutor {
     final KsqlConfig config = statement.getConfig()
         .cloneWithPropertyOverwrite(statement.getOverrides());
 
-    final RowData row = extractRow(insertValues, dataSource);
-    final byte[] key = serializeKey(row.key, dataSource, config, serviceContext);
-    final byte[] value = serializeValue(row.value, dataSource, config, serviceContext);
-
-    final String topicName = dataSource.getKafkaTopicName();
-
-    final ProducerRecord<byte[], byte[]> record = new ProducerRecord<>(
-        topicName,
-        null,
-        row.ts,
-        key,
-        value
-    );
-
     try {
+      final RowData row = extractRow(insertValues, dataSource);
+      final byte[] key = serializeKey(row.key, dataSource, config, serviceContext);
+      final byte[] value = serializeValue(row.value, dataSource, config, serviceContext);
+
+      final String topicName = dataSource.getKafkaTopicName();
+
+      final ProducerRecord<byte[], byte[]> record = new ProducerRecord<>(
+          topicName,
+          null,
+          row.ts,
+          key,
+          value
+      );
+
       producer.sendRecord(record, serviceContext, config.getProducerClientConfigProps());
     } catch (final Exception e) {
       throw new KsqlException("Failed to insert values into stream/table: "
@@ -342,9 +347,27 @@ public class InsertValuesExecutor {
         NoopProcessingLogContext.INSTANCE
     );
 
+    final String topicName = dataSource.getKafkaTopicName();
+
     try {
-      return valueSerde.serializer().serialize(dataSource.getKafkaTopicName(), row);
+      return valueSerde.serializer().serialize(topicName, row);
     } catch (final Exception e) {
+      if (dataSource.getKsqlTopic().getValueFormat().getFormat() == Format.AVRO) {
+        final Throwable rootCause = ExceptionUtils.getRootCause(e);
+        if (rootCause instanceof RestClientException) {
+          switch (((RestClientException) rootCause).getStatus()) {
+            case HttpStatus.SC_UNAUTHORIZED:
+            case HttpStatus.SC_FORBIDDEN:
+              throw new KsqlException(String.format(
+                  "Not authorized to write Schema Registry subject: [%s]",
+                  topicName + KsqlConstants.SCHEMA_REGISTRY_VALUE_SUFFIX
+              ));
+            default:
+              throw new KsqlException("Could not serialize row: " + row, e);
+          }
+        }
+      }
+
       throw new KsqlException("Could not serialize row: " + row, e);
     }
   }

--- a/ksql-engine/src/main/java/io/confluent/ksql/util/AvroUtil.java
+++ b/ksql-engine/src/main/java/io/confluent/ksql/util/AvroUtil.java
@@ -57,14 +57,18 @@ public final class AvroUtil {
           "Could not check Schema compatibility: %s", e.getMessage()
       ));
     } catch (final RestClientException e) {
-      if (e.getStatus() == HttpStatus.SC_NOT_FOUND) {
-        // Assume the subject is unknown.
-        // See https://github.com/confluentinc/schema-registry/issues/951
-        return true;
+      switch (e.getStatus()) {
+        case HttpStatus.SC_NOT_FOUND:
+        case HttpStatus.SC_UNAUTHORIZED:
+        case HttpStatus.SC_FORBIDDEN:
+          // Assume the subject is unknown.
+          // See https://github.com/confluentinc/schema-registry/issues/951
+          return true;
+        default:
+          throw new KsqlException(String.format(
+              "Could not connect to Schema Registry service: %s", e.getMessage()
+          ));
       }
-      throw new KsqlException(String.format(
-          "Could not connect to Schema Registry service: %s", e.getMessage()
-      ));
     }
   }
 }

--- a/ksql-engine/src/test/java/io/confluent/ksql/engine/InsertValuesExecutorTest.java
+++ b/ksql-engine/src/test/java/io/confluent/ksql/engine/InsertValuesExecutorTest.java
@@ -15,6 +15,8 @@
 
 package io.confluent.ksql.engine;
 
+import static org.hamcrest.Matchers.containsString;
+import static org.junit.internal.matchers.ThrowableMessageMatcher.hasMessage;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.mock;
@@ -485,7 +487,7 @@ public class InsertValuesExecutorTest {
 
     // Expect:
     expectedException.expect(KsqlException.class);
-    expectedException.expectMessage("Could not serialize key");
+    expectedException.expectCause(hasMessage(containsString("Could not serialize key")));
 
     // When:
     executor.execute(statement, engine, serviceContext);
@@ -507,7 +509,7 @@ public class InsertValuesExecutorTest {
 
     // Expect:
     expectedException.expect(KsqlException.class);
-    expectedException.expectMessage("Could not serialize row");
+    expectedException.expectCause(hasMessage(containsString("Could not serialize row")));
 
     // When:
     executor.execute(statement, engine, serviceContext);
@@ -525,7 +527,7 @@ public class InsertValuesExecutorTest {
 
     // Expect:
     expectedException.expect(KsqlException.class);
-    expectedException.expectMessage("Expected ROWKEY and COL0 to match");
+    expectedException.expectCause(hasMessage(containsString("Expected ROWKEY and COL0 to match")));
 
     // When:
     executor.execute(statement, engine, serviceContext);
@@ -542,7 +544,7 @@ public class InsertValuesExecutorTest {
 
     // Expect:
     expectedException.expect(KsqlException.class);
-    expectedException.expectMessage("Expected a value for each column");
+    expectedException.expectCause(hasMessage(containsString("Expected a value for each column")));
 
     // When:
     executor.execute(statement, engine, serviceContext);
@@ -562,7 +564,7 @@ public class InsertValuesExecutorTest {
 
     // Expect:
     expectedException.expect(KsqlException.class);
-    expectedException.expectMessage("Expected type INTEGER for field");
+    expectedException.expectCause(hasMessage(containsString("Expected type INTEGER for field")));
 
     // When:
     executor.execute(statement, engine, serviceContext);

--- a/ksql-functional-tests/src/test/java/io/confluent/ksql/test/tools/KsqlTestingToolTest.java
+++ b/ksql-functional-tests/src/test/java/io/confluent/ksql/test/tools/KsqlTestingToolTest.java
@@ -189,7 +189,7 @@ public class KsqlTestingToolTest {
 
     // Then:
     assertThat(errContent.toString(UTF_8),
-            containsString("Test failed: Expected type INTEGER for field ID but got 14.5\n"));
+            containsString("Test failed: Failed to insert values into stream/table: TEST\n"));
   }
 
   private void runTestCaseAndAssertPassed(


### PR DESCRIPTION
### Description 
Fixes a few error messages caused by SchemaRegistry authorization errors. 
For instance, this error was displayed when attempting to create an AVRO stream without SR schem access:
```
ksql> create stream avro with (kafka_topic='avro', value_format='avro');
Schema registry fetch for topic avro request failed.
Caused by: Unrecognized token 'User': was expecting ('true', 'false' or 'null')

	at [Source: (sun.net.www.protocol.http.HttpURLConnection$HttpInputStream); line:
	1, column: 6]; error code: 50005
```

The new fixed error just adds a new line at the end of an old SR access error. In a secured SR environment, SR returns an authorization error even if the Subject does not exist.

```
ksql> create stream avro with (kafka_topic='avro', value_format='avro');
Avro schema for message values on topic avro does not exist or you do not have permissions in the Schema Registry.Subject: avro-value
Possible causes include:
- The topic itself does not exist	-> Use SHOW TOPICS; to check
- Messages on the topic are not Avro serialized	-> Use PRINT 'avro' FROM BEGINNING; to verify
- Messages on the topic have not been serialized using the Confluent Schema Registry Avro serializer	-> See https://docs.confluent.io/current/schema-registry/docs/serializer-formatter.html
- The schema is registered on a different instance of the Schema Registry	-> Use the REST API to list available subjects	https://docs.confluent.io/current/schema-registry/docs/api.html#get--subjects
- You do not have permissions to access the Schema Registry.Subject: avro-value	-> See https://docs.confluent.io/current/schema-registry/docs/security.html
```

Same error fix when attempting to insert data:
```
ksql> insert into avro(id) values(1);
Failed to insert values into stream/table: AVRO
Caused by: Not authorized to write Schema Registry subject: [avro-value]
```
This is similar to the current authorization error thrown by Kafka:
```
ksql> insert into avro(id) values(1);
Failed to insert values into stream/table: AVRO
Caused by: Not authorized to access topics: [avro]
```

### Testing done 
Manual verification.

### Reviewer checklist
- [ ] Ensure docs are updated if necessary. (eg. if a user visible feature is being added or changed).
- [ ] Ensure relevant issues are linked (description should include text like "Fixes #<issue number>")

