### PR TITLE
fix: Update repartition processor names for KAFKA-9098

### DIFF
--- a/ksql-engine/src/test/java/io/confluent/ksql/planner/plan/AggregateNodeTest.java
+++ b/ksql-engine/src/test/java/io/confluent/ksql/planner/plan/AggregateNodeTest.java
@@ -196,7 +196,7 @@ public class AggregateNodeTest {
 
     // Then:
     final TopologyDescription.Source node = (TopologyDescription.Source) getNodeByName(
-        builder.build(), "KSTREAM-SOURCE-0000000008");
+        builder.build(), "Aggregate-groupby-repartition-source");
     final List<String> successors = node.successors().stream().map(TopologyDescription.Node::name).collect(Collectors.toList());
     assertThat(node.predecessors(), equalTo(Collections.emptySet()));
     assertThat(successors, equalTo(Collections.singletonList("KSTREAM-AGGREGATE-0000000005")));
@@ -261,9 +261,9 @@ public class AggregateNodeTest {
 
     // Then:
     final TopologyDescription.Sink sink = (TopologyDescription.Sink) getNodeByName(builder.build(),
-        "KSTREAM-SINK-0000000006");
+        "Aggregate-groupby-repartition-sink");
     final TopologyDescription.Source source = (TopologyDescription.Source) getNodeByName(
-        builder.build(), "KSTREAM-SOURCE-0000000008");
+        builder.build(), "Aggregate-groupby-repartition-source");
     assertThat(sink.successors(), equalTo(Collections.emptySet()));
     assertThat(source.topicSet(), hasItem(sink.topic()));
   }

--- a/ksql-engine/src/test/java/io/confluent/ksql/planner/plan/JoinNodeTest.java
+++ b/ksql-engine/src/test/java/io/confluent/ksql/planner/plan/JoinNodeTest.java
@@ -278,7 +278,7 @@ public class JoinNodeTest {
     final List<String> predecessors = leftJoin.predecessors().stream()
         .map(TopologyDescription.Node::name).collect(Collectors.toList());
     assertThat(leftJoin.stores(), equalTo(Utils.mkSet("KafkaTopic_Right-reduce")));
-    assertThat(predecessors, equalTo(Collections.singletonList("KSTREAM-SOURCE-0000000011")));
+    assertThat(predecessors, equalTo(Collections.singletonList("Join-repartition-source")));
   }
 
   @Test

--- a/ksql-functional-tests/src/test/resources/expected_topology/0_6_0-pre/elements_-_group-by_removes_ROWTIME_from_output's_value_schema
+++ b/ksql-functional-tests/src/test/resources/expected_topology/0_6_0-pre/elements_-_group-by_removes_ROWTIME_from_output's_value_schema
@@ -59,20 +59,20 @@ Topologies:
       --> Aggregate-groupby
       <-- KSTREAM-MAPVALUES-0000000002
     Processor: Aggregate-groupby (stores: [])
-      --> KSTREAM-FILTER-0000000007
+      --> Aggregate-groupby-repartition-filter
       <-- KSTREAM-FILTER-0000000003
-    Processor: KSTREAM-FILTER-0000000007 (stores: [])
-      --> KSTREAM-SINK-0000000006
+    Processor: Aggregate-groupby-repartition-filter (stores: [])
+      --> Aggregate-groupby-repartition-sink
       <-- Aggregate-groupby
-    Sink: KSTREAM-SINK-0000000006 (topic: Aggregate-groupby-repartition)
-      <-- KSTREAM-FILTER-0000000007
+    Sink: Aggregate-groupby-repartition-sink (topic: Aggregate-groupby-repartition)
+      <-- Aggregate-groupby-repartition-filter
 
   Sub-topology: 1
-    Source: KSTREAM-SOURCE-0000000008 (topics: [Aggregate-groupby-repartition])
+    Source: Aggregate-groupby-repartition-source (topics: [Aggregate-groupby-repartition])
       --> KSTREAM-AGGREGATE-0000000005
     Processor: KSTREAM-AGGREGATE-0000000005 (stores: [Aggregate-aggregate])
       --> KTABLE-MAPVALUES-0000000009
-      <-- KSTREAM-SOURCE-0000000008
+      <-- Aggregate-groupby-repartition-source
     Processor: KTABLE-MAPVALUES-0000000009 (stores: [])
       --> KTABLE-MAPVALUES-0000000010
       <-- KSTREAM-AGGREGATE-0000000005

--- a/ksql-functional-tests/src/test/resources/expected_topology/0_6_0-pre/group-by_-_ROWTIME_(stream-_table)
+++ b/ksql-functional-tests/src/test/resources/expected_topology/0_6_0-pre/group-by_-_ROWTIME_(stream-_table)
@@ -59,20 +59,20 @@ Topologies:
       --> Aggregate-groupby
       <-- KSTREAM-MAPVALUES-0000000002
     Processor: Aggregate-groupby (stores: [])
-      --> KSTREAM-FILTER-0000000007
+      --> Aggregate-groupby-repartition-filter
       <-- KSTREAM-FILTER-0000000003
-    Processor: KSTREAM-FILTER-0000000007 (stores: [])
-      --> KSTREAM-SINK-0000000006
+    Processor: Aggregate-groupby-repartition-filter (stores: [])
+      --> Aggregate-groupby-repartition-sink
       <-- Aggregate-groupby
-    Sink: KSTREAM-SINK-0000000006 (topic: Aggregate-groupby-repartition)
-      <-- KSTREAM-FILTER-0000000007
+    Sink: Aggregate-groupby-repartition-sink (topic: Aggregate-groupby-repartition)
+      <-- Aggregate-groupby-repartition-filter
 
   Sub-topology: 1
-    Source: KSTREAM-SOURCE-0000000008 (topics: [Aggregate-groupby-repartition])
+    Source: Aggregate-groupby-repartition-source (topics: [Aggregate-groupby-repartition])
       --> KSTREAM-AGGREGATE-0000000005
     Processor: KSTREAM-AGGREGATE-0000000005 (stores: [Aggregate-aggregate])
       --> KTABLE-MAPVALUES-0000000009
-      <-- KSTREAM-SOURCE-0000000008
+      <-- Aggregate-groupby-repartition-source
     Processor: KTABLE-MAPVALUES-0000000009 (stores: [])
       --> KTABLE-MAPVALUES-0000000010
       <-- KSTREAM-AGGREGATE-0000000005

--- a/ksql-functional-tests/src/test/resources/expected_topology/0_6_0-pre/group-by_-_UDAF_nested_in_UDF_in_select_expression_(stream-_table)
+++ b/ksql-functional-tests/src/test/resources/expected_topology/0_6_0-pre/group-by_-_UDAF_nested_in_UDF_in_select_expression_(stream-_table)
@@ -59,20 +59,20 @@ Topologies:
       --> Aggregate-groupby
       <-- KSTREAM-MAPVALUES-0000000002
     Processor: Aggregate-groupby (stores: [])
-      --> KSTREAM-FILTER-0000000007
+      --> Aggregate-groupby-repartition-filter
       <-- KSTREAM-FILTER-0000000003
-    Processor: KSTREAM-FILTER-0000000007 (stores: [])
-      --> KSTREAM-SINK-0000000006
+    Processor: Aggregate-groupby-repartition-filter (stores: [])
+      --> Aggregate-groupby-repartition-sink
       <-- Aggregate-groupby
-    Sink: KSTREAM-SINK-0000000006 (topic: Aggregate-groupby-repartition)
-      <-- KSTREAM-FILTER-0000000007
+    Sink: Aggregate-groupby-repartition-sink (topic: Aggregate-groupby-repartition)
+      <-- Aggregate-groupby-repartition-filter
 
   Sub-topology: 1
-    Source: KSTREAM-SOURCE-0000000008 (topics: [Aggregate-groupby-repartition])
+    Source: Aggregate-groupby-repartition-source (topics: [Aggregate-groupby-repartition])
       --> KSTREAM-AGGREGATE-0000000005
     Processor: KSTREAM-AGGREGATE-0000000005 (stores: [Aggregate-aggregate])
       --> KTABLE-MAPVALUES-0000000009
-      <-- KSTREAM-SOURCE-0000000008
+      <-- Aggregate-groupby-repartition-source
     Processor: KTABLE-MAPVALUES-0000000009 (stores: [])
       --> KTABLE-MAPVALUES-0000000010
       <-- KSTREAM-AGGREGATE-0000000005

--- a/ksql-functional-tests/src/test/resources/expected_topology/0_6_0-pre/group-by_-_UDF_nested_in_UDAF_in_select_expression_(stream-_table)
+++ b/ksql-functional-tests/src/test/resources/expected_topology/0_6_0-pre/group-by_-_UDF_nested_in_UDAF_in_select_expression_(stream-_table)
@@ -59,20 +59,20 @@ Topologies:
       --> Aggregate-groupby
       <-- KSTREAM-MAPVALUES-0000000002
     Processor: Aggregate-groupby (stores: [])
-      --> KSTREAM-FILTER-0000000007
+      --> Aggregate-groupby-repartition-filter
       <-- KSTREAM-FILTER-0000000003
-    Processor: KSTREAM-FILTER-0000000007 (stores: [])
-      --> KSTREAM-SINK-0000000006
+    Processor: Aggregate-groupby-repartition-filter (stores: [])
+      --> Aggregate-groupby-repartition-sink
       <-- Aggregate-groupby
-    Sink: KSTREAM-SINK-0000000006 (topic: Aggregate-groupby-repartition)
-      <-- KSTREAM-FILTER-0000000007
+    Sink: Aggregate-groupby-repartition-sink (topic: Aggregate-groupby-repartition)
+      <-- Aggregate-groupby-repartition-filter
 
   Sub-topology: 1
-    Source: KSTREAM-SOURCE-0000000008 (topics: [Aggregate-groupby-repartition])
+    Source: Aggregate-groupby-repartition-source (topics: [Aggregate-groupby-repartition])
       --> KSTREAM-AGGREGATE-0000000005
     Processor: KSTREAM-AGGREGATE-0000000005 (stores: [Aggregate-aggregate])
       --> KTABLE-MAPVALUES-0000000009
-      <-- KSTREAM-SOURCE-0000000008
+      <-- Aggregate-groupby-repartition-source
     Processor: KTABLE-MAPVALUES-0000000009 (stores: [])
       --> KTABLE-MAPVALUES-0000000010
       <-- KSTREAM-AGGREGATE-0000000005

