### PR TITLE
feat: expose query status through EXPLAIN

### DIFF
--- a/ksql-cli/src/main/java/io/confluent/ksql/cli/console/Console.java
+++ b/ksql-cli/src/main/java/io/confluent/ksql/cli/console/Console.java
@@ -640,6 +640,9 @@ public class Console implements Closeable {
     if (query.getStatementText().length() > 0) {
       writer().println(String.format("%-20s : %s", "SQL", query.getStatementText()));
     }
+    if (query.getState().isPresent()) {
+      writer().println(String.format("%-20s : %s", "Status", query.getState().get()));
+    }
     writer().println();
     printSchema(query.getFields(), "");
     printQuerySources(query);

--- a/ksql-engine/src/main/java/io/confluent/ksql/util/PersistentQueryMetadata.java
+++ b/ksql-engine/src/main/java/io/confluent/ksql/util/PersistentQueryMetadata.java
@@ -25,7 +25,6 @@ import io.confluent.ksql.metastore.model.DataSource.DataSourceType;
 import io.confluent.ksql.name.SourceName;
 import io.confluent.ksql.query.QueryId;
 import io.confluent.ksql.schema.ksql.PhysicalSchema;
-import io.confluent.ksql.serde.Format;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
@@ -121,10 +120,6 @@ public class PersistentQueryMetadata extends QueryMetadata {
 
   public SourceName getSinkName() {
     return sinkName;
-  }
-
-  public Format getResultTopicFormat() {
-    return resultTopic.getValueFormat().getFormat();
   }
 
   public String getSchemasDescription() {

--- a/ksql-rest-app/src/main/java/io/confluent/ksql/rest/entity/QueryDescriptionFactory.java
+++ b/ksql-rest-app/src/main/java/io/confluent/ksql/rest/entity/QueryDescriptionFactory.java
@@ -22,6 +22,7 @@ import io.confluent.ksql.rest.util.EntityUtil;
 import io.confluent.ksql.util.PersistentQueryMetadata;
 import io.confluent.ksql.util.QueryMetadata;
 import java.util.Collections;
+import java.util.Optional;
 import java.util.Set;
 import java.util.stream.Collectors;
 
@@ -37,17 +38,26 @@ public final class QueryDescriptionFactory {
           persistentQuery.getQueryId(),
           persistentQuery,
           ImmutableSet.of(persistentQuery.getSinkName()),
-          false
+          false,
+          Optional.of(persistentQuery.getState())
       );
     }
-    return create(new QueryId(""), queryMetadata, Collections.emptySet(), true);
+
+    return create(
+        new QueryId(""),
+        queryMetadata,
+        Collections.emptySet(),
+        true,
+        Optional.empty()
+    );
   }
 
   private static QueryDescription create(
       final QueryId id,
       final QueryMetadata queryMetadata,
       final Set<SourceName> sinks,
-      final boolean valueSchemaOnly
+      final boolean valueSchemaOnly,
+      final Optional<String> state
   ) {
     return new QueryDescription(
         id,
@@ -57,8 +67,8 @@ public final class QueryDescriptionFactory {
         sinks.stream().map(SourceName::name).collect(Collectors.toSet()),
         queryMetadata.getTopologyDescription(),
         queryMetadata.getExecutionPlan(),
-        queryMetadata.getOverriddenProperties()
+        queryMetadata.getOverriddenProperties(),
+        state
     );
   }
-
 }

--- a/ksql-rest-app/src/test/java/io/confluent/ksql/rest/server/execution/ExplainExecutorTest.java
+++ b/ksql-rest-app/src/test/java/io/confluent/ksql/rest/server/execution/ExplainExecutorTest.java
@@ -44,14 +44,17 @@ import org.mockito.junit.MockitoJUnitRunner;
 @RunWith(MockitoJUnitRunner.class)
 public class ExplainExecutorTest {
 
-  @Rule public final TemporaryEngine engine = new TemporaryEngine();
-  @Rule public ExpectedException expectedException = ExpectedException.none();
+  @Rule
+  public final TemporaryEngine engine = new TemporaryEngine();
+  @Rule
+  public ExpectedException expectedException = ExpectedException.none();
 
   @Test
   public void shouldExplainQueryId() {
     // Given:
     final ConfiguredStatement<?> explain = engine.configure("EXPLAIN id;");
     final PersistentQueryMetadata metadata = givenPersistentQuery("id");
+    when(metadata.getState()).thenReturn("Running");
 
     KsqlEngine engine = mock(KsqlEngine.class);
     when(engine.getPersistentQuery(metadata.getQueryId())).thenReturn(Optional.of(metadata));
@@ -67,7 +70,6 @@ public class ExplainExecutorTest {
     // Then:
     assertThat(query.getQueryDescription(), equalTo(QueryDescriptionFactory.forQueryMetadata(metadata)));
   }
-
 
   @Test
   public void shouldExplainPersistentStatement() {

--- a/ksql-rest-app/src/test/java/io/confluent/ksql/rest/server/execution/ListQueriesExecutorTest.java
+++ b/ksql-rest-app/src/test/java/io/confluent/ksql/rest/server/execution/ListQueriesExecutorTest.java
@@ -87,6 +87,7 @@ public class ListQueriesExecutorTest {
     // Given
     final ConfiguredStatement<?> showQueries = engine.configure("SHOW QUERIES EXTENDED;");
     final PersistentQueryMetadata metadata = givenPersistentQuery("id");
+    when(metadata.getState()).thenReturn("Running");
 
     final KsqlEngine engine = mock(KsqlEngine.class);
     when(engine.getPersistentQueries()).thenReturn(ImmutableList.of(metadata));

--- a/ksql-rest-model/src/main/java/io/confluent/ksql/rest/entity/QueryDescription.java
+++ b/ksql-rest-model/src/main/java/io/confluent/ksql/rest/entity/QueryDescription.java
@@ -23,6 +23,7 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
+import java.util.Optional;
 import java.util.Set;
 
 @JsonIgnoreProperties(ignoreUnknown = true)
@@ -36,7 +37,9 @@ public class QueryDescription {
   private final String topology;
   private final String executionPlan;
   private final Map<String, Object> overriddenProperties;
+  private final Optional<String> state;
 
+  @SuppressWarnings("WeakerAccess") // Invoked via reflection
   @JsonCreator
   public QueryDescription(
       @JsonProperty("id") final QueryId id,
@@ -46,7 +49,8 @@ public class QueryDescription {
       @JsonProperty("sinks") final Set<String> sinks,
       @JsonProperty("topology") final String topology,
       @JsonProperty("executionPlan") final String executionPlan,
-      @JsonProperty("overriddenProperties") final Map<String, Object> overriddenProperties
+      @JsonProperty("overriddenProperties") final Map<String, Object> overriddenProperties,
+      @JsonProperty("state") final Optional<String> state
   ) {
     this.id = id;
     this.statementText = statementText;
@@ -56,6 +60,7 @@ public class QueryDescription {
     this.topology = topology;
     this.executionPlan = executionPlan;
     this.overriddenProperties = Collections.unmodifiableMap(overriddenProperties);
+    this.state = Objects.requireNonNull(state, "state");
   }
 
   public QueryId getId() {
@@ -90,8 +95,14 @@ public class QueryDescription {
     return overriddenProperties;
   }
 
+  public Optional<String> getState() {
+    return state;
+  }
+
+  // CHECKSTYLE_RULES.OFF: CyclomaticComplexity
   @Override
   public boolean equals(final Object o) {
+    // CHECKSTYLE_RULES.ON: CyclomaticComplexity
     if (this == o) {
       return true;
     }
@@ -106,12 +117,22 @@ public class QueryDescription {
         && Objects.equals(executionPlan, that.executionPlan)
         && Objects.equals(sources, that.sources)
         && Objects.equals(sinks, that.sinks)
-        && Objects.equals(overriddenProperties, that.overriddenProperties);
+        && Objects.equals(overriddenProperties, that.overriddenProperties)
+        && Objects.equals(state, that.state);
   }
 
   @Override
   public int hashCode() {
     return Objects.hash(
-        id, statementText, fields, topology, executionPlan, sources, sinks, overriddenProperties);
+        id,
+        statementText,
+        fields,
+        topology,
+        executionPlan,
+        sources,
+        sinks,
+        overriddenProperties,
+        state
+    );
   }
 }


### PR DESCRIPTION
### Description 

Fixes #3208

With this commit the status of any persistent query is exposed as part of the response from `EXPLAIN <some-query-id>;`

For example,

```
ksql>EXPLAIN CSAS_ID_0_1;

ID                   : CSAS_ID_0_1
SQL                  : CREATE STREAM ID_0 WITH (KAFKA_TOPIC='ID_0', PARTITIONS=1, REPLICAS=1) AS SELECT *
FROM ORDER_KSTREAM ORDER_KSTREAM
EMIT CHANGES;
Status               : REBALANCING

 Field       | Type
-----------------------------------------
 ROWTIME     | BIGINT           (system)
 ROWKEY      | VARCHAR(STRING)  (system)
 ORDERTIME   | BIGINT
 ORDERID     | VARCHAR(STRING)
 ITEMID      | VARCHAR(STRING)
 ORDERUNITS  | DOUBLE
 TIMESTAMP   | VARCHAR(STRING)
 PRICEARRAY  | ARRAY<DOUBLE>
 KEYVALUEMAP | MAP<STRING, DOUBLE>
-----------------------------------------
...
```

Note the new `Status               : REBALANCING` part.

### Testing done 

manual + suitable tests added

### Reviewer checklist
- [ ] Ensure docs are updated if necessary. (eg. if a user visible feature is being added or changed).
- [ ] Ensure relevant issues are linked (description should include text like "Fixes #<issue number>")

