### PR TITLE
refactor: build aggregate functions only once

### DIFF
--- a/ksql-engine/src/main/java/io/confluent/ksql/planner/plan/AggregateNode.java
+++ b/ksql-engine/src/main/java/io/confluent/ksql/planner/plan/AggregateNode.java
@@ -229,10 +229,19 @@ public class AggregateNode extends PlanNode {
         internalSchema
     );
 
-    final LogicalSchema aggStageSchema = buildAggregateSchema(
-        aggregateArgExpanded.getSchema(),
+    final KudafInitializer initializer = new KudafInitializer(requiredColumns.size());
+
+    final Map<Integer, KsqlAggregateFunction> aggValToFunctionMap = createAggValToFunctionMap(
+        aggregateArgExpanded,
+        initializer,
+        requiredColumns.size(),
         builder.getFunctionRegistry(),
         internalSchema
+    );
+
+    final LogicalSchema aggStageSchema = buildAggregateSchema(
+        aggregateArgExpanded.getSchema(),
+        aggValToFunctionMap
     );
 
     final QueryContext.Stacker aggregationContext = contextStacker.push(AGGREGATION_OP_NAME);
@@ -242,12 +251,6 @@ public class AggregateNode extends PlanNode {
         PhysicalSchema.from(aggStageSchema, SerdeOption.none()),
         aggregationContext.getQueryContext()
     );
-
-    final KudafInitializer initializer = new KudafInitializer(aggValToValColumnMap.size());
-
-    final Map<Integer, KsqlAggregateFunction> aggValToFunctionMap = createAggValToFunctionMap(
-        aggregateArgExpanded, initializer, aggValToValColumnMap.size(),
-        builder.getFunctionRegistry(), internalSchema);
 
     final SchemaKTable<?> schemaKTable = schemaKGroupedStream.aggregate(
         initializer,
@@ -360,27 +363,24 @@ public class AggregateNode extends PlanNode {
   }
 
   private LogicalSchema buildAggregateSchema(
-      final LogicalSchema schema,
-      final FunctionRegistry functionRegistry,
-      final InternalSchema internalSchema
+      final LogicalSchema inputSchema,
+      final Map<Integer, KsqlAggregateFunction> aggregateFunctions
   ) {
     final LogicalSchema.Builder schemaBuilder = LogicalSchema.builder();
-    final List<Field> fields = schema.valueFields();
+    final List<Field> fields = inputSchema.valueFields();
 
-    schemaBuilder.keyFields(schema.keyFields());
+    schemaBuilder.keyFields(inputSchema.keyFields());
 
-    for (int i = 0; i < getRequiredColumns().size(); i++) {
+    for (int i = 0; i < requiredColumns.size(); i++) {
       schemaBuilder.valueField(fields.get(i));
     }
 
     final ConnectToSqlTypeConverter converter = SchemaConverters.connectToSqlConverter();
 
-    for (int idx = 0; idx < getFunctionCalls().size(); idx++) {
-      final KsqlAggregateFunction aggregateFunction = getAggregateFunction(
-          functionRegistry,
-          internalSchema,
-          getFunctionCalls().get(idx),
-          schema);
+    for (int idx = 0; idx < aggregateFunctions.size(); idx++) {
+
+      final KsqlAggregateFunction aggregateFunction = aggregateFunctions
+          .get(requiredColumns.size() + idx);
 
       final String fieldName = AggregateExpressionRewriter.AGGREGATE_FUNCTION_VARIABLE_PREFIX + idx;
       final SqlType fieldType = converter.toSqlType(aggregateFunction.getReturnType());


### PR DESCRIPTION
### Description 

The change means the AggregateNode only builds the aggregate functions once.

Before it would build them first to get the return type needed to build the schema, then again to pass to the `aggregate` function.

This change reverses the order of these two steps, so now the schema can be built using the same aggregate function instances that will be later passed to `aggregate`.

### Testing done 

`mvn test`

### Reviewer checklist
- [ ] Ensure docs are updated if necessary. (eg. if a user visible feature is being added or changed).
- [ ] Ensure relevant issues are linked (description should include text like "Fixes #<issue number>")

