### PR TITLE
chore: move build failure alerts to the new #ksql-alerts channel

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,7 +1,7 @@
 #!/usr/bin/env groovy
 
 dockerfile {
-    slackChannel = '#ksql-eng'
+    slackChannel = '#ksql-alerts'
     upstreamProjects = 'confluentinc/schema-registry'
     dockerRepos = ['confluentinc/ksql-examples', 'confluentinc/ksql-cli', 'confluentinc/ksql-clickstream-demo', 'confluentinc/cp-ksql-server', 'confluentinc/cp-ksql-cli']
     extraBuildArgs = '-Ddocker.skip=false'


### PR DESCRIPTION
### Description 
Clean up the #ksql-eng channel by moving the build alerts to a new channel which is reserved for automated alerts.

### Testing done 
N/A

### Reviewer checklist
- [ ] Ensure docs are updated if necessary. (eg. if a user visible feature is being added or changed).
- [ ] Ensure relevant issues are linked (description should include text like "Fixes #<issue number>")

