### PR TITLE
Avoid unnecessary repartition of stream on `GROUP BY ROWKEY`

### DIFF
--- a/ksql-common/src/main/java/io/confluent/ksql/util/KsqlConfig.java
+++ b/ksql-common/src/main/java/io/confluent/ksql/util/KsqlConfig.java
@@ -148,6 +148,8 @@ public class KsqlConfig extends AbstractConfig {
   private static final String KSQL_USE_NAMED_AVRO_MAPS_DOC = "";
 
   public static final String KSQL_USE_LEGACY_KEY_FIELD = "ksql.query.fields.key.legacy";
+  public static final String KSQL_LEGACY_REPARTITION_ON_GROUP_BY_ROWKEY =
+      "ksql.query.stream.groupby.rowkey.repartition";
 
   public static final String KSQL_WRAP_SINGLE_VALUES =
       "ksql.persistence.wrap.single.values";
@@ -277,6 +279,16 @@ public class KsqlConfig extends AbstractConfig {
                   + "This setting is automatically applied for persistent queries started by "
                   + "older versions of KSQL. "
                   + "This setting should not be set manually."
+          ),
+          new CompatibilityBreakingConfigDef(
+              KSQL_LEGACY_REPARTITION_ON_GROUP_BY_ROWKEY,
+              ConfigDef.Type.BOOLEAN,
+              true,
+              false,
+              ConfigDef.Importance.LOW,
+              Optional.empty(),
+              "Ensures legacy queries that perform a 'GROUP BY ROWKEY' continue to "
+                  + "perform an unnecessary repartition step"
           )
   );
 