--- a/ksql-functional-tests/src/test/resources/expected_topology/0_6_0-pre/group-by_-_arithmetic_binary_expression_with_projection_in-order_&_non-commutative_group_by_(stream-_table)
+++ b/ksql-functional-tests/src/test/resources/expected_topology/0_6_0-pre/group-by_-_arithmetic_binary_expression_with_projection_in-order_&_non-commutative_group_by_(stream-_table)
@@ -59,20 +59,20 @@ Topologies:
       --> Aggregate-groupby
       <-- KSTREAM-MAPVALUES-0000000002
     Processor: Aggregate-groupby (stores: [])
-      --> KSTREAM-FILTER-0000000007
+      --> Aggregate-groupby-repartition-filter
       <-- KSTREAM-FILTER-0000000003
-    Processor: KSTREAM-FILTER-0000000007 (stores: [])
-      --> KSTREAM-SINK-0000000006
+    Processor: Aggregate-groupby-repartition-filter (stores: [])
+      --> Aggregate-groupby-repartition-sink
       <-- Aggregate-groupby
-    Sink: KSTREAM-SINK-0000000006 (topic: Aggregate-groupby-repartition)
-      <-- KSTREAM-FILTER-0000000007
+    Sink: Aggregate-groupby-repartition-sink (topic: Aggregate-groupby-repartition)
+      <-- Aggregate-groupby-repartition-filter
 
   Sub-topology: 1
-    Source: KSTREAM-SOURCE-0000000008 (topics: [Aggregate-groupby-repartition])
+    Source: Aggregate-groupby-repartition-source (topics: [Aggregate-groupby-repartition])
       --> KSTREAM-AGGREGATE-0000000005
     Processor: KSTREAM-AGGREGATE-0000000005 (stores: [Aggregate-aggregate])
       --> KTABLE-MAPVALUES-0000000009
-      <-- KSTREAM-SOURCE-0000000008
+      <-- Aggregate-groupby-repartition-source
     Processor: KTABLE-MAPVALUES-0000000009 (stores: [])
       --> KTABLE-MAPVALUES-0000000010
       <-- KSTREAM-AGGREGATE-0000000005

--- a/ksql-functional-tests/src/test/resources/expected_topology/0_6_0-pre/group-by_-_constant_(stream-_table)
+++ b/ksql-functional-tests/src/test/resources/expected_topology/0_6_0-pre/group-by_-_constant_(stream-_table)
@@ -59,20 +59,20 @@ Topologies:
       --> Aggregate-groupby
       <-- KSTREAM-MAPVALUES-0000000002
     Processor: Aggregate-groupby (stores: [])
-      --> KSTREAM-FILTER-0000000007
+      --> Aggregate-groupby-repartition-filter
       <-- KSTREAM-FILTER-0000000003
     Processor: KSTREAM-FILTER-0000000007 (stores: [])
-      --> KSTREAM-SINK-0000000006
+      --> Aggregate-groupby-repartition-sink
       <-- Aggregate-groupby
-    Sink: KSTREAM-SINK-0000000006 (topic: Aggregate-groupby-repartition)
+    Sink: Aggregate-groupby-repartition-sink (topic: Aggregate-groupby-repartition)
       <-- KSTREAM-FILTER-0000000007
 
   Sub-topology: 1
-    Source: KSTREAM-SOURCE-0000000008 (topics: [Aggregate-groupby-repartition])
+    Source: Aggregate-groupby-repartition-source (topics: [Aggregate-groupby-repartition])
       --> KSTREAM-AGGREGATE-0000000005
     Processor: KSTREAM-AGGREGATE-0000000005 (stores: [Aggregate-aggregate])
       --> KTABLE-MAPVALUES-0000000009
-      <-- KSTREAM-SOURCE-0000000008
+      <-- Aggregate-groupby-repartition-source
     Processor: KTABLE-MAPVALUES-0000000009 (stores: [])
       --> KTABLE-MAPVALUES-0000000010
       <-- KSTREAM-AGGREGATE-0000000005

--- a/ksql-functional-tests/src/test/resources/expected_topology/0_6_0-pre/group-by_-_constant_(stream-_table)
+++ b/ksql-functional-tests/src/test/resources/expected_topology/0_6_0-pre/group-by_-_constant_(stream-_table)
@@ -61,11 +61,11 @@ Topologies:
     Processor: Aggregate-groupby (stores: [])
       --> Aggregate-groupby-repartition-filter
       <-- KSTREAM-FILTER-0000000003
-    Processor: KSTREAM-FILTER-0000000007 (stores: [])
+    Processor: Aggregate-groupby-repartition-filter (stores: [])
       --> Aggregate-groupby-repartition-sink
       <-- Aggregate-groupby
     Sink: Aggregate-groupby-repartition-sink (topic: Aggregate-groupby-repartition)
-      <-- KSTREAM-FILTER-0000000007
+      <-- Aggregate-groupby-repartition-filter
 
   Sub-topology: 1
     Source: Aggregate-groupby-repartition-source (topics: [Aggregate-groupby-repartition])

--- a/ksql-functional-tests/src/test/resources/expected_topology/0_6_0-pre/group-by_-_duplicate_fields_(stream-_table)
+++ b/ksql-functional-tests/src/test/resources/expected_topology/0_6_0-pre/group-by_-_duplicate_fields_(stream-_table)
@@ -59,20 +59,20 @@ Topologies:
       --> Aggregate-groupby
       <-- KSTREAM-MAPVALUES-0000000002
     Processor: Aggregate-groupby (stores: [])
-      --> KSTREAM-FILTER-0000000007
+      --> Aggregate-groupby-repartition-filter
       <-- KSTREAM-FILTER-0000000003
-    Processor: KSTREAM-FILTER-0000000007 (stores: [])
-      --> KSTREAM-SINK-0000000006
+    Processor: Aggregate-groupby-repartition-filter (stores: [])
+      --> Aggregate-groupby-repartition-sink
       <-- Aggregate-groupby
-    Sink: KSTREAM-SINK-0000000006 (topic: Aggregate-groupby-repartition)
-      <-- KSTREAM-FILTER-0000000007
+    Sink: Aggregate-groupby-repartition-sink (topic: Aggregate-groupby-repartition)
+      <-- Aggregate-groupby-repartition-filter
 
   Sub-topology: 1
-    Source: KSTREAM-SOURCE-0000000008 (topics: [Aggregate-groupby-repartition])
+    Source: Aggregate-groupby-repartition-source (topics: [Aggregate-groupby-repartition])
       --> KSTREAM-AGGREGATE-0000000005
     Processor: KSTREAM-AGGREGATE-0000000005 (stores: [Aggregate-aggregate])
       --> KTABLE-MAPVALUES-0000000009
-      <-- KSTREAM-SOURCE-0000000008
+      <-- Aggregate-groupby-repartition-source
     Processor: KTABLE-MAPVALUES-0000000009 (stores: [])
       --> KTABLE-MAPVALUES-0000000010
       <-- KSTREAM-AGGREGATE-0000000005

--- a/ksql-functional-tests/src/test/resources/expected_topology/0_6_0-pre/group-by_-_field_with_field_used_in_function_in_projection_(stream-_table)
+++ b/ksql-functional-tests/src/test/resources/expected_topology/0_6_0-pre/group-by_-_field_with_field_used_in_function_in_projection_(stream-_table)
@@ -59,20 +59,20 @@ Topologies:
       --> Aggregate-groupby
       <-- KSTREAM-MAPVALUES-0000000002
     Processor: Aggregate-groupby (stores: [])
-      --> KSTREAM-FILTER-0000000007
+      --> Aggregate-groupby-repartition-filter
       <-- KSTREAM-FILTER-0000000003
-    Processor: KSTREAM-FILTER-0000000007 (stores: [])
-      --> KSTREAM-SINK-0000000006
+    Processor: Aggregate-groupby-repartition-filter (stores: [])
+      --> Aggregate-groupby-repartition-sink
       <-- Aggregate-groupby
-    Sink: KSTREAM-SINK-0000000006 (topic: Aggregate-groupby-repartition)
-      <-- KSTREAM-FILTER-0000000007
+    Sink: Aggregate-groupby-repartition-sink (topic: Aggregate-groupby-repartition)
+      <-- Aggregate-groupby-repartition-filter
 
   Sub-topology: 1
-    Source: KSTREAM-SOURCE-0000000008 (topics: [Aggregate-groupby-repartition])
+    Source: Aggregate-groupby-repartition-source (topics: [Aggregate-groupby-repartition])
       --> KSTREAM-AGGREGATE-0000000005
     Processor: KSTREAM-AGGREGATE-0000000005 (stores: [Aggregate-aggregate])
       --> KTABLE-MAPVALUES-0000000009
-      <-- KSTREAM-SOURCE-0000000008
+      <-- Aggregate-groupby-repartition-source
     Processor: KTABLE-MAPVALUES-0000000009 (stores: [])
       --> KTABLE-MAPVALUES-0000000010
       <-- KSTREAM-AGGREGATE-0000000005

--- a/ksql-functional-tests/src/test/resources/expected_topology/0_6_0-pre/group-by_-_field_with_re-key_(stream-_table)
+++ b/ksql-functional-tests/src/test/resources/expected_topology/0_6_0-pre/group-by_-_field_with_re-key_(stream-_table)
@@ -59,20 +59,20 @@ Topologies:
       --> Aggregate-groupby
       <-- KSTREAM-MAPVALUES-0000000002
     Processor: Aggregate-groupby (stores: [])
-      --> KSTREAM-FILTER-0000000007
+      --> Aggregate-groupby-repartition-filter
       <-- KSTREAM-FILTER-0000000003
-    Processor: KSTREAM-FILTER-0000000007 (stores: [])
-      --> KSTREAM-SINK-0000000006
+    Processor: Aggregate-groupby-repartition-filter (stores: [])
+      --> Aggregate-groupby-repartition-sink
       <-- Aggregate-groupby
-    Sink: KSTREAM-SINK-0000000006 (topic: Aggregate-groupby-repartition)
-      <-- KSTREAM-FILTER-0000000007
+    Sink: Aggregate-groupby-repartition-sink (topic: Aggregate-groupby-repartition)
+      <-- Aggregate-groupby-repartition-filter
 
   Sub-topology: 1
-    Source: KSTREAM-SOURCE-0000000008 (topics: [Aggregate-groupby-repartition])
+    Source: Aggregate-groupby-repartition-source (topics: [Aggregate-groupby-repartition])
       --> KSTREAM-AGGREGATE-0000000005
     Processor: KSTREAM-AGGREGATE-0000000005 (stores: [Aggregate-aggregate])
       --> KTABLE-MAPVALUES-0000000009
