### PR TITLE
feat: generated java code now uses standard naming to refer to sql cols

### DIFF
--- a/ksql-common/src/test/java/io/confluent/ksql/schema/ksql/LogicalSchemaTest.java
+++ b/ksql-common/src/test/java/io/confluent/ksql/schema/ksql/LogicalSchemaTest.java
@@ -895,6 +895,36 @@ public class LogicalSchemaTest {
     ));
   }
 
+  @Test
+  public void shouldCreateConsistentInternalNameMapping() {
+    // Given:
+    final Field key = Field.of("key", SqlTypes.STRING);
+    final Field value = Field.of("value", SqlTypes.STRING);
+    final LogicalSchema schema = LogicalSchema.builder()
+        .keyField(key)
+        .valueField(key)
+        .valueField(value)
+        .build();
+
+    // Then:
+    assertThat(schema.getFieldFromInternalName(schema.getInternalName(key)), is(key));
+    assertThat(schema.getFieldFromInternalName(schema.getInternalName(value)), is(value));
+  }
+
+  @Test
+  public void shouldCreateInternalNamesWithSourcePrefix() {
+    // Given:
+    final Field key = Field.of("key", SqlTypes.STRING);
+    final Field value = Field.of("source", "value", SqlTypes.STRING);
+    final LogicalSchema schema = LogicalSchema.builder()
+        .keyField(key)
+        .valueField(value)
+        .build();
+
+    // Then:
+    assertThat(schema.getInternalName(value), containsString("SOURCE_"));
+  }
+
   private static org.apache.kafka.connect.data.Field connectField(
       final String fieldName,
       final int index,

--- a/ksql-engine/src/main/java/io/confluent/ksql/codegen/CodeGenRunner.java
+++ b/ksql-engine/src/main/java/io/confluent/ksql/codegen/CodeGenRunner.java
@@ -181,7 +181,7 @@ public class CodeGenRunner {
       parameters.add(new ParameterType(
           SQL_TO_JAVA_TYPE_CONVERTER.toJavaType(schemaField.type()),
           schemaField.fullName(),
-          schemaField.fullName().replace(".", "_"),
+          schema.getInternalName(schemaField),
           ksqlConfig));
     }
 

--- a/ksql-engine/src/main/java/io/confluent/ksql/codegen/SqlToJavaVisitor.java
+++ b/ksql-engine/src/main/java/io/confluent/ksql/codegen/SqlToJavaVisitor.java
@@ -272,8 +272,9 @@ public class SqlToJavaVisitor {
           .orElseThrow(() ->
               new KsqlException("Field not found: " + fieldName));
 
+      final String internalColName = schema.getInternalName(schemaField);
       final Schema schema = SQL_TO_CONNECT_SCHEMA_CONVERTER.toConnectSchema(schemaField.type());
-      return new Pair<>(fieldName.replace(".", "_"), schema);
+      return new Pair<>(internalColName, schema);
     }
 
     @Override
@@ -286,8 +287,9 @@ public class SqlToJavaVisitor {
           .orElseThrow(() ->
               new KsqlException("Field not found: " + fieldName));
 
+      final String internalColName = schema.getInternalName(schemaField);
       final Schema schema = SQL_TO_CONNECT_SCHEMA_CONVERTER.toConnectSchema(schemaField.type());
-      return new Pair<>(fieldName.replace(".", "_"), schema);
+      return new Pair<>(internalColName, schema);
     }
 
     private String formatQualifiedName(final QualifiedName name) {


### PR DESCRIPTION
### Description 

Code generation now uses internal column names that are guaranteed to be compatible with java variable naming rules. The entire pipeline does not yet work with such names, but this is required for the quoted identifier work that is being done. Note that this still requires that the source names are valid java identifiers.

For more design spec, see #2951.

### Testing done 
- Unit tests
- `mvn clean install`

### Reviewer checklist
- [ ] Ensure docs are updated if necessary. (eg. if a user visible feature is being added or changed).
- [ ] Ensure relevant issues are linked (description should include text like "Fixes #<issue number>")

