### PR TITLE
feat: add username to internal groups/topics for transient queries

### DIFF
--- a/ksql-common/src/main/java/io/confluent/ksql/util/KsqlConfig.java
+++ b/ksql-common/src/main/java/io/confluent/ksql/util/KsqlConfig.java
@@ -192,6 +192,14 @@ public class KsqlConfig extends AbstractConfig {
           + "whether the Kafka cluster supports the required API, and enables the validator if "
           + "it does.";
 
+  public static final String KSQL_APPEND_USERNAME_ON_APPLICATION_ID =
+      "ksql.append.username.on.application.id";
+  public static final String KSQL_APPEND_USERNAME_ON_APPLICATION_ID_DOC =
+      "Appends the authenticated username to the query application ID created when running "
+          + "transient queries. This config affects the name of the internal groups/topics "
+          + "created by transient queries. This config is only affected when a user impersonation "
+          + "context is provided by the KSQL security extension.";
+
   public static final Collection<CompatibilityBreakingConfigDef> COMPATIBLY_BREAKING_CONFIG_DEFS
       = ImmutableList.of(
           new CompatibilityBreakingConfigDef(
@@ -557,6 +565,12 @@ public class KsqlConfig extends AbstractConfig {
             ),
             ConfigDef.Importance.LOW,
             KSQL_ACCESS_VALIDATOR_DOC
+        ).define(
+            KSQL_APPEND_USERNAME_ON_APPLICATION_ID,
+            Type.BOOLEAN,
+            true,
+            ConfigDef.Importance.LOW,
+            KSQL_APPEND_USERNAME_ON_APPLICATION_ID_DOC
         )
         .withClientSslSupport();
     for (final CompatibilityBreakingConfigDef compatibilityBreakingConfigDef

--- a/ksql-common/src/main/java/io/confluent/ksql/util/KsqlConfig.java
+++ b/ksql-common/src/main/java/io/confluent/ksql/util/KsqlConfig.java
@@ -192,9 +192,9 @@ public class KsqlConfig extends AbstractConfig {
           + "whether the Kafka cluster supports the required API, and enables the validator if "
           + "it does.";
 
-  public static final String KSQL_APPEND_USERNAME_ON_APPLICATION_ID =
-      "ksql.append.username.on.application.id";
-  public static final String KSQL_APPEND_USERNAME_ON_APPLICATION_ID_DOC =
+  public static final String KSQL_TRANSIENT_APPLICATION_ID_APPEND_USERNAME =
+      "ksql.transient.application.id.append.username";
+  public static final String KSQL_TRANSIENT_APPLICATION_ID_APPEND_USERNAME_DOC =
       "Appends the authenticated username to the query application ID created when running "
           + "transient queries. This config affects the name of the internal groups/topics "
           + "created by transient queries. This config is only affected when a user impersonation "
@@ -566,11 +566,11 @@ public class KsqlConfig extends AbstractConfig {
             ConfigDef.Importance.LOW,
             KSQL_ACCESS_VALIDATOR_DOC
         ).define(
-            KSQL_APPEND_USERNAME_ON_APPLICATION_ID,
+            KSQL_TRANSIENT_APPLICATION_ID_APPEND_USERNAME,
             Type.BOOLEAN,
             true,
             ConfigDef.Importance.LOW,
-            KSQL_APPEND_USERNAME_ON_APPLICATION_ID_DOC
+            KSQL_TRANSIENT_APPLICATION_ID_APPEND_USERNAME_DOC
         )
         .withClientSslSupport();
     for (final CompatibilityBreakingConfigDef compatibilityBreakingConfigDef

--- a/ksql-engine/src/main/java/io/confluent/ksql/services/DefaultServiceContext.java
+++ b/ksql-engine/src/main/java/io/confluent/ksql/services/DefaultServiceContext.java
@@ -18,6 +18,7 @@ package io.confluent.ksql.services;
 import io.confluent.kafka.schemaregistry.client.SchemaRegistryClient;
 import io.confluent.ksql.util.KsqlConfig;
 import java.util.Objects;
+import java.util.Optional;
 import java.util.function.Supplier;
 import org.apache.kafka.clients.admin.Admin;
 import org.apache.kafka.streams.KafkaClientSupplier;
@@ -27,6 +28,8 @@ import org.apache.kafka.streams.KafkaClientSupplier;
  */
 public class DefaultServiceContext implements ServiceContext, AutoCloseable {
 
+  private final ContextType contextType;
+  private final Optional<String> userName;
   private final KafkaClientSupplier kafkaClientSupplier;
   private final Admin adminClient;
   private final KafkaTopicClient topicClient;
@@ -41,12 +44,44 @@ public class DefaultServiceContext implements ServiceContext, AutoCloseable {
       final Supplier<SchemaRegistryClient> srClientFactory,
       final ConnectClient connectClient
   ) {
+    this(
+        ContextType.SERVER_CONTEXT,
+        Optional.empty(),
+        kafkaClientSupplier,
+        adminClient,
+        topicClient,
+        srClientFactory,
+        connectClient
+    );
+  }
+
+  DefaultServiceContext(
+      final ContextType contextType,
+      final Optional<String> userName,
+      final KafkaClientSupplier kafkaClientSupplier,
+      final Admin adminClient,
+      final KafkaTopicClient topicClient,
+      final Supplier<SchemaRegistryClient> srClientFactory,
+      final ConnectClient connectClient
+  ) {
+    this.contextType = Objects.requireNonNull(contextType, "contextType");
+    this.userName = Objects.requireNonNull(userName, "userName");
     this.kafkaClientSupplier = Objects.requireNonNull(kafkaClientSupplier, "kafkaClientSupplier");
     this.adminClient = Objects.requireNonNull(adminClient, "adminClient");
     this.topicClient = Objects.requireNonNull(topicClient, "topicClient");
     this.srClientFactory = Objects.requireNonNull(srClientFactory, "srClientFactory");
     this.srClient = Objects.requireNonNull(srClientFactory.get(), "srClient");
     this.connectClient = Objects.requireNonNull(connectClient, "connectClient");
+  }
+
+  @Override
+  public ContextType getContextType() {
+    return contextType;
+  }
+
+  @Override
+  public Optional<String> getUsername() {
+    return userName;
   }
 
   @Override

--- a/ksql-engine/src/main/java/io/confluent/ksql/services/LazyServiceContext.java
+++ b/ksql-engine/src/main/java/io/confluent/ksql/services/LazyServiceContext.java
@@ -17,6 +17,8 @@ package io.confluent.ksql.services;
 
 import com.google.common.base.Suppliers;
 import io.confluent.kafka.schemaregistry.client.SchemaRegistryClient;
+
+import java.util.Optional;
 import java.util.function.Supplier;
 import org.apache.kafka.clients.admin.Admin;
 import org.apache.kafka.streams.KafkaClientSupplier;
@@ -26,6 +28,16 @@ public class LazyServiceContext implements ServiceContext {
 
   public LazyServiceContext(final Supplier<ServiceContext> serviceContextSupplier) {
     this.serviceContextSupplier = Suppliers.memoize(serviceContextSupplier::get)::get;
+  }
+
+  @Override
+  public ContextType getContextType() {
+    return serviceContextSupplier.get().getContextType();
+  }
+
+  @Override
+  public Optional<String> getUsername() {
+    return serviceContextSupplier.get().getUsername();
   }
 
   @Override

--- a/ksql-engine/src/main/java/io/confluent/ksql/services/SandboxedServiceContext.java
+++ b/ksql-engine/src/main/java/io/confluent/ksql/services/SandboxedServiceContext.java
@@ -18,6 +18,7 @@ package io.confluent.ksql.services;
 import io.confluent.kafka.schemaregistry.client.SchemaRegistryClient;
 import io.confluent.ksql.util.Sandbox;
 import java.util.Objects;
+import java.util.Optional;
 import java.util.function.Supplier;
 import org.apache.kafka.clients.admin.Admin;
 import org.apache.kafka.streams.KafkaClientSupplier;
@@ -30,6 +31,8 @@ import org.apache.kafka.streams.KafkaClientSupplier;
 @Sandbox
 public final class SandboxedServiceContext implements ServiceContext {
 
+  private final ContextType contextType;
+  private final Optional<String> userName;
   private final KafkaTopicClient topicClient;
   private final SchemaRegistryClient srClient;
   private final KafkaClientSupplier kafkaClientSupplier;
@@ -48,6 +51,8 @@ public final class SandboxedServiceContext implements ServiceContext {
     final ConnectClient connectClient = SandboxConnectClient.createProxy();
 
     return new SandboxedServiceContext(
+        serviceContext.getContextType(),
+        serviceContext.getUsername(),
         kafkaClientSupplier,
         kafkaTopicClient,
         schemaRegistryClient,
@@ -55,15 +60,29 @@ public final class SandboxedServiceContext implements ServiceContext {
   }
 
   private SandboxedServiceContext(
+      final ContextType contextType,
+      final Optional<String> userName,
       final KafkaClientSupplier kafkaClientSupplier,
       final KafkaTopicClient topicClient,
       final SchemaRegistryClient srClient,
       final ConnectClient connectClient
   ) {
+    this.contextType = Objects.requireNonNull(contextType, "contextType");
+    this.userName = Objects.requireNonNull(userName, "userName");
     this.kafkaClientSupplier = Objects.requireNonNull(kafkaClientSupplier, "kafkaClientSupplier");
     this.topicClient = Objects.requireNonNull(topicClient, "topicClient");
     this.srClient = Objects.requireNonNull(srClient, "srClient");
     this.connectClient = Objects.requireNonNull(connectClient, "connectClient");
+  }
+
+  @Override
+  public ContextType getContextType() {
+    return contextType;
+  }
+
+  @Override
+  public Optional<String> getUsername() {
+    return userName;
   }
 
   @Override

--- a/ksql-execution/src/main/java/io/confluent/ksql/services/ServiceContext.java
+++ b/ksql-execution/src/main/java/io/confluent/ksql/services/ServiceContext.java
@@ -16,6 +16,8 @@
 package io.confluent.ksql.services;
 
 import io.confluent.kafka.schemaregistry.client.SchemaRegistryClient;
+
+import java.util.Optional;
 import java.util.function.Supplier;
 import org.apache.kafka.clients.admin.Admin;
 import org.apache.kafka.streams.KafkaClientSupplier;
@@ -24,6 +26,29 @@ import org.apache.kafka.streams.KafkaClientSupplier;
  * Provides access to clients required to communicate with remote services.
  */
 public interface ServiceContext extends AutoCloseable {
+  /**
+   * The {@code ContexType} specifies how this {@code ServiceContext} is being executed.
+   *
+   * <p>As an authenticated user using impersonation ({@code CLIENT_CONTEXT}, or as the
+   * KSQL service principal ({@code SERVER_CONTEXT}.
+   */
+  enum ContextType {
+    CLIENT_CONTEXT, SERVER_CONTEXT
+  }
+
+  /**
+   * Get the {@code ContextType} for this {@code ServiceContext}.
+   *
+   * @return the {@code ContextType} for this {@code ServiceContext}.
+   */
+  ContextType getContextType();
+
+  /**
+   * Get the user name whom this {@code ServiceContext} is configured.
+   *
+   * @return
+   */
+  Optional<String> getUsername();
 
   /**
    * Get the shared {@link Admin} instance.

--- a/ksql-execution/src/main/java/io/confluent/ksql/services/ServiceContext.java
+++ b/ksql-execution/src/main/java/io/confluent/ksql/services/ServiceContext.java
@@ -29,8 +29,8 @@ public interface ServiceContext extends AutoCloseable {
   /**
    * The {@code ContexType} specifies how this {@code ServiceContext} is being executed.
    *
-   * <p>As an authenticated user using impersonation ({@code CLIENT_CONTEXT}, or as the
-   * KSQL service principal ({@code SERVER_CONTEXT}.
+   * <p>As an authenticated user using impersonation {@code CLIENT_CONTEXT}, or as the
+   * KSQL service principal {@code SERVER_CONTEXT}.
    */
   enum ContextType {
     CLIENT_CONTEXT, SERVER_CONTEXT

--- a/ksql-rest-app/src/main/java/io/confluent/ksql/rest/server/resources/streaming/WSQueryEndpoint.java
+++ b/ksql-rest-app/src/main/java/io/confluent/ksql/rest/server/resources/streaming/WSQueryEndpoint.java
@@ -104,6 +104,8 @@ public class WSQueryEndpoint {
   @FunctionalInterface
   interface UserServiceContextFactory {
     ServiceContext create(
+        ServiceContext.ContextType contextType,
+        Optional<String> userName,
         KsqlConfig ksqlConfig,
         KafkaClientSupplier kafkaClientSupplier,
         Supplier<SchemaRegistryClient> srClientFactory
@@ -288,13 +290,15 @@ public class WSQueryEndpoint {
     // Creates a ServiceContext using the user's credentials, so the WS query topics are
     // accessed with the user permission context (defaults to KSQL service context)
 
-    if (!securityExtension.getUserContextProvider().isPresent()) {
+    if (principal == null || !securityExtension.getUserContextProvider().isPresent()) {
       return defaultServiceContextFactory.apply(ksqlConfig);
     }
 
     return securityExtension.getUserContextProvider()
         .map(provider ->
             serviceContextFactory.create(
+                ServiceContext.ContextType.CLIENT_CONTEXT,
+                Optional.of(principal.getName()),
                 ksqlConfig,
                 provider.getKafkaClientSupplier(principal),
                 provider.getSchemaRegistryClientFactory(principal)))


### PR DESCRIPTION
### Description 
When the KSQL security extension is enabled, the provided impersonated context allows KSQL to execute transient queries using the Client user credentials so Kafka streams are executed with the right User permissions.

This KStream execution creates some internal groups/topics when running the queries, and if the User does not have permissions on them, then the transient query fails.
```
ksql> select last_name from names_table;
Could not create topic _confluent-ksql-ksqltransient_338843436700155011_1561677941055-KsqlTopic-reduce-changelog.
Caused by: Not authorized to access topics: [Topic authorization failed.]
Query terminated
```

A workaround is to grant Users permissions to Create/Read/Write from those internal groups/topics using Kafka prefixed permissions.
i.e.
```
  Group:PREFIXED:_confluent_ksql-default_transient
  Topic:PREFIXED:_confluent_ksql-default_transient
```

However, in the case of tables, the prefixed permissions also grant Users access to internal table state from other User's transient queries on tables.

To fix this problem, this PR includes the authenticated username to those internal groups/topics so Admins can grant permissions to Users on their groups/topics created.
i.e. 
```
  Group:PREFIXED:_confluent_ksql-default_User1transient
  Topic:PREFIXED:_confluent_ksql-default_User1transient
```

With the above prefixes, Users will only have access to groups/topics from transient queries they execute.

`How to review`
1. Commit 1: Modify the `ServiceContext` (and its impls) to add the username whom the service was configured. If a username is provided by authentication and the KSQL security extension provides an impersonation context, then this username is set on the `ServiceContext` + a `CLIENT_CONTEXT` flag is set to differentiate between server and clients. 
1.1 The `KsqlRestServiceContextFactory` is the one that sets this Client information in the above case.  
2. Commit 2: Add the username to the application ID in the `PhysicalPlanBuilder` so it is passed when building the stream application. 
2.1 Kafka has different rules for topics and user names. Usernames accept almost any character, but topics do not. KSQL must sanitize the user name before including it in the topic (see https://github.com/apache/kafka/blob/trunk/clients/src/main/java/org/apache/kafka/common/utils/Sanitizer.java and https://github.com/apache/kafka/blob/trunk/clients/src/main/java/org/apache/kafka/common/internals/Topic.java).
2.2 Topics has a max. length of 249 chars. To prevent issues when a user name and service ID is too long that causes transient queries to fail, then I added a flag that disables this feature. I don't see this to happen, but just in case, we can use it as quick fix. 

### Testing done 
- Added unit tests
- Run manual tests
```
ksql> select * from aug23_t;
Could not create topic _confluent-ksql-default_user1transient_7566640532637605065_1566849431000-KsqlTopic-reduce-changelog.
Caused by: Topic authorization failed.
Query terminated
```

### Reviewer checklist
- [ ] Ensure docs are updated if necessary. (eg. if a user visible feature is being added or changed).
- [ ] Ensure relevant issues are linked (description should include text like "Fixes #<issue number>")

