### PR TITLE
refactor: change KsqlAuthorizationException to KsqlTopicAuthorizationException

### DIFF
--- a/ksql-engine/src/main/java/io/confluent/ksql/engine/AuthorizationTopicAccessValidator.java
+++ b/ksql-engine/src/main/java/io/confluent/ksql/engine/AuthorizationTopicAccessValidator.java
@@ -15,6 +15,7 @@
 
 package io.confluent.ksql.engine;
 
+import io.confluent.ksql.exception.KsqlTopicAuthorizationException;
 import io.confluent.ksql.metastore.MetaStore;
 import io.confluent.ksql.metastore.model.DataSource;
 import io.confluent.ksql.parser.tree.CreateAsSelect;
@@ -23,7 +24,6 @@ import io.confluent.ksql.parser.tree.Query;
 import io.confluent.ksql.parser.tree.Statement;
 import io.confluent.ksql.services.ServiceContext;
 import io.confluent.ksql.topic.SourceTopicsExtractor;
-import io.confluent.ksql.util.KsqlAuthorizationException;
 import io.confluent.ksql.util.KsqlException;
 
 import java.util.Collections;
@@ -128,7 +128,7 @@ public class AuthorizationTopicAccessValidator implements TopicAccessValidator {
     if (authorizedOperations != null && !authorizedOperations.contains(operation)) {
       // This error message is similar to what Kafka throws when it cannot access the topic
       // due to an authorization error. I used this message to keep a consistent message.
-      throw new KsqlAuthorizationException(operation, Collections.singleton(topicName));
+      throw new KsqlTopicAuthorizationException(operation, Collections.singleton(topicName));
     }
   }
 

--- a/ksql-engine/src/main/java/io/confluent/ksql/exception/KsqlTopicAuthorizationException.java
+++ b/ksql-engine/src/main/java/io/confluent/ksql/exception/KsqlTopicAuthorizationException.java
@@ -13,22 +13,26 @@
  * specific language governing permissions and limitations under the License.
  */
 
-package io.confluent.ksql.util;
+package io.confluent.ksql.exception;
 
 import java.util.Collection;
 
 import org.apache.commons.lang3.StringUtils;
 import org.apache.kafka.common.acl.AclOperation;
+import org.apache.kafka.common.errors.TopicAuthorizationException;
 
-public class KsqlAuthorizationException extends RuntimeException {
+/**
+ * Used to return custom error messages when TopicAuthorizationException returned from Kafka
+ */
+public class KsqlTopicAuthorizationException extends TopicAuthorizationException {
 
-  public KsqlAuthorizationException(
+  public KsqlTopicAuthorizationException(
       final AclOperation operation,
       final Collection<String> topicNames) {
     super(String.format("Authorization denied to %s on topic(s): [%s]",
         StringUtils.capitalize(
             operation.toString().toLowerCase()),
-            StringUtils.join(topicNames, ", "))
-    );
+            StringUtils.join(topicNames, ", ")));
   }
+
 }

--- a/ksql-engine/src/main/java/io/confluent/ksql/services/KafkaTopicClientImpl.java
+++ b/ksql-engine/src/main/java/io/confluent/ksql/services/KafkaTopicClientImpl.java
@@ -18,9 +18,9 @@ package io.confluent.ksql.services;
 import com.google.common.collect.Lists;
 import io.confluent.ksql.exception.KafkaDeleteTopicsException;
 import io.confluent.ksql.exception.KafkaResponseGetFailedException;
+import io.confluent.ksql.exception.KsqlTopicAuthorizationException;
 import io.confluent.ksql.topic.TopicProperties;
 import io.confluent.ksql.util.ExecutorUtil;
-import io.confluent.ksql.util.KsqlAuthorizationException;
 import io.confluent.ksql.util.KsqlConstants;
 import io.confluent.ksql.util.KsqlException;
 import io.confluent.ksql.util.KsqlServerException;
