### PR TITLE
feat: add DROP CONNECTOR functionality

### DIFF
--- a/ksql-cli/src/main/java/io/confluent/ksql/cli/console/Console.java
+++ b/ksql-cli/src/main/java/io/confluent/ksql/cli/console/Console.java
@@ -29,6 +29,7 @@ import io.confluent.ksql.cli.console.table.Table.Builder;
 import io.confluent.ksql.cli.console.table.builder.CommandStatusTableBuilder;
 import io.confluent.ksql.cli.console.table.builder.ConnectorInfoTableBuilder;
 import io.confluent.ksql.cli.console.table.builder.ConnectorListTableBuilder;
+import io.confluent.ksql.cli.console.table.builder.DropConnectorTableBuilder;
 import io.confluent.ksql.cli.console.table.builder.ErrorEntityTableBuilder;
 import io.confluent.ksql.cli.console.table.builder.ExecutionPlanTableBuilder;
 import io.confluent.ksql.cli.console.table.builder.FunctionNameListTableBuilder;
@@ -45,6 +46,7 @@ import io.confluent.ksql.rest.entity.CommandStatusEntity;
 import io.confluent.ksql.rest.entity.ConnectorDescription;
 import io.confluent.ksql.rest.entity.ConnectorList;
 import io.confluent.ksql.rest.entity.CreateConnectorEntity;
+import io.confluent.ksql.rest.entity.DropConnectorEntity;
 import io.confluent.ksql.rest.entity.ErrorEntity;
 import io.confluent.ksql.rest.entity.ExecutionPlan;
 import io.confluent.ksql.rest.entity.FieldInfo;
@@ -149,6 +151,8 @@ public class Console implements Closeable {
               Console::printFunctionDescription)
           .put(CreateConnectorEntity.class,
               tablePrinter(CreateConnectorEntity.class, ConnectorInfoTableBuilder::new))
