### PR TITLE
Fix: KSQL should warn when forcing CSAS object names to upper cas…

### DIFF
--- a/ksql-rest-app/src/main/java/io/confluent/ksql/rest/server/computation/StatementExecutor.java
+++ b/ksql-rest-app/src/main/java/io/confluent/ksql/rest/server/computation/StatementExecutor.java
@@ -19,6 +19,7 @@ import com.google.common.annotations.VisibleForTesting;
 import com.google.common.collect.Lists;
 import io.confluent.ksql.engine.KsqlEngine;
 import io.confluent.ksql.exception.ExceptionUtil;
+import io.confluent.ksql.execution.expression.tree.QualifiedName;
 import io.confluent.ksql.metastore.MetaStore;
 import io.confluent.ksql.parser.KsqlParser.ParsedStatement;
 import io.confluent.ksql.parser.KsqlParser.PreparedStatement;
@@ -219,8 +220,9 @@ public class StatementExecutor implements KsqlConfigurable {
       successMessage = executeDdlStatement(statement, command);
     } else if (statement.getStatement() instanceof CreateAsSelect) {
       final PersistentQueryMetadata query = startQuery(statement, command, mode);
+      final QualifiedName name = ((CreateAsSelect)statement.getStatement()).getName();
       successMessage = statement.getStatement() instanceof CreateTableAsSelect
-          ? "Table created and running" : "Stream created and running";
+          ? "Table " + name + " created and running" : "Stream " + name + " created and running";
       successMessage += ". Created by query with query ID: " + query.getQueryId();
     } else if (statement.getStatement() instanceof InsertInto) {
       final PersistentQueryMetadata query = startQuery(statement, command, mode);


### PR DESCRIPTION
…e #1287

### Description 
This PR contains a fix for https://github.com/confluentinc/ksql/issues/1287 "KSQL should warn when forcing CSAS object names to upper case"

This PR changes the output of a KSQL cli "create table" or "create stream" statement so the name of the newly created table/stream, in uppercase, is included.

This makes it clear to the user that KSQL table / stream names are case insensitive and will always be displayed by the cli in uppercase.

### Testing done 
CliTest has been amended to verify the new output for create stream
I've also added a new test 'createTableTest' as one didn't exist before for create table.

