### PR TITLE
test: disable ZK admin server

### DIFF
--- a/ksql-test-util/pom.xml
+++ b/ksql-test-util/pom.xml
@@ -100,5 +100,17 @@
       <scope>compile</scope>
     </dependency>
 
+    <dependency>
+      <groupId>org.eclipse.jetty</groupId>
+      <artifactId>jetty-server</artifactId>
+      <scope>test</scope>
+    </dependency>
+
+    <dependency>
+      <groupId>org.eclipse.jetty</groupId>
+      <artifactId>jetty-servlet</artifactId>
+      <scope>test</scope>
+    </dependency>
+
   </dependencies>
 </project>

--- a/ksql-test-util/src/main/java/io/confluent/ksql/test/util/ZooKeeperEmbedded.java
+++ b/ksql-test-util/src/main/java/io/confluent/ksql/test/util/ZooKeeperEmbedded.java
@@ -38,6 +38,7 @@ class ZooKeeperEmbedded {
    */
   ZooKeeperEmbedded() throws Exception {
     log.debug("Starting embedded ZooKeeper server...");
+    System.setProperty("zookeeper.admin.enableServer", "false");
     this.server = createTestingServer();
     log.debug("Embedded ZooKeeper server at {} uses the temp directory at {}",
         server.getConnectString(), server.getTempDirectory());

--- a/ksql-test-util/src/test/java/io/confluent/ksql/test/util/ZooKeeperEmbeddedTest.java
+++ b/ksql-test-util/src/test/java/io/confluent/ksql/test/util/ZooKeeperEmbeddedTest.java
@@ -1,0 +1,90 @@
+/*
+ * Copyright 2019 Confluent Inc.
+ *
+ * Licensed under the Confluent Community License (the "License"); you may not use
+ * this file except in compliance with the License.  You may obtain a copy of the
+ * License at
+ *
+ * http://www.confluent.io/confluent-community-license
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package io.confluent.ksql.test.util;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+import org.apache.zookeeper.Watcher;
+import org.apache.zookeeper.Watcher.Event.KeeperState;
+import org.apache.zookeeper.ZooKeeper;
+import org.junit.Test;
+
+
+public class ZooKeeperEmbeddedTest {
+
+  /**
+   * Test is only valid if Jetty is on the class path:
+   */
+  @SuppressWarnings("unused")
+  private final org.eclipse.jetty.server.Connector ensureClassOnClassPath = null;
+  @SuppressWarnings("unused")
+  private final org.eclipse.jetty.servlet.ServletContextHandler ensureClassOnClassPath2 = null;
+
+  @Test
+  public void shouldSupportMultipleInstancesRunning() throws Exception {
+    // Given:
+    final ZooKeeperEmbedded first = new ZooKeeperEmbedded();
+
+    try {
+      // When:
+      final ZooKeeperEmbedded second = new ZooKeeperEmbedded();
+
+      // Then:
+      assertCanConnect(first, "first");
+      assertCanConnect(second, "second");
+
+      second.stop();
+    } finally {
+      first.stop();
+    }
+  }
+
+  private static void assertCanConnect(
+      final ZooKeeperEmbedded server,
+      final String name
+  ) {
+    final CountDownLatch connectionLatch = new CountDownLatch(1);
+
+    final Watcher watcher = event -> {
+      if (event.getState() == KeeperState.SyncConnected) {
+        connectionLatch.countDown();
+      }
+    };
+
+    ZooKeeper zooKeeper = null;
+
+    try {
+      final String connectString = server.connectString();
+      zooKeeper = new ZooKeeper(connectString, 2000, watcher);
+      final boolean success = connectionLatch.await(5, TimeUnit.SECONDS);
+      assertThat("Can not connect to " + name + " on " + connectString, success);
+
+    } catch (final Exception e) {
+      throw new RuntimeException(e);
+    } finally {
+      if (zooKeeper != null) {
+        try {
+          zooKeeper.close(0);
+        } catch (final Exception e) {
+          System.err.println(e.getMessage());
+          e.printStackTrace(System.err);
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
### Description 
This change disables the Zookeeper Admin Server that would otherwise be started by `ZookeeperEmbedded`.
The admin server defaults to using port 8080, which causes a port clash if two tests/instances are running on the same machine.
On a port clash the admin server fails to start, which causes Zookeeper to fail too.

### Testing done 

Non functional change.

### Reviewer checklist
- [ ] Ensure docs are updated if necessary. (eg. if a user visible feature is being added or changed).
- [ ] Ensure relevant issues are linked (description should include text like "Fixes #<issue number>")

