### PR TITLE
fix: validator to check actual java type matches supplied schema type

### DIFF
--- a/ksql-engine/src/main/java/io/confluent/ksql/function/FunctionValidator.java
+++ b/ksql-engine/src/main/java/io/confluent/ksql/function/FunctionValidator.java
@@ -1,0 +1,155 @@
+/*
+ * Copyright 2019 Confluent Inc.
+ *
+ * Licensed under the Confluent Community License (the "License"); you may not use
+ * this file except in compliance with the License.  You may obtain a copy of the
+ * License at
+ *
+ * http://www.confluent.io/confluent-community-license
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package io.confluent.ksql.function;
+
+import io.confluent.ksql.schema.ksql.SchemaConverters;
+import io.confluent.ksql.schema.ksql.types.SqlArray;
+import io.confluent.ksql.schema.ksql.types.SqlMap;
+import io.confluent.ksql.schema.ksql.types.SqlType;
+import io.confluent.ksql.util.KsqlException;
+import java.lang.reflect.GenericArrayType;
+import java.lang.reflect.ParameterizedType;
+import java.lang.reflect.Type;
+import java.lang.reflect.TypeVariable;
+import java.lang.reflect.WildcardType;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+
+/**
+ * Validates UDF/UDAFs.
+ */
+final class FunctionValidator {
+
+  void validateReturnType(final Type actualType, final SqlType expectedType) {
+    try {
+      validateType(actualType, expectedType);
+    } catch (final Exception e) {
+      throw new KsqlException(
+          "Return type does not match supplied "
+              + "schema: " + expectedType + ". " + e.getMessage(),
+          e
+      );
+    }
+  }
+
+  private void validateType(final Type actualType, final SqlType expectedType) {
+    validateActualType(actualType);
+
+    switch (expectedType.baseType()) {
+      case ARRAY:
+        validateArrayReturnType(actualType, (SqlArray) expectedType);
+        return;
+      case MAP:
+        validateMapReturnType(actualType, (SqlMap) expectedType);
+        return;
+      default:
+        final Class<?> expectedJavaType = SchemaConverters.sqlToJavaConverter()
+            .toJavaType(expectedType.baseType());
+
+        if (!actualType.equals(expectedJavaType)) {
+          throw new TypeMismatchException(expectedJavaType, actualType);
+        }
+    }
+  }
+
+  private void validateArrayReturnType(final Type actualType, final SqlArray expectedType) {
+    final Optional<ParameterizedType> pt = findParameterizedType(actualType, List.class);
+    if (!pt.isPresent()) {
+      return;
+    }
+
+    final ParameterizedType parameterized = pt.get();
+    final Type itemType = parameterized.getActualTypeArguments()[0];
+
+    try {
+      validateType(itemType, expectedType.getItemType());
+    } catch (final TypeMismatchException | UnsupportedOperationException e) {
+      throw new KsqlException("Type mismatch on element type. " + e.getMessage(), e);
+    }
+  }
+
+  private void validateMapReturnType(final Type actualType, final SqlMap expectedType) {
+    final Optional<ParameterizedType> pt = findParameterizedType(actualType, Map.class);
+    if (!pt.isPresent()) {
+      return;
+    }
+
+    final ParameterizedType parameterized = pt.get();
+
+    final Type keyType = parameterized.getActualTypeArguments()[0];
+    if (!keyType.equals(String.class)) {
+      throw new KsqlException(
+          "Type mismatch on map key type. expected: " + String.class + ", but got: " + keyType);
+    }
+
+    final Type valueType = parameterized.getActualTypeArguments()[1];
+
+    try {
+      validateType(valueType, expectedType.getValueType());
+    } catch (final TypeMismatchException | UnsupportedOperationException e) {
+      throw new KsqlException("Type mismatch on map value type. " + e.getMessage(), e);
+    }
+  }
+
+  private static void validateActualType(final Type actualType) {
+    if (actualType instanceof WildcardType) {
+      throw new UnsupportedOperationException(
+          "Wildcards, i.e. '?', are not supported. Please use specific types.");
+    }
+
+    if (actualType instanceof TypeVariable) {
+      throw new UnsupportedOperationException(
+          "Type variables, e.g. " + actualType + ", are not supported. "
+              + "Please use specific types.");
+    }
+
+    if (actualType instanceof GenericArrayType) {
+      throw new UnsupportedOperationException(
+          "Generic array types, e.g. " + actualType + ", are not supported. "
+              + "Please List<> for ARRAY types.");
+    }
+  }
+
+  private static Optional<ParameterizedType> findParameterizedType(
+      final Type actualType,
+      final Class<?> required
+  ) {
+    if (actualType instanceof Class) {
+      final Class<?> actualClass = (Class<?>) actualType;
+
+      if (!required.equals(actualClass)) {
+        throw new TypeMismatchException(required, actualType);
+      }
+
+      return Optional.empty();
+    }
+
+    final ParameterizedType parameterized = (ParameterizedType) actualType;
+    if (!required.isAssignableFrom((Class<?>) parameterized.getRawType())) {
+      throw new TypeMismatchException(required, actualType);
+    }
+
+    return Optional.of(parameterized);
+  }
+
+  private static final class TypeMismatchException extends RuntimeException {
+
+    TypeMismatchException(final Type expected, final Type actual) {
+      super("expected: " + expected + ", but got: " + actual);
+    }
+  }
+}

