### PR TITLE
refactor: expose KsqlAggregateFunction return type as SqlType

### DIFF
--- a/ksql-common/src/main/java/io/confluent/ksql/function/KsqlAggregateFunction.java
+++ b/ksql-common/src/main/java/io/confluent/ksql/function/KsqlAggregateFunction.java
@@ -15,6 +15,7 @@
 
 package io.confluent.ksql.function;
 
+import io.confluent.ksql.schema.ksql.types.SqlType;
 import java.util.List;
 import java.util.function.Supplier;
 import org.apache.kafka.connect.data.Schema;
@@ -31,6 +32,8 @@ public interface KsqlAggregateFunction<V, A> extends IndexedFunction {
   int getArgIndexInValue();
 
   Schema getReturnType();
+
+  SqlType returnType();
 
   boolean hasSameArgTypes(List<Schema> argTypeList);
 

--- a/ksql-engine/src/test/java/io/confluent/ksql/function/BaseAggregateFunctionTest.java
+++ b/ksql-engine/src/test/java/io/confluent/ksql/function/BaseAggregateFunctionTest.java
@@ -15,6 +15,10 @@
 
 package io.confluent.ksql.function;
 
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+
+import io.confluent.ksql.schema.ksql.types.SqlTypes;
 import java.util.Collections;
 import java.util.List;
 import java.util.function.Supplier;
@@ -24,8 +28,11 @@ import org.apache.kafka.streams.kstream.Merger;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ExpectedException;
+import org.junit.runner.RunWith;
 import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnitRunner;
 
+@RunWith(MockitoJUnitRunner.class)
 public class BaseAggregateFunctionTest {
 
   @Rule
@@ -49,6 +56,22 @@ public class BaseAggregateFunctionTest {
         Collections.emptyList(),
         "the description"
     );
+  }
+
+  @Test
+  public void shouldReturnSqlReturnType() {
+    // When:
+    final TestAggFunc aggFunc = new TestAggFunc(
+        "funcName",
+        0,
+        initialValueSupplier,
+        Schema.OPTIONAL_INT64_SCHEMA,
+        Collections.emptyList(),
+        "the description"
+    );
+
+    // Then:
+    assertThat(aggFunc.returnType(), is(SqlTypes.BIGINT));
   }
 
   private static final class TestAggFunc extends BaseAggregateFunction<String, Integer> {

--- a/ksql-engine/src/test/java/io/confluent/ksql/function/InternalFunctionRegistryTest.java
+++ b/ksql-engine/src/test/java/io/confluent/ksql/function/InternalFunctionRegistryTest.java
@@ -30,6 +30,7 @@ import static org.mockito.Mockito.when;
 import com.google.common.collect.Collections2;
 import com.google.common.collect.ImmutableList;
 import io.confluent.ksql.function.udf.Kudf;
+import io.confluent.ksql.schema.ksql.types.SqlType;
 import io.confluent.ksql.util.KsqlException;
 import java.util.Arrays;
 import java.util.Collection;
@@ -257,6 +258,11 @@ public class InternalFunctionRegistryTest {
 
               @Override
               public Schema getReturnType() {
+                return null;
+              }
+
+              @Override
+              public SqlType returnType() {
                 return null;
               }
 

--- a/ksql-engine/src/test/java/io/confluent/ksql/function/UdfCompilerTest.java
+++ b/ksql-engine/src/test/java/io/confluent/ksql/function/UdfCompilerTest.java
@@ -517,11 +517,11 @@ public class UdfCompilerTest {
     return null;
   }
   
-  public static Udaf<Map<String, Integer>, Map<Long, Boolean>> createMapMap() {
+  public static Udaf<Map<String, Integer>, Map<String, Boolean>> createMapMap() {
     return null;
   }
 
-  public static Udaf<Map<String, Integer>, Map<Long, Boolean>> createMapMap(int ignored) {
+  public static Udaf<Map<String, Integer>, Map<String, Boolean>> createMapMap(int ignored) {
     return null;
   }
 


### PR DESCRIPTION
### Description 

To aid migration away from Connect's Schema type `KsqlAggregateFunction` now exposes its return type as it's `SqlType`, as well as the existing `Schema`.

The latter can be removed once all usage has been flipped to the new method.

### Testing done 

`mvn test`

### Reviewer checklist
- [ ] Ensure docs are updated if necessary. (eg. if a user visible feature is being added or changed).
- [ ] Ensure relevant issues are linked (description should include text like "Fixes #<issue number>")

