### PR TITLE
fix: fix NPE when printing records with empty value (MINOR)

### DIFF
--- a/ksql-rest-app/src/main/java/io/confluent/ksql/rest/server/resources/streaming/TopicStream.java
+++ b/ksql-rest-app/src/main/java/io/confluent/ksql/rest/server/resources/streaming/TopicStream.java
@@ -68,6 +68,7 @@ public final class TopicStream {
           .stream(records.records(topicName).spliterator(), false)
           .filter(Objects::nonNull)
           .filter(r -> r.value() != null)
+          .filter(r -> r.value().get() != null)
           .filter(r -> r.value().get().length != 0)
           .map((record) -> {
             if (formatter == null) {

--- a/ksql-rest-app/src/main/java/io/confluent/ksql/rest/server/resources/streaming/TopicStream.java
+++ b/ksql-rest-app/src/main/java/io/confluent/ksql/rest/server/resources/streaming/TopicStream.java
@@ -68,6 +68,7 @@ public final class TopicStream {
           .stream(records.records(topicName).spliterator(), false)
           .filter(Objects::nonNull)
           .filter(r -> r.value() != null)
+          .filter(r -> r.value().get().length != 0)
           .map((record) -> {
             if (formatter == null) {
               formatter = getFormatter(record);
@@ -179,7 +180,9 @@ public final class TopicStream {
 
             objectNode.put(SchemaUtil.ROWTIME_NAME.name(), record.timestamp());
             objectNode.put(SchemaUtil.ROWKEY_NAME.name(), key);
-            objectNode.setAll((ObjectNode) jsonNode);
+            if (jsonNode != null) {
+              objectNode.setAll((ObjectNode) jsonNode);
+            }
 
             final StringWriter stringWriter = new StringWriter();
             objectMapper.writeValue(stringWriter, objectNode);

--- a/ksql-rest-app/src/main/java/io/confluent/ksql/rest/server/resources/streaming/TopicStream.java
+++ b/ksql-rest-app/src/main/java/io/confluent/ksql/rest/server/resources/streaming/TopicStream.java
@@ -180,9 +180,7 @@ public final class TopicStream {
 
             objectNode.put(SchemaUtil.ROWTIME_NAME.name(), record.timestamp());
             objectNode.put(SchemaUtil.ROWKEY_NAME.name(), key);
-            if (jsonNode != null) {
-              objectNode.setAll((ObjectNode) jsonNode);
-            }
+            objectNode.setAll((ObjectNode) jsonNode);
 
             final StringWriter stringWriter = new StringWriter();
             objectMapper.writeValue(stringWriter, objectNode);

--- a/ksql-rest-app/src/test/java/io/confluent/ksql/rest/server/resources/streaming/TopicStreamTest.java
+++ b/ksql-rest-app/src/test/java/io/confluent/ksql/rest/server/resources/streaming/TopicStreamTest.java
@@ -170,12 +170,24 @@ public class TopicStreamTest {
   }
 
   @Test
+  public void shouldFilterNullBytesValues() {
+    // Given:
+    replay(schemaRegistryClient);
+
+    // When:
+    final List<String> formatted = getFormattedRecord(new Bytes(null));
+
+    // Then:
+    assertThat(formatted, empty());
+  }
+
+  @Test
   public void shouldFilterEmptyValues() {
     // Given:
     replay(schemaRegistryClient);
 
     // When:
-    final List<String> formatted = getFormattedRecord(Bytes.EMPTY);
+    final List<String> formatted = getFormattedRecord(new Bytes(Bytes.EMPTY));
 
     // Then:
     assertThat(formatted, empty());
@@ -201,15 +213,15 @@ public class TopicStreamTest {
   }
 
   private Result getFormattedResult(final byte[] data) {
-    final List<String> formatted = getFormattedRecord(data);
+    final List<String> formatted = getFormattedRecord(new Bytes(data));
     assertThat("Only expect one line", formatted, hasSize(1));
 
     return new Result(formatter.getFormat(), formatted.get(0));
   }
 
-  private List<String> getFormattedRecord(final byte[] data) {
+  private List<String> getFormattedRecord(final Bytes data) {
     final ConsumerRecord<String, Bytes> record = new ConsumerRecord<>(
-        TOPIC_NAME, 1, 1, "key", new Bytes(data));
+        TOPIC_NAME, 1, 1, "key", data);
 
     final ConsumerRecords<String, Bytes> records = new ConsumerRecords<>(
         ImmutableMap.of(new TopicPartition(TOPIC_NAME, 1),

--- a/ksql-rest-app/src/test/java/io/confluent/ksql/rest/server/resources/streaming/TopicStreamTest.java
+++ b/ksql-rest-app/src/test/java/io/confluent/ksql/rest/server/resources/streaming/TopicStreamTest.java
@@ -53,11 +53,15 @@ import org.junit.Test;
 
 public class TopicStreamTest {
 
+  private static final String TOPIC_NAME = "some-topic";
+
   private SchemaRegistryClient schemaRegistryClient;
+  private RecordFormatter formatter;
 
   @Before
   public void setUp() {
     schemaRegistryClient = mock(SchemaRegistryClient.class);
+    formatter = new RecordFormatter(schemaRegistryClient, TOPIC_NAME);
   }
 
   @Test
@@ -83,7 +87,7 @@ public class TopicStreamTest {
     final byte[] avroData = serializeAvroRecord(avroRecord);
 
     // When:
-    final Result result = getFormatter(avroData);
+    final Result result = getFormattedResult(avroData);
 
     // Then:
     assertThat(result.format, is(Format.AVRO));
@@ -97,7 +101,7 @@ public class TopicStreamTest {
     final String notAvro = "test-data";
 
     // When:
-    final Result result = getFormatter(notAvro);
+    final Result result = getFormattedResult(notAvro);
 
     // Then:
     assertThat(result.format, is(not(Format.AVRO)));
@@ -114,7 +118,7 @@ public class TopicStreamTest {
         "}";
 
     // When:
-    final Result result = getFormatter(json);
+    final Result result = getFormattedResult(json);
 
     // Then:
     assertThat(result.format, is(Format.JSON));
@@ -133,7 +137,7 @@ public class TopicStreamTest {
         "}";
 
     // When:
-    final Result result = getFormatter(notJson);
+    final Result result = getFormattedResult(notJson);
 
     // Then:
     assertThat(result.format, is(not(Format.JSON)));
@@ -147,7 +151,7 @@ public class TopicStreamTest {
     final String stringValue = "v1";
 
     // When:
-    final Result result = getFormatter(stringValue);
+    final Result result = getFormattedResult(stringValue);
 
     // Then:
     assertThat(result.format, is(Format.STRING));
@@ -155,17 +159,26 @@ public class TopicStreamTest {
 
   @Test
   public void shouldFilterNullValues() {
+    // Given:
     replay(schemaRegistryClient);
 
-    final ConsumerRecord<String, Bytes> record = new ConsumerRecord<>(
-        "some-topic", 1, 1, "key", null);
-    final RecordFormatter formatter =
-        new RecordFormatter(schemaRegistryClient, "some-topic");
-    final ConsumerRecords<String, Bytes> records = new ConsumerRecords<>(
-        ImmutableMap.of(new TopicPartition("some-topic", 1),
-            ImmutableList.of(record)));
+    // When:
+    final List<String> formatted = getFormattedRecord(null);
 
-    assertThat(formatter.format(records), empty());
+    // Then:
+    assertThat(formatted, empty());
+  }
+
+  @Test
+  public void shouldFilterEmptyValues() {
+    // Given:
+    replay(schemaRegistryClient);
+
+    // When:
+    final List<String> formatted = getFormattedRecord(Bytes.EMPTY);
+
+    // Then:
+    assertThat(formatted, empty());
   }
 
   @Test
@@ -174,34 +187,35 @@ public class TopicStreamTest {
         SimpleDateFormat.getDateTimeInstance(3, 1, Locale.getDefault());
 
     final ConsumerRecord<String, Bytes> record = new ConsumerRecord<>(
-        "some-topic", 1, 1, "key", null);
+        TOPIC_NAME, 1, 1, "key", null);
 
     final String formatted =
         Format.STRING.maybeGetFormatter(
-            "some-topic", record, null, dateFormat).get().print(record);
+            TOPIC_NAME, record, null, dateFormat).get().print(record);
 
     assertThat(formatted, endsWith(", key , NULL\n"));
   }
 
-  private Result getFormatter(final String data) {
-    return getFormatter(data.getBytes(StandardCharsets.UTF_8));
+  private Result getFormattedResult(final String data) {
+    return getFormattedResult(data.getBytes(StandardCharsets.UTF_8));
   }
 
-  private Result getFormatter(final byte[] data) {
-    final ConsumerRecord<String, Bytes> record = new ConsumerRecord<>(
-        "some-topic", 1, 1, "key", new Bytes(data));
-
-    final RecordFormatter formatter =
-        new RecordFormatter(schemaRegistryClient, "some-topic");
-
-    final ConsumerRecords<String, Bytes> records = new ConsumerRecords<>(
-        ImmutableMap.of(new TopicPartition("some-topic", 1),
-                        ImmutableList.of(record)));
-
-    final List<String> formatted = formatter.format(records);
+  private Result getFormattedResult(final byte[] data) {
+    final List<String> formatted = getFormattedRecord(data);
     assertThat("Only expect one line", formatted, hasSize(1));
 
     return new Result(formatter.getFormat(), formatted.get(0));
+  }
+
+  private List<String> getFormattedRecord(final byte[] data) {
+    final ConsumerRecord<String, Bytes> record = new ConsumerRecord<>(
+        TOPIC_NAME, 1, 1, "key", new Bytes(data));
+
+    final ConsumerRecords<String, Bytes> records = new ConsumerRecords<>(
+        ImmutableMap.of(new TopicPartition(TOPIC_NAME, 1),
+            ImmutableList.of(record)));
+
+    return formatter.format(records);
   }
 
   @SuppressWarnings("SameParameterValue")


### PR DESCRIPTION
### Description 

Fixes https://github.com/confluentinc/ksql/issues/3450.

Currently when `print topic` encounters a JSON record with an empty value, a NullPointerException is thrown:
```
[2019-10-03 10:17:52,063] ERROR Exception encountered while writing to output stream (io.confluent.ksql.rest.server.resources.streaming.TopicStreamWriter:122)
java.lang.NullPointerException
        at com.fasterxml.jackson.databind.node.ObjectNode.setAll(ObjectNode.java:408)
        at io.confluent.ksql.rest.server.resources.streaming.TopicStream$Format$3$1.print(TopicStream.java:182)
        at io.confluent.ksql.rest.server.resources.streaming.TopicStream$RecordFormatter.lambda$format$1(TopicStream.java:76)
        at java.util.stream.ReferencePipeline$3$1.accept(ReferencePipeline.java:193)
        at java.util.stream.ReferencePipeline$2$1.accept(ReferencePipeline.java:175)
        at java.util.stream.ReferencePipeline$2$1.accept(ReferencePipeline.java:175)
        at java.util.Iterator.forEachRemaining(Iterator.java:116)
        at java.util.Spliterators$IteratorSpliterator.forEachRemaining(Spliterators.java:1801)
        at java.util.stream.AbstractPipeline.copyInto(AbstractPipeline.java:481)
        at java.util.stream.AbstractPipeline.wrapAndCopyInto(AbstractPipeline.java:471)
        at java.util.stream.ReduceOps$ReduceOp.evaluateSequential(ReduceOps.java:708)
        at java.util.stream.AbstractPipeline.evaluate(AbstractPipeline.java:234)
        at java.util.stream.ReferencePipeline.collect(ReferencePipeline.java:499)
        at io.confluent.ksql.rest.server.resources.streaming.TopicStream$RecordFormatter.format(TopicStream.java:83)
        at io.confluent.ksql.rest.server.resources.streaming.TopicStreamWriter.write(TopicStreamWriter.java:100)
        at org.glassfish.jersey.message.internal.StreamingOutputProvider.writeTo(StreamingOutputProvider.java:79)
        at org.glassfish.jersey.message.internal.StreamingOutputProvider.writeTo(StreamingOutputProvider.java:61)
        at org.glassfish.jersey.message.internal.WriterInterceptorExecutor$TerminalWriterInterceptor.invokeWriteTo(WriterInterceptorExecutor.java:266)
        at org.glassfish.jersey.message.internal.WriterInterceptorExecutor$TerminalWriterInterceptor.aroundWriteTo(WriterInterceptorExecutor.java:251)
        at org.glassfish.jersey.message.internal.WriterInterceptorExecutor.proceed(WriterInterceptorExecutor.java:163)
        at org.glassfish.jersey.server.internal.JsonWithPaddingInterceptor.aroundWriteTo(JsonWithPaddingInterceptor.java:109)
        at org.glassfish.jersey.message.internal.WriterInterceptorExecutor.proceed(WriterInterceptorExecutor.java:163)
        at org.glassfish.jersey.server.internal.MappableExceptionWrapperInterceptor.aroundWriteTo(MappableExceptionWrapperInterceptor.java:85)
        at org.glassfish.jersey.message.internal.WriterInterceptorExecutor.proceed(WriterInterceptorExecutor.java:163)
        at org.glassfish.jersey.message.internal.MessageBodyFactory.writeTo(MessageBodyFactory.java:1135)
        at org.glassfish.jersey.server.ServerRuntime$Responder.writeResponse(ServerRuntime.java:662)
        at org.glassfish.jersey.server.ServerRuntime$Responder.processResponse(ServerRuntime.java:395)
        at org.glassfish.jersey.server.ServerRuntime$Responder.process(ServerRuntime.java:385)
        at org.glassfish.jersey.server.ServerRuntime$1.run(ServerRuntime.java:280)
        at org.glassfish.jersey.internal.Errors$1.call(Errors.java:272)
        at org.glassfish.jersey.internal.Errors$1.call(Errors.java:268)
        at org.glassfish.jersey.internal.Errors.process(Errors.java:316)
        at org.glassfish.jersey.internal.Errors.process(Errors.java:298)
        at org.glassfish.jersey.internal.Errors.process(Errors.java:268)
        at org.glassfish.jersey.process.internal.RequestScope.runInScope(RequestScope.java:289)
        at org.glassfish.jersey.server.ServerRuntime.process(ServerRuntime.java:256)
        at org.glassfish.jersey.server.ApplicationHandler.handle(ApplicationHandler.java:703)
        at org.glassfish.jersey.servlet.WebComponent.serviceImpl(WebComponent.java:416)
        at org.glassfish.jersey.servlet.ServletContainer.serviceImpl(ServletContainer.java:409)
        at org.glassfish.jersey.servlet.ServletContainer.doFilter(ServletContainer.java:584)
        at org.glassfish.jersey.servlet.ServletContainer.doFilter(ServletContainer.java:525)
        at org.glassfish.jersey.servlet.ServletContainer.doFilter(ServletContainer.java:462)
        at org.eclipse.jetty.servlet.ServletHandler$CachedChain.doFilter(ServletHandler.java:1610)
        at org.eclipse.jetty.servlet.ServletHandler.doHandle(ServletHandler.java:540)
        at org.eclipse.jetty.server.handler.ScopedHandler.nextHandle(ScopedHandler.java:255)
        at org.eclipse.jetty.server.session.SessionHandler.doHandle(SessionHandler.java:1700)
        at org.eclipse.jetty.server.handler.ScopedHandler.nextHandle(ScopedHandler.java:255)
        at org.eclipse.jetty.server.handler.ContextHandler.doHandle(ContextHandler.java:1345)
        at org.eclipse.jetty.server.handler.ScopedHandler.nextScope(ScopedHandler.java:203)
        at org.eclipse.jetty.servlet.ServletHandler.doScope(ServletHandler.java:480)
        at org.eclipse.jetty.server.session.SessionHandler.doScope(SessionHandler.java:1667)
        at org.eclipse.jetty.server.handler.ScopedHandler.nextScope(ScopedHandler.java:201)
        at org.eclipse.jetty.server.handler.ContextHandler.doScope(ContextHandler.java:1247)
        at org.eclipse.jetty.server.handler.ScopedHandler.handle(ScopedHandler.java:144)
        at org.eclipse.jetty.server.handler.HandlerCollection.handle(HandlerCollection.java:152)
        at org.eclipse.jetty.server.handler.StatisticsHandler.handle(StatisticsHandler.java:174)
        at org.eclipse.jetty.server.handler.ContextHandlerCollection.handle(ContextHandlerCollection.java:220)
        at org.eclipse.jetty.server.handler.gzip.GzipHandler.handle(GzipHandler.java:753)
        at org.eclipse.jetty.server.handler.HandlerWrapper.handle(HandlerWrapper.java:132)
        at org.eclipse.jetty.server.Server.handle(Server.java:505)
        at org.eclipse.jetty.server.HttpChannel.handle(HttpChannel.java:370)
        at org.eclipse.jetty.server.HttpConnection.onFillable(HttpConnection.java:267)
        at org.eclipse.jetty.io.AbstractConnection$ReadCallback.succeeded(AbstractConnection.java:305)
        at org.eclipse.jetty.io.FillInterest.fillable(FillInterest.java:103)
        at org.eclipse.jetty.io.ChannelEndPoint$2.run(ChannelEndPoint.java:117)
        at org.eclipse.jetty.util.thread.strategy.EatWhatYouKill.runTask(EatWhatYouKill.java:333)
        at org.eclipse.jetty.util.thread.strategy.EatWhatYouKill.doProduce(EatWhatYouKill.java:310)
        at org.eclipse.jetty.util.thread.strategy.EatWhatYouKill.tryProduce(EatWhatYouKill.java:168)
        at org.eclipse.jetty.util.thread.strategy.EatWhatYouKill.produce(EatWhatYouKill.java:132)
        at org.eclipse.jetty.util.thread.QueuedThreadPool.runJob(QueuedThreadPool.java:698)
        at org.eclipse.jetty.util.thread.QueuedThreadPool$Runner.run(QueuedThreadPool.java:804)
        at java.lang.Thread.run(Thread.java:748)
```

This PR fixes the NPE by skipping the record, as we currently do for records with null value.

### Testing done 

Unit test + manual.

### Reviewer checklist
- [ ] Ensure docs are updated if necessary. (eg. if a user visible feature is being added or changed).
- [ ] Ensure relevant issues are linked (description should include text like "Fixes #<issue number>")

