### PR TITLE
refactor: remove ExecutionContext.execute(stmt) completely

### DIFF
--- a/ksql-engine/src/main/java/io/confluent/ksql/KsqlExecutionContext.java
+++ b/ksql-engine/src/main/java/io/confluent/ksql/KsqlExecutionContext.java
@@ -89,13 +89,6 @@ public interface KsqlExecutionContext {
   PreparedStatement<?> prepare(ParsedStatement stmt);
 
   /**
-   * Executes a statement using the engine's primary service context.
-   *
-   * @see #execute(ServiceContext, ConfiguredStatement)
-   */
-  ExecuteResult execute(ConfiguredStatement<?> statement);
-
-  /**
    * Execute the supplied statement, updating the meta store and registering any query.
    *
    * <p>The statement must be executable. See {@link KsqlEngine#isExecutableStatement}.

--- a/ksql-engine/src/main/java/io/confluent/ksql/engine/KsqlEngine.java
+++ b/ksql-engine/src/main/java/io/confluent/ksql/engine/KsqlEngine.java
@@ -161,13 +161,6 @@ public class KsqlEngine implements KsqlExecutionContext, Closeable {
 
   @Override
   public ExecuteResult execute(
-      final ConfiguredStatement<?> statement
-  ) {
-    return execute(primaryContext.getServiceContext(), statement);
-  }
-
-  @Override
-  public ExecuteResult execute(
       final ServiceContext serviceContext,
       final ConfiguredStatement<?> statement
   ) {

--- a/ksql-engine/src/main/java/io/confluent/ksql/engine/SandboxedExecutionContext.java
+++ b/ksql-engine/src/main/java/io/confluent/ksql/engine/SandboxedExecutionContext.java
@@ -81,13 +81,6 @@ final class SandboxedExecutionContext implements KsqlExecutionContext {
 
   @Override
   public ExecuteResult execute(
-      final ConfiguredStatement<?> statement
-  ) {
-    return execute(engineContext.getServiceContext(), statement);
-  }
-
-  @Override
-  public ExecuteResult execute(
       final ServiceContext serviceContext,
       final ConfiguredStatement<?> statement
   ) {

--- a/ksql-engine/src/test/java/io/confluent/ksql/integration/JsonFormatTest.java
+++ b/ksql-engine/src/test/java/io/confluent/ksql/integration/JsonFormatTest.java
@@ -158,9 +158,12 @@ public class JsonFormatTest {
     final String messageStreamStr = String.format("CREATE STREAM %s (message varchar) WITH (value_format = 'json', "
         + "kafka_topic='%s');", messageLogStream, messageLogTopic);
 
-    KsqlEngineTestUtil.execute(ksqlEngine, ordersStreamStr, ksqlConfig, Collections.emptyMap());
-    KsqlEngineTestUtil.execute(ksqlEngine, usersTableStr, ksqlConfig, Collections.emptyMap());
-    KsqlEngineTestUtil.execute(ksqlEngine, messageStreamStr, ksqlConfig, Collections.emptyMap());
+    KsqlEngineTestUtil.execute(
+        serviceContext, ksqlEngine, ordersStreamStr, ksqlConfig, Collections.emptyMap());
+    KsqlEngineTestUtil.execute(
+        serviceContext, ksqlEngine, usersTableStr, ksqlConfig, Collections.emptyMap());
+    KsqlEngineTestUtil.execute(
+        serviceContext, ksqlEngine, messageStreamStr, ksqlConfig, Collections.emptyMap());
   }
 
   @After
@@ -238,7 +241,8 @@ public class JsonFormatTest {
 
   private void executePersistentQuery(final String queryString) {
     final QueryMetadata queryMetadata = KsqlEngineTestUtil
-        .execute(ksqlEngine, queryString, ksqlConfig, Collections.emptyMap()).get(0);
+        .execute(serviceContext, ksqlEngine, queryString, ksqlConfig, Collections.emptyMap())
+        .get(0);
 
     queryMetadata.start();
     queryId = ((PersistentQueryMetadata)queryMetadata).getQueryId();

--- a/ksql-engine/src/test/java/io/confluent/ksql/integration/SecureIntegrationTest.java
+++ b/ksql-engine/src/test/java/io/confluent/ksql/integration/SecureIntegrationTest.java
@@ -346,7 +346,13 @@ public class SecureIntegrationTest {
                                            + "kafka_topic='%s' , "
                                            + "key='ordertime');", INPUT_STREAM, INPUT_TOPIC);
 
-    KsqlEngineTestUtil.execute(ksqlEngine, ordersStreamStr, ksqlConfig, Collections.emptyMap());
+    KsqlEngineTestUtil.execute(
+        serviceContext,
+        ksqlEngine,
+        ordersStreamStr,
+        ksqlConfig,
+        Collections.emptyMap()
+    );
   }
 
   private void executePersistentQuery(final String queryString,
@@ -354,7 +360,7 @@ public class SecureIntegrationTest {
     final String query = String.format(queryString, params);
 
     final QueryMetadata queryMetadata = KsqlEngineTestUtil
-        .execute(ksqlEngine, query, ksqlConfig, Collections.emptyMap()).get(0);
+        .execute(serviceContext, ksqlEngine, query, ksqlConfig, Collections.emptyMap()).get(0);
 
     queryMetadata.start();
     queryId = ((PersistentQueryMetadata) queryMetadata).getQueryId();

--- a/ksql-engine/src/test/java/io/confluent/ksql/physical/PhysicalPlanBuilderTest.java
+++ b/ksql-engine/src/test/java/io/confluent/ksql/physical/PhysicalPlanBuilderTest.java
@@ -628,6 +628,7 @@ public class PhysicalPlanBuilderTest {
 
   private List<QueryMetadata> execute(final String sql) {
     return KsqlEngineTestUtil.execute(
+        serviceContext,
         ksqlEngine,
         sql,
         ksqlConfig,

--- a/ksql-rest-app/src/main/java/io/confluent/ksql/rest/server/KsqlRestApplication.java
+++ b/ksql-rest-app/src/main/java/io/confluent/ksql/rest/server/KsqlRestApplication.java
@@ -477,7 +477,7 @@ public final class KsqlRestApplication extends Application<KsqlRestConfig> imple
         restConfig.getCommandProducerProperties());
 
     final StatementExecutor statementExecutor =
-        new StatementExecutor(ksqlEngine, hybridQueryIdGenerator);
+        new StatementExecutor(serviceContext, ksqlEngine, hybridQueryIdGenerator);
 
     final RootDocument rootDocument = new RootDocument();
 

--- a/ksql-rest-app/src/test/java/io/confluent/ksql/rest/server/computation/RecoveryTest.java
+++ b/ksql-rest-app/src/test/java/io/confluent/ksql/rest/server/computation/RecoveryTest.java
@@ -186,7 +186,11 @@ public class RecoveryTest {
           }
       );
 
-      this.statementExecutor = new StatementExecutor(ksqlEngine, hybridQueryIdGenerator);
+      this.statementExecutor = new StatementExecutor(
+          serviceContext,
+          ksqlEngine,
+          hybridQueryIdGenerator
+      );
 
       this.commandRunner = new CommandRunner(
           statementExecutor,

--- a/ksql-rest-app/src/test/java/io/confluent/ksql/rest/server/resources/KsqlResourceTest.java
+++ b/ksql-rest-app/src/test/java/io/confluent/ksql/rest/server/resources/KsqlResourceTest.java
@@ -1845,7 +1845,7 @@ public class KsqlResourceTest {
 
   private Answer<?> executeAgainstEngine(final String sql) {
     return invocation -> {
-      KsqlEngineTestUtil.execute(ksqlEngine, sql, ksqlConfig, emptyMap());
+      KsqlEngineTestUtil.execute(serviceContext, ksqlEngine, sql, ksqlConfig, emptyMap());
       return null;
     };
   }
@@ -1889,8 +1889,13 @@ public class KsqlResourceTest {
   private List<PersistentQueryMetadata> createQueries(
       final String sql,
       final Map<String, Object> overriddenProperties) {
-    return KsqlEngineTestUtil.execute(ksqlEngine, sql, ksqlConfig, overriddenProperties)
-        .stream()
+    return KsqlEngineTestUtil.execute(
+        serviceContext,
+        ksqlEngine,
+        sql,
+        ksqlConfig,
+        overriddenProperties
+    ).stream()
         .map(PersistentQueryMetadata.class::cast)
         .collect(Collectors.toList());
   }
@@ -2009,7 +2014,13 @@ public class KsqlResourceTest {
       final Map<String, Object> overriddenProperties,
       final KsqlEntity entity) {
     final QueryMetadata queryMetadata = KsqlEngineTestUtil
-        .execute(ksqlEngine, ksqlQueryString, ksqlConfig, overriddenProperties).get(0);
+        .execute(
+            serviceContext,
+            ksqlEngine,
+            ksqlQueryString,
+            ksqlConfig,
+            overriddenProperties)
+        .get(0);
 
     validateQueryDescription(queryMetadata, overriddenProperties, entity);
   }


### PR DESCRIPTION
### Description 
This is part2 of https://github.com/confluentinc/ksql/pull/3530.

This PR replaces the rest of the classes using `ExecutionContext.execute(stmt)` for `ExecutionContext.execute(ctx, stmt)`, and finally removes the method from the `ExecutionContext` interface.

### Testing done 
Updated unit tests.

### Reviewer checklist
- [ ] Ensure docs are updated if necessary. (eg. if a user visible feature is being added or changed).
- [ ] Ensure relevant issues are linked (description should include text like "Fixes #<issue number>")

