### PR TITLE
feat: add command topic offset to commands and perform validation based on offset when executing commands

### DIFF
--- a/ksql-rest-app/src/main/java/io/confluent/ksql/rest/server/CommandTopic.java
+++ b/ksql-rest-app/src/main/java/io/confluent/ksql/rest/server/CommandTopic.java
@@ -127,7 +127,8 @@ public class CommandTopic {
             new QueuedCommand(
                 record.key(),
                 record.value(),
-                Optional.empty()));
+                Optional.empty(),
+                (int) record.offset()));
       }
       records = commandConsumer.poll(duration);
     }

--- a/ksql-rest-app/src/main/java/io/confluent/ksql/rest/server/KsqlRestApplication.java
+++ b/ksql-rest-app/src/main/java/io/confluent/ksql/rest/server/KsqlRestApplication.java
@@ -465,7 +465,8 @@ public final class KsqlRestApplication extends Application<KsqlRestConfig> imple
     final CommandStore commandStore = CommandStore.Factory.create(
         commandTopic,
         restConfig.getCommandConsumerProperties(),
-        restConfig.getCommandProducerProperties());
+        restConfig.getCommandProducerProperties(),
+        ksqlEngine);
 
     final StatementExecutor statementExecutor = new StatementExecutor(ksqlEngine);
 

