### PR TITLE
fix: changes required for compatibility with KIP-479

### DIFF
--- a/ksql-engine/src/test/java/io/confluent/ksql/structured/SchemaKStreamTest.java
+++ b/ksql-engine/src/test/java/io/confluent/ksql/structured/SchemaKStreamTest.java
@@ -277,7 +277,7 @@ public class SchemaKStreamTest {
         queryBuilder,
         mock(SqlPredicateFactory.class),
         mock(AggregateParams.Factory.class),
-        new StreamsFactories(mockGroupedFactory, mockJoinedFactory, mockMaterializedFactory)
+        new StreamsFactories(mockGroupedFactory, mockJoinedFactory, mockMaterializedFactory, mockStreamJoinedFactory)
     );
   }
 

--- a/ksql-engine/src/test/java/io/confluent/ksql/structured/SchemaKTableTest.java
+++ b/ksql-engine/src/test/java/io/confluent/ksql/structured/SchemaKTableTest.java
@@ -43,6 +43,7 @@ import io.confluent.ksql.execution.ddl.commands.KsqlTopic;
 import io.confluent.ksql.execution.expression.tree.ComparisonExpression;
 import io.confluent.ksql.execution.expression.tree.Expression;
 import io.confluent.ksql.execution.expression.tree.LongLiteral;
+import io.confluent.ksql.execution.streams.StreamJoinedFactory;
 import io.confluent.ksql.name.ColumnName;
 import io.confluent.ksql.name.SourceName;
 import io.confluent.ksql.schema.ksql.ColumnRef;
@@ -206,7 +207,8 @@ public class SchemaKTableTest {
         new StreamsFactories(
             groupedFactory,
             mock(JoinedFactory.class),
-            mock(MaterializedFactory.class)
+            mock(MaterializedFactory.class),
+            mock(StreamJoinedFactory.class)
         )
     );
   }

--- a/ksql-functional-tests/src/main/java/io/confluent/ksql/test/tools/TestExecutor.java
+++ b/ksql-functional-tests/src/main/java/io/confluent/ksql/test/tools/TestExecutor.java
@@ -64,11 +64,11 @@ import org.apache.kafka.clients.producer.ProducerRecord;
 import org.apache.kafka.common.serialization.Serializer;
 import org.apache.kafka.streams.StreamsConfig;
 import org.apache.kafka.streams.TopologyTestDriver;
-import org.apache.kafka.streams.test.ConsumerRecordFactory;
 import org.hamcrest.Matcher;
 import org.hamcrest.StringDescription;
 
 // CHECKSTYLE_RULES.OFF: ClassDataAbstractionCoupling
