### PR TITLE
feat: add SHOW TYPES to list all custom types

### DIFF
--- a/ksql-cli/src/main/java/io/confluent/ksql/cli/console/table/builder/TypeListTableBuilder.java
+++ b/ksql-cli/src/main/java/io/confluent/ksql/cli/console/table/builder/TypeListTableBuilder.java
@@ -18,7 +18,9 @@ package io.confluent.ksql.cli.console.table.builder;
 import com.google.common.collect.ImmutableList;
 import io.confluent.ksql.cli.console.table.Table;
 import io.confluent.ksql.rest.entity.TypeList;
+import java.util.Comparator;
 import java.util.List;
+import java.util.Map.Entry;
 
 public class TypeListTableBuilder implements TableBuilder<TypeList> {
 
@@ -32,6 +34,7 @@ public class TypeListTableBuilder implements TableBuilder<TypeList> {
             .getTypes()
             .entrySet()
             .stream()
+            .sorted(Comparator.comparing(Entry::getKey))
             .map(entry -> ImmutableList.of(entry.getKey(), entry.getValue().toTypeString())))
         .build();
   }

--- a/ksql-cli/src/main/java/io/confluent/ksql/cli/console/table/builder/TypeListTableBuilder.java
+++ b/ksql-cli/src/main/java/io/confluent/ksql/cli/console/table/builder/TypeListTableBuilder.java
@@ -1,0 +1,38 @@
+/*
+ * Copyright 2019 Confluent Inc.
+ *
+ * Licensed under the Confluent Community License (the "License"; you may not use
+ * this file except in compliance with the License. You may obtain a copy of the
+ * License at
+ *
+ * http://www.confluent.io/confluent-community-license
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package io.confluent.ksql.cli.console.table.builder;
+
+import com.google.common.collect.ImmutableList;
+import io.confluent.ksql.cli.console.table.Table;
+import io.confluent.ksql.rest.entity.TypeList;
+import java.util.List;
+
+public class TypeListTableBuilder implements TableBuilder<TypeList> {
+
+  private static final List<String> HEADERS = ImmutableList.of("Type Name", "Schema");
+
+  @Override
+  public Table buildTable(final TypeList entity) {
+    return new Table.Builder()
+        .withColumnHeaders(HEADERS)
+        .withRows(entity
+            .getTypes()
+            .entrySet()
+            .stream()
+            .map(entry -> ImmutableList.of(entry.getKey(), entry.getValue().toTypeString())))
+        .build();
+  }
+}

--- a/ksql-cli/src/test/java/io/confluent/ksql/cli/console/ConsoleTest.java
+++ b/ksql-cli/src/test/java/io/confluent/ksql/cli/console/ConsoleTest.java
@@ -868,15 +868,15 @@ public class ConsoleTest {
     // Given:
     final KsqlEntityList entities = new KsqlEntityList(ImmutableList.of(
         new TypeList("statement", ImmutableMap.of(
+            "typeB", new SchemaInfo(
+                SqlBaseType.ARRAY,
+                null,
+                new SchemaInfo(SqlBaseType.STRING, null, null)),
             "typeA", new SchemaInfo(
                 SqlBaseType.STRUCT,
                 ImmutableList.of(
                     new FieldInfo("f1", new SchemaInfo(SqlBaseType.STRING, null, null))),
-                null),
-            "typeB", new SchemaInfo(
-                SqlBaseType.ARRAY,
-                null,
-                new SchemaInfo(SqlBaseType.STRING, null, null))
+                null)
         ))
     ));
 
@@ -890,6 +890,15 @@ public class ConsoleTest {
           + "  \"@type\" : \"type_list\",\n"
           + "  \"statementText\" : \"statement\",\n"
           + "  \"types\" : {\n"
+          + "    \"typeB\" : {\n"
+          + "      \"type\" : \"ARRAY\",\n"
+          + "      \"fields\" : null,\n"
+          + "      \"memberSchema\" : {\n"
+          + "        \"type\" : \"STRING\",\n"
+          + "        \"fields\" : null,\n"
+          + "        \"memberSchema\" : null\n"
+          + "      }\n"
+          + "    },\n"
           + "    \"typeA\" : {\n"
           + "      \"type\" : \"STRUCT\",\n"
           + "      \"fields\" : [ {\n"
@@ -901,15 +910,6 @@ public class ConsoleTest {
           + "        }\n"
           + "      } ],\n"
           + "      \"memberSchema\" : null\n"
-          + "    },\n"
-          + "    \"typeB\" : {\n"
-          + "      \"type\" : \"ARRAY\",\n"
-          + "      \"fields\" : null,\n"
-          + "      \"memberSchema\" : {\n"
-          + "        \"type\" : \"STRING\",\n"
-          + "        \"fields\" : null,\n"
-          + "        \"memberSchema\" : null\n"
-          + "      }\n"
           + "    }\n"
           + "  },\n"
           + "  \"warnings\" : [ ]\n"

--- a/ksql-cli/src/test/java/io/confluent/ksql/cli/console/ConsoleTest.java
+++ b/ksql-cli/src/test/java/io/confluent/ksql/cli/console/ConsoleTest.java
@@ -64,6 +64,7 @@ import io.confluent.ksql.rest.entity.StreamedRow;
 import io.confluent.ksql.rest.entity.StreamsList;
 import io.confluent.ksql.rest.entity.TablesList;
 import io.confluent.ksql.rest.entity.TopicDescription;
+import io.confluent.ksql.rest.entity.TypeList;
 import io.confluent.ksql.rest.server.computation.CommandId;
 import io.confluent.ksql.rest.util.EntityUtil;
 import io.confluent.ksql.schema.ksql.LogicalSchema;
@@ -859,6 +860,67 @@ public class ConsoleTest {
           + " foo            | SOURCE  | clazz \n"
           + " bar            | UNKNOWN |       \n"
           + "----------------------------------\n"));
+    }
+  }
+
+  @Test
+  public void shouldPrintTypesList() throws IOException {
+    // Given:
+    final KsqlEntityList entities = new KsqlEntityList(ImmutableList.of(
+        new TypeList("statement", ImmutableMap.of(
+            "typeA", new SchemaInfo(
+                SqlBaseType.STRUCT,
+                ImmutableList.of(
+                    new FieldInfo("f1", new SchemaInfo(SqlBaseType.STRING, null, null))),
+                null),
+            "typeB", new SchemaInfo(
+                SqlBaseType.ARRAY,
+                null,
+                new SchemaInfo(SqlBaseType.STRING, null, null))
+        ))
+    ));
+
+    // When:
+    console.printKsqlEntityList(entities);
+
+    // Then:
+    final String output = terminal.getOutputString();
+    if (console.getOutputFormat() == OutputFormat.JSON) {
+      assertThat(output, is("[ {\n"
+          + "  \"@type\" : \"type_list\",\n"
+          + "  \"statementText\" : \"statement\",\n"
+          + "  \"types\" : {\n"
+          + "    \"typeA\" : {\n"
+          + "      \"type\" : \"STRUCT\",\n"
+          + "      \"fields\" : [ {\n"
+          + "        \"name\" : \"f1\",\n"
+          + "        \"schema\" : {\n"
+          + "          \"type\" : \"STRING\",\n"
+          + "          \"fields\" : null,\n"
+          + "          \"memberSchema\" : null\n"
+          + "        }\n"
+          + "      } ],\n"
+          + "      \"memberSchema\" : null\n"
+          + "    },\n"
+          + "    \"typeB\" : {\n"
+          + "      \"type\" : \"ARRAY\",\n"
+          + "      \"fields\" : null,\n"
+          + "      \"memberSchema\" : {\n"
+          + "        \"type\" : \"STRING\",\n"
+          + "        \"fields\" : null,\n"
+          + "        \"memberSchema\" : null\n"
+          + "      }\n"
+          + "    }\n"
+          + "  },\n"
+          + "  \"warnings\" : [ ]\n"
+          + "} ]\n"));
+    } else {
+      assertThat(output, is("\n"
+          + " Type Name | Schema                     \n"
+          + "----------------------------------------\n"
+          + " typeA     | STRUCT<f1 VARCHAR(STRING)> \n"
+          + " typeB     | ARRAY<VARCHAR(STRING)>     \n"
+          + "----------------------------------------\n"));
     }
   }
 

--- a/ksql-parser/src/main/antlr4/io/confluent/ksql/parser/SqlBase.g4
+++ b/ksql-parser/src/main/antlr4/io/confluent/ksql/parser/SqlBase.g4
@@ -39,6 +39,7 @@ statement
     | (LIST | SHOW) TABLES EXTENDED?                                        #listTables
     | (LIST | SHOW) FUNCTIONS                                               #listFunctions
     | (LIST | SHOW) (SOURCE | SINK)? CONNECTORS                             #listConnectors
+    | (LIST | SHOW) TYPES                                                   #listTypes
     | DESCRIBE EXTENDED? qualifiedName                                      #showColumns
     | DESCRIBE FUNCTION qualifiedName                                       #describeFunction
     | DESCRIBE CONNECTOR identifier                                         #describeConnector
@@ -319,7 +320,7 @@ nonReserved
     | STRUCT | MAP | ARRAY | PARTITION
     | INTEGER | DATE | TIME | TIMESTAMP | INTERVAL | ZONE
     | YEAR | MONTH | DAY | HOUR | MINUTE | SECOND
-    | EXPLAIN | ANALYZE | TYPE
+    | EXPLAIN | ANALYZE | TYPE | TYPES
     | SET | RESET
     | IF
     | SOURCE | SINK
@@ -403,6 +404,7 @@ PRINT: 'PRINT';
 EXPLAIN: 'EXPLAIN';
 ANALYZE: 'ANALYZE';
 TYPE: 'TYPE';
+TYPES: 'TYPES';
 CAST: 'CAST';
 SHOW: 'SHOW';
 LIST: 'LIST';

--- a/ksql-parser/src/main/java/io/confluent/ksql/parser/AstBuilder.java
+++ b/ksql-parser/src/main/java/io/confluent/ksql/parser/AstBuilder.java
@@ -63,6 +63,7 @@ import io.confluent.ksql.parser.SqlBaseParser.InsertValuesContext;
 import io.confluent.ksql.parser.SqlBaseParser.IntervalClauseContext;
 import io.confluent.ksql.parser.SqlBaseParser.LimitClauseContext;
 import io.confluent.ksql.parser.SqlBaseParser.ListConnectorsContext;
+import io.confluent.ksql.parser.SqlBaseParser.ListTypesContext;
 import io.confluent.ksql.parser.SqlBaseParser.RegisterTypeContext;
 import io.confluent.ksql.parser.SqlBaseParser.SingleStatementContext;
 import io.confluent.ksql.parser.SqlBaseParser.TablePropertiesContext;
@@ -99,6 +100,7 @@ import io.confluent.ksql.parser.tree.ListQueries;
 import io.confluent.ksql.parser.tree.ListStreams;
 import io.confluent.ksql.parser.tree.ListTables;
 import io.confluent.ksql.parser.tree.ListTopics;
+import io.confluent.ksql.parser.tree.ListTypes;
 import io.confluent.ksql.parser.tree.PrintTopic;
 import io.confluent.ksql.parser.tree.Query;
 import io.confluent.ksql.parser.tree.RegisterType;
@@ -621,6 +623,11 @@ public class AstBuilder {
     @Override
     public Node visitDropType(final DropTypeContext ctx) {
       return new DropType(getLocation(ctx), getIdentifierText(ctx.identifier()));
+    }
+
+    @Override
+    public Node visitListTypes(final ListTypesContext ctx) {
+      return new ListTypes(getLocation(ctx));
     }
 
     @Override

--- a/ksql-parser/src/main/java/io/confluent/ksql/parser/tree/AstVisitor.java
+++ b/ksql-parser/src/main/java/io/confluent/ksql/parser/tree/AstVisitor.java
@@ -168,6 +168,10 @@ public abstract class AstVisitor<R, C> {
     return visitStatement(node, context);
   }
 
+  protected R visitListTypes(final ListTypes listTypes, final C context) {
+    return visitStatement(listTypes, context);
+  }
+
   protected R visitUnsetProperty(final UnsetProperty node, final C context) {
     return visitStatement(node, context);
   }

--- a/ksql-parser/src/main/java/io/confluent/ksql/parser/tree/ListTypes.java
+++ b/ksql-parser/src/main/java/io/confluent/ksql/parser/tree/ListTypes.java
@@ -28,6 +28,11 @@ public class ListTypes extends Statement {
   }
 
   @Override
+  public <R, C> R accept(final AstVisitor<R, C> visitor, final C context) {
+    return visitor.visitListTypes(this, context);
+  }
+
+  @Override
   public int hashCode() {
     return Objects.hashCode(getClass());
   }

--- a/ksql-parser/src/main/java/io/confluent/ksql/parser/tree/ListTypes.java
+++ b/ksql-parser/src/main/java/io/confluent/ksql/parser/tree/ListTypes.java
@@ -1,0 +1,44 @@
+/*
+ * Copyright 2019 Confluent Inc.
+ *
+ * Licensed under the Confluent Community License (the "License"; you may not use
+ * this file except in compliance with the License. You may obtain a copy of the
+ * License at
+ *
+ * http://www.confluent.io/confluent-community-license
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package io.confluent.ksql.parser.tree;
+
+import com.google.errorprone.annotations.Immutable;
+import io.confluent.ksql.parser.NodeLocation;
+import java.util.Objects;
+import java.util.Optional;
+
+@Immutable
+public class ListTypes extends Statement {
+
+  public ListTypes(final Optional<NodeLocation> location) {
+    super(location);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hashCode(getClass());
+  }
+
+  @Override
+  public boolean equals(final Object obj) {
+    return this == obj || (obj != null && obj.getClass().equals(getClass()));
+  }
+
+  @Override
+  public String toString() {
+    return "ListTypes{}";
+  }
+}

--- a/ksql-rest-app/src/main/java/io/confluent/ksql/rest/entity/KsqlEntity.java
+++ b/ksql-rest-app/src/main/java/io/confluent/ksql/rest/entity/KsqlEntity.java
@@ -47,6 +47,7 @@ import java.util.List;
     @JsonSubTypes.Type(value = DropConnectorEntity.class, name = "drop_connector"),
     @JsonSubTypes.Type(value = ConnectorList.class, name = "connector_list"),
     @JsonSubTypes.Type(value = ConnectorDescription.class, name = "connector_description"),
+    @JsonSubTypes.Type(value = TypeList.class, name = "type_list"),
     @JsonSubTypes.Type(value = ErrorEntity.class, name = "error_entity")
 })
 public abstract class KsqlEntity {

--- a/ksql-rest-app/src/main/java/io/confluent/ksql/rest/entity/SchemaInfo.java
+++ b/ksql-rest-app/src/main/java/io/confluent/ksql/rest/entity/SchemaInfo.java
@@ -24,6 +24,7 @@ import io.confluent.ksql.schema.ksql.SqlBaseType;
 import java.util.List;
 import java.util.Objects;
 import java.util.Optional;
+import java.util.stream.Collectors;
 
 @Immutable
 @JsonIgnoreProperties(ignoreUnknown = true)
@@ -74,5 +75,29 @@ public class SchemaInfo {
   @Override
   public int hashCode() {
     return Objects.hash(type, fields, memberSchema);
+  }
+
+  public String toTypeString() {
+    switch (getType()) {
+      case ARRAY:
+        return SqlBaseType.ARRAY + "<"
+            + memberSchema.toTypeString()
+            + ">";
+      case MAP:
+        return SqlBaseType.MAP
+            + "<"
+            + SqlBaseType.STRING + ", "
+            + memberSchema.toTypeString()
+            + ">";
+      case STRUCT:
+        return fields
+            .stream()
+            .map(f -> f.getName() + " " + f.getSchema().toTypeString())
+            .collect(Collectors.joining(", ", SqlBaseType.STRUCT + "<", ">"));
+      case STRING:
+        return "VARCHAR(STRING)";
+      default:
+        return type.name();
+    }
   }
 }

--- a/ksql-rest-app/src/main/java/io/confluent/ksql/rest/entity/TypeList.java
+++ b/ksql-rest-app/src/main/java/io/confluent/ksql/rest/entity/TypeList.java
@@ -1,0 +1,61 @@
+/*
+ * Copyright 2019 Confluent Inc.
+ *
+ * Licensed under the Confluent Community License (the "License"; you may not use
+ * this file except in compliance with the License. You may obtain a copy of the
+ * License at
+ *
+ * http://www.confluent.io/confluent-community-license
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package io.confluent.ksql.rest.entity;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.google.common.collect.ImmutableMap;
+import com.google.errorprone.annotations.Immutable;
+import java.util.Map;
+import java.util.Objects;
+
+@Immutable
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class TypeList extends KsqlEntity {
+
+  private final ImmutableMap<String, SchemaInfo> types;
+
+  @JsonCreator
+  public TypeList(
+      @JsonProperty("statementText")  final String statementText,
+      @JsonProperty("types")          final Map<String, SchemaInfo> types
+  ) {
+    super(statementText);
+    this.types = ImmutableMap.copyOf(Objects.requireNonNull(types, "types"));
+  }
+
+  public Map<String, SchemaInfo> getTypes() {
+    return types;
+  }
+
+  @Override
+  public boolean equals(final Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    final TypeList typeList = (TypeList) o;
+    return Objects.equals(types, typeList.types);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(types);
+  }
+}

--- a/ksql-rest-app/src/main/java/io/confluent/ksql/rest/server/execution/CustomExecutors.java
+++ b/ksql-rest-app/src/main/java/io/confluent/ksql/rest/server/execution/CustomExecutors.java
@@ -31,6 +31,7 @@ import io.confluent.ksql.parser.tree.ListQueries;
 import io.confluent.ksql.parser.tree.ListStreams;
 import io.confluent.ksql.parser.tree.ListTables;
 import io.confluent.ksql.parser.tree.ListTopics;
+import io.confluent.ksql.parser.tree.ListTypes;
 import io.confluent.ksql.parser.tree.SetProperty;
 import io.confluent.ksql.parser.tree.ShowColumns;
 import io.confluent.ksql.parser.tree.Statement;
@@ -60,6 +61,7 @@ public enum CustomExecutors {
   LIST_QUERIES(ListQueries.class, ListQueriesExecutor::execute),
   LIST_PROPERTIES(ListProperties.class, ListPropertiesExecutor::execute),
   LIST_CONNECTORS(ListConnectors.class, ListConnectorsExecutor::execute),
+  LIST_TYPES(ListTypes.class, ListTypesExecutor::execute),
 
   SHOW_COLUMNS(ShowColumns.class, ListSourceExecutor::columns),
   EXPLAIN(Explain.class, ExplainExecutor::execute),

--- a/ksql-rest-app/src/main/java/io/confluent/ksql/rest/server/execution/ListTypesExecutor.java
+++ b/ksql-rest-app/src/main/java/io/confluent/ksql/rest/server/execution/ListTypesExecutor.java
@@ -1,0 +1,50 @@
+/*
+ * Copyright 2019 Confluent Inc.
+ *
+ * Licensed under the Confluent Community License (the "License"; you may not use
+ * this file except in compliance with the License. You may obtain a copy of the
+ * License at
+ *
+ * http://www.confluent.io/confluent-community-license
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package io.confluent.ksql.rest.server.execution;
+
+import com.google.common.collect.ImmutableMap;
+import io.confluent.ksql.KsqlExecutionContext;
+import io.confluent.ksql.metastore.TypeRegistry.CustomType;
+import io.confluent.ksql.parser.tree.ListTypes;
+import io.confluent.ksql.rest.entity.KsqlEntity;
+import io.confluent.ksql.rest.entity.SchemaInfo;
+import io.confluent.ksql.rest.entity.TypeList;
+import io.confluent.ksql.rest.util.EntityUtil;
+import io.confluent.ksql.services.ServiceContext;
+import io.confluent.ksql.statement.ConfiguredStatement;
+import java.util.Iterator;
+import java.util.Optional;
+
+public final class ListTypesExecutor {
+
+  private ListTypesExecutor() { }
+
+  public static Optional<KsqlEntity> execute(
+      final ConfiguredStatement<ListTypes> configuredStatement,
+      final KsqlExecutionContext executionContext,
+      final ServiceContext serviceContext
+  ) {
+    final ImmutableMap.Builder<String, SchemaInfo> types = ImmutableMap.builder();
+
+    final Iterator<CustomType> customTypes = executionContext.getMetaStore().types();
+    while (customTypes.hasNext()) {
+      final CustomType customType = customTypes.next();
+      types.put(customType.getName(), EntityUtil.schemaInfo(customType.getType()));
+    }
+
+    return Optional.of(new TypeList(configuredStatement.getStatementText(), types.build()));
+  }
+}

--- a/ksql-rest-app/src/main/java/io/confluent/ksql/rest/server/validation/CustomValidators.java
+++ b/ksql-rest-app/src/main/java/io/confluent/ksql/rest/server/validation/CustomValidators.java
@@ -31,6 +31,7 @@ import io.confluent.ksql.parser.tree.ListQueries;
 import io.confluent.ksql.parser.tree.ListStreams;
 import io.confluent.ksql.parser.tree.ListTables;
 import io.confluent.ksql.parser.tree.ListTopics;
+import io.confluent.ksql.parser.tree.ListTypes;
 import io.confluent.ksql.parser.tree.PrintTopic;
 import io.confluent.ksql.parser.tree.Query;
 import io.confluent.ksql.parser.tree.SetProperty;
@@ -70,6 +71,7 @@ public enum CustomValidators {
   LIST_QUERIES(ListQueries.class, StatementValidator.NO_VALIDATION),
   LIST_PROPERTIES(ListProperties.class, StatementValidator.NO_VALIDATION),
   LIST_CONNECTORS(ListConnectors.class, StatementValidator.NO_VALIDATION),
+  LIST_TYPES(ListTypes.class, StatementValidator.NO_VALIDATION),
   CREATE_CONNECTOR(CreateConnector.class, StatementValidator.NO_VALIDATION),
   DROP_CONNECTOR(DropConnector.class, StatementValidator.NO_VALIDATION),
 

--- a/ksql-rest-app/src/main/java/io/confluent/ksql/rest/util/EntityUtil.java
+++ b/ksql-rest-app/src/main/java/io/confluent/ksql/rest/util/EntityUtil.java
@@ -59,7 +59,7 @@ public final class EntityUtil {
         .collect(Collectors.toList());
   }
 
-  private static SchemaInfo getSchema(final SqlType type) {
+  public static SchemaInfo schemaInfo(final SqlType type) {
     return SqlTypeWalker.visit(type, new Converter());
   }
 

--- a/ksql-rest-app/src/test/java/io/confluent/ksql/rest/server/execution/ListTypesExecutorTest.java
+++ b/ksql-rest-app/src/test/java/io/confluent/ksql/rest/server/execution/ListTypesExecutorTest.java
@@ -1,0 +1,82 @@
+/*
+ * Copyright 2019 Confluent Inc.
+ *
+ * Licensed under the Confluent Community License (the "License"; you may not use
+ * this file except in compliance with the License. You may obtain a copy of the
+ * License at
+ *
+ * http://www.confluent.io/confluent-community-license
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package io.confluent.ksql.rest.server.execution;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.*;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+import io.confluent.ksql.KsqlExecutionContext;
+import io.confluent.ksql.metastore.MetaStore;
+import io.confluent.ksql.metastore.TypeRegistry.CustomType;
+import io.confluent.ksql.parser.KsqlParser.PreparedStatement;
+import io.confluent.ksql.parser.tree.ListTypes;
+import io.confluent.ksql.rest.entity.KsqlEntity;
+import io.confluent.ksql.rest.entity.TypeList;
+import io.confluent.ksql.rest.util.EntityUtil;
+import io.confluent.ksql.schema.ksql.SqlBaseType;
+import io.confluent.ksql.schema.ksql.types.SqlPrimitiveType;
+import io.confluent.ksql.statement.ConfiguredStatement;
+import io.confluent.ksql.util.KsqlConfig;
+import java.util.Optional;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnitRunner;
+
+@RunWith(MockitoJUnitRunner.class)
+public class ListTypesExecutorTest {
+
+  private static final KsqlConfig KSQL_CONFIG = new KsqlConfig(ImmutableMap.of());
+
+  @Mock
+  private KsqlExecutionContext context;
+  @Mock
+  private MetaStore metaStore;
+
+  @Before
+  public void setUp() {
+    when(context.getMetaStore()).thenReturn(metaStore);
+    when(metaStore.types())
+        .thenReturn(
+            ImmutableList.of(
+                new CustomType("foo", SqlPrimitiveType.of(SqlBaseType.STRING))
+            ).iterator());
+  }
+
+  @Test
+  public void shouldListTypes() {
+    // When:
+    final Optional<KsqlEntity> entity = ListTypesExecutor.execute(
+        ConfiguredStatement.of(
+            PreparedStatement.of("statement", new ListTypes(Optional.empty())),
+            ImmutableMap.of(),
+            KSQL_CONFIG),
+        context,
+        null);
+
+    // Then:
+    assertThat("expected a response", entity.isPresent());
+    assertThat(((TypeList) entity.get()).getTypes(), is(ImmutableMap.of(
+        "foo", EntityUtil.schemaInfo(SqlPrimitiveType.of(SqlBaseType.STRING))
+    )));
+  }
+
+}


### PR DESCRIPTION
### Description 

Pretty straightforward. Allows users to list all of their custom types. Note that nested custom types will show up resolved.

### Testing done 
- Unit Testing
- E2E local testing

```
ksql> CREATE TYPE PERSON AS STRUCT<name VARCHAR, address ADDRESS>;

 Message
--------------------------------------------------------------------------------------------------------------------------------------------------
 Registered custom type with name 'PERSON' and SQL type STRUCT<`NAME` STRING, `ADDRESS` STRUCT<`NUMBER` INTEGER, `STREET` STRING, `CITY` STRING>>
--------------------------------------------------------------------------------------------------------------------------------------------------
ksql> SHOW TYPES;

 Type Name | Schema
------------------------------------------------------------------------------------------------------------------------
 PERSON    | STRUCT<NAME VARCHAR(STRING), ADDRESS STRUCT<NUMBER INTEGER, STREET VARCHAR(STRING), CITY VARCHAR(STRING)>>
 ADDRESS   | STRUCT<NUMBER INTEGER, STREET VARCHAR(STRING), CITY VARCHAR(STRING)>
------------------------------------------------------------------------------------------------------------------------
```

### Reviewer checklist
- [ ] Ensure docs are updated if necessary. (eg. if a user visible feature is being added or changed).
- [ ] Ensure relevant issues are linked (description should include text like "Fixes #<issue number>")

