### PR TITLE
feat: pass auth header to connect client for RBAC integration

### DIFF
--- a/ksql-engine/src/main/java/io/confluent/ksql/services/DefaultConnectClient.java
+++ b/ksql-engine/src/main/java/io/confluent/ksql/services/DefaultConnectClient.java
@@ -29,14 +29,18 @@ import java.net.URISyntaxException;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
+import java.util.Optional;
 import java.util.concurrent.Callable;
 import java.util.concurrent.ExecutionException;
 import java.util.function.Function;
+import javax.ws.rs.core.HttpHeaders;
+import org.apache.http.Header;
 import org.apache.http.HttpEntity;
 import org.apache.http.HttpStatus;
 import org.apache.http.client.ResponseHandler;
 import org.apache.http.client.fluent.Request;
 import org.apache.http.entity.ContentType;
+import org.apache.http.message.BasicHeader;
 import org.apache.http.util.EntityUtils;
 import org.apache.kafka.connect.runtime.rest.entities.ConnectorInfo;
 import org.apache.kafka.connect.runtime.rest.entities.ConnectorStateInfo;
@@ -59,9 +63,14 @@ public class DefaultConnectClient implements ConnectClient {
   private static final int MAX_ATTEMPTS = 3;
 
   private final URI connectUri;
+  private final Optional<String> authHeader;
 
-  public DefaultConnectClient(final String connectUri) {
+  public DefaultConnectClient(
+      final String connectUri,
+      final Optional<String> authHeader
+  ) {
     Objects.requireNonNull(connectUri, "connectUri");
+    this.authHeader = Objects.requireNonNull(authHeader, "authHeader");
 
     try {
       this.connectUri = new URI(connectUri);
@@ -84,6 +93,7 @@ public class DefaultConnectClient implements ConnectClient {
 
       final ConnectResponse<ConnectorInfo> connectResponse = withRetries(() -> Request
           .Post(connectUri.resolve(CONNECTORS))
+          .setHeaders(headers())
           .socketTimeout(DEFAULT_TIMEOUT_MS)
           .connectTimeout(DEFAULT_TIMEOUT_MS)
           .bodyString(
@@ -114,6 +124,7 @@ public class DefaultConnectClient implements ConnectClient {
 
       final ConnectResponse<List<String>> connectResponse = withRetries(() -> Request
           .Get(connectUri.resolve(CONNECTORS))
+          .setHeaders(headers())
           .socketTimeout(DEFAULT_TIMEOUT_MS)
           .connectTimeout(DEFAULT_TIMEOUT_MS)
           .execute()
@@ -138,6 +149,7 @@ public class DefaultConnectClient implements ConnectClient {
 
       final ConnectResponse<ConnectorStateInfo> connectResponse = withRetries(() -> Request
           .Get(connectUri.resolve(CONNECTORS + "/" + connector + STATUS))
+          .setHeaders(headers())
           .socketTimeout(DEFAULT_TIMEOUT_MS)
           .connectTimeout(DEFAULT_TIMEOUT_MS)
           .execute()
@@ -162,6 +174,7 @@ public class DefaultConnectClient implements ConnectClient {
 
       final ConnectResponse<ConnectorInfo> connectResponse = withRetries(() -> Request
           .Get(connectUri.resolve(String.format("%s/%s", CONNECTORS, connector)))
+          .setHeaders(headers())
           .socketTimeout(DEFAULT_TIMEOUT_MS)
           .connectTimeout(DEFAULT_TIMEOUT_MS)
           .execute()
@@ -185,6 +198,7 @@ public class DefaultConnectClient implements ConnectClient {
 
       final ConnectResponse<String> connectResponse = withRetries(() -> Request
           .Delete(connectUri.resolve(String.format("%s/%s", CONNECTORS, connector)))
+          .setHeaders(headers())
           .socketTimeout(DEFAULT_TIMEOUT_MS)
           .connectTimeout(DEFAULT_TIMEOUT_MS)
           .execute()
@@ -198,6 +212,12 @@ public class DefaultConnectClient implements ConnectClient {
     } catch (final Exception e) {
       throw new KsqlServerException(e);
     }
+  }
+
+  private Header[] headers() {
+    return authHeader.isPresent()
+        ? new Header[]{new BasicHeader(HttpHeaders.AUTHORIZATION, authHeader.get())}
+        : new Header[]{};
   }
 
   @SuppressWarnings("unchecked")

--- a/ksql-engine/src/main/java/io/confluent/ksql/services/ServiceContextFactory.java
+++ b/ksql-engine/src/main/java/io/confluent/ksql/services/ServiceContextFactory.java
@@ -19,6 +19,7 @@ import io.confluent.kafka.schemaregistry.client.SchemaRegistryClient;
 import io.confluent.ksql.schema.registry.KsqlSchemaRegistryClientFactory;
 import io.confluent.ksql.util.KsqlConfig;
 import java.util.Collections;
+import java.util.Optional;
 import java.util.function.Supplier;
 import org.apache.kafka.clients.admin.Admin;
 import org.apache.kafka.streams.KafkaClientSupplier;
@@ -35,7 +36,10 @@ public final class ServiceContextFactory {
         ksqlConfig,
         new DefaultKafkaClientSupplier(),
         new KsqlSchemaRegistryClientFactory(ksqlConfig, Collections.emptyMap())::get,
-        ksqlClient
+        ksqlClient,
+        new DefaultConnectClient(
+            ksqlConfig.getString(KsqlConfig.CONNECT_URL_PROPERTY),
+            Optional.empty())
     );
   }
 
@@ -43,7 +47,8 @@ public final class ServiceContextFactory {
       final KsqlConfig ksqlConfig,
       final KafkaClientSupplier kafkaClientSupplier,
       final Supplier<SchemaRegistryClient> srClientFactory,
-      final SimpleKsqlClient ksqlClient
+      final SimpleKsqlClient ksqlClient,
+      final ConnectClient connectClient
   ) {
     final Admin adminClient = kafkaClientSupplier.getAdmin(
         ksqlConfig.getKsqlAdminClientConfigProps()
@@ -54,7 +59,7 @@ public final class ServiceContextFactory {
         adminClient,
         new KafkaTopicClientImpl(adminClient),
         srClientFactory,
-        new DefaultConnectClient(ksqlConfig.getString(KsqlConfig.CONNECT_URL_PROPERTY)),
+        connectClient,
         ksqlClient
     );
   }

--- a/ksql-engine/src/main/java/io/confluent/ksql/services/ServiceContextFactory.java
+++ b/ksql-engine/src/main/java/io/confluent/ksql/services/ServiceContextFactory.java
@@ -36,10 +36,10 @@ public final class ServiceContextFactory {
         ksqlConfig,
         new DefaultKafkaClientSupplier(),
         new KsqlSchemaRegistryClientFactory(ksqlConfig, Collections.emptyMap())::get,
-        ksqlClient,
         new DefaultConnectClient(
             ksqlConfig.getString(KsqlConfig.CONNECT_URL_PROPERTY),
-            Optional.empty())
+            Optional.empty()),
+        ksqlClient
     );
   }
 
@@ -47,8 +47,8 @@ public final class ServiceContextFactory {
       final KsqlConfig ksqlConfig,
       final KafkaClientSupplier kafkaClientSupplier,
       final Supplier<SchemaRegistryClient> srClientFactory,
-      final SimpleKsqlClient ksqlClient,
-      final ConnectClient connectClient
+      final ConnectClient connectClient,
+      final SimpleKsqlClient ksqlClient
   ) {
     final Admin adminClient = kafkaClientSupplier.getAdmin(
         ksqlConfig.getKsqlAdminClientConfigProps()

--- a/ksql-engine/src/test/java/io/confluent/ksql/embedded/KsqlContextTestUtil.java
+++ b/ksql-engine/src/test/java/io/confluent/ksql/embedded/KsqlContextTestUtil.java
@@ -28,6 +28,7 @@ import io.confluent.ksql.services.ServiceContext;
 import io.confluent.ksql.services.TestServiceContext;
 import io.confluent.ksql.statement.Injectors;
 import io.confluent.ksql.util.KsqlConfig;
+import java.util.Optional;
 import java.util.concurrent.atomic.AtomicInteger;
 import org.apache.kafka.clients.admin.Admin;
 import org.apache.kafka.streams.KafkaClientSupplier;
@@ -57,7 +58,9 @@ public final class KsqlContextTestUtil {
         adminClient,
         kafkaTopicClient,
         () -> schemaRegistryClient,
-        new DefaultConnectClient(ksqlConfig.getString(KsqlConfig.CONNECT_URL_PROPERTY))
+        new DefaultConnectClient(
+            ksqlConfig.getString(KsqlConfig.CONNECT_URL_PROPERTY),
+            Optional.empty())
     );
 
     final String metricsPrefix = "instance-" + COUNTER.getAndIncrement() + "-";

--- a/ksql-engine/src/test/java/io/confluent/ksql/services/DefaultConnectClientTest.java
+++ b/ksql-engine/src/test/java/io/confluent/ksql/services/DefaultConnectClientTest.java
@@ -29,6 +29,7 @@ import io.confluent.ksql.json.JsonMapper;
 import io.confluent.ksql.metastore.model.MetaStoreMatchers.OptionalMatchers;
 import io.confluent.ksql.services.ConnectClient.ConnectResponse;
 import java.util.List;
+import java.util.Optional;
 import org.apache.http.HttpStatus;
 import org.apache.kafka.connect.runtime.rest.entities.ConnectorInfo;
 import org.apache.kafka.connect.runtime.rest.entities.ConnectorStateInfo;
@@ -66,7 +67,7 @@ public class DefaultConnectClientTest {
 
   @Before
   public void setup() {
-    client = new DefaultConnectClient("http://localhost:" + wireMockRule.port());
+    client = new DefaultConnectClient("http://localhost:" + wireMockRule.port(), Optional.empty());
   }
 
   @Test

--- a/ksql-engine/src/test/java/io/confluent/ksql/services/TestServiceContext.java
+++ b/ksql-engine/src/test/java/io/confluent/ksql/services/TestServiceContext.java
@@ -20,6 +20,7 @@ import io.confluent.kafka.schemaregistry.client.SchemaRegistryClient;
 import io.confluent.ksql.util.FakeKafkaClientSupplier;
 import io.confluent.ksql.util.KsqlConfig;
 import java.util.Collections;
+import java.util.Optional;
 import java.util.function.Supplier;
 import org.apache.kafka.clients.admin.Admin;
 import org.apache.kafka.streams.KafkaClientSupplier;
@@ -63,7 +64,7 @@ public final class TestServiceContext {
         new FakeKafkaClientSupplier().getAdmin(Collections.emptyMap()),
         topicClient,
         srClientFactory,
-        new DefaultConnectClient("http://localhost:8083")
+        new DefaultConnectClient("http://localhost:8083", Optional.empty())
     );
   }
 
@@ -80,7 +81,9 @@ public final class TestServiceContext {
         adminClient,
         new KafkaTopicClientImpl(adminClient),
         srClientFactory,
-        new DefaultConnectClient(ksqlConfig.getString(KsqlConfig.CONNECT_URL_PROPERTY))
+        new DefaultConnectClient(
+            ksqlConfig.getString(KsqlConfig.CONNECT_URL_PROPERTY),
+            Optional.empty())
     );
   }
 

--- a/ksql-functional-tests/src/main/java/io/confluent/ksql/test/tools/TestExecutor.java
+++ b/ksql-functional-tests/src/main/java/io/confluent/ksql/test/tools/TestExecutor.java
@@ -416,7 +416,7 @@ public class TestExecutor implements Closeable {
         new StubKafkaClientSupplier().getAdmin(Collections.emptyMap()),
         new StubKafkaTopicClient(),
         () -> schemaRegistryClient,
-        new DefaultConnectClient("http://localhost:8083"),
+        new DefaultConnectClient("http://localhost:8083", Optional.empty()),
         DisabledKsqlClient.instance()
     );
   }

--- a/ksql-rest-app/src/main/java/io/confluent/ksql/rest/server/services/RestServiceContextFactory.java
+++ b/ksql-rest-app/src/main/java/io/confluent/ksql/rest/server/services/RestServiceContextFactory.java
@@ -17,6 +17,7 @@ package io.confluent.ksql.rest.server.services;
 
 import io.confluent.kafka.schemaregistry.client.SchemaRegistryClient;
 import io.confluent.ksql.schema.registry.KsqlSchemaRegistryClientFactory;
+import io.confluent.ksql.services.DefaultConnectClient;
 import io.confluent.ksql.services.ServiceContext;
 import io.confluent.ksql.services.ServiceContextFactory;
 import io.confluent.ksql.util.KsqlConfig;
@@ -71,7 +72,8 @@ public final class RestServiceContextFactory {
         ksqlConfig,
         kafkaClientSupplier,
         srClientFactory,
-        new DefaultKsqlClient(authHeader)
+        new DefaultKsqlClient(authHeader),
+        new DefaultConnectClient(ksqlConfig.getString(KsqlConfig.CONNECT_URL_PROPERTY), authHeader)
     );
   }
 }

--- a/ksql-rest-app/src/main/java/io/confluent/ksql/rest/server/services/RestServiceContextFactory.java
+++ b/ksql-rest-app/src/main/java/io/confluent/ksql/rest/server/services/RestServiceContextFactory.java
@@ -72,8 +72,8 @@ public final class RestServiceContextFactory {
         ksqlConfig,
         kafkaClientSupplier,
         srClientFactory,
-        new DefaultKsqlClient(authHeader),
-        new DefaultConnectClient(ksqlConfig.getString(KsqlConfig.CONNECT_URL_PROPERTY), authHeader)
+        new DefaultConnectClient(ksqlConfig.getString(KsqlConfig.CONNECT_URL_PROPERTY), authHeader),
+        new DefaultKsqlClient(authHeader)
     );
   }
 }


### PR DESCRIPTION
### Description 

This patch passes along the auth header that is used to the connect client so that we can forward it to the connect cluster when making requests.

### Testing done 

I setup RBAC following https://github.com/confluentinc/examples/tree/5.3.0-post/security/rbac and then tried to run KSQL locally to create a connector:

```sql
ksql> CREATE SOURCE CONNECTOR `datagen-pageviews` WITH(  "connector.class"='io.confluent.connect.jdbc.JdbcSourceConnector',  "connection.url"='jdbc:postgresql://localhost:5432/almog.gavra',  "mode"='timestamp',  "timestamp.column.name"='created_at',  "topic.prefix"='jdbc-',  "key"='username',  "table.whitelist"='users');

 Error
------------------------
 Unauthorized operation
------------------------
```

In another shell, run 
```sh
confluent iam rolebinding create --principal User:ksqlcli --role ResourceOwner --resource Connector:datagen-pageviews --kafka-cluster-id pFESsWFwRHKy9E-3szNATQ --connect-cluster-id connect-cluster
```

We now can create the `datagen-pageviews` connector. I was lazy and didn't actually successfully create the connector because that means adding more roles to more topics and jazz like that, but we can see that the auth header passes along well.
```sql
ksql> CREATE SOURCE CONNECTOR `datagen-pageviews` WITH(  "connector.class"='io.confluent.connect.jdbc.JdbcSourceConnector',  "connection.url"='jdbc:postgresql://localhost:5432/almog.gavra',  "mode"='timestamp',  "timestamp.column.name"='created_at',  "topic.prefix"='jdbc-',  "key"='username',  "table.whitelist"='users');

 Error
------------------------------------------------------------------------------------------------
 {
  "error_code" : 400,
  "message" : "... error message is not important, we can now create it ..."
}
------------------------------------------------------------------------------------------------
```

### Reviewer checklist
- [ ] Ensure docs are updated if necessary. (eg. if a user visible feature is being added or changed).
- [ ] Ensure relevant issues are linked (description should include text like "Fixes #<issue number>")

