### PR TITLE
docs: New docs for table functions

### DIFF
--- a/docs/developer-guide/implement-a-udf.rst
+++ b/docs/developer-guide/implement-a-udf.rst
@@ -1,21 +1,21 @@
 .. _implement-a-udf:
 
-Implement a User-defined Function (UDF and UDAF)
-################################################
+Implement a User-defined Function (UDF, UDAF or UDTF)
+#####################################################
 
 Prerequisites
      - `Apache Maven <https://maven.apache.org/download.cgi>`__
      - |cp| :ref:`installed <installation>` locally
      - Internet connectivity for downloading Confluent POM files
 
-Create a user-defined function (UDF) or a user-defined aggregation function
-(UDAF) by following these steps:
+Create a user-defined function (UDF), a user-defined aggregation function
+(UDAF) or a user-defined table function (UDTF) by following these steps:
 
 #. :ref:`Create the KSQL extensions directory <create-ksql-ext-dir>` that
-   contains your UDF and UDAF packages.
+   contains your packages.
 #. :ref:`Create Java source and project files <create-source-and-project-files>`
    for your implementation.
-#. :ref:`Build the package <build-udf-package>` for your UDF or UDAF.
+#. :ref:`Build the package <build-udf-package>` for your function.
 #. :ref:`Use your custom function <use-udf-in-ksql-query>` in a KSQL query or
    statement.
 
@@ -379,13 +379,21 @@ Your output should resemble:
 
 Press Ctrl+C to terminate the query.
 
-Custom Aggregation Function (UDAF)
-**********************************
+User Defined Aggregate Function (UDAF)
+**************************************
 
 Implementing a user-defined aggregation function (UDAF) is similar to the way
 that you implement a UDF. You use the ``UdafDescription`` and ``UdafFactory``
 annotations in your Java code, and you deploy a JAR to the KSQL extensions
 directory. For more information, see :ref:`ksql-udafs`.
+
+User Defined Table Function (UDTF)
+**********************************
+
+Implementing a user-defined table function (UDTF) is similar to the way
+that you implement a UDF. You use the ``UdtfDescription`` and ``Udtf``
+annotations in your Java code, and you deploy a JAR to the KSQL extensions
+directory. For more information, see :ref:`ksql-udtfs`.
 
 Next Steps
 **********

--- a/docs/developer-guide/index.rst
+++ b/docs/developer-guide/index.rst
@@ -13,6 +13,7 @@ These topics show how to develop KSQL applications for |cp|.
     create-a-stream
     create-a-table
     aggregate-streaming-data
+    table-functions
     query-with-arrays-and-maps
     query-with-structured-data
     join-streams-and-tables

--- a/docs/developer-guide/syntax-reference.rst
+++ b/docs/developer-guide/syntax-reference.rst
@@ -1648,6 +1648,13 @@ Scalar functions
 |                        |                                                                           | function is 1-indexed. ELT is the complement to   |
 |                        |                                                                           | FIELD.                                            |
 +------------------------+---------------------------------------------------------------------------+---------------------------------------------------+
+| ENTRIES                | ``ENTRIES(map MAP, sorted BOOLEAN)``                                      | Constructs an array of structs from the entries in|
+|                        |                                                                           | a map. Each struct has a field with name ``K``    |
+|                        |                                                                           | containing the key which is a String and a        |
+|                        |                                                                           | field with name ``V`` holding the value.          |
+|                        |                                                                           | If ``sorted`` is true the entries will be sorted  |
+|                        |                                                                           | by key.                                           |
++------------------------|---------------------------------------------------------------------------+---------------------------------------------------+
 | EXTRACTJSONFIELD       |  ``EXTRACTJSONFIELD(message, '$.log.cloud')``                             | Given a string column in JSON format, extract     |
 |                        |                                                                           | the field that matches.                           |
 |                        |                                                                           |                                                   |
