### PR TITLE
fix: increment query_id on failed queries to prevent id offset during restore

### DIFF
--- a/ksql-engine/src/main/java/io/confluent/ksql/engine/EngineContext.java
+++ b/ksql-engine/src/main/java/io/confluent/ksql/engine/EngineContext.java
@@ -196,4 +196,8 @@ final class EngineContext {
 
     outerOnQueryCloseCallback.accept(serviceContext, query);
   }
+
+  void incrementQueryId() {
+    this.queryIdGenerator.getNextId();
+  }
 }

--- a/ksql-engine/src/main/java/io/confluent/ksql/engine/KsqlEngine.java
+++ b/ksql-engine/src/main/java/io/confluent/ksql/engine/KsqlEngine.java
@@ -221,4 +221,8 @@ public class KsqlEngine implements KsqlExecutionContext, Closeable {
 
     StreamsErrorCollector.notifyApplicationClose(applicationId);
   }
+
+  public void incrementQueryId() {
+    this.primaryContext.incrementQueryId();
+  }
 }


### PR DESCRIPTION
### Description 
Continuation of https://github.com/confluentinc/ksql/pull/3278
The previous didn't generalize to other forms of failures during query creation other than missing sources/sinks. This new approach will increment on any failure if the statement being processed is a CreateStreamAsSelect, InsertInto, and CreateTableAsSelect
### Testing done 
Unit tests 
Local testing:
```
CREATE STREAM test(age BIGINT) WITH (KAFKA_TOPIC='test',  VALUE_FORMAT='JSON');
CREATE STREAM foo(age BIGINT) WITH (KAFKA_TOPIC='foo',  VALUE_FORMAT='JSON');
CREATE STREAM foo_copy AS SELECT * from foo; 
INSERT INTO test  SELECT age FROM foo;
INSERT INTO foo SELECT age FROM test;
TERMINATE CSAS_FOO_COPY_0;
TERMINATE InsertQuery_1;
TERMINATE InsertQuery_2;

CREATE STREAM bar (age BIGINT) WITH (KAFKA_TOPIC='bar', VALUE_FORMAT='JSON');
CREATE STREAM bar_copy AS SELECT * from bar; 
INSERT INTO test  SELECT age FROM bar;
INSERT INTO bar  SELECT age FROM test;
TERMINATE CSAS_BAR_COPY_3;
TERMINATE InsertQuery_4;
TERMINATE InsertQuery_5;

# Turn off server, delete topic foo, restart server
# Behavior on master
SHOW QUERIES;
 Query ID        | Kafka Topic | Query String                                                                               
----------------------------------------------------------------------------------------------------------------------------
 CSAS_BAR_COPY_0 | BAR_COPY    | CREATE STREAM BAR_COPY WITH (KAFKA_TOPIC='BAR_COPY', PARTITIONS=1, REPLICAS=1) AS SELECT *
FROM BAR BAR; 
 InsertQuery_1   | TEST        | INSERT INTO test  SELECT age FROM bar;                                                     
 InsertQuery_2   | BAR         | INSERT INTO bar  SELECT age FROM test;                                                     
----------------------------------------------------------------------------------------------------------------------------

# Behavior after change
SHOW QUERIES;
----------------------------------------------------------------------------------------------------------------------------                                                  
----------------------------------------------------------------------------------------------------------------------------
```
### Reviewer checklist
- [ ] Ensure docs are updated if necessary. (eg. if a user visible feature is being added or changed).
- [ ] Ensure relevant issues are linked (description should include text like "Fixes #<issue number>")

