### PR TITLE
Refactor: Remove fuzzy logic used in `LogicalSchema.findXXX` methods

### DIFF
--- a/ksql-common/src/main/java/io/confluent/ksql/schema/ksql/Column.java
+++ b/ksql-common/src/main/java/io/confluent/ksql/schema/ksql/Column.java
@@ -124,6 +124,7 @@ public final class Column {
    * @param ref the reference to check
    * @return whether or not {@code ref} matches this instance
    */
+  // todo(ac): drop?
   public boolean matches(final ColumnRef ref) {
     return ref.name().equals(this.ref.name())
         && (!source().isPresent()

--- a/ksql-common/src/main/java/io/confluent/ksql/schema/ksql/Column.java
+++ b/ksql-common/src/main/java/io/confluent/ksql/schema/ksql/Column.java
@@ -124,7 +124,6 @@ public final class Column {
    * @param ref the reference to check
    * @return whether or not {@code ref} matches this instance
    */
-  // todo(ac): drop?
   public boolean matches(final ColumnRef ref) {
     return ref.name().equals(this.ref.name())
         && (!source().isPresent()

--- a/ksql-common/src/main/java/io/confluent/ksql/schema/ksql/ColumnRef.java
+++ b/ksql-common/src/main/java/io/confluent/ksql/schema/ksql/ColumnRef.java
@@ -65,6 +65,14 @@ public final class ColumnRef {
     return new ColumnRef(Optional.empty(), name);
   }
 
+  public ColumnRef withoutSource() {
+    return withoutSource(name);
+  }
+
+  public ColumnRef withSource(final SourceName source) {
+    return of(source, name);
+  }
+
   private ColumnRef(final Optional<SourceName> qualifier, final ColumnName name) {
     this.qualifier = requireNonNull(qualifier, "qualifier");
     this.name = requireNonNull(name, "name");
@@ -114,9 +122,5 @@ public final class ColumnRef {
   @Override
   public int hashCode() {
     return Objects.hash(qualifier, name);
-  }
-
-  public ColumnRef withSource(final SourceName source) {
-    return of(source, name);
   }
 }

--- a/ksql-common/src/main/java/io/confluent/ksql/schema/ksql/LogicalSchema.java
+++ b/ksql-common/src/main/java/io/confluent/ksql/schema/ksql/LogicalSchema.java
@@ -120,14 +120,13 @@ public final class LogicalSchema {
   }
 
   /**
-   * Search for a value column with the supplied {@code target}.
+   * Search for a value column with the supplied {@code columnRef}.
    *
-   * @param target the column name, where any alias is ignored.
+   * @param columnRef the column source and name to match.
    * @return the value column if found, else {@code Optional.empty()}.
    */
-  // todo(ac): Exact version
-  public Optional<Column> findValueColumn(final ColumnRef target) {
-    return findNamespacedColumn(withNamespace(Namespace.VALUE).and(thatLooselyMatches(target)))
+  public Optional<Column> findValueColumn(final ColumnRef columnRef) {
+    return findNamespacedColumn(withNamespace(Namespace.VALUE).and(withRef(columnRef)))
         .map(NamespacedColumn::column);
   }
 

--- a/ksql-common/src/main/java/io/confluent/ksql/schema/ksql/LogicalSchema.java
+++ b/ksql-common/src/main/java/io/confluent/ksql/schema/ksql/LogicalSchema.java
@@ -136,11 +136,10 @@ public final class LogicalSchema {
    * @param target the exact name of the column to get the index of.
    * @return the index if it exists or else {@code empty()}.
    */
-  // Todo(ac): exact match version?
   public OptionalInt valueColumnIndex(final ColumnRef target) {
     int idx = 0;
     for (final Column column : value()) {
-      if (column.matches(target)) {
+      if (column.ref().equals(target)) {
         return OptionalInt.of(idx);
       }
       ++idx;
@@ -313,16 +312,11 @@ public final class LogicalSchema {
     value.stream()
         .filter(c -> !findNamespacedColumn(
             (withNamespace(Namespace.META).or(withNamespace(Namespace.KEY))
-                .and(thatLooselyMatches(c.column().ref())) // Todo(ac): exact?
+                .and(withRef(c.column().ref()))
             )).isPresent())
         .forEach(builder::add);
 
     return new LogicalSchema(builder.build());
-  }
-
-  // Todo(ac): drop
-  private static Predicate<NamespacedColumn> thatLooselyMatches(final ColumnRef ref) {
-    return c -> c.column().matches(ref);
   }
 
   private static Predicate<NamespacedColumn> withRef(final ColumnRef ref) {

--- a/ksql-common/src/test/java/io/confluent/ksql/schema/ksql/LogicalSchemaTest.java
+++ b/ksql-common/src/test/java/io/confluent/ksql/schema/ksql/LogicalSchemaTest.java
@@ -293,7 +293,27 @@ public class LogicalSchemaTest {
   }
 
   @Test
-  public void shouldGetColumnIndex() {
+  public void shouldFindExactColumnWithSource() {
+    // Given:
+    final LogicalSchema schema = LogicalSchema.builder()
+        .keyColumn(F0, SqlTypes.BIGINT)
+        .valueColumn(BOB, F0, SqlTypes.STRING)
+        .build();
+
+    // Then:
+    assertThat(
+        schema.findColumn(ColumnRef.withoutSource(F0)),
+        is(Optional.of(Column.of(ColumnRef.withoutSource(F0), SqlTypes.BIGINT)))
+    );
+
+    assertThat(
+        schema.findColumn(ColumnRef.of(BOB, F0)),
+        is(Optional.of(Column.of(ColumnRef.of(BOB, F0), SqlTypes.STRING)))
+    );
+  }
+
+  @Test
+  public void shouldGetValueColumnIndex() {
     assertThat(SOME_SCHEMA.valueColumnIndex(ColumnRef.withoutSource(F0)), is(OptionalInt.of(0)));
     assertThat(SOME_SCHEMA.valueColumnIndex(ColumnRef.withoutSource(F1)), is(OptionalInt.of(1)));
   }

--- a/ksql-common/src/test/java/io/confluent/ksql/schema/ksql/LogicalSchemaTest.java
+++ b/ksql-common/src/test/java/io/confluent/ksql/schema/ksql/LogicalSchemaTest.java
@@ -222,12 +222,12 @@ public class LogicalSchemaTest {
   @Test
   public void shouldGetColumnByAliasedName() {
     // When:
-    final Optional<Column> result = SOME_SCHEMA.findValueColumn(
-        ColumnRef.of(SourceName.of("SomeAlias"), F0)
+    final Optional<Column> result = ALIASED_SCHEMA.findValueColumn(
+        ColumnRef.of(BOB, F0)
     );
 
     // Then:
-    assertThat(result, is(Optional.of(Column.of(F0, SqlTypes.STRING))));
+    assertThat(result, is(Optional.of(Column.of(ColumnRef.of(BOB, F0), SqlTypes.STRING))));
   }
 
   @Test
@@ -243,7 +243,7 @@ public class LogicalSchemaTest {
   @Test
   public void shouldGetColumnByNameIfBothColumnAndNameAreAliased() {
     // When:
-    final Optional<Column> result = ALIASED_SCHEMA.findValueColumn(ColumnRef.of(SourceName.of("bob"), F0));
+    final Optional<Column> result = ALIASED_SCHEMA.findValueColumn(ColumnRef.of(BOB, F0));
 
     // Then:
     assertThat(result, is(Optional.of(Column.of(BOB, F0, SqlTypes.STRING))));
@@ -269,6 +269,26 @@ public class LogicalSchemaTest {
   public void shouldGetKeyColumnFromValueIfAdded() {
     assertThat(SOME_SCHEMA.withMetaAndKeyColsInValue().findValueColumn(ColumnRef.withoutSource(K0)),
         is(not(Optional.empty())));
+  }
+
+  @Test
+  public void shouldFindExactValueColumnWithSource() {
+    // Given:
+    final LogicalSchema schema = LogicalSchema.builder()
+        .valueColumn(F0, SqlTypes.BIGINT)
+        .valueColumn(BOB, F0, SqlTypes.STRING)
+        .build();
+
+    // Then:
+    assertThat(
+        schema.findValueColumn(ColumnRef.withoutSource(F0)),
+        is(Optional.of(Column.of(ColumnRef.withoutSource(F0), SqlTypes.BIGINT)))
+    );
+
+    assertThat(
+        schema.findValueColumn(ColumnRef.of(BOB, F0)),
+        is(Optional.of(Column.of(ColumnRef.of(BOB, F0), SqlTypes.STRING)))
+    );
   }
 
   @Test
@@ -330,7 +350,7 @@ public class LogicalSchemaTest {
 
   @Test
   public void shouldGetAliasedColumnIndex() {
-    assertThat(ALIASED_SCHEMA.valueColumnIndex(ColumnRef.of(SourceName.of("bob"), F1)), is(OptionalInt.of(1)));
+    assertThat(ALIASED_SCHEMA.valueColumnIndex(ColumnRef.of(BOB, F1)), is(OptionalInt.of(1)));
   }
 
   @Test
@@ -584,10 +604,10 @@ public class LogicalSchemaTest {
 
     // Then:
     assertThat(result.value(), hasSize(schema.value().size() + 2));
-    assertThat(result.value().get(0).source().get(), is(SourceName.of("bob")));
+    assertThat(result.value().get(0).source().get(), is(BOB));
     assertThat(result.value().get(0).name(), is(ROWTIME_NAME));
     assertThat(result.value().get(0).type(), is(SqlTypes.BIGINT));
-    assertThat(result.value().get(1).source().get(), is(SourceName.of("bob")));
+    assertThat(result.value().get(1).source().get(), is(BOB));
     assertThat(result.value().get(1).name(), is(ROWKEY_NAME));
     assertThat(result.value().get(1).type(), is(SqlTypes.STRING));
   }

--- a/ksql-common/src/test/java/io/confluent/ksql/schema/ksql/LogicalSchemaTest.java
+++ b/ksql-common/src/test/java/io/confluent/ksql/schema/ksql/LogicalSchemaTest.java
@@ -272,7 +272,7 @@ public class LogicalSchemaTest {
   }
 
   @Test
-  public void shouldFindExactValueColumnWithSource() {
+  public void shouldFindExactValueColumn() {
     // Given:
     final LogicalSchema schema = LogicalSchema.builder()
         .valueColumn(F0, SqlTypes.BIGINT)
@@ -313,7 +313,7 @@ public class LogicalSchemaTest {
   }
 
   @Test
-  public void shouldFindExactColumnWithSource() {
+  public void shouldFindExactColumn() {
     // Given:
     final LogicalSchema schema = LogicalSchema.builder()
         .keyColumn(F0, SqlTypes.BIGINT)
@@ -351,6 +351,26 @@ public class LogicalSchemaTest {
   @Test
   public void shouldGetAliasedColumnIndex() {
     assertThat(ALIASED_SCHEMA.valueColumnIndex(ColumnRef.of(BOB, F1)), is(OptionalInt.of(1)));
+  }
+
+  @Test
+  public void shouldFindExactColumnIndex() {
+    // Given:
+    final LogicalSchema schema = LogicalSchema.builder()
+        .valueColumn(F0, SqlTypes.BIGINT)
+        .valueColumn(BOB, F0, SqlTypes.STRING)
+        .build();
+
+    // Then:
+    assertThat(
+        schema.valueColumnIndex(ColumnRef.withoutSource(F0)),
+        is(OptionalInt.of(0))
+    );
+
+    assertThat(
+        schema.valueColumnIndex(ColumnRef.of(BOB, F0)),
+        is(OptionalInt.of(1))
+    );
   }
 
   @Test

--- a/ksql-engine/src/main/java/io/confluent/ksql/analyzer/Analyzer.java
+++ b/ksql-engine/src/main/java/io/confluent/ksql/analyzer/Analyzer.java
@@ -165,7 +165,7 @@ class Analyzer {
     private void analyzeNonStdOutSink(final Sink sink) {
       analysis.setProperties(sink.getProperties());
       sink.getPartitionBy()
-          .map(name -> ColumnRef.of(sink.getName(), name.name()))
+          .map(name -> ColumnRef.withoutSource(name.name()))
           .ifPresent(analysis::setPartitionBy);
 
       setSerdeOptions(sink);

--- a/ksql-engine/src/main/java/io/confluent/ksql/analyzer/Analyzer.java
+++ b/ksql-engine/src/main/java/io/confluent/ksql/analyzer/Analyzer.java
@@ -459,7 +459,7 @@ class Analyzer {
       final ColumnRef fieldName = joinFieldName.get();
 
       final Optional<ColumnRef> joinField =
-          getJoinFieldNameFromSource(fieldName, sourceAlias, sourceSchema);
+          getJoinFieldNameFromSource(fieldName.withoutSource(), sourceAlias, sourceSchema);
 
       return joinField
           .orElseThrow(() -> new KsqlException(

--- a/ksql-engine/src/main/java/io/confluent/ksql/analyzer/SourceSchemas.java
+++ b/ksql-engine/src/main/java/io/confluent/ksql/analyzer/SourceSchemas.java
@@ -72,7 +72,7 @@ final class SourceSchemas {
       return ImmutableSet.of();
     }
 
-    return sourceSchema.findColumn(target).isPresent()
+    return sourceSchema.findColumn(target.withoutSource()).isPresent()
         ? ImmutableSet.of(sourceName)
         : ImmutableSet.of();
   }

--- a/ksql-engine/src/main/java/io/confluent/ksql/ddl/commands/CreateSourceFactory.java
+++ b/ksql-engine/src/main/java/io/confluent/ksql/ddl/commands/CreateSourceFactory.java
@@ -152,12 +152,11 @@ public final class CreateSourceFactory {
       final LogicalSchema schema) {
     if (statement.getProperties().getKeyField().isPresent()) {
       final ColumnRef column = statement.getProperties().getKeyField().get();
-      schema.findValueColumn(column).orElseThrow(
-          () -> new KsqlException(
+      schema.findValueColumn(column)
+          .orElseThrow(() -> new KsqlException(
               "The KEY column set in the WITH clause does not exist in the schema: '"
                   + column.toString(FormatOptions.noEscape()) + "'"
-          )
-      );
+          ));
       return Optional.of(column.name());
     } else {
       return Optional.empty();

--- a/ksql-engine/src/main/java/io/confluent/ksql/ddl/commands/CreateSourceFactory.java
+++ b/ksql-engine/src/main/java/io/confluent/ksql/ddl/commands/CreateSourceFactory.java
@@ -151,14 +151,14 @@ public final class CreateSourceFactory {
       final CreateSource statement,
       final LogicalSchema schema) {
     if (statement.getProperties().getKeyField().isPresent()) {
-      final ColumnName columnName = statement.getProperties().getKeyField().get().name();
-      schema.findValueColumn(ColumnRef.withoutSource(columnName)).orElseThrow(
+      final ColumnRef column = statement.getProperties().getKeyField().get();
+      schema.findValueColumn(column).orElseThrow(
           () -> new KsqlException(
               "The KEY column set in the WITH clause does not exist in the schema: '"
-                  + columnName.toString(FormatOptions.noEscape()) + "'"
+                  + column.toString(FormatOptions.noEscape()) + "'"
           )
       );
-      return Optional.of(columnName);
+      return Optional.of(column.name());
     } else {
       return Optional.empty();
     }

--- a/ksql-engine/src/main/java/io/confluent/ksql/ddl/commands/DdlCommandExec.java
+++ b/ksql-engine/src/main/java/io/confluent/ksql/ddl/commands/DdlCommandExec.java
@@ -137,14 +137,14 @@ public class DdlCommandExec {
         return keyFieldOverride.get();
       }
       if (keyFieldName.isPresent()) {
-        final Column keyColumn = schema.findValueColumn(
-            // for DDL commands, the key name is never specified with a source
-            ColumnRef.withoutSource(keyFieldName.get()))
+        // for DDL commands, the key name is never specified with a source
+        final ColumnRef columnRef = ColumnRef.withoutSource(keyFieldName.get());
+        final Column keyColumn = schema.findValueColumn(columnRef)
             .orElseThrow(() -> new IllegalStateException(
                 "The KEY column set in the WITH clause does not exist in the schema: '"
                     + keyFieldName + "'"
             ));
-        return KeyField.of(ColumnRef.withoutSource(keyFieldName.get()), keyColumn);
+        return KeyField.of(columnRef, keyColumn);
       } else {
         return KeyField.none();
       }

--- a/ksql-engine/src/main/java/io/confluent/ksql/planner/plan/AggregateNode.java
+++ b/ksql-engine/src/main/java/io/confluent/ksql/planner/plan/AggregateNode.java
@@ -368,7 +368,7 @@ public class AggregateNode extends PlanNode {
         final ColumnReferenceExp nameRef = (ColumnReferenceExp) e;
         return new ColumnReferenceExp(
             nameRef.getLocation(),
-            ColumnRef.withoutSource(nameRef.getReference().name())
+            nameRef.getReference().withoutSource()
         );
       };
 

--- a/ksql-engine/src/main/java/io/confluent/ksql/planner/plan/DataSourceNode.java
+++ b/ksql-engine/src/main/java/io/confluent/ksql/planner/plan/DataSourceNode.java
@@ -180,12 +180,7 @@ public class DataSourceNode extends PlanNode {
     }
 
     return originalSchema.valueColumnIndex(timestampField)
-        .orElse(
-            originalSchema
-                .withAlias(alias)
-                .valueColumnIndex(timestampField)
-                .orElse(-1)
-        );
+        .orElseThrow(IllegalStateException::new);
   }
 
   private static Optional<Topology.AutoOffsetReset> getAutoOffsetReset(

--- a/ksql-engine/src/main/java/io/confluent/ksql/planner/plan/KsqlStructuredDataOutputNode.java
+++ b/ksql-engine/src/main/java/io/confluent/ksql/planner/plan/KsqlStructuredDataOutputNode.java
@@ -137,7 +137,6 @@ public class KsqlStructuredDataOutputNode extends OutputNode {
     );
   }
 
-  @SuppressWarnings("unchecked")
   private SchemaKStream<?> createOutputStream(
       final SchemaKStream schemaKStream,
       final QueryContext.Stacker contextStacker

--- a/ksql-engine/src/main/java/io/confluent/ksql/structured/SchemaKStream.java
+++ b/ksql-engine/src/main/java/io/confluent/ksql/structured/SchemaKStream.java
@@ -201,7 +201,6 @@ public class SchemaKStream<K> {
     this.functionRegistry = requireNonNull(functionRegistry, "functionRegistry");
   }
 
-  @SuppressWarnings("unchecked")
   public SchemaKTable<K> toTable(
       final KeyFormat keyFormat,
       final ValueFormat valueFormat,
@@ -235,7 +234,6 @@ public class SchemaKStream<K> {
     );
   }
 
-  @SuppressWarnings("unchecked")
   public SchemaKStream<K> into(
       final String kafkaTopicName,
       final LogicalSchema outputSchema,
@@ -750,7 +748,7 @@ public class SchemaKStream<K> {
     return functionRegistry;
   }
 
-  ColumnRef groupedKeyNameFor(final List<Expression> groupByExpressions) {
+  static ColumnRef groupedKeyNameFor(final List<Expression> groupByExpressions) {
     if (groupByExpressions.size() == 1 && groupByExpressions.get(0) instanceof ColumnReferenceExp) {
       return ((ColumnReferenceExp) groupByExpressions.get(0)).getReference();
     }

--- a/ksql-engine/src/main/java/io/confluent/ksql/structured/SchemaKTable.java
+++ b/ksql-engine/src/main/java/io/confluent/ksql/structured/SchemaKTable.java
@@ -156,7 +156,7 @@ public class SchemaKTable<K> extends SchemaKStream<K> {
   }
 
   @Override
-  public SchemaKGroupedStream groupBy(
+  public SchemaKGroupedTable groupBy(
       final ValueFormat valueFormat,
       final List<Expression> groupByExpressions,
       final QueryContext.Stacker contextStacker

--- a/ksql-engine/src/main/java/io/confluent/ksql/structured/SchemaKTable.java
+++ b/ksql-engine/src/main/java/io/confluent/ksql/structured/SchemaKTable.java
@@ -75,7 +75,6 @@ public class SchemaKTable<K> extends SchemaKStream<K> {
   }
 
   @Override
-  @SuppressWarnings("unchecked")
   public SchemaKTable<K> into(
       final String kafkaTopicName,
       final LogicalSchema outputSchema,
@@ -101,7 +100,6 @@ public class SchemaKTable<K> extends SchemaKStream<K> {
     );
   }
 
-  @SuppressWarnings("unchecked")
   @Override
   public SchemaKTable<K> filter(
       final Expression filterExpression,
@@ -158,7 +156,6 @@ public class SchemaKTable<K> extends SchemaKStream<K> {
   }
 
   @Override
-  @SuppressWarnings("unchecked")
   public SchemaKGroupedStream groupBy(
       final ValueFormat valueFormat,
       final List<Expression> groupByExpressions,
@@ -170,7 +167,7 @@ public class SchemaKTable<K> extends SchemaKStream<K> {
     final ColumnRef aggregateKeyName = groupedKeyNameFor(groupByExpressions);
     final LegacyField legacyKeyField = LegacyField.notInSchema(aggregateKeyName, SqlTypes.STRING);
     final Optional<ColumnRef> newKeyField = getSchema()
-        .findValueColumn(ColumnRef.withoutSource(aggregateKeyName.name()))
+        .findValueColumn(aggregateKeyName.withoutSource())
         .map(Column::ref);
 
     final TableGroupBy<K> step = ExecutionStepFactory.tableGroupBy(

--- a/ksql-engine/src/test/java/io/confluent/ksql/planner/plan/DataSourceNodeTest.java
+++ b/ksql-engine/src/test/java/io/confluent/ksql/planner/plan/DataSourceNodeTest.java
@@ -323,7 +323,8 @@ public class DataSourceNodeTest {
   public void shouldBuildSourceStreamWithCorrectTimestampIndexForQualifiedFieldName() {
     // Given:
     reset(timestampExtractionPolicy);
-    when(timestampExtractionPolicy.timestampField()).thenReturn(ColumnRef.of(SourceName.of("name"), ColumnName.of("field2")));
+    when(timestampExtractionPolicy.timestampField())
+        .thenReturn(ColumnRef.withoutSource(ColumnName.of("field2")));
     final DataSourceNode node = buildNodeWithMockSource();
 
     // When:

--- a/ksql-functional-tests/src/test/resources/query-validation-tests/joins.json
+++ b/ksql-functional-tests/src/test/resources/query-validation-tests/joins.json
@@ -2179,6 +2179,38 @@
         "type": "io.confluent.ksql.util.KsqlStatementException",
         "message": "Invalid join criteria (T.ID = TT.IID). Column TT.IID does not exist."
       }
+    },
+    {
+      "name": "unqualified join criteria",
+      "statements": [
+        "CREATE STREAM TEST (LEFT_ID bigint, NAME varchar) WITH (kafka_topic='left_topic', value_format='JSON', key='LEFT_ID');",
+        "CREATE STREAM TEST_STREAM (RIGHT_ID bigint, F1 varchar) WITH (kafka_topic='right_topic', value_format='JSON', key='RIGHT_ID');",
+        "CREATE STREAM LEFT_OUTER_JOIN as SELECT t.left_id, name, f1 FROM test t left join TEST_STREAM tt WITHIN 11 seconds ON left_id = right_id;"
+      ],
+      "inputs": [
+        {"topic": "left_topic", "key": 0, "value": {"LEFT_ID": 0, "NAME": "zero"}, "timestamp": 0},
+        {"topic": "right_topic", "key": 0, "value": {"RIGHT_ID": 0, "F1": "blah"}, "timestamp": 10000},
+        {"topic": "left_topic", "key": 10, "value": {"LEFT_ID": 10, "NAME": "100"}, "timestamp": 11000},
+        {"topic": "left_topic", "key": 0, "value": {"LEFT_ID": 0, "NAME": "foo"}, "timestamp": 13000},
+        {"topic": "right_topic", "key": 0, "value": {"RIGHT_ID": 0, "F1": "a"}, "timestamp": 15000},
+        {"topic": "right_topic", "key": 100, "value": {"RIGHT_ID": 100, "F1": "newblah"}, "timestamp": 16000},
+        {"topic": "left_topic", "key": 90, "value": {"LEFT_ID": 90, "NAME": "ninety"}, "timestamp": 17000},
+        {"topic": "left_topic", "key": 0, "value": {"LEFT_ID": 0, "NAME": "bar"}, "timestamp": 30000}
+      ],
+      "outputs": [
+        {"topic": "LEFT_OUTER_JOIN", "key": 0, "value": {"LEFT_ID": 0, "NAME": "zero", "F1": null}, "timestamp": 0},
+        {"topic": "LEFT_OUTER_JOIN", "key": 0, "value": {"LEFT_ID": 0, "NAME": "zero", "F1": "blah"}, "timestamp": 10000},
+        {"topic": "LEFT_OUTER_JOIN", "key": 10, "value": {"LEFT_ID": 10, "NAME": "100", "F1": null}, "timestamp": 11000},
+        {"topic": "LEFT_OUTER_JOIN", "key": 0, "value": {"LEFT_ID": 0, "NAME": "foo", "F1": "blah"}, "timestamp": 13000},
+        {"topic": "LEFT_OUTER_JOIN", "key": 0, "value": {"LEFT_ID": 0, "NAME": "foo", "F1": "a"}, "timestamp": 15000},
+        {"topic": "LEFT_OUTER_JOIN", "key": 90, "value": {"LEFT_ID": 90, "NAME": "ninety", "F1": null}, "timestamp": 17000},
+        {"topic": "LEFT_OUTER_JOIN", "key": 0, "value": {"LEFT_ID": 0, "NAME": "bar", "F1": null}, "timestamp": 30000}
+      ],
+      "post": {
+        "sources": [
+          {"name": "LEFT_OUTER_JOIN", "type": "stream", "keyField": {"name": "LEFT_ID"}}
+        ]
+      }
     }
   ]
 }

--- a/ksql-rest-app/src/main/java/io/confluent/ksql/rest/server/execution/StaticQueryExecutor.java
+++ b/ksql-rest-app/src/main/java/io/confluent/ksql/rest/server/execution/StaticQueryExecutor.java
@@ -596,7 +596,7 @@ public final class StaticQueryExecutor {
         .noImplicitColumns();
 
     final ExpressionTypeManager expressionTypeManager = new ExpressionTypeManager(
-        input.schema,
+        input.schema.withAlias(analysis.getFromDataSources().get(0).getAlias()),
         executionContext.getMetaStore()
     );
 


### PR DESCRIPTION
### Description 

`LogicalSchema` has a couple of methods that find columns:

* `findColumn(ColumnRef)` finds a column in the schema that 'matches' the supplied `ColumnRef`
* `finaValueColumn(ColumnRef)` as above, but only searching value columns
* `valueColumnIndex(ColumnRef)` returns the index of the column in the value columns that 'matches' the supplied `ColumnRef`.

The reason 'matches' in the list above is in quotes is because it doesn't do what you might think. The matching logic only takes the `SourceName` of a column into account if both the schema column and the supplied `ColumnRef` have a source name.  If either does not have a source, then the source is ignored!

For example, the test below would fail on the master branch without this PR:

```java
  @Test
  public void shouldFindExactColumn() {
    // Given:
    final LogicalSchema schema = LogicalSchema.builder()
        .keyColumn(F0, SqlTypes.BIGINT)
        .valueColumn(BOB, F0, SqlTypes.STRING)
        .build();

    // When:
    final Column result = schema.findColumn(ColumnRef.of(BOB, F0))

    // Then:
    // This assert will fail because the source KEY column does not have a source, so the source in the column ref passed to `findColumn` is ignored!!! 
    // `result` is actually set to the key column, not the value column
    assertThat(
        result,
        is(Optional.of(Column.of(ColumnRef.of(BOB, F0), SqlTypes.STRING)))
    );
  }
```

This PR addresses this by making the above three methods do _exact_ matches, i.e. a column is only matched if the column name _AND_ the source match. 

### Testing done 

Suitable tests added + `mvn test`.

### Reviewer checklist
- [ ] Ensure docs are updated if necessary. (eg. if a user visible feature is being added or changed).
- [ ] Ensure relevant issues are linked (description should include text like "Fixes #<issue number>")

