### PR TITLE
feat: move groupBy into plan builders

### DIFF
--- a/ksql-engine/src/main/java/io/confluent/ksql/planner/plan/AggregateNode.java
+++ b/ksql-engine/src/main/java/io/confluent/ksql/planner/plan/AggregateNode.java
@@ -221,12 +221,6 @@ public class AggregateNode extends PlanNode {
         .getKsqlTopic()
         .getValueFormat();
 
-    final Serde<GenericRow> genericRowSerde = builder.buildValueSerde(
-        valueFormat.getFormatInfo(),
-        PhysicalSchema.from(prepareSchema, SerdeOption.none()),
-        groupByContext.getQueryContext()
-    );
-
     final List<Expression> internalGroupByColumns = internalSchema.resolveGroupByExpressions(
         getGroupByExpressions(),
         aggregateArgExpanded,
@@ -235,9 +229,9 @@ public class AggregateNode extends PlanNode {
 
     final SchemaKGroupedStream schemaKGroupedStream = aggregateArgExpanded.groupBy(
         valueFormat,
-        genericRowSerde,
         internalGroupByColumns,
-        groupByContext
+        groupByContext,
+        builder
     );
 
     // Aggregate computations

--- a/ksql-engine/src/main/java/io/confluent/ksql/streams/StreamsFactories.java
+++ b/ksql-engine/src/main/java/io/confluent/ksql/streams/StreamsFactories.java
@@ -15,6 +15,7 @@
 
 package io.confluent.ksql.streams;
 
+import io.confluent.ksql.execution.streams.GroupedFactory;
 import io.confluent.ksql.execution.streams.MaterializedFactory;
 import io.confluent.ksql.util.KsqlConfig;
 import java.util.Objects;

--- a/ksql-engine/src/test/java/io/confluent/ksql/planner/plan/AggregateNodeTest.java
+++ b/ksql-engine/src/test/java/io/confluent/ksql/planner/plan/AggregateNodeTest.java
@@ -52,6 +52,7 @@ import io.confluent.ksql.query.QueryId;
 import io.confluent.ksql.schema.ksql.Column;
 import io.confluent.ksql.schema.ksql.PersistenceSchema;
 import io.confluent.ksql.schema.ksql.types.SqlTypes;
+import io.confluent.ksql.serde.FormatInfo;
 import io.confluent.ksql.serde.KeySerde;
 import io.confluent.ksql.serde.WindowInfo;
 import io.confluent.ksql.structured.SchemaKStream;

--- a/ksql-engine/src/test/java/io/confluent/ksql/planner/plan/KsqlBareOutputNodeTest.java
+++ b/ksql-engine/src/test/java/io/confluent/ksql/planner/plan/KsqlBareOutputNodeTest.java
@@ -35,6 +35,7 @@ import io.confluent.ksql.query.QueryId;
 import io.confluent.ksql.schema.ksql.Column;
 import io.confluent.ksql.schema.ksql.LogicalSchema;
 import io.confluent.ksql.schema.ksql.types.SqlTypes;
+import io.confluent.ksql.serde.FormatInfo;
 import io.confluent.ksql.serde.KeySerde;
 import io.confluent.ksql.structured.SchemaKStream;
 import io.confluent.ksql.testutils.AnalysisTestUtil;

--- a/ksql-engine/src/test/java/io/confluent/ksql/streams/GroupedFactoryTest.java
+++ b/ksql-engine/src/test/java/io/confluent/ksql/streams/GroupedFactoryTest.java
@@ -22,6 +22,7 @@ import static org.mockito.Mockito.when;
 
 import com.google.common.collect.ImmutableMap;
 import io.confluent.ksql.GenericRow;
+import io.confluent.ksql.execution.streams.GroupedFactory;
 import io.confluent.ksql.util.KsqlConfig;
 import org.apache.kafka.common.serialization.Serde;
 import org.apache.kafka.streams.StreamsConfig;

--- a/ksql-execution/src/main/java/io/confluent/ksql/execution/plan/ExecutionStep.java
+++ b/ksql-execution/src/main/java/io/confluent/ksql/execution/plan/ExecutionStep.java
@@ -15,6 +15,7 @@
 package io.confluent.ksql.execution.plan;
 
 import io.confluent.ksql.execution.builder.KsqlQueryBuilder;
+import io.confluent.ksql.schema.ksql.LogicalSchema;
 import java.util.List;
 
 public interface ExecutionStep<S> {
@@ -23,4 +24,8 @@ public interface ExecutionStep<S> {
   List<ExecutionStep<?>> getSources();
 
   S build(KsqlQueryBuilder queryBuilder);
+
+  default LogicalSchema getSchema() {
+    return getProperties().getSchema();
+  }
 }

--- a/ksql-execution/src/main/java/io/confluent/ksql/execution/plan/StreamGroupBy.java
+++ b/ksql-execution/src/main/java/io/confluent/ksql/execution/plan/StreamGroupBy.java
@@ -78,7 +78,7 @@ public class StreamGroupBy<K> implements ExecutionStep<KGroupedStream<Struct, Ge
     if (o == null || getClass() != o.getClass()) {
       return false;
     }
-    final StreamGroupBy that = (StreamGroupBy) o;
+    final StreamGroupBy<?> that = (StreamGroupBy<?>) o;
     return Objects.equals(properties, that.properties)
         && Objects.equals(source, that.source)
         && Objects.equals(formats, that.formats)
@@ -87,7 +87,6 @@ public class StreamGroupBy<K> implements ExecutionStep<KGroupedStream<Struct, Ge
 
   @Override
   public int hashCode() {
-
     return Objects.hash(properties, source, formats, groupByExpressions);
   }
 }

--- a/ksql-execution/src/main/java/io/confluent/ksql/execution/plan/StreamGroupBy.java
+++ b/ksql-execution/src/main/java/io/confluent/ksql/execution/plan/StreamGroupBy.java
@@ -15,22 +15,26 @@
 package io.confluent.ksql.execution.plan;
 
 import com.google.errorprone.annotations.Immutable;
+import io.confluent.ksql.GenericRow;
 import io.confluent.ksql.execution.builder.KsqlQueryBuilder;
 import io.confluent.ksql.execution.expression.tree.Expression;
 import java.util.Collections;
 import java.util.List;
 import java.util.Objects;
+import org.apache.kafka.connect.data.Struct;
+import org.apache.kafka.streams.kstream.KGroupedStream;
+import org.apache.kafka.streams.kstream.KStream;
 
 @Immutable
-public class StreamGroupBy<S, G> implements ExecutionStep<G> {
+public class StreamGroupBy<K> implements ExecutionStep<KGroupedStream<Struct, GenericRow>> {
   private final ExecutionStepProperties properties;
-  private final ExecutionStep<S> source;
+  private final ExecutionStep<KStream<K, GenericRow>> source;
   private final Formats formats;
   private final List<Expression> groupByExpressions;
 
   public StreamGroupBy(
       final ExecutionStepProperties properties,
-      final ExecutionStep<S> source,
+      final ExecutionStep<KStream<K, GenericRow>> source,
       final Formats formats,
       final List<Expression> groupByExpressions) {
     this.properties = Objects.requireNonNull(properties, "properties");
@@ -53,8 +57,16 @@ public class StreamGroupBy<S, G> implements ExecutionStep<G> {
     return Collections.singletonList(source);
   }
 
+  public Formats getFormats() {
+    return formats;
+  }
+
+  public ExecutionStep<KStream<K, GenericRow>> getSource() {
+    return source;
+  }
+
   @Override
-  public G build(final KsqlQueryBuilder streamsBuilder) {
+  public KGroupedStream<Struct, GenericRow> build(final KsqlQueryBuilder streamsBuilder) {
     throw new UnsupportedOperationException();
   }
 
@@ -66,7 +78,7 @@ public class StreamGroupBy<S, G> implements ExecutionStep<G> {
     if (o == null || getClass() != o.getClass()) {
       return false;
     }
-    final StreamGroupBy<?, ?> that = (StreamGroupBy<?, ?>) o;
+    final StreamGroupBy that = (StreamGroupBy) o;
     return Objects.equals(properties, that.properties)
         && Objects.equals(source, that.source)
         && Objects.equals(formats, that.formats)

--- a/ksql-execution/src/main/java/io/confluent/ksql/execution/plan/StreamGroupByKey.java
+++ b/ksql-execution/src/main/java/io/confluent/ksql/execution/plan/StreamGroupByKey.java
@@ -17,31 +17,26 @@ package io.confluent.ksql.execution.plan;
 import com.google.errorprone.annotations.Immutable;
 import io.confluent.ksql.GenericRow;
 import io.confluent.ksql.execution.builder.KsqlQueryBuilder;
-import io.confluent.ksql.execution.expression.tree.Expression;
 import java.util.Collections;
 import java.util.List;
 import java.util.Objects;
 import org.apache.kafka.connect.data.Struct;
-import org.apache.kafka.streams.kstream.KGroupedTable;
-import org.apache.kafka.streams.kstream.KTable;
+import org.apache.kafka.streams.kstream.KGroupedStream;
+import org.apache.kafka.streams.kstream.KStream;
 
 @Immutable
-public class TableGroupBy<K> implements ExecutionStep<KGroupedTable<Struct, GenericRow>> {
+public class StreamGroupByKey implements ExecutionStep<KGroupedStream<Struct, GenericRow>> {
   private final ExecutionStepProperties properties;
-  private final ExecutionStep<KTable<K, GenericRow>> source;
+  private final ExecutionStep<KStream<Struct, GenericRow>> source;
   private final Formats formats;
-  private final List<Expression> groupByExpressions;
 
-  public TableGroupBy(
+  public StreamGroupByKey(
       final ExecutionStepProperties properties,
-      final ExecutionStep<KTable<K, GenericRow>> source,
-      final Formats formats,
-      final List<Expression> groupByExpressions
-  ) {
+      final ExecutionStep<KStream<Struct, GenericRow>> source,
+      final Formats formats) {
     this.properties = Objects.requireNonNull(properties, "properties");
-    this.source = Objects.requireNonNull(source, "source");
     this.formats = Objects.requireNonNull(formats, "formats");
-    this.groupByExpressions = Objects.requireNonNull(groupByExpressions, "groupByExpressions");
+    this.source = Objects.requireNonNull(source, "source");
   }
 
   @Override
@@ -54,20 +49,16 @@ public class TableGroupBy<K> implements ExecutionStep<KGroupedTable<Struct, Gene
     return Collections.singletonList(source);
   }
 
+  public ExecutionStep<KStream<Struct, GenericRow>> getSource() {
+    return source;
+  }
+
   public Formats getFormats() {
     return formats;
   }
 
-  public List<Expression> getGroupByExpressions() {
-    return groupByExpressions;
-  }
-
-  public ExecutionStep<KTable<K, GenericRow>> getSource() {
-    return source;
-  }
-
   @Override
-  public KGroupedTable<Struct, GenericRow> build(final KsqlQueryBuilder builder) {
+  public KGroupedStream<Struct, GenericRow> build(final KsqlQueryBuilder streamsBuilder) {
     throw new UnsupportedOperationException();
   }
 
@@ -79,16 +70,15 @@ public class TableGroupBy<K> implements ExecutionStep<KGroupedTable<Struct, Gene
     if (o == null || getClass() != o.getClass()) {
       return false;
     }
-    final TableGroupBy<?> that = (TableGroupBy<?>) o;
+    final StreamGroupByKey that = (StreamGroupByKey) o;
     return Objects.equals(properties, that.properties)
         && Objects.equals(source, that.source)
-        && Objects.equals(formats, that.formats)
-        && Objects.equals(groupByExpressions, that.groupByExpressions);
+        && Objects.equals(formats, that.formats);
   }
 
   @Override
   public int hashCode() {
 
-    return Objects.hash(properties, source, formats, groupByExpressions);
+    return Objects.hash(properties, source, formats);
   }
 }

--- a/ksql-streams/src/main/java/io/confluent/ksql/execution/streams/ExecutionStepFactory.java
+++ b/ksql-streams/src/main/java/io/confluent/ksql/execution/streams/ExecutionStepFactory.java
@@ -28,6 +28,7 @@ import io.confluent.ksql.execution.plan.SelectExpression;
 import io.confluent.ksql.execution.plan.StreamAggregate;
 import io.confluent.ksql.execution.plan.StreamFilter;
 import io.confluent.ksql.execution.plan.StreamGroupBy;
+import io.confluent.ksql.execution.plan.StreamGroupByKey;
 import io.confluent.ksql.execution.plan.StreamMapValues;
 import io.confluent.ksql.execution.plan.StreamSelectKey;
 import io.confluent.ksql.execution.plan.StreamSink;
@@ -320,12 +321,11 @@ public final class ExecutionStepFactory {
     );
   }
 
-  public static <K> StreamGroupBy<KStream<K, GenericRow>, KGroupedStream<Struct, GenericRow>>
-      streamGroupBy(
-          final QueryContext.Stacker stacker,
-          final ExecutionStep<KStream<K, GenericRow>> sourceStep,
-          final Formats format,
-          final List<Expression> groupingExpressions
+  public static <K> StreamGroupBy<K> streamGroupBy(
+      final QueryContext.Stacker stacker,
+      final ExecutionStep<KStream<K, GenericRow>> sourceStep,
+      final Formats format,
+      final List<Expression> groupingExpressions
   ) {
     final QueryContext queryContext = stacker.getQueryContext();
     return new StreamGroupBy<>(
@@ -333,6 +333,19 @@ public final class ExecutionStepFactory {
         sourceStep,
         format,
         groupingExpressions
+    );
+  }
+
+  public static StreamGroupByKey streamGroupByKey(
+      final QueryContext.Stacker stacker,
+      final ExecutionStep<KStream<Struct, GenericRow>> sourceStep,
+      final Formats formats
+  ) {
+    final QueryContext queryContext = stacker.getQueryContext();
+    return new StreamGroupByKey(
+        sourceStep.getProperties().withQueryContext(queryContext),
+        sourceStep,
+        formats
     );
   }
 
@@ -355,12 +368,11 @@ public final class ExecutionStepFactory {
     );
   }
 
-  public static <K> TableGroupBy<KTable<K, GenericRow>, KGroupedTable<Struct, GenericRow>>
-      tableGroupBy(
-          final QueryContext.Stacker stacker,
-          final ExecutionStep<KTable<K, GenericRow>> sourceStep,
-          final Formats format,
-          final List<Expression> groupingExpressions
+  public static <K> TableGroupBy<K> tableGroupBy(
+      final QueryContext.Stacker stacker,
+      final ExecutionStep<KTable<K, GenericRow>> sourceStep,
+      final Formats format,
+      final List<Expression> groupingExpressions
   ) {
     final QueryContext queryContext = stacker.getQueryContext();
     return new TableGroupBy<>(

--- a/ksql-streams/src/main/java/io/confluent/ksql/execution/streams/GroupByMapper.java
+++ b/ksql-streams/src/main/java/io/confluent/ksql/execution/streams/GroupByMapper.java
@@ -13,12 +13,11 @@
  * specific language governing permissions and limitations under the License.
  */
 
-package io.confluent.ksql.structured;
+package io.confluent.ksql.execution.streams;
 
 import com.google.common.collect.ImmutableList;
 import io.confluent.ksql.GenericRow;
 import io.confluent.ksql.execution.codegen.ExpressionMetadata;
-import io.confluent.ksql.execution.expression.tree.Expression;
 import io.confluent.ksql.execution.util.StructKeyUtil;
 import java.util.List;
 import java.util.Objects;
@@ -29,11 +28,11 @@ import org.apache.kafka.streams.kstream.KeyValueMapper;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-class GroupByMapper implements KeyValueMapper<Object, GenericRow, Struct> {
+class GroupByMapper<K> implements KeyValueMapper<K, GenericRow, Struct> {
 
   private static final Logger LOG = LoggerFactory.getLogger(GroupByMapper.class);
 
-  private static final String GROUP_BY_COLUMN_SEPARATOR = "|+|";
+  private static final String GROUP_BY_VALUE_SEPARATOR = "|+|";
 
   private final List<ExpressionMetadata> expressions;
 
@@ -45,18 +44,12 @@ class GroupByMapper implements KeyValueMapper<Object, GenericRow, Struct> {
   }
 
   @Override
-  public Struct apply(final Object key, final GenericRow row) {
+  public Struct apply(final K key, final GenericRow row) {
     final String stringRowKey = IntStream.range(0, expressions.size())
         .mapToObj(idx -> processColumn(idx, expressions.get(idx), row))
-        .collect(Collectors.joining(GROUP_BY_COLUMN_SEPARATOR));
+        .collect(Collectors.joining(GROUP_BY_VALUE_SEPARATOR));
 
     return StructKeyUtil.asStructKey(stringRowKey);
-  }
-
-  static String keyNameFor(final List<Expression> groupByExpressions) {
-    return groupByExpressions.stream()
-        .map(Expression::toString)
-        .collect(Collectors.joining(GROUP_BY_COLUMN_SEPARATOR));
   }
 
   private static String processColumn(
@@ -70,5 +63,9 @@ class GroupByMapper implements KeyValueMapper<Object, GenericRow, Struct> {
       LOG.error("Error calculating group-by field with index {}", index, e);
       return "null";
     }
+  }
+
+  List<ExpressionMetadata> getExpressionMetadata() {
+    return expressions;
   }
 }

--- a/ksql-streams/src/main/java/io/confluent/ksql/execution/streams/GroupedFactory.java
+++ b/ksql-streams/src/main/java/io/confluent/ksql/execution/streams/GroupedFactory.java
@@ -13,9 +13,8 @@
  * specific language governing permissions and limitations under the License.
  */
 
-package io.confluent.ksql.streams;
+package io.confluent.ksql.execution.streams;
 
-import io.confluent.ksql.execution.streams.StreamsUtil;
 import io.confluent.ksql.util.KsqlConfig;
 import org.apache.kafka.common.serialization.Serde;
 import org.apache.kafka.streams.kstream.Grouped;

--- a/ksql-streams/src/main/java/io/confluent/ksql/execution/streams/StreamGroupByBuilder.java
+++ b/ksql-streams/src/main/java/io/confluent/ksql/execution/streams/StreamGroupByBuilder.java
@@ -1,0 +1,109 @@
+/*
+ * Copyright 2019 Confluent Inc.
+ *
+ * Licensed under the Confluent Community License (the "License"); you may not use
+ * this file except in compliance with the License.  You may obtain a copy of the
+ * License at
+ *
+ * http://www.confluent.io/confluent-community-license
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package io.confluent.ksql.execution.streams;
+
+import io.confluent.ksql.GenericRow;
+import io.confluent.ksql.execution.builder.KsqlQueryBuilder;
+import io.confluent.ksql.execution.codegen.CodeGenRunner;
+import io.confluent.ksql.execution.codegen.ExpressionMetadata;
+import io.confluent.ksql.execution.context.QueryContext;
+import io.confluent.ksql.execution.plan.Formats;
+import io.confluent.ksql.execution.plan.StreamGroupBy;
+import io.confluent.ksql.execution.plan.StreamGroupByKey;
+import io.confluent.ksql.schema.ksql.LogicalSchema;
+import io.confluent.ksql.schema.ksql.PhysicalSchema;
+import io.confluent.ksql.serde.KeySerde;
+import java.util.List;
+import org.apache.kafka.common.serialization.Serde;
+import org.apache.kafka.connect.data.Struct;
+import org.apache.kafka.streams.kstream.Grouped;
+import org.apache.kafka.streams.kstream.KGroupedStream;
+import org.apache.kafka.streams.kstream.KStream;
+
+public final class StreamGroupByBuilder {
+  private StreamGroupByBuilder() {
+  }
+
+  public static KGroupedStream<Struct, GenericRow> build(
+      final KStream<Struct, GenericRow> kstream,
+      final StreamGroupByKey step,
+      final KsqlQueryBuilder queryBuilder,
+      final GroupedFactory groupedFactory
+  ) {
+    final LogicalSchema sourceSchema = step.getSource().getSchema();
+    final QueryContext queryContext =  step.getProperties().getQueryContext();
+    final Formats formats = step.getFormats();
+    final Grouped<Struct, GenericRow> grouped = buildGrouped(
+        formats,
+        sourceSchema,
+        queryContext,
+        queryBuilder,
+        groupedFactory
+    );
+    return kstream.groupByKey(grouped);
+  }
+
+  public static <K> KGroupedStream<Struct, GenericRow> build(
+      final KStream<K, GenericRow> kstream,
+      final StreamGroupBy<K> step,
+      final KsqlQueryBuilder queryBuilder,
+      final GroupedFactory groupedFactory
+  ) {
+    final LogicalSchema sourceSchema = step.getSource().getSchema();
+    final QueryContext queryContext =  step.getProperties().getQueryContext();
+    final Formats formats = step.getFormats();
+    final Grouped<Struct, GenericRow> grouped = buildGrouped(
+        formats,
+        sourceSchema,
+        queryContext,
+        queryBuilder,
+        groupedFactory
+    );
+    final List<ExpressionMetadata> groupBy = CodeGenRunner.compileExpressions(
+        step.getGroupByExpressions().stream(),
+        "Group By",
+        sourceSchema,
+        queryBuilder.getKsqlConfig(),
+        queryBuilder.getFunctionRegistry()
+    );
+    final GroupByMapper<K> mapper = new GroupByMapper<>(groupBy);
+    return kstream.filter((key, value) -> value != null).groupBy(mapper, grouped);
+  }
+
+  private static Grouped<Struct, GenericRow> buildGrouped(
+      final Formats formats,
+      final LogicalSchema schema,
+      final QueryContext queryContext,
+      final KsqlQueryBuilder queryBuilder,
+      final GroupedFactory groupedFactory
+  ) {
+    final PhysicalSchema physicalSchema = PhysicalSchema.from(
+        schema,
+        formats.getOptions()
+    );
+    final KeySerde<Struct> keySerde = queryBuilder.buildKeySerde(
+        formats.getKeyFormat().getFormatInfo(),
+        physicalSchema,
+        queryContext
+    );
+    final Serde<GenericRow> valSerde = queryBuilder.buildValueSerde(
+        formats.getValueFormat().getFormatInfo(),
+        physicalSchema,
+        queryContext
+    );
+    return groupedFactory.create(StreamsUtil.buildOpName(queryContext), keySerde, valSerde);
+  }
+}

--- a/ksql-streams/src/main/java/io/confluent/ksql/execution/streams/TableGroupByBuilder.java
+++ b/ksql-streams/src/main/java/io/confluent/ksql/execution/streams/TableGroupByBuilder.java
@@ -1,0 +1,100 @@
+/*
+ * Copyright 2019 Confluent Inc.
+ *
+ * Licensed under the Confluent Community License (the "License"); you may not use
+ * this file except in compliance with the License.  You may obtain a copy of the
+ * License at
+ *
+ * http://www.confluent.io/confluent-community-license
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package io.confluent.ksql.execution.streams;
+
+import io.confluent.ksql.GenericRow;
+import io.confluent.ksql.execution.builder.KsqlQueryBuilder;
+import io.confluent.ksql.execution.codegen.CodeGenRunner;
+import io.confluent.ksql.execution.codegen.ExpressionMetadata;
+import io.confluent.ksql.execution.context.QueryContext;
+import io.confluent.ksql.execution.plan.Formats;
+import io.confluent.ksql.execution.plan.TableGroupBy;
+import io.confluent.ksql.schema.ksql.LogicalSchema;
+import io.confluent.ksql.schema.ksql.PhysicalSchema;
+import io.confluent.ksql.serde.KeySerde;
+import java.util.List;
+import java.util.Objects;
+import org.apache.kafka.common.serialization.Serde;
+import org.apache.kafka.connect.data.Struct;
+import org.apache.kafka.streams.KeyValue;
+import org.apache.kafka.streams.kstream.Grouped;
+import org.apache.kafka.streams.kstream.KGroupedTable;
+import org.apache.kafka.streams.kstream.KTable;
+import org.apache.kafka.streams.kstream.KeyValueMapper;
+
+public final class TableGroupByBuilder {
+  private TableGroupByBuilder() {
+  }
+
+  public static <K> KGroupedTable<Struct, GenericRow> build(
+      final KTable<K, GenericRow> ktable,
+      final TableGroupBy<K> step,
+      final KsqlQueryBuilder queryBuilder,
+      final GroupedFactory groupedFactory
+  ) {
+    final LogicalSchema sourceSchema = step.getSource().getSchema();
+    final QueryContext queryContext =  step.getProperties().getQueryContext();
+    final Formats formats = step.getFormats();
+    final PhysicalSchema physicalSchema = PhysicalSchema.from(
+        sourceSchema,
+        formats.getOptions()
+    );
+    final KeySerde<Struct> keySerde = queryBuilder.buildKeySerde(
+        formats.getKeyFormat().getFormatInfo(),
+        physicalSchema,
+        queryContext
+    );
+    final Serde<GenericRow> valSerde = queryBuilder.buildValueSerde(
+        formats.getValueFormat().getFormatInfo(),
+        physicalSchema,
+        queryContext
+    );
+    final Grouped<Struct, GenericRow> grouped = groupedFactory.create(
+        StreamsUtil.buildOpName(queryContext),
+        keySerde,
+        valSerde
+    );
+    final List<ExpressionMetadata> groupBy = CodeGenRunner.compileExpressions(
+        step.getGroupByExpressions().stream(),
+        "Group By",
+        sourceSchema,
+        queryBuilder.getKsqlConfig(),
+        queryBuilder.getFunctionRegistry()
+    );
+    final GroupByMapper<K> mapper = new GroupByMapper<>(groupBy);
+    return ktable
+        .filter((key, value) -> value != null)
+        .groupBy(new TableKeyValueMapper<>(mapper), grouped);
+  }
+
+  public static final class TableKeyValueMapper<K>
+      implements KeyValueMapper<K, GenericRow, KeyValue<Struct, GenericRow>> {
+    private final GroupByMapper<K> groupByMapper;
+
+    private TableKeyValueMapper(final GroupByMapper<K> groupByMapper) {
+      this.groupByMapper = Objects.requireNonNull(groupByMapper, "groupByMapper");
+    }
+
+    @Override
+    public KeyValue<Struct, GenericRow> apply(final K key, final GenericRow value) {
+      return new KeyValue<>(groupByMapper.apply(key, value), value);
+    }
+
+    GroupByMapper<K> getGroupByMapper() {
+      return groupByMapper;
+    }
+  }
+}

--- a/ksql-streams/src/test/java/io/confluent/ksql/execution/streams/GroupByMapperTest.java
+++ b/ksql-streams/src/test/java/io/confluent/ksql/execution/streams/GroupByMapperTest.java
@@ -13,7 +13,7 @@
  * specific language governing permissions and limitations under the License.
  */
 
-package io.confluent.ksql.structured;
+package io.confluent.ksql.execution.streams;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
@@ -47,21 +47,21 @@ public class GroupByMapperTest {
   @Mock(MockType.NICE)
   private GenericRow row;
 
-  private GroupByMapper mapper;
+  private GroupByMapper<Struct> mapper;
 
   @Before
   public void setUp() {
-    mapper = new GroupByMapper(ImmutableList.of(groupBy0, groupBy1));
+    mapper = new GroupByMapper<>(ImmutableList.of(groupBy0, groupBy1));
   }
 
   @Test(expected = NullPointerException.class)
   public void shouldThrowOnNullParam() {
-    new GroupByMapper(null);
+    new GroupByMapper<Struct>(null);
   }
 
   @Test(expected = IllegalArgumentException.class)
   public void shouldThrowOnEmptyParam() {
-    new GroupByMapper(Collections.emptyList());
+    new GroupByMapper<Struct>(Collections.emptyList());
   }
 
   @Test
@@ -72,7 +72,7 @@ public class GroupByMapperTest {
     EasyMock.replay(groupBy0, groupBy1);
 
     // When:
-    final Struct result = mapper.apply("key", row);
+    final Struct result = mapper.apply(StructKeyUtil.asStructKey("key"), row);
 
     // Then:
     assertThat(result, is(StructKeyUtil.asStructKey("result0|+|result1")));
@@ -86,7 +86,7 @@ public class GroupByMapperTest {
     EasyMock.replay(groupBy0, groupBy1);
 
     // When:
-    final Struct result = mapper.apply("key", row);
+    final Struct result = mapper.apply(StructKeyUtil.asStructKey("key"), row);
 
     // Then:
     assertThat(result, is(StructKeyUtil.asStructKey("null|+|result1")));
@@ -100,22 +100,9 @@ public class GroupByMapperTest {
     EasyMock.replay(groupBy0, groupBy1);
 
     // When:
-    final Struct result = mapper.apply("key", row);
+    final Struct result = mapper.apply(StructKeyUtil.asStructKey("key"), row);
 
     // Then:
     assertThat(result, is(StructKeyUtil.asStructKey("null|+|result1")));
-  }
-
-  @Test
-  public void shouldGetKeyName() {
-    // Given:
-    final Expression exp0 = new QualifiedNameReference(QualifiedName.of("Fred", "f1"));
-    final Expression exp1 = new QualifiedNameReference(QualifiedName.of("Bob", "b1"));
-
-    // When:
-    final String result = GroupByMapper.keyNameFor(ImmutableList.of(exp0, exp1));
-
-    // Then:
-    assertThat(result, is("Fred.f1|+|Bob.b1"));
   }
 }

--- a/ksql-streams/src/test/java/io/confluent/ksql/execution/streams/StreamGroupByBuilderTest.java
+++ b/ksql-streams/src/test/java/io/confluent/ksql/execution/streams/StreamGroupByBuilderTest.java
@@ -1,0 +1,261 @@
+package io.confluent.ksql.execution.streams;
+
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.hasSize;
+import static org.hamcrest.Matchers.is;
+import static org.junit.Assert.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.same;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoMoreInteractions;
+import static org.mockito.Mockito.when;
+
+import com.google.common.collect.ImmutableList;
+import io.confluent.ksql.GenericRow;
+import io.confluent.ksql.execution.builder.KsqlQueryBuilder;
+import io.confluent.ksql.execution.context.QueryContext;
+import io.confluent.ksql.execution.expression.tree.Expression;
+import io.confluent.ksql.execution.expression.tree.QualifiedName;
+import io.confluent.ksql.execution.expression.tree.QualifiedNameReference;
+import io.confluent.ksql.execution.plan.DefaultExecutionStepProperties;
+import io.confluent.ksql.execution.plan.ExecutionStep;
+import io.confluent.ksql.execution.plan.ExecutionStepProperties;
+import io.confluent.ksql.execution.plan.Formats;
+import io.confluent.ksql.execution.plan.StreamGroupBy;
+import io.confluent.ksql.execution.plan.StreamGroupByKey;
+import io.confluent.ksql.execution.util.StructKeyUtil;
+import io.confluent.ksql.function.FunctionRegistry;
+import io.confluent.ksql.query.QueryId;
+import io.confluent.ksql.schema.ksql.LogicalSchema;
+import io.confluent.ksql.schema.ksql.PhysicalSchema;
+import io.confluent.ksql.schema.ksql.types.SqlTypes;
+import io.confluent.ksql.serde.Format;
+import io.confluent.ksql.serde.FormatInfo;
+import io.confluent.ksql.serde.KeyFormat;
+import io.confluent.ksql.serde.KeySerde;
+import io.confluent.ksql.serde.SerdeOption;
+import io.confluent.ksql.serde.ValueFormat;
+import io.confluent.ksql.util.KsqlConfig;
+import java.util.List;
+import org.apache.kafka.common.serialization.Serde;
+import org.apache.kafka.connect.data.Struct;
+import org.apache.kafka.streams.kstream.Grouped;
+import org.apache.kafka.streams.kstream.KGroupedStream;
+import org.apache.kafka.streams.kstream.KStream;
+import org.apache.kafka.streams.kstream.KeyValueMapper;
+import org.apache.kafka.streams.kstream.Predicate;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Captor;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnit;
+import org.mockito.junit.MockitoRule;
+
+public class StreamGroupByBuilderTest {
+  private static final String ALIAS = "SOURCE";
+  private static final LogicalSchema SCHEMA = LogicalSchema.builder()
+      .valueColumn("PAC", SqlTypes.BIGINT)
+      .valueColumn("MAN", SqlTypes.STRING)
+      .build()
+      .withAlias(ALIAS)
+      .withMetaAndKeyColsInValue();
+  private static final PhysicalSchema PHYSICAL_SCHEMA =
+      PhysicalSchema.from(SCHEMA, SerdeOption.none());
+  private static final List<Expression> GROUP_BY_EXPRESSIONS = ImmutableList.of(
+      columnReference("PAC"),
+      columnReference("MAN")
+  );
+  private static final QueryContext SOURCE_CTX =
+      new QueryContext.Stacker(new QueryId("qid")).push("foo").push("source").getQueryContext();
+  private static final QueryContext STEP_CTX =
+      new QueryContext.Stacker(new QueryId("qid")).push("foo").push("groupby").getQueryContext();
+  private static final ExecutionStepProperties SOURCE_PROPERTIES
+      = new DefaultExecutionStepProperties(SCHEMA, SOURCE_CTX);
+  private static final ExecutionStepProperties PROPERTIES = new DefaultExecutionStepProperties(
+      SCHEMA,
+      STEP_CTX
+  );
+  private static final Formats FORMATS = Formats.of(
+      KeyFormat.nonWindowed(FormatInfo.of(Format.KAFKA)),
+      ValueFormat.of(FormatInfo.of(Format.JSON)),
+      SerdeOption.none()
+  );
+
+  @Mock
+  private KsqlQueryBuilder queryBuilder;
+  @Mock
+  private KsqlConfig ksqlConfig;
+  @Mock
+  private FunctionRegistry functionRegistry;
+  @Mock
+  private GroupedFactory groupedFactory;
+  @Mock
+  private ExecutionStep sourceStep;
+  @Mock
+  private KeySerde<Struct> keySerde;
+  @Mock
+  private Serde<GenericRow> valueSerde;
+  @Mock
+  private Grouped<Struct, GenericRow> grouped;
+  @Mock
+  private KStream<Struct, GenericRow> sourceStream;
+  @Mock
+  private KStream<Struct, GenericRow> filteredStream;
+  @Mock
+  private KGroupedStream<Struct, GenericRow> groupedStream;
+  @Captor
+  private ArgumentCaptor<GroupByMapper<Struct>> mapperCaptor;
+  @Captor
+  private ArgumentCaptor<Predicate<Struct, GenericRow>> predicateCaptor;
+
+  private StreamGroupBy<Struct> streamGroupBy;
+  private StreamGroupByKey streamGroupByKey;
+
+  @Rule
+  public final MockitoRule mockitoRule = MockitoJUnit.rule();
+
+  @Before
+  @SuppressWarnings("unchecked")
+  public void init() {
+    when(queryBuilder.getKsqlConfig()).thenReturn(ksqlConfig);
+    when(queryBuilder.getFunctionRegistry()).thenReturn(functionRegistry);
+    when(queryBuilder.buildKeySerde(any(), any(), any())).thenReturn(keySerde);
+    when(queryBuilder.buildValueSerde(any(), any(), any())).thenReturn(valueSerde);
+    when(groupedFactory.create(any(), any(KeySerde.class), any())).thenReturn(grouped);
+    when(sourceStream.groupByKey(any(Grouped.class))).thenReturn(groupedStream);
+    when(sourceStream.filter(any())).thenReturn(filteredStream);
+    when(filteredStream.groupBy(any(KeyValueMapper.class), any(Grouped.class)))
+        .thenReturn(groupedStream);
+    when(sourceStep.getProperties()).thenReturn(SOURCE_PROPERTIES);
+    when(sourceStep.getSchema()).thenReturn(SCHEMA);
+    streamGroupBy = new StreamGroupBy<>(
+        PROPERTIES,
+        sourceStep,
+        FORMATS,
+        GROUP_BY_EXPRESSIONS
+    );
+    streamGroupByKey = new StreamGroupByKey(PROPERTIES, sourceStep, FORMATS);
+  }
+
+  @Test
+  public void shouldPerformGroupByCorrectly() {
+    // When:
+    final KGroupedStream result =
+        StreamGroupByBuilder.build(sourceStream, streamGroupBy, queryBuilder, groupedFactory);
+
+    // Then:
+    assertThat(result, is(groupedStream));
+    verify(sourceStream).filter(any());
+    verify(filteredStream).groupBy(mapperCaptor.capture(), same(grouped));
+    verifyNoMoreInteractions(filteredStream, sourceStream);
+    final GroupByMapper<?> mapper = mapperCaptor.getValue();
+    assertThat(mapper.getExpressionMetadata(), hasSize(2));
+    assertThat(
+        mapper.getExpressionMetadata().get(0).getExpression(),
+        equalTo(GROUP_BY_EXPRESSIONS.get(0))
+    );
+    assertThat(
+        mapper.getExpressionMetadata().get(1).getExpression(),
+        equalTo(GROUP_BY_EXPRESSIONS.get(1))
+    );
+  }
+
+  @Test
+  public void shouldFilterNullRowsBeforeGroupBy() {
+    // When:
+    StreamGroupByBuilder.build(sourceStream, streamGroupBy, queryBuilder, groupedFactory);
+
+    // Then:
+    verify(sourceStream).filter(predicateCaptor.capture());
+    final Predicate<Struct, GenericRow> predicate = predicateCaptor.getValue();
+    assertThat(predicate.test(StructKeyUtil.asStructKey("foo"), new GenericRow()), is(true));
+    assertThat(predicate.test(StructKeyUtil.asStructKey("foo"), null),  is(false));
+  }
+
+  @Test
+  public void shouldBuildGroupedCorrectlyForGroupBy() {
+    // When:
+    StreamGroupByBuilder.build(sourceStream, streamGroupBy, queryBuilder, groupedFactory);
+
+    // Then:
+    verify(groupedFactory).create("foo-groupby", keySerde, valueSerde);
+  }
+
+  @Test
+  public void shouldBuildKeySerdeCorrectlyForGroupBy() {
+    // When:
+    StreamGroupByBuilder.build(sourceStream, streamGroupBy, queryBuilder, groupedFactory);
+
+    // Then:
+    verify(queryBuilder).buildKeySerde(
+        FORMATS.getKeyFormat().getFormatInfo(),
+        PHYSICAL_SCHEMA,
+        STEP_CTX
+    );
+  }
+
+  @Test
+  public void shouldBuildValueSerdeCorrectlyForGroupBy() {
+    // When:
+    StreamGroupByBuilder.build(sourceStream, streamGroupBy, queryBuilder, groupedFactory);
+
+    // Then:
+    verify(queryBuilder).buildValueSerde(
+        FORMATS.getValueFormat().getFormatInfo(),
+        PHYSICAL_SCHEMA,
+        STEP_CTX
+    );
+  }
+
+  @Test
+  public void shouldPerformGroupByKeyCorrectly() {
+    // When:
+    final KGroupedStream result =
+        StreamGroupByBuilder.build(sourceStream, streamGroupByKey, queryBuilder, groupedFactory);
+
+    // Then:
+    assertThat(result, is(groupedStream));
+    verify(sourceStream).groupByKey(grouped);
+    verifyNoMoreInteractions(sourceStream);
+  }
+
+  @Test
+  public void shouldBuildGroupedCorrectlyForGroupByKey() {
+    // When:
+    StreamGroupByBuilder.build(sourceStream, streamGroupByKey, queryBuilder, groupedFactory);
+
+    // Then:
+    verify(groupedFactory).create("foo-groupby", keySerde, valueSerde);
+  }
+
+  @Test
+  public void shouldBuildKeySerdeCorrectlyForGroupByKey() {
+    // When:
+    StreamGroupByBuilder.build(sourceStream, streamGroupByKey, queryBuilder, groupedFactory);
+
+    // Then:
+    verify(queryBuilder).buildKeySerde(
+        FORMATS.getKeyFormat().getFormatInfo(),
+        PHYSICAL_SCHEMA,
+        STEP_CTX);
+  }
+
+  @Test
+  public void shouldBuildValueSerdeCorrectlyForGroupByKey() {
+    // When:
+    StreamGroupByBuilder.build(sourceStream, streamGroupByKey, queryBuilder, groupedFactory);
+
+    // Then:
+    verify(queryBuilder).buildValueSerde(
+        FORMATS.getValueFormat().getFormatInfo(),
+        PHYSICAL_SCHEMA,
+        STEP_CTX
+    );
+  }
+
+  private static Expression columnReference(final String column) {
+    return new QualifiedNameReference(QualifiedName.of(ALIAS, column));
+  }
+}

--- a/ksql-streams/src/test/java/io/confluent/ksql/execution/streams/TableGroupByBuilderTest.java
+++ b/ksql-streams/src/test/java/io/confluent/ksql/execution/streams/TableGroupByBuilderTest.java
@@ -1,0 +1,216 @@
+package io.confluent.ksql.execution.streams;
+
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.hasSize;
+import static org.hamcrest.Matchers.is;
+import static org.junit.Assert.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.same;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoMoreInteractions;
+import static org.mockito.Mockito.when;
+
+import com.google.common.collect.ImmutableList;
+import io.confluent.ksql.GenericRow;
+import io.confluent.ksql.execution.builder.KsqlQueryBuilder;
+import io.confluent.ksql.execution.context.QueryContext;
+import io.confluent.ksql.execution.expression.tree.DereferenceExpression;
+import io.confluent.ksql.execution.expression.tree.Expression;
+import io.confluent.ksql.execution.expression.tree.QualifiedName;
+import io.confluent.ksql.execution.expression.tree.QualifiedNameReference;
+import io.confluent.ksql.execution.plan.DefaultExecutionStepProperties;
+import io.confluent.ksql.execution.plan.ExecutionStep;
+import io.confluent.ksql.execution.plan.ExecutionStepProperties;
+import io.confluent.ksql.execution.plan.Formats;
+import io.confluent.ksql.execution.plan.TableGroupBy;
+import io.confluent.ksql.execution.streams.TableGroupByBuilder.TableKeyValueMapper;
+import io.confluent.ksql.execution.util.StructKeyUtil;
+import io.confluent.ksql.function.FunctionRegistry;
+import io.confluent.ksql.query.QueryId;
+import io.confluent.ksql.schema.ksql.LogicalSchema;
+import io.confluent.ksql.schema.ksql.PhysicalSchema;
+import io.confluent.ksql.schema.ksql.types.SqlTypes;
+import io.confluent.ksql.serde.Format;
+import io.confluent.ksql.serde.FormatInfo;
+import io.confluent.ksql.serde.KeyFormat;
+import io.confluent.ksql.serde.KeySerde;
+import io.confluent.ksql.serde.SerdeOption;
+import io.confluent.ksql.serde.ValueFormat;
+import io.confluent.ksql.util.KsqlConfig;
+import java.util.List;
+import java.util.Optional;
+import org.apache.kafka.common.serialization.Serde;
+import org.apache.kafka.connect.data.Struct;
+import org.apache.kafka.streams.kstream.Grouped;
+import org.apache.kafka.streams.kstream.KGroupedTable;
+import org.apache.kafka.streams.kstream.KTable;
+import org.apache.kafka.streams.kstream.KeyValueMapper;
+import org.apache.kafka.streams.kstream.Predicate;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Captor;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnit;
+import org.mockito.junit.MockitoRule;
+
+public class TableGroupByBuilderTest {
+  private static final String ALIAS = "SOURCE";
+  private static final LogicalSchema SCHEMA = LogicalSchema.builder()
+      .valueColumn("PAC", SqlTypes.BIGINT)
+      .valueColumn("MAN", SqlTypes.STRING)
+      .build()
+      .withAlias(ALIAS)
+      .withMetaAndKeyColsInValue();
+  private static final PhysicalSchema PHYSICAL_SCHEMA = PhysicalSchema.from(SCHEMA, SerdeOption.none());
+
+  private final List<Expression> groupByExpressions = ImmutableList.of(
+      columnReference("PAC"),
+      columnReference("MAN")
+  );
+  private final QueryContext sourceContext =
+      new QueryContext.Stacker(new QueryId("qid")).push("foo").push("source").getQueryContext();
+  private final QueryContext stepContext =
+      new QueryContext.Stacker(new QueryId("qid")).push("foo").push("groupby").getQueryContext();
+  private final ExecutionStepProperties sourceProperties = new DefaultExecutionStepProperties(
+      SCHEMA,
+      sourceContext
+  );
+  private final ExecutionStepProperties properties = new DefaultExecutionStepProperties(
+      SCHEMA,
+      stepContext
+  );
+  private final Formats formats = Formats.of(
+      KeyFormat.nonWindowed(FormatInfo.of(Format.KAFKA)),
+      ValueFormat.of(FormatInfo.of(Format.JSON)),
+      SerdeOption.none()
+  );
+
+  @Mock
+  private KsqlQueryBuilder queryBuilder;
+  @Mock
+  private KsqlConfig ksqlConfig;
+  @Mock
+  private FunctionRegistry functionRegistry;
+  @Mock
+  private GroupedFactory groupedFactory;
+  @Mock
+  private ExecutionStep sourceStep;
+  @Mock
+  private KeySerde<Struct> keySerde;
+  @Mock
+  private Serde<GenericRow> valueSerde;
+  @Mock
+  private Grouped<Struct, GenericRow> grouped;
+  @Mock
+  private KTable<Struct, GenericRow> sourceTable;
+  @Mock
+  private KTable<Struct, GenericRow> filteredTable;
+  @Mock
+  private KGroupedTable<Struct, GenericRow> groupedTable;
+  @Captor
+  private ArgumentCaptor<TableKeyValueMapper<Struct>> mapperCaptor;
+  @Captor
+  private ArgumentCaptor<Predicate<Struct, GenericRow>> predicateCaptor;
+
+  private TableGroupBy<Struct> groupBy;
+
+  @Rule
+  public final MockitoRule mockitoRule = MockitoJUnit.rule();
+
+  @Before
+  @SuppressWarnings("unchecked")
+  public void init() {
+    when(queryBuilder.getKsqlConfig()).thenReturn(ksqlConfig);
+    when(queryBuilder.getFunctionRegistry()).thenReturn(functionRegistry);
+    when(queryBuilder.buildKeySerde(any(), any(), any())).thenReturn(keySerde);
+    when(queryBuilder.buildValueSerde(any(), any(), any())).thenReturn(valueSerde);
+    when(groupedFactory.create(any(), any(KeySerde.class), any())).thenReturn(grouped);
+    when(sourceTable.filter(any())).thenReturn(filteredTable);
+    when(filteredTable.groupBy(any(KeyValueMapper.class), any(Grouped.class)))
+        .thenReturn(groupedTable);
+    when(sourceStep.getProperties()).thenReturn(sourceProperties);
+    when(sourceStep.getSchema()).thenReturn(SCHEMA);
+    groupBy = new TableGroupBy<>(
+        properties,
+        sourceStep,
+        formats,
+        groupByExpressions
+    );
+  }
+
+  @Test
+  public void shouldPerformGroupByCorrectly() {
+    // When:
+    final KGroupedTable result =
+        TableGroupByBuilder.build(sourceTable, groupBy, queryBuilder, groupedFactory);
+
+    // Then:
+    assertThat(result, is(groupedTable));
+    verify(sourceTable).filter(any());
+    verify(filteredTable).groupBy(mapperCaptor.capture(), same(grouped));
+    verifyNoMoreInteractions(filteredTable, sourceTable);
+    final GroupByMapper<Struct> mapper = mapperCaptor.getValue().getGroupByMapper();
+    assertThat(mapper.getExpressionMetadata(), hasSize(2));
+    assertThat(
+        mapper.getExpressionMetadata().get(0).getExpression(),
+        equalTo(groupByExpressions.get(0))
+    );
+    assertThat(
+        mapper.getExpressionMetadata().get(1).getExpression(),
+        equalTo(groupByExpressions.get(1))
+    );
+  }
+
+  @Test
+  public void shouldFilterNullRowsBeforeGroupBy() {
+    // When:
+    TableGroupByBuilder.build(sourceTable, groupBy, queryBuilder, groupedFactory);
+
+    // Then:
+    verify(sourceTable).filter(predicateCaptor.capture());
+    final Predicate<Struct, GenericRow> predicate = predicateCaptor.getValue();
+    assertThat(predicate.test(StructKeyUtil.asStructKey("key"), new GenericRow()), is(true));
+    assertThat(predicate.test(StructKeyUtil.asStructKey("key"), null),  is(false));
+  }
+
+  @Test
+  public void shouldBuildGroupedCorrectlyForGroupBy() {
+    // When:
+    TableGroupByBuilder.build(sourceTable, groupBy, queryBuilder, groupedFactory);
+
+    // Then:
+    verify(groupedFactory).create("foo-groupby", keySerde, valueSerde);
+  }
+
+  @Test
+  public void shouldBuildKeySerdeCorrectlyForGroupBy() {
+    // When:
+    TableGroupByBuilder.build(sourceTable, groupBy, queryBuilder, groupedFactory);
+
+    // Then:
+    verify(queryBuilder).buildKeySerde(
+        formats.getKeyFormat().getFormatInfo(),
+        PHYSICAL_SCHEMA,
+        stepContext
+    );
+  }
+
+  @Test
+  public void shouldBuildValueSerdeCorrectlyForGroupBy() {
+    // When:
+    TableGroupByBuilder.build(sourceTable, groupBy, queryBuilder, groupedFactory);
+
+    // Then:
+    verify(queryBuilder).buildValueSerde(
+        formats.getValueFormat().getFormatInfo(),
+        PHYSICAL_SCHEMA,
+        stepContext
+    );
+  }
+
+  private static Expression columnReference(final String column) {
+    return new QualifiedNameReference(QualifiedName.of(ALIAS, column));
+  }
+}


### PR DESCRIPTION
### Description 

This patch moves the code for regrouping streams/tables into plan
builders. This also required adding a new execution step for
groupByKey, which we missed the first go-round.

### Testing done 

Adds tests for the new grouped step builders.

### Reviewer checklist
- [ ] Ensure docs are updated if necessary. (eg. if a user visible feature is being added or changed).
- [ ] Ensure relevant issues are linked (description should include text like "Fixes #<issue number>")

