### PR TITLE
Fix: Consistency between inserted rowkey and key values when inserting into a table with a key

### DIFF
--- a/ksql-engine/src/main/java/io/confluent/ksql/engine/InsertValuesExecutor.java
+++ b/ksql-engine/src/main/java/io/confluent/ksql/engine/InsertValuesExecutor.java
@@ -323,8 +323,12 @@ public class InsertValuesExecutor {
       final Object rowKeyValue = values.get(SchemaUtil.ROWKEY_NAME);
 
       if (keyValue != null ^ rowKeyValue != null) {
-        values.putIfAbsent(key, rowKeyValue);
-        values.putIfAbsent(SchemaUtil.ROWKEY_NAME, keyValue);
+        if (keyValue == null) {
+          values.putIfAbsent(key, rowKeyValue);
+        } else {
+          // Note, ROWKEY must always be a String
+          values.putIfAbsent(SchemaUtil.ROWKEY_NAME, keyValue.toString());
+        }
       } else if (!Objects.equals(keyValue, rowKeyValue)) {
         throw new KsqlException(
             String.format(

--- a/ksql-engine/src/main/java/io/confluent/ksql/engine/InsertValuesExecutor.java
+++ b/ksql-engine/src/main/java/io/confluent/ksql/engine/InsertValuesExecutor.java
@@ -324,10 +324,9 @@ public class InsertValuesExecutor {
 
       if (keyValue != null ^ rowKeyValue != null) {
         if (keyValue == null) {
-          values.putIfAbsent(key, rowKeyValue);
+          values.put(key, rowKeyValue);
         } else {
-          // Note, ROWKEY must always be a String, but key might not be so we need toString()
-          values.putIfAbsent(SchemaUtil.ROWKEY_NAME, keyValue.toString());
+          values.put(SchemaUtil.ROWKEY_NAME, keyValue.toString());
         }
       } else if (keyValue != null && !Objects.equals(keyValue.toString(), rowKeyValue)) {
         throw new KsqlException(String.format(

--- a/ksql-engine/src/main/java/io/confluent/ksql/engine/InsertValuesExecutor.java
+++ b/ksql-engine/src/main/java/io/confluent/ksql/engine/InsertValuesExecutor.java
@@ -329,8 +329,7 @@ public class InsertValuesExecutor {
           // Note, ROWKEY must always be a String, but key might not be so we need toString()
           values.putIfAbsent(SchemaUtil.ROWKEY_NAME, keyValue.toString());
         }
-      } else if (keyValue != null) {
-        if (!Objects.equals(keyValue.toString(), rowKeyValue)) {
+      } else if (keyValue != null && !Objects.equals(keyValue.toString(), rowKeyValue)) {
           throw new KsqlException(
               String.format(
                   "Expected ROWKEY and %s to match but got %s and %s respectively.",

--- a/ksql-engine/src/main/java/io/confluent/ksql/engine/InsertValuesExecutor.java
+++ b/ksql-engine/src/main/java/io/confluent/ksql/engine/InsertValuesExecutor.java
@@ -326,14 +326,16 @@ public class InsertValuesExecutor {
         if (keyValue == null) {
           values.putIfAbsent(key, rowKeyValue);
         } else {
-          // Note, ROWKEY must always be a String
+          // Note, ROWKEY must always be a String, but key might not be so we need toString()
           values.putIfAbsent(SchemaUtil.ROWKEY_NAME, keyValue.toString());
         }
-      } else if (!Objects.equals(keyValue, rowKeyValue)) {
-        throw new KsqlException(
-            String.format(
-                "Expected ROWKEY and %s to match but got %s and %s respectively.",
-                key, rowKeyValue, keyValue));
+      } else if (keyValue != null) {
+        if (!Objects.equals(keyValue.toString(), rowKeyValue)) {
+          throw new KsqlException(
+              String.format(
+                  "Expected ROWKEY and %s to match but got %s and %s respectively.",
+                  key, rowKeyValue, keyValue));
+        }
       }
     }
   }

--- a/ksql-engine/src/main/java/io/confluent/ksql/engine/InsertValuesExecutor.java
+++ b/ksql-engine/src/main/java/io/confluent/ksql/engine/InsertValuesExecutor.java
@@ -330,11 +330,9 @@ public class InsertValuesExecutor {
           values.putIfAbsent(SchemaUtil.ROWKEY_NAME, keyValue.toString());
         }
       } else if (keyValue != null && !Objects.equals(keyValue.toString(), rowKeyValue)) {
-          throw new KsqlException(
-              String.format(
-                  "Expected ROWKEY and %s to match but got %s and %s respectively.",
-                  key, rowKeyValue, keyValue));
-        }
+        throw new KsqlException(String.format(
+            "Expected ROWKEY and %s to match but got %s and %s respectively.",
+            key, rowKeyValue, keyValue));
       }
     }
   }

--- a/ksql-functional-tests/src/test/resources/rest-query-validation-tests/insert-values.json
+++ b/ksql-functional-tests/src/test/resources/rest-query-validation-tests/insert-values.json
@@ -67,7 +67,7 @@
       ]
     },
     {
-      "name": "rowkey should be set when stream has int key and only id specified in insert",
+      "name": "rowkey should be set when stream has int key and only key specified in insert",
       "statements": [
         "CREATE STREAM TEST (ID INT) WITH (kafka_topic='test_topic', value_format='JSON', key='ID');",
         "INSERT INTO TEST (ID) VALUES (10);"
@@ -79,7 +79,7 @@
       ]
     },
     {
-      "name": "rowkey should be set when stream has String key and only id specified in insert",
+      "name": "rowkey should be set when stream has String key and only key specified in insert",
       "statements": [
         "CREATE STREAM TEST (ID VARCHAR) WITH (kafka_topic='test_topic', value_format='JSON', key='ID');",
         "INSERT INTO TEST (ID) VALUES ('10');"
@@ -91,7 +91,7 @@
       ]
     },
     {
-      "name": "rowkey should be set when stream has double key and only id specified in insert",
+      "name": "rowkey should be set when stream has double key and only key specified in insert",
       "statements": [
         "CREATE STREAM TEST (ID DOUBLE) WITH (kafka_topic='test_topic', value_format='JSON', key='ID');",
         "INSERT INTO TEST (ID) VALUES (1.23);"
@@ -103,7 +103,7 @@
       ]
     },
     {
-      "name": "rowkey should be set when stream has bigint key and only id specified in insert",
+      "name": "rowkey should be set when stream has bigint key and only key specified in insert",
       "statements": [
         "CREATE STREAM TEST (ID BIGINT) WITH (kafka_topic='test_topic', value_format='JSON', key='ID');",
         "INSERT INTO TEST (ID) VALUES (10);"
@@ -115,7 +115,7 @@
       ]
     },
     {
-      "name": "rowkey should be set when stream has boolean key and only id specified in insert",
+      "name": "rowkey should be set when stream has boolean key and only key specified in insert",
       "statements": [
         "CREATE STREAM TEST (ID BOOLEAN) WITH (kafka_topic='test_topic', value_format='JSON', key='ID');",
         "INSERT INTO TEST (ID) VALUES (TRUE);"
@@ -127,7 +127,7 @@
       ]
     },
     {
-      "name": "id should be set when stream has string key and only rowkey specicified in insert",
+      "name": "keyfield should be set when stream has string key and only rowkey specified in insert",
       "statements": [
         "CREATE STREAM TEST (ID STRING) WITH (kafka_topic='test_topic', value_format='JSON', key='ID');",
         "INSERT INTO TEST (ROWKEY) VALUES ('10');"
@@ -139,7 +139,7 @@
       ]
     },
     {
-      "name": "rowkey and id should match when stream has int key",
+      "name": "rowkey and key should match when stream has int key",
       "statements": [
         "CREATE STREAM TEST (ID INT) WITH (kafka_topic='test_topic', value_format='JSON', key='ID');",
         "INSERT INTO TEST (ROWKEY, ID) VALUES ('10', 10);"
@@ -151,7 +151,7 @@
       ]
     },
     {
-      "name": "rowkey and id should match when stream has String key",
+      "name": "rowkey and key should match when stream has String key",
       "statements": [
         "CREATE STREAM TEST (ID STRING) WITH (kafka_topic='test_topic', value_format='JSON', key='ID');",
         "INSERT INTO TEST (ROWKEY, ID) VALUES ('10', '10');"
@@ -163,7 +163,7 @@
       ]
     },
     {
-      "name": "rowkey and id should match when stream has double key",
+      "name": "rowkey and key should match when stream has double key",
       "statements": [
         "CREATE STREAM TEST (ID DOUBLE) WITH (kafka_topic='test_topic', value_format='JSON', key='ID');",
         "INSERT INTO TEST (ROWKEY, ID) VALUES ('1.23', 1.23);"
@@ -175,7 +175,7 @@
       ]
     },
     {
-      "name": "rowkey and id should match when stream has bigint key",
+      "name": "rowkey and key should match when stream has bigint key",
       "statements": [
         "CREATE STREAM TEST (ID BIGINT) WITH (kafka_topic='test_topic', value_format='JSON', key='ID');",
         "INSERT INTO TEST (ROWKEY, ID) VALUES ('10', 10);"
@@ -187,7 +187,7 @@
       ]
     },
     {
-      "name": "rowkey and id should match when stream has boolean key",
+      "name": "rowkey and key should match when stream has boolean key",
       "statements": [
         "CREATE STREAM TEST (ID BOOLEAN) WITH (kafka_topic='test_topic', value_format='JSON', key='ID');",
         "INSERT INTO TEST (ROWKEY, ID) VALUES ('true', true);"
@@ -211,7 +211,7 @@
       }
     },
     {
-      "name": "should fail on mismatch between rowkey and id values when stream has key",
+      "name": "should fail on mismatch between rowkey and key values when stream has key",
       "statements": [
         "CREATE STREAM TEST (ID INT) WITH (kafka_topic='test_topic', value_format='JSON', key='ID');",
         "INSERT INTO TEST (ROWKEY, ID) VALUES ('10', 5);"

--- a/ksql-functional-tests/src/test/resources/rest-query-validation-tests/insert-values.json
+++ b/ksql-functional-tests/src/test/resources/rest-query-validation-tests/insert-values.json
@@ -67,6 +67,138 @@
       ]
     },
     {
+      "name": "rowkey should be set when stream has int key and only id specified in insert",
+      "statements": [
+        "CREATE STREAM TEST (ID INT) WITH (kafka_topic='test_topic', value_format='JSON', key='ID');",
+        "INSERT INTO TEST (ID) VALUES (10);"
+      ],
+      "inputs": [
+      ],
+      "outputs": [
+        {"topic": "test_topic", "key": "10", "value": {"ID": 10}}
+      ]
+    },
+    {
+      "name": "rowkey should be set when stream has String key and only id specified in insert",
+      "statements": [
+        "CREATE STREAM TEST (ID VARCHAR) WITH (kafka_topic='test_topic', value_format='JSON', key='ID');",
+        "INSERT INTO TEST (ID) VALUES ('10');"
+      ],
+      "inputs": [
+      ],
+      "outputs": [
+        {"topic": "test_topic", "key": "10", "value": {"ID": "10"}}
+      ]
+    },
+    {
+      "name": "rowkey should be set when stream has double key and only id specified in insert",
+      "statements": [
+        "CREATE STREAM TEST (ID DOUBLE) WITH (kafka_topic='test_topic', value_format='JSON', key='ID');",
+        "INSERT INTO TEST (ID) VALUES (1.23);"
+      ],
+      "inputs": [
+      ],
+      "outputs": [
+        {"topic": "test_topic", "key": "1.23", "value": {"ID": 1.23}}
+      ]
+    },
+    {
+      "name": "rowkey should be set when stream has bigint key and only id specified in insert",
+      "statements": [
+        "CREATE STREAM TEST (ID BIGINT) WITH (kafka_topic='test_topic', value_format='JSON', key='ID');",
+        "INSERT INTO TEST (ID) VALUES (10);"
+      ],
+      "inputs": [
+      ],
+      "outputs": [
+        {"topic": "test_topic", "key": "10", "value": {"ID": 10}}
+      ]
+    },
+    {
+      "name": "rowkey should be set when stream has boolean key and only id specified in insert",
+      "statements": [
+        "CREATE STREAM TEST (ID BOOLEAN) WITH (kafka_topic='test_topic', value_format='JSON', key='ID');",
+        "INSERT INTO TEST (ID) VALUES (TRUE);"
+      ],
+      "inputs": [
+      ],
+      "outputs": [
+        {"topic": "test_topic", "key": "true", "value": {"ID": true}}
+      ]
+    },
+    {
+      "name": "id should be set when stream has string key and only rowkey specicified in insert",
+      "statements": [
+        "CREATE STREAM TEST (ID STRING) WITH (kafka_topic='test_topic', value_format='JSON', key='ID');",
+        "INSERT INTO TEST (ROWKEY) VALUES ('10');"
+      ],
+      "inputs": [
+      ],
+      "outputs": [
+        {"topic": "test_topic", "key": "10", "value": {"ID": "10"}}
+      ]
+    },
+    {
+      "name": "rowkey and id should match when stream has int key",
+      "statements": [
+        "CREATE STREAM TEST (ID INT) WITH (kafka_topic='test_topic', value_format='JSON', key='ID');",
+        "INSERT INTO TEST (ROWKEY, ID) VALUES ('10', 10);"
+      ],
+      "inputs": [
+      ],
+      "outputs": [
+        {"topic": "test_topic", "key": "10", "value": {"ID": 10}}
+      ]
+    },
+    {
+      "name": "rowkey and id should match when stream has String key",
+      "statements": [
+        "CREATE STREAM TEST (ID STRING) WITH (kafka_topic='test_topic', value_format='JSON', key='ID');",
+        "INSERT INTO TEST (ROWKEY, ID) VALUES ('10', '10');"
+      ],
+      "inputs": [
+      ],
+      "outputs": [
+        {"topic": "test_topic", "key": "10", "value": {"ID": "10"}}
+      ]
+    },
+    {
+      "name": "rowkey and id should match when stream has double key",
+      "statements": [
+        "CREATE STREAM TEST (ID DOUBLE) WITH (kafka_topic='test_topic', value_format='JSON', key='ID');",
+        "INSERT INTO TEST (ROWKEY, ID) VALUES ('1.23', 1.23);"
+      ],
+      "inputs": [
+      ],
+      "outputs": [
+        {"topic": "test_topic", "key": "1.23", "value": {"ID": 1.23}}
+      ]
+    },
+    {
+      "name": "rowkey and id should match when stream has bigint key",
+      "statements": [
+        "CREATE STREAM TEST (ID BIGINT) WITH (kafka_topic='test_topic', value_format='JSON', key='ID');",
+        "INSERT INTO TEST (ROWKEY, ID) VALUES ('10', 10);"
+      ],
+      "inputs": [
+      ],
+      "outputs": [
+        {"topic": "test_topic", "key": "10", "value": {"ID": 10}}
+      ]
+    },
+    {
+      "name": "rowkey and id should match when stream has boolean key",
+      "statements": [
+        "CREATE STREAM TEST (ID BOOLEAN) WITH (kafka_topic='test_topic', value_format='JSON', key='ID');",
+        "INSERT INTO TEST (ROWKEY, ID) VALUES ('true', true);"
+      ],
+      "inputs": [
+      ],
+      "outputs": [
+        {"topic": "test_topic", "key": "true", "value": {"ID": true}}
+      ]
+    },
+    {
       "name": "should fail on mismatch between explicit columns and value counts",
       "statements": [
         "CREATE STREAM TEST (ID INT) WITH (kafka_topic='test_topic', value_format='JSON');",
@@ -75,6 +207,18 @@
       "expectedError": {
         "type": "io.confluent.ksql.rest.entity.KsqlStatementErrorMessage",
         "message": "Failed to prepare statement: Expected number columns and values to match: [ROWKEY, ID], ['10']",
+        "status": 400
+      }
+    },
+    {
+      "name": "should fail on mismatch between rowkey and id values when stream has key",
+      "statements": [
+        "CREATE STREAM TEST (ID INT) WITH (kafka_topic='test_topic', value_format='JSON', key='ID');",
+        "INSERT INTO TEST (ROWKEY, ID) VALUES ('10', 5);"
+      ],
+      "expectedError": {
+        "type": "io.confluent.ksql.rest.entity.KsqlStatementErrorMessage",
+        "message": "Failed to insert values into 'TEST'. Expected ROWKEY and ID to match but got 10 and 5 respectively.",
         "status": 400
       }
     }


### PR DESCRIPTION
### Description 

Fixes #3347 

- When inserting into a TABLE with a key, and specifying the key field but not the rowkey, we ensure that the rowkey is set to the string form of the key
- When inserting into a TABLE with a key and specifying both the rowkey and the key, we check that the rowkey matches the string form of the key

### Testing done 

Added several new RQTT tests to test various combinations of inserting with rowkey and key for different types.

### Reviewer checklist
- [ ] Ensure docs are updated if necessary. (eg. if a user visible feature is being added or changed).
- [ ] Ensure relevant issues are linked (description should include text like "Fixes #<issue number>")

