### PR TITLE
fix: Revert named stores in expected topologies, disable naming stores from StreamJoined, re-enable join tests.

### DIFF
--- a/ksql-functional-tests/src/test/resources/expected_topology/5_2_0/join-with-custom-timestamp_-_stream_stream_inner_join_with_ts
+++ b/ksql-functional-tests/src/test/resources/expected_topology/5_2_0/join-with-custom-timestamp_-_stream_stream_inner_join_with_ts
@@ -48,16 +48,16 @@ Topologies:
     Processor: KSTREAM-TRANSFORMVALUES-0000000005 (stores: [])
       --> Join-other-windowed
       <-- KSTREAM-MAPVALUES-0000000004
-    Processor: Join-other-windowed (stores: [Join-other-join-store])
+    Processor: Join-other-windowed (stores: [KSTREAM-JOINOTHER-0000000009-store])
       --> Join-other-join
       <-- KSTREAM-TRANSFORMVALUES-0000000005
-    Processor: Join-this-windowed (stores: [Join-this-join-store])
+    Processor: Join-this-windowed (stores: [KSTREAM-JOINTHIS-0000000008-store])
       --> Join-this-join
       <-- KSTREAM-TRANSFORMVALUES-0000000002
-    Processor: Join-other-join (stores: [Join-this-join-store])
+    Processor: Join-other-join (stores: [KSTREAM-JOINTHIS-0000000008-store])
       --> Join-merge
       <-- Join-other-windowed
-    Processor: Join-this-join (stores: [Join-other-join-store])
+    Processor: Join-this-join (stores: [KSTREAM-JOINOTHER-0000000009-store])
       --> Join-merge
       <-- Join-this-windowed
     Processor: Join-merge (stores: [])

--- a/ksql-functional-tests/src/test/resources/expected_topology/5_2_0/join-with-custom-timestamp_-_stream_stream_inner_join_with_ts_extractor_both_sides
+++ b/ksql-functional-tests/src/test/resources/expected_topology/5_2_0/join-with-custom-timestamp_-_stream_stream_inner_join_with_ts_extractor_both_sides
@@ -48,16 +48,16 @@ Topologies:
     Processor: KSTREAM-TRANSFORMVALUES-0000000005 (stores: [])
       --> Join-other-windowed
       <-- KSTREAM-MAPVALUES-0000000004
-    Processor: Join-other-windowed (stores: [Join-other-join-store])
+    Processor: Join-other-windowed (stores: [KSTREAM-JOINOTHER-0000000009-store])
       --> Join-other-join
       <-- KSTREAM-TRANSFORMVALUES-0000000005
-    Processor: Join-this-windowed (stores: [Join-this-join-store])
+    Processor: Join-this-windowed (stores: [KSTREAM-JOINTHIS-0000000008-store])
       --> Join-this-join
       <-- KSTREAM-TRANSFORMVALUES-0000000002
-    Processor: Join-other-join (stores: [Join-this-join-store])
+    Processor: Join-other-join (stores: [KSTREAM-JOINTHIS-0000000008-store])
       --> Join-merge
       <-- Join-other-windowed
-    Processor: Join-this-join (stores: [Join-other-join-store])
+    Processor: Join-this-join (stores: [KSTREAM-JOINOTHER-0000000009-store])
       --> Join-merge
       <-- Join-this-windowed
     Processor: Join-merge (stores: [])

--- a/ksql-functional-tests/src/test/resources/expected_topology/5_2_0/joins_-_stream_stream_inner_join
+++ b/ksql-functional-tests/src/test/resources/expected_topology/5_2_0/joins_-_stream_stream_inner_join
@@ -48,16 +48,16 @@ Topologies:
     Processor: KSTREAM-TRANSFORMVALUES-0000000005 (stores: [])
       --> Join-other-windowed
       <-- KSTREAM-MAPVALUES-0000000004
-    Processor: Join-other-windowed (stores: [Join-other-join-store])
+    Processor: Join-other-windowed (stores: [KSTREAM-JOINOTHER-0000000009-store])
       --> Join-other-join
       <-- KSTREAM-TRANSFORMVALUES-0000000005
-    Processor: Join-this-windowed (stores: [Join-this-join-store])
+    Processor: Join-this-windowed (stores: [KSTREAM-JOINTHIS-0000000008-store])
       --> Join-this-join
       <-- KSTREAM-TRANSFORMVALUES-0000000002
-    Processor: Join-other-join (stores: [Join-this-join-store])
+    Processor: Join-other-join (stores: [KSTREAM-JOINTHIS-0000000008-store])
       --> Join-merge
       <-- Join-other-windowed
-    Processor: Join-this-join (stores: [Join-other-join-store])
+    Processor: Join-this-join (stores: [KSTREAM-JOINOTHER-0000000009-store])
       --> Join-merge
       <-- Join-this-windowed
     Processor: Join-merge (stores: [])

--- a/ksql-functional-tests/src/test/resources/expected_topology/5_2_0/joins_-_stream_stream_inner_join_all_left_fields_some_right
+++ b/ksql-functional-tests/src/test/resources/expected_topology/5_2_0/joins_-_stream_stream_inner_join_all_left_fields_some_right
@@ -48,16 +48,16 @@ Topologies:
     Processor: KSTREAM-TRANSFORMVALUES-0000000005 (stores: [])
       --> Join-other-windowed
       <-- KSTREAM-MAPVALUES-0000000004
-    Processor: Join-other-windowed (stores: [Join-other-join-store])
+    Processor: Join-other-windowed (stores: [KSTREAM-JOINOTHER-0000000009-store])
       --> Join-other-join
       <-- KSTREAM-TRANSFORMVALUES-0000000005
-    Processor: Join-this-windowed (stores: [Join-this-join-store])
+    Processor: Join-this-windowed (stores: [KSTREAM-JOINTHIS-0000000008-store])
       --> Join-this-join
       <-- KSTREAM-TRANSFORMVALUES-0000000002
-    Processor: Join-other-join (stores: [Join-this-join-store])
+    Processor: Join-other-join (stores: [KSTREAM-JOINTHIS-0000000008-store])
       --> Join-merge
       <-- Join-other-windowed
-    Processor: Join-this-join (stores: [Join-other-join-store])
+    Processor: Join-this-join (stores: [KSTREAM-JOINOTHER-0000000009-store])
       --> Join-merge
       <-- Join-this-windowed
     Processor: Join-merge (stores: [])

