### PR TITLE
feat: use a SR proxy to inject better authorization error msgs

### DIFF
--- a/ksql-engine/src/main/java/io/confluent/ksql/exception/KsqlSchemaAuthorizationException.java
+++ b/ksql-engine/src/main/java/io/confluent/ksql/exception/KsqlSchemaAuthorizationException.java
@@ -1,0 +1,38 @@
+/*
+ * Copyright 2019 Confluent Inc.
+ *
+ * Licensed under the Confluent Community License (the "License"); you may not use
+ * this file except in compliance with the License.  You may obtain a copy of the
+ * License at
+ *
+ * http://www.confluent.io/confluent-community-license
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package io.confluent.ksql.exception;
+
+import org.apache.commons.lang3.StringUtils;
+import org.apache.kafka.common.acl.AclOperation;
+
+public class KsqlSchemaAuthorizationException extends RuntimeException {
+  public enum Type {
+    SUBJECT, SCHEMA_ID, METHOD
+  }
+
+  public KsqlSchemaAuthorizationException(
+      final AclOperation operation,
+      final Type objectType,
+      final String objectName
+  ) {
+    super(String.format(
+        "Denied access to %s from Schema Registry %s: %s",
+        StringUtils.capitalize(operation.toString().toLowerCase()),
+        objectType.toString().toLowerCase(),
+        objectName
+    ));
+  }
+}

--- a/ksql-engine/src/main/java/io/confluent/ksql/schema/ksql/inference/SchemaRegistryTopicSchemaSupplier.java
+++ b/ksql-engine/src/main/java/io/confluent/ksql/schema/ksql/inference/SchemaRegistryTopicSchemaSupplier.java
@@ -137,8 +137,7 @@ public class SchemaRegistryTopicSchemaSupplier implements TopicSchemaSupplier {
             + "\t-> Use the REST API to list available subjects"
             + "\t" + DocumentationLinks.SR_REST_GETSUBJECTS_DOC_URL
             + System.lineSeparator()
-            + "- You do not have permissions to access the Schema Registry.Subject: "
-            + topicName + KsqlConstants.SCHEMA_REGISTRY_VALUE_SUFFIX
+            + "- You do not have permissions to access the Schema Registry."
             + "\t-> See " + DocumentationLinks.SCHEMA_REGISTRY_SECURITY_DOC_URL));
   }
 

--- a/ksql-engine/src/main/java/io/confluent/ksql/schema/registry/KsqlSchemaRegistryClient.java
+++ b/ksql-engine/src/main/java/io/confluent/ksql/schema/registry/KsqlSchemaRegistryClient.java
@@ -1,0 +1,159 @@
+/*
+ * Copyright 2019 Confluent Inc.
+ *
+ * Licensed under the Confluent Community License (the "License"); you may not use
+ * this file except in compliance with the License.  You may obtain a copy of the
+ * License at
+ *
+ * http://www.confluent.io/confluent-community-license
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package io.confluent.ksql.schema.registry;
+
+import static io.confluent.ksql.exception.KsqlSchemaAuthorizationException.Type.METHOD;
+import static io.confluent.ksql.exception.KsqlSchemaAuthorizationException.Type.SCHEMA_ID;
+import static io.confluent.ksql.exception.KsqlSchemaAuthorizationException.Type.SUBJECT;
+import static io.confluent.ksql.util.LimitedProxyBuilder.methodParams;
+import static io.confluent.ksql.util.LimitedProxyBuilder.noParams;
+import static java.util.Objects.requireNonNull;
+
+import io.confluent.kafka.schemaregistry.client.SchemaMetadata;
+import io.confluent.kafka.schemaregistry.client.SchemaRegistryClient;
+import io.confluent.kafka.schemaregistry.client.rest.exceptions.RestClientException;
+import io.confluent.ksql.exception.KsqlSchemaAuthorizationException;
+import io.confluent.ksql.util.LimitedProxyBuilder;
+import java.io.IOException;
+import java.util.Collection;
+import java.util.List;
+
+import org.apache.avro.Schema;
+import org.apache.http.HttpStatus;
+import org.apache.kafka.common.acl.AclOperation;
+
+public class KsqlSchemaRegistryClient {
+  public static SchemaRegistryClient createProxy(final SchemaRegistryClient schemaRegistryClient) {
+    final KsqlSchemaRegistryClient ksqlSchemaRegistryClient =
+        new KsqlSchemaRegistryClient(schemaRegistryClient);
+
+    return LimitedProxyBuilder.forClass(SchemaRegistryClient.class)
+        .forward("deleteSubject",
+            methodParams(String.class),
+            ksqlSchemaRegistryClient)
+        .forward("getById",
+            methodParams(int.class),
+            ksqlSchemaRegistryClient)
+        .forward("getAllSubjects",
+            noParams(),
+            ksqlSchemaRegistryClient)
+        .forward("getLatestSchemaMetadata",
+            methodParams(String.class),
+            ksqlSchemaRegistryClient)
+        .forward("register",
+            methodParams(String.class, Schema.class),
+            ksqlSchemaRegistryClient)
+        .forward("testCompatibility",
+            methodParams(String.class, Schema.class),
+            ksqlSchemaRegistryClient)
+        .build();
+  }
+
+  private final SchemaRegistryClient delegate;
+
+  public KsqlSchemaRegistryClient(final SchemaRegistryClient delegate) {
+    this.delegate = requireNonNull(delegate, "delegate");
+  }
+
+  public List<Integer> deleteSubject(final String subject) throws IOException, RestClientException {
+    try {
+      return delegate.deleteSubject(subject);
+    } catch (final RestClientException e) {
+      if (isAuthorizationError(e)) {
+        throw new KsqlSchemaAuthorizationException(AclOperation.DELETE, SUBJECT, subject);
+      }
+
+      throw e;
+    }
+  }
+
+  public Collection<String> getAllSubjects() throws IOException, RestClientException {
+    try {
+      return delegate.getAllSubjects();
+    } catch (final RestClientException e) {
+      if (isAuthorizationError(e)) {
+        throw new KsqlSchemaAuthorizationException(AclOperation.READ, METHOD, "getAllSubjects()");
+      }
+
+      throw e;
+    }
+  }
+
+  public Schema getById(final int id) throws IOException, RestClientException {
+    try {
+      return delegate.getById(id);
+    } catch (final RestClientException e) {
+      if (isAuthorizationError(e)) {
+        throw new KsqlSchemaAuthorizationException(
+            AclOperation.READ,
+            SCHEMA_ID,
+            String.valueOf(id)
+        );
+      }
+
+      throw e;
+    }
+  }
+
+  public SchemaMetadata getLatestSchemaMetadata(final String subject)
+      throws IOException, RestClientException {
+    try {
+      return delegate.getLatestSchemaMetadata(subject);
+    } catch (final RestClientException e) {
+      if (isAuthorizationError(e)) {
+        throw new KsqlSchemaAuthorizationException(AclOperation.READ, SUBJECT, subject);
+      }
+
+      throw e;
+    }
+  }
+
+  public int register(final String subject, final Schema schema)
+      throws IOException, RestClientException {
+    try {
+      return delegate.register(subject, schema);
+    } catch (final RestClientException e) {
+      if (isAuthorizationError(e)) {
+        throw new KsqlSchemaAuthorizationException(AclOperation.WRITE, SUBJECT, subject);
+      }
+
+      throw e;
+    }
+  }
+
+  public boolean testCompatibility(final String subject, final Schema schema)
+      throws IOException, RestClientException {
+    try {
+      return delegate.testCompatibility(subject, schema);
+    } catch (final RestClientException e) {
+      if (isAuthorizationError(e)) {
+        throw new KsqlSchemaAuthorizationException(AclOperation.WRITE, SUBJECT, subject);
+      }
+
+      throw e;
+    }
+  }
+
+  private boolean isAuthorizationError(final RestClientException e) {
+    switch (e.getStatus()) {
+      case HttpStatus.SC_UNAUTHORIZED:
+      case HttpStatus.SC_FORBIDDEN:
+        return true;
+      default:
+        return false;
+    }
+  }
+}

--- a/ksql-engine/src/main/java/io/confluent/ksql/schema/registry/KsqlSchemaRegistryClientFactory.java
+++ b/ksql-engine/src/main/java/io/confluent/ksql/schema/registry/KsqlSchemaRegistryClientFactory.java
@@ -83,11 +83,11 @@ public class KsqlSchemaRegistryClientFactory {
       restService.setSslSocketFactory(sslContext.getSocketFactory());
     }
 
-    return schemaRegistryClientFactory.create(
+    return KsqlSchemaRegistryClient.createProxy(schemaRegistryClientFactory.create(
         restService,
         1000,
         schemaRegistryClientConfigs,
         httpHeaders
-    );
+    ));
   }
 }

--- a/ksql-engine/src/test/java/io/confluent/ksql/schema/registry/KsqlSchemaRegistryClientFactoryTest.java
+++ b/ksql-engine/src/test/java/io/confluent/ksql/schema/registry/KsqlSchemaRegistryClientFactoryTest.java
@@ -77,10 +77,6 @@ public class KsqlSchemaRegistryClientFactoryTest {
   }
 
   @Test
-  public void should() {
-  }
-
-  @Test
   public void shouldSetSocketFactoryWhenNoSpecificSslConfig() {
     // Given:
     final KsqlConfig config = config();

--- a/ksql-engine/src/test/java/io/confluent/ksql/schema/registry/KsqlSchemaRegistryClientTest.java
+++ b/ksql-engine/src/test/java/io/confluent/ksql/schema/registry/KsqlSchemaRegistryClientTest.java
@@ -1,0 +1,149 @@
+/*
+ * Copyright 2019 Confluent Inc.
+ *
+ * Licensed under the Confluent Community License (the "License"); you may not use
+ * this file except in compliance with the License.  You may obtain a copy of the
+ * License at
+ *
+ * http://www.confluent.io/confluent-community-license
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package io.confluent.ksql.schema.registry;
+
+import io.confluent.kafka.schemaregistry.client.SchemaRegistryClient;
+import io.confluent.kafka.schemaregistry.client.rest.exceptions.RestClientException;
+import io.confluent.ksql.exception.KsqlSchemaAuthorizationException;
+import org.apache.avro.Schema;
+import org.apache.commons.lang3.StringUtils;
+import org.apache.kafka.common.acl.AclOperation;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnitRunner;
+
+import java.io.IOException;
+
+import static javax.servlet.http.HttpServletResponse.SC_FORBIDDEN;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.when;
+
+@RunWith(MockitoJUnitRunner.class)
+public class KsqlSchemaRegistryClientTest {
+  @Rule
+  public final ExpectedException expectedException = ExpectedException.none();
+
+  @Mock
+  private SchemaRegistryClient schemaRegistryClient;
+
+  private SchemaRegistryClient ksqlSchemaRegistryClient;
+
+  @Before
+  public void setUp() {
+    ksqlSchemaRegistryClient = KsqlSchemaRegistryClient.createProxy(schemaRegistryClient);
+  }
+
+  @Test
+  public void shouldThrowAuthorizationExceptionOnDeleteSubject()
+      throws IOException, RestClientException {
+    // Given
+    doThrow(new RestClientException("", SC_FORBIDDEN, 1))
+        .when(schemaRegistryClient).deleteSubject("s1");
+
+    // Then
+    expectedException.expect(KsqlSchemaAuthorizationException.class);
+    expectedException.expectMessage(messageFor(AclOperation.DELETE, "subject: s1"));
+
+    // When
+    ksqlSchemaRegistryClient.deleteSubject("s1");
+  }
+
+  @Test
+  public void shouldThrowAuthorizationExceptionOnGetAllSubjects()
+      throws IOException, RestClientException {
+    // Given
+    doThrow(new RestClientException("", SC_FORBIDDEN, 1))
+        .when(schemaRegistryClient).getAllSubjects();
+
+    // Then
+    expectedException.expect(KsqlSchemaAuthorizationException.class);
+    expectedException.expectMessage(messageFor(AclOperation.READ, "method: getAllSubjects()"));
+
+    // When
+    ksqlSchemaRegistryClient.getAllSubjects();
+  }
+
+  @Test
+  public void shouldThrowAuthorizationExceptionOnGetById()
+      throws IOException, RestClientException {
+    // Given
+    doThrow(new RestClientException("", SC_FORBIDDEN, 1))
+        .when(schemaRegistryClient).getById(1);
+
+    // Then
+    expectedException.expect(KsqlSchemaAuthorizationException.class);
+    expectedException.expectMessage(messageFor(AclOperation.READ, "schema_id: 1"));
+
+    // When
+    ksqlSchemaRegistryClient.getById(1);
+  }
+
+  @Test
+  public void shouldThrowAuthorizationExceptionOnGetLatestSchema()
+      throws IOException, RestClientException {
+    // Given
+    doThrow(new RestClientException("", SC_FORBIDDEN, 1))
+        .when(schemaRegistryClient).getLatestSchemaMetadata("s");
+
+    // Then
+    expectedException.expect(KsqlSchemaAuthorizationException.class);
+    expectedException.expectMessage(messageFor(AclOperation.READ, "subject: s"));
+
+    // When
+    ksqlSchemaRegistryClient.getLatestSchemaMetadata("s");
+  }
+
+  @Test
+  public void shouldThrowAuthorizationExceptionOnRegister()
+      throws IOException, RestClientException {
+    // Given
+    doThrow(new RestClientException("", SC_FORBIDDEN, 1))
+        .when(schemaRegistryClient).register(any(), any());
+
+    // Then
+    expectedException.expect(KsqlSchemaAuthorizationException.class);
+    expectedException.expectMessage(messageFor(AclOperation.WRITE, "subject: s"));
+
+    // When
+    ksqlSchemaRegistryClient.register("s", Schema.create(Schema.Type.STRING));
+  }
+
+  @Test
+  public void shouldThrowAuthorizationExceptionOnTestCompatibility()
+      throws IOException, RestClientException {
+    // Given
+    doThrow(new RestClientException("", SC_FORBIDDEN, 1))
+        .when(schemaRegistryClient).testCompatibility(any(), any());
+
+    // Then
+    expectedException.expect(KsqlSchemaAuthorizationException.class);
+    expectedException.expectMessage(messageFor(AclOperation.WRITE, "subject: s"));
+
+    // When
+    ksqlSchemaRegistryClient.testCompatibility("s", Schema.create(Schema.Type.STRING));
+  }
+
+  private String messageFor(final AclOperation aclOperation, final String str) {
+    return String.format("Denied access to %s from Schema Registry %s",
+        StringUtils.capitalize(aclOperation.toString().toLowerCase()),
+        str);
+  }
+}


### PR DESCRIPTION
### Description 
This PR uses a proxy SchemaRegistry client so that KSQL can inject better authorization error messages when the SR `RestClientException` is thrown. SR currently does not throw a nice message, and even if it returns a good one, it might not add extra information that KSQL requires to provide a better feedback to the user.

The solution was to use a proxy client which is returned by the `KsqlSchemaRegistryClientFactory` (used by `ServiceContextFactory`) so that we get the advantage of these errors messages whenever the SR client is used.

An extra fix I added was to avoid retrying SR authorization errors on the `ExecutorUtil` class, so that deleting schemas is not retried anymore.

### Testing done 
- Added unit tests
- Verified with manual tests

### Reviewer checklist
- [ ] Ensure docs are updated if necessary. (eg. if a user visible feature is being added or changed).
- [ ] Ensure relevant issues are linked (description should include text like "Fixes #<issue number>")

