### PR TITLE
fix: fix a bug in testing tool serde

### DIFF
--- a/ksql-functional-tests/src/main/java/io/confluent/ksql/test/serde/avro/ValueSpecAvroSerdeSupplier.java
+++ b/ksql-functional-tests/src/main/java/io/confluent/ksql/test/serde/avro/ValueSpecAvroSerdeSupplier.java
@@ -191,6 +191,9 @@ public class ValueSpecAvroSerdeSupplier implements SerdeSupplier<Object> {
     @SuppressWarnings("unchecked")
     private static GenericRecord getAvroRecord(final Object spec, final Schema schema) {
       final GenericRecord record = new GenericData.Record(schema);
+      if (spec instanceof ValueSpec) {
+        return getAvroRecord(((ValueSpec) spec).getSpec(), schema);
+      }
       final Map<String, String> caseInsensitiveFieldNames
           = getUppercaseKeyToActualKey((Map) spec);
       for (final org.apache.avro.Schema.Field field : schema.getFields()) {

--- a/ksql-functional-tests/src/test/resources/test-runner/correct/multi_join/input.json
+++ b/ksql-functional-tests/src/test/resources/test-runner/correct/multi_join/input.json
@@ -1,0 +1,15 @@
+{
+  "inputs": [
+    {"topic": "lookup1", "key": "lu1_0", "value": {"ID": "lu1_0", "value": "lu1_0_val"}, "timestamp": 0},
+    {"topic": "lookup1", "key": "lu1_1", "value": {"ID": "lu1_1", "value": "lu1_1_val"}, "timestamp": 0},
+    {"topic": "lookup1", "key": "lu1_2", "value": {"ID": "lu1_2", "value": "lu1_2_val"}, "timestamp": 0},
+
+    {"topic": "lookup2", "key": "lu2_0", "value": {"ID": "lu2_0", "value": "lu2_0_val"}, "timestamp": 0},
+    {"topic": "lookup2", "key": "lu2_1", "value": {"ID": "lu2_1", "value": "lu2_1_val"}, "timestamp": 0},
+    {"topic": "lookup2", "key": "lu2_2", "value": {"ID": "lu2_2", "value": "lu2_2_val"}, "timestamp": 0},
+
+    {"topic": "test", "key": "id0", "value": {"ID": "id0", "lookup1": "lu1_0", "lookup2": "lu2_2"}, "timestamp": 10},
+    {"topic": "test", "key": "id1", "value": {"ID": "id1", "lookup1": "lu1_2", "lookup2": "lu2_0"}, "timestamp": 20},
+    {"topic": "test", "key": "id2", "value": {"ID": "id2", "lookup1": "lu1_1", "lookup2": "lu2_2"}, "timestamp": 30}
+  ]
+}

--- a/ksql-functional-tests/src/test/resources/test-runner/correct/multi_join/output.json
+++ b/ksql-functional-tests/src/test/resources/test-runner/correct/multi_join/output.json
@@ -1,0 +1,11 @@
+{
+  "outputs": [
+    {"topic": "TEST_LOOKUP1_OUTPUT", "key": "lu1_0", "value": {"ID": "id0", "LOOKUP1_VALUE": "lu1_0_val", "LOOKUP2": "lu2_2"}, "timestamp": 10},
+    {"topic": "TEST_LOOKUP1_OUTPUT", "key": "lu1_2", "value": {"ID": "id1", "LOOKUP1_VALUE": "lu1_2_val", "LOOKUP2": "lu2_0"}, "timestamp": 20},
+    {"topic": "TEST_LOOKUP1_OUTPUT", "key": "lu1_1", "value": {"ID": "id2", "LOOKUP1_VALUE": "lu1_1_val", "LOOKUP2": "lu2_2"}, "timestamp": 30},
+
+    {"topic": "TEST_LOOKUP2_OUTPUT", "key": "lu2_2", "value": {"ID": "id0", "LOO": "lu1_0_val", "LOOKUP2_VALUE": "lu2_2_val"}, "timestamp": 10},
+    {"topic": "TEST_LOOKUP2_OUTPUT", "key": "lu2_0", "value": {"ID": "id1", "LOO": "lu1_2_val", "LOOKUP2_VALUE": "lu2_0_val"}, "timestamp": 20},
+    {"topic": "TEST_LOOKUP2_OUTPUT", "key": "lu2_2", "value": {"ID": "id2", "LOO": "lu1_1_val", "LOOKUP2_VALUE": "lu2_2_val"}, "timestamp": 30}
+  ]
+}

--- a/ksql-functional-tests/src/test/resources/test-runner/correct/multi_join/statements.sql
+++ b/ksql-functional-tests/src/test/resources/test-runner/correct/multi_join/statements.sql
@@ -1,0 +1,39 @@
+CREATE STREAM test (
+       id STRING,
+       lookup1 STRING,
+       lookup2 STRING)
+  WITH (VALUE_FORMAT='AVRO',
+       KAFKA_TOPIC = 'test',
+       KEY = 'id');
+
+CREATE TABLE lookup1 (
+       id STRING,
+       value STRING)
+  WITH (VALUE_FORMAT='AVRO',
+       KAFKA_TOPIC = 'lookup1',
+       KEY = 'id');
+
+CREATE TABLE lookup2 (
+       id STRING,
+       value STRING)
+  WITH (VALUE_FORMAT='AVRO',
+       KAFKA_TOPIC = 'lookup2',
+       KEY = 'id');
+
+CREATE STREAM test_lookup1_output
+    AS
+SELECT t.id AS id,
+       l1.value AS lookup1_value,
+       t.lookup2 AS lookup2
+  FROM test t
+  JOIN lookup1 l1
+    ON t.lookup1 = l1.id;
+
+ CREATE STREAM test_lookup2_output
+    AS
+SELECT t.id AS id,
+       t.lookup1_value AS loo,
+       l2.value AS lookup2_value
+  FROM test_lookup1_output t
+  JOIN lookup2 l2
+    ON t.lookup2 = l2.id;


### PR DESCRIPTION
Testing tool Avro serde can now handle ValueSpec object even when the higher level object is passed. Also added one more test for multiple joins.

