### PR TITLE
test: correct docs and extend QTT to allow it to run only against latest

### DIFF
--- a/ksql-functional-tests/README.md
+++ b/ksql-functional-tests/README.md
@@ -37,18 +37,21 @@ The above commands can execute only a single test (sum.json) or multiple tests (
 
 To run this test against specific previously released versions, set the system property
 "topology.versions" to the desired version(s). The property value should be a comma-delimited list of
-version number(s) found under the `src/test/resources/expected_topology` directory, for example, `"5.0,5.1"`.
+version number(s) found under the `src/test/resources/expected_topology` directory, 
+for example, `"5_0,5_3_0"`, or `latest-only` if only the current version is required.
 
 The are two places system properties may be set:
   * Within Intellij
     1. Click Run/Edit configurations
     1. Select the QueryTranslationTest
     1. Enter `-Dtopology.versions=X` in the "VM options:" form entry
-       where X is a comma-delimited list of the desired previously released version number(s).
+       where X is a comma-delimited list of the desired previously released version number(s),
+       or `latest-only` if only the current version is required.
   * From the command line
     1. run `mvn clean package -DskipTests=true` from the base of the KSQL project
     1. Then run `mvn test -Dtopology.versions=X -Dtest=QueryTranslationTest -pl ksql-functional-tests`.
-       Again X is a list of the versions you want to run the tests against.
+       Again X is a list of the versions you want to run the tests against, 
+       or `latest-only` if only the current version is required.
 
   Note that for both options above the version(s) must exist
   under the `src/test/resources/expected_topology` directory.

--- a/ksql-functional-tests/src/test/java/io/confluent/ksql/test/QueryTranslationTest.java
+++ b/ksql-functional-tests/src/test/java/io/confluent/ksql/test/QueryTranslationTest.java
@@ -50,7 +50,7 @@ public class QueryTranslationTest {
 
   private static final Path QUERY_VALIDATION_TEST_DIR = Paths.get("query-validation-tests");
   private static final String TOPOLOGY_CHECKS_DIR = "expected_topology/";
-  private static Set<String> EXCLUDED_TESTS = ImmutableSet
+  private static final Set<String> EXCLUDED_TESTS = ImmutableSet
       .of("query-validation-tests/scratch.json");
 
   @Parameterized.Parameters(name = "{0}")

--- a/ksql-functional-tests/src/test/java/io/confluent/ksql/test/loader/ExpectedTopologiesTestLoader.java
+++ b/ksql-functional-tests/src/test/java/io/confluent/ksql/test/loader/ExpectedTopologiesTestLoader.java
@@ -57,6 +57,7 @@ public class ExpectedTopologiesTestLoader<T extends VersionedTest> implements Te
   private static final Pattern TOPOLOGY_VERSION_PATTERN = Pattern.compile("(\\d+)_(\\d+)(_\\d+)?");
   private static final String TOPOLOGY_VERSIONS_DELIMITER = ",";
   private static final String TOPOLOGY_VERSIONS_PROP = "topology.versions";
+  private static final String TOPOLOGY_VERSION_LATEST = "latest-only";
 
   private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper();
   private static final KsqlVersion CURRENT_VERSION = KsqlVersion.current();
@@ -126,7 +127,9 @@ public class ExpectedTopologiesTestLoader<T extends VersionedTest> implements Te
 
     final Stream<String> versionStrings = versionProp.isEmpty()
         ? findExpectedTopologyDirectories().stream()
-        : Arrays.stream(versionProp.split(TOPOLOGY_VERSIONS_DELIMITER));
+        : versionProp.equalsIgnoreCase(TOPOLOGY_VERSION_LATEST)
+            ? Stream.of()
+            : Arrays.stream(versionProp.split(TOPOLOGY_VERSIONS_DELIMITER));
 
     return versionStrings
         .map(this::getVersion)


### PR DESCRIPTION
### Description 

The docs around setting which topology versions to run when running the QTT test were wrong. The syntax is `-Dtopology.versions="5_0,5_3_0"`, not `-Dtopology.versions="5.0,5.3.0"`, i.e. the supplied versions must match the name of the folders under the `expected-topologies` directory.

Plus, there was no way that I could find to just run the latest version of the tests, so I've added the ability to set `-Dtopology.versions=latest-only`.

### Testing done 

Test only change.

### Reviewer checklist
- [ ] Ensure docs are updated if necessary. (eg. if a user visible feature is being added or changed).
- [ ] Ensure relevant issues are linked (description should include text like "Fixes #<issue number>")

