### PR TITLE
fix(3356): struct rewritter missed EXPLAIN

### DIFF
--- a/ksql-execution/src/main/java/io/confluent/ksql/execution/util/ExpressionTypeManager.java
+++ b/ksql-execution/src/main/java/io/confluent/ksql/execution/util/ExpressionTypeManager.java
@@ -224,13 +224,8 @@ public class ExpressionTypeManager {
         final DereferenceExpression node,
         final ExpressionTypeContext expressionTypeContext
     ) {
-      final Column schemaColumn = schema.findValueColumn(node.toString())
-          .orElseThrow(() ->
-              new KsqlException(String.format("Invalid Expression %s.", node.toString())));
-
-      final Schema schema = SQL_TO_CONNECT_SCHEMA_CONVERTER.toConnectSchema(schemaColumn.type());
-      expressionTypeContext.setSchema(schemaColumn.type(), schema);
-      return null;
+      throw new IllegalArgumentException("Dereferenced expressions should have been rewritten to "
+          + FetchFieldFromStruct.FUNCTION_NAME + " by this point");
     }
 
     @Override

--- a/ksql-execution/src/test/java/io/confluent/ksql/execution/util/ExpressionTypeManagerTest.java
+++ b/ksql-execution/src/test/java/io/confluent/ksql/execution/util/ExpressionTypeManagerTest.java
@@ -37,6 +37,7 @@ import io.confluent.ksql.execution.expression.tree.ArithmeticBinaryExpression;
 import io.confluent.ksql.execution.expression.tree.BooleanLiteral;
 import io.confluent.ksql.execution.expression.tree.ComparisonExpression;
 import io.confluent.ksql.execution.expression.tree.ComparisonExpression.Type;
+import io.confluent.ksql.execution.expression.tree.DereferenceExpression;
 import io.confluent.ksql.execution.expression.tree.Expression;
 import io.confluent.ksql.execution.expression.tree.FunctionCall;
 import io.confluent.ksql.execution.expression.tree.InListExpression;
@@ -45,6 +46,7 @@ import io.confluent.ksql.execution.expression.tree.IntegerLiteral;
 import io.confluent.ksql.execution.expression.tree.LikePredicate;
 import io.confluent.ksql.execution.expression.tree.NotExpression;
 import io.confluent.ksql.execution.expression.tree.QualifiedName;
+import io.confluent.ksql.execution.expression.tree.QualifiedNameReference;
 import io.confluent.ksql.execution.expression.tree.SearchedCaseExpression;
 import io.confluent.ksql.execution.expression.tree.SimpleCaseExpression;
 import io.confluent.ksql.execution.expression.tree.StringLiteral;
@@ -274,7 +276,23 @@ public class ExpressionTypeManagerTest {
   }
 
   @Test