--- a/ksql-rest-app/src/main/java/io/confluent/ksql/rest/server/computation/Command.java
+++ b/ksql-rest-app/src/main/java/io/confluent/ksql/rest/server/computation/Command.java
@@ -25,15 +25,21 @@ import java.util.Objects;
 @JsonSubTypes({})
 public class Command {
   private final String statement;
+  private final int commandTopicOffset;
   private final Map<String, Object> overwriteProperties;
   private final Map<String, String> originalProperties;
   private final boolean preVersion5;
 
+  public static final Integer DEFAULT_COMMAND_TOPIC_OFFSET = -1;
+
   @JsonCreator
   public Command(@JsonProperty("statement") final String statement,
+                 @JsonProperty("commandTopicOffset") final Integer commandTopicOffset,
                  @JsonProperty("streamsProperties") final Map<String, Object> overwriteProperties,
                  @JsonProperty("originalProperties") final Map<String, String> originalProperties) {
     this.statement = statement;
+    this.commandTopicOffset =
+        commandTopicOffset == null ? DEFAULT_COMMAND_TOPIC_OFFSET : commandTopicOffset;
     this.overwriteProperties = Collections.unmodifiableMap(overwriteProperties);
     this.preVersion5 = originalProperties == null;
     this.originalProperties =
@@ -43,6 +49,11 @@ public class Command {
   @JsonProperty("statement")
   public String getStatement() {
     return statement;
+  }
+
+  @JsonProperty("commandTopicOffset")
+  public int getCommandTopicOffset() {
+    return commandTopicOffset;
   }
 
   @JsonProperty("streamsProperties")
@@ -64,19 +75,21 @@ public class Command {
     return
         o instanceof Command
         && Objects.equals(statement, ((Command)o).statement)
+        && Objects.equals(commandTopicOffset, ((Command)o).commandTopicOffset)
         && Objects.equals(overwriteProperties, ((Command)o).overwriteProperties)
         && Objects.equals(originalProperties, ((Command)o).originalProperties);
   }
 
   @Override
   public int hashCode() {
-    return Objects.hash(statement, overwriteProperties, originalProperties);
+    return Objects.hash(statement, commandTopicOffset, overwriteProperties, originalProperties);
   }
 
   @Override
   public String toString() {
     return "Command{"
         + "statement='" + statement + '\''
+        + ",commandTopicOffset=" + commandTopicOffset
         + ", overwriteProperties=" + overwriteProperties
         + '}';
   }

--- a/ksql-rest-app/src/main/java/io/confluent/ksql/rest/server/computation/CommandQueue.java
+++ b/ksql-rest-app/src/main/java/io/confluent/ksql/rest/server/computation/CommandQueue.java
@@ -91,4 +91,10 @@ public interface CommandQueue extends Closeable {
    */
   @Override
   void close();
+
+  void setOffsetValue(int offsetValue);
+
+  void setSnapshot();
+
+  SnapshotWithOffset getSnapshotWithOffset();
 }

--- a/ksql-rest-app/src/main/java/io/confluent/ksql/rest/server/computation/QueuedCommand.java
+++ b/ksql-rest-app/src/main/java/io/confluent/ksql/rest/server/computation/QueuedCommand.java
@@ -23,17 +23,28 @@ public class QueuedCommand {
   private final CommandId commandId;
   private final Command command;
   private final Optional<CommandStatusFuture> status;
+  private final int offset;
 
   public QueuedCommand(final CommandId commandId,
                        final Command command,
-                       final Optional<CommandStatusFuture> status) {
+                       final Optional<CommandStatusFuture> status,
+                       final int offset) {
     this.commandId = Objects.requireNonNull(commandId);
     this.command = Objects.requireNonNull(command);
     this.status = Objects.requireNonNull(status);
+    this.offset = Objects.requireNonNull(offset);
   }
 
   QueuedCommand(final CommandId commandId, final Command command) {
-    this(commandId, command, Optional.empty());
+    this(commandId, command, Optional.empty(), -1);
+  }
+
+  public QueuedCommand(
+      final CommandId commandId,
+      final Command command,
+      final Optional<CommandStatusFuture> status
+  ) {
+    this(commandId, command, status, -1);
   }
 
   public CommandId getCommandId() {
@@ -48,6 +59,10 @@ public class QueuedCommand {
     return command;
   }
 
+  public int getOffset() {
+    return offset;
+  }
+
   @Override
   public boolean equals(final Object o) {
     if (this == o) {
@@ -59,11 +74,12 @@ public class QueuedCommand {
     final QueuedCommand that = (QueuedCommand) o;
     return Objects.equals(commandId, that.commandId)
         && Objects.equals(command, that.command)
-        && Objects.equals(status, that.status);
+        && Objects.equals(status, that.status)
+        && Objects.equals(offset, that.offset);
   }
 
   @Override
   public int hashCode() {
-    return Objects.hash(commandId, command, status);
+    return Objects.hash(commandId, command, status, offset);
   }
 }

--- a/ksql-rest-app/src/main/java/io/confluent/ksql/rest/server/computation/SnapshotWithOffset.java
+++ b/ksql-rest-app/src/main/java/io/confluent/ksql/rest/server/computation/SnapshotWithOffset.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright 2019 Confluent Inc.
+ *
+ * Licensed under the Confluent Community License (the "License"); you may not use
+ * this file except in compliance with the License.  You may obtain a copy of the
+ * License at
+ *
+ * http://www.confluent.io/confluent-community-license
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package io.confluent.ksql.rest.server.computation;
+
+import io.confluent.ksql.KsqlExecutionContext;
+
+public class SnapshotWithOffset {
+  private KsqlExecutionContext ksqlExecutionContext;
+  private int snapshotOffset;
+
+  public SnapshotWithOffset(final KsqlExecutionContext ksqlExecutionContext) {
+    this.ksqlExecutionContext = ksqlExecutionContext;
+    this.snapshotOffset = 0;
+  }
+
+  public KsqlExecutionContext getKsqlExecutionContext() {
+    return ksqlExecutionContext.createSandbox(ksqlExecutionContext.getServiceContext());
+  }
+
+  public int getSnapshotOffset() {
+    return snapshotOffset;
+  }
+
+  public void updateSnapshot(final KsqlExecutionContext ksqlExecutionContext) {
+    this.ksqlExecutionContext = ksqlExecutionContext;
+  }
+
+  public void updateOffsetValue(final int snapshotOffset) {
+    this.snapshotOffset = snapshotOffset;
+  }
+}
+

--- a/ksql-rest-app/src/test/java/io/confluent/ksql/rest/server/CommandTopicTest.java
+++ b/ksql-rest-app/src/test/java/io/confluent/ksql/rest/server/CommandTopicTest.java
@@ -173,9 +173,9 @@ public class CommandTopicTest {
     when(commandConsumer.poll(any(Duration.class)))
         .thenReturn(someConsumerRecords(
             new ConsumerRecord<>("topic", 0, 0, commandId1, command1),
-            new ConsumerRecord<>("topic", 0, 0, commandId2, command2)))
+            new ConsumerRecord<>("topic", 0, 1, commandId2, command2)))
         .thenReturn(someConsumerRecords(
-            new ConsumerRecord<>("topic", 0, 0, commandId3, command3)))
+            new ConsumerRecord<>("topic", 0, 2, commandId3, command3)))
         .thenReturn(new ConsumerRecords<>(Collections.emptyMap()));
 
     // When:
@@ -187,11 +187,35 @@ public class CommandTopicTest {
     assertThat(topicPartitionsCaptor.getValue(),
         equalTo(Collections.singletonList(new TopicPartition(COMMAND_TOPIC_NAME, 0))));
     assertThat(queuedCommandList, equalTo(ImmutableList.of(
-        new QueuedCommand(commandId1, command1, Optional.empty()),
-        new QueuedCommand(commandId2, command2, Optional.empty()),
-        new QueuedCommand(commandId3, command3, Optional.empty()))));
+        new QueuedCommand(commandId1, command1, Optional.empty(), 0),
+        new QueuedCommand(commandId2, command2, Optional.empty(), 1),
+        new QueuedCommand(commandId3, command3, Optional.empty(), 2))));
   }
 