@@ -1733,6 +1740,16 @@ Scalar functions
 |                        |                                                                           | will return ``My Test -nnn``.                     |
 +------------------------+---------------------------------------------------------------------------+---------------------------------------------------+
 | RANDOM                 |  ``RANDOM()``                                                             | Return a random DOUBLE value between 0.0 and 1.0. |
++------------------------+---------------------------------------------------------------------------+---------------------------------------------------+
+| RANGE                  |  ``GENERATE_SERIES(start, end)``                                          | Constructs an array of values between             |
+|                        |                                                                           | ``start`` and ``end`` (inclusive).                |
+|                        |                                                                           | Parameters can be ``INT`` or ``BIGINT``.          |
++------------------------+---------------------------------------------------------------------------+---------------------------------------------------+
+| RANGE                  |  ``GENERATE_SERIES(start, end, step)``                                    | Constructs an array of values between             |
+|                        |                                                                           | ``start`` and ``end`` (inclusive) with a specified|
+|                        |                                                                           | step size. Step can be positive or negative.      |
+|                        |                                                                           | Parameters ``start`` and ``end`` can be ``INT`` or|
+|                        |                                                                           | ``BIGINT``. Parameter ``step`` must be an ``INT``.|
 +------------------------+---------------------------------------------------------------------------+---------------------------------------------------+
 | REPLACE                |  ``REPLACE(col1, 'foo', 'bar')``                                          | Replace all instances of a substring in a string  |
 |                        |                                                                           | with a new string.                                |
@@ -1992,6 +2009,23 @@ Aggregate functions
 For more information, see :ref:`aggregate-streaming-data-with-ksql`.
 
 .. _ksql_key_requirements:
+
+
+.. _ksql_table_functions:
+
+===============
+Table functions
+===============
+
+>+------------------------+---------------------------+------------+---------------------------------------------------------------------+
+>| Function               | Example                   | Input Type | Description                                                         |
+>+========================+===========================+============+=====================================================================+
+>| EXPLODE                | ``EXPLODE(col1)``         | Array      | This function takes an Array and outputs one value for each of the  |
+>|                        |                           |            | elements of the array. The output values have the same type as the  |                                     |
+>|                        |                           |            | array elements.                                                     |
+>+------------------------+---------------------------+------------+---------------------------------------------------------------------+
+
+For more information, see :ref:`table-functions`.
 
 ================
 Key Requirements

--- a/docs/developer-guide/syntax-reference.rst
+++ b/docs/developer-guide/syntax-reference.rst
@@ -1648,8 +1648,8 @@ Scalar functions
 |                        |                                                                           | function is 1-indexed. ELT is the complement to   |
 |                        |                                                                           | FIELD.                                            |
 +------------------------+---------------------------------------------------------------------------+---------------------------------------------------+
-| ENTRIES                | ``ENTRIES(map MAP, sorted BOOLEAN)``                                      | Constructs an array of structs from the entries in|
-|                        |                                                                           | a map. Each struct has a field with name ``K``    |
+| ENTRIES                | ``ENTRIES(map MAP, sorted BOOLEAN)``                                      | Constructs an array of structs from the entries   |
+|                        |                                                                           | in a map. Each struct has a field with name ``K`` |
 |                        |                                                                           | containing the key which is a String and a        |
 |                        |                                                                           | field with name ``V`` holding the value.          |
 |                        |                                                                           | If ``sorted`` is true the entries will be sorted  |
@@ -1679,6 +1679,16 @@ Scalar functions
 |                        |                                                                           | complement to ELT.                                |
 +------------------------+---------------------------------------------------------------------------+---------------------------------------------------+
 | FLOOR                  |  ``FLOOR(col1)``                                                          | The floor of a value.                             |
