### PR TITLE
chore: fix incompatible serialization of KsqlErrorMessage

### DIFF
--- a/ksql-rest-model/src/main/java/io/confluent/ksql/rest/entity/KsqlErrorMessage.java
+++ b/ksql-rest-model/src/main/java/io/confluent/ksql/rest/entity/KsqlErrorMessage.java
@@ -66,6 +66,7 @@ public class KsqlErrorMessage {
         .collect(Collectors.toList());
   }
 
+  @JsonProperty("error_code")
   public int getErrorCode() {
     return errorCode;
   }

--- a/ksql-rest-model/src/test/java/io/confluent/ksql/rest/entity/KsqlErrorMessageTest.java
+++ b/ksql-rest-model/src/test/java/io/confluent/ksql/rest/entity/KsqlErrorMessageTest.java
@@ -1,0 +1,72 @@
+/*
+ * Copyright 2019 Confluent Inc.
+ *
+ * Licensed under the Confluent Community License (the "License"); you may not use
+ * this file except in compliance with the License.  You may obtain a copy of the
+ * License at
+ *
+ * http://www.confluent.io/confluent-community-license
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package io.confluent.ksql.rest.entity;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.confluent.ksql.json.JsonMapper;
+import java.io.IOException;
+import java.util.Collections;
+import org.junit.Test;
+
+public class KsqlErrorMessageTest {
+
+  private static final ObjectMapper OBJECT_MAPPER = JsonMapper.INSTANCE.mapper;
+
+  private static final KsqlErrorMessage MESSAGE =
+      new KsqlErrorMessage(40301, "foo", Collections.emptyList());
+  private static final String SERIALIZED_MESSAGE =
+      "{\"@type\":\"generic_error\",\"error_code\":40301,\"message\":\"foo\",\"stackTrace\":[]}";
+
+  @Test
+  public void shouldSerializeToJson() {
+    // When:
+    final String jsonMessage = serialize(MESSAGE);
+
+    // Then:
+    assertThat(jsonMessage, is(SERIALIZED_MESSAGE));
+  }
+
+  @Test
+  public void shouldDeserializeFromJson() {
+    // When:
+    final KsqlErrorMessage message = deserialize(SERIALIZED_MESSAGE);
+
+    // Then:
+    assertThat(message, is(MESSAGE));
+  }
+
+  private static String serialize(final KsqlErrorMessage errorMessage) {
+    try {
+      return OBJECT_MAPPER.writeValueAsString(errorMessage);
+    } catch (IOException e) {
+      throw new RuntimeException("test invalid", e);
+    }
+  }
+
+  private static KsqlErrorMessage deserialize(final String json) {
+    try {
+      return OBJECT_MAPPER.readValue(json, KsqlErrorMessage.class);
+    } catch (IOException e) {
+      if (e.getCause() instanceof RuntimeException) {
+        throw (RuntimeException) e.getCause();
+      }
+      throw new RuntimeException(e);
+    }
+  }
+}


### PR DESCRIPTION
### Description 

As part of the refactor of `KsqlErrorMessage` to no longer inherit from [rest-util's `ErrorMessage`](https://github.com/confluentinc/rest-utils/blob/f4b871c578777cacdb6487445a66a745f0077308/core/src/main/java/io/confluent/rest/entities/ErrorMessage.java), the JSON serialization was inadvertently changed in a backwards-incompatible way: the field that was previously serialized as `error_code` is now being serialized as `errorCode`. This PR reverts back to using `error_code` to avoid the backwards incompatibility.

### Testing done 

Added unit tests.

### Reviewer checklist
- [ ] Ensure docs are updated if necessary. (eg. if a user visible feature is being added or changed).
- [ ] Ensure relevant issues are linked (description should include text like "Fixes #<issue number>")