+          .put(DropConnectorEntity.class,
+              tablePrinter(DropConnectorEntity.class, DropConnectorTableBuilder::new))
           .put(ConnectorList.class,
               tablePrinter(ConnectorList.class, ConnectorListTableBuilder::new))
           .put(ConnectorDescription.class,

--- a/ksql-cli/src/main/java/io/confluent/ksql/cli/console/table/builder/DropConnectorTableBuilder.java
+++ b/ksql-cli/src/main/java/io/confluent/ksql/cli/console/table/builder/DropConnectorTableBuilder.java
@@ -1,0 +1,30 @@
+/*
+ * Copyright 2019 Confluent Inc.
+ *
+ * Licensed under the Confluent Community License (the "License"; you may not use
+ * this file except in compliance with the License. You may obtain a copy of the
+ * License at
+ *
+ * http://www.confluent.io/confluent-community-license
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package io.confluent.ksql.cli.console.table.builder;
+
+import io.confluent.ksql.cli.console.table.Table;
+import io.confluent.ksql.rest.entity.DropConnectorEntity;
+
+public class DropConnectorTableBuilder implements TableBuilder<DropConnectorEntity> {
+
+  @Override
+  public Table buildTable(final DropConnectorEntity entity) {
+    return new Table.Builder()
+        .withColumnHeaders("Message")
+        .withRow("Dropped connector \"" + entity.getConnectorName() + '"')
+        .build();
+  }
+}

--- a/ksql-cli/src/test/java/io/confluent/ksql/cli/console/ConsoleTest.java
+++ b/ksql-cli/src/test/java/io/confluent/ksql/cli/console/ConsoleTest.java
@@ -41,6 +41,7 @@ import io.confluent.ksql.rest.entity.CommandStatus;
 import io.confluent.ksql.rest.entity.CommandStatusEntity;
 import io.confluent.ksql.rest.entity.ConnectorDescription;
 import io.confluent.ksql.rest.entity.ConnectorList;
+import io.confluent.ksql.rest.entity.DropConnectorEntity;
 import io.confluent.ksql.rest.entity.EntityQueryId;
 import io.confluent.ksql.rest.entity.ErrorEntity;
 import io.confluent.ksql.rest.entity.ExecutionPlan;
@@ -1036,6 +1037,37 @@ public class ConsoleTest {
     } else {
       assertThat(output, containsString("\"message\" : \"oops\""));
       assertThat(output, containsString("\"message\" : \"doh!\""));
+    }
+  }
+
+  @Test
+  public void shouldPrintDropConnector() throws IOException {
+    // Given:
+    final KsqlEntity entity = new DropConnectorEntity("statementText", "connectorName");
+
+    // When:
+    console.printKsqlEntityList(ImmutableList.of(entity));
+
+    // Then:
+    final String output = terminal.getOutputString();
+    if (console.getOutputFormat() == OutputFormat.TABULAR) {
+      assertThat(
+          output,
+          is("\n"
+              + " Message                           \n"
+              + "-----------------------------------\n"
+              + " Dropped connector \"connectorName\" \n"
+              + "-----------------------------------\n")
+      );
+    } else {
+      assertThat(
+          output,
+          is("[ {\n"
+              + "  \"statementText\" : \"statementText\",\n"
+              + "  \"connectorName\" : \"connectorName\",\n"
+              + "  \"warnings\" : [ ]\n"
+              + "} ]\n")
+      );
     }
   }
 

--- a/ksql-engine/src/main/java/io/confluent/ksql/services/ConnectClient.java
+++ b/ksql-engine/src/main/java/io/confluent/ksql/services/ConnectClient.java
@@ -59,6 +59,13 @@ public interface ConnectClient {
   ConnectResponse<ConnectorStateInfo> status(String connector);
 
   /**
+   * Delete the {@code connector}.
+   *
+   * @param connector the connector name
+   */
+  ConnectResponse<String> delete(String connector);
+
+  /**
    * An optionally successful response. Either contains a value of type
    * {@code <T>} or an error, which is the string representation of the
    * response entity.
@@ -68,11 +75,11 @@ public interface ConnectClient {
     private final Optional<String> error;
     private final int httpCode;
 
-    public static <T> ConnectResponse<T> of(final T datum, final int code) {
+    public static <T> ConnectResponse<T> success(final T datum, final int code) {
       return new ConnectResponse<>(datum, null, code);
     }
 
-    public static <T> ConnectResponse<T> of(final String error, final int code) {
+    public static <T> ConnectResponse<T> failure(final String error, final int code) {
       return new ConnectResponse<>(null, error, code);
     }
 

--- a/ksql-engine/src/main/java/io/confluent/ksql/services/SandboxConnectClient.java
+++ b/ksql-engine/src/main/java/io/confluent/ksql/services/SandboxConnectClient.java
@@ -34,13 +34,15 @@ final class SandboxConnectClient {
   public static ConnectClient createProxy() {
     return LimitedProxyBuilder.forClass(ConnectClient.class)
         .swallow("create", methodParams(String.class, Map.class),
-            ConnectResponse.of("sandbox", HttpStatus.SC_INTERNAL_SERVER_ERROR))
+            ConnectResponse.failure("sandbox", HttpStatus.SC_INTERNAL_SERVER_ERROR))
         .swallow("describe", methodParams(String.class),
-            ConnectResponse.of("sandbox", HttpStatus.SC_INTERNAL_SERVER_ERROR))
+            ConnectResponse.failure("sandbox", HttpStatus.SC_INTERNAL_SERVER_ERROR))
         .swallow("connectors", methodParams(),
-            ConnectResponse.of(ImmutableList.of(), HttpStatus.SC_OK))
+            ConnectResponse.success(ImmutableList.of(), HttpStatus.SC_OK))
         .swallow("status", methodParams(String.class),
-            ConnectResponse.of("sandbox", HttpStatus.SC_INTERNAL_SERVER_ERROR))
+            ConnectResponse.failure("sandbox", HttpStatus.SC_INTERNAL_SERVER_ERROR))
+        .swallow("delete", methodParams(String.class),
+            ConnectResponse.success("sandbox", HttpStatus.SC_NO_CONTENT))
         .build();
   }
 }

--- a/ksql-engine/src/test/java/io/confluent/ksql/connect/ConnectConfigServiceTest.java
+++ b/ksql-engine/src/test/java/io/confluent/ksql/connect/ConnectConfigServiceTest.java
@@ -228,14 +228,14 @@ public class ConnectConfigServiceTest {
 
   private void givenConnectors(final String... names){
     for (final String name : names) {
-      when(connectClient.describe(name)).thenReturn(ConnectResponse.of(new ConnectorInfo(
+      when(connectClient.describe(name)).thenReturn(ConnectResponse.success(new ConnectorInfo(
           name,
           ImmutableMap.of(),
           ImmutableList.of(),
           ConnectorType.SOURCE
       ), HttpStatus.SC_CREATED));
     }
-    when(connectClient.connectors()).thenReturn(ConnectResponse.of(ImmutableList.copyOf(names),
+    when(connectClient.connectors()).thenReturn(ConnectResponse.success(ImmutableList.copyOf(names),
         HttpStatus.SC_OK));
   }
 

--- a/ksql-engine/src/test/java/io/confluent/ksql/services/DefaultConnectClientTest.java
+++ b/ksql-engine/src/test/java/io/confluent/ksql/services/DefaultConnectClientTest.java
@@ -170,6 +170,23 @@ public class DefaultConnectClientTest {
   }
 
   @Test
+  public void testDelete() throws JsonProcessingException {
+    // Given:
+    WireMock.stubFor(
+        WireMock.delete(WireMock.urlEqualTo("/connectors/foo"))
+            .willReturn(WireMock.aResponse()
+                .withStatus(HttpStatus.SC_NO_CONTENT))
+    );
+
+    // When:
+    final ConnectResponse<String> response = client.delete("foo");
+
+    // Then:
+    assertThat(response.datum(), OptionalMatchers.of(is("foo")));
+    assertThat("Expected no error!", !response.error().isPresent());
+  }
+
+  @Test
   public void testListShouldRetryOnFailure() throws JsonProcessingException {
     // Given:
     WireMock.stubFor(

--- a/ksql-parser/src/main/antlr4/io/confluent/ksql/parser/SqlBase.g4
+++ b/ksql-parser/src/main/antlr4/io/confluent/ksql/parser/SqlBase.g4
@@ -63,6 +63,7 @@ statement
     | INSERT INTO qualifiedName (columns)? VALUES values                    #insertValues
     | DROP STREAM (IF EXISTS)? qualifiedName (DELETE TOPIC)?                #dropStream
     | DROP TABLE (IF EXISTS)? qualifiedName  (DELETE TOPIC)?                #dropTable
+    | DROP CONNECTOR identifier                                             #dropConnector
     | EXPLAIN  (statement | qualifiedName)                                  #explain
     | RUN SCRIPT STRING                                                     #runScript
     ;

--- a/ksql-parser/src/main/java/io/confluent/ksql/parser/AstBuilder.java
+++ b/ksql-parser/src/main/java/io/confluent/ksql/parser/AstBuilder.java
@@ -56,6 +56,7 @@ import io.confluent.ksql.metastore.MetaStore;
 import io.confluent.ksql.metastore.model.DataSource;
 import io.confluent.ksql.parser.SqlBaseParser.CreateConnectorContext;
 import io.confluent.ksql.parser.SqlBaseParser.DescribeConnectorContext;
+import io.confluent.ksql.parser.SqlBaseParser.DropConnectorContext;
 import io.confluent.ksql.parser.SqlBaseParser.InsertValuesContext;
 import io.confluent.ksql.parser.SqlBaseParser.IntervalClauseContext;
 import io.confluent.ksql.parser.SqlBaseParser.LimitClauseContext;
@@ -75,6 +76,7 @@ import io.confluent.ksql.parser.tree.CreateTable;
 import io.confluent.ksql.parser.tree.CreateTableAsSelect;
 import io.confluent.ksql.parser.tree.DescribeConnector;
 import io.confluent.ksql.parser.tree.DescribeFunction;
+import io.confluent.ksql.parser.tree.DropConnector;
 import io.confluent.ksql.parser.tree.DropStream;
 import io.confluent.ksql.parser.tree.DropTable;
 import io.confluent.ksql.parser.tree.Explain;
@@ -347,6 +349,14 @@ public class AstBuilder {
           ParserUtil.getQualifiedName(context.qualifiedName()),
           context.EXISTS() != null,
           context.DELETE() != null
+      );
+    }
+
+    @Override
+    public Node visitDropConnector(final DropConnectorContext context) {
+      return new DropConnector(
+          getLocation(context),
+          ParserUtil.getIdentifierText(context.identifier())
       );
     }
 

--- a/ksql-parser/src/main/java/io/confluent/ksql/parser/tree/DropConnector.java
+++ b/ksql-parser/src/main/java/io/confluent/ksql/parser/tree/DropConnector.java
@@ -1,0 +1,58 @@
+/*
+ * Copyright 2019 Confluent Inc.
+ *
+ * Licensed under the Confluent Community License (the "License"; you may not use
+ * this file except in compliance with the License. You may obtain a copy of the
+ * License at
+ *
+ * http://www.confluent.io/confluent-community-license
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package io.confluent.ksql.parser.tree;
+
+import io.confluent.ksql.parser.NodeLocation;
+import java.util.Objects;
+import java.util.Optional;
+
+public class DropConnector extends Statement {
+
+  private final String connectorName;
+
+  public DropConnector(final Optional<NodeLocation> location, final String connectorName) {
+    super(location);
+    this.connectorName = connectorName;
+  }
+
+  public String getConnectorName() {
+    return connectorName;
+  }
+
+  @Override
+  public boolean equals(final Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    final DropConnector that = (DropConnector) o;
+    return Objects.equals(connectorName, that.connectorName);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(connectorName);
+  }
+
+  @Override
+  public String toString() {
+    return "DropConnector{"
+        + "connectorName='" + connectorName + '\''
+        + '}';
+  }
+}

--- a/ksql-rest-app/src/main/java/io/confluent/ksql/rest/entity/DropConnectorEntity.java
+++ b/ksql-rest-app/src/main/java/io/confluent/ksql/rest/entity/DropConnectorEntity.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright 2019 Confluent Inc.
+ *
+ * Licensed under the Confluent Community License (the "License"; you may not use
+ * this file except in compliance with the License. You may obtain a copy of the
+ * License at
+ *
+ * http://www.confluent.io/confluent-community-license
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package io.confluent.ksql.rest.entity;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import java.util.Objects;
+
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class DropConnectorEntity extends KsqlEntity {
+
+  private final String connectorName;
+
+  public DropConnectorEntity(
+      @JsonProperty("statementText") final String statementText,
+      @JsonProperty("connectorName") final String connectorName
+  ) {
+    super(statementText);
+    this.connectorName = Objects.requireNonNull(connectorName, "connectorName");
+  }
+
+  public String getConnectorName() {
+    return connectorName;
+  }
+
+  @Override
+  public String toString() {
+    return "DropConnectorEntity{"
+        + "connectorName='" + connectorName + '\''
+        + '}';
+  }
+}

--- a/ksql-rest-app/src/main/java/io/confluent/ksql/rest/entity/KsqlEntity.java
+++ b/ksql-rest-app/src/main/java/io/confluent/ksql/rest/entity/KsqlEntity.java
@@ -44,6 +44,7 @@ import java.util.List;
     @JsonSubTypes.Type(value = FunctionDescriptionList.class, name = "describe_function"),
     @JsonSubTypes.Type(value = FunctionNameList.class, name = "function_names"),
     @JsonSubTypes.Type(value = CreateConnectorEntity.class, name = "connector_info"),
+    @JsonSubTypes.Type(value = DropConnectorEntity.class, name = "drop_connector"),
     @JsonSubTypes.Type(value = ConnectorList.class, name = "connector_list"),
     @JsonSubTypes.Type(value = ConnectorDescription.class, name = "connector_description"),
     @JsonSubTypes.Type(value = ErrorEntity.class, name = "error_entity")

--- a/ksql-rest-app/src/main/java/io/confluent/ksql/rest/server/execution/CustomExecutors.java
+++ b/ksql-rest-app/src/main/java/io/confluent/ksql/rest/server/execution/CustomExecutors.java
@@ -21,6 +21,7 @@ import io.confluent.ksql.engine.InsertValuesExecutor;
 import io.confluent.ksql.parser.tree.CreateConnector;
 import io.confluent.ksql.parser.tree.DescribeConnector;
 import io.confluent.ksql.parser.tree.DescribeFunction;
+import io.confluent.ksql.parser.tree.DropConnector;
 import io.confluent.ksql.parser.tree.Explain;
 import io.confluent.ksql.parser.tree.InsertValues;
 import io.confluent.ksql.parser.tree.ListConnectors;
@@ -67,6 +68,7 @@ public enum CustomExecutors {
   UNSET_PROPERTY(UnsetProperty.class, PropertyExecutor::unset),
   INSERT_VALUES(InsertValues.class, insertValuesExecutor()),
   CREATE_CONNECTOR(CreateConnector.class, ConnectExecutor::execute),
+  DROP_CONNECTOR(DropConnector.class, DropConnectorExecutor::execute),
   DESCRIBE_CONNECTOR(DescribeConnector.class, new DescribeConnectorExecutor()::execute)
   ;
 

--- a/ksql-rest-app/src/main/java/io/confluent/ksql/rest/server/execution/DropConnectorExecutor.java
+++ b/ksql-rest-app/src/main/java/io/confluent/ksql/rest/server/execution/DropConnectorExecutor.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright 2019 Confluent Inc.
+ *
+ * Licensed under the Confluent Community License (the "License"; you may not use
+ * this file except in compliance with the License. You may obtain a copy of the
+ * License at
+ *
+ * http://www.confluent.io/confluent-community-license
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package io.confluent.ksql.rest.server.execution;
+
+import io.confluent.ksql.KsqlExecutionContext;
+import io.confluent.ksql.parser.tree.DropConnector;
+import io.confluent.ksql.rest.entity.DropConnectorEntity;
+import io.confluent.ksql.rest.entity.ErrorEntity;
+import io.confluent.ksql.rest.entity.KsqlEntity;
+import io.confluent.ksql.services.ConnectClient.ConnectResponse;
+import io.confluent.ksql.services.ServiceContext;
+import io.confluent.ksql.statement.ConfiguredStatement;
+import java.util.Optional;
+
+public final class DropConnectorExecutor {
+
+  private DropConnectorExecutor() { }
+
+  public static Optional<KsqlEntity> execute(
+      final ConfiguredStatement<DropConnector> statement,
+      final KsqlExecutionContext executionContext,
+      final ServiceContext serviceContext
+  ) {
+    final String connectorName = statement.getStatement().getConnectorName();
+    final ConnectResponse<String> response =
+        serviceContext.getConnectClient().delete(connectorName);
+
+    if (response.error().isPresent()) {
+      return Optional.of(new ErrorEntity(statement.getStatementText(), response.error().get()));
+    }
+
+    return Optional.of(new DropConnectorEntity(statement.getStatementText(), connectorName));
+  }
+}

--- a/ksql-rest-app/src/main/java/io/confluent/ksql/rest/server/validation/CustomValidators.java
+++ b/ksql-rest-app/src/main/java/io/confluent/ksql/rest/server/validation/CustomValidators.java
@@ -21,6 +21,7 @@ import io.confluent.ksql.engine.InsertValuesExecutor;
 import io.confluent.ksql.parser.tree.CreateConnector;
 import io.confluent.ksql.parser.tree.DescribeConnector;
 import io.confluent.ksql.parser.tree.DescribeFunction;
+import io.confluent.ksql.parser.tree.DropConnector;
 import io.confluent.ksql.parser.tree.Explain;
 import io.confluent.ksql.parser.tree.InsertValues;
 import io.confluent.ksql.parser.tree.ListConnectors;
@@ -70,6 +71,7 @@ public enum CustomValidators {
   LIST_PROPERTIES(ListProperties.class, StatementValidator.NO_VALIDATION),
   LIST_CONNECTORS(ListConnectors.class, StatementValidator.NO_VALIDATION),
   CREATE_CONNECTOR(CreateConnector.class, StatementValidator.NO_VALIDATION),
+  DROP_CONNECTOR(DropConnector.class, StatementValidator.NO_VALIDATION),
 
   INSERT_VALUES(InsertValues.class, new InsertValuesExecutor()::execute),
   SHOW_COLUMNS(ShowColumns.class, ListSourceExecutor::columns),

--- a/ksql-rest-app/src/test/java/io/confluent/ksql/rest/server/execution/DescribeConnectorExecutorTest.java
+++ b/ksql-rest-app/src/test/java/io/confluent/ksql/rest/server/execution/DescribeConnectorExecutorTest.java
@@ -123,8 +123,8 @@ public class DescribeConnectorExecutorTest {
     when(source.getDataSourceType()).thenReturn(DataSourceType.KTABLE);
     when(source.getKeyField()).thenReturn(KeyField.none());
     when(source.getName()).thenReturn("source");
-    when(connectClient.status(CONNECTOR_NAME)).thenReturn(ConnectResponse.of(STATUS, HttpStatus.SC_OK));
-    when(connectClient.describe("connector")).thenReturn(ConnectResponse.of(INFO, HttpStatus.SC_OK));
+    when(connectClient.status(CONNECTOR_NAME)).thenReturn(ConnectResponse.success(STATUS, HttpStatus.SC_OK));
+    when(connectClient.describe("connector")).thenReturn(ConnectResponse.success(INFO, HttpStatus.SC_OK));
 
     when(connector.matches(any())).thenReturn(false);
     when(connector.matches("kafka-topic")).thenReturn(true);
@@ -160,7 +160,7 @@ public class DescribeConnectorExecutorTest {
   @Test
   public void shouldErrorIfConnectClientFailsStatus() {
     // Given:
-    when(connectClient.describe(any())).thenReturn(ConnectResponse.of("error", HttpStatus.SC_INTERNAL_SERVER_ERROR));
+    when(connectClient.describe(any())).thenReturn(ConnectResponse.failure("error", HttpStatus.SC_INTERNAL_SERVER_ERROR));
 
     // When:
     final Optional<KsqlEntity> entity = executor.execute(describeStatement, engine, serviceContext);
@@ -175,7 +175,7 @@ public class DescribeConnectorExecutorTest {
   @Test
   public void shouldErrorIfConnectClientFailsDescribe() {
     // Given:
-    when(connectClient.describe(any())).thenReturn(ConnectResponse.of("error", HttpStatus.SC_INTERNAL_SERVER_ERROR));
+    when(connectClient.describe(any())).thenReturn(ConnectResponse.failure("error", HttpStatus.SC_INTERNAL_SERVER_ERROR));
 
     // When:
     final Optional<KsqlEntity> entity = executor.execute(describeStatement, engine, serviceContext);

--- a/ksql-rest-app/src/test/java/io/confluent/ksql/rest/server/execution/ListConnectorsExecutorTest.java
+++ b/ksql-rest-app/src/test/java/io/confluent/ksql/rest/server/execution/ListConnectorsExecutorTest.java
@@ -69,16 +69,16 @@ public class ListConnectorsExecutorTest {
   public void setUp() {
     when(serviceContext.getConnectClient()).thenReturn(connectClient);
     when(connectClient.describe("connector"))
-        .thenReturn(ConnectResponse.of(INFO, HttpStatus.SC_OK));
+        .thenReturn(ConnectResponse.success(INFO, HttpStatus.SC_OK));
     when(connectClient.describe("connector2"))
-        .thenReturn(ConnectResponse.of("DANGER WILL ROBINSON.", HttpStatus.SC_NOT_FOUND));
+        .thenReturn(ConnectResponse.failure("DANGER WILL ROBINSON.", HttpStatus.SC_NOT_FOUND));
   }
 
   @Test
   public void shouldListValidConnector() {
     // Given:
     when(connectClient.connectors())
-        .thenReturn(ConnectResponse.of(ImmutableList.of("connector"), HttpStatus.SC_OK));
+        .thenReturn(ConnectResponse.success(ImmutableList.of("connector"), HttpStatus.SC_OK));
     final ConfiguredStatement<ListConnectors> statement = ConfiguredStatement.of(
         PreparedStatement.of("", new ListConnectors(Optional.empty(), Scope.ALL)),
         ImmutableMap.of(),
@@ -106,7 +106,7 @@ public class ListConnectorsExecutorTest {
   public void shouldFilterNonMatchingConnectors() {
     // Given:
     when(connectClient.connectors())
-        .thenReturn(ConnectResponse.of(ImmutableList.of("connector", "connector2"),
+        .thenReturn(ConnectResponse.success(ImmutableList.of("connector", "connector2"),
             HttpStatus.SC_OK));
     final ConfiguredStatement<ListConnectors> statement = ConfiguredStatement.of(
         PreparedStatement.of("", new ListConnectors(Optional.empty(), Scope.SINK)),
@@ -133,7 +133,7 @@ public class ListConnectorsExecutorTest {
   public void shouldListInvalidConnectorWithNoInfo() {
     // Given:
     when(connectClient.connectors())
-        .thenReturn(ConnectResponse.of(ImmutableList.of("connector2"), HttpStatus.SC_OK));
+        .thenReturn(ConnectResponse.success(ImmutableList.of("connector2"), HttpStatus.SC_OK));
     final ConfiguredStatement<ListConnectors> statement = ConfiguredStatement.of(
         PreparedStatement.of("", new ListConnectors(Optional.empty(), Scope.ALL)),
         ImmutableMap.of(),


### PR DESCRIPTION
### Description 
Pretty straightforward, `DROP CONNECTOR` will now delete a connector.

### Testing done 
- Unit Tests
- Local Testing

```
ksql> CREATE SOURCE CONNECTOR `jdbc-connector2` WITH("connector.class"='io.confluent.connect.jdbc.JdbcSourceConnector',"connection.url"='jdbc:postgresql://localhost:5432/almog.gavra',"mode"='bulk',"topic.prefix"='jdbc2-', "key"='username');

 Message
-----------------------------------
 Created connector jdbc-connector2
-----------------------------------
ksql> DROP CONNECTOR "jdbc-connector2";

 Message
-------------------------------------
 Dropped connector "jdbc-connector2"
-------------------------------------
```

### Reviewer checklist
- [ ] Ensure docs are updated if necessary. (eg. if a user visible feature is being added or changed).
- [ ] Ensure relevant issues are linked (description should include text like "Fixes #<issue number>")

