### PR TITLE
fix: pull queries available on `/query` rest & ws endpoint

### DIFF
--- a/ksql-cli/src/main/java/io/confluent/ksql/util/TabularRow.java
+++ b/ksql-cli/src/main/java/io/confluent/ksql/util/TabularRow.java
@@ -29,7 +29,7 @@ import java.util.List;
 import java.util.Objects;
 import java.util.stream.Collectors;
 
-public class TabularRow {
+public final class TabularRow {
 
   private static final String CLIPPED = "...";
   private static final int MIN_CELL_WIDTH = 5;

--- a/ksql-rest-app/src/main/java/io/confluent/ksql/rest/server/execution/StaticQueryExecutor.java
+++ b/ksql-rest-app/src/main/java/io/confluent/ksql/rest/server/execution/StaticQueryExecutor.java
@@ -132,25 +132,19 @@ public final class StaticQueryExecutor {
     if (!queryStmt.isStatic()) {
       throw new KsqlRestException(Errors.queryEndpoint(statement.getStatementText()));
     }
-
-    try {
-      final Analysis analysis = analyze(statement, executionContext);
-
-      final PersistentQueryMetadata query = findMaterializingQuery(executionContext, analysis);
-
-      extractWhereInfo(analysis, query);
-    } catch (final Exception e) {
-      throw new KsqlStatementException(
-          e.getMessage(),
-          statement.getStatementText(),
-          e
-      );
-    }
   }
 
   public static Optional<KsqlEntity> execute(
       final ConfiguredStatement<Query> statement,
       final Map<String, ?> sessionProperties,
+      final KsqlExecutionContext executionContext,
+      final ServiceContext serviceContext
+  ) {
+    return Optional.of(execute(statement, executionContext, serviceContext));
+  }
+
+  public static TableRowsEntity execute(
+      final ConfiguredStatement<Query> statement,
       final KsqlExecutionContext executionContext,
       final ServiceContext serviceContext
   ) {
@@ -172,7 +166,7 @@ public final class StaticQueryExecutor {
 
       final KsqlNode owner = getOwner(rowKey, mat);
       if (!owner.isLocal()) {
-        return Optional.of(proxyTo(owner, statement, serviceContext));
+        return proxyTo(owner, statement, serviceContext);
       }
 
       final Result result;
@@ -206,14 +200,12 @@ public final class StaticQueryExecutor {
         rows = handleSelects(result, statement, executionContext, analysis, outputSchema);
       }
 
-      final TableRowsEntity entity = new TableRowsEntity(
+      return new TableRowsEntity(
           statement.getStatementText(),
           queryId,
           outputSchema,
           rows
       );
-
-      return Optional.of(entity);
     } catch (final Exception e) {
       throw new KsqlStatementException(
           e.getMessage() == null ? "Server Error" : e.getMessage(),
@@ -637,7 +629,7 @@ public final class StaticQueryExecutor {
     }
     if (queries.size() > 1) {
       throw new KsqlException("Multiple queries currently materialize '" + sourceName + "'."
-          + " KSQL currently only supports static queries when the table has only been"
+          + " KSQL currently only supports pull queries when the table has only been"
           + " materialized once.");
     }
 
@@ -668,7 +660,7 @@ public final class StaticQueryExecutor {
     );
   }
 
-  private static KsqlEntity proxyTo(
+  private static TableRowsEntity proxyTo(
       final KsqlNode owner,
       final ConfiguredStatement<Query> statement,
       final ServiceContext serviceContext
@@ -686,7 +678,7 @@ public final class StaticQueryExecutor {
       throw new RuntimeException("Boom - expected 1 entity, got: " + entities.size());
     }
 
-    return entities.get(0);
+    return (TableRowsEntity) entities.get(0);
   }
 
   private static KsqlException notMaterializedException(final SourceName sourceTable) {

--- a/ksql-rest-app/src/main/java/io/confluent/ksql/rest/server/resources/streaming/Flow.java
+++ b/ksql-rest-app/src/main/java/io/confluent/ksql/rest/server/resources/streaming/Flow.java
@@ -19,7 +19,7 @@ import io.confluent.ksql.schema.ksql.LogicalSchema;
 
 /**
  * Flow constructs borrowed from Java 9
- * https://docs.oracle.com/javase/9/docs/api/java/util/concurrent/Flow.Subscription.html
+ * @see <a href="https://docs.oracle.com/javase/9/docs/api/java/util/concurrent/Flow.Subscription.html">Flow Java 9 Docs</a>
  */
 public class Flow {
 

--- a/ksql-rest-app/src/main/java/io/confluent/ksql/rest/server/resources/streaming/PullQueryPublisher.java
+++ b/ksql-rest-app/src/main/java/io/confluent/ksql/rest/server/resources/streaming/PullQueryPublisher.java
@@ -72,7 +72,7 @@ class PullQueryPublisher implements Flow.Publisher<Collection<StreamedRow>> {
     subscriber.onSubscribe(subscription);
   }
 
-  private static class PullQuerySubscription implements Flow.Subscription {
+  private static final class PullQuerySubscription implements Flow.Subscription {
 
     private final Subscriber<Collection<StreamedRow>> subscriber;
     private final Callable<TableRowsEntity> executor;

--- a/ksql-rest-app/src/main/java/io/confluent/ksql/rest/server/resources/streaming/PullQueryPublisher.java
+++ b/ksql-rest-app/src/main/java/io/confluent/ksql/rest/server/resources/streaming/PullQueryPublisher.java
@@ -1,0 +1,134 @@
+/*
+ * Copyright 2019 Confluent Inc.
+ *
+ * Licensed under the Confluent Community License (the "License"); you may not use
+ * this file except in compliance with the License.  You may obtain a copy of the
+ * License at
+ *
+ * http://www.confluent.io/confluent-community-license
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package io.confluent.ksql.rest.server.resources.streaming;
+
+import static java.util.Objects.requireNonNull;
+
+import com.google.common.annotations.VisibleForTesting;
+import com.google.common.base.Preconditions;
+import io.confluent.ksql.GenericRow;
+import io.confluent.ksql.KsqlExecutionContext;
+import io.confluent.ksql.engine.KsqlEngine;
+import io.confluent.ksql.parser.tree.Query;
+import io.confluent.ksql.rest.entity.StreamedRow;
+import io.confluent.ksql.rest.entity.TableRowsEntity;
+import io.confluent.ksql.rest.server.execution.StaticQueryExecutor;
+import io.confluent.ksql.rest.server.resources.streaming.Flow.Subscriber;
+import io.confluent.ksql.services.ServiceContext;
+import io.confluent.ksql.statement.ConfiguredStatement;
+import java.util.Collection;
+import java.util.List;
+import java.util.concurrent.Callable;
+import java.util.stream.Collectors;
+
+class PullQueryPublisher implements Flow.Publisher<Collection<StreamedRow>> {
+
+  private final KsqlEngine ksqlEngine;
+  private final ServiceContext serviceContext;
+  private final ConfiguredStatement<Query> query;
+  private final PullQueryExecutor pullQueryExecutor;
+
+  PullQueryPublisher(
+      final KsqlEngine ksqlEngine,
+      final ServiceContext serviceContext,
+      final ConfiguredStatement<Query> query
+  ) {
+    this(ksqlEngine, serviceContext, query, StaticQueryExecutor::execute);
+  }
+
+  @VisibleForTesting
+  PullQueryPublisher(
+      final KsqlEngine ksqlEngine,
+      final ServiceContext serviceContext,
+      final ConfiguredStatement<Query> query,
+      final PullQueryExecutor pullQueryExecutor
+  ) {
+    this.ksqlEngine = requireNonNull(ksqlEngine, "ksqlEngine");
+    this.serviceContext = requireNonNull(serviceContext, "serviceContext");
+    this.query = requireNonNull(query, "query");
+    this.pullQueryExecutor = requireNonNull(pullQueryExecutor, "pullQueryExecutor");
+  }
+
+  @Override
+  public synchronized void subscribe(final Subscriber<Collection<StreamedRow>> subscriber) {
+    final PullQuerySubscription subscription = new PullQuerySubscription(
+        subscriber,
+        () -> pullQueryExecutor.execute(query, ksqlEngine, serviceContext)
+    );
+
+    subscriber.onSubscribe(subscription);
+  }
+
+  private static class PullQuerySubscription implements Flow.Subscription {
+
+    private final Subscriber<Collection<StreamedRow>> subscriber;
+    private final Callable<TableRowsEntity> executor;
+    private boolean done = false;
+
+    private PullQuerySubscription(
+        final Subscriber<Collection<StreamedRow>> subscriber,
+        final Callable<TableRowsEntity> executor
+    ) {
+      this.subscriber = requireNonNull(subscriber, "subscriber");
+      this.executor = requireNonNull(executor, "executor");
+    }
+
+    @Override
+    public void request(final long n) {
+      Preconditions.checkArgument(n == 1, "number of requested items must be 1");
+
+      if (done) {
+        return;
+      }
+
+      done = true;
+
+      try {
+        final TableRowsEntity entity = executor.call();
+
+        subscriber.onSchema(entity.getSchema());
+
+        final List<StreamedRow> rows = entity.getRows().stream()
+            .map(PullQuerySubscription::toGenericRow)
+            .map(StreamedRow::row)
+            .collect(Collectors.toList());
+
+        subscriber.onNext(rows);
+        subscriber.onComplete();
+      } catch (final Exception e) {
+        subscriber.onError(e);
+      }
+    }
+
+    @Override
+    public void cancel() {
+    }
+
+    @SuppressWarnings("unchecked")
+    private static GenericRow toGenericRow(final List<?> values) {
+      return new GenericRow((List)values);
+    }
+  }
+
+  interface PullQueryExecutor {
+
+    TableRowsEntity execute(
+        ConfiguredStatement<Query> statement,
+        KsqlExecutionContext executionContext,
+        ServiceContext serviceContext
+    );
+  }
+}

--- a/ksql-rest-app/src/main/java/io/confluent/ksql/rest/server/resources/streaming/QueryStreamWriter.java
+++ b/ksql-rest-app/src/main/java/io/confluent/ksql/rest/server/resources/streaming/QueryStreamWriter.java
@@ -18,8 +18,11 @@ package io.confluent.ksql.rest.server.resources.streaming;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.common.collect.Lists;
 import io.confluent.ksql.GenericRow;
+import io.confluent.ksql.query.QueryId;
 import io.confluent.ksql.rest.Errors;
 import io.confluent.ksql.rest.entity.StreamedRow;
+import io.confluent.ksql.schema.ksql.LogicalSchema;
+import io.confluent.ksql.schema.ksql.LogicalSchema.Builder;
 import io.confluent.ksql.util.KsqlException;
 import io.confluent.ksql.util.TransientQueryMetadata;
 import java.io.EOFException;
@@ -37,6 +40,7 @@ import org.slf4j.LoggerFactory;
 class QueryStreamWriter implements StreamingOutput {
 
   private static final Logger log = LoggerFactory.getLogger(QueryStreamWriter.class);
+  private static final QueryId NO_QUERY_ID = new QueryId("none");
 
   private final TransientQueryMetadata queryMetadata;
   private final long disconnectCheckInterval;
@@ -60,13 +64,15 @@ class QueryStreamWriter implements StreamingOutput {
   @Override
   public void write(final OutputStream out) {
     try {
+      write(out, buildHeader());
+
       while (queryMetadata.isRunning() && !limitReached) {
         final KeyValue<String, GenericRow> value = queryMetadata.getRowQueue().poll(
             disconnectCheckInterval,
             TimeUnit.MILLISECONDS
         );
         if (value != null) {
-          write(out, value.value);
+          write(out, StreamedRow.row(value.value));
         } else {
           // If no new rows have been written, the user may have terminated the connection without
           // us knowing. Check by trying to write a single newline.
@@ -98,10 +104,22 @@ class QueryStreamWriter implements StreamingOutput {
     }
   }
 
-  private void write(final OutputStream output, final GenericRow row) throws IOException {
-    objectMapper.writeValue(output, StreamedRow.row(row));
+  private void write(final OutputStream output, final StreamedRow row) throws IOException {
+    objectMapper.writeValue(output, row);
     output.write("\n".getBytes(StandardCharsets.UTF_8));
     output.flush();
+  }
+
+  private StreamedRow buildHeader() {
+    // Push queries only return value columns, but query metadata schema includes key and meta:
+    final LogicalSchema storedSchema = queryMetadata.getLogicalSchema();
+
+    final Builder actualSchemaBuilder = LogicalSchema.builder()
+        .noImplicitColumns();
+
+    storedSchema.value().forEach(actualSchemaBuilder::valueColumn);
+
+    return StreamedRow.header(NO_QUERY_ID, actualSchemaBuilder.build());
   }
 
   private void outputException(final OutputStream out, final Throwable exception) {
@@ -133,7 +151,7 @@ class QueryStreamWriter implements StreamingOutput {
     queryMetadata.getRowQueue().drainTo(rows);
 
     for (final KeyValue<String, GenericRow> row : rows) {
-      write(out, row.value);
+      write(out, StreamedRow.row(row.value));
     }
   }
 

--- a/ksql-rest-app/src/test/java/io/confluent/ksql/rest/integration/RestApiTest.java
+++ b/ksql-rest-app/src/test/java/io/confluent/ksql/rest/integration/RestApiTest.java
@@ -15,22 +15,31 @@
 
 package io.confluent.ksql.rest.integration;
 
+import static io.confluent.ksql.test.util.AssertEventually.assertThatEventually;
 import static io.confluent.ksql.test.util.EmbeddedSingleNodeKafkaCluster.VALID_USER1;
 import static io.confluent.ksql.test.util.EmbeddedSingleNodeKafkaCluster.VALID_USER2;
 import static io.confluent.ksql.test.util.EmbeddedSingleNodeKafkaCluster.ops;
 import static io.confluent.ksql.test.util.EmbeddedSingleNodeKafkaCluster.prefixedResource;
 import static io.confluent.ksql.test.util.EmbeddedSingleNodeKafkaCluster.resource;
+import static junit.framework.TestCase.fail;
 import static org.apache.kafka.common.acl.AclOperation.ALL;
+import static org.apache.kafka.common.acl.AclOperation.CREATE;
+import static org.apache.kafka.common.acl.AclOperation.DESCRIBE;
 import static org.apache.kafka.common.acl.AclOperation.DESCRIBE_CONFIGS;
 import static org.apache.kafka.common.resource.ResourceType.CLUSTER;
 import static org.apache.kafka.common.resource.ResourceType.GROUP;
 import static org.apache.kafka.common.resource.ResourceType.TOPIC;
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.hasSize;
+import static org.hamcrest.Matchers.instanceOf;
 import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.notNullValue;
 
+import com.fasterxml.jackson.core.type.TypeReference;
 import io.confluent.common.utils.IntegrationTest;
 import io.confluent.ksql.integration.IntegrationTestHarness;
+import io.confluent.ksql.json.JsonMapper;
 import io.confluent.ksql.rest.entity.Versions;
 import io.confluent.ksql.rest.server.TestKsqlRestApp;
 import io.confluent.ksql.serde.Format;
@@ -40,12 +49,15 @@ import io.confluent.ksql.test.util.secure.ClientTrustStore;
 import io.confluent.ksql.test.util.secure.Credentials;
 import io.confluent.ksql.test.util.secure.SecureKafkaHelper;
 import io.confluent.ksql.util.PageViewDataProvider;
+import java.util.Arrays;
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
 import java.util.concurrent.CopyOnWriteArrayList;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicReference;
+import java.util.function.Supplier;
 import javax.websocket.CloseReason.CloseCodes;
 import javax.ws.rs.core.MediaType;
 import org.eclipse.jetty.websocket.api.Session;
@@ -54,6 +66,7 @@ import org.eclipse.jetty.websocket.api.annotations.OnWebSocketError;
 import org.eclipse.jetty.websocket.api.annotations.OnWebSocketMessage;
 import org.eclipse.jetty.websocket.api.annotations.WebSocket;
 import org.eclipse.jetty.websocket.client.WebSocketClient;
+import org.junit.After;
 import org.junit.BeforeClass;
 import org.junit.ClassRule;
 import org.junit.Test;
@@ -64,11 +77,14 @@ import org.junit.rules.RuleChain;
 public class RestApiTest {
 
   private static final int HEADER = 1;  // <-- some responses include a header as the first message.
+  private static final int FOOTER = 1;  // <-- some responses include a footer as the last message.
   private static final int LIMIT = 2;
   private static final String PAGE_VIEW_TOPIC = "pageviews";
   private static final String PAGE_VIEW_STREAM = "pageviews_original";
+  private static final String AGG_TABLE = "AGG_TABLE";
   private static final Credentials SUPER_USER = VALID_USER1;
   private static final Credentials NORMAL_USER = VALID_USER2;
+  private static final String AN_AGG_KEY = "USER_1";
 
   private static final IntegrationTestHarness TEST_HARNESS = IntegrationTestHarness.builder()
       .withKafkaCluster(
@@ -79,11 +95,11 @@ public class RestApiTest {
               .withAcl(
                   NORMAL_USER,
                   resource(CLUSTER, "kafka-cluster"),
-                  ops(DESCRIBE_CONFIGS)
+                  ops(DESCRIBE_CONFIGS, CREATE)
               )
               .withAcl(
                   NORMAL_USER,
-                  resource(TOPIC, "_confluent-ksql-default__command_topic"),
+                  prefixedResource(TOPIC, "_confluent-ksql-default_"),
                   ops(ALL)
               )
               .withAcl(
@@ -106,6 +122,16 @@ public class RestApiTest {
                   resource(TOPIC, "X"),
                   ops(ALL)
               )
+              .withAcl(
+                  NORMAL_USER,
+                  resource(TOPIC, "AGG_TABLE"),
+                  ops(ALL)
+              )
+              .withAcl(
+                  NORMAL_USER,
+                  resource(TOPIC, "__consumer_offsets"),
+                  ops(DESCRIBE)
+              )
       )
       .build();
 
@@ -120,6 +146,8 @@ public class RestApiTest {
   @ClassRule
   public static final RuleChain CHAIN = RuleChain.outerRule(TEST_HARNESS).around(REST_APP);
 
+  private ServiceContext serviceContext;
+
   @BeforeClass
   public static void setUpClass() {
     TEST_HARNESS.ensureTopics(PAGE_VIEW_TOPIC);
@@ -127,70 +155,231 @@ public class RestApiTest {
     TEST_HARNESS.produceRows(PAGE_VIEW_TOPIC, new PageViewDataProvider(), Format.JSON);
 
     RestIntegrationTestUtil.createStreams(REST_APP, PAGE_VIEW_STREAM, PAGE_VIEW_TOPIC);
+
+    makeKsqlRequest("CREATE TABLE " + AGG_TABLE + " AS "
+        + "SELECT COUNT(1) AS COUNT FROM " + PAGE_VIEW_STREAM + " GROUP BY USERID;");
+  }
+
+  @After
+  public void tearDown() {
+    if (serviceContext != null) {
+      serviceContext.close();
+    }
   }
 
   @Test
-  public void shouldExecuteStreamingQueryWithV1ContentType() throws Exception {
+  public void shouldExecutePushQueryOverWebSocketWithV1ContentType() {
     // When:
-    final List<String> messages = makeStreamingRequest(
+    final List<String> messages = makeWebSocketRequest(
         "SELECT * from " + PAGE_VIEW_STREAM + " EMIT CHANGES LIMIT " + LIMIT + ";",
         Versions.KSQL_V1_JSON_TYPE,
         Versions.KSQL_V1_JSON_TYPE
     );
 
     // Then:
-    assertThat(messages, hasSize(is(HEADER + LIMIT)));
+    assertThat(messages, hasSize(HEADER + LIMIT));
+    assertValidJsonMessages(messages);
   }
 
   @Test
-  public void shouldExecuteStreamingQueryWithJsonContentType() throws Exception {
+  public void shouldExecutePushQueryOverWebSocketWithJsonContentType() {
     // When:
-    final List<String> messages = makeStreamingRequest(
+    final List<String> messages = makeWebSocketRequest(
         "SELECT * from " + PAGE_VIEW_STREAM + " EMIT CHANGES LIMIT " + LIMIT + ";",
         MediaType.APPLICATION_JSON_TYPE,
         MediaType.APPLICATION_JSON_TYPE
     );
 
     // Then:
-    assertThat(messages, hasSize(is(HEADER + LIMIT)));
+    assertThat(messages, hasSize(HEADER + LIMIT));
+    assertValidJsonMessages(messages);
   }
 
   @Test
-  public void shouldPrintTopic() throws Exception {
+  public void shouldExecutePushQueryOverRest() {
     // When:
-    final List<String> messages = makeStreamingRequest(
+    final String response = rawRestQueryRequest(
+        "SELECT USERID, PAGEID, VIEWTIME, ROWKEY from " + PAGE_VIEW_STREAM + " EMIT CHANGES LIMIT "
+            + LIMIT + ";"
+    );
+
+    // Then:
+    final String[] messages = response.split(System.lineSeparator());
+    assertThat(messages.length, is(HEADER + LIMIT + FOOTER));
+    assertThat(messages[0],
+        is("{\"header\":{\"queryId\":\"none\",\"schema\":\"`USERID` STRING, `PAGEID` STRING, `VIEWTIME` BIGINT, `ROWKEY` STRING\"}}"));
+    assertThat(messages[1], is("{\"row\":{\"columns\":[\"USER_1\",\"PAGE_1\",1,\"1\"]}}"));
+    assertThat(messages[2], is("{\"row\":{\"columns\":[\"USER_2\",\"PAGE_2\",2,\"2\"]}}"));
+    assertThat(messages[3], is("{\"finalMessage\":\"Limit Reached\"}"));
+  }
+
+  @Test
+  public void shouldExecutePullQueryOverWebSocketWithV1ContentType() {
+    // When:
+    final Supplier<List<String>> call = () -> makeWebSocketRequest(
+        "SELECT * from " + AGG_TABLE + " WHERE ROWKEY='" + AN_AGG_KEY + "';",
+        Versions.KSQL_V1_JSON_TYPE,
+        Versions.KSQL_V1_JSON_TYPE
+    );
+
+    // Then:
+    final List<String> messages = assertThatEventually(call, hasSize(HEADER + 1));
+    assertValidJsonMessages(messages);
+    assertThat(messages.get(0),
+        is("[{\"name\":\"COUNT\",\"schema\":{\"type\":\"BIGINT\",\"fields\":null,\"memberSchema\":null}}]"));
+    assertThat(messages.get(1),
+        is("{\"row\":{\"columns\":[\"USER_1\",1]}}"));
+  }
+
+  @Test
+  public void shouldExecutePullQueryOverWebSocketWithJsonContentType() {
+    // When:
+    final Supplier<List<String>> call = () -> makeWebSocketRequest(
+        "SELECT * from " + AGG_TABLE + " WHERE ROWKEY='" + AN_AGG_KEY + "';",
+        MediaType.APPLICATION_JSON_TYPE,
+        MediaType.APPLICATION_JSON_TYPE
+    );
+
+    // Then:
+    final List<String> messages = assertThatEventually(call, hasSize(HEADER + 1));
+    assertValidJsonMessages(messages);
+    assertThat(messages.get(0),
+        is("[{\"name\":\"COUNT\",\"schema\":{\"type\":\"BIGINT\",\"fields\":null,\"memberSchema\":null}}]"));
+    assertThat(messages.get(1),
+        is("{\"row\":{\"columns\":[\"USER_1\",1]}}"));
+  }
+
+  @Test
+  public void shouldReturnCorrectSchemaForPullQueryWithOnlyKeyInSelect() {
+    // When:
+    final Supplier<List<String>> call = () -> makeWebSocketRequest(
+        "SELECT * from " + AGG_TABLE + " WHERE ROWKEY='" + AN_AGG_KEY + "';",
+        MediaType.APPLICATION_JSON_TYPE,
+        MediaType.APPLICATION_JSON_TYPE
+    );
+
+    // Then:
+    final List<String> messages = assertThatEventually(call, hasSize(HEADER + 1));
+    assertValidJsonMessages(messages);
+    assertThat(messages.get(0),
+        is("[{\"name\":\"COUNT\",\"schema\":{\"type\":\"BIGINT\",\"fields\":null,\"memberSchema\":null}}]"));
+    assertThat(messages.get(1),
+        is("{\"row\":{\"columns\":[\"USER_1\",1]}}"));
+  }
+
+  @Test
+  public void shouldReturnCorrectSchemaForPullQueryWithOnlyValueColumnInSelect() {
+    // When:
+    final Supplier<List<String>> call = () -> makeWebSocketRequest(
+        "SELECT COUNT from " + AGG_TABLE + " WHERE ROWKEY='" + AN_AGG_KEY + "';",
+        MediaType.APPLICATION_JSON_TYPE,
+        MediaType.APPLICATION_JSON_TYPE
+    );
+
+    // Then:
+    final List<String> messages = assertThatEventually(call, hasSize(HEADER + 1));
+    assertValidJsonMessages(messages);
+    assertThat(messages.get(0),
+        is("[{\"name\":\"COUNT\",\"schema\":{\"type\":\"BIGINT\",\"fields\":null,\"memberSchema\":null}}]"));
+    assertThat(messages.get(1),
+        is("{\"row\":{\"columns\":[1]}}"));
+  }
+
+  @Test
+  public void shouldExecutePullQueryOverRest() {
+    // When:
+    final Supplier<List<String>> call = () -> {
+      final String response = rawRestQueryRequest(
+          "SELECT * from " + AGG_TABLE + " WHERE ROWKEY='" + AN_AGG_KEY + "';"
+      );
+      return Arrays.asList(response.split(System.lineSeparator()));
+    };
+
+    // Then:
+    final List<String> messages = assertThatEventually(call, hasSize(HEADER + 1));
+    final List<Map<String, Object>> parsed = parseRawRestQueryResponse(String.join("", messages));
+    assertThat(parsed, hasSize(HEADER + 1));
+    assertThat(parsed.get(0).get("header"), instanceOf(Map.class));
+    assertThat(((Map) parsed.get(0).get("header")).get("queryId"), is(notNullValue()));
+    assertThat(((Map) parsed.get(0).get("header")).get("schema"),
+        is("`ROWKEY` STRING KEY, `COUNT` BIGINT"));
+    assertThat(messages.get(1), is("{\"row\":{\"columns\":[[\"USER_1\",1]]}}]"));
+  }
+
+  @Test
+  public void shouldReportErrorOnInvalidPullQueryOverRest() {
+    // When:
+    final String response = rawRestQueryRequest(
+        "SELECT * from " + AGG_TABLE + ";"
+    );
+
+    // Then:
+    assertThat(response, containsString("Missing WHERE clause"));
+  }
+
+  @Test
+  public void shouldPrintTopicOverWebSocket() {
+    // When:
+    final List<String> messages = makeWebSocketRequest(
         "PRINT '" + PAGE_VIEW_TOPIC + "' FROM BEGINNING LIMIT " + LIMIT + ";",
         MediaType.APPLICATION_JSON_TYPE,
         MediaType.APPLICATION_JSON_TYPE);
 
     // Then:
-    assertThat(messages, hasSize(is(LIMIT)));
+    assertThat(messages, hasSize(LIMIT));
   }
 
   @Test
   public void shouldDeleteTopic() {
-    try (final ServiceContext serviceContext = REST_APP.getServiceContext()) {
-      // Given:
-      RestIntegrationTestUtil.makeKsqlRequest(
-          REST_APP,
-          "CREATE STREAM X AS SELECT * FROM " + PAGE_VIEW_STREAM + ";");
-      assertThat("Expected topic X to be created", serviceContext.getTopicClient().isTopicExists("X"));
+    // Given:
+    makeKsqlRequest("CREATE STREAM X AS SELECT * FROM " + PAGE_VIEW_STREAM + ";"
+        + "TERMINATE QUERY CSAS_X_2; ");
 
-      // When:
-      RestIntegrationTestUtil.makeKsqlRequest(
-          REST_APP,
-          "TERMINATE QUERY CSAS_X_1; DROP STREAM X DELETE TOPIC;");
+    assertThat("Expected topic X to be created", topicExists("X"));
 
-      // Then:
-      assertThat("Expected topic X to be deleted", !serviceContext.getTopicClient().isTopicExists("X"));
+    // When:
+    makeKsqlRequest("DROP STREAM X DELETE TOPIC;");
+
+    // Then:
+    assertThat("Expected topic X to be deleted", !topicExists("X"));
+  }
+
+  private boolean topicExists(final String topicName) {
+    return getServiceContext().getTopicClient().isTopicExists(topicName);
+  }
+
+  private ServiceContext getServiceContext() {
+    if (serviceContext == null) {
+      serviceContext = REST_APP.getServiceContext();
+    }
+    return serviceContext;
+  }
+
+  private static void makeKsqlRequest(final String sql) {
+    RestIntegrationTestUtil.makeKsqlRequest(REST_APP, sql);
+  }
+
+  private static String rawRestQueryRequest(final String sql) {
+    return RestIntegrationTestUtil.rawRestQueryRequest(REST_APP, sql, Optional.empty());
+  }
+
+  private static List<Map<String, Object>> parseRawRestQueryResponse(final String response) {
+    try {
+      return JsonMapper.INSTANCE.mapper.readValue(
+          response,
+          new TypeReference<List<Map<String, Object>>>() {
+          }
+      );
+    } catch (final Exception e) {
+      throw new AssertionError("Invalid JSON received: " + response);
     }
   }
 
-  private static List<String> makeStreamingRequest(
+  private static List<String> makeWebSocketRequest(
       final String sql,
       final MediaType mediaType,
       final MediaType contentType
-  ) throws Exception {
+  ) {
     final WebSocketListener listener = new WebSocketListener();
 
     final WebSocketClient wsClient = RestIntegrationTestUtil.makeWsRequest(
@@ -205,7 +394,21 @@ public class RestApiTest {
     try {
       return listener.awaitMessages();
     } finally {
-      wsClient.stop();
+      try {
+        wsClient.stop();
+      } catch (final Exception e) {
+        fail("Failed to close ws");
+      }
+    }
+  }
+
+  private static void assertValidJsonMessages(final Iterable<String> messages) {
+    for (final String msg : messages) {
+      try {
+        JsonMapper.INSTANCE.mapper.readValue(msg, Object.class);
+      } catch (final Exception e) {
+        throw new AssertionError("Invalid JSON message received: " + msg, e);
+      }
     }
   }
 

--- a/ksql-rest-app/src/test/java/io/confluent/ksql/rest/server/resources/streaming/PullQueryPublisherTest.java
+++ b/ksql-rest-app/src/test/java/io/confluent/ksql/rest/server/resources/streaming/PullQueryPublisherTest.java
@@ -1,0 +1,181 @@
+/*
+ * Copyright 2019 Confluent Inc.
+ *
+ * Licensed under the Confluent Community License (the "License"); you may not use
+ * this file except in compliance with the License.  You may obtain a copy of the
+ * License at
+ *
+ * http://www.confluent.io/confluent-community-license
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package io.confluent.ksql.rest.server.resources.streaming;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.inOrder;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.google.common.collect.ImmutableList;
+import io.confluent.ksql.GenericRow;
+import io.confluent.ksql.engine.KsqlEngine;
+import io.confluent.ksql.name.ColumnName;
+import io.confluent.ksql.parser.tree.Query;
+import io.confluent.ksql.rest.entity.StreamedRow;
+import io.confluent.ksql.rest.entity.TableRowsEntity;
+import io.confluent.ksql.rest.server.resources.streaming.Flow.Subscriber;
+import io.confluent.ksql.rest.server.resources.streaming.Flow.Subscription;
+import io.confluent.ksql.rest.server.resources.streaming.PullQueryPublisher.PullQueryExecutor;
+import io.confluent.ksql.schema.ksql.LogicalSchema;
+import io.confluent.ksql.schema.ksql.types.SqlTypes;
+import io.confluent.ksql.services.ServiceContext;
+import io.confluent.ksql.statement.ConfiguredStatement;
+import java.util.Collection;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Captor;
+import org.mockito.InOrder;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnitRunner;
+import org.mockito.stubbing.Answer;
+
+@RunWith(MockitoJUnitRunner.class)
+public class PullQueryPublisherTest {
+
+  private static final LogicalSchema SCHEMA = LogicalSchema.builder()
+      .valueColumn(ColumnName.of("bob"), SqlTypes.BIGINT)
+      .build();
+
+  @Mock
+  private KsqlEngine engine;
+  @Mock
+  private ServiceContext serviceContext;
+  @Mock
+  private ConfiguredStatement<Query> statement;
+  @Mock
+  private Subscriber<Collection<StreamedRow>> subscriber;
+  @Mock
+  private PullQueryExecutor pullQueryExecutor;
+  @Mock
+  private TableRowsEntity entity;
+  @Captor
+  private ArgumentCaptor<Subscription> subscriptionCaptor;
+
+  private Subscription subscription;
+  private PullQueryPublisher publisher;
+
+  @Before
+  public void setUp() {
+    publisher = new PullQueryPublisher(engine, serviceContext, statement, pullQueryExecutor);
+
+    when(pullQueryExecutor.execute(any(), any(), any())).thenReturn(entity);
+
+    when(entity.getSchema()).thenReturn(SCHEMA);
+
+    doAnswer(callRequestAgain()).when(subscriber).onNext(any());
+  }
+
+  @Test
+  public void shouldSubscribe() {
+    // When:
+    publisher.subscribe(subscriber);
+
+    // Then:
+    verify(subscriber).onSubscribe(any());
+  }
+
+  @Test
+  public void shouldRunQueryWithCorrectParams() {
+    // Given:
+    givenSubscribed();
+
+    // When:
+    subscription.request(1);
+
+    // Then:
+    verify(pullQueryExecutor).execute(statement, engine, serviceContext);
+  }
+
+  @Test
+  public void shouldOnlyExecuteOnce() {
+    // Given:
+    givenSubscribed();
+
+    // When:
+    subscription.request(1);
+
+    // Then:
+    verify(subscriber).onNext(any());
+    verify(pullQueryExecutor).execute(statement, engine, serviceContext);
+  }
+
+  @Test
+  public void shouldCallOnSchemaThenOnNextThenOnCompleteOnSuccess() {
+    // Given:
+    givenSubscribed();
+
+    // When:
+    subscription.request(1);
+
+    // Then:
+    final InOrder inOrder = inOrder(subscriber);
+    inOrder.verify(subscriber).onSchema(SCHEMA);
+    inOrder.verify(subscriber).onNext(ImmutableList.of());
+    inOrder.verify(subscriber).onComplete();
+  }
+
+  @Test
+  public void shouldCallOnErrorOnFailure() {
+    // Given:
+    givenSubscribed();
+
+    final Throwable e = new RuntimeException("Boom!");
+    when(pullQueryExecutor.execute(any(), any(), any())).thenThrow(e);
+
+    // When:
+    subscription.request(1);
+
+    // Then:
+    verify(subscriber).onError(e);
+  }
+
+  @Test
+  public void shouldBuildStreamingRows() {
+    // Given:
+    givenSubscribed();
+
+    when(entity.getRows()).thenReturn(ImmutableList.of(
+        ImmutableList.of("a", 1, 2L, 3.0f),
+        ImmutableList.of("b", 1, 2L, 3.0f)
+    ));
+
+    // When:
+    subscription.request(1);
+
+    // Then:
+    verify(subscriber).onNext(ImmutableList.of(
+        StreamedRow.row(new GenericRow("a", 1, 2L, 3.0f)),
+        StreamedRow.row(new GenericRow("b", 1, 2L, 3.0f))
+    ));
+  }
+
+  private Answer<Void> callRequestAgain() {
+    return inv -> {
+      subscription.request(1);
+      return null;
+    };
+  }
+
+  private void givenSubscribed() {
+    publisher.subscribe(subscriber);
+    verify(subscriber).onSubscribe(subscriptionCaptor.capture());
+    subscription = subscriptionCaptor.getValue();
+  }
+}

--- a/ksql-rest-model/src/main/java/io/confluent/ksql/rest/entity/StreamedRow.java
+++ b/ksql-rest-model/src/main/java/io/confluent/ksql/rest/entity/StreamedRow.java
@@ -35,7 +35,7 @@ import java.util.Optional;
 @JsonIgnoreProperties(ignoreUnknown = true)
 @JsonInclude(Include.NON_ABSENT)
 @JsonSubTypes({})
-public class StreamedRow {
+public final class StreamedRow {
 
   private final Optional<Header> header;
   private final Optional<GenericRow> row;

--- a/ksql-rest-model/src/main/java/io/confluent/ksql/rest/entity/StreamedRow.java
+++ b/ksql-rest-model/src/main/java/io/confluent/ksql/rest/entity/StreamedRow.java
@@ -15,64 +15,103 @@
 
 package io.confluent.ksql.rest.entity;
 
+import static java.util.Objects.requireNonNull;
+
 import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonInclude.Include;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonSubTypes;
+import com.google.errorprone.annotations.Immutable;
 import io.confluent.ksql.GenericRow;
+import io.confluent.ksql.query.QueryId;
+import io.confluent.ksql.schema.ksql.LogicalSchema;
 import java.util.Arrays;
-import java.util.List;
 import java.util.Objects;
+import java.util.Optional;
 
 @JsonIgnoreProperties(ignoreUnknown = true)
+@JsonInclude(Include.NON_ABSENT)
 @JsonSubTypes({})
 public class StreamedRow {
 
-  private final GenericRow row;
-  private final KsqlErrorMessage errorMessage;
-  private final String finalMessage;
+  private final Optional<Header> header;
+  private final Optional<GenericRow> row;
+  private final Optional<KsqlErrorMessage> errorMessage;
+  private final Optional<String> finalMessage;
+
+  public static StreamedRow header(final QueryId queryId, final LogicalSchema schema) {
+    return new StreamedRow(
+        Optional.of(Header.of(queryId, schema)),
+        Optional.empty(),
+        Optional.empty(),
+        Optional.empty()
+    );
+  }
 
   public static StreamedRow row(final GenericRow row) {
-    return new StreamedRow(row, null, null);
+    return new StreamedRow(
+        Optional.empty(),
+        Optional.of(row),
+        Optional.empty(),
+        Optional.empty()
+    );
   }
 
   public static StreamedRow error(final Throwable exception, final int errorCode) {
     return new StreamedRow(
-        null,
-        new KsqlErrorMessage(errorCode, exception),
-        null);
+        Optional.empty(),
+        Optional.empty(),
+        Optional.of(new KsqlErrorMessage(errorCode, exception)),
+        Optional.empty()
+    );
   }
 
   public static StreamedRow finalMessage(final String finalMessage) {
-    return new StreamedRow(null, null, finalMessage);
+    return new StreamedRow(
+        Optional.empty(),
+        Optional.empty(),
+        Optional.empty(),
+        Optional.of(finalMessage)
+    );
   }
 
   @JsonCreator
-  public StreamedRow(
-      @JsonProperty("row") final GenericRow row,
-      @JsonProperty("errorMessage") final KsqlErrorMessage errorMessage,
-      @JsonProperty("finalMessage") final String finalMessage
+  private StreamedRow(
+      @JsonProperty("header") final Optional<Header> header,
+      @JsonProperty("row") final Optional<GenericRow> row,
+      @JsonProperty("errorMessage") final Optional<KsqlErrorMessage> errorMessage,
+      @JsonProperty("finalMessage") final Optional<String> finalMessage
   ) {
-    checkUnion(row, errorMessage, finalMessage);
-    this.row = row;
-    this.errorMessage = errorMessage;
-    this.finalMessage = finalMessage;
+    this.header = requireNonNull(header, "header");
+    this.row = requireNonNull(row, "row");
+    this.errorMessage = requireNonNull(errorMessage, "errorMessage");
+    this.finalMessage = requireNonNull(finalMessage, "finalMessage");
+
+    checkUnion(header, row, errorMessage, finalMessage);
   }
 
-  public GenericRow getRow() {
+  public Optional<Header> getHeader() {
+    return header;
+  }
+
+  public Optional<GenericRow> getRow() {
     return row;
   }
 
-  public KsqlErrorMessage getErrorMessage() {
+  public Optional<KsqlErrorMessage> getErrorMessage() {
     return errorMessage;
   }
 
-  public String getFinalMessage() {
+  public Optional<String> getFinalMessage() {
     return finalMessage;
   }
 
+  @JsonIgnore
   public boolean isTerminal() {
-    return finalMessage != null || errorMessage != null;
+    return finalMessage.isPresent() || errorMessage.isPresent();
   }
 
   @Override
@@ -84,24 +123,53 @@ public class StreamedRow {
       return false;
     }
     final StreamedRow that = (StreamedRow) o;
-    return Objects.equals(row, that.row)
-           && Objects.equals(errorMessage, that.errorMessage)
-           && Objects.equals(finalMessage, that.finalMessage);
+    return Objects.equals(header, that.header)
+        && Objects.equals(row, that.row)
+        && Objects.equals(errorMessage, that.errorMessage)
+        && Objects.equals(finalMessage, that.finalMessage);
   }
 
   @Override
   public int hashCode() {
-    return Objects.hash(row, errorMessage, finalMessage);
+    return Objects.hash(header, row, errorMessage, finalMessage);
   }
 
-  private static void checkUnion(final Object... fields) {
-    final List<Object> fs = Arrays.asList(fields);
-    final long count = fs.stream()
-        .filter(Objects::nonNull)
+  private static void checkUnion(final Optional<?>... fs) {
+    final long count = Arrays.stream(fs)
+        .filter(Optional::isPresent)
         .count();
 
     if (count != 1) {
-      throw new IllegalArgumentException("Exactly one parameter should be non-null. got: " + fs);
+      throw new IllegalArgumentException("Exactly one parameter should be non-null. got: " + count);
+    }
+  }
+
+  @Immutable
+  @JsonIgnoreProperties(ignoreUnknown = true)
+  public static final class Header {
+
+    private final QueryId queryId;
+    private final LogicalSchema schema;
+
+    @JsonCreator
+    public static Header of(
+        @JsonProperty(value = "queryId", required = true) final QueryId queryId,
+        @JsonProperty(value = "schema", required = true) final LogicalSchema schema
+    ) {
+      return new Header(queryId, schema);
+    }
+
+    public QueryId getQueryId() {
+      return queryId;
+    }
+
+    public LogicalSchema getSchema() {
+      return schema;
+    }
+
+    private Header(final QueryId queryId, final LogicalSchema schema) {
+      this.queryId = requireNonNull(queryId, "queryId");
+      this.schema = requireNonNull(schema, "schema");
     }
   }
 }


### PR DESCRIPTION
### Description 

fixes: #3672 by providing alternative way of issuing pull queries that does NOT log
fixes: #3806

We should look to include #3819 as part of this fix.

Makes pull queries available on the `/query` RESTful and Websocket endpoints, in the same way that push queries are.

Note: this change does not _remove_ pull query support from the `/ksql` endpoint, nor does it switch the CLI over to use
the `/query` endpoint. The CLI continues to use the `/ksql` endpoint for pull queries.

Push and pull queries to the `/query` rest endpoint now return the schema of the rows in the first message.
This is required as the 'DESCRIBE' that CLI was previously running to get column headers doesn't work for pull queries yet. (Known issue: #3495).
This is similar to the pattern used by the websocket endpoint, which also sends the schema in the first message.

In addition, I've hidden null fields and added a 'header' row to return the schema of the data. The output now looks like:

```json
{"header":{"queryId":"someId","schema":"`USERID` STRING, `PAGEID` STRING, `VIEWTIME` BIGINT, `ROWKEY` STRING"}}
{"row":{"columns":["USER_1","PAGE_1",1,"1"]}}
{"row":{"columns":["USER_2","PAGE_2",2,"2"]}}
{"finalMessage":"Limit Reached"}"
```

Note: With this PR the payload from the rest endpoint continues to be invalid JSON, just like it is for push queries. #3819 addresses this.

BREAKING CHANGE: the response from the RESTful API for push queries has changed: it now returns a line with the schema and query id in a `header` field and null fields are not included in the payload.

The CLI is backwards compatible with older versions of the server, though it won't output column headings from older versions.

Note: This PR does NOT address issue #3663. At the moment I have a feeling an admin client is still made per-request.

Outstanding tasks:
- [ ] the schema being returned for pull queries is incorrect. (Working on this)
- [ ] Decide if we want to switch CLI to use `/query` endpoint. 
- [ ] Decide if we want to drop pull query support from `/ksql` endpoint.
- [ ] Perf test this new endpoint

### Testing done 

Lots of testing, including manual

### Reviewer checklist
- [ ] Ensure docs are updated if necessary. (eg. if a user visible feature is being added or changed).
- [ ] Ensure relevant issues are linked (description should include text like "Fixes #<issue number>")

