### PR TITLE
test: fix RQTT to wait for all state stores to be warm (MINOR)

### DIFF
--- a/ksql-functional-tests/src/test/java/io/confluent/ksql/test/rest/RestTestExecutor.java
+++ b/ksql-functional-tests/src/test/java/io/confluent/ksql/test/rest/RestTestExecutor.java
@@ -180,8 +180,8 @@ public class RestTestExecutor implements Closeable {
 
     if (!testCase.expectedError().isPresent()) {
       for (int idx = firstStatic; testCase.getExpectedResponses().size() > idx; ++idx) {
-        final String staticStatement = allStatements.get(firstStatic);
-        final Response staticResponse = testCase.getExpectedResponses().get(firstStatic);
+        final String staticStatement = allStatements.get(idx);
+        final Response staticResponse = testCase.getExpectedResponses().get(idx);
 
         waitForWarmStateStores(staticStatement, staticResponse);
       }
@@ -353,18 +353,18 @@ public class RestTestExecutor implements Closeable {
   }
 
   private void waitForWarmStateStores(
-      final String firstStaticStatement,
-      final Response firstStaticResponse
+      final String staticStatement,
+      final Response staticResponse
   ) {
     // Special handling for static queries is required, as they depend on materialized state stores
     // being warmed up.  Initial requests may return null values.
 
-    final ImmutableList<Response> expectedResponse = ImmutableList.of(firstStaticResponse);
-    final ImmutableList<String> statements = ImmutableList.of(firstStaticStatement);
+    final ImmutableList<Response> expectedResponse = ImmutableList.of(staticResponse);
+    final ImmutableList<String> statements = ImmutableList.of(staticStatement);
 
     final long threshold = System.currentTimeMillis() + MAX_STATIC_WARMUP.toMillis();
     while (System.currentTimeMillis() < threshold) {
-      final RestResponse<KsqlEntityList> resp = restClient.makeKsqlRequest(firstStaticStatement);
+      final RestResponse<KsqlEntityList> resp = restClient.makeKsqlRequest(staticStatement);
       if (resp.isErroneous()) {
         Thread.yield();
         LOG.info("Server responded with an error code to a static query. "


### PR DESCRIPTION
### Description 

There's a block of code in the RQTT that looks set up to wait for all relevant state stores to be warm but as implemented only waits for the first one. This PR updates the block to wait for all of them.

Motivated by the following flaky test failure (observed in Jenkins): This test ([link](https://github.com/confluentinc/ksql/blob/d83c7878494583d6000146e4cb82a81d67e5f1eb/ksql-functional-tests/src/test/resources/rest-query-validation-tests/materialized-aggregate-static-queries.json#L207)) failed with
```
Response mismatch at index 3 on key: rows
Expected: is <[[10, 12345, 13456, 2], [10, 24456, 24456, 1]]>
     but: was <[[10, 12345, 13456, 2]]>
```
without waiting for this timeout ([link](https://github.com/confluentinc/ksql/blob/d83c7878494583d6000146e4cb82a81d67e5f1eb/ksql-functional-tests/src/test/java/io/confluent/ksql/test/rest/RestTestExecutor.java#L365)) since currently the timeout only applies to the first static query. (The failure occurred on the second static query.)

### Testing done 

`mvn clean package`.

### Reviewer checklist
- [ ] Ensure docs are updated if necessary. (eg. if a user visible feature is being added or changed).
- [ ] Ensure relevant issues are linked (description should include text like "Fixes #<issue number>")