@@ -117,7 +117,7 @@ public class KafkaTopicClientImpl implements KafkaTopicClient {
       validateTopicProperties(topic, numPartitions, replicationFactor);
 
     } catch (final TopicAuthorizationException e) {
-      throw new KsqlAuthorizationException(
+      throw new KsqlTopicAuthorizationException(
           AclOperation.CREATE, Collections.singleton(topic));
 
     } catch (final Exception e) {
@@ -185,7 +185,7 @@ public class KafkaTopicClientImpl implements KafkaTopicClient {
       throw new KafkaResponseGetFailedException(
           "Failed to Describe Kafka Topic(s): " + topicNames, e.getCause());
     } catch (final TopicAuthorizationException e) {
-      throw new KsqlAuthorizationException(
+      throw new KsqlTopicAuthorizationException(
           AclOperation.DESCRIBE, topicNames);
     } catch (final Exception e) {
       throw new KafkaResponseGetFailedException(
@@ -270,7 +270,7 @@ public class KafkaTopicClientImpl implements KafkaTopicClient {
               + "To delete the topic, you must set '" + DELETE_TOPIC_ENABLE + "' to true in "
               + "the Kafka broker configuration.");
         } else if (rootCause instanceof TopicAuthorizationException) {
-          throw new KsqlAuthorizationException(
+          throw new KsqlTopicAuthorizationException(
               AclOperation.DELETE, Collections.singleton(entry.getKey()));
         } else if (!(rootCause instanceof UnknownTopicOrPartitionException)) {
           LOG.error(String.format("Could not delete topic '%s'", entry.getKey()), e);

--- a/ksql-engine/src/test/java/io/confluent/ksql/engine/AuthorizationTopicAccessValidatorTest.java
+++ b/ksql-engine/src/test/java/io/confluent/ksql/engine/AuthorizationTopicAccessValidatorTest.java
@@ -18,6 +18,7 @@ package io.confluent.ksql.engine;
 import static org.mockito.Mockito.when;
 
 import io.confluent.ksql.exception.KafkaResponseGetFailedException;
+import io.confluent.ksql.exception.KsqlTopicAuthorizationException;
 import io.confluent.ksql.function.InternalFunctionRegistry;
 import io.confluent.ksql.metastore.MetaStoreImpl;
 import io.confluent.ksql.metastore.MutableMetaStore;
@@ -33,8 +34,6 @@ import io.confluent.ksql.serde.SerdeOption;
 import io.confluent.ksql.serde.ValueFormat;
 import io.confluent.ksql.services.KafkaTopicClient;
 import io.confluent.ksql.services.ServiceContext;
-import io.confluent.ksql.util.KsqlAuthorizationException;
-import io.confluent.ksql.util.KsqlException;
 import io.confluent.ksql.util.timestamp.MetadataTimestampExtractionPolicy;
 import java.util.Collections;
 import java.util.Set;
@@ -137,7 +136,7 @@ public class AuthorizationTopicAccessValidatorTest {
     );
 
     // Then:
-    expectedException.expect(KsqlAuthorizationException.class);
+    expectedException.expect(KsqlTopicAuthorizationException.class);
     expectedException.expectMessage(String.format(
         "Authorization denied to Read on topic(s): [%s]", TOPIC_1.name()
     ));
@@ -172,7 +171,7 @@ public class AuthorizationTopicAccessValidatorTest {
     );
 
     // Then:
-    expectedException.expect(KsqlAuthorizationException.class);
+    expectedException.expect(KsqlTopicAuthorizationException.class);
     expectedException.expectMessage(String.format(
         "Authorization denied to Read on topic(s): [%s]", TOPIC_1.name()
     ));
@@ -191,7 +190,7 @@ public class AuthorizationTopicAccessValidatorTest {
     );
 
     // Then:
-    expectedException.expect(KsqlAuthorizationException.class);
+    expectedException.expect(KsqlTopicAuthorizationException.class);
     expectedException.expectMessage(String.format(
         "Authorization denied to Read on topic(s): [%s]", TOPIC_2.name()
     ));
@@ -210,7 +209,7 @@ public class AuthorizationTopicAccessValidatorTest {
     );
 
     // Then:
-    expectedException.expect(KsqlAuthorizationException.class);
+    expectedException.expect(KsqlTopicAuthorizationException.class);
     expectedException.expectMessage(String.format(
         "Authorization denied to Read on topic(s): [%s]", TOPIC_1.name()
     ));
@@ -245,7 +244,7 @@ public class AuthorizationTopicAccessValidatorTest {
     );
 
     // Then:
-    expectedException.expect(KsqlAuthorizationException.class);
+    expectedException.expect(KsqlTopicAuthorizationException.class);
     expectedException.expectMessage(String.format(
         "Authorization denied to Write on topic(s): [%s]", TOPIC_2.name()
     ));
@@ -264,7 +263,7 @@ public class AuthorizationTopicAccessValidatorTest {
     );
 
     // Then:
-    expectedException.expect(KsqlAuthorizationException.class);
+    expectedException.expect(KsqlTopicAuthorizationException.class);
     expectedException.expectMessage(String.format(
         "Authorization denied to Read on topic(s): [%s]", TOPIC_1.name()
     ));
@@ -282,7 +281,7 @@ public class AuthorizationTopicAccessValidatorTest {
     );
 
     // Then:
-    expectedException.expect(KsqlAuthorizationException.class);
+    expectedException.expect(KsqlTopicAuthorizationException.class);
     expectedException.expectMessage(String.format(
         "Authorization denied to Read on topic(s): [%s]", TOPIC_1.name()
     ));
@@ -317,7 +316,7 @@ public class AuthorizationTopicAccessValidatorTest {
     );
 
     // Then:
-    expectedException.expect(KsqlAuthorizationException.class);
+    expectedException.expect(KsqlTopicAuthorizationException.class);
     expectedException.expectMessage(String.format(
         "Authorization denied to Write on topic(s): [%s]", TOPIC_2.name()
     ));

--- a/ksql-engine/src/test/java/io/confluent/ksql/services/KafkaTopicClientImplTest.java
+++ b/ksql-engine/src/test/java/io/confluent/ksql/services/KafkaTopicClientImplTest.java
@@ -31,8 +31,8 @@ import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
 import io.confluent.ksql.exception.KafkaDeleteTopicsException;
 import io.confluent.ksql.exception.KafkaResponseGetFailedException;
+import io.confluent.ksql.exception.KsqlTopicAuthorizationException;
 import io.confluent.ksql.exception.KafkaTopicExistsException;
-import io.confluent.ksql.util.KsqlAuthorizationException;
 import io.confluent.ksql.util.KsqlConstants;
 import java.util.Arrays;
 import java.util.Collection;
@@ -64,7 +64,6 @@ import org.apache.kafka.clients.admin.TopicDescription;
 import org.apache.kafka.common.KafkaFuture;
 import org.apache.kafka.common.Node;
 import org.apache.kafka.common.TopicPartitionInfo;
-import org.apache.kafka.common.acl.AclOperation;
 import org.apache.kafka.common.config.ConfigResource;
 import org.apache.kafka.common.config.TopicConfig;
 import org.apache.kafka.common.errors.DisconnectException;
@@ -166,7 +165,7 @@ public class KafkaTopicClientImplTest {
     replay(adminClient);
 
     // Expect:
-    expectedException.expect(KsqlAuthorizationException.class);
+    expectedException.expect(KsqlTopicAuthorizationException.class);
     expectedException.expectMessage(
         String.format("Authorization denied to Create on topic(s): [%s]", topicName1));
 
@@ -241,7 +240,7 @@ public class KafkaTopicClientImplTest {
     replay(adminClient);
 
     // Expect:
-    expectedException.expect(KsqlAuthorizationException.class);
+    expectedException.expect(KsqlTopicAuthorizationException.class);
     expectedException.expectMessage(
         String.format("Authorization denied to Describe on topic(s): [%s]", topicName1));
 
@@ -343,7 +342,7 @@ public class KafkaTopicClientImplTest {
     final KafkaTopicClient kafkaTopicClient = new KafkaTopicClientImpl(adminClient);
 
     // Expect:
-    expectedException.expect(KsqlAuthorizationException.class);
+    expectedException.expect(KsqlTopicAuthorizationException.class);
     expectedException.expectMessage(
         String.format("Authorization denied to Delete on topic(s): [%s]", topicName1));
 


### PR DESCRIPTION
### Description 
KsqlAuthorizationException changed to KsqlTopicAuthorizationException. KsqlAuthorizationException too ambiguous since it could apply to both SchemaRegistry auth failures and also Kafka auth failures.
### Testing done 
mvn clean install
Verify error messages still same
### Reviewer checklist
- [ ] Ensure docs are updated if necessary. (eg. if a user visible feature is being added or changed).
- [ ] Ensure relevant issues are linked (description should include text like "Fixes #<issue number>")