-      <-- KSTREAM-SOURCE-0000000008
+      <-- Aggregate-groupby-repartition-source
     Processor: KTABLE-MAPVALUES-0000000009 (stores: [])
       --> KTABLE-MAPVALUES-0000000010
       <-- KSTREAM-AGGREGATE-0000000005

--- a/ksql-functional-tests/src/test/resources/expected_topology/0_6_0-pre/group-by_-_field_with_re-key_(stream-_table)_-_format
+++ b/ksql-functional-tests/src/test/resources/expected_topology/0_6_0-pre/group-by_-_field_with_re-key_(stream-_table)_-_format
@@ -59,20 +59,20 @@ Topologies:
       --> Aggregate-groupby
       <-- KSTREAM-MAPVALUES-0000000002
     Processor: Aggregate-groupby (stores: [])
-      --> KSTREAM-FILTER-0000000007
+      --> Aggregate-groupby-repartition-filter
       <-- KSTREAM-FILTER-0000000003
-    Processor: KSTREAM-FILTER-0000000007 (stores: [])
-      --> KSTREAM-SINK-0000000006
+    Processor: Aggregate-groupby-repartition-filter (stores: [])
+      --> Aggregate-groupby-repartition-sink
       <-- Aggregate-groupby
-    Sink: KSTREAM-SINK-0000000006 (topic: Aggregate-groupby-repartition)
-      <-- KSTREAM-FILTER-0000000007
+    Sink: Aggregate-groupby-repartition-sink (topic: Aggregate-groupby-repartition)
+      <-- Aggregate-groupby-repartition-filter
 
   Sub-topology: 1
-    Source: KSTREAM-SOURCE-0000000008 (topics: [Aggregate-groupby-repartition])
+    Source: Aggregate-groupby-repartition-source (topics: [Aggregate-groupby-repartition])
       --> KSTREAM-AGGREGATE-0000000005
     Processor: KSTREAM-AGGREGATE-0000000005 (stores: [Aggregate-aggregate])
       --> KTABLE-MAPVALUES-0000000009
-      <-- KSTREAM-SOURCE-0000000008
+      <-- Aggregate-groupby-repartition-source
     Processor: KTABLE-MAPVALUES-0000000009 (stores: [])
       --> KTABLE-MAPVALUES-0000000010
       <-- KSTREAM-AGGREGATE-0000000005

--- a/ksql-functional-tests/src/test/resources/expected_topology/0_6_0-pre/group-by_-_fields_(stream-_table)
+++ b/ksql-functional-tests/src/test/resources/expected_topology/0_6_0-pre/group-by_-_fields_(stream-_table)
@@ -59,20 +59,20 @@ Topologies:
       --> Aggregate-groupby
       <-- KSTREAM-MAPVALUES-0000000002
     Processor: Aggregate-groupby (stores: [])
-      --> KSTREAM-FILTER-0000000007
+      --> Aggregate-groupby-repartition-filter
       <-- KSTREAM-FILTER-0000000003
-    Processor: KSTREAM-FILTER-0000000007 (stores: [])
-      --> KSTREAM-SINK-0000000006
+    Processor: Aggregate-groupby-repartition-filter (stores: [])
+      --> Aggregate-groupby-repartition-sink
       <-- Aggregate-groupby
-    Sink: KSTREAM-SINK-0000000006 (topic: Aggregate-groupby-repartition)
-      <-- KSTREAM-FILTER-0000000007
+    Sink: Aggregate-groupby-repartition-sink (topic: Aggregate-groupby-repartition)
+      <-- Aggregate-groupby-repartition-filter
 
   Sub-topology: 1
-    Source: KSTREAM-SOURCE-0000000008 (topics: [Aggregate-groupby-repartition])
+    Source: Aggregate-groupby-repartition-source (topics: [Aggregate-groupby-repartition])
       --> KSTREAM-AGGREGATE-0000000005
     Processor: KSTREAM-AGGREGATE-0000000005 (stores: [Aggregate-aggregate])
       --> KTABLE-MAPVALUES-0000000009
-      <-- KSTREAM-SOURCE-0000000008
+      <-- Aggregate-groupby-repartition-source
     Processor: KTABLE-MAPVALUES-0000000009 (stores: [])
       --> KTABLE-MAPVALUES-0000000010
       <-- KSTREAM-AGGREGATE-0000000005

--- a/ksql-functional-tests/src/test/resources/expected_topology/0_6_0-pre/group-by_-_fields_(stream-_table)_-_format
+++ b/ksql-functional-tests/src/test/resources/expected_topology/0_6_0-pre/group-by_-_fields_(stream-_table)_-_format
@@ -59,20 +59,20 @@ Topologies:
       --> Aggregate-groupby
       <-- KSTREAM-MAPVALUES-0000000002
     Processor: Aggregate-groupby (stores: [])
-      --> KSTREAM-FILTER-0000000007
+      --> Aggregate-groupby-repartition-filter
       <-- KSTREAM-FILTER-0000000003
-    Processor: KSTREAM-FILTER-0000000007 (stores: [])
-      --> KSTREAM-SINK-0000000006
+    Processor: Aggregate-groupby-repartition-filter (stores: [])
+      --> Aggregate-groupby-repartition-sink
       <-- Aggregate-groupby
-    Sink: KSTREAM-SINK-0000000006 (topic: Aggregate-groupby-repartition)
-      <-- KSTREAM-FILTER-0000000007
+    Sink: Aggregate-groupby-repartition-sink (topic: Aggregate-groupby-repartition)
+      <-- Aggregate-groupby-repartition-filter
 
   Sub-topology: 1
-    Source: KSTREAM-SOURCE-0000000008 (topics: [Aggregate-groupby-repartition])
+    Source: Aggregate-groupby-repartition-source (topics: [Aggregate-groupby-repartition])
       --> KSTREAM-AGGREGATE-0000000005
     Processor: KSTREAM-AGGREGATE-0000000005 (stores: [Aggregate-aggregate])
       --> KTABLE-MAPVALUES-0000000009
-      <-- KSTREAM-SOURCE-0000000008
+      <-- Aggregate-groupby-repartition-source
     Processor: KTABLE-MAPVALUES-0000000009 (stores: [])
       --> KTABLE-MAPVALUES-0000000010
       <-- KSTREAM-AGGREGATE-0000000005

--- a/ksql-functional-tests/src/test/resources/expected_topology/0_6_0-pre/group-by_-_function_(stream-_table)
+++ b/ksql-functional-tests/src/test/resources/expected_topology/0_6_0-pre/group-by_-_function_(stream-_table)
@@ -59,20 +59,20 @@ Topologies:
       --> Aggregate-groupby
       <-- KSTREAM-MAPVALUES-0000000002
     Processor: Aggregate-groupby (stores: [])
-      --> KSTREAM-FILTER-0000000007
+      --> Aggregate-groupby-repartition-filter
       <-- KSTREAM-FILTER-0000000003
-    Processor: KSTREAM-FILTER-0000000007 (stores: [])
-      --> KSTREAM-SINK-0000000006
+    Processor: Aggregate-groupby-repartition-filter (stores: [])
+      --> Aggregate-groupby-repartition-sink
       <-- Aggregate-groupby
-    Sink: KSTREAM-SINK-0000000006 (topic: Aggregate-groupby-repartition)
-      <-- KSTREAM-FILTER-0000000007
+    Sink: Aggregate-groupby-repartition-sink (topic: Aggregate-groupby-repartition)
+      <-- Aggregate-groupby-repartition-filter
 
   Sub-topology: 1
-    Source: KSTREAM-SOURCE-0000000008 (topics: [Aggregate-groupby-repartition])
+    Source: Aggregate-groupby-repartition-source (topics: [Aggregate-groupby-repartition])
       --> KSTREAM-AGGREGATE-0000000005
     Processor: KSTREAM-AGGREGATE-0000000005 (stores: [Aggregate-aggregate])
       --> KTABLE-MAPVALUES-0000000009
-      <-- KSTREAM-SOURCE-0000000008
+      <-- Aggregate-groupby-repartition-source
     Processor: KTABLE-MAPVALUES-0000000009 (stores: [])
       --> KTABLE-MAPVALUES-0000000010
       <-- KSTREAM-AGGREGATE-0000000005

--- a/ksql-functional-tests/src/test/resources/expected_topology/0_6_0-pre/group-by_-_json_field_(stream-_table)
+++ b/ksql-functional-tests/src/test/resources/expected_topology/0_6_0-pre/group-by_-_json_field_(stream-_table)
@@ -59,20 +59,20 @@ Topologies:
       --> Aggregate-groupby
       <-- KSTREAM-MAPVALUES-0000000002
     Processor: Aggregate-groupby (stores: [])
-      --> KSTREAM-FILTER-0000000007
+      --> Aggregate-groupby-repartition-filter
       <-- KSTREAM-FILTER-0000000003
-    Processor: KSTREAM-FILTER-0000000007 (stores: [])
-      --> KSTREAM-SINK-0000000006
+    Processor: Aggregate-groupby-repartition-filter (stores: [])
+      --> Aggregate-groupby-repartition-sink
       <-- Aggregate-groupby
-    Sink: KSTREAM-SINK-0000000006 (topic: Aggregate-groupby-repartition)
-      <-- KSTREAM-FILTER-0000000007
+    Sink: Aggregate-groupby-repartition-sink (topic: Aggregate-groupby-repartition)
+      <-- Aggregate-groupby-repartition-filter
 
   Sub-topology: 1
-    Source: KSTREAM-SOURCE-0000000008 (topics: [Aggregate-groupby-repartition])
+    Source: Aggregate-groupby-repartition-source (topics: [Aggregate-groupby-repartition])
       --> KSTREAM-AGGREGATE-0000000005
     Processor: KSTREAM-AGGREGATE-0000000005 (stores: [Aggregate-aggregate])
       --> KTABLE-MAPVALUES-0000000009
-      <-- KSTREAM-SOURCE-0000000008
+      <-- Aggregate-groupby-repartition-source
     Processor: KTABLE-MAPVALUES-0000000009 (stores: [])
       --> KTABLE-MAPVALUES-0000000010
       <-- KSTREAM-AGGREGATE-0000000005

