### PR TITLE
fix: rename Delimiter.of(String) to Delimiter.parse(String)

### DIFF
--- a/ksql-common/src/main/java/io/confluent/ksql/properties/with/CommonCreateConfigs.java
+++ b/ksql-common/src/main/java/io/confluent/ksql/properties/with/CommonCreateConfigs.java
@@ -126,7 +126,7 @@ public final class CommonCreateConfigs {
             VALUE_DELIMITER_PROPERTY,
             ConfigDef.Type.STRING,
             null,
-            ConfigValidators.nullsAllowed(ConfigValidators.parses(Delimiter::of)),
+            ConfigValidators.nullsAllowed(ConfigValidators.parses(Delimiter::parse)),
             Importance.LOW,
             "The delimiter to use when VALUE_FORMAT='DELIMITED'. Supports single "
               + "character to be a delimiter, defaults to ','. For space and tab delimited values "

--- a/ksql-common/src/main/java/io/confluent/ksql/serde/Delimiter.java
+++ b/ksql-common/src/main/java/io/confluent/ksql/serde/Delimiter.java
@@ -35,7 +35,7 @@ public final class Delimiter {
 
   private final char delimiter;
 
-  public static Delimiter of(final char ch) {
+  public static Delimiter parse(final char ch) {
     return new Delimiter(ch);
   }
 
@@ -43,7 +43,7 @@ public final class Delimiter {
     this.delimiter = delimiter;
   }
 
-  public static Delimiter of(final String str) {
+  public static Delimiter parse(final String str) {
     if (str == null) {
       throw new NullPointerException();
     }

--- a/ksql-common/src/test/java/io/confluent/ksql/serde/FormatInfoTest.java
+++ b/ksql-common/src/test/java/io/confluent/ksql/serde/FormatInfoTest.java
@@ -45,8 +45,8 @@ public class FormatInfoTest {
   public void shouldImplementEquals() {
     new EqualsTester()
         .addEqualityGroup(
-            FormatInfo.of(Format.DELIMITED, Optional.empty(), Optional.of(Delimiter.of('x'))),
-            FormatInfo.of(Format.DELIMITED, Optional.empty(), Optional.of(Delimiter.of('x')))
+            FormatInfo.of(Format.DELIMITED, Optional.empty(), Optional.of(Delimiter.parse('x'))),
+            FormatInfo.of(Format.DELIMITED, Optional.empty(), Optional.of(Delimiter.parse('x')))
         )
         .addEqualityGroup(
             FormatInfo.of(Format.AVRO, Optional.of("something"), Optional.empty()),
@@ -79,7 +79,7 @@ public class FormatInfoTest {
   @Test
   public void shouldImplementToStringDelimited() {
     // Given:
-    final FormatInfo info = FormatInfo.of(DELIMITED, Optional.empty(), Optional.of(Delimiter.of("~")));
+    final FormatInfo info = FormatInfo.of(DELIMITED, Optional.empty(), Optional.of(Delimiter.parse("~")));
 
     // When:
     final String result = info.toString();
@@ -130,7 +130,7 @@ public class FormatInfoTest {
     expectedException.expectMessage("Delimeter only supported with DELIMITED format");
 
     // When:
-    FormatInfo.of(Format.AVRO, Optional.of("something"), Optional.of(Delimiter.of('x')));
+    FormatInfo.of(Format.AVRO, Optional.of("something"), Optional.of(Delimiter.parse('x')));
   }
 
   @Test
@@ -140,6 +140,6 @@ public class FormatInfoTest {
     expectedException.expectMessage("Delimeter only supported with DELIMITED format");
 
     // When:
-    FormatInfo.of(Format.JSON, Optional.empty(), Optional.of(Delimiter.of('x')));
+    FormatInfo.of(Format.JSON, Optional.empty(), Optional.of(Delimiter.parse('x')));
   }
 }

--- a/ksql-parser/src/main/java/io/confluent/ksql/parser/properties/with/CreateSourceAsProperties.java
+++ b/ksql-parser/src/main/java/io/confluent/ksql/parser/properties/with/CreateSourceAsProperties.java
@@ -98,7 +98,7 @@ public final class CreateSourceAsProperties {
 
   public Optional<Delimiter> getValueDelimiter() {
     final String val = props.getString(CommonCreateConfigs.VALUE_DELIMITER_PROPERTY);
-    return val == null ? Optional.empty() : Optional.of(Delimiter.of(val));
+    return val == null ? Optional.empty() : Optional.of(Delimiter.parse(val));
   }
 
   public CreateSourceAsProperties withTopic(

--- a/ksql-parser/src/main/java/io/confluent/ksql/parser/properties/with/CreateSourceProperties.java
+++ b/ksql-parser/src/main/java/io/confluent/ksql/parser/properties/with/CreateSourceProperties.java
@@ -133,7 +133,7 @@ public final class CreateSourceProperties {
 
   public Optional<Delimiter> getValueDelimiter() {
     final String val = props.getString(CommonCreateConfigs.VALUE_DELIMITER_PROPERTY);
-    return val == null ? Optional.empty() : Optional.of(Delimiter.of(val));
+    return val == null ? Optional.empty() : Optional.of(Delimiter.parse(val));
   }
 
   public CreateSourceProperties withSchemaId(final int id) {

--- a/ksql-serde/src/main/java/io/confluent/ksql/serde/delimited/KsqlDelimitedSerdeFactory.java
+++ b/ksql-serde/src/main/java/io/confluent/ksql/serde/delimited/KsqlDelimitedSerdeFactory.java
@@ -38,7 +38,7 @@ import org.apache.kafka.connect.data.Schema.Type;
 @Immutable
 public class KsqlDelimitedSerdeFactory implements KsqlSerdeFactory {
 
-  private static final Delimiter DEFAULT_DELIMITER = Delimiter.of(',');
+  private static final Delimiter DEFAULT_DELIMITER = Delimiter.parse(',');
 
   private final CSVFormat csvFormat;
 

--- a/ksql-serde/src/test/java/io/confluent/ksql/serde/delimited/KsqlDelimitedSerdeFactoryTest.java
+++ b/ksql-serde/src/test/java/io/confluent/ksql/serde/delimited/KsqlDelimitedSerdeFactoryTest.java
@@ -39,7 +39,7 @@ public class KsqlDelimitedSerdeFactoryTest {
 
   @Before
   public void setUp() {
-    factory = new KsqlDelimitedSerdeFactory(Optional.of(Delimiter.of(',')));
+    factory = new KsqlDelimitedSerdeFactory(Optional.of(Delimiter.parse(',')));
   }
 
   @Test


### PR DESCRIPTION
### Description 

This PR renames Delimiter.of(String) to Delimiter.parse(String)

### Testing done 

Run test suite

### Reviewer checklist
- [ ] Ensure docs are updated if necessary. (eg. if a user visible feature is being added or changed).
- [ ] Ensure relevant issues are linked (description should include text like "Fixes #<issue number>")

