### PR TITLE
feat: Ignore local scratch QTT file called scratch.json from git

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,3 +25,4 @@ logs/
 .settings
 .tern-port
 ui/
+/ksql-functional-tests/src/test/resources/**/scratch.json


### PR DESCRIPTION
### Description 

This PR adds '/ksql-functional-tests/src/test/resources/**/scratch.json' to .gitignore so you can maintain a local QTT query file for playing around that won't be added to git.

### Testing done 

Manually tested it worked.

### Reviewer checklist
- [ ] Ensure docs are updated if necessary. (eg. if a user visible feature is being added or changed).
- [ ] Ensure relevant issues are linked (description should include text like "Fixes #<issue number>")

