### PR TITLE
fix: validate CLI using REST / instead of REST /info

### DIFF
--- a/ksql-cli/src/test/java/io/confluent/ksql/cli/CliTest.java
+++ b/ksql-cli/src/test/java/io/confluent/ksql/cli/CliTest.java
@@ -58,6 +58,7 @@ import io.confluent.ksql.rest.server.KsqlRestConfig;
 import io.confluent.ksql.rest.server.TestKsqlRestApp;
 import io.confluent.ksql.rest.server.computation.CommandId;
 import io.confluent.ksql.rest.server.resources.Errors;
+import io.confluent.ksql.rest.server.resources.RootDocument;
 import io.confluent.ksql.schema.ksql.KsqlSchema;
 import io.confluent.ksql.test.util.EmbeddedSingleNodeKafkaCluster;
 import io.confluent.ksql.test.util.KsqlIdentifierTestUtil;
@@ -985,7 +986,7 @@ public class CliTest {
     givenCommandSequenceNumber(mockRestClient, 5L);
     givenRequestPipelining("ON");
     when(mockRestClient.makeRootRequest()).thenReturn(
-        RestResponse.successful(new ServerInfo("version", "clusterId", "serviceId")));
+        RestResponse.successful(new RootDocument()));
 
     // When:
     runCliSpecificCommand("server foo");

--- a/ksql-cli/src/test/java/io/confluent/ksql/cli/console/cmd/RemoteServerSpecificCommandTest.java
+++ b/ksql-cli/src/test/java/io/confluent/ksql/cli/console/cmd/RemoteServerSpecificCommandTest.java
@@ -30,6 +30,7 @@ import io.confluent.ksql.rest.client.RestResponse;
 import io.confluent.ksql.rest.client.exception.KsqlRestClientException;
 import io.confluent.ksql.rest.entity.ServerInfo;
 import io.confluent.ksql.rest.server.resources.Errors;
+import io.confluent.ksql.rest.server.resources.RootDocument;
 import io.confluent.ksql.util.Event;
 import java.io.PrintWriter;
 import java.io.StringWriter;
@@ -47,8 +48,7 @@ public class RemoteServerSpecificCommandTest {
 
   private static final String INITIAL_SERVER_ADDRESS = "http://192.168.0.1:8080";
   private static final String VALID_SERVER_ADDRESS = "http://localhost:8088";
-  private static final ServerInfo SERVER_INFO =
-      new ServerInfo("1.x", "myClusterId", "myKsqlServiceId");
+  private static final RootDocument ROOT_DOCUMENT = new RootDocument();
 
   @Mock
   private KsqlRestClient restClient;
@@ -65,7 +65,7 @@ public class RemoteServerSpecificCommandTest {
     terminal = new PrintWriter(out);
     command = RemoteServerSpecificCommand.create(restClient, resetCliForNewServer);
 
-    when(restClient.makeRootRequest()).thenReturn(RestResponse.successful(SERVER_INFO));
+    when(restClient.makeRootRequest()).thenReturn(RestResponse.successful(ROOT_DOCUMENT));
     when(restClient.getServerAddress()).thenReturn(new URI(INITIAL_SERVER_ADDRESS));
   }
 

--- a/ksql-rest-app/src/main/java/io/confluent/ksql/rest/client/KsqlRestClient.java
+++ b/ksql-rest-app/src/main/java/io/confluent/ksql/rest/client/KsqlRestClient.java
@@ -30,6 +30,7 @@ import io.confluent.ksql.rest.entity.KsqlRequest;
 import io.confluent.ksql.rest.entity.ServerInfo;
 import io.confluent.ksql.rest.entity.StreamedRow;
 import io.confluent.ksql.rest.server.resources.Errors;
+import io.confluent.ksql.rest.server.resources.RootDocument;
 import io.confluent.ksql.rest.ssl.DefaultSslClientConfigurer;
 import io.confluent.ksql.rest.ssl.SslClientConfigurer;
 import io.confluent.rest.validation.JacksonMessageBodyProvider;
@@ -154,8 +155,8 @@ public class KsqlRestClient implements Closeable {
     this.serverAddresses = parseServerAddresses(serverAddress);
   }
 
-  public RestResponse<ServerInfo> makeRootRequest() {
-    return getServerInfo();
+  public RestResponse<RootDocument> makeRootRequest() {
+    return getRequest("/", RootDocument.class);
   }
 
   public RestResponse<ServerInfo> getServerInfo() {


### PR DESCRIPTION
BREAKING CHANGE: Previously CLI startup permissions were based on whether the user has access to `/info`, but now it's based on whether the user has access to `/`. This change implies that if a user has permissions to `/` but not `/info`, they now have access to the CLI whereas previously they did not.

### Description
The CLI currently makes a call to `GET /info` to validate if a client can connect to the KSQL server. If the server is not authorized to access the endpoint, then the CLI displays the correct access error (or any other access) on the console.

With the introduction of the KSQL security extensions, these REST endpoints might have different access restrictions. For instance, the `GET /info` call might be opened to any authenticated user to get information about the KSQL server (such as KSQL and Kafka clusters IDs) and send the info to the KSQL admins to request access this KSQL server. Because of this, then the CLI will never show if a user is authorized to access the server during the CLI initialization.

To improve this CLI message, we should validate the client using the `GET /` endpoint instead. This endpoint is not used and looks like a dummy endpoint. 

### Testing done 
- Modified the current unit tests to use the new endpoint
- Verified the CLI messages manually:
```
 ./bin/ksql --user u1 --password u1 http://localhost:8088                 
...

CLI v5.4.0-SNAPSHOT, Server v5.4.0-SNAPSHOT located at http://localhost:8088

Having trouble? Type 'help' (case-insensitive) for a rundown of how things work!

Couldn't connect to the KSQL server: Access denied: Contribute permissions required to access "GET /"

ksql>
```

### Reviewer checklist
- [ ] Ensure docs are updated if necessary. (eg. if a user visible feature is being added or changed).
- [ ] Ensure relevant issues are linked (description should include text like "Fixes #<issue number>")

