### PR TITLE
test: extend test framework to allow bounds on KSQL version

### DIFF
--- a/ksql-functional-tests/README.md
+++ b/ksql-functional-tests/README.md
@@ -88,6 +88,10 @@ The following is a template test file:
     {
       "name": "test using insert statements",
       "description": "an example positive test that uses insert into values statements instead of inputs",
+      "versions" : {
+        "min": "5.0",
+        "max": "5.4.1"
+      },
       "statements": [
         "CREATE STREAM test (ID name) WITH (kafka_topic='input_topic', value_format='JSON');",
         "INSERT INTO test (name, number) VALUES ('foo', 45)",
@@ -126,6 +130,7 @@ Each test case can have the following attributes:
 |------------------|:------------|
 | name             | (Required) The name of the test case as will be displayed in IDEs and Logs. This would be the function name in a JUnit test |
 | description      | (Optional) A description of what the test case is testing. Not used or displayed anywhere |
+| versions         | (Optional) A object describing the min and/or max version of KSQL the test is valid for. (See below for more info) |
 | format           | (Optional) An array of multiple different formats to run the test case as, e.g. AVRO, JSON, DELIMITED. (See below for more info) |
 | statements       | (Required) The list of statements to execute as this test case |
 | properties       | (Optional) A map of property name to value. Can contain any valid Ksql config. The config is passed to the engine when executing the statements in the test case |
@@ -134,6 +139,37 @@ Each test case can have the following attributes:
 | outputs          | (Required if `expectedException` not supplied) The set of output messages expected in the output topic(s), (See below for more info) |
 | expectedException| (Required in `inputs` and `outputs` not supplied) The exception that should be thrown when executing the supplied statements, (See below for more info) |
 | post             | (Optional) Defines post conditions that must exist after the statements have run, (See below for more info) |
+
+### Versions
+A test can can optionally supply the bounds on Ksql version that the test is valid for.
+
+For example:
+```json
+[{
+  "name": "test only valid before version 5.4",
+  "versions": {
+     "max": "5.3"  
+  }  
+},
+{
+  "name": "test only valid for versions at or after 5.4",
+  "versions": {
+     "max": "5.4"  
+  }  
+},
+{
+  "name": "test only valid between versions 5.2 and 5.4",
+  "versions": {
+     "min": "5.2",
+     "max": "5.4"  
+  }  
+}]
+```
+
+| Attribute | Description |
+|-----------|:------------|
+| min       | (Optional) lower bound on version, (inclusive) |
+| max       | (Optional) upper bound on version, (inclusive) |
 
 ### Formats
 A test case can optionally supply an array of formats to run the test case as.

--- a/ksql-functional-tests/src/main/java/io/confluent/ksql/test/model/TestCaseNode.java
+++ b/ksql-functional-tests/src/main/java/io/confluent/ksql/test/model/TestCaseNode.java
@@ -16,6 +16,8 @@
 
 package io.confluent.ksql.test.model;
 
+import static java.util.Objects.requireNonNull;
+
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.google.common.collect.ImmutableList;
@@ -33,6 +35,7 @@ import java.util.Optional;
 public final class TestCaseNode {
 
   private final String name;
+  private final VersionBoundsNode versionBounds;
   private final List<String> formats;
   private final List<RecordNode> inputs;
   private final List<RecordNode> outputs;
@@ -43,8 +46,10 @@ public final class TestCaseNode {
   private final Optional<PostConditionsNode> postConditions;
   private final boolean enabled;
 
+  // CHECKSTYLE_RULES.OFF: ParameterNumberCheck
   public TestCaseNode(
       @JsonProperty("name") final String name,
+      @JsonProperty("versions") final Optional<VersionBoundsNode> versionBounds,
       @JsonProperty("format") final List<String> formats,
       @JsonProperty("inputs") final List<RecordNode> inputs,
       @JsonProperty("outputs") final List<RecordNode> outputs,
@@ -55,8 +60,10 @@ public final class TestCaseNode {
       @JsonProperty("post") final PostConditionsNode postConditions,
       @JsonProperty("enabled") final Boolean enabled
   ) {
+    // CHECKSTYLE_RULES.ON: ParameterNumberCheck
     this.name = name == null ? "" : name;
     this.formats = immutableCopyOf(formats);
+    this.versionBounds = requireNonNull(versionBounds).orElse(VersionBoundsNode.allVersions());
     this.statements = immutableCopyOf(statements);
     this.inputs = immutableCopyOf(inputs);
     this.outputs = immutableCopyOf(outputs);
@@ -75,6 +82,10 @@ public final class TestCaseNode {
 
   public String name() {
     return name;
+  }
+
+  public VersionBoundsNode versionBounds() {
+    return versionBounds;
   }
 
   public List<String> formats() {

--- a/ksql-functional-tests/src/main/java/io/confluent/ksql/test/model/VersionBoundsNode.java
+++ b/ksql-functional-tests/src/main/java/io/confluent/ksql/test/model/VersionBoundsNode.java
@@ -1,0 +1,50 @@
+/*
+ * Copyright 2019 Confluent Inc.
+ *
+ * Licensed under the Confluent Community License (the "License"); you may not use
+ * this file except in compliance with the License.  You may obtain a copy of the
+ * License at
+ *
+ * http://www.confluent.io/confluent-community-license
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package io.confluent.ksql.test.model;
+
+import static java.util.Objects.requireNonNull;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import io.confluent.ksql.test.tools.VersionBounds;
+import java.util.Optional;
+
+/**
+ * JSON serializable Pojo controlling the version bounds a test if valid for
+ */
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class VersionBoundsNode {
+
+  private final Optional<KsqlVersion> min;
+  private final Optional<KsqlVersion> max;
+
+  @SuppressWarnings("WeakerAccess") // Invoked via reflection
+  public VersionBoundsNode(
+      @JsonProperty("min") final Optional<String> min,
+      @JsonProperty("max") final Optional<String> max
+  ) {
+    this.min = requireNonNull(min, "min").map(KsqlVersion::parse);
+    this.max = requireNonNull(max, "max").map(KsqlVersion::parse);
+  }
+
+  static VersionBoundsNode allVersions() {
+    return new VersionBoundsNode(Optional.empty(), Optional.empty());
+  }
+
+  public VersionBounds build() {
+    return VersionBounds.of(min, max);
+  }
+}

--- a/ksql-functional-tests/src/main/java/io/confluent/ksql/test/tools/KsqlTestingTool.java
+++ b/ksql-functional-tests/src/main/java/io/confluent/ksql/test/tools/KsqlTestingTool.java
@@ -32,6 +32,7 @@ import java.nio.charset.StandardCharsets;
 import java.nio.file.Paths;
 import java.util.Collections;
 import java.util.List;
+import java.util.Optional;
 import java.util.stream.Collectors;
 
 public final class KsqlTestingTool {
@@ -42,7 +43,7 @@ public final class KsqlTestingTool {
 
   private static final ObjectMapper OBJECT_MAPPER = JsonMapper.INSTANCE.mapper;
 
-  public static void main(final String[] args) throws Exception {
+  public static void main(final String[] args) {
 
     try {
       final TestOptions testOptions = TestOptions.parse(args);
@@ -110,6 +111,7 @@ public final class KsqlTestingTool {
 
     final TestCaseNode testCaseNode = new TestCaseNode(
         "KSQL_Test",
+        Optional.empty(),
         null,
         (inputFile == null) ? null : inputRecordNodes.getInputRecords(),
         outRecordNodes.getOutputRecords(),

--- a/ksql-functional-tests/src/main/java/io/confluent/ksql/test/tools/TestCaseBuilder.java
+++ b/ksql-functional-tests/src/main/java/io/confluent/ksql/test/tools/TestCaseBuilder.java
@@ -66,6 +66,8 @@ public final class TestCaseBuilder {
     );
 
     try {
+      final VersionBounds versionBounds = test.versionBounds().build();
+
       final List<String> statements = TestCaseBuilderUtil.buildStatements(
           test.statements(),
           explicitFormat
@@ -99,7 +101,7 @@ public final class TestCaseBuilder {
       return new TestCase(
           testPath,
           testName,
-          Optional.empty(),
+          versionBounds,
           test.properties(),
           topics.values(),
           inputRecords,

--- a/ksql-functional-tests/src/main/java/io/confluent/ksql/test/tools/VersionBounds.java
+++ b/ksql-functional-tests/src/main/java/io/confluent/ksql/test/tools/VersionBounds.java
@@ -1,0 +1,65 @@
+/*
+ * Copyright 2019 Confluent Inc.
+ *
+ * Licensed under the Confluent Community License (the "License"); you may not use
+ * this file except in compliance with the License.  You may obtain a copy of the
+ * License at
+ *
+ * http://www.confluent.io/confluent-community-license
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package io.confluent.ksql.test.tools;
+
+import com.google.common.collect.Range;
+import com.google.errorprone.annotations.Immutable;
+import io.confluent.ksql.test.model.KsqlVersion;
+import java.util.Optional;
+
+/**
+ * Pojo for holding the bounds for which a test is valid
+ */
+@Immutable
+public class VersionBounds {
+
+  private final Range<KsqlVersion> range;
+
+  public static VersionBounds of(
+      final Optional<KsqlVersion> min,
+      final Optional<KsqlVersion> max
+  ) {
+    return new VersionBounds(min, max);
+  }
+
+  public static VersionBounds allVersions() {
+    return of(Optional.empty(), Optional.empty());
+  }
+
+  private VersionBounds(
+      final Optional<KsqlVersion> min,
+      final Optional<KsqlVersion> max
+  ) {
+    if (min.isPresent() && max.isPresent()) {
+      this.range = Range.closed(min.get(), max.get());
+    } else if (!min.isPresent() && !max.isPresent()) {
+      this.range = Range.all();
+    } else {
+      this.range = min
+          .map(Range::atLeast)
+          .orElseGet(() -> Range.atMost(max.get()));
+    }
+  }
+
+  public boolean contains(final KsqlVersion version) {
+    return range.contains(version);
+  }
+
+  @Override
+  public String toString() {
+    return range.toString();
+  }
+}

--- a/ksql-functional-tests/src/main/java/io/confluent/ksql/test/tools/VersionBounds.java
+++ b/ksql-functional-tests/src/main/java/io/confluent/ksql/test/tools/VersionBounds.java
@@ -24,7 +24,7 @@ import java.util.Optional;
  * Pojo for holding the bounds for which a test is valid
  */
 @Immutable
-public class VersionBounds {
+public final class VersionBounds {
 
   private final Range<KsqlVersion> range;
 

--- a/ksql-functional-tests/src/main/java/io/confluent/ksql/test/tools/VersionedTest.java
+++ b/ksql-functional-tests/src/main/java/io/confluent/ksql/test/tools/VersionedTest.java
@@ -19,7 +19,7 @@ import io.confluent.ksql.test.model.KsqlVersion;
 
 public interface VersionedTest extends Test {
 
-  VersionedTest withVersion(KsqlVersion version);
+  VersionBounds getVersionBounds();
 
-  void setExpectedTopology(TopologyAndConfigs expectedTopology);
-}  
+  VersionedTest withExpectedTopology(KsqlVersion version, TopologyAndConfigs expectedTopology);
+}

--- a/ksql-functional-tests/src/test/java/io/confluent/ksql/test/SchemaTranslationTest.java
+++ b/ksql-functional-tests/src/test/java/io/confluent/ksql/test/SchemaTranslationTest.java
@@ -18,6 +18,7 @@ import io.confluent.ksql.test.serde.string.StringSerdeSupplier;
 import io.confluent.ksql.test.tools.Record;
 import io.confluent.ksql.test.tools.TestCase;
 import io.confluent.ksql.test.tools.Topic;
+import io.confluent.ksql.test.tools.VersionBounds;
 import io.confluent.ksql.test.tools.conditions.PostConditions;
 import io.confluent.ksql.test.tools.exceptions.MissingFieldException;
 import java.nio.file.Path;
@@ -177,7 +178,7 @@ public class SchemaTranslationTest {
         return Stream.of(new TestCase(
             testPath,
             name,
-            Optional.empty(),
+            VersionBounds.allVersions(),
             Collections.emptyMap(),
             ImmutableList.of(srcTopic, OUTPUT_TOPIC),
             inputRecords,

--- a/ksql-functional-tests/src/test/java/io/confluent/ksql/test/model/KsqlVersionTest.java
+++ b/ksql-functional-tests/src/test/java/io/confluent/ksql/test/model/KsqlVersionTest.java
@@ -1,0 +1,65 @@
+/*
+ * Copyright 2019 Confluent Inc.
+ *
+ * Licensed under the Confluent Community License (the "License"); you may not use
+ * this file except in compliance with the License.  You may obtain a copy of the
+ * License at
+ *
+ * http://www.confluent.io/confluent-community-license
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package io.confluent.ksql.test.model;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+
+import io.confluent.ksql.model.SemanticVersion;
+import org.junit.Test;
+
+public class KsqlVersionTest {
+
+  @Test
+  public void shouldParseMajorMinor() {
+    // When:
+    final KsqlVersion result = KsqlVersion.parse("5.4");
+
+    // Then:
+    assertThat(result.getName(), is("5.4"));
+    assertThat(result.getVersion(), is(SemanticVersion.of(5, 4, 0)));
+  }
+
+  @Test
+  public void shouldParseMajorMinorSnapshot() {
+    // When:
+    final KsqlVersion result = KsqlVersion.parse("5.4-SNAPSHOT");
+
+    // Then:
+    assertThat(result.getName(), is("5.4-SNAPSHOT"));
+    assertThat(result.getVersion(), is(SemanticVersion.of(5, 4, 0)));
+  }
+
+  @Test
+  public void shouldParseMajorMinorPoint() {
+    // When:
+    final KsqlVersion result = KsqlVersion.parse("5.4.1");
+
+    // Then:
+    assertThat(result.getName(), is("5.4.1"));
+    assertThat(result.getVersion(), is(SemanticVersion.of(5, 4, 1)));
+  }
+
+  @Test
+  public void shouldParseMajorMinorPointSnapshot() {
+    // When:
+    final KsqlVersion result = KsqlVersion.parse("5.4.1-SNAPSHOT");
+
+    // Then:
+    assertThat(result.getName(), is("5.4.1-SNAPSHOT"));
+    assertThat(result.getVersion(), is(SemanticVersion.of(5, 4, 1)));
+  }
+}

--- a/ksql-functional-tests/src/test/resources/query-validation-tests/joins.json
+++ b/ksql-functional-tests/src/test/resources/query-validation-tests/joins.json
@@ -375,6 +375,9 @@
     },
     {
       "name": "stream stream inner join all fields",
+      "versions": {
+        "max": "5.3"
+      },
       "format": ["AVRO", "JSON"],
       "statements": [
         "CREATE STREAM TEST (ID bigint, NAME varchar) WITH (kafka_topic='left_topic', value_format='{FORMAT}', key='ID');",
@@ -1188,6 +1191,9 @@
         "There are explicit tests for JSON and AVRO, rather than making use of the 'format's node,",
         "as the internal topic schema differs between the formats"
       ],
+      "versions": {
+        "max": "5.3"
+      },
       "statements": [
         "CREATE STREAM TEST (ID bigint, NAME varchar, VALUE bigint) WITH (kafka_topic='test_topic', value_format='JSON', key='ID');",
         "CREATE TABLE TEST_TABLE (ID bigint, F1 varchar, F2 bigint) WITH (kafka_topic='test_table', value_format='JSON', key='ID');",
@@ -1232,6 +1238,9 @@
         "There are explicit tests for JSON and AVRO, rather than making use of the 'format's node,",
         "as the internal topic schema differs between the formats"
       ],
+      "versions": {
+        "max": "5.3"
+      },
       "statements": [
         "CREATE STREAM TEST (ID bigint, NAME varchar, VALUE bigint) WITH (kafka_topic='test_topic', value_format='AVRO', key='ID');",
         "CREATE TABLE TEST_TABLE (ID bigint, F1 varchar, F2 bigint) WITH (kafka_topic='test_table', value_format='AVRO', key='ID');",


### PR DESCRIPTION
### Description 
This commit allows a new `versions` element to be added to test cases that controls the `min` and `max` versions of KSQL the test case is valid for.

This allows us to make known backwards-compatible changes to KSQL that would previously have caused an existing test to fail, e.g. changing the name of the internal topics.  With this commit we can mark the old test as only valid up to the last version and create a new version of the test for, with a min version, to test versions going forward

e.g.

```json
[{
      "name": "stream stream left join",
      "versions": {
        "max": "5.3"
      },
      "statements": [
        ...
      ],
      "inputs": [
        ...
      ],
      "outputs": [
        {"topic": "_confluent-ksql-some.ksql.service.idquery_CSAS_LEFT_OUTER_JOIN_0-KSTREAM-JOINTHIS-0000000008-store-changelog", "value": {"ROWTIME": 0, "ROWKEY": "0", "ID": 0, "NAME": "zero", "VALUE": 0}, "timestamp": 0},
        {"topic": "LEFT_OUTER_JOIN", "key": 0, "value": {"T_ID": 0, "NAME": "zero", "VALUE": 0, "F1": null, "F2": null}, "timestamp": 0}
      ]
    },
    {
      "name": "stream stream left join post v5.4",
      "versions": {
        "min": "5.4"
      },
      "statements": [
        ... same statements
      ],
      "inputs": [
        ... same inputs
      ],
      "outputs": [
        {"topic": "different-internal-topic-store-changelog", "value": {"ROWTIME": 0, "ROWKEY": "0", "ID": 0, "NAME": "zero", "VALUE": 0}, "timestamp": 0},
        {"topic": "LEFT_OUTER_JOIN", "key": 0, "value": {"T_ID": 0, "NAME": "zero", "VALUE": 0, "F1": null, "F2": null}, "timestamp": 0}
      ]
    }]
```

### Reviewing notes:
I think this order of reviewing makes sense:
1. `VersionBoundsNode` is the JSON pojo used to deserialize the new `versions` node
1. `VersionBounds` is the immutable pojo that is built from the node, (following existing pattern).
1. `TestCaseNode` now accepts an optional `VersionBoundsNode`.
1. `TestCase`, which is built from `TestCaseNode`, now expects a `VersionBounds`
1. `TestCase` no longer takes the `ksqlVersion` param, as it wasn't used and I've simplified the `VersionedTestCase` interface to match our usage of it.
1. I've extended `SemanticVersion` and `KsqlVersion` to help with storing, comparing and parsing versions.
1. The magic happens in `ExpectedTopologiesTestLoader`, which now does not add test cases where the versions aren't within bounds.

### Testing done 
usual

### Reviewer checklist
- [ ] Ensure docs are updated if necessary. (eg. if a user visible feature is being added or changed).
- [ ] Ensure relevant issues are linked (description should include text like "Fixes #<issue number>")