--- a/ksql-functional-tests/src/test/resources/expected_topology/5_2_0/joins_-_stream_stream_inner_join_all_right_fields_some_left
+++ b/ksql-functional-tests/src/test/resources/expected_topology/5_2_0/joins_-_stream_stream_inner_join_all_right_fields_some_left
@@ -48,16 +48,16 @@ Topologies:
     Processor: KSTREAM-TRANSFORMVALUES-0000000005 (stores: [])
       --> Join-other-windowed
       <-- KSTREAM-MAPVALUES-0000000004
-    Processor: Join-other-windowed (stores: [Join-other-join-store])
+    Processor: Join-other-windowed (stores: [KSTREAM-JOINOTHER-0000000009-store])
       --> Join-other-join
       <-- KSTREAM-TRANSFORMVALUES-0000000005
-    Processor: Join-this-windowed (stores: [Join-this-join-store])
+    Processor: Join-this-windowed (stores: [KSTREAM-JOINTHIS-0000000008-store])
       --> Join-this-join
       <-- KSTREAM-TRANSFORMVALUES-0000000002
-    Processor: Join-other-join (stores: [Join-this-join-store])
+    Processor: Join-other-join (stores: [KSTREAM-JOINTHIS-0000000008-store])
       --> Join-merge
       <-- Join-other-windowed
-    Processor: Join-this-join (stores: [Join-other-join-store])
+    Processor: Join-this-join (stores: [KSTREAM-JOINOTHER-0000000009-store])
       --> Join-merge
       <-- Join-this-windowed
     Processor: Join-merge (stores: [])

--- a/ksql-functional-tests/src/test/resources/expected_topology/5_2_0/joins_-_stream_stream_inner_join_with_different_before_and_after_windows
+++ b/ksql-functional-tests/src/test/resources/expected_topology/5_2_0/joins_-_stream_stream_inner_join_with_different_before_and_after_windows
@@ -48,16 +48,16 @@ Topologies:
     Processor: KSTREAM-TRANSFORMVALUES-0000000005 (stores: [])
       --> Join-other-windowed
       <-- KSTREAM-MAPVALUES-0000000004
-    Processor: Join-other-windowed (stores: [Join-other-join-store])
+    Processor: Join-other-windowed (stores: [KSTREAM-JOINOTHER-0000000009-store])
       --> Join-other-join
       <-- KSTREAM-TRANSFORMVALUES-0000000005
-    Processor: Join-this-windowed (stores: [Join-this-join-store])
+    Processor: Join-this-windowed (stores: [KSTREAM-JOINTHIS-0000000008-store])
       --> Join-this-join
       <-- KSTREAM-TRANSFORMVALUES-0000000002
-    Processor: Join-other-join (stores: [Join-this-join-store])
+    Processor: Join-other-join (stores: [KSTREAM-JOINTHIS-0000000008-store])
       --> Join-merge
       <-- Join-other-windowed
-    Processor: Join-this-join (stores: [Join-other-join-store])
+    Processor: Join-this-join (stores: [KSTREAM-JOINOTHER-0000000009-store])
       --> Join-merge
       <-- Join-this-windowed
     Processor: Join-merge (stores: [])

--- a/ksql-functional-tests/src/test/resources/expected_topology/5_2_0/joins_-_stream_stream_inner_join_with_out_of_order_messages
+++ b/ksql-functional-tests/src/test/resources/expected_topology/5_2_0/joins_-_stream_stream_inner_join_with_out_of_order_messages
@@ -48,16 +48,16 @@ Topologies:
     Processor: KSTREAM-TRANSFORMVALUES-0000000005 (stores: [])
       --> Join-other-windowed
       <-- KSTREAM-MAPVALUES-0000000004
-    Processor: Join-other-windowed (stores: [Join-other-join-store])
+    Processor: Join-other-windowed (stores: [KSTREAM-JOINOTHER-0000000009-store])
       --> Join-other-join
       <-- KSTREAM-TRANSFORMVALUES-0000000005
-    Processor: Join-this-windowed (stores: [Join-this-join-store])
+    Processor: Join-this-windowed (stores: [KSTREAM-JOINTHIS-0000000008-store])
       --> Join-this-join
       <-- KSTREAM-TRANSFORMVALUES-0000000002
-    Processor: Join-other-join (stores: [Join-this-join-store])
+    Processor: Join-other-join (stores: [KSTREAM-JOINTHIS-0000000008-store])
       --> Join-merge
       <-- Join-other-windowed
-    Processor: Join-this-join (stores: [Join-other-join-store])
+    Processor: Join-this-join (stores: [KSTREAM-JOINOTHER-0000000009-store])
       --> Join-merge
       <-- Join-this-windowed
     Processor: Join-merge (stores: [])

--- a/ksql-functional-tests/src/test/resources/expected_topology/5_2_0/joins_-_stream_stream_left_join
+++ b/ksql-functional-tests/src/test/resources/expected_topology/5_2_0/joins_-_stream_stream_left_join
@@ -48,16 +48,16 @@ Topologies:
     Processor: KSTREAM-TRANSFORMVALUES-0000000005 (stores: [])
       --> Join-other-windowed
       <-- KSTREAM-MAPVALUES-0000000004
-    Processor: Join-other-windowed (stores: [Join-outer-other-join-store])
+    Processor: Join-other-windowed (stores: [KSTREAM-OUTEROTHER-0000000009-store])
       --> Join-outer-other-join
       <-- KSTREAM-TRANSFORMVALUES-0000000005
-    Processor: Join-this-windowed (stores: [Join-this-join-store])
+    Processor: Join-this-windowed (stores: [KSTREAM-JOINTHIS-0000000008-store])
       --> Join-this-join
       <-- KSTREAM-TRANSFORMVALUES-0000000002
-    Processor: Join-outer-other-join (stores: [Join-this-join-store])
+    Processor: Join-outer-other-join (stores: [KSTREAM-JOINTHIS-0000000008-store])
       --> Join-merge
       <-- Join-other-windowed
-    Processor: Join-this-join (stores: [Join-outer-other-join-store])
+    Processor: Join-this-join (stores: [KSTREAM-OUTEROTHER-0000000009-store])
       --> Join-merge
       <-- Join-this-windowed
     Processor: Join-merge (stores: [])

--- a/ksql-functional-tests/src/test/resources/expected_topology/5_2_0/joins_-_stream_stream_outer_join
+++ b/ksql-functional-tests/src/test/resources/expected_topology/5_2_0/joins_-_stream_stream_outer_join
@@ -48,16 +48,16 @@ Topologies:
     Processor: KSTREAM-TRANSFORMVALUES-0000000005 (stores: [])
       --> Join-other-windowed
       <-- KSTREAM-MAPVALUES-0000000004
