### PR TITLE
feat: add flag to disable pull queries (MINOR)

### DIFF
--- a/ksql-common/src/main/java/io/confluent/ksql/config/ImmutableProperties.java
+++ b/ksql-common/src/main/java/io/confluent/ksql/config/ImmutableProperties.java
@@ -29,6 +29,7 @@ public final class ImmutableProperties {
       .add(StreamsConfig.BOOTSTRAP_SERVERS_CONFIG)
       .add(KsqlConfig.KSQL_EXT_DIR)
       .add(KsqlConfig.KSQL_ACTIVE_PERSISTENT_QUERY_LIMIT_CONFIG)
+      .add(KsqlConfig.KSQL_PULL_QUERIES_ENABLE_CONFIG)
       .addAll(KsqlConfig.SSL_CONFIG_NAMES)
       .build();
 

--- a/ksql-common/src/main/java/io/confluent/ksql/util/KsqlConfig.java
+++ b/ksql-common/src/main/java/io/confluent/ksql/util/KsqlConfig.java
@@ -196,6 +196,11 @@ public class KsqlConfig extends AbstractConfig {
           + "whether the Kafka cluster supports the required API, and enables the validator if "
           + "it does.";
 
+  public static final String KSQL_PULL_QUERIES_ENABLE_CONFIG = "ksql.pull.queries.enable";
+  public static final String KSQL_PULL_QUERIES_ENABLE_DOC =
+      "Config to enable or disable transient pull queries on a specific KSQL server.";
+  public static final boolean KSQL_PULL_QUERIES_ENABLE_DEFAULT = true;
+
   public static final Collection<CompatibilityBreakingConfigDef> COMPATIBLY_BREAKING_CONFIG_DEFS
       = ImmutableList.of(
           new CompatibilityBreakingConfigDef(
@@ -560,6 +565,12 @@ public class KsqlConfig extends AbstractConfig {
             "",
             Importance.LOW,
             METRIC_REPORTER_CLASSES_DOC
+        ).define(
+            KSQL_PULL_QUERIES_ENABLE_CONFIG,
+            Type.BOOLEAN,
+            KSQL_PULL_QUERIES_ENABLE_DEFAULT,
+            Importance.LOW,
+            KSQL_PULL_QUERIES_ENABLE_DOC
         )
         .withClientSslSupport();
     for (final CompatibilityBreakingConfigDef compatibilityBreakingConfigDef

--- a/ksql-rest-app/src/main/java/io/confluent/ksql/rest/server/execution/StaticQueryExecutor.java
+++ b/ksql-rest-app/src/main/java/io/confluent/ksql/rest/server/execution/StaticQueryExecutor.java
@@ -124,7 +124,8 @@ public final class StaticQueryExecutor {
           Errors.badStatement(
               "Pull queries are disabled on this KSQL server - please set "
                   + KsqlConfig.KSQL_PULL_QUERIES_ENABLE_CONFIG + "=true to enable this feature. "
-                  + "If you intended to issue a push query, resubmit the query with EMIT CHANGES.",
+                  + "If you intended to issue a push query, resubmit the query with the "
+                  + "EMIT CHANGES clause.",
               statement.getStatementText()));
     }
 

--- a/ksql-rest-app/src/main/java/io/confluent/ksql/rest/server/execution/StaticQueryExecutor.java
+++ b/ksql-rest-app/src/main/java/io/confluent/ksql/rest/server/execution/StaticQueryExecutor.java
@@ -119,6 +119,15 @@ public final class StaticQueryExecutor {
   ) {
     final Query queryStmt = statement.getStatement();
 
+    if (!statement.getConfig().getBoolean(KsqlConfig.KSQL_PULL_QUERIES_ENABLE_CONFIG)) {
+      throw new KsqlRestException(
+          Errors.badStatement(
+              "Pull queries are disabled on this KSQL server - please set "
+                  + KsqlConfig.KSQL_PULL_QUERIES_ENABLE_CONFIG + "=true to enable this feature. "
+                  + "If you intended to issue a push query, resubmit the query with EMIT CHANGES.",
+              statement.getStatementText()));
+    }
+
     if (!queryStmt.isStatic()) {
       throw new KsqlRestException(Errors.queryEndpoint(statement.getStatementText()));
     }

--- a/ksql-rest-app/src/test/java/io/confluent/ksql/rest/server/TemporaryEngine.java
+++ b/ksql-rest-app/src/test/java/io/confluent/ksql/rest/server/TemporaryEngine.java
@@ -56,6 +56,7 @@ import io.confluent.rest.RestConfig;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
 import org.junit.rules.ExternalResource;
 
@@ -75,6 +76,7 @@ public class TemporaryEngine extends ExternalResource {
   private KsqlConfig ksqlConfig;
   private KsqlEngine engine;
   private ServiceContext serviceContext;
+  private Map<String, Object> configs = ImmutableMap.of();
 
   @Override
   protected void before() {
@@ -86,10 +88,11 @@ public class TemporaryEngine extends ExternalResource {
 
     ksqlConfig = KsqlConfigTestUtil.create(
         "localhost:9092",
-        ImmutableMap.of(
-            "ksql.command.topic.suffix", "commands",
-            RestConfig.LISTENERS_CONFIG, "http://localhost:8088"
-        )
+        ImmutableMap.<String, Object>builder()
+            .putAll(configs)
+            .put("ksql.command.topic.suffix", "commands")
+            .put( RestConfig.LISTENERS_CONFIG, "http://localhost:8088" )
+            .build()
     );
 
     final SqlTypeParser typeParser = SqlTypeParser.create(TypeRegistry.EMPTY);
@@ -98,6 +101,11 @@ public class TemporaryEngine extends ExternalResource {
     );
     udtfLoader.loadUdtfFromClass(TestUdtf1.class, "whatever");
     udtfLoader.loadUdtfFromClass(TestUdtf2.class, "whatever");
+  }
+
+  public TemporaryEngine withConfigs(final Map<String, Object> configs) {
+    this.configs = configs;
+    return this;
   }
 
   @Override

--- a/ksql-rest-app/src/test/java/io/confluent/ksql/rest/server/execution/StaticQueryExecutorTest.java
+++ b/ksql-rest-app/src/test/java/io/confluent/ksql/rest/server/execution/StaticQueryExecutorTest.java
@@ -37,7 +37,6 @@ import org.junit.Test;
 import org.junit.experimental.runners.Enclosed;
 import org.junit.rules.ExpectedException;
 import org.junit.runner.RunWith;
-import org.mockito.junit.MockitoJUnitRunner;
 
 @RunWith(Enclosed.class)
 public class StaticQueryExecutorTest {


### PR DESCRIPTION
### Description 

Adds a flag to make sure that allows servers to disable ad-hoc pull queries.

### Testing done 

- Unit testing
- E2E testing:
```
ksql> SET 'ksql.pull.queries.enable'='true';
Cannot override property 'ksql.pull.queries.enable'
ksql> SELECT * FROM ALERTS;
Pull queries are disabled on this KSQL server - please enable ksql.pull.queries.enable
```

### Reviewer checklist
- [ ] Ensure docs are updated if necessary. (eg. if a user visible feature is being added or changed).
- [ ] Ensure relevant issues are linked (description should include text like "Fixes #<issue number>")