--- a/ksql-functional-tests/src/test/resources/expected_topology/0_6_0-pre/group-by_-_missing_matching_projection_field_(stream-_table)
+++ b/ksql-functional-tests/src/test/resources/expected_topology/0_6_0-pre/group-by_-_missing_matching_projection_field_(stream-_table)
@@ -59,13 +59,13 @@ Topologies:
       --> Aggregate-groupby
       <-- KSTREAM-MAPVALUES-0000000002
     Processor: Aggregate-groupby (stores: [])
-      --> KSTREAM-FILTER-0000000007
+      --> Aggregate-groupby-repartition-filter
       <-- KSTREAM-FILTER-0000000003
-    Processor: KSTREAM-FILTER-0000000007 (stores: [])
+    Processor: Aggregate-groupby-repartition-filter (stores: [])
       --> Aggregate-groupby-repartition-sink
       <-- Aggregate-groupby
     Sink: Aggregate-groupby-repartition-sink (topic: Aggregate-groupby-repartition)
-      <-- KSTREAM-FILTER-0000000007
+      <-- Aggregate-groupby-repartition-filter
 
   Sub-topology: 1
     Source: Aggregate-groupby-repartition-source (topics: [Aggregate-groupby-repartition])

--- a/ksql-functional-tests/src/test/resources/expected_topology/0_6_0-pre/group-by_-_missing_matching_projection_field_(stream-_table)
+++ b/ksql-functional-tests/src/test/resources/expected_topology/0_6_0-pre/group-by_-_missing_matching_projection_field_(stream-_table)
@@ -62,17 +62,17 @@ Topologies:
       --> KSTREAM-FILTER-0000000007
       <-- KSTREAM-FILTER-0000000003
     Processor: KSTREAM-FILTER-0000000007 (stores: [])
-      --> KSTREAM-SINK-0000000006
+      --> Aggregate-groupby-repartition-sink
       <-- Aggregate-groupby
-    Sink: KSTREAM-SINK-0000000006 (topic: Aggregate-groupby-repartition)
+    Sink: Aggregate-groupby-repartition-sink (topic: Aggregate-groupby-repartition)
       <-- KSTREAM-FILTER-0000000007
 
   Sub-topology: 1
-    Source: KSTREAM-SOURCE-0000000008 (topics: [Aggregate-groupby-repartition])
+    Source: Aggregate-groupby-repartition-source (topics: [Aggregate-groupby-repartition])
       --> KSTREAM-AGGREGATE-0000000005
     Processor: KSTREAM-AGGREGATE-0000000005 (stores: [Aggregate-aggregate])
       --> KTABLE-MAPVALUES-0000000009
-      <-- KSTREAM-SOURCE-0000000008
+      <-- Aggregate-groupby-repartition-source
     Processor: KTABLE-MAPVALUES-0000000009 (stores: [])
       --> KTABLE-MAPVALUES-0000000010
       <-- KSTREAM-AGGREGATE-0000000005

--- a/ksql-functional-tests/src/test/resources/expected_topology/0_6_0-pre/group-by_-_string_concat_using_+_op_(stream-_table)
+++ b/ksql-functional-tests/src/test/resources/expected_topology/0_6_0-pre/group-by_-_string_concat_using_+_op_(stream-_table)
@@ -59,20 +59,20 @@ Topologies:
       --> Aggregate-groupby
       <-- KSTREAM-MAPVALUES-0000000002
     Processor: Aggregate-groupby (stores: [])
-      --> KSTREAM-FILTER-0000000007
+      --> Aggregate-groupby-repartition-filter
       <-- KSTREAM-FILTER-0000000003
-    Processor: KSTREAM-FILTER-0000000007 (stores: [])
-      --> KSTREAM-SINK-0000000006
+    Processor: Aggregate-groupby-repartition-filter (stores: [])
+      --> Aggregate-groupby-repartition-sink
       <-- Aggregate-groupby
-    Sink: KSTREAM-SINK-0000000006 (topic: Aggregate-groupby-repartition)
-      <-- KSTREAM-FILTER-0000000007
+    Sink: Aggregate-groupby-repartition-sink (topic: Aggregate-groupby-repartition)
+      <-- Aggregate-groupby-repartition-filter
 
   Sub-topology: 1
-    Source: KSTREAM-SOURCE-0000000008 (topics: [Aggregate-groupby-repartition])
+    Source: Aggregate-groupby-repartition-source (topics: [Aggregate-groupby-repartition])
       --> KSTREAM-AGGREGATE-0000000005
     Processor: KSTREAM-AGGREGATE-0000000005 (stores: [Aggregate-aggregate])
       --> KTABLE-MAPVALUES-0000000009
-      <-- KSTREAM-SOURCE-0000000008
+      <-- Aggregate-groupby-repartition-source
     Processor: KTABLE-MAPVALUES-0000000009 (stores: [])
       --> KTABLE-MAPVALUES-0000000010
       <-- KSTREAM-AGGREGATE-0000000005

--- a/ksql-functional-tests/src/test/resources/expected_topology/0_6_0-pre/group-by_-_with_aggregate_arithmetic_(stream-_table)
+++ b/ksql-functional-tests/src/test/resources/expected_topology/0_6_0-pre/group-by_-_with_aggregate_arithmetic_(stream-_table)
@@ -59,20 +59,20 @@ Topologies:
       --> Aggregate-groupby
       <-- KSTREAM-MAPVALUES-0000000002
     Processor: Aggregate-groupby (stores: [])
-      --> KSTREAM-FILTER-0000000007
+      --> Aggregate-groupby-repartition-filter
       <-- KSTREAM-FILTER-0000000003
-    Processor: KSTREAM-FILTER-0000000007 (stores: [])
-      --> KSTREAM-SINK-0000000006
+    Processor: Aggregate-groupby-repartition-filter (stores: [])
+      --> Aggregate-groupby-repartition-sink
       <-- Aggregate-groupby
-    Sink: KSTREAM-SINK-0000000006 (topic: Aggregate-groupby-repartition)
-      <-- KSTREAM-FILTER-0000000007
+    Sink: Aggregate-groupby-repartition-sink (topic: Aggregate-groupby-repartition)
+      <-- Aggregate-groupby-repartition-filter
 
   Sub-topology: 1
-    Source: KSTREAM-SOURCE-0000000008 (topics: [Aggregate-groupby-repartition])
+    Source: Aggregate-groupby-repartition-source (topics: [Aggregate-groupby-repartition])
       --> KSTREAM-AGGREGATE-0000000005
     Processor: KSTREAM-AGGREGATE-0000000005 (stores: [Aggregate-aggregate])
       --> KTABLE-MAPVALUES-0000000009
-      <-- KSTREAM-SOURCE-0000000008
+      <-- Aggregate-groupby-repartition-source
     Processor: KTABLE-MAPVALUES-0000000009 (stores: [])
       --> KTABLE-MAPVALUES-0000000010
       <-- KSTREAM-AGGREGATE-0000000005

--- a/ksql-functional-tests/src/test/resources/expected_topology/0_6_0-pre/group-by_-_with_aggregate_arithmetic_involving_source_field_(stream-_table)
+++ b/ksql-functional-tests/src/test/resources/expected_topology/0_6_0-pre/group-by_-_with_aggregate_arithmetic_involving_source_field_(stream-_table)
@@ -59,20 +59,20 @@ Topologies:
       --> Aggregate-groupby
       <-- KSTREAM-MAPVALUES-0000000002
     Processor: Aggregate-groupby (stores: [])
-      --> KSTREAM-FILTER-0000000007
+      --> Aggregate-groupby-repartition-filter
       <-- KSTREAM-FILTER-0000000003
-    Processor: KSTREAM-FILTER-0000000007 (stores: [])
-      --> KSTREAM-SINK-0000000006
+    Processor: Aggregate-groupby-repartition-filter (stores: [])
+      --> Aggregate-groupby-repartition-sink
       <-- Aggregate-groupby
-    Sink: KSTREAM-SINK-0000000006 (topic: Aggregate-groupby-repartition)
-      <-- KSTREAM-FILTER-0000000007
+    Sink: Aggregate-groupby-repartition-sink (topic: Aggregate-groupby-repartition)
+      <-- Aggregate-groupby-repartition-filter
 
   Sub-topology: 1
-    Source: KSTREAM-SOURCE-0000000008 (topics: [Aggregate-groupby-repartition])
+    Source: Aggregate-groupby-repartition-source (topics: [Aggregate-groupby-repartition])
       --> KSTREAM-AGGREGATE-0000000005
     Processor: KSTREAM-AGGREGATE-0000000005 (stores: [Aggregate-aggregate])
       --> KTABLE-MAPVALUES-0000000009
-      <-- KSTREAM-SOURCE-0000000008
+      <-- Aggregate-groupby-repartition-source
     Processor: KTABLE-MAPVALUES-0000000009 (stores: [])
       --> KTABLE-MAPVALUES-0000000010
       <-- KSTREAM-AGGREGATE-0000000005

--- a/ksql-functional-tests/src/test/resources/expected_topology/0_6_0-pre/group-by_-_with_constant_having_(stream-table)
+++ b/ksql-functional-tests/src/test/resources/expected_topology/0_6_0-pre/group-by_-_with_constant_having_(stream-table)
@@ -59,20 +59,20 @@ Topologies:
       --> Aggregate-groupby
       <-- KSTREAM-MAPVALUES-0000000002
     Processor: Aggregate-groupby (stores: [])
-      --> KSTREAM-FILTER-0000000007
+      --> Aggregate-groupby-repartition-filter
       <-- KSTREAM-FILTER-0000000003
-    Processor: KSTREAM-FILTER-0000000007 (stores: [])
-      --> KSTREAM-SINK-0000000006
+    Processor: Aggregate-groupby-repartition-filter (stores: [])
+      --> Aggregate-groupby-repartition-sink
       <-- Aggregate-groupby
-    Sink: KSTREAM-SINK-0000000006 (topic: Aggregate-groupby-repartition)
-      <-- KSTREAM-FILTER-0000000007
+    Sink: Aggregate-groupby-repartition-sink (topic: Aggregate-groupby-repartition)
+      <-- Aggregate-groupby-repartition-filter
 
   Sub-topology: 1
-    Source: KSTREAM-SOURCE-0000000008 (topics: [Aggregate-groupby-repartition])
+    Source: Aggregate-groupby-repartition-source (topics: [Aggregate-groupby-repartition])
       --> KSTREAM-AGGREGATE-0000000005
     Processor: KSTREAM-AGGREGATE-0000000005 (stores: [Aggregate-aggregate])
       --> KTABLE-MAPVALUES-0000000009