--- a/ksql-functional-tests/README.md
+++ b/ksql-functional-tests/README.md
@@ -241,7 +241,10 @@ A test can define a set of post conditions that must be met for the test to pass
   "post": {
     "sources": [
       {"name": "INPUT", "type": "stream", "keyField": null}
-    ]
+    ],
+    "topics": {
+      "blacklist": ".*-not-allowed"
+    }
   }
 }
 ```
@@ -272,6 +275,22 @@ Each source can define the following attributes:
 | type        | (Required) Specifies if the source is a STREAM or TABLE. |
 | keyField    | (Optional) Specifies the keyField for the source. (See below for details of key field) |
 | valueSchema | (Optional) Specifies the value SQL schema for the source. |
+
+#### Topics
+A post condition can define a check against the set of topics the case creates
+
+```json
+{
+  "blacklist": ".*-repartition"
+}
+```
+
+The topics object can define the following attributes:
+
+| Attribute   | Description |
+|-------------|:------------|
+| blacklist   | Regex defining a blacklist of topic names that should not be created. |
+
 
 ##### Key Fields
 

--- a/ksql-functional-tests/src/main/java/io/confluent/ksql/test/model/PostConditionsNode.java
+++ b/ksql-functional-tests/src/main/java/io/confluent/ksql/test/model/PostConditionsNode.java
@@ -22,16 +22,23 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import com.google.common.collect.ImmutableList;
 import io.confluent.ksql.metastore.model.DataSource;
 import io.confluent.ksql.test.tools.conditions.PostConditions;
+import io.confluent.ksql.test.tools.exceptions.InvalidFieldException;
 import java.util.List;
+import java.util.regex.Pattern;
 import org.hamcrest.Matcher;
 
 @JsonIgnoreProperties(ignoreUnknown = true)
 public final class PostConditionsNode {
 
   private final List<SourceNode> sources;
+  private final TopicsNode topics;
 
-  public PostConditionsNode(@JsonProperty("sources") final List<SourceNode> sources) {
+  public PostConditionsNode(
+      @JsonProperty("sources") final List<SourceNode> sources,
+      @JsonProperty("topics") final TopicsNode topics
+  ) {
     this.sources = sources == null ? ImmutableList.of() : ImmutableList.copyOf(sources);
+    this.topics = topics == null ? new TopicsNode(PostConditions.MATCH_NOTHING) : topics;
   }
 
   @SuppressWarnings("unchecked")
@@ -41,6 +48,28 @@ public final class PostConditionsNode {
         .toArray(Matcher[]::new);
 
     final Matcher<Iterable<DataSource<?>>> sourcesMatcher = hasItems(matchers);
-    return new PostConditions(sourcesMatcher);
+    final Pattern blackListPattern = topics.build();
+
+    return new PostConditions(sourcesMatcher, blackListPattern);
+  }
+
+  @JsonIgnoreProperties(ignoreUnknown = true)
+  public static final class TopicsNode {
+
+    private final String blackList;
+
+    public TopicsNode(
+        @JsonProperty("blacklist") final String blackList
+    ) {
+      this.blackList = blackList == null ? "" : blackList;
+    }
+
+    Pattern build() {
+      try {
+        return Pattern.compile(blackList);
+      } catch (final Exception e) {
+        throw new InvalidFieldException("blacklist", "not valid regex", e);
+      }
+    }
   }
 }

--- a/ksql-functional-tests/src/main/java/io/confluent/ksql/test/tools/KafkaStreamsInternalTopicsAccessor.java
+++ b/ksql-functional-tests/src/main/java/io/confluent/ksql/test/tools/KafkaStreamsInternalTopicsAccessor.java
@@ -1,0 +1,54 @@
+/*
+ * Copyright 2019 Confluent Inc.
+ *
+ * Licensed under the Confluent Community License (the "License"); you may not use
+ * this file except in compliance with the License.  You may obtain a copy of the
+ * License at
+ *
+ * http://www.confluent.io/confluent-community-license
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package io.confluent.ksql.test.tools;
+
+import java.lang.reflect.Field;
+import java.util.Set;
+import org.apache.kafka.streams.TopologyTestDriver;
+
+/**
+ * Hack to get around the fact that the {@link TopologyTestDriver} class does not expose its set of
+ * internal topics, which is needed to determine if any unexpected topics have been created.
+ */
+final class KafkaStreamsInternalTopicsAccessor {
+
+  private static final Field INTERNAL_TOPICS_FIELD = getInternalTopicsField();
+
+  private KafkaStreamsInternalTopicsAccessor() {
+  }
+
+  @SuppressWarnings("unchecked")
+  static Set<String> getInternalTopics(
+      final TopologyTestDriver topologyTestDriver
+  ) {
+    try {
+      return (Set<String>) INTERNAL_TOPICS_FIELD.get(topologyTestDriver);
+    } catch (IllegalAccessException e) {
+      throw new AssertionError("Failed to get internal topic names", e);
+    }
+  }
+
+  private static Field getInternalTopicsField() {
+    try {
+      final Field field = TopologyTestDriver.class.getDeclaredField("internalTopics");
+      field.setAccessible(true);
+      return field;
+    } catch (final NoSuchFieldException e) {
+      throw new AssertionError(
+          "Kafka Streams's TopologyTestDriver class has changed its internals", e);
+    }
+  }
+}

--- a/ksql-functional-tests/src/test/resources/query-validation-tests/group-by.json
+++ b/ksql-functional-tests/src/test/resources/query-validation-tests/group-by.json
@@ -509,6 +509,35 @@
       ]
     },
     {
+      "name": "ROWKEY (stream->table) - without repartition",
+      "comment": [
+        "Clone of test 'ROWKEY (stream->table)' but checking no repartition topic is created post v5.4"
+      ],
+      "statements": [
+        "CREATE STREAM TEST (ignored VARCHAR) WITH (kafka_topic='test_topic', value_format='DELIMITED');",
+        "CREATE TABLE OUTPUT AS SELECT ROWKEY, COUNT(*) FROM TEST GROUP BY ROWKEY;"
+      ],
+      "inputs": [
+        {"topic": "test_topic", "key": 1, "value": "-"},
+        {"topic": "test_topic", "key": 2, "value": "-"},
+        {"topic": "test_topic", "key": 1, "value": "-"},
+        {"topic": "test_topic", "key": 2, "value": "-"},
+        {"topic": "test_topic", "key": 1, "value": "-"}
+      ],
+      "outputs": [
+        {"topic": "OUTPUT", "key": "1", "value": "1"},
+        {"topic": "OUTPUT", "key": "2", "value": "1"},
+        {"topic": "OUTPUT", "key": "1", "value": "2"},
+        {"topic": "OUTPUT", "key": "2", "value": "2"},
+        {"topic": "OUTPUT", "key": "1", "value": "3"}
+      ],
+      "post": {
+        "topics": {
+          "blacklist": ".*-repartition"
+        }
+      }
+    },
+    {
       "name": "ROWKEY without ROWKEY in projection (stream->table)",
       "statements": [
         "CREATE STREAM TEST (ignored VARCHAR) WITH (kafka_topic='test_topic', value_format='DELIMITED');",

--- a/ksql-functional-tests/src/test/resources/query-validation-tests/key-field.json
+++ b/ksql-functional-tests/src/test/resources/query-validation-tests/key-field.json
@@ -60,7 +60,10 @@
       "post": {
         "sources": [
           {"name": "OUTPUT", "type": "stream", "keyField": {"name": null, "legacyName": null}}
-        ]
+        ],
+        "topics": {
+          "blacklist": ".*-repartition"
+        }
       }
     },
     {
@@ -425,7 +428,10 @@
       "post": {
         "sources": [
           {"name": "DOWNSTREAM", "type": "stream", "keyField": {"name": "FOO", "legacyName": "FOO", "legacySchema": "INT"}}
-        ]
+        ],
+        "topics": {
+          "blacklist": ".*-repartition"
+        }
       }
     },
     {
@@ -492,7 +498,10 @@
         "sources": [
           {"name": "INPUT", "type": "stream", "keyField": {"name": "FOO", "legacyName": "FOO", "legacySchema": "INT"}},
           {"name": "OUTPUT", "type": "stream", "keyField": {"name": "FOO", "legacyName": "FOO", "legacySchema": "INT"}}
-        ]
+        ],
+        "topics": {
+          "blacklist": ".*-repartition"
+        }
       }
     },
     {
@@ -533,7 +542,10 @@
         "sources": [
           {"name": "INPUT", "type": "stream", "keyField": {"name": "FOO"}},
           {"name": "OUTPUT", "type": "stream", "keyField": {"name": "ALIASED"}}
-        ]
+        ],
+        "topics": {
+          "blacklist": ".*-repartition"
+        }
       }
     },
     {
@@ -582,7 +594,10 @@
         "sources": [
           {"name": "INPUT", "type": "stream", "keyField": {"name": "FOO", "legacyName": "FOO", "legacySchema": "INT"}},
           {"name": "OUTPUT", "type": "stream", "keyField": {"name": "ALIASED", "legacyName": "ALIASED", "legacySchema": "INT"}}
-        ]
+        ],
+        "topics": {
+          "blacklist": ".*-repartition"
+        }
       }
     },
     {
@@ -612,7 +627,10 @@
         "sources": [
           {"name": "INPUT", "type": "stream", "keyField": {"name": "FOO", "legacyName": "FOO", "legacySchema": "INT"}},
           {"name": "OUTPUT", "type": "table", "keyField": {"name": "FOO", "legacyName": "FOO", "legacySchema": "INT"}}
-        ]
+        ],
+        "topics": {
+          "blacklist": ".*-repartition"
+        }
       }
     },
     {
@@ -631,7 +649,10 @@
         "sources": [
           {"name": "INPUT", "type": "stream", "keyField": {"name": "FOO", "legacyName": "FOO", "legacySchema": "INT"}},
           {"name": "OUTPUT", "type": "table", "keyField": {"name": "ALIASED", "legacyName": "ALIASED", "legacySchema": "INT"}}
-        ]
+        ],
+        "topics": {
+          "blacklist": ".*-repartition"
+        }
       }
     },
     {
@@ -649,7 +670,10 @@
       "post": {
         "sources": [
           {"name": "OUTPUT", "type": "table", "keyField": {"name": null, "legacyName": null}}
-        ]
+        ],
+        "topics": {
+          "blacklist": ".*-repartition"
+        }
       }
     },
     {

--- a/ksql-functional-tests/src/test/resources/query-validation-tests/partition-by.json
+++ b/ksql-functional-tests/src/test/resources/query-validation-tests/partition-by.json
@@ -116,7 +116,12 @@
         "CREATE STREAM OUTPUT AS select * from INPUT partition by ROWKEY;"
       ],
       "inputs": [{"topic": "input", "key": 10, "value": {"ID":  22}}],
-      "outputs": [{"topic": "OUTPUT", "key": "10", "value": {"ID":  22}}]
+      "outputs": [{"topic": "OUTPUT", "key": "10", "value": {"ID":  22}}],
+      "post": {
+        "topics": {
+          "blacklist": ".*-repartition"
+        }
+      }
     },
     {
       "name": "partition by ROWTIME",


### PR DESCRIPTION
### Description 

Note: this PR is based of the [QTT blacklist PR](https://github.com/confluentinc/ksql/pull/3365) - review that first. 

While investigating recent RQTT build failures I noticed that the queries that involved a `GROUP BY ROWKEY` were going through a repartition topic - which is unnecessary and costly.

This PR fixes the issue and adds a new compatibility breaking config to ensure old queries continue to maintain the repartition step to avoid data loss.

### Testing done 

Tests added.

### Reviewer checklist
- [ ] Ensure docs are updated if necessary. (eg. if a user visible feature is being added or changed).
- [ ] Ensure relevant issues are linked (description should include text like "Fixes #<issue number>")

