### PR TITLE
refactor: improved error message for CREATE, DESCRIBE, and DELETE when no ACLs set for topic

### DIFF
--- a/ksql-cli/src/main/java/io/confluent/ksql/cli/console/Console.java
+++ b/ksql-cli/src/main/java/io/confluent/ksql/cli/console/Console.java
@@ -484,13 +484,21 @@ public class Console implements Closeable {
     writer().println(String.format("%-20s : %s", "Value format", source.getFormat()));
 
     if (!source.getTopic().isEmpty()) {
-      writer().println(String.format(
-          "%-20s : %s (partitions: %d, replication: %d)",
+      String topicInformation = String.format("%-20s : %s",
           "Kafka topic",
-          source.getTopic(),
-          source.getPartitions(),
-          source.getReplication()
-      ));
+          source.getTopic()
+      );
+
+      // If Describe ACLs permissions aren't given for a topic, partitions and replica default to 0
+      // Details aren't printed out if the Describe fails.
+      if (source.getPartitions() != 0) {
+        topicInformation = topicInformation.concat(String.format(
+            " (partitions: %d, replication: %d)",
+            source.getPartitions(),
+            source.getReplication()
+        ));
+      }
+      writer().println(topicInformation);
     }
   }
 

--- a/ksql-common/src/main/java/io/confluent/ksql/util/KsqlAuthorizationException.java
+++ b/ksql-common/src/main/java/io/confluent/ksql/util/KsqlAuthorizationException.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright 2019 Confluent Inc.
+ *
+ * Licensed under the Confluent Community License (the "License"); you may not use
+ * this file except in compliance with the License.  You may obtain a copy of the
+ * License at
+ *
+ * http://www.confluent.io/confluent-community-license
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package io.confluent.ksql.util;
+
+import java.util.Collection;
+
+import org.apache.commons.lang3.StringUtils;
+import org.apache.kafka.common.acl.AclOperation;
+
+public class KsqlAuthorizationException extends RuntimeException {
+
+  public KsqlAuthorizationException(
+      final AclOperation operation,
+      final Collection<String> topicNames) {
+    super(String.format("Authorization denied to %s on topic(s): [%s]",
+        StringUtils.capitalize(
+            operation.toString().toLowerCase()),
+            StringUtils.join(topicNames, ", "))
+    );
+  }
+}

--- a/ksql-engine/src/main/java/io/confluent/ksql/engine/AuthorizationTopicAccessValidator.java
+++ b/ksql-engine/src/main/java/io/confluent/ksql/engine/AuthorizationTopicAccessValidator.java
@@ -23,9 +23,11 @@ import io.confluent.ksql.parser.tree.Query;
 import io.confluent.ksql.parser.tree.Statement;
 import io.confluent.ksql.services.ServiceContext;
 import io.confluent.ksql.topic.SourceTopicsExtractor;
+import io.confluent.ksql.util.KsqlAuthorizationException;
 import io.confluent.ksql.util.KsqlException;
+
+import java.util.Collections;
 import java.util.Set;
