### PR TITLE
fix: address deprecation of getAdminClient

### DIFF
--- a/ksql-engine/src/main/java/io/confluent/ksql/services/ConfiguredKafkaClientSupplier.java
+++ b/ksql-engine/src/main/java/io/confluent/ksql/services/ConfiguredKafkaClientSupplier.java
@@ -19,7 +19,7 @@ import com.google.common.collect.ImmutableMap;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Objects;
-import org.apache.kafka.clients.admin.AdminClient;
+import org.apache.kafka.clients.admin.Admin;
 import org.apache.kafka.clients.consumer.Consumer;
 import org.apache.kafka.clients.producer.Producer;
 import org.apache.kafka.streams.KafkaClientSupplier;
@@ -49,8 +49,8 @@ public class ConfiguredKafkaClientSupplier implements KafkaClientSupplier {
   }
 
   @Override
-  public AdminClient getAdminClient(final Map<String, Object> config) {
-    return defaultSupplier.getAdminClient(injectSupplierProperties(config));
+  public Admin getAdmin(final Map<String, Object> config) {
+    return defaultSupplier.getAdmin(injectSupplierProperties(config));
   }
 
   @Override

--- a/ksql-engine/src/main/java/io/confluent/ksql/services/SandboxedKafkaClientSupplier.java
+++ b/ksql-engine/src/main/java/io/confluent/ksql/services/SandboxedKafkaClientSupplier.java
@@ -16,7 +16,7 @@
 package io.confluent.ksql.services;
 
 import java.util.Map;
-import org.apache.kafka.clients.admin.AdminClient;
+import org.apache.kafka.clients.admin.Admin;
 import org.apache.kafka.clients.consumer.Consumer;
 import org.apache.kafka.clients.producer.Producer;
 import org.apache.kafka.streams.KafkaClientSupplier;
@@ -35,7 +35,7 @@ class SandboxedKafkaClientSupplier implements KafkaClientSupplier {
   }
 
   @Override
-  public AdminClient getAdminClient(final Map<String, Object> config) {
+  public Admin getAdmin(final Map<String, Object> config) {
     return new SandboxedAdminClient();
   }
 

--- a/ksql-engine/src/main/java/io/confluent/ksql/services/ServiceContextFactory.java
+++ b/ksql-engine/src/main/java/io/confluent/ksql/services/ServiceContextFactory.java
@@ -40,7 +40,7 @@ public final class ServiceContextFactory {
       final KafkaClientSupplier kafkaClientSupplier,
       final Supplier<SchemaRegistryClient> srClientFactory
   ) {
-    final Admin adminClient = kafkaClientSupplier.getAdminClient(
+    final Admin adminClient = kafkaClientSupplier.getAdmin(
         ksqlConfig.getKsqlAdminClientConfigProps()
     );
 

--- a/ksql-engine/src/test/java/io/confluent/ksql/KsqlContextTestUtil.java
+++ b/ksql-engine/src/test/java/io/confluent/ksql/KsqlContextTestUtil.java
@@ -46,7 +46,7 @@ public final class KsqlContextTestUtil {
     final KafkaClientSupplier clientSupplier = new DefaultKafkaClientSupplier();
 
     final Admin adminClient = clientSupplier
-        .getAdminClient(ksqlConfig.getKsqlAdminClientConfigProps());
+        .getAdmin(ksqlConfig.getKsqlAdminClientConfigProps());
 
     final KafkaTopicClient kafkaTopicClient = new KafkaTopicClientImpl(adminClient);
 

--- a/ksql-engine/src/test/java/io/confluent/ksql/services/SandboxedKafkaClientSupplierTest.java
+++ b/ksql-engine/src/test/java/io/confluent/ksql/services/SandboxedKafkaClientSupplierTest.java
@@ -46,7 +46,7 @@ public final class SandboxedKafkaClientSupplierTest {
     @Parameterized.Parameters(name = "{0}")
     public static Collection<TestCase<SandboxedKafkaClientSupplier>> getMethodsToTest() {
       return TestMethods.builder(SandboxedKafkaClientSupplier.class)
-          .ignore("getAdminClient", Map.class)
+          .ignore("getAdmin", Map.class)
           .ignore("getProducer", Map.class)
           .ignore("getConsumer", Map.class)
           .ignore("getRestoreConsumer", Map.class)
@@ -83,7 +83,7 @@ public final class SandboxedKafkaClientSupplierTest {
 
     @Test
     public void shouldReturnTryAdminClient() {
-      assertThat(sandboxedKafkaClientSupplier.getAdminClient(config),
+      assertThat(sandboxedKafkaClientSupplier.getAdmin(config),
           is(instanceOf(SandboxedAdminClient.class)));
     }
 

--- a/ksql-engine/src/test/java/io/confluent/ksql/services/TestServiceContext.java
+++ b/ksql-engine/src/test/java/io/confluent/ksql/services/TestServiceContext.java
@@ -60,7 +60,7 @@ public final class TestServiceContext {
   ) {
     return create(
         new FakeKafkaClientSupplier(),
-        new FakeKafkaClientSupplier().getAdminClient(Collections.emptyMap()),
+        new FakeKafkaClientSupplier().getAdmin(Collections.emptyMap()),
         topicClient,
         srClientFactory,
         new DefaultConnectClient("http://localhost:8083")
@@ -73,7 +73,7 @@ public final class TestServiceContext {
   ) {
     final DefaultKafkaClientSupplier kafkaClientSupplier = new DefaultKafkaClientSupplier();
     final Admin adminClient = kafkaClientSupplier
-        .getAdminClient(ksqlConfig.getKsqlAdminClientConfigProps());
+        .getAdmin(ksqlConfig.getKsqlAdminClientConfigProps());
 
     return create(
         kafkaClientSupplier,

--- a/ksql-engine/src/test/java/io/confluent/ksql/util/FakeKafkaClientSupplier.java
+++ b/ksql-engine/src/test/java/io/confluent/ksql/util/FakeKafkaClientSupplier.java
@@ -17,7 +17,7 @@ package io.confluent.ksql.util;
 
 import java.util.Collections;
 import java.util.Map;
-import org.apache.kafka.clients.admin.AdminClient;
+import org.apache.kafka.clients.admin.Admin;
 import org.apache.kafka.clients.admin.MockAdminClient;
 import org.apache.kafka.clients.consumer.Consumer;
 import org.apache.kafka.clients.consumer.MockConsumer;
@@ -30,7 +30,7 @@ import org.apache.kafka.streams.KafkaClientSupplier;
 public class FakeKafkaClientSupplier implements KafkaClientSupplier {
 
   @Override
-  public AdminClient getAdminClient(final Map<String, Object> config) {
+  public Admin getAdmin(final Map<String, Object> config) {
     final Node node = new Node(1, "localhost", 1234);
     return new MockAdminClient(Collections.singletonList(node), node);
   }


### PR DESCRIPTION
### Description 

Replace usage with `getAdmin` because KStreams deprecated `getAdminClient`

### Testing done 
`mvn clean install`

### Reviewer checklist
- [ ] Ensure docs are updated if necessary. (eg. if a user visible feature is being added or changed).
- [ ] Ensure relevant issues are linked (description should include text like "Fixes #<issue number>")

