### PR TITLE
docs: copy new recommended KSQL server config (DOCS-2816)

### DIFF
--- a/docs-md/installation/server-config/config-reference.md
+++ b/docs-md/installation/server-config/config-reference.md
@@ -526,22 +526,27 @@ ksql.streams.producer.delivery.timeout.ms=2147483647
 # Kafka cluster is unavailable.
 ksql.streams.producer.max.block.ms=9223372036854775807
 
-# For better fault tolerance and durability, set the replication factor for the KSQL
-# Server's internal topics. Note: the value 3 requires at least 3 brokers in your Kafka cluster.
-ksql.internal.topic.replicas=3
-
-# For better fault tolerance and durability, set the replication factor for
-# the internal topics that Kafka Streams creates for some queries.
-# Note: the value 3 requires at least 3 brokers in your Kafka cluster.
+# Configure underlying Kafka Streams internal topics to achieve better
+# fault tolerance and durability, even in the face of Kafka broker failures.
+# Highly recommended for mission critical applications.
+# Note that a value of 3 requires at least 3 brokers in your Kafka cluster.
 ksql.streams.replication.factor=3
+ksql.streams.producer.acks=all
+ksql.streams.topic.min.insync.replicas=2
 
 # Set the storage directory for stateful operations like aggregations and
 # joins to be at a durable location. By default, they are stored in /tmp.
-ksql.streams.state.dir=/some/non-temporary-storage-path/
+# Note that the following path must be replaced with the actual path.
+ksql.streams.state.dir=</some/non-temporary-storage-path/>
 
 # Bump the number of replicas for state storage for stateful operations
 # like aggregations and joins. By having two replicas (one main and one
-# standby) recovery from node failures is quicker since the state doesn't
-# have to be rebuilt from scratch.
+# standby) recovery from node failures is quicker since the state doesn't 
+# need to be rebuilt from scratch. This configuration is also essential for
+# pull queries to be highly available during node failures.
 ksql.streams.num.standby.replicas=1
 ```
+
+For more information, see the
+[ksql-production-server.properties](https://github.com/confluentinc/ksql/blob/master/config/ksql-production-server.properties)
+example file.


### PR DESCRIPTION
Migrate new content from https://github.com/confluentinc/ksql/pull/3691.