-    Processor: Join-other-windowed (stores: [Join-outer-other-join-store])
+    Processor: Join-other-windowed (stores: [KSTREAM-OUTEROTHER-0000000009-store])
       --> Join-outer-other-join
       <-- KSTREAM-TRANSFORMVALUES-0000000005
-    Processor: Join-this-windowed (stores: [Join-outer-this-join-store])
+    Processor: Join-this-windowed (stores: [KSTREAM-OUTERTHIS-0000000008-store])
       --> Join-outer-this-join
       <-- KSTREAM-TRANSFORMVALUES-0000000002
-    Processor: Join-outer-other-join (stores: [Join-outer-this-join-store])
+    Processor: Join-outer-other-join (stores: [KSTREAM-OUTERTHIS-0000000008-store])
       --> Join-merge
       <-- Join-other-windowed
-    Processor: Join-outer-this-join (stores: [Join-outer-other-join-store])
+    Processor: Join-outer-this-join (stores: [KSTREAM-OUTEROTHER-0000000009-store])
       --> Join-merge
       <-- Join-this-windowed
     Processor: Join-merge (stores: [])

--- a/ksql-functional-tests/src/test/resources/expected_topology/5_3_0/identifiers_-_aliased_join_source
+++ b/ksql-functional-tests/src/test/resources/expected_topology/5_3_0/identifiers_-_aliased_join_source
@@ -56,16 +56,16 @@ Topologies:
     Processor: KSTREAM-TRANSFORMVALUES-0000000005 (stores: [])
       --> Join-other-windowed
       <-- KSTREAM-MAPVALUES-0000000004
-    Processor: Join-other-windowed (stores: [Join-other-join-store])
+    Processor: Join-other-windowed (stores: [KSTREAM-JOINOTHER-0000000009-store])
       --> Join-other-join
       <-- KSTREAM-TRANSFORMVALUES-0000000005
-    Processor: Join-this-windowed (stores: [Join-this-join-store])
+    Processor: Join-this-windowed (stores: [KSTREAM-JOINTHIS-0000000008-store])
       --> Join-this-join
       <-- KSTREAM-TRANSFORMVALUES-0000000002
-    Processor: Join-other-join (stores: [Join-this-join-store])
+    Processor: Join-other-join (stores: [KSTREAM-JOINTHIS-0000000008-store])
       --> Join-merge
       <-- Join-other-windowed
-    Processor: Join-this-join (stores: [Join-other-join-store])
+    Processor: Join-this-join (stores: [KSTREAM-JOINOTHER-0000000009-store])
       --> Join-merge
       <-- Join-this-windowed
     Processor: Join-merge (stores: [])

--- a/ksql-functional-tests/src/test/resources/expected_topology/5_3_0/identifiers_-_aliased_join_source_with_AS
+++ b/ksql-functional-tests/src/test/resources/expected_topology/5_3_0/identifiers_-_aliased_join_source_with_AS
@@ -56,16 +56,16 @@ Topologies:
     Processor: KSTREAM-TRANSFORMVALUES-0000000005 (stores: [])
       --> Join-other-windowed
       <-- KSTREAM-MAPVALUES-0000000004
-    Processor: Join-other-windowed (stores: [Join-other-join-store])
+    Processor: Join-other-windowed (stores: [KSTREAM-JOINOTHER-0000000009-store])
       --> Join-other-join
       <-- KSTREAM-TRANSFORMVALUES-0000000005
-    Processor: Join-this-windowed (stores: [Join-this-join-store])
+    Processor: Join-this-windowed (stores: [KSTREAM-JOINTHIS-0000000008-store])
       --> Join-this-join
       <-- KSTREAM-TRANSFORMVALUES-0000000002
-    Processor: Join-other-join (stores: [Join-this-join-store])
+    Processor: Join-other-join (stores: [KSTREAM-JOINTHIS-0000000008-store])
       --> Join-merge
       <-- Join-other-windowed
-    Processor: Join-this-join (stores: [Join-other-join-store])
+    Processor: Join-this-join (stores: [KSTREAM-JOINOTHER-0000000009-store])
       --> Join-merge
       <-- Join-this-windowed
     Processor: Join-merge (stores: [])

--- a/ksql-functional-tests/src/test/resources/expected_topology/5_3_0/identifiers_-_aliased_left_unaliased_right
+++ b/ksql-functional-tests/src/test/resources/expected_topology/5_3_0/identifiers_-_aliased_left_unaliased_right
@@ -56,16 +56,16 @@ Topologies:
     Processor: KSTREAM-TRANSFORMVALUES-0000000005 (stores: [])
       --> Join-other-windowed
       <-- KSTREAM-MAPVALUES-0000000004
-    Processor: Join-other-windowed (stores: [Join-other-join-store])
+    Processor: Join-other-windowed (stores: [KSTREAM-JOINOTHER-0000000009-store])
       --> Join-other-join
       <-- KSTREAM-TRANSFORMVALUES-0000000005
-    Processor: Join-this-windowed (stores: [Join-this-join-store])
+    Processor: Join-this-windowed (stores: [KSTREAM-JOINTHIS-0000000008-store])
       --> Join-this-join
       <-- KSTREAM-TRANSFORMVALUES-0000000002
-    Processor: Join-other-join (stores: [Join-this-join-store])
+    Processor: Join-other-join (stores: [KSTREAM-JOINTHIS-0000000008-store])
       --> Join-merge
       <-- Join-other-windowed
-    Processor: Join-this-join (stores: [Join-other-join-store])
+    Processor: Join-this-join (stores: [KSTREAM-JOINOTHER-0000000009-store])
       --> Join-merge
       <-- Join-this-windowed
     Processor: Join-merge (stores: [])

--- a/ksql-functional-tests/src/test/resources/expected_topology/5_3_0/identifiers_-_unaliased_left_aliased_right
+++ b/ksql-functional-tests/src/test/resources/expected_topology/5_3_0/identifiers_-_unaliased_left_aliased_right
@@ -56,16 +56,16 @@ Topologies:
     Processor: KSTREAM-TRANSFORMVALUES-0000000005 (stores: [])
       --> Join-other-windowed
       <-- KSTREAM-MAPVALUES-0000000004
-    Processor: Join-other-windowed (stores: [Join-other-join-store])
+    Processor: Join-other-windowed (stores: [KSTREAM-JOINOTHER-0000000009-store])
       --> Join-other-join
       <-- KSTREAM-TRANSFORMVALUES-0000000005
-    Processor: Join-this-windowed (stores: [Join-this-join-store])
+    Processor: Join-this-windowed (stores: [KSTREAM-JOINTHIS-0000000008-store])
       --> Join-this-join
       <-- KSTREAM-TRANSFORMVALUES-0000000002
