### PR TITLE
feat: perform topic permission checks for KSQL service principal

### DIFF
--- a/ksql-engine/src/test/java/io/confluent/ksql/engine/AuthorizationTopicAccessValidatorTest.java
+++ b/ksql-engine/src/test/java/io/confluent/ksql/engine/AuthorizationTopicAccessValidatorTest.java
@@ -307,26 +307,6 @@ public class AuthorizationTopicAccessValidatorTest {
   }
 
   @Test
-  public void shouldCreateAsSelectExistingStreamWithoutWritePermissionsDenied() {
-    // Given:
-    givenTopicPermissions(TOPIC_1, Collections.singleton(AclOperation.READ));
-    givenTopicPermissions(TOPIC_2, Collections.singleton(AclOperation.READ));
-    final Statement statement = givenStatement(String.format(
-        "CREATE STREAM %s AS SELECT * FROM %s;", STREAM_TOPIC_2, STREAM_TOPIC_1)
-    );
-
-    // Then:
-    expectedException.expect(KsqlTopicAuthorizationException.class);
-    expectedException.expectMessage(String.format(
-        "Authorization denied to Write on topic(s): [%s]", TOPIC_2.name()
-    ));
-
-
-    // When:
-    accessValidator.validate(serviceContext, metaStore, statement);
-  }
-
-  @Test
   public void shouldCreateAsSelectWithTopicAndWritePermissionsAllowed() {
     // Given:
     givenTopicPermissions(TOPIC_1, Collections.singleton(AclOperation.READ));

--- a/ksql-engine/src/test/java/io/confluent/ksql/engine/InsertValuesExecutorTest.java
+++ b/ksql-engine/src/test/java/io/confluent/ksql/engine/InsertValuesExecutorTest.java
@@ -19,6 +19,7 @@ import static org.hamcrest.Matchers.containsString;
 import static org.junit.internal.matchers.ThrowableMessageMatcher.hasMessage;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
@@ -63,6 +64,7 @@ import io.confluent.ksql.util.timestamp.MetadataTimestampExtractionPolicy;
 import java.math.BigDecimal;
 import java.math.MathContext;
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
 import java.util.Set;
@@ -74,6 +76,7 @@ import java.util.stream.Collectors;
 import org.apache.kafka.clients.producer.KafkaProducer;
 import org.apache.kafka.clients.producer.ProducerRecord;
 import org.apache.kafka.common.errors.SerializationException;
+import org.apache.kafka.common.errors.TopicAuthorizationException;
 import org.apache.kafka.common.serialization.Serde;
 import org.apache.kafka.common.serialization.Serializer;
 import org.apache.kafka.connect.data.Schema;
@@ -510,6 +513,30 @@ public class InsertValuesExecutorTest {
     // Expect:
     expectedException.expect(KsqlException.class);
     expectedException.expectCause(hasMessage(containsString("Could not serialize row")));
+
+    // When:
+    executor.execute(statement, engine, serviceContext);
+  }
+
+  @Test
+  public void shouldThrowOnTopicAuthorizationException() {
+    // Given:
+    final ConfiguredStatement<InsertValues> statement = givenInsertValues(
+        allFieldNames(SCHEMA),
+        ImmutableList.of(
+            new LongLiteral(1L),
+            new StringLiteral("str"),
+            new StringLiteral("str"),
+            new LongLiteral(2L))
+    );
+    doThrow(new TopicAuthorizationException(Collections.singleton("t1")))
+        .when(producer).send(any());
+
+    // Expect:
+    expectedException.expect(KsqlException.class);
+    expectedException.expectCause(hasMessage(
+        containsString("Authorization denied to Write on topic(s): [t1]"))
+    );
 
     // When:
     executor.execute(statement, engine, serviceContext);

--- a/ksql-rest-app/src/main/java/io/confluent/ksql/rest/server/resources/KsqlResource.java
+++ b/ksql-rest-app/src/main/java/io/confluent/ksql/rest/server/resources/KsqlResource.java
@@ -113,7 +113,8 @@ public class KsqlResource {
         injectorFactory,
         ksqlEngine::createSandbox,
         ksqlConfig,
-        topicAccessValidator);
+        topicAccessValidator,
+        SandboxedServiceContext.create(ksqlEngine.getServiceContext()));
     this.handler = new RequestHandler(
         CustomExecutors.EXECUTOR_MAP,
         new DistributingExecutor(

--- a/ksql-rest-app/src/test/java/io/confluent/ksql/rest/server/resources/KsqlResourceTest.java
+++ b/ksql-rest-app/src/test/java/io/confluent/ksql/rest/server/resources/KsqlResourceTest.java
@@ -1725,6 +1725,7 @@ public class KsqlResourceTest {
         .thenAnswer(invocation -> realEngine.createSandbox(serviceContext).prepare(invocation.getArgument(0)));
     when(ksqlEngine.createSandbox(any())).thenReturn(sandbox);
     when(ksqlEngine.getMetaStore()).thenReturn(metaStore);
+    when(ksqlEngine.getServiceContext()).thenReturn(serviceContext);
     when(topicInjectorFactory.apply(ksqlEngine)).thenReturn(topicInjector);
     setUpKsqlResource();
   }


### PR DESCRIPTION
### Description 
KSQL performs topic permission checks for the CLI user requesting to execute a command. This returns correct authorization error messages if the CLI user does not have access to the statement resources. 

However, some commands require that the KSQL server executes them in the background. This PR to perform those permissions checks for the KSQL server as well.

The following output messages are displayed:
1. User does not have READ permissions on a topic
```
ksql> create stream aug15(id int) with (kafka_topic='aug15', value_format='json');
Authorization denied to Read on topic(s): [aug15]
```
2. KSQL does not have READ permissions on a topic
```
ksql> create stream aug15(id int) with (kafka_topic='aug15', value_format='json');
The KSQL server cannot execute the given command.
Caused by: Authorization denied to Describe on topic(s): [aug15]
```
3. Same User and KSQL authorizations denies but with CSAS
```
ksql> create stream aug15_stream as select * from aug15;
Authorization denied to Create on topic(s): [AUG15_STREAM]

ksql> create stream aug15_stream as select * from aug15;
The KSQL server cannot execute the given command.
Caused by: Authorization denied to Describe on topic(s): [AUG15_STREAM]
```
4. Fix authorization error message when executing `INSERT INTO VALUES`
```
ksql> insert into aug15(id) values (2);
Failed to insert values into stream/table: AUG15
Caused by: Authorization denied to Write on topic(s): [aug15]
```

### Testing done 
- Added unit tests
- Verified manually (See above output messages)

### Reviewer checklist
- [ ] Ensure docs are updated if necessary. (eg. if a user visible feature is being added or changed).
- [ ] Ensure relevant issues are linked (description should include text like "Fixes #<issue number>")

