### PR TITLE
feat: Add UDFs RANGE AND ENTRIES

### DIFF
--- a/ksql-engine/src/main/java/io/confluent/ksql/function/udf/array/Entries.java
+++ b/ksql-engine/src/main/java/io/confluent/ksql/function/udf/array/Entries.java
@@ -1,0 +1,109 @@
+/*
+ * Copyright 2019 Confluent Inc.
+ *
+ * Licensed under the Confluent Community License (the "License"; you may not use
+ * this file except in compliance with the License. You may obtain a copy of the
+ * License at
+ *
+ * http://www.confluent.io/confluent-community-license
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package io.confluent.ksql.function.udf.array;
+
+import io.confluent.ksql.function.udf.Udf;
+import io.confluent.ksql.function.udf.UdfDescription;
+import io.confluent.ksql.function.udf.UdfParameter;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Comparator;
+import java.util.List;
+import java.util.Map;
+import java.util.Map.Entry;
+import org.apache.kafka.connect.data.Schema;
+import org.apache.kafka.connect.data.SchemaBuilder;
+import org.apache.kafka.connect.data.Struct;
+
+/**
+ * This UDF constructs an array of structs from the entries in a map. Each struct has a field with
+ * name "K" containing the key (this is always a String) and a field with name "V" holding the
+ * value;
+ */
+@UdfDescription(name = "ENTRIES", description = "Construct an array from the entries in a map")
+public class Entries {
+
+  private static final Schema INT_STRUCT_SCHEMA = buildStructSchema(Schema.OPTIONAL_INT32_SCHEMA);
+  private static final Schema BIGINT_STRUCT_SCHEMA = buildStructSchema(
+      Schema.OPTIONAL_INT64_SCHEMA);
+  private static final Schema DOUBLE_STRUCT_SCHEMA = buildStructSchema(
+      Schema.OPTIONAL_FLOAT64_SCHEMA);
+  private static final Schema BOOLEAN_STRUCT_SCHEMA = buildStructSchema(
+      Schema.OPTIONAL_BOOLEAN_SCHEMA);
+  private static final Schema STRING_STRUCT_SCHEMA = buildStructSchema(
+      Schema.OPTIONAL_STRING_SCHEMA);
+  private static final String KEY_FIELD_NAME = "K";
+  private static final String VALUE_FIELD_NAME = "V";
+
+  private static Schema buildStructSchema(final Schema valueSchema) {
+    return SchemaBuilder.struct().field(KEY_FIELD_NAME, Schema.OPTIONAL_STRING_SCHEMA)
+        .field(VALUE_FIELD_NAME, valueSchema).optional().build();
+  }
+
+  @Udf(schema = "ARRAY<STRUCT<K STRING, V INT>>")
+  public List<Struct> entriesInt(
+      @UdfParameter final Map<String, Integer> map, @UdfParameter final boolean sorted
+  ) {
+    return entries(map, INT_STRUCT_SCHEMA, sorted);
+  }
+
+  @Udf(schema = "ARRAY<STRUCT<K STRING, V BIGINT>>")
+  public List<Struct> entriesBigInt(
+      @UdfParameter final Map<String, Long> map, @UdfParameter final boolean sorted
+  ) {
+    return entries(map, BIGINT_STRUCT_SCHEMA, sorted);
+  }
+
+  @Udf(schema = "ARRAY<STRUCT<K STRING, V DOUBLE>>")
+  public List<Struct> entriesDouble(
+      @UdfParameter final Map<String, Double> map, @UdfParameter final boolean sorted
+  ) {
+    return entries(map, DOUBLE_STRUCT_SCHEMA, sorted);
+  }
+
+  @Udf(schema = "ARRAY<STRUCT<K STRING, V BOOLEAN>>")
+  public List<Struct> entriesBoolean(
+      @UdfParameter final Map<String, Boolean> map, @UdfParameter final boolean sorted
+  ) {
+    return entries(map, BOOLEAN_STRUCT_SCHEMA, sorted);
+  }
+
+  @Udf(schema = "ARRAY<STRUCT<K STRING, V STRING>>")
+  public List<Struct> entriesString(
+      @UdfParameter final Map<String, String> map, @UdfParameter final boolean sorted
+  ) {
+    return entries(map, STRING_STRUCT_SCHEMA, sorted);
+  }
+
+  private <T> List<Struct> entries(
+      final Map<String, T> map, final Schema structSchema, final boolean sorted
+  ) {
+    final List<Struct> structs = new ArrayList<>(map.size());
+    Collection<Entry<String, T>> entries = map.entrySet();
+    if (sorted) {
+      final List<Entry<String, T>> list = new ArrayList<>(entries);
+      list.sort(Comparator.comparing(Entry::getKey));
+      entries = list;
+    }
+    for (Map.Entry<String, T> entry : entries) {
+      final Struct struct = new Struct(structSchema);
+      struct.put(KEY_FIELD_NAME, entry.getKey()).put(VALUE_FIELD_NAME, entry.getValue());
+      structs.add(struct);
+    }
+    return structs;
+  }
+
+}

