### PR TITLE
docs: update broken stream-stream join example

### DIFF
--- a/docs/developer-guide/join-streams-and-tables.rst
+++ b/docs/developer-guide/join-streams-and-tables.rst
@@ -35,23 +35,21 @@ combination of a ``pageviews`` stream and a ``users`` table:
 
 For the full code example, see :ref:`ksql_quickstart-docker`.
 
-When you join two streams, you can specify an optional WITHIN clause for
+When you join two streams, you must specify a WITHIN clause for
 matching records that both occur within a specified time interval. For valid
 time units, see :ref:`ksql-time-units`.
 
 Here's an example stream-stream join that combines a ``shipments`` stream with
-an ``orders`` stream, within a time window. The resulting ``late_orders`` stream
-detects late orders by matching ``shipments`` rows with ``orders`` rows that
-occur within a two-hour window. If there's no match, the right-hand side of the
-join result is NULL, which indicates that the order wasn't shipped within the
-expected time of two hours.
+an ``orders`` stream, as long as the shipment was sent within two hours of when
+the order was placed.
 
 .. code:: sql
 
-   CREATE STREAM late_orders AS
-     SELECT o.orderid, o.itemid FROM orders o
-     FULL OUTER JOIN shipments s WITHIN 2 HOURS
-     ON s.orderid = o.orderid WHERE s.orderid IS NULL;
+   CREATE STREAM shipped_orders AS
+     SELECT o.orderid, o.itemid, s.shipmentid
+     FROM orders o
+     INNER JOIN shipments s WITHIN 2 HOURS
+     ON s.orderid = o.orderid;
 
 Joins and Windows
 *****************

--- a/docs/developer-guide/join-streams-and-tables.rst
+++ b/docs/developer-guide/join-streams-and-tables.rst
@@ -40,8 +40,8 @@ matching records that both occur within a specified time interval. For valid
 time units, see :ref:`ksql-time-units`.
 
 Here's an example stream-stream join that combines a ``shipments`` stream with
-an ``orders`` stream, as long as the shipment was sent within two hours of when
-the order was placed.
+an ``orders`` stream. The resulting ``shipped_orders`` stream contains all
+orders shipped within two hours of when the order was placed.
 
 .. code:: sql
 


### PR DESCRIPTION
### Description 

The existing example is broken in that, assuming orders arrive before shipments, then `late_orders` will contain an entry for every order as soon as the order arrives (before the shipment has been processed) so `late_orders` is really all orders which is misleading. The late orders example is difficult to fix as true identification of late orders requires waiting two hours after the order has arrived and KSQL doesn't support this kind of time-delay/suppression operation today. As a result, this PR updates the example to compute `shipped_orders` instead.

### Testing done 

Docs-only change.

### Reviewer checklist
- [ ] Ensure docs are updated if necessary. (eg. if a user visible feature is being added or changed).
- [ ] Ensure relevant issues are linked (description should include text like "Fixes #<issue number>")