-    Processor: Join-other-join (stores: [Join-this-join-store])
+    Processor: Join-other-join (stores: [KSTREAM-JOINTHIS-0000000008-store])
       --> Join-merge
       <-- Join-other-windowed
-    Processor: Join-this-join (stores: [Join-other-join-store])
+    Processor: Join-this-join (stores: [KSTREAM-JOINOTHER-0000000009-store])
       --> Join-merge
       <-- Join-this-windowed
     Processor: Join-merge (stores: [])

--- a/ksql-functional-tests/src/test/resources/expected_topology/5_3_0/join-with-custom-timestamp_-_stream_stream_inner_join_with_ts
+++ b/ksql-functional-tests/src/test/resources/expected_topology/5_3_0/join-with-custom-timestamp_-_stream_stream_inner_join_with_ts
@@ -56,16 +56,16 @@ Topologies:
     Processor: KSTREAM-TRANSFORMVALUES-0000000005 (stores: [])
       --> Join-other-windowed
       <-- KSTREAM-MAPVALUES-0000000004
-    Processor: Join-other-windowed (stores: [Join-other-join-store])
+    Processor: Join-other-windowed (stores: [KSTREAM-JOINOTHER-0000000009-store])
       --> Join-other-join
       <-- KSTREAM-TRANSFORMVALUES-0000000005
-    Processor: Join-this-windowed (stores: [Join-this-join-store])
+    Processor: Join-this-windowed (stores: [KSTREAM-JOINTHIS-0000000008-store])
       --> Join-this-join
       <-- KSTREAM-TRANSFORMVALUES-0000000002
-    Processor: Join-other-join (stores: [Join-this-join-store])
+    Processor: Join-other-join (stores: [KSTREAM-JOINTHIS-0000000008-store])
       --> Join-merge
       <-- Join-other-windowed
-    Processor: Join-this-join (stores: [Join-other-join-store])
+    Processor: Join-this-join (stores: [KSTREAM-JOINOTHER-0000000009-store])
       --> Join-merge
       <-- Join-this-windowed
     Processor: Join-merge (stores: [])

--- a/ksql-functional-tests/src/test/resources/expected_topology/5_3_0/join-with-custom-timestamp_-_stream_stream_inner_join_with_ts_extractor_both_sides
+++ b/ksql-functional-tests/src/test/resources/expected_topology/5_3_0/join-with-custom-timestamp_-_stream_stream_inner_join_with_ts_extractor_both_sides
@@ -56,16 +56,16 @@ Topologies:
     Processor: KSTREAM-TRANSFORMVALUES-0000000005 (stores: [])
       --> Join-other-windowed
       <-- KSTREAM-MAPVALUES-0000000004
-    Processor: Join-other-windowed (stores: [Join-other-join-store])
+    Processor: Join-other-windowed (stores: [KSTREAM-JOINOTHER-0000000009-store])
       --> Join-other-join
       <-- KSTREAM-TRANSFORMVALUES-0000000005
-    Processor: Join-this-windowed (stores: [Join-this-join-store])
+    Processor: Join-this-windowed (stores: [KSTREAM-JOINTHIS-0000000008-store])
       --> Join-this-join
       <-- KSTREAM-TRANSFORMVALUES-0000000002
-    Processor: Join-other-join (stores: [Join-this-join-store])
+    Processor: Join-other-join (stores: [KSTREAM-JOINTHIS-0000000008-store])
       --> Join-merge
       <-- Join-other-windowed
-    Processor: Join-this-join (stores: [Join-other-join-store])
+    Processor: Join-this-join (stores: [KSTREAM-JOINOTHER-0000000009-store])
       --> Join-merge
       <-- Join-this-windowed
     Processor: Join-merge (stores: [])

--- a/ksql-functional-tests/src/test/resources/expected_topology/5_3_0/joins_-_join_using_ROWKEY_in_the_criteria_-_new_key_fields_-_no_source_key_fields
+++ b/ksql-functional-tests/src/test/resources/expected_topology/5_3_0/joins_-_join_using_ROWKEY_in_the_criteria_-_new_key_fields_-_no_source_key_fields
@@ -56,16 +56,16 @@ Topologies:
     Processor: KSTREAM-TRANSFORMVALUES-0000000005 (stores: [])
       --> Join-other-windowed
       <-- KSTREAM-MAPVALUES-0000000004
-    Processor: Join-other-windowed (stores: [Join-outer-other-join-store])
+    Processor: Join-other-windowed (stores: [KSTREAM-OUTEROTHER-0000000009-store])
       --> Join-outer-other-join
       <-- KSTREAM-TRANSFORMVALUES-0000000005
-    Processor: Join-this-windowed (stores: [Join-this-join-store])
+    Processor: Join-this-windowed (stores: [KSTREAM-JOINTHIS-0000000008-store])
       --> Join-this-join
       <-- KSTREAM-TRANSFORMVALUES-0000000002
-    Processor: Join-outer-other-join (stores: [Join-this-join-store])
+    Processor: Join-outer-other-join (stores: [KSTREAM-JOINTHIS-0000000008-store])
       --> Join-merge
       <-- Join-other-windowed
-    Processor: Join-this-join (stores: [Join-outer-other-join-store])
+    Processor: Join-this-join (stores: [KSTREAM-OUTEROTHER-0000000009-store])
       --> Join-merge
       <-- Join-this-windowed
     Processor: Join-merge (stores: [])

--- a/ksql-functional-tests/src/test/resources/expected_topology/5_3_0/joins_-_stream_stream_inner_join
+++ b/ksql-functional-tests/src/test/resources/expected_topology/5_3_0/joins_-_stream_stream_inner_join
@@ -56,16 +56,16 @@ Topologies:
     Processor: KSTREAM-TRANSFORMVALUES-0000000005 (stores: [])
       --> Join-other-windowed
       <-- KSTREAM-MAPVALUES-0000000004
-    Processor: Join-other-windowed (stores: [Join-other-join-store])
+    Processor: Join-other-windowed (stores: [KSTREAM-JOINOTHER-0000000009-store])
       --> Join-other-join
       <-- KSTREAM-TRANSFORMVALUES-0000000005
-    Processor: Join-this-windowed (stores: [Join-this-join-store])
+    Processor: Join-this-windowed (stores: [KSTREAM-JOINTHIS-0000000008-store])
       --> Join-this-join
       <-- KSTREAM-TRANSFORMVALUES-0000000002
-    Processor: Join-other-join (stores: [Join-this-join-store])
+    Processor: Join-other-join (stores: [KSTREAM-JOINTHIS-0000000008-store])
       --> Join-merge
       <-- Join-other-windowed