--- a/ksql-engine/src/test/java/io/confluent/ksql/function/FunctionValidatorTest.java
+++ b/ksql-engine/src/test/java/io/confluent/ksql/function/FunctionValidatorTest.java
@@ -1,0 +1,339 @@
+/*
+ * Copyright 2019 Confluent Inc.
+ *
+ * Licensed under the Confluent Community License (the "License"); you may not use
+ * this file except in compliance with the License.  You may obtain a copy of the
+ * License at
+ *
+ * http://www.confluent.io/confluent-community-license
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package io.confluent.ksql.function;
+
+import io.confluent.ksql.schema.ksql.types.SqlType;
+import io.confluent.ksql.schema.ksql.types.SqlTypes;
+import io.confluent.ksql.util.KsqlException;
+import java.lang.reflect.Type;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+
+public class FunctionValidatorTest {
+
+  @Rule
+  public final ExpectedException expectedException = ExpectedException.none();
+
+  private FunctionValidator validator;
+
+  @Before
+  public void setUp() {
+    validator = new FunctionValidator();
+  }
+
+  @Test
+  public void shouldThrowOnArrayElementTypeMismatch() {
+    // Given:
+    final Type actualType = getReturnType("arrayOfLong");
+
+    final SqlType expectedType = SqlTypes.array(SqlTypes.INTEGER);
+
+    // Then:
+    expectedException.expect(KsqlException.class);
+    expectedException.expectMessage(
+        "Return type does not match supplied schema: ARRAY<INTEGER>. "
+            + "Type mismatch on element type. expected: class java.lang.Integer, but got: class java.lang.Long");
+
+    // When:
+    validator.validateReturnType(actualType, expectedType);
+  }
+
+  @Test
+  public void shouldNotThrowIfArrayTypeMatchesSchema() {
+    // Given:
+    final Type actualType = getReturnType("arrayOfLong");
+
+    final SqlType expectedType = SqlTypes.array(SqlTypes.BIGINT);
+
+    // When:
+    validator.validateReturnType(actualType, expectedType);
+
+    // Then:
+    // passed validation
+  }
+
+  @Test
+  public void shouldNotThrowOnRawList() {
+    // Given:
+    final Type actualType = getReturnType("rawArray");
+
+    final SqlType expectedType = SqlTypes.array(SqlTypes.INTEGER);
+
+    // When:
+    validator.validateReturnType(actualType, expectedType);
+
+    // Then:
+    // passed validation
+  }
+
+  @Test
+  public void shouldThrowOnMapKeyTypeMismatch() {
+    // Given:
+    final Type actualType = getReturnType("mapWithIntKey");
+
+    final SqlType expectedType = SqlTypes.map(SqlTypes.INTEGER);
+
+    // Then:
+    expectedException.expect(KsqlException.class);
+    expectedException.expectMessage(
+        "Return type does not match supplied schema: MAP<STRING, INTEGER>. "
+            + "Type mismatch on map key type. "
+            + "expected: class java.lang.String, but got: class java.lang.Integer");
+
+    // When:
+    validator.validateReturnType(actualType, expectedType);
+  }
+
+  @Test
+  public void shouldThrowOnMapValueTypeMismatch() {
+    // Given:
+    final Type actualType = getReturnType("mapWithIntValue");
+
+    final SqlType expectedType = SqlTypes.map(SqlTypes.BIGINT);
+
+    // Then:
+    expectedException.expect(KsqlException.class);
+    expectedException.expectMessage(
+        "Return type does not match supplied schema: MAP<STRING, BIGINT>. "
+            + "Type mismatch on map value type. "
+            + "expected: class java.lang.Long, but got: class java.lang.Integer");
+
+    // When:
+    validator.validateReturnType(actualType, expectedType);
+  }
+
+  @Test
+  public void shouldNotThrowIfMapTypeMatchesSchema() {
+    // Given:
+    final Type actualType = getReturnType("mapWithIntValue");
+
+    final SqlType expectedType = SqlTypes.map(SqlTypes.INTEGER);
+
+    // When:
+    validator.validateReturnType(actualType, expectedType);
+
+    // Then:
+    // passed validation
+  }
+
+  @Test
+  public void shouldNotThrowOnRawMap() {
+    // Given:
+    final Type actualType = getReturnType("rawMap");
+
+    final SqlType expectedType = SqlTypes.map(SqlTypes.INTEGER);
+
+    // When:
+    validator.validateReturnType(actualType, expectedType);
+
+    // Then:
+    // passed validation
+  }
+
+  @Test
+  public void shouldThrowOnWrongRawType() {
+    // Given:
+    final Type actualType = getReturnType("rawMap");
+
+    final SqlType expectedType = SqlTypes.array(SqlTypes.INTEGER);
+
+    // Then:
+    expectedException.expect(KsqlException.class);
+    expectedException.expectMessage(
+        "Return type does not match supplied schema: ARRAY<INTEGER>. "
+            + "expected: interface java.util.List, but got: interface java.util.Map");
+
+    // When:
+    validator.validateReturnType(actualType, expectedType);
+  }
+
+  @Test
+  public void shouldThrowOnWildcard() {
+    // Given:
+    final Type actualType = getReturnType("withWildcard");
+
+    final SqlType expectedType = SqlTypes.array(SqlTypes.INTEGER);
+
+    // Then:
+    expectedException.expect(KsqlException.class);
+    expectedException.expectMessage(
+        "Wildcards, i.e. '?', are not supported. Please use specific types.");
+
+    // When:
+    validator.validateReturnType(actualType, expectedType);
+  }
+
+  @Test
+  public void shouldThrowOnTypeVar() {
+    // Given:
+    final Type actualType = getReturnType("typeVariable");
+
+    final SqlType expectedType = SqlTypes.array(SqlTypes.INTEGER);
+
+    // Then:
+    expectedException.expect(KsqlException.class);
+    expectedException.expectMessage(
+        "Type variables, e.g. V, are not supported. Please use specific types.");
+
+    // When:
+    validator.validateReturnType(actualType, expectedType);
+  }
+
+  @Test
+  public void shouldThrowOnGenericArray() {
+    // Given:
+    final Type actualType = getReturnType("genericArray");
+
+    final SqlType expectedType = SqlTypes.array(SqlTypes.INTEGER);
+
+    // Then:
+    expectedException.expect(KsqlException.class);
+    expectedException.expectMessage(
+        "Generic array types, e.g. V[], are not supported. "
+            + "Please List<> for ARRAY types.");
+
+    // When:
+    validator.validateReturnType(actualType, expectedType);
+  }
+
+  @Test
+  public void shouldSupportImplementations() {
+    // Given:
+    final Type actualType = getReturnType("mapImpl");
+
+    final SqlType expectedType = SqlTypes.map(SqlTypes.INTEGER);
+
+    // When:
+    validator.validateReturnType(actualType, expectedType);
+
+    // Then:
+    // passed validation
+  }
+
+  @Test
+  public void shouldNotSupportSubclassed() {
+    // Given:
+    final Type actualType = getReturnType("mapOfIntSubclass");
+
+    final SqlType expectedType = SqlTypes.map(SqlTypes.INTEGER);
+
+    // Then:
+    expectedException.expect(KsqlException.class);
+    expectedException.expectMessage(
+        "expected: interface java.util.Map, "
+            + "but got: class io.confluent.ksql.function.FunctionValidatorTest$TestTypes$MapOfInt");
+
+    // When:
+    validator.validateReturnType(actualType, expectedType);
+  }
+
+  @Test
+  public void shouldSupportNestedTypes() {
+    // Given:
+    final Type actualType = getReturnType("arrayOfMapOfStrings");
+
+    final SqlType expectedType = SqlTypes.array(SqlTypes.map(SqlTypes.STRING));
+
+    // When:
+    validator.validateReturnType(actualType, expectedType);
+
+    // Then:
+    // passed validation
+  }
+
+  @Test
+  public void shouldThrowIfNestedTypeIsWrong() {
+    // Given:
+    final Type actualType = getReturnType("arrayOfMapOfStrings");
+
+    final SqlType expectedType = SqlTypes.array(SqlTypes.map(SqlTypes.DOUBLE));
+
+    // Then:
+    expectedException.expect(KsqlException.class);
+    expectedException.expectMessage(
+        "Return type does not match supplied schema: ARRAY<MAP<STRING, DOUBLE>>. "
+            + "Type mismatch on map value type. "
+            + "expected: class java.lang.Double, but got: class java.lang.String");
+
+    // When:
+    validator.validateReturnType(actualType, expectedType);
+  }
+
+  private static Type getReturnType(final String funcName) {
+    try {
+      return TestTypes.class.getDeclaredMethod(funcName).getGenericReturnType();
+    } catch (final Exception e) {
+      throw new RuntimeException("Invalid test");
+    }
+  }
+
+  @SuppressWarnings("unused") // Used via reflection
+  private static final class TestTypes {
+
+    private static List<Long> arrayOfLong() {
+      return null;
+    }
+
+    private static List rawArray() {
+      return null;
+    }
+
+    private static Map<Integer, Integer> mapWithIntKey() {
+      return null;
+    }
+
+    private static Map<String, Integer> mapWithIntValue() {
+      return null;
+    }
+
+    private static Map rawMap() {
+      return null;
+    }
+
+    private static List<?> withWildcard() {
+      return null;
+    }
+
+    private static <V> List<V> typeVariable() {
+      return null;
+    }
+
+    private static <V> List<V[]> genericArray() {
+      return null;
+    }
+
+    public static List<Map<String, String>> arrayOfMapOfStrings() {
+      return null;
+    }
+
+    private static HashMap<String, Integer> mapImpl() {
+      return null;
+    }
+
+    private static MapOfInt mapOfIntSubclass() {
+      return null;
+    }
+
+    private static final class MapOfInt extends HashMap<String, Integer> {
+
+    }
+  }
+}


### PR DESCRIPTION
### Description 

This PR adds the start of a validator for UDF/UDAFs. It is not currently wired up. This is being added to help @vpapavas to fix issues in the current UDF framework where the java type of a UDFs return type or parameter is not validated to ensure it is compatible with any schema provided via:

- `@Udf(schema = "x")`
- `@Udf(schemaProvider = "someMethod")`
- `@UdfParameter(schema = "y")`

The code can handle `ParameterizedType` as well as straight up `Class` and throws useful error messages for most cases of misuse.  

The only thing that I'm aware the code doesn't handle, which we potentially could, is if users were to write UDFs that returned custom types, which either implement the required interface, e.g. `class MyArray implements List<String>` or are subclasses, e.g. `class MyArray extends ArrayList<String>`.   Handling these requires more code to find the type arguments and I wasn't sure if its needed.  Maybe custom types work will mean we need this, e.g. if a UDF returns a custom type?  cc @agavra @vpapavas thoughts?

### Testing done 

Added unit tests.

### Reviewer checklist
- [ ] Ensure docs are updated if necessary. (eg. if a user visible feature is being added or changed).
- [ ] Ensure relevant issues are linked (description should include text like "Fixes #<issue number>")

