### PR TITLE
refactor: clean up structured package

### DIFF
--- a/ksql-engine/src/main/java/io/confluent/ksql/planner/plan/AggregateNode.java
+++ b/ksql-engine/src/main/java/io/confluent/ksql/planner/plan/AggregateNode.java
@@ -218,8 +218,7 @@ public class AggregateNode extends PlanNode {
     final SchemaKGroupedStream schemaKGroupedStream = aggregateArgExpanded.groupBy(
         valueFormat,
         internalGroupByColumns,
-        groupByContext,
-        builder
+        groupByContext
     );
 
     final List<FunctionCall> functionsWithInternalIdentifiers = functionList.stream()
@@ -267,11 +266,7 @@ public class AggregateNode extends PlanNode {
         .map(internalSchema::resolveToInternal);
 
     if (havingExpression.isPresent()) {
-      aggregated = aggregated.filter(
-          havingExpression.get(),
-          contextStacker.push(FILTER_OP_NAME),
-          builder
-      );
+      aggregated = aggregated.filter(havingExpression.get(), contextStacker.push(FILTER_OP_NAME));
     }
 
     final List<SelectExpression> finalSelects = internalSchema

--- a/ksql-engine/src/main/java/io/confluent/ksql/planner/plan/DataSourceNode.java
+++ b/ksql-engine/src/main/java/io/confluent/ksql/planner/plan/DataSourceNode.java
@@ -145,8 +145,8 @@ public class DataSourceNode extends PlanNode {
     return schemaKStream.toTable(
         dataSource.getKsqlTopic().getKeyFormat(),
         dataSource.getKsqlTopic().getValueFormat(),
-        reduceContextStacker,
-        builder);
+        reduceContextStacker
+    );
   }
 
   interface SchemaKStreamFactory {

--- a/ksql-engine/src/main/java/io/confluent/ksql/planner/plan/FilterNode.java
+++ b/ksql-engine/src/main/java/io/confluent/ksql/planner/plan/FilterNode.java
@@ -81,8 +81,7 @@ public class FilterNode extends PlanNode {
     return getSource().buildStream(builder)
         .filter(
             getPredicate(),
-            builder.buildNodeContext(getId().toString()),
-            builder
+            builder.buildNodeContext(getId().toString())
         );
   }
 }

--- a/ksql-engine/src/main/java/io/confluent/ksql/planner/plan/JoinNode.java
+++ b/ksql-engine/src/main/java/io/confluent/ksql/planner/plan/JoinNode.java
@@ -355,8 +355,7 @@ public class JoinNode extends PlanNode {
               joinNode.withinExpression.get().joinWindow(),
               getFormatForSource(joinNode.left),
               getFormatForSource(joinNode.right),
-              contextStacker,
-              builder
+              contextStacker
           );
         case OUTER:
           return leftStream.outerJoin(
@@ -366,8 +365,7 @@ public class JoinNode extends PlanNode {
               joinNode.withinExpression.get().joinWindow(),
               getFormatForSource(joinNode.left),
               getFormatForSource(joinNode.right),
-              contextStacker,
-              builder
+              contextStacker
           );
         case INNER:
           return leftStream.join(
@@ -377,8 +375,7 @@ public class JoinNode extends PlanNode {
               joinNode.withinExpression.get().joinWindow(),
               getFormatForSource(joinNode.left),
               getFormatForSource(joinNode.right),
-              contextStacker,
-              builder
+              contextStacker
           );
         default:
           throw new KsqlException("Invalid join type encountered: " + joinNode.joinType);
@@ -417,8 +414,7 @@ public class JoinNode extends PlanNode {
               joinNode.schema,
               getJoinedKeyField(joinNode.left.getAlias(), leftStream.getKeyField()),
               getFormatForSource(joinNode.left),
-              contextStacker,
-              builder
+              contextStacker
           );
 
         case INNER:
@@ -427,8 +423,7 @@ public class JoinNode extends PlanNode {
               joinNode.schema,
               getJoinedKeyField(joinNode.left.getAlias(), leftStream.getKeyField()),
               getFormatForSource(joinNode.left),
-              contextStacker,
-              builder
+              contextStacker
           );
         case OUTER:
           throw new KsqlException("Full outer joins between streams and tables are not supported.");

--- a/ksql-engine/src/main/java/io/confluent/ksql/planner/plan/KsqlStructuredDataOutputNode.java
+++ b/ksql-engine/src/main/java/io/confluent/ksql/planner/plan/KsqlStructuredDataOutputNode.java
@@ -133,8 +133,7 @@ public class KsqlStructuredDataOutputNode extends OutputNode {
         getSchema(),
         getKsqlTopic().getValueFormat(),
         serdeOptions,
-        contextStacker,
-        builder
+        contextStacker
     );
   }
 

--- a/ksql-engine/src/main/java/io/confluent/ksql/structured/SchemaKGroupedTable.java
+++ b/ksql-engine/src/main/java/io/confluent/ksql/structured/SchemaKGroupedTable.java
@@ -25,7 +25,6 @@ import io.confluent.ksql.execution.plan.ExecutionStep;
 import io.confluent.ksql.execution.plan.Formats;
 import io.confluent.ksql.execution.plan.TableAggregate;
 import io.confluent.ksql.execution.streams.ExecutionStepFactory;
-import io.confluent.ksql.execution.streams.MaterializedFactory;
 import io.confluent.ksql.function.FunctionRegistry;
 import io.confluent.ksql.function.KsqlAggregateFunction;
 import io.confluent.ksql.metastore.model.KeyField;
@@ -33,7 +32,6 @@ import io.confluent.ksql.name.FunctionName;
 import io.confluent.ksql.parser.tree.WindowExpression;
 import io.confluent.ksql.schema.ksql.LogicalSchema;
 import io.confluent.ksql.serde.KeyFormat;
-import io.confluent.ksql.serde.KeySerde;
 import io.confluent.ksql.serde.SerdeOption;
 import io.confluent.ksql.serde.ValueFormat;
 import io.confluent.ksql.util.KsqlConfig;
@@ -51,42 +49,18 @@ public class SchemaKGroupedTable extends SchemaKGroupedStream {
   SchemaKGroupedTable(
       final ExecutionStep<KGroupedTable<Struct, GenericRow>> sourceTableStep,
       final KeyFormat keyFormat,
-      final KeySerde<Struct> keySerde,
       final KeyField keyField,
       final List<SchemaKStream> sourceSchemaKStreams,
       final KsqlConfig ksqlConfig,
       final FunctionRegistry functionRegistry
   ) {
-    this(
-        sourceTableStep,
-        keyFormat,
-        keySerde,
-        keyField,
-        sourceSchemaKStreams,
-        ksqlConfig,
-        functionRegistry,
-        MaterializedFactory.create(ksqlConfig));
-  }
-
-  SchemaKGroupedTable(
-      final ExecutionStep<KGroupedTable<Struct, GenericRow>> sourceTableStep,
-      final KeyFormat keyFormat,
-      final KeySerde<Struct> keySerde,
-      final KeyField keyField,
-      final List<SchemaKStream> sourceSchemaKStreams,
-      final KsqlConfig ksqlConfig,
-      final FunctionRegistry functionRegistry,
-      final MaterializedFactory materializedFactory
-  ) {
     super(
         null,
         keyFormat,
-        keySerde,
         keyField,
         sourceSchemaKStreams,
         ksqlConfig,
-        functionRegistry,
-        materializedFactory
+        functionRegistry
     );
 
     this.sourceTableStep = Objects.requireNonNull(sourceTableStep, "sourceTableStep");
@@ -141,7 +115,6 @@ public class SchemaKGroupedTable extends SchemaKGroupedStream {
     return new SchemaKTable<>(
         step,
         keyFormat,
-        keySerde,
         keyField,
         sourceSchemaKStreams,
         SchemaKStream.Type.AGGREGATE,

--- a/ksql-engine/src/test/java/io/confluent/ksql/planner/plan/AggregateNodeTest.java
+++ b/ksql-engine/src/test/java/io/confluent/ksql/planner/plan/AggregateNodeTest.java
@@ -116,13 +116,6 @@ public class AggregateNodeTest {
   private final ProcessingLogContext processingLogContext = ProcessingLogContext.create();
   private final QueryId queryId = new QueryId("queryid");
 
-  @Before
-  public void setUp()  {
-    when(keySerde.rebind(any(WindowInfo.class))).thenReturn(windowedKeySerde);
-    when(reboundKeySerde.rebind(any(WindowInfo.class))).thenReturn(windowedKeySerde);
-    when(keySerde.rebind(any(PersistenceSchema.class))).thenReturn(reboundKeySerde);
-  }
-
   @Test
   public void shouldBuildSourceNode() {
     // When:

--- a/ksql-engine/src/test/java/io/confluent/ksql/planner/plan/FilterNodeTest.java
+++ b/ksql-engine/src/test/java/io/confluent/ksql/planner/plan/FilterNodeTest.java
@@ -56,7 +56,7 @@ public class FilterNodeTest {
     when(sourceNode.buildStream(any()))
         .thenReturn(schemaKStream);
     when(sourceNode.getNodeOutputType()).thenReturn(DataSourceType.KSTREAM);
-    when(schemaKStream.filter(any(), any(), any()))
+    when(schemaKStream.filter(any(), any()))
         .thenReturn(schemaKStream);
 
     when(ksqlStreamBuilder.buildNodeContext(nodeId.toString())).thenReturn(stacker);
@@ -71,6 +71,6 @@ public class FilterNodeTest {
 
     // Then:
     verify(sourceNode).buildStream(ksqlStreamBuilder);
-    verify(schemaKStream).filter(predicate, stacker, ksqlStreamBuilder);
+    verify(schemaKStream).filter(predicate, stacker);
   }
 }

--- a/ksql-engine/src/test/java/io/confluent/ksql/planner/plan/JoinNodeTest.java
+++ b/ksql-engine/src/test/java/io/confluent/ksql/planner/plan/JoinNodeTest.java
@@ -25,7 +25,6 @@ import static org.hamcrest.Matchers.is;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyBoolean;
 import static org.mockito.ArgumentMatchers.eq;
-import static org.mockito.ArgumentMatchers.same;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
@@ -53,11 +52,9 @@ import io.confluent.ksql.schema.ksql.Column;
 import io.confluent.ksql.schema.ksql.ColumnRef;
 import io.confluent.ksql.schema.ksql.FormatOptions;
 import io.confluent.ksql.schema.ksql.LogicalSchema;
-import io.confluent.ksql.schema.ksql.PersistenceSchema;
 import io.confluent.ksql.schema.ksql.types.SqlTypes;
 import io.confluent.ksql.serde.Format;
 import io.confluent.ksql.serde.FormatInfo;
-import io.confluent.ksql.serde.KeySerde;
 import io.confluent.ksql.serde.ValueFormat;
 import io.confluent.ksql.services.KafkaTopicClient;
 import io.confluent.ksql.services.ServiceContext;
@@ -80,7 +77,6 @@ import org.apache.kafka.clients.admin.TopicDescription;
 import org.apache.kafka.common.Node;
 import org.apache.kafka.common.TopicPartitionInfo;
 import org.apache.kafka.common.utils.Utils;
-import org.apache.kafka.connect.data.Struct;
 import org.apache.kafka.streams.StreamsBuilder;
 import org.apache.kafka.streams.Topology;
 import org.apache.kafka.streams.TopologyDescription;
@@ -170,10 +166,6 @@ public class JoinNodeTest {
   private FunctionRegistry functionRegistry;
   @Mock
   private KafkaTopicClient mockKafkaTopicClient;
-  @Mock
-  private KeySerde<Struct> keySerde;
-  @Mock
-  private KeySerde<Struct> reboundKeySerde;
 
   @Before
   public void setUp() {
@@ -191,9 +183,6 @@ public class JoinNodeTest {
     when(ksqlStreamBuilder.buildNodeContext(any())).thenAnswer(inv ->
         new QueryContext.Stacker()
             .push(inv.getArgument(0).toString()));
-    when(ksqlStreamBuilder.buildKeySerde(any(), any(), any())).thenReturn(keySerde);
-
-    when(keySerde.rebind(any(PersistenceSchema.class))).thenReturn(reboundKeySerde);
 
     when(left.getAlias()).thenReturn(LEFT_ALIAS);
     when(right.getAlias()).thenReturn(RIGHT_ALIAS);
@@ -363,8 +352,7 @@ public class JoinNodeTest {
         eq(WITHIN_EXPRESSION.get().joinWindow()),
         eq(VALUE_FORMAT),
         eq(OTHER_FORMAT),
-        eq(CONTEXT_STACKER),
-        same(ksqlStreamBuilder)
+        eq(CONTEXT_STACKER)
     );
   }
 
@@ -395,8 +383,7 @@ public class JoinNodeTest {
         eq(WITHIN_EXPRESSION.get().joinWindow()),
         eq(VALUE_FORMAT),
         eq(OTHER_FORMAT),
-        eq(CONTEXT_STACKER),
-        same(ksqlStreamBuilder)
+        eq(CONTEXT_STACKER)
     );
   }
 
@@ -427,8 +414,7 @@ public class JoinNodeTest {
         eq(WITHIN_EXPRESSION.get().joinWindow()),
         eq(VALUE_FORMAT),
         eq(OTHER_FORMAT),
-        eq(CONTEXT_STACKER),
-        same(ksqlStreamBuilder)
+        eq(CONTEXT_STACKER)
     );
   }
 
@@ -568,8 +554,7 @@ public class JoinNodeTest {
         eq(JOIN_SCHEMA),
         eq(leftJoinField),
         eq(VALUE_FORMAT),
-        eq(CONTEXT_STACKER),
-        same(ksqlStreamBuilder)
+        eq(CONTEXT_STACKER)
     );
   }
 
@@ -598,8 +583,7 @@ public class JoinNodeTest {
         eq(JOIN_SCHEMA),
         eq(leftJoinField),
         eq(VALUE_FORMAT),
-        eq(CONTEXT_STACKER),
-        same(ksqlStreamBuilder)
+        eq(CONTEXT_STACKER)
     );
   }
 
@@ -628,8 +612,7 @@ public class JoinNodeTest {
         eq(JOIN_SCHEMA),
         eq(leftJoinField),
         eq(VALUE_FORMAT),
-        eq(CONTEXT_STACKER),
-        same(ksqlStreamBuilder)
+        eq(CONTEXT_STACKER)
     );
   }
 

--- a/ksql-engine/src/test/java/io/confluent/ksql/planner/plan/KsqlStructuredDataOutputNodeTest.java
+++ b/ksql-engine/src/test/java/io/confluent/ksql/planner/plan/KsqlStructuredDataOutputNodeTest.java
@@ -129,11 +129,11 @@ public class KsqlStructuredDataOutputNodeTest {
 
     when(sourceStream.withKeyField(any()))
         .thenReturn(resultStream);
-    when(resultStream.into(any(), any(), any(), any(), any(), any()))
+    when(resultStream.into(any(), any(), any(), any(), any()))
         .thenReturn((SchemaKStream) sinkStream);
     when(resultStream.selectKey(any(), anyBoolean(), any()))
         .thenReturn((SchemaKStream) resultWithKeySelected);
-    when(resultWithKeySelected.into(any(), any(), any(), any(), any(), any()))
+    when(resultWithKeySelected.into(any(), any(), any(), any(), any()))
         .thenReturn((SchemaKStream) sinkStreamWithKeySelected);
 
     when(ksqlStreamBuilder.buildNodeContext(any())).thenAnswer(inv ->
@@ -318,7 +318,7 @@ public class KsqlStructuredDataOutputNodeTest {
     outputNode.buildStream(ksqlStreamBuilder);
 
     // Then:
-    verify(resultStream).into(any(), any(), eq(valueFormat), any(), any(), any());
+    verify(resultStream).into(any(), any(), eq(valueFormat), any(), any());
   }
 
   @Test
@@ -332,8 +332,7 @@ public class KsqlStructuredDataOutputNodeTest {
         eq(SCHEMA),
         eq(JSON_FORMAT),
         eq(SerdeOption.none()),
-        stackerCaptor.capture(),
-        same(ksqlStreamBuilder)
+        stackerCaptor.capture()
     );
     assertThat(
         stackerCaptor.getValue().getQueryContext().getContext(),

--- a/ksql-engine/src/test/java/io/confluent/ksql/structured/SchemaKGroupedStreamTest.java
+++ b/ksql-engine/src/test/java/io/confluent/ksql/structured/SchemaKGroupedStreamTest.java
@@ -29,7 +29,6 @@ import io.confluent.ksql.execution.expression.tree.FunctionCall;
 import io.confluent.ksql.execution.plan.ExecutionStep;
 import io.confluent.ksql.execution.plan.Formats;
 import io.confluent.ksql.execution.streams.ExecutionStepFactory;
-import io.confluent.ksql.execution.streams.MaterializedFactory;
 import io.confluent.ksql.execution.windows.KsqlWindowExpression;
 import io.confluent.ksql.execution.windows.SessionWindowExpression;
 import io.confluent.ksql.function.FunctionRegistry;
@@ -91,12 +90,6 @@ public class SchemaKGroupedStreamTest {
   @Mock
   private WindowExpression windowExp;
   @Mock
-  private MaterializedFactory materializedFactory;
-  @Mock
-  private KeySerde<Struct> keySerde;
-  @Mock
-  private KeySerde<Windowed<Struct>> windowedKeySerde;
-  @Mock
   private ExecutionStep sourceStep;
   @Mock
   private KeyFormat keyFormat;
@@ -116,16 +109,13 @@ public class SchemaKGroupedStreamTest {
     schemaGroupedStream = new SchemaKGroupedStream(
         sourceStep,
         keyFormat,
-        keySerde,
         keyField,
         sourceStreams,
         config,
-        functionRegistry,
-        materializedFactory
+        functionRegistry
     );
     when(windowExp.getKsqlWindowExpression()).thenReturn(KSQL_WINDOW_EXP);
     when(config.getBoolean(KsqlConfig.KSQL_WINDOWED_SESSION_KEY_LEGACY_CONFIG)).thenReturn(false);
-    when(keySerde.rebind(any(WindowInfo.class))).thenReturn(windowedKeySerde);
   }
 
   @Test

--- a/ksql-engine/src/test/java/io/confluent/ksql/structured/SchemaKGroupedTableTest.java
+++ b/ksql-engine/src/test/java/io/confluent/ksql/structured/SchemaKGroupedTableTest.java
@@ -18,7 +18,6 @@ package io.confluent.ksql.structured;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.is;
-import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
@@ -30,7 +29,6 @@ import io.confluent.ksql.execution.expression.tree.FunctionCall;
 import io.confluent.ksql.execution.plan.ExecutionStep;
 import io.confluent.ksql.execution.plan.Formats;
 import io.confluent.ksql.execution.streams.ExecutionStepFactory;
-import io.confluent.ksql.execution.streams.MaterializedFactory;
 import io.confluent.ksql.function.InternalFunctionRegistry;
 import io.confluent.ksql.metastore.model.KeyField;
 import io.confluent.ksql.name.ColumnName;
@@ -43,18 +41,12 @@ import io.confluent.ksql.schema.ksql.types.SqlTypes;
 import io.confluent.ksql.serde.Format;
 import io.confluent.ksql.serde.FormatInfo;
 import io.confluent.ksql.serde.KeyFormat;
-import io.confluent.ksql.serde.KeySerde;
 import io.confluent.ksql.serde.SerdeOption;
 import io.confluent.ksql.serde.ValueFormat;
 import io.confluent.ksql.util.KsqlConfig;
 import io.confluent.ksql.util.KsqlException;
 import java.util.Collections;
 import java.util.Optional;
-import org.apache.kafka.connect.data.Struct;
-import org.apache.kafka.streams.kstream.KGroupedTable;
-import org.apache.kafka.streams.kstream.KTable;
-import org.apache.kafka.streams.kstream.Materialized;
-import org.apache.kafka.streams.kstream.ValueMapper;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
@@ -87,16 +79,14 @@ public class SchemaKGroupedTableTest {
 
   private final KsqlConfig ksqlConfig = new KsqlConfig(Collections.emptyMap());
   private final InternalFunctionRegistry functionRegistry = new InternalFunctionRegistry();
-  private final MaterializedFactory materializedFactory = mock(MaterializedFactory.class);
-  private final QueryContext.Stacker queryContext = new QueryContext.Stacker().push("node");
+  private final QueryContext.Stacker queryContext
+      = new QueryContext.Stacker().push("node");
   private final ValueFormat valueFormat = ValueFormat.of(FormatInfo.of(Format.JSON));
   private final KeyFormat keyFormat = KeyFormat.nonWindowed(FormatInfo.of(Format.JSON));
 
   @Rule
   public final ExpectedException expectedException = ExpectedException.none();
 
-  @Mock
-  private KeySerde<Struct> keySerde;
   @Mock
   private KsqlQueryBuilder queryBuilder;
 
@@ -116,7 +106,7 @@ public class SchemaKGroupedTableTest {
     // Given:
     final WindowExpression windowExp = mock(WindowExpression.class);
 
-    final SchemaKGroupedTable groupedTable = buildSchemaKGroupedTable(materializedFactory);
+    final SchemaKGroupedTable groupedTable = buildSchemaKGroupedTable();
 
     // Then:
     expectedException.expect(KsqlException.class);
@@ -138,7 +128,7 @@ public class SchemaKGroupedTableTest {
   @Test
   public void shouldFailUnsupportedAggregateFunction() {
     // Given:
-    final SchemaKGroupedTable kGroupedTable = buildSchemaKGroupedTable(materializedFactory);
+    final SchemaKGroupedTable kGroupedTable = buildSchemaKGroupedTable();
 
     // Then:
     expectedException.expect(KsqlException.class);
@@ -158,26 +148,23 @@ public class SchemaKGroupedTableTest {
     );
   }
 
-  private SchemaKGroupedTable buildSchemaKGroupedTable(
-      final MaterializedFactory materializedFactory
-  ) {
+  private SchemaKGroupedTable buildSchemaKGroupedTable() {
     return new SchemaKGroupedTable(
         buildSourceTableStep(IN_SCHEMA),
         keyFormat,
-        keySerde,
         KeyField.of(
             IN_SCHEMA.value().get(0).ref(),
             IN_SCHEMA.value().get(0)),
         Collections.emptyList(),
         ksqlConfig,
-        functionRegistry,
-        materializedFactory);
+        functionRegistry
+    );
   }
 
   @Test
   public void shouldBuildStepForAggregate() {
     // Given:
-    final SchemaKGroupedTable kGroupedTable = buildSchemaKGroupedTable(materializedFactory);
+    final SchemaKGroupedTable kGroupedTable = buildSchemaKGroupedTable();
 
     final SchemaKTable result = kGroupedTable.aggregate(
         AGG_SCHEMA,
@@ -210,7 +197,7 @@ public class SchemaKGroupedTableTest {
   @Test
   public void shouldReturnKTableWithOutputSchema() {
     // Given:
-    final SchemaKGroupedTable groupedTable = buildSchemaKGroupedTable(materializedFactory);
+    final SchemaKGroupedTable groupedTable = buildSchemaKGroupedTable();
 
     // When:
     final SchemaKTable result = groupedTable.aggregate(
@@ -231,7 +218,7 @@ public class SchemaKGroupedTableTest {
   @Test(expected = IllegalArgumentException.class)
   public void shouldThrowOnColumnCountMismatch() {
     // Given:
-    final SchemaKGroupedTable groupedTable = buildSchemaKGroupedTable(materializedFactory);
+    final SchemaKGroupedTable groupedTable = buildSchemaKGroupedTable();
 
     // When:
     groupedTable.aggregate(

--- a/ksql-engine/src/test/java/io/confluent/ksql/structured/SchemaKTableTest.java
+++ b/ksql-engine/src/test/java/io/confluent/ksql/structured/SchemaKTableTest.java
@@ -86,7 +86,6 @@ import io.confluent.ksql.serde.Format;
 import io.confluent.ksql.serde.FormatInfo;
 import io.confluent.ksql.serde.GenericRowSerDe;
 import io.confluent.ksql.serde.KeyFormat;
-import io.confluent.ksql.serde.KeySerde;
 import io.confluent.ksql.serde.SerdeOption;
 import io.confluent.ksql.serde.ValueFormat;
 import io.confluent.ksql.execution.streams.StreamsFactories;
@@ -162,10 +161,6 @@ public class SchemaKTableTest {
   private PlanBuilder planBuilder;
 
   @Mock
-  private KeySerde<Struct> keySerde;
-  @Mock
-  private KeySerde<Struct> reboundKeySerde;
-  @Mock
   private KsqlQueryBuilder queryBuilder;
   @Mock
   private KeySerdeFactory<Struct> keySerdeFactory;
@@ -195,7 +190,6 @@ public class SchemaKTableTest {
     secondSchemaKTable = buildSchemaKTableForJoin(secondKsqlTable, secondKTable);
     joinSchema = getJoinSchema(ksqlTable.getSchema(), secondKsqlTable.getSchema());
 
-    when(keySerde.rebind(any(PersistenceSchema.class))).thenReturn(reboundKeySerde);
     when(queryBuilder.getQueryId()).thenReturn(new QueryId("query"));
     when(queryBuilder.getKsqlConfig()).thenReturn(ksqlConfig);
     when(queryBuilder.getProcessingLogContext()).thenReturn(processingLogContext);
@@ -229,7 +223,6 @@ public class SchemaKTableTest {
     return new SchemaKTable(
         buildSourceStep(schema, kTable),
         keyFormat,
-        keySerde,
         keyField,
         new ArrayList<>(),
         Type.SOURCE,
@@ -242,7 +235,6 @@ public class SchemaKTableTest {
     return new SchemaKTable(
         buildSourceStep(logicalPlan.getTheSourceNode().getSchema(), kTable),
         keyFormat,
-        keySerde,
         logicalPlan.getTheSourceNode().getKeyField(),
         new ArrayList<>(),
         SchemaKStream.Type.SOURCE,
@@ -372,8 +364,7 @@ public class SchemaKTableTest {
     // When:
     final SchemaKTable filteredSchemaKStream = initialSchemaKTable.filter(
         filterNode.getPredicate(),
-        childContextStacker,
-        queryBuilder
+        childContextStacker
     );
 
     // Then:
@@ -403,8 +394,7 @@ public class SchemaKTableTest {
     // When:
     final SchemaKTable filteredSchemaKTable = initialSchemaKTable.filter(
         filterNode.getPredicate(),
-        childContextStacker,
-        queryBuilder
+        childContextStacker
     );
 
     // Then:
@@ -433,8 +423,7 @@ public class SchemaKTableTest {
     // When:
     final SchemaKTable filteredSchemaKStream = initialSchemaKTable.filter(
         filterNode.getPredicate(),
-        childContextStacker,
-        queryBuilder
+        childContextStacker
     );
 
     // Then:
@@ -462,8 +451,8 @@ public class SchemaKTableTest {
     final SchemaKGroupedStream groupedSchemaKTable = initialSchemaKTable.groupBy(
         valueFormat,
         groupByExpressions,
-        childContextStacker,
-        queryBuilder);
+        childContextStacker
+    );
 
     // Then:
     assertThat(groupedSchemaKTable, instanceOf(SchemaKGroupedTable.class));
@@ -484,8 +473,8 @@ public class SchemaKTableTest {
     final SchemaKGroupedStream groupedSchemaKTable = initialSchemaKTable.groupBy(
         valueFormat,
         groupByExpressions,
-        childContextStacker,
-        queryBuilder);
+        childContextStacker
+    );
 
     // Then:
     assertThat(
@@ -523,7 +512,7 @@ public class SchemaKTableTest {
 
     // When:
     final SchemaKGroupedStream result =
-        schemaKTable.groupBy(valueFormat, groupByExpressions, childContextStacker, queryBuilder);
+        schemaKTable.groupBy(valueFormat, groupByExpressions, childContextStacker);
 
     // Then:
     ((SchemaKGroupedTable) result).getSourceTableStep().build(planBuilder);
@@ -549,7 +538,6 @@ public class SchemaKTableTest {
     initialSchemaKTable = new SchemaKTable(
         buildSourceStep(logicalPlan.getTheSourceNode().getSchema(), mockKTable),
         keyFormat,
-        keySerde,
         logicalPlan.getTheSourceNode().getKeyField(),
         new ArrayList<>(),
         SchemaKStream.Type.SOURCE,
@@ -561,7 +549,7 @@ public class SchemaKTableTest {
 
     // Call groupBy and extract the captured mapper
     final SchemaKGroupedStream result = initialSchemaKTable.groupBy(
-        valueFormat, groupByExpressions, childContextStacker, queryBuilder);
+        valueFormat, groupByExpressions, childContextStacker);
     ((SchemaKGroupedTable) result).getSourceTableStep().build(planBuilder);
     verify(mockKTable, mockKGroupedTable);
     final KeyValueMapper keySelector = capturedKeySelector.getValue();
@@ -816,7 +804,7 @@ public class SchemaKTableTest {
 
     // When:
     final SchemaKGroupedStream result = initialSchemaKTable
-        .groupBy(valueFormat, groupByExprs, childContextStacker, queryBuilder);
+        .groupBy(valueFormat, groupByExprs, childContextStacker);
 
     // Then:
     assertThat(result.getKeyField(),
@@ -851,7 +839,6 @@ public class SchemaKTableTest {
     initialSchemaKTable = new SchemaKTable(
         buildSourceStep(logicalPlan.getTheSourceNode().getSchema(), kTable),
         keyFormat,
-        keySerde,
         logicalPlan.getTheSourceNode().getKeyField(),
         new ArrayList<>(),
         SchemaKStream.Type.SOURCE,


### PR DESCRIPTION
### Description 

Clean up unused code from the structured package after moving
that functionality to the execution plan builders:
   - cleans up key serdes from schemakX
   - cleans up unused parameters from schemakX interfaces
   - cleans up unit tests

