### PR TITLE
fix: Don't throw NPE on null columns

### DIFF
--- a/ksql-rest-app/src/main/java/io/confluent/ksql/rest/entity/TableRowsEntityFactory.java
+++ b/ksql-rest-app/src/main/java/io/confluent/ksql/rest/entity/TableRowsEntityFactory.java
@@ -16,7 +16,6 @@
 package io.confluent.ksql.rest.entity;
 
 import com.google.common.collect.ImmutableList;
-import com.google.common.collect.ImmutableList.Builder;
 import io.confluent.ksql.execution.streams.materialization.TableRow;
 import io.confluent.ksql.model.WindowType;
 import io.confluent.ksql.name.ColumnName;
@@ -24,6 +23,7 @@ import io.confluent.ksql.schema.ksql.Column;
 import io.confluent.ksql.schema.ksql.LogicalSchema;
 import io.confluent.ksql.schema.ksql.types.SqlTypes;
 import java.time.Instant;
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
 import java.util.stream.Collectors;
@@ -79,18 +79,18 @@ public final class TableRowsEntityFactory {
   }
 
   private static List<?> createRow(final TableRow row) {
-    final Builder<Object> builder = ImmutableList.builder();
+    final List<Object> rowList = new ArrayList<>();
 
-    keyFields(row.key()).forEach(builder::add);
+    keyFields(row.key()).forEach(rowList::add);
 
     row.window().ifPresent(window -> {
-      builder.add(window.start().toEpochMilli());
-      window.end().map(Instant::toEpochMilli).ifPresent(builder::add);
+      rowList.add(window.start().toEpochMilli());
+      window.end().map(Instant::toEpochMilli).ifPresent(rowList::add);
     });
 
-    builder.addAll(row.value().getColumns());
+    rowList.addAll(row.value().getColumns());
 
-    return builder.build();
+    return rowList;
   }
 
   private static Stream<?> keyFields(final Struct key) {

--- a/ksql-rest-app/src/test/java/io/confluent/ksql/rest/entity/TableRowsEntityFactoryTest.java
+++ b/ksql-rest-app/src/test/java/io/confluent/ksql/rest/entity/TableRowsEntityFactoryTest.java
@@ -111,7 +111,7 @@ public class TableRowsEntityFactoryTest {
   }
 
   @Test
-  public void shouldSupportNullColumn() {
+  public void shouldSupportNullColumns() {
     // Given:
     final List<Object> newColumns = new ArrayList<>();
     newColumns.add(null);


### PR DESCRIPTION
Fixes #3617 

### Description 
`TableRowsEntityFactory.createRows` was throwing a NPE when a column of a row was null.

### Testing done 
Added extra tests to check if a column of different types is NULL.

CLI output for  query: `ksql> SELECT * FROM METRICS_TABLE WHERE ROWKEY='fetch_latency_ms|+|cluster_xyz|+|topic_3|+|null';`

**Previous** output: `Server Error`

**After** changes output: 

```
 ROWKEY STRING KEY                               | WINDOWSTART BIGINT KEY | METRICS_NAME STRING | CLUSTER STRING | TOPIC_NAME STRING | ENV STRING | AVG_VALUE DOUBLE
---------------------------------------------------------------------------------------------------------------------------------------------------------------------
 fetch_latency_ms|+|cluster_xyz|+|topic_3|+|null | 1572304800000          | fetch_latency_ms    | cluster_xyz    | topic_3           | null       | 0.031829
---------------------------------------------------------------------------------------------------------------------------------------------------------------------
```

CLI output for query: `ksql> SELECT * FROM ORDER_QUANTITIES where rowkey='null';`

```
 ROWKEY STRING KEY | ORDER_ID STRING | TOTAL_QTY INTEGER
---------------------------------------------------------
 null              | null          | 1
---------------------------------------------------------
```

## Reviewer checklist
- [ ] Ensure docs are updated if necessary. (eg. if a user visible feature is being added or changed).
- [ ] Ensure relevant issues are linked (description should include text like "Fixes #<issue number>")