-    Processor: Join-this-join (stores: [Join-other-join-store])
+    Processor: Join-this-join (stores: [KSTREAM-JOINOTHER-0000000009-store])
       --> Join-merge
       <-- Join-this-windowed
     Processor: Join-merge (stores: [])

--- a/ksql-functional-tests/src/test/resources/expected_topology/5_3_0/joins_-_stream_stream_inner_join_-_join_key_not_in_projection
+++ b/ksql-functional-tests/src/test/resources/expected_topology/5_3_0/joins_-_stream_stream_inner_join_-_join_key_not_in_projection
@@ -56,16 +56,16 @@ Topologies:
     Processor: KSTREAM-TRANSFORMVALUES-0000000005 (stores: [])
       --> Join-other-windowed
       <-- KSTREAM-MAPVALUES-0000000004
-    Processor: Join-other-windowed (stores: [Join-other-join-store])
+    Processor: Join-other-windowed (stores: [KSTREAM-JOINOTHER-0000000009-store])
       --> Join-other-join
       <-- KSTREAM-TRANSFORMVALUES-0000000005
-    Processor: Join-this-windowed (stores: [Join-this-join-store])
+    Processor: Join-this-windowed (stores: [KSTREAM-JOINTHIS-0000000008-store])
       --> Join-this-join
       <-- KSTREAM-TRANSFORMVALUES-0000000002
-    Processor: Join-other-join (stores: [Join-this-join-store])
+    Processor: Join-other-join (stores: [KSTREAM-JOINTHIS-0000000008-store])
       --> Join-merge
       <-- Join-other-windowed
-    Processor: Join-this-join (stores: [Join-other-join-store])
+    Processor: Join-this-join (stores: [KSTREAM-JOINOTHER-0000000009-store])
       --> Join-merge
       <-- Join-this-windowed
     Processor: Join-merge (stores: [])

--- a/ksql-functional-tests/src/test/resources/expected_topology/5_3_0/joins_-_stream_stream_inner_join_-_right_join_key_in_projection
+++ b/ksql-functional-tests/src/test/resources/expected_topology/5_3_0/joins_-_stream_stream_inner_join_-_right_join_key_in_projection
@@ -56,16 +56,16 @@ Topologies:
     Processor: KSTREAM-TRANSFORMVALUES-0000000005 (stores: [])
       --> Join-other-windowed
       <-- KSTREAM-MAPVALUES-0000000004
-    Processor: Join-other-windowed (stores: [Join-other-join-store])
+    Processor: Join-other-windowed (stores: [KSTREAM-JOINOTHER-0000000009-store])
       --> Join-other-join
       <-- KSTREAM-TRANSFORMVALUES-0000000005
-    Processor: Join-this-windowed (stores: [Join-this-join-store])
+    Processor: Join-this-windowed (stores: [KSTREAM-JOINTHIS-0000000008-store])
       --> Join-this-join
       <-- KSTREAM-TRANSFORMVALUES-0000000002
-    Processor: Join-other-join (stores: [Join-this-join-store])
+    Processor: Join-other-join (stores: [KSTREAM-JOINTHIS-0000000008-store])
       --> Join-merge
       <-- Join-other-windowed
-    Processor: Join-this-join (stores: [Join-other-join-store])
+    Processor: Join-this-join (stores: [KSTREAM-JOINOTHER-0000000009-store])
       --> Join-merge
       <-- Join-this-windowed
     Processor: Join-merge (stores: [])

--- a/ksql-functional-tests/src/test/resources/expected_topology/5_3_0/joins_-_stream_stream_inner_join_all_fields
+++ b/ksql-functional-tests/src/test/resources/expected_topology/5_3_0/joins_-_stream_stream_inner_join_all_fields
@@ -56,16 +56,16 @@ Topologies:
     Processor: KSTREAM-TRANSFORMVALUES-0000000005 (stores: [])
       --> Join-other-windowed
       <-- KSTREAM-MAPVALUES-0000000004
-    Processor: Join-other-windowed (stores: [Join-other-join-store])
+    Processor: Join-other-windowed (stores: [KSTREAM-JOINOTHER-0000000009-store])
       --> Join-other-join
       <-- KSTREAM-TRANSFORMVALUES-0000000005
-    Processor: Join-this-windowed (stores: [Join-this-join-store])
+    Processor: Join-this-windowed (stores: [KSTREAM-JOINTHIS-0000000008-store])
       --> Join-this-join
       <-- KSTREAM-TRANSFORMVALUES-0000000002
-    Processor: Join-other-join (stores: [Join-this-join-store])
+    Processor: Join-other-join (stores: [KSTREAM-JOINTHIS-0000000008-store])
       --> Join-merge
       <-- Join-other-windowed
-    Processor: Join-this-join (stores: [Join-other-join-store])
+    Processor: Join-this-join (stores: [KSTREAM-JOINOTHER-0000000009-store])
       --> Join-merge
       <-- Join-this-windowed
     Processor: Join-merge (stores: [])

--- a/ksql-functional-tests/src/test/resources/expected_topology/5_3_0/joins_-_stream_stream_inner_join_all_left_fields_some_right
+++ b/ksql-functional-tests/src/test/resources/expected_topology/5_3_0/joins_-_stream_stream_inner_join_all_left_fields_some_right
@@ -56,16 +56,16 @@ Topologies:
     Processor: KSTREAM-TRANSFORMVALUES-0000000005 (stores: [])
       --> Join-other-windowed
       <-- KSTREAM-MAPVALUES-0000000004
-    Processor: Join-other-windowed (stores: [Join-other-join-store])
+    Processor: Join-other-windowed (stores: [KSTREAM-JOINOTHER-0000000009-store])
       --> Join-other-join
       <-- KSTREAM-TRANSFORMVALUES-0000000005
-    Processor: Join-this-windowed (stores: [Join-this-join-store])
+    Processor: Join-this-windowed (stores: [KSTREAM-JOINTHIS-0000000008-store])
       --> Join-this-join
       <-- KSTREAM-TRANSFORMVALUES-0000000002
-    Processor: Join-other-join (stores: [Join-this-join-store])
+    Processor: Join-other-join (stores: [KSTREAM-JOINTHIS-0000000008-store])
       --> Join-merge
       <-- Join-other-windowed
-    Processor: Join-this-join (stores: [Join-other-join-store])
+    Processor: Join-this-join (stores: [KSTREAM-JOINOTHER-0000000009-store])
       --> Join-merge
       <-- Join-this-windowed
     Processor: Join-merge (stores: [])

