### PR TITLE
test: increase session timeout on ZK test

### DIFF
--- a/ksql-test-util/src/test/java/io/confluent/ksql/test/util/ZooKeeperEmbeddedTest.java
+++ b/ksql-test-util/src/test/java/io/confluent/ksql/test/util/ZooKeeperEmbeddedTest.java
@@ -70,7 +70,7 @@ public class ZooKeeperEmbeddedTest {
 
     try {
       final String connectString = server.connectString();
-      zooKeeper = new ZooKeeper(connectString, 2000, watcher);
+      zooKeeper = new ZooKeeper(connectString, 30_000, watcher);
       final boolean success = connectionLatch.await(5, TimeUnit.SECONDS);
       assertThat("Can not connect to " + name + " on " + connectString, success);
 


### PR DESCRIPTION
### Description 

To fix build failure: https://jenkins.confluent.io/job/Confluentinc%20Contributors/job/ksql/job/PR-3326/1/testReport/junit/io.confluent.ksql.test.util/ZooKeeperEmbeddedTest/shouldSupportMultipleInstancesRunning/

This now matches the timeout we use in our EmbeddedKafka.

### Testing done 
_Describe the testing strategy. Unit and integration tests are expected for any behavior changes._

### Reviewer checklist
- [ ] Ensure docs are updated if necessary. (eg. if a user visible feature is being added or changed).
- [ ] Ensure relevant issues are linked (description should include text like "Fixes #<issue number>")

