### PR TITLE
feat(static): switch partial datetime parser to use UTC by default

### DIFF
--- a/ksql-common/src/main/java/io/confluent/ksql/util/timestamp/PartialStringToTimestampParser.java
+++ b/ksql-common/src/main/java/io/confluent/ksql/util/timestamp/PartialStringToTimestampParser.java
@@ -83,7 +83,7 @@ public class PartialStringToTimestampParser {
 
   private static ZoneId parseTimezone(final String timezone) {
     if (timezone.trim().isEmpty()) {
-      return ZoneId.systemDefault();
+      return ZoneId.of("+0000");
     }
 
     try {

--- a/ksql-common/src/test/java/io/confluent/ksql/util/timestamp/PartialStringToTimestampParserTest.java
+++ b/ksql-common/src/test/java/io/confluent/ksql/util/timestamp/PartialStringToTimestampParserTest.java
@@ -28,7 +28,7 @@ import org.junit.rules.ExpectedException;
 public class PartialStringToTimestampParserTest {
 
   private static final StringToTimestampParser FULL_PARSER =
-      new StringToTimestampParser(KsqlConstants.DATE_TIME_PATTERN);
+      new StringToTimestampParser(KsqlConstants.DATE_TIME_PATTERN + "X");
 
   @Rule
   public final ExpectedException expectedException = ExpectedException.none();
@@ -43,44 +43,44 @@ public class PartialStringToTimestampParserTest {
   @Test
   public void shouldParseYear() {
     // When:
-    assertThat(parser.parse("2017"), is(fullParse("2017-01-01T00:00:00.000")));
+    assertThat(parser.parse("2017"), is(fullParse("2017-01-01T00:00:00.000+0000")));
   }
 
   @Test
   public void shouldParseYearMonth() {
     // When:
-    assertThat(parser.parse("2020-02"), is(fullParse("2020-02-01T00:00:00.000")));
+    assertThat(parser.parse("2020-02"), is(fullParse("2020-02-01T00:00:00.000+0000")));
   }
 
   @Test
   public void shouldParseFullDate() {
     // When:
-    assertThat(parser.parse("2020-01-02"), is(fullParse("2020-01-02T00:00:00.000")));
-    assertThat(parser.parse("2020-01-02T"), is(fullParse("2020-01-02T00:00:00.000")));
+    assertThat(parser.parse("2020-01-02"), is(fullParse("2020-01-02T00:00:00.000+0000")));
+    assertThat(parser.parse("2020-01-02T"), is(fullParse("2020-01-02T00:00:00.000+0000")));
   }
 
   @Test
   public void shouldParseDateWithHour() {
     // When:
-    assertThat(parser.parse("2020-12-02T13"), is(fullParse("2020-12-02T13:00:00.000")));
+    assertThat(parser.parse("2020-12-02T13"), is(fullParse("2020-12-02T13:00:00.000+0000")));
   }
 
   @Test
   public void shouldParseDateWithHourMinute() {
     // When:
-    assertThat(parser.parse("2020-12-02T13:59"), is(fullParse("2020-12-02T13:59:00.000")));
+    assertThat(parser.parse("2020-12-02T13:59"), is(fullParse("2020-12-02T13:59:00.000+0000")));
   }
 
   @Test
   public void shouldParseDateWithHourMinuteSecond() {
     // When:
-    assertThat(parser.parse("2020-12-02T13:59:58"), is(fullParse("2020-12-02T13:59:58.000")));
+    assertThat(parser.parse("2020-12-02T13:59:58"), is(fullParse("2020-12-02T13:59:58.000+0000")));
   }
 
   @Test
   public void shouldParseFullDateTime() {
     // When:
-    assertThat(parser.parse("2020-12-02T13:59:58.123"), is(fullParse("2020-12-02T13:59:58.123")));
+    assertThat(parser.parse("2020-12-02T13:59:58.123"), is(fullParse("2020-12-02T13:59:58.123+0000")));
   }
 
   @Test

--- a/ksql-functional-tests/src/test/resources/rest-query-validation-tests/materialized-aggregate-static-queries.json
+++ b/ksql-functional-tests/src/test/resources/rest-query-validation-tests/materialized-aggregate-static-queries.json
@@ -464,7 +464,7 @@
       "statements": [
         "CREATE STREAM INPUT (IGNORED INT) WITH (kafka_topic='test_topic', value_format='JSON');",
         "CREATE TABLE AGGREGATE AS SELECT COUNT(1) AS COUNT FROM INPUT WINDOW TUMBLING(SIZE 1 SECOND) GROUP BY ROWKEY;",
-        "SELECT * FROM AGGREGATE WHERE ROWKEY='10' AND WindowStart='2020-02-23T23:45:12.000+0000';"
+        "SELECT * FROM AGGREGATE WHERE ROWKEY='10' AND WindowStart='2020-02-23T23:45:12.000';"
       ],
       "inputs": [
         {"topic": "test_topic", "timestamp": 1582501512456, "key": "11", "value": {}},


### PR DESCRIPTION

### Description 

With this change the ROWTIME rewriter and static queries will use UTC by default for datetime strings, if not explicit timezone is provided.


### Testing done 

USual

### Reviewer checklist
- [ ] Ensure docs are updated if necessary. (eg. if a user visible feature is being added or changed).
- [ ] Ensure relevant issues are linked (description should include text like "Fixes #<issue number>")