+  @Test
+  public void shouldHaveOffsetsInQueuedCommands() {
+    // Given:
+    when(commandConsumer.poll(any(Duration.class)))
+            .thenReturn(someConsumerRecords(
+                    new ConsumerRecord<>("topic", 0, 0, commandId1, command1),
+                    new ConsumerRecord<>("topic", 0, 1, commandId2, command2)))
+            .thenReturn(someConsumerRecords(
+                    new ConsumerRecord<>("topic", 0, 2, commandId3, command3)))
+            .thenReturn(new ConsumerRecords<>(Collections.emptyMap()));
+
+    // When:
+    final List<QueuedCommand> queuedCommandList = commandTopic
+            .getRestoreCommands(Duration.ofMillis(1));
+
+    // Then:
+    verify(commandConsumer).seekToBeginning(topicPartitionsCaptor.capture());
+    assertThat(topicPartitionsCaptor.getValue(),
+            equalTo(Collections.singletonList(new TopicPartition(COMMAND_TOPIC_NAME, 0))));
+    assertThat(queuedCommandList, equalTo(ImmutableList.of(
+            new QueuedCommand(commandId1, command1, Optional.empty(), 0),
+            new QueuedCommand(commandId2, command2, Optional.empty(),1),
+            new QueuedCommand(commandId3, command3, Optional.empty(), 2))));
+  }
 
   @Test
   public void shouldGetRestoreCommandsCorrectlyWithDuplicateKeys() {
@@ -199,10 +223,10 @@ public class CommandTopicTest {
     when(commandConsumer.poll(any(Duration.class)))
         .thenReturn(someConsumerRecords(
             new ConsumerRecord<>("topic", 0, 0, commandId1, command1),
-            new ConsumerRecord<>("topic", 0, 0, commandId2, command2)))
+            new ConsumerRecord<>("topic", 0, 1, commandId2, command2)))
         .thenReturn(someConsumerRecords(
-            new ConsumerRecord<>("topic", 0, 0, commandId2, command3),
-            new ConsumerRecord<>("topic", 0, 0, commandId3, command3)))
+            new ConsumerRecord<>("topic", 0, 2, commandId2, command3),
+            new ConsumerRecord<>("topic", 0, 3, commandId3, command3)))
         .thenReturn(new ConsumerRecords<>(Collections.emptyMap()));
 
     // When:
@@ -211,10 +235,10 @@ public class CommandTopicTest {
 
     // Then:
     assertThat(queuedCommandList, equalTo(ImmutableList.of(
-        new QueuedCommand(commandId1, command1, Optional.empty()),
-        new QueuedCommand(commandId2, command2, Optional.empty()),
-        new QueuedCommand(commandId2, command3, Optional.empty()),
-        new QueuedCommand(commandId3, command3, Optional.empty()))));
+        new QueuedCommand(commandId1, command1, Optional.empty(), 0),
+        new QueuedCommand(commandId2, command2, Optional.empty(), 1),
+        new QueuedCommand(commandId2, command3, Optional.empty(), 2),
+        new QueuedCommand(commandId3, command3, Optional.empty(), 3))));
   }
 
 
