### PR TITLE
feat: expose execution plans from the ksql engine API

### DIFF
--- a/ksql-engine/src/main/java/io/confluent/ksql/KsqlExecutionContext.java
+++ b/ksql-engine/src/main/java/io/confluent/ksql/KsqlExecutionContext.java
@@ -16,14 +16,18 @@
 package io.confluent.ksql;
 
 import io.confluent.ksql.engine.KsqlEngine;
+import io.confluent.ksql.engine.KsqlPlan;
 import io.confluent.ksql.metastore.MetaStore;
 import io.confluent.ksql.parser.KsqlParser.ParsedStatement;
 import io.confluent.ksql.parser.KsqlParser.PreparedStatement;
+import io.confluent.ksql.parser.tree.Query;
+import io.confluent.ksql.planner.plan.ConfiguredKsqlPlan;
 import io.confluent.ksql.query.QueryId;
 import io.confluent.ksql.services.ServiceContext;
 import io.confluent.ksql.statement.ConfiguredStatement;
 import io.confluent.ksql.util.PersistentQueryMetadata;
 import io.confluent.ksql.util.QueryMetadata;
+import io.confluent.ksql.util.TransientQueryMetadata;
 import java.util.List;
 import java.util.Objects;
 import java.util.Optional;
@@ -87,6 +91,24 @@ public interface KsqlExecutionContext {
    * @return the prepared statement.
    */
   PreparedStatement<?> prepare(ParsedStatement stmt);
+
+  /**
+   * Executes a query using the supplied service context.
+   */
+  TransientQueryMetadata executeQuery(
+      ServiceContext serviceContext,
+      ConfiguredStatement<Query> statement
+  );
+
+  /**
+   * Computes a plan for executing a DDL/DML statement using the supplied service context.
+   */
+  KsqlPlan plan(ServiceContext serviceContext, ConfiguredStatement<?> statement);
+
+  /**
+   * Executes a KSQL plan using the supplied service context.
+   */
+  ExecuteResult execute(ServiceContext serviceContext, ConfiguredKsqlPlan plan);
 
   /**
    * Execute the supplied statement, updating the meta store and registering any query.

--- a/ksql-engine/src/main/java/io/confluent/ksql/engine/EngineExecutor.java
+++ b/ksql-engine/src/main/java/io/confluent/ksql/engine/EngineExecutor.java
@@ -98,15 +98,8 @@ final class EngineExecutor {
     return new EngineExecutor(engineContext, serviceContext, ksqlConfig, overriddenProperties);
   }
 
-  ExecuteResult execute(final ConfiguredStatement<?> statement) {
-    if (statement.getStatement() instanceof Query) {
-      return ExecuteResult.of(executeQuery(statement.cast()));
-    }
-    return execute(plan(statement));
-  }
-
   @SuppressWarnings("OptionalGetWithoutIsPresent") // Known to be non-empty
-  private ExecuteResult execute(final KsqlPlan plan) {
+  ExecuteResult execute(final KsqlPlan plan) {
     final Optional<String> ddlResult = plan.getDdlCommand()
         .map(ddl -> executeDdl(ddl, plan.getStatementText()));
 
@@ -119,7 +112,7 @@ final class EngineExecutor {
   }
 
   @SuppressWarnings("OptionalGetWithoutIsPresent") // Known to be non-empty
-  private TransientQueryMetadata executeQuery(final ConfiguredStatement<Query> statement) {
+  TransientQueryMetadata executeQuery(final ConfiguredStatement<Query> statement) {
     final ExecutorPlans plans = planQuery(statement, statement.getStatement(), Optional.empty());
     final OutputNode outputNode = plans.logicalPlan.getNode().get();
     final QueryExecutor executor = engineContext.createQueryExecutor(
@@ -139,7 +132,7 @@ final class EngineExecutor {
   }
 
   @SuppressWarnings("OptionalGetWithoutIsPresent") // Known to be non-empty
-  private KsqlPlan plan(final ConfiguredStatement<?> statement) {
+  KsqlPlan plan(final ConfiguredStatement<?> statement) {
     try {
       throwOnNonExecutableStatement(statement);
 

--- a/ksql-engine/src/main/java/io/confluent/ksql/engine/KsqlEngine.java
+++ b/ksql-engine/src/main/java/io/confluent/ksql/engine/KsqlEngine.java
@@ -31,6 +31,7 @@ import io.confluent.ksql.parser.tree.ExecutableDdlStatement;
 import io.confluent.ksql.parser.tree.Query;
 import io.confluent.ksql.parser.tree.QueryContainer;
 import io.confluent.ksql.parser.tree.Statement;
+import io.confluent.ksql.planner.plan.ConfiguredKsqlPlan;
 import io.confluent.ksql.query.QueryId;
 import io.confluent.ksql.query.id.QueryIdGenerator;
 import io.confluent.ksql.schema.registry.SchemaRegistryUtil;
@@ -38,6 +39,7 @@ import io.confluent.ksql.services.ServiceContext;
 import io.confluent.ksql.statement.ConfiguredStatement;
 import io.confluent.ksql.util.PersistentQueryMetadata;
 import io.confluent.ksql.util.QueryMetadata;
+import io.confluent.ksql.util.TransientQueryMetadata;
 import java.io.Closeable;
 import java.util.List;
 import java.util.Objects;
@@ -160,17 +162,49 @@ public class KsqlEngine implements KsqlExecutionContext, Closeable {
   }
 
   @Override
+  public KsqlPlan plan(
+      final ServiceContext serviceContext,
+      final ConfiguredStatement<?> statement
+  ) {
+    return EngineExecutor
+        .create(primaryContext, serviceContext, statement.getConfig(), statement.getOverrides())
+        .plan(statement);
+  }
+
+  @Override
+  public ExecuteResult execute(final ServiceContext serviceContext, final ConfiguredKsqlPlan plan) {
+    final ExecuteResult result = EngineExecutor
+        .create(primaryContext, serviceContext, plan.getConfig(), plan.getOverrides())
+        .execute(plan.getPlan());
+    result.getQuery().ifPresent(this::registerQuery);
+    return result;
+  }
+
+  @Override
   public ExecuteResult execute(
       final ServiceContext serviceContext,
       final ConfiguredStatement<?> statement
   ) {
-    final ExecuteResult result = EngineExecutor
+    return execute(
+        serviceContext,
+        ConfiguredKsqlPlan.of(
+            plan(serviceContext, statement),
+            statement.getOverrides(),
+            statement.getConfig()
+        )
+    );
+  }
+
+  @Override
+  public TransientQueryMetadata executeQuery(
+      final ServiceContext serviceContext,
+      final ConfiguredStatement<Query> statement)
+  {
+    final TransientQueryMetadata query = EngineExecutor
         .create(primaryContext, serviceContext, statement.getConfig(), statement.getOverrides())
-        .execute(statement);
-
-    result.getQuery().ifPresent(this::registerQuery);
-
-    return result;
+        .executeQuery(statement);
+    registerQuery(query);
+    return query;
   }
 
   @Override

--- a/ksql-engine/src/main/java/io/confluent/ksql/engine/KsqlEngine.java
+++ b/ksql-engine/src/main/java/io/confluent/ksql/engine/KsqlEngine.java
@@ -198,8 +198,8 @@ public class KsqlEngine implements KsqlExecutionContext, Closeable {
   @Override
   public TransientQueryMetadata executeQuery(
       final ServiceContext serviceContext,
-      final ConfiguredStatement<Query> statement)
-  {
+      final ConfiguredStatement<Query> statement
+  ) {
     final TransientQueryMetadata query = EngineExecutor
         .create(primaryContext, serviceContext, statement.getConfig(), statement.getOverrides())
         .executeQuery(statement);

--- a/ksql-engine/src/main/java/io/confluent/ksql/planner/plan/ConfiguredKsqlPlan.java
+++ b/ksql-engine/src/main/java/io/confluent/ksql/planner/plan/ConfiguredKsqlPlan.java
@@ -1,0 +1,57 @@
+/*
+ * Copyright 2019 Confluent Inc.
+ *
+ * Licensed under the Confluent Community License (the "License"); you may not use
+ * this file except in compliance with the License.  You may obtain a copy of the
+ * License at
+ *
+ * http://www.confluent.io/confluent-community-license
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package io.confluent.ksql.planner.plan;
+
+import io.confluent.ksql.engine.KsqlPlan;
+import io.confluent.ksql.util.KsqlConfig;
+import java.util.Map;
+import java.util.Objects;
+
+public final class ConfiguredKsqlPlan {
+  private final KsqlPlan plan;
+  private final Map<String, Object> overrides;
+  private final KsqlConfig config;
+
+  public static ConfiguredKsqlPlan of(
+      final KsqlPlan plan,
+      final Map<String, Object> overrides,
+      final KsqlConfig config
+  ) {
+    return new ConfiguredKsqlPlan(plan, overrides, config);
+  }
+
+  private ConfiguredKsqlPlan(
+      final KsqlPlan plan,
+      final Map<String, Object> overrides,
+      final KsqlConfig config
+  ) {
+    this.plan = Objects.requireNonNull(plan, "plan");
+    this.overrides = Objects.requireNonNull(overrides, "overrides");
+    this.config = Objects.requireNonNull(config, "config");
+  }
+
+  public KsqlPlan getPlan() {
+    return plan;
+  }
+
+  public Map<String, Object> getOverrides() {
+    return overrides;
+  }
+
+  public KsqlConfig getConfig() {
+    return config;
+  }
+}

--- a/ksql-engine/src/test/java/io/confluent/ksql/embedded/KsqlContextTest.java
+++ b/ksql-engine/src/test/java/io/confluent/ksql/embedded/KsqlContextTest.java
@@ -123,7 +123,8 @@ public class KsqlContextTest {
     when(ksqlEngine.prepare(PARSED_STMT_0)).thenReturn((PreparedStatement) PREPARED_STMT_0);
     when(ksqlEngine.prepare(PARSED_STMT_1)).thenReturn((PreparedStatement) PREPARED_STMT_1);
 
-    when(ksqlEngine.execute(any(), any())).thenReturn(ExecuteResult.of("success"));
+    when(ksqlEngine.execute(any(), any(ConfiguredStatement.class)))
+        .thenReturn(ExecuteResult.of("success"));
 
     when(ksqlEngine.createSandbox(any())).thenReturn(sandbox);
 
@@ -204,7 +205,7 @@ public class KsqlContextTest {
   @Test
   public void shouldThrowIfSandboxExecuteThrows() {
     // Given:
-    when(sandbox.execute(any(), any()))
+    when(sandbox.execute(any(), any(ConfiguredStatement.class)))
         .thenThrow(new KsqlException("Bad tings happen"));
 
     // Expect
@@ -218,7 +219,7 @@ public class KsqlContextTest {
   @Test
   public void shouldThrowIfExecuteThrows() {
     // Given:
-    when(ksqlEngine.execute(any(), any()))
+    when(ksqlEngine.execute(any(), any(ConfiguredStatement.class)))
         .thenThrow(new KsqlException("Bad tings happen"));
 
     // Expect
@@ -232,7 +233,7 @@ public class KsqlContextTest {
   @Test
   public void shouldNotExecuteAnyStatementsIfTryExecuteThrows() {
     // Given:
-    when(sandbox.execute(any(), any()))
+    when(sandbox.execute(any(), any(ConfiguredStatement.class)))
         .thenThrow(new KsqlException("Bad tings happen"));
 
     // When:
@@ -243,13 +244,13 @@ public class KsqlContextTest {
     }
 
     // Then:
-    verify(ksqlEngine, never()).execute(any(), any());
+    verify(ksqlEngine, never()).execute(any(), any(ConfiguredStatement.class));
   }
 
   @Test
   public void shouldStartPersistentQueries() {
     // Given:
-    when(ksqlEngine.execute(any(), any()))
+    when(ksqlEngine.execute(any(), any(ConfiguredStatement.class)))
         .thenReturn(ExecuteResult.of(persistentQuery));
 
     // When:
@@ -262,7 +263,7 @@ public class KsqlContextTest {
   @Test
   public void shouldNotBlowUpOnSqlThatDoesNotResultInPersistentQueries() {
     // Given:
-    when(ksqlEngine.execute(any(), any()))
+    when(ksqlEngine.execute(any(), any(ConfiguredStatement.class)))
         .thenReturn(ExecuteResult.of(transientQuery));
 
     // When:

--- a/ksql-engine/src/test/java/io/confluent/ksql/engine/KsqlEngineTest.java
+++ b/ksql-engine/src/test/java/io/confluent/ksql/engine/KsqlEngineTest.java
@@ -659,12 +659,12 @@ public class KsqlEngineTest {
   @Test
   public void shouldCleanUpInternalTopicsOnClose() {
     // Given:
-    final QueryMetadata query = KsqlEngineTestUtil.execute(
+    final QueryMetadata query = KsqlEngineTestUtil.executeQuery(
         serviceContext,
         ksqlEngine,
         "select * from test1 EMIT CHANGES;",
         KSQL_CONFIG, Collections.emptyMap()
-    ).get(0);
+    );
 
     query.start();
 
@@ -720,12 +720,12 @@ public class KsqlEngineTest {
     // Given:
     final int startingLiveQueries = ksqlEngine.numberOfLiveQueries();
 
-    final QueryMetadata query = KsqlEngineTestUtil.execute(
+    final QueryMetadata query = KsqlEngineTestUtil.executeQuery(
         serviceContext,
         ksqlEngine,
         "select * from test1 EMIT CHANGES;",
         KSQL_CONFIG, Collections.emptyMap()
-    ).get(0);
+    );
 
     // When:
     query.close();

--- a/ksql-rest-app/src/main/java/io/confluent/ksql/rest/server/resources/streaming/PushQueryPublisher.java
+++ b/ksql-rest-app/src/main/java/io/confluent/ksql/rest/server/resources/streaming/PushQueryPublisher.java
@@ -60,11 +60,7 @@ class PushQueryPublisher implements Flow.Publisher<Collection<StreamedRow>> {
   @SuppressWarnings("OptionalGetWithoutIsPresent")
   @Override
   public synchronized void subscribe(final Flow.Subscriber<Collection<StreamedRow>> subscriber) {
-    final TransientQueryMetadata queryMetadata =
-        (TransientQueryMetadata) ksqlEngine.execute(serviceContext, query)
-            .getQuery()
-            .get();
-
+    final TransientQueryMetadata queryMetadata = ksqlEngine.executeQuery(serviceContext, query);
     final PushQuerySubscription subscription = new PushQuerySubscription(subscriber, queryMetadata);
 
     log.info("Running query {}", queryMetadata.getQueryApplicationId());

--- a/ksql-rest-app/src/main/java/io/confluent/ksql/rest/server/resources/streaming/StreamedQueryResource.java
+++ b/ksql-rest-app/src/main/java/io/confluent/ksql/rest/server/resources/streaming/StreamedQueryResource.java
@@ -42,7 +42,6 @@ import io.confluent.ksql.statement.ConfiguredStatement;
 import io.confluent.ksql.util.KsqlConfig;
 import io.confluent.ksql.util.KsqlException;
 import io.confluent.ksql.util.KsqlStatementException;
-import io.confluent.ksql.util.QueryMetadata;
 import io.confluent.ksql.util.TransientQueryMetadata;
 import io.confluent.ksql.version.metrics.ActivenessRegistrar;
 import java.time.Duration;
@@ -269,19 +268,10 @@ public class StreamedQueryResource implements KsqlConfigurable {
     final ConfiguredStatement<Query> configured =
         ConfiguredStatement.of(statement, streamsProperties, ksqlConfig);
 
-    final QueryMetadata query = ksqlEngine.execute(serviceContext, configured)
-        .getQuery()
-        .get();
-
-    if (!(query instanceof TransientQueryMetadata)) {
-      throw new IllegalStateException(String.format(
-          "Unexpected metadata type: expected TransientQueryMetadata, found %s instead",
-          query.getClass()
-      ));
-    }
+    final TransientQueryMetadata query = ksqlEngine.executeQuery(serviceContext, configured);
 
     final QueryStreamWriter queryStreamWriter = new QueryStreamWriter(
-        (TransientQueryMetadata) query,
+        query,
         disconnectCheckInterval.toMillis(),
         objectMapper);
 

--- a/ksql-rest-app/src/test/java/io/confluent/ksql/rest/server/KsqlRestApplicationTest.java
+++ b/ksql-rest-app/src/test/java/io/confluent/ksql/rest/server/KsqlRestApplicationTest.java
@@ -56,6 +56,7 @@ import io.confluent.ksql.security.KsqlAuthorizationProvider;
 import io.confluent.ksql.security.KsqlSecurityExtension;
 import io.confluent.ksql.services.KafkaTopicClient;
 import io.confluent.ksql.services.ServiceContext;
+import io.confluent.ksql.statement.ConfiguredStatement;
 import io.confluent.ksql.util.KsqlConfig;
 import io.confluent.ksql.util.KsqlException;
 import io.confluent.ksql.version.metrics.VersionCheckerAgent;
@@ -284,7 +285,8 @@ public class KsqlRestApplicationTest {
   @Test
   public void shouldNotCreateLogStreamIfValidationFails() {
     // Given:
-    when(sandBox.execute(any(), any())).thenThrow(new KsqlException("error"));
+    when(sandBox.execute(any(), any(ConfiguredStatement.class)))
+        .thenThrow(new KsqlException("error"));
 
     // When:
     app.startKsql();

--- a/ksql-rest-app/src/test/java/io/confluent/ksql/rest/server/StandaloneExecutorTest.java
+++ b/ksql-rest-app/src/test/java/io/confluent/ksql/rest/server/StandaloneExecutorTest.java
@@ -258,7 +258,8 @@ public class StandaloneExecutorTest {
     when(ksqlEngine.prepare(PARSED_STMT_0)).thenReturn((PreparedStatement) PREPARED_STMT_0);
     when(ksqlEngine.prepare(PARSED_STMT_1)).thenReturn((PreparedStatement) PREPARED_STMT_1);
 
-    when(ksqlEngine.execute(any(), any())).thenReturn(ExecuteResult.of(persistentQuery));
+    when(ksqlEngine.execute(any(), any(ConfiguredStatement.class)))
+        .thenReturn(ExecuteResult.of(persistentQuery));
 
     when(ksqlEngine.createSandbox(any())).thenReturn(sandBox);
 
@@ -266,7 +267,8 @@ public class StandaloneExecutorTest {
     when(sandBox.prepare(PARSED_STMT_1)).thenReturn((PreparedStatement) PREPARED_STMT_1);
 
     when(sandBox.getServiceContext()).thenReturn(sandBoxServiceContext);
-    when(sandBox.execute(any(), any())).thenReturn(ExecuteResult.of("success"));
+    when(sandBox.execute(any(), any(ConfiguredStatement.class)))
+        .thenReturn(ExecuteResult.of("success"));
     when(sandBox.execute(sandBoxServiceContext, CSAS_CFG_WITH_TOPIC))
         .thenReturn(ExecuteResult.of(persistentQuery));
 
@@ -595,7 +597,7 @@ public class StandaloneExecutorTest {
     // Given:
     givenFileContainsAPersistentQuery();
 
-    when(sandBox.execute(any(), any()))
+    when(sandBox.execute(any(), any(ConfiguredStatement.class)))
         .thenReturn(ExecuteResult.of("well, this is unexpected."));
 
     expectedException.expect(KsqlException.class);
@@ -610,7 +612,7 @@ public class StandaloneExecutorTest {
     // Given:
     givenFileContainsAPersistentQuery();
 
-    when(sandBox.execute(any(), any()))
+    when(sandBox.execute(any(), any(ConfiguredStatement.class)))
         .thenReturn(ExecuteResult.of(nonPersistentQueryMd));
 
     expectedException.expect(KsqlException.class);
@@ -632,7 +634,8 @@ public class StandaloneExecutorTest {
   @Test(expected = RuntimeException.class)
   public void shouldThrowIfExecuteThrows() {
     // Given:
-    when(ksqlEngine.execute(any(), any())).thenThrow(new RuntimeException("Boom!"));
+    when(ksqlEngine.execute(any(), any(ConfiguredStatement.class)))
+        .thenThrow(new RuntimeException("Boom!"));
 
     // When:
     standaloneExecutor.startAsync();
@@ -672,7 +675,8 @@ public class StandaloneExecutorTest {
   public void shouldNotStartValidationPhaseQueries() {
     // Given:
     givenFileContainsAPersistentQuery();
-    when(sandBox.execute(any(), any())).thenReturn(ExecuteResult.of(sandBoxQuery));
+    when(sandBox.execute(any(), any(ConfiguredStatement.class)))
+        .thenReturn(ExecuteResult.of(sandBoxQuery));
 
     // When:
     standaloneExecutor.startAsync();

--- a/ksql-rest-app/src/test/java/io/confluent/ksql/rest/server/resources/streaming/StreamedQueryResourceTest.java
+++ b/ksql-rest-app/src/test/java/io/confluent/ksql/rest/server/resources/streaming/StreamedQueryResourceTest.java
@@ -38,7 +38,6 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
 import io.confluent.ksql.GenericRow;
-import io.confluent.ksql.KsqlExecutionContext.ExecuteResult;
 import io.confluent.ksql.engine.KsqlEngine;
 import io.confluent.ksql.exception.KsqlTopicAuthorizationException;
 import io.confluent.ksql.json.JsonMapper;
@@ -136,13 +135,16 @@ public class StreamedQueryResourceTest {
   @Mock
   private KsqlAuthorizationValidator authorizationValidator;
   private StreamedQueryResource testResource;
-  private PreparedStatement<Statement> statement;
+  private PreparedStatement<Statement> invalid;
+  private PreparedStatement<Query> query;
+  private PreparedStatement<PrintTopic> print;
 
   @Before
   public void setup() {
     when(serviceContext.getTopicClient()).thenReturn(mockKafkaTopicClient);
-    statement = PreparedStatement.of(PUSH_QUERY_STRING, mock(Statement.class));
-    when(mockStatementParser.parseSingleStatement(PUSH_QUERY_STRING)).thenReturn(statement);
+    query = PreparedStatement.of(PUSH_QUERY_STRING, mock(Query.class));
+    invalid = PreparedStatement.of("sql", mock(Statement.class));
+    when(mockStatementParser.parseSingleStatement(PUSH_QUERY_STRING)).thenReturn(invalid);
 
     final Query pullQuery = mock(Query.class);
     when(pullQuery.isPullQuery()).thenReturn(true);
@@ -358,11 +360,10 @@ public class StreamedQueryResourceTest {
 
     final KafkaStreams mockKafkaStreams = mock(KafkaStreams.class);
 
-    final Map<String, Object> requestStreamsProperties = Collections.emptyMap();
+    when(mockStatementParser.<Query>parseSingleStatement(queryString))
+        .thenReturn(query);
 
-    statement = PreparedStatement.of("query", mock(Query.class));
-    when(mockStatementParser.parseSingleStatement(queryString))
-        .thenReturn(statement);
+    final Map<String, Object> requestStreamsProperties = Collections.emptyMap();
 
     final TransientQueryMetadata transientQueryMetadata =
         new TransientQueryMetadata(
@@ -379,9 +380,9 @@ public class StreamedQueryResourceTest {
             Collections.emptyMap(),
             queryCloseCallback);
 
-    when(mockKsqlEngine.execute(serviceContext,
-        ConfiguredStatement.of(statement, requestStreamsProperties, VALID_CONFIG)))
-        .thenReturn(ExecuteResult.of(transientQueryMetadata));
+    when(mockKsqlEngine.executeQuery(serviceContext,
+        ConfiguredStatement.of(query, requestStreamsProperties, VALID_CONFIG)))
+        .thenReturn(transientQueryMetadata);
 
     final Response response =
         testResource.streamQuery(
@@ -535,10 +536,8 @@ public class StreamedQueryResourceTest {
   @Test
   public void shouldReturnForbiddenKafkaAccessIfKsqlTopicAuthorizationException() {
     // Given:
-    statement = PreparedStatement.of("query", mock(Query.class));
-    when(mockStatementParser.parseSingleStatement(PUSH_QUERY_STRING))
-        .thenReturn(statement);
-
+    when(mockStatementParser.<Query>parseSingleStatement(PUSH_QUERY_STRING))
+        .thenReturn(query);
     doThrow(
         new KsqlTopicAuthorizationException(AclOperation.READ, Collections.singleton(TOPIC_NAME)))
         .when(authorizationValidator).checkAuthorization(any(), any(), any());
@@ -561,9 +560,8 @@ public class StreamedQueryResourceTest {
   @Test
   public void shouldReturnForbiddenKafkaAccessIfRootCauseKsqlTopicAuthorizationException() {
     // Given:
-    statement = PreparedStatement.of("query", mock(Query.class));
-    when(mockStatementParser.parseSingleStatement(PUSH_QUERY_STRING))
-        .thenReturn(statement);
+    when(mockStatementParser.<Query>parseSingleStatement(PUSH_QUERY_STRING))
+        .thenReturn(query);
     doThrow(new KsqlException(
         "",
         new KsqlTopicAuthorizationException(AclOperation.READ, Collections.singleton(TOPIC_NAME))))
@@ -589,9 +587,9 @@ public class StreamedQueryResourceTest {
   @Test
   public void shouldReturnForbiddenKafkaAccessIfPrintTopicKsqlTopicAuthorizationException() {
     // Given:
-    statement = PreparedStatement.of("print", mock(PrintTopic.class));
-    when(mockStatementParser.parseSingleStatement(PRINT_TOPIC))
-        .thenReturn(statement);
+    print = PreparedStatement.of("print", mock(PrintTopic.class));
+    when(mockStatementParser.<PrintTopic>parseSingleStatement(PRINT_TOPIC))
+        .thenReturn(print);
 
     doThrow(
         new KsqlTopicAuthorizationException(AclOperation.READ, Collections.singleton(TOPIC_NAME)))
@@ -615,9 +613,9 @@ public class StreamedQueryResourceTest {
     // Given:
     final PrintTopic cmd = mock(PrintTopic.class);
     when(cmd.getTopic()).thenReturn("TEST_TOPIC");
-    statement = PreparedStatement.of("print", cmd);
-    when(mockStatementParser.parseSingleStatement(any()))
-        .thenReturn(statement);
+    print = PreparedStatement.of("print", cmd);
+    when(mockStatementParser.<PrintTopic>parseSingleStatement(any()))
+        .thenReturn(print);
 
     when(mockKafkaTopicClient.isTopicExists(any())).thenReturn(false);
     when(mockKafkaTopicClient.listTopicNames()).thenReturn(ImmutableSet.of(


### PR DESCRIPTION
### Description 

This patch adds interfaces to build and execute plans in the KSQL engine
API, and changes StatementExecutor to use these interfaces to run statements.
It also exposes a method executeQuery that the query endpoint can use to build
transient queries.

