### PR TITLE
refactor: remove unused setting of application id (MINOR)

### DIFF
--- a/ksql-cli/src/main/java/io/confluent/ksql/Ksql.java
+++ b/ksql-cli/src/main/java/io/confluent/ksql/Ksql.java
@@ -22,7 +22,6 @@ import io.confluent.ksql.cli.console.OutputFormat;
 import io.confluent.ksql.properties.PropertiesUtil;
 import io.confluent.ksql.rest.client.KsqlRestClient;
 import io.confluent.ksql.util.ErrorMessageUtil;
-import io.confluent.ksql.util.KsqlConfig;
 import io.confluent.ksql.version.metrics.KsqlVersionCheckerAgent;
 import io.confluent.ksql.version.metrics.collector.KsqlModuleType;
 import java.io.File;
@@ -32,7 +31,6 @@ import java.util.Map;
 import java.util.Objects;
 import java.util.Properties;
 import java.util.function.Predicate;
-import org.apache.kafka.streams.StreamsConfig;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -109,17 +107,8 @@ public final class Ksql {
     return PropertiesUtil.filterByKey(props, NOT_CLIENT_SIDE_CONFIG);
   }
 
-  @SuppressWarnings("OptionalUsedAsFieldOrParameterType")
   private static Map<String, String> loadProperties(final String propertiesFile) {
-    final Map<String, String> properties = PropertiesUtil
-        .loadProperties(new File(propertiesFile));
-
-    final String serviceId = properties.get(KsqlConfig.KSQL_SERVICE_ID_CONFIG);
-    if (serviceId != null) {
-      properties.put(StreamsConfig.APPLICATION_ID_CONFIG, serviceId);
-    }
-
-    return properties;
+    return PropertiesUtil.loadProperties(new File(propertiesFile));
   }
 
   interface KsqlClientBuilder {

--- a/ksql-functional-tests/src/main/java/io/confluent/ksql/test/tools/TestExecutor.java
+++ b/ksql-functional-tests/src/main/java/io/confluent/ksql/test/tools/TestExecutor.java
@@ -437,7 +437,6 @@ public class TestExecutor implements Closeable {
         .put(ConsumerConfig.AUTO_OFFSET_RESET_CONFIG, "earliest")
         .put(StreamsConfig.CACHE_MAX_BYTES_BUFFERING_CONFIG, 0)
         .put(StreamsConfig.STATE_DIR_CONFIG, TestUtils.tempDirectory().getPath())
-        .put(StreamsConfig.APPLICATION_ID_CONFIG, "some.ksql.service.id")
         .put(KsqlConfig.KSQL_SERVICE_ID_CONFIG, "some.ksql.service.id")
         .put(
             KsqlConfig.KSQL_USE_NAMED_INTERNAL_TOPICS,

--- a/ksql-functional-tests/src/test/java/io/confluent/ksql/test/TopologyFileGenerator.java
+++ b/ksql-functional-tests/src/test/java/io/confluent/ksql/test/TopologyFileGenerator.java
@@ -179,7 +179,6 @@ public final class TopologyFileGenerator {
             .put(ConsumerConfig.AUTO_OFFSET_RESET_CONFIG, "earliest")
             .put(StreamsConfig.CACHE_MAX_BYTES_BUFFERING_CONFIG, 0)
             .put(StreamsConfig.STATE_DIR_CONFIG, TestUtils.tempDirectory().getPath())
-            .put(StreamsConfig.APPLICATION_ID_CONFIG, "some.ksql.service.id")
             .put(KsqlConfig.KSQL_SERVICE_ID_CONFIG, "some.ksql.service.id")
             .put(KsqlConfig.KSQL_USE_NAMED_INTERNAL_TOPICS,
                 KsqlConfig.KSQL_USE_NAMED_INTERNAL_TOPICS_ON)

--- a/ksql-rest-app/src/main/java/io/confluent/ksql/rest/server/KsqlServerMain.java
+++ b/ksql-rest-app/src/main/java/io/confluent/ksql/rest/server/KsqlServerMain.java
@@ -16,8 +16,6 @@
 package io.confluent.ksql.rest.server;
 
 import com.google.common.annotations.VisibleForTesting;
-import com.google.common.collect.ImmutableMap;
-import com.google.common.collect.ImmutableMap.Builder;
 import io.confluent.ksql.properties.PropertiesUtil;
 import io.confluent.ksql.util.KsqlConfig;
 import io.confluent.ksql.util.KsqlServerException;
@@ -34,7 +32,6 @@ import org.slf4j.LoggerFactory;
 public class KsqlServerMain {
 
   private static final Logger log = LoggerFactory.getLogger(KsqlServerMain.class);
-  private static final String KSQL_REST_SERVER_DEFAULT_APP_ID = "KSQL_REST_SERVER_DEFAULT_APP_ID";
 
   private final Executable executable;
 
@@ -93,7 +90,7 @@ public class KsqlServerMain {
       return StandaloneExecutorFactory.create(properties, queriesFile.get(), installDir);
     }
 
-    final KsqlRestConfig restConfig = new KsqlRestConfig(ensureValidProps(properties));
+    final KsqlRestConfig restConfig = new KsqlRestConfig(properties);
     final Executable restApp = KsqlRestApplication.buildApplication(
         restConfig,
         KsqlVersionCheckerAgent::new
@@ -106,17 +103,6 @@ public class KsqlServerMain {
 
     final Executable connect = ConnectExecutable.of(connectConfigFile);
     return MultiExecutable.of(connect, restApp);
-  }
-
-  private static Map<?, ?> ensureValidProps(final Map<String, String> properties) {
-    if (properties.containsKey(StreamsConfig.APPLICATION_ID_CONFIG)) {
-      return properties;
-    }
-
-    final Builder<String, String> builder = ImmutableMap.builder();
-    builder.putAll(properties);
-    builder.put(StreamsConfig.APPLICATION_ID_CONFIG, KSQL_REST_SERVER_DEFAULT_APP_ID);
-    return builder.build();
   }
 
   @VisibleForTesting

--- a/ksql-rest-app/src/test/java/io/confluent/ksql/rest/server/KsqlRestConfigTest.java
+++ b/ksql-rest-app/src/test/java/io/confluent/ksql/rest/server/KsqlRestConfigTest.java
@@ -34,7 +34,6 @@ public class KsqlRestConfigTest {
 
   private static final Map<String, ?> MIN_VALID_CONFIGS = ImmutableMap.<String, Object>builder()
       .put(StreamsConfig.BOOTSTRAP_SERVERS_CONFIG, "localhost:9092")
-      .put(StreamsConfig.APPLICATION_ID_CONFIG, "ksql_config_test")
       .put(RestConfig.LISTENERS_CONFIG, "http://localhost:8088")
       .build();
 
@@ -49,7 +48,6 @@ public class KsqlRestConfigTest {
     final Map<String, Object> ksqlConfigProperties = config.getKsqlConfigProperties();
     final Map<String, Object> expectedKsqlConfigProperties = new HashMap<>();
     expectedKsqlConfigProperties.put(StreamsConfig.BOOTSTRAP_SERVERS_CONFIG, "localhost:9092");
-    expectedKsqlConfigProperties.put(StreamsConfig.APPLICATION_ID_CONFIG, "ksql_config_test");
     expectedKsqlConfigProperties.put(RestConfig.LISTENERS_CONFIG, "http://localhost:8088");
     expectedKsqlConfigProperties.put(ConsumerConfig.AUTO_OFFSET_RESET_CONFIG, "earliest");
     expectedKsqlConfigProperties.put(KsqlConfig.KSQL_SERVICE_ID_CONFIG, "test");

--- a/ksql-rest-app/src/test/java/io/confluent/ksql/rest/server/mock/MockApplication.java
+++ b/ksql-rest-app/src/test/java/io/confluent/ksql/rest/server/mock/MockApplication.java
@@ -83,7 +83,6 @@ public class MockApplication extends Application<KsqlRestConfig> {
     final Map<String, Object> props = ImmutableMap.<String, Object>builder()
         .put(KsqlRestConfig.LISTENERS_CONFIG, "http://localhost:0")
         .put(StreamsConfig.BOOTSTRAP_SERVERS_CONFIG, "localhost:9092")
-        .put(StreamsConfig.APPLICATION_ID_CONFIG, "ksql_config_test")
         .put(RestConfig.SHUTDOWN_GRACEFUL_MS_CONFIG, (int) TimeUnit.SECONDS.toMillis(30))
         .build();
 


### PR DESCRIPTION
### Description 

The Streams config `application.id` is set in the physical plan builder (and is unique for each query), so there's no point setting it to some default, unused value in the CLI or at the time of server creation. This PR cleans up the unused, legacy code.

### Testing done 

`mvn clean package`

### Reviewer checklist
- [ ] Ensure docs are updated if necessary. (eg. if a user visible feature is being added or changed).
- [ ] Ensure relevant issues are linked (description should include text like "Fixes #<issue number>")

