### PR TITLE
fix: ensure default server config works with IP6 (fixes #3309)

### DIFF
--- a/config/ksql-server.properties
+++ b/config/ksql-server.properties
@@ -17,7 +17,8 @@
 
 ### HTTP  ###
 # The URL the KSQL server will listen on:
-listeners=http://0.0.0.0:8088
+# The default is any IP4 or IP6 interface on the machine.
+listeners=http://0.0.0.0:8088,http://[::]:8088
 
 ### HTTPS ###
 # To switch KSQL over to communicating using HTTPS comment out the 'listeners' line above

--- a/config/ksql-server.properties
+++ b/config/ksql-server.properties
@@ -17,7 +17,7 @@
 
 ### HTTP  ###
 # The URL the KSQL server will listen on:
-# The default is any IP4 or IP6 interface on the machine.
+# The default is any IPv4 or IPv6 interface on the machine.
 listeners=http://0.0.0.0:8088,http://[::]:8088
 
 ### HTTPS ###

--- a/docs/installation/install-ksql-with-docker.rst
+++ b/docs/installation/install-ksql-with-docker.rst
@@ -264,7 +264,7 @@ Run a KSQL Server that uses a secure connection to a Kafka cluster:
 
 ``KSQL_LISTENERS``
     A list of URIs, including the protocol, that the broker listens on.
-    If you are using IP6 then you should set to ``http://[::]:8088``.
+    If you are using IPv6 , set to ``http://[::]:8088``.
     
 ``KSQL_KSQL_SINK_REPLICAS``
     The default number of replicas for the topics created by KSQL.

--- a/docs/installation/install-ksql-with-docker.rst
+++ b/docs/installation/install-ksql-with-docker.rst
@@ -182,7 +182,7 @@ Run a KSQL Server that enables manual interaction by using the KSQL CLI:
 
 ``KSQL_LISTENERS``
     A list of URIs, including the protocol, that the broker listens on.
-    If you are using IP6 then you should set to ``http://[::]:8088``.
+    If you are using IPv6, set to ``http://[::]:8088``.
 
 In interactive mode, a KSQL CLI instance running outside of Docker can connect
 to the KSQL server running in Docker.

--- a/docs/installation/install-ksql-with-docker.rst
+++ b/docs/installation/install-ksql-with-docker.rst
@@ -395,7 +395,7 @@ running in a different container.
 
 ``KSQL_OPTS``
     A space-separated list of Java options.
-    If you are using IP6 then you should set listeners to ``http://[::]:8088``.
+    If you are using IPv6, set ``listeners`` to ``http://[::]:8088``.
 
 The Docker network created by KSQL Server enables you to connect with a
 dockerized KSQL CLI.

--- a/docs/installation/install-ksql-with-docker.rst
+++ b/docs/installation/install-ksql-with-docker.rst
@@ -182,6 +182,7 @@ Run a KSQL Server that enables manual interaction by using the KSQL CLI:
 
 ``KSQL_LISTENERS``
     A list of URIs, including the protocol, that the broker listens on.
+    If you are using IP6 then you should set to ``http://[::]:8088``.
 
 In interactive mode, a KSQL CLI instance running outside of Docker can connect
 to the KSQL server running in Docker.
@@ -214,7 +215,8 @@ the KSQL CLI:
     internal topics created by KSQL.
 
 ``KSQL_LISTENERS``
-    A list of URIs, including the protocol, that the broker listens on.    
+    A list of URIs, including the protocol, that the broker listens on.
+    If you are using IP6 then you should set to ``http://[::]:8088``.
 
 ``KSQL_PRODUCER_INTERCEPTOR_CLASSES``
     A list of fully qualified class names for producer interceptors.
@@ -262,6 +264,7 @@ Run a KSQL Server that uses a secure connection to a Kafka cluster:
 
 ``KSQL_LISTENERS``
     A list of URIs, including the protocol, that the broker listens on.
+    If you are using IP6 then you should set to ``http://[::]:8088``.
     
 ``KSQL_KSQL_SINK_REPLICAS``
     The default number of replicas for the topics created by KSQL.
@@ -392,6 +395,7 @@ running in a different container.
 
 ``KSQL_OPTS``
     A space-separated list of Java options.
+    If you are using IP6 then you should set listeners to ``http://[::]:8088``.
 
 The Docker network created by KSQL Server enables you to connect with a
 dockerized KSQL CLI.

--- a/docs/installation/install-ksql-with-docker.rst
+++ b/docs/installation/install-ksql-with-docker.rst
@@ -216,7 +216,7 @@ the KSQL CLI:
 
 ``KSQL_LISTENERS``
     A list of URIs, including the protocol, that the broker listens on.
-    If you are using IP6 then you should set to ``http://[::]:8088``.
+    If you are using IPv6, set to ``http://[::]:8088``.
 
 ``KSQL_PRODUCER_INTERCEPTOR_CLASSES``
     A list of fully qualified class names for producer interceptors.

--- a/docs/installation/installing.rst
+++ b/docs/installation/installing.rst
@@ -81,7 +81,7 @@ Follow these instructions to start KSQL server using the ``ksql-server-start`` s
     ::
 
         bootstrap.servers=localhost:9092
-        listeners=http://0.0.0.0:8088
+        listeners=http://0.0.0.0:8088,http://[::]:8088
 
     For more information, see :ref:`ksql-server-config`.
 

--- a/docs/installation/server-config/config-reference.rst
+++ b/docs/installation/server-config/config-reference.rst
@@ -361,7 +361,7 @@ Update this to a specific interface to bind only to a single interface. For exam
 
 ::
 
-    # Bind to all interfaces IP.
+    # Bind to all interfaces, (both IPv4 and IPv6).
     listeners=http://0.0.0.0:8088,http://[::]:8088
 
     # Bind only to localhost.

--- a/docs/installation/server-config/config-reference.rst
+++ b/docs/installation/server-config/config-reference.rst
@@ -356,7 +356,7 @@ listeners
 The ``listeners`` setting controls the REST API endpoint for the KSQL server.
 For more info, see :ref:`ksql-rest-api`.
 
-The default ``listeners`` is ``http://0.0.0.0:8088,http://[::]:8088``, which binds to all IP4 and IP6 interfaces.
+The default ``listeners`` is ``http://0.0.0.0:8088,http://[::]:8088``, which binds to all IPv4 and IPv6 interfaces.
 Update this to a specific interface to bind only to a single interface. For example:
 
 ::

--- a/docs/installation/server-config/config-reference.rst
+++ b/docs/installation/server-config/config-reference.rst
@@ -356,13 +356,13 @@ listeners
 The ``listeners`` setting controls the REST API endpoint for the KSQL server.
 For more info, see :ref:`ksql-rest-api`.
 
-The default hostname is ``0.0.0.0`` which binds to all interfaces. Update this
-to a specific interface to bind only to a single interface. For example:
+The default ``listeners`` is ``http://0.0.0.0:8088,http://[::]:8088``, which binds to all IP4 and IP6 interfaces.
+Update this to a specific interface to bind only to a single interface. For example:
 
 ::
 
-    # Bind to all interfaces.
-    listeners=http://0.0.0.0:8088
+    # Bind to all interfaces IP.
+    listeners=http://0.0.0.0:8088,http://[::]:8088
 
     # Bind only to localhost.
     listeners=http://localhost:8088

--- a/docs/operations.rst
+++ b/docs/operations.rst
@@ -171,6 +171,13 @@ setting:
 
     listeners=http://0.0.0.0:8088
 
+Or if you are running over IP6:
+
+.. code:: bash
+
+    listeners=http://[::]:8088
+
+
 For more info, see :ref:`Starting KSQL Server <start_ksql-server>`.
 
 Check for a port conflict

--- a/docs/operations.rst
+++ b/docs/operations.rst
@@ -171,7 +171,7 @@ setting:
 
     listeners=http://0.0.0.0:8088
 
-Or if you are running over IP6:
+Or if you are running over IPv6:
 
 .. code:: bash
 

--- a/docs/operations.rst
+++ b/docs/operations.rst
@@ -173,7 +173,7 @@ setting:
 
 Or if you are running over IPv6:
 
-.. code:: bash
+::
 
     listeners=http://[::]:8088
 

--- a/docs/troubleshoot-ksql.rst
+++ b/docs/troubleshoot-ksql.rst
@@ -172,7 +172,7 @@ setting in the file and verify it is set correctly.
 
     listeners=http://0.0.0.0:8088
 
-Or if you are running over IP6:
+Or if you are running over IPv6:
 
 .. code:: bash
 

--- a/docs/troubleshoot-ksql.rst
+++ b/docs/troubleshoot-ksql.rst
@@ -174,7 +174,7 @@ setting in the file and verify it is set correctly.
 
 Or if you are running over IPv6:
 
-.. code:: bash
+::
 
     listeners=http://[::]:8088
 

--- a/docs/troubleshoot-ksql.rst
+++ b/docs/troubleshoot-ksql.rst
@@ -172,6 +172,12 @@ setting in the file and verify it is set correctly.
 
     listeners=http://0.0.0.0:8088
 
+Or if you are running over IP6:
+
+.. code:: bash
+
+    listeners=http://[::]:8088
+
 See :ref:`Starting KSQL Server <start_ksql-server>` for more information.
 
 

--- a/docs/tutorials/docker-compose.yml
+++ b/docs/tutorials/docker-compose.yml
@@ -45,6 +45,6 @@ services:
       - schema-registry
     environment:
       KSQL_BOOTSTRAP_SERVERS: kafka:39092
-      KSQL_LISTENERS: http://0.0.0.0:8088
+      KSQL_LISTENERS: http://0.0.0.0:8088,http://[::]:8088
       KSQL_KSQL_SCHEMA_REGISTRY_URL: http://schema-registry:8081
 


### PR DESCRIPTION
### Description 

Fixes #3309 by adding the IP6 equiv of `http://0.0.0.0:8088` - the server will no listen on all IP6 interfaces too.

### Testing done 

Manual testing - can run server with just the IP6 listener and still connect using default CLI server of `http://localhost:8088`

### Reviewer checklist
- [ ] Ensure docs are updated if necessary. (eg. if a user visible feature is being added or changed).
- [ ] Ensure relevant issues are linked (description should include text like "Fixes #<issue number>")