++------------------------+---------------------------------------------------------------------------+---------------------------------------------------+
+| GENERATE_SERIES        |  ``GENERATE_SERIES(start, end)``                                          | Constructs an array of values between             |
+|                        |                                                                           | ``start`` and ``end`` (inclusive).                |
+|                        |                                                                           | Parameters can be ``INT`` or ``BIGINT``.          |
++------------------------+---------------------------------------------------------------------------+---------------------------------------------------+
+| GENERATE_SERIES        |  ``GENERATE_SERIES(start, end, step)``                                    | Constructs an array of values between             |
+|                        |                                                                           | ``start`` and ``end`` (inclusive) with a specified|
+|                        |                                                                           | step size. Step can be positive or negative.      |
+|                        |                                                                           | Parameters ``start`` and ``end`` can be ``INT`` or|
+|                        |                                                                           | ``BIGINT``. Parameter ``step`` must be an ``INT``.|
 +------------------------+---------------------------------------------------------------------------+---------------------------------------------------+
 | GEO_DISTANCE           |  ``GEO_DISTANCE(lat1, lon1, lat2, lon2, unit)``                           | The great-circle distance between two lat-long    |
 |                        |                                                                           | points, both specified in decimal degrees. An     |
@@ -1740,16 +1750,6 @@ Scalar functions
 |                        |                                                                           | will return ``My Test -nnn``.                     |
 +------------------------+---------------------------------------------------------------------------+---------------------------------------------------+
 | RANDOM                 |  ``RANDOM()``                                                             | Return a random DOUBLE value between 0.0 and 1.0. |
-+------------------------+---------------------------------------------------------------------------+---------------------------------------------------+
-| RANGE                  |  ``GENERATE_SERIES(start, end)``                                          | Constructs an array of values between             |
-|                        |                                                                           | ``start`` and ``end`` (inclusive).                |
-|                        |                                                                           | Parameters can be ``INT`` or ``BIGINT``.          |
-+------------------------+---------------------------------------------------------------------------+---------------------------------------------------+
-| RANGE                  |  ``GENERATE_SERIES(start, end, step)``                                    | Constructs an array of values between             |
-|                        |                                                                           | ``start`` and ``end`` (inclusive) with a specified|
-|                        |                                                                           | step size. Step can be positive or negative.      |
-|                        |                                                                           | Parameters ``start`` and ``end`` can be ``INT`` or|
-|                        |                                                                           | ``BIGINT``. Parameter ``step`` must be an ``INT``.|
 +------------------------+---------------------------------------------------------------------------+---------------------------------------------------+
 | REPLACE                |  ``REPLACE(col1, 'foo', 'bar')``                                          | Replace all instances of a substring in a string  |
 |                        |                                                                           | with a new string.                                |

--- a/docs/developer-guide/syntax-reference.rst
+++ b/docs/developer-guide/syntax-reference.rst
@@ -2008,24 +2008,23 @@ Aggregate functions
 
 For more information, see :ref:`aggregate-streaming-data-with-ksql`.
 
-.. _ksql_key_requirements:
-
-
 .. _ksql_table_functions:
 
 ===============
 Table functions
 ===============
 
->+------------------------+---------------------------+------------+---------------------------------------------------------------------+
->| Function               | Example                   | Input Type | Description                                                         |
->+========================+===========================+============+=====================================================================+
->| EXPLODE                | ``EXPLODE(col1)``         | Array      | This function takes an Array and outputs one value for each of the  |
->|                        |                           |            | elements of the array. The output values have the same type as the  |                                     |
->|                        |                           |            | array elements.                                                     |
->+------------------------+---------------------------+------------+---------------------------------------------------------------------+
++------------------------+---------------------------+------------+---------------------------------------------------------------------+
+| Function               | Example                   | Input Type | Description                                                         |
++========================+===========================+============+=====================================================================+
+| EXPLODE                | ``EXPLODE(col1)``         | Array      | This function takes an Array and outputs one value for each of the  |
+|                        |                           |            | elements of the array. The output values have the same type as the  |
+|                        |                           |            | array elements.                                                     |
++------------------------+---------------------------+------------+---------------------------------------------------------------------+
 
 For more information, see :ref:`table-functions`.
