### PR TITLE
refactor: start of our own internal Struct class

### DIFF
--- a/ksql-common/src/main/java/io/confluent/ksql/schema/ksql/DataException.java
+++ b/ksql-common/src/main/java/io/confluent/ksql/schema/ksql/DataException.java
@@ -1,0 +1,30 @@
+/*
+ * Copyright 2019 Confluent Inc.
+ *
+ * Licensed under the Confluent Community License (the "License"); you may not use
+ * this file except in compliance with the License.  You may obtain a copy of the
+ * License at
+ *
+ * http://www.confluent.io/confluent-community-license
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package io.confluent.ksql.schema.ksql;
+
+/**
+ * Issue with data.
+ */
+public class DataException extends RuntimeException {
+
+  public DataException(final String msg) {
+    super(msg);
+  }
+
+  public DataException(final String msg, final Throwable cause) {
+    super(msg, cause);
+  }
+}

--- a/ksql-common/src/main/java/io/confluent/ksql/schema/ksql/FieldName.java
+++ b/ksql-common/src/main/java/io/confluent/ksql/schema/ksql/FieldName.java
@@ -1,0 +1,128 @@
+/*
+ * Copyright 2019 Confluent Inc.
+ *
+ * Licensed under the Confluent Community License (the "License"); you may not use
+ * this file except in compliance with the License.  You may obtain a copy of the
+ * License at
+ *
+ * http://www.confluent.io/confluent-community-license
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package io.confluent.ksql.schema.ksql;
+
+import com.google.errorprone.annotations.Immutable;
+import io.confluent.ksql.util.SchemaUtil;
+import java.util.Objects;
+import java.util.Optional;
+
+/**
+ * Immutable POJO for storing a {@link Field}'s name
+ */
+@Immutable
+public final class FieldName {
+
+  private final Optional<String> source;
+  private final String name;
+  private final String fullName;
+
+  public static FieldName of(final String name) {
+    return of(Optional.empty(), name);
+  }
+
+  public static FieldName of(final String source, final String name) {
+    return of(Optional.of(source), name);
+  }
+
+  public static FieldName of(final Optional<String> source, final String name) {
+    return new FieldName(source, name);
+  }
+
+  private FieldName(final Optional<String> source, final String fullName) {
+    this.source = Objects.requireNonNull(source, "source");
+    this.name = Objects.requireNonNull(fullName, "name");
+    this.fullName = source
+        .map(s -> SchemaUtil.buildAliasedFieldName(s, name))
+        .orElse(name);
+
+    this.source.ifPresent(src -> {
+      if (!src.trim().equals(src)) {
+        throw new IllegalArgumentException("source is not trimmed: '" + src + "'");
+      }
+
+      if (src.isEmpty()) {
+        throw new IllegalArgumentException("source is empty");
+      }
+
+    });
+
+    if (!name.trim().equals(name)) {
+      throw new IllegalArgumentException("name is not trimmed: '" + name + "'");
+    }
+
+    if (name.isEmpty()) {
+      throw new IllegalArgumentException("name is empty");
+    }
+  }
+
+  /**
+   * @return the name of the source of the field, where known.
+   */
+  public Optional<String> source() {
+    return source;
+  }
+
+  /**
+   * @return the name of the field.
+   */
+  public String name() {
+    return name;
+  }
+
+  /**
+   * @return the fully qualified field name.
+   */
+  public String fullName() {
+    return fullName;
+  }
+
+  public FieldName withSource(final String source) {
+    return new FieldName(Optional.of(source), name);
+  }
+
+  @Override
+  public boolean equals(final Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    final FieldName fieldName = (FieldName) o;
+    return Objects.equals(fullName, fieldName.fullName);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(fullName);
+  }
+
+  @Override
+  public String toString() {
+    return toString(FormatOptions.none());
+  }
+
+  public String toString(final FormatOptions formatOptions) {
+    final Optional<String> base = source.map(val -> escape(val, formatOptions));
+    final String escaped = escape(name, formatOptions);
+    return base.map(s -> s + "." + escaped).orElse(escaped);
+  }
+
+  private static String escape(final String string, final FormatOptions formatOptions) {
+    return formatOptions.isReservedWord(string) ? "`" + string + "`" : string;
+  }
+}

