### PR TITLE
test: fix flaky CliTest

### DIFF
--- a/ksql-cli/src/test/java/io/confluent/ksql/cli/CliTest.java
+++ b/ksql-cli/src/test/java/io/confluent/ksql/cli/CliTest.java
@@ -627,10 +627,14 @@ public class CliTest {
     );
 
     // When:
-    run("SELECT * FROM Y WHERE ROWKEY='ITEM_1';", localCli);
+    final Supplier<String> runner = () -> {
+      // It's possible that the state store is not warm on the first invocation, hence the retry
+      run("SELECT * FROM Y WHERE ROWKEY='ITEM_1';", localCli);
+      return terminal.getOutputString();
+    };
 
-    assertThat(terminal.getOutputString(), containsString("ROWKEY STRING KEY"));
-    assertThat(terminal.getOutputString(), containsString("COUNT BIGINT"));
+    assertThatEventually(runner, containsString("ROWKEY STRING KEY"));
+    assertThatEventually(runner, containsString("COUNT BIGINT"));
   }
 
   @Test


### PR DESCRIPTION
### Description 

The test was failing because the materialized state store was not warm when the pull query was issued.

Example failed build: https://jenkins.confluent.io/job/confluentinc/job/ksql/job/5.4.x/7/

### Testing done 

Test only change.

### Reviewer checklist
- [ ] Ensure docs are updated if necessary. (eg. if a user visible feature is being added or changed).
- [ ] Ensure relevant issues are linked (description should include text like "Fixes #<issue number>")

