### PR TITLE
refactor: decouple query id from query context

### DIFF
--- a/ksql-engine/src/main/java/io/confluent/ksql/materialization/MaterializationProvider.java
+++ b/ksql-engine/src/main/java/io/confluent/ksql/materialization/MaterializationProvider.java
@@ -16,6 +16,7 @@
 package io.confluent.ksql.materialization;
 
 import io.confluent.ksql.execution.context.QueryContext;
+import io.confluent.ksql.query.QueryId;
 
 public interface MaterializationProvider {
 
@@ -25,5 +26,5 @@ public interface MaterializationProvider {
    * @param contextStacker the query context stacker.
    * @return the materialization.
    */
-  Materialization build(QueryContext.Stacker contextStacker);
+  Materialization build(QueryId queryId, QueryContext.Stacker contextStacker);
 }

--- a/ksql-engine/src/main/java/io/confluent/ksql/physical/PhysicalPlanBuilder.java
+++ b/ksql-engine/src/main/java/io/confluent/ksql/physical/PhysicalPlanBuilder.java
@@ -87,7 +87,7 @@ public class PhysicalPlanBuilder {
         queryId,
         resultStream.getSourceStep(),
         materializationInfo,
-        resultStream.getExecutionPlan(""),
+        resultStream.getExecutionPlan(queryId, ""),
         resultStream.getKeyField()
     );
   }

--- a/ksql-engine/src/main/java/io/confluent/ksql/query/QueryExecutor.java
+++ b/ksql-engine/src/main/java/io/confluent/ksql/query/QueryExecutor.java
@@ -359,10 +359,11 @@ public final class QueryExecutor {
             streamsProperties
         );
 
-    return ksMaterialization.map(ksMat -> contextStacker -> ksqlMaterializationFactory
+    return ksMaterialization.map(ksMat -> (queryId, contextStacker) -> ksqlMaterializationFactory
         .create(
             ksMat,
             info,
+            queryId,
             contextStacker
         ));
   }

--- a/ksql-engine/src/main/java/io/confluent/ksql/structured/SchemaKStream.java
+++ b/ksql-engine/src/main/java/io/confluent/ksql/structured/SchemaKStream.java
@@ -56,6 +56,7 @@ import io.confluent.ksql.metastore.model.DataSource;
 import io.confluent.ksql.metastore.model.KeyField;
 import io.confluent.ksql.metastore.model.KeyField.LegacyField;
 import io.confluent.ksql.name.ColumnName;
+import io.confluent.ksql.query.QueryId;
 import io.confluent.ksql.schema.ksql.Column;
 import io.confluent.ksql.schema.ksql.ColumnRef;
 import io.confluent.ksql.schema.ksql.FormatOptions;
@@ -760,19 +761,19 @@ public class SchemaKStream<K> {
     return sourceSchemaKStreams;
   }
 
-  public String getExecutionPlan(final String indent) {
+  public String getExecutionPlan(final QueryId queryId, final String indent) {
     final StringBuilder stringBuilder = new StringBuilder();
     stringBuilder.append(indent)
         .append(" > [ ")
         .append(type).append(" ] | Schema: ")
         .append(getSchema().toString(FORMAT_OPTIONS))
-        .append(" | Logger: ").append(QueryLoggerUtil.queryLoggerName(getQueryContext()))
+        .append(" | Logger: ").append(QueryLoggerUtil.queryLoggerName(queryId, getQueryContext()))
         .append("\n");
     for (final SchemaKStream schemaKStream : sourceSchemaKStreams) {
       stringBuilder
           .append("\t")
           .append(indent)
-          .append(schemaKStream.getExecutionPlan(indent + "\t"));
+          .append(schemaKStream.getExecutionPlan(queryId, indent + "\t"));
     }
     return stringBuilder.toString();
   }

--- a/ksql-engine/src/main/java/io/confluent/ksql/util/PersistentQueryMetadata.java
+++ b/ksql-engine/src/main/java/io/confluent/ksql/util/PersistentQueryMetadata.java
@@ -136,8 +136,9 @@ public class PersistentQueryMetadata extends QueryMetadata {
   }
 
   public Optional<Materialization> getMaterialization(
+      final QueryId queryId,
       final QueryContext.Stacker contextStacker
   ) {
-    return materializationProvider.map(builder -> builder.build(contextStacker));
+    return materializationProvider.map(builder -> builder.build(queryId, contextStacker));
   }
 }