--- a/ksql-common/src/main/java/io/confluent/ksql/schema/ksql/LogicalSchema.java
+++ b/ksql-common/src/main/java/io/confluent/ksql/schema/ksql/LogicalSchema.java
@@ -229,7 +229,7 @@ public final class LogicalSchema {
    * @return {@code true} is aliased, {@code false} otherwise.
    */
   public boolean isAliased() {
-    return metaFields.get(0).source().isPresent();
+    return metaFields.get(0).fieldName().source().isPresent();
   }
 
   /**
@@ -411,7 +411,7 @@ public final class LogicalSchema {
       final String fieldName = SchemaUtil.getFieldNameWithNoAlias(field.name());
       final SqlType fieldType = converter.toSqlType(field.schema());
 
-      builder.add(Field.of(source, fieldName, fieldType));
+      builder.add(Field.of(FieldName.of(source, fieldName), fieldType));
     }
 
     return builder.build();

--- a/ksql-common/src/main/java/io/confluent/ksql/schema/ksql/types/SqlArray.java
+++ b/ksql-common/src/main/java/io/confluent/ksql/schema/ksql/types/SqlArray.java
@@ -18,9 +18,13 @@ package io.confluent.ksql.schema.ksql.types;
 import static java.util.Objects.requireNonNull;
 
 import com.google.errorprone.annotations.Immutable;
+import io.confluent.ksql.schema.ksql.DataException;
 import io.confluent.ksql.schema.ksql.FormatOptions;
+import io.confluent.ksql.schema.ksql.SchemaConverters;
 import io.confluent.ksql.schema.ksql.SqlBaseType;
+import java.util.List;
 import java.util.Objects;
+import java.util.stream.IntStream;
 
 @Immutable
 public final class SqlArray extends SqlType {
@@ -43,6 +47,31 @@ public final class SqlArray extends SqlType {
   @Override
   public boolean supportsCast() {
     return false;
+  }
+
+  @Override
+  public void validateValue(final Object value) {
+    if (value == null) {
+      return;
+    }
+
+    if (!(value instanceof List)) {
+      final SqlBaseType sqlBaseType = SchemaConverters.javaToSqlConverter()
+          .toSqlType(value.getClass());
+
+      throw new DataException("Expected ARRAY, got " + sqlBaseType);
+    }
+
+    final List<?> array = (List<?>) value;
+
+    IntStream.range(0, array.size()).forEach(idx -> {
+      try {
+        final Object element = array.get(idx);
+        itemType.validateValue(element);
+      } catch (final DataException e) {
+        throw new DataException("ARRAY element " + (idx + 1) + ": " + e.getMessage(), e);
+      }
+    });
   }
 
   @Override

--- a/ksql-common/src/main/java/io/confluent/ksql/schema/ksql/types/SqlMap.java
+++ b/ksql-common/src/main/java/io/confluent/ksql/schema/ksql/types/SqlMap.java
@@ -18,12 +18,17 @@ package io.confluent.ksql.schema.ksql.types;
 import static java.util.Objects.requireNonNull;
 
 import com.google.errorprone.annotations.Immutable;
+import io.confluent.ksql.schema.ksql.DataException;
 import io.confluent.ksql.schema.ksql.FormatOptions;
+import io.confluent.ksql.schema.ksql.SchemaConverters;
 import io.confluent.ksql.schema.ksql.SqlBaseType;
+import java.util.Map;
 import java.util.Objects;
 
 @Immutable
 public final class SqlMap extends SqlType {
+
+  private static final SqlType KEY_TYPE = SqlTypes.STRING;
 
   private final SqlType valueType;
 
@@ -43,6 +48,35 @@ public final class SqlMap extends SqlType {
   @Override
   public boolean supportsCast() {
     return false;
+  }
+
+  @Override
+  public void validateValue(final Object value) {
+    if (value == null) {
+      return;
+    }
+
+    if (!(value instanceof Map)) {
+      final SqlBaseType sqlBaseType = SchemaConverters.javaToSqlConverter()
+          .toSqlType(value.getClass());
+
+      throw new DataException("Expected MAP, got " + sqlBaseType);
+    }
+
+    final Map<?, ?> map = (Map<?, ?>) value;
+    map.forEach((k, v) -> {
+      try {
+        KEY_TYPE.validateValue(k);
+      } catch (final DataException e) {
+        throw new DataException("MAP key: " + e.getMessage(), e);
+      }
+
+      try {
+        valueType.validateValue(v);
+      } catch (final DataException e) {
+        throw new DataException("MAP value for key '" + k + "': " + e.getMessage(), e);
+      }
+    });
   }
 
   @Override

--- a/ksql-common/src/main/java/io/confluent/ksql/schema/ksql/types/SqlPrimitiveType.java
+++ b/ksql-common/src/main/java/io/confluent/ksql/schema/ksql/types/SqlPrimitiveType.java
@@ -18,7 +18,9 @@ package io.confluent.ksql.schema.ksql.types;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
 import com.google.errorprone.annotations.Immutable;
+import io.confluent.ksql.schema.ksql.DataException;
 import io.confluent.ksql.schema.ksql.FormatOptions;
+import io.confluent.ksql.schema.ksql.SchemaConverters;
 import io.confluent.ksql.schema.ksql.SqlBaseType;
 import io.confluent.ksql.util.KsqlException;
 import java.util.Objects;
@@ -80,6 +82,20 @@ public final class SqlPrimitiveType extends SqlType {
   @Override
   public boolean supportsCast() {
     return true;
+  }
+
+  @Override
+  public void validateValue(final Object value) {
+    if (value == null) {
+      return;
+    }
+
+    final SqlBaseType actualType = SchemaConverters.javaToSqlConverter()
+        .toSqlType(value.getClass());
+
+    if (!baseType().equals(actualType)) {
+      throw new DataException("Expected " + baseType() + ", got " + actualType);
+    }
   }
 
   @Override

--- a/ksql-common/src/main/java/io/confluent/ksql/schema/ksql/types/SqlStruct.java
+++ b/ksql-common/src/main/java/io/confluent/ksql/schema/ksql/types/SqlStruct.java
@@ -19,9 +19,12 @@ import static java.util.Objects.requireNonNull;
 
 import com.google.common.collect.ImmutableList;
 import com.google.errorprone.annotations.Immutable;
+import io.confluent.ksql.schema.ksql.DataException;
 import io.confluent.ksql.schema.ksql.Field;
 import io.confluent.ksql.schema.ksql.FormatOptions;
+import io.confluent.ksql.schema.ksql.SchemaConverters;
 import io.confluent.ksql.schema.ksql.SqlBaseType;
+import io.confluent.ksql.types.KsqlStruct;
 import io.confluent.ksql.util.KsqlException;
 import java.util.ArrayList;
 import java.util.List;
@@ -49,6 +52,25 @@ public final class SqlStruct extends SqlType {
   @Override
   public boolean supportsCast() {
     return false;
+  }
+
+  @Override
+  public void validateValue(final Object value) {
+    if (value == null) {
+      return;
+    }
+
+    if (!(value instanceof KsqlStruct)) {
+      final SqlBaseType sqlBaseType = SchemaConverters.javaToSqlConverter()
+          .toSqlType(value.getClass());
+
+      throw new DataException("Expected STRUCT, got " + sqlBaseType);
+    }
+
+    final KsqlStruct struct = (KsqlStruct)value;
+    if (!struct.schema().equals(this)) {
+      throw new DataException("Expected " + this + ", got " + struct.schema());
+    }
   }
 
   @Override

--- a/ksql-common/src/main/java/io/confluent/ksql/schema/ksql/types/SqlType.java
+++ b/ksql-common/src/main/java/io/confluent/ksql/schema/ksql/types/SqlType.java
@@ -38,5 +38,7 @@ public abstract class SqlType {
 
   public abstract boolean supportsCast();
 
+  public abstract void validateValue(Object value);
+
   public abstract String toString(FormatOptions formatOptions);
 }

--- a/ksql-common/src/main/java/io/confluent/ksql/types/KsqlStruct.java
+++ b/ksql-common/src/main/java/io/confluent/ksql/types/KsqlStruct.java
@@ -1,0 +1,134 @@
+/*
+ * Copyright 2019 Confluent Inc.
+ *
+ * Licensed under the Confluent Community License (the "License"); you may not use
+ * this file except in compliance with the License.  You may obtain a copy of the
+ * License at
+ *
+ * http://www.confluent.io/confluent-community-license
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package io.confluent.ksql.types;
+
+import com.google.common.collect.ImmutableList;
+import com.google.errorprone.annotations.Immutable;
+import io.confluent.ksql.schema.ksql.Field;
+import io.confluent.ksql.schema.ksql.FieldName;
+import io.confluent.ksql.schema.ksql.types.SqlStruct;
+import io.confluent.ksql.util.KsqlException;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Objects;
+import java.util.Optional;
+
+/**
+ * Instance of {@link io.confluent.ksql.schema.ksql.types.SqlStruct}.
+ */
+@Immutable
+public final class KsqlStruct {
+
+  private final SqlStruct schema;
+  private final ImmutableList<Optional<?>> values;
+
+  public static Builder builder(final SqlStruct schema) {
+    return new Builder(schema);
+  }
+
+  private KsqlStruct(
+      final SqlStruct schema,
+      final List<Optional<?>> values
+  ) {
+    this.schema = Objects.requireNonNull(schema, "schema");
+    this.values = ImmutableList.copyOf(Objects.requireNonNull(values, "values"));
+  }
+
+  public SqlStruct schema() {
+    return this.schema;
+  }
+
+  public List<Optional<?>> values() {
+    return values;
+  }
+
+  @Override
+  public boolean equals(final Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    final KsqlStruct that = (KsqlStruct) o;
+    return Objects.equals(schema, that.schema)
+        && Objects.equals(values, that.values);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(schema, values);
+  }
+
+  @Override
+  public String toString() {
+    return "KsqlStruct{"
+        + "values=" + values
+        + ", schema=" + schema
+        + '}';
+  }
+
+  private static FieldInfo getField(final FieldName name, final SqlStruct schema) {
+    final List<Field> fields = schema.getFields();
+
+    for (int idx = 0; idx < fields.size(); idx++) {
+      final Field field = fields.get(idx);
+      if (field.fieldName().equals(name)) {
+        return new FieldInfo(idx, field);
+      }
+    }
+
+    throw new KsqlException("Unknown field: " + name);
+  }
+
+  public static final class Builder {
+
+    private final SqlStruct schema;
+    private final List<Optional<?>> values;
+
+    public Builder(final SqlStruct schema) {
+      this.schema = Objects.requireNonNull(schema, "schema");
+      this.values = new ArrayList<>(schema.getFields().size());
+      schema.getFields().forEach(f -> values.add(Optional.empty()));
+    }
+
+    public Builder set(final FieldName field, final Optional<?> value) {
+      final FieldInfo info = getField(field, schema);
+      info.field.type().validateValue(value.orElse(null));
+      values.set(info.index, value);
+      return this;
+    }
+
+    public Builder set(final String field, final Object value) {
+      return set(FieldName.of(field), Optional.ofNullable(value));
+    }
+
+    public KsqlStruct build() {
+      return new KsqlStruct(schema, values);
+    }
+  }
+
+  private static final class FieldInfo {
+
+    final int index;
+    final Field field;
+
+    private FieldInfo(final int index, final Field field) {
+      this.index = index;
+      this.field = Objects.requireNonNull(field, "field");
+    }
+  }
+}

--- a/ksql-common/src/test/java/io/confluent/ksql/schema/ksql/FieldNameTest.java
+++ b/ksql-common/src/test/java/io/confluent/ksql/schema/ksql/FieldNameTest.java
@@ -1,0 +1,145 @@
+/*
+ * Copyright 2019 Confluent Inc.
+ *
+ * Licensed under the Confluent Community License (the "License"); you may not use
+ * this file except in compliance with the License.  You may obtain a copy of the
+ * License at
+ *
+ * http://www.confluent.io/confluent-community-license
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package io.confluent.ksql.schema.ksql;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+
+import com.google.common.testing.EqualsTester;
+import com.google.common.testing.NullPointerTester;
+import java.util.Optional;
+import org.junit.Before;
+import org.junit.Test;
+
+public class FieldNameTest {
+
+  private FieldName fieldName;
+  private FieldName fieldNameNoSource;
+
+  @Before
+  public void setUp() {
+    fieldName = FieldName.of(Optional.of("someSource"), "someName");
+    fieldNameNoSource = FieldName.of(Optional.empty(), "someName");
+  }
+
+  @Test
+  public void shouldThrowNPE() {
+    new NullPointerTester()
+        .testAllPublicStaticMethods(FieldName.class);
+  }
+
+  @Test
+  public void shouldImplementEqualsProperly() {
+    new EqualsTester()
+        .addEqualityGroup(
+            FieldName.of(Optional.of("someSource"), "someName"),
+            FieldName.of(Optional.of("someSource"), "someName")
+        )
+        .addEqualityGroup(
+            FieldName.of(Optional.empty(), "someName".toUpperCase())
+        )
+        .testEquals();
+  }
+
+  @Test(expected = IllegalArgumentException.class)
+  public void shouldThrowOnLeadingWhiteSpaceOfSource() {
+    FieldName.of(Optional.of("  source_with_leading_ws"), "name");
+  }
+
+  @Test(expected = IllegalArgumentException.class)
+  public void shouldThrowOnLeadingWhiteSpaceOfNameWhenNoSource() {
+    FieldName.of(Optional.empty(), "  name_with_leading_ws");
+  }
+
+  @Test(expected = IllegalArgumentException.class)
+  public void shouldThrowOnLeadingWhiteSpaceOfNameWhenSource() {
+    FieldName.of(Optional.of("source"), "  name_with_leading_ws");
+  }
+
+  @Test(expected = IllegalArgumentException.class)
+  public void shouldThrowOnTrailingWhiteSpaceOfSource() {
+    FieldName.of(Optional.of("source_with_leading_ws  "), "name");
+  }
+
+  @Test(expected = IllegalArgumentException.class)
+  public void shouldThrowOnTrailingWhiteSpaceOfNameWhenNoSource() {
+    FieldName.of(Optional.empty(), "name_with_leading_ws  ");
+  }
+
+  @Test(expected = IllegalArgumentException.class)
+  public void shouldThrowOnTrailingWhiteSpaceOfNameWhenSource() {
+    FieldName.of(Optional.of("source"), "name_with_leading_ws  ");
+  }
+
+  @Test(expected = IllegalArgumentException.class)
+  public void shouldThrowOnEmptySource() {
+    FieldName.of(Optional.of(""), "name");
+  }
+
+  @Test(expected = IllegalArgumentException.class)
+  public void shouldThrowOnEmptyName() {
+    FieldName.of(Optional.empty(), "");
+  }
+
+  @Test
+  public void shouldReturnSource() {
+    assertThat(fieldName.source(), is(Optional.of("someSource")));
+  }
+
+  @Test
+  public void shouldReturnName() {
+    assertThat(fieldName.name(), is("someName"));
+  }
+
+  @Test
+  public void shouldReturnFullName() {
+    assertThat(fieldName.fullName(), is("someSource.someName"));
+  }
+
+  @Test
+  public void shouldReturnFullNameNoSource() {
+    assertThat(fieldNameNoSource.fullName(), is("someName"));
+  }
+
+  @Test
+  public void shouldToString() {
+    assertThat(fieldName.toString(), is("`someSource`.`someName`"));
+    assertThat(fieldNameNoSource.toString(), is("`someName`"));
+  }
+
+  @Test
+  public void shouldToStringWithReservedWords() {
+    // Given:
+    final FormatOptions options = FormatOptions.of(
+        identifier -> identifier.equals("reserved")
+            || identifier.equals("word")
+            || identifier.equals("reserved.name")
+    );
+
+    // Then:
+    assertThat(FieldName.of("not-reserved").toString(options),
+        is("not-reserved"));
+
+    assertThat(FieldName.of("reserved").toString(options),
+        is("`reserved`"));
+
+    assertThat(FieldName.of("reserved", "word").toString(options),
+        is("`reserved`.`word`"));
+
+    assertThat(FieldName.of("source", "word").toString(options),
+        is("source.`word`"));
+  }
+}

--- a/ksql-common/src/test/java/io/confluent/ksql/schema/ksql/FieldTest.java
+++ b/ksql-common/src/test/java/io/confluent/ksql/schema/ksql/FieldTest.java
@@ -60,16 +60,16 @@ public class FieldTest {
   }
 
   @Test
-  public void shouldReturnName() {
+  public void shouldReturnFieldName() {
     assertThat(Field.of("SomeName", SqlTypes.BOOLEAN).fieldName(),
         is(FieldName.of(Optional.empty(), "SomeName")));
 
-    assertThat(Field.of("SomeSource", "SomeName", SqlTypes.BOOLEAN).name(),
+    assertThat(Field.of("SomeSource", "SomeName", SqlTypes.BOOLEAN).fieldName(),
         is(FieldName.of(Optional.of("SomeSource"), "SomeName")));
   }
 
   @Test
-  public void shouldReturnName2() {
+  public void shouldReturnName() {
     assertThat(Field.of("SomeName", SqlTypes.BOOLEAN).name(),
         is("SomeName"));
 

--- a/ksql-common/src/test/java/io/confluent/ksql/schema/ksql/types/SqlPrimitiveTypeTest.java
+++ b/ksql-common/src/test/java/io/confluent/ksql/schema/ksql/types/SqlPrimitiveTypeTest.java
@@ -23,6 +23,7 @@ import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
 import com.google.common.testing.EqualsTester;
+import io.confluent.ksql.schema.ksql.DataException;
 import io.confluent.ksql.schema.ksql.SqlBaseType;
 import io.confluent.ksql.util.KsqlException;
 import java.util.List;
@@ -173,5 +174,38 @@ public class SqlPrimitiveTypeTest {
       // Then:
       assertThat(SqlPrimitiveType.of(type).toString(), is(type.toString()));
     });
+  }
+
+  @Test
+  public void shoudlValidatePrimitiveTypes() {
+    SqlPrimitiveType.of(SqlBaseType.BOOLEAN).validateValue(true);
+    SqlPrimitiveType.of(SqlBaseType.INTEGER).validateValue(19);
+    SqlPrimitiveType.of(SqlBaseType.BIGINT).validateValue(33L);
+    SqlPrimitiveType.of(SqlBaseType.DOUBLE).validateValue(45.0D);
+    SqlPrimitiveType.of(SqlBaseType.STRING).validateValue("");
+  }
+
+  @SuppressWarnings("UnnecessaryBoxing")
+  @Test
+  public void shouldValidateBoxedTypes() {
+    SqlPrimitiveType.of(SqlBaseType.BOOLEAN).validateValue(Boolean.FALSE);
+    SqlPrimitiveType.of(SqlBaseType.INTEGER).validateValue(Integer.valueOf(19));
+    SqlPrimitiveType.of(SqlBaseType.BIGINT).validateValue(Long.valueOf(33L));
+    SqlPrimitiveType.of(SqlBaseType.DOUBLE).validateValue(Double.valueOf(45.0D));
+  }
+
+  @Test
+  public void shouldValidateNullValue() {
+    SqlPrimitiveType.of(SqlBaseType.BOOLEAN).validateValue(null);
+  }
+
+  @Test
+  public void shouldFailValidationForWrongType() {
+    // Then:
+    expectedException.expect(DataException.class);
+    expectedException.expectMessage("Expected BOOLEAN, got INT");
+
+    // When:
+    SqlPrimitiveType.of(SqlBaseType.BOOLEAN).validateValue(10);
   }
 }

--- a/ksql-common/src/test/java/io/confluent/ksql/types/KsqlStructTest.java
+++ b/ksql-common/src/test/java/io/confluent/ksql/types/KsqlStructTest.java
@@ -1,0 +1,97 @@
+/*
+ * Copyright 2019 Confluent Inc.
+ *
+ * Licensed under the Confluent Community License (the "License"); you may not use
+ * this file except in compliance with the License.  You may obtain a copy of the
+ * License at
+ *
+ * http://www.confluent.io/confluent-community-license
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package io.confluent.ksql.types;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.contains;
+
+import io.confluent.ksql.schema.ksql.DataException;
+import io.confluent.ksql.schema.ksql.Field;
+import io.confluent.ksql.schema.ksql.FieldName;
+import io.confluent.ksql.schema.ksql.types.SqlStruct;
+import io.confluent.ksql.schema.ksql.types.SqlTypes;
+import io.confluent.ksql.util.KsqlException;
+import java.util.Optional;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+
+public class KsqlStructTest {
+
+  private static final SqlStruct SCHEMA = SqlTypes.struct()
+      .field("f0", SqlTypes.BIGINT)
+      .field(Field.of(FieldName.of("s1", "v1"), SqlTypes.BOOLEAN))
+      .build();
+
+  @Rule
+  public final ExpectedException expectedException = ExpectedException.none();
+
+  @Test
+  public void shouldHandleExplicitNulls() {
+    // When:
+    final KsqlStruct struct = KsqlStruct.builder(SCHEMA)
+        .set(FieldName.of("f0"), Optional.empty())
+        .set(FieldName.of("s1", "v1"), Optional.empty())
+        .build();
+
+    // Then:
+    assertThat(struct.values(), contains(Optional.empty(), Optional.empty()));
+  }
+
+  @Test
+  public void shouldHandleImplicitNulls() {
+    // When:
+    final KsqlStruct struct = KsqlStruct.builder(SCHEMA)
+        .build();
+
+    // Then:
+    assertThat(struct.values(), contains(Optional.empty(), Optional.empty()));
+  }
+
+  @Test
+  public void shouldThrowFieldNotKnown() {
+    // Then:
+    expectedException.expect(KsqlException.class);
+    expectedException.expectMessage("Unknown field: `??`");
+
+    // When:
+    KsqlStruct.builder(SCHEMA)
+        .set("??", Optional.empty());
+  }
+
+  @Test
+  public void shouldThrowIfValueWrongType() {
+    // Then:
+    expectedException.expect(DataException.class);
+    expectedException.expectMessage("Expected BIGINT, got STRING");
+
+    // When:
+    KsqlStruct.builder(SCHEMA)
+        .set("f0", "field is BIGINT, so won't like this");
+  }
+
+  @Test
+  public void shouldBuildStruct() {
+    // When:
+    final KsqlStruct struct = KsqlStruct.builder(SCHEMA)
+        .set(FieldName.of("f0"), Optional.of(10L))
+        .set(FieldName.of("s1", "v1"), Optional.of(true))
+        .build();
+
+    // Then:
+    assertThat(struct.values(), contains(Optional.of(10L), Optional.of(true)));
+  }
+}

--- a/ksql-engine/src/main/java/io/confluent/ksql/structured/SchemaKStream.java
+++ b/ksql-engine/src/main/java/io/confluent/ksql/structured/SchemaKStream.java
@@ -41,6 +41,7 @@ import io.confluent.ksql.metastore.model.KeyField;
 import io.confluent.ksql.metastore.model.KeyField.LegacyField;
 import io.confluent.ksql.metastore.model.KsqlTopic;
 import io.confluent.ksql.schema.ksql.Field;
+import io.confluent.ksql.schema.ksql.FieldName;
 import io.confluent.ksql.schema.ksql.FormatOptions;
 import io.confluent.ksql.schema.ksql.LogicalSchema;
 import io.confluent.ksql.schema.ksql.types.SqlTypes;
@@ -369,8 +370,9 @@ public class SchemaKStream<K> {
       final String fullFieldName = getKeyField().name().get();
       final Optional<String> fieldAlias = SchemaUtil.getFieldNameAlias(fullFieldName);
       final String fieldNameWithNoAlias = SchemaUtil.getFieldNameWithNoAlias(fullFieldName);
+      final FieldName fieldName = FieldName.of(fieldAlias, fieldNameWithNoAlias);
 
-      final Field keyField = Field.of(fieldAlias, fieldNameWithNoAlias, SqlTypes.STRING);
+      final Field keyField = Field.of(fieldName, SqlTypes.STRING);
 
       return doFindKeyField(selectExpressions, keyField)
           .map(Field::fullName);


### PR DESCRIPTION
### Description 

This PR introduces the start of our own internal replacement for Connect's `Struct` class. Introducing... `KsqlStruct.

To facilitate this I've pulled `FieldName` out of `Field` and I've added a `validateValue` function to each `SqlType` to do deep validation that a value matches a schema.

### Testing done 

Suitable tests added.

`mvn test`

### Reviewer checklist
- [ ] Ensure docs are updated if necessary. (eg. if a user visible feature is being added or changed).
- [ ] Ensure relevant issues are linked (description should include text like "Fixes #<issue number>")

