### PR TITLE
feat: add KsqlUncaughtExceptionHandler and new KsqlRestConfig for enabling it

### DIFF
--- a/ksql-engine/src/main/java/io/confluent/ksql/physical/PhysicalPlanBuilder.java
+++ b/ksql-engine/src/main/java/io/confluent/ksql/physical/PhysicalPlanBuilder.java
@@ -53,6 +53,7 @@ import io.confluent.ksql.serde.KeyFormat;
 import io.confluent.ksql.services.ServiceContext;
 import io.confluent.ksql.structured.SchemaKStream;
 import io.confluent.ksql.structured.SchemaKTable;
+import io.confluent.ksql.util.KafkaStreamsUncaughtExceptionHandler;
 import io.confluent.ksql.util.KsqlConfig;
 import io.confluent.ksql.util.KsqlConstants;
 import io.confluent.ksql.util.KsqlException;
@@ -281,6 +282,7 @@ public class PhysicalPlanBuilder {
     );
 
     final KafkaStreams streams = kafkaStreamsBuilder.buildKafkaStreams(builder, streamsProperties);
+    streams.setUncaughtExceptionHandler(new KafkaStreamsUncaughtExceptionHandler());
 
     final Topology topology = builder.build();
 

--- a/ksql-engine/src/main/java/io/confluent/ksql/util/KafkaStreamsUncaughtExceptionHandler.java
+++ b/ksql-engine/src/main/java/io/confluent/ksql/util/KafkaStreamsUncaughtExceptionHandler.java
@@ -1,0 +1,28 @@
+/*
+ * Copyright 2019 Confluent Inc.
+ *
+ * Licensed under the Confluent Community License (the "License"); you may not use
+ * this file except in compliance with the License.  You may obtain a copy of the
+ * License at
+ *
+ * http://www.confluent.io/confluent-community-license
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package io.confluent.ksql.util;
+
+import io.confluent.ksql.engine.KsqlEngine;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class KafkaStreamsUncaughtExceptionHandler implements Thread.UncaughtExceptionHandler {
+  private static final Logger log = LoggerFactory.getLogger(KsqlEngine.class);
+
+  public void uncaughtException(final Thread t, final Throwable e) {
+    log.error("Unhandled exception caught in streams thread {}.", t.getName(), e);
+  }
+}

--- a/ksql-rest-app/src/main/java/io/confluent/ksql/rest/server/KsqlRestApplication.java
+++ b/ksql-rest-app/src/main/java/io/confluent/ksql/rest/server/KsqlRestApplication.java
@@ -58,6 +58,7 @@ import io.confluent.ksql.rest.server.state.ServerState;
 import io.confluent.ksql.rest.server.state.ServerStateDynamicBinding;
 import io.confluent.ksql.rest.util.ClusterTerminator;
 import io.confluent.ksql.rest.util.KsqlInternalTopicUtils;
+import io.confluent.ksql.rest.util.KsqlUncaughtExceptionHandler;
 import io.confluent.ksql.rest.util.ProcessingLogServerUtils;
 import io.confluent.ksql.rest.util.RocksDBConfigSetterHandler;
 import io.confluent.ksql.security.KsqlAuthorizationValidator;
@@ -107,6 +108,7 @@ import javax.websocket.server.ServerEndpointConfig.Configurator;
 import javax.ws.rs.core.Configurable;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.kafka.streams.StreamsConfig;
+import org.apache.log4j.LogManager;
 import org.eclipse.jetty.server.ServerConnector;
 import org.eclipse.jetty.websocket.jsr356.server.ServerContainer;
 import org.glassfish.hk2.utilities.Binder;
@@ -445,8 +447,14 @@ public final class KsqlRestApplication extends Application<KsqlRestConfig> imple
 
     final MutableFunctionRegistry functionRegistry = new InternalFunctionRegistry();
 
+    if (restConfig.getBoolean(KsqlRestConfig.KSQL_SERVER_ENABLE_UNCAUGHT_EXCEPTION_HANDLER)) {
+      Thread.setDefaultUncaughtExceptionHandler(
+          new KsqlUncaughtExceptionHandler(LogManager::shutdown));
+    }
+    
     final HybridQueryIdGenerator hybridQueryIdGenerator =
         new HybridQueryIdGenerator();
+
     final KsqlEngine ksqlEngine = new KsqlEngine(
         serviceContext,
         processingLogContext,

--- a/ksql-rest-app/src/main/java/io/confluent/ksql/rest/server/KsqlRestConfig.java
+++ b/ksql-rest-app/src/main/java/io/confluent/ksql/rest/server/KsqlRestConfig.java
@@ -64,6 +64,13 @@ public class KsqlRestConfig extends RestConfig {
       + "will not start serving requests until all preconditions are satisfied. Until that time, "
       + "requests will return a 503 error";
 
+  static final String KSQL_SERVER_ENABLE_UNCAUGHT_EXCEPTION_HANDLER =
+      KSQL_CONFIG_PREFIX + "server.uncaught.exception.handler.enable";
+
+  private static final String KSQL_SERVER_UNCAUGHT_EXCEPTION_HANDLER_DOC =
+      "Whether or not to set KsqlUncaughtExceptionHandler as the UncaughtExceptionHandler "
+          + "for all threads in the application (this can be overridden). Default is false.";
+
   private static final ConfigDef CONFIG_DEF;
 
   static {
@@ -97,6 +104,12 @@ public class KsqlRestConfig extends RestConfig {
         "",
        Importance.LOW,
        KSQL_SERVER_PRECONDITIONS_DOC
+    ).define(
+        KSQL_SERVER_ENABLE_UNCAUGHT_EXCEPTION_HANDLER,
+        ConfigDef.Type.BOOLEAN,
+        false,
+        Importance.LOW,
+        KSQL_SERVER_UNCAUGHT_EXCEPTION_HANDLER_DOC
     );
   }
 

--- a/ksql-rest-app/src/main/java/io/confluent/ksql/rest/server/KsqlRestConfig.java
+++ b/ksql-rest-app/src/main/java/io/confluent/ksql/rest/server/KsqlRestConfig.java
@@ -65,7 +65,7 @@ public class KsqlRestConfig extends RestConfig {
       + "requests will return a 503 error";
 
   static final String KSQL_SERVER_ENABLE_UNCAUGHT_EXCEPTION_HANDLER =
-      KSQL_CONFIG_PREFIX + "server.uncaught.exception.handler.enable";
+      KSQL_CONFIG_PREFIX + "server.exception.uncaught.handler.enable";
 
   private static final String KSQL_SERVER_UNCAUGHT_EXCEPTION_HANDLER_DOC =
       "Whether or not to set KsqlUncaughtExceptionHandler as the UncaughtExceptionHandler "

--- a/ksql-rest-app/src/main/java/io/confluent/ksql/rest/server/computation/CommandRunner.java
+++ b/ksql-rest-app/src/main/java/io/confluent/ksql/rest/server/computation/CommandRunner.java
@@ -98,7 +98,7 @@ public class CommandRunner implements Closeable {
    * {@link WakeupException} is thrown or the {@link #close()} method is called.
    */
   public void start() {
-    executor.submit(new Runner());
+    executor.execute(new Runner());
     executor.shutdown();
   }
 