--- a/ksql-engine/src/main/java/io/confluent/ksql/function/udf/array/Range.java
+++ b/ksql-engine/src/main/java/io/confluent/ksql/function/udf/array/Range.java
@@ -1,0 +1,46 @@
+/*
+ * Copyright 2019 Confluent Inc.
+ *
+ * Licensed under the Confluent Community License (the "License"; you may not use
+ * this file except in compliance with the License. You may obtain a copy of the
+ * License at
+ *
+ * http://www.confluent.io/confluent-community-license
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package io.confluent.ksql.function.udf.array;
+
+import io.confluent.ksql.function.udf.Udf;
+import io.confluent.ksql.function.udf.UdfDescription;
+import io.confluent.ksql.function.udf.UdfParameter;
+import java.util.List;
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
+import java.util.stream.LongStream;
+
+/**
+ * This UDF constructs an array containing an array of INTs or BIGINTs in the specified range
+ */
+@UdfDescription(name = "RANGE", description = "Construct an array of a range of values")
+public class Range {
+
+  @Udf
+  public List<Integer> rangeInt(
+      @UdfParameter final int startInclusive, @UdfParameter final int endExclusive
+  ) {
+    return IntStream.range(startInclusive, endExclusive).boxed().collect(Collectors.toList());
+  }
+
+  @Udf
+  public List<Long> rangeLong(
+      @UdfParameter final long startInclusive, @UdfParameter final long endExclusive
+  ) {
+    return LongStream.range(startInclusive, endExclusive).boxed().collect(Collectors.toList());
+  }
+
+}

