### PR TITLE
refactor: remove final uses of fuzzy `Column.matches`

### DIFF
--- a/ksql-common/src/main/java/io/confluent/ksql/schema/ksql/Column.java
+++ b/ksql-common/src/main/java/io/confluent/ksql/schema/ksql/Column.java
@@ -116,21 +116,6 @@ public final class Column {
     return new Column(ref.withSource(source), type);
   }
 
-  /**
-   * A column {@code matches} a column reference if the names match
-   * and either the reference does not specify a source, or the specified
-   * source matches.
-   *
-   * @param ref the reference to check
-   * @return whether or not {@code ref} matches this instance
-   */
-  public boolean matches(final ColumnRef ref) {
-    return ref.name().equals(this.ref.name())
-        && (!source().isPresent()
-        || !ref.source().isPresent()
-        || ref.source().equals(this.ref.source()));
-  }
-
   @Override
   public boolean equals(final Object o) {
     if (this == o) {

--- a/ksql-engine/src/main/java/io/confluent/ksql/planner/plan/JoinNode.java
+++ b/ksql-engine/src/main/java/io/confluent/ksql/planner/plan/JoinNode.java
@@ -254,7 +254,7 @@ public class JoinNode extends PlanNode {
       );
 
       final boolean namesMatch = keyColumn
-          .map(field -> field.matches(joinFieldName))
+          .map(field -> field.ref().equals(joinFieldName))
           .orElse(false);
 
       if (namesMatch || joinFieldName.equals(rowKey)) {

--- a/ksql-engine/src/main/java/io/confluent/ksql/structured/SchemaKStream.java
+++ b/ksql-engine/src/main/java/io/confluent/ksql/structured/SchemaKStream.java
@@ -319,7 +319,7 @@ public class SchemaKStream<K> {
           final ColumnReferenceExp nameRef
               = (ColumnReferenceExp) toExpression;
 
-          if (keyColumn.matches(nameRef.getReference())) {
+          if (keyColumn.ref().equals(nameRef.getReference())) {
             found = Optional.of(Column.of(toName, keyColumn.type()));
             break;
           }
@@ -499,7 +499,7 @@ public class SchemaKStream<K> {
         : KeyField.of(columnRef);
 
     final boolean namesMatch = existingKey
-        .map(kf -> kf.matches(proposedKey.ref()))
+        .map(kf -> kf.ref().equals(proposedKey.ref()))
         .orElse(false);
 
     if (namesMatch || isRowKey(proposedKey.ref())) {


### PR DESCRIPTION
### Description 

Following on from #3748, with legacy key fields now gone, (#3764), we can now drop the final use of `Column.matches`.


### Testing done 

usual

### Reviewer checklist
- [ ] Ensure docs are updated if necessary. (eg. if a user visible feature is being added or changed).
- [ ] Ensure relevant issues are linked (description should include text like "Fixes #<issue number>")

