### PR TITLE
feat: move joins to plan builder

### DIFF
--- a/ksql-engine/src/main/java/io/confluent/ksql/streams/StreamsFactories.java
+++ b/ksql-engine/src/main/java/io/confluent/ksql/streams/StreamsFactories.java
@@ -16,6 +16,7 @@
 package io.confluent.ksql.streams;
 
 import io.confluent.ksql.execution.streams.GroupedFactory;
+import io.confluent.ksql.execution.streams.JoinedFactory;
 import io.confluent.ksql.execution.streams.MaterializedFactory;
 import io.confluent.ksql.util.KsqlConfig;
 import java.util.Objects;

--- a/ksql-engine/src/test/java/io/confluent/ksql/planner/plan/JoinNodeTest.java
+++ b/ksql-engine/src/test/java/io/confluent/ksql/planner/plan/JoinNodeTest.java
@@ -25,6 +25,7 @@ import static org.hamcrest.Matchers.is;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyBoolean;
 import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.ArgumentMatchers.same;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
@@ -360,9 +361,9 @@ public class JoinNodeTest {
         eq(WITHIN_EXPRESSION.get().joinWindow()),
         eq(VALUE_FORMAT),
         eq(OTHER_FORMAT),
-        any(),
-        any(),
-        eq(CONTEXT_STACKER));
+        eq(CONTEXT_STACKER),
+        same(ksqlStreamBuilder)
+    );
   }
 
   @Test
@@ -392,9 +393,9 @@ public class JoinNodeTest {
         eq(WITHIN_EXPRESSION.get().joinWindow()),
         eq(VALUE_FORMAT),
         eq(OTHER_FORMAT),
-        any(),
-        any(),
-        eq(CONTEXT_STACKER));
+        eq(CONTEXT_STACKER),
+        same(ksqlStreamBuilder)
+    );
   }
 
   @Test
@@ -424,9 +425,9 @@ public class JoinNodeTest {
         eq(WITHIN_EXPRESSION.get().joinWindow()),
         eq(VALUE_FORMAT),
         eq(OTHER_FORMAT),
-        any(),
-        any(),
-        eq(CONTEXT_STACKER));
+        eq(CONTEXT_STACKER),
+        same(ksqlStreamBuilder)
+    );
   }
 
   @Test
@@ -565,8 +566,9 @@ public class JoinNodeTest {
         eq(JOIN_SCHEMA),
         eq(leftJoinField),
         eq(VALUE_FORMAT),
-        any(),
-        eq(CONTEXT_STACKER));
+        eq(CONTEXT_STACKER),
+        same(ksqlStreamBuilder)
+    );
   }
 
   @Test
@@ -594,8 +596,9 @@ public class JoinNodeTest {
         eq(JOIN_SCHEMA),
         eq(leftJoinField),
         eq(VALUE_FORMAT),
-        any(),
-        eq(CONTEXT_STACKER));
+        eq(CONTEXT_STACKER),
+        same(ksqlStreamBuilder)
+    );
   }
 
   @Test
@@ -623,8 +626,9 @@ public class JoinNodeTest {
         eq(JOIN_SCHEMA),
         eq(leftJoinField),
         eq(VALUE_FORMAT),
-        any(),
-        eq(CONTEXT_STACKER));
+        eq(CONTEXT_STACKER),
+        same(ksqlStreamBuilder)
+    );
   }
 
   @Test
@@ -908,64 +912,6 @@ public class JoinNodeTest {
         anyBoolean(),
         any()
     );
-  }
-
-  @Test
-  public void shouldBuildLeftRowSerde() {
-    // Given:
-    setupStream(left, leftSchemaKStream);
-    setupStream(right, rightSchemaKStream);
-
-    final JoinNode joinNode = new JoinNode(
-        nodeId,
-        JoinNode.JoinType.LEFT,
-        left,
-        right,
-        LEFT_JOIN_FIELD_NAME,
-        RIGHT_JOIN_FIELD_NAME,
-        WITHIN_EXPRESSION
-    );
-
-    // When:
-    joinNode.buildStream(ksqlStreamBuilder);
-
-    // Then:
-    final PhysicalSchema expected = PhysicalSchema
-        .from(LEFT_NODE_SCHEMA.withoutAlias(), SerdeOption.none());
-
-    verify(ksqlStreamBuilder).buildValueSerde(
-        any(),
-        eq(expected),
-        any());
-  }
-
-  @Test
-  public void shouldBuildRightRowSerde() {
-    // Given:
-    setupStream(left, leftSchemaKStream);
-    setupStream(right, rightSchemaKStream);
-
-    final JoinNode joinNode = new JoinNode(
-        nodeId,
-        JoinNode.JoinType.LEFT,
-        left,
-        right,
-        LEFT_JOIN_FIELD_NAME,
-        RIGHT_JOIN_FIELD_NAME,
-        WITHIN_EXPRESSION
-    );
-
-    // When:
-    joinNode.buildStream(ksqlStreamBuilder);
-
-    // Then:
-    final PhysicalSchema expected = PhysicalSchema
-        .from(RIGHT_NODE_SCHEMA.withoutAlias(), SerdeOption.none());
-
-    verify(ksqlStreamBuilder).buildValueSerde(
-        any(),
-        eq(expected),
-        any());
   }
 
   @Test

--- a/ksql-engine/src/test/java/io/confluent/ksql/streams/JoinedFactoryTest.java
+++ b/ksql-engine/src/test/java/io/confluent/ksql/streams/JoinedFactoryTest.java
@@ -22,6 +22,7 @@ import static org.mockito.Mockito.when;
 
 import com.google.common.collect.ImmutableMap;
 import io.confluent.ksql.GenericRow;
+import io.confluent.ksql.execution.streams.JoinedFactory;
 import io.confluent.ksql.util.KsqlConfig;
 import org.apache.kafka.common.serialization.Serde;
 import org.apache.kafka.streams.StreamsConfig;

--- a/ksql-engine/src/test/java/io/confluent/ksql/structured/SchemaKTableTest.java
+++ b/ksql-engine/src/test/java/io/confluent/ksql/structured/SchemaKTableTest.java
@@ -54,6 +54,7 @@ import io.confluent.ksql.execution.plan.TableFilter;
 import io.confluent.ksql.execution.streams.ExecutionStepFactory;
 import io.confluent.ksql.execution.streams.MaterializedFactory;
 import io.confluent.ksql.execution.streams.StreamsUtil;
+import io.confluent.ksql.execution.streams.KsqlValueJoiner;
 import io.confluent.ksql.execution.util.StructKeyUtil;
 import io.confluent.ksql.function.InternalFunctionRegistry;
 import io.confluent.ksql.logging.processing.ProcessingLogContext;
@@ -78,7 +79,7 @@ import io.confluent.ksql.serde.KeySerde;
 import io.confluent.ksql.serde.SerdeOption;
 import io.confluent.ksql.serde.ValueFormat;
 import io.confluent.ksql.execution.streams.GroupedFactory;
-import io.confluent.ksql.streams.JoinedFactory;
+import io.confluent.ksql.execution.streams.JoinedFactory;
 import io.confluent.ksql.streams.StreamsFactories;
 import io.confluent.ksql.structured.SchemaKStream.Type;
 import io.confluent.ksql.testutils.AnalysisTestUtil;
@@ -555,7 +556,7 @@ public class SchemaKTableTest {
   @Test
   public void shouldPerformTableToTableLeftJoin() {
     expect(mockKTable.leftJoin(eq(secondSchemaKTable.getKtable()),
-                               anyObject(SchemaKStream.KsqlValueJoiner.class)))
+                               anyObject(KsqlValueJoiner.class)))
         .andReturn(EasyMock.niceMock(KTable.class));
 
     replay(mockKTable);
@@ -581,7 +582,7 @@ public class SchemaKTableTest {
   @Test
   public void shouldPerformTableToTableInnerJoin() {
     expect(mockKTable.join(eq(secondSchemaKTable.getKtable()),
-                           anyObject(SchemaKStream.KsqlValueJoiner.class)))
+                           anyObject(KsqlValueJoiner.class)))
         .andReturn(EasyMock.niceMock(KTable.class));
 
     replay(mockKTable);
