### PR TITLE
refactor: rename CommandRunner's StatementExecutor to InteractiveStatementExecutor (MINOR)

### DIFF
--- a/docs/developer-guide/udf.rst
+++ b/docs/developer-guide/udf.rst
@@ -922,7 +922,7 @@ in the KSQL server log (ksql.log) . The error would look something like:
 
 ::
 
-    [2018-07-04 12:37:28,602] ERROR Failed to handle: Command{statement='create stream pageviews_ts as select tostring(viewtime) from pageviews;', overwriteProperties={}} (io.confluent.ksql.rest.server.computation.StatementExecutor:210)
+    [2018-07-04 12:37:28,602] ERROR Failed to handle: Command{statement='create stream pageviews_ts as select tostring(viewtime) from pageviews;', overwriteProperties={}} (io.confluent.ksql.rest.server.computation.InteractiveStatementExecutor:218)
     io.confluent.ksql.util.KsqlException: Can't find any functions with the name 'TOSTRING'
 
 

--- a/ksql-rest-app/src/main/java/io/confluent/ksql/rest/server/KsqlRestApplication.java
+++ b/ksql-rest-app/src/main/java/io/confluent/ksql/rest/server/KsqlRestApplication.java
@@ -43,7 +43,7 @@ import io.confluent.ksql.rest.entity.KsqlErrorMessage;
 import io.confluent.ksql.rest.server.computation.CommandQueue;
 import io.confluent.ksql.rest.server.computation.CommandRunner;
 import io.confluent.ksql.rest.server.computation.CommandStore;
-import io.confluent.ksql.rest.server.computation.StatementExecutor;
+import io.confluent.ksql.rest.server.computation.InteractiveStatementExecutor;
 import io.confluent.ksql.rest.server.context.KsqlRestServiceContextBinder;
 import io.confluent.ksql.rest.server.filters.KsqlAuthorizationFilter;
 import io.confluent.ksql.rest.server.resources.HealthCheckResource;
@@ -475,12 +475,12 @@ public final class KsqlRestApplication extends ExecutableApplication<KsqlRestCon
         restConfig.getCommandConsumerProperties(),
         restConfig.getCommandProducerProperties());
 
-    final StatementExecutor statementExecutor =
-        new StatementExecutor(serviceContext, ksqlEngine, hybridQueryIdGenerator);
+    final InteractiveStatementExecutor interactiveStatementExecutor =
+        new InteractiveStatementExecutor(serviceContext, ksqlEngine, hybridQueryIdGenerator);
 
     final RootDocument rootDocument = new RootDocument();
 
-    final StatusResource statusResource = new StatusResource(statementExecutor);
+    final StatusResource statusResource = new StatusResource(interactiveStatementExecutor);
     final VersionCheckerAgent versionChecker
         = versionCheckerFactory.apply(ksqlEngine::hasActiveQueries);
 
@@ -515,7 +515,7 @@ public final class KsqlRestApplication extends ExecutableApplication<KsqlRestCon
       managedTopics.add(ProcessingLogServerUtils.getTopicName(processingLogConfig, ksqlConfig));
     }
     final CommandRunner commandRunner = new CommandRunner(
-        statementExecutor,
+        interactiveStatementExecutor,
         commandStore,
         maxStatementRetries,
         new ClusterTerminator(ksqlEngine, serviceContext, managedTopics),
@@ -530,7 +530,7 @@ public final class KsqlRestApplication extends ExecutableApplication<KsqlRestCon
     final List<KsqlConfigurable> configurables = ImmutableList.of(
         ksqlResource,
         streamedQueryResource,
-        statementExecutor
+        interactiveStatementExecutor
     );
 
     final Consumer<KsqlConfig> rocksDBConfigSetterHandler =

--- a/ksql-rest-app/src/main/java/io/confluent/ksql/rest/server/KsqlRestApplication.java
+++ b/ksql-rest-app/src/main/java/io/confluent/ksql/rest/server/KsqlRestApplication.java
@@ -475,12 +475,12 @@ public final class KsqlRestApplication extends ExecutableApplication<KsqlRestCon
         restConfig.getCommandConsumerProperties(),
         restConfig.getCommandProducerProperties());
 
-    final InteractiveStatementExecutor interactiveStatementExecutor =
+    final InteractiveStatementExecutor statementExecutor =
         new InteractiveStatementExecutor(serviceContext, ksqlEngine, hybridQueryIdGenerator);
 
     final RootDocument rootDocument = new RootDocument();
 
-    final StatusResource statusResource = new StatusResource(interactiveStatementExecutor);
+    final StatusResource statusResource = new StatusResource(statementExecutor);
     final VersionCheckerAgent versionChecker
         = versionCheckerFactory.apply(ksqlEngine::hasActiveQueries);
 
