### PR TITLE
refactor: Lazy initialization of clients (admin, sr, ksql, connect)

### DIFF
--- a/ksql-engine/src/main/java/io/confluent/ksql/embedded/KsqlContext.java
+++ b/ksql-engine/src/main/java/io/confluent/ksql/embedded/KsqlContext.java
@@ -76,7 +76,7 @@ public class KsqlContext implements AutoCloseable {
   ) {
     Objects.requireNonNull(ksqlConfig, "ksqlConfig cannot be null.");
     final ServiceContext serviceContext =
-        ServiceContextFactory.create(ksqlConfig, DisabledKsqlClient.instance());
+        ServiceContextFactory.create(ksqlConfig, DisabledKsqlClient::instance);
     final MutableFunctionRegistry functionRegistry = new InternalFunctionRegistry();
     UserFunctionLoader.newInstance(ksqlConfig, functionRegistry, ".").load();
     final ServiceInfo serviceInfo = ServiceInfo.create(ksqlConfig);

--- a/ksql-engine/src/main/java/io/confluent/ksql/services/DefaultServiceContext.java
+++ b/ksql-engine/src/main/java/io/confluent/ksql/services/DefaultServiceContext.java
@@ -34,7 +34,7 @@ public class DefaultServiceContext implements ServiceContext {
   private final KafkaClientSupplier kafkaClientSupplier;
   private final MemoizedSupplier<Admin> adminClientSupplier;
   private final MemoizedSupplier<KafkaTopicClient>  topicClientSupplier;
-  private final Supplier<SchemaRegistryClient> srClientFactory;
+  private final Supplier<SchemaRegistryClient> srClientFactorySupplier;
   private final MemoizedSupplier<SchemaRegistryClient> srClient;
   private final MemoizedSupplier<ConnectClient> connectClientSupplier;
   private final MemoizedSupplier<SimpleKsqlClient> ksqlClientSupplier;
@@ -86,7 +86,7 @@ public class DefaultServiceContext implements ServiceContext {
     requireNonNull(adminClientSupplier, "adminClientSupplier");
     this.adminClientSupplier = new MemoizedSupplier<>(adminClientSupplier);
 
-    this.srClientFactory = requireNonNull(srClientSupplier, "srClientSupplier");
+    this.srClientFactorySupplier = requireNonNull(srClientSupplier, "srClientSupplier");
 
     requireNonNull(connectClientSupplier, "connectClientSupplier");
     this.connectClientSupplier = new MemoizedSupplier<>(
@@ -125,7 +125,7 @@ public class DefaultServiceContext implements ServiceContext {
 
   @Override
   public Supplier<SchemaRegistryClient> getSchemaRegistryClientFactory() {
-    return srClientFactory;
+    return srClientFactorySupplier;
   }
 
   @Override

--- a/ksql-engine/src/main/java/io/confluent/ksql/services/DefaultServiceContext.java
+++ b/ksql-engine/src/main/java/io/confluent/ksql/services/DefaultServiceContext.java
@@ -145,7 +145,8 @@ public class DefaultServiceContext implements ServiceContext {
     }
   }
 
-  private static final class MemoizedSupplier<T> implements Supplier<T> {
+
+  static final class MemoizedSupplier<T> implements Supplier<T> {
 
     private final Supplier<T> supplier;
     private volatile boolean initialized = false;

--- a/ksql-engine/src/main/java/io/confluent/ksql/services/KafkaTopicClientImpl.java
+++ b/ksql-engine/src/main/java/io/confluent/ksql/services/KafkaTopicClientImpl.java
@@ -75,11 +75,13 @@ public class KafkaTopicClientImpl implements KafkaTopicClient {
 
   /**
    * Construct a topic client from an existing admin client.
+   * Note, the admin client is shared between all methods of this class, i.e the admin client
+   * is created only once and then reused.
    *
-   * @param adminClient the admin client.
+   * @param sharedAdminClient the admin client .
    */
-  public KafkaTopicClientImpl(final Supplier<Admin> adminClient) {
-    this.adminClient = Objects.requireNonNull(adminClient, "adminClient");
+  public KafkaTopicClientImpl(final Supplier<Admin> sharedAdminClient) {
+    this.adminClient = Objects.requireNonNull(sharedAdminClient, "sharedAdminClient");
   }
 
   @Override

--- a/ksql-engine/src/main/java/io/confluent/ksql/services/KafkaTopicClientImpl.java
+++ b/ksql-engine/src/main/java/io/confluent/ksql/services/KafkaTopicClientImpl.java
@@ -33,6 +33,7 @@ import java.util.Objects;
 import java.util.Set;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeUnit;
+import java.util.function.Supplier;
 import java.util.stream.Collectors;
 import javax.annotation.concurrent.ThreadSafe;
 import org.apache.commons.lang3.exception.ExceptionUtils;
@@ -70,14 +71,14 @@ public class KafkaTopicClientImpl implements KafkaTopicClient {
   private static final String DEFAULT_REPLICATION_PROP = "default.replication.factor";
   private static final String DELETE_TOPIC_ENABLE = "delete.topic.enable";
 
-  private final Admin adminClient;
+  private final Supplier<Admin> adminClient;
 
   /**
    * Construct a topic client from an existing admin client.
    *
    * @param adminClient the admin client.
    */
-  public KafkaTopicClientImpl(final Admin adminClient) {
+  public KafkaTopicClientImpl(final Supplier<Admin> adminClient) {
     this.adminClient = Objects.requireNonNull(adminClient, "adminClient");
   }
 
@@ -108,7 +109,7 @@ public class KafkaTopicClientImpl implements KafkaTopicClient {
       );
 
       ExecutorUtil.executeWithRetries(
-          () -> adminClient.createTopics(
+          () -> adminClient.get().createTopics(
               Collections.singleton(newTopic),
               createOptions
           ).all().get(),
@@ -165,7 +166,7 @@ public class KafkaTopicClientImpl implements KafkaTopicClient {
   public Set<String> listTopicNames() {
     try {
       return ExecutorUtil.executeWithRetries(
-          () -> adminClient.listTopics().names().get(),
+          () -> adminClient.get().listTopics().names().get(),
           ExecutorUtil.RetryBehaviour.ON_RETRYABLE);
     } catch (final Exception e) {
       throw new KafkaResponseGetFailedException("Failed to retrieve Kafka Topic names", e);
@@ -184,7 +185,7 @@ public class KafkaTopicClientImpl implements KafkaTopicClient {
   public Map<String, TopicDescription> describeTopics(final Collection<String> topicNames) {
     try {
       return ExecutorUtil.executeWithRetries(
-          () -> adminClient.describeTopics(
+          () -> adminClient.get().describeTopics(
               topicNames,
               new DescribeTopicsOptions().includeAuthorizedOperations(true)
           ).all().get(),
@@ -228,7 +229,7 @@ public class KafkaTopicClientImpl implements KafkaTopicClient {
           Collections.singletonMap(resource, entries);
 
       ExecutorUtil.executeWithRetries(
-          () -> adminClient.incrementalAlterConfigs(request).all().get(),
+          () -> adminClient.get().incrementalAlterConfigs(request).all().get(),
           ExecutorUtil.RetryBehaviour.ON_RETRYABLE);
 
       return true;
@@ -263,7 +264,7 @@ public class KafkaTopicClientImpl implements KafkaTopicClient {
       return;
     }
 
-    final DeleteTopicsResult deleteTopicsResult = adminClient.deleteTopics(topicsToDelete);
+    final DeleteTopicsResult deleteTopicsResult = adminClient.get().deleteTopics(topicsToDelete);
     final Map<String, KafkaFuture<Void>> results = deleteTopicsResult.values();
     final List<String> failList = Lists.newArrayList();
     final List<Pair<String, Throwable>> exceptionList = Lists.newArrayList();
@@ -315,7 +316,7 @@ public class KafkaTopicClientImpl implements KafkaTopicClient {
   }
 
   private Config getConfig() {
-    return KafkaClusterUtil.getConfig(adminClient);
+    return KafkaClusterUtil.getConfig(adminClient.get());
   }
 
   private static boolean isInternalTopic(final String topicName, final String applicationId) {
@@ -344,7 +345,7 @@ public class KafkaTopicClientImpl implements KafkaTopicClient {
 
     try {
       final Config config = ExecutorUtil.executeWithRetries(
-          () -> adminClient.describeConfigs(request).all().get(),
+          () -> adminClient.get().describeConfigs(request).all().get(),
           ExecutorUtil.RetryBehaviour.ON_RETRYABLE).get(resource);
       return config.entries().stream()
           .filter(e -> includeDefaults
@@ -374,7 +375,7 @@ public class KafkaTopicClientImpl implements KafkaTopicClient {
           Collections.singletonMap(resource, new Config(entries));
 
       ExecutorUtil.executeWithRetries(
-          () -> adminClient.alterConfigs(request).all().get(),
+          () -> adminClient.get().alterConfigs(request).all().get(),
           ExecutorUtil.RetryBehaviour.ON_RETRYABLE);
 
       return true;

--- a/ksql-engine/src/main/java/io/confluent/ksql/services/ServiceContextFactory.java
+++ b/ksql-engine/src/main/java/io/confluent/ksql/services/ServiceContextFactory.java
@@ -21,16 +21,16 @@ import io.confluent.ksql.util.KsqlConfig;
 import java.util.Collections;
 import java.util.Optional;
 import java.util.function.Supplier;
-import org.apache.kafka.clients.admin.Admin;
 import org.apache.kafka.streams.KafkaClientSupplier;
 import org.apache.kafka.streams.processor.internals.DefaultKafkaClientSupplier;
 
 public final class ServiceContextFactory {
-  private ServiceContextFactory() {}
+
+  private ServiceContextFactory() { }
 
   public static ServiceContext create(
       final KsqlConfig ksqlConfig,
-      final SimpleKsqlClient ksqlClient
+      final Supplier<SimpleKsqlClient> ksqlClient
   ) {
     return create(
         ksqlConfig,
@@ -48,19 +48,16 @@ public final class ServiceContextFactory {
       final KafkaClientSupplier kafkaClientSupplier,
       final Supplier<SchemaRegistryClient> srClientFactory,
       final ConnectClient connectClient,
-      final SimpleKsqlClient ksqlClient
+      final Supplier<SimpleKsqlClient> ksqlClientSupplier
   ) {
-    final Admin adminClient = kafkaClientSupplier.getAdmin(
-        ksqlConfig.getKsqlAdminClientConfigProps()
-    );
 
     return new DefaultServiceContext(
         kafkaClientSupplier,
-        adminClient,
-        new KafkaTopicClientImpl(adminClient),
+        () -> kafkaClientSupplier
+            .getAdmin(ksqlConfig.getKsqlAdminClientConfigProps()),
         srClientFactory,
-        connectClient,
-        ksqlClient
+        () -> connectClient,
+        ksqlClientSupplier
     );
   }
 }

--- a/ksql-engine/src/main/java/io/confluent/ksql/services/ServiceContextFactory.java
+++ b/ksql-engine/src/main/java/io/confluent/ksql/services/ServiceContextFactory.java
@@ -30,16 +30,15 @@ public final class ServiceContextFactory {
 
   public static ServiceContext create(
       final KsqlConfig ksqlConfig,
-      final Supplier<SimpleKsqlClient> ksqlClient
+      final Supplier<SimpleKsqlClient> ksqlClientSupplier
   ) {
     return create(
         ksqlConfig,
         new DefaultKafkaClientSupplier(),
         new KsqlSchemaRegistryClientFactory(ksqlConfig, Collections.emptyMap())::get,
-        new DefaultConnectClient(
-            ksqlConfig.getString(KsqlConfig.CONNECT_URL_PROPERTY),
-            Optional.empty()),
-        ksqlClient
+        () -> new DefaultConnectClient(ksqlConfig.getString(KsqlConfig.CONNECT_URL_PROPERTY),
+                                       Optional.empty()),
+        ksqlClientSupplier
     );
   }
 
@@ -47,7 +46,7 @@ public final class ServiceContextFactory {
       final KsqlConfig ksqlConfig,
       final KafkaClientSupplier kafkaClientSupplier,
       final Supplier<SchemaRegistryClient> srClientFactory,
-      final ConnectClient connectClient,
+      final Supplier<ConnectClient> connectClientSupplier,
       final Supplier<SimpleKsqlClient> ksqlClientSupplier
   ) {
 
@@ -56,7 +55,7 @@ public final class ServiceContextFactory {
         () -> kafkaClientSupplier
             .getAdmin(ksqlConfig.getKsqlAdminClientConfigProps()),
         srClientFactory,
-        () -> connectClient,
+        connectClientSupplier,
         ksqlClientSupplier
     );
   }

--- a/ksql-engine/src/test/java/io/confluent/ksql/embedded/KsqlContextTestUtil.java
+++ b/ksql-engine/src/test/java/io/confluent/ksql/embedded/KsqlContextTestUtil.java
@@ -51,7 +51,7 @@ public final class KsqlContextTestUtil {
     final Admin adminClient = clientSupplier
         .getAdmin(ksqlConfig.getKsqlAdminClientConfigProps());
 
-    final KafkaTopicClient kafkaTopicClient = new KafkaTopicClientImpl(adminClient);
+    final KafkaTopicClient kafkaTopicClient = new KafkaTopicClientImpl(() -> adminClient);
 
     final ServiceContext serviceContext = TestServiceContext.create(
         clientSupplier,

--- a/ksql-engine/src/test/java/io/confluent/ksql/integration/JsonFormatTest.java
+++ b/ksql-engine/src/test/java/io/confluent/ksql/integration/JsonFormatTest.java
@@ -95,7 +95,7 @@ public class JsonFormatTest {
     streamName = "STREAM_" + COUNTER.getAndIncrement();
 
     ksqlConfig = KsqlConfigTestUtil.create(CLUSTER);
-    serviceContext = ServiceContextFactory.create(ksqlConfig, DisabledKsqlClient.instance());
+    serviceContext = ServiceContextFactory.create(ksqlConfig, DisabledKsqlClient::instance);
 
     ksqlEngine = new KsqlEngine(
         serviceContext,

--- a/ksql-engine/src/test/java/io/confluent/ksql/services/KafkaTopicClientImplTest.java
+++ b/ksql-engine/src/test/java/io/confluent/ksql/services/KafkaTopicClientImplTest.java
@@ -123,7 +123,7 @@ public class KafkaTopicClientImplTest {
         .andReturn(getCreateTopicsResult());
     replay(adminClient);
 
-    final KafkaTopicClient kafkaTopicClient = new KafkaTopicClientImpl(adminClient);
+    final KafkaTopicClient kafkaTopicClient = new KafkaTopicClientImpl(() -> adminClient);
     kafkaTopicClient.createTopic("test", 1, (short) 1);
     verify(adminClient);
   }
@@ -135,7 +135,7 @@ public class KafkaTopicClientImplTest {
         .andReturn(getCreateTopicsResult());
     replay(adminClient);
 
-    final KafkaTopicClient kafkaTopicClient = new KafkaTopicClientImpl(adminClient);
+    final KafkaTopicClient kafkaTopicClient = new KafkaTopicClientImpl(() -> adminClient);
     kafkaTopicClient.validateCreateTopic("test", 1, (short) 1);
     verify(adminClient);
   }
@@ -147,7 +147,7 @@ public class KafkaTopicClientImplTest {
         .andReturn(getDescribeTopicsResult());
     replay(adminClient);
 
-    final KafkaTopicClient kafkaTopicClient = new KafkaTopicClientImpl(adminClient);
+    final KafkaTopicClient kafkaTopicClient = new KafkaTopicClientImpl(() -> adminClient);
     kafkaTopicClient.createTopic(topicName1, 1, (short) 1);
     verify(adminClient);
   }
@@ -165,7 +165,7 @@ public class KafkaTopicClientImplTest {
     expect(adminClient.describeTopics(anyObject(), anyObject()))
         .andReturn(getDescribeTopicsResult());
     replay(adminClient);
-    final KafkaTopicClient kafkaTopicClient = new KafkaTopicClientImpl(adminClient);
+    final KafkaTopicClient kafkaTopicClient = new KafkaTopicClientImpl(() -> adminClient);
     kafkaTopicClient.createTopic(topicName1, 1, (short) 2);
     verify(adminClient);
   }
@@ -185,7 +185,7 @@ public class KafkaTopicClientImplTest {
         String.format("Authorization denied to Create on topic(s): [%s]", topicName1));
 
     // When:
-    final KafkaTopicClient kafkaTopicClient = new KafkaTopicClientImpl(adminClient);
+    final KafkaTopicClient kafkaTopicClient = new KafkaTopicClientImpl(() -> adminClient);
     kafkaTopicClient.createTopic(topicName1, 1, (short) 2);
     verify(adminClient);
   }
@@ -196,7 +196,7 @@ public class KafkaTopicClientImplTest {
     expect(adminClient.describeTopics(anyObject(), anyObject()))
         .andReturn(getDescribeTopicsResult());
     replay(adminClient);
-    final KafkaTopicClient kafkaTopicClient = new KafkaTopicClientImpl(adminClient);
+    final KafkaTopicClient kafkaTopicClient = new KafkaTopicClientImpl(() -> adminClient);
     kafkaTopicClient.createTopic(topicName1, 1, (short) -1);
     verify(adminClient);
   }
@@ -209,7 +209,7 @@ public class KafkaTopicClientImplTest {
     expect(adminClient.describeTopics(anyObject(), anyObject()))
         .andReturn(getDescribeTopicsResult());
     replay(adminClient);
-    final KafkaTopicClient kafkaTopicClient = new KafkaTopicClientImpl(adminClient);
+    final KafkaTopicClient kafkaTopicClient = new KafkaTopicClientImpl(() -> adminClient);
     kafkaTopicClient.createTopic(topicName1, 1, (short) 1);
     verify(adminClient);
   }
@@ -225,7 +225,7 @@ public class KafkaTopicClientImplTest {
     expect(adminClient.describeTopics(anyObject(), anyObject()))
         .andReturn(getDescribeTopicsResult()).once();
     replay(adminClient);
-    final KafkaTopicClient kafkaTopicClient = new KafkaTopicClientImpl(adminClient);
+    final KafkaTopicClient kafkaTopicClient = new KafkaTopicClientImpl(() -> adminClient);
     kafkaTopicClient.createTopic(topicName1, 1, (short) 1);
     verify(adminClient);
   }
@@ -240,7 +240,7 @@ public class KafkaTopicClientImplTest {
         .andReturn(describeTopicReturningUnknownPartitionException())
         .andReturn(describeTopicReturningUnknownPartitionException());
     replay(adminClient);
-    final KafkaTopicClient kafkaTopicClient = new KafkaTopicClientImpl(adminClient);
+    final KafkaTopicClient kafkaTopicClient = new KafkaTopicClientImpl(() -> adminClient);
     kafkaTopicClient.describeTopics(Collections.singleton(topicName1));
     verify(adminClient);
   }
@@ -260,7 +260,7 @@ public class KafkaTopicClientImplTest {
         String.format("Authorization denied to Describe on topic(s): [%s]", topicName1));
 
     // When:
-    final KafkaTopicClient kafkaTopicClient = new KafkaTopicClientImpl(adminClient);
+    final KafkaTopicClient kafkaTopicClient = new KafkaTopicClientImpl(() -> adminClient);
     kafkaTopicClient.describeTopics(Collections.singleton(topicName1));
     verify(adminClient);
   }
@@ -270,7 +270,7 @@ public class KafkaTopicClientImplTest {
     expect(adminClient.listTopics()).andReturn(listTopicResultWithNotControllerException()).once();
     expect(adminClient.listTopics()).andReturn(getListTopicsResult());
     replay(adminClient);
-    final KafkaTopicClient kafkaTopicClient = new KafkaTopicClientImpl(adminClient);
+    final KafkaTopicClient kafkaTopicClient = new KafkaTopicClientImpl(() -> adminClient);
     final Set<String> names = kafkaTopicClient.listTopicNames();
     assertThat(names, equalTo(Utils.mkSet(topicName1, topicName2, topicName3)));
     verify(adminClient);
@@ -280,7 +280,7 @@ public class KafkaTopicClientImplTest {
   public void shouldFilterInternalTopics() {
     expect(adminClient.listTopics()).andReturn(getListTopicsResultWithInternalTopics());
     replay(adminClient);
-    final KafkaTopicClient kafkaTopicClient = new KafkaTopicClientImpl(adminClient);
+    final KafkaTopicClient kafkaTopicClient = new KafkaTopicClientImpl(() -> adminClient);
     final Set<String> names = kafkaTopicClient.listNonInternalTopicNames();
     assertThat(names, equalTo(Utils.mkSet(topicName1, topicName2, topicName3)));
     verify(adminClient);
@@ -290,7 +290,7 @@ public class KafkaTopicClientImplTest {
   public void shouldListTopicNames() {
     expect(adminClient.listTopics()).andReturn(getListTopicsResult());
     replay(adminClient);
-    final KafkaTopicClient kafkaTopicClient = new KafkaTopicClientImpl(adminClient);
+    final KafkaTopicClient kafkaTopicClient = new KafkaTopicClientImpl(() -> adminClient);
     final Set<String> names = kafkaTopicClient.listTopicNames();
     assertThat(names, equalTo(Utils.mkSet(topicName1, topicName2, topicName3)));
     verify(adminClient);
@@ -300,7 +300,7 @@ public class KafkaTopicClientImplTest {
   public void shouldDeleteTopics() {
     expect(adminClient.deleteTopics(anyObject())).andReturn(getDeleteTopicsResult());
     replay(adminClient);
-    final KafkaTopicClient kafkaTopicClient = new KafkaTopicClientImpl(adminClient);
+    final KafkaTopicClient kafkaTopicClient = new KafkaTopicClientImpl(() -> adminClient);
     final List<String> topics = Collections.singletonList(topicName2);
     kafkaTopicClient.deleteTopics(topics);
     verify(adminClient);
@@ -310,7 +310,7 @@ public class KafkaTopicClientImplTest {
   public void shouldReturnIfDeleteTopicsIsEmpty() {
     // Given:
     replay(adminClient);
-    final KafkaTopicClient kafkaTopicClient = new KafkaTopicClientImpl(adminClient);
+    final KafkaTopicClient kafkaTopicClient = new KafkaTopicClientImpl(() -> adminClient);
 
     // When:
     kafkaTopicClient.deleteTopics(Collections.emptyList());
@@ -324,7 +324,7 @@ public class KafkaTopicClientImplTest {
     expect(adminClient.deleteTopics(Arrays.asList(internalTopic2, internalTopic1)))
         .andReturn(getDeleteInternalTopicsResult());
     replay(adminClient);
-    final KafkaTopicClient kafkaTopicClient = new KafkaTopicClientImpl(adminClient);
+    final KafkaTopicClient kafkaTopicClient = new KafkaTopicClientImpl(() -> adminClient);
     final String applicationId = String.format("%s%s",
         KsqlConstants.KSQL_INTERNAL_TOPIC_PREFIX,
         "default_query_CTAS_USERS_BY_CITY");
@@ -340,7 +340,7 @@ public class KafkaTopicClientImplTest {
         deleteTopicException(new TopicDeletionDisabledException("error")));
     replay(adminClient);
 
-    final KafkaTopicClient kafkaTopicClient = new KafkaTopicClientImpl(adminClient);
+    final KafkaTopicClient kafkaTopicClient = new KafkaTopicClientImpl(() -> adminClient);
 
     // When:
     kafkaTopicClient.deleteTopics(Collections.singletonList(topicName1));
@@ -354,7 +354,7 @@ public class KafkaTopicClientImplTest {
         (deleteTopicException(new TopicAuthorizationException("error"))));
     replay(adminClient);
 
-    final KafkaTopicClient kafkaTopicClient = new KafkaTopicClientImpl(adminClient);
+    final KafkaTopicClient kafkaTopicClient = new KafkaTopicClientImpl(() -> adminClient);
 
     // Expect:
     expectedException.expect(KsqlTopicAuthorizationException.class);
@@ -373,7 +373,7 @@ public class KafkaTopicClientImplTest {
         (deleteTopicException(new Exception("error"))));
     replay(adminClient);
 
-    final KafkaTopicClient kafkaTopicClient = new KafkaTopicClientImpl(adminClient);
+    final KafkaTopicClient kafkaTopicClient = new KafkaTopicClientImpl(() -> adminClient);
 
     // When:
     kafkaTopicClient.deleteTopics(Collections.singletonList(topicName1));
@@ -387,7 +387,7 @@ public class KafkaTopicClientImplTest {
         (deleteTopicException(new UnknownTopicOrPartitionException("error"))));
     replay(adminClient);
 
-    final KafkaTopicClient kafkaTopicClient = new KafkaTopicClientImpl(adminClient);
+    final KafkaTopicClient kafkaTopicClient = new KafkaTopicClientImpl(() -> adminClient);
 
     // When:
     kafkaTopicClient.deleteTopics(Collections.singletonList(topicName1));
@@ -403,7 +403,7 @@ public class KafkaTopicClientImplTest {
         ));
     replay(adminClient);
 
-    final KafkaTopicClient kafkaTopicClient = new KafkaTopicClientImpl(adminClient);
+    final KafkaTopicClient kafkaTopicClient = new KafkaTopicClientImpl(() -> adminClient);
     final Map<String, String> config = kafkaTopicClient.getTopicConfig("fred");
 
     assertThat(config.get(TopicConfig.RETENTION_MS_CONFIG), is("12345"));
@@ -416,7 +416,7 @@ public class KafkaTopicClientImplTest {
         .andReturn(topicConfigResponse(new RuntimeException()));
     replay(adminClient);
 
-    final KafkaTopicClient kafkaTopicClient = new KafkaTopicClientImpl(adminClient);
+    final KafkaTopicClient kafkaTopicClient = new KafkaTopicClientImpl(() -> adminClient);
     final Map<String, String> config = kafkaTopicClient.getTopicConfig("fred");
 
     assertThat(config.get(TopicConfig.RETENTION_MS_CONFIG), is("12345"));
@@ -434,7 +434,7 @@ public class KafkaTopicClientImplTest {
         ));
     replay(adminClient);
 
-    final KafkaTopicClient kafkaTopicClient = new KafkaTopicClientImpl(adminClient);
+    final KafkaTopicClient kafkaTopicClient = new KafkaTopicClientImpl(() -> adminClient);
     final Map<String, String> config = kafkaTopicClient.getTopicConfig("fred");
 
     assertThat(config.get(TopicConfig.RETENTION_MS_CONFIG), is("12345"));
@@ -452,7 +452,7 @@ public class KafkaTopicClientImplTest {
         .andReturn(getCreateTopicsResult());
     replay(adminClient);
 
-    final KafkaTopicClient kafkaTopicClient = new KafkaTopicClientImpl(adminClient);
+    final KafkaTopicClient kafkaTopicClient = new KafkaTopicClientImpl(() -> adminClient);
     kafkaTopicClient.createTopic(topicName1,
         1,
         (short) 1,
@@ -482,7 +482,7 @@ public class KafkaTopicClientImplTest {
         .andReturn(alterTopicConfigResponse());
     replay(adminClient);
 
-    final KafkaTopicClient kafkaTopicClient = new KafkaTopicClientImpl(adminClient);
+    final KafkaTopicClient kafkaTopicClient = new KafkaTopicClientImpl(() -> adminClient);
     kafkaTopicClient.addTopicConfig("peter", overrides);
 
     verify(adminClient);
@@ -515,7 +515,7 @@ public class KafkaTopicClientImplTest {
         .andReturn(alterTopicConfigResponse());
     replay(adminClient);
 
-    final KafkaTopicClient kafkaTopicClient = new KafkaTopicClientImpl(adminClient);
+    final KafkaTopicClient kafkaTopicClient = new KafkaTopicClientImpl(() -> adminClient);
     kafkaTopicClient.addTopicConfig("peter", overrides);
 
     verify(adminClient);
@@ -536,7 +536,7 @@ public class KafkaTopicClientImplTest {
 
     replay(adminClient);
 
-    final KafkaTopicClient kafkaTopicClient = new KafkaTopicClientImpl(adminClient);
+    final KafkaTopicClient kafkaTopicClient = new KafkaTopicClientImpl(() -> adminClient);
     kafkaTopicClient.addTopicConfig("peter", overrides);
 
     verify(adminClient);
@@ -560,7 +560,7 @@ public class KafkaTopicClientImplTest {
         .andReturn(alterTopicConfigResponse());
     replay(adminClient);
 
-    final KafkaTopicClient kafkaTopicClient = new KafkaTopicClientImpl(adminClient);
+    final KafkaTopicClient kafkaTopicClient = new KafkaTopicClientImpl(() -> adminClient);
     kafkaTopicClient.addTopicConfig("peter", overrides);
 
     verify(adminClient);

--- a/ksql-engine/src/test/java/io/confluent/ksql/services/MemoizedSupplierTest.java
+++ b/ksql-engine/src/test/java/io/confluent/ksql/services/MemoizedSupplierTest.java
@@ -1,0 +1,60 @@
+/*
+ * Copyright 2019 Confluent Inc.
+ *
+ * Licensed under the Confluent Community License (the "License"; you may not use
+ * this file except in compliance with the License. You may obtain a copy of the
+ * License at
+ *
+ * http://www.confluent.io/confluent-community-license
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package io.confluent.ksql.services;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.sameInstance;
+import static org.hamcrest.Matchers.is;
+
+import io.confluent.ksql.services.DefaultServiceContext.MemoizedSupplier;
+import org.junit.Test;
+
+public class MemoizedSupplierTest {
+
+  @Test
+  public void shouldReturnIsInitializedAfterConstructor() {
+    // Given
+    MemoizedSupplier<String> memoizedSupplier = new MemoizedSupplier<>(() -> "");
+
+    // When
+    memoizedSupplier.get();
+
+    // Then
+    assertThat(memoizedSupplier.isInitialized(), is(true));
+  }
+
+  @Test
+  public void shouldReturnNotInitializedAfterConstructor() {
+    // Given
+    MemoizedSupplier<String> memoizedSupplier = new MemoizedSupplier<>(() -> "");
+
+    // Then
+    assertThat(memoizedSupplier.isInitialized(), is(false));
+  }
+
+  @Test
+  public void shouldReturnSameInstance() {
+    // Given
+    MemoizedSupplier<String> memoizedSupplier = new MemoizedSupplier<>(() -> "");
+
+    // When
+    String s1 = memoizedSupplier.get();
+    String s2 = memoizedSupplier.get();
+
+    // Then
+    assertThat(s1, sameInstance(s2));
+  }
+}

--- a/ksql-engine/src/test/java/io/confluent/ksql/services/TestServiceContext.java
+++ b/ksql-engine/src/test/java/io/confluent/ksql/services/TestServiceContext.java
@@ -79,7 +79,7 @@ public final class TestServiceContext {
     return create(
         kafkaClientSupplier,
         adminClient,
-        new KafkaTopicClientImpl(adminClient),
+        new KafkaTopicClientImpl(() -> adminClient),
         srClientFactory,
         new DefaultConnectClient(
             ksqlConfig.getString(KsqlConfig.CONNECT_URL_PROPERTY),
@@ -96,10 +96,11 @@ public final class TestServiceContext {
   ) {
     return new DefaultServiceContext(
         kafkaClientSupplier,
-        adminClient, topicClient,
+        () -> adminClient,
+        topicClient,
         srClientFactory,
-        connectClient,
-        DisabledKsqlClient.instance()
+        () -> connectClient,
+        DisabledKsqlClient::instance
     );
   }
 }

--- a/ksql-engine/src/test/java/io/confluent/ksql/util/KafkaTopicClientImplIntegrationTest.java
+++ b/ksql-engine/src/test/java/io/confluent/ksql/util/KafkaTopicClientImplIntegrationTest.java
@@ -76,7 +76,7 @@ public class KafkaTopicClientImplIntegrationTest {
     adminClient = AdminClient.create(ImmutableMap.of(
         AdminClientConfig.BOOTSTRAP_SERVERS_CONFIG, KAFKA.bootstrapServers()));
 
-    client = new KafkaTopicClientImpl(adminClient);
+    client = new KafkaTopicClientImpl(() -> adminClient);
 
     allowForAsyncTopicCreation();
   }

--- a/ksql-functional-tests/src/main/java/io/confluent/ksql/test/tools/TestExecutor.java
+++ b/ksql-functional-tests/src/main/java/io/confluent/ksql/test/tools/TestExecutor.java
@@ -430,13 +430,14 @@ public class TestExecutor implements Closeable {
 
   static ServiceContext getServiceContext() {
     final SchemaRegistryClient schemaRegistryClient = new MockSchemaRegistryClient();
+
     return new DefaultServiceContext(
         new StubKafkaClientSupplier(),
-        new StubKafkaClientSupplier().getAdmin(Collections.emptyMap()),
+        () -> new StubKafkaClientSupplier().getAdmin(Collections.emptyMap()),
         new StubKafkaTopicClient(),
         () -> schemaRegistryClient,
-        new DefaultConnectClient("http://localhost:8083", Optional.empty()),
-        DisabledKsqlClient.instance()
+        () -> new DefaultConnectClient("http://localhost:8083", Optional.empty()),
+        DisabledKsqlClient::instance
     );
   }
 

--- a/ksql-rest-app/src/main/java/io/confluent/ksql/rest/server/KsqlRestApplication.java
+++ b/ksql-rest-app/src/main/java/io/confluent/ksql/rest/server/KsqlRestApplication.java
@@ -135,7 +135,7 @@ public final class KsqlRestApplication extends ExecutableApplication<KsqlRestCon
   private final KsqlResource ksqlResource;
   private final VersionCheckerAgent versionCheckerAgent;
   private final ServiceContext serviceContext;
-  private final BiFunction<KsqlConfig, KsqlSecurityExtension, Binder>  serviceContextBinderFactory;
+  private final BiFunction<KsqlConfig, KsqlSecurityExtension, Binder> serviceContextBinderFactory;
   private final KsqlSecurityExtension securityExtension;
   private final ServerState serverState;
   private final ProcessingLogContext processingLogContext;

--- a/ksql-rest-app/src/main/java/io/confluent/ksql/rest/server/StandaloneExecutorFactory.java
+++ b/ksql-rest-app/src/main/java/io/confluent/ksql/rest/server/StandaloneExecutorFactory.java
@@ -57,7 +57,7 @@ public final class StandaloneExecutorFactory {
         properties,
         queriesFile,
         installDir,
-        config -> ServiceContextFactory.create(config, DisabledKsqlClient.instance()),
+        config -> ServiceContextFactory.create(config, DisabledKsqlClient::instance),
         KafkaConfigStore::new,
         KsqlVersionCheckerAgent::new,
         StandaloneExecutor::new

--- a/ksql-rest-app/src/main/java/io/confluent/ksql/rest/server/services/RestServiceContextFactory.java
+++ b/ksql-rest-app/src/main/java/io/confluent/ksql/rest/server/services/RestServiceContextFactory.java
@@ -72,7 +72,8 @@ public final class RestServiceContextFactory {
         ksqlConfig,
         kafkaClientSupplier,
         srClientFactory,
-        new DefaultConnectClient(ksqlConfig.getString(KsqlConfig.CONNECT_URL_PROPERTY), authHeader),
+        () -> new DefaultConnectClient(ksqlConfig.getString(KsqlConfig.CONNECT_URL_PROPERTY),
+                                       authHeader),
         () -> new DefaultKsqlClient(authHeader)
     );
   }

--- a/ksql-rest-app/src/main/java/io/confluent/ksql/rest/server/services/RestServiceContextFactory.java
+++ b/ksql-rest-app/src/main/java/io/confluent/ksql/rest/server/services/RestServiceContextFactory.java
@@ -73,7 +73,7 @@ public final class RestServiceContextFactory {
         kafkaClientSupplier,
         srClientFactory,
         new DefaultConnectClient(ksqlConfig.getString(KsqlConfig.CONNECT_URL_PROPERTY), authHeader),
-        new DefaultKsqlClient(authHeader)
+        () -> new DefaultKsqlClient(authHeader)
     );
   }
 }

--- a/ksql-rest-app/src/test/java/io/confluent/ksql/rest/server/TestKsqlRestApp.java
+++ b/ksql-rest-app/src/test/java/io/confluent/ksql/rest/server/TestKsqlRestApp.java
@@ -414,7 +414,7 @@ public class TestKsqlRestApp extends ExternalResource {
     final KsqlConfig config =
         new KsqlConfig(buildConfig(bootstrapServers, baseConfig).getKsqlConfigProperties());
 
-    return ServiceContextFactory.create(config, DisabledKsqlClient.instance());
+    return ServiceContextFactory.create(config, DisabledKsqlClient::instance);
   }
 
   public static final class Builder {

--- a/ksql-rest-app/src/test/java/io/confluent/ksql/rest/server/resources/streaming/StreamedQueryResourceTest.java
+++ b/ksql-rest-app/src/test/java/io/confluent/ksql/rest/server/resources/streaming/StreamedQueryResourceTest.java
@@ -133,6 +133,10 @@ public class StreamedQueryResourceTest {
   private KsqlAuthorizationValidator authorizationValidator;
   private StreamedQueryResource testResource;
 
+
+  private final static String queryString = "SELECT * FROM test_stream EMIT CHANGES;";
+  private final static String printString = "Print TEST_TOPIC;";
+  private final static String topicName = "test_stream";
   private PreparedStatement<Statement> statement;
 
   @Before


### PR DESCRIPTION
### Description 
Fixes #3663 

When RBAC is not enabled, a new service context with kafka, sr, ksql clients is created PER request. With this PR, we will reuse the default SchemaContext created when the ksql REST application starts in the case of not enabled RBAC.

Open issues that need to resolved after the release: Should we make the `SchemaRegistryClient` lazy as well? Issue #3852 


### Testing done 
Added tests to `StreamedQueryResourceTest` and `MemoizedSupplierTest`

### Reviewer checklist
- [ ] Ensure docs are updated if necessary. (eg. if a user visible feature is being added or changed).
- [ ] Ensure relevant issues are linked (description should include text like "Fixes #<issue number>")

