### PR TITLE
refactor: split up streamsource step

### DIFF
--- a/ksql-engine/src/main/java/io/confluent/ksql/structured/SchemaKStream.java
+++ b/ksql-engine/src/main/java/io/confluent/ksql/structured/SchemaKStream.java
@@ -29,6 +29,7 @@ import io.confluent.ksql.execution.context.QueryLoggerUtil;
 import io.confluent.ksql.execution.ddl.commands.KsqlTopic;
 import io.confluent.ksql.execution.expression.tree.ColumnReferenceExp;
 import io.confluent.ksql.execution.expression.tree.Expression;
+import io.confluent.ksql.execution.plan.AbstractStreamSource;
 import io.confluent.ksql.execution.plan.ExecutionStep;
 import io.confluent.ksql.execution.plan.ExecutionStepProperties;
 import io.confluent.ksql.execution.plan.Formats;
@@ -46,6 +47,7 @@ import io.confluent.ksql.execution.plan.StreamSource;
 import io.confluent.ksql.execution.plan.StreamStreamJoin;
 import io.confluent.ksql.execution.plan.StreamTableJoin;
 import io.confluent.ksql.execution.plan.StreamToTable;
+import io.confluent.ksql.execution.plan.WindowedStreamSource;
 import io.confluent.ksql.execution.streams.ExecutionStepFactory;
 import io.confluent.ksql.execution.streams.StreamSourceBuilder;
 import io.confluent.ksql.execution.util.StructKeyUtil;
@@ -75,7 +77,6 @@ import java.util.stream.Collectors;
 import org.apache.kafka.connect.data.Struct;
 import org.apache.kafka.streams.Topology.AutoOffsetReset;
 import org.apache.kafka.streams.kstream.JoinWindows;
-import org.apache.kafka.streams.kstream.Windowed;
 
 // CHECKSTYLE_RULES.OFF: ClassDataAbstractionCoupling
 @SuppressWarnings("OptionalUsedAsFieldOrParameterType")
