### PR TITLE
feat: udf and udaf support same parameters

### DIFF
--- a/ksql-engine/src/main/java/io/confluent/ksql/function/FunctionCompiler.java
+++ b/ksql-engine/src/main/java/io/confluent/ksql/function/FunctionCompiler.java
@@ -1,0 +1,112 @@
+/*
+ * Copyright 2019 Confluent Inc.
+ *
+ * Licensed under the Confluent Community License (the "License"; you may not use
+ * this file except in compliance with the License. You may obtain a copy of the
+ * License at
+ *
+ * http://www.confluent.io/confluent-community-license
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package io.confluent.ksql.function;
+
+import com.google.common.collect.ImmutableSet;
+import io.confluent.ksql.execution.function.UdfUtil;
+import io.confluent.ksql.metastore.TypeRegistry;
+import io.confluent.ksql.schema.ksql.SchemaConverters;
+import io.confluent.ksql.schema.ksql.SqlTypeParser;
+import io.confluent.ksql.util.KsqlException;
+import io.confluent.ksql.util.SchemaUtil;
+import java.lang.reflect.Method;
+import java.lang.reflect.ParameterizedType;
+import java.lang.reflect.Type;
+import java.math.BigDecimal;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Optional;
+import java.util.Set;
+import org.apache.kafka.connect.data.Schema;
+import org.apache.kafka.connect.data.Struct;
+
+public abstract class FunctionCompiler {
+
+  static final Set<Class<?>> SUPPORTED_TYPES = ImmutableSet.<Class<?>>builder()
+      .add(int.class)
+      .add(long.class)
+      .add(double.class)
+      .add(boolean.class)
+      .add(Integer.class)
+      .add(Long.class)
+      .add(Double.class)
+      .add(BigDecimal.class)
+      .add(Boolean.class)
+      .add(String.class)
+      .add(Struct.class)
+      .add(List.class)
+      .add(Map.class)
+      .build();
+
+  private static final SqlTypeParser typeParser = SqlTypeParser.create(TypeRegistry.EMPTY);
+
+  static void validateMethodSignature(final Method method, final String functionName) {
+  }
+
+  static void validateParameters(final Method method) {
+  }
+
+  static Schema parseParameter(final Type type,
+                                       final Optional<String> schemaString,
+                                       final String msg,
+                                       final String name,
+                                       final String doc) {
+
+    validateStructAnnotation(type, schemaString, msg);
+    return SchemaUtil.ensureOptional(getSchemaFromInputParameter(type, schemaString, name, doc));
+  }
+
+  static void validateStructAnnotation(final Type type,
+                                               final Optional<String> schema,
+                                               final String msg) {
+
+    if (type.equals(Struct.class) && !schema.isPresent()) {
+      throw new KsqlException(String.format("Must specify '%s' for STRUCT parameter in "
+                                                + "@UdafFactory.", msg));
+    }
+  }
+
+  static Type getRawType(final Type type) {
+    if (type instanceof ParameterizedType) {
+      return ((ParameterizedType) type).getRawType();
+    }
+    return type;
+  }
+
+  static Schema getSchemaFromInputParameter(final Type type,
+                                                    final Optional<String> paramSchema,
+                                                    final String paramName,
+                                                    final String paramDoc) {
+
+    Objects.requireNonNull(paramName);
+    Objects.requireNonNull(paramDoc);
+    if (paramSchema.isPresent()) {
+      return SchemaConverters.sqlToConnectConverter().toConnectSchema(
+          typeParser.parse(paramSchema.get()).getSqlType(), paramName, paramDoc);
+    }
+
+    return UdfUtil.getSchemaFromType(type, paramName, paramDoc);
+  }
+
+  static boolean isUnsupportedType(final Class<?> type) {
+    return !SUPPORTED_TYPES.contains(type)
+        && (!type.isArray() || !SUPPORTED_TYPES.contains(type.getComponentType()))
+        && SUPPORTED_TYPES.stream().noneMatch(supported -> supported.isAssignableFrom(type));
+  }
+
+
+}

--- a/ksql-engine/src/main/java/io/confluent/ksql/function/UdafCompiler.java
+++ b/ksql-engine/src/main/java/io/confluent/ksql/function/UdafCompiler.java
@@ -1,0 +1,245 @@
+/*
+ * Copyright 2019 Confluent Inc.
+ *
+ * Licensed under the Confluent Community License (the "License"; you may not use
+ * this file except in compliance with the License. You may obtain a copy of the
+ * License at
+ *
+ * http://www.confluent.io/confluent-community-license
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package io.confluent.ksql.function;
+
+import com.google.errorprone.annotations.Immutable;
+import io.confluent.ksql.function.udaf.TableUdaf;
+import io.confluent.ksql.function.udaf.Udaf;
+import io.confluent.ksql.function.udaf.UdafFactory;
+import io.confluent.ksql.function.udaf.UdfArgSupplier;
+import io.confluent.ksql.util.KsqlException;
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.lang.reflect.AnnotatedParameterizedType;
+import java.lang.reflect.GenericArrayType;
+import java.lang.reflect.Method;
+import java.lang.reflect.ParameterizedType;
+import java.lang.reflect.Type;
+import java.lang.reflect.TypeVariable;
+import java.nio.charset.StandardCharsets;
+import java.util.Collections;
+import java.util.List;
+import java.util.Objects;
+import java.util.Optional;
+import org.apache.kafka.common.metrics.Metrics;
+import org.apache.kafka.connect.data.Schema;
+import org.codehaus.commons.compiler.CompilerFactoryFactory;
+import org.codehaus.commons.compiler.IScriptEvaluator;
+import org.codehaus.janino.JavaSourceClassLoader;
+import org.codehaus.janino.util.resource.Resource;
+import org.codehaus.janino.util.resource.ResourceFinder;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+@Immutable
+public class UdafCompiler extends FunctionCompiler {
+
+  private static final Logger LOGGER = LoggerFactory
+      .getLogger(io.confluent.ksql.function.UdafCompiler.class);
+
+
+  private static final String UDAF_PACKAGE = "io.confluent.ksql.function.udaf.";
+
+  @SuppressWarnings("OptionalUsedAsFieldOrParameterType")
+  private final Optional<Metrics> metrics;
+
+  @SuppressWarnings("OptionalUsedAsFieldOrParameterType")
+  UdafCompiler(final Optional<Metrics> metrics) {
+    this.metrics = Objects.requireNonNull(metrics, "metrics can't be null");
+  }
+
+
+  KsqlAggregateFunction<?, ?, ?> compileAggregate(final Method method,
+                                                  final ClassLoader loader,
+                                                  final String functionName,
+                                                  final String description) {
+
+    validateMethodSignature(method, functionName);
+    validateParameters(method);
+
+    final UdafTypes types = new UdafTypes(method);
+    final Schema inputValue = types.getInputSchema();
+    final List<Schema> args = Collections.singletonList(inputValue);
+    final Schema aggregateValue = types.getAggregateSchema();
+    final Schema returnValue = types.getOutputSchema();
+
+    try {
+      final String generatedClassName
+          = method.getDeclaringClass().getSimpleName() + "_" + method.getName() + "_Aggregate";
+      final String udafClass = UdafTemplate.generateCode(method,
+                                                         generatedClassName,
+                                                         functionName,
+                                                         description);
+
+      LOGGER.trace("Generated class for functionName={}, method={} class\n{}\n",
+                   functionName,
+                   method.getName(),
+                   udafClass);
+
+      final ClassLoader javaSourceClassLoader
+          = createJavaSourceClassLoader(loader, generatedClassName, udafClass);
+      final IScriptEvaluator scriptEvaluator =
+          createScriptEvaluator(method,
+                                javaSourceClassLoader,
+                                UDAF_PACKAGE + generatedClassName);
+      final UdfArgSupplier evaluator = (UdfArgSupplier)
+          scriptEvaluator.createFastEvaluator("return new " + generatedClassName
+                            + "(args, aggregateType, outputType, metrics);",
+                            UdfArgSupplier.class,
+                            new String[]{"args", "aggregateType", "outputType", "metrics"});
+
+      return evaluator.apply(args, aggregateValue, returnValue, metrics);
+    } catch (final Exception e) {
+      throw new KsqlException("Failed to compile KSqlAggregateFunction for method='"
+                                  + method.getName() + "' in class='" + method.getDeclaringClass()
+                                  + "'", e);
+    }
+  }
+
+  private static class UdafTypes {
+
+    private final Type inputType;
+    private final Type aggregateType;
+    private final Type outputType;
+    private final Method method;
+    private final Optional<UdafFactory> annotation;
+
+    UdafTypes(final Method m) {
+      this.method = Objects.requireNonNull(m);
+      final AnnotatedParameterizedType annotatedReturnType
+          = (AnnotatedParameterizedType) method.getAnnotatedReturnType();
+      final ParameterizedType type = (ParameterizedType) annotatedReturnType.getType();
+      this.annotation = method.getAnnotation(UdafFactory.class) == null
+          ? Optional.empty() : Optional.of(method.getAnnotation(UdafFactory.class));
+
+      inputType = type.getActualTypeArguments()[0];
+      aggregateType = type.getActualTypeArguments()[1];
+      outputType = type.getActualTypeArguments()[2];
+    }
+
+    Schema getInputSchema() {
+      final Optional<String> inSchema = annotation.map(UdafFactory::paramSchema).filter(
+          val -> !val.isEmpty());
+      return parseParameter(inputType, inSchema, "paramSchema", "", "");
+    }
+
+    Schema getAggregateSchema() {
+      final Optional<String> aggSchema = annotation.map(UdafFactory::aggregateSchema).filter(
+          val -> !val.isEmpty());
+      return parseParameter(aggregateType, aggSchema, "aggregateSchema", "", "");
+    }
+
+    Schema getOutputSchema() {
+      final Optional<String> outSchema = annotation.map(UdafFactory::returnSchema).filter(
+          val -> !val.isEmpty());
+      return parseParameter(outputType, outSchema, "returnSchema", "", "");
+    }
+  }
+
+  static void validateParameters(final Method method) {
+
+    final AnnotatedParameterizedType annotatedReturnType
+        = (AnnotatedParameterizedType) method.getAnnotatedReturnType();
+    final ParameterizedType parameterizedType = (ParameterizedType) annotatedReturnType.getType();
+
+    final Type[] types = parameterizedType.getActualTypeArguments();
+    for (int i = 0; i < types.length; i++) {
+      final Type type = types[i];
+
+      if (type instanceof TypeVariable || type instanceof GenericArrayType) {
+        // this is the case where the type parameter is generic
+        continue;
+      }
+
+      if (isUnsupportedType((Class<?>) getRawType(type))) {
+        throw new KsqlException(
+            String.format(
+                "Type %s is not supported by UDAF methods. "
+                    + "Supported types %s. method=%s, class=%s",
+                type,
+                SUPPORTED_TYPES,
+                method.getName(),
+                method.getDeclaringClass()
+            )
+        );
+      }
+    }
+  }
+
+  static void validateMethodSignature(final Method method, final String functionName) {
+    final String functionInfo = String.format("method='%s', functionName='%s', UDFClass='%s'",
+                                              method.getName(),
+                                              functionName,
+                                              method.getDeclaringClass());
+
+    if (!(Udaf.class.equals(method.getReturnType())
+        || TableUdaf.class.equals(method.getReturnType()))) {
+      throw new KsqlException("UDAFs must implement " + Udaf.class.getName() + " or "
+                                  + TableUdaf.class.getName() + ". "
+                                  + functionInfo);
+    }
+  }
+
+  private static JavaSourceClassLoader createJavaSourceClassLoader(
+      final ClassLoader loader,
+      final String generatedClassName,
+      final String udafClass
+  ) {
+    final long lastMod = System.currentTimeMillis();
+    return new JavaSourceClassLoader(loader, new ResourceFinder() {
+      @Override
+      public Resource findResource(final String resource) {
+        if (resource.endsWith(generatedClassName + ".java")) {
+          return new Resource() {
+            @Override
+            public InputStream open() throws IOException {
+              return new ByteArrayInputStream(udafClass.getBytes(StandardCharsets.UTF_8.name()));
+            }
+
+            @Override
+            public String getFileName() {
+              return resource;
+            }
+
+            @Override
+            public long lastModified() {
+              return lastMod;
+            }
+          };
+        }
+        return null;
+      }
+    }, StandardCharsets.UTF_8.name());
+  }
+
+  private static IScriptEvaluator createScriptEvaluator(
+      final Method method,
+      final ClassLoader loader,
+      final String udfClass
+  ) throws Exception {
+    final IScriptEvaluator scriptEvaluator
+        = CompilerFactoryFactory.getDefaultCompilerFactory().newScriptEvaluator();
+    scriptEvaluator.setClassName(method.getDeclaringClass().getName() + "_" + method.getName());
+    scriptEvaluator.setDefaultImports(new String[]{
+        "java.util.*",
+        "io.confluent.ksql.function.KsqlFunctionException",
+        udfClass,
+    });
+    scriptEvaluator.setParentClassLoader(loader);
+    return scriptEvaluator;
+  }
+}

--- a/ksql-engine/src/main/java/io/confluent/ksql/function/UdfCompiler.java
+++ b/ksql-engine/src/main/java/io/confluent/ksql/function/UdfCompiler.java
@@ -16,48 +16,35 @@
 package io.confluent.ksql.function;
 
 import com.google.common.annotations.VisibleForTesting;
-import com.google.common.collect.ImmutableSet;
 import com.google.errorprone.annotations.Immutable;
 import io.confluent.ksql.execution.function.UdfUtil;
-import io.confluent.ksql.function.udaf.TableUdaf;
-import io.confluent.ksql.function.udaf.Udaf;
-import io.confluent.ksql.function.udaf.UdafFactory;
-import io.confluent.ksql.function.udaf.UdfArgSupplier;
-import io.confluent.ksql.function.udf.UdfDescription;
+import io.confluent.ksql.function.udf.Kudf;
+import io.confluent.ksql.function.udf.PluggableUdf;
+import io.confluent.ksql.function.udf.Udf;
 import io.confluent.ksql.function.udf.UdfParameter;
 import io.confluent.ksql.metastore.TypeRegistry;
 import io.confluent.ksql.schema.ksql.SchemaConverters;
 import io.confluent.ksql.schema.ksql.SqlTypeParser;
+import io.confluent.ksql.util.KsqlConfig;
 import io.confluent.ksql.util.KsqlException;
 import io.confluent.ksql.util.SchemaUtil;
-import java.io.ByteArrayInputStream;
-import java.io.IOException;
-import java.io.InputStream;
-import java.lang.reflect.AnnotatedParameterizedType;
 import java.lang.reflect.GenericArrayType;
 import java.lang.reflect.Method;
 import java.lang.reflect.Parameter;
-import java.lang.reflect.ParameterizedType;
 import java.lang.reflect.Type;
 import java.lang.reflect.TypeVariable;
-import java.math.BigDecimal;
-import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.Arrays;
-import java.util.Collections;
 import java.util.List;
-import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
-import java.util.Set;
+import java.util.function.Function;
+import org.apache.kafka.common.Configurable;
 import org.apache.kafka.common.metrics.Metrics;
+import org.apache.kafka.common.utils.Time;
 import org.apache.kafka.connect.data.Schema;
-import org.apache.kafka.connect.data.Struct;
 import org.codehaus.commons.compiler.CompilerFactoryFactory;
 import org.codehaus.commons.compiler.IScriptEvaluator;
-import org.codehaus.janino.JavaSourceClassLoader;
-import org.codehaus.janino.util.resource.Resource;
-import org.codehaus.janino.util.resource.ResourceFinder;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -67,26 +54,9 @@ import org.slf4j.LoggerFactory;
  * For UDAFs it is a {@link KsqlAggregateFunction}
  */
 @Immutable
