### PR TITLE
refactor: add type safety to column name aliasing

### DIFF
--- a/ksql-cli/src/main/java/io/confluent/ksql/cli/console/table/builder/TableRowsTableBuilder.java
+++ b/ksql-cli/src/main/java/io/confluent/ksql/cli/console/table/builder/TableRowsTableBuilder.java
@@ -46,10 +46,10 @@ public class TableRowsTableBuilder implements TableBuilder<TableRowsEntity> {
     final LogicalSchema schema = entity.getSchema();
 
     final Stream<String> keys = schema.key().stream()
-        .map(f -> f.fullName() + " " + f.type() + " KEY");
+        .map(f -> f.ref().aliasedFieldName() + " " + f.type() + " KEY");
 
     final Stream<String> values = schema.value().stream()
-        .map(f -> f.fullName() + " " + f.type());
+        .map(f -> f.ref().aliasedFieldName() + " " + f.type());
 
     return Stream.concat(keys, values)
         .collect(Collectors.toList());

--- a/ksql-common/src/main/java/io/confluent/ksql/function/IndexedFunction.java
+++ b/ksql-common/src/main/java/io/confluent/ksql/function/IndexedFunction.java
@@ -15,6 +15,7 @@
 
 package io.confluent.ksql.function;
 
+import io.confluent.ksql.name.FunctionName;
 import java.util.List;
 import org.apache.kafka.connect.data.Schema;
 
@@ -27,7 +28,7 @@ public interface IndexedFunction {
   /**
    * @return the function name
    */
-  String getFunctionName();
+  FunctionName getFunctionName();
 
   /**
    * @return the schemas for the parameters

--- a/ksql-common/src/main/java/io/confluent/ksql/function/KsqlFunction.java
+++ b/ksql-common/src/main/java/io/confluent/ksql/function/KsqlFunction.java
@@ -18,6 +18,8 @@ package io.confluent.ksql.function;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.Iterables;
 import io.confluent.ksql.function.udf.Kudf;
+import io.confluent.ksql.name.FunctionName;
+import io.confluent.ksql.schema.ksql.FormatOptions;
 import io.confluent.ksql.schema.ksql.SchemaConverters;
 import io.confluent.ksql.util.KsqlConfig;
 import io.confluent.ksql.util.KsqlException;
@@ -41,7 +43,7 @@ public final class KsqlFunction implements IndexedFunction {
   private final Function<List<Schema>,Schema> returnSchemaProvider;
   private final Schema javaReturnType;
   private final List<Schema> parameters;
-  private final String functionName;
+  private final FunctionName functionName;
   private final Class<? extends Kudf> kudfClass;
   private final Function<KsqlConfig, Kudf> udfFactory;
   private final String description;
@@ -52,7 +54,7 @@ public final class KsqlFunction implements IndexedFunction {
       final Function<List<Schema>,Schema> returnSchemaProvider,
       final Schema javaReturnType,
       final List<Schema> arguments,
-      final String functionName,
+      final FunctionName functionName,
       final Class<? extends Kudf> kudfClass,
       final Function<KsqlConfig, Kudf> udfFactory,
       final String description,
@@ -92,7 +94,7 @@ public final class KsqlFunction implements IndexedFunction {
   public static KsqlFunction createLegacyBuiltIn(
       final Schema returnType,
       final List<Schema> arguments,
-      final String functionName,
+      final FunctionName functionName,
       final Class<? extends Kudf> kudfClass
   ) {
     final Function<KsqlConfig, Kudf> udfFactory = ksqlConfig -> {
@@ -118,7 +120,7 @@ public final class KsqlFunction implements IndexedFunction {
       final Function<List<Schema>,Schema> schemaProvider,
       final Schema javaReturnType,
       final List<Schema> arguments,
-      final String functionName,
+      final FunctionName functionName,
       final Class<? extends Kudf> kudfClass,
       final Function<KsqlConfig, Kudf> udfFactory,
       final String description,
@@ -180,7 +182,7 @@ public final class KsqlFunction implements IndexedFunction {
                                                 + "return type %s.",
                                             SchemaConverters.connectToSqlConverter().toSqlType(
                                                 s1).toString(),
-                                            functionName,
+                                            functionName.toString(FormatOptions.noEscape()),
                                             SchemaConverters.connectToSqlConverter().toSqlType(
                                                 s2).toString()));
     }
@@ -190,7 +192,7 @@ public final class KsqlFunction implements IndexedFunction {
     return parameters;
   }
 
-  public String getFunctionName() {
+  public FunctionName getFunctionName() {
     return functionName;
   }
 

--- a/ksql-common/src/main/java/io/confluent/ksql/function/UdfIndex.java
+++ b/ksql-common/src/main/java/io/confluent/ksql/function/UdfIndex.java
@@ -240,7 +240,7 @@ public class UdfIndex<T extends IndexedFunction> {
 
     @Override
     public String toString() {
-      return value != null ? value.getFunctionName() : "EMPTY";
+      return value != null ? value.getFunctionName().name() : "EMPTY";
     }
 
     int compare(final Node other) {

--- a/ksql-common/src/main/java/io/confluent/ksql/name/ColumnName.java
+++ b/ksql-common/src/main/java/io/confluent/ksql/name/ColumnName.java
@@ -31,7 +31,7 @@ public final class ColumnName extends Name<ColumnName> {
   }
 
   public static ColumnName of(final String name) {
-    KsqlPreconditions.checkArgument(!name.contains("."), "expected no aliased fields!");
+    KsqlPreconditions.checkServerCondition(!name.contains("."), "expected no aliased fields!");
     return new ColumnName(name);
   }
 

--- a/ksql-common/src/main/java/io/confluent/ksql/name/ColumnName.java
+++ b/ksql-common/src/main/java/io/confluent/ksql/name/ColumnName.java
@@ -16,6 +16,7 @@
 package io.confluent.ksql.name;
 
 import com.google.errorprone.annotations.Immutable;
+import io.confluent.ksql.util.KsqlPreconditions;
 
 /**
  * The name of a column within a source.
@@ -30,6 +31,13 @@ public final class ColumnName extends Name<ColumnName> {
   }
 
   public static ColumnName of(final String name) {
+    KsqlPreconditions.checkArgument(!name.contains("."), "expected no aliased fields!");
+    return new ColumnName(name);
+  }
+
+  // this can be used to create a column name without validating that it doesn't
+  // have an alias - unfortunately this is necessary for our group by key creation :(
+  public static ColumnName withoutValidation(final String name) {
     return new ColumnName(name);
   }
 

--- a/ksql-common/src/main/java/io/confluent/ksql/schema/ksql/Column.java
+++ b/ksql-common/src/main/java/io/confluent/ksql/schema/ksql/Column.java
@@ -37,7 +37,16 @@ public final class Column {
    * @return the immutable field.
    */
   public static Column of(final ColumnName name, final SqlType type) {
-    return new Column(ColumnRef.of(name), type);
+    return new Column(ColumnRef.withoutSource(name), type);
+  }
+
+  /**
+   * @param ref  the column reference
+   * @param type the type of the column
+   * @return the immutable column
+   */
+  public static Column of(final ColumnRef ref, final SqlType type) {
+    return new Column(ref, type);
   }
 
   /**
@@ -70,17 +79,10 @@ public final class Column {
   }
 
   /**
-   * @return the fully qualified field name.
-   */
-  public String fullName() {
-    return ref.aliasedFieldName();
-  }
-
-  /**
    * @return the source of the Column
    */
   public Optional<SourceName> source() {
-    return ref.qualifier();
+    return ref.source();
   }
 
   /**
@@ -98,6 +100,13 @@ public final class Column {
   }
 
   /**
+   * @return the column reference
+   */
+  public ColumnRef ref() {
+    return ref;
+  }
+
+  /**
    * Create a new Field that matches the current, but with the supplied {@code source}.
    *
    * @param source the source to set of the new field.
@@ -105,6 +114,21 @@ public final class Column {
    */
   public Column withSource(final SourceName source) {
     return new Column(ref.withSource(source), type);
+  }
+
+  /**
+   * A column {@code matches} a column reference if the names match
+   * and either the reference does not specify a source, or the specified
+   * source matches.
+   *
+   * @param ref the reference to check
+   * @return whether or not {@code ref} matches this instance
+   */
+  public boolean matches(final ColumnRef ref) {
+    return ref.name().equals(this.ref.name())
+        && (!source().isPresent()
+        || !ref.source().isPresent()
+        || ref.source().equals(this.ref.source()));
   }
 
   @Override

--- a/ksql-common/src/main/java/io/confluent/ksql/schema/ksql/ColumnRef.java
+++ b/ksql-common/src/main/java/io/confluent/ksql/schema/ksql/ColumnRef.java
@@ -17,7 +17,6 @@ package io.confluent.ksql.schema.ksql;
 
 import static java.util.Objects.requireNonNull;
 
-import com.google.common.annotations.VisibleForTesting;
 import com.google.errorprone.annotations.Immutable;
 import io.confluent.ksql.name.ColumnName;
 import io.confluent.ksql.name.SourceName;
@@ -62,16 +61,8 @@ public final class ColumnRef {
   /**
    * @see #of(Optional, ColumnName)
    */
-  public static ColumnRef of(final ColumnName name) {
+  public static ColumnRef withoutSource(final ColumnName name) {
     return new ColumnRef(Optional.empty(), name);
-  }
-
-  /**
-   * @see #of(Optional, ColumnName)
-   */
-  @VisibleForTesting
-  public static ColumnRef of(final String name) {
-    return new ColumnRef(Optional.empty(), ColumnName.of(name));
   }
 
   private ColumnRef(final Optional<SourceName> qualifier, final ColumnName name) {
@@ -79,7 +70,7 @@ public final class ColumnRef {
     this.name = requireNonNull(name, "name");
   }
 
-  public Optional<SourceName> qualifier() {
+  public Optional<SourceName> source() {
     return qualifier;
   }
 

--- a/ksql-common/src/main/java/io/confluent/ksql/util/KsqlPreconditions.java
+++ b/ksql-common/src/main/java/io/confluent/ksql/util/KsqlPreconditions.java
@@ -31,4 +31,16 @@ public final class KsqlPreconditions {
     }
   }
 
+  /**
+   * Ensures the truth of an expression involving one or more parameters to the calling method.
+   *
+   * @param expression a boolean expression
+   * @throws KsqlServerException if {@code expression} is false
+   */
+  public static void checkServerCondition(final boolean expression, final String message) {
+    if (!expression) {
+      throw new KsqlServerException(message);
+    }
+  }
+
 }

--- a/ksql-common/src/main/java/io/confluent/ksql/util/timestamp/LongColumnTimestampExtractionPolicy.java
+++ b/ksql-common/src/main/java/io/confluent/ksql/util/timestamp/LongColumnTimestampExtractionPolicy.java
@@ -15,20 +15,17 @@
 
 package io.confluent.ksql.util.timestamp;
 
-import com.fasterxml.jackson.annotation.JsonCreator;
-import com.fasterxml.jackson.annotation.JsonProperty;
 import com.google.errorprone.annotations.Immutable;
+import io.confluent.ksql.schema.ksql.ColumnRef;
 import java.util.Objects;
 import org.apache.kafka.streams.processor.TimestampExtractor;
 
 @Immutable
 public class LongColumnTimestampExtractionPolicy implements TimestampExtractionPolicy {
 
-  private final String timestampField;
+  private final ColumnRef timestampField;
 
-  @JsonCreator
-  public LongColumnTimestampExtractionPolicy(
-      @JsonProperty("timestampField") final String timestampField) {
+  public LongColumnTimestampExtractionPolicy(final ColumnRef timestampField) {
     Objects.requireNonNull(timestampField, "timestampField can't be null");
     this.timestampField = timestampField;
   }
@@ -39,7 +36,7 @@ public class LongColumnTimestampExtractionPolicy implements TimestampExtractionP
   }
 
   @Override
-  public String timestampField() {
+  public ColumnRef timestampField() {
     return timestampField;
   }
 

--- a/ksql-common/src/main/java/io/confluent/ksql/util/timestamp/StringTimestampExtractionPolicy.java
+++ b/ksql-common/src/main/java/io/confluent/ksql/util/timestamp/StringTimestampExtractionPolicy.java
@@ -15,22 +15,20 @@
 
 package io.confluent.ksql.util.timestamp;
 
-import com.fasterxml.jackson.annotation.JsonCreator;
-import com.fasterxml.jackson.annotation.JsonProperty;
 import com.google.errorprone.annotations.Immutable;
+import io.confluent.ksql.schema.ksql.ColumnRef;
 import java.util.Objects;
 import org.apache.kafka.streams.processor.TimestampExtractor;
 
 @Immutable
 public class StringTimestampExtractionPolicy implements TimestampExtractionPolicy {
 
-  private final String timestampField;
+  private final ColumnRef timestampField;
   private final String format;
 
-  @JsonCreator
   public StringTimestampExtractionPolicy(
-      @JsonProperty("timestampField") final String timestampField,
-      @JsonProperty("format") final String format) {
+      final ColumnRef timestampField,
+      final String format) {
     Objects.requireNonNull(timestampField, "timestampField can't be null");
     Objects.requireNonNull(format, "format can't be null");
     this.timestampField = timestampField;
@@ -43,7 +41,7 @@ public class StringTimestampExtractionPolicy implements TimestampExtractionPolic
   }
 
   @Override
-  public String timestampField() {
+  public ColumnRef timestampField() {
     return timestampField;
   }
 

--- a/ksql-common/src/main/java/io/confluent/ksql/util/timestamp/TimestampExtractionPolicy.java
+++ b/ksql-common/src/main/java/io/confluent/ksql/util/timestamp/TimestampExtractionPolicy.java
@@ -16,6 +16,7 @@
 package io.confluent.ksql.util.timestamp;
 
 import com.google.errorprone.annotations.Immutable;
+import io.confluent.ksql.schema.ksql.ColumnRef;
 import org.apache.kafka.streams.processor.TimestampExtractor;
 
 @Immutable
@@ -23,7 +24,7 @@ public interface TimestampExtractionPolicy {
 
   TimestampExtractor create(int columnIndex);
 
-  default String timestampField() {
+  default ColumnRef timestampField() {
     return null;
   }
 }

--- a/ksql-common/src/test/java/io/confluent/ksql/function/KsqlFunctionTest.java
+++ b/ksql-common/src/test/java/io/confluent/ksql/function/KsqlFunctionTest.java
@@ -20,6 +20,7 @@ import static org.hamcrest.MatcherAssert.assertThat;
 
 import com.google.common.collect.ImmutableList;
 import io.confluent.ksql.function.udf.Kudf;
+import io.confluent.ksql.name.FunctionName;
 import io.confluent.ksql.util.DecimalUtil;
 import io.confluent.ksql.util.KsqlConfig;
 import java.util.List;
@@ -149,7 +150,7 @@ public class KsqlFunctionTest {
         schemaProviderFunction,
         decimalSchema,
         ImmutableList.of(Schema.INT32_SCHEMA),
-        "funcName",
+        FunctionName.of("funcName"),
         MyUdf.class,
         udfFactory,
         "the description",
@@ -176,7 +177,7 @@ public class KsqlFunctionTest {
         ignored -> returnSchema,
         returnSchema,
         args,
-        "funcName",
+        FunctionName.of("funcName"),
         MyUdf.class,
         udfFactory,
         "the description",

--- a/ksql-common/src/test/java/io/confluent/ksql/function/UdfFactoryTest.java
+++ b/ksql-common/src/test/java/io/confluent/ksql/function/UdfFactoryTest.java
@@ -18,6 +18,7 @@ package io.confluent.ksql.function;
 import com.google.common.collect.ImmutableList;
 import io.confluent.ksql.function.udf.Kudf;
 import io.confluent.ksql.function.udf.UdfMetadata;
+import io.confluent.ksql.name.FunctionName;
 import java.util.Collections;
 import org.apache.kafka.common.KafkaException;
 import org.apache.kafka.connect.data.Schema;
@@ -50,7 +51,7 @@ public class UdfFactoryTest {
         ignored -> Schema.OPTIONAL_STRING_SCHEMA,
         Schema.OPTIONAL_STRING_SCHEMA,
         Collections.<Schema>emptyList(),
-        "TestFunc",
+        FunctionName.of("TestFunc"),
         TestFunc.class,
         ksqlConfig -> null,
         "",

--- a/ksql-common/src/test/java/io/confluent/ksql/function/UdfIndexTest.java
+++ b/ksql-common/src/test/java/io/confluent/ksql/function/UdfIndexTest.java
@@ -7,6 +7,7 @@ import static org.hamcrest.Matchers.is;
 
 import com.google.common.collect.ImmutableList;
 import io.confluent.ksql.function.udf.Kudf;
+import io.confluent.ksql.name.FunctionName;
 import io.confluent.ksql.util.DecimalUtil;
 import io.confluent.ksql.util.KsqlConfig;
 import io.confluent.ksql.util.KsqlException;
@@ -38,8 +39,8 @@ public class UdfIndexTest {
   private static final Schema STRING_LIST = SchemaBuilder.array(STRING).build();
   private static final Schema INT_LIST = SchemaBuilder.array(INT).build();
 
-  private static final String EXPECTED = "expected";
-  private static final String OTHER = "other";
+  private static final FunctionName EXPECTED = FunctionName.of("expected");
+  private static final FunctionName OTHER = FunctionName.of("other");
 
   private UdfIndex<KsqlFunction> udfIndex;
 
@@ -729,6 +730,14 @@ public class UdfIndexTest {
 
   private static KsqlFunction function(
       final String name,
+      final boolean isVarArgs,
+      final Schema... args
+  ) {
+    return function(FunctionName.of(name), isVarArgs, args);
+  }
+
+  private static KsqlFunction function(
+      final FunctionName name,
       final boolean isVarArgs,
       final Schema... args
   ) {

--- a/ksql-common/src/test/java/io/confluent/ksql/schema/ksql/ColumnTest.java
+++ b/ksql-common/src/test/java/io/confluent/ksql/schema/ksql/ColumnTest.java
@@ -43,6 +43,7 @@ public class ColumnTest {
         .setDefault(SqlType.class, SqlTypes.BIGINT)
         .setDefault(ColumnName.class, SOME_NAME)
         .setDefault(SourceName.class, SOME_SOURCE)
+        .setDefault(ColumnRef.class, ColumnRef.of(SOME_SOURCE, SOME_NAME))
         .testAllPublicStaticMethods(Column.class);
   }
 
@@ -73,15 +74,6 @@ public class ColumnTest {
 
     assertThat(Column.of(SOME_SOURCE, SOME_NAME, SqlTypes.BOOLEAN).name(),
         is(SOME_NAME));
-  }
-
-  @Test
-  public void shouldReturnFullName() {
-    assertThat(Column.of(SOME_NAME, SqlTypes.BOOLEAN).fullName(),
-        is("SomeName"));
-
-    assertThat(Column.of(SOME_SOURCE, SOME_NAME, SqlTypes.BOOLEAN).fullName(),
-        is("SomeSource.SomeName"));
   }
 
   @Test

--- a/ksql-common/src/test/java/io/confluent/ksql/util/timestamp/LongColumnTimestampExtractionPolicyTest.java
+++ b/ksql-common/src/test/java/io/confluent/ksql/util/timestamp/LongColumnTimestampExtractionPolicyTest.java
@@ -16,6 +16,8 @@
 package io.confluent.ksql.util.timestamp;
 
 import com.google.common.testing.EqualsTester;
+import io.confluent.ksql.name.ColumnName;
+import io.confluent.ksql.schema.ksql.ColumnRef;
 import org.junit.Test;
 
 public class LongColumnTimestampExtractionPolicyTest {
@@ -23,9 +25,9 @@ public class LongColumnTimestampExtractionPolicyTest {
   public void shouldTestEqualityCorrectly() {
     new EqualsTester()
         .addEqualityGroup(
-            new LongColumnTimestampExtractionPolicy("field1"),
-            new LongColumnTimestampExtractionPolicy("field1"))
-        .addEqualityGroup(new LongColumnTimestampExtractionPolicy("field2"))
+            new LongColumnTimestampExtractionPolicy(ColumnRef.withoutSource(ColumnName.of("field1"))),
+            new LongColumnTimestampExtractionPolicy(ColumnRef.withoutSource(ColumnName.of("field1"))))
+        .addEqualityGroup(new LongColumnTimestampExtractionPolicy(ColumnRef.withoutSource(ColumnName.of("field2"))))
         .testEquals();
   }
 }

--- a/ksql-common/src/test/java/io/confluent/ksql/util/timestamp/StringTimestampExtractionPolicyTest.java
+++ b/ksql-common/src/test/java/io/confluent/ksql/util/timestamp/StringTimestampExtractionPolicyTest.java
@@ -16,6 +16,8 @@
 package io.confluent.ksql.util.timestamp;
 
 import com.google.common.testing.EqualsTester;
+import io.confluent.ksql.name.ColumnName;
+import io.confluent.ksql.schema.ksql.ColumnRef;
 import org.junit.Test;
 
 public class StringTimestampExtractionPolicyTest {
@@ -23,10 +25,10 @@ public class StringTimestampExtractionPolicyTest {
   public void shouldTestEqualityCorrectly() {
     new EqualsTester()
         .addEqualityGroup(
-            new StringTimestampExtractionPolicy("field1", "yyMMddHHmmssZ"),
-            new StringTimestampExtractionPolicy("field1", "yyMMddHHmmssZ"))
-        .addEqualityGroup(new StringTimestampExtractionPolicy("field2", "yyMMddHHmmssZ"))
-        .addEqualityGroup(new StringTimestampExtractionPolicy("field1", "ddMMyyHHmmssZ"))
+            new StringTimestampExtractionPolicy(ColumnRef.withoutSource(ColumnName.of("field1")), "yyMMddHHmmssZ"),
+            new StringTimestampExtractionPolicy(ColumnRef.withoutSource(ColumnName.of("field1")), "yyMMddHHmmssZ"))
+        .addEqualityGroup(new StringTimestampExtractionPolicy(ColumnRef.withoutSource(ColumnName.of("field2")), "yyMMddHHmmssZ"))
+        .addEqualityGroup(new StringTimestampExtractionPolicy(ColumnRef.withoutSource(ColumnName.of("field1")), "ddMMyyHHmmssZ"))
         .testEquals();
   }
 }

--- a/ksql-common/src/test/java/io/confluent/ksql/util/timestamp/TimestampExtractionPolicyFactoryTest.java
+++ b/ksql-common/src/test/java/io/confluent/ksql/util/timestamp/TimestampExtractionPolicyFactoryTest.java
@@ -21,6 +21,7 @@ import static org.hamcrest.core.IsInstanceOf.instanceOf;
 
 import com.google.common.collect.ImmutableMap;
 import io.confluent.ksql.name.ColumnName;
+import io.confluent.ksql.schema.ksql.ColumnRef;
 import io.confluent.ksql.schema.ksql.LogicalSchema;
 import io.confluent.ksql.schema.ksql.types.SqlTypes;
 import io.confluent.ksql.util.KsqlConfig;
@@ -142,11 +143,16 @@ public class TimestampExtractionPolicyFactoryTest {
 
     // When:
     final TimestampExtractionPolicy result = TimestampExtractionPolicyFactory
-        .create(ksqlConfig, schema, Optional.of(timestamp), Optional.empty());
+        .create(
+            ksqlConfig,
+            schema,
+            Optional.of(ColumnRef.withoutSource(ColumnName.of(timestamp.toUpperCase()))),
+            Optional.empty());
 
     // Then:
     assertThat(result, instanceOf(LongColumnTimestampExtractionPolicy.class));
-    assertThat(result.timestampField(), equalTo(timestamp.toUpperCase()));
+    assertThat(result.timestampField(),
+        equalTo(ColumnRef.withoutSource(ColumnName.of(timestamp.toUpperCase()))));
   }
 
   @Test
@@ -159,7 +165,7 @@ public class TimestampExtractionPolicyFactoryTest {
         .create(
             ksqlConfig,
             schemaBuilder2.build(),
-            Optional.of("whateva"),
+            Optional.of(ColumnRef.withoutSource(ColumnName.of("whateva"))),
             Optional.empty()
         );
   }
@@ -174,11 +180,16 @@ public class TimestampExtractionPolicyFactoryTest {
 
     // When:
     final TimestampExtractionPolicy result = TimestampExtractionPolicyFactory
-        .create(ksqlConfig, schema, Optional.of(field), Optional.of("yyyy-MM-DD"));
+        .create(
+            ksqlConfig,
+            schema,
+            Optional.of(ColumnRef.withoutSource(ColumnName.of(field.toUpperCase()))),
+            Optional.of("yyyy-MM-DD"));
 
     // Then:
     assertThat(result, instanceOf(StringTimestampExtractionPolicy.class));
-    assertThat(result.timestampField(), equalTo(field.toUpperCase()));
+    assertThat(result.timestampField(),
+        equalTo(ColumnRef.withoutSource(ColumnName.of(field.toUpperCase()))));
   }
 
   @Test
@@ -194,7 +205,11 @@ public class TimestampExtractionPolicyFactoryTest {
 
     // When:
     TimestampExtractionPolicyFactory
-        .create(ksqlConfig, schema, Optional.of(field), Optional.empty());
+        .create(
+            ksqlConfig,
+            schema,
+            Optional.of(ColumnRef.withoutSource(ColumnName.of(field.toUpperCase()))),
+            Optional.empty());
   }
 
   @Test
@@ -210,7 +225,10 @@ public class TimestampExtractionPolicyFactoryTest {
 
     // When:
     TimestampExtractionPolicyFactory
-        .create(ksqlConfig, schema, Optional.of(timestamp), Optional.of("b"));
+        .create(ksqlConfig,
+            schema,
+            Optional.of(ColumnRef.withoutSource(ColumnName.of(timestamp.toUpperCase()))),
+            Optional.of("b"));
   }
 
   @Test
@@ -226,6 +244,9 @@ public class TimestampExtractionPolicyFactoryTest {
 
     // When:
     TimestampExtractionPolicyFactory
-        .create(ksqlConfig, schema, Optional.of(field), Optional.empty());
+        .create(ksqlConfig,
+            schema,
+            Optional.of(ColumnRef.withoutSource(ColumnName.of(field))),
+            Optional.empty());
   }
 }

--- a/ksql-engine/src/main/java/io/confluent/ksql/analyzer/Analysis.java
+++ b/ksql-engine/src/main/java/io/confluent/ksql/analyzer/Analysis.java
@@ -61,7 +61,7 @@ public class Analysis {
   private final Set<ColumnRef> selectColumnRefs = new HashSet<>();
   private final List<Expression> groupByExpressions = new ArrayList<>();
   private Optional<WindowExpression> windowExpression = Optional.empty();
-  private Optional<ColumnName> partitionBy = Optional.empty();
+  private Optional<ColumnRef> partitionBy = Optional.empty();
   private ImmutableSet<SerdeOption> serdeOptions = ImmutableSet.of();
   private Optional<Expression> havingExpression = Optional.empty();
   private OptionalInt limitClause = OptionalInt.empty();
@@ -131,11 +131,11 @@ public class Analysis {
     this.havingExpression = Optional.of(havingExpression);
   }
 
-  public Optional<ColumnName> getPartitionBy() {
+  public Optional<ColumnRef> getPartitionBy() {
     return partitionBy;
   }
 
-  void setPartitionBy(final ColumnName partitionBy) {
+  void setPartitionBy(final ColumnRef partitionBy) {
     this.partitionBy = Optional.of(partitionBy);
   }
 
@@ -270,14 +270,14 @@ public class Analysis {
   @Immutable
   public static final class JoinInfo {
 
-    private final ColumnName leftJoinField;
-    private final ColumnName rightJoinField;
+    private final ColumnRef leftJoinField;
+    private final ColumnRef rightJoinField;
     private final JoinNode.JoinType type;
     private final Optional<WithinExpression> withinExpression;
 
     JoinInfo(
-        final ColumnName leftJoinField,
-        final ColumnName rightJoinField,
+        final ColumnRef leftJoinField,
+        final ColumnRef rightJoinField,
         final JoinType type,
         final Optional<WithinExpression> withinExpression
 
@@ -288,11 +288,11 @@ public class Analysis {
       this.withinExpression = requireNonNull(withinExpression, "withinExpression");
     }
 
-    public ColumnName getLeftJoinField() {
+    public ColumnRef getLeftJoinField() {
       return leftJoinField;
     }
 
-    public ColumnName getRightJoinField() {
+    public ColumnRef getRightJoinField() {
       return rightJoinField;
     }
 

--- a/ksql-engine/src/main/java/io/confluent/ksql/ddl/commands/DdlCommandExec.java
+++ b/ksql-engine/src/main/java/io/confluent/ksql/ddl/commands/DdlCommandExec.java
@@ -30,6 +30,7 @@ import io.confluent.ksql.metastore.model.KsqlTable;
 import io.confluent.ksql.name.ColumnName;
 import io.confluent.ksql.name.SourceName;
 import io.confluent.ksql.schema.ksql.Column;
+import io.confluent.ksql.schema.ksql.ColumnRef;
 import io.confluent.ksql.schema.ksql.LogicalSchema;
 import io.confluent.ksql.schema.ksql.types.SqlType;
 import java.util.Optional;
@@ -120,12 +121,14 @@ public class DdlCommandExec {
         final LogicalSchema schema
     ) {
       if (keyFieldName.isPresent()) {
-        final Column keyColumn = schema.findValueColumn(keyFieldName.get())
+        final Column keyColumn = schema.findValueColumn(
+            // for DDL commands, the key name is never specified with a source
+            ColumnRef.withoutSource(keyFieldName.get()))
             .orElseThrow(() -> new IllegalStateException(
                 "The KEY column set in the WITH clause does not exist in the schema: '"
                     + keyFieldName + "'"
             ));
-        return KeyField.of(keyFieldName.get(), keyColumn);
+        return KeyField.of(ColumnRef.withoutSource(keyFieldName.get()), keyColumn);
       } else {
         return KeyField.none();
       }

--- a/ksql-engine/src/main/java/io/confluent/ksql/function/BaseAggregateFunction.java
+++ b/ksql-engine/src/main/java/io/confluent/ksql/function/BaseAggregateFunction.java
@@ -15,6 +15,7 @@
 
 package io.confluent.ksql.function;
 
+import io.confluent.ksql.name.FunctionName;
 import io.confluent.ksql.schema.ksql.SchemaConverters;
 import io.confluent.ksql.schema.ksql.SchemaConverters.ConnectToSqlTypeConverter;
 import io.confluent.ksql.schema.ksql.types.SqlType;
@@ -83,8 +84,8 @@ public abstract class BaseAggregateFunction<I, A, O> implements KsqlAggregateFun
     return this.arguments.equals(argTypeList);
   }
 
-  public String getFunctionName() {
-    return functionName;
+  public FunctionName getFunctionName() {
+    return FunctionName.of(functionName);
   }
 
   public Supplier<A> getInitialValueSupplier() {

--- a/ksql-engine/src/main/java/io/confluent/ksql/function/InternalFunctionRegistry.java
+++ b/ksql-engine/src/main/java/io/confluent/ksql/function/InternalFunctionRegistry.java
@@ -34,6 +34,7 @@ import io.confluent.ksql.function.udf.string.LCaseKudf;
 import io.confluent.ksql.function.udf.string.LenKudf;
 import io.confluent.ksql.function.udf.string.TrimKudf;
 import io.confluent.ksql.function.udf.string.UCaseKudf;
+import io.confluent.ksql.name.FunctionName;
 import io.confluent.ksql.util.KsqlException;
 import java.util.ArrayList;
 import java.util.Collections;
@@ -67,7 +68,7 @@ public class InternalFunctionRegistry implements MutableFunctionRegistry {
 
   @Override
   public void addFunction(final KsqlFunction ksqlFunction) {
-    final UdfFactory udfFactory = udfs.get(ksqlFunction.getFunctionName().toUpperCase());
+    final UdfFactory udfFactory = udfs.get(ksqlFunction.getFunctionName().name().toUpperCase());
     if (udfFactory == null) {
       throw new KsqlException("Unknown function factory: " + ksqlFunction.getFunctionName());
     }
@@ -185,33 +186,33 @@ public class InternalFunctionRegistry implements MutableFunctionRegistry {
       addBuiltInFunction(KsqlFunction.createLegacyBuiltIn(
           Schema.OPTIONAL_STRING_SCHEMA,
           Collections.singletonList(Schema.OPTIONAL_STRING_SCHEMA),
-          "LCASE", LCaseKudf.class));
+          FunctionName.of("LCASE"), LCaseKudf.class));
 
       addBuiltInFunction(KsqlFunction.createLegacyBuiltIn(
           Schema.OPTIONAL_STRING_SCHEMA,
           Collections.singletonList(Schema.OPTIONAL_STRING_SCHEMA),
-          "UCASE", UCaseKudf.class));
+          FunctionName.of("UCASE"), UCaseKudf.class));
 
       addBuiltInFunction(KsqlFunction.createLegacyBuiltIn(
           Schema.OPTIONAL_STRING_SCHEMA,
           ImmutableList.of(Schema.OPTIONAL_STRING_SCHEMA, Schema.OPTIONAL_STRING_SCHEMA),
-          ConcatKudf.NAME, ConcatKudf.class));
+          FunctionName.of(ConcatKudf.NAME), ConcatKudf.class));
 
       addBuiltInFunction(KsqlFunction.createLegacyBuiltIn(
           Schema.OPTIONAL_STRING_SCHEMA,
           Collections.singletonList(Schema.OPTIONAL_STRING_SCHEMA),
-          "TRIM", TrimKudf.class));
+          FunctionName.of("TRIM"), TrimKudf.class));
 
       addBuiltInFunction(KsqlFunction.createLegacyBuiltIn(
           Schema.OPTIONAL_STRING_SCHEMA,
           ImmutableList.of(Schema.OPTIONAL_STRING_SCHEMA,
               Schema.OPTIONAL_STRING_SCHEMA),
-          "IFNULL", IfNullKudf.class));
+          FunctionName.of("IFNULL"), IfNullKudf.class));
 
       addBuiltInFunction(KsqlFunction.createLegacyBuiltIn(
           Schema.OPTIONAL_INT32_SCHEMA,
           Collections.singletonList(Schema.OPTIONAL_STRING_SCHEMA),
-          "LEN",
+          FunctionName.of("LEN"),
           LenKudf.class));
     }
 
@@ -220,13 +221,13 @@ public class InternalFunctionRegistry implements MutableFunctionRegistry {
       addBuiltInFunction(KsqlFunction.createLegacyBuiltIn(
           Schema.OPTIONAL_FLOAT64_SCHEMA,
           Collections.singletonList(Schema.OPTIONAL_FLOAT64_SCHEMA),
-          "CEIL",
+          FunctionName.of("CEIL"),
           CeilKudf.class));
 
       addBuiltInFunction(KsqlFunction.createLegacyBuiltIn(
           Schema.OPTIONAL_FLOAT64_SCHEMA,
           Collections.emptyList(),
-          "RANDOM",
+          FunctionName.of("RANDOM"),
           RandomKudf.class));
     }
 
@@ -235,13 +236,13 @@ public class InternalFunctionRegistry implements MutableFunctionRegistry {
       addBuiltInFunction(KsqlFunction.createLegacyBuiltIn(
           Schema.OPTIONAL_STRING_SCHEMA,
           ImmutableList.of(Schema.OPTIONAL_STRING_SCHEMA, Schema.OPTIONAL_STRING_SCHEMA),
-          JsonExtractStringKudf.NAME,
+          FunctionName.of(JsonExtractStringKudf.NAME),
           JsonExtractStringKudf.class));
 
       addBuiltInFunction(KsqlFunction.createLegacyBuiltIn(
           Schema.OPTIONAL_BOOLEAN_SCHEMA,
           ImmutableList.of(Schema.OPTIONAL_STRING_SCHEMA, Schema.OPTIONAL_STRING_SCHEMA),
-          "ARRAYCONTAINS",
+          FunctionName.of("ARRAYCONTAINS"),
           ArrayContainsKudf.class));
 
       addBuiltInFunction(KsqlFunction.createLegacyBuiltIn(
@@ -249,7 +250,7 @@ public class InternalFunctionRegistry implements MutableFunctionRegistry {
           ImmutableList.of(
               SchemaBuilder.array(Schema.OPTIONAL_STRING_SCHEMA).optional().build(),
               Schema.OPTIONAL_STRING_SCHEMA),
-          "ARRAYCONTAINS",
+          FunctionName.of("ARRAYCONTAINS"),
           ArrayContainsKudf.class));
 
       addBuiltInFunction(KsqlFunction.createLegacyBuiltIn(
@@ -257,7 +258,7 @@ public class InternalFunctionRegistry implements MutableFunctionRegistry {
           ImmutableList.of(
               SchemaBuilder.array(Schema.OPTIONAL_INT32_SCHEMA).optional().build(),
               Schema.OPTIONAL_INT32_SCHEMA),
-          "ARRAYCONTAINS",
+          FunctionName.of("ARRAYCONTAINS"),
           ArrayContainsKudf.class));
 
       addBuiltInFunction(KsqlFunction.createLegacyBuiltIn(
@@ -265,7 +266,7 @@ public class InternalFunctionRegistry implements MutableFunctionRegistry {
           ImmutableList.of(
               SchemaBuilder.array(Schema.OPTIONAL_INT64_SCHEMA).optional().build(),
               Schema.OPTIONAL_INT64_SCHEMA),
-          "ARRAYCONTAINS",
+          FunctionName.of("ARRAYCONTAINS"),
           ArrayContainsKudf.class));
 
       addBuiltInFunction(KsqlFunction.createLegacyBuiltIn(
@@ -273,7 +274,7 @@ public class InternalFunctionRegistry implements MutableFunctionRegistry {
           ImmutableList.of(
               SchemaBuilder.array(Schema.OPTIONAL_FLOAT64_SCHEMA).optional().build(),
               Schema.OPTIONAL_FLOAT64_SCHEMA),
-          "ARRAYCONTAINS",
+          FunctionName.of("ARRAYCONTAINS"),
           ArrayContainsKudf.class));
     }
 
@@ -284,7 +285,7 @@ public class InternalFunctionRegistry implements MutableFunctionRegistry {
           ImmutableList.of(
               SchemaBuilder.struct().optional().build(),
               Schema.STRING_SCHEMA),
-          FetchFieldFromStruct.FUNCTION_NAME,
+          FunctionName.of(FetchFieldFromStruct.FUNCTION_NAME),
           FetchFieldFromStruct.class),
           true);
     }
@@ -316,7 +317,7 @@ public class InternalFunctionRegistry implements MutableFunctionRegistry {
         final boolean internal
     ) {
       final UdfMetadata metadata = new UdfMetadata(
-          ksqlFunction.getFunctionName(),
+          ksqlFunction.getFunctionName().name(),
           ksqlFunction.getDescription(),
           "Confluent",
           "",

--- a/ksql-engine/src/main/java/io/confluent/ksql/function/UdfLoader.java
+++ b/ksql-engine/src/main/java/io/confluent/ksql/function/UdfLoader.java
@@ -27,6 +27,7 @@ import io.confluent.ksql.function.udf.UdfParameter;
 import io.confluent.ksql.function.udf.UdfSchemaProvider;
 import io.confluent.ksql.metastore.TypeRegistry;
 import io.confluent.ksql.metrics.MetricCollectors;
+import io.confluent.ksql.name.FunctionName;
 import io.confluent.ksql.schema.ksql.SchemaConverters;
 import io.confluent.ksql.schema.ksql.SqlTypeParser;
 import io.confluent.ksql.schema.ksql.types.SqlType;
@@ -339,7 +340,7 @@ public class UdfLoader {
                               classLevelAnnotation),
         javaReturnSchema,
         parameters,
-        functionName,
+        FunctionName.of(functionName.toUpperCase()),
         udfClass,
         ksqlConfig -> {
           final Object actualUdf = instantiateUdfClass(method, classLevelAnnotation);

--- a/ksql-engine/src/main/java/io/confluent/ksql/function/UdfLoaderUtil.java
+++ b/ksql-engine/src/main/java/io/confluent/ksql/function/UdfLoaderUtil.java
@@ -35,7 +35,7 @@ public final class UdfLoaderUtil {
 
   public static UdfFactory createTestUdfFactory(final KsqlFunction udf) {
     final UdfMetadata metadata = new UdfMetadata(
-        udf.getFunctionName(),
+        udf.getFunctionName().name(),
         udf.getDescription(),
         "Test Author",
         "",

--- a/ksql-engine/src/main/java/io/confluent/ksql/planner/plan/KsqlBareOutputNode.java
+++ b/ksql-engine/src/main/java/io/confluent/ksql/planner/plan/KsqlBareOutputNode.java
@@ -39,7 +39,7 @@ public class KsqlBareOutputNode extends OutputNode {
       final TimestampExtractionPolicy extractionPolicy
   ) {
     super(id, source, schema, limit, extractionPolicy);
-    this.keyField = KeyField.of(source.getKeyField().name(), Optional.empty())
+    this.keyField = KeyField.of(source.getKeyField().ref(), Optional.empty())
         .validateKeyExistsIn(schema);
   }
 

--- a/ksql-engine/src/main/java/io/confluent/ksql/planner/plan/KsqlStructuredDataOutputNode.java
+++ b/ksql-engine/src/main/java/io/confluent/ksql/planner/plan/KsqlStructuredDataOutputNode.java
@@ -23,10 +23,10 @@ import io.confluent.ksql.execution.builder.KsqlQueryBuilder;
 import io.confluent.ksql.execution.context.QueryContext;
 import io.confluent.ksql.execution.ddl.commands.KsqlTopic;
 import io.confluent.ksql.metastore.model.KeyField;
-import io.confluent.ksql.name.ColumnName;
 import io.confluent.ksql.name.SourceName;
 import io.confluent.ksql.query.QueryId;
 import io.confluent.ksql.query.id.QueryIdGenerator;
+import io.confluent.ksql.schema.ksql.ColumnRef;
 import io.confluent.ksql.schema.ksql.LogicalSchema;
 import io.confluent.ksql.serde.SerdeOption;
 import io.confluent.ksql.structured.SchemaKStream;
@@ -41,7 +41,7 @@ public class KsqlStructuredDataOutputNode extends OutputNode {
 
   private final KsqlTopic ksqlTopic;
   private final KeyField keyField;
-  private final Optional<ColumnName> partitionByField;
+  private final Optional<ColumnRef> partitionByField;
   private final boolean doCreateInto;
   private final Set<SerdeOption> serdeOptions;
   private final SourceName intoSourceName;
@@ -54,7 +54,7 @@ public class KsqlStructuredDataOutputNode extends OutputNode {
       final TimestampExtractionPolicy timestampExtractionPolicy,
       final KeyField keyField,
       final KsqlTopic ksqlTopic,
-      final Optional<ColumnName> partitionByField,
+      final Optional<ColumnRef> partitionByField,
       final OptionalInt limit,
       final boolean doCreateInto,
       final Set<SerdeOption> serdeOptions,
@@ -149,7 +149,7 @@ public class KsqlStructuredDataOutputNode extends OutputNode {
     }
 
     final KeyField resultKeyField = KeyField.of(
-        schemaKStream.getKeyField().name(),
+        schemaKStream.getKeyField().ref(),
         getKeyField().legacy()
     );
 
@@ -167,13 +167,13 @@ public class KsqlStructuredDataOutputNode extends OutputNode {
       return;
     }
 
-    final ColumnName fieldName = partitionByField.get();
+    final ColumnRef fieldName = partitionByField.get();
 
-    if (getSchema().isMetaColumn(fieldName) || getSchema().isKeyColumn(fieldName)) {
+    if (getSchema().isMetaColumn(fieldName.name()) || getSchema().isKeyColumn(fieldName.name())) {
       return;
     }
 
-    if (!keyField.name().equals(Optional.of(fieldName))) {
+    if (!keyField.ref().equals(Optional.of(fieldName))) {
       throw new IllegalArgumentException("keyField must match partition by field");
     }
   }

--- a/ksql-engine/src/main/java/io/confluent/ksql/planner/plan/ProjectNode.java
+++ b/ksql-engine/src/main/java/io/confluent/ksql/planner/plan/ProjectNode.java
@@ -21,8 +21,8 @@ import com.google.common.collect.ImmutableList;
 import io.confluent.ksql.execution.builder.KsqlQueryBuilder;
 import io.confluent.ksql.execution.plan.SelectExpression;
 import io.confluent.ksql.metastore.model.KeyField;
-import io.confluent.ksql.name.ColumnName;
 import io.confluent.ksql.schema.ksql.Column;
+import io.confluent.ksql.schema.ksql.ColumnRef;
 import io.confluent.ksql.schema.ksql.LogicalSchema;
 import io.confluent.ksql.services.KafkaTopicClient;
 import io.confluent.ksql.structured.SchemaKStream;
@@ -43,7 +43,7 @@ public class ProjectNode extends PlanNode {
       final PlanNodeId id,
       final PlanNode source,
       final LogicalSchema schema,
-      final Optional<ColumnName> keyFieldName,
+      final Optional<ColumnRef> keyFieldName,
       final List<SelectExpression> projectExpressions
   ) {
     super(id, source.getNodeOutputType());
@@ -113,7 +113,7 @@ public class ProjectNode extends PlanNode {
       final Column column = schema.value().get(i);
       final SelectExpression selectExpression = projectExpressions.get(i);
 
-      if (!column.name().equals(selectExpression.getName())) {
+      if (!column.name().equals(selectExpression.getAlias())) {
         throw new IllegalArgumentException("Mismatch between schema and selects");
       }
     }

--- a/ksql-engine/src/main/java/io/confluent/ksql/structured/SchemaKGroupedTable.java
+++ b/ksql-engine/src/main/java/io/confluent/ksql/structured/SchemaKGroupedTable.java
@@ -29,6 +29,7 @@ import io.confluent.ksql.execution.streams.MaterializedFactory;
 import io.confluent.ksql.function.FunctionRegistry;
 import io.confluent.ksql.function.KsqlAggregateFunction;
 import io.confluent.ksql.metastore.model.KeyField;
+import io.confluent.ksql.name.FunctionName;
 import io.confluent.ksql.parser.tree.WindowExpression;
 import io.confluent.ksql.schema.ksql.LogicalSchema;
 import io.confluent.ksql.serde.KeyFormat;
@@ -118,6 +119,7 @@ public class SchemaKGroupedTable extends SchemaKGroupedStream {
             queryBuilder.getFunctionRegistry(), call, sourceTableStep.getSchema())
         ).filter(function -> !(function instanceof TableAggregationFunction))
         .map(KsqlAggregateFunction::getFunctionName)
+        .map(FunctionName::name)
         .collect(Collectors.toList());
     if (!unsupportedFunctionNames.isEmpty()) {
       throw new KsqlException(

--- a/ksql-engine/src/main/java/io/confluent/ksql/structured/SchemaKTable.java
+++ b/ksql-engine/src/main/java/io/confluent/ksql/structured/SchemaKTable.java
@@ -34,8 +34,8 @@ import io.confluent.ksql.execution.util.StructKeyUtil;
 import io.confluent.ksql.function.FunctionRegistry;
 import io.confluent.ksql.metastore.model.KeyField;
 import io.confluent.ksql.metastore.model.KeyField.LegacyField;
-import io.confluent.ksql.name.ColumnName;
 import io.confluent.ksql.schema.ksql.Column;
+import io.confluent.ksql.schema.ksql.ColumnRef;
 import io.confluent.ksql.schema.ksql.LogicalSchema;
 import io.confluent.ksql.schema.ksql.types.SqlTypes;
 import io.confluent.ksql.serde.KeyFormat;
@@ -176,10 +176,11 @@ public class SchemaKTable<K> extends SchemaKStream<K> {
     final KeySerde<Struct> groupedKeySerde = keySerde
         .rebind(StructKeyUtil.ROWKEY_SERIALIZED_SCHEMA);
 
-    final ColumnName aggregateKeyName = groupedKeyNameFor(groupByExpressions);
+    final ColumnRef aggregateKeyName = groupedKeyNameFor(groupByExpressions);
     final LegacyField legacyKeyField = LegacyField.notInSchema(aggregateKeyName, SqlTypes.STRING);
-    final Optional<ColumnName> newKeyField =
-        getSchema().findValueColumn(aggregateKeyName).map(Column::fullName).map(ColumnName::of);
+    final Optional<ColumnRef> newKeyField = getSchema()
+        .findValueColumn(ColumnRef.withoutSource(aggregateKeyName.name()))
+        .map(Column::ref);
 
     final TableGroupBy<K> step = ExecutionStepFactory.tableGroupBy(
         contextStacker,

--- a/ksql-engine/src/main/java/io/confluent/ksql/util/AggregateExpressionRewriter.java
+++ b/ksql-engine/src/main/java/io/confluent/ksql/util/AggregateExpressionRewriter.java
@@ -48,7 +48,7 @@ public class AggregateExpressionRewriter
       final ColumnName aggVarName = ColumnName.aggregate(aggVariableIndex);
       aggVariableIndex++;
       return Optional.of(
-          new ColumnReferenceExp(node.getLocation(), ColumnRef.of(aggVarName)));
+          new ColumnReferenceExp(node.getLocation(), ColumnRef.withoutSource(aggVarName)));
     } else {
       final List<Expression> arguments = new ArrayList<>();
       for (final Expression argExpression: node.getArguments()) {

--- a/ksql-engine/src/test/java/io/confluent/ksql/analyzer/ExpressionAnalyzerTest.java
+++ b/ksql-engine/src/test/java/io/confluent/ksql/analyzer/ExpressionAnalyzerTest.java
@@ -98,7 +98,7 @@ public class ExpressionAnalyzerTest {
         ColumnRef.of(SourceName.of("fully"), ColumnName.of("qualified"))
     );
 
-    when(sourceSchemas.sourcesWithField(ColumnName.of("qualified")))
+    when(sourceSchemas.sourcesWithField(ColumnRef.withoutSource(ColumnName.of("qualified"))))
         .thenReturn(ImmutableSet.of("multiple", "sources", "fully").stream().map(SourceName::of).collect(Collectors.toSet()));
 
     // When:
@@ -114,7 +114,7 @@ public class ExpressionAnalyzerTest {
         ColumnRef.of(SourceName.of("fully"), ColumnName.of("qualified"))
     );
 
-    when(sourceSchemas.sourcesWithField(ColumnName.of("qualified")))
+    when(sourceSchemas.sourcesWithField(ColumnRef.withoutSource(ColumnName.of("qualified"))))
         .thenReturn(ImmutableSet.of("not-fully", "also-not-fully").stream().map(SourceName::of).collect(Collectors.toSet()));
 
     // Then:
@@ -130,10 +130,10 @@ public class ExpressionAnalyzerTest {
   public void shouldThrowOnMultipleSourcesIfNotFullyQualified() {
     // Given:
     final Expression expression = new ColumnReferenceExp(
-        ColumnRef.of("just-name")
+        ColumnRef.withoutSource(ColumnName.of("just-name"))
     );
 
-    when(sourceSchemas.sourcesWithField(ColumnName.of("just-name")))
+    when(sourceSchemas.sourcesWithField(ColumnRef.withoutSource(ColumnName.of("just-name"))))
         .thenReturn(ImmutableSet.of("multiple", "sources").stream().map(SourceName::of).collect(Collectors.toSet()));
 
     // Then:
@@ -149,10 +149,10 @@ public class ExpressionAnalyzerTest {
   public void shouldThrowOnNoSources() {
     // Given:
     final Expression expression = new ColumnReferenceExp(
-        ColumnRef.of("just-name")
+        ColumnRef.withoutSource(ColumnName.of("just-name"))
     );
 
-    when(sourceSchemas.sourcesWithField(ColumnName.of("just-name")))
+    when(sourceSchemas.sourcesWithField(ColumnRef.withoutSource(ColumnName.of("just-name"))))
         .thenReturn(ImmutableSet.of());
 
     // Then:

--- a/ksql-engine/src/test/java/io/confluent/ksql/analyzer/QueryAnalyzerFunctionalTest.java
+++ b/ksql-engine/src/test/java/io/confluent/ksql/analyzer/QueryAnalyzerFunctionalTest.java
@@ -206,7 +206,7 @@ public class QueryAnalyzerFunctionalTest {
     // Then:
     assertThat(aggregateAnalysis.getNonAggregateSelectExpressions().get(ITEM_ID), contains(ITEM_ID));
     assertThat(aggregateAnalysis.getFinalSelectExpressions(), equalTo(Arrays.asList(ITEM_ID, new ColumnReferenceExp(
-        ColumnRef.of("KSQL_AGG_VARIABLE_0")))));
+        ColumnRef.withoutSource(ColumnName.of("KSQL_AGG_VARIABLE_0"))))));
     assertThat(aggregateAnalysis.getAggregateFunctionArguments(), equalTo(Collections.singletonList(ORDER_UNITS)));
     assertThat(aggregateAnalysis.getRequiredColumns(), containsInAnyOrder(ITEM_ID, ORDER_UNITS));
   }
@@ -350,7 +350,7 @@ public class QueryAnalyzerFunctionalTest {
     final Expression havingExpression = aggregateAnalysis.getHavingExpression();
     assertThat(havingExpression, equalTo(new ComparisonExpression(
         ComparisonExpression.Type.GREATER_THAN,
-        new ColumnReferenceExp(ColumnRef.of("KSQL_AGG_VARIABLE_1")),
+        new ColumnReferenceExp(ColumnRef.withoutSource(ColumnName.of("KSQL_AGG_VARIABLE_1"))),
         new IntegerLiteral(10))));
   }
 

--- a/ksql-engine/src/test/java/io/confluent/ksql/analyzer/SourceSchemasTest.java
+++ b/ksql-engine/src/test/java/io/confluent/ksql/analyzer/SourceSchemasTest.java
@@ -24,8 +24,10 @@ import static org.hamcrest.Matchers.is;
 import com.google.common.collect.ImmutableMap;
 import io.confluent.ksql.name.ColumnName;
 import io.confluent.ksql.name.SourceName;
+import io.confluent.ksql.schema.ksql.ColumnRef;
 import io.confluent.ksql.schema.ksql.LogicalSchema;
 import io.confluent.ksql.schema.ksql.types.SqlTypes;
+import io.confluent.ksql.util.SchemaUtil;
 import org.junit.Before;
 import org.junit.Test;
 
@@ -77,68 +79,68 @@ public class SourceSchemasTest {
 
   @Test
   public void shouldFindNoField() {
-    assertThat(sourceSchemas.sourcesWithField(ColumnName.of("unknown")), is(empty()));
+    assertThat(sourceSchemas.sourcesWithField(ColumnRef.withoutSource(ColumnName.of("unknown"))), is(empty()));
   }
 
   @Test
   public void shouldFindNoQualifiedField() {
-    assertThat(sourceSchemas.sourcesWithField(ColumnName.of(ALIAS_1.name() + ".F2")), is(empty()));
+    assertThat(sourceSchemas.sourcesWithField(ColumnRef.of(ALIAS_1, ColumnName.of("F2"))), is(empty()));
   }
 
   @Test
   public void shouldFindUnqualifiedUniqueField() {
-    assertThat(sourceSchemas.sourcesWithField(ColumnName.of("F1")), contains(ALIAS_1));
+    assertThat(sourceSchemas.sourcesWithField(ColumnRef.withoutSource(ColumnName.of("F1"))), contains(ALIAS_1));
   }
 
   @Test
   public void shouldFindQualifiedUniqueField() {
-    assertThat(sourceSchemas.sourcesWithField(ColumnName.of(ALIAS_2.name() + ".F2")), contains(ALIAS_2));
+    assertThat(sourceSchemas.sourcesWithField(ColumnRef.of(ALIAS_2, ColumnName.of("F2"))), contains(ALIAS_2));
   }
 
   @Test
   public void shouldFindUnqualifiedCommonField() {
-    assertThat(sourceSchemas.sourcesWithField(COMMON_FIELD_NAME),
+    assertThat(sourceSchemas.sourcesWithField(ColumnRef.withoutSource(COMMON_FIELD_NAME)),
         containsInAnyOrder(ALIAS_1, ALIAS_2));
   }
 
   @Test
   public void shouldFindQualifiedFieldOnlyInThatSource() {
-    assertThat(sourceSchemas.sourcesWithField(ColumnName.of(ALIAS_1.name() + "." + COMMON_FIELD_NAME.name())),
+    assertThat(sourceSchemas.sourcesWithField(ColumnRef.of(ALIAS_1, COMMON_FIELD_NAME)),
         contains(ALIAS_1));
   }
 
   @Test
   public void shouldMatchNonValueFieldNameIfMetaField() {
-    assertThat(sourceSchemas.matchesNonValueField("ROWTIME"), is(true));
+    assertThat(sourceSchemas.matchesNonValueField(ColumnRef.withoutSource(SchemaUtil.ROWTIME_NAME)), is(true));
   }
 
   @Test
   public void shouldMatchNonValueFieldNameIfAliaasedMetaField() {
-    assertThat(sourceSchemas.matchesNonValueField(ALIAS_2.name() + ".ROWTIME"), is(true));
+    assertThat(sourceSchemas.matchesNonValueField(ColumnRef.of(ALIAS_2, SchemaUtil.ROWTIME_NAME)), is(true));
   }
 
   @Test
   public void shouldMatchNonValueFieldNameIfKeyField() {
-    assertThat(sourceSchemas.matchesNonValueField("ROWKEY"), is(true));
+    assertThat(sourceSchemas.matchesNonValueField(ColumnRef.withoutSource(SchemaUtil.ROWKEY_NAME)), is(true));
   }
 
   @Test
   public void shouldMatchNonValueFieldNameIfAliasedKeyField() {
-    assertThat(sourceSchemas.matchesNonValueField(ALIAS_2.name() + ".ROWKEY"), is(true));
+    assertThat(sourceSchemas.matchesNonValueField(ColumnRef.of(ALIAS_2, SchemaUtil.ROWKEY_NAME)), is(true));
   }
 
   @Test(expected = IllegalArgumentException.class)
-  public void shouldThrowOnUknonwnSourceWhenMatchingNonValueFields() {
-    sourceSchemas.matchesNonValueField("unknown.ROWKEY");
+  public void shouldThrowOnUnknownSourceWhenMatchingNonValueFields() {
+    sourceSchemas.matchesNonValueField(ColumnRef.of(SourceName.of("unknown"), SchemaUtil.ROWKEY_NAME));
   }
 
   @Test
   public void shouldNotMatchOtherFields() {
-    assertThat(sourceSchemas.matchesNonValueField(ALIAS_2.name() + ".F2"), is(false));
+    assertThat(sourceSchemas.matchesNonValueField(ColumnRef.of(ALIAS_2, ColumnName.of("F2"))), is(false));
   }
 
   @Test
   public void shouldNotMatchUnknownFields() {
-    assertThat(sourceSchemas.matchesNonValueField("unknown"), is(false));
+    assertThat(sourceSchemas.matchesNonValueField(ColumnRef.withoutSource(ColumnName.of("unknown"))), is(false));
   }
 }

--- a/ksql-engine/src/test/java/io/confluent/ksql/analyzer/StaticQueryValidatorTest.java
+++ b/ksql-engine/src/test/java/io/confluent/ksql/analyzer/StaticQueryValidatorTest.java
@@ -127,7 +127,7 @@ public class StaticQueryValidatorTest {
   @Test
   public void shouldThrowOnPartitionBy() {
     // Given:
-    when(analysis.getPartitionBy()).thenReturn(Optional.of(ColumnName.of("Something")));
+    when(analysis.getPartitionBy()).thenReturn(Optional.of(ColumnRef.withoutSource(ColumnName.of("Something"))));
 
     // Then:
     expectedException.expect(KsqlException.class);
@@ -167,7 +167,7 @@ public class StaticQueryValidatorTest {
   public void shouldThrowOnRowTimeInProjection() {
     // Given:
     when(analysis.getSelectColumnRefs())
-        .thenReturn(ImmutableSet.of(ColumnRef.of(SchemaUtil.ROWTIME_NAME)));
+        .thenReturn(ImmutableSet.of(ColumnRef.withoutSource(SchemaUtil.ROWTIME_NAME)));
 
     // Then:
     expectedException.expect(KsqlException.class);

--- a/ksql-engine/src/test/java/io/confluent/ksql/engine/InsertValuesExecutorTest.java
+++ b/ksql-engine/src/test/java/io/confluent/ksql/engine/InsertValuesExecutorTest.java
@@ -46,6 +46,7 @@ import io.confluent.ksql.name.SourceName;
 import io.confluent.ksql.parser.KsqlParser.PreparedStatement;
 import io.confluent.ksql.parser.tree.InsertValues;
 import io.confluent.ksql.schema.ksql.Column;
+import io.confluent.ksql.schema.ksql.ColumnRef;
 import io.confluent.ksql.schema.ksql.LogicalSchema;
 import io.confluent.ksql.schema.ksql.PersistenceSchema;
 import io.confluent.ksql.schema.ksql.types.SqlTypes;
@@ -706,7 +707,9 @@ public class InsertValuesExecutorTest {
     );
 
     final KeyField valueKeyField = keyField
-        .map(kf -> KeyField.of(kf, schema.findValueColumn(kf).get()))
+        .map(kf -> KeyField.of(
+            ColumnRef.withoutSource(kf),
+            schema.findValueColumn(ColumnRef.withoutSource(kf)).get()))
         .orElse(KeyField.none());
     final DataSource<?> dataSource = new KsqlStream<>(
         "",

--- a/ksql-engine/src/test/java/io/confluent/ksql/engine/rewrite/ExpressionTreeRewriterTest.java
+++ b/ksql-engine/src/test/java/io/confluent/ksql/engine/rewrite/ExpressionTreeRewriterTest.java
@@ -48,6 +48,7 @@ import io.confluent.ksql.execution.expression.tree.LogicalBinaryExpression;
 import io.confluent.ksql.execution.expression.tree.LongLiteral;
 import io.confluent.ksql.execution.expression.tree.NotExpression;
 import io.confluent.ksql.execution.expression.tree.NullLiteral;
+import io.confluent.ksql.name.ColumnName;
 import io.confluent.ksql.schema.ksql.ColumnRef;
 import io.confluent.ksql.execution.expression.tree.ColumnReferenceExp;
 import io.confluent.ksql.execution.expression.tree.SearchedCaseExpression;
@@ -591,7 +592,8 @@ public class ExpressionTreeRewriterTest {
   @Test
   public void shouldRewriteQualifiedNameReference() {
     // Given:
-    final ColumnReferenceExp expression = new ColumnReferenceExp(ColumnRef.of("foo"));
+    final ColumnReferenceExp expression = new ColumnReferenceExp(ColumnRef.withoutSource(
+        ColumnName.of("foo")));
 
     // When:
     final Expression rewritten = expressionRewriter.rewrite(expression, context);
@@ -603,7 +605,8 @@ public class ExpressionTreeRewriterTest {
   @Test
   public void shouldRewriteQualifiedNameReferenceUsingPlugin() {
     // Given:
-    final ColumnReferenceExp expression = new ColumnReferenceExp(ColumnRef.of("foo"));
+    final ColumnReferenceExp expression = new ColumnReferenceExp(ColumnRef.withoutSource(
+        ColumnName.of("foo")));
 
     // When/Then:
     shouldRewriteUsingPlugin(expression);

--- a/ksql-engine/src/test/java/io/confluent/ksql/function/InternalFunctionRegistryTest.java
+++ b/ksql-engine/src/test/java/io/confluent/ksql/function/InternalFunctionRegistryTest.java
@@ -30,6 +30,7 @@ import static org.mockito.Mockito.when;
 import com.google.common.collect.Collections2;
 import com.google.common.collect.ImmutableList;
 import io.confluent.ksql.function.udf.Kudf;
+import io.confluent.ksql.name.FunctionName;
 import io.confluent.ksql.schema.ksql.types.SqlType;
 import io.confluent.ksql.util.KsqlException;
 import java.util.Arrays;
@@ -73,7 +74,7 @@ public class InternalFunctionRegistryTest {
   private final InternalFunctionRegistry functionRegistry = new InternalFunctionRegistry();
   private final KsqlFunction func = KsqlFunction.createLegacyBuiltIn(Schema.OPTIONAL_STRING_SCHEMA,
       Collections.emptyList(),
-      "func",
+      FunctionName.of("func"),
       Func1.class);
 
   @Rule
@@ -243,8 +244,8 @@ public class InternalFunctionRegistryTest {
               }
 
               @Override
-              public String getFunctionName() {
-                return "my_aggregate";
+              public FunctionName getFunctionName() {
+                return FunctionName.of("my_aggregate");
               }
 
               @Override
@@ -323,7 +324,7 @@ public class InternalFunctionRegistryTest {
     givenUdfFactoryRegistered();
     functionRegistry.addFunction(func);
     final KsqlFunction func2 = KsqlFunction.createLegacyBuiltIn(Schema.OPTIONAL_INT64_SCHEMA,
-        Collections.singletonList(Schema.OPTIONAL_INT64_SCHEMA), "func", Func1.class);
+        Collections.singletonList(Schema.OPTIONAL_INT64_SCHEMA), FunctionName.of("func"), Func1.class);
 
     // When:
     functionRegistry.addFunction(func2);

--- a/ksql-engine/src/test/java/io/confluent/ksql/function/UdfLoaderTest.java
+++ b/ksql-engine/src/test/java/io/confluent/ksql/function/UdfLoaderTest.java
@@ -156,7 +156,7 @@ public class UdfLoaderTest {
         .getFunction(ImmutableList.of(schema));
 
     // Then:
-    assertThat(fun.getFunctionName(), equalToIgnoringCase("floor"));
+    assertThat(fun.getFunctionName().name(), equalToIgnoringCase("floor"));
   }
 
   @Test
@@ -248,7 +248,7 @@ public class UdfLoaderTest {
 
     // Expect:
     expectedException.expect(KsqlException.class);
-    expectedException.expectMessage(is("Return type DECIMAL(2, 1) of UDF ReturnIncompatible does not "
+    expectedException.expectMessage(is("Return type DECIMAL(2, 1) of UDF RETURNINCOMPATIBLE does not "
                                            + "match the declared return type STRING."));
 
     // When:
@@ -457,7 +457,7 @@ public class UdfLoaderTest {
     // Then:
     assertThat(udfFactory, not(nullValue()));
     final KsqlFunction function = udfFactory.getFunction(args);
-    assertThat(function.getFunctionName(), equalToIgnoringCase("somefunction"));
+    assertThat(function.getFunctionName().name(), equalToIgnoringCase("somefunction"));
 
   }
 

--- a/ksql-engine/src/test/java/io/confluent/ksql/planner/LogicalPlannerTest.java
+++ b/ksql-engine/src/test/java/io/confluent/ksql/planner/LogicalPlannerTest.java
@@ -17,6 +17,7 @@ package io.confluent.ksql.planner;
 
 import static io.confluent.ksql.metastore.model.DataSource.DataSourceType;
 import static io.confluent.ksql.metastore.model.MetaStoreMatchers.LegacyFieldMatchers.hasName;
+import static io.confluent.ksql.metastore.model.MetaStoreMatchers.LegacyFieldMatchers.hasSource;
 import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.CoreMatchers.instanceOf;
 import static org.hamcrest.MatcherAssert.assertThat;
@@ -34,6 +35,7 @@ import io.confluent.ksql.planner.plan.FilterNode;
 import io.confluent.ksql.planner.plan.JoinNode;
 import io.confluent.ksql.planner.plan.PlanNode;
 import io.confluent.ksql.planner.plan.ProjectNode;
+import io.confluent.ksql.schema.ksql.ColumnRef;
 import io.confluent.ksql.schema.ksql.types.SqlTypes;
 import io.confluent.ksql.testutils.AnalysisTestUtil;
 import io.confluent.ksql.util.KsqlConfig;
@@ -113,8 +115,9 @@ public class LogicalPlannerTest {
     assertThat(logicalPlan.getSources().get(0), instanceOf(ProjectNode.class));
     final ProjectNode projectNode = (ProjectNode) logicalPlan.getSources().get(0);
 
-    assertThat(projectNode.getKeyField().name(), is(Optional.of(ColumnName.of("T1_COL1"))));
-    assertThat(projectNode.getKeyField().legacy(), OptionalMatchers.of(hasName("T1.COL1")));
+    assertThat(projectNode.getKeyField().ref(), is(Optional.of(ColumnRef.withoutSource(ColumnName.of("T1_COL1")))));
+    assertThat(projectNode.getKeyField().legacy(), OptionalMatchers.of(hasName("COL1")));
+    assertThat(projectNode.getKeyField().legacy(), OptionalMatchers.of(hasSource("T1")));
     assertThat(projectNode.getSchema().value().size(), equalTo(5));
 
     assertThat(projectNode.getSources().get(0), instanceOf(FilterNode.class));
@@ -245,11 +248,11 @@ public class LogicalPlannerTest {
     final PlanNode logicalPlan = buildLogicalPlan(simpleQuery);
 
     // Then:
-    assertThat(logicalPlan.getKeyField().name(), is(Optional.of(ColumnName.of("NEW_KEY"))));
+    assertThat(logicalPlan.getKeyField().ref(), is(Optional.of(ColumnRef.withoutSource(ColumnName.of("NEW_KEY")))));
     assertThat(logicalPlan.getKeyField().legacy(), is(Optional.empty()));
 
     final PlanNode source = logicalPlan.getSources().get(0);
-    assertThat(source.getKeyField().name(), is(Optional.of(ColumnName.of("NEW_KEY"))));
+    assertThat(source.getKeyField().ref(), is(Optional.of(ColumnRef.withoutSource(ColumnName.of("NEW_KEY")))));
     assertThat(source.getKeyField().legacy(), is(OptionalMatchers.of(hasName("COL0"))));
   }
 

--- a/ksql-engine/src/test/java/io/confluent/ksql/planner/plan/AggregateNodeTest.java
+++ b/ksql-engine/src/test/java/io/confluent/ksql/planner/plan/AggregateNodeTest.java
@@ -371,7 +371,7 @@ public class AggregateNodeTest {
         + "GROUP BY UCASE(col1) EMIT CHANGES;");
 
     // Then:
-    assertThat(stream.getKeyField().name(), is(Optional.empty()));
+    assertThat(stream.getKeyField().ref(), is(Optional.empty()));
     assertThat(stream.getKeyField().legacy(), OptionalMatchers.of(hasName("UCASE(KSQL_INTERNAL_COL_0)")));
   }
 
@@ -382,7 +382,7 @@ public class AggregateNodeTest {
         + "GROUP BY col0 + 10 EMIT CHANGES;");
 
     // Then:
-    assertThat(stream.getKeyField().name(), is(Optional.empty()));
+    assertThat(stream.getKeyField().ref(), is(Optional.empty()));
     assertThat(stream.getKeyField().legacy(), OptionalMatchers.of(hasName("(KSQL_INTERNAL_COL_0 + 10)")));
   }
 

--- a/ksql-engine/src/test/java/io/confluent/ksql/planner/plan/KsqlStructuredDataOutputNodeTest.java
+++ b/ksql-engine/src/test/java/io/confluent/ksql/planner/plan/KsqlStructuredDataOutputNodeTest.java
@@ -37,6 +37,7 @@ import io.confluent.ksql.name.ColumnName;
 import io.confluent.ksql.name.SourceName;
 import io.confluent.ksql.query.QueryId;
 import io.confluent.ksql.query.id.QueryIdGenerator;
+import io.confluent.ksql.schema.ksql.ColumnRef;
 import io.confluent.ksql.schema.ksql.LogicalSchema;
 import io.confluent.ksql.schema.ksql.types.SqlTypes;
 import io.confluent.ksql.serde.Format;
@@ -77,7 +78,9 @@ public class KsqlStructuredDataOutputNodeTest {
       .build();
 
   private static final KeyField KEY_FIELD =
-      KeyField.of(ColumnName.of("key"), SCHEMA.findValueColumn("key").get());
+      KeyField.of(
+          ColumnRef.withoutSource(ColumnName.of("key")),
+          SCHEMA.findValueColumn(ColumnRef.withoutSource(ColumnName.of("key"))).get());
   private static final PlanNodeId PLAN_NODE_ID = new PlanNodeId("0");
   private static final ValueFormat JSON_FORMAT = ValueFormat.of(FormatInfo.of(Format.JSON));
 
@@ -107,7 +110,7 @@ public class KsqlStructuredDataOutputNodeTest {
 
   private KsqlStructuredDataOutputNode outputNode;
   private LogicalSchema schema;
-  private Optional<ColumnName> partitionBy;
+  private Optional<ColumnRef> partitionBy;
   private boolean createInto;
 
   @SuppressWarnings("unchecked")
@@ -149,10 +152,10 @@ public class KsqlStructuredDataOutputNodeTest {
         new PlanNodeId("0"),
         sourceNode,
         SCHEMA,
-        new LongColumnTimestampExtractionPolicy("timestamp"),
+        new LongColumnTimestampExtractionPolicy(ColumnRef.withoutSource(ColumnName.of("timestamp"))),
         KeyField.none(),
         ksqlTopic,
-        Optional.of(ColumnName.of("something")),
+        Optional.of(ColumnRef.withoutSource(ColumnName.of("something"))),
         OptionalInt.empty(),
         false,
         SerdeOption.none(),
@@ -166,10 +169,10 @@ public class KsqlStructuredDataOutputNodeTest {
         new PlanNodeId("0"),
         sourceNode,
         SCHEMA,
-        new LongColumnTimestampExtractionPolicy("timestamp"),
-        KeyField.of(Optional.of(ColumnName.of("something else")), Optional.empty()),
+        new LongColumnTimestampExtractionPolicy(ColumnRef.withoutSource(ColumnName.of("timestamp"))),
+        KeyField.of(Optional.of(ColumnRef.withoutSource(ColumnName.of("something else"))), Optional.empty()),
         ksqlTopic,
-        Optional.of(ColumnName.of("something")),
+        Optional.of(ColumnRef.withoutSource(ColumnName.of("something"))),
         OptionalInt.empty(),
         false,
         SerdeOption.none(),
@@ -220,7 +223,7 @@ public class KsqlStructuredDataOutputNodeTest {
 
     // Then:
     verify(resultStream).selectKey(
-        KEY_FIELD.name().get(),
+        KEY_FIELD.ref().get(),
         false,
         new QueryContext.Stacker(QUERY_ID).push(PLAN_NODE_ID.toString())
     );
@@ -238,7 +241,7 @@ public class KsqlStructuredDataOutputNodeTest {
 
     // Then:
     verify(resultStream).selectKey(
-        ColumnName.of("ROWKEY"),
+        ColumnRef.withoutSource(ColumnName.of("ROWKEY")),
         false,
         new QueryContext.Stacker(QUERY_ID).push(PLAN_NODE_ID.toString())
     );
@@ -256,7 +259,7 @@ public class KsqlStructuredDataOutputNodeTest {
 
     // Then:
     verify(resultStream).selectKey(
-        ColumnName.of("ROWTIME"),
+        ColumnRef.withoutSource(ColumnName.of("ROWTIME")),
         false,
         new QueryContext.Stacker(QUERY_ID).push(PLAN_NODE_ID.toString())
     );
@@ -345,7 +348,7 @@ public class KsqlStructuredDataOutputNodeTest {
   }
 
   private void givenNodePartitioningByKey(final String field) {
-    this.partitionBy = Optional.of(ColumnName.of(field));
+    this.partitionBy = Optional.of(ColumnRef.withoutSource(ColumnName.of(field)));
     buildNode();
   }
 
@@ -359,7 +362,7 @@ public class KsqlStructuredDataOutputNodeTest {
         PLAN_NODE_ID,
         sourceNode,
         schema,
-        new LongColumnTimestampExtractionPolicy("timestamp"),
+        new LongColumnTimestampExtractionPolicy(ColumnRef.withoutSource(ColumnName.of("timestamp"))),
         KEY_FIELD,
         ksqlTopic,
         partitionBy,

--- a/ksql-engine/src/test/java/io/confluent/ksql/planner/plan/ProjectNodeTest.java
+++ b/ksql-engine/src/test/java/io/confluent/ksql/planner/plan/ProjectNodeTest.java
@@ -34,6 +34,7 @@ import io.confluent.ksql.metastore.model.DataSource.DataSourceType;
 import io.confluent.ksql.metastore.model.KeyField;
 import io.confluent.ksql.name.ColumnName;
 import io.confluent.ksql.schema.ksql.Column;
+import io.confluent.ksql.schema.ksql.ColumnRef;
 import io.confluent.ksql.schema.ksql.LogicalSchema;
 import io.confluent.ksql.schema.ksql.types.SqlTypes;
 import io.confluent.ksql.structured.SchemaKStream;
@@ -59,7 +60,9 @@ public class ProjectNodeTest {
       .valueColumn(ColumnName.of("col1"), SqlTypes.STRING)
       .build();
   private static final KeyField SOURCE_KEY_FIELD = KeyField
-      .of(ColumnName.of("source-key"), Column.of(ColumnName.of("legacy-source-key"), SqlTypes.STRING));
+      .of(
+          ColumnRef.withoutSource(ColumnName.of("source-key")),
+          Column.of(ColumnName.of("legacy-source-key"), SqlTypes.STRING));
 
   @Mock
   private PlanNode source;
@@ -85,7 +88,7 @@ public class ProjectNodeTest {
         NODE_ID,
         source,
         SCHEMA,
-        Optional.of(ColumnName.of(KEY_FIELD_NAME)),
+        Optional.of(ColumnRef.withoutSource(ColumnName.of(KEY_FIELD_NAME))),
         ImmutableList.of(SELECT_0, SELECT_1));
   }
 
@@ -95,7 +98,7 @@ public class ProjectNodeTest {
         NODE_ID,
         source,
         SCHEMA,
-        Optional.of(ColumnName.of(KEY_FIELD_NAME)),
+        Optional.of(ColumnRef.withoutSource(ColumnName.of(KEY_FIELD_NAME))),
         ImmutableList.of(SELECT_0)); // <-- not enough expressions
   }
 
@@ -105,7 +108,7 @@ public class ProjectNodeTest {
         NODE_ID,
         source,
         SCHEMA,
-        Optional.of(ColumnName.of(KEY_FIELD_NAME)),
+        Optional.of(ColumnRef.withoutSource(ColumnName.of(KEY_FIELD_NAME))),
         ImmutableList.of(
             SelectExpression.of(ColumnName.of("wrongName"), TRUE_EXPRESSION),
             SELECT_1
@@ -141,7 +144,7 @@ public class ProjectNodeTest {
         NODE_ID,
         source,
         SCHEMA,
-        Optional.of(ColumnName.of("Unknown Key Field")),
+        Optional.of(ColumnRef.withoutSource(ColumnName.of("Unknown Key Field"))),
         ImmutableList.of(SELECT_0, SELECT_1));
   }
 
@@ -151,7 +154,7 @@ public class ProjectNodeTest {
     final KeyField keyField = projectNode.getKeyField();
 
     // Then:
-    assertThat(keyField.name(), is(Optional.of(ColumnName.of(KEY_FIELD_NAME))));
+    assertThat(keyField.ref(), is(Optional.of(ColumnRef.withoutSource(ColumnName.of(KEY_FIELD_NAME)))));
     assertThat(keyField.legacy(), is(SOURCE_KEY_FIELD.legacy()));
   }
 }

--- a/ksql-engine/src/test/java/io/confluent/ksql/structured/SchemaKGroupedStreamTest.java
+++ b/ksql-engine/src/test/java/io/confluent/ksql/structured/SchemaKGroupedStreamTest.java
@@ -75,7 +75,7 @@ public class SchemaKGroupedStreamTest {
       .build();
   private static final FunctionCall AGG = new FunctionCall(
       FunctionName.of("SUM"),
-      ImmutableList.of(new ColumnReferenceExp(ColumnRef.of(ColumnName.of("IN1"))))
+      ImmutableList.of(new ColumnReferenceExp(ColumnRef.withoutSource(ColumnName.of("IN1"))))
   );
   private static final KsqlWindowExpression KSQL_WINDOW_EXP = new SessionWindowExpression(
       100, TimeUnit.SECONDS

--- a/ksql-engine/src/test/java/io/confluent/ksql/structured/SchemaKGroupedTableTest.java
+++ b/ksql-engine/src/test/java/io/confluent/ksql/structured/SchemaKGroupedTableTest.java
@@ -166,7 +166,9 @@ public class SchemaKGroupedTableTest {
         buildSourceTableStep(IN_SCHEMA),
         keyFormat,
         keySerde,
-        KeyField.of(IN_SCHEMA.value().get(0).name(), IN_SCHEMA.value().get(0)),
+        KeyField.of(
+            IN_SCHEMA.value().get(0).ref(),
+            IN_SCHEMA.value().get(0)),
         Collections.emptyList(),
         ksqlConfig,
         functionRegistry,
@@ -248,7 +250,7 @@ public class SchemaKGroupedTableTest {
   private static FunctionCall udaf(final String name) {
     return new FunctionCall(
         FunctionName.of(name),
-        ImmutableList.of(new ColumnReferenceExp(ColumnRef.of("IN1")))
+        ImmutableList.of(new ColumnReferenceExp(ColumnRef.withoutSource(ColumnName.of("IN1"))))
     );
   }
 }

--- a/ksql-examples/src/main/java/io/confluent/ksql/datagen/RowGenerator.java
+++ b/ksql-examples/src/main/java/io/confluent/ksql/datagen/RowGenerator.java
@@ -19,6 +19,7 @@ import io.confluent.avro.random.generator.Generator;
 import io.confluent.connect.avro.AvroData;
 import io.confluent.ksql.GenericRow;
 import io.confluent.ksql.name.ColumnName;
+import io.confluent.ksql.schema.ksql.ColumnRef;
 import io.confluent.ksql.schema.ksql.LogicalSchema;
 import io.confluent.ksql.schema.ksql.LogicalSchema.Builder;
 import io.confluent.ksql.schema.ksql.SchemaConverters;
@@ -66,7 +67,7 @@ public class RowGenerator {
     this.key = Objects.requireNonNull(key, "key");
     this.ksqlSchema = buildLogicalSchema(generator, avroData);
 
-    if (!ksqlSchema.findValueColumn(key).isPresent()) {
+    if (!ksqlSchema.findValueColumn(ColumnRef.withoutSource(ColumnName.of(key))).isPresent()) {
       throw new IllegalArgumentException("key field does not exist in schema: " + key);
     }
   }

--- a/ksql-execution/src/main/java/io/confluent/ksql/execution/codegen/CodeGenRunner.java
+++ b/ksql-execution/src/main/java/io/confluent/ksql/execution/codegen/CodeGenRunner.java
@@ -15,32 +15,20 @@
 
 package io.confluent.ksql.execution.codegen;
 
-import com.google.common.collect.ImmutableMap;
-import com.google.common.collect.ImmutableMap.Builder;
-import io.confluent.ksql.execution.expression.tree.ArithmeticBinaryExpression;
-import io.confluent.ksql.execution.expression.tree.ArithmeticUnaryExpression;
-import io.confluent.ksql.execution.expression.tree.BetweenPredicate;
-import io.confluent.ksql.execution.expression.tree.Cast;
 import io.confluent.ksql.execution.expression.tree.ColumnReferenceExp;
-import io.confluent.ksql.execution.expression.tree.ComparisonExpression;
-import io.confluent.ksql.execution.expression.tree.DereferenceExpression;
 import io.confluent.ksql.execution.expression.tree.Expression;
 import io.confluent.ksql.execution.expression.tree.FunctionCall;
-import io.confluent.ksql.execution.expression.tree.IsNotNullPredicate;
-import io.confluent.ksql.execution.expression.tree.IsNullPredicate;
 import io.confluent.ksql.execution.expression.tree.LikePredicate;
-import io.confluent.ksql.execution.expression.tree.LogicalBinaryExpression;
-import io.confluent.ksql.execution.expression.tree.NotExpression;
-import io.confluent.ksql.execution.expression.tree.SearchedCaseExpression;
 import io.confluent.ksql.execution.expression.tree.SubscriptExpression;
-import io.confluent.ksql.execution.expression.tree.VisitParentExpressionVisitor;
+import io.confluent.ksql.execution.expression.tree.TraversalExpressionVisitor;
 import io.confluent.ksql.execution.util.ExpressionTypeManager;
 import io.confluent.ksql.execution.util.GenericRowValueTypeEnforcer;
 import io.confluent.ksql.function.FunctionRegistry;
 import io.confluent.ksql.function.KsqlFunction;
 import io.confluent.ksql.function.UdfFactory;
-import io.confluent.ksql.function.udf.Kudf;
+import io.confluent.ksql.name.FunctionName;
 import io.confluent.ksql.schema.ksql.Column;
+import io.confluent.ksql.schema.ksql.ColumnRef;
 import io.confluent.ksql.schema.ksql.LogicalSchema;
 import io.confluent.ksql.schema.ksql.SchemaConverters;
 import io.confluent.ksql.schema.ksql.SchemaConverters.SqlToJavaTypeConverter;
@@ -48,11 +36,8 @@ import io.confluent.ksql.schema.ksql.types.SqlType;
 import io.confluent.ksql.util.KsqlConfig;
 import io.confluent.ksql.util.KsqlException;
 import java.util.ArrayList;
-import java.util.HashSet;
 import java.util.List;
 import java.util.Objects;
-import java.util.Optional;
-import java.util.Set;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 import org.apache.kafka.connect.data.Schema;
@@ -95,12 +80,12 @@ public class CodeGenRunner {
     this.expressionTypeManager = new ExpressionTypeManager(schema, functionRegistry);
   }
 
-  public Set<ParameterType> getParameterInfo(final Expression expression) {
+  public CodeGenSpec getCodeGenSpec(final Expression expression) {
     final Visitor visitor =
         new Visitor(schema, functionRegistry, expressionTypeManager, ksqlConfig);
 
     visitor.process(expression, null);
-    return visitor.parameters;
+    return visitor.spec;
   }
 
   public ExpressionMetadata buildCodeGenFromParseTree(
@@ -108,35 +93,17 @@ public class CodeGenRunner {
       final String type
   ) {
     try {
-      final Set<ParameterType> parameters = getParameterInfo(expression);
-
-      final String[] parameterNames = new String[parameters.size()];
-      final Class[] parameterTypes = new Class[parameters.size()];
-      final List<Integer> columnIndexes = new ArrayList<>(parameters.size());
-      final List<Kudf> kudfObjects = new ArrayList<>(parameters.size());
-
-      final Builder<String, String> fieldToParamName = ImmutableMap.<String, String>builder();
-      int index = 0;
-      for (final ParameterType param : parameters) {
-        final String paramName = CodeGenUtil.paramName(index);
-        fieldToParamName.put(param.fieldName, paramName);
-        parameterNames[index] = paramName;
-        parameterTypes[index] = param.type;
-        columnIndexes.add(schema.valueColumnIndex(param.fieldName).orElse(-1));
-        kudfObjects.add(param.getKudf());
-        index++;
-      }
-
+      final CodeGenSpec spec = getCodeGenSpec(expression);
       final String javaCode = new SqlToJavaVisitor(
           schema,
           functionRegistry,
-          fieldToParamName.build()::get
+          spec
       ).process(expression);
 
       final IExpressionEvaluator ee =
           CompilerFactoryFactory.getDefaultCompilerFactory().newExpressionEvaluator();
       ee.setDefaultImports(SqlToJavaVisitor.JAVA_IMPORTS.toArray(new String[0]));
-      ee.setParameters(parameterNames, parameterTypes);
+      ee.setParameters(spec.argumentNames(), spec.argumentTypes());
 
       final SqlType expressionType = expressionTypeManager
           .getExpressionSqlType(expression);
@@ -147,8 +114,7 @@ public class CodeGenRunner {
 
       return new ExpressionMetadata(
           ee,
-          columnIndexes,
-          kudfObjects,
+          spec,
           expressionType,
           new GenericRowValueTypeEnforcer(schema),
           expression);
@@ -162,15 +128,13 @@ public class CodeGenRunner {
     }
   }
 
-  private static final class Visitor extends VisitParentExpressionVisitor<Object, Object> {
+  private static final class Visitor extends TraversalExpressionVisitor<Void> {
 
+    private final CodeGenSpec spec;
     private final LogicalSchema schema;
-    private final Set<ParameterType> parameters;
     private final FunctionRegistry functionRegistry;
     private final ExpressionTypeManager expressionTypeManager;
     private final KsqlConfig ksqlConfig;
-
-    private int functionCounter = 0;
 
     private Visitor(
         final LogicalSchema schema,
@@ -180,133 +144,53 @@ public class CodeGenRunner {
     ) {
       this.schema = Objects.requireNonNull(schema, "schema");
       this.ksqlConfig = Objects.requireNonNull(ksqlConfig, "ksqlConfig");
-      this.parameters = new HashSet<>();
       this.functionRegistry = functionRegistry;
       this.expressionTypeManager = expressionTypeManager;
+      this.spec = new CodeGenSpec();
     }
 
     private void addParameter(final Column schemaColumn) {
-      parameters.add(new ParameterType(
+      spec.addParameter(
+          schemaColumn.ref(),
           SQL_TO_JAVA_TYPE_CONVERTER.toJavaType(schemaColumn.type()),
-          schemaColumn.fullName(),
-          ksqlConfig));
+          schema.valueColumnIndex(schemaColumn.ref())
+              .orElseThrow(() -> new KsqlException(
+                  "Expected to find column in schema, but was missing: " + schemaColumn))
+      );
     }
 
-    public Object visitLikePredicate(final LikePredicate node, final Object context) {
+    public Void visitLikePredicate(final LikePredicate node, final Void context) {
       process(node.getValue(), null);
       return null;
     }
 
     @SuppressWarnings("deprecation") // Need to migrate away from Connect Schema use.
-    public Object visitFunctionCall(final FunctionCall node, final Object context) {
-      final int functionNumber = functionCounter++;
+    public Void visitFunctionCall(final FunctionCall node, final Void context) {
       final List<Schema> argumentTypes = new ArrayList<>();
-      final String functionName = node.getName().name();
+      final FunctionName functionName = node.getName();
       for (final Expression argExpr : node.getArguments()) {
         process(argExpr, null);
         argumentTypes.add(expressionTypeManager.getExpressionSchema(argExpr));
       }
 
-      final UdfFactory holder = functionRegistry.getUdfFactory(functionName);
+      final UdfFactory holder = functionRegistry.getUdfFactory(functionName.name());
       final KsqlFunction function = holder.getFunction(argumentTypes);
-      final String parameterName = CodeGenUtil.functionName(node.getName().name(), functionNumber);
-      parameters.add(new ParameterType(
-          function,
-          parameterName,
-          ksqlConfig));
-      return null;
-    }
-
-    public Object visitArithmeticBinary(
-        final ArithmeticBinaryExpression node,
-        final Object context) {
-      process(node.getLeft(), null);
-      process(node.getRight(), null);
-      return null;
-    }
-
-    public Object visitArithmeticUnary(
-        final ArithmeticUnaryExpression node,
-        final Object context) {
-      process(node.getValue(), null);
-      return null;
-    }
-
-    public Object visitIsNotNullPredicate(final IsNotNullPredicate node, final Object context) {
-      return process(node.getValue(), context);
-    }
-
-    public Object visitIsNullPredicate(final IsNullPredicate node, final Object context) {
-      return process(node.getValue(), context);
-    }
-
-    public Object visitLogicalBinaryExpression(
-        final LogicalBinaryExpression node,
-        final Object context) {
-      process(node.getLeft(), null);
-      process(node.getRight(), null);
-      return null;
-    }
-
-    @Override
-    public Object visitComparisonExpression(
-        final ComparisonExpression node,
-        final Object context) {
-      process(node.getLeft(), null);
-      process(node.getRight(), null);
-      return null;
-    }
-
-    @Override
-    public Object visitBetweenPredicate(final BetweenPredicate node, final Object context) {
-      process(node.getValue(), null);
-      process(node.getMax(), null);
-      process(node.getMin(), null);
-      return null;
-    }
-
-    @Override
-    public Object visitNotExpression(final NotExpression node, final Object context) {
-      return process(node.getValue(), null);
-    }
-
-    @Override
-    public Object visitDereferenceExpression(
-        final DereferenceExpression node,
-        final Object context
-    ) {
-      throw new UnsupportedOperationException(
-          "DereferenceExpression should have been resolved by now");
-    }
-
-    @Override
-    public Object visitSearchedCaseExpression(
-        final SearchedCaseExpression node,
-        final Object context) {
-      node.getWhenClauses().forEach(
-          whenClause -> {
-            process(whenClause.getOperand(), context);
-            process(whenClause.getResult(), context);
-          }
+      spec.addFunction(
+          function.getFunctionName(),
+          function.newInstance(ksqlConfig)
       );
-      node.getDefaultValue().ifPresent(defaultVal -> process(defaultVal, context));
+
       return null;
     }
 
     @Override
-    public Object visitCast(final Cast node, final Object context) {
-      process(node.getExpression(), context);
-      return null;
-    }
-
-    @Override
-    public Object visitSubscriptExpression(
+    public Void visitSubscriptExpression(
         final SubscriptExpression node,
-        final Object context
+        final Void context
     ) {
       if (node.getBase() instanceof ColumnReferenceExp) {
-        final String arrayBaseName = node.getBase().toString();
-        addParameter(getRequiredColumn(arrayBaseName));
+        final ColumnReferenceExp arrayBaseName = (ColumnReferenceExp) node.getBase();
+        addParameter(getRequiredColumn(arrayBaseName.getReference()));
       } else {
         process(node.getBase(), context);
       }
@@ -315,94 +199,21 @@ public class CodeGenRunner {
     }
 
     @Override
-    public Object visitColumnReference(
+    public Void visitColumnReference(
         final ColumnReferenceExp node,
-        final Object context
+        final Void context
     ) {
-      addParameter(getRequiredColumn(node.getReference().toString()));
+      addParameter(getRequiredColumn(node.getReference()));
       return null;
     }
 
-    private Column getRequiredColumn(final String columnName) {
-      return schema.findValueColumn(columnName)
+    private Column getRequiredColumn(final ColumnRef target) {
+      return schema.findValueColumn(target)
           .orElseThrow(() -> new RuntimeException(
               "Cannot find the select field in the available fields."
-                  + " field: " + columnName
+                  + " field: " + target
                   + ", schema: " + schema.value()));
     }
   }
 
-  public static final class ParameterType {
-
-    private final Class type;
-    private final Optional<KsqlFunction> function;
-    private final String fieldName;
-    private final KsqlConfig ksqlConfig;
-
-    private ParameterType(
-        final Class type,
-        final String fieldName,
-        final KsqlConfig ksqlConfig
-    ) {
-      this(
-          null,
-          Objects.requireNonNull(type, "type"),
-          fieldName,
-          ksqlConfig);
-    }
-
-    private ParameterType(
-        final KsqlFunction function,
-        final String fieldName,
-        final KsqlConfig ksqlConfig) {
-      this(
-          Objects.requireNonNull(function, "function"),
-          function.getKudfClass(),
-          fieldName,
-          ksqlConfig);
-    }
-
-    private ParameterType(
-        final KsqlFunction function,
-        final Class type,
-        final String fieldName,
-        final KsqlConfig ksqlConfig
-    ) {
-      this.function = Optional.ofNullable(function);
-      this.type = Objects.requireNonNull(type, "type");
-      this.fieldName = Objects.requireNonNull(fieldName, "fieldName");
-      this.ksqlConfig = Objects.requireNonNull(ksqlConfig, "ksqlConfig");
-    }
-
-    public Class getType() {
-      return type;
-    }
-
-    public String getFieldName() {
-      return fieldName;
-    }
-
-    public Kudf getKudf() {
-      return function.map(f -> f.newInstance(ksqlConfig)).orElse(null);
-    }
-
-    @Override
-    public boolean equals(final Object o) {
-      if (this == o) {
-        return true;
-      }
-      if (o == null || getClass() != o.getClass()) {
-        return false;
-      }
-      final ParameterType that = (ParameterType) o;
-      return Objects.equals(type, that.type)
-          && Objects.equals(function, that.function)
-          && Objects.equals(fieldName, that.fieldName);
-    }
-
-    @Override
-    public int hashCode() {
-      return Objects.hash(type, function, fieldName);
-    }
-  }
 }

--- a/ksql-execution/src/main/java/io/confluent/ksql/execution/codegen/CodeGenSpec.java
+++ b/ksql-execution/src/main/java/io/confluent/ksql/execution/codegen/CodeGenSpec.java
@@ -1,0 +1,161 @@
+/*
+ * Copyright 2019 Confluent Inc.
+ *
+ * Licensed under the Confluent Community License (the "License"; you may not use
+ * this file except in compliance with the License. You may obtain a copy of the
+ * License at
+ *
+ * http://www.confluent.io/confluent-community-license
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package io.confluent.ksql.execution.codegen;
+
+import com.google.common.collect.ArrayListMultimap;
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ListMultimap;
+import com.google.errorprone.annotations.Immutable;
+import io.confluent.ksql.GenericRow;
+import io.confluent.ksql.execution.util.GenericRowValueTypeEnforcer;
+import io.confluent.ksql.function.udf.Kudf;
+import io.confluent.ksql.name.FunctionName;
+import io.confluent.ksql.schema.ksql.ColumnRef;
+import io.confluent.ksql.util.KsqlException;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.OptionalInt;
+
+public class CodeGenSpec {
+
+  private List<ArgumentSpec> arguments = new ArrayList<>();
+  private Map<ColumnRef, String> columnToCodeName = new HashMap<>();
+  private ListMultimap<FunctionName, String> functionToCodeName = ArrayListMultimap.create();
+
+  public void addParameter(final ColumnRef columnRef, final Class<?> type, final int colIndex) {
+    final String codeName = CodeGenUtil.paramName(arguments.size());
+    arguments.add(new ArgumentSpec(
+        codeName,
+        type,
+        OptionalInt.of(colIndex),
+        Optional.empty()
+    ));
+    columnToCodeName.put(columnRef, codeName);
+  }
+
+  public void addFunction(final FunctionName functionName, final Kudf function) {
+    final String codeName = CodeGenUtil.functionName(functionName, arguments.size());
+    arguments.add(new ArgumentSpec(
+        codeName,
+        function.getClass(),
+        OptionalInt.empty(),
+        Optional.of(function)
+    ));
+    functionToCodeName.put(functionName, codeName);
+  }
+
+  public String[] argumentNames() {
+    return arguments.stream().map(ArgumentSpec::name).toArray(String[]::new);
+  }
+
+  public Class[] argumentTypes() {
+    return arguments.stream().map(ArgumentSpec::type).toArray(Class[]::new);
+  }
+
+  public List<ArgumentSpec> arguments() {
+    return ImmutableList.copyOf(arguments);
+  }
+
+  public String getCodeName(final ColumnRef columnRef) {
+    return columnToCodeName.get(columnRef);
+  }
+
+  public String reserveFunctionName(final FunctionName functionName) {
+    final List<String> names = functionToCodeName.get(functionName);
+    if (names.isEmpty()) {
+      throw new KsqlException("Ran out of unique names for: " + functionName);
+    }
+    return names.remove(0);
+  }
+
+  public void resolve(
+      final GenericRow row,
+      final GenericRowValueTypeEnforcer typeEnforcer,
+      final Object[] parameters) {
+    for (int paramIdx = 0; paramIdx < arguments.size(); paramIdx++) {
+      final ArgumentSpec spec = arguments.get(paramIdx);
+
+      if (spec.colIndex().isPresent()) {
+        final int colIndex = spec.colIndex().getAsInt();
+        parameters[paramIdx] = typeEnforcer
+            .enforceColumnType(colIndex, row.getColumns().get(colIndex));
+      } else {
+        final int copyOfParamIdxForLambda = paramIdx;
+        parameters[paramIdx] = spec.kudf()
+            .orElseThrow(() -> new KsqlException(
+                "Expected parameter at index "
+                    + copyOfParamIdxForLambda
+                    + " to be a function, but was "
+                    + spec));
+      }
+    }
+  }
+
+  /**
+   * Represents either a named reference to a column in a generic row, or
+   * a function wrapped in a {@code Kudf}.
+   */
+  @Immutable
+  public static class ArgumentSpec {
+
+    private final String name;
+    private final Class<?> type;
+    private final OptionalInt columnIndex;
+    private final Optional<Kudf> kudf;
+
+    ArgumentSpec(
+        final String name,
+        final Class<?> type,
+        final OptionalInt columnIndex,
+        final Optional<Kudf> kudf
+    ) {
+      this.name = name;
+      this.type = type;
+      this.columnIndex = columnIndex;
+      this.kudf = kudf;
+    }
+
+    public String name() {
+      return name;
+    }
+
+    public Class<?> type() {
+      return type;
+    }
+
+    public OptionalInt colIndex() {
+      return columnIndex;
+    }
+
+    public Optional<Kudf> kudf() {
+      return kudf;
+    }
+
+    @Override
+    public String toString() {
+      return "ArgumentSpec{"
+          + "name='" + name + '\''
+          + ", type=" + type
+          + ", columnIndex=" + columnIndex
+          + ", kudf=" + kudf
+          + '}';
+    }
+  }
+
+}

--- a/ksql-execution/src/main/java/io/confluent/ksql/execution/codegen/FunctionSpec.java
+++ b/ksql-execution/src/main/java/io/confluent/ksql/execution/codegen/FunctionSpec.java
@@ -20,6 +20,7 @@ import io.confluent.ksql.function.KsqlFunction;
 import io.confluent.ksql.function.udf.Kudf;
 import io.confluent.ksql.name.FunctionName;
 import io.confluent.ksql.util.KsqlConfig;
+import java.util.Objects;
 
 @Immutable
 public final class FunctionSpec {
@@ -33,10 +34,10 @@ public final class FunctionSpec {
       final String codegenName,
       final KsqlConfig ksqlConfig
   ) {
-    this.type = function.getKudfClass();
-    this.function = function;
-    this.codegenName = codegenName;
-    this.ksqlConfig = ksqlConfig;
+    this.type = Objects.requireNonNull(function.getKudfClass(), "kudfClass");
+    this.function = Objects.requireNonNull(function, "function");
+    this.codegenName = Objects.requireNonNull(codegenName, "codegenName");
+    this.ksqlConfig = Objects.requireNonNull(ksqlConfig, "ksqlConfig");
   }
 
   public Class type() {

--- a/ksql-execution/src/main/java/io/confluent/ksql/execution/codegen/FunctionSpec.java
+++ b/ksql-execution/src/main/java/io/confluent/ksql/execution/codegen/FunctionSpec.java
@@ -1,0 +1,57 @@
+/*
+ * Copyright 2019 Confluent Inc.
+ *
+ * Licensed under the Confluent Community License (the "License"; you may not use
+ * this file except in compliance with the License. You may obtain a copy of the
+ * License at
+ *
+ * http://www.confluent.io/confluent-community-license
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package io.confluent.ksql.execution.codegen;
+
+import com.google.errorprone.annotations.Immutable;
+import io.confluent.ksql.function.KsqlFunction;
+import io.confluent.ksql.function.udf.Kudf;
+import io.confluent.ksql.name.FunctionName;
+import io.confluent.ksql.util.KsqlConfig;
+
+@Immutable
+public final class FunctionSpec {
+  private final Class type;
+  private final KsqlFunction function;
+  private final String codegenName;
+  private final KsqlConfig ksqlConfig;
+
+  FunctionSpec(
+      final KsqlFunction function,
+      final String codegenName,
+      final KsqlConfig ksqlConfig
+  ) {
+    this.type = function.getKudfClass();
+    this.function = function;
+    this.codegenName = codegenName;
+    this.ksqlConfig = ksqlConfig;
+  }
+
+  public Class type() {
+    return type;
+  }
+
+  public String codeGenName() {
+    return codegenName;
+  }
+
+  public FunctionName functionName() {
+    return function.getFunctionName();
+  }
+
+  public Kudf newInstance() {
+    return function.newInstance(ksqlConfig);
+  }
+}

--- a/ksql-execution/src/main/java/io/confluent/ksql/execution/function/udaf/window/WindowSelectMapper.java
+++ b/ksql-execution/src/main/java/io/confluent/ksql/execution/function/udaf/window/WindowSelectMapper.java
@@ -48,7 +48,7 @@ public final class WindowSelectMapper
   ) {
     final ImmutableMap.Builder<Integer, Type> selectsBuilder = new Builder<>();
     for (int i = 0; i < functions.size(); i++) {
-      final String name = functions.get(i).getFunctionName().toUpperCase();
+      final String name = functions.get(i).getFunctionName().name().toUpperCase();
       if (WINDOW_FUNCTION_NAMES.containsKey(name)) {
         selectsBuilder.put(initialUdafIndex + i, WINDOW_FUNCTION_NAMES.get(name));
       }

--- a/ksql-execution/src/main/java/io/confluent/ksql/execution/plan/SelectExpression.java
+++ b/ksql-execution/src/main/java/io/confluent/ksql/execution/plan/SelectExpression.java
@@ -26,11 +26,11 @@ import javax.annotation.concurrent.Immutable;
 @Immutable
 public final class SelectExpression {
 
-  private final ColumnName name;
+  private final ColumnName alias;
   private final Expression expression;
 
-  private SelectExpression(final ColumnName name, final Expression expression) {
-    this.name = Objects.requireNonNull(name, "name");
+  private SelectExpression(final ColumnName alias, final Expression expression) {
+    this.alias = Objects.requireNonNull(alias, "alias");
     this.expression = Objects.requireNonNull(expression, "expression");
   }
 
@@ -38,8 +38,8 @@ public final class SelectExpression {
     return new SelectExpression(name, expression);
   }
 
-  public ColumnName getName() {
-    return name;
+  public ColumnName getAlias() {
+    return alias;
   }
 
   public Expression getExpression() {
@@ -55,19 +55,19 @@ public final class SelectExpression {
       return false;
     }
     final SelectExpression that = (SelectExpression) o;
-    return Objects.equals(name, that.name)
+    return Objects.equals(alias, that.alias)
         && Objects.equals(expression, that.expression);
   }
 
   @Override
   public int hashCode() {
-    return Objects.hash(name, expression);
+    return Objects.hash(alias, expression);
   }
 
   @Override
   public String toString() {
     return "SelectExpression{"
-        + "name='" + name + '\''
+        + "name='" + alias + '\''
         + ", expression=" + expression
         + '}';
   }

--- a/ksql-execution/src/main/java/io/confluent/ksql/execution/plan/StreamSelectKey.java
+++ b/ksql-execution/src/main/java/io/confluent/ksql/execution/plan/StreamSelectKey.java
@@ -15,7 +15,7 @@
 package io.confluent.ksql.execution.plan;
 
 import com.google.errorprone.annotations.Immutable;
-import io.confluent.ksql.name.ColumnName;
+import io.confluent.ksql.schema.ksql.ColumnRef;
 import java.util.Collections;
 import java.util.List;
 import java.util.Objects;
@@ -24,14 +24,14 @@ import org.apache.kafka.connect.data.Struct;
 @Immutable
 public class StreamSelectKey<K> implements ExecutionStep<KStreamHolder<Struct>> {
   private final ExecutionStepProperties properties;
-  private final ColumnName fieldName;
+  private final ColumnRef fieldName;
   private final ExecutionStep<KStreamHolder<K>> source;
   private final boolean updateRowKey;
 
   public StreamSelectKey(
       final ExecutionStepProperties properties,
       final ExecutionStep<KStreamHolder<K>> source,
-      final ColumnName fieldName,
+      final ColumnRef fieldName,
       final boolean updateRowKey) {
     this.properties = Objects.requireNonNull(properties, "properties");
     this.source = Objects.requireNonNull(source, "source");
@@ -53,7 +53,7 @@ public class StreamSelectKey<K> implements ExecutionStep<KStreamHolder<Struct>> 
     return updateRowKey;
   }
 
-  public ColumnName getFieldName() {
+  public ColumnRef getFieldName() {
     return fieldName;
   }
 

--- a/ksql-execution/src/main/java/io/confluent/ksql/execution/util/ExpressionTypeManager.java
+++ b/ksql-execution/src/main/java/io/confluent/ksql/execution/util/ExpressionTypeManager.java
@@ -210,7 +210,7 @@ public class ExpressionTypeManager {
         final ColumnReferenceExp node,
         final ExpressionTypeContext expressionTypeContext
     ) {
-      final Column schemaColumn = schema.findColumn(node.getReference().name())
+      final Column schemaColumn = schema.findColumn(node.getReference())
           .orElseThrow(() ->
               new KsqlException(String.format("Invalid Expression %s.", node.toString())));
 

--- a/ksql-execution/src/test/java/io/confluent/ksql/execution/codegen/SqlToJavaVisitorTest.java
+++ b/ksql-execution/src/test/java/io/confluent/ksql/execution/codegen/SqlToJavaVisitorTest.java
@@ -56,13 +56,16 @@ import io.confluent.ksql.execution.expression.tree.WhenClause;
 import io.confluent.ksql.function.FunctionRegistry;
 import io.confluent.ksql.function.KsqlFunction;
 import io.confluent.ksql.function.UdfFactory;
+import io.confluent.ksql.name.ColumnName;
 import io.confluent.ksql.name.FunctionName;
+import io.confluent.ksql.name.SourceName;
 import io.confluent.ksql.schema.Operator;
 import io.confluent.ksql.schema.ksql.ColumnRef;
 import io.confluent.ksql.schema.ksql.types.SqlDecimal;
 import io.confluent.ksql.schema.ksql.types.SqlPrimitiveType;
 import io.confluent.ksql.schema.ksql.types.SqlTypes;
 import java.util.Optional;
+import java.util.concurrent.atomic.AtomicInteger;
 import org.apache.kafka.connect.data.Schema;
 import org.junit.Before;
 import org.junit.Rule;
@@ -73,6 +76,8 @@ import org.mockito.junit.MockitoJUnit;
 import org.mockito.junit.MockitoRule;
 
 public class SqlToJavaVisitorTest {
+
+  private static final SourceName TEST1 = SourceName.of("TEST1");
 
   @Mock
   private FunctionRegistry functionRegistry;
@@ -87,10 +92,12 @@ public class SqlToJavaVisitorTest {
 
   @Before
   public void init() {
+    final AtomicInteger funCounter = new AtomicInteger();
     sqlToJavaVisitor = new SqlToJavaVisitor(
         SCHEMA,
         functionRegistry,
-        fn -> fn.replace(".", "_")
+        ref -> ref.aliasedFieldName().replace(".", "_"),
+        name -> name.name() + "_" + funCounter.getAndIncrement()
     );
   }
 
@@ -353,8 +360,8 @@ public class SqlToJavaVisitorTest {
     // Given:
     final ArithmeticBinaryExpression binExp = new ArithmeticBinaryExpression(
         Operator.ADD,
-        new ColumnReferenceExp(ColumnRef.of("TEST1.COL8")),
-        new ColumnReferenceExp(ColumnRef.of("TEST1.COL8"))
+        new ColumnReferenceExp(ColumnRef.of(TEST1, ColumnName.of("COL8"))),
+        new ColumnReferenceExp(ColumnRef.of(TEST1, ColumnName.of("COL8")))
     );
 
     // When:
@@ -369,8 +376,8 @@ public class SqlToJavaVisitorTest {
     // Given:
     final ArithmeticBinaryExpression binExp = new ArithmeticBinaryExpression(
         Operator.ADD,
-        new ColumnReferenceExp(ColumnRef.of("TEST1.COL8")),
-        new ColumnReferenceExp(ColumnRef.of("TEST1.COL0"))
+        new ColumnReferenceExp(ColumnRef.of(TEST1, ColumnName.of("COL8"))),
+        new ColumnReferenceExp(ColumnRef.of(TEST1, ColumnName.of("COL0")))
     );
 
     // When:
@@ -385,8 +392,8 @@ public class SqlToJavaVisitorTest {
     // Given:
     final ArithmeticBinaryExpression binExp = new ArithmeticBinaryExpression(
         Operator.ADD,
-        new ColumnReferenceExp(ColumnRef.of("TEST1.COL8")),
-        new ColumnReferenceExp(ColumnRef.of("TEST1.COL3"))
+        new ColumnReferenceExp(ColumnRef.of(TEST1, ColumnName.of("COL8"))),
+        new ColumnReferenceExp(ColumnRef.of(TEST1, ColumnName.of("COL3")))
     );
 
     // When:
@@ -401,8 +408,8 @@ public class SqlToJavaVisitorTest {
     // Given:
     final ArithmeticBinaryExpression binExp = new ArithmeticBinaryExpression(
         Operator.SUBTRACT,
-        new ColumnReferenceExp(ColumnRef.of("TEST1.COL8")),
-        new ColumnReferenceExp(ColumnRef.of("TEST1.COL8"))
+        new ColumnReferenceExp(ColumnRef.of(TEST1, ColumnName.of("COL8"))),
+        new ColumnReferenceExp(ColumnRef.of(TEST1, ColumnName.of("COL8")))
     );
 
     // When:
@@ -417,8 +424,8 @@ public class SqlToJavaVisitorTest {
     // Given:
     final ArithmeticBinaryExpression binExp = new ArithmeticBinaryExpression(
         Operator.MULTIPLY,
-        new ColumnReferenceExp(ColumnRef.of("TEST1.COL8")),
-        new ColumnReferenceExp(ColumnRef.of("TEST1.COL8"))
+        new ColumnReferenceExp(ColumnRef.of(TEST1, ColumnName.of("COL8"))),
+        new ColumnReferenceExp(ColumnRef.of(TEST1, ColumnName.of("COL8")))
     );
 
     // When:
@@ -433,8 +440,8 @@ public class SqlToJavaVisitorTest {
     // Given:
     final ArithmeticBinaryExpression binExp = new ArithmeticBinaryExpression(
         Operator.DIVIDE,
-        new ColumnReferenceExp(ColumnRef.of("TEST1.COL8")),
-        new ColumnReferenceExp(ColumnRef.of("TEST1.COL8"))
+        new ColumnReferenceExp(ColumnRef.of(TEST1, ColumnName.of("COL8"))),
+        new ColumnReferenceExp(ColumnRef.of(TEST1, ColumnName.of("COL8")))
     );
 
     // When:
@@ -449,8 +456,8 @@ public class SqlToJavaVisitorTest {
     // Given:
     final ArithmeticBinaryExpression binExp = new ArithmeticBinaryExpression(
         Operator.MODULUS,
-        new ColumnReferenceExp(ColumnRef.of("TEST1.COL8")),
-        new ColumnReferenceExp(ColumnRef.of("TEST1.COL8"))
+        new ColumnReferenceExp(ColumnRef.of(TEST1, ColumnName.of("COL8"))),
+        new ColumnReferenceExp(ColumnRef.of(TEST1, ColumnName.of("COL8")))
     );
 
     // When:
@@ -465,8 +472,8 @@ public class SqlToJavaVisitorTest {
     // Given:
     final ComparisonExpression compExp = new ComparisonExpression(
         ComparisonExpression.Type.EQUAL,
-        new ColumnReferenceExp(ColumnRef.of("TEST1.COL8")),
-        new ColumnReferenceExp(ColumnRef.of("TEST1.COL9"))
+        new ColumnReferenceExp(ColumnRef.of(TEST1, ColumnName.of("COL8"))),
+        new ColumnReferenceExp(ColumnRef.of(TEST1, ColumnName.of("COL9")))
     );
 
     // When:
@@ -481,8 +488,8 @@ public class SqlToJavaVisitorTest {
     // Given:
     final ComparisonExpression compExp = new ComparisonExpression(
         ComparisonExpression.Type.GREATER_THAN,
-        new ColumnReferenceExp(ColumnRef.of("TEST1.COL8")),
-        new ColumnReferenceExp(ColumnRef.of("TEST1.COL9"))
+        new ColumnReferenceExp(ColumnRef.of(TEST1, ColumnName.of("COL8"))),
+        new ColumnReferenceExp(ColumnRef.of(TEST1, ColumnName.of("COL9")))
     );
 
     // When:
@@ -497,8 +504,8 @@ public class SqlToJavaVisitorTest {
     // Given:
     final ComparisonExpression compExp = new ComparisonExpression(
         ComparisonExpression.Type.GREATER_THAN_OR_EQUAL,
-        new ColumnReferenceExp(ColumnRef.of("TEST1.COL8")),
-        new ColumnReferenceExp(ColumnRef.of("TEST1.COL9"))
+        new ColumnReferenceExp(ColumnRef.of(TEST1, ColumnName.of("COL8"))),
+        new ColumnReferenceExp(ColumnRef.of(TEST1, ColumnName.of("COL9")))
     );
 
     // When:
@@ -513,8 +520,8 @@ public class SqlToJavaVisitorTest {
     // Given:
     final ComparisonExpression compExp = new ComparisonExpression(
         ComparisonExpression.Type.LESS_THAN,
-        new ColumnReferenceExp(ColumnRef.of("TEST1.COL8")),
-        new ColumnReferenceExp(ColumnRef.of("TEST1.COL9"))
+        new ColumnReferenceExp(ColumnRef.of(TEST1, ColumnName.of("COL8"))),
+        new ColumnReferenceExp(ColumnRef.of(TEST1, ColumnName.of("COL9")))
     );
 
     // When:
@@ -529,8 +536,8 @@ public class SqlToJavaVisitorTest {
     // Given:
     final ComparisonExpression compExp = new ComparisonExpression(
         ComparisonExpression.Type.LESS_THAN_OR_EQUAL,
-        new ColumnReferenceExp(ColumnRef.of("TEST1.COL8")),
-        new ColumnReferenceExp(ColumnRef.of("TEST1.COL9"))
+        new ColumnReferenceExp(ColumnRef.of(TEST1, ColumnName.of("COL8"))),
+        new ColumnReferenceExp(ColumnRef.of(TEST1, ColumnName.of("COL9")))
     );
 
     // When:
@@ -545,8 +552,8 @@ public class SqlToJavaVisitorTest {
     // Given:
     final ComparisonExpression compExp = new ComparisonExpression(
         ComparisonExpression.Type.IS_DISTINCT_FROM,
-        new ColumnReferenceExp(ColumnRef.of("TEST1.COL8")),
-        new ColumnReferenceExp(ColumnRef.of("TEST1.COL9"))
+        new ColumnReferenceExp(ColumnRef.of(TEST1, ColumnName.of("COL8"))),
+        new ColumnReferenceExp(ColumnRef.of(TEST1, ColumnName.of("COL9")))
     );
 
     // When:
@@ -561,8 +568,8 @@ public class SqlToJavaVisitorTest {
     // Given:
     final ComparisonExpression compExp = new ComparisonExpression(
         ComparisonExpression.Type.EQUAL,
-        new ColumnReferenceExp(ColumnRef.of("TEST1.COL8")),
-        new ColumnReferenceExp(ColumnRef.of("TEST1.COL3"))
+        new ColumnReferenceExp(ColumnRef.of(TEST1, ColumnName.of("COL8"))),
+        new ColumnReferenceExp(ColumnRef.of(TEST1, ColumnName.of("COL3")))
     );
 
     // When:
@@ -577,8 +584,8 @@ public class SqlToJavaVisitorTest {
     // Given:
     final ComparisonExpression compExp = new ComparisonExpression(
         ComparisonExpression.Type.EQUAL,
-        new ColumnReferenceExp(ColumnRef.of("TEST1.COL3")),
-        new ColumnReferenceExp(ColumnRef.of("TEST1.COL8"))
+        new ColumnReferenceExp(ColumnRef.of(TEST1, ColumnName.of("COL3"))),
+        new ColumnReferenceExp(ColumnRef.of(TEST1, ColumnName.of("COL8")))
     );
 
     // When:
@@ -594,7 +601,7 @@ public class SqlToJavaVisitorTest {
     final ArithmeticUnaryExpression binExp = new ArithmeticUnaryExpression(
         Optional.empty(),
         Sign.MINUS,
-        new ColumnReferenceExp(ColumnRef.of("TEST1.COL8"))
+        new ColumnReferenceExp(ColumnRef.of(TEST1, ColumnName.of("COL8")))
     );
 
     // When:
@@ -610,7 +617,7 @@ public class SqlToJavaVisitorTest {
     final ArithmeticUnaryExpression binExp = new ArithmeticUnaryExpression(
         Optional.empty(),
         Sign.PLUS,
-    new ColumnReferenceExp(ColumnRef.of("TEST1.COL8")));
+    new ColumnReferenceExp(ColumnRef.of(TEST1, ColumnName.of("COL8"))));
 
       // When:
     final String java = sqlToJavaVisitor.process(binExp);
@@ -623,7 +630,7 @@ public class SqlToJavaVisitorTest {
   public void shouldGenerateCorrectCodeForDecimalCast() {
     // Given:
     final Cast cast = new Cast(
-        new ColumnReferenceExp(ColumnRef.of("TEST1.COL3")),
+        new ColumnReferenceExp(ColumnRef.of(TEST1, ColumnName.of("COL3"))),
         new Type(SqlDecimal.of(2, 1))
     );
 
@@ -638,7 +645,7 @@ public class SqlToJavaVisitorTest {
   public void shouldGenerateCorrectCodeForDecimalCastNoOp() {
     // Given:
     final Cast cast = new Cast(
-        new ColumnReferenceExp(ColumnRef.of("TEST1.COL8")),
+        new ColumnReferenceExp(ColumnRef.of(TEST1, ColumnName.of("COL8"))),
         new Type(SqlDecimal.of(2, 1))
     );
 
@@ -653,7 +660,7 @@ public class SqlToJavaVisitorTest {
   public void shouldGenerateCorrectCodeForDecimalToIntCast() {
     // Given:
     final Cast cast = new Cast(
-        new ColumnReferenceExp(ColumnRef.of("TEST1.COL8")),
+        new ColumnReferenceExp(ColumnRef.of(TEST1, ColumnName.of("COL8"))),
         new Type(SqlTypes.INTEGER)
     );
 
@@ -668,7 +675,7 @@ public class SqlToJavaVisitorTest {
   public void shouldGenerateCorrectCodeForDecimalToLongCast() {
     // Given:
     final Cast cast = new Cast(
-        new ColumnReferenceExp(ColumnRef.of("TEST1.COL8")),
+        new ColumnReferenceExp(ColumnRef.of(TEST1, ColumnName.of("COL8"))),
         new Type(SqlTypes.BIGINT)
     );
 
@@ -683,7 +690,7 @@ public class SqlToJavaVisitorTest {
   public void shouldGenerateCorrectCodeForDecimalToDoubleCast() {
     // Given:
     final Cast cast = new Cast(
-        new ColumnReferenceExp(ColumnRef.of("TEST1.COL8")),
+        new ColumnReferenceExp(ColumnRef.of(TEST1, ColumnName.of("COL8"))),
         new Type(SqlTypes.DOUBLE)
     );
 
@@ -698,7 +705,7 @@ public class SqlToJavaVisitorTest {
   public void shouldGenerateCorrectCodeForDecimalToStringCast() {
     // Given:
     final Cast cast = new Cast(
-        new ColumnReferenceExp(ColumnRef.of("TEST1.COL8")),
+        new ColumnReferenceExp(ColumnRef.of(TEST1, ColumnName.of("COL8"))),
         new Type(SqlTypes.STRING)
     );
 

--- a/ksql-execution/src/test/java/io/confluent/ksql/execution/expression/formatter/ExpressionFormatterTest.java
+++ b/ksql-execution/src/test/java/io/confluent/ksql/execution/expression/formatter/ExpressionFormatterTest.java
@@ -25,6 +25,7 @@ import io.confluent.ksql.execution.expression.tree.ArithmeticUnaryExpression;
 import io.confluent.ksql.execution.expression.tree.BetweenPredicate;
 import io.confluent.ksql.execution.expression.tree.BooleanLiteral;
 import io.confluent.ksql.execution.expression.tree.Cast;
+import io.confluent.ksql.execution.expression.tree.ColumnReferenceExp;
 import io.confluent.ksql.execution.expression.tree.ComparisonExpression;
 import io.confluent.ksql.execution.expression.tree.DecimalLiteral;
 import io.confluent.ksql.execution.expression.tree.DereferenceExpression;
@@ -39,9 +40,6 @@ import io.confluent.ksql.execution.expression.tree.LogicalBinaryExpression;
 import io.confluent.ksql.execution.expression.tree.LongLiteral;
 import io.confluent.ksql.execution.expression.tree.NotExpression;
 import io.confluent.ksql.execution.expression.tree.NullLiteral;
-import io.confluent.ksql.name.FunctionName;
-import io.confluent.ksql.schema.ksql.ColumnRef;
-import io.confluent.ksql.execution.expression.tree.ColumnReferenceExp;
 import io.confluent.ksql.execution.expression.tree.SearchedCaseExpression;
 import io.confluent.ksql.execution.expression.tree.SimpleCaseExpression;
 import io.confluent.ksql.execution.expression.tree.StringLiteral;
@@ -50,8 +48,11 @@ import io.confluent.ksql.execution.expression.tree.TimeLiteral;
 import io.confluent.ksql.execution.expression.tree.TimestampLiteral;
 import io.confluent.ksql.execution.expression.tree.Type;
 import io.confluent.ksql.execution.expression.tree.WhenClause;
+import io.confluent.ksql.name.ColumnName;
+import io.confluent.ksql.name.FunctionName;
 import io.confluent.ksql.parser.NodeLocation;
 import io.confluent.ksql.schema.Operator;
+import io.confluent.ksql.schema.ksql.ColumnRef;
 import io.confluent.ksql.schema.ksql.FormatOptions;
 import io.confluent.ksql.schema.ksql.types.SqlArray;
 import io.confluent.ksql.schema.ksql.types.SqlMap;
@@ -115,7 +116,8 @@ public class ExpressionFormatterTest {
 
   @Test
   public void shouldFormatQualifiedNameReference() {
-    assertThat(ExpressionFormatter.formatExpression(new ColumnReferenceExp(ColumnRef.of("name"))), equalTo("name"));
+    assertThat(ExpressionFormatter.formatExpression(new ColumnReferenceExp(ColumnRef.withoutSource(
+        ColumnName.of("name")))), equalTo("name"));
   }
 
   @Test

--- a/ksql-execution/src/test/java/io/confluent/ksql/execution/expression/tree/InListExpressionTest.java
+++ b/ksql-execution/src/test/java/io/confluent/ksql/execution/expression/tree/InListExpressionTest.java
@@ -17,6 +17,7 @@ package io.confluent.ksql.execution.expression.tree;
 
 import com.google.common.collect.ImmutableList;
 import com.google.common.testing.EqualsTester;
+import io.confluent.ksql.name.ColumnName;
 import io.confluent.ksql.parser.NodeLocation;
 import io.confluent.ksql.schema.ksql.ColumnRef;
 import java.util.Collections;
@@ -28,7 +29,7 @@ public class InListExpressionTest {
 
   public static final NodeLocation SOME_LOCATION = new NodeLocation(0, 0);
   public static final NodeLocation OTHER_LOCATION = new NodeLocation(1, 0);
-  private static final ColumnRef SOME_NAME = ColumnRef.of("bob");
+  private static final ColumnRef SOME_NAME = ColumnRef.withoutSource(ColumnName.of("bob"));
   private static final List<Expression> SOME_EXPRESSIONS = ImmutableList.of(
       new StringLiteral("jane"));
   private static final List<Expression> OTHER_EXPRESSIONS = ImmutableList.of(

--- a/ksql-execution/src/test/java/io/confluent/ksql/execution/function/UdafUtilTest.java
+++ b/ksql-execution/src/test/java/io/confluent/ksql/execution/function/UdafUtilTest.java
@@ -51,7 +51,7 @@ public class UdafUtilTest {
       .build();
   private static final FunctionCall FUNCTION_CALL = new FunctionCall(
       FunctionName.of("AGG"),
-      ImmutableList.of(new ColumnReferenceExp(ColumnRef.of("BAR")))
+      ImmutableList.of(new ColumnReferenceExp(ColumnRef.withoutSource(ColumnName.of("BAR"))))
   );
 
   @Mock

--- a/ksql-execution/src/test/java/io/confluent/ksql/execution/function/udaf/window/WindowSelectMapperTest.java
+++ b/ksql-execution/src/test/java/io/confluent/ksql/execution/function/udaf/window/WindowSelectMapperTest.java
@@ -22,6 +22,7 @@ import static org.hamcrest.Matchers.sameInstance;
 import com.google.common.collect.ImmutableList;
 import io.confluent.ksql.GenericRow;
 import io.confluent.ksql.function.KsqlAggregateFunction;
+import io.confluent.ksql.name.FunctionName;
 import java.util.ArrayList;
 import java.util.Arrays;
 import org.apache.kafka.streams.kstream.Window;
@@ -47,9 +48,10 @@ public class WindowSelectMapperTest {
 
   @Before
   public void setUp() {
-    EasyMock.expect(windowStartFunc.getFunctionName()).andReturn("WinDowStarT").anyTimes();
-    EasyMock.expect(windowEndFunc.getFunctionName()).andReturn("WinDowEnD").anyTimes();
-    EasyMock.expect(otherFunc.getFunctionName()).andReturn("NotWindowStartOrWindowEnd").anyTimes();
+    EasyMock.expect(windowStartFunc.getFunctionName()).andReturn(FunctionName.of("WinDowStarT")).anyTimes();
+    EasyMock.expect(windowEndFunc.getFunctionName()).andReturn(FunctionName.of("WinDowEnD")).anyTimes();
+    EasyMock.expect(otherFunc.getFunctionName()).andReturn(
+        FunctionName.of("NotWindowStartOrWindowEnd")).anyTimes();
     EasyMock.replay(windowStartFunc, windowEndFunc, otherFunc);
   }
 

--- a/ksql-execution/src/test/java/io/confluent/ksql/execution/sqlpredicate/SqlPredicateTest.java
+++ b/ksql-execution/src/test/java/io/confluent/ksql/execution/sqlpredicate/SqlPredicateTest.java
@@ -83,7 +83,7 @@ public class SqlPredicateTest {
   private static final KsqlFunction LEN_FUNCTION = KsqlFunction.createLegacyBuiltIn(
       Schema.OPTIONAL_INT32_SCHEMA,
       ImmutableList.of(Schema.OPTIONAL_STRING_SCHEMA),
-      "LEN",
+      FunctionName.of("LEN"),
       LenDummy.class
   );
 
@@ -192,7 +192,7 @@ public class SqlPredicateTest {
     );
   }
 
-  private static class LenDummy implements Kudf {
+  public static class LenDummy implements Kudf {
 
     @Override
     public Object evaluate(Object... args) {

--- a/ksql-execution/src/test/java/io/confluent/ksql/execution/util/ExpressionTypeManagerTest.java
+++ b/ksql-execution/src/test/java/io/confluent/ksql/execution/util/ExpressionTypeManagerTest.java
@@ -406,7 +406,7 @@ public class ExpressionTypeManagerTest {
     final SqlType result = expressionTypeManager.getExpressionSqlType(expression);
 
     // Then:
-    final SqlType sqlType = SCHEMA.findColumn(ADDRESS.getReference().name()).get().type();
+    final SqlType sqlType = SCHEMA.findColumn(ADDRESS.getReference()).get().type();
     assertThat(result, is(sqlType));
   }
 

--- a/ksql-functional-tests/src/main/java/io/confluent/ksql/test/model/matchers/MetaStoreMatchers.java
+++ b/ksql-functional-tests/src/main/java/io/confluent/ksql/test/model/matchers/MetaStoreMatchers.java
@@ -22,8 +22,10 @@ import io.confluent.ksql.metastore.model.KeyField;
 import io.confluent.ksql.metastore.model.KeyField.LegacyField;
 import io.confluent.ksql.name.ColumnName;
 import io.confluent.ksql.name.SourceName;
+import io.confluent.ksql.schema.ksql.ColumnRef;
 import io.confluent.ksql.schema.ksql.types.SqlType;
 import io.confluent.ksql.serde.KeyFormat;
+import io.confluent.ksql.test.utils.TestParsingUtil;
 import java.util.Optional;
 import org.apache.kafka.connect.data.Schema;
 import org.hamcrest.FeatureMatcher;
@@ -98,25 +100,25 @@ public final class MetaStoreMatchers {
 
     public static Matcher<KeyField> hasName(final Optional<String> name) {
       return new FeatureMatcher<KeyField, Optional<ColumnName>>(
-          is(name.map(ColumnName::of)),
+          is(name.map(TestParsingUtil::parseColumnRef).map(ColumnRef::name)),
           "field with name",
           "name"
       ) {
         @Override
         protected Optional<ColumnName> featureValueOf(final KeyField actual) {
-          return actual.name();
+          return actual.ref().map(ColumnRef::name);
         }
       };
     }
 
     public static Matcher<KeyField> hasLegacyName(final Optional<String> name) {
       return new FeatureMatcher<KeyField, Optional<ColumnName>>(
-          is(name.map(ColumnName::of)),
+          is(name.map(TestParsingUtil::parseColumnRef).map(ColumnRef::name)),
           "field with legacy name",
           "legacy name") {
         @Override
         protected Optional<ColumnName> featureValueOf(final KeyField actual) {
-          return actual.legacy().map(LegacyField::name);
+          return actual.legacy().map(LegacyField::columnRef).map(ColumnRef::name);
         }
       };
     }

--- a/ksql-functional-tests/src/main/java/io/confluent/ksql/test/tools/conditions/PostConditions.java
+++ b/ksql-functional-tests/src/main/java/io/confluent/ksql/test/tools/conditions/PostConditions.java
@@ -66,7 +66,7 @@ public class PostConditions {
 
     final String text = values.stream()
         .map(s -> s.getDataSourceType() + ":" + s.getName().name()
-            + ", key:" + s.getKeyField().name()
+            + ", key:" + s.getKeyField().ref()
             + ", value:" + s.getSchema())
         .collect(Collectors.joining(System.lineSeparator()));
 

--- a/ksql-functional-tests/src/main/java/io/confluent/ksql/test/utils/TestParsingUtil.java
+++ b/ksql-functional-tests/src/main/java/io/confluent/ksql/test/utils/TestParsingUtil.java
@@ -13,23 +13,27 @@
  * specific language governing permissions and limitations under the License.
  */
 
-package io.confluent.ksql.execution.codegen;
+package io.confluent.ksql.test.utils;
 
-import io.confluent.ksql.name.FunctionName;
+import io.confluent.ksql.name.ColumnName;
+import io.confluent.ksql.name.SourceName;
+import io.confluent.ksql.schema.ksql.ColumnRef;
 
-public final class CodeGenUtil {
+public final class TestParsingUtil {
 
-  private static final String PARAM_NAME_PREFIX = "var";
-
-  private CodeGenUtil() {
+  private TestParsingUtil() {
   }
 
-  public static String paramName(final int index) {
-    return PARAM_NAME_PREFIX + index;
-  }
+  public static ColumnRef parseColumnRef(final String columnString) {
+    final String[] split = columnString.split("\\.", 2);
+    if (split.length == 1) {
+      return ColumnRef.withoutSource(ColumnName.of(split[0]));
+    }
 
-  public static String functionName(final FunctionName fun, final int index) {
-    return fun.name() + "_" + index;
+    return ColumnRef.of(
+        SourceName.of(split[0]),
+        ColumnName.of(split[1])
+    );
   }
 
 }

--- a/ksql-metastore/src/main/java/io/confluent/ksql/metastore/model/StructuredDataSource.java
+++ b/ksql-metastore/src/main/java/io/confluent/ksql/metastore/model/StructuredDataSource.java
@@ -21,6 +21,7 @@ import com.google.common.collect.ImmutableSet;
 import com.google.errorprone.annotations.Immutable;
 import io.confluent.ksql.execution.ddl.commands.KsqlTopic;
 import io.confluent.ksql.name.SourceName;
+import io.confluent.ksql.schema.ksql.ColumnRef;
 import io.confluent.ksql.schema.ksql.LogicalSchema;
 import io.confluent.ksql.serde.SerdeOption;
 import io.confluent.ksql.util.SchemaUtil;
@@ -59,8 +60,8 @@ abstract class StructuredDataSource<K> implements DataSource<K> {
     this.ksqlTopic = requireNonNull(ksqlTopic, "ksqlTopic");
     this.serdeOptions = ImmutableSet.copyOf(requireNonNull(serdeOptions, "serdeOptions"));
 
-    if (schema.findValueColumn(SchemaUtil.ROWKEY_NAME).isPresent()
-        || schema.findValueColumn(SchemaUtil.ROWTIME_NAME).isPresent()) {
+    if (schema.findValueColumn(ColumnRef.withoutSource(SchemaUtil.ROWKEY_NAME)).isPresent()
+        || schema.findValueColumn(ColumnRef.withoutSource(SchemaUtil.ROWTIME_NAME)).isPresent()) {
       throw new IllegalArgumentException("Schema contains implicit columns in value schema");
     }
   }

--- a/ksql-metastore/src/test/java/io/confluent/ksql/metastore/model/MetaStoreMatchers.java
+++ b/ksql-metastore/src/test/java/io/confluent/ksql/metastore/model/MetaStoreMatchers.java
@@ -21,6 +21,7 @@ import io.confluent.ksql.metastore.model.KeyField.LegacyField;
 import io.confluent.ksql.name.ColumnName;
 import io.confluent.ksql.name.SourceName;
 import io.confluent.ksql.schema.ksql.Column;
+import io.confluent.ksql.schema.ksql.ColumnRef;
 import io.confluent.ksql.schema.ksql.types.SqlType;
 import io.confluent.ksql.serde.KeyFormat;
 import io.confluent.ksql.serde.SerdeOption;
@@ -113,7 +114,7 @@ public final class MetaStoreMatchers {
           (is(name.map(ColumnName::of)), "field with name", "name") {
         @Override
         protected Optional<ColumnName> featureValueOf(final KeyField actual) {
-          return actual.name();
+          return actual.ref().map(ColumnRef::name);
         }
       };
     }
@@ -127,7 +128,7 @@ public final class MetaStoreMatchers {
           (is(name.map(ColumnName::of)), "field with legacy name", "legacy name") {
         @Override
         protected Optional<ColumnName> featureValueOf(final KeyField actual) {
-          return actual.legacy().map(LegacyField::name);
+          return actual.legacy().map(LegacyField::columnRef).map(ColumnRef::name);
         }
       };
     }
@@ -157,7 +158,17 @@ public final class MetaStoreMatchers {
           (is(ColumnName.of(name)), "field with name", "name") {
         @Override
         protected ColumnName featureValueOf(final LegacyField actual) {
-          return actual.name();
+          return actual.columnRef().name();
+        }
+      };
+    }
+
+    public static Matcher<LegacyField> hasSource(final String name) {
+      return new FeatureMatcher<LegacyField, SourceName>
+          (is(SourceName.of(name)), "field with name", "name") {
+        @Override
+        protected SourceName featureValueOf(final LegacyField actual) {
+          return actual.columnRef().source().get();
         }
       };
     }
@@ -183,7 +194,7 @@ public final class MetaStoreMatchers {
           (is(name), "field with name", "name") {
         @Override
         protected String featureValueOf(final Column actual) {
-          return actual.fullName();
+          return actual.ref().aliasedFieldName();
         }
       };
     }
@@ -193,7 +204,7 @@ public final class MetaStoreMatchers {
           (is(name), "field with name", "name") {
         @Override
         protected String featureValueOf(final Column actual) {
-          return actual.fullName();
+          return actual.ref().aliasedFieldName();
         }
       };
     }

--- a/ksql-metastore/src/test/java/io/confluent/ksql/metastore/model/MetaStoreModelTest.java
+++ b/ksql-metastore/src/test/java/io/confluent/ksql/metastore/model/MetaStoreModelTest.java
@@ -28,6 +28,7 @@ import io.confluent.ksql.metastore.model.KeyField.LegacyField;
 import io.confluent.ksql.name.ColumnName;
 import io.confluent.ksql.name.SourceName;
 import io.confluent.ksql.schema.ksql.Column;
+import io.confluent.ksql.schema.ksql.ColumnRef;
 import io.confluent.ksql.schema.ksql.LogicalSchema;
 import io.confluent.ksql.schema.ksql.types.SqlType;
 import io.confluent.ksql.schema.ksql.types.SqlTypes;
@@ -61,10 +62,11 @@ public class MetaStoreModelTest {
       ))
       .put(ColumnName.class, ColumnName.of("f0"))
       .put(SourceName.class, SourceName.of("f0"))
+      .put(ColumnRef.class, ColumnRef.withoutSource(ColumnName.of("f0")))
       .put(org.apache.kafka.connect.data.Field.class,
           new org.apache.kafka.connect.data.Field("bob", 1, Schema.OPTIONAL_STRING_SCHEMA))
       .put(KeyField.class, KeyField.of(Optional.empty(), Optional.empty()))
-      .put(LegacyField.class, LegacyField.of(ColumnName.of("something"), SqlTypes.DOUBLE))
+      .put(LegacyField.class, LegacyField.of(ColumnRef.withoutSource(ColumnName.of("something")), SqlTypes.DOUBLE))
       .put(Column.class, Column.of(ColumnName.of("someField"), SqlTypes.INTEGER))
       .put(SqlType.class, SqlTypes.INTEGER)
       .put(LogicalSchema.class, LogicalSchema.builder()

--- a/ksql-metastore/src/test/java/io/confluent/ksql/util/MetaStoreFixture.java
+++ b/ksql-metastore/src/test/java/io/confluent/ksql/util/MetaStoreFixture.java
@@ -24,6 +24,7 @@ import io.confluent.ksql.metastore.model.KsqlStream;
 import io.confluent.ksql.metastore.model.KsqlTable;
 import io.confluent.ksql.name.ColumnName;
 import io.confluent.ksql.name.SourceName;
+import io.confluent.ksql.schema.ksql.ColumnRef;
 import io.confluent.ksql.schema.ksql.LogicalSchema;
 import io.confluent.ksql.schema.ksql.types.SqlType;
 import io.confluent.ksql.schema.ksql.types.SqlTypes;
@@ -76,7 +77,8 @@ public final class MetaStoreFixture {
         SourceName.of("TEST0"),
         test1Schema,
         SerdeOption.none(),
-        KeyField.of(ColumnName.of("COL0"), test1Schema.findValueColumn("COL0").get()),
+        KeyField.of(ColumnRef.withoutSource(ColumnName.of("COL0")), test1Schema.findValueColumn(
+            ColumnRef.withoutSource(ColumnName.of("COL0"))).get()),
         timestampExtractionPolicy,
         ksqlTopic0
     );
@@ -95,7 +97,9 @@ public final class MetaStoreFixture {
         SourceName.of("TEST1"),
         test1Schema,
         SerdeOption.none(),
-        KeyField.of(ColumnName.of("COL0"), test1Schema.findValueColumn("COL0").get()),
+        KeyField.of(
+            ColumnRef.withoutSource(ColumnName.of("COL0")),
+            test1Schema.findValueColumn(ColumnRef.withoutSource(ColumnName.of("COL0"))).get()),
         timestampExtractionPolicy,
         ksqlTopic1
     );
@@ -121,7 +125,9 @@ public final class MetaStoreFixture {
         SourceName.of("TEST2"),
         test2Schema,
         SerdeOption.none(),
-        KeyField.of(ColumnName.of("COL0"), test2Schema.findValueColumn("COL0").get()),
+        KeyField.of(
+            ColumnRef.withoutSource(ColumnName.of("COL0")),
+            test2Schema.findValueColumn(ColumnRef.withoutSource(ColumnName.of("COL0"))).get()),
         timestampExtractionPolicy,
         ksqlTopic2
     );
@@ -170,7 +176,8 @@ public final class MetaStoreFixture {
         SourceName.of("ORDERS"),
         ordersSchema,
         SerdeOption.none(),
-        KeyField.of(ColumnName.of("ORDERTIME"), ordersSchema.findValueColumn("ORDERTIME").get()),
+        KeyField.of(ColumnRef.withoutSource(ColumnName.of("ORDERTIME")),
+            ordersSchema.findValueColumn(ColumnRef.withoutSource(ColumnName.of("ORDERTIME"))).get()),
         timestampExtractionPolicy,
         ksqlTopicOrders
     );
@@ -196,7 +203,9 @@ public final class MetaStoreFixture {
         SourceName.of("TEST3"),
         testTable3,
         SerdeOption.none(),
-        KeyField.of(ColumnName.of("COL0"), testTable3.findValueColumn("COL0").get()),
+        KeyField.of(
+            ColumnRef.withoutSource(ColumnName.of("COL0")),
+            testTable3.findValueColumn(ColumnRef.withoutSource(ColumnName.of("COL0"))).get()),
         timestampExtractionPolicy,
         ksqlTopic3
     );

--- a/ksql-parser/src/main/java/io/confluent/ksql/parser/AstBuilder.java
+++ b/ksql-parser/src/main/java/io/confluent/ksql/parser/AstBuilder.java
@@ -579,7 +579,7 @@ public class AstBuilder {
               .getCommonFieldNames()
               .contains(name.name())
           ) {
-            alias = name.qualifier()
+            alias = name.source()
                 .map(q -> q.name() + "_" + name.name().name())
                 .map(ColumnName::of)
                 .orElseGet(name::name);
@@ -1221,7 +1221,8 @@ public class AstBuilder {
       }
 
       final Optional<NodeLocation> location = getLocation(identifier);
-      final ColumnRef name = ColumnRef.of(ColumnName.of(ParserUtil.getIdentifierText(identifier)));
+      final ColumnRef name = ColumnRef.withoutSource(
+          ColumnName.of(ParserUtil.getIdentifierText(identifier)));
       return Optional.of(new ColumnReferenceExp(location, name));
     }
 

--- a/ksql-parser/src/main/java/io/confluent/ksql/parser/properties/with/CreateSourceAsProperties.java
+++ b/ksql-parser/src/main/java/io/confluent/ksql/parser/properties/with/CreateSourceAsProperties.java
@@ -22,6 +22,7 @@ import io.confluent.ksql.execution.expression.tree.Literal;
 import io.confluent.ksql.execution.expression.tree.StringLiteral;
 import io.confluent.ksql.properties.with.CommonCreateConfigs;
 import io.confluent.ksql.properties.with.CreateAsConfigs;
+import io.confluent.ksql.schema.ksql.ColumnRef;
 import io.confluent.ksql.serde.Delimiter;
 import io.confluent.ksql.serde.Format;
 import io.confluent.ksql.util.KsqlException;
@@ -80,8 +81,8 @@ public final class CreateSourceAsProperties {
   }
 
 
-  public Optional<String> getTimestampColumnName() {
-    return Optional.ofNullable(props.getString(CommonCreateConfigs.TIMESTAMP_NAME_PROPERTY));
+  public Optional<ColumnRef> getTimestampColumnName() {
+    return props.getTimestampColumn();
   }
 
   public Optional<String> getTimestampFormat() {

--- a/ksql-parser/src/main/java/io/confluent/ksql/parser/properties/with/CreateSourceProperties.java
+++ b/ksql-parser/src/main/java/io/confluent/ksql/parser/properties/with/CreateSourceProperties.java
@@ -23,6 +23,7 @@ import io.confluent.ksql.model.WindowType;
 import io.confluent.ksql.parser.DurationParser;
 import io.confluent.ksql.properties.with.CommonCreateConfigs;
 import io.confluent.ksql.properties.with.CreateConfigs;
+import io.confluent.ksql.schema.ksql.ColumnRef;
 import io.confluent.ksql.serde.Delimiter;
 import io.confluent.ksql.serde.Format;
 import io.confluent.ksql.util.KsqlException;
@@ -111,8 +112,8 @@ public final class CreateSourceProperties {
     }
   }
 
-  public Optional<String> getTimestampColumnName() {
-    return Optional.ofNullable(props.getString(CommonCreateConfigs.TIMESTAMP_NAME_PROPERTY));
+  public Optional<ColumnRef> getTimestampColumnName() {
+    return props.getTimestampColumn();
   }
 
   public Optional<String> getTimestampFormat() {

--- a/ksql-parser/src/main/java/io/confluent/ksql/parser/tree/Sink.java
+++ b/ksql-parser/src/main/java/io/confluent/ksql/parser/tree/Sink.java
@@ -62,10 +62,10 @@ public final class Sink {
             properties,
             Optional.of(((ColumnReferenceExp) partitionByExp).getReference())
         );
-      } else {
-        throw new KsqlException(
-            "Expected partition by to be a valid column but got " + partitionByExp);
       }
+
+      throw new KsqlException(
+          "Expected partition by to be a valid column but got " + partitionByExp);
     }
 
     return new Sink(name, createSink, properties, Optional.empty());

--- a/ksql-parser/src/main/java/io/confluent/ksql/parser/tree/Sink.java
+++ b/ksql-parser/src/main/java/io/confluent/ksql/parser/tree/Sink.java
@@ -18,10 +18,12 @@ package io.confluent.ksql.parser.tree;
 import static java.util.Objects.requireNonNull;
 
 import com.google.errorprone.annotations.Immutable;
+import io.confluent.ksql.execution.expression.tree.ColumnReferenceExp;
 import io.confluent.ksql.execution.expression.tree.Expression;
-import io.confluent.ksql.name.ColumnName;
 import io.confluent.ksql.name.SourceName;
 import io.confluent.ksql.parser.properties.with.CreateSourceAsProperties;
+import io.confluent.ksql.schema.ksql.ColumnRef;
+import io.confluent.ksql.util.KsqlException;
 import java.util.Objects;
 import java.util.Optional;
 
@@ -34,7 +36,7 @@ public final class Sink {
   private final SourceName name;
   private final boolean createSink;
   private final CreateSourceAsProperties properties;
-  private final Optional<ColumnName> partitionBy;
+  private final Optional<ColumnRef> partitionBy;
 
   /**
    * Info about the sink of a query.
@@ -51,19 +53,29 @@ public final class Sink {
       final CreateSourceAsProperties properties,
       final Optional<Expression> partitionBy
   ) {
-    final Optional<ColumnName> partitionByExp = partitionBy
-        .map(Object::toString)
-        .map(String::toUpperCase)
-        .map(ColumnName::of);
+    if (partitionBy.isPresent()) {
+      final Expression partitionByExp = partitionBy.get();
+      if (partitionByExp instanceof ColumnReferenceExp) {
+        return new Sink(
+            name,
+            createSink,
+            properties,
+            Optional.of(((ColumnReferenceExp) partitionByExp).getReference())
+        );
+      } else {
+        throw new KsqlException(
+            "Expected partition by to be a valid column but got " + partitionByExp);
+      }
+    }
 
-    return new Sink(name, createSink, properties, partitionByExp);
+    return new Sink(name, createSink, properties, Optional.empty());
   }
 
   private Sink(
       final SourceName name,
       final boolean createSink,
       final CreateSourceAsProperties properties,
-      final Optional<ColumnName> partitionBy
+      final Optional<ColumnRef> partitionBy
   ) {
     this.name = requireNonNull(name, "name");
     this.properties = requireNonNull(properties, "properties");
@@ -83,7 +95,7 @@ public final class Sink {
     return properties;
   }
 
-  public Optional<ColumnName> getPartitionBy() {
+  public Optional<ColumnRef> getPartitionBy() {
     return partitionBy;
   }
 }

--- a/ksql-parser/src/test/java/io/confluent/ksql/parser/KsqlParserTest.java
+++ b/ksql-parser/src/test/java/io/confluent/ksql/parser/KsqlParserTest.java
@@ -77,6 +77,7 @@ import io.confluent.ksql.parser.tree.Statement;
 import io.confluent.ksql.parser.tree.TableElement;
 import io.confluent.ksql.parser.tree.TableElements;
 import io.confluent.ksql.parser.tree.WithinExpression;
+import io.confluent.ksql.schema.ksql.ColumnRef;
 import io.confluent.ksql.schema.ksql.LogicalSchema;
 import io.confluent.ksql.schema.ksql.SqlBaseType;
 import io.confluent.ksql.schema.ksql.types.SqlArray;
@@ -159,7 +160,8 @@ public class KsqlParserTest {
         SourceName.of("ADDRESS"),
         ORDERS_SCHEMA,
         SerdeOption.none(),
-        KeyField.of(ColumnName.of("ORDERTIME"), ORDERS_SCHEMA.findValueColumn("ORDERTIME").get()),
+        KeyField.of(ColumnRef.withoutSource(ColumnName.of("ORDERTIME")),
+            ORDERS_SCHEMA.findValueColumn(ColumnRef.withoutSource(ColumnName.of("ORDERTIME"))).get()),
         new MetadataTimestampExtractionPolicy(),
         ksqlTopicOrders
     );
@@ -178,7 +180,8 @@ public class KsqlParserTest {
         SourceName.of("ITEMID"),
         ORDERS_SCHEMA,
         SerdeOption.none(),
-        KeyField.of(ColumnName.of("ITEMID"), ORDERS_SCHEMA.findValueColumn("ITEMID").get()),
+        KeyField.of(ColumnRef.withoutSource(ColumnName.of("ITEMID")),
+            ORDERS_SCHEMA.findValueColumn(ColumnRef.withoutSource(ColumnName.of("ITEMID"))).get()),
         new MetadataTimestampExtractionPolicy(),
         ksqlTopicItems
     );

--- a/ksql-parser/src/test/java/io/confluent/ksql/parser/SqlFormatterTest.java
+++ b/ksql-parser/src/test/java/io/confluent/ksql/parser/SqlFormatterTest.java
@@ -56,6 +56,7 @@ import io.confluent.ksql.parser.tree.TerminateQuery;
 import io.confluent.ksql.parser.tree.WithinExpression;
 import io.confluent.ksql.properties.with.CommonCreateConfigs;
 import io.confluent.ksql.properties.with.CreateConfigs;
+import io.confluent.ksql.schema.ksql.ColumnRef;
 import io.confluent.ksql.schema.ksql.LogicalSchema;
 import io.confluent.ksql.schema.ksql.types.SqlStruct;
 import io.confluent.ksql.schema.ksql.types.SqlType;
@@ -172,7 +173,9 @@ public class SqlFormatterTest {
         SourceName.of("ADDRESS"),
         ORDERS_SCHEMA,
         SerdeOption.none(),
-        KeyField.of(ColumnName.of("ORDERTIME"), ORDERS_SCHEMA.findValueColumn("ORDERTIME").get()),
+        KeyField.of(
+            ColumnRef.withoutSource(ColumnName.of("ORDERTIME")),
+            ORDERS_SCHEMA.findValueColumn(ColumnRef.withoutSource(ColumnName.of("ORDERTIME"))).get()),
         new MetadataTimestampExtractionPolicy(),
         ksqlTopicOrders
     );
@@ -190,7 +193,9 @@ public class SqlFormatterTest {
         SourceName.of("ITEMID"),
         ITEM_INFO_SCHEMA,
         SerdeOption.none(),
-        KeyField.of(ColumnName.of("ITEMID"), ITEM_INFO_SCHEMA.findValueColumn("ITEMID").get()),
+        KeyField.of(
+            ColumnRef.withoutSource(ColumnName.of("ITEMID")),
+            ITEM_INFO_SCHEMA.findValueColumn(ColumnRef.withoutSource(ColumnName.of("ITEMID"))).get()),
         new MetadataTimestampExtractionPolicy(),
         ksqlTopicItems
     );
@@ -202,7 +207,9 @@ public class SqlFormatterTest {
         SourceName.of("TABLE"),
         tableSchema,
         SerdeOption.none(),
-        KeyField.of(ColumnName.of("TABLE"), tableSchema.findValueColumn("TABLE").get()),
+        KeyField.of(
+            ColumnRef.withoutSource(ColumnName.of("TABLE")),
+            tableSchema.findValueColumn(ColumnRef.withoutSource(ColumnName.of("TABLE"))).get()),
         new MetadataTimestampExtractionPolicy(),
         ksqlTopicItems
     );

--- a/ksql-parser/src/test/java/io/confluent/ksql/parser/properties/with/CreateSourceAsPropertiesTest.java
+++ b/ksql-parser/src/test/java/io/confluent/ksql/parser/properties/with/CreateSourceAsPropertiesTest.java
@@ -25,7 +25,10 @@ import io.confluent.ksql.execution.expression.tree.BooleanLiteral;
 import io.confluent.ksql.execution.expression.tree.IntegerLiteral;
 import io.confluent.ksql.execution.expression.tree.Literal;
 import io.confluent.ksql.execution.expression.tree.StringLiteral;
+import io.confluent.ksql.name.ColumnName;
+import io.confluent.ksql.name.SourceName;
 import io.confluent.ksql.properties.with.CommonCreateConfigs;
+import io.confluent.ksql.schema.ksql.ColumnRef;
 import io.confluent.ksql.util.KsqlException;
 import java.util.Optional;
 import org.junit.Rule;
@@ -66,7 +69,17 @@ public class CreateSourceAsPropertiesTest {
         ImmutableMap.of(CommonCreateConfigs.TIMESTAMP_NAME_PROPERTY, new StringLiteral("ts")));
 
     // Then:
-    assertThat(properties.getTimestampColumnName(), is(Optional.of("ts")));
+    assertThat(properties.getTimestampColumnName(), is(Optional.of(ColumnRef.withoutSource(ColumnName.of("TS")))));
+  }
+
+  @Test
+  public void shouldSetValidQualifiedTimestampName() {
+    // When:
+    final CreateSourceAsProperties properties = CreateSourceAsProperties.from(
+        ImmutableMap.of(CommonCreateConfigs.TIMESTAMP_NAME_PROPERTY, new StringLiteral("a.ts")));
+
+    // Then:
+    assertThat(properties.getTimestampColumnName(), is(Optional.of(ColumnRef.of(SourceName.of("A"), ColumnName.of("TS")))));
   }
 
   @Test

--- a/ksql-parser/src/test/java/io/confluent/ksql/parser/properties/with/CreateSourcePropertiesTest.java
+++ b/ksql-parser/src/test/java/io/confluent/ksql/parser/properties/with/CreateSourcePropertiesTest.java
@@ -28,8 +28,10 @@ import io.confluent.ksql.execution.expression.tree.IntegerLiteral;
 import io.confluent.ksql.execution.expression.tree.Literal;
 import io.confluent.ksql.execution.expression.tree.StringLiteral;
 import io.confluent.ksql.model.WindowType;
+import io.confluent.ksql.name.ColumnName;
 import io.confluent.ksql.properties.with.CommonCreateConfigs;
 import io.confluent.ksql.properties.with.CreateConfigs;
+import io.confluent.ksql.schema.ksql.ColumnRef;
 import io.confluent.ksql.serde.Format;
 import io.confluent.ksql.util.KsqlException;
 import java.time.Duration;
@@ -108,7 +110,7 @@ public class CreateSourcePropertiesTest {
             .build());
 
     // Then:
-    assertThat(properties.getTimestampColumnName(), is(Optional.of("ts")));
+    assertThat(properties.getTimestampColumnName(), is(Optional.of(ColumnRef.withoutSource(ColumnName.of("TS")))));
   }
 
   @Test

--- a/ksql-parser/src/test/java/io/confluent/ksql/parser/tree/ParserModelTest.java
+++ b/ksql-parser/src/test/java/io/confluent/ksql/parser/tree/ParserModelTest.java
@@ -32,6 +32,7 @@ import io.confluent.ksql.execution.expression.tree.StringLiteral;
 import io.confluent.ksql.execution.expression.tree.Type;
 import io.confluent.ksql.execution.windows.KsqlWindowExpression;
 import io.confluent.ksql.execution.windows.TumblingWindowExpression;
+import io.confluent.ksql.name.ColumnName;
 import io.confluent.ksql.name.SourceName;
 import io.confluent.ksql.parser.properties.with.CreateSourceAsProperties;
 import io.confluent.ksql.parser.properties.with.CreateSourceProperties;
@@ -68,7 +69,7 @@ public class ParserModelTest {
 
   private static final ImmutableMap<Class<?>, Object> DEFAULTS = ImmutableMap
       .<Class<?>, Object>builder()
-      .put(ColumnRef.class, ColumnRef.of("bob"))
+      .put(ColumnRef.class, ColumnRef.withoutSource(ColumnName.of("bob")))
       .put(Expression.class, DEFAULT_TYPE)
       .put(KsqlWindowExpression.class, new TumblingWindowExpression(1, TimeUnit.SECONDS))
       .put(Relation.class, DEFAULT_RELATION)

--- a/ksql-parser/src/test/java/io/confluent/ksql/parser/tree/QueryTest.java
+++ b/ksql-parser/src/test/java/io/confluent/ksql/parser/tree/QueryTest.java
@@ -40,7 +40,8 @@ public class QueryTest {
   private static final Select SOME_SELECT = new Select(ImmutableList.of(
       new AllColumns(Optional.empty())));
   private static final Select OTHER_SELECT = new Select(ImmutableList.of(new SingleColumn(
-      new ColumnReferenceExp(ColumnRef.of("Bob")), ColumnName.of("B"))));
+      new ColumnReferenceExp(ColumnRef.withoutSource(ColumnName.of("Bob"))),
+      ColumnName.of("B"))));
   private static final Relation SOME_FROM = new Table(SourceName.of("from"));
   private static final Optional<WindowExpression> SOME_WINDOW = Optional.of(
       mock(WindowExpression.class)

--- a/ksql-rest-app/src/main/java/io/confluent/ksql/rest/entity/SourceDescriptionFactory.java
+++ b/ksql-rest-app/src/main/java/io/confluent/ksql/rest/entity/SourceDescriptionFactory.java
@@ -43,9 +43,10 @@ public final class SourceDescriptionFactory {
         writeQueries,
         EntityUtil.buildSourceSchemaEntity(dataSource.getSchema(), false),
         dataSource.getDataSourceType().getKsqlType(),
-        dataSource.getKeyField().name().map(c -> c.toString(FormatOptions.noEscape())).orElse(""),
+        dataSource.getKeyField().ref().map(c -> c.toString(FormatOptions.noEscape())).orElse(""),
         Optional.ofNullable(dataSource.getTimestampExtractionPolicy())
-            .map(TimestampExtractionPolicy::timestampField).orElse(""),
+            .map(TimestampExtractionPolicy::timestampField)
+            .map(c -> c.toString(FormatOptions.noEscape())).orElse(""),
         (extended
             ? MetricCollectors.getAndFormatStatsFor(
             dataSource.getKafkaTopicName(), false) : ""),

--- a/ksql-rest-app/src/main/java/io/confluent/ksql/rest/server/execution/StaticQueryExecutor.java
+++ b/ksql-rest-app/src/main/java/io/confluent/ksql/rest/server/execution/StaticQueryExecutor.java
@@ -596,10 +596,10 @@ public final class StaticQueryExecutor {
       final SelectExpression select = analysis.getSelectExpressions().get(idx);
       final SqlType type = expressionTypeManager.getExpressionSqlType(select.getExpression());
 
-      if (input.schema.isKeyColumn(select.getName())) {
-        schemaBuilder.keyColumn(select.getName(), type);
+      if (input.schema.isKeyColumn(select.getAlias())) {
+        schemaBuilder.keyColumn(select.getAlias(), type);
       } else {
-        schemaBuilder.valueColumn(select.getName(), type);
+        schemaBuilder.valueColumn(select.getAlias(), type);
       }
     }
     return schemaBuilder;

--- a/ksql-rest-app/src/main/java/io/confluent/ksql/rest/util/EntityUtil.java
+++ b/ksql-rest-app/src/main/java/io/confluent/ksql/rest/util/EntityUtil.java
@@ -56,7 +56,8 @@ public final class EntityUtil {
     }
 
     return columns.stream()
-        .map(col -> SqlTypeWalker.visit(Field.of(col.fullName(), col.type()), new Converter()))
+        .map(col -> SqlTypeWalker.visit(
+            Field.of(col.ref().aliasedFieldName(), col.type()), new Converter()))
         .collect(Collectors.toList());
   }
 

--- a/ksql-rest-app/src/test/java/io/confluent/ksql/rest/entity/SourceDescriptionFactoryTest.java
+++ b/ksql-rest-app/src/test/java/io/confluent/ksql/rest/entity/SourceDescriptionFactoryTest.java
@@ -83,7 +83,7 @@ public class SourceDescriptionFactoryTest {
         SourceName.of("stream"),
         schema,
         SerdeOption.none(),
-        KeyField.of(schema.value().get(0).name(), schema.value().get(0)),
+        KeyField.of(schema.value().get(0).ref(), schema.value().get(0)),
         new MetadataTimestampExtractionPolicy(),
         topic
     );

--- a/ksql-rest-app/src/test/java/io/confluent/ksql/rest/server/TemporaryEngine.java
+++ b/ksql-rest-app/src/test/java/io/confluent/ksql/rest/server/TemporaryEngine.java
@@ -31,6 +31,7 @@ import io.confluent.ksql.metastore.model.KsqlTable;
 import io.confluent.ksql.name.ColumnName;
 import io.confluent.ksql.name.SourceName;
 import io.confluent.ksql.parser.DefaultKsqlParser;
+import io.confluent.ksql.schema.ksql.ColumnRef;
 import io.confluent.ksql.schema.ksql.LogicalSchema;
 import io.confluent.ksql.schema.ksql.types.SqlTypes;
 import io.confluent.ksql.serde.Format;
@@ -111,7 +112,9 @@ public class TemporaryEngine extends ExternalResource {
                 SourceName.of(name),
                 SCHEMA,
                 SerdeOption.none(),
-                KeyField.of(ColumnName.of("val"), SCHEMA.findValueColumn("val").get()),
+                KeyField.of(
+                    ColumnRef.withoutSource(ColumnName.of("val")),
+                    SCHEMA.findValueColumn(ColumnRef.withoutSource(ColumnName.of("val"))).get()),
                 new MetadataTimestampExtractionPolicy(),
                 topic
             );
@@ -123,7 +126,9 @@ public class TemporaryEngine extends ExternalResource {
                 SourceName.of(name),
                 SCHEMA,
                 SerdeOption.none(),
-                KeyField.of(ColumnName.of("val"), SCHEMA.findValueColumn("val").get()),
+                KeyField.of(
+                    ColumnRef.withoutSource(ColumnName.of("val")),
+                    SCHEMA.findValueColumn(ColumnRef.withoutSource(ColumnName.of("val"))).get()),
                 new MetadataTimestampExtractionPolicy(),
                 topic
             );

--- a/ksql-rest-app/src/test/java/io/confluent/ksql/rest/server/resources/KsqlResourceTest.java
+++ b/ksql-rest-app/src/test/java/io/confluent/ksql/rest/server/resources/KsqlResourceTest.java
@@ -2074,7 +2074,7 @@ public class KsqlResourceTest {
               schema,
               SerdeOption.none(),
               KeyField
-                  .of(schema.value().get(0).name(), schema.value().get(0)),
+                  .of(schema.value().get(0).ref(), schema.value().get(0)),
               new MetadataTimestampExtractionPolicy(),
               ksqlTopic
           ));
@@ -2087,7 +2087,7 @@ public class KsqlResourceTest {
               schema,
               SerdeOption.none(),
               KeyField
-                  .of(schema.value().get(0).name(), schema.value().get(0)),
+                  .of(schema.value().get(0).ref(), schema.value().get(0)),
               new MetadataTimestampExtractionPolicy(),
               ksqlTopic
           ));

--- a/ksql-streams/src/main/java/io/confluent/ksql/execution/streams/ExecutionStepFactory.java
+++ b/ksql-streams/src/main/java/io/confluent/ksql/execution/streams/ExecutionStepFactory.java
@@ -46,7 +46,7 @@ import io.confluent.ksql.execution.plan.TableMapValues;
 import io.confluent.ksql.execution.plan.TableSink;
 import io.confluent.ksql.execution.plan.TableTableJoin;
 import io.confluent.ksql.execution.windows.KsqlWindowExpression;
-import io.confluent.ksql.name.ColumnName;
+import io.confluent.ksql.schema.ksql.ColumnRef;
 import io.confluent.ksql.schema.ksql.LogicalSchema;
 import io.confluent.ksql.util.timestamp.TimestampExtractionPolicy;
 import java.time.Duration;
@@ -216,11 +216,10 @@ public final class ExecutionStepFactory {
     );
   }
 
-  @SuppressWarnings("unchecked")
   public static <K> StreamSelectKey<K> streamSelectKey(
       final QueryContext.Stacker stacker,
       final ExecutionStep<KStreamHolder<K>> source,
-      final ColumnName fieldName,
+      final ColumnRef fieldName,
       final boolean updateRowKey
   ) {
     final QueryContext queryContext = stacker.getQueryContext();

--- a/ksql-streams/src/main/java/io/confluent/ksql/execution/streams/SelectValueMapperFactory.java
+++ b/ksql-streams/src/main/java/io/confluent/ksql/execution/streams/SelectValueMapperFactory.java
@@ -78,7 +78,7 @@ public final class SelectValueMapperFactory {
         .buildCodeGenFromParseTree(selectExpression.getExpression(), EXP_TYPE);
 
     return SelectInfo.of(
-        selectExpression.getName(),
+        selectExpression.getAlias(),
         evaluator
     );
   }

--- a/ksql-streams/src/main/java/io/confluent/ksql/execution/streams/StreamSelectKeyBuilder.java
+++ b/ksql-streams/src/main/java/io/confluent/ksql/execution/streams/StreamSelectKeyBuilder.java
@@ -37,7 +37,7 @@ public final class StreamSelectKeyBuilder {
     final LogicalSchema sourceSchema = selectKey.getSources().get(0).getProperties().getSchema();
     final Column keyColumn = sourceSchema.findValueColumn(selectKey.getFieldName())
         .orElseThrow(IllegalArgumentException::new);
-    final int keyIndexInValue = sourceSchema.valueColumnIndex(keyColumn.fullName())
+    final int keyIndexInValue = sourceSchema.valueColumnIndex(keyColumn.ref())
         .orElseThrow(IllegalStateException::new);
     final boolean updateRowKey = selectKey.isUpdateRowKey();
     final KStream<?, GenericRow> kstream = stream.getStream();

--- a/ksql-streams/src/test/java/io/confluent/ksql/execution/streams/AggregateParamsTest.java
+++ b/ksql-streams/src/test/java/io/confluent/ksql/execution/streams/AggregateParamsTest.java
@@ -46,20 +46,20 @@ public class AggregateParamsTest {
       .build();
   private static final FunctionCall AGG0 = new FunctionCall(
       FunctionName.of("AGG0"),
-      ImmutableList.of(new ColumnReferenceExp(ColumnRef.of("ARGUMENT0")))
+      ImmutableList.of(new ColumnReferenceExp(ColumnRef.withoutSource(ColumnName.of("ARGUMENT0"))))
   );
   private static final long INITIAL_VALUE0 = 123;
   private static final FunctionCall AGG1 = new FunctionCall(
       FunctionName.of("AGG1"),
-      ImmutableList.of(new ColumnReferenceExp(ColumnRef.of("ARGUMENT1")))
+      ImmutableList.of(new ColumnReferenceExp(ColumnRef.withoutSource(ColumnName.of("ARGUMENT1"))))
   );
   private static final FunctionCall TABLE_AGG = new FunctionCall(
       FunctionName.of("TABLE_AGG"),
-      ImmutableList.of(new ColumnReferenceExp(ColumnRef.of("ARGUMENT0")))
+      ImmutableList.of(new ColumnReferenceExp(ColumnRef.withoutSource(ColumnName.of("ARGUMENT0"))))
   );
   private static final FunctionCall WINDOW_START = new FunctionCall(
       FunctionName.of("WindowStart"),
-      ImmutableList.of(new ColumnReferenceExp(ColumnRef.of("ARGUMENT0")))
+      ImmutableList.of(new ColumnReferenceExp(ColumnRef.withoutSource(ColumnName.of("ARGUMENT0"))))
   );
   private static final String INITIAL_VALUE1 = "initial";
   private static final List<FunctionCall> FUNCTIONS = ImmutableList.of(AGG0, AGG1);
@@ -90,11 +90,11 @@ public class AggregateParamsTest {
   public void init() {
     when(functionRegistry.getAggregate(same(AGG0.getName().name()), any())).thenReturn(agg0);
     when(agg0Resolved.getInitialValueSupplier()).thenReturn(() -> INITIAL_VALUE0);
-    when(agg0Resolved.getFunctionName()).thenReturn(AGG0.getName().name());
+    when(agg0Resolved.getFunctionName()).thenReturn(AGG0.getName());
     when(agg0.getInstance(any())).thenReturn(agg0Resolved);
     when(functionRegistry.getAggregate(same(AGG1.getName().name()), any())).thenReturn(agg1);
     when(agg1Resolved.getInitialValueSupplier()).thenReturn(() -> INITIAL_VALUE1);
-    when(agg1Resolved.getFunctionName()).thenReturn(AGG1.getName().name());
+    when(agg1Resolved.getFunctionName()).thenReturn(AGG1.getName());
     when(agg1.getInstance(any())).thenReturn(agg1Resolved);
     when(functionRegistry.getAggregate(same(TABLE_AGG.getName().name()), any()))
         .thenReturn(tableAgg);
@@ -104,7 +104,7 @@ public class AggregateParamsTest {
         .thenReturn(windowStart);
     when(windowStart.getInitialValueSupplier()).thenReturn(() -> INITIAL_VALUE0);
     when(windowStart.getInstance(any())).thenReturn(windowStart);
-    when(windowStart.getFunctionName()).thenReturn(WINDOW_START.getName().name());
+    when(windowStart.getFunctionName()).thenReturn(WINDOW_START.getName());
 
     when(udafFactory.create(anyInt(), any())).thenReturn(aggregator);
 

--- a/ksql-streams/src/test/java/io/confluent/ksql/execution/streams/SelectValueMapperFactoryTest.java
+++ b/ksql-streams/src/test/java/io/confluent/ksql/execution/streams/SelectValueMapperFactoryTest.java
@@ -62,8 +62,8 @@ public class SelectValueMapperFactoryTest {
   public void setUp() {
     factory = new SelectValueMapperFactory(codeGenerator);
 
-    when(select_0.getName()).thenReturn(ColumnName.of("field_0"));
-    when(select_1.getName()).thenReturn(ColumnName.of("field_1"));
+    when(select_0.getAlias()).thenReturn(ColumnName.of("field_0"));
+    when(select_1.getAlias()).thenReturn(ColumnName.of("field_1"));
     when(select_1.getExpression()).thenReturn(exp_1);
     when(select_0.getExpression()).thenReturn(exp_0);
     when(select_1.getExpression()).thenReturn(exp_1);

--- a/ksql-streams/src/test/java/io/confluent/ksql/execution/streams/StreamAggregateBuilderTest.java
+++ b/ksql-streams/src/test/java/io/confluent/ksql/execution/streams/StreamAggregateBuilderTest.java
@@ -108,11 +108,11 @@ public class StreamAggregateBuilderTest {
   );
   private static final FunctionCall AGG0 = new FunctionCall(
       FunctionName.of("AGG0"),
-      ImmutableList.of(new ColumnReferenceExp(ColumnRef.of("ARGUMENT0")))
+      ImmutableList.of(new ColumnReferenceExp(ColumnRef.withoutSource(ColumnName.of("ARGUMENT0"))))
   );
   private static final FunctionCall AGG1 = new FunctionCall(
       FunctionName.of("AGG1"),
-      ImmutableList.of(new ColumnReferenceExp(ColumnRef.of("ARGUMENT1")))
+      ImmutableList.of(new ColumnReferenceExp(ColumnRef.withoutSource(ColumnName.of("ARGUMENT1"))))
   );
   private static final List<FunctionCall> FUNCTIONS = ImmutableList.of(AGG0, AGG1);
   private static final QueryContext CTX =

--- a/ksql-streams/src/test/java/io/confluent/ksql/execution/streams/StreamSelectKeyBuilderTest.java
+++ b/ksql-streams/src/test/java/io/confluent/ksql/execution/streams/StreamSelectKeyBuilderTest.java
@@ -37,6 +37,7 @@ import io.confluent.ksql.execution.plan.StreamSelectKey;
 import io.confluent.ksql.name.ColumnName;
 import io.confluent.ksql.name.SourceName;
 import io.confluent.ksql.query.QueryId;
+import io.confluent.ksql.schema.ksql.ColumnRef;
 import io.confluent.ksql.schema.ksql.LogicalSchema;
 import io.confluent.ksql.schema.ksql.PhysicalSchema;
 import io.confluent.ksql.schema.ksql.types.SqlTypes;
@@ -68,7 +69,7 @@ public class StreamSelectKeyBuilderTest {
       .build()
       .withAlias(ALIAS)
       .withMetaAndKeyColsInValue();
-  private static final ColumnName KEY = ColumnName.of("ATL.BOI");
+  private static final ColumnRef KEY = ColumnRef.of(SourceName.of("ATL"), ColumnName.of("BOI"));
 
   @Mock
   private KStream<Struct, GenericRow> kstream;

--- a/ksql-streams/src/test/java/io/confluent/ksql/execution/streams/StreamSourceBuilderTest.java
+++ b/ksql-streams/src/test/java/io/confluent/ksql/execution/streams/StreamSourceBuilderTest.java
@@ -42,6 +42,7 @@ import io.confluent.ksql.execution.plan.LogicalSchemaWithMetaAndKeyFields;
 import io.confluent.ksql.execution.plan.StreamSource;
 import io.confluent.ksql.name.ColumnName;
 import io.confluent.ksql.name.SourceName;
+import io.confluent.ksql.schema.ksql.ColumnRef;
 import io.confluent.ksql.schema.ksql.LogicalSchema;
 import io.confluent.ksql.schema.ksql.PhysicalSchema;
 import io.confluent.ksql.schema.ksql.types.SqlTypes;
@@ -163,7 +164,7 @@ public class StreamSourceBuilderTest {
     when(consumed.withOffsetResetPolicy(any())).thenReturn(consumed);
     when(consumed.withTimestampExtractor(any())).thenReturn(consumed);
     when(extractionPolicy.create(anyInt())).thenReturn(extractor);
-    when(extractionPolicy.timestampField()).thenReturn("field2");
+    when(extractionPolicy.timestampField()).thenReturn(ColumnRef.withoutSource(ColumnName.of("field2")));
     when(queryBuilder.getStreamsBuilder()).thenReturn(streamsBuilder);
     when(streamsBuilder.stream(anyString(), any(Consumed.class))).thenReturn(kStream);
     when(kStream.mapValues(any(ValueMapperWithKey.class))).thenReturn(kStream);

--- a/ksql-streams/src/test/java/io/confluent/ksql/execution/streams/TableAggregateBuilderTest.java
+++ b/ksql-streams/src/test/java/io/confluent/ksql/execution/streams/TableAggregateBuilderTest.java
@@ -91,11 +91,11 @@ public class TableAggregateBuilderTest {
   );
   private static final FunctionCall AGG0 = new FunctionCall(
       FunctionName.of("AGG0"),
-      ImmutableList.of(new ColumnReferenceExp(ColumnRef.of("ARGUMENT0")))
+      ImmutableList.of(new ColumnReferenceExp(ColumnRef.withoutSource(ColumnName.of("ARGUMENT0"))))
   );
   private static final FunctionCall AGG1 = new FunctionCall(
       FunctionName.of("AGG1"),
-      ImmutableList.of(new ColumnReferenceExp(ColumnRef.of("ARGUMENT1")))
+      ImmutableList.of(new ColumnReferenceExp(ColumnRef.withoutSource(ColumnName.of("ARGUMENT1"))))
   );
   private static final List<FunctionCall> FUNCTIONS = ImmutableList.of(AGG0, AGG1);
   private static final QueryContext CTX =


### PR DESCRIPTION
### Description 

This change basically added the following lines to `ColumnName` and saw what broke, then replaced what broke to use `ColumnRef`:
```java
    KsqlPreconditions.checkArgument(!name.contains("."), "expected no aliased fields!");
```
In a future PR (when QuotedIdentifiers are supported, i.e. right after this change) I will remove this precondition check.

I also removed `fullName` because that functionality shouldn't be there. Anywhere using `aliasedFieldName` is just for display purposes.

A few other interesting places to note:
- look at `Column#matches` and `LogicalSchema`, which is the new logic about whether or not a certain column ref matches a column (removed `shouldNotGetColumnByNameIfColumnIsAliasedAndNameIsNot` because that's wrong behavior, we actually hack around it in other parts of the code)
- replaced String with FunctionName in a few more places 
- the group by key that we create still needs to have a `.` sometimes in the column name to be backwards compatible, that is the only code that uses `ColumnName#withoutValidation` (see `SchemaKStream` for where this happens)
- added `PropertiesConfig#getTimestampColumn` to be able to parse out a qualified name in the with clause for timestamp. this is temporary and will be removed in the future to use the real parser so that we can have quoted identifiers in the timestamp extractor

Also note:
- Simplified `CodeGenRunner` and added `CodeGenSpec` to make it easier to work with the new column names (if necessary, I can move this to another PR)
- Pulled out `ParameterType` into its own class
- Shared code with `SqlPredicate` and `CodeGenRunner`

### Testing done 

- `mvn clean install`, there is no functionality change in this PR

### Reviewer checklist
- [ ] Ensure docs are updated if necessary. (eg. if a user visible feature is being added or changed).
- [ ] Ensure relevant issues are linked (description should include text like "Fixes #<issue number>")

