### PR TITLE
fix: revert default listeners value and update docs

### DIFF
--- a/config/ksql-server.properties
+++ b/config/ksql-server.properties
@@ -17,8 +17,11 @@
 
 ### HTTP  ###
 # The URL the KSQL server will listen on:
-# The default is any IPv4 or IPv6 interface on the machine.
-listeners=http://0.0.0.0:8088,http://[::]:8088
+# The default is any IPv4 interface on the machine.
+listeners=http://0.0.0.0:8088
+
+# Use the 'listeners' line below for any IPv6 interface on the machine.
+# listeners=http://[::]:8088
 
 ### HTTPS ###
 # To switch KSQL over to communicating using HTTPS comment out the 'listeners' line above

--- a/docs/installation/installing.rst
+++ b/docs/installation/installing.rst
@@ -81,7 +81,7 @@ Follow these instructions to start KSQL server using the ``ksql-server-start`` s
     ::
 
         bootstrap.servers=localhost:9092
-        listeners=http://0.0.0.0:8088,http://[::]:8088
+        listeners=http://0.0.0.0:8088
 
     For more information, see :ref:`ksql-server-config`.
 

--- a/docs/installation/server-config/config-reference.rst
+++ b/docs/installation/server-config/config-reference.rst
@@ -356,13 +356,17 @@ listeners
 The ``listeners`` setting controls the REST API endpoint for the KSQL server.
 For more info, see :ref:`ksql-rest-api`.
 
-The default ``listeners`` is ``http://0.0.0.0:8088,http://[::]:8088``, which binds to all IPv4 and IPv6 interfaces.
+The default ``listeners`` is ``http://0.0.0.0:8088``, which binds to all IPv4 interfaces.
+Set ``listeners`` to ``http://[::]:8088`` to bind to all IPv6 interfaces.
 Update this to a specific interface to bind only to a single interface. For example:
 
 ::
 
-    # Bind to all interfaces, (both IPv4 and IPv6).
-    listeners=http://0.0.0.0:8088,http://[::]:8088
+    # Bind to all IPv4 interfaces.
+    listeners=http://0.0.0.0:8088
+
+    # Bind to all IPv6 interfaces.
+    listeners=http://[::]:8088
 
     # Bind only to localhost.
     listeners=http://localhost:8088

--- a/docs/tutorials/docker-compose.yml
+++ b/docs/tutorials/docker-compose.yml
@@ -45,6 +45,6 @@ services:
       - schema-registry
     environment:
       KSQL_BOOTSTRAP_SERVERS: kafka:39092
-      KSQL_LISTENERS: http://0.0.0.0:8088,http://[::]:8088
+      KSQL_LISTENERS: http://0.0.0.0:8088
       KSQL_KSQL_SCHEMA_REGISTRY_URL: http://schema-registry:8081
 


