### PR TITLE
fix: Created new test for running topology generation manually from t…

### DIFF
--- a/ksql-functional-tests/src/test/java/io/confluent/ksql/test/ManualTopologyFileGeneratorTest.java
+++ b/ksql-functional-tests/src/test/java/io/confluent/ksql/test/ManualTopologyFileGeneratorTest.java
@@ -1,0 +1,33 @@
+/*
+ * Copyright 2019 Confluent Inc.
+ *
+ * Licensed under the Confluent Community License (the "License"); you may not use
+ * this file except in compliance with the License.  You may obtain a copy of the
+ * License at
+ *
+ * http://www.confluent.io/confluent-community-license
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package io.confluent.ksql.test;
+
+import org.junit.Ignore;
+import org.junit.Test;
+
+/**
+ * This test exists only to be able to generate topologies as part of the release process
+ * It can be run manually from the IDE
+ * It is deliberately excluded from the test suite
+ */
+@Ignore
+public final class ManualTopologyFileGeneratorTest {
+
+    @Test
+    public void manuallyGenerateTopologies() throws Exception {
+        TopologyFileGenerator.generateTopologies();
+    }
+}

--- a/ksql-functional-tests/src/test/java/io/confluent/ksql/test/TopologyFileGenerator.java
+++ b/ksql-functional-tests/src/test/java/io/confluent/ksql/test/TopologyFileGenerator.java
@@ -86,10 +86,6 @@ public final class TopologyFileGenerator {
     private TopologyFileGenerator() {
     }
 
-    public static void main(final String[] args) throws Exception {
-        generateTopologies(findBaseDir());
-    }
-
     static Path findBaseDir() {
         Path path = Paths.get("./ksql-functional-tests");
         if (Files.exists(path)) {
@@ -102,6 +98,10 @@ public final class TopologyFileGenerator {
         throw new RuntimeException("Failed to determine location of expected topologies directory. "
             + "App should be run with current directory set to either the root of the repo or the "
             + "root of the ksql-functional-tests module");
+    }
+
+    static void generateTopologies() throws Exception {
+        generateTopologies(findBaseDir());
     }
 
     static void generateTopologies(final Path base) throws Exception {


### PR DESCRIPTION
### Description 

Fixes https://github.com/confluentinc/ksql/issues/3607

TopologyFileGenerator should only be run as a test as it requires test dependencies.

This PR removes the main() from the class to avoid temptation to run it directly in the IDE.

A new ignore manually test is added which should be run manually to generate the topology stuff.

### Testing done 

N/A

### Reviewer checklist
- [ ] Ensure docs are updated if necessary. (eg. if a user visible feature is being added or changed).
- [ ] Ensure relevant issues are linked (description should include text like "Fixes #<issue number>")

