### PR TITLE
test: add test covering use of KS caching to avoid intermediate results (DO NOT REVIEW)

### DIFF
--- a/ksql-functional-tests/src/test/resources/query-validation-tests/group-by.json
+++ b/ksql-functional-tests/src/test/resources/query-validation-tests/group-by.json
@@ -203,6 +203,29 @@
       ]
     },
     {
+      "name": "fields (table->table) with suppression through config",
+      "statements": [
+        "CREATE TABLE TEST (AccountId INT, Amount DOUBLE) WITH (kafka_topic='input_topic', value_format='DELIMITED');",
+        "CREATE TABLE OUTPUT AS SELECT COUNT(1), SUM(Amount) FROM TEST GROUP BY AccountId;"
+      ],
+      "properties": {
+        "ksql.streams.cache.max.bytes.buffering": 10000000
+      },
+      "inputs": [
+        {"topic": "input_topic", "key": 1, "value": "1,106.0"},
+        {"topic": "input_topic", "key": 1, "value": "1,107.0"},
+        {"topic": "input_topic", "key": 2, "value": "1,10.0"},
+        {"topic": "input_topic", "key": 2, "value": "2,10.0"}
+      ],
+      "outputs": [
+        {"topic": "OUTPUT", "key": "1", "value": "1,106.0"},
+        {"topic": "OUTPUT", "key": "1", "value": "1,107.0"},
+        {"topic": "OUTPUT", "key": "1", "value": "2,117.0"},
+        {"topic": "OUTPUT", "key": "1", "value": "1,107.0"},
+        {"topic": "OUTPUT", "key": "2", "value": "1,10.0"}
+      ]
+    },
+    {
       "name": "field with re-key (stream->table)",
       "statements": [
         "CREATE STREAM TEST (data VARCHAR) WITH (kafka_topic='test_topic', value_format='DELIMITED');",


### PR DESCRIPTION
### Description 

Add test highlighting that it looks like setting `cache.max.bytes.buffering` on KS does not suppress intermediate results.

The new test fails.  I've confirmed that `StreamsConfig` is indeed created with a non-zero value for `cache.max.bytes.buffering`.

Expected outcome is that the output is as described in the new test case.

Actual outcome is that the output still contains the intermediate result:

```
Actual records: 
<1, 1,106.0> with timestamp=0 
<1, 0,0.0> with timestamp=0        <-- unexpected
<1, 1,107.0> with timestamp=0 
<1, 2,117.0> with timestamp=0 
<1, 1,107.0> with timestamp=0 
<2, 1,10.0> with timestamp=0 
```

