### PR TITLE
docs: remove FAQ about setting retention time

### DIFF
--- a/docs/faq.rst
+++ b/docs/faq.rst
@@ -277,27 +277,6 @@ Check runtime stats for the KSQL server that you're connected to.
 The KSQL REST API supports a "server info" request (for example, ``http://<ksql-server-url>/info``), 
 which returns info such as the KSQL version. For more info, see :ref:`ksql-rest-api`.
 
-=======================================================================
-How do I set the retention period for streams created for KSQL queries?
-=======================================================================
-
-When you create a stream, you can set ``retention.ms`` for the output topic.
-In the KSQL CLI, use the SET statement to assign a value to ``ksql.streams.retention.ms``:
-
-.. code:: bash
-
-    SET 'ksql.streams.retention.ms' = '86400000';
-
-Make the setting global by assigning ``ksql.streams.retention.ms`` in the KSQL
-server configuration file.
-
-.. note:: If you set ``windowstore.changelog.additional.retention.ms``, the
-          ``ksql.streams.retention.ms`` value is added to the retention period
-          for changelog topics. For example, if you set ``ksql.streams.retention.ms``
-          to 7 days, the sink topic retention is 7 days. If you set ``windowstore.changelog.additional.retention.ms``
-          to 2 days, the retention for the internal changelog topic for
-          statestore is the sum of these values: 7 + 2 = 9 days.
-
 ===============================================
 What if automatic topic creation is turned off?
 ===============================================


### PR DESCRIPTION
### Description 

Remove FAQ about configuring retention time for KSQL sink topics as KSQL doesn't currently support this, i.e., the answer in the FAQ is wrong. We should add the FAQ back in once KSQL actually supports this functionality. 

Related issues:

- https://github.com/confluentinc/ksql/issues/2346
- https://github.com/confluentinc/ksql/issues/408#issuecomment-399073255

### Testing done 

Docs-only change.

### Reviewer checklist
- [ ] Ensure docs are updated if necessary. (eg. if a user visible feature is being added or changed).
- [ ] Ensure relevant issues are linked (description should include text like "Fixes #<issue number>")