--- a/ksql-functional-tests/src/test/resources/expected_topology/5_3_0/joins_-_stream_stream_inner_join_all_right_fields_some_left
+++ b/ksql-functional-tests/src/test/resources/expected_topology/5_3_0/joins_-_stream_stream_inner_join_all_right_fields_some_left
@@ -56,16 +56,16 @@ Topologies:
     Processor: KSTREAM-TRANSFORMVALUES-0000000005 (stores: [])
       --> Join-other-windowed
       <-- KSTREAM-MAPVALUES-0000000004
-    Processor: Join-other-windowed (stores: [Join-other-join-store])
+    Processor: Join-other-windowed (stores: [KSTREAM-JOINOTHER-0000000009-store])
       --> Join-other-join
       <-- KSTREAM-TRANSFORMVALUES-0000000005
-    Processor: Join-this-windowed (stores: [Join-this-join-store])
+    Processor: Join-this-windowed (stores: [KSTREAM-JOINTHIS-0000000008-store])
       --> Join-this-join
       <-- KSTREAM-TRANSFORMVALUES-0000000002
-    Processor: Join-other-join (stores: [Join-this-join-store])
+    Processor: Join-other-join (stores: [KSTREAM-JOINTHIS-0000000008-store])
       --> Join-merge
       <-- Join-other-windowed
-    Processor: Join-this-join (stores: [Join-other-join-store])
+    Processor: Join-this-join (stores: [KSTREAM-JOINOTHER-0000000009-store])
       --> Join-merge
       <-- Join-this-windowed
     Processor: Join-merge (stores: [])

--- a/ksql-functional-tests/src/test/resources/expected_topology/5_3_0/joins_-_stream_stream_inner_join_with_different_before_and_after_windows
+++ b/ksql-functional-tests/src/test/resources/expected_topology/5_3_0/joins_-_stream_stream_inner_join_with_different_before_and_after_windows
@@ -56,16 +56,16 @@ Topologies:
     Processor: KSTREAM-TRANSFORMVALUES-0000000005 (stores: [])
       --> Join-other-windowed
       <-- KSTREAM-MAPVALUES-0000000004
-    Processor: Join-other-windowed (stores: [Join-other-join-store])
+    Processor: Join-other-windowed (stores: [KSTREAM-JOINOTHER-0000000009-store])
       --> Join-other-join
       <-- KSTREAM-TRANSFORMVALUES-0000000005
-    Processor: Join-this-windowed (stores: [Join-this-join-store])
+    Processor: Join-this-windowed (stores: [KSTREAM-JOINTHIS-0000000008-store])
       --> Join-this-join
       <-- KSTREAM-TRANSFORMVALUES-0000000002
-    Processor: Join-other-join (stores: [Join-this-join-store])
+    Processor: Join-other-join (stores: [KSTREAM-JOINTHIS-0000000008-store])
       --> Join-merge
       <-- Join-other-windowed
-    Processor: Join-this-join (stores: [Join-other-join-store])
+    Processor: Join-this-join (stores: [KSTREAM-JOINOTHER-0000000009-store])
       --> Join-merge
       <-- Join-this-windowed
     Processor: Join-merge (stores: [])

--- a/ksql-functional-tests/src/test/resources/expected_topology/5_3_0/joins_-_stream_stream_inner_join_with_out_of_order_messages
+++ b/ksql-functional-tests/src/test/resources/expected_topology/5_3_0/joins_-_stream_stream_inner_join_with_out_of_order_messages
@@ -56,16 +56,16 @@ Topologies:
     Processor: KSTREAM-TRANSFORMVALUES-0000000005 (stores: [])
       --> Join-other-windowed
       <-- KSTREAM-MAPVALUES-0000000004
-    Processor: Join-other-windowed (stores: [Join-other-join-store])
+    Processor: Join-other-windowed (stores: [KSTREAM-JOINOTHER-0000000009-store])
       --> Join-other-join
       <-- KSTREAM-TRANSFORMVALUES-0000000005
-    Processor: Join-this-windowed (stores: [Join-this-join-store])
+    Processor: Join-this-windowed (stores: [KSTREAM-JOINTHIS-0000000008-store])
       --> Join-this-join
       <-- KSTREAM-TRANSFORMVALUES-0000000002
-    Processor: Join-other-join (stores: [Join-this-join-store])
+    Processor: Join-other-join (stores: [KSTREAM-JOINTHIS-0000000008-store])
       --> Join-merge
       <-- Join-other-windowed
-    Processor: Join-this-join (stores: [Join-other-join-store])
+    Processor: Join-this-join (stores: [KSTREAM-JOINOTHER-0000000009-store])
       --> Join-merge
       <-- Join-this-windowed
     Processor: Join-merge (stores: [])

--- a/ksql-functional-tests/src/test/resources/expected_topology/5_3_0/joins_-_stream_stream_left_join
+++ b/ksql-functional-tests/src/test/resources/expected_topology/5_3_0/joins_-_stream_stream_left_join
@@ -56,16 +56,16 @@ Topologies:
     Processor: KSTREAM-TRANSFORMVALUES-0000000005 (stores: [])
       --> Join-other-windowed
       <-- KSTREAM-MAPVALUES-0000000004
-    Processor: Join-other-windowed (stores: [Join-outer-other-join-store])
+    Processor: Join-other-windowed (stores: [KSTREAM-OUTEROTHER-0000000009-store])
       --> Join-outer-other-join
       <-- KSTREAM-TRANSFORMVALUES-0000000005
-    Processor: Join-this-windowed (stores: [Join-this-join-store])
+    Processor: Join-this-windowed (stores: [KSTREAM-JOINTHIS-0000000008-store])
       --> Join-this-join
       <-- KSTREAM-TRANSFORMVALUES-0000000002
-    Processor: Join-outer-other-join (stores: [Join-this-join-store])
+    Processor: Join-outer-other-join (stores: [KSTREAM-JOINTHIS-0000000008-store])
       --> Join-merge
       <-- Join-other-windowed
-    Processor: Join-this-join (stores: [Join-outer-other-join-store])
+    Processor: Join-this-join (stores: [KSTREAM-OUTEROTHER-0000000009-store])
       --> Join-merge
       <-- Join-this-windowed
     Processor: Join-merge (stores: [])

--- a/ksql-functional-tests/src/test/resources/expected_topology/5_3_0/joins_-_stream_stream_left_join_-_both_join_keys_in_projection
+++ b/ksql-functional-tests/src/test/resources/expected_topology/5_3_0/joins_-_stream_stream_left_join_-_both_join_keys_in_projection
@@ -92,16 +92,16 @@ Topologies:
       --> Join-this-windowed
     Source: KSTREAM-SOURCE-0000000017 (topics: [Join-right-repartition])
       --> Join-other-windowed
