### PR TITLE
fix: increment query_id even on failed queries to prevent id offset during restore

### DIFF
--- a/ksql-common/src/main/java/io/confluent/ksql/util/KsqlMissingSourceException.java
+++ b/ksql-common/src/main/java/io/confluent/ksql/util/KsqlMissingSourceException.java
@@ -1,0 +1,23 @@
+/*
+ * Copyright 2019 Confluent Inc.
+ *
+ * Licensed under the Confluent Community License (the "License"); you may not use
+ * this file except in compliance with the License.  You may obtain a copy of the
+ * License at
+ *
+ * http://www.confluent.io/confluent-community-license
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package io.confluent.ksql.util;
+
+public class KsqlMissingSourceException extends KsqlException {
+
+  public KsqlMissingSourceException(final String message) {
+    super(message);
+  }
+}

--- a/ksql-engine/src/main/java/io/confluent/ksql/engine/EngineContext.java
+++ b/ksql-engine/src/main/java/io/confluent/ksql/engine/EngineContext.java
@@ -196,4 +196,8 @@ final class EngineContext {
 
     outerOnQueryCloseCallback.accept(serviceContext, query);
   }
+
+  void incrementQueryId() {
+    this.queryIdGenerator.getNextId();
+  }
 }

--- a/ksql-engine/src/main/java/io/confluent/ksql/engine/KsqlEngine.java
+++ b/ksql-engine/src/main/java/io/confluent/ksql/engine/KsqlEngine.java
@@ -221,4 +221,8 @@ public class KsqlEngine implements KsqlExecutionContext, Closeable {
 
     StreamsErrorCollector.notifyApplicationClose(applicationId);
   }
+
+  public void incrementQueryId() {
+    this.primaryContext.incrementQueryId();
+  }
 }

--- a/ksql-parser/src/main/java/io/confluent/ksql/parser/AstBuilder.java
+++ b/ksql-parser/src/main/java/io/confluent/ksql/parser/AstBuilder.java
@@ -124,6 +124,7 @@ import io.confluent.ksql.schema.Operator;
 import io.confluent.ksql.util.DataSourceExtractor;
 import io.confluent.ksql.util.KsqlConstants;
 import io.confluent.ksql.util.KsqlException;
+import io.confluent.ksql.util.KsqlMissingSourceException;
 import io.confluent.ksql.util.Pair;
 import io.confluent.ksql.util.ParserUtil;
 import java.util.ArrayList;
@@ -1245,7 +1246,8 @@ public class AstBuilder {
     ) {
       final DataSource<?> source = metaStore.getSource(name);
       if (source == null) {
-        throw new InvalidColumnReferenceException(location, name + " does not exist.");
+        throw new InvalidColumnReferenceException(location, name + " does not exist.",
+            new KsqlMissingSourceException("Could not find source: " + name));
       }
 
       return source;
@@ -1258,6 +1260,14 @@ public class AstBuilder {
           final String message
       ) {
         super(location.map(loc -> loc + ": ").orElse("") + message);
+      }
+
+      private InvalidColumnReferenceException(
+              final Optional<NodeLocation> location,
+              final String message,
+              final Throwable cause
+      ) {
+        super(location.map(loc -> loc + ": ").orElse("") + message, cause);
       }
     }
   }

--- a/ksql-parser/src/main/java/io/confluent/ksql/util/DataSourceExtractor.java
+++ b/ksql-parser/src/main/java/io/confluent/ksql/util/DataSourceExtractor.java
@@ -145,7 +145,9 @@ public class DataSourceExtractor {
         fromAlias = alias;
         fromName = table.getName().getSuffix().toUpperCase();
         if (metaStore.getSource(table.getName().getSuffix()) == null) {
-          throw new KsqlException(table.getName().getSuffix() + " does not exist.");
+          throw new KsqlException(table.getName().getSuffix() + " does not exist.",
+              new KsqlMissingSourceException(
+                  "Could not find source: " + table.getName().getSuffix()));
         }
 
         return null;

--- a/ksql-parser/src/test/java/io/confluent/ksql/util/DataSourceExtractorTest.java
+++ b/ksql-parser/src/test/java/io/confluent/ksql/util/DataSourceExtractorTest.java
@@ -16,8 +16,11 @@
 package io.confluent.ksql.util;
 
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.allOf;
+import static org.hamcrest.Matchers.hasProperty;
 import static org.hamcrest.Matchers.hasSize;
 import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.isA;
 import static org.mockito.Mockito.mock;
 
 import io.confluent.ksql.function.FunctionRegistry;
@@ -93,6 +96,11 @@ public class DataSourceExtractorTest {
     // Then:
     expectedException.expect(KsqlException.class);
     expectedException.expectMessage("UNKNOWN does not exist.");
+    expectedException.expectCause(
+        allOf(
+            isA(KsqlMissingSourceException.class),
+            hasProperty("message", is("Could not find source: UNKNOWN")
+    )));
 
     // When:
     extractor.extractDataSources(stmt);


### PR DESCRIPTION
### Description 
Issue: https://github.com/confluentinc/ksql/issues/3269

To the best of my understanding, the command topic doesn't store statements that don't succeed while the server is running, so CREATE statements or any statement that failed while the server is running won't be executed during restore and therefore won't affect the QueryId.

Sample of behavior currently

Before every scenario run these
```
CREATE STREAM foo(age BIGINT) WITH (KAFKA_TOPIC='foo',  VALUE_FORMAT='JSON');
CREATE STREAM bar (age BIGINT) WITH (KAFKA_TOPIC='bar', VALUE_FORMAT='JSON');
CREATE STREAM test(age BIGINT) WITH (KAFKA_TOPIC='test',  VALUE_FORMAT='JSON');
```
_______ 
```
CREATE STREAM foo_copy AS SELECT * from foo; 
TERMINATE CSAS_FOO_COPY_0;

CREATE STREAM bar_copy AS SELECT * from bar; 
TERMINATE CSAS_BAR_COPY_1;
```
No queries remaining
Close server, Delete topic foo, reboot server
CSAS_BAR_COPY_0 is running 
_________________________________________________________________________________
```
INSERT INTO test  SELECT age FROM foo;
TERMINATE InsertQuery_0;

INSERT INTO test  SELECT age FROM bar;
TERMINATE InsertQuery_1;
```
No queries remaining
Close server, Delete topic foo, reboot server
InsertQuery_0 (INSERT INTO test  SELECT age FROM bar) is running
___________________________________________________________________________________
```
INSERT INTO foo SELECT age FROM test;
TERMINATE InsertQuery_0;

INSERT INTO bar SELECT age FROM test;
TERMINATE InsertQuery_1;
```
No queries remaining
Close server, Delete topic foo, reboot server
InsertQuery_0 (INSERT INTO bar  SELECT age FROM test) is running
Logs indicate a InvalidColumnReferenceException thrown when trying to getSource of InsertInto node for inserting into stream foo (different exception to first two examples)

### Testing done 
Unit tests 
Local testing:
```
CREATE STREAM test(age BIGINT) WITH (KAFKA_TOPIC='test',  VALUE_FORMAT='JSON');
CREATE STREAM foo(age BIGINT) WITH (KAFKA_TOPIC='foo',  VALUE_FORMAT='JSON');
CREATE STREAM foo_copy AS SELECT * from foo; 
INSERT INTO test  SELECT age FROM foo;
INSERT INTO foo SELECT age FROM test;
TERMINATE CSAS_FOO_COPY_0;
TERMINATE InsertQuery_1;
TERMINATE InsertQuery_2;

CREATE STREAM bar (age BIGINT) WITH (KAFKA_TOPIC='bar', VALUE_FORMAT='JSON');
CREATE STREAM bar_copy AS SELECT * from bar; 
INSERT INTO test  SELECT age FROM bar;
INSERT INTO bar  SELECT age FROM test;
TERMINATE CSAS_BAR_COPY_3;
TERMINATE InsertQuery_4;
TERMINATE InsertQuery_5;

# Behavior on master
SHOW QUERIES;
 Query ID        | Kafka Topic | Query String                                                                               
----------------------------------------------------------------------------------------------------------------------------
 CSAS_BAR_COPY_0 | BAR_COPY    | CREATE STREAM BAR_COPY WITH (KAFKA_TOPIC='BAR_COPY', PARTITIONS=1, REPLICAS=1) AS SELECT *
FROM BAR BAR; 
 InsertQuery_1   | TEST        | INSERT INTO test  SELECT age FROM bar;                                                     
 InsertQuery_2   | BAR         | INSERT INTO bar  SELECT age FROM test;                                                     
----------------------------------------------------------------------------------------------------------------------------

# Behavior after change
SHOW QUERIES;
----------------------------------------------------------------------------------------------------------------------------                                                  
----------------------------------------------------------------------------------------------------------------------------
```
### Reviewer checklist
- [ ] Ensure docs are updated if necessary. (eg. if a user visible feature is being added or changed).
- [ ] Ensure relevant issues are linked (description should include text like "Fixes #<issue number>")

