### PR TITLE
refactor: get the physical plan (almost) out of the engine

### DIFF
--- a/ksql-engine/src/main/java/io/confluent/ksql/engine/EngineExecutor.java
+++ b/ksql-engine/src/main/java/io/confluent/ksql/engine/EngineExecutor.java
@@ -19,24 +19,42 @@ import static io.confluent.ksql.metastore.model.DataSource.DataSourceType;
 
 import io.confluent.kafka.schemaregistry.client.SchemaRegistryClient;
 import io.confluent.ksql.KsqlExecutionContext.ExecuteResult;
+import io.confluent.ksql.execution.ddl.commands.CreateSourceCommand;
+import io.confluent.ksql.execution.ddl.commands.CreateStreamCommand;
+import io.confluent.ksql.execution.ddl.commands.CreateTableCommand;
+import io.confluent.ksql.execution.ddl.commands.DdlCommand;
+import io.confluent.ksql.metastore.model.DataSource;
+import io.confluent.ksql.metastore.model.KeyField;
+import io.confluent.ksql.name.SourceName;
 import io.confluent.ksql.parser.tree.CreateStreamAsSelect;
 import io.confluent.ksql.parser.tree.CreateTableAsSelect;
 import io.confluent.ksql.parser.tree.ExecutableDdlStatement;
 import io.confluent.ksql.parser.tree.Query;
 import io.confluent.ksql.parser.tree.QueryContainer;
 import io.confluent.ksql.parser.tree.Sink;
+import io.confluent.ksql.physical.PhysicalPlan;
 import io.confluent.ksql.planner.LogicalPlanNode;
+import io.confluent.ksql.planner.PlanSourceExtractorVisitor;
+import io.confluent.ksql.planner.plan.KsqlStructuredDataOutputNode;
 import io.confluent.ksql.planner.plan.OutputNode;
+import io.confluent.ksql.planner.plan.PlanNode;
+import io.confluent.ksql.query.QueryExecutor;
+import io.confluent.ksql.schema.ksql.Column;
+import io.confluent.ksql.schema.ksql.ColumnRef;
+import io.confluent.ksql.schema.ksql.LogicalSchema;
 import io.confluent.ksql.services.ServiceContext;
 import io.confluent.ksql.statement.ConfiguredStatement;
 import io.confluent.ksql.util.AvroUtil;
 import io.confluent.ksql.util.KsqlConfig;
+import io.confluent.ksql.util.KsqlException;
 import io.confluent.ksql.util.KsqlStatementException;
+
 import io.confluent.ksql.util.PersistentQueryMetadata;
-import io.confluent.ksql.util.QueryMetadata;
+import io.confluent.ksql.util.TransientQueryMetadata;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
+import java.util.Set;
 
 /**
  * Executor of {@code PreparedStatement} within a specific {@code EngineContext} and using a
@@ -48,7 +66,9 @@ import java.util.Optional;
  * or less permissions than the one specified. This approach is useful when KSQL needs to
  * impersonate the current REST user executing the statements.
  */
