### PR TITLE
fix: the QTTs now run through SqlFormatter & various other formatting fixes

### DIFF
--- a/ksql-engine/src/test/java/io/confluent/ksql/engine/SqlFormatInjector.java
+++ b/ksql-engine/src/test/java/io/confluent/ksql/engine/SqlFormatInjector.java
@@ -21,6 +21,7 @@ import io.confluent.ksql.parser.SqlFormatter;
 import io.confluent.ksql.parser.tree.Statement;
 import io.confluent.ksql.statement.ConfiguredStatement;
 import io.confluent.ksql.statement.Injector;
+import io.confluent.ksql.util.KsqlException;
 import java.util.Objects;
 
 public class SqlFormatInjector implements Injector {
@@ -45,7 +46,8 @@ public class SqlFormatInjector implements Injector {
 
       return statement.withStatement(sql, (T) prepare.getStatement());
     } catch (final Exception e) {
-      return statement;
+      throw new KsqlException("Unable to format statement! This is bad because "
+          + "it means we cannot persist it onto the command topic: " + statement, e);
     }
   }
 }

--- a/ksql-execution/src/main/java/io/confluent/ksql/execution/expression/formatter/ExpressionFormatter.java
+++ b/ksql-execution/src/main/java/io/confluent/ksql/execution/expression/formatter/ExpressionFormatter.java
@@ -144,7 +144,7 @@ public final class ExpressionFormatter {
     @Override
     public String visitQualifiedNameReference(final QualifiedNameReference node,
         final Context context) {
-      return formatQualifiedName(node.getName());
+      return formatQualifiedName(node.getName(), context);
     }
 
     @Override
@@ -153,15 +153,16 @@ public final class ExpressionFormatter {
         final Context context) {
       final String baseString = process(node.getBase(), context);
       if (node.getBase() instanceof QualifiedNameReference) {
-        return baseString + KsqlConstants.DOT + formatIdentifier(node.getFieldName());
+        return baseString + KsqlConstants.DOT + formatIdentifier(node.getFieldName(), context);
       }
-      return baseString + KsqlConstants.STRUCT_FIELD_REF + formatIdentifier(node.getFieldName());
+      return baseString + KsqlConstants.STRUCT_FIELD_REF
+          + formatIdentifier(node.getFieldName(), context);
     }
 
-    private static String formatQualifiedName(final QualifiedName name) {
+    private static String formatQualifiedName(final QualifiedName name, final Context context) {
       final List<String> parts = new ArrayList<>();
       for (final String part : name.getParts()) {
-        parts.add(formatIdentifier(part));
+        parts.add(formatIdentifier(part, context));
       }
       return Joiner.on(KsqlConstants.DOT).join(parts);
     }
@@ -175,7 +176,7 @@ public final class ExpressionFormatter {
         arguments = "*";
       }
 
-      builder.append(formatQualifiedName(node.getName()))
+      builder.append(formatQualifiedName(node.getName(), context))
           .append('(').append(arguments).append(')');
 
       return builder.toString();
@@ -337,9 +338,8 @@ public final class ExpressionFormatter {
           .iterator());
     }
 
-    private static String formatIdentifier(final String s) {
-      // TODO: handle escaping properly
-      return s;
+    private static String formatIdentifier(final String s, final Context context) {
+      return context.isReserved.test(s) ? "`" + s + "`" : s;
     }
 
     private static String formatStringLiteral(final String s) {

--- a/ksql-functional-tests/src/test/resources/query-validation-tests/ensure-formatter.json
+++ b/ksql-functional-tests/src/test/resources/query-validation-tests/ensure-formatter.json
@@ -1,0 +1,29 @@
+{
+  "comments": [
+    "Query Translation tests should make sure that the command that is being executed can be ",
+    "persisted properly onto the command topic (i.e. serialized using SqlFormatter). Otherwise, ",
+    "it is possible that we may not execute the same statement after enqueuing as we did before. ",
+    "This test will fail if we refactor QueryTranslationTest in a way that makes it no longer go ",
+    "through the SqlFormatInjector, which serializes and then deserializes the statements to make ",
+    "sure that these inconsistencies are caught.",
+    "",
+    "NOTE: This test is a little hacky at the moment because it relies on us not formatting SET ",
+    "expressions. There is nothing preventing us in the future from doing this, but I don't have ",
+    "a better way as of now to ensure failure."
+  ],
+  "tests": [
+    {
+      "name": "ensure QTTs go through SqlFormatter",
+      "statements": [
+        "CREATE STREAM IGNORED (ID bigint) WITH (kafka_topic='topic', value_format='DELIMITED');",
+        "SET 'auto.offset.reset'='earliest';"
+      ],
+      "inputs": [ ],
+      "outputs": [ ],
+      "expectedException": {
+        "type": "io.confluent.ksql.util.KsqlException",
+        "message": "Unable to format statement!"
+      }
+    }
+  ]
+}

--- a/ksql-parser/src/main/java/io/confluent/ksql/parser/tree/AstVisitor.java
+++ b/ksql-parser/src/main/java/io/confluent/ksql/parser/tree/AstVisitor.java
@@ -155,4 +155,15 @@ public abstract class AstVisitor<R, C> {
     return visitGroupingElement(node, context);
   }
 
+  protected R visitTerminateQuery(final TerminateQuery node, final C context) {
+    return visitStatement(node, context);
+  }
+
+  protected R visitListStreams(final ListStreams node, final C context) {
+    return visitStatement(node, context);
+  }
+
+  protected R visitListTables(final ListTables node, final C context) {
+    return visitStatement(node, context);
+  }
 }

--- a/ksql-parser/src/main/java/io/confluent/ksql/parser/tree/ListStreams.java
+++ b/ksql-parser/src/main/java/io/confluent/ksql/parser/tree/ListStreams.java
@@ -37,6 +37,11 @@ public class ListStreams extends Statement {
   }
 
   @Override
+  public <R, C> R accept(final AstVisitor<R, C> visitor, final C context) {
+    return visitor.visitListStreams(this, context);
+  }
+
+  @Override
   public boolean equals(final Object o) {
     if (this == o) {
       return true;

--- a/ksql-parser/src/main/java/io/confluent/ksql/parser/tree/ListTables.java
+++ b/ksql-parser/src/main/java/io/confluent/ksql/parser/tree/ListTables.java
@@ -37,6 +37,11 @@ public class ListTables extends Statement {
   }
 
   @Override
+  public <R, C> R accept(final AstVisitor<R, C> visitor, final C context) {
+    return visitor.visitListTables(this, context);
+  }
+
+  @Override
   public boolean equals(final Object o) {
     if (this == o) {
       return true;

--- a/ksql-parser/src/main/java/io/confluent/ksql/parser/tree/TerminateQuery.java
+++ b/ksql-parser/src/main/java/io/confluent/ksql/parser/tree/TerminateQuery.java
@@ -40,6 +40,11 @@ public class TerminateQuery extends Statement {
   }
 
   @Override
+  public <R, C> R accept(final AstVisitor<R, C> visitor, final C context) {
+    return visitor.visitTerminateQuery(this, context);
+  }
+
+  @Override
   public boolean equals(final Object o) {
     if (this == o) {
       return true;


### PR DESCRIPTION
Co-authored-by: Sergio Peña <sergio@confluent.io>

### Description 
This reinstates #3037 into the current code path for the new testing tool. It also fixes some issues:
- `SqlFormatInjector` was allowing statements that cannot be parsed to go through in order to appease some tests. This is no longer the case
- `SqlFormatter` adds some formatting for statements that don't need it, but go through the testing path
- #3216 is applied (thanks @spena co-authored)
- `SqlFormatter` now properly escapes identifiers nested in structs
- `ensure-formatter.json` was added to make sure that a future refactor does not skip this code path

### Testing done 
- unit testing
- `ensure-formatter.json`

### Reviewer checklist
- [ ] Ensure docs are updated if necessary. (eg. if a user visible feature is being added or changed).
- [ ] Ensure relevant issues are linked (description should include text like "Fixes #<issue number>")

