### PR TITLE
feat(static): support ROWKEY in the projection of static queries

### DIFF
--- a/ksql-engine/src/test/java/io/confluent/ksql/materialization/KsqlMaterializationTest.java
+++ b/ksql-engine/src/test/java/io/confluent/ksql/materialization/KsqlMaterializationTest.java
@@ -325,7 +325,7 @@ public class KsqlMaterializationTest {
     when(aggregateTransform.apply(any())).thenReturn(TRANSFORMED);
 
     // When:
-    table.get(A_KEY, AN_INSTANT, AN_INSTANT);
+    table.get(A_KEY, WINDOW_START_BOUNDS);
 
     // Then:
     verify(havingPredicate).test(A_KEY, TRANSFORMED);

--- a/ksql-execution/src/main/java/io/confluent/ksql/execution/util/ExpressionTypeManager.java
+++ b/ksql-execution/src/main/java/io/confluent/ksql/execution/util/ExpressionTypeManager.java
@@ -210,7 +210,7 @@ public class ExpressionTypeManager {
         final ColumnReferenceExp node,
         final ExpressionTypeContext expressionTypeContext
     ) {
-      final Column schemaColumn = schema.findValueColumn(node.getReference().toString())
+      final Column schemaColumn = schema.findColumn(node.getReference().name())
           .orElseThrow(() ->
               new KsqlException(String.format("Invalid Expression %s.", node.toString())));
 

--- a/ksql-functional-tests/src/test/resources/rest-query-validation-tests/materialized-aggregate-static-queries.json
+++ b/ksql-functional-tests/src/test/resources/rest-query-validation-tests/materialized-aggregate-static-queries.json
@@ -460,10 +460,11 @@
     },
     {
       "name": "text datetime window bounds",
+      "comment": "Note: this test must specify a timezone in the exact lookup so that it works when run from any TZ.",
       "statements": [
         "CREATE STREAM INPUT (IGNORED INT) WITH (kafka_topic='test_topic', value_format='JSON');",
         "CREATE TABLE AGGREGATE AS SELECT COUNT(1) AS COUNT FROM INPUT WINDOW TUMBLING(SIZE 1 SECOND) GROUP BY ROWKEY;",
-        "SELECT * FROM AGGREGATE WHERE ROWKEY='10' AND WindowStart='2020-02-23T23:45:12.000';"
+        "SELECT * FROM AGGREGATE WHERE ROWKEY='10' AND WindowStart='2020-02-23T23:45:12.000+0000';"
       ],
       "inputs": [
         {"topic": "test_topic", "timestamp": 1582501512456, "key": "11", "value": {}},
@@ -498,13 +499,15 @@
     },
     {
       "name": "partial text datetime window bounds",
+      "comment": "Note: this test has side enough range on dates to ensure running in different timezones do not cause it to fail",
       "statements": [
         "CREATE STREAM INPUT (IGNORED INT) WITH (kafka_topic='test_topic', value_format='JSON');",
         "CREATE TABLE AGGREGATE AS SELECT COUNT(1) AS COUNT FROM INPUT WINDOW TUMBLING(SIZE 1 SECOND) GROUP BY ROWKEY;",
-        "SELECT * FROM AGGREGATE WHERE '2020-02-23T23:45' <= WindowStart AND WindowStart < '2020-02-23T24' AND ROWKEY='10';"
+        "SELECT * FROM AGGREGATE WHERE '2020-02-22T23:45' <= WindowStart AND WindowStart < '2020-02-24T24' AND ROWKEY='10';"
       ],
       "inputs": [
         {"topic": "test_topic", "timestamp": 1582501512456, "key": "11", "value": {}},
+        {"topic": "test_topic", "timestamp": 1582401512456, "key": "10", "value": {}},
         {"topic": "test_topic", "timestamp": 1582501512456, "key": "10", "value": {}},
         {"topic": "test_topic", "timestamp": 1582501552456, "key": "10", "value": {}}
       ],

--- a/ksql-functional-tests/src/test/resources/rest-query-validation-tests/materialized-aggregate-static-queries.json
+++ b/ksql-functional-tests/src/test/resources/rest-query-validation-tests/materialized-aggregate-static-queries.json
@@ -27,45 +27,6 @@
       ]
     },
     {
-      "name": "non-windowed with projection",
-      "statements": [
-        "CREATE STREAM INPUT (IGNORED INT) WITH (kafka_topic='test_topic', value_format='JSON');",
-        "CREATE TABLE AGGREGATE AS SELECT ROWKEY AS ID, COUNT(1) AS COUNT FROM INPUT GROUP BY ROWKEY;",
-        "SELECT COUNT, CONCAT(ID, 'x') AS ID, COUNT * 2 FROM AGGREGATE WHERE ROWKEY='10';"
-      ],
-      "inputs": [
-        {"topic": "test_topic", "key": "11", "value": {}},
-        {"topic": "test_topic", "key": "10", "value": {}}
-      ],
-      "responses": [
-        {"@type": "currentStatus"},
-        {"@type": "currentStatus"},
-        {"@type": "rows", "rows": [
-          ["10", 1, "10x", 2]
-        ]}
-      ]
-    },
-    {
-      "name": "windowed with projection",
-      "statements": [
-        "CREATE STREAM INPUT (IGNORED INT) WITH (kafka_topic='test_topic', value_format='JSON');",
-        "CREATE TABLE AGGREGATE AS SELECT ROWKEY AS ID, COUNT(1) AS COUNT FROM INPUT WINDOW TUMBLING(SIZE 1 SECOND) GROUP BY ROWKEY;",
-        "SELECT COUNT, CONCAT(ID, 'x') AS ID, COUNT * 2 FROM AGGREGATE WHERE ROWKEY='10' AND WindowStart=12000;"
-      ],
-      "inputs": [
-        {"topic": "test_topic", "timestamp": 12345, "key": "11", "value": {}},
-        {"topic": "test_topic", "timestamp": 11345, "key": "10", "value": {}},
-        {"topic": "test_topic", "timestamp": 12345, "key": "10", "value": {}}
-      ],
-      "responses": [
-        {"@type": "currentStatus"},
-        {"@type": "currentStatus"},
-        {"@type": "rows", "rows": [
-          ["10", 12000, 1, "10x", 2]
-        ]}
-      ]
-    },
-    {
       "name": "tumbling windowed single key lookup with exact window start",
       "statements": [
         "CREATE STREAM INPUT (IGNORED INT) WITH (kafka_topic='test_topic', value_format='JSON');",
@@ -232,6 +193,92 @@
             ["10", 12345, 13456, 2],
             ["10", 24456, 24456, 1]
           ]
+        }
+      ]
+    },
+    {
+      "name": "non-windowed with projection",
+      "statements": [
+        "CREATE STREAM INPUT (IGNORED INT) WITH (kafka_topic='test_topic', value_format='JSON');",
+        "CREATE TABLE AGGREGATE AS SELECT ROWKEY AS ID, COUNT(1) AS COUNT FROM INPUT GROUP BY ROWKEY;",
+        "SELECT COUNT, CONCAT(ID, 'x') AS ID, COUNT * 2 FROM AGGREGATE WHERE ROWKEY='10';"
+      ],
+      "inputs": [
+        {"topic": "test_topic", "key": "11", "value": {}},
+        {"topic": "test_topic", "key": "10", "value": {}}
+      ],
+      "responses": [
+        {"@type": "currentStatus"},
+        {"@type": "currentStatus"},
+        {
+          "@type": "rows",
+          "schema": "`COUNT` BIGINT, `ID` STRING, `KSQL_COL_2` BIGINT",
+          "rows": [[1, "10x", 2]]
+        }
+      ]
+    },
+    {
+      "name": "windowed with projection",
+      "statements": [
+        "CREATE STREAM INPUT (IGNORED INT) WITH (kafka_topic='test_topic', value_format='JSON');",
+        "CREATE TABLE AGGREGATE AS SELECT ROWKEY AS ID, COUNT(1) AS COUNT FROM INPUT WINDOW TUMBLING(SIZE 1 SECOND) GROUP BY ROWKEY;",
+        "SELECT COUNT, CONCAT(ID, 'x') AS ID, COUNT * 2 FROM AGGREGATE WHERE ROWKEY='10' AND WindowStart=12000;"
+      ],
+      "inputs": [
+        {"topic": "test_topic", "timestamp": 12345, "key": "11", "value": {}},
+        {"topic": "test_topic", "timestamp": 11345, "key": "10", "value": {}},
+        {"topic": "test_topic", "timestamp": 12345, "key": "10", "value": {}}
+      ],
+      "responses": [
+        {"@type": "currentStatus"},
+        {"@type": "currentStatus"},
+        {
+          "@type": "rows",
+          "schema": "`COUNT` BIGINT, `ID` STRING, `KSQL_COL_2` BIGINT",
+          "rows": [[1, "10x", 2]]
+        }
+      ]
+    },
+    {
+      "name": "non-windowed projection WITH ROWKEY",
+      "statements": [
+        "CREATE STREAM INPUT (IGNORED INT) WITH (kafka_topic='test_topic', value_format='JSON');",
+        "CREATE TABLE AGGREGATE AS SELECT COUNT(1) AS COUNT FROM INPUT GROUP BY ROWKEY;",
+        "SELECT ROWKEY, COUNT FROM AGGREGATE WHERE ROWKEY='10';"
+      ],
+      "inputs": [
+        {"topic": "test_topic", "key": "11", "value": {}},
+        {"topic": "test_topic", "key": "10", "value": {}}
+      ],
+      "responses": [
+        {"@type": "currentStatus"},
+        {"@type": "currentStatus"},
+        {
+          "@type": "rows",
+          "schema": "`ROWKEY` STRING KEY, `COUNT` BIGINT",
+          "rows": [["10", 1]]
+        }
+      ]
+    },
+    {
+      "name": "windowed with projection with ROWKEY",
+      "statements": [
+        "CREATE STREAM INPUT (IGNORED INT) WITH (kafka_topic='test_topic', value_format='JSON');",
+        "CREATE TABLE AGGREGATE AS SELECT COUNT(1) AS COUNT FROM INPUT WINDOW TUMBLING(SIZE 1 SECOND) GROUP BY ROWKEY;",
+        "SELECT COUNT, ROWKEY FROM AGGREGATE WHERE ROWKEY='10' AND WindowStart=12000;"
+      ],
+      "inputs": [
+        {"topic": "test_topic", "timestamp": 12345, "key": "11", "value": {}},
+        {"topic": "test_topic", "timestamp": 11345, "key": "10", "value": {}},
+        {"topic": "test_topic", "timestamp": 12345, "key": "10", "value": {}}
+      ],
+      "responses": [
+        {"@type": "currentStatus"},
+        {"@type": "currentStatus"},
+        {
+          "@type": "rows",
+          "schema": "`COUNT` BIGINT, `ROWKEY` STRING KEY",
+          "rows": [[1, "10"]]
         }
       ]
     },

