### PR TITLE
feat: Perform Schema Registry permissions checks

### DIFF
--- a/ksql-engine/src/main/java/io/confluent/ksql/engine/InsertValuesExecutor.java
+++ b/ksql-engine/src/main/java/io/confluent/ksql/engine/InsertValuesExecutor.java
@@ -48,7 +48,6 @@ import io.confluent.ksql.util.KsqlConstants;
 import io.confluent.ksql.util.KsqlException;
 import io.confluent.ksql.util.SchemaUtil;
 import java.time.Duration;
-import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -376,7 +375,7 @@ public class InsertValuesExecutor {
       if (isAvroSchema(dataSource) && isSchemaAccessUnauthorized(e)) {
         rootCause = new KsqlSchemaAuthorizationException(
             AclOperation.WRITE,
-            Collections.singleton(topicName + KsqlConstants.SCHEMA_REGISTRY_VALUE_SUFFIX)
+            topicName + KsqlConstants.SCHEMA_REGISTRY_VALUE_SUFFIX
         );
       }
 
@@ -384,11 +383,11 @@ public class InsertValuesExecutor {
     }
   }
 
-  private boolean isAvroSchema(final DataSource dataSource) {
+  private static boolean isAvroSchema(final DataSource dataSource) {
     return dataSource.getKsqlTopic().getValueFormat().getFormat() == Format.AVRO;
   }
 
-  private boolean isSchemaAccessUnauthorized(final Exception e) {
+  private static boolean isSchemaAccessUnauthorized(final Exception e) {
     final Throwable rootCause = ExceptionUtils.getRootCause(e);
     if (rootCause instanceof RestClientException) {
       switch (((RestClientException) rootCause).getStatus()) {

--- a/ksql-engine/src/main/java/io/confluent/ksql/exception/KsqlSchemaAuthorizationException.java
+++ b/ksql-engine/src/main/java/io/confluent/ksql/exception/KsqlSchemaAuthorizationException.java
@@ -15,12 +15,11 @@
 
 package io.confluent.ksql.exception;
 
-import java.util.Set;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.kafka.common.acl.AclOperation;
 
 public class KsqlSchemaAuthorizationException extends RuntimeException {
-  public KsqlSchemaAuthorizationException(final Set<String> unauthorizedSchema) {
+  public KsqlSchemaAuthorizationException(final String unauthorizedSchema) {
     super(
         "Authorization denied to access Schema Registry subject(s): " + unauthorizedSchema
     );
@@ -28,7 +27,7 @@ public class KsqlSchemaAuthorizationException extends RuntimeException {
 
   public KsqlSchemaAuthorizationException(
       final AclOperation operation,
-      final Set<String> unauthorizedSchema
+      final String unauthorizedSchema
   ) {
     super(String.format(
         "Authorization denied to %s on Schema Registry subject(s): %s",

--- a/ksql-engine/src/main/java/io/confluent/ksql/exception/KsqlSchemaAuthorizationException.java
+++ b/ksql-engine/src/main/java/io/confluent/ksql/exception/KsqlSchemaAuthorizationException.java
@@ -31,7 +31,7 @@ public class KsqlSchemaAuthorizationException extends RuntimeException {
       final Set<String> unauthorizedSchema
   ) {
     super(String.format(
-        "Authorization denied to %s on Schema Registry subject(s): ",
+        "Authorization denied to %s on Schema Registry subject(s): %s",
         StringUtils.capitalize(operation.toString().toLowerCase()), unauthorizedSchema
     ));
   }

--- a/ksql-engine/src/main/java/io/confluent/ksql/exception/KsqlSchemaAuthorizationException.java
+++ b/ksql-engine/src/main/java/io/confluent/ksql/exception/KsqlSchemaAuthorizationException.java
@@ -1,0 +1,38 @@
+/*
+ * Copyright 2019 Confluent Inc.
+ *
+ * Licensed under the Confluent Community License (the "License"); you may not use
+ * this file except in compliance with the License.  You may obtain a copy of the
+ * License at
+ *
+ * http://www.confluent.io/confluent-community-license
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package io.confluent.ksql.exception;
+
+import java.util.Set;
+import org.apache.commons.lang3.StringUtils;
+import org.apache.kafka.common.acl.AclOperation;
+
+public class KsqlSchemaAuthorizationException extends RuntimeException {
+  public KsqlSchemaAuthorizationException(final Set<String> unauthorizedSchema) {
+    super(
+        "Authorization denied to access Schema Registry subject(s): " + unauthorizedSchema
+    );
+  }
+
+  public KsqlSchemaAuthorizationException(
+      final AclOperation operation,
+      final Set<String> unauthorizedSchema
+  ) {
+    super(String.format(
+        "Authorization denied to %s on Schema Registry subject(s): ",
+        StringUtils.capitalize(operation.toString().toLowerCase()), unauthorizedSchema
+    ));
+  }
+}

--- a/ksql-engine/src/main/java/io/confluent/ksql/schema/ksql/inference/SchemaRegistryTopicSchemaSupplier.java
+++ b/ksql-engine/src/main/java/io/confluent/ksql/schema/ksql/inference/SchemaRegistryTopicSchemaSupplier.java
@@ -137,7 +137,7 @@ public class SchemaRegistryTopicSchemaSupplier implements TopicSchemaSupplier {
             + "\t-> Use the REST API to list available subjects"
             + "\t" + DocumentationLinks.SR_REST_GETSUBJECTS_DOC_URL
             + System.lineSeparator()
-            + "- You do not have permissions to access the Schema Registry.Subject"
+            + "- You do not have permissions to access the Schema Registry."
             + "\t-> See " + DocumentationLinks.SCHEMA_REGISTRY_SECURITY_DOC_URL));
   }
 

--- a/ksql-engine/src/main/java/io/confluent/ksql/schema/ksql/inference/SchemaRegistryTopicSchemaSupplier.java
+++ b/ksql-engine/src/main/java/io/confluent/ksql/schema/ksql/inference/SchemaRegistryTopicSchemaSupplier.java
@@ -137,8 +137,7 @@ public class SchemaRegistryTopicSchemaSupplier implements TopicSchemaSupplier {
             + "\t-> Use the REST API to list available subjects"
             + "\t" + DocumentationLinks.SR_REST_GETSUBJECTS_DOC_URL
             + System.lineSeparator()
-            + "- You do not have permissions to access the Schema Registry.Subject: "
-            + topicName + KsqlConstants.SCHEMA_REGISTRY_VALUE_SUFFIX
+            + "- You do not have permissions to access the Schema Registry.Subject"
             + "\t-> See " + DocumentationLinks.SCHEMA_REGISTRY_SECURITY_DOC_URL));
   }
 

--- a/ksql-engine/src/main/java/io/confluent/ksql/schema/registry/SchemaRegistryUtil.java
+++ b/ksql-engine/src/main/java/io/confluent/ksql/schema/registry/SchemaRegistryUtil.java
@@ -22,7 +22,6 @@ import io.confluent.kafka.schemaregistry.client.rest.exceptions.RestClientExcept
 import io.confluent.ksql.exception.KsqlSchemaAuthorizationException;
 import io.confluent.ksql.util.ExecutorUtil;
 import io.confluent.ksql.util.KsqlConstants;
-import java.util.Collections;
 import java.util.stream.Stream;
 import org.apache.http.HttpStatus;
 import org.apache.kafka.common.acl.AclOperation;
@@ -78,7 +77,7 @@ public final class SchemaRegistryUtil {
           case HttpStatus.SC_FORBIDDEN:
             throw new KsqlSchemaAuthorizationException(
                 AclOperation.DELETE,
-                Collections.singleton(subject)
+                subject
             );
           default:
             throw e;

--- a/ksql-engine/src/main/java/io/confluent/ksql/security/KsqlAuthorizationValidatorImpl.java
+++ b/ksql-engine/src/main/java/io/confluent/ksql/security/KsqlAuthorizationValidatorImpl.java
@@ -179,7 +179,7 @@ public class KsqlAuthorizationValidatorImpl implements KsqlAuthorizationValidato
       switch (e.getStatus()) {
         case HttpStatus.SC_UNAUTHORIZED:
         case HttpStatus.SC_FORBIDDEN:
-          throw new KsqlSchemaAuthorizationException(operation, Collections.singleton(subject));
+          throw new KsqlSchemaAuthorizationException(operation, subject);
         default:
           // Do nothing. We assume the NOT FOUND and other errors are caught and  displayed
           // in different place

--- a/ksql-engine/src/main/java/io/confluent/ksql/topic/SourceTopicsExtractor.java
+++ b/ksql-engine/src/main/java/io/confluent/ksql/topic/SourceTopicsExtractor.java
@@ -15,6 +15,7 @@
 
 package io.confluent.ksql.topic;
 
+import io.confluent.ksql.execution.ddl.commands.KsqlTopic;
 import io.confluent.ksql.metastore.MetaStore;
 import io.confluent.ksql.metastore.model.DataSource;
 import io.confluent.ksql.parser.DefaultTraversalVisitor;
@@ -30,20 +31,20 @@ import java.util.Set;
  * Helper class that extracts all source topics from a query node.
  */
 public class SourceTopicsExtractor extends DefaultTraversalVisitor<AstNode, Void> {
-  private final Set<String> sourceTopics = new HashSet<>();
+  private final Set<KsqlTopic> sourceTopics = new HashSet<>();
   private final MetaStore metaStore;
 
-  private String primaryKafkaTopicName = null;
+  private KsqlTopic primaryKafkaTopicName = null;
 
   public SourceTopicsExtractor(final MetaStore metaStore) {
     this.metaStore = metaStore;
   }
 
-  public String getPrimaryKafkaTopicName() {
+  public KsqlTopic getPrimaryKsqlTopic() {
     return primaryKafkaTopicName;
   }
 
-  public Set<String> getSourceTopics() {
+  public Set<KsqlTopic> getKsqlTopics() {
     return sourceTopics;
   }
 
@@ -64,10 +65,10 @@ public class SourceTopicsExtractor extends DefaultTraversalVisitor<AstNode, Void
 
     // This method is called first with the primary kafka topic (or the node.getFrom() node)
     if (primaryKafkaTopicName == null) {
-      primaryKafkaTopicName = source.getKafkaTopicName();
+      primaryKafkaTopicName = source.getKsqlTopic();
     }
 
-    sourceTopics.add(source.getKafkaTopicName());
+    sourceTopics.add(source.getKsqlTopic());
     return node;
   }
 }

--- a/ksql-engine/src/main/java/io/confluent/ksql/topic/TopicCreateInjector.java
+++ b/ksql-engine/src/main/java/io/confluent/ksql/topic/TopicCreateInjector.java
@@ -147,7 +147,7 @@ public class TopicCreateInjector implements Injector {
 
     final SourceTopicsExtractor extractor = new SourceTopicsExtractor(metaStore);
     extractor.process(statement.getStatement().getQuery(), null);
-    final String sourceTopicName = extractor.getPrimaryKafkaTopicName();
+    final String sourceTopicName = extractor.getPrimaryKsqlTopic().getKafkaTopicName();
 
     topicPropertiesBuilder
         .withName(prefix + createAsSelect.getName().name())

--- a/ksql-engine/src/main/java/io/confluent/ksql/util/AvroUtil.java
+++ b/ksql-engine/src/main/java/io/confluent/ksql/util/AvroUtil.java
@@ -17,8 +17,10 @@ package io.confluent.ksql.util;
 
 import io.confluent.kafka.schemaregistry.client.SchemaRegistryClient;
 import io.confluent.kafka.schemaregistry.client.rest.exceptions.RestClientException;
+import io.confluent.ksql.exception.KsqlSchemaAuthorizationException;
 import io.confluent.ksql.serde.Format;
 import java.io.IOException;
+import java.util.Collections;
 
 import org.apache.http.HttpStatus;
 
@@ -86,16 +88,14 @@ public final class AvroUtil {
         return true;
       }
 
-      String errorMessage = e.getMessage();
       if (e.getStatus() == HttpStatus.SC_UNAUTHORIZED || e.getStatus() == HttpStatus.SC_FORBIDDEN) {
-        errorMessage = String.format(
-            "Not authorized to access Schema Registry subject: [%s]",
-            topicName + KsqlConstants.SCHEMA_REGISTRY_VALUE_SUFFIX
+        throw new KsqlSchemaAuthorizationException(
+            Collections.singleton(topicName + KsqlConstants.SCHEMA_REGISTRY_VALUE_SUFFIX)
         );
       }
 
       throw new KsqlException(String.format(
-          "Could not connect to Schema Registry service: %s", errorMessage
+          "Could not connect to Schema Registry service: %s", e.getMessage()
       ));
     }
   }

--- a/ksql-engine/src/main/java/io/confluent/ksql/util/AvroUtil.java
+++ b/ksql-engine/src/main/java/io/confluent/ksql/util/AvroUtil.java
@@ -20,9 +20,9 @@ import io.confluent.kafka.schemaregistry.client.rest.exceptions.RestClientExcept
 import io.confluent.ksql.exception.KsqlSchemaAuthorizationException;
 import io.confluent.ksql.serde.Format;
 import java.io.IOException;
-import java.util.Collections;
 
 import org.apache.http.HttpStatus;
+import org.apache.kafka.common.acl.AclOperation;
 
 public final class AvroUtil {
 
@@ -90,7 +90,8 @@ public final class AvroUtil {
 
       if (e.getStatus() == HttpStatus.SC_UNAUTHORIZED || e.getStatus() == HttpStatus.SC_FORBIDDEN) {
         throw new KsqlSchemaAuthorizationException(
-            Collections.singleton(topicName + KsqlConstants.SCHEMA_REGISTRY_VALUE_SUFFIX)
+            AclOperation.WRITE,
+            topicName + KsqlConstants.SCHEMA_REGISTRY_VALUE_SUFFIX
         );
       }
 

--- a/ksql-engine/src/test/java/io/confluent/ksql/topic/SourceTopicsExtractorTest.java
+++ b/ksql-engine/src/test/java/io/confluent/ksql/topic/SourceTopicsExtractorTest.java
@@ -50,6 +50,9 @@ import org.junit.runner.RunWith;
 import org.mockito.Mock;
 import org.mockito.junit.MockitoJUnitRunner;
 
+import java.util.Set;
+import java.util.stream.Collectors;
+
 @RunWith(MockitoJUnitRunner.class)
 public class SourceTopicsExtractorTest {
 
@@ -107,7 +110,7 @@ public class SourceTopicsExtractorTest {
     extractor.process(statement, null);
 
     // Then:
-    assertThat(extractor.getPrimaryKafkaTopicName(), is(TOPIC_1.name()));
+    assertThat(extractor.getPrimaryKsqlTopic().getKafkaTopicName(), is(TOPIC_1.name()));
   }
 
   @Test
@@ -121,7 +124,7 @@ public class SourceTopicsExtractorTest {
     extractor.process(statement, null);
 
     // Then:
-    assertThat(extractor.getPrimaryKafkaTopicName(), is(TOPIC_1.name()));
+    assertThat(extractor.getPrimaryKsqlTopic().getKafkaTopicName(), is(TOPIC_1.name()));
   }
 
   @Test
@@ -135,7 +138,12 @@ public class SourceTopicsExtractorTest {
     extractor.process(statement, null);
 
     // Then:
-    assertThat(extractor.getSourceTopics(), contains(TOPIC_1.name(), TOPIC_2.name()));
+    final Set<String> topicsNames = extractor.getKsqlTopics()
+        .stream()
+        .map(k -> k.getKafkaTopicName())
+        .collect(Collectors.toSet());
+
+    assertThat(topicsNames, contains(TOPIC_1.name(), TOPIC_2.name()));
   }
 
   @Test

--- a/ksql-engine/src/test/java/io/confluent/ksql/util/AvroUtilTest.java
+++ b/ksql-engine/src/test/java/io/confluent/ksql/util/AvroUtilTest.java
@@ -16,7 +16,10 @@
 
 package io.confluent.ksql.util;
 
+import static org.hamcrest.Matchers.contains;
 import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.Matchers.instanceOf;
+import static org.junit.internal.matchers.ThrowableCauseMatcher.hasCause;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.eq;
@@ -27,6 +30,7 @@ import io.confluent.connect.avro.AvroData;
 import io.confluent.connect.avro.AvroDataConfig;
 import io.confluent.kafka.schemaregistry.client.SchemaRegistryClient;
 import io.confluent.kafka.schemaregistry.client.rest.exceptions.RestClientException;
+import io.confluent.ksql.exception.KsqlSchemaAuthorizationException;
 import io.confluent.ksql.execution.ddl.commands.KsqlTopic;
 import io.confluent.ksql.schema.ksql.LogicalSchema;
 import io.confluent.ksql.schema.ksql.LogicalSchema.Builder;
@@ -213,10 +217,9 @@ public class AvroUtilTest {
         .thenThrow(new RestClientException("Unknown subject", 403, 40401));
 
     // Expect:
-    expectedException.expect(KsqlException.class);
-    expectedException.expectMessage("Could not connect to Schema Registry service");
+    expectedException.expect(KsqlSchemaAuthorizationException.class);
     expectedException.expectMessage(containsString(String.format(
-        "Not authorized to access Schema Registry subject: [%s]",
+        "Authorization denied to access Schema Registry subject(s): [%s]",
         persistentQuery.getResultTopic().getKafkaTopicName()
             + KsqlConstants.SCHEMA_REGISTRY_VALUE_SUFFIX
     )));


### PR DESCRIPTION
### Description 
This change makes KSQL perform Schema access permissions checks on the statement to execute in order to provide better authorization error messages when the User and/or the KSQL service principal do not have access to the Schema.

First, when SR is configured with Authorization, the following invalid error was displayed on KSQL when it cannot access the schema which was not helping users to recognize it as an access denied aerror:
```
io.confluent.kafka.schemaregistry.client.rest.exceptions.RestClientException: Unrecognized token 'User': was expecting ('true', 'false' or 'null')
 at [Source: (sun.net.www.protocol.http.HttpURLConnection$HttpInputStream); line: 1, column: 6]; error code: 50005
```

This PR changes the message to like:
```
ksql> create stream s10 with (kafka_topic='s10', value_format='avro');
Authorization denied to Read on Schema Registry subject(s): [s10-value]
```

It also perform the check for the KSQL service principal, and the error will look like:
```
ksql> create stream s10 with (kafka_topic='s10', value_format='avro');
The KSQL server is not permitted to execute the command
Caused by: Authorization denied to Read on Schema Registry subject(s):
	[s10-value]
```

SR checks are done in `KsqlAuthorizationValidatorImpl` (where Topic permissions checks are done). This class checks access to the schema of some statements that use AVRO topics only. 

How to review it?
1. Commit #1 added a `KsqlSchemaAuthorizationException` which will be used throw the desired error message.
2. Commit #2 calls the `KsqlSchemaAuthorizationException` on places where SR is denying access + when doing permissions checks on `KsqlAuthorizationValidatorImpl`

### Testing done 
- Unit tests
- Verified manually on CLI

### Reviewer checklist
- [ ] Ensure docs are updated if necessary. (eg. if a user visible feature is being added or changed).
- [ ] Ensure relevant issues are linked (description should include text like "Fixes #<issue number>")