-  public void shouldHandleStruct() {
+  public void shouldThrowOnStructFieldDereference() {
+    // Given:
+    final Expression expression = new DereferenceExpression(
+        Optional.empty(),
+        new QualifiedNameReference(QualifiedName.of("TEST1", "COL6")),
+        "STREET"
+    );
+
+    // Then:
+    expectedException.expect(IllegalArgumentException.class);
+
+    // When:
+    expressionTypeManager.getExpressionSqlType(expression);
+  }
+
+  @Test
+  public void shouldHandleRewrittenStruct() {
     final Expression expression = new FunctionCall(
         QualifiedName.of(FetchFieldFromStruct.FUNCTION_NAME),
         ImmutableList.of(ADDRESS, new StringLiteral("NUMBER"))

--- a/ksql-parser/src/main/java/io/confluent/ksql/parser/rewrite/StatementRewriteForStruct.java
+++ b/ksql-parser/src/main/java/io/confluent/ksql/parser/rewrite/StatementRewriteForStruct.java
@@ -24,6 +24,7 @@ import io.confluent.ksql.execution.expression.tree.QualifiedName;
 import io.confluent.ksql.execution.expression.tree.StringLiteral;
 import io.confluent.ksql.execution.expression.tree.VisitParentExpressionVisitor;
 import io.confluent.ksql.parser.rewrite.ExpressionTreeRewriter.Context;
+import io.confluent.ksql.parser.tree.Explain;
 import io.confluent.ksql.parser.tree.Query;
 import io.confluent.ksql.parser.tree.QueryContainer;
 import io.confluent.ksql.parser.tree.Statement;
@@ -46,7 +47,8 @@ public final class StatementRewriteForStruct {
 
   public static boolean requiresRewrite(final Statement statement) {
     return statement instanceof Query
-        || statement instanceof QueryContainer;
+        || statement instanceof QueryContainer
+        || statement instanceof Explain;
   }
 
   private static final class Plugin

--- a/ksql-parser/src/main/java/io/confluent/ksql/parser/rewrite/StatementRewriter.java
+++ b/ksql-parser/src/main/java/io/confluent/ksql/parser/rewrite/StatementRewriter.java
@@ -26,6 +26,7 @@ import io.confluent.ksql.parser.tree.CreateStreamAsSelect;
 import io.confluent.ksql.parser.tree.CreateTable;
 import io.confluent.ksql.parser.tree.CreateTableAsSelect;
 import io.confluent.ksql.parser.tree.DropTable;
+import io.confluent.ksql.parser.tree.Explain;
 import io.confluent.ksql.parser.tree.GroupBy;
 import io.confluent.ksql.parser.tree.GroupingElement;
 import io.confluent.ksql.parser.tree.InsertInto;
@@ -147,6 +148,22 @@ public final class StatementRewriter<C> {
           node.getResultMaterialization(),
           node.isStatic(),
           node.getLimit()
+      );
+    }
+
+    @Override
+    protected AstNode visitExplain(final Explain node, final C context) {
+      if (!node.getStatement().isPresent()) {
+        return node;
+      }
+
+      final Statement original = node.getStatement().get();
+      final Statement rewritten = (Statement) rewriter.apply(original, context);
+
+      return new Explain(
+          node.getLocation(),
+          node.getQueryId(),
+          rewritten == null ? Optional.of(original) : Optional.of(rewritten)
       );
     }
 

--- a/ksql-parser/src/main/java/io/confluent/ksql/parser/rewrite/StatementRewriter.java
+++ b/ksql-parser/src/main/java/io/confluent/ksql/parser/rewrite/StatementRewriter.java
@@ -107,6 +107,11 @@ public final class StatementRewriter<C> {
     }
 
     @Override
+    protected AstNode visitNode(final AstNode node, final C context) {
+      return node;
+    }
+
+    @Override
     protected AstNode visitStatements(final Statements node, final C context) {
       final List<Statement> rewrittenStatements = node.getStatements()
           .stream()
@@ -163,7 +168,7 @@ public final class StatementRewriter<C> {
       return new Explain(
           node.getLocation(),
           node.getQueryId(),
-          rewritten == null ? Optional.of(original) : Optional.of(rewritten)
+          Optional.of(rewritten)
       );
     }
 

--- a/ksql-parser/src/test/java/io/confluent/ksql/parser/rewrite/StatementRewriterTest.java
+++ b/ksql-parser/src/test/java/io/confluent/ksql/parser/rewrite/StatementRewriterTest.java
@@ -51,6 +51,7 @@ import org.mockito.junit.MockitoJUnit;
 import org.mockito.junit.MockitoRule;
 
 public class StatementRewriterTest {
+
   @Mock
   private BiFunction<Expression, Object, Expression> expressionRewriter;
   @Mock

--- a/ksql-rest-app/src/test/java/io/confluent/ksql/rest/server/TemporaryEngine.java
+++ b/ksql-rest-app/src/test/java/io/confluent/ksql/rest/server/TemporaryEngine.java
@@ -53,6 +53,10 @@ public class TemporaryEngine extends ExternalResource {
   public static final LogicalSchema SCHEMA = LogicalSchema.builder()
       .valueColumn("val", SqlTypes.STRING)
       .valueColumn("val2", SqlTypes.decimal(2, 1))
+      .valueColumn("ADDRESS", SqlTypes.struct()
+          .field("STREET", SqlTypes.STRING)
+          .field("STATE", SqlTypes.STRING)
+          .build())
       .build();
 
   private MutableMetaStore metaStore;

--- a/ksql-rest-app/src/test/java/io/confluent/ksql/rest/server/execution/ExplainExecutorTest.java
+++ b/ksql-rest-app/src/test/java/io/confluent/ksql/rest/server/execution/ExplainExecutorTest.java
@@ -106,6 +106,25 @@ public class ExplainExecutorTest {
   }
 
   @Test
+  public void shouldExplainStatementWithStructFieldDereference() {
+    // Given:
+    engine.givenSource(DataSourceType.KSTREAM, "Y");
+    final String statementText = "SELECT address->street FROM Y EMIT CHANGES;";
+    final ConfiguredStatement<?> explain = engine.configure("EXPLAIN " + statementText);
+
+    // When:
+    final QueryDescriptionEntity query = (QueryDescriptionEntity) CustomExecutors.EXPLAIN.execute(
+        explain,
+        engine.getEngine(),
+        engine.getServiceContext()
+    ).orElseThrow(IllegalStateException::new);
+
+    // Then:
+    assertThat(query.getQueryDescription().getStatementText(), equalTo(statementText));
+    assertThat(query.getQueryDescription().getSources(), containsInAnyOrder("Y"));
+  }
+
+  @Test
   public void shouldFailOnNonQueryExplain() {
     // Expect:
     expectedException.expect(KsqlException.class);


### PR DESCRIPTION
### Description 

Fixes: #3356

KSQL uses a statement rewritter to convert STRUCT field dereferences into `FETCH_FIELD_FROM_STRUCT` function calls.  The rewrite is done for `Query`, `C*AS` and `INSERT INTO` statements, but was missing `EXPLAIN`.

It is valid to execute `EXPLAIN` on a query string, e.g.  `EXPLAIN SELECT address->street FROM Y;`.  It is therefore important that the query within the `EXPLAIN` statement has the same rewrites applied to it as would be applied should the statement be executed directly.

### Testing done 

Suitable unit tests added.

### Reviewer checklist
- [ ] Ensure docs are updated if necessary. (eg. if a user visible feature is being added or changed).
- [ ] Ensure relevant issues are linked (description should include text like "Fixes #<issue number>")

