### PR TITLE
test: allow concurrent instances of KSQL to run in tests

### DIFF
--- a/ksql-engine/src/main/java/io/confluent/ksql/KsqlContext.java
+++ b/ksql-engine/src/main/java/io/confluent/ksql/KsqlContext.java
@@ -53,7 +53,7 @@ import java.util.stream.Collectors;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-public class KsqlContext {
+public class KsqlContext implements AutoCloseable {
 
   private static final Logger LOG = LoggerFactory.getLogger(KsqlContext.class);
 
@@ -171,7 +171,7 @@ public class KsqlContext {
     ksqlEngine.getPersistentQuery(queryId).ifPresent(QueryMetadata::close);
   }
 
-  private ExecuteResult execute(
+  private static ExecuteResult execute(
       final KsqlExecutionContext executionContext,
       final ParsedStatement stmt,
       final KsqlConfig ksqlConfig,

--- a/ksql-engine/src/main/java/io/confluent/ksql/ServiceInfo.java
+++ b/ksql-engine/src/main/java/io/confluent/ksql/ServiceInfo.java
@@ -24,15 +24,31 @@ import java.util.Optional;
 public final class ServiceInfo {
 
   private final String serviceId;
+  private final String metricsPrefix;
   private final Map<String, String> customMetricsTags;
   private final Optional<KsqlMetricsExtension> metricsExtension;
 
   /**
-   * Create an object to be passed from the KSQL context down to the KSQL engine.
+   * Create ServiceInfo required by KSQL engine.
+   *
+   * @param ksqlConfig the server config.
+   * @return new instance.
    */
   public static ServiceInfo create(final KsqlConfig ksqlConfig) {
-    Objects.requireNonNull(ksqlConfig, "ksqlConfig cannot be null.");
+    return create(ksqlConfig, "");
+  }
 
+  /**
+   * Create ServiceInfo required by KSQL engine.
+   *
+   * @param ksqlConfig the server config.
+   * @param metricsPrefix optional prefix for metrics group names. Default is empty string.
+   * @return new instance.
+   */
+  public static ServiceInfo create(
+      final KsqlConfig ksqlConfig,
+      final String metricsPrefix
+  ) {
     final String serviceId = ksqlConfig.getString(KsqlConfig.KSQL_SERVICE_ID_CONFIG);
     final Map<String, String> customMetricsTags =
         ksqlConfig.getStringAsMap(KsqlConfig.KSQL_CUSTOM_METRICS_TAGS);
@@ -42,17 +58,19 @@ public final class ServiceInfo {
             KsqlMetricsExtension.class
         ));
 
-    return new ServiceInfo(serviceId, customMetricsTags, metricsExtension);
+    return new ServiceInfo(serviceId, customMetricsTags, metricsExtension, metricsPrefix);
   }
 
   private ServiceInfo(
       final String serviceId,
       final Map<String, String> customMetricsTags,
-      final Optional<KsqlMetricsExtension> metricsExtension
+      final Optional<KsqlMetricsExtension> metricsExtension,
+      final String metricsPrefix
   ) {
     this.serviceId = Objects.requireNonNull(serviceId, "serviceId");
     this.customMetricsTags = Objects.requireNonNull(customMetricsTags, "customMetricsTags");
     this.metricsExtension = Objects.requireNonNull(metricsExtension, "metricsExtension");
+    this.metricsPrefix = Objects.requireNonNull(metricsPrefix, "metricsPrefix");
   }
 
   public String serviceId() {
@@ -65,5 +83,9 @@ public final class ServiceInfo {
 
   public Optional<KsqlMetricsExtension> metricsExtension() {
     return metricsExtension;
+  }
+
+  public String metricsPrefix() {
+    return metricsPrefix;
   }
 }

--- a/ksql-engine/src/main/java/io/confluent/ksql/engine/KsqlEngine.java
+++ b/ksql-engine/src/main/java/io/confluent/ksql/engine/KsqlEngine.java
@@ -75,7 +75,11 @@ public class KsqlEngine implements KsqlExecutionContext, Closeable {
         serviceInfo.serviceId(),
         new MetaStoreImpl(functionRegistry),
         (engine) -> new KsqlEngineMetrics(
-            engine, serviceInfo.customMetricsTags(), serviceInfo.metricsExtension()));
+            serviceInfo.metricsPrefix(),
+            engine,
+            serviceInfo.customMetricsTags(),
+            serviceInfo.metricsExtension()
+        ));
   }
 
   KsqlEngine(

--- a/ksql-engine/src/main/java/io/confluent/ksql/internal/QueryStateListener.java
+++ b/ksql-engine/src/main/java/io/confluent/ksql/internal/QueryStateListener.java
@@ -30,13 +30,15 @@ public class QueryStateListener implements StateListener {
 
   QueryStateListener(
       final Metrics metrics,
+      final String groupPrefix,
       final String queryApplicationId
   ) {
+    Objects.requireNonNull(groupPrefix, "groupPrefix");
     Objects.requireNonNull(queryApplicationId, "queryApplicationId");
     this.metrics = Objects.requireNonNull(metrics, "metrics cannot be null.");
     this.metricName = metrics.metricName(
         "query-status",
-        "ksql-queries",
+        groupPrefix + "ksql-queries",
         "The current status of the given query.",
         Collections.singletonMap("status", queryApplicationId));
 

--- a/ksql-engine/src/test/java/io/confluent/ksql/KsqlContextTestUtil.java
+++ b/ksql-engine/src/test/java/io/confluent/ksql/KsqlContextTestUtil.java
@@ -26,11 +26,14 @@ import io.confluent.ksql.services.ServiceContext;
 import io.confluent.ksql.services.TestServiceContext;
 import io.confluent.ksql.statement.Injectors;
 import io.confluent.ksql.util.KsqlConfig;
+import java.util.concurrent.atomic.AtomicInteger;
 import org.apache.kafka.clients.admin.Admin;
 import org.apache.kafka.streams.KafkaClientSupplier;
 import org.apache.kafka.streams.processor.internals.DefaultKafkaClientSupplier;
 
 public final class KsqlContextTestUtil {
+
+  private static final AtomicInteger COUNTER = new AtomicInteger();
 
   private KsqlContextTestUtil() {
   }
@@ -55,11 +58,13 @@ public final class KsqlContextTestUtil {
         new DefaultConnectClient(ksqlConfig.getString(KsqlConfig.CONNECT_URL_PROPERTY))
     );
 
+    final String metricsPrefix = "instance-" + COUNTER.getAndIncrement() + "-";
+
     final KsqlEngine engine = new KsqlEngine(
         serviceContext,
         ProcessingLogContext.create(),
         functionRegistry,
-        ServiceInfo.create(ksqlConfig)
+        ServiceInfo.create(ksqlConfig, metricsPrefix)
     );
 
     return new KsqlContext(

--- a/ksql-engine/src/test/java/io/confluent/ksql/KsqlContextTestUtilTest.java
+++ b/ksql-engine/src/test/java/io/confluent/ksql/KsqlContextTestUtilTest.java
@@ -1,0 +1,63 @@
+/*
+ * Copyright 2019 Confluent Inc.
+ *
+ * Licensed under the Confluent Community License (the "License"); you may not use
+ * this file except in compliance with the License.  You may obtain a copy of the
+ * License at
+ *
+ * http://www.confluent.io/confluent-community-license
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package io.confluent.ksql;
+
+import com.google.common.collect.ImmutableMap;
+import io.confluent.kafka.schemaregistry.client.SchemaRegistryClient;
+import io.confluent.ksql.function.FunctionRegistry;
+import io.confluent.ksql.query.QueryId;
+import io.confluent.ksql.util.KsqlConfig;
+import org.apache.kafka.clients.CommonClientConfigs;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnitRunner;
+
+@RunWith(MockitoJUnitRunner.class)
+public class KsqlContextTestUtilTest {
+
+  private static final KsqlConfig BASE_CONFIG = new KsqlConfig(ImmutableMap.of(
+      CommonClientConfigs.BOOTSTRAP_SERVERS_CONFIG, "localhost:10"
+  ));
+
+  @Mock
+  private SchemaRegistryClient srClient;
+  @Mock
+  private FunctionRegistry functionRegistry;
+
+  @SuppressWarnings("unused")
+  @Test
+  public void shouldBeAbleToHaveTwoInstancesWithDifferentNames() {
+    // Given:
+    try (KsqlContext first = KsqlContextTestUtil.create(
+        BASE_CONFIG,
+        srClient,
+        functionRegistry
+    )) {
+      first.terminateQuery(new QueryId("avoid compiler warning"));
+
+      // When:
+      KsqlContext second = KsqlContextTestUtil.create(
+          BASE_CONFIG,
+          srClient,
+          functionRegistry
+      );
+
+      // Then: did not throw due to metrics name clash.
+      second.close();
+    }
+  }
+}

--- a/ksql-engine/src/test/java/io/confluent/ksql/engine/KsqlEngineTestUtil.java
+++ b/ksql-engine/src/test/java/io/confluent/ksql/engine/KsqlEngineTestUtil.java
@@ -50,7 +50,7 @@ public final class KsqlEngineTestUtil {
         ProcessingLogContext.create(),
         "test_instance_",
         metaStore,
-        (engine) -> new KsqlEngineMetrics(engine, Collections.emptyMap(), Optional.empty())
+        (engine) -> new KsqlEngineMetrics("", engine, Collections.emptyMap(), Optional.empty())
     );
   }
 

--- a/ksql-engine/src/test/java/io/confluent/ksql/integration/TestKsqlContext.java
+++ b/ksql-engine/src/test/java/io/confluent/ksql/integration/TestKsqlContext.java
@@ -31,6 +31,9 @@ import java.util.Map;
 import java.util.Objects;
 import org.junit.rules.ExternalResource;
 
+/**
+ * Junit external resource for managing an instance of {@link KsqlContext}.
+ */
 public final class TestKsqlContext extends ExternalResource {
 
   private final IntegrationTestHarness testHarness;

--- a/ksql-engine/src/test/java/io/confluent/ksql/internal/QueryStateListenerTest.java
+++ b/ksql-engine/src/test/java/io/confluent/ksql/internal/QueryStateListenerTest.java
@@ -22,6 +22,7 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyMap;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.ArgumentMatchers.isA;
+import static org.mockito.Mockito.clearInvocations;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
@@ -55,7 +56,7 @@ public class QueryStateListenerTest {
   public void setUp() {
     when(metrics.metricName(any(), any(), any(), anyMap())).thenReturn(METRIC_NAME);
 
-    listener = new QueryStateListener(metrics, "app-id");
+    listener = new QueryStateListener(metrics, "", "app-id");
   }
 
   @Test
@@ -74,6 +75,22 @@ public class QueryStateListenerTest {
         ImmutableMap.of("status", "app-id"));
 
     verify(metrics).addMetric(eq(METRIC_NAME), isA(Gauge.class));
+  }
+
+  @Test
+  public void shouldAddMetricWithSuppliedPrefix() {
+    // Given:
+    final String groupPrefix = "some-prefix-";
+
+    clearInvocations(metrics);
+
+    // When:
+    listener = new QueryStateListener(metrics, groupPrefix, "app-id");
+
+    // Then:
+    verify(metrics).metricName("query-status", groupPrefix + "ksql-queries",
+        "The current status of the given query.",
+        ImmutableMap.of("status", "app-id"));
   }
 
   @Test

--- a/ksql-rest-app/src/main/java/io/confluent/ksql/rest/server/KsqlRestApplication.java
+++ b/ksql-rest-app/src/main/java/io/confluent/ksql/rest/server/KsqlRestApplication.java
@@ -309,7 +309,7 @@ public final class KsqlRestApplication extends Application<KsqlRestConfig> imple
     }
   }
 
-  public List<URL> getListeners() {
+  List<URL> getListeners() {
     return Arrays.stream(server.getConnectors())
         .filter(connector -> connector instanceof ServerConnector)
         .map(ServerConnector.class::cast)
@@ -353,6 +353,7 @@ public final class KsqlRestApplication extends Application<KsqlRestConfig> imple
     );
   }
 
+  @SuppressWarnings("UnstableApiUsage")
   @Override
   protected void registerWebSocketEndpoints(final ServerContainer container) {
     try {
@@ -403,24 +404,25 @@ public final class KsqlRestApplication extends Application<KsqlRestConfig> imple
     }
   }
 
-  public static KsqlRestApplication buildApplication(
+  static KsqlRestApplication buildApplication(
       final KsqlRestConfig restConfig,
-      final Function<Supplier<Boolean>, VersionCheckerAgent> versionCheckerFactory,
-      final int maxStatementRetries
+      final Function<Supplier<Boolean>, VersionCheckerAgent> versionCheckerFactory
   ) {
     final KsqlConfig ksqlConfig = new KsqlConfig(restConfig.getKsqlConfigProperties());
     final ServiceContext serviceContext
         = new LazyServiceContext(() -> ServiceContextFactory.create(ksqlConfig));
 
     return buildApplication(
+        "",
         restConfig,
         versionCheckerFactory,
-        maxStatementRetries,
+        Integer.MAX_VALUE,
         serviceContext,
         KsqlRestServiceContextBinder::new);
   }
 
   static KsqlRestApplication buildApplication(
+      final String metricsPrefix,
       final KsqlRestConfig restConfig,
       final Function<Supplier<Boolean>, VersionCheckerAgent> versionCheckerFactory,
       final int maxStatementRetries,
@@ -442,7 +444,8 @@ public final class KsqlRestApplication extends Application<KsqlRestConfig> imple
         serviceContext,
         processingLogContext,
         functionRegistry,
-        ServiceInfo.create(ksqlConfig));
+        ServiceInfo.create(ksqlConfig, metricsPrefix)
+    );
 
     UdfLoader.newInstance(ksqlConfig, functionRegistry, ksqlInstallDir).load();
 
@@ -596,7 +599,7 @@ public final class KsqlRestApplication extends Application<KsqlRestConfig> imple
     writer.flush();
   }
 
-  static void maybeCreateProcessingLogStream(
+  private static void maybeCreateProcessingLogStream(
       final ProcessingLogConfig config,
       final KsqlConfig ksqlConfig,
       final KsqlEngine ksqlEngine,

--- a/ksql-rest-app/src/main/java/io/confluent/ksql/rest/server/KsqlServerMain.java
+++ b/ksql-rest-app/src/main/java/io/confluent/ksql/rest/server/KsqlServerMain.java
@@ -93,8 +93,7 @@ public class KsqlServerMain {
     final KsqlRestConfig restConfig = new KsqlRestConfig(ensureValidProps(properties));
     return KsqlRestApplication.buildApplication(
         restConfig,
-        KsqlVersionCheckerAgent::new,
-        Integer.MAX_VALUE
+        KsqlVersionCheckerAgent::new
     );
   }
 

--- a/ksql-rest-app/src/test/java/io/confluent/ksql/rest/server/TestKsqlRestApp.java
+++ b/ksql-rest-app/src/test/java/io/confluent/ksql/rest/server/TestKsqlRestApp.java
@@ -51,6 +51,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Set;
+import java.util.concurrent.atomic.AtomicInteger;
 import java.util.function.BiFunction;
 import java.util.function.Supplier;
 import java.util.stream.Collectors;
@@ -62,8 +63,7 @@ import org.glassfish.hk2.utilities.Binder;
 import org.junit.rules.ExternalResource;
 
 /**
- * Junit external resource for managing an instance of
- * {@link io.confluent.ksql.rest.server.KsqlRestApplication}.
+ * Junit external resource for managing an instance of {@link KsqlRestApplication}.
  *
  * Generally used in conjunction with {@link EmbeddedSingleNodeKafkaCluster}
  *
@@ -80,6 +80,9 @@ import org.junit.rules.ExternalResource;
  */
 public class TestKsqlRestApp extends ExternalResource {
 
+  private static final AtomicInteger COUNTER = new AtomicInteger();
+
+  private final String metricsPrefix = "app-" + COUNTER.getAndIncrement() + "-";
   private final Map<String, ?> baseConfig;
   private final Supplier<String> bootstrapServers;
   private final Supplier<ServiceContext> serviceContext;
@@ -91,8 +94,8 @@ public class TestKsqlRestApp extends ExternalResource {
       final Supplier<String> bootstrapServers,
       final Map<String, Object> additionalProps,
       final Supplier<ServiceContext> serviceContext,
-      final BiFunction<KsqlConfig, KsqlSecurityExtension, Binder>  serviceContextBinderFactory) {
-
+      final BiFunction<KsqlConfig, KsqlSecurityExtension, Binder> serviceContextBinderFactory
+  ) {
     this.baseConfig = buildBaseConfig(additionalProps);
     this.bootstrapServers = Objects.requireNonNull(bootstrapServers, "bootstrapServers");
     this.serviceContext = Objects.requireNonNull(serviceContext, "serviceContext");
@@ -100,10 +103,12 @@ public class TestKsqlRestApp extends ExternalResource {
         .requireNonNull(serviceContextBinderFactory, "serviceContextBinderFactory");
   }
 
+  @SuppressWarnings("WeakerAccess") // Part of public API
   public List<URL> getListeners() {
     return this.listeners;
   }
 
+  @SuppressWarnings("unused") // Part of public API
   public Map<String, ?> getBaseConfig() {
     return Collections.unmodifiableMap(this.baseConfig);
   }
@@ -201,6 +206,7 @@ public class TestKsqlRestApp extends ExternalResource {
 
     try {
       restServer = KsqlRestApplication.buildApplication(
+          metricsPrefix,
           buildConfig(bootstrapServers, baseConfig),
           (booleanSupplier) -> niceMock(VersionCheckerAgent.class),
           3,

--- a/ksql-rest-app/src/test/java/io/confluent/ksql/rest/server/TestKsqlRestAppTest.java
+++ b/ksql-rest-app/src/test/java/io/confluent/ksql/rest/server/TestKsqlRestAppTest.java
@@ -1,0 +1,50 @@
+/*
+ * Copyright 2019 Confluent Inc.
+ *
+ * Licensed under the Confluent Community License (the "License"); you may not use
+ * this file except in compliance with the License.  You may obtain a copy of the
+ * License at
+ *
+ * http://www.confluent.io/confluent-community-license
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package io.confluent.ksql.rest.server;
+
+import io.confluent.ksql.integration.IntegrationTestHarness;
+import org.junit.ClassRule;
+import org.junit.Test;
+
+public class TestKsqlRestAppTest {
+
+  @ClassRule
+  public static final IntegrationTestHarness TEST_HARNESS = IntegrationTestHarness.build();
+
+  @Test
+  public void shouldBeAbleToHaveTwoInstancesWithDifferentNames() {
+    // Given:
+    final TestKsqlRestApp first = TestKsqlRestApp
+        .builder(TEST_HARNESS::kafkaBootstrapServers)
+        .build();
+
+    final TestKsqlRestApp second = TestKsqlRestApp
+        .builder(TEST_HARNESS::kafkaBootstrapServers)
+        .build();
+
+    first.start();
+
+    try {
+      // When:
+      second.start();
+
+      // Then: did not throw due to metrics name clash.
+    } finally {
+      first.stop();
+      second.stop();
+    }
+  }
+}


### PR DESCRIPTION
### Description 

Previously starting a second instance of KSQL in a test would result in a clash on the metrics name. This is now avoided by providing a unique metrics group name prefix per test instance.

The default naming remains the same.

This is needed to allow future tests to run multiple instances, e.g. to test routing between instances for point queries work.

### Testing done 

Suitable tests added.

`mvn test`

### Reviewer checklist
- [ ] Ensure docs are updated if necessary. (eg. if a user visible feature is being added or changed).
- [ ] Ensure relevant issues are linked (description should include text like "Fixes #<issue number>")