@@ -605,7 +606,7 @@ public class SchemaKTableTest {
   @Test
   public void shouldPerformTableToTableOuterJoin() {
     expect(mockKTable.outerJoin(eq(secondSchemaKTable.getKtable()),
-                                anyObject(SchemaKStream.KsqlValueJoiner.class)))
+                                anyObject(KsqlValueJoiner.class)))
         .andReturn(EasyMock.niceMock(KTable.class));
 
     replay(mockKTable);
@@ -639,15 +640,15 @@ public class SchemaKTableTest {
     final KTable resultTable = EasyMock.niceMock(KTable.class);
     expect(mockKTable.outerJoin(
         eq(secondSchemaKTable.getKtable()),
-        anyObject(SchemaKStream.KsqlValueJoiner.class))
+        anyObject(KsqlValueJoiner.class))
     ).andReturn(resultTable);
     expect(mockKTable.join(
         eq(secondSchemaKTable.getKtable()),
-        anyObject(SchemaKStream.KsqlValueJoiner.class))
+        anyObject(KsqlValueJoiner.class))
     ).andReturn(resultTable);
     expect(mockKTable.leftJoin(
         eq(secondSchemaKTable.getKtable()),
-        anyObject(SchemaKStream.KsqlValueJoiner.class))
+        anyObject(KsqlValueJoiner.class))
     ).andReturn(resultTable);
     replay(mockKTable);
 

--- a/ksql-execution/src/main/java/io/confluent/ksql/execution/plan/StreamStreamJoin.java
+++ b/ksql-execution/src/main/java/io/confluent/ksql/execution/plan/StreamStreamJoin.java
@@ -16,20 +16,22 @@ package io.confluent.ksql.execution.plan;
 
 import com.google.common.collect.ImmutableList;
 import com.google.errorprone.annotations.Immutable;
+import io.confluent.ksql.GenericRow;
 import io.confluent.ksql.execution.builder.KsqlQueryBuilder;
 import java.time.Duration;
 import java.util.List;
 import java.util.Objects;
+import org.apache.kafka.streams.kstream.KStream;
 
 @Immutable
