### PR TITLE
feat: improved error message and updated error code for PrintTopics command

### DIFF
--- a/ksql-engine/src/main/java/io/confluent/ksql/engine/AuthorizationTopicAccessValidator.java
+++ b/ksql-engine/src/main/java/io/confluent/ksql/engine/AuthorizationTopicAccessValidator.java
@@ -20,6 +20,7 @@ import io.confluent.ksql.metastore.MetaStore;
 import io.confluent.ksql.metastore.model.DataSource;
 import io.confluent.ksql.parser.tree.CreateAsSelect;
 import io.confluent.ksql.parser.tree.InsertInto;
+import io.confluent.ksql.parser.tree.PrintTopic;
 import io.confluent.ksql.parser.tree.Query;
 import io.confluent.ksql.parser.tree.Statement;
 import io.confluent.ksql.services.ServiceContext;
@@ -49,6 +50,8 @@ public class AuthorizationTopicAccessValidator implements TopicAccessValidator {
       validateInsertInto(serviceContext, metaStore, (InsertInto)statement);
     } else if (statement instanceof CreateAsSelect) {
       validateCreateAsSelect(serviceContext, metaStore, (CreateAsSelect)statement);
+    } else if (statement instanceof PrintTopic) {
+      validatePrintTopic(serviceContext, (PrintTopic)statement);
     }
   }
 
