### PR TITLE
Fix: NPE when coercing on INSERT + improve err msg + better coercion test coverage

### DIFF
--- a/ksql-common/src/main/java/io/confluent/ksql/schema/ksql/SqlBaseType.java
+++ b/ksql-common/src/main/java/io/confluent/ksql/schema/ksql/SqlBaseType.java
@@ -27,6 +27,6 @@ public enum SqlBaseType {
   }
 
   public boolean canUpCast(final SqlBaseType to) {
-    return isNumber() && this.ordinal() <= to.ordinal();
+    return isNumber() && to.isNumber() && this.ordinal() <= to.ordinal();
   }
 }

--- a/ksql-engine/src/main/java/io/confluent/ksql/engine/InsertValuesExecutor.java
+++ b/ksql-engine/src/main/java/io/confluent/ksql/engine/InsertValuesExecutor.java
@@ -193,15 +193,13 @@ public class InsertValuesExecutor {
 
       final String topicName = dataSource.getKafkaTopicName();
 
-      final ProducerRecord<byte[], byte[]> record = new ProducerRecord<>(
+      return new ProducerRecord<>(
           topicName,
           null,
           row.ts,
           key,
           value
-      );
-
-      return record;
+      );;
     } catch (Exception e) {
       throw new KsqlStatementException(
           createInsertFailedExceptionMessage(tableStreamName) + " " + e.getMessage(),
@@ -209,7 +207,7 @@ public class InsertValuesExecutor {
     }
   }
 
-  private String createInsertFailedExceptionMessage(final String streamTableName) {
+  private static String createInsertFailedExceptionMessage(final String streamTableName) {
     return "Failed to insert values into stream/table: " + streamTableName + ".";
   }
 

--- a/ksql-engine/src/main/java/io/confluent/ksql/engine/InsertValuesExecutor.java
+++ b/ksql-engine/src/main/java/io/confluent/ksql/engine/InsertValuesExecutor.java
@@ -143,8 +143,6 @@ public class InsertValuesExecutor {
     final ProducerRecord<byte[], byte[]> record =
         buildRecord(statement, executionContext, serviceContext);
 
-    final String tableStreamName = insertValues.getTarget().name();
-
     try {
       producer.sendRecord(record, serviceContext, config.getProducerClientConfigProps());
     } catch (final TopicAuthorizationException e) {
@@ -203,12 +201,13 @@ public class InsertValuesExecutor {
     } catch (Exception e) {
       throw new KsqlStatementException(
           createInsertFailedExceptionMessage(insertValues) + " " + e.getMessage(),
-          statement.getStatementText(), e);
+          statement.getStatementText(),
+          e);
     }
   }
 
   private static String createInsertFailedExceptionMessage(final InsertValues insertValues) {
-    return "Failed to insert values into stream/table: " + insertValues.getTarget().name() + ".";
+    return "Failed to insert values into '" + insertValues.getTarget().name() + "'.";
   }
 
   private void throwIfDisabled(final KsqlConfig config) {

--- a/ksql-engine/src/test/java/io/confluent/ksql/engine/InsertValuesExecutorTest.java
+++ b/ksql-engine/src/test/java/io/confluent/ksql/engine/InsertValuesExecutorTest.java
@@ -467,7 +467,7 @@ public class InsertValuesExecutorTest {
 
     // Expect:
     expectedException.expect(KsqlException.class);
-    expectedException.expectMessage("Failed to insert values into stream/table: ");
+    expectedException.expectMessage("Failed to insert values into ");
 
     // When:
     executor.execute(statement, engine, serviceContext);

--- a/ksql-functional-tests/src/test/java/io/confluent/ksql/test/tools/KsqlTestingToolTest.java
+++ b/ksql-functional-tests/src/test/java/io/confluent/ksql/test/tools/KsqlTestingToolTest.java
@@ -180,7 +180,7 @@ public class KsqlTestingToolTest {
   }
 
   @Test
-  public void shouldPropegateInsertValuesExecutorError() throws Exception {
+  public void shouldPropagateInsertValuesExecutorError() throws Exception {
     // When:
     KsqlTestingTool.runWithTripleFiles(
             "src/test/resources/test-runner/incorrect-test6/statements.sql",
@@ -189,8 +189,8 @@ public class KsqlTestingToolTest {
 
     // Then:
     assertThat(errContent.toString(UTF_8),
-            containsString("Test failed: Failed to insert values into stream/table: " +
-                "Expected type INTEGER for field ID but got DOUBLE(14.5)\n"));
+            containsString("Test failed: Failed to insert values into stream/table: TEST." +
+                " Expected type INTEGER for field ID but got DOUBLE(14.5)\n"));
   }
 
   private void runTestCaseAndAssertPassed(

--- a/ksql-functional-tests/src/test/java/io/confluent/ksql/test/tools/KsqlTestingToolTest.java
+++ b/ksql-functional-tests/src/test/java/io/confluent/ksql/test/tools/KsqlTestingToolTest.java
@@ -189,8 +189,7 @@ public class KsqlTestingToolTest {
 
     // Then:
     assertThat(errContent.toString(UTF_8),
-            containsString("Test failed: Failed to insert values into stream/table: TEST." +
-                " Expected type INTEGER for field ID but got DOUBLE(14.5)\n"));
+            containsString("Test failed: Failed to insert values into 'TEST'."));
   }
 
   private void runTestCaseAndAssertPassed(

--- a/ksql-functional-tests/src/test/java/io/confluent/ksql/test/tools/KsqlTestingToolTest.java
+++ b/ksql-functional-tests/src/test/java/io/confluent/ksql/test/tools/KsqlTestingToolTest.java
@@ -189,7 +189,8 @@ public class KsqlTestingToolTest {
 
     // Then:
     assertThat(errContent.toString(UTF_8),
-            containsString("Test failed: Failed to insert values into stream/table: TEST\n"));
+            containsString("Test failed: Failed to insert values into stream/table: " +
+                "Expected type INTEGER for field ID but got DOUBLE(14.5)\n"));
   }
 
   private void runTestCaseAndAssertPassed(

--- a/ksql-parser/src/test/java/io/confluent/ksql/schema/ksql/DefaultSqlValueCoercerTest.java
+++ b/ksql-parser/src/test/java/io/confluent/ksql/schema/ksql/DefaultSqlValueCoercerTest.java
@@ -141,6 +141,15 @@ public class DefaultSqlValueCoercerTest {
   }
 
   @Test
+  public void shouldNotCoerceIntegerIntoString() {
+    // Given:
+    final int val = 23;
+
+    // Expect:
+    assertThat(coercer.coerce(val, SqlTypes.STRING), is(Optional.empty()));
+  }
+
+  @Test
   public void shouldThrowIfInvalidCoercionString() {
     // Given:
     final String val = "hello";

--- a/ksql-parser/src/test/java/io/confluent/ksql/schema/ksql/DefaultSqlValueCoercerTest.java
+++ b/ksql-parser/src/test/java/io/confluent/ksql/schema/ksql/DefaultSqlValueCoercerTest.java
@@ -146,7 +146,8 @@ public class DefaultSqlValueCoercerTest {
 
   @Test
   public void shouldNotCoerceToDecimal() {
-    assertThat(coercer.coerce(true, SqlTypes.STRING), is(Optional.empty()));
+    assertThat(coercer.coerce(true, SqlTypes.decimal(2, 1)),
+        is(Optional.empty()));
   }
 
   @Test


### PR DESCRIPTION
### Description 

Fixes https://github.com/confluentinc/ksql/issues/3348

* Fixes NPE when trying to INSERT integer into String field
* Improves error message when such an insert fails. New error message is:

```
ksql> CREATE STREAM S2 (ID string) WITH (kafka_topic='test_topic', value_format='JSON');

 Message
----------------
 Stream created
----------------
ksql> insert into s2(id) values (1);
Failed to insert values into stream/table: S2. Expected type STRING for field ID but got INTEGER(1)
ksql>
```
* Simplified / refactored DefaultSqlValueCoercerTest and make sure all combinations are covered

### Testing done 

Improved and completed DefaultSqlValueCoercerTest

### Reviewer checklist
- [ ] Ensure docs are updated if necessary. (eg. if a user visible feature is being added or changed).
- [ ] Ensure relevant issues are linked (description should include text like "Fixes #<issue number>")

