### PR TITLE
test: stabilise RQTT (MINOR)

### DIFF
--- a/ksql-functional-tests/src/test/java/io/confluent/ksql/test/rest/RestTestExecutor.java
+++ b/ksql-functional-tests/src/test/java/io/confluent/ksql/test/rest/RestTestExecutor.java
@@ -177,13 +177,13 @@ public class RestTestExecutor implements Closeable {
       return results;
     }
 
-    if (!testCase.expectedError().isPresent()
-        && testCase.getExpectedResponses().size() > firstStatic
-    ) {
-      final String firstStaticStatement = statics.get(0);
-      final Response firstStaticResponse = testCase.getExpectedResponses().get(firstStatic);
+    if (!testCase.expectedError().isPresent()) {
+      for (int idx = firstStatic; testCase.getExpectedResponses().size() > idx; ++idx) {
+        final String staticStatement = allStatements.get(firstStatic);
+        final Response staticResponse = testCase.getExpectedResponses().get(firstStatic);
 
-      waitForWarmStateStores(firstStaticStatement, firstStaticResponse);
+        waitForWarmStateStores(staticStatement, staticResponse);
+      }
     }
 
     final Optional<List<KsqlEntity>> moreResults = sendStatements(testCase, statics);


### PR DESCRIPTION
### Description 

To work around the inherent race condition between state stores warming up and static query requests the test executor has a retry look on static queries to give KS time to process messages.

Previously, this retry look was only around the first static query.  However, it's possible that the KS has processed enough input to meet the expected output of the first static query, but not the second.  Hence, to stabilise this test the executor must retry each static query in turn, thereby ensuring KS has time to process the input required to meet each static query's expected response.

### Testing done 

Ran tests many 100's of times locally.

### Reviewer checklist
- [ ] Ensure docs are updated if necessary. (eg. if a user visible feature is being added or changed).
- [ ] Ensure relevant issues are linked (description should include text like "Fixes #<issue number>")

