### PR TITLE
feat(static): allow windowed queries without bounds on rowtime

### DIFF
--- a/ksql-engine/src/main/java/io/confluent/ksql/materialization/ks/KsMaterializedWindowTable.java
+++ b/ksql-engine/src/main/java/io/confluent/ksql/materialization/ks/KsMaterializedWindowTable.java
@@ -53,8 +53,13 @@ class KsMaterializedWindowTable implements MaterializedWindowedTable {
       final ReadOnlyWindowStore<Struct, GenericRow> store = stateStore
           .store(QueryableStoreTypes.windowStore());
 
-      final Instant lower = windowStartBounds.lowerEndpoint();
-      final Instant upper = windowStartBounds.upperEndpoint();
+      final Instant lower = windowStartBounds.hasLowerBound()
+          ? windowStartBounds.lowerEndpoint()
+          : Instant.ofEpochMilli(Long.MIN_VALUE);
+
+      final Instant upper = windowStartBounds.hasUpperBound()
+          ? windowStartBounds.upperEndpoint()
+          : Instant.ofEpochMilli(Long.MAX_VALUE);
 
       try (WindowStoreIterator<GenericRow> it = store.fetch(key, lower, upper)) {
 

--- a/ksql-engine/src/test/java/io/confluent/ksql/materialization/KsqlMaterializationTest.java
+++ b/ksql-engine/src/test/java/io/confluent/ksql/materialization/KsqlMaterializationTest.java
@@ -325,7 +325,7 @@ public class KsqlMaterializationTest {
     when(aggregateTransform.apply(any())).thenReturn(TRANSFORMED);
 
     // When:
-    table.get(A_KEY, AN_INSTANT, AN_INSTANT);
+    table.get(A_KEY, WINDOW_START_BOUNDS);
 
     // Then:
     verify(havingPredicate).test(A_KEY, TRANSFORMED);

--- a/ksql-engine/src/test/java/io/confluent/ksql/materialization/ks/KsMaterializedSessionTableTest.java
+++ b/ksql-engine/src/test/java/io/confluent/ksql/materialization/ks/KsMaterializedSessionTableTest.java
@@ -18,6 +18,7 @@ package io.confluent.ksql.materialization.ks;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.contains;
 import static org.hamcrest.Matchers.empty;
+import static org.hamcrest.Matchers.hasSize;
 import static org.hamcrest.Matchers.instanceOf;
 import static org.hamcrest.Matchers.is;
 import static org.mockito.ArgumentMatchers.any;
@@ -296,8 +297,10 @@ public class KsMaterializedSessionTableTest {
   @Test
   public void shouldReturnMultipleSessions() {
     // Given:
+    givenSingleSession(LOWER_INSTANT.minusMillis(1), LOWER_INSTANT.plusSeconds(1));
     givenSingleSession(LOWER_INSTANT, LOWER_INSTANT);
     givenSingleSession(UPPER_INSTANT, UPPER_INSTANT);
+    givenSingleSession(UPPER_INSTANT.plusMillis(1), UPPER_INSTANT.plusSeconds(1));
 
     // When:
     final List<WindowedRow> result = table.get(A_KEY, WINDOW_START_BOUNDS);
@@ -307,6 +310,19 @@ public class KsMaterializedSessionTableTest {
         WindowedRow.of(SCHEMA, A_KEY, Window.of(LOWER_INSTANT, Optional.of(LOWER_INSTANT)), A_VALUE),
         WindowedRow.of(SCHEMA, A_KEY, Window.of(UPPER_INSTANT, Optional.of(UPPER_INSTANT)), A_VALUE)
     ));
+  }
+
+  @Test
+  public void shouldReturnAllSessionsForRangeall() {
+    // Given:
+    givenSingleSession(Instant.now().minusSeconds(1000), Instant.now().plusSeconds(1000));
+    givenSingleSession(Instant.now().minusSeconds(1000), Instant.now().plusSeconds(1000));
+
+    // When:
+    final List<WindowedRow> result = table.get(A_KEY, Range.all());
+
+    // Then:
+    assertThat(result, hasSize(2));
   }
 
   private void givenSingleSession(

--- a/ksql-engine/src/test/java/io/confluent/ksql/materialization/ks/KsMaterializedWindowTableTest.java
+++ b/ksql-engine/src/test/java/io/confluent/ksql/materialization/ks/KsMaterializedWindowTableTest.java
@@ -282,4 +282,17 @@ public class KsMaterializedWindowTableTest {
         )
     ));
   }
+
+  @Test
+  public void shouldSupportRangeAll() {
+    // When:
+    table.get(A_KEY, Range.all());
+
+    // Then:
+    verify(tableStore).fetch(
+        A_KEY,
+        Instant.ofEpochMilli(Long.MIN_VALUE),
+        Instant.ofEpochMilli(Long.MAX_VALUE)
+    );
+  }
 }

