### PR TITLE
feat(static): fail on ROWTIME in projection

### DIFF
--- a/ksql-engine/src/main/java/io/confluent/ksql/analyzer/Analysis.java
+++ b/ksql-engine/src/main/java/io/confluent/ksql/analyzer/Analysis.java
@@ -40,7 +40,9 @@ import io.confluent.ksql.schema.ksql.LogicalSchema;
 import io.confluent.ksql.serde.SerdeOption;
 import io.confluent.ksql.util.SchemaUtil;
 import java.util.ArrayList;
+import java.util.Collection;
 import java.util.Collections;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
@@ -56,6 +58,7 @@ public class Analysis {
   private Optional<JoinInfo> joinInfo = Optional.empty();
   private Optional<Expression> whereExpression = Optional.empty();
   private final List<SelectExpression> selectExpressions = new ArrayList<>();
+  private final Set<ColumnRef> selectColumnRefs = new HashSet<>();
   private final List<Expression> groupByExpressions = new ArrayList<>();
   private Optional<WindowExpression> windowExpression = Optional.empty();
   private Optional<ColumnName> partitionBy = Optional.empty();
@@ -76,6 +79,10 @@ public class Analysis {
     selectExpressions.add(SelectExpression.of(alias, expression));
   }
 
+  void addSelectColumnRefs(final Collection<ColumnRef> columnRefs) {
+    selectColumnRefs.addAll(columnRefs);
+  }
+
   public Optional<Into> getInto() {
     return into;
   }
@@ -94,6 +101,10 @@ public class Analysis {
 
   public List<SelectExpression> getSelectExpressions() {
     return Collections.unmodifiableList(selectExpressions);
+  }
+
+  Set<ColumnRef> getSelectColumnRefs() {
+    return Collections.unmodifiableSet(selectColumnRefs);
   }
 
   public List<Expression> getGroupByExpressions() {
@@ -156,7 +167,7 @@ public class Analysis {
     return ImmutableList.copyOf(fromDataSources);
   }
 
-  public SourceSchemas getFromSourceSchemas() {
+  SourceSchemas getFromSourceSchemas() {
     final Map<SourceName, LogicalSchema> schemaBySource = fromDataSources.stream()
         .collect(Collectors.toMap(
             AliasedDataSource::getAlias,

--- a/ksql-engine/src/main/java/io/confluent/ksql/analyzer/Analyzer.java
+++ b/ksql-engine/src/main/java/io/confluent/ksql/analyzer/Analyzer.java
@@ -610,7 +610,7 @@ class Analyzer {
       final Set<ColumnRef> columnRefs = new HashSet<>();
       final TraversalExpressionVisitor<Void> visitor = new TraversalExpressionVisitor<Void>() {
         @Override
-        public Void visitQualifiedNameReference(
+        public Void visitColumnReference(
             final ColumnReferenceExp node,
             final Void context
         ) {

--- a/ksql-engine/src/main/java/io/confluent/ksql/analyzer/StaticQueryValidator.java
+++ b/ksql-engine/src/main/java/io/confluent/ksql/analyzer/StaticQueryValidator.java
@@ -17,7 +17,9 @@ package io.confluent.ksql.analyzer;
 
 import com.google.common.collect.ImmutableList;
 import io.confluent.ksql.parser.tree.ResultMaterialization;
+import io.confluent.ksql.schema.ksql.ColumnRef;
 import io.confluent.ksql.util.KsqlException;
+import io.confluent.ksql.util.SchemaUtil;
 import java.util.List;
 import java.util.Objects;
 import java.util.function.Predicate;
@@ -89,6 +91,12 @@ public class StaticQueryValidator implements QueryValidator {
       Rule.of(
           analysis -> !analysis.getLimitClause().isPresent(),
           "Static queries don't support LIMIT clauses."
+      ),
+      Rule.of(
+          analysis -> analysis.getSelectColumnRefs().stream()
+                  .map(ColumnRef::name)
+                  .noneMatch(n -> n.equals(SchemaUtil.ROWTIME_NAME)),
+          "Static queries don't support ROWTIME in the projection."
       )
   );
 

--- a/ksql-engine/src/main/java/io/confluent/ksql/analyzer/StaticQueryValidator.java
+++ b/ksql-engine/src/main/java/io/confluent/ksql/analyzer/StaticQueryValidator.java
@@ -96,7 +96,7 @@ public class StaticQueryValidator implements QueryValidator {
           analysis -> analysis.getSelectColumnRefs().stream()
                   .map(ColumnRef::name)
                   .noneMatch(n -> n.equals(SchemaUtil.ROWTIME_NAME)),
-          "Static queries don't support ROWTIME in the projection."
+          "Static queries don't support ROWTIME in select columns."
       )
   );
 

--- a/ksql-engine/src/test/java/io/confluent/ksql/analyzer/StaticQueryValidatorTest.java
+++ b/ksql-engine/src/test/java/io/confluent/ksql/analyzer/StaticQueryValidatorTest.java
@@ -19,12 +19,15 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
 import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableSet;
 import io.confluent.ksql.analyzer.Analysis.Into;
 import io.confluent.ksql.execution.expression.tree.Expression;
 import io.confluent.ksql.name.ColumnName;
 import io.confluent.ksql.parser.tree.ResultMaterialization;
 import io.confluent.ksql.parser.tree.WindowExpression;
+import io.confluent.ksql.schema.ksql.ColumnRef;
 import io.confluent.ksql.util.KsqlException;
+import io.confluent.ksql.util.SchemaUtil;
 import java.util.Optional;
 import java.util.OptionalInt;
 import org.junit.Before;
@@ -109,7 +112,7 @@ public class StaticQueryValidatorTest {
   }
 
   @Test
-  public void shouldThrowOnStaticQueryThatHasGroupBy() {
+  public void shouldThrowOnGroupBy() {
     // Given:
     when(analysis.getGroupByExpressions()).thenReturn(ImmutableList.of(AN_EXPRESSION));
 
@@ -122,7 +125,7 @@ public class StaticQueryValidatorTest {
   }
 
   @Test
-  public void shouldThrowOnStaticQueryThatHasPartitionBy() {
+  public void shouldThrowOnPartitionBy() {
     // Given:
     when(analysis.getPartitionBy()).thenReturn(Optional.of(ColumnName.of("Something")));
 
@@ -135,7 +138,7 @@ public class StaticQueryValidatorTest {
   }
 
   @Test
-  public void shouldThrowOnStaticQueryThatHasHavingClause() {
+  public void shouldThrowOnHavingClause() {
     // Given:
     when(analysis.getHavingExpression()).thenReturn(Optional.of(AN_EXPRESSION));
 
@@ -148,13 +151,27 @@ public class StaticQueryValidatorTest {
   }
 
   @Test
-  public void shouldThrowOnStaticQueryThatHasLimitClause() {
+  public void shouldThrowOnLimitClause() {
     // Given:
     when(analysis.getLimitClause()).thenReturn(OptionalInt.of(1));
 
     // Then:
     expectedException.expect(KsqlException.class);
     expectedException.expectMessage("Static queries don't support LIMIT clauses.");
+
+    // When:
+    validator.validate(analysis);
+  }
+
+  @Test
+  public void shouldThrowOnRowTimeInProjection() {
+    // Given:
+    when(analysis.getSelectColumnRefs())
+        .thenReturn(ImmutableSet.of(ColumnRef.of(SchemaUtil.ROWTIME_NAME)));
+
+    // Then:
+    expectedException.expect(KsqlException.class);
+    expectedException.expectMessage("Static queries don't support ROWTIME in the projection.");
 
     // When:
     validator.validate(analysis);

--- a/ksql-engine/src/test/java/io/confluent/ksql/analyzer/StaticQueryValidatorTest.java
+++ b/ksql-engine/src/test/java/io/confluent/ksql/analyzer/StaticQueryValidatorTest.java
@@ -171,7 +171,7 @@ public class StaticQueryValidatorTest {
 
     // Then:
     expectedException.expect(KsqlException.class);
-    expectedException.expectMessage("Static queries don't support ROWTIME in the projection.");
+    expectedException.expectMessage("Static queries don't support ROWTIME in select columns.");
 
     // When:
     validator.validate(analysis);

--- a/ksql-functional-tests/src/test/resources/rest-query-validation-tests/materialized-aggregate-static-queries.json
+++ b/ksql-functional-tests/src/test/resources/rest-query-validation-tests/materialized-aggregate-static-queries.json
@@ -244,7 +244,7 @@
       ],
       "expectedError": {
         "type": "io.confluent.ksql.rest.entity.KsqlStatementErrorMessage",
-        "message": "Static queries don't support ROWTIME in the projection.",
+        "message": "Static queries don't support ROWTIME in select columns.",
         "status": 400
       }
     },
@@ -257,7 +257,7 @@
       ],
       "expectedError": {
         "type": "io.confluent.ksql.rest.entity.KsqlStatementErrorMessage",
-        "message": "Static queries don't support ROWTIME in the projection.",
+        "message": "Static queries don't support ROWTIME in select columns.",
         "status": 400
       }
     },

--- a/ksql-functional-tests/src/test/resources/rest-query-validation-tests/materialized-aggregate-static-queries.json
+++ b/ksql-functional-tests/src/test/resources/rest-query-validation-tests/materialized-aggregate-static-queries.json
@@ -236,6 +236,32 @@
       ]
     },
     {
+      "name": "non-windowed projection WITH ROWTIME",
+      "statements": [
+        "CREATE STREAM INPUT (IGNORED INT) WITH (kafka_topic='test_topic', value_format='JSON');",
+        "CREATE TABLE AGGREGATE AS SELECT COUNT(1) AS COUNT FROM INPUT GROUP BY ROWKEY;",
+        "SELECT ROWTIME + 10, COUNT FROM AGGREGATE WHERE ROWKEY='10';"
+      ],
+      "expectedError": {
+        "type": "io.confluent.ksql.rest.entity.KsqlStatementErrorMessage",
+        "message": "Static queries don't support ROWTIME in the projection.",
+        "status": 400
+      }
+    },
+    {
+      "name": "windowed with projection with ROWTIME",
+      "statements": [
+        "CREATE STREAM INPUT (IGNORED INT) WITH (kafka_topic='test_topic', value_format='JSON');",
+        "CREATE TABLE AGGREGATE AS SELECT COUNT(1) AS COUNT FROM INPUT WINDOW TUMBLING(SIZE 1 SECOND) GROUP BY ROWKEY;",
+        "SELECT COUNT, ROWTIME + 10 FROM AGGREGATE WHERE ROWKEY='10' AND WindowStart=12000;"
+      ],
+      "expectedError": {
+        "type": "io.confluent.ksql.rest.entity.KsqlStatementErrorMessage",
+        "message": "Static queries don't support ROWTIME in the projection.",
+        "status": 400
+      }
+    },
+    {
       "name": "text datetime window bounds",
       "enabled": false,
       "statements": [


### PR DESCRIPTION
### Description 

At the moment static queries do not support returning ROWTIME as this information is not available in the response for KS IQ. So this PR explicitly handles cases where ROWTIME appears in the projects and gives a better error message than just `unknown column`.

In the future, we _may_ choose to support this by always including ROWTIME in the value of the changelog topic, but this is out of scope for this initial MVP.

### Testing done 

Suitable tests added.

### Reviewer checklist
- [ ] Ensure docs are updated if necessary. (eg. if a user visible feature is being added or changed).
- [ ] Ensure relevant issues are linked (description should include text like "Fixes #<issue number>")

