### PR TITLE
feat(static): add forEach() to KsqlStruct (MINOR)

### DIFF
--- a/ksql-common/src/main/java/io/confluent/ksql/types/KsqlStruct.java
+++ b/ksql-common/src/main/java/io/confluent/ksql/types/KsqlStruct.java
@@ -25,6 +25,7 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Objects;
 import java.util.Optional;
+import java.util.function.BiConsumer;
 
 /**
  * Instance of {@link io.confluent.ksql.schema.ksql.types.SqlStruct}.
@@ -53,6 +54,14 @@ public final class KsqlStruct {
 
   public List<Optional<?>> values() {
     return values;
+  }
+
+  public void forEach(final BiConsumer<? super Field, ? super Optional<?>> consumer) {
+    for (int idx = 0; idx < values.size(); idx++) {
+      final Field field = schema.fields().get(idx);
+      final Optional<?> value = values.get(idx);
+      consumer.accept(field, value);
+    }
   }
 
   @Override


### PR DESCRIPTION
### Description 

Iterating across the values and their schemas is a common pattern, so lets add a method to facilitate.

### Testing done 

Usual

### Reviewer checklist
- [ ] Ensure docs are updated if necessary. (eg. if a user visible feature is being added or changed).
- [ ] Ensure relevant issues are linked (description should include text like "Fixes #<issue number>")

