### PR TITLE
fix: support NULL return values from CASE statements

### DIFF
--- a/ksql-common/src/main/java/io/confluent/ksql/schema/Operator.java
+++ b/ksql-common/src/main/java/io/confluent/ksql/schema/Operator.java
@@ -61,7 +61,7 @@ public enum Operator {
    */
   public SqlType resultType(final SqlType left, final SqlType right) {
     if (left.baseType().isNumber() && right.baseType().isNumber()) {
-      if (left.baseType().canUpCast(right.baseType())) {
+      if (left.baseType().canImplicitlyCast(right.baseType())) {
         if (right.baseType() != SqlBaseType.DECIMAL) {
           return right;
         }
@@ -69,7 +69,7 @@ public enum Operator {
         return binaryResolver.apply(toDecimal(left), (SqlDecimal) right);
       }
 
-      if (right.baseType().canUpCast(left.baseType())) {
+      if (right.baseType().canImplicitlyCast(left.baseType())) {
         if (left.baseType() != SqlBaseType.DECIMAL) {
           return left;
         }

--- a/ksql-common/src/main/java/io/confluent/ksql/schema/ksql/SqlBaseType.java
+++ b/ksql-common/src/main/java/io/confluent/ksql/schema/ksql/SqlBaseType.java
@@ -29,17 +29,15 @@ public enum SqlBaseType {
   }
 
   /**
-   * Test to see if this type can be up-cast to another.
+   * Test to see if this type can be <i>implicitly</i>u cast to another.
    *
-   * <p>This defines if KSQL supports <i>implicitly</i> converting one numeric type to another.
-   *
-   * <p>Types can always be upcast to themselves. Only numeric types can be upcast to different
-   * numeric types. Note: STRING to DECIMAL handling is not seen as up-casting, it's parsing.
+   * <p>Types can always be cast to themselves. Only numeric types can be implicitly cast to other
+   * numeric types. Note: STRING to DECIMAL handling is not seen as casting: it's parsing.
    *
    * @param to the target type.
-   * @return true if this type can be upcast to the supplied type.
+   * @return true if this type can be implicitly cast to the supplied type.
    */
-  public boolean canUpCast(final SqlBaseType to) {
+  public boolean canImplicitlyCast(final SqlBaseType to) {
     return this.equals(to)
         || (isNumber() && to.isNumber() && this.ordinal() <= to.ordinal());
   }

--- a/ksql-common/src/test/java/io/confluent/ksql/schema/ksql/SqlBaseTypeTest.java
+++ b/ksql-common/src/test/java/io/confluent/ksql/schema/ksql/SqlBaseTypeTest.java
@@ -56,7 +56,7 @@ public class SqlBaseTypeTest {
   public void shouldNotUpCastIfNotNumber() {
     nonNumberTypes().forEach(sqlType -> assertThat(
         sqlType + " should not upcast",
-        sqlType.canUpCast(SqlBaseType.DOUBLE),
+        sqlType.canImplicitlyCast(SqlBaseType.DOUBLE),
         is(false))
     );
   }
@@ -65,7 +65,7 @@ public class SqlBaseTypeTest {
   public void shouldUpCastIfNumber() {
     numberTypes().forEach(sqlType -> assertThat(
         sqlType + " should upcast",
-        sqlType.canUpCast(SqlBaseType.DOUBLE),
+        sqlType.canImplicitlyCast(SqlBaseType.DOUBLE),
         is(true))
     );
   }
@@ -73,43 +73,43 @@ public class SqlBaseTypeTest {
   @Test
   public void shouldUpCastToSelf() {
     allTypes().forEach(sqlType ->
-        assertThat(sqlType + " should upcast to self", sqlType.canUpCast(sqlType), is(true)));
+        assertThat(sqlType + " should upcast to self", sqlType.canImplicitlyCast(sqlType), is(true)));
   }
 
   @Test
   public void shouldUpCastInt() {
-    assertThat(SqlBaseType.INTEGER.canUpCast(SqlBaseType.BIGINT), is(true));
-    assertThat(SqlBaseType.INTEGER.canUpCast(SqlBaseType.DECIMAL), is(true));
-    assertThat(SqlBaseType.INTEGER.canUpCast(SqlBaseType.DOUBLE), is(true));
+    assertThat(SqlBaseType.INTEGER.canImplicitlyCast(SqlBaseType.BIGINT), is(true));
+    assertThat(SqlBaseType.INTEGER.canImplicitlyCast(SqlBaseType.DECIMAL), is(true));
+    assertThat(SqlBaseType.INTEGER.canImplicitlyCast(SqlBaseType.DOUBLE), is(true));
   }
 
   @Test
   public void shouldUpCastBigInt() {
-    assertThat(SqlBaseType.BIGINT.canUpCast(SqlBaseType.DECIMAL), is(true));
-    assertThat(SqlBaseType.BIGINT.canUpCast(SqlBaseType.DOUBLE), is(true));
+    assertThat(SqlBaseType.BIGINT.canImplicitlyCast(SqlBaseType.DECIMAL), is(true));
+    assertThat(SqlBaseType.BIGINT.canImplicitlyCast(SqlBaseType.DOUBLE), is(true));
   }
 
   @Test
   public void shouldUpCastDecimal() {
-    assertThat(SqlBaseType.DECIMAL.canUpCast(SqlBaseType.DOUBLE), is(true));
+    assertThat(SqlBaseType.DECIMAL.canImplicitlyCast(SqlBaseType.DOUBLE), is(true));
   }
 
   @Test
   public void shouldNotDownCastBigInt() {
-    assertThat(SqlBaseType.BIGINT.canUpCast(SqlBaseType.INTEGER), is(false));
+    assertThat(SqlBaseType.BIGINT.canImplicitlyCast(SqlBaseType.INTEGER), is(false));
   }
 
   @Test
   public void shouldNotDownCastDecimal() {
-    assertThat(SqlBaseType.DECIMAL.canUpCast(SqlBaseType.INTEGER), is(false));
-    assertThat(SqlBaseType.DECIMAL.canUpCast(SqlBaseType.BIGINT), is(false));
+    assertThat(SqlBaseType.DECIMAL.canImplicitlyCast(SqlBaseType.INTEGER), is(false));
+    assertThat(SqlBaseType.DECIMAL.canImplicitlyCast(SqlBaseType.BIGINT), is(false));
   }
 
   @Test
   public void shouldNotDownCastDouble() {
-    assertThat(SqlBaseType.DOUBLE.canUpCast(SqlBaseType.INTEGER), is(false));
-    assertThat(SqlBaseType.DOUBLE.canUpCast(SqlBaseType.BIGINT), is(false));
-    assertThat(SqlBaseType.DOUBLE.canUpCast(SqlBaseType.DECIMAL), is(false));
+    assertThat(SqlBaseType.DOUBLE.canImplicitlyCast(SqlBaseType.INTEGER), is(false));
+    assertThat(SqlBaseType.DOUBLE.canImplicitlyCast(SqlBaseType.BIGINT), is(false));
+    assertThat(SqlBaseType.DOUBLE.canImplicitlyCast(SqlBaseType.DECIMAL), is(false));
   }
 
   private static Stream<SqlBaseType> numberTypes() {

--- a/ksql-execution/src/main/java/io/confluent/ksql/execution/util/ExpressionTypeManager.java
+++ b/ksql-execution/src/main/java/io/confluent/ksql/execution/util/ExpressionTypeManager.java
@@ -314,11 +314,11 @@ public class ExpressionTypeManager {
       if (whenType.isPresent() && defaultType.isPresent()) {
         if (!whenType.get().equals(defaultType.get())) {
           throw new KsqlException("Invalid Case expression. "
-              + "Schema for the default clause should be the same as for 'THEN' clauses."
+              + "Type for the default clause should be the same as for 'THEN' clauses."
               + System.lineSeparator()
-              + "THEN schema: " + whenType.get() + "."
+              + "THEN type: " + whenType.get() + "."
               + System.lineSeparator()
-              + "DEFAULT schema: " + defaultType.get() + "."
+              + "DEFAULT type: " + defaultType.get() + "."
           );
         }
 
@@ -328,7 +328,7 @@ public class ExpressionTypeManager {
       } else if (defaultType.isPresent()) {
         context.setSqlType(defaultType.get());
       } else {
-        throw new KsqlException("Invalid Case expression. All case branches have NULL schema");
+        throw new KsqlException("Invalid Case expression. All case branches have NULL type");
       }
       return null;
     }
@@ -484,9 +484,9 @@ public class ExpressionTypeManager {
         final SqlType operandType = context.getSqlType();
 
         if (operandType.baseType() != SqlBaseType.BOOLEAN) {
-          throw new KsqlException("WHEN operand schema should be boolean."
+          throw new KsqlException("WHEN operand type should be boolean."
               + System.lineSeparator()
-              + "Schema for '" + whenClause.getOperand() + "' is " + operandType
+              + "Type for '" + whenClause.getOperand() + "' is " + operandType
           );
         }
 
@@ -504,11 +504,11 @@ public class ExpressionTypeManager {
 
         if (!previousResult.get().equals(resultType)) {
           throw new KsqlException("Invalid Case expression. "
-              + "Schemas for all 'THEN' clauses should be the same."
+              + "Type for all 'THEN' clauses should be the same."
               + System.lineSeparator()
-              + "THEN expression '" + whenClause + "' has schema: " + resultType + "."
+              + "THEN expression '" + whenClause + "' has type: " + resultType + "."
               + System.lineSeparator()
-              + "Previous THEN expression(s) schema: " + previousResult.get() + ".");
+              + "Previous THEN expression(s) type: " + previousResult.get() + ".");
         }
       }
 

--- a/ksql-execution/src/main/java/io/confluent/ksql/execution/util/ExpressionTypeManager.java
+++ b/ksql-execution/src/main/java/io/confluent/ksql/execution/util/ExpressionTypeManager.java
@@ -55,6 +55,7 @@ import io.confluent.ksql.function.UdfFactory;
 import io.confluent.ksql.schema.ksql.Column;
 import io.confluent.ksql.schema.ksql.LogicalSchema;
 import io.confluent.ksql.schema.ksql.SchemaConverters;
+import io.confluent.ksql.schema.ksql.SqlBaseType;
 import io.confluent.ksql.schema.ksql.types.SqlArray;
 import io.confluent.ksql.schema.ksql.types.SqlMap;
 import io.confluent.ksql.schema.ksql.types.SqlType;
@@ -64,6 +65,7 @@ import io.confluent.ksql.util.VisitorUtil;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Objects;
+import java.util.Optional;
 import java.util.stream.Collectors;
 import org.apache.kafka.connect.data.Schema;
 
@@ -302,10 +304,32 @@ public class ExpressionTypeManager {
     @Override
     public Void visitSearchedCaseExpression(
         final SearchedCaseExpression node,
-        final ExpressionTypeContext expressionTypeContext
+        final ExpressionTypeContext context
     ) {
-      validateSearchedCaseExpression(node);
-      process(node.getWhenClauses().get(0).getResult(), expressionTypeContext);
+      final Optional<SqlType> whenType = validateWhenClauses(node.getWhenClauses(), context);
+
+      final Optional<SqlType> defaultType = node.getDefaultValue()
+          .map(ExpressionTypeManager.this::getExpressionSqlType);
+
+      if (whenType.isPresent() && defaultType.isPresent()) {
+        if (!whenType.get().equals(defaultType.get())) {
+          throw new KsqlException("Invalid Case expression. "
+              + "Schema for the default clause should be the same as for 'THEN' clauses."
+              + System.lineSeparator()
+              + "THEN schema: " + whenType.get() + "."
+              + System.lineSeparator()
+              + "DEFAULT schema: " + defaultType.get() + "."
+          );
+        }
+
+        context.setSqlType(whenType.get());
+      } else if (whenType.isPresent()) {
+        context.setSqlType(whenType.get());
+      } else if (defaultType.isPresent()) {
+        context.setSqlType(defaultType.get());
+      } else {
+        throw new KsqlException("Invalid Case expression. All case branches have NULL schema");
+      }
       return null;
     }
 
@@ -449,38 +473,46 @@ public class ExpressionTypeManager {
       throw VisitorUtil.illegalState(this, whenClause);
     }
 
-    private void validateSearchedCaseExpression(
-        final SearchedCaseExpression searchedCaseExpression) {
-      final Schema firstResultSchema = getExpressionSchema(
-          searchedCaseExpression.getWhenClauses().get(0).getResult());
-      searchedCaseExpression.getWhenClauses()
-          .forEach(whenClause -> validateWhenClause(whenClause, firstResultSchema));
-      searchedCaseExpression.getDefaultValue()
-          .map(ExpressionTypeManager.this::getExpressionSchema)
-          .filter(defaultSchema -> !firstResultSchema.equals(defaultSchema))
-          .ifPresent(badSchema -> {
-            throw new KsqlException("Invalid Case expression."
-                + " Schema for the default clause should be the same as schema for THEN clauses."
-                + " Result scheme: " + firstResultSchema + "."
-                + " Schema for default expression is " + badSchema);
-          });
-    }
+    private Optional<SqlType> validateWhenClauses(
+        final List<WhenClause> whenClauses,
+        final ExpressionTypeContext context
+    ) {
+      Optional<SqlType> previousResult = Optional.empty();
+      for (final WhenClause whenClause : whenClauses) {
+        process(whenClause.getOperand(), context);
 
-    private void validateWhenClause(final WhenClause whenClause,
-        final Schema expectedResultSchema) {
-      final Schema operandSchema = getExpressionSchema(whenClause.getOperand());
-      if (!operandSchema.equals(Schema.OPTIONAL_BOOLEAN_SCHEMA)) {
-        throw new KsqlException("When operand schema should be boolean. Schema for ("
-            + whenClause.getOperand() + ") is " + operandSchema);
+        final SqlType operandType = context.getSqlType();
+
+        if (operandType.baseType() != SqlBaseType.BOOLEAN) {
+          throw new KsqlException("When operand schema should be boolean."
+              + System.lineSeparator()
+              + "Schema for '" + whenClause.getOperand() + "' is " + operandType
+          );
+        }
+
+        process(whenClause.getResult(), context);
+
+        final SqlType resultType = context.getSqlType();
+        if (resultType == null) {
+          continue; // `null` type
+        }
+
+        if (!previousResult.isPresent()) {
+          previousResult = Optional.of(resultType);
+          continue;
+        }
+
+        if (!previousResult.get().equals(resultType)) {
+          throw new KsqlException("Invalid Case expression. "
+              + "Schemas for all 'THEN' clauses should be the same."
+              + System.lineSeparator()
+              + "THEN expression '" + whenClause + "' has schema: " + resultType + "."
+              + System.lineSeparator()
+              + "Previous THEN expression(s) schema: " + previousResult.get() + ".");
+        }
       }
-      final Schema resultSchema = getExpressionSchema(whenClause.getResult());
-      if (!expectedResultSchema.equals(resultSchema)) {
-        throw new KsqlException("Invalid Case expression."
-            + " Schemas for 'THEN' clauses should be the same."
-            + " Result schema: " + expectedResultSchema + "."
-            + " Schema for THEN expression '" + whenClause + "'"
-            + " is " + resultSchema);
-      }
+
+      return previousResult;
     }
   }
 }

--- a/ksql-execution/src/main/java/io/confluent/ksql/execution/util/ExpressionTypeManager.java
+++ b/ksql-execution/src/main/java/io/confluent/ksql/execution/util/ExpressionTypeManager.java
@@ -484,7 +484,7 @@ public class ExpressionTypeManager {
         final SqlType operandType = context.getSqlType();
 
         if (operandType.baseType() != SqlBaseType.BOOLEAN) {
-          throw new KsqlException("When operand schema should be boolean."
+          throw new KsqlException("WHEN operand schema should be boolean."
               + System.lineSeparator()
               + "Schema for '" + whenClause.getOperand() + "' is " + operandType
           );

--- a/ksql-execution/src/test/java/io/confluent/ksql/execution/util/ExpressionTypeManagerTest.java
+++ b/ksql-execution/src/test/java/io/confluent/ksql/execution/util/ExpressionTypeManagerTest.java
@@ -423,7 +423,11 @@ public class ExpressionTypeManagerTest {
         Optional.empty()
     );
     expectedException.expect(KsqlException.class);
-    expectedException.expectMessage("When operand schema should be boolean. Schema for ((TEST1.COL0 + 10)) is Schema{INT64}");
+    expectedException.expectMessage(
+        "When operand schema should be boolean."
+            + System.lineSeparator()
+            + "Schema for '(TEST1.COL0 + 10)' is BIGINT"
+    );
 
     // When:
     expressionTypeManager.getExpressionSqlType(expression);
@@ -444,7 +448,13 @@ public class ExpressionTypeManagerTest {
         Optional.empty()
     );
     expectedException.expect(KsqlException.class);
-    expectedException.expectMessage("Invalid Case expression. Schemas for 'THEN' clauses should be the same. Result schema: Schema{STRING}. Schema for THEN expression 'WHEN (TEST1.COL0 = 10) THEN 10' is Schema{INT32}");
+    expectedException.expectMessage(
+        "Invalid Case expression. Schemas for all 'THEN' clauses should be the same."
+            + System.lineSeparator()
+            + "THEN expression 'WHEN (TEST1.COL0 = 10) THEN 10' has schema: INTEGER."
+            + System.lineSeparator()
+            + "Previous THEN expression(s) schema: STRING."
+    );
 
     // When:
     expressionTypeManager.getExpressionSqlType(expression);
@@ -463,7 +473,13 @@ public class ExpressionTypeManagerTest {
         Optional.of(new BooleanLiteral("true"))
     );
     expectedException.expect(KsqlException.class);
-    expectedException.expectMessage("Invalid Case expression. Schema for the default clause should be the same as schema for THEN clauses. Result scheme: Schema{STRING}. Schema for default expression is Schema{BOOLEAN}");
+    expectedException.expectMessage(
+        "Invalid Case expression. Schema for the default clause should be the same as for 'THEN' clauses."
+            + System.lineSeparator()
+            + "THEN schema: STRING."
+            + System.lineSeparator()
+            + "DEFAULT schema: BOOLEAN."
+    );
 
     // When:
     expressionTypeManager.getExpressionSqlType(expression);

--- a/ksql-execution/src/test/java/io/confluent/ksql/execution/util/ExpressionTypeManagerTest.java
+++ b/ksql-execution/src/test/java/io/confluent/ksql/execution/util/ExpressionTypeManagerTest.java
@@ -424,7 +424,7 @@ public class ExpressionTypeManagerTest {
     );
     expectedException.expect(KsqlException.class);
     expectedException.expectMessage(
-        "When operand schema should be boolean."
+        "WHEN operand schema should be boolean."
             + System.lineSeparator()
             + "Schema for '(TEST1.COL0 + 10)' is BIGINT"
     );

--- a/ksql-execution/src/test/java/io/confluent/ksql/execution/util/ExpressionTypeManagerTest.java
+++ b/ksql-execution/src/test/java/io/confluent/ksql/execution/util/ExpressionTypeManagerTest.java
@@ -424,9 +424,9 @@ public class ExpressionTypeManagerTest {
     );
     expectedException.expect(KsqlException.class);
     expectedException.expectMessage(
-        "WHEN operand schema should be boolean."
+        "WHEN operand type should be boolean."
             + System.lineSeparator()
-            + "Schema for '(TEST1.COL0 + 10)' is BIGINT"
+            + "Type for '(TEST1.COL0 + 10)' is BIGINT"
     );
 
     // When:
@@ -449,11 +449,11 @@ public class ExpressionTypeManagerTest {
     );
     expectedException.expect(KsqlException.class);
     expectedException.expectMessage(
-        "Invalid Case expression. Schemas for all 'THEN' clauses should be the same."
+        "Invalid Case expression. Type for all 'THEN' clauses should be the same."
             + System.lineSeparator()
-            + "THEN expression 'WHEN (TEST1.COL0 = 10) THEN 10' has schema: INTEGER."
+            + "THEN expression 'WHEN (TEST1.COL0 = 10) THEN 10' has type: INTEGER."
             + System.lineSeparator()
-            + "Previous THEN expression(s) schema: STRING."
+            + "Previous THEN expression(s) type: STRING."
     );
 
     // When:
@@ -474,11 +474,11 @@ public class ExpressionTypeManagerTest {
     );
     expectedException.expect(KsqlException.class);
     expectedException.expectMessage(
-        "Invalid Case expression. Schema for the default clause should be the same as for 'THEN' clauses."
+        "Invalid Case expression. Type for the default clause should be the same as for 'THEN' clauses."
             + System.lineSeparator()
-            + "THEN schema: STRING."
+            + "THEN type: STRING."
             + System.lineSeparator()
-            + "DEFAULT schema: BOOLEAN."
+            + "DEFAULT type: BOOLEAN."
     );
 
     // When:

--- a/ksql-functional-tests/src/test/resources/query-validation-tests/case-expression.json
+++ b/ksql-functional-tests/src/test/resources/query-validation-tests/case-expression.json
@@ -115,7 +115,7 @@
       ],
       "expectedException": {
         "type": "io.confluent.ksql.util.KsqlStatementException",
-        "message": "Invalid Case expression. All case branches have NULL schema"
+        "message": "Invalid Case expression. All case branches have NULL type"
       }
     },
     {

--- a/ksql-functional-tests/src/test/resources/query-validation-tests/case-expression.json
+++ b/ksql-functional-tests/src/test/resources/query-validation-tests/case-expression.json
@@ -28,7 +28,7 @@
     {
       "name": "searched case with arithmetic expression in result",
       "statements": [
-        "CREATE STREAM orders (orderid bigint, ORDERUNITS double) WITH (kafka_topic='test_topic', key='orderid', value_format='JSON');",
+        "CREATE STREAM orders (orderid bigint, ORDERUNITS double) WITH (kafka_topic='test_topic', value_format='JSON');",
         "CREATE STREAM S1 AS SELECT CASE WHEN orderunits < 2.0 THEN orderid + 2 END AS case_resault FROM orders;"
       ],
       "inputs": [
@@ -43,7 +43,7 @@
     {
       "name": "searched case with null in when",
       "statements": [
-        "CREATE STREAM orders (orderid bigint, ORDERUNITS double) WITH (kafka_topic='test_topic', key='orderid', value_format='JSON');",
+        "CREATE STREAM orders (orderid bigint, ORDERUNITS double) WITH (kafka_topic='test_topic', value_format='JSON');",
         "CREATE STREAM S1 AS SELECT CASE WHEN orderunits > 2.0 THEN 'foo' ELSE 'default' END AS case_resault FROM orders;"
       ],
       "inputs": [
@@ -57,6 +57,66 @@
         {"topic": "S1", "value": {"CASE_RESAULT": "foo"}
         }
       ]
+    },
+    {
+      "name": "searched case returning null in first branch",
+      "statements": [
+        "CREATE STREAM orders (ORDERUNITS double) WITH (kafka_topic='test_topic', value_format='JSON');",
+        "CREATE STREAM S1 AS SELECT CASE WHEN orderunits < 2.0 THEN null WHEN orderunits < 4.0 THEN 'medium' ELSE 'large' END AS case_result FROM orders;"
+      ],
+      "inputs": [
+        {"topic": "test_topic", "value": {"ORDERUNITS": 4.2}},
+        {"topic": "test_topic", "value": {"ORDERUNITS": 3.99}},
+        {"topic": "test_topic", "value": {"ORDERUNITS": 1.1}}
+      ],
+      "outputs": [
+        {"topic": "S1", "value": {"CASE_RESULT": "large"}},
+        {"topic": "S1", "value": {"CASE_RESULT": "medium"}},
+        {"topic": "S1", "value": {"CASE_RESULT": null}}
+      ]
+    },
+    {
+      "name": "searched case returning null in later branch",
+      "statements": [
+        "CREATE STREAM orders (ORDERUNITS double) WITH (kafka_topic='test_topic', value_format='JSON');",
+        "CREATE STREAM S1 AS SELECT CASE WHEN orderunits < 2.0 THEN 'small' WHEN orderunits < 4.0 THEN null ELSE 'large' END AS case_result FROM orders;"
+      ],
+      "inputs": [
+        {"topic": "test_topic", "value": {"ORDERUNITS": 4.2}},
+        {"topic": "test_topic", "value": {"ORDERUNITS": 3.99}},
+        {"topic": "test_topic", "value": {"ORDERUNITS": 1.1}}
+      ],
+      "outputs": [
+        {"topic": "S1", "value": {"CASE_RESULT": "large"}},
+        {"topic": "S1", "value": {"CASE_RESULT": null}},
+        {"topic": "S1", "value": {"CASE_RESULT": "small"}}
+      ]
+    },
+    {
+      "name": "searched case returning null in default branch",
+      "statements": [
+        "CREATE STREAM orders (ORDERUNITS double) WITH (kafka_topic='test_topic', value_format='JSON');",
+        "CREATE STREAM S1 AS SELECT CASE WHEN orderunits < 2.0 THEN 'small' ELSE null END AS case_result FROM orders;"
+      ],
+      "inputs": [
+        {"topic": "test_topic", "value": {"ORDERUNITS": 4.2}},
+        {"topic": "test_topic", "value": {"ORDERUNITS": 1.1}}
+      ],
+      "outputs": [
+        {"topic": "S1", "value": {"CASE_RESULT": null}},
+        {"topic": "S1", "value": {"CASE_RESULT": "small"}}
+      ]
+    },
+    {
+      "name": "searched case returning null in all branch",
+      "statements": [
+        "CREATE STREAM orders (ORDERUNITS double) WITH (kafka_topic='test_topic', value_format='JSON');",
+        "CREATE STREAM S1 AS SELECT CASE WHEN orderunits < 2.0 THEN null ELSE null END AS case_result FROM orders;"
+      ],
+      "expectedException": {
+        "type": "io.confluent.ksql.util.KsqlStatementException",
+        "message": "Invalid Case expression. All case branches have NULL schema"
+      }
     },
     {
       "name": "searched case expression with structs, multiple expression and the same type",

--- a/ksql-parser/src/main/java/io/confluent/ksql/schema/ksql/DefaultSqlValueCoercer.java
+++ b/ksql-parser/src/main/java/io/confluent/ksql/schema/ksql/DefaultSqlValueCoercer.java
@@ -54,7 +54,7 @@ public final class DefaultSqlValueCoercer implements SqlValueCoercer {
       return coerceDecimal(value, (SqlDecimal) targetType);
     }
 
-    if (!(value instanceof Number) || !valueSqlType.canUpCast(targetType.baseType())) {
+    if (!(value instanceof Number) || !valueSqlType.canImplicitlyCast(targetType.baseType())) {
       return Optional.empty();
     }
 

--- a/ksql-parser/src/test/java/io/confluent/ksql/schema/ksql/DefaultSqlValueCoercerTest.java
+++ b/ksql-parser/src/test/java/io/confluent/ksql/schema/ksql/DefaultSqlValueCoercerTest.java
@@ -228,7 +228,7 @@ public class DefaultSqlValueCoercerTest {
       // Handled by parsing the string to a decimal:
       return true;
     }
-    return fromBaseType.canUpCast(toBaseType);
+    return fromBaseType.canImplicitlyCast(toBaseType);
   }
 
   private static List<SqlBaseType> supportedTypes() {


### PR DESCRIPTION
### Description 

Fixes: #3405, #3344

This commit enhances the processing of `CASE` statements so that both `THEN` and the default return types can be `NULL`.

At least one branch must be non-null so that KSQL can determine the result type of the statement.

All non-null branches must have the same result schema, i.e. we don't (yet) do any implicit casting of numeric types.

The commit also improves some error messages by using KSQL types rather than connect schema types so that error messages use, for example, `BIGINT` rather than `Schema{INT64}`.

### Testing done 

Usual

### Reviewer checklist
- [ ] Ensure docs are updated if necessary. (eg. if a user visible feature is being added or changed).
- [ ] Ensure relevant issues are linked (description should include text like "Fixes #<issue number>")

