### PR TITLE
perf: enabled streams standby replicas by default

### DIFF
--- a/ksql-common/src/main/java/io/confluent/ksql/util/KsqlConfig.java
+++ b/ksql-common/src/main/java/io/confluent/ksql/util/KsqlConfig.java
@@ -650,6 +650,8 @@ public class KsqlConfig extends AbstractConfig {
             .defaultCacheMaxBytesBufferingConfig);
     streamsConfigDefaults.put(StreamsConfig.NUM_STREAM_THREADS_CONFIG, KsqlConstants
         .defaultNumberOfStreamsThreads);
+    streamsConfigDefaults.put(StreamsConfig.NUM_STANDBY_REPLICAS_CONFIG, KsqlConstants
+        .defaultNumberOfStandbyReplicas);
     if (!getBooleanConfig(FAIL_ON_DESERIALIZATION_ERROR_CONFIG, false)) {
       streamsConfigDefaults.put(
           StreamsConfig.DEFAULT_DESERIALIZATION_EXCEPTION_HANDLER_CLASS_CONFIG,

--- a/ksql-common/src/main/java/io/confluent/ksql/util/KsqlConstants.java
+++ b/ksql-common/src/main/java/io/confluent/ksql/util/KsqlConstants.java
@@ -38,6 +38,7 @@ public final class KsqlConstants {
   public static final long defaultCommitIntervalMsConfig = 2000;
   public static final long defaultCacheMaxBytesBufferingConfig = 10000000;
   public static final int defaultNumberOfStreamsThreads = 4;
+  public static final int defaultNumberOfStandbyReplicas = 1;
 
   public static final String LEGACY_RUN_SCRIPT_STATEMENTS_CONTENT = "ksql.run.script.statements";
 

--- a/ksql-common/src/test/java/io/confluent/ksql/util/KsqlConfigTest.java
+++ b/ksql-common/src/test/java/io/confluent/ksql/util/KsqlConfigTest.java
@@ -110,6 +110,14 @@ public class KsqlConfigTest {
   }
 
   @Test
+  public void shouldEnableStandbyReplicasByDefault() {
+    final KsqlConfig ksqlConfig = new KsqlConfig(Collections.emptyMap());
+    final Object result = ksqlConfig.getKsqlStreamConfigProps()
+        .get(StreamsConfig.NUM_STANDBY_REPLICAS_CONFIG);
+    assertThat(result, equalTo(1));
+  }
+
+  @Test
   public void shouldSetStreamsConfigConsumerUnprefixedProperties() {
     final KsqlConfig ksqlConfig = new KsqlConfig(Collections.singletonMap(ConsumerConfig.AUTO_OFFSET_RESET_CONFIG, "earliest"));
     final Object result = ksqlConfig.getKsqlStreamConfigProps().get(ConsumerConfig.AUTO_OFFSET_RESET_CONFIG);


### PR DESCRIPTION
### Description 

BREAKING CHANGE: existing multi instance ksql deployments could see increased disk usage, due to additional standby state replication, with the benefit of improving state availability for pull queries. By default, we tolerate 1 instance failure and there is no effect on single instance deployment

### Testing done 
Unit test added. Tested on my box bringing up ksql server

### Reviewer checklist
- [ ] Ensure docs are updated if necessary. (eg. if a user visible feature is being added or changed).
- [ ] Ensure relevant issues are linked (description should include text like "Fixes #<issue number>")