-    Processor: Join-other-windowed (stores: [Join-outer-other-join-store])
+    Processor: Join-other-windowed (stores: [KSTREAM-OUTEROTHER-0000000021-store])
       --> Join-outer-other-join
       <-- KSTREAM-SOURCE-0000000017
-    Processor: Join-this-windowed (stores: [Join-this-join-store])
+    Processor: Join-this-windowed (stores: [KSTREAM-JOINTHIS-0000000020-store])
       --> Join-this-join
       <-- KSTREAM-SOURCE-0000000014
-    Processor: Join-outer-other-join (stores: [Join-this-join-store])
+    Processor: Join-outer-other-join (stores: [KSTREAM-JOINTHIS-0000000020-store])
       --> Join-merge
       <-- Join-other-windowed
-    Processor: Join-this-join (stores: [Join-outer-other-join-store])
+    Processor: Join-this-join (stores: [KSTREAM-OUTEROTHER-0000000021-store])
       --> Join-merge
       <-- Join-this-windowed
     Processor: Join-merge (stores: [])

--- a/ksql-functional-tests/src/test/resources/expected_topology/5_3_0/joins_-_stream_stream_left_join_-_join_key_not_in_projection
+++ b/ksql-functional-tests/src/test/resources/expected_topology/5_3_0/joins_-_stream_stream_left_join_-_join_key_not_in_projection
@@ -56,16 +56,16 @@ Topologies:
     Processor: KSTREAM-TRANSFORMVALUES-0000000005 (stores: [])
       --> Join-other-windowed
       <-- KSTREAM-MAPVALUES-0000000004
-    Processor: Join-other-windowed (stores: [Join-outer-other-join-store])
+    Processor: Join-other-windowed (stores: [KSTREAM-OUTEROTHER-0000000009-store])
       --> Join-outer-other-join
       <-- KSTREAM-TRANSFORMVALUES-0000000005
-    Processor: Join-this-windowed (stores: [Join-this-join-store])
+    Processor: Join-this-windowed (stores: [KSTREAM-JOINTHIS-0000000008-store])
       --> Join-this-join
       <-- KSTREAM-TRANSFORMVALUES-0000000002
-    Processor: Join-outer-other-join (stores: [Join-this-join-store])
+    Processor: Join-outer-other-join (stores: [KSTREAM-JOINTHIS-0000000008-store])
       --> Join-merge
       <-- Join-other-windowed
-    Processor: Join-this-join (stores: [Join-outer-other-join-store])
+    Processor: Join-this-join (stores: [KSTREAM-OUTEROTHER-0000000009-store])
       --> Join-merge
       <-- Join-this-windowed
     Processor: Join-merge (stores: [])

--- a/ksql-functional-tests/src/test/resources/expected_topology/5_3_0/joins_-_stream_stream_left_join_-_rekey
+++ b/ksql-functional-tests/src/test/resources/expected_topology/5_3_0/joins_-_stream_stream_left_join_-_rekey
@@ -92,16 +92,16 @@ Topologies:
       --> Join-this-windowed
     Source: KSTREAM-SOURCE-0000000017 (topics: [Join-right-repartition])
       --> Join-other-windowed
-    Processor: Join-other-windowed (stores: [Join-outer-other-join-store])
+    Processor: Join-other-windowed (stores: [KSTREAM-OUTEROTHER-0000000021-store])
       --> Join-outer-other-join
       <-- KSTREAM-SOURCE-0000000017
-    Processor: Join-this-windowed (stores: [Join-this-join-store])
+    Processor: Join-this-windowed (stores: [KSTREAM-JOINTHIS-0000000020-store])
       --> Join-this-join
       <-- KSTREAM-SOURCE-0000000014
-    Processor: Join-outer-other-join (stores: [Join-this-join-store])
+    Processor: Join-outer-other-join (stores: [KSTREAM-JOINTHIS-0000000020-store])
       --> Join-merge
       <-- Join-other-windowed
-    Processor: Join-this-join (stores: [Join-outer-other-join-store])
+    Processor: Join-this-join (stores: [KSTREAM-OUTEROTHER-0000000021-store])
       --> Join-merge
       <-- Join-this-windowed
     Processor: Join-merge (stores: [])

--- a/ksql-functional-tests/src/test/resources/expected_topology/5_3_0/joins_-_stream_stream_left_join_-_right_join_key_in_projection
+++ b/ksql-functional-tests/src/test/resources/expected_topology/5_3_0/joins_-_stream_stream_left_join_-_right_join_key_in_projection
@@ -92,16 +92,16 @@ Topologies:
       --> Join-this-windowed
     Source: KSTREAM-SOURCE-0000000017 (topics: [Join-right-repartition])
       --> Join-other-windowed
-    Processor: Join-other-windowed (stores: [Join-outer-other-join-store])
+    Processor: Join-other-windowed (stores: [KSTREAM-OUTEROTHER-0000000021-store])
       --> Join-outer-other-join
       <-- KSTREAM-SOURCE-0000000017
-    Processor: Join-this-windowed (stores: [Join-this-join-store])
+    Processor: Join-this-windowed (stores: [KSTREAM-JOINTHIS-0000000020-store])
       --> Join-this-join
       <-- KSTREAM-SOURCE-0000000014
-    Processor: Join-outer-other-join (stores: [Join-this-join-store])
+    Processor: Join-outer-other-join (stores: [KSTREAM-JOINTHIS-0000000020-store])
       --> Join-merge
       <-- Join-other-windowed
-    Processor: Join-this-join (stores: [Join-outer-other-join-store])
+    Processor: Join-this-join (stores: [KSTREAM-OUTEROTHER-0000000021-store])
       --> Join-merge
       <-- Join-this-windowed
     Processor: Join-merge (stores: [])

--- a/ksql-functional-tests/src/test/resources/expected_topology/5_3_0/joins_-_stream_stream_outer_join
+++ b/ksql-functional-tests/src/test/resources/expected_topology/5_3_0/joins_-_stream_stream_outer_join
@@ -56,16 +56,16 @@ Topologies:
     Processor: KSTREAM-TRANSFORMVALUES-0000000005 (stores: [])
       --> Join-other-windowed
       <-- KSTREAM-MAPVALUES-0000000004
-    Processor: Join-other-windowed (stores: [Join-outer-other-join-store])
+    Processor: Join-other-windowed (stores: [KSTREAM-OUTEROTHER-0000000009-store])
       --> Join-outer-other-join
       <-- KSTREAM-TRANSFORMVALUES-0000000005
