### PR TITLE
feat: change /metadata REST path to /v1/metadata

### DIFF
--- a/ksql-rest-app/src/main/java/io/confluent/ksql/rest/server/resources/ServerMetadataResource.java
+++ b/ksql-rest-app/src/main/java/io/confluent/ksql/rest/server/resources/ServerMetadataResource.java
@@ -29,7 +29,7 @@ import javax.ws.rs.Produces;
 import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.Response;
 
-@Path("/metadata")
+@Path("/v1/metadata")
 @Produces({Versions.KSQL_V1_JSON, MediaType.APPLICATION_JSON})
 public final class ServerMetadataResource {
   private final ServerMetadata serverMetadata;

--- a/ksql-rest-app/src/test/java/io/confluent/ksql/rest/server/filters/KsqlAuthorizationFilterTest.java
+++ b/ksql-rest-app/src/test/java/io/confluent/ksql/rest/server/filters/KsqlAuthorizationFilterTest.java
@@ -90,7 +90,7 @@ public class KsqlAuthorizationFilterTest {
   @Test
   public void filterShouldContinueOnUnauthorizedMetadataPath() {
     // Given:
-    ContainerRequest request = givenRequestContext(userPrincipal, "GET", "metadata");
+    ContainerRequest request = givenRequestContext(userPrincipal, "GET", "v1/metadata");
 
     // When:
     authorizationFilter.filter(request);
@@ -103,7 +103,7 @@ public class KsqlAuthorizationFilterTest {
   @Test
   public void filterShouldContinueOnUnauthorizedMetadataIdPath() {
     // Given:
-    ContainerRequest request = givenRequestContext(userPrincipal, "GET", "metadata/id");
+    ContainerRequest request = givenRequestContext(userPrincipal, "GET", "v1/metadata/id");
 
     // When:
     authorizationFilter.filter(request);

--- a/ksql-rest-model/src/main/java/io/confluent/ksql/rest/entity/ServerClusterId.java
+++ b/ksql-rest-model/src/main/java/io/confluent/ksql/rest/entity/ServerClusterId.java
@@ -20,6 +20,8 @@ import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.google.common.collect.ImmutableMap;
 import com.google.errorprone.annotations.Immutable;
+
+import java.util.Collections;
 import java.util.Map;
 import java.util.Objects;
 
@@ -30,19 +32,22 @@ public final class ServerClusterId {
   private static final String KSQL_CLUSTER = "ksql-cluster";
 
   private static final String id = "";
-  private final Map<String, String> scope;
+  private final Map<String, Object> scope;
 
   @JsonCreator
   ServerClusterId(
-      @JsonProperty("scope") final Map<String, String> scope
+      @JsonProperty("scope") final Map<String, Object> scope
   ) {
     this.scope = ImmutableMap.copyOf(Objects.requireNonNull(scope, "scope"));
   }
 
   public static ServerClusterId of(final String kafkaClusterId, final String ksqlClusterId) {
     return new ServerClusterId(ImmutableMap.of(
-        KAFKA_CLUSTER, kafkaClusterId,
-        KSQL_CLUSTER, ksqlClusterId
+        "path", Collections.emptyList(),
+        "clusters", ImmutableMap.of(
+            KAFKA_CLUSTER, kafkaClusterId,
+            KSQL_CLUSTER, ksqlClusterId
+        )
     ));
   }
 
@@ -50,7 +55,7 @@ public final class ServerClusterId {
     return id;
   }
 
-  public Map<String, String> getScope() {
+  public Map<String, Object> getScope() {
     return scope;
   }
 

--- a/ksql-rest-model/src/main/java/io/confluent/ksql/rest/entity/ServerClusterId.java
+++ b/ksql-rest-model/src/main/java/io/confluent/ksql/rest/entity/ServerClusterId.java
@@ -31,6 +31,9 @@ public final class ServerClusterId {
   private static final String KAFKA_CLUSTER = "kafka-cluster";
   private static final String KSQL_CLUSTER = "ksql-cluster";
 
+  // ID is unused for now, but it might be used later to include a URL that joins both, kafka and
+  // ksql, clusters names into one single string. This one URL string will be easier to pass
+  // through authorization commands to authorize access to this KSQL cluster.
   private static final String id = "";
   private final Map<String, Object> scope;
 
@@ -43,6 +46,8 @@ public final class ServerClusterId {
 
   public static ServerClusterId of(final String kafkaClusterId, final String ksqlClusterId) {
     return new ServerClusterId(ImmutableMap.of(
+        // 'path' is unused for now, but it might be used by Cloud environments that specify
+        // which account organization this cluster belongs to.
         "path", Collections.emptyList(),
         "clusters", ImmutableMap.of(
             KAFKA_CLUSTER, kafkaClusterId,

--- a/ksql-rest-model/src/test/java/io/confluent/ksql/rest/entity/ServerClusterIdTest.java
+++ b/ksql-rest-model/src/test/java/io/confluent/ksql/rest/entity/ServerClusterIdTest.java
@@ -15,7 +15,9 @@
 
 package io.confluent.ksql.rest.entity;
 
-import static org.junit.Assert.assertEquals;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.is;
+import static org.junit.Assert.assertThat;
 
 import com.google.common.collect.ImmutableMap;
 
@@ -34,15 +36,15 @@ public class ServerClusterIdTest {
     final Map<String, Object> scope = serverClusterId.getScope();
 
     // Then:
-    assertEquals("", id);
-    assertEquals(
-        ImmutableMap.of(
+    assertThat(id, is(""));
+    assertThat(
+        scope,
+        equalTo(ImmutableMap.of(
             "path", Collections.emptyList(),
             "clusters", ImmutableMap.of(
                 "kafka-cluster", "kafka1",
                 "ksql-cluster", "ksql1")
-        ),
-        scope
+        ))
     );
   }
 }

--- a/ksql-rest-model/src/test/java/io/confluent/ksql/rest/entity/ServerClusterIdTest.java
+++ b/ksql-rest-model/src/test/java/io/confluent/ksql/rest/entity/ServerClusterIdTest.java
@@ -18,6 +18,8 @@ package io.confluent.ksql.rest.entity;
 import static org.junit.Assert.assertEquals;
 
 import com.google.common.collect.ImmutableMap;
+
+import java.util.Collections;
 import java.util.Map;
 import org.junit.Test;
 
@@ -29,14 +31,17 @@ public class ServerClusterIdTest {
 
     // When:
     final String id = serverClusterId.getId();
-    final Map<String, String> scope = serverClusterId.getScope();
+    final Map<String, Object> scope = serverClusterId.getScope();
 
     // Then:
     assertEquals("", id);
     assertEquals(
         ImmutableMap.of(
-            "kafka-cluster", "kafka1",
-            "ksql-cluster", "ksql1"),
+            "path", Collections.emptyList(),
+            "clusters", ImmutableMap.of(
+                "kafka-cluster", "kafka1",
+                "ksql-cluster", "ksql1")
+        ),
         scope
     );
   }


### PR DESCRIPTION
### Description 
To be consistent with other Confluent platforms, the `/metadata` and `/metadata/id` paths were renamed to `/v1/metadata` and `/v1/metadata/id`.

Also, the `/v1/metadata/id` modified the output to this:
```
{
  "scope": {
    "path": [],
    "clusters": {
      "kafka-cluster": "ywqBIQ3PSU-K_5ttFkivCQ",
      "ksql-cluster": "default_"
    }
  },
  "id": ""
}
```

The kafka/ksql clusters ID are wrapped inside a `clusters` section. The `path` is also included, which for now is empty.

### Testing done 
- Updated unit tests
- Run manual tests

### Reviewer checklist
- [ ] Ensure docs are updated if necessary. (eg. if a user visible feature is being added or changed).
- [ ] Ensure relevant issues are linked (description should include text like "Fixes #<issue number>")

