### PR TITLE
feat: add offset to QueuedCommand and flag to Command

### DIFF
--- a/ksql-rest-app/src/main/java/io/confluent/ksql/rest/server/CommandTopic.java
+++ b/ksql-rest-app/src/main/java/io/confluent/ksql/rest/server/CommandTopic.java
@@ -127,7 +127,8 @@ public class CommandTopic {
             new QueuedCommand(
                 record.key(),
                 record.value(),
-                Optional.empty()));
+                Optional.empty(),
+                record.offset()));
       }
       records = commandConsumer.poll(duration);
     }

--- a/ksql-rest-app/src/main/java/io/confluent/ksql/rest/server/computation/Command.java
+++ b/ksql-rest-app/src/main/java/io/confluent/ksql/rest/server/computation/Command.java
@@ -25,15 +25,18 @@ import java.util.Objects;
 @JsonSubTypes({})
 public class Command {
   private final String statement;
+  private final boolean useOffsetAsQueryID;
   private final Map<String, Object> overwriteProperties;
   private final Map<String, String> originalProperties;
   private final boolean preVersion5;
 
   @JsonCreator
   public Command(@JsonProperty("statement") final String statement,
+                 @JsonProperty("useOffsetAsQueryID") final Boolean useOffsetAsQueryID,
                  @JsonProperty("streamsProperties") final Map<String, Object> overwriteProperties,
                  @JsonProperty("originalProperties") final Map<String, String> originalProperties) {
     this.statement = statement;
+    this.useOffsetAsQueryID = useOffsetAsQueryID == null ? false : useOffsetAsQueryID;
     this.overwriteProperties = Collections.unmodifiableMap(overwriteProperties);
     this.preVersion5 = originalProperties == null;
     this.originalProperties =
@@ -43,6 +46,11 @@ public class Command {
   @JsonProperty("statement")
   public String getStatement() {
     return statement;
+  }
+
+  @JsonProperty("useOffsetAsQueryID")
+  public boolean getUseOffsetAsQueryID() {
+    return useOffsetAsQueryID;
   }
 
   @JsonProperty("streamsProperties")
@@ -64,19 +72,21 @@ public class Command {
     return
         o instanceof Command
         && Objects.equals(statement, ((Command)o).statement)
+        && Objects.equals(useOffsetAsQueryID, ((Command)o).useOffsetAsQueryID)
         && Objects.equals(overwriteProperties, ((Command)o).overwriteProperties)
         && Objects.equals(originalProperties, ((Command)o).originalProperties);
   }
 
   @Override
   public int hashCode() {
-    return Objects.hash(statement, overwriteProperties, originalProperties);
+    return Objects.hash(statement, useOffsetAsQueryID, overwriteProperties, originalProperties);
   }
 
   @Override
   public String toString() {
     return "Command{"
         + "statement='" + statement + '\''
+        + ",useOffsetAsQueryID=" + useOffsetAsQueryID
         + ", overwriteProperties=" + overwriteProperties
         + '}';
   }

--- a/ksql-rest-app/src/main/java/io/confluent/ksql/rest/server/computation/QueuedCommand.java
+++ b/ksql-rest-app/src/main/java/io/confluent/ksql/rest/server/computation/QueuedCommand.java
@@ -23,17 +23,28 @@ public class QueuedCommand {
   private final CommandId commandId;
   private final Command command;
   private final Optional<CommandStatusFuture> status;
+  private final Long offset;
 
   public QueuedCommand(final CommandId commandId,
                        final Command command,
-                       final Optional<CommandStatusFuture> status) {
+                       final Optional<CommandStatusFuture> status,
+                       final Long offset) {
     this.commandId = Objects.requireNonNull(commandId);
     this.command = Objects.requireNonNull(command);
     this.status = Objects.requireNonNull(status);
+    this.offset = Objects.requireNonNull(offset);
   }
 
   QueuedCommand(final CommandId commandId, final Command command) {
-    this(commandId, command, Optional.empty());
+    this(commandId, command, Optional.empty(), -1L);
+  }
+
+  public QueuedCommand(
+      final CommandId commandId,
+      final Command command,
+      final Optional<CommandStatusFuture> status
+  ) {
+    this(commandId, command, status, -1L);
   }
 
   public CommandId getCommandId() {
@@ -48,6 +59,10 @@ public class QueuedCommand {
     return command;
   }
 
+  public Long getOffset() {
+    return offset;
+  }
+
   @Override
   public boolean equals(final Object o) {
     if (this == o) {
@@ -59,11 +74,12 @@ public class QueuedCommand {
     final QueuedCommand that = (QueuedCommand) o;
     return Objects.equals(commandId, that.commandId)
         && Objects.equals(command, that.command)
-        && Objects.equals(status, that.status);
+        && Objects.equals(status, that.status)
+        && Objects.equals(offset, that.offset);
   }
 
   @Override
   public int hashCode() {
-    return Objects.hash(commandId, command, status);
+    return Objects.hash(commandId, command, status, offset);
   }
 }

--- a/ksql-rest-app/src/test/java/io/confluent/ksql/rest/server/computation/CommandStoreTest.java
+++ b/ksql-rest-app/src/test/java/io/confluent/ksql/rest/server/computation/CommandStoreTest.java
@@ -97,7 +97,7 @@ public class CommandStoreTest {
   private final CommandId commandId =
       new CommandId(CommandId.Type.STREAM, "foo", CommandId.Action.CREATE);
   private final Command command =
-      new Command(statementText, Collections.emptyMap(), Collections.emptyMap());
+      new Command(statementText, true, Collections.emptyMap(), Collections.emptyMap());
   private final RecordMetadata recordMetadata = new RecordMetadata(
       COMMAND_TOPIC_PARTITION, 0, 0, RecordBatch.NO_TIMESTAMP, 0L, 0, 0);
 
@@ -176,6 +176,7 @@ public class CommandStoreTest {
           assertThat(
               queuedCommand.getStatus().get().getStatus().getStatus(),
               equalTo(CommandStatus.Status.QUEUED));
+          assertThat(queuedCommand.getOffset(), equalTo(0L));
           return recordMetadata;
         }
     );

--- a/ksql-rest-app/src/test/java/io/confluent/ksql/rest/server/computation/RecoveryTest.java
+++ b/ksql-rest-app/src/test/java/io/confluent/ksql/rest/server/computation/RecoveryTest.java
@@ -118,6 +118,7 @@ public class RecoveryTest {
               commandId,
               new Command(
                   statement.getStatementText(),
+                  true,
                   Collections.emptyMap(),
                   statement.getConfig().getAllConfigPropsWithSecretsObfuscated()),
               Optional.empty()));
@@ -578,7 +579,7 @@ public class RecoveryTest {
     shouldRecover(ImmutableList.of(
         new QueuedCommand(
             new CommandId(Type.STREAM, "B", Action.DROP),
-            new Command("DROP STREAM B DELETE TOPIC;", ImmutableMap.of(), ImmutableMap.of()))
+            new Command("DROP STREAM B DELETE TOPIC;", true, ImmutableMap.of(), ImmutableMap.of()))
     ));
 
     assertThat(topicClient.listTopicNames(), hasItem("B"));
@@ -637,6 +638,7 @@ public class RecoveryTest {
                 new Command(
                     "CREATE STREAM A (COLUMN STRING) "
                         + "WITH (KAFKA_TOPIC='A', VALUE_FORMAT='JSON');",
+                    true,
                     Collections.emptyMap(),
                     null
                 )
@@ -645,6 +647,7 @@ public class RecoveryTest {
                 new CommandId(Type.STREAM, "A", Action.CREATE),
                 new Command(
                     "CREATE STREAM B AS SELECT * FROM A;",
+                    true,
                     Collections.emptyMap(),
                     null
                 )
@@ -659,7 +662,7 @@ public class RecoveryTest {
     commands.add(
         new QueuedCommand(
             new CommandId(Type.STREAM, "B", Action.DROP),
-            new Command("DROP STREAM B;", Collections.emptyMap(), null)
+            new Command("DROP STREAM B;", true, Collections.emptyMap(), null)
         )
     );
     final KsqlServer recovered = new KsqlServer(commands);

--- a/ksql-rest-app/src/test/java/io/confluent/ksql/rest/server/computation/StatementExecutorTest.java
+++ b/ksql-rest-app/src/test/java/io/confluent/ksql/rest/server/computation/StatementExecutorTest.java
@@ -188,6 +188,7 @@ public class StatementExecutorTest extends EasyMockSupport {
         exception);
     final Command command = new Command(
         statementText,
+        true,
         emptyMap(),
         emptyMap());
     final CommandId commandId =  new CommandId(
@@ -232,6 +233,7 @@ public class StatementExecutorTest extends EasyMockSupport {
 
     final Command csasCommand = new Command(
         statementText,
+        true,
         emptyMap(),
         originalConfig.getAllConfigPropsWithSecretsObfuscated());
     final CommandId csasCommandId =  new CommandId(
@@ -284,10 +286,11 @@ public class StatementExecutorTest extends EasyMockSupport {
   public void shouldCompleteFutureOnSuccess() {
     final Command command = new Command(
         "CREATE STREAM foo ("
-            + "biz bigint,"
-            + " baz varchar) "
-            + "WITH (kafka_topic = 'foo', "
-            + "value_format = 'json');",
+        + "biz bigint,"
+        + " baz varchar) "
+        + "WITH (kafka_topic = 'foo', "
+        + "value_format = 'json');",
+        true,
         emptyMap(),
         ksqlConfig.getAllConfigPropsWithSecretsObfuscated());
     final CommandId commandId =  new CommandId(CommandId.Type.STREAM,
@@ -313,10 +316,11 @@ public class StatementExecutorTest extends EasyMockSupport {
 
     final Command command = new Command(
         "CREATE STREAM foo ("
-            + "biz bigint,"
-            + " baz varchar) "
-            + "WITH (kafka_topic = 'foo', "
-            + "value_format = 'json');",
+        + "biz bigint,"
+        + " baz varchar) "
+        + "WITH (kafka_topic = 'foo', "
+        + "value_format = 'json');",
+        true,
         emptyMap(),
         ksqlConfig.getAllConfigPropsWithSecretsObfuscated());
     final CommandId commandId =  new CommandId(CommandId.Type.STREAM,
@@ -380,6 +384,7 @@ public class StatementExecutorTest extends EasyMockSupport {
     // Now drop should be successful
     final Command dropTableCommand2 = new Command(
         "drop table table1;",
+        true,
         emptyMap(),
         ksqlConfig.getAllConfigPropsWithSecretsObfuscated());
     final CommandId dropTableCommandId2 =
@@ -397,7 +402,9 @@ public class StatementExecutorTest extends EasyMockSupport {
 
     // DROP should succeed since no query is using the stream.
     final Command dropStreamCommand3 = new Command(
-        "drop stream pageview;", emptyMap(),
+        "drop stream pageview;",
+        true,
+        emptyMap(),
         ksqlConfig.getAllConfigPropsWithSecretsObfuscated());
     final CommandId dropStreamCommandId3 =
         new CommandId(CommandId.Type.STREAM, "_user1pv", CommandId.Action.DROP);
@@ -486,7 +493,7 @@ public class StatementExecutorTest extends EasyMockSupport {
     statementExecutorWithMocks.handleRestore(
         new QueuedCommand(
             new CommandId(Type.STREAM, name, Action.CREATE),
-            new Command("CSAS", emptyMap(), emptyMap())
+            new Command("CSAS", true, emptyMap(), emptyMap())
         )
     );
 
@@ -516,7 +523,7 @@ public class StatementExecutorTest extends EasyMockSupport {
     statementExecutorWithMocks.handleRestore(
         new QueuedCommand(
             new CommandId(Type.STREAM, "foo", Action.DROP),
-            new Command("DROP", emptyMap(), PRE_VERSION_5_NULL_ORIGINAL_PROPS)
+            new Command("DROP", true, emptyMap(), PRE_VERSION_5_NULL_ORIGINAL_PROPS)
         )
     );
 
@@ -549,7 +556,7 @@ public class StatementExecutorTest extends EasyMockSupport {
     statementExecutorWithMocks.handleRestore(
         new QueuedCommand(
             new CommandId(Type.STREAM, "foo", Action.DROP),
-            new Command(drop, emptyMap(), emptyMap())
+            new Command(drop, true, emptyMap(), emptyMap())
         )
     );
 
@@ -622,6 +629,7 @@ public class StatementExecutorTest extends EasyMockSupport {
             new CommandId(CommandId.Type.STREAM, "RunScript", CommandId.Action.EXECUTE),
             new Command(
                 runScriptStatement,
+                true,
                 Collections.singletonMap("ksql.run.script.statements", queryStatement),
                 emptyMap())
         )
@@ -644,9 +652,8 @@ public class StatementExecutorTest extends EasyMockSupport {
         new QueuedCommand(
             new CommandId(CommandId.Type.STREAM, "RunScript", CommandId.Action.EXECUTE),
             new Command(
-                runScriptStatement,
-                Collections.singletonMap("ksql.run.script.statements", queryStatement),
-                emptyMap())
+                runScriptStatement, true,
+                    Collections.singletonMap("ksql.run.script.statements", queryStatement), emptyMap())
         )
     );
 
@@ -661,9 +668,8 @@ public class StatementExecutorTest extends EasyMockSupport {
             + " pageid varchar, "
             + "userid varchar) "
             + "WITH (kafka_topic = 'pageview_topic_json', "
-            + "value_format = 'json');",
-        emptyMap(),
-        ksqlConfig.getAllConfigPropsWithSecretsObfuscated());
+            + "value_format = 'json');", true,
+            emptyMap(), ksqlConfig.getAllConfigPropsWithSecretsObfuscated());
     final CommandId csCommandId =  new CommandId(CommandId.Type.STREAM,
         "_CSASStreamGen",
         CommandId.Action.CREATE);
@@ -672,9 +678,8 @@ public class StatementExecutorTest extends EasyMockSupport {
     final Command csasCommand = new Command(
         "CREATE STREAM user1pv AS "
             + "select * from pageview"
-            + " WHERE userid = 'user1';",
-        emptyMap(),
-        ksqlConfig.getAllConfigPropsWithSecretsObfuscated());
+            + " WHERE userid = 'user1';", true,
+            emptyMap(), ksqlConfig.getAllConfigPropsWithSecretsObfuscated());
 
     final CommandId csasCommandId =  new CommandId(CommandId.Type.STREAM,
         "_CSASGen",
@@ -687,6 +692,7 @@ public class StatementExecutorTest extends EasyMockSupport {
             + "FROM pageview "
             + "WINDOW TUMBLING ( SIZE 10 SECONDS) "
             + "GROUP BY pageid;",
+        true,
         emptyMap(),
         ksqlConfig.getAllConfigPropsWithSecretsObfuscated());
 
@@ -703,6 +709,7 @@ public class StatementExecutorTest extends EasyMockSupport {
   private void tryDropThatViolatesReferentialIntegrity() {
     final Command dropStreamCommand1 = new Command(
         "drop stream pageview;",
+        true,
         emptyMap(),
         ksqlConfig.getAllConfigPropsWithSecretsObfuscated());
     final CommandId dropStreamCommandId1 =  new CommandId(CommandId.Type.STREAM,
@@ -742,6 +749,7 @@ public class StatementExecutorTest extends EasyMockSupport {
 
     final Command dropStreamCommand2 = new Command(
         "drop stream user1pv;",
+        true,
         emptyMap(),
         ksqlConfig.getAllConfigPropsWithSecretsObfuscated());
     final CommandId dropStreamCommandId2 =
@@ -778,6 +786,7 @@ public class StatementExecutorTest extends EasyMockSupport {
 
     final Command dropTableCommand1 = new Command(
         "drop table table1;",
+        true,
         emptyMap(),
         ksqlConfig.getAllConfigPropsWithSecretsObfuscated());
     final CommandId dropTableCommandId1 =
@@ -829,9 +838,8 @@ public class StatementExecutorTest extends EasyMockSupport {
 
   private void terminateQueries() {
     final Command terminateCommand1 = new Command(
-        "TERMINATE CSAS_USER1PV_0;",
-        emptyMap(),
-        ksqlConfig.getAllConfigPropsWithSecretsObfuscated());
+        "TERMINATE CSAS_USER1PV_0;", true,
+            emptyMap(), ksqlConfig.getAllConfigPropsWithSecretsObfuscated());
     final CommandId terminateCommandId1 =
         new CommandId(CommandId.Type.STREAM, "_TerminateGen", CommandId.Action.CREATE);
     handleStatement(
@@ -841,7 +849,8 @@ public class StatementExecutorTest extends EasyMockSupport {
 
     final Command terminateCommand2 = new Command(
         "TERMINATE CTAS_TABLE1_1;",
-        emptyMap(),
+        true,
+      emptyMap(),
         ksqlConfig.getAllConfigPropsWithSecretsObfuscated());
     final CommandId terminateCommandId2 =
         new CommandId(CommandId.Type.TABLE, "_TerminateGen", CommandId.Action.CREATE);
@@ -865,6 +874,6 @@ public class StatementExecutorTest extends EasyMockSupport {
 
   private static Command givenCommand(final String statementStr, final KsqlConfig ksqlConfig) {
     return new Command(
-        statementStr, emptyMap(), ksqlConfig.getAllConfigPropsWithSecretsObfuscated());
+        statementStr, true, emptyMap(), ksqlConfig.getAllConfigPropsWithSecretsObfuscated());
   }
 }

--- a/ksql-rest-app/src/test/java/io/confluent/ksql/rest/server/utils/TestUtils.java
+++ b/ksql-rest-app/src/test/java/io/confluent/ksql/rest/server/utils/TestUtils.java
@@ -31,14 +31,14 @@ public class TestUtils {
 
     final Command csCommand = new Command("CREATE STREAM pageview "
                                     + "(viewtime bigint, pageid varchar, userid varchar) "
-                                    + "WITH (kafka_topic='pageview_topic_json', value_format='json');",
-                                    Collections.emptyMap(), Collections.emptyMap());
+                                    + "WITH (kafka_topic='pageview_topic_json', value_format='json');", true,
+            Collections.emptyMap(), Collections.emptyMap());
     final CommandId csCommandId =  new CommandId(CommandId.Type.STREAM, "_CSASStreamGen", CommandId.Action.CREATE);
     priorCommands.add(new Pair<>(csCommandId, csCommand));
 
     final Command csasCommand = new Command("CREATE STREAM user1pv "
-                                      + " AS select * from pageview WHERE userid = 'user1';",
-                                      Collections.emptyMap(), Collections.emptyMap());
+                                      + " AS select * from pageview WHERE userid = 'user1';", true,
+            Collections.emptyMap(), Collections.emptyMap());
 
     final CommandId csasCommandId =  new CommandId(CommandId.Type.STREAM, "_CSASGen", CommandId.Action.CREATE);
     priorCommands.add(new Pair<>(csasCommandId, csasCommand));
@@ -47,8 +47,8 @@ public class TestUtils {
     final Command ctasCommand = new Command("CREATE TABLE user1pvtb "
                                       + " AS select * from pageview window tumbling(size 5 "
                                       + "second) WHERE userid = "
-                                      + "'user1' group by pageid;",
-                                      Collections.emptyMap(), Collections.emptyMap());
+                                      + "'user1' group by pageid;", true,
+            Collections.emptyMap(), Collections.emptyMap());
 
     final CommandId ctasCommandId =  new CommandId(CommandId.Type.TABLE, "_CTASGen", CommandId.Action.CREATE);
     priorCommands.add(new Pair<>(ctasCommandId, ctasCommand));


### PR DESCRIPTION
### Description 
Breaking down the PR at https://github.com/confluentinc/ksql/pull/3330 into smaller pieces, this one focuses on the simpler task of adding new offset values  and flags to the command objects. Validation will be done at a later date after more offline discussion. This PR is a precursor to updating the query id generating code for interactive mode.


The flag in Command is to indicate whether or not a command should use the old query id generation or use the new offset based query id. This is needed to ensure that if a server is relying on a command topic with old commands, the old commands will still follow the same pattern for query id generation and query ids are maintained if the server needs to restore.

The field in QueuedCommand represents the offset that the command was read from, it's assigned from the corresponding Kafka ConsumerRecord.offset()

### Testing done 
Local tests
Deserialization test for new Command 
Update existing unit tests
### Reviewer checklist
- [ ] Ensure docs are updated if necessary. (eg. if a user visible feature is being added or changed).
- [ ] Ensure relevant issues are linked (description should include text like "Fixes #<issue number>")

