### PR TITLE
fix: schema converters should handle List and Map impl (MINOR)

### DIFF
--- a/ksql-common/src/main/java/io/confluent/ksql/schema/ksql/SchemaConverters.java
+++ b/ksql-common/src/main/java/io/confluent/ksql/schema/ksql/SchemaConverters.java
@@ -29,6 +29,7 @@ import io.confluent.ksql.util.KsqlException;
 import java.math.BigDecimal;
 import java.util.List;
 import java.util.Map;
+import java.util.Map.Entry;
 import java.util.function.Function;
 import org.apache.kafka.connect.data.Schema;
 import org.apache.kafka.connect.data.SchemaBuilder;
@@ -285,12 +286,11 @@ public final class SchemaConverters {
 
     @Override
     public SqlBaseType toSqlType(final Class<?> javaType) {
-      final SqlBaseType sqlType = JAVA_TO_SQL.get(javaType);
-      if (sqlType == null) {
-        throw new KsqlException("Unexpected java type: " + javaType);
-      }
-
-      return sqlType;
+      return JAVA_TO_SQL.entrySet().stream()
+          .filter(e -> e.getKey().isAssignableFrom(javaType))
+          .map(Entry::getValue)
+          .findAny()
+          .orElseThrow(() -> new KsqlException("Unexpected java type: " + javaType));
     }
   }
 

--- a/ksql-common/src/test/java/io/confluent/ksql/schema/ksql/SchemaConvertersTest.java
+++ b/ksql-common/src/test/java/io/confluent/ksql/schema/ksql/SchemaConvertersTest.java
@@ -21,6 +21,8 @@ import static org.hamcrest.Matchers.is;
 
 import com.google.common.collect.BiMap;
 import com.google.common.collect.ImmutableBiMap;
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
 import io.confluent.ksql.schema.ksql.types.SqlArray;
 import io.confluent.ksql.schema.ksql.types.SqlDecimal;
@@ -31,6 +33,8 @@ import io.confluent.ksql.schema.ksql.types.SqlTypes;
 import io.confluent.ksql.util.DecimalUtil;
 import io.confluent.ksql.util.KsqlException;
 import java.math.BigDecimal;
+import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
@@ -174,6 +178,26 @@ public class SchemaConvertersTest {
   public void shouldGetSqlTypeForAllJavaTypes() {
     SQL_TO_JAVA.inverse().forEach((java, sqlType) -> {
       assertThat(SchemaConverters.javaToSqlConverter().toSqlType(java), is(sqlType));
+    });
+  }
+
+  @Test
+  public void shouldGetSqArrayForImplementationsOfJavaList() {
+    ImmutableList.<Class<?>>of(
+        ArrayList.class,
+        ImmutableList.class
+    ).forEach(javaType -> {
+      assertThat(SchemaConverters.javaToSqlConverter().toSqlType(javaType), is(SqlBaseType.ARRAY));
+    });
+  }
+
+  @Test
+  public void shouldGetSqlMapForImplementationsOfJavaMap() {
+    ImmutableList.<Class<?>>of(
+        HashMap.class,
+        ImmutableMap.class
+    ).forEach(javaType -> {
+      assertThat(SchemaConverters.javaToSqlConverter().toSqlType(javaType), is(SqlBaseType.MAP));
     });
   }
 


### PR DESCRIPTION
### Description 

The Java to Sql schema converter should handle converting `HashMap` -> `MAP` and `ArrayList` -> `ARRAY` etc, not just the interface types themselves.

### Testing done 

`mvn test`

### Reviewer checklist
- [ ] Ensure docs are updated if necessary. (eg. if a user visible feature is being added or changed).
- [ ] Ensure relevant issues are linked (description should include text like "Fixes #<issue number>")

