### PR TITLE
chore: fix accidental rename of `InsertValuesExecutor` (MINOR)

### DIFF
--- a/ksql-engine/src/main/java/io/confluent/ksql/engine/InsertValuesExecutor.java
+++ b/ksql-engine/src/main/java/io/confluent/ksql/engine/InsertValuesExecutor.java
@@ -73,7 +73,7 @@ import org.apache.kafka.common.serialization.Serde;
 import org.apache.kafka.connect.data.Struct;
 
 // CHECKSTYLE_RULES.OFF: ClassDataAbstractionCoupling
-public class StubValuesExecutor {
+public class InsertValuesExecutor {
   // CHECKSTYLE_RULES.ON: ClassDataAbstractionCoupling
 
   private static final Duration MAX_SEND_TIMEOUT = Duration.ofSeconds(5);
@@ -84,8 +84,8 @@ public class StubValuesExecutor {
   private final ValueSerdeFactory valueSerdeFactory;
   private final KeySerdeFactory keySerdeFactory;
 
-  public StubValuesExecutor() {
-    this(true, StubValuesExecutor::sendRecord);
+  public InsertValuesExecutor() {
+    this(true, InsertValuesExecutor::sendRecord);
   }
 
   public interface RecordProducer {
@@ -98,7 +98,7 @@ public class StubValuesExecutor {
   }
 
   @VisibleForTesting
-  StubValuesExecutor(
+  InsertValuesExecutor(
       final boolean canBeDisabledByConfig,
       final RecordProducer producer
   ) {
@@ -112,15 +112,15 @@ public class StubValuesExecutor {
   }
 
   @VisibleForTesting
-  StubValuesExecutor(
+  InsertValuesExecutor(
       final LongSupplier clock,
       final KeySerdeFactory keySerdeFactory,
       final ValueSerdeFactory valueSerdeFactory
   ) {
-    this(StubValuesExecutor::sendRecord, true, clock, keySerdeFactory, valueSerdeFactory);
+    this(InsertValuesExecutor::sendRecord, true, clock, keySerdeFactory, valueSerdeFactory);
   }
 
-  private StubValuesExecutor(
+  private InsertValuesExecutor(
       final RecordProducer producer,
       final boolean canBeDisabledByConfig,
       final LongSupplier clock,

--- a/ksql-engine/src/test/java/io/confluent/ksql/engine/InsertValuesExecutorTest.java
+++ b/ksql-engine/src/test/java/io/confluent/ksql/engine/InsertValuesExecutorTest.java
@@ -146,7 +146,7 @@ public class InsertValuesExecutorTest {
   private KeySerdeFactory keySerdeFactory;
   @Mock
   private Supplier<SchemaRegistryClient> srClientFactory;
-  private StubValuesExecutor executor;
+  private InsertValuesExecutor executor;
 
   @Before
   public void setup() {
@@ -174,7 +174,7 @@ public class InsertValuesExecutorTest {
 
     when(clock.getAsLong()).thenReturn(1L);
 
-    executor = new StubValuesExecutor(clock, keySerdeFactory, valueSerdeFactory);
+    executor = new InsertValuesExecutor(clock, keySerdeFactory, valueSerdeFactory);
   }
 
   @Test

--- a/ksql-functional-tests/src/main/java/io/confluent/ksql/engine/StubInsertValuesExecutor.java
+++ b/ksql-functional-tests/src/main/java/io/confluent/ksql/engine/StubInsertValuesExecutor.java
@@ -34,10 +34,10 @@ public final class StubInsertValuesExecutor {
   private StubInsertValuesExecutor() {
   }
 
-  public static StubValuesExecutor of(final StubKafkaService stubKafkaService) {
+  public static InsertValuesExecutor of(final StubKafkaService stubKafkaService) {
     final StubProducer stubProducer = new StubProducer(stubKafkaService);
 
-    return new StubValuesExecutor(
+    return new InsertValuesExecutor(
         false,
         (record, ignored1, ingnored2) -> stubProducer.sendRecord(record));
   }

--- a/ksql-rest-app/src/main/java/io/confluent/ksql/rest/server/execution/CustomExecutors.java
+++ b/ksql-rest-app/src/main/java/io/confluent/ksql/rest/server/execution/CustomExecutors.java
@@ -17,7 +17,7 @@ package io.confluent.ksql.rest.server.execution;
 
 import com.google.common.collect.ImmutableMap;
 import io.confluent.ksql.KsqlExecutionContext;
-import io.confluent.ksql.engine.StubValuesExecutor;
+import io.confluent.ksql.engine.InsertValuesExecutor;
 import io.confluent.ksql.parser.tree.CreateConnector;
 import io.confluent.ksql.parser.tree.DescribeConnector;
 import io.confluent.ksql.parser.tree.DescribeFunction;
@@ -113,7 +113,7 @@ public enum CustomExecutors {
   }
 
   private static StatementExecutor insertValuesExecutor() {
-    final StubValuesExecutor executor = new StubValuesExecutor();
+    final InsertValuesExecutor executor = new InsertValuesExecutor();
 
     return (statement, executionContext, serviceContext) -> {
       executor.execute(statement, executionContext, serviceContext);

--- a/ksql-rest-app/src/main/java/io/confluent/ksql/rest/server/validation/CustomValidators.java
+++ b/ksql-rest-app/src/main/java/io/confluent/ksql/rest/server/validation/CustomValidators.java
@@ -17,7 +17,7 @@ package io.confluent.ksql.rest.server.validation;
 
 import com.google.common.collect.ImmutableMap;
 import io.confluent.ksql.KsqlExecutionContext;
-import io.confluent.ksql.engine.StubValuesExecutor;
+import io.confluent.ksql.engine.InsertValuesExecutor;
 import io.confluent.ksql.parser.tree.CreateConnector;
 import io.confluent.ksql.parser.tree.DescribeConnector;
 import io.confluent.ksql.parser.tree.DescribeFunction;
@@ -76,7 +76,7 @@ public enum CustomValidators {
   CREATE_CONNECTOR(CreateConnector.class, StatementValidator.NO_VALIDATION),
   DROP_CONNECTOR(DropConnector.class, StatementValidator.NO_VALIDATION),
 
-  INSERT_VALUES(InsertValues.class, new StubValuesExecutor()::execute),
+  INSERT_VALUES(InsertValues.class, new InsertValuesExecutor()::execute),
   SHOW_COLUMNS(ShowColumns.class, ListSourceExecutor::columns),
   EXPLAIN(Explain.class, ExplainExecutor::execute),
   DESCRIBE_FUNCTION(DescribeFunction.class, DescribeFunctionExecutor::execute),


### PR DESCRIPTION
### Description 

The name of this class looks to have accidentally renamed in a previous PR, which was looking to rename some test classes. However, this is a production class.

### Testing done 

Just a rename.

### Reviewer checklist
- [ ] Ensure docs are updated if necessary. (eg. if a user visible feature is being added or changed).
- [ ] Ensure relevant issues are linked (description should include text like "Fixes #<issue number>")

