### PR TITLE
test: output topic and message index when QTT detects mismatch (MINOR)

### DIFF
--- a/ksql-functional-tests/src/main/java/io/confluent/ksql/test/tools/TestExecutor.java
+++ b/ksql-functional-tests/src/main/java/io/confluent/ksql/test/tools/TestExecutor.java
@@ -180,6 +180,7 @@ public class TestExecutor implements Closeable {
 
     expectedByTopic.forEach((kafkaTopic, expectedRecords) ->
         validateTopicData(
+            kafkaTopic,
             expectedRecords,
             actualByTopic.getOrDefault(kafkaTopic, ImmutableList.of()),
             ranWithInsertStatements
@@ -187,6 +188,7 @@ public class TestExecutor implements Closeable {
   }
 
   private static void validateTopicData(
+      final String topicName,
       final List<Record> expected,
       final List<FakeKafkaRecord> actual,
       final boolean ranWithInsertStatements
@@ -200,7 +202,13 @@ public class TestExecutor implements Closeable {
       final Record expectedRecord = expected.get(i);
       final ProducerRecord<?, ?> actualProducerRecord = actual.get(i).getProducerRecord();
 
-      validateCreatedMessage(expectedRecord, actualProducerRecord, ranWithInsertStatements);
+      validateCreatedMessage(
+          topicName,
+          expectedRecord,
+          actualProducerRecord,
+          ranWithInsertStatements,
+          i
+      );
     }
   }
 
@@ -416,9 +424,11 @@ public class TestExecutor implements Closeable {
   }
 
   private static void validateCreatedMessage(
+      final String topicName,
       final Record expectedRecord,
       final ProducerRecord<?, ?> actualProducerRecord,
-      final boolean ranWithInsertStatements
+      final boolean ranWithInsertStatements,
+      final int messageIndex
   ) {
     final Object actualKey = actualProducerRecord.key();
     final Object actualValue = actualProducerRecord.value();
@@ -429,7 +439,8 @@ public class TestExecutor implements Closeable {
     final long expectedTimestamp = expectedRecord.timestamp().orElse(actualTimestamp);
 
     final AssertionError error = new AssertionError(
-        "Expected <" + expectedKey + ", " + expectedValue + "> "
+        "Topic '" + topicName + "', message " + messageIndex
+            + ": Expected <" + expectedKey + ", " + expectedValue + "> "
             + "with timestamp=" + expectedTimestamp
             + " but was " + getProducerRecordInString(actualProducerRecord));
 


### PR DESCRIPTION
### Description 

The QTT test used to output both the name of the topic and the message index when it failed due to a mismatch between the expected output and the actual. This was lost in the recent changes. This info really helps to zero in on what is different.

So you now get and error that includes the topic name, e.g. `S2` and the message index, e.g. `0` in the assert message:

```
java.lang.AssertionError: Topic 'S2', message 0: Expected <[0@0/30000], {ID=0, TOPK=[0.1]}> with timestamp=0 but was <[0@0/30000], {ID=0, TOPK=[0.0]}> with timestamp=0
failed test: hopping-windows - topk hopping
in file: query-validation-tests/hopping-windows.json
```

### Testing done 

`mvn test`

### Reviewer checklist
- [ ] Ensure docs are updated if necessary. (eg. if a user visible feature is being added or changed).
- [ ] Ensure relevant issues are linked (description should include text like "Fixes #<issue number>")

