### PR TITLE
refactor: Remove KsqlAggregateFunction.getInstance

### DIFF
--- a/ksql-common/src/main/java/io/confluent/ksql/function/AggregateFunctionFactory.java
+++ b/ksql-common/src/main/java/io/confluent/ksql/function/AggregateFunctionFactory.java
@@ -45,8 +45,8 @@ public abstract class AggregateFunctionFactory {
     this.metadata = Objects.requireNonNull(metadata, "metadata can't be null");
   }
 
-  public abstract KsqlAggregateFunction<?, ?, ?> getProperAggregateFunction(
-      List<Schema> argTypeList);
+  public abstract KsqlAggregateFunction<?, ?, ?> createAggregateFunction(
+      List<Schema> argTypeList, AggregateFunctionInitArguments initArgs);
 
   protected abstract List<List<Schema>> supportedArgs();
 
@@ -71,10 +71,16 @@ public abstract class AggregateFunctionFactory {
   }
 
   public void eachFunction(final Consumer<KsqlAggregateFunction<?, ?, ?>> consumer) {
-    supportedArgs().forEach(args -> consumer.accept(getProperAggregateFunction(args)));
+    supportedArgs().forEach(args ->
+        consumer.accept(createAggregateFunction(args, getDefaultArguments())));
   }
 
   public boolean isInternal() {
     return metadata.isInternal();
   }
+
+  public AggregateFunctionInitArguments getDefaultArguments() {
+    return AggregateFunctionInitArguments.EMPTY_ARGS;
+  }
+
 }

--- a/ksql-common/src/main/java/io/confluent/ksql/function/AggregateFunctionInitArguments.java
+++ b/ksql-common/src/main/java/io/confluent/ksql/function/AggregateFunctionInitArguments.java
@@ -22,7 +22,7 @@ import java.util.List;
 import java.util.Objects;
 
 /**
- * Represents a list of initial arguments for the creation of a
+ * Represents a list of initial arguments for the creation of a UDAF
  * {@link io.confluent.ksql.function.KsqlAggregateFunction}
  *
  * <p>The initial arguments are always constants.
@@ -42,6 +42,12 @@ public class AggregateFunctionInitArguments {
 
   public static AggregateFunctionInitArguments ofFunctionArgs(final int index,
       final List<String> initArgs) {
+    /*
+    The first argument to an aggregate function is the value being aggregated, the
+    arguments after that are the actual init arguments (constants).
+    So we remove the first argument as it's not an init argument.
+    The args can also be empty (e.g. in the case of COUNT(*)
+    */
     return new AggregateFunctionInitArguments(index, Objects.requireNonNull(
         initArgs.size() < 2 ? Collections.emptyList() : initArgs.subList(1, initArgs.size())
     ));

--- a/ksql-common/src/main/java/io/confluent/ksql/function/AggregateFunctionInitArguments.java
+++ b/ksql-common/src/main/java/io/confluent/ksql/function/AggregateFunctionInitArguments.java
@@ -21,6 +21,12 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Objects;
 