--- a/ksql-functional-tests/src/test/resources/rest-query-validation-tests/materialized-aggregate-static-queries.json
+++ b/ksql-functional-tests/src/test/resources/rest-query-validation-tests/materialized-aggregate-static-queries.json
@@ -309,6 +309,49 @@
       }
     },
     {
+      "name": "non-windowed projection with ROWMEY and more columns in aggregate",
+      "statements": [
+        "CREATE STREAM INPUT (VAL INT) WITH (kafka_topic='test_topic', value_format='JSON');",
+        "CREATE TABLE AGGREGATE AS SELECT COUNT(1) AS COUNT, SUM(VAL) AS SUM, MIN(VAL) AS MIN FROM INPUT GROUP BY ROWKEY;",
+        "SELECT ROWKEY, COUNT FROM AGGREGATE WHERE ROWKEY='10';"
+      ],
+      "inputs": [
+        {"topic": "test_topic", "key": "11", "value": {"val": 1}},
+        {"topic": "test_topic", "key": "10", "value": {"val": 2}}
+      ],
+      "responses": [
+        {"@type": "currentStatus"},
+        {"@type": "currentStatus"},
+        {
+          "@type": "rows",
+          "schema": "`ROWKEY` STRING KEY, `COUNT` BIGINT",
+          "rows": [["10", 1]]
+        }
+      ]
+    },
+    {
+      "name": "non-windowed projection with ROWMEY and more columns in lookup",
+      "statements": [
+        "CREATE STREAM INPUT (IGNORED INT) WITH (kafka_topic='test_topic', value_format='JSON');",
+        "CREATE TABLE AGGREGATE AS SELECT COUNT(1) AS COUNT FROM INPUT GROUP BY ROWKEY;",
+        "SELECT COUNT, ROWKEY, COUNT AS COUNT2 FROM AGGREGATE WHERE ROWKEY='10';"
+      ],
+      "inputs": [
+        {"topic": "test_topic", "timestamp": 12345, "key": "11", "value": {}},
+        {"topic": "test_topic", "timestamp": 11345, "key": "10", "value": {}},
+        {"topic": "test_topic", "timestamp": 12345, "key": "10", "value": {}}
+      ],
+      "responses": [
+        {"@type": "currentStatus"},
+        {"@type": "currentStatus"},
+        {
+          "@type": "rows",
+          "schema": "`COUNT` BIGINT, `ROWKEY` STRING KEY, `COUNT2` BIGINT",
+          "rows": [[2,"10",2]]
+        }
+      ]
+    },
+    {
       "name": "text datetime window bounds",
       "statements": [
         "CREATE STREAM INPUT (IGNORED INT) WITH (kafka_topic='test_topic', value_format='JSON');",

--- a/ksql-rest-app/src/main/java/io/confluent/ksql/rest/server/execution/StaticQueryExecutor.java
+++ b/ksql-rest-app/src/main/java/io/confluent/ksql/rest/server/execution/StaticQueryExecutor.java
@@ -52,6 +52,7 @@ import io.confluent.ksql.metastore.model.DataSource;
 import io.confluent.ksql.name.SourceName;
 import io.confluent.ksql.parser.tree.AllColumns;
 import io.confluent.ksql.parser.tree.Query;
+import io.confluent.ksql.parser.tree.Select;
 import io.confluent.ksql.parser.tree.SelectItem;
 import io.confluent.ksql.query.QueryId;
 import io.confluent.ksql.rest.Errors;
@@ -64,6 +65,7 @@ import io.confluent.ksql.rest.entity.TableRowsEntityFactory;
 import io.confluent.ksql.rest.server.resources.KsqlRestException;
 import io.confluent.ksql.schema.ksql.FormatOptions;
 import io.confluent.ksql.schema.ksql.LogicalSchema;
+import io.confluent.ksql.schema.ksql.LogicalSchema.Builder;
 import io.confluent.ksql.schema.ksql.PhysicalSchema;
 import io.confluent.ksql.schema.ksql.types.SqlType;
 import io.confluent.ksql.serde.SerdeOption;
@@ -85,6 +87,7 @@ import java.util.Map.Entry;
 import java.util.Objects;
 import java.util.Optional;
 import java.util.Set;
+import java.util.function.BiFunction;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 import org.apache.kafka.connect.data.Struct;
@@ -154,7 +157,7 @@ public final class StaticQueryExecutor {
         return Optional.of(proxyTo(owner, statement));
       }
 
-      Result result;
+      final Result result;
       if (whereInfo.windowStartBounds.isPresent()) {
         final Range<Instant> windowStart = whereInfo.windowStartBounds.get();
 
@@ -171,12 +174,24 @@ public final class StaticQueryExecutor {
         result = new Result(mat.schema(), rows);
       }
 
-      result = handleSelects(result, statement, executionContext, analysis);
+      final LogicalSchema outputSchema;
+      final List<List<?>> rows;
+      if (isSelectStar(statement.getStatement().getSelect())) {
+        outputSchema = TableRowsEntityFactory.buildSchema(result.schema, mat.windowType());
+        rows = TableRowsEntityFactory.createRows(result.rows);
+      } else {
+        final LogicalSchema.Builder schemaBuilder =
+            selectSchemaBuilder(result, executionContext, analysis);
+
+        outputSchema = schemaBuilder.build();
+
+        rows = handleSelects(result, statement, executionContext, analysis, schemaBuilder);
+      }
 
       final TableRowsEntity entity = new TableRowsEntity(
           statement.getStatementText(),
-          TableRowsEntityFactory.buildSchema(result.schema, mat.windowType()),
-          TableRowsEntityFactory.createRows(result.rows)
+          outputSchema,
+          rows
       );
 
       return Optional.of(entity);
@@ -478,23 +493,84 @@ public final class StaticQueryExecutor {
     }
   }
 
-  private static boolean isSelectStar(final List<SelectItem> selects) {
+  private static boolean isSelectStar(final Select select) {
+    final List<SelectItem> selects = select.getSelectItems();
     return selects.size() == 1 && selects.get(0) instanceof AllColumns;
   }
 
-  private static Result handleSelects(
+  private static List<List<?>> handleSelects(
       final Result input,
       final ConfiguredStatement<Query> statement,
       final KsqlExecutionContext executionContext,
-      final Analysis analysis
+      final Analysis analysis,
+      final Builder schemaBuilder
   ) {
-    final List<SelectItem> selectItems = statement.getStatement().getSelect().getSelectItems();
-    if (input.rows.isEmpty() || isSelectStar(selectItems)) {
-      return input;
+    final LogicalSchema outputSchema = schemaBuilder.build();
+
+    final LogicalSchema intermediateSchema;
+    final BiFunction<Struct, GenericRow, GenericRow> preSelectTransform;
+    if (outputSchema.key().isEmpty()) {
+      intermediateSchema = input.schema;
+      preSelectTransform = (key, value) -> value;
+    } else {
+      // SelectValueMapper requires the key fields in the value schema :(
+      schemaBuilder.valueColumns(outputSchema.key());
+      intermediateSchema = schemaBuilder.build();
+
+      preSelectTransform = (key, value) -> {
+        key.schema().fields().forEach(f -> {
+          final Object keyField = key.get(f);
+          value.getColumns().add(keyField);
+        });
+        return value;
+      };
     }
 
-    final LogicalSchema.Builder schemaBuilder = LogicalSchema.builder();
-    schemaBuilder.keyColumns(input.schema.key());
+    final SourceName sourceName = getSourceName(analysis);
+
+    final KsqlConfig ksqlConfig = statement.getConfig()
+        .cloneWithPropertyOverwrite(statement.getOverrides());
+
+    final SelectValueMapper select = SelectValueMapperFactory.create(
+        analysis.getSelectExpressions(),
+        intermediateSchema.withAlias(sourceName),
+        ksqlConfig,
+        executionContext.getMetaStore(),
+        NoopProcessingLogContext.INSTANCE.getLoggerFactory().getLogger("any")
+    );
+
+    final ImmutableList.Builder<List<?>> output = ImmutableList.builder();
+    input.rows.forEach(r -> {
+      final GenericRow intermediate = preSelectTransform.apply(r.key(), r.value());
+      final GenericRow mapped = select.apply(intermediate);
+      validateProjection(mapped, outputSchema);
+      output.add(ImmutableList.copyOf(mapped.getColumns()));
+    });
+
+    return output.build();
+  }
+
+  private static void validateProjection(
+      final GenericRow fullRow,
+      final LogicalSchema schema
+  ) {
+    final int actual = fullRow.getColumns().size();
+    final int expected = schema.columns().size();
+    if (actual != expected) {
+      throw new IllegalStateException("Row column count mismatch."
+          + " expected:" + expected
+          + ", got:" + actual
+      );
+    }
+  }
+
+  private static LogicalSchema.Builder selectSchemaBuilder(
+      final Result input,
+      final KsqlExecutionContext executionContext,
+      final Analysis analysis
+  ) {
+    final Builder schemaBuilder = LogicalSchema.builder()
+        .noImplicitColumns();
 
     final ExpressionTypeManager expressionTypeManager = new ExpressionTypeManager(
         input.schema,
@@ -504,32 +580,14 @@ public final class StaticQueryExecutor {
     for (int idx = 0; idx < analysis.getSelectExpressions().size(); idx++) {
       final SelectExpression select = analysis.getSelectExpressions().get(idx);
       final SqlType type = expressionTypeManager.getExpressionSqlType(select.getExpression());
-      schemaBuilder.valueColumn(select.getName(), type);
+
+      if (input.schema.isKeyColumn(select.getName())) {
+        schemaBuilder.keyColumn(select.getName(), type);
+      } else {
+        schemaBuilder.valueColumn(select.getName(), type);
+      }
     }
-
-    final LogicalSchema schema = schemaBuilder.build();
-
-    final SourceName sourceName = getSourceName(analysis);
-
-    final KsqlConfig ksqlConfig = statement.getConfig()
-        .cloneWithPropertyOverwrite(statement.getOverrides());
-
-    final SelectValueMapper mapper = SelectValueMapperFactory.create(
-        analysis.getSelectExpressions(),
-        input.schema.withAlias(sourceName),
-        ksqlConfig,
-        executionContext.getMetaStore(),
-        NoopProcessingLogContext.INSTANCE.getLoggerFactory().getLogger("any")
-    );
-
-    final ImmutableList.Builder<TableRow> output = ImmutableList.builder();
-    input.rows.forEach(r -> {
-      final GenericRow mapped = mapper.apply(r.value());
-      final TableRow tableRow = r.withValue(mapped, schema);
-      output.add(tableRow);
-    });
-
-    return new Result(schema, output.build());
+    return schemaBuilder;
   }
 
   private static PersistentQueryMetadata findMaterializingQuery(

--- a/ksql-rest-model/src/main/java/io/confluent/ksql/rest/entity/TableRowsEntity.java
+++ b/ksql-rest-model/src/main/java/io/confluent/ksql/rest/entity/TableRowsEntity.java
@@ -76,7 +76,7 @@ public class TableRowsEntity extends KsqlEntity {
     final int actualSize = row.size();
 
     if (expectedSize != actualSize) {
-      throw new IllegalArgumentException("field count mismatch."
+      throw new IllegalArgumentException("column count mismatch."
           + " expected: " + expectedSize
           + ", got: " + actualSize
       );


### PR DESCRIPTION
### Description 

With this PR you can now have `ROWKEY` in the projection of a static query, e.g.

```sql
SELECT ROWKEY, ID FROM X WHERE ROWKEY=10;
```

This involves more hacking about in `StaticQueryExecutor`, which will be refactored into something more manageable.  Deadlines, deadlines!

cc @derekjn ,  @MichaelDrogalis 

### Testing done 
_Describe the testing strategy. Unit and integration tests are expected for any behavior changes._

### Reviewer checklist
- [ ] Ensure docs are updated if necessary. (eg. if a user visible feature is being added or changed).
- [ ] Ensure relevant issues are linked (description should include text like "Fixes #<issue number>")