+
+.. _ksql_key_requirements:
 
 ================
 Key Requirements

--- a/docs/developer-guide/table-functions.rst
+++ b/docs/developer-guide/table-functions.rst
@@ -1,0 +1,90 @@
+.. _table-functions:
+
+
+Using Table Functions With KSQL
+###############################
+
+A _table function_ is a function that returns a set of zero or more rows. Contrast this to a scalar
+function, which returns a single value.
+
+Table functions are analagous to the ``FlatMap`` operation commonly found in
+functional programming or stream processing frameworks such as |kstreams|.
+
+Table functions are used in the SELECT clause of a query. They cause the query to potentially
+output more than one row for each input value.
+
+The current implementation of table functions only allows a single column to be returned. This column
+can be any valid KSQL type.
+
+Here's an example of the ``EXPLODE`` built-in table function, which takes an ARRAY and outputs one value
+for each element of the array:
+
+.. code:: sql
+
+  {sensor_id:12345 readings: [23, 56, 3, 76, 75]}
+  {sensor_id:54321 readings: [12, 65, 38]}
+
+
+The following stream:
+
+.. code:: sql
+
+  CREATE STREAM exploded_stream AS
+    SELECT sensor_id, EXPLODE(readings) AS reading FROM batched_readings;
+
+Would emit:
+
+.. code:: sql
+
+  {sensor_id:12345 reading: 23}
+  {sensor_id:12345 reading: 56}
+  {sensor_id:12345 reading: 3}
+  {sensor_id:12345 reading: 76}
+  {sensor_id:12345 reading: 75}
+  {sensor_id:54321 reading: 12}
+  {sensor_id:54321 reading: 65}
+  {sensor_id:54321 reading: 38}
+
+When scalar values are mixed with table function return values in a SELECT clause, the scalar values
+like ``sensor_id`` in the previous example, are copied for each value returned from the table function.
+
+You can also use multiple table functions in a SELECT clause. In this situation, the results of the
+table functions are "zipped" together. The total number of rows returned is equal to the greatest
+number of values returned from any of the table functions. If some of the functions return fewer
+rows than others, the missing values are replaced with ``null``.
+
+Here's an example that illustrates using multiple table functions in a SELECT clause.
+
+With the following input data:
+
+.. code:: sql
+
+  {country:'UK', customer_names: ['john', 'paul', 'george', 'ringo'], customer_ages: [23, 56, 3]}
+  {country:'USA', customer_names: ['chad', 'chip', 'brad'], customer_ages: [56, 34, 76, 84, 56]}
+
+And the following stream:
+
+.. code:: sql
+
+  CREATE STREAM country_customers AS
+    SELECT country, EXPLODE(customer_names) AS name, EXPLODE(customer_ages) AS age FROM country_batches;
+
+Would give:
+
+.. code:: sql
+
+  {country: 'UK', name: 'john', age: 23}
+  {country: 'UK', name: 'paul', age: 56}
+  {country: 'UK', name: 'george', age: 3}
+  {country: 'UK', name: 'ringo', age: null}
+  {country: 'USA', name: 'chad', age: 56}
+  {country: 'USA', name: 'chip', age: 34}
+  {country: 'USA', name: 'brad', age: 76}
+  {country: 'USA', name: null, age: 84}
+  {country: 'USA', name: null, age: 56}
+
+
+Built-in Table Functions
+========================
+
+KSQL comes with built-in table functions. For more information, see :ref:`ksql_table_functions`.

--- a/docs/developer-guide/table-functions.rst
+++ b/docs/developer-guide/table-functions.rst
@@ -4,7 +4,7 @@
 Using Table Functions With KSQL
 ###############################
 
-A _table function_ is a function that returns a set of zero or more rows. Contrast this to a scalar
+A table function is a function that returns a set of zero or more rows. Contrast this to a scalar
 function, which returns a single value.
 
 Table functions are analagous to the ``FlatMap`` operation commonly found in

