### PR TITLE
refactor: errorCode 40301 returned when KsqlTopicAuthorizationException/TopicAuthorizationException thrown

### DIFF
--- a/ksql-rest-app/src/main/java/io/confluent/ksql/rest/server/resources/Errors.java
+++ b/ksql-rest-app/src/main/java/io/confluent/ksql/rest/server/resources/Errors.java
@@ -37,6 +37,8 @@ public final class Errors {
   public static final int ERROR_CODE_UNAUTHORIZED = toErrorCode(UNAUTHORIZED.getStatusCode());
 
   public static final int ERROR_CODE_FORBIDDEN = toErrorCode(FORBIDDEN.getStatusCode());
+  public static final int ERROR_CODE_FORBIDDEN_KAFKA_ACCESS =
+      toErrorCode(FORBIDDEN.getStatusCode()) + 1;
 
   static final int ERROR_CODE_NOT_FOUND = toErrorCode(NOT_FOUND.getStatusCode());
 
@@ -67,6 +69,13 @@ public final class Errors {
     return Response
         .status(FORBIDDEN)
         .entity(new KsqlErrorMessage(ERROR_CODE_FORBIDDEN, msg))
+        .build();
+  }
+
+  public static Response accessDeniedFromKafka(final Exception error) {
+    return Response
+        .status(FORBIDDEN)
+        .entity(new KsqlErrorMessage(ERROR_CODE_FORBIDDEN_KAFKA_ACCESS, error.getMessage()))
         .build();
   }
 

--- a/ksql-rest-app/src/main/java/io/confluent/ksql/rest/server/resources/KsqlResource.java
+++ b/ksql-rest-app/src/main/java/io/confluent/ksql/rest/server/resources/KsqlResource.java
@@ -42,6 +42,7 @@ import io.confluent.ksql.rest.server.execution.RequestHandler;
 import io.confluent.ksql.rest.server.validation.CustomValidators;
 import io.confluent.ksql.rest.server.validation.RequestValidator;
 import io.confluent.ksql.rest.util.CommandStoreUtil;
+import io.confluent.ksql.rest.util.ErrorResponseUtil;
 import io.confluent.ksql.rest.util.TerminateCluster;
 import io.confluent.ksql.services.SandboxedServiceContext;
 import io.confluent.ksql.services.ServiceContext;
@@ -50,6 +51,7 @@ import io.confluent.ksql.util.KsqlConfig;
 import io.confluent.ksql.util.KsqlException;
 import io.confluent.ksql.util.KsqlStatementException;
 import io.confluent.ksql.version.metrics.ActivenessRegistrar;
+
 import java.time.Duration;
 import java.util.List;
 import java.util.Objects;
@@ -178,9 +180,11 @@ public class KsqlResource {
     } catch (final KsqlStatementException e) {
       return Errors.badStatement(e.getRawMessage(), e.getSqlStatement());
     } catch (final KsqlException e) {
-      return Errors.badRequest(e);
+      return ErrorResponseUtil.generateResponse(
+          e, Errors.badRequest(e));
     } catch (final Exception e) {
-      return Errors.serverErrorForStatement(e, request.getKsql());
+      return ErrorResponseUtil.generateResponse(
+          e, Errors.serverErrorForStatement(e, request.getKsql()));
     }
   }
 

--- a/ksql-rest-app/src/main/java/io/confluent/ksql/rest/server/resources/streaming/StreamedQueryResource.java
+++ b/ksql-rest-app/src/main/java/io/confluent/ksql/rest/server/resources/streaming/StreamedQueryResource.java
@@ -29,6 +29,7 @@ import io.confluent.ksql.rest.server.computation.CommandQueue;
 import io.confluent.ksql.rest.server.resources.Errors;
 import io.confluent.ksql.rest.server.resources.KsqlRestException;
 import io.confluent.ksql.rest.util.CommandStoreUtil;
+import io.confluent.ksql.rest.util.ErrorResponseUtil;
 import io.confluent.ksql.services.ServiceContext;
 import io.confluent.ksql.statement.ConfiguredStatement;
 import io.confluent.ksql.util.KsqlConfig;
@@ -47,6 +48,8 @@ import javax.ws.rs.Produces;
 import javax.ws.rs.core.Context;
 import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.Response;
