### PR TITLE
fix: improve print topic error message when topic does not exist

### DIFF
--- a/ksql-engine/src/test/java/io/confluent/ksql/materialization/ks/KsStateStoreTest.java
+++ b/ksql-engine/src/test/java/io/confluent/ksql/materialization/ks/KsStateStoreTest.java
@@ -65,7 +65,7 @@ public class KsStateStoreTest {
       .build();
 
   @Rule
-  public final Timeout timeout = Timeout.seconds(1);
+  public final Timeout timeout = Timeout.seconds(10);
 
   @Rule
   public final ExpectedException expectedException = ExpectedException.none();

--- a/ksql-rest-app/src/main/java/io/confluent/ksql/rest/server/resources/streaming/StreamedQueryResource.java
+++ b/ksql-rest-app/src/main/java/io/confluent/ksql/rest/server/resources/streaming/StreamedQueryResource.java
@@ -253,7 +253,8 @@ public class StreamedQueryResource implements KsqlConfigurable {
       throw new KsqlRestException(
           Errors.badRequest(
               "Could not find topic '" + topicName + "', "
-                  + "or the KSQL user does not have permissions to list the topic."
+                  + "or the KSQL user does not have permissions to list the topic. "
+                  + "Topic names are case-sensitive."
                   + reverseSuggestion
           ));
     }


### PR DESCRIPTION
#### Description 

The message incorrectly stated that KSQL treats unquoted topic names as uppercase. This is not the case.

Also, the suggested alternative was just the opposite case to the supplied, which is fairly arbitrary, e.g. if the user issues `print PageView` and the topic does not exist the error message will suggest `pAGEvIEW`, even though no such topic exists.

With this change the error message will include any other topics that exist in the cluster with the same name,  but different case.

New error message looks like:

```bash
ksql> print PageVIEWS;
Could not find topic 'PageVIEWS', or the KSQL user does not have permissions to list the topic. Topic names are case-sensitive.
Did you mean:
	print pageviews;
	print PageViews;
ksql>
```

### Testing done 

Test class switched from EasyMock to Mockito and suitable test added.

### Reviewer checklist
- [ ] Ensure docs are updated if necessary. (eg. if a user visible feature is being added or changed).
- [ ] Ensure relevant issues are linked (description should include text like "Fixes #<issue number>")

