### PR TITLE
refactor: replace ExecutionContext execute(stmt) for execute(ctx, stmt) (PART 1)

### DIFF
--- a/ksql-engine/src/test/java/io/confluent/ksql/embedded/KsqlContextTest.java
+++ b/ksql-engine/src/test/java/io/confluent/ksql/embedded/KsqlContextTest.java
@@ -165,9 +165,9 @@ public class KsqlContextTest {
     // Then:
     final InOrder inOrder = inOrder(ksqlEngine);
     inOrder.verify(ksqlEngine).prepare(PARSED_STMT_0);
-    inOrder.verify(ksqlEngine).execute(eq(serviceContext), eq(STMT_0_WITH_SCHEMA));
+    inOrder.verify(ksqlEngine).execute(serviceContext, STMT_0_WITH_SCHEMA);
     inOrder.verify(ksqlEngine).prepare(PARSED_STMT_1);
-    inOrder.verify(ksqlEngine).execute(eq(serviceContext), eq(STMT_1_WITH_SCHEMA));
+    inOrder.verify(ksqlEngine).execute(serviceContext, STMT_1_WITH_SCHEMA);
   }
 
   @Test
@@ -181,10 +181,10 @@ public class KsqlContextTest {
 
     // Then:
     final InOrder inOrder = inOrder(ksqlEngine, sandbox);
-    inOrder.verify(sandbox).execute(eq(sandbox.getServiceContext()), eq(STMT_0_WITH_SCHEMA));
-    inOrder.verify(sandbox).execute(eq(sandbox.getServiceContext()), eq(STMT_1_WITH_SCHEMA));
-    inOrder.verify(ksqlEngine).execute(eq(ksqlEngine.getServiceContext()), eq(STMT_0_WITH_SCHEMA));
-    inOrder.verify(ksqlEngine).execute(eq(ksqlEngine.getServiceContext()), eq(STMT_1_WITH_SCHEMA));
+    inOrder.verify(sandbox).execute(sandbox.getServiceContext(), STMT_0_WITH_SCHEMA);
+    inOrder.verify(sandbox).execute(sandbox.getServiceContext(), STMT_1_WITH_SCHEMA);
+    inOrder.verify(ksqlEngine).execute(ksqlEngine.getServiceContext(), STMT_0_WITH_SCHEMA);
+    inOrder.verify(ksqlEngine).execute(ksqlEngine.getServiceContext(), STMT_1_WITH_SCHEMA);
   }
 
   @Test
@@ -362,7 +362,7 @@ public class KsqlContextTest {
     ksqlContext.sql("Some SQL", SOME_PROPERTIES);
 
     // Then:
-    verify(ksqlEngine).execute(eq(serviceContext), eq(STMT_1_WITH_TOPIC));
+    verify(ksqlEngine).execute(serviceContext, STMT_1_WITH_TOPIC);
   }
 
   @SuppressWarnings("unchecked")