-    Processor: Join-this-windowed (stores: [Join-outer-this-join-store])
+    Processor: Join-this-windowed (stores: [KSTREAM-OUTERTHIS-0000000008-store])
       --> Join-outer-this-join
       <-- KSTREAM-TRANSFORMVALUES-0000000002
-    Processor: Join-outer-other-join (stores: [Join-outer-this-join-store])
+    Processor: Join-outer-other-join (stores: [KSTREAM-OUTERTHIS-0000000008-store])
       --> Join-merge
       <-- Join-other-windowed
-    Processor: Join-outer-this-join (stores: [Join-outer-other-join-store])
+    Processor: Join-outer-this-join (stores: [KSTREAM-OUTEROTHER-0000000009-store])
       --> Join-merge
       <-- Join-this-windowed
     Processor: Join-merge (stores: [])

--- a/ksql-functional-tests/src/test/resources/expected_topology/5_3_0/joins_-_stream_stream_outer_join_-_right_join_key_in_projection
+++ b/ksql-functional-tests/src/test/resources/expected_topology/5_3_0/joins_-_stream_stream_outer_join_-_right_join_key_in_projection
@@ -56,16 +56,16 @@ Topologies:
     Processor: KSTREAM-TRANSFORMVALUES-0000000005 (stores: [])
       --> Join-other-windowed
       <-- KSTREAM-MAPVALUES-0000000004
-    Processor: Join-other-windowed (stores: [Join-outer-other-join-store])
+    Processor: Join-other-windowed (stores: [KSTREAM-OUTEROTHER-0000000009-store])
       --> Join-outer-other-join
       <-- KSTREAM-TRANSFORMVALUES-0000000005
-    Processor: Join-this-windowed (stores: [Join-outer-this-join-store])
+    Processor: Join-this-windowed (stores: [KSTREAM-OUTERTHIS-0000000008-store])
       --> Join-outer-this-join
       <-- KSTREAM-TRANSFORMVALUES-0000000002
-    Processor: Join-outer-other-join (stores: [Join-outer-this-join-store])
+    Processor: Join-outer-other-join (stores: [KSTREAM-OUTERTHIS-0000000008-store])
       --> Join-merge
       <-- Join-other-windowed
-    Processor: Join-outer-this-join (stores: [Join-outer-other-join-store])
+    Processor: Join-outer-this-join (stores: [KSTREAM-OUTEROTHER-0000000009-store])
       --> Join-merge
       <-- Join-this-windowed
     Processor: Join-merge (stores: [])

--- a/ksql-functional-tests/src/test/resources/query-validation-tests/joins.json
+++ b/ksql-functional-tests/src/test/resources/query-validation-tests/joins.json
@@ -1,8 +1,8 @@
 {
   "tests": [
     {
-      "comment": "re-enable after KIP-479 is merged",
-      "enabled": false,
+      "comment": "Tests covering the use of Joins",
+      "enabled": true,
       "name": "stream stream left join",
       "format": ["AVRO", "JSON"],
       "statements": [
@@ -85,8 +85,8 @@
       }
     },
     {
-      "comment": "re-enable after KIP-479 is merged",
-      "enabled": false,
+      "comment": "Tests covering the use of Joins",
+      "enabled": true,
       "name": "stream stream left join - rekey",
       "format": ["AVRO", "JSON"],
       "statements": [
@@ -264,8 +264,8 @@
       }
     },
     {
-      "comment": "re-enable after KIP-479 is merged",
-      "enabled": false,
+      "comment": "Tests covering the use of Joins",
+      "enabled": true,
       "name": "stream stream inner join",
       "format": ["AVRO", "JSON"],
       "statements": [
@@ -324,8 +324,8 @@
       }
     },
     {
-      "comment": "re-enable after KIP-479 is merged",
-      "enabled": false,
+      "comment": "Tests covering the use of Joins",
+      "enabled": true,
       "name": "stream stream inner join all left fields some right",
       "format": ["AVRO", "JSON"],
       "statements": [
@@ -382,8 +382,8 @@
       }
     },
     {
-      "comment": "re-enable after KIP-479 is merged",
-      "enabled": false,
+      "comment": "Tests covering the use of Joins",
+      "enabled": true,
       "name": "stream stream inner join all fields",
       "format": ["AVRO", "JSON"],
       "statements": [

--- a/ksql-functional-tests/src/test/resources/query-validation-tests/joins.json
+++ b/ksql-functional-tests/src/test/resources/query-validation-tests/joins.json
@@ -1,8 +1,6 @@
 {
   "tests": [
     {
-      "comment": "Tests covering the use of Joins",
-      "enabled": true,
       "name": "stream stream left join",
       "format": ["AVRO", "JSON"],
       "statements": [
@@ -85,8 +83,6 @@
       }
     },
     {
-      "comment": "Tests covering the use of Joins",
-      "enabled": true,
       "name": "stream stream left join - rekey",
       "format": ["AVRO", "JSON"],
       "statements": [
@@ -264,8 +260,6 @@
       }
     },
     {
-      "comment": "Tests covering the use of Joins",
-      "enabled": true,
       "name": "stream stream inner join",
       "format": ["AVRO", "JSON"],
       "statements": [
@@ -324,8 +318,6 @@
       }
     },
     {
-      "comment": "Tests covering the use of Joins",
-      "enabled": true,
       "name": "stream stream inner join all left fields some right",
       "format": ["AVRO", "JSON"],
       "statements": [
@@ -382,8 +374,6 @@
       }
     },
     {
-      "comment": "Tests covering the use of Joins",
-      "enabled": true,
       "name": "stream stream inner join all fields",
       "format": ["AVRO", "JSON"],
       "statements": [

--- a/ksql-streams/src/main/java/io/confluent/ksql/execution/streams/StreamJoinedFactory.java
+++ b/ksql-streams/src/main/java/io/confluent/ksql/execution/streams/StreamJoinedFactory.java
@@ -39,7 +39,7 @@ public interface StreamJoinedFactory {
             final String name,
             final String storeName) {
           return StreamJoined.with(keySerde, leftSerde, rightSerde)
-              .withName(name).withStoreName(storeName);
+              .withName(name);
         }
       };
     }


### PR DESCRIPTION
### Description 
This PR disables the naming of stores in join operations and reverts the named stores in the expected topologies files.  Note that in the future KSQL can easily re-enable the naming of state stores for joins.  After this PR is merged, we should be able to close #3364 

### Testing done 
Updated all expected topology files and ran all tests, everything passing.

### Reviewer checklist
- [ ] Ensure docs are updated if necessary. (eg. if a user visible feature is being added or changed).
- [ ] Ensure relevant issues are linked (description should include text like "Fixes #<issue number>")

