### PR TITLE
refactor: remove the pointless valToVal map passed to KsqlAggregator

### DIFF
--- a/ksql-engine/src/main/java/io/confluent/ksql/planner/plan/AggregateNode.java
+++ b/ksql-engine/src/main/java/io/confluent/ksql/planner/plan/AggregateNode.java
@@ -224,11 +224,6 @@ public class AggregateNode extends PlanNode {
     );
 
     // Aggregate computations
-    final Map<Integer, Integer> aggValToValColumnMap = createAggregateValueToValueColumnMap(
-        aggregateArgExpanded,
-        internalSchema
-    );
-
     final LogicalSchema aggStageSchema = buildAggregateSchema(
         aggregateArgExpanded.getSchema(),
         builder.getFunctionRegistry(),
@@ -243,19 +238,24 @@ public class AggregateNode extends PlanNode {
         aggregationContext.getQueryContext()
     );
 
-    final KudafInitializer initializer = new KudafInitializer(aggValToValColumnMap.size());
+    final KudafInitializer initializer = new KudafInitializer(requiredColumns.size());
 
     final Map<Integer, KsqlAggregateFunction> aggValToFunctionMap = createAggValToFunctionMap(
-        aggregateArgExpanded, initializer, aggValToValColumnMap.size(),
-        builder.getFunctionRegistry(), internalSchema);
+        aggregateArgExpanded,
+        initializer,
+        requiredColumns.size(),
+        builder.getFunctionRegistry(),
+        internalSchema
+    );
 
     final SchemaKTable<?> schemaKTable = schemaKGroupedStream.aggregate(
         initializer,
+        requiredColumns.size(),
         aggValToFunctionMap,
-        aggValToValColumnMap,
         getWindowExpression(),
         aggValueGenericRowSerde,
-        aggregationContext);
+        aggregationContext
+    );
 
     SchemaKTable<?> result = new SchemaKTable<>(
         schemaKTable.getKtable(), aggStageSchema,
@@ -284,26 +284,6 @@ public class AggregateNode extends PlanNode {
   protected int getPartitions(final KafkaTopicClient kafkaTopicClient) {
     return source.getPartitions(kafkaTopicClient);
   }
-
-  private Map<Integer, Integer> createAggregateValueToValueColumnMap(
-      final SchemaKStream aggregateArgExpanded,
-      final InternalSchema internalSchema
-  ) {
-    final Map<Integer, Integer> aggValToValColumnMap = new HashMap<>();
-    int nonAggColumnIndex = 0;
-    for (final Expression expression : getRequiredColumns()) {
-      final String exprStr =
-          internalSchema.getInternalColumnForExpression(expression);
-
-      final int index = aggregateArgExpanded.getSchema().valueFieldIndex(exprStr)
-          .orElseThrow(IllegalStateException::new);
-
-      aggValToValColumnMap.put(nonAggColumnIndex, index);
-      nonAggColumnIndex++;
-    }
-    return aggValToValColumnMap;
-  }
-
 
   private Map<Integer, KsqlAggregateFunction> createAggValToFunctionMap(
       final SchemaKStream aggregateArgExpanded,

--- a/ksql-engine/src/main/java/io/confluent/ksql/structured/SchemaKGroupedStream.java
+++ b/ksql-engine/src/main/java/io/confluent/ksql/structured/SchemaKGroupedStream.java
@@ -102,20 +102,20 @@ public class SchemaKGroupedStream {
   @SuppressWarnings("unchecked")
   public SchemaKTable<?> aggregate(
       final Initializer initializer,
+      final int nonFuncColumnCount,
       final Map<Integer, KsqlAggregateFunction> aggValToFunctionMap,
-      final Map<Integer, Integer> aggValToValColumnMap,
       final WindowExpression windowExpression,
       final Serde<GenericRow> topicValueSerDe,
-      final QueryContext.Stacker contextStacker) {
-
+      final QueryContext.Stacker contextStacker
+  ) {
     final KTable table;
     final KeySerde<?> newKeySerde;
     if (windowExpression != null) {
       newKeySerde = getKeySerde(windowExpression);
       table = aggregateWindowed(
           initializer,
+          nonFuncColumnCount,
           aggValToFunctionMap,
-          aggValToValColumnMap,
           windowExpression,
           topicValueSerDe,
           contextStacker);
@@ -124,8 +124,8 @@ public class SchemaKGroupedStream {
 
       table = aggregateNonWindowed(
           initializer,
+          nonFuncColumnCount,
           aggValToFunctionMap,
-          aggValToValColumnMap,
           topicValueSerDe,
           contextStacker);
     }
@@ -145,13 +145,12 @@ public class SchemaKGroupedStream {
   @SuppressWarnings("unchecked")
   private KTable aggregateNonWindowed(
       final Initializer initializer,
+      final int nonFuncColumnCount,
       final Map<Integer, KsqlAggregateFunction> indexToFunctionMap,
-      final Map<Integer, Integer> indexToValueMap,
       final Serde<GenericRow> topicValueSerDe,
-      final QueryContext.Stacker contextStacker) {
-
-    final UdafAggregator aggregator = new KudafAggregator(
-        indexToFunctionMap, indexToValueMap);
+      final QueryContext.Stacker contextStacker
+  ) {
+    final UdafAggregator aggregator = new KudafAggregator(nonFuncColumnCount, indexToFunctionMap);
 
     final Materialized<Struct, GenericRow, ?> materialized = materializedFactory.create(
         keySerde,
@@ -165,14 +164,13 @@ public class SchemaKGroupedStream {
   @SuppressWarnings("unchecked")
   private KTable aggregateWindowed(
       final Initializer initializer,
+      final int nonFuncColumnCount,
       final Map<Integer, KsqlAggregateFunction> indexToFunctionMap,
-      final Map<Integer, Integer> indexToValueMap,
       final WindowExpression windowExpression,
       final Serde<GenericRow> topicValueSerDe,
-      final QueryContext.Stacker contextStacker) {
-
-    final UdafAggregator aggregator = new KudafAggregator(
-        indexToFunctionMap, indexToValueMap);
+      final QueryContext.Stacker contextStacker
+  ) {
+    final UdafAggregator aggregator = new KudafAggregator(nonFuncColumnCount, indexToFunctionMap);
 
     final KsqlWindowExpression ksqlWindowExpression = windowExpression.getKsqlWindowExpression();
 

--- a/ksql-engine/src/main/java/io/confluent/ksql/structured/SchemaKGroupedTable.java
+++ b/ksql-engine/src/main/java/io/confluent/ksql/structured/SchemaKGroupedTable.java
@@ -83,11 +83,12 @@ public class SchemaKGroupedTable extends SchemaKGroupedStream {
   @Override
   public SchemaKTable<Struct> aggregate(
       final Initializer initializer,
+      final int nonFuncColumnCount,
       final Map<Integer, KsqlAggregateFunction> aggValToFunctionMap,
-      final Map<Integer, Integer> aggValToValColumnMap,
       final WindowExpression windowExpression,
       final Serde<GenericRow> topicValueSerDe,
-      final QueryContext.Stacker contextStacker) {
+      final QueryContext.Stacker contextStacker
+  ) {
     if (windowExpression != null) {
       throw new KsqlException("Windowing not supported for table aggregations.");
     }
@@ -105,7 +106,7 @@ public class SchemaKGroupedTable extends SchemaKGroupedStream {
     }
 
     final KudafAggregator aggregator = new KudafAggregator(
-        aggValToFunctionMap, aggValToValColumnMap);
+        nonFuncColumnCount, aggValToFunctionMap);
 
     final Map<Integer, TableAggregationFunction> aggValToUndoFunctionMap =
         aggValToFunctionMap.keySet()
@@ -114,8 +115,9 @@ public class SchemaKGroupedTable extends SchemaKGroupedStream {
                 Collectors.toMap(
                     k -> k,
                     k -> ((TableAggregationFunction) aggValToFunctionMap.get(k))));
+
     final KudafUndoAggregator subtractor = new KudafUndoAggregator(
-        aggValToUndoFunctionMap, aggValToValColumnMap);
+        nonFuncColumnCount, aggValToUndoFunctionMap);
 
     final Materialized<Struct, GenericRow, ?> materialized = materializedFactory.create(
         keySerde,

--- a/ksql-engine/src/test/java/io/confluent/ksql/function/KudafUndoAggregatorTest.java
+++ b/ksql-engine/src/test/java/io/confluent/ksql/function/KudafUndoAggregatorTest.java
@@ -32,9 +32,6 @@ public class KudafUndoAggregatorTest {
   @Test
   public void shouldApplyUndoableAggregateFunctions() {
     final InternalFunctionRegistry functionRegistry = new InternalFunctionRegistry();
-    final Map<Integer, Integer> aggValToValColumnMap = new HashMap<>();
-    aggValToValColumnMap.put(0, 1);
-    aggValToValColumnMap.put(1, 0);
     final Map<Integer, TableAggregationFunction> aggValToAggFunctionMap = new HashMap<>();
     final KsqlAggregateFunction functionInfo = functionRegistry.getAggregate(
         "SUM", Schema.OPTIONAL_INT32_SCHEMA);
@@ -48,7 +45,7 @@ public class KudafUndoAggregatorTest {
     final GenericRow aggRow = new GenericRow(Arrays.asList("jon", "snow", 5));
 
     final KudafUndoAggregator aggregator = new KudafUndoAggregator(
-        aggValToAggFunctionMap, aggValToValColumnMap);
+        2, aggValToAggFunctionMap);
 
     final GenericRow resultRow = aggregator.apply(null, row, aggRow);
 

--- a/ksql-engine/src/test/java/io/confluent/ksql/function/KudafUndoAggregatorTest.java
+++ b/ksql-engine/src/test/java/io/confluent/ksql/function/KudafUndoAggregatorTest.java
@@ -42,13 +42,13 @@ public class KudafUndoAggregatorTest {
         ));
 
     final GenericRow row = new GenericRow(Arrays.asList("snow", "jon", 3));
-    final GenericRow aggRow = new GenericRow(Arrays.asList("jon", "snow", 5));
+    final GenericRow aggRow = new GenericRow(Arrays.asList("snow", "jon", 5));
 
     final KudafUndoAggregator aggregator = new KudafUndoAggregator(
         2, aggValToAggFunctionMap);
 
     final GenericRow resultRow = aggregator.apply(null, row, aggRow);
 
-    assertThat(resultRow, equalTo(new GenericRow(Arrays.asList("jon", "snow", 2))));
+    assertThat(resultRow, equalTo(new GenericRow(Arrays.asList("snow", "jon", 2))));
   }
 }

--- a/ksql-engine/src/test/java/io/confluent/ksql/structured/SchemaKGroupedStreamTest.java
+++ b/ksql-engine/src/test/java/io/confluent/ksql/structured/SchemaKGroupedStreamTest.java
@@ -175,7 +175,7 @@ public class SchemaKGroupedStreamTest {
 
     // When:
     final SchemaKTable result = schemaGroupedStream
-        .aggregate(initializer, emptyMap(), emptyMap(), windowExp, topicValueSerDe, queryContext);
+        .aggregate(initializer, 0, emptyMap(), windowExp, topicValueSerDe, queryContext);
 
     // Then:
     verify(keySerde).rebind(windowInfo);
@@ -192,7 +192,7 @@ public class SchemaKGroupedStreamTest {
 
     // When:
     final SchemaKTable result = schemaGroupedStream
-        .aggregate(initializer, emptyMap(), emptyMap(), windowExp, topicValueSerDe, queryContext);
+        .aggregate(initializer, 0, emptyMap(), windowExp, topicValueSerDe, queryContext);
 
     // Then:
     verify(keySerde).rebind(windowInfo);
@@ -209,7 +209,7 @@ public class SchemaKGroupedStreamTest {
 
     // When:
     final SchemaKTable result = schemaGroupedStream
-        .aggregate(initializer, emptyMap(), emptyMap(), windowExp, topicValueSerDe, queryContext);
+        .aggregate(initializer, 0, emptyMap(), windowExp, topicValueSerDe, queryContext);
 
     // Then:
     verify(keySerde).rebind(windowInfo);
@@ -224,7 +224,7 @@ public class SchemaKGroupedStreamTest {
 
     // When:
     final SchemaKTable result = schemaGroupedStream
-        .aggregate(initializer, emptyMap(), emptyMap(), windowExp, topicValueSerDe, queryContext);
+        .aggregate(initializer, 0, emptyMap(), windowExp, topicValueSerDe, queryContext);
 
     // Then:
     verify(keySerde)
@@ -247,7 +247,7 @@ public class SchemaKGroupedStreamTest {
 
     // When:
     final SchemaKTable result = schemaGroupedStream
-        .aggregate(initializer, funcMap, emptyMap(), windowExp, topicValueSerDe, queryContext);
+        .aggregate(initializer, 0, funcMap, windowExp, topicValueSerDe, queryContext);
 
     // Then:
     assertThat(result.getKtable(), is(sameInstance(table)));
@@ -267,7 +267,7 @@ public class SchemaKGroupedStreamTest {
 
     // When:
     final SchemaKTable result = schemaGroupedStream
-        .aggregate(initializer, funcMap, emptyMap(), windowExp, topicValueSerDe, queryContext);
+        .aggregate(initializer, 0, funcMap, windowExp, topicValueSerDe, queryContext);
 
     // Then:
     assertThat(result.getKtable(), is(sameInstance(table2)));
@@ -293,7 +293,7 @@ public class SchemaKGroupedStreamTest {
     // When:
     schemaGroupedStream.aggregate(
         () -> null,
-        Collections.emptyMap(),
+        0,
         Collections.emptyMap(),
         null,
         topicValueSerDe,
@@ -320,7 +320,7 @@ public class SchemaKGroupedStreamTest {
     // When:
     schemaGroupedStream.aggregate(
         () -> null,
-        Collections.emptyMap(),
+        0,
         Collections.emptyMap(),
         windowExp,
         topicValueSerDe,

--- a/ksql-engine/src/test/java/io/confluent/ksql/structured/SchemaKGroupedTableTest.java
+++ b/ksql-engine/src/test/java/io/confluent/ksql/structured/SchemaKGroupedTableTest.java
@@ -29,6 +29,10 @@ import static org.mockito.Mockito.when;
 
 import io.confluent.kafka.schemaregistry.client.MockSchemaRegistryClient;
 import io.confluent.ksql.GenericRow;
+import io.confluent.ksql.execution.expression.tree.DereferenceExpression;
+import io.confluent.ksql.execution.expression.tree.Expression;
+import io.confluent.ksql.execution.expression.tree.QualifiedName;
+import io.confluent.ksql.execution.expression.tree.QualifiedNameReference;
 import io.confluent.ksql.function.InternalFunctionRegistry;
 import io.confluent.ksql.function.KsqlAggregateFunction;
 import io.confluent.ksql.function.udaf.KudafInitializer;
@@ -37,10 +41,6 @@ import io.confluent.ksql.logging.processing.ProcessingLogContext;
 import io.confluent.ksql.metastore.MetaStore;
 import io.confluent.ksql.metastore.model.KeyField;
 import io.confluent.ksql.metastore.model.KsqlTable;
-import io.confluent.ksql.execution.expression.tree.DereferenceExpression;
-import io.confluent.ksql.execution.expression.tree.Expression;
-import io.confluent.ksql.execution.expression.tree.QualifiedName;
-import io.confluent.ksql.execution.expression.tree.QualifiedNameReference;
 import io.confluent.ksql.parser.tree.TumblingWindowExpression;
 import io.confluent.ksql.parser.tree.WindowExpression;
 import io.confluent.ksql.planner.plan.PlanNode;
@@ -173,10 +173,10 @@ public class SchemaKGroupedTableTest {
     try {
       kGroupedTable.aggregate(
           new KudafInitializer(1),
+          1,
           Collections.singletonMap(
               0,
               functionRegistry.getAggregate("SUM", Schema.OPTIONAL_INT64_SCHEMA)),
-          Collections.singletonMap(0, 0),
           windowExpression,
           GenericRowSerDe.from(
               FormatInfo.of(Format.JSON, Optional.empty()),
@@ -206,8 +206,8 @@ public class SchemaKGroupedTableTest {
           1, functionRegistry.getAggregate("MIN", Schema.OPTIONAL_INT64_SCHEMA));
       kGroupedTable.aggregate(
           new KudafInitializer(1),
+          1,
           aggValToFunctionMap,
-          Collections.singletonMap(0, 0),
           null,
           GenericRowSerDe.from(
               FormatInfo.of(Format.JSON, Optional.empty()),
@@ -271,7 +271,7 @@ public class SchemaKGroupedTableTest {
     // When:
     groupedTable.aggregate(
         () -> null,
-        Collections.emptyMap(),
+        0,
         Collections.emptyMap(),
         null,
         valueSerde,

--- a/ksql-functional-tests/src/test/resources/query-validation-tests/group-by.json
+++ b/ksql-functional-tests/src/test/resources/query-validation-tests/group-by.json
@@ -48,23 +48,23 @@
       ],
       "format": ["AVRO", "JSON"],
       "inputs": [
-        {"topic": "test_topic", "key": "d1", "value": {"DATA": "d1"}},
-        {"topic": "test_topic", "key": "d2", "value": {"DATA": "d2"}},
-        {"topic": "test_topic", "key": "d1", "value": {"DATA": "d1"}},
-        {"topic": "test_topic", "key": "d2", "value": {"DATA": "d2"}},
-        {"topic": "test_topic", "key": "d1", "value": {"DATA": "d1"}}
+        {"topic": "test_topic", "key": "d1", "value": {"DATA": "d1"}, "timestamp": 1},
+        {"topic": "test_topic", "key": "d2", "value": {"DATA": "d2"}, "timestamp": 2},
+        {"topic": "test_topic", "key": "d1", "value": {"DATA": "d1"}, "timestamp": 3},
+        {"topic": "test_topic", "key": "d2", "value": {"DATA": "d2"}, "timestamp": 4},
+        {"topic": "test_topic", "key": "d1", "value": {"DATA": "d1"}, "timestamp": 5}
       ],
       "outputs": [
-        {"topic": "_confluent-ksql-some.ksql.service.idquery_CTAS_OUTPUT_0-Aggregate-aggregate-changelog", "key": "d1", "value": {"KSQL_INTERNAL_COL_0": "d1", "KSQL_INTERNAL_COL_1": 0, "KSQL_AGG_VARIABLE_0": 1}},
-        {"topic": "_confluent-ksql-some.ksql.service.idquery_CTAS_OUTPUT_0-Aggregate-aggregate-changelog", "key": "d2", "value": {"KSQL_INTERNAL_COL_0": "d2", "KSQL_INTERNAL_COL_1": 0, "KSQL_AGG_VARIABLE_0": 1}},
-        {"topic": "_confluent-ksql-some.ksql.service.idquery_CTAS_OUTPUT_0-Aggregate-aggregate-changelog", "key": "d1", "value": {"KSQL_INTERNAL_COL_0": "d1", "KSQL_INTERNAL_COL_1": 0, "KSQL_AGG_VARIABLE_0": 2}},
-        {"topic": "_confluent-ksql-some.ksql.service.idquery_CTAS_OUTPUT_0-Aggregate-aggregate-changelog", "key": "d2", "value": {"KSQL_INTERNAL_COL_0": "d2", "KSQL_INTERNAL_COL_1": 0, "KSQL_AGG_VARIABLE_0": 2}},
-        {"topic": "_confluent-ksql-some.ksql.service.idquery_CTAS_OUTPUT_0-Aggregate-aggregate-changelog", "key": "d1", "value": {"KSQL_INTERNAL_COL_0": "d1", "KSQL_INTERNAL_COL_1": 0, "KSQL_AGG_VARIABLE_0": 3}},
-        {"topic": "OUTPUT", "key": "d1", "value": {"DATA": "d1", "KSQL_COL_1":1}},
-        {"topic": "OUTPUT", "key": "d2", "value": {"DATA": "d2", "KSQL_COL_1":1}},
-        {"topic": "OUTPUT", "key": "d1", "value": {"DATA": "d1", "KSQL_COL_1":2}},
-        {"topic": "OUTPUT", "key": "d2", "value": {"DATA": "d2", "KSQL_COL_1":2}},
-        {"topic": "OUTPUT", "key": "d1", "value": {"DATA": "d1", "KSQL_COL_1":3}}
+        {"topic": "_confluent-ksql-some.ksql.service.idquery_CTAS_OUTPUT_0-Aggregate-aggregate-changelog", "key": "d1", "value": {"KSQL_INTERNAL_COL_0": "d1", "KSQL_INTERNAL_COL_1": 1, "KSQL_AGG_VARIABLE_0": 1}, "timestamp": 1},
+        {"topic": "_confluent-ksql-some.ksql.service.idquery_CTAS_OUTPUT_0-Aggregate-aggregate-changelog", "key": "d2", "value": {"KSQL_INTERNAL_COL_0": "d2", "KSQL_INTERNAL_COL_1": 2, "KSQL_AGG_VARIABLE_0": 1}, "timestamp": 2},
+        {"topic": "_confluent-ksql-some.ksql.service.idquery_CTAS_OUTPUT_0-Aggregate-aggregate-changelog", "key": "d1", "value": {"KSQL_INTERNAL_COL_0": "d1", "KSQL_INTERNAL_COL_1": 3, "KSQL_AGG_VARIABLE_0": 2}, "timestamp": 3},
+        {"topic": "_confluent-ksql-some.ksql.service.idquery_CTAS_OUTPUT_0-Aggregate-aggregate-changelog", "key": "d2", "value": {"KSQL_INTERNAL_COL_0": "d2", "KSQL_INTERNAL_COL_1": 4, "KSQL_AGG_VARIABLE_0": 2}, "timestamp": 4},
+        {"topic": "_confluent-ksql-some.ksql.service.idquery_CTAS_OUTPUT_0-Aggregate-aggregate-changelog", "key": "d1", "value": {"KSQL_INTERNAL_COL_0": "d1", "KSQL_INTERNAL_COL_1": 5, "KSQL_AGG_VARIABLE_0": 3}, "timestamp": 5},
+        {"topic": "OUTPUT", "key": "d1", "value": {"DATA": "d1", "KSQL_COL_1":1}, "timestamp": 1},
+        {"topic": "OUTPUT", "key": "d2", "value": {"DATA": "d2", "KSQL_COL_1":1}, "timestamp": 2},
+        {"topic": "OUTPUT", "key": "d1", "value": {"DATA": "d1", "KSQL_COL_1":2}, "timestamp": 3},
+        {"topic": "OUTPUT", "key": "d2", "value": {"DATA": "d2", "KSQL_COL_1":2}, "timestamp": 4},
+        {"topic": "OUTPUT", "key": "d1", "value": {"DATA": "d1", "KSQL_COL_1":3}, "timestamp": 5}
       ]
     },
     {
@@ -913,18 +913,21 @@
     {
       "name": "missing matching projection field (stream->table)",
       "statements": [
-        "CREATE STREAM TEST (data VARCHAR) WITH (kafka_topic='test_topic', value_format='DELIMITED');",
+        "CREATE STREAM TEST (data VARCHAR) WITH (kafka_topic='test_topic', value_format='JSON');",
         "CREATE TABLE OUTPUT AS SELECT COUNT(*) FROM TEST GROUP BY data;"
       ],
       "inputs": [
-        {"topic": "test_topic", "value": "d1"},
-        {"topic": "test_topic", "value": "d2"},
-        {"topic": "test_topic", "value": "d1"}
+        {"topic": "test_topic", "value": {"DATA": "d1"}, "timestamp": 1},
+        {"topic": "test_topic", "value": {"DATA": "d2"}, "timestamp": 2},
+        {"topic": "test_topic", "value": {"DATA": "d1"}, "timestamp": 3}
       ],
       "outputs": [
-        {"topic": "OUTPUT", "key": "d1", "value": "1"},
-        {"topic": "OUTPUT", "key": "d2", "value": "1"},
-        {"topic": "OUTPUT", "key": "d1", "value": "2"}
+        {"topic": "_confluent-ksql-some.ksql.service.idquery_CTAS_OUTPUT_0-Aggregate-aggregate-changelog", "key": "d1", "value": {"KSQL_INTERNAL_COL_0": 1, "KSQL_INTERNAL_COL_1": "d1", "KSQL_AGG_VARIABLE_0": 1}, "timestamp": 1},
+        {"topic": "_confluent-ksql-some.ksql.service.idquery_CTAS_OUTPUT_0-Aggregate-aggregate-changelog", "key": "d2", "value": {"KSQL_INTERNAL_COL_0": 2, "KSQL_INTERNAL_COL_1": "d2", "KSQL_AGG_VARIABLE_0": 1}, "timestamp": 2},
+        {"topic": "_confluent-ksql-some.ksql.service.idquery_CTAS_OUTPUT_0-Aggregate-aggregate-changelog", "key": "d1", "value": {"KSQL_INTERNAL_COL_0": 3, "KSQL_INTERNAL_COL_1": "d1", "KSQL_AGG_VARIABLE_0": 2}, "timestamp": 3},
+        {"topic": "OUTPUT", "key": "d1", "value": {"KSQL_COL_0": 1}, "timestamp": 1},
+        {"topic": "OUTPUT", "key": "d2", "value": {"KSQL_COL_0": 1}, "timestamp": 2},
+        {"topic": "OUTPUT", "key": "d1", "value": {"KSQL_COL_0": 2}, "timestamp": 3}
       ]
     },
     {
@@ -948,6 +951,26 @@
         {"topic": "OUTPUT", "key": "b", "value": "1"},
         {"topic": "OUTPUT", "key": "b", "value": "0"},
         {"topic": "OUTPUT", "key": "a", "value": "1"}
+      ]
+    },
+    {
+      "name": "duplicate fields (stream->table)",
+      "statements": [
+        "CREATE STREAM TEST (data VARCHAR) WITH (kafka_topic='test_topic', value_format='JSON');",
+        "CREATE TABLE OUTPUT AS SELECT DATA, COUNT(1), COUNT(*), DATA AS COPY FROM TEST GROUP BY data;"
+      ],
+      "inputs": [
+        {"topic": "test_topic", "value": {"DATA": "d1"}, "timestamp": 1},
+        {"topic": "test_topic", "value": {"DATA": "d2"}, "timestamp": 2},
+        {"topic": "test_topic", "value": {"DATA": "d1"}, "timestamp": 3}
+      ],
+      "outputs": [
+        {"topic": "_confluent-ksql-some.ksql.service.idquery_CTAS_OUTPUT_0-Aggregate-aggregate-changelog", "key": "d1", "value": {"KSQL_INTERNAL_COL_0": "d1", "KSQL_INTERNAL_COL_1": 1, "KSQL_AGG_VARIABLE_0": 1, "KSQL_AGG_VARIABLE_1": 1}, "timestamp": 1},
+        {"topic": "_confluent-ksql-some.ksql.service.idquery_CTAS_OUTPUT_0-Aggregate-aggregate-changelog", "key": "d2", "value": {"KSQL_INTERNAL_COL_0": "d2", "KSQL_INTERNAL_COL_1": 2, "KSQL_AGG_VARIABLE_0": 1, "KSQL_AGG_VARIABLE_1": 1}, "timestamp": 2},
+        {"topic": "_confluent-ksql-some.ksql.service.idquery_CTAS_OUTPUT_0-Aggregate-aggregate-changelog", "key": "d1", "value": {"KSQL_INTERNAL_COL_0": "d1", "KSQL_INTERNAL_COL_1": 3, "KSQL_AGG_VARIABLE_0": 2, "KSQL_AGG_VARIABLE_1": 2}, "timestamp": 3},
+        {"topic": "OUTPUT", "key": "d1", "value": {"DATA": "d1", "KSQL_COL_1": 1, "KSQL_COL_2": 1, "COPY": "d1"}, "timestamp": 1},
+        {"topic": "OUTPUT", "key": "d2", "value": {"DATA": "d2", "KSQL_COL_1": 1, "KSQL_COL_2": 1, "COPY": "d2"}, "timestamp": 2},
+        {"topic": "OUTPUT", "key": "d1", "value": {"DATA": "d1", "KSQL_COL_1": 2, "KSQL_COL_2": 2, "COPY": "d1"}, "timestamp": 3}
       ]
     },
     {


### PR DESCRIPTION
### Description 

`KsqlAggregator`, and its sister `KsqlUndoAggregator` are passed a `aggValToValColumnMap` which always has values that match their keys and where the keys start at zero and are monotonically increasing, e.g. {0->0, 1->1}.   This is pretty pointless and makes the code harder to read - hence this change removes this complexity.

### Testing done 

`mvn test`

### Reviewer checklist
- [ ] Ensure docs are updated if necessary. (eg. if a user visible feature is being added or changed).
- [ ] Ensure relevant issues are linked (description should include text like "Fixes #<issue number>")