### PR DESCRIPTION
### Description 
Follow up to: https://github.com/confluentinc/ksql/pull/3310
`listeners=http://0.0.0.0:8088,http://[::]:8088` change in the previous PR will cause the server initialization to fail with:
```
...
[2019-09-09 12:49:35,916] INFO Starting server (io.confluent.ksql.rest.server.KsqlServerMain:75)
[2019-09-09 12:49:36,043] INFO Adding listener: http://0.0.0.0:8088 (io.confluent.rest.Application:241)
[2019-09-09 12:49:36,061] INFO Adding listener: http://[::]:8088 (io.confluent.rest.Application:241)
[2019-09-09 12:49:36,230] INFO jetty-9.4.18.v20190429; built: 2019-04-29T20:42:08.989Z; git: e1bc35120a6617ee3df052294e433f3a25ce7097; jvm 1.8.0_202-ea-b03 (org.eclipse.jetty.server.Server:370)
[2019-09-09 12:49:36,265] INFO DefaultSessionIdManager workerName=node0 (org.eclipse.jetty.server.session:365)
[2019-09-09 12:49:36,265] INFO No SessionScavenger set, using defaults (org.eclipse.jetty.server.session:370)
[2019-09-09 12:49:36,266] INFO node0 Scavenging every 660000ms (org.eclipse.jetty.server.session:149)
[2019-09-09 12:49:36,698] INFO HV000001: Hibernate Validator 5.1.3.Final (org.hibernate.validator.internal.util.Version:27)
[2019-09-09 12:49:36,814] INFO Started o.e.j.s.ServletContextHandler@592238c5{/,null,AVAILABLE} (org.eclipse.jetty.server.handler.ContextHandler:855)
[2019-09-09 12:49:36,843] INFO Started o.e.j.s.ServletContextHandler@1aa99005{/ws,null,AVAILABLE} (org.eclipse.jetty.server.handler.ContextHandler:855)
[2019-09-09 12:49:36,859] INFO Started NetworkTrafficServerConnector@377008df{HTTP/1.1,[http/1.1]}{0.0.0.0:8088} (org.eclipse.jetty.server.AbstractConnector:292)
[2019-09-09 12:49:36,859] INFO Server shutting down (io.confluent.ksql.rest.server.KsqlServerMain:80)
[2019-09-09 12:49:51,881] INFO Stopped NetworkTrafficServerConnector@377008df{HTTP/1.1,[http/1.1]}{0.0.0.0:8088} (org.eclipse.jetty.server.AbstractConnector:341)
[2019-09-09 12:49:51,881] INFO Stopped NetworkTrafficServerConnector@105b693d{HTTP/1.1,[http/1.1]}{[::]:8088} (org.eclipse.jetty.server.AbstractConnector:341)
[2019-09-09 12:49:51,882] INFO node0 Stopped scavenging (org.eclipse.jetty.server.session:167)
[2019-09-09 12:49:51,883] INFO Stopped o.e.j.s.ServletContextHandler@1aa99005{/ws,null,UNAVAILABLE} (org.eclipse.jetty.server.handler.ContextHandler:1045)
[2019-09-09 12:49:51,887] INFO Stopped o.e.j.s.ServletContextHandler@592238c5{/,null,UNAVAILABLE} (org.eclipse.jetty.server.handler.ContextHandler:1045)
[2019-09-09 12:49:51,888] ERROR Failed to start KSQL (io.confluent.ksql.rest.server.KsqlServerMain:64)
java.io.IOException: Failed to bind to /0:0:0:0:0:0:0:0:8088
	at org.eclipse.jetty.server.ServerConnector.openAcceptChannel(ServerConnector.java:346)
	at org.eclipse.jetty.server.ServerConnector.open(ServerConnector.java:308)
	at org.eclipse.jetty.server.AbstractNetworkConnector.doStart(AbstractNetworkConnector.java:80)
	at org.eclipse.jetty.server.ServerConnector.doStart(ServerConnector.java:236)
	at org.eclipse.jetty.util.component.AbstractLifeCycle.start(AbstractLifeCycle.java:68)
	at org.eclipse.jetty.server.Server.doStart(Server.java:396)
	at org.eclipse.jetty.util.component.AbstractLifeCycle.start(AbstractLifeCycle.java:68)
	at io.confluent.rest.Application.start(Application.java:746)
	at io.confluent.ksql.rest.server.KsqlRestApplication.start(KsqlRestApplication.java:205)
	at io.confluent.ksql.rest.server.KsqlServerMain.tryStartApp(KsqlServerMain.java:76)
	at io.confluent.ksql.rest.server.KsqlServerMain.main(KsqlServerMain.java:62)
Caused by: java.net.BindException: Address already in use
	at sun.nio.ch.Net.bind0(Native Method)
	at sun.nio.ch.Net.bind(Net.java:433)
	at sun.nio.ch.Net.bind(Net.java:425)
	at sun.nio.ch.ServerSocketChannelImpl.bind(ServerSocketChannelImpl.java:223)
	at sun.nio.ch.ServerSocketAdaptor.bind(ServerSocketAdaptor.java:74)
	at org.eclipse.jetty.server.ServerConnector.openAcceptChannel(ServerConnector.java:342)
	... 10 more
```
This doesn't happen when `listeners=http://[::]:8088` 
________
```
[2019-09-09 12:49:36,043] INFO Adding listener: http://0.0.0.0:8088 (io.confluent.rest.Application:241)
[2019-09-09 12:49:36,061] INFO Adding listener: http://[::]:8088 (io.confluent.rest.Application:241)
```
indicates that both listeners are registered. `http://[::]:8088` is considered the same as 
`http://0.0.0.0:8088`

### Testing done 
`./bin/ksql-server-start ./config/ksql-server.properties`
with
`listeners=http://[::]:8088`
### Reviewer checklist
- [ ] Ensure docs are updated if necessary. (eg. if a user visible feature is being added or changed).
- [ ] Ensure relevant issues are linked (description should include text like "Fixes #<issue number>")

