### PR TITLE
fix: address upstream change in KafkaAvroDeserializer (revert previous fix)

### DIFF
--- a/ksql-functional-tests/src/main/java/io/confluent/ksql/test/serde/avro/AvroSerdeSupplier.java
+++ b/ksql-functional-tests/src/main/java/io/confluent/ksql/test/serde/avro/AvroSerdeSupplier.java
@@ -30,6 +30,6 @@ public class AvroSerdeSupplier implements SerdeSupplier<Object> {
 
   @Override
   public Deserializer<Object> getDeserializer(final SchemaRegistryClient schemaRegistryClient) {
-    return new KafkaAvroDeserializer<>(schemaRegistryClient);
+    return new KafkaAvroDeserializer(schemaRegistryClient);
   }
 } 

--- a/ksql-functional-tests/src/main/java/io/confluent/ksql/test/serde/avro/ValueSpecAvroSerdeSupplier.java
+++ b/ksql-functional-tests/src/main/java/io/confluent/ksql/test/serde/avro/ValueSpecAvroSerdeSupplier.java
@@ -247,11 +247,11 @@ public class ValueSpecAvroSerdeSupplier implements SerdeSupplier<Object> {
   private static final class ValueSpecAvroDeserializer implements Deserializer<Object> {
 
     private final SchemaRegistryClient schemaRegistryClient;
-    private final KafkaAvroDeserializer<?> avroDeserializer;
+    private final KafkaAvroDeserializer avroDeserializer;
 
     ValueSpecAvroDeserializer(final SchemaRegistryClient schemaRegistryClient) {
       this.schemaRegistryClient = schemaRegistryClient;
-      this.avroDeserializer = new KafkaAvroDeserializer<>(schemaRegistryClient);
+      this.avroDeserializer = new KafkaAvroDeserializer(schemaRegistryClient);
     }
 
     @Override

--- a/ksql-rest-app/src/main/java/io/confluent/ksql/rest/server/resources/streaming/TopicStream.java
+++ b/ksql-rest-app/src/main/java/io/confluent/ksql/rest/server/resources/streaming/TopicStream.java
@@ -50,7 +50,7 @@ public final class TopicStream {
 
     private static final Logger log = LoggerFactory.getLogger(RecordFormatter.class);
 
-    private final KafkaAvroDeserializer<?> avroDeserializer;
+    private final KafkaAvroDeserializer avroDeserializer;
     private final String topicName;
     private final DateFormat dateFormat =
         SimpleDateFormat.getDateTimeInstance(3, 1, Locale.getDefault());
@@ -60,7 +60,7 @@ public final class TopicStream {
     public RecordFormatter(final SchemaRegistryClient schemaRegistryClient,
                            final String topicName) {
       this.topicName = Objects.requireNonNull(topicName, "topicName");
-      this.avroDeserializer = new KafkaAvroDeserializer<>(schemaRegistryClient);
+      this.avroDeserializer = new KafkaAvroDeserializer(schemaRegistryClient);
     }
 
     public List<String> format(final ConsumerRecords<String, Bytes> records) {
@@ -112,7 +112,7 @@ public final class TopicStream {
       public Optional<Formatter> maybeGetFormatter(
           final String topicName,
           final ConsumerRecord<String, Bytes> record,
-          final KafkaAvroDeserializer<?> avroDeserializer,
+          final KafkaAvroDeserializer avroDeserializer,
           final DateFormat dateFormat) {
         try {
           avroDeserializer.deserialize(topicName, record.value().get());
@@ -123,7 +123,7 @@ public final class TopicStream {
       }
 
       private Formatter createFormatter(final String topicName,
-                                        final KafkaAvroDeserializer<?> avroDeserializer,
+                                        final KafkaAvroDeserializer avroDeserializer,
                                         final DateFormat dateFormat) {
         return new Formatter() {
           @Override
@@ -149,7 +149,7 @@ public final class TopicStream {
       public Optional<Formatter> maybeGetFormatter(
           final String topicName,
           final ConsumerRecord<String, Bytes> record,
-          final KafkaAvroDeserializer<?> avroDeserializer,
+          final KafkaAvroDeserializer avroDeserializer,
           final DateFormat dateFormat) {
         try {
           final JsonNode jsonNode = JsonMapper.INSTANCE.mapper.readTree(record.value().toString());
@@ -198,7 +198,7 @@ public final class TopicStream {
       public Optional<Formatter> maybeGetFormatter(
           final String topicName,
           final ConsumerRecord<String, Bytes> record,
-          final KafkaAvroDeserializer<?> avroDeserializer,
+          final KafkaAvroDeserializer avroDeserializer,
           final DateFormat dateFormat) {
         // STRING always returns a formatter because its last in the enum list
         return Optional.of(createFormatter(dateFormat));
@@ -226,7 +226,7 @@ public final class TopicStream {
     Optional<Formatter> maybeGetFormatter(
         final String topicName,
         final ConsumerRecord<String, Bytes> record,
-        final KafkaAvroDeserializer<?> avroDeserializer,
+        final KafkaAvroDeserializer avroDeserializer,
         final DateFormat dateFormat) {
       return Optional.empty();
     }

--- a/ksql-serde/src/test/java/io/confluent/ksql/serde/avro/KsqlAvroSerializerTest.java
+++ b/ksql-serde/src/test/java/io/confluent/ksql/serde/avro/KsqlAvroSerializerTest.java
@@ -169,7 +169,7 @@ public class KsqlAvroSerializerTest {
         AbstractKafkaAvroSerDeConfig.SCHEMA_REGISTRY_URL_CONFIG, ""
     );
 
-    deserializer = new KafkaAvroDeserializer<>(schemaRegistryClient, configs);
+    deserializer = new KafkaAvroDeserializer(schemaRegistryClient, configs);
 
     orderStruct = new Struct(ORDER_SCHEMA)
         .put(ORDERTIME, 1511897796092L)


### PR DESCRIPTION
### Description 
https://github.com/confluentinc/ksql/pull/3372 was merged in order to unblock our build due to an upstream change in SR https://github.com/confluentinc/schema-registry/commit/c4b487923e0193db5083b17f2744838edd8b24e1

That SR change has been reverted in https://github.com/confluentinc/schema-registry/commit/ca4f640542316f0bf915ac3ada65ea508147a7e0
so we need to undo the previous fix in order for the build to work.

### Testing done 
mvn clean install 
### Reviewer checklist
- [ ] Ensure docs are updated if necessary. (eg. if a user visible feature is being added or changed).
- [ ] Ensure relevant issues are linked (description should include text like "Fixes #<issue number>")

