### PR TITLE
feat: add ability to DROP custom types

### DIFF
--- a/ksql-engine/src/main/java/io/confluent/ksql/ddl/commands/CommandFactories.java
+++ b/ksql-engine/src/main/java/io/confluent/ksql/ddl/commands/CommandFactories.java
@@ -17,6 +17,7 @@ package io.confluent.ksql.ddl.commands;
 
 import static io.confluent.ksql.metastore.model.DataSource.DataSourceType;
 
+import io.confluent.ksql.parser.DropType;
 import io.confluent.ksql.parser.tree.CreateStream;
 import io.confluent.ksql.parser.tree.CreateTable;
 import io.confluent.ksql.parser.tree.DdlStatement;
@@ -45,6 +46,7 @@ public class CommandFactories implements DdlCommandFactory {
       .put(DropStream.class, CommandFactories::handleDropStream)
       .put(DropTable.class, CommandFactories::handleDropTable)
       .put(RegisterType.class, CommandFactories::handleRegisterType)
+      .put(DropType.class, CommandFactories::handleDropType)
       .build();
 
   private final ServiceContext serviceContext;
@@ -116,6 +118,10 @@ public class CommandFactories implements DdlCommandFactory {
   @SuppressWarnings("MethodMayBeStatic")
   private RegisterTypeCommand handleRegisterType(final RegisterType statement) {
     return new RegisterTypeCommand(statement);
+  }
+
+  private DropTypeCommand handleDropType(final DropType statement) {
+    return new DropTypeCommand(statement);
   }
 
   private static final class CallInfo {

--- a/ksql-engine/src/main/java/io/confluent/ksql/ddl/commands/CommandFactories.java
+++ b/ksql-engine/src/main/java/io/confluent/ksql/ddl/commands/CommandFactories.java
@@ -121,7 +121,7 @@ public class CommandFactories implements DdlCommandFactory {
   }
 
   private DropTypeCommand handleDropType(final DropType statement) {
-    return new DropTypeCommand(statement);
+    return new DropTypeCommand(statement.getTypeName());
   }
 
   private static final class CallInfo {

--- a/ksql-engine/src/main/java/io/confluent/ksql/ddl/commands/DropTypeCommand.java
+++ b/ksql-engine/src/main/java/io/confluent/ksql/ddl/commands/DropTypeCommand.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright 2019 Confluent Inc.
+ *
+ * Licensed under the Confluent Community License (the "License"; you may not use
+ * this file except in compliance with the License. You may obtain a copy of the
+ * License at
+ *
+ * http://www.confluent.io/confluent-community-license
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package io.confluent.ksql.ddl.commands;
+
+import io.confluent.ksql.metastore.MutableMetaStore;
+import io.confluent.ksql.parser.DropType;
+import java.util.Objects;
+
+public class DropTypeCommand implements DdlCommand {
+
+  private final DropType dropType;
+
+  public DropTypeCommand(final DropType dropType) {
+    this.dropType = Objects.requireNonNull(dropType, "dropType");
+  }
+
+  @Override
+  public DdlCommandResult run(final MutableMetaStore metaStore) {
+    final boolean wasDeleted = metaStore.deleteType(dropType.getTypeName());
+    return wasDeleted
+        ? new DdlCommandResult(true, "Dropped type '" + dropType.getTypeName() + "'")
+        : new DdlCommandResult(true, "Type '" + dropType.getTypeName() + "' does not exist");
+  }
+}

--- a/ksql-engine/src/main/java/io/confluent/ksql/ddl/commands/DropTypeCommand.java
+++ b/ksql-engine/src/main/java/io/confluent/ksql/ddl/commands/DropTypeCommand.java
@@ -16,22 +16,21 @@
 package io.confluent.ksql.ddl.commands;
 
 import io.confluent.ksql.metastore.MutableMetaStore;
-import io.confluent.ksql.parser.DropType;
 import java.util.Objects;
 
 public class DropTypeCommand implements DdlCommand {
 
-  private final DropType dropType;
+  private final String typeName;
 
-  public DropTypeCommand(final DropType dropType) {
-    this.dropType = Objects.requireNonNull(dropType, "dropType");
+  public DropTypeCommand(final String typeName) {
+    this.typeName = Objects.requireNonNull(typeName, "typeName");
   }
 
   @Override
   public DdlCommandResult run(final MutableMetaStore metaStore) {
-    final boolean wasDeleted = metaStore.deleteType(dropType.getTypeName());
+    final boolean wasDeleted = metaStore.deleteType(typeName);
     return wasDeleted
-        ? new DdlCommandResult(true, "Dropped type '" + dropType.getTypeName() + "'")
-        : new DdlCommandResult(true, "Type '" + dropType.getTypeName() + "' does not exist");
+        ? new DdlCommandResult(true, "Dropped type '" + typeName + "'")
+        : new DdlCommandResult(true, "Type '" + typeName + "' does not exist");
   }
 }

--- a/ksql-engine/src/test/java/io/confluent/ksql/ddl/commands/DropTypeCommandTest.java
+++ b/ksql-engine/src/test/java/io/confluent/ksql/ddl/commands/DropTypeCommandTest.java
@@ -1,0 +1,69 @@
+/*
+ * Copyright 2019 Confluent Inc.
+ *
+ * Licensed under the Confluent Community License (the "License"; you may not use
+ * this file except in compliance with the License. You may obtain a copy of the
+ * License at
+ *
+ * http://www.confluent.io/confluent-community-license
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package io.confluent.ksql.ddl.commands;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.*;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import io.confluent.ksql.metastore.MutableMetaStore;
+import io.confluent.ksql.parser.DropType;
+import java.util.Optional;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnitRunner;
+
+@RunWith(MockitoJUnitRunner.class)
+public class DropTypeCommandTest {
+
+  private static final DropTypeCommand DROP =
+      new DropTypeCommand(new DropType(Optional.empty(), "type"));
+
+  @Mock
+  private MutableMetaStore metaStore;
+
+  @Test
+  public void shouldDropExistingType() {
+    // Given:
+    when(metaStore.deleteType("type")).thenReturn(true);
+
+    // When:
+    final DdlCommandResult result = DROP.run(metaStore);
+
+    // Then:
+    verify(metaStore).deleteType("type");
+    assertThat("Expected successful execution", result.isSuccess());
+    assertThat(result.getMessage(), is("Dropped type 'type'"));
+  }
+
+  @Test
+  public void shouldDropMissingType() {
+    // Given:
+    final DropTypeCommand command = new DropTypeCommand(new DropType(Optional.empty(), "type"));
+    when(metaStore.deleteType("type")).thenReturn(false);
+
+    // When:
+    final DdlCommandResult result = command.run(metaStore);
+
+    // Then:
+    verify(metaStore).deleteType("type");
+    assertThat("Expected successful execution", result.isSuccess());
+    assertThat(result.getMessage(), is("Type 'type' does not exist"));
+  }
+
+}

--- a/ksql-engine/src/test/java/io/confluent/ksql/ddl/commands/DropTypeCommandTest.java
+++ b/ksql-engine/src/test/java/io/confluent/ksql/ddl/commands/DropTypeCommandTest.java
@@ -31,8 +31,7 @@ import org.mockito.junit.MockitoJUnitRunner;
 @RunWith(MockitoJUnitRunner.class)
 public class DropTypeCommandTest {
 
-  private static final DropTypeCommand DROP =
-      new DropTypeCommand(new DropType(Optional.empty(), "type"));
+  private static final DropTypeCommand DROP = new DropTypeCommand("type");
 
   @Mock
   private MutableMetaStore metaStore;
@@ -54,11 +53,10 @@ public class DropTypeCommandTest {
   @Test
   public void shouldDropMissingType() {
     // Given:
-    final DropTypeCommand command = new DropTypeCommand(new DropType(Optional.empty(), "type"));
     when(metaStore.deleteType("type")).thenReturn(false);
 
     // When:
-    final DdlCommandResult result = command.run(metaStore);
+    final DdlCommandResult result = DROP.run(metaStore);
 
     // Then:
     verify(metaStore).deleteType("type");

--- a/ksql-parser/src/main/java/io/confluent/ksql/parser/AstBuilder.java
+++ b/ksql-parser/src/main/java/io/confluent/ksql/parser/AstBuilder.java
@@ -17,6 +17,7 @@ package io.confluent.ksql.parser;
 
 import static io.confluent.ksql.metastore.model.DataSource.DataSourceType;
 import static io.confluent.ksql.schema.ksql.TypeContextUtil.getType;
+import static io.confluent.ksql.util.ParserUtil.getIdentifierText;
 import static io.confluent.ksql.util.ParserUtil.getLocation;
 import static io.confluent.ksql.util.ParserUtil.processIntegerNumber;
 import static java.util.Objects.requireNonNull;
@@ -57,6 +58,7 @@ import io.confluent.ksql.metastore.model.DataSource;
 import io.confluent.ksql.parser.SqlBaseParser.CreateConnectorContext;
 import io.confluent.ksql.parser.SqlBaseParser.DescribeConnectorContext;
 import io.confluent.ksql.parser.SqlBaseParser.DropConnectorContext;
+import io.confluent.ksql.parser.SqlBaseParser.DropTypeContext;
 import io.confluent.ksql.parser.SqlBaseParser.InsertValuesContext;
 import io.confluent.ksql.parser.SqlBaseParser.IntervalClauseContext;
 import io.confluent.ksql.parser.SqlBaseParser.LimitClauseContext;
@@ -614,6 +616,11 @@ public class AstBuilder {
       }
 
       return new ListConnectors(getLocation(ctx), scope);
+    }
+
+    @Override
+    public Node visitDropType(final DropTypeContext ctx) {
+      return new DropType(getLocation(ctx), getIdentifierText(ctx.identifier()));
     }
 
     @Override

--- a/ksql-parser/src/main/java/io/confluent/ksql/parser/DropType.java
+++ b/ksql-parser/src/main/java/io/confluent/ksql/parser/DropType.java
@@ -16,6 +16,7 @@
 package io.confluent.ksql.parser;
 
 import com.google.errorprone.annotations.Immutable;
+import io.confluent.ksql.parser.tree.AstVisitor;
 import io.confluent.ksql.parser.tree.ExecutableDdlStatement;
 import io.confluent.ksql.parser.tree.Statement;
 import java.util.Objects;
@@ -33,6 +34,11 @@ public class DropType extends Statement implements ExecutableDdlStatement {
 
   public String getTypeName() {
     return typeName;
+  }
+
+  @Override
+  public <R, C> R accept(final AstVisitor<R, C> visitor, final C context) {
+    return visitor.visitDropType(this, context);
   }
 
   @Override

--- a/ksql-parser/src/main/java/io/confluent/ksql/parser/DropType.java
+++ b/ksql-parser/src/main/java/io/confluent/ksql/parser/DropType.java
@@ -1,0 +1,61 @@
+/*
+ * Copyright 2019 Confluent Inc.
+ *
+ * Licensed under the Confluent Community License (the "License"; you may not use
+ * this file except in compliance with the License. You may obtain a copy of the
+ * License at
+ *
+ * http://www.confluent.io/confluent-community-license
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package io.confluent.ksql.parser;
+
+import com.google.errorprone.annotations.Immutable;
+import io.confluent.ksql.parser.tree.ExecutableDdlStatement;
+import io.confluent.ksql.parser.tree.Statement;
+import java.util.Objects;
+import java.util.Optional;
+
+@Immutable
+public class DropType extends Statement implements ExecutableDdlStatement {
+
+  private final String typeName;
+
+  public DropType(final Optional<NodeLocation> location, final String typeName) {
+    super(location);
+    this.typeName = Objects.requireNonNull(typeName, "typeName");
+  }
+
+  public String getTypeName() {
+    return typeName;
+  }
+
+  @Override
+  public boolean equals(final Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    final DropType that = (DropType) o;
+    return Objects.equals(typeName, that.typeName);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(typeName);
+  }
+
+  @Override
+  public String toString() {
+    return "DropType{"
+        + "typeName='" + typeName + '\''
+        + '}';
+  }
+}

--- a/ksql-parser/src/main/java/io/confluent/ksql/parser/tree/AstVisitor.java
+++ b/ksql-parser/src/main/java/io/confluent/ksql/parser/tree/AstVisitor.java
@@ -15,6 +15,7 @@
 
 package io.confluent.ksql.parser.tree;
 
+import io.confluent.ksql.parser.DropType;
 import javax.annotation.Nullable;
 
 public abstract class AstVisitor<R, C> {
@@ -176,6 +177,10 @@ public abstract class AstVisitor<R, C> {
   }
 
   public R visitRegisterType(final RegisterType node, final C context) {
+    return visitStatement(node, context);
+  }
+
+  public R visitDropType(final DropType node, final C context) {
     return visitStatement(node, context);
   }
 }

--- a/ksql-rest-app/src/main/java/io/confluent/ksql/rest/server/computation/CommandIdAssigner.java
+++ b/ksql-rest-app/src/main/java/io/confluent/ksql/rest/server/computation/CommandIdAssigner.java
@@ -16,6 +16,7 @@
 package io.confluent.ksql.rest.server.computation;
 
 import com.google.common.collect.ImmutableMap;
+import io.confluent.ksql.parser.DropType;
 import io.confluent.ksql.parser.tree.CreateStream;
 import io.confluent.ksql.parser.tree.CreateStreamAsSelect;
 import io.confluent.ksql.parser.tree.CreateTable;
@@ -49,6 +50,8 @@ public class CommandIdAssigner {
             command -> getSelectTableCommandId((CreateTableAsSelect) command))
           .put(RegisterType.class,
               command -> getRegisterTypeCommandId((RegisterType) command))
+          .put(DropType.class,
+              command -> getDropTypeCommandId((DropType) command))
           .put(InsertInto.class,
             command -> getInsertIntoCommandId((InsertInto) command))
           .put(TerminateQuery.class,
@@ -99,6 +102,10 @@ public class CommandIdAssigner {
 
   private static CommandId getRegisterTypeCommandId(final RegisterType registerType) {
     return new CommandId(CommandId.Type.TYPE, registerType.getName(), Action.CREATE);
+  }
+
+  private static CommandId getDropTypeCommandId(final DropType dropType) {
+    return new CommandId(CommandId.Type.TYPE, dropType.getTypeName(), Action.DROP);
   }
 
   private static CommandId getTerminateCommandId(final TerminateQuery terminateQuery) {


### PR DESCRIPTION
### Description 
Drops a previously registered type. This does not affect any previously issued commands or custom types (e.g. if I have `CREATE TYPE B AS STRUCT<A>` and `A` is `STRING`, dropping `A` will not affect `B`, which remains `STRUCT<STRING>`)

### Testing done 
- Unit testing
- E2E Manual Testing (after merging #3280)

```
ksql> CREATE TYPE ADDRESS AS STRUCT<number INTEGER, street VARCHAR, city VARCHAR>;

 Message
-------------------------------------------------------------------------------------------------
 Registered alias ADDRESS with SQL type STRUCT<`NUMBER` INTEGER, `STREET` STRING, `CITY` STRING>
-------------------------------------------------------------------------------------------------
ksql> SHOW TYPES;

 Type Name | Schema
----------------------------------------------------------------------------------
 ADDRESS   | STRUCT<NUMBER INTEGER, STREET VARCHAR(STRING), CITY VARCHAR(STRING)>
----------------------------------------------------------------------------------
ksql> DROP TYPE ADDRESS;

 Message
------------------------
 Dropped type 'ADDRESS'
------------------------
ksql> SHOW TYPES;

 Type Name | Schema
--------------------
--------------------
```

### Reviewer checklist
- [ ] Ensure docs are updated if necessary. (eg. if a user visible feature is being added or changed).
- [ ] Ensure relevant issues are linked (description should include text like "Fixes #<issue number>")

