### PR TITLE
feat: add option for datagen to produce indefinitely (MINOR)

### DIFF
--- a/ksql-examples/src/main/java/io/confluent/ksql/datagen/DataGen.java
+++ b/ksql-examples/src/main/java/io/confluent/ksql/datagen/DataGen.java
@@ -149,7 +149,7 @@ public final class DataGen {
             + "'delimited') " + newLine
         + "topic=<kafka topic name> " + newLine
         + "key=<name of key column> " + newLine
-        + "[iterations=<number of rows> (defaults to 1,000,000; pass -1 to produce "
+        + "[iterations=<number of rows> (if no value is specified, datagen will produce "
             + "indefinitely)] " + newLine
         + "[maxInterval=<Max time in ms between rows> (defaults to 500)] " + newLine
         + "[propertiesFile=<file specifying Kafka client properties>] " + newLine
@@ -230,7 +230,7 @@ public final class DataGen {
               .put("format", (builder, argVal) -> builder.valueFormat = parseFormat(argVal))
               .put("topic", (builder, argVal) -> builder.topicName = argVal)
               .put("key", (builder, argVal) -> builder.keyName = argVal)
-              .put("iterations", (builder, argVal) -> builder.iterations = parseInt(argVal, -1))
+              .put("iterations", (builder, argVal) -> builder.iterations = parseInt(argVal, 1))
               .put("maxInterval",
                   (builder, argVal) -> builder.maxInterval = parseInt(argVal, 0))
               .put("schemaRegistryUrl", (builder, argVal) -> builder.schemaRegistryUrl = argVal)
@@ -267,7 +267,7 @@ public final class DataGen {
         valueFormat = null;
         topicName = null;
         keyName = null;
-        iterations = 1000000;
+        iterations = -1;
         maxInterval = -1;
         schemaRegistryUrl = "http://localhost:8081";
         propertiesFile = null;

--- a/ksql-examples/src/main/java/io/confluent/ksql/datagen/DataGen.java
+++ b/ksql-examples/src/main/java/io/confluent/ksql/datagen/DataGen.java
@@ -149,7 +149,8 @@ public final class DataGen {
             + "'delimited') " + newLine
         + "topic=<kafka topic name> " + newLine
         + "key=<name of key column> " + newLine
-        + "[iterations=<number of rows> (defaults to 1,000,000)] " + newLine
+        + "[iterations=<number of rows> (defaults to 1,000,000; pass -1 to produce "
+            + "indefinitely)] " + newLine
         + "[maxInterval=<Max time in ms between rows> (defaults to 500)] " + newLine
         + "[propertiesFile=<file specifying Kafka client properties>] " + newLine
         + "[nThreads=<number of producer threads to start>] " + newLine
@@ -229,7 +230,7 @@ public final class DataGen {
               .put("format", (builder, argVal) -> builder.valueFormat = parseFormat(argVal))
               .put("topic", (builder, argVal) -> builder.topicName = argVal)
               .put("key", (builder, argVal) -> builder.keyName = argVal)
-              .put("iterations", (builder, argVal) -> builder.iterations = parseInt(argVal, 1))
+              .put("iterations", (builder, argVal) -> builder.iterations = parseInt(argVal, -1))
               .put("maxInterval",
                   (builder, argVal) -> builder.maxInterval = parseInt(argVal, 0))
               .put("schemaRegistryUrl", (builder, argVal) -> builder.schemaRegistryUrl = argVal)


### PR DESCRIPTION
### Description 

BREAKING CHANGE: If no value is passed for the KSQL datagen option `iterations`, datagen will now produce indefinitely, rather than terminating after a default of 1,000,000 rows.

This change is valuable because previously there was no way to specify that datagen should produce indefinitely. This PR adds this ability, and updates it to be the default behavior. (Users can still use the old behavior of terminating the process after a fixed number of rows by passing that number via `iterations`.)

### Testing done 

Manual.

### Reviewer checklist
- [ ] Ensure docs are updated if necessary. (eg. if a user visible feature is being added or changed).
- [ ] Ensure relevant issues are linked (description should include text like "Fixes #<issue number>")