@@ -224,8 +248,8 @@ public class CommandTopicTest {
     when(commandConsumer.poll(any(Duration.class)))
         .thenReturn(someConsumerRecords(
             new ConsumerRecord<>("topic", 0, 0, commandId1, command1),
-            new ConsumerRecord<>("topic", 0, 0, commandId2, command2),
-            new ConsumerRecord<>("topic", 0, 0, commandId2, null)
+            new ConsumerRecord<>("topic", 0, 1, commandId2, command2),
+            new ConsumerRecord<>("topic", 0, 2, commandId2, null)
         ))
         .thenReturn(new ConsumerRecords<>(Collections.emptyMap()));
 
@@ -235,8 +259,8 @@ public class CommandTopicTest {
 
     // Then:
     assertThat(queuedCommandList, equalTo(ImmutableList.of(
-        new QueuedCommand(commandId1, command1, Optional.empty()),
-        new QueuedCommand(commandId2, command2, Optional.empty()))));
+        new QueuedCommand(commandId1, command1, Optional.empty(), 0),
+        new QueuedCommand(commandId2, command2, Optional.empty(), 1))));
   }
 
   @Test
@@ -263,8 +287,8 @@ public class CommandTopicTest {
     // Given:
     final ConsumerRecords<CommandId, Command> records = someConsumerRecords(
         new ConsumerRecord<>("topic", 0, 0, commandId1, command1),
-        new ConsumerRecord<>("topic", 0, 0, commandId2, command2),
-        new ConsumerRecord<>("topic", 0, 0, commandId3, command3));
+        new ConsumerRecord<>("topic", 0, 1, commandId2, command2),
+        new ConsumerRecord<>("topic", 0, 2, commandId3, command3));
 
     when(commandTopic.getNewCommands(any()))
         .thenReturn(records)
@@ -275,9 +299,9 @@ public class CommandTopicTest {
 
     // Then:
     assertThat(commands, equalTo(Arrays.asList(
-        new QueuedCommand(commandId1, command1, Optional.empty()),
-        new QueuedCommand(commandId2, command2, Optional.empty()),
-        new QueuedCommand(commandId3, command3, Optional.empty())
+        new QueuedCommand(commandId1, command1, Optional.empty(), 0),
+        new QueuedCommand(commandId2, command2, Optional.empty(), 1),
+        new QueuedCommand(commandId3, command3, Optional.empty(), 2)
     )));
   }
 

--- a/ksql-rest-app/src/test/java/io/confluent/ksql/rest/server/computation/CommandRunnerTest.java
+++ b/ksql-rest-app/src/test/java/io/confluent/ksql/rest/server/computation/CommandRunnerTest.java
@@ -15,6 +15,7 @@
 
 package io.confluent.ksql.rest.server.computation;
 
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.not;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyList;
@@ -35,6 +36,8 @@ import io.confluent.ksql.rest.util.TerminateCluster;
 import java.time.Duration;
 import java.util.Arrays;
 import java.util.concurrent.ExecutorService;