+// CHECKSTYLE_RULES.OFF: ClassDataAbstractionCoupling
 final class EngineExecutor {
+  // CHECKSTYLE_RULES.ON: ClassDataAbstractionCoupling
 
   private final EngineContext engineContext;
   private final ServiceContext serviceContext;
@@ -80,20 +100,77 @@ final class EngineExecutor {
   }
 
   ExecuteResult execute(final ConfiguredStatement<?> statement) {
+    if (statement.getStatement() instanceof Query) {
+      return ExecuteResult.of(executeQuery(statement.cast()));
+    }
+    return execute(plan(statement));
+  }
+
+  ExecuteResult execute(final KsqlPlan plan) {
+    final Optional<String> ddlResult = plan.getDdlCommand().map(ddl -> executeDDL(plan));
+    final Optional<PersistentQueryMetadata> queryMetadata =
+        plan.getQueryPlan().map(qp -> executePersistentQuery(plan));
+    return queryMetadata.map(ExecuteResult::of).orElseGet(() -> ExecuteResult.of(ddlResult.get()));
+  }
+
+  TransientQueryMetadata executeQuery(final ConfiguredStatement<Query> statement) {
+    final ExecutorPlans plans = planQuery(statement, statement.getStatement(), Optional.empty());
+    final OutputNode outputNode = plans.logicalPlan.getNode().get();
+    final QueryExecutor executor = engineContext.createQueryExecutor(
+        ksqlConfig,
+        overriddenProperties,
+        serviceContext
+    );
+    return executor.buildTransientQuery(
+        statement.getStatementText(),
+        plans.physicalPlan.getQueryId(),
+        getSourceNames(outputNode),
+        plans.physicalPlan.getPhysicalPlan(),
+        plans.physicalPlan.getPlanSummary(),
+        outputNode.getSchema(),
+        outputNode.getLimit()
+    );
+  }
+
+  KsqlPlan plan(final ConfiguredStatement<?> statement) {
     try {
       throwOnNonExecutableStatement(statement);
-
-      if (statement.getStatement() instanceof Query) {
-        return executeQuery(statement, (Query)statement.getStatement(), Optional.empty());
-      }
-      if (statement.getStatement() instanceof QueryContainer) {
-        return executeQuery(
-            statement,
-            ((QueryContainer)statement.getStatement()).getQuery(),
-            Optional.of(((QueryContainer)statement.getStatement()).getSink())
+      if (statement.getStatement() instanceof ExecutableDdlStatement) {
+        final DdlCommand ddlCommand = engineContext.createDdlCommand(
+            statement.getStatementText(),
+            (ExecutableDdlStatement) statement.getStatement(),
+            ksqlConfig,
+            overriddenProperties
+        );
+        return new KsqlPlan(
+            statement.getStatementText(),
+            Optional.of(ddlCommand),
+            Optional.empty()
         );
       }
-      return executeDdl(statement);
+      final ExecutorPlans plans = planQuery(
+          statement,
+          ((QueryContainer) statement.getStatement()).getQuery(),
+          Optional.of(((QueryContainer) statement.getStatement()).getSink())
+      );
+      final KsqlStructuredDataOutputNode outputNode =
+          (KsqlStructuredDataOutputNode) plans.logicalPlan.getNode().get();
+      final Optional<DdlCommand> ddlCommand = maybeCreateSinkDDL(
+          statement.getStatementText(),
+          outputNode,
+          plans.physicalPlan.getKeyField());
+      validateQuery(outputNode.getNodeOutputType(), statement);
+      return new KsqlPlan(
+          statement.getStatementText(),
+          ddlCommand,
+          Optional.of(
+              new QueryPlan(
+                  getSourceNames(outputNode),
+                  outputNode.getIntoSourceName(),
+                  plans.physicalPlan
+              )
+          )
+      );
     } catch (final KsqlStatementException e) {
       throw e;
     } catch (final Exception e) {
@@ -101,53 +178,150 @@ final class EngineExecutor {
     }
   }
 
-  private ExecuteResult executeQuery(final ConfiguredStatement<?> statement,
+  private ExecutorPlans planQuery(
+      final ConfiguredStatement<?> statement,
       final Query query,
       final Optional<Sink> sink) {
-
     final QueryEngine queryEngine = engineContext.createQueryEngine(serviceContext);
-
     final OutputNode outputNode = QueryEngine.buildQueryLogicalPlan(
         query,
         sink,
         engineContext.getMetaStore(),
         ksqlConfig.cloneWithPropertyOverwrite(overriddenProperties)
     );
-
-    final LogicalPlanNode logicalPlan =
-        new LogicalPlanNode(statement.getStatementText(), Optional.of(outputNode));
-
-    final QueryMetadata queryMetadata = queryEngine.buildPhysicalPlan(
+    final LogicalPlanNode logicalPlan = new LogicalPlanNode(
+        statement.getStatementText(),
+        Optional.of(outputNode)
+    );
+    final PhysicalPlan<?> physicalPlan = queryEngine.buildPhysicalPlan(
         logicalPlan,
         ksqlConfig,
         overriddenProperties,
         engineContext.getMetaStore()
     );
-
-    validateQuery(queryMetadata, statement);
-
-    engineContext.registerQuery(queryMetadata);
-
-    return ExecuteResult.of(queryMetadata);
+    return new ExecutorPlans(logicalPlan, physicalPlan);
   }
 
-  private ExecuteResult executeDdl(final ConfiguredStatement<?> statement) {
-    final String msg = engineContext.executeDdlStatement(
-        statement.getStatementText(),
-        (ExecutableDdlStatement) statement.getStatement(),
-        ksqlConfig,
-        overriddenProperties
+  private static final class ExecutorPlans {
+    private final LogicalPlanNode logicalPlan;
+    private final PhysicalPlan<?> physicalPlan;
+
+    private ExecutorPlans(
+        final LogicalPlanNode logicalPlan,
+        final PhysicalPlan<?> physicalPlan) {
+      this.logicalPlan = Objects.requireNonNull(logicalPlan, "logicalPlan");
+      this.physicalPlan = Objects.requireNonNull(physicalPlan, "physicalPlanNode");
+    }
+  }
+
+  private Optional<DdlCommand> maybeCreateSinkDDL(
+      final String sql,
+      final KsqlStructuredDataOutputNode outputNode,
+      final KeyField keyField) {
+    if (!outputNode.isDoCreateInto()) {
+      validateExistingSink(outputNode, keyField);
+      return Optional.empty();
+    }
+    final CreateSourceCommand ddl;
+    if (outputNode.getNodeOutputType() == DataSourceType.KSTREAM) {
+      ddl = new CreateStreamCommand(
+          sql,
+          outputNode.getIntoSourceName(),
+          outputNode.getSchema(),
+          keyField.ref().map(ColumnRef::name),
+          outputNode.getTimestampExtractionPolicy(),
+          outputNode.getSerdeOptions(),
+          outputNode.getKsqlTopic()
+      );
+    } else {
+      ddl = new CreateTableCommand(
+          sql,
+          outputNode.getIntoSourceName(),
+          outputNode.getSchema(),
+          keyField.ref().map(ColumnRef::name),
+          outputNode.getTimestampExtractionPolicy(),
+          outputNode.getSerdeOptions(),
+          outputNode.getKsqlTopic()
+      );
+    }
+    final SchemaRegistryClient srClient = serviceContext.getSchemaRegistryClient();
+    AvroUtil.throwOnInvalidSchemaEvolution(sql, ddl, srClient);
+    return Optional.of(ddl);
+  }
+
+  private void validateExistingSink(
+      final KsqlStructuredDataOutputNode outputNode,
+      final KeyField keyField
+  ) {
+    final SourceName name = outputNode.getIntoSourceName();
+    final DataSource<?> existing = engineContext.getMetaStore().getSource(name);
+
+    if (existing == null) {
+      throw new KsqlException(String.format("%s does not exist.", outputNode));
+    }
+
+    if (existing.getDataSourceType() != outputNode.getNodeOutputType()) {
+      throw new KsqlException(String.format("Incompatible data sink and query result. Data sink"
+              + " (%s) type is %s but select query result is %s.",
+          name.name(),
+          existing.getDataSourceType(),
+          outputNode.getNodeOutputType())
+      );
+    }
+
+    final LogicalSchema resultSchema = outputNode.getSchema();
+    final LogicalSchema existingSchema = existing.getSchema();
+
+    if (!resultSchema.equals(existingSchema)) {
+      throw new KsqlException("Incompatible schema between results and sink. "
+          + "Result schema is " + resultSchema
+          + ", but the sink schema is " + existingSchema + ".");
+    }
+
+    enforceKeyEquivalence(
+        existing.getKeyField().resolve(existingSchema, ksqlConfig),
+        keyField.resolve(resultSchema, ksqlConfig)
     );
-
-    return ExecuteResult.of(msg);
   }
 
-  private void validateQuery(
-      final QueryMetadata query,
+  private static void enforceKeyEquivalence(
+      final Optional<Column> sinkKeyCol,
+      final Optional<Column> resultKeyCol
+  ) {
+    if (!sinkKeyCol.isPresent() && !resultKeyCol.isPresent()) {
+      return;
+    }
+
+    if (sinkKeyCol.isPresent()
+        && resultKeyCol.isPresent()
+        && sinkKeyCol.get().name().equals(resultKeyCol.get().name())
+        && Objects.equals(sinkKeyCol.get().type(), resultKeyCol.get().type())) {
+      return;
+    }
+
+    throwIncompatibleKeysException(sinkKeyCol, resultKeyCol);
+  }
+
+  private static void throwIncompatibleKeysException(
+      final Optional<Column> sinkKeyCol,
+      final Optional<Column> resultKeyCol
+  ) {
+    throw new KsqlException(String.format(
+        "Incompatible key fields for sink and results. Sink"
+            + " key field is %s (type: %s) while result key "
+            + "field is %s (type: %s)",
+        sinkKeyCol.map(c -> c.name().name()).orElse(null),
+        sinkKeyCol.map(Column::type).orElse(null),
+        resultKeyCol.map(c -> c.name().name()).orElse(null),
+        resultKeyCol.map(Column::type).orElse(null)));
+  }
+
+  private static void validateQuery(
+      final DataSourceType dataSourceType,
       final ConfiguredStatement<?> statement
   ) {
     if (statement.getStatement() instanceof CreateStreamAsSelect
-        && query.getDataSourceType() == DataSourceType.KTABLE) {
+        && dataSourceType == DataSourceType.KTABLE) {
       throw new KsqlStatementException("Invalid result type. "
           + "Your SELECT query produces a TABLE. "
           + "Please use CREATE TABLE AS SELECT statement instead.",
@@ -155,18 +329,11 @@ final class EngineExecutor {
     }
 
     if (statement.getStatement() instanceof CreateTableAsSelect
-        && query.getDataSourceType() == DataSourceType.KSTREAM) {
+        && dataSourceType == DataSourceType.KSTREAM) {
       throw new KsqlStatementException("Invalid result type. "
           + "Your SELECT query produces a STREAM. "
           + "Please use CREATE STREAM AS SELECT statement instead.",
           statement.getStatementText());
-    }
-
-    if (query instanceof PersistentQueryMetadata) {
-      final PersistentQueryMetadata persistentQuery = (PersistentQueryMetadata) query;
-      final SchemaRegistryClient srClient = serviceContext.getSchemaRegistryClient();
-
-      AvroUtil.throwOnInvalidSchemaEvolution(persistentQuery, srClient);
     }
   }
 
@@ -174,5 +341,46 @@ final class EngineExecutor {
     if (!KsqlEngine.isExecutableStatement(statement.getStatement())) {
       throw new KsqlStatementException("Statement not executable", statement.getStatementText());
     }
+  }
+
+  private static Set<SourceName> getSourceNames(final PlanNode outputNode) {
+    final PlanSourceExtractorVisitor<?, ?> visitor = new PlanSourceExtractorVisitor<>();
+    visitor.process(outputNode, null);
+    return visitor.getSourceNames();
+  }
+
+  private String executeDDL(final KsqlPlan ksqlPlan) {
+    final DdlCommand ddlCommand = ksqlPlan.getDdlCommand().get();
+    final Optional<KeyField> keyField = ksqlPlan.getQueryPlan()
+        .map(QueryPlan::getPhysicalPlan)
+        .map(PhysicalPlan::getKeyField);
+    try {
+      return engineContext.executeDdl(ksqlPlan.getStatementText(), ddlCommand, keyField);
+    } catch (final KsqlStatementException e) {
+      throw e;
+    } catch (final Exception e) {
+      throw new KsqlStatementException(e.getMessage(), ksqlPlan.getStatementText(), e);
+    }
+  }
+
+  private PersistentQueryMetadata executePersistentQuery(final KsqlPlan ksqlPlan) {
+    final QueryPlan queryPlan = ksqlPlan.getQueryPlan().get();
+    final PhysicalPlan<?> physicalPlan = queryPlan.getPhysicalPlan();
+    final QueryExecutor executor = engineContext.createQueryExecutor(
+        ksqlConfig,
+        overriddenProperties,
+        serviceContext
+    );
+    final PersistentQueryMetadata queryMetadata = executor.buildQuery(
+        ksqlPlan.getStatementText(),
+        physicalPlan.getQueryId(),
+        engineContext.getMetaStore().getSource(queryPlan.getSink()),
+        physicalPlan.getMaterializationInfo(),
+        queryPlan.getSources(),
+        physicalPlan.getPhysicalPlan(),
+        physicalPlan.getPlanSummary()
+    );
+    engineContext.registerQuery(queryMetadata);
+    return queryMetadata;
   }
 }

--- a/ksql-engine/src/main/java/io/confluent/ksql/engine/KsqlPlan.java
+++ b/ksql-engine/src/main/java/io/confluent/ksql/engine/KsqlPlan.java
@@ -1,0 +1,48 @@
+/*
+ * Copyright 2019 Confluent Inc.
+ *
+ * Licensed under the Confluent Community License (the "License"); you may not use
+ * this file except in compliance with the License.  You may obtain a copy of the
+ * License at
+ *
+ * http://www.confluent.io/confluent-community-license
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package io.confluent.ksql.engine;
+
+import io.confluent.ksql.execution.ddl.commands.DdlCommand;
+import java.util.Objects;
+import java.util.Optional;
+
+public final class KsqlPlan {
+  private final String statementText;
+  private Optional<DdlCommand> ddlCommand;
+  private Optional<QueryPlan> queryPlan;
+
+  public KsqlPlan(
+      final String statementText,
+      final Optional<DdlCommand> ddlCommand,
+      final Optional<QueryPlan> queryPlan
+  ) {
+    this.statementText = Objects.requireNonNull(statementText, "statementText");
+    this.ddlCommand = Objects.requireNonNull(ddlCommand, "ddlCommand");
+    this.queryPlan = Objects.requireNonNull(queryPlan, "queryPlan");
+  }
+
+  public Optional<DdlCommand> getDdlCommand() {
+    return ddlCommand;
+  }
+
+  public Optional<QueryPlan> getQueryPlan() {
+    return queryPlan;
+  }
+
+  public String getStatementText() {
+    return statementText;
+  }
+}

--- a/ksql-engine/src/main/java/io/confluent/ksql/engine/QueryPlan.java
+++ b/ksql-engine/src/main/java/io/confluent/ksql/engine/QueryPlan.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright 2019 Confluent Inc.
+ *
+ * Licensed under the Confluent Community License (the "License"); you may not use
+ * this file except in compliance with the License.  You may obtain a copy of the
+ * License at
+ *
+ * http://www.confluent.io/confluent-community-license
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package io.confluent.ksql.engine;
+
+import io.confluent.ksql.name.SourceName;
+import io.confluent.ksql.physical.PhysicalPlan;
+import java.util.Objects;
+import java.util.Set;
+
+public final class QueryPlan  {
+  private final Set<SourceName> sources;
+  private final SourceName sink;
+  private final PhysicalPlan<?> physicalPlan;
+
+  public QueryPlan(
+      final Set<SourceName> sources,
+      final SourceName sink,
+      final PhysicalPlan<?> physicalPlan
+  ) {
+    this.sources = Objects.requireNonNull(sources, "sources");
+    this.sink = Objects.requireNonNull(sink, "sink");
+    this.physicalPlan = Objects.requireNonNull(physicalPlan, "physicalPlan");
+  }
+
+  public SourceName getSink() {
+    return sink;
+  }
+
+  public Set<SourceName> getSources() {
+    return sources;
+  }
+
+  public PhysicalPlan<?> getPhysicalPlan() {
+    return physicalPlan;
+  }
+}

--- a/ksql-engine/src/main/java/io/confluent/ksql/physical/PhysicalPlan.java
+++ b/ksql-engine/src/main/java/io/confluent/ksql/physical/PhysicalPlan.java
@@ -1,0 +1,67 @@
+/*
+ * Copyright 2019 Confluent Inc.
+ *
+ * Licensed under the Confluent Community License (the "License"); you may not use
+ * this file except in compliance with the License.  You may obtain a copy of the
+ * License at
+ *
+ * http://www.confluent.io/confluent-community-license
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package io.confluent.ksql.physical;
+
+import io.confluent.ksql.execution.plan.ExecutionStep;
+import io.confluent.ksql.materialization.MaterializationInfo;
+import io.confluent.ksql.metastore.model.KeyField;
+import io.confluent.ksql.query.QueryId;
+import java.util.Objects;
+import java.util.Optional;
+import jdk.nashorn.internal.ir.annotations.Immutable;
+
+@Immutable
+public final class PhysicalPlan<T> {
+  private final QueryId queryId;
+  private final ExecutionStep<T> physicalPlan;
+  private final Optional<MaterializationInfo> materializationInfo;
+  private final String planSummary;
+  private final transient KeyField keyField;
+
+  PhysicalPlan(
+      final QueryId queryId,
+      final ExecutionStep<T> physicalPlan,
+      final Optional<MaterializationInfo> materializationInfo,
+      final String planSummary,
+      final KeyField keyField
+  ) {
+    this.queryId = Objects.requireNonNull(queryId, "queryId");
+    this.physicalPlan = Objects.requireNonNull(physicalPlan, "physicalPlan");
+    this.planSummary = Objects.requireNonNull(planSummary, "planSummary");
+    this.keyField = Objects.requireNonNull(keyField, "keyField");
+    this.materializationInfo = Objects.requireNonNull(materializationInfo, "materializationInfo");
+  }
+
+  public ExecutionStep<?> getPhysicalPlan() {
+    return physicalPlan;
+  }
+
+  public String getPlanSummary() {
+    return planSummary;
+  }
+
+  public KeyField getKeyField() {
+    return keyField;
+  }
+
+  public QueryId getQueryId() {
+    return queryId;
+  }
+
+  public Optional<MaterializationInfo> getMaterializationInfo() {
+    return materializationInfo;
+  }
+}

--- a/ksql-engine/src/main/java/io/confluent/ksql/physical/PhysicalPlanBuilder.java
+++ b/ksql-engine/src/main/java/io/confluent/ksql/physical/PhysicalPlanBuilder.java
@@ -17,89 +17,31 @@ package io.confluent.ksql.physical;
 
 import static io.confluent.ksql.metastore.model.DataSource.DataSourceType;
 
-import io.confluent.ksql.GenericRow;
-import io.confluent.ksql.errors.ProductionExceptionHandlerUtil;
 import io.confluent.ksql.execution.builder.KsqlQueryBuilder;
-import io.confluent.ksql.execution.plan.PlanBuilder;
-import io.confluent.ksql.execution.streams.KSPlanBuilder;
 import io.confluent.ksql.function.FunctionRegistry;
-import io.confluent.ksql.logging.processing.NoopProcessingLogContext;
 import io.confluent.ksql.logging.processing.ProcessingLogContext;
-import io.confluent.ksql.logging.processing.ProcessingLogger;
-import io.confluent.ksql.materialization.KsqlMaterializationFactory;
 import io.confluent.ksql.materialization.MaterializationInfo;
-import io.confluent.ksql.materialization.MaterializationProvider;
-import io.confluent.ksql.materialization.ks.KsMaterialization;
-import io.confluent.ksql.materialization.ks.KsMaterializationFactory;
-import io.confluent.ksql.metastore.MutableMetaStore;
-import io.confluent.ksql.metastore.model.DataSource;
-import io.confluent.ksql.metastore.model.KsqlStream;
-import io.confluent.ksql.metastore.model.KsqlTable;
-import io.confluent.ksql.metrics.ConsumerCollector;
-import io.confluent.ksql.metrics.ProducerCollector;
-import io.confluent.ksql.name.ColumnName;
-import io.confluent.ksql.name.SourceName;
 import io.confluent.ksql.planner.LogicalPlanNode;
-import io.confluent.ksql.planner.PlanSourceExtractorVisitor;
 import io.confluent.ksql.planner.plan.AggregateNode;
-import io.confluent.ksql.planner.plan.KsqlBareOutputNode;
-import io.confluent.ksql.planner.plan.KsqlStructuredDataOutputNode;
 import io.confluent.ksql.planner.plan.OutputNode;
 import io.confluent.ksql.planner.plan.PlanNode;
 import io.confluent.ksql.query.QueryId;
 import io.confluent.ksql.query.id.QueryIdGenerator;
-import io.confluent.ksql.schema.ksql.Column;
-import io.confluent.ksql.schema.ksql.LogicalSchema;
-import io.confluent.ksql.schema.ksql.PhysicalSchema;
-import io.confluent.ksql.serde.GenericKeySerDe;
-import io.confluent.ksql.serde.KeyFormat;
 import io.confluent.ksql.services.ServiceContext;
 import io.confluent.ksql.structured.SchemaKStream;
 import io.confluent.ksql.structured.SchemaKTable;
-import io.confluent.ksql.util.KafkaStreamsUncaughtExceptionHandler;
 import io.confluent.ksql.util.KsqlConfig;
-import io.confluent.ksql.util.KsqlConstants;
-import io.confluent.ksql.util.KsqlException;
-import io.confluent.ksql.util.PersistentQueryMetadata;
-import io.confluent.ksql.util.QueryMetadata;
-import io.confluent.ksql.util.TransientQueryMetadata;
-import java.util.Arrays;
-import java.util.HashMap;
-import java.util.LinkedList;
-import java.util.List;
-import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
-import java.util.Set;
-import java.util.function.Consumer;
-import org.apache.kafka.clients.consumer.ConsumerConfig;
-import org.apache.kafka.clients.producer.ProducerConfig;
-import org.apache.kafka.common.serialization.Serializer;
-import org.apache.kafka.connect.data.Struct;
-import org.apache.kafka.streams.KafkaStreams;
 import org.apache.kafka.streams.StreamsBuilder;
-import org.apache.kafka.streams.StreamsConfig;
-import org.apache.kafka.streams.Topology;
-import org.apache.kafka.streams.kstream.KStream;
-import org.apache.kafka.streams.kstream.KTable;
 
-// CHECKSTYLE_RULES.OFF: ClassDataAbstractionCoupling
 public class PhysicalPlanBuilder {
-  // CHECKSTYLE_RULES.ON: ClassDataAbstractionCoupling
-
   private final StreamsBuilder builder;
   private final KsqlConfig ksqlConfig;
   private final ServiceContext serviceContext;
   private final ProcessingLogContext processingLogContext;
   private final FunctionRegistry functionRegistry;
-  private final Map<String, Object> overriddenProperties;
-  private final MutableMetaStore metaStore;
   private final QueryIdGenerator queryIdGenerator;
-  private final KafkaStreamsBuilder kafkaStreamsBuilder;
-  private final Consumer<QueryMetadata> queryCloseCallback;
-  private final KsMaterializationFactory ksMaterializationFactory;
-  private final KsqlMaterializationFactory ksqlMaterializationFactory;
-
 
   public PhysicalPlanBuilder(
       final StreamsBuilder builder,
@@ -107,11 +49,7 @@ public class PhysicalPlanBuilder {
       final ServiceContext serviceContext,
       final ProcessingLogContext processingLogContext,
       final FunctionRegistry functionRegistry,
-      final Map<String, Object> overriddenProperties,
-      final MutableMetaStore metaStore,
-      final QueryIdGenerator queryIdGenerator,
-      final KafkaStreamsBuilder kafkaStreamsBuilder,
-      final Consumer<QueryMetadata> queryCloseCallback
+      final QueryIdGenerator queryIdGenerator
   ) {
     this.builder = Objects.requireNonNull(builder, "builder");
     this.ksqlConfig = Objects.requireNonNull(ksqlConfig, "ksqlConfig");
@@ -120,21 +58,10 @@ public class PhysicalPlanBuilder {
         processingLogContext,
         "processingLogContext");
     this.functionRegistry = Objects.requireNonNull(functionRegistry, "functionRegistry");
-    this.overriddenProperties =
-        Objects.requireNonNull(overriddenProperties, "overriddenProperties");
-    this.metaStore = Objects.requireNonNull(metaStore, "metaStore");
     this.queryIdGenerator = Objects.requireNonNull(queryIdGenerator, "queryIdGenerator");
-    this.kafkaStreamsBuilder = Objects.requireNonNull(kafkaStreamsBuilder, "kafkaStreamsBuilder");
-    this.queryCloseCallback = Objects.requireNonNull(queryCloseCallback, "queryCloseCallback");
-    this.ksMaterializationFactory = new KsMaterializationFactory();
-    this.ksqlMaterializationFactory = new KsqlMaterializationFactory(
-        ksqlConfig,
-        functionRegistry,
-        processingLogContext
-    );
   }
 
-  public QueryMetadata buildPhysicalPlan(final LogicalPlanNode logicalPlanNode) {
+  public PhysicalPlan<?> buildPhysicalPlan(final LogicalPlanNode logicalPlanNode) {
     final OutputNode outputNode = logicalPlanNode.getNode()
         .orElseThrow(() -> new IllegalArgumentException("Need an output node to build a plan"));
 
@@ -150,194 +77,18 @@ public class PhysicalPlanBuilder {
     );
 
     final SchemaKStream<?> resultStream = outputNode.buildStream(ksqlQueryBuilder);
-
-    if (outputNode instanceof KsqlBareOutputNode) {
-      final String transientQueryPrefix =
-          ksqlConfig.getString(KsqlConfig.KSQL_TRANSIENT_QUERY_NAME_PREFIX_CONFIG);
-
-      return buildPlanForBareQuery(
-          ksqlQueryBuilder,
-          resultStream,
-          (KsqlBareOutputNode) outputNode,
-          getServiceId(),
-          transientQueryPrefix,
-          queryId,
-          logicalPlanNode.getStatementText()
-      );
-    }
-
-    if (outputNode instanceof KsqlStructuredDataOutputNode) {
-      final KsqlStructuredDataOutputNode ksqlStructuredDataOutputNode =
-          (KsqlStructuredDataOutputNode) outputNode;
-
-      final String persistanceQueryPrefix =
-          ksqlConfig.getString(KsqlConfig.KSQL_PERSISTENT_QUERY_NAME_PREFIX_CONFIG);
-
-      return buildPlanForStructuredOutputNode(
-          ksqlQueryBuilder,
-          logicalPlanNode.getStatementText(),
-          resultStream,
-          ksqlStructuredDataOutputNode,
-          getServiceId(),
-          persistanceQueryPrefix,
-          queryId
-      );
-    }
-
-    throw new KsqlException("Sink data source type unsupported: " + outputNode.getClass());
-  }
-
-  private QueryMetadata buildPlanForBareQuery(
-      final KsqlQueryBuilder ksqlQueryBuilder,
-      final SchemaKStream<?> schemaKStream,
-      final KsqlBareOutputNode bareOutputNode,
-      final String serviceId,
-      final String transientQueryPrefix,
-      final QueryId queryId,
-      final String statement
-  ) {
-
-    final String applicationId = addTimeSuffix(getQueryApplicationId(
-        serviceId,
-        transientQueryPrefix,
-        queryId
-    ));
-
-    final Map<String, Object> streamsProperties = buildStreamsProperties(
-        applicationId,
-        ksqlConfig,
-        queryId,
-        processingLogContext
-    );
-
-    final KStream<?, GenericRow> kStream;
-    final PlanBuilder planBuilder = new KSPlanBuilder(ksqlQueryBuilder);
-    if (schemaKStream instanceof SchemaKTable) {
-      final KTable<?, GenericRow> kTable =
-          ((SchemaKTable<?>) schemaKStream).getSourceTableStep().build(planBuilder).getTable();
-      kStream = kTable.toStream();
-    } else {
-      kStream = schemaKStream.getSourceStep().build(planBuilder).getStream();
-    }
-
-    final TransientQueryQueue<?> queue =
-        new TransientQueryQueue<>(kStream, bareOutputNode.getLimit());
-
-    final KafkaStreams streams = kafkaStreamsBuilder.buildKafkaStreams(builder, streamsProperties);
-
-    final SchemaKStream sourceSchemaKstream = schemaKStream.getSourceSchemaKStreams().get(0);
-
-    return new TransientQueryMetadata(
-        statement,
-        streams,
-        bareOutputNode.getSchema(),
-        getSourceNames(bareOutputNode),
-        queue::setLimitHandler,
-        schemaKStream.getExecutionPlan(""),
-        queue.getQueue(),
-        (sourceSchemaKstream instanceof SchemaKTable)
-            ? DataSourceType.KTABLE
-            : DataSourceType.KSTREAM,
-        applicationId,
-        builder.build(),
-        streamsProperties,
-        overriddenProperties,
-        queryCloseCallback
-    );
-  }
-
-  private QueryMetadata buildPlanForStructuredOutputNode(
-      final KsqlQueryBuilder ksqlQueryBuilder,
-      final String sqlExpression,
-      final SchemaKStream<?> schemaKStream,
-      final KsqlStructuredDataOutputNode outputNode,
-      final String serviceId,
-      final String persistanceQueryPrefix,
-      final QueryId queryId
-  ) {
-    final DataSourceType sourceType = (schemaKStream instanceof SchemaKTable)
+    final DataSourceType sourceType = (resultStream instanceof SchemaKTable)
         ? DataSourceType.KTABLE
         : DataSourceType.KSTREAM;
-
-    final DataSource<?> sinkDataSource;
-    final PlanBuilder planBuilder = new KSPlanBuilder(ksqlQueryBuilder);
-    if (sourceType == DataSourceType.KTABLE) {
-      ((SchemaKTable) schemaKStream).getSourceTableStep().build(planBuilder);
-      sinkDataSource = new KsqlTable<>(
-          sqlExpression,
-          outputNode.getIntoSourceName(),
-          outputNode.getSchema(),
-          outputNode.getSerdeOptions(),
-          schemaKStream.getKeyField(),
-          outputNode.getTimestampExtractionPolicy(),
-          outputNode.getKsqlTopic()
-      );
-    } else {
-      schemaKStream.getSourceStep().build(planBuilder);
-      sinkDataSource = new KsqlStream<>(
-          sqlExpression,
-          outputNode.getIntoSourceName(),
-          outputNode.getSchema(),
-          outputNode.getSerdeOptions(),
-          schemaKStream.getKeyField(),
-          outputNode.getTimestampExtractionPolicy(),
-          outputNode.getKsqlTopic()
-      );
-    }
-
-    sinkSetUp(outputNode, sinkDataSource);
-
-    final String applicationId = getQueryApplicationId(
-        serviceId,
-        persistanceQueryPrefix,
-        queryId
-    );
-
-    final Map<String, Object> streamsProperties = buildStreamsProperties(
-        applicationId,
-        ksqlConfig,
-        queryId,
-        processingLogContext
-    );
-
-    final KafkaStreams streams = kafkaStreamsBuilder.buildKafkaStreams(builder, streamsProperties);
-    streams.setUncaughtExceptionHandler(new KafkaStreamsUncaughtExceptionHandler());
-
-    final Topology topology = builder.build();
-
-    final PhysicalSchema querySchema = PhysicalSchema
-        .from(outputNode.getSchema(), outputNode.getSerdeOptions());
-
     final Optional<MaterializationInfo> materializationInfo = sourceType == DataSourceType.KTABLE
         ? findMaterializationInfo(outputNode)
         : Optional.empty();
-
-    final Optional<MaterializationProvider> materializationBuilder = materializationInfo
-        .flatMap(info -> buildMaterializationProvider(
-            info,
-            streams,
-            querySchema,
-            sinkDataSource.getKsqlTopic().getKeyFormat(),
-            streamsProperties
-        ));
-
-    return new PersistentQueryMetadata(
-        sqlExpression,
-        streams,
-        querySchema,
-        getSourceNames(outputNode),
-        sinkDataSource.getName(),
-        schemaKStream.getExecutionPlan(""),
+    return new PhysicalPlan<>(
         queryId,
-        sourceType,
-        materializationBuilder,
-        applicationId,
-        sinkDataSource.getKsqlTopic(),
-        topology,
-        ksqlQueryBuilder.getSchemas(),
-        streamsProperties,
-        overriddenProperties,
-        queryCloseCallback
+        resultStream.getSourceStep(),
+        materializationInfo,
+        resultStream.getExecutionPlan(""),
+        resultStream.getKeyField()
     );
   }
 
@@ -353,184 +104,6 @@ public class PhysicalPlanBuilder {
         .filter(Optional::isPresent)
         .map(Optional::get)
         .findFirst();
-  }
-
-  private Optional<MaterializationProvider> buildMaterializationProvider(
-      final MaterializationInfo info,
-      final KafkaStreams kafkaStreams,
-      final PhysicalSchema schema,
-      final KeyFormat keyFormat,
-      final Map<String, Object> streamsProperties
-  ) {
-    final Serializer<Struct> keySerializer = new GenericKeySerDe().create(
-        keyFormat.getFormatInfo(),
-        schema.keySchema(),
-        ksqlConfig,
-        serviceContext.getSchemaRegistryClientFactory(),
-        "",
-        NoopProcessingLogContext.INSTANCE
-    ).serializer();
-
-    final Optional<KsMaterialization> ksMaterialization = ksMaterializationFactory
-        .create(
-            info.stateStoreName(),
-            kafkaStreams,
-            info.aggregationSchema(),
-            keySerializer,
-            keyFormat.getWindowType(),
-            streamsProperties
-        );
-
-    return ksMaterialization.map(ksMat -> contextStacker -> ksqlMaterializationFactory
-        .create(
-            ksMat,
-            info,
-            contextStacker
-        ));
-  }
-
-  private void sinkSetUp(
-      final KsqlStructuredDataOutputNode outputNode,
-      final DataSource<?> sinkDataSource
-  ) {
-    if (outputNode.isDoCreateInto()) {
-      metaStore.putSource(sinkDataSource);
-      return;
-    }
-
-    final DataSource<?> existing =
-        metaStore.getSource(sinkDataSource.getName());
-
-    if (existing.getDataSourceType() != sinkDataSource.getDataSourceType()) {
-      throw new KsqlException(String.format("Incompatible data sink and query result. Data sink"
-              + " (%s) type is %s but select query result is %s.",
-          sinkDataSource.getName().name(),
-          sinkDataSource.getDataSourceType(),
-          existing.getDataSourceType()));
-    }
-
-    final LogicalSchema resultSchema = sinkDataSource.getSchema();
-    final LogicalSchema existingSchema = existing.getSchema();
-
-    if (!resultSchema.equals(existingSchema)) {
-      throw new KsqlException("Incompatible schema between results and sink. "
-          + "Result schema is " + resultSchema
-          + ", but the sink schema is " + existingSchema + ".");
-    }
-
-    enforceKeyEquivalence(
-        existing.getKeyField().resolve(existingSchema, ksqlConfig),
-        sinkDataSource.getKeyField().resolve(resultSchema, ksqlConfig)
-    );
-  }
-
-  private static String getQueryApplicationId(
-      final String serviceId,
-      final String queryPrefix,
-      final QueryId queryId) {
-    return serviceId + queryPrefix + queryId;
-  }
-
-  private static String addTimeSuffix(final String original) {
-    return String.format("%s_%d", original, System.currentTimeMillis());
-  }
-
-  @SuppressWarnings("unchecked")
-  private static void updateListProperty(
-      final Map<String, Object> properties,
-      final String key,
-      final Object value
-  ) {
-    final Object obj = properties.getOrDefault(key, new LinkedList<String>());
-    final List valueList;
-    // The property value is either a comma-separated string of class names, or a list of class
-    // names
-    if (obj instanceof String) {
-      // If its a string just split it on the separator so we dont have to worry about adding a
-      // separator
-      final String asString = (String) obj;
-      valueList = new LinkedList<>(Arrays.asList(asString.split("\\s*,\\s*")));
-    } else if (obj instanceof List) {
-      // The incoming list could be an instance of an immutable list. So we create a modifiable
-      // List out of it to ensure that it is mutable.
-      valueList = new LinkedList<>((List) obj);
-    } else {
-      throw new KsqlException("Expecting list or string for property: " + key);
-    }
-    valueList.add(value);
-    properties.put(key, valueList);
-  }
-
-  private static Map<String, Object> buildStreamsProperties(
-      final String applicationId,
-      final KsqlConfig ksqlConfig,
-      final QueryId queryId,
-      final ProcessingLogContext processingLogContext
-  ) {
-    final Map<String, Object> newStreamsProperties
-        = new HashMap<>(ksqlConfig.getKsqlStreamConfigProps());
-    newStreamsProperties.put(StreamsConfig.APPLICATION_ID_CONFIG, applicationId);
-    final ProcessingLogger logger
-        = processingLogContext.getLoggerFactory().getLogger(queryId.toString());
-    newStreamsProperties.put(
-        ProductionExceptionHandlerUtil.KSQL_PRODUCTION_ERROR_LOGGER,
-        logger);
-
-    updateListProperty(
-        newStreamsProperties,
-        StreamsConfig.consumerPrefix(ConsumerConfig.INTERCEPTOR_CLASSES_CONFIG),
-        ConsumerCollector.class.getCanonicalName()
-    );
-    updateListProperty(
-        newStreamsProperties,
-        StreamsConfig.producerPrefix(ProducerConfig.INTERCEPTOR_CLASSES_CONFIG),
-        ProducerCollector.class.getCanonicalName()
-    );
-    return newStreamsProperties;
-  }
-
-  private static void enforceKeyEquivalence(
-      final Optional<Column> sinkKeyCol,
-      final Optional<Column> resultKeyCol
-  ) {
-    if (!sinkKeyCol.isPresent() && !resultKeyCol.isPresent()) {
-      return;
-    }
-
-    if (sinkKeyCol.isPresent()
-        && resultKeyCol.isPresent()
-        && sinkKeyCol.get().name().equals(resultKeyCol.get().name())
-        && Objects.equals(sinkKeyCol.get().type(), resultKeyCol.get().type())) {
-      return;
-    }
-
-    throwIncompatibleKeysException(sinkKeyCol, resultKeyCol);
-  }
-
-  private static void throwIncompatibleKeysException(
-      final Optional<Column> sinkKeyCol,
-      final Optional<Column> resultKeyCol
-  ) {
-    throw new KsqlException(String.format(
-        "Incompatible key fields for sink and results. Sink"
-            + " key field is %s (type: %s) while result key "
-            + "field is %s (type: %s)",
-        sinkKeyCol.map(Column::name).map(ColumnName::name).orElse(null),
-        sinkKeyCol.map(Column::type).orElse(null),
-        resultKeyCol.map(Column::name).map(ColumnName::name).orElse(null),
-        resultKeyCol.map(Column::type).orElse(null)));
-  }
-
-  // Package private because of test
-  String getServiceId() {
-    return KsqlConstants.KSQL_INTERNAL_TOPIC_PREFIX
-           + ksqlConfig.getString(KsqlConfig.KSQL_SERVICE_ID_CONFIG);
-  }
-
-  private static Set<SourceName> getSourceNames(final PlanNode outputNode) {
-    final PlanSourceExtractorVisitor<?, ?> visitor = new PlanSourceExtractorVisitor<>();
-    visitor.process(outputNode, null);
-    return visitor.getSourceNames();
   }
 }
 

--- a/ksql-engine/src/main/java/io/confluent/ksql/query/KafkaStreamsBuilder.java
+++ b/ksql-engine/src/main/java/io/confluent/ksql/query/KafkaStreamsBuilder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 Confluent Inc.
+ * Copyright 2018 Confluent Inc.
  *
  * Licensed under the Confluent Community License (the "License"); you may not use
  * this file except in compliance with the License.  You may obtain a copy of the
@@ -13,12 +13,12 @@
  * specific language governing permissions and limitations under the License.
  */
 
-package io.confluent.ksql.physical;
+package io.confluent.ksql.query;
 
-public interface LimitHandler {
+import java.util.Map;
+import org.apache.kafka.streams.KafkaStreams;
+import org.apache.kafka.streams.StreamsBuilder;
 
-  /**
-   * Fired when the limit is reached
-   */
-  void limitReached();
+public interface KafkaStreamsBuilder {
+  KafkaStreams buildKafkaStreams(StreamsBuilder builder, Map<String, Object> conf);
 }

--- a/ksql-engine/src/main/java/io/confluent/ksql/query/KafkaStreamsBuilderImpl.java
+++ b/ksql-engine/src/main/java/io/confluent/ksql/query/KafkaStreamsBuilderImpl.java
@@ -13,7 +13,7 @@
  * specific language governing permissions and limitations under the License.
  */
 
-package io.confluent.ksql.physical;
+package io.confluent.ksql.query;
 
 import java.util.Map;
 import java.util.Objects;

--- a/ksql-engine/src/main/java/io/confluent/ksql/query/LimitHandler.java
+++ b/ksql-engine/src/main/java/io/confluent/ksql/query/LimitHandler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018 Confluent Inc.
+ * Copyright 2019 Confluent Inc.
  *
  * Licensed under the Confluent Community License (the "License"); you may not use
  * this file except in compliance with the License.  You may obtain a copy of the
@@ -13,12 +13,12 @@
  * specific language governing permissions and limitations under the License.
  */
 
-package io.confluent.ksql.physical;
+package io.confluent.ksql.query;
 
-import java.util.Map;
-import org.apache.kafka.streams.KafkaStreams;
-import org.apache.kafka.streams.StreamsBuilder;
+public interface LimitHandler {
 
-public interface KafkaStreamsBuilder {
-  KafkaStreams buildKafkaStreams(StreamsBuilder builder, Map<String, Object> conf);
+  /**
+   * Fired when the limit is reached
+   */
+  void limitReached();
 }

--- a/ksql-engine/src/main/java/io/confluent/ksql/query/LimitQueueCallback.java
+++ b/ksql-engine/src/main/java/io/confluent/ksql/query/LimitQueueCallback.java
@@ -13,23 +13,16 @@
  * specific language governing permissions and limitations under the License.
  */
 
-package io.confluent.ksql.physical;
+package io.confluent.ksql.query;
 
-/**
- * A {@code LimitQueueCallback} that does not apply a limit.
- */
-public class UnlimitedQueueCallback implements LimitQueueCallback {
+public interface LimitQueueCallback extends QueueCallback {
 
-  @Override
-  public void setLimitHandler(final LimitHandler limitHandler) {
-  }
-
-  @Override
-  public boolean shouldQueue() {
-    return true;
-  }
-
-  @Override
-  public void onQueued() {
-  }
+  /**
+   * Sets the limit handler that will be called when the limit is reached.
+   *
+   * <p>Replaces any previous handler.
+   *
+   * @param limitHandler the handler.
+   */
+  void setLimitHandler(LimitHandler limitHandler);
 }

--- a/ksql-engine/src/main/java/io/confluent/ksql/query/LimitedQueueCallback.java
+++ b/ksql-engine/src/main/java/io/confluent/ksql/query/LimitedQueueCallback.java
@@ -13,7 +13,7 @@
  * specific language governing permissions and limitations under the License.
  */
 
-package io.confluent.ksql.physical;
+package io.confluent.ksql.query;
 
 import java.util.Objects;
 import java.util.concurrent.atomic.AtomicInteger;

--- a/ksql-engine/src/main/java/io/confluent/ksql/query/QueryExecutor.java
+++ b/ksql-engine/src/main/java/io/confluent/ksql/query/QueryExecutor.java
@@ -1,0 +1,369 @@
+/*
+ * Copyright 2019 Confluent Inc.
+ *
+ * Licensed under the Confluent Community License (the "License"); you may not use
+ * this file except in compliance with the License.  You may obtain a copy of the
+ * License at
+ *
+ * http://www.confluent.io/confluent-community-license
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package io.confluent.ksql.query;
+
+import io.confluent.ksql.GenericRow;
+import io.confluent.ksql.errors.ProductionExceptionHandlerUtil;
+import io.confluent.ksql.execution.builder.KsqlQueryBuilder;
+import io.confluent.ksql.execution.plan.ExecutionStep;
+import io.confluent.ksql.execution.plan.KStreamHolder;
+import io.confluent.ksql.execution.plan.KTableHolder;
+import io.confluent.ksql.execution.plan.PlanBuilder;
+import io.confluent.ksql.execution.streams.KSPlanBuilder;
+import io.confluent.ksql.function.FunctionRegistry;
+import io.confluent.ksql.logging.processing.NoopProcessingLogContext;
+import io.confluent.ksql.logging.processing.ProcessingLogContext;
+import io.confluent.ksql.logging.processing.ProcessingLogger;
+import io.confluent.ksql.materialization.KsqlMaterializationFactory;
+import io.confluent.ksql.materialization.MaterializationInfo;
+import io.confluent.ksql.materialization.MaterializationProvider;
+import io.confluent.ksql.materialization.ks.KsMaterialization;
+import io.confluent.ksql.materialization.ks.KsMaterializationFactory;
+import io.confluent.ksql.metastore.model.DataSource;
+import io.confluent.ksql.metrics.ConsumerCollector;
+import io.confluent.ksql.metrics.ProducerCollector;
+import io.confluent.ksql.name.SourceName;
+import io.confluent.ksql.schema.ksql.LogicalSchema;
+import io.confluent.ksql.schema.ksql.PhysicalSchema;
+import io.confluent.ksql.serde.GenericKeySerDe;
+import io.confluent.ksql.serde.KeyFormat;
+import io.confluent.ksql.services.ServiceContext;
+import io.confluent.ksql.util.KafkaStreamsUncaughtExceptionHandler;
+import io.confluent.ksql.util.KsqlConfig;
+import io.confluent.ksql.util.KsqlConstants;
+import io.confluent.ksql.util.KsqlException;
+import io.confluent.ksql.util.PersistentQueryMetadata;
+import io.confluent.ksql.util.QueryMetadata;
+import io.confluent.ksql.util.TransientQueryMetadata;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Optional;
+import java.util.OptionalInt;
+import java.util.Set;
+import java.util.function.Consumer;
+import org.apache.kafka.clients.consumer.ConsumerConfig;
+import org.apache.kafka.clients.producer.ProducerConfig;
+import org.apache.kafka.common.serialization.Serializer;
+import org.apache.kafka.connect.data.Struct;
+import org.apache.kafka.streams.KafkaStreams;
+import org.apache.kafka.streams.StreamsBuilder;
+import org.apache.kafka.streams.StreamsConfig;
+import org.apache.kafka.streams.Topology;
+import org.apache.kafka.streams.kstream.KStream;
+import org.apache.kafka.streams.kstream.KTable;
+
+// CHECKSTYLE_RULES.OFF: ClassDataAbstractionCoupling
+public final class QueryExecutor {
+  // CHECKSTYLE_RULES.ON: ClassDataAbstractionCoupling
+  private final KsqlConfig ksqlConfig;
+  private final Map<String, Object> overrides;
+  private final ProcessingLogContext processingLogContext;
+  private final ServiceContext serviceContext;
+  private final FunctionRegistry functionRegistry;
+  private final KafkaStreamsBuilder kafkaStreamsBuilder;
+  private final Consumer<QueryMetadata> queryCloseCallback;
+  private final KsMaterializationFactory ksMaterializationFactory;
+  private final KsqlMaterializationFactory ksqlMaterializationFactory;
+  private final StreamsBuilder streamsBuilder;
+
+  public QueryExecutor(
+      final KsqlConfig ksqlConfig,
+      final Map<String, Object> overrides,
+      final ProcessingLogContext processingLogContext,
+      final ServiceContext serviceContext,
+      final FunctionRegistry functionRegistry,
+      final Consumer<QueryMetadata> queryCloseCallback) {
+    this(
+        ksqlConfig,
+        overrides,
+        processingLogContext,
+        serviceContext,
+        functionRegistry,
+        queryCloseCallback,
+        new KafkaStreamsBuilderImpl(
+            Objects.requireNonNull(serviceContext, "serviceContext").getKafkaClientSupplier()),
+        new StreamsBuilder(),
+        new KsqlMaterializationFactory(
+            Objects.requireNonNull(ksqlConfig, "ksqlConfig"),
+            Objects.requireNonNull(functionRegistry, "functionRegistry"),
+            Objects.requireNonNull(processingLogContext, "processingLogContext")
+        ),
+        new KsMaterializationFactory()
+    );
+  }
+
+  QueryExecutor(
+      final KsqlConfig ksqlConfig,
+      final Map<String, Object> overrides,
+      final ProcessingLogContext processingLogContext,
+      final ServiceContext serviceContext,
+      final FunctionRegistry functionRegistry,
+      final Consumer<QueryMetadata> queryCloseCallback,
+      final KafkaStreamsBuilder kafkaStreamsBuilder,
+      final StreamsBuilder streamsBuilder,
+      final KsqlMaterializationFactory ksqlMaterializationFactory,
+      final KsMaterializationFactory ksMaterializationFactory) {
+    this.ksqlConfig = Objects.requireNonNull(ksqlConfig, "ksqlConfig");
+    this.overrides = Objects.requireNonNull(overrides, "overrides");
+    this.processingLogContext = Objects.requireNonNull(
+        processingLogContext,
+        "processingLogContext"
+    );
+    this.serviceContext = Objects.requireNonNull(serviceContext, "serviceContext");
+    this.functionRegistry = Objects.requireNonNull(functionRegistry, "functionRegistry");
+    this.queryCloseCallback = Objects.requireNonNull(
+        queryCloseCallback,
+        "queryCloseCallback"
+    );
+    this.ksMaterializationFactory = Objects.requireNonNull(
+        ksMaterializationFactory,
+        "ksMaterializationFactory"
+    );
+    this.ksqlMaterializationFactory = Objects.requireNonNull(
+        ksqlMaterializationFactory,
+        "ksqlMaterializationFactory"
+    );
+    this.kafkaStreamsBuilder = Objects.requireNonNull(kafkaStreamsBuilder);
+    this.streamsBuilder = Objects.requireNonNull(streamsBuilder, "builder");
+  }
+
+  public TransientQueryMetadata buildTransientQuery(
+      final String statementText,
+      final QueryId queryId,
+      final Set<SourceName> sources,
+      final ExecutionStep<?> physicalPlan,
+      final String planSummary,
+      final LogicalSchema schema,
+      final OptionalInt limit
+  ) {
+    final TransientQueryQueue queue = buildTransientQueryQueue(queryId, physicalPlan, limit);
+    final String transientQueryPrefix =
+        ksqlConfig.getString(KsqlConfig.KSQL_TRANSIENT_QUERY_NAME_PREFIX_CONFIG);
+    final String applicationId = addTimeSuffix(getQueryApplicationId(
+        getServiceId(),
+        transientQueryPrefix,
+        queryId
+    ));
+    final Map<String, Object> streamsProperties = buildStreamsProperties(applicationId, queryId);
+    final KafkaStreams streams =
+        kafkaStreamsBuilder.buildKafkaStreams(streamsBuilder, streamsProperties);
+    streams.setUncaughtExceptionHandler(new KafkaStreamsUncaughtExceptionHandler());
+    return new TransientQueryMetadata(
+        statementText,
+        streams,
+        schema,
+        sources,
+        queue::setLimitHandler,
+        planSummary,
+        queue.getQueue(),
+        applicationId,
+        streamsBuilder.build(),
+        streamsProperties,
+        overrides,
+        queryCloseCallback
+    );
+  }
+
+  public PersistentQueryMetadata buildQuery(
+      final String statementText,
+      final QueryId queryId,
+      final DataSource<?> sinkDataSource,
+      final Optional<MaterializationInfo> materializationInfo,
+      final Set<SourceName> sources,
+      final ExecutionStep<?> physicalPlan,
+      final String planSummary
+  ) {
+    final KsqlQueryBuilder ksqlQueryBuilder = queryBuilder(queryId);
+    final PlanBuilder planBuilder = new KSPlanBuilder(ksqlQueryBuilder);
+    physicalPlan.build(planBuilder);
+    final String persistanceQueryPrefix =
+        ksqlConfig.getString(KsqlConfig.KSQL_PERSISTENT_QUERY_NAME_PREFIX_CONFIG);
+    final String applicationId = getQueryApplicationId(
+        getServiceId(),
+        persistanceQueryPrefix,
+        queryId
+    );
+    final Map<String, Object> streamsProperties = buildStreamsProperties(applicationId, queryId);
+    final KafkaStreams streams =
+        kafkaStreamsBuilder.buildKafkaStreams(streamsBuilder, streamsProperties);
+    final Topology topology = streamsBuilder.build();
+    final PhysicalSchema querySchema = PhysicalSchema.from(
+        sinkDataSource.getSchema(),
+        sinkDataSource.getSerdeOptions()
+    );
+    final Optional<MaterializationProvider> materializationBuilder = materializationInfo
+        .flatMap(info -> buildMaterializationProvider(
+            info,
+            streams,
+            querySchema,
+            sinkDataSource.getKsqlTopic().getKeyFormat(),
+            streamsProperties
+        ));
+    return new PersistentQueryMetadata(
+        statementText,
+        streams,
+        querySchema,
+        sources,
+        sinkDataSource.getName(),
+        planSummary,
+        queryId,
+        sinkDataSource.getDataSourceType(),
+        materializationBuilder,
+        applicationId,
+        sinkDataSource.getKsqlTopic(),
+        topology,
+        ksqlQueryBuilder.getSchemas(),
+        streamsProperties,
+        overrides,
+        queryCloseCallback
+    );
+  }
+
+  private TransientQueryQueue buildTransientQueryQueue(
+      final QueryId queryId,
+      final ExecutionStep<?> physicalPlan,
+      final OptionalInt limit) {
+    final KsqlQueryBuilder ksqlQueryBuilder = queryBuilder(queryId);
+    final PlanBuilder planBuilder = new KSPlanBuilder(ksqlQueryBuilder);
+    final Object buildResult = physicalPlan.build(planBuilder);
+    final KStream<?, GenericRow> kstream;
+    if (buildResult instanceof KStreamHolder<?>) {
+      kstream = ((KStreamHolder<?>) buildResult).getStream();
+    } else if (buildResult instanceof KTableHolder<?>) {
+      final KTable<?, GenericRow> ktable = ((KTableHolder<?>) buildResult).getTable();
+      kstream = ktable.toStream();
+    } else {
+      throw new IllegalStateException("Unexpected type built from exection plan");
+    }
+    return new TransientQueryQueue(kstream, limit);
+  }
+
+  private KsqlQueryBuilder queryBuilder(final QueryId queryId) {
+    return KsqlQueryBuilder.of(
+        streamsBuilder,
+        ksqlConfig,
+        serviceContext,
+        processingLogContext,
+        functionRegistry,
+        queryId
+    );
+  }
+
+  private String getServiceId() {
+    return KsqlConstants.KSQL_INTERNAL_TOPIC_PREFIX
+        + ksqlConfig.getString(KsqlConfig.KSQL_SERVICE_ID_CONFIG);
+  }
+
+  private Map<String, Object> buildStreamsProperties(
+      final String applicationId,
+      final QueryId queryId
+  ) {
+    final Map<String, Object> newStreamsProperties
+        = new HashMap<>(ksqlConfig.getKsqlStreamConfigProps());
+    newStreamsProperties.put(StreamsConfig.APPLICATION_ID_CONFIG, applicationId);
+    final ProcessingLogger logger
+        = processingLogContext.getLoggerFactory().getLogger(queryId.toString());
+    newStreamsProperties.put(
+        ProductionExceptionHandlerUtil.KSQL_PRODUCTION_ERROR_LOGGER,
+        logger);
+
+    updateListProperty(
+        newStreamsProperties,
+        StreamsConfig.consumerPrefix(ConsumerConfig.INTERCEPTOR_CLASSES_CONFIG),
+        ConsumerCollector.class.getCanonicalName()
+    );
+    updateListProperty(
+        newStreamsProperties,
+        StreamsConfig.producerPrefix(ProducerConfig.INTERCEPTOR_CLASSES_CONFIG),
+        ProducerCollector.class.getCanonicalName()
+    );
+    return newStreamsProperties;
+  }
+
+  private static String getQueryApplicationId(
+      final String serviceId,
+      final String queryPrefix,
+      final QueryId queryId) {
+    return serviceId + queryPrefix + queryId;
+  }
+
+  private static void updateListProperty(
+      final Map<String, Object> properties,
+      final String key,
+      final Object value
+  ) {
+    final Object obj = properties.getOrDefault(key, new LinkedList<String>());
+    final List<Object> valueList;
+    // The property value is either a comma-separated string of class names, or a list of class
+    // names
+    if (obj instanceof String) {
+      // If its a string just split it on the separator so we dont have to worry about adding a
+      // separator
+      final String asString = (String) obj;
+      valueList = new LinkedList<>(Arrays.asList(asString.split("\\s*,\\s*")));
+    } else if (obj instanceof List) {
+      // The incoming list could be an instance of an immutable list. So we create a modifiable
+      // List out of it to ensure that it is mutable.
+      valueList = new LinkedList<>((List<?>) obj);
+    } else {
+      throw new KsqlException("Expecting list or string for property: " + key);
+    }
+    valueList.add(value);
+    properties.put(key, valueList);
+  }
+
+  private static String addTimeSuffix(final String original) {
+    return String.format("%s_%d", original, System.currentTimeMillis());
+  }
+
+  private Optional<MaterializationProvider> buildMaterializationProvider(
+      final MaterializationInfo info,
+      final KafkaStreams kafkaStreams,
+      final PhysicalSchema schema,
+      final KeyFormat keyFormat,
+      final Map<String, Object> streamsProperties
+  ) {
+    final Serializer<Struct> keySerializer = new GenericKeySerDe().create(
+        keyFormat.getFormatInfo(),
+        schema.keySchema(),
+        ksqlConfig,
+        serviceContext.getSchemaRegistryClientFactory(),
+        "",
+        NoopProcessingLogContext.INSTANCE
+    ).serializer();
+
+    final Optional<KsMaterialization> ksMaterialization = ksMaterializationFactory
+        .create(
+            info.stateStoreName(),
+            kafkaStreams,
+            info.aggregationSchema(),
+            keySerializer,
+            keyFormat.getWindowType(),
+            streamsProperties
+        );
+
+    return ksMaterialization.map(ksMat -> contextStacker -> ksqlMaterializationFactory
+        .create(
+            ksMat,
+            info,
+            contextStacker
+        ));
+  }
+}

--- a/ksql-engine/src/main/java/io/confluent/ksql/query/QueueCallback.java
+++ b/ksql-engine/src/main/java/io/confluent/ksql/query/QueueCallback.java
@@ -13,7 +13,7 @@
  * specific language governing permissions and limitations under the License.
  */
 
-package io.confluent.ksql.physical;
+package io.confluent.ksql.query;
 
 import javax.annotation.concurrent.ThreadSafe;
 

--- a/ksql-engine/src/main/java/io/confluent/ksql/query/TransientQueryQueue.java
+++ b/ksql-engine/src/main/java/io/confluent/ksql/query/TransientQueryQueue.java
@@ -13,7 +13,7 @@
  * specific language governing permissions and limitations under the License.
  */
 
-package io.confluent.ksql.physical;
+package io.confluent.ksql.query;
 
 import io.confluent.ksql.GenericRow;
 import io.confluent.ksql.util.KsqlException;
@@ -28,10 +28,8 @@ import org.apache.kafka.streams.kstream.Windowed;
 
 /**
  * A queue of rows for transient queries.
- *
- * @param <K> the key type.
  */
-class TransientQueryQueue<K> {
+class TransientQueryQueue {
 
   private final LimitQueueCallback callback;
   private final BlockingQueue<KeyValue<String, GenericRow>> rowQueue =

--- a/ksql-engine/src/main/java/io/confluent/ksql/query/UnlimitedQueueCallback.java
+++ b/ksql-engine/src/main/java/io/confluent/ksql/query/UnlimitedQueueCallback.java
@@ -13,16 +13,23 @@
  * specific language governing permissions and limitations under the License.
  */
 
-package io.confluent.ksql.physical;
+package io.confluent.ksql.query;
 
-public interface LimitQueueCallback extends QueueCallback {
+/**
+ * A {@code LimitQueueCallback} that does not apply a limit.
+ */
+public class UnlimitedQueueCallback implements LimitQueueCallback {
 
-  /**
-   * Sets the limit handler that will be called when the limit is reached.
-   *
-   * <p>Replaces any previous handler.
-   *
-   * @param limitHandler the handler.
-   */
-  void setLimitHandler(LimitHandler limitHandler);
+  @Override
+  public void setLimitHandler(final LimitHandler limitHandler) {
+  }
+
+  @Override
+  public boolean shouldQueue() {
+    return true;
+  }
+
+  @Override
+  public void onQueued() {
+  }
 }

--- a/ksql-engine/src/main/java/io/confluent/ksql/statement/ConfiguredStatement.java
+++ b/ksql-engine/src/main/java/io/confluent/ksql/statement/ConfiguredStatement.java
@@ -49,6 +49,11 @@ public final class ConfiguredStatement<T extends Statement> {
     this.config = Objects.requireNonNull(config, "config");
   }
 
+  @SuppressWarnings("unchecked")
+  public <S extends Statement> ConfiguredStatement<S> cast() {
+    return (ConfiguredStatement<S>) this;
+  }
+
   public T getStatement() {
     return statement.getStatement();
   }

--- a/ksql-engine/src/main/java/io/confluent/ksql/structured/SchemaKStream.java
+++ b/ksql-engine/src/main/java/io/confluent/ksql/structured/SchemaKStream.java
@@ -672,7 +672,7 @@ public class SchemaKStream<K> {
     final boolean rekey = rekeyRequired(groupByExpressions);
     final KeyFormat rekeyedKeyFormat = KeyFormat.nonWindowed(keyFormat.getFormatInfo());
     if (!rekey) {
-      return groupByKey(rekeyedKeyFormat, valueFormat, contextStacker, queryBuilder);
+      return groupByKey(rekeyedKeyFormat, valueFormat, contextStacker);
     }
 
     final KeySerde<Struct> groupedKeySerde = keySerde
@@ -706,8 +706,7 @@ public class SchemaKStream<K> {
   private SchemaKGroupedStream groupByKey(
       final KeyFormat rekeyedKeyFormat,
       final ValueFormat valueFormat,
-      final QueryContext.Stacker contextStacker,
-      final KsqlQueryBuilder queryBuilder
+      final QueryContext.Stacker contextStacker
   ) {
     final KeySerde<Struct> structKeySerde = getGroupByKeyKeySerde();
     final StreamGroupByKey step =
@@ -736,7 +735,7 @@ public class SchemaKStream<K> {
     return (KeySerde<Struct>) keySerde;
   }
 
-  public ExecutionStep<KStreamHolder<K>> getSourceStep() {
+  public ExecutionStep<?> getSourceStep() {
     return sourceStep;
   }
 

--- a/ksql-engine/src/main/java/io/confluent/ksql/structured/SchemaKTable.java
+++ b/ksql-engine/src/main/java/io/confluent/ksql/structured/SchemaKTable.java
@@ -158,6 +158,11 @@ public class SchemaKTable<K> extends SchemaKStream<K> {
     );
   }
 
+  @Override
+  public ExecutionStep<?> getSourceStep() {
+    return sourceTableStep;
+  }
+
   public ExecutionStep<KTableHolder<K>> getSourceTableStep() {
     return sourceTableStep;
   }

--- a/ksql-engine/src/main/java/io/confluent/ksql/util/PersistentQueryMetadata.java
+++ b/ksql-engine/src/main/java/io/confluent/ksql/util/PersistentQueryMetadata.java
@@ -44,6 +44,7 @@ public class PersistentQueryMetadata extends QueryMetadata {
   private final SourceName sinkName;
   private final QuerySchemas schemas;
   private final PhysicalSchema resultSchema;
+  private final DataSourceType dataSourceType;
   private final Optional<MaterializationProvider> materializationProvider;
 
   // CHECKSTYLE_RULES.OFF: ParameterNumberCheck
@@ -72,7 +73,6 @@ public class PersistentQueryMetadata extends QueryMetadata {
         schema.logicalSchema(),
         sourceNames,
         executionPlan,
-        dataSourceType,
         queryApplicationId,
         topology,
         streamsProperties,
@@ -86,6 +86,7 @@ public class PersistentQueryMetadata extends QueryMetadata {
     this.resultSchema = requireNonNull(schema, "schema");
     this.materializationProvider =
         requireNonNull(materializationProvider, "materializationProvider");
+    this.dataSourceType = Objects.requireNonNull(dataSourceType, "dataSourceType");
   }
 
   private PersistentQueryMetadata(
@@ -99,10 +100,15 @@ public class PersistentQueryMetadata extends QueryMetadata {
     this.schemas = other.schemas;
     this.resultSchema = other.resultSchema;
     this.materializationProvider = other.materializationProvider;
+    this.dataSourceType = other.dataSourceType;
   }
 
   public PersistentQueryMetadata copyWith(final Consumer<QueryMetadata> closeCallback) {
     return new PersistentQueryMetadata(this, closeCallback);
+  }
+
+  public DataSourceType getDataSourceType() {
+    return dataSourceType;
   }
 
   public QueryId getQueryId() {

--- a/ksql-engine/src/main/java/io/confluent/ksql/util/QueryMetadata.java
+++ b/ksql-engine/src/main/java/io/confluent/ksql/util/QueryMetadata.java
@@ -17,7 +17,6 @@ package io.confluent.ksql.util;
 
 import com.google.common.collect.ImmutableMap;
 import io.confluent.ksql.internal.QueryStateListener;
-import io.confluent.ksql.metastore.model.DataSource.DataSourceType;
 import io.confluent.ksql.name.SourceName;
 import io.confluent.ksql.schema.ksql.LogicalSchema;
 import java.lang.Thread.UncaughtExceptionHandler;
@@ -38,7 +37,6 @@ public class QueryMetadata {
   private final String statementString;
   private final KafkaStreams kafkaStreams;
   private final String executionPlan;
-  private final DataSourceType dataSourceType;
   private final String queryApplicationId;
   private final Topology topology;
   private final Map<String, Object> streamsProperties;
@@ -57,7 +55,6 @@ public class QueryMetadata {
       final LogicalSchema logicalSchema,
       final Set<SourceName> sourceNames,
       final String executionPlan,
-      final DataSourceType dataSourceType,
       final String queryApplicationId,
       final Topology topology,
       final Map<String, Object> streamsProperties,
@@ -68,7 +65,6 @@ public class QueryMetadata {
     this.statementString = Objects.requireNonNull(statementString, "statementString");
     this.kafkaStreams = Objects.requireNonNull(kafkaStreams, "kafkaStreams");
     this.executionPlan = Objects.requireNonNull(executionPlan, "executionPlan");
-    this.dataSourceType = Objects.requireNonNull(dataSourceType, "dataSourceType");
     this.queryApplicationId = Objects.requireNonNull(queryApplicationId, "queryApplicationId");
     this.topology = Objects.requireNonNull(topology, "kafkaTopicClient");
     this.streamsProperties =
@@ -86,7 +82,6 @@ public class QueryMetadata {
     this.statementString = other.statementString;
     this.kafkaStreams = other.kafkaStreams;
     this.executionPlan = other.executionPlan;
-    this.dataSourceType = other.dataSourceType;
     this.queryApplicationId = other.queryApplicationId;
     this.topology = other.topology;
     this.streamsProperties = other.streamsProperties;
@@ -119,10 +114,6 @@ public class QueryMetadata {
 
   public String getExecutionPlan() {
     return executionPlan;
-  }
-
-  public DataSourceType getDataSourceType() {
-    return dataSourceType;
   }
 
   public String getQueryApplicationId() {

--- a/ksql-engine/src/main/java/io/confluent/ksql/util/TransientQueryMetadata.java
+++ b/ksql-engine/src/main/java/io/confluent/ksql/util/TransientQueryMetadata.java
@@ -16,9 +16,8 @@
 package io.confluent.ksql.util;
 
 import io.confluent.ksql.GenericRow;
-import io.confluent.ksql.metastore.model.DataSource.DataSourceType;
 import io.confluent.ksql.name.SourceName;
-import io.confluent.ksql.physical.LimitHandler;
+import io.confluent.ksql.query.LimitHandler;
 import io.confluent.ksql.schema.ksql.LogicalSchema;
 import java.util.Map;
 import java.util.Objects;
@@ -48,7 +47,6 @@ public class TransientQueryMetadata extends QueryMetadata {
       final Consumer<LimitHandler> limitHandlerSetter,
       final String executionPlan,
       final BlockingQueue<KeyValue<String, GenericRow>> rowQueue,
-      final DataSourceType dataSourceType,
       final String queryApplicationId,
       final Topology topology,
       final Map<String, Object> streamsProperties,
@@ -61,7 +59,6 @@ public class TransientQueryMetadata extends QueryMetadata {
         logicalSchema,
         sourceNames,
         executionPlan,
-        dataSourceType,
         queryApplicationId,
         topology,
         streamsProperties,

--- a/ksql-engine/src/test/java/io/confluent/ksql/physical/PhysicalPlanBuilderTest.java
+++ b/ksql-engine/src/test/java/io/confluent/ksql/physical/PhysicalPlanBuilderTest.java
@@ -15,11 +15,7 @@
 
 package io.confluent.ksql.physical;
 
-import static io.confluent.ksql.metastore.model.DataSource.DataSourceType;
 import static io.confluent.ksql.metastore.model.MetaStoreMatchers.hasSerdeOptions;
-import static io.confluent.ksql.planner.plan.PlanTestUtil.verifyProcessorNode;
-import static io.confluent.ksql.util.KsqlExceptionMatcher.rawMessage;
-import static io.confluent.ksql.util.KsqlExceptionMatcher.statementText;
 import static org.hamcrest.CoreMatchers.containsString;
 import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.MatcherAssert.assertThat;
@@ -29,34 +25,15 @@ import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.not;
 import static org.hamcrest.Matchers.startsWith;
 import static org.hamcrest.core.IsInstanceOf.instanceOf;
-import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.Mockito.doReturn;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.spy;
-import static org.mockito.Mockito.when;
-
-import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import io.confluent.ksql.KsqlConfigTestUtil;
 import io.confluent.ksql.engine.KsqlEngine;
 import io.confluent.ksql.engine.KsqlEngineTestUtil;
-import io.confluent.ksql.errors.ProductionExceptionHandlerUtil;
 import io.confluent.ksql.function.InternalFunctionRegistry;
-import io.confluent.ksql.logging.processing.ProcessingLogContext;
-import io.confluent.ksql.logging.processing.ProcessingLogger;
-import io.confluent.ksql.logging.processing.ProcessingLoggerFactory;
 import io.confluent.ksql.metastore.MetaStoreImpl;
-import io.confluent.ksql.metastore.MutableMetaStore;
-import io.confluent.ksql.metrics.ConsumerCollector;
-import io.confluent.ksql.metrics.ProducerCollector;
 import io.confluent.ksql.name.ColumnName;
 import io.confluent.ksql.name.SourceName;
-import io.confluent.ksql.parser.exception.ParseFailedException;
-import io.confluent.ksql.planner.LogicalPlanNode;
-import io.confluent.ksql.planner.plan.OutputNode;
-import io.confluent.ksql.planner.plan.PlanTestUtil;
-import io.confluent.ksql.query.QueryId;
-import io.confluent.ksql.query.id.QueryIdGenerator;
+import io.confluent.ksql.metastore.model.DataSource.DataSourceType;
 import io.confluent.ksql.schema.ksql.LogicalSchema;
 import io.confluent.ksql.schema.ksql.types.SqlTypes;
 import io.confluent.ksql.serde.Format;
@@ -65,36 +42,14 @@ import io.confluent.ksql.services.FakeKafkaTopicClient;
 import io.confluent.ksql.services.KafkaTopicClient;
 import io.confluent.ksql.services.ServiceContext;
 import io.confluent.ksql.services.TestServiceContext;
-import io.confluent.ksql.testutils.AnalysisTestUtil;
 import io.confluent.ksql.util.KsqlConfig;
-import io.confluent.ksql.util.KsqlConstants;
 import io.confluent.ksql.util.KsqlException;
-import io.confluent.ksql.util.KsqlStatementException;
-import io.confluent.ksql.util.MetaStoreFixture;
 import io.confluent.ksql.util.PersistentQueryMetadata;
 import io.confluent.ksql.util.QueryMetadata;
 import io.confluent.ksql.util.TransientQueryMetadata;
 import java.util.Arrays;
 import java.util.Collections;
-import java.util.HashMap;
-import java.util.LinkedList;
 import java.util.List;
-import java.util.Map;
-import java.util.Optional;
-import java.util.Properties;
-import java.util.function.Consumer;
-import org.apache.kafka.clients.consumer.ConsumerConfig;
-import org.apache.kafka.clients.consumer.ConsumerInterceptor;
-import org.apache.kafka.clients.consumer.ConsumerRecords;
-import org.apache.kafka.clients.producer.ProducerConfig;
-import org.apache.kafka.clients.producer.ProducerInterceptor;
-import org.apache.kafka.clients.producer.ProducerRecord;
-import org.apache.kafka.clients.producer.RecordMetadata;
-import org.apache.kafka.streams.KafkaStreams;
-import org.apache.kafka.streams.StreamsBuilder;
-import org.apache.kafka.streams.StreamsConfig;
-import org.apache.kafka.streams.TopologyDescription;
-import org.apache.kafka.streams.TopologyDescription.Processor;
 import org.junit.After;
 import org.junit.Assert;
 import org.junit.Before;
@@ -102,17 +57,11 @@ import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ExpectedException;
 import org.junit.runner.RunWith;
-import org.mockito.ArgumentMatchers;
-import org.mockito.Mock;
 import org.mockito.junit.MockitoJUnitRunner;
 
 @SuppressWarnings("unchecked")
 @RunWith(MockitoJUnitRunner.class)
 public class PhysicalPlanBuilderTest {
-
-  private static final String FILTER_NODE = "KSTREAM-FILTER-0000000003";
-  private static final String FILTER_MAPVALUES_NODE = "KSTREAM-MAPVALUES-0000000004";
-  private static final String FOREACH_NODE = "KSTREAM-FOREACH-0000000005";
 
   private static final String CREATE_STREAM_TEST1 = "CREATE STREAM TEST1 "
       + "(COL0 BIGINT, COL1 VARCHAR, COL2 DOUBLE) "
@@ -142,67 +91,23 @@ public class PhysicalPlanBuilderTest {
       + "(ID BIGINT, COL0 VARCHAR, COL1 DOUBLE) "
       + " WITH (KAFKA_TOPIC = 'test7', VALUE_FORMAT = 'JSON');";
 
-  private static final String simpleSelectFilter = "SELECT col0, col2, col3 FROM test1 WHERE col0 > 100 EMIT CHANGES;";
-  private PhysicalPlanBuilder physicalPlanBuilder;
-  private final MutableMetaStore metaStore = MetaStoreFixture.getNewMetaStore(new InternalFunctionRegistry());
+  private static final String simpleSelectFilter = "SELECT col0, col2 FROM test1 WHERE col0 > 100 EMIT CHANGES;";
   private static final KsqlConfig INITIAL_CONFIG = KsqlConfigTestUtil.create("what-eva");
   private final KafkaTopicClient kafkaTopicClient = new FakeKafkaTopicClient();
   private KsqlEngine ksqlEngine;
-  private ProcessingLogContext processingLogContext;
-  private final QueryIdGenerator queryIdGenerator = mock(QueryIdGenerator.class);
 
   @Rule
   public final ExpectedException expectedException = ExpectedException.none();
 
   private ServiceContext serviceContext;
-  @Mock
-  private Consumer<QueryMetadata> queryCloseCallback;
 
   private KsqlConfig ksqlConfig;
   private MetaStoreImpl engineMetastore;
-
-  // Test implementation of KafkaStreamsBuilder that tracks calls and returned values
-  private static class TestKafkaStreamsBuilder implements KafkaStreamsBuilder {
-
-    private final ServiceContext serviceContext;
-
-    private TestKafkaStreamsBuilder(final ServiceContext serviceContext) {
-      this.serviceContext = serviceContext;
-    }
-
-    private static class Call {
-      private final Properties props;
-
-      private Call(final Properties props) {
-        this.props = props;
-      }
-    }
-
-    private final List<Call> calls = new LinkedList<>();
-
-    @Override
-    public KafkaStreams buildKafkaStreams(final StreamsBuilder builder, final Map<String, Object> conf) {
-      final Properties props = new Properties();
-      props.putAll(conf);
-      final KafkaStreams kafkaStreams = new KafkaStreams(builder.build(), props, serviceContext.getKafkaClientSupplier());
-      calls.add(new Call(props));
-      return kafkaStreams;
-    }
-
-    List<Call> getCalls() {
-      return calls;
-    }
-  }
-
-  private TestKafkaStreamsBuilder testKafkaStreamsBuilder;
 
   @Before
   public void before() {
     ksqlConfig = INITIAL_CONFIG;
     serviceContext = TestServiceContext.create(kafkaTopicClient);
-    processingLogContext = ProcessingLogContext.create();
-    testKafkaStreamsBuilder = new TestKafkaStreamsBuilder(serviceContext);
-    physicalPlanBuilder = buildPhysicalPlanBuilder(Collections.emptyMap());
     engineMetastore = new MetaStoreImpl(new InternalFunctionRegistry());
     ksqlEngine = KsqlEngineTestUtil.createKsqlEngine(
         serviceContext,
@@ -216,51 +121,33 @@ public class PhysicalPlanBuilderTest {
     serviceContext.close();
   }
 
-  private PhysicalPlanBuilder buildPhysicalPlanBuilder(
-      final Map<String, Object> overrideProperties) {
-    final StreamsBuilder streamsBuilder = new StreamsBuilder();
-    final InternalFunctionRegistry functionRegistry = new InternalFunctionRegistry();
-    return new PhysicalPlanBuilder(
-        streamsBuilder,
-        ksqlConfig.cloneWithPropertyOverwrite(overrideProperties),
-        serviceContext,
-        processingLogContext,
-        functionRegistry,
-        overrideProperties,
-        metaStore,
-        queryIdGenerator,
-        testKafkaStreamsBuilder,
-        queryCloseCallback
-    );
-  }
-
-  private QueryMetadata buildPhysicalPlan(final String query) {
-    final OutputNode logical = AnalysisTestUtil.buildLogicalPlan(ksqlConfig, query, metaStore);;
-    return physicalPlanBuilder.buildPhysicalPlan(new LogicalPlanNode(query, Optional.of(logical)));
+  private QueryMetadata buildQuery(final String query) {
+    givenKafkaTopicsExist("test1");
+    return execute(CREATE_STREAM_TEST1 + query).get(0);
   }
 
   @Test
   public void shouldHaveKStreamDataSource() {
-    final QueryMetadata metadata = buildPhysicalPlan(simpleSelectFilter);
+    final PersistentQueryMetadata metadata = (PersistentQueryMetadata) buildQuery(
+        "CREATE STREAM FOO AS " + simpleSelectFilter);
     assertThat(metadata.getDataSourceType(), equalTo(DataSourceType.KSTREAM));
   }
 
   @Test
   public void shouldMakeBareQuery() {
-    final QueryMetadata queryMetadata = buildPhysicalPlan(simpleSelectFilter);
+    final QueryMetadata queryMetadata = buildQuery(simpleSelectFilter);
     assertThat(queryMetadata, instanceOf(TransientQueryMetadata.class));
   }
 
   @Test
   public void shouldBuildTransientQueryWithCorrectSchema() {
     // When:
-    final QueryMetadata queryMetadata = buildPhysicalPlan(simpleSelectFilter);
+    final QueryMetadata queryMetadata = buildQuery(simpleSelectFilter);
 
     // Then:
     assertThat(queryMetadata.getLogicalSchema(), is(LogicalSchema.builder()
         .valueColumn(ColumnName.of("COL0"), SqlTypes.BIGINT)
-        .valueColumn(ColumnName.of("COL2"), SqlTypes.STRING)
-        .valueColumn(ColumnName.of("COL3"), SqlTypes.DOUBLE)
+        .valueColumn(ColumnName.of("COL2"), SqlTypes.DOUBLE)
         .build()
     ));
   }
@@ -268,15 +155,13 @@ public class PhysicalPlanBuilderTest {
   @Test
   public void shouldBuildPersistentQueryWithCorrectSchema() {
     // When:
-    final QueryMetadata queryMetadata = buildPhysicalPlan(
+    final QueryMetadata queryMetadata = buildQuery(
         "CREATE STREAM FOO AS " + simpleSelectFilter);
 
     // Then:
     assertThat(queryMetadata.getLogicalSchema(), is(LogicalSchema.builder()
-
         .valueColumn(ColumnName.of("COL0"), SqlTypes.BIGINT)
-        .valueColumn(ColumnName.of("COL2"), SqlTypes.STRING)
-        .valueColumn(ColumnName.of("COL3"), SqlTypes.DOUBLE)
+        .valueColumn(ColumnName.of("COL2"), SqlTypes.DOUBLE)
         .build()
     ));
   }
@@ -288,41 +173,23 @@ public class PhysicalPlanBuilderTest {
 
     // When:
     final QueryMetadata queryMetadata =
-        buildPhysicalPlan("CREATE STREAM FOO AS " + simpleSelectFilter);
+        buildQuery("CREATE STREAM FOO AS " + simpleSelectFilter);
 
     // Then:
     assertThat(queryMetadata, instanceOf(PersistentQueryMetadata.class));
   }
 
   @Test
-  public void shouldBuildMapValuesNodeForTransientQueries() {
-    // Given:
-    final QueryMetadata query = buildPhysicalPlan(simpleSelectFilter);
-
-    // When:
-    final TopologyDescription.Processor node = getNodeByName(query, FILTER_MAPVALUES_NODE);
-
-    // Then:
-    verifyProcessorNode(node, ImmutableList.of(FILTER_NODE), ImmutableList.of(FOREACH_NODE));
-  }
-
-  @Test
-  public void shouldBuildForEachNodeForTransientQueries() {
-    // Given:
-    final QueryMetadata query = buildPhysicalPlan(simpleSelectFilter);
-
-    // When:
-    final TopologyDescription.Processor node = getNodeByName(query, FOREACH_NODE);
-
-    // Then:
-    verifyProcessorNode(node, ImmutableList.of(FILTER_MAPVALUES_NODE), ImmutableList.of());
-  }
-
-  @Test
   public void shouldCreateExecutionPlan() {
-    final String queryString = "SELECT col0, sum(col3), count(col3) FROM test1 "
-        + "WHERE col0 > 100 GROUP BY col0 EMIT CHANGES;";
-    final QueryMetadata metadata = buildPhysicalPlan(queryString);
+    final String queryString =
+        "CREATE STREAM TEST1 ("
+            + "COL0 BIGINT, COL1 VARCHAR, COL2 STRING, COL3 DOUBLE,"
+            + " COL4 ARRAY<DOUBLE>, COL5 MAP<STRING, DOUBLE>)"
+            + " WITH (KAFKA_TOPIC = 'test1', VALUE_FORMAT = 'JSON');"
+            + "SELECT col0, sum(col3), count(col3) FROM test1"
+            + " WHERE col0 > 100 GROUP BY col0 EMIT CHANGES;";
+    givenKafkaTopicsExist("test1");
+    final QueryMetadata metadata = execute(queryString).get(0);
     final String planText = metadata.getExecutionPlan();
     final String[] lines = planText.split("\n");
     assertThat(lines[0], startsWith(
@@ -375,60 +242,6 @@ public class PhysicalPlanBuilderTest {
   }
 
   @Test
-  public void shouldFailIfInsertSinkDoesNotExist() {
-    // Given:
-    final String insertIntoQuery = "INSERT INTO s1 SELECT col0, col1, col2 FROM test1;";
-    givenKafkaTopicsExist("test1");
-
-    // Then:
-    expectedException.expect(ParseFailedException.class);
-    expectedException.expect(statementText(is("INSERT INTO s1 SELECT col0, col1, col2 FROM test1;")));
-    expectedException.expect(rawMessage(containsString("S1 does not exist.")));
-
-    // When:
-    execute(CREATE_STREAM_TEST1 + insertIntoQuery);
-  }
-
-  @Test
-  public void shouldFailInsertIfTheResultSchemaDoesNotMatch() {
-    // Given:
-    final String csasQuery = "CREATE STREAM s1 AS SELECT col0, col1 FROM test1;";
-    final String insertIntoQuery = "INSERT INTO s1 SELECT col0, col1, col2 FROM test1;";
-    givenKafkaTopicsExist("test1");
-
-    // Then:
-    expectedException.expect(KsqlStatementException.class);
-    expectedException.expect(rawMessage(is(
-        "Incompatible schema between results and sink. Result schema is "
-            + "[`ROWKEY` STRING KEY, `COL0` BIGINT, `COL1` STRING, `COL2` DOUBLE], "
-            + "but the sink schema is "
-            + "[`ROWKEY` STRING KEY, `COL0` BIGINT, `COL1` STRING].")));
-
-    // When:
-    execute(CREATE_STREAM_TEST1 + csasQuery + insertIntoQuery);
-  }
-
-  @Test
-  public void shouldThrowOnInsertIntoTableFromTable() {
-    // Given:
-    final String createTable = "CREATE TABLE T1 (COL0 BIGINT, COL1 VARCHAR, COL2 DOUBLE, COL3 "
-        + "DOUBLE) "
-        + "WITH ( "
-        + "KAFKA_TOPIC = 'test1', VALUE_FORMAT = 'JSON', KEY = 'COL1' );";
-    final String csasQuery = "CREATE TABLE T2 AS SELECT * FROM T1;";
-    final String insertIntoQuery = "INSERT INTO T2 SELECT *  FROM T1;";
-    givenKafkaTopicsExist("test1");
-
-    // Then:
-    expectedException.expect(KsqlStatementException.class);
-    expectedException.expect(rawMessage(containsString(
-        "INSERT INTO can only be used to insert into a stream. T2 is a table.")));
-
-    // When:
-    execute(createTable + csasQuery + insertIntoQuery);
-  }
-
-  @Test
   public void shouldCreatePlanForInsertIntoStreamFromStream() {
     // Given:
     final String cs = "CREATE STREAM test1 (col0 INT) "
@@ -456,29 +269,6 @@ public class PhysicalPlanBuilderTest {
   }
 
   @Test
-  public void shouldFailInsertIfTheResultTypesDoNotMatch() {
-    // Given:
-    final String createTable = "CREATE TABLE T1 (COL0 BIGINT, COL1 VARCHAR, COL2 DOUBLE, COL3 "
-        + "DOUBLE) "
-        + "WITH ( "
-        + "KAFKA_TOPIC = 't1', VALUE_FORMAT = 'JSON', KEY = 'COL1' );";
-    final String csasQuery = "CREATE STREAM S2 AS SELECT * FROM TEST1;";
-    final String insertIntoQuery = "INSERT INTO S2 SELECT col0, col1, col2, col3 FROM T1;";
-    // No need for setting the correct clean up policy in test.
-    givenKafkaTopicsExist("t1");
-    givenKafkaTopicsExist("test1");
-
-    // Then:
-    expectedException.expect(KsqlStatementException.class);
-    expectedException.expect(rawMessage(is(
-        "Incompatible data sink and query result. "
-        + "Data sink (S2) type is KTABLE but select query result is KSTREAM.")));
-
-    // When:
-    execute(createTable + CREATE_STREAM_TEST1 + csasQuery + insertIntoQuery);
-  }
-
-  @Test
   public void shouldRekeyIfPartitionByDoesNotMatchResultKey() {
     final String csasQuery = "CREATE STREAM s1 AS SELECT col0, col1, col2 FROM test1 PARTITION BY col0;";
     final String insertIntoQuery = "INSERT INTO s1 SELECT col0, col1, col2 FROM test1 PARTITION BY col0;";
@@ -497,256 +287,6 @@ public class PhysicalPlanBuilderTest {
             + "| Logger: InsertQuery_1.S1"));
     assertThat(lines[2], equalTo("\t\t\t\t > [ PROJECT ] | Schema: [ROWKEY STRING KEY, COL0 BIGINT, COL1 STRING"
         + ", COL2 DOUBLE] | Logger: InsertQuery_1.Project"));
-  }
-
-  @Test
-  public void shouldFailIfSinkAndResultKeysDoNotMatch() {
-    final String csasQuery = "CREATE STREAM s1 AS SELECT col0, col1, col2 FROM test1 PARTITION BY col0;";
-    final String insertIntoQuery = "INSERT INTO s1 SELECT col0, col1, col2 FROM test1;";
-    givenKafkaTopicsExist("test1");
-
-    // Then:
-    expectedException.expect(KsqlStatementException.class);
-    expectedException.expect(rawMessage(is(
-        "Incompatible key fields for sink and results. "
-        + "Sink key field is COL0 (type: BIGINT) "
-        + "while result key field is null (type: null)")));
-
-    // When:
-    execute(CREATE_STREAM_TEST1 + csasQuery + insertIntoQuery);
-  }
-
-  @Test
-  public void shouldAddMetricsInterceptors() throws Exception {
-    buildPhysicalPlan(simpleSelectFilter);
-
-    final List<TestKafkaStreamsBuilder.Call> calls = testKafkaStreamsBuilder.getCalls();
-    Assert.assertEquals(1, calls.size());
-    final Properties props = calls.get(0).props;
-
-    Object val = props.get(StreamsConfig.consumerPrefix(ConsumerConfig.INTERCEPTOR_CLASSES_CONFIG));
-    Assert.assertThat(val, instanceOf(List.class));
-    final List<String> consumerInterceptors = (List<String>) val;
-    assertThat(consumerInterceptors.size(), equalTo(1));
-    assertThat(ConsumerCollector.class, equalTo(Class.forName(consumerInterceptors.get(0))));
-
-    val = props.get(StreamsConfig.producerPrefix(ConsumerConfig.INTERCEPTOR_CLASSES_CONFIG));
-    Assert.assertThat(val, instanceOf(List.class));
-    final List<String> producerInterceptors = (List<String>) val;
-    assertThat(producerInterceptors.size(), equalTo(1));
-    assertThat(ProducerCollector.class, equalTo(Class.forName(producerInterceptors.get(0))));
-  }
-
-  private void shouldUseProvidedOptimizationConfig(Object value) {
-    // Given:
-    final Map<String, Object> properties =
-        Collections.singletonMap(StreamsConfig.TOPOLOGY_OPTIMIZATION, value);
-    physicalPlanBuilder = buildPhysicalPlanBuilder(properties);
-
-    // When:
-    buildPhysicalPlan(simpleSelectFilter);
-
-    // Then:
-    final List<TestKafkaStreamsBuilder.Call> calls = testKafkaStreamsBuilder.getCalls();
-    assertThat(calls.size(), equalTo(1));
-    final Properties props = calls.get(0).props;
-    assertThat(
-        props.get(StreamsConfig.TOPOLOGY_OPTIMIZATION),
-        equalTo(value));
-  }
-
-  @Test
-  public void shouldUseOptimizationConfigProvidedWhenOn() {
-    shouldUseProvidedOptimizationConfig(StreamsConfig.OPTIMIZE);
-  }
-
-  @Test
-  public void shouldUseOptimizationConfigProvidedWhenOff() {
-    shouldUseProvidedOptimizationConfig(StreamsConfig.NO_OPTIMIZATION);
-  }
-
-  public static class DummyConsumerInterceptor implements ConsumerInterceptor {
-
-    public ConsumerRecords onConsume(final ConsumerRecords consumerRecords) {
-      return consumerRecords;
-    }
-
-    public void close() {
-    }
-
-    public void onCommit(final Map map) {
-    }
-
-    public void configure(final Map<String, ?> map) {
-    }
-  }
-
-  public static class DummyProducerInterceptor implements ProducerInterceptor {
-
-    public void onAcknowledgement(final RecordMetadata rm, final Exception e) {
-    }
-
-    public ProducerRecord onSend(final ProducerRecord producerRecords) {
-      return producerRecords;
-    }
-
-    public void close() {
-    }
-
-    public void configure(final Map<String, ?> map) {
-    }
-  }
-
-  @Test
-  public void shouldAddMetricsInterceptorsToExistingList() throws Exception {
-    // Initialize override properties with lists for producer/consumer interceptors
-    final Map<String, Object> overrideProperties = new HashMap<>();
-    List<String> consumerInterceptors = new LinkedList<>();
-    consumerInterceptors.add(DummyConsumerInterceptor.class.getName());
-    overrideProperties.put(StreamsConfig.consumerPrefix(ConsumerConfig.INTERCEPTOR_CLASSES_CONFIG),
-        consumerInterceptors);
-    List<String> producerInterceptors = new LinkedList<>();
-    producerInterceptors.add(DummyProducerInterceptor.class.getName());
-    overrideProperties.put(StreamsConfig.producerPrefix(ConsumerConfig.INTERCEPTOR_CLASSES_CONFIG),
-        producerInterceptors);
-    physicalPlanBuilder = buildPhysicalPlanBuilder(overrideProperties);
-
-    buildPhysicalPlan(simpleSelectFilter);
-
-    final List<TestKafkaStreamsBuilder.Call> calls = testKafkaStreamsBuilder.getCalls();
-    Assert.assertEquals(1, calls.size());
-    final Properties props = calls.get(0).props;
-
-    Object val = props.get(StreamsConfig.consumerPrefix(ConsumerConfig.INTERCEPTOR_CLASSES_CONFIG));
-    Assert.assertThat(val, instanceOf(List.class));
-    consumerInterceptors = (List<String>) val;
-    assertThat(consumerInterceptors.size(), equalTo(2));
-    assertThat(DummyConsumerInterceptor.class.getName(), equalTo(consumerInterceptors.get(0)));
-    assertThat(ConsumerCollector.class, equalTo(Class.forName(consumerInterceptors.get(1))));
-
-    val = props.get(StreamsConfig.producerPrefix(ProducerConfig.INTERCEPTOR_CLASSES_CONFIG));
-    Assert.assertThat(val, instanceOf(List.class));
-    producerInterceptors = (List<String>) val;
-    assertThat(producerInterceptors.size(), equalTo(2));
-    assertThat(DummyProducerInterceptor.class.getName(), equalTo(producerInterceptors.get(0)));
-    assertThat(ProducerCollector.class, equalTo(Class.forName(producerInterceptors.get(1))));
-  }
-
-  @Test
-  public void shouldAddMetricsInterceptorsToExistingString() throws Exception {
-    // Initialize override properties with class name strings for producer/consumer interceptors
-    final Map<String, Object> overrideProperties = new HashMap<>();
-    overrideProperties.put(StreamsConfig.consumerPrefix(ConsumerConfig.INTERCEPTOR_CLASSES_CONFIG),
-        DummyConsumerInterceptor.class.getName());
-    overrideProperties.put(StreamsConfig.producerPrefix(ConsumerConfig.INTERCEPTOR_CLASSES_CONFIG),
-        DummyProducerInterceptor.class.getName());
-    physicalPlanBuilder = buildPhysicalPlanBuilder(overrideProperties);
-
-    buildPhysicalPlan(simpleSelectFilter);
-
-    final List<TestKafkaStreamsBuilder.Call> calls = testKafkaStreamsBuilder.getCalls();
-    assertThat(calls.size(), equalTo(1));
-    final Properties props = calls.get(0).props;
-
-    Object val = props.get(StreamsConfig.consumerPrefix(ConsumerConfig.INTERCEPTOR_CLASSES_CONFIG));
-    Assert.assertThat(val, instanceOf(List.class));
-    final List<String> consumerInterceptors = (List<String>) val;
-    assertThat(consumerInterceptors.size(), equalTo(2));
-    assertThat(DummyConsumerInterceptor.class.getName(), equalTo(consumerInterceptors.get(0)));
-    assertThat(ConsumerCollector.class, equalTo(Class.forName(consumerInterceptors.get(1))));
-
-    val = props.get(StreamsConfig.producerPrefix(ProducerConfig.INTERCEPTOR_CLASSES_CONFIG));
-    Assert.assertThat(val, instanceOf(List.class));
-    final List<String> producerInterceptors = (List<String>) val;
-    assertThat(producerInterceptors.size(), equalTo(2));
-    assertThat(DummyProducerInterceptor.class.getName(), equalTo(producerInterceptors.get(0)));
-    assertThat(ProducerCollector.class, equalTo(Class.forName(producerInterceptors.get(1))));
-  }
-
-  public static class DummyConsumerInterceptor2 implements ConsumerInterceptor {
-
-    public ConsumerRecords onConsume(final ConsumerRecords consumerRecords) {
-      return consumerRecords;
-    }
-
-    public void close() {
-    }
-
-    public void onCommit(final Map map) {
-    }
-
-    public void configure(final Map<String, ?> map) {
-    }
-  }
-
-  @Test
-  public void shouldConfigureProducerErrorHandlerLogger() {
-    // Given:
-    processingLogContext = mock(ProcessingLogContext.class);
-    final ProcessingLoggerFactory loggerFactory = mock(ProcessingLoggerFactory.class);
-    final ProcessingLogger logger = mock(ProcessingLogger.class);
-    when(processingLogContext.getLoggerFactory()).thenReturn(loggerFactory);
-    final OutputNode spyNode = spy(
-        AnalysisTestUtil.buildLogicalPlan(ksqlConfig, simpleSelectFilter, metaStore));
-    doReturn(new QueryId("foo")).when(spyNode).getQueryId(any());
-    when(loggerFactory.getLogger("foo")).thenReturn(logger);
-    when(loggerFactory.getLogger(ArgumentMatchers.startsWith("foo.")))
-        .thenReturn(mock(ProcessingLogger.class));
-    physicalPlanBuilder = buildPhysicalPlanBuilder(Collections.emptyMap());
-
-    // When:
-    physicalPlanBuilder.buildPhysicalPlan(
-        new LogicalPlanNode(simpleSelectFilter, Optional.of(spyNode)));
-
-    // Then:
-    final TestKafkaStreamsBuilder.Call call = testKafkaStreamsBuilder.calls.get(0);
-    assertThat(
-        call.props.get(ProductionExceptionHandlerUtil.KSQL_PRODUCTION_ERROR_LOGGER),
-        is(logger));
-  }
-
-  @Test
-  public void shouldAddMetricsInterceptorsToExistingStringList() throws Exception {
-    // Initialize override properties with class name strings for producer/consumer interceptors
-    final Map<String, Object> overrideProperties = new HashMap<>();
-    final String consumerInterceptorStr = DummyConsumerInterceptor.class.getName()
-        + " , " + DummyConsumerInterceptor2.class.getName();
-    overrideProperties.put(StreamsConfig.consumerPrefix(ConsumerConfig.INTERCEPTOR_CLASSES_CONFIG),
-        consumerInterceptorStr);
-    physicalPlanBuilder = buildPhysicalPlanBuilder(overrideProperties);
-
-    buildPhysicalPlan(simpleSelectFilter);
-
-    final List<TestKafkaStreamsBuilder.Call> calls = testKafkaStreamsBuilder.getCalls();
-    Assert.assertEquals(1, calls.size());
-    final Properties props = calls.get(0).props;
-
-    final Object val = props.get(
-        StreamsConfig.consumerPrefix(ConsumerConfig.INTERCEPTOR_CLASSES_CONFIG));
-    Assert.assertThat(val, instanceOf(List.class));
-    final List<String> consumerInterceptors = (List<String>) val;
-    assertThat(consumerInterceptors.size(), equalTo(3));
-    assertThat(DummyConsumerInterceptor.class.getName(), equalTo(consumerInterceptors.get(0)));
-    assertThat(DummyConsumerInterceptor2.class.getName(), equalTo(consumerInterceptors.get(1)));
-    assertThat(ConsumerCollector.class, equalTo(Class.forName(consumerInterceptors.get(2))));
-  }
-
-  @Test
-  public void shouldCreateExpectedServiceId() {
-    final String serviceId = physicalPlanBuilder.getServiceId();
-    assertThat(serviceId, equalTo(KsqlConstants.KSQL_INTERNAL_TOPIC_PREFIX
-        + KsqlConfig.KSQL_SERVICE_ID_DEFAULT));
-  }
-
-  @Test
-  public void shouldSetIsKSQLSinkInMetastoreCorrectly() {
-    final String csasQuery = "CREATE STREAM s1 AS SELECT col0, col1, col2 FROM test1;";
-    final String ctasQuery = "CREATE TABLE t1 AS SELECT col0, COUNT(*) FROM test1 GROUP BY col0;";
-    givenKafkaTopicsExist("test1");
-    execute(CREATE_STREAM_TEST1 + csasQuery + ctasQuery);
-    assertThat(ksqlEngine.getMetaStore().getSource(SourceName.of("TEST1")).getKsqlTopic().isKsqlSink(), equalTo(false));
-    assertThat(ksqlEngine.getMetaStore().getSource(SourceName.of("S1")).getKsqlTopic().isKsqlSink(), equalTo(true));
-    assertThat(ksqlEngine.getMetaStore().getSource(SourceName.of("T1")).getKsqlTopic().isKsqlSink(), equalTo(true));
   }
 
   @Test
@@ -1098,9 +638,5 @@ public class PhysicalPlanBuilderTest {
     Arrays.stream(names).forEach(name ->
         kafkaTopicClient.createTopic(name, 1, (short) 1, Collections.emptyMap())
     );
-  }
-
-  private static Processor getNodeByName(final QueryMetadata query, final String nodeName) {
-    return (Processor) PlanTestUtil.getNodeByName(query.getTopology(), nodeName);
   }
 }

--- a/ksql-engine/src/test/java/io/confluent/ksql/query/LimitedQueueCallbackTest.java
+++ b/ksql-engine/src/test/java/io/confluent/ksql/query/LimitedQueueCallbackTest.java
@@ -13,7 +13,7 @@
  * specific language governing permissions and limitations under the License.
  */
 
-package io.confluent.ksql.physical;
+package io.confluent.ksql.query;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;

--- a/ksql-engine/src/test/java/io/confluent/ksql/query/QueryExecutorTest.java
+++ b/ksql-engine/src/test/java/io/confluent/ksql/query/QueryExecutorTest.java
@@ -1,0 +1,611 @@
+package io.confluent.ksql.query;
+
+import static org.hamcrest.Matchers.contains;
+import static org.hamcrest.Matchers.is;
+import static org.junit.Assert.assertThat;
+import static org.hamcrest.Matchers.equalTo;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.ArgumentMatchers.same;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.ImmutableSet;
+import io.confluent.ksql.GenericRow;
+import io.confluent.ksql.errors.ProductionExceptionHandlerUtil;
+import io.confluent.ksql.execution.context.QueryContext;
+import io.confluent.ksql.execution.context.QueryContext.Stacker;
+import io.confluent.ksql.execution.ddl.commands.KsqlTopic;
+import io.confluent.ksql.execution.plan.ExecutionStep;
+import io.confluent.ksql.execution.plan.KStreamHolder;
+import io.confluent.ksql.function.FunctionRegistry;
+import io.confluent.ksql.logging.processing.ProcessingLogContext;
+import io.confluent.ksql.logging.processing.ProcessingLogger;
+import io.confluent.ksql.logging.processing.ProcessingLoggerFactory;
+import io.confluent.ksql.materialization.KsqlMaterializationFactory;
+import io.confluent.ksql.materialization.Materialization;
+import io.confluent.ksql.materialization.MaterializationInfo;
+import io.confluent.ksql.materialization.ks.KsMaterialization;
+import io.confluent.ksql.materialization.ks.KsMaterializationFactory;
+import io.confluent.ksql.metastore.model.DataSource;
+import io.confluent.ksql.metastore.model.DataSource.DataSourceType;
+import io.confluent.ksql.metrics.ConsumerCollector;
+import io.confluent.ksql.metrics.ProducerCollector;
+import io.confluent.ksql.name.ColumnName;
+import io.confluent.ksql.name.SourceName;
+import io.confluent.ksql.schema.ksql.LogicalSchema;
+import io.confluent.ksql.schema.ksql.PhysicalSchema;
+import io.confluent.ksql.schema.ksql.types.SqlTypes;
+import io.confluent.ksql.serde.Format;
+import io.confluent.ksql.serde.FormatInfo;
+import io.confluent.ksql.serde.KeyFormat;
+import io.confluent.ksql.serde.SerdeOption;
+import io.confluent.ksql.services.ServiceContext;
+import io.confluent.ksql.util.KsqlConfig;
+import io.confluent.ksql.util.PersistentQueryMetadata;
+import io.confluent.ksql.util.QueryMetadata;
+import io.confluent.ksql.util.TransientQueryMetadata;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.OptionalInt;
+import java.util.Set;
+import java.util.function.Consumer;
+import org.apache.kafka.clients.consumer.ConsumerConfig;
+import org.apache.kafka.clients.consumer.ConsumerInterceptor;
+import org.apache.kafka.clients.consumer.ConsumerRecords;
+import org.apache.kafka.clients.producer.ProducerConfig;
+import org.apache.kafka.clients.producer.ProducerInterceptor;
+import org.apache.kafka.clients.producer.ProducerRecord;
+import org.apache.kafka.clients.producer.RecordMetadata;
+import org.apache.kafka.connect.data.Struct;
+import org.apache.kafka.streams.KafkaStreams;
+import org.apache.kafka.streams.StreamsBuilder;
+import org.apache.kafka.streams.StreamsConfig;
+import org.apache.kafka.streams.Topology;
+import org.apache.kafka.streams.kstream.KStream;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Captor;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnitRunner;
+
+@RunWith(MockitoJUnitRunner.class)
+public class QueryExecutorTest {
+  private static final String STATEMENT_TEXT = "KSQL STATEMENT";
+  private static final QueryId QUERY_ID = new QueryId("queryid");
+  private static final Set<SourceName> SOURCES
+      = ImmutableSet.of(SourceName.of("foo"), SourceName.of("bar"));
+  private static final SourceName SINK_NAME = SourceName.of("baz");
+  private static final String STORE_NAME = "store";
+  private static final String SUMMARY = "summary";
+  private static final Map<String, Object> OVERRIDES = Collections.emptyMap();
+  private static final LogicalSchema SINK_SCHEMA = LogicalSchema.builder()
+      .valueColumn(ColumnName.of("col0"), SqlTypes.BIGINT)
+      .valueColumn(ColumnName.of("col1"), SqlTypes.STRING)
+      .build();
+  private static final KeyFormat KEY_FORMAT = KeyFormat.nonWindowed(FormatInfo.of(Format.JSON));
+  private static final PhysicalSchema SINK_PHYSICAL_SCHEMA = PhysicalSchema.from(
+      SINK_SCHEMA,
+      SerdeOption.none()
+  );
+  private static final OptionalInt LIMIT = OptionalInt.of(123);
+  private static final String SERVICE_ID = "service-";
+  private static final String PERSISTENT_PREFIX = "persistent-";
+
+  @Mock
+  private ExecutionStep<KStreamHolder<Struct>> physicalPlan;
+  @Mock
+  private KStream<Struct, GenericRow> kstream;
+  @Mock
+  private DataSource<?> sink;
+  @Mock
+  private KsqlTopic ksqlTopic;
+  @Mock
+  private MaterializationInfo materializationInfo;
+  @Mock
+  private KsqlConfig ksqlConfig;
+  @Mock
+  private ProcessingLogContext processingLogContext;
+  @Mock
+  private ProcessingLoggerFactory processingLoggerFactory;
+  @Mock
+  private ProcessingLogger processingLogger;
+  @Mock
+  private ServiceContext serviceContext;
+  @Mock
+  private Consumer<QueryMetadata> closeCallback;
+  @Mock
+  private KafkaStreamsBuilder kafkaStreamsBuilder;
+  @Mock
+  private StreamsBuilder streamsBuilder;
+  @Mock
+  private FunctionRegistry functionRegistry;
+  @Mock
+  private KafkaStreams kafkaStreams;
+  @Mock
+  private Topology topology;
+  @Mock
+  private KsMaterializationFactory ksMaterializationFactory;
+  @Mock
+  private KsMaterialization ksMaterialization;
+  @Mock
+  private KsqlMaterializationFactory ksqlMaterializationFactory;
+  @Mock
+  private Materialization materialization;
+  @Mock
+  private LogicalSchema aggregationSchema;
+  @Mock
+  private KStreamHolder<Struct> streamWithSerdeFactory;
+  @Captor
+  private ArgumentCaptor<Map<String, Object>> propertyCaptor;
+
+  private QueryExecutor queryBuilder;
+
+  @Before
+  public void setup() {
+    when(sink.getSchema()).thenReturn(SINK_SCHEMA);
+    when(sink.getSerdeOptions()).thenReturn(SerdeOption.none());
+    when(sink.getKsqlTopic()).thenReturn(ksqlTopic);
+    when(sink.getName()).thenReturn(SINK_NAME);
+    when(sink.getDataSourceType()).thenReturn(DataSourceType.KSTREAM);
+    when(ksqlTopic.getKeyFormat()).thenReturn(KEY_FORMAT);
+    when(kafkaStreamsBuilder.buildKafkaStreams(any(), any())).thenReturn(kafkaStreams);
+    when(streamsBuilder.build()).thenReturn(topology);
+    when(materializationInfo.aggregationSchema()).thenReturn(aggregationSchema);
+    when(materializationInfo.stateStoreName()).thenReturn(STORE_NAME);
+    when(ksMaterializationFactory.create(any(), any(), any(), any(), any(), any()))
+        .thenReturn(Optional.of(ksMaterialization));
+    when(ksqlMaterializationFactory.create(any(), any(), any())).thenReturn(materialization);
+    when(processingLogContext.getLoggerFactory()).thenReturn(processingLoggerFactory);
+    when(processingLoggerFactory.getLogger(any())).thenReturn(processingLogger);
+    when(ksqlConfig.getKsqlStreamConfigProps()).thenReturn(Collections.emptyMap());
+    when(ksqlConfig.getString(KsqlConfig.KSQL_PERSISTENT_QUERY_NAME_PREFIX_CONFIG))
+        .thenReturn(PERSISTENT_PREFIX);
+    when(ksqlConfig.getString(KsqlConfig.KSQL_SERVICE_ID_CONFIG)).thenReturn(SERVICE_ID);
+    queryBuilder = new QueryExecutor(
+        ksqlConfig,
+        OVERRIDES,
+        processingLogContext,
+        serviceContext,
+        functionRegistry,
+        closeCallback,
+        kafkaStreamsBuilder,
+        streamsBuilder,
+        ksqlMaterializationFactory,
+        ksMaterializationFactory
+    );
+  }
+
+  @Test
+  public void shouldBuildTransientQueryCorrectly() {
+    // Given:
+    givenTransientQuery();
+
+    // When:
+    final TransientQueryMetadata queryMetadata = queryBuilder.buildTransientQuery(
+        STATEMENT_TEXT,
+        QUERY_ID,
+        SOURCES,
+        physicalPlan,
+        SUMMARY,
+        SINK_SCHEMA,
+        LIMIT
+    );
+
+    // Then:
+    assertThat(queryMetadata.getStatementString(), equalTo(STATEMENT_TEXT));
+    assertThat(queryMetadata.getSourceNames(), equalTo(SOURCES));
+    assertThat(queryMetadata.getExecutionPlan(), equalTo(SUMMARY));
+    assertThat(queryMetadata.getTopology(), is(topology));
+    assertThat(queryMetadata.getOverriddenProperties(), equalTo(OVERRIDES));
+    verify(kafkaStreamsBuilder).buildKafkaStreams(any(), propertyCaptor.capture());
+    assertThat(queryMetadata.getStreamsProperties(), equalTo(propertyCaptor.getValue()));
+  }
+
+  @Test
+  public void shouldBuildPersistentQueryCorrectly() {
+    // When:
+    final PersistentQueryMetadata queryMetadata = queryBuilder.buildQuery(
+        STATEMENT_TEXT,
+        QUERY_ID,
+        sink,
+        Optional.of(materializationInfo),
+        SOURCES,
+        physicalPlan,
+        SUMMARY
+    );
+
+    // Then:
+    assertThat(queryMetadata.getStatementString(), equalTo(STATEMENT_TEXT));
+    assertThat(queryMetadata.getQueryId(), equalTo(QUERY_ID));
+    assertThat(queryMetadata.getSinkName(), equalTo(SINK_NAME));
+    assertThat(queryMetadata.getPhysicalSchema(), equalTo(SINK_PHYSICAL_SCHEMA));
+    assertThat(queryMetadata.getResultTopic(), is(ksqlTopic));
+    assertThat(queryMetadata.getSourceNames(), equalTo(SOURCES));
+    assertThat(queryMetadata.getDataSourceType(), equalTo(DataSourceType.KSTREAM));
+    assertThat(queryMetadata.getExecutionPlan(), equalTo(SUMMARY));
+    assertThat(queryMetadata.getTopology(), is(topology));
+    assertThat(queryMetadata.getOverriddenProperties(), equalTo(OVERRIDES));
+    assertThat(queryMetadata.getStreamsProperties(), equalTo(capturedStreamsProperties()));
+  }
+
+  @Test
+  public void shouldBuildPersistentQueryWithCorrectStreamsApp() {
+    // When:
+    final PersistentQueryMetadata queryMetadata = queryBuilder.buildQuery(
+        STATEMENT_TEXT,
+        QUERY_ID,
+        sink,
+        Optional.of(materializationInfo),
+        SOURCES,
+        physicalPlan,
+        SUMMARY
+    );
+    queryMetadata.start();
+
+    // Then:
+    verify(kafkaStreams).start();
+  }
+
+  @Test
+  public void shouldBuildPersistentQueryWithCorrectMaterializationProvider() {
+    // When:
+    final PersistentQueryMetadata queryMetadata = queryBuilder.buildQuery(
+        STATEMENT_TEXT,
+        QUERY_ID,
+        sink,
+        Optional.of(materializationInfo),
+        SOURCES,
+        physicalPlan,
+        SUMMARY
+    );
+    final QueryContext.Stacker stacker = new Stacker(QUERY_ID);
+    final Optional<Materialization> result = queryMetadata.getMaterialization(stacker);
+
+    // Then:
+    assertThat(result.get(), is(materialization));
+  }
+
+  @Test
+  public void shouldCreateKSMaterializationCorrectly() {
+    // When:
+    queryBuilder.buildQuery(
+        STATEMENT_TEXT,
+        QUERY_ID,
+        sink,
+        Optional.of(materializationInfo),
+        SOURCES,
+        physicalPlan,
+        SUMMARY
+    );
+
+    // Then:
+    final Map<String, Object> properties = capturedStreamsProperties();
+    verify(ksMaterializationFactory).create(
+        eq(STORE_NAME),
+        same(kafkaStreams),
+        same(aggregationSchema),
+        any(),
+        eq(Optional.empty()),
+        eq(properties)
+    );
+  }
+
+  @Test
+  public void shouldMaterializeCorrectly() {
+    // When:
+    final PersistentQueryMetadata queryMetadata = queryBuilder.buildQuery(
+        STATEMENT_TEXT,
+        QUERY_ID,
+        sink,
+        Optional.of(materializationInfo),
+        SOURCES,
+        physicalPlan,
+        SUMMARY
+    );
+    final QueryContext.Stacker stacker = new Stacker(QUERY_ID);
+    queryMetadata.getMaterialization(stacker);
+
+    // Then:
+    verify(ksqlMaterializationFactory).create(
+        ksMaterialization,
+        materializationInfo,
+        stacker
+    );
+  }
+
+  @Test
+  public void shouldNotIncludeMaterializationProviderIfNoMaterialization() {
+    // When:
+    final PersistentQueryMetadata queryMetadata = queryBuilder.buildQuery(
+        STATEMENT_TEXT,
+        QUERY_ID,
+        sink,
+        Optional.empty(),
+        SOURCES,
+        physicalPlan,
+        SUMMARY
+    );
+    final QueryContext.Stacker stacker = new Stacker(QUERY_ID);
+    final Optional<Materialization> result = queryMetadata.getMaterialization(stacker);
+
+    assertThat(result, is(Optional.empty()));
+  }
+
+  @Test
+  public void shouldCreateExpectedServiceId() {
+    // When:
+    queryBuilder.buildQuery(
+        STATEMENT_TEXT,
+        QUERY_ID,
+        sink,
+        Optional.of(materializationInfo),
+        SOURCES,
+        physicalPlan,
+        SUMMARY
+    );
+
+    // Then:
+    assertThat(
+        capturedStreamsProperties().get(StreamsConfig.APPLICATION_ID_CONFIG),
+        equalTo("_confluent-ksql-service-persistent-queryid")
+    );
+  }
+
+  @Test
+  @SuppressWarnings("unchecked")
+  public void shouldAddMetricsInterceptorsToStreamsConfig() {
+    // When:
+    queryBuilder.buildQuery(
+        STATEMENT_TEXT,
+        QUERY_ID,
+        sink,
+        Optional.of(materializationInfo),
+        SOURCES,
+        physicalPlan,
+        SUMMARY
+    );
+
+    // Then:
+    final Map<String, Object> streamsProperties = capturedStreamsProperties();
+    final List<String> ciList = (List<String>) streamsProperties.get(
+        StreamsConfig.consumerPrefix(ConsumerConfig.INTERCEPTOR_CLASSES_CONFIG)
+    );
+    assertThat(ciList, contains(ConsumerCollector.class.getName()));
+
+    final List<String> piList = (List<String>) streamsProperties.get(
+        StreamsConfig.producerPrefix(ConsumerConfig.INTERCEPTOR_CLASSES_CONFIG)
+    );
+    assertThat(piList, contains(ProducerCollector.class.getName()));
+  }
+
+  private void shouldUseProvidedOptimizationConfig(final Object value) {
+    // Given:
+    final Map<String, Object> properties =
+        Collections.singletonMap(StreamsConfig.TOPOLOGY_OPTIMIZATION, value);
+    when(ksqlConfig.getKsqlStreamConfigProps()).thenReturn(properties);
+
+    // When:
+    queryBuilder.buildQuery(
+        STATEMENT_TEXT,
+        QUERY_ID,
+        sink,
+        Optional.of(materializationInfo),
+        SOURCES,
+        physicalPlan,
+        SUMMARY
+    );
+
+    // Then:
+    final Map<String, Object> captured = capturedStreamsProperties();
+    assertThat(captured.get(StreamsConfig.TOPOLOGY_OPTIMIZATION), equalTo(value));
+  }
+
+  @Test
+  public void shouldUseOptimizationConfigProvidedWhenOn() {
+    shouldUseProvidedOptimizationConfig(StreamsConfig.OPTIMIZE);
+  }
+
+  @Test
+  public void shouldUseOptimizationConfigProvidedWhenOff() {
+    shouldUseProvidedOptimizationConfig(StreamsConfig.NO_OPTIMIZATION);
+  }
+
+  @SuppressWarnings("unchecked")
+  private void assertPropertiesContainDummyInterceptors() {
+    final Map<String, Object> streamsProperties = capturedStreamsProperties();
+    final List<String> cInterceptors = (List<String>) streamsProperties.get(
+        StreamsConfig.consumerPrefix(ConsumerConfig.INTERCEPTOR_CLASSES_CONFIG));
+    assertThat(
+        cInterceptors,
+        contains(
+            DummyConsumerInterceptor.class.getName(),
+            ConsumerCollector.class.getName()
+        )
+    );
+    final List<String> pInterceptors = (List<String>) streamsProperties.get(
+        StreamsConfig.producerPrefix(ProducerConfig.INTERCEPTOR_CLASSES_CONFIG));
+    assertThat(
+        pInterceptors,
+        contains(
+            DummyProducerInterceptor.class.getName(),
+            ProducerCollector.class.getName()
+        )
+    );
+  }
+
+  @Test
+  @SuppressWarnings("unchecked")
+  public void shouldAddMetricsInterceptorsToExistingList() {
+    // Given:
+    when(ksqlConfig.getKsqlStreamConfigProps()).thenReturn(ImmutableMap.of(
+        StreamsConfig.consumerPrefix(ConsumerConfig.INTERCEPTOR_CLASSES_CONFIG),
+        ImmutableList.of(DummyConsumerInterceptor.class.getName()),
+        StreamsConfig.producerPrefix(ConsumerConfig.INTERCEPTOR_CLASSES_CONFIG),
+        ImmutableList.of(DummyProducerInterceptor.class.getName())
+    ));
+
+    // When:
+    queryBuilder.buildQuery(
+        STATEMENT_TEXT,
+        QUERY_ID,
+        sink,
+        Optional.of(materializationInfo),
+        SOURCES,
+        physicalPlan,
+        SUMMARY
+    );
+
+    // Then:
+    assertPropertiesContainDummyInterceptors();
+  }
+
+  @Test
+  public void shouldAddMetricsInterceptorsToExistingString() {
+    // When:
+    when(ksqlConfig.getKsqlStreamConfigProps()).thenReturn(ImmutableMap.of(
+        StreamsConfig.consumerPrefix(ConsumerConfig.INTERCEPTOR_CLASSES_CONFIG),
+        DummyConsumerInterceptor.class.getName(),
+        StreamsConfig.producerPrefix(ConsumerConfig.INTERCEPTOR_CLASSES_CONFIG),
+        DummyProducerInterceptor.class.getName()
+    ));
+
+    // When:
+    queryBuilder.buildQuery(
+        STATEMENT_TEXT,
+        QUERY_ID,
+        sink,
+        Optional.of(materializationInfo),
+        SOURCES,
+        physicalPlan,
+        SUMMARY
+    );
+
+    // Then:
+    assertPropertiesContainDummyInterceptors();
+  }
+
+  @Test
+  @SuppressWarnings("unchecked")
+  public void shouldAddMetricsInterceptorsToExistingStringList() {
+    // When:
+    when(ksqlConfig.getKsqlStreamConfigProps()).thenReturn(ImmutableMap.of(
+        StreamsConfig.consumerPrefix(ConsumerConfig.INTERCEPTOR_CLASSES_CONFIG),
+        DummyConsumerInterceptor.class.getName()
+            + ","
+            + DummyConsumerInterceptor2.class.getName()
+    ));
+
+    // When:
+    queryBuilder.buildQuery(
+        STATEMENT_TEXT,
+        QUERY_ID,
+        sink,
+        Optional.of(materializationInfo),
+        SOURCES,
+        physicalPlan,
+        SUMMARY
+    );
+
+    // Then:
+    final Map<String, Object> streamsProperties = capturedStreamsProperties();
+    final List<String> cInterceptors = (List<String>) streamsProperties.get(
+        StreamsConfig.consumerPrefix(ConsumerConfig.INTERCEPTOR_CLASSES_CONFIG));
+    assertThat(
+        cInterceptors,
+        contains(
+            DummyConsumerInterceptor.class.getName(),
+            DummyConsumerInterceptor2.class.getName(),
+            ConsumerCollector.class.getName()
+        )
+    );
+  }
+
+  @Test
+  public void shouldConfigureProducerErrorHandler() {
+    final ProcessingLogger logger = mock(ProcessingLogger.class);
+    when(processingLoggerFactory.getLogger(QUERY_ID.getId())).thenReturn(logger);
+
+    // When:
+    queryBuilder.buildQuery(
+        STATEMENT_TEXT,
+        QUERY_ID,
+        sink,
+        Optional.of(materializationInfo),
+        SOURCES,
+        physicalPlan,
+        SUMMARY
+    );
+
+    // Then:
+    final Map<String, Object> streamsProps = capturedStreamsProperties();
+    assertThat(
+        streamsProps.get(ProductionExceptionHandlerUtil.KSQL_PRODUCTION_ERROR_LOGGER),
+        is(logger));
+  }
+
+  public static class DummyConsumerInterceptor implements ConsumerInterceptor {
+
+    public ConsumerRecords onConsume(final ConsumerRecords consumerRecords) {
+      return consumerRecords;
+    }
+
+    public void close() {
+    }
+
+    public void onCommit(final Map map) {
+    }
+
+    public void configure(final Map<String, ?> map) {
+    }
+  }
+
+  public static class DummyProducerInterceptor implements ProducerInterceptor {
+
+    public void onAcknowledgement(final RecordMetadata rm, final Exception e) {
+    }
+
+    public ProducerRecord onSend(final ProducerRecord producerRecords) {
+      return producerRecords;
+    }
+
+    public void close() {
+    }
+
+    public void configure(final Map<String, ?> map) {
+    }
+  }
+
+  public static class DummyConsumerInterceptor2 implements ConsumerInterceptor {
+
+    public ConsumerRecords onConsume(final ConsumerRecords consumerRecords) {
+      return consumerRecords;
+    }
+
+    public void close() {
+    }
+
+    public void onCommit(final Map map) {
+    }
+
+    public void configure(final Map<String, ?> map) {
+    }
+  }
+
+  private Map<String, Object> capturedStreamsProperties() {
+    verify(kafkaStreamsBuilder).buildKafkaStreams(any(), propertyCaptor.capture());
+    return propertyCaptor.getValue();
+  }
+
+  private void givenTransientQuery() {
+    when(physicalPlan.build(any())).thenReturn(streamWithSerdeFactory);
+    when(streamWithSerdeFactory.getStream()).thenReturn(kstream);
+  }
+}

--- a/ksql-engine/src/test/java/io/confluent/ksql/query/TransientQueryQueueTest.java
+++ b/ksql-engine/src/test/java/io/confluent/ksql/query/TransientQueryQueueTest.java
@@ -13,7 +13,7 @@
  * specific language governing permissions and limitations under the License.
  */
 
-package io.confluent.ksql.physical;
+package io.confluent.ksql.query;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.empty;
@@ -23,11 +23,9 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.when;
 
 import io.confluent.ksql.GenericRow;
-import io.confluent.ksql.physical.TransientQueryQueue.QueuePopulator;
-import io.confluent.ksql.structured.SchemaKStream;
+import io.confluent.ksql.query.TransientQueryQueue.QueuePopulator;
 import java.util.OptionalInt;
 import java.util.Queue;
 import java.util.stream.IntStream;
@@ -60,8 +58,8 @@ public class TransientQueryQueueTest {
 
   @Before
   public void setUp() {
-    final TransientQueryQueue<String> queuer =
-        new TransientQueryQueue<>(kStreamsApp, OptionalInt.of(SOME_LIMIT));
+    final TransientQueryQueue queuer =
+        new TransientQueryQueue(kStreamsApp, OptionalInt.of(SOME_LIMIT));
 
     queuer.setLimitHandler(limitHandler);
 

--- a/ksql-engine/src/test/java/io/confluent/ksql/util/QueryMetadataTest.java
+++ b/ksql-engine/src/test/java/io/confluent/ksql/util/QueryMetadataTest.java
@@ -68,7 +68,6 @@ public class QueryMetadataTest {
         SOME_SCHEMA,
         SOME_SOURCES,
         "bar",
-        DataSourceType.KSTREAM,
         QUERY_APPLICATION_ID,
         topoplogy,
         Collections.emptyMap(),

--- a/ksql-execution/src/main/java/io/confluent/ksql/execution/ddl/commands/CreateSourceCommand.java
+++ b/ksql-execution/src/main/java/io/confluent/ksql/execution/ddl/commands/CreateSourceCommand.java
@@ -27,7 +27,7 @@ import java.util.Set;
 /**
  * Base class of create table/stream command
  */
-abstract class CreateSourceCommand implements DdlCommand {
+public abstract class CreateSourceCommand implements DdlCommand {
   private final String sqlExpression;
   private final SourceName sourceName;
   private final LogicalSchema schema;

--- a/ksql-rest-app/src/main/java/io/confluent/ksql/rest/server/resources/streaming/QueryStreamWriter.java
+++ b/ksql-rest-app/src/main/java/io/confluent/ksql/rest/server/resources/streaming/QueryStreamWriter.java
@@ -146,7 +146,7 @@ class QueryStreamWriter implements StreamingOutput {
     }
   }
 
-  private class LimitHandler implements io.confluent.ksql.physical.LimitHandler {
+  private class LimitHandler implements io.confluent.ksql.query.LimitHandler {
     @Override
     public void limitReached() {
       limitReached = true;

--- a/ksql-rest-app/src/test/java/io/confluent/ksql/rest/entity/QueryDescriptionFactoryTest.java
+++ b/ksql-rest-app/src/test/java/io/confluent/ksql/rest/entity/QueryDescriptionFactoryTest.java
@@ -25,7 +25,7 @@ import io.confluent.ksql.execution.ddl.commands.KsqlTopic;
 import io.confluent.ksql.metastore.model.DataSource.DataSourceType;
 import io.confluent.ksql.name.ColumnName;
 import io.confluent.ksql.name.SourceName;
-import io.confluent.ksql.physical.LimitHandler;
+import io.confluent.ksql.query.LimitHandler;
 import io.confluent.ksql.query.QueryId;
 import io.confluent.ksql.schema.ksql.LogicalSchema;
 import io.confluent.ksql.schema.ksql.PhysicalSchema;
@@ -96,7 +96,6 @@ public class QueryDescriptionFactoryTest {
         limitHandler,
         "execution plan",
         new LinkedBlockingQueue<>(),
-        DataSourceType.KSTREAM,
         "app id",
         topology,
         STREAMS_PROPS,
@@ -199,7 +198,6 @@ public class QueryDescriptionFactoryTest {
         limitHandler,
         "execution plan",
         new LinkedBlockingQueue<>(),
-        DataSourceType.KSTREAM,
         "app id",
         topology,
         STREAMS_PROPS,
@@ -233,7 +231,6 @@ public class QueryDescriptionFactoryTest {
         limitHandler,
         "execution plan",
         new LinkedBlockingQueue<>(),
-        DataSourceType.KSTREAM,
         "app id",
         topology,
         STREAMS_PROPS,

--- a/ksql-rest-app/src/test/java/io/confluent/ksql/rest/server/resources/streaming/QueryStreamWriterTest.java
+++ b/ksql-rest-app/src/test/java/io/confluent/ksql/rest/server/resources/streaming/QueryStreamWriterTest.java
@@ -32,7 +32,7 @@ import io.confluent.ksql.GenericRow;
 import io.confluent.ksql.engine.KsqlEngine;
 import io.confluent.ksql.json.JsonMapper;
 import io.confluent.ksql.name.ColumnName;
-import io.confluent.ksql.physical.LimitHandler;
+import io.confluent.ksql.query.LimitHandler;
 import io.confluent.ksql.schema.ksql.LogicalSchema;
 import io.confluent.ksql.schema.ksql.types.SqlTypes;
 import io.confluent.ksql.util.KsqlException;

--- a/ksql-rest-app/src/test/java/io/confluent/ksql/rest/server/resources/streaming/StreamedQueryResourceTest.java
+++ b/ksql-rest-app/src/test/java/io/confluent/ksql/rest/server/resources/streaming/StreamedQueryResourceTest.java
@@ -339,7 +339,6 @@ public class StreamedQueryResourceTest {
             limitHandler -> {},
             "",
             rowQueue,
-            DataSourceType.KSTREAM,
             "",
             mock(Topology.class),
             Collections.emptyMap(),


### PR DESCRIPTION
### Description 

This patch refactors the engine and physical plan builder so that
we can return the query plan from the engine:

First, we define the pojos that define the plan:
   - PhysicalPlan: this contains all the information needed to
     reconstruct the kafka streams app, and is the new return type
     for PhysicalPlanBuilder.
   - QueryPlan: this contains the PhysicalPlan, and other information
     needed about a query, such as the set of data sources read, and
     the data source written into.
   - KsqlPlan: this contains an optional QueryPlan, and an optional
     DdlCommand. A given DDL/DML statement can contain one or both of
     these.

PhysicalPlanBuilder has been simplified to just return a PhysicalPlan,
but not actually build the plan into a Kafka Streams app.

EngineExecutor has been rearranged to support building/executing KsqlPlan,
in addition to ConfiguredStatement. It's new interface has:
   - plan(ConfiguredStatement<?> statement): given a ddl or dml, build a
     KsqlPlan instance.
   - execute(KsqlPlan plan): given a plan, execute the plan (apply any
     ddls, and create a PersistentQueryMetadata)
   - execute(ConfiguredStatement<?> statement): fully execute a given
     statement.
   - executeQuery(ConfiguredStatement<Query> statement): fully execute
     a transient query.

Under the hood, EngineExecutor uses a new class called QueryExecutor to
execute query plans from a physical plan. QueryExecutor is responsible for
producing the final streams app and wrapping it in an instance of
QueryMetadata. QueryExecutor is basically doing most of what
PhysicalPlanBuilder used to do.

### Testing done 
- Added unit tests for QueryExecutor.


### Reviewer checklist
- [ ] Ensure docs are updated if necessary. (eg. if a user visible feature is being added or changed).
- [ ] Ensure relevant issues are linked (description should include text like "Fixes #<issue number>")

