### PR TITLE
refactor: store function expr in flatmap step

### DIFF
--- a/ksql-execution/src/main/java/io/confluent/ksql/execution/plan/StreamFlatMap.java
+++ b/ksql-execution/src/main/java/io/confluent/ksql/execution/plan/StreamFlatMap.java
@@ -15,7 +15,7 @@
 package io.confluent.ksql.execution.plan;
 
 import com.google.errorprone.annotations.Immutable;
-import io.confluent.ksql.execution.function.udtf.TableFunctionApplier;
+import io.confluent.ksql.execution.expression.tree.FunctionCall;
 import java.util.Collections;
 import java.util.List;
 import java.util.Objects;
@@ -25,16 +25,16 @@ public class StreamFlatMap<K> implements ExecutionStep<KStreamHolder<K>> {
 
   private final ExecutionStepProperties properties;
   private final ExecutionStep<KStreamHolder<K>> source;
-  private final List<TableFunctionApplier> tableFunctionAppliers;
+  private final List<FunctionCall> tableFunctions;
 
   public StreamFlatMap(
       final ExecutionStepProperties properties,
       final ExecutionStep<KStreamHolder<K>> source,
-      final List<TableFunctionApplier> tableFunctionAppliers
+      final List<FunctionCall> tableFunctionAppliers
   ) {
     this.properties = Objects.requireNonNull(properties, "properties");
     this.source = Objects.requireNonNull(source, "source");
-    this.tableFunctionAppliers = Objects.requireNonNull(tableFunctionAppliers);
+    this.tableFunctions = Objects.requireNonNull(tableFunctionAppliers);
   }
 
   @Override
@@ -52,8 +52,8 @@ public class StreamFlatMap<K> implements ExecutionStep<KStreamHolder<K>> {
     return builder.visitFlatMap(this);
   }
 
-  public List<TableFunctionApplier> getTableFunctionAppliers() {
-    return tableFunctionAppliers;
+  public List<FunctionCall> getTableFunctions() {
+    return tableFunctions;
   }
 
   public ExecutionStep<KStreamHolder<K>> getSource() {

--- a/ksql-streams/src/main/java/io/confluent/ksql/execution/streams/ExecutionStepFactory.java
+++ b/ksql-streams/src/main/java/io/confluent/ksql/execution/streams/ExecutionStepFactory.java
@@ -19,7 +19,6 @@ import io.confluent.ksql.execution.builder.KsqlQueryBuilder;
 import io.confluent.ksql.execution.context.QueryContext;
 import io.confluent.ksql.execution.expression.tree.Expression;
 import io.confluent.ksql.execution.expression.tree.FunctionCall;
-import io.confluent.ksql.execution.function.udtf.TableFunctionApplier;
 import io.confluent.ksql.execution.plan.DefaultExecutionStepProperties;
 import io.confluent.ksql.execution.plan.ExecutionStep;
 import io.confluent.ksql.execution.plan.Formats;
@@ -147,13 +146,13 @@ public final class ExecutionStepFactory {
       final QueryContext.Stacker stacker,
       final ExecutionStep<KStreamHolder<K>> source,
       final LogicalSchema resultSchema,
-      final List<TableFunctionApplier> tableFunctionAppliers
+      final List<FunctionCall> tableFunctions
   ) {
     final QueryContext queryContext = stacker.getQueryContext();
     return new StreamFlatMap<>(
         new DefaultExecutionStepProperties(resultSchema, queryContext),
         source,
-        tableFunctionAppliers
+        tableFunctions
     );
   }
 

--- a/ksql-streams/src/main/java/io/confluent/ksql/execution/streams/KSPlanBuilder.java
+++ b/ksql-streams/src/main/java/io/confluent/ksql/execution/streams/KSPlanBuilder.java
@@ -130,7 +130,7 @@ public final class KSPlanBuilder implements PlanBuilder {
   @Override
   public <K> KStreamHolder<K> visitFlatMap(final StreamFlatMap<K> streamFlatMap) {
     final KStreamHolder<K> source = streamFlatMap.getSource().build(this);
-    return StreamFlatMapBuilder.build(source, streamFlatMap);
+    return StreamFlatMapBuilder.build(source, streamFlatMap, queryBuilder);
   }
 
   @Override

--- a/ksql-streams/src/main/java/io/confluent/ksql/execution/streams/StreamFlatMapBuilder.java
+++ b/ksql-streams/src/main/java/io/confluent/ksql/execution/streams/StreamFlatMapBuilder.java
@@ -15,9 +15,20 @@
 
 package io.confluent.ksql.execution.streams;
 
+import io.confluent.ksql.execution.builder.KsqlQueryBuilder;
+import io.confluent.ksql.execution.codegen.CodeGenRunner;
+import io.confluent.ksql.execution.codegen.ExpressionMetadata;
+import io.confluent.ksql.execution.expression.tree.Expression;
+import io.confluent.ksql.execution.expression.tree.FunctionCall;
+import io.confluent.ksql.execution.function.UdtfUtil;
 import io.confluent.ksql.execution.function.udtf.KudtfFlatMapper;
+import io.confluent.ksql.execution.function.udtf.TableFunctionApplier;
 import io.confluent.ksql.execution.plan.KStreamHolder;
 import io.confluent.ksql.execution.plan.StreamFlatMap;
+import io.confluent.ksql.function.KsqlTableFunction;
+import io.confluent.ksql.schema.ksql.LogicalSchema;
+import java.util.ArrayList;
+import java.util.List;
 
 public final class StreamFlatMapBuilder {
 
@@ -26,9 +37,32 @@ public final class StreamFlatMapBuilder {
 
   public static <K> KStreamHolder<K> build(
       final KStreamHolder<K> stream,
-      final StreamFlatMap<K> step) {
+      final StreamFlatMap<K> step,
+      final KsqlQueryBuilder queryBuilder) {
+    final List<FunctionCall> tableFunctions = step.getTableFunctions();
+    final LogicalSchema schema = step.getSource().getSchema();
+    final List<TableFunctionApplier> tableFunctionAppliers = new ArrayList<>(tableFunctions.size());
+    final CodeGenRunner codeGenRunner =
+        new CodeGenRunner(schema, queryBuilder.getKsqlConfig(), queryBuilder.getFunctionRegistry());
+    for (FunctionCall functionCall: tableFunctions) {
+      final List<ExpressionMetadata> expressionMetadataList = new ArrayList<>(
+          functionCall.getArguments().size());
+      for (Expression expression : functionCall.getArguments()) {
+        final ExpressionMetadata expressionMetadata =
+            codeGenRunner.buildCodeGenFromParseTree(expression, "Table function");
+        expressionMetadataList.add(expressionMetadata);
+      }
+      final KsqlTableFunction tableFunction = UdtfUtil.resolveTableFunction(
+          queryBuilder.getFunctionRegistry(),
+          functionCall,
+          schema
+      );
+      final TableFunctionApplier tableFunctionApplier =
+          new TableFunctionApplier(tableFunction, expressionMetadataList);
+      tableFunctionAppliers.add(tableFunctionApplier);
+    }
     return stream.withStream(stream.getStream().flatMapValues(
-        new KudtfFlatMapper(step.getTableFunctionAppliers())));
+        new KudtfFlatMapper(tableFunctionAppliers))
+    );
   }
-
 }


### PR DESCRIPTION
Minor refactor to have the flat map exec step store the function call
rather than the applier.