### PR TITLE
fix: do not allow inserts into tables with null key

### DIFF
--- a/ksql-engine/src/main/java/io/confluent/ksql/engine/InsertValuesExecutor.java
+++ b/ksql-engine/src/main/java/io/confluent/ksql/engine/InsertValuesExecutor.java
@@ -346,13 +346,6 @@ public class InsertValuesExecutor {
     }
   }
 
-  private static void throwOnTableMissingRowKey(final Map<ColumnName, ?> values) {
-    final Object rowKeyValue = values.get(SchemaUtil.ROWKEY_NAME);
-    if (rowKeyValue == null) {
-      throw new KsqlException("Value for ROWKEY is required for tables");
-    }
-  }
-
   private static SqlType columnType(final ColumnName column, final LogicalSchema schema) {
     return schema
         .findColumn(ColumnRef.withoutSource(column))


### PR DESCRIPTION
### Description 

Fixes: #3021

Tables do not support rows with `null` keys, so we should not allow users to insert rows with `null` keys.

### Testing done 

tests added

### Reviewer checklist
- [ ] Ensure docs are updated if necessary. (eg. if a user visible feature is being added or changed).
- [ ] Ensure relevant issues are linked (description should include text like "Fixes #<issue number>")

