### PR TITLE
fix:Output to console the key and value that was inserted by a I…

### DIFF
--- a/ksql-cli/src/main/java/io/confluent/ksql/cli/console/Console.java
+++ b/ksql-cli/src/main/java/io/confluent/ksql/cli/console/Console.java
@@ -62,6 +62,7 @@ import io.confluent.ksql.rest.entity.KsqlEntityList;
 import io.confluent.ksql.rest.entity.KsqlErrorMessage;
 import io.confluent.ksql.rest.entity.KsqlStatementErrorMessage;
 import io.confluent.ksql.rest.entity.KsqlWarning;
+import io.confluent.ksql.rest.entity.MessageEntity;
 import io.confluent.ksql.rest.entity.PropertiesList;
 import io.confluent.ksql.rest.entity.Queries;
 import io.confluent.ksql.rest.entity.QueryDescription;
@@ -166,6 +167,7 @@ public class Console implements Closeable {
               tablePrinter(ErrorEntity.class, ErrorEntityTableBuilder::new))
           .put(QueryResultEntity.class,
               tablePrinter(QueryResultEntity.class, QueryResultTableBuilder::new))
+          .put(MessageEntity.class, Console::printMessage)
           .build();
 
   private static <T extends KsqlEntity> Handler1<KsqlEntity, Console> tablePrinter(
@@ -784,6 +786,12 @@ public class Console implements Closeable {
       flush();
     } catch (final IOException e) {
       throw new RuntimeIOException("Failed to write to console", e);
+    }
+  }
+
+  private void printMessage(final MessageEntity message) {
+    if (message.getMessage().isPresent()) {
+      writer().println(message.getMessage().get());
     }
   }
 

--- a/ksql-cli/src/test/java/io/confluent/ksql/cli/CliTest.java
+++ b/ksql-cli/src/test/java/io/confluent/ksql/cli/CliTest.java
@@ -860,6 +860,28 @@ public class CliTest {
   }
 
   @Test
+  public void shouldDisplayInsertedKeyValue() throws Exception {
+
+    final String message = String.format(
+        "Inserted:%nkey:%s%nvalue:%s%n",
+        "null",
+        "[ 294 | 8.1 ]"
+    );
+
+    final String line =
+        "CREATE STREAM " + streamName + "(id INT, rating DOUBLE) WITH "
+            + "(kafka_topic='ratings', partitions=1, value_format='json');\n"
+        + "INSERT INTO " + streamName + "(id, rating) VALUES (294, 8.1);";
+
+    localCli.handleLine(line);
+
+    dropStream(streamName);
+
+    final String output = terminal.getOutputString();
+    assertThat(output, containsString(message));
+  }
+
+  @Test
   public void shouldPrintErrorIfCantFindFunction() throws Exception {
     localCli.handleLine("describe function foobar;");
 

--- a/ksql-cli/src/test/java/io/confluent/ksql/cli/CliTest.java
+++ b/ksql-cli/src/test/java/io/confluent/ksql/cli/CliTest.java
@@ -246,6 +246,9 @@ public class CliTest {
     System.out.println("[Terminal Output]");
     System.out.println(terminal.getOutputString());
 
+    dropStream(streamName);
+    dropTable(tableName);
+
     localCli.close();
     console.close();
   }
@@ -276,8 +279,6 @@ public class CliTest {
     /* Assert Results */
     final Map<String, GenericRow> results = topicConsumer
         .readResults(streamName, resultSchema, expectedResults.size(), new StringDeserializer());
-
-    dropStream(streamName);
 
     assertThat(results, equalTo(expectedResults));
   }
@@ -698,7 +699,6 @@ public class CliTest {
             isRow(is("Parsing statement")),
             isRow(is("Executing statement"))));
 
-    dropTable(tableName);
   }
 
   @Test