--- a/ksql-functional-tests/src/test/resources/rest-query-validation-tests/materialized-aggregate-static-queries.json
+++ b/ksql-functional-tests/src/test/resources/rest-query-validation-tests/materialized-aggregate-static-queries.json
@@ -150,8 +150,10 @@
       "statements": [
         "CREATE STREAM INPUT (IGNORED INT) WITH (kafka_topic='test_topic', value_format='JSON');",
         "CREATE TABLE AGGREGATE AS SELECT COUNT(1) AS COUNT FROM INPUT WINDOW TUMBLING(SIZE 1 SECOND) GROUP BY ROWKEY;",
-        "SELECT * FROM AGGREGATE WHERE 11111 <= WindowStart AND WindowStart < 14144 AND ROWKEY='10';",
-        "SELECT * FROM AGGREGATE WHERE WindowStart >= 17000 AND 11234756356 > WindowStart AND ROWKEY='10';"
+        "SELECT * FROM AGGREGATE WHERE 100 <= WindowStart AND WindowStart < 200000 AND ROWKEY='10';",
+        "SELECT * FROM AGGREGATE WHERE 12000 <= WindowStart AND WindowStart < 14000 AND ROWKEY='10';",
+        "SELECT * FROM AGGREGATE WHERE 12000 < WindowStart AND WindowStart <= 14000 AND ROWKEY='10';",
+        "SELECT * FROM AGGREGATE WHERE WindowStart > 17000 AND 11234756356 > WindowStart AND ROWKEY='10';"
       ],
       "inputs": [
         {"topic": "test_topic", "timestamp": 12001, "key": "11", "value": {}},
@@ -168,6 +170,21 @@
           "schema": "`ROWKEY` STRING KEY, `WINDOWSTART` BIGINT KEY, `COUNT` BIGINT",
           "rows": [
             ["10", 12000, 2],
+            ["10", 14000, 1],
+            ["10", 15000, 1]
+          ]
+        },
+        {
+          "@type": "rows",
+          "schema": "`ROWKEY` STRING KEY, `WINDOWSTART` BIGINT KEY, `COUNT` BIGINT",
+          "rows": [
+            ["10", 12000, 2]
+          ]
+        },
+        {
+          "@type": "rows",
+          "schema": "`ROWKEY` STRING KEY, `WINDOWSTART` BIGINT KEY, `COUNT` BIGINT",
+          "rows": [
             ["10", 14000, 1]
           ]
         },