+@SuppressWarnings("deprecation")
 public class TestExecutor implements Closeable {
   // CHECKSTYLE_RULES.ON: ClassDataAbstractionCoupling
 
@@ -333,7 +333,8 @@ public class TestExecutor implements Closeable {
             : recordTopic.getValueSerializer(schemaRegistryClient);
 
     final Object key = getKey(inputRecord);
-    final ConsumerRecord<byte[], byte[]> consumerRecord = new ConsumerRecordFactory<>(
+    final ConsumerRecord<byte[], byte[]> consumerRecord =
+        new org.apache.kafka.streams.test.ConsumerRecordFactory<>(
         keySerializer,
         valueSerializer
     ).create(

--- a/ksql-functional-tests/src/main/java/io/confluent/ksql/test/tools/TestExecutorUtil.java
+++ b/ksql-functional-tests/src/main/java/io/confluent/ksql/test/tools/TestExecutorUtil.java
@@ -67,6 +67,7 @@ import org.apache.kafka.streams.Topology;
 import org.apache.kafka.streams.TopologyTestDriver;
 
 // CHECKSTYLE_RULES.OFF: ClassDataAbstractionCoupling
+@SuppressWarnings("deprecation")
 public final class TestExecutorUtil {
   // CHECKSTYLE_RULES.ON: ClassDataAbstractionCoupling
 

--- a/ksql-streams/src/main/java/io/confluent/ksql/execution/streams/KSPlanBuilder.java
+++ b/ksql-streams/src/main/java/io/confluent/ksql/execution/streams/KSPlanBuilder.java
@@ -160,7 +160,7 @@ public final class KSPlanBuilder implements PlanBuilder {
         right,
         join,
         queryBuilder,
-        streamsFactories.getJoinedFactory()
+        streamsFactories.getStreamJoinedFactory()
     );
   }
 

--- a/ksql-streams/src/main/java/io/confluent/ksql/execution/streams/StreamJoinedFactory.java
+++ b/ksql-streams/src/main/java/io/confluent/ksql/execution/streams/StreamJoinedFactory.java
@@ -1,0 +1,58 @@
+/*
+ * Copyright 2018 Confluent Inc.
+ *
+ * Licensed under the Confluent Community License (the "License"); you may not use
+ * this file except in compliance with the License.  You may obtain a copy of the
+ * License at
+ *
+ * http://www.confluent.io/confluent-community-license
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package io.confluent.ksql.execution.streams;
+
+import io.confluent.ksql.util.KsqlConfig;
+import org.apache.kafka.common.serialization.Serde;
+import org.apache.kafka.streams.kstream.StreamJoined;
+
+public interface StreamJoinedFactory {
+  <K, V, V0> StreamJoined<K, V, V0> create(
+      Serde<K> keySerde,
+      Serde<V> leftSerde,
+      Serde<V0> rightSerde,
+      String name,
+      String storeName);
+
+
+  static StreamJoinedFactory create(final KsqlConfig ksqlConfig) {
+    if (StreamsUtil.useProvidedName(ksqlConfig)) {
+      return new StreamJoinedFactory() {
+        @Override
+        public <K, V, V0> StreamJoined<K, V, V0> create(
+            final Serde<K> keySerde,
+            final Serde<V> leftSerde,
+            final Serde<V0> rightSerde,
+            final String name,
+            final String storeName) {
+          return StreamJoined.with(keySerde, leftSerde, rightSerde)
+              .withName(name).withStoreName(storeName);
+        }
+      };
+    }
+    return new StreamJoinedFactory() {
+      @Override
+      public <K, V, V0> StreamJoined<K, V, V0> create(
+          final Serde<K> keySerde,
+          final Serde<V> leftSerde,
+          final Serde<V0> rightSerde,
+          final String name,
+          final String storeName) {
+        return  StreamJoined.with(keySerde, leftSerde, rightSerde);
+      }
+    };
+  }
+}

--- a/ksql-streams/src/main/java/io/confluent/ksql/execution/streams/StreamStreamJoinBuilder.java
+++ b/ksql-streams/src/main/java/io/confluent/ksql/execution/streams/StreamStreamJoinBuilder.java
@@ -26,8 +26,8 @@ import io.confluent.ksql.schema.ksql.PhysicalSchema;
 import io.confluent.ksql.serde.KeySerde;
 import org.apache.kafka.common.serialization.Serde;
 import org.apache.kafka.streams.kstream.JoinWindows;
-import org.apache.kafka.streams.kstream.Joined;
 import org.apache.kafka.streams.kstream.KStream;
+import org.apache.kafka.streams.kstream.StreamJoined;
 
 public final class StreamStreamJoinBuilder {
   private static final String LEFT_SERDE_CTX = "left";
@@ -41,7 +41,7 @@ public final class StreamStreamJoinBuilder {
       final KStreamHolder<K> right,
       final StreamStreamJoin<K> join,
       final KsqlQueryBuilder queryBuilder,
-      final JoinedFactory joinedFactory) {
+      final StreamJoinedFactory streamJoinedFactory) {
     final Formats leftFormats = join.getLeftFormats();
     final QueryContext queryContext = join.getProperties().getQueryContext();
     final QueryContext.Stacker stacker = QueryContext.Stacker.of(queryContext);
@@ -71,10 +71,11 @@ public final class StreamStreamJoinBuilder {
         leftPhysicalSchema,
         queryContext
     );
-    final Joined<K, GenericRow, GenericRow> joined = joinedFactory.create(
+    final StreamJoined<K, GenericRow, GenericRow> joined = streamJoinedFactory.create(
         keySerde,
         leftSerde,
         rightSerde,
+        StreamsUtil.buildOpName(queryContext),
         StreamsUtil.buildOpName(queryContext)
     );
     final KsqlValueJoiner joiner = new KsqlValueJoiner(leftSchema, rightSchema);

--- a/ksql-streams/src/main/java/io/confluent/ksql/execution/streams/StreamsFactories.java
+++ b/ksql-streams/src/main/java/io/confluent/ksql/execution/streams/StreamsFactories.java
@@ -22,23 +22,27 @@ public class StreamsFactories {
   private final GroupedFactory groupedFactory;
   private final JoinedFactory joinedFactory;
   private final MaterializedFactory materializedFactory;
+  private final StreamJoinedFactory streamJoinedFactory;
 
   public static StreamsFactories create(final KsqlConfig ksqlConfig) {
     Objects.requireNonNull(ksqlConfig);
     return new StreamsFactories(
         GroupedFactory.create(ksqlConfig),
         JoinedFactory.create(ksqlConfig),
-        MaterializedFactory.create(ksqlConfig)
+        MaterializedFactory.create(ksqlConfig),
+        StreamJoinedFactory.create(ksqlConfig)
     );
   }
 
   public StreamsFactories(
       final GroupedFactory groupedFactory,
       final JoinedFactory joinedFactory,
-      final MaterializedFactory materializedFactory) {
+      final MaterializedFactory materializedFactory,
+      final StreamJoinedFactory streamJoinedFactory) {
     this.groupedFactory = Objects.requireNonNull(groupedFactory);
     this.joinedFactory = Objects.requireNonNull(joinedFactory);
     this.materializedFactory = Objects.requireNonNull(materializedFactory);
+    this.streamJoinedFactory = Objects.requireNonNull(streamJoinedFactory);
   }
 
   public GroupedFactory getGroupedFactory() {
@@ -51,5 +55,9 @@ public class StreamsFactories {
 
   public MaterializedFactory getMaterializedFactory() {
     return materializedFactory;
+  }
+
+  public StreamJoinedFactory getStreamJoinedFactory() {
+    return streamJoinedFactory;
   }
 }

--- a/ksql-streams/src/test/java/io/confluent/ksql/execution/streams/StreamAggregateBuilderTest.java
+++ b/ksql-streams/src/test/java/io/confluent/ksql/execution/streams/StreamAggregateBuilderTest.java
@@ -197,7 +197,8 @@ public class StreamAggregateBuilderTest {
         new StreamsFactories(
             mock(GroupedFactory.class),
             mock(JoinedFactory.class),
-            materializedFactory
+            materializedFactory,
+            mock(StreamJoinedFactory.class)
         )
     );
   }

--- a/ksql-streams/src/test/java/io/confluent/ksql/execution/streams/StreamGroupByBuilderTest.java
+++ b/ksql-streams/src/test/java/io/confluent/ksql/execution/streams/StreamGroupByBuilderTest.java
@@ -152,7 +152,8 @@ public class StreamGroupByBuilderTest {
         new StreamsFactories(
             groupedFactory,
             mock(JoinedFactory.class),
-            mock(MaterializedFactory.class)
+            mock(MaterializedFactory.class),
+            mock(StreamJoinedFactory.class)
         )
     );
     streamGroupByKey = new StreamGroupByKey(PROPERTIES, sourceStep, FORMATS);

--- a/ksql-streams/src/test/java/io/confluent/ksql/execution/streams/StreamStreamJoinBuilderTest.java
+++ b/ksql-streams/src/test/java/io/confluent/ksql/execution/streams/StreamStreamJoinBuilderTest.java
@@ -11,6 +11,7 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoMoreInteractions;
 import static org.mockito.Mockito.when;
 
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import io.confluent.ksql.GenericRow;
 import io.confluent.ksql.execution.builder.KsqlQueryBuilder;
 import io.confluent.ksql.execution.context.QueryContext;
@@ -253,6 +254,7 @@ public class StreamStreamJoinBuilderTest {
   }
 
   @Test
+  @SuppressFBWarnings
   public void shouldBuildJoinedCorrectly() {
     // Given:
     givenInnerJoin();

--- a/ksql-streams/src/test/java/io/confluent/ksql/execution/streams/StreamStreamJoinBuilderTest.java
+++ b/ksql-streams/src/test/java/io/confluent/ksql/execution/streams/StreamStreamJoinBuilderTest.java
@@ -3,6 +3,7 @@ package io.confluent.ksql.execution.streams;
 import static org.hamcrest.Matchers.is;
 import static org.junit.Assert.assertThat;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.ArgumentMatchers.same;
 import static org.mockito.Mockito.mock;
@@ -128,7 +129,7 @@ public class StreamStreamJoinBuilderTest {
         .thenReturn(leftSerde);
     when(queryBuilder.buildValueSerde(eq(FormatInfo.of(Format.AVRO)), any(), any()))
         .thenReturn(rightSerde);
-    when(streamJoinedFactory.create(any(Serde.class), any(), any(), any())).thenReturn(joined);
+    when(streamJoinedFactory.create(any(Serde.class), any(Serde.class), any(Serde.class), anyString(), anyString())).thenReturn(joined);
     when(left.build(any())).thenReturn(
         new KStreamHolder<>(leftKStream, keySerdeFactory));
     when(right.build(any())).thenReturn(
@@ -139,15 +140,16 @@ public class StreamStreamJoinBuilderTest {
         mock(AggregateParams.Factory.class),
         new StreamsFactories(
             mock(GroupedFactory.class),
-            streamJoinedFactory,
-            mock(MaterializedFactory.class)
+            mock(JoinedFactory.class),
+            mock(MaterializedFactory.class),
+            streamJoinedFactory
         )
     );
   }
 
   @SuppressWarnings("unchecked")
   private void givenLeftJoin() {
-    when(leftKStream.leftJoin(any(KStream.class), any(), any(), any())).thenReturn(resultKStream);
+    when(leftKStream.leftJoin(any(KStream.class), any(), any(), any(StreamJoined.class))).thenReturn(resultKStream);
     join = new StreamStreamJoin<>(
         new DefaultExecutionStepProperties(SCHEMA, CTX),
         JoinType.LEFT,

--- a/ksql-streams/src/test/java/io/confluent/ksql/execution/streams/StreamStreamJoinBuilderTest.java
+++ b/ksql-streams/src/test/java/io/confluent/ksql/execution/streams/StreamStreamJoinBuilderTest.java
@@ -254,7 +254,7 @@ public class StreamStreamJoinBuilderTest {
   }
 
   @Test
-  @SuppressFBWarnings
+  @SuppressFBWarnings("RV_RETURN_VALUE_IGNORED_NO_SIDE_EFFECT")
   public void shouldBuildJoinedCorrectly() {
     // Given:
     givenInnerJoin();

--- a/ksql-streams/src/test/java/io/confluent/ksql/execution/streams/StreamTableJoinBuilderTest.java
+++ b/ksql-streams/src/test/java/io/confluent/ksql/execution/streams/StreamTableJoinBuilderTest.java
@@ -135,7 +135,8 @@ public class StreamTableJoinBuilderTest {
         new StreamsFactories(
             mock(GroupedFactory.class),
             joinedFactory,
-            mock(MaterializedFactory.class)
+            mock(MaterializedFactory.class),
+            mock(StreamJoinedFactory.class)
         )
     );
   }

--- a/ksql-streams/src/test/java/io/confluent/ksql/execution/streams/StreamToTableBuilderTest.java
+++ b/ksql-streams/src/test/java/io/confluent/ksql/execution/streams/StreamToTableBuilderTest.java
@@ -138,7 +138,8 @@ public class StreamToTableBuilderTest {
         new StreamsFactories(
             mock(GroupedFactory.class),
             mock(JoinedFactory.class),
-            materializedFactory
+            materializedFactory,
+            mock(StreamJoinedFactory.class)
         )
     );
   }

--- a/ksql-streams/src/test/java/io/confluent/ksql/execution/streams/TableAggregateBuilderTest.java
+++ b/ksql-streams/src/test/java/io/confluent/ksql/execution/streams/TableAggregateBuilderTest.java
@@ -172,7 +172,8 @@ public class TableAggregateBuilderTest {
         new StreamsFactories(
             mock(GroupedFactory.class),
             mock(JoinedFactory.class),
-            materializedFactory
+            materializedFactory,
+            mock(StreamJoinedFactory.class)
         )
     );
   }

--- a/ksql-streams/src/test/java/io/confluent/ksql/execution/streams/TableGroupByBuilderTest.java
+++ b/ksql-streams/src/test/java/io/confluent/ksql/execution/streams/TableGroupByBuilderTest.java
@@ -151,7 +151,8 @@ public class TableGroupByBuilderTest {
         new StreamsFactories(
             groupedFactory,
             mock(JoinedFactory.class),
-            mock(MaterializedFactory.class)
+            mock(MaterializedFactory.class),
+            mock(StreamJoinedFactory.class)
         )
     );
   }


### PR DESCRIPTION
### Description 
This PR introduces the `StreamJoined` object from [KIP-479](https://cwiki.apache.org/confluence/display/KAFKA/KIP-479%3A+Add+StreamJoined+config+object+to+Join).  Specifically this PR

1. Removes use of the now deprecated `KStream#join(KStream,....Joined)` methods in favor of `KStream#join(KStream,....StreamJoined)`
2. Keeps the name of the stores so none of the expected topologies needed changing.  This was a judgment call on my part, and the KSQL team will need to let me know their preferences.

### Testing done 
I updated existing tests.  Since this PR does not introduce new behavior, I felt that updating the current tests is sufficient.
EDIT: I ran the `QueryTranslationTest`, `ksql-engine`, and `ksql-streams` tests locally and all passed.

### Reviewer checklist
- [ ] Ensure docs are updated if necessary. (eg. if a user visible feature is being added or changed).
- [ ] Ensure relevant issues are linked (description should include text like "Fixes #<issue number>")