-public class StreamStreamJoin<S> implements ExecutionStep<S> {
+public class StreamStreamJoin<K> implements ExecutionStep<KStream<K, GenericRow>> {
 
   private final ExecutionStepProperties properties;
   private final JoinType joinType;
   private final Formats leftFormats;
   private final Formats rightFormats;
-  private final ExecutionStep<S> left;
-  private final ExecutionStep<S> right;
+  private final ExecutionStep<KStream<K, GenericRow>> left;
+  private final ExecutionStep<KStream<K, GenericRow>> right;
   private final Duration before;
   private final Duration after;
 
@@ -38,8 +40,8 @@ public class StreamStreamJoin<S> implements ExecutionStep<S> {
       final JoinType joinType,
       final Formats leftFormats,
       final Formats rightFormats,
-      final ExecutionStep<S> left,
-      final ExecutionStep<S> right,
+      final ExecutionStep<KStream<K, GenericRow>> left,
+      final ExecutionStep<KStream<K, GenericRow>> right,
       final Duration before,
       final Duration after) {
     this.properties = Objects.requireNonNull(properties, "properties");
@@ -63,8 +65,36 @@ public class StreamStreamJoin<S> implements ExecutionStep<S> {
   }
 
   @Override
-  public S build(final KsqlQueryBuilder streamsBuilder) {
+  public KStream<K, GenericRow> build(final KsqlQueryBuilder streamsBuilder) {
     throw new UnsupportedOperationException();
+  }
+
+  public Formats getLeftFormats() {
+    return leftFormats;
+  }
+
+  public Formats getRightFormats() {
+    return rightFormats;
+  }
+
+  public ExecutionStep<KStream<K, GenericRow>> getLeft() {
+    return left;
+  }
+
+  public ExecutionStep<KStream<K, GenericRow>> getRight() {
+    return right;
+  }
+
+  public JoinType getJoinType() {
+    return joinType;
+  }
+
+  public Duration getAfter() {
+    return after;
+  }
+
+  public Duration getBefore() {
+    return before;
   }
 
   // CHECKSTYLE_RULES.OFF: CyclomaticComplexity

--- a/ksql-execution/src/main/java/io/confluent/ksql/execution/plan/StreamTableJoin.java
+++ b/ksql-execution/src/main/java/io/confluent/ksql/execution/plan/StreamTableJoin.java
@@ -16,25 +16,28 @@ package io.confluent.ksql.execution.plan;
 
 import com.google.common.collect.ImmutableList;
 import com.google.errorprone.annotations.Immutable;
+import io.confluent.ksql.GenericRow;
 import io.confluent.ksql.execution.builder.KsqlQueryBuilder;
 import java.util.List;
 import java.util.Objects;
+import org.apache.kafka.streams.kstream.KStream;
+import org.apache.kafka.streams.kstream.KTable;
 
 @Immutable
-public class StreamTableJoin<S, T> implements ExecutionStep<S> {
+public class StreamTableJoin<K> implements ExecutionStep<KStream<K, GenericRow>> {
 
   private final ExecutionStepProperties properties;
   private final JoinType joinType;
   private final Formats formats;
-  private final ExecutionStep<S> left;
-  private final ExecutionStep<T> right;
+  private final ExecutionStep<KStream<K, GenericRow>> left;
+  private final ExecutionStep<KTable<K, GenericRow>> right;
 
   public StreamTableJoin(
       final ExecutionStepProperties properties,
       final JoinType joinType,
       final Formats formats,
-      final ExecutionStep<S> left,
-      final ExecutionStep<T> right) {
+      final ExecutionStep<KStream<K, GenericRow>> left,
+      final ExecutionStep<KTable<K, GenericRow>> right) {
     this.properties = Objects.requireNonNull(properties, "properties");
     this.formats = Objects.requireNonNull(formats, "formats");
     this.joinType = Objects.requireNonNull(joinType, "joinType");
@@ -53,8 +56,24 @@ public class StreamTableJoin<S, T> implements ExecutionStep<S> {
   }
 
   @Override
-  public S build(final KsqlQueryBuilder streamsBuilder) {
+  public KStream<K, GenericRow> build(final KsqlQueryBuilder streamsBuilder) {
     throw new UnsupportedOperationException();
+  }
+
+  public Formats getFormats() {
+    return formats;
+  }
+
+  public ExecutionStep<KStream<K, GenericRow>> getLeft() {
+    return left;
+  }
+
+  public ExecutionStep<KTable<K, GenericRow>> getRight() {
+    return right;
+  }
+
+  public JoinType getJoinType() {
+    return joinType;
   }
 
   @Override
@@ -65,7 +84,7 @@ public class StreamTableJoin<S, T> implements ExecutionStep<S> {
     if (o == null || getClass() != o.getClass()) {
       return false;
     }
-    final StreamTableJoin<?, ?> that = (StreamTableJoin<?, ?>) o;
+    final StreamTableJoin<?> that = (StreamTableJoin<?>) o;
     return Objects.equals(properties, that.properties)
         && joinType == that.joinType
         && Objects.equals(formats, that.formats)

--- a/ksql-execution/src/main/java/io/confluent/ksql/execution/plan/TableTableJoin.java
+++ b/ksql-execution/src/main/java/io/confluent/ksql/execution/plan/TableTableJoin.java
@@ -16,22 +16,24 @@ package io.confluent.ksql.execution.plan;
 
 import com.google.common.collect.ImmutableList;
 import com.google.errorprone.annotations.Immutable;
+import io.confluent.ksql.GenericRow;
 import io.confluent.ksql.execution.builder.KsqlQueryBuilder;
 import java.util.List;
 import java.util.Objects;
+import org.apache.kafka.streams.kstream.KTable;
 
 @Immutable
-public class TableTableJoin<T> implements ExecutionStep<T> {
+public class TableTableJoin<K> implements ExecutionStep<KTable<K, GenericRow>> {
   private final ExecutionStepProperties properties;
   private final JoinType joinType;
-  private final ExecutionStep<T> left;
-  private final ExecutionStep<T> right;
+  private final ExecutionStep<KTable<K, GenericRow>> left;
+  private final ExecutionStep<KTable<K, GenericRow>> right;
 
   public TableTableJoin(
       final ExecutionStepProperties properties,
       final JoinType joinType,
-      final ExecutionStep<T> left,
-      final ExecutionStep<T> right) {
+      final ExecutionStep<KTable<K, GenericRow>> left,
+      final ExecutionStep<KTable<K, GenericRow>> right) {
     this.properties = Objects.requireNonNull(properties, "properties");
     this.joinType = Objects.requireNonNull(joinType, "joinType");
     this.left = Objects.requireNonNull(left, "left");
@@ -48,8 +50,20 @@ public class TableTableJoin<T> implements ExecutionStep<T> {
     return ImmutableList.of(left, right);
   }
 
+  public ExecutionStep<KTable<K, GenericRow>> getLeft() {
+    return left;
+  }
+
+  public ExecutionStep<KTable<K, GenericRow>> getRight() {
+    return right;
+  }
+
+  public JoinType getJoinType() {
+    return joinType;
+  }
+
   @Override
-  public T build(final KsqlQueryBuilder builder) {
+  public KTable<K, GenericRow> build(final KsqlQueryBuilder builder) {
     throw new UnsupportedOperationException();
   }
 

--- a/ksql-streams/src/main/java/io/confluent/ksql/execution/streams/ExecutionStepFactory.java
+++ b/ksql-streams/src/main/java/io/confluent/ksql/execution/streams/ExecutionStepFactory.java
@@ -174,14 +174,13 @@ public final class ExecutionStepFactory {
     );
   }
 
-  public static <K> StreamTableJoin<KStream<K, GenericRow>, KTable<K, GenericRow>>
-      streamTableJoin(
-          final QueryContext.Stacker stacker,
-          final JoinType joinType,
-          final Formats formats,
-          final ExecutionStep<KStream<K, GenericRow>> left,
-          final ExecutionStep<KTable<K, GenericRow>> right,
-          final LogicalSchema resultSchema
+  public static <K> StreamTableJoin<K> streamTableJoin(
+      final QueryContext.Stacker stacker,
+      final JoinType joinType,
+      final Formats formats,
+      final ExecutionStep<KStream<K, GenericRow>> left,
+      final ExecutionStep<KTable<K, GenericRow>> right,
+      final LogicalSchema resultSchema
   ) {
     final QueryContext queryContext = stacker.getQueryContext();
     return new StreamTableJoin<>(
@@ -193,7 +192,7 @@ public final class ExecutionStepFactory {
     );
   }
 
-  public static <K> StreamStreamJoin<KStream<K, GenericRow>> streamStreamJoin(
+  public static <K> StreamStreamJoin<K> streamStreamJoin(
       final QueryContext.Stacker stacker,
       final JoinType joinType,
       final Formats leftFormats,
@@ -286,7 +285,7 @@ public final class ExecutionStepFactory {
     );
   }
 
-  public static <K> TableTableJoin<KTable<K, GenericRow>> tableTableJoin(
+  public static <K> TableTableJoin<K> tableTableJoin(
       final QueryContext.Stacker stacker,
       final JoinType joinType,
       final ExecutionStep<KTable<K, GenericRow>> left,

--- a/ksql-streams/src/main/java/io/confluent/ksql/execution/streams/JoinedFactory.java
+++ b/ksql-streams/src/main/java/io/confluent/ksql/execution/streams/JoinedFactory.java
@@ -13,9 +13,8 @@
  * specific language governing permissions and limitations under the License.
  */
 
-package io.confluent.ksql.streams;
+package io.confluent.ksql.execution.streams;
 
-import io.confluent.ksql.execution.streams.StreamsUtil;
 import io.confluent.ksql.util.KsqlConfig;
 import org.apache.kafka.common.serialization.Serde;
 import org.apache.kafka.streams.kstream.Joined;

--- a/ksql-streams/src/main/java/io/confluent/ksql/execution/streams/KsqlValueJoiner.java
+++ b/ksql-streams/src/main/java/io/confluent/ksql/execution/streams/KsqlValueJoiner.java
@@ -1,0 +1,75 @@
+/*
+ * Copyright 2019 Confluent Inc.
+ *
+ * Licensed under the Confluent Community License (the "License"); you may not use
+ * this file except in compliance with the License.  You may obtain a copy of the
+ * License at
+ *
+ * http://www.confluent.io/confluent-community-license
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package io.confluent.ksql.execution.streams;
+
+import io.confluent.ksql.GenericRow;
+import io.confluent.ksql.schema.ksql.LogicalSchema;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Objects;
+import org.apache.kafka.streams.kstream.ValueJoiner;
+
+public final class KsqlValueJoiner implements ValueJoiner<GenericRow, GenericRow, GenericRow> {
+  private final LogicalSchema leftSchema;
+  private final LogicalSchema rightSchema;
+
+  KsqlValueJoiner(final LogicalSchema leftSchema, final LogicalSchema rightSchema) {
+    this.leftSchema = Objects.requireNonNull(leftSchema, "leftSchema");
+    this.rightSchema = Objects.requireNonNull(rightSchema, "rightSchema");
+  }
+
+  @Override
+  public GenericRow apply(final GenericRow left, final GenericRow right) {
+    final List<Object> columns = new ArrayList<>();
+    if (left != null) {
+      columns.addAll(left.getColumns());
+    } else {
+      fillWithNulls(columns, leftSchema.value().size());
+    }
+
+    if (right != null) {
+      columns.addAll(right.getColumns());
+    } else {
+      fillWithNulls(columns, rightSchema.value().size());
+    }
+
+    return new GenericRow(columns);
+  }
+
+  private static void fillWithNulls(final List<Object> columns, final int numToFill) {
+    for (int i = 0; i < numToFill; ++i) {
+      columns.add(null);
+    }
+  }
+
+  @Override
+  public boolean equals(final Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    final KsqlValueJoiner that = (KsqlValueJoiner) o;
+    return Objects.equals(leftSchema, that.leftSchema)
+        && Objects.equals(rightSchema, that.rightSchema);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(leftSchema, rightSchema);
+  }
+}

--- a/ksql-streams/src/main/java/io/confluent/ksql/execution/streams/StreamStreamJoinBuilder.java
+++ b/ksql-streams/src/main/java/io/confluent/ksql/execution/streams/StreamStreamJoinBuilder.java
@@ -1,0 +1,93 @@
+/*
+ * Copyright 2019 Confluent Inc.
+ *
+ * Licensed under the Confluent Community License (the "License"); you may not use
+ * this file except in compliance with the License.  You may obtain a copy of the
+ * License at
+ *
+ * http://www.confluent.io/confluent-community-license
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package io.confluent.ksql.execution.streams;
+
+import io.confluent.ksql.GenericRow;
+import io.confluent.ksql.execution.builder.KsqlQueryBuilder;
+import io.confluent.ksql.execution.context.QueryContext;
+import io.confluent.ksql.execution.plan.Formats;
+import io.confluent.ksql.execution.plan.StreamStreamJoin;
+import io.confluent.ksql.schema.ksql.LogicalSchema;
+import io.confluent.ksql.schema.ksql.PhysicalSchema;
+import io.confluent.ksql.serde.KeySerde;
+import org.apache.kafka.common.serialization.Serde;
+import org.apache.kafka.streams.kstream.JoinWindows;
+import org.apache.kafka.streams.kstream.Joined;
+import org.apache.kafka.streams.kstream.KStream;
+
+public final class StreamStreamJoinBuilder {
+  private static final String LEFT_SERDE_CTX = "left";
+  private static final String RIGHT_SERDE_CTX = "right";
+
+  private StreamStreamJoinBuilder() {
+  }
+
+  public static <K> KStream<K, GenericRow> build(
+      final KStream<K, GenericRow> left,
+      final KStream<K, GenericRow> right,
+      final StreamStreamJoin<K> join,
+      final KeySerdeFactory<K> keySerdeFactory,
+      final KsqlQueryBuilder queryBuilder,
+      final JoinedFactory joinedFactory) {
+    final Formats leftFormats = join.getLeftFormats();
+    final QueryContext queryContext = join.getProperties().getQueryContext();
+    final QueryContext.Stacker stacker = QueryContext.Stacker.of(queryContext);
+    final LogicalSchema leftSchema = join.getLeft().getProperties().getSchema();
+    final PhysicalSchema leftPhysicalSchema = PhysicalSchema.from(
+        leftSchema.withoutAlias(),
+        leftFormats.getOptions()
+    );
+    final Serde<GenericRow> leftSerde = queryBuilder.buildValueSerde(
+        leftFormats.getValueFormat().getFormatInfo(),
+        leftPhysicalSchema,
+        stacker.push(LEFT_SERDE_CTX).getQueryContext()
+    );
+    final Formats rightFormats = join.getRightFormats();
+    final LogicalSchema rightSchema = join.getRight().getProperties().getSchema();
+    final PhysicalSchema rightPhysicalSchema = PhysicalSchema.from(
+        rightSchema.withoutAlias(),
+        rightFormats.getOptions()
+    );
+    final Serde<GenericRow> rightSerde = queryBuilder.buildValueSerde(
+        rightFormats.getValueFormat().getFormatInfo(),
+        rightPhysicalSchema,
+        stacker.push(RIGHT_SERDE_CTX).getQueryContext()
+    );
+    final KeySerde<K> keySerde = keySerdeFactory.buildKeySerde(
+        leftFormats.getKeyFormat(),
+        leftPhysicalSchema,
+        queryContext
+    );
+    final Joined<K, GenericRow, GenericRow> joined = joinedFactory.create(
+        keySerde,
+        leftSerde,
+        rightSerde,
+        StreamsUtil.buildOpName(queryContext)
+    );
+    final KsqlValueJoiner joiner = new KsqlValueJoiner(leftSchema, rightSchema);
+    final JoinWindows joinWindows = JoinWindows.of(join.getBefore()).after(join.getAfter());
+    switch (join.getJoinType()) {
+      case LEFT:
+        return left.leftJoin(right, joiner, joinWindows, joined);
+      case OUTER:
+        return left.outerJoin(right, joiner, joinWindows, joined);
+      case INNER:
+        return left.join(right, joiner, joinWindows, joined);
+      default:
+        throw new IllegalStateException("invalid join type");
+    }
+  }
+}

--- a/ksql-streams/src/main/java/io/confluent/ksql/execution/streams/StreamTableJoinBuilder.java
+++ b/ksql-streams/src/main/java/io/confluent/ksql/execution/streams/StreamTableJoinBuilder.java
@@ -1,0 +1,79 @@
+/*
+ * Copyright 2019 Confluent Inc.
+ *
+ * Licensed under the Confluent Community License (the "License"); you may not use
+ * this file except in compliance with the License.  You may obtain a copy of the
+ * License at
+ *
+ * http://www.confluent.io/confluent-community-license
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package io.confluent.ksql.execution.streams;
+
+import io.confluent.ksql.GenericRow;
+import io.confluent.ksql.execution.builder.KsqlQueryBuilder;
+import io.confluent.ksql.execution.context.QueryContext;
+import io.confluent.ksql.execution.plan.Formats;
+import io.confluent.ksql.execution.plan.StreamTableJoin;
+import io.confluent.ksql.schema.ksql.LogicalSchema;
+import io.confluent.ksql.schema.ksql.PhysicalSchema;
+import io.confluent.ksql.serde.KeySerde;
+import org.apache.kafka.common.serialization.Serde;
+import org.apache.kafka.streams.kstream.Joined;
+import org.apache.kafka.streams.kstream.KStream;
+import org.apache.kafka.streams.kstream.KTable;
+
+public final class StreamTableJoinBuilder {
+  private static final String SERDE_CTX = "left";
+
+  private StreamTableJoinBuilder() {
+  }
+
+  public static <K> KStream<K, GenericRow> build(
+      final KStream<K, GenericRow> left,
+      final KTable<K, GenericRow> right,
+      final StreamTableJoin<K> join,
+      final KeySerdeFactory<K> keySerdeFactory,
+      final KsqlQueryBuilder queryBuilder,
+      final JoinedFactory joinedFactory) {
+    final Formats leftFormats = join.getFormats();
+    final QueryContext queryContext = join.getProperties().getQueryContext();
+    final QueryContext.Stacker stacker = QueryContext.Stacker.of(queryContext);
+    final LogicalSchema leftSchema = join.getLeft().getProperties().getSchema();
+    final PhysicalSchema leftPhysicalSchema = PhysicalSchema.from(
+        leftSchema.withoutAlias(),
+        leftFormats.getOptions()
+    );
+    final Serde<GenericRow> leftSerde = queryBuilder.buildValueSerde(
+        leftFormats.getValueFormat().getFormatInfo(),
+        leftPhysicalSchema,
+        stacker.push(SERDE_CTX).getQueryContext()
+    );
+    final KeySerde<K> keySerde = keySerdeFactory.buildKeySerde(
+        leftFormats.getKeyFormat(),
+        leftPhysicalSchema,
+        queryContext
+    );
+    final Joined<K, GenericRow, GenericRow> joined = joinedFactory.create(
+        keySerde,
+        leftSerde,
+        null,
+        StreamsUtil.buildOpName(queryContext)
+    );
+    final LogicalSchema rightSchema = join.getRight().getProperties().getSchema();
+    final KsqlValueJoiner joiner = new KsqlValueJoiner(leftSchema, rightSchema);
+    switch (join.getJoinType()) {
+      case LEFT:
+        return left.leftJoin(right, joiner, joined);
+      case INNER:
+        return left.join(right, joiner, joined);
+      default:
+        throw new IllegalStateException("invalid join type");
+    }
+  }
+}

--- a/ksql-streams/src/main/java/io/confluent/ksql/execution/streams/TableTableJoinBuilder.java
+++ b/ksql-streams/src/main/java/io/confluent/ksql/execution/streams/TableTableJoinBuilder.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright 2019 Confluent Inc.
+ *
+ * Licensed under the Confluent Community License (the "License"); you may not use
+ * this file except in compliance with the License.  You may obtain a copy of the
+ * License at
+ *
+ * http://www.confluent.io/confluent-community-license
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package io.confluent.ksql.execution.streams;
+
+import io.confluent.ksql.GenericRow;
+import io.confluent.ksql.execution.plan.TableTableJoin;
+import io.confluent.ksql.schema.ksql.LogicalSchema;
+import org.apache.kafka.streams.kstream.KTable;
+
+public final class TableTableJoinBuilder {
+  private TableTableJoinBuilder() {
+  }
+
+  public static <K> KTable<K, GenericRow> build(
+      final KTable<K, GenericRow> left,
+      final KTable<K, GenericRow> right,
+      final TableTableJoin join) {
+    final LogicalSchema leftSchema = join.getLeft().getProperties().getSchema();
+    final LogicalSchema rightSchema = join.getRight().getProperties().getSchema();
+    final KsqlValueJoiner joiner = new KsqlValueJoiner(leftSchema, rightSchema);
+    switch (join.getJoinType()) {
+      case LEFT:
+        return left.leftJoin(right, joiner);
+      case INNER:
+        return left.join(right, joiner);
+      case OUTER:
+        return left.outerJoin(right, joiner);
+      default:
+        throw new IllegalStateException("invalid join type");
+    }
+  }
+}

--- a/ksql-streams/src/test/java/io/confluent/ksql/execution/streams/KsqlValueJoinerTest.java
+++ b/ksql-streams/src/test/java/io/confluent/ksql/execution/streams/KsqlValueJoinerTest.java
@@ -13,7 +13,7 @@
  * specific language governing permissions and limitations under the License.
  */
 
-package io.confluent.ksql.structured;
+package io.confluent.ksql.execution.streams;
 
 import static org.junit.Assert.assertEquals;
 
@@ -47,8 +47,7 @@ public class KsqlValueJoinerTest {
 
   @Test
   public void shouldJoinValueBothNonNull() {
-    final SchemaKStream.KsqlValueJoiner joiner = new SchemaKStream.KsqlValueJoiner(leftSchema,
-                                                                             rightSchema);
+    final KsqlValueJoiner joiner = new KsqlValueJoiner(leftSchema, rightSchema);
 
     final GenericRow joined = joiner.apply(leftRow, rightRow);
     final List<Object> expected = Arrays.asList(12L, "foobar", 20L, "baz");
@@ -57,8 +56,7 @@ public class KsqlValueJoinerTest {
 
   @Test
   public void shouldJoinValueRightEmpty() {
-    final SchemaKStream.KsqlValueJoiner joiner = new SchemaKStream.KsqlValueJoiner(leftSchema,
-                                                                             rightSchema);
+    final KsqlValueJoiner joiner = new KsqlValueJoiner(leftSchema, rightSchema);
 
     final GenericRow joined = joiner.apply(leftRow, null);
     final List<Object> expected = Arrays.asList(12L, "foobar", null, null);
@@ -67,8 +65,7 @@ public class KsqlValueJoinerTest {
 
   @Test
   public void shouldJoinValueLeftEmpty() {
-    final SchemaKStream.KsqlValueJoiner joiner = new SchemaKStream.KsqlValueJoiner(leftSchema,
-                                                                             rightSchema);
+    final KsqlValueJoiner joiner = new KsqlValueJoiner(leftSchema, rightSchema);
 
     final GenericRow joined = joiner.apply(null, rightRow);
     final List<Object> expected = Arrays.asList(null, null, 20L, "baz");

--- a/ksql-streams/src/test/java/io/confluent/ksql/execution/streams/StreamStreamJoinBuilderTest.java
+++ b/ksql-streams/src/test/java/io/confluent/ksql/execution/streams/StreamStreamJoinBuilderTest.java
@@ -1,0 +1,331 @@
+package io.confluent.ksql.execution.streams;
+
+import static org.hamcrest.Matchers.is;
+import static org.junit.Assert.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.ArgumentMatchers.same;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoMoreInteractions;
+import static org.mockito.Mockito.when;
+
+import io.confluent.ksql.GenericRow;
+import io.confluent.ksql.execution.builder.KsqlQueryBuilder;
+import io.confluent.ksql.execution.context.QueryContext;
+import io.confluent.ksql.execution.plan.DefaultExecutionStepProperties;
+import io.confluent.ksql.execution.plan.ExecutionStep;
+import io.confluent.ksql.execution.plan.Formats;
+import io.confluent.ksql.execution.plan.JoinType;
+import io.confluent.ksql.execution.plan.StreamStreamJoin;
+import io.confluent.ksql.query.QueryId;
+import io.confluent.ksql.schema.ksql.LogicalSchema;
+import io.confluent.ksql.schema.ksql.PhysicalSchema;
+import io.confluent.ksql.schema.ksql.types.SqlTypes;
+import io.confluent.ksql.serde.Format;
+import io.confluent.ksql.serde.FormatInfo;
+import io.confluent.ksql.serde.KeyFormat;
+import io.confluent.ksql.serde.KeySerde;
+import io.confluent.ksql.serde.SerdeOption;
+import io.confluent.ksql.serde.ValueFormat;
+import java.time.Duration;
+import org.apache.kafka.common.serialization.Serde;
+import org.apache.kafka.connect.data.Struct;
+import org.apache.kafka.streams.kstream.JoinWindows;
+import org.apache.kafka.streams.kstream.Joined;
+import org.apache.kafka.streams.kstream.KStream;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnitRunner;
+
+@RunWith(MockitoJUnitRunner.class)
+public class StreamStreamJoinBuilderTest {
+  private static final String LEFT = "LEFT";
+  private static final String RIGHT = "RIGHT";
+  private static final String ALIAS = "ALIAS";
+  private static final LogicalSchema LEFT_SCHEMA = LogicalSchema.builder()
+      .valueColumn("BLUE", SqlTypes.STRING)
+      .valueColumn("GREEN", SqlTypes.INTEGER)
+      .build()
+      .withAlias(LEFT)
+      .withMetaAndKeyColsInValue();
+  private static final LogicalSchema RIGHT_SCHEMA = LogicalSchema.builder()
+      .valueColumn("RED", SqlTypes.BIGINT)
+      .valueColumn("ORANGE", SqlTypes.DOUBLE)
+      .build()
+      .withAlias(RIGHT)
+      .withMetaAndKeyColsInValue();
+  private static final LogicalSchema SCHEMA = LogicalSchema.builder()
+      .valueColumn("BLUE", SqlTypes.STRING)
+      .valueColumn("GREEN", SqlTypes.STRING)
+      .valueColumn("RED", SqlTypes.BIGINT)
+      .valueColumn("ORANGE", SqlTypes.DOUBLE)
+      .build()
+      .withAlias(ALIAS)
+      .withMetaAndKeyColsInValue();
+  private static final PhysicalSchema LEFT_PHYSICAL =
+      PhysicalSchema.from(LEFT_SCHEMA.withoutAlias(), SerdeOption.none());
+  private static final PhysicalSchema RIGHT_PHYSICAL =
+      PhysicalSchema.from(RIGHT_SCHEMA.withoutAlias(), SerdeOption.none());
+  private static final Formats LEFT_FMT = Formats.of(
+      KeyFormat.nonWindowed(FormatInfo.of(Format.KAFKA)),
+      ValueFormat.of(FormatInfo.of(Format.JSON)),
+      SerdeOption.none()
+  );
+  private static final Formats RIGHT_FMT = Formats.of(
+      KeyFormat.nonWindowed(FormatInfo.of(Format.KAFKA)),
+      ValueFormat.of(FormatInfo.of(Format.AVRO)),
+      SerdeOption.none()
+  );
+  private static final Duration BEFORE = Duration.ofMillis(1000);
+  private static final Duration AFTER = Duration.ofMillis(2000);
+  private static final JoinWindows WINDOWS = JoinWindows.of(BEFORE).after(AFTER);
+  private final QueryContext SRC_CTX =
+      new QueryContext.Stacker(new QueryId("qid")).push("src").getQueryContext();
+  private final QueryContext CTX =
+      new QueryContext.Stacker(new QueryId("qid")).push("jo").push("in").getQueryContext();
+
+  @Mock
+  private KStream<Struct, GenericRow> leftStream;
+  @Mock
+  private KStream<Struct, GenericRow>  rightStream;
+  @Mock
+  private KStream<Struct, GenericRow>  resultStream;
+  @Mock
+  private ExecutionStep<KStream<Struct, GenericRow>> left;
+  @Mock
+  private ExecutionStep<KStream<Struct, GenericRow>> right;
+  @Mock
+  private Joined<Struct, GenericRow, GenericRow> joined;
+  @Mock
+  private JoinedFactory joinedFactory;
+  @Mock
+  private KsqlQueryBuilder queryBuilder;
+  @Mock
+  private KeySerdeFactory<Struct> keySerdeFactory;
+  @Mock
+  private KeySerde<Struct> keySerde;
+  @Mock
+  private Serde<GenericRow> leftSerde;
+  @Mock
+  private Serde<GenericRow> rightSerde;
+
+  private StreamStreamJoin<Struct> join;
+
+  @Before
+  @SuppressWarnings("unchecked")
+  public void init() {
+    when(left.getProperties()).thenReturn(
+        new DefaultExecutionStepProperties(LEFT_SCHEMA, SRC_CTX));
+    when(right.getProperties()).thenReturn(
+        new DefaultExecutionStepProperties(RIGHT_SCHEMA, SRC_CTX));
+    when(keySerdeFactory.buildKeySerde(any(KeyFormat.class), any(), any())).thenReturn(keySerde);
+    when(queryBuilder.buildValueSerde(eq(FormatInfo.of(Format.JSON)), any(), any()))
+        .thenReturn(leftSerde);
+    when(queryBuilder.buildValueSerde(eq(FormatInfo.of(Format.AVRO)), any(), any()))
+        .thenReturn(rightSerde);
+    when(joinedFactory.create(any(Serde.class), any(), any(), any())).thenReturn(joined);
+  }
+
+  @SuppressWarnings("unchecked")
+  private void givenLeftJoin() {
+    when(leftStream.leftJoin(any(KStream.class), any(), any(), any())).thenReturn(resultStream);
+    join = new StreamStreamJoin<>(
+        new DefaultExecutionStepProperties(SCHEMA, CTX),
+        JoinType.LEFT,
+        LEFT_FMT,
+        RIGHT_FMT,
+        left,
+        right,
+        BEFORE,
+        AFTER
+    );
+  }
+
+  @SuppressWarnings("unchecked")
+  private void givenOuterJoin() {
+    when(leftStream.outerJoin(any(KStream.class), any(), any(), any())).thenReturn(resultStream);
+    join = new StreamStreamJoin<>(
+        new DefaultExecutionStepProperties(SCHEMA, CTX),
+        JoinType.OUTER,
+        LEFT_FMT,
+        RIGHT_FMT,
+        left,
+        right,
+        BEFORE,
+        AFTER
+    );
+  }
+
+  @SuppressWarnings("unchecked")
+  private void givenInnerJoin() {
+    when(leftStream.join(any(KStream.class), any(), any(), any())).thenReturn(resultStream);
+    join = new StreamStreamJoin<>(
+        new DefaultExecutionStepProperties(SCHEMA, CTX),
+        JoinType.INNER,
+        LEFT_FMT,
+        RIGHT_FMT,
+        left,
+        right,
+        BEFORE,
+        AFTER
+    );
+  }
+
+  @Test
+  public void shouldDoLeftJoin() {
+    // Given:
+    givenLeftJoin();
+
+    // When:
+    final KStream result = StreamStreamJoinBuilder.build(
+        leftStream,
+        rightStream,
+        join,
+        keySerdeFactory,
+        queryBuilder,
+        joinedFactory
+    );
+
+    // Then:
+    verify(leftStream).leftJoin(
+        same(rightStream),
+        eq(new KsqlValueJoiner(LEFT_SCHEMA, RIGHT_SCHEMA)),
+        eq(WINDOWS),
+        same(joined)
+    );
+    verifyNoMoreInteractions(leftStream, rightStream, resultStream);
+    assertThat(result, is(resultStream));
+  }
+
+  @Test
+  public void shouldDoOuterJoin() {
+    // Given:
+    givenOuterJoin();
+
+    // When:
+    final KStream result = StreamStreamJoinBuilder.build(
+        leftStream,
+        rightStream,
+        join,
+        keySerdeFactory,
+        queryBuilder,
+        joinedFactory
+    );
+
+    // Then:
+    verify(leftStream).outerJoin(
+        same(rightStream),
+        eq(new KsqlValueJoiner(LEFT_SCHEMA, RIGHT_SCHEMA)),
+        eq(WINDOWS),
+        same(joined)
+    );
+    verifyNoMoreInteractions(leftStream, rightStream, resultStream);
+    assertThat(result, is(resultStream));
+  }
+
+  @Test
+  public void shouldDoInnerJoin() {
+    // Given:
+    givenInnerJoin();
+
+    // When:
+    final KStream result = StreamStreamJoinBuilder.build(
+        leftStream,
+        rightStream,
+        join,
+        keySerdeFactory,
+        queryBuilder,
+        joinedFactory
+    );
+
+    // Then:
+    verify(leftStream).join(
+        same(rightStream),
+        eq(new KsqlValueJoiner(LEFT_SCHEMA, RIGHT_SCHEMA)),
+        eq(WINDOWS),
+        same(joined)
+    );
+    verifyNoMoreInteractions(leftStream, rightStream, resultStream);
+    assertThat(result, is(resultStream));
+  }
+
+  @Test
+  public void shouldBuildJoinedCorrectly() {
+    // Given:
+    givenInnerJoin();
+
+    // When:
+    StreamStreamJoinBuilder.build(
+        leftStream,
+        rightStream,
+        join,
+        keySerdeFactory,
+        queryBuilder,
+        joinedFactory
+    );
+
+    // Then:
+    verify(joinedFactory).create(keySerde, leftSerde, rightSerde, "jo-in");
+  }
+
+  @Test
+  public void shouldBuildKeySerdeCorrectly() {
+    // Given:
+    givenInnerJoin();
+
+    // When:
+    StreamStreamJoinBuilder.build(
+        leftStream,
+        rightStream,
+        join,
+        keySerdeFactory,
+        queryBuilder,
+        joinedFactory
+    );
+
+    // Then:
+    verify(keySerdeFactory).buildKeySerde(LEFT_FMT.getKeyFormat(), LEFT_PHYSICAL, CTX);
+  }
+
+  @Test
+  public void shouldBuildLeftSerdeCorrectly() {
+    // Given:
+    givenInnerJoin();
+
+    // When:
+    StreamStreamJoinBuilder.build(
+        leftStream,
+        rightStream,
+        join,
+        keySerdeFactory,
+        queryBuilder,
+        joinedFactory
+    );
+
+    // Then:
+    final QueryContext leftCtx = QueryContext.Stacker.of(CTX).push("left").getQueryContext();
+    verify(queryBuilder).buildValueSerde(FormatInfo.of(Format.JSON), LEFT_PHYSICAL, leftCtx);
+  }
+
+  @Test
+  public void shouldBuildRightSerdeCorrectly() {
+    // Given:
+    givenInnerJoin();
+
+    // When:
+    StreamStreamJoinBuilder.build(
+        leftStream,
+        rightStream,
+        join,
+        keySerdeFactory,
+        queryBuilder,
+        joinedFactory
+    );
+
+    // Then:
+    final QueryContext leftCtx = QueryContext.Stacker.of(CTX).push("right").getQueryContext();
+    verify(queryBuilder).buildValueSerde(FormatInfo.of(Format.AVRO), RIGHT_PHYSICAL, leftCtx);
+  }
+}

--- a/ksql-streams/src/test/java/io/confluent/ksql/execution/streams/StreamTableJoinBuilderTest.java
+++ b/ksql-streams/src/test/java/io/confluent/ksql/execution/streams/StreamTableJoinBuilderTest.java
@@ -1,0 +1,282 @@
+package io.confluent.ksql.execution.streams;
+
+import static org.hamcrest.Matchers.is;
+import static org.junit.Assert.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.ArgumentMatchers.same;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoMoreInteractions;
+import static org.mockito.Mockito.when;
+
+import io.confluent.ksql.GenericRow;
+import io.confluent.ksql.execution.builder.KsqlQueryBuilder;
+import io.confluent.ksql.execution.context.QueryContext;
+import io.confluent.ksql.execution.plan.DefaultExecutionStepProperties;
+import io.confluent.ksql.execution.plan.ExecutionStep;
+import io.confluent.ksql.execution.plan.Formats;
+import io.confluent.ksql.execution.plan.JoinType;
+import io.confluent.ksql.execution.plan.StreamTableJoin;
+import io.confluent.ksql.query.QueryId;
+import io.confluent.ksql.schema.ksql.LogicalSchema;
+import io.confluent.ksql.schema.ksql.PhysicalSchema;
+import io.confluent.ksql.schema.ksql.types.SqlTypes;
+import io.confluent.ksql.serde.Format;
+import io.confluent.ksql.serde.FormatInfo;
+import io.confluent.ksql.serde.KeyFormat;
+import io.confluent.ksql.serde.KeySerde;
+import io.confluent.ksql.serde.SerdeOption;
+import io.confluent.ksql.serde.ValueFormat;
+import org.apache.kafka.common.serialization.Serde;
+import org.apache.kafka.connect.data.Struct;
+import org.apache.kafka.streams.kstream.Joined;
+import org.apache.kafka.streams.kstream.KStream;
+import org.apache.kafka.streams.kstream.KTable;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnitRunner;
+
+@RunWith(MockitoJUnitRunner.class)
+public class StreamTableJoinBuilderTest {
+  private static final String LEFT = "LEFT";
+  private static final String RIGHT = "RIGHT";
+  private static final String ALIAS = "ALIAS";
+  private static final LogicalSchema LEFT_SCHEMA = LogicalSchema.builder()
+      .valueColumn("BLUE", SqlTypes.STRING)
+      .valueColumn("GREEN", SqlTypes.INTEGER)
+      .build()
+      .withAlias(LEFT)
+      .withMetaAndKeyColsInValue();
+  private static final LogicalSchema RIGHT_SCHEMA = LogicalSchema.builder()
+      .valueColumn("RED", SqlTypes.BIGINT)
+      .valueColumn("ORANGE", SqlTypes.DOUBLE)
+      .build()
+      .withAlias(RIGHT)
+      .withMetaAndKeyColsInValue();
+  private static final LogicalSchema SCHEMA = LogicalSchema.builder()
+      .valueColumn("BLUE", SqlTypes.STRING)
+      .valueColumn("GREEN", SqlTypes.STRING)
+      .valueColumn("RED", SqlTypes.BIGINT)
+      .valueColumn("ORANGE", SqlTypes.DOUBLE)
+      .build()
+      .withAlias(ALIAS)
+      .withMetaAndKeyColsInValue();
+  private static final PhysicalSchema LEFT_PHYSICAL =
+      PhysicalSchema.from(LEFT_SCHEMA.withoutAlias(), SerdeOption.none());
+  private static final Formats LEFT_FMT = Formats.of(
+      KeyFormat.nonWindowed(FormatInfo.of(Format.KAFKA)),
+      ValueFormat.of(FormatInfo.of(Format.JSON)),
+      SerdeOption.none()
+  );
+  private final QueryContext SRC_CTX =
+      new QueryContext.Stacker(new QueryId("qid")).push("src").getQueryContext();
+  private final QueryContext CTX =
+      new QueryContext.Stacker(new QueryId("qid")).push("jo").push("in").getQueryContext();
+
+  @Mock
+  private KStream<Struct, GenericRow> leftStream;
+  @Mock
+  private KTable<Struct, GenericRow> rightTable;
+  @Mock
+  private KStream<Struct, GenericRow> resultStream;
+  @Mock
+  private ExecutionStep<KStream<Struct, GenericRow>> left;
+  @Mock
+  private ExecutionStep<KTable<Struct, GenericRow>> right;
+  @Mock
+  private Joined<Struct, GenericRow, GenericRow> joined;
+  @Mock
+  private JoinedFactory joinedFactory;
+  @Mock
+  private KsqlQueryBuilder queryBuilder;
+  @Mock
+  private KeySerdeFactory<Struct> keySerdeFactory;
+  @Mock
+  private KeySerde<Struct> keySerde;
+  @Mock
+  private Serde<GenericRow> leftSerde;
+
+  private StreamTableJoin<Struct> join;
+
+  @Rule
+  public final ExpectedException expectedException = ExpectedException.none();
+
+  @Before
+  @SuppressWarnings("unchecked")
+  public void init() {
+    when(left.getProperties()).thenReturn(
+        new DefaultExecutionStepProperties(LEFT_SCHEMA, SRC_CTX));
+    when(right.getProperties()).thenReturn(
+        new DefaultExecutionStepProperties(RIGHT_SCHEMA, SRC_CTX));
+    when(keySerdeFactory.buildKeySerde(any(KeyFormat.class), any(), any())).thenReturn(keySerde);
+    when(queryBuilder.buildValueSerde(eq(FormatInfo.of(Format.JSON)), any(), any()))
+        .thenReturn(leftSerde);
+    when(joinedFactory.create(any(Serde.class), any(), any(), any())).thenReturn(joined);
+  }
+
+  @SuppressWarnings("unchecked")
+  private void givenLeftJoin() {
+    when(leftStream.leftJoin(any(KTable.class), any(), any())).thenReturn(resultStream);
+    join = new StreamTableJoin(
+        new DefaultExecutionStepProperties(SCHEMA, CTX),
+        JoinType.LEFT,
+        LEFT_FMT,
+        left,
+        right
+    );
+  }
+
+  @SuppressWarnings("unchecked")
+  private void givenOuterJoin() {
+    join = new StreamTableJoin(
+        new DefaultExecutionStepProperties(SCHEMA, CTX),
+        JoinType.OUTER,
+        LEFT_FMT,
+        left,
+        right
+    );
+  }
+
+  @SuppressWarnings("unchecked")
+  private void givenInnerJoin() {
+    when(leftStream.join(any(KTable.class), any(), any())).thenReturn(resultStream);
+    join = new StreamTableJoin(
+        new DefaultExecutionStepProperties(SCHEMA, CTX),
+        JoinType.INNER,
+        LEFT_FMT,
+        left,
+        right
+    );
+  }
+
+  @Test
+  public void shouldDoLeftJoin() {
+    // Given:
+    givenLeftJoin();
+
+    // When:
+    final KStream result = StreamTableJoinBuilder.build(
+        leftStream,
+        rightTable,
+        join,
+        keySerdeFactory,
+        queryBuilder,
+        joinedFactory
+    );
+
+    // Then:
+    verify(leftStream).leftJoin(
+        same(rightTable),
+        eq(new KsqlValueJoiner(LEFT_SCHEMA, RIGHT_SCHEMA)),
+        same(joined)
+    );
+    verifyNoMoreInteractions(leftStream, rightTable, resultStream);
+    assertThat(result, is(resultStream));
+  }
+
+  @Test
+  public void shoulFailOnOuterJoin() {
+    // Given:
+    givenOuterJoin();
+
+    // Then:
+    expectedException.expect(IllegalStateException.class);
+
+    // When:
+    StreamTableJoinBuilder.build(
+        leftStream,
+        rightTable,
+        join,
+        keySerdeFactory,
+        queryBuilder,
+        joinedFactory
+    );
+  }
+
+  @Test
+  public void shouldDoInnerJoin() {
+    // Given:
+    givenInnerJoin();
+
+    // When:
+    final KStream result = StreamTableJoinBuilder.build(
+        leftStream,
+        rightTable,
+        join,
+        keySerdeFactory,
+        queryBuilder,
+        joinedFactory
+    );
+
+    // Then:
+    verify(leftStream).join(
+        same(rightTable),
+        eq(new KsqlValueJoiner(LEFT_SCHEMA, RIGHT_SCHEMA)),
+        same(joined)
+    );
+    verifyNoMoreInteractions(leftStream, rightTable, resultStream);
+    assertThat(result, is(resultStream));
+  }
+
+  @Test
+  public void shouldBuildJoinedCorrectly() {
+    // Given:
+    givenInnerJoin();
+
+    // When:
+    StreamTableJoinBuilder.build(
+        leftStream,
+        rightTable,
+        join,
+        keySerdeFactory,
+        queryBuilder,
+        joinedFactory
+    );
+
+    // Then:
+    verify(joinedFactory).create(keySerde, leftSerde, null, "jo-in");
+  }
+
+  @Test
+  public void shouldBuildKeySerdeCorrectly() {
+    // Given:
+    givenInnerJoin();
+
+    // When:
+    StreamTableJoinBuilder.build(
+        leftStream,
+        rightTable,
+        join,
+        keySerdeFactory,
+        queryBuilder,
+        joinedFactory
+    );
+
+    // Then:
+    verify(keySerdeFactory).buildKeySerde(LEFT_FMT.getKeyFormat(), LEFT_PHYSICAL, CTX);
+  }
+
+  @Test
+  public void shouldBuildLeftSerdeCorrectly() {
+    // Given:
+    givenInnerJoin();
+
+    // When:
+    StreamTableJoinBuilder.build(
+        leftStream,
+        rightTable,
+        join,
+        keySerdeFactory,
+        queryBuilder,
+        joinedFactory
+    );
+
+    // Then:
+    final QueryContext leftCtx = QueryContext.Stacker.of(CTX).push("left").getQueryContext();
+    verify(queryBuilder).buildValueSerde(FormatInfo.of(Format.JSON), LEFT_PHYSICAL, leftCtx);
+  }
+}

--- a/ksql-streams/src/test/java/io/confluent/ksql/execution/streams/TableTableJoinBuilderTest.java
+++ b/ksql-streams/src/test/java/io/confluent/ksql/execution/streams/TableTableJoinBuilderTest.java
@@ -1,0 +1,171 @@
+package io.confluent.ksql.execution.streams;
+
+import static org.hamcrest.Matchers.is;
+import static org.junit.Assert.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.ArgumentMatchers.same;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoMoreInteractions;
+import static org.mockito.Mockito.when;
+
+import io.confluent.ksql.GenericRow;
+import io.confluent.ksql.execution.context.QueryContext;
+import io.confluent.ksql.execution.plan.DefaultExecutionStepProperties;
+import io.confluent.ksql.execution.plan.ExecutionStep;
+import io.confluent.ksql.execution.plan.JoinType;
+import io.confluent.ksql.execution.plan.TableTableJoin;
+import io.confluent.ksql.query.QueryId;
+import io.confluent.ksql.schema.ksql.LogicalSchema;
+import io.confluent.ksql.schema.ksql.types.SqlTypes;
+import org.apache.kafka.common.serialization.Serde;
+import org.apache.kafka.connect.data.Struct;
+import org.apache.kafka.streams.kstream.Joined;
+import org.apache.kafka.streams.kstream.KTable;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnitRunner;
+
+@RunWith(MockitoJUnitRunner.class)
+public class TableTableJoinBuilderTest {
+  private static final String LEFT = "LEFT";
+  private static final String RIGHT = "RIGHT";
+  private static final String ALIAS = "ALIAS";
+  private static final LogicalSchema LEFT_SCHEMA = LogicalSchema.builder()
+      .valueColumn("BLUE", SqlTypes.STRING)
+      .valueColumn("GREEN", SqlTypes.INTEGER)
+      .build()
+      .withAlias(LEFT)
+      .withMetaAndKeyColsInValue();
+  private static final LogicalSchema RIGHT_SCHEMA = LogicalSchema.builder()
+      .valueColumn("RED", SqlTypes.BIGINT)
+      .valueColumn("ORANGE", SqlTypes.DOUBLE)
+      .build()
+      .withAlias(RIGHT)
+      .withMetaAndKeyColsInValue();
+  private static final LogicalSchema SCHEMA = LogicalSchema.builder()
+      .valueColumn("BLUE", SqlTypes.STRING)
+      .valueColumn("GREEN", SqlTypes.STRING)
+      .valueColumn("RED", SqlTypes.BIGINT)
+      .valueColumn("ORANGE", SqlTypes.DOUBLE)
+      .build()
+      .withAlias(ALIAS)
+      .withMetaAndKeyColsInValue();
+  private final QueryContext SRC_CTX =
+      new QueryContext.Stacker(new QueryId("qid")).push("src").getQueryContext();
+  private final QueryContext CTX =
+      new QueryContext.Stacker(new QueryId("qid")).push("jo").push("in").getQueryContext();
+
+  @Mock
+  private KTable<Struct, GenericRow> leftTable;
+  @Mock
+  private KTable<Struct, GenericRow>  rightTable;
+  @Mock
+  private KTable<Struct, GenericRow>  resultTable;
+  @Mock
+  private ExecutionStep<KTable<Struct, GenericRow>> left;
+  @Mock
+  private ExecutionStep<KTable<Struct, GenericRow>> right;
+  @Mock
+  private Joined<Struct, GenericRow, GenericRow> joined;
+  @Mock
+  private JoinedFactory joinedFactory;
+
+  private TableTableJoin<Struct> join;
+
+  @Before
+  @SuppressWarnings("unchecked")
+  public void init() {
+    when(left.getProperties()).thenReturn(
+        new DefaultExecutionStepProperties(LEFT_SCHEMA, SRC_CTX));
+    when(right.getProperties()).thenReturn(
+        new DefaultExecutionStepProperties(RIGHT_SCHEMA, SRC_CTX));
+    when(joinedFactory.create(any(Serde.class), any(), any(), any())).thenReturn(joined);
+  }
+
+  @SuppressWarnings("unchecked")
+  private void givenLeftJoin() {
+    when(leftTable.leftJoin(any(KTable.class), any())).thenReturn(resultTable);
+    join = new TableTableJoin<>(
+        new DefaultExecutionStepProperties(SCHEMA, CTX),
+        JoinType.LEFT,
+        left,
+        right
+    );
+  }
+
+  @SuppressWarnings("unchecked")
+  private void givenOuterJoin() {
+    when(leftTable.outerJoin(any(KTable.class), any())).thenReturn(resultTable);
+    join = new TableTableJoin<>(
+        new DefaultExecutionStepProperties(SCHEMA, CTX),
+        JoinType.OUTER,
+        left,
+        right
+    );
+  }
+
+  @SuppressWarnings("unchecked")
+  private void givenInnerJoin() {
+    when(leftTable.join(any(KTable.class), any())).thenReturn(resultTable);
+    join = new TableTableJoin<>(
+        new DefaultExecutionStepProperties(SCHEMA, CTX),
+        JoinType.INNER,
+        left,
+        right
+    );
+  }
+
+  @Test
+  public void shouldDoLeftJoin() {
+    // Given:
+    givenLeftJoin();
+
+    // When:
+    final KTable result = TableTableJoinBuilder.build(leftTable, rightTable, join);
+
+    // Then:
+    verify(leftTable).leftJoin(
+        same(rightTable),
+        eq(new KsqlValueJoiner(LEFT_SCHEMA, RIGHT_SCHEMA))
+    );
+    verifyNoMoreInteractions(leftTable, rightTable, resultTable);
+    assertThat(result, is(resultTable));
+  }
+
+  @Test
+  public void shouldDoOuterJoin() {
+    // Given:
+    givenOuterJoin();
+
+    // When:
+    final KTable result = TableTableJoinBuilder.build(leftTable, rightTable, join);
+
+    // Then:
+    verify(leftTable).outerJoin(
+        same(rightTable),
+        eq(new KsqlValueJoiner(LEFT_SCHEMA, RIGHT_SCHEMA))
+    );
+    verifyNoMoreInteractions(leftTable, rightTable, resultTable);
+    assertThat(result, is(resultTable));
+  }
+
+  @Test
+  public void shouldDoInnerJoin() {
+    // Given:
+    givenInnerJoin();
+
+    // When:
+    final KTable result = TableTableJoinBuilder.build(leftTable, rightTable, join);
+
+    // Then:
+    verify(leftTable).join(
+        same(rightTable),
+        eq(new KsqlValueJoiner(LEFT_SCHEMA, RIGHT_SCHEMA))
+    );
+    verifyNoMoreInteractions(leftTable, rightTable, resultTable);
+    assertThat(result, is(resultTable));
+  }
+}


### PR DESCRIPTION
### Description 

Moves code for joining kstreams/ktables out of SchemaKStream/Table
and into execution plan builders. Also moves KsqlValueJoiner into
ksql-streams, so that it can be used from the plan builders. Also
adds a buildKeySerde API for building both windowed and unwindowed
keys, since most of the plan builders dont have type information
for the key.

### Testing done 

Added unit tests for step builders

### Reviewer checklist
- [ ] Ensure docs are updated if necessary. (eg. if a user visible feature is being added or changed).
- [ ] Ensure relevant issues are linked (description should include text like "Fixes #<issue number>")

