### PR TITLE
Refactor: Split UdfLoader into multiple files

### DIFF
--- a/ksql-benchmark/src/main/java/io/confluent/ksql/benchmark/UdfInvokerBenchmark.java
+++ b/ksql-benchmark/src/main/java/io/confluent/ksql/benchmark/UdfInvokerBenchmark.java
@@ -16,7 +16,7 @@
 package io.confluent.ksql.benchmark;
 
 import io.confluent.ksql.function.FunctionInvoker;
-import io.confluent.ksql.function.UdfLoader;
+import io.confluent.ksql.function.FunctionLoaderUtils;
 import io.confluent.ksql.function.udf.PluggableUdf;
 import java.lang.reflect.Method;
 import java.util.concurrent.TimeUnit;
@@ -71,7 +71,7 @@ public class UdfInvokerBenchmark {
 
     private PluggableUdf createPluggableUdf(final Method method) {
       try {
-        final FunctionInvoker invoker = UdfLoader.createFunctionInvoker(method);
+        final FunctionInvoker invoker = FunctionLoaderUtils.createFunctionInvoker(method);
         return new PluggableUdf(invoker, this);
       } catch (Exception e) {
         throw new RuntimeException(e);

--- a/ksql-common/src/main/java/io/confluent/ksql/function/FunctionRegistry.java
+++ b/ksql-common/src/main/java/io/confluent/ksql/function/FunctionRegistry.java
@@ -75,7 +75,7 @@ public interface FunctionRegistry {
    * <code>KsqlAggregateFunction</code> instance.
    *
    * @param functionName the name of the function.
-   * @param argumentType the schema of the argument or {@link #DEFAULT_FUNCTION_ARG_SCHEMA}.
+   * @param argumentType the schema of the argument.
    * @return the function instance.
    * @throws KsqlException on unknown UDAF, or on unsupported {@code argumentType}.
    */

--- a/ksql-engine/src/main/java/io/confluent/ksql/embedded/KsqlContext.java
+++ b/ksql-engine/src/main/java/io/confluent/ksql/embedded/KsqlContext.java
@@ -23,7 +23,7 @@ import io.confluent.ksql.ServiceInfo;
 import io.confluent.ksql.engine.KsqlEngine;
 import io.confluent.ksql.function.InternalFunctionRegistry;
 import io.confluent.ksql.function.MutableFunctionRegistry;
-import io.confluent.ksql.function.UdfLoader;
+import io.confluent.ksql.function.UserFunctionLoader;
 import io.confluent.ksql.logging.processing.ProcessingLogContext;
 import io.confluent.ksql.metastore.MetaStore;
 import io.confluent.ksql.parser.KsqlParser.ParsedStatement;
@@ -78,7 +78,7 @@ public class KsqlContext implements AutoCloseable {
     final ServiceContext serviceContext =
         ServiceContextFactory.create(ksqlConfig, DisabledKsqlClient.instance());
     final MutableFunctionRegistry functionRegistry = new InternalFunctionRegistry();
-    UdfLoader.newInstance(ksqlConfig, functionRegistry, ".").load();
+    UserFunctionLoader.newInstance(ksqlConfig, functionRegistry, ".").load();
     final ServiceInfo serviceInfo = ServiceInfo.create(ksqlConfig);
     final KsqlEngine engine = new KsqlEngine(
         serviceContext,

--- a/ksql-engine/src/main/java/io/confluent/ksql/function/FunctionLoaderUtils.java
+++ b/ksql-engine/src/main/java/io/confluent/ksql/function/FunctionLoaderUtils.java
@@ -46,6 +46,9 @@ import org.apache.kafka.common.metrics.stats.Rate;
 import org.apache.kafka.common.metrics.stats.WindowedCount;
 import org.apache.kafka.connect.data.Schema;
 
+/**
+ * Utility class for loading different types of user defined funcrions
+ */
 public final class FunctionLoaderUtils {
 
   private static final String UDF_METRIC_GROUP = "ksql-udf";

--- a/ksql-engine/src/main/java/io/confluent/ksql/function/FunctionLoaderUtils.java
+++ b/ksql-engine/src/main/java/io/confluent/ksql/function/FunctionLoaderUtils.java
@@ -1,0 +1,249 @@
+/*
+ * Copyright 2018 Confluent Inc.
+ *
+ * Licensed under the Confluent Community License (the "License"); you may not use
+ * this file except in compliance with the License.  You may obtain a copy of the
+ * License at
+ *
+ * http://www.confluent.io/confluent-community-license
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package io.confluent.ksql.function;
+
+import com.google.common.annotations.VisibleForTesting;
+import io.confluent.ksql.execution.function.UdfUtil;
+import io.confluent.ksql.function.udf.Udf;
+import io.confluent.ksql.function.udf.UdfDescription;
+import io.confluent.ksql.function.udf.UdfParameter;
+import io.confluent.ksql.function.udf.UdfSchemaProvider;
+import io.confluent.ksql.schema.ksql.SchemaConverters;
+import io.confluent.ksql.schema.ksql.SqlTypeParser;
+import io.confluent.ksql.schema.ksql.types.SqlType;
+import io.confluent.ksql.util.DecimalUtil;
+import io.confluent.ksql.util.KsqlException;
+import io.confluent.ksql.util.SchemaUtil;
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
+import java.lang.reflect.Parameter;
+import java.lang.reflect.Type;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Optional;
+import java.util.concurrent.TimeUnit;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
+import org.apache.kafka.common.metrics.Metrics;
+import org.apache.kafka.common.metrics.Sensor;
+import org.apache.kafka.common.metrics.stats.Avg;
+import org.apache.kafka.common.metrics.stats.Max;
+import org.apache.kafka.common.metrics.stats.Rate;
+import org.apache.kafka.common.metrics.stats.WindowedCount;
+import org.apache.kafka.connect.data.Schema;
+
+public final class FunctionLoaderUtils {
+
+  private static final String UDF_METRIC_GROUP = "ksql-udf";
+
+  private FunctionLoaderUtils() {
+  }
+
+  static List<Schema> createParameters(
+      final Method method, final String functionName,
+      final SqlTypeParser typeParser
+  ) {
+    return IntStream.range(0, method.getParameterCount()).mapToObj(idx -> {
+      final Type type = method.getGenericParameterTypes()[idx];
+      final Optional<UdfParameter> annotation = Arrays.stream(method.getParameterAnnotations()[idx])
+          .filter(UdfParameter.class::isInstance)
+          .map(UdfParameter.class::cast)
+          .findAny();
+
+      final Parameter param = method.getParameters()[idx];
+      final String name = annotation.map(UdfParameter::value)
+          .filter(val -> !val.isEmpty())
+          .orElse(param.isNamePresent() ? param.getName() : "");
+
+      if (name.trim().isEmpty()) {
+        throw new KsqlFunctionException(
+            String.format("Cannot resolve parameter name for param at index %d for UDF %s:%s. "
+                    + "Please specify a name in @UdfParameter or compile your JAR with -parameters "
+                    + "to infer the name from the parameter name.",
+                idx, functionName, method.getName()
+            ));
+      }
+
+      final String doc = annotation.map(UdfParameter::description).orElse("");
+      if (annotation.isPresent() && !annotation.get().schema().isEmpty()) {
+        return SchemaConverters.sqlToConnectConverter()
+            .toConnectSchema(
+                typeParser.parse(annotation.get().schema()).getSqlType(),
+                name,
+                doc
+            );
+      }
+
+      return UdfUtil.getSchemaFromType(type, name, doc);
+    }).collect(Collectors.toList());
+  }
+
+  @VisibleForTesting
+  public static FunctionInvoker createFunctionInvoker(final Method method) {
+    return new DynamicFunctionInvoker(method);
+  }
+
+  static Object instantiateFunctionInstance(
+      final Class functionClass,
+      final String functionName
+  ) {
+    try {
+      return functionClass.newInstance();
+    } catch (final Exception e) {
+      throw new KsqlException(
+          "Failed to create instance for UDF/UDTF="
+              + functionName,
+          e
+      );
+    }
+  }
+
+  static void addSensor(
+      final String sensorName, final String udfName, final Optional<Metrics> theMetrics
+  ) {
+    theMetrics.ifPresent(metrics -> {
+      if (metrics.getSensor(sensorName) == null) {
+        final Sensor sensor = metrics.sensor(sensorName);
+        sensor.add(
+            metrics.metricName(sensorName + "-avg", UDF_METRIC_GROUP,
+                "Average time for an invocation of " + udfName + " udf"
+            ),
+            new Avg()
+        );
+        sensor.add(
+            metrics.metricName(sensorName + "-max", UDF_METRIC_GROUP,
+                "Max time for an invocation of " + udfName + " udf"
+            ),
+            new Max()
+        );
+        sensor.add(
+            metrics.metricName(sensorName + "-count", UDF_METRIC_GROUP,
+                "Total number of invocations of " + udfName + " udf"
+            ),
+            new WindowedCount()
+        );
+        sensor.add(
+            metrics.metricName(sensorName + "-rate", UDF_METRIC_GROUP,
+                "The average number of occurrence of " + udfName + " operation per second "
+                    + udfName + " udf"
+            ),
+            new Rate(TimeUnit.SECONDS, new WindowedCount())
+        );
+      }
+    });
+  }
+
+  static Schema getReturnType(
+      final Method method, final String annotationSchema,
+      final SqlTypeParser typeParser
+  ) {
+    return getReturnType(method, method.getGenericReturnType(), annotationSchema, typeParser);
+  }
+
+  static Schema getReturnType(
+      final Method method, final Type type, final String annotationSchema,
+      final SqlTypeParser typeParser
+  ) {
+    try {
+      final Schema returnType = annotationSchema.isEmpty()
+          ? UdfUtil.getSchemaFromType(type)
+          : SchemaConverters
+              .sqlToConnectConverter()
+              .toConnectSchema(
+                  typeParser.parse(annotationSchema).getSqlType());
+
+      return SchemaUtil.ensureOptional(returnType);
+    } catch (final KsqlException e) {
+      throw new KsqlException("Could not load UDF method with signature: " + method, e);
+    }
+  }
+
+  static Function<List<Schema>, Schema> handleUdfReturnSchema(
+      final Class theClass,
+      final Schema javaReturnSchema,
+      final Udf udfAnnotation,
+      final UdfDescription descAnnotation
+  ) {
+    final String schemaProviderName = udfAnnotation.schemaProvider();
+
+    if (!schemaProviderName.equals("")) {
+      return handleUdfSchemaProviderAnnotation(schemaProviderName, theClass, descAnnotation);
+    } else if (DecimalUtil.isDecimal(javaReturnSchema)) {
+      throw new KsqlException(String.format("Cannot load UDF %s. BigDecimal return type "
+          + "is not supported without a schema provider method.", descAnnotation.name()));
+    }
+
+    return ignored -> javaReturnSchema;
+  }
+
+  private static Function<List<Schema>, Schema> handleUdfSchemaProviderAnnotation(
+      final String schemaProviderName,
+      final Class theClass,
+      final UdfDescription annotation
+  ) {
+    // throws exception if cannot find method
+    final Method m = findSchemaProvider(theClass, schemaProviderName);
+    final Object instance = FunctionLoaderUtils
+        .instantiateFunctionInstance(theClass, annotation.name());
+
+    return parameterSchemas -> {
+      final List<SqlType> parameterTypes = parameterSchemas.stream()
+          .map(p -> SchemaConverters.connectToSqlConverter().toSqlType(p))
+          .collect(Collectors.toList());
+      return SchemaConverters.sqlToConnectConverter().toConnectSchema(invokeSchemaProviderMethod(
+          instance, m, parameterTypes, annotation));
+    };
+  }
+
+  private static Method findSchemaProvider(
+      final Class<?> theClass,
+      final String schemaProviderName
+  ) {
+    try {
+      final Method m = theClass.getDeclaredMethod(schemaProviderName, List.class);
+      if (!m.isAnnotationPresent(UdfSchemaProvider.class)) {
+        throw new KsqlException(String.format(
+            "Method %s should be annotated with @UdfSchemaProvider.",
+            schemaProviderName
+        ));
+      }
+      return m;
+    } catch (NoSuchMethodException e) {
+      throw new KsqlException(String.format(
+          "Cannot find schema provider method with name %s and parameter List<SqlType> in class "
+              + "%s.", schemaProviderName, theClass.getName()), e);
+    }
+  }
+
+  private static SqlType invokeSchemaProviderMethod(
+      final Object instance,
+      final Method m,
+      final List<SqlType> args,
+      final UdfDescription annotation
+  ) {
+    try {
+      return (SqlType) m.invoke(instance, args);
+    } catch (IllegalAccessException
+        | InvocationTargetException e) {
+      throw new KsqlException(String.format("Cannot invoke the schema provider "
+              + "method %s for UDF %s. ",
+          m.getName(), annotation.name()
+      ), e);
+    }
+  }
+
+}

--- a/ksql-engine/src/main/java/io/confluent/ksql/function/UdafLoader.java
+++ b/ksql-engine/src/main/java/io/confluent/ksql/function/UdafLoader.java
@@ -1,0 +1,126 @@
+/*
+ * Copyright 2019 Confluent Inc.
+ *
+ * Licensed under the Confluent Community License (the "License"); you may not use
+ * this file except in compliance with the License.  You may obtain a copy of the
+ * License at
+ *
+ * http://www.confluent.io/confluent-community-license
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package io.confluent.ksql.function;
+
+import io.confluent.ksql.function.udaf.UdafDescription;
+import io.confluent.ksql.function.udaf.UdafFactory;
+import io.confluent.ksql.function.udf.UdfMetadata;
+import io.confluent.ksql.name.FunctionName;
+import io.confluent.ksql.schema.ksql.SqlTypeParser;
+import java.lang.reflect.Method;
+import java.lang.reflect.Modifier;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Optional;
+import java.util.stream.Collectors;
+import org.apache.kafka.common.metrics.Metrics;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+class UdafLoader {
+
+  private static final Logger LOGGER = LoggerFactory.getLogger(UdafLoader.class);
+
+  private final MutableFunctionRegistry functionRegistry;
+  private final Optional<Metrics> metrics;
+  private final SqlTypeParser typeParser;
+
+  UdafLoader(
+      final MutableFunctionRegistry functionRegistry,
+      final Optional<Metrics> metrics,
+      final SqlTypeParser typeParser
+  ) {
+    this.functionRegistry = functionRegistry;
+    this.metrics = metrics;
+    this.typeParser = typeParser;
+  }
+
+  void loadUdafFromClass(final Class<?> theClass, final String path) {
+    final UdafDescription udafAnnotation = theClass.getAnnotation(UdafDescription.class);
+    final List<UdafFactoryInvoker> argCreators
+        = Arrays.stream(theClass.getMethods())
+        .filter(method -> method.getAnnotation(UdafFactory.class) != null)
+        .filter(method -> {
+          if (!Modifier.isStatic(method.getModifiers())) {
+            LOGGER.warn(
+                "Trying to create a UDAF from a non-static factory method. Udaf factory"
+                    + " methods must be static. class={}, method={}, name={}",
+                method.getDeclaringClass(),
+                method.getName(),
+                udafAnnotation.name()
+            );
+            return false;
+          }
+          return true;
+        })
+        .map(method -> {
+          final UdafFactory annotation = method.getAnnotation(UdafFactory.class);
+          try {
+            LOGGER.info(
+                "Adding UDAF name={} from path={} class={}",
+                udafAnnotation.name(),
+                path,
+                method.getDeclaringClass()
+            );
+            return Optional.of(createUdafFactoryInvoker(
+                method,
+                FunctionName.of(udafAnnotation.name()),
+                annotation.description(),
+                annotation.paramSchema(),
+                annotation.aggregateSchema(),
+                annotation.returnSchema()
+            ));
+          } catch (final Exception e) {
+            LOGGER.warn(
+                "Failed to create UDAF name={}, method={}, class={}, path={}",
+                udafAnnotation.name(),
+                method.getName(),
+                method.getDeclaringClass(),
+                path,
+                e
+            );
+          }
+          return Optional.<UdafFactoryInvoker>empty();
+        }).filter(Optional::isPresent)
+        .map(Optional::get)
+        .collect(Collectors.toList());
+
+    functionRegistry.addAggregateFunctionFactory(new UdafAggregateFunctionFactory(
+        new UdfMetadata(
+            udafAnnotation.name(),
+            udafAnnotation.description(),
+            udafAnnotation.author(),
+            udafAnnotation.version(),
+            path,
+            false
+        ),
+        argCreators
+    ));
+  }
+
+  UdafFactoryInvoker createUdafFactoryInvoker(
+      final Method method,
+      final FunctionName functionName,
+      final String description,
+      final String inputSchema,
+      final String aggregateSchema,
+      final String outputSchema
+  ) {
+    return new UdafFactoryInvoker(method, functionName, description, inputSchema,
+        aggregateSchema, outputSchema, typeParser, metrics
+    );
+  }
+}

--- a/ksql-engine/src/main/java/io/confluent/ksql/function/UdafLoader.java
+++ b/ksql-engine/src/main/java/io/confluent/ksql/function/UdafLoader.java
@@ -30,6 +30,9 @@ import org.apache.kafka.common.metrics.Metrics;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+/**
+ * Loads user defined aggregate functions (UDAFs)
+ */
 class UdafLoader {
 
   private static final Logger LOGGER = LoggerFactory.getLogger(UdafLoader.class);

--- a/ksql-engine/src/main/java/io/confluent/ksql/function/UdfLoader.java
+++ b/ksql-engine/src/main/java/io/confluent/ksql/function/UdfLoader.java
@@ -35,6 +35,9 @@ import org.apache.kafka.connect.data.Schema;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+/**
+ * Loads user defined functions (UDFs)
+ */
 public class UdfLoader {
 
   private static final Logger LOGGER = LoggerFactory.getLogger(UdfLoader.class);

--- a/ksql-engine/src/main/java/io/confluent/ksql/function/UdfLoader.java
+++ b/ksql-engine/src/main/java/io/confluent/ksql/function/UdfLoader.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018 Confluent Inc.
+ * Copyright 2019 Confluent Inc.
  *
  * Licensed under the Confluent Community License (the "License"); you may not use
  * this file except in compliance with the License.  You may obtain a copy of the
@@ -15,152 +15,45 @@
 
 package io.confluent.ksql.function;
 
-import static java.util.Optional.empty;
-
 import com.google.common.annotations.VisibleForTesting;
-import io.confluent.ksql.execution.function.UdfUtil;
-import io.confluent.ksql.function.udaf.UdafDescription;
-import io.confluent.ksql.function.udaf.UdafFactory;
 import io.confluent.ksql.function.udf.Kudf;
 import io.confluent.ksql.function.udf.PluggableUdf;
 import io.confluent.ksql.function.udf.Udf;
 import io.confluent.ksql.function.udf.UdfDescription;
 import io.confluent.ksql.function.udf.UdfMetadata;
-import io.confluent.ksql.function.udf.UdfParameter;
-import io.confluent.ksql.function.udf.UdfSchemaProvider;
-import io.confluent.ksql.function.udtf.Udtf;
-import io.confluent.ksql.function.udtf.UdtfDescription;
-import io.confluent.ksql.metastore.TypeRegistry;
-import io.confluent.ksql.metrics.MetricCollectors;
 import io.confluent.ksql.name.FunctionName;
-import io.confluent.ksql.schema.ksql.SchemaConverters;
 import io.confluent.ksql.schema.ksql.SqlTypeParser;
-import io.confluent.ksql.schema.ksql.types.SqlType;
-import io.confluent.ksql.security.ExtensionSecurityManager;
-import io.confluent.ksql.util.DecimalUtil;
-import io.confluent.ksql.util.KsqlConfig;
 import io.confluent.ksql.util.KsqlException;
-import io.confluent.ksql.util.SchemaUtil;
-import io.github.lukehutch.fastclasspathscanner.FastClasspathScanner;
-import java.io.File;
-import java.io.IOException;
-import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
-import java.lang.reflect.Modifier;
-import java.lang.reflect.Parameter;
-import java.lang.reflect.ParameterizedType;
-import java.lang.reflect.Type;
-import java.nio.file.Files;
-import java.nio.file.Path;
 import java.util.Arrays;
 import java.util.List;
-import java.util.Objects;
 import java.util.Optional;
-import java.util.concurrent.TimeUnit;
-import java.util.function.Function;
-import java.util.function.Predicate;
-import java.util.stream.Collectors;
-import java.util.stream.IntStream;
 import org.apache.kafka.common.Configurable;
 import org.apache.kafka.common.metrics.Metrics;
-import org.apache.kafka.common.metrics.Sensor;
-import org.apache.kafka.common.metrics.stats.Avg;
-import org.apache.kafka.common.metrics.stats.Max;
-import org.apache.kafka.common.metrics.stats.Rate;
-import org.apache.kafka.common.metrics.stats.WindowedCount;
 import org.apache.kafka.common.utils.Time;
 import org.apache.kafka.connect.data.Schema;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-// CHECKSTYLE_RULES.OFF: ClassDataAbstractionCoupling
 public class UdfLoader {
-  // CHECKSTYLE_RULES.ON: ClassDataAbstractionCoupling
 
   private static final Logger LOGGER = LoggerFactory.getLogger(UdfLoader.class);
-  private static final String UDF_METRIC_GROUP = "ksql-udf";
 
   private final MutableFunctionRegistry functionRegistry;
-  private final File pluginDir;
-  private final ClassLoader parentClassLoader;
-  private final Predicate<String> blacklist;
-  @SuppressWarnings("OptionalUsedAsFieldOrParameterType")
   private final Optional<Metrics> metrics;
-  private final boolean loadCustomerUdfs;
   private final SqlTypeParser typeParser;
+  private final ClassLoader parentClassLoader;
 
-  @SuppressWarnings("OptionalUsedAsFieldOrParameterType")
-  public UdfLoader(
+  UdfLoader(
       final MutableFunctionRegistry functionRegistry,
-      final File pluginDir,
-      final ClassLoader parentClassLoader,
-      final Predicate<String> blacklist,
       final Optional<Metrics> metrics,
-      final boolean loadCustomerUdfs
+      final SqlTypeParser typeParser,
+      final ClassLoader parentClassLoader
   ) {
-    this.functionRegistry = Objects
-        .requireNonNull(functionRegistry, "functionRegistry can't be null");
-    this.pluginDir = Objects.requireNonNull(pluginDir, "pluginDir can't be null");
-    this.parentClassLoader = Objects.requireNonNull(
-        parentClassLoader,
-        "parentClassLoader can't be null"
-    );
-    this.blacklist = Objects.requireNonNull(blacklist, "blacklist can't be null");
-    this.metrics = Objects.requireNonNull(metrics, "metrics can't be null");
-    this.loadCustomerUdfs = loadCustomerUdfs;
-    this.typeParser = SqlTypeParser.create(TypeRegistry.EMPTY);
-  }
-
-  public void load() {
-    // load functions packaged as part of ksql first
-    loadFunctions(parentClassLoader, empty());
-    if (loadCustomerUdfs) {
-      try {
-        if (!pluginDir.exists() && !pluginDir.isDirectory()) {
-          LOGGER.info(
-              "UDFs can't be loaded as as dir {} doesn't exist or is not a directory",
-              pluginDir
-          );
-          return;
-        }
-        Files.find(pluginDir.toPath(), 1,
-            (path, attributes) -> path.toString().endsWith(".jar")
-        )
-            .map(path -> UdfClassLoader.newClassLoader(path, parentClassLoader, blacklist))
-            .forEach(classLoader ->
-                loadFunctions(classLoader, Optional.of(classLoader.getJarPath())));
-      } catch (final IOException e) {
-        LOGGER.error("Failed to load UDFs from location {}", pluginDir, e);
-      }
-    }
-  }
-
-  @SuppressWarnings("OptionalUsedAsFieldOrParameterType")
-  private void loadFunctions(final ClassLoader loader, final Optional<Path> path) {
-    final String pathLoadedFrom
-        = path.map(Path::toString).orElse(KsqlFunction.INTERNAL_PATH);
-    final FastClasspathScanner fastClasspathScanner = new FastClasspathScanner();
-    if (loader != parentClassLoader) {
-      fastClasspathScanner.overrideClassLoaders(loader);
-    }
-    fastClasspathScanner
-        .ignoreParentClassLoaders()
-        // if we are loading from the parent classloader then restrict the name space to only
-        // jars/dirs containing "ksql-engine". This is so we don't end up scanning every jar
-        .filterClasspathElements(
-            name -> {
-              if (parentClassLoader != loader) {
-                return true;
-              }
-              return name.contains("ksql-engine");
-            })
-        .matchClassesWithAnnotation(
-            UdfDescription.class, theClass -> loadUdfFromClass(theClass, pathLoadedFrom, loader))
-        .matchClassesWithAnnotation(
-            UdafDescription.class, theClass -> loadUdafFromClass(theClass, pathLoadedFrom))
-        .matchClassesWithAnnotation(
-            UdtfDescription.class, theClass -> loadUdtfFromClass(theClass, pathLoadedFrom))
-        .scan();
+    this.functionRegistry = functionRegistry;
+    this.metrics = metrics;
+    this.typeParser = typeParser;
+    this.parentClassLoader = parentClassLoader;
   }
 
   // Does not handle customer udfs, i.e the loader is the ParentClassLoader and path is internal
@@ -173,7 +66,7 @@ public class UdfLoader {
     }
   }
 
-  private void loadUdfFromClass(
+  void loadUdfFromClass(
       final Class<?> theClass,
       final String path,
       final ClassLoader loader
@@ -188,7 +81,7 @@ public class UdfLoader {
     @SuppressWarnings("unchecked") final Class<? extends Kudf> udfClass = metrics
         .map(m -> (Class) UdfMetricProducer.class)
         .orElse(PluggableUdf.class);
-    addSensor(sensorName, functionName);
+    FunctionLoaderUtils.addSensor(sensorName, functionName, metrics);
 
     final UdfFactory factory = new UdfFactory(
         udfClass,
@@ -240,19 +133,22 @@ public class UdfLoader {
       final Class<? extends Kudf> udfClass
   ) {
     // sanity check
-    instantiateUdfClass(method, udfDescriptionAnnotation);
-    final FunctionInvoker invoker = createFunctionInvoker(method);
+    FunctionLoaderUtils
+        .instantiateFunctionInstance(method.getDeclaringClass(), udfDescriptionAnnotation.name());
+    final FunctionInvoker invoker = FunctionLoaderUtils.createFunctionInvoker(method);
     final Udf udfAnnotation = method.getAnnotation(Udf.class);
     final String functionName = udfDescriptionAnnotation.name();
 
     LOGGER.info("Adding function " + functionName + " for method " + method);
 
-    final List<Schema> parameters = createParameters(method, functionName);
+    final List<Schema> parameters = FunctionLoaderUtils
+        .createParameters(method, functionName, typeParser);
 
-    final Schema javaReturnSchema = getReturnType(method, udfAnnotation.schema());
+    final Schema javaReturnSchema = FunctionLoaderUtils
+        .getReturnType(method, udfAnnotation.schema(), typeParser);
 
     return KsqlFunction.create(
-        handleUdfReturnSchema(
+        FunctionLoaderUtils.handleUdfReturnSchema(
             theClass,
             javaReturnSchema,
             udfAnnotation,
@@ -263,7 +159,8 @@ public class UdfLoader {
         FunctionName.of(functionName.toUpperCase()),
         udfClass,
         ksqlConfig -> {
-          final Object actualUdf = instantiateUdfClass(method, udfDescriptionAnnotation);
+          final Object actualUdf = FunctionLoaderUtils.instantiateFunctionInstance(
+              method.getDeclaringClass(), udfDescriptionAnnotation.name());
           if (actualUdf instanceof Configurable) {
             ((Configurable) actualUdf)
                 .configure(ksqlConfig.getKsqlFunctionsConfigProps(functionName));
@@ -279,409 +176,4 @@ public class UdfLoader {
         method.isVarArgs()
     );
   }
-
-  private List<Schema> createParameters(final Method method, final String functionName) {
-    return IntStream.range(0, method.getParameterCount()).mapToObj(idx -> {
-      final Type type = method.getGenericParameterTypes()[idx];
-      final Optional<UdfParameter> annotation = Arrays.stream(method.getParameterAnnotations()[idx])
-          .filter(UdfParameter.class::isInstance)
-          .map(UdfParameter.class::cast)
-          .findAny();
-
-      final Parameter param = method.getParameters()[idx];
-      final String name = annotation.map(UdfParameter::value)
-          .filter(val -> !val.isEmpty())
-          .orElse(param.isNamePresent() ? param.getName() : "");
-
-      if (name.trim().isEmpty()) {
-        throw new KsqlFunctionException(
-            String.format("Cannot resolve parameter name for param at index %d for UDF %s:%s. "
-                    + "Please specify a name in @UdfParameter or compile your JAR with -parameters "
-                    + "to infer the name from the parameter name.",
-                idx, functionName, method.getName()
-            ));
-      }
-
-      final String doc = annotation.map(UdfParameter::description).orElse("");
-      if (annotation.isPresent() && !annotation.get().schema().isEmpty()) {
-        return SchemaConverters.sqlToConnectConverter()
-            .toConnectSchema(
-                typeParser.parse(annotation.get().schema()).getSqlType(),
-                name,
-                doc
-            );
-      }
-
-      return UdfUtil.getSchemaFromType(type, name, doc);
-    }).collect(Collectors.toList());
-  }
-
-  @VisibleForTesting
-  public static FunctionInvoker createFunctionInvoker(final Method method) {
-    return new DynamicFunctionInvoker(method);
-  }
-
-  private void loadUdafFromClass(final Class<?> theClass, final String path) {
-    final UdafDescription udafAnnotation = theClass.getAnnotation(UdafDescription.class);
-    final List<UdafFactoryInvoker> argCreators
-        = Arrays.stream(theClass.getMethods())
-        .filter(method -> method.getAnnotation(UdafFactory.class) != null)
-        .filter(method -> {
-          if (!Modifier.isStatic(method.getModifiers())) {
-            LOGGER.warn(
-                "Trying to create a UDAF from a non-static factory method. Udaf factory"
-                    + " methods must be static. class={}, method={}, name={}",
-                method.getDeclaringClass(),
-                method.getName(),
-                udafAnnotation.name()
-            );
-            return false;
-          }
-          return true;
-        })
-        .map(method -> {
-          final UdafFactory annotation = method.getAnnotation(UdafFactory.class);
-          try {
-            LOGGER.info(
-                "Adding UDAF name={} from path={} class={}",
-                udafAnnotation.name(),
-                path,
-                method.getDeclaringClass()
-            );
-            return Optional.of(createUdafFactoryInvoker(
-                method,
-                FunctionName.of(udafAnnotation.name()),
-                annotation.description(),
-                annotation.paramSchema(),
-                annotation.aggregateSchema(),
-                annotation.returnSchema()
-            ));
-          } catch (final Exception e) {
-            LOGGER.warn(
-                "Failed to create UDAF name={}, method={}, class={}, path={}",
-                udafAnnotation.name(),
-                method.getName(),
-                method.getDeclaringClass(),
-                path,
-                e
-            );
-          }
-          return Optional.<UdafFactoryInvoker>empty();
-        }).filter(Optional::isPresent)
-        .map(Optional::get)
-        .collect(Collectors.toList());
-
-    functionRegistry.addAggregateFunctionFactory(new UdafAggregateFunctionFactory(
-        new UdfMetadata(
-            udafAnnotation.name(),
-            udafAnnotation.description(),
-            udafAnnotation.author(),
-            udafAnnotation.version(),
-            path,
-            false
-        ),
-        argCreators
-    ));
-  }
-
-
-  UdafFactoryInvoker createUdafFactoryInvoker(
-      final Method method,
-      final FunctionName functionName,
-      final String description,
-      final String inputSchema,
-      final String aggregateSchema,
-      final String outputSchema
-  ) {
-    return new UdafFactoryInvoker(method, functionName, description, inputSchema,
-        aggregateSchema, outputSchema, typeParser, metrics
-    );
-  }
-
-  private void loadUdtfFromClass(
-      final Class<?> theClass,
-      final String path
-  ) {
-    final UdtfDescription udtfDescriptionAnnotation = theClass.getAnnotation(UdtfDescription.class);
-    if (udtfDescriptionAnnotation == null) {
-      throw new KsqlException(String.format("Cannot load class %s. Classes containing UDTFs must"
-          + "be annotated with @UdtfDescription.", theClass.getName()));
-    }
-    final String functionName = udtfDescriptionAnnotation.name();
-    final String sensorName = "ksql-udtf-" + functionName;
-    addSensor(sensorName, functionName);
-
-    final UdfMetadata metadata = new UdfMetadata(
-        udtfDescriptionAnnotation.name(),
-        udtfDescriptionAnnotation.description(),
-        udtfDescriptionAnnotation.author(),
-        udtfDescriptionAnnotation.version(),
-        path,
-        false
-    );
-
-    final UdtfTableFunctionFactory udtfFactory = new UdtfTableFunctionFactory(metadata);
-
-    Arrays.stream(theClass.getMethods())
-        .filter(method -> method.getAnnotation(Udtf.class) != null)
-        .map(method -> {
-          try {
-            final Udtf annotation = method.getAnnotation(Udtf.class);
-            if (method.getReturnType() != List.class) {
-              throw new KsqlException(String
-                  .format("UDTF functions must return a List. Class %s Method %s",
-                      theClass.getName(), method.getName()
-                  ));
-            }
-            final Type ret = method.getGenericReturnType();
-            if (!(ret instanceof ParameterizedType)) {
-              throw new KsqlException(String
-                  .format("UDTF functions must return a generic List. Class %s Method %s",
-                      theClass.getName(), method.getName()
-                  ));
-            }
-            final Type typeArg = ((ParameterizedType) ret).getActualTypeArguments()[0];
-            final Schema returnType = getReturnType(method, typeArg, annotation.schema());
-            final List<Schema> parameters = createParameters(method, functionName);
-            return Optional
-                .of(createTableFunction(method, FunctionName.of(functionName), returnType,
-                    parameters,
-                    udtfDescriptionAnnotation.description()
-                ));
-          } catch (final KsqlException e) {
-            LOGGER.warn(
-                "Failed to add UDF to the MetaStore. name={} method={}",
-                udtfDescriptionAnnotation.name(),
-                method,
-                e
-            );
-          }
-          return Optional.<KsqlTableFunction>empty();
-        })
-        .filter(Optional::isPresent)
-        .map(Optional::get)
-        .forEach(udtfFactory::addFunction);
-
-    functionRegistry.addTableFunctionFactory(udtfFactory);
-  }
-
-  private KsqlTableFunction createTableFunction(
-      final Method method,
-      final FunctionName functionName,
-      final Schema outputType,
-      final List<Schema> arguments,
-      final String description
-  ) {
-    final FunctionInvoker invoker = createFunctionInvoker(method);
-    final Object instance = instantiateUdtfClass(method, description);
-    @SuppressWarnings("unchecked") final KsqlTableFunction tableFunction = new BaseTableFunction(
-        functionName, outputType, arguments, description) {
-      @Override
-      public List<?> apply(final Object... args) {
-        return (List) invoker.eval(instance, args);
-      }
-    };
-    return tableFunction;
-  }
-
-  private static Object instantiateUdfClass(
-      final Method method,
-      final UdfDescription annotation
-  ) {
-    try {
-      return method.getDeclaringClass().newInstance();
-    } catch (final Exception e) {
-      throw new KsqlException(
-          "Failed to create instance for UDF="
-              + annotation.name()
-              + ", method=" + method,
-          e
-      );
-    }
-  }
-
-  private static Object instantiateUdfClass(
-      final Class udfClass,
-      final UdfDescription annotation
-  ) {
-    try {
-      return udfClass.newInstance();
-    } catch (final Exception e) {
-      throw new KsqlException("Failed to create instance for UDF="
-          + annotation.name(), e);
-    }
-  }
-
-  private static Object instantiateUdtfClass(
-      final Method method,
-      final String udtfName
-  ) {
-    try {
-      return method.getDeclaringClass().newInstance();
-    } catch (final Exception e) {
-      throw new KsqlException(
-          "Failed to create instance for UDTF="
-              + udtfName
-              + ", method=" + method,
-          e
-      );
-    }
-  }
-
-  private static Function<List<Schema>, Schema> handleUdfReturnSchema(
-      final Class theClass,
-      final Schema javaReturnSchema,
-      final Udf udfAnnotation,
-      final UdfDescription descAnnotation
-  ) {
-    final String schemaProviderName = udfAnnotation.schemaProvider();
-
-    if (!schemaProviderName.equals("")) {
-      return handleUdfSchemaProviderAnnotation(schemaProviderName, theClass, descAnnotation);
-    } else if (DecimalUtil.isDecimal(javaReturnSchema)) {
-      throw new KsqlException(String.format("Cannot load UDF %s. BigDecimal return type "
-          + "is not supported without a schema provider method.", descAnnotation.name()));
-    }
-
-    return ignored -> javaReturnSchema;
-  }
-
-  private static Function<List<Schema>, Schema> handleUdfSchemaProviderAnnotation(
-      final String schemaProviderName,
-      final Class theClass,
-      final UdfDescription annotation
-  ) {
-    // throws exception if cannot find method
-    final Method m = findSchemaProvider(theClass, schemaProviderName);
-    final Object instance = instantiateUdfClass(theClass, annotation);
-
-    return parameterSchemas -> {
-      final List<SqlType> parameterTypes = parameterSchemas.stream()
-          .map(p -> SchemaConverters.connectToSqlConverter().toSqlType(p))
-          .collect(Collectors.toList());
-      return SchemaConverters.sqlToConnectConverter().toConnectSchema(invokeSchemaProviderMethod(
-          instance, m, parameterTypes, annotation));
-    };
-  }
-
-  private static Method findSchemaProvider(
-      final Class<?> theClass,
-      final String schemaProviderName
-  ) {
-    try {
-      final Method m = theClass.getDeclaredMethod(schemaProviderName, List.class);
-      if (!m.isAnnotationPresent(UdfSchemaProvider.class)) {
-        throw new KsqlException(String.format(
-            "Method %s should be annotated with @UdfSchemaProvider.",
-            schemaProviderName
-        ));
-      }
-      return m;
-    } catch (NoSuchMethodException e) {
-      throw new KsqlException(String.format(
-          "Cannot find schema provider method with name %s and parameter List<SqlType> in class "
-              + "%s.", schemaProviderName, theClass.getName()), e);
-    }
-  }
-
-  private static SqlType invokeSchemaProviderMethod(
-      final Object instance,
-      final Method m,
-      final List<SqlType> args,
-      final UdfDescription annotation
-  ) {
-    try {
-      return (SqlType) m.invoke(instance, args);
-    } catch (IllegalAccessException
-        | InvocationTargetException e) {
-      throw new KsqlException(String.format("Cannot invoke the schema provider "
-              + "method %s for UDF %s. ",
-          m.getName(), annotation.name()
-      ), e);
-    }
-  }
-
-  private void addSensor(final String sensorName, final String udfName) {
-    metrics.ifPresent(metrics -> {
-      if (metrics.getSensor(sensorName) == null) {
-        final Sensor sensor = metrics.sensor(sensorName);
-        sensor.add(
-            metrics.metricName(sensorName + "-avg", UDF_METRIC_GROUP,
-                "Average time for an invocation of " + udfName + " udf"
-            ),
-            new Avg()
-        );
-        sensor.add(
-            metrics.metricName(sensorName + "-max", UDF_METRIC_GROUP,
-                "Max time for an invocation of " + udfName + " udf"
-            ),
-            new Max()
-        );
-        sensor.add(
-            metrics.metricName(sensorName + "-count", UDF_METRIC_GROUP,
-                "Total number of invocations of " + udfName + " udf"
-            ),
-            new WindowedCount()
-        );
-        sensor.add(
-            metrics.metricName(sensorName + "-rate", UDF_METRIC_GROUP,
-                "The average number of occurrence of " + udfName + " operation per second "
-                    + udfName + " udf"
-            ),
-            new Rate(TimeUnit.SECONDS, new WindowedCount())
-        );
-      }
-    });
-  }
-
-  public static UdfLoader newInstance(
-      final KsqlConfig config,
-      final MutableFunctionRegistry metaStore,
-      final String ksqlInstallDir
-  ) {
-    final Boolean loadCustomerUdfs = config.getBoolean(KsqlConfig.KSQL_ENABLE_UDFS);
-    final Boolean collectMetrics = config.getBoolean(KsqlConfig.KSQL_COLLECT_UDF_METRICS);
-    final String extDirName = config.getString(KsqlConfig.KSQL_EXT_DIR);
-    final File pluginDir = KsqlConfig.DEFAULT_EXT_DIR.equals(extDirName)
-        ? new File(ksqlInstallDir, extDirName)
-        : new File(extDirName);
-
-    final Optional<Metrics> metrics = collectMetrics
-        ? Optional.of(MetricCollectors.getMetrics())
-        : empty();
-
-    if (config.getBoolean(KsqlConfig.KSQL_UDF_SECURITY_MANAGER_ENABLED)) {
-      System.setSecurityManager(ExtensionSecurityManager.INSTANCE);
-    }
-    return new UdfLoader(
-        metaStore,
-        pluginDir,
-        Thread.currentThread().getContextClassLoader(),
-        new Blacklist(new File(pluginDir, "resource-blacklist.txt")),
-        metrics,
-        loadCustomerUdfs
-    );
-  }
-
-  private Schema getReturnType(final Method method, final String annotationSchema) {
-    return getReturnType(method, method.getGenericReturnType(), annotationSchema);
-  }
-
-  private Schema getReturnType(
-      final Method method, final Type type, final String annotationSchema
-  ) {
-    try {
-      final Schema returnType = annotationSchema.isEmpty()
-          ? UdfUtil.getSchemaFromType(type)
-          : SchemaConverters
-              .sqlToConnectConverter()
-              .toConnectSchema(
-                  typeParser.parse(annotationSchema).getSqlType());
-
-      return SchemaUtil.ensureOptional(returnType);
-    } catch (final KsqlException e) {
-      throw new KsqlException("Could not load UDF method with signature: " + method, e);
-    }
-  }
-
 }

--- a/ksql-engine/src/main/java/io/confluent/ksql/function/UdfLoaderUtil.java
+++ b/ksql-engine/src/main/java/io/confluent/ksql/function/UdfLoaderUtil.java
@@ -23,7 +23,8 @@ public final class UdfLoaderUtil {
   private UdfLoaderUtil() {}
 
   public static FunctionRegistry load(final MutableFunctionRegistry functionRegistry) {
-    new UdfLoader(functionRegistry,
+    new UserFunctionLoader(
+        functionRegistry,
         new File("src/test/resources/udf-example.jar"),
         UdfLoaderUtil.class.getClassLoader(),
         value -> false, Optional.empty(), true

--- a/ksql-engine/src/main/java/io/confluent/ksql/function/UdtfLoader.java
+++ b/ksql-engine/src/main/java/io/confluent/ksql/function/UdtfLoader.java
@@ -1,0 +1,141 @@
+/*
+ * Copyright 2019 Confluent Inc.
+ *
+ * Licensed under the Confluent Community License (the "License"); you may not use
+ * this file except in compliance with the License.  You may obtain a copy of the
+ * License at
+ *
+ * http://www.confluent.io/confluent-community-license
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package io.confluent.ksql.function;
+
+import io.confluent.ksql.function.udf.UdfMetadata;
+import io.confluent.ksql.function.udtf.Udtf;
+import io.confluent.ksql.function.udtf.UdtfDescription;
+import io.confluent.ksql.name.FunctionName;
+import io.confluent.ksql.schema.ksql.SqlTypeParser;
+import io.confluent.ksql.util.KsqlException;
+import java.lang.reflect.Method;
+import java.lang.reflect.ParameterizedType;
+import java.lang.reflect.Type;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Optional;
+import org.apache.kafka.common.metrics.Metrics;
+import org.apache.kafka.connect.data.Schema;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+class UdtfLoader {
+
+  private static final Logger LOGGER = LoggerFactory.getLogger(UdtfLoader.class);
+
+  private final MutableFunctionRegistry functionRegistry;
+  private final Optional<Metrics> metrics;
+  private final SqlTypeParser typeParser;
+
+  UdtfLoader(
+      final MutableFunctionRegistry functionRegistry,
+      final Optional<Metrics> metrics,
+      final SqlTypeParser typeParser
+  ) {
+    this.functionRegistry = functionRegistry;
+    this.metrics = metrics;
+    this.typeParser = typeParser;
+  }
+
+  void loadUdtfFromClass(
+      final Class<?> theClass,
+      final String path
+  ) {
+    final UdtfDescription udtfDescriptionAnnotation = theClass.getAnnotation(UdtfDescription.class);
+    if (udtfDescriptionAnnotation == null) {
+      throw new KsqlException(String.format("Cannot load class %s. Classes containing UDTFs must"
+          + "be annotated with @UdtfDescription.", theClass.getName()));
+    }
+    final String functionName = udtfDescriptionAnnotation.name();
+    final String sensorName = "ksql-udtf-" + functionName;
+    FunctionLoaderUtils.addSensor(sensorName, functionName, metrics);
+
+    final UdfMetadata metadata = new UdfMetadata(
+        udtfDescriptionAnnotation.name(),
+        udtfDescriptionAnnotation.description(),
+        udtfDescriptionAnnotation.author(),
+        udtfDescriptionAnnotation.version(),
+        path,
+        false
+    );
+
+    final UdtfTableFunctionFactory udtfFactory = new UdtfTableFunctionFactory(metadata);
+
+    Arrays.stream(theClass.getMethods())
+        .filter(method -> method.getAnnotation(Udtf.class) != null)
+        .map(method -> {
+          try {
+            final Udtf annotation = method.getAnnotation(Udtf.class);
+            if (method.getReturnType() != List.class) {
+              throw new KsqlException(String
+                  .format("UDTF functions must return a List. Class %s Method %s",
+                      theClass.getName(), method.getName()
+                  ));
+            }
+            final Type ret = method.getGenericReturnType();
+            if (!(ret instanceof ParameterizedType)) {
+              throw new KsqlException(String
+                  .format("UDTF functions must return a generic List. Class %s Method %s",
+                      theClass.getName(), method.getName()
+                  ));
+            }
+            final Type typeArg = ((ParameterizedType) ret).getActualTypeArguments()[0];
+            final Schema returnType = FunctionLoaderUtils
+                .getReturnType(method, typeArg, annotation.schema(), typeParser);
+            final List<Schema> parameters = FunctionLoaderUtils
+                .createParameters(method, functionName, typeParser);
+            return Optional
+                .of(createTableFunction(method, FunctionName.of(functionName), returnType,
+                    parameters,
+                    udtfDescriptionAnnotation.description()
+                ));
+          } catch (final KsqlException e) {
+            LOGGER.warn(
+                "Failed to add UDF to the MetaStore. name={} method={}",
+                udtfDescriptionAnnotation.name(),
+                method,
+                e
+            );
+          }
+          return Optional.<KsqlTableFunction>empty();
+        })
+        .filter(Optional::isPresent)
+        .map(Optional::get)
+        .forEach(udtfFactory::addFunction);
+
+    functionRegistry.addTableFunctionFactory(udtfFactory);
+  }
+
+  private KsqlTableFunction createTableFunction(
+      final Method method,
+      final FunctionName functionName,
+      final Schema outputType,
+      final List<Schema> arguments,
+      final String description
+  ) {
+    final FunctionInvoker invoker = FunctionLoaderUtils.createFunctionInvoker(method);
+    final Object instance = FunctionLoaderUtils
+        .instantiateFunctionInstance(method.getDeclaringClass(), description);
+    @SuppressWarnings("unchecked") final KsqlTableFunction tableFunction = new BaseTableFunction(
+        functionName, outputType, arguments, description) {
+      @Override
+      public List<?> apply(final Object... args) {
+        return (List) invoker.eval(instance, args);
+      }
+    };
+    return tableFunction;
+  }
+}

--- a/ksql-engine/src/main/java/io/confluent/ksql/function/UdtfLoader.java
+++ b/ksql-engine/src/main/java/io/confluent/ksql/function/UdtfLoader.java
@@ -32,6 +32,9 @@ import org.apache.kafka.connect.data.Schema;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+/**
+ * Loads user defined table functions (UDTFs)
+ */
 class UdtfLoader {
 
   private static final Logger LOGGER = LoggerFactory.getLogger(UdtfLoader.class);

--- a/ksql-engine/src/main/java/io/confluent/ksql/function/UserFunctionLoader.java
+++ b/ksql-engine/src/main/java/io/confluent/ksql/function/UserFunctionLoader.java
@@ -37,6 +37,10 @@ import org.apache.kafka.common.metrics.Metrics;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+/**
+ * Coordinates the loading of UDFs, UDAFs and UDTFs. The actual loading of the functions is done in
+ * of the specific function loader classes
+ */
 public class UserFunctionLoader {
 
   private static final Logger LOGGER = LoggerFactory.getLogger(UserFunctionLoader.class);

--- a/ksql-engine/src/main/java/io/confluent/ksql/function/UserFunctionLoader.java
+++ b/ksql-engine/src/main/java/io/confluent/ksql/function/UserFunctionLoader.java
@@ -1,0 +1,162 @@
+/*
+ * Copyright 2018 Confluent Inc.
+ *
+ * Licensed under the Confluent Community License (the "License"); you may not use
+ * this file except in compliance with the License.  You may obtain a copy of the
+ * License at
+ *
+ * http://www.confluent.io/confluent-community-license
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package io.confluent.ksql.function;
+
+import static java.util.Optional.empty;
+
+import io.confluent.ksql.function.udaf.UdafDescription;
+import io.confluent.ksql.function.udf.UdfDescription;
+import io.confluent.ksql.function.udtf.UdtfDescription;
+import io.confluent.ksql.metastore.TypeRegistry;
+import io.confluent.ksql.metrics.MetricCollectors;
+import io.confluent.ksql.schema.ksql.SqlTypeParser;
+import io.confluent.ksql.security.ExtensionSecurityManager;
+import io.confluent.ksql.util.KsqlConfig;
+import io.github.lukehutch.fastclasspathscanner.FastClasspathScanner;
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.Objects;
+import java.util.Optional;
+import java.util.function.Predicate;
+import org.apache.kafka.common.metrics.Metrics;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class UserFunctionLoader {
+
+  private static final Logger LOGGER = LoggerFactory.getLogger(UserFunctionLoader.class);
+
+  private final File pluginDir;
+  private final ClassLoader parentClassLoader;
+  private final Predicate<String> blacklist;
+  private final boolean loadCustomerUdfs;
+  private final UdfLoader udfLoader;
+  private final UdafLoader udafLoader;
+  private final UdtfLoader udtfLoader;
+
+  @SuppressWarnings("OptionalUsedAsFieldOrParameterType")
+  public UserFunctionLoader(
+      final MutableFunctionRegistry functionRegistry,
+      final File pluginDir,
+      final ClassLoader parentClassLoader,
+      final Predicate<String> blacklist,
+      final Optional<Metrics> metrics,
+      final boolean loadCustomerUdfs
+  ) {
+    Objects.requireNonNull(functionRegistry, "functionRegistry can't be null");
+    this.pluginDir = Objects.requireNonNull(pluginDir, "pluginDir can't be null");
+    this.parentClassLoader = Objects.requireNonNull(
+        parentClassLoader,
+        "parentClassLoader can't be null"
+    );
+    this.blacklist = Objects.requireNonNull(blacklist, "blacklist can't be null");
+    Objects.requireNonNull(metrics, "metrics can't be null");
+    this.loadCustomerUdfs = loadCustomerUdfs;
+    final SqlTypeParser typeParser = SqlTypeParser.create(TypeRegistry.EMPTY);
+    this.udfLoader = new UdfLoader(functionRegistry, metrics, typeParser, parentClassLoader);
+    this.udafLoader = new UdafLoader(functionRegistry, metrics, typeParser);
+    this.udtfLoader = new UdtfLoader(functionRegistry, metrics, typeParser);
+  }
+
+  public void load() {
+    // load functions packaged as part of ksql first
+    loadFunctions(parentClassLoader, empty());
+    if (loadCustomerUdfs) {
+      try {
+        if (!pluginDir.exists() && !pluginDir.isDirectory()) {
+          LOGGER.info(
+              "UDFs can't be loaded as as dir {} doesn't exist or is not a directory",
+              pluginDir
+          );
+          return;
+        }
+        Files.find(pluginDir.toPath(), 1,
+            (path, attributes) -> path.toString().endsWith(".jar")
+        )
+            .map(path -> UdfClassLoader.newClassLoader(path, parentClassLoader, blacklist))
+            .forEach(classLoader ->
+                loadFunctions(classLoader, Optional.of(classLoader.getJarPath())));
+      } catch (final IOException e) {
+        LOGGER.error("Failed to load UDFs from location {}", pluginDir, e);
+      }
+    }
+  }
+
+  @SuppressWarnings("OptionalUsedAsFieldOrParameterType")
+  private void loadFunctions(final ClassLoader loader, final Optional<Path> path) {
+    final String pathLoadedFrom
+        = path.map(Path::toString).orElse(KsqlFunction.INTERNAL_PATH);
+    final FastClasspathScanner fastClasspathScanner = new FastClasspathScanner();
+    if (loader != parentClassLoader) {
+      fastClasspathScanner.overrideClassLoaders(loader);
+    }
+    fastClasspathScanner
+        .ignoreParentClassLoaders()
+        // if we are loading from the parent classloader then restrict the name space to only
+        // jars/dirs containing "ksql-engine". This is so we don't end up scanning every jar
+        .filterClasspathElements(
+            name -> {
+              if (parentClassLoader != loader) {
+                return true;
+              }
+              return name.contains("ksql-engine");
+            })
+        .matchClassesWithAnnotation(
+            UdfDescription.class,
+            theClass -> udfLoader.loadUdfFromClass(theClass, pathLoadedFrom, loader)
+        )
+        .matchClassesWithAnnotation(
+            UdafDescription.class,
+            theClass -> udafLoader.loadUdafFromClass(theClass, pathLoadedFrom)
+        )
+        .matchClassesWithAnnotation(
+            UdtfDescription.class,
+            theClass -> udtfLoader.loadUdtfFromClass(theClass, pathLoadedFrom)
+        )
+        .scan();
+  }
+
+  public static UserFunctionLoader newInstance(
+      final KsqlConfig config,
+      final MutableFunctionRegistry metaStore,
+      final String ksqlInstallDir
+  ) {
+    final Boolean loadCustomerUdfs = config.getBoolean(KsqlConfig.KSQL_ENABLE_UDFS);
+    final Boolean collectMetrics = config.getBoolean(KsqlConfig.KSQL_COLLECT_UDF_METRICS);
+    final String extDirName = config.getString(KsqlConfig.KSQL_EXT_DIR);
+    final File pluginDir = KsqlConfig.DEFAULT_EXT_DIR.equals(extDirName)
+        ? new File(ksqlInstallDir, extDirName)
+        : new File(extDirName);
+
+    final Optional<Metrics> metrics = collectMetrics
+        ? Optional.of(MetricCollectors.getMetrics())
+        : empty();
+
+    if (config.getBoolean(KsqlConfig.KSQL_UDF_SECURITY_MANAGER_ENABLED)) {
+      System.setSecurityManager(ExtensionSecurityManager.INSTANCE);
+    }
+    return new UserFunctionLoader(
+        metaStore,
+        pluginDir,
+        Thread.currentThread().getContextClassLoader(),
+        new Blacklist(new File(pluginDir, "resource-blacklist.txt")),
+        metrics,
+        loadCustomerUdfs
+    );
+  }
+}

--- a/ksql-engine/src/test/java/TestUdfWithNoPackage.java
+++ b/ksql-engine/src/test/java/TestUdfWithNoPackage.java
@@ -18,7 +18,7 @@ import static org.hamcrest.CoreMatchers.nullValue;
 import static org.hamcrest.MatcherAssert.assertThat;
 
 import io.confluent.ksql.function.FunctionInvoker;
-import io.confluent.ksql.function.UdfLoader;
+import io.confluent.ksql.function.FunctionLoaderUtils;
 import org.junit.Test;
 
 public class TestUdfWithNoPackage {
@@ -35,7 +35,7 @@ public class TestUdfWithNoPackage {
 
     // When:
     // motivated by https://github.com/square/javapoet/pull/723
-    final FunctionInvoker udf = UdfLoader
+    final FunctionInvoker udf = FunctionLoaderUtils
         .createFunctionInvoker(getClass().getMethod("udf"));
 
     // Then:

--- a/ksql-engine/src/test/java/io/confluent/ksql/analyzer/QueryAnalyzerFunctionalTest.java
+++ b/ksql-engine/src/test/java/io/confluent/ksql/analyzer/QueryAnalyzerFunctionalTest.java
@@ -34,7 +34,7 @@ import io.confluent.ksql.execution.expression.tree.Expression;
 import io.confluent.ksql.execution.expression.tree.IntegerLiteral;
 import io.confluent.ksql.execution.plan.SelectExpression;
 import io.confluent.ksql.function.InternalFunctionRegistry;
-import io.confluent.ksql.function.UdfLoader;
+import io.confluent.ksql.function.UserFunctionLoader;
 import io.confluent.ksql.metastore.MetaStore;
 import io.confluent.ksql.metastore.model.DataSource;
 import io.confluent.ksql.metastore.model.KsqlStream;
@@ -199,7 +199,7 @@ public class QueryAnalyzerFunctionalTest {
   public void shouldAnalyseTableFunctions() {
 
     // We need to load udfs for this
-    UdfLoader loader = new UdfLoader(functionRegistry, new File(""),
+    UserFunctionLoader loader = new UserFunctionLoader(functionRegistry, new File(""),
         Thread.currentThread().getContextClassLoader(),
         s -> false,
         Optional.empty(), true

--- a/ksql-engine/src/test/java/io/confluent/ksql/function/UdtfLoaderTest.java
+++ b/ksql-engine/src/test/java/io/confluent/ksql/function/UdtfLoaderTest.java
@@ -212,15 +212,15 @@ public class UdtfLoaderTest {
 
   private static FunctionRegistry initializeFunctionRegistry() {
     final MutableFunctionRegistry functionRegistry = new InternalFunctionRegistry();
-    final UdfLoader pluginLoader = createUdfLoader(functionRegistry);
+    final UserFunctionLoader pluginLoader = createUdfLoader(functionRegistry);
     pluginLoader.load();
     return functionRegistry;
   }
 
-  private static UdfLoader createUdfLoader(
+  private static UserFunctionLoader createUdfLoader(
       final MutableFunctionRegistry functionRegistry
   ) {
-    return new UdfLoader(
+    return new UserFunctionLoader(
         functionRegistry,
         new File("src/test/resources/udf-example.jar"),
         PARENT_CLASS_LOADER,

--- a/ksql-rest-app/src/main/java/io/confluent/ksql/rest/server/KsqlRestApplication.java
+++ b/ksql-rest-app/src/main/java/io/confluent/ksql/rest/server/KsqlRestApplication.java
@@ -30,7 +30,7 @@ import io.confluent.ksql.ServiceInfo;
 import io.confluent.ksql.engine.KsqlEngine;
 import io.confluent.ksql.function.InternalFunctionRegistry;
 import io.confluent.ksql.function.MutableFunctionRegistry;
-import io.confluent.ksql.function.UdfLoader;
+import io.confluent.ksql.function.UserFunctionLoader;
 import io.confluent.ksql.json.JsonMapper;
 import io.confluent.ksql.logging.processing.ProcessingLogConfig;
 import io.confluent.ksql.logging.processing.ProcessingLogContext;
@@ -468,7 +468,7 @@ public final class KsqlRestApplication extends Application<KsqlRestConfig> imple
         hybridQueryIdGenerator
     );
 
-    UdfLoader.newInstance(ksqlConfig, functionRegistry, ksqlInstallDir).load();
+    UserFunctionLoader.newInstance(ksqlConfig, functionRegistry, ksqlInstallDir).load();
 
     final String commandTopic = KsqlInternalTopicUtils.getTopicName(
         ksqlConfig, KsqlRestConfig.COMMAND_TOPIC_SUFFIX);

--- a/ksql-rest-app/src/main/java/io/confluent/ksql/rest/server/StandaloneExecutor.java
+++ b/ksql-rest-app/src/main/java/io/confluent/ksql/rest/server/StandaloneExecutor.java
@@ -21,7 +21,7 @@ import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.Iterables;
 import io.confluent.ksql.KsqlExecutionContext;
 import io.confluent.ksql.engine.KsqlEngine;
-import io.confluent.ksql.function.UdfLoader;
+import io.confluent.ksql.function.UserFunctionLoader;
 import io.confluent.ksql.logging.processing.ProcessingLogConfig;
 import io.confluent.ksql.parser.KsqlParser.ParsedStatement;
 import io.confluent.ksql.parser.KsqlParser.PreparedStatement;
@@ -76,7 +76,7 @@ public class StandaloneExecutor implements Executable {
   private final KsqlConfig ksqlConfig;
   private final KsqlEngine ksqlEngine;
   private final String queriesFile;
-  private final UdfLoader udfLoader;
+  private final UserFunctionLoader udfLoader;
   private final CountDownLatch shutdownLatch = new CountDownLatch(1);
   private final boolean failOnNoQueries;
   private final VersionCheckerAgent versionChecker;
@@ -88,7 +88,7 @@ public class StandaloneExecutor implements Executable {
       final KsqlConfig ksqlConfig,
       final KsqlEngine ksqlEngine,
       final String queriesFile,
-      final UdfLoader udfLoader,
+      final UserFunctionLoader udfLoader,
       final boolean failOnNoQueries,
       final VersionCheckerAgent versionChecker,
       final BiFunction<KsqlExecutionContext, ServiceContext, Injector> injectorFactory

--- a/ksql-rest-app/src/main/java/io/confluent/ksql/rest/server/StandaloneExecutorFactory.java
+++ b/ksql-rest-app/src/main/java/io/confluent/ksql/rest/server/StandaloneExecutorFactory.java
@@ -21,7 +21,7 @@ import io.confluent.ksql.ServiceInfo;
 import io.confluent.ksql.engine.KsqlEngine;
 import io.confluent.ksql.function.InternalFunctionRegistry;
 import io.confluent.ksql.function.MutableFunctionRegistry;
-import io.confluent.ksql.function.UdfLoader;
+import io.confluent.ksql.function.UserFunctionLoader;
 import io.confluent.ksql.logging.processing.ProcessingLogConfig;
 import io.confluent.ksql.logging.processing.ProcessingLogContext;
 import io.confluent.ksql.query.id.SequentialQueryIdGenerator;
@@ -72,7 +72,7 @@ public final class StandaloneExecutorFactory {
         KsqlConfig ksqlConfig,
         KsqlEngine ksqlEngine,
         String queriesFile,
-        UdfLoader udfLoader,
+        UserFunctionLoader udfLoader,
         boolean failOnNoQueries,
         VersionCheckerAgent versionChecker,
         BiFunction<KsqlExecutionContext, ServiceContext, Injector> injectorFactory
@@ -117,8 +117,8 @@ public final class StandaloneExecutorFactory {
         ServiceInfo.create(ksqlConfig),
         new SequentialQueryIdGenerator());
 
-    final UdfLoader udfLoader =
-        UdfLoader.newInstance(ksqlConfig, functionRegistry, installDir);
+    final UserFunctionLoader udfLoader =
+        UserFunctionLoader.newInstance(ksqlConfig, functionRegistry, installDir);
 
     final VersionCheckerAgent versionChecker = versionCheckerFactory
         .apply(ksqlEngine::hasActiveQueries);

--- a/ksql-rest-app/src/test/java/io/confluent/ksql/rest/server/StandaloneExecutorTest.java
+++ b/ksql-rest-app/src/test/java/io/confluent/ksql/rest/server/StandaloneExecutorTest.java
@@ -39,7 +39,7 @@ import io.confluent.ksql.KsqlExecutionContext.ExecuteResult;
 import io.confluent.ksql.engine.KsqlEngine;
 import io.confluent.ksql.execution.expression.tree.StringLiteral;
 import io.confluent.ksql.execution.expression.tree.Type;
-import io.confluent.ksql.function.UdfLoader;
+import io.confluent.ksql.function.UserFunctionLoader;
 import io.confluent.ksql.logging.processing.ProcessingLogConfig;
 import io.confluent.ksql.name.ColumnName;
 import io.confluent.ksql.name.SourceName;
@@ -216,7 +216,7 @@ public class StandaloneExecutorTest {
   @Mock
   private KsqlExecutionContext sandBox;
   @Mock
-  private UdfLoader udfLoader;
+  private UserFunctionLoader udfLoader;
   @Mock
   private PersistentQueryMetadata persistentQuery;
   @Mock


### PR DESCRIPTION
### Description 

This is the 4th PR in a stack. The previous PR is https://github.com/confluentinc/ksql/pull/3687. please don't review the commits from the previous PR you will see in here.

This PR refactors UdfLoader to be more manageable - it was becoming a sprawling mega-class that did too much and suffered from poor cyclomatic complexity.

There is more or less zero new code in this PR - it pretty much extracts existing code to new classes and does some renaming.

Now:

* UdfLoader loads udfs
* UdafLoader loads udafs
* UdtfLoader loads udtfs
* UserFunctionLoader is the corordinator for the overall loading process
* FunctionLoaderUtils contains static util functions used by the different loaders
* UdfLoader Passes checkstyle cyclomatic complexity check (previously it didn't)

### Testing done 

Non functional change.

### Reviewer checklist
- [ ] Ensure docs are updated if necessary. (eg. if a user visible feature is being added or changed).
- [ ] Ensure relevant issues are linked (description should include text like "Fixes #<issue number>")

