### PR TITLE
test: harden the StaticQueryFunctionalTest (MINOR)

### DIFF
--- a/ksql-rest-app/src/test/java/io/confluent/ksql/rest/integration/StaticQueryFunctionalTest.java
+++ b/ksql-rest-app/src/test/java/io/confluent/ksql/rest/integration/StaticQueryFunctionalTest.java
@@ -133,8 +133,6 @@ public class StaticQueryFunctionalTest {
   public void cleanUp() {
     REST_APP_0.closePersistentQueries();
     REST_APP_0.dropSourcesExcept(USERS_STREAM);
-    REST_APP_1.closePersistentQueries();
-    REST_APP_1.dropSourcesExcept(USERS_STREAM);
   }
 
   @Test


### PR DESCRIPTION
### Description 

Seeing occasional test failures:

```
java.lang.AssertionError:
Failed to terminate queries. lastError:Unknown queryId: CTAS_ID_18_0

	at io.confluent.ksql.rest.integration.StaticQueryFunctionalTest.cleanUp(StaticQueryFunctionalTest.java:136)
```

This was because the test tries to stop all queries and drop all source ON BOTH instances.  But they're communicating through the command topic, so its only needed on one!

### Testing done 

`mvn test`.

### Reviewer checklist
- [ ] Ensure docs are updated if necessary. (eg. if a user visible feature is being added or changed).
- [ ] Ensure relevant issues are linked (description should include text like "Fixes #<issue number>")