-      <-- KSTREAM-SOURCE-0000000008
+      <-- Aggregate-groupby-repartition-source
     Processor: KTABLE-MAPVALUES-0000000009 (stores: [])
       --> KTABLE-FILTER-0000000010
       <-- KSTREAM-AGGREGATE-0000000005

--- a/ksql-functional-tests/src/test/resources/expected_topology/0_6_0-pre/group-by_-_with_groupings_(stream-_table)
+++ b/ksql-functional-tests/src/test/resources/expected_topology/0_6_0-pre/group-by_-_with_groupings_(stream-_table)
@@ -59,20 +59,20 @@ Topologies:
       --> Aggregate-groupby
       <-- KSTREAM-MAPVALUES-0000000002
     Processor: Aggregate-groupby (stores: [])
-      --> KSTREAM-FILTER-0000000007
+      --> Aggregate-groupby-repartition-filter
       <-- KSTREAM-FILTER-0000000003
-    Processor: KSTREAM-FILTER-0000000007 (stores: [])
-      --> KSTREAM-SINK-0000000006
+    Processor: Aggregate-groupby-repartition-filter (stores: [])
+      --> Aggregate-groupby-repartition-sink
       <-- Aggregate-groupby
-    Sink: KSTREAM-SINK-0000000006 (topic: Aggregate-groupby-repartition)
-      <-- KSTREAM-FILTER-0000000007
+    Sink: Aggregate-groupby-repartition-sink (topic: Aggregate-groupby-repartition)
+      <-- Aggregate-groupby-repartition-filter
 
   Sub-topology: 1
-    Source: KSTREAM-SOURCE-0000000008 (topics: [Aggregate-groupby-repartition])
+    Source: Aggregate-groupby-repartition-source (topics: [Aggregate-groupby-repartition])
       --> KSTREAM-AGGREGATE-0000000005
     Processor: KSTREAM-AGGREGATE-0000000005 (stores: [Aggregate-aggregate])
       --> KTABLE-MAPVALUES-0000000009
-      <-- KSTREAM-SOURCE-0000000008
+      <-- Aggregate-groupby-repartition-source
     Processor: KTABLE-MAPVALUES-0000000009 (stores: [])
       --> KTABLE-MAPVALUES-0000000010
       <-- KSTREAM-AGGREGATE-0000000005

--- a/ksql-functional-tests/src/test/resources/expected_topology/0_6_0-pre/group-by_-_with_having_expression_on_non-group-by_field_(stream-_table)
+++ b/ksql-functional-tests/src/test/resources/expected_topology/0_6_0-pre/group-by_-_with_having_expression_on_non-group-by_field_(stream-_table)
@@ -59,20 +59,20 @@ Topologies:
       --> Aggregate-groupby
       <-- KSTREAM-MAPVALUES-0000000002
     Processor: Aggregate-groupby (stores: [])
-      --> KSTREAM-FILTER-0000000007
+      --> Aggregate-groupby-repartition-filter
       <-- KSTREAM-FILTER-0000000003
-    Processor: KSTREAM-FILTER-0000000007 (stores: [])
-      --> KSTREAM-SINK-0000000006
+    Processor: Aggregate-groupby-repartition-filter (stores: [])
+      --> Aggregate-groupby-repartition-sink
       <-- Aggregate-groupby
-    Sink: KSTREAM-SINK-0000000006 (topic: Aggregate-groupby-repartition)
-      <-- KSTREAM-FILTER-0000000007
+    Sink: Aggregate-groupby-repartition-sink (topic: Aggregate-groupby-repartition)
+      <-- Aggregate-groupby-repartition-filter
 
   Sub-topology: 1
-    Source: KSTREAM-SOURCE-0000000008 (topics: [Aggregate-groupby-repartition])
+    Source: Aggregate-groupby-repartition-source (topics: [Aggregate-groupby-repartition])
       --> KSTREAM-AGGREGATE-0000000005
     Processor: KSTREAM-AGGREGATE-0000000005 (stores: [Aggregate-aggregate])
       --> KTABLE-MAPVALUES-0000000009
-      <-- KSTREAM-SOURCE-0000000008
+      <-- Aggregate-groupby-repartition-source
     Processor: KTABLE-MAPVALUES-0000000009 (stores: [])
       --> KTABLE-FILTER-0000000010
       <-- KSTREAM-AGGREGATE-0000000005

--- a/ksql-functional-tests/src/test/resources/expected_topology/0_6_0-pre/group-by_-_with_multiple_having_expressions_(stream-_table)
+++ b/ksql-functional-tests/src/test/resources/expected_topology/0_6_0-pre/group-by_-_with_multiple_having_expressions_(stream-_table)
@@ -59,20 +59,20 @@ Topologies:
       --> Aggregate-groupby
       <-- KSTREAM-MAPVALUES-0000000002
     Processor: Aggregate-groupby (stores: [])
-      --> KSTREAM-FILTER-0000000007
+      --> Aggregate-groupby-repartition-filter
       <-- KSTREAM-FILTER-0000000003
-    Processor: KSTREAM-FILTER-0000000007 (stores: [])
-      --> KSTREAM-SINK-0000000006
+    Processor: Aggregate-groupby-repartition-filter (stores: [])
+      --> Aggregate-groupby-repartition-sink
       <-- Aggregate-groupby
-    Sink: KSTREAM-SINK-0000000006 (topic: Aggregate-groupby-repartition)
-      <-- KSTREAM-FILTER-0000000007
+    Sink: Aggregate-groupby-repartition-sink (topic: Aggregate-groupby-repartition)
+      <-- Aggregate-groupby-repartition-filter
 
   Sub-topology: 1
-    Source: KSTREAM-SOURCE-0000000008 (topics: [Aggregate-groupby-repartition])
+    Source: Aggregate-groupby-repartition-source (topics: [Aggregate-groupby-repartition])
       --> KSTREAM-AGGREGATE-0000000005
     Processor: KSTREAM-AGGREGATE-0000000005 (stores: [Aggregate-aggregate])
       --> KTABLE-MAPVALUES-0000000009
-      <-- KSTREAM-SOURCE-0000000008
+      <-- Aggregate-groupby-repartition-source
     Processor: KTABLE-MAPVALUES-0000000009 (stores: [])
       --> KTABLE-FILTER-0000000010
       <-- KSTREAM-AGGREGATE-0000000005

--- a/ksql-functional-tests/src/test/resources/expected_topology/0_6_0-pre/joins_-_stream_stream_left_join_-_both_join_keys_in_projection
+++ b/ksql-functional-tests/src/test/resources/expected_topology/0_6_0-pre/joins_-_stream_stream_left_join_-_both_join_keys_in_projection
@@ -60,13 +60,13 @@ Topologies:
       --> KSTREAM-MAPVALUES-0000000004
       <-- KSTREAM-FILTER-0000000002
     Processor: KSTREAM-MAPVALUES-0000000004 (stores: [])
-      --> KSTREAM-FILTER-0000000011
+      --> Join-left-repartition-filter
       <-- KSTREAM-KEY-SELECT-0000000003
-    Processor: KSTREAM-FILTER-0000000011 (stores: [])
-      --> KSTREAM-SINK-0000000010
+    Processor: Join-left-repartition-filter (stores: [])
+      --> Join-left-repartition-sink
       <-- KSTREAM-MAPVALUES-0000000004
-    Sink: KSTREAM-SINK-0000000010 (topic: Join-left-repartition)
-      <-- KSTREAM-FILTER-0000000011
+    Sink: Join-left-repartition-sink (topic: Join-left-repartition)
+      <-- Join-left-repartition-filter
 
   Sub-topology: 1
     Source: KSTREAM-SOURCE-0000000005 (topics: [right_topic])
@@ -81,25 +81,25 @@ Topologies:
       --> KSTREAM-MAPVALUES-0000000009
       <-- KSTREAM-FILTER-0000000007
     Processor: KSTREAM-MAPVALUES-0000000009 (stores: [])
-      --> KSTREAM-FILTER-0000000014
+      --> Join-right-repartition-filter
       <-- KSTREAM-KEY-SELECT-0000000008
-    Processor: KSTREAM-FILTER-0000000014 (stores: [])
-      --> KSTREAM-SINK-0000000013
+    Processor: Join-right-repartition-filter (stores: [])
+      --> Join-right-repartition-sink
       <-- KSTREAM-MAPVALUES-0000000009
-    Sink: KSTREAM-SINK-0000000013 (topic: Join-right-repartition)
-      <-- KSTREAM-FILTER-0000000014
+    Sink: Join-right-repartition-sink (topic: Join-right-repartition)
+      <-- Join-right-repartition-filter
 
   Sub-topology: 2
-    Source: KSTREAM-SOURCE-0000000012 (topics: [Join-left-repartition])
+    Source: Join-left-repartition-source (topics: [Join-left-repartition])
       --> Join-this-windowed
-    Source: KSTREAM-SOURCE-0000000015 (topics: [Join-right-repartition])
+    Source: Join-right-repartition-source (topics: [Join-right-repartition])
       --> Join-other-windowed
     Processor: Join-other-windowed (stores: [KSTREAM-OUTEROTHER-0000000019-store])
       --> Join-outer-other-join
-      <-- KSTREAM-SOURCE-0000000015
+      <-- Join-right-repartition-source
     Processor: Join-this-windowed (stores: [KSTREAM-JOINTHIS-0000000018-store])
       --> Join-this-join
-      <-- KSTREAM-SOURCE-0000000012
+      <-- Join-left-repartition-source
     Processor: Join-outer-other-join (stores: [KSTREAM-JOINTHIS-0000000018-store])
       --> Join-merge
       <-- Join-other-windowed

--- a/ksql-functional-tests/src/test/resources/expected_topology/0_6_0-pre/joins_-_stream_stream_left_join_-_rekey
+++ b/ksql-functional-tests/src/test/resources/expected_topology/0_6_0-pre/joins_-_stream_stream_left_join_-_rekey
@@ -60,13 +60,13 @@ Topologies:
       --> KSTREAM-MAPVALUES-0000000004
       <-- KSTREAM-FILTER-0000000002
     Processor: KSTREAM-MAPVALUES-0000000004 (stores: [])
-      --> KSTREAM-FILTER-0000000011
+      --> Join-left-repartition-filter
       <-- KSTREAM-KEY-SELECT-0000000003
-    Processor: KSTREAM-FILTER-0000000011 (stores: [])
-      --> KSTREAM-SINK-0000000010
+    Processor: Join-left-repartition-filter (stores: [])
+      --> Join-left-repartition-sink
       <-- KSTREAM-MAPVALUES-0000000004