--- a/docs/developer-guide/udf.rst
+++ b/docs/developer-guide/udf.rst
@@ -60,7 +60,7 @@ Creating UDFs, UDAFs and UDTFs
 ==============================
 
 KSQL supports creating User Defined Scalar Functions (UDFs), User Defined Aggregate Functions (UDAFs) and
- User Defined Table Functions (UDTFs) via custom jars that are
+User Defined Table Functions (UDTFs) via custom jars that are
 uploaded to the ``ext/`` directory of the KSQL installation.
 At start up time KSQL scans the jars in the directory looking for any classes that annotated
 with ``@UdfDescription`` (UDF), ``@UdafDescription`` (UDAF) or ``@UdtfDescription`` (UDTF).
@@ -688,11 +688,13 @@ You can use this to better describe what a particular version of the UDF does, f
     public static Udaf<String, Struct, Double> averageStringLength(final String initialString){...}
 
 
+.. _ksql-udtfs:
+
 UDTFs
-----
+-----
 
 To create a UDTF you need to create a class that is annotated with ``@UdtfDescription``.
-Each method in the class that represents a UDF must be public and annotated with ``@Udtf``. The class
+Each method in the class that represents a UDTF must be public and annotated with ``@Udtf``. The class
 you create represents a collection of UDTFs all with the same name but may have different
 arguments and return types.
 
@@ -733,6 +735,9 @@ To use this functionality, you need to specify a method with signature
 Also, you need to link it to the corresponding UDF by using the ``schemaProvider=<your-method-name>``
 parameter of the ``@Udtf`` annotation.
 
+Please note that if your UDTF method returns a value of type ``List<T>`` then the type referred to
+by the schema provider method is the type ``T`` not the type ``List<T>``.
+
 .. _example-udtf-class:
 
 Example UDTF class
@@ -740,7 +745,11 @@ Example UDTF class
 
 The class below creates a UDTF named ``split_string``. The name of the UDTF is provided in the ``name``
 parameter of the ``UdtfDescription`` annotation. This name is case-insensitive and is what can be
-used to call the UDTF. As can be seen this UDTF can be invoked in two different ways:
+used to call the UDTF.
+
+UDTF methods must return a value of type ``List<T>`` where T is any of the supported KSQL Java types.
+
+As can be seen this UDTF can be invoked in two different ways:
 
 - with a single String containing the String to split
 - with a String containing the String to split and a regex to define the delimiter

--- a/docs/developer-guide/udf.rst
+++ b/docs/developer-guide/udf.rst
@@ -735,7 +735,7 @@ To use this functionality, you need to specify a method with signature
 Also, you need to link it to the corresponding UDF by using the ``schemaProvider=<your-method-name>``
 parameter of the ``@Udtf`` annotation.
 
-Please note that if your UDTF method returns a value of type ``List<T>`` then the type referred to
+If your UDTF method returns a value of type ``List<T>``, the type referred to
 by the schema provider method is the type ``T`` not the type ``List<T>``.
 
 .. _example-udtf-class:
@@ -744,12 +744,12 @@ Example UDTF class
 ~~~~~~~~~~~~~~~~~~
 
 The class below creates a UDTF named ``split_string``. The name of the UDTF is provided in the ``name``
-parameter of the ``UdtfDescription`` annotation. This name is case-insensitive and is what can be
-used to call the UDTF.
+parameter of the ``UdtfDescription`` annotation. This name is case-insensitive and you can use it
+to call the UDTF.
 
 UDTF methods must return a value of type ``List<T>`` where T is any of the supported KSQL Java types.
 
-As can be seen this UDTF can be invoked in two different ways:
+You can invoke this UDTF in two different ways:
 
 - with a single String containing the String to split
 - with a String containing the String to split and a regex to define the delimiter