+/**
+ * Represents a list of initial arguments for the creation of a
+ * {@link io.confluent.ksql.function.KsqlAggregateFunction}
+ *
+ * <p>The initial arguments are always constants.
+ */
 public class AggregateFunctionInitArguments {
 
   private final int udafIndex;

--- a/ksql-common/src/main/java/io/confluent/ksql/function/FunctionRegistry.java
+++ b/ksql-common/src/main/java/io/confluent/ksql/function/FunctionRegistry.java
@@ -62,7 +62,8 @@ public interface FunctionRegistry {
    * @return the function instance.
    * @throws KsqlException on unknown UDAF, or on unsupported {@code argumentType}.
    */
-  KsqlAggregateFunction<?, ?, ?> getAggregate(String functionName, Schema argumentType);
+  KsqlAggregateFunction<?, ?, ?> getAggregate(String functionName, Schema argumentType,
+      AggregateFunctionInitArguments initArgs);
 
   /**
    * @return all UDF factories.

--- a/ksql-common/src/main/java/io/confluent/ksql/function/FunctionRegistry.java
+++ b/ksql-common/src/main/java/io/confluent/ksql/function/FunctionRegistry.java
@@ -53,16 +53,23 @@ public interface FunctionRegistry {
   /**
    * Get an instance of an aggregate function.
    *
-   * <p>The current assumption is that all aggregate functions take a single argument.
-   * For functions that have no arguments pass {@link #DEFAULT_FUNCTION_ARG_SCHEMA} for the
+   * <p>The current assumption is that all aggregate functions take a single argument for
+   * computing the aggregate at runtime.
+   * For functions that have no runtime arguments pass {@link #DEFAULT_FUNCTION_ARG_SCHEMA} for the
    * {@code argumentType} parameter.
+   *
+   * <p>Some aggregate functions also take initialisation arguments, e.g.
+   * <code> SELECT TOPK(AGE, 5) FROM PEOPLE</code>.
+   *
+   * <p>In the above 5 is an initialisation argument which needs to be provided when creating the
+   * <code>KsqlAggregateFunction</code> instance.
    *
    * @param functionName the name of the function.
    * @param argumentType the schema of the argument or {@link #DEFAULT_FUNCTION_ARG_SCHEMA}.
    * @return the function instance.
    * @throws KsqlException on unknown UDAF, or on unsupported {@code argumentType}.
    */
-  KsqlAggregateFunction<?, ?, ?> getAggregate(String functionName, Schema argumentType,
+  KsqlAggregateFunction<?, ?, ?> getAggregateFunction(String functionName, Schema argumentType,
       AggregateFunctionInitArguments initArgs);
 
   /**

--- a/ksql-common/src/main/java/io/confluent/ksql/function/FunctionSignature.java
+++ b/ksql-common/src/main/java/io/confluent/ksql/function/FunctionSignature.java
@@ -20,10 +20,9 @@ import java.util.List;
 import org.apache.kafka.connect.data.Schema;
 
 /**
- * Something that can be indexed as if it were a function
- * {@link UdfIndex}.
+ * Describes something that has a function signature and can be indexed in a {@link UdfIndex}.
  */
-public interface IndexableAsFunction {
+public interface FunctionSignature {
 
   /**
    * @return the function name

--- a/ksql-common/src/main/java/io/confluent/ksql/function/IndexableAsFunction.java
+++ b/ksql-common/src/main/java/io/confluent/ksql/function/IndexableAsFunction.java
@@ -20,10 +20,10 @@ import java.util.List;
 import org.apache.kafka.connect.data.Schema;
 
 /**
- * An interface that designates functions that can be indexed using the
+ * Something that can be indexed as if it were a function
  * {@link UdfIndex}.
  */
-public interface IndexedFunction {
+public interface IndexableAsFunction {
 
   /**
    * @return the function name

--- a/ksql-common/src/main/java/io/confluent/ksql/function/KsqlAggregateFunction.java
+++ b/ksql-common/src/main/java/io/confluent/ksql/function/KsqlAggregateFunction.java
@@ -16,17 +16,13 @@
 package io.confluent.ksql.function;
 
 import io.confluent.ksql.schema.ksql.types.SqlType;
-import java.util.List;
 import java.util.function.Function;
 import java.util.function.Supplier;
 import org.apache.kafka.connect.data.Schema;
 import org.apache.kafka.connect.data.Struct;
 import org.apache.kafka.streams.kstream.Merger;
 
-
-public interface KsqlAggregateFunction<I, A, O> extends IndexedFunction {
-
-  KsqlAggregateFunction<I, A, O> getInstance(AggregateFunctionArguments aggregateFunctionArguments);
+public interface KsqlAggregateFunction<I, A, O> extends IndexableAsFunction {
 
   Supplier<A> getInitialValueSupplier();
 
@@ -40,10 +36,9 @@ public interface KsqlAggregateFunction<I, A, O> extends IndexedFunction {
 
   SqlType returnType();
 
-  boolean hasSameArgTypes(List<Schema> argTypeList);
-
   /**
    * Merges values inside the window.
+   *
    * @return A - type of return value
    */
   A aggregate(I currentValue, A aggregateValue);

--- a/ksql-common/src/main/java/io/confluent/ksql/function/KsqlAggregateFunction.java
+++ b/ksql-common/src/main/java/io/confluent/ksql/function/KsqlAggregateFunction.java
@@ -22,7 +22,7 @@ import org.apache.kafka.connect.data.Schema;
 import org.apache.kafka.connect.data.Struct;
 import org.apache.kafka.streams.kstream.Merger;
 
-public interface KsqlAggregateFunction<I, A, O> extends IndexableAsFunction {
+public interface KsqlAggregateFunction<I, A, O> extends FunctionSignature {
 
   Supplier<A> getInitialValueSupplier();
 

--- a/ksql-common/src/main/java/io/confluent/ksql/function/KsqlFunction.java
+++ b/ksql-common/src/main/java/io/confluent/ksql/function/KsqlFunction.java
@@ -36,7 +36,7 @@ import org.apache.kafka.connect.data.Schema.Type;
 import org.apache.kafka.connect.data.SchemaBuilder;
 
 @Immutable
-public final class KsqlFunction implements IndexableAsFunction {
+public final class KsqlFunction implements FunctionSignature {
 
   static final String INTERNAL_PATH = "internal";
 

--- a/ksql-common/src/main/java/io/confluent/ksql/function/KsqlFunction.java
+++ b/ksql-common/src/main/java/io/confluent/ksql/function/KsqlFunction.java
@@ -36,7 +36,7 @@ import org.apache.kafka.connect.data.Schema.Type;
 import org.apache.kafka.connect.data.SchemaBuilder;
 
 @Immutable
-public final class KsqlFunction implements IndexedFunction {
+public final class KsqlFunction implements IndexableAsFunction {
 
   static final String INTERNAL_PATH = "internal";
 

--- a/ksql-common/src/main/java/io/confluent/ksql/function/UdfIndex.java
+++ b/ksql-common/src/main/java/io/confluent/ksql/function/UdfIndex.java
@@ -56,7 +56,7 @@ import org.slf4j.LoggerFactory;
  *       that was added first.</li>
  * </ul>
  */
-public class UdfIndex<T extends IndexedFunction> {
+public class UdfIndex<T extends IndexableAsFunction> {
   // this class is implemented as a custom Trie data structure that resolves
   // the rules described above. the Trie is built so that each node in the
   // trie references a single possible parameter in the signature. take for

--- a/ksql-common/src/main/java/io/confluent/ksql/function/UdfIndex.java
+++ b/ksql-common/src/main/java/io/confluent/ksql/function/UdfIndex.java
@@ -56,7 +56,7 @@ import org.slf4j.LoggerFactory;
  *       that was added first.</li>
  * </ul>
  */
-public class UdfIndex<T extends IndexableAsFunction> {
+public class UdfIndex<T extends FunctionSignature> {
   // this class is implemented as a custom Trie data structure that resolves
   // the rules described above. the Trie is built so that each node in the
   // trie references a single possible parameter in the signature. take for

--- a/ksql-engine/src/main/java/io/confluent/ksql/function/BaseAggregateFunction.java
+++ b/ksql-engine/src/main/java/io/confluent/ksql/function/BaseAggregateFunction.java
@@ -77,13 +77,6 @@ public abstract class BaseAggregateFunction<I, A, O> implements KsqlAggregateFun
     }
   }
 
-  public boolean hasSameArgTypes(final List<Schema> argTypeList) {
-    if (argTypeList == null) {
-      throw new KsqlException("Argument type list is null.");
-    }
-    return this.arguments.equals(argTypeList);
-  }
-
   public FunctionName getFunctionName() {
     return FunctionName.of(functionName);
   }

--- a/ksql-engine/src/main/java/io/confluent/ksql/function/GeneratedTableAggregateFunction.java
+++ b/ksql-engine/src/main/java/io/confluent/ksql/function/GeneratedTableAggregateFunction.java
@@ -17,11 +17,10 @@ package io.confluent.ksql.function;
 
 import io.confluent.ksql.execution.function.TableAggregationFunction;
 import io.confluent.ksql.function.udaf.TableUdaf;
+import io.confluent.ksql.function.udaf.Udaf;
 import java.util.List;
 import java.util.Optional;
-import java.util.function.Supplier;
 import org.apache.kafka.common.metrics.Metrics;
-import org.apache.kafka.common.metrics.Sensor;
 import org.apache.kafka.connect.data.Schema;
 
 @SuppressWarnings("unused") // used in generated code
@@ -30,27 +29,15 @@ public abstract class GeneratedTableAggregateFunction<I, A, O>
 
   public GeneratedTableAggregateFunction(
       final String functionName,
+      final int udafIndex,
+      final Udaf<I, A, O> udaf,
       final Schema aggregateType,
       final Schema outputType,
       final List<Schema> arguments,
       final String description,
       final Optional<Metrics> metrics) {
-    super(functionName, aggregateType, outputType, arguments, description, metrics);
-  }
-
-  protected GeneratedTableAggregateFunction(
-      final String functionName,
-      final int udafIndex,
-      final Supplier<A> udafSupplier,
-      final Schema aggregateType,
-      final Schema outputType,
-      final List<Schema> arguments,
-      final String description,
-      final Optional<Sensor> aggregateSensor,
-      final Optional<Sensor> mapSensor,
-      final Optional<Sensor> mergeSensor) {
-    super(functionName, udafIndex, udafSupplier, aggregateType, outputType,
-          arguments, description, aggregateSensor, mapSensor, mergeSensor);
+    super(functionName, udafIndex, udaf, aggregateType, outputType, arguments, description,
+        metrics);
   }
 
   @Override

--- a/ksql-engine/src/main/java/io/confluent/ksql/function/InternalFunctionRegistry.java
+++ b/ksql-engine/src/main/java/io/confluent/ksql/function/InternalFunctionRegistry.java
@@ -103,7 +103,7 @@ public class InternalFunctionRegistry implements MutableFunctionRegistry {
   }
 
   @Override
-  public KsqlAggregateFunction getAggregate(
+  public KsqlAggregateFunction getAggregateFunction(
       final String functionName,
       final Schema argumentType,
       final AggregateFunctionInitArguments initArgs

--- a/ksql-engine/src/main/java/io/confluent/ksql/function/InternalFunctionRegistry.java
+++ b/ksql-engine/src/main/java/io/confluent/ksql/function/InternalFunctionRegistry.java
@@ -105,14 +105,15 @@ public class InternalFunctionRegistry implements MutableFunctionRegistry {
   @Override
   public KsqlAggregateFunction getAggregate(
       final String functionName,
-      final Schema argumentType
+      final Schema argumentType,
+      final AggregateFunctionInitArguments initArgs
   ) {
     final AggregateFunctionFactory udafFactory = udafs.get(functionName.toUpperCase());
     if (udafFactory == null) {
       throw new KsqlException("No aggregate function with name " + functionName + " exists!");
     }
-
-    return udafFactory.getProperAggregateFunction(Collections.singletonList(argumentType));
+    return udafFactory.createAggregateFunction(Collections.singletonList(argumentType),
+        initArgs);
   }
 
   @Override

--- a/ksql-engine/src/main/java/io/confluent/ksql/function/UdafAggregateFunctionFactory.java
+++ b/ksql-engine/src/main/java/io/confluent/ksql/function/UdafAggregateFunctionFactory.java
@@ -22,34 +22,38 @@ import java.util.stream.Collectors;
 import org.apache.kafka.connect.data.Schema;
 
 public class UdafAggregateFunctionFactory extends AggregateFunctionFactory {
-  private final UdfIndex<KsqlAggregateFunction<?, ?, ?>> udfIndex;
+
+  private final UdfIndex<UdafCreator> udfIndex;
 
   UdafAggregateFunctionFactory(
       final UdfMetadata metadata,
-      final List<KsqlAggregateFunction<?, ?, ?>> functionList
+      final List<UdafCreator> factoryList
   ) {
     super(metadata);
     udfIndex = new UdfIndex<>(metadata.getName());
-    functionList.forEach(udfIndex::addFunction);
+    factoryList.forEach(udfIndex::addFunction);
   }
 
   @Override
-  public KsqlAggregateFunction<?, ?, ?> getProperAggregateFunction(final List<Schema> argTypeList) {
-    final KsqlAggregateFunction ksqlAggregateFunction = udfIndex.getFunction(argTypeList);
-    if (ksqlAggregateFunction == null) {
+  public KsqlAggregateFunction<?, ?, ?> createAggregateFunction(
+      final List<Schema> argTypeList,
+      final AggregateFunctionInitArguments initArgs
+  ) {
+    final UdafCreator creator = udfIndex.getFunction(argTypeList);
+    if (creator == null) {
       throw new KsqlException("There is no aggregate function with name='" + getName()
           + "' that has arguments of type="
           + argTypeList.stream().map(schema -> schema.type().getName())
           .collect(Collectors.joining(",")));
     }
-    return ksqlAggregateFunction;
+    return creator.createFunction(initArgs);
   }
 
   @Override
   public List<List<Schema>> supportedArgs() {
     return udfIndex.values()
         .stream()
-        .map(KsqlAggregateFunction::getArguments)
+        .map(UdafCreator::getArguments)
         .collect(Collectors.toList());
   }
 }

--- a/ksql-engine/src/main/java/io/confluent/ksql/function/UdafCreator.java
+++ b/ksql-engine/src/main/java/io/confluent/ksql/function/UdafCreator.java
@@ -1,0 +1,68 @@
+/*
+ * Copyright 2018 Confluent Inc.
+ *
+ * Licensed under the Confluent Community License (the "License"); you may not use
+ * this file except in compliance with the License.  You may obtain a copy of the
+ * License at
+ *
+ * http://www.confluent.io/confluent-community-license
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package io.confluent.ksql.function;
+
+import io.confluent.ksql.function.udaf.UdafArgApplier;
+import io.confluent.ksql.name.FunctionName;
+import java.util.List;
+import java.util.Optional;
+import org.apache.kafka.common.metrics.Metrics;
+import org.apache.kafka.connect.data.Schema;
+
+class UdafCreator implements IndexableAsFunction {
+
+  private final FunctionName functionName;
+  private final UdafArgApplier argSupplier;
+  private final Schema aggregateArgType;
+  private final Schema aggregateReturnType;
+  private final Optional<Metrics> metrics;
+  private final List<Schema> argTypes;
+
+  UdafCreator(
+      final String functionName,
+      final UdafArgApplier argSupplier,
+      final Schema aggregateArgType,
+      final Schema aggregateReturnType,
+      final Optional<Metrics> metrics,
+      final List<Schema> argTypes
+  ) {
+    this.functionName = FunctionName.of(functionName);
+    this.argSupplier = argSupplier;
+    this.aggregateArgType = aggregateArgType;
+    this.aggregateReturnType = aggregateReturnType;
+    this.metrics = metrics;
+    this.argTypes = argTypes;
+  }
+
+  KsqlAggregateFunction createFunction(final AggregateFunctionInitArguments initArgs) {
+    return argSupplier.apply(initArgs, argTypes, aggregateArgType, aggregateReturnType, metrics);
+  }
+
+  @Override
+  public FunctionName getFunctionName() {
+    return functionName;
+  }
+
+  @Override
+  public List<Schema> getArguments() {
+    return argTypes;
+  }
+
+  @Override
+  public boolean isVariadic() {
+    return false;
+  }
+}

--- a/ksql-engine/src/main/java/io/confluent/ksql/function/UdafCreator.java
+++ b/ksql-engine/src/main/java/io/confluent/ksql/function/UdafCreator.java
@@ -22,7 +22,7 @@ import java.util.Optional;
 import org.apache.kafka.common.metrics.Metrics;
 import org.apache.kafka.connect.data.Schema;
 
-class UdafCreator implements IndexableAsFunction {
+class UdafCreator implements FunctionSignature {
 
   private final FunctionName functionName;
   private final UdafArgApplier argSupplier;

--- a/ksql-engine/src/main/java/io/confluent/ksql/function/UdafTemplate.java
+++ b/ksql-engine/src/main/java/io/confluent/ksql/function/UdafTemplate.java
@@ -21,7 +21,6 @@ import com.squareup.javapoet.MethodSpec;
 import com.squareup.javapoet.ParameterizedTypeName;
 import com.squareup.javapoet.TypeSpec;
 import io.confluent.ksql.function.udaf.TableUdaf;
-import io.confluent.ksql.function.udaf.Udaf;
 import java.lang.reflect.Method;
 import java.util.List;
 import java.util.Optional;
@@ -29,17 +28,17 @@ import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 import javax.lang.model.element.Modifier;
 import org.apache.kafka.common.metrics.Metrics;
-import org.apache.kafka.common.metrics.Sensor;
 import org.apache.kafka.connect.data.Schema;
 import org.apache.kafka.connect.data.Struct;
 
 @SuppressWarnings("unused") // Used from generated code
 public final class UdafTemplate {
 
-  private UdafTemplate() { }
+  private UdafTemplate() {
+  }
 
   static String generateCode(
-      final Method udaf,
+      final Method udafMethod,
       final String className,
       final String udafName,
       final String description) {
@@ -47,70 +46,43 @@ public final class UdafTemplate {
     final TypeSpec.Builder udafTypeSpec = TypeSpec.classBuilder(className);
     udafTypeSpec.addModifiers(Modifier.PUBLIC);
 
-    if (TableUdaf.class.isAssignableFrom(udaf.getReturnType())) {
+    if (TableUdaf.class.isAssignableFrom(udafMethod.getReturnType())) {
       udafTypeSpec.superclass(GeneratedTableAggregateFunction.class);
     } else {
       udafTypeSpec.superclass(GeneratedAggregateFunction.class);
     }
 
-    udafTypeSpec.addMethod(
-        MethodSpec.constructorBuilder()
-            .addModifiers(Modifier.PUBLIC)
-            .addParameter(ParameterizedTypeName.get(List.class, Schema.class), "args")
-            .addParameter(Schema.class, "aggregateType")
-            .addParameter(Schema.class, "outputType")
-            .addParameter(ParameterizedTypeName.get(Optional.class, Metrics.class), "metrics")
-            .addStatement("super($S, aggregateType, outputType, args, $S, metrics)",
-                          udafName,
-                          description)
-            .build());
+    final String udafArgs = IntStream.range(0, udafMethod.getParameterTypes().length)
+        .mapToObj(i -> String.format("(%s) coerce(initArgs, %s.class, %d)",
+            Primitives.wrap(udafMethod.getParameterTypes()[i]).getName(),
+            udafMethod.getParameterTypes()[i].getName(),
+            i))
+        .collect(Collectors.joining(", "));
 
     udafTypeSpec.addMethod(
         MethodSpec.constructorBuilder()
-            .addModifiers(Modifier.PRIVATE)
-            .addParameter(Udaf.class, "udaf")
-            .addParameter(int.class, "index")
-            .addParameter(ParameterizedTypeName.get(List.class, Schema.class), "args")
+            .addModifiers(Modifier.PUBLIC)
+            .addParameter(AggregateFunctionInitArguments.class, "initArgs")
+            .addParameter(ParameterizedTypeName.get(List.class, Schema.class), "argTypes")
             .addParameter(Schema.class, "aggregateType")
             .addParameter(Schema.class, "outputType")
-            .addParameter(ParameterizedTypeName.get(Optional.class, Sensor.class), "aggSensor")
-            .addParameter(ParameterizedTypeName.get(Optional.class, Sensor.class), "mapSensor")
-            .addParameter(ParameterizedTypeName.get(Optional.class, Sensor.class), "mergeSensor")
+            .addParameter(ParameterizedTypeName.get(Optional.class, Metrics.class), "metrics")
             .addStatement(
-                "super($S, index, supplier(udaf), aggregateType, outputType, args, $S, "
-                    + "aggSensor, mapSensor, mergeSensor)", udafName, description)
-            .addStatement("this.udaf = udaf")
+                "super($S, initArgs.udafIndex(), $T.$L($L), aggregateType, "
+                    + "outputType, argTypes, $S, metrics)",
+                udafName,
+                udafMethod.getDeclaringClass(),
+                udafMethod.getName(),
+                udafArgs,
+                description)
             .build());
 
     udafTypeSpec.addMethod(
         MethodSpec.methodBuilder("getSourceMethodName")
             .addAnnotation(Override.class)
             .addModifiers(Modifier.PROTECTED)
-            .addStatement("return $S", udaf.getName())
+            .addStatement("return $S", udafMethod.getName())
             .returns(String.class)
-            .build());
-
-    final String udafArgs = IntStream.range(0, udaf.getParameterTypes().length)
-        .mapToObj(i -> String.format("(%s) coerce(args, %s.class, %d)",
-                                     Primitives.wrap(udaf.getParameterTypes()[i]).getName(),
-                                     udaf.getParameterTypes()[i].getName(),
-                                     i))
-        .collect(Collectors.joining(", "));
-
-    udafTypeSpec.addMethod(
-        MethodSpec.methodBuilder("getInstance")
-            .addAnnotation(Override.class)
-            .addModifiers(Modifier.PUBLIC)
-            .addParameter(AggregateFunctionArguments.class, "args", Modifier.FINAL)
-            .addStatement("args.ensureArgCount($L, $S)", udaf.getParameters().length + 1, udafName)
-            .returns(KsqlAggregateFunction.class)
-            .addStatement(
-                "return new $L($T.$L($L), args.udafIndex(), getArguments(), getAggregateType(),"
-                    + " getReturnType(), aggregateSensor, mapSensor, mergeSensor)",
-                className,
-                udaf.getDeclaringClass(),
-                udaf.getName(),
-                udafArgs)
             .build());
 
     return JavaFile.builder("io.confluent.ksql.function.udaf", udafTypeSpec.build())
@@ -121,27 +93,27 @@ public final class UdafTemplate {
 
   @SuppressWarnings("unchecked")
   public static <T> T coerce(
-      final AggregateFunctionArguments args,
+      final AggregateFunctionInitArguments args,
       final Class<?> clazz,
       final int index) {
     if (Integer.class.isAssignableFrom(Primitives.wrap(clazz))) {
-      return (T) Integer.valueOf(args.arg(index + 1));
+      return (T) Integer.valueOf(args.arg(index));
     } else if (Long.class.isAssignableFrom(Primitives.wrap(clazz))) {
-      return (T) Long.valueOf(args.arg(index + 1));
+      return (T) Long.valueOf(args.arg(index));
     } else if (Double.class.isAssignableFrom(Primitives.wrap(clazz))) {
-      return (T) Double.valueOf(args.arg(index + 1));
+      return (T) Double.valueOf(args.arg(index));
     } else if (Float.class.isAssignableFrom(Primitives.wrap(clazz))) {
-      return (T) Float.valueOf(args.arg(index + 1));
+      return (T) Float.valueOf(args.arg(index));
     } else if (Byte.class.isAssignableFrom(Primitives.wrap(clazz))) {
-      return (T) Byte.valueOf(args.arg(index + 1));
+      return (T) Byte.valueOf(args.arg(index));
     } else if (Short.class.isAssignableFrom(Primitives.wrap(clazz))) {
-      return (T) Short.valueOf(args.arg(index + 1));
+      return (T) Short.valueOf(args.arg(index));
     } else if (Boolean.class.isAssignableFrom(Primitives.wrap(clazz))) {
-      return (T) Boolean.valueOf(args.arg(index + 1));
+      return (T) Boolean.valueOf(args.arg(index));
     } else if (String.class.isAssignableFrom(clazz)) {
-      return (T) args.arg(index + 1);
+      return (T) args.arg(index);
     } else if (Struct.class.isAssignableFrom(clazz)) {
-      return (T) args.arg(index + 1);
+      return (T) args.arg(index);
     }
 
     throw new KsqlFunctionException("Unsupported udaf argument type: " + clazz);

--- a/ksql-engine/src/main/java/io/confluent/ksql/function/udaf/UdafArgApplier.java
+++ b/ksql-engine/src/main/java/io/confluent/ksql/function/udaf/UdafArgApplier.java
@@ -15,6 +15,7 @@
 
 package io.confluent.ksql.function.udaf;
 
+import io.confluent.ksql.function.AggregateFunctionInitArguments;
 import io.confluent.ksql.function.KsqlAggregateFunction;
 import java.util.List;
 import java.util.Optional;
@@ -23,11 +24,15 @@ import org.apache.kafka.connect.data.Schema;
 
 @SuppressWarnings("OptionalUsedAsFieldOrParameterType")
 /*
- * Used during when creating UDAFS from the ext dir
+ * Used during when creating UDAFS
  */
-public interface UdfArgSupplier {
-  KsqlAggregateFunction apply(List<Schema> args,
-                              Schema aggregateType,
-                              Schema outputType,
-                              Optional<Metrics> metrics);
+public interface UdafArgApplier {
+
+  KsqlAggregateFunction apply(
+      AggregateFunctionInitArguments initArgs,
+      List<Schema> argTypes,
+      Schema aggregateType,
+      Schema outputType,
+      Optional<Metrics> metrics
+  );
 }

--- a/ksql-engine/src/main/java/io/confluent/ksql/function/udaf/count/CountAggFunctionFactory.java
+++ b/ksql-engine/src/main/java/io/confluent/ksql/function/udaf/count/CountAggFunctionFactory.java
@@ -17,11 +17,13 @@ package io.confluent.ksql.function.udaf.count;
 
 import com.google.common.collect.ImmutableList;
 import io.confluent.ksql.function.AggregateFunctionFactory;
+import io.confluent.ksql.function.AggregateFunctionInitArguments;
 import io.confluent.ksql.function.KsqlAggregateFunction;
 import java.util.List;
 import org.apache.kafka.connect.data.Schema;
 
 public class CountAggFunctionFactory extends AggregateFunctionFactory {
+
   private static final String FUNCTION_NAME = "COUNT";
 
   public CountAggFunctionFactory() {
@@ -29,8 +31,11 @@ public class CountAggFunctionFactory extends AggregateFunctionFactory {
   }
 
   @Override
-  public KsqlAggregateFunction getProperAggregateFunction(final List<Schema> argTypeList) {
-    return new CountKudaf(FUNCTION_NAME, -1);
+  public KsqlAggregateFunction createAggregateFunction(
+      final List<Schema> argTypeList,
+      final AggregateFunctionInitArguments initArgs
+  ) {
+    return new CountKudaf(FUNCTION_NAME, initArgs.udafIndex());
   }
 
   @Override

--- a/ksql-engine/src/main/java/io/confluent/ksql/function/udaf/count/CountKudaf.java
+++ b/ksql-engine/src/main/java/io/confluent/ksql/function/udaf/count/CountKudaf.java
@@ -16,11 +16,8 @@
 package io.confluent.ksql.function.udaf.count;
 
 import io.confluent.ksql.execution.function.TableAggregationFunction;
-import io.confluent.ksql.function.AggregateFunctionArguments;
 import io.confluent.ksql.function.BaseAggregateFunction;
-import io.confluent.ksql.function.KsqlAggregateFunction;
 import java.util.Collections;
-import java.util.List;
 import java.util.function.Function;
 import org.apache.kafka.connect.data.Schema;
 import org.apache.kafka.connect.data.Struct;
@@ -35,7 +32,7 @@ public class CountKudaf
           argIndexInValue, () -> 0L,
           Schema.OPTIONAL_INT64_SCHEMA, Schema.OPTIONAL_INT64_SCHEMA,
           Collections.singletonList(Schema.OPTIONAL_FLOAT64_SCHEMA),
-          "Counts records by key."
+         "Counts records by key."
     );
   }
 
@@ -66,14 +63,4 @@ public class CountKudaf
     return aggregateValue - 1;
   }
 
-  @Override
-  public KsqlAggregateFunction<Object, Long, Long> getInstance(
-      final AggregateFunctionArguments aggregateFunctionArguments) {
-    return new CountKudaf(functionName, aggregateFunctionArguments.udafIndex());
-  }
-
-  @Override
-  public boolean hasSameArgTypes(final List<Schema> argTypeList) {
-    return false;
-  }
 }

--- a/ksql-engine/src/main/java/io/confluent/ksql/function/udaf/max/DecimalMaxKudaf.java
+++ b/ksql-engine/src/main/java/io/confluent/ksql/function/udaf/max/DecimalMaxKudaf.java
@@ -15,8 +15,6 @@
 
 package io.confluent.ksql.function.udaf.max;
 
-import io.confluent.ksql.function.AggregateFunctionArguments;
-import io.confluent.ksql.function.KsqlAggregateFunction;
 import io.confluent.ksql.function.udaf.BaseNumberKudaf;
 import java.math.BigDecimal;
 import org.apache.kafka.connect.data.Schema;
@@ -35,11 +33,4 @@ public class DecimalMaxKudaf extends BaseNumberKudaf<BigDecimal> {
           "Computes the maximum decimal value for a key.");
   }
 
-  @Override
-  public KsqlAggregateFunction<BigDecimal, BigDecimal, BigDecimal> getInstance(
-      final AggregateFunctionArguments aggregateFunctionArguments
-  ) {
-    return new DecimalMaxKudaf(
-        functionName, aggregateFunctionArguments.udafIndex(), getReturnType());
-  }
 }

--- a/ksql-engine/src/main/java/io/confluent/ksql/function/udaf/max/DoubleMaxKudaf.java
+++ b/ksql-engine/src/main/java/io/confluent/ksql/function/udaf/max/DoubleMaxKudaf.java
@@ -15,8 +15,6 @@
 
 package io.confluent.ksql.function.udaf.max;
 
-import io.confluent.ksql.function.AggregateFunctionArguments;
-import io.confluent.ksql.function.KsqlAggregateFunction;
 import io.confluent.ksql.function.udaf.BaseNumberKudaf;
 import org.apache.kafka.connect.data.Schema;
 
@@ -30,9 +28,4 @@ public class DoubleMaxKudaf extends BaseNumberKudaf<Double> {
           "Computes the maximum double value for a key.");
   }
 
-  @Override
-  public KsqlAggregateFunction<Double, Double, Double> getInstance(
-      final AggregateFunctionArguments aggregateFunctionArguments) {
-    return new DoubleMaxKudaf(functionName, aggregateFunctionArguments.udafIndex());
-  }
 }

--- a/ksql-engine/src/main/java/io/confluent/ksql/function/udaf/max/IntegerMaxKudaf.java
+++ b/ksql-engine/src/main/java/io/confluent/ksql/function/udaf/max/IntegerMaxKudaf.java
@@ -15,8 +15,6 @@
 
 package io.confluent.ksql.function.udaf.max;
 
-import io.confluent.ksql.function.AggregateFunctionArguments;
-import io.confluent.ksql.function.KsqlAggregateFunction;
 import io.confluent.ksql.function.udaf.BaseNumberKudaf;
 import org.apache.kafka.connect.data.Schema;
 
@@ -30,9 +28,4 @@ public class IntegerMaxKudaf extends BaseNumberKudaf<Integer> {
           "Computes the maximum integer value for a key.");
   }
 
-  @Override
-  public KsqlAggregateFunction<Integer, Integer, Integer> getInstance(
-      final AggregateFunctionArguments aggregateFunctionArguments) {
-    return new IntegerMaxKudaf(functionName, aggregateFunctionArguments.udafIndex());
-  }
 }

--- a/ksql-engine/src/main/java/io/confluent/ksql/function/udaf/max/LongMaxKudaf.java
+++ b/ksql-engine/src/main/java/io/confluent/ksql/function/udaf/max/LongMaxKudaf.java
@@ -15,8 +15,6 @@
 
 package io.confluent.ksql.function.udaf.max;
 
-import io.confluent.ksql.function.AggregateFunctionArguments;
-import io.confluent.ksql.function.KsqlAggregateFunction;
 import io.confluent.ksql.function.udaf.BaseNumberKudaf;
 import org.apache.kafka.connect.data.Schema;
 
@@ -30,9 +28,4 @@ public class LongMaxKudaf extends BaseNumberKudaf<Long> {
           "Computes the maximum long value for a key.");
   }
 
-  @Override
-  public KsqlAggregateFunction<Long, Long, Long> getInstance(
-      final AggregateFunctionArguments aggregateFunctionArguments) {
-    return new LongMaxKudaf(functionName, aggregateFunctionArguments.udafIndex());
-  }
 }

--- a/ksql-engine/src/main/java/io/confluent/ksql/function/udaf/max/MaxAggFunctionFactory.java
+++ b/ksql-engine/src/main/java/io/confluent/ksql/function/udaf/max/MaxAggFunctionFactory.java
@@ -16,6 +16,7 @@
 package io.confluent.ksql.function.udaf.max;
 
 import io.confluent.ksql.function.AggregateFunctionFactory;
+import io.confluent.ksql.function.AggregateFunctionInitArguments;
 import io.confluent.ksql.function.KsqlAggregateFunction;
 import io.confluent.ksql.util.DecimalUtil;
 import io.confluent.ksql.util.KsqlException;
@@ -24,6 +25,7 @@ import java.util.List;
 import org.apache.kafka.connect.data.Schema;
 
 public class MaxAggFunctionFactory extends AggregateFunctionFactory {
+
   private static final String FUNCTION_NAME = "MAX";
 
   public MaxAggFunctionFactory() {
@@ -31,7 +33,10 @@ public class MaxAggFunctionFactory extends AggregateFunctionFactory {
   }
 
   @Override
-  public KsqlAggregateFunction getProperAggregateFunction(final List<Schema> argTypeList) {
+  public KsqlAggregateFunction createAggregateFunction(
+      final List<Schema> argTypeList,
+      final AggregateFunctionInitArguments initArgs
+  ) {
     KsqlPreconditions.checkArgument(
         argTypeList.size() == 1,
         "expected exactly one argument to aggregate MAX function");
@@ -39,14 +44,14 @@ public class MaxAggFunctionFactory extends AggregateFunctionFactory {
     final Schema argSchema = argTypeList.get(0);
     switch (argSchema.type()) {
       case INT32:
-        return new IntegerMaxKudaf(FUNCTION_NAME, -1);
+        return new IntegerMaxKudaf(FUNCTION_NAME, initArgs.udafIndex());
       case INT64:
-        return new LongMaxKudaf(FUNCTION_NAME, -1);
+        return new LongMaxKudaf(FUNCTION_NAME, initArgs.udafIndex());
       case FLOAT64:
-        return new DoubleMaxKudaf(FUNCTION_NAME, -1);
+        return new DoubleMaxKudaf(FUNCTION_NAME, initArgs.udafIndex());
       case BYTES:
         DecimalUtil.requireDecimal(argSchema);
-        return new DecimalMaxKudaf(FUNCTION_NAME, -1, argSchema);
+        return new DecimalMaxKudaf(FUNCTION_NAME, initArgs.udafIndex(), argSchema);
       default:
         throw new KsqlException("No Max aggregate function with " + argTypeList.get(0) + " "
             + " argument type exists!");

--- a/ksql-engine/src/main/java/io/confluent/ksql/function/udaf/min/DecimalMinKudaf.java
+++ b/ksql-engine/src/main/java/io/confluent/ksql/function/udaf/min/DecimalMinKudaf.java
@@ -15,8 +15,6 @@
 
 package io.confluent.ksql.function.udaf.min;
 
-import io.confluent.ksql.function.AggregateFunctionArguments;
-import io.confluent.ksql.function.KsqlAggregateFunction;
 import io.confluent.ksql.function.udaf.BaseNumberKudaf;
 import java.math.BigDecimal;
 import org.apache.kafka.connect.data.Schema;
@@ -35,11 +33,4 @@ public class DecimalMinKudaf extends BaseNumberKudaf<BigDecimal> {
           "Computes the minimum decimal value for a key.");
   }
 
-  @Override
-  public KsqlAggregateFunction<BigDecimal, BigDecimal, BigDecimal> getInstance(
-      final AggregateFunctionArguments aggregateFunctionArguments
-  ) {
-    return new DecimalMinKudaf(
-        functionName, aggregateFunctionArguments.udafIndex(), getReturnType());
-  }
 }

--- a/ksql-engine/src/main/java/io/confluent/ksql/function/udaf/min/DoubleMinKudaf.java
+++ b/ksql-engine/src/main/java/io/confluent/ksql/function/udaf/min/DoubleMinKudaf.java
@@ -15,8 +15,6 @@
 
 package io.confluent.ksql.function.udaf.min;
 
-import io.confluent.ksql.function.AggregateFunctionArguments;
-import io.confluent.ksql.function.KsqlAggregateFunction;
 import io.confluent.ksql.function.udaf.BaseNumberKudaf;
 import org.apache.kafka.connect.data.Schema;
 
@@ -28,11 +26,5 @@ public class DoubleMinKudaf extends BaseNumberKudaf<Double> {
           Schema.OPTIONAL_FLOAT64_SCHEMA,
           Double::min,
           "Computes the minimum double value by key.");
-  }
-
-  @Override
-  public KsqlAggregateFunction<Double, Double, Double> getInstance(
-      final AggregateFunctionArguments aggregateFunctionArguments) {
-    return new DoubleMinKudaf(functionName, aggregateFunctionArguments.udafIndex());
   }
 }

--- a/ksql-engine/src/main/java/io/confluent/ksql/function/udaf/min/IntegerMinKudaf.java
+++ b/ksql-engine/src/main/java/io/confluent/ksql/function/udaf/min/IntegerMinKudaf.java
@@ -15,8 +15,6 @@
 
 package io.confluent.ksql.function.udaf.min;
 
-import io.confluent.ksql.function.AggregateFunctionArguments;
-import io.confluent.ksql.function.KsqlAggregateFunction;
 import io.confluent.ksql.function.udaf.BaseNumberKudaf;
 import org.apache.kafka.connect.data.Schema;
 
@@ -30,9 +28,4 @@ public class IntegerMinKudaf extends BaseNumberKudaf<Integer> {
           "Computes the minimum integer value for a key.");
   }
 
-  @Override
-  public KsqlAggregateFunction<Integer, Integer, Integer> getInstance(
-      final AggregateFunctionArguments aggregateFunctionArguments) {
-    return new IntegerMinKudaf(functionName, aggregateFunctionArguments.udafIndex());
-  }
 }

--- a/ksql-engine/src/main/java/io/confluent/ksql/function/udaf/min/LongMinKudaf.java
+++ b/ksql-engine/src/main/java/io/confluent/ksql/function/udaf/min/LongMinKudaf.java
@@ -15,8 +15,6 @@
 
 package io.confluent.ksql.function.udaf.min;
 
-import io.confluent.ksql.function.AggregateFunctionArguments;
-import io.confluent.ksql.function.KsqlAggregateFunction;
 import io.confluent.ksql.function.udaf.BaseNumberKudaf;
 import org.apache.kafka.connect.data.Schema;
 
@@ -30,9 +28,4 @@ public class LongMinKudaf extends BaseNumberKudaf<Long> {
           "Computes the minimum long value for a key.");
   }
 
-  @Override
-  public KsqlAggregateFunction<Long, Long, Long> getInstance(
-      final AggregateFunctionArguments aggregateFunctionArguments) {
-    return new LongMinKudaf(functionName, aggregateFunctionArguments.udafIndex());
-  }
 }

--- a/ksql-engine/src/main/java/io/confluent/ksql/function/udaf/min/MinAggFunctionFactory.java
+++ b/ksql-engine/src/main/java/io/confluent/ksql/function/udaf/min/MinAggFunctionFactory.java
@@ -16,6 +16,7 @@
 package io.confluent.ksql.function.udaf.min;
 
 import io.confluent.ksql.function.AggregateFunctionFactory;
+import io.confluent.ksql.function.AggregateFunctionInitArguments;
 import io.confluent.ksql.function.KsqlAggregateFunction;
 import io.confluent.ksql.util.DecimalUtil;
 import io.confluent.ksql.util.KsqlException;
@@ -24,6 +25,7 @@ import java.util.List;
 import org.apache.kafka.connect.data.Schema;
 
 public class MinAggFunctionFactory extends AggregateFunctionFactory {
+
   private static final String FUNCTION_NAME = "MIN";
 
   public MinAggFunctionFactory() {
@@ -31,7 +33,9 @@ public class MinAggFunctionFactory extends AggregateFunctionFactory {
   }
 
   @Override
-  public KsqlAggregateFunction getProperAggregateFunction(final List<Schema> argTypeList) {
+  public KsqlAggregateFunction createAggregateFunction(
+      final List<Schema> argTypeList,
+      final AggregateFunctionInitArguments initArgs) {
     KsqlPreconditions.checkArgument(
         argTypeList.size() == 1,
         "expected exactly one argument to aggregate MAX function");
@@ -39,14 +43,14 @@ public class MinAggFunctionFactory extends AggregateFunctionFactory {
     final Schema argSchema = argTypeList.get(0);
     switch (argSchema.type()) {
       case INT32:
-        return new IntegerMinKudaf(FUNCTION_NAME, -1);
+        return new IntegerMinKudaf(FUNCTION_NAME, initArgs.udafIndex());
       case INT64:
-        return new LongMinKudaf(FUNCTION_NAME, -1);
+        return new LongMinKudaf(FUNCTION_NAME, initArgs.udafIndex());
       case FLOAT64:
-        return new DoubleMinKudaf(FUNCTION_NAME, -1);
+        return new DoubleMinKudaf(FUNCTION_NAME, initArgs.udafIndex());
       case BYTES:
         DecimalUtil.requireDecimal(argSchema);
-        return new DecimalMinKudaf(FUNCTION_NAME, -1, argSchema);
+        return new DecimalMinKudaf(FUNCTION_NAME, initArgs.udafIndex(), argSchema);
       default:
         throw new KsqlException("No Max aggregate function with " + argTypeList.get(0) + " "
             + " argument type exists!");

--- a/ksql-engine/src/main/java/io/confluent/ksql/function/udaf/sum/DecimalSumKudaf.java
+++ b/ksql-engine/src/main/java/io/confluent/ksql/function/udaf/sum/DecimalSumKudaf.java
@@ -16,9 +16,7 @@
 package io.confluent.ksql.function.udaf.sum;
 
 import io.confluent.ksql.execution.function.TableAggregationFunction;
-import io.confluent.ksql.function.AggregateFunctionArguments;
 import io.confluent.ksql.function.BaseAggregateFunction;
-import io.confluent.ksql.function.KsqlAggregateFunction;
 import io.confluent.ksql.util.DecimalUtil;
 import java.math.BigDecimal;
 import java.math.MathContext;
@@ -49,13 +47,6 @@ public class DecimalSumKudaf
         "Computes the sum of decimal values for a key, resulting in a decimal with the same "
             + "precision and scale.");
     context = new MathContext(DecimalUtil.precision(outputSchema));
-  }
-
-  @Override
-  public KsqlAggregateFunction<BigDecimal, BigDecimal, BigDecimal> getInstance(
-      final AggregateFunctionArguments aggregateFunctionArguments) {
-    return new DecimalSumKudaf(
-        functionName, aggregateFunctionArguments.udafIndex(), getAggregateType());
   }
 
   @Override

--- a/ksql-engine/src/main/java/io/confluent/ksql/function/udaf/sum/DoubleSumKudaf.java
+++ b/ksql-engine/src/main/java/io/confluent/ksql/function/udaf/sum/DoubleSumKudaf.java
@@ -16,9 +16,7 @@
 package io.confluent.ksql.function.udaf.sum;
 
 import io.confluent.ksql.execution.function.TableAggregationFunction;
-import io.confluent.ksql.function.AggregateFunctionArguments;
 import io.confluent.ksql.function.BaseAggregateFunction;
-import io.confluent.ksql.function.KsqlAggregateFunction;
 import java.util.Collections;
 import java.util.function.Function;
 import org.apache.kafka.connect.data.Schema;
@@ -64,9 +62,4 @@ public class DoubleSumKudaf
     return Function.identity();
   }
 
-  @Override
-  public KsqlAggregateFunction<Double, Double, Double> getInstance(
-      final AggregateFunctionArguments aggregateFunctionArguments) {
-    return new DoubleSumKudaf(functionName, aggregateFunctionArguments.udafIndex());
-  }
 }

--- a/ksql-engine/src/main/java/io/confluent/ksql/function/udaf/sum/IntegerSumKudaf.java
+++ b/ksql-engine/src/main/java/io/confluent/ksql/function/udaf/sum/IntegerSumKudaf.java
@@ -16,9 +16,7 @@
 package io.confluent.ksql.function.udaf.sum;
 
 import io.confluent.ksql.execution.function.TableAggregationFunction;
-import io.confluent.ksql.function.AggregateFunctionArguments;
 import io.confluent.ksql.function.BaseAggregateFunction;
-import io.confluent.ksql.function.KsqlAggregateFunction;
 import java.util.Collections;
 import java.util.function.Function;
 import org.apache.kafka.connect.data.Schema;
@@ -63,9 +61,4 @@ public class IntegerSumKudaf
     return Function.identity();
   }
 
-  @Override
-  public KsqlAggregateFunction<Integer, Integer, Integer> getInstance(
-      final AggregateFunctionArguments aggregateFunctionArguments) {
-    return new IntegerSumKudaf(functionName, aggregateFunctionArguments.udafIndex());
-  }
 }

--- a/ksql-engine/src/main/java/io/confluent/ksql/function/udaf/sum/LongSumKudaf.java
+++ b/ksql-engine/src/main/java/io/confluent/ksql/function/udaf/sum/LongSumKudaf.java
@@ -16,9 +16,7 @@
 package io.confluent.ksql.function.udaf.sum;
 
 import io.confluent.ksql.execution.function.TableAggregationFunction;
-import io.confluent.ksql.function.AggregateFunctionArguments;
 import io.confluent.ksql.function.BaseAggregateFunction;
-import io.confluent.ksql.function.KsqlAggregateFunction;
 import java.util.Collections;
 import java.util.function.Function;
 import org.apache.kafka.connect.data.Schema;
@@ -64,9 +62,4 @@ public class LongSumKudaf
     return Function.identity();
   }
 
-  @Override
-  public KsqlAggregateFunction<Long, Long, Long> getInstance(
-      final AggregateFunctionArguments aggregateFunctionArguments) {
-    return new LongSumKudaf(functionName, aggregateFunctionArguments.udafIndex());
-  }
 }

--- a/ksql-engine/src/main/java/io/confluent/ksql/function/udaf/sum/SumAggFunctionFactory.java
+++ b/ksql-engine/src/main/java/io/confluent/ksql/function/udaf/sum/SumAggFunctionFactory.java
@@ -16,6 +16,7 @@
 package io.confluent.ksql.function.udaf.sum;
 
 import io.confluent.ksql.function.AggregateFunctionFactory;
+import io.confluent.ksql.function.AggregateFunctionInitArguments;
 import io.confluent.ksql.function.KsqlAggregateFunction;
 import io.confluent.ksql.util.DecimalUtil;
 import io.confluent.ksql.util.KsqlException;
@@ -24,6 +25,7 @@ import java.util.List;
 import org.apache.kafka.connect.data.Schema;
 
 public class SumAggFunctionFactory extends AggregateFunctionFactory {
+
   private static final String FUNCTION_NAME = "SUM";
 
   public SumAggFunctionFactory() {
@@ -31,7 +33,10 @@ public class SumAggFunctionFactory extends AggregateFunctionFactory {
   }
 
   @Override
-  public KsqlAggregateFunction getProperAggregateFunction(final List<Schema> argTypeList) {
+  public KsqlAggregateFunction createAggregateFunction(
+      final List<Schema> argTypeList,
+      final AggregateFunctionInitArguments initArgs
+  ) {
     KsqlPreconditions.checkArgument(
         argTypeList.size() == 1,
         "expected exactly one argument to aggregate MAX function");
@@ -39,14 +44,14 @@ public class SumAggFunctionFactory extends AggregateFunctionFactory {
     final Schema argSchema = argTypeList.get(0);
     switch (argSchema.type()) {
       case INT32:
-        return new IntegerSumKudaf(FUNCTION_NAME, -1);
+        return new IntegerSumKudaf(FUNCTION_NAME, initArgs.udafIndex());
       case INT64:
-        return new LongSumKudaf(FUNCTION_NAME, -1);
+        return new LongSumKudaf(FUNCTION_NAME, initArgs.udafIndex());
       case FLOAT64:
-        return new DoubleSumKudaf(FUNCTION_NAME, -1);
+        return new DoubleSumKudaf(FUNCTION_NAME, initArgs.udafIndex());
       case BYTES:
         DecimalUtil.requireDecimal(argSchema);
-        return new DecimalSumKudaf(FUNCTION_NAME, -1, argSchema);
+        return new DecimalSumKudaf(FUNCTION_NAME, initArgs.udafIndex(), argSchema);
       default:
         throw new KsqlException("No Max aggregate function with " + argTypeList.get(0) + " "
             + " argument type exists!");

--- a/ksql-engine/src/main/java/io/confluent/ksql/function/udaf/topk/TopKAggregateFunctionFactory.java
+++ b/ksql-engine/src/main/java/io/confluent/ksql/function/udaf/topk/TopKAggregateFunctionFactory.java
@@ -17,6 +17,7 @@ package io.confluent.ksql.function.udaf.topk;
 
 import com.google.common.collect.ImmutableList;
 import io.confluent.ksql.function.AggregateFunctionFactory;
+import io.confluent.ksql.function.AggregateFunctionInitArguments;
 import io.confluent.ksql.function.KsqlAggregateFunction;
 import io.confluent.ksql.util.KsqlException;
 import java.util.Collections;
@@ -25,8 +26,8 @@ import org.apache.kafka.connect.data.Schema;
 import org.apache.kafka.connect.data.SchemaBuilder;
 
 public class TopKAggregateFunctionFactory extends AggregateFunctionFactory {
+
   private static final String NAME = "TOPK";
-  private final int topKSize;
 
   private static final List<List<Schema>> SUPPORTED_TYPES = ImmutableList
       .<List<Schema>>builder()
@@ -38,61 +39,67 @@ public class TopKAggregateFunctionFactory extends AggregateFunctionFactory {
 
   public TopKAggregateFunctionFactory() {
     super(NAME);
-    this.topKSize = 0;
   }
 
-  TopKAggregateFunctionFactory(final int topKSize) {
-    super(NAME);
-    this.topKSize = topKSize;
-  }
+  private static final AggregateFunctionInitArguments DEFAULT_INIT_ARGS =
+      new AggregateFunctionInitArguments(0, "1");
 
   @Override
-  public KsqlAggregateFunction getProperAggregateFunction(final List<Schema> argumentType) {
+  public KsqlAggregateFunction createAggregateFunction(
+      final List<Schema> argumentType,
+      final AggregateFunctionInitArguments initArgs
+  ) {
     if (argumentType.isEmpty()) {
       throw new KsqlException("TOPK function should have two arguments.");
     }
+    final int tkValFromArg = Integer.parseInt(initArgs.arg(0));
     final Schema argSchema = argumentType.get(0);
     switch (argSchema.type()) {
       case INT32:
         return new TopkKudaf<>(
             NAME,
-            -1,
-            topKSize,
+            initArgs.udafIndex(),
+            tkValFromArg,
             SchemaBuilder.array(Schema.OPTIONAL_INT32_SCHEMA).optional().build(),
             Collections.singletonList(Schema.OPTIONAL_INT32_SCHEMA),
             Integer.class);
       case INT64:
         return new TopkKudaf<>(
             NAME,
-            -1,
-            topKSize,
+            initArgs.udafIndex(),
+            tkValFromArg,
             SchemaBuilder.array(Schema.OPTIONAL_INT64_SCHEMA).optional().build(),
             Collections.singletonList(Schema.OPTIONAL_INT64_SCHEMA),
             Long.class);
       case FLOAT64:
         return new TopkKudaf<>(
             NAME,
-            -1,
-            topKSize,
+            initArgs.udafIndex(),
+            tkValFromArg,
             SchemaBuilder.array(Schema.OPTIONAL_FLOAT64_SCHEMA).optional().build(),
             Collections.singletonList(Schema.OPTIONAL_FLOAT64_SCHEMA),
             Double.class);
       case STRING:
         return new TopkKudaf<>(
             NAME,
-            -1,
-            topKSize,
+            initArgs.udafIndex(),
+            tkValFromArg,
             SchemaBuilder.array(Schema.OPTIONAL_STRING_SCHEMA).optional().build(),
             Collections.singletonList(Schema.OPTIONAL_STRING_SCHEMA),
             String.class);
       default:
         throw new KsqlException("No TOPK aggregate function with " + argumentType.get(0)
-                                + " argument type exists!");
+            + " argument type exists!");
     }
   }
 
   @Override
   public List<List<Schema>> supportedArgs() {
     return SUPPORTED_TYPES;
+  }
+
+  @Override
+  public AggregateFunctionInitArguments getDefaultArguments() {
+    return DEFAULT_INIT_ARGS;
   }
 }

--- a/ksql-engine/src/main/java/io/confluent/ksql/function/udaf/topk/TopkKudaf.java
+++ b/ksql-engine/src/main/java/io/confluent/ksql/function/udaf/topk/TopkKudaf.java
@@ -15,9 +15,7 @@
 
 package io.confluent.ksql.function.udaf.topk;
 
-import io.confluent.ksql.function.AggregateFunctionArguments;
 import io.confluent.ksql.function.BaseAggregateFunction;
-import io.confluent.ksql.function.KsqlAggregateFunction;
 import java.util.ArrayList;
 import java.util.Comparator;
 import java.util.List;
@@ -117,13 +115,4 @@ public class TopkKudaf<T extends Comparable<? super T>>
     return Function.identity();
   }
 
-  @Override
-  public KsqlAggregateFunction<T, List<T>, List<T>> getInstance(
-      final AggregateFunctionArguments aggregateFunctionArguments) {
-    aggregateFunctionArguments.ensureArgCount(2, "TopK");
-    final int udafIndex = aggregateFunctionArguments.udafIndex();
-    final int topKSize = Integer.parseInt(aggregateFunctionArguments.arg(1));
-    return new TopkKudaf<>(functionName, udafIndex, topKSize, outputSchema,
-                           argumentTypes, clazz);
-  }
 }

--- a/ksql-engine/src/main/java/io/confluent/ksql/function/udaf/topkdistinct/TopkDistinctKudaf.java
+++ b/ksql-engine/src/main/java/io/confluent/ksql/function/udaf/topkdistinct/TopkDistinctKudaf.java
@@ -15,9 +15,7 @@
 
 package io.confluent.ksql.function.udaf.topkdistinct;
 
-import io.confluent.ksql.function.AggregateFunctionArguments;
 import io.confluent.ksql.function.BaseAggregateFunction;
-import io.confluent.ksql.function.KsqlAggregateFunction;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.Comparator;
@@ -125,17 +123,4 @@ public class TopkDistinctKudaf<T extends Comparable<? super T>>
     return idx < aggList.size() ? aggList.get(idx) : null;
   }
 
-  @Override
-  public KsqlAggregateFunction<T, List<T>, List<T>> getInstance(
-      final AggregateFunctionArguments aggregateFunctionArguments) {
-    aggregateFunctionArguments.ensureArgCount(2, "TopkDistinct");
-    final int udafIndex = aggregateFunctionArguments.udafIndex();
-    final int tkValFromArg = Integer.parseInt(aggregateFunctionArguments.arg(1));
-    return new TopkDistinctKudaf<>(functionName, udafIndex, tkValFromArg,
-                                   outputSchema, ttClass);
-  }
-
-  Schema getOutputSchema() {
-    return outputSchema;
-  }
 }

--- a/ksql-engine/src/test/java/io/confluent/ksql/function/BaseAggregateFunctionTest.java
+++ b/ksql-engine/src/test/java/io/confluent/ksql/function/BaseAggregateFunctionTest.java
@@ -90,12 +90,6 @@ public class BaseAggregateFunctionTest {
     }
 
     @Override
-    public KsqlAggregateFunction<String, Integer, Integer> getInstance(
-        final AggregateFunctionArguments args) {
-      return null;
-    }
-
-    @Override
     public Integer aggregate(final String currentValue, final Integer aggregateValue) {
       return null;
     }

--- a/ksql-engine/src/test/java/io/confluent/ksql/function/InternalFunctionRegistryTest.java
+++ b/ksql-engine/src/test/java/io/confluent/ksql/function/InternalFunctionRegistryTest.java
@@ -307,7 +307,7 @@ public class InternalFunctionRegistryTest {
             return ImmutableList.of();
           }
         });
-    assertThat(functionRegistry.getAggregate("my_aggregate",
+    assertThat(functionRegistry.getAggregateFunction("my_aggregate",
         Schema.OPTIONAL_INT32_SCHEMA,
         AggregateFunctionInitArguments.EMPTY_ARGS), not(nullValue()));
   }

--- a/ksql-engine/src/test/java/io/confluent/ksql/function/InternalFunctionRegistryTest.java
+++ b/ksql-engine/src/test/java/io/confluent/ksql/function/InternalFunctionRegistryTest.java
@@ -236,12 +236,9 @@ public class InternalFunctionRegistryTest {
     functionRegistry.addAggregateFunctionFactory(
         new AggregateFunctionFactory("my_aggregate") {
           @Override
-          public KsqlAggregateFunction getProperAggregateFunction(final List<Schema> argTypeList) {
+          public KsqlAggregateFunction createAggregateFunction(final List<Schema> argTypeList,
+              final AggregateFunctionInitArguments initArgs) {
             return new KsqlAggregateFunction() {
-              @Override
-              public KsqlAggregateFunction getInstance(final AggregateFunctionArguments aggregateFunctionArguments) {
-                return null;
-              }
 
               @Override
               public FunctionName getFunctionName() {
@@ -279,11 +276,6 @@ public class InternalFunctionRegistryTest {
               }
 
               @Override
-              public boolean hasSameArgTypes(final List argTypeList) {
-                return false;
-              }
-
-              @Override
               public Object aggregate(final Object currentValue, final Object aggregateValue) {
                 return null;
               }
@@ -315,7 +307,9 @@ public class InternalFunctionRegistryTest {
             return ImmutableList.of();
           }
         });
-    assertThat(functionRegistry.getAggregate("my_aggregate", Schema.OPTIONAL_INT32_SCHEMA), not(nullValue()));
+    assertThat(functionRegistry.getAggregate("my_aggregate",
+        Schema.OPTIONAL_INT32_SCHEMA,
+        AggregateFunctionInitArguments.EMPTY_ARGS), not(nullValue()));
   }
 
   @Test

--- a/ksql-engine/src/test/java/io/confluent/ksql/function/KudafUndoAggregatorTest.java
+++ b/ksql-engine/src/test/java/io/confluent/ksql/function/KudafUndoAggregatorTest.java
@@ -23,7 +23,6 @@ import io.confluent.ksql.GenericRow;
 import io.confluent.ksql.execution.function.TableAggregationFunction;
 import io.confluent.ksql.execution.function.udaf.KudafUndoAggregator;
 import java.util.Arrays;
-import java.util.Collections;
 import java.util.List;
 import org.apache.kafka.connect.data.Schema;
 import org.junit.Before;
@@ -33,18 +32,16 @@ public class KudafUndoAggregatorTest {
   private static final InternalFunctionRegistry FUNCTION_REGISTRY = new InternalFunctionRegistry();
   private static final KsqlAggregateFunction SUM_INFO = FUNCTION_REGISTRY.getAggregate(
       "SUM",
-      Schema.OPTIONAL_INT32_SCHEMA
+      Schema.OPTIONAL_INT32_SCHEMA,
+      new AggregateFunctionInitArguments(2)
   );
 
   private KudafUndoAggregator aggregator;
 
   @Before
   public void init() {
-    final List<TableAggregationFunction<?, ?, ?>> functions = ImmutableList.of(
-        (TableAggregationFunction<?, ?, ?>) SUM_INFO.getInstance(
-            new AggregateFunctionArguments(2, Collections.singletonList("baz"))
-        )
-    );
+    final List<TableAggregationFunction<?, ?, ?>> functions =
+        ImmutableList.of((TableAggregationFunction)SUM_INFO);
     aggregator = new KudafUndoAggregator(2, functions);
   }
 

--- a/ksql-engine/src/test/java/io/confluent/ksql/function/KudafUndoAggregatorTest.java
+++ b/ksql-engine/src/test/java/io/confluent/ksql/function/KudafUndoAggregatorTest.java
@@ -30,7 +30,7 @@ import org.junit.Test;
 
 public class KudafUndoAggregatorTest {
   private static final InternalFunctionRegistry FUNCTION_REGISTRY = new InternalFunctionRegistry();
-  private static final KsqlAggregateFunction SUM_INFO = FUNCTION_REGISTRY.getAggregate(
+  private static final KsqlAggregateFunction SUM_INFO = FUNCTION_REGISTRY.getAggregateFunction(
       "SUM",
       Schema.OPTIONAL_INT32_SCHEMA,
       new AggregateFunctionInitArguments(2)

--- a/ksql-engine/src/test/java/io/confluent/ksql/function/UdfLoaderTest.java
+++ b/ksql-engine/src/test/java/io/confluent/ksql/function/UdfLoaderTest.java
@@ -109,10 +109,9 @@ public class UdfLoaderTest {
   @SuppressWarnings("unchecked")
   @Test
   public void shouldLoadUdafs() {
-    final KsqlAggregateFunction aggregate = FUNC_REG
-        .getAggregate("test_udaf", Schema.OPTIONAL_INT64_SCHEMA);
-    final KsqlAggregateFunction<Long, Long, Long> instance = aggregate.getInstance(
-        new AggregateFunctionArguments(0, Collections.singletonList("udfIndex")));
+    final KsqlAggregateFunction instance = FUNC_REG
+        .getAggregate("test_udaf", Schema.OPTIONAL_INT64_SCHEMA,
+            AggregateFunctionInitArguments.EMPTY_ARGS);
     assertThat(instance.getInitialValueSupplier().get(), equalTo(0L));
     assertThat(instance.aggregate(1L, 1L), equalTo(2L));
     assertThat(instance.getMerger().apply(null, 2L, 3L), equalTo(5L));
@@ -127,10 +126,8 @@ public class UdfLoaderTest {
         .optional()
         .build();
 
-    final KsqlAggregateFunction aggregate = FUNC_REG
-        .getAggregate("test_udaf", schema);
-    final KsqlAggregateFunction<Struct, Struct, Struct> instance = aggregate.getInstance(
-        new AggregateFunctionArguments(0, Collections.singletonList("udfIndex")));
+    final KsqlAggregateFunction instance = FUNC_REG
+        .getAggregate("test_udaf", schema, AggregateFunctionInitArguments.EMPTY_ARGS);
 
     assertThat(instance.getInitialValueSupplier().get(),
         equalTo(new Struct(schema).put("A", 0).put("B", 0)));

--- a/ksql-engine/src/test/java/io/confluent/ksql/function/UdfLoaderTest.java
+++ b/ksql-engine/src/test/java/io/confluent/ksql/function/UdfLoaderTest.java
@@ -110,7 +110,7 @@ public class UdfLoaderTest {
   @Test
   public void shouldLoadUdafs() {
     final KsqlAggregateFunction instance = FUNC_REG
-        .getAggregate("test_udaf", Schema.OPTIONAL_INT64_SCHEMA,
+        .getAggregateFunction("test_udaf", Schema.OPTIONAL_INT64_SCHEMA,
             AggregateFunctionInitArguments.EMPTY_ARGS);
     assertThat(instance.getInitialValueSupplier().get(), equalTo(0L));
     assertThat(instance.aggregate(1L, 1L), equalTo(2L));
@@ -127,7 +127,7 @@ public class UdfLoaderTest {
         .build();
 
     final KsqlAggregateFunction instance = FUNC_REG
-        .getAggregate("test_udaf", schema, AggregateFunctionInitArguments.EMPTY_ARGS);
+        .getAggregateFunction("test_udaf", schema, AggregateFunctionInitArguments.EMPTY_ARGS);
 
     assertThat(instance.getInitialValueSupplier().get(),
         equalTo(new Struct(schema).put("A", 0).put("B", 0)));

--- a/ksql-engine/src/test/java/io/confluent/ksql/function/udaf/count/CountKudafTest.java
+++ b/ksql-engine/src/test/java/io/confluent/ksql/function/udaf/count/CountKudafTest.java
@@ -19,6 +19,7 @@ import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.CoreMatchers.instanceOf;
 import static org.junit.Assert.assertThat;
 
+import io.confluent.ksql.function.AggregateFunctionInitArguments;
 import io.confluent.ksql.function.KsqlAggregateFunction;
 import java.util.Collections;
 import org.apache.kafka.connect.data.Schema;
@@ -88,7 +89,8 @@ public class CountKudafTest {
 
   private CountKudaf getDoubleCountKudaf() {
     final KsqlAggregateFunction aggregateFunction = new CountAggFunctionFactory()
-        .getProperAggregateFunction(Collections.singletonList(Schema.OPTIONAL_FLOAT64_SCHEMA));
+        .createAggregateFunction(Collections.singletonList(Schema.OPTIONAL_FLOAT64_SCHEMA),
+            AggregateFunctionInitArguments.EMPTY_ARGS);
     assertThat(aggregateFunction, instanceOf(CountKudaf.class));
     return  (CountKudaf) aggregateFunction;
   }

--- a/ksql-engine/src/test/java/io/confluent/ksql/function/udaf/max/DecimalMaxKudafTest.java
+++ b/ksql-engine/src/test/java/io/confluent/ksql/function/udaf/max/DecimalMaxKudafTest.java
@@ -20,6 +20,7 @@ import static org.hamcrest.CoreMatchers.instanceOf;
 import static org.hamcrest.Matchers.is;
 import static org.junit.Assert.assertThat;
 
+import io.confluent.ksql.function.AggregateFunctionInitArguments;
 import io.confluent.ksql.function.KsqlAggregateFunction;
 import io.confluent.ksql.util.DecimalUtil;
 import java.math.BigDecimal;
@@ -78,7 +79,8 @@ public class DecimalMaxKudafTest {
 
   private DecimalMaxKudaf getDecimalMaxKudaf(final int precision) {
     final KsqlAggregateFunction aggregateFunction = new MaxAggFunctionFactory()
-        .getProperAggregateFunction(Collections.singletonList(DecimalUtil.builder(precision, 1)));
+        .createAggregateFunction(Collections.singletonList(DecimalUtil.builder(precision, 1))
+            , AggregateFunctionInitArguments.EMPTY_ARGS);
     assertThat(aggregateFunction, instanceOf(DecimalMaxKudaf.class));
     return  (DecimalMaxKudaf) aggregateFunction;
   }

--- a/ksql-engine/src/test/java/io/confluent/ksql/function/udaf/max/DoubleMaxKudafTest.java
+++ b/ksql-engine/src/test/java/io/confluent/ksql/function/udaf/max/DoubleMaxKudafTest.java
@@ -19,6 +19,7 @@ import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.CoreMatchers.instanceOf;
 import static org.junit.Assert.assertThat;
 
+import io.confluent.ksql.function.AggregateFunctionInitArguments;
 import io.confluent.ksql.function.KsqlAggregateFunction;
 import java.util.Collections;
 import org.apache.kafka.connect.data.Schema;
@@ -74,7 +75,8 @@ public class DoubleMaxKudafTest {
 
   private DoubleMaxKudaf getDoubleMaxKudaf() {
     final KsqlAggregateFunction aggregateFunction = new MaxAggFunctionFactory()
-        .getProperAggregateFunction(Collections.singletonList(Schema.OPTIONAL_FLOAT64_SCHEMA));
+        .createAggregateFunction(Collections.singletonList(Schema.OPTIONAL_FLOAT64_SCHEMA),
+            AggregateFunctionInitArguments.EMPTY_ARGS);
     assertThat(aggregateFunction, instanceOf(DoubleMaxKudaf.class));
     return  (DoubleMaxKudaf) aggregateFunction;
   }

--- a/ksql-engine/src/test/java/io/confluent/ksql/function/udaf/max/IntegerMaxKudafTest.java
+++ b/ksql-engine/src/test/java/io/confluent/ksql/function/udaf/max/IntegerMaxKudafTest.java
@@ -19,6 +19,7 @@ import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.CoreMatchers.instanceOf;
 import static org.junit.Assert.assertThat;
 
+import io.confluent.ksql.function.AggregateFunctionInitArguments;
 import io.confluent.ksql.function.KsqlAggregateFunction;
 import java.util.Collections;
 import org.apache.kafka.connect.data.Schema;
@@ -75,7 +76,8 @@ public class IntegerMaxKudafTest {
 
   private IntegerMaxKudaf getIntegerMaxKudaf() {
     final KsqlAggregateFunction aggregateFunction = new MaxAggFunctionFactory()
-        .getProperAggregateFunction(Collections.singletonList(Schema.OPTIONAL_INT32_SCHEMA));
+        .createAggregateFunction(Collections.singletonList(Schema.OPTIONAL_INT32_SCHEMA),
+            AggregateFunctionInitArguments.EMPTY_ARGS);
     assertThat(aggregateFunction, instanceOf(IntegerMaxKudaf.class));
     return  (IntegerMaxKudaf) aggregateFunction;
   }

--- a/ksql-engine/src/test/java/io/confluent/ksql/function/udaf/max/LongMaxKudafTest.java
+++ b/ksql-engine/src/test/java/io/confluent/ksql/function/udaf/max/LongMaxKudafTest.java
@@ -19,6 +19,7 @@ import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.CoreMatchers.instanceOf;
 import static org.junit.Assert.assertThat;
 
+import io.confluent.ksql.function.AggregateFunctionInitArguments;
 import io.confluent.ksql.function.KsqlAggregateFunction;
 import java.util.Collections;
 import org.apache.kafka.connect.data.Schema;
@@ -75,7 +76,8 @@ public class LongMaxKudafTest {
 
   private LongMaxKudaf getLongMaxKudaf() {
     final KsqlAggregateFunction aggregateFunction = new MaxAggFunctionFactory()
-        .getProperAggregateFunction(Collections.singletonList(Schema.OPTIONAL_INT64_SCHEMA));
+        .createAggregateFunction(Collections.singletonList(Schema.OPTIONAL_INT64_SCHEMA),
+            AggregateFunctionInitArguments.EMPTY_ARGS);
     assertThat(aggregateFunction, instanceOf(LongMaxKudaf.class));
     return  (LongMaxKudaf) aggregateFunction;
   }

--- a/ksql-engine/src/test/java/io/confluent/ksql/function/udaf/min/DecimalMinKudafTest.java
+++ b/ksql-engine/src/test/java/io/confluent/ksql/function/udaf/min/DecimalMinKudafTest.java
@@ -20,6 +20,7 @@ import static org.hamcrest.CoreMatchers.instanceOf;
 import static org.hamcrest.Matchers.is;
 import static org.junit.Assert.assertThat;
 
+import io.confluent.ksql.function.AggregateFunctionInitArguments;
 import io.confluent.ksql.function.KsqlAggregateFunction;
 import io.confluent.ksql.util.DecimalUtil;
 import java.math.BigDecimal;
@@ -78,7 +79,8 @@ public class DecimalMinKudafTest {
 
   private DecimalMinKudaf getDecimalMinKudaf(final int precision) {
     final KsqlAggregateFunction aggregateFunction = new MinAggFunctionFactory()
-        .getProperAggregateFunction(Collections.singletonList(DecimalUtil.builder(precision, 1)));
+        .createAggregateFunction(Collections.singletonList(DecimalUtil.builder(precision, 1)),
+            AggregateFunctionInitArguments.EMPTY_ARGS);
     assertThat(aggregateFunction, instanceOf(DecimalMinKudaf.class));
     return  (DecimalMinKudaf) aggregateFunction;
   }

--- a/ksql-engine/src/test/java/io/confluent/ksql/function/udaf/min/DoubleMinKudafTest.java
+++ b/ksql-engine/src/test/java/io/confluent/ksql/function/udaf/min/DoubleMinKudafTest.java
@@ -19,6 +19,7 @@ import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.CoreMatchers.instanceOf;
 import static org.junit.Assert.assertThat;
 
+import io.confluent.ksql.function.AggregateFunctionInitArguments;
 import io.confluent.ksql.function.KsqlAggregateFunction;
 import java.util.Collections;
 import org.apache.kafka.connect.data.Schema;
@@ -76,7 +77,8 @@ public class DoubleMinKudafTest {
 
   private DoubleMinKudaf getDoubleMinKudaf() {
     final KsqlAggregateFunction aggregateFunction = new MinAggFunctionFactory()
-        .getProperAggregateFunction(Collections.singletonList(Schema.OPTIONAL_FLOAT64_SCHEMA));
+        .createAggregateFunction(Collections.singletonList(Schema.OPTIONAL_FLOAT64_SCHEMA),
+            AggregateFunctionInitArguments.EMPTY_ARGS);
     assertThat(aggregateFunction, instanceOf(DoubleMinKudaf.class));
     return  (DoubleMinKudaf) aggregateFunction;
   }

--- a/ksql-engine/src/test/java/io/confluent/ksql/function/udaf/min/IntegerMinKudafTest.java
+++ b/ksql-engine/src/test/java/io/confluent/ksql/function/udaf/min/IntegerMinKudafTest.java
@@ -19,6 +19,7 @@ import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.CoreMatchers.instanceOf;
 import static org.junit.Assert.assertThat;
 
+import io.confluent.ksql.function.AggregateFunctionInitArguments;
 import io.confluent.ksql.function.KsqlAggregateFunction;
 import java.util.Collections;
 import org.apache.kafka.connect.data.Schema;
@@ -76,7 +77,8 @@ public class IntegerMinKudafTest {
 
   private IntegerMinKudaf getIntegerMinKudaf() {
     final KsqlAggregateFunction aggregateFunction = new MinAggFunctionFactory()
-        .getProperAggregateFunction(Collections.singletonList(Schema.OPTIONAL_INT32_SCHEMA));
+        .createAggregateFunction(Collections.singletonList(Schema.OPTIONAL_INT32_SCHEMA),
+            AggregateFunctionInitArguments.EMPTY_ARGS);
     assertThat(aggregateFunction, instanceOf(IntegerMinKudaf.class));
     return  (IntegerMinKudaf) aggregateFunction;
   }

--- a/ksql-engine/src/test/java/io/confluent/ksql/function/udaf/min/LongMinKudafTest.java
+++ b/ksql-engine/src/test/java/io/confluent/ksql/function/udaf/min/LongMinKudafTest.java
@@ -19,6 +19,7 @@ import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.CoreMatchers.instanceOf;
 import static org.junit.Assert.assertThat;
 
+import io.confluent.ksql.function.AggregateFunctionInitArguments;
 import io.confluent.ksql.function.KsqlAggregateFunction;
 import java.util.Collections;
 import org.apache.kafka.connect.data.Schema;
@@ -76,7 +77,8 @@ public class LongMinKudafTest {
 
   private LongMinKudaf getLongMinKudaf() {
     final KsqlAggregateFunction aggregateFunction = new MinAggFunctionFactory()
-        .getProperAggregateFunction(Collections.singletonList(Schema.OPTIONAL_INT64_SCHEMA));
+        .createAggregateFunction(Collections.singletonList(Schema.OPTIONAL_INT64_SCHEMA),
+            AggregateFunctionInitArguments.EMPTY_ARGS);
     assertThat(aggregateFunction, instanceOf(LongMinKudaf.class));
     return  (LongMinKudaf) aggregateFunction;
   }

--- a/ksql-engine/src/test/java/io/confluent/ksql/function/udaf/sum/DecimalSumKudafTest.java
+++ b/ksql-engine/src/test/java/io/confluent/ksql/function/udaf/sum/DecimalSumKudafTest.java
@@ -18,6 +18,7 @@ package io.confluent.ksql.function.udaf.sum;
 import static org.hamcrest.CoreMatchers.instanceOf;
 import static org.junit.Assert.assertThat;
 
+import io.confluent.ksql.function.AggregateFunctionInitArguments;
 import io.confluent.ksql.function.KsqlAggregateFunction;
 import io.confluent.ksql.util.DecimalUtil;
 import java.math.BigDecimal;
@@ -31,7 +32,8 @@ public class DecimalSumKudafTest extends BaseSumKudafTest<BigDecimal, DecimalSum
 
   protected DecimalSumKudaf getSumKudaf() {
     final KsqlAggregateFunction aggregateFunction = new SumAggFunctionFactory()
-        .getProperAggregateFunction(Collections.singletonList(DecimalUtil.builder(4, 2)));
+        .createAggregateFunction(Collections.singletonList(DecimalUtil.builder(4, 2)),
+            AggregateFunctionInitArguments.EMPTY_ARGS);
     assertThat(aggregateFunction, instanceOf(DecimalSumKudaf.class));
     return (DecimalSumKudaf) aggregateFunction;
   }

--- a/ksql-engine/src/test/java/io/confluent/ksql/function/udaf/sum/DoubleSumKudafTest.java
+++ b/ksql-engine/src/test/java/io/confluent/ksql/function/udaf/sum/DoubleSumKudafTest.java
@@ -18,6 +18,7 @@ package io.confluent.ksql.function.udaf.sum;
 import static org.hamcrest.CoreMatchers.instanceOf;
 import static org.junit.Assert.assertThat;
 
+import io.confluent.ksql.function.AggregateFunctionInitArguments;
 import io.confluent.ksql.function.KsqlAggregateFunction;
 import java.util.Collections;
 import org.apache.kafka.connect.data.Schema;
@@ -29,7 +30,8 @@ public class DoubleSumKudafTest extends BaseSumKudafTest<Double, DoubleSumKudaf>
 
   protected DoubleSumKudaf getSumKudaf() {
     final KsqlAggregateFunction aggregateFunction = new SumAggFunctionFactory()
-        .getProperAggregateFunction(Collections.singletonList(Schema.OPTIONAL_FLOAT64_SCHEMA));
+        .createAggregateFunction(Collections.singletonList(Schema.OPTIONAL_FLOAT64_SCHEMA),
+            AggregateFunctionInitArguments.EMPTY_ARGS);
     assertThat(aggregateFunction, instanceOf(DoubleSumKudaf.class));
     return  (DoubleSumKudaf) aggregateFunction;
   }

--- a/ksql-engine/src/test/java/io/confluent/ksql/function/udaf/sum/IntegerSumKudafTest.java
+++ b/ksql-engine/src/test/java/io/confluent/ksql/function/udaf/sum/IntegerSumKudafTest.java
@@ -18,6 +18,7 @@ package io.confluent.ksql.function.udaf.sum;
 import static org.hamcrest.CoreMatchers.instanceOf;
 import static org.junit.Assert.assertThat;
 
+import io.confluent.ksql.function.AggregateFunctionInitArguments;
 import io.confluent.ksql.function.KsqlAggregateFunction;
 import java.util.Collections;
 import org.apache.kafka.connect.data.Schema;
@@ -29,7 +30,8 @@ public class IntegerSumKudafTest extends BaseSumKudafTest<Integer, IntegerSumKud
 
   protected IntegerSumKudaf getSumKudaf() {
     final KsqlAggregateFunction aggregateFunction = new SumAggFunctionFactory()
-        .getProperAggregateFunction(Collections.singletonList(Schema.OPTIONAL_INT32_SCHEMA));
+        .createAggregateFunction(Collections.singletonList(Schema.OPTIONAL_INT32_SCHEMA),
+            AggregateFunctionInitArguments.EMPTY_ARGS);
     assertThat(aggregateFunction, instanceOf(IntegerSumKudaf.class));
     return  (IntegerSumKudaf) aggregateFunction;
   }

--- a/ksql-engine/src/test/java/io/confluent/ksql/function/udaf/sum/LongSumKudafTest.java
+++ b/ksql-engine/src/test/java/io/confluent/ksql/function/udaf/sum/LongSumKudafTest.java
@@ -18,6 +18,7 @@ package io.confluent.ksql.function.udaf.sum;
 import static org.hamcrest.CoreMatchers.instanceOf;
 import static org.junit.Assert.assertThat;
 
+import io.confluent.ksql.function.AggregateFunctionInitArguments;
 import io.confluent.ksql.function.KsqlAggregateFunction;
 import java.util.Collections;
 import org.apache.kafka.connect.data.Schema;
@@ -29,7 +30,8 @@ public class LongSumKudafTest extends BaseSumKudafTest<Long, LongSumKudaf> {
 
   protected LongSumKudaf getSumKudaf() {
     final KsqlAggregateFunction aggregateFunction = new SumAggFunctionFactory()
-        .getProperAggregateFunction(Collections.singletonList(Schema.OPTIONAL_INT64_SCHEMA));
+        .createAggregateFunction(Collections.singletonList(Schema.OPTIONAL_INT64_SCHEMA),
+            AggregateFunctionInitArguments.EMPTY_ARGS);
     assertThat(aggregateFunction, instanceOf(LongSumKudaf.class));
     return  (LongSumKudaf) aggregateFunction;
   }

--- a/ksql-engine/src/test/java/io/confluent/ksql/function/udaf/topk/DoubleTopkKudafTest.java
+++ b/ksql-engine/src/test/java/io/confluent/ksql/function/udaf/topk/DoubleTopkKudafTest.java
@@ -19,6 +19,7 @@ import static org.hamcrest.CoreMatchers.equalTo;
 import static org.junit.Assert.assertThat;
 
 import com.google.common.collect.ImmutableList;
+import io.confluent.ksql.function.AggregateFunctionInitArguments;
 import io.confluent.ksql.function.KsqlAggregateFunction;
 import java.util.ArrayList;
 import java.util.Collections;
@@ -34,16 +35,19 @@ public class DoubleTopkKudafTest {
   private TopKAggregateFunctionFactory topKFactory;
   private List<Schema> argumentType;
 
+  private final AggregateFunctionInitArguments args =
+      new AggregateFunctionInitArguments(0, "3");
+
   @Before
   public void setup() {
-    topKFactory = new TopKAggregateFunctionFactory(3);
+    topKFactory = new TopKAggregateFunctionFactory();
     argumentType = Collections.singletonList(Schema.OPTIONAL_FLOAT64_SCHEMA);
   }
 
   @Test
   public void shouldAggregateTopK() {
     final KsqlAggregateFunction<Object, List<Double>, List<Double>> topkKudaf =
-        topKFactory.getProperAggregateFunction(argumentType);
+        topKFactory.createAggregateFunction(argumentType, args);
     List<Double> window = new ArrayList<>();
     for (final Object value : valuesArray) {
       window = topkKudaf.aggregate(value , window);
@@ -55,7 +59,7 @@ public class DoubleTopkKudafTest {
   @Test
   public void shouldAggregateTopKWithLessThanKValues() {
     final KsqlAggregateFunction<Object, List<Double>, List<Double>> topkKudaf =
-        topKFactory.getProperAggregateFunction(argumentType);
+        topKFactory.createAggregateFunction(argumentType, args);
     List<Double> currentVal = new ArrayList<>();
     currentVal = topkKudaf.aggregate(10.0, currentVal);
 
@@ -65,7 +69,7 @@ public class DoubleTopkKudafTest {
   @Test
   public void shouldMergeTopK() {
     final KsqlAggregateFunction<Object, List<Double>, List<Double>> topkKudaf =
-        topKFactory.getProperAggregateFunction(argumentType);
+        topKFactory.createAggregateFunction(argumentType, args);
     final List<Double> array1 = ImmutableList.of(50.0, 45.0, 25.0);
     final List<Double> array2 = ImmutableList.of(60.0, 55.0, 48.0);
 
@@ -76,7 +80,7 @@ public class DoubleTopkKudafTest {
   @Test
   public void shouldMergeTopKWithNulls() {
     final KsqlAggregateFunction<Object, List<Double>, List<Double>> topkKudaf =
-        topKFactory.getProperAggregateFunction(argumentType);
+        topKFactory.createAggregateFunction(argumentType, args);
     final List<Double> array1 = ImmutableList.of(50.0, 45.0);
     final List<Double> array2 = ImmutableList.of(60.0);
 
@@ -87,7 +91,7 @@ public class DoubleTopkKudafTest {
   @Test
   public void shouldMergeTopKWithMoreNulls() {
     final KsqlAggregateFunction<Object, List<Double>, List<Double>> topkKudaf =
-        topKFactory.getProperAggregateFunction(argumentType);
+        topKFactory.createAggregateFunction(argumentType, args);
     final List<Double> array1 = ImmutableList.of(50.0);
     final List<Double> array2 = ImmutableList.of(60.0);
 

--- a/ksql-engine/src/test/java/io/confluent/ksql/function/udaf/topk/IntTopkKudafTest.java
+++ b/ksql-engine/src/test/java/io/confluent/ksql/function/udaf/topk/IntTopkKudafTest.java
@@ -20,6 +20,7 @@ import static org.hamcrest.CoreMatchers.is;
 import static org.junit.Assert.assertThat;
 
 import com.google.common.collect.ImmutableList;
+import io.confluent.ksql.function.AggregateFunctionInitArguments;
 import io.confluent.ksql.function.KsqlAggregateFunction;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -37,11 +38,16 @@ public class IntTopkKudafTest {
   private final List<Integer> valuesArray = ImmutableList.of(10, 30, 45, 10, 50, 60, 20, 60, 80, 35, 25);
   private KsqlAggregateFunction<Integer, List<Integer>, List<Integer>> topkKudaf;
 
+  private AggregateFunctionInitArguments createArgs(int k) {
+    return new AggregateFunctionInitArguments(0, String.valueOf(k));
+  }
+
   @SuppressWarnings("unchecked")
   @Before
   public void setup() {
-    topkKudaf = new TopKAggregateFunctionFactory(3)
-        .getProperAggregateFunction(Collections.singletonList(Schema.OPTIONAL_INT32_SCHEMA));
+    topkKudaf = new TopKAggregateFunctionFactory()
+        .createAggregateFunction(Collections.singletonList(Schema.OPTIONAL_INT32_SCHEMA),
+            createArgs(3));
   }
 
   @Test
@@ -102,8 +108,9 @@ public class IntTopkKudafTest {
   public void shouldWorkWithLargeValuesOfKay() {
     // Given:
     final int topKSize = 300;
-    topkKudaf = new TopKAggregateFunctionFactory(topKSize)
-        .getProperAggregateFunction(Collections.singletonList(Schema.OPTIONAL_INT32_SCHEMA));
+    topkKudaf = new TopKAggregateFunctionFactory()
+        .createAggregateFunction(Collections.singletonList(Schema.OPTIONAL_INT32_SCHEMA),
+            createArgs(topKSize));
     final List<Integer> initialAggregate = IntStream.range(0, topKSize)
             .boxed().sorted(Comparator.reverseOrder()).collect(Collectors.toList());
 
@@ -121,8 +128,9 @@ public class IntTopkKudafTest {
   @Test
   public void shouldBeThreadSafe() {
     // Given:
-    topkKudaf = new TopKAggregateFunctionFactory(12)
-        .getProperAggregateFunction(Collections.singletonList(Schema.OPTIONAL_INT32_SCHEMA));
+    topkKudaf = new TopKAggregateFunctionFactory()
+        .createAggregateFunction(Collections.singletonList(Schema.OPTIONAL_INT32_SCHEMA),
+            createArgs(12));
 
     final List<Integer> values = ImmutableList.of(10, 30, 45, 10, 50, 60, 20, 70, 80, 35, 25);
 
@@ -149,8 +157,9 @@ public class IntTopkKudafTest {
   public void testAggregatePerformance() {
     final int iterations = 1_000_000_000;
     final int topX = 10;
-    topkKudaf = new TopKAggregateFunctionFactory(topX)
-        .getProperAggregateFunction(Collections.singletonList(Schema.OPTIONAL_INT32_SCHEMA));
+    topkKudaf = new TopKAggregateFunctionFactory()
+        .createAggregateFunction(Collections.singletonList(Schema.OPTIONAL_INT32_SCHEMA),
+            createArgs(topX));
     final List<Integer> aggregate = new ArrayList<>();
     final long start = System.currentTimeMillis();
 
@@ -167,8 +176,9 @@ public class IntTopkKudafTest {
   public void testMergePerformance() {
     final int iterations = 1_000_000_000;
     final int topX = 10;
-    topkKudaf = new TopKAggregateFunctionFactory(topX)
-        .getProperAggregateFunction(Collections.singletonList(Schema.OPTIONAL_INT32_SCHEMA));
+    topkKudaf = new TopKAggregateFunctionFactory()
+        .createAggregateFunction(Collections.singletonList(Schema.OPTIONAL_INT32_SCHEMA),
+            createArgs(topX));
 
     final List<Integer> aggregate1 = IntStream.range(0, topX)
         .mapToObj(v -> v % 2 == 0 ? v + 1 : v)

--- a/ksql-engine/src/test/java/io/confluent/ksql/function/udaf/topk/LongTopkKudafTest.java
+++ b/ksql-engine/src/test/java/io/confluent/ksql/function/udaf/topk/LongTopkKudafTest.java
@@ -19,6 +19,7 @@ import static org.hamcrest.CoreMatchers.equalTo;
 import static org.junit.Assert.assertThat;
 
 import com.google.common.collect.ImmutableList;
+import io.confluent.ksql.function.AggregateFunctionInitArguments;
 import io.confluent.ksql.function.KsqlAggregateFunction;
 import java.util.ArrayList;
 import java.util.Collections;
@@ -33,17 +34,19 @@ public class LongTopkKudafTest {
       25L);
   private TopKAggregateFunctionFactory topKFactory;
   private List<Schema> argumentType;
-
+  private final AggregateFunctionInitArguments args =
+      new AggregateFunctionInitArguments(0, "3");
+      
   @Before
   public void setup() {
-    topKFactory = new TopKAggregateFunctionFactory(3);
+    topKFactory = new TopKAggregateFunctionFactory();
     argumentType = Collections.singletonList(Schema.OPTIONAL_INT64_SCHEMA);
   }
 
   @Test
   public void shouldAggregateTopK() {
     final KsqlAggregateFunction<Long, List<Long>, List<Long>> longTopkKudaf =
-        topKFactory.getProperAggregateFunction(argumentType);
+        topKFactory.createAggregateFunction(argumentType, args);
     List<Long> window = new ArrayList<>();
     for (final Long value : valuesArray) {
       window = longTopkKudaf.aggregate(value, window);
@@ -54,7 +57,7 @@ public class LongTopkKudafTest {
   @Test
   public void shouldAggregateTopKWithLessThanKValues() {
     final KsqlAggregateFunction<Long, List<Long>, List<Long>> longTopkKudaf =
-        topKFactory.getProperAggregateFunction(argumentType);
+        topKFactory.createAggregateFunction(argumentType, args);
     final List<Long> window = longTopkKudaf.aggregate(80L, new ArrayList());
     assertThat("Invalid results.", window, equalTo(ImmutableList.of(80L)));
   }
@@ -62,7 +65,7 @@ public class LongTopkKudafTest {
   @Test
   public void shouldMergeTopK() {
     final KsqlAggregateFunction<Long, List<Long>, List<Long>> topkKudaf =
-        topKFactory.getProperAggregateFunction(argumentType);
+        topKFactory.createAggregateFunction(argumentType, args);
     final List<Long> array1 = ImmutableList.of(50L, 45L, 25L);
     final List<Long> array2 = ImmutableList.of(60L, 55L, 48L);
 
@@ -73,7 +76,7 @@ public class LongTopkKudafTest {
   @Test
   public void shouldMergeTopKWithNulls() {
     final KsqlAggregateFunction<Long, List<Long>, List<Long>> topkKudaf =
-        topKFactory.getProperAggregateFunction(argumentType);
+        topKFactory.createAggregateFunction(argumentType, args);
     final List<Long> array1 = ImmutableList.of(50L, 45L);
     final List<Long> array2 = ImmutableList.of(60L);
 
@@ -84,7 +87,7 @@ public class LongTopkKudafTest {
   @Test
   public void shouldMergeTopKWithMoreNulls() {
     final KsqlAggregateFunction<Long, List<Long>, List<Long>> topkKudaf =
-        topKFactory.getProperAggregateFunction(argumentType);
+        topKFactory.createAggregateFunction(argumentType, args);
     final List<Long> array1 = ImmutableList.of(50L);
     final List<Long> array2 = ImmutableList.of(60L);
 

--- a/ksql-engine/src/test/java/io/confluent/ksql/function/udaf/topk/StringTopkKudafTest.java
+++ b/ksql-engine/src/test/java/io/confluent/ksql/function/udaf/topk/StringTopkKudafTest.java
@@ -19,6 +19,7 @@ import static org.hamcrest.CoreMatchers.equalTo;
 import static org.junit.Assert.assertThat;
 
 import com.google.common.collect.ImmutableList;
+import io.confluent.ksql.function.AggregateFunctionInitArguments;
 import io.confluent.ksql.function.KsqlAggregateFunction;
 import java.util.ArrayList;
 import java.util.Collections;
@@ -34,16 +35,19 @@ public class StringTopkKudafTest {
   private TopKAggregateFunctionFactory topKFactory;
   private List<Schema> argumentType;
 
+  private final AggregateFunctionInitArguments args =
+      new AggregateFunctionInitArguments(0, "3");
+
   @Before
   public void setup() {
-    topKFactory = new TopKAggregateFunctionFactory(3);
+    topKFactory = new TopKAggregateFunctionFactory();
     argumentType = Collections.singletonList(Schema.OPTIONAL_STRING_SCHEMA);
   }
 
   @Test
   public void shouldAggregateTopK() {
     final KsqlAggregateFunction<String, List<String>, List<String>> topkKudaf =
-        topKFactory.getProperAggregateFunction(argumentType);
+        topKFactory.createAggregateFunction(argumentType, args);
     List<String> currentVal = new ArrayList<>();
     for (final String value : valueArray) {
       currentVal = topkKudaf.aggregate(value , currentVal);
@@ -55,7 +59,7 @@ public class StringTopkKudafTest {
   @Test
   public void shouldAggregateTopKWithLessThanKValues() {
     final KsqlAggregateFunction<String, List<String>, List<String>> topkKudaf =
-        topKFactory.getProperAggregateFunction(argumentType);
+        topKFactory.createAggregateFunction(argumentType, args);
     List<String> currentVal = new ArrayList<>();
     currentVal = topkKudaf.aggregate("why", currentVal);
 
@@ -65,7 +69,7 @@ public class StringTopkKudafTest {
   @Test
   public void shouldMergeTopK() {
     final KsqlAggregateFunction<String, List<String>, List<String>> topkKudaf =
-        topKFactory.getProperAggregateFunction(argumentType);
+        topKFactory.createAggregateFunction(argumentType, args);
     final List<String> array1 = ImmutableList.of("paper", "Hello", "123");
     final List<String> array2 = ImmutableList.of("Zzz", "Hi", "456");
 
@@ -76,7 +80,7 @@ public class StringTopkKudafTest {
   @Test
   public void shouldMergeTopKWithNulls() {
     final KsqlAggregateFunction<String, List<String>, List<String>> topkKudaf =
-        topKFactory.getProperAggregateFunction(argumentType);
+        topKFactory.createAggregateFunction(argumentType, args);
     final List<String> array1 = ImmutableList.of("50", "45");
     final List<String> array2 = ImmutableList.of("60");
 
@@ -87,7 +91,7 @@ public class StringTopkKudafTest {
   @Test
   public void shouldMergeTopKWithMoreNulls() {
     final KsqlAggregateFunction<String, List<String>, List<String>> topkKudaf =
-        topKFactory.getProperAggregateFunction(argumentType);
+        topKFactory.createAggregateFunction(argumentType, args);
     final List<String> array1 = ImmutableList.of("50");
     final List<String> array2 = ImmutableList.of("60");
 

--- a/ksql-engine/src/test/java/io/confluent/ksql/function/udaf/topkdistinct/TopKDistinctTestUtils.java
+++ b/ksql-engine/src/test/java/io/confluent/ksql/function/udaf/topkdistinct/TopKDistinctTestUtils.java
@@ -15,8 +15,7 @@
 
 package io.confluent.ksql.function.udaf.topkdistinct;
 
-import io.confluent.ksql.function.AggregateFunctionArguments;
-import java.util.Arrays;
+import io.confluent.ksql.function.AggregateFunctionInitArguments;
 import java.util.Collections;
 import org.apache.kafka.connect.data.Schema;
 
@@ -25,9 +24,8 @@ public class TopKDistinctTestUtils {
   public static <T extends Comparable<? super T>> TopkDistinctKudaf<T> getTopKDistinctKudaf(
       final int topk, final Schema schema) {
     return (TopkDistinctKudaf<T>) new TopkDistinctAggFunctionFactory()
-        .getProperAggregateFunction(
-            Collections.singletonList(schema))
-        .getInstance(
-            new AggregateFunctionArguments(0, Arrays.asList("foo", Integer.toString(topk))));
+        .createAggregateFunction(
+            Collections.singletonList(schema),
+            new AggregateFunctionInitArguments(0, String.valueOf(topk)));
   }
 }

--- a/ksql-execution/src/main/java/io/confluent/ksql/execution/function/UdafUtil.java
+++ b/ksql-execution/src/main/java/io/confluent/ksql/execution/function/UdafUtil.java
@@ -63,7 +63,7 @@ public final class UdafUtil {
           .map(Expression::toString)
           .collect(Collectors.toList());
 
-      return functionRegistry.getAggregate(
+      return functionRegistry.getAggregateFunction(
           functionCall.getName().name(),
           argumentType,
           AggregateFunctionInitArguments.ofFunctionArgs(

--- a/ksql-execution/src/main/java/io/confluent/ksql/execution/util/ExpressionTypeManager.java
+++ b/ksql-execution/src/main/java/io/confluent/ksql/execution/util/ExpressionTypeManager.java
@@ -359,7 +359,7 @@ public class ExpressionTypeManager {
             AggregateFunctionInitArguments.ofFunctionArgs(0, sargs);
 
         final KsqlAggregateFunction aggFunc = functionRegistry
-            .getAggregate(node.getName().name(), schema, args);
+            .getAggregateFunction(node.getName().name(), schema, args);
 
         final Schema returnSchema = aggFunc.getReturnType();
 

--- a/ksql-execution/src/main/java/io/confluent/ksql/execution/util/ExpressionTypeManager.java
+++ b/ksql-execution/src/main/java/io/confluent/ksql/execution/util/ExpressionTypeManager.java
@@ -47,6 +47,7 @@ import io.confluent.ksql.execution.expression.tree.TimestampLiteral;
 import io.confluent.ksql.execution.expression.tree.Type;
 import io.confluent.ksql.execution.expression.tree.WhenClause;
 import io.confluent.ksql.execution.function.udf.structfieldextractor.FetchFieldFromStruct;
+import io.confluent.ksql.function.AggregateFunctionInitArguments;
 import io.confluent.ksql.function.FunctionRegistry;
 import io.confluent.ksql.function.KsqlAggregateFunction;
 import io.confluent.ksql.function.KsqlFunctionException;
@@ -67,6 +68,7 @@ import io.confluent.ksql.util.VisitorUtil;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Objects;
+import java.util.stream.Collectors;
 import org.apache.kafka.connect.data.Schema;
 
 @SuppressWarnings("deprecation") // Need to migrate away from Connect Schema use.
@@ -351,8 +353,13 @@ public class ExpressionTypeManager {
             ? FunctionRegistry.DEFAULT_FUNCTION_ARG_SCHEMA
             : getExpressionSchema(node.getArguments().get(0));
 
+        final List<String> sargs =
+            node.getArguments().stream().map(Object::toString).collect(Collectors.toList());
+        final AggregateFunctionInitArguments args =
+            AggregateFunctionInitArguments.ofFunctionArgs(0, sargs);
+
         final KsqlAggregateFunction aggFunc = functionRegistry
-            .getAggregate(node.getName().name(), schema);
+            .getAggregate(node.getName().name(), schema, args);
 
         final Schema returnSchema = aggFunc.getReturnType();
 

--- a/ksql-execution/src/test/java/io/confluent/ksql/execution/function/UdafUtilTest.java
+++ b/ksql-execution/src/test/java/io/confluent/ksql/execution/function/UdafUtilTest.java
@@ -63,7 +63,7 @@ public class UdafUtilTest {
   @Before
   @SuppressWarnings("unchecked")
   public void init() {
-    when(functionRegistry.getAggregate(any(), any(), any())).thenReturn(function);
+    when(functionRegistry.getAggregateFunction(any(), any(), any())).thenReturn(function);
   }
 
   @Test
@@ -82,7 +82,7 @@ public class UdafUtilTest {
     UdafUtil.resolveAggregateFunction(functionRegistry, FUNCTION_CALL, SCHEMA);
 
     // Then:
-    verify(functionRegistry).getAggregate(eq("AGG"), any(), any());
+    verify(functionRegistry).getAggregateFunction(eq("AGG"), any(), any());
   }
 
   @Test
@@ -91,7 +91,7 @@ public class UdafUtilTest {
     UdafUtil.resolveAggregateFunction(functionRegistry, FUNCTION_CALL, SCHEMA);
 
     // Then:
-    verify(functionRegistry).getAggregate(any(), eq(Schema.OPTIONAL_INT64_SCHEMA), any());
+    verify(functionRegistry).getAggregateFunction(any(), eq(Schema.OPTIONAL_INT64_SCHEMA), any());
   }
 
 }

--- a/ksql-execution/src/test/java/io/confluent/ksql/execution/function/UdafUtilTest.java
+++ b/ksql-execution/src/test/java/io/confluent/ksql/execution/function/UdafUtilTest.java
@@ -15,7 +15,6 @@
 
 package io.confluent.ksql.execution.function;
 
-import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.is;
 import static org.junit.Assert.assertThat;
 import static org.mockito.ArgumentMatchers.any;
@@ -26,7 +25,7 @@ import static org.mockito.Mockito.when;
 import com.google.common.collect.ImmutableList;
 import io.confluent.ksql.execution.expression.tree.ColumnReferenceExp;
 import io.confluent.ksql.execution.expression.tree.FunctionCall;
-import io.confluent.ksql.function.AggregateFunctionArguments;
+import io.confluent.ksql.function.AggregateFunctionInitArguments;
 import io.confluent.ksql.function.FunctionRegistry;
 import io.confluent.ksql.function.KsqlAggregateFunction;
 import io.confluent.ksql.name.ColumnName;
@@ -58,16 +57,13 @@ public class UdafUtilTest {
   private FunctionRegistry functionRegistry;
   @Mock
   private KsqlAggregateFunction function;
-  @Mock
-  private KsqlAggregateFunction resolved;
   @Captor
-  private ArgumentCaptor<AggregateFunctionArguments> argumentsCaptor;
+  private ArgumentCaptor<AggregateFunctionInitArguments> argumentsCaptor;
 
   @Before
   @SuppressWarnings("unchecked")
   public void init() {
-    when(functionRegistry.getAggregate(any(), any())).thenReturn(function);
-    when(function.getInstance(any())).thenReturn(resolved);
+    when(functionRegistry.getAggregate(any(), any(), any())).thenReturn(function);
   }
 
   @Test
@@ -77,7 +73,7 @@ public class UdafUtilTest {
         UdafUtil.resolveAggregateFunction(functionRegistry, FUNCTION_CALL, SCHEMA);
 
     // Then:
-    assertThat(returned, is(resolved));
+    assertThat(returned, is(function));
   }
 
   @Test
@@ -86,7 +82,7 @@ public class UdafUtilTest {
     UdafUtil.resolveAggregateFunction(functionRegistry, FUNCTION_CALL, SCHEMA);
 
     // Then:
-    verify(functionRegistry).getAggregate(eq("AGG"), any());
+    verify(functionRegistry).getAggregate(eq("AGG"), any(), any());
   }
 
   @Test
@@ -95,17 +91,7 @@ public class UdafUtilTest {
     UdafUtil.resolveAggregateFunction(functionRegistry, FUNCTION_CALL, SCHEMA);
 
     // Then:
-    verify(functionRegistry).getAggregate(any(), eq(Schema.OPTIONAL_INT64_SCHEMA));
+    verify(functionRegistry).getAggregate(any(), eq(Schema.OPTIONAL_INT64_SCHEMA), any());
   }
 
-  @Test
-  public void shouldResolveWithCorrectArgs() {
-    // When:
-    UdafUtil.resolveAggregateFunction(functionRegistry, FUNCTION_CALL, SCHEMA);
-
-    // Then:
-    verify(function).getInstance(argumentsCaptor.capture());
-    final AggregateFunctionArguments arguments = argumentsCaptor.getValue();
-    assertThat(arguments.udafIndex(), equalTo(1));
-  }
 }

--- a/ksql-metastore/src/main/java/io/confluent/ksql/metastore/MetaStoreImpl.java
+++ b/ksql-metastore/src/main/java/io/confluent/ksql/metastore/MetaStoreImpl.java
@@ -16,6 +16,7 @@
 package io.confluent.ksql.metastore;
 
 import io.confluent.ksql.function.AggregateFunctionFactory;
+import io.confluent.ksql.function.AggregateFunctionInitArguments;
 import io.confluent.ksql.function.FunctionRegistry;
 import io.confluent.ksql.function.KsqlAggregateFunction;
 import io.confluent.ksql.function.UdfFactory;
@@ -211,9 +212,10 @@ public final class MetaStoreImpl implements MutableMetaStore {
 
   public KsqlAggregateFunction<?, ?, ?> getAggregate(
       final String functionName,
-      final Schema argumentType
+      final Schema argumentType,
+      final AggregateFunctionInitArguments initArgs
   ) {
-    return functionRegistry.getAggregate(functionName, argumentType);
+    return functionRegistry.getAggregate(functionName, argumentType, initArgs);
   }
 
   @Override

--- a/ksql-metastore/src/main/java/io/confluent/ksql/metastore/MetaStoreImpl.java
+++ b/ksql-metastore/src/main/java/io/confluent/ksql/metastore/MetaStoreImpl.java
@@ -210,12 +210,12 @@ public final class MetaStoreImpl implements MutableMetaStore {
     return functionRegistry.isAggregate(functionName);
   }
 
-  public KsqlAggregateFunction<?, ?, ?> getAggregate(
+  public KsqlAggregateFunction<?, ?, ?> getAggregateFunction(
       final String functionName,
       final Schema argumentType,
       final AggregateFunctionInitArguments initArgs
   ) {
-    return functionRegistry.getAggregate(functionName, argumentType, initArgs);
+    return functionRegistry.getAggregateFunction(functionName, argumentType, initArgs);
   }
 
   @Override

--- a/ksql-streams/src/test/java/io/confluent/ksql/execution/streams/AggregateParamsTest.java
+++ b/ksql-streams/src/test/java/io/confluent/ksql/execution/streams/AggregateParamsTest.java
@@ -69,11 +69,7 @@ public class AggregateParamsTest {
   @Mock
   private KsqlAggregateFunction agg0;
   @Mock
-  private KsqlAggregateFunction agg0Resolved;
-  @Mock
   private KsqlAggregateFunction agg1;
-  @Mock
-  private KsqlAggregateFunction agg1Resolved;
   @Mock
   private TableAggregationFunction tableAgg;
   @Mock
@@ -88,22 +84,18 @@ public class AggregateParamsTest {
   @Before
   @SuppressWarnings("unchecked")
   public void init() {
-    when(functionRegistry.getAggregate(same(AGG0.getName().name()), any())).thenReturn(agg0);
-    when(agg0Resolved.getInitialValueSupplier()).thenReturn(() -> INITIAL_VALUE0);
-    when(agg0Resolved.getFunctionName()).thenReturn(AGG0.getName());
-    when(agg0.getInstance(any())).thenReturn(agg0Resolved);
-    when(functionRegistry.getAggregate(same(AGG1.getName().name()), any())).thenReturn(agg1);
-    when(agg1Resolved.getInitialValueSupplier()).thenReturn(() -> INITIAL_VALUE1);
-    when(agg1Resolved.getFunctionName()).thenReturn(AGG1.getName());
-    when(agg1.getInstance(any())).thenReturn(agg1Resolved);
-    when(functionRegistry.getAggregate(same(TABLE_AGG.getName().name()), any()))
+    when(functionRegistry.getAggregate(same(AGG0.getName().name()), any(), any())).thenReturn(agg0);
+    when(agg0.getInitialValueSupplier()).thenReturn(() -> INITIAL_VALUE0);
+    when(agg0.getFunctionName()).thenReturn(AGG0.getName());
+    when(functionRegistry.getAggregate(same(AGG1.getName().name()), any(), any())).thenReturn(agg1);
+    when(agg1.getInitialValueSupplier()).thenReturn(() -> INITIAL_VALUE1);
+    when(agg1.getFunctionName()).thenReturn(AGG1.getName());
+    when(functionRegistry.getAggregate(same(TABLE_AGG.getName().name()), any(), any()))
         .thenReturn(tableAgg);
     when(tableAgg.getInitialValueSupplier()).thenReturn(() -> INITIAL_VALUE0);
-    when(tableAgg.getInstance(any())).thenReturn(tableAgg);
-    when(functionRegistry.getAggregate(same(WINDOW_START.getName().name()), any()))
+    when(functionRegistry.getAggregate(same(WINDOW_START.getName().name()), any(), any()))
         .thenReturn(windowStart);
     when(windowStart.getInitialValueSupplier()).thenReturn(() -> INITIAL_VALUE0);
-    when(windowStart.getInstance(any())).thenReturn(windowStart);
     when(windowStart.getFunctionName()).thenReturn(WINDOW_START.getName());
 
     when(udafFactory.create(anyInt(), any())).thenReturn(aggregator);
@@ -126,7 +118,7 @@ public class AggregateParamsTest {
     // Then:
     verify(udafFactory).create(
         2,
-         ImmutableList.of(agg0Resolved, agg1Resolved)
+         ImmutableList.of(agg0, agg1)
     );
   }
 

--- a/ksql-streams/src/test/java/io/confluent/ksql/execution/streams/AggregateParamsTest.java
+++ b/ksql-streams/src/test/java/io/confluent/ksql/execution/streams/AggregateParamsTest.java
@@ -10,7 +10,6 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import com.google.common.collect.ImmutableList;
-import com.google.common.collect.ImmutableMap;
 import io.confluent.ksql.GenericRow;
 import io.confluent.ksql.execution.expression.tree.ColumnReferenceExp;
 import io.confluent.ksql.execution.expression.tree.FunctionCall;
@@ -84,16 +83,16 @@ public class AggregateParamsTest {
   @Before
   @SuppressWarnings("unchecked")
   public void init() {
-    when(functionRegistry.getAggregate(same(AGG0.getName().name()), any(), any())).thenReturn(agg0);
+    when(functionRegistry.getAggregateFunction(same(AGG0.getName().name()), any(), any())).thenReturn(agg0);
     when(agg0.getInitialValueSupplier()).thenReturn(() -> INITIAL_VALUE0);
     when(agg0.getFunctionName()).thenReturn(AGG0.getName());
-    when(functionRegistry.getAggregate(same(AGG1.getName().name()), any(), any())).thenReturn(agg1);
+    when(functionRegistry.getAggregateFunction(same(AGG1.getName().name()), any(), any())).thenReturn(agg1);
     when(agg1.getInitialValueSupplier()).thenReturn(() -> INITIAL_VALUE1);
     when(agg1.getFunctionName()).thenReturn(AGG1.getName());
-    when(functionRegistry.getAggregate(same(TABLE_AGG.getName().name()), any(), any()))
+    when(functionRegistry.getAggregateFunction(same(TABLE_AGG.getName().name()), any(), any()))
         .thenReturn(tableAgg);
     when(tableAgg.getInitialValueSupplier()).thenReturn(() -> INITIAL_VALUE0);
-    when(functionRegistry.getAggregate(same(WINDOW_START.getName().name()), any(), any()))
+    when(functionRegistry.getAggregateFunction(same(WINDOW_START.getName().name()), any(), any()))
         .thenReturn(windowStart);
     when(windowStart.getInitialValueSupplier()).thenReturn(() -> INITIAL_VALUE0);
     when(windowStart.getFunctionName()).thenReturn(WINDOW_START.getName());


### PR DESCRIPTION
### Description 

Previously, the way we obtained and initialised instances of `KSqlAggregateFunction` was over complex: We would obtain an instance with `functionRegistry.getAggregate`, and then call `getInstance` on the KsqlAggregateFunction to obtain a second instance of the class. The first instance was then garbage collected.

This was inefficient and led to unnecessarily complex code. It also meant the code generation of UDAFs was more complex than it needed to be.

It seems that the `getInstance` method was introduced with the `TopkKudaf`. This was the first to take an extra initialisation parameter (the number k in this case), and this value needs to be known by the udaf implementation. The old `functionRegistry.getAggregateFunction` API didn't allow initialisation parameters to be passed in, so the `getInstance` method was introduced to allow a new instance with the new params to be created from the old instance.

This refactoring removes `KSqlAggregateFunction.getInstance` and allows initialisation parameters to be passed to `functionRegistry.getAggregate` (which has been renamed to `functionRegistry.getAggregateFunction` as that is what it does). This means we don't need an extra `getInstance` method to create an instance with the right initialisation parameters. The udaf generation code is now simpler as we don't have to generate a `getInstance` method.

### Testing done 

Amended tests as per the new API

### Reviewer checklist
- [ ] Ensure docs are updated if necessary. (eg. if a user visible feature is being added or changed).
- [ ] Ensure relevant issues are linked (description should include text like "Fixes #<issue number>")