-import org.apache.commons.lang3.StringUtils;
 import org.apache.kafka.common.acl.AclOperation;
 
 /**
@@ -126,11 +128,7 @@ public class AuthorizationTopicAccessValidator implements TopicAccessValidator {
     if (authorizedOperations != null && !authorizedOperations.contains(operation)) {
       // This error message is similar to what Kafka throws when it cannot access the topic
       // due to an authorization error. I used this message to keep a consistent message.
-      throw new KsqlException(String.format(
-              "Failed to %s Kafka topic: [%s]%n"
-                  + "Caused by: Not authorized to access topic: [%s]",
-              StringUtils.capitalize(operation.toString().toLowerCase()), topicName, topicName)
-      );
+      throw new KsqlAuthorizationException(operation, Collections.singleton(topicName));
     }
   }
 

--- a/ksql-engine/src/test/java/io/confluent/ksql/engine/AuthorizationTopicAccessValidatorTest.java
+++ b/ksql-engine/src/test/java/io/confluent/ksql/engine/AuthorizationTopicAccessValidatorTest.java
@@ -33,6 +33,7 @@ import io.confluent.ksql.serde.SerdeOption;
 import io.confluent.ksql.serde.ValueFormat;
 import io.confluent.ksql.services.KafkaTopicClient;
 import io.confluent.ksql.services.ServiceContext;
+import io.confluent.ksql.util.KsqlAuthorizationException;
 import io.confluent.ksql.util.KsqlException;
 import io.confluent.ksql.util.timestamp.MetadataTimestampExtractionPolicy;
 import java.util.Collections;
@@ -136,9 +137,9 @@ public class AuthorizationTopicAccessValidatorTest {
     );
 
     // Then:
-    expectedException.expect(KsqlException.class);
+    expectedException.expect(KsqlAuthorizationException.class);
     expectedException.expectMessage(String.format(
-        "Failed to Read Kafka topic: [%s]", TOPIC_1.name()
+        "Authorization denied to Read on topic(s): [%s]", TOPIC_1.name()
     ));
 
     // When:
@@ -171,9 +172,9 @@ public class AuthorizationTopicAccessValidatorTest {
     );
 
     // Then:
-    expectedException.expect(KsqlException.class);
+    expectedException.expect(KsqlAuthorizationException.class);
     expectedException.expectMessage(String.format(
-        "Failed to Read Kafka topic: [%s]", TOPIC_1.name()
+        "Authorization denied to Read on topic(s): [%s]", TOPIC_1.name()
     ));
 
     // When:
@@ -190,9 +191,9 @@ public class AuthorizationTopicAccessValidatorTest {
     );
 
     // Then:
-    expectedException.expect(KsqlException.class);
+    expectedException.expect(KsqlAuthorizationException.class);
     expectedException.expectMessage(String.format(
-        "Failed to Read Kafka topic: [%s]", TOPIC_2.name()
+        "Authorization denied to Read on topic(s): [%s]", TOPIC_2.name()
     ));
 
     // When:
@@ -209,9 +210,9 @@ public class AuthorizationTopicAccessValidatorTest {
     );
 
     // Then:
-    expectedException.expect(KsqlException.class);
+    expectedException.expect(KsqlAuthorizationException.class);
     expectedException.expectMessage(String.format(
-        "Failed to Read Kafka topic: [%s]", TOPIC_1.name()
+        "Authorization denied to Read on topic(s): [%s]", TOPIC_1.name()
     ));
 
     // When:
@@ -244,9 +245,9 @@ public class AuthorizationTopicAccessValidatorTest {
     );
 
     // Then:
-    expectedException.expect(KsqlException.class);
+    expectedException.expect(KsqlAuthorizationException.class);
     expectedException.expectMessage(String.format(
-        "Failed to Write Kafka topic: [%s]", TOPIC_2.name()
+        "Authorization denied to Write on topic(s): [%s]", TOPIC_2.name()
     ));
 
     // When:
@@ -263,9 +264,9 @@ public class AuthorizationTopicAccessValidatorTest {
     );
 
     // Then:
-    expectedException.expect(KsqlException.class);
+    expectedException.expect(KsqlAuthorizationException.class);
     expectedException.expectMessage(String.format(
-        "Failed to Read Kafka topic: [%s]", TOPIC_1.name()
+        "Authorization denied to Read on topic(s): [%s]", TOPIC_1.name()
     ));
 
     // When:
@@ -281,9 +282,9 @@ public class AuthorizationTopicAccessValidatorTest {
     );
 
     // Then:
-    expectedException.expect(KsqlException.class);
+    expectedException.expect(KsqlAuthorizationException.class);
     expectedException.expectMessage(String.format(
-        "Failed to Read Kafka topic: [%s]", TOPIC_1.name()
+        "Authorization denied to Read on topic(s): [%s]", TOPIC_1.name()
     ));
 
     // When:
@@ -316,9 +317,9 @@ public class AuthorizationTopicAccessValidatorTest {
     );
 
     // Then:
-    expectedException.expect(KsqlException.class);
+    expectedException.expect(KsqlAuthorizationException.class);
     expectedException.expectMessage(String.format(
-        "Failed to Write Kafka topic: [%s]", TOPIC_2.name()
+        "Authorization denied to Write on topic(s): [%s]", TOPIC_2.name()
     ));
 
 


### PR DESCRIPTION
### Description 
KSQL-1444
KSQL-2891
Updated the createTopic and deleteTopic error handlers to catch TopicAuthorizationException which is returned when ACLs aren't set.
Created a util for generating ACL error messages 

```CREATE STREAM ASDFASDF(age BIGINT) WITH (KAFKA_TOPIC='new_topic', PARTITIONS=1, VALUE_FORMAT='DELIMITED');```

(Old error message):
```
Failed to guarantee existence of topic new_topic Caused by: Not authorized to access topics: [Authorization failed.]
```

(New error message): 
```
Authorization denied to Create on topic(s): [new_topic]
```
__________________________________________________________
```DROP STREAM SOURCE_TOPIC DELETE TOPIC;```

(Old error message): 
```
Could not delete the corresponding kafka topic: test_topic Caused by: Failed to clean up topics: test_topic
```

(New error message): 
```
Could not delete the corresponding kafka topic: SOURCE_TOPIC
Caused by: Authorization denied to Delete on topic(s): [test_topic]
```
___________________________
```
DESCRIBE EXTENDED TEST_SOURCE;
```
(Old error message): 
```
ksql> describe extended test;

Name                 : TEST
Type                 : TABLE
Key field            : 
Key format           : STRING
Timestamp field      : Not set - using <ROWTIME>
Value format         : JSON
Kafka topic          : test_topic (partitions: 0, replication: 0)

 Field   | Type                      
-------------------------------------
 ROWTIME | BIGINT           (system) 
 ROWKEY  | VARCHAR(STRING)  (system) 
 AGE     | BIGINT                    
-------------------------------------

Local runtime statistics
------------------------


(Statistics of the local KSQL server interaction with the Kafka topic test_topic)
WARNING: Error from Kafka: Failed to Describe Kafka topic(s): test_topic
```
(New error message): 
```
ksql> describe extended test;

Name                 : TEST
Type                 : TABLE
Key field            : 
Key format           : STRING
Timestamp field      : Not set - using <ROWTIME>
Value format         : JSON
Kafka topic          : test_topic 

 Field   | Type                      
-------------------------------------
 ROWTIME | BIGINT           (system) 
 ROWKEY  | VARCHAR(STRING)  (system) 
 AGE     | BIGINT                    
-------------------------------------

Local runtime statistics
------------------------


(Statistics of the local KSQL server interaction with the Kafka topic test_topic)
WARNING: Authorization denied to Describe on topic(s): [test_topic]
```
### Testing done 
Unit tests
Tested in local ksql-server with a Kafka cluster with ACLs set

### Reviewer checklist
- [ ] Ensure docs are updated if necessary. (eg. if a user visible feature is being added or changed).
- [ ] Ensure relevant issues are linked (description should include text like "Fixes #<issue number>")

