### PR TITLE
docs: use push/pull naming in help messages

### DIFF
--- a/ksql-engine/src/main/java/io/confluent/ksql/analyzer/StaticQueryValidator.java
+++ b/ksql-engine/src/main/java/io/confluent/ksql/analyzer/StaticQueryValidator.java
@@ -27,36 +27,36 @@ import java.util.function.Predicate;
 public class StaticQueryValidator implements QueryValidator {
 
   private static final String NEW_QUERY_SYNTAX_HELP = " "
-      + "Did you mean to execute a continuous query? Add an 'EMIT CHANGES' clause to do so."
+      + "Did you mean to execute a push query? Add an 'EMIT CHANGES' clause to do so."
       + System.lineSeparator()
       + System.lineSeparator()
       + "Query syntax in KSQL has changed. There are now two broad categories of queries:"
       + System.lineSeparator()
-      + "- Static queries: query the current state of the system, return a result, and terminate "
+      + "- Pull queries: query the current state of the system, return a result, and terminate "
       + "the query."
       + System.lineSeparator()
-      + "- Streaming queries: query the state of the system in motion and continue to output "
+      + "- Push queries: query the state of the system in motion and continue to output "
       + "results until they meet a LIMIT clause condition or the user terminates the query."
       + System.lineSeparator()
       + System.lineSeparator()
-      + "Use 'EMIT CHANGES' to indicate that a query is continuous and outputs all changes. "
-      + "To convert a static query into a streaming query, which was the default behavior in older "
+      + "'EMIT CHANGES' is used to to indicate a query is a push query. "
+      + "To convert a pull query into a push query, which was the default behavior in older "
       + "versions of KSQL, add `EMIT CHANGES` to the end of the statement before any LIMIT clause."
       + System.lineSeparator()
       + System.lineSeparator()
-      + "For example, the following are static queries:"
+      + "For example, the following are pull queries:"
       + System.lineSeparator()
       + "\t'SELECT * FROM X WHERE ROWKEY=Y;' (non-windowed table)"
       + System.lineSeparator()
       + "\t'SELECT * FROM X WHERE ROWKEY=Y AND WINDOWSTART>=Z;' (windowed table)"
       + System.lineSeparator()
       + System.lineSeparator()
-      + "The following is a streaming query:"
+      + "The following is a push query:"
       + System.lineSeparator()
       + "\t'SELECT * FROM X EMIT CHANGES;'"
       + System.lineSeparator()
       + System.lineSeparator()
-      + "Note: Persistent queries, like `CREATE TABLE AS ...`, have an implicit "
+      + "Note: Persistent queries, e.g. `CREATE TABLE AS ...`, have an implicit "
       + "`EMIT CHANGES`, but we recommend adding `EMIT CHANGES` to these statements.";
 
   private static final List<Rule> RULES = ImmutableList.of(

--- a/ksql-functional-tests/src/test/resources/rest-query-validation-tests/materialized-aggregate-static-queries.json
+++ b/ksql-functional-tests/src/test/resources/rest-query-validation-tests/materialized-aggregate-static-queries.json
@@ -738,7 +738,7 @@
       ],
       "expectedError": {
         "type": "io.confluent.ksql.rest.entity.KsqlStatementErrorMessage",
-        "message": "Table 'X' is not materialized. KSQL currently only supports static queries on materialized aggregate tables. i.e. those created by a 'CREATE TABLE AS SELECT <fields>, <aggregate_functions> FROM <sources> GROUP BY <key>' style statement.",
+        "message": "Table 'X' is not materialized. KSQL currently only supports pull queries on materialized aggregate tables. i.e. those created by a 'CREATE TABLE AS SELECT <fields>, <aggregate_functions> FROM <sources> GROUP BY <key>' style statement.",
         "status": 400
       }
     },

--- a/ksql-rest-app/src/main/java/io/confluent/ksql/rest/server/execution/StaticQueryExecutor.java
+++ b/ksql-rest-app/src/main/java/io/confluent/ksql/rest/server/execution/StaticQueryExecutor.java
@@ -680,12 +680,16 @@ public final class StaticQueryExecutor {
   }
 
   private static KsqlException notMaterializedException(final SourceName sourceTable) {
-    return new KsqlException(
-        "Table '" + sourceTable.toString(FormatOptions.noEscape()) + "' is not materialized."
-            + " KSQL currently only supports static queries on materialized aggregate tables."
-            + " i.e. those created by a"
-            + " 'CREATE TABLE AS SELECT <fields>, <aggregate_functions> "
-            + "FROM <sources> GROUP BY <key>' style statement.");
+    return new KsqlException("Pull query: "
+        + "Table '" + sourceTable.toString(FormatOptions.noEscape()) + "' is not materialized."
+        + " KSQL currently only supports pull queries on materialized aggregate tables."
+        + " i.e. those created by a 'CREATE TABLE AS SELECT <fields>, <aggregate_functions> "
+        + "FROM <sources> GROUP BY <key>' style statement."
+        + System.lineSeparator()
+        + "Did you mean to execute a push query? "
+        + "Push queries were the only queries supported before v5.4.0. "
+        + "If so, add `EMIT CHANGES` to the end of your query."
+    );
   }
 
   private static KsqlException invalidWhereClauseException(


### PR DESCRIPTION
### Description 

Switch the help messages returned to users on invalid pull queries to use the push vs pull query names.

### Testing done 

usual.

### Reviewer checklist
- [ ] Ensure docs are updated if necessary. (eg. if a user visible feature is being added or changed).
- [ ] Ensure relevant issues are linked (description should include text like "Fixes #<issue number>")

