### PR TITLE
refactor: Bake select mapper (minor)

### DIFF
--- a/ksql-common/src/main/java/io/confluent/ksql/schema/ksql/SchemaConverters.java
+++ b/ksql-common/src/main/java/io/confluent/ksql/schema/ksql/SchemaConverters.java
@@ -130,6 +130,10 @@ public final class SchemaConverters {
      * @return the java type.
      */
     Class<?> toJavaType(SqlBaseType sqlBaseType);
+
+    default Class<?> toJavaType(SqlType sqlType) {
+      return toJavaType(sqlType.baseType());
+    }
   }
 
   public static ConnectToSqlTypeConverter connectToSqlConverter() {

--- a/ksql-common/src/main/java/io/confluent/ksql/schema/ksql/types/SqlStruct.java
+++ b/ksql-common/src/main/java/io/confluent/ksql/schema/ksql/types/SqlStruct.java
@@ -100,9 +100,6 @@ public final class SqlStruct extends SqlType {
     }
 
     public SqlStruct build() {
-      if (fields.isEmpty()) {
-        throw new KsqlException("STRUCT type must define fields");
-      }
       return new SqlStruct(fields);
     }
 

--- a/ksql-common/src/test/java/io/confluent/ksql/schema/ksql/types/SqlStructTest.java
+++ b/ksql-common/src/test/java/io/confluent/ksql/schema/ksql/types/SqlStructTest.java
@@ -71,12 +71,7 @@ public class SqlStructTest {
   }
 
   @Test
-  public void shouldThrowIfNoFields() {
-    // Then:
-    expectedException.expect(KsqlException.class);
-    expectedException.expectMessage("STRUCT type must define fields");
-
-    // When:
+  public void shouldNotThrowIfNoFields() {
     SqlStruct.builder().build();
   }
 

--- a/ksql-common/src/test/java/io/confluent/ksql/util/SchemaUtilTest.java
+++ b/ksql-common/src/test/java/io/confluent/ksql/util/SchemaUtilTest.java
@@ -32,8 +32,9 @@ import org.apache.kafka.connect.data.ConnectSchema;
 import org.apache.kafka.connect.data.Field;
 import org.apache.kafka.connect.data.Schema;
 import org.apache.kafka.connect.data.SchemaBuilder;
-import org.junit.Assert;
+import org.junit.Rule;
 import org.junit.Test;
+import org.junit.rules.ExpectedException;
 
 public class SchemaUtilTest {
 
@@ -72,6 +73,9 @@ public class SchemaUtilTest {
               .field("ss0", STRUCT_SCHEMA))
           .build())
       .build();
+
+  @Rule
+  public final ExpectedException expectedException = ExpectedException.none();
 
   @Test
   public void shouldGetCorrectJavaClassForBoolean() {
@@ -432,14 +436,13 @@ public class SchemaUtilTest {
   }
 
   @Test
-  public void shouldFailForCorrectJavaType() {
-    try {
-      SchemaUtil.getJavaType(Schema.BYTES_SCHEMA);
-      Assert.fail();
-    } catch (final KsqlException ksqlException) {
-      assertThat("Invalid type retured.", ksqlException.getMessage(), equalTo("Type is not "
-          + "supported: BYTES"));
-    }
+  public void shouldFailForGetJavaTypeOnUnsuppportedConnectType() {
+    // Then:
+    expectedException.expect(KsqlException.class);
+    expectedException.expectMessage("Unexpected schema type: Schema{INT8}");
+
+    // When:
+    SchemaUtil.getJavaType(Schema.INT8_SCHEMA);
   }
 
   @Test

--- a/ksql-engine/src/main/java/io/confluent/ksql/codegen/SqlToJavaVisitor.java
+++ b/ksql-engine/src/main/java/io/confluent/ksql/codegen/SqlToJavaVisitor.java
@@ -330,6 +330,7 @@ public class SqlToJavaVisitor {
       return new Pair<>(codeString, functionReturnSchema);
     }
 
+    @SuppressWarnings("deprecation") // Need to migrate away from Connect Schema use.
     private Schema getFunctionReturnSchema(
         final FunctionCall node,
         final String functionName) {
@@ -701,6 +702,7 @@ public class SqlToJavaVisitor {
       );
     }
 
+    @SuppressWarnings("deprecation") // Need to migrate away from Connect Schema use.
     @Override
     public Pair<String, Schema> visitSubscriptExpression(
         final SubscriptExpression node,
@@ -725,7 +727,7 @@ public class SqlToJavaVisitor {
               trueIdx);
 
           return new Pair<>(code, internalSchema.valueSchema());
-          
+
         case MAP:
           return new Pair<>(
               String.format("((%s) ((%s)%s).get(%s))",

--- a/ksql-engine/src/main/java/io/confluent/ksql/planner/plan/AggregateNode.java
+++ b/ksql-engine/src/main/java/io/confluent/ksql/planner/plan/AggregateNode.java
@@ -295,6 +295,7 @@ public class AggregateNode extends PlanNode {
     return aggValToAggFunctionMap;
   }
 
+  @SuppressWarnings("deprecation") // Need to migrate away from Connect Schema use.
   private static KsqlAggregateFunction getAggregateFunction(
       final FunctionRegistry functionRegistry,
       final InternalSchema internalSchema,

--- a/ksql-engine/src/main/java/io/confluent/ksql/structured/SelectValueMapperFactory.java
+++ b/ksql-engine/src/main/java/io/confluent/ksql/structured/SelectValueMapperFactory.java
@@ -30,7 +30,7 @@ import java.util.stream.Collectors;
 /**
  * Factor class for {@link SelectValueMapper}.
  */
-final class SelectValueMapperFactory {
+public final class SelectValueMapperFactory {
 
   private static final String EXP_TYPE = "Select";
 
@@ -41,7 +41,7 @@ final class SelectValueMapperFactory {
     this.codeGenerator = codeGenerator;
   }
 
-  static SelectValueMapper create(
+  public static SelectValueMapper create(
       final List<SelectExpression> selectExpressions,
       final LogicalSchema sourceSchema,
       final KsqlConfig ksqlConfig,

--- a/ksql-engine/src/main/java/io/confluent/ksql/structured/SelectValueMapperFactory.java
+++ b/ksql-engine/src/main/java/io/confluent/ksql/structured/SelectValueMapperFactory.java
@@ -1,0 +1,85 @@
+/*
+ * Copyright 2019 Confluent Inc.
+ *
+ * Licensed under the Confluent Community License (the "License"); you may not use
+ * this file except in compliance with the License.  You may obtain a copy of the
+ * License at
+ *
+ * http://www.confluent.io/confluent-community-license
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package io.confluent.ksql.structured;
+
+import com.google.common.annotations.VisibleForTesting;
+import io.confluent.ksql.codegen.CodeGenRunner;
+import io.confluent.ksql.execution.plan.SelectExpression;
+import io.confluent.ksql.function.FunctionRegistry;
+import io.confluent.ksql.logging.processing.ProcessingLogger;
+import io.confluent.ksql.schema.ksql.LogicalSchema;
+import io.confluent.ksql.structured.SelectValueMapper.SelectInfo;
+import io.confluent.ksql.util.ExpressionMetadata;
+import io.confluent.ksql.util.KsqlConfig;
+import java.util.List;
+import java.util.stream.Collectors;
+
+/**
+ * Factor class for {@link SelectValueMapper}.
+ */
+final class SelectValueMapperFactory {
+
+  private static final String EXP_TYPE = "Select";
+
+  private final CodeGenRunner codeGenerator;
+
+  @VisibleForTesting
+  SelectValueMapperFactory(final CodeGenRunner codeGenerator) {
+    this.codeGenerator = codeGenerator;
+  }
+
+  static SelectValueMapper create(
+      final List<SelectExpression> selectExpressions,
+      final LogicalSchema sourceSchema,
+      final KsqlConfig ksqlConfig,
+      final FunctionRegistry functionRegistry,
+      final ProcessingLogger processingLogger
+  ) {
+    final CodeGenRunner codeGen = new CodeGenRunner(sourceSchema, ksqlConfig, functionRegistry);
+
+    return new SelectValueMapperFactory(codeGen).create(
+        selectExpressions,
+        processingLogger
+    );
+  }
+
+  @VisibleForTesting
+  SelectValueMapper create(
+      final List<SelectExpression> selectExpressions,
+      final ProcessingLogger processingLogger
+  ) {
+    return new SelectValueMapper(
+        buildSelects(selectExpressions),
+        processingLogger
+    );
+  }
+
+  private List<SelectInfo> buildSelects(final List<SelectExpression> selectExpressions) {
+    return selectExpressions.stream()
+        .map(this::buildSelect)
+        .collect(Collectors.toList());
+  }
+
+  private SelectInfo buildSelect(final SelectExpression selectExpression) {
+    final ExpressionMetadata evaluator = codeGenerator
+        .buildCodeGenFromParseTree(selectExpression.getExpression(), EXP_TYPE);
+
+    return SelectInfo.of(
+        selectExpression.getName(),
+        evaluator
+    );
+  }
+}

--- a/ksql-engine/src/main/java/io/confluent/ksql/util/ExpressionMetadata.java
+++ b/ksql-engine/src/main/java/io/confluent/ksql/util/ExpressionMetadata.java
@@ -18,11 +18,11 @@ package io.confluent.ksql.util;
 import io.confluent.ksql.GenericRow;
 import io.confluent.ksql.execution.expression.tree.Expression;
 import io.confluent.ksql.function.udf.Kudf;
+import io.confluent.ksql.schema.ksql.types.SqlType;
 import java.lang.reflect.InvocationTargetException;
 import java.util.Collections;
 import java.util.List;
 import java.util.Objects;
-import org.apache.kafka.connect.data.Schema;
 import org.codehaus.commons.compiler.IExpressionEvaluator;
 
 public class ExpressionMetadata {
@@ -30,7 +30,7 @@ public class ExpressionMetadata {
   private final IExpressionEvaluator expressionEvaluator;
   private final List<Integer> indexes;
   private final List<Kudf> udfs;
-  private final Schema expressionType;
+  private final SqlType expressionType;
   private final GenericRowValueTypeEnforcer typeEnforcer;
   private final ThreadLocal<Object[]> threadLocalParameters;
   private final Expression expression;
@@ -39,9 +39,10 @@ public class ExpressionMetadata {
       final IExpressionEvaluator expressionEvaluator,
       final List<Integer> indexes,
       final List<Kudf> udfs,
-      final Schema expressionType,
+      final SqlType expressionType,
       final GenericRowValueTypeEnforcer typeEnforcer,
-      final Expression expression) {
+      final Expression expression
+  ) {
     this.expressionEvaluator = Objects.requireNonNull(expressionEvaluator, "expressionEvaluator");
     this.indexes = Collections.unmodifiableList(Objects.requireNonNull(indexes, "indexes"));
     this.udfs = Collections.unmodifiableList(Objects.requireNonNull(udfs, "udfs"));
@@ -59,7 +60,7 @@ public class ExpressionMetadata {
     return udfs;
   }
 
-  public Schema getExpressionType() {
+  public SqlType getExpressionType() {
     return expressionType;
   }
 

--- a/ksql-engine/src/main/java/io/confluent/ksql/util/ExpressionTypeManager.java
+++ b/ksql-engine/src/main/java/io/confluent/ksql/util/ExpressionTypeManager.java
@@ -67,6 +67,7 @@ import java.util.List;
 import java.util.Objects;
 import org.apache.kafka.connect.data.Schema;
 
+@SuppressWarnings("deprecation") // Need to migrate away from Connect Schema use.
 public class ExpressionTypeManager {
 
   private static final SqlToConnectTypeConverter SQL_TO_CONNECT_SCHEMA_CONVERTER =
@@ -86,6 +87,11 @@ public class ExpressionTypeManager {
     this.functionRegistry = Objects.requireNonNull(functionRegistry, "functionRegistry");
   }
 
+  /**
+   * @deprecated use getExpressionSqlType in new code.
+   */
+  @SuppressWarnings("DeprecatedIsStillUsed")
+  @Deprecated
   public Schema getExpressionSchema(final Expression expression) {
     final ExpressionTypeContext expressionTypeContext = new ExpressionTypeContext();
     new Visitor().process(expression, expressionTypeContext);
@@ -121,6 +127,7 @@ public class ExpressionTypeManager {
   }
 
   private class Visitor implements ExpressionVisitor<Void, ExpressionTypeContext> {
+
     @Override
     public Void visitArithmeticBinary(
         final ArithmeticBinaryExpression node,

--- a/ksql-engine/src/test/java/io/confluent/ksql/schema/ksql/inference/DefaultSchemaInjectorFunctionalTest.java
+++ b/ksql-engine/src/test/java/io/confluent/ksql/schema/ksql/inference/DefaultSchemaInjectorFunctionalTest.java
@@ -34,7 +34,6 @@ import io.confluent.ksql.schema.ksql.SchemaConverters;
 import io.confluent.ksql.statement.ConfiguredStatement;
 import io.confluent.ksql.util.DecimalUtil;
 import io.confluent.ksql.util.KsqlConfig;
-import io.confluent.ksql.util.KsqlException;
 import io.confluent.ksql.util.ParserUtil;
 import org.apache.kafka.connect.data.Schema;
 import org.apache.kafka.connect.data.SchemaBuilder;
@@ -267,16 +266,6 @@ public class DefaultSchemaInjectorFunctionalTest {
             .optional()
             .build()
     );
-  }
-
-  @Test
-  public void shouldThrowIfNoFields() {
-    // expect:
-    expectedException.expect(KsqlException.class);
-    expectedException.expectMessage("STRUCT type must define fields");
-
-    // when:
-    shouldInferConnectType(SchemaBuilder.struct(), null);
   }
 
   @Test

--- a/ksql-engine/src/test/java/io/confluent/ksql/structured/SelectValueMapperFactoryTest.java
+++ b/ksql-engine/src/test/java/io/confluent/ksql/structured/SelectValueMapperFactoryTest.java
@@ -1,0 +1,94 @@
+/*
+ * Copyright 2019 Confluent Inc.
+ *
+ * Licensed under the Confluent Community License (the "License"); you may not use
+ * this file except in compliance with the License.  You may obtain a copy of the
+ * License at
+ *
+ * http://www.confluent.io/confluent-community-license
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package io.confluent.ksql.structured;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.contains;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.google.common.collect.ImmutableList;
+import io.confluent.ksql.codegen.CodeGenRunner;
+import io.confluent.ksql.execution.expression.tree.Expression;
+import io.confluent.ksql.execution.plan.SelectExpression;
+import io.confluent.ksql.logging.processing.ProcessingLogger;
+import io.confluent.ksql.structured.SelectValueMapper.SelectInfo;
+import io.confluent.ksql.util.ExpressionMetadata;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnitRunner;
+
+@RunWith(MockitoJUnitRunner.class)
+public class SelectValueMapperFactoryTest {
+
+  @Mock
+  private CodeGenRunner codeGenerator;
+  @Mock
+  private SelectExpression select_0;
+  @Mock
+  private SelectExpression select_1;
+  @Mock
+  private Expression exp_0;
+  @Mock
+  private Expression exp_1;
+  @Mock
+  private ExpressionMetadata md_0;
+  @Mock
+  private ExpressionMetadata md_1;
+  @Mock
+  private ProcessingLogger processingLogger;
+
+  private SelectValueMapperFactory factory;
+
+  @Before
+  public void setUp() {
+    factory = new SelectValueMapperFactory(codeGenerator);
+
+    when(select_0.getName()).thenReturn("field_0");
+    when(select_1.getName()).thenReturn("field_1");
+    when(select_1.getExpression()).thenReturn(exp_1);
+    when(select_0.getExpression()).thenReturn(exp_0);
+    when(select_1.getExpression()).thenReturn(exp_1);
+    when(codeGenerator.buildCodeGenFromParseTree(eq(exp_0), any())).thenReturn(md_0);
+    when(codeGenerator.buildCodeGenFromParseTree(eq(exp_1), any())).thenReturn(md_1);
+  }
+
+  @Test
+  public void shouldBuildSelects() {
+    // When:
+    final SelectValueMapper mapper = factory
+        .create(ImmutableList.of(select_0, select_1), processingLogger);
+
+    // Then:
+    assertThat(mapper.getSelects(), contains(
+       SelectInfo.of("field_0", md_0),
+       SelectInfo.of("field_1", md_1)
+    ));
+  }
+
+  @Test
+  public void shouldInvokeCodeGenWithCorrectExpressionType() {
+    // When:
+    factory.create(ImmutableList.of(select_0), processingLogger);
+
+    // Then:
+    verify(codeGenerator).buildCodeGenFromParseTree(any(), eq("Select"));
+  }
+}

--- a/ksql-engine/src/test/java/io/confluent/ksql/util/ExpressionMetadataTest.java
+++ b/ksql-engine/src/test/java/io/confluent/ksql/util/ExpressionMetadataTest.java
@@ -12,14 +12,15 @@ import static org.mockito.Mockito.when;
 
 import com.google.common.collect.ImmutableList;
 import io.confluent.ksql.GenericRow;
-import io.confluent.ksql.function.udf.Kudf;
 import io.confluent.ksql.execution.expression.tree.Expression;
+import io.confluent.ksql.function.udf.Kudf;
+import io.confluent.ksql.schema.ksql.types.SqlType;
+import io.confluent.ksql.schema.ksql.types.SqlTypes;
 import java.lang.reflect.InvocationTargetException;
 import java.util.Collections;
 import java.util.List;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
-import org.apache.kafka.connect.data.Schema;
 import org.codehaus.commons.compiler.IExpressionEvaluator;
 import org.junit.Before;
 import org.junit.Rule;
@@ -36,7 +37,7 @@ public class ExpressionMetadataTest {
   private List<Kudf> udfs;
   @Mock
   private Kudf udf;
-  private final Schema expressionType = Schema.OPTIONAL_INT64_SCHEMA;
+  private final SqlType expressionType = SqlTypes.BIGINT;
   @Mock
   private GenericRowValueTypeEnforcer typeEnforcer;
   @Mock

--- a/ksql-rest-app/src/main/java/io/confluent/ksql/rest/server/KsqlRestApplication.java
+++ b/ksql-rest-app/src/main/java/io/confluent/ksql/rest/server/KsqlRestApplication.java
@@ -100,6 +100,7 @@ import javax.websocket.server.ServerEndpoint;
 import javax.websocket.server.ServerEndpointConfig;
 import javax.websocket.server.ServerEndpointConfig.Configurator;
 import javax.ws.rs.core.Configurable;
+import org.apache.commons.lang3.StringUtils;
 import org.apache.kafka.streams.StreamsConfig;
 import org.eclipse.jetty.server.ServerConnector;
 import org.eclipse.jetty.websocket.jsr356.server.ServerContainer;
@@ -195,6 +196,7 @@ public final class KsqlRestApplication extends Application<KsqlRestConfig> imple
   @Override
   public void start() throws Exception {
     super.start();
+    log.info("KSQL RESTful API listening on {}", StringUtils.join(getListeners(), ", "));
     final KsqlConfig ksqlConfigWithPort = buildConfigWithPort();
     configurables.forEach(c -> c.configure(ksqlConfigWithPort));
     startKsql();


### PR DESCRIPTION
### Description 

In the current code the code for baking the select expressions into java code is in the `Selection` class that is nested inside `SchemaKStream`.   The baked `ExpressionMetadata` is then used to build a `SelectValueMapper`.

However, I'll soon need to build the `SelectValueMapper` as part of the work for static queries. Hence I'm pulling out the baking code into a new `SelectValueMapperFactory` class, which can be called from both places.

### Testing done 

New tests added.

`mvn test`

### Reviewer checklist
- [ ] Ensure docs are updated if necessary. (eg. if a user visible feature is being added or changed).
- [ ] Ensure relevant issues are linked (description should include text like "Fixes #<issue number>")