--- a/ksql-engine/src/test/java/io/confluent/ksql/function/udf/array/EntriesTest.java
+++ b/ksql-engine/src/test/java/io/confluent/ksql/function/udf/array/EntriesTest.java
@@ -1,0 +1,134 @@
+/*
+ * Copyright 2019 Confluent Inc.
+ *
+ * Licensed under the Confluent Community License (the "License"); you may not use
+ * this file except in compliance with the License.  You may obtain a copy of the
+ * License at
+ *
+ * http://www.confluent.io/confluent-community-license
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package io.confluent.ksql.function.udf.array;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.hasSize;
+import static org.hamcrest.Matchers.is;
+
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Map.Entry;
+import java.util.UUID;
+import java.util.function.Function;
+import java.util.function.Supplier;
+import org.apache.kafka.connect.data.Struct;
+import org.junit.Test;
+
+public class EntriesTest {
+
+  private static final int ENTRIES = 20;
+
+  private Entries entriesUdf = new Entries();
+
+  @Test
+  public void shouldComputeIntEntries() {
+    Map<String, Integer> map = createMap(i -> i);
+    shouldComputeEntries(map, () -> entriesUdf.entriesInt(map, false));
+  }
+
+  @Test
+  public void shouldComputeBigIntEntries() {
+    Map<String, Long> map = createMap(Long::valueOf);
+    shouldComputeEntries(map, () -> entriesUdf.entriesBigInt(map, false));
+  }
+
+  @Test
+  public void shouldComputeDoubleEntries() {
+    Map<String, Double> map = createMap(Double::valueOf);
+    shouldComputeEntries(map, () -> entriesUdf.entriesDouble(map, false));
+  }
+
+  @Test
+  public void shouldComputeBooleanEntries() {
+    Map<String, Boolean> map = createMap(i -> i % 2 == 0);
+    shouldComputeEntries(map, () -> entriesUdf.entriesBoolean(map, false));
+  }
+
+  @Test
+  public void shouldComputeStringEntries() {
+    Map<String, String> map = createMap(String::valueOf);
+    shouldComputeEntries(map, () -> entriesUdf.entriesString(map, false));
+  }
+
+  @Test
+  public void shouldComputeIntEntriesSorted() {
+    Map<String, Integer> map = createMap(i -> i);
+    shouldComputeEntriesSorted(map, () -> entriesUdf.entriesInt(map, true));
+  }
+
+  @Test
+  public void shouldComputeBigIntEntriesSorted() {
+    Map<String, Long> map = createMap(Long::valueOf);
+    shouldComputeEntriesSorted(map, () -> entriesUdf.entriesBigInt(map, true));
+  }
+
+  @Test
+  public void shouldComputeDoubleEntriesSorted() {
+    Map<String, Double> map = createMap(Double::valueOf);
+    shouldComputeEntriesSorted(map, () -> entriesUdf.entriesDouble(map, true));
+  }
+
+  @Test
+  public void shouldComputeBooleanEntriesSorted() {
+    Map<String, Boolean> map = createMap(i -> i % 2 == 0);
+    shouldComputeEntriesSorted(map, () -> entriesUdf.entriesBoolean(map, true));
+  }
+
+  @Test
+  public void shouldComputeStringEntriesSorted() {
+    Map<String, String> map = createMap(String::valueOf);
+    shouldComputeEntriesSorted(map, () -> entriesUdf.entriesString(map, true));
+  }
+
+  private <T> void shouldComputeEntries(
+      Map<String, T> map, Supplier<List<Struct>> supplier
+  ) {
+    List<Struct> out = supplier.get();
+    assertThat(out, hasSize(map.size()));
+    for (int i = 0; i < out.size(); i++) {
+      Struct struct = out.get(i);
+      T val = map.get(struct.getString("K"));
+      assertThat(val == null, is(false));
+      assertThat(val, is(struct.get("V")));
+    }
+  }
+
+  private <T> void shouldComputeEntriesSorted(Map<String, T> map, Supplier<List<Struct>> supplier) {
+    List<Struct> out = supplier.get();
+    List<Map.Entry<String, T>> entries = new ArrayList<>(map.entrySet());
+    entries.sort(Comparator.comparing(Entry::getKey));
+    assertThat(out.size(), is(entries.size()));
+    for (int i = 0; i < entries.size(); i++) {
+      Struct struct = out.get(i);
+      Map.Entry<String, T> entry = entries.get(i);
+      assertThat(struct.get("K"), is(entry.getKey()));
+      assertThat(struct.get("V"), is(entry.getValue()));
+    }
+  }
+
+  private <T> Map<String, T> createMap(Function<Integer, T> valueSupplier) {
+    Map<String, T> map = new HashMap<>();
+    for (int i = 0; i < ENTRIES; i++) {
+      map.put(UUID.randomUUID().toString(), valueSupplier.apply(i));
+    }
+    return map;
+  }
+
+}

--- a/ksql-engine/src/test/java/io/confluent/ksql/function/udf/array/RangeTest.java
+++ b/ksql-engine/src/test/java/io/confluent/ksql/function/udf/array/RangeTest.java
@@ -1,0 +1,73 @@
+/*
+ * Copyright 2019 Confluent Inc.
+ *
+ * Licensed under the Confluent Community License (the "License"); you may not use
+ * this file except in compliance with the License.  You may obtain a copy of the
+ * License at
+ *
+ * http://www.confluent.io/confluent-community-license
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package io.confluent.ksql.function.udf.array;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.hasSize;
+import static org.hamcrest.Matchers.is;
+
+import java.util.List;
+import org.junit.Test;
+
+public class RangeTest {
+
+  private Range rangeUdf = new Range();
+
+  @Test
+  public void shouldComputeIntRange() {
+    List<Integer> range = rangeUdf.rangeInt(0, 10);
+    assertThat(range, hasSize(10));
+    int index = 0;
+    for (Integer i : range) {
+      assertThat(index++, is(i));
+    }
+  }
+
+  @Test
+  public void shouldComputeEmptyIntRange() {
+    List<Integer> range = rangeUdf.rangeInt(5, 5);
+    assertThat(range, hasSize(0));
+  }
+
+  @Test
+  public void shouldComputeEmptyIntRangeWhenEndLessThanStart() {
+    List<Integer> range = rangeUdf.rangeInt(5, 0);
+    assertThat(range, hasSize(0));
+  }
+
+  @Test
+  public void shouldComputeLongRange() {
+    List<Long> range = rangeUdf.rangeLong(0, 10);
+    assertThat(range, hasSize(10));
+    long index = 0;
+    for (Long i : range) {
+      assertThat(index++, is(i));
+    }
+  }
+
+  @Test
+  public void shouldComputeEmptyLongRange() {
+    List<Long> range = rangeUdf.rangeLong(5, 5);
+    assertThat(range, hasSize(0));
+  }
+
+  @Test
+  public void shouldComputeEmptyLongRangeWhenEndLessThanStart() {
+    List<Long> range = rangeUdf.rangeLong(5, 0);
+    assertThat(range, hasSize(0));
+  }
+
+}

--- a/ksql-functional-tests/src/test/resources/query-validation-tests/array.json
+++ b/ksql-functional-tests/src/test/resources/query-validation-tests/array.json
@@ -1,0 +1,54 @@
+{
+  "comments": [
+    "Tests covering the use of the array returning UDFs."
+  ],
+  "tests": [
+    {
+      "name": "entries sorted",
+      "statements": [
+        "CREATE STREAM TEST (INTMAP MAP<STRING, INT>, BIGINTMAP MAP<STRING, BIGINT>, DOUBLEMAP MAP<STRING, DOUBLE>, BOOLEANMAP MAP<STRING, BOOLEAN>, STRINGMAP MAP<STRING, STRING>) WITH (kafka_topic='test_topic', value_format='JSON');",
+        "CREATE STREAM OUTPUT AS SELECT ENTRIES(INTMAP, TRUE), ENTRIES(BIGINTMAP, TRUE), ENTRIES(DOUBLEMAP, TRUE), ENTRIES(BOOLEANMAP, TRUE), ENTRIES(STRINGMAP, TRUE) FROM TEST;"
+      ],
+      "inputs": [
+        {
+          "topic": "test_topic", "key": 1, "value": {
+          "INTMAP": {"K1": 1, "K2": 2, "K3": 3},
+          "BIGINTMAP": {"K1": 1, "K2": 2, "K3": 3},
+          "DOUBLEMAP": {"K1": 1.0, "K2": 2.0, "K3": 3.0},
+          "BOOLEANMAP": {"K1": true, "K2": false, "K3": true},
+          "STRINGMAP": {"K1": "V1", "K2": "V2", "K3": "V3"}
+        }
+        }
+      ],
+      "outputs": [
+        {
+          "topic": "OUTPUT", "key": 1,
+          "value": {
+            "KSQL_COL_0": [{"K": "K1", "V": 1}, {"K": "K2", "V": 2}, {"K": "K3", "V": 3}],
+            "KSQL_COL_1": [{"K": "K1", "V": 1}, {"K": "K2", "V": 2}, {"K": "K3", "V": 3}],
+            "KSQL_COL_2": [{"K": "K1", "V": 1.0}, {"K": "K2", "V": 2.0}, {"K": "K3", "V": 3.0}],
+            "KSQL_COL_3": [{"K": "K1", "V": true}, {"K": "K2", "V": false}, {"K": "K3", "V": true}],
+            "KSQL_COL_4": [{"K": "K1", "V": "V1"}, {"K": "K2", "V": "V2"}, {"K": "K3", "V": "V3"}]
+          }
+        }
+      ]
+    },
+    {
+      "name": "range",
+      "statements": [
+        "CREATE STREAM TEST (F0 INT, F1 INT, F2 BIGINT, F3 BIGINT) WITH (kafka_topic='test_topic', value_format='JSON');",
+        "CREATE STREAM OUTPUT AS SELECT RANGE(F0, F1), RANGE(F2, F3) FROM TEST;"
+      ],
+      "inputs": [
+        {"topic": "test_topic", "key": 1, "value": {"F0": 0, "F1": 4, "F2": 0, "F3": 4}},
+        {"topic": "test_topic", "key": 1, "value": {"F0": 4, "F1": 4, "F2": 4, "F3": 4}},
+        {"topic": "test_topic", "key": 1, "value": {"F0": 4, "F1": 0, "F2": 4, "F3": 0}}
+      ],
+      "outputs": [
+        {"topic": "OUTPUT", "key": 1, "value": {"KSQL_COL_0": [0, 1, 2, 3], "KSQL_COL_1": [0, 1, 2, 3]}},
+        {"topic": "OUTPUT", "key": 1, "value": {"KSQL_COL_0": [], "KSQL_COL_1": []}},
+        {"topic": "OUTPUT", "key": 1, "value": {"KSQL_COL_0": [], "KSQL_COL_1": []}}
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
### Description 

Fixes https://github.com/confluentinc/ksql/issues/3506

Please note this PR is stacked on top of https://github.com/confluentinc/ksql/pull/3692 - please do not review files from the previous PRs.

This PR add new UDFS RANGE AND ENTRIES - these will be useful when used to together with the EXPLODE table function.

RANGE - generates an ARRAY of INTs/BIGINTs in the specified range
ENTRIES - generates an ARRAY of STRUCT for the given MAP (one STRUCT for each K, V pair).

### Testing done 

Added new unit tests and QTT tests

### Reviewer checklist
- [ ] Ensure docs are updated if necessary. (eg. if a user visible feature is being added or changed).
- [ ] Ensure relevant issues are linked (description should include text like "Fixes #<issue number>")

