### PR TITLE
refactor: LogicalSchema

### DIFF
--- a/ksql-benchmark/src/main/java/io/confluent/ksql/benchmark/SerdeBenchmark.java
+++ b/ksql-benchmark/src/main/java/io/confluent/ksql/benchmark/SerdeBenchmark.java
@@ -98,7 +98,7 @@ public class SerdeBenchmark {
 
       final Pair<Struct, GenericRow> genericRowPair = rowGenerator.generateRow();
       row = genericRowPair.getRight();
-      schema = rowGenerator.schema().valueSchema();
+      schema = rowGenerator.schema().valueConnectSchema();
     }
 
     private InputStream getSchemaStream() {

--- a/ksql-cli/src/test/java/io/confluent/ksql/cli/CliTest.java
+++ b/ksql-cli/src/test/java/io/confluent/ksql/cli/CliTest.java
@@ -58,6 +58,7 @@ import io.confluent.ksql.rest.server.KsqlRestApplication;
 import io.confluent.ksql.rest.server.TestKsqlRestApp;
 import io.confluent.ksql.schema.ksql.LogicalSchema;
 import io.confluent.ksql.schema.ksql.PhysicalSchema;
+import io.confluent.ksql.schema.ksql.types.SqlTypes;
 import io.confluent.ksql.serde.SerdeOption;
 import io.confluent.ksql.test.util.EmbeddedSingleNodeKafkaCluster;
 import io.confluent.ksql.test.util.KsqlIdentifierTestUtil;
@@ -84,8 +85,6 @@ import javax.ws.rs.ProcessingException;
 import kafka.zookeeper.ZooKeeperClientException;
 import org.apache.kafka.clients.consumer.ConsumerConfig;
 import org.apache.kafka.common.serialization.StringDeserializer;
-import org.apache.kafka.connect.data.Schema;
-import org.apache.kafka.connect.data.SchemaBuilder;
 import org.apache.kafka.streams.StreamsConfig;
 import org.eclipse.jetty.http.HttpStatus;
 import org.eclipse.jetty.http.HttpStatus.Code;
@@ -534,14 +533,11 @@ public class CliTest {
             new Double[]{1100.0, 1110.99, 970.0})));
 
     final PhysicalSchema resultSchema = PhysicalSchema.from(
-        LogicalSchema.of(SchemaBuilder.struct()
-            .field("ITEMID", SchemaBuilder.OPTIONAL_STRING_SCHEMA)
-            .field("ORDERUNITS", SchemaBuilder.OPTIONAL_FLOAT64_SCHEMA)
-            .field("PRICEARRAY", SchemaBuilder
-                .array(SchemaBuilder.OPTIONAL_FLOAT64_SCHEMA)
-                .optional()
-                .build())
-            .build()),
+        LogicalSchema.builder()
+            .valueField("ITEMID", SqlTypes.STRING)
+            .valueField("ORDERUNITS", SqlTypes.DOUBLE)
+            .valueField("PRICEARRAY", SqlTypes.array(SqlTypes.DOUBLE))
+            .build(),
         SerdeOption.none()
     );
 
@@ -640,15 +636,14 @@ public class CliTest {
         orderDataProvider.kstreamName()
     );
 
-    final Schema sourceSchema = orderDataProvider.schema().logicalSchema().valueSchema();
     final PhysicalSchema resultSchema = PhysicalSchema.from(
-        LogicalSchema.of(SchemaBuilder.struct()
-            .field("ITEMID", sourceSchema.field("ITEMID").schema())
-            .field("COL1", sourceSchema.field("ORDERUNITS").schema())
-            .field("COL2", sourceSchema.field("PRICEARRAY").schema().valueSchema())
-            .field("COL3", sourceSchema.field("KEYVALUEMAP").schema().valueSchema())
-            .field("COL4", SchemaBuilder.OPTIONAL_BOOLEAN_SCHEMA)
-            .build()),
+        LogicalSchema.builder()
+            .valueField("ITEMID", SqlTypes.STRING)
+            .valueField("COL1", SqlTypes.DOUBLE)
+            .valueField("COL2", SqlTypes.DOUBLE)
+            .valueField("COL3", SqlTypes.DOUBLE)
+            .valueField("COL4", SqlTypes.BOOLEAN)
+            .build(),
         SerdeOption.none()
     );
 

