### PR TITLE
feat: use coherent naming scheme for generated java code

### DIFF
--- a/ksql-execution/src/main/java/io/confluent/ksql/execution/codegen/CodeGenUtil.java
+++ b/ksql-execution/src/main/java/io/confluent/ksql/execution/codegen/CodeGenUtil.java
@@ -1,0 +1,33 @@
+/*
+ * Copyright 2019 Confluent Inc.
+ *
+ * Licensed under the Confluent Community License (the "License"; you may not use
+ * this file except in compliance with the License. You may obtain a copy of the
+ * License at
+ *
+ * http://www.confluent.io/confluent-community-license
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package io.confluent.ksql.execution.codegen;
+
+public final class CodeGenUtil {
+
+  private static final String PARAM_NAME_PREFIX = "var";
+
+  private CodeGenUtil() {
+  }
+
+  public static String paramName(final int index) {
+    return PARAM_NAME_PREFIX + index;
+  }
+
+  public static String functionName(final String fun, final int index) {
+    return fun + "_" + index;
+  }
+
+}

--- a/ksql-execution/src/test/java/io/confluent/ksql/execution/codegen/SqlToJavaVisitorTest.java
+++ b/ksql-execution/src/test/java/io/confluent/ksql/execution/codegen/SqlToJavaVisitorTest.java
@@ -63,6 +63,7 @@ import io.confluent.ksql.schema.ksql.types.SqlDecimal;
 import io.confluent.ksql.schema.ksql.types.SqlPrimitiveType;
 import io.confluent.ksql.schema.ksql.types.SqlTypes;
 import java.util.Optional;
+import java.util.function.Function;
 import org.apache.kafka.connect.data.Schema;
 import org.junit.Before;
 import org.junit.Rule;
@@ -87,7 +88,11 @@ public class SqlToJavaVisitorTest {
 
   @Before
   public void init() {
-    sqlToJavaVisitor = new SqlToJavaVisitor(SCHEMA, functionRegistry);
+    sqlToJavaVisitor = new SqlToJavaVisitor(
+        SCHEMA,
+        functionRegistry,
+        fn -> fn.replace(".", "_")
+    );
   }
 
   @Test


### PR DESCRIPTION
### Description 

This patch ensures that all generated code uses valid Java identifiers instead of arbitrary column names by generating `varX` where `X` is the column index for the parameter being passed in. Note that the only "real" changes in this PR are in `SqlToJavaVisitor` and `CodeGenRunner` (both of which are single line changes).

As part of this change I also:

- `Column` also has an index
- `LogicalSchema.Builder` tracks Column Indices
- `LogicalSchema` uses the builder to do internal copies to maintain unique indices (when copying metadata/keys into value)

### Testing done 

- `mvn clean install`

### Reviewer checklist
- [ ] Ensure docs are updated if necessary. (eg. if a user visible feature is being added or changed).
- [ ] Ensure relevant issues are linked (description should include text like "Fixes #<issue number>")

