### PR TITLE
test: stabilize security integration tests

### DIFF
--- a/ksql-engine/src/test/java/io/confluent/ksql/integration/SecureIntegrationTest.java
+++ b/ksql-engine/src/test/java/io/confluent/ksql/integration/SecureIntegrationTest.java
@@ -74,7 +74,6 @@ import org.apache.kafka.common.acl.AclOperation;
 import org.apache.kafka.common.acl.AclPermissionType;
 import org.apache.kafka.common.resource.ResourcePattern;
 import org.apache.kafka.common.security.auth.SecurityProtocol;
-import org.apache.kafka.test.TestUtils;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.ClassRule;
@@ -288,13 +287,16 @@ public class SecureIntegrationTest {
                           outputTopic, INPUT_STREAM);
   }
 
-  private void assertCanRunKsqlQuery(final String queryString,
-                                     final Object... args) throws Exception {
+  private void assertCanRunKsqlQuery(
+      final String queryString,
+      final Object... args
+  ) {
     executePersistentQuery(queryString, args);
 
-    TestUtils.waitForCondition(
-        () -> topicClient.isTopicExists(this.outputTopic),
-        "Wait for async topic creation"
+    assertThatEventually(
+        "Wait for async topic creation",
+        () -> topicClient.isTopicExists(outputTopic),
+        is(true)
     );
 
     final TopicConsumer consumer = new TopicConsumer(SECURE_CLUSTER);


### PR DESCRIPTION
### Description 

This test waits only up to 15 seconds for the topic to be created. ZK can take 10+ seconds to initialize.

Switching test to use `assertThatEventually` with its default timeout of 30 seconds.

Should hopefully reduce the chance of failures such as: https://jenkins.confluent.io/job/confluentinc-pr/job/ksql/job/PR-3462/1/

### Testing done 

test only change

### Reviewer checklist
- [ ] Ensure docs are updated if necessary. (eg. if a user visible feature is being added or changed).
- [ ] Ensure relevant issues are linked (description should include text like "Fixes #<issue number>")