@@ -862,22 +862,23 @@ public class CliTest {
   @Test
   public void shouldDisplayInsertedKeyValue() throws Exception {
 
-    final String message = String.format(
-        "Inserted:%nkey:%s%nvalue:%s%n",
-        "null",
-        "[ 294 | 8.1 ]"
-    );
+    final String message =
+        "Inserted:\n"
+        + "key:null\n"
+        + "value:[ 294 | 8.1 ]";
 
+    // Given:
     final String line =
         "CREATE STREAM " + streamName + "(id INT, rating DOUBLE) WITH "
             + "(kafka_topic='ratings', partitions=1, value_format='json');\n"
         + "INSERT INTO " + streamName + "(id, rating) VALUES (294, 8.1);";
 
+    // When:
     localCli.handleLine(line);
 
-    dropStream(streamName);
-
     final String output = terminal.getOutputString();
+
+    // Then:
     assertThat(output, containsString(message));
   }
 

--- a/ksql-engine/src/main/java/io/confluent/ksql/engine/InsertValuesExecutor.java
+++ b/ksql-engine/src/main/java/io/confluent/ksql/engine/InsertValuesExecutor.java
@@ -146,6 +146,8 @@ public class InsertValuesExecutor {
     try {
       producer.sendRecord(producerRecordInfo.record,
           serviceContext, config.getProducerClientConfigProps());
+
+      return Optional.of(producerRecordInfo.toString());
     } catch (final TopicAuthorizationException e) {
       // TopicAuthorizationException does not give much detailed information about why it failed,
       // except which topics are denied. Here we just add the ACL to make the error message
@@ -159,13 +161,6 @@ public class InsertValuesExecutor {
     } catch (final Exception e) {
       throw new KsqlException(createInsertFailedExceptionMessage(insertValues), e);
     }
-
-    final String message = String.format(
-        "Inserted:%nkey:%s%nvalue:%s%n",
-        producerRecordInfo.row.key.get("ROWKEY"),
-        producerRecordInfo.row.value
-        );
-    return Optional.of(message);
   }
 
   private ProducerRecordInfo buildRecord(
@@ -478,8 +473,17 @@ public class InsertValuesExecutor {
 
     ProducerRecordInfo(final RowData row,
         final ProducerRecord<byte[], byte[]> record) {
-      this.row = row;
-      this.record = record;
+      this.row = Objects.requireNonNull(row);
+      this.record = Objects.requireNonNull(record);
+    }
+
+    @Override
+    public String toString() {
+      return String.format(
+          "Inserted:%nkey:%s%nvalue:%s%n",
+          row.key.get("ROWKEY"),
+          row.value
+      );
     }
   }
 

--- a/ksql-rest-app/src/main/java/io/confluent/ksql/rest/server/execution/CustomExecutors.java
+++ b/ksql-rest-app/src/main/java/io/confluent/ksql/rest/server/execution/CustomExecutors.java
@@ -38,6 +38,7 @@ import io.confluent.ksql.parser.tree.ShowColumns;
 import io.confluent.ksql.parser.tree.Statement;
 import io.confluent.ksql.parser.tree.UnsetProperty;
 import io.confluent.ksql.rest.entity.KsqlEntity;
+import io.confluent.ksql.rest.entity.MessageEntity;
 import io.confluent.ksql.services.ServiceContext;
 import io.confluent.ksql.statement.ConfiguredStatement;
 import java.util.EnumSet;
@@ -116,8 +117,9 @@ public enum CustomExecutors {
     final InsertValuesExecutor executor = new InsertValuesExecutor();
 
     return (statement, executionContext, serviceContext) -> {
-      executor.execute(statement, executionContext, serviceContext);
-      return Optional.empty();
+      final Optional<String> message =
+          executor.execute(statement, executionContext, serviceContext);
+      return Optional.of(new MessageEntity(statement.getStatementText(), null, message));
     };
   }
 }

--- a/ksql-rest-app/src/main/java/io/confluent/ksql/rest/server/execution/CustomExecutors.java
+++ b/ksql-rest-app/src/main/java/io/confluent/ksql/rest/server/execution/CustomExecutors.java
@@ -115,11 +115,10 @@ public enum CustomExecutors {
 
   private static StatementExecutor insertValuesExecutor() {
     final InsertValuesExecutor executor = new InsertValuesExecutor();
-
     return (statement, executionContext, serviceContext) -> {
-      final Optional<String> message =
-          executor.execute(statement, executionContext, serviceContext);
-      return Optional.of(new MessageEntity(statement.getStatementText(), null, message));
+      final Optional<String> res = executor.execute(statement, executionContext, serviceContext);
+      return res.map(msg -> new MessageEntity(statement.getStatementText(),
+              null, Optional.of(msg)));
     };
   }
 }

--- a/ksql-rest-model/src/main/java/io/confluent/ksql/rest/entity/KsqlEntity.java
+++ b/ksql-rest-model/src/main/java/io/confluent/ksql/rest/entity/KsqlEntity.java
@@ -49,7 +49,8 @@ import java.util.List;
     @JsonSubTypes.Type(value = ConnectorDescription.class, name = "connector_description"),
     @JsonSubTypes.Type(value = TypeList.class, name = "type_list"),
     @JsonSubTypes.Type(value = ErrorEntity.class, name = "error_entity"),
-    @JsonSubTypes.Type(value = QueryResultEntity.class, name = "row")
+    @JsonSubTypes.Type(value = QueryResultEntity.class, name = "row"),
+    @JsonSubTypes.Type(value = MessageEntity.class, name = "message")
 })
 public abstract class KsqlEntity {
   private final String statementText;

--- a/ksql-rest-model/src/main/java/io/confluent/ksql/rest/entity/MessageEntity.java
+++ b/ksql-rest-model/src/main/java/io/confluent/ksql/rest/entity/MessageEntity.java
@@ -31,13 +31,13 @@ public class MessageEntity extends KsqlEntity {
       @JsonProperty("warnings")       final List<KsqlWarning> warnings,
       @JsonProperty("message")        final Optional<String> message) {
     super(statementText, warnings);
-    Objects.requireNonNull(message);
-    this.message = message;
+    this.message = Objects.requireNonNull(message);
   }
 
   public Optional<String> getMessage() {
     return message;
   }
+
 
   @Override
   public boolean equals(final Object o) {

--- a/ksql-rest-model/src/main/java/io/confluent/ksql/rest/entity/MessageEntity.java
+++ b/ksql-rest-model/src/main/java/io/confluent/ksql/rest/entity/MessageEntity.java
@@ -1,0 +1,59 @@
+/*
+ * Copyright 2018 Confluent Inc.
+ *
+ * Licensed under the Confluent Community License (the "License"); you may not use
+ * this file except in compliance with the License.  You may obtain a copy of the
+ * License at
+ *
+ * http://www.confluent.io/confluent-community-license
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package io.confluent.ksql.rest.entity;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import java.util.List;
+import java.util.Objects;
+import java.util.Optional;
+
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class MessageEntity extends KsqlEntity {
+
+  private final Optional<String> message;
+
+  public MessageEntity(
+      @JsonProperty("statementText")  final String statementText,
+      @JsonProperty("warnings")       final List<KsqlWarning> warnings,
+      @JsonProperty("message")        final Optional<String> message) {
+    super(statementText, warnings);
+    Objects.requireNonNull(message);
+    this.message = message;
+  }
+
+  public Optional<String> getMessage() {
+    return message;
+  }
+
+  @Override
+  public boolean equals(final Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    final MessageEntity that = (MessageEntity) o;
+    return message.equals(that.message);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(message);
+  }
+}
+


### PR DESCRIPTION
### Description
Fixes #3349
This PR introduces a change whereby the key and value that was inserted is now output to the console after a successful INSERT INTO statement.

Here's an example

```
INSERT INTO ratings (id, rating) VALUES (294, 8.1)
Inserted:
key:null
value:[ 294 | 8.1 ]
```
### Testing done

Manual testing
Added a new CliTest

### Reviewer checklist
- [ ] Ensure docs are updated if necessary. (eg. if a user visible feature is being added or changed).
- [ ] Ensure relevant issues are linked (description should include text like "Fixes #<issue number>")

