### PR TITLE
refactor: switch `KudafAggregator` to take List of functions

### DIFF
--- a/ksql-engine/src/test/java/io/confluent/ksql/function/KudafUndoAggregatorTest.java
+++ b/ksql-engine/src/test/java/io/confluent/ksql/function/KudafUndoAggregatorTest.java
@@ -33,7 +33,7 @@ public class KudafUndoAggregatorTest {
   @Test
   public void shouldApplyUndoableAggregateFunctions() {
     final InternalFunctionRegistry functionRegistry = new InternalFunctionRegistry();
-    final Map<Integer, TableAggregationFunction> aggValToAggFunctionMap = new HashMap<>();
+    final Map<Integer, TableAggregationFunction<?, ?, ?>> aggValToAggFunctionMap = new HashMap<>();
     final KsqlAggregateFunction functionInfo = functionRegistry.getAggregate(
         "SUM", Schema.OPTIONAL_INT32_SCHEMA);
     assertThat(functionInfo, instanceOf(TableAggregationFunction.class));

--- a/ksql-execution/src/main/java/io/confluent/ksql/execution/function/UdafUtil.java
+++ b/ksql-execution/src/main/java/io/confluent/ksql/execution/function/UdafUtil.java
@@ -32,7 +32,7 @@ public final class UdafUtil {
   }
 
   @SuppressWarnings("deprecation") // Need to migrate away from Connect Schema use.
-  public static KsqlAggregateFunction resolveAggregateFunction(
+  public static KsqlAggregateFunction<?, ?, ?> resolveAggregateFunction(
       final FunctionRegistry functionRegistry,
       final FunctionCall functionCall,
       final LogicalSchema schema

--- a/ksql-execution/src/main/java/io/confluent/ksql/execution/function/udaf/KudafAggregator.java
+++ b/ksql-execution/src/main/java/io/confluent/ksql/execution/function/udaf/KudafAggregator.java
@@ -18,48 +18,46 @@ package io.confluent.ksql.execution.function.udaf;
 import static java.util.Objects.requireNonNull;
 
 import com.google.common.collect.ImmutableList;
-import com.google.common.collect.ImmutableList.Builder;
 import io.confluent.ksql.GenericRow;
 import io.confluent.ksql.function.KsqlAggregateFunction;
 import io.confluent.ksql.function.UdafAggregator;
 import java.util.ArrayList;
 import java.util.List;
-import java.util.Map;
-import java.util.stream.Collectors;
 import org.apache.kafka.connect.data.Struct;
 import org.apache.kafka.streams.kstream.Merger;
 import org.apache.kafka.streams.kstream.ValueMapper;
 
 public class KudafAggregator implements UdafAggregator {
 
-  private final int nonFuncColumnCount;
-  private final List<KsqlAggregateFunction> aggregateFunctions;
+  private final int initialUdafIndex;
+  private final List<KsqlAggregateFunction<?, ?, ?>> aggregateFunctions;
   private final int columnCount;
 
   public KudafAggregator(
-      final int nonFuncColumnCount,
-      final Map<Integer, KsqlAggregateFunction> aggValToAggFunctionMap
+      final int initialUdafIndex,
+      final List<KsqlAggregateFunction<?, ?, ?>> functions
   ) {
-    this.nonFuncColumnCount = nonFuncColumnCount;
-    this.aggregateFunctions = validateAggregates(
-        nonFuncColumnCount,
-        requireNonNull(aggValToAggFunctionMap, "aggValToAggFunctionMap")
-    );
-    this.columnCount = nonFuncColumnCount + aggregateFunctions.size();
+    this.initialUdafIndex = initialUdafIndex;
+    this.aggregateFunctions = ImmutableList.copyOf(requireNonNull(functions, "functions"));
+    this.columnCount = initialUdafIndex + aggregateFunctions.size();
+
+    if (aggregateFunctions.isEmpty()) {
+      throw new IllegalArgumentException("Aggregator needs aggregate functions");
+    }
   }
 
   @SuppressWarnings("unchecked")
   @Override
   public GenericRow apply(final Struct k, final GenericRow rowValue, final GenericRow aggRowValue) {
     // copy over group-by and aggregate parameter columns into the output row
-    for (int idx = 0; idx < nonFuncColumnCount; idx++) {
+    for (int idx = 0; idx < initialUdafIndex; idx++) {
       aggRowValue.getColumns().set(idx, rowValue.getColumns().get(idx));
     }
 
     // compute the aggregation and write it into the output row. Its assumed that
     // the columns written by this statement do not overlap with those written by
     // the above statement.
-    for (int idx = nonFuncColumnCount; idx < columnCount; idx++) {
+    for (int idx = initialUdafIndex; idx < columnCount; idx++) {
       final KsqlAggregateFunction function = aggregateFunctionForColumn(idx);
       final Object currentValue = rowValue.getColumns().get(function.getArgIndexInValue());
       final Object currentAggregate = aggRowValue.getColumns().get(idx);
@@ -76,11 +74,11 @@ public class KudafAggregator implements UdafAggregator {
     return aggRow -> {
       final List<Object> columns = new ArrayList<>(columnCount);
 
-      for (int idx = 0; idx < nonFuncColumnCount; idx++) {
+      for (int idx = 0; idx < initialUdafIndex; idx++) {
         columns.add(idx, aggRow.getColumns().get(idx));
       }
 
-      for (int idx = nonFuncColumnCount; idx < columnCount; idx++) {
+      for (int idx = initialUdafIndex; idx < columnCount; idx++) {
         final KsqlAggregateFunction function = aggregateFunctionForColumn(idx);
         final Object agg = aggRow.getColumns().get(idx);
         final Object reduced = function.getResultMapper().apply(agg);
@@ -98,7 +96,7 @@ public class KudafAggregator implements UdafAggregator {
     return (key, aggRowOne, aggRowTwo) -> {
       final List<Object> columns = new ArrayList<>(columnCount);
 
-      for (int idx = 0; idx < nonFuncColumnCount; idx++) {
+      for (int idx = 0; idx < initialUdafIndex; idx++) {
         if (aggRowOne.getColumns().get(idx) == null) {
           columns.add(idx, aggRowTwo.getColumns().get(idx));
         } else {
@@ -106,7 +104,7 @@ public class KudafAggregator implements UdafAggregator {
         }
       }
 
-      for (int idx = nonFuncColumnCount; idx < columnCount; idx++) {
+      for (int idx = initialUdafIndex; idx < columnCount; idx++) {
         final KsqlAggregateFunction function = aggregateFunctionForColumn(idx);
         final Object aggOne = aggRowOne.getColumns().get(idx);
         final Object aggTwo = aggRowTwo.getColumns().get(idx);
@@ -119,44 +117,6 @@ public class KudafAggregator implements UdafAggregator {
   }
 
   private KsqlAggregateFunction aggregateFunctionForColumn(final int columnIndex) {
-    return aggregateFunctions.get(columnIndex - nonFuncColumnCount);
-  }
-
-  private static List<KsqlAggregateFunction> validateAggregates(
-      final int nonFuncColumnCount,
-      final Map<Integer, KsqlAggregateFunction> aggValToAggFunctionMap
-  ) {
-    final List<Integer> indexes = aggValToAggFunctionMap.keySet().stream()
-        .sorted()
-        .collect(Collectors.toList());
-
-    if (indexes.isEmpty()) {
-      throw new IllegalArgumentException("Aggregator needs aggregate functions");
-    }
-
-    Integer last = nonFuncColumnCount - 1;
-    for (final Integer idx : indexes) {
-      if (idx != (last + 1)) {
-        throw new IllegalArgumentException("Non-sequential aggregate indexes");
-      }
-
-      last = idx;
-    }
-
-    final Builder<KsqlAggregateFunction> builder = ImmutableList.builder();
-
-    final int total = nonFuncColumnCount + aggValToAggFunctionMap.size();
-    for (int idx = nonFuncColumnCount; idx < total; idx++) {
-      builder.add(aggValToAggFunctionMap.get(idx));
-    }
-    return builder.build();
-  }
-
-  public int getNonFuncColumnCount() {
-    return nonFuncColumnCount;
-  }
-
-  public List<KsqlAggregateFunction> getAggValToAggFunctionMap() {
-    return aggregateFunctions;
+    return aggregateFunctions.get(columnIndex - initialUdafIndex);
   }
 }

--- a/ksql-execution/src/main/java/io/confluent/ksql/execution/function/udaf/KudafInitializer.java
+++ b/ksql-execution/src/main/java/io/confluent/ksql/execution/function/udaf/KudafInitializer.java
@@ -29,7 +29,7 @@ public class KudafInitializer implements Initializer<GenericRow> {
   private final List<Supplier> initialValueSuppliers;
   private final int nonAggValSize;
 
-  public KudafInitializer(final int nonAggValSize, final List<Supplier> initialValueSuppliers) {
+  public KudafInitializer(final int nonAggValSize, final List<Supplier<?>> initialValueSuppliers) {
     this.nonAggValSize = nonAggValSize;
     this.initialValueSuppliers = ImmutableList.copyOf(
         Objects.requireNonNull(initialValueSuppliers, "initialValueSuppliers")

--- a/ksql-execution/src/main/java/io/confluent/ksql/execution/function/udaf/KudafUndoAggregator.java
+++ b/ksql-execution/src/main/java/io/confluent/ksql/execution/function/udaf/KudafUndoAggregator.java
@@ -30,7 +30,7 @@ public class KudafUndoAggregator implements Aggregator<Struct, GenericRow, Gener
 
   public KudafUndoAggregator(
       final int nonFuncColumnCount,
-      final Map<Integer, TableAggregationFunction> aggValToAggFunctionMap
+      final Map<Integer, TableAggregationFunction<?, ?, ?>> aggValToAggFunctionMap
   ) {
     Objects.requireNonNull(aggValToAggFunctionMap);
     this.aggValToAggFunctionMap = ImmutableMap.copyOf(aggValToAggFunctionMap);

--- a/ksql-execution/src/main/java/io/confluent/ksql/execution/function/udaf/window/WindowSelectMapper.java
+++ b/ksql-execution/src/main/java/io/confluent/ksql/execution/function/udaf/window/WindowSelectMapper.java
@@ -42,7 +42,8 @@ public final class WindowSelectMapper
   private final Map<Integer, Type> windowSelects;
 
   public WindowSelectMapper(
-      final Map<Integer, KsqlAggregateFunction> aggFunctionsByIndex) {
+      final Map<Integer, KsqlAggregateFunction<?, ?, ?>> aggFunctionsByIndex
+  ) {
     this.windowSelects = aggFunctionsByIndex.entrySet().stream()
         .filter(e ->
             WINDOW_FUNCTION_NAMES.containsKey(e.getValue().getFunctionName().toUpperCase()))

--- a/ksql-streams/src/main/java/io/confluent/ksql/execution/streams/AggregateParams.java
+++ b/ksql-streams/src/main/java/io/confluent/ksql/execution/streams/AggregateParams.java
@@ -15,9 +15,11 @@
 
 package io.confluent.ksql.execution.streams;
 
-import com.google.common.collect.ImmutableMap;
+import static java.util.Objects.requireNonNull;
+
+import com.google.common.annotations.VisibleForTesting;
+import com.google.common.collect.ImmutableList;
 import io.confluent.ksql.execution.expression.tree.FunctionCall;
-import io.confluent.ksql.execution.function.TableAggregationFunction;
 import io.confluent.ksql.execution.function.UdafUtil;
 import io.confluent.ksql.execution.function.udaf.KudafAggregator;
 import io.confluent.ksql.execution.function.udaf.KudafInitializer;
@@ -27,16 +29,17 @@ import io.confluent.ksql.function.FunctionRegistry;
 import io.confluent.ksql.function.KsqlAggregateFunction;
 import io.confluent.ksql.schema.ksql.LogicalSchema;
 import java.util.HashMap;
-import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
 import java.util.function.Supplier;
 import java.util.stream.Collectors;
 
 public final class AggregateParams {
+
   private final KudafInitializer initializer;
   private final int initialUdafIndex;
-  private final Map<Integer, KsqlAggregateFunction> indexToFunction;
+  private final List<KsqlAggregateFunction<?, ?, ?>> functions;
+  private final KudafAggregatorFactory aggregatorFactory;
 
   AggregateParams(
       final LogicalSchema internalSchema,
@@ -44,22 +47,31 @@ public final class AggregateParams {
       final FunctionRegistry functionRegistry,
       final List<FunctionCall> functionList
   ) {
-    final List<Supplier> initialValueSuppliers = new LinkedList<>();
-    int udafIndexInAggSchema = initialUdafIndex;
-    final Map<Integer, KsqlAggregateFunction> indexToFunction = new HashMap<>();
-    for (final FunctionCall functionCall : functionList) {
-      final KsqlAggregateFunction aggregateFunction = UdafUtil.resolveAggregateFunction(
-          functionRegistry,
-          functionCall,
-          internalSchema
-      );
+    this(internalSchema, initialUdafIndex, functionRegistry, functionList, KudafAggregator::new);
+  }
 
-      indexToFunction.put(udafIndexInAggSchema++, aggregateFunction);
-      initialValueSuppliers.add(aggregateFunction.getInitialValueSupplier());
-    }
+  @VisibleForTesting
+  AggregateParams(
+      final LogicalSchema internalSchema,
+      final int initialUdafIndex,
+      final FunctionRegistry functionRegistry,
+      final List<FunctionCall> functionList,
+      final KudafAggregatorFactory aggregatorFactory
+  ) {
     this.initialUdafIndex = initialUdafIndex;
+    this.functions = ImmutableList.copyOf(functionList.stream()
+        .map(funcCall -> UdafUtil.resolveAggregateFunction(
+            functionRegistry,
+            funcCall,
+            internalSchema
+        )).collect(Collectors.toList()));
+
+    final List<Supplier<?>> initialValueSuppliers = functions.stream()
+        .map(KsqlAggregateFunction::getInitialValueSupplier)
+        .collect(Collectors.toList());
+
     this.initializer = new KudafInitializer(initialUdafIndex, initialValueSuppliers);
-    this.indexToFunction = ImmutableMap.copyOf(indexToFunction);
+    this.aggregatorFactory = requireNonNull(aggregatorFactory, "aggregatorFactory");
   }
 
   public KudafInitializer getInitializer() {
@@ -67,30 +79,42 @@ public final class AggregateParams {
   }
 
   public KudafAggregator getAggregator() {
-    return new KudafAggregator(initialUdafIndex, indexToFunction);
+    return aggregatorFactory.create(initialUdafIndex, functions);
   }
 
   public KudafUndoAggregator getUndoAggregator() {
-    final Map<Integer, TableAggregationFunction> indexToUndo =
-        indexToFunction.keySet()
-            .stream()
-            .collect(
-                Collectors.toMap(
-                    k -> k,
-                    k -> ((TableAggregationFunction) indexToFunction.get(k))));
-    return new KudafUndoAggregator(initialUdafIndex, indexToUndo);
+    return new KudafUndoAggregator(initialUdafIndex, toIndexedMap());
   }
 
   public WindowSelectMapper getWindowSelectMapper() {
-    return new WindowSelectMapper(indexToFunction);
+    return new WindowSelectMapper(toIndexedMap());
+  }
+
+  @SuppressWarnings("unchecked")
+  private <T extends KsqlAggregateFunction> Map<Integer, T> toIndexedMap() {
+    int index = initialUdafIndex;
+    final Map<Integer, T> byIndex = new HashMap<>();
+    for (final KsqlAggregateFunction aggregateFunction : functions) {
+      byIndex.put(index++, ((T) aggregateFunction));
+    }
+    return byIndex;
   }
 
   public interface Factory {
+
     AggregateParams create(
         LogicalSchema internalSchema,
         int initialUdafIndex,
         FunctionRegistry functionRegistry,
         List<FunctionCall> functionList
+    );
+  }
+
+  interface KudafAggregatorFactory {
+
+    KudafAggregator create(
+        int initialUdafIndex,
+        List<KsqlAggregateFunction<?, ?, ?>> functions
     );
   }
 }


### PR DESCRIPTION
### Description 

Extend the recent internal refactor of `KudafAggregator` (to use a list of functions, rather than a map), out to the place its built from.

### Testing done 

usual

### Reviewer checklist
- [ ] Ensure docs are updated if necessary. (eg. if a user visible feature is being added or changed).
- [ ] Ensure relevant issues are linked (description should include text like "Fixes #<issue number>")

