### PR TITLE
chore: remove deprecated Application methods

### DIFF
--- a/ksql-rest-app/src/main/java/io/confluent/ksql/rest/server/ConnectExecutable.java
+++ b/ksql-rest-app/src/main/java/io/confluent/ksql/rest/server/ConnectExecutable.java
@@ -51,7 +51,7 @@ public final class ConnectExecutable implements Executable {
   }
 
   @Override
-  public void start() {
+  public void startAsync() {
     try {
       connect = connectDistributed.startConnect(workerProps);
     } catch (final ConnectException e) {
@@ -64,14 +64,14 @@ public final class ConnectExecutable implements Executable {
   }
 
   @Override
-  public void stop() {
+  public void triggerShutdown() {
     if (connect != null) {
       connect.stop();
     }
   }
 
   @Override
-  public void join() {
+  public void awaitTerminated() {
     if (connect != null) {
       connect.awaitStop();
     }

--- a/ksql-rest-app/src/main/java/io/confluent/ksql/rest/server/Executable.java
+++ b/ksql-rest-app/src/main/java/io/confluent/ksql/rest/server/Executable.java
@@ -15,10 +15,27 @@
 
 package io.confluent.ksql.rest.server;
 
+/**
+ * An {@code Executable} is a lifecycle interface that does not conflict with
+ * {@link org.eclipse.jetty.util.component.LifeCycle} so that it can be used
+ * to specify additional operations during start/stop/join.
+ */
 public interface Executable {
-  void start() throws Exception;
 
-  void stop() throws Exception;
+  /**
+   * Starts the executable asynchronously.
+   */
+  default void startAsync() throws Exception {}
 
-  void join() throws InterruptedException;
+  /**
+   * Triggers a shutdown asynchronously, in order to ensure that the shutdown
+   * has finished use {@link #awaitTerminated()}
+   */
+  default void triggerShutdown() throws Exception {}
+
+  /**
+   * Awaits the {@link #triggerShutdown()} to finish. This is a blocking
+   * operation.
+   */
+  default void awaitTerminated() throws InterruptedException {}
 }

--- a/ksql-rest-app/src/main/java/io/confluent/ksql/rest/server/ExecutableApplication.java
+++ b/ksql-rest-app/src/main/java/io/confluent/ksql/rest/server/ExecutableApplication.java
@@ -1,0 +1,36 @@
+/*
+ * Copyright 2019 Confluent Inc.
+ *
+ * Licensed under the Confluent Community License (the "License"; you may not use
+ * this file except in compliance with the License. You may obtain a copy of the
+ * License at
+ *
+ * http://www.confluent.io/confluent-community-license
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package io.confluent.ksql.rest.server;
+
+import io.confluent.rest.Application;
+import io.confluent.rest.RestConfig;
+
+/**
+ * A strongly typed class indicating that the implementing class is an {@code Application}
+ * that implements {@code Executable}.
+ */
+public abstract class ExecutableApplication<T extends RestConfig>
+    extends Application<T>
+    implements Executable {
+
+  public ExecutableApplication(final T config) {
+    super(config);
+  }
+
+  public ExecutableApplication(final T config, final String path) {
+    super(config, path);
+  }
+}

--- a/ksql-rest-app/src/main/java/io/confluent/ksql/rest/server/ExecutableServer.java
+++ b/ksql-rest-app/src/main/java/io/confluent/ksql/rest/server/ExecutableServer.java
@@ -1,0 +1,65 @@
+/*
+ * Copyright 2019 Confluent Inc.
+ *
+ * Licensed under the Confluent Community License (the "License"; you may not use
+ * this file except in compliance with the License. You may obtain a copy of the
+ * License at
+ *
+ * http://www.confluent.io/confluent-community-license
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package io.confluent.ksql.rest.server;
+
+import io.confluent.rest.ApplicationServer;
+import io.confluent.rest.RestConfig;
+import java.util.List;
+
+/**
+ * An {@code Executable} that wraps a {@link ApplicationServer} and delegates
+ * the lifecycle methods.
+ *
+ * @param <T> the type of the rest server config
+ */
+public class ExecutableServer<T extends RestConfig> implements Executable {
+
+  private final ApplicationServer<T> server;
+  private final List<ExecutableApplication<T>> apps;
+
+  public ExecutableServer(ApplicationServer<T> server, List<ExecutableApplication<T>> apps) {
+    this.server = server;
+    this.apps = apps;
+  }
+
+  @Override
+  public void startAsync() throws Exception {
+    apps.forEach(server::registerApplication);
+    server.start();
+
+    for (ExecutableApplication<T> app : apps) {
+      app.startAsync();
+    }
+  }
+
+  @Override
+  public void triggerShutdown() throws Exception {
+    for (final ExecutableApplication<T> app : apps) {
+      app.triggerShutdown();
+    }
+
+    server.stop();
+  }
+
+  @Override
+  public void awaitTerminated() throws InterruptedException {
+    for (final ExecutableApplication<T> app : apps) {
+      app.awaitTerminated();
+    }
+
+    server.join();
+  }
+}

--- a/ksql-rest-app/src/main/java/io/confluent/ksql/rest/server/KsqlRestApplication.java
+++ b/ksql-rest-app/src/main/java/io/confluent/ksql/rest/server/KsqlRestApplication.java
@@ -78,7 +78,6 @@ import io.confluent.ksql.util.Version;
 import io.confluent.ksql.util.WelcomeMsgUtils;
 import io.confluent.ksql.version.metrics.VersionCheckerAgent;
 import io.confluent.ksql.version.metrics.collector.KsqlModuleType;
-import io.confluent.rest.Application;
 import io.confluent.rest.RestConfig;
 import io.confluent.rest.validation.JacksonMessageBodyProvider;
 import java.io.Console;
@@ -119,7 +118,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 // CHECKSTYLE_RULES.OFF: ClassDataAbstractionCoupling
-public final class KsqlRestApplication extends Application<KsqlRestConfig> implements Executable {
+public final class KsqlRestApplication extends ExecutableApplication<KsqlRestConfig> {
   // CHECKSTYLE_RULES.ON: ClassDataAbstractionCoupling
 
   private static final Logger log = LoggerFactory.getLogger(KsqlRestApplication.class);
@@ -208,8 +207,7 @@ public final class KsqlRestApplication extends Application<KsqlRestConfig> imple
   }
 
   @Override
-  public void start() throws Exception {
-    super.start();
+  public void startAsync() throws Exception {
     log.info("KSQL RESTful API listening on {}", StringUtils.join(getListeners(), ", "));
     final KsqlConfig ksqlConfigWithPort = buildConfigWithPort();
     configurables.forEach(c -> c.configure(ksqlConfigWithPort));
@@ -287,7 +285,7 @@ public final class KsqlRestApplication extends Application<KsqlRestConfig> imple
   }
 
   @Override
-  public void stop() {
+  public void triggerShutdown() {
     try {
       ksqlEngine.close();
     } catch (final Exception e) {
@@ -311,12 +309,11 @@ public final class KsqlRestApplication extends Application<KsqlRestConfig> imple
     } catch (final Exception e) {
       log.error("Exception while closing security extension", e);
     }
+  }
 
-    try {
-      super.stop();
-    } catch (final Exception e) {
-      log.error("Exception while stopping rest server", e);
-    }
+  @Override
+  public void onShutdown() {
+    triggerShutdown();
   }
 
   List<URL> getListeners() {

--- a/ksql-rest-app/src/main/java/io/confluent/ksql/rest/server/MultiExecutable.java
+++ b/ksql-rest-app/src/main/java/io/confluent/ksql/rest/server/MultiExecutable.java
@@ -38,18 +38,18 @@ public final class MultiExecutable implements Executable  {
   }
 
   @Override
-  public void start() throws Exception {
-    doAction(Executable::start);
+  public void startAsync() throws Exception {
+    doAction(Executable::startAsync);
   }
 
   @Override
-  public void stop() throws Exception {
-    doAction(Executable::stop);
+  public void triggerShutdown() throws Exception {
+    doAction(Executable::triggerShutdown);
   }
 
   @Override
-  public void join() throws InterruptedException {
-    doAction(Executable::join);
+  public void awaitTerminated() throws InterruptedException {
+    doAction(Executable::awaitTerminated);
   }
 
   @SuppressWarnings("unchecked")

--- a/ksql-rest-app/src/main/java/io/confluent/ksql/rest/server/StandaloneExecutor.java
+++ b/ksql-rest-app/src/main/java/io/confluent/ksql/rest/server/StandaloneExecutor.java
@@ -104,7 +104,7 @@ public class StandaloneExecutor implements Executable {
     this.injectorFactory = requireNonNull(injectorFactory, "injectorFactory");
   }
 
-  public void start() {
+  public void startAsync() {
     try {
       udfLoader.load();
       ProcessingLogServerUtils.maybeCreateProcessingLogTopic(
@@ -122,12 +122,12 @@ public class StandaloneExecutor implements Executable {
       versionChecker.start(KsqlModuleType.SERVER, properties);
     } catch (final Exception e) {
       log.error("Failed to start KSQL Server with query file: " + queriesFile, e);
-      stop();
+      triggerShutdown();
       throw e;
     }
   }
 
-  public void stop() {
+  public void triggerShutdown() {
     try {
       ksqlEngine.close();
     } catch (final Exception e) {
@@ -142,7 +142,7 @@ public class StandaloneExecutor implements Executable {
   }
 
   @Override
-  public void join() throws InterruptedException {
+  public void awaitTerminated() throws InterruptedException {
     shutdownLatch.await();
   }
 

--- a/ksql-rest-app/src/test/java/io/confluent/ksql/rest/server/ConnectIntegrationTest.java
+++ b/ksql-rest-app/src/test/java/io/confluent/ksql/rest/server/ConnectIntegrationTest.java
@@ -87,12 +87,12 @@ public class ConnectIntegrationTest {
         .put("config.storage.replication.factor", "1")
         .build()
     );
-    CONNECT.start();
+    CONNECT.startAsync();
   }
 
   @AfterClass
   public static void tearDownClass() {
-    CONNECT.stop();
+    CONNECT.triggerShutdown();
   }
 
   private KsqlRestClient ksqlRestClient;

--- a/ksql-rest-app/src/test/java/io/confluent/ksql/rest/server/KsqlRestApplicationTest.java
+++ b/ksql-rest-app/src/test/java/io/confluent/ksql/rest/server/KsqlRestApplicationTest.java
@@ -185,7 +185,7 @@ public class KsqlRestApplicationTest {
   @Test
   public void shouldCloseServiceContextOnClose() {
     // When:
-    app.stop();
+    app.triggerShutdown();
 
     // Then:
     verify(serviceContext).close();
@@ -194,7 +194,7 @@ public class KsqlRestApplicationTest {
   @Test
   public void shouldCloseSecurityExtensionOnClose() {
     // When:
-    app.stop();
+    app.triggerShutdown();
 
     // Then:
     verify(securityExtension).close();

--- a/ksql-rest-app/src/test/java/io/confluent/ksql/rest/server/KsqlServerMainTest.java
+++ b/ksql-rest-app/src/test/java/io/confluent/ksql/rest/server/KsqlServerMainTest.java
@@ -59,7 +59,7 @@ public class KsqlServerMainTest {
   @Test
   public void shouldStopAppOnJoin() throws Exception {
     // Given:
-    executable.stop();
+    executable.triggerShutdown();
     expectLastCall();
     replay(executable);
 
@@ -73,10 +73,10 @@ public class KsqlServerMainTest {
   @Test
   public void shouldStopAppOnErrorStarting() throws Exception {
     // Given:
-    executable.start();
+    executable.startAsync();
     expectLastCall().andThrow(new RuntimeException("Boom"));
 
-    executable.stop();
+    executable.triggerShutdown();
     expectLastCall();
     replay(executable);
 

--- a/ksql-rest-app/src/test/java/io/confluent/ksql/rest/server/MultiExecutableTest.java
+++ b/ksql-rest-app/src/test/java/io/confluent/ksql/rest/server/MultiExecutableTest.java
@@ -50,44 +50,44 @@ public class MultiExecutableTest {
   @Test
   public void shouldStartAll() throws Exception {
     // When:
-    multiExecutable.start();
+    multiExecutable.startAsync();
 
     // Then:
     final InOrder inOrder = Mockito.inOrder(executable1, executable2);
-    inOrder.verify(executable1).start();
-    inOrder.verify(executable2).start();
+    inOrder.verify(executable1).startAsync();
+    inOrder.verify(executable2).startAsync();
     inOrder.verifyNoMoreInteractions();
   }
 
   @Test
   public void shouldJoinAll() throws Exception {
     // When:
-    multiExecutable.join();
+    multiExecutable.awaitTerminated();
 
     // Then:
     final InOrder inOrder = Mockito.inOrder(executable1, executable2);
-    inOrder.verify(executable1).join();
-    inOrder.verify(executable2).join();
+    inOrder.verify(executable1).awaitTerminated();
+    inOrder.verify(executable2).awaitTerminated();
     inOrder.verifyNoMoreInteractions();
   }
 
   @Test
   public void shouldStopAll() throws Exception {
     // When:
-    multiExecutable.stop();
+    multiExecutable.triggerShutdown();
 
     // Then:
     final InOrder inOrder = Mockito.inOrder(executable1, executable2);
-    inOrder.verify(executable1).stop();
-    inOrder.verify(executable2).stop();
+    inOrder.verify(executable1).triggerShutdown();
+    inOrder.verify(executable2).triggerShutdown();
     inOrder.verifyNoMoreInteractions();
   }
 
   @Test
   public void shouldSuppressExceptions() throws Exception {
     // Given:
-    doThrow(new RuntimeException("danger executable1!")).when(executable1).start();
-    doThrow(new RuntimeException("danger executable2!")).when(executable2).start();
+    doThrow(new RuntimeException("danger executable1!")).when(executable1).startAsync();
+    doThrow(new RuntimeException("danger executable2!")).when(executable2).startAsync();
 
     // Expect:
     expectedException.expectMessage("danger executable1!");
@@ -104,7 +104,7 @@ public class MultiExecutableTest {
     });
 
     // When:
-    multiExecutable.start();
+    multiExecutable.startAsync();
   }
 
 }

--- a/ksql-rest-app/src/test/java/io/confluent/ksql/rest/server/StandaloneExecutorFunctionalTest.java
+++ b/ksql-rest-app/src/test/java/io/confluent/ksql/rest/server/StandaloneExecutorFunctionalTest.java
@@ -131,8 +131,8 @@ public class StandaloneExecutorFunctionalTest {
 
   @After
   public void tearDown() throws Exception {
-    standalone.stop();
-    standalone.join();
+    standalone.triggerShutdown();
+    standalone.awaitTerminated();
   }
 
   @Test
@@ -165,7 +165,7 @@ public class StandaloneExecutorFunctionalTest {
     );
 
     // When:
-    standalone.start();
+    standalone.startAsync();
 
     // Then:
     // CSAS and INSERT INTO both input into S1:
@@ -206,7 +206,7 @@ public class StandaloneExecutorFunctionalTest {
     );
 
     // When:
-    standalone.start();
+    standalone.startAsync();
 
     // Then:
     // CSAS and INSERT INTO both input into S1:
@@ -228,7 +228,7 @@ public class StandaloneExecutorFunctionalTest {
         + "CREATE STREAM " + s1 + " AS SELECT * FROM S;");
 
     // When:
-    standalone.start();
+    standalone.startAsync();
 
     // Then:
     TEST_HARNESS.verifyAvailableRows(s1, DATA_SIZE, AVRO, DATA_SCHEMA);
@@ -250,7 +250,7 @@ public class StandaloneExecutorFunctionalTest {
         "Schema registry fetch for topic topic-without-schema request failed");
 
     // When:
-    standalone.start();
+    standalone.startAsync();
   }
 
   @Test
@@ -270,7 +270,7 @@ public class StandaloneExecutorFunctionalTest {
     expectedException.expectMessage("schema is incompatible with the current schema version registered for the topic");
 
     // When:
-    standalone.start();
+    standalone.startAsync();
   }
 
   @Test
@@ -291,7 +291,7 @@ public class StandaloneExecutorFunctionalTest {
         + "CREATE STREAM " + s1 + "  AS SELECT * FROM S;");
 
     // When:
-    standalone.start();
+    standalone.startAsync();
 
     // Then:
     TEST_HARNESS.verifyAvailableRows(s1, DATA_SIZE, JSON, DATA_SCHEMA);


### PR DESCRIPTION
### Description 

https://github.com/confluentinc/rest-utils/pull/155 enabled a single `ApplicationServer` to handle multiple applications. This patch makes KSQL use the same pattern. In order to do that I needed to:

- Change `Executable` methods to no longer clash with `LifeCycle` methods because their public usage was deprecated in `Application`
- Add an `ExecutableServer` which delegates `Executable` methods to the corresponding `LifeCycle` methods on `ApplicationServer`
- Make `KsqlRestApplication` no longer depend on having `ApplicationServer` internally; instead it is created externally. The `setServer` is handled in the `registerApplication` method

**Disclaimer**: I don't know if I love this change, but let's get it through so that master is unblocked. Afterwards (sometime next week hopefully) I'll see if I can restructure everything to use Guava's `Service` abstraction which I think is much cleaner than using our own bootstrapped stuff.

### Testing done 

- Updated the unit tests
- `mvn clean install`
- smoke testing to make sure it starts up

### Reviewer checklist
- [ ] Ensure docs are updated if necessary. (eg. if a user visible feature is being added or changed).
- [ ] Ensure relevant issues are linked (description should include text like "Fixes #<issue number>")