-    Sink: KSTREAM-SINK-0000000010 (topic: Join-left-repartition)
-      <-- KSTREAM-FILTER-0000000011
+    Sink: Join-left-repartition-sink (topic: Join-left-repartition)
+      <-- Join-left-repartition-filter
 
   Sub-topology: 1
     Source: KSTREAM-SOURCE-0000000005 (topics: [right_topic])
@@ -81,25 +81,25 @@ Topologies:
       --> KSTREAM-MAPVALUES-0000000009
       <-- KSTREAM-FILTER-0000000007
     Processor: KSTREAM-MAPVALUES-0000000009 (stores: [])
-      --> KSTREAM-FILTER-0000000014
+      --> Join-right-repartition-filter
       <-- KSTREAM-KEY-SELECT-0000000008
-    Processor: KSTREAM-FILTER-0000000014 (stores: [])
-      --> KSTREAM-SINK-0000000013
+    Processor: Join-right-repartition-filter (stores: [])
+      --> Join-right-repartition-sink
       <-- KSTREAM-MAPVALUES-0000000009
-    Sink: KSTREAM-SINK-0000000013 (topic: Join-right-repartition)
-      <-- KSTREAM-FILTER-0000000014
+    Sink: Join-right-repartition-sink (topic: Join-right-repartition)
+      <-- Join-right-repartition-filter
 
   Sub-topology: 2
-    Source: KSTREAM-SOURCE-0000000012 (topics: [Join-left-repartition])
+    Source: Join-left-repartition-source (topics: [Join-left-repartition])
       --> Join-this-windowed
-    Source: KSTREAM-SOURCE-0000000015 (topics: [Join-right-repartition])
+    Source: Join-right-repartition-source (topics: [Join-right-repartition])
       --> Join-other-windowed
     Processor: Join-other-windowed (stores: [KSTREAM-OUTEROTHER-0000000019-store])
       --> Join-outer-other-join
-      <-- KSTREAM-SOURCE-0000000015
+      <-- Join-right-repartition-source
     Processor: Join-this-windowed (stores: [KSTREAM-JOINTHIS-0000000018-store])
       --> Join-this-join
-      <-- KSTREAM-SOURCE-0000000012
+      <-- Join-left-repartition-source
     Processor: Join-outer-other-join (stores: [KSTREAM-JOINTHIS-0000000018-store])
       --> Join-merge
       <-- Join-other-windowed

--- a/ksql-functional-tests/src/test/resources/expected_topology/0_6_0-pre/joins_-_stream_stream_left_join_-_right_join_key_in_projection
+++ b/ksql-functional-tests/src/test/resources/expected_topology/0_6_0-pre/joins_-_stream_stream_left_join_-_right_join_key_in_projection
@@ -60,13 +60,13 @@ Topologies:
       --> KSTREAM-MAPVALUES-0000000004
       <-- KSTREAM-FILTER-0000000002
     Processor: KSTREAM-MAPVALUES-0000000004 (stores: [])
-      --> KSTREAM-FILTER-0000000011
+      --> Join-left-repartition-filter
       <-- KSTREAM-KEY-SELECT-0000000003
-    Processor: KSTREAM-FILTER-0000000011 (stores: [])
-      --> KSTREAM-SINK-0000000010
+    Processor: Join-left-repartition-filter (stores: [])
+      --> Join-left-repartition-sink
       <-- KSTREAM-MAPVALUES-0000000004
-    Sink: KSTREAM-SINK-0000000010 (topic: Join-left-repartition)
-      <-- KSTREAM-FILTER-0000000011
+    Sink: Join-left-repartition-sink (topic: Join-left-repartition)
+      <-- Join-left-repartition-filter
 
   Sub-topology: 1
     Source: KSTREAM-SOURCE-0000000005 (topics: [right_topic])
@@ -81,25 +81,25 @@ Topologies:
       --> KSTREAM-MAPVALUES-0000000009
       <-- KSTREAM-FILTER-0000000007
     Processor: KSTREAM-MAPVALUES-0000000009 (stores: [])
-      --> KSTREAM-FILTER-0000000014
+      --> Join-right-repartition-filter
       <-- KSTREAM-KEY-SELECT-0000000008
-    Processor: KSTREAM-FILTER-0000000014 (stores: [])
-      --> KSTREAM-SINK-0000000013
+    Processor: Join-right-repartition-filter (stores: [])
+      --> Join-right-repartition-sink
       <-- KSTREAM-MAPVALUES-0000000009
-    Sink: KSTREAM-SINK-0000000013 (topic: Join-right-repartition)
-      <-- KSTREAM-FILTER-0000000014
+    Sink: Join-right-repartition-sink (topic: Join-right-repartition)
+      <-- Join-right-repartition-filter
 
   Sub-topology: 2
-    Source: KSTREAM-SOURCE-0000000012 (topics: [Join-left-repartition])
+    Source: Join-left-repartition-source (topics: [Join-left-repartition])
       --> Join-this-windowed
-    Source: KSTREAM-SOURCE-0000000015 (topics: [Join-right-repartition])
+    Source: Join-right-repartition-source (topics: [Join-right-repartition])
       --> Join-other-windowed
     Processor: Join-other-windowed (stores: [KSTREAM-OUTEROTHER-0000000019-store])
       --> Join-outer-other-join
-      <-- KSTREAM-SOURCE-0000000015
+      <-- Join-right-repartition-source
     Processor: Join-this-windowed (stores: [KSTREAM-JOINTHIS-0000000018-store])
       --> Join-this-join
-      <-- KSTREAM-SOURCE-0000000012
+      <-- Join-left-repartition-source
     Processor: Join-outer-other-join (stores: [KSTREAM-JOINTHIS-0000000018-store])
       --> Join-merge
       <-- Join-other-windowed

--- a/ksql-functional-tests/src/test/resources/expected_topology/0_6_0-pre/joins_-_stream_to_table_when_neither_have_key_field_and_joining_by_table_ROWKEY
+++ b/ksql-functional-tests/src/test/resources/expected_topology/0_6_0-pre/joins_-_stream_to_table_when_neither_have_key_field_and_joining_by_table_ROWKEY
@@ -48,11 +48,11 @@ CSAS_OUTPUT_0.OUTPUT = STRUCT<S_ID BIGINT, NAME VARCHAR> NOT NULL
 SCHEMAS_END
 Topologies:
    Sub-topology: 0
-    Source: KSTREAM-SOURCE-0000000011 (topics: [Join-repartition])
+    Source: Join-repartition-source (topics: [Join-repartition])
       --> Join
     Processor: Join (stores: [KafkaTopic_Right-reduce])
       --> KSTREAM-MAPVALUES-0000000013
-      <-- KSTREAM-SOURCE-0000000011
+      <-- Join-repartition-source
     Source: KSTREAM-SOURCE-0000000000 (topics: [NO_KEY])
       --> KSTREAM-TRANSFORMVALUES-0000000001
     Processor: KSTREAM-MAPVALUES-0000000013 (stores: [])
@@ -86,11 +86,11 @@ Topologies:
       --> KSTREAM-MAPVALUES-0000000008
       <-- KSTREAM-FILTER-0000000006
     Processor: KSTREAM-MAPVALUES-0000000008 (stores: [])
-      --> KSTREAM-FILTER-0000000010
+      --> Join-repartition-filter
       <-- KSTREAM-KEY-SELECT-0000000007
-    Processor: KSTREAM-FILTER-0000000010 (stores: [])
-      --> KSTREAM-SINK-0000000009
+    Processor: Join-repartition-filter (stores: [])
+      --> Join-repartition-sink
       <-- KSTREAM-MAPVALUES-0000000008
-    Sink: KSTREAM-SINK-0000000009 (topic: Join-repartition)
-      <-- KSTREAM-FILTER-0000000010
+    Sink: Join-repartition-sink (topic: Join-repartition)
+      <-- Join-repartition-filter
 

--- a/ksql-functional-tests/src/test/resources/expected_topology/0_6_0-pre/key-field_-_stream___initially_null___group_by_(-)___key_in_value___aliasing
+++ b/ksql-functional-tests/src/test/resources/expected_topology/0_6_0-pre/key-field_-_stream___initially_null___group_by_(-)___key_in_value___aliasing
@@ -59,20 +59,20 @@ Topologies:
       --> Aggregate-groupby
       <-- KSTREAM-MAPVALUES-0000000002
     Processor: Aggregate-groupby (stores: [])
-      --> KSTREAM-FILTER-0000000007
+      --> Aggregate-groupby-repartition-filter
       <-- KSTREAM-FILTER-0000000003
-    Processor: KSTREAM-FILTER-0000000007 (stores: [])
-      --> KSTREAM-SINK-0000000006
+    Processor: Aggregate-groupby-repartition-filter (stores: [])
+      --> Aggregate-groupby-repartition-sink
       <-- Aggregate-groupby
-    Sink: KSTREAM-SINK-0000000006 (topic: Aggregate-groupby-repartition)
-      <-- KSTREAM-FILTER-0000000007
+    Sink: Aggregate-groupby-repartition-sink (topic: Aggregate-groupby-repartition)
+      <-- Aggregate-groupby-repartition-filter
 
   Sub-topology: 1
-    Source: KSTREAM-SOURCE-0000000008 (topics: [Aggregate-groupby-repartition])
+    Source: Aggregate-groupby-repartition-source (topics: [Aggregate-groupby-repartition])
       --> KSTREAM-AGGREGATE-0000000005
     Processor: KSTREAM-AGGREGATE-0000000005 (stores: [Aggregate-aggregate])
       --> KTABLE-MAPVALUES-0000000009
-      <-- KSTREAM-SOURCE-0000000008
+      <-- Aggregate-groupby-repartition-source
     Processor: KTABLE-MAPVALUES-0000000009 (stores: [])
       --> KTABLE-MAPVALUES-0000000010
       <-- KSTREAM-AGGREGATE-0000000005

--- a/ksql-functional-tests/src/test/resources/expected_topology/0_6_0-pre/key-field_-_stream___initially_null___group_by_(-)___key_in_value___no_aliasing
+++ b/ksql-functional-tests/src/test/resources/expected_topology/0_6_0-pre/key-field_-_stream___initially_null___group_by_(-)___key_in_value___no_aliasing
@@ -59,20 +59,20 @@ Topologies:
       --> Aggregate-groupby
       <-- KSTREAM-MAPVALUES-0000000002
     Processor: Aggregate-groupby (stores: [])
-      --> KSTREAM-FILTER-0000000007
+      --> Aggregate-groupby-repartition-filter
       <-- KSTREAM-FILTER-0000000003