--- a/ksql-common/src/main/java/io/confluent/ksql/schema/ksql/SchemaConverters.java
+++ b/ksql-common/src/main/java/io/confluent/ksql/schema/ksql/SchemaConverters.java
@@ -261,7 +261,7 @@ public final class SchemaConverters {
     private static SchemaBuilder fromSqlStruct(final SqlStruct struct) {
       final SchemaBuilder builder = SchemaBuilder.struct();
 
-      struct.getFields()
+      struct.fields()
           .forEach(field -> builder.field(field.fullName(), connectType(field.type()).build()));
 
       return builder

--- a/ksql-common/src/main/java/io/confluent/ksql/schema/ksql/SqlTypeWalker.java
+++ b/ksql-common/src/main/java/io/confluent/ksql/schema/ksql/SqlTypeWalker.java
@@ -139,7 +139,7 @@ public final class SqlTypeWalker {
       final SqlType type
   ) {
     final SqlStruct struct = (SqlStruct) type;
-    final List<F> fields = struct.getFields().stream()
+    final List<F> fields = struct.fields().stream()
         .map(field -> visitField(visitor, field))
         .collect(Collectors.toList());
 

--- a/ksql-common/src/main/java/io/confluent/ksql/schema/ksql/types/SqlStruct.java
+++ b/ksql-common/src/main/java/io/confluent/ksql/schema/ksql/types/SqlStruct.java
@@ -45,7 +45,7 @@ public final class SqlStruct extends SqlType {
     this.fields = ImmutableList.copyOf(requireNonNull(fields, "fields"));
   }
 
-  public List<Field> getFields() {
+  public List<Field> fields() {
     return fields;
   }
 

--- a/ksql-common/src/main/java/io/confluent/ksql/types/KsqlStruct.java
+++ b/ksql-common/src/main/java/io/confluent/ksql/types/KsqlStruct.java
@@ -82,7 +82,7 @@ public final class KsqlStruct {
   }
 
   private static FieldInfo getField(final FieldName name, final SqlStruct schema) {
-    final List<Field> fields = schema.getFields();
+    final List<Field> fields = schema.fields();
 
     for (int idx = 0; idx < fields.size(); idx++) {
       final Field field = fields.get(idx);
@@ -101,8 +101,8 @@ public final class KsqlStruct {
 
     public Builder(final SqlStruct schema) {
       this.schema = Objects.requireNonNull(schema, "schema");
-      this.values = new ArrayList<>(schema.getFields().size());
-      schema.getFields().forEach(f -> values.add(Optional.empty()));
+      this.values = new ArrayList<>(schema.fields().size());
+      schema.fields().forEach(f -> values.add(Optional.empty()));
     }
 
     public Builder set(final FieldName field, final Optional<?> value) {
@@ -112,8 +112,8 @@ public final class KsqlStruct {
       return this;
     }
 
-    public Builder set(final String field, final Object value) {
-      return set(FieldName.of(field), Optional.ofNullable(value));
+    public Builder set(final String field, final Optional<?> value) {
+      return set(FieldName.of(field), value);
     }
 
     public KsqlStruct build() {

--- a/ksql-common/src/test/java/io/confluent/ksql/schema/ksql/types/SqlStructTest.java
+++ b/ksql-common/src/test/java/io/confluent/ksql/schema/ksql/types/SqlStructTest.java
@@ -26,6 +26,7 @@ import io.confluent.ksql.schema.ksql.FormatOptions;
 import io.confluent.ksql.schema.ksql.SqlBaseType;
 import io.confluent.ksql.types.KsqlStruct;
 import io.confluent.ksql.util.KsqlException;
+import java.util.Optional;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ExpectedException;
@@ -66,7 +67,7 @@ public class SqlStructTest {
         .build();
 
     // Then:
-    assertThat(struct.getFields(), contains(
+    assertThat(struct.fields(), contains(
         Field.of("f0", SqlTypes.BIGINT),
         Field.of("f1", SqlTypes.DOUBLE)
     ));
@@ -170,7 +171,7 @@ public class SqlStructTest {
         .build();
 
     final KsqlStruct value = KsqlStruct.builder(mismatching)
-        .set("f0", 10.0D)
+        .set("f0", Optional.of(10.0D))
         .build();
 
     // Then:
@@ -200,7 +201,7 @@ public class SqlStructTest {
         .build();
 
     final KsqlStruct value = KsqlStruct.builder(schema)
-        .set("f0", 10L)
+        .set("f0", Optional.of(10L))
         .build();
 
     // When:

--- a/ksql-common/src/test/java/io/confluent/ksql/types/KsqlStructTest.java
+++ b/ksql-common/src/test/java/io/confluent/ksql/types/KsqlStructTest.java
@@ -80,7 +80,7 @@ public class KsqlStructTest {
 
     // When:
     KsqlStruct.builder(SCHEMA)
-        .set("f0", "field is BIGINT, so won't like this");
+        .set("f0", Optional.of("field is BIGINT, so won't like this"));
   }
 
   @Test

--- a/ksql-common/src/test/java/io/confluent/ksql/util/timestamp/TimestampExtractionPolicyFactoryTest.java
+++ b/ksql-common/src/test/java/io/confluent/ksql/util/timestamp/TimestampExtractionPolicyFactoryTest.java
@@ -21,11 +21,11 @@ import static org.hamcrest.core.IsInstanceOf.instanceOf;
 
 import com.google.common.collect.ImmutableMap;
 import io.confluent.ksql.schema.ksql.LogicalSchema;
+import io.confluent.ksql.schema.ksql.types.SqlTypes;
 import io.confluent.ksql.util.KsqlConfig;
 import io.confluent.ksql.util.KsqlException;
 import java.util.Collections;
 import java.util.Optional;
-import org.apache.kafka.common.config.ConfigException;
 import org.apache.kafka.connect.data.Schema;
 import org.apache.kafka.connect.data.SchemaBuilder;
 import org.apache.kafka.streams.StreamsConfig;
@@ -38,6 +38,8 @@ import org.junit.rules.ExpectedException;
 
 public class TimestampExtractionPolicyFactoryTest {
 
+  private final LogicalSchema.Builder schemaBuilder2 = LogicalSchema.builder()
+      .valueField("id", SqlTypes.BIGINT);
 
   private final SchemaBuilder schemaBuilder = SchemaBuilder.struct()
       .field("id", Schema.OPTIONAL_INT64_SCHEMA);
@@ -58,7 +60,7 @@ public class TimestampExtractionPolicyFactoryTest {
     final TimestampExtractionPolicy result = TimestampExtractionPolicyFactory
         .create(
             ksqlConfig,
-            LogicalSchema.of(schemaBuilder.build()),
+            schemaBuilder2.build(),
             Optional.empty(),
             Optional.empty()
         );
@@ -85,7 +87,7 @@ public class TimestampExtractionPolicyFactoryTest {
     TimestampExtractionPolicyFactory
         .create(
             ksqlConfig,
-            LogicalSchema.of(schemaBuilder.build()),
+            schemaBuilder2.build(),
             Optional.empty(),
             Optional.empty()
         );
@@ -97,7 +99,7 @@ public class TimestampExtractionPolicyFactoryTest {
     final TimestampExtractionPolicy result = TimestampExtractionPolicyFactory
         .create(
             ksqlConfig,
-            LogicalSchema.of(schemaBuilder.build()),
+            schemaBuilder2.build(),
             Optional.empty(),
             Optional.empty()
         );
@@ -119,7 +121,7 @@ public class TimestampExtractionPolicyFactoryTest {
     final TimestampExtractionPolicy result = TimestampExtractionPolicyFactory
         .create(
             ksqlConfig,
-            LogicalSchema.of(schemaBuilder.build()),
+            schemaBuilder2.build(),
             Optional.empty(),
             Optional.empty()
         );
@@ -133,13 +135,13 @@ public class TimestampExtractionPolicyFactoryTest {
   public void shouldCreateLongTimestampPolicyWhenTimestampFieldIsOfTypeLong() {
     // Given:
     final String timestamp = "timestamp";
-    final Schema schema = schemaBuilder
-        .field(timestamp.toUpperCase(), Schema.OPTIONAL_INT64_SCHEMA)
+    final LogicalSchema schema = schemaBuilder2
+        .valueField(timestamp.toUpperCase(), SqlTypes.BIGINT)
         .build();
 
     // When:
     final TimestampExtractionPolicy result = TimestampExtractionPolicyFactory
-        .create(ksqlConfig, LogicalSchema.of(schema), Optional.of(timestamp), Optional.empty());
+        .create(ksqlConfig, schema, Optional.of(timestamp), Optional.empty());
 
     // Then:
     assertThat(result, instanceOf(LongColumnTimestampExtractionPolicy.class));
@@ -155,7 +157,7 @@ public class TimestampExtractionPolicyFactoryTest {
     TimestampExtractionPolicyFactory
         .create(
             ksqlConfig,
-            LogicalSchema.of(schemaBuilder.build()),
+            schemaBuilder2.build(),
             Optional.of("whateva"),
             Optional.empty()
         );
@@ -165,13 +167,13 @@ public class TimestampExtractionPolicyFactoryTest {
   public void shouldCreateStringTimestampPolicyWhenTimestampFieldIsStringTypeAndFormatProvided() {
     // Given:
     final String field = "my_string_field";
-    final Schema schema = schemaBuilder
-        .field(field.toUpperCase(), Schema.OPTIONAL_STRING_SCHEMA)
+    final LogicalSchema schema = schemaBuilder2
+        .valueField(field.toUpperCase(), SqlTypes.STRING)
         .build();
 
     // When:
     final TimestampExtractionPolicy result = TimestampExtractionPolicyFactory
-        .create(ksqlConfig, LogicalSchema.of(schema), Optional.of(field), Optional.of("yyyy-MM-DD"));
+        .create(ksqlConfig, schema, Optional.of(field), Optional.of("yyyy-MM-DD"));
 
     // Then:
     assertThat(result, instanceOf(StringTimestampExtractionPolicy.class));
@@ -182,8 +184,8 @@ public class TimestampExtractionPolicyFactoryTest {
   public void shouldFailIfStringTimestampTypeAndFormatNotSupplied() {
     // Given:
     final String field = "my_string_field";
-    final Schema schema = schemaBuilder
-        .field(field.toUpperCase(), Schema.OPTIONAL_STRING_SCHEMA)
+    final LogicalSchema schema = schemaBuilder2
+        .valueField(field.toUpperCase(), SqlTypes.STRING)
         .build();
 
     // Then:
@@ -191,15 +193,15 @@ public class TimestampExtractionPolicyFactoryTest {
 
     // When:
     TimestampExtractionPolicyFactory
-        .create(ksqlConfig, LogicalSchema.of(schema), Optional.of(field), Optional.empty());
+        .create(ksqlConfig, schema, Optional.of(field), Optional.empty());
   }
 
   @Test
   public void shouldThorwIfLongTimestampTypeAndFormatIsSupplied() {
     // Given:
     final String timestamp = "timestamp";
-    final Schema schema = schemaBuilder
-        .field(timestamp.toUpperCase(), Schema.OPTIONAL_INT64_SCHEMA)
+    final LogicalSchema schema = schemaBuilder2
+        .valueField(timestamp.toUpperCase(), SqlTypes.BIGINT)
         .build();
 
     // Then:
@@ -207,15 +209,15 @@ public class TimestampExtractionPolicyFactoryTest {
 
     // When:
     TimestampExtractionPolicyFactory
-        .create(ksqlConfig, LogicalSchema.of(schema), Optional.of(timestamp), Optional.of("b"));
+        .create(ksqlConfig, schema, Optional.of(timestamp), Optional.of("b"));
   }
 
   @Test
   public void shouldThrowIfTimestampFieldTypeIsNotLongOrString() {
     // Given:
     final String field = "blah";
-    final Schema schema = schemaBuilder
-        .field(field.toUpperCase(), Schema.OPTIONAL_FLOAT64_SCHEMA)
+    final LogicalSchema schema = schemaBuilder2
+        .valueField(field.toUpperCase(), SqlTypes.DOUBLE)
         .build();
 
     // Then:
@@ -223,6 +225,6 @@ public class TimestampExtractionPolicyFactoryTest {
 
     // When:
     TimestampExtractionPolicyFactory
-        .create(ksqlConfig, LogicalSchema.of(schema), Optional.of(field), Optional.empty());
+        .create(ksqlConfig, schema, Optional.of(field), Optional.empty());
   }
 }

--- a/ksql-engine/src/main/java/io/confluent/ksql/analyzer/SourceSchemas.java
+++ b/ksql-engine/src/main/java/io/confluent/ksql/analyzer/SourceSchemas.java
@@ -110,11 +110,11 @@ final class SourceSchemas {
   }
 
   private static Set<String> nonValueFieldNames(final LogicalSchema schema) {
-    final Set<String> fieldNames = schema.metaFields().stream()
+    final Set<String> fieldNames = schema.metadata().fields().stream()
         .map(Field::fullName)
         .collect(Collectors.toSet());
 
-    schema.keyFields().stream()
+    schema.key().fields().stream()
         .map(Field::fullName)
         .forEach(fieldNames::add);
 

--- a/ksql-engine/src/main/java/io/confluent/ksql/codegen/CodeGenRunner.java
+++ b/ksql-engine/src/main/java/io/confluent/ksql/codegen/CodeGenRunner.java
@@ -323,7 +323,7 @@ public class CodeGenRunner {
           .orElseThrow(() -> new RuntimeException(
               "Cannot find the select field in the available fields."
                   + " field: " + fieldName
-                  + ", schema: " + schema.valueFields()));
+                  + ", schema: " + schema.value()));
     }
   }
 

--- a/ksql-engine/src/main/java/io/confluent/ksql/engine/InsertValuesExecutor.java
+++ b/ksql-engine/src/main/java/io/confluent/ksql/engine/InsertValuesExecutor.java
@@ -220,7 +220,8 @@ public class InsertValuesExecutor {
       final LogicalSchema schema,
       final Map<String, Object> values
   ) {
-    final Struct key = new Struct(schema.keySchema());
+
+    final Struct key = new Struct(schema.keyConnectSchema());
 
     for (final org.apache.kafka.connect.data.Field field : key.schema().fields()) {
       final Object value = values.get(field.name());
@@ -236,7 +237,8 @@ public class InsertValuesExecutor {
   ) {
     return new GenericRow(
         schema
-            .valueFields()
+            .value()
+            .fields()
             .stream()
             .map(Field::name)
             .map(values::get)
@@ -252,8 +254,8 @@ public class InsertValuesExecutor {
     final LogicalSchema schema = dataSource.getSchema();
 
     final List<String> fieldNames = Streams.concat(
-        schema.keyFields().stream(),
-        schema.valueFields().stream())
+        schema.key().fields().stream(),
+        schema.value().fields().stream())
         .map(Field::name)
         .collect(Collectors.toList());
 

--- a/ksql-engine/src/main/java/io/confluent/ksql/planner/LogicalPlanner.java
+++ b/ksql-engine/src/main/java/io/confluent/ksql/planner/LogicalPlanner.java
@@ -293,8 +293,8 @@ public class LogicalPlanner {
     final Builder builder = LogicalSchema.builder();
 
     final List<Field> keyFields = sourcePlanNode.getSchema().isAliased()
-        ? sourcePlanNode.getSchema().withoutAlias().keyFields()
-        : sourcePlanNode.getSchema().keyFields();
+        ? sourcePlanNode.getSchema().withoutAlias().key().fields()
+        : sourcePlanNode.getSchema().key().fields();
 
     builder.keyFields(keyFields);
 

--- a/ksql-engine/src/main/java/io/confluent/ksql/planner/plan/AggregateNode.java
+++ b/ksql-engine/src/main/java/io/confluent/ksql/planner/plan/AggregateNode.java
@@ -162,17 +162,17 @@ public class AggregateNode extends PlanNode {
 
   private List<SelectExpression> getFinalSelectExpressions() {
     final List<SelectExpression> finalSelectExpressionList = new ArrayList<>();
-    if (finalSelectExpressions.size() != schema.valueFields().size()) {
+    if (finalSelectExpressions.size() != schema.value().fields().size()) {
       throw new RuntimeException(
           "Incompatible aggregate schema, field count must match, "
               + "selected field count:"
               + finalSelectExpressions.size()
               + " schema field count:"
-              + schema.valueFields().size());
+              + schema.value().fields().size());
     }
     for (int i = 0; i < finalSelectExpressions.size(); i++) {
       finalSelectExpressionList.add(SelectExpression.of(
-          schema.valueFields().get(i).name(),
+          schema.value().fields().get(i).name(),
           finalSelectExpressions.get(i)
       ));
     }
@@ -335,9 +335,9 @@ public class AggregateNode extends PlanNode {
       final Map<Integer, KsqlAggregateFunction> aggregateFunctions
   ) {
     final LogicalSchema.Builder schemaBuilder = LogicalSchema.builder();
-    final List<Field> fields = inputSchema.valueFields();
+    final List<Field> fields = inputSchema.value().fields();
 
-    schemaBuilder.keyFields(inputSchema.keyFields());
+    schemaBuilder.keyFields(inputSchema.key().fields());
 
     for (int i = 0; i < requiredColumns.size(); i++) {
       schemaBuilder.valueField(fields.get(i));

--- a/ksql-engine/src/main/java/io/confluent/ksql/planner/plan/JoinNode.java
+++ b/ksql-engine/src/main/java/io/confluent/ksql/planner/plan/JoinNode.java
@@ -521,9 +521,9 @@ public class JoinNode extends PlanNode {
 
     final LogicalSchema.Builder joinSchema = LogicalSchema.builder();
 
-    joinSchema.valueFields(leftSchema.valueFields());
+    joinSchema.valueFields(leftSchema.value().fields());
 
-    joinSchema.valueFields(rightSchema.valueFields());
+    joinSchema.valueFields(rightSchema.value().fields());
 
     // Hard-wire for now, until we support custom type/name of key fields:
     joinSchema.keyField(SchemaUtil.ROWKEY_NAME, SqlTypes.STRING);

--- a/ksql-engine/src/main/java/io/confluent/ksql/planner/plan/KsqlStructuredDataOutputNode.java
+++ b/ksql-engine/src/main/java/io/confluent/ksql/planner/plan/KsqlStructuredDataOutputNode.java
@@ -193,11 +193,11 @@ public class KsqlStructuredDataOutputNode extends OutputNode {
 
   @SuppressWarnings("UnstableApiUsage")
   private static Set<Integer> implicitAndKeyColumnIndexesInValueSchema(final LogicalSchema schema) {
-    final ConnectSchema valueSchema = schema.valueSchema();
+    final ConnectSchema valueSchema = schema.valueConnectSchema();
 
     final Stream<Field> fields = Streams.concat(
-        schema.metaFields().stream(),
-        schema.keyFields().stream()
+        schema.metadata().fields().stream(),
+        schema.key().fields().stream()
     );
 
     return fields

--- a/ksql-engine/src/main/java/io/confluent/ksql/planner/plan/ProjectNode.java
+++ b/ksql-engine/src/main/java/io/confluent/ksql/planner/plan/ProjectNode.java
@@ -56,7 +56,7 @@ public class ProjectNode extends PlanNode {
         source.getKeyField().legacy())
         .validateKeyExistsIn(schema);
 
-    if (schema.valueFields().size() != projectExpressions.size()) {
+    if (schema.value().fields().size() != projectExpressions.size()) {
       throw new KsqlException("Error in projection. Schema fields and expression list are not "
           + "compatible.");
     }
@@ -90,7 +90,7 @@ public class ProjectNode extends PlanNode {
     final List<SelectExpression> selects = new ArrayList<>();
     for (int i = 0; i < projectExpressions.size(); i++) {
       final SelectExpression selectExp = SelectExpression
-          .of(schema.valueFields().get(i).name(), projectExpressions.get(i));
+          .of(schema.value().fields().get(i).name(), projectExpressions.get(i));
 
       selects.add(selectExp);
     }

--- a/ksql-engine/src/main/java/io/confluent/ksql/serde/SerdeOptions.java
+++ b/ksql-engine/src/main/java/io/confluent/ksql/serde/SerdeOptions.java
@@ -63,7 +63,7 @@ public final class SerdeOptions {
       final Optional<Boolean> wrapSingleValues,
       final KsqlConfig ksqlConfig
   ) {
-    final boolean singleField = schema.valueSchema().fields().size() == 1;
+    final boolean singleField = schema.valueConnectSchema().fields().size() == 1;
     final Set<SerdeOption> singleFieldDefaults = buildDefaults(ksqlConfig);
     return build(singleField, valueFormat, wrapSingleValues, singleFieldDefaults);
   }

--- a/ksql-engine/src/main/java/io/confluent/ksql/structured/SchemaKGroupedStream.java
+++ b/ksql-engine/src/main/java/io/confluent/ksql/structured/SchemaKGroupedStream.java
@@ -257,7 +257,7 @@ public class SchemaKGroupedStream {
     final int nonAggColumnCount = aggValToFunctionMap.size();
     final int totalColumnCount = nonAggColumnCount + nonFuncColumnCount;
 
-    final int valueColumnCount = aggregateSchema.valueFields().size();
+    final int valueColumnCount = aggregateSchema.value().fields().size();
     if (valueColumnCount != totalColumnCount) {
       throw new IllegalArgumentException(
           "Aggregate schema value field count does not match expected."

--- a/ksql-engine/src/main/java/io/confluent/ksql/structured/SchemaKStream.java
+++ b/ksql-engine/src/main/java/io/confluent/ksql/structured/SchemaKStream.java
@@ -495,8 +495,8 @@ public class SchemaKStream<K> {
       final LogicalSchema.Builder schemaBuilder = LogicalSchema.builder();
 
       final List<Field> keyFields = SchemaKStream.this.getSchema().isAliased()
-          ? SchemaKStream.this.getSchema().withoutAlias().keyFields()
-          : SchemaKStream.this.getSchema().keyFields();
+          ? SchemaKStream.this.getSchema().withoutAlias().key().fields()
+          : SchemaKStream.this.getSchema().key().fields();
 
       schemaBuilder.keyFields(keyFields);
 
@@ -827,7 +827,7 @@ public class SchemaKStream<K> {
   }
 
   private Object extractColumn(final int keyIndexInValue, final GenericRow value) {
-    if (value.getColumns().size() != getSchema().valueFields().size()) {
+    if (value.getColumns().size() != getSchema().value().fields().size()) {
       throw new IllegalStateException("Field count mismatch. "
           + "Schema fields: " + getSchema()
           + ", row:" + value);
@@ -1040,13 +1040,13 @@ public class SchemaKStream<K> {
       if (left != null) {
         columns.addAll(left.getColumns());
       } else {
-        fillWithNulls(columns, leftSchema.valueFields().size());
+        fillWithNulls(columns, leftSchema.value().fields().size());
       }
 
       if (right != null) {
         columns.addAll(right.getColumns());
       } else {
-        fillWithNulls(columns, rightSchema.valueFields().size());
+        fillWithNulls(columns, rightSchema.value().fields().size());
       }
 
       return new GenericRow(columns);

--- a/ksql-engine/src/main/java/io/confluent/ksql/util/GenericRowValueTypeEnforcer.java
+++ b/ksql-engine/src/main/java/io/confluent/ksql/util/GenericRowValueTypeEnforcer.java
@@ -43,7 +43,7 @@ public class GenericRowValueTypeEnforcer {
           .build();
 
   public GenericRowValueTypeEnforcer(final LogicalSchema schema) {
-    this.fields = schema.valueFields();
+    this.fields = schema.value().fields();
   }
 
   public Object enforceFieldType(final int index, final Object value) {

--- a/ksql-engine/src/test/java/io/confluent/ksql/analyzer/AnalyzerTest.java
+++ b/ksql-engine/src/test/java/io/confluent/ksql/analyzer/AnalyzerTest.java
@@ -32,6 +32,7 @@ import com.google.common.collect.Iterables;
 import io.confluent.ksql.analyzer.Analysis.Into;
 import io.confluent.ksql.analyzer.Analysis.JoinInfo;
 import io.confluent.ksql.analyzer.Analyzer.SerdeOptionsSupplier;
+import io.confluent.ksql.execution.ddl.commands.KsqlTopic;
 import io.confluent.ksql.execution.expression.tree.BooleanLiteral;
 import io.confluent.ksql.execution.expression.tree.Literal;
 import io.confluent.ksql.execution.expression.tree.StringLiteral;
@@ -40,7 +41,6 @@ import io.confluent.ksql.metastore.MetaStore;
 import io.confluent.ksql.metastore.MutableMetaStore;
 import io.confluent.ksql.metastore.model.KeyField;
 import io.confluent.ksql.metastore.model.KsqlStream;
-import io.confluent.ksql.execution.ddl.commands.KsqlTopic;
 import io.confluent.ksql.parser.ExpressionFormatterUtil;
 import io.confluent.ksql.parser.KsqlParser.PreparedStatement;
 import io.confluent.ksql.parser.KsqlParserTestUtil;
@@ -66,8 +66,6 @@ import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
 import java.util.stream.Collectors;
-import org.apache.kafka.connect.data.Schema;
-import org.apache.kafka.connect.data.SchemaBuilder;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Rule;
@@ -518,8 +516,8 @@ public class AnalyzerTest {
   }
 
   private void registerKafkaSource() {
-    final Schema schema = SchemaBuilder.struct()
-        .field("COL0", Schema.OPTIONAL_INT64_SCHEMA)
+    final LogicalSchema schema = LogicalSchema.builder()
+        .valueField("COL0", SqlTypes.BIGINT)
         .build();
 
     final KsqlTopic topic = new KsqlTopic(
@@ -531,7 +529,7 @@ public class AnalyzerTest {
     final KsqlStream<?> stream = new KsqlStream<>(
         "sqlexpression",
         "KAFKA_SOURCE",
-        LogicalSchema.of(schema),
+        schema,
         SerdeOption.none(),
         KeyField.none(),
         new MetadataTimestampExtractionPolicy(),

--- a/ksql-engine/src/test/java/io/confluent/ksql/analyzer/SourceSchemasTest.java
+++ b/ksql-engine/src/test/java/io/confluent/ksql/analyzer/SourceSchemasTest.java
@@ -23,8 +23,7 @@ import static org.hamcrest.Matchers.is;
 
 import com.google.common.collect.ImmutableMap;
 import io.confluent.ksql.schema.ksql.LogicalSchema;
-import org.apache.kafka.connect.data.Schema;
-import org.apache.kafka.connect.data.SchemaBuilder;
+import io.confluent.ksql.schema.ksql.types.SqlTypes;
 import org.junit.Before;
 import org.junit.Test;
 
@@ -34,17 +33,15 @@ public class SourceSchemasTest {
   private static final String ALIAS_2 = "S2";
   private static final String COMMON_FIELD_NAME = "F0";
 
-  private static final LogicalSchema SCHEMA_1 = LogicalSchema.of(SchemaBuilder.struct()
-      .field(COMMON_FIELD_NAME, Schema.OPTIONAL_STRING_SCHEMA)
-      .field("F1", Schema.OPTIONAL_STRING_SCHEMA)
-      .build()
-  );
+  private static final LogicalSchema SCHEMA_1 = LogicalSchema.builder()
+      .valueField(COMMON_FIELD_NAME, SqlTypes.STRING)
+      .valueField("F1", SqlTypes.STRING)
+      .build();
 
-  private static final LogicalSchema SCHEMA_2 = LogicalSchema.of(SchemaBuilder.struct()
-      .field(COMMON_FIELD_NAME, Schema.OPTIONAL_STRING_SCHEMA)
-      .field("F2", Schema.OPTIONAL_STRING_SCHEMA)
-      .build()
-  );
+  private static final LogicalSchema SCHEMA_2 = LogicalSchema.builder()
+      .valueField(COMMON_FIELD_NAME, SqlTypes.STRING)
+      .valueField("F2", SqlTypes.STRING)
+      .build();
 
   private SourceSchemas sourceSchemas;
 

--- a/ksql-engine/src/test/java/io/confluent/ksql/codegen/CodeGenRunnerTest.java
+++ b/ksql-engine/src/test/java/io/confluent/ksql/codegen/CodeGenRunnerTest.java
@@ -33,6 +33,8 @@ import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import io.confluent.ksql.GenericRow;
 import io.confluent.ksql.analyzer.Analysis;
+import io.confluent.ksql.execution.ddl.commands.KsqlTopic;
+import io.confluent.ksql.execution.expression.tree.Expression;
 import io.confluent.ksql.function.InternalFunctionRegistry;
 import io.confluent.ksql.function.KsqlFunction;
 import io.confluent.ksql.function.MutableFunctionRegistry;
@@ -41,8 +43,6 @@ import io.confluent.ksql.function.udf.Kudf;
 import io.confluent.ksql.metastore.MutableMetaStore;
 import io.confluent.ksql.metastore.model.KeyField;
 import io.confluent.ksql.metastore.model.KsqlStream;
-import io.confluent.ksql.execution.ddl.commands.KsqlTopic;
-import io.confluent.ksql.execution.expression.tree.Expression;
 import io.confluent.ksql.schema.ksql.LogicalSchema;
 import io.confluent.ksql.schema.ksql.SchemaConverters;
 import io.confluent.ksql.schema.ksql.types.SqlTypes;
@@ -173,8 +173,7 @@ public class CodeGenRunnerTest {
 
         metaStore.putSource(ksqlStream);
 
-        final LogicalSchema schema = LogicalSchema.of(META_STORE_SCHEMA.valueSchema())
-            .withAlias("CODEGEN_TEST");
+        final LogicalSchema schema = META_STORE_SCHEMA.withAlias("CODEGEN_TEST");
 
         codeGenRunner = new CodeGenRunner(schema, ksqlConfig, functionRegistry);
     }

--- a/ksql-engine/src/test/java/io/confluent/ksql/ddl/commands/CommandFactoriesTest.java
+++ b/ksql-engine/src/test/java/io/confluent/ksql/ddl/commands/CommandFactoriesTest.java
@@ -89,8 +89,6 @@ import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
 import org.apache.kafka.common.serialization.Serde;
-import org.apache.kafka.connect.data.Schema;
-import org.apache.kafka.connect.data.SchemaBuilder;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
@@ -574,10 +572,9 @@ public class CommandFactoriesTest {
     // Given:
     givenCommandFactoriesWithMocks();
     final CreateStream statement = new CreateStream(SOME_NAME, ONE_ELEMENT, true, withProperties);
-    final LogicalSchema schema = LogicalSchema.of(SchemaBuilder
-        .struct()
-        .field("bob", Schema.OPTIONAL_STRING_SCHEMA)
-        .build());
+    final LogicalSchema schema = LogicalSchema.builder()
+        .valueField("bob", SqlTypes.STRING)
+        .build();
     when(serdeOptionsSupplier.build(any(), any(), any(), any())).thenReturn(SOME_SERDE_OPTIONS);
 
     // When:
@@ -612,17 +609,12 @@ public class CommandFactoriesTest {
     );
 
     // Then:
-    assertThat(result.getSchema(), is(LogicalSchema.of(
-        SchemaBuilder
-            .struct()
-            .field("ROWKEY", Schema.OPTIONAL_STRING_SCHEMA)
-            .build(),
-        SchemaBuilder
-            .struct()
-            .field("bob", Schema.OPTIONAL_STRING_SCHEMA)
-            .field("hojjat", Schema.OPTIONAL_STRING_SCHEMA)
-            .build()
-    )));
+    assertThat(result.getSchema(), is(LogicalSchema.builder()
+        .keyField("ROWKEY", SqlTypes.STRING)
+        .valueField("bob", SqlTypes.STRING)
+        .valueField("hojjat", SqlTypes.STRING)
+        .build()
+    ));
   }
 
   @Test
@@ -648,17 +640,12 @@ public class CommandFactoriesTest {
     );
 
     // Then:
-    assertThat(result.getSchema(), is(LogicalSchema.of(
-        SchemaBuilder
-            .struct()
-            .field("ROWKEY", Schema.OPTIONAL_STRING_SCHEMA)
-            .build(),
-        SchemaBuilder
-            .struct()
-            .field("bob", Schema.OPTIONAL_STRING_SCHEMA)
-            .field("hojjat", Schema.OPTIONAL_STRING_SCHEMA)
-            .build()
-    )));
+    assertThat(result.getSchema(), is(LogicalSchema.builder()
+        .keyField("ROWKEY", SqlTypes.STRING)
+        .valueField("bob", SqlTypes.STRING)
+        .valueField("hojjat", SqlTypes.STRING)
+        .build()
+    ));
   }
 
   @Test
@@ -666,11 +653,10 @@ public class CommandFactoriesTest {
     // Given:
     givenCommandFactoriesWithMocks();
     final CreateStream statement = new CreateStream(SOME_NAME, TWO_ELEMENTS, true, withProperties);
-    final LogicalSchema schema = LogicalSchema.of(SchemaBuilder
-        .struct()
-        .field("bob", Schema.OPTIONAL_STRING_SCHEMA)
-        .field("hojjat", Schema.OPTIONAL_STRING_SCHEMA)
-        .build());
+    final LogicalSchema schema = LogicalSchema.builder()
+        .valueField("bob", SqlTypes.STRING)
+        .valueField("hojjat", SqlTypes.STRING)
+        .build();
 
     // When:
     commandFactories.create("expression", statement, ksqlConfig, emptyMap());
@@ -678,7 +664,7 @@ public class CommandFactoriesTest {
     // Then:
     verify(serdeFactory).create(
         FormatInfo.of(JSON, Optional.empty()),
-        PersistenceSchema.from(schema.valueSchema(), false),
+        PersistenceSchema.from(schema.valueConnectSchema(), false),
         ksqlConfig,
         serviceContext.getSchemaRegistryClientFactory(),
         "",

--- a/ksql-engine/src/test/java/io/confluent/ksql/integration/JsonFormatTest.java
+++ b/ksql-engine/src/test/java/io/confluent/ksql/integration/JsonFormatTest.java
@@ -31,6 +31,7 @@ import io.confluent.ksql.metastore.model.DataSource;
 import io.confluent.ksql.query.QueryId;
 import io.confluent.ksql.schema.ksql.LogicalSchema;
 import io.confluent.ksql.schema.ksql.PhysicalSchema;
+import io.confluent.ksql.schema.ksql.types.SqlTypes;
 import io.confluent.ksql.serde.SerdeOption;
 import io.confluent.ksql.services.KafkaTopicClient;
 import io.confluent.ksql.services.ServiceContext;
@@ -50,8 +51,6 @@ import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
 import kafka.zookeeper.ZooKeeperClientException;
 import org.apache.kafka.common.serialization.StringDeserializer;
-import org.apache.kafka.connect.data.Schema;
-import org.apache.kafka.connect.data.SchemaBuilder;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.ClassRule;
@@ -120,7 +119,9 @@ public class JsonFormatTest {
     topicProducer
             .produceInputData(inputTopic, orderDataProvider.data(), orderDataProvider.schema());
 
-    final Schema messageSchema = SchemaBuilder.struct().field("MESSAGE", SchemaBuilder.OPTIONAL_STRING_SCHEMA).build();
+    final LogicalSchema messageSchema = LogicalSchema.builder()
+        .valueField("MESSAGE", SqlTypes.STRING)
+        .build();
 
     final GenericRow messageRow = new GenericRow(Collections.singletonList(
         "{\"log\":{\"@timestamp\":\"2017-05-30T16:44:22.175Z\",\"@version\":\"1\","
@@ -130,7 +131,7 @@ public class JsonFormatTest {
     records.put("1", messageRow);
 
     final PhysicalSchema schema = PhysicalSchema.from(
-        LogicalSchema.of(messageSchema),
+        messageSchema,
         SerdeOption.none()
     );
 

--- a/ksql-engine/src/test/java/io/confluent/ksql/physical/PhysicalPlanBuilderTest.java
+++ b/ksql-engine/src/test/java/io/confluent/ksql/physical/PhysicalPlanBuilderTest.java
@@ -55,6 +55,7 @@ import io.confluent.ksql.planner.plan.OutputNode;
 import io.confluent.ksql.planner.plan.PlanTestUtil;
 import io.confluent.ksql.query.QueryId;
 import io.confluent.ksql.schema.ksql.LogicalSchema;
+import io.confluent.ksql.schema.ksql.types.SqlTypes;
 import io.confluent.ksql.serde.Format;
 import io.confluent.ksql.serde.SerdeOption;
 import io.confluent.ksql.services.FakeKafkaTopicClient;
@@ -87,8 +88,6 @@ import org.apache.kafka.clients.producer.ProducerConfig;
 import org.apache.kafka.clients.producer.ProducerInterceptor;
 import org.apache.kafka.clients.producer.ProducerRecord;
 import org.apache.kafka.clients.producer.RecordMetadata;
-import org.apache.kafka.connect.data.Schema;
-import org.apache.kafka.connect.data.SchemaBuilder;
 import org.apache.kafka.streams.KafkaStreams;
 import org.apache.kafka.streams.StreamsBuilder;
 import org.apache.kafka.streams.StreamsConfig;
@@ -255,13 +254,12 @@ public class PhysicalPlanBuilderTest {
     final QueryMetadata queryMetadata = buildPhysicalPlan(simpleSelectFilter);
 
     // Then:
-    assertThat(queryMetadata.getLogicalSchema(), is(LogicalSchema.of(
-        SchemaBuilder.struct()
-            .field("COL0", Schema.OPTIONAL_INT64_SCHEMA)
-            .field("COL2", Schema.OPTIONAL_STRING_SCHEMA)
-            .field("COL3", Schema.OPTIONAL_FLOAT64_SCHEMA)
-            .build()
-    )));
+    assertThat(queryMetadata.getLogicalSchema(), is(LogicalSchema.builder()
+        .valueField("COL0", SqlTypes.BIGINT)
+        .valueField("COL2", SqlTypes.STRING)
+        .valueField("COL3", SqlTypes.DOUBLE)
+        .build()
+    ));
   }
 
   @Test
@@ -271,13 +269,13 @@ public class PhysicalPlanBuilderTest {
         "CREATE STREAM FOO AS " + simpleSelectFilter);
 
     // Then:
-    assertThat(queryMetadata.getLogicalSchema(), is(LogicalSchema.of(
-        SchemaBuilder.struct()
-            .field("COL0", Schema.OPTIONAL_INT64_SCHEMA)
-            .field("COL2", Schema.OPTIONAL_STRING_SCHEMA)
-            .field("COL3", Schema.OPTIONAL_FLOAT64_SCHEMA)
-            .build()
-    )));
+    assertThat(queryMetadata.getLogicalSchema(), is(LogicalSchema.builder()
+
+        .valueField("COL0", SqlTypes.BIGINT)
+        .valueField("COL2", SqlTypes.STRING)
+        .valueField("COL3", SqlTypes.DOUBLE)
+        .build()
+    ));
   }
 
   @Test

--- a/ksql-engine/src/test/java/io/confluent/ksql/planner/LogicalPlannerTest.java
+++ b/ksql-engine/src/test/java/io/confluent/ksql/planner/LogicalPlannerTest.java
@@ -22,7 +22,6 @@ import static org.hamcrest.CoreMatchers.instanceOf;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
 
-import io.confluent.ksql.function.InternalFunctionRegistry;
 import io.confluent.ksql.function.TestFunctionRegistry;
 import io.confluent.ksql.metastore.MetaStore;
 import io.confluent.ksql.metastore.model.DataSource;
@@ -37,7 +36,6 @@ import io.confluent.ksql.schema.ksql.types.SqlTypes;
 import io.confluent.ksql.testutils.AnalysisTestUtil;
 import io.confluent.ksql.util.KsqlConfig;
 import io.confluent.ksql.util.MetaStoreFixture;
-
 import java.util.Collections;
 import java.util.Optional;
 import org.junit.Assert;
@@ -81,7 +79,7 @@ public class LogicalPlannerTest {
     assertThat(logicalPlan.getSources().get(0).getSources().get(0).getSources().get(0),
         instanceOf(DataSourceNode.class));
 
-    assertThat(logicalPlan.getSchema().valueFields().size(), equalTo( 3));
+    assertThat(logicalPlan.getSchema().value().fields().size(), equalTo( 3));
     Assert.assertNotNull(((FilterNode) logicalPlan.getSources().get(0).getSources().get(0)).getPredicate());
   }
 
@@ -97,7 +95,7 @@ public class LogicalPlannerTest {
     assertThat(logicalPlan.getSources().get(0).getSources().get(0).getSources()
                           .get(1), instanceOf(DataSourceNode.class));
 
-    assertThat(logicalPlan.getSchema().valueFields().size(), equalTo(4));
+    assertThat(logicalPlan.getSchema().value().fields().size(), equalTo(4));
 
   }
 
@@ -114,7 +112,7 @@ public class LogicalPlannerTest {
 
     assertThat(projectNode.getKeyField().name(), is(Optional.of("T1_COL1")));
     assertThat(projectNode.getKeyField().legacy(), OptionalMatchers.of(hasName("T1.COL1")));
-    assertThat(projectNode.getSchema().valueFields().size(), equalTo(5));
+    assertThat(projectNode.getSchema().value().fields().size(), equalTo(5));
 
     assertThat(projectNode.getSources().get(0), instanceOf(FilterNode.class));
     final FilterNode filterNode = (FilterNode) projectNode.getSources().get(0);
@@ -142,9 +140,9 @@ public class LogicalPlannerTest {
     assertThat(aggregateNode.getGroupByExpressions().size(), equalTo(1));
     assertThat(aggregateNode.getGroupByExpressions().get(0).toString(), equalTo("TEST1.COL0"));
     assertThat(aggregateNode.getRequiredColumns().size(), equalTo(2));
-    assertThat(aggregateNode.getSchema().valueFields().get(1).type(), equalTo(SqlTypes.DOUBLE));
-    assertThat(aggregateNode.getSchema().valueFields().get(2).type(), equalTo(SqlTypes.BIGINT));
-    assertThat(logicalPlan.getSources().get(0).getSchema().valueFields().size(), equalTo(3));
+    assertThat(aggregateNode.getSchema().value().fields().get(1).type(), equalTo(SqlTypes.DOUBLE));
+    assertThat(aggregateNode.getSchema().value().fields().get(2).type(), equalTo(SqlTypes.BIGINT));
+    assertThat(logicalPlan.getSources().get(0).getSchema().value().fields().size(), equalTo(3));
 
   }
 
@@ -164,8 +162,8 @@ public class LogicalPlannerTest {
     assertThat(aggregateNode.getGroupByExpressions().size(), equalTo(1));
     assertThat(aggregateNode.getGroupByExpressions().get(0).toString(), equalTo("TEST1.COL0"));
     assertThat(aggregateNode.getRequiredColumns().size(), equalTo(2));
-    assertThat(aggregateNode.getSchema().valueFields().get(1).type(), equalTo(SqlTypes.DOUBLE));
-    assertThat(logicalPlan.getSources().get(0).getSchema().valueFields().size(), equalTo(2));
+    assertThat(aggregateNode.getSchema().value().fields().get(1).type(), equalTo(SqlTypes.DOUBLE));
+    assertThat(logicalPlan.getSources().get(0).getSchema().value().fields().size(), equalTo(2));
 
   }
 

--- a/ksql-engine/src/test/java/io/confluent/ksql/planner/plan/AggregateNodeTest.java
+++ b/ksql-engine/src/test/java/io/confluent/ksql/planner/plan/AggregateNodeTest.java
@@ -301,7 +301,7 @@ public class AggregateNodeTest {
         + "WHERE col0 > 100 GROUP BY col0;");
 
     // Then:
-    assertThat(stream.getSchema().valueFields(), contains(
+    assertThat(stream.getSchema().value().fields(), contains(
         Field.of("COL0", SqlTypes.BIGINT),
         Field.of("KSQL_COL_1", SqlTypes.DOUBLE),
         Field.of("KSQL_COL_2", SqlTypes.BIGINT)));

--- a/ksql-engine/src/test/java/io/confluent/ksql/planner/plan/DataSourceNodeTest.java
+++ b/ksql-engine/src/test/java/io/confluent/ksql/planner/plan/DataSourceNodeTest.java
@@ -39,17 +39,18 @@ import io.confluent.ksql.GenericRow;
 import io.confluent.ksql.execution.builder.KsqlQueryBuilder;
 import io.confluent.ksql.execution.context.QueryContext;
 import io.confluent.ksql.execution.context.QueryLoggerUtil;
+import io.confluent.ksql.execution.ddl.commands.KsqlTopic;
 import io.confluent.ksql.execution.plan.StreamSource;
 import io.confluent.ksql.function.FunctionRegistry;
 import io.confluent.ksql.metastore.model.DataSource;
 import io.confluent.ksql.metastore.model.KeyField;
 import io.confluent.ksql.metastore.model.KsqlStream;
 import io.confluent.ksql.metastore.model.KsqlTable;
-import io.confluent.ksql.execution.ddl.commands.KsqlTopic;
 import io.confluent.ksql.model.WindowType;
 import io.confluent.ksql.query.QueryId;
 import io.confluent.ksql.schema.ksql.LogicalSchema;
 import io.confluent.ksql.schema.ksql.PhysicalSchema;
+import io.confluent.ksql.schema.ksql.types.SqlTypes;
 import io.confluent.ksql.serde.Format;
 import io.confluent.ksql.serde.FormatInfo;
 import io.confluent.ksql.serde.KeyFormat;
@@ -74,8 +75,6 @@ import java.util.stream.Collectors;
 import org.apache.kafka.common.serialization.Deserializer;
 import org.apache.kafka.common.serialization.Serde;
 import org.apache.kafka.common.serialization.Serializer;
-import org.apache.kafka.connect.data.Schema;
-import org.apache.kafka.connect.data.SchemaBuilder;
 import org.apache.kafka.streams.StreamsBuilder;
 import org.apache.kafka.streams.Topology;
 import org.apache.kafka.streams.Topology.AutoOffsetReset;
@@ -105,13 +104,13 @@ public class DataSourceNodeTest {
   private final KsqlConfig realConfig = new KsqlConfig(Collections.emptyMap());
   private SchemaKStream realStream;
   private StreamsBuilder realBuilder;
-  private static final LogicalSchema REAL_SCHEMA = LogicalSchema.of(SchemaBuilder.struct()
-      .field("field1", Schema.OPTIONAL_STRING_SCHEMA)
-      .field("field2", Schema.OPTIONAL_STRING_SCHEMA)
-      .field("field3", Schema.OPTIONAL_STRING_SCHEMA)
-      .field(TIMESTAMP_FIELD, Schema.OPTIONAL_INT64_SCHEMA)
-      .field("key", Schema.OPTIONAL_STRING_SCHEMA)
-      .build());
+  private static final LogicalSchema REAL_SCHEMA = LogicalSchema.builder()
+      .valueField("field1", SqlTypes.STRING)
+      .valueField("field2", SqlTypes.STRING)
+      .valueField("field3", SqlTypes.STRING)
+      .valueField(TIMESTAMP_FIELD, SqlTypes.BIGINT)
+      .valueField("key", SqlTypes.STRING)
+      .build();
   private static final KeyField KEY_FIELD
       = KeyField.of("field1", REAL_SCHEMA.findValueField("field1").get());
   private static final Optional<AutoOffsetReset> OFFSET_RESET = Optional.of(AutoOffsetReset.LATEST);
@@ -372,15 +371,15 @@ public class DataSourceNodeTest {
 
     // Then:
     assertThat(schema, is(
-        LogicalSchema.of(SchemaBuilder.struct()
-            .field(SchemaUtil.ROWTIME_NAME, Schema.OPTIONAL_INT64_SCHEMA)
-            .field(SchemaUtil.ROWKEY_NAME, Schema.OPTIONAL_STRING_SCHEMA)
-            .field("field1", Schema.OPTIONAL_STRING_SCHEMA)
-            .field("field2", Schema.OPTIONAL_STRING_SCHEMA)
-            .field("field3", Schema.OPTIONAL_STRING_SCHEMA)
-            .field(TIMESTAMP_FIELD, Schema.OPTIONAL_INT64_SCHEMA)
-            .field("key", Schema.OPTIONAL_STRING_SCHEMA)
-            .build()).withAlias(sourceName)));
+        LogicalSchema.builder()
+            .valueField(SchemaUtil.ROWTIME_NAME, SqlTypes.BIGINT)
+            .valueField(SchemaUtil.ROWKEY_NAME, SqlTypes.STRING)
+            .valueField("field1", SqlTypes.STRING)
+            .valueField("field2", SqlTypes.STRING)
+            .valueField("field3", SqlTypes.STRING)
+            .valueField(TIMESTAMP_FIELD, SqlTypes.BIGINT)
+            .valueField("key", SqlTypes.STRING)
+            .build().withAlias(sourceName)));
   }
 
   @Test

--- a/ksql-engine/src/test/java/io/confluent/ksql/planner/plan/KsqlBareOutputNodeTest.java
+++ b/ksql-engine/src/test/java/io/confluent/ksql/planner/plan/KsqlBareOutputNodeTest.java
@@ -129,7 +129,7 @@ public class KsqlBareOutputNodeTest {
   @Test
   public void shouldCreateCorrectSchema() {
     final LogicalSchema schema = stream.getSchema();
-    assertThat(schema.valueFields(), contains(
+    assertThat(schema.value().fields(), contains(
         Field.of("COL0", SqlTypes.BIGINT),
         Field.of("COL2", SqlTypes.STRING),
         Field.of("COL3", SqlTypes.DOUBLE)));

--- a/ksql-engine/src/test/java/io/confluent/ksql/planner/plan/KsqlStructuredDataOutputNodeTest.java
+++ b/ksql-engine/src/test/java/io/confluent/ksql/planner/plan/KsqlStructuredDataOutputNodeTest.java
@@ -33,13 +33,14 @@ import io.confluent.ksql.GenericRow;
 import io.confluent.ksql.execution.builder.KsqlQueryBuilder;
 import io.confluent.ksql.execution.context.QueryContext;
 import io.confluent.ksql.execution.context.QueryLoggerUtil;
+import io.confluent.ksql.execution.ddl.commands.KsqlTopic;
 import io.confluent.ksql.function.FunctionRegistry;
 import io.confluent.ksql.metastore.model.DataSource.DataSourceType;
 import io.confluent.ksql.metastore.model.KeyField;
-import io.confluent.ksql.execution.ddl.commands.KsqlTopic;
 import io.confluent.ksql.query.QueryId;
 import io.confluent.ksql.schema.ksql.LogicalSchema;
 import io.confluent.ksql.schema.ksql.PhysicalSchema;
+import io.confluent.ksql.schema.ksql.types.SqlTypes;
 import io.confluent.ksql.serde.Format;
 import io.confluent.ksql.serde.FormatInfo;
 import io.confluent.ksql.serde.SerdeOption;
@@ -52,8 +53,6 @@ import java.util.Optional;
 import java.util.OptionalInt;
 import java.util.Set;
 import org.apache.kafka.common.serialization.Serde;
-import org.apache.kafka.connect.data.Schema;
-import org.apache.kafka.connect.data.SchemaBuilder;
 import org.apache.kafka.streams.kstream.KStream;
 import org.junit.Before;
 import org.junit.Rule;
@@ -76,13 +75,13 @@ public class KsqlStructuredDataOutputNodeTest {
 
   private static final String SINK_KAFKA_TOPIC_NAME = "output_kafka";
 
-  private static final LogicalSchema SCHEMA = LogicalSchema.of(SchemaBuilder.struct()
-      .field("field1", Schema.OPTIONAL_STRING_SCHEMA)
-      .field("field2", Schema.OPTIONAL_STRING_SCHEMA)
-      .field("field3", Schema.OPTIONAL_STRING_SCHEMA)
-      .field("timestamp", Schema.OPTIONAL_INT64_SCHEMA)
-      .field("key", Schema.OPTIONAL_STRING_SCHEMA)
-      .build());
+  private static final LogicalSchema SCHEMA = LogicalSchema.builder()
+      .valueField("field1", SqlTypes.STRING)
+      .valueField("field2", SqlTypes.STRING)
+      .valueField("field3", SqlTypes.STRING)
+      .valueField("timestamp", SqlTypes.BIGINT)
+      .valueField("key", SqlTypes.STRING)
+      .build();
 
   private static final KeyField KEY_FIELD =
       KeyField.of("key", SCHEMA.findValueField("key").get());
@@ -404,15 +403,15 @@ public class KsqlStructuredDataOutputNodeTest {
   @Test
   public void shouldCallIntoWithIndexesToRemoveImplicitsAndRowKeyRegardlessOfLocation() {
     // Given:
-    final LogicalSchema schema = LogicalSchema.of(SchemaBuilder.struct()
-        .field("field1", Schema.OPTIONAL_STRING_SCHEMA)
-        .field("field2", Schema.OPTIONAL_STRING_SCHEMA)
-        .field("ROWKEY", Schema.OPTIONAL_STRING_SCHEMA)
-        .field("field3", Schema.OPTIONAL_STRING_SCHEMA)
-        .field("timestamp", Schema.OPTIONAL_INT64_SCHEMA)
-        .field("ROWTIME", Schema.OPTIONAL_INT64_SCHEMA)
-        .field("key", Schema.OPTIONAL_STRING_SCHEMA)
-        .build());
+    final LogicalSchema schema = LogicalSchema.builder()
+        .valueField("field1", SqlTypes.STRING)
+        .valueField("field2", SqlTypes.STRING)
+        .valueField("ROWKEY", SqlTypes.STRING)
+        .valueField("field3", SqlTypes.STRING)
+        .valueField("timestamp", SqlTypes.BIGINT)
+        .valueField("ROWTIME", SqlTypes.BIGINT)
+        .valueField("key", SqlTypes.STRING)
+        .build();
 
     givenNodeWithSchema(schema);
 

--- a/ksql-engine/src/test/java/io/confluent/ksql/planner/plan/ProjectNodeTest.java
+++ b/ksql-engine/src/test/java/io/confluent/ksql/planner/plan/ProjectNodeTest.java
@@ -40,8 +40,6 @@ import io.confluent.ksql.structured.SchemaKStream;
 import io.confluent.ksql.util.KsqlException;
 import java.util.Arrays;
 import java.util.Optional;
-import org.apache.kafka.connect.data.Schema;
-import org.apache.kafka.connect.data.SchemaBuilder;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -55,10 +53,10 @@ public class ProjectNodeTest {
   private static final BooleanLiteral TRUE_EXPRESSION = new BooleanLiteral("true");
   private static final BooleanLiteral FALSE_EXPRESSION = new BooleanLiteral("false");
   private static final String KEY_FIELD_NAME = "field1";
-  private static final LogicalSchema SCHEMA = LogicalSchema.of(SchemaBuilder.struct()
-      .field("field1", Schema.OPTIONAL_STRING_SCHEMA)
-      .field("field2", Schema.OPTIONAL_STRING_SCHEMA)
-      .build());
+  private static final LogicalSchema SCHEMA = LogicalSchema.builder()
+      .valueField("field1", SqlTypes.STRING)
+      .valueField("field2", SqlTypes.STRING)
+      .build();
   private static final KeyField SOURCE_KEY_FIELD = KeyField
       .of("source-key", Field.of("legacy-source-key", SqlTypes.STRING));
 

--- a/ksql-engine/src/test/java/io/confluent/ksql/security/KsqlAuthorizationValidatorImplTest.java
+++ b/ksql-engine/src/test/java/io/confluent/ksql/security/KsqlAuthorizationValidatorImplTest.java
@@ -21,14 +21,15 @@ import io.confluent.ksql.engine.KsqlEngine;
 import io.confluent.ksql.engine.KsqlEngineTestUtil;
 import io.confluent.ksql.exception.KafkaResponseGetFailedException;
 import io.confluent.ksql.exception.KsqlTopicAuthorizationException;
+import io.confluent.ksql.execution.ddl.commands.KsqlTopic;
 import io.confluent.ksql.function.InternalFunctionRegistry;
 import io.confluent.ksql.metastore.MetaStoreImpl;
 import io.confluent.ksql.metastore.MutableMetaStore;
 import io.confluent.ksql.metastore.model.KeyField;
 import io.confluent.ksql.metastore.model.KsqlStream;
-import io.confluent.ksql.execution.ddl.commands.KsqlTopic;
 import io.confluent.ksql.parser.tree.Statement;
 import io.confluent.ksql.schema.ksql.LogicalSchema;
+import io.confluent.ksql.schema.ksql.types.SqlTypes;
 import io.confluent.ksql.serde.Format;
 import io.confluent.ksql.serde.FormatInfo;
 import io.confluent.ksql.serde.KeyFormat;
@@ -41,8 +42,6 @@ import java.util.Collections;
 import java.util.Set;
 import org.apache.kafka.clients.admin.TopicDescription;
 import org.apache.kafka.common.acl.AclOperation;
-import org.apache.kafka.connect.data.Schema;
-import org.apache.kafka.connect.data.SchemaBuilder;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Rule;
@@ -55,10 +54,9 @@ import org.mockito.junit.MockitoJUnitRunner;
 @RunWith(MockitoJUnitRunner.class)
 public class KsqlAuthorizationValidatorImplTest {
 
-  private static final LogicalSchema SCHEMA = LogicalSchema.of(SchemaBuilder
-      .struct()
-      .field("F1", Schema.OPTIONAL_STRING_SCHEMA)
-      .build());
+  private static final LogicalSchema SCHEMA = LogicalSchema.builder()
+      .valueField("F1", SqlTypes.STRING)
+      .build();
 
   private static final String STREAM_TOPIC_1 = "s1";
   private static final String STREAM_TOPIC_2 = "s2";

--- a/ksql-engine/src/test/java/io/confluent/ksql/serde/SerdeOptionsTest.java
+++ b/ksql-engine/src/test/java/io/confluent/ksql/serde/SerdeOptionsTest.java
@@ -22,14 +22,13 @@ import static org.hamcrest.Matchers.not;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import io.confluent.ksql.schema.ksql.LogicalSchema;
+import io.confluent.ksql.schema.ksql.types.SqlTypes;
 import io.confluent.ksql.util.KsqlConfig;
 import io.confluent.ksql.util.KsqlException;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Optional;
 import java.util.Set;
-import org.apache.kafka.connect.data.Schema;
-import org.apache.kafka.connect.data.SchemaBuilder;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
@@ -40,16 +39,14 @@ import org.mockito.junit.MockitoJUnitRunner;
 @RunWith(MockitoJUnitRunner.class)
 public class SerdeOptionsTest {
 
-  private static final LogicalSchema SINGLE_FIELD_SCHEMA = LogicalSchema.of(SchemaBuilder
-      .struct()
-      .field("f0", Schema.OPTIONAL_INT64_SCHEMA)
-      .build());
+  private static final LogicalSchema SINGLE_FIELD_SCHEMA = LogicalSchema.builder()
+      .valueField("f0", SqlTypes.BIGINT)
+      .build();
 
-  private static final LogicalSchema MULTI_FIELD_SCHEMA = LogicalSchema.of(SchemaBuilder
-      .struct()
-      .field("f0", Schema.OPTIONAL_INT64_SCHEMA)
-      .field("f1", Schema.OPTIONAL_FLOAT64_SCHEMA)
-      .build());
+  private static final LogicalSchema MULTI_FIELD_SCHEMA = LogicalSchema.builder()
+      .valueField("f0", SqlTypes.BIGINT)
+      .valueField("f1", SqlTypes.DOUBLE)
+      .build();
 
   private static final List<String> SINGLE_COLUMN_NAME = ImmutableList.of("bob");
   private static final List<String> MULTI_FIELD_NAMES = ImmutableList.of("bob", "vic");

--- a/ksql-engine/src/test/java/io/confluent/ksql/structured/KsqlValueJoinerTest.java
+++ b/ksql-engine/src/test/java/io/confluent/ksql/structured/KsqlValueJoinerTest.java
@@ -19,9 +19,9 @@ import static org.junit.Assert.assertEquals;
 
 import io.confluent.ksql.GenericRow;
 import io.confluent.ksql.schema.ksql.LogicalSchema;
+import io.confluent.ksql.schema.ksql.types.SqlTypes;
 import java.util.Arrays;
 import java.util.List;
-import org.apache.kafka.connect.data.SchemaBuilder;
 import org.junit.Before;
 import org.junit.Test;
 
@@ -34,12 +34,12 @@ public class KsqlValueJoinerTest {
 
   @Before
   public void setUp() {
-    final SchemaBuilder schemaBuilder = SchemaBuilder.struct()
-        .field("col0", SchemaBuilder.OPTIONAL_INT64_SCHEMA)
-        .field("col1", SchemaBuilder.OPTIONAL_STRING_SCHEMA);
+    leftSchema = LogicalSchema.builder()
+        .valueField("col0", SqlTypes.BIGINT)
+        .valueField("col1", SqlTypes.STRING)
+        .build();
 
-    leftSchema = LogicalSchema.of(schemaBuilder.build());
-    rightSchema = LogicalSchema.of(schemaBuilder.build());
+    rightSchema = leftSchema;
 
     leftRow = new GenericRow(Arrays.asList(12L, "foobar"));
     rightRow = new GenericRow(Arrays.asList(20L, "baz"));

--- a/ksql-engine/src/test/java/io/confluent/ksql/structured/SchemaKGroupedStreamTest.java
+++ b/ksql-engine/src/test/java/io/confluent/ksql/structured/SchemaKGroupedStreamTest.java
@@ -47,6 +47,7 @@ import io.confluent.ksql.parser.tree.WindowExpression;
 import io.confluent.ksql.query.QueryId;
 import io.confluent.ksql.schema.ksql.Field;
 import io.confluent.ksql.schema.ksql.LogicalSchema;
+import io.confluent.ksql.schema.ksql.types.SqlStruct;
 import io.confluent.ksql.serde.Format;
 import io.confluent.ksql.serde.FormatInfo;
 import io.confluent.ksql.serde.KeyFormat;
@@ -159,6 +160,8 @@ public class SchemaKGroupedStreamTest {
         .thenReturn(WindowInfo.of(WindowType.SESSION, Optional.empty()));
 
     when(keySerde.rebind(any(WindowInfo.class))).thenReturn(windowedKeySerde);
+
+    when(aggregateSchema.value()).thenReturn(mock(SqlStruct.class));
   }
 
   @Test
@@ -454,7 +457,7 @@ public class SchemaKGroupedStreamTest {
   public void shouldBuildStepForAggregate() {
     // Given:
     final Map<Integer, KsqlAggregateFunction> functions = ImmutableMap.of(1,  otherFunc);
-    when(aggregateSchema.valueFields())
+    when(aggregateSchema.value().fields())
         .thenReturn(ImmutableList.of(mock(Field.class), mock(Field.class)));
 
     // When:
@@ -550,6 +553,6 @@ public class SchemaKGroupedStreamTest {
         .mapToObj(i -> field)
         .collect(Collectors.toList());
 
-    when(aggregateSchema.valueFields()).thenReturn(valueFields);
+    when(aggregateSchema.value().fields()).thenReturn(valueFields);
   }
 }

--- a/ksql-engine/src/test/java/io/confluent/ksql/topic/SourceTopicsExtractorTest.java
+++ b/ksql-engine/src/test/java/io/confluent/ksql/topic/SourceTopicsExtractorTest.java
@@ -22,14 +22,15 @@ import static org.mockito.Mockito.when;
 
 import io.confluent.ksql.engine.KsqlEngine;
 import io.confluent.ksql.engine.KsqlEngineTestUtil;
+import io.confluent.ksql.execution.ddl.commands.KsqlTopic;
 import io.confluent.ksql.function.InternalFunctionRegistry;
 import io.confluent.ksql.metastore.MetaStoreImpl;
 import io.confluent.ksql.metastore.MutableMetaStore;
 import io.confluent.ksql.metastore.model.KeyField;
 import io.confluent.ksql.metastore.model.KsqlStream;
-import io.confluent.ksql.execution.ddl.commands.KsqlTopic;
 import io.confluent.ksql.parser.tree.Statement;
 import io.confluent.ksql.schema.ksql.LogicalSchema;
+import io.confluent.ksql.schema.ksql.types.SqlTypes;
 import io.confluent.ksql.serde.Format;
 import io.confluent.ksql.serde.FormatInfo;
 import io.confluent.ksql.serde.KeyFormat;
@@ -40,8 +41,6 @@ import io.confluent.ksql.services.ServiceContext;
 import io.confluent.ksql.util.KsqlException;
 import io.confluent.ksql.util.timestamp.MetadataTimestampExtractionPolicy;
 import org.apache.kafka.clients.admin.TopicDescription;
-import org.apache.kafka.connect.data.Schema;
-import org.apache.kafka.connect.data.SchemaBuilder;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Rule;
@@ -53,10 +52,10 @@ import org.mockito.junit.MockitoJUnitRunner;
 
 @RunWith(MockitoJUnitRunner.class)
 public class SourceTopicsExtractorTest {
-  private static final LogicalSchema SCHEMA = LogicalSchema.of(SchemaBuilder
-      .struct()
-      .field("F1", Schema.OPTIONAL_STRING_SCHEMA)
-      .build());
+
+  private static final LogicalSchema SCHEMA = LogicalSchema.builder()
+      .valueField("F1", SqlTypes.STRING)
+      .build();
 
   private static final String STREAM_TOPIC_1 = "s1";
   private static final String STREAM_TOPIC_2 = "s2";

--- a/ksql-engine/src/test/java/io/confluent/ksql/topic/TopicCreateInjectorTest.java
+++ b/ksql-engine/src/test/java/io/confluent/ksql/topic/TopicCreateInjectorTest.java
@@ -26,12 +26,12 @@ import static org.mockito.Mockito.when;
 import static org.mockito.hamcrest.MockitoHamcrest.argThat;
 
 import com.google.common.collect.ImmutableMap;
+import io.confluent.ksql.execution.ddl.commands.KsqlTopic;
 import io.confluent.ksql.function.InternalFunctionRegistry;
 import io.confluent.ksql.metastore.MetaStoreImpl;
 import io.confluent.ksql.metastore.MutableMetaStore;
 import io.confluent.ksql.metastore.model.KeyField;
 import io.confluent.ksql.metastore.model.KsqlStream;
-import io.confluent.ksql.execution.ddl.commands.KsqlTopic;
 import io.confluent.ksql.parser.DefaultKsqlParser;
 import io.confluent.ksql.parser.KsqlParser;
 import io.confluent.ksql.parser.KsqlParser.PreparedStatement;
@@ -40,6 +40,7 @@ import io.confluent.ksql.parser.properties.with.CreateSourceProperties;
 import io.confluent.ksql.parser.tree.CreateAsSelect;
 import io.confluent.ksql.parser.tree.CreateSource;
 import io.confluent.ksql.schema.ksql.LogicalSchema;
+import io.confluent.ksql.schema.ksql.types.SqlTypes;
 import io.confluent.ksql.serde.Format;
 import io.confluent.ksql.serde.FormatInfo;
 import io.confluent.ksql.serde.KeyFormat;
@@ -56,8 +57,6 @@ import java.util.Optional;
 import java.util.function.Supplier;
 import org.apache.kafka.clients.admin.TopicDescription;
 import org.apache.kafka.common.config.TopicConfig;
-import org.apache.kafka.connect.data.Schema;
-import org.apache.kafka.connect.data.SchemaBuilder;
 import org.hamcrest.Description;
 import org.hamcrest.TypeSafeMatcher;
 import org.junit.Before;
@@ -71,10 +70,9 @@ import org.mockito.junit.MockitoJUnitRunner;
 @RunWith(MockitoJUnitRunner.class)
 public class TopicCreateInjectorTest {
 
-  private static final LogicalSchema SCHEMA = LogicalSchema.of(SchemaBuilder
-      .struct()
-      .field("F1", Schema.OPTIONAL_STRING_SCHEMA)
-      .build());
+  private static final LogicalSchema SCHEMA = LogicalSchema.builder()
+      .valueField("F1", SqlTypes.STRING)
+      .build();
 
   @Rule
   public final ExpectedException expectedException = ExpectedException.none();

--- a/ksql-engine/src/test/java/io/confluent/ksql/util/ExpressionTypeManagerTest.java
+++ b/ksql-engine/src/test/java/io/confluent/ksql/util/ExpressionTypeManagerTest.java
@@ -29,8 +29,6 @@ import io.confluent.ksql.schema.ksql.LogicalSchema;
 import io.confluent.ksql.schema.ksql.types.SqlType;
 import io.confluent.ksql.schema.ksql.types.SqlTypes;
 import io.confluent.ksql.testutils.ExpressionParseTestUtil;
-import org.apache.kafka.connect.data.Schema;
-import org.apache.kafka.connect.data.SchemaBuilder;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
@@ -52,14 +50,14 @@ public class ExpressionTypeManagerTest {
   public void init() {
     metaStore = MetaStoreFixture.getNewMetaStore(FUNCTION_REGISTRY);
 
-    final Schema schema = SchemaBuilder.struct()
-        .field("TEST1.COL0", SchemaBuilder.OPTIONAL_INT64_SCHEMA)
-        .field("TEST1.COL1", SchemaBuilder.OPTIONAL_STRING_SCHEMA)
-        .field("TEST1.COL2", SchemaBuilder.OPTIONAL_STRING_SCHEMA)
-        .field("TEST1.COL3", SchemaBuilder.OPTIONAL_FLOAT64_SCHEMA)
+    final LogicalSchema schema = LogicalSchema.builder()
+        .valueField("TEST1.COL0", SqlTypes.BIGINT)
+        .valueField("TEST1.COL1", SqlTypes.STRING)
+        .valueField("TEST1.COL2", SqlTypes.STRING)
+        .valueField("TEST1.COL3", SqlTypes.DOUBLE)
         .build();
 
-    expressionTypeManager = new ExpressionTypeManager(LogicalSchema.of(schema), FUNCTION_REGISTRY);
+    expressionTypeManager = new ExpressionTypeManager(schema, FUNCTION_REGISTRY);
     ordersExpressionTypeManager = new ExpressionTypeManager(
         metaStore.getSource("ORDERS").getSchema(),
         FUNCTION_REGISTRY

--- a/ksql-engine/src/test/java/io/confluent/ksql/util/GenericRowValueTypeEnforcerTest.java
+++ b/ksql-engine/src/test/java/io/confluent/ksql/util/GenericRowValueTypeEnforcerTest.java
@@ -20,8 +20,7 @@ import static org.junit.Assert.assertNull;
 import static org.junit.Assert.fail;
 
 import io.confluent.ksql.schema.ksql.LogicalSchema;
-import org.apache.kafka.connect.data.Schema;
-import org.apache.kafka.connect.data.SchemaBuilder;
+import io.confluent.ksql.schema.ksql.types.SqlTypes;
 import org.junit.Test;
 
 /**
@@ -33,9 +32,9 @@ public class GenericRowValueTypeEnforcerTest {
 
   @Test
   public void testEnforceBoolean() {
-    final LogicalSchema schema = LogicalSchema.of(SchemaBuilder.struct()
-        .field("boolean", Schema.OPTIONAL_BOOLEAN_SCHEMA)
-        .build());
+    final LogicalSchema schema = LogicalSchema.builder()
+        .valueField("boolean", SqlTypes.BOOLEAN)
+        .build();
     
     final GenericRowValueTypeEnforcer genericRowValueTypeEnforcer =
         new GenericRowValueTypeEnforcer(schema);
@@ -51,9 +50,9 @@ public class GenericRowValueTypeEnforcerTest {
 
   @Test
   public void testEnforceBooleanReturningBooleanWhereBooleanValueIsFalse() {
-    final LogicalSchema schema = LogicalSchema.of(SchemaBuilder.struct()
-        .field("boolean", Schema.OPTIONAL_BOOLEAN_SCHEMA)
-        .build());
+    final LogicalSchema schema = LogicalSchema.builder()
+        .valueField("boolean", SqlTypes.BOOLEAN)
+        .build();
 
     final GenericRowValueTypeEnforcer genericRowValueTypeEnforcer =
         new GenericRowValueTypeEnforcer(schema);
@@ -63,9 +62,9 @@ public class GenericRowValueTypeEnforcerTest {
 
   @Test
   public void testEnforceBooleanReturningBooleanWhereBooleanValueIsTrue() {
-    final LogicalSchema schema = LogicalSchema.of(SchemaBuilder.struct()
-        .field("boolean", Schema.OPTIONAL_BOOLEAN_SCHEMA)
-        .build());
+    final LogicalSchema schema = LogicalSchema.builder()
+        .valueField("boolean", SqlTypes.BOOLEAN)
+        .build();
 
     final GenericRowValueTypeEnforcer genericRowValueTypeEnforcer =
         new GenericRowValueTypeEnforcer(schema);
@@ -75,9 +74,9 @@ public class GenericRowValueTypeEnforcerTest {
 
   @Test
   public void testEnforceBooleanReturningNull() {
-    final LogicalSchema schema = LogicalSchema.of(SchemaBuilder.struct()
-        .field("boolean", Schema.OPTIONAL_BOOLEAN_SCHEMA)
-        .build());
+    final LogicalSchema schema = LogicalSchema.builder()
+        .valueField("boolean", SqlTypes.BOOLEAN)
+        .build();
 
     final GenericRowValueTypeEnforcer genericRowValueTypeEnforcer =
         new GenericRowValueTypeEnforcer(schema);
@@ -87,9 +86,9 @@ public class GenericRowValueTypeEnforcerTest {
 
   @Test
   public void testEnforceString() {
-    final LogicalSchema schema = LogicalSchema.of(SchemaBuilder.struct()
-        .field("string", Schema.OPTIONAL_STRING_SCHEMA)
-        .build());
+    final LogicalSchema schema = LogicalSchema.builder()
+        .valueField("string", SqlTypes.STRING)
+        .build();
 
     final GenericRowValueTypeEnforcer genericRowValueTypeEnforcer =
         new GenericRowValueTypeEnforcer(schema);
@@ -105,9 +104,9 @@ public class GenericRowValueTypeEnforcerTest {
 
   @Test
   public void testEnforceStringReturningNull() {
-    final LogicalSchema schema = LogicalSchema.of(SchemaBuilder.struct()
-        .field("string", Schema.OPTIONAL_STRING_SCHEMA)
-        .build());
+    final LogicalSchema schema = LogicalSchema.builder()
+        .valueField("string", SqlTypes.STRING)
+        .build();
 
     final GenericRowValueTypeEnforcer genericRowValueTypeEnforcer =
         new GenericRowValueTypeEnforcer(schema);
@@ -117,9 +116,9 @@ public class GenericRowValueTypeEnforcerTest {
 
   @Test
   public void testEnforceInteger() {
-    final LogicalSchema schema = LogicalSchema.of(SchemaBuilder.struct()
-        .field("int", Schema.OPTIONAL_INT32_SCHEMA)
-        .build());
+    final LogicalSchema schema = LogicalSchema.builder()
+        .valueField("int", SqlTypes.INTEGER)
+        .build();
 
     final GenericRowValueTypeEnforcer genericRowValueTypeEnforcer =
         new GenericRowValueTypeEnforcer(schema);
@@ -135,9 +134,9 @@ public class GenericRowValueTypeEnforcerTest {
 
   @Test
   public void testEnforceIntegerThrowsNumberFormatExceptionOnInvalidCharSequence() {
-    final LogicalSchema schema = LogicalSchema.of(SchemaBuilder.struct()
-        .field("int", Schema.OPTIONAL_INT32_SCHEMA)
-        .build());
+    final LogicalSchema schema = LogicalSchema.builder()
+        .valueField("int", SqlTypes.INTEGER)
+        .build();
 
     final GenericRowValueTypeEnforcer genericRowValueTypeEnforcer =
         new GenericRowValueTypeEnforcer(schema);
@@ -152,9 +151,9 @@ public class GenericRowValueTypeEnforcerTest {
 
   @Test
   public void testEnforceIntegerThrowsNumberFormatExceptionOnInvalidString() {
-    final LogicalSchema schema = LogicalSchema.of(SchemaBuilder.struct()
-        .field("int", Schema.OPTIONAL_INT32_SCHEMA)
-        .build());
+    final LogicalSchema schema = LogicalSchema.builder()
+        .valueField("int", SqlTypes.INTEGER)
+        .build();
 
     final GenericRowValueTypeEnforcer genericRowValueTypeEnforcer =
         new GenericRowValueTypeEnforcer(schema);
@@ -169,9 +168,9 @@ public class GenericRowValueTypeEnforcerTest {
 
   @Test
   public void testEnforceIntegerOnValidCharSequence() {
-    final LogicalSchema schema = LogicalSchema.of(SchemaBuilder.struct()
-        .field("int", Schema.OPTIONAL_INT32_SCHEMA)
-        .build());
+    final LogicalSchema schema = LogicalSchema.builder()
+        .valueField("int", SqlTypes.INTEGER)
+        .build();
 
     final GenericRowValueTypeEnforcer genericRowValueTypeEnforcer =
         new GenericRowValueTypeEnforcer(schema);
@@ -181,9 +180,9 @@ public class GenericRowValueTypeEnforcerTest {
 
   @Test
   public void testEnforceIntegerOnValidString() {
-    final LogicalSchema schema = LogicalSchema.of(SchemaBuilder.struct()
-        .field("int", Schema.OPTIONAL_INT32_SCHEMA)
-        .build());
+    final LogicalSchema schema = LogicalSchema.builder()
+        .valueField("int", SqlTypes.INTEGER)
+        .build();
 
     final GenericRowValueTypeEnforcer genericRowValueTypeEnforcer =
         new GenericRowValueTypeEnforcer(schema);
@@ -193,9 +192,9 @@ public class GenericRowValueTypeEnforcerTest {
 
   @Test
   public void testEnforceIntegerAndEnforceIntegerOne() {
-    final LogicalSchema schema = LogicalSchema.of(SchemaBuilder.struct()
-        .field("int", Schema.OPTIONAL_INT32_SCHEMA)
-        .build());
+    final LogicalSchema schema = LogicalSchema.builder()
+        .valueField("int", SqlTypes.INTEGER)
+        .build();
 
     final GenericRowValueTypeEnforcer genericRowValueTypeEnforcer =
         new GenericRowValueTypeEnforcer(schema);
@@ -205,9 +204,9 @@ public class GenericRowValueTypeEnforcerTest {
 
   @Test
   public void testEnforceIntegerAndEnforceIntegerThree() {
-    final LogicalSchema schema = LogicalSchema.of(SchemaBuilder.struct()
-        .field("int", Schema.OPTIONAL_INT32_SCHEMA)
-        .build());
+    final LogicalSchema schema = LogicalSchema.builder()
+        .valueField("int", SqlTypes.INTEGER)
+        .build();
 
     final GenericRowValueTypeEnforcer genericRowValueTypeEnforcer =
         new GenericRowValueTypeEnforcer(schema);
@@ -217,9 +216,9 @@ public class GenericRowValueTypeEnforcerTest {
 
   @Test
   public void testEnforceIntegerAndEnforceIntegerFour() {
-    final LogicalSchema schema = LogicalSchema.of(SchemaBuilder.struct()
-        .field("int", Schema.OPTIONAL_INT32_SCHEMA)
-        .build());
+    final LogicalSchema schema = LogicalSchema.builder()
+        .valueField("int", SqlTypes.INTEGER)
+        .build();
 
     final GenericRowValueTypeEnforcer genericRowValueTypeEnforcer =
         new GenericRowValueTypeEnforcer(schema);
@@ -229,9 +228,9 @@ public class GenericRowValueTypeEnforcerTest {
 
   @Test
   public void testEnforceIntegerReturningNull() {
-    final LogicalSchema schema = LogicalSchema.of(SchemaBuilder.struct()
-        .field("int", Schema.OPTIONAL_INT32_SCHEMA)
-        .build());
+    final LogicalSchema schema = LogicalSchema.builder()
+        .valueField("int", SqlTypes.INTEGER)
+        .build();
 
     final GenericRowValueTypeEnforcer genericRowValueTypeEnforcer =
         new GenericRowValueTypeEnforcer(schema);
@@ -241,9 +240,9 @@ public class GenericRowValueTypeEnforcerTest {
 
   @Test
   public void testEnforceLong() {
-    final LogicalSchema schema = LogicalSchema.of(SchemaBuilder.struct()
-        .field("long", Schema.OPTIONAL_INT64_SCHEMA)
-        .build());
+    final LogicalSchema schema = LogicalSchema.builder()
+        .valueField("long", SqlTypes.BIGINT)
+        .build();
 
     final GenericRowValueTypeEnforcer genericRowValueTypeEnforcer =
         new GenericRowValueTypeEnforcer(schema);
@@ -259,9 +258,9 @@ public class GenericRowValueTypeEnforcerTest {
 
   @Test
   public void testEnforceLongThrowsNumberFormatExceptionOnInvalidCharSequence() {
-    final LogicalSchema schema = LogicalSchema.of(SchemaBuilder.struct()
-        .field("long", Schema.OPTIONAL_INT64_SCHEMA)
-        .build());
+    final LogicalSchema schema = LogicalSchema.builder()
+        .valueField("long", SqlTypes.BIGINT)
+        .build();
 
     final GenericRowValueTypeEnforcer genericRowValueTypeEnforcer =
         new GenericRowValueTypeEnforcer(schema);
@@ -276,9 +275,9 @@ public class GenericRowValueTypeEnforcerTest {
 
   @Test
   public void testEnforceLongThrowsNumberFormatExceptionOnInvalidString() {
-    final LogicalSchema schema = LogicalSchema.of(SchemaBuilder.struct()
-        .field("long", Schema.OPTIONAL_INT64_SCHEMA)
-        .build());
+    final LogicalSchema schema = LogicalSchema.builder()
+        .valueField("long", SqlTypes.BIGINT)
+        .build();
 
     final GenericRowValueTypeEnforcer genericRowValueTypeEnforcer =
         new GenericRowValueTypeEnforcer(schema);
@@ -293,9 +292,9 @@ public class GenericRowValueTypeEnforcerTest {
 
   @Test
   public void testEnforceLongOnValidCharSequence() {
-    final LogicalSchema schema = LogicalSchema.of(SchemaBuilder.struct()
-        .field("long", Schema.OPTIONAL_INT64_SCHEMA)
-        .build());
+    final LogicalSchema schema = LogicalSchema.builder()
+        .valueField("long", SqlTypes.BIGINT)
+        .build();
 
     final GenericRowValueTypeEnforcer genericRowValueTypeEnforcer =
         new GenericRowValueTypeEnforcer(schema);
@@ -305,9 +304,9 @@ public class GenericRowValueTypeEnforcerTest {
 
   @Test
   public void testEnforceLongOnValidString() {
-    final LogicalSchema schema = LogicalSchema.of(SchemaBuilder.struct()
-        .field("long", Schema.OPTIONAL_INT64_SCHEMA)
-        .build());
+    final LogicalSchema schema = LogicalSchema.builder()
+        .valueField("long", SqlTypes.BIGINT)
+        .build();
 
     final GenericRowValueTypeEnforcer genericRowValueTypeEnforcer =
         new GenericRowValueTypeEnforcer(schema);
@@ -317,9 +316,9 @@ public class GenericRowValueTypeEnforcerTest {
 
   @Test
   public void testEnforceLongAndEnforceLongOne() {
-    final LogicalSchema schema = LogicalSchema.of(SchemaBuilder.struct()
-        .field("long", Schema.OPTIONAL_INT64_SCHEMA)
-        .build());
+    final LogicalSchema schema = LogicalSchema.builder()
+        .valueField("long", SqlTypes.BIGINT)
+        .build();
 
     final GenericRowValueTypeEnforcer genericRowValueTypeEnforcer =
         new GenericRowValueTypeEnforcer(schema);
@@ -329,9 +328,9 @@ public class GenericRowValueTypeEnforcerTest {
 
   @Test
   public void testEnforceLongReturningLongWhereByteValueIsNegative() {
-    final LogicalSchema schema = LogicalSchema.of(SchemaBuilder.struct()
-        .field("long", Schema.OPTIONAL_INT64_SCHEMA)
-        .build());
+    final LogicalSchema schema = LogicalSchema.builder()
+        .valueField("long", SqlTypes.BIGINT)
+        .build();
 
     final GenericRowValueTypeEnforcer genericRowValueTypeEnforcer =
         new GenericRowValueTypeEnforcer(schema);
@@ -341,9 +340,9 @@ public class GenericRowValueTypeEnforcerTest {
 
   @Test
   public void testEnforceLongReturningLongWhereShortValueIsNegative() {
-    final LogicalSchema schema = LogicalSchema.of(SchemaBuilder.struct()
-        .field("long", Schema.OPTIONAL_INT64_SCHEMA)
-        .build());
+    final LogicalSchema schema = LogicalSchema.builder()
+        .valueField("long", SqlTypes.BIGINT)
+        .build();
 
     final GenericRowValueTypeEnforcer genericRowValueTypeEnforcer =
         new GenericRowValueTypeEnforcer(schema);
@@ -353,9 +352,9 @@ public class GenericRowValueTypeEnforcerTest {
 
   @Test
   public void testEnforceLongReturningNull() {
-    final LogicalSchema schema = LogicalSchema.of(SchemaBuilder.struct()
-        .field("long", Schema.OPTIONAL_INT64_SCHEMA)
-        .build());
+    final LogicalSchema schema = LogicalSchema.builder()
+        .valueField("long", SqlTypes.BIGINT)
+        .build();
 
     final GenericRowValueTypeEnforcer genericRowValueTypeEnforcer =
         new GenericRowValueTypeEnforcer(schema);
@@ -365,9 +364,9 @@ public class GenericRowValueTypeEnforcerTest {
 
   @Test
   public void testEnforceDouble() {
-    final LogicalSchema schema = LogicalSchema.of(SchemaBuilder.struct()
-        .field("double", Schema.OPTIONAL_FLOAT64_SCHEMA)
-        .build());
+    final LogicalSchema schema = LogicalSchema.builder()
+        .valueField("double", SqlTypes.DOUBLE)
+        .build();
 
     final GenericRowValueTypeEnforcer genericRowValueTypeEnforcer =
         new GenericRowValueTypeEnforcer(schema);
@@ -384,9 +383,9 @@ public class GenericRowValueTypeEnforcerTest {
 
   @Test(expected = NumberFormatException.class)
   public void testEnforceDoubleThrowsNumberFormatExceptionOnInvalidCharSequence() {
-    final LogicalSchema schema = LogicalSchema.of(SchemaBuilder.struct()
-        .field("double", Schema.OPTIONAL_FLOAT64_SCHEMA)
-        .build());
+    final LogicalSchema schema = LogicalSchema.builder()
+        .valueField("double", SqlTypes.DOUBLE)
+        .build();
 
     final GenericRowValueTypeEnforcer genericRowValueTypeEnforcer =
         new GenericRowValueTypeEnforcer(schema);
@@ -396,9 +395,9 @@ public class GenericRowValueTypeEnforcerTest {
 
   @Test(expected = NumberFormatException.class)
   public void testEnforceDoubleThrowsNumberFormatExceptionOnInvalidString() {
-    final LogicalSchema schema = LogicalSchema.of(SchemaBuilder.struct()
-        .field("double", Schema.OPTIONAL_FLOAT64_SCHEMA)
-        .build());
+    final LogicalSchema schema = LogicalSchema.builder()
+        .valueField("double", SqlTypes.DOUBLE)
+        .build();
 
     final GenericRowValueTypeEnforcer genericRowValueTypeEnforcer =
         new GenericRowValueTypeEnforcer(schema);
@@ -408,9 +407,9 @@ public class GenericRowValueTypeEnforcerTest {
 
   @Test
   public void testEnforceDoubleOnValidCharSequence() {
-    final LogicalSchema schema = LogicalSchema.of(SchemaBuilder.struct()
-        .field("double", Schema.OPTIONAL_FLOAT64_SCHEMA)
-        .build());
+    final LogicalSchema schema = LogicalSchema.builder()
+        .valueField("double", SqlTypes.DOUBLE)
+        .build();
 
     final GenericRowValueTypeEnforcer genericRowValueTypeEnforcer =
         new GenericRowValueTypeEnforcer(schema);
@@ -420,9 +419,9 @@ public class GenericRowValueTypeEnforcerTest {
 
   @Test
   public void testEnforceDoubleOnValidString() {
-    final LogicalSchema schema = LogicalSchema.of(SchemaBuilder.struct()
-        .field("double", Schema.OPTIONAL_FLOAT64_SCHEMA)
-        .build());
+    final LogicalSchema schema = LogicalSchema.builder()
+        .valueField("double", SqlTypes.DOUBLE)
+        .build();
 
     final GenericRowValueTypeEnforcer genericRowValueTypeEnforcer =
         new GenericRowValueTypeEnforcer(schema);
@@ -432,9 +431,9 @@ public class GenericRowValueTypeEnforcerTest {
 
   @Test
   public void testEnforceDoubleAndEnforceDoubleOne() {
-    final LogicalSchema schema = LogicalSchema.of(SchemaBuilder.struct()
-        .field("double", Schema.OPTIONAL_FLOAT64_SCHEMA)
-        .build());
+    final LogicalSchema schema = LogicalSchema.builder()
+        .valueField("double", SqlTypes.DOUBLE)
+        .build();
 
     final GenericRowValueTypeEnforcer genericRowValueTypeEnforcer =
         new GenericRowValueTypeEnforcer(schema);
@@ -444,9 +443,9 @@ public class GenericRowValueTypeEnforcerTest {
 
   @Test
   public void testEnforceDoubleReturningDoubleWhereByteValueIsNegative() {
-    final LogicalSchema schema = LogicalSchema.of(SchemaBuilder.struct()
-        .field("double", Schema.OPTIONAL_FLOAT64_SCHEMA)
-        .build());
+    final LogicalSchema schema = LogicalSchema.builder()
+        .valueField("double", SqlTypes.DOUBLE)
+        .build();
 
     final GenericRowValueTypeEnforcer genericRowValueTypeEnforcer =
         new GenericRowValueTypeEnforcer(schema);
@@ -456,9 +455,9 @@ public class GenericRowValueTypeEnforcerTest {
 
   @Test
   public void testEnforceDoubleAndEnforceDoubleTwo() {
-    final LogicalSchema schema = LogicalSchema.of(SchemaBuilder.struct()
-        .field("double", Schema.OPTIONAL_FLOAT64_SCHEMA)
-        .build());
+    final LogicalSchema schema = LogicalSchema.builder()
+        .valueField("double", SqlTypes.DOUBLE)
+        .build();
 
     final GenericRowValueTypeEnforcer genericRowValueTypeEnforcer =
         new GenericRowValueTypeEnforcer(schema);
@@ -468,9 +467,9 @@ public class GenericRowValueTypeEnforcerTest {
 
   @Test
   public void testEnforceDoubleReturningDoubleWhereShortValueIsPositive() {
-    final LogicalSchema schema = LogicalSchema.of(SchemaBuilder.struct()
-        .field("double", Schema.OPTIONAL_FLOAT64_SCHEMA)
-        .build());
+    final LogicalSchema schema = LogicalSchema.builder()
+        .valueField("double", SqlTypes.DOUBLE)
+        .build();
 
     final GenericRowValueTypeEnforcer genericRowValueTypeEnforcer =
         new GenericRowValueTypeEnforcer(schema);
@@ -480,9 +479,9 @@ public class GenericRowValueTypeEnforcerTest {
 
   @Test
   public void testEnforceDoubleReturningDoubleWhereShortValueIsNegative() {
-    final LogicalSchema schema = LogicalSchema.of(SchemaBuilder.struct()
-        .field("double", Schema.OPTIONAL_FLOAT64_SCHEMA)
-        .build());
+    final LogicalSchema schema = LogicalSchema.builder()
+        .valueField("double", SqlTypes.DOUBLE)
+        .build();
 
     final GenericRowValueTypeEnforcer genericRowValueTypeEnforcer =
         new GenericRowValueTypeEnforcer(schema);
@@ -492,9 +491,9 @@ public class GenericRowValueTypeEnforcerTest {
 
   @Test
   public void testEnforceDoubleReturningNull() {
-    final LogicalSchema schema = LogicalSchema.of(SchemaBuilder.struct()
-        .field("double", Schema.OPTIONAL_FLOAT64_SCHEMA)
-        .build());
+    final LogicalSchema schema = LogicalSchema.builder()
+        .valueField("double", SqlTypes.DOUBLE)
+        .build();
 
     final GenericRowValueTypeEnforcer genericRowValueTypeEnforcer =
         new GenericRowValueTypeEnforcer(schema);

--- a/ksql-engine/src/test/java/io/confluent/ksql/util/ItemDataProvider.java
+++ b/ksql-engine/src/test/java/io/confluent/ksql/util/ItemDataProvider.java
@@ -18,11 +18,11 @@ package io.confluent.ksql.util;
 import io.confluent.ksql.GenericRow;
 import io.confluent.ksql.schema.ksql.LogicalSchema;
 import io.confluent.ksql.schema.ksql.PhysicalSchema;
+import io.confluent.ksql.schema.ksql.types.SqlTypes;
 import io.confluent.ksql.serde.SerdeOption;
 import java.util.Arrays;
 import java.util.HashMap;
 import java.util.Map;
-import org.apache.kafka.connect.data.SchemaBuilder;
 
 public class ItemDataProvider extends TestDataProvider {
 
@@ -34,10 +34,10 @@ public class ItemDataProvider extends TestDataProvider {
 
   private static final String key = "ID";
 
-  private static final LogicalSchema schema = LogicalSchema.of(SchemaBuilder.struct()
-      .field("ID", SchemaBuilder.OPTIONAL_STRING_SCHEMA)
-      .field("DESCRIPTION", SchemaBuilder.OPTIONAL_STRING_SCHEMA)
-      .build());
+  private static final LogicalSchema schema = LogicalSchema.builder()
+      .valueField("ID", SqlTypes.STRING)
+      .valueField("DESCRIPTION", SqlTypes.STRING)
+      .build();
 
   private static final Map<String, GenericRow> data = buildData();
 

--- a/ksql-engine/src/test/java/io/confluent/ksql/util/OrderDataProvider.java
+++ b/ksql-engine/src/test/java/io/confluent/ksql/util/OrderDataProvider.java
@@ -18,12 +18,11 @@ package io.confluent.ksql.util;
 import io.confluent.ksql.GenericRow;
 import io.confluent.ksql.schema.ksql.LogicalSchema;
 import io.confluent.ksql.schema.ksql.PhysicalSchema;
+import io.confluent.ksql.schema.ksql.types.SqlTypes;
 import io.confluent.ksql.serde.SerdeOption;
 import java.util.Arrays;
 import java.util.HashMap;
 import java.util.Map;
-import org.apache.kafka.connect.data.Schema;
-import org.apache.kafka.connect.data.SchemaBuilder;
 
 public class OrderDataProvider extends TestDataProvider {
 
@@ -35,22 +34,15 @@ public class OrderDataProvider extends TestDataProvider {
 
   private static final String key = "ORDERTIME";
 
-  private static final LogicalSchema schema = LogicalSchema.of(SchemaBuilder.struct()
-      .field("ORDERTIME", SchemaBuilder.OPTIONAL_INT64_SCHEMA)
-      .field("ORDERID", SchemaBuilder.OPTIONAL_STRING_SCHEMA)
-      .field("ITEMID", SchemaBuilder.OPTIONAL_STRING_SCHEMA)
-      .field("ORDERUNITS", SchemaBuilder.OPTIONAL_FLOAT64_SCHEMA)
-      .field("TIMESTAMP", Schema.OPTIONAL_STRING_SCHEMA)
-      .field("PRICEARRAY", SchemaBuilder
-          .array(SchemaBuilder.OPTIONAL_FLOAT64_SCHEMA)
-          .optional()
-          .build())
-      .field("KEYVALUEMAP", SchemaBuilder
-          .map(SchemaBuilder.OPTIONAL_STRING_SCHEMA, SchemaBuilder.OPTIONAL_FLOAT64_SCHEMA)
-          .optional()
-          .build())
-      .optional()
-      .build());
+  private static final LogicalSchema schema = LogicalSchema.builder()
+      .valueField("ORDERTIME", SqlTypes.BIGINT)
+      .valueField("ORDERID", SqlTypes.STRING)
+      .valueField("ITEMID", SqlTypes.STRING)
+      .valueField("ORDERUNITS", SqlTypes.DOUBLE)
+      .valueField("TIMESTAMP", SqlTypes.STRING)
+      .valueField("PRICEARRAY", SqlTypes.array(SqlTypes.DOUBLE))
+      .valueField("KEYVALUEMAP", SqlTypes.map(SqlTypes.DOUBLE))
+      .build();
 
   private static final Map<String, GenericRow> data = buildData();
 

--- a/ksql-engine/src/test/java/io/confluent/ksql/util/PageViewDataProvider.java
+++ b/ksql-engine/src/test/java/io/confluent/ksql/util/PageViewDataProvider.java
@@ -17,11 +17,11 @@ package io.confluent.ksql.util;
 import io.confluent.ksql.GenericRow;
 import io.confluent.ksql.schema.ksql.LogicalSchema;
 import io.confluent.ksql.schema.ksql.PhysicalSchema;
+import io.confluent.ksql.schema.ksql.types.SqlTypes;
 import io.confluent.ksql.serde.SerdeOption;
 import java.util.Arrays;
 import java.util.HashMap;
 import java.util.Map;
-import org.apache.kafka.connect.data.SchemaBuilder;
 
 public class PageViewDataProvider extends TestDataProvider {
   private static final String namePrefix =
@@ -31,11 +31,11 @@ public class PageViewDataProvider extends TestDataProvider {
 
   private static final String key = "VIEWTIME";
 
-  private static final LogicalSchema schema = LogicalSchema.of(SchemaBuilder.struct()
-      .field("VIEWTIME", SchemaBuilder.OPTIONAL_INT64_SCHEMA)
-      .field("USERID", SchemaBuilder.OPTIONAL_STRING_SCHEMA)
-      .field("PAGEID", SchemaBuilder.OPTIONAL_STRING_SCHEMA)
-      .build());
+  private static final LogicalSchema schema = LogicalSchema.builder()
+      .valueField("VIEWTIME", SqlTypes.BIGINT)
+      .valueField("USERID", SqlTypes.STRING)
+      .valueField("PAGEID", SqlTypes.STRING)
+      .build();
 
   private static final Map<String, GenericRow> data = buildData();
 

--- a/ksql-engine/src/test/java/io/confluent/ksql/util/QueryMetadataTest.java
+++ b/ksql-engine/src/test/java/io/confluent/ksql/util/QueryMetadataTest.java
@@ -25,10 +25,10 @@ import static org.mockito.Mockito.when;
 import com.google.common.collect.ImmutableSet;
 import io.confluent.ksql.internal.QueryStateListener;
 import io.confluent.ksql.schema.ksql.LogicalSchema;
+import io.confluent.ksql.schema.ksql.types.SqlTypes;
 import java.util.Collections;
 import java.util.Set;
 import java.util.function.Consumer;
-import org.apache.kafka.connect.data.SchemaBuilder;
 import org.apache.kafka.streams.KafkaStreams;
 import org.apache.kafka.streams.KafkaStreams.State;
 import org.apache.kafka.streams.Topology;
@@ -43,9 +43,9 @@ import org.mockito.junit.MockitoJUnitRunner;
 public class QueryMetadataTest {
 
   private static final String QUERY_APPLICATION_ID = "Query1";
-  private static final LogicalSchema SOME_SCHEMA = LogicalSchema.of(SchemaBuilder.struct()
-      .field("f0", SchemaBuilder.OPTIONAL_STRING_SCHEMA)
-      .build());
+  private static final LogicalSchema SOME_SCHEMA = LogicalSchema.builder()
+      .valueField("f0", SqlTypes.STRING)
+      .build();
   private static final Set<String> SOME_SOURCES = ImmutableSet.of("s1", "s2");
 
   @Mock

--- a/ksql-engine/src/test/java/io/confluent/ksql/util/UserDataProvider.java
+++ b/ksql-engine/src/test/java/io/confluent/ksql/util/UserDataProvider.java
@@ -17,11 +17,11 @@ package io.confluent.ksql.util;
 import io.confluent.ksql.GenericRow;
 import io.confluent.ksql.schema.ksql.LogicalSchema;
 import io.confluent.ksql.schema.ksql.PhysicalSchema;
+import io.confluent.ksql.schema.ksql.types.SqlTypes;
 import io.confluent.ksql.serde.SerdeOption;
 import java.util.Arrays;
 import java.util.HashMap;
 import java.util.Map;
-import org.apache.kafka.connect.data.SchemaBuilder;
 
 public class UserDataProvider extends TestDataProvider {
   private static final String namePrefix = "USER";
@@ -30,12 +30,12 @@ public class UserDataProvider extends TestDataProvider {
 
   private static final String key = "USERID";
 
-  private static final LogicalSchema schema = LogicalSchema.of(SchemaBuilder.struct()
-      .field("REGISTERTIME", SchemaBuilder.OPTIONAL_INT64_SCHEMA)
-      .field("GENDER", SchemaBuilder.OPTIONAL_STRING_SCHEMA)
-      .field("REGIONID", SchemaBuilder.OPTIONAL_STRING_SCHEMA)
-      .field("USERID", SchemaBuilder.OPTIONAL_STRING_SCHEMA)
-      .build());
+  private static final LogicalSchema schema = LogicalSchema.builder()
+      .valueField("REGISTERTIME", SqlTypes.BIGINT)
+      .valueField("GENDER", SqlTypes.STRING)
+      .valueField("REGIONID", SqlTypes.STRING)
+      .valueField("USERID", SqlTypes.STRING)
+      .build();
 
   private static final Map<String, GenericRow> data = buildData();
 

--- a/ksql-examples/src/main/java/io/confluent/ksql/datagen/DataGenProducer.java
+++ b/ksql-examples/src/main/java/io/confluent/ksql/datagen/DataGenProducer.java
@@ -71,7 +71,7 @@ public class DataGenProducer {
     final Serializer<Struct> keySerializer = getKeySerializer();
 
     final Serializer<GenericRow> valueSerializer =
-        getValueSerializer(rowGenerator.schema().valueSchema());
+        getValueSerializer(rowGenerator.schema().valueConnectSchema());
 
     final KafkaProducer<Struct, GenericRow> producer = new KafkaProducer<>(
         props,

--- a/ksql-execution/src/test/java/io/confluent/ksql/execution/builder/KsqlQueryBuilderTest.java
+++ b/ksql-execution/src/test/java/io/confluent/ksql/execution/builder/KsqlQueryBuilderTest.java
@@ -34,6 +34,7 @@ import io.confluent.ksql.model.WindowType;
 import io.confluent.ksql.query.QueryId;
 import io.confluent.ksql.schema.ksql.LogicalSchema;
 import io.confluent.ksql.schema.ksql.PhysicalSchema;
+import io.confluent.ksql.schema.ksql.types.SqlTypes;
 import io.confluent.ksql.serde.Format;
 import io.confluent.ksql.serde.FormatInfo;
 import io.confluent.ksql.serde.KeySerde;
@@ -47,8 +48,6 @@ import java.time.Duration;
 import java.util.Optional;
 import java.util.function.Supplier;
 import org.apache.kafka.common.serialization.Serde;
-import org.apache.kafka.connect.data.Schema;
-import org.apache.kafka.connect.data.SchemaBuilder;
 import org.apache.kafka.connect.data.Struct;
 import org.apache.kafka.streams.StreamsBuilder;
 import org.apache.kafka.streams.kstream.Windowed;
@@ -63,9 +62,9 @@ import org.mockito.junit.MockitoJUnitRunner;
 public class KsqlQueryBuilderTest {
 
   private static final PhysicalSchema SOME_SCHEMA = PhysicalSchema.from(
-      LogicalSchema.of(SchemaBuilder.struct()
-          .field("f0", Schema.OPTIONAL_BOOLEAN_SCHEMA)
-          .build()),
+      LogicalSchema.builder()
+          .valueField("f0", SqlTypes.BOOLEAN)
+          .build(),
       SerdeOption.none()
   );
 

--- a/ksql-execution/src/test/java/io/confluent/ksql/execution/plan/LogicalSchemaWithMetaAndKeyFieldsTest.java
+++ b/ksql-execution/src/test/java/io/confluent/ksql/execution/plan/LogicalSchemaWithMetaAndKeyFieldsTest.java
@@ -19,16 +19,15 @@ import static org.hamcrest.Matchers.equalTo;
 import static org.junit.Assert.assertThat;
 
 import io.confluent.ksql.schema.ksql.LogicalSchema;
-import org.apache.kafka.connect.data.Schema;
-import org.apache.kafka.connect.data.SchemaBuilder;
+import io.confluent.ksql.schema.ksql.types.SqlTypes;
 import org.junit.Test;
 
 public class LogicalSchemaWithMetaAndKeyFieldsTest {
   private static final String ALIAS = "alias";
-  private static final LogicalSchema ORIGINAL = LogicalSchema.of(SchemaBuilder.struct()
-      .field("field1", Schema.OPTIONAL_STRING_SCHEMA)
-      .field("field2", Schema.OPTIONAL_INT64_SCHEMA)
-      .build());
+  private static final LogicalSchema ORIGINAL = LogicalSchema.builder()
+      .valueField("field1", SqlTypes.STRING)
+      .valueField("field2", SqlTypes.BIGINT)
+      .build();
 
   private final LogicalSchemaWithMetaAndKeyFields schema
       = LogicalSchemaWithMetaAndKeyFields.fromOriginal(ALIAS, ORIGINAL);

--- a/ksql-functional-tests/src/main/java/io/confluent/ksql/test/model/TopicNode.java
+++ b/ksql-functional-tests/src/main/java/io/confluent/ksql/test/model/TopicNode.java
@@ -23,6 +23,9 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.node.NullNode;
 import io.confluent.connect.avro.AvroData;
 import io.confluent.ksql.schema.ksql.LogicalSchema;
+import io.confluent.ksql.schema.ksql.LogicalSchema.Builder;
+import io.confluent.ksql.schema.ksql.SchemaConverters;
+import io.confluent.ksql.schema.ksql.types.SqlStruct;
 import io.confluent.ksql.serde.Format;
 import io.confluent.ksql.test.TestFrameworkException;
 import io.confluent.ksql.test.serde.SerdeSupplier;
@@ -94,7 +97,14 @@ public final class TopicNode {
     final org.apache.kafka.connect.data.Schema valueSchema = new AvroData(1)
         .toConnectSchema(avroSchema.get());
 
-    return LogicalSchema.of(valueSchema);
+    final SqlStruct valueType = (SqlStruct) SchemaConverters.connectToSqlConverter()
+        .toSqlType(valueSchema);
+
+    final Builder schemaBuilder = LogicalSchema.builder();
+
+    valueType.fields().forEach(schemaBuilder::valueField);
+
+    return schemaBuilder.build();
   }
 
   private static Optional<Schema> buildAvroSchema(final JsonNode schema) {

--- a/ksql-functional-tests/src/main/java/io/confluent/ksql/test/serde/kafka/KafkaSerdeSupplier.java
+++ b/ksql-functional-tests/src/main/java/io/confluent/ksql/test/serde/kafka/KafkaSerdeSupplier.java
@@ -49,7 +49,10 @@ public class KafkaSerdeSupplier implements SerdeSupplier<Object> {
 
   private ConnectSchema getConnectSchema(final boolean isKey) {
     final LogicalSchema schema = schemaSupplier.get();
-    final ConnectSchema connectSchema = isKey ? schema.keySchema() : schema.valueSchema();
+    final ConnectSchema connectSchema = isKey
+        ? schema.keyConnectSchema()
+        : schema.valueConnectSchema();
+
     final List<Field> fields = connectSchema.fields();
     if (fields.isEmpty()) {
       throw new IllegalStateException("No fields in schema");

--- a/ksql-metastore/src/test/java/io/confluent/ksql/metastore/model/KeyFieldTest.java
+++ b/ksql-metastore/src/test/java/io/confluent/ksql/metastore/model/KeyFieldTest.java
@@ -49,9 +49,9 @@ public class KeyFieldTest {
       LegacyField.of("won't find me anywhere", SqlTypes.STRING);
 
   private static final LegacyField LEGACY_FIELD = LegacyField
-      .of(SCHEMA.valueFields().get(0).fullName(), SCHEMA.valueFields().get(0).type());
+      .of(SCHEMA.value().fields().get(0).fullName(), SCHEMA.value().fields().get(0).type());
 
-  private static final Field OTHER_SCHEMA_FIELD = SCHEMA.valueFields().get(1);
+  private static final Field OTHER_SCHEMA_FIELD = SCHEMA.value().fields().get(1);
 
   private static final String SOME_ALIAS = "fred";
 

--- a/ksql-metastore/src/test/java/io/confluent/ksql/metastore/model/MetaStoreMatchers.java
+++ b/ksql-metastore/src/test/java/io/confluent/ksql/metastore/model/MetaStoreMatchers.java
@@ -64,7 +64,7 @@ public final class MetaStoreMatchers {
         (schemaMatcher, "source with value schema", "value schema") {
       @Override
       protected Schema featureValueOf(final DataSource<?> actual) {
-        return actual.getSchema().valueSchema();
+        return actual.getSchema().valueConnectSchema();
       }
     };
   }

--- a/ksql-metastore/src/test/java/io/confluent/ksql/metastore/model/StructuredDataSourceTest.java
+++ b/ksql-metastore/src/test/java/io/confluent/ksql/metastore/model/StructuredDataSourceTest.java
@@ -20,11 +20,10 @@ import static org.mockito.Mockito.verify;
 
 import io.confluent.ksql.execution.ddl.commands.KsqlTopic;
 import io.confluent.ksql.schema.ksql.LogicalSchema;
+import io.confluent.ksql.schema.ksql.types.SqlTypes;
 import io.confluent.ksql.serde.SerdeOption;
 import io.confluent.ksql.util.SchemaUtil;
 import io.confluent.ksql.util.timestamp.TimestampExtractionPolicy;
-import org.apache.kafka.connect.data.Schema;
-import org.apache.kafka.connect.data.SchemaBuilder;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.Mock;
@@ -33,11 +32,9 @@ import org.mockito.junit.MockitoJUnitRunner;
 @RunWith(MockitoJUnitRunner.class)
 public class StructuredDataSourceTest {
 
-  private static final LogicalSchema SOME_SCHEMA = LogicalSchema.of(
-      SchemaBuilder.struct()
-          .field("f0", Schema.OPTIONAL_INT64_SCHEMA)
-          .build()
-  );
+  private static final LogicalSchema SOME_SCHEMA = LogicalSchema.builder()
+      .valueField("f0", SqlTypes.BIGINT)
+      .build();
 
   @Mock
   public KeyField keyField;
@@ -57,12 +54,10 @@ public class StructuredDataSourceTest {
   @Test(expected = IllegalArgumentException.class)
   public void shouldThrowIfSchemaContainsRowTime() {
     // Given:
-    final LogicalSchema schema = LogicalSchema.of(
-        SchemaBuilder.struct()
-            .field(SchemaUtil.ROWTIME_NAME, Schema.OPTIONAL_INT64_SCHEMA)
-            .field("f0", Schema.OPTIONAL_INT64_SCHEMA)
-            .build()
-    );
+    final LogicalSchema schema = LogicalSchema.builder()
+        .valueField(SchemaUtil.ROWTIME_NAME, SqlTypes.BIGINT)
+        .valueField("f0", SqlTypes.BIGINT)
+        .build();
 
     // When:
     new TestStructuredDataSource(
@@ -74,12 +69,10 @@ public class StructuredDataSourceTest {
   @Test(expected = IllegalArgumentException.class)
   public void shouldThrowIfSchemaContainsRowKey() {
     // Given:
-    final LogicalSchema schema = LogicalSchema.of(
-        SchemaBuilder.struct()
-            .field(SchemaUtil.ROWKEY_NAME, Schema.OPTIONAL_STRING_SCHEMA)
-            .field("f0", Schema.OPTIONAL_INT64_SCHEMA)
-            .build()
-    );
+    final LogicalSchema schema = LogicalSchema.builder()
+        .valueField(SchemaUtil.ROWKEY_NAME, SqlTypes.STRING)
+        .valueField("f0", SqlTypes.BIGINT)
+        .build();
 
     // When:
     new TestStructuredDataSource(

--- a/ksql-parser/src/test/java/io/confluent/ksql/parser/KsqlParserTest.java
+++ b/ksql-parser/src/test/java/io/confluent/ksql/parser/KsqlParserTest.java
@@ -32,18 +32,25 @@ import static org.junit.Assert.fail;
 import static org.mockito.Mockito.mock;
 
 import com.google.common.collect.Iterables;
+import io.confluent.ksql.execution.ddl.commands.KsqlTopic;
+import io.confluent.ksql.execution.expression.tree.ArithmeticUnaryExpression;
+import io.confluent.ksql.execution.expression.tree.ComparisonExpression;
+import io.confluent.ksql.execution.expression.tree.Expression;
+import io.confluent.ksql.execution.expression.tree.FunctionCall;
+import io.confluent.ksql.execution.expression.tree.IntegerLiteral;
+import io.confluent.ksql.execution.expression.tree.Literal;
+import io.confluent.ksql.execution.expression.tree.LongLiteral;
+import io.confluent.ksql.execution.expression.tree.SearchedCaseExpression;
+import io.confluent.ksql.execution.expression.tree.StringLiteral;
 import io.confluent.ksql.function.FunctionRegistry;
 import io.confluent.ksql.metastore.MutableMetaStore;
 import io.confluent.ksql.metastore.model.KeyField;
 import io.confluent.ksql.metastore.model.KsqlStream;
 import io.confluent.ksql.metastore.model.KsqlTable;
-import io.confluent.ksql.execution.ddl.commands.KsqlTopic;
 import io.confluent.ksql.parser.KsqlParser.PreparedStatement;
 import io.confluent.ksql.parser.exception.ParseFailedException;
 import io.confluent.ksql.parser.tree.AliasedRelation;
 import io.confluent.ksql.parser.tree.AllColumns;
-import io.confluent.ksql.execution.expression.tree.ArithmeticUnaryExpression;
-import io.confluent.ksql.execution.expression.tree.ComparisonExpression;
 import io.confluent.ksql.parser.tree.CreateConnector;
 import io.confluent.ksql.parser.tree.CreateSource;
 import io.confluent.ksql.parser.tree.CreateStream;
@@ -51,26 +58,19 @@ import io.confluent.ksql.parser.tree.CreateStreamAsSelect;
 import io.confluent.ksql.parser.tree.CreateTable;
 import io.confluent.ksql.parser.tree.DropStream;
 import io.confluent.ksql.parser.tree.DropTable;
-import io.confluent.ksql.execution.expression.tree.Expression;
-import io.confluent.ksql.execution.expression.tree.FunctionCall;
 import io.confluent.ksql.parser.tree.InsertInto;
-import io.confluent.ksql.execution.expression.tree.IntegerLiteral;
 import io.confluent.ksql.parser.tree.Join;
 import io.confluent.ksql.parser.tree.ListProperties;
 import io.confluent.ksql.parser.tree.ListQueries;
 import io.confluent.ksql.parser.tree.ListStreams;
 import io.confluent.ksql.parser.tree.ListTables;
 import io.confluent.ksql.parser.tree.ListTopics;
-import io.confluent.ksql.execution.expression.tree.Literal;
-import io.confluent.ksql.execution.expression.tree.LongLiteral;
 import io.confluent.ksql.parser.tree.Query;
-import io.confluent.ksql.execution.expression.tree.SearchedCaseExpression;
 import io.confluent.ksql.parser.tree.RegisterType;
 import io.confluent.ksql.parser.tree.SelectItem;
 import io.confluent.ksql.parser.tree.SetProperty;
 import io.confluent.ksql.parser.tree.SingleColumn;
 import io.confluent.ksql.parser.tree.Statement;
-import io.confluent.ksql.execution.expression.tree.StringLiteral;
 import io.confluent.ksql.parser.tree.TableElement;
 import io.confluent.ksql.parser.tree.TableElements;
 import io.confluent.ksql.parser.tree.WithinExpression;
@@ -135,7 +135,7 @@ public class KsqlParserTest {
       .valueField("ITEMID", SqlTypes.STRING)
       .valueField("ITEMINFO", SqlTypes
           .struct()
-          .fields(itemInfoSchema.valueFields())
+          .fields(itemInfoSchema.value().fields())
           .build())
       .valueField("ORDERUNITS", SqlTypes.INTEGER)
       .valueField("ARRAYCOL", SqlTypes.array(SqlTypes.DOUBLE))

--- a/ksql-parser/src/test/java/io/confluent/ksql/parser/SqlFormatterTest.java
+++ b/ksql-parser/src/test/java/io/confluent/ksql/parser/SqlFormatterTest.java
@@ -24,6 +24,7 @@ import static org.junit.Assert.assertEquals;
 import static org.mockito.Mockito.mock;
 
 import com.google.common.collect.ImmutableMap;
+import io.confluent.ksql.execution.ddl.commands.KsqlTopic;
 import io.confluent.ksql.execution.expression.tree.ComparisonExpression;
 import io.confluent.ksql.execution.expression.tree.QualifiedName;
 import io.confluent.ksql.execution.expression.tree.StringLiteral;
@@ -33,7 +34,6 @@ import io.confluent.ksql.metastore.MutableMetaStore;
 import io.confluent.ksql.metastore.model.KeyField;
 import io.confluent.ksql.metastore.model.KsqlStream;
 import io.confluent.ksql.metastore.model.KsqlTable;
-import io.confluent.ksql.execution.ddl.commands.KsqlTopic;
 import io.confluent.ksql.parser.exception.ParseFailedException;
 import io.confluent.ksql.parser.properties.with.CreateSourceProperties;
 import io.confluent.ksql.parser.tree.AliasedRelation;
@@ -114,7 +114,7 @@ public class SqlFormatterTest {
       .valueField("ITEMID", SqlTypes.STRING)
       .valueField("ITEMINFO", SqlTypes
           .struct()
-          .fields(itemInfoSchema.valueFields())
+          .fields(itemInfoSchema.value().fields())
           .build())
       .valueField("ORDERUNITS", SqlTypes.INTEGER)
       .valueField("ARRAYCOL", SqlTypes.array(SqlTypes.DOUBLE))

--- a/ksql-parser/src/test/java/io/confluent/ksql/parser/tree/TableElementsTest.java
+++ b/ksql-parser/src/test/java/io/confluent/ksql/parser/tree/TableElementsTest.java
@@ -32,8 +32,6 @@ import io.confluent.ksql.schema.ksql.types.SqlTypes;
 import io.confluent.ksql.util.KsqlException;
 import java.util.List;
 import java.util.stream.Collectors;
-import org.apache.kafka.connect.data.Schema;
-import org.apache.kafka.connect.data.SchemaBuilder;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ExpectedException;
@@ -230,16 +228,11 @@ public class TableElementsTest {
     final LogicalSchema schema = tableElements.toLogicalSchema();
 
     // Then:
-    assertThat(schema, is(LogicalSchema.of(
-        SchemaBuilder
-            .struct()
-            .field("k0", Schema.OPTIONAL_STRING_SCHEMA)
-        .build(),
-        SchemaBuilder
-            .struct()
-            .field("v0", Schema.OPTIONAL_INT32_SCHEMA)
-            .build()
-    )));
+    assertThat(schema, is(LogicalSchema.builder()
+        .keyField("k0", SqlTypes.STRING)
+        .valueField("v0", SqlTypes.INTEGER)
+        .build()
+    ));
   }
 
   private static TableElement tableElement(

--- a/ksql-rest-app/src/main/java/io/confluent/ksql/rest/util/EntityUtil.java
+++ b/ksql-rest-app/src/main/java/io/confluent/ksql/rest/util/EntityUtil.java
@@ -41,10 +41,10 @@ public final class EntityUtil {
 
     final List<FieldInfo> allFields = new ArrayList<>();
     if (!valueSchemaOnly) {
-      allFields.addAll(getFields(schema.metaFields(), "meta"));
-      allFields.addAll(getFields(schema.keyFields(), "key"));
+      allFields.addAll(getFields(schema.metadata().fields(), "meta"));
+      allFields.addAll(getFields(schema.key().fields(), "key"));
     }
-    allFields.addAll(getFields(schema.valueFields(), "value"));
+    allFields.addAll(getFields(schema.value().fields(), "value"));
 
     return allFields;
   }

--- a/ksql-rest-app/src/test/java/io/confluent/ksql/rest/entity/QueryDescriptionFactoryTest.java
+++ b/ksql-rest-app/src/test/java/io/confluent/ksql/rest/entity/QueryDescriptionFactoryTest.java
@@ -28,6 +28,7 @@ import io.confluent.ksql.query.QueryId;
 import io.confluent.ksql.schema.ksql.LogicalSchema;
 import io.confluent.ksql.schema.ksql.PhysicalSchema;
 import io.confluent.ksql.schema.ksql.SqlBaseType;
+import io.confluent.ksql.schema.ksql.types.SqlTypes;
 import io.confluent.ksql.serde.SerdeOption;
 import io.confluent.ksql.util.PersistentQueryMetadata;
 import io.confluent.ksql.util.QueryMetadata;
@@ -38,8 +39,6 @@ import java.util.LinkedHashMap;
 import java.util.Map;
 import java.util.concurrent.LinkedBlockingQueue;
 import java.util.function.Consumer;
-import org.apache.kafka.connect.data.Schema;
-import org.apache.kafka.connect.data.SchemaBuilder;
 import org.apache.kafka.streams.KafkaStreams;
 import org.apache.kafka.streams.Topology;
 import org.apache.kafka.streams.TopologyDescription;
@@ -53,11 +52,10 @@ import org.mockito.junit.MockitoJUnitRunner;
 @RunWith(MockitoJUnitRunner.class)
 public class QueryDescriptionFactoryTest {
 
-  private static final LogicalSchema SOME_SCHEMA = LogicalSchema.of(
-      SchemaBuilder.struct()
-          .field("field1", Schema.OPTIONAL_INT32_SCHEMA)
-          .field("field2", Schema.OPTIONAL_STRING_SCHEMA)
-          .build());
+  private static final LogicalSchema SOME_SCHEMA = LogicalSchema.builder()
+      .valueField("field1", SqlTypes.INTEGER)
+      .valueField("field2", SqlTypes.STRING)
+      .build();
 
   private static final Map<String, Object> STREAMS_PROPS = Collections.singletonMap("k1", "v1");
   private static final Map<String, Object> PROP_OVERRIDES = Collections.singletonMap("k2", "v2");
@@ -182,12 +180,11 @@ public class QueryDescriptionFactoryTest {
   @Test
   public void shouldHandleRowTimeInValueSchemaForTransientQuery() {
     // Given:
-    final LogicalSchema schema = LogicalSchema.of(
-        SchemaBuilder.struct()
-            .field("field1", Schema.OPTIONAL_INT32_SCHEMA)
-            .field("ROWTIME", Schema.OPTIONAL_INT64_SCHEMA)
-            .field("field2", Schema.OPTIONAL_STRING_SCHEMA)
-            .build());
+    final LogicalSchema schema = LogicalSchema.builder()
+        .valueField("field1", SqlTypes.INTEGER)
+        .valueField("ROWTIME", SqlTypes.BIGINT)
+        .valueField("field2", SqlTypes.STRING)
+        .build();
 
     transientQuery = new TransientQueryMetadata(
         SQL_TEXT,
@@ -217,12 +214,11 @@ public class QueryDescriptionFactoryTest {
   @Test
   public void shouldHandleRowKeyInValueSchemaForTransientQuery() {
     // Given:
-    final LogicalSchema schema = LogicalSchema.of(
-        SchemaBuilder.struct()
-            .field("field1", Schema.OPTIONAL_INT32_SCHEMA)
-            .field("ROWKEY", Schema.OPTIONAL_STRING_SCHEMA)
-            .field("field2", Schema.OPTIONAL_STRING_SCHEMA)
-            .build());
+    final LogicalSchema schema = LogicalSchema.builder()
+        .valueField("field1", SqlTypes.INTEGER)
+        .valueField("ROWKEY", SqlTypes.STRING)
+        .valueField("field2", SqlTypes.STRING)
+        .build();
 
     transientQuery = new TransientQueryMetadata(
         SQL_TEXT,

--- a/ksql-rest-app/src/test/java/io/confluent/ksql/rest/entity/SourceDescriptionFactoryTest.java
+++ b/ksql-rest-app/src/test/java/io/confluent/ksql/rest/entity/SourceDescriptionFactoryTest.java
@@ -19,13 +19,14 @@ import static org.hamcrest.CoreMatchers.containsString;
 import static org.junit.Assert.assertThat;
 
 import com.google.common.collect.ImmutableMap;
+import io.confluent.ksql.execution.ddl.commands.KsqlTopic;
 import io.confluent.ksql.metastore.model.DataSource;
 import io.confluent.ksql.metastore.model.KeyField;
 import io.confluent.ksql.metastore.model.KsqlStream;
-import io.confluent.ksql.execution.ddl.commands.KsqlTopic;
 import io.confluent.ksql.metrics.ConsumerCollector;
 import io.confluent.ksql.metrics.StreamsErrorCollector;
 import io.confluent.ksql.schema.ksql.LogicalSchema;
+import io.confluent.ksql.schema.ksql.types.SqlTypes;
 import io.confluent.ksql.serde.Format;
 import io.confluent.ksql.serde.FormatInfo;
 import io.confluent.ksql.serde.KeyFormat;
@@ -40,8 +41,6 @@ import org.apache.kafka.clients.consumer.ConsumerRecord;
 import org.apache.kafka.clients.consumer.ConsumerRecords;
 import org.apache.kafka.common.TopicPartition;
 import org.apache.kafka.common.record.TimestampType;
-import org.apache.kafka.connect.data.Schema;
-import org.apache.kafka.connect.data.SchemaBuilder;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
@@ -66,9 +65,9 @@ public class SourceDescriptionFactoryTest {
   }
 
   private static DataSource<?> buildDataSource(final String kafkaTopicName) {
-    final LogicalSchema schema = LogicalSchema.of(SchemaBuilder.struct()
-        .field("field0", Schema.OPTIONAL_INT32_SCHEMA)
-        .build());
+    final LogicalSchema schema = LogicalSchema.builder()
+        .valueField("field0", SqlTypes.INTEGER)
+        .build();
 
     final KsqlTopic topic = new KsqlTopic(
         kafkaTopicName,
@@ -82,7 +81,7 @@ public class SourceDescriptionFactoryTest {
         "stream",
         schema,
         SerdeOption.none(),
-        KeyField.of(schema.valueFields().get(0).name(), schema.valueFields().get(0)),
+        KeyField.of(schema.value().fields().get(0).name(), schema.value().fields().get(0)),
         new MetadataTimestampExtractionPolicy(),
         topic
     );

--- a/ksql-rest-app/src/test/java/io/confluent/ksql/rest/integration/KsqlResourceFunctionalTest.java
+++ b/ksql-rest-app/src/test/java/io/confluent/ksql/rest/integration/KsqlResourceFunctionalTest.java
@@ -34,6 +34,7 @@ import io.confluent.ksql.rest.entity.SourceDescriptionEntity;
 import io.confluent.ksql.rest.server.TestKsqlRestApp;
 import io.confluent.ksql.schema.ksql.LogicalSchema;
 import io.confluent.ksql.schema.ksql.PhysicalSchema;
+import io.confluent.ksql.schema.ksql.types.SqlTypes;
 import io.confluent.ksql.serde.Format;
 import io.confluent.ksql.serde.SerdeOption;
 import io.confluent.ksql.util.KsqlConstants;
@@ -43,8 +44,6 @@ import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
 import kafka.zookeeper.ZooKeeperClientException;
 import org.apache.kafka.clients.consumer.ConsumerRecord;
-import org.apache.kafka.connect.data.Schema;
-import org.apache.kafka.connect.data.SchemaBuilder;
 import org.hamcrest.Description;
 import org.hamcrest.Matcher;
 import org.hamcrest.TypeSafeMatcher;
@@ -150,10 +149,10 @@ public class KsqlResourceFunctionalTest {
   public void shouldInsertIntoValuesForAvroTopic() throws Exception {
     // Given:
     final PhysicalSchema schema = PhysicalSchema.from(
-        LogicalSchema.of(SchemaBuilder.struct()
-            .field("AUTHOR", Schema.OPTIONAL_STRING_SCHEMA)
-            .field("TITLE", Schema.OPTIONAL_STRING_SCHEMA)
-            .build()),
+        LogicalSchema.builder()
+            .valueField("AUTHOR", SqlTypes.STRING)
+            .valueField("TITLE", SqlTypes.STRING)
+            .build(),
         SerdeOption.none()
     );
 

--- a/ksql-rest-app/src/test/java/io/confluent/ksql/rest/server/StandaloneExecutorFunctionalTest.java
+++ b/ksql-rest-app/src/test/java/io/confluent/ksql/rest/server/StandaloneExecutorFunctionalTest.java
@@ -26,6 +26,7 @@ import io.confluent.ksql.integration.IntegrationTestHarness;
 import io.confluent.ksql.rest.server.computation.ConfigStore;
 import io.confluent.ksql.schema.ksql.LogicalSchema;
 import io.confluent.ksql.schema.ksql.PhysicalSchema;
+import io.confluent.ksql.schema.ksql.types.SqlTypes;
 import io.confluent.ksql.serde.SerdeOption;
 import io.confluent.ksql.services.ServiceContext;
 import io.confluent.ksql.services.TestServiceContext;
@@ -42,8 +43,6 @@ import java.nio.file.Path;
 import java.util.Map;
 import java.util.function.Function;
 import org.apache.kafka.clients.CommonClientConfigs;
-import org.apache.kafka.connect.data.Schema;
-import org.apache.kafka.connect.data.SchemaBuilder;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.BeforeClass;
@@ -158,9 +157,9 @@ public class StandaloneExecutorFunctionalTest {
         + "CREATE STREAM " + s2 + " AS SELECT * FROM S;\n");
 
     final PhysicalSchema dataSchema = PhysicalSchema.from(
-        LogicalSchema.of(SchemaBuilder.struct()
-            .field("ORDERTIME", Schema.OPTIONAL_INT64_SCHEMA)
-            .build()),
+        LogicalSchema.builder()
+            .valueField("ORDERTIME", SqlTypes.BIGINT)
+            .build(),
         SerdeOption.none()
     );
 
@@ -199,9 +198,9 @@ public class StandaloneExecutorFunctionalTest {
         + "CREATE STREAM " + s2 + " AS SELECT * FROM S;\n");
 
     final PhysicalSchema dataSchema = PhysicalSchema.from(
-        LogicalSchema.of(SchemaBuilder.struct()
-            .field("ORDERTIME", Schema.OPTIONAL_INT64_SCHEMA)
-            .build()),
+        LogicalSchema.builder()
+            .valueField("ORDERTIME", SqlTypes.BIGINT)
+            .build(),
         SerdeOption.none()
     );
 
@@ -298,16 +297,12 @@ public class StandaloneExecutorFunctionalTest {
   }
 
   private static void givenIncompatibleSchemaExists(final String topicName) {
-    final LogicalSchema logical = LogicalSchema.of(
-        SchemaBuilder.struct()
-            .field("ORDERID", SchemaBuilder
-                .struct()
-                .field("fred", Schema.OPTIONAL_INT32_SCHEMA)
-                .optional()
-                .build())
-            .field("Other", Schema.OPTIONAL_INT64_SCHEMA)
-            .build()
-    );
+    final LogicalSchema logical = LogicalSchema.builder()
+        .valueField("ORDERID", SqlTypes.struct()
+            .field("fred", SqlTypes.INTEGER)
+            .build())
+        .valueField("Other", SqlTypes.BIGINT)
+        .build();
 
     final PhysicalSchema incompatiblePhysical = PhysicalSchema.from(
         logical,

--- a/ksql-rest-app/src/test/java/io/confluent/ksql/rest/server/TemporaryEngine.java
+++ b/ksql-rest-app/src/test/java/io/confluent/ksql/rest/server/TemporaryEngine.java
@@ -19,6 +19,7 @@ import com.google.common.collect.ImmutableMap;
 import io.confluent.ksql.KsqlConfigTestUtil;
 import io.confluent.ksql.engine.KsqlEngine;
 import io.confluent.ksql.engine.KsqlEngineTestUtil;
+import io.confluent.ksql.execution.ddl.commands.KsqlTopic;
 import io.confluent.ksql.function.InternalFunctionRegistry;
 import io.confluent.ksql.metastore.MetaStoreImpl;
 import io.confluent.ksql.metastore.MutableMetaStore;
@@ -27,9 +28,9 @@ import io.confluent.ksql.metastore.model.DataSource.DataSourceType;
 import io.confluent.ksql.metastore.model.KeyField;
 import io.confluent.ksql.metastore.model.KsqlStream;
 import io.confluent.ksql.metastore.model.KsqlTable;
-import io.confluent.ksql.execution.ddl.commands.KsqlTopic;
 import io.confluent.ksql.parser.DefaultKsqlParser;
 import io.confluent.ksql.schema.ksql.LogicalSchema;
+import io.confluent.ksql.schema.ksql.types.SqlTypes;
 import io.confluent.ksql.serde.Format;
 import io.confluent.ksql.serde.FormatInfo;
 import io.confluent.ksql.serde.KeyFormat;
@@ -39,23 +40,20 @@ import io.confluent.ksql.services.FakeKafkaTopicClient;
 import io.confluent.ksql.services.ServiceContext;
 import io.confluent.ksql.services.TestServiceContext;
 import io.confluent.ksql.statement.ConfiguredStatement;
-import io.confluent.ksql.util.DecimalUtil;
 import io.confluent.ksql.util.KsqlConfig;
 import io.confluent.ksql.util.timestamp.MetadataTimestampExtractionPolicy;
 import io.confluent.rest.RestConfig;
 import java.util.Collections;
 import java.util.HashMap;
-import org.apache.kafka.connect.data.Schema;
-import org.apache.kafka.connect.data.SchemaBuilder;
 import org.junit.rules.ExternalResource;
 
 @SuppressWarnings("OptionalGetWithoutIsPresent")
 public class TemporaryEngine extends ExternalResource {
 
-  public static final LogicalSchema SCHEMA = LogicalSchema.of(SchemaBuilder.struct()
-      .field("val", Schema.OPTIONAL_STRING_SCHEMA)
-      .field("val2", DecimalUtil.builder(2, 1).build())
-      .build());
+  public static final LogicalSchema SCHEMA = LogicalSchema.builder()
+      .valueField("val", SqlTypes.STRING)
+      .valueField("val2", SqlTypes.decimal(2, 1))
+      .build();
 
   private MutableMetaStore metaStore;
 

--- a/ksql-rest-app/src/test/java/io/confluent/ksql/rest/server/resources/KsqlResourceTest.java
+++ b/ksql-rest-app/src/test/java/io/confluent/ksql/rest/server/resources/KsqlResourceTest.java
@@ -67,6 +67,7 @@ import io.confluent.ksql.KsqlExecutionContext;
 import io.confluent.ksql.engine.KsqlEngine;
 import io.confluent.ksql.engine.KsqlEngineTestUtil;
 import io.confluent.ksql.exception.KsqlTopicAuthorizationException;
+import io.confluent.ksql.execution.ddl.commands.KsqlTopic;
 import io.confluent.ksql.execution.expression.tree.QualifiedName;
 import io.confluent.ksql.execution.expression.tree.StringLiteral;
 import io.confluent.ksql.function.InternalFunctionRegistry;
@@ -75,7 +76,6 @@ import io.confluent.ksql.metastore.model.DataSource.DataSourceType;
 import io.confluent.ksql.metastore.model.KeyField;
 import io.confluent.ksql.metastore.model.KsqlStream;
 import io.confluent.ksql.metastore.model.KsqlTable;
-import io.confluent.ksql.execution.ddl.commands.KsqlTopic;
 import io.confluent.ksql.parser.KsqlParser.PreparedStatement;
 import io.confluent.ksql.parser.properties.with.CreateSourceProperties;
 import io.confluent.ksql.parser.tree.CreateStream;
@@ -163,8 +163,6 @@ import org.apache.avro.Schema.Type;
 import org.apache.kafka.clients.consumer.ConsumerConfig;
 import org.apache.kafka.clients.producer.ProducerConfig;
 import org.apache.kafka.common.acl.AclOperation;
-import org.apache.kafka.connect.data.Schema;
-import org.apache.kafka.connect.data.SchemaBuilder;
 import org.apache.kafka.streams.StreamsConfig;
 import org.eclipse.jetty.http.HttpStatus.Code;
 import org.hamcrest.CoreMatchers;
@@ -191,9 +189,9 @@ public class KsqlResourceTest {
       "CREATE STREAM S AS SELECT * FROM test_stream;",
       ImmutableMap.of(ConsumerConfig.AUTO_OFFSET_RESET_CONFIG, "earliest"),
       0L);
-  private static final LogicalSchema SINGLE_FIELD_SCHEMA = LogicalSchema.of(SchemaBuilder.struct()
-      .field("val", Schema.OPTIONAL_STRING_SCHEMA)
-      .build());
+  private static final LogicalSchema SINGLE_FIELD_SCHEMA = LogicalSchema.builder()
+      .valueField("val", SqlTypes.STRING)
+      .build();
 
   private static final ClusterTerminateRequest VALID_TERMINATE_REQUEST =
       new ClusterTerminateRequest(ImmutableList.of("Foo"));
@@ -232,9 +230,9 @@ public class KsqlResourceTest {
       new KsqlConfig(getDefaultKsqlConfig())
   );
 
-  private static final LogicalSchema SOME_SCHEMA = LogicalSchema.of(SchemaBuilder.struct()
-      .field("f1", Schema.OPTIONAL_STRING_SCHEMA)
-      .build());
+  private static final LogicalSchema SOME_SCHEMA = LogicalSchema.builder()
+      .valueField("f1", SqlTypes.STRING)
+      .build();
 
   @Rule
   public final ExpectedException expectedException = ExpectedException.none();
@@ -429,10 +427,10 @@ public class KsqlResourceTest {
   @Test
   public void shouldShowStreamsExtended() {
     // Given:
-    final LogicalSchema schema = LogicalSchema.of(SchemaBuilder.struct()
-        .field("FIELD1", Schema.OPTIONAL_BOOLEAN_SCHEMA)
-        .field("FIELD2", Schema.OPTIONAL_STRING_SCHEMA)
-        .build());
+    final LogicalSchema schema = LogicalSchema.builder()
+        .valueField("FIELD1", SqlTypes.BOOLEAN)
+        .valueField("FIELD2", SqlTypes.STRING)
+        .build();
 
     givenSource(
         DataSourceType.KSTREAM, "new_stream", "new_topic",
@@ -458,10 +456,10 @@ public class KsqlResourceTest {
   @Test
   public void shouldShowTablesExtended() {
     // Given:
-    final LogicalSchema schema = LogicalSchema.of(SchemaBuilder.struct()
-        .field("FIELD1", Schema.OPTIONAL_BOOLEAN_SCHEMA)
-        .field("FIELD2", Schema.OPTIONAL_STRING_SCHEMA)
-        .build());
+    final LogicalSchema schema = LogicalSchema.builder()
+        .valueField("FIELD1", SqlTypes.BOOLEAN)
+        .valueField("FIELD2", SqlTypes.STRING)
+        .build();
 
     givenSource(
         DataSourceType.KTABLE, "new_table", "new_topic",
@@ -2015,17 +2013,17 @@ public class KsqlResourceTest {
   }
 
   private void addTestTopicAndSources() {
-    final LogicalSchema schema1 = LogicalSchema.of(SchemaBuilder.struct()
-            .field("S1_F1", Schema.OPTIONAL_BOOLEAN_SCHEMA)
-            .build());
+    final LogicalSchema schema1 = LogicalSchema.builder()
+        .valueField("S1_F1", SqlTypes.BOOLEAN)
+        .build();
 
     givenSource(
         DataSourceType.KTABLE,
         "TEST_TABLE", "KAFKA_TOPIC_1", schema1);
 
-    final LogicalSchema schema2 = LogicalSchema.of(SchemaBuilder.struct()
-        .field("S2_F1", Schema.OPTIONAL_STRING_SCHEMA)
-        .build());
+    final LogicalSchema schema2 = LogicalSchema.builder()
+        .valueField("S2_F1", SqlTypes.STRING)
+        .build();
 
     givenSource(
         DataSourceType.KSTREAM,
@@ -2054,7 +2052,8 @@ public class KsqlResourceTest {
               sourceName,
               schema,
               SerdeOption.none(),
-              KeyField.of(schema.valueFields().get(0).name(), schema.valueFields().get(0)),
+              KeyField
+                  .of(schema.value().fields().get(0).name(), schema.value().fields().get(0)),
               new MetadataTimestampExtractionPolicy(),
               ksqlTopic
           ));
@@ -2066,7 +2065,8 @@ public class KsqlResourceTest {
               sourceName,
               schema,
               SerdeOption.none(),
-              KeyField.of(schema.valueFields().get(0).name(), schema.valueFields().get(0)),
+              KeyField
+                  .of(schema.value().fields().get(0).name(), schema.value().fields().get(0)),
               new MetadataTimestampExtractionPolicy(),
               ksqlTopic
           ));

--- a/ksql-rest-app/src/test/java/io/confluent/ksql/rest/server/resources/streaming/PollingSubscriptionTest.java
+++ b/ksql-rest-app/src/test/java/io/confluent/ksql/rest/server/resources/streaming/PollingSubscriptionTest.java
@@ -28,12 +28,11 @@ import io.confluent.ksql.rest.server.resources.streaming.Flow.Subscriber;
 import io.confluent.ksql.rest.server.resources.streaming.Flow.Subscription;
 import io.confluent.ksql.rest.server.resources.streaming.StreamingTestUtils.TestSubscriber;
 import io.confluent.ksql.schema.ksql.LogicalSchema;
+import io.confluent.ksql.schema.ksql.types.SqlTypes;
 import java.util.Queue;
 import java.util.concurrent.Executors;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.TimeUnit;
-import org.apache.kafka.connect.data.Schema;
-import org.apache.kafka.connect.data.SchemaBuilder;
 import org.junit.Test;
 
 
@@ -68,10 +67,9 @@ public class PollingSubscriptionTest {
       super(
           MoreExecutors.listeningDecorator(exec),
           subscriber,
-          LogicalSchema.of(SchemaBuilder
-              .struct()
-              .field("f0", Schema.OPTIONAL_STRING_SCHEMA)
-              .build())
+          LogicalSchema.builder()
+              .valueField("f0", SqlTypes.STRING)
+              .build()
       );
     }
 

--- a/ksql-rest-app/src/test/java/io/confluent/ksql/rest/server/resources/streaming/QueryStreamWriterTest.java
+++ b/ksql-rest-app/src/test/java/io/confluent/ksql/rest/server/resources/streaming/QueryStreamWriterTest.java
@@ -33,6 +33,7 @@ import io.confluent.ksql.engine.KsqlEngine;
 import io.confluent.ksql.json.JsonMapper;
 import io.confluent.ksql.physical.LimitHandler;
 import io.confluent.ksql.schema.ksql.LogicalSchema;
+import io.confluent.ksql.schema.ksql.types.SqlTypes;
 import io.confluent.ksql.util.KsqlException;
 import io.confluent.ksql.util.TransientQueryMetadata;
 import java.io.ByteArrayOutputStream;
@@ -43,8 +44,6 @@ import java.util.List;
 import java.util.concurrent.BlockingQueue;
 import java.util.concurrent.TimeUnit;
 import java.util.stream.Collectors;
-import org.apache.kafka.connect.data.Schema;
-import org.apache.kafka.connect.data.SchemaBuilder;
 import org.apache.kafka.streams.KafkaStreams;
 import org.apache.kafka.streams.KafkaStreams.State;
 import org.apache.kafka.streams.KeyValue;
@@ -92,9 +91,9 @@ public class QueryStreamWriterTest {
     drainCapture = newCapture();
     limitHandlerCapture = newCapture();
 
-    final LogicalSchema schema = LogicalSchema.of(SchemaBuilder.struct()
-        .field("col1", Schema.OPTIONAL_STRING_SCHEMA)
-        .build());
+    final LogicalSchema schema = LogicalSchema.builder()
+        .valueField("col1", SqlTypes.STRING)
+        .build();
 
     final KafkaStreams kStreams = niceMock(KafkaStreams.class);
 

--- a/ksql-rest-app/src/test/java/io/confluent/ksql/rest/server/resources/streaming/StreamedQueryResourceTest.java
+++ b/ksql-rest-app/src/test/java/io/confluent/ksql/rest/server/resources/streaming/StreamedQueryResourceTest.java
@@ -56,6 +56,7 @@ import io.confluent.ksql.rest.server.StatementParser;
 import io.confluent.ksql.rest.server.computation.CommandQueue;
 import io.confluent.ksql.rest.server.resources.KsqlRestException;
 import io.confluent.ksql.schema.ksql.LogicalSchema;
+import io.confluent.ksql.schema.ksql.types.SqlTypes;
 import io.confluent.ksql.security.KsqlAuthorizationValidator;
 import io.confluent.ksql.services.KafkaTopicClient;
 import io.confluent.ksql.services.ServiceContext;
@@ -81,7 +82,6 @@ import java.util.function.Consumer;
 import javax.ws.rs.core.Response;
 import javax.ws.rs.core.StreamingOutput;
 import org.apache.kafka.common.acl.AclOperation;
-import org.apache.kafka.connect.data.SchemaBuilder;
 import org.apache.kafka.streams.KafkaStreams;
 import org.apache.kafka.streams.KeyValue;
 import org.apache.kafka.streams.StreamsConfig;
@@ -103,9 +103,9 @@ public class StreamedQueryResourceTest {
 
   private static final Duration DISCONNECT_CHECK_INTERVAL = Duration.ofMillis(1000);
   private static final Duration COMMAND_QUEUE_CATCHUP_TIMOEUT = Duration.ofMillis(1000);
-  private static final LogicalSchema SOME_SCHEMA = LogicalSchema.of(SchemaBuilder.struct()
-      .field("f1", SchemaBuilder.OPTIONAL_INT32_SCHEMA)
-      .build());
+  private static final LogicalSchema SOME_SCHEMA = LogicalSchema.builder()
+      .valueField("f1", SqlTypes.INTEGER)
+      .build();
 
   private static final KsqlConfig VALID_CONFIG = new KsqlConfig(ImmutableMap.of(
       StreamsConfig.APPLICATION_SERVER_CONFIG, "something:1"

--- a/ksql-rest-app/src/test/java/io/confluent/ksql/rest/server/resources/streaming/WebSocketSubscriberTest.java
+++ b/ksql-rest-app/src/test/java/io/confluent/ksql/rest/server/resources/streaming/WebSocketSubscriberTest.java
@@ -23,6 +23,7 @@ import com.google.common.collect.ImmutableMap;
 import io.confluent.ksql.json.JsonMapper;
 import io.confluent.ksql.rest.server.resources.streaming.Flow.Subscription;
 import io.confluent.ksql.schema.ksql.LogicalSchema;
+import io.confluent.ksql.schema.ksql.types.SqlTypes;
 import java.io.IOException;
 import java.util.Map;
 import javax.websocket.CloseReason;
@@ -30,8 +31,6 @@ import javax.websocket.CloseReason.CloseCodes;
 import javax.websocket.RemoteEndpoint.Async;
 import javax.websocket.RemoteEndpoint.Basic;
 import javax.websocket.Session;
-import org.apache.kafka.connect.data.Schema;
-import org.apache.kafka.connect.data.SchemaBuilder;
 import org.easymock.Capture;
 import org.easymock.CaptureType;
 import org.easymock.EasyMock;
@@ -118,10 +117,10 @@ public class WebSocketSubscriberTest {
 
     EasyMock.replay(subscription, session, basic);
 
-    subscriber.onSchema(LogicalSchema.of(SchemaBuilder.struct()
-        .field("currency", Schema.OPTIONAL_STRING_SCHEMA)
-        .field("amount", Schema.OPTIONAL_FLOAT64_SCHEMA)
-        .build()));
+    subscriber.onSchema(LogicalSchema.builder()
+        .valueField("currency", SqlTypes.STRING)
+        .valueField("amount", SqlTypes.DOUBLE)
+        .build());
 
     subscriber.close();
 

--- a/ksql-rest-app/src/test/java/io/confluent/ksql/rest/util/EntityUtilTest.java
+++ b/ksql-rest-app/src/test/java/io/confluent/ksql/rest/util/EntityUtilTest.java
@@ -21,49 +21,46 @@ import static org.junit.Assert.assertThat;
 
 import io.confluent.ksql.rest.entity.FieldInfo;
 import io.confluent.ksql.schema.ksql.LogicalSchema;
+import io.confluent.ksql.schema.ksql.types.SqlType;
+import io.confluent.ksql.schema.ksql.types.SqlTypes;
 import java.util.List;
 import java.util.Optional;
-import org.apache.kafka.connect.data.Schema;
-import org.apache.kafka.connect.data.SchemaBuilder;
 import org.junit.Test;
 
+@SuppressWarnings("OptionalGetWithoutIsPresent")
 public class EntityUtilTest {
 
   @Test
   public void shouldBuildCorrectIntegerField() {
-    shouldBuildCorrectPrimitiveField(Schema.OPTIONAL_INT32_SCHEMA, "INTEGER");
+    shouldBuildCorrectPrimitiveField(SqlTypes.INTEGER, "INTEGER");
   }
 
   @Test
   public void shouldBuildCorrectBigintField() {
-    shouldBuildCorrectPrimitiveField(Schema.OPTIONAL_INT64_SCHEMA, "BIGINT");
+    shouldBuildCorrectPrimitiveField(SqlTypes.BIGINT, "BIGINT");
   }
 
   @Test
   public void shouldBuildCorrectDoubleField() {
-    shouldBuildCorrectPrimitiveField(Schema.OPTIONAL_FLOAT64_SCHEMA, "DOUBLE");
+    shouldBuildCorrectPrimitiveField(SqlTypes.DOUBLE, "DOUBLE");
   }
 
   @Test
   public void shouldBuildCorrectStringField() {
-    shouldBuildCorrectPrimitiveField(Schema.OPTIONAL_STRING_SCHEMA, "STRING");
+    shouldBuildCorrectPrimitiveField(SqlTypes.STRING, "STRING");
   }
 
   @Test
   public void shouldBuildCorrectBooleanField() {
-    shouldBuildCorrectPrimitiveField(Schema.OPTIONAL_BOOLEAN_SCHEMA, "BOOLEAN");
+    shouldBuildCorrectPrimitiveField(SqlTypes.BOOLEAN, "BOOLEAN");
   }
 
   @Test
   public void shouldBuildCorrectMapField() {
     // Given:
-    final LogicalSchema schema = LogicalSchema.of(SchemaBuilder
-        .struct()
-        .field("field", SchemaBuilder
-            .map(Schema.OPTIONAL_STRING_SCHEMA, Schema.OPTIONAL_INT32_SCHEMA)
-            .optional()
-            .build())
-        .build());
+    final LogicalSchema schema = LogicalSchema.builder()
+        .valueField("field", SqlTypes.map(SqlTypes.INTEGER))
+        .build();
 
     // When:
     final List<FieldInfo> fields = EntityUtil.buildSourceSchemaEntity(schema, true);
@@ -80,13 +77,9 @@ public class EntityUtilTest {
   @Test
   public void shouldBuildCorrectArrayField() {
     // Given:
-    final LogicalSchema schema = LogicalSchema.of(SchemaBuilder
-        .struct()
-        .field("field", SchemaBuilder
-            .array(SchemaBuilder.OPTIONAL_INT64_SCHEMA)
-            .optional()
-            .build())
-        .build());
+    final LogicalSchema schema = LogicalSchema.builder()
+        .valueField("field", SqlTypes.array(SqlTypes.BIGINT))
+        .build();
 
     // When:
     final List<FieldInfo> fields = EntityUtil.buildSourceSchemaEntity(schema, true);
@@ -103,16 +96,11 @@ public class EntityUtilTest {
   @Test
   public void shouldBuildCorrectStructField() {
     // Given:
-    final LogicalSchema schema = LogicalSchema.of(SchemaBuilder
-        .struct()
-        .field(
-            "field",
-            SchemaBuilder.
-                struct()
-                .field("innerField", Schema.OPTIONAL_STRING_SCHEMA)
-                .optional()
-                .build())
-        .build());
+    final LogicalSchema schema = LogicalSchema.builder()
+        .valueField("field", SqlTypes.struct()
+            .field("innerField", SqlTypes.STRING)
+            .build())
+        .build();
 
     // When:
     final List<FieldInfo> fields = EntityUtil.buildSourceSchemaEntity(schema, true);
@@ -130,11 +118,10 @@ public class EntityUtilTest {
   @Test
   public void shouldBuildMiltipleFieldsCorrectly() {
     // Given:
-    final LogicalSchema schema = LogicalSchema.of(SchemaBuilder
-        .struct()
-        .field("field1", Schema.OPTIONAL_INT32_SCHEMA)
-        .field("field2", Schema.OPTIONAL_INT64_SCHEMA)
-        .build());
+    final LogicalSchema schema = LogicalSchema.builder()
+        .valueField("field1", SqlTypes.INTEGER)
+        .valueField("field2", SqlTypes.BIGINT)
+        .build();
 
     // When:
     final List<FieldInfo> fields = EntityUtil.buildSourceSchemaEntity(schema, true);
@@ -150,12 +137,11 @@ public class EntityUtilTest {
   @Test
   public void shouldSupportRowTimeAndKeyInValueSchema() {
     // Given:
-    final LogicalSchema schema = LogicalSchema.of(SchemaBuilder
-        .struct()
-        .field("ROWKEY", Schema.OPTIONAL_STRING_SCHEMA)
-        .field("ROWTIME", Schema.OPTIONAL_INT32_SCHEMA)
-        .field("field1", Schema.OPTIONAL_INT32_SCHEMA)
-        .build());
+    final LogicalSchema schema = LogicalSchema.builder()
+        .valueField("ROWKEY", SqlTypes.STRING)
+        .valueField("ROWTIME", SqlTypes.INTEGER)
+        .valueField("field1", SqlTypes.INTEGER)
+        .build();
 
     // When:
     final List<FieldInfo> fields = EntityUtil.buildSourceSchemaEntity(schema, true);
@@ -169,10 +155,9 @@ public class EntityUtilTest {
   @Test
   public void shouldSupportGettingFullSchema() {
     // Given:
-    final LogicalSchema schema = LogicalSchema.of(SchemaBuilder
-        .struct()
-        .field("field1", Schema.OPTIONAL_INT32_SCHEMA)
-        .build());
+    final LogicalSchema schema = LogicalSchema.builder()
+        .valueField("field1", SqlTypes.INTEGER)
+        .build();
 
     // When:
     final List<FieldInfo> fields = EntityUtil.buildSourceSchemaEntity(schema, false);
@@ -187,14 +172,13 @@ public class EntityUtilTest {
   }
 
   private static void shouldBuildCorrectPrimitiveField(
-      final Schema primitiveSchema,
+      final SqlType primitiveSchema,
       final String schemaName
   ) {
     // Given:
-    final LogicalSchema schema = LogicalSchema.of(SchemaBuilder
-        .struct()
-        .field("field", primitiveSchema)
-        .build());
+    final LogicalSchema schema = LogicalSchema.builder()
+        .valueField("field", primitiveSchema)
+        .build();
 
     // When:
     final List<FieldInfo> fields = EntityUtil.buildSourceSchemaEntity(schema, true);

--- a/ksql-rest-app/src/test/java/io/confluent/ksql/rest/util/ProcessingLogServerUtilsTest.java
+++ b/ksql-rest-app/src/test/java/io/confluent/ksql/rest/util/ProcessingLogServerUtilsTest.java
@@ -155,7 +155,7 @@ public class ProcessingLogServerUtilsTest {
     assertThat(stream.getKsqlTopic().getValueFormat().getFormat(), is(Format.JSON));
     assertThat(stream.getKsqlTopic().getKafkaTopicName(), equalTo(topicName));
     assertThat(
-        stream.getSchema().valueFields().stream().map(Field::name).collect(toList()),
+        stream.getSchema().value().fields().stream().map(Field::name).collect(toList()),
         equalTo(
             new ImmutableList.Builder<String>()
                 .addAll(
@@ -168,7 +168,7 @@ public class ProcessingLogServerUtilsTest {
     expected.fields().forEach(
         f -> assertLogSchema(
             f.schema(),
-            stream.getSchema().valueSchema().field(f.name().toUpperCase()).schema(),
+            stream.getSchema().valueConnectSchema().field(f.name().toUpperCase()).schema(),
             ImmutableList.of(f.name())));
   }
 

--- a/ksql-serde/src/main/java/io/confluent/ksql/schema/ksql/PhysicalSchema.java
+++ b/ksql-serde/src/main/java/io/confluent/ksql/schema/ksql/PhysicalSchema.java
@@ -81,8 +81,8 @@ public final class PhysicalSchema {
   ) {
     this.logicalSchema = requireNonNull(logicalSchema, "logicalSchema");
     this.serdeOptions = ImmutableSet.copyOf(requireNonNull(serdeOptions, "serdeOptions"));
-    this.keySchema = buildKeyPhysical(logicalSchema.keySchema());
-    this.valueSchema = buildValuePhysical(logicalSchema.valueSchema(), serdeOptions);
+    this.keySchema = buildKeyPhysical(logicalSchema.keyConnectSchema());
+    this.valueSchema = buildValuePhysical(logicalSchema.valueConnectSchema(), serdeOptions);
   }
 
   @Override

--- a/ksql-serde/src/test/java/io/confluent/ksql/schema/ksql/PhysicalSchemaTest.java
+++ b/ksql-serde/src/test/java/io/confluent/ksql/schema/ksql/PhysicalSchemaTest.java
@@ -20,25 +20,24 @@ import static org.hamcrest.Matchers.is;
 
 import com.google.common.testing.EqualsTester;
 import com.google.common.testing.NullPointerTester;
+import io.confluent.ksql.schema.ksql.types.SqlTypes;
 import io.confluent.ksql.serde.SerdeOption;
 import io.confluent.ksql.test.util.ImmutableTester;
 import io.confluent.ksql.util.KsqlException;
-import org.apache.kafka.connect.data.Schema;
-import org.apache.kafka.connect.data.SchemaBuilder;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ExpectedException;
 
 public class PhysicalSchemaTest {
 
-  private static final LogicalSchema SCHEMA_WITH_MULTIPLE_FIELDS = LogicalSchema.of(SchemaBuilder.struct()
-      .field("f0", Schema.OPTIONAL_BOOLEAN_SCHEMA)
-      .field("f1", Schema.OPTIONAL_BOOLEAN_SCHEMA)
-      .build());
+  private static final LogicalSchema SCHEMA_WITH_MULTIPLE_FIELDS = LogicalSchema.builder()
+      .valueField("f0", SqlTypes.BOOLEAN)
+      .valueField("f1", SqlTypes.BOOLEAN)
+      .build();
 
-  private static final LogicalSchema SCHEMA_WITH_SINGLE_FIELD = LogicalSchema.of(SchemaBuilder.struct()
-      .field("f0", Schema.OPTIONAL_BOOLEAN_SCHEMA)
-      .build());
+  private static final LogicalSchema SCHEMA_WITH_SINGLE_FIELD = LogicalSchema.builder()
+      .valueField("f0", SqlTypes.BOOLEAN)
+      .build();
 
   @Rule
   public final ExpectedException expectedException = ExpectedException.none();
@@ -81,7 +80,7 @@ public class PhysicalSchemaTest {
 
     // Then:
     assertThat(result.valueSchema().serializedSchema(),
-        is(SCHEMA_WITH_MULTIPLE_FIELDS.valueSchema()));
+        is(SCHEMA_WITH_MULTIPLE_FIELDS.valueConnectSchema()));
   }
 
   @Test
@@ -104,7 +103,7 @@ public class PhysicalSchemaTest {
 
     // Then:
     assertThat(result.valueSchema().serializedSchema(),
-        is(SCHEMA_WITH_SINGLE_FIELD.valueSchema()));
+        is(SCHEMA_WITH_SINGLE_FIELD.valueConnectSchema()));
   }
 
   @Test
@@ -115,6 +114,6 @@ public class PhysicalSchemaTest {
 
     // Then:
     assertThat(result.valueSchema().serializedSchema(),
-        is(SCHEMA_WITH_SINGLE_FIELD.valueSchema().fields().get(0).schema()));
+        is(SCHEMA_WITH_SINGLE_FIELD.valueConnectSchema().fields().get(0).schema()));
   }
 }

--- a/ksql-serde/src/test/java/io/confluent/ksql/serde/delimited/KsqlDelimitedSerdeFactoryTest.java
+++ b/ksql-serde/src/test/java/io/confluent/ksql/serde/delimited/KsqlDelimitedSerdeFactoryTest.java
@@ -18,10 +18,10 @@ package io.confluent.ksql.serde.delimited;
 import io.confluent.ksql.schema.ksql.LogicalSchema;
 import io.confluent.ksql.schema.ksql.PersistenceSchema;
 import io.confluent.ksql.schema.ksql.PhysicalSchema;
+import io.confluent.ksql.schema.ksql.types.SqlType;
+import io.confluent.ksql.schema.ksql.types.SqlTypes;
 import io.confluent.ksql.serde.SerdeOption;
 import io.confluent.ksql.util.KsqlException;
-import org.apache.kafka.connect.data.Schema;
-import org.apache.kafka.connect.data.SchemaBuilder;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
@@ -42,10 +42,7 @@ public class KsqlDelimitedSerdeFactoryTest {
   @Test
   public void shouldThrowOnValidateIfArray() {
     // Given:
-    final PersistenceSchema schema = schemaWithFieldOfType(SchemaBuilder
-        .array(Schema.OPTIONAL_STRING_SCHEMA)
-        .optional()
-        .build());
+    final PersistenceSchema schema = schemaWithFieldOfType(SqlTypes.array(SqlTypes.STRING));
 
     // Then:
     expectedException.expect(KsqlException.class);
@@ -58,10 +55,7 @@ public class KsqlDelimitedSerdeFactoryTest {
   @Test
   public void shouldThrowOnValidateIfMap() {
     // Given:
-    final PersistenceSchema schema = schemaWithFieldOfType(SchemaBuilder
-        .map(Schema.OPTIONAL_STRING_SCHEMA, Schema.OPTIONAL_STRING_SCHEMA)
-        .optional()
-        .build());
+    final PersistenceSchema schema = schemaWithFieldOfType(SqlTypes.map(SqlTypes.STRING));
 
     // Then:
     expectedException.expect(KsqlException.class);
@@ -74,11 +68,10 @@ public class KsqlDelimitedSerdeFactoryTest {
   @Test
   public void shouldThrowOnValidateIfStruct() {
     // Given:
-    final PersistenceSchema schema = schemaWithFieldOfType(SchemaBuilder
-        .struct()
-        .field("f0", Schema.OPTIONAL_STRING_SCHEMA)
-        .optional()
-        .build());
+    final PersistenceSchema schema = schemaWithFieldOfType(SqlTypes.struct()
+        .field("f0", SqlTypes.STRING)
+        .build()
+    );
 
     // Then:
     expectedException.expect(KsqlException.class);
@@ -88,14 +81,13 @@ public class KsqlDelimitedSerdeFactoryTest {
     factory.validate(schema);
   }
 
-  private static PersistenceSchema schemaWithFieldOfType(final Schema fieldSchema) {
-    final Schema connectSchema = SchemaBuilder
-        .struct()
-        .field("f0", fieldSchema)
+  private static PersistenceSchema schemaWithFieldOfType(final SqlType fieldSchema) {
+    final LogicalSchema schema = LogicalSchema.builder()
+        .keyField("k0", fieldSchema)
+        .valueField("v0", fieldSchema)
         .build();
 
-    final LogicalSchema logicalSchema = LogicalSchema.of(connectSchema, connectSchema);
-    final PhysicalSchema physicalSchema = PhysicalSchema.from(logicalSchema, SerdeOption.none());
+    final PhysicalSchema physicalSchema = PhysicalSchema.from(schema, SerdeOption.none());
     return physicalSchema.valueSchema();
   }
 }

--- a/ksql-streams/src/main/java/io/confluent/ksql/execution/streams/StreamSourceBuilder.java
+++ b/ksql-streams/src/main/java/io/confluent/ksql/execution/streams/StreamSourceBuilder.java
@@ -141,10 +141,10 @@ public final class StreamSourceBuilder {
 
   private static org.apache.kafka.connect.data.Field getKeySchemaSingleField(
       final LogicalSchema schema) {
-    if (schema.keySchema().fields().size() != 1) {
+    if (schema.keyConnectSchema().fields().size() != 1) {
       throw new IllegalStateException("Only single key fields are currently supported");
     }
-    return schema.keySchema().fields().get(0);
+    return schema.keyConnectSchema().fields().get(0);
   }
 
   private static ValueMapperWithKey<Windowed<Struct>, GenericRow, GenericRow> windowedMapper(

--- a/ksql-streams/src/test/java/io/confluent/ksql/execution/streams/StreamSourceBuilderTest.java
+++ b/ksql-streams/src/test/java/io/confluent/ksql/execution/streams/StreamSourceBuilderTest.java
@@ -38,6 +38,7 @@ import io.confluent.ksql.execution.plan.LogicalSchemaWithMetaAndKeyFields;
 import io.confluent.ksql.execution.plan.StreamSource;
 import io.confluent.ksql.schema.ksql.LogicalSchema;
 import io.confluent.ksql.schema.ksql.PhysicalSchema;
+import io.confluent.ksql.schema.ksql.types.SqlTypes;
 import io.confluent.ksql.serde.FormatInfo;
 import io.confluent.ksql.serde.KeyFormat;
 import io.confluent.ksql.serde.KeySerde;
@@ -78,10 +79,11 @@ import org.mockito.junit.MockitoRule;
 
 
 public class StreamSourceBuilderTest {
-  private static final LogicalSchema SOURCE_SCHEMA = LogicalSchema.of(SchemaBuilder.struct()
-      .field("field1", Schema.OPTIONAL_STRING_SCHEMA)
-      .field("field2", Schema.OPTIONAL_INT64_SCHEMA)
-      .build());
+
+  private static final LogicalSchema SOURCE_SCHEMA = LogicalSchema.builder()
+      .valueField("field1", SqlTypes.STRING)
+      .valueField("field2", SqlTypes.BIGINT)
+      .build();
   private static final Schema KEY_SCHEMA = SchemaBuilder.struct()
       .field("k1", Schema.OPTIONAL_STRING_SCHEMA)
       .build();
@@ -309,7 +311,6 @@ public class StreamSourceBuilderTest {
   }
 
   @Test
-  @SuppressWarnings("unchecked")
   public void shouldThrowOnMultiFieldKey() {
     // Given:
     final StreamSource<KStream<?, GenericRow>> streamSource = new StreamSource<>(
@@ -319,13 +320,11 @@ public class StreamSourceBuilderTest {
         extractionPolicy,
         TIMESTAMP_IDX,
         offsetReset,
-        LogicalSchema.of(
-            SchemaBuilder.struct()
-                .field("f1", Schema.INT32_SCHEMA)
-                .field( "f2", Schema.INT64_SCHEMA)
-                .build(),
-            SCHEMA.valueSchema()
-        ),
+        LogicalSchema.builder()
+            .keyField("f1", SqlTypes.INTEGER)
+            .keyField("f2", SqlTypes.BIGINT)
+            .valueFields(SCHEMA.value().fields())
+            .build(),
         StreamSourceBuilder::buildUnwindowed
     );
 


### PR DESCRIPTION
### Description 

Refactored to:
- internally use `SqlStruct` rather than `List<Field>`
- as this allows us to expose `SqlStruct` schemas for metadata, key and value
- also remove old factor methods that take Connect `Schema`, which were only used in tests. Replace with builder.

BIG change - but it's all just changing test code to use the builder, rather than the old `of` factory method.

#### How to review:

1. Review changes to `LogicalSchema`.
1. Review changes to `KsqlStruct`.

All the rest is just noise.

### Testing done 
_Describe the testing strategy. Unit and integration tests are expected for any behavior changes._

### Reviewer checklist
- [ ] Ensure docs are updated if necessary. (eg. if a user visible feature is being added or changed).
- [ ] Ensure relevant issues are linked (description should include text like "Fixes #<issue number>")

