### PR TITLE
feat: validate createTopic permissions on SandboxedKafkaTopicClient

### DIFF
--- a/ksql-engine/src/main/java/io/confluent/ksql/services/SandboxedKafkaTopicClient.java
+++ b/ksql-engine/src/main/java/io/confluent/ksql/services/SandboxedKafkaTopicClient.java
@@ -99,6 +99,9 @@ final class SandboxedKafkaTopicClient {
             Collections.emptyList()))
         .collect(Collectors.toList());
 
+    // This is useful to validate permissions to create the topic
+    delegate.validateCreateTopic(topic, numPartitions, replicationFactor, configs);
+
     createdTopics.put(topic, new SandboxedTopicDescription(
         topic,
         false,

--- a/ksql-engine/src/test/java/io/confluent/ksql/services/FakeKafkaTopicClient.java
+++ b/ksql-engine/src/test/java/io/confluent/ksql/services/FakeKafkaTopicClient.java
@@ -31,6 +31,8 @@ import java.util.Set;
 import java.util.function.Function;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
+
+import org.apache.kafka.clients.admin.CreateTopicsOptions;
 import org.apache.kafka.clients.admin.TopicDescription;
 import org.apache.kafka.common.Node;
 import org.apache.kafka.common.TopicPartitionInfo;
@@ -122,7 +124,8 @@ public class FakeKafkaTopicClient implements KafkaTopicClient {
       final String topic,
       final int numPartitions,
       final short replicationFactor,
-      final Map<String, ?> configs
+      final Map<String, ?> configs,
+      final CreateTopicsOptions createOptions
   ) {
     final short replicas = replicationFactor == TopicProperties.DEFAULT_REPLICAS
         ? 1

--- a/ksql-engine/src/test/java/io/confluent/ksql/services/KafkaTopicClientImplTest.java
+++ b/ksql-engine/src/test/java/io/confluent/ksql/services/KafkaTopicClientImplTest.java
@@ -16,6 +16,7 @@
 package io.confluent.ksql.services;
 
 import static org.easymock.EasyMock.anyObject;
+import static org.easymock.EasyMock.eq;
 import static org.easymock.EasyMock.expect;
 import static org.easymock.EasyMock.expectLastCall;
 import static org.easymock.EasyMock.mock;
@@ -53,6 +54,7 @@ import org.apache.kafka.clients.admin.AlterConfigOp.OpType;
 import org.apache.kafka.clients.admin.AlterConfigsResult;
 import org.apache.kafka.clients.admin.Config;
 import org.apache.kafka.clients.admin.ConfigEntry;
+import org.apache.kafka.clients.admin.CreateTopicsOptions;
 import org.apache.kafka.clients.admin.CreateTopicsResult;
 import org.apache.kafka.clients.admin.DeleteTopicsResult;
 import org.apache.kafka.clients.admin.DescribeClusterResult;
@@ -118,11 +120,24 @@ public class KafkaTopicClientImplTest {
   @Test
   public void shouldCreateTopic() {
     expect(adminClient.listTopics()).andReturn(getListTopicsResult());
-    expect(adminClient.createTopics(anyObject())).andReturn(getCreateTopicsResult());
+    expect(adminClient.createTopics(anyObject(), shouldValidateCreate(false)))
+        .andReturn(getCreateTopicsResult());
     replay(adminClient);
 
     final KafkaTopicClient kafkaTopicClient = new KafkaTopicClientImpl(adminClient);
     kafkaTopicClient.createTopic("test", 1, (short) 1);
+    verify(adminClient);
+  }
+
+  @Test
+  public void shouldValidateCreateTopic() {
+    expect(adminClient.listTopics()).andReturn(getListTopicsResult());
+    expect(adminClient.createTopics(anyObject(), shouldValidateCreate(true)))
+        .andReturn(getCreateTopicsResult());
+    replay(adminClient);
+
+    final KafkaTopicClient kafkaTopicClient = new KafkaTopicClientImpl(adminClient);
+    kafkaTopicClient.validateCreateTopic("test", 1, (short) 1);
     verify(adminClient);
   }
 
@@ -160,7 +175,8 @@ public class KafkaTopicClientImplTest {
   public void shouldFailCreateTopicWhenNoAclsSet() {
     // Given:
     expect(adminClient.listTopics()).andReturn(getEmptyListTopicResult());
-    expect(adminClient.createTopics(anyObject())).andReturn(createTopicAuthorizationException());
+    expect(adminClient.createTopics(anyObject(), anyObject()))
+        .andReturn(createTopicAuthorizationException());
 
     replay(adminClient);
 
@@ -189,7 +205,7 @@ public class KafkaTopicClientImplTest {
   @Test
   public void shouldNotFailIfTopicAlreadyExistsWhenCreating() {
     expect(adminClient.listTopics()).andReturn(getEmptyListTopicResult());
-    expect(adminClient.createTopics(anyObject()))
+    expect(adminClient.createTopics(anyObject(), anyObject()))
         .andReturn(createTopicReturningTopicExistsException());
     expect(adminClient.describeTopics(anyObject(), anyObject()))
         .andReturn(getDescribeTopicsResult());
@@ -202,7 +218,7 @@ public class KafkaTopicClientImplTest {
   @Test
   public void shouldRetryDescribeTopicOnRetriableException() {
     expect(adminClient.listTopics()).andReturn(getEmptyListTopicResult());
-    expect(adminClient.createTopics(anyObject()))
+    expect(adminClient.createTopics(anyObject(), anyObject()))
         .andReturn(createTopicReturningTopicExistsException());
     expect(adminClient.describeTopics(anyObject(), anyObject()))
         .andReturn(describeTopicReturningUnknownPartitionException()).once();
@@ -433,7 +449,8 @@ public class KafkaTopicClientImplTest {
     // Verify that the new topic configuration being passed to the admin client is what we expect.
     final NewTopic newTopic = new NewTopic(topicName1, 1, (short) 1);
     newTopic.configs(Collections.singletonMap("cleanup.policy", "compact"));
-    expect(adminClient.createTopics(singleNewTopic(newTopic))).andReturn(getCreateTopicsResult());
+    expect(adminClient.createTopics(singleNewTopic(newTopic), anyObject()))
+        .andReturn(getCreateTopicsResult());
     replay(adminClient);
 
     final KafkaTopicClient kafkaTopicClient = new KafkaTopicClientImpl(adminClient);
@@ -826,6 +843,23 @@ public class KafkaTopicClientImplTest {
     }
 
     EasyMock.reportMatcher(new NewTopicsMatcher());
+    return null;
+  }
+
+  private CreateTopicsOptions shouldValidateCreate(final boolean validateOnly) {
+    EasyMock.reportMatcher(new IArgumentMatcher() {
+      @Override
+      public boolean matches(Object argument) {
+        return argument instanceof CreateTopicsOptions
+            && ((CreateTopicsOptions) argument).shouldValidateOnly() == validateOnly;
+      }
+
+      @Override
+      public void appendTo(StringBuffer buffer) {
+        buffer.append("validateOnly(\"" + validateOnly + "\")");
+      }
+    });
+
     return null;
   }
 }

--- a/ksql-rest-app/src/test/java/io/confluent/ksql/rest/server/mock/MockKafkaTopicClient.java
+++ b/ksql-rest-app/src/test/java/io/confluent/ksql/rest/server/mock/MockKafkaTopicClient.java
@@ -20,6 +20,8 @@ import java.util.Collection;
 import java.util.Collections;
 import java.util.Map;
 import java.util.Set;
+
+import org.apache.kafka.clients.admin.CreateTopicsOptions;
 import org.apache.kafka.clients.admin.TopicDescription;
 
 /**
@@ -32,7 +34,8 @@ public class MockKafkaTopicClient implements KafkaTopicClient {
   public void createTopic(final String topic,
                           final int numPartitions,
                           final short replicationFactor,
-                          final Map<String, ?> configs) {
+                          final Map<String, ?> configs,
+                          final CreateTopicsOptions createOptions) {
   }
 
   @Override


### PR DESCRIPTION
### Description 
This PR adds a validation option to the sandboxed topic client to ensure a user have permissions to create a topic before creating the topic in the sandbox. 

This allows the `RequestValidator` to validate CSAS requests when the user does not have permissions to create the sink topic.

### Testing done 
- Added unit tests
- Verified manually with debugging that RequestValidator fails if user does not have permissions on the delegated kafka topic client. 

### Reviewer checklist
- [ ] Ensure docs are updated if necessary. (eg. if a user visible feature is being added or changed).
- [ ] Ensure relevant issues are linked (description should include text like "Fixes #<issue number>")