+
+import io.confluent.ksql.services.ServiceContext;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -83,6 +86,9 @@ public class CommandRunnerTest {
     when(queuedCommand3.getCommand()).thenReturn(command);
 
     givenQueuedCommands(queuedCommand1, queuedCommand2, queuedCommand3);
+
+    when(commandStore.getSnapshotWithOffset())
+        .thenReturn(new SnapshotWithOffset(ksqlEngine));
 
     commandRunner = new CommandRunner(
         statementExecutor,

--- a/ksql-rest-app/src/test/java/io/confluent/ksql/rest/server/computation/CommandStoreTest.java
+++ b/ksql-rest-app/src/test/java/io/confluent/ksql/rest/server/computation/CommandStoreTest.java
@@ -30,6 +30,7 @@ import static org.mockito.Mockito.inOrder;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
+import io.confluent.ksql.engine.KsqlEngine;
 import io.confluent.ksql.parser.KsqlParser.PreparedStatement;
 import io.confluent.ksql.parser.tree.Statement;
 import io.confluent.ksql.rest.entity.CommandId;
@@ -89,6 +90,8 @@ public class CommandStoreTest {
   @Mock
   private CommandTopic commandTopic;
   @Mock
+  private KsqlEngine ksqlEngine;
+  @Mock
   private Statement statement;
   @Mock
   private CommandIdAssigner commandIdAssigner;
@@ -97,7 +100,7 @@ public class CommandStoreTest {
   private final CommandId commandId =
       new CommandId(CommandId.Type.STREAM, "foo", CommandId.Action.CREATE);
   private final Command command =
-      new Command(statementText, Collections.emptyMap(), Collections.emptyMap());
+      new Command(statementText, 0, Collections.emptyMap(), Collections.emptyMap());
   private final RecordMetadata recordMetadata = new RecordMetadata(
       COMMAND_TOPIC_PARTITION, 0, 0, RecordBatch.NO_TIMESTAMP, 0L, 0, 0);
 
@@ -123,7 +126,8 @@ public class CommandStoreTest {
     commandStore = new CommandStore(
         commandTopic,
         commandIdAssigner,
-        sequenceNumberFutureStore
+        sequenceNumberFutureStore,
+        ksqlEngine
     );
   }
 
@@ -176,6 +180,7 @@ public class CommandStoreTest {
           assertThat(
               queuedCommand.getStatus().get().getStatus().getStatus(),
               equalTo(CommandStatus.Status.QUEUED));
+          assertThat(queuedCommand.getOffset(), equalTo(0));
           return recordMetadata;
         }
     );

--- a/ksql-rest-app/src/test/java/io/confluent/ksql/rest/server/computation/CommandTest.java
+++ b/ksql-rest-app/src/test/java/io/confluent/ksql/rest/server/computation/CommandTest.java
@@ -31,6 +31,7 @@ public class CommandTest {
   public void shouldDeserializeCorrectly() throws IOException {
     final String commandStr = "{" +
         "\"statement\": \"test statement;\", " +
+        "\"commandTopicOffset\": 1, " +
         "\"streamsProperties\": {\"foo\": \"bar\"}, " +
         "\"originalProperties\": {\"biz\": \"baz\"} " +
         "}";
@@ -44,12 +45,14 @@ public class CommandTest {
         = Collections.singletonMap("biz", "baz");
     assertThat(command.getOriginalProperties(), equalTo(expectedOriginalProperties));
     assertThat(command.isPreVersion5(), is(false));
+    assertThat(command.getCommandTopicOffset(), is(1));
   }
 
   @Test
   public void shouldDeserializeWithoutKsqlConfigCorrectly() throws IOException {
     final String commandStr = "{" +
         "\"statement\": \"test statement;\", " +
+        "\"commandTopicOffset\": 3, " +
         "\"streamsProperties\": {\"foo\": \"bar\"}" +
         "}";
     final ObjectMapper mapper = JsonMapper.INSTANCE.mapper;
@@ -59,6 +62,27 @@ public class CommandTest {
     assertThat(command.getOverwriteProperties(), equalTo(expecteOverwriteProperties));
     assertThat(command.getOriginalProperties(), equalTo(Collections.emptyMap()));
     assertThat(command.isPreVersion5(), equalTo(true));
+    assertThat(command.getCommandTopicOffset(), is(3));
+  }
+
+  @Test
+  public void shouldDeserializeWithoutOffsetCorrectly() throws IOException {
+    final String commandStr = "{" +
+            "\"statement\": \"test statement;\", " +
+            "\"streamsProperties\": {\"foo\": \"bar\"}, " +
+            "\"originalProperties\": {\"biz\": \"baz\"} " +
+            "}";
+    final ObjectMapper mapper = JsonMapper.INSTANCE.mapper;
+    final Command command = mapper.readValue(commandStr, Command.class);
+    assertThat(command.getStatement(), equalTo("test statement;"));
+    final Map<String, Object> expecteOverwriteProperties
+            = Collections.singletonMap("foo", "bar");
+    assertThat(command.getOverwriteProperties(), equalTo(expecteOverwriteProperties));
+    final Map<String, Object> expectedOriginalProperties
+            = Collections.singletonMap("biz", "baz");
+    assertThat(command.getOriginalProperties(), equalTo(expectedOriginalProperties));
+    assertThat(command.isPreVersion5(), is(false));
+    assertThat(command.getCommandTopicOffset(), is(-1));
   }
 
   void grep(final String string, final String regex) {
@@ -68,13 +92,13 @@ public class CommandTest {
   @Test
   public void shouldSerializeDeserializeCorrectly() throws IOException {
     final Command command = new Command(
-        "test statement;",
-        Collections.singletonMap("foo", "bar"),
-        Collections.singletonMap("biz", "baz"));
+        "test statement;", 2,
+            Collections.singletonMap("foo", "bar"), Collections.singletonMap("biz", "baz"));
     final ObjectMapper mapper = JsonMapper.INSTANCE.mapper;
     final String serialized = mapper.writeValueAsString(command);
     grep(serialized, ".*\"streamsProperties\" *: *\\{ *\"foo\" *: *\"bar\" *\\}.*");
     grep(serialized, ".*\"statement\" *: *\"test statement;\".*");
+    grep(serialized, ".*\"commandTopicOffset\".*:2.*");
     grep(serialized, ".*\"originalProperties\" *: *\\{ *\"biz\" *: *\"baz\" *\\}.*");
     final Command deserialized = mapper.readValue(serialized, Command.class);
     assertThat(deserialized, equalTo(command));

--- a/ksql-rest-app/src/test/java/io/confluent/ksql/rest/server/computation/StatementExecutorTest.java
+++ b/ksql-rest-app/src/test/java/io/confluent/ksql/rest/server/computation/StatementExecutorTest.java
@@ -188,6 +188,7 @@ public class StatementExecutorTest extends EasyMockSupport {
         exception);
     final Command command = new Command(
         statementText,
+        0,
         emptyMap(),
         emptyMap());
     final CommandId commandId =  new CommandId(
@@ -232,6 +233,7 @@ public class StatementExecutorTest extends EasyMockSupport {
 
     final Command csasCommand = new Command(
         statementText,
+        0,
         emptyMap(),
         originalConfig.getAllConfigPropsWithSecretsObfuscated());
     final CommandId csasCommandId =  new CommandId(
@@ -284,10 +286,11 @@ public class StatementExecutorTest extends EasyMockSupport {
   public void shouldCompleteFutureOnSuccess() {
     final Command command = new Command(
         "CREATE STREAM foo ("
-            + "biz bigint,"
-            + " baz varchar) "
-            + "WITH (kafka_topic = 'foo', "
-            + "value_format = 'json');",
+        + "biz bigint,"
+        + " baz varchar) "
+        + "WITH (kafka_topic = 'foo', "
+        + "value_format = 'json');",
+        0,
         emptyMap(),
         ksqlConfig.getAllConfigPropsWithSecretsObfuscated());
     final CommandId commandId =  new CommandId(CommandId.Type.STREAM,
@@ -313,10 +316,11 @@ public class StatementExecutorTest extends EasyMockSupport {
 
     final Command command = new Command(
         "CREATE STREAM foo ("
-            + "biz bigint,"
-            + " baz varchar) "
-            + "WITH (kafka_topic = 'foo', "
-            + "value_format = 'json');",
+        + "biz bigint,"
+        + " baz varchar) "
+        + "WITH (kafka_topic = 'foo', "
+        + "value_format = 'json');",
+        0,
         emptyMap(),
         ksqlConfig.getAllConfigPropsWithSecretsObfuscated());
     final CommandId commandId =  new CommandId(CommandId.Type.STREAM,
@@ -380,6 +384,7 @@ public class StatementExecutorTest extends EasyMockSupport {
     // Now drop should be successful
     final Command dropTableCommand2 = new Command(
         "drop table table1;",
+        0,
         emptyMap(),
         ksqlConfig.getAllConfigPropsWithSecretsObfuscated());
     final CommandId dropTableCommandId2 =
@@ -397,7 +402,9 @@ public class StatementExecutorTest extends EasyMockSupport {
 
     // DROP should succeed since no query is using the stream.
     final Command dropStreamCommand3 = new Command(
-        "drop stream pageview;", emptyMap(),
+        "drop stream pageview;",
+        0,
+        emptyMap(),
         ksqlConfig.getAllConfigPropsWithSecretsObfuscated());
     final CommandId dropStreamCommandId3 =
         new CommandId(CommandId.Type.STREAM, "_user1pv", CommandId.Action.DROP);
@@ -486,7 +493,7 @@ public class StatementExecutorTest extends EasyMockSupport {
     statementExecutorWithMocks.handleRestore(
         new QueuedCommand(
             new CommandId(Type.STREAM, name, Action.CREATE),
-            new Command("CSAS", emptyMap(), emptyMap())
+            new Command("CSAS", 0, emptyMap(), emptyMap())
         )
     );
 
@@ -516,7 +523,7 @@ public class StatementExecutorTest extends EasyMockSupport {
     statementExecutorWithMocks.handleRestore(
         new QueuedCommand(
             new CommandId(Type.STREAM, "foo", Action.DROP),
-            new Command("DROP", emptyMap(), PRE_VERSION_5_NULL_ORIGINAL_PROPS)
+            new Command("DROP", 0, emptyMap(), PRE_VERSION_5_NULL_ORIGINAL_PROPS)
         )
     );
 
@@ -549,7 +556,7 @@ public class StatementExecutorTest extends EasyMockSupport {
     statementExecutorWithMocks.handleRestore(
         new QueuedCommand(
             new CommandId(Type.STREAM, "foo", Action.DROP),
-            new Command(drop, emptyMap(), emptyMap())
+            new Command(drop, 0, emptyMap(), emptyMap())
         )
     );
 
@@ -622,6 +629,7 @@ public class StatementExecutorTest extends EasyMockSupport {
             new CommandId(CommandId.Type.STREAM, "RunScript", CommandId.Action.EXECUTE),
             new Command(
                 runScriptStatement,
+                0,
                 Collections.singletonMap("ksql.run.script.statements", queryStatement),
                 emptyMap())
         )
@@ -644,9 +652,8 @@ public class StatementExecutorTest extends EasyMockSupport {
         new QueuedCommand(
             new CommandId(CommandId.Type.STREAM, "RunScript", CommandId.Action.EXECUTE),
             new Command(
-                runScriptStatement,
-                Collections.singletonMap("ksql.run.script.statements", queryStatement),
-                emptyMap())
+                runScriptStatement, 0,
+                    Collections.singletonMap("ksql.run.script.statements", queryStatement), emptyMap())
         )
     );
 
@@ -661,9 +668,8 @@ public class StatementExecutorTest extends EasyMockSupport {
             + " pageid varchar, "
             + "userid varchar) "
             + "WITH (kafka_topic = 'pageview_topic_json', "
-            + "value_format = 'json');",
-        emptyMap(),
-        ksqlConfig.getAllConfigPropsWithSecretsObfuscated());
+            + "value_format = 'json');", 0,
+            emptyMap(), ksqlConfig.getAllConfigPropsWithSecretsObfuscated());
     final CommandId csCommandId =  new CommandId(CommandId.Type.STREAM,
         "_CSASStreamGen",
         CommandId.Action.CREATE);
@@ -672,9 +678,8 @@ public class StatementExecutorTest extends EasyMockSupport {
     final Command csasCommand = new Command(
         "CREATE STREAM user1pv AS "
             + "select * from pageview"
-            + " WHERE userid = 'user1';",
-        emptyMap(),
-        ksqlConfig.getAllConfigPropsWithSecretsObfuscated());
+            + " WHERE userid = 'user1';", 0,
+            emptyMap(), ksqlConfig.getAllConfigPropsWithSecretsObfuscated());
 
     final CommandId csasCommandId =  new CommandId(CommandId.Type.STREAM,
         "_CSASGen",
@@ -687,6 +692,7 @@ public class StatementExecutorTest extends EasyMockSupport {
             + "FROM pageview "
             + "WINDOW TUMBLING ( SIZE 10 SECONDS) "
             + "GROUP BY pageid;",
+        0,
         emptyMap(),
         ksqlConfig.getAllConfigPropsWithSecretsObfuscated());
 
@@ -703,6 +709,7 @@ public class StatementExecutorTest extends EasyMockSupport {
   private void tryDropThatViolatesReferentialIntegrity() {
     final Command dropStreamCommand1 = new Command(
         "drop stream pageview;",
+        0,
         emptyMap(),
         ksqlConfig.getAllConfigPropsWithSecretsObfuscated());
     final CommandId dropStreamCommandId1 =  new CommandId(CommandId.Type.STREAM,
@@ -742,6 +749,7 @@ public class StatementExecutorTest extends EasyMockSupport {
 
     final Command dropStreamCommand2 = new Command(
         "drop stream user1pv;",
+        0,
         emptyMap(),
         ksqlConfig.getAllConfigPropsWithSecretsObfuscated());
     final CommandId dropStreamCommandId2 =
@@ -778,6 +786,7 @@ public class StatementExecutorTest extends EasyMockSupport {
 
     final Command dropTableCommand1 = new Command(
         "drop table table1;",
+        0,
         emptyMap(),
         ksqlConfig.getAllConfigPropsWithSecretsObfuscated());
     final CommandId dropTableCommandId1 =
@@ -829,9 +838,8 @@ public class StatementExecutorTest extends EasyMockSupport {
 
   private void terminateQueries() {
     final Command terminateCommand1 = new Command(
-        "TERMINATE CSAS_USER1PV_0;",
-        emptyMap(),
-        ksqlConfig.getAllConfigPropsWithSecretsObfuscated());
+        "TERMINATE CSAS_USER1PV_0;", 0,
+            emptyMap(), ksqlConfig.getAllConfigPropsWithSecretsObfuscated());
     final CommandId terminateCommandId1 =
         new CommandId(CommandId.Type.STREAM, "_TerminateGen", CommandId.Action.CREATE);
     handleStatement(
@@ -841,7 +849,8 @@ public class StatementExecutorTest extends EasyMockSupport {
 
     final Command terminateCommand2 = new Command(
         "TERMINATE CTAS_TABLE1_1;",
-        emptyMap(),
+        0,
+      emptyMap(),
         ksqlConfig.getAllConfigPropsWithSecretsObfuscated());
     final CommandId terminateCommandId2 =
         new CommandId(CommandId.Type.TABLE, "_TerminateGen", CommandId.Action.CREATE);
@@ -865,6 +874,6 @@ public class StatementExecutorTest extends EasyMockSupport {
 
   private static Command givenCommand(final String statementStr, final KsqlConfig ksqlConfig) {
     return new Command(
-        statementStr, emptyMap(), ksqlConfig.getAllConfigPropsWithSecretsObfuscated());
+        statementStr, 0, emptyMap(), ksqlConfig.getAllConfigPropsWithSecretsObfuscated());
   }
 }

--- a/ksql-rest-app/src/test/java/io/confluent/ksql/rest/server/utils/TestUtils.java
+++ b/ksql-rest-app/src/test/java/io/confluent/ksql/rest/server/utils/TestUtils.java
@@ -31,14 +31,14 @@ public class TestUtils {
 
     final Command csCommand = new Command("CREATE STREAM pageview "
                                     + "(viewtime bigint, pageid varchar, userid varchar) "
-                                    + "WITH (kafka_topic='pageview_topic_json', value_format='json');",
-                                    Collections.emptyMap(), Collections.emptyMap());
+                                    + "WITH (kafka_topic='pageview_topic_json', value_format='json');", 0,
+            Collections.emptyMap(), Collections.emptyMap());
     final CommandId csCommandId =  new CommandId(CommandId.Type.STREAM, "_CSASStreamGen", CommandId.Action.CREATE);
     priorCommands.add(new Pair<>(csCommandId, csCommand));
 
     final Command csasCommand = new Command("CREATE STREAM user1pv "
-                                      + " AS select * from pageview WHERE userid = 'user1';",
-                                      Collections.emptyMap(), Collections.emptyMap());
+                                      + " AS select * from pageview WHERE userid = 'user1';", 1,
+            Collections.emptyMap(), Collections.emptyMap());
 
     final CommandId csasCommandId =  new CommandId(CommandId.Type.STREAM, "_CSASGen", CommandId.Action.CREATE);
     priorCommands.add(new Pair<>(csasCommandId, csasCommand));
@@ -47,8 +47,8 @@ public class TestUtils {
     final Command ctasCommand = new Command("CREATE TABLE user1pvtb "
                                       + " AS select * from pageview window tumbling(size 5 "
                                       + "second) WHERE userid = "
-                                      + "'user1' group by pageid;",
-                                      Collections.emptyMap(), Collections.emptyMap());
+                                      + "'user1' group by pageid;", 2,
+            Collections.emptyMap(), Collections.emptyMap());
 
     final CommandId ctasCommandId =  new CommandId(CommandId.Type.TABLE, "_CTASGen", CommandId.Action.CREATE);
     priorCommands.add(new Pair<>(ctasCommandId, ctasCommand));


### PR DESCRIPTION
### Description 
Based off of discussion in https://github.com/confluentinc/ksql/pull/3278 and https://github.com/confluentinc/ksql/issues/2435.

This PR adds an offset value to both Command and QueuedCommand objects. The field in Command represents the point when a Ksql statement was validated and put on the CommandTopic. The field in QueuedCommand represents the offset that the command was read from, it's assigned from the corresponding Kafka ConsumerRecord.offset()

Request Validator was also rewritten to take a KsqlExecutionContext instead of a ServiceContext

This change also makes it so that when a statement that creates a query is executed, query_id generation can utilize the current statement offset instead of relying on incrementing a value (Future PR).

## Testing done 
Local tests
Update existing tests
### Reviewer checklist
- [ ] Ensure docs are updated if necessary. (eg. if a user visible feature is being added or changed).
- [ ] Ensure relevant issues are linked (description should include text like "Fixes #<issue number>")

