### PR TITLE
feat: Don't perform validation for pull queries

### DIFF
--- a/ksql-rest-app/src/main/java/io/confluent/ksql/rest/server/resources/KsqlResource.java
+++ b/ksql-rest-app/src/main/java/io/confluent/ksql/rest/server/resources/KsqlResource.java
@@ -22,12 +22,10 @@ import io.confluent.ksql.KsqlExecutionContext;
 import io.confluent.ksql.engine.KsqlEngine;
 import io.confluent.ksql.parser.DefaultKsqlParser;
 import io.confluent.ksql.parser.KsqlParser.ParsedStatement;
-import io.confluent.ksql.parser.KsqlParser.PreparedStatement;
 import io.confluent.ksql.parser.tree.DescribeFunction;
 import io.confluent.ksql.parser.tree.ListFunctions;
 import io.confluent.ksql.parser.tree.ListProperties;
 import io.confluent.ksql.parser.tree.ListTopics;
-import io.confluent.ksql.parser.tree.Query;
 import io.confluent.ksql.parser.tree.SetProperty;
 import io.confluent.ksql.parser.tree.Statement;
 import io.confluent.ksql.parser.tree.UnsetProperty;
@@ -211,23 +209,23 @@ public class KsqlResource implements KsqlConfigurable {
 
       final List<ParsedStatement> statements = ksqlEngine.parse(request.getKsql());
 
-      boolean isPullQuery = false;
-      for (ParsedStatement statement: statements) {
-        final PreparedStatement<?> prepared = ksqlEngine.prepare(statement);
-        final Class<? extends Statement> statementClass = prepared.getStatement().getClass();
-        if (statementClass.equals(Query.class)) {
-          isPullQuery = true;
-        }
-      }
-
-      if (!isPullQuery) {
-        validator.validate(
-            SandboxedServiceContext.create(serviceContext),
-            statements,
-            request.getStreamsProperties(),
-            request.getKsql()
-        );
-      }
+      // boolean isPullQuery = false;
+      // for (ParsedStatement statement: statements) {
+      // final PreparedStatement<?> prepared = ksqlEngine.prepare(statement);
+      // final Class<? extends Statement> statementClass = prepared.getStatement().getClass();
+      // if (statementClass.equals(Query.class)) {
+      // isPullQuery = true;
+      // }
+      // }
+      //
+      //if (!isPullQuery) {
+      validator.validate(
+          SandboxedServiceContext.create(serviceContext),
+          statements,
+          request.getStreamsProperties(),
+          request.getKsql()
+      );
+      // }
 
       final KsqlEntityList entities = handler.execute(
           serviceContext,

--- a/ksql-rest-app/src/main/java/io/confluent/ksql/rest/server/resources/KsqlResource.java
+++ b/ksql-rest-app/src/main/java/io/confluent/ksql/rest/server/resources/KsqlResource.java
@@ -209,23 +209,12 @@ public class KsqlResource implements KsqlConfigurable {
 
       final List<ParsedStatement> statements = ksqlEngine.parse(request.getKsql());
 
-      // boolean isPullQuery = false;
-      // for (ParsedStatement statement: statements) {
-      // final PreparedStatement<?> prepared = ksqlEngine.prepare(statement);
-      // final Class<? extends Statement> statementClass = prepared.getStatement().getClass();
-      // if (statementClass.equals(Query.class)) {
-      // isPullQuery = true;
-      // }
-      // }
-      //
-      //if (!isPullQuery) {
       validator.validate(
           SandboxedServiceContext.create(serviceContext),
           statements,
           request.getStreamsProperties(),
           request.getKsql()
       );
-      // }
 
       final KsqlEntityList entities = handler.execute(
           serviceContext,

--- a/ksql-rest-app/src/main/java/io/confluent/ksql/rest/server/validation/RequestValidator.java
+++ b/ksql-rest-app/src/main/java/io/confluent/ksql/rest/server/validation/RequestValidator.java
@@ -24,6 +24,7 @@ import io.confluent.ksql.parser.KsqlParser.ParsedStatement;
 import io.confluent.ksql.parser.KsqlParser.PreparedStatement;
 import io.confluent.ksql.parser.tree.CreateAsSelect;
 import io.confluent.ksql.parser.tree.InsertInto;
+import io.confluent.ksql.parser.tree.Query;
 import io.confluent.ksql.parser.tree.RunScript;
 import io.confluent.ksql.parser.tree.Statement;
 import io.confluent.ksql.rest.util.QueryCapacityUtil;
@@ -107,6 +108,12 @@ public class RequestValidator {
       final PreparedStatement<?> prepared = ctx.prepare(parsed);
       final ConfiguredStatement<?> configured = ConfiguredStatement.of(
           prepared, scopedPropertyOverrides, ksqlConfig);
+
+      final Class<? extends Statement> statementClass = prepared.getStatement().getClass();
+      if (statementClass.equals(Query.class)
+          && ((Query) prepared.getStatement()).isStatic()) {
+        continue;
+      }
 
       numPersistentQueries += (prepared.getStatement() instanceof RunScript)
           ? validateRunScript(serviceContext, configured, scopedPropertyOverrides, ctx)

--- a/ksql-rest-app/src/main/java/io/confluent/ksql/rest/server/validation/RequestValidator.java
+++ b/ksql-rest-app/src/main/java/io/confluent/ksql/rest/server/validation/RequestValidator.java
@@ -106,14 +106,15 @@ public class RequestValidator {
     int numPersistentQueries = 0;
     for (ParsedStatement parsed : statements) {
       final PreparedStatement<?> prepared = ctx.prepare(parsed);
-      final ConfiguredStatement<?> configured = ConfiguredStatement.of(
-          prepared, scopedPropertyOverrides, ksqlConfig);
 
       final Class<? extends Statement> statementClass = prepared.getStatement().getClass();
       if (statementClass.equals(Query.class)
           && ((Query) prepared.getStatement()).isStatic()) {
         continue;
       }
+
+      final ConfiguredStatement<?> configured = ConfiguredStatement.of(
+          prepared, scopedPropertyOverrides, ksqlConfig);
 
       numPersistentQueries += (prepared.getStatement() instanceof RunScript)
           ? validateRunScript(serviceContext, configured, scopedPropertyOverrides, ctx)


### PR DESCRIPTION
### Description 
Fixes #3711 

Since validation happens by checking the Kafka topic, we feel that it doesn't make sense to validate pull queries since they don't query any Kafka topic but rather only access the state store. There is no ACL protection on the state store so why perform the validation?

Background info: When a streaming query is running, and ACLs change, the query should stop and report to the user that they don't have permissions anymore. Instead it was left hanging hence this validation check was added. For pull queries, this argument doesn't make sense as it is a one-off query that accesses the state store and not a topic. 

### Testing done 
No new tests

### Reviewer checklist
- [ ] Ensure docs are updated if necessary. (eg. if a user visible feature is being added or changed).
- [ ] Ensure relevant issues are linked (description should include text like "Fixes #<issue number>")

