### PR TITLE
fix: make sure use of non-threadsafe UdfIndex is synchronized

### DIFF
--- a/ksql-common/src/main/java/io/confluent/ksql/function/UdfFactory.java
+++ b/ksql-common/src/main/java/io/confluent/ksql/function/UdfFactory.java
@@ -36,7 +36,7 @@ public class UdfFactory {
     this.udfIndex = new UdfIndex<>(metadata.getName());
   }
 
-  void addFunction(final KsqlFunction ksqlFunction) {
+  synchronized void addFunction(final KsqlFunction ksqlFunction) {
     checkCompatible(ksqlFunction);
     udfIndex.addFunction(ksqlFunction);
   }
@@ -69,7 +69,7 @@ public class UdfFactory {
     return metadata.getDescription();
   }
 
-  public void eachFunction(final Consumer<KsqlFunction> consumer) {
+  public synchronized void eachFunction(final Consumer<KsqlFunction> consumer) {
     udfIndex.values().forEach(consumer);
   }
 
@@ -95,7 +95,7 @@ public class UdfFactory {
         + '}';
   }
 
-  public KsqlFunction getFunction(final List<Schema> paramTypes) {
+  public synchronized KsqlFunction getFunction(final List<Schema> paramTypes) {
     return udfIndex.getFunction(paramTypes);
   }
 }

--- a/ksql-engine/src/main/java/io/confluent/ksql/function/UdafAggregateFunctionFactory.java
+++ b/ksql-engine/src/main/java/io/confluent/ksql/function/UdafAggregateFunctionFactory.java
@@ -34,7 +34,9 @@ public class UdafAggregateFunctionFactory extends AggregateFunctionFactory {
   }
 
   @Override
-  public KsqlAggregateFunction<?, ?, ?> getProperAggregateFunction(final List<Schema> argTypeList) {
+  public synchronized KsqlAggregateFunction<?, ?, ?> getProperAggregateFunction(
+      final List<Schema> argTypeList
+  ) {
     final KsqlAggregateFunction ksqlAggregateFunction = udfIndex.getFunction(argTypeList);
     if (ksqlAggregateFunction == null) {
       throw new KsqlException("There is no aggregate function with name='" + getName()
@@ -46,7 +48,7 @@ public class UdafAggregateFunctionFactory extends AggregateFunctionFactory {
   }
 
   @Override
-  public List<List<Schema>> supportedArgs() {
+  public synchronized List<List<Schema>> supportedArgs() {
     return udfIndex.values()
         .stream()
         .map(KsqlAggregateFunction::getArguments)


### PR DESCRIPTION
### Description 

`UdfIndex` is not thread-safe, and is used in two place in the codebase where it could be accessed by different threads: `UdfFactory` and `UdfAggregateFunctionFactory`.

This PR adds synchronization to `UdfFactory` and `UdfAggregateFunctionFactory' to make this access thread-safe.

Currently `addFunction` is always called (in clock time) before `getFunction`. (Although this access pattern is not enforced in the class).

Note that this doesn't make the access safe, because there is no obvious happens-before relationship between the actions on a thread calling `addFunction` and another thread calling `getFunction`. 

There could be an accidental happens-before due to the way threads are currently started in the server but relying on this is fragile. By synchronizing we guarantee a happens-before relationship between threads accessing these functions.

### Testing done 

Non functional change

### Reviewer checklist
- [ ] Ensure docs are updated if necessary. (eg. if a user visible feature is being added or changed).
- [ ] Ensure relevant issues are linked (description should include text like "Fixes #<issue number>")

