### PR TITLE
fix: insert/values does not convert Number to String

### DIFF
--- a/ksql-parser/src/main/java/io/confluent/ksql/schema/ksql/DefaultSqlValueCoercer.java
+++ b/ksql-parser/src/main/java/io/confluent/ksql/schema/ksql/DefaultSqlValueCoercer.java
@@ -58,6 +58,10 @@ public final class DefaultSqlValueCoercer implements SqlValueCoercer {
       return Optional.empty();
     }
 
+    if (targetType.baseType() == SqlBaseType.STRING) {
+      return optional(String.valueOf(value));
+    }
+
     final Number result = UPCASTER.get(targetType.baseType()).apply((Number) value);
     return optional(result);
   }

--- a/ksql-parser/src/test/java/io/confluent/ksql/schema/ksql/DefaultSqlValueCoercerTest.java
+++ b/ksql-parser/src/test/java/io/confluent/ksql/schema/ksql/DefaultSqlValueCoercerTest.java
@@ -20,6 +20,7 @@ import static org.hamcrest.Matchers.is;
 
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.ImmutableSet;
 import io.confluent.ksql.schema.ksql.types.SqlTypes;
 import io.confluent.ksql.util.KsqlException;
 import java.math.BigDecimal;
@@ -138,6 +139,17 @@ public class DefaultSqlValueCoercerTest {
 
     // Expect:
     assertThat(coercer.coerce(val, SqlTypes.decimal(2, 1)), is(Optional.of(new BigDecimal("1.0"))));
+  }
+
+  @Test
+  public void shouldCoerceNumbersToString() {
+    ImmutableSet.of(
+        1,
+        2L,
+        3.3
+    ).forEach(number -> {
+      assertThat(coercer.coerce(number, SqlTypes.STRING), is(Optional.of(String.valueOf(number))));
+    });
   }
 
   @Test


### PR DESCRIPTION
### Description 
Insert integer values to a String column throws a NPE.

```
ksql> create stream stream1(id varchar) ...
ksql> insert into stream1(id) values (1);
Failed to insert values into stream/table: STREAM1
Caused by: java.lang.NullPointerException
```

Other databases support this conversion. This PR fixes this to allow integers to be converted to strings in the above case.

### Testing done 
- Added a test case
- Verified manually on the CLI

### Reviewer checklist
- [ ] Ensure docs are updated if necessary. (eg. if a user visible feature is being added or changed).
- [ ] Ensure relevant issues are linked (description should include text like "Fixes #<issue number>")