+
+import org.apache.kafka.common.errors.TopicAuthorizationException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -144,8 +147,11 @@ public class StreamedQueryResource {
       return Errors.badRequest(String.format(
           "Statement type `%s' not supported for this resource",
           statement.getClass().getName()));
+    } catch (final TopicAuthorizationException e) {
+      return Errors.accessDeniedFromKafka(e);
     } catch (final KsqlException e) {
-      return Errors.badRequest(e);
+      return ErrorResponseUtil.generateResponse(
+          e, Errors.badRequest(e));
     }
   }
 

--- a/ksql-rest-app/src/main/java/io/confluent/ksql/rest/util/ErrorResponseUtil.java
+++ b/ksql-rest-app/src/main/java/io/confluent/ksql/rest/util/ErrorResponseUtil.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright 2019 Confluent Inc.
+ *
+ * Licensed under the Confluent Community License (the "License"); you may not use
+ * this file except in compliance with the License.  You may obtain a copy of the
+ * License at
+ *
+ * http://www.confluent.io/confluent-community-license
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package io.confluent.ksql.rest.util;
+
+import io.confluent.ksql.rest.server.resources.Errors;
+
+import javax.ws.rs.core.Response;
+import org.apache.commons.lang3.exception.ExceptionUtils;
+import org.apache.kafka.common.errors.TopicAuthorizationException;
+
+
+public final class ErrorResponseUtil {
+
+  private ErrorResponseUtil() {
+  }
+
+  public static Response generateResponse(final Exception e, final Response defaultResponse) {
+    if (ExceptionUtils.indexOfType(e, TopicAuthorizationException.class) >= 0) {
+      return Errors.accessDeniedFromKafka(e);
+    } else {
+      return defaultResponse;
+    }
+  }
+}


### PR DESCRIPTION
### Description 
Some AuthorizationExceptions can be wrapped with another exception so created a util that would check root cause of thrown exceptions to ensure the correct response is returned.

Current sample 500 response:
```
{
"@type": "statement_error",
"error_code": 50000,
"message": "Failed to Create Kafka topic: [new_topic]\nCaused by: Not authorized to access topic: [new_topic]",
"stackTrace": [],
"statementText": "CREATE STREAM Test_Topic(age BIGINT) WITH (KAFKA_TOPIC='new_topic', PARTITIONS=1, VALUE_FORMAT='DELIMITED');",
"entities": []
}
```

Updated 403 response:
```
{
    "@type": "generic_error",
    "error_code": 40301,
    "message": "Authorization denied to Create on topic(s): [new_topic]",
    "stackTrace": []
}
```

### Testing done 
Unit tests
Local Ksql server testing using Postman

```
//Initialization
CREATE STREAM TESTSTREAM(age BIGINT) WITH (KAFKA_TOPIC='qwerqwerqwerqwerqtly', VALUE_FORMAT='JSON');
CREATE STREAM SECONDARY(age BIGINT) WITH (KAFKA_TOPIC='qwerqwerqwerqwerqtly', VALUE_FORMAT='JSON');

DROP STREAM TESTSTREAM DELETE TOPIC; (DROP STREAM SECONDARY;)
CREATE STREAM TARGET_STREAM WITH (KAFKA_TOPIC='NEW_TOPIC', PARTITIONS=2, REPLICAS = 1) AS SELECT * FROM TESTSTREAM;
INSERT INTO TESTSTREAM SELECT AGE FROM SECONDARY;
CREATE STREAM qq(age BIGINT) WITH (KAFKA_TOPIC='ttttt', PARTITIONS=1, VALUE_FORMAT='DELIMITED');
CREATE TABLE qq(age BIGINT) WITH (KAFKA_TOPIC='ttttt', PARTITIONS=1, VALUE_FORMAT='DELIMITED');
INSERT INTO TESTSTREAM (ROWTIME, ROWKEY, age) VALUES ( 1234, 'KEY', 4);
DESCRIBE EXTENDED TESTSTREAM;   (remove Acls permissions for Describe)
Select * from TESTSTREAM; (/query)
```

### Reviewer checklist
- [ ] Ensure docs are updated if necessary. (eg. if a user visible feature is being added or changed).
- [ ] Ensure relevant issues are linked (description should include text like "Fixes #<issue number>")

