### PR TITLE
test: align ZK test's timeouts with what we use in our `KafkaEmbedded`

### DIFF
--- a/ksql-test-util/src/main/java/io/confluent/ksql/test/util/KafkaEmbedded.java
+++ b/ksql-test-util/src/main/java/io/confluent/ksql/test/util/KafkaEmbedded.java
@@ -270,7 +270,8 @@ class KafkaEmbedded {
     effectiveConfig.put(KafkaConfig.MessageMaxBytesProp(), 1_000_000);
     effectiveConfig.put(KafkaConfig.ControlledShutdownEnableProp(), true);
     effectiveConfig.put(KafkaConfig.ZkSessionTimeoutMsProp(), (int) ZK_SESSION_TIMEOUT.toMillis());
-    effectiveConfig.put(KafkaConfig.ZkConnectionTimeoutMsProp(), (int) ZK_CONNECT_TIMEOUT.toMillis());
+    effectiveConfig
+        .put(KafkaConfig.ZkConnectionTimeoutMsProp(), (int) ZK_CONNECT_TIMEOUT.toMillis());
 
     effectiveConfig.putAll(initialConfig);
     effectiveConfig.put(KafkaConfig.LogDirProp(), logDir.getAbsolutePath());

--- a/ksql-test-util/src/main/java/io/confluent/ksql/test/util/KafkaEmbedded.java
+++ b/ksql-test-util/src/main/java/io/confluent/ksql/test/util/KafkaEmbedded.java
@@ -269,8 +269,8 @@ class KafkaEmbedded {
     effectiveConfig.put(KafkaConfig.AutoCreateTopicsEnableProp(), true);
     effectiveConfig.put(KafkaConfig.MessageMaxBytesProp(), 1_000_000);
     effectiveConfig.put(KafkaConfig.ControlledShutdownEnableProp(), true);
-    effectiveConfig.put(KafkaConfig.ZkSessionTimeoutMsProp(), ZK_SESSION_TIMEOUT.toMillis());
-    effectiveConfig.put(KafkaConfig.ZkConnectionTimeoutMsProp(), ZK_CONNECT_TIMEOUT.toMillis());
+    effectiveConfig.put(KafkaConfig.ZkSessionTimeoutMsProp(), (int) ZK_SESSION_TIMEOUT.toMillis());
+    effectiveConfig.put(KafkaConfig.ZkConnectionTimeoutMsProp(), (int) ZK_CONNECT_TIMEOUT.toMillis());
 
     effectiveConfig.putAll(initialConfig);
     effectiveConfig.put(KafkaConfig.LogDirProp(), logDir.getAbsolutePath());

--- a/ksql-test-util/src/main/java/io/confluent/ksql/test/util/KafkaEmbedded.java
+++ b/ksql-test-util/src/main/java/io/confluent/ksql/test/util/KafkaEmbedded.java
@@ -24,6 +24,7 @@ import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
 import java.io.File;
 import java.io.IOException;
+import java.time.Duration;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.Map;
@@ -58,6 +59,10 @@ class KafkaEmbedded {
   // CHECKSTYLE_RULES.ON: ClassDataAbstractionCoupling
 
   private static final Logger log = LoggerFactory.getLogger(KafkaEmbedded.class);
+
+  public static final Duration ZK_SESSION_TIMEOUT = Duration.ofSeconds(30);
+  // Jenkins builds can take ages to create the ZK log, so the initial connect can be slow, hence:
+  public static final Duration ZK_CONNECT_TIMEOUT = Duration.ofSeconds(60);
 
   private final Properties effectiveConfig;
   private final File logDir;
@@ -264,7 +269,8 @@ class KafkaEmbedded {
     effectiveConfig.put(KafkaConfig.AutoCreateTopicsEnableProp(), true);
     effectiveConfig.put(KafkaConfig.MessageMaxBytesProp(), 1_000_000);
     effectiveConfig.put(KafkaConfig.ControlledShutdownEnableProp(), true);
-    effectiveConfig.put(KafkaConfig.ZkSessionTimeoutMsProp(), 30_000);
+    effectiveConfig.put(KafkaConfig.ZkSessionTimeoutMsProp(), ZK_SESSION_TIMEOUT.toMillis());
+    effectiveConfig.put(KafkaConfig.ZkConnectionTimeoutMsProp(), ZK_CONNECT_TIMEOUT.toMillis());
 
     effectiveConfig.putAll(initialConfig);
     effectiveConfig.put(KafkaConfig.LogDirProp(), logDir.getAbsolutePath());

--- a/ksql-test-util/src/test/java/io/confluent/ksql/test/util/ZooKeeperEmbeddedTest.java
+++ b/ksql-test-util/src/test/java/io/confluent/ksql/test/util/ZooKeeperEmbeddedTest.java
@@ -65,7 +65,7 @@ public class ZooKeeperEmbeddedTest {
     final CountDownLatch connectionLatch = new CountDownLatch(1);
 
     final Watcher watcher = event -> {
-      System.out.println(currentTime() + "Watcher event: " + event);
+      System.out.println(currentTime() + name + ": Watcher event: " + event);
       if (event.getState() == KeeperState.SyncConnected) {
         connectionLatch.countDown();
       }
@@ -75,10 +75,10 @@ public class ZooKeeperEmbeddedTest {
 
     try {
       final String connectString = server.connectString();
-      System.out.println(currentTime() + "Attempting to connect to : " + name);
+      System.out.println(currentTime() + name + ": Attempting to connect to : " + name);
       zooKeeper = new ZooKeeper(connectString, 30_000, watcher);
       final boolean success = connectionLatch.await(5, TimeUnit.SECONDS);
-      assertThat(currentTime() + "Can not connect to " + name + " on " + connectString, success);
+      assertThat(currentTime() + name + ": Can not connect to " + connectString, success);
 
     } catch (final Exception e) {
       throw new RuntimeException(e);

--- a/ksql-test-util/src/test/java/io/confluent/ksql/test/util/ZooKeeperEmbeddedTest.java
+++ b/ksql-test-util/src/test/java/io/confluent/ksql/test/util/ZooKeeperEmbeddedTest.java
@@ -17,6 +17,10 @@ package io.confluent.ksql.test.util;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 
+import java.time.Instant;
+import java.time.ZoneId;
+import java.time.format.DateTimeFormatter;
+import java.time.format.FormatStyle;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
 import org.apache.zookeeper.Watcher;
@@ -61,6 +65,7 @@ public class ZooKeeperEmbeddedTest {
     final CountDownLatch connectionLatch = new CountDownLatch(1);
 
     final Watcher watcher = event -> {
+      System.out.println(currentTime() + "Watcher event: " + event);
       if (event.getState() == KeeperState.SyncConnected) {
         connectionLatch.countDown();
       }
@@ -70,9 +75,10 @@ public class ZooKeeperEmbeddedTest {
 
     try {
       final String connectString = server.connectString();
+      System.out.println(currentTime() + "Attempting to connect to : " + name);
       zooKeeper = new ZooKeeper(connectString, 30_000, watcher);
       final boolean success = connectionLatch.await(5, TimeUnit.SECONDS);
-      assertThat("Can not connect to " + name + " on " + connectString, success);
+      assertThat(currentTime() + "Can not connect to " + name + " on " + connectString, success);
 
     } catch (final Exception e) {
       throw new RuntimeException(e);
@@ -86,5 +92,12 @@ public class ZooKeeperEmbeddedTest {
         }
       }
     }
+  }
+
+  private static String currentTime() {
+    final DateTimeFormatter formatter = DateTimeFormatter
+        .ofLocalizedDateTime(FormatStyle.SHORT)
+        .withZone(ZoneId.systemDefault());
+    return formatter.format(Instant.now()) + " ";
   }
 }


### PR DESCRIPTION
### Description 

Build failures such as:

https://jenkins.confluent.io/job/Confluentinc%20Contributors/job/ksql/job/PR-3379/7/testReport/junit/io.confluent.ksql.test.util/ZooKeeperEmbeddedTest/shouldSupportMultipleInstancesRunning/

Where caused by too short a timeout on the latch in the test.  Test running in Jenkins failed in this case because it tool 12 seconds for ZK to create its log !!! 

Aligned the tests timeouts with `KafkaEmbedded` and increased the connection timeout in that to help stabilize Kafka based tests on Jenkins, (which still sometimes wig out due to ZK issues)

### Testing done 

non-functional change.

### Reviewer checklist
- [ ] Ensure docs are updated if necessary. (eg. if a user visible feature is being added or changed).
- [ ] Ensure relevant issues are linked (description should include text like "Fixes #<issue number>")

