### PR TITLE
feat: move setup of the sink to plan builders

### DIFF
--- a/ksql-engine/src/main/java/io/confluent/ksql/structured/SchemaKGroupedStream.java
+++ b/ksql-engine/src/main/java/io/confluent/ksql/structured/SchemaKGroupedStream.java
@@ -232,6 +232,15 @@ public class SchemaKGroupedStream {
   }
 
   private KeyFormat getKeyFormat(final WindowExpression windowExpression) {
+    if (ksqlConfig.getBoolean(KsqlConfig.KSQL_WINDOWED_SESSION_KEY_LEGACY_CONFIG)) {
+      return KeyFormat.windowed(
+          FormatInfo.of(Format.KAFKA),
+          WindowInfo.of(
+              WindowType.TUMBLING,
+              Optional.of(Duration.ofMillis(Long.MAX_VALUE))
+          )
+      );
+    }
     return KeyFormat.windowed(
         FormatInfo.of(Format.KAFKA),
         windowExpression.getKsqlWindowExpression().getWindowInfo()

--- a/ksql-engine/src/main/java/io/confluent/ksql/structured/SchemaKTable.java
+++ b/ksql-engine/src/main/java/io/confluent/ksql/structured/SchemaKTable.java
@@ -51,7 +51,6 @@ import java.util.List;
 import java.util.Objects;
 import java.util.Optional;
 import java.util.Set;
-import org.apache.kafka.common.serialization.Serde;
 import org.apache.kafka.connect.data.Struct;
 import org.apache.kafka.streams.kstream.KStream;
 import org.apache.kafka.streams.kstream.KTable;

--- a/ksql-engine/src/test/java/io/confluent/ksql/planner/plan/DataSourceNodeTest.java
+++ b/ksql-engine/src/test/java/io/confluent/ksql/planner/plan/DataSourceNodeTest.java
@@ -190,7 +190,8 @@ public class DataSourceNodeTest {
         new QueryContext.Stacker(queryId)
             .push(inv.getArgument(0).toString()));
 
-    when(ksqlStreamBuilder.buildKeySerde(any(), any(), any())).thenReturn((KeySerde)keySerde);
+    when(ksqlStreamBuilder.buildKeySerde(any(), any(), any()))
+        .thenReturn((KeySerde)keySerde);
     when(ksqlStreamBuilder.buildKeySerde(any(), any(), any(), any())).thenReturn((KeySerde)keySerde);
     when(ksqlStreamBuilder.buildValueSerde(any(), any(), any())).thenReturn(rowSerde);
     when(ksqlStreamBuilder.getFunctionRegistry()).thenReturn(functionRegistry);

--- a/ksql-engine/src/test/java/io/confluent/ksql/planner/plan/KsqlStructuredDataOutputNodeTest.java
+++ b/ksql-engine/src/test/java/io/confluent/ksql/planner/plan/KsqlStructuredDataOutputNodeTest.java
@@ -92,13 +92,9 @@ public class KsqlStructuredDataOutputNodeTest {
   public final ExpectedException expectedException = ExpectedException.none();
 
   @Mock
-  private KsqlConfig ksqlConfig;
-  @Mock
   private QueryIdGenerator queryIdGenerator;
   @Mock
   private KsqlQueryBuilder ksqlStreamBuilder;
-  @Mock
-  private FunctionRegistry functionRegistry;
   @Mock
   private PlanNode sourceNode;
   @Mock
@@ -112,17 +108,9 @@ public class KsqlStructuredDataOutputNodeTest {
   @Mock
   private SchemaKStream<?> sinkStreamWithKeySelected;
   @Mock
-  private KStream<String, GenericRow> kstream;
-  @Mock
   private KsqlTopic ksqlTopic;
-  @Mock
-  private Serde<GenericRow> rowSerde;
-  @Captor
-  private ArgumentCaptor<QueryContext> queryContextCaptor;
   @Captor
   private ArgumentCaptor<QueryContext.Stacker> stackerCaptor;
-
-  private final Set<SerdeOption> serdeOptions = SerdeOption.none();
 
   private KsqlStructuredDataOutputNode outputNode;
   private LogicalSchema schema;
@@ -145,14 +133,13 @@ public class KsqlStructuredDataOutputNodeTest {
 
     when(sourceStream.withKeyField(any()))
         .thenReturn(resultStream);
-    when(resultStream.into(any(), any(), any(), any(), any(), any(), any()))
+    when(resultStream.into(any(), any(), any(), any(), any(), any()))
         .thenReturn((SchemaKStream) sinkStream);
     when(resultStream.selectKey(any(), anyBoolean(), any()))
         .thenReturn((SchemaKStream) resultWithKeySelected);
-    when(resultWithKeySelected.into(any(), any(), any(), any(), any(), any(), any()))
+    when(resultWithKeySelected.into(any(), any(), any(), any(), any(), any()))
         .thenReturn((SchemaKStream) sinkStreamWithKeySelected);
 
-    when(ksqlStreamBuilder.buildValueSerde(any(), any(), any())).thenReturn(rowSerde);
     when(ksqlStreamBuilder.buildNodeContext(any())).thenAnswer(inv ->
         new QueryContext.Stacker(QUERY_ID)
             .push(inv.getArgument(0).toString()));
@@ -334,27 +321,7 @@ public class KsqlStructuredDataOutputNodeTest {
     outputNode.buildStream(ksqlStreamBuilder);
 
     // Then:
-    verify(ksqlStreamBuilder).buildValueSerde(
-        eq(valueFormat.getFormatInfo()),
-        any(),
-        any()
-    );
-  }
-
-  @Test
-  public void shouldBuildRowSerdeCorrectly() {
-    // When:
-    outputNode.buildStream(ksqlStreamBuilder);
-
-    // Then:
-    verify(ksqlStreamBuilder).buildValueSerde(
-        eq(FormatInfo.of(Format.JSON)),
-        eq(PhysicalSchema.from(SCHEMA, serdeOptions)),
-        queryContextCaptor.capture()
-    );
-
-    assertThat(QueryLoggerUtil.queryLoggerName(queryContextCaptor.getValue()),
-        is("output-test.0"));
+    verify(resultStream).into(any(), any(), eq(valueFormat), any(), any(), any());
   }
 
   @Test
@@ -365,69 +332,17 @@ public class KsqlStructuredDataOutputNodeTest {
     // Then:
     verify(resultStream).into(
         eq(SINK_KAFKA_TOPIC_NAME),
-        same(rowSerde),
         eq(SCHEMA),
         eq(JSON_FORMAT),
         eq(SerdeOption.none()),
-        eq(ImmutableSet.of()),
-        stackerCaptor.capture()
+        stackerCaptor.capture(),
+        same(ksqlStreamBuilder)
     );
     assertThat(
         stackerCaptor.getValue().getQueryContext().getContext(),
         equalTo(ImmutableList.of("0"))
     );
     assertThat(result, sameInstance(sinkStream));
-  }
-
-  @Test
-  public void shouldCallIntoWithIndexesToRemoveImplicitsAndRowKey() {
-    // Given:
-    final LogicalSchema schema = SCHEMA.withMetaAndKeyColsInValue();
-    givenNodeWithSchema(schema);
-
-    // When:
-    outputNode.buildStream(ksqlStreamBuilder);
-
-    // Then:
-    verify(resultStream).into(
-        eq(SINK_KAFKA_TOPIC_NAME),
-        same(rowSerde),
-        any(),
-        any(),
-        any(),
-        eq(ImmutableSet.of(0, 1)),
-        any()
-    );
-  }
-
-  @Test
-  public void shouldCallIntoWithIndexesToRemoveImplicitsAndRowKeyRegardlessOfLocation() {
-    // Given:
-    final LogicalSchema schema = LogicalSchema.builder()
-        .valueColumn("field1", SqlTypes.STRING)
-        .valueColumn("field2", SqlTypes.STRING)
-        .valueColumn("ROWKEY", SqlTypes.STRING)
-        .valueColumn("field3", SqlTypes.STRING)
-        .valueColumn("timestamp", SqlTypes.BIGINT)
-        .valueColumn("ROWTIME", SqlTypes.BIGINT)
-        .valueColumn("key", SqlTypes.STRING)
-        .build();
-
-    givenNodeWithSchema(schema);
-
-    // When:
-    outputNode.buildStream(ksqlStreamBuilder);
-
-    // Then:
-    verify(resultStream).into(
-        eq(SINK_KAFKA_TOPIC_NAME),
-        same(rowSerde),
-        any(),
-        any(),
-        any(),
-        eq(ImmutableSet.of(2, 5)),
-        any()
-    );
   }
 
   private void givenInsertIntoNode() {

--- a/ksql-execution/src/main/java/io/confluent/ksql/execution/plan/StreamSink.java
+++ b/ksql-execution/src/main/java/io/confluent/ksql/execution/plan/StreamSink.java
@@ -15,21 +15,23 @@
 package io.confluent.ksql.execution.plan;
 
 import com.google.errorprone.annotations.Immutable;
+import io.confluent.ksql.GenericRow;
 import io.confluent.ksql.execution.builder.KsqlQueryBuilder;
 import java.util.Collections;
 import java.util.List;
 import java.util.Objects;
+import org.apache.kafka.streams.kstream.KStream;
 
 @Immutable
-public class StreamSink<S> implements ExecutionStep<S> {
+public class StreamSink<K> implements ExecutionStep<KStream<K, GenericRow>> {
   private final ExecutionStepProperties properties;
-  private final ExecutionStep<S>  source;
+  private final ExecutionStep<KStream<K, GenericRow>>  source;
   private final Formats formats;
   private final String topicName;
 
   public StreamSink(
       final ExecutionStepProperties properties,
-      final ExecutionStep<S> source,
+      final ExecutionStep<KStream<K, GenericRow>> source,
       final Formats formats,
       final String topicName) {
     this.properties = Objects.requireNonNull(properties, "properties");
@@ -52,10 +54,15 @@ public class StreamSink<S> implements ExecutionStep<S> {
     return Collections.singletonList(source);
   }
 
+  public Formats getFormats() {
+    return formats;
+  }
+
   @Override
-  public S build(final KsqlQueryBuilder streamsBuilder) {
+  public KStream<K, GenericRow> build(final KsqlQueryBuilder streamsBuilder) {
     throw new UnsupportedOperationException();
   }
+
 
   @Override
   public boolean equals(final Object o) {

--- a/ksql-execution/src/main/java/io/confluent/ksql/execution/plan/TableSink.java
+++ b/ksql-execution/src/main/java/io/confluent/ksql/execution/plan/TableSink.java
@@ -15,21 +15,23 @@
 package io.confluent.ksql.execution.plan;
 
 import com.google.errorprone.annotations.Immutable;
+import io.confluent.ksql.GenericRow;
 import io.confluent.ksql.execution.builder.KsqlQueryBuilder;
 import java.util.Collections;
 import java.util.List;
 import java.util.Objects;
+import org.apache.kafka.streams.kstream.KTable;
 
 @Immutable
-public class TableSink<T> implements ExecutionStep<T> {
+public class TableSink<K> implements ExecutionStep<KTable<K, GenericRow>> {
   private final ExecutionStepProperties properties;
-  private final ExecutionStep<T> source;
+  private final ExecutionStep<KTable<K, GenericRow>> source;
   private final Formats formats;
   private final String topicName;
 
   public TableSink(
       final ExecutionStepProperties properties,
-      final ExecutionStep<T> source,
+      final ExecutionStep<KTable<K, GenericRow>> source,
       final Formats formats,
       final String topicName
   ) {
@@ -53,8 +55,12 @@ public class TableSink<T> implements ExecutionStep<T> {
     return Collections.singletonList(source);
   }
 
+  public Formats getFormats() {
+    return formats;
+  }
+
   @Override
-  public T build(final KsqlQueryBuilder builder) {
+  public KTable<K, GenericRow> build(final KsqlQueryBuilder builder) {
     throw new UnsupportedOperationException();
   }
 

--- a/ksql-execution/src/main/java/io/confluent/ksql/execution/util/SinkSchemaUtil.java
+++ b/ksql-execution/src/main/java/io/confluent/ksql/execution/util/SinkSchemaUtil.java
@@ -1,0 +1,55 @@
+/*
+ * Copyright 2019 Confluent Inc.
+ *
+ * Licensed under the Confluent Community License (the "License"); you may not use
+ * this file except in compliance with the License.  You may obtain a copy of the
+ * License at
+ *
+ * http://www.confluent.io/confluent-community-license
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package io.confluent.ksql.execution.util;
+
+import com.google.common.collect.Streams;
+import io.confluent.ksql.execution.plan.ExecutionStep;
+import io.confluent.ksql.schema.ksql.Column;
+import io.confluent.ksql.schema.ksql.LogicalSchema;
+import java.util.Objects;
+import java.util.Set;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+import org.apache.kafka.connect.data.ConnectSchema;
+
+public final class SinkSchemaUtil {
+  private SinkSchemaUtil() {
+  }
+
+  public static LogicalSchema sinkSchema(final ExecutionStep<?> step) {
+    final LogicalSchema schema = step.getSources().get(0).getProperties().getSchema();
+    return schema.withoutMetaAndKeyColsInValue();
+  }
+
+  public static Set<Integer> implicitAndKeyColumnIndexesInValueSchema(
+      final ExecutionStep<?> step
+  ) {
+    final LogicalSchema schema = step.getSources().get(0).getProperties().getSchema();
+    final ConnectSchema valueSchema = schema.valueConnectSchema();
+
+    final Stream<Column> cols = Streams.concat(
+        schema.metadata().stream(),
+        schema.key().stream()
+    );
+
+    return cols
+        .map(Column::name)
+        .map(valueSchema::field)
+        .filter(Objects::nonNull)
+        .map(org.apache.kafka.connect.data.Field::index)
+        .collect(Collectors.toSet());
+  }
+}

--- a/ksql-execution/src/test/java/io/confluent/ksql/execution/util/SinkSchemaUtilTest.java
+++ b/ksql-execution/src/test/java/io/confluent/ksql/execution/util/SinkSchemaUtilTest.java
@@ -1,0 +1,90 @@
+/*
+ * Copyright 2019 Confluent Inc.
+ *
+ * Licensed under the Confluent Community License (the "License"); you may not use
+ * this file except in compliance with the License.  You may obtain a copy of the
+ * License at
+ *
+ * http://www.confluent.io/confluent-community-license
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package io.confluent.ksql.execution.util;
+
+import static org.hamcrest.Matchers.contains;
+import static org.junit.Assert.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import com.google.common.collect.ImmutableList;
+import io.confluent.ksql.execution.context.QueryContext;
+import io.confluent.ksql.execution.plan.DefaultExecutionStepProperties;
+import io.confluent.ksql.execution.plan.ExecutionStep;
+import io.confluent.ksql.schema.ksql.LogicalSchema;
+import io.confluent.ksql.schema.ksql.types.SqlTypes;
+import java.util.Set;
+import org.junit.Rule;
+import org.junit.Test;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnit;
+import org.mockito.junit.MockitoRule;
+
+public class SinkSchemaUtilTest {
+  @Mock
+  private ExecutionStep step;
+
+  @Rule
+  public final MockitoRule mockitoRule = MockitoJUnit.rule();
+
+  private void givenStepWithSchema(final LogicalSchema schema) {
+    when(step.getSources()).thenReturn(ImmutableList.of(step));
+    when(step.getProperties()).thenReturn(
+        new DefaultExecutionStepProperties(schema, mock(QueryContext.class))
+    );
+  }
+
+  @Test
+  public void shouldComputeIndexesToRemoveImplicitsAndRowKey() {
+    // Given:
+    givenStepWithSchema(LogicalSchema.builder()
+        .valueColumn("field1", SqlTypes.STRING)
+        .valueColumn("field2", SqlTypes.STRING)
+        .valueColumn("field3", SqlTypes.STRING)
+        .valueColumn("timestamp", SqlTypes.BIGINT)
+        .valueColumn("key", SqlTypes.STRING)
+        .build()
+        .withMetaAndKeyColsInValue()
+    );
+
+    // When:
+    final Set<Integer> indices = SinkSchemaUtil.implicitAndKeyColumnIndexesInValueSchema(step);
+
+    // Then:
+    assertThat(indices, contains(0, 1));
+  }
+
+  @Test
+  public void shouldComputeIndexesToRemoveImplicitsAndRowKeyRegardlessOfLocation() {
+    // Given:
+    givenStepWithSchema(LogicalSchema.builder()
+        .valueColumn("field1", SqlTypes.STRING)
+        .valueColumn("field2", SqlTypes.STRING)
+        .valueColumn("ROWKEY", SqlTypes.STRING)
+        .valueColumn("field3", SqlTypes.STRING)
+        .valueColumn("timestamp", SqlTypes.BIGINT)
+        .valueColumn("ROWTIME", SqlTypes.BIGINT)
+        .valueColumn("key", SqlTypes.STRING)
+        .build()
+    );
+
+    // When:
+    final Set<Integer> indices = SinkSchemaUtil.implicitAndKeyColumnIndexesInValueSchema(step);
+
+    // Then:
+    assertThat(indices, contains(2, 5));
+  }
+}

--- a/ksql-streams/src/main/java/io/confluent/ksql/execution/streams/ExecutionStepFactory.java
+++ b/ksql-streams/src/main/java/io/confluent/ksql/execution/streams/ExecutionStepFactory.java
@@ -123,7 +123,7 @@ public final class ExecutionStepFactory {
     );
   }
 
-  public static <K> StreamSink<KStream<K, GenericRow>> streamSink(
+  public static <K> StreamSink<K> streamSink(
       final QueryContext.Stacker stacker,
       final LogicalSchema outputSchema,
       final Formats formats,
@@ -235,7 +235,7 @@ public final class ExecutionStepFactory {
     );
   }
 
-  public static <K> TableSink<KTable<K, GenericRow>> tableSink(
+  public static <K> TableSink<K> tableSink(
       final QueryContext.Stacker stacker,
       final LogicalSchema outputSchema,
       final ExecutionStep<KTable<K, GenericRow>> source,

--- a/ksql-streams/src/main/java/io/confluent/ksql/execution/streams/KeySerdeFactory.java
+++ b/ksql-streams/src/main/java/io/confluent/ksql/execution/streams/KeySerdeFactory.java
@@ -1,0 +1,28 @@
+/*
+ * Copyright 2019 Confluent Inc.
+ *
+ * Licensed under the Confluent Community License; you may not use this file
+ * except in compliance with the License.  You may obtain a copy of the License at
+ *
+ * http://www.confluent.io/confluent-community-license
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package io.confluent.ksql.execution.streams;
+
+import io.confluent.ksql.execution.context.QueryContext;
+import io.confluent.ksql.schema.ksql.PhysicalSchema;
+import io.confluent.ksql.serde.KeyFormat;
+import io.confluent.ksql.serde.KeySerde;
+
+public interface KeySerdeFactory<K> {
+  KeySerde<K> buildKeySerde(
+      KeyFormat keyFormat,
+      PhysicalSchema physicalSchema,
+      QueryContext queryContext
+  );
+}

--- a/ksql-streams/src/main/java/io/confluent/ksql/execution/streams/StreamSinkBuilder.java
+++ b/ksql-streams/src/main/java/io/confluent/ksql/execution/streams/StreamSinkBuilder.java
@@ -1,0 +1,74 @@
+/*
+ * Copyright 2019 Confluent Inc.
+ *
+ * Licensed under the Confluent Community License (the "License"); you may not use
+ * this file except in compliance with the License.  You may obtain a copy of the
+ * License at
+ *
+ * http://www.confluent.io/confluent-community-license
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package io.confluent.ksql.execution.streams;
+
+import io.confluent.ksql.GenericRow;
+import io.confluent.ksql.execution.builder.KsqlQueryBuilder;
+import io.confluent.ksql.execution.context.QueryContext;
+import io.confluent.ksql.execution.plan.Formats;
+import io.confluent.ksql.execution.plan.StreamSink;
+import io.confluent.ksql.execution.util.SinkSchemaUtil;
+import io.confluent.ksql.schema.ksql.LogicalSchema;
+import io.confluent.ksql.schema.ksql.PhysicalSchema;
+import io.confluent.ksql.serde.KeySerde;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Set;
+import org.apache.kafka.common.serialization.Serde;
+import org.apache.kafka.streams.kstream.KStream;
+import org.apache.kafka.streams.kstream.Produced;
+
+public final class StreamSinkBuilder {
+  private StreamSinkBuilder() {
+  }
+
+  public static <K> void build(
+      final KStream<K, GenericRow> kstream,
+      final StreamSink<K> streamSink,
+      final KeySerdeFactory<K> keySerdeFactory,
+      final KsqlQueryBuilder queryBuilder) {
+    final QueryContext queryContext = streamSink.getProperties().getQueryContext();
+    final LogicalSchema schema = SinkSchemaUtil.sinkSchema(streamSink);
+    final Formats formats = streamSink.getFormats();
+    final PhysicalSchema physicalSchema = PhysicalSchema.from(schema, formats.getOptions());
+    final KeySerde<K> keySerde = keySerdeFactory.buildKeySerde(
+        formats.getKeyFormat(),
+        physicalSchema,
+        queryContext
+    );
+    final Serde<GenericRow> valueSerde = queryBuilder.buildValueSerde(
+        formats.getValueFormat().getFormatInfo(),
+        physicalSchema,
+        queryContext
+    );
+    final Set<Integer> rowkeyIndexes =
+        SinkSchemaUtil.implicitAndKeyColumnIndexesInValueSchema(streamSink);
+    final String kafkaTopicName = streamSink.getTopicName();
+    kstream
+        .mapValues(row -> {
+          if (row == null) {
+            return null;
+          }
+          final List<Object> columns = new ArrayList<>();
+          for (int i = 0; i < row.getColumns().size(); i++) {
+            if (!rowkeyIndexes.contains(i)) {
+              columns.add(row.getColumns().get(i));
+            }
+          }
+          return new GenericRow(columns);
+        }).to(kafkaTopicName, Produced.with(keySerde, valueSerde));
+  }
+}

--- a/ksql-streams/src/main/java/io/confluent/ksql/execution/streams/TableSinkBuilder.java
+++ b/ksql-streams/src/main/java/io/confluent/ksql/execution/streams/TableSinkBuilder.java
@@ -1,0 +1,75 @@
+/*
+ * Copyright 2019 Confluent Inc.
+ *
+ * Licensed under the Confluent Community License (the "License"); you may not use
+ * this file except in compliance with the License.  You may obtain a copy of the
+ * License at
+ *
+ * http://www.confluent.io/confluent-community-license
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package io.confluent.ksql.execution.streams;
+
+import io.confluent.ksql.GenericRow;
+import io.confluent.ksql.execution.builder.KsqlQueryBuilder;
+import io.confluent.ksql.execution.context.QueryContext;
+import io.confluent.ksql.execution.plan.Formats;
+import io.confluent.ksql.execution.plan.TableSink;
+import io.confluent.ksql.execution.util.SinkSchemaUtil;
+import io.confluent.ksql.schema.ksql.LogicalSchema;
+import io.confluent.ksql.schema.ksql.PhysicalSchema;
+import io.confluent.ksql.serde.KeySerde;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Set;
+import org.apache.kafka.common.serialization.Serde;
+import org.apache.kafka.streams.kstream.KTable;
+import org.apache.kafka.streams.kstream.Produced;
+
+public final class TableSinkBuilder {
+  private TableSinkBuilder() {
+  }
+
+  public static <K> void build(
+      final KTable<K, GenericRow> ktable,
+      final TableSink<K> tableSink,
+      final KeySerdeFactory<K> keySerdeFactory,
+      final KsqlQueryBuilder queryBuilder) {
+    final QueryContext queryContext = tableSink.getProperties().getQueryContext();
+    final LogicalSchema schema = SinkSchemaUtil.sinkSchema(tableSink);
+    final Formats formats = tableSink.getFormats();
+    final PhysicalSchema physicalSchema = PhysicalSchema.from(schema, formats.getOptions());
+    final KeySerde<K> keySerde = keySerdeFactory.buildKeySerde(
+        formats.getKeyFormat(),
+        physicalSchema,
+        queryContext
+    );
+    final Serde<GenericRow> valueSerde = queryBuilder.buildValueSerde(
+        formats.getValueFormat().getFormatInfo(),
+        physicalSchema,
+        queryContext
+    );
+    final Set<Integer> rowkeyIndexes =
+        SinkSchemaUtil.implicitAndKeyColumnIndexesInValueSchema(tableSink);
+    final String kafkaTopicName = tableSink.getTopicName();
+    ktable.toStream()
+        .mapValues(row -> {
+              if (row == null) {
+                return null;
+              }
+              final List<Object> columns = new ArrayList<>();
+              for (int i = 0; i < row.getColumns().size(); i++) {
+                if (!rowkeyIndexes.contains(i)) {
+                  columns.add(row.getColumns().get(i));
+                }
+              }
+              return new GenericRow(columns);
+            }
+        ).to(kafkaTopicName, Produced.with(keySerde, valueSerde));
+  }
+}

--- a/ksql-streams/src/test/java/io/confluent/ksql/execution/streams/StreamSinkBuilderTest.java
+++ b/ksql-streams/src/test/java/io/confluent/ksql/execution/streams/StreamSinkBuilderTest.java
@@ -1,0 +1,192 @@
+/*
+ * Copyright 2019 Confluent Inc.
+ *
+ * Licensed under the Confluent Community License (the "License"); you may not use
+ * this file except in compliance with the License.  You may obtain a copy of the
+ * License at
+ *
+ * http://www.confluent.io/confluent-community-license
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package io.confluent.ksql.execution.streams;
+
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.nullValue;
+import static org.junit.Assert.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoMoreInteractions;
+import static org.mockito.Mockito.when;
+
+import io.confluent.ksql.GenericRow;
+import io.confluent.ksql.execution.builder.KsqlQueryBuilder;
+import io.confluent.ksql.execution.context.QueryContext;
+import io.confluent.ksql.execution.plan.DefaultExecutionStepProperties;
+import io.confluent.ksql.execution.plan.ExecutionStep;
+import io.confluent.ksql.execution.plan.Formats;
+import io.confluent.ksql.execution.plan.StreamSink;
+import io.confluent.ksql.query.QueryId;
+import io.confluent.ksql.schema.ksql.LogicalSchema;
+import io.confluent.ksql.schema.ksql.PhysicalSchema;
+import io.confluent.ksql.schema.ksql.types.SqlTypes;
+import io.confluent.ksql.serde.Format;
+import io.confluent.ksql.serde.FormatInfo;
+import io.confluent.ksql.serde.KeyFormat;
+import io.confluent.ksql.serde.KeySerde;
+import io.confluent.ksql.serde.SerdeOption;
+import io.confluent.ksql.serde.ValueFormat;
+import org.apache.kafka.common.serialization.Serde;
+import org.apache.kafka.connect.data.Struct;
+import org.apache.kafka.streams.kstream.KStream;
+import org.apache.kafka.streams.kstream.Produced;
+import org.apache.kafka.streams.kstream.ValueMapper;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Captor;
+import org.mockito.InOrder;
+import org.mockito.Mock;
+import org.mockito.Mockito;
+import org.mockito.junit.MockitoJUnit;
+import org.mockito.junit.MockitoRule;
+
+public class StreamSinkBuilderTest {
+  private static final String TOPIC = "TOPIC";
+  private static final LogicalSchema SCHEMA = LogicalSchema.builder()
+      .valueColumn("BLUE", SqlTypes.BIGINT)
+      .valueColumn("GREEN", SqlTypes.STRING)
+      .build()
+      .withMetaAndKeyColsInValue();
+  private static final PhysicalSchema PHYSICAL_SCHEMA =
+      PhysicalSchema.from(SCHEMA.withoutMetaAndKeyColsInValue(), SerdeOption.none());
+  private static final KeyFormat KEY_FORMAT = KeyFormat.nonWindowed(FormatInfo.of(Format.KAFKA));
+  private static final ValueFormat VALUE_FORMAT = ValueFormat.of(FormatInfo.of(Format.JSON));
+
+  @Mock
+  private KsqlQueryBuilder queryBuilder;
+  @Mock
+  private KeySerdeFactory<Struct> keySerdeFactory;
+  @Mock
+  private KStream<Struct, GenericRow> stream;
+  @Mock
+  private ExecutionStep<KStream<Struct, GenericRow>> source;
+  @Mock
+  private KeySerde<Struct> keySerde;
+  @Mock
+  private Serde<GenericRow> valSerde;
+  @Captor
+  private ArgumentCaptor<ValueMapper<GenericRow, GenericRow>> mapperCaptor;
+
+  private final QueryContext queryContext =
+      new QueryContext.Stacker(new QueryId("qid")).push("sink").getQueryContext();
+
+  private StreamSink<Struct> sink;
+
+  @Rule
+  public final MockitoRule mockitoRule = MockitoJUnit.rule();
+
+  @Before
+  @SuppressWarnings("unchecked")
+  public void setup() {
+    when(keySerdeFactory.buildKeySerde(any(), any(), any())).thenReturn(keySerde);
+    when(queryBuilder.buildValueSerde(any(), any(), any())).thenReturn(valSerde);
+    when(stream.mapValues(any(ValueMapper.class))).thenReturn(stream);
+    when(source.getProperties()).thenReturn(
+        new DefaultExecutionStepProperties(SCHEMA, mock(QueryContext.class))
+    );
+    sink = new StreamSink<>(
+        new DefaultExecutionStepProperties(SCHEMA, queryContext),
+        source,
+        Formats.of(KEY_FORMAT, VALUE_FORMAT, SerdeOption.none()),
+        TOPIC
+    );
+  }
+
+  @Test
+  @SuppressWarnings("unchecked")
+  public void shouldWriteOutStream() {
+    // When:
+    StreamSinkBuilder.build(stream, sink, keySerdeFactory, queryBuilder);
+
+    // Then:
+    final InOrder inOrder = Mockito.inOrder(stream);
+    inOrder.verify(stream).mapValues(any(ValueMapper.class));
+    inOrder.verify(stream).to(anyString(), any());
+    verifyNoMoreInteractions(stream);
+  }
+
+  @Test
+  public void shouldWriteOutStreamToCorrectTopic() {
+    // When:
+    StreamSinkBuilder.build(stream, sink, keySerdeFactory, queryBuilder);
+
+    // Then:
+    verify(stream).to(eq(TOPIC), any());
+  }
+
+  @Test
+  public void shouldBuildKeySerdeCorrectly() {
+    // When:
+    StreamSinkBuilder.build(stream, sink, keySerdeFactory, queryBuilder);
+
+    // Then:
+    verify(keySerdeFactory).buildKeySerde(KEY_FORMAT, PHYSICAL_SCHEMA, queryContext);
+  }
+
+  @Test
+  public void shouldBuildValueSerdeCorrectly() {
+    // When:
+    StreamSinkBuilder.build(stream, sink, keySerdeFactory, queryBuilder);
+
+    // Then:
+    verify(queryBuilder).buildValueSerde(
+        VALUE_FORMAT.getFormatInfo(),
+        PHYSICAL_SCHEMA,
+        queryContext
+    );
+  }
+
+  @Test
+  public void shouldWriteOutStreamWithCorrectSerdes() {
+    // When:
+    StreamSinkBuilder.build(stream, sink, keySerdeFactory, queryBuilder);
+
+    // Then:
+    verify(stream).to(anyString(), eq(Produced.with(keySerde, valSerde)));
+  }
+
+  @Test
+  public void shouldRemoveKeyAndTimeFieldsFromValue() {
+    // When:
+    StreamSinkBuilder.build(stream, sink, keySerdeFactory, queryBuilder);
+
+    // Then:
+    verify(stream).mapValues(mapperCaptor.capture());
+    final ValueMapper<GenericRow, GenericRow> mapper = mapperCaptor.getValue();
+    assertThat(
+        mapper.apply(new GenericRow(123, "456", 789, "101112")),
+        equalTo(new GenericRow(789, "101112"))
+    );
+  }
+
+  @Test
+  public void shouldIgnoreNullRowsWhenRemovingKeyAndTimeFieldsFromValue() {
+    // When:
+    StreamSinkBuilder.build(stream, sink, keySerdeFactory, queryBuilder);
+
+    // Then:
+    verify(stream).mapValues(mapperCaptor.capture());
+    final ValueMapper<GenericRow, GenericRow> mapper = mapperCaptor.getValue();
+    assertThat(mapper.apply(null), is(nullValue()));
+  }
+}

--- a/ksql-streams/src/test/java/io/confluent/ksql/execution/streams/StreamSinkBuilderTest.java
+++ b/ksql-streams/src/test/java/io/confluent/ksql/execution/streams/StreamSinkBuilderTest.java
@@ -34,7 +34,6 @@ import io.confluent.ksql.execution.plan.DefaultExecutionStepProperties;
 import io.confluent.ksql.execution.plan.ExecutionStep;
 import io.confluent.ksql.execution.plan.Formats;
 import io.confluent.ksql.execution.plan.StreamSink;
-import io.confluent.ksql.query.QueryId;
 import io.confluent.ksql.schema.ksql.LogicalSchema;
 import io.confluent.ksql.schema.ksql.PhysicalSchema;
 import io.confluent.ksql.schema.ksql.types.SqlTypes;
@@ -50,16 +49,16 @@ import org.apache.kafka.streams.kstream.KStream;
 import org.apache.kafka.streams.kstream.Produced;
 import org.apache.kafka.streams.kstream.ValueMapper;
 import org.junit.Before;
-import org.junit.Rule;
 import org.junit.Test;
+import org.junit.runner.RunWith;
 import org.mockito.ArgumentCaptor;
 import org.mockito.Captor;
 import org.mockito.InOrder;
 import org.mockito.Mock;
 import org.mockito.Mockito;
-import org.mockito.junit.MockitoJUnit;
-import org.mockito.junit.MockitoRule;
+import org.mockito.junit.MockitoJUnitRunner;
 
+@RunWith(MockitoJUnitRunner.class)
 public class StreamSinkBuilderTest {
   private static final String TOPIC = "TOPIC";
   private static final LogicalSchema SCHEMA = LogicalSchema.builder()
@@ -86,14 +85,10 @@ public class StreamSinkBuilderTest {
   private Serde<GenericRow> valSerde;
   @Captor
   private ArgumentCaptor<ValueMapper<GenericRow, GenericRow>> mapperCaptor;
-
-  private final QueryContext queryContext =
-      new QueryContext.Stacker(new QueryId("qid")).push("sink").getQueryContext();
+  @Mock
+  private QueryContext queryContext;
 
   private StreamSink<Struct> sink;
-
-  @Rule
-  public final MockitoRule mockitoRule = MockitoJUnit.rule();
 
   @Before
   @SuppressWarnings("unchecked")

--- a/ksql-streams/src/test/java/io/confluent/ksql/execution/streams/TableSinkBuilderTest.java
+++ b/ksql-streams/src/test/java/io/confluent/ksql/execution/streams/TableSinkBuilderTest.java
@@ -51,16 +51,16 @@ import org.apache.kafka.streams.kstream.KTable;
 import org.apache.kafka.streams.kstream.Produced;
 import org.apache.kafka.streams.kstream.ValueMapper;
 import org.junit.Before;
-import org.junit.Rule;
 import org.junit.Test;
+import org.junit.runner.RunWith;
 import org.mockito.ArgumentCaptor;
 import org.mockito.Captor;
 import org.mockito.InOrder;
 import org.mockito.Mock;
 import org.mockito.Mockito;
-import org.mockito.junit.MockitoJUnit;
-import org.mockito.junit.MockitoRule;
+import org.mockito.junit.MockitoJUnitRunner;
 
+@RunWith(MockitoJUnitRunner.class)
 public class TableSinkBuilderTest {
   private static final String TOPIC = "TOPIC";
   private static final LogicalSchema SCHEMA = LogicalSchema.builder()
@@ -94,9 +94,6 @@ public class TableSinkBuilderTest {
       new QueryContext.Stacker(new QueryId("qid")).push("sink").getQueryContext();
 
   private TableSink<Struct> sink;
-
-  @Rule
-  public final MockitoRule mockitoRule = MockitoJUnit.rule();
 
   @Before
   @SuppressWarnings("unchecked")

--- a/ksql-streams/src/test/java/io/confluent/ksql/execution/streams/TableSinkBuilderTest.java
+++ b/ksql-streams/src/test/java/io/confluent/ksql/execution/streams/TableSinkBuilderTest.java
@@ -1,0 +1,197 @@
+/*
+ * Copyright 2019 Confluent Inc.
+ *
+ * Licensed under the Confluent Community License (the "License"); you may not use
+ * this file except in compliance with the License.  You may obtain a copy of the
+ * License at
+ *
+ * http://www.confluent.io/confluent-community-license
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package io.confluent.ksql.execution.streams;
+
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.nullValue;
+import static org.junit.Assert.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoMoreInteractions;
+import static org.mockito.Mockito.when;
+
+import io.confluent.ksql.GenericRow;
+import io.confluent.ksql.execution.builder.KsqlQueryBuilder;
+import io.confluent.ksql.execution.context.QueryContext;
+import io.confluent.ksql.execution.plan.DefaultExecutionStepProperties;
+import io.confluent.ksql.execution.plan.ExecutionStep;
+import io.confluent.ksql.execution.plan.Formats;
+import io.confluent.ksql.execution.plan.TableSink;
+import io.confluent.ksql.query.QueryId;
+import io.confluent.ksql.schema.ksql.LogicalSchema;
+import io.confluent.ksql.schema.ksql.PhysicalSchema;
+import io.confluent.ksql.schema.ksql.types.SqlTypes;
+import io.confluent.ksql.serde.Format;
+import io.confluent.ksql.serde.FormatInfo;
+import io.confluent.ksql.serde.KeyFormat;
+import io.confluent.ksql.serde.KeySerde;
+import io.confluent.ksql.serde.SerdeOption;
+import io.confluent.ksql.serde.ValueFormat;
+import org.apache.kafka.common.serialization.Serde;
+import org.apache.kafka.connect.data.Struct;
+import org.apache.kafka.streams.kstream.KStream;
+import org.apache.kafka.streams.kstream.KTable;
+import org.apache.kafka.streams.kstream.Produced;
+import org.apache.kafka.streams.kstream.ValueMapper;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Captor;
+import org.mockito.InOrder;
+import org.mockito.Mock;
+import org.mockito.Mockito;
+import org.mockito.junit.MockitoJUnit;
+import org.mockito.junit.MockitoRule;
+
+public class TableSinkBuilderTest {
+  private static final String TOPIC = "TOPIC";
+  private static final LogicalSchema SCHEMA = LogicalSchema.builder()
+      .valueColumn("BLUE", SqlTypes.BIGINT)
+      .valueColumn("GREEN", SqlTypes.STRING)
+      .build()
+      .withMetaAndKeyColsInValue();
+  private static final PhysicalSchema PHYSICAL_SCHEMA =
+      PhysicalSchema.from(SCHEMA.withoutMetaAndKeyColsInValue(), SerdeOption.none());
+  private static final KeyFormat KEY_FORMAT = KeyFormat.nonWindowed(FormatInfo.of(Format.KAFKA));
+  private static final ValueFormat VALUE_FORMAT = ValueFormat.of(FormatInfo.of(Format.JSON));
+
+  @Mock
+  private KsqlQueryBuilder queryBuilder;
+  @Mock
+  private KeySerdeFactory<Struct> keySerdeFactory;
+  @Mock
+  private KTable<Struct, GenericRow>  table;
+  @Mock
+  private KStream<Struct, GenericRow>  stream;
+  @Mock
+  private ExecutionStep<KTable<Struct, GenericRow>> source;
+  @Mock
+  private KeySerde<Struct>  keySerde;
+  @Mock
+  private Serde<GenericRow> valSerde;
+  @Captor
+  private ArgumentCaptor<ValueMapper<GenericRow, GenericRow>> mapperCaptor;
+
+  private final QueryContext queryContext =
+      new QueryContext.Stacker(new QueryId("qid")).push("sink").getQueryContext();
+
+  private TableSink<Struct> sink;
+
+  @Rule
+  public final MockitoRule mockitoRule = MockitoJUnit.rule();
+
+  @Before
+  @SuppressWarnings("unchecked")
+  public void setup() {
+    when(keySerdeFactory.buildKeySerde(any(), any(), any())).thenReturn(keySerde);
+    when(queryBuilder.buildValueSerde(any(), any(), any())).thenReturn(valSerde);
+    when(table.toStream()).thenReturn(stream);
+    when(stream.mapValues(any(ValueMapper.class))).thenReturn(stream);
+    when(source.getProperties()).thenReturn(
+        new DefaultExecutionStepProperties(SCHEMA, mock(QueryContext.class))
+    );
+    sink = new TableSink<>(
+        new DefaultExecutionStepProperties(SCHEMA, queryContext),
+        source,
+        Formats.of(KEY_FORMAT, VALUE_FORMAT, SerdeOption.none()),
+        TOPIC
+    );
+  }
+
+  @Test
+  @SuppressWarnings("unchecked")
+  public void shouldWriteOutTable() {
+    // When:
+    TableSinkBuilder.build(table, sink, keySerdeFactory, queryBuilder);
+
+    // Then:
+    final InOrder inOrder = Mockito.inOrder(table, stream);
+    inOrder.verify(table).toStream();
+    inOrder.verify(stream).mapValues(any(ValueMapper.class));
+    inOrder.verify(stream).to(anyString(), any());
+    verifyNoMoreInteractions(stream);
+  }
+
+  @Test
+  public void shouldWriteOutTableToCorrectTopic() {
+    // When:
+    TableSinkBuilder.build(table, sink, keySerdeFactory, queryBuilder);
+
+    // Then:
+    verify(stream).to(eq(TOPIC), any());
+  }
+
+  @Test
+  public void shouldBuildKeySerdeCorrectly() {
+    // When:
+    TableSinkBuilder.build(table, sink, keySerdeFactory, queryBuilder);
+
+    // Then:
+    verify(keySerdeFactory).buildKeySerde(KEY_FORMAT, PHYSICAL_SCHEMA, queryContext);
+  }
+
+  @Test
+  public void shouldBuildValueSerdeCorrectly() {
+    // When:
+    TableSinkBuilder.build(table, sink, keySerdeFactory, queryBuilder);
+
+    // Then:
+    verify(queryBuilder).buildValueSerde(
+        VALUE_FORMAT.getFormatInfo(),
+        PHYSICAL_SCHEMA,
+        queryContext
+    );
+  }
+
+  @Test
+  public void shouldWriteOutTableWithCorrectSerdes() {
+    // When:
+    TableSinkBuilder.build(table, sink, keySerdeFactory, queryBuilder);
+
+    // Then:
+    verify(stream).to(anyString(), eq(Produced.with(keySerde, valSerde)));
+  }
+
+  @Test
+  public void shouldRemoveKeyAndTimeFieldsFromValue() {
+    // When:
+    TableSinkBuilder.build(table, sink, keySerdeFactory, queryBuilder);
+
+    // Then:
+    verify(stream).mapValues(mapperCaptor.capture());
+    final ValueMapper<GenericRow, GenericRow> mapper = mapperCaptor.getValue();
+    assertThat(
+        mapper.apply(new GenericRow(123, "456", 789, "101112")),
+        equalTo(new GenericRow(789, "101112"))
+    );
+  }
+
+  @Test
+  public void shouldIgnoreNullRowsWhenRemovingKeyAndTimeFieldsFromValue() {
+    // When:
+    TableSinkBuilder.build(table, sink, keySerdeFactory, queryBuilder);
+
+    // Then:
+    verify(stream).mapValues(mapperCaptor.capture());
+    final ValueMapper<GenericRow, GenericRow> mapper = mapperCaptor.getValue();
+    assertThat(mapper.apply(null), is(nullValue()));
+  }
+}


### PR DESCRIPTION
### Description 

This patch moves stream and table sinks (SchemaKX.into) into execution
plan builders. This change also moves computation of the rowkey/rowtime
indexes to be excluded from the output into the plan builder.

### Testing done 

Added unit tests for step builders.

### Reviewer checklist
- [ ] Ensure docs are updated if necessary. (eg. if a user visible feature is being added or changed).
- [ ] Ensure relevant issues are linked (description should include text like "Fixes #<issue number>")

