### PR TITLE
fix: Remove duplicate ksql-common dependency in ksql-streams pom

### DIFF
--- a/ksql-streams/pom.xml
+++ b/ksql-streams/pom.xml
@@ -69,10 +69,6 @@
             <version>${project.version}</version>
             <scope>test</scope>
         </dependency>
-      <dependency>
-        <groupId>io.confluent.ksql</groupId>
-        <artifactId>ksql-common</artifactId>
-      </dependency>
 
     </dependencies>
 


### PR DESCRIPTION
Maven complains with warnings if there are duplicated dependencies

### Description 
_What behavior do you want to change, why, how does your patch achieve the changes?_

### Testing done 
_Describe the testing strategy. Unit and integration tests are expected for any behavior changes._

### Reviewer checklist
- [ ] Ensure docs are updated if necessary. (eg. if a user visible feature is being added or changed).
- [ ] Ensure relevant issues are linked (description should include text like "Fixes #<issue number>")