-public class UdfCompiler {
+public class UdfCompiler extends FunctionCompiler {
+
   private static final Logger LOGGER = LoggerFactory.getLogger(UdfCompiler.class);
-
-  private static final Set<Class<?>> SUPPORTED_TYPES = ImmutableSet.<Class<?>>builder()
-      .add(int.class)
-      .add(long.class)
-      .add(double.class)
-      .add(boolean.class)
-      .add(Integer.class)
-      .add(Long.class)
-      .add(Double.class)
-      .add(BigDecimal.class)
-      .add(Boolean.class)
-      .add(String.class)
-      .add(Struct.class)
-      .add(List.class)
-      .add(Map.class)
-      .build();
-
-  private static final String UDAF_PACKAGE = "io.confluent.ksql.function.udaf.";
   private static final SqlTypeParser typeParser = SqlTypeParser.create(TypeRegistry.EMPTY);
 
   @SuppressWarnings("OptionalUsedAsFieldOrParameterType")
@@ -97,15 +67,55 @@ public class UdfCompiler {
     this.metrics = Objects.requireNonNull(metrics, "metrics can't be null");
   }
 
+
+  KsqlFunction compileFunction(final Method method,
+                               final String functionName,
+                               final ClassLoader loader,
+                               final Class<? extends Kudf> udfClass,
+                               final String path,
+                               final String sensorName,
+                               final Function<List<Schema>, Schema> returnSchema) {
+
+    final Udf udfAnnotation = method.getAnnotation(Udf.class);
+
+    validateMethodSignature(method);
+    validateParameters(method);
+    final List<Schema> parameters = parseUdfInputParameters(method, functionName);
+    final Schema javaReturnSchema = getReturnType(method, udfAnnotation);
+    final UdfInvoker udf =  generateCode(method, functionName, loader);
+    final Function<KsqlConfig, Kudf> udfFactory = getUdfFactory(method,
+                                                                functionName,
+                                                                udf,
+                                                                metrics,
+                                                                sensorName);
+
+    return KsqlFunction.create(
+        returnSchema,
+        javaReturnSchema,
+        parameters,
+        functionName,
+        udfClass,
+        udfFactory,
+        udfAnnotation.description(),
+        path,
+        method.isVarArgs());
+  }
+
   @VisibleForTesting
-  public static UdfInvoker compile(final Method method, final ClassLoader loader) {
+  public static UdfInvoker generateCode(final Method method,
+                                        final String functionName,
+                                        final ClassLoader loader) {
     try {
-      validateUdfMethodSignature(method);
-      validateUdfInputParameters(method);
       final IScriptEvaluator scriptEvaluator = createScriptEvaluator(method,
           loader,
           method.getDeclaringClass().getName());
       final String code = UdfTemplate.generateCode(method, "thiz");
+
+      LOGGER.trace("Generated class for functionName={}, method={} class\n{}\n",
+                   functionName,
+                   method.getName(),
+                   code);
+
       return (UdfInvoker) scriptEvaluator.createFastEvaluator(code,
           UdfInvoker.class, new String[]{"thiz", "args"});
     } catch (final KsqlException e) {
@@ -116,98 +126,54 @@ public class UdfCompiler {
     }
   }
 
-  KsqlAggregateFunction<?, ?, ?> compileAggregate(
-      final Method method,
-      final ClassLoader loader,
-      final String functionName,
-      final String description
-  ) {
+  private static Function<KsqlConfig, Kudf> getUdfFactory(final Method method,
+                                                          final String functionName,
+                                                          final UdfInvoker udf,
+                                                          final Optional<Metrics> metrics,
+                                                          final String sensorName) {
+    return ksqlConfig -> {
+      final Object actualUdf = instantiateUdfClass(method, functionName);
+      if (actualUdf instanceof Configurable) {
+        ((Configurable)actualUdf)
+            .configure(ksqlConfig.getKsqlFunctionsConfigProps(functionName));
+      }
+      final PluggableUdf theUdf = new PluggableUdf(udf, actualUdf, method);
+      return metrics.<Kudf>map(m -> new UdfMetricProducer(m.getSensor(sensorName),
+                                                          theUdf,
+                                                          Time.SYSTEM)).orElse(theUdf);
+    };
+  }
 
-    final String functionInfo = String.format("method='%s', functionName='%s', UDFClass='%s'",
-                                      method.getName(), functionName, method.getDeclaringClass());
-
-    validateUdafMethodSignature(method, functionName);
-    validateUdafInputParameters(method);
-
-    final UdafTypes types = new UdafTypes(method, functionName);
-    final Schema inputValue = types.getInputSchema();
-    final List<Schema> args = Collections.singletonList(inputValue);
-    final Schema aggregateValue = types.getAggregateSchema();
-    final Schema returnValue = types.getOutputSchema();
-
+  private static Object instantiateUdfClass(final Method method,
+                                            final String functioName) {
     try {
-      final String generatedClassName
-          = method.getDeclaringClass().getSimpleName() + "_" + method.getName() + "_Aggregate";
-      final String udafClass = generateUdafClass(generatedClassName,
-          method,
-          functionName,
-          description);
-
-      LOGGER.trace("Generated class for functionName={}, method={} class\n{}\n",
-          functionName,
-          method.getName(),
-          udafClass);
-
-      final ClassLoader javaSourceClassLoader
-          = createJavaSourceClassLoader(loader, generatedClassName, udafClass);
-      final IScriptEvaluator scriptEvaluator =
-          createScriptEvaluator(method,
-              javaSourceClassLoader,
-              UDAF_PACKAGE + generatedClassName);
-      final UdfArgSupplier evaluator = (UdfArgSupplier)
-          scriptEvaluator.createFastEvaluator("return new " + generatedClassName
-                  + "(args, aggregateType, outputType, metrics);",
-              UdfArgSupplier.class, new String[]{"args", "aggregateType", "outputType", "metrics"});
-
-      return evaluator.apply(args, aggregateValue, returnValue, metrics);
+      return method.getDeclaringClass().newInstance();
     } catch (final Exception e) {
-      throw new KsqlException("Failed to compile KSqlAggregateFunction for method='"
-          + method.getName() + "' in class='" + method.getDeclaringClass() + "'", e);
+      throw new KsqlException("Failed to create instance for UDF="
+                                  + functioName
+                                  + ", method=" + method,
+                              e);
     }
   }
 
-  private class UdafTypes {
+  private Schema getReturnType(final Method method, final Udf udfAnnotation) {
+    try {
+      final Schema returnType = udfAnnotation.schema().isEmpty()
+          ? UdfUtil.getSchemaFromType(method.getGenericReturnType())
+          : SchemaConverters
+              .sqlToConnectConverter()
+              .toConnectSchema(
+                  typeParser.parse(udfAnnotation.schema()).getSqlType());
 
-    private final Type inputType;
-    private final Type aggregateType;
-    private final Type outputType;
-    private final Method method;
-    private final Optional<UdafFactory> annotation;
-
-    UdafTypes(final Method m, final String functionInfo) {
-      this.method = Objects.requireNonNull(m);
-      final AnnotatedParameterizedType annotatedReturnType
-          = (AnnotatedParameterizedType) method.getAnnotatedReturnType();
-      final ParameterizedType type = (ParameterizedType) annotatedReturnType.getType();
-      this.annotation = method.getAnnotation(UdafFactory.class) == null
-          ? Optional.empty() : Optional.of(method.getAnnotation(UdafFactory.class));
-
-      inputType = type.getActualTypeArguments()[0];
-      aggregateType = type.getActualTypeArguments()[1];
-      outputType = type.getActualTypeArguments()[2];
-    }
-
-    Schema getInputSchema() {
-      final Optional<String> inSchema = annotation.map(UdafFactory::paramSchema).filter(
-          val -> !val.isEmpty());
-      return parseParameter(inputType, inSchema, "paramSchema", "", "");
-    }
-
-    Schema getAggregateSchema() {
-      final Optional<String> aggSchema = annotation.map(UdafFactory::aggregateSchema).filter(
-          val -> !val.isEmpty());
-      return parseParameter(aggregateType, aggSchema, "aggregateSchema", "", "");
-    }
-
-    Schema getOutputSchema() {
-      final Optional<String> outSchema = annotation.map(UdafFactory::returnSchema).filter(
-          val -> !val.isEmpty());
-      return parseParameter(outputType, outSchema, "returnSchema", "", "");
+      return SchemaUtil.ensureOptional(returnType);
+    } catch (final KsqlException e) {
+      throw new KsqlException("Could not load UDF method with signature: " + method, e);
     }
   }
+
 
   static List<Schema> parseUdfInputParameters(final Method method,
-                                              final UdfDescription classLevelAnnotation) {
+                                              final String functionName) {
 
     final List<Schema> inputSchemas = new ArrayList<>(method.getParameterCount());
     for (int idx = 0; idx < method.getParameterCount(); idx++) {
@@ -228,7 +194,7 @@ public class UdfCompiler {
             String.format("Cannot resolve parameter name for param at index %d for UDF %s:%s. "
                               + "Please specify a name in @UdfParameter or compile your JAR with"
                               + " -parameters to infer the name from the parameter name.",
-                          idx, classLevelAnnotation.name(), method.getName()));
+                          idx, functionName, method.getName()));
       }
 
       final String doc = annotation.map(UdfParameter::description).orElse("");
@@ -241,197 +207,8 @@ public class UdfCompiler {
     return inputSchemas;
   }
 
-  private static Schema parseParameter(final Type type,
-                                       final Optional<String> schemaString,
-                                       final String msg,
-                                       final String name,
-                                       final String doc) {
+  static void validateParameters(final Method method) {
 
-    validateStructAnnotation(type, schemaString, msg);
-    return SchemaUtil.ensureOptional(getSchemaFromInputParameter(type, schemaString, name, doc));
-  }
-
-  private static Schema getSchemaFromInputParameter(final Type type,
-                                                    final Optional<String> paramSchema,
-                                                    final String paramName,
-                                                    final String paramDoc) {
-
-    Objects.requireNonNull(paramName);
-    Objects.requireNonNull(paramDoc);
-    if (paramSchema.isPresent()) {
-      return SchemaConverters.sqlToConnectConverter().toConnectSchema(
-          typeParser.parse(paramSchema.get()).getSqlType(), paramName, paramDoc);
-    }
-
-    return UdfUtil.getSchemaFromType(type, paramName, paramDoc);
-  }
-
-  private static void validateUdfInputParameters(final Method method) {
-
-    final Class<?>[] types = method.getParameterTypes();
-    for (int i = 0; i < types.length; i++) {
-      final Class<?> type = types[i];
-
-      if (method.getGenericParameterTypes()[i] instanceof TypeVariable
-          || method.getGenericParameterTypes()[i] instanceof GenericArrayType) {
-        // this is the case where the type parameter is generic
-        continue;
-      }
-
-      if (!UdfCompiler.isUnsupportedType(type)) {
-        throw new KsqlException(
-            String.format(
-                "Type %s is not supported by UDF methods. "
-                    + "Supported types %s. method=%s, class=%s",
-                type,
-                SUPPORTED_TYPES,
-                method.getName(),
-                method.getDeclaringClass()
-            )
-        );
-      }
-    }
-  }
-
-  private static void validateUdafInputParameters(final Method method) {
-
-    final AnnotatedParameterizedType annotatedReturnType
-        = (AnnotatedParameterizedType) method.getAnnotatedReturnType();
-    final ParameterizedType parameterizedType = (ParameterizedType) annotatedReturnType.getType();
-
-    final Type[] types = parameterizedType.getActualTypeArguments();
-    for (int i = 0; i < types.length; i++) {
-      final Type type = types[i];
-
-      if (type instanceof TypeVariable || type instanceof GenericArrayType) {
-        // this is the case where the type parameter is generic
-        continue;
-      }
-
-      if (!UdfCompiler.isUnsupportedType((Class<?>) getRawType(type))) {
-        throw new KsqlException(
-            String.format(
-                "Type %s is not supported by UDAF methods. "
-                    + "Supported types %s. method=%s, class=%s",
-                type,
-                SUPPORTED_TYPES,
-                method.getName(),
-                method.getDeclaringClass()
-            )
-        );
-      }
-    }
-  }
-
-  private static void validateStructAnnotation(final Type type,
-                                               final Optional<String> schema,
-                                               final String msg) {
-
-    if (type.equals(Struct.class) && !schema.isPresent()) {
-      throw new KsqlException(String.format("Must specify '%s' for STRUCT parameter in "
-                                                + "@UdafFactory.", msg));
-    }
-  }
-
-  private static Type getRawType(final Type type) {
-    if (type instanceof ParameterizedType) {
-      return ((ParameterizedType) type).getRawType();
-    }
-    return type;
-  }
-
-  private static void validateUdafMethodSignature(final Method method, final String functionName) {
-    final String functionInfo = String.format("method='%s', functionName='%s', UDFClass='%s'",
-                                              method.getName(),
-                                              functionName,
-                                              method.getDeclaringClass());
-
-    if (!(Udaf.class.equals(method.getReturnType())
-        || TableUdaf.class.equals(method.getReturnType()))) {
-      throw new KsqlException("UDAFs must implement " + Udaf.class.getName() + " or "
-                                  + TableUdaf.class.getName() + " ."
-                                  + functionInfo);
-    }
-  }
-
-
-  private static void validateUdfMethodSignature(final Method method) {
-    for (int i = 0; i < method.getParameterTypes().length; i++) {
-      if (method.getParameterTypes()[i].isArray()) {
-        if (!method.isVarArgs() || i != method.getParameterCount() - 1) {
-          throw new KsqlFunctionException(
-              "Invalid UDF method signature (contains non var-arg array): " + method);
-        }
-      }
-    }
-  }
-
-  private static JavaSourceClassLoader createJavaSourceClassLoader(
-      final ClassLoader loader,
-      final String generatedClassName,
-      final String udafClass
-  ) {
-    final long lastMod = System.currentTimeMillis();
-    return new JavaSourceClassLoader(loader, new ResourceFinder() {
-      @Override
-      public Resource findResource(final String resource) {
-        if (resource.endsWith(generatedClassName + ".java")) {
-          return new Resource() {
-            @Override
-            public InputStream open() throws IOException {
-              return new ByteArrayInputStream(udafClass.getBytes(StandardCharsets.UTF_8.name()));
-            }
-
-            @Override
-            public String getFileName() {
-              return resource;
-            }
-
-            @Override
-            public long lastModified() {
-              return lastMod;
-            }
-          };
-        }
-        return null;
-      }
-    }, StandardCharsets.UTF_8.name());
-  }
-
-  private static String generateUdafClass(
-      final String generatedClassName,
-      final Method method,
-      final String functionName,
-      final String description
-  ) {
-    validateMethodSignature(method);
-    Arrays.stream(method.getParameterTypes())
-        .filter(UdfCompiler::isUnsupportedType)
-        .findFirst()
-        .ifPresent(type -> {
-          throw new KsqlException(
-              String.format(
-                  "Type %s is not supported by UDAF Factory methods. "
-                      + "Supported types %s. functionName=%s, method=%s, class=%s",
-                  type,
-                  SUPPORTED_TYPES,
-                  functionName,
-                  method.getName(),
-                  method.getDeclaringClass()
-              )
-          );
-        });
-
-    return UdafTemplate.generateCode(method, generatedClassName, functionName, description);
-  }
-
-  /**
-   * Generates code for the given method.
-   * @param method  the UDF to generate the code for
-   * @return String representation of the code that should be compiled for the UDF
-   */
-  private static String generateCode(final Method method) {
-    validateMethodSignature(method);
     final Class<?>[] types = method.getParameterTypes();
     for (int i = 0; i < types.length; i++) {
       final Class<?> type = types[i];
@@ -455,11 +232,9 @@ public class UdfCompiler {
         );
       }
     }
-
-    return UdfTemplate.generateCode(method, "thiz");
   }
 
-  private static void validateMethodSignature(final Method method) {
+  static void validateMethodSignature(final Method method) {
     for (int i = 0; i < method.getParameterTypes().length; i++) {
       if (method.getParameterTypes()[i].isArray()) {
         if (!method.isVarArgs() || i != method.getParameterCount() - 1) {
@@ -468,12 +243,6 @@ public class UdfCompiler {
         }
       }
     }
-  }
-
-  private static boolean isUnsupportedType(final Class<?> type) {
-    return !SUPPORTED_TYPES.contains(type)
-        && (!type.isArray() || !SUPPORTED_TYPES.contains(type.getComponentType()))
-        && SUPPORTED_TYPES.stream().noneMatch(supported -> supported.isAssignableFrom(type));
   }
 
   private static IScriptEvaluator createScriptEvaluator(

--- a/ksql-engine/src/main/java/io/confluent/ksql/function/UdfLoader.java
+++ b/ksql-engine/src/main/java/io/confluent/ksql/function/UdfLoader.java
@@ -52,14 +52,12 @@ import java.util.concurrent.TimeUnit;
 import java.util.function.Function;
 import java.util.function.Predicate;
 import java.util.stream.Collectors;
-import org.apache.kafka.common.Configurable;
 import org.apache.kafka.common.metrics.Metrics;
 import org.apache.kafka.common.metrics.Sensor;
 import org.apache.kafka.common.metrics.stats.Avg;
 import org.apache.kafka.common.metrics.stats.Max;
 import org.apache.kafka.common.metrics.stats.Rate;
 import org.apache.kafka.common.metrics.stats.WindowedCount;
-import org.apache.kafka.common.utils.Time;
 import org.apache.kafka.connect.data.Schema;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -75,7 +73,8 @@ public class UdfLoader {
   private final File pluginDir;
   private final ClassLoader parentClassLoader;
   private final Predicate<String> blacklist;
-  private final UdfCompiler compiler;
+  private final UdfCompiler udfCompiler;
+  private final UdafCompiler udafCompiler;
   @SuppressWarnings("OptionalUsedAsFieldOrParameterType")
   private final Optional<Metrics> metrics;
   private final boolean loadCustomerUdfs;
@@ -88,7 +87,8 @@ public class UdfLoader {
       final File pluginDir,
       final ClassLoader parentClassLoader,
       final Predicate<String> blacklist,
-      final UdfCompiler compiler,
+      final UdfCompiler udfCompiler,
+      final UdafCompiler udafCompiler,
       final Optional<Metrics> metrics,
       final boolean loadCustomerUdfs
   ) {
@@ -98,7 +98,8 @@ public class UdfLoader {
     this.parentClassLoader = Objects.requireNonNull(parentClassLoader,
         "parentClassLoader can't be null");
     this.blacklist = Objects.requireNonNull(blacklist, "blacklist can't be null");
-    this.compiler = Objects.requireNonNull(compiler, "compiler can't be null");
+    this.udfCompiler = Objects.requireNonNull(udfCompiler, "compiler can't be null");
+    this.udafCompiler = Objects.requireNonNull(udafCompiler, "compiler can't be null");
     this.metrics = Objects.requireNonNull(metrics, "metrics can't be null");
     this.loadCustomerUdfs = loadCustomerUdfs;
     this.typeParser = SqlTypeParser.create(TypeRegistry.EMPTY);
@@ -197,7 +198,7 @@ public class UdfLoader {
                   udafAnnotation.name(),
                   path,
                   method.getDeclaringClass());
-              return Optional.of(compiler.compileAggregate(method,
+              return Optional.of(udafCompiler.compileAggregate(method,
                   loader,
                   udafAnnotation.name(),
                   annotation.description()
@@ -254,22 +255,13 @@ public class UdfLoader {
   }
 
   private void handleUdfAnnotation(final Class<?> theClass,
-                                   final UdfDescription annotation,
+                                   final UdfDescription classLevelAnnotation,
                                    final Method method,
                                    final ClassLoader classLoader,
                                    final String path) {
 
-    LOGGER.info("Adding UDF name='{}' from class={}", annotation.name(), theClass);
-    final UdfInvoker udf = UdfCompiler.compile(method, classLoader);
-    addFunction(theClass, annotation, method, udf, path);
-  }
+    LOGGER.info("Adding UDF name='{}' from class={}", classLevelAnnotation.name(), theClass);
 
-
-  private void addFunction(final Class theClass,
-                           final UdfDescription classLevelAnnotation,
-                           final Method method,
-                           final UdfInvoker udf,
-                           final String path) {
     // sanity check
     instantiateUdfClass(method, classLevelAnnotation);
     final Udf udfAnnotation = method.getAnnotation(Udf.class);
@@ -280,47 +272,36 @@ public class UdfLoader {
     final Class<? extends Kudf> udfClass = metrics
         .map(m -> (Class)UdfMetricProducer.class)
         .orElse(PluggableUdf.class);
+
     addSensor(sensorName, functionName);
 
     LOGGER.info("Adding function " + functionName + " for method " + method);
-    functionRegistry.ensureFunctionFactory(new UdfFactory(udfClass,
+    functionRegistry.ensureFunctionFactory(new UdfFactory(
+        udfClass,
         new UdfMetadata(functionName,
-            classLevelAnnotation.description(),
-            classLevelAnnotation.author(),
-            classLevelAnnotation.version(),
-            path,
-            false)));
-
-    final List<Schema> parameters = UdfCompiler.parseUdfInputParameters(
-        method,
-        classLevelAnnotation);
+                        classLevelAnnotation.description(),
+                        classLevelAnnotation.author(),
+                        classLevelAnnotation.version(),
+                        path,
+                        false)));
 
     final Schema javaReturnSchema = getReturnType(method, udfAnnotation);
 
-    functionRegistry.addFunction(KsqlFunction.create(
-        handleUdfReturnSchema(theClass,
-                              javaReturnSchema,
-                              udfAnnotation,
-                              classLevelAnnotation),
+    final Function<List<Schema>, Schema> returnSchema = handleUdfReturnSchema(
+        theClass,
         javaReturnSchema,
-        parameters,
-        functionName,
-        udfClass,
-        ksqlConfig -> {
-          final Object actualUdf = instantiateUdfClass(method, classLevelAnnotation);
-          if (actualUdf instanceof Configurable) {
-            ((Configurable)actualUdf)
-                .configure(ksqlConfig.getKsqlFunctionsConfigProps(functionName));
-          }
-          final PluggableUdf theUdf = new PluggableUdf(udf, actualUdf, method);
-          return metrics.<Kudf>map(m -> new UdfMetricProducer(m.getSensor(sensorName),
-              theUdf,
-              Time.SYSTEM)).orElse(theUdf);
-        }, udfAnnotation.description(),
-        path,
-        method.isVarArgs()));
-  }
+        udfAnnotation,
+        classLevelAnnotation);
 
+    functionRegistry.addFunction(udfCompiler.compileFunction(
+        method,
+        classLevelAnnotation.name(),
+        classLoader,
+        udfClass,
+        path,
+        sensorName,
+        returnSchema));
+  }
 
   private static Object instantiateUdfClass(final Method method,
                                             final UdfDescription annotation) {
@@ -454,13 +435,13 @@ public class UdfLoader {
       System.setSecurityManager(ExtensionSecurityManager.INSTANCE);
     }
     return new UdfLoader(metaStore,
-        pluginDir,
-        Thread.currentThread().getContextClassLoader(),
-        new Blacklist(new File(pluginDir, "resource-blacklist.txt")),
-        new UdfCompiler(metrics),
-        metrics,
-        loadCustomerUdfs
-    );
+                         pluginDir,
+                         Thread.currentThread().getContextClassLoader(),
+                         new Blacklist(new File(pluginDir, "resource-blacklist.txt")),
+                         new UdfCompiler(metrics),
+                         new UdafCompiler(metrics),
+                         metrics,
+                         loadCustomerUdfs);
   }
 
   private Schema getReturnType(final Method method, final Udf udfAnnotation) {

--- a/ksql-engine/src/main/java/io/confluent/ksql/function/UdfLoaderUtil.java
+++ b/ksql-engine/src/main/java/io/confluent/ksql/function/UdfLoaderUtil.java
@@ -20,14 +20,19 @@ import java.io.File;
 import java.util.Optional;
 
 public final class UdfLoaderUtil {
-  private UdfLoaderUtil() {}
+  private UdfLoaderUtil() {
+
+  }
 
   public static FunctionRegistry load(final MutableFunctionRegistry functionRegistry) {
     new UdfLoader(functionRegistry,
         new File("src/test/resources/udf-example.jar"),
         UdfLoaderUtil.class.getClassLoader(),
-        value -> false, new UdfCompiler(Optional.empty()), Optional.empty(), true
-    )
+        value -> false,
+                  new UdfCompiler(Optional.empty()),
+                  new UdafCompiler(Optional.empty()),
+                  Optional.empty(),
+                  true)
         .load();
 
     return functionRegistry;

--- a/ksql-engine/src/test/java/TestUdfWithNoPackage.java
+++ b/ksql-engine/src/test/java/TestUdfWithNoPackage.java
@@ -36,7 +36,7 @@ public class TestUdfWithNoPackage {
     // When:
     // motivated by https://github.com/square/javapoet/pull/723
     final UdfInvoker udf = UdfCompiler
-        .compile(getClass().getMethod("udf"), this.getClass().getClassLoader());
+        .generateCode(getClass().getMethod("udf"), "test", this.getClass().getClassLoader());
 
     // Then:
     assertThat(udf.eval(this), is("udf"));

--- a/ksql-engine/src/test/java/io/confluent/ksql/function/UdfCompilerTest.java
+++ b/ksql-engine/src/test/java/io/confluent/ksql/function/UdfCompilerTest.java
@@ -26,6 +26,8 @@ import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import io.confluent.ksql.execution.function.TableAggregationFunction;
 import io.confluent.ksql.function.udaf.TestUdaf;
 import io.confluent.ksql.function.udaf.Udaf;
+import io.confluent.ksql.function.udaf.UdafFactory;
+import io.confluent.ksql.function.udf.PluggableUdf;
 import io.confluent.ksql.util.KsqlException;
 import java.util.Arrays;
 import java.util.Collections;
@@ -52,101 +54,105 @@ public class UdfCompilerTest {
   public final ExpectedException expectedException = ExpectedException.none();
   private final ClassLoader classLoader = UdfCompilerTest.class.getClassLoader();
   private final UdfCompiler udfCompiler = new UdfCompiler(Optional.empty());
+  private final UdafCompiler udafCompiler = new UdafCompiler(Optional.empty());
 
   @Test
   public void shouldCompileFunctionWithMapArgument() throws Exception {
-    final UdfInvoker udf = UdfCompiler.compile(getClass().getMethod("udf", Map.class), classLoader);
+    final UdfInvoker udf = UdfCompiler.generateCode(getClass().getMethod("udf", Map.class),
+                                                    "test",
+                                                    classLoader);
     assertThat(udf.eval(this, Collections.emptyMap()), equalTo("{}"));
   }
 
   @Test
   public void shouldCompileFunctionWithListArgument() throws Exception {
     final UdfInvoker udf = UdfCompiler
-        .compile(getClass().getMethod("udf", List.class), classLoader);
+        .generateCode(getClass().getMethod("udf", List.class), "test", classLoader);
     assertThat(udf.eval(this, Collections.emptyList()), equalTo("[]"));
   }
 
   @Test
   public void shouldCompileFunctionWithDoubleArgument() throws Exception {
     final UdfInvoker udf = UdfCompiler
-        .compile(getClass().getMethod("udf", Double.class), classLoader);
+        .generateCode(getClass().getMethod("udf", Double.class), "test", classLoader);
     assertThat(udf.eval(this, 1), equalTo(1.0));
   }
 
   @Test
   public void shouldCompileFunctionWithIntegerArgument() throws Exception {
     final UdfInvoker udf = UdfCompiler
-        .compile(getClass().getMethod("udf", Integer.class), classLoader);
+        .generateCode(getClass().getMethod("udf", Integer.class), "test", classLoader);
     assertThat(udf.eval(this, 1), equalTo(1));
   }
 
   @Test
   public void shouldCompileFunctionWithLongArgument() throws Exception {
     final UdfInvoker udf = UdfCompiler
-        .compile(getClass().getMethod("udf", Long.class), classLoader);
+        .generateCode(getClass().getMethod("udf", Long.class),"test", classLoader);
     assertThat(udf.eval(this, 1), equalTo(1L));
   }
 
   @Test
   public void shouldCompileFunctionWithBooleanArgument() throws Exception {
     final UdfInvoker udf = UdfCompiler
-        .compile(getClass().getMethod("udf", Boolean.class), classLoader);
+        .generateCode(getClass().getMethod("udf", Boolean.class), "test", classLoader);
     assertThat(udf.eval(this, true), equalTo(true));
   }
 
   @Test
   public void shouldCompileFunctionWithIntArgument() throws Exception {
     final UdfInvoker udf = UdfCompiler
-        .compile(getClass().getMethod("udfPrimitive", int.class), classLoader);
+        .generateCode(getClass().getMethod("udfPrimitive", int.class), "test", classLoader);
     assertThat(udf.eval(this, 1), equalTo(1));
   }
 
   @Test
   public void shouldCompileFunctionWithIntVarArgs() throws Exception {
     final UdfInvoker udf = UdfCompiler
-        .compile(getClass().getMethod("udfPrimitive", int[].class), classLoader);
+        .generateCode(getClass().getMethod("udfPrimitive", int[].class), "test", classLoader);
     assertThat(udf.eval(this, (Object) new int[]{1, 1}), equalTo(2));
   }
 
   @Test
   public void shouldCompileFunctionWithPrimitiveLongArgument() throws Exception {
     final UdfInvoker udf = UdfCompiler
-        .compile(getClass().getMethod("udfPrimitive", long.class), classLoader);
+        .generateCode(getClass().getMethod("udfPrimitive", long.class), "test", classLoader);
     assertThat(udf.eval(this, 1), equalTo(1L));
   }
 
   @Test
   public void shouldCompileFunctionWithPrimitiveDoubleArgument() throws Exception {
     final UdfInvoker udf = UdfCompiler
-        .compile(getClass().getMethod("udfPrimitive", double.class), classLoader);
+        .generateCode(getClass().getMethod("udfPrimitive", double.class), "test", classLoader);
     assertThat(udf.eval(this, 1), equalTo(1.0));
   }
 
   @Test
   public void shouldCompileFunctionWithPrimitiveBooleanArgument() throws Exception {
     final UdfInvoker udf = UdfCompiler
-        .compile(getClass().getMethod("udfPrimitive", boolean.class), classLoader);
+        .generateCode(getClass().getMethod("udfPrimitive", boolean.class), "test", classLoader);
     assertThat(udf.eval(this, true), equalTo(true));
   }
 
   @Test
   public void shouldCompileFunctionWithStringArgument() throws Exception {
     final UdfInvoker udf = UdfCompiler
-        .compile(getClass().getMethod("udf", String.class), classLoader);
+        .generateCode(getClass().getMethod("udf", String.class), "test", classLoader);
     assertThat(udf.eval(this, "foo"), equalTo("foo"));
   }
 
   @Test
   public void shouldCompileFunctionWithStringVarArgs() throws Exception {
     final UdfInvoker udf = UdfCompiler
-        .compile(getClass().getMethod("udf", String[].class), classLoader);
+        .generateCode(getClass().getMethod("udf", String[].class), "test", classLoader);
     assertThat(udf.eval(this, (Object) new String[]{"foo", "bar"}), equalTo("foobar"));
   }
 
   @Test
   public void shouldHandleMethodsWithMultipleArguments() throws Exception {
-    final UdfInvoker udf = UdfCompiler.compile(
+    final UdfInvoker udf = UdfCompiler.generateCode(
         getClass().getMethod("multi", int.class, long.class, double.class),
+        "test",
         classLoader);
 
     assertThat(udf.eval(this, 1, 2, 3), equalTo(6.0));
@@ -154,8 +160,9 @@ public class UdfCompilerTest {
 
   @Test
   public void shouldHandleMethodsWithGenericArguments() throws Exception {
-    final UdfInvoker udf = UdfCompiler.compile(
+    final UdfInvoker udf = UdfCompiler.generateCode(
         getClass().getMethod("generic", int.class, Object.class),
+        "test",
         classLoader);
 
     assertThat(udf.eval(this, 1, "hi"), equalTo("hi"));
@@ -163,8 +170,9 @@ public class UdfCompilerTest {
 
   @Test
   public void shouldHandleMethodsWithParameterizedGenericArguments() throws Exception {
-    final UdfInvoker udf = UdfCompiler.compile(
+    final UdfInvoker udf = UdfCompiler.generateCode(
         getClass().getMethod("generic", int.class, List.class),
+        "test",
         classLoader);
 
     assertThat(udf.eval(this, 1, ImmutableList.of("hi")), equalTo("hi"));
@@ -173,7 +181,7 @@ public class UdfCompilerTest {
   @Test
   public void shouldCompileUdafWithMethodWithNoArgs() throws Exception {
     final KsqlAggregateFunction function
-        = udfCompiler.compileAggregate(TestUdaf.class.getMethod("createSumLong"),
+        = udafCompiler.compileAggregate(TestUdaf.class.getMethod("createSumLong"),
         classLoader,
         "test-udf",
         "desc");
@@ -185,21 +193,21 @@ public class UdfCompilerTest {
   @Test
   public void shouldCompileFunctionWithStructReturnValue() throws Exception {
     final UdfInvoker udf = UdfCompiler
-        .compile(getClass().getMethod("udfStruct", String.class), classLoader);
+        .generateCode(getClass().getMethod("udfStruct", String.class), "test", classLoader);
     assertThat(udf.eval(this, "val"), equalTo(new Struct(STRUCT_SCHEMA).put("a", "val")));
   }
 
   @Test
   public void shouldCompileFunctionWithStructParameter() throws Exception {
     final UdfInvoker udf = UdfCompiler
-        .compile(getClass().getMethod("udfStruct", Struct.class), classLoader);
+        .generateCode(getClass().getMethod("udfStruct", Struct.class), "test", classLoader);
     assertThat(udf.eval(this, new Struct(STRUCT_SCHEMA).put("a", "val")), equalTo("val"));
   }
 
   @Test
   public void shouldImplementTableAggregateFunctionWhenTableUdafClass() throws Exception {
     final KsqlAggregateFunction function
-        = udfCompiler.compileAggregate(TestUdaf.class.getMethod("createSumLong"),
+        = udafCompiler.compileAggregate(TestUdaf.class.getMethod("createSumLong"),
         classLoader,
         "test-udf",
         "desc");
@@ -209,7 +217,7 @@ public class UdfCompilerTest {
   @Test
   public void shouldCompileUdafWhenMethodHasArgs() throws Exception {
     final KsqlAggregateFunction function
-        = udfCompiler.compileAggregate(TestUdaf.class.getMethod("createSumLengthString",
+        = udafCompiler.compileAggregate(TestUdaf.class.getMethod("createSumLengthString",
         String.class),
         classLoader,
         "test-udf",
@@ -226,9 +234,9 @@ public class UdfCompilerTest {
   @Test
   public void shouldCollectMetricsForUdafsWhenEnabled() throws Exception {
     final Metrics metrics = new Metrics();
-    final UdfCompiler udfCompiler = new UdfCompiler(Optional.of(metrics));
+    final UdafCompiler udafCompiler = new UdafCompiler(Optional.of(metrics));
     final KsqlAggregateFunction function
-        = udfCompiler.compileAggregate(TestUdaf.class.getMethod("createSumLong"),
+        = udafCompiler.compileAggregate(TestUdaf.class.getMethod("createSumLong"),
         classLoader,
         "test-udf",
         "desc");
@@ -246,14 +254,18 @@ public class UdfCompilerTest {
 
   @Test(expected = KsqlException.class)
   public void shouldThrowIfUnsupportedArgumentType() throws Exception {
-    UdfCompiler.compile(
-        getClass().getMethod("udf", Set.class),
-        classLoader);
+    udfCompiler.compileFunction(UdfCompilerTest.class.getMethod("udf", Set.class),
+                                "test",
+                                classLoader,
+                                PluggableUdf.class,
+                                "test",
+                                "sensor",
+                                ignored -> {return Schema.OPTIONAL_STRING_SCHEMA;});
   }
 
   @Test(expected = KsqlException.class)
   public void shouldThrowIfUnsupportedInputType() throws Exception {
-    udfCompiler.compileAggregate(UdfCompilerTest.class.getMethod("invalidInputTypeUdaf"),
+    udafCompiler.compileAggregate(UdfCompilerTest.class.getMethod("invalidInputTypeUdaf"),
                                  classLoader,
                                  "test",
                                  "desc");
@@ -267,7 +279,7 @@ public class UdfCompilerTest {
         "Must specify 'paramSchema' for STRUCT parameter in @UdafFactory.");
 
     // When:
-    udfCompiler.compileAggregate(
+    udafCompiler.compileAggregate(
         UdfCompilerTest.class.getMethod("missingInputSchemaAnnotationUdaf"),
         classLoader,
         "test",
@@ -282,7 +294,7 @@ public class UdfCompilerTest {
         "Must specify 'aggregateSchema' for STRUCT parameter in @UdafFactory.");
 
     // When:
-    udfCompiler.compileAggregate(
+    udafCompiler.compileAggregate(
         UdfCompilerTest.class.getMethod("missingAggregateSchemaAnnotationUdaf"),
         classLoader,
         "test",
@@ -297,7 +309,7 @@ public class UdfCompilerTest {
         "Must specify 'returnSchema' for STRUCT parameter in @UdafFactory.");
 
     // When:
-    udfCompiler.compileAggregate(
+    udafCompiler.compileAggregate(
         UdfCompilerTest.class.getMethod("missingOutputSchemaAnnotationUdaf"),
         classLoader,
         "test",
@@ -309,18 +321,26 @@ public class UdfCompilerTest {
   public void shouldThrowIfArrayWithoutVarArgs() throws Exception {
     expectedException.expect(KsqlFunctionException.class);
     expectedException.expectMessage("Invalid UDF method signature (contains non var-arg array)");
-    UdfCompiler.compile(
-        getClass().getMethod("invalidUdf", int[].class),
-        classLoader);
+    udfCompiler.compileFunction(UdfCompilerTest.class.getMethod("invalidUdf", int[].class),
+                                "test",
+                                classLoader,
+                                PluggableUdf.class,
+                                "test",
+                                "sensor",
+                                ignored -> {return Schema.OPTIONAL_STRING_SCHEMA;});
   }
 
   @Test
   public void shouldThrowIfArrayAndVarArgs() throws Exception {
     expectedException.expect(KsqlFunctionException.class);
     expectedException.expectMessage("Invalid UDF method signature (contains non var-arg array):");
-    UdfCompiler.compile(
-        getClass().getMethod("invalidUdf", int[].class, int[].class),
-        classLoader);
+    udfCompiler.compileFunction(UdfCompilerTest.class.getMethod("invalidUdf", int[].class, int[].class),
+                                "test",
+                                classLoader,
+                                PluggableUdf.class,
+                                "test",
+                                "sensor",
+                                ignored -> {return Schema.OPTIONAL_STRING_SCHEMA;});
   }
 
   @Test
@@ -329,7 +349,9 @@ public class UdfCompilerTest {
     expectedException.expect(KsqlFunctionException.class);
     expectedException.expectMessage("Can't coerce argument at index 0 from null to a primitive type");
     final UdfInvoker udf =
-        UdfCompiler.compile(getClass().getMethod("udfPrimitive", double.class), classLoader);
+        UdfCompiler.generateCode(getClass().getMethod("udfPrimitive", double.class),
+                                 "test",
+                                 classLoader);
     udf.eval(this, new Object[]{null});
   }
 
@@ -339,7 +361,7 @@ public class UdfCompilerTest {
     expectedException.expectMessage("UDAFs must implement io.confluent.ksql.function.udaf.Udaf "
         + "or io.confluent.ksql.function.udaf.TableUdaf. method='createBlah', functionName='test',"
         + " UDFClass='class io.confluent.ksql.function.UdfCompilerTest'");
-    udfCompiler.compileAggregate(UdfCompilerTest.class.getMethod("createBlah"),
+    udafCompiler.compileAggregate(UdfCompilerTest.class.getMethod("createBlah"),
         classLoader,
         "test",
         "desc");
@@ -347,7 +369,7 @@ public class UdfCompilerTest {
 
   @Test
   public void shouldHandleUdafsWithLongValTypeDoubleAggType() throws Exception {
-    udfCompiler.compileAggregate(UdfCompilerTest.class.getMethod("createLongDouble"),
+    udafCompiler.compileAggregate(UdfCompilerTest.class.getMethod("createLongDouble"),
         classLoader,
         "test",
         "desc");
@@ -355,7 +377,7 @@ public class UdfCompilerTest {
 
   @Test
   public void shouldHandleUdafsWithDoubleValTypeLongAggType() throws Exception {
-    udfCompiler.compileAggregate(UdfCompilerTest.class.getMethod("createDoubleLong"),
+    udafCompiler.compileAggregate(UdfCompilerTest.class.getMethod("createDoubleLong"),
         classLoader,
         "test",
         "desc");
@@ -363,7 +385,7 @@ public class UdfCompilerTest {
 
   @Test
   public void shouldHandleUdafsWithIntegerValTypeStringAggType() throws Exception {
-    udfCompiler.compileAggregate(UdfCompilerTest.class.getMethod("createIntegerString"),
+    udafCompiler.compileAggregate(UdfCompilerTest.class.getMethod("createIntegerString"),
         classLoader,
         "test",
         "desc");
@@ -371,7 +393,7 @@ public class UdfCompilerTest {
 
   @Test
   public void shouldHandleUdafsWithStringValTypeIntegerAggType() throws Exception {
-    udfCompiler.compileAggregate(UdfCompilerTest.class.getMethod("createStringInteger"),
+    udafCompiler.compileAggregate(UdfCompilerTest.class.getMethod("createStringInteger"),
         classLoader,
         "test",
         "desc");
@@ -379,7 +401,7 @@ public class UdfCompilerTest {
 
   @Test
   public void shouldHandleUdafsWithBooleanValTypeListAggType() throws Exception {
-    udfCompiler.compileAggregate(UdfCompilerTest.class.getMethod("createBooleanList"),
+    udafCompiler.compileAggregate(UdfCompilerTest.class.getMethod("createBooleanList"),
         classLoader,
         "test",
         "desc");
@@ -387,7 +409,7 @@ public class UdfCompilerTest {
 
   @Test
   public void shouldHandleUdafsWithListValTypeBooleanAggType() throws Exception {
-    udfCompiler.compileAggregate(UdfCompilerTest.class.getMethod("createListBoolean"),
+    udafCompiler.compileAggregate(UdfCompilerTest.class.getMethod("createListBoolean"),
         classLoader,
         "test",
         "desc");
@@ -395,7 +417,7 @@ public class UdfCompilerTest {
 
   @Test
   public void shouldHandleUdafsWithMapValMapAggTypes() throws Exception {
-    udfCompiler.compileAggregate(UdfCompilerTest.class.getMethod("createMapMap"),
+    udafCompiler.compileAggregate(UdfCompilerTest.class.getMethod("createMapMap"),
         classLoader,
         "test",
         "desc");
@@ -403,7 +425,7 @@ public class UdfCompilerTest {
 
   @Test
   public void shouldHandleUdafsWithMapValMapAggTypesAndFactoryArg() throws Exception {
-    udfCompiler.compileAggregate(UdfCompilerTest.class.getMethod("createMapMap", int.class),
+    udafCompiler.compileAggregate(UdfCompilerTest.class.getMethod("createMapMap", int.class),
         classLoader,
         "test",
         "desc");
@@ -411,7 +433,7 @@ public class UdfCompilerTest {
 
   @Test
   public void shouldHandleUdafsWithStructStructTypes() throws Exception {
-    udfCompiler.compileAggregate(UdfCompilerTest.class.getMethod("createStructStruct"),
+    udafCompiler.compileAggregate(UdfCompilerTest.class.getMethod("createStructStruct"),
         classLoader,
         "test",
         "desc");
@@ -419,7 +441,7 @@ public class UdfCompilerTest {
 
   @Test(expected = KsqlException.class)
   public void shouldThrowWhenTryingToGenerateUdafThatHasIncorrectTypes() throws Exception {
-    udfCompiler.compileAggregate(UdfCompilerTest.class.getMethod("createBad"),
+    udafCompiler.compileAggregate(UdfCompilerTest.class.getMethod("createBad"),
         classLoader,
         "test",
         "desc");
@@ -427,7 +449,7 @@ public class UdfCompilerTest {
 
   @Test(expected = KsqlException.class)
   public void shouldThrowWhenUdafFactoryMethodIsntStatic() throws Exception {
-    udfCompiler.compileAggregate(UdfCompilerTest.class.getMethod("createNonStatic"),
+    udafCompiler.compileAggregate(UdfCompilerTest.class.getMethod("createNonStatic"),
         classLoader,
         "test",
         "desc");
@@ -549,6 +571,10 @@ public class UdfCompilerTest {
     return null;
   }
 
+  @UdafFactory(description = "test struct parameters.",
+      paramSchema = "STRUCT<SUM bigint, COUNT bigint>",
+      aggregateSchema = "STRUCT<SUM bigint, COUNT bigint>",
+      returnSchema = "STRUCT<SUM bigint, COUNT bigint>")
   public static Udaf<Struct, Struct, Struct> createStructStruct() {
     return null;
   }

--- a/ksql-engine/src/test/java/io/confluent/ksql/function/UdfCompilerTest.java
+++ b/ksql-engine/src/test/java/io/confluent/ksql/function/UdfCompilerTest.java
@@ -176,10 +176,7 @@ public class UdfCompilerTest {
         = udfCompiler.compileAggregate(TestUdaf.class.getMethod("createSumLong"),
         classLoader,
         "test-udf",
-        "desc",
-        "",
-        "",
-        "");
+        "desc");
     assertThat(function.getInstance(
         new AggregateFunctionArguments(0, Collections.singletonList("udfIndex"))),
         not(nullValue()));
@@ -205,10 +202,7 @@ public class UdfCompilerTest {
         = udfCompiler.compileAggregate(TestUdaf.class.getMethod("createSumLong"),
         classLoader,
         "test-udf",
-        "desc",
-        "",
-        "",
-        "");
+        "desc");
     assertThat(function, instanceOf(TableAggregationFunction.class));
   }
 
@@ -219,10 +213,7 @@ public class UdfCompilerTest {
         String.class),
         classLoader,
         "test-udf",
-        "desc",
-        "",
-        "",
-        "");
+        "desc");
     final KsqlAggregateFunction instance = function.getInstance(
         new AggregateFunctionArguments(0, Arrays.asList("udfIndex", "some string")));
     assertThat(instance,
@@ -240,10 +231,7 @@ public class UdfCompilerTest {
         = udfCompiler.compileAggregate(TestUdaf.class.getMethod("createSumLong"),
         classLoader,
         "test-udf",
-        "desc",
-        "",
-        "",
-        "");
+        "desc");
 
     final KsqlAggregateFunction<Long, Long, Long> executable = function.getInstance(
         new AggregateFunctionArguments(0, Collections.singletonList("udfIndex")));
@@ -268,10 +256,7 @@ public class UdfCompilerTest {
     udfCompiler.compileAggregate(UdfCompilerTest.class.getMethod("invalidInputTypeUdaf"),
                                  classLoader,
                                  "test",
-                                 "desc",
-                                 "",
-                                 "",
-                                 "");
+                                 "desc");
   }
 
   @Test
@@ -286,10 +271,7 @@ public class UdfCompilerTest {
         UdfCompilerTest.class.getMethod("missingInputSchemaAnnotationUdaf"),
         classLoader,
         "test",
-        "desc",
-        "",
-        "",
-        "");
+        "desc");
   }
 
   @Test
@@ -304,10 +286,7 @@ public class UdfCompilerTest {
         UdfCompilerTest.class.getMethod("missingAggregateSchemaAnnotationUdaf"),
         classLoader,
         "test",
-        "desc",
-        "",
-        "",
-        "");
+        "desc");
   }
 
   @Test
@@ -322,10 +301,7 @@ public class UdfCompilerTest {
         UdfCompilerTest.class.getMethod("missingOutputSchemaAnnotationUdaf"),
         classLoader,
         "test",
-        "desc",
-        "",
-        "",
-        ""
+        "desc"
     );
   }
 
@@ -366,10 +342,7 @@ public class UdfCompilerTest {
     udfCompiler.compileAggregate(UdfCompilerTest.class.getMethod("createBlah"),
         classLoader,
         "test",
-        "desc",
-        "",
-        "",
-        "");
+        "desc");
   }
 
   @Test
@@ -377,10 +350,7 @@ public class UdfCompilerTest {
     udfCompiler.compileAggregate(UdfCompilerTest.class.getMethod("createLongDouble"),
         classLoader,
         "test",
-        "desc",
-        "",
-        "",
-        "");
+        "desc");
   }
 
   @Test
@@ -388,10 +358,7 @@ public class UdfCompilerTest {
     udfCompiler.compileAggregate(UdfCompilerTest.class.getMethod("createDoubleLong"),
         classLoader,
         "test",
-        "desc",
-        "",
-        "",
-        "");
+        "desc");
   }
 
   @Test
@@ -399,10 +366,7 @@ public class UdfCompilerTest {
     udfCompiler.compileAggregate(UdfCompilerTest.class.getMethod("createIntegerString"),
         classLoader,
         "test",
-        "desc",
-        "",
-        "",
-        "");
+        "desc");
   }
 
   @Test
@@ -410,10 +374,7 @@ public class UdfCompilerTest {
     udfCompiler.compileAggregate(UdfCompilerTest.class.getMethod("createStringInteger"),
         classLoader,
         "test",
-        "desc",
-        "",
-        "",
-        "");
+        "desc");
   }
 
   @Test
@@ -421,10 +382,7 @@ public class UdfCompilerTest {
     udfCompiler.compileAggregate(UdfCompilerTest.class.getMethod("createBooleanList"),
         classLoader,
         "test",
-        "desc",
-        "",
-        "",
-        "");
+        "desc");
   }
 
   @Test
@@ -432,10 +390,7 @@ public class UdfCompilerTest {
     udfCompiler.compileAggregate(UdfCompilerTest.class.getMethod("createListBoolean"),
         classLoader,
         "test",
-        "desc",
-        "",
-        "",
-        "");
+        "desc");
   }
 
   @Test
@@ -443,10 +398,7 @@ public class UdfCompilerTest {
     udfCompiler.compileAggregate(UdfCompilerTest.class.getMethod("createMapMap"),
         classLoader,
         "test",
-        "desc",
-        "",
-        "",
-        "");
+        "desc");
   }
 
   @Test
@@ -454,10 +406,7 @@ public class UdfCompilerTest {
     udfCompiler.compileAggregate(UdfCompilerTest.class.getMethod("createMapMap", int.class),
         classLoader,
         "test",
-        "desc",
-        "",
-        "",
-        "");
+        "desc");
   }
 
   @Test
@@ -465,10 +414,7 @@ public class UdfCompilerTest {
     udfCompiler.compileAggregate(UdfCompilerTest.class.getMethod("createStructStruct"),
         classLoader,
         "test",
-        "desc",
-        "STRUCT<A VARCHAR>",
-        "STRUCT<B VARCHAR>",
-        "STRUCT<B VARCHAR>");
+        "desc");
   }
 
   @Test(expected = KsqlException.class)
@@ -476,10 +422,7 @@ public class UdfCompilerTest {
     udfCompiler.compileAggregate(UdfCompilerTest.class.getMethod("createBad"),
         classLoader,
         "test",
-        "desc",
-        "",
-        "",
-        "");
+        "desc");
   }
 
   @Test(expected = KsqlException.class)
@@ -487,10 +430,7 @@ public class UdfCompilerTest {
     udfCompiler.compileAggregate(UdfCompilerTest.class.getMethod("createNonStatic"),
         classLoader,
         "test",
-        "desc",
-        "",
-        "",
-        "");
+        "desc");
   }
 
   public String udf(final Set val) {

--- a/ksql-engine/src/test/java/io/confluent/ksql/function/UdfLoaderTest.java
+++ b/ksql-engine/src/test/java/io/confluent/ksql/function/UdfLoaderTest.java
@@ -68,8 +68,8 @@ import org.junit.rules.ExpectedException;
 public class UdfLoaderTest {
 
   private static final ClassLoader PARENT_CLASS_LOADER = UdfLoaderTest.class.getClassLoader();
-  private static final UdfCompiler COMPILER = new UdfCompiler(Optional.empty());
   private static final Metrics METRICS = new Metrics();
+
 
   private static final FunctionRegistry FUNC_REG =
       initializeFunctionRegistry(true, Optional.empty());
@@ -268,7 +268,8 @@ public class UdfLoaderTest {
                                               new File("src/test/resources/udf-failing-tests.jar"),
                                               udfClassLoader,
                                               value -> false,
-                                              COMPILER,
+                                              new UdfCompiler(Optional.empty()),
+                                              new UdafCompiler(Optional.empty()),
                                               Optional.empty(),
                                               true);
 
@@ -295,7 +296,8 @@ public class UdfLoaderTest {
                                               new File("src/test/resources/udf-failing-tests.jar"),
                                               udfClassLoader,
                                               value -> false,
-                                              COMPILER,
+                                              new UdfCompiler(Optional.empty()),
+                                              new UdafCompiler(Optional.empty()),
                                               Optional.empty(),
                                               true);
 
@@ -323,7 +325,8 @@ public class UdfLoaderTest {
                                               new File("src/test/resources/udf-failing-tests.jar"),
                                               udfClassLoader,
                                               value -> false,
-                                              COMPILER,
+                                              new UdfCompiler(Optional.empty()),
+                                              new UdafCompiler(Optional.empty()),
                                               Optional.empty(),
                                               true);
 
@@ -421,7 +424,8 @@ public class UdfLoaderTest {
                                               new File("src/test/resources"),
                                               PARENT_CLASS_LOADER,
                                               value -> false,
-                                              COMPILER,
+                                              new UdfCompiler(Optional.empty()),
+                                              new UdafCompiler(Optional.empty()),
                                               Optional.empty(),
                                               false);
     udfLoader.loadUdfFromClass(UdfLoaderTest.SomeFunctionUdf.class);
@@ -442,7 +446,8 @@ public class UdfLoaderTest {
                                               new File("src/test/resources"),
                                               PARENT_CLASS_LOADER,
                                               value -> false,
-                                              COMPILER,
+                                              new UdfCompiler(Optional.empty()),
+                                              new UdafCompiler(Optional.empty()),
                                               Optional.empty(),
                                               false);
     final List<Schema> args = ImmutableList.of(
@@ -591,13 +596,13 @@ public class UdfLoaderTest {
       final Optional<Metrics> metrics
   ) {
     return new UdfLoader(functionRegistry,
-        new File("src/test/resources/udf-example.jar"),
-        PARENT_CLASS_LOADER,
-        value -> false,
-        COMPILER,
-        metrics,
-        loadCustomerUdfs
-    );
+                         new File("src/test/resources/udf-example.jar"),
+                         PARENT_CLASS_LOADER,
+                         value -> false,
+                         new UdfCompiler(metrics),
+                         new UdafCompiler(metrics),
+                         metrics,
+                         loadCustomerUdfs);
   }
 
   private static ClassLoader getActualUdfClassLoader(final Kudf udf) throws Exception {


### PR DESCRIPTION
### Description 
**Work in progres**
Udafs support different types because the `UdfCompiler` had not been updated. I pulled from the `UdfLoader` the code responsible for validating and parsing parameters for Udfs and put it into a common abstract class, `FunctionCompiler`. Moreover, I created a separate compiler, `UdafCompiler` that handles compiling of udafs. It is easier now to see what is common and what is different when compiling udfs versus udafs. Case in point, for udafs we are testing whether a schema is provided with a struct parameter but we don't do this check for udfs. Moreover, there is no test case for this in `UdfCompilerTest`.

If you agree with this change, then I will proceed to add further test cases.

TODO
1. Create separate test class `UdafCompilerTest`
2. Make sure tests check all validation cases
3. Make sure we throw correct error messages 
4. Move code for parsing return schema of udfs to `UdfCompiler`?
5. I have a test case failing for ksql-cli and I can't figure out why.

### Testing done 
Didn't add new tests, if you agree with the change I will proceed with adding more tests.

### Reviewer checklist
- [ ] Ensure docs are updated if necessary. (eg. if a user visible feature is being added or changed).
- [ ] Ensure relevant issues are linked (description should include text like "Fixes #<issue number>")

