### PR TITLE
fix: race condition in KsStateStore

### DIFF
--- a/ksql-engine/src/main/java/io/confluent/ksql/materialization/ks/KsStateStore.java
+++ b/ksql-engine/src/main/java/io/confluent/ksql/materialization/ks/KsStateStore.java
@@ -74,6 +74,11 @@ class KsStateStore {
     try {
       return kafkaStreams.store(stateStoreName, queryableStoreType);
     } catch (final Exception e) {
+      final State state = kafkaStreams.state();
+      if (state != State.RUNNING) {
+        throw new NotRunningException("The query was not in a running state. state: " + state);
+      }
+
       throw new MaterializationException("State store currently unavailable: " + stateStoreName, e);
     }
   }
@@ -87,11 +92,6 @@ class KsStateStore {
       }
 
       Thread.yield();
-    }
-
-    final State state = kafkaStreams.state();
-    if (state != State.RUNNING) {
-      throw new NotRunningException("The query was not in a running state. state: " + state);
     }
   }
 }

--- a/ksql-engine/src/test/java/io/confluent/ksql/materialization/ks/KsStateStoreTest.java
+++ b/ksql-engine/src/test/java/io/confluent/ksql/materialization/ks/KsStateStoreTest.java
@@ -128,32 +128,17 @@ public class KsStateStoreTest {
   }
 
   @Test
-  public void shouldThrowIfNotRunningAfterRebalanced() {
+  public void shouldThrowIfNotRunningAfterFailedToGetStore() {
     // Given:
     when(kafkaStreams.state())
-        .thenReturn(State.REBALANCING)
-        .thenReturn(State.REBALANCING)
+        .thenReturn(State.RUNNING)
         .thenReturn(State.NOT_RUNNING);
+
+    when(kafkaStreams.store(any(), any())).thenThrow(new IllegalStateException());
 
     // When:
     expectedException.expect(NotRunningException.class);
     expectedException.expectMessage("The query was not in a running state. state: NOT_RUNNING");
-
-    // When:
-    store.store(QueryableStoreTypes.sessionStore());
-  }
-
-  @Test
-  public void shouldThrowIfPendingShutdown() {
-    // Given:
-    when(kafkaStreams.state())
-        .thenReturn(State.REBALANCING)
-        .thenReturn(State.REBALANCING)
-        .thenReturn(State.PENDING_SHUTDOWN);
-
-    // When:
-    expectedException.expect(NotRunningException.class);
-    expectedException.expectMessage("The query was not in a running state. state: PENDING_SHUTDOWN");
 
     // When:
     store.store(QueryableStoreTypes.sessionStore());


### PR DESCRIPTION
### Description 

Addressing outstanding comment in previous PR: https://github.com/confluentinc/ksql/pull/3340#discussion_r323964589 and https://github.com/confluentinc/ksql/pull/3340#discussion_r323966550

Unfortunately, it is not possible to avoid the `Thread.yield` call by use of the state listener on `KafkaStreams` as this can only be a single listener and can only be set when the instance is created. 

Hence this PR only addresses the second bit, about the race condition. 

### Testing done 

usual

### Reviewer checklist
- [ ] Ensure docs are updated if necessary. (eg. if a user visible feature is being added or changed).
- [ ] Ensure relevant issues are linked (description should include text like "Fixes #<issue number>")

