### PR TITLE
fix: apply filter before flat mapping in logical planner

### DIFF
--- a/ksql-engine/src/main/java/io/confluent/ksql/planner/LogicalPlanner.java
+++ b/ksql-engine/src/main/java/io/confluent/ksql/planner/LogicalPlanner.java
@@ -77,12 +77,12 @@ public class LogicalPlanner {
   public OutputNode buildPlan() {
     PlanNode currentNode = buildSourceNode();
 
-    if (!analysis.getTableFunctions().isEmpty()) {
-      currentNode = buildFlatMapNode(currentNode);
-    }
-
     if (analysis.getWhereExpression().isPresent()) {
       currentNode = buildFilterNode(currentNode, analysis.getWhereExpression().get());
+    }
+
+    if (!analysis.getTableFunctions().isEmpty()) {
+      currentNode = buildFlatMapNode(currentNode);
     }
 
     if (analysis.getGroupByExpressions().isEmpty()) {

--- a/ksql-functional-tests/src/test/resources/query-validation-tests/table-functions.json
+++ b/ksql-functional-tests/src/test/resources/query-validation-tests/table-functions.json
@@ -217,6 +217,26 @@
           }
         ]
       }
+    },
+    {
+      "name": "table function with where clause",
+      "statements": [
+        "CREATE STREAM TEST (F0 INT, F1 ARRAY<INT>) WITH (kafka_topic='test_topic', value_format='JSON');",
+        "CREATE STREAM OUTPUT AS SELECT F0, EXPLODE(F1) VAL FROM TEST WHERE F0 <> 1;"
+      ],
+      "inputs": [
+        {"topic": "test_topic", "key": 0, "value": {"F0": 0, "F1": [1, 2, 3]}},
+        {"topic": "test_topic", "key": 0, "value": {"F0": 1, "F1": [4, 5, 6]}},
+        {"topic": "test_topic", "key": 0, "value": {"F0": 2, "F1": [7, 8, 9]}}
+      ],
+      "outputs": [
+        {"topic": "OUTPUT", "key": "0", "value": {"F0": 0, "VAL": 1}},
+        {"topic": "OUTPUT", "key": "0", "value": {"F0": 0, "VAL": 2}},
+        {"topic": "OUTPUT", "key": "0", "value": {"F0": 0, "VAL": 3}},
+        {"topic": "OUTPUT", "key": "0", "value": {"F0": 2, "VAL": 7}},
+        {"topic": "OUTPUT", "key": "0", "value": {"F0": 2, "VAL": 8}},
+        {"topic": "OUTPUT", "key": "0", "value": {"F0": 2, "VAL": 9}}
+      ]
     }
   ]
 }


### PR DESCRIPTION
### Description 

This PR changes the logic plan so that any filter node gets applied before a flat map node.

### Testing done 

Non functional change but I've added a new QTT test for a table function with a where clause anyway.

### Reviewer checklist
- [ ] Ensure docs are updated if necessary. (eg. if a user visible feature is being added or changed).
- [ ] Ensure relevant issues are linked (description should include text like "Fixes #<issue number>")

