### PR TITLE
fix: replace nashorn @Immutable with errorprone for JDK12 (MINOR)

### DIFF
--- a/ksql-execution/src/main/java/io/confluent/ksql/execution/plan/DefaultExecutionStepProperties.java
+++ b/ksql-execution/src/main/java/io/confluent/ksql/execution/plan/DefaultExecutionStepProperties.java
@@ -14,9 +14,9 @@
 
 package io.confluent.ksql.execution.plan;
 
+import com.google.errorprone.annotations.Immutable;
 import io.confluent.ksql.schema.ksql.LogicalSchema;
 import java.util.Objects;
-import jdk.nashorn.internal.ir.annotations.Immutable;
 
 @Immutable
 public class DefaultExecutionStepProperties implements ExecutionStepProperties {

--- a/ksql-execution/src/main/java/io/confluent/ksql/execution/plan/StreamAggregate.java
+++ b/ksql-execution/src/main/java/io/confluent/ksql/execution/plan/StreamAggregate.java
@@ -14,13 +14,13 @@
 
 package io.confluent.ksql.execution.plan;
 
+import com.google.errorprone.annotations.Immutable;
 import io.confluent.ksql.GenericRow;
 import io.confluent.ksql.function.KsqlAggregateFunction;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
-import jdk.nashorn.internal.ir.annotations.Immutable;
 import org.apache.kafka.streams.StreamsBuilder;
 import org.apache.kafka.streams.kstream.KGroupedStream;
 import org.apache.kafka.streams.kstream.KTable;

--- a/ksql-execution/src/main/java/io/confluent/ksql/execution/plan/StreamFilter.java
+++ b/ksql-execution/src/main/java/io/confluent/ksql/execution/plan/StreamFilter.java
@@ -14,12 +14,12 @@
 
 package io.confluent.ksql.execution.plan;
 
+import com.google.errorprone.annotations.Immutable;
 import io.confluent.ksql.GenericRow;
 import io.confluent.ksql.execution.expression.tree.Expression;
 import java.util.Collections;
 import java.util.List;
 import java.util.Objects;
-import jdk.nashorn.internal.ir.annotations.Immutable;
 import org.apache.kafka.streams.StreamsBuilder;
 import org.apache.kafka.streams.kstream.KStream;
 

--- a/ksql-execution/src/main/java/io/confluent/ksql/execution/plan/StreamGroupBy.java
+++ b/ksql-execution/src/main/java/io/confluent/ksql/execution/plan/StreamGroupBy.java
@@ -14,12 +14,12 @@
 
 package io.confluent.ksql.execution.plan;
 
+import com.google.errorprone.annotations.Immutable;
 import io.confluent.ksql.GenericRow;
 import io.confluent.ksql.execution.expression.tree.Expression;
 import java.util.Collections;
 import java.util.List;
 import java.util.Objects;
-import jdk.nashorn.internal.ir.annotations.Immutable;
 import org.apache.kafka.streams.StreamsBuilder;
 import org.apache.kafka.streams.kstream.KGroupedStream;
 import org.apache.kafka.streams.kstream.KStream;

--- a/ksql-execution/src/main/java/io/confluent/ksql/execution/plan/StreamMapValues.java
+++ b/ksql-execution/src/main/java/io/confluent/ksql/execution/plan/StreamMapValues.java
@@ -15,11 +15,11 @@
 package io.confluent.ksql.execution.plan;
 
 import com.google.common.collect.ImmutableList;
+import com.google.errorprone.annotations.Immutable;
 import io.confluent.ksql.GenericRow;
 import java.util.Collections;
 import java.util.List;
 import java.util.Objects;
-import jdk.nashorn.internal.ir.annotations.Immutable;
 import org.apache.kafka.streams.StreamsBuilder;
 import org.apache.kafka.streams.kstream.KStream;
 

--- a/ksql-execution/src/main/java/io/confluent/ksql/execution/plan/StreamSink.java
+++ b/ksql-execution/src/main/java/io/confluent/ksql/execution/plan/StreamSink.java
@@ -14,11 +14,11 @@
 
 package io.confluent.ksql.execution.plan;
 
+import com.google.errorprone.annotations.Immutable;
 import io.confluent.ksql.GenericRow;
 import java.util.Collections;
 import java.util.List;
 import java.util.Objects;
-import jdk.nashorn.internal.ir.annotations.Immutable;
 import org.apache.kafka.streams.StreamsBuilder;
 import org.apache.kafka.streams.kstream.KStream;
 

--- a/ksql-execution/src/main/java/io/confluent/ksql/execution/plan/TableFilter.java
+++ b/ksql-execution/src/main/java/io/confluent/ksql/execution/plan/TableFilter.java
@@ -14,12 +14,12 @@
 
 package io.confluent.ksql.execution.plan;
 
+import com.google.errorprone.annotations.Immutable;
 import io.confluent.ksql.GenericRow;
 import io.confluent.ksql.execution.expression.tree.Expression;
 import java.util.Collections;
 import java.util.List;
 import java.util.Objects;
-import jdk.nashorn.internal.ir.annotations.Immutable;
 import org.apache.kafka.streams.StreamsBuilder;
 import org.apache.kafka.streams.kstream.KTable;
 

--- a/ksql-execution/src/main/java/io/confluent/ksql/execution/plan/TableMapValues.java
+++ b/ksql-execution/src/main/java/io/confluent/ksql/execution/plan/TableMapValues.java
@@ -14,11 +14,11 @@
 
 package io.confluent.ksql.execution.plan;
 
+import com.google.errorprone.annotations.Immutable;
 import io.confluent.ksql.GenericRow;
 import java.util.Collections;
 import java.util.List;
 import java.util.Objects;
-import jdk.nashorn.internal.ir.annotations.Immutable;
 import org.apache.kafka.streams.StreamsBuilder;
 import org.apache.kafka.streams.kstream.KTable;
 


### PR DESCRIPTION
JDK 12 removes nashorn - I'm pretty sure the intention was to use errorprone annotation.
