### PR TITLE
fix: Kafka Streams does not like negative time

### DIFF
--- a/ksql-engine/src/main/java/io/confluent/ksql/materialization/ks/KsMaterializedWindowTable.java
+++ b/ksql-engine/src/main/java/io/confluent/ksql/materialization/ks/KsMaterializedWindowTable.java
@@ -55,7 +55,7 @@ class KsMaterializedWindowTable implements MaterializedWindowedTable {
 
       final Instant lower = windowStartBounds.hasLowerBound()
           ? windowStartBounds.lowerEndpoint()
-          : Instant.ofEpochMilli(Long.MIN_VALUE);
+          : Instant.ofEpochMilli(0);
 
       final Instant upper = windowStartBounds.hasUpperBound()
           ? windowStartBounds.upperEndpoint()

--- a/ksql-engine/src/test/java/io/confluent/ksql/materialization/ks/KsMaterializedWindowTableTest.java
+++ b/ksql-engine/src/test/java/io/confluent/ksql/materialization/ks/KsMaterializedWindowTableTest.java
@@ -291,7 +291,7 @@ public class KsMaterializedWindowTableTest {
     // Then:
     verify(tableStore).fetch(
         A_KEY,
-        Instant.ofEpochMilli(Long.MIN_VALUE),
+        Instant.ofEpochMilli(0L),
         Instant.ofEpochMilli(Long.MAX_VALUE)
     );
   }


### PR DESCRIPTION
### Description 

KS does not like negative, so switch 'all windows' lower time boundary to `0L` rather than `Long.MIN_VALUE`.

### Testing done 

Manual and usual

### Reviewer checklist
- [ ] Ensure docs are updated if necessary. (eg. if a user visible feature is being added or changed).
- [ ] Ensure relevant issues are linked (description should include text like "Fixes #<issue number>")