@@ -103,7 +104,7 @@ public class SchemaKStream<K> {
       final KsqlQueryBuilder builder,
       final KeyFormat keyFormat,
       final KeySerde<K> keySerde,
-      final StreamSource<K> streamSource,
+      final AbstractStreamSource<KStreamHolder<K>> streamSource,
       final KeyField keyField) {
     return new SchemaKStream<>(
         streamSource,
@@ -128,7 +129,7 @@ public class SchemaKStream<K> {
   ) {
     final KsqlTopic topic = dataSource.getKsqlTopic();
     if (topic.getKeyFormat().isWindowed()) {
-      final StreamSource<Windowed<Struct>> step = streamSourceWindowed(
+      final WindowedStreamSource step = streamSourceWindowed(
           contextStacker,
           schemaWithMetaAndKeyFields,
           topic.getKafkaTopicName(),
@@ -144,7 +145,7 @@ public class SchemaKStream<K> {
           step,
           keyField);
     } else {
-      final StreamSource<Struct> step = streamSource(
+      final StreamSource step = streamSource(
           contextStacker,
           schemaWithMetaAndKeyFields,
           topic.getKafkaTopicName(),

--- a/ksql-execution/src/main/java/io/confluent/ksql/execution/plan/AbstractStreamSource.java
+++ b/ksql-execution/src/main/java/io/confluent/ksql/execution/plan/AbstractStreamSource.java
@@ -1,0 +1,125 @@
+/*
+ * Copyright 2019 Confluent Inc.
+ *
+ * Licensed under the Confluent Community License (the "License"); you may not use
+ * this file except in compliance with the License.  You may obtain a copy of the
+ * License at
+ *
+ * http://www.confluent.io/confluent-community-license
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package io.confluent.ksql.execution.plan;
+
+import com.google.common.annotations.VisibleForTesting;
+import io.confluent.ksql.name.SourceName;
+import io.confluent.ksql.schema.ksql.LogicalSchema;
+import io.confluent.ksql.util.timestamp.TimestampExtractionPolicy;
+import java.util.Collections;
+import java.util.List;
+import java.util.Objects;
+import java.util.Optional;
+import org.apache.kafka.streams.Topology.AutoOffsetReset;
+
+public abstract class AbstractStreamSource<K> implements ExecutionStep<K> {
+  private final ExecutionStepProperties properties;
+  private final String topicName;
+  private final Formats formats;
+  private final TimestampExtractionPolicy timestampPolicy;
+  private final int timestampIndex;
+  private final Optional<AutoOffsetReset> offsetReset;
+  private final LogicalSchema sourceSchema;
+
+  public static LogicalSchemaWithMetaAndKeyFields getSchemaWithMetaAndKeyFields(
+      final SourceName alias,
+      final LogicalSchema schema) {
+    return LogicalSchemaWithMetaAndKeyFields.fromOriginal(alias, schema);
+  }
+
+  @VisibleForTesting
+  public AbstractStreamSource(
+      final ExecutionStepProperties properties,
+      final String topicName,
+      final Formats formats,
+      final TimestampExtractionPolicy timestampPolicy,
+      final int timestampIndex,
+      final Optional<AutoOffsetReset> offsetReset,
+      final LogicalSchema sourceSchema) {
+    this.properties = Objects.requireNonNull(properties, "properties");
+    this.topicName = Objects.requireNonNull(topicName, "topicName");
+    this.formats = Objects.requireNonNull(formats, "formats");
+    this.timestampPolicy = Objects.requireNonNull(timestampPolicy, "timestampPolicy");
+    this.timestampIndex = timestampIndex;
+    this.offsetReset = Objects.requireNonNull(offsetReset, "offsetReset");
+    this.sourceSchema = Objects.requireNonNull(sourceSchema, "sourceSchema");
+  }
+
+  @Override
+  public ExecutionStepProperties getProperties() {
+    return properties;
+  }
+
+  @Override
+  public List<ExecutionStep<?>> getSources() {
+    return Collections.emptyList();
+  }
+
+  public LogicalSchema getSourceSchema() {
+    return sourceSchema;
+  }
+
+  public Optional<AutoOffsetReset> getOffsetReset() {
+    return offsetReset;
+  }
+
+  public int getTimestampIndex() {
+    return timestampIndex;
+  }
+
+  public TimestampExtractionPolicy getTimestampPolicy() {
+    return timestampPolicy;
+  }
+
+  public Formats getFormats() {
+    return formats;
+  }
+
+  public String getTopicName() {
+    return topicName;
+  }
+
+  @Override
+  public boolean equals(final Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    final AbstractStreamSource that = (AbstractStreamSource) o;
+    return Objects.equals(properties, that.properties)
+        && Objects.equals(topicName, that.topicName)
+        && Objects.equals(formats, that.formats)
+        && Objects.equals(timestampPolicy, that.timestampPolicy)
+        && Objects.equals(timestampIndex, that.timestampIndex)
+        && Objects.equals(offsetReset, that.offsetReset)
+        && Objects.equals(sourceSchema, that.sourceSchema);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(
+        properties,
+        topicName,
+        formats,
+        timestampPolicy,
+        timestampIndex,
+        offsetReset,
+        sourceSchema
+    );
+  }
+}

--- a/ksql-execution/src/main/java/io/confluent/ksql/execution/plan/PlanBuilder.java
+++ b/ksql-execution/src/main/java/io/confluent/ksql/execution/plan/PlanBuilder.java
@@ -42,7 +42,10 @@ public interface PlanBuilder {
 
   <K> KStreamHolder<K> visitStreamSink(StreamSink<K> streamSink);
 
-  <K> KStreamHolder<K> visitStreamSource(StreamSource<K> streamSource);
+  KStreamHolder<Struct> visitStreamSource(StreamSource streamSource);
+
+  KStreamHolder<Windowed<Struct>> visitWindowedStreamSource(
+      WindowedStreamSource windowedStreamSource);
 
   <K> KStreamHolder<K> visitStreamStreamJoin(StreamStreamJoin<K> streamStreamJoin);
 

--- a/ksql-execution/src/main/java/io/confluent/ksql/execution/plan/WindowedStreamSource.java
+++ b/ksql-execution/src/main/java/io/confluent/ksql/execution/plan/WindowedStreamSource.java
@@ -1,8 +1,9 @@
 /*
  * Copyright 2019 Confluent Inc.
  *
- * Licensed under the Confluent Community License; you may not use this file
- * except in compliance with the License.  You may obtain a copy of the License at
+ * Licensed under the Confluent Community License (the "License"); you may not use
+ * this file except in compliance with the License.  You may obtain a copy of the
+ * License at
  *
  * http://www.confluent.io/confluent-community-license
  *
@@ -14,16 +15,16 @@
 
 package io.confluent.ksql.execution.plan;
 
-import com.google.errorprone.annotations.Immutable;
 import io.confluent.ksql.schema.ksql.LogicalSchema;
 import io.confluent.ksql.util.timestamp.TimestampExtractionPolicy;
 import java.util.Optional;
 import org.apache.kafka.connect.data.Struct;
 import org.apache.kafka.streams.Topology.AutoOffsetReset;
+import org.apache.kafka.streams.kstream.Windowed;
 
-@Immutable
-public final class StreamSource extends AbstractStreamSource<KStreamHolder<Struct>> {
-  public StreamSource(
+public final class WindowedStreamSource
+    extends AbstractStreamSource<KStreamHolder<Windowed<Struct>>> {
+  public WindowedStreamSource(
       final ExecutionStepProperties properties,
       final String topicName,
       final Formats formats,
@@ -43,7 +44,7 @@ public final class StreamSource extends AbstractStreamSource<KStreamHolder<Struc
   }
 
   @Override
-  public KStreamHolder<Struct> build(final PlanBuilder builder) {
-    return builder.visitStreamSource(this);
+  public KStreamHolder<Windowed<Struct>> build(final PlanBuilder builder) {
+    return builder.visitWindowedStreamSource(this);
   }
 }

--- a/ksql-streams/src/main/java/io/confluent/ksql/execution/streams/ExecutionStepFactory.java
+++ b/ksql-streams/src/main/java/io/confluent/ksql/execution/streams/ExecutionStepFactory.java
@@ -45,6 +45,7 @@ import io.confluent.ksql.execution.plan.TableGroupBy;
 import io.confluent.ksql.execution.plan.TableMapValues;
 import io.confluent.ksql.execution.plan.TableSink;
 import io.confluent.ksql.execution.plan.TableTableJoin;
+import io.confluent.ksql.execution.plan.WindowedStreamSource;
 import io.confluent.ksql.execution.windows.KsqlWindowExpression;
 import io.confluent.ksql.schema.ksql.ColumnRef;
 import io.confluent.ksql.schema.ksql.LogicalSchema;
@@ -57,7 +58,6 @@ import org.apache.kafka.streams.Topology.AutoOffsetReset;
 import org.apache.kafka.streams.kstream.JoinWindows;
 import org.apache.kafka.streams.kstream.KGroupedStream;
 import org.apache.kafka.streams.kstream.KGroupedTable;
-import org.apache.kafka.streams.kstream.Windowed;
 
 // CHECKSTYLE_RULES.OFF: ClassDataAbstractionCoupling
 public final class ExecutionStepFactory {
@@ -65,7 +65,7 @@ public final class ExecutionStepFactory {
   private ExecutionStepFactory() {
   }
 
-  public static StreamSource<Windowed<Struct>> streamSourceWindowed(
+  public static WindowedStreamSource streamSourceWindowed(
       final QueryContext.Stacker stacker,
       final LogicalSchemaWithMetaAndKeyFields schema,
       final String topicName,
@@ -75,7 +75,7 @@ public final class ExecutionStepFactory {
       final Optional<AutoOffsetReset> offsetReset
   ) {
     final QueryContext queryContext = stacker.getQueryContext();
-    return new StreamSource<>(
+    return new WindowedStreamSource(
         new DefaultExecutionStepProperties(
             schema.getSchema(),
             queryContext),
@@ -88,7 +88,7 @@ public final class ExecutionStepFactory {
     );
   }
 
-  public static StreamSource<Struct> streamSource(
+  public static StreamSource streamSource(
       final QueryContext.Stacker stacker,
       final LogicalSchemaWithMetaAndKeyFields schema,
       final String topicName,
@@ -98,7 +98,7 @@ public final class ExecutionStepFactory {
       final Optional<AutoOffsetReset> offsetReset
   ) {
     final QueryContext queryContext = stacker.getQueryContext();
-    return new StreamSource<>(
+    return new StreamSource(
         new DefaultExecutionStepProperties(
             schema.getSchema(),
             queryContext),

--- a/ksql-streams/src/main/java/io/confluent/ksql/execution/streams/KSPlanBuilder.java
+++ b/ksql-streams/src/main/java/io/confluent/ksql/execution/streams/KSPlanBuilder.java
@@ -38,6 +38,7 @@ import io.confluent.ksql.execution.plan.TableGroupBy;
 import io.confluent.ksql.execution.plan.TableMapValues;
 import io.confluent.ksql.execution.plan.TableSink;
 import io.confluent.ksql.execution.plan.TableTableJoin;
+import io.confluent.ksql.execution.plan.WindowedStreamSource;
 import io.confluent.ksql.execution.sqlpredicate.SqlPredicate;
 import java.util.Objects;
 import org.apache.kafka.connect.data.Struct;
@@ -140,8 +141,14 @@ public final class KSPlanBuilder implements PlanBuilder {
   }
 
   @Override
-  public <K> KStreamHolder<K> visitStreamSource(final StreamSource<K> streamSource) {
+  public KStreamHolder<Struct> visitStreamSource(final StreamSource streamSource) {
     return StreamSourceBuilder.build(queryBuilder, streamSource);
+  }
+
+  @Override
+  public KStreamHolder<Windowed<Struct>> visitWindowedStreamSource(
+      final WindowedStreamSource windowedStreamSource) {
+    return StreamSourceBuilder.buildWindowed(queryBuilder, windowedStreamSource);
   }
 
   @Override


### PR DESCRIPTION
### Description 

This patch splits StreamSource into StreamSource and WindowedStreamSource.
This way, we can build a strongly typed source stream without doing unchecked
casts.

### Testing done 
Refactor, so no new tests

### Reviewer checklist
- [ ] Ensure docs are updated if necessary. (eg. if a user visible feature is being added or changed).
- [ ] Ensure relevant issues are linked (description should include text like "Fixes #<issue number>")

