### PR TITLE
fix: should be able to parse empty STRUCT schema (MINOR)

### DIFF
--- a/ksql-common/src/main/java/io/confluent/ksql/schema/ksql/types/SqlStruct.java
+++ b/ksql-common/src/main/java/io/confluent/ksql/schema/ksql/types/SqlStruct.java
@@ -34,6 +34,10 @@ import java.util.stream.Collectors;
 @Immutable
 public final class SqlStruct extends SqlType {
 
+  private static final String PREFIX = "STRUCT<";
+  private static final String POSTFIX = ">";
+  private static final String EMPTY_STRUCT = PREFIX + " " + POSTFIX;
+
   private final ImmutableList<Field> fields;
 
   public static Builder builder() {
@@ -97,9 +101,13 @@ public final class SqlStruct extends SqlType {
 
   @Override
   public String toString(final FormatOptions formatOptions) {
+    if (fields.isEmpty()) {
+      return EMPTY_STRUCT;
+    }
+
     return fields.stream()
         .map(f -> f.toString(formatOptions))
-        .collect(Collectors.joining(", ", "STRUCT<", ">"));
+        .collect(Collectors.joining(", ", PREFIX, POSTFIX));
   }
 
   public static final class Builder {

--- a/ksql-common/src/test/java/io/confluent/ksql/schema/ksql/types/SqlStructTest.java
+++ b/ksql-common/src/test/java/io/confluent/ksql/schema/ksql/types/SqlStructTest.java
@@ -122,6 +122,18 @@ public class SqlStructTest {
   }
 
   @Test
+  public void shouldImplementToStringForEmptyStruct() {
+    // Given:
+    final SqlStruct emptyStruct = SqlStruct.builder().build();
+
+    // When:
+    final String sql = emptyStruct.toString();
+
+    // Then:
+    assertThat(sql, is("STRUCT< >"));
+  }
+
+  @Test
   public void shouldImplementToStringWithReservedWordHandling() {
     // Given:
     final SqlStruct struct = SqlStruct.builder()

--- a/ksql-functional-tests/src/main/java/io/confluent/ksql/test/model/SourceNode.java
+++ b/ksql-functional-tests/src/main/java/io/confluent/ksql/test/model/SourceNode.java
@@ -25,7 +25,7 @@ import io.confluent.ksql.metastore.model.KsqlStream;
 import io.confluent.ksql.metastore.model.KsqlTable;
 import io.confluent.ksql.metastore.model.MetaStoreMatchers;
 import io.confluent.ksql.schema.ksql.SchemaConverters;
-import io.confluent.ksql.schema.ksql.TypeContextUtil;
+import io.confluent.ksql.schema.ksql.SqlTypeParser;
 import io.confluent.ksql.test.tools.exceptions.InvalidFieldException;
 import java.util.Objects;
 import java.util.Optional;
@@ -117,7 +117,7 @@ final class SourceNode {
 
   private static Optional<Schema> parseSchema(final String schema) {
     return Optional.ofNullable(schema)
-        .map(schemaString -> TypeContextUtil.getType(schemaString, TypeRegistry.EMPTY))
+        .map(schemaString -> SqlTypeParser.create(TypeRegistry.EMPTY).parse(schemaString))
         .map(Type::getSqlType)
         .map(SchemaConverters.sqlToConnectConverter()::toConnectSchema)
         .map(SourceNode::makeTopLevelStructNoneOptional);

--- a/ksql-functional-tests/src/main/java/io/confluent/ksql/test/serde/KeyFieldDeserializer.java
+++ b/ksql-functional-tests/src/main/java/io/confluent/ksql/test/serde/KeyFieldDeserializer.java
@@ -21,7 +21,7 @@ import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.deser.std.StdDeserializer;
 import io.confluent.ksql.execution.expression.tree.Type;
 import io.confluent.ksql.metastore.TypeRegistry;
-import io.confluent.ksql.schema.ksql.TypeContextUtil;
+import io.confluent.ksql.schema.ksql.SqlTypeParser;
 import io.confluent.ksql.schema.ksql.types.SqlType;
 import io.confluent.ksql.test.model.KeyFieldNode;
 import io.confluent.ksql.test.tools.exceptions.InvalidFieldException;
@@ -81,7 +81,7 @@ public class KeyFieldDeserializer extends StdDeserializer<KeyFieldNode> {
 
     try {
       return Optional.ofNullable(valueSchema)
-          .map(schema -> TypeContextUtil.getType(schema, TypeRegistry.EMPTY))
+          .map(schema -> SqlTypeParser.create(TypeRegistry.EMPTY).parse(schema))
           .map(Type::getSqlType);
     } catch (final Exception e) {
       throw new InvalidFieldException("legacySchema", "Failed to parse: " + valueSchema, e);

--- a/ksql-parser/src/main/antlr4/io/confluent/ksql/parser/SqlBase.g4
+++ b/ksql-parser/src/main/antlr4/io/confluent/ksql/parser/SqlBase.g4
@@ -274,7 +274,7 @@ type
     : type ARRAY
     | ARRAY '<' type '>'
     | MAP '<' type ',' type '>'
-    | STRUCT '<' identifier type (',' identifier type)* '>'
+    | STRUCT '<' (identifier type (',' identifier type)*)? '>'
     | DECIMAL '(' number ',' number ')'
     | baseType ('(' typeParameter (',' typeParameter)* ')')?
     ;

--- a/ksql-parser/src/main/java/io/confluent/ksql/parser/AstBuilder.java
+++ b/ksql-parser/src/main/java/io/confluent/ksql/parser/AstBuilder.java
@@ -16,7 +16,6 @@
 package io.confluent.ksql.parser;
 
 import static io.confluent.ksql.metastore.model.DataSource.DataSourceType;
-import static io.confluent.ksql.schema.ksql.TypeContextUtil.getType;
 import static io.confluent.ksql.util.ParserUtil.getIdentifierText;
 import static io.confluent.ksql.util.ParserUtil.getLocation;
 import static io.confluent.ksql.util.ParserUtil.processIntegerNumber;
@@ -125,6 +124,7 @@ import io.confluent.ksql.parser.tree.UnsetProperty;
 import io.confluent.ksql.parser.tree.WindowExpression;
 import io.confluent.ksql.parser.tree.WithinExpression;
 import io.confluent.ksql.schema.Operator;
+import io.confluent.ksql.schema.ksql.SqlTypeParser;
 import io.confluent.ksql.util.DataSourceExtractor;
 import io.confluent.ksql.util.KsqlConstants;
 import io.confluent.ksql.util.KsqlException;
@@ -167,6 +167,7 @@ public class AstBuilder {
 
     private final DataSourceExtractor dataSourceExtractor;
     private final MetaStore metaStore;
+    private final SqlTypeParser typeParser;
 
     private int selectItemIndex = 0;
 
@@ -176,6 +177,7 @@ public class AstBuilder {
     ) {
       this.dataSourceExtractor = Objects.requireNonNull(dataSourceExtractor, "dataSourceExtractor");
       this.metaStore = Objects.requireNonNull(metaStore, "metaStore");
+      this.typeParser = SqlTypeParser.create(metaStore);
     }
 
     @Override
@@ -921,7 +923,7 @@ public class AstBuilder {
       return new Cast(
           getLocation(context),
           (Expression) visit(context.expression()),
-          getType(context.type(), metaStore)
+          typeParser.getType(context.type())
       );
     }
 
@@ -1064,7 +1066,7 @@ public class AstBuilder {
           getLocation(context),
           context.KEY() == null ? Namespace.VALUE : Namespace.KEY,
           ParserUtil.getIdentifierText(context.identifier()),
-          getType(context.type(), metaStore)
+          typeParser.getType(context.type())
       );
     }
 
@@ -1163,7 +1165,7 @@ public class AstBuilder {
       return new RegisterType(
           getLocation(context),
           ParserUtil.getIdentifierText(context.identifier()),
-          getType(context.type(), metaStore)
+          typeParser.getType(context.type())
       );
     }
 

--- a/ksql-parser/src/main/java/io/confluent/ksql/parser/SchemaParser.java
+++ b/ksql-parser/src/main/java/io/confluent/ksql/parser/SchemaParser.java
@@ -15,7 +15,6 @@
 
 package io.confluent.ksql.parser;
 
-import static io.confluent.ksql.schema.ksql.TypeContextUtil.getType;
 import static io.confluent.ksql.util.ParserUtil.getLocation;
 
 import com.google.common.annotations.VisibleForTesting;
@@ -23,6 +22,7 @@ import io.confluent.ksql.metastore.TypeRegistry;
 import io.confluent.ksql.parser.tree.TableElement;
 import io.confluent.ksql.parser.tree.TableElement.Namespace;
 import io.confluent.ksql.parser.tree.TableElements;
+import io.confluent.ksql.schema.ksql.SqlTypeParser;
 import io.confluent.ksql.util.KsqlException;
 import io.confluent.ksql.util.ParserUtil;
 import java.util.List;
@@ -77,13 +77,15 @@ public final class SchemaParser {
     parser.removeErrorListeners();
     parser.addErrorListener(errorListener);
 
+    final SqlTypeParser typeParser = SqlTypeParser.create(typeRegistry);
+
     final List<TableElement> elements = parser.tableElements().tableElement()
         .stream()
         .map(ctx -> new TableElement(
             getLocation(ctx),
             ctx.KEY() == null ? Namespace.VALUE : Namespace.KEY,
             ParserUtil.getIdentifierText(ctx.identifier()),
-            getType(ctx.type(), typeRegistry)
+            typeParser.getType(ctx.type())
         ))
         .collect(Collectors.toList());
 


### PR DESCRIPTION
### Description 

The main purpose of this PR is to ensure we can parse an empty `STRUCT`, i.e. one without any fields.  This is a valid edge case as we have the potential for either the key or value part of a schema to not have any fields, and such parts are represented as STRUCT.

So, for example, when we're responding to a static query request we include the schemas of the key and value in the response. Such schemas may have no fields.  Our parser should be able to handle this.

So....

1. I've updated the syntax to allow a `STRUCT` with out fields `STRUCT< >`
1. I've updated `SqlStruct`'s `toString` to include a space between the `<` and `>`, as otherwise the lexer interprets `<>` as `NEQ`.
1. I've added suitable tests.

Also, while in there I've renamed `TypeContextUtil` to `SqlTypeParser`, as that's what it is, and slightly refactored it to make it suitable for dependency injection.

### Testing done 

Tests added, `mvn test`.

### Reviewer checklist
- [ ] Ensure docs are updated if necessary. (eg. if a user visible feature is being added or changed).
- [ ] Ensure relevant issues are linked (description should include text like "Fixes #<issue number>")

