### PR TITLE
feat: move selectKey impl to plan builder

### DIFF
--- a/ksql-engine/src/main/java/io/confluent/ksql/structured/GroupByMapper.java
+++ b/ksql-engine/src/main/java/io/confluent/ksql/structured/GroupByMapper.java
@@ -19,6 +19,7 @@ import com.google.common.collect.ImmutableList;
 import io.confluent.ksql.GenericRow;
 import io.confluent.ksql.execution.codegen.ExpressionMetadata;
 import io.confluent.ksql.execution.expression.tree.Expression;
+import io.confluent.ksql.execution.util.StructKeyUtil;
 import java.util.List;
 import java.util.Objects;
 import java.util.stream.Collectors;

--- a/ksql-engine/src/main/java/io/confluent/ksql/structured/SchemaKTable.java
+++ b/ksql-engine/src/main/java/io/confluent/ksql/structured/SchemaKTable.java
@@ -30,6 +30,7 @@ import io.confluent.ksql.execution.streams.ExecutionStepFactory;
 import io.confluent.ksql.execution.streams.StreamsUtil;
 import io.confluent.ksql.execution.streams.TableFilterBuilder;
 import io.confluent.ksql.execution.streams.TableMapValuesBuilder;
+import io.confluent.ksql.execution.util.StructKeyUtil;
 import io.confluent.ksql.function.FunctionRegistry;
 import io.confluent.ksql.metastore.model.KeyField;
 import io.confluent.ksql.metastore.model.KeyField.LegacyField;

--- a/ksql-engine/src/test/java/io/confluent/ksql/structured/GroupByMapperTest.java
+++ b/ksql-engine/src/test/java/io/confluent/ksql/structured/GroupByMapperTest.java
@@ -24,6 +24,7 @@ import io.confluent.ksql.execution.codegen.ExpressionMetadata;
 import io.confluent.ksql.execution.expression.tree.Expression;
 import io.confluent.ksql.execution.expression.tree.QualifiedName;
 import io.confluent.ksql.execution.expression.tree.QualifiedNameReference;
+import io.confluent.ksql.execution.util.StructKeyUtil;
 import java.util.Collections;
 import org.apache.kafka.connect.data.Struct;
 import org.easymock.EasyMock;

--- a/ksql-engine/src/test/java/io/confluent/ksql/structured/SchemaKTableTest.java
+++ b/ksql-engine/src/test/java/io/confluent/ksql/structured/SchemaKTableTest.java
@@ -54,6 +54,7 @@ import io.confluent.ksql.execution.plan.TableFilter;
 import io.confluent.ksql.execution.streams.ExecutionStepFactory;
 import io.confluent.ksql.execution.streams.MaterializedFactory;
 import io.confluent.ksql.execution.streams.StreamsUtil;
+import io.confluent.ksql.execution.util.StructKeyUtil;
 import io.confluent.ksql.function.InternalFunctionRegistry;
 import io.confluent.ksql.logging.processing.ProcessingLogContext;
 import io.confluent.ksql.metastore.MetaStore;

--- a/ksql-execution/src/main/java/io/confluent/ksql/execution/plan/StreamSelectKey.java
+++ b/ksql-execution/src/main/java/io/confluent/ksql/execution/plan/StreamSelectKey.java
@@ -15,21 +15,24 @@
 package io.confluent.ksql.execution.plan;
 
 import com.google.errorprone.annotations.Immutable;
+import io.confluent.ksql.GenericRow;
 import io.confluent.ksql.execution.builder.KsqlQueryBuilder;
 import java.util.Collections;
 import java.util.List;
 import java.util.Objects;
+import org.apache.kafka.connect.data.Struct;
+import org.apache.kafka.streams.kstream.KStream;
 
 @Immutable
