### PR TITLE
docs: describe how aliases are assigned to columns in SELECT clause

### DIFF
--- a/docs/developer-guide/syntax-reference.rst
+++ b/docs/developer-guide/syntax-reference.rst
@@ -1233,7 +1233,7 @@ a column of a FROM_ITEM, then the output name is the name of that column.
         SELECT 1, KSQL_COL_0
           FROM orders;
 
-is not allowed as the output name for the literal ```1``` is ```KSQL_COL_0```.
+is not allowed as the output name for the literal ``1`` is ``KSQL_COL_0``.
 
 CAST
 ~~~~

--- a/docs/developer-guide/syntax-reference.rst
+++ b/docs/developer-guide/syntax-reference.rst
@@ -1221,6 +1221,18 @@ the following WINDOW types:
          WINDOW SESSION (20 SECONDS)
          GROUP BY item_id;
 
+Every output column of an expression in the SELECT list has an output name. To specify the output name of a column, use
+```AS OUTPUT_NAME``` after the expression definition. If it is omitted, KSQL will assign a system generated name
+```KSQL_COL_i``` where ```i``` is the ordinal number of the expression in the SELECT list. If the expression references
+a column of a FROM_ITEM, then the output name is the name of that column.
+
+**Tip:** KSQL will throw an error for duplicate output names. For example,
+    ...code:: sql
+        SELECT 1, KSQL_COL_0
+        FROM orders;
+
+is not allowed as the output name for the literal ```1``` is ```KSQL_COL_0```.
+
 CAST
 ~~~~
 

--- a/docs/developer-guide/syntax-reference.rst
+++ b/docs/developer-guide/syntax-reference.rst
@@ -1224,7 +1224,7 @@ the following WINDOW types:
 Every output column of an expression in the SELECT list has an output name. To specify the output name of a column, use
 ``AS OUTPUT_NAME`` after the expression definition. If it is omitted, KSQL will assign a system generated name
 ``KSQL_COL_i`` where ``i`` is the ordinal number of the expression in the SELECT list. If the expression references
-a column of a FROM_ITEM, then the output name is the name of that column.
+a column of a from_item, then the output name is the name of that column.
 
 **Tip:** KSQL will throw an error for duplicate output names. For example:
 

--- a/docs/developer-guide/syntax-reference.rst
+++ b/docs/developer-guide/syntax-reference.rst
@@ -1222,14 +1222,16 @@ the following WINDOW types:
          GROUP BY item_id;
 
 Every output column of an expression in the SELECT list has an output name. To specify the output name of a column, use
-```AS OUTPUT_NAME``` after the expression definition. If it is omitted, KSQL will assign a system generated name
-```KSQL_COL_i``` where ```i``` is the ordinal number of the expression in the SELECT list. If the expression references
+``AS OUTPUT_NAME`` after the expression definition. If it is omitted, KSQL will assign a system generated name
+``KSQL_COL_i`` where ``i`` is the ordinal number of the expression in the SELECT list. If the expression references
 a column of a FROM_ITEM, then the output name is the name of that column.
 
-**Tip:** KSQL will throw an error for duplicate output names. For example,
-    ...code:: sql
+**Tip:** KSQL will throw an error for duplicate output names. For example:
+
+   .. code:: sql
+
         SELECT 1, KSQL_COL_0
-        FROM orders;
+          FROM orders;
 
 is not allowed as the output name for the literal ```1``` is ```KSQL_COL_0```.
 


### PR DESCRIPTION
### Description 
I added a paragraph in the docs about how alias are assigned to columns in the SELECT clause.
This is in regard to issue #2401 .

### Testing done 
No testing, changes are only on docs.

### Reviewer checklist
- [ ] Ensure docs are updated if necessary. (eg. if a user visible feature is being added or changed).
- [ ] Ensure relevant issues are linked (description should include text like "Fixes #<issue number>")

