### PR TITLE
fix: typo in static query WHERE clause example

### DIFF
--- a/ksql-rest-app/src/main/java/io/confluent/ksql/rest/server/execution/StaticQueryExecutor.java
+++ b/ksql-rest-app/src/main/java/io/confluent/ksql/rest/server/execution/StaticQueryExecutor.java
@@ -634,7 +634,7 @@ public final class StaticQueryExecutor {
             + System.lineSeparator()
             + "    + a single window lower bound, e.g. `WHERE WINDOWSTART = z`, or"
             + System.lineSeparator()
-            + "    + a range, e.g. `WHERE a < WINDOWSTART AND WINDOWSTART < b"
+            + "    + a range, e.g. `WHERE a <= WINDOWSTART AND WINDOWSTART < b"
             + System.lineSeparator()
             + "WINDOWSTART currently supports operators: " + VALID_WINDOW_BOUNDS_TYPES_STRING
             + System.lineSeparator()


### PR DESCRIPTION
### Description 

Issuing a static query with `WINDOWSTART` bounds of the form `WHERE a < WINDOWSTART AND WINDOWSTART < b` returns in the error:
```
Server failed to execute statement
statement: 
reason: Unsupported WINDOWSTART bounds: [GREATER_THAN]
Static queries currently require a WHERE clause that:
 - limits the query to a single ROWKEY, e.g. `SELECT * FROM X WHERE ROWKEY=Y;`.
 - limits the time bounds of the windowed table. This can be: 
    + a single window lower bound, e.g. `WHERE WINDOWSTART = z`, or
    + a range, e.g. `WHERE a < WINDOWSTART AND WINDOWSTART < b
WINDOWSTART currently supports operators: [EQUAL, GREATER_THAN_OR_EQUAL, LESS_THAN]
WINDOWSTART currently comparison with epoch milliseconds or a datetime string in the form: yyyy-MM-dd'T'HH:mm:ss.SSS
```

This PR updates the error message to show what the form of the bounds actually needs to be.

### Testing done 

Non-functional change.

### Reviewer checklist
- [ ] Ensure docs are updated if necessary. (eg. if a user visible feature is being added or changed).
- [ ] Ensure relevant issues are linked (description should include text like "Fixes #<issue number>")

