### PR TITLE
fix: improve error message on query or print statement on /ksql (MINOR)

### DIFF
--- a/ksql-rest-app/src/test/java/io/confluent/ksql/rest/server/resources/KsqlResourceTest.java
+++ b/ksql-rest-app/src/test/java/io/confluent/ksql/rest/server/resources/KsqlResourceTest.java
@@ -631,9 +631,11 @@ public class KsqlResourceTest {
     expectedException.expect(KsqlRestException.class);
     expectedException.expect(exceptionStatusCode(is(Code.BAD_REQUEST)));
     expectedException.expect(exceptionStatementErrorMessage(errorMessage(is(
-            "RUN SCRIPT cannot be used with the following statements: \n"
-                    + "* PRINT\n"
-                    + "* SELECT"))));
+        "The following statement types should be issued to the websocket endpoint '/query':"
+            + System.lineSeparator()
+            + "\t* PRINT"
+            + System.lineSeparator()
+            + "\t* SELECT"))));
     expectedException.expect(exceptionStatementErrorMessage(statement(is(
         "SELECT * FROM test_table;"))));
 
@@ -647,9 +649,11 @@ public class KsqlResourceTest {
     expectedException.expect(KsqlRestException.class);
     expectedException.expect(exceptionStatusCode(is(Code.BAD_REQUEST)));
     expectedException.expect(exceptionStatementErrorMessage(errorMessage(is(
-            "RUN SCRIPT cannot be used with the following statements: \n"
-                    + "* PRINT\n"
-                    + "* SELECT"))));
+        "The following statement types should be issued to the websocket endpoint '/query':"
+            + System.lineSeparator()
+            + "\t* PRINT"
+            + System.lineSeparator()
+            + "\t* SELECT"))));
     expectedException.expect(exceptionStatementErrorMessage(statement(is(
         "PRINT 'orders-topic';"))));
 

--- a/ksql-rest-app/src/test/java/io/confluent/ksql/rest/server/validation/QueryValidatorTest.java
+++ b/ksql-rest-app/src/test/java/io/confluent/ksql/rest/server/validation/QueryValidatorTest.java
@@ -44,28 +44,27 @@ public class QueryValidatorTest {
 
   @Test
   public void shouldThrowExceptionOnQueryEndpoint() {
-    // Expect:
-    // Expect:
+    // Given:
+    final ConfiguredStatement<Query> query = ConfiguredStatement.of(
+        PreparedStatement.of("SELECT * FROM test_table;", mock(Query.class)),
+        ImmutableMap.of(),
+        engine.getKsqlConfig()
+    );
+
+    // Then:
     expectedException.expect(KsqlRestException.class);
     expectedException.expect(exceptionStatusCode(is(Code.BAD_REQUEST)));
     expectedException.expect(exceptionStatementErrorMessage(errorMessage(containsString(
-            "RUN SCRIPT cannot be used with the following statements: \n"
-                    + "* PRINT\n"
-                    + "* SELECT"))));
+        "The following statement types should be issued to the websocket endpoint '/query'"
+    ))));
     expectedException.expect(exceptionStatementErrorMessage(statement(containsString(
         "SELECT * FROM test_table"))));
 
     // When:
     CustomValidators.QUERY_ENDPOINT.validate(
-        ConfiguredStatement.of(
-            PreparedStatement.of("SELECT * FROM test_table;", mock(Query.class)),
-            ImmutableMap.of(),
-            engine.getKsqlConfig()
-        ),
+        query,
         engine.getEngine(),
         engine.getServiceContext()
     );
   }
-
-
 }

--- a/ksql-rest-model/src/main/java/io/confluent/ksql/rest/Errors.java
+++ b/ksql-rest-model/src/main/java/io/confluent/ksql/rest/Errors.java
@@ -136,10 +136,12 @@ public final class Errors {
     return Response
         .status(BAD_REQUEST)
         .entity(new KsqlStatementErrorMessage(
-                ERROR_CODE_QUERY_ENDPOINT,
-                "RUN SCRIPT cannot be used with the following statements: \n"
-                        + "* PRINT\n"
-                        + "* SELECT",
+            ERROR_CODE_QUERY_ENDPOINT,
+            "The following statement types should be issued to the websocket endpoint '/query':"
+                + System.lineSeparator()
+                + "\t* PRINT"
+                + System.lineSeparator()
+                + "\t* SELECT",
             statementText, new KsqlEntityList()))
         .build();
   }


### PR DESCRIPTION
### Description 

If someone issues a `PRINT` or `SELECT` statement to the normal HTTP `/ksql` endpoint it returns an error. The previous error talked about `RUN SCRIPT`, which is misleading. We don't even have `RUN SCRIPT` anymore.

> RUN SCRIPT cannot be used with the following statements: 
>      * PRINT
>      * SELECT

New error message just tells users to target such statements to the websocket endpoint `/query`

> The following statement types should be issued to the websocket endpoint '/query':
>          * PRINT
>          * SELECT


### Testing done 

`mvn test`

### Reviewer checklist
- [ ] Ensure docs are updated if necessary. (eg. if a user visible feature is being added or changed).
- [ ] Ensure relevant issues are linked (description should include text like "Fixes #<issue number>")