-    Processor: KSTREAM-FILTER-0000000007 (stores: [])
-      --> KSTREAM-SINK-0000000006
+    Processor: Aggregate-groupby-repartition-filter (stores: [])
+      --> Aggregate-groupby-repartition-sink
       <-- Aggregate-groupby
-    Sink: KSTREAM-SINK-0000000006 (topic: Aggregate-groupby-repartition)
-      <-- KSTREAM-FILTER-0000000007
+    Sink: Aggregate-groupby-repartition-sink (topic: Aggregate-groupby-repartition)
+      <-- Aggregate-groupby-repartition-filter
 
   Sub-topology: 1
-    Source: KSTREAM-SOURCE-0000000008 (topics: [Aggregate-groupby-repartition])
+    Source: Aggregate-groupby-repartition-source (topics: [Aggregate-groupby-repartition])
       --> KSTREAM-AGGREGATE-0000000005
     Processor: KSTREAM-AGGREGATE-0000000005 (stores: [Aggregate-aggregate])
       --> KTABLE-MAPVALUES-0000000009
-      <-- KSTREAM-SOURCE-0000000008
+      <-- Aggregate-groupby-repartition-source
     Processor: KTABLE-MAPVALUES-0000000009 (stores: [])
       --> KTABLE-MAPVALUES-0000000010
       <-- KSTREAM-AGGREGATE-0000000005

--- a/ksql-functional-tests/src/test/resources/expected_topology/0_6_0-pre/key-field_-_stream___initially_null___group_by_(-)___key_not_in_value___-
+++ b/ksql-functional-tests/src/test/resources/expected_topology/0_6_0-pre/key-field_-_stream___initially_null___group_by_(-)___key_not_in_value___-
@@ -59,20 +59,20 @@ Topologies:
       --> Aggregate-groupby
       <-- KSTREAM-MAPVALUES-0000000002
     Processor: Aggregate-groupby (stores: [])
-      --> KSTREAM-FILTER-0000000007
+      --> Aggregate-groupby-repartition-filter
       <-- KSTREAM-FILTER-0000000003
-    Processor: KSTREAM-FILTER-0000000007 (stores: [])
-      --> KSTREAM-SINK-0000000006
+    Processor: Aggregate-groupby-repartition-filter (stores: [])
+      --> Aggregate-groupby-repartition-sink
       <-- Aggregate-groupby
-    Sink: KSTREAM-SINK-0000000006 (topic: Aggregate-groupby-repartition)
-      <-- KSTREAM-FILTER-0000000007
+    Sink: Aggregate-groupby-repartition-sink (topic: Aggregate-groupby-repartition)
+      <-- Aggregate-groupby-repartition-filter
 
   Sub-topology: 1
-    Source: KSTREAM-SOURCE-0000000008 (topics: [Aggregate-groupby-repartition])
+    Source: Aggregate-groupby-repartition-source (topics: [Aggregate-groupby-repartition])
       --> KSTREAM-AGGREGATE-0000000005
     Processor: KSTREAM-AGGREGATE-0000000005 (stores: [Aggregate-aggregate])
       --> KTABLE-MAPVALUES-0000000009
-      <-- KSTREAM-SOURCE-0000000008
+      <-- Aggregate-groupby-repartition-source
     Processor: KTABLE-MAPVALUES-0000000009 (stores: [])
       --> KTABLE-MAPVALUES-0000000010
       <-- KSTREAM-AGGREGATE-0000000005

--- a/ksql-functional-tests/src/test/resources/expected_topology/0_6_0-pre/key-field_-_stream___initially_set___group_by_(different)___key_in_value___aliasing
+++ b/ksql-functional-tests/src/test/resources/expected_topology/0_6_0-pre/key-field_-_stream___initially_set___group_by_(different)___key_in_value___aliasing
@@ -59,20 +59,20 @@ Topologies:
       --> Aggregate-groupby
       <-- KSTREAM-MAPVALUES-0000000002
     Processor: Aggregate-groupby (stores: [])
-      --> KSTREAM-FILTER-0000000007
+      --> Aggregate-groupby-repartition-filter
       <-- KSTREAM-FILTER-0000000003
-    Processor: KSTREAM-FILTER-0000000007 (stores: [])
-      --> KSTREAM-SINK-0000000006
+    Processor: Aggregate-groupby-repartition-filter (stores: [])
+      --> Aggregate-groupby-repartition-sink
       <-- Aggregate-groupby
-    Sink: KSTREAM-SINK-0000000006 (topic: Aggregate-groupby-repartition)
-      <-- KSTREAM-FILTER-0000000007
+    Sink: Aggregate-groupby-repartition-sink (topic: Aggregate-groupby-repartition)
+      <-- Aggregate-groupby-repartition-filter
 
   Sub-topology: 1
-    Source: KSTREAM-SOURCE-0000000008 (topics: [Aggregate-groupby-repartition])
+    Source: Aggregate-groupby-repartition-source (topics: [Aggregate-groupby-repartition])
       --> KSTREAM-AGGREGATE-0000000005
     Processor: KSTREAM-AGGREGATE-0000000005 (stores: [Aggregate-aggregate])
       --> KTABLE-MAPVALUES-0000000009
-      <-- KSTREAM-SOURCE-0000000008
+      <-- Aggregate-groupby-repartition-source
     Processor: KTABLE-MAPVALUES-0000000009 (stores: [])
       --> KTABLE-MAPVALUES-0000000010
       <-- KSTREAM-AGGREGATE-0000000005

--- a/ksql-functional-tests/src/test/resources/expected_topology/0_6_0-pre/key-field_-_stream___initially_set___group_by_(different)___key_in_value___no_aliasing
+++ b/ksql-functional-tests/src/test/resources/expected_topology/0_6_0-pre/key-field_-_stream___initially_set___group_by_(different)___key_in_value___no_aliasing
@@ -59,20 +59,20 @@ Topologies:
       --> Aggregate-groupby
       <-- KSTREAM-MAPVALUES-0000000002
     Processor: Aggregate-groupby (stores: [])
-      --> KSTREAM-FILTER-0000000007
+      --> Aggregate-groupby-repartition-filter
       <-- KSTREAM-FILTER-0000000003
-    Processor: KSTREAM-FILTER-0000000007 (stores: [])
-      --> KSTREAM-SINK-0000000006
+    Processor: Aggregate-groupby-repartition-filter (stores: [])
+      --> Aggregate-groupby-repartition-sink
       <-- Aggregate-groupby
-    Sink: KSTREAM-SINK-0000000006 (topic: Aggregate-groupby-repartition)
-      <-- KSTREAM-FILTER-0000000007
+    Sink: Aggregate-groupby-repartition-sink (topic: Aggregate-groupby-repartition)
+      <-- Aggregate-groupby-repartition-filter
 
   Sub-topology: 1
-    Source: KSTREAM-SOURCE-0000000008 (topics: [Aggregate-groupby-repartition])
+    Source: Aggregate-groupby-repartition-source (topics: [Aggregate-groupby-repartition])
       --> KSTREAM-AGGREGATE-0000000005
     Processor: KSTREAM-AGGREGATE-0000000005 (stores: [Aggregate-aggregate])
       --> KTABLE-MAPVALUES-0000000009
-      <-- KSTREAM-SOURCE-0000000008
+      <-- Aggregate-groupby-repartition-source
     Processor: KTABLE-MAPVALUES-0000000009 (stores: [])
       --> KTABLE-MAPVALUES-0000000010
       <-- KSTREAM-AGGREGATE-0000000005

--- a/ksql-functional-tests/src/test/resources/expected_topology/0_6_0-pre/key-field_-_stream___initially_set___group_by_(different)___key_not_in_value___-
+++ b/ksql-functional-tests/src/test/resources/expected_topology/0_6_0-pre/key-field_-_stream___initially_set___group_by_(different)___key_not_in_value___-
@@ -59,20 +59,20 @@ Topologies:
       --> Aggregate-groupby
       <-- KSTREAM-MAPVALUES-0000000002
     Processor: Aggregate-groupby (stores: [])
-      --> KSTREAM-FILTER-0000000007
+      --> Aggregate-groupby-repartition-filter
       <-- KSTREAM-FILTER-0000000003
-    Processor: KSTREAM-FILTER-0000000007 (stores: [])
-      --> KSTREAM-SINK-0000000006
+    Processor: Aggregate-groupby-repartition-filter (stores: [])
+      --> Aggregate-groupby-repartition-sink
       <-- Aggregate-groupby
-    Sink: KSTREAM-SINK-0000000006 (topic: Aggregate-groupby-repartition)
-      <-- KSTREAM-FILTER-0000000007
+    Sink: Aggregate-groupby-repartition-sink (topic: Aggregate-groupby-repartition)
+      <-- Aggregate-groupby-repartition-filter
 
   Sub-topology: 1
-    Source: KSTREAM-SOURCE-0000000008 (topics: [Aggregate-groupby-repartition])
+    Source: Aggregate-groupby-repartition-source (topics: [Aggregate-groupby-repartition])
       --> KSTREAM-AGGREGATE-0000000005
     Processor: KSTREAM-AGGREGATE-0000000005 (stores: [Aggregate-aggregate])
       --> KTABLE-MAPVALUES-0000000009
-      <-- KSTREAM-SOURCE-0000000008
+      <-- Aggregate-groupby-repartition-source
     Processor: KTABLE-MAPVALUES-0000000009 (stores: [])
       --> KTABLE-MAPVALUES-0000000010
       <-- KSTREAM-AGGREGATE-0000000005

--- a/ksql-functional-tests/src/test/resources/expected_topology/0_6_0-pre/key-field_-_stream___initially_set___group_by_expression___key_in_value___no_aliasing
+++ b/ksql-functional-tests/src/test/resources/expected_topology/0_6_0-pre/key-field_-_stream___initially_set___group_by_expression___key_in_value___no_aliasing
@@ -59,20 +59,20 @@ Topologies:
       --> Aggregate-groupby
       <-- KSTREAM-MAPVALUES-0000000002
     Processor: Aggregate-groupby (stores: [])
-      --> KSTREAM-FILTER-0000000007
+      --> Aggregate-groupby-repartition-filter
       <-- KSTREAM-FILTER-0000000003
-    Processor: KSTREAM-FILTER-0000000007 (stores: [])
-      --> KSTREAM-SINK-0000000006
+    Processor: Aggregate-groupby-repartition-filter (stores: [])
+      --> Aggregate-groupby-repartition-sink
       <-- Aggregate-groupby