@@ -787,7 +787,7 @@ To compile with the latest version of ``ksql-udf``:
 
     compile 'io.confluent.ksql:ksql-udf:+'
 
-If you're using Maven to build your UDF or UDAF, specify the ``ksql-udf``
+If you're using Maven to build your function, specify the ``ksql-udf``
 dependency in your POM file:
 
 .. codewithvars:: xml

--- a/docs/developer-guide/udf.rst
+++ b/docs/developer-guide/udf.rst
@@ -1,7 +1,7 @@
 .. _ksql-udfs:
 
-KSQL Custom Function Reference (UDF and UDAF)
-=============================================
+KSQL Custom Function Reference (UDF, UDAF and UDTF)
+===================================================
 
 KSQL has many built-in functions that help with processing records in
 streaming data, like ABS and SUM. Functions are used within a KSQL query
@@ -24,20 +24,24 @@ Stateful aggregate function (UDAF)
     enables aggregating results. When you implement a custom aggregate function,
     it's called a *User-Defined Aggregate Function (UDAF)*.
 
-.. note:: Tabular functions, which take one input row and return *N* output
-          values, aren't supported.
+Table function (UDTF)
+    A table function that takes one input row and returns zero or more output rows.
+    No state is retained between function calls. When you implement a custom
+    table function, it's called a *User-Defined Table Function (UDTF)*.
 
 Implement a Custom Function
 *************************** 
 
 Follow these steps to create your custom functions:
 
-#. Write your UDF or UDAF class in Java.
+#. Write your UDF, UDAF or UDTF class in Java.
 
    * If your Java class is a UDF, mark it with the ``@UdfDescription`` and
      ``@Udf`` annotations.
    * If your class is a UDAF, mark it with the ``@UdafDescription`` and
      ``@UdafFactory`` annotations.
+   * If your class is a UDTF, mark it with the ``@UdtfDescription`` and
+     ``@UdtfFactory`` annotations.
 
    For more information, see :ref:`example-udf-class` and :ref:`example-udaf-class`. 
 
@@ -51,19 +55,21 @@ Follow these steps to create your custom functions:
 
 For a detailed walkthrough on creating a UDF, see :ref:`implement-a-udf`.
 
-=======================
-Creating UDFs and UDAFs
-=======================
+==============================
+Creating UDFs, UDAFs and UDTFs
+==============================
 
-KSQL supports creating User Defined Scalar Functions (UDFs) and User Defined Aggregate Functions (UDAFs) via custom jars that are
+KSQL supports creating User Defined Scalar Functions (UDFs), User Defined Aggregate Functions (UDAFs) and
+ User Defined Table Functions (UDTFs) via custom jars that are
 uploaded to the ``ext/`` directory of the KSQL installation.
 At start up time KSQL scans the jars in the directory looking for any classes that annotated
-with ``@UdfDescription`` (UDF) or ``@UdafDescription`` (UDAF).
+with ``@UdfDescription`` (UDF), ``@UdafDescription`` (UDAF) or ``@UdtfDescription`` (UDTF).
 Classes annotated with ``@UdfDescription`` are scanned for any public methods that are annotated
 with ``@Udf``. Classes annotated with ``@UdafDescription`` are scanned for any public static methods
-that are annotated with ``@UdafFactory``. Each UD(A)F that is found is parsed and, if successful, loaded into KSQL.
+that are annotated with ``@UdafFactory``. Classes annotated with ``@UdtfDescription`` are scanned for any public methods
+that are annotated with ``@Udtf``. Each function that is found is parsed and, if successful, loaded into KSQL.
 
-Each UD(A)F instance has its own child-first ``ClassLoader`` that is isolated from other UD(A)Fs. If you
+Each function instance has its own child-first ``ClassLoader`` that is isolated from other functions. If you
 need to use any third-party libraries with your UDFs then they should also be part of your jar, i.e.,
 you should create an "uber-jar". The classes in your uber-jar will be loaded in preference to any
 classes on the KSQL classpath excluding anything vital to the running of KSQL, i.e., classes that are
