### PR TITLE
fix: create persistent queries fail with reserved words

### DIFF
--- a/ksql-execution/src/main/java/io/confluent/ksql/execution/expression/formatter/ExpressionFormatter.java
+++ b/ksql-execution/src/main/java/io/confluent/ksql/execution/expression/formatter/ExpressionFormatter.java
@@ -153,9 +153,14 @@ public final class ExpressionFormatter {
         final Context context) {
       final String baseString = process(node.getBase(), context);
       if (node.getBase() instanceof QualifiedNameReference) {
-        return baseString + KsqlConstants.DOT + formatIdentifier(node.getFieldName());
+        return baseString + KsqlConstants.DOT
+            + quoteReservedWord(formatIdentifier(node.getFieldName()), context);
       }
       return baseString + KsqlConstants.STRUCT_FIELD_REF + formatIdentifier(node.getFieldName());
+    }
+
+    private String quoteReservedWord(final String s, final Context context) {
+      return context.isReserved.test(s) ? "`" + s + "`" : s;
     }
 
     private static String formatQualifiedName(final QualifiedName name) {

--- a/ksql-parser/src/test/java/io/confluent/ksql/parser/SqlFormatterTest.java
+++ b/ksql-parser/src/test/java/io/confluent/ksql/parser/SqlFormatterTest.java
@@ -113,6 +113,7 @@ public class SqlFormatterTest {
       .valueField("ARRAYCOL", SqlTypes.array(SqlTypes.DOUBLE))
       .valueField("MAPCOL", SqlTypes.map(SqlTypes.DOUBLE))
       .valueField("ADDRESS", addressSchema)
+      .valueField("SIZE", SqlTypes.INTEGER) // Reserved word
       .build();
 
   private static final CreateSourceProperties SOME_WITH_PROPS = CreateSourceProperties.from(
@@ -356,6 +357,15 @@ public class SqlFormatterTest {
     assertThat(SqlFormatter.formatSql(statement),
         equalTo("CREATE STREAM S AS SELECT *\n"
             + "FROM ADDRESS ADDRESS"));
+  }
+
+  @Test
+  public void shouldFormatCSASWithReservedWords() {
+    final String statementString = "CREATE STREAM S AS SELECT ITEMID, \"SIZE\" FROM address;";
+    final Statement statement = parseSingle(statementString);
+    assertThat(SqlFormatter.formatSql(statement),
+        equalTo("CREATE STREAM S AS SELECT\n" +
+            "  ADDRESS.ITEMID \"ITEMID\",\n  ADDRESS.`SIZE` \"SIZE\"\nFROM ADDRESS ADDRESS"));
   }
 
   @Test


### PR DESCRIPTION
### Description 
Fixes https://github.com/confluentinc/ksql/issues/3202

This PR adds quotes around the column identifier that uses reserved words when the identifier is brought from another stream using a CSAS/CSAT. 

### Testing done 
- Add a unit test in the `SqlFormatterTest` to validate the new CSAS columns come with quotes.
- Verify it manually
```
ksql> CREATE STREAM TEST (START STRING, `END` STRING) WITH (KAFKA_TOPIC='test_topic', value_format='JSON');

ksql> CREATE STREAM S1 AS SELECT `START`, `END` FROM TEST;

 Message                                                               
-----------------------------------------------------------------------
 Stream created and running. Created by query with query ID: CSAS_S1_5 
-----------------------------------------------------------------------

ksql> select * from s1;
+---------------------------------------------+---------------------------------------------+---------------------------------------------+---------------------------------------------+
|ROWTIME                                      |ROWKEY                                       |START                                        |END                                          |
+---------------------------------------------+---------------------------------------------+---------------------------------------------+---------------------------------------------+
|1565799422152                                |null                                         |2019-04-08T15:50.10                          |2019-04-08T15:50.31                          |
```

### Reviewer checklist
- [ ] Ensure docs are updated if necessary. (eg. if a user visible feature is being added or changed).
- [ ] Ensure relevant issues are linked (description should include text like "Fixes #<issue number>")

