### PR TITLE
feat: remove equalsIgnoreCase from all Name classes (MINOR)

### DIFF
--- a/ksql-common/src/main/java/io/confluent/ksql/name/Name.java
+++ b/ksql-common/src/main/java/io/confluent/ksql/name/Name.java
@@ -42,20 +42,6 @@ public abstract class Name<T extends Name<?>> {
     return name;
   }
 
-  /**
-   * @see String#equalsIgnoreCase(String)
-   */
-  public boolean equalsIgnoreCase(final T o) {
-    if (this == o) {
-      return true;
-    }
-    if (o == null || getClass() != o.getClass()) {
-      return false;
-    }
-
-    return name.equalsIgnoreCase(o.name());
-  }
-
   public boolean startsWith(final T o) {
     if (this == o) {
       return true;

--- a/ksql-common/src/main/java/io/confluent/ksql/schema/ksql/FormatOptions.java
+++ b/ksql-common/src/main/java/io/confluent/ksql/schema/ksql/FormatOptions.java
@@ -28,6 +28,12 @@ public final class FormatOptions {
     return new FormatOptions(word -> true);
   }
 
+  /**
+   * @return options that escape nothing
+   * @apiNote this is <i>dangerous</i> and could cause reserved identifiers
+   *          to be mangled. Use this API sparingly (e.g. in logging error
+   *          messages)
+   */
   public static FormatOptions noEscape() {
     return new FormatOptions(word -> false);
   }

--- a/ksql-common/src/main/java/io/confluent/ksql/schema/ksql/LogicalSchema.java
+++ b/ksql-common/src/main/java/io/confluent/ksql/schema/ksql/LogicalSchema.java
@@ -131,7 +131,7 @@ public final class LogicalSchema {
   }
 
   @VisibleForTesting
-  public Optional<Column> findColumn(final String columnName) {
+  private Optional<Column> findColumn(final String columnName) {
     Optional<Column> found = doFindColumn(columnName, metadata);
     if (found.isPresent()) {
       return found;

--- a/ksql-common/src/test/java/io/confluent/ksql/schema/ksql/LogicalSchemaTest.java
+++ b/ksql-common/src/test/java/io/confluent/ksql/schema/ksql/LogicalSchemaTest.java
@@ -268,7 +268,7 @@ public class LogicalSchemaTest {
 
   @Test
   public void shouldGetMetaFields() {
-    assertThat(SOME_SCHEMA.findColumn("ROWTIME"), is(Optional.of(
+    assertThat(SOME_SCHEMA.findColumn(ROWTIME_NAME), is(Optional.of(
         Column.of(ROWTIME_NAME, SqlTypes.BIGINT)
     )));
   }

--- a/ksql-engine/src/main/java/io/confluent/ksql/analyzer/Analyzer.java
+++ b/ksql-engine/src/main/java/io/confluent/ksql/analyzer/Analyzer.java
@@ -266,8 +266,8 @@ class Analyzer {
         }
 
         final ColumnName columnName = select.getName();
-        if (columnName.equalsIgnoreCase(SchemaUtil.ROWTIME_NAME)
-            || columnName.equalsIgnoreCase(SchemaUtil.ROWKEY_NAME)) {
+        if (columnName.equals(SchemaUtil.ROWTIME_NAME)
+            || columnName.equals(SchemaUtil.ROWKEY_NAME)) {
           columnNames.remove(idx);
         }
       }
@@ -457,7 +457,7 @@ class Analyzer {
         final SourceName sourceAlias
     ) {
       if (nameRef.getReference().qualifier().isPresent()
-          && !nameRef.getReference().qualifier().get().equalsIgnoreCase(sourceAlias)) {
+          && !nameRef.getReference().qualifier().get().equals(sourceAlias)) {
         return Optional.empty();
       }
 

--- a/ksql-engine/src/main/java/io/confluent/ksql/analyzer/SourceSchemas.java
+++ b/ksql-engine/src/main/java/io/confluent/ksql/analyzer/SourceSchemas.java
@@ -79,7 +79,7 @@ final class SourceSchemas {
       return ImmutableSet.of();
     }
 
-    return sourceSchema.findColumn(baseColumnName).isPresent()
+    return sourceSchema.findColumn(ColumnName.of(baseColumnName)).isPresent()
         ? ImmutableSet.of(sourceName)
         : ImmutableSet.of();
   }

--- a/ksql-engine/src/main/java/io/confluent/ksql/ddl/commands/CommandFactories.java
+++ b/ksql-engine/src/main/java/io/confluent/ksql/ddl/commands/CommandFactories.java
@@ -271,11 +271,11 @@ public class CommandFactories implements DdlCommandFactory {
     }
 
     tableElements.forEach(e -> {
-      if (e.getName().equalsIgnoreCase(SchemaUtil.ROWTIME_NAME)) {
+      if (e.getName().equals(SchemaUtil.ROWTIME_NAME)) {
         throw new KsqlException("'" + e.getName().name() + "' is a reserved column name.");
       }
 
-      final boolean isRowKey = e.getName().equalsIgnoreCase(SchemaUtil.ROWKEY_NAME);
+      final boolean isRowKey = e.getName().equals(SchemaUtil.ROWKEY_NAME);
 
       if (e.getNamespace() == Namespace.KEY) {
         if (!isRowKey) {

--- a/ksql-engine/src/main/java/io/confluent/ksql/physical/PhysicalPlanBuilder.java
+++ b/ksql-engine/src/main/java/io/confluent/ksql/physical/PhysicalPlanBuilder.java
@@ -478,7 +478,7 @@ public class PhysicalPlanBuilder {
 
     if (sinkKeyCol.isPresent()
         && resultKeyCol.isPresent()
-        && sinkKeyCol.get().name().equalsIgnoreCase(resultKeyCol.get().name())
+        && sinkKeyCol.get().name().equals(resultKeyCol.get().name())
         && Objects.equals(sinkKeyCol.get().type(), resultKeyCol.get().type())) {
       return;
     }

--- a/ksql-engine/src/test/java/io/confluent/ksql/analyzer/AnalyzerFunctionalTest.java
+++ b/ksql-engine/src/test/java/io/confluent/ksql/analyzer/AnalyzerFunctionalTest.java
@@ -21,6 +21,7 @@ import static org.hamcrest.Matchers.contains;
 import static org.hamcrest.Matchers.hasSize;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.not;
+import static org.junit.Assert.assertEquals;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.verify;
@@ -134,9 +135,9 @@ public class AnalyzerFunctionalTest {
   public void testSimpleQueryAnalysis() {
     final String simpleQuery = "SELECT col0, col2, col3 FROM test1 WHERE col0 > 100 EMIT CHANGES;";
     final Analysis analysis = analyzeQuery(simpleQuery, jsonMetaStore);
-    Assert.assertTrue("FROM was not analyzed correctly.",
-        analysis.getFromDataSources().get(0).getDataSource().getName()
-                          .equalsIgnoreCase(SourceName.of("test1")));
+    assertEquals("FROM was not analyzed correctly.",
+        analysis.getFromDataSources().get(0).getDataSource().getName(),
+        SourceName.of("TEST1"));
     assertThat(analysis.getWhereExpression().get().toString(), is("(TEST1.COL0 > 100)"));
 
     final List<SelectExpression> selects = analysis.getSelectExpressions();
@@ -201,9 +202,8 @@ public class AnalyzerFunctionalTest {
     final String queryStr = "SELECT col0 = 10, col2, col3 > col1 FROM test1 EMIT CHANGES;";
     final Analysis analysis = analyzeQuery(queryStr, jsonMetaStore);
 
-    Assert.assertTrue("FROM was not analyzed correctly.",
-        analysis.getFromDataSources().get(0).getDataSource().getName()
-                          .equalsIgnoreCase(SourceName.of("test1")));
+    assertEquals("FROM was not analyzed correctly.",
+        analysis.getFromDataSources().get(0).getDataSource().getName(), SourceName.of("TEST1"));
 
     final List<SelectExpression> selects = analysis.getSelectExpressions();
     assertThat(selects.get(0).getExpression().toString(), is("(TEST1.COL0 = 10)"));

--- a/ksql-execution/src/test/java/io/confluent/ksql/execution/util/ExpressionTypeManagerTest.java
+++ b/ksql-execution/src/test/java/io/confluent/ksql/execution/util/ExpressionTypeManagerTest.java
@@ -397,7 +397,7 @@ public class ExpressionTypeManagerTest {
     final SqlType result = expressionTypeManager.getExpressionSqlType(expression);
 
     // Then:
-    final SqlType sqlType = SCHEMA.findColumn(ADDRESS.toString()).get().type();
+    final SqlType sqlType = SCHEMA.findColumn(ColumnName.of(ADDRESS.toString())).get().type();
     assertThat(result, is(sqlType));
   }
 

--- a/ksql-parser/src/main/java/io/confluent/ksql/parser/AstBuilder.java
+++ b/ksql-parser/src/main/java/io/confluent/ksql/parser/AstBuilder.java
@@ -1037,14 +1037,14 @@ public class AstBuilder {
 
     private boolean isValidNameOrAlias(final SourceName name) {
       if (dataSourceExtractor.isJoin()) {
-        final boolean sameAsLeft = name.equalsIgnoreCase(dataSourceExtractor.getLeftAlias())
-            || name.equalsIgnoreCase(dataSourceExtractor.getLeftName());
-        final boolean sameAsRight = name.equalsIgnoreCase(dataSourceExtractor.getRightAlias())
-            || name.equalsIgnoreCase(dataSourceExtractor.getRightName());
+        final boolean sameAsLeft = name.equals(dataSourceExtractor.getLeftAlias())
+            || name.equals(dataSourceExtractor.getLeftName());
+        final boolean sameAsRight = name.equals(dataSourceExtractor.getRightAlias())
+            || name.equals(dataSourceExtractor.getRightName());
         return sameAsLeft || sameAsRight;
       }
-      return ((name.equalsIgnoreCase(dataSourceExtractor.getFromAlias())
-          || name.equalsIgnoreCase(dataSourceExtractor.getFromName())));
+      return ((name.equals(dataSourceExtractor.getFromAlias())
+          || name.equals(dataSourceExtractor.getFromName())));
     }
 
     @Override

--- a/ksql-parser/src/test/java/io/confluent/ksql/parser/KsqlParserTest.java
+++ b/ksql-parser/src/test/java/io/confluent/ksql/parser/KsqlParserTest.java
@@ -212,8 +212,8 @@ public class KsqlParserTest {
     Assert.assertTrue(query.getSelect().getSelectItems().size() == 3);
     Assert.assertTrue(query.getSelect().getSelectItems().get(0) instanceof SingleColumn);
     final SingleColumn column0 = (SingleColumn)query.getSelect().getSelectItems().get(0);
-    Assert.assertTrue(column0.getAlias().equalsIgnoreCase(ColumnName.of("COL0")));
-    Assert.assertTrue(column0.getExpression().toString().equalsIgnoreCase("TEST1.COL0"));
+    Assert.assertTrue(column0.getAlias().equals(ColumnName.of("COL0")));
+    Assert.assertTrue(column0.getExpression().toString().equals("TEST1.COL0"));
   }
 
   @Test
@@ -227,15 +227,15 @@ public class KsqlParserTest {
     Assert.assertTrue(query.getSelect().getSelectItems().get(0) instanceof SingleColumn);
     final SingleColumn column0 = (SingleColumn)query.getSelect().getSelectItems().get(0);
     Assert.assertTrue("testProjectionWithArrayMap fails",
-        column0.getAlias().equalsIgnoreCase(ColumnName.of("COL0")));
-    Assert.assertTrue(column0.getExpression().toString().equalsIgnoreCase("TEST1.COL0"));
+        column0.getAlias().equals(ColumnName.of("COL0")));
+    Assert.assertTrue(column0.getExpression().toString().equals("TEST1.COL0"));
 
     final SingleColumn column3 = (SingleColumn)query.getSelect().getSelectItems().get(3);
     final SingleColumn column4 = (SingleColumn)query.getSelect().getSelectItems().get(4);
     Assert.assertTrue(column3.getExpression().toString()
-        .equalsIgnoreCase("TEST1.COL4[0]"));
+        .equals("TEST1.COL4[0]"));
     Assert.assertTrue(column4.getExpression().toString()
-        .equalsIgnoreCase("TEST1.COL5['key1']"));
+        .equals("TEST1.COL5['key1']"));
   }
 
   @Test
@@ -259,7 +259,7 @@ public class KsqlParserTest {
     Assert.assertTrue(statement instanceof Query);
     final Query query = (Query) statement;
     final SingleColumn column0 = (SingleColumn)query.getSelect().getSelectItems().get(0);
-    Assert.assertTrue(column0.getAlias().equalsIgnoreCase(ColumnName.of("KSQL_COL_0")));
+    Assert.assertTrue(column0.getAlias().equals(ColumnName.of("KSQL_COL_0")));
     Assert.assertTrue(column0.getExpression().toString().equalsIgnoreCase("(TEST1.COL0 + 10)"));
   }
 
@@ -270,7 +270,7 @@ public class KsqlParserTest {
     Assert.assertTrue(statement instanceof Query);
     final Query query = (Query) statement;
     final SingleColumn column0 = (SingleColumn)query.getSelect().getSelectItems().get(0);
-    Assert.assertTrue(column0.getAlias().equalsIgnoreCase(ColumnName.of("KSQL_COL_0")));
+    Assert.assertTrue(column0.getAlias().equals(ColumnName.of("KSQL_COL_0")));
     Assert.assertTrue(column0.getExpression().toString().equalsIgnoreCase("(TEST1.COL0 = 10)"));
   }
 
@@ -281,27 +281,27 @@ public class KsqlParserTest {
     Assert.assertTrue(statement instanceof Query);
     final Query query = (Query) statement;
     final SingleColumn column0 = (SingleColumn)query.getSelect().getSelectItems().get(0);
-    Assert.assertTrue(column0.getAlias().equalsIgnoreCase(ColumnName.of("KSQL_COL_0")));
+    Assert.assertTrue(column0.getAlias().equals(ColumnName.of("KSQL_COL_0")));
     Assert.assertTrue(column0.getExpression().toString().equalsIgnoreCase("10"));
 
     final SingleColumn column1 = (SingleColumn)query.getSelect().getSelectItems().get(1);
-    Assert.assertTrue(column1.getAlias().equalsIgnoreCase(ColumnName.of("COL2")));
+    Assert.assertTrue(column1.getAlias().equals(ColumnName.of("COL2")));
     Assert.assertTrue(column1.getExpression().toString().equalsIgnoreCase("TEST1.COL2"));
 
     final SingleColumn column2 = (SingleColumn)query.getSelect().getSelectItems().get(2);
-    Assert.assertTrue(column2.getAlias().equalsIgnoreCase(ColumnName.of("KSQL_COL_2")));
+    Assert.assertTrue(column2.getAlias().equals(ColumnName.of("KSQL_COL_2")));
     Assert.assertTrue(column2.getExpression().toString().equalsIgnoreCase("'test'"));
 
     final SingleColumn column3 = (SingleColumn)query.getSelect().getSelectItems().get(3);
-    Assert.assertTrue(column3.getAlias().equalsIgnoreCase(ColumnName.of("KSQL_COL_3")));
+    Assert.assertTrue(column3.getAlias().equals(ColumnName.of("KSQL_COL_3")));
     Assert.assertTrue(column3.getExpression().toString().equalsIgnoreCase("2.5"));
 
     final SingleColumn column4 = (SingleColumn)query.getSelect().getSelectItems().get(4);
-    Assert.assertTrue(column4.getAlias().equalsIgnoreCase(ColumnName.of("KSQL_COL_4")));
+    Assert.assertTrue(column4.getAlias().equals(ColumnName.of("KSQL_COL_4")));
     Assert.assertTrue(column4.getExpression().toString().equalsIgnoreCase("true"));
 
     final SingleColumn column5 = (SingleColumn)query.getSelect().getSelectItems().get(5);
-    Assert.assertTrue(column5.getAlias().equalsIgnoreCase(ColumnName.of("KSQL_COL_5")));
+    Assert.assertTrue(column5.getAlias().equals(ColumnName.of("KSQL_COL_5")));
     Assert.assertTrue(column5.getExpression().toString().equalsIgnoreCase("-5"));
   }
 
@@ -355,15 +355,15 @@ public class KsqlParserTest {
     Assert.assertTrue(statement instanceof Query);
     final Query query = (Query) statement;
     final SingleColumn column0 = (SingleColumn)query.getSelect().getSelectItems().get(0);
-    Assert.assertTrue(column0.getAlias().equalsIgnoreCase(ColumnName.of("KSQL_COL_0")));
+    Assert.assertTrue(column0.getAlias().equals(ColumnName.of("KSQL_COL_0")));
     Assert.assertTrue(column0.getExpression().toString().equalsIgnoreCase("10"));
 
     final SingleColumn column1 = (SingleColumn)query.getSelect().getSelectItems().get(1);
-    Assert.assertTrue(column1.getAlias().equalsIgnoreCase(ColumnName.of("COL2")));
+    Assert.assertTrue(column1.getAlias().equals(ColumnName.of("COL2")));
     Assert.assertTrue(column1.getExpression().toString().equalsIgnoreCase("TEST1.COL2"));
 
     final SingleColumn column2 = (SingleColumn)query.getSelect().getSelectItems().get(2);
-    Assert.assertTrue(column2.getAlias().equalsIgnoreCase(ColumnName.of("KSQL_COL_2")));
+    Assert.assertTrue(column2.getAlias().equals(ColumnName.of("KSQL_COL_2")));
     Assert.assertTrue(column2.getExpression().toString().equalsIgnoreCase("'test'"));
 
   }
@@ -397,8 +397,8 @@ public class KsqlParserTest {
     final Join join = (Join) query.getFrom();
     Assert.assertTrue("testSimpleLeftJoin fails", join.getType().toString().equalsIgnoreCase("LEFT"));
 
-    Assert.assertTrue("testSimpleLeftJoin fails", ((AliasedRelation)join.getLeft()).getAlias().equalsIgnoreCase(SourceName.of("T1")));
-    Assert.assertTrue("testSimpleLeftJoin fails", ((AliasedRelation)join.getRight()).getAlias().equalsIgnoreCase(SourceName.of("T2")));
+    Assert.assertTrue("testSimpleLeftJoin fails", ((AliasedRelation)join.getLeft()).getAlias().equals(SourceName.of("T1")));
+    Assert.assertTrue("testSimpleLeftJoin fails", ((AliasedRelation)join.getRight()).getAlias().equals(SourceName.of("T2")));
 
   }
 
@@ -415,8 +415,8 @@ public class KsqlParserTest {
     final Join join = (Join) query.getFrom();
     Assert.assertTrue(join.getType().toString().equalsIgnoreCase("LEFT"));
 
-    Assert.assertTrue(((AliasedRelation)join.getLeft()).getAlias().equalsIgnoreCase(SourceName.of("T1")));
-    Assert.assertTrue(((AliasedRelation)join.getRight()).getAlias().equalsIgnoreCase(SourceName.of("T2")));
+    Assert.assertTrue(((AliasedRelation)join.getLeft()).getAlias().equals(SourceName.of("T1")));
+    Assert.assertTrue(((AliasedRelation)join.getRight()).getAlias().equals(SourceName.of("T2")));
 
     Assert.assertTrue(query.getWhere().get().toString().equalsIgnoreCase("(T2.COL2 = 'test')"));
   }
@@ -480,15 +480,15 @@ public class KsqlParserTest {
     final Query query = (Query) statement;
 
     final SingleColumn column0 = (SingleColumn)query.getSelect().getSelectItems().get(0);
-    Assert.assertTrue(column0.getAlias().equalsIgnoreCase(ColumnName.of("KSQL_COL_0")));
+    Assert.assertTrue(column0.getAlias().equals(ColumnName.of("KSQL_COL_0")));
     Assert.assertTrue(column0.getExpression().toString().equalsIgnoreCase("LCASE(T1.COL1)"));
 
     final SingleColumn column1 = (SingleColumn)query.getSelect().getSelectItems().get(1);
-    Assert.assertTrue(column1.getAlias().equalsIgnoreCase(ColumnName.of("KSQL_COL_1")));
+    Assert.assertTrue(column1.getAlias().equals(ColumnName.of("KSQL_COL_1")));
     Assert.assertTrue(column1.getExpression().toString().equalsIgnoreCase("CONCAT(T1.COL2, 'hello')"));
 
     final SingleColumn column2 = (SingleColumn)query.getSelect().getSelectItems().get(2);
-    Assert.assertTrue(column2.getAlias().equalsIgnoreCase(ColumnName.of("KSQL_COL_2")));
+    Assert.assertTrue(column2.getAlias().equals(ColumnName.of("KSQL_COL_2")));
     Assert.assertTrue(column2.getExpression().toString().equalsIgnoreCase("FLOOR(ABS(T1.COL3))"));
   }
 
@@ -601,7 +601,7 @@ public class KsqlParserTest {
     Assert.assertTrue(query.getSelect().getSelectItems
         ().size() == 2);
     Assert.assertTrue(query.getWhere().get().toString().equalsIgnoreCase("(ORDERS.ORDERUNITS > 5)"));
-    Assert.assertTrue(((AliasedRelation)query.getFrom()).getAlias().equalsIgnoreCase(SourceName.of("ORDERS")));
+    Assert.assertTrue(((AliasedRelation)query.getFrom()).getAlias().equals(SourceName.of("ORDERS")));
     Assert.assertTrue(query.getWindow().isPresent());
     Assert.assertTrue(query.getWindow().get().toString().equalsIgnoreCase(" WINDOW STREAMWINDOW  TUMBLING ( SIZE 30 SECONDS ) "));
   }
@@ -641,7 +641,7 @@ public class KsqlParserTest {
     Assert.assertTrue(query.getSelect().getSelectItems
         ().size() == 2);
     Assert.assertTrue(query.getWhere().get().toString().equalsIgnoreCase("(ORDERS.ORDERUNITS > 5)"));
-    Assert.assertTrue(((AliasedRelation)query.getFrom()).getAlias().equalsIgnoreCase(SourceName.of("ORDERS")));
+    Assert.assertTrue(((AliasedRelation)query.getFrom()).getAlias().equals(SourceName.of("ORDERS")));
     Assert.assertTrue(query
         .getWindow().isPresent());
     Assert.assertTrue(query

--- a/ksql-rest-app/src/main/java/io/confluent/ksql/rest/server/execution/ListSourceExecutor.java
+++ b/ksql-rest-app/src/main/java/io/confluent/ksql/rest/server/execution/ListSourceExecutor.java
@@ -154,7 +154,7 @@ public final class ListSourceExecutor {
   ) {
     return executionContext.getMetaStore().getAllDataSources().values().stream()
         .filter(KsqlTable.class::isInstance)
-        .filter(structuredDataSource -> !structuredDataSource.getName().equalsIgnoreCase(
+        .filter(structuredDataSource -> !structuredDataSource.getName().equals(
             KsqlRestApplication.getCommandsStreamName()))
         .map(table -> (KsqlTable<?>) table)
         .collect(Collectors.toList());
@@ -165,7 +165,7 @@ public final class ListSourceExecutor {
   ) {
     return executionContext.getMetaStore().getAllDataSources().values().stream()
         .filter(KsqlStream.class::isInstance)
-        .filter(structuredDataSource -> !structuredDataSource.getName().equalsIgnoreCase(
+        .filter(structuredDataSource -> !structuredDataSource.getName().equals(
             KsqlRestApplication.getCommandsStreamName()))
         .map(table -> (KsqlStream<?>) table)
         .collect(Collectors.toList());


### PR DESCRIPTION
### Description 

We don't ever actually need to compare ignoring case because `ParserUtil` will parse anything unquoted into upper case.

This patch also includes some very minor refactors and javadoc improvements.

### Testing done 

`mvn clean install`

### Reviewer checklist
- [ ] Ensure docs are updated if necessary. (eg. if a user visible feature is being added or changed).
- [ ] Ensure relevant issues are linked (description should include text like "Fixes #<issue number>")