-    Sink: KSTREAM-SINK-0000000006 (topic: Aggregate-groupby-repartition)
-      <-- KSTREAM-FILTER-0000000007
+    Sink: Aggregate-groupby-repartition-sink (topic: Aggregate-groupby-repartition)
+      <-- Aggregate-groupby-repartition-filter
 
   Sub-topology: 1
-    Source: KSTREAM-SOURCE-0000000008 (topics: [Aggregate-groupby-repartition])
+    Source: Aggregate-groupby-repartition-source (topics: [Aggregate-groupby-repartition])
       --> KSTREAM-AGGREGATE-0000000005
     Processor: KSTREAM-AGGREGATE-0000000005 (stores: [Aggregate-aggregate])
       --> KTABLE-MAPVALUES-0000000009
-      <-- KSTREAM-SOURCE-0000000008
+      <-- Aggregate-groupby-repartition-source
     Processor: KTABLE-MAPVALUES-0000000009 (stores: [])
       --> KTABLE-MAPVALUES-0000000010
       <-- KSTREAM-AGGREGATE-0000000005

--- a/ksql-functional-tests/src/test/resources/expected_topology/0_6_0-pre/key-field_-_stream___initially_set___group_by_multiple___key_in_value___no_aliasing
+++ b/ksql-functional-tests/src/test/resources/expected_topology/0_6_0-pre/key-field_-_stream___initially_set___group_by_multiple___key_in_value___no_aliasing
@@ -59,20 +59,20 @@ Topologies:
       --> Aggregate-groupby
       <-- KSTREAM-MAPVALUES-0000000002
     Processor: Aggregate-groupby (stores: [])
-      --> KSTREAM-FILTER-0000000007
+      --> Aggregate-groupby-repartition-filter
       <-- KSTREAM-FILTER-0000000003
-    Processor: KSTREAM-FILTER-0000000007 (stores: [])
-      --> KSTREAM-SINK-0000000006
+    Processor: Aggregate-groupby-repartition-filter (stores: [])
+      --> Aggregate-groupby-repartition-sink
       <-- Aggregate-groupby
-    Sink: KSTREAM-SINK-0000000006 (topic: Aggregate-groupby-repartition)
-      <-- KSTREAM-FILTER-0000000007
+    Sink: Aggregate-groupby-repartition-sink (topic: Aggregate-groupby-repartition)
+      <-- Aggregate-groupby-repartition-filter
 
   Sub-topology: 1
-    Source: KSTREAM-SOURCE-0000000008 (topics: [Aggregate-groupby-repartition])
+    Source: Aggregate-groupby-repartition-source (topics: [Aggregate-groupby-repartition])
       --> KSTREAM-AGGREGATE-0000000005
     Processor: KSTREAM-AGGREGATE-0000000005 (stores: [Aggregate-aggregate])
       --> KTABLE-MAPVALUES-0000000009
-      <-- KSTREAM-SOURCE-0000000008
+      <-- Aggregate-groupby-repartition-source
     Processor: KTABLE-MAPVALUES-0000000009 (stores: [])
       --> KTABLE-MAPVALUES-0000000010
       <-- KSTREAM-AGGREGATE-0000000005

--- a/ksql-functional-tests/src/test/resources/expected_topology/0_6_0-pre/quoted-identifiers_-_joins_using_fields_that_require_quotes
+++ b/ksql-functional-tests/src/test/resources/expected_topology/0_6_0-pre/quoted-identifiers_-_joins_using_fields_that_require_quotes
@@ -48,11 +48,11 @@ CSAS_JOINED_0.JOINED = STRUCT<field! VARCHAR> NOT NULL
 SCHEMAS_END
 Topologies:
    Sub-topology: 0
-    Source: KSTREAM-SOURCE-0000000011 (topics: [Join-repartition])
+    Source: Join-repartition-source (topics: [Join-repartition])
       --> Join
     Processor: Join (stores: [KafkaTopic_Right-reduce])
       --> KSTREAM-MAPVALUES-0000000013
-      <-- KSTREAM-SOURCE-0000000011
+      <-- Join-repartition-source
     Source: KSTREAM-SOURCE-0000000000 (topics: [right_topic])
       --> KSTREAM-TRANSFORMVALUES-0000000001
     Processor: KSTREAM-MAPVALUES-0000000013 (stores: [])
@@ -86,11 +86,11 @@ Topologies:
       --> KSTREAM-MAPVALUES-0000000008
       <-- KSTREAM-FILTER-0000000006
     Processor: KSTREAM-MAPVALUES-0000000008 (stores: [])
-      --> KSTREAM-FILTER-0000000010
+      --> Join-repartition-filter
       <-- KSTREAM-KEY-SELECT-0000000007
-    Processor: KSTREAM-FILTER-0000000010 (stores: [])
-      --> KSTREAM-SINK-0000000009
+    Processor: Join-repartition-filter (stores: [])
+      --> Join-repartition-sink
       <-- KSTREAM-MAPVALUES-0000000008
-    Sink: KSTREAM-SINK-0000000009 (topic: Join-repartition)
-      <-- KSTREAM-FILTER-0000000010
+    Sink: Join-repartition-sink (topic: Join-repartition)
+      <-- Join-repartition-filter
 

--- a/ksql-functional-tests/src/test/resources/expected_topology/0_6_0-pre/substring_-_in_group_by
+++ b/ksql-functional-tests/src/test/resources/expected_topology/0_6_0-pre/substring_-_in_group_by
@@ -59,20 +59,20 @@ Topologies:
       --> Aggregate-groupby
       <-- KSTREAM-MAPVALUES-0000000002
     Processor: Aggregate-groupby (stores: [])
-      --> KSTREAM-FILTER-0000000007
+      --> Aggregate-groupby-repartition-filter
       <-- KSTREAM-FILTER-0000000003
-    Processor: KSTREAM-FILTER-0000000007 (stores: [])
-      --> KSTREAM-SINK-0000000006
+    Processor: Aggregate-groupby-repartition-filter (stores: [])
+      --> Aggregate-groupby-repartition-sink
       <-- Aggregate-groupby
-    Sink: KSTREAM-SINK-0000000006 (topic: Aggregate-groupby-repartition)
-      <-- KSTREAM-FILTER-0000000007
+    Sink: Aggregate-groupby-repartition-sink (topic: Aggregate-groupby-repartition)
+      <-- Aggregate-groupby-repartition-filter
 
   Sub-topology: 1
-    Source: KSTREAM-SOURCE-0000000008 (topics: [Aggregate-groupby-repartition])
+    Source: Aggregate-groupby-repartition-source (topics: [Aggregate-groupby-repartition])
       --> KSTREAM-AGGREGATE-0000000005
     Processor: KSTREAM-AGGREGATE-0000000005 (stores: [Aggregate-aggregate])
       --> KTABLE-MAPVALUES-0000000009
-      <-- KSTREAM-SOURCE-0000000008
+      <-- Aggregate-groupby-repartition-source
     Processor: KTABLE-MAPVALUES-0000000009 (stores: [])
       --> KTABLE-MAPVALUES-0000000010
       <-- KSTREAM-AGGREGATE-0000000005

--- a/ksql-functional-tests/src/test/resources/expected_topology/0_6_0-pre/test-custom-udaf_-_test_udaf_with_struct
+++ b/ksql-functional-tests/src/test/resources/expected_topology/0_6_0-pre/test-custom-udaf_-_test_udaf_with_struct
@@ -59,20 +59,20 @@ Topologies:
       --> Aggregate-groupby
       <-- KSTREAM-MAPVALUES-0000000002
     Processor: Aggregate-groupby (stores: [])
-      --> KSTREAM-FILTER-0000000007
+      --> Aggregate-groupby-repartition-filter
       <-- KSTREAM-FILTER-0000000003
-    Processor: KSTREAM-FILTER-0000000007 (stores: [])
-      --> KSTREAM-SINK-0000000006
+    Processor: Aggregate-groupby-repartition-filter (stores: [])
+      --> Aggregate-groupby-repartition-sink
       <-- Aggregate-groupby
-    Sink: KSTREAM-SINK-0000000006 (topic: Aggregate-groupby-repartition)
-      <-- KSTREAM-FILTER-0000000007
+    Sink: Aggregate-groupby-repartition-sink (topic: Aggregate-groupby-repartition)
+      <-- Aggregate-groupby-repartition-filter
 
   Sub-topology: 1
-    Source: KSTREAM-SOURCE-0000000008 (topics: [Aggregate-groupby-repartition])
+    Source: Aggregate-groupby-repartition-source (topics: [Aggregate-groupby-repartition])
       --> KSTREAM-AGGREGATE-0000000005
     Processor: KSTREAM-AGGREGATE-0000000005 (stores: [Aggregate-aggregate])
       --> KTABLE-MAPVALUES-0000000009
-      <-- KSTREAM-SOURCE-0000000008
+      <-- Aggregate-groupby-repartition-source
     Processor: KTABLE-MAPVALUES-0000000009 (stores: [])
       --> KTABLE-MAPVALUES-0000000010
       <-- KSTREAM-AGGREGATE-0000000005


### PR DESCRIPTION
### Description 
When Kafka Streams introduced the ability to name repartition topics, the accompanying `Filter`, `Source` and `Sink` processors continued to use the generated names. With the addition of KIP-307, users can now name every operator in a Streams DSL application.  The repartition `Filter`, `Source`, and `Sink` operators are internally generated and the users have no ability to name these operations.  

So if a user goes through and names every operation in their DSL application, when viewing a topology description they will still see some `KSTREAM-XXX-00000000N` names (if there is a repartition topic), which could be confusing.  

Now when users provide a name for the repartition topic Kafka Streams will name the processors for the repartition in the following manner:

repartition topic name = `my-aggregation-repartition`
`KSTREAM-FILTER-00000000N` -> `my-aggregation-repartition-filter`
`KSTREAM-SINK-00000000N` -> `my-aggregation-repartition-sink`
`KSTREAM-SOURCE-00000000N` -> `my-aggregation-repartition-source`

Since these processors are stateless this is a _**non-breaking change**_

**This PR should only get merged after the AK PR is merged to CCS.**

### Testing done 
I ran `mvn clean package` against the branch with the Kafka Streams changes with updated expected topology files and tests for all modules passed.

### Reviewer checklist
- [ ] Ensure docs are updated if necessary. (eg. if a user visible feature is being added or changed).
- [ ] Ensure relevant issues are linked (description should include text like "Fixes #<issue number>")