--- a/ksql-rest-app/src/main/java/io/confluent/ksql/rest/util/KsqlUncaughtExceptionHandler.java
+++ b/ksql-rest-app/src/main/java/io/confluent/ksql/rest/util/KsqlUncaughtExceptionHandler.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright 2019 Confluent Inc.
+ *
+ * Licensed under the Confluent Community License (the "License"); you may not use
+ * this file except in compliance with the License.  You may obtain a copy of the
+ * License at
+ *
+ * http://www.confluent.io/confluent-community-license
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package io.confluent.ksql.rest.util;
+
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
+import io.confluent.ksql.rest.server.KsqlServerMain;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+
+public class KsqlUncaughtExceptionHandler implements Thread.UncaughtExceptionHandler {
+  private final Runnable flusher;
+
+  private static final Logger log = LoggerFactory.getLogger(KsqlServerMain.class);
+
+  public KsqlUncaughtExceptionHandler(final Runnable flusher) {
+    this.flusher = flusher;
+  }
+
+  @SuppressFBWarnings
+  public void uncaughtException(final Thread t, final Throwable e) {
+    log.error("Unhandled exception caught in thread {}.", t.getName(), e);
+    System.err.println(
+        "Unhandled exception caught in thread: " + t.getName() + ". Exception:" + e.getMessage());
+
+    flusher.run();
+
+    System.exit(-1);
+  }
+}

--- a/ksql-rest-app/src/test/java/io/confluent/ksql/rest/server/computation/CommandRunnerTest.java
+++ b/ksql-rest-app/src/test/java/io/confluent/ksql/rest/server/computation/CommandRunnerTest.java
@@ -196,7 +196,7 @@ public class CommandRunnerTest {
 
     // Then:
     final InOrder inOrder = inOrder(executor);
-    inOrder.verify(executor).submit(any(Runnable.class));
+    inOrder.verify(executor).execute(any(Runnable.class));
     inOrder.verify(executor).shutdown();
   }
 


### PR DESCRIPTION
### Description 
Currently, there's no way to bring back a thread that dies due to exception. This PR adds a UncaughtExceptionHandler to the CommandRunner thread which will take down the server when the thread dies due to an unknown exception. the executorService was also changed to execute() because submit() doesn't call UncaughtExceptionHandler.

https://stackoverflow.com/questions/1838923/why-is-uncaughtexceptionhandler-not-called-by-executorservice

Example: if the CommandRunner thread encounters problems when polling the commandTopic, the exception returned isn't being handled currently and the thread will die. The server is then left in a state where it can't process any more commands now that the thread is dead. The only way to restore functionality is to just restart the entire server. 

This PR also adds a new KafkaStreamsUncaughtExceptionHandler() for persistent queries since if there's an exception in them, the server can still function normally.
### Testing done 
Set the new config and threw a RuntimeException from CommandRunner thread and it closed the server after it was thrown.

When the config wasn't set and the exception thrown from CommandRunner, the thread died and the server continued running.
### Reviewer checklist
- [ ] Ensure docs are updated if necessary. (eg. if a user visible feature is being added or changed).
- [ ] Ensure relevant issues are linked (description should include text like "Fixes #<issue number>")