@@ -179,7 +196,8 @@
       "statements": [
         "CREATE STREAM INPUT (IGNORED INT) WITH (kafka_topic='test_topic', value_format='JSON');",
         "CREATE TABLE AGGREGATE AS SELECT COUNT(1) AS COUNT FROM INPUT WINDOW HOPPING(SIZE 5 SECOND, ADVANCE BY 1 SECONDS) GROUP BY ROWKEY;",
-        "SELECT * FROM AGGREGATE WHERE ROWKEY='10' AND 6001 <= WindowStart AND WindowStart < 12000;",
+        "SELECT * FROM AGGREGATE WHERE ROWKEY='10' AND 7000 <= WindowStart AND WindowStart < 11000;",
+        "SELECT * FROM AGGREGATE WHERE ROWKEY='10' AND 7000 < WindowStart AND WindowStart <= 11000;",
         "SELECT * FROM AGGREGATE WHERE ROWKEY='10' AND 13001 <= WindowStart AND WindowStart < 11234756356;"
       ],
       "inputs": [
@@ -196,6 +214,14 @@
             ["10", 7000, 1],
             ["10", 8000, 1],
             ["10", 9000, 2],
+            ["10", 10000, 2]
+          ]
+        },
+        {
+          "@type": "rows",
+          "rows": [
+            ["10", 8000, 1],
+            ["10", 9000, 2],
             ["10", 10000, 2],
             ["10", 11000, 1]
           ]
@@ -207,15 +233,16 @@
       "name": "session windowed single key lookup with window start range",
       "statements": [
         "CREATE STREAM INPUT (IGNORED INT) WITH (kafka_topic='test_topic', value_format='JSON');",
-        "CREATE TABLE AGGREGATE AS SELECT COUNT(1) AS COUNT FROM INPUT WINDOW SESSION(10 SECOND) GROUP BY ROWKEY;",
+        "CREATE TABLE AGGREGATE AS SELECT COUNT(1) AS COUNT FROM INPUT WINDOW SESSION(5 SECOND) GROUP BY ROWKEY;",
+        "SELECT * FROM AGGREGATE WHERE ROWKEY='10' AND 10 <= WindowStart AND WindowStart < 200000;",
         "SELECT * FROM AGGREGATE WHERE ROWKEY='10' AND 8001 <= WindowStart AND WindowStart < 19444;",
-        "SELECT * FROM AGGREGATE WHERE ROWKEY='10' AND 8001 <= WindowStart AND WindowStart < 11234756356;"
+        "SELECT * FROM AGGREGATE WHERE ROWKEY='10' AND 8001 < WindowStart AND WindowStart <= 19444;"
       ],
       "inputs": [
         {"topic": "test_topic", "timestamp": 12345, "key": "11", "value": {}},
-        {"topic": "test_topic", "timestamp": 12345, "key": "10", "value": {}},
-        {"topic": "test_topic", "timestamp": 13456, "key": "10", "value": {}},
-        {"topic": "test_topic", "timestamp": 24456, "key": "10", "value": {}}
+        {"topic": "test_topic", "timestamp": 8001, "key": "10", "value": {}},
+        {"topic": "test_topic", "timestamp": 10456, "key": "10", "value": {}},
+        {"topic": "test_topic", "timestamp": 19444, "key": "10", "value": {}}
       ],
       "responses": [
         {"@type": "currentStatus"},
@@ -223,14 +250,20 @@
         {
           "@type": "rows",
           "rows": [
-            ["10", 12345, 13456, 2]
+            ["10", 8001, 10456, 2],
+            ["10", 19444, 19444, 1]
           ]
         },
         {
           "@type": "rows",
           "rows": [
-            ["10", 12345, 13456, 2],
-            ["10", 24456, 24456, 1]
+            ["10", 8001, 10456, 2]
+          ]
+        },
+        {
+          "@type": "rows",
+          "rows": [
+            ["10", 19444, 19444, 1]
           ]
         }
       ]

--- a/ksql-functional-tests/src/test/resources/rest-query-validation-tests/materialized-aggregate-static-queries.json
+++ b/ksql-functional-tests/src/test/resources/rest-query-validation-tests/materialized-aggregate-static-queries.json
@@ -269,6 +269,80 @@
       ]
     },
     {
+      "name": "tumbling windowed single key lookup with unbounded window start",
+      "statements": [
+        "CREATE STREAM INPUT (IGNORED INT) WITH (kafka_topic='test_topic', value_format='JSON');",
+        "CREATE TABLE AGGREGATE AS SELECT COUNT(1) AS COUNT FROM INPUT WINDOW TUMBLING(SIZE 1 SECOND) GROUP BY ROWKEY;",
+        "SELECT * FROM AGGREGATE WHERE ROWKEY='10';"
+      ],
+      "inputs": [
+        {"topic": "test_topic", "timestamp": 12345, "key": "11", "value": {}},
+        {"topic": "test_topic", "timestamp": 11345, "key": "10", "value": {}},
+        {"topic": "test_topic", "timestamp": 12345, "key": "10", "value": {}}
+      ],
+      "responses": [
+        {"@type": "currentStatus"},
+        {"@type": "currentStatus"},
+        {
+          "@type": "rows",
+          "rows": [
+            ["10", 11000, 1],
+            ["10", 12000, 1]
+          ]
+        }
+      ]
+    },
+    {
+      "name": "hopping windowed single key lookup with unbounded window start",
+      "statements": [
+        "CREATE STREAM INPUT (IGNORED INT) WITH (kafka_topic='test_topic', value_format='JSON');",
+        "CREATE TABLE AGGREGATE AS SELECT COUNT(1) AS COUNT FROM INPUT WINDOW HOPPING(SIZE 4 SECOND, ADVANCE BY 1 SECONDS) GROUP BY ROWKEY;",
+        "SELECT * FROM AGGREGATE WHERE ROWKEY='10';"
+      ],
+      "inputs": [
+        {"topic": "test_topic", "timestamp": 10345, "key": "11", "value": {}},
+        {"topic": "test_topic", "timestamp": 10345, "key": "10", "value": {}},
+        {"topic": "test_topic", "timestamp": 13345, "key": "10", "value": {}}
+      ],
+      "responses": [
+        {"@type": "currentStatus"},
+        {"@type": "currentStatus"},
+        {
+          "@type": "rows",
+          "rows": [
+            ["10", 7000, 1],
+            ["10", 8000, 1],
+            ["10", 9000, 1],
+            ["10", 10000, 2],
+            ["10", 11000, 1],
+            ["10", 12000, 1],
+            ["10", 13000, 1]
+          ]
+        }
+      ]
+    },
+    {
+      "name": "session windowed single key lookup with unbounded window start",
+      "statements": [
+        "CREATE STREAM INPUT (IGNORED INT) WITH (kafka_topic='test_topic', value_format='JSON');",
+        "CREATE TABLE AGGREGATE AS SELECT COUNT(1) AS COUNT FROM INPUT WINDOW SESSION(10 SECOND) GROUP BY ROWKEY;",
+        "SELECT * FROM AGGREGATE WHERE ROWKEY='10';"
+      ],
+      "inputs": [
+        {"topic": "test_topic", "timestamp": 12345, "key": "11", "value": {}},
+        {"topic": "test_topic", "timestamp": 12345, "key": "10", "value": {}},
+        {"topic": "test_topic", "timestamp": 12366, "key": "10", "value": {}}
+      ],
+      "responses": [
+        {"@type": "currentStatus"},
+        {"@type": "currentStatus"},
+        {
+          "@type": "rows",
+          "rows": [["10", 12345, 12366, 2]]
+        }
+      ]
+    },
+    {
       "name": "non-windowed projection WITH ROWTIME",
       "statements": [
         "CREATE STREAM INPUT (IGNORED INT) WITH (kafka_topic='test_topic', value_format='JSON');",
@@ -530,19 +604,6 @@
       "expectedError": {
         "type": "io.confluent.ksql.rest.entity.KsqlStatementErrorMessage",
         "message": "Table 'X' is not materialized. KSQL currently only supports static queries on materialized aggregate tables. i.e. those created by a 'CREATE TABLE AS SELECT <fields> FROM <sources> GROUP BY <key>' style statement.",
-        "status": 400
-      }
-    },
-    {
-      "name": "fail on windowed table if no window start bounds provided",
-      "statements": [
-        "CREATE STREAM INPUT (IGNORED INT) WITH (kafka_topic='test_topic', value_format='JSON');",
-        "CREATE TABLE AGGREGATE AS SELECT COUNT(1) AS COUNT FROM INPUT WINDOW TUMBLING(SIZE 1 SECOND) GROUP BY ROWKEY;",
-        "SELECT * FROM AGGREGATE WHERE ROWKEY='10';"
-      ],
-      "expectedError": {
-        "type": "io.confluent.ksql.rest.entity.KsqlStatementErrorMessage",
-        "message": "WHERE clause missing WINDOWSTART",
         "status": 400
       }
     },


### PR DESCRIPTION
### Description 

This PR has two parts.

The first commit makes it possible to have WHERE clause bounding WINDOWSTART using the following comparison types:
 - `>`
 - `>=`
 - `=`
 - `<`
 - `>=`

 Some of which were already supported in certain situations, but are now all full supported.

The second commit removes the requirement to have a bound on WINDOWSTART at all for windowed tables. With no bounds, all windows are returned.

e.g.

```sql
-- get all windows for a key:
SELECT * FROM X WHERE ROWKEY=Y;

-- upper and lower bounds on window start exclusive:
SELECT * FROM X WHERE ROWKEY=Y AND '2019' < WINDOWSTART AND WINDOWSTART < '2020';

-- upper and lower bounds on window start inclusive:
SELECT * FROM X WHERE ROWKEY=Y AND '2019' <= WINDOWSTART AND WINDOWSTART <= '2020';
```

cc @derekjn ,  @MichaelDrogalis 

### Testing done 

usual

### Reviewer checklist
- [ ] Ensure docs are updated if necessary. (eg. if a user visible feature is being added or changed).
- [ ] Ensure relevant issues are linked (description should include text like "Fixes #<issue number>")

