### PR TITLE
feat: add jackson annotations for exec plans

### DIFF
--- a/ksql-common/src/main/java/io/confluent/ksql/query/QueryId.java
+++ b/ksql-common/src/main/java/io/confluent/ksql/query/QueryId.java
@@ -24,11 +24,13 @@ import java.util.Objects;
 
 @Immutable
 public class QueryId {
+  private static final String ID = "id";
 
+  @JsonProperty(ID)
   private final String id;
 
   @JsonCreator
-  public QueryId(@JsonProperty("id") final String id) {
+  public QueryId(@JsonProperty(ID) final String id) {
     this.id = requireNonNull(id, "id");
   }
 

--- a/ksql-common/src/main/java/io/confluent/ksql/schema/ksql/Field.java
+++ b/ksql-common/src/main/java/io/confluent/ksql/schema/ksql/Field.java
@@ -15,6 +15,8 @@
 
 package io.confluent.ksql.schema.ksql;
 
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
 import com.google.errorprone.annotations.Immutable;
 import io.confluent.ksql.schema.ksql.types.SqlType;
 import io.confluent.ksql.util.SchemaUtil;
@@ -26,11 +28,18 @@ import java.util.Optional;
  */
 @Immutable
 public final class Field {
+  private static final String SOURCE = "source";
+  private static final String NAME = "name";
+  private static final String TYPE = "type";
 
+  @JsonProperty(SOURCE)
   private final Optional<String> source;
-  private final String fullName;
+  @JsonProperty(NAME)
   private final String name;
+  @JsonProperty(TYPE)
   private final SqlType type;
+
+  private transient final String fullName;
 
   /**
    * @param name the name of the field.
@@ -61,7 +70,11 @@ public final class Field {
     return new Field(source, name, type);
   }
 
-  private Field(final Optional<String> source, final String name, final SqlType type) {
+  @JsonCreator
+  private Field(
+      @JsonProperty(SOURCE) final Optional<String> source,
+      @JsonProperty(NAME) final String name,
+      @JsonProperty(TYPE) final SqlType type) {
     this.source = Objects.requireNonNull(source, "source");
     this.name = Objects.requireNonNull(name, "name");
     this.type = Objects.requireNonNull(type, "type");

--- a/ksql-common/src/main/java/io/confluent/ksql/schema/ksql/LogicalSchema.java
+++ b/ksql-common/src/main/java/io/confluent/ksql/schema/ksql/LogicalSchema.java
@@ -17,6 +17,8 @@ package io.confluent.ksql.schema.ksql;
 
 import static java.util.Objects.requireNonNull;
 
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
 import com.google.common.collect.ImmutableList;
 import com.google.errorprone.annotations.Immutable;
 import io.confluent.ksql.schema.ksql.SchemaConverters.ConnectToSqlTypeConverter;
@@ -43,6 +45,9 @@ import org.apache.kafka.connect.data.SchemaBuilder;
  */
 @Immutable
 public final class LogicalSchema {
+  private static final String FIELD_META_FIELDS = "metaFields";
+  private static final String FIELD_KEY_FIELDS = "keyFields";
+  private static final String FIELD_VALUE_FIELDS = "valueFields";
 
   private static final String KEY_KEYWORD = "KEY";
 
@@ -54,8 +59,11 @@ public final class LogicalSchema {
       Field.of(SchemaUtil.ROWKEY_NAME, SqlTypes.STRING)
   );
 
+  @JsonProperty(FIELD_META_FIELDS)
   private final List<Field> metaFields;
+  @JsonProperty(FIELD_KEY_FIELDS)
   private final List<Field> keyFields;
+  @JsonProperty(FIELD_VALUE_FIELDS)
   private final List<Field> valueFields;
 
   public static Builder builder() {
@@ -76,10 +84,11 @@ public final class LogicalSchema {
     return new LogicalSchema(META_FIELDS, keyFields, valueFields);
   }
 
+  @JsonCreator
   public LogicalSchema(
-      final List<Field> metaFields,
-      final List<Field> keyFields,
-      final List<Field> valueFields
+      @JsonProperty(FIELD_META_FIELDS) final List<Field> metaFields,
+      @JsonProperty(FIELD_KEY_FIELDS) final List<Field> keyFields,
+      @JsonProperty(FIELD_VALUE_FIELDS) final List<Field> valueFields
   ) {
     this.metaFields = ImmutableList.copyOf(requireNonNull(metaFields, "metaFields"));
     this.keyFields = ImmutableList.copyOf(requireNonNull(keyFields, "keyFields"));

--- a/ksql-common/src/main/java/io/confluent/ksql/schema/ksql/types/SqlArray.java
+++ b/ksql-common/src/main/java/io/confluent/ksql/schema/ksql/types/SqlArray.java
@@ -17,6 +17,8 @@ package io.confluent.ksql.schema.ksql.types;
 
 import static java.util.Objects.requireNonNull;
 
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
 import com.google.errorprone.annotations.Immutable;
 import io.confluent.ksql.schema.ksql.FormatOptions;
 import io.confluent.ksql.schema.ksql.SqlBaseType;
@@ -24,14 +26,17 @@ import java.util.Objects;
 
 @Immutable
 public final class SqlArray extends SqlType {
+  private static final String ITEM_TYPE = "itemType";
 
+  @JsonProperty(ITEM_TYPE)
   private final SqlType itemType;
 
   public static SqlArray of(final SqlType itemType) {
     return new SqlArray(itemType);
   }
 
-  private SqlArray(final SqlType itemType) {
+  @JsonCreator
+  private SqlArray(@JsonProperty(ITEM_TYPE) final SqlType itemType) {
     super(SqlBaseType.ARRAY);
     this.itemType = requireNonNull(itemType, "itemType");
   }

--- a/ksql-common/src/main/java/io/confluent/ksql/schema/ksql/types/SqlDecimal.java
+++ b/ksql-common/src/main/java/io/confluent/ksql/schema/ksql/types/SqlDecimal.java
@@ -15,6 +15,8 @@
 
 package io.confluent.ksql.schema.ksql.types;
 
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
 import com.google.errorprone.annotations.Immutable;
 import io.confluent.ksql.schema.ksql.FormatOptions;
 import io.confluent.ksql.schema.ksql.SqlBaseType;
@@ -23,15 +25,22 @@ import java.util.Objects;
 
 @Immutable
 public final class SqlDecimal extends SqlType {
+  private static final String PRECISION = "precision";
+  private static final String SCALE = "scale";
 
+  @JsonProperty(PRECISION)
   private final int precision;
+  @JsonProperty(SCALE)
   private final int scale;
 
   public static SqlDecimal of(final int precision, final int scale) {
     return new SqlDecimal(precision, scale);
   }
 
-  private SqlDecimal(final int precision, final int scale) {
+  @JsonCreator
+  private SqlDecimal(
+      @JsonProperty(PRECISION) final int precision,
+      @JsonProperty(SCALE) final int scale) {
     super(SqlBaseType.DECIMAL);
     this.precision = precision;
     this.scale = scale;

--- a/ksql-common/src/main/java/io/confluent/ksql/schema/ksql/types/SqlMap.java
+++ b/ksql-common/src/main/java/io/confluent/ksql/schema/ksql/types/SqlMap.java
@@ -17,6 +17,8 @@ package io.confluent.ksql.schema.ksql.types;
 
 import static java.util.Objects.requireNonNull;
 
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
 import com.google.errorprone.annotations.Immutable;
 import io.confluent.ksql.schema.ksql.FormatOptions;
 import io.confluent.ksql.schema.ksql.SqlBaseType;
@@ -24,14 +26,17 @@ import java.util.Objects;
 
 @Immutable
 public final class SqlMap extends SqlType {
+  private static final String VALUE_TYPE = "valueType";
 
+  @JsonProperty(VALUE_TYPE)
   private final SqlType valueType;
 
   public static SqlMap of(final SqlType valueType) {
     return new SqlMap(valueType);
   }
 
-  private SqlMap(final SqlType valueType) {
+  @JsonCreator
+  private SqlMap(@JsonProperty(VALUE_TYPE) final SqlType valueType) {
     super(SqlBaseType.MAP);
     this.valueType = requireNonNull(valueType, "valueType");
   }

--- a/ksql-common/src/main/java/io/confluent/ksql/schema/ksql/types/SqlPrimitiveType.java
+++ b/ksql-common/src/main/java/io/confluent/ksql/schema/ksql/types/SqlPrimitiveType.java
@@ -15,6 +15,8 @@
 
 package io.confluent.ksql.schema.ksql.types;
 
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
 import com.google.errorprone.annotations.Immutable;
@@ -65,7 +67,8 @@ public final class SqlPrimitiveType extends SqlType {
     }
   }
 
-  public static SqlPrimitiveType of(final SqlBaseType sqlType) {
+  @JsonCreator
+  public static SqlPrimitiveType of(@JsonProperty(BASE_TYPE) final SqlBaseType sqlType) {
     final SqlPrimitiveType primitive = TYPES.get(Objects.requireNonNull(sqlType, "sqlType"));
     if (primitive == null) {
       throw new KsqlException("Invalid primitive type: " + sqlType);

--- a/ksql-common/src/main/java/io/confluent/ksql/schema/ksql/types/SqlStruct.java
+++ b/ksql-common/src/main/java/io/confluent/ksql/schema/ksql/types/SqlStruct.java
@@ -17,6 +17,8 @@ package io.confluent.ksql.schema.ksql.types;
 
 import static java.util.Objects.requireNonNull;
 
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
 import com.google.common.collect.ImmutableList;
 import com.google.errorprone.annotations.Immutable;
 import io.confluent.ksql.schema.ksql.Field;
@@ -30,14 +32,17 @@ import java.util.stream.Collectors;
 
 @Immutable
 public final class SqlStruct extends SqlType {
+  private static final String FIELDS = "fields";
 
+  @JsonProperty(FIELDS)
   private final ImmutableList<Field> fields;
 
   public static Builder builder() {
     return new Builder();
   }
 
-  private SqlStruct(final List<Field> fields) {
+  @JsonCreator
+  private SqlStruct(@JsonProperty(FIELDS) final List<Field> fields) {
     super(SqlBaseType.STRUCT);
     this.fields = ImmutableList.copyOf(requireNonNull(fields, "fields"));
   }

--- a/ksql-common/src/main/java/io/confluent/ksql/schema/ksql/types/SqlType.java
+++ b/ksql-common/src/main/java/io/confluent/ksql/schema/ksql/types/SqlType.java
@@ -15,6 +15,11 @@
 
 package io.confluent.ksql.schema.ksql.types;
 
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonSubTypes;
+import com.fasterxml.jackson.annotation.JsonSubTypes.Type;
+import com.fasterxml.jackson.annotation.JsonTypeInfo;
+import com.fasterxml.jackson.annotation.JsonTypeInfo.As;
 import com.google.errorprone.annotations.Immutable;
 import io.confluent.ksql.schema.ksql.FormatOptions;
 import io.confluent.ksql.schema.ksql.SqlBaseType;
@@ -24,8 +29,21 @@ import java.util.Objects;
  * Base for all SQL types in KSQL.
  */
 @Immutable
+@JsonTypeInfo(
+    use = JsonTypeInfo.Id.NAME,
+    include = As.WRAPPER_OBJECT
+)
+@JsonSubTypes({
+    @Type(value = SqlPrimitiveType.class, name = "primitive"),
+    @Type(value = SqlStruct.class, name = "struct"),
+    @Type(value = SqlArray.class, name = "array"),
+    @Type(value = SqlMap.class, name = "map"),
+    @Type(value = SqlDecimal.class, name = "decimal")
+})
 public abstract class SqlType {
+  static final String BASE_TYPE = "baseType";
 
+  @JsonProperty(BASE_TYPE)
   private final SqlBaseType baseType;
 
   SqlType(final SqlBaseType baseType) {

--- a/ksql-common/src/main/java/io/confluent/ksql/serde/FormatInfo.java
+++ b/ksql-common/src/main/java/io/confluent/ksql/serde/FormatInfo.java
@@ -15,6 +15,8 @@
 
 package io.confluent.ksql.serde;
 
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
 import com.google.errorprone.annotations.Immutable;
 import io.confluent.ksql.util.KsqlException;
 import java.util.Objects;
@@ -25,8 +27,12 @@ import java.util.Optional;
  */
 @Immutable
 public final class FormatInfo {
+  private static final String FORMAT = "format";
+  private static final String AVRO_SCHEMA_FULL_NAME = "avroSchemaFullName";
 
+  @JsonProperty(FORMAT)
   private final Format format;
+  @JsonProperty(AVRO_SCHEMA_FULL_NAME)
   private final Optional<String> avroFullSchemaName;
 
   public static FormatInfo of(final Format format) {
@@ -40,9 +46,10 @@ public final class FormatInfo {
     return new FormatInfo(format, avroFullSchemaName);
   }
 
+  @JsonCreator
   private FormatInfo(
-      final Format format,
-      final Optional<String> avroFullSchemaName
+      @JsonProperty(FORMAT) final Format format,
+      @JsonProperty(AVRO_SCHEMA_FULL_NAME) final Optional<String> avroFullSchemaName
   ) {
     this.format = Objects.requireNonNull(format, "format");
     this.avroFullSchemaName = Objects.requireNonNull(avroFullSchemaName, "avroFullSchemaName");

--- a/ksql-common/src/main/java/io/confluent/ksql/serde/KeyFormat.java
+++ b/ksql-common/src/main/java/io/confluent/ksql/serde/KeyFormat.java
@@ -15,6 +15,8 @@
 
 package io.confluent.ksql.serde;
 
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
 import com.google.errorprone.annotations.Immutable;
 import io.confluent.ksql.model.WindowType;
 import java.time.Duration;
@@ -26,8 +28,12 @@ import java.util.Optional;
  */
 @Immutable
 public final class KeyFormat {
+  private static final String FORMAT_INFO = "formatInfo";
+  private static final String WINDOW_INFO = "windowInfo";
 
+  @JsonProperty(FORMAT_INFO)
   private final FormatInfo format;
+  @JsonProperty(WINDOW_INFO)
   private final Optional<WindowInfo> window;
 
   public static KeyFormat nonWindowed(final FormatInfo format) {
@@ -52,9 +58,10 @@ public final class KeyFormat {
     return new KeyFormat(format, Optional.of(windowInfo));
   }
 
+  @JsonCreator
   private KeyFormat(
-      final FormatInfo format,
-      final Optional<WindowInfo> window
+      @JsonProperty(FORMAT_INFO) final FormatInfo format,
+      @JsonProperty(WINDOW_INFO) final Optional<WindowInfo> window
   ) {
     this.format = Objects.requireNonNull(format, "format");
     this.window = Objects.requireNonNull(window, "window");

--- a/ksql-common/src/main/java/io/confluent/ksql/serde/ValueFormat.java
+++ b/ksql-common/src/main/java/io/confluent/ksql/serde/ValueFormat.java
@@ -15,6 +15,8 @@
 
 package io.confluent.ksql.serde;
 
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
 import com.google.errorprone.annotations.Immutable;
 import java.util.Objects;
 
@@ -23,7 +25,9 @@ import java.util.Objects;
  */
 @Immutable
 public final class ValueFormat {
+  private final static String FORMAT = "format";
 
+  @JsonProperty(FORMAT)
   private final FormatInfo format;
 
   public static ValueFormat of(
@@ -32,9 +36,8 @@ public final class ValueFormat {
     return new ValueFormat(format);
   }
 
-  private ValueFormat(
-      final FormatInfo format
-  ) {
+  @JsonCreator
+  private ValueFormat(@JsonProperty(FORMAT) final FormatInfo format) {
     this.format = Objects.requireNonNull(format, "format");
   }
 

--- a/ksql-common/src/main/java/io/confluent/ksql/serde/WindowInfo.java
+++ b/ksql-common/src/main/java/io/confluent/ksql/serde/WindowInfo.java
@@ -15,6 +15,8 @@
 
 package io.confluent.ksql.serde;
 
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
 import com.google.errorprone.annotations.Immutable;
 import io.confluent.ksql.model.WindowType;
 import java.time.Duration;
@@ -26,15 +28,22 @@ import java.util.Optional;
  */
 @Immutable
 public final class WindowInfo {
+  private static final String TYPE = "type";
+  private static final String SIZE = "size";
 
+  @JsonProperty(TYPE)
   private final WindowType type;
+  @JsonProperty(SIZE)
   private final Optional<Duration> size;
 
   public static WindowInfo of(final WindowType type, final Optional<Duration> size) {
     return new WindowInfo(type, size);
   }
 
-  private WindowInfo(final WindowType type, final Optional<Duration> size) {
+  @JsonCreator
+  private WindowInfo(
+      @JsonProperty(TYPE) final WindowType type,
+      @JsonProperty(SIZE) final Optional<Duration> size) {
     this.type = Objects.requireNonNull(type, "type");
     this.size = Objects.requireNonNull(size, "size");
 

--- a/ksql-common/src/main/java/io/confluent/ksql/util/timestamp/LongColumnTimestampExtractionPolicy.java
+++ b/ksql-common/src/main/java/io/confluent/ksql/util/timestamp/LongColumnTimestampExtractionPolicy.java
@@ -23,12 +23,14 @@ import org.apache.kafka.streams.processor.TimestampExtractor;
 
 @Immutable
 public class LongColumnTimestampExtractionPolicy implements TimestampExtractionPolicy {
+  private static final String TIMESTAMP_FIELD = "timestampField";
 
+  @JsonProperty(TIMESTAMP_FIELD)
   private final String timestampField;
 
   @JsonCreator
   public LongColumnTimestampExtractionPolicy(
-      @JsonProperty("timestampField") final String timestampField) {
+      @JsonProperty(TIMESTAMP_FIELD) final String timestampField) {
     Objects.requireNonNull(timestampField, "timestampField can't be null");
     this.timestampField = timestampField;
   }

--- a/ksql-common/src/main/java/io/confluent/ksql/util/timestamp/StringTimestampExtractionPolicy.java
+++ b/ksql-common/src/main/java/io/confluent/ksql/util/timestamp/StringTimestampExtractionPolicy.java
@@ -23,14 +23,18 @@ import org.apache.kafka.streams.processor.TimestampExtractor;
 
 @Immutable
 public class StringTimestampExtractionPolicy implements TimestampExtractionPolicy {
+  private static final String TIMESTAMP_FIELD = "timestampField";
+  private static final String FORMAT = "format";
 
+  @JsonProperty(TIMESTAMP_FIELD)
   private final String timestampField;
+  @JsonProperty(FORMAT)
   private final String format;
 
   @JsonCreator
   public StringTimestampExtractionPolicy(
-      @JsonProperty("timestampField") final String timestampField,
-      @JsonProperty("format") final String format) {
+      @JsonProperty(TIMESTAMP_FIELD) final String timestampField,
+      @JsonProperty(FORMAT) final String format) {
     Objects.requireNonNull(timestampField, "timestampField can't be null");
     Objects.requireNonNull(format, "format can't be null");
     this.timestampField = timestampField;

--- a/ksql-common/src/main/java/io/confluent/ksql/util/timestamp/TimestampExtractionPolicy.java
+++ b/ksql-common/src/main/java/io/confluent/ksql/util/timestamp/TimestampExtractionPolicy.java
@@ -15,10 +15,23 @@
 
 package io.confluent.ksql.util.timestamp;
 
+import com.fasterxml.jackson.annotation.JsonSubTypes;
+import com.fasterxml.jackson.annotation.JsonSubTypes.Type;
+import com.fasterxml.jackson.annotation.JsonTypeInfo;
+import com.fasterxml.jackson.annotation.JsonTypeInfo.As;
 import com.google.errorprone.annotations.Immutable;
 import org.apache.kafka.streams.processor.TimestampExtractor;
 
 @Immutable
+@JsonTypeInfo(
+    use = JsonTypeInfo.Id.NAME,
+    include = As.WRAPPER_OBJECT
+)
+@JsonSubTypes({
+    @Type(value = MetadataTimestampExtractionPolicy.class, name = "metadata"),
+    @Type(value = StringTimestampExtractionPolicy.class, name = "stringColumn"),
+    @Type(value = LongColumnTimestampExtractionPolicy.class, name = "longColumn")
+})
 public interface TimestampExtractionPolicy {
 
   TimestampExtractor create(int columnIndex);

--- a/ksql-engine/src/main/java/io/confluent/ksql/structured/SchemaKStream.java
+++ b/ksql-engine/src/main/java/io/confluent/ksql/structured/SchemaKStream.java
@@ -108,8 +108,8 @@ public class SchemaKStream<K> {
       final KeyFormat keyFormat,
       final KeySerde<K> keySerde,
       final StreamSource<KStream<K, GenericRow>> streamSource,
-      final KeyField keyField) {
-    final KStream<K, GenericRow> kstream = streamSource.build(builder);
+      final KeyField keyField,
+      final KStream<K, GenericRow> kstream) {
     return new SchemaKStream<>(
         kstream,
         streamSource,
@@ -148,7 +148,8 @@ public class SchemaKStream<K> {
           topic.getKeyFormat(),
           StreamSourceBuilder.getWindowedKeySerde(builder, step),
           step,
-          keyField);
+          keyField,
+          StreamSourceBuilder.buildWindowed(builder, step));
     } else {
       final StreamSource<KStream<Struct, GenericRow>> step = streamSource(
           contextStacker,
@@ -164,7 +165,8 @@ public class SchemaKStream<K> {
           topic.getKeyFormat(),
           StreamSourceBuilder.getKeySerde(builder, step),
           step,
-          keyField);
+          keyField,
+          StreamSourceBuilder.buildUnwindowed(builder, step));
     }
   }
 

--- a/ksql-execution/pom.xml
+++ b/ksql-execution/pom.xml
@@ -48,6 +48,12 @@
             <artifactId>connect-runtime</artifactId>
         </dependency>
 
+        <dependency>
+            <groupId>com.fasterxml.jackson.datatype</groupId>
+            <artifactId>jackson-datatype-jsr310</artifactId>
+            <version>${jackson.version}</version>
+        </dependency>
+
         <!-- Required for running tests -->
 
         <dependency>

--- a/ksql-execution/src/main/java/io/confluent/ksql/execution/context/QueryContext.java
+++ b/ksql-execution/src/main/java/io/confluent/ksql/execution/context/QueryContext.java
@@ -15,6 +15,8 @@
 
 package io.confluent.ksql.execution.context;
 
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
 import com.google.common.collect.ImmutableList;
 import io.confluent.ksql.query.QueryId;
 import java.util.Arrays;
@@ -23,14 +25,22 @@ import java.util.List;
 import java.util.Objects;
 
 public final class QueryContext {
+  private static final String QUERY_ID = "queryId";
+  private static final String CONTEXT = "context";
+
+  @JsonProperty(QUERY_ID)
   private final QueryId queryId;
+  @JsonProperty(CONTEXT)
   private final List<String> context;
 
   private QueryContext(final QueryId queryId) {
     this(queryId, Collections.emptyList());
   }
 
-  private QueryContext(final QueryId queryId, final List<String> context) {
+  @JsonCreator
+  private QueryContext(
+      @JsonProperty(QUERY_ID) final QueryId queryId,
+      @JsonProperty(CONTEXT) final List<String> context) {
     this.queryId = Objects.requireNonNull(queryId);
     this.context = Objects.requireNonNull(context);
   }

--- a/ksql-execution/src/main/java/io/confluent/ksql/execution/ddl/commands/CreateSourceCommand.java
+++ b/ksql-execution/src/main/java/io/confluent/ksql/execution/ddl/commands/CreateSourceCommand.java
@@ -15,6 +15,7 @@
 
 package io.confluent.ksql.execution.ddl.commands;
 
+import com.fasterxml.jackson.annotation.JsonProperty;
 import io.confluent.ksql.schema.ksql.LogicalSchema;
 import io.confluent.ksql.serde.SerdeOption;
 import io.confluent.ksql.util.timestamp.TimestampExtractionPolicy;
@@ -26,12 +27,27 @@ import java.util.Set;
  * Base class of create table/stream command
  */
 abstract class CreateSourceCommand implements DdlCommand {
+  final static String SQL_EXPRESSION = "sqlExpression";
+  final static String SOURCE_NAME = "sourceName";
+  final static String SCHEMA = "schema";
+  final static String KEY_FIELD = "keyField";
+  final static String TIMESTAMP_EXTRACTION_POLICY = "timestampExtractionPolicy";
+  final static String SERDE_OPTIONS = "serdeOptions";
+  final static String TOPIC = "topic";
+
+  @JsonProperty(SQL_EXPRESSION)
   private final String sqlExpression;
+  @JsonProperty(SOURCE_NAME)
   private final String sourceName;
+  @JsonProperty(SCHEMA)
   private final LogicalSchema schema;
+  @JsonProperty(KEY_FIELD)
   private final Optional<String> keyField;
+  @JsonProperty(TIMESTAMP_EXTRACTION_POLICY)
   private final TimestampExtractionPolicy timestampExtractionPolicy;
+  @JsonProperty(SERDE_OPTIONS)
   private final Set<SerdeOption> serdeOptions;
+  @JsonProperty(TOPIC)
   private final KsqlTopic topic;
 
   CreateSourceCommand(

--- a/ksql-execution/src/main/java/io/confluent/ksql/execution/ddl/commands/CreateStreamCommand.java
+++ b/ksql-execution/src/main/java/io/confluent/ksql/execution/ddl/commands/CreateStreamCommand.java
@@ -15,6 +15,8 @@
 
 package io.confluent.ksql.execution.ddl.commands;
 
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
 import com.google.errorprone.annotations.Immutable;
 import io.confluent.ksql.schema.ksql.LogicalSchema;
 import io.confluent.ksql.serde.SerdeOption;
@@ -24,15 +26,15 @@ import java.util.Set;
 
 @Immutable
 public class CreateStreamCommand extends CreateSourceCommand {
-
+  @JsonCreator
   public CreateStreamCommand(
-      final String sqlExpression,
-      final String sourceName,
-      final LogicalSchema schema,
-      final Optional<String> keyField,
-      final TimestampExtractionPolicy timestampExtractionPolicy,
-      final Set<SerdeOption> serdeOptions,
-      final KsqlTopic ksqlTopic
+      @JsonProperty(SQL_EXPRESSION) final String sqlExpression,
+      @JsonProperty(SOURCE_NAME) final String sourceName,
+      @JsonProperty(SCHEMA) final LogicalSchema schema,
+      @JsonProperty(KEY_FIELD) final Optional<String> keyField,
+      @JsonProperty(TIMESTAMP_EXTRACTION_POLICY) final TimestampExtractionPolicy timestampExtractionPolicy,
+      @JsonProperty(SERDE_OPTIONS) final Set<SerdeOption> serdeOptions,
+      @JsonProperty(TOPIC) final KsqlTopic ksqlTopic
   ) {
     super(
         sqlExpression,

--- a/ksql-execution/src/main/java/io/confluent/ksql/execution/ddl/commands/CreateTableCommand.java
+++ b/ksql-execution/src/main/java/io/confluent/ksql/execution/ddl/commands/CreateTableCommand.java
@@ -15,6 +15,8 @@
 
 package io.confluent.ksql.execution.ddl.commands;
 
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
 import com.google.errorprone.annotations.Immutable;
 import io.confluent.ksql.schema.ksql.LogicalSchema;
 import io.confluent.ksql.serde.SerdeOption;
@@ -24,15 +26,15 @@ import java.util.Set;
 
 @Immutable
 public class CreateTableCommand extends CreateSourceCommand {
-
+  @JsonCreator
   public CreateTableCommand(
-      final String sqlExpression,
-      final String sourceName,
-      final LogicalSchema schema,
-      final Optional<String> keyField,
-      final TimestampExtractionPolicy timestampExtractionPolicy,
-      final Set<SerdeOption> serdeOptions,
-      final KsqlTopic ksqlTopic
+      @JsonProperty(SQL_EXPRESSION) final String sqlExpression,
+      @JsonProperty(SOURCE_NAME) final String sourceName,
+      @JsonProperty(SCHEMA) final LogicalSchema schema,
+      @JsonProperty(KEY_FIELD) final Optional<String> keyField,
+      @JsonProperty(TIMESTAMP_EXTRACTION_POLICY) final TimestampExtractionPolicy timestampExtractionPolicy,
+      @JsonProperty(SERDE_OPTIONS) final Set<SerdeOption> serdeOptions,
+      @JsonProperty(TOPIC) final KsqlTopic ksqlTopic
   ) {
     super(
         sqlExpression,

--- a/ksql-execution/src/main/java/io/confluent/ksql/execution/ddl/commands/DdlCommand.java
+++ b/ksql-execution/src/main/java/io/confluent/ksql/execution/ddl/commands/DdlCommand.java
@@ -15,6 +15,22 @@
 
 package io.confluent.ksql.execution.ddl.commands;
 
+import com.fasterxml.jackson.annotation.JsonSubTypes;
+import com.fasterxml.jackson.annotation.JsonSubTypes.Type;
+import com.fasterxml.jackson.annotation.JsonTypeInfo;
+import com.fasterxml.jackson.annotation.JsonTypeInfo.As;
+
+@JsonTypeInfo(
+    use = JsonTypeInfo.Id.NAME,
+    include = As.WRAPPER_OBJECT
+)
+@JsonSubTypes({
+    @Type(value = CreateStreamCommand.class, name = "createStreamV1"),
+    @Type(value = CreateTableCommand.class, name = "createTableV1"),
+    @Type(value = RegisterTypeCommand.class, name = "registerTypeV1"),
+    @Type(value = DropSourceCommand.class, name = "dropSourceV1"),
+    @Type(value = DropTypeCommand.class, name = "dropTypeV1")
+})
 public interface DdlCommand {
   DdlCommandResult execute(Executor executor);
 }

--- a/ksql-execution/src/main/java/io/confluent/ksql/execution/ddl/commands/DropSourceCommand.java
+++ b/ksql-execution/src/main/java/io/confluent/ksql/execution/ddl/commands/DropSourceCommand.java
@@ -15,15 +15,20 @@
 
 package io.confluent.ksql.execution.ddl.commands;
 
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
 import com.google.errorprone.annotations.Immutable;
 import java.util.Objects;
 
 @Immutable
 public class DropSourceCommand implements DdlCommand {
+  private static final String SOURCE_NAME = "sourceName";
 
+  @JsonProperty(SOURCE_NAME)
   private final String sourceName;
 
-  public DropSourceCommand(final String sourceName) {
+  @JsonCreator
+  public DropSourceCommand(@JsonProperty(SOURCE_NAME) final String sourceName) {
     this.sourceName = Objects.requireNonNull(sourceName, "sourceName");
   }
 

--- a/ksql-execution/src/main/java/io/confluent/ksql/execution/ddl/commands/DropTypeCommand.java
+++ b/ksql-execution/src/main/java/io/confluent/ksql/execution/ddl/commands/DropTypeCommand.java
@@ -15,12 +15,16 @@
 
 package io.confluent.ksql.execution.ddl.commands;
 
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
 import com.google.errorprone.annotations.Immutable;
 import java.util.Objects;
 
 @Immutable
 public class DropTypeCommand implements DdlCommand {
+  private static final String TYPE_NAME = "typeName";
 
+  @JsonProperty(TYPE_NAME)
   private final String typeName;
 
   @Override
@@ -28,7 +32,8 @@ public class DropTypeCommand implements DdlCommand {
     return executor.executeDropType(this);
   }
 
-  public DropTypeCommand(final String typeName) {
+  @JsonCreator
+  public DropTypeCommand(@JsonProperty(TYPE_NAME) final String typeName) {
     this.typeName = Objects.requireNonNull(typeName, "typeName");
   }
 

--- a/ksql-execution/src/main/java/io/confluent/ksql/execution/ddl/commands/KsqlTopic.java
+++ b/ksql-execution/src/main/java/io/confluent/ksql/execution/ddl/commands/KsqlTopic.java
@@ -17,23 +17,34 @@ package io.confluent.ksql.execution.ddl.commands;
 
 import static java.util.Objects.requireNonNull;
 
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
 import com.google.errorprone.annotations.Immutable;
 import io.confluent.ksql.serde.KeyFormat;
 import io.confluent.ksql.serde.ValueFormat;
 
 @Immutable
 public class KsqlTopic {
+  private static final String KAFKA_TOPIC_NAME = "kafkaTopicName";
+  private static final String KEY_FORMAT = "keyFormat";
+  private static final String VALUE_FORMAT = "valueFormat";
+  private static final String IS_KSQL_SINK = "isKsqlSink";
 
+  @JsonProperty(KAFKA_TOPIC_NAME)
   private final String kafkaTopicName;
+  @JsonProperty(KEY_FORMAT)
   private final KeyFormat keyFormat;
+  @JsonProperty(VALUE_FORMAT)
   private final ValueFormat valueFormat;
+  @JsonProperty(IS_KSQL_SINK)
   private final boolean isKsqlSink;
 
+  @JsonCreator
   public KsqlTopic(
-      final String kafkaTopicName,
-      final KeyFormat keyFormat,
-      final ValueFormat valueFormat,
-      final boolean isKsqlSink
+      @JsonProperty(KAFKA_TOPIC_NAME) final String kafkaTopicName,
+      @JsonProperty(KEY_FORMAT) final KeyFormat keyFormat,
+      @JsonProperty(VALUE_FORMAT) final ValueFormat valueFormat,
+      @JsonProperty(IS_KSQL_SINK) final boolean isKsqlSink
   ) {
     this.kafkaTopicName = requireNonNull(kafkaTopicName, "kafkaTopicName");
     this.keyFormat = requireNonNull(keyFormat, "keyFormat");

--- a/ksql-execution/src/main/java/io/confluent/ksql/execution/ddl/commands/RegisterTypeCommand.java
+++ b/ksql-execution/src/main/java/io/confluent/ksql/execution/ddl/commands/RegisterTypeCommand.java
@@ -15,16 +15,26 @@
 
 package io.confluent.ksql.execution.ddl.commands;
 
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
 import com.google.errorprone.annotations.Immutable;
 import io.confluent.ksql.schema.ksql.types.SqlType;
 import java.util.Objects;
 
 @Immutable
 public class RegisterTypeCommand implements DdlCommand {
+  private final static String TYPE = "TYPE";
+  private final static String NAME = "NAME";
+
+  @JsonProperty(TYPE)
   private final SqlType type;
+  @JsonProperty(NAME)
   private final String name;
 
-  public RegisterTypeCommand(final SqlType type, final String name) {
+  @JsonCreator
+  public RegisterTypeCommand(
+      @JsonProperty(TYPE) final SqlType type,
+      @JsonProperty(NAME) final String name) {
     this.type = Objects.requireNonNull(type, "type");
     this.name = Objects.requireNonNull(name, "name");
   }

--- a/ksql-execution/src/main/java/io/confluent/ksql/execution/expression/tree/ArithmeticBinaryExpression.java
+++ b/ksql-execution/src/main/java/io/confluent/ksql/execution/expression/tree/ArithmeticBinaryExpression.java
@@ -15,6 +15,8 @@
 
 package io.confluent.ksql.execution.expression.tree;
 
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
 import com.google.errorprone.annotations.Immutable;
 import io.confluent.ksql.parser.NodeLocation;
 import io.confluent.ksql.schema.Operator;
@@ -23,15 +25,22 @@ import java.util.Optional;
 
 @Immutable
 public class ArithmeticBinaryExpression extends Expression {
+  private static final String OPERATOR = "operator";
+  private static final String LEFT = "left";
+  private static final String RIGHT = "right";
 
+  @JsonProperty(OPERATOR)
   private final Operator operator;
+  @JsonProperty(LEFT)
   private final Expression left;
+  @JsonProperty(RIGHT)
   private final Expression right;
 
+  @JsonCreator
   public ArithmeticBinaryExpression(
-      final Operator operator,
-      final Expression left,
-      final Expression right
+      @JsonProperty(OPERATOR) final Operator operator,
+      @JsonProperty(LEFT) final Expression left,
+      @JsonProperty(RIGHT) final Expression right
   ) {
     this(Optional.empty(), operator, left, right);
   }

--- a/ksql-execution/src/main/java/io/confluent/ksql/execution/expression/tree/ArithmeticUnaryExpression.java
+++ b/ksql-execution/src/main/java/io/confluent/ksql/execution/expression/tree/ArithmeticUnaryExpression.java
@@ -17,6 +17,8 @@ package io.confluent.ksql.execution.expression.tree;
 
 import static java.util.Objects.requireNonNull;
 
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
 import com.google.errorprone.annotations.Immutable;
 import io.confluent.ksql.parser.NodeLocation;
 import java.util.Objects;
@@ -24,13 +26,17 @@ import java.util.Optional;
 
 @Immutable
 public class ArithmeticUnaryExpression extends Expression {
+  private final static String VALUE = "value";
+  private final static String SIGN = "sign";
 
   public enum Sign {
     PLUS,
     MINUS
   }
 
+  @JsonProperty(VALUE)
   private final Expression value;
+  @JsonProperty(SIGN)
   private final Sign sign;
 
   public ArithmeticUnaryExpression(
@@ -41,6 +47,14 @@ public class ArithmeticUnaryExpression extends Expression {
     super(location);
     this.value = requireNonNull(value, "value");
     this.sign = requireNonNull(sign, "sign");
+  }
+
+  @JsonCreator
+  private ArithmeticUnaryExpression(
+      @JsonProperty(SIGN) final Sign sign,
+      @JsonProperty(VALUE) final Expression value
+  ) {
+    this(Optional.empty(), sign, value);
   }
 
   public static ArithmeticUnaryExpression positive(

--- a/ksql-execution/src/main/java/io/confluent/ksql/execution/expression/tree/BetweenPredicate.java
+++ b/ksql-execution/src/main/java/io/confluent/ksql/execution/expression/tree/BetweenPredicate.java
@@ -17,6 +17,8 @@ package io.confluent.ksql.execution.expression.tree;
 
 import static java.util.Objects.requireNonNull;
 
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
 import com.google.errorprone.annotations.Immutable;
 import io.confluent.ksql.parser.NodeLocation;
 import java.util.Objects;
@@ -24,15 +26,22 @@ import java.util.Optional;
 
 @Immutable
 public class BetweenPredicate extends Expression {
+  private static final String VALUE = "value";
+  private static final String MIN = "min";
+  private static final String MAX = "max";
 
+  @JsonProperty(VALUE)
   private final Expression value;
+  @JsonProperty(MIN)
   private final Expression min;
+  @JsonProperty(MAX)
   private final Expression max;
 
+  @JsonCreator
   public BetweenPredicate(
-      final Expression value,
-      final Expression min,
-      final Expression max
+      @JsonProperty(VALUE) final Expression value,
+      @JsonProperty(MIN) final Expression min,
+      @JsonProperty(MAX) final Expression max
   ) {
     this(Optional.empty(), value, min, max);
   }

--- a/ksql-execution/src/main/java/io/confluent/ksql/execution/expression/tree/BooleanLiteral.java
+++ b/ksql-execution/src/main/java/io/confluent/ksql/execution/expression/tree/BooleanLiteral.java
@@ -18,6 +18,8 @@ package io.confluent.ksql.execution.expression.tree;
 import static java.util.Locale.ENGLISH;
 import static java.util.Objects.requireNonNull;
 
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
 import com.google.common.base.Preconditions;
 import com.google.errorprone.annotations.Immutable;
 import io.confluent.ksql.parser.NodeLocation;
@@ -26,10 +28,13 @@ import java.util.Optional;
 
 @Immutable
 public class BooleanLiteral extends Literal {
+  private static final String VALUE = "value";
 
+  @JsonProperty(VALUE)
   private final boolean value;
 
-  public BooleanLiteral(final String value) {
+  @JsonCreator
+  public BooleanLiteral(@JsonProperty(VALUE) final String value) {
     this(Optional.empty(), value);
   }
 

--- a/ksql-execution/src/main/java/io/confluent/ksql/execution/expression/tree/Cast.java
+++ b/ksql-execution/src/main/java/io/confluent/ksql/execution/expression/tree/Cast.java
@@ -17,6 +17,8 @@ package io.confluent.ksql.execution.expression.tree;
 
 import static java.util.Objects.requireNonNull;
 
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
 import com.google.errorprone.annotations.Immutable;
 import io.confluent.ksql.parser.NodeLocation;
 import java.util.Objects;
@@ -24,13 +26,18 @@ import java.util.Optional;
 
 @Immutable
 public final class Cast extends Expression {
+  private static final String EXPRESSION = "expression";
+  private static final String TYPE = "type";
 
+  @JsonProperty(EXPRESSION)
   private final Expression expression;
+  @JsonProperty(TYPE)
   private final Type type;
 
+  @JsonCreator
   public Cast(
-      final Expression expression,
-      final Type type
+      @JsonProperty(EXPRESSION) final Expression expression,
+      @JsonProperty(TYPE) final Type type
   ) {
     this(Optional.empty(), expression, type);
   }

--- a/ksql-execution/src/main/java/io/confluent/ksql/execution/expression/tree/ComparisonExpression.java
+++ b/ksql-execution/src/main/java/io/confluent/ksql/execution/expression/tree/ComparisonExpression.java
@@ -17,6 +17,8 @@ package io.confluent.ksql.execution.expression.tree;
 
 import static java.util.Objects.requireNonNull;
 
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
 import com.google.errorprone.annotations.Immutable;
 import io.confluent.ksql.parser.NodeLocation;
 import java.util.Objects;
@@ -24,6 +26,9 @@ import java.util.Optional;
 
 @Immutable
 public class ComparisonExpression extends Expression {
+  private static final String TYPE = "type";
+  private static final String LEFT = "left";
+  private static final String RIGHT = "right";
 
   public enum Type {
     EQUAL("="),
@@ -85,14 +90,18 @@ public class ComparisonExpression extends Expression {
     }
   }
 
+  @JsonProperty(TYPE)
   private final Type type;
+  @JsonProperty(LEFT)
   private final Expression left;
+  @JsonProperty(RIGHT)
   private final Expression right;
 
+  @JsonCreator
   public ComparisonExpression(
-      final Type type,
-      final Expression left,
-      final Expression right
+      @JsonProperty(TYPE) final Type type,
+      @JsonProperty(LEFT) final Expression left,
+      @JsonProperty(RIGHT) final Expression right
   ) {
     this(Optional.empty(), type, left, right);
   }

--- a/ksql-execution/src/main/java/io/confluent/ksql/execution/expression/tree/DecimalLiteral.java
+++ b/ksql-execution/src/main/java/io/confluent/ksql/execution/expression/tree/DecimalLiteral.java
@@ -17,6 +17,8 @@ package io.confluent.ksql.execution.expression.tree;
 
 import static java.util.Objects.requireNonNull;
 
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
 import com.google.errorprone.annotations.Immutable;
 import io.confluent.ksql.parser.NodeLocation;
 import java.util.Objects;
@@ -24,10 +26,13 @@ import java.util.Optional;
 
 @Immutable
 public class DecimalLiteral extends Literal {
+  private static final String VALUE = "value";
 
+  @JsonProperty(VALUE)
   private final String value;
 
-  public DecimalLiteral(final String value) {
+  @JsonCreator
+  public DecimalLiteral(@JsonProperty(VALUE) final String value) {
     this(Optional.empty(), value);
   }
 

--- a/ksql-execution/src/main/java/io/confluent/ksql/execution/expression/tree/DereferenceExpression.java
+++ b/ksql-execution/src/main/java/io/confluent/ksql/execution/expression/tree/DereferenceExpression.java
@@ -17,6 +17,8 @@ package io.confluent.ksql.execution.expression.tree;
 
 import static java.util.Objects.requireNonNull;
 
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
 import com.google.errorprone.annotations.Immutable;
 import io.confluent.ksql.parser.NodeLocation;
 import java.util.ArrayList;
@@ -26,13 +28,18 @@ import java.util.Optional;
 
 @Immutable
 public class DereferenceExpression extends Expression {
+  private static final String BASE = "base";
+  private static final String FIELD_NAME = "fieldName";
 
+  @JsonProperty(BASE)
   private final Expression base;
+  @JsonProperty(FIELD_NAME)
   private final String fieldName;
 
+  @JsonCreator
   public DereferenceExpression(
-      final Expression base,
-      final String fieldName
+      @JsonProperty(BASE) final Expression base,
+      @JsonProperty(FIELD_NAME) final String fieldName
   ) {
     this(Optional.empty(), base, fieldName);
   }

--- a/ksql-execution/src/main/java/io/confluent/ksql/execution/expression/tree/DoubleLiteral.java
+++ b/ksql-execution/src/main/java/io/confluent/ksql/execution/expression/tree/DoubleLiteral.java
@@ -15,16 +15,21 @@
 
 package io.confluent.ksql.execution.expression.tree;
 
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
 import com.google.errorprone.annotations.Immutable;
 import io.confluent.ksql.parser.NodeLocation;
 import java.util.Optional;
 
 @Immutable
 public class DoubleLiteral extends Literal {
+  private static final String VALUE = "value";
 
+  @JsonProperty(VALUE)
   private final double value;
 
-  public DoubleLiteral(final double value) {
+  @JsonCreator
+  public DoubleLiteral(@JsonProperty(VALUE) final double value) {
     this(Optional.empty(), value);
   }
 

--- a/ksql-execution/src/main/java/io/confluent/ksql/execution/expression/tree/Expression.java
+++ b/ksql-execution/src/main/java/io/confluent/ksql/execution/expression/tree/Expression.java
@@ -15,6 +15,10 @@
 
 package io.confluent.ksql.execution.expression.tree;
 
+import com.fasterxml.jackson.annotation.JsonSubTypes;
+import com.fasterxml.jackson.annotation.JsonSubTypes.Type;
+import com.fasterxml.jackson.annotation.JsonTypeInfo;
+import com.fasterxml.jackson.annotation.JsonTypeInfo.As;
 import com.google.errorprone.annotations.Immutable;
 import io.confluent.ksql.execution.expression.formatter.ExpressionFormatter;
 import io.confluent.ksql.parser.Node;
@@ -25,6 +29,42 @@ import java.util.Optional;
  * Expressions are used to declare select items, where and having clauses and join criteria in
  * queries.
  */
+@JsonTypeInfo(
+    use = JsonTypeInfo.Id.NAME,
+    include = As.WRAPPER_OBJECT
+)
+@JsonSubTypes({
+    @Type(value = ArithmeticBinaryExpression.class, name = "ArithmeticBinaryExpression"),
+    @Type(value = ArithmeticUnaryExpression.class, name = "ArithmeticUnaryExpression"),
+    @Type(value = BetweenPredicate.class, name = "BetweenPredicate"),
+    @Type(value = BooleanLiteral.class, name = "BooleanLiteral"),
+    @Type(value = Cast.class, name = "Cast"),
+    @Type(value = ComparisonExpression.class, name = "ComparisonExpression"),
+    @Type(value = DecimalLiteral.class, name = "DecimalLiteral"),
+    @Type(value = DereferenceExpression.class, name = "DereferenceExpression"),
+    @Type(value = DoubleLiteral.class, name = "DoubleLiteral"),
+    @Type(value = FunctionCall.class, name = "FunctionCall"),
+    @Type(value = InListExpression.class, name = "InListExpression"),
+    @Type(value = InPredicate.class, name = "InPredicate"),
+    @Type(value = IntegerLiteral.class, name = "IntegerLiteral"),
+    @Type(value = IsNotNullPredicate.class, name = "IsNotNullPredicate"),
+    @Type(value = IsNullPredicate.class, name = "IsNullPredicate"),
+    @Type(value = LikePredicate.class, name = "LikePredicate"),
+    @Type(value = LogicalBinaryExpression.class, name = "LogicalBinaryExpression"),
+    @Type(value = LongLiteral.class, name = "LongLiteral"),
+    @Type(value = NotExpression.class, name = "NotExpression"),
+    @Type(value = NullLiteral.class, name = "NullLiteral"),
+    @Type(value = QualifiedName.class, name = "QualifiedName"),
+    @Type(value = QualifiedNameReference.class, name = "QualifiedNameReference"),
+    @Type(value = SearchedCaseExpression.class, name = "SearchedCaseExpression"),
+    @Type(value = SimpleCaseExpression.class, name = "SimpleCaseExpression"),
+    @Type(value = StringLiteral.class, name = "StringLiteral"),
+    @Type(value = SubscriptExpression.class, name = "SubscriptExpression"),
+    @Type(value = TimeLiteral.class, name = "TimeLiteral"),
+    @Type(value = TimestampLiteral.class, name = "TimestampLiteral"),
+    @Type(value = io.confluent.ksql.execution.expression.tree.Type.class, name = "Type"),
+    @Type(value = WhenClause.class, name = "WhenClause")
+})
 @Immutable
 public abstract class Expression extends Node {
 

--- a/ksql-execution/src/main/java/io/confluent/ksql/execution/expression/tree/FunctionCall.java
+++ b/ksql-execution/src/main/java/io/confluent/ksql/execution/expression/tree/FunctionCall.java
@@ -17,6 +17,8 @@ package io.confluent.ksql.execution.expression.tree;
 
 import static java.util.Objects.requireNonNull;
 
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
 import com.google.common.collect.ImmutableList;
 import com.google.errorprone.annotations.Immutable;
 import io.confluent.ksql.parser.NodeLocation;
@@ -26,13 +28,18 @@ import java.util.Optional;
 
 @Immutable
 public class FunctionCall extends Expression {
+  private static final String NAME = "name";
+  private static final String ARGUMENTS = "arguments";
 
+  @JsonProperty(NAME)
   private final QualifiedName name;
+  @JsonProperty(ARGUMENTS)
   private final ImmutableList<Expression> arguments;
 
+  @JsonCreator
   public FunctionCall(
-      final QualifiedName name,
-      final List<Expression> arguments
+      @JsonProperty(NAME) final QualifiedName name,
+      @JsonProperty(ARGUMENTS) final List<Expression> arguments
   ) {
     this(Optional.empty(), name,  arguments);
   }

--- a/ksql-execution/src/main/java/io/confluent/ksql/execution/expression/tree/InListExpression.java
+++ b/ksql-execution/src/main/java/io/confluent/ksql/execution/expression/tree/InListExpression.java
@@ -17,6 +17,8 @@ package io.confluent.ksql.execution.expression.tree;
 
 import static java.util.Objects.requireNonNull;
 
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
 import com.google.common.collect.ImmutableList;
 import com.google.errorprone.annotations.Immutable;
 import io.confluent.ksql.parser.NodeLocation;
@@ -26,10 +28,13 @@ import java.util.Optional;
 
 @Immutable
 public class InListExpression extends Expression {
+  private static final String VALUES = "values";
 
+  @JsonProperty(VALUES)
   private final ImmutableList<Expression> values;
 
-  public InListExpression(final List<Expression> values) {
+  @JsonCreator
+  public InListExpression(@JsonProperty(VALUES) final List<Expression> values) {
     this(Optional.empty(), values);
   }
 

--- a/ksql-execution/src/main/java/io/confluent/ksql/execution/expression/tree/InPredicate.java
+++ b/ksql-execution/src/main/java/io/confluent/ksql/execution/expression/tree/InPredicate.java
@@ -17,6 +17,8 @@ package io.confluent.ksql.execution.expression.tree;
 
 import static java.util.Objects.requireNonNull;
 
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
 import com.google.errorprone.annotations.Immutable;
 import io.confluent.ksql.parser.NodeLocation;
 import java.util.Objects;
@@ -24,13 +26,18 @@ import java.util.Optional;
 
 @Immutable
 public class InPredicate extends Expression {
+  private static final String VALUE = "value";
+  private static final String VALUE_LIST = "valueList";
 
+  @JsonProperty(VALUE)
   private final Expression value;
+  @JsonProperty(VALUE_LIST)
   private final InListExpression valueList;
 
+  @JsonCreator
   public InPredicate(
-      final Expression value,
-      final InListExpression valueList
+      @JsonProperty(VALUE) final Expression value,
+      @JsonProperty(VALUE_LIST) final InListExpression valueList
   ) {
     this(Optional.empty(), value, valueList);
   }

--- a/ksql-execution/src/main/java/io/confluent/ksql/execution/expression/tree/IntegerLiteral.java
+++ b/ksql-execution/src/main/java/io/confluent/ksql/execution/expression/tree/IntegerLiteral.java
@@ -15,6 +15,8 @@
 
 package io.confluent.ksql.execution.expression.tree;
 
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
 import com.google.errorprone.annotations.Immutable;
 import io.confluent.ksql.parser.NodeLocation;
 import java.util.Objects;
@@ -22,10 +24,13 @@ import java.util.Optional;
 
 @Immutable
 public class IntegerLiteral extends Literal {
+  private static final String VALUE = "value";
 
+  @JsonProperty(VALUE)
   private final int value;
 
-  public IntegerLiteral(final int value) {
+  @JsonCreator
+  public IntegerLiteral(@JsonProperty(VALUE) final int value) {
     this (Optional.empty(), value);
   }
 

--- a/ksql-execution/src/main/java/io/confluent/ksql/execution/expression/tree/IsNotNullPredicate.java
+++ b/ksql-execution/src/main/java/io/confluent/ksql/execution/expression/tree/IsNotNullPredicate.java
@@ -17,6 +17,8 @@ package io.confluent.ksql.execution.expression.tree;
 
 import static java.util.Objects.requireNonNull;
 
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
 import com.google.errorprone.annotations.Immutable;
 import io.confluent.ksql.parser.NodeLocation;
 import java.util.Objects;
@@ -24,10 +26,13 @@ import java.util.Optional;
 
 @Immutable
 public class IsNotNullPredicate extends Expression {
+  private static final String VALUE = "value";
 
+  @JsonProperty(VALUE)
   private final Expression value;
 
-  public IsNotNullPredicate(final Expression value) {
+  @JsonCreator
+  public IsNotNullPredicate(@JsonProperty(VALUE) final Expression value) {
     this(Optional.empty(), value);
   }
 

--- a/ksql-execution/src/main/java/io/confluent/ksql/execution/expression/tree/IsNullPredicate.java
+++ b/ksql-execution/src/main/java/io/confluent/ksql/execution/expression/tree/IsNullPredicate.java
@@ -17,6 +17,8 @@ package io.confluent.ksql.execution.expression.tree;
 
 import static java.util.Objects.requireNonNull;
 
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
 import com.google.errorprone.annotations.Immutable;
 import io.confluent.ksql.parser.NodeLocation;
 import java.util.Objects;
@@ -24,10 +26,13 @@ import java.util.Optional;
 
 @Immutable
 public class IsNullPredicate extends Expression {
+  private static final String VALUE = "value";
 
+  @JsonProperty(VALUE)
   private final Expression value;
 
-  public IsNullPredicate(final Expression value) {
+  @JsonCreator
+  public IsNullPredicate(@JsonProperty(VALUE) final Expression value) {
     this(Optional.empty(), value);
   }
 

--- a/ksql-execution/src/main/java/io/confluent/ksql/execution/expression/tree/LikePredicate.java
+++ b/ksql-execution/src/main/java/io/confluent/ksql/execution/expression/tree/LikePredicate.java
@@ -17,6 +17,8 @@ package io.confluent.ksql.execution.expression.tree;
 
 import static java.util.Objects.requireNonNull;
 
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
 import com.google.errorprone.annotations.Immutable;
 import io.confluent.ksql.parser.NodeLocation;
 import java.util.Objects;
@@ -24,13 +26,18 @@ import java.util.Optional;
 
 @Immutable
 public class LikePredicate extends Expression {
+  private static final String VALUE = "value";
+  private static final String PATTERN = "pattern";
 
+  @JsonProperty(VALUE)
   private final Expression value;
+  @JsonProperty(PATTERN)
   private final Expression pattern;
 
+  @JsonCreator
   public LikePredicate(
-      final Expression value,
-      final Expression pattern
+      @JsonProperty(VALUE) final Expression value,
+      @JsonProperty(PATTERN) final Expression pattern
   ) {
     this(Optional.empty(), value, pattern);
   }

--- a/ksql-execution/src/main/java/io/confluent/ksql/execution/expression/tree/LogicalBinaryExpression.java
+++ b/ksql-execution/src/main/java/io/confluent/ksql/execution/expression/tree/LogicalBinaryExpression.java
@@ -17,6 +17,8 @@ package io.confluent.ksql.execution.expression.tree;
 
 import static java.util.Objects.requireNonNull;
 
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
 import com.google.errorprone.annotations.Immutable;
 import io.confluent.ksql.parser.NodeLocation;
 import java.util.Objects;
@@ -24,19 +26,26 @@ import java.util.Optional;
 
 @Immutable
 public class LogicalBinaryExpression extends Expression {
+  private static final String TYPE = "type";
+  private static final String LEFT = "left";
+  private static final String RIGHT = "right";
 
   public enum Type {
     AND, OR
   }
 
+  @JsonProperty(TYPE)
   private final Type type;
+  @JsonProperty(LEFT)
   private final Expression left;
+  @JsonProperty(RIGHT)
   private final Expression right;
 
+  @JsonCreator
   public LogicalBinaryExpression(
-      final Type type,
-      final Expression left,
-      final Expression right
+      @JsonProperty(TYPE) final Type type,
+      @JsonProperty(LEFT) final Expression left,
+      @JsonProperty(RIGHT) final Expression right
   ) {
     this(Optional.empty(), type, left, right);
   }

--- a/ksql-execution/src/main/java/io/confluent/ksql/execution/expression/tree/LongLiteral.java
+++ b/ksql-execution/src/main/java/io/confluent/ksql/execution/expression/tree/LongLiteral.java
@@ -15,16 +15,21 @@
 
 package io.confluent.ksql.execution.expression.tree;
 
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
 import com.google.errorprone.annotations.Immutable;
 import io.confluent.ksql.parser.NodeLocation;
 import java.util.Optional;
 
 @Immutable
 public class LongLiteral extends Literal {
+  private static final String VALUE = "value";
 
+  @JsonProperty(VALUE)
   private final long value;
 
-  public LongLiteral(final long value) {
+  @JsonCreator
+  public LongLiteral(@JsonProperty(VALUE) final long value) {
     this(Optional.empty(), value);
   }
 

--- a/ksql-execution/src/main/java/io/confluent/ksql/execution/expression/tree/NotExpression.java
+++ b/ksql-execution/src/main/java/io/confluent/ksql/execution/expression/tree/NotExpression.java
@@ -17,6 +17,8 @@ package io.confluent.ksql.execution.expression.tree;
 
 import static java.util.Objects.requireNonNull;
 
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
 import com.google.errorprone.annotations.Immutable;
 import io.confluent.ksql.parser.NodeLocation;
 import java.util.Objects;
@@ -24,10 +26,13 @@ import java.util.Optional;
 
 @Immutable
 public class NotExpression extends Expression {
+  private static final String VALUE = "value";
 
+  @JsonProperty(VALUE)
   private final Expression value;
 
-  public NotExpression(final Expression value) {
+  @JsonCreator
+  public NotExpression(@JsonProperty(VALUE) final Expression value) {
     this(Optional.empty(), value);
   }
 

--- a/ksql-execution/src/main/java/io/confluent/ksql/execution/expression/tree/NullLiteral.java
+++ b/ksql-execution/src/main/java/io/confluent/ksql/execution/expression/tree/NullLiteral.java
@@ -15,6 +15,7 @@
 
 package io.confluent.ksql.execution.expression.tree;
 
+import com.fasterxml.jackson.annotation.JsonCreator;
 import com.google.errorprone.annotations.Immutable;
 import io.confluent.ksql.parser.NodeLocation;
 import java.util.Optional;
@@ -22,6 +23,7 @@ import java.util.Optional;
 @Immutable
 public class NullLiteral extends Literal {
 
+  @JsonCreator
   public NullLiteral() {
     super(Optional.empty());
   }

--- a/ksql-execution/src/main/java/io/confluent/ksql/execution/expression/tree/QualifiedName.java
+++ b/ksql-execution/src/main/java/io/confluent/ksql/execution/expression/tree/QualifiedName.java
@@ -19,6 +19,8 @@ import static com.google.common.base.Preconditions.checkArgument;
 import static com.google.common.collect.Iterables.isEmpty;
 import static java.util.Objects.requireNonNull;
 
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
 import com.google.common.base.Joiner;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.Iterables;
@@ -29,7 +31,9 @@ import java.util.Optional;
 
 @Immutable
 public final class QualifiedName {
+  private static final String PARTS = "parts";
 
+  @JsonProperty(PARTS)
   private final ImmutableList<String> parts;
 
   public static QualifiedName of(final String first, final String... rest) {
@@ -48,7 +52,8 @@ public final class QualifiedName {
     return new QualifiedName(ImmutableList.copyOf(parts));
   }
 
-  private QualifiedName(final ImmutableList<String> parts) {
+  @JsonCreator
+  private QualifiedName(@JsonProperty(PARTS) final ImmutableList<String> parts) {
     this.parts = requireNonNull(parts, "parts");
   }
 

--- a/ksql-execution/src/main/java/io/confluent/ksql/execution/expression/tree/QualifiedNameReference.java
+++ b/ksql-execution/src/main/java/io/confluent/ksql/execution/expression/tree/QualifiedNameReference.java
@@ -17,6 +17,8 @@ package io.confluent.ksql.execution.expression.tree;
 
 import static java.util.Objects.requireNonNull;
 
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
 import com.google.errorprone.annotations.Immutable;
 import io.confluent.ksql.parser.NodeLocation;
 import java.util.Objects;
@@ -24,10 +26,13 @@ import java.util.Optional;
 
 @Immutable
 public class QualifiedNameReference extends Expression {
+  private static final String NAME = "name";
 
+  @JsonProperty(NAME)
   private final QualifiedName name;
 
-  public QualifiedNameReference(final QualifiedName name) {
+  @JsonCreator
+  public QualifiedNameReference(@JsonProperty(NAME) final QualifiedName name) {
     this(Optional.empty(), name);
   }
 

--- a/ksql-execution/src/main/java/io/confluent/ksql/execution/expression/tree/SearchedCaseExpression.java
+++ b/ksql-execution/src/main/java/io/confluent/ksql/execution/expression/tree/SearchedCaseExpression.java
@@ -17,6 +17,8 @@ package io.confluent.ksql.execution.expression.tree;
 
 import static java.util.Objects.requireNonNull;
 
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
 import com.google.common.collect.ImmutableList;
 import com.google.errorprone.annotations.Immutable;
 import io.confluent.ksql.parser.NodeLocation;
@@ -26,13 +28,18 @@ import java.util.Optional;
 
 @Immutable
 public class SearchedCaseExpression extends Expression {
+  private static final String WHEN_CLAUSES = "whenClauses";
+  private static final String DEFAULT_VALUE = "defaultValue";
 
+  @JsonProperty(WHEN_CLAUSES)
   private final ImmutableList<WhenClause> whenClauses;
+  @JsonProperty(DEFAULT_VALUE)
   private final Optional<Expression> defaultValue;
 
+  @JsonCreator
   public SearchedCaseExpression(
-      final List<WhenClause> whenClauses,
-      final Optional<Expression> defaultValue
+      @JsonProperty(WHEN_CLAUSES) final List<WhenClause> whenClauses,
+      @JsonProperty(DEFAULT_VALUE) final Optional<Expression> defaultValue
   ) {
     this(Optional.empty(), whenClauses, defaultValue);
   }

--- a/ksql-execution/src/main/java/io/confluent/ksql/execution/expression/tree/SimpleCaseExpression.java
+++ b/ksql-execution/src/main/java/io/confluent/ksql/execution/expression/tree/SimpleCaseExpression.java
@@ -17,6 +17,8 @@ package io.confluent.ksql.execution.expression.tree;
 
 import static java.util.Objects.requireNonNull;
 
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
 import com.google.common.collect.ImmutableList;
 import com.google.errorprone.annotations.Immutable;
 import io.confluent.ksql.parser.NodeLocation;
@@ -26,15 +28,22 @@ import java.util.Optional;
 
 @Immutable
 public class SimpleCaseExpression extends Expression {
+  private static final String OPERAND = "operand";
+  private static final String WHEN_CLAUSES = "whenClauses";
+  private static final String DEFAULT_VALUE = "defaultValue";
 
+  @JsonProperty(OPERAND)
   private final Expression operand;
+  @JsonProperty(WHEN_CLAUSES)
   private final ImmutableList<WhenClause> whenClauses;
+  @JsonProperty(DEFAULT_VALUE)
   private final Optional<Expression> defaultValue;
 
+  @JsonCreator
   public SimpleCaseExpression(
-      final Expression operand,
-      final List<WhenClause> whenClauses,
-      final Optional<Expression> defaultValue
+      @JsonProperty(OPERAND) final Expression operand,
+      @JsonProperty(WHEN_CLAUSES) final List<WhenClause> whenClauses,
+      @JsonProperty(DEFAULT_VALUE) final Optional<Expression> defaultValue
   ) {
     this(Optional.empty(), operand, whenClauses, defaultValue);
   }

--- a/ksql-execution/src/main/java/io/confluent/ksql/execution/expression/tree/StringLiteral.java
+++ b/ksql-execution/src/main/java/io/confluent/ksql/execution/expression/tree/StringLiteral.java
@@ -15,6 +15,8 @@
 
 package io.confluent.ksql.execution.expression.tree;
 
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
 import com.google.errorprone.annotations.Immutable;
 import io.confluent.ksql.parser.NodeLocation;
 import io.confluent.ksql.util.StringUtil;
@@ -23,10 +25,13 @@ import java.util.Optional;
 
 @Immutable
 public class StringLiteral extends Literal {
+  private static final String VALUE = "value";
 
+  @JsonProperty(VALUE)
   private final String value;
 
-  public StringLiteral(final String value) {
+  @JsonCreator
+  public StringLiteral(@JsonProperty(VALUE) final String value) {
     this(Optional.empty(), value);
   }
 

--- a/ksql-execution/src/main/java/io/confluent/ksql/execution/expression/tree/SubscriptExpression.java
+++ b/ksql-execution/src/main/java/io/confluent/ksql/execution/expression/tree/SubscriptExpression.java
@@ -17,6 +17,8 @@ package io.confluent.ksql.execution.expression.tree;
 
 import static java.util.Objects.requireNonNull;
 
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
 import com.google.errorprone.annotations.Immutable;
 import io.confluent.ksql.parser.NodeLocation;
 import java.util.Objects;
@@ -24,13 +26,18 @@ import java.util.Optional;
 
 @Immutable
 public class SubscriptExpression extends Expression {
+  private static final String BASE = "base";
+  private static final String INDEX = "index";
 
+  @JsonProperty(BASE)
   private final Expression base;
+  @JsonProperty(INDEX)
   private final Expression index;
 
+  @JsonCreator
   public SubscriptExpression(
-      final Expression base,
-      final Expression index
+      @JsonProperty(BASE) final Expression base,
+      @JsonProperty(INDEX) final Expression index
   ) {
     this(Optional.empty(), base, index);
   }

--- a/ksql-execution/src/main/java/io/confluent/ksql/execution/expression/tree/TimeLiteral.java
+++ b/ksql-execution/src/main/java/io/confluent/ksql/execution/expression/tree/TimeLiteral.java
@@ -17,6 +17,8 @@ package io.confluent.ksql.execution.expression.tree;
 
 import static java.util.Objects.requireNonNull;
 
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
 import com.google.errorprone.annotations.Immutable;
 import io.confluent.ksql.parser.NodeLocation;
 import java.util.Objects;
@@ -24,10 +26,13 @@ import java.util.Optional;
 
 @Immutable
 public class TimeLiteral extends Literal {
+  private static final String VALUE = "value";
 
+  @JsonProperty(VALUE)
   private final String value;
 
-  public TimeLiteral(final String value) {
+  @JsonCreator
+  public TimeLiteral(@JsonProperty(VALUE) final String value) {
     this(Optional.empty(), value);
   }
 

--- a/ksql-execution/src/main/java/io/confluent/ksql/execution/expression/tree/TimestampLiteral.java
+++ b/ksql-execution/src/main/java/io/confluent/ksql/execution/expression/tree/TimestampLiteral.java
@@ -17,6 +17,8 @@ package io.confluent.ksql.execution.expression.tree;
 
 import static java.util.Objects.requireNonNull;
 
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
 import com.google.errorprone.annotations.Immutable;
 import io.confluent.ksql.parser.NodeLocation;
 import java.util.Objects;
@@ -24,10 +26,13 @@ import java.util.Optional;
 
 @Immutable
 public class TimestampLiteral extends Literal {
+  private static final String VALUE = "value";
 
+  @JsonProperty(VALUE)
   private final String value;
 
-  public TimestampLiteral(final String value) {
+  @JsonCreator
+  public TimestampLiteral(@JsonProperty(VALUE) final String value) {
     this(Optional.empty(), value);
   }
 

--- a/ksql-execution/src/main/java/io/confluent/ksql/execution/expression/tree/Type.java
+++ b/ksql-execution/src/main/java/io/confluent/ksql/execution/expression/tree/Type.java
@@ -17,6 +17,8 @@ package io.confluent.ksql.execution.expression.tree;
 
 import static java.util.Objects.requireNonNull;
 
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
 import com.google.errorprone.annotations.Immutable;
 import io.confluent.ksql.parser.NodeLocation;
 import io.confluent.ksql.schema.ksql.types.SqlType;
@@ -25,10 +27,13 @@ import java.util.Optional;
 
 @Immutable
 public final class Type extends Expression {
+  private static final String SQL_TYPE = "sqlType";
 
+  @JsonProperty(SQL_TYPE)
   private final SqlType sqlType;
 
-  public Type(final SqlType sqlType) {
+  @JsonCreator
+  public Type(@JsonProperty(SQL_TYPE) final SqlType sqlType) {
     this(Optional.empty(), sqlType);
   }
 

--- a/ksql-execution/src/main/java/io/confluent/ksql/execution/expression/tree/WhenClause.java
+++ b/ksql-execution/src/main/java/io/confluent/ksql/execution/expression/tree/WhenClause.java
@@ -17,6 +17,8 @@ package io.confluent.ksql.execution.expression.tree;
 
 import static java.util.Objects.requireNonNull;
 
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
 import com.google.errorprone.annotations.Immutable;
 import io.confluent.ksql.parser.NodeLocation;
 import java.util.Objects;
@@ -24,11 +26,18 @@ import java.util.Optional;
 
 @Immutable
 public class WhenClause extends Expression {
+  private static final String OPERAND = "operand";
+  private static final String RESULT = "result";
 
+  @JsonProperty(OPERAND)
   private final Expression operand;
+  @JsonProperty(RESULT)
   private final Expression result;
 
-  public WhenClause(final Expression operand, final Expression result) {
+  @JsonCreator
+  public WhenClause(
+      @JsonProperty(OPERAND) final Expression operand,
+      @JsonProperty(RESULT) final Expression result) {
     this(Optional.empty(), operand, result);
   }
 

--- a/ksql-execution/src/main/java/io/confluent/ksql/execution/mapper/ObjectMapperFactory.java
+++ b/ksql-execution/src/main/java/io/confluent/ksql/execution/mapper/ObjectMapperFactory.java
@@ -1,0 +1,43 @@
+package io.confluent.ksql.execution.mapper;
+
+import com.fasterxml.jackson.databind.JsonDeserializer;
+import com.fasterxml.jackson.databind.JsonSerializer;
+import com.fasterxml.jackson.databind.MapperFeature;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.module.SimpleModule;
+import com.fasterxml.jackson.datatype.jdk8.Jdk8Module;
+import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
+import io.confluent.ksql.execution.expression.tree.Expression;
+import io.confluent.ksql.execution.expression.tree.FunctionCall;
+
+public final class ObjectMapperFactory {
+  private ObjectMapperFactory() {
+  }
+
+  public static ObjectMapper build(
+      final JsonSerializer<Expression> expressionSerializer,
+      final JsonDeserializer<Expression> expressionDeserializer) {
+    final ObjectMapper objectMapper = new ObjectMapper();
+    objectMapper
+        .configure(MapperFeature.AUTO_DETECT_CREATORS, false)
+        .configure(MapperFeature.AUTO_DETECT_FIELDS, false)
+        .configure(MapperFeature.AUTO_DETECT_GETTERS, false)
+        .configure(MapperFeature.AUTO_DETECT_IS_GETTERS, false)
+        .configure(MapperFeature.AUTO_DETECT_SETTERS, false);
+    objectMapper.registerModule(new Jdk8Module());
+    objectMapper.registerModule(new JavaTimeModule());
+    objectMapper.registerModule(new ExpressionModule(expressionSerializer, expressionDeserializer));
+    return objectMapper;
+  }
+
+  private static class ExpressionModule extends SimpleModule {
+    @SuppressWarnings("unchecked")
+    ExpressionModule(
+        final JsonSerializer<Expression> serializer,
+        final JsonDeserializer<Expression> deserializer) {
+      addSerializer(Expression.class, serializer);
+      addDeserializer(Expression.class, deserializer);
+      addDeserializer(FunctionCall.class, (JsonDeserializer) deserializer);
+    }
+  }
+}

--- a/ksql-execution/src/main/java/io/confluent/ksql/execution/plan/DefaultExecutionStepProperties.java
+++ b/ksql-execution/src/main/java/io/confluent/ksql/execution/plan/DefaultExecutionStepProperties.java
@@ -14,6 +14,8 @@
 
 package io.confluent.ksql.execution.plan;
 
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
 import com.google.errorprone.annotations.Immutable;
 import io.confluent.ksql.execution.context.QueryContext;
 import io.confluent.ksql.schema.ksql.LogicalSchema;
@@ -21,12 +23,18 @@ import java.util.Objects;
 
 @Immutable
 public class DefaultExecutionStepProperties implements ExecutionStepProperties {
+  private static final String CONTEXT = "context";
+  private static final String SCHEMA = "schema";
+
+  @JsonProperty(CONTEXT)
   private final QueryContext queryContext;
+  @JsonProperty(SCHEMA)
   private final LogicalSchema schema;
 
+  @JsonCreator
   public DefaultExecutionStepProperties(
-      final LogicalSchema schema,
-      final QueryContext queryContext) {
+      @JsonProperty(SCHEMA) final LogicalSchema schema,
+      @JsonProperty(CONTEXT) final QueryContext queryContext) {
     this.queryContext = Objects.requireNonNull(queryContext, "queryContext");
     this.schema = Objects.requireNonNull(schema, "schema");
   }

--- a/ksql-execution/src/main/java/io/confluent/ksql/execution/plan/ExecutionStep.java
+++ b/ksql-execution/src/main/java/io/confluent/ksql/execution/plan/ExecutionStep.java
@@ -14,10 +14,38 @@
 
 package io.confluent.ksql.execution.plan;
 
+import com.fasterxml.jackson.annotation.JsonSubTypes;
+import com.fasterxml.jackson.annotation.JsonSubTypes.Type;
+import com.fasterxml.jackson.annotation.JsonTypeInfo;
+import com.fasterxml.jackson.annotation.JsonTypeInfo.As;
 import io.confluent.ksql.execution.builder.KsqlQueryBuilder;
 import java.util.List;
 
+@JsonTypeInfo(
+    use = JsonTypeInfo.Id.NAME,
+    include = As.WRAPPER_OBJECT
+)
+@JsonSubTypes({
+    @Type(value = StreamAggregate.class, name = "streamAggregateV1"),
+    @Type(value = StreamFilter.class, name = "streamFilterV1"),
+    @Type(value = StreamGroupBy.class, name = "streamGroupByV1"),
+    @Type(value = StreamMapValues.class, name = "streamMapValuesV1"),
+    @Type(value = StreamSelectKey.class, name = "streamSelectKeyV1"),
+    @Type(value = StreamSink.class, name = "streamSinkV1"),
+    @Type(value = StreamSource.class, name = "streamSourceV1"),
+    @Type(value = StreamStreamJoin.class, name = "streamStreamJoinV1"),
+    @Type(value = StreamTableJoin.class, name = "streamTableJoinV1"),
+    @Type(value = StreamToTable.class, name = "streamToTableV1"),
+    @Type(value = TableAggregate.class, name = "tableAggregateV1"),
+    @Type(value = TableFilter.class, name = "tableFilterV1"),
+    @Type(value = TableGroupBy.class, name = "tableGroupByV1"),
+    @Type(value = TableMapValues.class, name = "tableMapValuesV1"),
+    @Type(value = TableSink.class, name="tableSinkV1"),
+    @Type(value = TableTableJoin.class, name="tableTableJoinV1")
+})
 public interface ExecutionStep<S> {
+  String PROPERTIES = "properties";
+
   ExecutionStepProperties getProperties();
 
   List<ExecutionStep<?>> getSources();

--- a/ksql-execution/src/main/java/io/confluent/ksql/execution/plan/ExecutionStepProperties.java
+++ b/ksql-execution/src/main/java/io/confluent/ksql/execution/plan/ExecutionStepProperties.java
@@ -14,9 +14,18 @@
 
 package io.confluent.ksql.execution.plan;
 
+import com.fasterxml.jackson.annotation.JsonSubTypes;
+import com.fasterxml.jackson.annotation.JsonSubTypes.Type;
+import com.fasterxml.jackson.annotation.JsonTypeInfo;
 import io.confluent.ksql.execution.context.QueryContext;
 import io.confluent.ksql.schema.ksql.LogicalSchema;
 
+@JsonTypeInfo(
+    use = JsonTypeInfo.Id.NAME,
+    include = JsonTypeInfo.As.PROPERTY,
+    property = "type")
+@JsonSubTypes({
+    @Type(value = DefaultExecutionStepProperties.class, name = "default") })
 public interface ExecutionStepProperties {
   LogicalSchema getSchema();
 

--- a/ksql-execution/src/main/java/io/confluent/ksql/execution/plan/Formats.java
+++ b/ksql-execution/src/main/java/io/confluent/ksql/execution/plan/Formats.java
@@ -14,6 +14,8 @@
 
 package io.confluent.ksql.execution.plan;
 
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
 import com.google.errorprone.annotations.Immutable;
 import io.confluent.ksql.serde.KeyFormat;
 import io.confluent.ksql.serde.SerdeOption;
@@ -23,8 +25,15 @@ import java.util.Set;
 
 @Immutable
 public final class Formats {
+  private static final String KEY_FORMAT = "keyFormat";
+  private static final String VALUE_FORMAT = "valueFormat";
+  private static final String SERDE_OPTIONS = "serdeOptions";
+
+  @JsonProperty(KEY_FORMAT)
   private final KeyFormat keyFormat;
+  @JsonProperty(VALUE_FORMAT)
   private final ValueFormat valueFormat;
+  @JsonProperty(SERDE_OPTIONS)
   private final Set<SerdeOption> options;
 
   public static Formats of(
@@ -34,10 +43,11 @@ public final class Formats {
     return new Formats(keyFormat, valueFormat, options);
   }
 
+  @JsonCreator
   private Formats(
-      final KeyFormat keyFormat,
-      final ValueFormat valueFormat,
-      final Set<SerdeOption> options) {
+      @JsonProperty(KEY_FORMAT) final KeyFormat keyFormat,
+      @JsonProperty(VALUE_FORMAT) final ValueFormat valueFormat,
+      @JsonProperty(SERDE_OPTIONS) final Set<SerdeOption> options) {
     this.keyFormat = Objects.requireNonNull(keyFormat, "keyFormat");
     this.valueFormat = Objects.requireNonNull(valueFormat, "valueFormat");
     this.options = Objects.requireNonNull(options, "options");

--- a/ksql-execution/src/main/java/io/confluent/ksql/execution/plan/SelectExpression.java
+++ b/ksql-execution/src/main/java/io/confluent/ksql/execution/plan/SelectExpression.java
@@ -15,6 +15,8 @@
 
 package io.confluent.ksql.execution.plan;
 
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
 import io.confluent.ksql.execution.expression.tree.Expression;
 import java.util.Objects;
 import javax.annotation.concurrent.Immutable;
@@ -24,11 +26,18 @@ import javax.annotation.concurrent.Immutable;
  */
 @Immutable
 public final class SelectExpression {
+  private static final String NAME = "name";
+  private static final String EXPRESSION = "expression";
 
+  @JsonProperty(NAME)
   private final String name;
+  @JsonProperty(EXPRESSION)
   private final Expression expression;
 
-  private SelectExpression(final String name, final Expression expression) {
+  @JsonCreator
+  private SelectExpression(
+      @JsonProperty(NAME) final String name,
+      @JsonProperty(EXPRESSION) final Expression expression) {
     this.name = Objects.requireNonNull(name, "name");
     this.expression = Objects.requireNonNull(expression, "expression");
   }

--- a/ksql-execution/src/main/java/io/confluent/ksql/execution/plan/StreamAggregate.java
+++ b/ksql-execution/src/main/java/io/confluent/ksql/execution/plan/StreamAggregate.java
@@ -14,6 +14,8 @@
 
 package io.confluent.ksql.execution.plan;
 
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
 import com.google.errorprone.annotations.Immutable;
 import io.confluent.ksql.execution.builder.KsqlQueryBuilder;
 import io.confluent.ksql.execution.expression.tree.FunctionCall;
@@ -23,18 +25,29 @@ import java.util.Objects;
 
 @Immutable
 public class StreamAggregate<T, G> implements ExecutionStep<T> {
+  private static final String FORMATS = "formats";
+  private static final String SOURCE = "source";
+  private static final String NON_FUNC_COLUMN_COUNT = "nonFuncColumnCount";
+  private static final String AGGREGATIONS = "aggregations";
+
+  @JsonProperty(PROPERTIES)
   private final ExecutionStepProperties properties;
-  private final ExecutionStep<G> source;
+  @JsonProperty(FORMATS)
   private final Formats formats;
+  @JsonProperty(SOURCE)
+  private final ExecutionStep<G> source;
+  @JsonProperty(NON_FUNC_COLUMN_COUNT)
   private final int nonFuncColumnCount;
+  @JsonProperty(AGGREGATIONS)
   private final List<FunctionCall> aggregations;
 
+  @JsonCreator
   public StreamAggregate(
-      final ExecutionStepProperties properties,
-      final ExecutionStep<G> source,
-      final Formats formats,
-      final int nonFuncColumnCount,
-      final List<FunctionCall> aggregations) {
+      @JsonProperty(PROPERTIES) final ExecutionStepProperties properties,
+      @JsonProperty(SOURCE) final ExecutionStep<G> source,
+      @JsonProperty(FORMATS) final Formats formats,
+      @JsonProperty(NON_FUNC_COLUMN_COUNT) final int nonFuncColumnCount,
+      @JsonProperty(AGGREGATIONS) final List<FunctionCall> aggregations) {
     this.properties = Objects.requireNonNull(properties, "properties");
     this.source = Objects.requireNonNull(source, "source");
     this.formats = Objects.requireNonNull(formats, "formats");

--- a/ksql-execution/src/main/java/io/confluent/ksql/execution/plan/StreamFilter.java
+++ b/ksql-execution/src/main/java/io/confluent/ksql/execution/plan/StreamFilter.java
@@ -14,6 +14,8 @@
 
 package io.confluent.ksql.execution.plan;
 
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
 import com.google.errorprone.annotations.Immutable;
 import io.confluent.ksql.execution.builder.KsqlQueryBuilder;
 import io.confluent.ksql.execution.expression.tree.Expression;
@@ -23,15 +25,21 @@ import java.util.Objects;
 
 @Immutable
 public class StreamFilter<S> implements ExecutionStep<S> {
+  private static final String FILTER_EXPRESSION = "filterExpression";
+  private static final String SOURCE = "source";
 
+  @JsonProperty(PROPERTIES)
   private final ExecutionStepProperties properties;
+  @JsonProperty(SOURCE)
   private final ExecutionStep<S> source;
+  @JsonProperty(FILTER_EXPRESSION)
   private final Expression filterExpression;
 
+  @JsonCreator
   public StreamFilter(
-      final ExecutionStepProperties properties,
-      final ExecutionStep<S> source,
-      final Expression filterExpression) {
+      @JsonProperty(PROPERTIES) final ExecutionStepProperties properties,
+      @JsonProperty(SOURCE) final ExecutionStep<S> source,
+      @JsonProperty(FILTER_EXPRESSION) final Expression filterExpression) {
     this.properties = Objects.requireNonNull(properties, "properties");
     this.source = Objects.requireNonNull(source, "source");
     this.filterExpression = Objects.requireNonNull(filterExpression, "filterExpression");

--- a/ksql-execution/src/main/java/io/confluent/ksql/execution/plan/StreamGroupBy.java
+++ b/ksql-execution/src/main/java/io/confluent/ksql/execution/plan/StreamGroupBy.java
@@ -14,6 +14,8 @@
 
 package io.confluent.ksql.execution.plan;
 
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
 import com.google.errorprone.annotations.Immutable;
 import io.confluent.ksql.execution.builder.KsqlQueryBuilder;
 import io.confluent.ksql.execution.expression.tree.Expression;
@@ -23,16 +25,25 @@ import java.util.Objects;
 
 @Immutable
 public class StreamGroupBy<S, G> implements ExecutionStep<G> {
+  private static final String SOURCE = "source";
+  private static final String FORMATS = "formats";
+  private static final String GROUP_BY_EXPRESSIONS = "groupByExpressions";
+
+  @JsonProperty(PROPERTIES)
   private final ExecutionStepProperties properties;
+  @JsonProperty(SOURCE)
   private final ExecutionStep<S> source;
+  @JsonProperty(FORMATS)
   private final Formats formats;
+  @JsonProperty(GROUP_BY_EXPRESSIONS)
   private final List<Expression> groupByExpressions;
 
+  @JsonCreator
   public StreamGroupBy(
-      final ExecutionStepProperties properties,
-      final ExecutionStep<S> source,
-      final Formats formats,
-      final List<Expression> groupByExpressions) {
+      @JsonProperty(PROPERTIES) final ExecutionStepProperties properties,
+      @JsonProperty(SOURCE) final ExecutionStep<S> source,
+      @JsonProperty(FORMATS) final Formats formats,
+      @JsonProperty(GROUP_BY_EXPRESSIONS) final List<Expression> groupByExpressions) {
     this.properties = Objects.requireNonNull(properties, "properties");
     this.formats = Objects.requireNonNull(formats, "formats");
     this.source = Objects.requireNonNull(source, "source");

--- a/ksql-execution/src/main/java/io/confluent/ksql/execution/plan/StreamMapValues.java
+++ b/ksql-execution/src/main/java/io/confluent/ksql/execution/plan/StreamMapValues.java
@@ -14,6 +14,8 @@
 
 package io.confluent.ksql.execution.plan;
 
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
 import com.google.common.collect.ImmutableList;
 import com.google.errorprone.annotations.Immutable;
 import io.confluent.ksql.execution.builder.KsqlQueryBuilder;
@@ -23,14 +25,21 @@ import java.util.Objects;
 
 @Immutable
 public class StreamMapValues<S> implements ExecutionStep<S> {
+  private static final String SOURCE = "source";
+  private static final String SELECT_EXPRESSIONS = "selectExpressions";
+
+  @JsonProperty(PROPERTIES)
   private final ExecutionStepProperties properties;
+  @JsonProperty(SOURCE)
   private final ExecutionStep<S> source;
+  @JsonProperty(SELECT_EXPRESSIONS)
   private final List<SelectExpression> selectExpressions;
 
+  @JsonCreator
   public StreamMapValues(
-      final ExecutionStepProperties properties,
-      final ExecutionStep<S> source,
-      final List<SelectExpression> selectExpressions) {
+      @JsonProperty(PROPERTIES) final ExecutionStepProperties properties,
+      @JsonProperty(SOURCE) final ExecutionStep<S> source,
+      @JsonProperty(SELECT_EXPRESSIONS) final List<SelectExpression> selectExpressions) {
     this.properties = Objects.requireNonNull(properties, "properties");
     this.source = Objects.requireNonNull(source, "source");
     this.selectExpressions = ImmutableList.copyOf(selectExpressions);

--- a/ksql-execution/src/main/java/io/confluent/ksql/execution/plan/StreamSelectKey.java
+++ b/ksql-execution/src/main/java/io/confluent/ksql/execution/plan/StreamSelectKey.java
@@ -14,6 +14,8 @@
 
 package io.confluent.ksql.execution.plan;
 
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
 import com.google.errorprone.annotations.Immutable;
 import io.confluent.ksql.execution.builder.KsqlQueryBuilder;
 import java.util.Collections;
@@ -22,18 +24,28 @@ import java.util.Objects;
 
 @Immutable
 public class StreamSelectKey<S> implements ExecutionStep<S> {
+  private static final String PROPERTIES = "properties";
+  private static final String SOURCE = "source";
+  private static final String FIELD_NAME = "fieldName";
+  private static final String UPDATE_ROW_KEY = "updateRowKey";
+
+  @JsonProperty(PROPERTIES)
   private final ExecutionStepProperties properties;
+  @JsonProperty(SOURCE)
   private final ExecutionStep<S> source;
+  @JsonProperty(FIELD_NAME)
   private final String fieldName;
+  @JsonProperty(UPDATE_ROW_KEY)
   private final boolean updateRowKey;
 
+  @JsonCreator
   public StreamSelectKey(
-      final ExecutionStepProperties properties,
-      final ExecutionStep<S> source,
-      final String fieldName,
-      final boolean updateRowKey) {
+      @JsonProperty(PROPERTIES) final ExecutionStepProperties properties,
+      @JsonProperty(SOURCE) final ExecutionStep<S> source,
+      @JsonProperty(FIELD_NAME) final String fieldName,
+      @JsonProperty(UPDATE_ROW_KEY) final boolean updateRowKey) {
     this.properties = Objects.requireNonNull(properties, "properties");
-    this.source = Objects.requireNonNull(source, "source");
+    this.source = source;  // Objects.requireNonNull(source, "source");
     this.fieldName = Objects.requireNonNull(fieldName, "fieldName");
     this.updateRowKey = updateRowKey;
   }
@@ -46,6 +58,10 @@ public class StreamSelectKey<S> implements ExecutionStep<S> {
   @Override
   public List<ExecutionStep<?>> getSources() {
     return Collections.singletonList(source);
+  }
+
+  public ExecutionStep<S> getSource() {
+    return source;
   }
 
   @Override

--- a/ksql-execution/src/main/java/io/confluent/ksql/execution/plan/StreamSink.java
+++ b/ksql-execution/src/main/java/io/confluent/ksql/execution/plan/StreamSink.java
@@ -14,6 +14,8 @@
 
 package io.confluent.ksql.execution.plan;
 
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
 import com.google.errorprone.annotations.Immutable;
 import io.confluent.ksql.execution.builder.KsqlQueryBuilder;
 import java.util.Collections;
@@ -22,16 +24,25 @@ import java.util.Objects;
 
 @Immutable
 public class StreamSink<S> implements ExecutionStep<S> {
+  private static final String SOURCE = "source";
+  private static final String FORMATS = "formats";
+  private static final String TOPIC_NAME = "topicName";
+
+  @JsonProperty(PROPERTIES)
   private final ExecutionStepProperties properties;
+  @JsonProperty(SOURCE)
   private final ExecutionStep<S>  source;
+  @JsonProperty(FORMATS)
   private final Formats formats;
+  @JsonProperty(TOPIC_NAME)
   private final String topicName;
 
+  @JsonCreator
   public StreamSink(
-      final ExecutionStepProperties properties,
-      final ExecutionStep<S> source,
-      final Formats formats,
-      final String topicName) {
+      @JsonProperty(PROPERTIES) final ExecutionStepProperties properties,
+      @JsonProperty(SOURCE) final ExecutionStep<S> source,
+      @JsonProperty(FORMATS) final Formats formats,
+      @JsonProperty(TOPIC_NAME) final String topicName) {
     this.properties = Objects.requireNonNull(properties, "properties");
     this.formats = Objects.requireNonNull(formats, "formats");
     this.source = Objects.requireNonNull(source, "source");

--- a/ksql-execution/src/main/java/io/confluent/ksql/execution/plan/StreamSource.java
+++ b/ksql-execution/src/main/java/io/confluent/ksql/execution/plan/StreamSource.java
@@ -14,6 +14,8 @@
 
 package io.confluent.ksql.execution.plan;
 
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
 import com.google.common.annotations.VisibleForTesting;
 import com.google.errorprone.annotations.Immutable;
 import io.confluent.ksql.execution.builder.KsqlQueryBuilder;
@@ -28,14 +30,27 @@ import org.apache.kafka.streams.Topology.AutoOffsetReset;
 
 @Immutable
 public class StreamSource<S> implements ExecutionStep<S> {
+  private static final String TOPIC_NAME = "topicName";
+  private static final String FORMATS = "formats";
+  private static final String TIMESTAMP_POLICY = "timestampPolicy";
+  private static final String TIMESTMAP_INDEX = "timestampIndex";
+  private static final String OFFSET_RESET = "offsetReset";
+  private static final String SOURCE_SCHEMA = "sourceSchema";
+
+  @JsonProperty(PROPERTIES)
   private final ExecutionStepProperties properties;
+  @JsonProperty(TOPIC_NAME)
   private final String topicName;
+  @JsonProperty(FORMATS)
   private final Formats formats;
+  @JsonProperty(TIMESTAMP_POLICY)
   private final TimestampExtractionPolicy timestampPolicy;
+  @JsonProperty(TIMESTMAP_INDEX)
   private final int timestampIndex;
+  @JsonProperty(OFFSET_RESET)
   private final Optional<AutoOffsetReset> offsetReset;
+  @JsonProperty(SOURCE_SCHEMA)
   private final LogicalSchema sourceSchema;
-  private final BiFunction<KsqlQueryBuilder, StreamSource<S>, S> builder;
 
   public static LogicalSchemaWithMetaAndKeyFields getSchemaWithMetaAndKeyFields(
       final String alias,
@@ -44,15 +59,15 @@ public class StreamSource<S> implements ExecutionStep<S> {
   }
 
   @VisibleForTesting
+  @JsonCreator
   public StreamSource(
-      final ExecutionStepProperties properties,
-      final String topicName,
-      final Formats formats,
-      final TimestampExtractionPolicy timestampPolicy,
-      final int timestampIndex,
-      final Optional<AutoOffsetReset> offsetReset,
-      final LogicalSchema sourceSchema,
-      final BiFunction<KsqlQueryBuilder, StreamSource<S>, S> builder) {
+      @JsonProperty(PROPERTIES) final ExecutionStepProperties properties,
+      @JsonProperty(TOPIC_NAME) final String topicName,
+      @JsonProperty(FORMATS) final Formats formats,
+      @JsonProperty(TIMESTAMP_POLICY) final TimestampExtractionPolicy timestampPolicy,
+      @JsonProperty(TIMESTMAP_INDEX) final int timestampIndex,
+      @JsonProperty(OFFSET_RESET) final Optional<AutoOffsetReset> offsetReset,
+      @JsonProperty(SOURCE_SCHEMA) final LogicalSchema sourceSchema) {
     this.properties = Objects.requireNonNull(properties, "properties");
     this.topicName = Objects.requireNonNull(topicName, "topicName");
     this.formats = Objects.requireNonNull(formats, "formats");
@@ -60,12 +75,11 @@ public class StreamSource<S> implements ExecutionStep<S> {
     this.timestampIndex = timestampIndex;
     this.offsetReset = Objects.requireNonNull(offsetReset, "offsetReset");
     this.sourceSchema = Objects.requireNonNull(sourceSchema, "sourceSchema");
-    this.builder = Objects.requireNonNull(builder, "builder");
   }
 
   @Override
   public S build(final KsqlQueryBuilder ksqlQueryBuilder) {
-    return builder.apply(ksqlQueryBuilder, this);
+    return null;
   }
 
   @Override

--- a/ksql-execution/src/main/java/io/confluent/ksql/execution/plan/StreamStreamJoin.java
+++ b/ksql-execution/src/main/java/io/confluent/ksql/execution/plan/StreamStreamJoin.java
@@ -14,6 +14,8 @@
 
 package io.confluent.ksql.execution.plan;
 
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
 import com.google.common.collect.ImmutableList;
 import com.google.errorprone.annotations.Immutable;
 import io.confluent.ksql.execution.builder.KsqlQueryBuilder;
@@ -23,25 +25,41 @@ import java.util.Objects;
 
 @Immutable
 public class StreamStreamJoin<S> implements ExecutionStep<S> {
+  private static final String JOIN_TYPE = "joinType";
+  private static final String LEFT_FORMATS = "leftFormats";
+  private static final String RIGHT_FORMATS = "rightFormats";
+  private static final String LEFT = "left";
+  private static final String RIGHT = "right";
+  private static final String BEFORE = "before";
+  private static final String AFTER = "after";
 
+  @JsonProperty(PROPERTIES)
   private final ExecutionStepProperties properties;
+  @JsonProperty(JOIN_TYPE)
   private final JoinType joinType;
+  @JsonProperty(LEFT_FORMATS)
   private final Formats leftFormats;
+  @JsonProperty(RIGHT_FORMATS)
   private final Formats rightFormats;
+  @JsonProperty(LEFT)
   private final ExecutionStep<S> left;
+  @JsonProperty(RIGHT)
   private final ExecutionStep<S> right;
+  @JsonProperty(BEFORE)
   private final Duration before;
+  @JsonProperty(AFTER)
   private final Duration after;
 
+  @JsonCreator
   public StreamStreamJoin(
-      final ExecutionStepProperties properties,
-      final JoinType joinType,
-      final Formats leftFormats,
-      final Formats rightFormats,
-      final ExecutionStep<S> left,
-      final ExecutionStep<S> right,
-      final Duration before,
-      final Duration after) {
+      @JsonProperty(PROPERTIES) final ExecutionStepProperties properties,
+      @JsonProperty(JOIN_TYPE) final JoinType joinType,
+      @JsonProperty(LEFT_FORMATS) final Formats leftFormats,
+      @JsonProperty(RIGHT_FORMATS) final Formats rightFormats,
+      @JsonProperty(LEFT) final ExecutionStep<S> left,
+      @JsonProperty(RIGHT) final ExecutionStep<S> right,
+      @JsonProperty(BEFORE) final Duration before,
+      @JsonProperty(AFTER) final Duration after) {
     this.properties = Objects.requireNonNull(properties, "properties");
     this.leftFormats = Objects.requireNonNull(leftFormats, "formats");
     this.rightFormats = Objects.requireNonNull(rightFormats, "rightFormats");

--- a/ksql-execution/src/main/java/io/confluent/ksql/execution/plan/StreamTableJoin.java
+++ b/ksql-execution/src/main/java/io/confluent/ksql/execution/plan/StreamTableJoin.java
@@ -14,6 +14,8 @@
 
 package io.confluent.ksql.execution.plan;
 
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
 import com.google.common.collect.ImmutableList;
 import com.google.errorprone.annotations.Immutable;
 import io.confluent.ksql.execution.builder.KsqlQueryBuilder;
@@ -22,19 +24,29 @@ import java.util.Objects;
 
 @Immutable
 public class StreamTableJoin<S, T> implements ExecutionStep<S> {
+  private static final String JOIN_TYPE = "joinType";
+  private static final String FORMATS = "formats";
+  private static final String LEFT = "left";
+  private static final String RIGHT = "right";
 
+  @JsonProperty(PROPERTIES)
   private final ExecutionStepProperties properties;
+  @JsonProperty(JOIN_TYPE)
   private final JoinType joinType;
+  @JsonProperty(FORMATS)
   private final Formats formats;
+  @JsonProperty(LEFT)
   private final ExecutionStep<S> left;
+  @JsonProperty(RIGHT)
   private final ExecutionStep<T> right;
 
+  @JsonCreator
   public StreamTableJoin(
-      final ExecutionStepProperties properties,
-      final JoinType joinType,
-      final Formats formats,
-      final ExecutionStep<S> left,
-      final ExecutionStep<T> right) {
+      @JsonProperty(PROPERTIES) final ExecutionStepProperties properties,
+      @JsonProperty(JOIN_TYPE) final JoinType joinType,
+      @JsonProperty(FORMATS) final Formats formats,
+      @JsonProperty(LEFT) final ExecutionStep<S> left,
+      @JsonProperty(RIGHT) final ExecutionStep<T> right) {
     this.properties = Objects.requireNonNull(properties, "properties");
     this.formats = Objects.requireNonNull(formats, "formats");
     this.joinType = Objects.requireNonNull(joinType, "joinType");

--- a/ksql-execution/src/main/java/io/confluent/ksql/execution/plan/StreamToTable.java
+++ b/ksql-execution/src/main/java/io/confluent/ksql/execution/plan/StreamToTable.java
@@ -14,6 +14,8 @@
 
 package io.confluent.ksql.execution.plan;
 
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
 import com.google.common.collect.ImmutableList;
 import com.google.errorprone.annotations.Immutable;
 import io.confluent.ksql.execution.builder.KsqlQueryBuilder;
@@ -22,14 +24,21 @@ import java.util.Objects;
 
 @Immutable
 public class StreamToTable<S, T> implements ExecutionStep<T> {
+  private static final String FORMATS = "formats";
+  private static final String SOURCE = "source";
+
+  @JsonProperty(SOURCE)
   private final ExecutionStep<S> source;
+  @JsonProperty(FORMATS)
   private final Formats formats;
+  @JsonProperty(PROPERTIES)
   private final ExecutionStepProperties properties;
 
+  @JsonCreator
   public StreamToTable(
-      final ExecutionStep<S> source,
-      final Formats formats,
-      final ExecutionStepProperties properties) {
+      @JsonProperty(SOURCE) final ExecutionStep<S> source,
+      @JsonProperty(FORMATS) final Formats formats,
+      @JsonProperty(PROPERTIES) final ExecutionStepProperties properties) {
     this.source = Objects.requireNonNull(source, "source");
     this.formats = Objects.requireNonNull(formats, "formats");
     this.properties = Objects.requireNonNull(properties, "properties");

--- a/ksql-execution/src/main/java/io/confluent/ksql/execution/plan/TableAggregate.java
+++ b/ksql-execution/src/main/java/io/confluent/ksql/execution/plan/TableAggregate.java
@@ -14,6 +14,8 @@
 
 package io.confluent.ksql.execution.plan;
 
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
 import com.google.errorprone.annotations.Immutable;
 import io.confluent.ksql.execution.builder.KsqlQueryBuilder;
 import io.confluent.ksql.execution.expression.tree.FunctionCall;
@@ -23,18 +25,29 @@ import java.util.Objects;
 
 @Immutable
 public class TableAggregate<T, G> implements ExecutionStep<T> {
+  private static final String SOURCE = "source";
+  private static final String FORMATS = "formats";
+  private static final String NON_FUNC_COLUMN_COUNT = "nonFuncColumnCount";
+  private static final String AGGREGATIONS = "aggregations";
+
+  @JsonProperty(PROPERTIES)
   private final ExecutionStepProperties properties;
+  @JsonProperty(SOURCE)
   private final ExecutionStep<G> source;
+  @JsonProperty(FORMATS)
   private final Formats formats;
+  @JsonProperty(NON_FUNC_COLUMN_COUNT)
   private final int nonFuncColumnCount;
+  @JsonProperty(AGGREGATIONS)
   private final List<FunctionCall> aggregations;
 
+  @JsonCreator
   public TableAggregate(
-      final ExecutionStepProperties properties,
-      final ExecutionStep<G> source,
-      final Formats formats,
-      final int nonFuncColumnCount,
-      final List<FunctionCall> aggregations) {
+      @JsonProperty(PROPERTIES) final ExecutionStepProperties properties,
+      @JsonProperty(SOURCE) final ExecutionStep<G> source,
+      @JsonProperty(FORMATS) final Formats formats,
+      @JsonProperty(NON_FUNC_COLUMN_COUNT) final int nonFuncColumnCount,
+      @JsonProperty(AGGREGATIONS) final List<FunctionCall> aggregations) {
     this.properties = Objects.requireNonNull(properties, "properties");
     this.source = Objects.requireNonNull(source, "source");
     this.formats = Objects.requireNonNull(formats, "formats");

--- a/ksql-execution/src/main/java/io/confluent/ksql/execution/plan/TableFilter.java
+++ b/ksql-execution/src/main/java/io/confluent/ksql/execution/plan/TableFilter.java
@@ -14,6 +14,8 @@
 
 package io.confluent.ksql.execution.plan;
 
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
 import com.google.errorprone.annotations.Immutable;
 import io.confluent.ksql.execution.builder.KsqlQueryBuilder;
 import io.confluent.ksql.execution.expression.tree.Expression;
@@ -23,14 +25,21 @@ import java.util.Objects;
 
 @Immutable
 public class TableFilter<T> implements ExecutionStep<T> {
+  private static final String SOURCE = "source";
+  private static final String FILTER_EXPRESSION = "filterExpression";
+
+  @JsonProperty(PROPERTIES)
   private final ExecutionStepProperties properties;
+  @JsonProperty(SOURCE)
   private final ExecutionStep<T> source;
+  @JsonProperty(FILTER_EXPRESSION)
   private final Expression filterExpression;
 
+  @JsonCreator
   public TableFilter(
-      final ExecutionStepProperties properties,
-      final ExecutionStep<T> source,
-      final Expression filterExpression
+      @JsonProperty(PROPERTIES) final ExecutionStepProperties properties,
+      @JsonProperty(SOURCE) final ExecutionStep<T> source,
+      @JsonProperty(FILTER_EXPRESSION) final Expression filterExpression
   ) {
     this.properties = Objects.requireNonNull(properties, "properties");
     this.source = Objects.requireNonNull(source, "source");

--- a/ksql-execution/src/main/java/io/confluent/ksql/execution/plan/TableGroupBy.java
+++ b/ksql-execution/src/main/java/io/confluent/ksql/execution/plan/TableGroupBy.java
@@ -14,6 +14,8 @@
 
 package io.confluent.ksql.execution.plan;
 
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
 import com.google.errorprone.annotations.Immutable;
 import io.confluent.ksql.execution.builder.KsqlQueryBuilder;
 import io.confluent.ksql.execution.expression.tree.Expression;
@@ -23,16 +25,25 @@ import java.util.Objects;
 
 @Immutable
 public class TableGroupBy<T, G> implements ExecutionStep<G> {
+  private static final String SOURCE = "source";
+  private static final String FORMATS = "formats";
+  private static final String GROUP_BY_EXPRESSIONS = "groupByExpressions";
+
+  @JsonProperty(PROPERTIES)
   private final ExecutionStepProperties properties;
+  @JsonProperty(SOURCE)
   private final ExecutionStep<T> source;
+  @JsonProperty(FORMATS)
   private final Formats formats;
+  @JsonProperty(GROUP_BY_EXPRESSIONS)
   private final List<Expression> groupByExpressions;
 
+  @JsonCreator
   public TableGroupBy(
-      final ExecutionStepProperties properties,
-      final ExecutionStep<T> source,
-      final Formats formats,
-      final List<Expression> groupByExpressions
+      @JsonProperty(PROPERTIES) final ExecutionStepProperties properties,
+      @JsonProperty(SOURCE) final ExecutionStep<T> source,
+      @JsonProperty(FORMATS) final Formats formats,
+      @JsonProperty(GROUP_BY_EXPRESSIONS) final List<Expression> groupByExpressions
   ) {
     this.properties = Objects.requireNonNull(properties, "properties");
     this.source = Objects.requireNonNull(source, "source");

--- a/ksql-execution/src/main/java/io/confluent/ksql/execution/plan/TableMapValues.java
+++ b/ksql-execution/src/main/java/io/confluent/ksql/execution/plan/TableMapValues.java
@@ -14,6 +14,8 @@
 
 package io.confluent.ksql.execution.plan;
 
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
 import com.google.errorprone.annotations.Immutable;
 import io.confluent.ksql.execution.builder.KsqlQueryBuilder;
 import java.util.Collections;
@@ -22,14 +24,21 @@ import java.util.Objects;
 
 @Immutable
 public class TableMapValues<T> implements ExecutionStep<T> {
+  private static final String SOURCE = "source";
+  private static final String SELECT_EXPRESSIONS = "selectExpressions";
+
+  @JsonProperty(PROPERTIES)
   private final ExecutionStepProperties properties;
+  @JsonProperty(SOURCE)
   private final ExecutionStep<T> source;
+  @JsonProperty(SELECT_EXPRESSIONS)
   private final List<SelectExpression> selectExpressions;
 
+  @JsonCreator
   public TableMapValues(
-      final ExecutionStepProperties properties,
-      final ExecutionStep<T> source,
-      final List<SelectExpression> selectExpressions
+      @JsonProperty(PROPERTIES) final ExecutionStepProperties properties,
+      @JsonProperty(SOURCE) final ExecutionStep<T> source,
+      @JsonProperty(SELECT_EXPRESSIONS) final List<SelectExpression> selectExpressions
   ) {
     this.properties = Objects.requireNonNull(properties, "properties");
     this.source = Objects.requireNonNull(source, "source");

--- a/ksql-execution/src/main/java/io/confluent/ksql/execution/plan/TableSink.java
+++ b/ksql-execution/src/main/java/io/confluent/ksql/execution/plan/TableSink.java
@@ -14,6 +14,8 @@
 
 package io.confluent.ksql.execution.plan;
 
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
 import com.google.errorprone.annotations.Immutable;
 import io.confluent.ksql.execution.builder.KsqlQueryBuilder;
 import java.util.Collections;
@@ -22,16 +24,25 @@ import java.util.Objects;
 
 @Immutable
 public class TableSink<T> implements ExecutionStep<T> {
+  private static final String SOURCE = "source";
+  private static final String FORMATS = "formats";
+  private static final String TOPIC_NAME = "topicName";
+
+  @JsonProperty(PROPERTIES)
   private final ExecutionStepProperties properties;
+  @JsonProperty(SOURCE)
   private final ExecutionStep<T> source;
+  @JsonProperty(FORMATS)
   private final Formats formats;
+  @JsonProperty(TOPIC_NAME)
   private final String topicName;
 
+  @JsonCreator
   public TableSink(
-      final ExecutionStepProperties properties,
-      final ExecutionStep<T> source,
-      final Formats formats,
-      final String topicName
+      @JsonProperty(PROPERTIES) final ExecutionStepProperties properties,
+      @JsonProperty(SOURCE) final ExecutionStep<T> source,
+      @JsonProperty(FORMATS) final Formats formats,
+      @JsonProperty(TOPIC_NAME) final String topicName
   ) {
     this.properties = Objects.requireNonNull(properties, "properties");
     this.source = Objects.requireNonNull(source, "source");

--- a/ksql-execution/src/main/java/io/confluent/ksql/execution/plan/TableTableJoin.java
+++ b/ksql-execution/src/main/java/io/confluent/ksql/execution/plan/TableTableJoin.java
@@ -14,6 +14,8 @@
 
 package io.confluent.ksql.execution.plan;
 
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
 import com.google.common.collect.ImmutableList;
 import com.google.errorprone.annotations.Immutable;
 import io.confluent.ksql.execution.builder.KsqlQueryBuilder;
@@ -22,16 +24,25 @@ import java.util.Objects;
 
 @Immutable
 public class TableTableJoin<T> implements ExecutionStep<T> {
+  private static final String JOIN_TYPE = "joinType";
+  private static final String LEFT = "left";
+  private static final String RIGHT = "right";
+
+  @JsonProperty(PROPERTIES)
   private final ExecutionStepProperties properties;
+  @JsonProperty(JOIN_TYPE)
   private final JoinType joinType;
+  @JsonProperty(LEFT)
   private final ExecutionStep<T> left;
+  @JsonProperty(RIGHT)
   private final ExecutionStep<T> right;
 
+  @JsonCreator
   public TableTableJoin(
-      final ExecutionStepProperties properties,
-      final JoinType joinType,
-      final ExecutionStep<T> left,
-      final ExecutionStep<T> right) {
+      @JsonProperty(PROPERTIES) final ExecutionStepProperties properties,
+      @JsonProperty(JOIN_TYPE) final JoinType joinType,
+      @JsonProperty(LEFT) final ExecutionStep<T> left,
+      @JsonProperty(RIGHT) final ExecutionStep<T> right) {
     this.properties = Objects.requireNonNull(properties, "properties");
     this.joinType = Objects.requireNonNull(joinType, "joinType");
     this.left = Objects.requireNonNull(left, "left");

--- a/ksql-streams/src/main/java/io/confluent/ksql/execution/streams/ExecutionStepFactory.java
+++ b/ksql-streams/src/main/java/io/confluent/ksql/execution/streams/ExecutionStepFactory.java
@@ -79,8 +79,7 @@ public final class ExecutionStepFactory {
         timestampPolicy,
         timestampIndex,
         offsetReset,
-        schema.getOriginalSchema(),
-        StreamSourceBuilder::buildWindowed
+        schema.getOriginalSchema()
     );
   }
 
@@ -103,8 +102,7 @@ public final class ExecutionStepFactory {
         timestampPolicy,
         timestampIndex,
         offsetReset,
-        schema.getOriginalSchema(),
-        StreamSourceBuilder::buildUnwindowed
+        schema.getOriginalSchema()
     );
   }
 


### PR DESCRIPTION
This patch adds jackson annotations for the pojos that we need to serialize
into our execution plans. At a high level, this includes:
    - LogicalSchema and the underlying type classes
    - TimestampExtractor and its implementations
    - KeyFormat/ValueFormat
    - Expression Tree
    - ExecutionStep and its implementations

Planned follow-ups include:
   - Adding tests for the actual serialized format
   - Moving the serialized pojos into their own module, called ksql-model

### Description 
_What behavior do you want to change, why, how does your patch achieve the changes?_

### Testing done 
_Describe the testing strategy. Unit and integration tests are expected for any behavior changes._

### Reviewer checklist
- [ ] Ensure docs are updated if necessary. (eg. if a user visible feature is being added or changed).
- [ ] Ensure relevant issues are linked (description should include text like "Fixes #<issue number>")

