### PR TITLE
refactor: remove dead code (MINOR)

### DIFF
--- a/ksql-engine/src/main/java/io/confluent/ksql/engine/KsqlEngine.java
+++ b/ksql-engine/src/main/java/io/confluent/ksql/engine/KsqlEngine.java
@@ -47,7 +47,6 @@ import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.Executors;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.TimeUnit;
-import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.function.Function;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -56,7 +55,6 @@ public class KsqlEngine implements KsqlExecutionContext, Closeable {
 
   private static final Logger log = LoggerFactory.getLogger(KsqlEngine.class);
 
-  private final AtomicBoolean acceptingStatements = new AtomicBoolean(true);
   private final Set<QueryMetadata> allLiveQueries = ConcurrentHashMap.newKeySet();
   private final KsqlEngineMetrics engineMetrics;
   private final ScheduledExecutorService aggregateMetricsCollector;
@@ -137,14 +135,6 @@ public class KsqlEngine implements KsqlExecutionContext, Closeable {
 
   public String getServiceId() {
     return serviceId;
-  }
-
-  public void stopAcceptingStatements() {
-    acceptingStatements.set(false);
-  }
-
-  public boolean isAcceptingStatements() {
-    return acceptingStatements.get();
   }
 
   @Override

--- a/ksql-rest-app/src/test/java/io/confluent/ksql/rest/server/resources/StreamedQueryResourceTest.java
+++ b/ksql-rest-app/src/test/java/io/confluent/ksql/rest/server/resources/StreamedQueryResourceTest.java
@@ -76,7 +76,6 @@ import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.Consumer;
 import javax.ws.rs.core.Response;
 import javax.ws.rs.core.StreamingOutput;
-
 import org.apache.kafka.common.acl.AclOperation;
 import org.apache.kafka.connect.data.SchemaBuilder;
 import org.apache.kafka.streams.KafkaStreams;
@@ -131,7 +130,6 @@ public class StreamedQueryResourceTest {
 
   @Before
   public void setup() {
-    expect(mockKsqlEngine.isAcceptingStatements()).andReturn(true);
     expect(serviceContext.getTopicClient()).andReturn(mockKafkaTopicClient);
     expect(mockKsqlEngine.hasActiveQueries()).andReturn(false);
     statement = PreparedStatement.of("s", mock(Statement.class));
@@ -305,7 +303,6 @@ public class StreamedQueryResourceTest {
         ConfiguredStatement.of(statement, requestStreamsProperties, ksqlConfig)))
         .andReturn(ExecuteResult.of(transientQueryMetadata));
 
-    expect(mockKsqlEngine.isAcceptingStatements()).andReturn(true);
     replay(mockKsqlEngine, mockStatementParser, mockKafkaStreams, mockOutputNode);
 
     final Response response =


### PR DESCRIPTION
### Description 

Remove dead code that looks to be left over from when `ServerState` was added.  Previously, this flag was used to detect cluster termination, which I'm assuming is now handled by `ServerState`.

@rodesai / @hjafarpour  - would be good for you if you could confirm cluster termination functionality was not compromised when this code became dead.

### Testing done 

None functional change.

### Reviewer checklist
- [ ] Ensure docs are updated if necessary. (eg. if a user visible feature is being added or changed).
- [ ] Ensure relevant issues are linked (description should include text like "Fixes #<issue number>")

