### PR TITLE
refactor: use the function call expression in flat map step

### DIFF
--- a/ksql-engine/src/main/java/io/confluent/ksql/structured/SchemaKStream.java
+++ b/ksql-engine/src/main/java/io/confluent/ksql/structured/SchemaKStream.java
@@ -690,8 +690,7 @@ public class SchemaKStream<K> {
       final List<FunctionCall> tableFunctions,
       final QueryContext.Stacker contextStacker
   ) {
-    final List<TableFunctionApplier> tableFunctionAppliers = new ArrayList<>();
-    for (FunctionCall functionCall: tableFunctions) {
+    for (final FunctionCall functionCall: tableFunctions) {
       final ColumnReferenceExp exp = (ColumnReferenceExp)functionCall.getArguments().get(0);
       final ColumnName columnName = exp.getReference().name();
       final ColumnRef ref = ColumnRef.withoutSource(columnName);
@@ -699,22 +698,14 @@ public class SchemaKStream<K> {
       if (!indexInInput.isPresent()) {
         throw new IllegalArgumentException("Can't find input column " + columnName);
       }
-      final KsqlTableFunction tableFunction = UdtfUtil.resolveTableFunction(
-          functionRegistry,
-          functionCall,
-          getSchema()
-      );
-      final TableFunctionApplier tableFunctionApplier =
-          new TableFunctionApplier(tableFunction, indexInInput.getAsInt());
-      tableFunctionAppliers.add(tableFunctionApplier);
     }
     final StreamFlatMap<K> step = ExecutionStepFactory.streamFlatMap(
         contextStacker,
         sourceStep,
         outputSchema,
-        tableFunctionAppliers
+        tableFunctions
     );
-    return new SchemaKStream<K>(
+    return new SchemaKStream<>(
         step,
         keyFormat,
         keyField,

--- a/ksql-execution/src/main/java/io/confluent/ksql/execution/plan/StreamFlatMap.java
+++ b/ksql-execution/src/main/java/io/confluent/ksql/execution/plan/StreamFlatMap.java
@@ -15,6 +15,7 @@
 package io.confluent.ksql.execution.plan;
 
 import com.google.errorprone.annotations.Immutable;
+import io.confluent.ksql.execution.expression.tree.FunctionCall;
 import io.confluent.ksql.execution.function.udtf.TableFunctionApplier;
 import java.util.Collections;
 import java.util.List;
@@ -25,16 +26,16 @@ public class StreamFlatMap<K> implements ExecutionStep<KStreamHolder<K>> {
 
   private final ExecutionStepProperties properties;
   private final ExecutionStep<KStreamHolder<K>> source;
-  private final List<TableFunctionApplier> tableFunctionAppliers;
+  private final List<FunctionCall> tableFunctions;
 
   public StreamFlatMap(
       final ExecutionStepProperties properties,
       final ExecutionStep<KStreamHolder<K>> source,
-      final List<TableFunctionApplier> tableFunctionAppliers
+      final List<FunctionCall> tableFunctionAppliers
   ) {
     this.properties = Objects.requireNonNull(properties, "properties");
     this.source = Objects.requireNonNull(source, "source");
-    this.tableFunctionAppliers = Objects.requireNonNull(tableFunctionAppliers);
+    this.tableFunctions = Objects.requireNonNull(tableFunctionAppliers);
   }
 
   @Override
@@ -52,8 +53,8 @@ public class StreamFlatMap<K> implements ExecutionStep<KStreamHolder<K>> {
     return builder.visitFlatMap(this);
   }
 
-  public List<TableFunctionApplier> getTableFunctionAppliers() {
-    return tableFunctionAppliers;
+  public List<FunctionCall> getTableFunctions() {
+    return tableFunctions;
   }
 
   public ExecutionStep<KStreamHolder<K>> getSource() {

--- a/ksql-streams/src/main/java/io/confluent/ksql/execution/streams/ExecutionStepFactory.java
+++ b/ksql-streams/src/main/java/io/confluent/ksql/execution/streams/ExecutionStepFactory.java
@@ -147,13 +147,13 @@ public final class ExecutionStepFactory {
       final QueryContext.Stacker stacker,
       final ExecutionStep<KStreamHolder<K>> source,
       final LogicalSchema resultSchema,
-      final List<TableFunctionApplier> tableFunctionAppliers
+      final List<FunctionCall> tableFunctions
   ) {
     final QueryContext queryContext = stacker.getQueryContext();
     return new StreamFlatMap<>(
         new DefaultExecutionStepProperties(resultSchema, queryContext),
         source,
-        tableFunctionAppliers
+        tableFunctions
     );
   }
 

--- a/ksql-streams/src/main/java/io/confluent/ksql/execution/streams/KSPlanBuilder.java
+++ b/ksql-streams/src/main/java/io/confluent/ksql/execution/streams/KSPlanBuilder.java
@@ -130,7 +130,7 @@ public final class KSPlanBuilder implements PlanBuilder {
   @Override
   public <K> KStreamHolder<K> visitFlatMap(final StreamFlatMap<K> streamFlatMap) {
     final KStreamHolder<K> source = streamFlatMap.getSource().build(this);
-    return StreamFlatMapBuilder.build(source, streamFlatMap);
+    return StreamFlatMapBuilder.build(source, streamFlatMap, queryBuilder);
   }
 
   @Override

--- a/ksql-streams/src/main/java/io/confluent/ksql/execution/streams/StreamFlatMapBuilder.java
+++ b/ksql-streams/src/main/java/io/confluent/ksql/execution/streams/StreamFlatMapBuilder.java
@@ -15,9 +15,21 @@
 
 package io.confluent.ksql.execution.streams;
 
+import io.confluent.ksql.execution.builder.KsqlQueryBuilder;
+import io.confluent.ksql.execution.expression.tree.ColumnReferenceExp;
+import io.confluent.ksql.execution.expression.tree.FunctionCall;
+import io.confluent.ksql.execution.function.UdtfUtil;
 import io.confluent.ksql.execution.function.udtf.KudtfFlatMapper;
+import io.confluent.ksql.execution.function.udtf.TableFunctionApplier;
 import io.confluent.ksql.execution.plan.KStreamHolder;
 import io.confluent.ksql.execution.plan.StreamFlatMap;
+import io.confluent.ksql.function.KsqlTableFunction;
+import io.confluent.ksql.name.ColumnName;
+import io.confluent.ksql.schema.ksql.ColumnRef;
+import io.confluent.ksql.schema.ksql.LogicalSchema;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.OptionalInt;
 
 public final class StreamFlatMapBuilder {
 
@@ -26,9 +38,29 @@ public final class StreamFlatMapBuilder {
 
   public static <K> KStreamHolder<K> build(
       final KStreamHolder<K> stream,
-      final StreamFlatMap<K> step) {
+      final StreamFlatMap<K> step,
+      final KsqlQueryBuilder queryBuilder) {
+    final List<TableFunctionApplier> tableFunctionAppliers = new ArrayList<>();
+    final LogicalSchema schema = step.getSource().getSchema();
+    for (final FunctionCall functionCall : step.getTableFunctions()) {
+      final ColumnReferenceExp exp = (ColumnReferenceExp)functionCall.getArguments().get(0);
+      final ColumnName columnName = exp.getReference().name();
+      final ColumnRef ref = ColumnRef.withoutSource(columnName);
+      final OptionalInt indexInInput = schema.valueColumnIndex(ref);
+      if (!indexInInput.isPresent()) {
+        throw new IllegalArgumentException("Can't find input column " + columnName);
+      }
+      final KsqlTableFunction tableFunction = UdtfUtil.resolveTableFunction(
+          queryBuilder.getFunctionRegistry(),
+          functionCall,
+          schema
+      );
+      final TableFunctionApplier tableFunctionApplier =
+          new TableFunctionApplier(tableFunction, indexInInput.getAsInt());
+      tableFunctionAppliers.add(tableFunctionApplier);
+    }
     return stream.withStream(stream.getStream().flatMapValues(
-        new KudtfFlatMapper(step.getTableFunctionAppliers())));
+        new KudtfFlatMapper(tableFunctionAppliers)));
   }
 
 }


### PR DESCRIPTION
### Description 

This patch changes the flat map execution plan step to contain a list of
function calls, rather than a list of appliers. This is preferable because
FunctionCall is part of the model that will be serialized to the command/config
topic. This is also consistent with other steps that execute functions (projection,
aggregation).

### Testing done 
refactor, so just ran existing tests

### Reviewer checklist
- [ ] Ensure docs are updated if necessary. (eg. if a user visible feature is being added or changed).
- [ ] Ensure relevant issues are linked (description should include text like "Fixes #<issue number>")

