### PR TITLE
feat: build ks app from an execution plan visitor

### DIFF
--- a/ksql-engine/src/main/java/io/confluent/ksql/physical/TransientQueryQueue.java
+++ b/ksql-engine/src/main/java/io/confluent/ksql/physical/TransientQueryQueue.java
@@ -16,7 +16,6 @@
 package io.confluent.ksql.physical;
 
 import io.confluent.ksql.GenericRow;
-import io.confluent.ksql.structured.SchemaKStream;
 import io.confluent.ksql.util.KsqlException;
 import java.util.Objects;
 import java.util.OptionalInt;
@@ -24,6 +23,7 @@ import java.util.concurrent.BlockingQueue;
 import java.util.concurrent.LinkedBlockingQueue;
 import org.apache.kafka.streams.KeyValue;
 import org.apache.kafka.streams.kstream.ForeachAction;
+import org.apache.kafka.streams.kstream.KStream;
 import org.apache.kafka.streams.kstream.Windowed;
 
 /**
@@ -37,13 +37,12 @@ class TransientQueryQueue<K> {
   private final BlockingQueue<KeyValue<String, GenericRow>> rowQueue =
       new LinkedBlockingQueue<>(100);
 
-  TransientQueryQueue(final SchemaKStream<K> schemaKStream, final OptionalInt limit) {
+  TransientQueryQueue(final KStream<?, GenericRow> kstream, final OptionalInt limit) {
     this.callback = limit.isPresent()
         ? new LimitedQueueCallback(limit.getAsInt())
         : new UnlimitedQueueCallback();
 
-    schemaKStream.getKstream()
-        .foreach(new TransientQueryQueue.QueuePopulator<>(rowQueue, callback));
+    kstream.foreach(new TransientQueryQueue.QueuePopulator<>(rowQueue, callback));
   }
 
   BlockingQueue<KeyValue<String, GenericRow>> getQueue() {

--- a/ksql-engine/src/main/java/io/confluent/ksql/structured/SchemaKGroupedTable.java
+++ b/ksql-engine/src/main/java/io/confluent/ksql/structured/SchemaKGroupedTable.java
@@ -26,7 +26,6 @@ import io.confluent.ksql.execution.plan.Formats;
 import io.confluent.ksql.execution.plan.TableAggregate;
 import io.confluent.ksql.execution.streams.ExecutionStepFactory;
 import io.confluent.ksql.execution.streams.MaterializedFactory;
-import io.confluent.ksql.execution.streams.TableAggregateBuilder;
 import io.confluent.ksql.function.FunctionRegistry;
 import io.confluent.ksql.function.KsqlAggregateFunction;
 import io.confluent.ksql.metastore.model.KeyField;
@@ -46,11 +45,9 @@ import org.apache.kafka.connect.data.Struct;
 import org.apache.kafka.streams.kstream.KGroupedTable;
 
 public class SchemaKGroupedTable extends SchemaKGroupedStream {
-  private final KGroupedTable kgroupedTable;
   private final ExecutionStep<KGroupedTable<Struct, GenericRow>> sourceTableStep;
 
   SchemaKGroupedTable(
-      final KGroupedTable kgroupedTable,
       final ExecutionStep<KGroupedTable<Struct, GenericRow>> sourceTableStep,
       final KeyFormat keyFormat,
       final KeySerde<Struct> keySerde,
@@ -60,7 +57,6 @@ public class SchemaKGroupedTable extends SchemaKGroupedStream {
       final FunctionRegistry functionRegistry
   ) {
     this(
-        kgroupedTable,
         sourceTableStep,
         keyFormat,
         keySerde,
@@ -72,7 +68,6 @@ public class SchemaKGroupedTable extends SchemaKGroupedStream {
   }
 
   SchemaKGroupedTable(
-      final KGroupedTable kgroupedTable,
       final ExecutionStep<KGroupedTable<Struct, GenericRow>> sourceTableStep,
       final KeyFormat keyFormat,
       final KeySerde<Struct> keySerde,
@@ -84,7 +79,6 @@ public class SchemaKGroupedTable extends SchemaKGroupedStream {
   ) {
     super(
         null,
-        null,
         keyFormat,
         keySerde,
         keyField,
@@ -94,7 +88,6 @@ public class SchemaKGroupedTable extends SchemaKGroupedStream {
         materializedFactory
     );
 
-    this.kgroupedTable = Objects.requireNonNull(kgroupedTable, "kgroupedTable");
     this.sourceTableStep = Objects.requireNonNull(sourceTableStep, "sourceTableStep");
   }
 
@@ -144,12 +137,6 @@ public class SchemaKGroupedTable extends SchemaKGroupedStream {
     );
 
     return new SchemaKTable<>(
-        TableAggregateBuilder.build(
-            kgroupedTable,
-            step,
-            queryBuilder,
-            materializedFactory
-        ),
         step,
         keyFormat,
         keySerde,

--- a/ksql-engine/src/main/java/io/confluent/ksql/structured/SchemaKTable.java
+++ b/ksql-engine/src/main/java/io/confluent/ksql/structured/SchemaKTable.java
@@ -16,13 +16,13 @@
 package io.confluent.ksql.structured;
 
 import com.google.common.collect.ImmutableList;
-import io.confluent.ksql.GenericRow;
 import io.confluent.ksql.execution.builder.KsqlQueryBuilder;
 import io.confluent.ksql.execution.context.QueryContext;
 import io.confluent.ksql.execution.expression.tree.Expression;
 import io.confluent.ksql.execution.plan.ExecutionStep;
 import io.confluent.ksql.execution.plan.Formats;
 import io.confluent.ksql.execution.plan.JoinType;
+import io.confluent.ksql.execution.plan.KTableHolder;
 import io.confluent.ksql.execution.plan.SelectExpression;
 import io.confluent.ksql.execution.plan.TableFilter;
 import io.confluent.ksql.execution.plan.TableGroupBy;
@@ -30,11 +30,6 @@ import io.confluent.ksql.execution.plan.TableMapValues;
 import io.confluent.ksql.execution.plan.TableSink;
 import io.confluent.ksql.execution.plan.TableTableJoin;
 import io.confluent.ksql.execution.streams.ExecutionStepFactory;
-import io.confluent.ksql.execution.streams.TableFilterBuilder;
-import io.confluent.ksql.execution.streams.TableGroupByBuilder;
-import io.confluent.ksql.execution.streams.TableMapValuesBuilder;
-import io.confluent.ksql.execution.streams.TableSinkBuilder;
-import io.confluent.ksql.execution.streams.TableTableJoinBuilder;
 import io.confluent.ksql.execution.util.StructKeyUtil;
 import io.confluent.ksql.function.FunctionRegistry;
 import io.confluent.ksql.metastore.model.KeyField;
@@ -47,7 +42,6 @@ import io.confluent.ksql.serde.KeyFormat;
 import io.confluent.ksql.serde.KeySerde;
 import io.confluent.ksql.serde.SerdeOption;
 import io.confluent.ksql.serde.ValueFormat;
-import io.confluent.ksql.streams.StreamsFactories;
 import io.confluent.ksql.util.KsqlConfig;
 import java.util.Collections;
 import java.util.List;
@@ -55,18 +49,14 @@ import java.util.Objects;
 import java.util.Optional;
 import java.util.Set;
 import org.apache.kafka.connect.data.Struct;
-import org.apache.kafka.streams.kstream.KStream;
-import org.apache.kafka.streams.kstream.KTable;
 
 // CHECKSTYLE_RULES.OFF: ClassDataAbstractionCoupling
 public class SchemaKTable<K> extends SchemaKStream<K> {
   // CHECKSTYLE_RULES.ON: ClassDataAbstractionCoupling
-  private final KTable<K, GenericRow> ktable;
-  private final ExecutionStep<KTable<K, GenericRow>> sourceTableStep;
+  private final ExecutionStep<KTableHolder<K>> sourceTableStep;
 
   public SchemaKTable(
-      final KTable<K, GenericRow> ktable,
-      final ExecutionStep<KTable<K, GenericRow>> sourceTableStep,
+      final ExecutionStep<KTableHolder<K>> sourceTableStep,
       final KeyFormat keyFormat,
       final KeySerde<K> keySerde,
       final KeyField keyField,
@@ -75,34 +65,7 @@ public class SchemaKTable<K> extends SchemaKStream<K> {
       final KsqlConfig ksqlConfig,
       final FunctionRegistry functionRegistry
   ) {
-    this(
-        ktable,
-        sourceTableStep,
-        keyFormat,
-        keySerde,
-        keyField,
-        sourceSchemaKStreams,
-        type,
-        ksqlConfig,
-        functionRegistry,
-        StreamsFactories.create(ksqlConfig)
-    );
-  }
-
-  SchemaKTable(
-      final KTable<K, GenericRow> ktable,
-      final ExecutionStep<KTable<K, GenericRow>> sourceTableStep,
-      final KeyFormat keyFormat,
-      final KeySerde<K> keySerde,
-      final KeyField keyField,
-      final List<SchemaKStream> sourceSchemaKStreams,
-      final Type type,
-      final KsqlConfig ksqlConfig,
-      final FunctionRegistry functionRegistry,
-      final StreamsFactories streamsFactories
-  ) {
     super(
-        null,
         null,
         Objects.requireNonNull(sourceTableStep, "sourceTableStep").getProperties(),
         keyFormat,
@@ -111,10 +74,8 @@ public class SchemaKTable<K> extends SchemaKStream<K> {
         sourceSchemaKStreams,
         type,
         ksqlConfig,
-        functionRegistry,
-        streamsFactories
+        functionRegistry
     );
-    this.ktable = ktable;
     this.sourceTableStep = sourceTableStep;
   }
 
@@ -135,14 +96,7 @@ public class SchemaKTable<K> extends SchemaKStream<K> {
         Formats.of(keyFormat, valueFormat, options),
         kafkaTopicName
     );
-    TableSinkBuilder.build(
-        ktable,
-        step,
-        (fmt, schema, ctx) -> keySerde,
-        builder
-    );
     return new SchemaKTable<>(
-        ktable,
         step,
         keyFormat,
         keySerde,
@@ -161,13 +115,12 @@ public class SchemaKTable<K> extends SchemaKStream<K> {
       final QueryContext.Stacker contextStacker,
       final KsqlQueryBuilder queryBuilder
   ) {
-    final TableFilter<KTable<K, GenericRow>> step = ExecutionStepFactory.tableFilter(
+    final TableFilter<K> step = ExecutionStepFactory.tableFilter(
         contextStacker,
         sourceTableStep,
         rewriteTimeComparisonForFilter(filterExpression)
     );
     return new SchemaKTable<>(
-        TableFilterBuilder.build(ktable, step, queryBuilder),
         step,
         keyFormat,
         keySerde,
@@ -187,14 +140,13 @@ public class SchemaKTable<K> extends SchemaKStream<K> {
     final KeySelection selection = new KeySelection(
         selectExpressions
     );
-    final TableMapValues<KTable<K, GenericRow>> step = ExecutionStepFactory.tableMapValues(
+    final TableMapValues<K> step = ExecutionStepFactory.tableMapValues(
         contextStacker,
         sourceTableStep,
         selectExpressions,
         ksqlQueryBuilder
     );
     return new SchemaKTable<>(
-        TableMapValuesBuilder.build(ktable, step, ksqlQueryBuilder),
         step,
         keyFormat,
         keySerde,
@@ -206,17 +158,7 @@ public class SchemaKTable<K> extends SchemaKStream<K> {
     );
   }
 
-  @SuppressWarnings("unchecked") // needs investigating
-  @Override
-  public KStream getKstream() {
-    return ktable.toStream();
-  }
-
-  public KTable<K, GenericRow> getKtable() {
-    return ktable;
-  }
-
-  public ExecutionStep<KTable<K, GenericRow>> getSourceTableStep() {
+  public ExecutionStep<KTableHolder<K>> getSourceTableStep() {
     return sourceTableStep;
   }
 
@@ -246,12 +188,6 @@ public class SchemaKTable<K> extends SchemaKStream<K> {
         groupByExpressions
     );
     return new SchemaKGroupedTable(
-        TableGroupByBuilder.build(
-            ktable,
-            step,
-            queryBuilder,
-            streamsFactories.getGroupedFactory()
-        ),
         step,
         groupedKeyFormat,
         groupedKeySerde,
@@ -275,7 +211,6 @@ public class SchemaKTable<K> extends SchemaKStream<K> {
         joinSchema
     );
     return new SchemaKTable<>(
-        TableTableJoinBuilder.build(ktable, schemaKTable.ktable, step),
         step,
         keyFormat,
         keySerde,
@@ -301,7 +236,6 @@ public class SchemaKTable<K> extends SchemaKStream<K> {
         joinSchema
     );
     return new SchemaKTable<>(
-        TableTableJoinBuilder.build(ktable, schemaKTable.ktable, step),
         step,
         keyFormat,
         keySerde,
@@ -327,7 +261,6 @@ public class SchemaKTable<K> extends SchemaKStream<K> {
         joinSchema
     );
     return new SchemaKTable<>(
-        TableTableJoinBuilder.build(ktable, schemaKTable.ktable, step),
         step,
         keyFormat,
         keySerde,

--- a/ksql-engine/src/test/java/io/confluent/ksql/physical/TransientQueryQueueTest.java
+++ b/ksql-engine/src/test/java/io/confluent/ksql/physical/TransientQueryQueueTest.java
@@ -53,8 +53,6 @@ public class TransientQueryQueueTest {
   private LimitHandler limitHandler;
   @Mock
   private KStream<String, GenericRow> kStreamsApp;
-  @Mock
-  private SchemaKStream<String> queuedKStream;
   @Captor
   private ArgumentCaptor<QueuePopulator<String>> queuePopulatorCaptor;
   private Queue<KeyValue<String, GenericRow>> queue;
@@ -62,10 +60,8 @@ public class TransientQueryQueueTest {
 
   @Before
   public void setUp() {
-    when(queuedKStream.getKstream()).thenReturn(kStreamsApp);
-
     final TransientQueryQueue<String> queuer =
-        new TransientQueryQueue<>(queuedKStream, OptionalInt.of(SOME_LIMIT));
+        new TransientQueryQueue<>(kStreamsApp, OptionalInt.of(SOME_LIMIT));
 
     queuer.setLimitHandler(limitHandler);
 

--- a/ksql-engine/src/test/java/io/confluent/ksql/planner/plan/AggregateNodeTest.java
+++ b/ksql-engine/src/test/java/io/confluent/ksql/planner/plan/AggregateNodeTest.java
@@ -43,6 +43,7 @@ import io.confluent.ksql.GenericRow;
 import io.confluent.ksql.execution.builder.KsqlQueryBuilder;
 import io.confluent.ksql.execution.context.QueryContext;
 import io.confluent.ksql.execution.context.QueryLoggerUtil;
+import io.confluent.ksql.execution.streams.KSPlanBuilder;
 import io.confluent.ksql.function.FunctionRegistry;
 import io.confluent.ksql.function.InternalFunctionRegistry;
 import io.confluent.ksql.logging.processing.ProcessingLogContext;
@@ -404,7 +405,9 @@ public class AggregateNodeTest {
             .push(inv.getArgument(0).toString()));
     when(ksqlStreamBuilder.buildKeySerde(any(), any(), any())).thenReturn(keySerde);
 
-    return aggregateNode.buildStream(ksqlStreamBuilder);
+    final SchemaKTable schemaKTable = (SchemaKTable) aggregateNode.buildStream(ksqlStreamBuilder);
+    schemaKTable.getSourceTableStep().build(new KSPlanBuilder(ksqlStreamBuilder));
+    return schemaKTable;
   }
 
   private static AggregateNode buildAggregateNode(final String queryString) {

--- a/ksql-engine/src/test/java/io/confluent/ksql/planner/plan/JoinNodeTest.java
+++ b/ksql-engine/src/test/java/io/confluent/ksql/planner/plan/JoinNodeTest.java
@@ -37,6 +37,7 @@ import com.google.common.collect.ImmutableSet;
 import io.confluent.ksql.execution.builder.KsqlQueryBuilder;
 import io.confluent.ksql.execution.context.QueryContext;
 import io.confluent.ksql.execution.ddl.commands.KsqlTopic;
+import io.confluent.ksql.execution.streams.KSPlanBuilder;
 import io.confluent.ksql.function.FunctionRegistry;
 import io.confluent.ksql.function.InternalFunctionRegistry;
 import io.confluent.ksql.metastore.MetaStore;
@@ -995,7 +996,13 @@ public class JoinNodeTest {
 
   private void buildJoin(final String queryString) {
     buildJoinNode(queryString);
-    joinNode.buildStream(ksqlStreamBuilder);
+    final SchemaKStream stream = joinNode.buildStream(ksqlStreamBuilder);
+    if (stream instanceof SchemaKTable) {
+      final SchemaKTable table = (SchemaKTable) stream;
+      table.getSourceTableStep().build(new KSPlanBuilder(ksqlStreamBuilder));
+    } else {
+      stream.getSourceStep().build(new KSPlanBuilder(ksqlStreamBuilder));
+    }
   }
 
   private void buildJoinNode(final String queryString) {

--- a/ksql-engine/src/test/java/io/confluent/ksql/planner/plan/KsqlBareOutputNodeTest.java
+++ b/ksql-engine/src/test/java/io/confluent/ksql/planner/plan/KsqlBareOutputNodeTest.java
@@ -27,6 +27,7 @@ import static org.mockito.Mockito.when;
 import com.google.common.collect.ImmutableSet;
 import io.confluent.ksql.execution.builder.KsqlQueryBuilder;
 import io.confluent.ksql.execution.context.QueryContext;
+import io.confluent.ksql.execution.streams.KSPlanBuilder;
 import io.confluent.ksql.function.FunctionRegistry;
 import io.confluent.ksql.function.InternalFunctionRegistry;
 import io.confluent.ksql.logging.processing.ProcessingLogContext;
@@ -96,6 +97,7 @@ public class KsqlBareOutputNodeTest {
         .buildLogicalPlan(ksqlConfig, SIMPLE_SELECT_WITH_FILTER, metaStore);
 
     stream = planNode.buildStream(ksqlStreamBuilder);
+    stream.getSourceStep().build(new KSPlanBuilder(ksqlStreamBuilder));
   }
 
   @Test

--- a/ksql-execution/src/main/java/io/confluent/ksql/execution/plan/ExecutionStep.java
+++ b/ksql-execution/src/main/java/io/confluent/ksql/execution/plan/ExecutionStep.java
@@ -14,7 +14,6 @@
 
 package io.confluent.ksql.execution.plan;
 
-import io.confluent.ksql.execution.builder.KsqlQueryBuilder;
 import io.confluent.ksql.schema.ksql.LogicalSchema;
 import java.util.List;
 
@@ -23,7 +22,7 @@ public interface ExecutionStep<S> {
 
   List<ExecutionStep<?>> getSources();
 
-  S build(KsqlQueryBuilder queryBuilder);
+  S build(PlanBuilder planBuilder);
 
   default LogicalSchema getSchema() {
     return getProperties().getSchema();

--- a/ksql-execution/src/main/java/io/confluent/ksql/execution/plan/KStreamHolder.java
+++ b/ksql-execution/src/main/java/io/confluent/ksql/execution/plan/KStreamHolder.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright 2019 Confluent Inc.
+ *
+ * Licensed under the Confluent Community License (the "License"); you may not use
+ * this file except in compliance with the License.  You may obtain a copy of the
+ * License at
+ *
+ * http://www.confluent.io/confluent-community-license
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package io.confluent.ksql.execution.plan;
+
+import io.confluent.ksql.GenericRow;
+import java.util.Objects;
+import org.apache.kafka.streams.kstream.KStream;
+
+public final class KStreamHolder<K> {
+  private final KStream<K, GenericRow> stream;
+  private final KeySerdeFactory<K> keySerdeFactory;
+
+  public KStreamHolder(
+      final KStream<K, GenericRow> stream,
+      final KeySerdeFactory<K> keySerdeFactory
+  ) {
+    this.stream = Objects.requireNonNull(stream, "stream");
+    this.keySerdeFactory = Objects.requireNonNull(keySerdeFactory, "keySerdeFactory");
+  }
+
+  public KeySerdeFactory<K> getKeySerdeFactory() {
+    return keySerdeFactory;
+  }
+
+  public KStream<K, GenericRow> getStream() {
+    return stream;
+  }
+
+  public KStreamHolder<K> withStream(final KStream<K, GenericRow> stream) {
+    return new KStreamHolder<>(stream, keySerdeFactory);
+  }
+}

--- a/ksql-execution/src/main/java/io/confluent/ksql/execution/plan/KTableHolder.java
+++ b/ksql-execution/src/main/java/io/confluent/ksql/execution/plan/KTableHolder.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright 2019 Confluent Inc.
+ *
+ * Licensed under the Confluent Community License (the "License"); you may not use
+ * this file except in compliance with the License.  You may obtain a copy of the
+ * License at
+ *
+ * http://www.confluent.io/confluent-community-license
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package io.confluent.ksql.execution.plan;
+
+import io.confluent.ksql.GenericRow;
+import java.util.Objects;
+import org.apache.kafka.streams.kstream.KTable;
+
+public final class KTableHolder<K> {
+  private final KTable<K, GenericRow> stream;
+  private final KeySerdeFactory<K> keySerdeFactory;
+
+  public KTableHolder(
+      final KTable<K, GenericRow> stream,
+      final KeySerdeFactory<K> keySerdeFactory
+  ) {
+    this.stream = Objects.requireNonNull(stream, "stream");
+    this.keySerdeFactory = Objects.requireNonNull(keySerdeFactory, "keySerdeFactory");
+  }
+
+  public KeySerdeFactory<K> getKeySerdeFactory() {
+    return keySerdeFactory;
+  }
+
+  public KTable<K, GenericRow> getTable() {
+    return stream;
+  }
+
+  public KTableHolder<K> withTable(final KTable<K, GenericRow> table) {
+    return new KTableHolder<>(table, keySerdeFactory);
+  }
+}

--- a/ksql-execution/src/main/java/io/confluent/ksql/execution/plan/PlanBuilder.java
+++ b/ksql-execution/src/main/java/io/confluent/ksql/execution/plan/PlanBuilder.java
@@ -1,0 +1,67 @@
+/*
+ * Copyright 2019 Confluent Inc.
+ *
+ * Licensed under the Confluent Community License (the "License"); you may not use
+ * this file except in compliance with the License.  You may obtain a copy of the
+ * License at
+ *
+ * http://www.confluent.io/confluent-community-license
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package io.confluent.ksql.execution.plan;
+
+import io.confluent.ksql.GenericRow;
+import org.apache.kafka.connect.data.Struct;
+import org.apache.kafka.streams.kstream.KGroupedStream;
+import org.apache.kafka.streams.kstream.KGroupedTable;
+import org.apache.kafka.streams.kstream.Windowed;
+
+/**
+ * A visitor interface for building a query from an execution plan. There is a single
+ * visit method for each execution step type (final implementations of ExecutionStep).
+ * Implementers typically implement the visit methods by applying the transformation
+ * specified in the step to the stream/table(s) returned by visiting hte source steps.
+ */
+public interface PlanBuilder {
+  <K> KStreamHolder<K> visitStreamFilter(StreamFilter<K> streamFilter);
+
+  <K> KGroupedStream<Struct, GenericRow> visitStreamGroupBy(StreamGroupBy<K> streamGroupBy);
+
+  KGroupedStream<Struct, GenericRow> visitStreamGroupByKey(StreamGroupByKey streamGroupByKey);
+
+  KTableHolder<Struct> visitStreamAggregate(StreamAggregate streamAggregate);
+
+  <K> KStreamHolder<K> visitStreamMapValues(StreamMapValues<K> streamMapValues);
+
+  KStreamHolder<Struct> visitStreamSelectKey(StreamSelectKey<?> streamSelectKey);
+
+  <K> KStreamHolder<K> visitStreamSink(StreamSink<K> streamSink);
+
+  <K> KStreamHolder<K> visitStreamSource(StreamSource<K> streamSource);
+
+  <K> KStreamHolder<K> visitStreamStreamJoin(StreamStreamJoin<K> streamStreamJoin);
+
+  <K> KStreamHolder<K> visitStreamTableJoin(StreamTableJoin<K> streamTableJoin);
+
+  <K> KTableHolder<K> visitStreamToTable(StreamToTable<K> streamToTable);
+
+  KTableHolder<Windowed<Struct>> visitStreamWindowedAggregate(
+      StreamWindowedAggregate streamWindowedAggregate);
+
+  KTableHolder<Struct> visitTableAggregate(TableAggregate tableAggregate);
+
+  <K> KTableHolder<K> visitTableFilter(TableFilter<K> tableFilter);
+
+  <K> KGroupedTable<Struct, GenericRow> visitTableGroupBy(TableGroupBy<K> tableGroupBy);
+
+  <K> KTableHolder<K> visitTableMapValues(TableMapValues<K> tableMapValues);
+
+  <K> KTableHolder<K> visitTableSink(TableSink<K> tableSink);
+
+  <K> KTableHolder<K> visitTableTableJoin(TableTableJoin<K> tableTableJoin);
+}

