### PR TITLE
feat: Config file for the no-response bot 

### DIFF
--- a/.github/no-response.yml
+++ b/.github/no-response.yml
@@ -1,0 +1,13 @@
+# Configuration for probot-no-response - https://github.com/probot/no-response
+
+# Number of days of inactivity before an Issue is closed for lack of response
+daysUntilClose: 30
+# Label requiring a response
+responseRequiredLabel: more-info-needed
+# Comment to post when closing an Issue for lack of response. Set to `false` to disable
+closeComment: >
+  Dear KSQL community member. This issue has been automatically closed because there has been no response
+  to our request for more information for 30 days. With only the
+  information that is currently in the issue, we don't have enough information
+  to take action. Please reach out if you have or find the answers we need so
+  that we can investigate further.


### PR DESCRIPTION
### Description 

This adds the config file for the no-response bot which automatically closes issues. https://github.com/probot/no-response

Issues that are labelled with 'more-info-needed' and which haven't had a response for 30 days will be closed.

### Testing done 

Tested the bot on a personal repo. Seemed to work ok. 

### Reviewer checklist
- [ ] Ensure docs are updated if necessary. (eg. if a user visible feature is being added or changed).
- [ ] Ensure relevant issues are linked (description should include text like "Fixes #<issue number>")