@@ -723,7 +729,7 @@ The types supported by UDFs are currently limited to:
 Deploying
 =========
 
-To deploy your UD(A)Fs you need to create a jar containing all of the classes required by the UD(A)Fs.
+To deploy your user defined functions you need to create a jar containing all of the classes required by the functions.
 If you depend on third-party libraries then this should be an uber-jar containing those libraries.
 Once the jar is created you need to deploy it to each KSQL server instance. The jar should be copied
 to the ``ext/`` directory that is part of the KSQL distribution. The ``ext/`` directory can be configured
@@ -753,7 +759,7 @@ correct jars installed.
 Usage
 =====
 
-Once your UD(A)Fs are deployed you can call them in the same way you would invoke any of the KSQL
+Once your functions are deployed you can call them in the same way you would invoke any of the KSQL
 built-in functions. The function names are case-insensitive. For example, using the ``multiply`` example above:
 
 .. code:: sql
@@ -800,7 +806,7 @@ Security Manager
 ----------------
 
 By default KSQL installs a simple java security manager for UD(A)F execution. The security manager
-blocks attempts by any UD(A)Fs to fork processes from the KSQL server. It also prevents them from
+blocks attempts by any functions to fork processes from the KSQL server. It also prevents them from
 calling ``System.exit(..)``.
 
 The security manager can be disabled by setting ``ksql.udf.enable.security.manager`` to false.

--- a/docs/developer-guide/udf.rst
+++ b/docs/developer-guide/udf.rst
@@ -858,32 +858,12 @@ fields:
 |               | Return Types for more info)  | passed in.             |
 +---------------+------------------------------+------------------------+
 
-UdtfParameter Annotation
-~~~~~~~~~~~~~~~~~~~~~~~
+Annotating UDTF Parameters
+~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-The ``@UdtfParameter`` annotation is applied to parameters of methods annotated with ``@Udtf``. KSQL
-will use the additional information in the ``@UdtfParameter`` annotation to specify the parameter
-schema (if it cannot be inferred from the Java type) or to provide users with richer information
-about the method when, for example, they execute ``DESCRIBE FUNCTION`` on the method.
-
-+------------+------------------------------+------------------------+
-| Field      | Description                  | Required               |
-+============+==============================+========================+
-| value      | The case-insensitive name of | Required if the JAR    |
-|            | the parameter                | was not compiled with  |
-|            |                              | the ``-parameters``    |
-|            |                              | javac argument.        |
-+------------+------------------------------+------------------------+
-| description| A string describing generally| No                     |
-|            | what the parameter represents|                        |
-+------------+------------------------------+------------------------+
-| schema     | The KSQL schema for the      | For complex types      |
-|            | parameter.                   | such as STRUCT         |
-+------------+------------------------------+------------------------+
-
-.. note:: If ``schema`` is supplied in the ``@UdtfParameter`` annotation for a ``STRUCT`` it is
-          considered "strict" - any inputs must match exactly, including order and names of the
-          fields.
+You can use the ``@UdfParameter`` annotation to provide extra information for UDTF parameters.
+This is the same annotation as used for UDFs. Please see the earlier documentation on this for
+further information.
 
 ===============
 Supported Types


### PR DESCRIPTION
### Description

This PR is a copy of https://github.com/confluentinc/ksql/pull/3705 which was closed due to a corrupt Jenkins workspace

Fixes #3509 #3510

This PR contains the docs for the new table function functionality. It includes:

New syntax reference for built in table functions
New syntax reference for new UDFs
New section in dev guide on table functions
Extended page on UDFS to include table functions
Extended page on "implement a udf" to include table functions.

### Reviewer checklist
- [ ] Ensure docs are updated if necessary. (eg. if a user visible feature is being added or changed).
- [ ] Ensure relevant issues are linked (description should include text like "Fixes #<issue number>")