-public class StreamSelectKey<S> implements ExecutionStep<S> {
+public class StreamSelectKey<K> implements ExecutionStep<KStream<Struct, GenericRow>> {
   private final ExecutionStepProperties properties;
-  private final ExecutionStep<S> source;
+  private final ExecutionStep<KStream<K, GenericRow>> source;
   private final String fieldName;
   private final boolean updateRowKey;
 
   public StreamSelectKey(
       final ExecutionStepProperties properties,
-      final ExecutionStep<S> source,
+      final ExecutionStep<KStream<K, GenericRow>> source,
       final String fieldName,
       final boolean updateRowKey) {
     this.properties = Objects.requireNonNull(properties, "properties");
@@ -48,8 +51,16 @@ public class StreamSelectKey<S> implements ExecutionStep<S> {
     return Collections.singletonList(source);
   }
 
+  public boolean isUpdateRowKey() {
+    return updateRowKey;
+  }
+
+  public String getFieldName() {
+    return fieldName;
+  }
+
   @Override
-  public S build(final KsqlQueryBuilder streamsBuilder) {
+  public KStream<Struct, GenericRow> build(final KsqlQueryBuilder streamsBuilder) {
     throw new UnsupportedOperationException();
   }
 

--- a/ksql-execution/src/main/java/io/confluent/ksql/execution/util/StructKeyUtil.java
+++ b/ksql-execution/src/main/java/io/confluent/ksql/execution/util/StructKeyUtil.java
@@ -13,7 +13,7 @@
  * specific language governing permissions and limitations under the License.
  */
 
-package io.confluent.ksql.structured;
+package io.confluent.ksql.execution.util;
 
 import io.confluent.ksql.schema.ksql.PersistenceSchema;
 import io.confluent.ksql.util.SchemaUtil;
@@ -25,7 +25,7 @@ import org.apache.kafka.connect.data.Struct;
 /**
  * Helper for dealing with Struct keys.
  */
-final class StructKeyUtil {
+public final class StructKeyUtil {
 
   private static final Schema ROWKEY_STRUCT_SCHEMA = SchemaBuilder
       .struct()
@@ -35,7 +35,7 @@ final class StructKeyUtil {
   private static final org.apache.kafka.connect.data.Field ROWKEY_FIELD =
       ROWKEY_STRUCT_SCHEMA.fields().get(0);
 
-  static final PersistenceSchema ROWKEY_SERIALIZED_SCHEMA = PersistenceSchema.from(
+  public static final PersistenceSchema ROWKEY_SERIALIZED_SCHEMA = PersistenceSchema.from(
       (ConnectSchema) ROWKEY_STRUCT_SCHEMA,
       false
   );
@@ -43,7 +43,7 @@ final class StructKeyUtil {
   private StructKeyUtil() {
   }
 
-  static Struct asStructKey(final String rowKey) {
+  public static Struct asStructKey(final String rowKey) {
     final Struct keyStruct = new Struct(ROWKEY_STRUCT_SCHEMA);
     keyStruct.put(ROWKEY_FIELD, rowKey);
     return keyStruct;

--- a/ksql-streams/src/main/java/io/confluent/ksql/execution/streams/ExecutionStepFactory.java
+++ b/ksql-streams/src/main/java/io/confluent/ksql/execution/streams/ExecutionStepFactory.java
@@ -215,7 +215,8 @@ public final class ExecutionStepFactory {
     );
   }
 
-  public static <K> StreamSelectKey<KStream<K, GenericRow>> streamSelectKey(
+  @SuppressWarnings("unchecked")
+  public static <K> StreamSelectKey<K> streamSelectKey(
       final QueryContext.Stacker stacker,
       final ExecutionStep<KStream<K, GenericRow>> source,
       final String fieldName,

--- a/ksql-streams/src/main/java/io/confluent/ksql/execution/streams/StreamSelectKeyBuilder.java
+++ b/ksql-streams/src/main/java/io/confluent/ksql/execution/streams/StreamSelectKeyBuilder.java
@@ -1,0 +1,70 @@
+/*
+ * Copyright 2019 Confluent Inc.
+ *
+ * Licensed under the Confluent Community License (the "License"); you may not use
+ * this file except in compliance with the License.  You may obtain a copy of the
+ * License at
+ *
+ * http://www.confluent.io/confluent-community-license
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package io.confluent.ksql.execution.streams;
+
+import io.confluent.ksql.GenericRow;
+import io.confluent.ksql.execution.plan.StreamSelectKey;
+import io.confluent.ksql.execution.util.StructKeyUtil;
+import io.confluent.ksql.schema.ksql.Column;
+import io.confluent.ksql.schema.ksql.LogicalSchema;
+import io.confluent.ksql.util.SchemaUtil;
+import org.apache.kafka.connect.data.Struct;
+import org.apache.kafka.streams.kstream.KStream;
+
+public final class StreamSelectKeyBuilder {
+  private StreamSelectKeyBuilder() {
+  }
+
+  public static KStream<Struct, GenericRow> build(
+      final KStream<?, GenericRow> kstream,
+      final StreamSelectKey<?> selectKey) {
+    final LogicalSchema sourceSchema = selectKey.getSources().get(0).getProperties().getSchema();
+    final Column keyColumn = sourceSchema.findValueColumn(selectKey.getFieldName())
+        .orElseThrow(IllegalArgumentException::new);
+    final int keyIndexInValue = sourceSchema.valueColumnIndex(keyColumn.fullName())
+        .orElseThrow(IllegalStateException::new);
+    final boolean updateRowKey = selectKey.isUpdateRowKey();
+    return kstream
+        .filter((key, value) ->
+            value != null && extractColumn(sourceSchema, keyIndexInValue, value) != null
+        ).selectKey((key, value) ->
+            StructKeyUtil.asStructKey(
+                extractColumn(sourceSchema, keyIndexInValue, value).toString()
+            )
+        ).mapValues((key, row) -> {
+          if (updateRowKey) {
+            final Object rowKey = key.get(key.schema().fields().get(0));
+            row.getColumns().set(SchemaUtil.ROWKEY_INDEX, rowKey);
+          }
+          return row;
+        });
+  }
+
+  private static Object extractColumn(
+      final LogicalSchema schema,
+      final int keyIndexInValue,
+      final GenericRow value
+  ) {
+    if (value.getColumns().size() != schema.value().size()) {
+      throw new IllegalStateException("Field count mismatch. "
+          + "Schema fields: " + schema
+          + ", row:" + value);
+    }
+    return value
+        .getColumns()
+        .get(keyIndexInValue);
+  }
+}

--- a/ksql-streams/src/test/java/io/confluent/ksql/execution/streams/StreamSelectKeyBuilderTest.java
+++ b/ksql-streams/src/test/java/io/confluent/ksql/execution/streams/StreamSelectKeyBuilderTest.java
@@ -1,0 +1,241 @@
+/*
+ * Copyright 2019 Confluent Inc.
+ *
+ * Licensed under the Confluent Community License (the "License"); you may not use
+ * this file except in compliance with the License.  You may obtain a copy of the
+ * License at
+ *
+ * http://www.confluent.io/confluent-community-license
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package io.confluent.ksql.execution.streams;
+
+import static io.confluent.ksql.execution.util.StructKeyUtil.asStructKey;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.is;
+import static org.junit.Assert.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoMoreInteractions;
+import static org.mockito.Mockito.when;
+
+import io.confluent.ksql.GenericRow;
+import io.confluent.ksql.execution.context.QueryContext;
+import io.confluent.ksql.execution.plan.DefaultExecutionStepProperties;
+import io.confluent.ksql.execution.plan.ExecutionStep;
+import io.confluent.ksql.execution.plan.ExecutionStepProperties;
+import io.confluent.ksql.execution.plan.StreamSelectKey;
+import io.confluent.ksql.query.QueryId;
+import io.confluent.ksql.schema.ksql.LogicalSchema;
+import io.confluent.ksql.schema.ksql.types.SqlTypes;
+import org.apache.kafka.connect.data.Struct;
+import org.apache.kafka.streams.kstream.KStream;
+import org.apache.kafka.streams.kstream.KeyValueMapper;
+import org.apache.kafka.streams.kstream.Predicate;
+import org.apache.kafka.streams.kstream.ValueMapperWithKey;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Captor;
+import org.mockito.InOrder;
+import org.mockito.Mock;
+import org.mockito.Mockito;
+import org.mockito.junit.MockitoJUnit;
+import org.mockito.junit.MockitoRule;
+
+public class StreamSelectKeyBuilderTest {
+  private static final String ALIAS = "ATL";
+  private static final LogicalSchema SCHEMA = LogicalSchema.builder()
+      .valueColumn("BIG", SqlTypes.BIGINT)
+      .valueColumn("BOI", SqlTypes.STRING)
+      .build()
+      .withAlias(ALIAS)
+      .withMetaAndKeyColsInValue();
+  private static final String KEY = "ATL.BOI";
+
+  @Mock
+  private KStream<Struct, GenericRow> kstream;
+  @Mock
+  private KStream<Struct, GenericRow> rekeyedKstream;
+  @Mock
+  private KStream<Struct, GenericRow> filteredKStream;
+  @Mock
+  private KStream<Struct, GenericRow> updatedKeyKStream;
+  @Mock
+  private ExecutionStep<KStream<Struct, GenericRow>> sourceStep;
+  @Captor
+  private ArgumentCaptor<Predicate<Struct, GenericRow>> predicateCaptor;
+  @Captor
+  private ArgumentCaptor<KeyValueMapper<Struct, GenericRow, Struct>> keyValueMapperCaptor;
+  @Captor
+  private ArgumentCaptor<ValueMapperWithKey<Struct, GenericRow, GenericRow>> mapperCaptor;
+
+  private final QueryContext queryContext =
+      new QueryContext.Stacker(new QueryId("hey")).push("ya").getQueryContext();
+  private final ExecutionStepProperties properties = new DefaultExecutionStepProperties(
+      SCHEMA,
+      queryContext
+  );
+
+  private StreamSelectKey selectKey;
+
+  @Rule
+  public final MockitoRule mockitoRule = MockitoJUnit.rule();
+
+  @Before
+  @SuppressWarnings("unchecked")
+  public void init() {
+    when(sourceStep.getProperties()).thenReturn(properties);
+    when(kstream.filter(any())).thenReturn(filteredKStream);
+    when(filteredKStream.selectKey(any(KeyValueMapper.class))).thenReturn(rekeyedKstream);
+    when(rekeyedKstream.mapValues(any(ValueMapperWithKey.class))).thenReturn(updatedKeyKStream);
+    givenUpdateRowkey();
+  }
+
+  private void givenUpdateRowkey() {
+    selectKey = new StreamSelectKey<>(
+        properties,
+        sourceStep,
+        KEY,
+        true
+    );
+  }
+
+  private void givenUpdateRowkeyFalse() {
+    selectKey = new StreamSelectKey<>(
+        properties,
+        sourceStep,
+        KEY,
+        false
+    );
+  }
+
+  @Test
+  @SuppressWarnings("unchecked")
+  public void shouldRekeyCorrectly() {
+    // When:
+    final KStream result = StreamSelectKeyBuilder.build(kstream, selectKey);
+
+    // Then:
+    final InOrder inOrder = Mockito.inOrder(kstream, filteredKStream, rekeyedKstream);
+    inOrder.verify(kstream).filter(any());
+    inOrder.verify(filteredKStream).selectKey(any());
+    inOrder.verify(rekeyedKstream).mapValues(any(ValueMapperWithKey.class));
+    inOrder.verifyNoMoreInteractions();
+    assertThat(result, is(updatedKeyKStream));
+  }
+
+  @Test
+  public void shouldFilterOutNullValues() {
+    // When:
+    StreamSelectKeyBuilder.build(kstream, selectKey);
+
+    // Then:
+    verify(kstream).filter(predicateCaptor.capture());
+    final Predicate<Struct, GenericRow> predicate = getPredicate();
+    assertThat(predicate.test(asStructKey("dre"), null), is(false));
+  }
+
+  @Test
+  public void shouldFilterOutNullKeyColumns() {
+    // When:
+    StreamSelectKeyBuilder.build(kstream, selectKey);
+
+    // Then:
+    verify(kstream).filter(predicateCaptor.capture());
+    final Predicate<Struct, GenericRow> predicate = getPredicate();
+    assertThat(
+        predicate.test(asStructKey("dre"), new GenericRow(0, "dre", 3000, null)),
+        is(false)
+    );
+  }
+
+  @Test
+  public void shouldNotFilterOutNonNullKeyColumns() {
+    // When:
+    StreamSelectKeyBuilder.build(kstream, selectKey);
+
+    // Then:
+    verify(kstream).filter(predicateCaptor.capture());
+    final Predicate<Struct, GenericRow> predicate = getPredicate();
+    assertThat(
+        predicate.test(asStructKey("dre"), new GenericRow(0, "dre", 3000, "bob")),
+        is(true)
+    );
+  }
+
+  @Test
+  public void shouldIgnoreNullNonKeyColumns() {
+    // When:
+    StreamSelectKeyBuilder.build(kstream, selectKey);
+
+    // Then:
+    verify(kstream).filter(predicateCaptor.capture());
+    final Predicate<Struct, GenericRow> predicate = getPredicate();
+    assertThat(predicate.test(asStructKey("dre"), new GenericRow(0, "dre", null, "bob")), is(true));
+  }
+
+  @Test
+  public void shouldComputeCorrectKey() {
+    // When:
+    StreamSelectKeyBuilder.build(kstream, selectKey);
+
+    // Then:
+    final KeyValueMapper<Struct, GenericRow, Struct> keyValueMapper = getKeyMapper();
+    assertThat(
+        keyValueMapper.apply(asStructKey("dre"), new GenericRow(0, "dre", 3000, "bob")),
+        is(asStructKey("bob"))
+    );
+  }
+
+  @Test
+  public void shouldUpdateRowkeyIfUpdateRowkeyTrue() {
+    // When:
+    StreamSelectKeyBuilder.build(kstream, selectKey);
+
+    // Then:
+    verify(rekeyedKstream).mapValues(mapperCaptor.capture());
+    final ValueMapperWithKey<Struct, GenericRow, GenericRow> mapper = getMapper();
+    assertThat(
+        mapper.apply(asStructKey("bob"), new GenericRow(0, "dre", 3000, "bob")),
+        equalTo(new GenericRow(0, "bob", 3000, "bob"))
+    );
+  }
+
+  @Test
+  public void shouldNotUpdateRowkeyIfUpdateRowkeyTrue() {
+    // Given:
+    givenUpdateRowkeyFalse();
+
+    // When:
+    StreamSelectKeyBuilder.build(kstream, selectKey);
+
+    // Then:
+    final ValueMapperWithKey<Struct, GenericRow, GenericRow> mapper = getMapper();
+    assertThat(
+        mapper.apply(asStructKey("bob"), new GenericRow(0, "dre", 3000, "bob")),
+        equalTo(new GenericRow(0, "dre", 3000, "bob"))
+    );
+  }
+
+  private KeyValueMapper<Struct, GenericRow, Struct> getKeyMapper() {
+    verify(filteredKStream).selectKey(keyValueMapperCaptor.capture());
+    return keyValueMapperCaptor.getValue();
+  }
+
+  private ValueMapperWithKey<Struct, GenericRow, GenericRow> getMapper() {
+    verify(rekeyedKstream).mapValues(mapperCaptor.capture());
+    return mapperCaptor.getValue();
+  }
+
+  private Predicate<Struct, GenericRow> getPredicate() {
+    verify(kstream).filter(predicateCaptor.capture());
+    return predicateCaptor.getValue();
+  }
+}


### PR DESCRIPTION
### Description 
Moves rekeying from SchemaKStream and into an execution plan builder.

### Testing done 
Added tests for step builder

### Reviewer checklist
- [ ] Ensure docs are updated if necessary. (eg. if a user visible feature is being added or changed).
- [ ] Ensure relevant issues are linked (description should include text like "Fixes #<issue number>")