@@ -515,7 +515,7 @@ public final class KsqlRestApplication extends ExecutableApplication<KsqlRestCon
       managedTopics.add(ProcessingLogServerUtils.getTopicName(processingLogConfig, ksqlConfig));
     }
     final CommandRunner commandRunner = new CommandRunner(
-        interactiveStatementExecutor,
+        statementExecutor,
         commandStore,
         maxStatementRetries,
         new ClusterTerminator(ksqlEngine, serviceContext, managedTopics),
@@ -530,7 +530,7 @@ public final class KsqlRestApplication extends ExecutableApplication<KsqlRestCon
     final List<KsqlConfigurable> configurables = ImmutableList.of(
         ksqlResource,
         streamedQueryResource,
-        interactiveStatementExecutor
+        statementExecutor
     );
 
     final Consumer<KsqlConfig> rocksDBConfigSetterHandler =

--- a/ksql-rest-app/src/main/java/io/confluent/ksql/rest/server/computation/InteractiveStatementExecutor.java
+++ b/ksql-rest-app/src/main/java/io/confluent/ksql/rest/server/computation/InteractiveStatementExecutor.java
@@ -61,9 +61,9 @@ import org.slf4j.LoggerFactory;
  * Handles the actual execution (or delegation to KSQL core) of all distributed statements, as well
  * as tracking their statuses as things move along.
  */
-public class StatementExecutor implements KsqlConfigurable {
+public class InteractiveStatementExecutor implements KsqlConfigurable {
 
-  private static final Logger log = LoggerFactory.getLogger(StatementExecutor.class);
+  private static final Logger log = LoggerFactory.getLogger(InteractiveStatementExecutor.class);
 
   private final ServiceContext serviceContext;
   private final KsqlEngine ksqlEngine;
@@ -77,7 +77,7 @@ public class StatementExecutor implements KsqlConfigurable {
     EXECUTE
   }
 
-  public StatementExecutor(
+  public InteractiveStatementExecutor(
       final ServiceContext serviceContext,
       final KsqlEngine ksqlEngine,
       final HybridQueryIdGenerator hybridQueryIdGenerator
@@ -91,7 +91,7 @@ public class StatementExecutor implements KsqlConfigurable {
   }
 
   @VisibleForTesting
-  StatementExecutor(
+  InteractiveStatementExecutor(
       final ServiceContext serviceContext,
       final KsqlEngine ksqlEngine,
       final StatementParser statementParser,

--- a/ksql-rest-app/src/main/java/io/confluent/ksql/rest/server/resources/StatusResource.java
+++ b/ksql-rest-app/src/main/java/io/confluent/ksql/rest/server/resources/StatusResource.java
@@ -33,16 +33,15 @@ import javax.ws.rs.core.Response;
 @Produces({Versions.KSQL_V1_JSON, MediaType.APPLICATION_JSON})
 public class StatusResource {
 
-  private final InteractiveStatementExecutor interactiveStatementExecutor;
+  private final InteractiveStatementExecutor statementExecutor;
 
-  public StatusResource(final InteractiveStatementExecutor interactiveStatementExecutor) {
-    this.interactiveStatementExecutor = interactiveStatementExecutor;
+  public StatusResource(final InteractiveStatementExecutor statementExecutor) {
+    this.statementExecutor = statementExecutor;
   }
 
   @GET
   public Response getAllStatuses() {
-    return Response.ok(
-        CommandStatuses.fromFullStatuses(interactiveStatementExecutor.getStatuses())).build();
+    return Response.ok(CommandStatuses.fromFullStatuses(statementExecutor.getStatuses())).build();
   }
 
   @GET
@@ -53,7 +52,7 @@ public class StatusResource {
       @PathParam("action") final String action) {
     final CommandId commandId = new CommandId(type, entity, action);
 
-    final Optional<CommandStatus> commandStatus = interactiveStatementExecutor.getStatus(commandId);
+    final Optional<CommandStatus> commandStatus = statementExecutor.getStatus(commandId);
 
     if (!commandStatus.isPresent()) {
       return Errors.notFound("Command not found");

--- a/ksql-rest-app/src/main/java/io/confluent/ksql/rest/server/resources/StatusResource.java
+++ b/ksql-rest-app/src/main/java/io/confluent/ksql/rest/server/resources/StatusResource.java
@@ -20,7 +20,7 @@ import io.confluent.ksql.rest.entity.CommandId;
 import io.confluent.ksql.rest.entity.CommandStatus;
 import io.confluent.ksql.rest.entity.CommandStatuses;
 import io.confluent.ksql.rest.entity.Versions;
-import io.confluent.ksql.rest.server.computation.StatementExecutor;
+import io.confluent.ksql.rest.server.computation.InteractiveStatementExecutor;
 import java.util.Optional;
 import javax.ws.rs.GET;
 import javax.ws.rs.Path;
@@ -33,15 +33,16 @@ import javax.ws.rs.core.Response;
 @Produces({Versions.KSQL_V1_JSON, MediaType.APPLICATION_JSON})
 public class StatusResource {
 
-  private final StatementExecutor statementExecutor;
+  private final InteractiveStatementExecutor interactiveStatementExecutor;
 
-  public StatusResource(final StatementExecutor statementExecutor) {
-    this.statementExecutor = statementExecutor;
+  public StatusResource(final InteractiveStatementExecutor interactiveStatementExecutor) {
+    this.interactiveStatementExecutor = interactiveStatementExecutor;
   }
 
   @GET
   public Response getAllStatuses() {
-    return Response.ok(CommandStatuses.fromFullStatuses(statementExecutor.getStatuses())).build();
+    return Response.ok(
+        CommandStatuses.fromFullStatuses(interactiveStatementExecutor.getStatuses())).build();
   }
 
   @GET
@@ -52,7 +53,7 @@ public class StatusResource {
       @PathParam("action") final String action) {
     final CommandId commandId = new CommandId(type, entity, action);
 
-    final Optional<CommandStatus> commandStatus = statementExecutor.getStatus(commandId);
+    final Optional<CommandStatus> commandStatus = interactiveStatementExecutor.getStatus(commandId);
 
     if (!commandStatus.isPresent()) {
       return Errors.notFound("Command not found");

--- a/ksql-rest-app/src/test/java/io/confluent/ksql/rest/server/computation/CommandRunnerTest.java
+++ b/ksql-rest-app/src/test/java/io/confluent/ksql/rest/server/computation/CommandRunnerTest.java
@@ -47,7 +47,7 @@ import org.mockito.stubbing.Answer;
 public class CommandRunnerTest {
 
   @Mock
-  private StatementExecutor statementExecutor;
+  private InteractiveStatementExecutor interactiveStatementExecutor;
   @Mock
   private CommandStore commandStore;
   @Mock
@@ -72,7 +72,7 @@ public class CommandRunnerTest {
 
   @Before
   public void setup() {
-    when(statementExecutor.getKsqlEngine()).thenReturn(ksqlEngine);
+    when(interactiveStatementExecutor.getKsqlEngine()).thenReturn(ksqlEngine);
 
     when(command.getStatement()).thenReturn("something that is not terminate");
     when(clusterTerminate.getStatement())
@@ -85,7 +85,7 @@ public class CommandRunnerTest {
     givenQueuedCommands(queuedCommand1, queuedCommand2, queuedCommand3);
 
     commandRunner = new CommandRunner(
-        statementExecutor,
+        interactiveStatementExecutor,
         commandStore,
         1,
         clusterTerminator,
@@ -102,10 +102,10 @@ public class CommandRunnerTest {
     commandRunner.processPriorCommands();
 
     // Then:
-    final InOrder inOrder = inOrder(statementExecutor);
-    inOrder.verify(statementExecutor).handleRestore(eq(queuedCommand1));
-    inOrder.verify(statementExecutor).handleRestore(eq(queuedCommand2));
-    inOrder.verify(statementExecutor).handleRestore(eq(queuedCommand3));
+    final InOrder inOrder = inOrder(interactiveStatementExecutor);
+    inOrder.verify(interactiveStatementExecutor).handleRestore(eq(queuedCommand1));
+    inOrder.verify(interactiveStatementExecutor).handleRestore(eq(queuedCommand2));
+    inOrder.verify(interactiveStatementExecutor).handleRestore(eq(queuedCommand3));
   }
 
   @Test
@@ -121,7 +121,7 @@ public class CommandRunnerTest {
     verify(serverState).setTerminating();
     verify(commandStore).close();
     verify(clusterTerminator).terminateCluster(anyList());
-    verify(statementExecutor, never()).handleRestore(any());
+    verify(interactiveStatementExecutor, never()).handleRestore(any());
   }
 
   @Test
@@ -134,7 +134,7 @@ public class CommandRunnerTest {
     commandRunner.processPriorCommands();
 
     // Then:
-    verify(statementExecutor, never()).handleRestore(any());
+    verify(interactiveStatementExecutor, never()).handleRestore(any());
   }
 
   @Test
@@ -146,10 +146,10 @@ public class CommandRunnerTest {
     commandRunner.fetchAndRunCommands();
 
     // Then:
-    final InOrder inOrder = inOrder(statementExecutor);
-    inOrder.verify(statementExecutor).handleStatement(queuedCommand1);
-    inOrder.verify(statementExecutor).handleStatement(queuedCommand2);
-    inOrder.verify(statementExecutor).handleStatement(queuedCommand3);
+    final InOrder inOrder = inOrder(interactiveStatementExecutor);
+    inOrder.verify(interactiveStatementExecutor).handleStatement(queuedCommand1);
+    inOrder.verify(interactiveStatementExecutor).handleStatement(queuedCommand2);
+    inOrder.verify(interactiveStatementExecutor).handleStatement(queuedCommand3);
   }
 
   @Test
@@ -162,22 +162,22 @@ public class CommandRunnerTest {
     commandRunner.fetchAndRunCommands();
 
     // Then:
-    verify(statementExecutor, never()).handleRestore(queuedCommand1);
-    verify(statementExecutor, never()).handleRestore(queuedCommand2);
-    verify(statementExecutor, never()).handleRestore(queuedCommand3);
+    verify(interactiveStatementExecutor, never()).handleRestore(queuedCommand1);
+    verify(interactiveStatementExecutor, never()).handleRestore(queuedCommand2);
+    verify(interactiveStatementExecutor, never()).handleRestore(queuedCommand3);
   }
 
   @Test
   public void shouldEarlyOutOnShutdown() {
     // Given:
     givenQueuedCommands(queuedCommand1, queuedCommand2);
-    doAnswer(closeRunner()).when(statementExecutor).handleStatement(queuedCommand1);
+    doAnswer(closeRunner()).when(interactiveStatementExecutor).handleStatement(queuedCommand1);
 
     // When:
     commandRunner.fetchAndRunCommands();
 
     // Then:
-    verify(statementExecutor, never()).handleRestore(queuedCommand2);
+    verify(interactiveStatementExecutor, never()).handleRestore(queuedCommand2);
   }
 
   @Test

--- a/ksql-rest-app/src/test/java/io/confluent/ksql/rest/server/computation/CommandRunnerTest.java
+++ b/ksql-rest-app/src/test/java/io/confluent/ksql/rest/server/computation/CommandRunnerTest.java
@@ -47,7 +47,7 @@ import org.mockito.stubbing.Answer;
 public class CommandRunnerTest {
 
   @Mock
-  private InteractiveStatementExecutor interactiveStatementExecutor;
+  private InteractiveStatementExecutor statementExecutor;
   @Mock
   private CommandStore commandStore;
   @Mock
@@ -72,7 +72,7 @@ public class CommandRunnerTest {
 
   @Before
   public void setup() {
-    when(interactiveStatementExecutor.getKsqlEngine()).thenReturn(ksqlEngine);
+    when(statementExecutor.getKsqlEngine()).thenReturn(ksqlEngine);
 
     when(command.getStatement()).thenReturn("something that is not terminate");
     when(clusterTerminate.getStatement())
@@ -85,7 +85,7 @@ public class CommandRunnerTest {
     givenQueuedCommands(queuedCommand1, queuedCommand2, queuedCommand3);
 
     commandRunner = new CommandRunner(
-        interactiveStatementExecutor,
+        statementExecutor,
         commandStore,
         1,
         clusterTerminator,
@@ -102,10 +102,10 @@ public class CommandRunnerTest {
     commandRunner.processPriorCommands();
 
     // Then:
-    final InOrder inOrder = inOrder(interactiveStatementExecutor);
-    inOrder.verify(interactiveStatementExecutor).handleRestore(eq(queuedCommand1));
-    inOrder.verify(interactiveStatementExecutor).handleRestore(eq(queuedCommand2));
-    inOrder.verify(interactiveStatementExecutor).handleRestore(eq(queuedCommand3));
+    final InOrder inOrder = inOrder(statementExecutor);
+    inOrder.verify(statementExecutor).handleRestore(eq(queuedCommand1));
+    inOrder.verify(statementExecutor).handleRestore(eq(queuedCommand2));
+    inOrder.verify(statementExecutor).handleRestore(eq(queuedCommand3));
   }
 
   @Test
@@ -121,7 +121,7 @@ public class CommandRunnerTest {
     verify(serverState).setTerminating();
     verify(commandStore).close();
     verify(clusterTerminator).terminateCluster(anyList());
-    verify(interactiveStatementExecutor, never()).handleRestore(any());
+    verify(statementExecutor, never()).handleRestore(any());
   }
 
   @Test
@@ -134,7 +134,7 @@ public class CommandRunnerTest {
     commandRunner.processPriorCommands();
 
     // Then:
-    verify(interactiveStatementExecutor, never()).handleRestore(any());
+    verify(statementExecutor, never()).handleRestore(any());
   }
 
   @Test
@@ -146,10 +146,10 @@ public class CommandRunnerTest {
     commandRunner.fetchAndRunCommands();
 
     // Then:
-    final InOrder inOrder = inOrder(interactiveStatementExecutor);
-    inOrder.verify(interactiveStatementExecutor).handleStatement(queuedCommand1);
-    inOrder.verify(interactiveStatementExecutor).handleStatement(queuedCommand2);
-    inOrder.verify(interactiveStatementExecutor).handleStatement(queuedCommand3);
+    final InOrder inOrder = inOrder(statementExecutor);
+    inOrder.verify(statementExecutor).handleStatement(queuedCommand1);
+    inOrder.verify(statementExecutor).handleStatement(queuedCommand2);
+    inOrder.verify(statementExecutor).handleStatement(queuedCommand3);
   }
 
   @Test
@@ -162,22 +162,22 @@ public class CommandRunnerTest {
     commandRunner.fetchAndRunCommands();
 
     // Then:
-    verify(interactiveStatementExecutor, never()).handleRestore(queuedCommand1);
-    verify(interactiveStatementExecutor, never()).handleRestore(queuedCommand2);
-    verify(interactiveStatementExecutor, never()).handleRestore(queuedCommand3);
+    verify(statementExecutor, never()).handleRestore(queuedCommand1);
+    verify(statementExecutor, never()).handleRestore(queuedCommand2);
+    verify(statementExecutor, never()).handleRestore(queuedCommand3);
   }
 
   @Test
   public void shouldEarlyOutOnShutdown() {
     // Given:
     givenQueuedCommands(queuedCommand1, queuedCommand2);
-    doAnswer(closeRunner()).when(interactiveStatementExecutor).handleStatement(queuedCommand1);
+    doAnswer(closeRunner()).when(statementExecutor).handleStatement(queuedCommand1);
 
     // When:
     commandRunner.fetchAndRunCommands();
 
     // Then:
-    verify(interactiveStatementExecutor, never()).handleRestore(queuedCommand2);
+    verify(statementExecutor, never()).handleRestore(queuedCommand2);
   }
 
   @Test

--- a/ksql-rest-app/src/test/java/io/confluent/ksql/rest/server/computation/InteractiveStatementExecutorTest.java
+++ b/ksql-rest-app/src/test/java/io/confluent/ksql/rest/server/computation/InteractiveStatementExecutorTest.java
@@ -98,7 +98,7 @@ public class InteractiveStatementExecutorTest extends EasyMockSupport {
   private static final Map<String, String> PRE_VERSION_5_NULL_ORIGINAL_PROPS = null;
 
   private KsqlEngine ksqlEngine;
-  private InteractiveStatementExecutor interactiveStatementExecutor;
+  private InteractiveStatementExecutor statementExecutor;
   private KsqlConfig ksqlConfig;
 
   private final StatementParser mockParser = niceMock(StatementParser.class);
@@ -108,7 +108,7 @@ public class InteractiveStatementExecutorTest extends EasyMockSupport {
   private final MetaStore mockMetaStore = niceMock(MetaStore.class);
   private final PersistentQueryMetadata mockQueryMetadata
       = niceMock(PersistentQueryMetadata.class);
-  private InteractiveStatementExecutor interactiveStatementExecutorWithMocks;
+  private InteractiveStatementExecutor statementExecutorWithMocks;
   private ServiceContext serviceContext;
 
   @Rule
@@ -139,21 +139,21 @@ public class InteractiveStatementExecutorTest extends EasyMockSupport {
 
     final StatementParser statementParser = new StatementParser(ksqlEngine);
 
-    interactiveStatementExecutor = new InteractiveStatementExecutor(
+    statementExecutor = new InteractiveStatementExecutor(
         serviceContext,
         ksqlEngine,
         statementParser,
         hybridQueryIdGenerator
     );
-    interactiveStatementExecutorWithMocks = new InteractiveStatementExecutor(
+    statementExecutorWithMocks = new InteractiveStatementExecutor(
         serviceContext,
         mockEngine,
         mockParser,
         mockQueryIdGenerator
     );
 
-    interactiveStatementExecutor.configure(ksqlConfig);
-    interactiveStatementExecutorWithMocks.configure(ksqlConfig);
+    statementExecutor.configure(ksqlConfig);
+    statementExecutorWithMocks.configure(ksqlConfig);
   }
 
   @After
@@ -175,13 +175,13 @@ public class InteractiveStatementExecutorTest extends EasyMockSupport {
     final KsqlConfig configNoAppServer = new KsqlConfig(ImmutableMap.of());
 
     // When:
-    interactiveStatementExecutorWithMocks.configure(configNoAppServer);
+    statementExecutorWithMocks.configure(configNoAppServer);
   }
 
   @Test(expected = IllegalStateException.class)
   public void shouldThrowOnHandleStatementIfNotConfigured() {
     // Given:
-    interactiveStatementExecutor = new InteractiveStatementExecutor(
+    statementExecutor = new InteractiveStatementExecutor(
         serviceContext,
         mockEngine,
         mockParser,
@@ -189,13 +189,13 @@ public class InteractiveStatementExecutorTest extends EasyMockSupport {
     );
 
     // When:
-    interactiveStatementExecutor.handleStatement(queuedCommand);
+    statementExecutor.handleStatement(queuedCommand);
   }
 
   @Test(expected = IllegalStateException.class)
   public void shouldThrowOnHandleRestoreIfNotConfigured() {
     // Given:
-    interactiveStatementExecutor = new InteractiveStatementExecutor(
+    statementExecutor = new InteractiveStatementExecutor(
         serviceContext,
         mockEngine,
         mockParser,
@@ -203,7 +203,7 @@ public class InteractiveStatementExecutorTest extends EasyMockSupport {
     );
 
     // When:
-    interactiveStatementExecutor.handleRestore(queuedCommand);
+    statementExecutor.handleRestore(queuedCommand);
   }
 
   @Test
@@ -225,7 +225,7 @@ public class InteractiveStatementExecutorTest extends EasyMockSupport {
 
     // When:
     try {
-      handleStatement(interactiveStatementExecutorWithMocks, command, commandId, Optional.empty(),0);
+      handleStatement(statementExecutorWithMocks, command, commandId, Optional.empty(),0);
       Assert.fail("handleStatement should throw");
     } catch (final RuntimeException caughtException) {
       // Then:
@@ -281,7 +281,7 @@ public class InteractiveStatementExecutorTest extends EasyMockSupport {
 
     replay(mockParser, mockEngine, mockMetaStore, mockQueryMetadata);
 
-    handleStatement(interactiveStatementExecutorWithMocks, csasCommand, csasCommandId, Optional.empty(), 1);
+    handleStatement(statementExecutorWithMocks, csasCommand, csasCommandId, Optional.empty(), 1);
 
     verify(mockParser, mockEngine, mockMetaStore, mockQueryMetadata);
   }
@@ -385,12 +385,12 @@ public class InteractiveStatementExecutorTest extends EasyMockSupport {
 
     for (int i = 0; i < priorCommands.size(); i++) {
       final Pair<CommandId, Command> pair = priorCommands.get(i);
-      interactiveStatementExecutor.handleRestore(
+      statementExecutor.handleRestore(
           new QueuedCommand(pair.left, pair.right, Optional.empty(), (long) i)
       );
     }
 
-    final Map<CommandId, CommandStatus> statusStore = interactiveStatementExecutor.getStatuses();
+    final Map<CommandId, CommandStatus> statusStore = statementExecutor.getStatuses();
     Assert.assertNotNull(statusStore);
     Assert.assertEquals(3, statusStore.size());
     Assert.assertEquals(CommandStatus.Status.SUCCESS, statusStore.get(csCommandId).getStatus());
@@ -419,11 +419,11 @@ public class InteractiveStatementExecutorTest extends EasyMockSupport {
     final CommandId dropTableCommandId2 =
         new CommandId(CommandId.Type.TABLE, "_TABLE1", CommandId.Action.DROP);
     handleStatement(
-        interactiveStatementExecutor, dropTableCommand2, dropTableCommandId2, Optional.empty(), 4);
+        statementExecutor, dropTableCommand2, dropTableCommandId2, Optional.empty(), 4);
 
     // DROP should succed since no query is using the table
     final Optional<CommandStatus> dropTableCommandStatus2 =
-        interactiveStatementExecutor.getStatus(dropTableCommandId2);
+        statementExecutor.getStatus(dropTableCommandId2);
 
     Assert.assertTrue(dropTableCommandStatus2.isPresent());
     assertThat(dropTableCommandStatus2.get().getStatus(), equalTo(CommandStatus.Status.SUCCESS));
@@ -438,10 +438,10 @@ public class InteractiveStatementExecutorTest extends EasyMockSupport {
     final CommandId dropStreamCommandId3 =
         new CommandId(CommandId.Type.STREAM, "_user1pv", CommandId.Action.DROP);
     handleStatement(
-        interactiveStatementExecutor, dropStreamCommand3, dropStreamCommandId3, Optional.empty(), 5);
+        statementExecutor, dropStreamCommand3, dropStreamCommandId3, Optional.empty(), 5);
 
     final Optional<CommandStatus> dropStreamCommandStatus3 =
-        interactiveStatementExecutor.getStatus(dropStreamCommandId3);
+        statementExecutor.getStatus(dropStreamCommandId3);
     assertThat(dropStreamCommandStatus3.get().getStatus(),
         CoreMatchers.equalTo(CommandStatus.Status.SUCCESS));
   }
@@ -521,7 +521,7 @@ public class InteractiveStatementExecutorTest extends EasyMockSupport {
     replayAll();
 
     // When:
-    interactiveStatementExecutorWithMocks.handleRestore(
+    statementExecutorWithMocks.handleRestore(
         new QueuedCommand(
             new CommandId(Type.STREAM, name, Action.CREATE),
             new Command("CSAS", true, emptyMap(), emptyMap()),
@@ -556,7 +556,7 @@ public class InteractiveStatementExecutorTest extends EasyMockSupport {
     replayAll();
 
     // When:
-    interactiveStatementExecutorWithMocks.handleRestore(
+    statementExecutorWithMocks.handleRestore(
         new QueuedCommand(
             new CommandId(Type.STREAM, "foo", Action.DROP),
             new Command("DROP", true, emptyMap(), PRE_VERSION_5_NULL_ORIGINAL_PROPS),
@@ -591,7 +591,7 @@ public class InteractiveStatementExecutorTest extends EasyMockSupport {
     replayAll();
 
     // When:
-    interactiveStatementExecutorWithMocks.handleRestore(
+    statementExecutorWithMocks.handleRestore(
         new QueuedCommand(
             new CommandId(Type.STREAM, "foo", Action.DROP),
             new Command(drop, true, emptyMap(), emptyMap()),
@@ -664,7 +664,7 @@ public class InteractiveStatementExecutorTest extends EasyMockSupport {
     replayAll();
 
     // When:
-    interactiveStatementExecutorWithMocks.handleStatement(
+    statementExecutorWithMocks.handleStatement(
         new QueuedCommand(
             new CommandId(CommandId.Type.STREAM, "RunScript", CommandId.Action.EXECUTE),
             new Command(
@@ -690,7 +690,7 @@ public class InteractiveStatementExecutorTest extends EasyMockSupport {
     replayAll();
 
     // When:
-    interactiveStatementExecutorWithMocks.handleRestore(
+    statementExecutorWithMocks.handleRestore(
         new QueuedCommand(
             new CommandId(CommandId.Type.STREAM, "RunScript", CommandId.Action.EXECUTE),
             new Command(
@@ -760,11 +760,11 @@ public class InteractiveStatementExecutorTest extends EasyMockSupport {
         "_PAGEVIEW",
         CommandId.Action.DROP);
     handleStatement(
-        interactiveStatementExecutor, dropStreamCommand1, dropStreamCommandId1, Optional.empty(), 0);
+        statementExecutor, dropStreamCommand1, dropStreamCommandId1, Optional.empty(), 0);
 
     // DROP statement should fail since the stream is being used.
     final Optional<CommandStatus> dropStreamCommandStatus1 =
-        interactiveStatementExecutor.getStatus(dropStreamCommandId1);
+        statementExecutor.getStatus(dropStreamCommandId1);
 
     Assert.assertTrue(dropStreamCommandStatus1.isPresent());
     assertThat(dropStreamCommandStatus1.get().getStatus(),
@@ -799,11 +799,10 @@ public class InteractiveStatementExecutorTest extends EasyMockSupport {
     final CommandId dropStreamCommandId2 =
         new CommandId(CommandId.Type.STREAM, "_user1pv", CommandId.Action.DROP);
     handleStatement(
-        interactiveStatementExecutor, dropStreamCommand2, dropStreamCommandId2, Optional.empty(), 0);
+        statementExecutor, dropStreamCommand2, dropStreamCommandId2, Optional.empty(), 0);
 
     // DROP statement should fail since the stream is being used.
-    final Optional<CommandStatus> dropStreamCommandStatus2 =
-        interactiveStatementExecutor.getStatus(dropStreamCommandId2);
+    final Optional<CommandStatus> dropStreamCommandStatus2 = statementExecutor.getStatus(dropStreamCommandId2);
 
     assertThat(dropStreamCommandStatus2.isPresent(), equalTo(true));
     assertThat(dropStreamCommandStatus2.get().getStatus(),
@@ -836,10 +835,10 @@ public class InteractiveStatementExecutorTest extends EasyMockSupport {
     final CommandId dropTableCommandId1 =
         new CommandId(CommandId.Type.TABLE, "_TABLE1", CommandId.Action.DROP);
     handleStatement(
-        interactiveStatementExecutor, dropTableCommand1, dropTableCommandId1, Optional.empty(), 0);
+        statementExecutor, dropTableCommand1, dropTableCommandId1, Optional.empty(), 0);
 
     final Optional<CommandStatus> dropTableCommandStatus1 =
-        interactiveStatementExecutor.getStatus(dropTableCommandId1);
+        statementExecutor.getStatus(dropTableCommandId1);
 
     // DROP statement should fail since the table is being used.
     Assert.assertTrue(dropTableCommandStatus1.isPresent());
@@ -870,16 +869,16 @@ public class InteractiveStatementExecutorTest extends EasyMockSupport {
       final CommandId commandId,
       final Optional<CommandStatusFuture> commandStatus,
       final long offset) {
-    handleStatement(interactiveStatementExecutor, command, commandId, commandStatus, offset);
+    handleStatement(statementExecutor, command, commandId, commandStatus, offset);
   }
 
   private static void handleStatement(
-      final InteractiveStatementExecutor interactiveStatementExecutor,
+      final InteractiveStatementExecutor statementExecutor,
       final Command command,
       final CommandId commandId,
       final Optional<CommandStatusFuture> commandStatus,
       final long offset) {
-    interactiveStatementExecutor.handleStatement(new QueuedCommand(commandId, command, commandStatus, offset));
+    statementExecutor.handleStatement(new QueuedCommand(commandId, command, commandStatus, offset));
   }
 
   private void terminateQueries() {
@@ -889,7 +888,7 @@ public class InteractiveStatementExecutorTest extends EasyMockSupport {
     final CommandId terminateCommandId1 =
         new CommandId(CommandId.Type.STREAM, "_TerminateGen", CommandId.Action.CREATE);
     handleStatement(
-        interactiveStatementExecutor, terminateCommand1, terminateCommandId1, Optional.empty(), 0);
+        statementExecutor, terminateCommand1, terminateCommandId1, Optional.empty(), 0);
     assertThat(
         getCommandStatus(terminateCommandId1).getStatus(), equalTo(CommandStatus.Status.SUCCESS));
 
@@ -901,13 +900,13 @@ public class InteractiveStatementExecutorTest extends EasyMockSupport {
     final CommandId terminateCommandId2 =
         new CommandId(CommandId.Type.TABLE, "_TerminateGen", CommandId.Action.CREATE);
     handleStatement(
-        interactiveStatementExecutor, terminateCommand2, terminateCommandId2, Optional.empty(), 0);
+        statementExecutor, terminateCommand2, terminateCommandId2, Optional.empty(), 0);
     assertThat(
         getCommandStatus(terminateCommandId2).getStatus(), equalTo(CommandStatus.Status.SUCCESS));
   }
 
   private CommandStatus getCommandStatus(CommandId commandId) {
-    final Optional<CommandStatus> commandStatus = interactiveStatementExecutor.getStatus(commandId);
+    final Optional<CommandStatus> commandStatus = statementExecutor.getStatus(commandId);
     assertThat("command not registered: " + commandId,
         commandStatus,
         is(not(equalTo(Optional.empty()))));

--- a/ksql-rest-app/src/test/java/io/confluent/ksql/rest/server/computation/RecoveryTest.java
+++ b/ksql-rest-app/src/test/java/io/confluent/ksql/rest/server/computation/RecoveryTest.java
@@ -168,7 +168,7 @@ public class RecoveryTest {
     final KsqlEngine ksqlEngine;
     final KsqlResource ksqlResource;
     final FakeCommandQueue fakeCommandQueue;
-    final StatementExecutor statementExecutor;
+    final InteractiveStatementExecutor interactiveStatementExecutor;
     final CommandRunner commandRunner;
     final ServerState serverState;
 
@@ -186,21 +186,21 @@ public class RecoveryTest {
           }
       );
 
-      this.statementExecutor = new StatementExecutor(
+      this.interactiveStatementExecutor = new InteractiveStatementExecutor(
           serviceContext,
           ksqlEngine,
           hybridQueryIdGenerator
       );
 
       this.commandRunner = new CommandRunner(
-          statementExecutor,
+          interactiveStatementExecutor,
           fakeCommandQueue,
           1,
           mock(ClusterTerminator.class),
           serverState
       );
 
-      this.statementExecutor.configure(ksqlConfig);
+      this.interactiveStatementExecutor.configure(ksqlConfig);
       this.ksqlResource.configure(ksqlConfig);
     }
 

--- a/ksql-rest-app/src/test/java/io/confluent/ksql/rest/server/computation/RecoveryTest.java
+++ b/ksql-rest-app/src/test/java/io/confluent/ksql/rest/server/computation/RecoveryTest.java
@@ -168,7 +168,7 @@ public class RecoveryTest {
     final KsqlEngine ksqlEngine;
     final KsqlResource ksqlResource;
     final FakeCommandQueue fakeCommandQueue;
-    final InteractiveStatementExecutor interactiveStatementExecutor;
+    final InteractiveStatementExecutor statementExecutor;
     final CommandRunner commandRunner;
     final ServerState serverState;
 
@@ -186,21 +186,21 @@ public class RecoveryTest {
           }
       );
 
-      this.interactiveStatementExecutor = new InteractiveStatementExecutor(
+      this.statementExecutor = new InteractiveStatementExecutor(
           serviceContext,
           ksqlEngine,
           hybridQueryIdGenerator
       );
 
       this.commandRunner = new CommandRunner(
-          interactiveStatementExecutor,
+          statementExecutor,
           fakeCommandQueue,
           1,
           mock(ClusterTerminator.class),
           serverState
       );
 
-      this.interactiveStatementExecutor.configure(ksqlConfig);
+      this.statementExecutor.configure(ksqlConfig);
       this.ksqlResource.configure(ksqlConfig);
     }
 

--- a/ksql-rest-app/src/test/java/io/confluent/ksql/rest/server/resources/StatusResourceTest.java
+++ b/ksql-rest-app/src/test/java/io/confluent/ksql/rest/server/resources/StatusResourceTest.java
@@ -29,7 +29,7 @@ import io.confluent.ksql.rest.entity.CommandId;
 import io.confluent.ksql.rest.entity.CommandStatus;
 import io.confluent.ksql.rest.entity.CommandStatuses;
 import io.confluent.ksql.rest.entity.KsqlErrorMessage;
-import io.confluent.ksql.rest.server.computation.StatementExecutor;
+import io.confluent.ksql.rest.server.computation.InteractiveStatementExecutor;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Optional;
@@ -60,19 +60,19 @@ public class StatusResourceTest {
   }
 
   private StatusResource getTestStatusResource() {
-    final StatementExecutor mockStatementExecutor = mock(StatementExecutor.class);
+    final InteractiveStatementExecutor mockInteractiveStatementExecutor = mock(InteractiveStatementExecutor.class);
 
-    expect(mockStatementExecutor.getStatuses()).andReturn(mockCommandStatuses);
+    expect(mockInteractiveStatementExecutor.getStatuses()).andReturn(mockCommandStatuses);
 
     for (final Map.Entry<CommandId, CommandStatus> commandEntry : mockCommandStatuses.entrySet()) {
-      expect(mockStatementExecutor.getStatus(commandEntry.getKey())).andReturn(Optional.of(commandEntry.getValue()));
+      expect(mockInteractiveStatementExecutor.getStatus(commandEntry.getKey())).andReturn(Optional.of(commandEntry.getValue()));
     }
 
-    expect(mockStatementExecutor.getStatus(anyObject(CommandId.class))).andReturn(Optional.empty());
+    expect(mockInteractiveStatementExecutor.getStatus(anyObject(CommandId.class))).andReturn(Optional.empty());
 
-    replay(mockStatementExecutor);
+    replay(mockInteractiveStatementExecutor);
 
-    return new StatusResource(mockStatementExecutor);
+    return new StatusResource(mockInteractiveStatementExecutor);
   }
 
   @Test

--- a/ksql-rest-app/src/test/java/io/confluent/ksql/rest/server/resources/StatusResourceTest.java
+++ b/ksql-rest-app/src/test/java/io/confluent/ksql/rest/server/resources/StatusResourceTest.java
@@ -60,19 +60,19 @@ public class StatusResourceTest {
   }
 
   private StatusResource getTestStatusResource() {
-    final InteractiveStatementExecutor mockInteractiveStatementExecutor = mock(InteractiveStatementExecutor.class);
+    final InteractiveStatementExecutor mockStatementExecutor = mock(InteractiveStatementExecutor.class);
 
-    expect(mockInteractiveStatementExecutor.getStatuses()).andReturn(mockCommandStatuses);
+    expect(mockStatementExecutor.getStatuses()).andReturn(mockCommandStatuses);
 
     for (final Map.Entry<CommandId, CommandStatus> commandEntry : mockCommandStatuses.entrySet()) {
-      expect(mockInteractiveStatementExecutor.getStatus(commandEntry.getKey())).andReturn(Optional.of(commandEntry.getValue()));
+      expect(mockStatementExecutor.getStatus(commandEntry.getKey())).andReturn(Optional.of(commandEntry.getValue()));
     }
 
-    expect(mockInteractiveStatementExecutor.getStatus(anyObject(CommandId.class))).andReturn(Optional.empty());
+    expect(mockStatementExecutor.getStatus(anyObject(CommandId.class))).andReturn(Optional.empty());
 
-    replay(mockInteractiveStatementExecutor);
+    replay(mockStatementExecutor);
 
-    return new StatusResource(mockInteractiveStatementExecutor);
+    return new StatusResource(mockStatementExecutor);
   }
 
   @Test


### PR DESCRIPTION
### Description 
In the theme of cleaning up the code base:

With the current name, the StatementExecutor class used by CommandRunner to execute commands containing statements from the command topic is confusing because there's also a StatementExecutor interface that's being used in the RequestHandler which is completely unrelated to the StatementExecutor class.

https://github.com/confluentinc/ksql/blob/master/ksql-rest-app/src/main/java/io/confluent/ksql/rest/server/computation/StatementExecutor.java

https://github.com/confluentinc/ksql/blob/master/ksql-rest-app/src/main/java/io/confluent/ksql/rest/server/execution/StatementExecutor.java 

Renaming the StatementExecutor class so the intended usage is clearer.

### Testing done 
Refactor only

### Reviewer checklist
- [ ] Ensure docs are updated if necessary. (eg. if a user visible feature is being added or changed).
- [ ] Ensure relevant issues are linked (description should include text like "Fixes #<issue number>")