--- a/ksql-engine/src/test/java/io/confluent/ksql/materialization/KsqlMaterializationFactoryTest.java
+++ b/ksql-engine/src/test/java/io/confluent/ksql/materialization/KsqlMaterializationFactoryTest.java
@@ -110,7 +110,8 @@ public class KsqlMaterializationFactoryTest {
   @Mock
   private MaterializationFactory materializationFactory;
 
-  private final Stacker contextStacker = new Stacker(new QueryId("start"));
+  private final QueryId queryId = new QueryId("start");
+  private final Stacker contextStacker = new Stacker();
 
   private KsqlMaterializationFactory factory;
 
@@ -159,7 +160,7 @@ public class KsqlMaterializationFactoryTest {
     when(info.havingExpression()).thenReturn(Optional.empty());
 
     // When:
-    factory.create(materialization, info, contextStacker);
+    factory.create(materialization, info, queryId, contextStacker);
 
     // Then:
     verify(sqlPredicateFactory, never()).create(any(), any(), any(), any(), any());
@@ -168,7 +169,7 @@ public class KsqlMaterializationFactoryTest {
   @Test
   public void shouldGetFilterProcessingLoggerWithCorrectParams() {
     // When:
-    factory.create(materialization, info, contextStacker);
+    factory.create(materialization, info, queryId, contextStacker);
 
     // Then:
     verify(processingLoggerFactory).getLogger("start.filter");
@@ -177,7 +178,7 @@ public class KsqlMaterializationFactoryTest {
   @Test
   public void shouldBuildHavingPredicateWithCorrectParams() {
     // When:
-    factory.create(materialization, info, contextStacker);
+    factory.create(materialization, info, queryId, contextStacker);
 
     // Then:
     verify(sqlPredicateFactory).create(
@@ -192,7 +193,7 @@ public class KsqlMaterializationFactoryTest {
   @Test
   public void shouldGetProjectProcessingLoggerWithCorrectParams() {
     // When:
-    factory.create(materialization, info, contextStacker);
+    factory.create(materialization, info, queryId, contextStacker);
 
     // Then:
     verify(processingLoggerFactory).getLogger("start.project");
@@ -204,7 +205,7 @@ public class KsqlMaterializationFactoryTest {
     when(info.tableSelects()).thenReturn(SELECTS);
 
     // When:
-    factory.create(materialization, info, contextStacker);
+    factory.create(materialization, info, queryId, contextStacker);
 
     // Then:
     verify(aggregateMapperFactory).create(
@@ -219,7 +220,7 @@ public class KsqlMaterializationFactoryTest {
     when(info.tableSelects()).thenReturn(SELECTS);
 
     // When:
-    factory.create(materialization, info, contextStacker);
+    factory.create(materialization, info, queryId, contextStacker);
 
     // Then:
     verify(selectMapperFactory).create(
@@ -234,7 +235,7 @@ public class KsqlMaterializationFactoryTest {
   @Test
   public void shouldBuildMaterializationWithCorrectParams() {
     // When:
-    factory.create(materialization, info, contextStacker);
+    factory.create(materialization, info, queryId, contextStacker);
 
     // Then:
     verify(materializationFactory).create(
@@ -255,7 +256,7 @@ public class KsqlMaterializationFactoryTest {
 
     // When:
     final Materialization result = factory
-        .create(materialization, info, contextStacker);
+        .create(materialization, info, queryId, contextStacker);
 
     // Then:
     assertThat(result, is(ksqlMaterialization));

--- a/ksql-engine/src/test/java/io/confluent/ksql/materialization/ks/KsMaterializationFunctionalTest.java
+++ b/ksql-engine/src/test/java/io/confluent/ksql/materialization/ks/KsMaterializationFunctionalTest.java
@@ -116,8 +116,8 @@ public class KsMaterializationFunctionalTest {
   private final List<QueryMetadata> toClose = new ArrayList<>();
 
   private String output;
-  private final QueryContext.Stacker contextStacker =
-      new QueryContext.Stacker(new QueryId("static"));
+  private final QueryId queryId = new QueryId("static");
+  private final QueryContext.Stacker contextStacker = new QueryContext.Stacker();
 
   @BeforeClass
   public static void classSetUp() {
@@ -153,7 +153,7 @@ public class KsMaterializationFunctionalTest {
     );
 
     // When:
-    final Optional<Materialization> result = query.getMaterialization(contextStacker);
+    final Optional<Materialization> result = query.getMaterialization(queryId, contextStacker);
 
     // Then:
     assertThat(result, is(Optional.empty()));
@@ -168,7 +168,7 @@ public class KsMaterializationFunctionalTest {
     );
 
     // When:
-    final Optional<Materialization> result = query.getMaterialization(contextStacker);
+    final Optional<Materialization> result = query.getMaterialization(queryId, contextStacker);
 
     // Then:
     assertThat(result, is(Optional.empty()));
@@ -188,7 +188,7 @@ public class KsMaterializationFunctionalTest {
       );
 
       // When:
-      final Optional<Materialization> result = query.getMaterialization(contextStacker);
+      final Optional<Materialization> result = query.getMaterialization(queryId, contextStacker);
 
       // Then:
       assertThat(result, is(Optional.empty()));
@@ -209,7 +209,7 @@ public class KsMaterializationFunctionalTest {
     final Map<String, GenericRow> rows = waitForTableRows(STRING_DESERIALIZER, schema);
 
     // When:
-    final Materialization materialization = query.getMaterialization(contextStacker).get();
+    final Materialization materialization = query.getMaterialization(queryId, contextStacker).get();
 
     // Then:
     assertThat(materialization.windowType(), is(Optional.empty()));
@@ -243,7 +243,7 @@ public class KsMaterializationFunctionalTest {
     final Map<String, GenericRow> rows = waitForTableRows(STRING_DESERIALIZER, schema);
 
     // When:
-    final Materialization materialization = query.getMaterialization(contextStacker).get();
+    final Materialization materialization = query.getMaterialization(queryId, contextStacker).get();
 
     // Then:
     assertThat(materialization.windowType(), is(Optional.empty()));
@@ -279,7 +279,7 @@ public class KsMaterializationFunctionalTest {
         waitForTableRows(TIME_WINDOWED_DESERIALIZER, schema);
 
     // When:
-    final Materialization materialization = query.getMaterialization(contextStacker).get();
+    final Materialization materialization = query.getMaterialization(queryId, contextStacker).get();
 
     // Then:
     assertThat(materialization.windowType(), is(Optional.of(WindowType.TUMBLING)));
@@ -327,7 +327,7 @@ public class KsMaterializationFunctionalTest {
         waitForTableRows(TIME_WINDOWED_DESERIALIZER, schema);
 
     // When:
-    final Materialization materialization = query.getMaterialization(contextStacker).get();
+    final Materialization materialization = query.getMaterialization(queryId, contextStacker).get();
 
     // Then:
     assertThat(materialization.windowType(), is(Optional.of(WindowType.HOPPING)));
@@ -374,7 +374,7 @@ public class KsMaterializationFunctionalTest {
         waitForTableRows(SESSION_WINDOWED_DESERIALIZER, schema);
 
     // When:
-    final Materialization materialization = query.getMaterialization(contextStacker).get();
+    final Materialization materialization = query.getMaterialization(queryId, contextStacker).get();
 
     // Then:
     assertThat(materialization.windowType(), is(Optional.of(WindowType.SESSION)));
@@ -424,7 +424,7 @@ public class KsMaterializationFunctionalTest {
 
 
     // When:
-    final Materialization materialization = query.getMaterialization(contextStacker).get();
+    final Materialization materialization = query.getMaterialization(queryId, contextStacker).get();
 
     // Then:
     assertThat(materialization.windowType(), is(Optional.empty()));
@@ -454,7 +454,7 @@ public class KsMaterializationFunctionalTest {
     final Map<String, GenericRow> rows = waitForTableRows(STRING_DESERIALIZER, schema);
 
     // When:
-    final Materialization materialization = query.getMaterialization(contextStacker).get();
+    final Materialization materialization = query.getMaterialization(queryId, contextStacker).get();
 
     // Then:
     assertThat(materialization.windowType(), is(Optional.empty()));
@@ -484,7 +484,7 @@ public class KsMaterializationFunctionalTest {
     final Map<String, GenericRow> rows = waitForTableRows(STRING_DESERIALIZER, schema);
 
     // When:
-    final Materialization materialization = query.getMaterialization(contextStacker).get();
+    final Materialization materialization = query.getMaterialization(queryId, contextStacker).get();
 
     // Then:
     final MaterializedTable table = materialization.nonWindowed();

--- a/ksql-engine/src/test/java/io/confluent/ksql/planner/plan/AggregateNodeTest.java
+++ b/ksql-engine/src/test/java/io/confluent/ksql/planner/plan/AggregateNodeTest.java
@@ -354,7 +354,7 @@ public class AggregateNodeTest {
     );
 
     final List<String> loggers = queryContextCaptor.getAllValues().stream()
-        .map(QueryLoggerUtil::queryLoggerName)
+        .map(ctx -> QueryLoggerUtil.queryLoggerName(queryId, ctx))
         .collect(Collectors.toList());
 
     assertThat(loggers, contains(
@@ -396,12 +396,13 @@ public class AggregateNodeTest {
 
   @SuppressWarnings("unchecked")
   private SchemaKStream buildQuery(final AggregateNode aggregateNode, final KsqlConfig ksqlConfig) {
+    when(ksqlStreamBuilder.getQueryId()).thenReturn(queryId);
     when(ksqlStreamBuilder.getKsqlConfig()).thenReturn(ksqlConfig);
     when(ksqlStreamBuilder.getStreamsBuilder()).thenReturn(builder);
     when(ksqlStreamBuilder.getProcessingLogContext()).thenReturn(processingLogContext);
     when(ksqlStreamBuilder.getFunctionRegistry()).thenReturn(FUNCTION_REGISTRY);
     when(ksqlStreamBuilder.buildNodeContext(any())).thenAnswer(inv ->
-        new QueryContext.Stacker(queryId)
+        new QueryContext.Stacker()
             .push(inv.getArgument(0).toString()));
     when(ksqlStreamBuilder.buildKeySerde(any(), any(), any())).thenReturn(keySerde);
 

--- a/ksql-engine/src/test/java/io/confluent/ksql/planner/plan/DataSourceNodeTest.java
+++ b/ksql-engine/src/test/java/io/confluent/ksql/planner/plan/DataSourceNodeTest.java
@@ -202,7 +202,7 @@ public class DataSourceNodeTest {
     when(ksqlStreamBuilder.getKsqlConfig()).thenReturn(realConfig);
     when(ksqlStreamBuilder.getStreamsBuilder()).thenReturn(realBuilder);
     when(ksqlStreamBuilder.buildNodeContext(any())).thenAnswer(inv ->
-        new QueryContext.Stacker(queryId)
+        new QueryContext.Stacker()
             .push(inv.getArgument(0).toString()));
 
     when(ksqlStreamBuilder.buildKeySerde(any(), any(), any()))
@@ -245,7 +245,7 @@ public class DataSourceNodeTest {
         queryContextCaptor.capture()
     );
 
-    assertThat(QueryLoggerUtil.queryLoggerName(queryContextCaptor.getValue()),
+    assertThat(QueryLoggerUtil.queryLoggerName(queryId, queryContextCaptor.getValue()),
         is("source-test.0.source"));
   }
 

--- a/ksql-engine/src/test/java/io/confluent/ksql/planner/plan/JoinNodeTest.java
+++ b/ksql-engine/src/test/java/io/confluent/ksql/planner/plan/JoinNodeTest.java
@@ -143,7 +143,7 @@ public class JoinNodeTest {
   private static final PlanNodeId nodeId = new PlanNodeId("join");
   private static final QueryId queryId = new QueryId("join-query");
   private static final QueryContext.Stacker CONTEXT_STACKER =
-      new QueryContext.Stacker(queryId).push(nodeId.toString());
+      new QueryContext.Stacker().push(nodeId.toString());
 
   @Rule
   public final ExpectedException expectedException = ExpectedException.none();
@@ -189,7 +189,7 @@ public class JoinNodeTest {
     when(ksqlStreamBuilder.withKsqlConfig(any())).thenReturn(ksqlStreamBuilder);
     when(ksqlStreamBuilder.getFunctionRegistry()).thenReturn(functionRegistry);
     when(ksqlStreamBuilder.buildNodeContext(any())).thenAnswer(inv ->
-        new QueryContext.Stacker(queryId)
+        new QueryContext.Stacker()
             .push(inv.getArgument(0).toString()));
     when(ksqlStreamBuilder.buildKeySerde(any(), any(), any())).thenReturn(keySerde);
 

--- a/ksql-engine/src/test/java/io/confluent/ksql/planner/plan/KsqlBareOutputNodeTest.java
+++ b/ksql-engine/src/test/java/io/confluent/ksql/planner/plan/KsqlBareOutputNodeTest.java
@@ -84,12 +84,13 @@ public class KsqlBareOutputNodeTest {
   public void before() {
     builder = new StreamsBuilder();
 
+    when(ksqlStreamBuilder.getQueryId()).thenReturn(queryId);
     when(ksqlStreamBuilder.getKsqlConfig()).thenReturn(new KsqlConfig(Collections.emptyMap()));
     when(ksqlStreamBuilder.getStreamsBuilder()).thenReturn(builder);
     when(ksqlStreamBuilder.getProcessingLogContext()).thenReturn(ProcessingLogContext.create());
     when(ksqlStreamBuilder.getFunctionRegistry()).thenReturn(functionRegistry);
     when(ksqlStreamBuilder.buildNodeContext(any())).thenAnswer(inv ->
-        new QueryContext.Stacker(queryId)
+        new QueryContext.Stacker()
             .push(inv.getArgument(0).toString()));
     when(ksqlStreamBuilder.buildKeySerde(any(), any(), any())).thenReturn(keySerde);
 

--- a/ksql-engine/src/test/java/io/confluent/ksql/planner/plan/KsqlStructuredDataOutputNodeTest.java
+++ b/ksql-engine/src/test/java/io/confluent/ksql/planner/plan/KsqlStructuredDataOutputNodeTest.java
@@ -137,7 +137,7 @@ public class KsqlStructuredDataOutputNodeTest {
         .thenReturn((SchemaKStream) sinkStreamWithKeySelected);
 
     when(ksqlStreamBuilder.buildNodeContext(any())).thenAnswer(inv ->
-        new QueryContext.Stacker(QUERY_ID)
+        new QueryContext.Stacker()
             .push(inv.getArgument(0).toString()));
     when(ksqlTopic.getKafkaTopicName()).thenReturn(SINK_KAFKA_TOPIC_NAME);
     when(ksqlTopic.getValueFormat()).thenReturn(JSON_FORMAT);
@@ -225,7 +225,7 @@ public class KsqlStructuredDataOutputNodeTest {
     verify(resultStream).selectKey(
         KEY_FIELD.ref().get(),
         false,
-        new QueryContext.Stacker(QUERY_ID).push(PLAN_NODE_ID.toString())
+        new QueryContext.Stacker().push(PLAN_NODE_ID.toString())
     );
 
     assertThat(result, is(sameInstance(sinkStreamWithKeySelected)));
@@ -243,7 +243,7 @@ public class KsqlStructuredDataOutputNodeTest {
     verify(resultStream).selectKey(
         ColumnRef.withoutSource(ColumnName.of("ROWKEY")),
         false,
-        new QueryContext.Stacker(QUERY_ID).push(PLAN_NODE_ID.toString())
+        new QueryContext.Stacker().push(PLAN_NODE_ID.toString())
     );
 
     assertThat(result, is(sameInstance(sinkStreamWithKeySelected)));
@@ -261,7 +261,7 @@ public class KsqlStructuredDataOutputNodeTest {
     verify(resultStream).selectKey(
         ColumnRef.withoutSource(ColumnName.of("ROWTIME")),
         false,
-        new QueryContext.Stacker(QUERY_ID).push(PLAN_NODE_ID.toString())
+        new QueryContext.Stacker().push(PLAN_NODE_ID.toString())
     );
 
     assertThat(result, is(sameInstance(sinkStreamWithKeySelected)));

--- a/ksql-engine/src/test/java/io/confluent/ksql/query/QueryExecutorTest.java
+++ b/ksql-engine/src/test/java/io/confluent/ksql/query/QueryExecutorTest.java
@@ -162,7 +162,7 @@ public class QueryExecutorTest {
     when(materializationInfo.stateStoreName()).thenReturn(STORE_NAME);
     when(ksMaterializationFactory.create(any(), any(), any(), any(), any(), any()))
         .thenReturn(Optional.of(ksMaterialization));
-    when(ksqlMaterializationFactory.create(any(), any(), any())).thenReturn(materialization);
+    when(ksqlMaterializationFactory.create(any(), any(), any(), any())).thenReturn(materialization);
     when(processingLogContext.getLoggerFactory()).thenReturn(processingLoggerFactory);
     when(processingLoggerFactory.getLogger(any())).thenReturn(processingLogger);
     when(ksqlConfig.getKsqlStreamConfigProps()).thenReturn(Collections.emptyMap());
@@ -266,8 +266,8 @@ public class QueryExecutorTest {
         physicalPlan,
         SUMMARY
     );
-    final QueryContext.Stacker stacker = new Stacker(QUERY_ID);
-    final Optional<Materialization> result = queryMetadata.getMaterialization(stacker);
+    final QueryContext.Stacker stacker = new Stacker();
+    final Optional<Materialization> result = queryMetadata.getMaterialization(QUERY_ID, stacker);
 
     // Then:
     assertThat(result.get(), is(materialization));
@@ -310,13 +310,14 @@ public class QueryExecutorTest {
         physicalPlan,
         SUMMARY
     );
-    final QueryContext.Stacker stacker = new Stacker(QUERY_ID);
-    queryMetadata.getMaterialization(stacker);
+    final QueryContext.Stacker stacker = new Stacker();
+    queryMetadata.getMaterialization(QUERY_ID, stacker);
 
     // Then:
     verify(ksqlMaterializationFactory).create(
         ksMaterialization,
         materializationInfo,
+        QUERY_ID,
         stacker
     );
   }
@@ -333,8 +334,8 @@ public class QueryExecutorTest {
         physicalPlan,
         SUMMARY
     );
-    final QueryContext.Stacker stacker = new Stacker(QUERY_ID);
-    final Optional<Materialization> result = queryMetadata.getMaterialization(stacker);
+    final QueryContext.Stacker stacker = new Stacker();
+    final Optional<Materialization> result = queryMetadata.getMaterialization(QUERY_ID, stacker);
 
     assertThat(result, is(Optional.empty()));
   }

--- a/ksql-engine/src/test/java/io/confluent/ksql/structured/QueryContextTest.java
+++ b/ksql-engine/src/test/java/io/confluent/ksql/structured/QueryContextTest.java
@@ -27,16 +27,12 @@ import io.confluent.ksql.query.QueryId;
 import org.junit.Test;
 
 public class QueryContextTest {
-  private final QueryId queryId = new QueryId("query");
-  private final QueryContext.Stacker contextStacker
-      = new QueryContext.Stacker(queryId).push("node");
+  private final QueryContext.Stacker contextStacker = new QueryContext.Stacker().push("node");
   private final QueryContext queryContext = contextStacker.getQueryContext();
 
   private static void assertQueryContext(
       final QueryContext queryContext,
-      final QueryId queryId,
       final String ...context) {
-    assertThat(queryContext.getQueryId(), equalTo(queryId));
     if (context.length > 0) {
       assertThat(queryContext.getContext(), contains(context));
     } else {
@@ -53,8 +49,8 @@ public class QueryContextTest {
 
     // Then:
     assertThat(ImmutableSet.of(queryContext, childContext, grandchildContext), hasSize(3));
-    assertQueryContext(queryContext, queryId, "node");
-    assertQueryContext(childContext, queryId, "node", "child");
-    assertQueryContext(grandchildContext, queryId, "node", "child", "grandchild");
+    assertQueryContext(queryContext, "node");
+    assertQueryContext(childContext, "node", "child");
+    assertQueryContext(grandchildContext, "node", "child", "grandchild");
   }
 }

--- a/ksql-engine/src/test/java/io/confluent/ksql/structured/SchemaKGroupedStreamTest.java
+++ b/ksql-engine/src/test/java/io/confluent/ksql/structured/SchemaKGroupedStreamTest.java
@@ -108,7 +108,7 @@ public class SchemaKGroupedStreamTest {
 
   private final FunctionRegistry functionRegistry = new InternalFunctionRegistry();
   private final QueryContext.Stacker queryContext
-      = new QueryContext.Stacker(new QueryId("query")).push("node");
+      = new QueryContext.Stacker().push("node");
 
   private SchemaKGroupedStream schemaGroupedStream;
 

--- a/ksql-engine/src/test/java/io/confluent/ksql/structured/SchemaKGroupedStreamTest.java
+++ b/ksql-engine/src/test/java/io/confluent/ksql/structured/SchemaKGroupedStreamTest.java
@@ -39,7 +39,6 @@ import io.confluent.ksql.model.WindowType;
 import io.confluent.ksql.name.ColumnName;
 import io.confluent.ksql.name.FunctionName;
 import io.confluent.ksql.parser.tree.WindowExpression;
-import io.confluent.ksql.query.QueryId;
 import io.confluent.ksql.schema.ksql.ColumnRef;
 import io.confluent.ksql.schema.ksql.LogicalSchema;
 import io.confluent.ksql.schema.ksql.types.SqlTypes;

--- a/ksql-engine/src/test/java/io/confluent/ksql/structured/SchemaKGroupedTableTest.java
+++ b/ksql-engine/src/test/java/io/confluent/ksql/structured/SchemaKGroupedTableTest.java
@@ -88,8 +88,7 @@ public class SchemaKGroupedTableTest {
   private final KsqlConfig ksqlConfig = new KsqlConfig(Collections.emptyMap());
   private final InternalFunctionRegistry functionRegistry = new InternalFunctionRegistry();
   private final MaterializedFactory materializedFactory = mock(MaterializedFactory.class);
-  private final QueryContext.Stacker queryContext
-      = new QueryContext.Stacker(new QueryId("query")).push("node");
+  private final QueryContext.Stacker queryContext = new QueryContext.Stacker().push("node");
   private final ValueFormat valueFormat = ValueFormat.of(FormatInfo.of(Format.JSON));
   private final KeyFormat keyFormat = KeyFormat.nonWindowed(FormatInfo.of(Format.JSON));
 

--- a/ksql-engine/src/test/java/io/confluent/ksql/structured/SchemaKStreamTest.java
+++ b/ksql-engine/src/test/java/io/confluent/ksql/structured/SchemaKStreamTest.java
@@ -167,7 +167,7 @@ public class SchemaKStreamTest {
       .valueColumn(ColumnName.of("val"), SqlTypes.BIGINT)
       .build();
   private final QueryContext.Stacker queryContext
-      = new QueryContext.Stacker(new QueryId("query")).push("node");
+      = new QueryContext.Stacker().push("node");
   private final QueryContext.Stacker childContextStacker = queryContext.push("child");
   private final ProcessingLogContext processingLogContext = ProcessingLogContext.create();
   private PlanBuilder planBuilder;
@@ -253,6 +253,7 @@ public class SchemaKStreamTest {
     when(keySerdeFactory.buildKeySerde(any(), any(), any())).thenReturn(keySerde);
     when(keySerde.rebind(any(PersistenceSchema.class))).thenReturn(reboundKeySerde);
 
+    when(queryBuilder.getQueryId()).thenReturn(new QueryId("query"));
     when(queryBuilder.getFunctionRegistry()).thenReturn(functionRegistry);
     when(queryBuilder.getKsqlConfig()).thenReturn(ksqlConfig);
     when(queryBuilder.getProcessingLogContext()).thenReturn(processingLogContext);
@@ -1199,7 +1200,7 @@ public class SchemaKStreamTest {
     // Given:
     when(sourceProperties.getSchema()).thenReturn(simpleSchema);
     final SchemaKStream parentSchemaKStream = mock(SchemaKStream.class);
-    when(parentSchemaKStream.getExecutionPlan(anyString()))
+    when(parentSchemaKStream.getExecutionPlan(any(), anyString()))
         .thenReturn("parent plan");
     when(sourceProperties.getQueryContext()).thenReturn(
         queryContext.push("source").getQueryContext());
@@ -1216,7 +1217,7 @@ public class SchemaKStreamTest {
     );
 
     // When/Then:
-    assertThat(schemaKtream.getExecutionPlan(""), equalTo(
+    assertThat(schemaKtream.getExecutionPlan(new QueryId("query"), ""), equalTo(
         " > [ SOURCE ] | Schema: [ROWKEY STRING KEY, key STRING, val BIGINT] | "
             + "Logger: query.node.source\n"
             + "\tparent plan"));
@@ -1242,7 +1243,7 @@ public class SchemaKStreamTest {
     );
 
     // When/Then:
-    assertThat(schemaKtream.getExecutionPlan(""), equalTo(
+    assertThat(schemaKtream.getExecutionPlan(new QueryId("query"), ""), equalTo(
         " > [ SOURCE ] | Schema: [ROWKEY STRING KEY, key STRING, val BIGINT] | "
             + "Logger: query.node.source\n"));
   }
@@ -1251,10 +1252,10 @@ public class SchemaKStreamTest {
   public void shouldSummarizeExecutionPlanCorrectlyWhenMultipleParents() {
     // Given:
     final SchemaKStream parentSchemaKStream1 = mock(SchemaKStream.class);
-    when(parentSchemaKStream1.getExecutionPlan(anyString()))
+    when(parentSchemaKStream1.getExecutionPlan(any(), anyString()))
         .thenReturn("parent 1 plan");
     final SchemaKStream parentSchemaKStream2 = mock(SchemaKStream.class);
-    when(parentSchemaKStream2.getExecutionPlan(anyString()))
+    when(parentSchemaKStream2.getExecutionPlan(any(), anyString()))
         .thenReturn("parent 2 plan");
     when(sourceProperties.getSchema()).thenReturn(simpleSchema);
     when(sourceProperties.getQueryContext()).thenReturn(
@@ -1273,7 +1274,7 @@ public class SchemaKStreamTest {
     );
 
     // When/Then:
-    assertThat(schemaKtream.getExecutionPlan(""), equalTo(
+    assertThat(schemaKtream.getExecutionPlan(new QueryId("query"), ""), equalTo(
         " > [ SOURCE ] | Schema: [ROWKEY STRING KEY, key STRING, val BIGINT] | "
             + "Logger: query.node.source\n"
             + "\tparent 1 plan"

--- a/ksql-engine/src/test/java/io/confluent/ksql/structured/SchemaKTableTest.java
+++ b/ksql-engine/src/test/java/io/confluent/ksql/structured/SchemaKTableTest.java
@@ -148,7 +148,7 @@ public class SchemaKTableTest {
   private SchemaKTable secondSchemaKTable;
   private LogicalSchema joinSchema;
   private final QueryContext.Stacker queryContext
-      = new QueryContext.Stacker(new QueryId("query")).push("node");
+      = new QueryContext.Stacker().push("node");
   private final QueryContext.Stacker childContextStacker = queryContext.push("child");
   private final ProcessingLogContext processingLogContext = ProcessingLogContext.create();
   private static final Expression TEST_2_COL_1 =
@@ -195,6 +195,7 @@ public class SchemaKTableTest {
     joinSchema = getJoinSchema(ksqlTable.getSchema(), secondKsqlTable.getSchema());
 
     when(keySerde.rebind(any(PersistenceSchema.class))).thenReturn(reboundKeySerde);
+    when(queryBuilder.getQueryId()).thenReturn(new QueryId("query"));
     when(queryBuilder.getKsqlConfig()).thenReturn(ksqlConfig);
     when(queryBuilder.getProcessingLogContext()).thenReturn(processingLogContext);
     when(queryBuilder.getFunctionRegistry()).thenReturn(functionRegistry);

--- a/ksql-engine/src/test/java/io/confluent/ksql/util/QueryLoggerUtilTest.java
+++ b/ksql-engine/src/test/java/io/confluent/ksql/util/QueryLoggerUtilTest.java
@@ -24,12 +24,14 @@ import io.confluent.ksql.query.QueryId;
 import org.junit.Test;
 
 public class QueryLoggerUtilTest {
-  private final QueryContext.Stacker contextStacker = new QueryContext.Stacker(new QueryId("queryid"));
+  private final QueryId queryId = new QueryId("queryid");
+  private final QueryContext.Stacker contextStacker = new QueryContext.Stacker();
 
   @Test
   public void shouldBuildCorrectName() {
     // When:
     final String name = QueryLoggerUtil.queryLoggerName(
+        queryId,
         contextStacker.push("biz", "baz").getQueryContext());
 
     // Then:
@@ -39,7 +41,7 @@ public class QueryLoggerUtilTest {
   @Test
   public void shouldBuildCorrectNameWhenNoSubhierarchy() {
     // When:
-    final String name = QueryLoggerUtil.queryLoggerName(contextStacker.getQueryContext());
+    final String name = QueryLoggerUtil.queryLoggerName(queryId, contextStacker.getQueryContext());
 
     // Then:
     assertThat(name, equalTo("queryid"));

--- a/ksql-execution/src/main/java/io/confluent/ksql/execution/builder/KsqlQueryBuilder.java
+++ b/ksql-execution/src/main/java/io/confluent/ksql/execution/builder/KsqlQueryBuilder.java
@@ -119,6 +119,10 @@ public final class KsqlQueryBuilder {
     return QuerySchemas.of(schemas);
   }
 
+  public QueryId getQueryId() {
+    return queryId;
+  }
+
   public KsqlQueryBuilder withKsqlConfig(final KsqlConfig newConfig) {
     return of(
         streamsBuilder,
@@ -131,7 +135,7 @@ public final class KsqlQueryBuilder {
   }
 
   public QueryContext.Stacker buildNodeContext(final String context) {
-    return new QueryContext.Stacker(queryId)
+    return new QueryContext.Stacker()
         .push(context);
   }
 
@@ -140,7 +144,7 @@ public final class KsqlQueryBuilder {
       final PhysicalSchema schema,
       final QueryContext queryContext
   ) {
-    final String loggerNamePrefix = QueryLoggerUtil.queryLoggerName(queryContext);
+    final String loggerNamePrefix = QueryLoggerUtil.queryLoggerName(queryId, queryContext);
 
     return keySerdeFactory.create(
         format,
@@ -158,7 +162,7 @@ public final class KsqlQueryBuilder {
       final PhysicalSchema schema,
       final QueryContext queryContext
   ) {
-    final String loggerNamePrefix = QueryLoggerUtil.queryLoggerName(queryContext);
+    final String loggerNamePrefix = QueryLoggerUtil.queryLoggerName(queryId, queryContext);
 
     return keySerdeFactory.create(
         format,
@@ -176,7 +180,7 @@ public final class KsqlQueryBuilder {
       final PhysicalSchema schema,
       final QueryContext queryContext
   ) {
-    final String loggerNamePrefix = QueryLoggerUtil.queryLoggerName(queryContext);
+    final String loggerNamePrefix = QueryLoggerUtil.queryLoggerName(queryId, queryContext);
 
     track(loggerNamePrefix, schema.valueSchema());
 

--- a/ksql-execution/src/main/java/io/confluent/ksql/execution/context/QueryContext.java
+++ b/ksql-execution/src/main/java/io/confluent/ksql/execution/context/QueryContext.java
@@ -16,7 +16,6 @@
 package io.confluent.ksql.execution.context;
 
 import com.google.common.collect.ImmutableList;
-import io.confluent.ksql.query.QueryId;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;

--- a/ksql-execution/src/main/java/io/confluent/ksql/execution/context/QueryContext.java
+++ b/ksql-execution/src/main/java/io/confluent/ksql/execution/context/QueryContext.java
@@ -23,20 +23,14 @@ import java.util.List;
 import java.util.Objects;
 
 public final class QueryContext {
-  private final QueryId queryId;
   private final List<String> context;
 
-  private QueryContext(final QueryId queryId) {
-    this(queryId, Collections.emptyList());
+  private QueryContext() {
+    this(Collections.emptyList());
   }
 
-  private QueryContext(final QueryId queryId, final List<String> context) {
-    this.queryId = Objects.requireNonNull(queryId);
+  private QueryContext(final List<String> context) {
     this.context = Objects.requireNonNull(context);
-  }
-
-  public QueryId getQueryId() {
-    return queryId;
   }
 
   public List<String> getContext() {
@@ -45,7 +39,6 @@ public final class QueryContext {
 
   private QueryContext push(final String ...context) {
     return new QueryContext(
-        queryId,
         new ImmutableList.Builder<String>()
             .addAll(this.context)
             .addAll(Arrays.asList(context))
@@ -56,8 +49,8 @@ public final class QueryContext {
   public static class Stacker {
     final QueryContext queryContext;
 
-    public Stacker(final QueryId queryId) {
-      this.queryContext = Objects.requireNonNull(new QueryContext(queryId));
+    public Stacker() {
+      this.queryContext = new QueryContext();
     }
 
     public static Stacker of(final QueryContext queryContext) {
@@ -91,7 +84,6 @@ public final class QueryContext {
   @Override
   public boolean equals(final Object o) {
     return o instanceof QueryContext
-        && Objects.equals(queryId ,((QueryContext)o).queryId)
         && Objects.equals(context, ((QueryContext)o).context);
   }
 

--- a/ksql-execution/src/main/java/io/confluent/ksql/execution/context/QueryLoggerUtil.java
+++ b/ksql-execution/src/main/java/io/confluent/ksql/execution/context/QueryLoggerUtil.java
@@ -16,16 +16,17 @@
 package io.confluent.ksql.execution.context;
 
 import com.google.common.collect.ImmutableList;
+import io.confluent.ksql.query.QueryId;
 
 public final class QueryLoggerUtil {
   private QueryLoggerUtil() {
   }
 
-  public static String queryLoggerName(final QueryContext queryContext) {
+  public static String queryLoggerName(final QueryId queryId, final QueryContext queryContext) {
     return String.join(
         ".",
         new ImmutableList.Builder<String>()
-            .add(queryContext.getQueryId().getId())
+            .add(queryId.getId())
             .addAll(queryContext.getContext())
             .build()
     );

--- a/ksql-execution/src/test/java/io/confluent/ksql/execution/builder/KsqlQueryBuilderTest.java
+++ b/ksql-execution/src/test/java/io/confluent/ksql/execution/builder/KsqlQueryBuilderTest.java
@@ -107,7 +107,7 @@ public class KsqlQueryBuilderTest {
   public void setUp() {
     when(serviceContext.getSchemaRegistryClientFactory()).thenReturn(srClientFactory);
 
-    queryContext = new QueryContext.Stacker(QUERY_ID).push("context").getQueryContext();
+    queryContext = new QueryContext.Stacker().push("context").getQueryContext();
 
     when(keySerdeFactory.create(any(), any(), any(), any(), any(), any()))
         .thenReturn(keySerde);
@@ -148,7 +148,7 @@ public class KsqlQueryBuilderTest {
     final Stacker result = ksqlQueryBuilder.buildNodeContext("some-id");
 
     // Then:
-    assertThat(result, is(new Stacker(QUERY_ID).push("some-id")));
+    assertThat(result, is(new Stacker().push("some-id")));
   }
 
   @Test
@@ -179,7 +179,7 @@ public class KsqlQueryBuilderTest {
         SOME_SCHEMA.keySchema(),
         ksqlConfig,
         srClientFactory,
-        QueryLoggerUtil.queryLoggerName(queryContext),
+        QueryLoggerUtil.queryLoggerName(QUERY_ID, queryContext),
         processingLogContext
     );
   }
@@ -201,7 +201,7 @@ public class KsqlQueryBuilderTest {
         SOME_SCHEMA.keySchema(),
         ksqlConfig,
         srClientFactory,
-        QueryLoggerUtil.queryLoggerName(queryContext),
+        QueryLoggerUtil.queryLoggerName(QUERY_ID, queryContext),
         processingLogContext
     );
   }
@@ -221,7 +221,7 @@ public class KsqlQueryBuilderTest {
         SOME_SCHEMA.valueSchema(),
         ksqlConfig,
         srClientFactory,
-        QueryLoggerUtil.queryLoggerName(queryContext),
+        QueryLoggerUtil.queryLoggerName(QUERY_ID, queryContext),
         processingLogContext
     );
   }

--- a/ksql-rest-app/src/main/java/io/confluent/ksql/rest/server/execution/StaticQueryExecutor.java
+++ b/ksql-rest-app/src/main/java/io/confluent/ksql/rest/server/execution/StaticQueryExecutor.java
@@ -149,10 +149,10 @@ public final class StaticQueryExecutor {
 
       final WhereInfo whereInfo = extractWhereInfo(analysis, query);
 
-      final QueryContext.Stacker contextStacker = new Stacker(new QueryId("static-query"));
+      final QueryContext.Stacker contextStacker = new Stacker();
 
       final Materialization mat = query
-          .getMaterialization(contextStacker)
+          .getMaterialization(new QueryId("static-query"), contextStacker)
           .orElseThrow(() -> notMaterializedException(getSourceName(analysis)));
 
       final Struct rowKey = asKeyStruct(whereInfo.rowkey, query.getPhysicalSchema());

--- a/ksql-streams/src/main/java/io/confluent/ksql/execution/streams/ExecutionStepFactory.java
+++ b/ksql-streams/src/main/java/io/confluent/ksql/execution/streams/ExecutionStepFactory.java
@@ -161,6 +161,7 @@ public final class ExecutionStepFactory {
   ) {
     final QueryContext queryContext = stacker.getQueryContext();
     final Selection selection = Selection.of(
+        queryBuilder.getQueryId(),
         queryContext,
         source.getProperties().getSchema(),
         selectExpressions,
@@ -271,6 +272,7 @@ public final class ExecutionStepFactory {
   ) {
     final QueryContext queryContext = stacker.getQueryContext();
     final Selection selection = Selection.of(
+        queryBuilder.getQueryId(),
         queryContext,
         source.getProperties().getSchema(),
         selectExpressions,

--- a/ksql-streams/src/main/java/io/confluent/ksql/execution/streams/Selection.java
+++ b/ksql-streams/src/main/java/io/confluent/ksql/execution/streams/Selection.java
@@ -21,6 +21,7 @@ import io.confluent.ksql.execution.plan.SelectExpression;
 import io.confluent.ksql.execution.streams.SelectValueMapper.SelectInfo;
 import io.confluent.ksql.function.FunctionRegistry;
 import io.confluent.ksql.logging.processing.ProcessingLogContext;
+import io.confluent.ksql.query.QueryId;
 import io.confluent.ksql.schema.ksql.Column;
 import io.confluent.ksql.schema.ksql.LogicalSchema;
 import io.confluent.ksql.util.KsqlConfig;
@@ -33,6 +34,7 @@ public final class Selection {
   private final LogicalSchema schema;
 
   public static Selection of(
+      final QueryId queryId,
       final QueryContext queryContext,
       final LogicalSchema sourceSchema,
       final List<SelectExpression> selectExpressions,
@@ -41,6 +43,7 @@ public final class Selection {
       final ProcessingLogContext processingLogContext) {
     final QueryContext.Stacker contextStacker = QueryContext.Stacker.of(queryContext);
     final String loggerName = QueryLoggerUtil.queryLoggerName(
+        queryId,
         contextStacker.push(SELECTION_CONTEXT).getQueryContext()
     );
     final SelectValueMapper mapper = SelectValueMapperFactory.create(

--- a/ksql-streams/src/main/java/io/confluent/ksql/execution/streams/StreamFilterBuilder.java
+++ b/ksql-streams/src/main/java/io/confluent/ksql/execution/streams/StreamFilterBuilder.java
@@ -48,6 +48,7 @@ public final class StreamFilterBuilder {
         queryBuilder.getFunctionRegistry(),
         queryBuilder.getProcessingLogContext().getLoggerFactory().getLogger(
             QueryLoggerUtil.queryLoggerName(
+                queryBuilder.getQueryId(),
                 contextStacker.push("FILTER").getQueryContext())
         )
     );

--- a/ksql-streams/src/main/java/io/confluent/ksql/execution/streams/StreamMapValuesBuilder.java
+++ b/ksql-streams/src/main/java/io/confluent/ksql/execution/streams/StreamMapValuesBuilder.java
@@ -33,6 +33,7 @@ public final class StreamMapValuesBuilder {
     final LogicalSchema sourceSchema = step.getSource().getProperties().getSchema();
     final Selection selection =
         Selection.of(
+            queryBuilder.getQueryId(),
             queryContext,
             sourceSchema,
             step.getSelectExpressions(),

--- a/ksql-streams/src/main/java/io/confluent/ksql/execution/streams/TableFilterBuilder.java
+++ b/ksql-streams/src/main/java/io/confluent/ksql/execution/streams/TableFilterBuilder.java
@@ -48,6 +48,7 @@ public final class TableFilterBuilder {
         queryBuilder.getFunctionRegistry(),
         queryBuilder.getProcessingLogContext().getLoggerFactory().getLogger(
             QueryLoggerUtil.queryLoggerName(
+                queryBuilder.getQueryId(),
                 contextStacker.push("FILTER").getQueryContext())
         )
     );

--- a/ksql-streams/src/main/java/io/confluent/ksql/execution/streams/TableMapValuesBuilder.java
+++ b/ksql-streams/src/main/java/io/confluent/ksql/execution/streams/TableMapValuesBuilder.java
@@ -33,6 +33,7 @@ public final class TableMapValuesBuilder {
     final LogicalSchema sourceSchema = step.getSource().getProperties().getSchema();
     final Selection selection =
         Selection.of(
+            queryBuilder.getQueryId(),
             queryContext,
             sourceSchema,
             step.getSelectExpressions(),

--- a/ksql-streams/src/test/java/io/confluent/ksql/execution/streams/SelectionTest.java
+++ b/ksql-streams/src/test/java/io/confluent/ksql/execution/streams/SelectionTest.java
@@ -66,7 +66,7 @@ public class SelectionTest {
   @Mock
   private ProcessingLogger processingLogger;
   private final QueryContext queryContext =
-      new QueryContext.Stacker(new QueryId("query")).getQueryContext();
+      new QueryContext.Stacker().getQueryContext();
 
   private Selection selection;
 
@@ -78,6 +78,7 @@ public class SelectionTest {
     when(processingLogContext.getLoggerFactory()).thenReturn(processingLoggerFactory);
     when(processingLoggerFactory.getLogger(anyString())).thenReturn(processingLogger);
     selection = Selection.of(
+        new QueryId("query"),
         queryContext,
         SCHEMA,
         SELECT_EXPRESSIONS,

--- a/ksql-streams/src/test/java/io/confluent/ksql/execution/streams/StreamAggregateBuilderTest.java
+++ b/ksql-streams/src/test/java/io/confluent/ksql/execution/streams/StreamAggregateBuilderTest.java
@@ -116,7 +116,7 @@ public class StreamAggregateBuilderTest {
   );
   private static final List<FunctionCall> FUNCTIONS = ImmutableList.of(AGG0, AGG1);
   private static final QueryContext CTX =
-      new QueryContext.Stacker(new QueryId("qid")).push("agg").push("regate").getQueryContext();
+      new QueryContext.Stacker().push("agg").push("regate").getQueryContext();
   private static final KeyFormat KEY_FORMAT = KeyFormat.nonWindowed(FormatInfo.of(Format.KAFKA));
   private static final ValueFormat VALUE_FORMAT = ValueFormat.of(FormatInfo.of(Format.JSON));
   private static final Duration WINDOW = Duration.ofMillis(30000);

--- a/ksql-streams/src/test/java/io/confluent/ksql/execution/streams/StreamFilterBuilderTest.java
+++ b/ksql-streams/src/test/java/io/confluent/ksql/execution/streams/StreamFilterBuilderTest.java
@@ -71,7 +71,7 @@ public class StreamFilterBuilderTest {
   private KeySerdeFactory<Struct> keySerdeFactory;
   private KStreamHolder<Struct> sourceWithSerdeFactory;
 
-  private final QueryContext queryContext = new QueryContext.Stacker(new QueryId("foo"))
+  private final QueryContext queryContext = new QueryContext.Stacker()
       .push("bar")
       .getQueryContext();
 
@@ -84,6 +84,7 @@ public class StreamFilterBuilderTest {
   @Before
   @SuppressWarnings("unchecked")
   public void init() {
+    when(queryBuilder.getQueryId()).thenReturn(new QueryId("foo"));
     when(queryBuilder.getKsqlConfig()).thenReturn(ksqlConfig);
     when(queryBuilder.getFunctionRegistry()).thenReturn(functionRegistry);
     when(queryBuilder.getProcessingLogContext()).thenReturn(processingLogContext);

--- a/ksql-streams/src/test/java/io/confluent/ksql/execution/streams/StreamGroupByBuilderTest.java
+++ b/ksql-streams/src/test/java/io/confluent/ksql/execution/streams/StreamGroupByBuilderTest.java
@@ -74,9 +74,9 @@ public class StreamGroupByBuilderTest {
       columnReference("MAN")
   );
   private static final QueryContext SOURCE_CTX =
-      new QueryContext.Stacker(new QueryId("qid")).push("foo").push("source").getQueryContext();
+      new QueryContext.Stacker().push("foo").push("source").getQueryContext();
   private static final QueryContext STEP_CTX =
-      new QueryContext.Stacker(new QueryId("qid")).push("foo").push("groupby").getQueryContext();
+      new QueryContext.Stacker().push("foo").push("groupby").getQueryContext();
   private static final ExecutionStepProperties SOURCE_PROPERTIES
       = new DefaultExecutionStepProperties(SCHEMA, SOURCE_CTX);
   private static final ExecutionStepProperties PROPERTIES = new DefaultExecutionStepProperties(

--- a/ksql-streams/src/test/java/io/confluent/ksql/execution/streams/StreamMapValuesBuilderTest.java
+++ b/ksql-streams/src/test/java/io/confluent/ksql/execution/streams/StreamMapValuesBuilderTest.java
@@ -105,7 +105,7 @@ public class StreamMapValuesBuilderTest {
   public final MockitoRule mockitoRule = MockitoJUnit.rule();
 
   private final QueryContext context =
-      new QueryContext.Stacker(new QueryId("qid")).getQueryContext();
+      new QueryContext.Stacker().getQueryContext();
 
   private PlanBuilder planBuilder;
   private StreamMapValues<Struct> step;
@@ -118,6 +118,7 @@ public class StreamMapValuesBuilderTest {
     when(properties.getQueryContext()).thenReturn(context);
     when(processingLogContext.getLoggerFactory()).thenReturn(processingLoggerFactory);
     when(processingLoggerFactory.getLogger(any())).thenReturn(mock(ProcessingLogger.class));
+    when(queryBuilder.getQueryId()).thenReturn(new QueryId("qid"));
     when(queryBuilder.getFunctionRegistry()).thenReturn(mock(FunctionRegistry.class));
     when(queryBuilder.getProcessingLogContext()).thenReturn(processingLogContext);
     when(queryBuilder.getKsqlConfig()).thenReturn(ksqlConfig);

--- a/ksql-streams/src/test/java/io/confluent/ksql/execution/streams/StreamSelectKeyBuilderTest.java
+++ b/ksql-streams/src/test/java/io/confluent/ksql/execution/streams/StreamSelectKeyBuilderTest.java
@@ -91,7 +91,7 @@ public class StreamSelectKeyBuilderTest {
   private ArgumentCaptor<ValueMapperWithKey<Struct, GenericRow, GenericRow>> mapperCaptor;
 
   private final QueryContext queryContext =
-      new QueryContext.Stacker(new QueryId("hey")).push("ya").getQueryContext();
+      new QueryContext.Stacker().push("ya").getQueryContext();
   private final ExecutionStepProperties properties = new DefaultExecutionStepProperties(
       SCHEMA,
       queryContext
@@ -106,6 +106,7 @@ public class StreamSelectKeyBuilderTest {
   @Before
   @SuppressWarnings("unchecked")
   public void init() {
+    when(queryBuilder.getQueryId()).thenReturn(new QueryId("hey"));
     when(sourceStep.getProperties()).thenReturn(properties);
     when(kstream.filter(any())).thenReturn(filteredKStream);
     when(filteredKStream.selectKey(any(KeyValueMapper.class))).thenReturn(rekeyedKstream);

--- a/ksql-streams/src/test/java/io/confluent/ksql/execution/streams/StreamStreamJoinBuilderTest.java
+++ b/ksql-streams/src/test/java/io/confluent/ksql/execution/streams/StreamStreamJoinBuilderTest.java
@@ -87,10 +87,8 @@ public class StreamStreamJoinBuilderTest {
   private static final Duration BEFORE = Duration.ofMillis(1000);
   private static final Duration AFTER = Duration.ofMillis(2000);
   private static final JoinWindows WINDOWS = JoinWindows.of(BEFORE).after(AFTER);
-  private final QueryContext SRC_CTX =
-      new QueryContext.Stacker(new QueryId("qid")).push("src").getQueryContext();
   private final QueryContext CTX =
-      new QueryContext.Stacker(new QueryId("qid")).push("jo").push("in").getQueryContext();
+      new QueryContext.Stacker().push("jo").push("in").getQueryContext();
 
   @Mock
   private KStream<Struct, GenericRow> leftKStream;

--- a/ksql-streams/src/test/java/io/confluent/ksql/execution/streams/StreamTableJoinBuilderTest.java
+++ b/ksql-streams/src/test/java/io/confluent/ksql/execution/streams/StreamTableJoinBuilderTest.java
@@ -80,9 +80,9 @@ public class StreamTableJoinBuilderTest {
       SerdeOption.none()
   );
   private final QueryContext SRC_CTX =
-      new QueryContext.Stacker(new QueryId("qid")).push("src").getQueryContext();
+      new QueryContext.Stacker().push("src").getQueryContext();
   private final QueryContext CTX =
-      new QueryContext.Stacker(new QueryId("qid")).push("jo").push("in").getQueryContext();
+      new QueryContext.Stacker().push("jo").push("in").getQueryContext();
 
   @Mock
   private KStream<Struct, GenericRow> leftKStream;

--- a/ksql-streams/src/test/java/io/confluent/ksql/execution/streams/StreamToTableBuilderTest.java
+++ b/ksql-streams/src/test/java/io/confluent/ksql/execution/streams/StreamToTableBuilderTest.java
@@ -101,7 +101,7 @@ public class StreamToTableBuilderTest {
   @Mock
   private ExecutionStep<KStreamHolder<Struct>> source;
 
-  private final QueryContext.Stacker stacker = new QueryContext.Stacker(new QueryId("qid"));
+  private final QueryContext.Stacker stacker = new QueryContext.Stacker();
   private final QueryContext queryContext = stacker.push("s2t").getQueryContext();
   private final ValueFormat valueFormat = ValueFormat.of(FormatInfo.of(Format.JSON));
   private final KeyFormat keyFormat = KeyFormat.nonWindowed(FormatInfo.of(Format.KAFKA));
@@ -127,6 +127,7 @@ public class StreamToTableBuilderTest {
     when(kStream.mapValues(any(ValueMapper.class))).thenReturn(kStream);
     when(kStream.groupByKey()).thenReturn(kGroupedStream);
     when(kGroupedStream.aggregate(any(), any(), any(Materialized.class))).thenReturn(kTable);
+    when(ksqlQueryBuilder.getQueryId()).thenReturn(new QueryId("qid"));
     when(ksqlQueryBuilder.buildValueSerde(any(), any(), any())).thenReturn(valueSerde);
     when(source.build(any())).thenReturn(
         new KStreamHolder<>(kStream, keySerdeFactory));

--- a/ksql-streams/src/test/java/io/confluent/ksql/execution/streams/TableAggregateBuilderTest.java
+++ b/ksql-streams/src/test/java/io/confluent/ksql/execution/streams/TableAggregateBuilderTest.java
@@ -99,7 +99,7 @@ public class TableAggregateBuilderTest {
   );
   private static final List<FunctionCall> FUNCTIONS = ImmutableList.of(AGG0, AGG1);
   private static final QueryContext CTX =
-      new QueryContext.Stacker(new QueryId("qid")).push("agg").push("regate").getQueryContext();
+      new QueryContext.Stacker().push("agg").push("regate").getQueryContext();
   private static final KeyFormat KEY_FORMAT = KeyFormat.nonWindowed(FormatInfo.of(Format.KAFKA));
   private static final ValueFormat VALUE_FORMAT = ValueFormat.of(FormatInfo.of(Format.JSON));
 

--- a/ksql-streams/src/test/java/io/confluent/ksql/execution/streams/TableFilterBuilderTest.java
+++ b/ksql-streams/src/test/java/io/confluent/ksql/execution/streams/TableFilterBuilderTest.java
@@ -70,7 +70,7 @@ public class TableFilterBuilderTest {
   @Mock
   private KeySerdeFactory<Struct> keySerdeFactory;
 
-  private final QueryContext queryContext = new QueryContext.Stacker(new QueryId("foo"))
+  private final QueryContext queryContext = new QueryContext.Stacker()
       .push("bar")
       .getQueryContext();
 
@@ -83,6 +83,7 @@ public class TableFilterBuilderTest {
   @Before
   @SuppressWarnings("unchecked")
   public void init() {
+    when(queryBuilder.getQueryId()).thenReturn(new QueryId("foo"));
     when(queryBuilder.getKsqlConfig()).thenReturn(ksqlConfig);
     when(queryBuilder.getFunctionRegistry()).thenReturn(functionRegistry);
     when(queryBuilder.getProcessingLogContext()).thenReturn(processingLogContext);

--- a/ksql-streams/src/test/java/io/confluent/ksql/execution/streams/TableGroupByBuilderTest.java
+++ b/ksql-streams/src/test/java/io/confluent/ksql/execution/streams/TableGroupByBuilderTest.java
@@ -74,9 +74,9 @@ public class TableGroupByBuilderTest {
       columnReference("MAN")
   );
   private static final QueryContext SOURCE_CONTEXT =
-      new QueryContext.Stacker(new QueryId("qid")).push("foo").push("source").getQueryContext();
+      new QueryContext.Stacker().push("foo").push("source").getQueryContext();
   private static final QueryContext STEP_CONTEXT =
-      new QueryContext.Stacker(new QueryId("qid")).push("foo").push("groupby").getQueryContext();
+      new QueryContext.Stacker().push("foo").push("groupby").getQueryContext();
   private static final ExecutionStepProperties SOURCE_PROPERTIES =
       new DefaultExecutionStepProperties(SCHEMA, SOURCE_CONTEXT);
   private static final ExecutionStepProperties PROPERTIES = new DefaultExecutionStepProperties(
@@ -125,6 +125,7 @@ public class TableGroupByBuilderTest {
   @Before
   @SuppressWarnings("unchecked")
   public void init() {
+    when(queryBuilder.getQueryId()).thenReturn(new QueryId("qid"));
     when(queryBuilder.getKsqlConfig()).thenReturn(ksqlConfig);
     when(queryBuilder.getFunctionRegistry()).thenReturn(functionRegistry);
     when(queryBuilder.buildKeySerde(any(), any(), any())).thenReturn(keySerde);

--- a/ksql-streams/src/test/java/io/confluent/ksql/execution/streams/TableSinkBuilderTest.java
+++ b/ksql-streams/src/test/java/io/confluent/ksql/execution/streams/TableSinkBuilderTest.java
@@ -95,7 +95,7 @@ public class TableSinkBuilderTest {
   private ArgumentCaptor<ValueMapper<GenericRow, GenericRow>> mapperCaptor;
 
   private final QueryContext queryContext =
-      new QueryContext.Stacker(new QueryId("qid")).push("sink").getQueryContext();
+      new QueryContext.Stacker().push("sink").getQueryContext();
 
   private PlanBuilder planBuilder;
   private TableSink<Struct> sink;

--- a/ksql-streams/src/test/java/io/confluent/ksql/execution/streams/TableTableJoinBuilderTest.java
+++ b/ksql-streams/src/test/java/io/confluent/ksql/execution/streams/TableTableJoinBuilderTest.java
@@ -59,9 +59,9 @@ public class TableTableJoinBuilderTest {
       .withAlias(ALIAS)
       .withMetaAndKeyColsInValue();
   private final QueryContext SRC_CTX =
-      new QueryContext.Stacker(new QueryId("qid")).push("src").getQueryContext();
+      new QueryContext.Stacker().push("src").getQueryContext();
   private final QueryContext CTX =
-      new QueryContext.Stacker(new QueryId("qid")).push("jo").push("in").getQueryContext();
+      new QueryContext.Stacker().push("jo").push("in").getQueryContext();
 
   @Mock
   private KTable<Struct, GenericRow> leftKTable;


### PR DESCRIPTION
### Description 
This is a small refactor to decouple the query id from the context. It's useful/reasonable
to be able to describe the current context within a query without including the query ID.
This way, we leave the option open to bake the context into the plan but choose the
query ID when executing.