### PR TITLE
fix(3525): `SET` should only affect statements after it

### DIFF
--- a/ksql-engine/src/main/java/io/confluent/ksql/engine/InsertValuesExecutor.java
+++ b/ksql-engine/src/main/java/io/confluent/ksql/engine/InsertValuesExecutor.java
@@ -136,6 +136,7 @@ public class InsertValuesExecutor {
 
   public void execute(
       final ConfiguredStatement<InsertValues> statement,
+      final Map<String, ?> sessionProperties,
       final KsqlExecutionContext executionContext,
       final ServiceContext serviceContext
   ) {

--- a/ksql-engine/src/main/java/io/confluent/ksql/properties/PropertyOverrider.java
+++ b/ksql-engine/src/main/java/io/confluent/ksql/properties/PropertyOverrider.java
@@ -21,22 +21,29 @@ import io.confluent.ksql.parser.tree.SetProperty;
 import io.confluent.ksql.parser.tree.UnsetProperty;
 import io.confluent.ksql.statement.ConfiguredStatement;
 import io.confluent.ksql.util.KsqlStatementException;
+import java.util.Map;
 
 public final class PropertyOverrider {
 
   private PropertyOverrider() { }
 
-  public static void set(final ConfiguredStatement<SetProperty> statement) {
+  public static void set(
+      final ConfiguredStatement<SetProperty> statement,
+      final Map<String, Object> mutableProperties
+  ) {
     final SetProperty setProperty = statement.getStatement();
     throwIfInvalidProperty(setProperty.getPropertyName(), statement.getStatementText());
     throwIfInvalidPropertyValues(setProperty, statement);
-    statement.getOverrides().put(setProperty.getPropertyName(), setProperty.getPropertyValue());
+    mutableProperties.put(setProperty.getPropertyName(), setProperty.getPropertyValue());
   }
 
-  public static void unset(final ConfiguredStatement<UnsetProperty> statement) {
+  public static void unset(
+      final ConfiguredStatement<UnsetProperty> statement,
+      final Map<String, Object> mutableProperties
+  ) {
     final UnsetProperty unsetProperty = statement.getStatement();
     throwIfInvalidProperty(unsetProperty.getPropertyName(), statement.getStatementText());
-    statement.getOverrides().remove(unsetProperty.getPropertyName());
+    mutableProperties.remove(unsetProperty.getPropertyName());
   }
 
   @SuppressFBWarnings("RV_RETURN_VALUE_IGNORED_INFERRED") // clone has side-effects

--- a/ksql-engine/src/main/java/io/confluent/ksql/statement/ConfiguredStatement.java
+++ b/ksql-engine/src/main/java/io/confluent/ksql/statement/ConfiguredStatement.java
@@ -15,6 +15,10 @@
 
 package io.confluent.ksql.statement;
 
+import static java.util.Objects.requireNonNull;
+
+import com.google.common.collect.ImmutableMap;
+import com.google.errorprone.annotations.Immutable;
 import io.confluent.ksql.parser.KsqlParser.PreparedStatement;
 import io.confluent.ksql.parser.tree.Statement;
 import io.confluent.ksql.util.KsqlConfig;
@@ -25,6 +29,7 @@ import java.util.Objects;
  * A prepared statement paired with the configurations needed to fully
  * execute it.
  */
+@Immutable
 public final class ConfiguredStatement<T extends Statement> {
 
   private final PreparedStatement<T> statement;
@@ -33,7 +38,7 @@ public final class ConfiguredStatement<T extends Statement> {
 
   public static <S extends Statement> ConfiguredStatement<S> of(
       final PreparedStatement<S> statement,
-      final Map<String, Object> overrides,
+      final Map<String, ?> overrides,
       final KsqlConfig config
   ) {
     return new ConfiguredStatement<>(statement, overrides, config);
@@ -41,12 +46,12 @@ public final class ConfiguredStatement<T extends Statement> {
 
   private ConfiguredStatement(
       final PreparedStatement<T> statement,
-      final Map<String, Object> overrides,
+      final Map<String, ?> overrides,
       final KsqlConfig config
   ) {
-    this.statement = Objects.requireNonNull(statement, "statement");
-    this.overrides = Objects.requireNonNull(overrides, "overrides");
-    this.config = Objects.requireNonNull(config, "config");
+    this.statement = requireNonNull(statement, "statement");
+    this.overrides = ImmutableMap.copyOf(requireNonNull(overrides, "overrides"));
+    this.config = requireNonNull(config, "config");
   }
 
   @SuppressWarnings("unchecked")

--- a/ksql-engine/src/test/java/io/confluent/ksql/engine/InsertValuesExecutorTest.java
+++ b/ksql-engine/src/test/java/io/confluent/ksql/engine/InsertValuesExecutorTest.java
@@ -189,7 +189,7 @@ public class InsertValuesExecutorTest {
     );
 
     // When:
-    executor.execute(statement, engine, serviceContext);
+    executor.execute(statement, ImmutableMap.of(), engine, serviceContext);
 
     // Then:
     verify(keySerializer).serialize(TOPIC_NAME, keyStruct("str"));
@@ -208,7 +208,7 @@ public class InsertValuesExecutorTest {
     );
 
     // When:
-    executor.execute(statement, engine, serviceContext);
+    executor.execute(statement, ImmutableMap.of(), engine, serviceContext);
 
     // Then:
     verify(keySerializer).serialize(TOPIC_NAME, keyStruct("new"));
@@ -228,7 +228,7 @@ public class InsertValuesExecutorTest {
     );
 
     // When:
-    executor.execute(statement, engine, serviceContext);
+    executor.execute(statement, ImmutableMap.of(), engine, serviceContext);
 
     // Then:
     verify(keySerializer).serialize(TOPIC_NAME, keyStruct("new"));
@@ -249,7 +249,7 @@ public class InsertValuesExecutorTest {
     );
 
     // When:
-    executor.execute(statement, engine, serviceContext);
+    executor.execute(statement, ImmutableMap.of(), engine, serviceContext);
 
     // Then:
     verify(keySerializer).serialize(TOPIC_NAME, keyStruct("str"));
@@ -270,7 +270,7 @@ public class InsertValuesExecutorTest {
     );
 
     // When:
-    executor.execute(statement, engine, serviceContext);
+    executor.execute(statement, ImmutableMap.of(), engine, serviceContext);
 
     // Then:
     verify(keySerializer).serialize(TOPIC_NAME, keyStruct("str"));
@@ -290,7 +290,7 @@ public class InsertValuesExecutorTest {
     );
 
     // When:
-    executor.execute(statement, engine, serviceContext);
+    executor.execute(statement, ImmutableMap.of(), engine, serviceContext);
 
     // Then:
     verify(keySerializer).serialize(TOPIC_NAME, keyStruct("str"));
@@ -311,7 +311,7 @@ public class InsertValuesExecutorTest {
     );
 
     // When:
-    executor.execute(statement, engine, serviceContext);
+    executor.execute(statement, ImmutableMap.of(), engine, serviceContext);
 
     // Then:
     verify(keySerializer).serialize(TOPIC_NAME, keyStruct("str"));
@@ -330,7 +330,7 @@ public class InsertValuesExecutorTest {
     );
 
     // When:
-    executor.execute(statement, engine, serviceContext);
+    executor.execute(statement, ImmutableMap.of(), engine, serviceContext);
 
     // Then:
     verify(keySerializer).serialize(TOPIC_NAME, keyStruct("str"));
@@ -350,7 +350,7 @@ public class InsertValuesExecutorTest {
     );
 
     // When:
-    executor.execute(statement, engine, serviceContext);
+    executor.execute(statement, ImmutableMap.of(), engine, serviceContext);
 
     // Then:
     verify(keySerializer).serialize(TOPIC_NAME, keyStruct("str"));
@@ -370,7 +370,7 @@ public class InsertValuesExecutorTest {
     );
 
     // When:
-    executor.execute(statement, engine, serviceContext);
+    executor.execute(statement, ImmutableMap.of(), engine, serviceContext);
 
     // Then:
     verify(keySerializer).serialize(TOPIC_NAME, keyStruct("str"));
@@ -389,7 +389,7 @@ public class InsertValuesExecutorTest {
     );
 
     // When:
-    executor.execute(statement, engine, serviceContext);
+    executor.execute(statement, ImmutableMap.of(), engine, serviceContext);
 
     // Then:
     verify(keySerializer).serialize(TOPIC_NAME, keyStruct("str"));
@@ -416,7 +416,7 @@ public class InsertValuesExecutorTest {
     );
 
     // When:
-    executor.execute(statement, engine, serviceContext);
+    executor.execute(statement, ImmutableMap.of(), engine, serviceContext);
 
     // Then:
     verify(keySerializer).serialize(TOPIC_NAME, keyStruct("str"));
@@ -442,7 +442,7 @@ public class InsertValuesExecutorTest {
     );
 
     // When:
-    executor.execute(statement, engine, serviceContext);
+    executor.execute(statement, ImmutableMap.of(), engine, serviceContext);
 
     // Then:
     verify(keySerializer).serialize(TOPIC_NAME, keyStruct("str"));
@@ -472,7 +472,7 @@ public class InsertValuesExecutorTest {
     expectedException.expectMessage("Failed to insert values into ");
 
     // When:
-    executor.execute(statement, engine, serviceContext);
+    executor.execute(statement, ImmutableMap.of(), engine, serviceContext);
   }
 
   @Test
@@ -493,7 +493,7 @@ public class InsertValuesExecutorTest {
     expectedException.expectCause(hasMessage(containsString("Could not serialize key")));
 
     // When:
-    executor.execute(statement, engine, serviceContext);
+    executor.execute(statement, ImmutableMap.of(), engine, serviceContext);
   }
 
   @Test
@@ -515,7 +515,7 @@ public class InsertValuesExecutorTest {
     expectedException.expectCause(hasMessage(containsString("Could not serialize row")));
 
     // When:
-    executor.execute(statement, engine, serviceContext);
+    executor.execute(statement, ImmutableMap.of(), engine, serviceContext);
   }
 
   @Test
@@ -539,7 +539,7 @@ public class InsertValuesExecutorTest {
     );
 
     // When:
-    executor.execute(statement, engine, serviceContext);
+    executor.execute(statement, ImmutableMap.of(), engine, serviceContext);
   }
 
   @Test
@@ -557,7 +557,7 @@ public class InsertValuesExecutorTest {
     expectedException.expectCause(hasMessage(containsString("Expected ROWKEY and COL0 to match")));
 
     // When:
-    executor.execute(statement, engine, serviceContext);
+    executor.execute(statement, ImmutableMap.of(), engine, serviceContext);
   }
 
   @Test
@@ -574,7 +574,7 @@ public class InsertValuesExecutorTest {
     expectedException.expectCause(hasMessage(containsString("Expected a value for each column")));
 
     // When:
-    executor.execute(statement, engine, serviceContext);
+    executor.execute(statement, ImmutableMap.of(), engine, serviceContext);
   }
 
   @Test
@@ -594,7 +594,7 @@ public class InsertValuesExecutorTest {
     expectedException.expectCause(hasMessage(containsString("Expected type INTEGER for field")));
 
     // When:
-    executor.execute(statement, engine, serviceContext);
+    executor.execute(statement, ImmutableMap.of(), engine, serviceContext);
   }
 
   @Test
@@ -611,7 +611,7 @@ public class InsertValuesExecutorTest {
     );
 
     // When:
-    executor.execute(statement, engine, serviceContext);
+    executor.execute(statement, ImmutableMap.of(), engine, serviceContext);
 
     // Then:
     verify(keySerializer).serialize(TOPIC_NAME, keyStruct("key"));
@@ -632,7 +632,7 @@ public class InsertValuesExecutorTest {
     );
 
     // When:
-    executor.execute(statement, engine, serviceContext);
+    executor.execute(statement, ImmutableMap.of(), engine, serviceContext);
 
     // Then:
     verify(keySerializer).serialize(TOPIC_NAME, keyStruct(null));
@@ -652,7 +652,7 @@ public class InsertValuesExecutorTest {
     );
 
     // When:
-    executor.execute(statement, engine, serviceContext);
+    executor.execute(statement, ImmutableMap.of(), engine, serviceContext);
 
     // Then:
     verify(keySerdeFactory).create(

--- a/ksql-engine/src/test/java/io/confluent/ksql/statement/ConfiguredStatementTest.java
+++ b/ksql-engine/src/test/java/io/confluent/ksql/statement/ConfiguredStatementTest.java
@@ -1,0 +1,65 @@
+/*
+ * Copyright 2019 Confluent Inc.
+ *
+ * Licensed under the Confluent Community License (the "License"); you may not use
+ * this file except in compliance with the License.  You may obtain a copy of the
+ * License at
+ *
+ * http://www.confluent.io/confluent-community-license
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package io.confluent.ksql.statement;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.instanceOf;
+import static org.hamcrest.Matchers.is;
+
+import com.google.common.collect.ImmutableMap;
+import io.confluent.ksql.parser.KsqlParser.PreparedStatement;
+import io.confluent.ksql.parser.tree.Statement;
+import io.confluent.ksql.util.KsqlConfig;
+import java.util.HashMap;
+import java.util.Map;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnitRunner;
+
+@RunWith(MockitoJUnitRunner.class)
+public class ConfiguredStatementTest {
+
+  private static final KsqlConfig CONFIG = new KsqlConfig(ImmutableMap.of());
+  @Mock
+  private PreparedStatement<? extends Statement> prepared;
+
+  @Test
+  public void shouldTakeDefensiveCopyOfProperties() {
+    // Given:
+    final Map<String, Object> props = new HashMap<>();
+    props.put("this", "that");
+
+    final ConfiguredStatement<? extends Statement> statement = ConfiguredStatement
+        .of(prepared, props, CONFIG);
+
+    // When:
+    props.put("other", "thing");
+
+    // Then:
+    assertThat(statement.getOverrides(), is(ImmutableMap.of("this", "that")));
+  }
+
+  @Test
+  public void shouldReturnImmutableProperties() {
+    // Given:
+    final ConfiguredStatement<? extends Statement> statement = ConfiguredStatement
+        .of(prepared, new HashMap<>(), CONFIG);
+
+    // Then:
+    assertThat(statement.getOverrides(), is(instanceOf(ImmutableMap.class)));
+  }
+}

--- a/ksql-engine/src/test/java/io/confluent/ksql/topic/TopicCreateInjectorTest.java
+++ b/ksql-engine/src/test/java/io/confluent/ksql/topic/TopicCreateInjectorTest.java
@@ -187,8 +187,8 @@ public class TopicCreateInjectorTest {
   @Test
   public void shouldGenerateNameWithCorrectPrefixFromOverrides() {
     // Given:
-    givenStatement("CREATE STREAM x AS SELECT * FROM SOURCE;");
     overrides.put(KsqlConfig.KSQL_OUTPUT_TOPIC_NAME_PREFIX_CONFIG, "prefix-");
+    givenStatement("CREATE STREAM x AS SELECT * FROM SOURCE;");
     config = new KsqlConfig(ImmutableMap.of(
         KsqlConfig.KSQL_OUTPUT_TOPIC_NAME_PREFIX_CONFIG, "nope"
     ));

--- a/ksql-functional-tests/src/main/java/io/confluent/ksql/test/tools/TestExecutorUtil.java
+++ b/ksql-functional-tests/src/main/java/io/confluent/ksql/test/tools/TestExecutorUtil.java
@@ -295,6 +295,7 @@ public final class TestExecutorUtil {
     if (prepared.getStatement() instanceof InsertValues) {
       StubInsertValuesExecutor.of(stubKafkaService).execute(
           (ConfiguredStatement<InsertValues>) configured,
+          overriddenProperties,
           executionContext,
           executionContext.getServiceContext()
       );

--- a/ksql-rest-app/src/main/java/io/confluent/ksql/rest/server/computation/DistributingExecutor.java
+++ b/ksql-rest-app/src/main/java/io/confluent/ksql/rest/server/computation/DistributingExecutor.java
@@ -27,6 +27,7 @@ import io.confluent.ksql.statement.ConfiguredStatement;
 import io.confluent.ksql.statement.Injector;
 import io.confluent.ksql.util.KsqlServerException;
 import java.time.Duration;
+import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
 import java.util.function.BiFunction;
@@ -61,9 +62,9 @@ public class DistributingExecutor implements StatementExecutor<Statement> {
   @Override
   public Optional<KsqlEntity> execute(
       final ConfiguredStatement<Statement> statement,
+      final Map<String, Object> mutableScopedProperties,
       final KsqlExecutionContext executionContext,
-      final ServiceContext serviceContext
-  ) {
+      final ServiceContext serviceContext) {
     final ConfiguredStatement<?> injected = injectorFactory
         .apply(executionContext, serviceContext)
         .inject(statement);

--- a/ksql-rest-app/src/main/java/io/confluent/ksql/rest/server/execution/ConnectExecutor.java
+++ b/ksql-rest-app/src/main/java/io/confluent/ksql/rest/server/execution/ConnectExecutor.java
@@ -26,6 +26,7 @@ import io.confluent.ksql.services.ConnectClient;
 import io.confluent.ksql.services.ConnectClient.ConnectResponse;
 import io.confluent.ksql.services.ServiceContext;
 import io.confluent.ksql.statement.ConfiguredStatement;
+import java.util.Map;
 import java.util.Optional;
 import org.apache.kafka.connect.runtime.rest.entities.ConnectorInfo;
 
@@ -35,6 +36,7 @@ public final class ConnectExecutor {
 
   public static Optional<KsqlEntity> execute(
       final ConfiguredStatement<CreateConnector> statement,
+      final Map<String, ?> sessionProperties,
       final KsqlExecutionContext executionContext,
       final ServiceContext serviceContext
   ) {

--- a/ksql-rest-app/src/main/java/io/confluent/ksql/rest/server/execution/CustomExecutors.java
+++ b/ksql-rest-app/src/main/java/io/confluent/ksql/rest/server/execution/CustomExecutors.java
@@ -107,16 +107,18 @@ public enum CustomExecutors {
 
   public Optional<KsqlEntity> execute(
       final ConfiguredStatement<?> statement,
+      final Map<String, Object> mutableScopedProperties,
       final KsqlExecutionContext executionCtx,
-      final ServiceContext serviceCtx) {
-    return executor.execute(statement, executionCtx, serviceCtx);
+      final ServiceContext serviceCtx
+  ) {
+    return executor.execute(statement, mutableScopedProperties, executionCtx, serviceCtx);
   }
 
   private static StatementExecutor insertValuesExecutor() {
     final InsertValuesExecutor executor = new InsertValuesExecutor();
 
-    return (statement, executionContext, serviceContext) -> {
-      executor.execute(statement, executionContext, serviceContext);
+    return (statement, sessionProperties, executionContext, serviceContext) -> {
+      executor.execute(statement, sessionProperties, executionContext, serviceContext);
       return Optional.empty();
     };
   }

--- a/ksql-rest-app/src/main/java/io/confluent/ksql/rest/server/execution/DescribeConnectorExecutor.java
+++ b/ksql-rest-app/src/main/java/io/confluent/ksql/rest/server/execution/DescribeConnectorExecutor.java
@@ -31,6 +31,7 @@ import io.confluent.ksql.services.ConnectClient.ConnectResponse;
 import io.confluent.ksql.services.ServiceContext;
 import io.confluent.ksql.statement.ConfiguredStatement;
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
 import java.util.concurrent.TimeUnit;
 import java.util.function.Function;
@@ -60,6 +61,7 @@ public final class DescribeConnectorExecutor {
   @SuppressWarnings("OptionalGetWithoutIsPresent")
   public Optional<KsqlEntity> execute(
       final ConfiguredStatement<DescribeConnector> configuredStatement,
+      final Map<String, ?> sessionProperties,
       final KsqlExecutionContext ksqlExecutionContext,
       final ServiceContext serviceContext
   ) {

--- a/ksql-rest-app/src/main/java/io/confluent/ksql/rest/server/execution/DescribeFunctionExecutor.java
+++ b/ksql-rest-app/src/main/java/io/confluent/ksql/rest/server/execution/DescribeFunctionExecutor.java
@@ -31,6 +31,7 @@ import io.confluent.ksql.statement.ConfiguredStatement;
 import io.confluent.ksql.util.IdentifierUtil;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
 import org.apache.kafka.connect.data.Schema;
 
@@ -43,6 +44,7 @@ public final class DescribeFunctionExecutor {
 
   public static Optional<KsqlEntity> execute(
       final ConfiguredStatement<DescribeFunction> statement,
+      final Map<String, ?> sessionProperties,
       final KsqlExecutionContext executionContext,
       final ServiceContext serviceContext
   ) {

--- a/ksql-rest-app/src/main/java/io/confluent/ksql/rest/server/execution/DropConnectorExecutor.java
+++ b/ksql-rest-app/src/main/java/io/confluent/ksql/rest/server/execution/DropConnectorExecutor.java
@@ -23,6 +23,7 @@ import io.confluent.ksql.rest.entity.KsqlEntity;
 import io.confluent.ksql.services.ConnectClient.ConnectResponse;
 import io.confluent.ksql.services.ServiceContext;
 import io.confluent.ksql.statement.ConfiguredStatement;
+import java.util.Map;
 import java.util.Optional;
 
 public final class DropConnectorExecutor {
@@ -31,6 +32,7 @@ public final class DropConnectorExecutor {
 
   public static Optional<KsqlEntity> execute(
       final ConfiguredStatement<DropConnector> statement,
+      final Map<String, ?> sessionProperties,
       final KsqlExecutionContext executionContext,
       final ServiceContext serviceContext
   ) {

--- a/ksql-rest-app/src/main/java/io/confluent/ksql/rest/server/execution/ExplainExecutor.java
+++ b/ksql-rest-app/src/main/java/io/confluent/ksql/rest/server/execution/ExplainExecutor.java
@@ -32,6 +32,7 @@ import io.confluent.ksql.util.KsqlException;
 import io.confluent.ksql.util.KsqlStatementException;
 import io.confluent.ksql.util.PersistentQueryMetadata;
 import io.confluent.ksql.util.QueryMetadata;
+import java.util.Map;
 import java.util.Optional;
 
 /**
@@ -44,6 +45,7 @@ public final class ExplainExecutor {
 
   public static Optional<KsqlEntity> execute(
       final ConfiguredStatement<Explain> statement,
+      final Map<String, ?> sessionProperties,
       final KsqlExecutionContext executionContext,
       final ServiceContext serviceContext
   ) {

--- a/ksql-rest-app/src/main/java/io/confluent/ksql/rest/server/execution/ListConnectorsExecutor.java
+++ b/ksql-rest-app/src/main/java/io/confluent/ksql/rest/server/execution/ListConnectorsExecutor.java
@@ -29,6 +29,7 @@ import io.confluent.ksql.services.ServiceContext;
 import io.confluent.ksql.statement.ConfiguredStatement;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
 import org.apache.kafka.connect.runtime.ConnectorConfig;
 import org.apache.kafka.connect.runtime.rest.entities.ConnectorInfo;
@@ -41,6 +42,7 @@ public final class ListConnectorsExecutor {
   @SuppressWarnings("OptionalGetWithoutIsPresent")
   public static Optional<KsqlEntity> execute(
       final ConfiguredStatement<ListConnectors> configuredStatement,
+      final Map<String, ?> sessionProperties,
       final KsqlExecutionContext ksqlExecutionContext,
       final ServiceContext serviceContext
   ) {

--- a/ksql-rest-app/src/main/java/io/confluent/ksql/rest/server/execution/ListFunctionsExecutor.java
+++ b/ksql-rest-app/src/main/java/io/confluent/ksql/rest/server/execution/ListFunctionsExecutor.java
@@ -25,6 +25,7 @@ import io.confluent.ksql.rest.entity.SimpleFunctionInfo;
 import io.confluent.ksql.services.ServiceContext;
 import io.confluent.ksql.statement.ConfiguredStatement;
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
 import java.util.stream.Collectors;
 
@@ -34,6 +35,7 @@ public final class ListFunctionsExecutor {
 
   public static Optional<KsqlEntity> execute(
       final ConfiguredStatement<ListFunctions> statement,
+      final Map<String, ?> sessionProperties,
       final KsqlExecutionContext executionContext,
       final ServiceContext serviceContext
   ) {

--- a/ksql-rest-app/src/main/java/io/confluent/ksql/rest/server/execution/ListPropertiesExecutor.java
+++ b/ksql-rest-app/src/main/java/io/confluent/ksql/rest/server/execution/ListPropertiesExecutor.java
@@ -35,6 +35,7 @@ public final class ListPropertiesExecutor {
 
   public static Optional<KsqlEntity> execute(
       final ConfiguredStatement<ListProperties> statement,
+      final Map<String, ?> sessionProperties,
       final KsqlExecutionContext executionContext,
       final ServiceContext serviceContext
   ) {

--- a/ksql-rest-app/src/main/java/io/confluent/ksql/rest/server/execution/ListQueriesExecutor.java
+++ b/ksql-rest-app/src/main/java/io/confluent/ksql/rest/server/execution/ListQueriesExecutor.java
@@ -24,6 +24,7 @@ import io.confluent.ksql.rest.entity.QueryDescriptionList;
 import io.confluent.ksql.rest.entity.RunningQuery;
 import io.confluent.ksql.services.ServiceContext;
 import io.confluent.ksql.statement.ConfiguredStatement;
+import java.util.Map;
 import java.util.Optional;
 import java.util.stream.Collectors;
 
@@ -33,6 +34,7 @@ public final class ListQueriesExecutor {
 
   public static Optional<KsqlEntity> execute(
       final ConfiguredStatement<ListQueries> statement,
+      final Map<String, ?> sessionProperties,
       final KsqlExecutionContext executionContext,
       final ServiceContext serviceContext
   ) {

--- a/ksql-rest-app/src/main/java/io/confluent/ksql/rest/server/execution/ListSourceExecutor.java
+++ b/ksql-rest-app/src/main/java/io/confluent/ksql/rest/server/execution/ListSourceExecutor.java
@@ -43,6 +43,7 @@ import io.confluent.ksql.util.KsqlStatementException;
 import io.confluent.ksql.util.PersistentQueryMetadata;
 import java.util.LinkedList;
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
 import java.util.function.Predicate;
 import java.util.stream.Collectors;
@@ -81,6 +82,7 @@ public final class ListSourceExecutor {
 
   public static Optional<KsqlEntity> streams(
       final ConfiguredStatement<ListStreams> statement,
+      final Map<String, ?> sessionProperties,
       final KsqlExecutionContext executionContext,
       final ServiceContext serviceContext
   ) {
@@ -105,6 +107,7 @@ public final class ListSourceExecutor {
 
   public static Optional<KsqlEntity> tables(
       final ConfiguredStatement<ListTables> statement,
+      final Map<String, ?> sessionProperties,
       final KsqlExecutionContext executionContext,
       final ServiceContext serviceContext
   ) {
@@ -128,6 +131,7 @@ public final class ListSourceExecutor {
 
   public static Optional<KsqlEntity> columns(
       final ConfiguredStatement<ShowColumns> statement,
+      final Map<String, ?> sessionProperties,
       final KsqlExecutionContext executionContext,
       final ServiceContext serviceContext
   ) {

--- a/ksql-rest-app/src/main/java/io/confluent/ksql/rest/server/execution/ListTopicsExecutor.java
+++ b/ksql-rest-app/src/main/java/io/confluent/ksql/rest/server/execution/ListTopicsExecutor.java
@@ -53,6 +53,7 @@ public final class ListTopicsExecutor {
 
   public static Optional<KsqlEntity> execute(
       final ConfiguredStatement<ListTopics> statement,
+      final Map<String, ?> sessionProperties,
       final KsqlExecutionContext executionContext,
       final ServiceContext serviceContext
   ) {

--- a/ksql-rest-app/src/main/java/io/confluent/ksql/rest/server/execution/ListTypesExecutor.java
+++ b/ksql-rest-app/src/main/java/io/confluent/ksql/rest/server/execution/ListTypesExecutor.java
@@ -26,6 +26,7 @@ import io.confluent.ksql.rest.util.EntityUtil;
 import io.confluent.ksql.services.ServiceContext;
 import io.confluent.ksql.statement.ConfiguredStatement;
 import java.util.Iterator;
+import java.util.Map;
 import java.util.Optional;
 
 public final class ListTypesExecutor {
@@ -34,6 +35,7 @@ public final class ListTypesExecutor {
 
   public static Optional<KsqlEntity> execute(
       final ConfiguredStatement<ListTypes> configuredStatement,
+      final Map<String, ?> sessionProperties,
       final KsqlExecutionContext executionContext,
       final ServiceContext serviceContext
   ) {

--- a/ksql-rest-app/src/main/java/io/confluent/ksql/rest/server/execution/PropertyExecutor.java
+++ b/ksql-rest-app/src/main/java/io/confluent/ksql/rest/server/execution/PropertyExecutor.java
@@ -22,6 +22,7 @@ import io.confluent.ksql.properties.PropertyOverrider;
 import io.confluent.ksql.rest.entity.KsqlEntity;
 import io.confluent.ksql.services.ServiceContext;
 import io.confluent.ksql.statement.ConfiguredStatement;
+import java.util.Map;
 import java.util.Optional;
 
 public final class PropertyExecutor {
@@ -30,19 +31,21 @@ public final class PropertyExecutor {
 
   public static Optional<KsqlEntity> set(
       final ConfiguredStatement<SetProperty> statement,
+      final Map<String, Object> mutableScopedProperties,
       final KsqlExecutionContext executionContext,
       final ServiceContext serviceContext
   ) {
-    PropertyOverrider.set(statement);
+    PropertyOverrider.set(statement, mutableScopedProperties);
     return Optional.empty();
   }
 
   public static Optional<KsqlEntity> unset(
       final ConfiguredStatement<UnsetProperty> statement,
+      final Map<String, Object> mutableScopedProperties,
       final KsqlExecutionContext executionContext,
       final ServiceContext serviceContext
   ) {
-    PropertyOverrider.unset(statement);
+    PropertyOverrider.unset(statement, mutableScopedProperties);
     return Optional.empty();
   }
 

--- a/ksql-rest-app/src/main/java/io/confluent/ksql/rest/server/execution/RequestHandler.java
+++ b/ksql-rest-app/src/main/java/io/confluent/ksql/rest/server/execution/RequestHandler.java
@@ -90,7 +90,8 @@ public class RequestHandler {
       } else {
         final ConfiguredStatement<?> configured = ConfiguredStatement.of(
             prepared, scopedPropertyOverrides, ksqlConfig);
-        executeStatement(serviceContext, configured, entities).ifPresent(entities::add);
+        executeStatement(serviceContext, configured, scopedPropertyOverrides, entities)
+            .ifPresent(entities::add);
       }
     }
     return entities;
@@ -100,6 +101,7 @@ public class RequestHandler {
   private <T extends Statement> Optional<KsqlEntity> executeStatement(
       final ServiceContext serviceContext,
       final ConfiguredStatement<T> configured,
+      final Map<String, Object> mutableScopedProperties,
       final KsqlEntityList entities
   ) {
     final Class<? extends Statement> statementClass = configured.getStatement().getClass();
@@ -110,6 +112,7 @@ public class RequestHandler {
 
     return executor.execute(
         configured,
+        mutableScopedProperties,
         ksqlEngine,
         serviceContext
     );
@@ -129,5 +132,4 @@ public class RequestHandler {
 
     return execute(serviceContext, ksqlEngine.parse(sql), propertyOverrides);
   }
-
 }

--- a/ksql-rest-app/src/main/java/io/confluent/ksql/rest/server/execution/StatementExecutor.java
+++ b/ksql-rest-app/src/main/java/io/confluent/ksql/rest/server/execution/StatementExecutor.java
@@ -20,6 +20,7 @@ import io.confluent.ksql.parser.tree.Statement;
 import io.confluent.ksql.rest.entity.KsqlEntity;
 import io.confluent.ksql.services.ServiceContext;
 import io.confluent.ksql.statement.ConfiguredStatement;
+import java.util.Map;
 import java.util.Optional;
 
 /**
@@ -31,11 +32,16 @@ public interface StatementExecutor<T extends Statement> {
   /**
    * Executes the query against the parameterized {@code ksqlEngine}.
    *
+   * @param statement the statement to execute
+   * @param mutableScopedProperties the session properties
+   * @param executionContext the context in which to execute it
+   * @param serviceContext the services to use to execute it
    * @return the execution result, if present, else {@link Optional#empty()}
    */
   Optional<KsqlEntity> execute(
       ConfiguredStatement<T> statement,
+      Map<String, Object> mutableScopedProperties,
       KsqlExecutionContext executionContext,
-      ServiceContext serviceContext);
-
+      ServiceContext serviceContext
+  );
 }

--- a/ksql-rest-app/src/main/java/io/confluent/ksql/rest/server/execution/StaticQueryExecutor.java
+++ b/ksql-rest-app/src/main/java/io/confluent/ksql/rest/server/execution/StaticQueryExecutor.java
@@ -113,6 +113,7 @@ public final class StaticQueryExecutor {
 
   public static void validate(
       final ConfiguredStatement<Query> statement,
+      final Map<String, ?> sessionProperties,
       final KsqlExecutionContext executionContext,
       final ServiceContext serviceContext
   ) {
@@ -139,6 +140,7 @@ public final class StaticQueryExecutor {
 
   public static Optional<KsqlEntity> execute(
       final ConfiguredStatement<Query> statement,
+      final Map<String, ?> sessionProperties,
       final KsqlExecutionContext executionContext,
       final ServiceContext serviceContext
   ) {

--- a/ksql-rest-app/src/main/java/io/confluent/ksql/rest/server/validation/CustomValidators.java
+++ b/ksql-rest-app/src/main/java/io/confluent/ksql/rest/server/validation/CustomValidators.java
@@ -116,8 +116,9 @@ public enum CustomValidators {
 
   public void validate(
       final ConfiguredStatement<?> statement,
+      final Map<String, Object> mutableScopedProperties,
       final KsqlExecutionContext executionContext,
       final ServiceContext serviceContext) throws KsqlException {
-    validator.validate(statement, executionContext, serviceContext);
+    validator.validate(statement, mutableScopedProperties, executionContext, serviceContext);
   }
 }

--- a/ksql-rest-app/src/main/java/io/confluent/ksql/rest/server/validation/PrintTopicValidator.java
+++ b/ksql-rest-app/src/main/java/io/confluent/ksql/rest/server/validation/PrintTopicValidator.java
@@ -20,6 +20,7 @@ import io.confluent.ksql.rest.Errors;
 import io.confluent.ksql.rest.server.resources.KsqlRestException;
 import io.confluent.ksql.services.ServiceContext;
 import io.confluent.ksql.statement.ConfiguredStatement;
+import java.util.Map;
 
 public final class PrintTopicValidator {
 
@@ -27,6 +28,7 @@ public final class PrintTopicValidator {
 
   public static void validate(
       final ConfiguredStatement<?> statement,
+      final Map<String, ?> sessionProperties,
       final KsqlExecutionContext context,
       final ServiceContext serviceContext) {
     throw new KsqlRestException(Errors.queryEndpoint(statement.getStatementText()));

--- a/ksql-rest-app/src/main/java/io/confluent/ksql/rest/server/validation/StatementValidator.java
+++ b/ksql-rest-app/src/main/java/io/confluent/ksql/rest/server/validation/StatementValidator.java
@@ -20,6 +20,7 @@ import io.confluent.ksql.parser.tree.Statement;
 import io.confluent.ksql.services.ServiceContext;
 import io.confluent.ksql.statement.ConfiguredStatement;
 import io.confluent.ksql.util.KsqlException;
+import java.util.Map;
 
 /**
  * An interface that allows for arbitrary validation code of a prepared statement
@@ -31,7 +32,7 @@ public interface StatementValidator<T extends Statement> {
   /**
    * A statement validator that does nothing.
    */
-  StatementValidator<Statement> NO_VALIDATION = (stmt, ectx, sctx) -> { };
+  StatementValidator<Statement> NO_VALIDATION = (stmt, props, ectx, sctx) -> { };
 
   /**
    * Validates the statement against the given parameters, and throws an exception
@@ -42,6 +43,7 @@ public interface StatementValidator<T extends Statement> {
    */
   void validate(
       ConfiguredStatement<T> statement,
+      Map<String, Object> mutableScopedProperties,
       KsqlExecutionContext executionContext,
       ServiceContext serviceContext) throws KsqlException;
 }

--- a/ksql-rest-app/src/main/java/io/confluent/ksql/rest/server/validation/TerminateQueryValidator.java
+++ b/ksql-rest-app/src/main/java/io/confluent/ksql/rest/server/validation/TerminateQueryValidator.java
@@ -21,6 +21,7 @@ import io.confluent.ksql.query.QueryId;
 import io.confluent.ksql.services.ServiceContext;
 import io.confluent.ksql.statement.ConfiguredStatement;
 import io.confluent.ksql.util.KsqlStatementException;
+import java.util.Map;
 
 public final class TerminateQueryValidator {
 
@@ -28,6 +29,7 @@ public final class TerminateQueryValidator {
 
   public static void validate(
       final ConfiguredStatement<?> statement,
+      final Map<String, ?> sessionProperties,
       final KsqlExecutionContext context,
       final ServiceContext serviceContext
   ) {

--- a/ksql-rest-app/src/test/java/io/confluent/ksql/rest/server/StandaloneExecutorTest.java
+++ b/ksql-rest-app/src/test/java/io/confluent/ksql/rest/server/StandaloneExecutorTest.java
@@ -486,6 +486,28 @@ public class StandaloneExecutorTest {
   }
 
   @Test
+  public void shouldSetPropertyOnlyOnCommandsFollowingTheSetStatement() {
+    // Given:
+    final PreparedStatement<SetProperty> setProp = PreparedStatement.of("SET PROP",
+        new SetProperty(Optional.empty(), ConsumerConfig.AUTO_OFFSET_RESET_CONFIG, "earliest"));
+
+    final PreparedStatement<CreateStream> cs = PreparedStatement.of("CS",
+        new CreateStream(SOME_NAME, SOME_ELEMENTS, false, JSON_PROPS));
+
+    givenQueryFileParsesTo(cs, setProp);
+
+    // When:
+    standaloneExecutor.start();
+
+    // Then:
+    verify(ksqlEngine).execute(ConfiguredStatement.of(
+        cs,
+        ImmutableMap.of(),
+        ksqlConfig
+    ));
+  }
+
+  @Test
   public void shouldRunUnSetStatements() {
     // Given:
     final PreparedStatement<SetProperty> setProp = PreparedStatement.of("SET",

--- a/ksql-rest-app/src/test/java/io/confluent/ksql/rest/server/computation/DistributingExecutorTest.java
+++ b/ksql-rest-app/src/test/java/io/confluent/ksql/rest/server/computation/DistributingExecutorTest.java
@@ -111,7 +111,7 @@ public class DistributingExecutorTest {
   @Test
   public void shouldEnqueueSuccessfulCommand() throws InterruptedException {
     // When:
-    distributor.execute(EMPTY_STATEMENT, executionContext, serviceContext);
+    distributor.execute(EMPTY_STATEMENT, ImmutableMap.of(), executionContext, serviceContext);
 
     // Then:
     verify(queue, times(1)).enqueueCommand(eq(EMPTY_STATEMENT));
@@ -120,7 +120,7 @@ public class DistributingExecutorTest {
   @Test
   public void shouldInferSchemas() {
     // When:
-    distributor.execute(EMPTY_STATEMENT, executionContext, serviceContext);
+    distributor.execute(EMPTY_STATEMENT, ImmutableMap.of(), executionContext, serviceContext);
 
     // Then:
     verify(schemaInjector, times(1)).inject(eq(EMPTY_STATEMENT));
@@ -132,6 +132,7 @@ public class DistributingExecutorTest {
     final CommandStatusEntity commandStatusEntity =
         (CommandStatusEntity) distributor.execute(
             EMPTY_STATEMENT,
+            ImmutableMap.of(),
             executionContext,
             serviceContext
         )
@@ -165,7 +166,7 @@ public class DistributingExecutorTest {
     expectedException.expectCause(is(cause));
 
     // When:
-    distributor.execute(configured, executionContext, serviceContext);
+    distributor.execute(configured, ImmutableMap.of(), executionContext, serviceContext);
   }
 
   @Test
@@ -182,7 +183,7 @@ public class DistributingExecutorTest {
     expectedException.expectMessage("Could not infer!");
 
     // When:
-    distributor.execute(configured, executionContext, serviceContext);
+    distributor.execute(configured, ImmutableMap.of(), executionContext, serviceContext);
   }
 
   @Test
@@ -200,7 +201,7 @@ public class DistributingExecutorTest {
     expectedException.expect(KsqlTopicAuthorizationException.class);
 
     // When:
-    distributor.execute(configured, executionContext, userServiceContext);
+    distributor.execute(configured, ImmutableMap.of(), executionContext, userServiceContext);
   }
 
   @Test
@@ -219,6 +220,6 @@ public class DistributingExecutorTest {
     expectedException.expectCause(is(instanceOf(KsqlTopicAuthorizationException.class)));
 
     // When:
-    distributor.execute(configured, executionContext, userServiceContext);
+    distributor.execute(configured, ImmutableMap.of(), executionContext, userServiceContext);
   }
 }

--- a/ksql-rest-app/src/test/java/io/confluent/ksql/rest/server/execution/ConnectExecutorTest.java
+++ b/ksql-rest-app/src/test/java/io/confluent/ksql/rest/server/execution/ConnectExecutorTest.java
@@ -24,10 +24,10 @@ import static org.mockito.Mockito.when;
 
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
+import io.confluent.ksql.execution.expression.tree.StringLiteral;
 import io.confluent.ksql.parser.KsqlParser.PreparedStatement;
 import io.confluent.ksql.parser.tree.CreateConnector;
 import io.confluent.ksql.parser.tree.CreateConnector.Type;
-import io.confluent.ksql.execution.expression.tree.StringLiteral;
 import io.confluent.ksql.rest.entity.CreateConnectorEntity;
 import io.confluent.ksql.rest.entity.ErrorEntity;
 import io.confluent.ksql.rest.entity.KsqlEntity;
@@ -78,7 +78,7 @@ public class ConnectExecutorTest {
     givenSuccess();
 
     // When:
-    ConnectExecutor.execute(CREATE_CONNECTOR_CONFIGURED, null, serviceContext);
+    ConnectExecutor.execute(CREATE_CONNECTOR_CONFIGURED, ImmutableMap.of(), null, serviceContext);
 
     // Then:
     verify(connectClient).create("foo", ImmutableMap.of("foo", "bar"));
@@ -91,7 +91,7 @@ public class ConnectExecutorTest {
 
     // When:
     final Optional<KsqlEntity> entity = ConnectExecutor
-        .execute(CREATE_CONNECTOR_CONFIGURED, null, serviceContext);
+        .execute(CREATE_CONNECTOR_CONFIGURED, ImmutableMap.of(), null, serviceContext);
 
     // Then:
     assertThat("Expected non-empty response", entity.isPresent());
@@ -105,7 +105,7 @@ public class ConnectExecutorTest {
 
     // When:
     final Optional<KsqlEntity> entity = ConnectExecutor
-        .execute(CREATE_CONNECTOR_CONFIGURED, null, serviceContext);
+        .execute(CREATE_CONNECTOR_CONFIGURED, ImmutableMap.of(), null, serviceContext);
 
     // Then:
     assertThat("Expected non-empty response", entity.isPresent());

--- a/ksql-rest-app/src/test/java/io/confluent/ksql/rest/server/execution/DescribeConnectorExecutorTest.java
+++ b/ksql-rest-app/src/test/java/io/confluent/ksql/rest/server/execution/DescribeConnectorExecutorTest.java
@@ -160,7 +160,8 @@ public class DescribeConnectorExecutorTest {
   @Test
   public void shouldDescribeKnownConnector() {
     // When:
-    final Optional<KsqlEntity> entity = executor.execute(describeStatement, engine, serviceContext);
+    final Optional<KsqlEntity> entity = executor
+        .execute(describeStatement, ImmutableMap.of(), engine, serviceContext);
 
     // Then:
     assertThat("Expected a response", entity.isPresent());
@@ -184,7 +185,8 @@ public class DescribeConnectorExecutorTest {
     when(topics.names()).thenReturn(fut);
 
     // When:
-    final Optional<KsqlEntity> entity = executor.execute(describeStatement, engine, serviceContext);
+    final Optional<KsqlEntity> entity = executor
+        .execute(describeStatement, ImmutableMap.of(), engine, serviceContext);
 
     // Then:
     assertThat("Expected a response", entity.isPresent());
@@ -202,7 +204,8 @@ public class DescribeConnectorExecutorTest {
     when(connectClient.describe(any())).thenReturn(ConnectResponse.failure("error", HttpStatus.SC_INTERNAL_SERVER_ERROR));
 
     // When:
-    final Optional<KsqlEntity> entity = executor.execute(describeStatement, engine, serviceContext);
+    final Optional<KsqlEntity> entity = executor
+        .execute(describeStatement, ImmutableMap.of(), engine, serviceContext);
 
     // Then:
     verify(connectClient).status("connector");
@@ -217,7 +220,8 @@ public class DescribeConnectorExecutorTest {
     when(connectClient.describe(any())).thenReturn(ConnectResponse.failure("error", HttpStatus.SC_INTERNAL_SERVER_ERROR));
 
     // When:
-    final Optional<KsqlEntity> entity = executor.execute(describeStatement, engine, serviceContext);
+    final Optional<KsqlEntity> entity = executor
+        .execute(describeStatement, ImmutableMap.of(), engine, serviceContext);
 
     // Then:
     verify(connectClient).status("connector");
@@ -234,7 +238,8 @@ public class DescribeConnectorExecutorTest {
     executor = new DescribeConnectorExecutor(connectorFactory);
 
     // When:
-    final Optional<KsqlEntity> entity = executor.execute(describeStatement, engine, serviceContext);
+    final Optional<KsqlEntity> entity = executor
+        .execute(describeStatement, ImmutableMap.of(), engine, serviceContext);
 
     // Then:
     assertThat("Expected a response", entity.isPresent());

--- a/ksql-rest-app/src/test/java/io/confluent/ksql/rest/server/execution/DescribeFunctionExecutorTest.java
+++ b/ksql-rest-app/src/test/java/io/confluent/ksql/rest/server/execution/DescribeFunctionExecutorTest.java
@@ -17,6 +17,7 @@ package io.confluent.ksql.rest.server.execution;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 
+import com.google.common.collect.ImmutableMap;
 import io.confluent.ksql.rest.entity.FunctionDescriptionList;
 import io.confluent.ksql.rest.entity.FunctionType;
 import io.confluent.ksql.rest.server.TemporaryEngine;
@@ -38,6 +39,7 @@ public class DescribeFunctionExecutorTest {
     final FunctionDescriptionList functionList = (FunctionDescriptionList)
         CustomExecutors.DESCRIBE_FUNCTION.execute(
             engine.configure("DESCRIBE FUNCTION CONCAT;"),
+            ImmutableMap.of(),
             engine.getEngine(),
             engine.getServiceContext()
         ).orElseThrow(IllegalStateException::new);
@@ -63,6 +65,7 @@ public class DescribeFunctionExecutorTest {
     final FunctionDescriptionList functionList = (FunctionDescriptionList)
         CustomExecutors.DESCRIBE_FUNCTION.execute(
             engine.configure("DESCRIBE FUNCTION MAX;"),
+            ImmutableMap.of(),
             engine.getEngine(),
             engine.getServiceContext()
         ).orElseThrow(IllegalStateException::new);

--- a/ksql-rest-app/src/test/java/io/confluent/ksql/rest/server/execution/DropConnectorExecutorTest.java
+++ b/ksql-rest-app/src/test/java/io/confluent/ksql/rest/server/execution/DropConnectorExecutorTest.java
@@ -16,7 +16,8 @@
 package io.confluent.ksql.rest.server.execution;
 
 import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.Matchers.*;
+import static org.hamcrest.Matchers.instanceOf;
+import static org.hamcrest.Matchers.is;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
@@ -73,7 +74,7 @@ public class DropConnectorExecutorTest {
         .thenReturn(ConnectResponse.success("foo", HttpStatus.SC_OK));
 
     // When:
-    DropConnectorExecutor.execute(DROP_CONNECTOR_CONFIGURED, null, serviceContext);
+    DropConnectorExecutor.execute(DROP_CONNECTOR_CONFIGURED, ImmutableMap.of(),null, serviceContext);
 
     // Then:
     verify(connectClient).delete("foo");
@@ -87,7 +88,7 @@ public class DropConnectorExecutorTest {
 
     // When:
     final Optional<KsqlEntity> response = DropConnectorExecutor
-        .execute(DROP_CONNECTOR_CONFIGURED, null, serviceContext);
+        .execute(DROP_CONNECTOR_CONFIGURED, ImmutableMap.of(),null, serviceContext);
 
     // Then:
     assertThat("expected response", response.isPresent());
@@ -102,7 +103,7 @@ public class DropConnectorExecutorTest {
 
     // When:
     final Optional<KsqlEntity> entity = DropConnectorExecutor
-        .execute(DROP_CONNECTOR_CONFIGURED, null, serviceContext);
+        .execute(DROP_CONNECTOR_CONFIGURED, ImmutableMap.of(),null, serviceContext);
 
     // Then:
     assertThat("Expected non-empty response", entity.isPresent());

--- a/ksql-rest-app/src/test/java/io/confluent/ksql/rest/server/execution/ExplainExecutorTest.java
+++ b/ksql-rest-app/src/test/java/io/confluent/ksql/rest/server/execution/ExplainExecutorTest.java
@@ -24,6 +24,7 @@ import static org.hamcrest.Matchers.is;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
+import com.google.common.collect.ImmutableMap;
 import io.confluent.ksql.engine.KsqlEngine;
 import io.confluent.ksql.name.SourceName;
 import io.confluent.ksql.query.QueryId;
@@ -58,6 +59,7 @@ public class ExplainExecutorTest {
     // When:
     final QueryDescriptionEntity query = (QueryDescriptionEntity) CustomExecutors.EXPLAIN.execute(
         explain,
+        ImmutableMap.of(),
         engine,
         this.engine.getServiceContext()
     ).orElseThrow(IllegalStateException::new);
@@ -77,6 +79,7 @@ public class ExplainExecutorTest {
     // When:
     final QueryDescriptionEntity query = (QueryDescriptionEntity) CustomExecutors.EXPLAIN.execute(
         explain,
+        ImmutableMap.of(),
         engine.getEngine(),
         engine.getServiceContext()
     ).orElseThrow(IllegalStateException::new);
@@ -97,6 +100,7 @@ public class ExplainExecutorTest {
     // When:
     final QueryDescriptionEntity query = (QueryDescriptionEntity) CustomExecutors.EXPLAIN.execute(
         explain,
+        ImmutableMap.of(),
         engine.getEngine(),
         engine.getServiceContext()
     ).orElseThrow(IllegalStateException::new);
@@ -116,6 +120,7 @@ public class ExplainExecutorTest {
     // When:
     final QueryDescriptionEntity query = (QueryDescriptionEntity) CustomExecutors.EXPLAIN.execute(
         explain,
+        ImmutableMap.of(),
         engine.getEngine(),
         engine.getServiceContext()
     ).orElseThrow(IllegalStateException::new);
@@ -134,6 +139,7 @@ public class ExplainExecutorTest {
     // When:
     CustomExecutors.EXPLAIN.execute(
         engine.configure("Explain SHOW TOPICS;"),
+        ImmutableMap.of(),
         engine.getEngine(),
         engine.getServiceContext()
     );

--- a/ksql-rest-app/src/test/java/io/confluent/ksql/rest/server/execution/ListConnectorsExecutorTest.java
+++ b/ksql-rest-app/src/test/java/io/confluent/ksql/rest/server/execution/ListConnectorsExecutorTest.java
@@ -87,7 +87,7 @@ public class ListConnectorsExecutorTest {
 
     // When:
     final Optional<KsqlEntity> entity = ListConnectorsExecutor
-        .execute(statement, engine, serviceContext);
+        .execute(statement, ImmutableMap.of(), engine, serviceContext);
 
     // Then:
     assertThat("expected response!", entity.isPresent());
@@ -116,7 +116,7 @@ public class ListConnectorsExecutorTest {
 
     // When:
     final Optional<KsqlEntity> entity = ListConnectorsExecutor
-        .execute(statement, engine, serviceContext);
+        .execute(statement, ImmutableMap.of(), engine, serviceContext);
 
     // Then:
     assertThat("expected response!", entity.isPresent());
@@ -142,7 +142,7 @@ public class ListConnectorsExecutorTest {
 
     // When:
     final Optional<KsqlEntity> entity = ListConnectorsExecutor
-        .execute(statement, engine, serviceContext);
+        .execute(statement, ImmutableMap.of(), engine, serviceContext);
 
     // Then:
     assertThat("expected response!", entity.isPresent());

--- a/ksql-rest-app/src/test/java/io/confluent/ksql/rest/server/execution/ListFunctionsExecutorTest.java
+++ b/ksql-rest-app/src/test/java/io/confluent/ksql/rest/server/execution/ListFunctionsExecutorTest.java
@@ -40,6 +40,7 @@ public class ListFunctionsExecutorTest {
     // When:
     final FunctionNameList functionList = (FunctionNameList) CustomExecutors.LIST_FUNCTIONS.execute(
         engine.configure("LIST FUNCTIONS;"),
+        ImmutableMap.of(),
         engine.getEngine(),
         engine.getServiceContext()
     ).orElseThrow(IllegalStateException::new);

--- a/ksql-rest-app/src/test/java/io/confluent/ksql/rest/server/execution/ListPropertiesExecutorTest.java
+++ b/ksql-rest-app/src/test/java/io/confluent/ksql/rest/server/execution/ListPropertiesExecutorTest.java
@@ -44,6 +44,7 @@ public class ListPropertiesExecutorTest {
     // When:
     final PropertiesList properties = (PropertiesList) CustomExecutors.LIST_PROPERTIES.execute(
         engine.configure("LIST PROPERTIES;"),
+        ImmutableMap.of(),
         engine.getEngine(),
         engine.getServiceContext()
     ).orElseThrow(IllegalStateException::new);
@@ -60,6 +61,7 @@ public class ListPropertiesExecutorTest {
     final PropertiesList properties = (PropertiesList) CustomExecutors.LIST_PROPERTIES.execute(
         engine.configure("LIST PROPERTIES;")
             .withProperties(ImmutableMap.of("ksql.streams.auto.offset.reset", "latest")),
+        ImmutableMap.of(),
         engine.getEngine(),
         engine.getServiceContext()
     ).orElseThrow(IllegalStateException::new);
@@ -75,6 +77,7 @@ public class ListPropertiesExecutorTest {
     // When:
     final PropertiesList properties = (PropertiesList) CustomExecutors.LIST_PROPERTIES.execute(
         engine.configure("LIST PROPERTIES;"),
+        ImmutableMap.of(),
         engine.getEngine(),
         engine.getServiceContext()
     ).orElseThrow(IllegalStateException::new);

--- a/ksql-rest-app/src/test/java/io/confluent/ksql/rest/server/execution/ListQueriesExecutorTest.java
+++ b/ksql-rest-app/src/test/java/io/confluent/ksql/rest/server/execution/ListQueriesExecutorTest.java
@@ -23,6 +23,7 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
 import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
 import io.confluent.ksql.engine.KsqlEngine;
 import io.confluent.ksql.name.SourceName;
@@ -49,6 +50,7 @@ public class ListQueriesExecutorTest {
     // When
     final Queries queries = (Queries) CustomExecutors.LIST_QUERIES.execute(
         engine.configure("SHOW QUERIES;"),
+        ImmutableMap.of(),
         engine.getEngine(),
         engine.getServiceContext()
     ).orElseThrow(IllegalStateException::new);
@@ -68,6 +70,7 @@ public class ListQueriesExecutorTest {
     // When
     final Queries queries = (Queries) CustomExecutors.LIST_QUERIES.execute(
         showQueries,
+        ImmutableMap.of(),
         engine,
         this.engine.getServiceContext()
     ).orElseThrow(IllegalStateException::new);
@@ -91,6 +94,7 @@ public class ListQueriesExecutorTest {
     // When
     final QueryDescriptionList queries = (QueryDescriptionList) CustomExecutors.LIST_QUERIES.execute(
         showQueries,
+        ImmutableMap.of(),
         engine,
         this.engine.getServiceContext()
     ).orElseThrow(IllegalStateException::new);

--- a/ksql-rest-app/src/test/java/io/confluent/ksql/rest/server/execution/ListSourceExecutorTest.java
+++ b/ksql-rest-app/src/test/java/io/confluent/ksql/rest/server/execution/ListSourceExecutorTest.java
@@ -81,6 +81,7 @@ public class ListSourceExecutorTest {
     final StreamsList descriptionList = (StreamsList)
         CustomExecutors.LIST_STREAMS.execute(
             engine.configure("SHOW STREAMS;"),
+            ImmutableMap.of(),
             engine.getEngine(),
             engine.getServiceContext()
         ).orElseThrow(IllegalStateException::new);
@@ -111,6 +112,7 @@ public class ListSourceExecutorTest {
     final SourceDescriptionList descriptionList = (SourceDescriptionList)
         CustomExecutors.LIST_STREAMS.execute(
             engine.configure("SHOW STREAMS EXTENDED;"),
+            ImmutableMap.of(),
             engine.getEngine(),
             engine.getServiceContext()
         ).orElseThrow(IllegalStateException::new);
@@ -145,6 +147,7 @@ public class ListSourceExecutorTest {
     final TablesList descriptionList = (TablesList)
         CustomExecutors.LIST_TABLES.execute(
             engine.configure("LIST TABLES;"),
+            ImmutableMap.of(),
             engine.getEngine(),
             engine.getServiceContext()
         ).orElseThrow(IllegalStateException::new);
@@ -177,6 +180,7 @@ public class ListSourceExecutorTest {
     final SourceDescriptionList descriptionList = (SourceDescriptionList)
         CustomExecutors.LIST_TABLES.execute(
             engine.configure("LIST TABLES EXTENDED;"),
+            ImmutableMap.of(),
             engine.getEngine(),
             engine.getServiceContext()
         ).orElseThrow(IllegalStateException::new);
@@ -224,6 +228,7 @@ public class ListSourceExecutorTest {
                 ImmutableMap.of(),
                 engine.getKsqlConfig()
             ),
+            ImmutableMap.of(),
             engine.getEngine(),
             engine.getServiceContext()
         ).orElseThrow(IllegalStateException::new);
@@ -251,6 +256,7 @@ public class ListSourceExecutorTest {
     // When:
     CustomExecutors.SHOW_COLUMNS.execute(
         engine.configure("DESCRIBE S;"),
+        ImmutableMap.of(),
         engine.getEngine(),
         engine.getServiceContext()
     );
@@ -272,6 +278,7 @@ public class ListSourceExecutorTest {
     // When:
     CustomExecutors.LIST_STREAMS.execute(
         engine.configure("SHOW STREAMS;"),
+        ImmutableMap.of(),
         engine.getEngine(),
         serviceContext
     ).orElseThrow(IllegalStateException::new);
@@ -328,6 +335,7 @@ public class ListSourceExecutorTest {
     // When:
     final KsqlEntity entity = CustomExecutors.LIST_STREAMS.execute(
         engine.configure("SHOW STREAMS EXTENDED;"),
+        ImmutableMap.of(),
         engine.getEngine(),
         serviceContext
     ).orElseThrow(IllegalStateException::new);
@@ -347,6 +355,7 @@ public class ListSourceExecutorTest {
     // When:
     final KsqlEntity entity = CustomExecutors.LIST_TABLES.execute(
         engine.configure("SHOW TABLES EXTENDED;"),
+        ImmutableMap.of(),
         engine.getEngine(),
         serviceContext
     ).orElseThrow(IllegalStateException::new);
@@ -365,6 +374,7 @@ public class ListSourceExecutorTest {
     // When:
     final KsqlEntity entity = CustomExecutors.SHOW_COLUMNS.execute(
         engine.configure("DESCRIBE EXTENDED STREAM1;"),
+        ImmutableMap.of(),
         engine.getEngine(),
         serviceContext
     ).orElseThrow(IllegalStateException::new);

--- a/ksql-rest-app/src/test/java/io/confluent/ksql/rest/server/execution/ListTopicsExecutorTest.java
+++ b/ksql-rest-app/src/test/java/io/confluent/ksql/rest/server/execution/ListTopicsExecutorTest.java
@@ -21,6 +21,7 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
 import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
 import io.confluent.ksql.rest.entity.KafkaTopicInfo;
 import io.confluent.ksql.rest.entity.KafkaTopicInfoExtended;
 import io.confluent.ksql.rest.entity.KafkaTopicsList;
@@ -63,6 +64,7 @@ public class ListTopicsExecutorTest {
     final KafkaTopicsList topicsList =
         (KafkaTopicsList) CustomExecutors.LIST_TOPICS.execute(
             engine.configure("LIST TOPICS;"),
+            ImmutableMap.of(),
             engine.getEngine(),
             serviceContext
         ).orElseThrow(IllegalStateException::new);
@@ -100,6 +102,7 @@ public class ListTopicsExecutorTest {
     final KafkaTopicsListExtended topicsList =
         (KafkaTopicsListExtended) CustomExecutors.LIST_TOPICS.execute(
             engine.configure("LIST TOPICS EXTENDED;"),
+            ImmutableMap.of(),
             engine.getEngine(),
             serviceContext
         ).orElseThrow(IllegalStateException::new);

--- a/ksql-rest-app/src/test/java/io/confluent/ksql/rest/server/execution/ListTypesExecutorTest.java
+++ b/ksql-rest-app/src/test/java/io/confluent/ksql/rest/server/execution/ListTypesExecutorTest.java
@@ -67,7 +67,9 @@ public class ListTypesExecutorTest {
         ConfiguredStatement.of(
             PreparedStatement.of("statement", new ListTypes(Optional.empty())),
             ImmutableMap.of(),
-            KSQL_CONFIG),
+            KSQL_CONFIG
+        ),
+        ImmutableMap.of(),
         context,
         null);
 

--- a/ksql-rest-app/src/test/java/io/confluent/ksql/rest/server/execution/PropertyExecutorTest.java
+++ b/ksql-rest-app/src/test/java/io/confluent/ksql/rest/server/execution/PropertyExecutorTest.java
@@ -43,8 +43,8 @@ public class PropertyExecutorTest {
 
     // When:
     CustomExecutors.SET_PROPERTY.execute(
-        engine.configure("SET '" + ConsumerConfig.AUTO_OFFSET_RESET_CONFIG + "' = 'none';")
-            .withProperties(properties),
+        engine.configure("SET '" + ConsumerConfig.AUTO_OFFSET_RESET_CONFIG + "' = 'none';"),
+        properties,
         engine.getEngine(),
         engine.getServiceContext()
     );
@@ -62,8 +62,8 @@ public class PropertyExecutorTest {
 
     // When:
     CustomExecutors.UNSET_PROPERTY.execute(
-        engine.configure("UNSET '" + ConsumerConfig.AUTO_OFFSET_RESET_CONFIG + "';")
-            .withProperties(properties),
+        engine.configure("UNSET '" + ConsumerConfig.AUTO_OFFSET_RESET_CONFIG + "';"),
+        properties,
         engine.getEngine(),
         engine.getServiceContext()
     );
@@ -71,6 +71,4 @@ public class PropertyExecutorTest {
     // Then:
     assertThat(properties, not(hasKey(ConsumerConfig.AUTO_OFFSET_RESET_CONFIG)));
   }
-
-
 }

--- a/ksql-rest-app/src/test/java/io/confluent/ksql/rest/server/resources/KsqlResourceTest.java
+++ b/ksql-rest-app/src/test/java/io/confluent/ksql/rest/server/resources/KsqlResourceTest.java
@@ -1303,6 +1303,25 @@ public class KsqlResourceTest {
   }
 
   @Test
+  public void shouldSetPropertyOnlyOnCommandsFollowingTheSetStatement() {
+    // Given:
+    final String csas = "CREATE STREAM " + streamName + " AS SELECT * FROM test_stream;";
+
+    // When:
+    makeMultipleRequest(
+        csas +
+            "SET '" + ConsumerConfig.AUTO_OFFSET_RESET_CONFIG + "' = 'earliest';",
+        CommandStatusEntity.class);
+
+    // Then:
+    verify(commandStore).enqueueCommand(
+        argThat(is(configured(
+            preparedStatementText(csas),
+            ImmutableMap.of(),
+            ksqlConfig))));
+  }
+
+  @Test
   public void shouldFailSetPropertyOnInvalidPropertyName() {
     // When:
     final KsqlErrorMessage response = makeFailingRequest(

--- a/ksql-rest-app/src/test/java/io/confluent/ksql/rest/server/validation/PrintTopicValidatorTest.java
+++ b/ksql-rest-app/src/test/java/io/confluent/ksql/rest/server/validation/PrintTopicValidatorTest.java
@@ -74,6 +74,7 @@ public class PrintTopicValidatorTest {
     // When:
     CustomValidators.PRINT_TOPIC.validate(
         query,
+        ImmutableMap.of(),
         ksqlEngine,
         serviceContext
     );

--- a/ksql-rest-app/src/test/java/io/confluent/ksql/rest/server/validation/PropertyOverriderTest.java
+++ b/ksql-rest-app/src/test/java/io/confluent/ksql/rest/server/validation/PropertyOverriderTest.java
@@ -20,6 +20,7 @@ import static org.hamcrest.Matchers.hasEntry;
 import static org.hamcrest.Matchers.hasKey;
 import static org.hamcrest.Matchers.not;
 
+import com.google.common.collect.ImmutableMap;
 import io.confluent.ksql.parser.KsqlParser.PreparedStatement;
 import io.confluent.ksql.parser.tree.SetProperty;
 import io.confluent.ksql.parser.tree.UnsetProperty;
@@ -55,7 +56,9 @@ public class PropertyOverriderTest {
             "SET 'consumer.invalid'='value';",
             new SetProperty(Optional.empty(), "consumer.invalid", "value")),
             new HashMap<>(),
-            engine.getKsqlConfig()),
+            engine.getKsqlConfig()
+        ),
+        ImmutableMap.of(),
         engine.getEngine(),
         engine.getServiceContext()
     );
@@ -72,8 +75,10 @@ public class PropertyOverriderTest {
         PreparedStatement.of(
             "SET '" + ConsumerConfig.AUTO_OFFSET_RESET_CONFIG + "' = 'earliest';",
             new SetProperty(Optional.empty(), ConsumerConfig.AUTO_OFFSET_RESET_CONFIG, "earliest")),
-            properties,
-            engine.getKsqlConfig()),
+            ImmutableMap.of(),
+            engine.getKsqlConfig()
+        ),
+        properties,
         engine.getEngine(),
         engine.getServiceContext()
     );
@@ -95,8 +100,10 @@ public class PropertyOverriderTest {
         PreparedStatement.of(
              "SET '" + ConsumerConfig.AUTO_OFFSET_RESET_CONFIG + "' = 'invalid';",
             new SetProperty(Optional.empty(), ConsumerConfig.AUTO_OFFSET_RESET_CONFIG, "invalid")),
-            new HashMap<>(),
-            engine.getKsqlConfig()),
+            ImmutableMap.of(),
+            engine.getKsqlConfig()
+        ),
+        new HashMap<>(),
         engine.getEngine(),
         engine.getServiceContext()
     );
@@ -115,7 +122,9 @@ public class PropertyOverriderTest {
             "UNSET 'consumer.invalid';",
             new UnsetProperty(Optional.empty(), "consumer.invalid")),
             new HashMap<>(),
-            engine.getKsqlConfig()),
+            engine.getKsqlConfig()
+        ),
+        ImmutableMap.of(),
         engine.getEngine(),
         engine.getServiceContext()
     );
@@ -133,8 +142,10 @@ public class PropertyOverriderTest {
         PreparedStatement.of(
             "UNSET '" + ConsumerConfig.AUTO_OFFSET_RESET_CONFIG + "';",
             new UnsetProperty(Optional.empty(), ConsumerConfig.AUTO_OFFSET_RESET_CONFIG)),
-            properties,
-            engine.getKsqlConfig()),
+            ImmutableMap.of(),
+            engine.getKsqlConfig()
+        ),
+        properties,
         engine.getEngine(),
         engine.getServiceContext()
     );

--- a/ksql-rest-app/src/test/java/io/confluent/ksql/rest/server/validation/QueryValidatorTest.java
+++ b/ksql-rest-app/src/test/java/io/confluent/ksql/rest/server/validation/QueryValidatorTest.java
@@ -63,6 +63,7 @@ public class QueryValidatorTest {
     // When:
     CustomValidators.QUERY_ENDPOINT.validate(
         query,
+        ImmutableMap.of(),
         engine.getEngine(),
         engine.getServiceContext()
     );

--- a/ksql-rest-app/src/test/java/io/confluent/ksql/rest/server/validation/RequestValidatorTest.java
+++ b/ksql-rest-app/src/test/java/io/confluent/ksql/rest/server/validation/RequestValidatorTest.java
@@ -128,6 +128,7 @@ public class RequestValidatorTest {
     // Then:
     verify(statementValidator, times(1)).validate(
         argThat(is(configured(preparedStatement(instanceOf(CreateStream.class))))),
+        eq(ImmutableMap.of()),
         eq(executionContext),
         any()
     );
@@ -156,7 +157,7 @@ public class RequestValidatorTest {
         ImmutableMap.of(CreateStream.class, statementValidator)
     );
     doThrow(new KsqlException("Fail"))
-        .when(statementValidator).validate(any(), any(), any());
+        .when(statementValidator).validate(any(), any(), any(), any());
 
     final List<ParsedStatement> statements =
         givenParsed(SOME_STREAM_SQL);
@@ -242,6 +243,7 @@ public class RequestValidatorTest {
     // Then:
     verify(statementValidator, times(1)).validate(
         argThat(is(configured(preparedStatement(instanceOf(CreateStream.class))))),
+        any(),
         eq(executionContext),
         any()
     );

--- a/ksql-rest-app/src/test/java/io/confluent/ksql/rest/server/validation/TerminateQueryValidatorTest.java
+++ b/ksql-rest-app/src/test/java/io/confluent/ksql/rest/server/validation/TerminateQueryValidatorTest.java
@@ -53,6 +53,7 @@ public class TerminateQueryValidatorTest {
             ImmutableMap.of(),
             engine.getKsqlConfig()
         ),
+        ImmutableMap.of(),
         engine.getEngine(),
         engine.getServiceContext()
     );
@@ -72,6 +73,7 @@ public class TerminateQueryValidatorTest {
             ImmutableMap.of(),
             engine.getKsqlConfig()
         ),
+        ImmutableMap.of(),
         mockEngine,
         engine.getServiceContext()
     );


### PR DESCRIPTION
### Description 

Fixes #3525

This commit fixes a regression that sees an old issue reappearing where by a SET statement affects not just statements that follow it, but also statements before it. The primary cause of this is the fact that `ConfiguredStatement` contains a reference to a mutable map containing the property overrides. This map is mutated by subsequent SET statements.  The fix is to make for `ConfiguredStatement` to take a immutable defensive copy, as is good programming practice.  This involves adding explicit handling of SET and UNSET statements, which can no long mutate the overrides in `ConfiguredStatement`.

### Testing done 

usual

### Reviewer checklist
- [ ] Ensure docs are updated if necessary. (eg. if a user visible feature is being added or changed).
- [ ] Ensure relevant issues are linked (description should include text like "Fixes #<issue number>")

