### PR TITLE
refactor: split out ddl creation from CommandFactories

### DIFF
--- a/ksql-engine/src/main/java/io/confluent/ksql/ddl/commands/CreateSourceFactory.java
+++ b/ksql-engine/src/main/java/io/confluent/ksql/ddl/commands/CreateSourceFactory.java
@@ -1,0 +1,251 @@
+/*
+ * Copyright 2019 Confluent Inc.
+ *
+ * Licensed under the Confluent Community License (the "License"); you may not use
+ * this file except in compliance with the License.  You may obtain a copy of the
+ * License at
+ *
+ * http://www.confluent.io/confluent-community-license
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package io.confluent.ksql.ddl.commands;
+
+import com.google.common.annotations.VisibleForTesting;
+import com.google.common.collect.Iterables;
+import io.confluent.ksql.execution.ddl.commands.CreateStreamCommand;
+import io.confluent.ksql.execution.ddl.commands.CreateTableCommand;
+import io.confluent.ksql.execution.ddl.commands.KsqlTopic;
+import io.confluent.ksql.logging.processing.NoopProcessingLogContext;
+import io.confluent.ksql.name.ColumnName;
+import io.confluent.ksql.name.SourceName;
+import io.confluent.ksql.parser.properties.with.CreateSourceProperties;
+import io.confluent.ksql.parser.tree.CreateSource;
+import io.confluent.ksql.parser.tree.CreateStream;
+import io.confluent.ksql.parser.tree.CreateTable;
+import io.confluent.ksql.parser.tree.TableElement.Namespace;
+import io.confluent.ksql.parser.tree.TableElements;
+import io.confluent.ksql.schema.ksql.ColumnRef;
+import io.confluent.ksql.schema.ksql.FormatOptions;
+import io.confluent.ksql.schema.ksql.LogicalSchema;
+import io.confluent.ksql.schema.ksql.PhysicalSchema;
+import io.confluent.ksql.schema.ksql.SqlBaseType;
+import io.confluent.ksql.serde.Format;
+import io.confluent.ksql.serde.GenericRowSerDe;
+import io.confluent.ksql.serde.SerdeOption;
+import io.confluent.ksql.serde.SerdeOptions;
+import io.confluent.ksql.serde.ValueSerdeFactory;
+import io.confluent.ksql.services.ServiceContext;
+import io.confluent.ksql.topic.TopicFactory;
+import io.confluent.ksql.util.KsqlConfig;
+import io.confluent.ksql.util.KsqlException;
+import io.confluent.ksql.util.SchemaUtil;
+import io.confluent.ksql.util.StringUtil;
+import io.confluent.ksql.util.timestamp.TimestampExtractionPolicy;
+import io.confluent.ksql.util.timestamp.TimestampExtractionPolicyFactory;
+import java.util.Objects;
+import java.util.Optional;
+import java.util.Set;
+
+public final class CreateSourceFactory {
+  private final ServiceContext serviceContext;
+  private final SerdeOptionsSupplier serdeOptionsSupplier;
+  private final ValueSerdeFactory serdeFactory;
+
+  public CreateSourceFactory(final ServiceContext serviceContext) {
+    this(serviceContext, SerdeOptions::buildForCreateStatement, new GenericRowSerDe());
+  }
+
+  @VisibleForTesting
+  CreateSourceFactory(
+      final ServiceContext serviceContext,
+      final SerdeOptionsSupplier serdeOptionsSupplier,
+      final ValueSerdeFactory serdeFactory
+  ) {
+    this.serviceContext = Objects.requireNonNull(serviceContext, "serviceContext");
+    this.serdeOptionsSupplier =
+        Objects.requireNonNull(serdeOptionsSupplier, "serdeOptionsSupplier");
+    this.serdeFactory = Objects.requireNonNull(serdeFactory, "serdeFactory");
+  }
+
+  public CreateStreamCommand createStreamCommand(
+      final String statementText,
+      final CreateStream statement,
+      final KsqlConfig ksqlConfig
+  ) {
+    final SourceName sourceName = statement.getName();
+    final KsqlTopic topic = buildTopic(statement.getProperties(), serviceContext);
+    final LogicalSchema schema = buildSchema(statement.getElements());
+    final Optional<ColumnName> keyFieldName = buildKeyFieldName(statement, schema);
+    final TimestampExtractionPolicy timestampExtractionPolicy = buildTimestampExtractor(
+        ksqlConfig,
+        statement.getProperties(),
+        schema
+    );
+    final Set<SerdeOption> serdeOptions = serdeOptionsSupplier.build(
+        schema,
+        topic.getValueFormat().getFormat(),
+        statement.getProperties().getWrapSingleValues(),
+        ksqlConfig
+    );
+    validateSerdeCanHandleSchemas(
+        ksqlConfig,
+        serviceContext,
+        serdeFactory,
+        PhysicalSchema.from(schema, serdeOptions),
+        topic
+    );
+    return new CreateStreamCommand(
+        statementText,
+        sourceName,
+        schema,
+        keyFieldName,
+        timestampExtractionPolicy,
+        serdeOptions,
+        topic
+    );
+  }
+
+  public CreateTableCommand createTableCommand(
+      final String statementText,
+      final CreateTable statement,
+      final KsqlConfig ksqlConfig
+  ) {
+    final SourceName sourceName = statement.getName();
+    final KsqlTopic topic = buildTopic(statement.getProperties(), serviceContext);
+    final LogicalSchema schema = buildSchema(statement.getElements());
+    final Optional<ColumnName> keyFieldName = buildKeyFieldName(statement, schema);
+    final TimestampExtractionPolicy timestampExtractionPolicy = buildTimestampExtractor(
+        ksqlConfig,
+        statement.getProperties(),
+        schema
+    );
+    final Set<SerdeOption> serdeOptions = serdeOptionsSupplier.build(
+        schema,
+        topic.getValueFormat().getFormat(),
+        statement.getProperties().getWrapSingleValues(),
+        ksqlConfig
+    );
+    validateSerdeCanHandleSchemas(
+        ksqlConfig,
+        serviceContext,
+        serdeFactory,
+        PhysicalSchema.from(schema, serdeOptions),
+        topic
+    );
+    return new CreateTableCommand(
+        statementText,
+        sourceName,
+        schema,
+        keyFieldName,
+        timestampExtractionPolicy,
+        serdeOptions,
+        topic
+    );
+  }
+
+  private static Optional<ColumnName> buildKeyFieldName(
+      final CreateSource statement,
+      final LogicalSchema schema) {
+    if (statement.getProperties().getKeyField().isPresent()) {
+      final String name = statement.getProperties().getKeyField().get().toUpperCase();
+      final ColumnName columnName = ColumnName.of(StringUtil.cleanQuotes(name));
+      schema.findValueColumn(ColumnRef.withoutSource(columnName)).orElseThrow(
+          () -> new KsqlException(
+              "The KEY column set in the WITH clause does not exist in the schema: '"
+                  + columnName.toString(FormatOptions.noEscape()) + "'"
+          )
+      );
+      return Optional.of(columnName);
+    } else {
+      return Optional.empty();
+    }
+  }
+
+  private static LogicalSchema buildSchema(final TableElements tableElements) {
+    if (Iterables.isEmpty(tableElements)) {
+      throw new KsqlException("The statement does not define any columns.");
+    }
+
+    tableElements.forEach(e -> {
+      if (e.getName().equals(SchemaUtil.ROWTIME_NAME)) {
+        throw new KsqlException("'" + e.getName().name() + "' is a reserved column name.");
+      }
+
+      final boolean isRowKey = e.getName().equals(SchemaUtil.ROWKEY_NAME);
+
+      if (e.getNamespace() == Namespace.KEY) {
+        if (!isRowKey) {
+          throw new KsqlException("'" + e.getName().name() + "' is an invalid KEY column name. "
+              + "KSQL currently only supports KEY columns named ROWKEY.");
+        }
+
+        if (e.getType().getSqlType().baseType() != SqlBaseType.STRING) {
+          throw new KsqlException("'" + e.getName().name()
+              + "' is a KEY column with an unsupported type. "
+              + "KSQL currently only supports KEY columns of type " + SqlBaseType.STRING + ".");
+        }
+      } else if (isRowKey) {
+        throw new KsqlException("'" + e.getName().name() + "' is a reserved column name. "
+            + "It can only be used for KEY columns.");
+      }
+    });
+
+    return tableElements.toLogicalSchema(true);
+  }
+
+  private static KsqlTopic buildTopic(
+      final CreateSourceProperties properties,
+      final ServiceContext serviceContext
+  ) {
+    final String kafkaTopicName = properties.getKafkaTopic();
+    if (!serviceContext.getTopicClient().isTopicExists(kafkaTopicName)) {
+      throw new KsqlException("Kafka topic does not exist: " + kafkaTopicName);
+    }
+
+    return TopicFactory.create(properties);
+  }
+
+  private static TimestampExtractionPolicy buildTimestampExtractor(
+      final KsqlConfig ksqlConfig,
+      final CreateSourceProperties properties,
+      final LogicalSchema schema
+  ) {
+    final Optional<ColumnRef> timestampName = properties.getTimestampColumnName();
+    final Optional<String> timestampFormat = properties.getTimestampFormat();
+    return TimestampExtractionPolicyFactory
+        .create(ksqlConfig, schema, timestampName, timestampFormat);
+  }
+
+  private static void validateSerdeCanHandleSchemas(
+      final KsqlConfig ksqlConfig,
+      final ServiceContext serviceContext,
+      final ValueSerdeFactory valueSerdeFactory,
+      final PhysicalSchema physicalSchema,
+      final KsqlTopic topic
+  ) {
+    valueSerdeFactory.create(
+        topic.getValueFormat().getFormatInfo(),
+        physicalSchema.valueSchema(),
+        ksqlConfig,
+        serviceContext.getSchemaRegistryClientFactory(),
+        "",
+        NoopProcessingLogContext.INSTANCE
+    ).close();
+  }
+
+  @FunctionalInterface
+  interface SerdeOptionsSupplier {
+
+    Set<SerdeOption> build(
+        LogicalSchema schema,
+        Format valueFormat,
+        Optional<Boolean> wrapSingleValues,
+        KsqlConfig ksqlConfig
+    );
+  }
+}

--- a/ksql-engine/src/main/java/io/confluent/ksql/ddl/commands/DropSourceFactory.java
+++ b/ksql-engine/src/main/java/io/confluent/ksql/ddl/commands/DropSourceFactory.java
@@ -1,0 +1,71 @@
+/*
+ * Copyright 2019 Confluent Inc.
+ *
+ * Licensed under the Confluent Community License (the "License"); you may not use
+ * this file except in compliance with the License.  You may obtain a copy of the
+ * License at
+ *
+ * http://www.confluent.io/confluent-community-license
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package io.confluent.ksql.ddl.commands;
+
+import com.google.common.annotations.VisibleForTesting;
+import io.confluent.ksql.execution.ddl.commands.DropSourceCommand;
+import io.confluent.ksql.metastore.MetaStore;
+import io.confluent.ksql.metastore.model.DataSource;
+import io.confluent.ksql.metastore.model.DataSource.DataSourceType;
+import io.confluent.ksql.name.SourceName;
+import io.confluent.ksql.parser.tree.DropStream;
+import io.confluent.ksql.parser.tree.DropTable;
+import io.confluent.ksql.util.KsqlException;
+import java.util.Objects;
+
+public final class DropSourceFactory {
+  private final MetaStore metaStore;
+
+  @VisibleForTesting
+  DropSourceFactory(final MetaStore metaStore) {
+    this.metaStore = Objects.requireNonNull(metaStore, "metaStore");
+  }
+
+  public DropSourceCommand create(final DropStream statement) {
+    return create(
+        statement.getName(),
+        statement.getIfExists(),
+        DataSourceType.KSTREAM
+    );
+  }
+
+  public DropSourceCommand create(final DropTable statement) {
+    return create(
+        statement.getName(),
+        statement.getIfExists(),
+        DataSourceType.KTABLE
+    );
+  }
+
+  private DropSourceCommand create(
+      final SourceName sourceName,
+      final boolean ifExists,
+      final DataSourceType dataSourceType) {
+    final DataSource<?> dataSource = metaStore.getSource(sourceName);
+    if (dataSource == null) {
+      if (ifExists) {
+        throw new KsqlException("Source " + sourceName.name() + " does not exist.");
+      }
+    } else if (dataSource.getDataSourceType() != dataSourceType) {
+      throw new KsqlException(String.format(
+          "Incompatible data source type is %s, but statement was DROP %s",
+          dataSource.getDataSourceType() == DataSourceType.KSTREAM ? "STREAM" : "TABLE",
+          dataSourceType == DataSourceType.KSTREAM ? "STREAM" : "TABLE"
+      ));
+    }
+    return new DropSourceCommand(sourceName);
+  }
+}

--- a/ksql-engine/src/main/java/io/confluent/ksql/ddl/commands/DropTypeFactory.java
+++ b/ksql-engine/src/main/java/io/confluent/ksql/ddl/commands/DropTypeFactory.java
@@ -1,0 +1,28 @@
+/*
+ * Copyright 2019 Confluent Inc.
+ *
+ * Licensed under the Confluent Community License (the "License"); you may not use
+ * this file except in compliance with the License.  You may obtain a copy of the
+ * License at
+ *
+ * http://www.confluent.io/confluent-community-license
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package io.confluent.ksql.ddl.commands;
+
+import io.confluent.ksql.execution.ddl.commands.DropTypeCommand;
+import io.confluent.ksql.parser.DropType;
+
+public class DropTypeFactory {
+  DropTypeFactory() {
+  }
+
+  public DropTypeCommand create(final DropType statement) {
+    return new DropTypeCommand(statement.getTypeName());
+  }
+}

--- a/ksql-engine/src/main/java/io/confluent/ksql/ddl/commands/RegisterTypeFactory.java
+++ b/ksql-engine/src/main/java/io/confluent/ksql/ddl/commands/RegisterTypeFactory.java
@@ -1,0 +1,31 @@
+/*
+ * Copyright 2019 Confluent Inc.
+ *
+ * Licensed under the Confluent Community License (the "License"); you may not use
+ * this file except in compliance with the License.  You may obtain a copy of the
+ * License at
+ *
+ * http://www.confluent.io/confluent-community-license
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package io.confluent.ksql.ddl.commands;
+
+import io.confluent.ksql.execution.ddl.commands.RegisterTypeCommand;
+import io.confluent.ksql.parser.tree.RegisterType;
+
+public final class RegisterTypeFactory {
+  RegisterTypeFactory() {
+  }
+
+  public RegisterTypeCommand create(final RegisterType statement) {
+    return new RegisterTypeCommand(
+        statement.getType().getSqlType(),
+        statement.getName()
+    );
+  }
+}

--- a/ksql-engine/src/test/java/io/confluent/ksql/ddl/commands/CommandFactoriesTest.java
+++ b/ksql-engine/src/test/java/io/confluent/ksql/ddl/commands/CommandFactoriesTest.java
@@ -15,48 +15,27 @@
 
 package io.confluent.ksql.ddl.commands;
 
-import static io.confluent.ksql.model.WindowType.HOPPING;
-import static io.confluent.ksql.model.WindowType.SESSION;
-import static io.confluent.ksql.model.WindowType.TUMBLING;
-import static io.confluent.ksql.parser.tree.TableElement.Namespace.KEY;
-import static io.confluent.ksql.parser.tree.TableElement.Namespace.VALUE;
-import static io.confluent.ksql.serde.Format.AVRO;
-import static io.confluent.ksql.serde.Format.JSON;
-import static io.confluent.ksql.serde.Format.KAFKA;
-import static io.confluent.ksql.util.SchemaUtil.ROWKEY_NAME;
-import static io.confluent.ksql.util.SchemaUtil.ROWTIME_NAME;
 import static java.util.Collections.emptyMap;
-import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.CoreMatchers.instanceOf;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.contains;
 import static org.hamcrest.Matchers.is;
-import static org.hamcrest.Matchers.not;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import com.google.common.collect.ImmutableMap;
-import com.google.common.collect.ImmutableSet;
-import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
-import io.confluent.ksql.GenericRow;
-import io.confluent.ksql.ddl.commands.CommandFactories.SerdeOptionsSupplier;
 import io.confluent.ksql.execution.ddl.commands.CreateStreamCommand;
 import io.confluent.ksql.execution.ddl.commands.CreateTableCommand;
 import io.confluent.ksql.execution.ddl.commands.DdlCommand;
 import io.confluent.ksql.execution.ddl.commands.DropSourceCommand;
 import io.confluent.ksql.execution.ddl.commands.DropTypeCommand;
 import io.confluent.ksql.execution.ddl.commands.RegisterTypeCommand;
-import io.confluent.ksql.execution.expression.tree.BooleanLiteral;
 import io.confluent.ksql.execution.expression.tree.Literal;
 import io.confluent.ksql.execution.expression.tree.StringLiteral;
 import io.confluent.ksql.execution.expression.tree.Type;
-import io.confluent.ksql.logging.processing.NoopProcessingLogContext;
 import io.confluent.ksql.metastore.MetaStore;
-import io.confluent.ksql.metastore.model.DataSource.DataSourceType;
-import io.confluent.ksql.metastore.model.KsqlStream;
-import io.confluent.ksql.metastore.model.KsqlTable;
 import io.confluent.ksql.name.ColumnName;
 import io.confluent.ksql.name.SourceName;
 import io.confluent.ksql.parser.DropType;
@@ -72,29 +51,17 @@ import io.confluent.ksql.parser.tree.TableElement;
 import io.confluent.ksql.parser.tree.TableElement.Namespace;
 import io.confluent.ksql.parser.tree.TableElements;
 import io.confluent.ksql.properties.with.CommonCreateConfigs;
-import io.confluent.ksql.properties.with.CreateConfigs;
-import io.confluent.ksql.schema.ksql.LogicalSchema;
-import io.confluent.ksql.schema.ksql.PersistenceSchema;
 import io.confluent.ksql.schema.ksql.SqlBaseType;
 import io.confluent.ksql.schema.ksql.types.SqlPrimitiveType;
 import io.confluent.ksql.schema.ksql.types.SqlStruct;
 import io.confluent.ksql.schema.ksql.types.SqlTypes;
-import io.confluent.ksql.serde.FormatInfo;
-import io.confluent.ksql.serde.KeyFormat;
 import io.confluent.ksql.serde.SerdeOption;
-import io.confluent.ksql.serde.ValueFormat;
-import io.confluent.ksql.serde.ValueSerdeFactory;
-import io.confluent.ksql.serde.WindowInfo;
 import io.confluent.ksql.services.KafkaTopicClient;
 import io.confluent.ksql.services.ServiceContext;
 import io.confluent.ksql.util.KsqlConfig;
 import io.confluent.ksql.util.KsqlException;
-import java.time.Duration;
-import java.util.Collections;
 import java.util.Map;
 import java.util.Optional;
-import java.util.Set;
-import org.apache.kafka.common.serialization.Serde;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
@@ -108,29 +75,20 @@ public class CommandFactoriesTest {
 
   private static final SourceName SOME_NAME = SourceName.of("bob");
   private static final SourceName TABLE_NAME = SourceName.of("tablename");
-  private static final Map<String, Object> NO_PROPS = Collections.emptyMap();
   private static final String sqlExpression = "sqlExpression";
   private static final TableElement ELEMENT1 =
       tableElement(Namespace.VALUE, "bob", new Type(SqlTypes.STRING));
-  private static final TableElement ELEMENT2 =
-      tableElement(Namespace.VALUE, "hojjat", new Type(SqlTypes.STRING));
   private static final TableElements SOME_ELEMENTS = TableElements.of(ELEMENT1);
-  private static final TableElements TWO_ELEMENTS = TableElements.of(ELEMENT1, ELEMENT2);
   private static final String TOPIC_NAME = "some topic";
   private static final Map<String, Literal> MINIMIM_PROPS = ImmutableMap.of(
       CommonCreateConfigs.VALUE_FORMAT_PROPERTY, new StringLiteral("JSON"),
       CommonCreateConfigs.KAFKA_TOPIC_NAME_PROPERTY, new StringLiteral(TOPIC_NAME)
   );
-  private static final TableElements ONE_ELEMENT = TableElements.of(
-      tableElement(Namespace.VALUE, "bob", new Type(SqlTypes.STRING)));
-  private static final Set<SerdeOption> SOME_SERDE_OPTIONS = ImmutableSet
-      .of(SerdeOption.UNWRAP_SINGLE_VALUES);
   private static final String SOME_TYPE_NAME = "newtype";
+  private static final Map<String, Object> OVERRIDES = ImmutableMap.of(
+      KsqlConfig.KSQL_WRAP_SINGLE_VALUES, !defaultConfigValue(KsqlConfig.KSQL_WRAP_SINGLE_VALUES)
+  );
 
-  @Mock
-  private KsqlStream ksqlStream;
-  @Mock
-  private KsqlTable ksqlTable;
   @Mock
   private KafkaTopicClient topicClient;
   @Mock
@@ -138,15 +96,27 @@ public class CommandFactoriesTest {
   @Mock
   private MetaStore metaStore;
   @Mock
-  private SerdeOptionsSupplier serdeOptionsSupplier;
+  private CreateSourceFactory createSourceFactory;
   @Mock
-  private ValueSerdeFactory serdeFactory;
+  private DropSourceFactory dropSourceFactory;
   @Mock
-  private Serde<GenericRow> serde;
+  private RegisterTypeFactory registerTypeFactory;
+  @Mock
+  private DropTypeFactory dropTypeFactory;
+  @Mock
+  private CreateStreamCommand createStreamCommand;
+  @Mock
+  private CreateTableCommand createTableCommand;
+  @Mock
+  private DropSourceCommand dropSourceCommand;
+  @Mock
+  private RegisterTypeCommand registerTypeCommand;
+  @Mock
+  private DropTypeCommand dropTypeCommand;
 
   private CommandFactories commandFactories;
   private KsqlConfig ksqlConfig = new KsqlConfig(ImmutableMap.of());
-  private CreateSourceProperties withProperties =
+  private final CreateSourceProperties withProperties =
       CreateSourceProperties.from(MINIMIM_PROPS);
 
   @Rule
@@ -157,13 +127,16 @@ public class CommandFactoriesTest {
   public void before() {
     when(serviceContext.getTopicClient()).thenReturn(topicClient);
     when(topicClient.isTopicExists(any())).thenReturn(true);
-    when(metaStore.getSource(SOME_NAME)).thenReturn(ksqlStream);
-    when(metaStore.getSource(TABLE_NAME)).thenReturn(ksqlTable);
-    when(ksqlStream.getDataSourceType()).thenReturn(DataSourceType.KSTREAM);
-    when(ksqlTable.getDataSourceType()).thenReturn(DataSourceType.KTABLE);
-    when(serdeFactory.create(any(), any(), any(), any(), any(), any())).thenReturn(serde);
+    when(createSourceFactory.createStreamCommand(any(), any(), any()))
+        .thenReturn(createStreamCommand);
+    when(createSourceFactory.createTableCommand(any(), any(), any()))
+        .thenReturn(createTableCommand);
+    when(dropSourceFactory.create(any(DropStream.class))).thenReturn(dropSourceCommand);
+    when(dropSourceFactory.create(any(DropTable.class))).thenReturn(dropSourceCommand);
+    when(registerTypeFactory.create(any())).thenReturn(registerTypeCommand);
+    when(dropTypeFactory.create(any())).thenReturn(dropTypeCommand);
 
-    givenCommandFactories();
+    givenCommandFactoriesWithMocks();
   }
 
   private void givenCommandFactories() {
@@ -175,30 +148,44 @@ public class CommandFactoriesTest {
 
   private void givenCommandFactoriesWithMocks() {
     commandFactories = new CommandFactories(
-        serviceContext,
-        metaStore,
-        serdeOptionsSupplier,
-        serdeFactory
+        createSourceFactory,
+        dropSourceFactory,
+        registerTypeFactory,
+        dropTypeFactory
     );
   }
 
   @Test
   public void shouldCreateCommandForCreateStream() {
     // Given:
-    final CreateStream ddlStatement =
-        new CreateStream(SOME_NAME, SOME_ELEMENTS, true, withProperties);
+    final CreateStream statement = new CreateStream(SOME_NAME, SOME_ELEMENTS, true, withProperties);
 
     // When:
     final DdlCommand result = commandFactories
-        .create(sqlExpression, ddlStatement, ksqlConfig, NO_PROPS);
+        .create(sqlExpression, statement, ksqlConfig, emptyMap());
 
-    assertThat(result, instanceOf(CreateStreamCommand.class));
+    assertThat(result, is(createStreamCommand));
+    verify(createSourceFactory).createStreamCommand(sqlExpression, statement, ksqlConfig);
+  }
+
+  @Test
+  public void shouldCreateCommandForStreamWithOverriddenProperties() {
+    // Given:
+    final CreateStream statement = new CreateStream(SOME_NAME, SOME_ELEMENTS, true, withProperties);
+
+    // When:
+    commandFactories.create(sqlExpression, statement, ksqlConfig, OVERRIDES);
+
+    verify(createSourceFactory).createStreamCommand(
+        sqlExpression,
+        statement,
+        ksqlConfig.cloneWithPropertyOverwrite(OVERRIDES));
   }
 
   @Test
   public void shouldCreateCommandForCreateTable() {
     // Given:
-    final CreateTable ddlStatement = new CreateTable(SOME_NAME,
+    final CreateTable statement = new CreateTable(SOME_NAME,
         TableElements.of(
             tableElement(Namespace.VALUE, "COL1", new Type(SqlTypes.BIGINT)),
             tableElement(Namespace.VALUE, "COL2", new Type(SqlTypes.STRING))),
@@ -206,10 +193,31 @@ public class CommandFactoriesTest {
 
     // When:
     final DdlCommand result = commandFactories
-        .create(sqlExpression, ddlStatement, ksqlConfig, NO_PROPS);
+        .create(sqlExpression, statement, ksqlConfig, emptyMap());
 
     // Then:
-    assertThat(result, instanceOf(CreateTableCommand.class));
+    assertThat(result, is(createTableCommand));
+    verify(createSourceFactory).createTableCommand(sqlExpression, statement, ksqlConfig);
+  }
+
+  @Test
+  public void shouldCreateCommandForCreateTableWithOverriddenProperties() {
+    // Given:
+    final CreateTable statement = new CreateTable(SOME_NAME,
+        TableElements.of(
+            tableElement(Namespace.VALUE, "COL1", new Type(SqlTypes.BIGINT)),
+            tableElement(Namespace.VALUE, "COL2", new Type(SqlTypes.STRING))),
+        true, withProperties);
+
+    // When:
+    commandFactories.create(sqlExpression, statement, ksqlConfig, OVERRIDES);
+
+    // Then:
+    verify(createSourceFactory).createTableCommand(
+        sqlExpression,
+        statement,
+        ksqlConfig.cloneWithPropertyOverwrite(OVERRIDES)
+    );
   }
 
   @Test
@@ -219,10 +227,11 @@ public class CommandFactoriesTest {
 
     // When:
     final DdlCommand result = commandFactories
-        .create(sqlExpression, ddlStatement, ksqlConfig, NO_PROPS);
+        .create(sqlExpression, ddlStatement, ksqlConfig, emptyMap());
 
     // Then:
-    assertThat(result, instanceOf(DropSourceCommand.class));
+    assertThat(result, is(dropSourceCommand));
+    verify(dropSourceFactory).create(ddlStatement);
   }
 
   @Test
@@ -232,10 +241,11 @@ public class CommandFactoriesTest {
 
     // When:
     final DdlCommand result = commandFactories
-        .create(sqlExpression, ddlStatement, ksqlConfig, NO_PROPS);
+        .create(sqlExpression, ddlStatement, ksqlConfig, emptyMap());
 
     // Then:
-    assertThat(result, instanceOf(DropSourceCommand.class));
+    assertThat(result, is(dropSourceCommand));
+    verify(dropSourceFactory).create(ddlStatement);
   }
 
   @Test
@@ -249,10 +259,11 @@ public class CommandFactoriesTest {
 
     // When:
     final DdlCommand result = commandFactories.create(
-        sqlExpression, ddlStatement, ksqlConfig, NO_PROPS);
+        sqlExpression, ddlStatement, ksqlConfig, emptyMap());
 
     // Then:
-    assertThat(result, instanceOf(RegisterTypeCommand.class));
+    assertThat(result, is(registerTypeCommand));
+    verify(registerTypeFactory).create(ddlStatement);
   }
 
   @Test
@@ -269,7 +280,8 @@ public class CommandFactoriesTest {
     );
 
     // Then:
-    assertThat(cmd.getTypeName(), equalTo(SOME_TYPE_NAME));
+    assertThat(cmd, is(dropTypeCommand));
+    verify(dropTypeFactory).create(dropType);
   }
 
   @Test(expected = KsqlException.class)
@@ -279,38 +291,13 @@ public class CommandFactoriesTest {
     };
 
     // Then:
-    commandFactories.create(sqlExpression, ddlStatement, ksqlConfig, NO_PROPS);
-  }
-
-  @Test
-  public void shouldCreateStreamCommandWithSingleValueWrappingFromPropertiesNotConfigOrOverrides() {
-    // Given:
-    ksqlConfig = new KsqlConfig(ImmutableMap.of(
-        KsqlConfig.KSQL_WRAP_SINGLE_VALUES, true
-    ));
-
-    final ImmutableMap<String, Object> overrides = ImmutableMap.of(
-        KsqlConfig.KSQL_WRAP_SINGLE_VALUES, true
-    );
-
-    givenProperty(CommonCreateConfigs.WRAP_SINGLE_VALUE, new BooleanLiteral("false"));
-
-    final DdlStatement statement =
-        new CreateStream(SOME_NAME, SOME_ELEMENTS, true, withProperties);
-
-    // When:
-    final DdlCommand cmd = commandFactories
-        .create(sqlExpression, statement, ksqlConfig, overrides);
-
-    // Then:
-    assertThat(cmd, is(instanceOf(CreateStreamCommand.class)));
-    assertThat(((CreateStreamCommand) cmd).getSerdeOptions(),
-        contains(SerdeOption.UNWRAP_SINGLE_VALUES));
+    commandFactories.create(sqlExpression, ddlStatement, ksqlConfig, emptyMap());
   }
 
   @Test
   public void shouldCreateStreamCommandWithSingleValueWrappingFromOverridesNotConfig() {
     // Given:
+    givenCommandFactories();
     ksqlConfig = new KsqlConfig(ImmutableMap.of(
         KsqlConfig.KSQL_WRAP_SINGLE_VALUES, true
     ));
@@ -329,74 +316,13 @@ public class CommandFactoriesTest {
     // Then:
     assertThat(cmd, is(instanceOf(CreateStreamCommand.class)));
     assertThat(((CreateStreamCommand) cmd).getSerdeOptions(),
-        contains(SerdeOption.UNWRAP_SINGLE_VALUES));
-  }
-
-  @Test
-  public void shouldCreateStreamCommandWithSingleValueWrappingFromConfig() {
-    // Given:
-    ksqlConfig = new KsqlConfig(ImmutableMap.of(
-        KsqlConfig.KSQL_WRAP_SINGLE_VALUES, false
-    ));
-
-    final DdlStatement statement =
-        new CreateStream(SOME_NAME, SOME_ELEMENTS, true, withProperties);
-
-    // When:
-    final DdlCommand cmd = commandFactories
-        .create(sqlExpression, statement, ksqlConfig, ImmutableMap.of());
-
-    // Then:
-    assertThat(cmd, is(instanceOf(CreateStreamCommand.class)));
-    assertThat(((CreateStreamCommand) cmd).getSerdeOptions(),
-        contains(SerdeOption.UNWRAP_SINGLE_VALUES));
-  }
-
-  @Test
-  public void shouldCreateStreamCommandWithSingleValueWrappingFromDefaultConfig() {
-    // Given:
-    final DdlStatement statement =
-        new CreateStream(SOME_NAME, SOME_ELEMENTS, true, withProperties);
-
-    // When:
-    final DdlCommand cmd = commandFactories
-        .create(sqlExpression, statement, ksqlConfig, ImmutableMap.of());
-
-    // Then:
-    assertThat(cmd, is(instanceOf(CreateStreamCommand.class)));
-    assertThat(((CreateStreamCommand) cmd).getSerdeOptions(),
-        not(contains(SerdeOption.UNWRAP_SINGLE_VALUES)));
-  }
-
-  @Test
-  public void shouldCreateTableCommandWithSingleValueWrappingFromPropertiesNotConfigOrOverrides() {
-    // Given:
-    ksqlConfig = new KsqlConfig(ImmutableMap.of(
-        KsqlConfig.KSQL_WRAP_SINGLE_VALUES, true
-    ));
-
-    final ImmutableMap<String, Object> overrides = ImmutableMap.of(
-        KsqlConfig.KSQL_WRAP_SINGLE_VALUES, true
-    );
-
-    givenProperty(CommonCreateConfigs.WRAP_SINGLE_VALUE, new BooleanLiteral("false"));
-
-    final DdlStatement statement =
-        new CreateTable(SOME_NAME, SOME_ELEMENTS, true, withProperties);
-
-    // When:
-    final DdlCommand cmd = commandFactories
-        .create(sqlExpression, statement, ksqlConfig, overrides);
-
-    // Then:
-    assertThat(cmd, is(instanceOf(CreateTableCommand.class)));
-    assertThat(((CreateTableCommand) cmd).getSerdeOptions(),
         contains(SerdeOption.UNWRAP_SINGLE_VALUES));
   }
 
   @Test
   public void shouldCreateTableCommandWithSingleValueWrappingFromOverridesNotConfig() {
     // Given:
+    givenCommandFactories();
     ksqlConfig = new KsqlConfig(ImmutableMap.of(
         KsqlConfig.KSQL_WRAP_SINGLE_VALUES, true
     ));
@@ -416,538 +342,6 @@ public class CommandFactoriesTest {
     assertThat(cmd, is(instanceOf(CreateTableCommand.class)));
     assertThat(((CreateTableCommand) cmd).getSerdeOptions(),
         contains(SerdeOption.UNWRAP_SINGLE_VALUES));
-  }
-
-  @Test
-  public void shouldCreateTableCommandWithSingleValueWrappingFromConfig() {
-    // Given:
-    ksqlConfig = new KsqlConfig(ImmutableMap.of(
-        KsqlConfig.KSQL_WRAP_SINGLE_VALUES, false
-    ));
-
-    final DdlStatement statement =
-        new CreateTable(SOME_NAME, SOME_ELEMENTS, true, withProperties);
-
-    // When:
-    final DdlCommand cmd = commandFactories
-        .create(sqlExpression, statement, ksqlConfig, ImmutableMap.of());
-
-    // Then:
-    assertThat(cmd, is(instanceOf(CreateTableCommand.class)));
-    assertThat(((CreateTableCommand) cmd).getSerdeOptions(),
-        contains(SerdeOption.UNWRAP_SINGLE_VALUES));
-  }
-
-  @Test
-  public void shouldCreateTableCommandWithSingleValueWrappingFromDefaultConfig() {
-    // Given:
-    final DdlStatement statement =
-        new CreateTable(SOME_NAME, SOME_ELEMENTS, true, withProperties);
-
-    // When:
-    final DdlCommand cmd = commandFactories
-        .create(sqlExpression, statement, ksqlConfig, ImmutableMap.of());
-
-    // Then:
-    assertThat(cmd, is(instanceOf(CreateTableCommand.class)));
-    assertThat(((CreateTableCommand) cmd).getSerdeOptions(),
-        not(contains(SerdeOption.UNWRAP_SINGLE_VALUES)));
-  }
-
-  @Test
-  public void shouldThrowOnNoElementsInCreateStream() {
-    // Given:
-    final DdlStatement statement
-        = new CreateStream(SOME_NAME, TableElements.of(), true, withProperties);
-
-    // Then:
-    expectedException.expect(KsqlException.class);
-    expectedException.expectMessage(
-        "The statement does not define any columns.");
-
-    // When:
-    commandFactories.create("expression", statement, ksqlConfig, emptyMap());
-  }
-
-  @Test
-  public void shouldThrowOnNoElementsInCreateTable() {
-    // Given:
-    final DdlStatement statement
-        = new CreateTable(SOME_NAME, TableElements.of(), true, withProperties);
-
-    // Then:
-    expectedException.expect(KsqlException.class);
-    expectedException.expectMessage(
-        "The statement does not define any columns.");
-
-    // When:
-    commandFactories.create("expression", statement, ksqlConfig, emptyMap());
-  }
-
-  @Test
-  public void shouldNotThrowWhenThereAreElementsInCreateStream() {
-    // Given:
-    final DdlStatement statement =
-        new CreateStream(SOME_NAME, SOME_ELEMENTS, true, withProperties);
-
-    // When:
-    commandFactories.create("expression", statement, ksqlConfig, emptyMap());
-
-    // Then: not exception thrown
-  }
-
-  @Test
-  public void shouldNotThrowWhenThereAreElementsInCreateTable() {
-    // Given:
-    final DdlStatement statement =
-        new CreateTable(SOME_NAME, SOME_ELEMENTS, true, withProperties);
-
-    // When:
-    commandFactories.create("expression", statement, ksqlConfig, emptyMap());
-
-    // Then: not exception thrown
-  }
-
-  @Test
-  public void shouldThrowIfTopicDoesNotExistForStream() {
-    // Given:
-    when(topicClient.isTopicExists(any())).thenReturn(false);
-    final DdlStatement statement =
-        new CreateStream(SOME_NAME, SOME_ELEMENTS, true, withProperties);
-
-    // Then:
-    expectedException.expect(KsqlException.class);
-    expectedException.expectMessage("Kafka topic does not exist: " + TOPIC_NAME);
-
-    // When:
-    commandFactories.create("expression", statement, ksqlConfig, emptyMap());
-  }
-
-  @SuppressFBWarnings("RV_RETURN_VALUE_IGNORED_NO_SIDE_EFFECT")
-  @Test
-  public void shouldNotThrowIfTopicDoesExist() {
-    // Given:
-    final DdlStatement statement =
-        new CreateStream(SOME_NAME, SOME_ELEMENTS, true, withProperties);
-
-    // When:
-    commandFactories.create("expression", statement, ksqlConfig, emptyMap());
-
-    // Then:
-    verify(topicClient).isTopicExists(TOPIC_NAME);
-  }
-
-  @Test
-  public void shouldThrowIfKeyFieldNotInSchemaForStream() {
-    // Given:
-    givenProperty(CreateConfigs.KEY_NAME_PROPERTY, new StringLiteral("will-not-find-me"));
-    final DdlStatement statement = new CreateStream(SOME_NAME, SOME_ELEMENTS, true, withProperties);
-
-    // Then:
-    expectedException.expect(KsqlException.class);
-    expectedException.expectMessage(
-        "The KEY column set in the WITH clause does not exist in the schema: "
-            + "'WILL-NOT-FIND-ME'");
-
-    // When:
-    commandFactories.create("expression", statement, ksqlConfig, emptyMap());
-  }
-
-  @Test
-  public void shouldThrowIfTimestampColumnDoesNotExistForStream() {
-    // Given:
-    givenProperty(
-        CommonCreateConfigs.TIMESTAMP_NAME_PROPERTY,
-        new StringLiteral("will-not-find-me")
-    );
-    final DdlStatement statement =
-        new CreateStream(SOME_NAME, SOME_ELEMENTS, true, withProperties);
-
-    // Then:
-    expectedException.expect(KsqlException.class);
-    expectedException.expectMessage(
-        "The TIMESTAMP column set in the WITH clause does not exist in the schema: "
-            + "'WILL-NOT-FIND-ME'");
-
-    // When:
-    commandFactories.create("expression", statement, ksqlConfig, emptyMap());
-  }
-
-  @Test
-  public void shouldBuildSerdeOptionsForStream() {
-    // Given:
-    givenCommandFactoriesWithMocks();
-    final CreateStream statement = new CreateStream(SOME_NAME, ONE_ELEMENT, true, withProperties);
-    final LogicalSchema schema = LogicalSchema.builder()
-        .valueColumn(ColumnName.of("bob"), SqlTypes.STRING)
-        .build();
-    when(serdeOptionsSupplier.build(any(), any(), any(), any())).thenReturn(SOME_SERDE_OPTIONS);
-
-    // When:
-    final CreateStreamCommand cmd = (CreateStreamCommand) commandFactories.create(
-        "expression",
-        statement,
-        ksqlConfig,
-        emptyMap()
-    );
-
-    // Then:
-    verify(serdeOptionsSupplier).build(
-        schema,
-        statement.getProperties().getValueFormat(),
-        statement.getProperties().getWrapSingleValues(),
-        ksqlConfig
-    );
-    assertThat(cmd.getSerdeOptions(), is(SOME_SERDE_OPTIONS));
-  }
-
-  @Test
-  public void shouldBuildSchemaWithImplicitKeyFieldForStream() {
-    // Given:
-    final CreateStream statement = new CreateStream(SOME_NAME, TWO_ELEMENTS, true, withProperties);
-
-    // When:
-    final CreateStreamCommand result = (CreateStreamCommand) commandFactories.create(
-        "expression",
-        statement,
-        ksqlConfig,
-        emptyMap()
-    );
-
-    // Then:
-    assertThat(result.getSchema(), is(LogicalSchema.builder()
-        .keyColumn(ColumnName.of("ROWKEY"), SqlTypes.STRING)
-        .valueColumn(ColumnName.of("bob"), SqlTypes.STRING)
-        .valueColumn(ColumnName.of("hojjat"), SqlTypes.STRING)
-        .build()
-    ));
-  }
-
-  @Test
-  public void shouldBuildSchemaWithExplicitKeyFieldForStream() {
-    // Given:
-    final CreateStream statement = new CreateStream(
-        SOME_NAME,
-        TableElements.of(
-            tableElement(Namespace.KEY, "ROWKEY", new Type(SqlTypes.STRING)),
-            ELEMENT1,
-            ELEMENT2
-        ),
-        true,
-        withProperties
-    );
-
-    // When:
-    final CreateStreamCommand result = (CreateStreamCommand) commandFactories.create(
-        "expression",
-        statement,
-        ksqlConfig,
-        emptyMap()
-    );
-
-    // Then:
-    assertThat(result.getSchema(), is(LogicalSchema.builder()
-        .keyColumn(ColumnName.of("ROWKEY"), SqlTypes.STRING)
-        .valueColumn(ColumnName.of("bob"), SqlTypes.STRING)
-        .valueColumn(ColumnName.of("hojjat"), SqlTypes.STRING)
-        .build()
-    ));
-  }
-
-  @Test
-  public void shouldCreateSerdeToValidateValueFormatCanHandleValueSchemaForStream() {
-    // Given:
-    givenCommandFactoriesWithMocks();
-    final CreateStream statement = new CreateStream(SOME_NAME, TWO_ELEMENTS, true, withProperties);
-    final LogicalSchema schema = LogicalSchema.builder()
-        .valueColumn(ColumnName.of("bob"), SqlTypes.STRING)
-        .valueColumn(ColumnName.of("hojjat"), SqlTypes.STRING)
-        .build();
-
-    // When:
-    commandFactories.create("expression", statement, ksqlConfig, emptyMap());
-
-    // Then:
-    verify(serdeFactory).create(
-        FormatInfo.of(JSON, Optional.empty(), Optional.empty()),
-        PersistenceSchema.from(schema.valueConnectSchema(), false),
-        ksqlConfig,
-        serviceContext.getSchemaRegistryClientFactory(),
-        "",
-        NoopProcessingLogContext.INSTANCE
-    );
-  }
-
-  @Test
-  public void shouldDefaultToKafkaKeySerdeForStream() {
-    final CreateStream statement = new CreateStream(SOME_NAME, SOME_ELEMENTS, true, withProperties);
-
-    // When:
-    final CreateStreamCommand cmd = (CreateStreamCommand) commandFactories.create(
-        "expression",
-        statement,
-        ksqlConfig,
-        emptyMap()
-    );
-
-    // Then:
-    assertThat(cmd.getTopic().getKeyFormat(), is(KeyFormat.nonWindowed(FormatInfo.of(KAFKA))));
-  }
-
-  @Test
-  public void shouldHandleValueAvroSchemaNameForStream() {
-    // Given:
-    givenCommandFactoriesWithMocks();
-    givenProperty("VALUE_FORMAT", new StringLiteral("Avro"));
-    givenProperty("value_avro_schema_full_name", new StringLiteral("full.schema.name"));
-    final CreateStream statement = new CreateStream(SOME_NAME, SOME_ELEMENTS, true, withProperties);
-
-    // When:
-    final CreateStreamCommand cmd = (CreateStreamCommand) commandFactories.create(
-        "expression",
-        statement,
-        ksqlConfig,
-        emptyMap()
-    );
-
-    // Then:
-    assertThat(cmd.getTopic().getValueFormat(),
-        is(ValueFormat.of(FormatInfo.of(AVRO, Optional.of("full.schema.name"), Optional.empty()))));
-  }
-
-  @Test
-  public void shouldHandleSessionWindowedKeyForStream() {
-    // Given:
-    givenProperty("window_type", new StringLiteral("session"));
-    final CreateStream statement = new CreateStream(SOME_NAME, SOME_ELEMENTS, true, withProperties);
-
-    // When:
-    final CreateStreamCommand cmd = (CreateStreamCommand) commandFactories.create(
-        "expression",
-        statement,
-        ksqlConfig,
-        emptyMap()
-    );
-
-    // Then:
-    assertThat(cmd.getTopic().getKeyFormat(), is(KeyFormat.windowed(
-        FormatInfo.of(KAFKA),
-        WindowInfo.of(SESSION, Optional.empty()))
-    ));
-  }
-
-  @Test
-  public void shouldHandleTumblingWindowedKeyForStream() {
-    // Given:
-    givenProperties(ImmutableMap.of(
-        "window_type", new StringLiteral("tumbling"),
-        "window_size", new StringLiteral("1 MINUTE")
-    ));
-    final CreateStream statement = new CreateStream(SOME_NAME, SOME_ELEMENTS, true, withProperties);
-
-    // When:
-    final CreateStreamCommand cmd = (CreateStreamCommand) commandFactories.create(
-        "expression",
-        statement,
-        ksqlConfig,
-        emptyMap()
-    );
-
-    // Then:
-    assertThat(cmd.getTopic().getKeyFormat(), is(KeyFormat.windowed(
-        FormatInfo.of(KAFKA),
-        WindowInfo.of(TUMBLING, Optional.of(Duration.ofMinutes(1))))
-    ));
-  }
-
-  @Test
-  public void shouldHandleHoppingWindowedKeyForStream() {
-    // Given:
-    givenProperties(ImmutableMap.of(
-        "window_type", new StringLiteral("Hopping"),
-        "window_size", new StringLiteral("2 SECONDS")
-    ));
-    final CreateStream statement = new CreateStream(SOME_NAME, SOME_ELEMENTS, true, withProperties);
-
-    // When:
-    final CreateStreamCommand cmd = (CreateStreamCommand) commandFactories.create(
-        "expression",
-        statement,
-        ksqlConfig,
-        emptyMap()
-    );
-
-    // Then:
-    assertThat(cmd.getTopic().getKeyFormat(), is(KeyFormat.windowed(
-        FormatInfo.of(KAFKA),
-        WindowInfo.of(HOPPING, Optional.of(Duration.ofSeconds(2))))
-    ));
-  }
-
-  @Test
-  public void shouldCreateDropSourceOnMissingSourceWithIfExistsForStream() {
-    // Given:
-    final DropStream dropStream = new DropStream(SOME_NAME, false, true);
-    when(metaStore.getSource(SOME_NAME)).thenReturn(null);
-
-    // When:
-    final DropSourceCommand cmd = (DropSourceCommand) commandFactories.create(
-        "sqlExpression",
-        dropStream,
-        ksqlConfig,
-        emptyMap()
-    );
-
-    // Then:
-    assertThat(cmd.getSourceName(), equalTo(SourceName.of("bob")));
-  }
-
-  @Test
-  public void shouldFailDropSourceOnMissingSourceWithNoIfExistsForStream() {
-    // Given:
-    final DropStream dropStream = new DropStream(SOME_NAME, true, true);
-    when(metaStore.getSource(SOME_NAME)).thenReturn(null);
-
-    // Then:
-    expectedException.expect(KsqlException.class);
-    expectedException.expectMessage("Source bob does not exist.");
-
-    // When:
-    commandFactories.create("sqlExpression", dropStream, ksqlConfig, emptyMap());
-  }
-
-  @Test
-  @SuppressWarnings("unchecked")
-  public void shouldFailDropSourceOnDropIncompatibleSourceForStream() {
-    // Given:
-    final DropStream dropStream = new DropStream(SOME_NAME, false, true);
-    when(metaStore.getSource(SOME_NAME)).thenReturn(ksqlTable);
-
-    // Expect:
-    expectedException.expect(KsqlException.class);
-    expectedException.expectMessage("Incompatible data source type is TABLE");
-
-    // When:
-    commandFactories.create("sqlExpression", dropStream, ksqlConfig, emptyMap());
-  }
-
-  @Test
-  public void shouldThrowOnRowTimeValueColumn() {
-    // Given:
-    final DdlStatement statement = new CreateStream(
-        SOME_NAME,
-        TableElements.of(tableElement(Namespace.VALUE, ROWTIME_NAME.name(), new Type(SqlTypes.BIGINT))),
-        true,
-        withProperties
-    );
-
-    // Then:
-    expectedException.expect(KsqlException.class);
-    expectedException.expectMessage("'ROWTIME' is a reserved column name.");
-
-    // When:
-    commandFactories.create("sqlExpression", statement, ksqlConfig, emptyMap());
-  }
-
-  @Test
-  public void shouldThrowOnRowTimeKeyColumn() {
-    // Given:
-    final DdlStatement statement = new CreateStream(
-        SOME_NAME,
-        TableElements.of(tableElement(Namespace.KEY, ROWTIME_NAME.name(), new Type(SqlTypes.BIGINT))),
-        true,
-        withProperties
-    );
-
-    // Then:
-    expectedException.expect(KsqlException.class);
-    expectedException.expectMessage("'ROWTIME' is a reserved column name.");
-
-    // When:
-    commandFactories.create("sqlExpression", statement, ksqlConfig, emptyMap());
-  }
-
-  @Test
-  public void shouldThrowOnRowKeyValueColumn() {
-    // Given:
-    final DdlStatement statement = new CreateStream(
-        SOME_NAME,
-        TableElements.of(tableElement(VALUE, ROWKEY_NAME.name(), new Type(SqlTypes.STRING))),
-        true,
-        withProperties
-    );
-
-    // Then:
-    expectedException.expect(KsqlException.class);
-    expectedException.expectMessage(
-        "'ROWKEY' is a reserved column name. It can only be used for KEY columns.");
-
-    // When:
-    commandFactories.create("sqlExpression", statement, ksqlConfig, emptyMap());
-  }
-
-  @Test
-  public void shouldNotThrowOnRowKeyKeyColumn() {
-    // Given:
-    final DdlStatement statement = new CreateStream(
-        SOME_NAME,
-        TableElements.of(tableElement(KEY, ROWKEY_NAME.name(), new Type(SqlTypes.STRING))),
-        true,
-        withProperties
-    );
-
-    // When:
-    commandFactories.create("sqlExpression", statement, ksqlConfig, emptyMap());
-
-    // Then: did not throw
-  }
-
-  @Test
-  public void shouldThrowOnRowKeyIfNotString() {
-    // Given:
-    final DdlStatement statement = new CreateStream(
-        SOME_NAME,
-        TableElements.of(tableElement(KEY, ROWKEY_NAME.name(), new Type(SqlTypes.INTEGER))),
-        true,
-        withProperties
-    );
-
-    // Then:
-    expectedException.expect(KsqlException.class);
-    expectedException.expectMessage("'ROWKEY' is a KEY column with an unsupported type. "
-        + "KSQL currently only supports KEY columns of type STRING.");
-
-    // When:
-    commandFactories.create("sqlExpression", statement, ksqlConfig, emptyMap());
-  }
-
-  @Test
-  public void shouldThrowOnKeyColumnThatIsNotCalledRowKey() {
-    // Given:
-    final DdlStatement statement = new CreateStream(
-        SOME_NAME,
-        TableElements.of(tableElement(KEY, "someKey", new Type(SqlTypes.STRING))),
-        true,
-        withProperties
-    );
-
-    // Then:
-    expectedException.expect(KsqlException.class);
-    expectedException.expectMessage("'someKey' is an invalid KEY column name. "
-        + "KSQL currently only supports KEY columns named ROWKEY.");
-
-    // When:
-    commandFactories.create("sqlExpression", statement, ksqlConfig, emptyMap());
-  }
-
-  private void givenProperty(final String name, final Literal value) {
-    givenProperties(ImmutableMap.of(name, value));
-  }
-
-  private void givenProperties(final Map<String, Literal> properties) {
-    final Map<String, Literal> props = withProperties.copyOfOriginalLiterals();
-    props.putAll(properties);
-    withProperties = CreateSourceProperties.from(props);
   }
 
   private static TableElement tableElement(
@@ -960,5 +354,9 @@ public class CommandFactoriesTest {
     when(te.getType()).thenReturn(type);
     when(te.getNamespace()).thenReturn(namespace);
     return te;
+  }
+
+  private static boolean defaultConfigValue(final String config) {
+    return new KsqlConfig(emptyMap()).getBoolean(config);
   }
 }

--- a/ksql-engine/src/test/java/io/confluent/ksql/ddl/commands/CreateSourceFactoryTest.java
+++ b/ksql-engine/src/test/java/io/confluent/ksql/ddl/commands/CreateSourceFactoryTest.java
@@ -1,0 +1,761 @@
+/*
+ * Copyright 2019 Confluent Inc.
+ *
+ * Licensed under the Confluent Community License (the "License"); you may not use
+ * this file except in compliance with the License.  You may obtain a copy of the
+ * License at
+ *
+ * http://www.confluent.io/confluent-community-license
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package io.confluent.ksql.ddl.commands;
+
+import static io.confluent.ksql.model.WindowType.HOPPING;
+import static io.confluent.ksql.model.WindowType.SESSION;
+import static io.confluent.ksql.model.WindowType.TUMBLING;
+import static io.confluent.ksql.parser.tree.TableElement.Namespace.KEY;
+import static io.confluent.ksql.parser.tree.TableElement.Namespace.VALUE;
+import static io.confluent.ksql.serde.Format.AVRO;
+import static io.confluent.ksql.serde.Format.JSON;
+import static io.confluent.ksql.serde.Format.KAFKA;
+import static io.confluent.ksql.util.SchemaUtil.ROWKEY_NAME;
+import static io.confluent.ksql.util.SchemaUtil.ROWTIME_NAME;
+import static org.hamcrest.CoreMatchers.instanceOf;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.contains;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.not;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.ImmutableSet;
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
+import io.confluent.ksql.GenericRow;
+import io.confluent.ksql.ddl.commands.CreateSourceFactory.SerdeOptionsSupplier;
+import io.confluent.ksql.execution.ddl.commands.CreateStreamCommand;
+import io.confluent.ksql.execution.ddl.commands.CreateTableCommand;
+import io.confluent.ksql.execution.ddl.commands.DdlCommand;
+import io.confluent.ksql.execution.expression.tree.BooleanLiteral;
+import io.confluent.ksql.execution.expression.tree.Literal;
+import io.confluent.ksql.execution.expression.tree.StringLiteral;
+import io.confluent.ksql.execution.expression.tree.Type;
+import io.confluent.ksql.logging.processing.NoopProcessingLogContext;
+import io.confluent.ksql.name.ColumnName;
+import io.confluent.ksql.name.SourceName;
+import io.confluent.ksql.parser.properties.with.CreateSourceProperties;
+import io.confluent.ksql.parser.tree.CreateStream;
+import io.confluent.ksql.parser.tree.CreateTable;
+import io.confluent.ksql.parser.tree.TableElement;
+import io.confluent.ksql.parser.tree.TableElement.Namespace;
+import io.confluent.ksql.parser.tree.TableElements;
+import io.confluent.ksql.properties.with.CommonCreateConfigs;
+import io.confluent.ksql.properties.with.CreateConfigs;
+import io.confluent.ksql.schema.ksql.LogicalSchema;
+import io.confluent.ksql.schema.ksql.PersistenceSchema;
+import io.confluent.ksql.schema.ksql.types.SqlTypes;
+import io.confluent.ksql.serde.FormatInfo;
+import io.confluent.ksql.serde.KeyFormat;
+import io.confluent.ksql.serde.SerdeOption;
+import io.confluent.ksql.serde.ValueFormat;
+import io.confluent.ksql.serde.ValueSerdeFactory;
+import io.confluent.ksql.serde.WindowInfo;
+import io.confluent.ksql.services.KafkaTopicClient;
+import io.confluent.ksql.services.ServiceContext;
+import io.confluent.ksql.util.KsqlConfig;
+import io.confluent.ksql.util.KsqlException;
+import java.time.Duration;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
+import org.apache.kafka.common.serialization.Serde;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnitRunner;
+
+@RunWith(MockitoJUnitRunner.class)
+public class CreateSourceFactoryTest {
+  private static final SourceName SOME_NAME = SourceName.of("bob");
+  private static final String sqlExpression = "sqlExpression";
+  private static final TableElement ELEMENT1 =
+      tableElement(Namespace.VALUE, "bob", new Type(SqlTypes.STRING));
+  private static final TableElement ELEMENT2 =
+      tableElement(Namespace.VALUE, "hojjat", new Type(SqlTypes.STRING));
+  private static final TableElements SOME_ELEMENTS = TableElements.of(ELEMENT1);
+  private static final TableElements TWO_ELEMENTS = TableElements.of(ELEMENT1, ELEMENT2);
+  private static final String TOPIC_NAME = "some topic";
+  private static final Map<String, Literal> MINIMIM_PROPS = ImmutableMap.of(
+      CommonCreateConfigs.VALUE_FORMAT_PROPERTY, new StringLiteral("JSON"),
+      CommonCreateConfigs.KAFKA_TOPIC_NAME_PROPERTY, new StringLiteral(TOPIC_NAME)
+  );
+  private static final TableElements ONE_ELEMENT = TableElements.of(
+      tableElement(Namespace.VALUE, "bob", new Type(SqlTypes.STRING)));
+  private static final Set<SerdeOption> SOME_SERDE_OPTIONS = ImmutableSet
+      .of(SerdeOption.UNWRAP_SINGLE_VALUES);
+
+  @Mock
+  private KafkaTopicClient topicClient;
+  @Mock
+  private ServiceContext serviceContext;
+  @Mock
+  private SerdeOptionsSupplier serdeOptionsSupplier;
+  @Mock
+  private ValueSerdeFactory serdeFactory;
+  @Mock
+  private Serde<GenericRow> serde;
+
+  private CreateSourceFactory createSourceFactory;
+  private KsqlConfig ksqlConfig = new KsqlConfig(ImmutableMap.of());
+  private CreateSourceProperties withProperties =
+      CreateSourceProperties.from(MINIMIM_PROPS);
+
+  @Rule
+  public final ExpectedException expectedException = ExpectedException.none();
+
+  @Before
+  @SuppressWarnings("unchecked")
+  public void before() {
+    when(serviceContext.getTopicClient()).thenReturn(topicClient);
+    when(topicClient.isTopicExists(any())).thenReturn(true);
+    when(serdeFactory.create(any(), any(), any(), any(), any(), any())).thenReturn(serde);
+
+    givenCommandFactories();
+  }
+
+  private void givenCommandFactories() {
+    createSourceFactory = new CreateSourceFactory(serviceContext);
+  }
+
+  private void givenCommandFactoriesWithMocks() {
+    createSourceFactory = new CreateSourceFactory(
+        serviceContext,
+        serdeOptionsSupplier,
+        serdeFactory
+    );
+  }
+
+  @Test
+  public void shouldCreateCommandForCreateStream() {
+    // Given:
+    final CreateStream ddlStatement =
+        new CreateStream(SOME_NAME, SOME_ELEMENTS, true, withProperties);
+
+    // When:
+    final DdlCommand result = createSourceFactory
+        .createStreamCommand(sqlExpression, ddlStatement, ksqlConfig);
+
+    assertThat(result, instanceOf(CreateStreamCommand.class));
+  }
+
+  @Test
+  public void shouldCreateCommandForCreateTable() {
+    // Given:
+    final CreateTable ddlStatement = new CreateTable(SOME_NAME,
+        TableElements.of(
+            tableElement(Namespace.VALUE, "COL1", new Type(SqlTypes.BIGINT)),
+            tableElement(Namespace.VALUE, "COL2", new Type(SqlTypes.STRING))),
+        true, withProperties);
+
+    // When:
+    final DdlCommand result = createSourceFactory
+        .createTableCommand(sqlExpression, ddlStatement, ksqlConfig);
+
+    // Then:
+    assertThat(result, instanceOf(CreateTableCommand.class));
+  }
+
+  @Test
+  public void shouldCreateStreamCommandWithSingleValueWrappingFromPropertiesNotConfig() {
+    // Given:
+    ksqlConfig = new KsqlConfig(ImmutableMap.of(
+        KsqlConfig.KSQL_WRAP_SINGLE_VALUES, true
+    ));
+
+    final ImmutableMap<String, Object> overrides = ImmutableMap.of(
+        KsqlConfig.KSQL_WRAP_SINGLE_VALUES, true
+    );
+
+    givenProperty(CommonCreateConfigs.WRAP_SINGLE_VALUE, new BooleanLiteral("false"));
+
+    final CreateStream statement =
+        new CreateStream(SOME_NAME, SOME_ELEMENTS, true, withProperties);
+
+    // When:
+    final DdlCommand cmd = createSourceFactory
+        .createStreamCommand(
+            sqlExpression,
+            statement,
+            ksqlConfig.cloneWithPropertyOverwrite(overrides)
+        );
+
+    // Then:
+    assertThat(cmd, is(instanceOf(CreateStreamCommand.class)));
+    assertThat(((CreateStreamCommand) cmd).getSerdeOptions(),
+        contains(SerdeOption.UNWRAP_SINGLE_VALUES));
+  }
+
+  @Test
+  public void shouldCreateStreamCommandWithSingleValueWrappingFromConfig() {
+    // Given:
+    ksqlConfig = new KsqlConfig(ImmutableMap.of(
+        KsqlConfig.KSQL_WRAP_SINGLE_VALUES, false
+    ));
+
+    final CreateStream statement =
+        new CreateStream(SOME_NAME, SOME_ELEMENTS, true, withProperties);
+
+    // When:
+    final DdlCommand cmd = createSourceFactory
+        .createStreamCommand(sqlExpression, statement, ksqlConfig);
+
+    // Then:
+    assertThat(cmd, is(instanceOf(CreateStreamCommand.class)));
+    assertThat(((CreateStreamCommand) cmd).getSerdeOptions(),
+        contains(SerdeOption.UNWRAP_SINGLE_VALUES));
+  }
+
+  @Test
+  public void shouldCreateStreamCommandWithSingleValueWrappingFromDefaultConfig() {
+    // Given:
+    final CreateStream statement =
+        new CreateStream(SOME_NAME, SOME_ELEMENTS, true, withProperties);
+
+    // When:
+    final DdlCommand cmd = createSourceFactory
+        .createStreamCommand(sqlExpression, statement, ksqlConfig);
+
+    // Then:
+    assertThat(cmd, is(instanceOf(CreateStreamCommand.class)));
+    assertThat(((CreateStreamCommand) cmd).getSerdeOptions(),
+        not(contains(SerdeOption.UNWRAP_SINGLE_VALUES)));
+  }
+
+  @Test
+  public void shouldCreateTableCommandWithSingleValueWrappingFromPropertiesNotConfig() {
+    // Given:
+    ksqlConfig = new KsqlConfig(ImmutableMap.of(
+        KsqlConfig.KSQL_WRAP_SINGLE_VALUES, true
+    ));
+
+    final ImmutableMap<String, Object> overrides = ImmutableMap.of(
+        KsqlConfig.KSQL_WRAP_SINGLE_VALUES, true
+    );
+
+    givenProperty(CommonCreateConfigs.WRAP_SINGLE_VALUE, new BooleanLiteral("false"));
+
+    final CreateTable statement =
+        new CreateTable(SOME_NAME, SOME_ELEMENTS, true, withProperties);
+
+    // When:
+    final DdlCommand cmd = createSourceFactory
+        .createTableCommand(
+            sqlExpression,
+            statement,
+            ksqlConfig.cloneWithPropertyOverwrite(overrides));
+
+    // Then:
+    assertThat(cmd, is(instanceOf(CreateTableCommand.class)));
+    assertThat(((CreateTableCommand) cmd).getSerdeOptions(),
+        contains(SerdeOption.UNWRAP_SINGLE_VALUES));
+  }
+
+  @Test
+  public void shouldCreateTableCommandWithSingleValueWrappingFromConfig() {
+    // Given:
+    ksqlConfig = new KsqlConfig(ImmutableMap.of(
+        KsqlConfig.KSQL_WRAP_SINGLE_VALUES, false
+    ));
+
+    final CreateTable statement =
+        new CreateTable(SOME_NAME, SOME_ELEMENTS, true, withProperties);
+
+    // When:
+    final DdlCommand cmd = createSourceFactory
+        .createTableCommand(sqlExpression, statement, ksqlConfig);
+
+    // Then:
+    assertThat(cmd, is(instanceOf(CreateTableCommand.class)));
+    assertThat(((CreateTableCommand) cmd).getSerdeOptions(),
+        contains(SerdeOption.UNWRAP_SINGLE_VALUES));
+  }
+
+  @Test
+  public void shouldCreateTableCommandWithSingleValueWrappingFromDefaultConfig() {
+    // Given:
+    final CreateTable statement =
+        new CreateTable(SOME_NAME, SOME_ELEMENTS, true, withProperties);
+
+    // When:
+    final DdlCommand cmd = createSourceFactory
+        .createTableCommand(sqlExpression, statement, ksqlConfig);
+
+    // Then:
+    assertThat(cmd, is(instanceOf(CreateTableCommand.class)));
+    assertThat(((CreateTableCommand) cmd).getSerdeOptions(),
+        not(contains(SerdeOption.UNWRAP_SINGLE_VALUES)));
+  }
+
+  @Test
+  public void shouldThrowOnNoElementsInCreateStream() {
+    // Given:
+    final CreateStream statement
+        = new CreateStream(SOME_NAME, TableElements.of(), true, withProperties);
+
+    // Then:
+    expectedException.expect(KsqlException.class);
+    expectedException.expectMessage(
+        "The statement does not define any columns.");
+
+    // When:
+    createSourceFactory.createStreamCommand("expression", statement, ksqlConfig);
+  }
+
+  @Test
+  public void shouldThrowOnNoElementsInCreateTable() {
+    // Given:
+    final CreateTable statement
+        = new CreateTable(SOME_NAME, TableElements.of(), true, withProperties);
+
+    // Then:
+    expectedException.expect(KsqlException.class);
+    expectedException.expectMessage(
+        "The statement does not define any columns.");
+
+    // When:
+    createSourceFactory.createTableCommand("expression", statement, ksqlConfig);
+  }
+
+  @Test
+  public void shouldNotThrowWhenThereAreElementsInCreateStream() {
+    // Given:
+    final CreateStream statement =
+        new CreateStream(SOME_NAME, SOME_ELEMENTS, true, withProperties);
+
+    // When:
+    createSourceFactory.createStreamCommand("expression", statement, ksqlConfig);
+
+    // Then: not exception thrown
+  }
+
+  @Test
+  public void shouldNotThrowWhenThereAreElementsInCreateTable() {
+    // Given:
+    final CreateTable statement =
+        new CreateTable(SOME_NAME, SOME_ELEMENTS, true, withProperties);
+
+    // When:
+    createSourceFactory.createTableCommand("expression", statement, ksqlConfig);
+
+    // Then: not exception thrown
+  }
+
+  @Test
+  public void shouldThrowIfTopicDoesNotExistForStream() {
+    // Given:
+    when(topicClient.isTopicExists(any())).thenReturn(false);
+    final CreateStream statement =
+        new CreateStream(SOME_NAME, SOME_ELEMENTS, true, withProperties);
+
+    // Then:
+    expectedException.expect(KsqlException.class);
+    expectedException.expectMessage("Kafka topic does not exist: " + TOPIC_NAME);
+
+    // When:
+    createSourceFactory.createStreamCommand("expression", statement, ksqlConfig);
+  }
+
+  @SuppressFBWarnings("RV_RETURN_VALUE_IGNORED_NO_SIDE_EFFECT")
+  @Test
+  public void shouldNotThrowIfTopicDoesExist() {
+    // Given:
+    final CreateStream statement =
+        new CreateStream(SOME_NAME, SOME_ELEMENTS, true, withProperties);
+
+    // When:
+    createSourceFactory.createStreamCommand("expression", statement, ksqlConfig);
+
+    // Then:
+    verify(topicClient).isTopicExists(TOPIC_NAME);
+  }
+
+  @Test
+  public void shouldThrowIfKeyFieldNotInSchemaForStream() {
+    // Given:
+    givenProperty(CreateConfigs.KEY_NAME_PROPERTY, new StringLiteral("will-not-find-me"));
+    final CreateStream statement = new CreateStream(SOME_NAME, SOME_ELEMENTS, true, withProperties);
+
+    // Then:
+    expectedException.expect(KsqlException.class);
+    expectedException.expectMessage(
+        "The KEY column set in the WITH clause does not exist in the schema: "
+            + "'WILL-NOT-FIND-ME'");
+
+    // When:
+    createSourceFactory.createStreamCommand("expression", statement, ksqlConfig);
+  }
+
+  @Test
+  public void shouldThrowIfTimestampColumnDoesNotExistForStream() {
+    // Given:
+    givenProperty(
+        CommonCreateConfigs.TIMESTAMP_NAME_PROPERTY,
+        new StringLiteral("will-not-find-me")
+    );
+    final CreateStream statement =
+        new CreateStream(SOME_NAME, SOME_ELEMENTS, true, withProperties);
+
+    // Then:
+    expectedException.expect(KsqlException.class);
+    expectedException.expectMessage(
+        "The TIMESTAMP column set in the WITH clause does not exist in the schema: "
+            + "'WILL-NOT-FIND-ME'");
+
+    // When:
+    createSourceFactory.createStreamCommand("expression", statement, ksqlConfig);
+  }
+
+  @Test
+  public void shouldBuildSerdeOptionsForStream() {
+    // Given:
+    givenCommandFactoriesWithMocks();
+    final CreateStream statement = new CreateStream(SOME_NAME, ONE_ELEMENT, true, withProperties);
+    final LogicalSchema schema = LogicalSchema.builder()
+        .valueColumn(ColumnName.of("bob"), SqlTypes.STRING)
+        .build();
+    when(serdeOptionsSupplier.build(any(), any(), any(), any())).thenReturn(SOME_SERDE_OPTIONS);
+
+    // When:
+    final CreateStreamCommand cmd = createSourceFactory.createStreamCommand(
+        "expression",
+        statement,
+        ksqlConfig
+    );
+
+    // Then:
+    verify(serdeOptionsSupplier).build(
+        schema,
+        statement.getProperties().getValueFormat(),
+        statement.getProperties().getWrapSingleValues(),
+        ksqlConfig
+    );
+    assertThat(cmd.getSerdeOptions(), is(SOME_SERDE_OPTIONS));
+  }
+
+  @Test
+  public void shouldBuildSchemaWithImplicitKeyFieldForStream() {
+    // Given:
+    final CreateStream statement = new CreateStream(SOME_NAME, TWO_ELEMENTS, true, withProperties);
+
+    // When:
+    final CreateStreamCommand result = createSourceFactory.createStreamCommand(
+        "expression",
+        statement,
+        ksqlConfig
+    );
+
+    // Then:
+    assertThat(result.getSchema(), is(LogicalSchema.builder()
+        .keyColumn(ColumnName.of("ROWKEY"), SqlTypes.STRING)
+        .valueColumn(ColumnName.of("bob"), SqlTypes.STRING)
+        .valueColumn(ColumnName.of("hojjat"), SqlTypes.STRING)
+        .build()
+    ));
+  }
+
+  @Test
+  public void shouldBuildSchemaWithExplicitKeyFieldForStream() {
+    // Given:
+    final CreateStream statement = new CreateStream(
+        SOME_NAME,
+        TableElements.of(
+            tableElement(Namespace.KEY, "ROWKEY", new Type(SqlTypes.STRING)),
+            ELEMENT1,
+            ELEMENT2
+        ),
+        true,
+        withProperties
+    );
+
+    // When:
+    final CreateStreamCommand result = createSourceFactory.createStreamCommand(
+        "expression",
+        statement,
+        ksqlConfig
+    );
+
+    // Then:
+    assertThat(result.getSchema(), is(LogicalSchema.builder()
+        .keyColumn(ColumnName.of("ROWKEY"), SqlTypes.STRING)
+        .valueColumn(ColumnName.of("bob"), SqlTypes.STRING)
+        .valueColumn(ColumnName.of("hojjat"), SqlTypes.STRING)
+        .build()
+    ));
+  }
+
+  @Test
+  public void shouldCreateSerdeToValidateValueFormatCanHandleValueSchemaForStream() {
+    // Given:
+    givenCommandFactoriesWithMocks();
+    final CreateStream statement = new CreateStream(SOME_NAME, TWO_ELEMENTS, true, withProperties);
+    final LogicalSchema schema = LogicalSchema.builder()
+        .valueColumn(ColumnName.of("bob"), SqlTypes.STRING)
+        .valueColumn(ColumnName.of("hojjat"), SqlTypes.STRING)
+        .build();
+
+    // When:
+    createSourceFactory.createStreamCommand("expression", statement, ksqlConfig);
+
+    // Then:
+    verify(serdeFactory).create(
+        FormatInfo.of(JSON, Optional.empty(), Optional.empty()),
+        PersistenceSchema.from(schema.valueConnectSchema(), false),
+        ksqlConfig,
+        serviceContext.getSchemaRegistryClientFactory(),
+        "",
+        NoopProcessingLogContext.INSTANCE
+    );
+  }
+
+  @Test
+  public void shouldDefaultToKafkaKeySerdeForStream() {
+    final CreateStream statement = new CreateStream(SOME_NAME, SOME_ELEMENTS, true, withProperties);
+
+    // When:
+    final CreateStreamCommand cmd = createSourceFactory.createStreamCommand(
+        "expression",
+        statement,
+        ksqlConfig
+    );
+
+    // Then:
+    assertThat(cmd.getTopic().getKeyFormat(), is(KeyFormat.nonWindowed(FormatInfo.of(KAFKA))));
+  }
+
+  @Test
+  public void shouldHandleValueAvroSchemaNameForStream() {
+    // Given:
+    givenCommandFactoriesWithMocks();
+    givenProperty("VALUE_FORMAT", new StringLiteral("Avro"));
+    givenProperty("value_avro_schema_full_name", new StringLiteral("full.schema.name"));
+    final CreateStream statement = new CreateStream(SOME_NAME, SOME_ELEMENTS, true, withProperties);
+
+    // When:
+    final CreateStreamCommand cmd = createSourceFactory.createStreamCommand(
+        "expression",
+        statement,
+        ksqlConfig
+    );
+
+    // Then:
+    assertThat(cmd.getTopic().getValueFormat(),
+        is(ValueFormat.of(FormatInfo.of(AVRO, Optional.of("full.schema.name"), Optional.empty()))));
+  }
+
+  @Test
+  public void shouldHandleSessionWindowedKeyForStream() {
+    // Given:
+    givenProperty("window_type", new StringLiteral("session"));
+    final CreateStream statement = new CreateStream(SOME_NAME, SOME_ELEMENTS, true, withProperties);
+
+    // When:
+    final CreateStreamCommand cmd = createSourceFactory.createStreamCommand(
+        "expression",
+        statement,
+        ksqlConfig
+    );
+
+    // Then:
+    assertThat(cmd.getTopic().getKeyFormat(), is(KeyFormat.windowed(
+        FormatInfo.of(KAFKA),
+        WindowInfo.of(SESSION, Optional.empty()))
+    ));
+  }
+
+  @Test
+  public void shouldHandleTumblingWindowedKeyForStream() {
+    // Given:
+    givenProperties(ImmutableMap.of(
+        "window_type", new StringLiteral("tumbling"),
+        "window_size", new StringLiteral("1 MINUTE")
+    ));
+    final CreateStream statement = new CreateStream(SOME_NAME, SOME_ELEMENTS, true, withProperties);
+
+    // When:
+    final CreateStreamCommand cmd = createSourceFactory.createStreamCommand(
+        "expression",
+        statement,
+        ksqlConfig
+    );
+
+    // Then:
+    assertThat(cmd.getTopic().getKeyFormat(), is(KeyFormat.windowed(
+        FormatInfo.of(KAFKA),
+        WindowInfo.of(TUMBLING, Optional.of(Duration.ofMinutes(1))))
+    ));
+  }
+
+  @Test
+  public void shouldHandleHoppingWindowedKeyForStream() {
+    // Given:
+    givenProperties(ImmutableMap.of(
+        "window_type", new StringLiteral("Hopping"),
+        "window_size", new StringLiteral("2 SECONDS")
+    ));
+    final CreateStream statement = new CreateStream(SOME_NAME, SOME_ELEMENTS, true, withProperties);
+
+    // When:
+    final CreateStreamCommand cmd = createSourceFactory.createStreamCommand(
+        "expression",
+        statement,
+        ksqlConfig
+    );
+
+    // Then:
+    assertThat(cmd.getTopic().getKeyFormat(), is(KeyFormat.windowed(
+        FormatInfo.of(KAFKA),
+        WindowInfo.of(HOPPING, Optional.of(Duration.ofSeconds(2))))
+    ));
+  }
+
+  @Test
+  public void shouldThrowOnRowTimeValueColumn() {
+    // Given:
+    final CreateStream statement = new CreateStream(
+        SOME_NAME,
+        TableElements.of(tableElement(Namespace.VALUE, ROWTIME_NAME.name(), new Type(SqlTypes.BIGINT))),
+        true,
+        withProperties
+    );
+
+    // Then:
+    expectedException.expect(KsqlException.class);
+    expectedException.expectMessage("'ROWTIME' is a reserved column name.");
+
+    // When:
+    createSourceFactory.createStreamCommand("sqlExpression", statement, ksqlConfig);
+  }
+
+  @Test
+  public void shouldThrowOnRowTimeKeyColumn() {
+    // Given:
+    final CreateStream statement = new CreateStream(
+        SOME_NAME,
+        TableElements.of(tableElement(Namespace.KEY, ROWTIME_NAME.name(), new Type(SqlTypes.BIGINT))),
+        true,
+        withProperties
+    );
+
+    // Then:
+    expectedException.expect(KsqlException.class);
+    expectedException.expectMessage("'ROWTIME' is a reserved column name.");
+
+    // When:
+    createSourceFactory.createStreamCommand("sqlExpression", statement, ksqlConfig);
+  }
+
+  @Test
+  public void shouldThrowOnRowKeyValueColumn() {
+    // Given:
+    final CreateStream statement = new CreateStream(
+        SOME_NAME,
+        TableElements.of(tableElement(VALUE, ROWKEY_NAME.name(), new Type(SqlTypes.STRING))),
+        true,
+        withProperties
+    );
+
+    // Then:
+    expectedException.expect(KsqlException.class);
+    expectedException.expectMessage(
+        "'ROWKEY' is a reserved column name. It can only be used for KEY columns.");
+
+    // When:
+    createSourceFactory.createStreamCommand("sqlExpression", statement, ksqlConfig);
+  }
+
+  @Test
+  public void shouldNotThrowOnRowKeyKeyColumn() {
+    // Given:
+    final CreateStream statement = new CreateStream(
+        SOME_NAME,
+        TableElements.of(tableElement(KEY, ROWKEY_NAME.name(), new Type(SqlTypes.STRING))),
+        true,
+        withProperties
+    );
+
+    // When:
+    createSourceFactory.createStreamCommand("sqlExpression", statement, ksqlConfig);
+
+    // Then: did not throw
+  }
+
+  @Test
+  public void shouldThrowOnRowKeyIfNotString() {
+    // Given:
+    final CreateStream statement = new CreateStream(
+        SOME_NAME,
+        TableElements.of(tableElement(KEY, ROWKEY_NAME.name(), new Type(SqlTypes.INTEGER))),
+        true,
+        withProperties
+    );
+
+    // Then:
+    expectedException.expect(KsqlException.class);
+    expectedException.expectMessage("'ROWKEY' is a KEY column with an unsupported type. "
+        + "KSQL currently only supports KEY columns of type STRING.");
+
+    // When:
+    createSourceFactory.createStreamCommand("sqlExpression", statement, ksqlConfig);
+  }
+
+  @Test
+  public void shouldThrowOnKeyColumnThatIsNotCalledRowKey() {
+    // Given:
+    final CreateStream statement = new CreateStream(
+        SOME_NAME,
+        TableElements.of(tableElement(KEY, "someKey", new Type(SqlTypes.STRING))),
+        true,
+        withProperties
+    );
+
+    // Then:
+    expectedException.expect(KsqlException.class);
+    expectedException.expectMessage("'someKey' is an invalid KEY column name. "
+        + "KSQL currently only supports KEY columns named ROWKEY.");
+
+    // When:
+    createSourceFactory.createStreamCommand("sqlExpression", statement, ksqlConfig);
+  }
+
+  private void givenProperty(final String name, final Literal value) {
+    givenProperties(ImmutableMap.of(name, value));
+  }
+
+  private void givenProperties(final Map<String, Literal> properties) {
+    final Map<String, Literal> props = withProperties.copyOfOriginalLiterals();
+    props.putAll(properties);
+    withProperties = CreateSourceProperties.from(props);
+  }
+
+  private static TableElement tableElement(
+      final Namespace namespace,
+      final String name,
+      final Type type
+  ) {
+    final TableElement te = mock(TableElement.class, name);
+    when(te.getName()).thenReturn(ColumnName.of(name));
+    when(te.getType()).thenReturn(type);
+    when(te.getNamespace()).thenReturn(namespace);
+    return te;
+  }
+}

--- a/ksql-engine/src/test/java/io/confluent/ksql/ddl/commands/DropSourceFactoryTest.java
+++ b/ksql-engine/src/test/java/io/confluent/ksql/ddl/commands/DropSourceFactoryTest.java
@@ -1,0 +1,134 @@
+/*
+ * Copyright 2019 Confluent Inc.
+ *
+ * Licensed under the Confluent Community License (the "License"); you may not use
+ * this file except in compliance with the License.  You may obtain a copy of the
+ * License at
+ *
+ * http://www.confluent.io/confluent-community-license
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package io.confluent.ksql.ddl.commands;
+
+import static org.hamcrest.CoreMatchers.equalTo;
+import static org.hamcrest.CoreMatchers.instanceOf;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.mockito.Mockito.when;
+
+import io.confluent.ksql.execution.ddl.commands.DdlCommand;
+import io.confluent.ksql.execution.ddl.commands.DropSourceCommand;
+import io.confluent.ksql.metastore.MetaStore;
+import io.confluent.ksql.metastore.model.DataSource.DataSourceType;
+import io.confluent.ksql.metastore.model.KsqlStream;
+import io.confluent.ksql.metastore.model.KsqlTable;
+import io.confluent.ksql.name.SourceName;
+import io.confluent.ksql.parser.tree.DropStream;
+import io.confluent.ksql.parser.tree.DropTable;
+import io.confluent.ksql.util.KsqlException;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnitRunner;
+
+@RunWith(MockitoJUnitRunner.class)
+public class DropSourceFactoryTest {
+  private static final SourceName SOME_NAME = SourceName.of("bob");
+  private static final SourceName TABLE_NAME = SourceName.of("tablename");
+
+  @Mock
+  private KsqlStream ksqlStream;
+  @Mock
+  private KsqlTable ksqlTable;
+  @Mock
+  private MetaStore metaStore;
+
+  private DropSourceFactory dropSourceFactory;
+
+  @Rule
+  public final ExpectedException expectedException = ExpectedException.none();
+
+  @Before
+  @SuppressWarnings("unchecked")
+  public void before() {
+    when(metaStore.getSource(SOME_NAME)).thenReturn(ksqlStream);
+    when(metaStore.getSource(TABLE_NAME)).thenReturn(ksqlTable);
+    when(ksqlStream.getDataSourceType()).thenReturn(DataSourceType.KSTREAM);
+    when(ksqlTable.getDataSourceType()).thenReturn(DataSourceType.KTABLE);
+
+    dropSourceFactory = new DropSourceFactory(metaStore);
+  }
+
+  @Test
+  public void shouldCreateCommandForDropStream() {
+    // Given:
+    final DropStream ddlStatement = new DropStream(SOME_NAME, true, true);
+
+    // When:
+    final DdlCommand result = dropSourceFactory.create(ddlStatement);
+
+    // Then:
+    assertThat(result, instanceOf(DropSourceCommand.class));
+  }
+
+  @Test
+  public void shouldCreateCommandForDropTable() {
+    // Given:
+    final DropTable ddlStatement = new DropTable(TABLE_NAME, true, true);
+
+    // When:
+    final DdlCommand result = dropSourceFactory.create(ddlStatement);
+
+    // Then:
+    assertThat(result, instanceOf(DropSourceCommand.class));
+  }
+
+  @Test
+  public void shouldCreateDropSourceOnMissingSourceWithIfExistsForStream() {
+    // Given:
+    final DropStream dropStream = new DropStream(SOME_NAME, false, true);
+    when(metaStore.getSource(SOME_NAME)).thenReturn(null);
+
+    // When:
+    final DropSourceCommand cmd = dropSourceFactory.create(dropStream);
+
+    // Then:
+    assertThat(cmd.getSourceName(), equalTo(SourceName.of("bob")));
+  }
+
+  @Test
+  public void shouldFailDropSourceOnMissingSourceWithNoIfExistsForStream() {
+    // Given:
+    final DropStream dropStream = new DropStream(SOME_NAME, true, true);
+    when(metaStore.getSource(SOME_NAME)).thenReturn(null);
+
+    // Then:
+    expectedException.expect(KsqlException.class);
+    expectedException.expectMessage("Source bob does not exist.");
+
+    // When:
+    dropSourceFactory.create(dropStream);
+  }
+
+  @Test
+  @SuppressWarnings("unchecked")
+  public void shouldFailDropSourceOnDropIncompatibleSourceForStream() {
+    // Given:
+    final DropStream dropStream = new DropStream(SOME_NAME, false, true);
+    when(metaStore.getSource(SOME_NAME)).thenReturn(ksqlTable);
+
+    // Expect:
+    expectedException.expect(KsqlException.class);
+    expectedException.expectMessage("Incompatible data source type is TABLE");
+
+    // When:
+    dropSourceFactory.create(dropStream);
+  }
+}

--- a/ksql-engine/src/test/java/io/confluent/ksql/ddl/commands/DropTypeFactoryTest.java
+++ b/ksql-engine/src/test/java/io/confluent/ksql/ddl/commands/DropTypeFactoryTest.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright 2019 Confluent Inc.
+ *
+ * Licensed under the Confluent Community License (the "License"); you may not use
+ * this file except in compliance with the License.  You may obtain a copy of the
+ * License at
+ *
+ * http://www.confluent.io/confluent-community-license
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package io.confluent.ksql.ddl.commands;
+
+import static org.hamcrest.CoreMatchers.equalTo;
+import static org.hamcrest.MatcherAssert.assertThat;
+
+import io.confluent.ksql.execution.ddl.commands.DropTypeCommand;
+import io.confluent.ksql.parser.DropType;
+import java.util.Optional;
+import org.junit.Test;
+
+public class DropTypeFactoryTest {
+  private static final String SOME_TYPE_NAME = "some_type";
+
+  private final DropTypeFactory factory = new DropTypeFactory();
+
+  @Test
+  public void shouldCreateDropType() {
+    // Given:
+    final DropType dropType = new DropType(Optional.empty(), SOME_TYPE_NAME);
+
+    // When:
+    final DropTypeCommand cmd = factory.create(dropType);
+
+    // Then:
+    assertThat(cmd.getTypeName(), equalTo(SOME_TYPE_NAME));
+  }
+}

--- a/ksql-engine/src/test/java/io/confluent/ksql/ddl/commands/RegisterTypeFactoryTest.java
+++ b/ksql-engine/src/test/java/io/confluent/ksql/ddl/commands/RegisterTypeFactoryTest.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright 2019 Confluent Inc.
+ *
+ * Licensed under the Confluent Community License (the "License"); you may not use
+ * this file except in compliance with the License.  You may obtain a copy of the
+ * License at
+ *
+ * http://www.confluent.io/confluent-community-license
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package io.confluent.ksql.ddl.commands;
+
+import static org.hamcrest.CoreMatchers.equalTo;
+import static org.hamcrest.MatcherAssert.assertThat;
+
+import io.confluent.ksql.execution.ddl.commands.RegisterTypeCommand;
+import io.confluent.ksql.execution.expression.tree.Type;
+import io.confluent.ksql.parser.tree.RegisterType;
+import io.confluent.ksql.schema.ksql.SqlBaseType;
+import io.confluent.ksql.schema.ksql.types.SqlPrimitiveType;
+import io.confluent.ksql.schema.ksql.types.SqlStruct;
+import java.util.Optional;
+import org.junit.Test;
+
+public class RegisterTypeFactoryTest {
+  private final RegisterTypeFactory factory = new RegisterTypeFactory();
+
+  @Test
+  public void shouldCreateCommandForRegisterType() {
+    // Given:
+    final RegisterType ddlStatement = new RegisterType(
+        Optional.empty(),
+        "alias",
+        new Type(SqlStruct.builder().field("foo", SqlPrimitiveType.of(SqlBaseType.STRING)).build())
+    );
+
+    // When:
+    final RegisterTypeCommand result = factory.create(ddlStatement);
+
+    // Then:
+    assertThat(result.getType(), equalTo(ddlStatement.getType().getSqlType()));
+    assertThat(result.getName(), equalTo("alias"));
+  }
+}


### PR DESCRIPTION
### Description 

This patch is a follow up to a previous commit which moved the logic
for initializing DDL commands out of the command pojos and into
`CommandFactories`. One of the follow-ups to that work was to make the
initialization logic more modular rather than just dumping it all into
`CommandFactories`. In this patch, we move this logic out into separate
factory classes for the different ddl types. `CommandFactories` now
just routes arbitrary ddl statements to the right factory.

### Testing done 

Refactored the unit tests as well to align with the new structure.

### Reviewer checklist
- [ ] Ensure docs are updated if necessary. (eg. if a user visible feature is being added or changed).
- [ ] Ensure relevant issues are linked (description should include text like "Fixes #<issue number>")

