### PR TITLE
fix: fix test for KIP-307 final PR

### DIFF
--- a/ksql-engine/src/test/java/io/confluent/ksql/structured/SchemaKGroupedStreamTest.java
+++ b/ksql-engine/src/test/java/io/confluent/ksql/structured/SchemaKGroupedStreamTest.java
@@ -218,7 +218,7 @@ public class SchemaKGroupedStreamTest {
   public void shouldBuildStepForWindowedAggregate() {
     // Given:
     when(groupedStream.windowedBy(any(SessionWindows.class))).thenReturn(sessionWindowedStream);
-    when(sessionWindowedStream.aggregate(any(), any(), any(), any())).thenReturn(table);
+    when(sessionWindowedStream.aggregate(any(), any(), any(), any(Materialized.class))).thenReturn(table);
     when(table.mapValues(any(ValueMapper.class))).thenReturn(table);
 
     // When:

--- a/ksql-engine/src/test/java/io/confluent/ksql/structured/SchemaKGroupedTableTest.java
+++ b/ksql-engine/src/test/java/io/confluent/ksql/structured/SchemaKGroupedTableTest.java
@@ -53,6 +53,7 @@ import java.util.Optional;
 import org.apache.kafka.connect.data.Struct;
 import org.apache.kafka.streams.kstream.KGroupedTable;
 import org.apache.kafka.streams.kstream.KTable;
+import org.apache.kafka.streams.kstream.Materialized;
 import org.apache.kafka.streams.kstream.ValueMapper;
 import org.junit.Before;
 import org.junit.Rule;
@@ -110,7 +111,7 @@ public class SchemaKGroupedTableTest {
   @Before
   public void init() {
     when(queryBuilder.getFunctionRegistry()).thenReturn(functionRegistry);
-    when(mockKGroupedTable.aggregate(any(), any(), any(), any())).thenReturn(table);
+    when(mockKGroupedTable.aggregate(any(), any(), any(), (Materialized)any())).thenReturn(table);
     when(table.mapValues(any(ValueMapper.class))).thenReturn(table);
   }
 


### PR DESCRIPTION
### Description 
The fifth and final PR for [KIP-307](https://github.com/apache/kafka/pull/6413) is getting merged today.  This PR adds the following overload  `KGoupedTable.aggregate(Initializer, Aggregator, Aggregator, Named`).  

This causes an error with the `SchemaKGroupedTableTest` when executing `mockKGroupedTable.aggregate(any(), any(), any(), any()))` method.  The compiler can't disambiguate the 4th argument, as it's either a `Materialized` or a `Named` object.  This PR fixes the test.

Update this PR build is passing now and can be merged once approved. 
### Testing done 
I updated the test and ran the entire KSQL test suite, all tests passed.

### Reviewer checklist
- [ ] Ensure docs are updated if necessary. (eg. if a user visible feature is being added or changed).
- [ ] Ensure relevant issues are linked (description should include text like "Fixes #<issue number>")