--- a/ksql-execution/src/main/java/io/confluent/ksql/execution/plan/StreamAggregate.java
+++ b/ksql-execution/src/main/java/io/confluent/ksql/execution/plan/StreamAggregate.java
@@ -16,7 +16,6 @@ package io.confluent.ksql.execution.plan;
 
 import com.google.errorprone.annotations.Immutable;
 import io.confluent.ksql.GenericRow;
-import io.confluent.ksql.execution.builder.KsqlQueryBuilder;
 import io.confluent.ksql.execution.expression.tree.FunctionCall;
 import io.confluent.ksql.schema.ksql.LogicalSchema;
 import java.util.Collections;
@@ -24,10 +23,9 @@ import java.util.List;
 import java.util.Objects;
 import org.apache.kafka.connect.data.Struct;
 import org.apache.kafka.streams.kstream.KGroupedStream;
-import org.apache.kafka.streams.kstream.KTable;
 
 @Immutable
-public class StreamAggregate implements ExecutionStep<KTable<Struct, GenericRow>> {
+public class StreamAggregate implements ExecutionStep<KTableHolder<Struct>> {
   private final ExecutionStepProperties properties;
   private final ExecutionStep<KGroupedStream<Struct, GenericRow>> source;
   private final Formats formats;
@@ -76,9 +74,13 @@ public class StreamAggregate implements ExecutionStep<KTable<Struct, GenericRow>
     return aggregationSchema;
   }
 
+  public ExecutionStep<KGroupedStream<Struct, GenericRow>> getSource() {
+    return source;
+  }
+
   @Override
-  public KTable<Struct, GenericRow> build(final KsqlQueryBuilder streamsBuilder) {
-    throw new UnsupportedOperationException();
+  public KTableHolder<Struct> build(final PlanBuilder builder) {
+    return builder.visitStreamAggregate(this);
   }
 
   @Override

--- a/ksql-execution/src/main/java/io/confluent/ksql/execution/plan/StreamFilter.java
+++ b/ksql-execution/src/main/java/io/confluent/ksql/execution/plan/StreamFilter.java
@@ -15,22 +15,21 @@
 package io.confluent.ksql.execution.plan;
 
 import com.google.errorprone.annotations.Immutable;
-import io.confluent.ksql.execution.builder.KsqlQueryBuilder;
 import io.confluent.ksql.execution.expression.tree.Expression;
 import java.util.Collections;
 import java.util.List;
 import java.util.Objects;
 
 @Immutable
-public class StreamFilter<S> implements ExecutionStep<S> {
+public class StreamFilter<K> implements ExecutionStep<KStreamHolder<K>> {
 
   private final ExecutionStepProperties properties;
-  private final ExecutionStep<S> source;
+  private final ExecutionStep<KStreamHolder<K>> source;
   private final Expression filterExpression;
 
   public StreamFilter(
       final ExecutionStepProperties properties,
-      final ExecutionStep<S> source,
+      final ExecutionStep<KStreamHolder<K>> source,
       final Expression filterExpression) {
     this.properties = Objects.requireNonNull(properties, "properties");
     this.source = Objects.requireNonNull(source, "source");
@@ -51,13 +50,13 @@ public class StreamFilter<S> implements ExecutionStep<S> {
     return filterExpression;
   }
 
-  public ExecutionStep<S> getSource() {
+  public ExecutionStep<KStreamHolder<K>> getSource() {
     return source;
   }
 
   @Override
-  public S build(final KsqlQueryBuilder streamsBuilder) {
-    throw new UnsupportedOperationException();
+  public KStreamHolder<K> build(final PlanBuilder builder) {
+    return builder.visitStreamFilter(this);
   }
 
   @Override

--- a/ksql-execution/src/main/java/io/confluent/ksql/execution/plan/StreamGroupBy.java
+++ b/ksql-execution/src/main/java/io/confluent/ksql/execution/plan/StreamGroupBy.java
@@ -16,25 +16,23 @@ package io.confluent.ksql.execution.plan;
 
 import com.google.errorprone.annotations.Immutable;
 import io.confluent.ksql.GenericRow;
-import io.confluent.ksql.execution.builder.KsqlQueryBuilder;
 import io.confluent.ksql.execution.expression.tree.Expression;
 import java.util.Collections;
 import java.util.List;
 import java.util.Objects;
 import org.apache.kafka.connect.data.Struct;
 import org.apache.kafka.streams.kstream.KGroupedStream;
-import org.apache.kafka.streams.kstream.KStream;
 
 @Immutable
 public class StreamGroupBy<K> implements ExecutionStep<KGroupedStream<Struct, GenericRow>> {
   private final ExecutionStepProperties properties;
-  private final ExecutionStep<KStream<K, GenericRow>> source;
+  private final ExecutionStep<KStreamHolder<K>> source;
   private final Formats formats;
   private final List<Expression> groupByExpressions;
 
   public StreamGroupBy(
       final ExecutionStepProperties properties,
-      final ExecutionStep<KStream<K, GenericRow>> source,
+      final ExecutionStep<KStreamHolder<K>> source,
       final Formats formats,
       final List<Expression> groupByExpressions) {
     this.properties = Objects.requireNonNull(properties, "properties");
@@ -61,13 +59,13 @@ public class StreamGroupBy<K> implements ExecutionStep<KGroupedStream<Struct, Ge
     return formats;
   }
 
-  public ExecutionStep<KStream<K, GenericRow>> getSource() {
+  public ExecutionStep<KStreamHolder<K>> getSource() {
     return source;
   }
 
   @Override
-  public KGroupedStream<Struct, GenericRow> build(final KsqlQueryBuilder streamsBuilder) {
-    throw new UnsupportedOperationException();
+  public KGroupedStream<Struct, GenericRow> build(final PlanBuilder planVisitor) {
+    return planVisitor.visitStreamGroupBy(this);
   }
 
   @Override

--- a/ksql-execution/src/main/java/io/confluent/ksql/execution/plan/StreamGroupByKey.java
+++ b/ksql-execution/src/main/java/io/confluent/ksql/execution/plan/StreamGroupByKey.java
@@ -16,23 +16,21 @@ package io.confluent.ksql.execution.plan;
 
 import com.google.errorprone.annotations.Immutable;
 import io.confluent.ksql.GenericRow;
-import io.confluent.ksql.execution.builder.KsqlQueryBuilder;
 import java.util.Collections;
 import java.util.List;
 import java.util.Objects;
 import org.apache.kafka.connect.data.Struct;
 import org.apache.kafka.streams.kstream.KGroupedStream;
-import org.apache.kafka.streams.kstream.KStream;
 
 @Immutable
 public class StreamGroupByKey implements ExecutionStep<KGroupedStream<Struct, GenericRow>> {
   private final ExecutionStepProperties properties;
-  private final ExecutionStep<KStream<Struct, GenericRow>> source;
+  private final ExecutionStep<KStreamHolder<Struct>> source;
   private final Formats formats;
 
   public StreamGroupByKey(
       final ExecutionStepProperties properties,
-      final ExecutionStep<KStream<Struct, GenericRow>> source,
+      final ExecutionStep<KStreamHolder<Struct>> source,
       final Formats formats) {
     this.properties = Objects.requireNonNull(properties, "properties");
     this.formats = Objects.requireNonNull(formats, "formats");
@@ -49,7 +47,7 @@ public class StreamGroupByKey implements ExecutionStep<KGroupedStream<Struct, Ge
     return Collections.singletonList(source);
   }
 
-  public ExecutionStep<KStream<Struct, GenericRow>> getSource() {
+  public ExecutionStep<KStreamHolder<Struct>> getSource() {
     return source;
   }
 
@@ -58,8 +56,8 @@ public class StreamGroupByKey implements ExecutionStep<KGroupedStream<Struct, Ge
   }
 
   @Override
-  public KGroupedStream<Struct, GenericRow> build(final KsqlQueryBuilder streamsBuilder) {
-    throw new UnsupportedOperationException();
+  public KGroupedStream<Struct, GenericRow> build(final PlanBuilder builder) {
+    return builder.visitStreamGroupByKey(this);
   }
 
   @Override

--- a/ksql-execution/src/main/java/io/confluent/ksql/execution/plan/StreamMapValues.java
+++ b/ksql-execution/src/main/java/io/confluent/ksql/execution/plan/StreamMapValues.java
@@ -16,20 +16,19 @@ package io.confluent.ksql.execution.plan;
 
 import com.google.common.collect.ImmutableList;
 import com.google.errorprone.annotations.Immutable;
-import io.confluent.ksql.execution.builder.KsqlQueryBuilder;
 import java.util.Collections;
 import java.util.List;
 import java.util.Objects;
 
 @Immutable
-public class StreamMapValues<S> implements ExecutionStep<S> {
+public class StreamMapValues<K> implements ExecutionStep<KStreamHolder<K>> {
   private final ExecutionStepProperties properties;
-  private final ExecutionStep<S> source;
+  private final ExecutionStep<KStreamHolder<K>> source;
   private final List<SelectExpression> selectExpressions;
 
   public StreamMapValues(
       final ExecutionStepProperties properties,
-      final ExecutionStep<S> source,
+      final ExecutionStep<KStreamHolder<K>> source,
       final List<SelectExpression> selectExpressions) {
     this.properties = Objects.requireNonNull(properties, "properties");
     this.source = Objects.requireNonNull(source, "source");
@@ -46,17 +45,17 @@ public class StreamMapValues<S> implements ExecutionStep<S> {
     return Collections.singletonList(source);
   }
 
-  @Override
-  public S build(final KsqlQueryBuilder streamsBuilder) {
-    throw new UnsupportedOperationException();
-  }
-
   public List<SelectExpression> getSelectExpressions() {
     return selectExpressions;
   }
 
-  public ExecutionStep<S> getSource() {
+  public ExecutionStep<KStreamHolder<K>> getSource() {
     return source;
+  }
+
+  @Override
+  public KStreamHolder<K> build(final PlanBuilder builder) {
+    return builder.visitStreamMapValues(this);
   }
 
   @Override

--- a/ksql-execution/src/main/java/io/confluent/ksql/execution/plan/StreamSelectKey.java
+++ b/ksql-execution/src/main/java/io/confluent/ksql/execution/plan/StreamSelectKey.java
@@ -15,25 +15,22 @@
 package io.confluent.ksql.execution.plan;
 
 import com.google.errorprone.annotations.Immutable;
-import io.confluent.ksql.GenericRow;
-import io.confluent.ksql.execution.builder.KsqlQueryBuilder;
 import io.confluent.ksql.name.ColumnName;
 import java.util.Collections;
 import java.util.List;
 import java.util.Objects;
 import org.apache.kafka.connect.data.Struct;
-import org.apache.kafka.streams.kstream.KStream;
 
 @Immutable
-public class StreamSelectKey<K> implements ExecutionStep<KStream<Struct, GenericRow>> {
+public class StreamSelectKey<K> implements ExecutionStep<KStreamHolder<Struct>> {
   private final ExecutionStepProperties properties;
-  private final ExecutionStep<KStream<K, GenericRow>> source;
   private final ColumnName fieldName;
+  private final ExecutionStep<KStreamHolder<K>> source;
   private final boolean updateRowKey;
 
   public StreamSelectKey(
       final ExecutionStepProperties properties,
-      final ExecutionStep<KStream<K, GenericRow>> source,
+      final ExecutionStep<KStreamHolder<K>> source,
       final ColumnName fieldName,
       final boolean updateRowKey) {
     this.properties = Objects.requireNonNull(properties, "properties");
@@ -60,9 +57,13 @@ public class StreamSelectKey<K> implements ExecutionStep<KStream<Struct, Generic
     return fieldName;
   }
 
+  public ExecutionStep<KStreamHolder<K>> getSource() {
+    return source;
+  }
+
   @Override
-  public KStream<Struct, GenericRow> build(final KsqlQueryBuilder streamsBuilder) {
-    throw new UnsupportedOperationException();
+  public KStreamHolder<Struct> build(final PlanBuilder builder) {
+    return builder.visitStreamSelectKey(this);
   }
 
   @Override

--- a/ksql-execution/src/main/java/io/confluent/ksql/execution/plan/StreamSink.java
+++ b/ksql-execution/src/main/java/io/confluent/ksql/execution/plan/StreamSink.java
@@ -15,23 +15,20 @@
 package io.confluent.ksql.execution.plan;
 
 import com.google.errorprone.annotations.Immutable;
-import io.confluent.ksql.GenericRow;
-import io.confluent.ksql.execution.builder.KsqlQueryBuilder;
 import java.util.Collections;
 import java.util.List;
 import java.util.Objects;
-import org.apache.kafka.streams.kstream.KStream;
 
 @Immutable
-public class StreamSink<K> implements ExecutionStep<KStream<K, GenericRow>> {
+public class StreamSink<K> implements ExecutionStep<KStreamHolder<K>> {
   private final ExecutionStepProperties properties;
-  private final ExecutionStep<KStream<K, GenericRow>>  source;
+  private final ExecutionStep<KStreamHolder<K>>  source;
   private final Formats formats;
   private final String topicName;
 
   public StreamSink(
       final ExecutionStepProperties properties,
-      final ExecutionStep<KStream<K, GenericRow>> source,
+      final ExecutionStep<KStreamHolder<K>> source,
       final Formats formats,
       final String topicName) {
     this.properties = Objects.requireNonNull(properties, "properties");
@@ -58,11 +55,14 @@ public class StreamSink<K> implements ExecutionStep<KStream<K, GenericRow>> {
     return formats;
   }
 
-  @Override
-  public KStream<K, GenericRow> build(final KsqlQueryBuilder streamsBuilder) {
-    throw new UnsupportedOperationException();
+  public ExecutionStep<KStreamHolder<K>> getSource() {
+    return source;
   }
 
+  @Override
+  public KStreamHolder<K> build(final PlanBuilder builder) {
+    return builder.visitStreamSink(this);
+  }
 
   @Override
   public boolean equals(final Object o) {

--- a/ksql-execution/src/main/java/io/confluent/ksql/execution/plan/StreamStreamJoin.java
+++ b/ksql-execution/src/main/java/io/confluent/ksql/execution/plan/StreamStreamJoin.java
@@ -16,22 +16,19 @@ package io.confluent.ksql.execution.plan;
 
 import com.google.common.collect.ImmutableList;
 import com.google.errorprone.annotations.Immutable;
-import io.confluent.ksql.GenericRow;
-import io.confluent.ksql.execution.builder.KsqlQueryBuilder;
 import java.time.Duration;
 import java.util.List;
 import java.util.Objects;
-import org.apache.kafka.streams.kstream.KStream;
 
 @Immutable
-public class StreamStreamJoin<K> implements ExecutionStep<KStream<K, GenericRow>> {
+public class StreamStreamJoin<K> implements ExecutionStep<KStreamHolder<K>> {
 
   private final ExecutionStepProperties properties;
   private final JoinType joinType;
   private final Formats leftFormats;
   private final Formats rightFormats;
-  private final ExecutionStep<KStream<K, GenericRow>> left;
-  private final ExecutionStep<KStream<K, GenericRow>> right;
+  private final ExecutionStep<KStreamHolder<K>> left;
+  private final ExecutionStep<KStreamHolder<K>> right;
   private final Duration before;
   private final Duration after;
 
@@ -40,8 +37,8 @@ public class StreamStreamJoin<K> implements ExecutionStep<KStream<K, GenericRow>
       final JoinType joinType,
       final Formats leftFormats,
       final Formats rightFormats,
-      final ExecutionStep<KStream<K, GenericRow>> left,
-      final ExecutionStep<KStream<K, GenericRow>> right,
+      final ExecutionStep<KStreamHolder<K>> left,
+      final ExecutionStep<KStreamHolder<K>> right,
       final Duration before,
       final Duration after) {
     this.properties = Objects.requireNonNull(properties, "properties");
@@ -64,11 +61,6 @@ public class StreamStreamJoin<K> implements ExecutionStep<KStream<K, GenericRow>
     return ImmutableList.of(left, right);
   }
 
-  @Override
-  public KStream<K, GenericRow> build(final KsqlQueryBuilder streamsBuilder) {
-    throw new UnsupportedOperationException();
-  }
-
   public Formats getLeftFormats() {
     return leftFormats;
   }
@@ -77,11 +69,11 @@ public class StreamStreamJoin<K> implements ExecutionStep<KStream<K, GenericRow>
     return rightFormats;
   }
 
-  public ExecutionStep<KStream<K, GenericRow>> getLeft() {
+  public ExecutionStep<KStreamHolder<K>> getLeft() {
     return left;
   }
 
-  public ExecutionStep<KStream<K, GenericRow>> getRight() {
+  public ExecutionStep<KStreamHolder<K>> getRight() {
     return right;
   }
 
@@ -95,6 +87,11 @@ public class StreamStreamJoin<K> implements ExecutionStep<KStream<K, GenericRow>
 
   public Duration getBefore() {
     return before;
+  }
+
+  @Override
+  public KStreamHolder<K> build(final PlanBuilder builder) {
+    return builder.visitStreamStreamJoin(this);
   }
 
   // CHECKSTYLE_RULES.OFF: CyclomaticComplexity

--- a/ksql-execution/src/main/java/io/confluent/ksql/execution/plan/StreamTableJoin.java
+++ b/ksql-execution/src/main/java/io/confluent/ksql/execution/plan/StreamTableJoin.java
@@ -16,28 +16,24 @@ package io.confluent.ksql.execution.plan;
 
 import com.google.common.collect.ImmutableList;
 import com.google.errorprone.annotations.Immutable;
-import io.confluent.ksql.GenericRow;
-import io.confluent.ksql.execution.builder.KsqlQueryBuilder;
 import java.util.List;
 import java.util.Objects;
-import org.apache.kafka.streams.kstream.KStream;
-import org.apache.kafka.streams.kstream.KTable;
 
 @Immutable
-public class StreamTableJoin<K> implements ExecutionStep<KStream<K, GenericRow>> {
+public class StreamTableJoin<K> implements ExecutionStep<KStreamHolder<K>> {
 
   private final ExecutionStepProperties properties;
   private final JoinType joinType;
   private final Formats formats;
-  private final ExecutionStep<KStream<K, GenericRow>> left;
-  private final ExecutionStep<KTable<K, GenericRow>> right;
+  private final ExecutionStep<KStreamHolder<K>> left;
+  private final ExecutionStep<KTableHolder<K>> right;
 
   public StreamTableJoin(
       final ExecutionStepProperties properties,
       final JoinType joinType,
       final Formats formats,
-      final ExecutionStep<KStream<K, GenericRow>> left,
-      final ExecutionStep<KTable<K, GenericRow>> right) {
+      final ExecutionStep<KStreamHolder<K>> left,
+      final ExecutionStep<KTableHolder<K>> right) {
     this.properties = Objects.requireNonNull(properties, "properties");
     this.formats = Objects.requireNonNull(formats, "formats");
     this.joinType = Objects.requireNonNull(joinType, "joinType");
@@ -55,25 +51,25 @@ public class StreamTableJoin<K> implements ExecutionStep<KStream<K, GenericRow>>
     return ImmutableList.of(left, right);
   }
 
-  @Override
-  public KStream<K, GenericRow> build(final KsqlQueryBuilder streamsBuilder) {
-    throw new UnsupportedOperationException();
-  }
-
   public Formats getFormats() {
     return formats;
   }
 
-  public ExecutionStep<KStream<K, GenericRow>> getLeft() {
+  public ExecutionStep<KStreamHolder<K>> getLeft() {
     return left;
   }
 
-  public ExecutionStep<KTable<K, GenericRow>> getRight() {
+  public ExecutionStep<KTableHolder<K>> getRight() {
     return right;
   }
 
   public JoinType getJoinType() {
     return joinType;
+  }
+
+  @Override
+  public KStreamHolder<K> build(final PlanBuilder builder) {
+    return builder.visitStreamTableJoin(this);
   }
 
   @Override

--- a/ksql-execution/src/main/java/io/confluent/ksql/execution/plan/StreamToTable.java
+++ b/ksql-execution/src/main/java/io/confluent/ksql/execution/plan/StreamToTable.java
@@ -16,18 +16,17 @@ package io.confluent.ksql.execution.plan;
 
 import com.google.common.collect.ImmutableList;
 import com.google.errorprone.annotations.Immutable;
-import io.confluent.ksql.execution.builder.KsqlQueryBuilder;
 import java.util.List;
 import java.util.Objects;
 
 @Immutable
-public class StreamToTable<S, T> implements ExecutionStep<T> {
-  private final ExecutionStep<S> source;
+public class StreamToTable<K> implements ExecutionStep<KTableHolder<K>> {
+  private final ExecutionStep<KStreamHolder<K>> source;
   private final Formats formats;
   private final ExecutionStepProperties properties;
 
   public StreamToTable(
-      final ExecutionStep<S> source,
+      final ExecutionStep<KStreamHolder<K>> source,
       final Formats formats,
       final ExecutionStepProperties properties) {
     this.source = Objects.requireNonNull(source, "source");
@@ -45,7 +44,7 @@ public class StreamToTable<S, T> implements ExecutionStep<T> {
     return ImmutableList.of(source);
   }
 
-  public ExecutionStep<S> getSource() {
+  public ExecutionStep<KStreamHolder<K>> getSource() {
     return source;
   }
 
@@ -54,8 +53,8 @@ public class StreamToTable<S, T> implements ExecutionStep<T> {
   }
 
   @Override
-  public T build(final KsqlQueryBuilder builder) {
-    throw new UnsupportedOperationException();
+  public KTableHolder<K> build(final PlanBuilder builder) {
+    return builder.visitStreamToTable(this);
   }
 
   @Override
@@ -66,7 +65,7 @@ public class StreamToTable<S, T> implements ExecutionStep<T> {
     if (o == null || getClass() != o.getClass()) {
       return false;
     }
-    final StreamToTable<?, ?> that = (StreamToTable<?, ?>) o;
+    final StreamToTable<?> that = (StreamToTable<?>) o;
     return Objects.equals(source, that.source)
         && Objects.equals(formats, that.formats)
         && Objects.equals(properties, that.properties);

--- a/ksql-execution/src/main/java/io/confluent/ksql/execution/plan/StreamWindowedAggregate.java
+++ b/ksql-execution/src/main/java/io/confluent/ksql/execution/plan/StreamWindowedAggregate.java
@@ -16,7 +16,6 @@
 package io.confluent.ksql.execution.plan;
 
 import io.confluent.ksql.GenericRow;
-import io.confluent.ksql.execution.builder.KsqlQueryBuilder;
 import io.confluent.ksql.execution.expression.tree.FunctionCall;
 import io.confluent.ksql.execution.windows.KsqlWindowExpression;
 import io.confluent.ksql.schema.ksql.LogicalSchema;
@@ -25,11 +24,10 @@ import java.util.List;
 import java.util.Objects;
 import org.apache.kafka.connect.data.Struct;
 import org.apache.kafka.streams.kstream.KGroupedStream;
-import org.apache.kafka.streams.kstream.KTable;
 import org.apache.kafka.streams.kstream.Windowed;
 
 public class StreamWindowedAggregate
-    implements ExecutionStep<KTable<Windowed<Struct>, GenericRow>> {
+    implements ExecutionStep<KTableHolder<Windowed<Struct>>> {
   private final ExecutionStepProperties properties;
   private final ExecutionStep<KGroupedStream<Struct, GenericRow>> source;
   private final Formats formats;
@@ -85,9 +83,13 @@ public class StreamWindowedAggregate
     return windowExpression;
   }
 
+  public ExecutionStep<KGroupedStream<Struct, GenericRow>> getSource() {
+    return source;
+  }
+
   @Override
-  public KTable<Windowed<Struct>, GenericRow> build(final KsqlQueryBuilder streamsBuilder) {
-    throw new UnsupportedOperationException();
+  public KTableHolder<Windowed<Struct>> build(final PlanBuilder builder) {
+    return builder.visitStreamWindowedAggregate(this);
   }
 
   @Override

--- a/ksql-execution/src/main/java/io/confluent/ksql/execution/plan/TableAggregate.java
+++ b/ksql-execution/src/main/java/io/confluent/ksql/execution/plan/TableAggregate.java
@@ -16,7 +16,6 @@ package io.confluent.ksql.execution.plan;
 
 import com.google.errorprone.annotations.Immutable;
 import io.confluent.ksql.GenericRow;
-import io.confluent.ksql.execution.builder.KsqlQueryBuilder;
 import io.confluent.ksql.execution.expression.tree.FunctionCall;
 import io.confluent.ksql.schema.ksql.LogicalSchema;
 import java.util.Collections;
@@ -24,10 +23,9 @@ import java.util.List;
 import java.util.Objects;
 import org.apache.kafka.connect.data.Struct;
 import org.apache.kafka.streams.kstream.KGroupedTable;
-import org.apache.kafka.streams.kstream.KTable;
 
 @Immutable
-public class TableAggregate implements ExecutionStep<KTable<Struct, GenericRow>> {
+public class TableAggregate implements ExecutionStep<KTableHolder<Struct>> {
   private final ExecutionStepProperties properties;
   private final ExecutionStep<KGroupedTable<Struct, GenericRow>> source;
   private final Formats formats;
@@ -76,9 +74,13 @@ public class TableAggregate implements ExecutionStep<KTable<Struct, GenericRow>>
     return aggregationSchema;
   }
 
+  public ExecutionStep<KGroupedTable<Struct, GenericRow>> getSource() {
+    return source;
+  }
+
   @Override
-  public KTable<Struct, GenericRow> build(final KsqlQueryBuilder builder) {
-    throw new UnsupportedOperationException();
+  public KTableHolder<Struct> build(final PlanBuilder builder) {
+    return builder.visitTableAggregate(this);
   }
 
   @Override

--- a/ksql-execution/src/main/java/io/confluent/ksql/execution/plan/TableFilter.java
+++ b/ksql-execution/src/main/java/io/confluent/ksql/execution/plan/TableFilter.java
@@ -15,21 +15,20 @@
 package io.confluent.ksql.execution.plan;
 
 import com.google.errorprone.annotations.Immutable;
-import io.confluent.ksql.execution.builder.KsqlQueryBuilder;
 import io.confluent.ksql.execution.expression.tree.Expression;
 import java.util.Collections;
 import java.util.List;
 import java.util.Objects;
 
 @Immutable
-public class TableFilter<T> implements ExecutionStep<T> {
+public class TableFilter<K> implements ExecutionStep<KTableHolder<K>> {
   private final ExecutionStepProperties properties;
-  private final ExecutionStep<T> source;
+  private final ExecutionStep<KTableHolder<K>> source;
   private final Expression filterExpression;
 
   public TableFilter(
       final ExecutionStepProperties properties,
-      final ExecutionStep<T> source,
+      final ExecutionStep<KTableHolder<K>> source,
       final Expression filterExpression
   ) {
     this.properties = Objects.requireNonNull(properties, "properties");
@@ -51,13 +50,13 @@ public class TableFilter<T> implements ExecutionStep<T> {
     return filterExpression;
   }
 
-  public ExecutionStep<T> getSource() {
+  public ExecutionStep<KTableHolder<K>> getSource() {
     return source;
   }
 
   @Override
-  public T build(final KsqlQueryBuilder builder) {
-    throw new UnsupportedOperationException();
+  public KTableHolder<K> build(final PlanBuilder builder) {
+    return builder.visitTableFilter(this);
   }
 
   @Override

--- a/ksql-execution/src/main/java/io/confluent/ksql/execution/plan/TableGroupBy.java
+++ b/ksql-execution/src/main/java/io/confluent/ksql/execution/plan/TableGroupBy.java
@@ -16,25 +16,23 @@ package io.confluent.ksql.execution.plan;
 
 import com.google.errorprone.annotations.Immutable;
 import io.confluent.ksql.GenericRow;
-import io.confluent.ksql.execution.builder.KsqlQueryBuilder;
 import io.confluent.ksql.execution.expression.tree.Expression;
 import java.util.Collections;
 import java.util.List;
 import java.util.Objects;
 import org.apache.kafka.connect.data.Struct;
 import org.apache.kafka.streams.kstream.KGroupedTable;
-import org.apache.kafka.streams.kstream.KTable;
 
 @Immutable
 public class TableGroupBy<K> implements ExecutionStep<KGroupedTable<Struct, GenericRow>> {
   private final ExecutionStepProperties properties;
-  private final ExecutionStep<KTable<K, GenericRow>> source;
+  private final ExecutionStep<KTableHolder<K>> source;
   private final Formats formats;
   private final List<Expression> groupByExpressions;
 
   public TableGroupBy(
       final ExecutionStepProperties properties,
-      final ExecutionStep<KTable<K, GenericRow>> source,
+      final ExecutionStep<KTableHolder<K>> source,
       final Formats formats,
       final List<Expression> groupByExpressions
   ) {
@@ -62,13 +60,13 @@ public class TableGroupBy<K> implements ExecutionStep<KGroupedTable<Struct, Gene
     return groupByExpressions;
   }
 
-  public ExecutionStep<KTable<K, GenericRow>> getSource() {
+  public ExecutionStep<KTableHolder<K>> getSource() {
     return source;
   }
 
   @Override
-  public KGroupedTable<Struct, GenericRow> build(final KsqlQueryBuilder builder) {
-    throw new UnsupportedOperationException();
+  public KGroupedTable<Struct, GenericRow> build(final PlanBuilder builder) {
+    return builder.visitTableGroupBy(this);
   }
 
   @Override

--- a/ksql-execution/src/main/java/io/confluent/ksql/execution/plan/TableMapValues.java
+++ b/ksql-execution/src/main/java/io/confluent/ksql/execution/plan/TableMapValues.java
@@ -15,20 +15,19 @@
 package io.confluent.ksql.execution.plan;
 
 import com.google.errorprone.annotations.Immutable;
-import io.confluent.ksql.execution.builder.KsqlQueryBuilder;
 import java.util.Collections;
 import java.util.List;
 import java.util.Objects;
 
 @Immutable
-public class TableMapValues<T> implements ExecutionStep<T> {
+public class TableMapValues<K> implements ExecutionStep<KTableHolder<K>> {
   private final ExecutionStepProperties properties;
-  private final ExecutionStep<T> source;
+  private final ExecutionStep<KTableHolder<K>> source;
   private final List<SelectExpression> selectExpressions;
 
   public TableMapValues(
       final ExecutionStepProperties properties,
-      final ExecutionStep<T> source,
+      final ExecutionStep<KTableHolder<K>> source,
       final List<SelectExpression> selectExpressions
   ) {
     this.properties = Objects.requireNonNull(properties, "properties");
@@ -50,13 +49,13 @@ public class TableMapValues<T> implements ExecutionStep<T> {
     return selectExpressions;
   }
 
-  public ExecutionStep<T> getSource() {
+  public ExecutionStep<KTableHolder<K>> getSource() {
     return source;
   }
 
   @Override
-  public T build(final KsqlQueryBuilder builder) {
-    throw new UnsupportedOperationException();
+  public KTableHolder<K> build(final PlanBuilder builder) {
+    return builder.visitTableMapValues(this);
   }
 
   @Override

--- a/ksql-execution/src/main/java/io/confluent/ksql/execution/plan/TableSink.java
+++ b/ksql-execution/src/main/java/io/confluent/ksql/execution/plan/TableSink.java
@@ -15,23 +15,20 @@
 package io.confluent.ksql.execution.plan;
 
 import com.google.errorprone.annotations.Immutable;
-import io.confluent.ksql.GenericRow;
-import io.confluent.ksql.execution.builder.KsqlQueryBuilder;
 import java.util.Collections;
 import java.util.List;
 import java.util.Objects;
-import org.apache.kafka.streams.kstream.KTable;
 
 @Immutable
-public class TableSink<K> implements ExecutionStep<KTable<K, GenericRow>> {
+public class TableSink<K> implements ExecutionStep<KTableHolder<K>> {
   private final ExecutionStepProperties properties;
-  private final ExecutionStep<KTable<K, GenericRow>> source;
+  private final ExecutionStep<KTableHolder<K>> source;
   private final Formats formats;
   private final String topicName;
 
   public TableSink(
       final ExecutionStepProperties properties,
-      final ExecutionStep<KTable<K, GenericRow>> source,
+      final ExecutionStep<KTableHolder<K>> source,
       final Formats formats,
       final String topicName
   ) {
@@ -59,9 +56,13 @@ public class TableSink<K> implements ExecutionStep<KTable<K, GenericRow>> {
     return formats;
   }
 
+  public ExecutionStep<KTableHolder<K>> getSource() {
+    return source;
+  }
+
   @Override
-  public KTable<K, GenericRow> build(final KsqlQueryBuilder builder) {
-    throw new UnsupportedOperationException();
+  public KTableHolder<K> build(final PlanBuilder builder) {
+    return builder.visitTableSink(this);
   }
 
   @Override

--- a/ksql-execution/src/main/java/io/confluent/ksql/execution/plan/TableTableJoin.java
+++ b/ksql-execution/src/main/java/io/confluent/ksql/execution/plan/TableTableJoin.java
@@ -16,24 +16,21 @@ package io.confluent.ksql.execution.plan;
 
 import com.google.common.collect.ImmutableList;
 import com.google.errorprone.annotations.Immutable;
-import io.confluent.ksql.GenericRow;
-import io.confluent.ksql.execution.builder.KsqlQueryBuilder;
 import java.util.List;
 import java.util.Objects;
-import org.apache.kafka.streams.kstream.KTable;
 
 @Immutable
-public class TableTableJoin<K> implements ExecutionStep<KTable<K, GenericRow>> {
+public class TableTableJoin<K> implements ExecutionStep<KTableHolder<K>> {
   private final ExecutionStepProperties properties;
   private final JoinType joinType;
-  private final ExecutionStep<KTable<K, GenericRow>> left;
-  private final ExecutionStep<KTable<K, GenericRow>> right;
+  private final ExecutionStep<KTableHolder<K>> left;
+  private final ExecutionStep<KTableHolder<K>> right;
 
   public TableTableJoin(
       final ExecutionStepProperties properties,
       final JoinType joinType,
-      final ExecutionStep<KTable<K, GenericRow>> left,
-      final ExecutionStep<KTable<K, GenericRow>> right) {
+      final ExecutionStep<KTableHolder<K>> left,
+      final ExecutionStep<KTableHolder<K>> right) {
     this.properties = Objects.requireNonNull(properties, "properties");
     this.joinType = Objects.requireNonNull(joinType, "joinType");
     this.left = Objects.requireNonNull(left, "left");
@@ -50,11 +47,11 @@ public class TableTableJoin<K> implements ExecutionStep<KTable<K, GenericRow>> {
     return ImmutableList.of(left, right);
   }
 
-  public ExecutionStep<KTable<K, GenericRow>> getLeft() {
+  public ExecutionStep<KTableHolder<K>> getLeft() {
     return left;
   }
 
-  public ExecutionStep<KTable<K, GenericRow>> getRight() {
+  public ExecutionStep<KTableHolder<K>> getRight() {
     return right;
   }
 
@@ -63,8 +60,8 @@ public class TableTableJoin<K> implements ExecutionStep<KTable<K, GenericRow>> {
   }
 
   @Override
-  public KTable<K, GenericRow> build(final KsqlQueryBuilder builder) {
-    throw new UnsupportedOperationException();
+  public KTableHolder<K> build(final PlanBuilder builder) {
+    return builder.visitTableTableJoin(this);
   }
 
   @Override

--- a/ksql-functional-tests/src/main/java/io/confluent/ksql/test/tools/TestExecutor.java
+++ b/ksql-functional-tests/src/main/java/io/confluent/ksql/test/tools/TestExecutor.java
@@ -16,6 +16,7 @@
 package io.confluent.ksql.test.tools;
 
 import static java.util.Objects.requireNonNull;
+import static org.hamcrest.Matchers.hasItems;
 import static org.hamcrest.Matchers.is;
 import static org.junit.Assert.assertThat;
 import static org.junit.matchers.JUnitMatchers.isThrowable;
@@ -45,6 +46,7 @@ import io.confluent.ksql.test.tools.stubs.StubKafkaTopicClient;
 import io.confluent.ksql.util.KsqlConfig;
 import io.confluent.ksql.util.KsqlException;
 import java.io.Closeable;
+import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
@@ -259,11 +261,15 @@ public class TestExecutor implements Closeable {
               + "THIS IS BAD!",
           actualTopology, is(expectedTopology));
 
-      expected.getSchemas().ifPresent(schemas -> assertThat("Schemas used by topology differ "
-              + "from those used by previous versions"
-              + " of KSQL - this likely means there is a non-backwards compatible change.\n"
-              + "THIS IS BAD!",
-          testCase.getGeneratedSchemas().get(0), is(schemas)));
+      expected.getSchemas().ifPresent(schemas -> {
+        final List<String> generated = Arrays.asList(
+            testCase.getGeneratedSchemas().get(0).split(System.lineSeparator()));
+        assertThat("Schemas used by topology differ "
+                + "from those used by previous versions"
+                + " of KSQL - this is likely to mean there is a non-backwards compatible change.\n"
+                + "THIS IS BAD!",
+            generated, hasItems(schemas.split(System.lineSeparator())));
+      });
     });
   }
 

--- a/ksql-functional-tests/src/test/java/io/confluent/ksql/test/tools/TestExecutorTest.java
+++ b/ksql-functional-tests/src/test/java/io/confluent/ksql/test/tools/TestExecutorTest.java
@@ -15,6 +15,7 @@
 
 package io.confluent.ksql.test.tools;
 
+import static org.hamcrest.Matchers.containsString;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
@@ -177,12 +178,10 @@ public class TestExecutorTest {
 
     // Then:
     expectedException.expect(AssertionError.class);
-    expectedException.expectMessage(
+    expectedException.expectMessage(containsString(
         "Schemas used by topology differ from those used by previous versions of KSQL "
             + "- this likely means there is a non-backwards compatible change.\n"
-            + "THIS IS BAD!\n"
-            + "Expected: is \"expected-schemas\"\n"
-            + "     but: was \"actual-schemas\"");
+            + "THIS IS BAD!\n"));
 
     // When:
     executor.buildAndExecuteQuery(testCase);

--- a/ksql-functional-tests/src/test/java/io/confluent/ksql/test/tools/TestExecutorTest.java
+++ b/ksql-functional-tests/src/test/java/io/confluent/ksql/test/tools/TestExecutorTest.java
@@ -180,7 +180,7 @@ public class TestExecutorTest {
     expectedException.expect(AssertionError.class);
     expectedException.expectMessage(containsString(
         "Schemas used by topology differ from those used by previous versions of KSQL "
-            + "- this likely means there is a non-backwards compatible change.\n"
+            + "- this is likely to mean there is a non-backwards compatible change.\n"
             + "THIS IS BAD!\n"));
 
     // When:

--- a/ksql-streams/src/main/java/io/confluent/ksql/execution/streams/KSPlanBuilder.java
+++ b/ksql-streams/src/main/java/io/confluent/ksql/execution/streams/KSPlanBuilder.java
@@ -1,0 +1,248 @@
+/*
+ * Copyright 2019 Confluent Inc.
+ *
+ * Licensed under the Confluent Community License (the "License"); you may not use
+ * this file except in compliance with the License.  You may obtain a copy of the
+ * License at
+ *
+ * http://www.confluent.io/confluent-community-license
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package io.confluent.ksql.execution.streams;
+
+import io.confluent.ksql.GenericRow;
+import io.confluent.ksql.execution.builder.KsqlQueryBuilder;
+import io.confluent.ksql.execution.plan.KStreamHolder;
+import io.confluent.ksql.execution.plan.KTableHolder;
+import io.confluent.ksql.execution.plan.PlanBuilder;
+import io.confluent.ksql.execution.plan.StreamAggregate;
+import io.confluent.ksql.execution.plan.StreamFilter;
+import io.confluent.ksql.execution.plan.StreamGroupBy;
+import io.confluent.ksql.execution.plan.StreamGroupByKey;
+import io.confluent.ksql.execution.plan.StreamMapValues;
+import io.confluent.ksql.execution.plan.StreamSelectKey;
+import io.confluent.ksql.execution.plan.StreamSink;
+import io.confluent.ksql.execution.plan.StreamSource;
+import io.confluent.ksql.execution.plan.StreamStreamJoin;
+import io.confluent.ksql.execution.plan.StreamTableJoin;
+import io.confluent.ksql.execution.plan.StreamToTable;
+import io.confluent.ksql.execution.plan.StreamWindowedAggregate;
+import io.confluent.ksql.execution.plan.TableAggregate;
+import io.confluent.ksql.execution.plan.TableFilter;
+import io.confluent.ksql.execution.plan.TableGroupBy;
+import io.confluent.ksql.execution.plan.TableMapValues;
+import io.confluent.ksql.execution.plan.TableSink;
+import io.confluent.ksql.execution.plan.TableTableJoin;
+import io.confluent.ksql.execution.sqlpredicate.SqlPredicate;
+import java.util.Objects;
+import org.apache.kafka.connect.data.Struct;
+import org.apache.kafka.streams.kstream.KGroupedStream;
+import org.apache.kafka.streams.kstream.KGroupedTable;
+import org.apache.kafka.streams.kstream.Windowed;
+
+/**
+ * An implementation of PlanBuilder that builds an execution plan into a
+ * Kafka Streams app
+ */
+public final class KSPlanBuilder implements PlanBuilder {
+  private final KsqlQueryBuilder queryBuilder;
+  private final SqlPredicateFactory sqlPredicateFactory;
+  private final AggregateParams.Factory aggregateParamFactory;
+  private final StreamsFactories streamsFactories;
+
+  public KSPlanBuilder(final KsqlQueryBuilder queryBuilder) {
+    this(
+        queryBuilder,
+        SqlPredicate::new,
+        AggregateParams::new,
+        StreamsFactories.create(queryBuilder.getKsqlConfig())
+    );
+  }
+
+  public KSPlanBuilder(
+      final KsqlQueryBuilder queryBuilder,
+      final SqlPredicateFactory sqlPredicateFactory,
+      final AggregateParams.Factory aggregateParamFactory,
+      final StreamsFactories streamsFactories) {
+    this.queryBuilder = Objects.requireNonNull(queryBuilder, "queryBuilder");
+    this.sqlPredicateFactory = Objects.requireNonNull(sqlPredicateFactory, "sqlPredicateFactory");
+    this.aggregateParamFactory =
+        Objects.requireNonNull(aggregateParamFactory, "aggregateParamsFactory");
+    this.streamsFactories = Objects.requireNonNull(streamsFactories, "streamsFactories");
+  }
+
+  public <K> KStreamHolder<K> visitStreamFilter(final StreamFilter<K> streamFilter) {
+    final KStreamHolder<K> source = streamFilter.getSource().build(this);
+    return StreamFilterBuilder.build(source, streamFilter, queryBuilder, sqlPredicateFactory);
+  }
+
+  @Override
+  public <K> KGroupedStream<Struct, GenericRow> visitStreamGroupBy(
+      final StreamGroupBy<K> streamGroupBy) {
+    final KStreamHolder<K> source = streamGroupBy.getSource().build(this);
+    return StreamGroupByBuilder.build(
+        source.getStream(),
+        streamGroupBy,
+        queryBuilder,
+        streamsFactories.getGroupedFactory()
+    );
+  }
+
+  @Override
+  public KGroupedStream<Struct, GenericRow> visitStreamGroupByKey(
+      final StreamGroupByKey streamGroupByKey) {
+    final KStreamHolder<Struct> source = streamGroupByKey.getSource().build(this);
+    return StreamGroupByBuilder.build(
+        source.getStream(),
+        streamGroupByKey,
+        queryBuilder,
+        streamsFactories.getGroupedFactory()
+    );
+  }
+
+  @Override
+  public KTableHolder<Struct> visitStreamAggregate(
+      final StreamAggregate streamAggregate) {
+    final KGroupedStream<Struct, GenericRow> source = streamAggregate.getSource().build(this);
+    return StreamAggregateBuilder.build(
+        source,
+        streamAggregate,
+        queryBuilder,
+        streamsFactories.getMaterializedFactory(),
+        aggregateParamFactory
+    );
+  }
+
+  @Override
+  public <K> KStreamHolder<K> visitStreamMapValues(
+      final StreamMapValues<K> streamMapValues) {
+    final KStreamHolder<K> source = streamMapValues.getSource().build(this);
+    return StreamMapValuesBuilder.build(source, streamMapValues, queryBuilder);
+  }
+
+  @Override
+  public KStreamHolder<Struct> visitStreamSelectKey(
+      final StreamSelectKey<?> streamSelectKey) {
+    final KStreamHolder<?> source = streamSelectKey.getSource().build(this);
+    return StreamSelectKeyBuilder.build(source, streamSelectKey, queryBuilder);
+  }
+
+  @Override
+  public <K> KStreamHolder<K> visitStreamSink(final StreamSink<K> streamSink) {
+    final KStreamHolder<K> source = streamSink.getSource().build(this);
+    StreamSinkBuilder.build(source, streamSink, queryBuilder);
+    return null;
+  }
+
+  @Override
+  public <K> KStreamHolder<K> visitStreamSource(final StreamSource<K> streamSource) {
+    return StreamSourceBuilder.build(queryBuilder, streamSource);
+  }
+
+  @Override
+  public <K> KStreamHolder<K> visitStreamStreamJoin(final StreamStreamJoin<K> join) {
+    final KStreamHolder<K> left = join.getLeft().build(this);
+    final KStreamHolder<K> right = join.getRight().build(this);
+    return StreamStreamJoinBuilder.build(
+        left,
+        right,
+        join,
+        queryBuilder,
+        streamsFactories.getJoinedFactory()
+    );
+  }
+
+  @Override
+  public <K> KStreamHolder<K> visitStreamTableJoin(final StreamTableJoin<K> join) {
+    final KTableHolder<K> right = join.getRight().build(this);
+    final KStreamHolder<K> left = join.getLeft().build(this);
+    return StreamTableJoinBuilder.build(
+        left,
+        right,
+        join,
+        queryBuilder,
+        streamsFactories.getJoinedFactory()
+    );
+  }
+
+  @Override
+  public <K> KTableHolder<K> visitStreamToTable(final StreamToTable<K> streamToTable) {
+    final KStreamHolder<K> source = streamToTable.getSource().build(this);
+    return StreamToTableBuilder.build(
+        source,
+        streamToTable,
+        queryBuilder,
+        streamsFactories.getMaterializedFactory()
+    );
+  }
+
+  @Override
+  public KTableHolder<Windowed<Struct>> visitStreamWindowedAggregate(
+      final StreamWindowedAggregate aggregate) {
+    final KGroupedStream<Struct, GenericRow> source = aggregate.getSource().build(this);
+    return StreamAggregateBuilder.build(
+        source,
+        aggregate,
+        queryBuilder,
+        streamsFactories.getMaterializedFactory(),
+        aggregateParamFactory
+    );
+  }
+
+  @Override
+  public KTableHolder<Struct> visitTableAggregate(final TableAggregate aggregate) {
+    final KGroupedTable<Struct, GenericRow> source = aggregate.getSource().build(this);
+    return TableAggregateBuilder.build(
+        source,
+        aggregate,
+        queryBuilder,
+        streamsFactories.getMaterializedFactory(),
+        aggregateParamFactory
+    );
+  }
+
+  @Override
+  public <K> KTableHolder<K> visitTableFilter(final TableFilter<K> tableFilter) {
+    final KTableHolder<K> source = tableFilter.getSource().build(this);
+    return TableFilterBuilder.build(source, tableFilter, queryBuilder, sqlPredicateFactory);
+  }
+
+  @Override
+  public <K> KGroupedTable<Struct, GenericRow> visitTableGroupBy(
+      final TableGroupBy<K> tableGroupBy) {
+    final KTableHolder<K> source = tableGroupBy.getSource().build(this);
+    return TableGroupByBuilder.build(
+        source,
+        tableGroupBy,
+        queryBuilder,
+        streamsFactories.getGroupedFactory()
+    );
+  }
+
+  @Override
+  public <K> KTableHolder<K> visitTableMapValues(
+      final TableMapValues<K> tableMapValues) {
+    final KTableHolder<K> source = tableMapValues.getSource().build(this);
+    return TableMapValuesBuilder.build(source, tableMapValues, queryBuilder);
+  }
+
+  @Override
+  public <K> KTableHolder<K> visitTableSink(final TableSink<K> tableSink) {
+    final KTableHolder<K> source = tableSink.getSource().build(this);
+    TableSinkBuilder.build(source, tableSink, queryBuilder);
+    return null;
+  }
+
+  @Override
+  public <K> KTableHolder<K> visitTableTableJoin(
+      final TableTableJoin<K> tableTableJoin) {
+    final KTableHolder<K> left = tableTableJoin.getLeft().build(this);
+    final KTableHolder<K> right = tableTableJoin.getRight().build(this);
+    return TableTableJoinBuilder.build(left, right, tableTableJoin);
+  }
+}

--- a/ksql-streams/src/main/java/io/confluent/ksql/execution/streams/SqlPredicateFactory.java
+++ b/ksql-streams/src/main/java/io/confluent/ksql/execution/streams/SqlPredicateFactory.java
@@ -22,7 +22,7 @@ import io.confluent.ksql.logging.processing.ProcessingLogger;
 import io.confluent.ksql.schema.ksql.LogicalSchema;
 import io.confluent.ksql.util.KsqlConfig;
 
-interface SqlPredicateFactory {
+public interface SqlPredicateFactory {
   SqlPredicate create(
       Expression filterExpression,
       LogicalSchema schema,

--- a/ksql-streams/src/main/java/io/confluent/ksql/execution/streams/StreamFilterBuilder.java
+++ b/ksql-streams/src/main/java/io/confluent/ksql/execution/streams/StreamFilterBuilder.java
@@ -15,28 +15,27 @@
 
 package io.confluent.ksql.execution.streams;
 
-import io.confluent.ksql.GenericRow;
 import io.confluent.ksql.execution.builder.KsqlQueryBuilder;
 import io.confluent.ksql.execution.context.QueryContext;
 import io.confluent.ksql.execution.context.QueryLoggerUtil;
+import io.confluent.ksql.execution.plan.KStreamHolder;
 import io.confluent.ksql.execution.plan.StreamFilter;
 import io.confluent.ksql.execution.sqlpredicate.SqlPredicate;
-import org.apache.kafka.streams.kstream.KStream;
 
 public final class StreamFilterBuilder {
   private StreamFilterBuilder() {
   }
 
-  public static <K> KStream<K, GenericRow> build(
-      final KStream<K, GenericRow> kstream,
-      final StreamFilter<KStream<K, GenericRow>> step,
+  public static <K> KStreamHolder<K> build(
+      final KStreamHolder<K> stream,
+      final StreamFilter<K> step,
       final KsqlQueryBuilder queryBuilder) {
-    return build(kstream, step, queryBuilder, SqlPredicate::new);
+    return build(stream, step, queryBuilder, SqlPredicate::new);
   }
 
-  static <K> KStream<K, GenericRow> build(
-      final KStream<K, GenericRow> kstream,
-      final StreamFilter<KStream<K, GenericRow>> step,
+  static <K> KStreamHolder<K> build(
+      final KStreamHolder<K> stream,
+      final StreamFilter<K> step,
       final KsqlQueryBuilder queryBuilder,
       final SqlPredicateFactory predicateFactory) {
     final QueryContext.Stacker contextStacker = QueryContext.Stacker.of(
@@ -52,6 +51,8 @@ public final class StreamFilterBuilder {
                 contextStacker.push("FILTER").getQueryContext())
         )
     );
-    return kstream.filter(predicate.getPredicate());
+    return stream.withStream(
+        stream.getStream().filter(predicate.getPredicate())
+    );
   }
 }

--- a/ksql-streams/src/main/java/io/confluent/ksql/execution/streams/StreamMapValuesBuilder.java
+++ b/ksql-streams/src/main/java/io/confluent/ksql/execution/streams/StreamMapValuesBuilder.java
@@ -15,20 +15,19 @@
 
 package io.confluent.ksql.execution.streams;
 
-import io.confluent.ksql.GenericRow;
 import io.confluent.ksql.execution.builder.KsqlQueryBuilder;
 import io.confluent.ksql.execution.context.QueryContext;
+import io.confluent.ksql.execution.plan.KStreamHolder;
 import io.confluent.ksql.execution.plan.StreamMapValues;
 import io.confluent.ksql.schema.ksql.LogicalSchema;
-import org.apache.kafka.streams.kstream.KStream;
 
 public final class StreamMapValuesBuilder {
   private StreamMapValuesBuilder() {
   }
 
-  public static <K> KStream<K, GenericRow> build(
-      final KStream<K, GenericRow> sourceKStream,
-      final StreamMapValues<KStream<K, GenericRow>> step,
+  public static <K> KStreamHolder<K> build(
+      final KStreamHolder<K> stream,
+      final StreamMapValues<K> step,
       final KsqlQueryBuilder queryBuilder) {
     final QueryContext queryContext = step.getProperties().getQueryContext();
     final LogicalSchema sourceSchema = step.getSource().getProperties().getSchema();
@@ -41,6 +40,8 @@ public final class StreamMapValuesBuilder {
             queryBuilder.getFunctionRegistry(),
             queryBuilder.getProcessingLogContext()
         );
-    return sourceKStream.mapValues(selection.getMapper());
+    return stream.withStream(
+        stream.getStream().mapValues(selection.getMapper())
+    );
   }
 }

--- a/ksql-streams/src/main/java/io/confluent/ksql/execution/streams/StreamSelectKeyBuilder.java
+++ b/ksql-streams/src/main/java/io/confluent/ksql/execution/streams/StreamSelectKeyBuilder.java
@@ -16,6 +16,8 @@
 package io.confluent.ksql.execution.streams;
 
 import io.confluent.ksql.GenericRow;
+import io.confluent.ksql.execution.builder.KsqlQueryBuilder;
+import io.confluent.ksql.execution.plan.KStreamHolder;
 import io.confluent.ksql.execution.plan.StreamSelectKey;
 import io.confluent.ksql.execution.util.StructKeyUtil;
 import io.confluent.ksql.schema.ksql.Column;
@@ -28,16 +30,18 @@ public final class StreamSelectKeyBuilder {
   private StreamSelectKeyBuilder() {
   }
 
-  public static KStream<Struct, GenericRow> build(
-      final KStream<?, GenericRow> kstream,
-      final StreamSelectKey<?> selectKey) {
+  public static KStreamHolder<Struct> build(
+      final KStreamHolder<?> stream,
+      final StreamSelectKey<?> selectKey,
+      final KsqlQueryBuilder queryBuilder) {
     final LogicalSchema sourceSchema = selectKey.getSources().get(0).getProperties().getSchema();
     final Column keyColumn = sourceSchema.findValueColumn(selectKey.getFieldName())
         .orElseThrow(IllegalArgumentException::new);
     final int keyIndexInValue = sourceSchema.valueColumnIndex(keyColumn.fullName())
         .orElseThrow(IllegalStateException::new);
     final boolean updateRowKey = selectKey.isUpdateRowKey();
-    return kstream
+    final KStream<?, GenericRow> kstream = stream.getStream();
+    final KStream<Struct, GenericRow> rekeyed = kstream
         .filter((key, value) ->
             value != null && extractColumn(sourceSchema, keyIndexInValue, value) != null
         ).selectKey((key, value) ->
@@ -51,6 +55,10 @@ public final class StreamSelectKeyBuilder {
           }
           return row;
         });
+    return new KStreamHolder<>(
+        rekeyed,
+        (fmt, schema, ctx) -> queryBuilder.buildKeySerde(fmt.getFormatInfo(), schema, ctx)
+    );
   }
 
   private static Object extractColumn(

--- a/ksql-streams/src/main/java/io/confluent/ksql/execution/streams/StreamToTableBuilder.java
+++ b/ksql-streams/src/main/java/io/confluent/ksql/execution/streams/StreamToTableBuilder.java
@@ -19,6 +19,8 @@ import io.confluent.ksql.GenericRow;
 import io.confluent.ksql.execution.builder.KsqlQueryBuilder;
 import io.confluent.ksql.execution.context.QueryContext;
 import io.confluent.ksql.execution.plan.ExecutionStep;
+import io.confluent.ksql.execution.plan.KStreamHolder;
+import io.confluent.ksql.execution.plan.KTableHolder;
 import io.confluent.ksql.execution.plan.StreamToTable;
 import io.confluent.ksql.schema.ksql.PhysicalSchema;
 import io.confluent.ksql.serde.KeyFormat;
@@ -27,7 +29,6 @@ import io.confluent.ksql.serde.ValueFormat;
 import java.util.Optional;
 import org.apache.kafka.common.serialization.Serde;
 import org.apache.kafka.common.utils.Bytes;
-import org.apache.kafka.streams.kstream.KStream;
 import org.apache.kafka.streams.kstream.KTable;
 import org.apache.kafka.streams.kstream.Materialized;
 import org.apache.kafka.streams.state.KeyValueStore;
@@ -36,13 +37,13 @@ public final class StreamToTableBuilder {
   private StreamToTableBuilder() {
   }
 
-  public static KTable<Object, GenericRow> build(
-      final KStream<Object, GenericRow> sourceStream,
-      final StreamToTable<KStream<Object, GenericRow>, KTable<Object, GenericRow>> streamToTable,
+  public static <K> KTableHolder<K> build(
+      final KStreamHolder<K> sourceStream,
+      final StreamToTable<K> streamToTable,
       final KsqlQueryBuilder queryBuilder,
       final MaterializedFactory materializedFactory) {
     final QueryContext queryContext = streamToTable.getProperties().getQueryContext();
-    final ExecutionStep<KStream<Object, GenericRow>> sourceStep = streamToTable.getSource();
+    final ExecutionStep<?> sourceStep = streamToTable.getSource();
     final PhysicalSchema physicalSchema = PhysicalSchema.from(
         sourceStep.getProperties().getSchema(),
         streamToTable.getFormats().getOptions()
@@ -54,19 +55,18 @@ public final class StreamToTableBuilder {
         queryContext
     );
     final KeyFormat keyFormat = streamToTable.getFormats().getKeyFormat();
-    final KeySerde<Object> keySerde = buildKeySerde(
+    final KeySerde<K> keySerde = sourceStream.getKeySerdeFactory().buildKeySerde(
         keyFormat,
-        queryBuilder,
         physicalSchema,
         queryContext
     );
-    final Materialized<Object, GenericRow, KeyValueStore<Bytes, byte[]>> materialized =
+    final Materialized<K, GenericRow, KeyValueStore<Bytes, byte[]>> materialized =
         materializedFactory.create(
             keySerde,
             valueSerde,
             StreamsUtil.buildOpName(queryContext)
         );
-    return  sourceStream
+    final KTable<K, GenericRow> table = sourceStream.getStream()
         // 1. mapValues to transform null records into Optional<GenericRow>.EMPTY. We eventually
         //    need to aggregate the KStream to produce the KTable. However the KStream aggregator
         //    filters out records with null keys or values. For tables, a null value for a key
@@ -83,28 +83,6 @@ public final class StreamToTableBuilder {
             () -> null,
             (k, value, oldValue) -> value.orElse(null),
             materialized);
-  }
-
-  @SuppressWarnings("unchecked")
-  private static KeySerde<Object> buildKeySerde(
-      final KeyFormat keyFormat,
-      final KsqlQueryBuilder queryBuilder,
-      final PhysicalSchema physicalSchema,
-      final QueryContext queryContext
-  ) {
-    if (keyFormat.isWindowed()) {
-      return (KeySerde) queryBuilder.buildKeySerde(
-          keyFormat.getFormatInfo(),
-          keyFormat.getWindowInfo().get(),
-          physicalSchema,
-          queryContext
-      );
-    } else {
-      return (KeySerde) queryBuilder.buildKeySerde(
-          keyFormat.getFormatInfo(),
-          physicalSchema,
-          queryContext
-      );
-    }
+    return new KTableHolder<>(table, sourceStream.getKeySerdeFactory());
   }
 }

--- a/ksql-streams/src/main/java/io/confluent/ksql/execution/streams/StreamsFactories.java
+++ b/ksql-streams/src/main/java/io/confluent/ksql/execution/streams/StreamsFactories.java
@@ -13,11 +13,8 @@
  * specific language governing permissions and limitations under the License.
  */
 
-package io.confluent.ksql.streams;
+package io.confluent.ksql.execution.streams;
 
-import io.confluent.ksql.execution.streams.GroupedFactory;
-import io.confluent.ksql.execution.streams.JoinedFactory;
-import io.confluent.ksql.execution.streams.MaterializedFactory;
 import io.confluent.ksql.util.KsqlConfig;
 import java.util.Objects;
 

--- a/ksql-streams/src/main/java/io/confluent/ksql/execution/streams/TableFilterBuilder.java
+++ b/ksql-streams/src/main/java/io/confluent/ksql/execution/streams/TableFilterBuilder.java
@@ -15,28 +15,27 @@
 
 package io.confluent.ksql.execution.streams;
 
-import io.confluent.ksql.GenericRow;
 import io.confluent.ksql.execution.builder.KsqlQueryBuilder;
 import io.confluent.ksql.execution.context.QueryContext;
 import io.confluent.ksql.execution.context.QueryLoggerUtil;
+import io.confluent.ksql.execution.plan.KTableHolder;
 import io.confluent.ksql.execution.plan.TableFilter;
 import io.confluent.ksql.execution.sqlpredicate.SqlPredicate;
-import org.apache.kafka.streams.kstream.KTable;
 
 public final class TableFilterBuilder {
   private TableFilterBuilder() {
   }
 
-  public static <K> KTable<K, GenericRow> build(
-      final KTable<K, GenericRow> ktable,
-      final TableFilter<KTable<K, GenericRow>> step,
+  public static <K> KTableHolder<K> build(
+      final KTableHolder<K> table,
+      final TableFilter<K> step,
       final KsqlQueryBuilder queryBuilder) {
-    return build(ktable, step, queryBuilder, SqlPredicate::new);
+    return build(table, step, queryBuilder, SqlPredicate::new);
   }
 
-  static <K> KTable<K, GenericRow> build(
-      final KTable<K, GenericRow> ktable,
-      final TableFilter<KTable<K, GenericRow>> step,
+  static <K> KTableHolder<K> build(
+      final KTableHolder<K> table,
+      final TableFilter<K> step,
       final KsqlQueryBuilder queryBuilder,
       final SqlPredicateFactory sqlPredicateFactory) {
     final QueryContext.Stacker contextStacker = QueryContext.Stacker.of(
@@ -52,6 +51,6 @@ public final class TableFilterBuilder {
                 contextStacker.push("FILTER").getQueryContext())
         )
     );
-    return ktable.filter(predicate.getPredicate());
+    return table.withTable(table.getTable().filter(predicate.getPredicate()));
   }
 }

--- a/ksql-streams/src/main/java/io/confluent/ksql/execution/streams/TableGroupByBuilder.java
+++ b/ksql-streams/src/main/java/io/confluent/ksql/execution/streams/TableGroupByBuilder.java
@@ -21,6 +21,7 @@ import io.confluent.ksql.execution.codegen.CodeGenRunner;
 import io.confluent.ksql.execution.codegen.ExpressionMetadata;
 import io.confluent.ksql.execution.context.QueryContext;
 import io.confluent.ksql.execution.plan.Formats;
+import io.confluent.ksql.execution.plan.KTableHolder;
 import io.confluent.ksql.execution.plan.TableGroupBy;
 import io.confluent.ksql.schema.ksql.LogicalSchema;
 import io.confluent.ksql.schema.ksql.PhysicalSchema;
@@ -32,7 +33,6 @@ import org.apache.kafka.connect.data.Struct;
 import org.apache.kafka.streams.KeyValue;
 import org.apache.kafka.streams.kstream.Grouped;
 import org.apache.kafka.streams.kstream.KGroupedTable;
-import org.apache.kafka.streams.kstream.KTable;
 import org.apache.kafka.streams.kstream.KeyValueMapper;
 
 public final class TableGroupByBuilder {
@@ -40,7 +40,7 @@ public final class TableGroupByBuilder {
   }
 
   public static <K> KGroupedTable<Struct, GenericRow> build(
-      final KTable<K, GenericRow> ktable,
+      final KTableHolder<K> table,
       final TableGroupBy<K> step,
       final KsqlQueryBuilder queryBuilder,
       final GroupedFactory groupedFactory
@@ -75,7 +75,7 @@ public final class TableGroupByBuilder {
         queryBuilder.getFunctionRegistry()
     );
     final GroupByMapper<K> mapper = new GroupByMapper<>(groupBy);
-    return ktable
+    return table.getTable()
         .filter((key, value) -> value != null)
         .groupBy(new TableKeyValueMapper<>(mapper), grouped);
   }

--- a/ksql-streams/src/main/java/io/confluent/ksql/execution/streams/TableMapValuesBuilder.java
+++ b/ksql-streams/src/main/java/io/confluent/ksql/execution/streams/TableMapValuesBuilder.java
@@ -15,20 +15,19 @@
 
 package io.confluent.ksql.execution.streams;
 
-import io.confluent.ksql.GenericRow;
 import io.confluent.ksql.execution.builder.KsqlQueryBuilder;
 import io.confluent.ksql.execution.context.QueryContext;
+import io.confluent.ksql.execution.plan.KTableHolder;
 import io.confluent.ksql.execution.plan.TableMapValues;
 import io.confluent.ksql.schema.ksql.LogicalSchema;
-import org.apache.kafka.streams.kstream.KTable;
 
 public final class TableMapValuesBuilder {
   private TableMapValuesBuilder() {
   }
 
-  public static <K> KTable<K, GenericRow> build(
-      final KTable<K, GenericRow> sourceKTable,
-      final TableMapValues<KTable<K, GenericRow>> step,
+  public static <K> KTableHolder<K> build(
+      final KTableHolder<K> table,
+      final TableMapValues<K> step,
       final KsqlQueryBuilder queryBuilder) {
     final QueryContext queryContext = step.getProperties().getQueryContext();
     final LogicalSchema sourceSchema = step.getSource().getProperties().getSchema();
@@ -41,6 +40,6 @@ public final class TableMapValuesBuilder {
             queryBuilder.getFunctionRegistry(),
             queryBuilder.getProcessingLogContext()
         );
-    return sourceKTable.mapValues(selection.getMapper());
+    return table.withTable(table.getTable().mapValues(selection.getMapper()));
   }
 }

--- a/ksql-streams/src/main/java/io/confluent/ksql/execution/streams/TableSinkBuilder.java
+++ b/ksql-streams/src/main/java/io/confluent/ksql/execution/streams/TableSinkBuilder.java
@@ -19,6 +19,7 @@ import io.confluent.ksql.GenericRow;
 import io.confluent.ksql.execution.builder.KsqlQueryBuilder;
 import io.confluent.ksql.execution.context.QueryContext;
 import io.confluent.ksql.execution.plan.Formats;
+import io.confluent.ksql.execution.plan.KTableHolder;
 import io.confluent.ksql.execution.plan.TableSink;
 import io.confluent.ksql.execution.util.SinkSchemaUtil;
 import io.confluent.ksql.schema.ksql.LogicalSchema;
@@ -28,7 +29,6 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Set;
 import org.apache.kafka.common.serialization.Serde;
-import org.apache.kafka.streams.kstream.KTable;
 import org.apache.kafka.streams.kstream.Produced;
 
 public final class TableSinkBuilder {
@@ -36,15 +36,14 @@ public final class TableSinkBuilder {
   }
 
   public static <K> void build(
-      final KTable<K, GenericRow> ktable,
+      final KTableHolder<K> table,
       final TableSink<K> tableSink,
-      final KeySerdeFactory<K> keySerdeFactory,
       final KsqlQueryBuilder queryBuilder) {
     final QueryContext queryContext = tableSink.getProperties().getQueryContext();
     final LogicalSchema schema = SinkSchemaUtil.sinkSchema(tableSink);
     final Formats formats = tableSink.getFormats();
     final PhysicalSchema physicalSchema = PhysicalSchema.from(schema, formats.getOptions());
-    final KeySerde<K> keySerde = keySerdeFactory.buildKeySerde(
+    final KeySerde<K> keySerde = table.getKeySerdeFactory().buildKeySerde(
         formats.getKeyFormat(),
         physicalSchema,
         queryContext
@@ -57,7 +56,7 @@ public final class TableSinkBuilder {
     final Set<Integer> rowkeyIndexes =
         SinkSchemaUtil.implicitAndKeyColumnIndexesInValueSchema(tableSink);
     final String kafkaTopicName = tableSink.getTopicName();
-    ktable.toStream()
+    table.getTable().toStream()
         .mapValues(row -> {
               if (row == null) {
                 return null;

--- a/ksql-streams/src/test/java/io/confluent/ksql/execution/streams/StreamFilterBuilderTest.java
+++ b/ksql-streams/src/test/java/io/confluent/ksql/execution/streams/StreamFilterBuilderTest.java
@@ -3,6 +3,7 @@ package io.confluent.ksql.execution.streams;
 import static org.hamcrest.Matchers.is;
 import static org.junit.Assert.assertThat;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
@@ -13,6 +14,9 @@ import io.confluent.ksql.execution.expression.tree.Expression;
 import io.confluent.ksql.execution.plan.DefaultExecutionStepProperties;
 import io.confluent.ksql.execution.plan.ExecutionStep;
 import io.confluent.ksql.execution.plan.ExecutionStepProperties;
+import io.confluent.ksql.execution.plan.KeySerdeFactory;
+import io.confluent.ksql.execution.plan.KStreamHolder;
+import io.confluent.ksql.execution.plan.PlanBuilder;
 import io.confluent.ksql.execution.plan.StreamFilter;
 import io.confluent.ksql.execution.sqlpredicate.SqlPredicate;
 import io.confluent.ksql.function.FunctionRegistry;
@@ -63,12 +67,16 @@ public class StreamFilterBuilderTest {
   private KStream<Struct, GenericRow> filteredKStream;
   @Mock
   private Expression filterExpression;
+  @Mock
+  private KeySerdeFactory<Struct> keySerdeFactory;
+  private KStreamHolder<Struct> sourceWithSerdeFactory;
 
   private final QueryContext queryContext = new QueryContext.Stacker(new QueryId("foo"))
       .push("bar")
       .getQueryContext();
 
-  private StreamFilter<KStream<Struct, GenericRow>> step;
+  private PlanBuilder planBuilder;
+  private StreamFilter<Struct> step;
 
   @Rule
   public final MockitoRule mockitoRule = MockitoJUnit.rule();
@@ -86,9 +94,18 @@ public class StreamFilterBuilderTest {
     when(sourceKStream.filter(any())).thenReturn(filteredKStream);
     when(predicateFactory.create(any(), any(), any(), any(), any())).thenReturn(sqlPredicate);
     when(sqlPredicate.getPredicate()).thenReturn(predicate);
+    sourceWithSerdeFactory =
+        new KStreamHolder<>(sourceKStream, keySerdeFactory);
+    when(sourceStep.build(any())).thenReturn(sourceWithSerdeFactory);
     final ExecutionStepProperties properties = new DefaultExecutionStepProperties(
         schema,
         queryContext
+    );
+    planBuilder = new KSPlanBuilder(
+        queryBuilder,
+        predicateFactory,
+        mock(AggregateParams.Factory.class),
+        mock(StreamsFactories.class)
     );
     step = new StreamFilter<>(properties, sourceStep, filterExpression);
   }
@@ -97,22 +114,18 @@ public class StreamFilterBuilderTest {
   @SuppressWarnings("unchecked")
   public void shouldFilterSourceStream() {
     // When:
-    final KStream result = StreamFilterBuilder.build(
-        sourceKStream,
-        step,
-        queryBuilder,
-        predicateFactory
-    );
+    final KStreamHolder<Struct> result = step.build(planBuilder);
 
     // Then:
-    assertThat(result, is(filteredKStream));
+    assertThat(result.getStream(), is(filteredKStream));
+    assertThat(result.getKeySerdeFactory(), is(keySerdeFactory));
     verify(sourceKStream).filter(predicate);
   }
 
   @Test
   public void shouldBuildSqlPredicateCorrectly() {
     // When:
-    StreamFilterBuilder.build(sourceKStream, step, queryBuilder, predicateFactory);
+    step.build(planBuilder);
 
     // Then:
     verify(predicateFactory).create(
@@ -127,7 +140,7 @@ public class StreamFilterBuilderTest {
   @Test
   public void shouldUseCorrectNameForProcessingLogger() {
     // When:
-    StreamFilterBuilder.build(sourceKStream, step, queryBuilder, predicateFactory);
+    step.build(planBuilder);
 
     // Then:
     verify(processingLoggerFactory).getLogger("foo.bar.FILTER");

--- a/ksql-streams/src/test/java/io/confluent/ksql/execution/streams/StreamSelectKeyBuilderTest.java
+++ b/ksql-streams/src/test/java/io/confluent/ksql/execution/streams/StreamSelectKeyBuilderTest.java
@@ -20,21 +20,30 @@ import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.is;
 import static org.junit.Assert.assertThat;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.verifyNoMoreInteractions;
 import static org.mockito.Mockito.when;
 
 import io.confluent.ksql.GenericRow;
+import io.confluent.ksql.execution.builder.KsqlQueryBuilder;
 import io.confluent.ksql.execution.context.QueryContext;
 import io.confluent.ksql.execution.plan.DefaultExecutionStepProperties;
 import io.confluent.ksql.execution.plan.ExecutionStep;
 import io.confluent.ksql.execution.plan.ExecutionStepProperties;
+import io.confluent.ksql.execution.plan.KStreamHolder;
+import io.confluent.ksql.execution.plan.KeySerdeFactory;
+import io.confluent.ksql.execution.plan.PlanBuilder;
 import io.confluent.ksql.execution.plan.StreamSelectKey;
 import io.confluent.ksql.name.ColumnName;
 import io.confluent.ksql.name.SourceName;
 import io.confluent.ksql.query.QueryId;
 import io.confluent.ksql.schema.ksql.LogicalSchema;
+import io.confluent.ksql.schema.ksql.PhysicalSchema;
 import io.confluent.ksql.schema.ksql.types.SqlTypes;
+import io.confluent.ksql.serde.Format;
+import io.confluent.ksql.serde.FormatInfo;
+import io.confluent.ksql.serde.KeyFormat;
+import io.confluent.ksql.serde.SerdeOption;
 import org.apache.kafka.connect.data.Struct;
 import org.apache.kafka.streams.kstream.KStream;
 import org.apache.kafka.streams.kstream.KeyValueMapper;
@@ -70,7 +79,9 @@ public class StreamSelectKeyBuilderTest {
   @Mock
   private KStream<Struct, GenericRow> updatedKeyKStream;
   @Mock
-  private ExecutionStep<KStream<Struct, GenericRow>> sourceStep;
+  private ExecutionStep<KStreamHolder<Struct>> sourceStep;
+  @Mock
+  private KsqlQueryBuilder queryBuilder;
   @Captor
   private ArgumentCaptor<Predicate<Struct, GenericRow>> predicateCaptor;
   @Captor
@@ -85,6 +96,7 @@ public class StreamSelectKeyBuilderTest {
       queryContext
   );
 
+  private PlanBuilder planBuilder;
   private StreamSelectKey selectKey;
 
   @Rule
@@ -97,6 +109,14 @@ public class StreamSelectKeyBuilderTest {
     when(kstream.filter(any())).thenReturn(filteredKStream);
     when(filteredKStream.selectKey(any(KeyValueMapper.class))).thenReturn(rekeyedKstream);
     when(rekeyedKstream.mapValues(any(ValueMapperWithKey.class))).thenReturn(updatedKeyKStream);
+    when(sourceStep.build(any())).thenReturn(
+        new KStreamHolder<>(kstream, mock(KeySerdeFactory.class)));
+    planBuilder = new KSPlanBuilder(
+        queryBuilder,
+        mock(SqlPredicateFactory.class),
+        mock(AggregateParams.Factory.class),
+        mock(StreamsFactories.class)
+    );
     givenUpdateRowkey();
   }
 
@@ -122,7 +142,7 @@ public class StreamSelectKeyBuilderTest {
   @SuppressWarnings("unchecked")
   public void shouldRekeyCorrectly() {
     // When:
-    final KStream result = StreamSelectKeyBuilder.build(kstream, selectKey);
+    final KStreamHolder<Struct> result = selectKey.build(planBuilder);
 
     // Then:
     final InOrder inOrder = Mockito.inOrder(kstream, filteredKStream, rekeyedKstream);
@@ -130,13 +150,31 @@ public class StreamSelectKeyBuilderTest {
     inOrder.verify(filteredKStream).selectKey(any());
     inOrder.verify(rekeyedKstream).mapValues(any(ValueMapperWithKey.class));
     inOrder.verifyNoMoreInteractions();
-    assertThat(result, is(updatedKeyKStream));
+    assertThat(result.getStream(), is(updatedKeyKStream));
+  }
+
+  @Test
+  @SuppressWarnings("unchecked")
+  public void shouldReturnCorrectSerdeFactory() {
+    // When:
+    final KStreamHolder<Struct> result = selectKey.build(planBuilder);
+
+    // Then:
+    result.getKeySerdeFactory().buildKeySerde(
+        KeyFormat.nonWindowed(FormatInfo.of(Format.JSON)),
+        PhysicalSchema.from(SCHEMA, SerdeOption.none()),
+        queryContext
+    );
+    verify(queryBuilder).buildKeySerde(
+        FormatInfo.of(Format.JSON),
+        PhysicalSchema.from(SCHEMA, SerdeOption.none()),
+        queryContext);
   }
 
   @Test
   public void shouldFilterOutNullValues() {
     // When:
-    StreamSelectKeyBuilder.build(kstream, selectKey);
+    selectKey.build(planBuilder);
 
     // Then:
     verify(kstream).filter(predicateCaptor.capture());
@@ -147,7 +185,7 @@ public class StreamSelectKeyBuilderTest {
   @Test
   public void shouldFilterOutNullKeyColumns() {
     // When:
-    StreamSelectKeyBuilder.build(kstream, selectKey);
+    selectKey.build(planBuilder);
 
     // Then:
     verify(kstream).filter(predicateCaptor.capture());
@@ -161,7 +199,7 @@ public class StreamSelectKeyBuilderTest {
   @Test
   public void shouldNotFilterOutNonNullKeyColumns() {
     // When:
-    StreamSelectKeyBuilder.build(kstream, selectKey);
+    selectKey.build(planBuilder);
 
     // Then:
     verify(kstream).filter(predicateCaptor.capture());
@@ -175,7 +213,7 @@ public class StreamSelectKeyBuilderTest {
   @Test
   public void shouldIgnoreNullNonKeyColumns() {
     // When:
-    StreamSelectKeyBuilder.build(kstream, selectKey);
+    selectKey.build(planBuilder);
 
     // Then:
     verify(kstream).filter(predicateCaptor.capture());
@@ -186,7 +224,7 @@ public class StreamSelectKeyBuilderTest {
   @Test
   public void shouldComputeCorrectKey() {
     // When:
-    StreamSelectKeyBuilder.build(kstream, selectKey);
+    selectKey.build(planBuilder);
 
     // Then:
     final KeyValueMapper<Struct, GenericRow, Struct> keyValueMapper = getKeyMapper();
@@ -199,7 +237,7 @@ public class StreamSelectKeyBuilderTest {
   @Test
   public void shouldUpdateRowkeyIfUpdateRowkeyTrue() {
     // When:
-    StreamSelectKeyBuilder.build(kstream, selectKey);
+    selectKey.build(planBuilder);
 
     // Then:
     verify(rekeyedKstream).mapValues(mapperCaptor.capture());
@@ -216,7 +254,7 @@ public class StreamSelectKeyBuilderTest {
     givenUpdateRowkeyFalse();
 
     // When:
-    StreamSelectKeyBuilder.build(kstream, selectKey);
+    selectKey.build(planBuilder);
 
     // Then:
     final ValueMapperWithKey<Struct, GenericRow, GenericRow> mapper = getMapper();

--- a/ksql-streams/src/test/java/io/confluent/ksql/execution/streams/StreamSinkBuilderTest.java
+++ b/ksql-streams/src/test/java/io/confluent/ksql/execution/streams/StreamSinkBuilderTest.java
@@ -33,6 +33,9 @@ import io.confluent.ksql.execution.context.QueryContext;
 import io.confluent.ksql.execution.plan.DefaultExecutionStepProperties;
 import io.confluent.ksql.execution.plan.ExecutionStep;
 import io.confluent.ksql.execution.plan.Formats;
+import io.confluent.ksql.execution.plan.KeySerdeFactory;
+import io.confluent.ksql.execution.plan.KStreamHolder;
+import io.confluent.ksql.execution.plan.PlanBuilder;
 import io.confluent.ksql.execution.plan.StreamSink;
 import io.confluent.ksql.name.ColumnName;
 import io.confluent.ksql.schema.ksql.LogicalSchema;
@@ -77,9 +80,9 @@ public class StreamSinkBuilderTest {
   @Mock
   private KeySerdeFactory<Struct> keySerdeFactory;
   @Mock
-  private KStream<Struct, GenericRow> stream;
+  private KStream<Struct, GenericRow> kStream;
   @Mock
-  private ExecutionStep<KStream<Struct, GenericRow>> source;
+  private ExecutionStep<KStreamHolder<Struct>> source;
   @Mock
   private KeySerde<Struct> keySerde;
   @Mock
@@ -89,6 +92,8 @@ public class StreamSinkBuilderTest {
   @Mock
   private QueryContext queryContext;
 
+  private PlanBuilder planBuilder;
+  private KStreamHolder<Struct> stream;
   private StreamSink<Struct> sink;
 
   @Before
@@ -96,15 +101,23 @@ public class StreamSinkBuilderTest {
   public void setup() {
     when(keySerdeFactory.buildKeySerde(any(), any(), any())).thenReturn(keySerde);
     when(queryBuilder.buildValueSerde(any(), any(), any())).thenReturn(valSerde);
-    when(stream.mapValues(any(ValueMapper.class))).thenReturn(stream);
+    when(kStream.mapValues(any(ValueMapper.class))).thenReturn(kStream);
     when(source.getProperties()).thenReturn(
         new DefaultExecutionStepProperties(SCHEMA, mock(QueryContext.class))
     );
+    stream = new KStreamHolder<>(kStream, keySerdeFactory);
+    when(source.build(any())).thenReturn(stream);
     sink = new StreamSink<>(
         new DefaultExecutionStepProperties(SCHEMA, queryContext),
         source,
         Formats.of(KEY_FORMAT, VALUE_FORMAT, SerdeOption.none()),
         TOPIC
+    );
+    planBuilder = new KSPlanBuilder(
+        queryBuilder,
+        mock(SqlPredicateFactory.class),
+        mock(AggregateParams.Factory.class),
+        mock(StreamsFactories.class)
     );
   }
 
@@ -112,28 +125,28 @@ public class StreamSinkBuilderTest {
   @SuppressWarnings("unchecked")
   public void shouldWriteOutStream() {
     // When:
-    StreamSinkBuilder.build(stream, sink, keySerdeFactory, queryBuilder);
+    sink.build(planBuilder);
 
     // Then:
-    final InOrder inOrder = Mockito.inOrder(stream);
-    inOrder.verify(stream).mapValues(any(ValueMapper.class));
-    inOrder.verify(stream).to(anyString(), any());
-    verifyNoMoreInteractions(stream);
+    final InOrder inOrder = Mockito.inOrder(kStream);
+    inOrder.verify(kStream).mapValues(any(ValueMapper.class));
+    inOrder.verify(kStream).to(anyString(), any());
+    verifyNoMoreInteractions(kStream);
   }
 
   @Test
   public void shouldWriteOutStreamToCorrectTopic() {
     // When:
-    StreamSinkBuilder.build(stream, sink, keySerdeFactory, queryBuilder);
+    sink.build(planBuilder);
 
     // Then:
-    verify(stream).to(eq(TOPIC), any());
+    verify(kStream).to(eq(TOPIC), any());
   }
 
   @Test
   public void shouldBuildKeySerdeCorrectly() {
     // When:
-    StreamSinkBuilder.build(stream, sink, keySerdeFactory, queryBuilder);
+    sink.build(planBuilder);
 
     // Then:
     verify(keySerdeFactory).buildKeySerde(KEY_FORMAT, PHYSICAL_SCHEMA, queryContext);
@@ -142,7 +155,7 @@ public class StreamSinkBuilderTest {
   @Test
   public void shouldBuildValueSerdeCorrectly() {
     // When:
-    StreamSinkBuilder.build(stream, sink, keySerdeFactory, queryBuilder);
+    sink.build(planBuilder);
 
     // Then:
     verify(queryBuilder).buildValueSerde(
@@ -155,19 +168,19 @@ public class StreamSinkBuilderTest {
   @Test
   public void shouldWriteOutStreamWithCorrectSerdes() {
     // When:
-    StreamSinkBuilder.build(stream, sink, keySerdeFactory, queryBuilder);
+    sink.build(planBuilder);
 
     // Then:
-    verify(stream).to(anyString(), eq(Produced.with(keySerde, valSerde)));
+    verify(kStream).to(anyString(), eq(Produced.with(keySerde, valSerde)));
   }
 
   @Test
   public void shouldRemoveKeyAndTimeFieldsFromValue() {
     // When:
-    StreamSinkBuilder.build(stream, sink, keySerdeFactory, queryBuilder);
+    sink.build(planBuilder);
 
     // Then:
-    verify(stream).mapValues(mapperCaptor.capture());
+    verify(kStream).mapValues(mapperCaptor.capture());
     final ValueMapper<GenericRow, GenericRow> mapper = mapperCaptor.getValue();
     assertThat(
         mapper.apply(new GenericRow(123, "456", 789, "101112")),
@@ -178,10 +191,10 @@ public class StreamSinkBuilderTest {
   @Test
   public void shouldIgnoreNullRowsWhenRemovingKeyAndTimeFieldsFromValue() {
     // When:
-    StreamSinkBuilder.build(stream, sink, keySerdeFactory, queryBuilder);
+    sink.build(planBuilder);
 
     // Then:
-    verify(stream).mapValues(mapperCaptor.capture());
+    verify(kStream).mapValues(mapperCaptor.capture());
     final ValueMapper<GenericRow, GenericRow> mapper = mapperCaptor.getValue();
     assertThat(mapper.apply(null), is(nullValue()));
   }

--- a/ksql-streams/src/test/java/io/confluent/ksql/execution/streams/StreamToTableBuilderTest.java
+++ b/ksql-streams/src/test/java/io/confluent/ksql/execution/streams/StreamToTableBuilderTest.java
@@ -22,6 +22,7 @@ import static org.junit.Assert.assertThat;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.ArgumentMatchers.same;
+import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
@@ -31,8 +32,11 @@ import io.confluent.ksql.execution.context.QueryContext;
 import io.confluent.ksql.execution.plan.DefaultExecutionStepProperties;
 import io.confluent.ksql.execution.plan.ExecutionStep;
 import io.confluent.ksql.execution.plan.Formats;
+import io.confluent.ksql.execution.plan.KeySerdeFactory;
+import io.confluent.ksql.execution.plan.KStreamHolder;
+import io.confluent.ksql.execution.plan.KTableHolder;
+import io.confluent.ksql.execution.plan.PlanBuilder;
 import io.confluent.ksql.execution.plan.StreamToTable;
-import io.confluent.ksql.model.WindowType;
 import io.confluent.ksql.name.ColumnName;
 import io.confluent.ksql.name.SourceName;
 import io.confluent.ksql.query.QueryId;
@@ -45,10 +49,9 @@ import io.confluent.ksql.serde.KeyFormat;
 import io.confluent.ksql.serde.KeySerde;
 import io.confluent.ksql.serde.SerdeOption;
 import io.confluent.ksql.serde.ValueFormat;
-import io.confluent.ksql.serde.WindowInfo;
-import java.time.Duration;
 import java.util.Optional;
 import org.apache.kafka.common.serialization.Serde;
+import org.apache.kafka.common.utils.Bytes;
 import org.apache.kafka.connect.data.Struct;
 import org.apache.kafka.streams.kstream.Aggregator;
 import org.apache.kafka.streams.kstream.Initializer;
@@ -57,7 +60,7 @@ import org.apache.kafka.streams.kstream.KStream;
 import org.apache.kafka.streams.kstream.KTable;
 import org.apache.kafka.streams.kstream.Materialized;
 import org.apache.kafka.streams.kstream.ValueMapper;
-import org.apache.kafka.streams.kstream.Windowed;
+import org.apache.kafka.streams.state.KeyValueStore;
 import org.hamcrest.MatcherAssert;
 import org.junit.Before;
 import org.junit.Rule;
@@ -78,40 +81,37 @@ public class StreamToTableBuilderTest {
       .withMetaAndKeyColsInValue();
 
   @Mock
-  private KStream kStream;
+  private KStream<Struct, GenericRow> kStream;
   @Mock
   private MaterializedFactory materializedFactory;
   @Mock
-  private Materialized materialized;
+  private Materialized<Struct, GenericRow, KeyValueStore<Bytes, byte[]>> materialized;
   @Mock
-  private KGroupedStream kGroupedStream;
+  private KGroupedStream<Struct, GenericRow> kGroupedStream;
   @Mock
-  private KTable kTable;
+  private KTable<Struct, GenericRow> kTable;
   @Mock
   private KsqlQueryBuilder ksqlQueryBuilder;
   @Mock
-  private KeySerde<Struct> keySerde;
+  private KeySerdeFactory<Struct> keySerdeFactory;
   @Mock
-  private KeySerde<Windowed<Struct>> windowedKeySerde;
+  private KeySerde<Struct> keySerde;
   @Mock
   private Serde<GenericRow> valueSerde;
   @Mock
-  private ExecutionStep<KStream<Object, GenericRow>> source;
+  private ExecutionStep<KStreamHolder<Struct>> source;
 
   private final QueryContext.Stacker stacker = new QueryContext.Stacker(new QueryId("qid"));
   private final QueryContext queryContext = stacker.push("s2t").getQueryContext();
   private final ValueFormat valueFormat = ValueFormat.of(FormatInfo.of(Format.JSON));
   private final KeyFormat keyFormat = KeyFormat.nonWindowed(FormatInfo.of(Format.KAFKA));
-  private final KeyFormat windowedKeyFormat = KeyFormat.windowed(
-      FormatInfo.of(Format.KAFKA),
-      WindowInfo.of(WindowType.TUMBLING, Optional.of(Duration.ofSeconds(10)))
-  );
   private final PhysicalSchema physicalSchema = PhysicalSchema.from(
       SCHEMA,
       SerdeOption.none()
   );
 
-  private StreamToTable<KStream<Object, GenericRow>, KTable<Object, GenericRow>> step;
+  private PlanBuilder planBuilder;
+  private StreamToTable<Struct> step;
 
   @Rule
   public final MockitoRule mockitoRule = MockitoJUnit.rule();
@@ -122,21 +122,24 @@ public class StreamToTableBuilderTest {
     when(source.getProperties()).thenReturn(
         new DefaultExecutionStepProperties(SCHEMA, stacker.push("source").getQueryContext())
     );
-    when(materializedFactory.create(any(), any(), any()))
+    when(materializedFactory.create(any(Serde.class), any(), any()))
         .thenReturn(materialized);
     when(kStream.mapValues(any(ValueMapper.class))).thenReturn(kStream);
     when(kStream.groupByKey()).thenReturn(kGroupedStream);
-    when(kGroupedStream.aggregate(any(), any(), any())).thenReturn(kTable);
+    when(kGroupedStream.aggregate(any(), any(), any(Materialized.class))).thenReturn(kTable);
     when(ksqlQueryBuilder.buildValueSerde(any(), any(), any())).thenReturn(valueSerde);
-  }
-
-  private void givenWindowed() {
-    step = new StreamToTable<>(
-        source,
-        Formats.of(windowedKeyFormat, valueFormat, SerdeOption.none()),
-        new DefaultExecutionStepProperties(SCHEMA, queryContext)
+    when(source.build(any())).thenReturn(
+        new KStreamHolder<>(kStream, keySerdeFactory));
+    planBuilder = new KSPlanBuilder(
+        ksqlQueryBuilder,
+        mock(SqlPredicateFactory.class),
+        mock(AggregateParams.Factory.class),
+        new StreamsFactories(
+            mock(GroupedFactory.class),
+            mock(JoinedFactory.class),
+            materializedFactory
+        )
     );
-    when(ksqlQueryBuilder.buildKeySerde(any(), any(), any(), any())).thenReturn(windowedKeySerde);
   }
 
   private void givenUnwindowed() {
@@ -145,7 +148,7 @@ public class StreamToTableBuilderTest {
         Formats.of(keyFormat, valueFormat, SerdeOption.none()),
         new DefaultExecutionStepProperties(SCHEMA, queryContext)
     );
-    when(ksqlQueryBuilder.buildKeySerde(any(), any(), any())).thenReturn(keySerde);
+    when(keySerdeFactory.buildKeySerde(any(), any(), any())).thenReturn(keySerde);
   }
 
   @Test
@@ -155,52 +158,29 @@ public class StreamToTableBuilderTest {
     givenUnwindowed();
 
     // When:
-    final KTable<Object, GenericRow> result = StreamToTableBuilder.build(
-        kStream,
-        step,
-        ksqlQueryBuilder,
-        materializedFactory
-    );
+    final KTableHolder<Struct> result = step.build(planBuilder);
 
     // Then:
     final InOrder inOrder = Mockito.inOrder(kStream);
     inOrder.verify(kStream).mapValues(any(ValueMapper.class));
     inOrder.verify(kStream).groupByKey();
     verify(kGroupedStream).aggregate(any(), any(), same(materialized));
-    assertThat(result, is(kTable));
+    assertThat(result.getTable(), is(kTable));
+    assertThat(result.getKeySerdeFactory(), is(keySerdeFactory));
   }
 
   @Test
   @SuppressWarnings("unchecked")
-  public void shouldBuildKeySerdeCorrectlyForWindowedKey() {
-    // Given:
-    givenWindowed();
-
-    // When:
-    StreamToTableBuilder.build(kStream, step, ksqlQueryBuilder, materializedFactory);
-
-    // Then:
-    verify(ksqlQueryBuilder).buildKeySerde(
-        windowedKeyFormat.getFormatInfo(),
-        windowedKeyFormat.getWindowInfo().get(),
-        physicalSchema,
-        queryContext
-    );
-    verify(materializedFactory).create(same(windowedKeySerde), any(), any());
-  }
-
-  @Test
-  @SuppressWarnings("unchecked")
-  public void shouldBuildKeySerdeCorrectlyForUnwindowedKey() {
+  public void shouldBuildKeySerdeCorrectly() {
     // Given:
     givenUnwindowed();
 
     // When:
-    StreamToTableBuilder.build(kStream, step, ksqlQueryBuilder, materializedFactory);
+    step.build(planBuilder);
 
     // Then:
-    verify(ksqlQueryBuilder).buildKeySerde(
-        keyFormat.getFormatInfo(),
+    verify(keySerdeFactory).buildKeySerde(
+        keyFormat,
         physicalSchema,
         queryContext
     );
@@ -214,7 +194,7 @@ public class StreamToTableBuilderTest {
     givenUnwindowed();
 
     // When:
-    StreamToTableBuilder.build(kStream, step, ksqlQueryBuilder, materializedFactory);
+    step.build(planBuilder);
 
     // Then:
     verify(ksqlQueryBuilder).buildValueSerde(
@@ -232,7 +212,7 @@ public class StreamToTableBuilderTest {
     givenUnwindowed();
 
     // When:
-    StreamToTableBuilder.build(kStream, step, ksqlQueryBuilder, materializedFactory);
+    step.build(planBuilder);
 
     // Then:
     verify(materializedFactory).create(any(), any(), eq(StreamsUtil.buildOpName(queryContext)));
@@ -245,7 +225,7 @@ public class StreamToTableBuilderTest {
     givenUnwindowed();
 
     // When:
-    StreamToTableBuilder.build(kStream, step, ksqlQueryBuilder, materializedFactory);
+    step.build(planBuilder);
 
     // Then:
     final ArgumentCaptor<ValueMapper> captor = ArgumentCaptor.forClass(ValueMapper.class);
@@ -262,7 +242,7 @@ public class StreamToTableBuilderTest {
     givenUnwindowed();
 
     // When:
-    StreamToTableBuilder.build(kStream, step, ksqlQueryBuilder, materializedFactory);
+    step.build(planBuilder);
 
     // Then:
     final ArgumentCaptor<Initializer> initCaptor = ArgumentCaptor.forClass(Initializer.class);

--- a/ksql-streams/src/test/java/io/confluent/ksql/execution/streams/TableSinkBuilderTest.java
+++ b/ksql-streams/src/test/java/io/confluent/ksql/execution/streams/TableSinkBuilderTest.java
@@ -33,6 +33,9 @@ import io.confluent.ksql.execution.context.QueryContext;
 import io.confluent.ksql.execution.plan.DefaultExecutionStepProperties;
 import io.confluent.ksql.execution.plan.ExecutionStep;
 import io.confluent.ksql.execution.plan.Formats;
+import io.confluent.ksql.execution.plan.KeySerdeFactory;
+import io.confluent.ksql.execution.plan.KTableHolder;
+import io.confluent.ksql.execution.plan.PlanBuilder;
 import io.confluent.ksql.execution.plan.TableSink;
 import io.confluent.ksql.name.ColumnName;
 import io.confluent.ksql.query.QueryId;
@@ -79,11 +82,11 @@ public class TableSinkBuilderTest {
   @Mock
   private KeySerdeFactory<Struct> keySerdeFactory;
   @Mock
-  private KTable<Struct, GenericRow>  table;
+  private KTable<Struct, GenericRow>  kTable;
   @Mock
-  private KStream<Struct, GenericRow>  stream;
+  private KStream<Struct, GenericRow> kStream;
   @Mock
-  private ExecutionStep<KTable<Struct, GenericRow>> source;
+  private ExecutionStep<KTableHolder<Struct>> source;
   @Mock
   private KeySerde<Struct>  keySerde;
   @Mock
@@ -94,6 +97,7 @@ public class TableSinkBuilderTest {
   private final QueryContext queryContext =
       new QueryContext.Stacker(new QueryId("qid")).push("sink").getQueryContext();
 
+  private PlanBuilder planBuilder;
   private TableSink<Struct> sink;
 
   @Before
@@ -101,16 +105,24 @@ public class TableSinkBuilderTest {
   public void setup() {
     when(keySerdeFactory.buildKeySerde(any(), any(), any())).thenReturn(keySerde);
     when(queryBuilder.buildValueSerde(any(), any(), any())).thenReturn(valSerde);
-    when(table.toStream()).thenReturn(stream);
-    when(stream.mapValues(any(ValueMapper.class))).thenReturn(stream);
+    when(kTable.toStream()).thenReturn(kStream);
+    when(kStream.mapValues(any(ValueMapper.class))).thenReturn(kStream);
     when(source.getProperties()).thenReturn(
         new DefaultExecutionStepProperties(SCHEMA, mock(QueryContext.class))
     );
+    when(source.build(any())).thenReturn(
+        new KTableHolder<>(kTable, keySerdeFactory));
     sink = new TableSink<>(
         new DefaultExecutionStepProperties(SCHEMA, queryContext),
         source,
         Formats.of(KEY_FORMAT, VALUE_FORMAT, SerdeOption.none()),
         TOPIC
+    );
+    planBuilder = new KSPlanBuilder(
+        queryBuilder,
+        mock(SqlPredicateFactory.class),
+        mock(AggregateParams.Factory.class),
+        mock(StreamsFactories.class)
     );
   }
 
@@ -118,29 +130,29 @@ public class TableSinkBuilderTest {
   @SuppressWarnings("unchecked")
   public void shouldWriteOutTable() {
     // When:
-    TableSinkBuilder.build(table, sink, keySerdeFactory, queryBuilder);
+    sink.build(planBuilder);
 
     // Then:
-    final InOrder inOrder = Mockito.inOrder(table, stream);
-    inOrder.verify(table).toStream();
-    inOrder.verify(stream).mapValues(any(ValueMapper.class));
-    inOrder.verify(stream).to(anyString(), any());
-    verifyNoMoreInteractions(stream);
+    final InOrder inOrder = Mockito.inOrder(kTable, kStream);
+    inOrder.verify(kTable).toStream();
+    inOrder.verify(kStream).mapValues(any(ValueMapper.class));
+    inOrder.verify(kStream).to(anyString(), any());
+    verifyNoMoreInteractions(kStream);
   }
 
   @Test
   public void shouldWriteOutTableToCorrectTopic() {
     // When:
-    TableSinkBuilder.build(table, sink, keySerdeFactory, queryBuilder);
+    sink.build(planBuilder);
 
     // Then:
-    verify(stream).to(eq(TOPIC), any());
+    verify(kStream).to(eq(TOPIC), any());
   }
 
   @Test
   public void shouldBuildKeySerdeCorrectly() {
     // When:
-    TableSinkBuilder.build(table, sink, keySerdeFactory, queryBuilder);
+    sink.build(planBuilder);
 
     // Then:
     verify(keySerdeFactory).buildKeySerde(KEY_FORMAT, PHYSICAL_SCHEMA, queryContext);
@@ -149,7 +161,7 @@ public class TableSinkBuilderTest {
   @Test
   public void shouldBuildValueSerdeCorrectly() {
     // When:
-    TableSinkBuilder.build(table, sink, keySerdeFactory, queryBuilder);
+    sink.build(planBuilder);
 
     // Then:
     verify(queryBuilder).buildValueSerde(
@@ -162,19 +174,19 @@ public class TableSinkBuilderTest {
   @Test
   public void shouldWriteOutTableWithCorrectSerdes() {
     // When:
-    TableSinkBuilder.build(table, sink, keySerdeFactory, queryBuilder);
+    sink.build(planBuilder);
 
     // Then:
-    verify(stream).to(anyString(), eq(Produced.with(keySerde, valSerde)));
+    verify(kStream).to(anyString(), eq(Produced.with(keySerde, valSerde)));
   }
 
   @Test
   public void shouldRemoveKeyAndTimeFieldsFromValue() {
     // When:
-    TableSinkBuilder.build(table, sink, keySerdeFactory, queryBuilder);
+    sink.build(planBuilder);
 
     // Then:
-    verify(stream).mapValues(mapperCaptor.capture());
+    verify(kStream).mapValues(mapperCaptor.capture());
     final ValueMapper<GenericRow, GenericRow> mapper = mapperCaptor.getValue();
     assertThat(
         mapper.apply(new GenericRow(123, "456", 789, "101112")),
@@ -185,10 +197,10 @@ public class TableSinkBuilderTest {
   @Test
   public void shouldIgnoreNullRowsWhenRemovingKeyAndTimeFieldsFromValue() {
     // When:
-    TableSinkBuilder.build(table, sink, keySerdeFactory, queryBuilder);
+    sink.build(planBuilder);
 
     // Then:
-    verify(stream).mapValues(mapperCaptor.capture());
+    verify(kStream).mapValues(mapperCaptor.capture());
     final ValueMapper<GenericRow, GenericRow> mapper = mapperCaptor.getValue();
     assertThat(mapper.apply(null), is(nullValue()));
   }


### PR DESCRIPTION
### Description 

This patch implements a visitor that iterates over the execution plan
and builds the final kstreams app. In addition to defining and
implementing the visitor, this required updating the type built by
many of the plan nodes to a wrapper class that includes both a kstream/
ktable, and a factory for building key serdes.

Now that we have this visior, we no longer need the code in SchemaKX
that makes calls into kafka streams, so that's all cleaned up.

Finally, we need to actually call the visitor to build the streams app.
For now that's happening in PhysicalPlanBuilder, but that will get moved
very soon.

### Testing done 
Adapted execution plan builder tests to incorporate the new visitor.

### Reviewer checklist
- [ ] Ensure docs are updated if necessary. (eg. if a user visible feature is being added or changed).
- [ ] Ensure relevant issues are linked (description should include text like "Fixes #<issue number>")