@@ -100,6 +103,13 @@ public class AuthorizationTopicAccessValidator implements TopicAccessValidator {
 
     final String kafkaTopic = getSourceTopicName(metaStore, insertInto.getTarget().getSuffix());
     checkAccess(serviceContext, kafkaTopic, AclOperation.WRITE);
+  }
+
+  private void validatePrintTopic(
+          final ServiceContext serviceContext,
+          final PrintTopic printTopic
+  ) {
+    checkAccess(serviceContext, printTopic.getTopic().toString(), AclOperation.READ);
   }
 
   private String getSourceTopicName(final MetaStore metaStore, final String streamOrTable) {

--- a/ksql-engine/src/test/java/io/confluent/ksql/engine/AuthorizationTopicAccessValidatorTest.java
+++ b/ksql-engine/src/test/java/io/confluent/ksql/engine/AuthorizationTopicAccessValidatorTest.java
@@ -60,6 +60,8 @@ public class AuthorizationTopicAccessValidatorTest {
 
   private static final String STREAM_TOPIC_1 = "s1";
   private static final String STREAM_TOPIC_2 = "s2";
+  private final static String TOPIC_NAME_1 = "topic1";
+  private final static String TOPIC_NAME_2 = "topic2";
 
   @Mock
   private ServiceContext serviceContext;
@@ -76,8 +78,6 @@ public class AuthorizationTopicAccessValidatorTest {
   private TopicAccessValidator accessValidator;
   private KsqlEngine ksqlEngine;
   private MutableMetaStore metaStore;
-  private final static String topicName1 = "topic1";
-  private final static String topicName2 = "topic2";
 
   @Before
   public void setUp() {
@@ -87,10 +87,10 @@ public class AuthorizationTopicAccessValidatorTest {
     accessValidator = new AuthorizationTopicAccessValidator();
     when(serviceContext.getTopicClient()).thenReturn(kafkaTopicClient);
 
-    givenTopic(topicName1, TOPIC_1);
+    givenTopic(TOPIC_NAME_1, TOPIC_1);
     givenStreamWithTopic(STREAM_TOPIC_1, TOPIC_1);
 
-    givenTopic(topicName2, TOPIC_2);
+    givenTopic(TOPIC_NAME_2, TOPIC_2);
     givenStreamWithTopic(STREAM_TOPIC_2, TOPIC_2);
   }
 
@@ -130,7 +130,7 @@ public class AuthorizationTopicAccessValidatorTest {
   }
 
   @Test
-  public void shouldSingleSelectWithoutReadPermissionsDenied() {
+  public void shouldThrowWhenSingleSelectWithoutReadPermissionsDenied() {
     // Given:
     givenTopicPermissions(TOPIC_1, Collections.emptySet());
     final Statement statement = givenStatement(String.format(
@@ -164,7 +164,7 @@ public class AuthorizationTopicAccessValidatorTest {
   }
 
   @Test
-  public void shouldJoinSelectWithoutReadPermissionsDenied() {
+  public void shouldThrowWhenJoinSelectWithoutReadPermissionsDenied() {
     // Given:
     givenTopicPermissions(TOPIC_1, Collections.singleton(AclOperation.WRITE));
     givenTopicPermissions(TOPIC_2, Collections.singleton(AclOperation.WRITE));
@@ -183,7 +183,7 @@ public class AuthorizationTopicAccessValidatorTest {
   }
 
   @Test
-  public void shouldJoinWithOneRightTopicWithReadPermissionsDenied() {
+  public void shouldThrowWhenJoinWithOneRightTopicWithReadPermissionsDenied() {
     // Given:
     givenTopicPermissions(TOPIC_1, Collections.singleton(AclOperation.READ));
     givenTopicPermissions(TOPIC_2, Collections.singleton(AclOperation.WRITE));
@@ -202,7 +202,7 @@ public class AuthorizationTopicAccessValidatorTest {
   }
 
   @Test
-  public void shouldJoinWitOneLeftTopicWithReadPermissionsDenied() {
+  public void shouldThrowWhenJoinWitOneLeftTopicWithReadPermissionsDenied() {
     // Given:
     givenTopicPermissions(TOPIC_1, Collections.singleton(AclOperation.WRITE));
     givenTopicPermissions(TOPIC_2, Collections.singleton(AclOperation.READ));
@@ -237,7 +237,7 @@ public class AuthorizationTopicAccessValidatorTest {
   }
 
   @Test
-  public void shouldInsertIntoWithOnlyReadPermissionsDenied() {
+  public void shouldThrowWhenInsertIntoWithOnlyReadPermissionsDenied() {
     // Given:
     givenTopicPermissions(TOPIC_1, Collections.singleton(AclOperation.READ));
     givenTopicPermissions(TOPIC_2, Collections.singleton(AclOperation.READ));
@@ -256,7 +256,7 @@ public class AuthorizationTopicAccessValidatorTest {
   }
 
   @Test
-  public void shouldInsertIntoWithOnlyWritePermissionsDenied() {
+  public void shouldThrowWhenInsertIntoWithOnlyWritePermissionsDenied() {
     // Given:
     givenTopicPermissions(TOPIC_1, Collections.singleton(AclOperation.WRITE));
     givenTopicPermissions(TOPIC_2, Collections.singleton(AclOperation.WRITE));
@@ -275,7 +275,7 @@ public class AuthorizationTopicAccessValidatorTest {
   }
 
   @Test
-  public void shouldCreateAsSelectWithoutReadPermissionsDenied() {
+  public void shouldThrowWhenCreateAsSelectWithoutReadPermissionsDenied() {
     // Given:
     givenTopicPermissions(TOPIC_1, Collections.emptySet());
     final Statement statement = givenStatement(String.format(
@@ -309,7 +309,7 @@ public class AuthorizationTopicAccessValidatorTest {
   }
 
   @Test
-  public void shouldCreateAsSelectExistingStreamWithoutWritePermissionsDenied() {
+  public void shouldThrowWhenCreateAsSelectExistingStreamWithoutWritePermissionsDenied() {
     // Given:
     givenTopicPermissions(TOPIC_1, Collections.singleton(AclOperation.READ));
     givenTopicPermissions(TOPIC_2, Collections.singleton(AclOperation.READ));
@@ -349,7 +349,7 @@ public class AuthorizationTopicAccessValidatorTest {
   public void shouldPrintTopicWithReadPermissionsAllowed() {
     // Given:
     givenTopicPermissions(TOPIC_1, Collections.singleton(AclOperation.READ));
-    final Statement statement = givenStatement(String.format("Print '%s';", topicName1));
+    final Statement statement = givenStatement(String.format("Print '%s';", TOPIC_NAME_1));
 
     // When:
     accessValidator.validate(serviceContext, metaStore, statement);
@@ -359,10 +359,10 @@ public class AuthorizationTopicAccessValidatorTest {
   }
 
   @Test
-  public void shouldPrintTopicWithoutReadPermissionsDenied() {
+  public void shouldThrowWhenThrowPrintTopicWithoutReadPermissionsDenied() {
     // Given:
     givenTopicPermissions(TOPIC_1, Collections.emptySet());
-    final Statement statement = givenStatement(String.format("Print '%s';", topicName1));
+    final Statement statement = givenStatement(String.format("Print '%s';", TOPIC_NAME_1));
 
     // Then:
     expectedException.expect(KsqlTopicAuthorizationException.class);

--- a/ksql-rest-app/src/main/java/io/confluent/ksql/rest/server/resources/streaming/StreamedQueryResource.java
+++ b/ksql-rest-app/src/main/java/io/confluent/ksql/rest/server/resources/streaming/StreamedQueryResource.java
@@ -129,6 +129,12 @@ public class StreamedQueryResource {
       final PreparedStatement<?> statement
   ) throws Exception {
     try {
+      topicAccessValidator.validate(
+          serviceContext,
+          ksqlEngine.getMetaStore(),
+          statement.getStatement()
+      );
+
       if (statement.getStatement() instanceof Query) {
         return handleQuery(
             serviceContext,
@@ -162,12 +168,6 @@ public class StreamedQueryResource {
   ) throws Exception {
     final ConfiguredStatement<Query> configured =
         ConfiguredStatement.of(statement, streamsProperties, ksqlConfig);
-
-    topicAccessValidator.validate(
-        serviceContext,
-        ksqlEngine.getMetaStore(),
-        statement.getStatement()
-    );
 
     final QueryMetadata query = ksqlEngine.execute(serviceContext, configured)
         .getQuery()

--- a/ksql-rest-app/src/test/java/io/confluent/ksql/rest/server/resources/StreamedQueryResourceTest.java
+++ b/ksql-rest-app/src/test/java/io/confluent/ksql/rest/server/resources/StreamedQueryResourceTest.java
@@ -448,27 +448,24 @@ public class StreamedQueryResourceTest {
   @Test
   public void shouldReturnForbiddenKafkaAccessIfKsqlTopicAuthorizationException() throws Exception {
     // Given:
-    reset(mockStatementParser);
+    reset(mockStatementParser, topicAccessValidator);
+
     statement = PreparedStatement.of("query", mock(Query.class));
     expect(mockStatementParser.parseSingleStatement(queryString))
-            .andReturn(statement);
-
-    replay(mockStatementParser);
-
-    reset(topicAccessValidator);
+        .andReturn(statement);
     topicAccessValidator.validate(anyObject(), anyObject(), anyObject());
     expectLastCall().andThrow(
         new KsqlTopicAuthorizationException(AclOperation.READ, Collections.singleton(topicName)));
 
-    replay(topicAccessValidator);
+    replay(mockStatementParser, topicAccessValidator);
 
     // When:
-    Response response = testResource.streamQuery(
+    final Response response = testResource.streamQuery(
         serviceContext,
         new KsqlRequest(queryString, Collections.emptyMap(), null)
     );
 
-    Response expected = Errors.accessDeniedFromKafka(
+    final Response expected = Errors.accessDeniedFromKafka(
         new KsqlTopicAuthorizationException(AclOperation.READ, Collections.singleton(topicName)));
 
     assertEquals(response.getStatus(), expected.getStatus());
@@ -478,14 +475,11 @@ public class StreamedQueryResourceTest {
   @Test
   public void shouldReturnForbiddenKafkaAccessIfRootCauseKsqlTopicAuthorizationException() throws Exception {
     // Given:
-    reset(mockStatementParser);
+    reset(mockStatementParser, topicAccessValidator);
+
     statement = PreparedStatement.of("query", mock(Query.class));
     expect(mockStatementParser.parseSingleStatement(queryString))
         .andReturn(statement);
-
-    replay(mockStatementParser);
-
-    reset(topicAccessValidator);
     topicAccessValidator.validate(anyObject(), anyObject(), anyObject());
     expectLastCall().andThrow(
         new KsqlException(
@@ -493,15 +487,15 @@ public class StreamedQueryResourceTest {
             new KsqlTopicAuthorizationException(AclOperation.READ, Collections.singleton(topicName)
     )));
 
-    replay(topicAccessValidator);
+    replay(mockStatementParser, topicAccessValidator);
 
     // When:
-    Response response = testResource.streamQuery(
+    final Response response = testResource.streamQuery(
         serviceContext,
         new KsqlRequest(queryString, Collections.emptyMap(), null)
     );
 
-    Response expected = Errors.accessDeniedFromKafka(
+    final Response expected = Errors.accessDeniedFromKafka(
         new KsqlException(
             "",
             new KsqlTopicAuthorizationException(AclOperation.READ, Collections.singleton(topicName))));
@@ -513,27 +507,24 @@ public class StreamedQueryResourceTest {
   @Test
   public void shouldReturnForbiddenKafkaAccessIfPrintTopicKsqlTopicAuthorizationException() throws Exception {
     // Given:
-    reset(mockStatementParser);
+    reset(mockStatementParser, topicAccessValidator);
+
     statement = PreparedStatement.of("print", mock(PrintTopic.class));
     expect(mockStatementParser.parseSingleStatement(printString))
         .andReturn(statement);
-
-    replay(mockStatementParser);
-
-    reset(topicAccessValidator);
     topicAccessValidator.validate(anyObject(), anyObject(), anyObject());
     expectLastCall().andThrow(
         new KsqlTopicAuthorizationException(AclOperation.READ, Collections.singleton(topicName)));
 
-    replay(topicAccessValidator);
+    replay(mockStatementParser, topicAccessValidator);
 
     // When:
-    Response response = testResource.streamQuery(
+    final Response response = testResource.streamQuery(
         serviceContext,
         new KsqlRequest(printString, Collections.emptyMap(), null)
     );
 
-    Response expected = Errors.accessDeniedFromKafka(
+    final Response expected = Errors.accessDeniedFromKafka(
         new KsqlTopicAuthorizationException(AclOperation.READ, Collections.singleton(topicName)));
 
     assertEquals(response.getStatus(), expected.getStatus());


### PR DESCRIPTION
### Description 
`print <topic>` returns a 200 response with a not too specific error message when trying to print a topic the user doesn't have Read permissions for. Updated to return 403 response, 40301 error code, and a more specific error message.

Old response
`Not authorized to access topics: [qwerqwerqwerqwerqtly]`

New response
```
{
    "@type": "generic_error",
    "error_code": 40301,
    "message": "Authorization denied to Read on topic(s): [qwerqwerqwerqwerqtly]",
    "stackTrace": []
}
```
### Testing done 
Unit test
Local testing
### Reviewer checklist
- [ ] Ensure docs are updated if necessary. (eg. if a user visible feature is being added or changed).
- [ ] Ensure relevant issues are linked (description should include text like "Fixes #<issue number>")

