### PR TITLE
fix: better error message if tz invalid in datetime string

### DIFF
--- a/ksql-common/src/test/java/io/confluent/ksql/util/timestamp/PartialStringToTimestampParserTest.java
+++ b/ksql-common/src/test/java/io/confluent/ksql/util/timestamp/PartialStringToTimestampParserTest.java
@@ -117,7 +117,7 @@ public class PartialStringToTimestampParserTest {
   public void shouldIncludeRequiredFormatInErrorMessage() {
     // Expect:
     expectedException.expectMessage("Required format is: \"yyyy-MM-dd'T'HH:mm:ss.SSS\", "
-        + "with an optional numeric timezone. Partials are also supported, for example \"2020-05-26\"");
+        + "with an optional numeric 4-digit timezone");
 
     // When:
     parser.parse("2017-01-01T00:00:00.000+foo");


### PR DESCRIPTION
### Description 

Improved error handling around invalid tz. Plus improved error message now mentioned optional tz.

### Testing done 

usual

### Reviewer checklist
- [ ] Ensure docs are updated if necessary. (eg. if a user visible feature is being added or changed).
- [ ] Ensure relevant issues are linked (description should include text like "Fixes #<issue number>")

