### PR TITLE
refactor: a QualifiedName now only consists of at most two parts

### DIFF
--- a/ksql-engine/src/main/java/io/confluent/ksql/analyzer/AggregateAnalyzer.java
+++ b/ksql-engine/src/main/java/io/confluent/ksql/analyzer/AggregateAnalyzer.java
@@ -96,7 +96,7 @@ class AggregateAnalyzer {
 
     @Override
     public Void visitFunctionCall(final FunctionCall node, final Void context) {
-      final String functionName = node.getName().getSuffix();
+      final String functionName = node.getName().name();
       final boolean aggregateFunc = functionRegistry.isAggregate(functionName);
 
       final FunctionCall functionCall = aggregateFunc && node.getArguments().isEmpty()

--- a/ksql-engine/src/main/java/io/confluent/ksql/analyzer/Analyzer.java
+++ b/ksql-engine/src/main/java/io/confluent/ksql/analyzer/Analyzer.java
@@ -428,7 +428,7 @@ class Analyzer {
       if (expression instanceof QualifiedNameReference) {
         final QualifiedNameReference qualifiedNameRef = (QualifiedNameReference) expression;
 
-        final String fieldName = qualifiedNameRef.getName().getSuffix();
+        final String fieldName = qualifiedNameRef.getName().name();
         return getJoinFieldFromSource(fieldName, sourceAlias, sourceSchema);
       }
       return Optional.empty();
@@ -445,7 +445,7 @@ class Analyzer {
 
     @Override
     protected AstNode visitAliasedRelation(final AliasedRelation node, final Void context) {
-      final String structuredDataSourceName = ((Table) node.getRelation()).getName().getSuffix();
+      final String structuredDataSourceName = ((Table) node.getRelation()).getName().name();
 
       final DataSource<?> source = metaStore.getSource(structuredDataSourceName);
       if (source == null) {

--- a/ksql-engine/src/main/java/io/confluent/ksql/analyzer/ExpressionAnalyzer.java
+++ b/ksql-engine/src/main/java/io/confluent/ksql/analyzer/ExpressionAnalyzer.java
@@ -143,7 +143,7 @@ class ExpressionAnalyzer {
         final QualifiedNameReference node,
         final Object context
     ) {
-      final String columnName = node.getName().getSuffix();
+      final String columnName = node.getName().name();
       throwOnUnknownField(columnName);
       return null;
     }

--- a/ksql-engine/src/main/java/io/confluent/ksql/ddl/commands/CommandFactories.java
+++ b/ksql-engine/src/main/java/io/confluent/ksql/ddl/commands/CommandFactories.java
@@ -123,7 +123,7 @@ public class CommandFactories implements DdlCommandFactory {
       final CallInfo callInfo,
       final CreateStream statement
   ) {
-    final String sourceName = statement.getName().getSuffix();
+    final String sourceName = statement.getName().name();
     final KsqlTopic topic = buildTopic(statement.getProperties(), serviceContext);
     final LogicalSchema schema = buildSchema(statement.getElements());
     final Optional<String> keyFieldName = buildKeyFieldName(statement, schema);
@@ -160,7 +160,7 @@ public class CommandFactories implements DdlCommandFactory {
       final CallInfo callInfo,
       final CreateTable statement
   ) {
-    final String sourceName = statement.getName().getSuffix();
+    final String sourceName = statement.getName().name();
     final KsqlTopic topic = buildTopic(statement.getProperties(), serviceContext);
     final LogicalSchema schema = buildSchema(statement.getElements());
     final Optional<String> keyFieldName = buildKeyFieldName(statement, schema);
@@ -196,7 +196,7 @@ public class CommandFactories implements DdlCommandFactory {
   @SuppressWarnings("MethodMayBeStatic")
   private DropSourceCommand handleDropStream(final DropStream statement) {
     return handleDropSource(
-        statement.getName().getSuffix(),
+        statement.getName().name(),
         statement.getIfExists(),
         DataSourceType.KSTREAM
     );
@@ -205,7 +205,7 @@ public class CommandFactories implements DdlCommandFactory {
   @SuppressWarnings("MethodMayBeStatic")
   private DropSourceCommand handleDropTable(final DropTable statement) {
     return handleDropSource(
-        statement.getName().getSuffix(),
+        statement.getName().name(),
         statement.getIfExists(),
         DataSourceType.KTABLE
     );

--- a/ksql-engine/src/main/java/io/confluent/ksql/engine/InsertValuesExecutor.java
+++ b/ksql-engine/src/main/java/io/confluent/ksql/engine/InsertValuesExecutor.java
@@ -138,11 +138,11 @@ public class InsertValuesExecutor {
     final InsertValues insertValues = statement.getStatement();
     final DataSource<?> dataSource = executionContext
         .getMetaStore()
-        .getSource(insertValues.getTarget().getSuffix());
+        .getSource(insertValues.getTarget().name());
 
     if (dataSource == null) {
       throw new KsqlException("Cannot insert values into an unknown stream/table: "
-          + insertValues.getTarget().getSuffix());
+          + insertValues.getTarget().name());
     }
 
     if (dataSource.getKsqlTopic().getKeyFormat().isWindowed()) {
@@ -178,10 +178,10 @@ public class InsertValuesExecutor {
       );
 
       throw new KsqlException("Failed to insert values into stream/table: "
-          + insertValues.getTarget().getSuffix(), rootCause);
+          + insertValues.getTarget().name(), rootCause);
     } catch (final Exception e) {
       throw new KsqlException("Failed to insert values into stream/table: "
-          + insertValues.getTarget().getSuffix(), e);
+          + insertValues.getTarget().name(), e);
     }
   }
 

--- a/ksql-engine/src/main/java/io/confluent/ksql/security/KsqlAuthorizationValidatorImpl.java
+++ b/ksql-engine/src/main/java/io/confluent/ksql/security/KsqlAuthorizationValidatorImpl.java
@@ -103,7 +103,7 @@ public class KsqlAuthorizationValidatorImpl implements KsqlAuthorizationValidato
 
     validateQuery(serviceContext, metaStore, insertInto.getQuery());
 
-    final String kafkaTopic = getSourceTopicName(metaStore, insertInto.getTarget().getSuffix());
+    final String kafkaTopic = getSourceTopicName(metaStore, insertInto.getTarget().name());
     checkAccess(serviceContext, kafkaTopic, AclOperation.WRITE);
   }
 
@@ -157,6 +157,6 @@ public class KsqlAuthorizationValidatorImpl implements KsqlAuthorizationValidato
       final CreateAsSelect createAsSelect
   ) {
     return createAsSelect.getProperties().getKafkaTopic()
-        .orElseGet(() -> getSourceTopicName(metaStore, createAsSelect.getName().getSuffix()));
+        .orElseGet(() -> getSourceTopicName(metaStore, createAsSelect.getName().name()));
   }
 }

--- a/ksql-engine/src/main/java/io/confluent/ksql/structured/SchemaKStream.java
+++ b/ksql-engine/src/main/java/io/confluent/ksql/structured/SchemaKStream.java
@@ -456,7 +456,7 @@ public class SchemaKStream<K> {
           final QualifiedNameReference nameRef
               = (QualifiedNameReference) toExpression;
 
-          if (SchemaUtil.isFieldName(nameRef.getName().getSuffix(), keyField.fullName())) {
+          if (SchemaUtil.isFieldName(nameRef.getName().name(), keyField.fullName())) {
             found = Optional.of(Column.of(toName, keyField.type()));
             break;
           }

--- a/ksql-engine/src/main/java/io/confluent/ksql/topic/SourceTopicsExtractor.java
+++ b/ksql-engine/src/main/java/io/confluent/ksql/topic/SourceTopicsExtractor.java
@@ -56,7 +56,7 @@ public class SourceTopicsExtractor extends DefaultTraversalVisitor<AstNode, Void
 
   @Override
   protected AstNode visitAliasedRelation(final AliasedRelation node, final Void context) {
-    final String structuredDataSourceName = ((Table) node.getRelation()).getName().getSuffix();
+    final String structuredDataSourceName = ((Table) node.getRelation()).getName().name();
     final DataSource<?> source = metaStore.getSource(structuredDataSourceName);
     if (source == null) {
       throw new KsqlException(structuredDataSourceName + " does not exist.");

--- a/ksql-engine/src/main/java/io/confluent/ksql/topic/TopicCreateInjector.java
+++ b/ksql-engine/src/main/java/io/confluent/ksql/topic/TopicCreateInjector.java
@@ -150,7 +150,7 @@ public class TopicCreateInjector implements Injector {
     final String sourceTopicName = extractor.getPrimaryKafkaTopicName();
 
     topicPropertiesBuilder
-        .withName(prefix + createAsSelect.getName().getSuffix())
+        .withName(prefix + createAsSelect.getName().name())
         .withSource(() -> topicClient.describeTopic(sourceTopicName))
         .withWithClause(
             properties.getKafkaTopic(),

--- a/ksql-engine/src/main/java/io/confluent/ksql/topic/TopicDeleteInjector.java
+++ b/ksql-engine/src/main/java/io/confluent/ksql/topic/TopicDeleteInjector.java
@@ -92,7 +92,7 @@ public class TopicDeleteInjector implements Injector {
       return statement;
     }
 
-    final String sourceName = dropStatement.getName().getSuffix();
+    final String sourceName = dropStatement.getName().name();
     final DataSource<?> source = metastore.getSource(sourceName);
 
     if (source != null) {

--- a/ksql-engine/src/main/java/io/confluent/ksql/util/AggregateExpressionRewriter.java
+++ b/ksql-engine/src/main/java/io/confluent/ksql/util/AggregateExpressionRewriter.java
@@ -43,7 +43,7 @@ public class AggregateExpressionRewriter
   public Optional<Expression> visitFunctionCall(
       final FunctionCall node,
       final ExpressionTreeRewriter.Context<Void> context) {
-    final String functionName = node.getName().getSuffix();
+    final String functionName = node.getName().name();
     if (functionRegistry.isAggregate(functionName)) {
       final String aggVarName = AGGREGATE_FUNCTION_VARIABLE_PREFIX + aggVariableIndex;
       aggVariableIndex++;

--- a/ksql-engine/src/test/java/io/confluent/ksql/analyzer/QueryAnalyzerTest.java
+++ b/ksql-engine/src/test/java/io/confluent/ksql/analyzer/QueryAnalyzerTest.java
@@ -352,8 +352,8 @@ public class QueryAnalyzerTest {
     expectedException.expect(KsqlException.class);
     expectedException.expectMessage(
         "Non-aggregate SELECT expression(s) not part of GROUP BY: "
-            + "[ORDERS.ORDERTIME, ORDERS.ROWTIME, ORDERS.ROWKEY, ORDERS.ORDERUNITS, ORDERS.MAPCOL, "
-            + "ORDERS.ORDERID, ORDERS.ITEMINFO, ORDERS.ARRAYCOL, ORDERS.ADDRESS]"
+            + "[ORDERS.ADDRESS, ORDERS.ARRAYCOL, ORDERS.ITEMINFO, ORDERS.MAPCOL, ORDERS.ORDERID, "
+            + "ORDERS.ORDERTIME, ORDERS.ORDERUNITS, ORDERS.ROWKEY, ORDERS.ROWTIME]"
     );
 
     // When:

--- a/ksql-engine/src/test/java/io/confluent/ksql/ddl/commands/CommandFactoriesTest.java
+++ b/ksql-engine/src/test/java/io/confluent/ksql/ddl/commands/CommandFactoriesTest.java
@@ -151,8 +151,8 @@ public class CommandFactoriesTest {
   public void before() {
     when(serviceContext.getTopicClient()).thenReturn(topicClient);
     when(topicClient.isTopicExists(any())).thenReturn(true);
-    when(metaStore.getSource(SOME_NAME.getSuffix())).thenReturn(ksqlStream);
-    when(metaStore.getSource(TABLE_NAME.getSuffix())).thenReturn(ksqlTable);
+    when(metaStore.getSource(SOME_NAME.name())).thenReturn(ksqlStream);
+    when(metaStore.getSource(TABLE_NAME.name())).thenReturn(ksqlTable);
     when(ksqlStream.getDataSourceType()).thenReturn(DataSourceType.KSTREAM);
     when(ksqlTable.getDataSourceType()).thenReturn(DataSourceType.KTABLE);
     when(serdeFactory.create(any(), any(), any(), any(), any(), any())).thenReturn(serde);
@@ -782,7 +782,7 @@ public class CommandFactoriesTest {
   public void shouldCreateDropSourceOnMissingSourceWithIfExistsForStream() {
     // Given:
     final DropStream dropStream = new DropStream(SOME_NAME, false, true);
-    when(metaStore.getSource(SOME_NAME.getSuffix())).thenReturn(null);
+    when(metaStore.getSource(SOME_NAME.name())).thenReturn(null);
 
     // When:
     final DropSourceCommand cmd = (DropSourceCommand) commandFactories.create(
@@ -815,7 +815,7 @@ public class CommandFactoriesTest {
   public void shouldFailDropSourceOnDropIncompatibleSourceForStream() {
     // Given:
     final DropStream dropStream = new DropStream(SOME_NAME, false, true);
-    when(metaStore.getSource(SOME_NAME.getSuffix())).thenReturn(ksqlTable);
+    when(metaStore.getSource(SOME_NAME.name())).thenReturn(ksqlTable);
 
     // Expect:
     expectedException.expect(KsqlException.class);

--- a/ksql-engine/src/test/java/io/confluent/ksql/planner/LogicalPlannerTest.java
+++ b/ksql-engine/src/test/java/io/confluent/ksql/planner/LogicalPlannerTest.java
@@ -135,7 +135,7 @@ public class LogicalPlannerTest {
     assertThat(logicalPlan.getSources().get(0), instanceOf(AggregateNode.class));
     final AggregateNode aggregateNode = (AggregateNode) logicalPlan.getSources().get(0);
     assertThat(aggregateNode.getFunctionCalls().size(), equalTo(2));
-    assertThat(aggregateNode.getFunctionCalls().get(0).getName().getSuffix(), equalTo("SUM"));
+    assertThat(aggregateNode.getFunctionCalls().get(0).getName().name(), equalTo("SUM"));
     assertThat(aggregateNode.getWindowExpression().getKsqlWindowExpression().toString(), equalTo(" TUMBLING ( SIZE 2 SECONDS ) "));
     assertThat(aggregateNode.getGroupByExpressions().size(), equalTo(1));
     assertThat(aggregateNode.getGroupByExpressions().get(0).toString(), equalTo("TEST1.COL0"));
@@ -157,7 +157,7 @@ public class LogicalPlannerTest {
     assertThat(logicalPlan.getSources().get(0), instanceOf(AggregateNode.class));
     final AggregateNode aggregateNode = (AggregateNode) logicalPlan.getSources().get(0);
     assertThat(aggregateNode.getFunctionCalls().size(), equalTo(2));
-    assertThat(aggregateNode.getFunctionCalls().get(0).getName().getSuffix(), equalTo("SUM"));
+    assertThat(aggregateNode.getFunctionCalls().get(0).getName().name(), equalTo("SUM"));
     assertThat(aggregateNode.getWindowExpression().getKsqlWindowExpression().toString(), equalTo(" HOPPING ( SIZE 2 SECONDS , ADVANCE BY 1 SECONDS ) "));
     assertThat(aggregateNode.getGroupByExpressions().size(), equalTo(1));
     assertThat(aggregateNode.getGroupByExpressions().get(0).toString(), equalTo("TEST1.COL0"));

--- a/ksql-execution/src/main/java/io/confluent/ksql/execution/codegen/CodeGenRunner.java
+++ b/ksql-execution/src/main/java/io/confluent/ksql/execution/codegen/CodeGenRunner.java
@@ -193,7 +193,7 @@ public class CodeGenRunner {
     public Object visitFunctionCall(final FunctionCall node, final Object context) {
       final int functionNumber = functionCounter++;
       final List<Schema> argumentTypes = new ArrayList<>();
-      final String functionName = node.getName().getSuffix();
+      final String functionName = node.getName().name();
       for (final Expression argExpr : node.getArguments()) {
         process(argExpr, null);
         argumentTypes.add(expressionTypeManager.getExpressionSchema(argExpr));
@@ -201,7 +201,7 @@ public class CodeGenRunner {
 
       final UdfFactory holder = functionRegistry.getUdfFactory(functionName);
       final KsqlFunction function = holder.getFunction(argumentTypes);
-      final String parameterName = node.getName().getSuffix() + "_" + functionNumber;
+      final String parameterName = node.getName().name() + "_" + functionNumber;
       parameters.add(new ParameterType(
           function,
           parameterName,
@@ -313,7 +313,7 @@ public class CodeGenRunner {
         final QualifiedNameReference node,
         final Object context
     ) {
-      addParameter(getRequiredColumn(node.getName().getSuffix()));
+      addParameter(getRequiredColumn(node.getName().name()));
       return null;
     }
 

--- a/ksql-execution/src/main/java/io/confluent/ksql/execution/codegen/SqlToJavaVisitor.java
+++ b/ksql-execution/src/main/java/io/confluent/ksql/execution/codegen/SqlToJavaVisitor.java
@@ -17,7 +17,6 @@ package io.confluent.ksql.execution.codegen;
 
 import static java.lang.String.format;
 
-import com.google.common.base.Joiner;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import io.confluent.ksql.execution.codegen.helpers.SearchedCaseFunction;
@@ -74,7 +73,6 @@ import io.confluent.ksql.util.SchemaUtil;
 import java.math.BigDecimal;
 import java.math.MathContext;
 import java.math.RoundingMode;
-import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
@@ -291,11 +289,7 @@ public class SqlToJavaVisitor {
     }
 
     private String formatQualifiedName(final QualifiedName name) {
-      final List<String> parts = new ArrayList<>();
-      for (final String part : name.getParts()) {
-        parts.add(formatIdentifier(part));
-      }
-      return Joiner.on('.').join(parts);
+      return name.toString(this::formatIdentifier);
     }
 
     public Pair<String, Schema> visitLongLiteral(
@@ -317,7 +311,7 @@ public class SqlToJavaVisitor {
     public Pair<String, Schema> visitFunctionCall(
         final FunctionCall node,
         final Void context) {
-      final String functionName = node.getName().getSuffix();
+      final String functionName = node.getName().name();
 
       final String instanceName = functionName + "_" + functionCounter++;
       final Schema functionReturnSchema = getFunctionReturnSchema(node, functionName);

--- a/ksql-execution/src/main/java/io/confluent/ksql/execution/expression/formatter/ExpressionFormatter.java
+++ b/ksql-execution/src/main/java/io/confluent/ksql/execution/expression/formatter/ExpressionFormatter.java
@@ -51,7 +51,6 @@ import io.confluent.ksql.execution.expression.tree.Type;
 import io.confluent.ksql.execution.expression.tree.WhenClause;
 import io.confluent.ksql.schema.ksql.FormatOptions;
 import io.confluent.ksql.util.KsqlConstants;
-import java.util.ArrayList;
 import java.util.List;
 import java.util.function.Predicate;
 
@@ -160,11 +159,7 @@ public final class ExpressionFormatter {
     }
 
     private static String formatQualifiedName(final QualifiedName name, final Context context) {
-      final List<String> parts = new ArrayList<>();
-      for (final String part : name.getParts()) {
-        parts.add(formatIdentifier(part, context));
-      }
-      return Joiner.on(KsqlConstants.DOT).join(parts);
+      return name.toString(s -> formatIdentifier(s, context));
     }
 
     @Override
@@ -172,7 +167,7 @@ public final class ExpressionFormatter {
       final StringBuilder builder = new StringBuilder();
 
       String arguments = joinExpressions(node.getArguments(), context);
-      if (node.getArguments().isEmpty() && "COUNT".equals(node.getName().getSuffix())) {
+      if (node.getArguments().isEmpty() && "COUNT".equals(node.getName().name())) {
         arguments = "*";
       }
 

--- a/ksql-execution/src/main/java/io/confluent/ksql/execution/expression/tree/DereferenceExpression.java
+++ b/ksql-execution/src/main/java/io/confluent/ksql/execution/expression/tree/DereferenceExpression.java
@@ -19,8 +19,6 @@ import static java.util.Objects.requireNonNull;
 
 import com.google.errorprone.annotations.Immutable;
 import io.confluent.ksql.parser.NodeLocation;
-import java.util.ArrayList;
-import java.util.List;
 import java.util.Objects;
 import java.util.Optional;
 
@@ -58,32 +56,6 @@ public class DereferenceExpression extends Expression {
 
   public String getFieldName() {
     return fieldName;
-  }
-
-  /**
-   * If this DereferenceExpression looks like a QualifiedName, return QualifiedName.
-   * Otherwise return null
-   */
-  public static QualifiedName getQualifiedName(final DereferenceExpression expression) {
-    final List<String> parts = tryParseParts(expression.base, expression.fieldName);
-    return parts == null ? null : QualifiedName.of(parts);
-  }
-
-  private static List<String> tryParseParts(final Expression base, final String fieldName) {
-    if (base instanceof QualifiedNameReference) {
-      final List<String> newList =
-          new ArrayList<>(((QualifiedNameReference) base).getName().getParts());
-      newList.add(fieldName);
-      return newList;
-    } else if (base instanceof DereferenceExpression) {
-      final QualifiedName baseQualifiedName = getQualifiedName((DereferenceExpression) base);
-      if (baseQualifiedName != null) {
-        final List<String> newList = new ArrayList<>(baseQualifiedName.getParts());
-        newList.add(fieldName);
-        return newList;
-      }
-    }
-    return null;
   }
 
   @Override

--- a/ksql-execution/src/main/java/io/confluent/ksql/execution/expression/tree/QualifiedName.java
+++ b/ksql-execution/src/main/java/io/confluent/ksql/execution/expression/tree/QualifiedName.java
@@ -15,67 +15,55 @@
 
 package io.confluent.ksql.execution.expression.tree;
 
-import static com.google.common.base.Preconditions.checkArgument;
-import static com.google.common.collect.Iterables.isEmpty;
 import static java.util.Objects.requireNonNull;
 
-import com.google.common.base.Joiner;
-import com.google.common.collect.ImmutableList;
-import com.google.common.collect.Iterables;
-import com.google.common.collect.Lists;
 import com.google.errorprone.annotations.Immutable;
-import java.util.List;
+import io.confluent.ksql.util.KsqlConstants;
+import java.util.Objects;
 import java.util.Optional;
+import java.util.function.Function;
 
 @Immutable
 public final class QualifiedName {
 
-  private final ImmutableList<String> parts;
+  private final Optional<String> qualifier;
+  private final String name;
 
-  public static QualifiedName of(final String first, final String... rest) {
-    requireNonNull(first, "first is null");
-    return of(ImmutableList.copyOf(Lists.asList(first, rest)));
+  public static QualifiedName of(final String qualifier, final String name) {
+    return new QualifiedName(Optional.of(qualifier), name);
+  }
+
+  public static QualifiedName of(final Optional<String> qualifier, final String name) {
+    return new QualifiedName(qualifier, name);
   }
 
   public static QualifiedName of(final String name) {
-    requireNonNull(name, "name is null");
-    return of(ImmutableList.of(name));
+    return new QualifiedName(Optional.empty(), name);
   }
 
-  public static QualifiedName of(final Iterable<String> parts) {
-    requireNonNull(parts, "parts is null");
-    checkArgument(!isEmpty(parts), "parts is empty");
-    return new QualifiedName(ImmutableList.copyOf(parts));
+  private QualifiedName(final Optional<String> qualifier, final String name) {
+    this.qualifier = requireNonNull(qualifier, "qualifier");
+    this.name = requireNonNull(name, "name");
   }
 
-  private QualifiedName(final ImmutableList<String> parts) {
-    this.parts = requireNonNull(parts, "parts");
+  public Optional<String> qualifier() {
+    return qualifier;
   }
 
-  public List<String> getParts() {
-    return parts;
+  public String name() {
+    return name;
   }
 
   @Override
   public String toString() {
-    return Joiner.on('.').join(parts);
+    return toString(Function.identity());
   }
 
-  /**
-   * For an identifier of the form "a.b.c.d", returns "a.b.c"
-   * For an identifier of the form "a", returns absent
-   */
-  public Optional<QualifiedName> getPrefix() {
-    if (parts.size() == 1) {
-      return Optional.empty();
-    }
-
-    final ImmutableList<String> subList = parts.subList(0, parts.size() - 1);
-    return Optional.of(new QualifiedName(subList));
-  }
-
-  public String getSuffix() {
-    return Iterables.getLast(parts);
+  public String toString(final Function<String, String> escapeFun) {
+    final String escaped = escapeFun.apply(name);
+    return qualifier
+        .map(q -> escapeFun.apply(q) + KsqlConstants.DOT + escaped)
+        .orElse(escaped);
   }
 
   @Override
@@ -86,11 +74,13 @@ public final class QualifiedName {
     if (o == null || getClass() != o.getClass()) {
       return false;
     }
-    return parts.equals(((QualifiedName) o).parts);
+    final QualifiedName that = (QualifiedName) o;
+    return Objects.equals(qualifier, that.qualifier)
+        && Objects.equals(name, that.name);
   }
 
   @Override
   public int hashCode() {
-    return parts.hashCode();
+    return Objects.hash(qualifier, name);
   }
 }

--- a/ksql-execution/src/main/java/io/confluent/ksql/execution/expression/tree/QualifiedNameReference.java
+++ b/ksql-execution/src/main/java/io/confluent/ksql/execution/expression/tree/QualifiedNameReference.java
@@ -40,10 +40,6 @@ public class QualifiedNameReference extends Expression {
     return name;
   }
 
-  public QualifiedName getSuffix() {
-    return QualifiedName.of(name.getSuffix());
-  }
-
   @Override
   public <R, C> R accept(final ExpressionVisitor<R, C> visitor, final C context) {
     return visitor.visitQualifiedNameReference(this, context);

--- a/ksql-execution/src/main/java/io/confluent/ksql/execution/util/ExpressionTypeManager.java
+++ b/ksql-execution/src/main/java/io/confluent/ksql/execution/util/ExpressionTypeManager.java
@@ -210,7 +210,7 @@ public class ExpressionTypeManager {
         final QualifiedNameReference node,
         final ExpressionTypeContext expressionTypeContext
     ) {
-      final Column schemaColumn = schema.findValueColumn(node.getName().getSuffix())
+      final Column schemaColumn = schema.findValueColumn(node.getName().name())
           .orElseThrow(() ->
               new KsqlException(String.format("Invalid Expression %s.", node.toString())));
 
@@ -351,13 +351,13 @@ public class ExpressionTypeManager {
         final FunctionCall node,
         final ExpressionTypeContext expressionTypeContext
     ) {
-      if (functionRegistry.isAggregate(node.getName().getSuffix())) {
+      if (functionRegistry.isAggregate(node.getName().name())) {
         final Schema schema = node.getArguments().isEmpty()
             ? FunctionRegistry.DEFAULT_FUNCTION_ARG_SCHEMA
             : getExpressionSchema(node.getArguments().get(0));
 
         final KsqlAggregateFunction aggFunc = functionRegistry
-            .getAggregate(node.getName().getSuffix(), schema);
+            .getAggregate(node.getName().name(), schema);
 
         final Schema returnSchema = aggFunc.getReturnType();
 
@@ -367,7 +367,7 @@ public class ExpressionTypeManager {
         return null;
       }
 
-      if (node.getName().getSuffix().equalsIgnoreCase(FetchFieldFromStruct.FUNCTION_NAME)) {
+      if (node.getName().name().equalsIgnoreCase(FetchFieldFromStruct.FUNCTION_NAME)) {
         process(node.getArguments().get(0), expressionTypeContext);
         final Schema firstArgSchema = expressionTypeContext.getSchema();
         final String fieldName = ((StringLiteral) node.getArguments().get(1)).getValue();
@@ -380,7 +380,7 @@ public class ExpressionTypeManager {
         final SqlType returnType = CONNECT_TO_SQL_SCHEMA_CONVERTER.toSqlType(returnSchema);
         expressionTypeContext.setSchema(returnType, returnSchema);
       } else {
-        final UdfFactory udfFactory = functionRegistry.getUdfFactory(node.getName().getSuffix());
+        final UdfFactory udfFactory = functionRegistry.getUdfFactory(node.getName().name());
         final List<Schema> argTypes = new ArrayList<>();
         for (final Expression expression : node.getArguments()) {
           process(expression, expressionTypeContext);

--- a/ksql-functional-tests/src/test/resources/query-validation-tests/group-by.json
+++ b/ksql-functional-tests/src/test/resources/query-validation-tests/group-by.json
@@ -713,7 +713,7 @@
       ],
       "expectedException": {
         "type": "io.confluent.ksql.util.KsqlStatementException",
-        "message": "Non-aggregate SELECT expression(s) not part of GROUP BY: [TEST.SUBREGION, TEST.REGION]"
+        "message": "Non-aggregate SELECT expression(s) not part of GROUP BY: [TEST.REGION, TEST.SUBREGION]"
       }
     },
     {

--- a/ksql-parser/src/main/antlr4/io/confluent/ksql/parser/SqlBase.g4
+++ b/ksql-parser/src/main/antlr4/io/confluent/ksql/parser/SqlBase.g4
@@ -297,7 +297,7 @@ whenClause
     ;
 
 qualifiedName
-    : identifier ('.' identifier)*
+    : identifier ('.' identifier)?
     ;
 
 identifier

--- a/ksql-parser/src/main/java/io/confluent/ksql/parser/AstBuilder.java
+++ b/ksql-parser/src/main/java/io/confluent/ksql/parser/AstBuilder.java
@@ -309,8 +309,7 @@ public class AstBuilder {
       final QualifiedName targetName = ParserUtil.getQualifiedName(context.qualifiedName());
       final Optional<NodeLocation> targetLocation = getLocation(context.qualifiedName());
 
-      final DataSource<?> target =
-          getSource(targetName.getSuffix(), targetLocation);
+      final DataSource<?> target = getSource(targetName.name(), targetLocation);
 
       if (target.getDataSourceType() != DataSourceType.KSTREAM) {
         throw new KsqlException(
@@ -568,7 +567,7 @@ public class AstBuilder {
         alias = ParserUtil.getIdentifierText(context.identifier());
       } else {
         if (selectItem instanceof QualifiedNameReference) {
-          alias = ((QualifiedNameReference) selectItem).getName().getSuffix();
+          alias = ((QualifiedNameReference) selectItem).getName().name();
         } else if (selectItem instanceof DereferenceExpression) {
           final DereferenceExpression dereferenceExp = (DereferenceExpression) selectItem;
           final String dereferenceExpressionString = dereferenceExp.toString();
@@ -772,7 +771,7 @@ public class AstBuilder {
       switch (context.children.size()) {
         case 1:
           final Table table = (Table) visit(context.relationPrimary());
-          alias = table.getName().getSuffix();
+          alias = table.getName().name();
           break;
 
         case 2:

--- a/ksql-parser/src/main/java/io/confluent/ksql/parser/SqlFormatter.java
+++ b/ksql-parser/src/main/java/io/confluent/ksql/parser/SqlFormatter.java
@@ -495,9 +495,6 @@ public final class SqlFormatter {
   }
 
   private static String escapedName(final QualifiedName name) {
-    return name.getParts()
-        .stream()
-        .map(IdentifierUtil::escape)
-        .collect(Collectors.joining("."));
+    return name.toString(IdentifierUtil::escape);
   }
 }

--- a/ksql-parser/src/main/java/io/confluent/ksql/parser/tree/CreateStreamAsSelect.java
+++ b/ksql-parser/src/main/java/io/confluent/ksql/parser/tree/CreateStreamAsSelect.java
@@ -54,7 +54,7 @@ public class CreateStreamAsSelect extends CreateAsSelect {
 
   @Override
   public Sink getSink() {
-    return Sink.of(getName().getSuffix(), true, getProperties(), getPartitionByColumn());
+    return Sink.of(getName().name(), true, getProperties(), getPartitionByColumn());
   }
 
   @Override

--- a/ksql-parser/src/main/java/io/confluent/ksql/parser/tree/CreateTableAsSelect.java
+++ b/ksql-parser/src/main/java/io/confluent/ksql/parser/tree/CreateTableAsSelect.java
@@ -62,7 +62,7 @@ public class CreateTableAsSelect extends CreateAsSelect {
 
   @Override
   public Sink getSink() {
-    return Sink.of(getName().getSuffix(), true, getProperties(), Optional.empty());
+    return Sink.of(getName().name(), true, getProperties(), Optional.empty());
   }
 
   @Override

--- a/ksql-parser/src/main/java/io/confluent/ksql/parser/tree/InsertInto.java
+++ b/ksql-parser/src/main/java/io/confluent/ksql/parser/tree/InsertInto.java
@@ -70,7 +70,7 @@ public class InsertInto
 
   @Override
   public Sink getSink() {
-    return Sink.of(target.getSuffix(), false, CreateSourceAsProperties.none(), partitionByColumn);
+    return Sink.of(target.name(), false, CreateSourceAsProperties.none(), partitionByColumn);
   }
 
   @Override

--- a/ksql-parser/src/main/java/io/confluent/ksql/util/DataSourceExtractor.java
+++ b/ksql-parser/src/main/java/io/confluent/ksql/util/DataSourceExtractor.java
@@ -123,7 +123,7 @@ public class DataSourceExtractor {
       final String alias;
       switch (context.children.size()) {
         case 1:
-          alias = table.getName().getSuffix().toUpperCase();
+          alias = table.getName().name().toUpperCase();
           break;
 
         case 2:
@@ -143,9 +143,9 @@ public class DataSourceExtractor {
 
       if (!isJoin) {
         fromAlias = alias;
-        fromName = table.getName().getSuffix().toUpperCase();
-        if (metaStore.getSource(table.getName().getSuffix()) == null) {
-          throw new KsqlException(table.getName().getSuffix() + " does not exist.");
+        fromName = table.getName().name().toUpperCase();
+        if (metaStore.getSource(table.getName().name()) == null) {
+          throw new KsqlException(table.getName().name() + " does not exist.");
         }
 
         return null;
@@ -159,24 +159,24 @@ public class DataSourceExtractor {
       isJoin = true;
       final AliasedRelation left = (AliasedRelation) visit(context.left);
       leftAlias = left.getAlias();
-      leftName = ((Table) left.getRelation()).getName().getSuffix();
+      leftName = ((Table) left.getRelation()).getName().name();
       final DataSource
           leftDataSource =
-          metaStore.getSource(((Table) left.getRelation()).getName().getSuffix());
+          metaStore.getSource(((Table) left.getRelation()).getName().name());
       if (leftDataSource == null) {
-        throw new KsqlException(((Table) left.getRelation()).getName().getSuffix() + " does not "
+        throw new KsqlException(((Table) left.getRelation()).getName().name() + " does not "
             + "exist.");
       }
       addFieldNames(leftDataSource.getSchema(), leftFieldNames);
 
       final AliasedRelation right = (AliasedRelation) visit(context.right);
       rightAlias = right.getAlias();
-      rightName = ((Table) right.getRelation()).getName().getSuffix();
+      rightName = ((Table) right.getRelation()).getName().name();
       final DataSource
           rightDataSource =
-          metaStore.getSource(((Table) right.getRelation()).getName().getSuffix());
+          metaStore.getSource(((Table) right.getRelation()).getName().name());
       if (rightDataSource == null) {
-        throw new KsqlException(((Table) right.getRelation()).getName().getSuffix() + " does not "
+        throw new KsqlException(((Table) right.getRelation()).getName().name() + " does not "
             + "exist.");
       }
       addFieldNames(rightDataSource.getSchema(), rightFieldNames);

--- a/ksql-parser/src/main/java/io/confluent/ksql/util/ParserUtil.java
+++ b/ksql-parser/src/main/java/io/confluent/ksql/util/ParserUtil.java
@@ -17,7 +17,6 @@ package io.confluent.ksql.util;
 
 import static io.confluent.ksql.parser.SqlBaseParser.DecimalLiteralContext;
 import static java.util.Objects.requireNonNull;
-import static java.util.stream.Collectors.toList;
 
 import io.confluent.ksql.execution.expression.tree.DoubleLiteral;
 import io.confluent.ksql.execution.expression.tree.IntegerLiteral;
@@ -29,7 +28,6 @@ import io.confluent.ksql.parser.ParsingException;
 import io.confluent.ksql.parser.SqlBaseParser;
 import io.confluent.ksql.parser.SqlBaseParser.IntegerLiteralContext;
 import io.confluent.ksql.parser.SqlBaseParser.NumberContext;
-import java.util.List;
 import java.util.Optional;
 import org.antlr.v4.runtime.ParserRuleContext;
 import org.antlr.v4.runtime.Token;
@@ -56,12 +54,18 @@ public final class ParserUtil {
   }
 
   public static QualifiedName getQualifiedName(final SqlBaseParser.QualifiedNameContext context) {
-    final List<String> parts = context
-        .identifier().stream()
-        .map(ParserUtil::getIdentifierText)
-        .collect(toList());
+    final Optional<String> qualifier;
+    final String name;
 
-    return QualifiedName.of(parts);
+    if (context.identifier(1) == null) {
+      qualifier = Optional.empty();
+      name = ParserUtil.getIdentifierText(context.identifier(0));
+    } else {
+      qualifier = Optional.of(ParserUtil.getIdentifierText(context.identifier(0)));
+      name = ParserUtil.getIdentifierText(context.identifier(1));
+    }
+
+    return QualifiedName.of(qualifier, name);
   }
 
   public static int processIntegerNumber(final NumberContext number, final String context) {

--- a/ksql-parser/src/test/java/io/confluent/ksql/parser/SqlFormatterTest.java
+++ b/ksql-parser/src/test/java/io/confluent/ksql/parser/SqlFormatterTest.java
@@ -146,8 +146,8 @@ public class SqlFormatterTest {
 
   @Before
   public void setUp() {
-    final Table left = new Table(QualifiedName.of(Collections.singletonList("left")));
-    final Table right = new Table(QualifiedName.of(Collections.singletonList("right")));
+    final Table left = new Table(QualifiedName.of("left"));
+    final Table right = new Table(QualifiedName.of("right"));
     leftAlias = new AliasedRelation(left, "l");
     rightAlias = new AliasedRelation(right, "r");
 

--- a/ksql-rest-app/src/main/java/io/confluent/ksql/rest/server/computation/CommandIdAssigner.java
+++ b/ksql-rest-app/src/main/java/io/confluent/ksql/rest/server/computation/CommandIdAssigner.java
@@ -120,7 +120,7 @@ public class CommandIdAssigner {
   private static CommandId getDropStreamCommandId(final DropStream dropStreamQuery) {
     return new CommandId(
         CommandId.Type.STREAM,
-        dropStreamQuery.getName().getSuffix(),
+        dropStreamQuery.getName().name(),
         CommandId.Action.DROP
     );
   }
@@ -128,7 +128,7 @@ public class CommandIdAssigner {
   private static CommandId getDropTableCommandId(final DropTable dropTableQuery) {
     return new CommandId(
         CommandId.Type.TABLE,
-        dropTableQuery.getName().getSuffix(),
+        dropTableQuery.getName().name(),
         CommandId.Action.DROP
     );
   }

--- a/ksql-rest-app/src/main/java/io/confluent/ksql/rest/server/execution/ListSourceExecutor.java
+++ b/ksql-rest-app/src/main/java/io/confluent/ksql/rest/server/execution/ListSourceExecutor.java
@@ -135,7 +135,7 @@ public final class ListSourceExecutor {
     final SourceDescriptionWithWarnings descriptionWithWarnings = describeSource(
         executionContext,
         serviceContext,
-        showColumns.getTable().getSuffix(),
+        showColumns.getTable().name(),
         showColumns.isExtended(),
         statement.getStatementText()
     );


### PR DESCRIPTION
### Description 

We never used the multiple parts feature of `QualifiedName`, this removes that and makes it way easier to work with.

### Review Guide

- Look at `QualifiedName`
- `QueryAnalyzer` now throws deterministic error messages
- Unused code was removed in various places
- Rest is jitter

### Testing done 

`mvn clean install`

### Reviewer checklist
- [ ] Ensure docs are updated if necessary. (eg. if a user visible feature is being added or changed).
- [ ] Ensure relevant issues are linked (description should include text like "Fixes #<issue number>")

