### PR TITLE
refactor: pass function list to undo/window-select

### DIFF
--- a/ksql-streams/src/test/java/io/confluent/ksql/execution/streams/AggregateParamsTest.java
+++ b/ksql-streams/src/test/java/io/confluent/ksql/execution/streams/AggregateParamsTest.java
@@ -161,10 +161,10 @@ public class AggregateParamsTest {
     final KudafUndoAggregator undoAggregator = aggregateParams.getUndoAggregator();
 
     // Then:
-    assertThat(undoAggregator.getNonFuncColumnCount(), equalTo(2));
+    assertThat(undoAggregator.getInitialUdafIndex(), equalTo(2));
     assertThat(
-        undoAggregator.getAggValToAggFunctionMap(),
-        equalTo(ImmutableMap.of(2, tableAgg))
+        undoAggregator.getAggregateFunctions(),
+        equalTo(ImmutableList.of(tableAgg))
     );
   }
 


### PR DESCRIPTION
### Description 

This patch refactors KudafUndoAggregator and WindowSelectMapper to
accept a list of functions rather than a map from index to function.

