### PR TITLE
ST-2519: Use a property to control the building of docker images.

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -4,6 +4,6 @@ dockerfile {
     slackChannel = '#ksql-alerts'
     upstreamProjects = 'confluentinc/schema-registry'
     dockerRepos = ['confluentinc/ksql-cli']
-    extraBuildArgs = '-Ddocker.skip=false'
-    extraDeployArgs = '-Ddocker.skip=true'
+    extraBuildArgs = '-Dskip.docker.build=false'
+    extraDeployArgs = '-Dskip.docker.build=true'
 }

--- a/ksql-cli/pom.xml
+++ b/ksql-cli/pom.xml
@@ -32,7 +32,8 @@
         <main-class>io.confluent.ksql.Ksql</main-class>
         <cli.skip-execute>false</cli.skip-execute>
         <cli.main-class>${main-class}</cli.main-class>
-        <docker.skip-build>false</docker.skip-build>
+        <docker.skip-build>${skip.docker.build}</docker.skip-build>
+        <docker.skip-test>${skip.docker.test}</docker.skip-test>
     </properties>
 
     <dependencies>

--- a/ksql-rest-app/pom.xml
+++ b/ksql-rest-app/pom.xml
@@ -33,7 +33,8 @@
         <main-class>io.confluent.ksql.rest.server.KsqlRestApplication</main-class>
         <cli.skip-execute>false</cli.skip-execute>
         <cli.main-class>${main-class}</cli.main-class>
-        <docker.skip-build>false</docker.skip-build>
+        <docker.skip-build>${skip.docker.build}</docker.skip-build>
+        <docker.skip-test>${skip.docker.test}</docker.skip-test>
     </properties>
 
     <dependencies>

--- a/pom.xml
+++ b/pom.xml
@@ -114,6 +114,8 @@
         <avro.random.generator.version>0.2.2</avro.random.generator.version>
         <apache.curator.version>2.9.0</apache.curator.version>
         <wiremock.version>2.24.0</wiremock.version>
+        <skip.docker.build>true</skip.docker.build>
+        <skip.docker.test>true</skip.docker.test>
     </properties>
 
     <dependencyManagement>


### PR DESCRIPTION
### Description 
This will allow us to control the building and testing of docker images using the docker maven plugin. Previously these docker images were not being built so this functionality was fully disabled. Since each pom in this repo does not have a dockerfile the standard property for skipping the docker image builds does not work.

### Testing done 
Verified that the default behavior remains the same and the docker images will not build. I also tested that when enabled the docker images build successfully.

### Reviewer checklist
- [ ] Ensure docs are updated if necessary. (eg. if a user visible feature is being added or changed).
- [ ] Ensure relevant issues are linked (description should include text like "Fixes #<issue number>")