@@ -384,8 +384,8 @@ public class KsqlContextTest {
     ksqlContext.sql("SQL;", ImmutableMap.of());
 
     // Then:
-    verify(ksqlEngine, times(3)).execute(
-        ksqlEngine.getServiceContext(),
+    verify(ksqlEngine).execute(
+        serviceContext,
         ConfiguredStatement.of(
             PREPARED_STMT_0, ImmutableMap.of(
                 ConsumerConfig.AUTO_OFFSET_RESET_CONFIG, "earliest"
@@ -413,8 +413,8 @@ public class KsqlContextTest {
     ksqlContext.sql("SQL;", ImmutableMap.of());
 
     // Then:
-    verify(ksqlEngine, times(3)).execute(
-        ksqlEngine.getServiceContext(),
+    verify(ksqlEngine).execute(
+        serviceContext,
         ConfiguredStatement.of(
             PREPARED_STMT_0, ImmutableMap.of(), SOME_CONFIG
         ));
@@ -441,8 +441,8 @@ public class KsqlContextTest {
     ksqlContext.sql("SQL;", properties);
 
     // Then:
-    verify(ksqlEngine, times(3)).execute(
-        ksqlEngine.getServiceContext(),
+    verify(ksqlEngine).execute(
+        serviceContext,
         ConfiguredStatement.of(
             PREPARED_STMT_0, ImmutableMap.of(), SOME_CONFIG
         ));

--- a/ksql-functional-tests/src/main/java/io/confluent/ksql/test/tools/TestExecutorUtil.java
+++ b/ksql-functional-tests/src/main/java/io/confluent/ksql/test/tools/TestExecutorUtil.java
@@ -311,7 +311,7 @@ public final class TestExecutorUtil {
 
     final ExecuteResult executeResult;
     try {
-      executeResult = executionContext.execute(reformatted);
+      executeResult = executionContext.execute(executionContext.getServiceContext(), reformatted);
     } catch (final KsqlStatementException statementException) {
       // use the original statement text in the exception so that tests
       // can easily check that the failed statement is the input statement

--- a/ksql-rest-app/src/main/java/io/confluent/ksql/rest/server/KsqlRestApplication.java
+++ b/ksql-rest-app/src/main/java/io/confluent/ksql/rest/server/KsqlRestApplication.java
@@ -575,7 +575,10 @@ public final class KsqlRestApplication extends Application<KsqlRestConfig> imple
 
     final ParsedStatement parsed = ksqlEngine.parse(createCmd).get(0);
     final PreparedStatement<?> prepared = ksqlEngine.prepare(parsed);
-    ksqlEngine.execute(ConfiguredStatement.of(prepared, ImmutableMap.of(), ksqlConfigNoPort));
+    ksqlEngine.execute(
+        serviceContext,
+        ConfiguredStatement.of(prepared, ImmutableMap.of(), ksqlConfigNoPort)
+    );
   }
 
   private static KsqlSecurityExtension loadSecurityExtension(final KsqlConfig ksqlConfig) {
@@ -632,7 +635,10 @@ public final class KsqlRestApplication extends Application<KsqlRestConfig> imple
         statement, Collections.emptyMap(), ksqlConfig);
 
     try {
-      ksqlEngine.createSandbox(ksqlEngine.getServiceContext()).execute(configured.get());
+      ksqlEngine.createSandbox(ksqlEngine.getServiceContext()).execute(
+          ksqlEngine.getServiceContext(),
+          configured.get()
+      );
     } catch (final KsqlException e) {
       log.warn("Failed to create processing log stream", e);
       return;

--- a/ksql-rest-app/src/test/java/io/confluent/ksql/rest/server/KsqlRestApplicationTest.java
+++ b/ksql-rest-app/src/test/java/io/confluent/ksql/rest/server/KsqlRestApplicationTest.java
@@ -233,7 +233,10 @@ public class KsqlRestApplicationTest {
 
     // Then:
     verify(commandQueue).isEmpty();
-    verify(sandBox).execute(argThat(configured(equalTo(logCreateStatement))));
+    verify(sandBox).execute(
+        argThat(equalTo(ksqlEngine.getServiceContext())),
+        argThat(configured(equalTo(logCreateStatement)))
+    );
     verify(commandQueue).enqueueCommand(
         argThat(configured(equalTo(logCreateStatement), Collections.emptyMap(), ksqlConfig)));
   }
@@ -266,7 +269,7 @@ public class KsqlRestApplicationTest {
   @Test
   public void shouldNotCreateLogStreamIfValidationFails() {
     // Given:
-    when(sandBox.execute(any())).thenThrow(new KsqlException("error"));
+    when(sandBox.execute(any(), any())).thenThrow(new KsqlException("error"));
 
     // When:
     app.startKsql();

--- a/ksql-rest-app/src/test/java/io/confluent/ksql/rest/server/execution/ListSourceExecutorTest.java
+++ b/ksql-rest-app/src/test/java/io/confluent/ksql/rest/server/execution/ListSourceExecutorTest.java
@@ -212,6 +212,7 @@ public class ListSourceExecutorTest {
     // Given:
     engine.givenSource(DataSourceType.KSTREAM, "SOURCE");
     final ExecuteResult result = engine.getEngine().execute(
+        engine.getServiceContext(),
         engine.configure("CREATE STREAM SINK AS SELECT * FROM source;")
     );
     final PersistentQueryMetadata metadata = (PersistentQueryMetadata) result.getQuery()

--- a/ksql-rest-app/src/test/java/io/confluent/ksql/rest/util/ProcessingLogServerUtilsTest.java
+++ b/ksql-rest-app/src/test/java/io/confluent/ksql/rest/util/ProcessingLogServerUtilsTest.java
@@ -185,7 +185,10 @@ public class ProcessingLogServerUtilsTest {
             config,
             ksqlConfig);
 
-    ksqlEngine.execute(ConfiguredStatement.of(statement, ImmutableMap.of(), ksqlConfig));
+    ksqlEngine.execute(
+        serviceContext,
+        ConfiguredStatement.of(statement, ImmutableMap.of(), ksqlConfig)
+    );
 
     // Then:
     assertThat(statement.getStatementText(), equalTo(
@@ -220,7 +223,10 @@ public class ProcessingLogServerUtilsTest {
             ),
             ksqlConfig);
 
-    ksqlEngine.execute(ConfiguredStatement.of(statement, ImmutableMap.of(), ksqlConfig));
+    ksqlEngine.execute(
+        serviceContext,
+        ConfiguredStatement.of(statement, ImmutableMap.of(), ksqlConfig)
+    );
 
     // Then:
     assertThat(statement.getStatementText(),


### PR DESCRIPTION
### Description 
This is part1 to replace the `ExecutionContext.execute(statement)` for `ExecutionContext.execute(serviceContext, statement)`. 

For this part, I made changes only in the following classes:
- TestExecutorUtil
- ListSourceExecutorTest
- ProcessingLogServerUtilsTest
- KsqlRestApplication
- KsqlContext

How to review?
- Each commit made changes only on one of the above classes for easy review.

### Testing done 
Updated unit tests

### Reviewer checklist
- [ ] Ensure docs are updated if necessary. (eg. if a user visible feature is being added or changed).
- [ ] Ensure relevant issues are linked (description should include text like "Fixes #<issue number>")

