### PR TITLE
refactor: build schemas when building streams app

### DIFF
--- a/ksql-engine/src/main/java/io/confluent/ksql/planner/plan/AggregateNode.java
+++ b/ksql-engine/src/main/java/io/confluent/ksql/planner/plan/AggregateNode.java
@@ -28,17 +28,12 @@ import io.confluent.ksql.execution.expression.tree.Expression;
 import io.confluent.ksql.execution.expression.tree.FunctionCall;
 import io.confluent.ksql.execution.expression.tree.Literal;
 import io.confluent.ksql.execution.expression.tree.VisitParentExpressionVisitor;
-import io.confluent.ksql.execution.function.UdafUtil;
 import io.confluent.ksql.execution.plan.SelectExpression;
-import io.confluent.ksql.function.FunctionRegistry;
-import io.confluent.ksql.function.KsqlAggregateFunction;
 import io.confluent.ksql.metastore.model.KeyField;
 import io.confluent.ksql.name.ColumnName;
 import io.confluent.ksql.parser.tree.WindowExpression;
-import io.confluent.ksql.schema.ksql.Column;
 import io.confluent.ksql.schema.ksql.ColumnRef;
 import io.confluent.ksql.schema.ksql.LogicalSchema;
-import io.confluent.ksql.schema.ksql.types.SqlType;
 import io.confluent.ksql.serde.ValueFormat;
 import io.confluent.ksql.services.KafkaTopicClient;
 import io.confluent.ksql.structured.SchemaKGroupedStream;
@@ -201,11 +196,6 @@ public class AggregateNode extends PlanNode {
         builder
     );
 
-    // This is the schema used in any repartition topic
-    // It contains only the fields from the source that are needed by the aggregation
-    // It uses internal column names, e.g. KSQL_INTERNAL_COL_0
-    final LogicalSchema prepareSchema = aggregateArgExpanded.getSchema();
-
     final QueryContext.Stacker groupByContext = contextStacker.push(GROUP_BY_OP_NAME);
 
     final ValueFormat valueFormat = streamSourceNode
@@ -234,36 +224,14 @@ public class AggregateNode extends PlanNode {
         )
         .collect(Collectors.toList());
 
-    // This is the schema of the aggregation change log topic and associated state store.
-    // It contains all columns from prepareSchema and columns for any aggregating functions
-    // It uses internal column names, e.g. KSQL_INTERNAL_COL_0 and KSQL_AGG_VARIABLE_0
-    final LogicalSchema aggregationSchema = buildLogicalSchema(
-        prepareSchema,
-        functionsWithInternalIdentifiers,
-        builder.getFunctionRegistry(),
-        true
-    );
-
     final QueryContext.Stacker aggregationContext = contextStacker.push(AGGREGATION_OP_NAME);
 
-    // This is the schema post any {@link Udaf#map} steps to reduce intermediate aggregate state
-    // to the final output state
-    final LogicalSchema outputSchema = buildLogicalSchema(
-        prepareSchema,
-        functionsWithInternalIdentifiers,
-        builder.getFunctionRegistry(),
-        false
-    );
-
     SchemaKTable<?> aggregated = schemaKGroupedStream.aggregate(
-        aggregationSchema,
-        outputSchema,
         requiredColumns.size(),
         functionsWithInternalIdentifiers,
         windowExpression,
         valueFormat,
-        aggregationContext,
-        builder
+        aggregationContext
     );
 
     final Optional<Expression> havingExpression = Optional.ofNullable(havingExpressions)
@@ -286,34 +254,6 @@ public class AggregateNode extends PlanNode {
 
   protected int getPartitions(final KafkaTopicClient kafkaTopicClient) {
     return source.getPartitions(kafkaTopicClient);
-  }
-
-  private LogicalSchema buildLogicalSchema(
-      final LogicalSchema inputSchema,
-      final List<FunctionCall> aggregations,
-      final FunctionRegistry functionRegistry,
-      final boolean useAggregate
-  ) {
-    final LogicalSchema.Builder schemaBuilder = LogicalSchema.builder();
-    final List<Column> cols = inputSchema.value();
-
-    schemaBuilder.keyColumns(inputSchema.key());
-
-    for (int i = 0; i < requiredColumns.size(); i++) {
-      schemaBuilder.valueColumn(cols.get(i));
-    }
-
-    for (int i = 0; i < aggregations.size(); i++) {
-      final KsqlAggregateFunction aggregateFunction =
-          UdafUtil.resolveAggregateFunction(functionRegistry, aggregations.get(i), inputSchema);
-      final ColumnName colName = ColumnName.aggregateColumn(i);
-      final SqlType fieldType = useAggregate
-          ? aggregateFunction.getAggregateType()
-          : aggregateFunction.returnType();
-      schemaBuilder.valueColumn(colName, fieldType);
-    }
-
-    return schemaBuilder.build();
   }
 
   private static class InternalSchema {

--- a/ksql-engine/src/main/java/io/confluent/ksql/planner/plan/DataSourceNode.java
+++ b/ksql-engine/src/main/java/io/confluent/ksql/planner/plan/DataSourceNode.java
@@ -144,7 +144,8 @@ public class DataSourceNode extends PlanNode {
         contextStacker.push(SOURCE_OP_NAME),
         timestampIndex(),
         getAutoOffsetReset(builder.getKsqlConfig().getKsqlStreamConfigProps()),
-        keyField
+        keyField,
+        alias
     );
     if (getDataSourceType() == DataSourceType.KSTREAM) {
       return schemaKStream;
@@ -165,7 +166,8 @@ public class DataSourceNode extends PlanNode {
         QueryContext.Stacker contextStacker,
         int timestampIndex,
         Optional<AutoOffsetReset> offsetReset,
-        KeyField keyField
+        KeyField keyField,
+        SourceName alias
     );
   }
 

--- a/ksql-engine/src/main/java/io/confluent/ksql/structured/SchemaKStream.java
+++ b/ksql-engine/src/main/java/io/confluent/ksql/structured/SchemaKStream.java
@@ -54,6 +54,7 @@ import io.confluent.ksql.function.FunctionRegistry;
 import io.confluent.ksql.metastore.model.DataSource;
 import io.confluent.ksql.metastore.model.KeyField;
 import io.confluent.ksql.name.ColumnName;
+import io.confluent.ksql.name.SourceName;
 import io.confluent.ksql.query.QueryId;
 import io.confluent.ksql.schema.ksql.Column;
 import io.confluent.ksql.schema.ksql.ColumnRef;
@@ -120,7 +121,8 @@ public class SchemaKStream<K> {
       final QueryContext.Stacker contextStacker,
       final int timestampIndex,
       final Optional<AutoOffsetReset> offsetReset,
-      final KeyField keyField
+      final KeyField keyField,
+      final SourceName alias
   ) {
     final KsqlTopic topic = dataSource.getKsqlTopic();
     if (topic.getKeyFormat().isWindowed()) {
@@ -131,7 +133,8 @@ public class SchemaKStream<K> {
           Formats.of(topic.getKeyFormat(), topic.getValueFormat(), dataSource.getSerdeOptions()),
           dataSource.getTimestampExtractionPolicy(),
           timestampIndex,
-          offsetReset
+          offsetReset,
+          alias
       );
       return forSource(
           builder,
@@ -146,7 +149,8 @@ public class SchemaKStream<K> {
           Formats.of(topic.getKeyFormat(), topic.getValueFormat(), dataSource.getSerdeOptions()),
           dataSource.getTimestampExtractionPolicy(),
           timestampIndex,
-          offsetReset
+          offsetReset,
+          alias
       );
       return forSource(
           builder,

--- a/ksql-engine/src/test/java/io/confluent/ksql/planner/plan/DataSourceNodeTest.java
+++ b/ksql-engine/src/test/java/io/confluent/ksql/planner/plan/DataSourceNodeTest.java
@@ -23,6 +23,7 @@ import static org.hamcrest.Matchers.is;
 import static org.junit.Assert.assertThat;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.ArgumentMatchers.same;
 import static org.mockito.Mockito.mock;
@@ -175,7 +176,7 @@ public class DataSourceNodeTest {
     when(ksqlTopic.getKeyFormat()).thenReturn(KeyFormat.nonWindowed(FormatInfo.of(Format.KAFKA)));
     when(ksqlTopic.getValueFormat()).thenReturn(ValueFormat.of(FormatInfo.of(Format.JSON)));
     when(timestampExtractionPolicy.timestampField()).thenReturn(TIMESTAMP_FIELD);
-    when(schemaKStreamFactory.create(any(), any(), any(), any(), anyInt(), any(), any()))
+    when(schemaKStreamFactory.create(any(), any(), any(), any(), anyInt(), any(), any(), any()))
         .thenReturn(stream);
     when(stream.toTable(any(), any(), any())).thenReturn(table);
   }
@@ -280,7 +281,7 @@ public class DataSourceNodeTest {
     node.buildStream(ksqlStreamBuilder);
 
     // Then:
-    verify(schemaKStreamFactory).create(any(), any(), any(), any(), eq(1), any(), any());
+    verify(schemaKStreamFactory).create(any(), any(), any(), any(), eq(1), any(), any(), any());
   }
 
   // should this even be possible? if you are using a timestamp extractor then shouldn't the name
@@ -297,7 +298,7 @@ public class DataSourceNodeTest {
     node.buildStream(ksqlStreamBuilder);
 
     // Then:
-    verify(schemaKStreamFactory).create(any(), any(), any(), any(), eq(1), any(), any());
+    verify(schemaKStreamFactory).create(any(), any(), any(), any(), eq(1), any(), any(), any());
   }
 
   @Test
@@ -318,7 +319,8 @@ public class DataSourceNodeTest {
         stackerCaptor.capture(),
         eq(3),
         eq(OFFSET_RESET),
-        same(node.getKeyField())
+        same(node.getKeyField()),
+        eq(SourceName.of("name"))
     );
     assertThat(
         stackerCaptor.getValue().getQueryContext().getContext(),
@@ -342,7 +344,8 @@ public class DataSourceNodeTest {
         stackerCaptor.capture(),
         eq(3),
         eq(OFFSET_RESET),
-        same(node.getKeyField())
+        same(node.getKeyField()),
+        eq(SourceName.of("name"))
     );
     assertThat(
         stackerCaptor.getValue().getQueryContext().getContext(),

--- a/ksql-engine/src/test/java/io/confluent/ksql/structured/SchemaKGroupedStreamTest.java
+++ b/ksql-engine/src/test/java/io/confluent/ksql/structured/SchemaKGroupedStreamTest.java
@@ -21,7 +21,6 @@ import static org.hamcrest.Matchers.is;
 import static org.mockito.Mockito.when;
 
 import com.google.common.collect.ImmutableList;
-import io.confluent.ksql.execution.builder.KsqlQueryBuilder;
 import io.confluent.ksql.execution.context.QueryContext;
 import io.confluent.ksql.execution.expression.tree.ColumnReferenceExp;
 import io.confluent.ksql.execution.expression.tree.FunctionCall;
@@ -59,13 +58,13 @@ import org.mockito.junit.MockitoJUnitRunner;
 @SuppressWarnings("unchecked")
 @RunWith(MockitoJUnitRunner.class)
 public class SchemaKGroupedStreamTest {
-  private static final LogicalSchema AGG_SCHEMA = LogicalSchema.builder()
+  private static final LogicalSchema IN_SCHEMA = LogicalSchema.builder()
       .valueColumn(ColumnName.of("IN0"), SqlTypes.STRING)
-      .valueColumn(ColumnName.of("AGG0"), SqlTypes.BIGINT)
+      .valueColumn(ColumnName.of("IN1"), SqlTypes.INTEGER)
       .build();
   private static final LogicalSchema OUT_SCHEMA = LogicalSchema.builder()
       .valueColumn(ColumnName.of("IN0"), SqlTypes.STRING)
-      .valueColumn(ColumnName.of("OUT0"), SqlTypes.STRING)
+      .valueColumn(ColumnName.of("KSQL_AGG_VARIABLE_0"), SqlTypes.INTEGER)
       .build();
   private static final FunctionCall AGG = new FunctionCall(
       FunctionName.of("SUM"),
@@ -82,8 +81,6 @@ public class SchemaKGroupedStreamTest {
   @Mock
   private KsqlConfig config;
   @Mock
-  private FunctionCall aggCall;
-  @Mock
   private WindowExpression windowExp;
   @Mock
   private ExecutionStep sourceStep;
@@ -91,8 +88,6 @@ public class SchemaKGroupedStreamTest {
   private KeyFormat keyFormat;
   @Mock
   private ValueFormat valueFormat;
-  @Mock
-  private KsqlQueryBuilder builder;
 
   private final FunctionRegistry functionRegistry = new InternalFunctionRegistry();
   private final QueryContext.Stacker queryContext
@@ -102,6 +97,7 @@ public class SchemaKGroupedStreamTest {
 
   @Before
   public void setUp() {
+    when(sourceStep.getSchema()).thenReturn(IN_SCHEMA);
     schemaGroupedStream = new SchemaKGroupedStream(
         sourceStep,
         keyFormat,
@@ -118,14 +114,11 @@ public class SchemaKGroupedStreamTest {
   public void shouldReturnKTableWithOutputSchema() {
     // When:
     final SchemaKTable result = schemaGroupedStream.aggregate(
-        AGG_SCHEMA,
-        OUT_SCHEMA,
         1,
         ImmutableList.of(AGG),
         Optional.empty(),
         valueFormat,
-        queryContext,
-        builder
+        queryContext
     );
 
     // Then:
@@ -136,14 +129,11 @@ public class SchemaKGroupedStreamTest {
   public void shouldBuildStepForAggregate() {
     // When:
     final SchemaKTable result = schemaGroupedStream.aggregate(
-        AGG_SCHEMA,
-        OUT_SCHEMA,
         1,
         ImmutableList.of(AGG),
         Optional.empty(),
         valueFormat,
-        queryContext,
-        builder
+        queryContext
     );
 
     // Then:
@@ -153,11 +143,10 @@ public class SchemaKGroupedStreamTest {
             ExecutionStepFactory.streamAggregate(
                 queryContext,
                 schemaGroupedStream.getSourceStep(),
-                OUT_SCHEMA,
                 Formats.of(keyFormat, valueFormat, SerdeOption.none()),
                 1,
                 ImmutableList.of(AGG),
-                AGG_SCHEMA
+                functionRegistry
             )
         )
     );
@@ -167,14 +156,11 @@ public class SchemaKGroupedStreamTest {
   public void shouldBuildStepForWindowedAggregate() {
     // When:
     final SchemaKTable result = schemaGroupedStream.aggregate(
-        AGG_SCHEMA,
-        OUT_SCHEMA,
         1,
         ImmutableList.of(AGG),
         Optional.of(windowExp),
         valueFormat,
-        queryContext,
-        builder
+        queryContext
     );
 
     // Then:
@@ -188,29 +174,13 @@ public class SchemaKGroupedStreamTest {
             ExecutionStepFactory.streamWindowedAggregate(
                 queryContext,
                 schemaGroupedStream.getSourceStep(),
-                OUT_SCHEMA,
                 Formats.of(expected, valueFormat, SerdeOption.none()),
                 1,
                 ImmutableList.of(AGG),
-                AGG_SCHEMA,
-                KSQL_WINDOW_EXP
+                KSQL_WINDOW_EXP,
+                functionRegistry
             )
         )
-    );
-  }
-
-  @Test(expected = IllegalArgumentException.class)
-  public void shouldThrowOnColumnCountMismatch() {
-    // When:
-    schemaGroupedStream.aggregate(
-        AGG_SCHEMA,
-        OUT_SCHEMA,
-        2,
-        ImmutableList.of(aggCall),
-        Optional.of(windowExp),
-        valueFormat,
-        queryContext,
-        builder
     );
   }
 }

--- a/ksql-engine/src/test/java/io/confluent/ksql/structured/SchemaKTableTest.java
+++ b/ksql-engine/src/test/java/io/confluent/ksql/structured/SchemaKTableTest.java
@@ -51,7 +51,7 @@ import io.confluent.ksql.execution.plan.KeySerdeFactory;
 import io.confluent.ksql.execution.plan.PlanBuilder;
 import io.confluent.ksql.execution.plan.SelectExpression;
 import io.confluent.ksql.execution.plan.TableFilter;
-import io.confluent.ksql.execution.streams.AggregateParams;
+import io.confluent.ksql.execution.streams.AggregateParamsFactory;
 import io.confluent.ksql.execution.streams.ExecutionStepFactory;
 import io.confluent.ksql.execution.streams.GroupedFactory;
 import io.confluent.ksql.execution.streams.JoinedFactory;
@@ -191,7 +191,7 @@ public class SchemaKTableTest {
     planBuilder = new KSPlanBuilder(
         queryBuilder,
         mock(SqlPredicateFactory.class),
-        mock(AggregateParams.Factory.class),
+        mock(AggregateParamsFactory.class),
         new StreamsFactories(
             groupedFactory,
             mock(JoinedFactory.class),
@@ -205,8 +205,8 @@ public class SchemaKTableTest {
     final ExecutionStep sourceStep = Mockito.mock(ExecutionStep.class);
     when(sourceStep.getProperties()).thenReturn(
         new DefaultExecutionStepProperties(schema, queryContext.getQueryContext()));
-    when(sourceStep.getSchema()).thenReturn(schema);
-    when(sourceStep.build(any())).thenReturn(KTableHolder.unmaterialized(kTable, keySerdeFactory));
+    when(sourceStep.build(any())).thenReturn(
+        KTableHolder.unmaterialized(kTable, schema, keySerdeFactory));
     return sourceStep;
   }
 
@@ -254,7 +254,9 @@ public class SchemaKTableTest {
 
   private SchemaKTable buildSchemaKTableForJoin(final KsqlTable ksqlTable, final KTable kTable) {
     return buildSchemaKTable(
-        ksqlTable.getSchema(), ksqlTable.getKeyField(), kTable
+        ksqlTable.getSchema().withAlias(ksqlTable.getName()),
+        ksqlTable.getKeyField().withAlias(ksqlTable.getName()),
+        kTable
     );
   }
 

--- a/ksql-execution/src/main/java/io/confluent/ksql/execution/plan/AbstractStreamSource.java
+++ b/ksql-execution/src/main/java/io/confluent/ksql/execution/plan/AbstractStreamSource.java
@@ -33,6 +33,7 @@ public abstract class AbstractStreamSource<K> implements ExecutionStep<K> {
   private final int timestampIndex;
   private final Optional<AutoOffsetReset> offsetReset;
   private final LogicalSchema sourceSchema;
+  private final SourceName alias;
 
   public static LogicalSchemaWithMetaAndKeyFields getSchemaWithMetaAndKeyFields(
       final SourceName alias,
@@ -48,7 +49,8 @@ public abstract class AbstractStreamSource<K> implements ExecutionStep<K> {
       final TimestampExtractionPolicy timestampPolicy,
       final int timestampIndex,
       final Optional<AutoOffsetReset> offsetReset,
-      final LogicalSchema sourceSchema) {
+      final LogicalSchema sourceSchema,
+      final SourceName alias) {
     this.properties = Objects.requireNonNull(properties, "properties");
     this.topicName = Objects.requireNonNull(topicName, "topicName");
     this.formats = Objects.requireNonNull(formats, "formats");
@@ -56,6 +58,7 @@ public abstract class AbstractStreamSource<K> implements ExecutionStep<K> {
     this.timestampIndex = timestampIndex;
     this.offsetReset = Objects.requireNonNull(offsetReset, "offsetReset");
     this.sourceSchema = Objects.requireNonNull(sourceSchema, "sourceSchema");
+    this.alias = Objects.requireNonNull(alias, "alias");
   }
 
   @Override
@@ -90,6 +93,10 @@ public abstract class AbstractStreamSource<K> implements ExecutionStep<K> {
 
   public String getTopicName() {
     return topicName;
+  }
+
+  public SourceName getAlias() {
+    return alias;
   }
 
   @Override

--- a/ksql-execution/src/main/java/io/confluent/ksql/execution/plan/KGroupedStreamHolder.java
+++ b/ksql-execution/src/main/java/io/confluent/ksql/execution/plan/KGroupedStreamHolder.java
@@ -1,0 +1,48 @@
+/*
+ * Copyright 2019 Confluent Inc.
+ *
+ * Licensed under the Confluent Community License (the "License"); you may not use
+ * this file except in compliance with the License.  You may obtain a copy of the
+ * License at
+ *
+ * http://www.confluent.io/confluent-community-license
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package io.confluent.ksql.execution.plan;
+
+import io.confluent.ksql.GenericRow;
+import io.confluent.ksql.schema.ksql.LogicalSchema;
+import java.util.Objects;
+import org.apache.kafka.connect.data.Struct;
+import org.apache.kafka.streams.kstream.KGroupedStream;
+
+public final class KGroupedStreamHolder {
+  final KGroupedStream<Struct, GenericRow> groupedStream;
+  final LogicalSchema schema;
+
+  private KGroupedStreamHolder(
+      KGroupedStream<Struct, GenericRow> groupedStream,
+      LogicalSchema schema) {
+    this.groupedStream = Objects.requireNonNull(groupedStream, "groupedStream");
+    this.schema = Objects.requireNonNull(schema, "schema");
+  }
+
+  public static KGroupedStreamHolder of(
+      KGroupedStream<Struct, GenericRow> groupedStream,
+      LogicalSchema schema) {
+    return new KGroupedStreamHolder(groupedStream, schema);
+  }
+
+  public LogicalSchema getSchema() {
+    return schema;
+  }
+
+  public KGroupedStream<Struct, GenericRow> getGroupedStream() {
+    return groupedStream;
+  }
+}

--- a/ksql-execution/src/main/java/io/confluent/ksql/execution/plan/KGroupedTableHolder.java
+++ b/ksql-execution/src/main/java/io/confluent/ksql/execution/plan/KGroupedTableHolder.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright 2019 Confluent Inc.
+ *
+ * Licensed under the Confluent Community License (the "License"); you may not use
+ * this file except in compliance with the License.  You may obtain a copy of the
+ * License at
+ *
+ * http://www.confluent.io/confluent-community-license
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package io.confluent.ksql.execution.plan;
+
+import io.confluent.ksql.GenericRow;
+import io.confluent.ksql.schema.ksql.LogicalSchema;
+import java.util.Objects;
+import org.apache.kafka.connect.data.Struct;
+import org.apache.kafka.streams.kstream.KGroupedTable;
+
+public final class KGroupedTableHolder {
+  private final KGroupedTable<Struct, GenericRow> groupedTable;
+  private final LogicalSchema schema;
+
+  private KGroupedTableHolder(
+      KGroupedTable<Struct, GenericRow> groupedTable,
+      LogicalSchema schema) {
+    this.groupedTable = Objects.requireNonNull(groupedTable, "groupedTable");
+    this.schema = Objects.requireNonNull(schema, "schema");
+  }
+
+  public static KGroupedTableHolder of(
+      KGroupedTable<Struct, GenericRow> groupedTable,
+      LogicalSchema schema
+  ) {
+    return new KGroupedTableHolder(groupedTable, schema);
+  }
+
+  public LogicalSchema getSchema() {
+    return schema;
+  }
+
+  public KGroupedTable<Struct, GenericRow> getGroupedTable() {
+    return groupedTable;
+  }
+}

--- a/ksql-execution/src/main/java/io/confluent/ksql/execution/plan/KStreamHolder.java
+++ b/ksql-execution/src/main/java/io/confluent/ksql/execution/plan/KStreamHolder.java
@@ -16,19 +16,23 @@
 package io.confluent.ksql.execution.plan;
 
 import io.confluent.ksql.GenericRow;
+import io.confluent.ksql.schema.ksql.LogicalSchema;
 import java.util.Objects;
 import org.apache.kafka.streams.kstream.KStream;
 
 public final class KStreamHolder<K> {
   private final KStream<K, GenericRow> stream;
   private final KeySerdeFactory<K> keySerdeFactory;
+  private final LogicalSchema schema;
 
   public KStreamHolder(
       final KStream<K, GenericRow> stream,
+      final LogicalSchema schema,
       final KeySerdeFactory<K> keySerdeFactory
   ) {
     this.stream = Objects.requireNonNull(stream, "stream");
     this.keySerdeFactory = Objects.requireNonNull(keySerdeFactory, "keySerdeFactory");
+    this.schema = Objects.requireNonNull(schema, "shcema");
   }
 
   public KeySerdeFactory<K> getKeySerdeFactory() {
@@ -39,7 +43,13 @@ public final class KStreamHolder<K> {
     return stream;
   }
 
-  public KStreamHolder<K> withStream(final KStream<K, GenericRow> stream) {
-    return new KStreamHolder<>(stream, keySerdeFactory);
+  public KStreamHolder<K> withStream(
+      final KStream<K, GenericRow> stream,
+      final LogicalSchema schema) {
+    return new KStreamHolder<>(stream, schema, keySerdeFactory);
+  }
+
+  public LogicalSchema getSchema() {
+    return schema;
   }
 }

--- a/ksql-execution/src/main/java/io/confluent/ksql/execution/plan/KTableHolder.java
+++ b/ksql-execution/src/main/java/io/confluent/ksql/execution/plan/KTableHolder.java
@@ -17,6 +17,7 @@ package io.confluent.ksql.execution.plan;
 
 import io.confluent.ksql.GenericRow;
 import io.confluent.ksql.execution.materialization.MaterializationInfo;
+import io.confluent.ksql.schema.ksql.LogicalSchema;
 import java.util.Objects;
 import java.util.Optional;
 import org.apache.kafka.streams.kstream.KTable;
@@ -24,32 +25,37 @@ import org.apache.kafka.streams.kstream.KTable;
 public final class KTableHolder<K> {
   private final KTable<K, GenericRow> stream;
   private final KeySerdeFactory<K> keySerdeFactory;
+  private final LogicalSchema schema;
   private final Optional<MaterializationInfo.Builder> materializationBuilder;
 
   private KTableHolder(
       final KTable<K, GenericRow> stream,
+      final LogicalSchema schema,
       final KeySerdeFactory<K> keySerdeFactory,
       final Optional<MaterializationInfo.Builder> materializationBuilder
   ) {
     this.stream = Objects.requireNonNull(stream, "stream");
     this.keySerdeFactory = Objects.requireNonNull(keySerdeFactory, "keySerdeFactory");
+    this.schema = Objects.requireNonNull(schema, "schema");
     this.materializationBuilder =
         Objects.requireNonNull(materializationBuilder, "materializationProvider");
   }
 
   public static <K> KTableHolder<K> unmaterialized(
       final KTable<K, GenericRow> stream,
+      final LogicalSchema schema,
       final KeySerdeFactory<K> keySerdeFactory
   ) {
-    return new KTableHolder<>(stream, keySerdeFactory, Optional.empty());
+    return new KTableHolder<>(stream, schema, keySerdeFactory, Optional.empty());
   }
 
   public static <K> KTableHolder<K> materialized(
       final KTable<K, GenericRow> stream,
+      final LogicalSchema schema,
       final KeySerdeFactory<K> keySerdeFactory,
       final MaterializationInfo.Builder materializationBuilder
   ) {
-    return new KTableHolder<>(stream, keySerdeFactory, Optional.of(materializationBuilder));
+    return new KTableHolder<>(stream, schema, keySerdeFactory, Optional.of(materializationBuilder));
   }
 
   public KeySerdeFactory<K> getKeySerdeFactory() {
@@ -64,13 +70,18 @@ public final class KTableHolder<K> {
     return materializationBuilder;
   }
 
-  public KTableHolder<K> withTable(final KTable<K, GenericRow> table) {
-    return new KTableHolder<>(table, keySerdeFactory, materializationBuilder);
+  public LogicalSchema getSchema() {
+    return schema;
+  }
+
+  public KTableHolder<K> withTable(final KTable<K, GenericRow> table, final LogicalSchema schema) {
+    return new KTableHolder<>(table, schema, keySerdeFactory, materializationBuilder);
   }
 
   public KTableHolder<K> withMaterialization(final Optional<MaterializationInfo.Builder> builder) {
     return new KTableHolder<>(
         stream,
+        schema,
         keySerdeFactory,
         builder
     );

--- a/ksql-execution/src/main/java/io/confluent/ksql/execution/plan/PlanBuilder.java
+++ b/ksql-execution/src/main/java/io/confluent/ksql/execution/plan/PlanBuilder.java
@@ -15,10 +15,7 @@
 
 package io.confluent.ksql.execution.plan;
 
-import io.confluent.ksql.GenericRow;
 import org.apache.kafka.connect.data.Struct;
-import org.apache.kafka.streams.kstream.KGroupedStream;
-import org.apache.kafka.streams.kstream.KGroupedTable;
 import org.apache.kafka.streams.kstream.Windowed;
 
 /**
@@ -30,9 +27,9 @@ import org.apache.kafka.streams.kstream.Windowed;
 public interface PlanBuilder {
   <K> KStreamHolder<K> visitStreamFilter(StreamFilter<K> streamFilter);
 
-  <K> KGroupedStream<Struct, GenericRow> visitStreamGroupBy(StreamGroupBy<K> streamGroupBy);
+  <K> KGroupedStreamHolder visitStreamGroupBy(StreamGroupBy<K> streamGroupBy);
 
-  KGroupedStream<Struct, GenericRow> visitStreamGroupByKey(StreamGroupByKey streamGroupByKey);
+  KGroupedStreamHolder visitStreamGroupByKey(StreamGroupByKey streamGroupByKey);
 
   KTableHolder<Struct> visitStreamAggregate(StreamAggregate streamAggregate);
 
@@ -62,7 +59,7 @@ public interface PlanBuilder {
 
   <K> KTableHolder<K> visitTableFilter(TableFilter<K> tableFilter);
 
-  <K> KGroupedTable<Struct, GenericRow> visitTableGroupBy(TableGroupBy<K> tableGroupBy);
+  <K> KGroupedTableHolder visitTableGroupBy(TableGroupBy<K> tableGroupBy);
 
   <K> KTableHolder<K> visitTableMapValues(TableMapValues<K> tableMapValues);
 

--- a/ksql-execution/src/main/java/io/confluent/ksql/execution/plan/StreamAggregate.java
+++ b/ksql-execution/src/main/java/io/confluent/ksql/execution/plan/StreamAggregate.java
@@ -15,37 +15,31 @@
 package io.confluent.ksql.execution.plan;
 
 import com.google.errorprone.annotations.Immutable;
-import io.confluent.ksql.GenericRow;
 import io.confluent.ksql.execution.expression.tree.FunctionCall;
-import io.confluent.ksql.schema.ksql.LogicalSchema;
 import java.util.Collections;
 import java.util.List;
 import java.util.Objects;
 import org.apache.kafka.connect.data.Struct;
-import org.apache.kafka.streams.kstream.KGroupedStream;
 
 @Immutable
 public class StreamAggregate implements ExecutionStep<KTableHolder<Struct>> {
   private final ExecutionStepProperties properties;
-  private final ExecutionStep<KGroupedStream<Struct, GenericRow>> source;
+  private final ExecutionStep<KGroupedStreamHolder> source;
   private final Formats formats;
   private final int nonFuncColumnCount;
   private final List<FunctionCall> aggregations;
-  private final LogicalSchema aggregationSchema;
 
   public StreamAggregate(
       final ExecutionStepProperties properties,
-      final ExecutionStep<KGroupedStream<Struct, GenericRow>> source,
+      final ExecutionStep<KGroupedStreamHolder> source,
       final Formats formats,
       final int nonFuncColumnCount,
-      final List<FunctionCall> aggregations,
-      final LogicalSchema aggregationSchema) {
+      final List<FunctionCall> aggregations) {
     this.properties = Objects.requireNonNull(properties, "properties");
     this.source = Objects.requireNonNull(source, "source");
     this.formats = Objects.requireNonNull(formats, "formats");
     this.nonFuncColumnCount = nonFuncColumnCount;
     this.aggregations = Objects.requireNonNull(aggregations, "aggregations");
-    this.aggregationSchema = Objects.requireNonNull(aggregationSchema, "aggregationSchema");
   }
 
   @Override
@@ -70,11 +64,7 @@ public class StreamAggregate implements ExecutionStep<KTableHolder<Struct>> {
     return formats;
   }
 
-  public LogicalSchema getAggregationSchema() {
-    return aggregationSchema;
-  }
-
-  public ExecutionStep<KGroupedStream<Struct, GenericRow>> getSource() {
+  public ExecutionStep<KGroupedStreamHolder> getSource() {
     return source;
   }
 
@@ -96,8 +86,7 @@ public class StreamAggregate implements ExecutionStep<KTableHolder<Struct>> {
         && Objects.equals(source, that.source)
         && Objects.equals(formats, that.formats)
         && Objects.equals(aggregations, that.aggregations)
-        && nonFuncColumnCount == that.nonFuncColumnCount
-        && aggregationSchema.equals(that.aggregationSchema);
+        && nonFuncColumnCount == that.nonFuncColumnCount;
   }
 
   @Override
@@ -108,8 +97,7 @@ public class StreamAggregate implements ExecutionStep<KTableHolder<Struct>> {
         source,
         formats,
         aggregations,
-        nonFuncColumnCount,
-        aggregationSchema
+        nonFuncColumnCount
     );
   }
 }

--- a/ksql-execution/src/main/java/io/confluent/ksql/execution/plan/StreamGroupBy.java
+++ b/ksql-execution/src/main/java/io/confluent/ksql/execution/plan/StreamGroupBy.java
@@ -15,16 +15,13 @@
 package io.confluent.ksql.execution.plan;
 
 import com.google.errorprone.annotations.Immutable;
-import io.confluent.ksql.GenericRow;
 import io.confluent.ksql.execution.expression.tree.Expression;
 import java.util.Collections;
 import java.util.List;
 import java.util.Objects;
-import org.apache.kafka.connect.data.Struct;
-import org.apache.kafka.streams.kstream.KGroupedStream;
 
 @Immutable
-public class StreamGroupBy<K> implements ExecutionStep<KGroupedStream<Struct, GenericRow>> {
+public class StreamGroupBy<K> implements ExecutionStep<KGroupedStreamHolder> {
   private final ExecutionStepProperties properties;
   private final ExecutionStep<KStreamHolder<K>> source;
   private final Formats formats;
@@ -64,7 +61,7 @@ public class StreamGroupBy<K> implements ExecutionStep<KGroupedStream<Struct, Ge
   }
 
   @Override
-  public KGroupedStream<Struct, GenericRow> build(final PlanBuilder planVisitor) {
+  public KGroupedStreamHolder build(final PlanBuilder planVisitor) {
     return planVisitor.visitStreamGroupBy(this);
   }
 

--- a/ksql-execution/src/main/java/io/confluent/ksql/execution/plan/StreamGroupByKey.java
+++ b/ksql-execution/src/main/java/io/confluent/ksql/execution/plan/StreamGroupByKey.java
@@ -15,15 +15,13 @@
 package io.confluent.ksql.execution.plan;
 
 import com.google.errorprone.annotations.Immutable;
-import io.confluent.ksql.GenericRow;
 import java.util.Collections;
 import java.util.List;
 import java.util.Objects;
 import org.apache.kafka.connect.data.Struct;
-import org.apache.kafka.streams.kstream.KGroupedStream;
 
 @Immutable
-public class StreamGroupByKey implements ExecutionStep<KGroupedStream<Struct, GenericRow>> {
+public class StreamGroupByKey implements ExecutionStep<KGroupedStreamHolder> {
   private final ExecutionStepProperties properties;
   private final ExecutionStep<KStreamHolder<Struct>> source;
   private final Formats formats;
@@ -56,7 +54,7 @@ public class StreamGroupByKey implements ExecutionStep<KGroupedStream<Struct, Ge
   }
 
   @Override
-  public KGroupedStream<Struct, GenericRow> build(final PlanBuilder builder) {
+  public KGroupedStreamHolder build(final PlanBuilder builder) {
     return builder.visitStreamGroupByKey(this);
   }
 

--- a/ksql-execution/src/main/java/io/confluent/ksql/execution/plan/StreamSource.java
+++ b/ksql-execution/src/main/java/io/confluent/ksql/execution/plan/StreamSource.java
@@ -15,6 +15,7 @@
 package io.confluent.ksql.execution.plan;
 
 import com.google.errorprone.annotations.Immutable;
+import io.confluent.ksql.name.SourceName;
 import io.confluent.ksql.schema.ksql.LogicalSchema;
 import io.confluent.ksql.util.timestamp.TimestampExtractionPolicy;
 import java.util.Optional;
@@ -30,7 +31,8 @@ public final class StreamSource extends AbstractStreamSource<KStreamHolder<Struc
       final TimestampExtractionPolicy timestampPolicy,
       final int timestampIndex,
       final Optional<AutoOffsetReset> offsetReset,
-      final LogicalSchema sourceSchema) {
+      final LogicalSchema sourceSchema,
+      final SourceName alias) {
     super(
         properties,
         topicName,
@@ -38,7 +40,8 @@ public final class StreamSource extends AbstractStreamSource<KStreamHolder<Struc
         timestampPolicy,
         timestampIndex,
         offsetReset,
-        sourceSchema
+        sourceSchema,
+        alias
     );
   }
 

--- a/ksql-execution/src/main/java/io/confluent/ksql/execution/plan/StreamWindowedAggregate.java
+++ b/ksql-execution/src/main/java/io/confluent/ksql/execution/plan/StreamWindowedAggregate.java
@@ -15,41 +15,35 @@
 
 package io.confluent.ksql.execution.plan;
 
-import io.confluent.ksql.GenericRow;
 import io.confluent.ksql.execution.expression.tree.FunctionCall;
 import io.confluent.ksql.execution.windows.KsqlWindowExpression;
-import io.confluent.ksql.schema.ksql.LogicalSchema;
 import java.util.Collections;
 import java.util.List;
 import java.util.Objects;
 import org.apache.kafka.connect.data.Struct;
-import org.apache.kafka.streams.kstream.KGroupedStream;
 import org.apache.kafka.streams.kstream.Windowed;
 
 public class StreamWindowedAggregate
     implements ExecutionStep<KTableHolder<Windowed<Struct>>> {
   private final ExecutionStepProperties properties;
-  private final ExecutionStep<KGroupedStream<Struct, GenericRow>> source;
+  private final ExecutionStep<KGroupedStreamHolder> source;
   private final Formats formats;
   private final int nonFuncColumnCount;
   private final List<FunctionCall> aggregations;
-  private final LogicalSchema aggregationSchema;
   private final KsqlWindowExpression windowExpression;
 
   public StreamWindowedAggregate(
       final ExecutionStepProperties properties,
-      final ExecutionStep<KGroupedStream<Struct, GenericRow>> source,
+      final ExecutionStep<KGroupedStreamHolder> source,
       final Formats formats,
       final int nonFuncColumnCount,
       final List<FunctionCall> aggregations,
-      final LogicalSchema aggregationSchema,
       final KsqlWindowExpression windowExpression) {
     this.properties = Objects.requireNonNull(properties, "properties");
     this.source = Objects.requireNonNull(source, "source");
     this.formats = Objects.requireNonNull(formats, "formats");
     this.nonFuncColumnCount = nonFuncColumnCount;
     this.aggregations = Objects.requireNonNull(aggregations, "aggregations");
-    this.aggregationSchema = Objects.requireNonNull(aggregationSchema, "aggregationSchema");
     this.windowExpression = Objects.requireNonNull(windowExpression, "windowExpression");
   }
 
@@ -75,15 +69,11 @@ public class StreamWindowedAggregate
     return formats;
   }
 
-  public LogicalSchema getAggregationSchema() {
-    return aggregationSchema;
-  }
-
   public KsqlWindowExpression getWindowExpression() {
     return windowExpression;
   }
 
-  public ExecutionStep<KGroupedStream<Struct, GenericRow>> getSource() {
+  public ExecutionStep<KGroupedStreamHolder> getSource() {
     return source;
   }
 
@@ -106,7 +96,6 @@ public class StreamWindowedAggregate
         && Objects.equals(formats, that.formats)
         && Objects.equals(aggregations, that.aggregations)
         && nonFuncColumnCount == that.nonFuncColumnCount
-        && Objects.equals(aggregationSchema, that.aggregationSchema)
         && Objects.equals(windowExpression, that.windowExpression);
   }
 
@@ -119,7 +108,6 @@ public class StreamWindowedAggregate
         formats,
         aggregations,
         nonFuncColumnCount,
-        aggregationSchema,
         windowExpression
     );
   }

--- a/ksql-execution/src/main/java/io/confluent/ksql/execution/plan/TableAggregate.java
+++ b/ksql-execution/src/main/java/io/confluent/ksql/execution/plan/TableAggregate.java
@@ -15,37 +15,31 @@
 package io.confluent.ksql.execution.plan;
 
 import com.google.errorprone.annotations.Immutable;
-import io.confluent.ksql.GenericRow;
 import io.confluent.ksql.execution.expression.tree.FunctionCall;
-import io.confluent.ksql.schema.ksql.LogicalSchema;
 import java.util.Collections;
 import java.util.List;
 import java.util.Objects;
 import org.apache.kafka.connect.data.Struct;
-import org.apache.kafka.streams.kstream.KGroupedTable;
 
 @Immutable
 public class TableAggregate implements ExecutionStep<KTableHolder<Struct>> {
   private final ExecutionStepProperties properties;
-  private final ExecutionStep<KGroupedTable<Struct, GenericRow>> source;
+  private final ExecutionStep<KGroupedTableHolder> source;
   private final Formats formats;
   private final int nonFuncColumnCount;
   private final List<FunctionCall> aggregations;
-  private final LogicalSchema aggregationSchema;
 
   public TableAggregate(
       final ExecutionStepProperties properties,
-      final ExecutionStep<KGroupedTable<Struct, GenericRow>> source,
+      final ExecutionStep<KGroupedTableHolder> source,
       final Formats formats,
       final int nonFuncColumnCount,
-      final List<FunctionCall> aggregations,
-      final LogicalSchema aggregationSchema) {
+      final List<FunctionCall> aggregations) {
     this.properties = Objects.requireNonNull(properties, "properties");
     this.source = Objects.requireNonNull(source, "source");
     this.formats = Objects.requireNonNull(formats, "formats");
     this.nonFuncColumnCount = nonFuncColumnCount;
     this.aggregations = Objects.requireNonNull(aggregations, "aggValToFunctionMap");
-    this.aggregationSchema = Objects.requireNonNull(aggregationSchema, "aggregationSchema");
   }
 
   @Override
@@ -70,11 +64,7 @@ public class TableAggregate implements ExecutionStep<KTableHolder<Struct>> {
     return nonFuncColumnCount;
   }
 
-  public LogicalSchema getAggregationSchema() {
-    return aggregationSchema;
-  }
-
-  public ExecutionStep<KGroupedTable<Struct, GenericRow>> getSource() {
+  public ExecutionStep<KGroupedTableHolder> getSource() {
     return source;
   }
 
@@ -96,8 +86,7 @@ public class TableAggregate implements ExecutionStep<KTableHolder<Struct>> {
         && Objects.equals(source, that.source)
         && Objects.equals(formats, that.formats)
         && nonFuncColumnCount == that.nonFuncColumnCount
-        && Objects.equals(aggregations, that.aggregations)
-        && Objects.equals(aggregationSchema, that.aggregationSchema);
+        && Objects.equals(aggregations, that.aggregations);
   }
 
   @Override

--- a/ksql-execution/src/main/java/io/confluent/ksql/execution/plan/TableGroupBy.java
+++ b/ksql-execution/src/main/java/io/confluent/ksql/execution/plan/TableGroupBy.java
@@ -15,16 +15,13 @@
 package io.confluent.ksql.execution.plan;
 
 import com.google.errorprone.annotations.Immutable;
-import io.confluent.ksql.GenericRow;
 import io.confluent.ksql.execution.expression.tree.Expression;
 import java.util.Collections;
 import java.util.List;
 import java.util.Objects;
-import org.apache.kafka.connect.data.Struct;
-import org.apache.kafka.streams.kstream.KGroupedTable;
 
 @Immutable
-public class TableGroupBy<K> implements ExecutionStep<KGroupedTable<Struct, GenericRow>> {
+public class TableGroupBy<K> implements ExecutionStep<KGroupedTableHolder> {
   private final ExecutionStepProperties properties;
   private final ExecutionStep<KTableHolder<K>> source;
   private final Formats formats;
@@ -65,7 +62,7 @@ public class TableGroupBy<K> implements ExecutionStep<KGroupedTable<Struct, Gene
   }
 
   @Override
-  public KGroupedTable<Struct, GenericRow> build(final PlanBuilder builder) {
+  public KGroupedTableHolder build(final PlanBuilder builder) {
     return builder.visitTableGroupBy(this);
   }
 

--- a/ksql-execution/src/main/java/io/confluent/ksql/execution/plan/WindowedStreamSource.java
+++ b/ksql-execution/src/main/java/io/confluent/ksql/execution/plan/WindowedStreamSource.java
@@ -15,6 +15,7 @@
 
 package io.confluent.ksql.execution.plan;
 
+import io.confluent.ksql.name.SourceName;
 import io.confluent.ksql.schema.ksql.LogicalSchema;
 import io.confluent.ksql.util.timestamp.TimestampExtractionPolicy;
 import java.util.Optional;
@@ -31,7 +32,8 @@ public final class WindowedStreamSource
       final TimestampExtractionPolicy timestampPolicy,
       final int timestampIndex,
       final Optional<AutoOffsetReset> offsetReset,
-      final LogicalSchema sourceSchema) {
+      final LogicalSchema sourceSchema,
+      final SourceName alias) {
     super(
         properties,
         topicName,
@@ -39,7 +41,8 @@ public final class WindowedStreamSource
         timestampPolicy,
         timestampIndex,
         offsetReset,
-        sourceSchema
+        sourceSchema,
+        alias
     );
   }
 

--- a/ksql-execution/src/main/java/io/confluent/ksql/execution/util/SinkSchemaUtil.java
+++ b/ksql-execution/src/main/java/io/confluent/ksql/execution/util/SinkSchemaUtil.java
@@ -16,7 +16,6 @@
 package io.confluent.ksql.execution.util;
 
 import com.google.common.collect.Streams;
-import io.confluent.ksql.execution.plan.ExecutionStep;
 import io.confluent.ksql.name.ColumnName;
 import io.confluent.ksql.schema.ksql.Column;
 import io.confluent.ksql.schema.ksql.LogicalSchema;
@@ -31,13 +30,11 @@ public final class SinkSchemaUtil {
   private SinkSchemaUtil() {
   }
 
-  public static LogicalSchema sinkSchema(ExecutionStep<?> step) {
-    LogicalSchema schema = step.getSources().get(0).getProperties().getSchema();
+  public static LogicalSchema sinkSchema(LogicalSchema schema) {
     return schema.withoutMetaAndKeyColsInValue();
   }
 
-  public static Set<Integer> implicitAndKeyColumnIndexesInValueSchema(ExecutionStep<?> step) {
-    LogicalSchema schema = step.getSources().get(0).getProperties().getSchema();
+  public static Set<Integer> implicitAndKeyColumnIndexesInValueSchema(LogicalSchema schema) {
     ConnectSchema valueSchema = schema.valueConnectSchema();
 
     Stream<Column> cols = Streams.concat(

--- a/ksql-execution/src/test/java/io/confluent/ksql/execution/util/SinkSchemaUtilTest.java
+++ b/ksql-execution/src/test/java/io/confluent/ksql/execution/util/SinkSchemaUtilTest.java
@@ -17,53 +17,27 @@ package io.confluent.ksql.execution.util;
 
 import static org.hamcrest.Matchers.contains;
 import static org.junit.Assert.assertThat;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.when;
-
-import com.google.common.collect.ImmutableList;
-import io.confluent.ksql.execution.context.QueryContext;
-import io.confluent.ksql.execution.plan.DefaultExecutionStepProperties;
-import io.confluent.ksql.execution.plan.ExecutionStep;
 import io.confluent.ksql.name.ColumnName;
 import io.confluent.ksql.schema.ksql.LogicalSchema;
 import io.confluent.ksql.schema.ksql.types.SqlTypes;
 import java.util.Set;
-import org.junit.Rule;
 import org.junit.Test;
-import org.mockito.Mock;
-import org.mockito.junit.MockitoJUnit;
-import org.mockito.junit.MockitoRule;
 
 public class SinkSchemaUtilTest {
-
-  @Mock
-  private ExecutionStep step;
-
-  @Rule
-  public final MockitoRule mockitoRule = MockitoJUnit.rule();
-
-  private void givenStepWithSchema(LogicalSchema schema) {
-    when(step.getSources()).thenReturn(ImmutableList.of(step));
-    when(step.getProperties()).thenReturn(
-        new DefaultExecutionStepProperties(schema, mock(QueryContext.class))
-    );
-  }
-
   @Test
   public void shouldComputeIndexesToRemoveImplicitsAndRowKey() {
     // Given:
-    givenStepWithSchema(LogicalSchema.builder()
+    LogicalSchema schema = LogicalSchema.builder()
         .valueColumn(ColumnName.of("field1"), SqlTypes.STRING)
         .valueColumn(ColumnName.of("field2"), SqlTypes.STRING)
         .valueColumn(ColumnName.of("field3"), SqlTypes.STRING)
         .valueColumn(ColumnName.of("timestamp"), SqlTypes.BIGINT)
         .valueColumn(ColumnName.of("key"), SqlTypes.STRING)
         .build()
-        .withMetaAndKeyColsInValue()
-    );
+        .withMetaAndKeyColsInValue();
 
     // When:
-    Set<Integer> indices = SinkSchemaUtil.implicitAndKeyColumnIndexesInValueSchema(step);
+    Set<Integer> indices = SinkSchemaUtil.implicitAndKeyColumnIndexesInValueSchema(schema);
 
     // Then:
     assertThat(indices, contains(0, 1));
@@ -72,7 +46,7 @@ public class SinkSchemaUtilTest {
   @Test
   public void shouldComputeIndexesToRemoveImplicitsAndRowKeyRegardlessOfLocation() {
     // Given:
-    givenStepWithSchema(LogicalSchema.builder()
+    LogicalSchema schema = LogicalSchema.builder()
         .valueColumn(ColumnName.of("field1"), SqlTypes.STRING)
         .valueColumn(ColumnName.of("field2"), SqlTypes.STRING)
         .valueColumn(ColumnName.of("ROWKEY"), SqlTypes.STRING)
@@ -80,11 +54,10 @@ public class SinkSchemaUtilTest {
         .valueColumn(ColumnName.of("timestamp"), SqlTypes.BIGINT)
         .valueColumn(ColumnName.of("ROWTIME"), SqlTypes.BIGINT)
         .valueColumn(ColumnName.of("key"), SqlTypes.STRING)
-        .build()
-    );
+        .build();
 
     // When:
-    Set<Integer> indices = SinkSchemaUtil.implicitAndKeyColumnIndexesInValueSchema(step);
+    Set<Integer> indices = SinkSchemaUtil.implicitAndKeyColumnIndexesInValueSchema(schema);
 
     // Then:
     assertThat(indices, contains(2, 5));

--- a/ksql-streams/src/main/java/io/confluent/ksql/execution/streams/AggregateParamsFactory.java
+++ b/ksql-streams/src/main/java/io/confluent/ksql/execution/streams/AggregateParamsFactory.java
@@ -1,0 +1,139 @@
+/*
+ * Copyright 2019 Confluent Inc.
+ *
+ * Licensed under the Confluent Community License (the "License"); you may not use
+ * this file except in compliance with the License.  You may obtain a copy of the
+ * License at
+ *
+ * http://www.confluent.io/confluent-community-license
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package io.confluent.ksql.execution.streams;
+
+import com.google.common.annotations.VisibleForTesting;
+import com.google.common.collect.ImmutableList;
+import io.confluent.ksql.execution.expression.tree.FunctionCall;
+import io.confluent.ksql.execution.function.TableAggregationFunction;
+import io.confluent.ksql.execution.function.UdafUtil;
+import io.confluent.ksql.execution.function.udaf.KudafAggregator;
+import io.confluent.ksql.execution.function.udaf.KudafInitializer;
+import io.confluent.ksql.execution.function.udaf.KudafUndoAggregator;
+import io.confluent.ksql.execution.function.udaf.window.WindowSelectMapper;
+import io.confluent.ksql.function.FunctionRegistry;
+import io.confluent.ksql.function.KsqlAggregateFunction;
+import io.confluent.ksql.name.ColumnName;
+import io.confluent.ksql.schema.ksql.Column;
+import io.confluent.ksql.schema.ksql.LogicalSchema;
+import io.confluent.ksql.schema.ksql.types.SqlType;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.Objects;
+import java.util.Optional;
+import java.util.function.Supplier;
+import java.util.stream.Collectors;
+
+public class AggregateParamsFactory {
+  private final KudafAggregatorFactory aggregatorFactory;
+
+  public AggregateParamsFactory() {
+    this(KudafAggregator::new);
+  }
+
+  @VisibleForTesting
+  AggregateParamsFactory(final KudafAggregatorFactory aggregatorFactory) {
+    this.aggregatorFactory = Objects.requireNonNull(aggregatorFactory);
+  }
+
+  public AggregateParams createUndoable(
+      final LogicalSchema schema,
+      final int initialUdafIndex,
+      final FunctionRegistry functionRegistry,
+      final List<FunctionCall> functionList
+  ) {
+    return create(schema, initialUdafIndex, functionRegistry, functionList, true);
+  }
+
+  public AggregateParams create(
+      final LogicalSchema schema,
+      final int initialUdafIndex,
+      final FunctionRegistry functionRegistry,
+      final List<FunctionCall> functionList
+  ) {
+    return create(schema, initialUdafIndex, functionRegistry, functionList, false);
+  }
+
+  private AggregateParams create(
+      final LogicalSchema schema,
+      final int initialUdafIndex,
+      final FunctionRegistry functionRegistry,
+      final List<FunctionCall> functionList,
+      final boolean table
+  ) {
+    final List<KsqlAggregateFunction<?, ?, ?>> functions = ImmutableList.copyOf(
+        functionList.stream().map(
+            funcCall -> UdafUtil.resolveAggregateFunction(
+                functionRegistry,
+                funcCall,
+                schema)
+        ).collect(Collectors.toList()));
+    final List<Supplier<?>> initialValueSuppliers = functions.stream()
+        .map(KsqlAggregateFunction::getInitialValueSupplier)
+        .collect(Collectors.toList());
+    final Optional<KudafUndoAggregator> undoAggregator;
+    if (table) {
+      final List<TableAggregationFunction<?, ?, ?>> tableFunctions = new LinkedList<>();
+      for (final KsqlAggregateFunction function : functions) {
+        tableFunctions.add((TableAggregationFunction<?, ?, ?>) function);
+      }
+      undoAggregator = Optional.of(new KudafUndoAggregator(initialUdafIndex, tableFunctions));
+    } else {
+      undoAggregator = Optional.empty();
+    }
+    return new AggregateParams(
+        new KudafInitializer(initialUdafIndex, initialValueSuppliers),
+        aggregatorFactory.create(initialUdafIndex, functions),
+        undoAggregator,
+        new WindowSelectMapper(initialUdafIndex, functions),
+        buildSchema(schema, initialUdafIndex, functions, true),
+        buildSchema(schema, initialUdafIndex, functions, false)
+    );
+  }
+
+  private static LogicalSchema buildSchema(
+      final LogicalSchema schema,
+      final int initialUdafIndex,
+      final List<KsqlAggregateFunction<?, ?, ?>> aggregateFunctions,
+      final boolean useAggregate) {
+    final LogicalSchema.Builder schemaBuilder = LogicalSchema.builder();
+    final List<Column> cols = schema.value();
+
+    schemaBuilder.keyColumns(schema.key());
+
+    for (int i = 0; i < initialUdafIndex; i++) {
+      schemaBuilder.valueColumn(cols.get(i));
+    }
+
+    for (int i = 0; i < aggregateFunctions.size(); i++) {
+      final KsqlAggregateFunction aggregateFunction = aggregateFunctions.get(i);
+      final ColumnName colName = ColumnName.aggregateColumn(i);
+      final SqlType fieldType = useAggregate
+          ? aggregateFunction.getAggregateType()
+          : aggregateFunction.returnType();
+      schemaBuilder.valueColumn(colName, fieldType);
+    }
+
+    return schemaBuilder.build();
+  }
+
+  interface KudafAggregatorFactory {
+    KudafAggregator create(
+        int initialUdafIndex,
+        List<KsqlAggregateFunction<?, ?, ?>> functions
+    );
+  }
+}

--- a/ksql-streams/src/main/java/io/confluent/ksql/execution/streams/ExecutionStepFactory.java
+++ b/ksql-streams/src/main/java/io/confluent/ksql/execution/streams/ExecutionStepFactory.java
@@ -14,7 +14,6 @@
 
 package io.confluent.ksql.execution.streams;
 
-import io.confluent.ksql.GenericRow;
 import io.confluent.ksql.execution.builder.KsqlQueryBuilder;
 import io.confluent.ksql.execution.context.QueryContext;
 import io.confluent.ksql.execution.expression.tree.Expression;
@@ -23,6 +22,8 @@ import io.confluent.ksql.execution.plan.DefaultExecutionStepProperties;
 import io.confluent.ksql.execution.plan.ExecutionStep;
 import io.confluent.ksql.execution.plan.Formats;
 import io.confluent.ksql.execution.plan.JoinType;
+import io.confluent.ksql.execution.plan.KGroupedStreamHolder;
+import io.confluent.ksql.execution.plan.KGroupedTableHolder;
 import io.confluent.ksql.execution.plan.KStreamHolder;
 import io.confluent.ksql.execution.plan.KTableHolder;
 import io.confluent.ksql.execution.plan.LogicalSchemaWithMetaAndKeyFields;
@@ -48,6 +49,8 @@ import io.confluent.ksql.execution.plan.TableSink;
 import io.confluent.ksql.execution.plan.TableTableJoin;
 import io.confluent.ksql.execution.plan.WindowedStreamSource;
 import io.confluent.ksql.execution.windows.KsqlWindowExpression;
+import io.confluent.ksql.function.FunctionRegistry;
+import io.confluent.ksql.name.SourceName;
 import io.confluent.ksql.schema.ksql.ColumnRef;
 import io.confluent.ksql.schema.ksql.LogicalSchema;
 import io.confluent.ksql.util.timestamp.TimestampExtractionPolicy;
@@ -57,8 +60,6 @@ import java.util.Optional;
 import org.apache.kafka.connect.data.Struct;
 import org.apache.kafka.streams.Topology.AutoOffsetReset;
 import org.apache.kafka.streams.kstream.JoinWindows;
-import org.apache.kafka.streams.kstream.KGroupedStream;
-import org.apache.kafka.streams.kstream.KGroupedTable;
 
 // CHECKSTYLE_RULES.OFF: ClassDataAbstractionCoupling
 public final class ExecutionStepFactory {
@@ -74,7 +75,8 @@ public final class ExecutionStepFactory {
       final Formats formats,
       final TimestampExtractionPolicy timestampPolicy,
       final int timestampIndex,
-      final Optional<AutoOffsetReset> offsetReset
+      final Optional<AutoOffsetReset> offsetReset,
+      final SourceName alias
   ) {
     final QueryContext queryContext = stacker.getQueryContext();
     return new WindowedStreamSource(
@@ -86,7 +88,8 @@ public final class ExecutionStepFactory {
         timestampPolicy,
         timestampIndex,
         offsetReset,
-        schema.getOriginalSchema()
+        schema.getOriginalSchema(),
+        alias
     );
   }
 
@@ -97,7 +100,8 @@ public final class ExecutionStepFactory {
       final Formats formats,
       final TimestampExtractionPolicy timestampPolicy,
       final int timestampIndex,
-      final Optional<AutoOffsetReset> offsetReset
+      final Optional<AutoOffsetReset> offsetReset,
+      final SourceName alias
   ) {
     final QueryContext queryContext = stacker.getQueryContext();
     return new StreamSource(
@@ -109,7 +113,8 @@ public final class ExecutionStepFactory {
         timestampPolicy,
         timestampIndex,
         offsetReset,
-        schema.getOriginalSchema()
+        schema.getOriginalSchema(),
+        alias
     );
   }
 
@@ -327,44 +332,58 @@ public final class ExecutionStepFactory {
     );
   }
 
+  private static LogicalSchema getAggregateSchema(
+      final ExecutionStep<?> sourceStep,
+      final int nonFuncColumnCount,
+      final List<FunctionCall> aggregations,
+      final FunctionRegistry functionRegistry
+  ) {
+    return new AggregateParamsFactory().create(
+        sourceStep.getSchema(),
+        nonFuncColumnCount,
+        functionRegistry,
+        aggregations
+    ).getSchema();
+  }
+
   public static StreamAggregate streamAggregate(
       final QueryContext.Stacker stacker,
-      final ExecutionStep<KGroupedStream<Struct, GenericRow>> sourceStep,
-      final LogicalSchema resultSchema,
+      final ExecutionStep<KGroupedStreamHolder> sourceStep,
       final Formats formats,
       final int nonFuncColumnCount,
       final List<FunctionCall> aggregations,
-      final LogicalSchema aggregateSchema
+      final FunctionRegistry functionRegistry
   ) {
     final QueryContext queryContext = stacker.getQueryContext();
+    final LogicalSchema schema =
+        getAggregateSchema(sourceStep, nonFuncColumnCount, aggregations, functionRegistry);
     return new StreamAggregate(
-        new DefaultExecutionStepProperties(resultSchema, queryContext),
+        new DefaultExecutionStepProperties(schema, queryContext),
         sourceStep,
         formats,
         nonFuncColumnCount,
-        aggregations,
-        aggregateSchema
+        aggregations
     );
   }
 
   public static StreamWindowedAggregate streamWindowedAggregate(
       final QueryContext.Stacker stacker,
-      final ExecutionStep<KGroupedStream<Struct, GenericRow>> sourceStep,
-      final LogicalSchema resultSchema,
+      final ExecutionStep<KGroupedStreamHolder> sourceStep,
       final Formats formats,
       final int nonFuncColumnCount,
       final List<FunctionCall> aggregations,
-      final LogicalSchema aggregateSchema,
-      final KsqlWindowExpression window
+      final KsqlWindowExpression window,
+      final FunctionRegistry functionRegistry
   ) {
     final QueryContext queryContext = stacker.getQueryContext();
+    final LogicalSchema schema =
+        getAggregateSchema(sourceStep, nonFuncColumnCount, aggregations, functionRegistry);
     return new StreamWindowedAggregate(
-        new DefaultExecutionStepProperties(resultSchema, queryContext),
+        new DefaultExecutionStepProperties(schema, queryContext),
         sourceStep,
         formats,
         nonFuncColumnCount,
         aggregations,
-        aggregateSchema,
         window
     );
   }
@@ -399,21 +418,21 @@ public final class ExecutionStepFactory {
 
   public static TableAggregate tableAggregate(
       final QueryContext.Stacker stacker,
-      final ExecutionStep<KGroupedTable<Struct, GenericRow>> sourceStep,
-      final LogicalSchema resultSchema,
+      final ExecutionStep<KGroupedTableHolder> sourceStep,
       final Formats formats,
       final int nonFuncColumnCount,
       final List<FunctionCall> aggregations,
-      final LogicalSchema aggregateSchema
+      final FunctionRegistry functionRegistry
   ) {
     final QueryContext queryContext = stacker.getQueryContext();
+    final LogicalSchema schema =
+        getAggregateSchema(sourceStep, nonFuncColumnCount, aggregations, functionRegistry);
     return new TableAggregate(
-        new DefaultExecutionStepProperties(resultSchema, queryContext),
+        new DefaultExecutionStepProperties(schema, queryContext),
         sourceStep,
         formats,
         nonFuncColumnCount,
-        aggregations,
-        aggregateSchema
+        aggregations
     );
   }
 

--- a/ksql-streams/src/main/java/io/confluent/ksql/execution/streams/JoinParams.java
+++ b/ksql-streams/src/main/java/io/confluent/ksql/execution/streams/JoinParams.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright 2019 Confluent Inc.
+ *
+ * Licensed under the Confluent Community License (the "License"); you may not use
+ * this file except in compliance with the License.  You may obtain a copy of the
+ * License at
+ *
+ * http://www.confluent.io/confluent-community-license
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package io.confluent.ksql.execution.streams;
+
+import io.confluent.ksql.schema.ksql.LogicalSchema;
+import java.util.Objects;
+
+public class JoinParams {
+  private final KsqlValueJoiner joiner;
+  private final LogicalSchema schema;
+
+  JoinParams(final KsqlValueJoiner joiner, final LogicalSchema schema) {
+    this.joiner = Objects.requireNonNull(joiner, "joiner");
+    this.schema = Objects.requireNonNull(schema, "schema");
+  }
+
+  public LogicalSchema getSchema() {
+    return schema;
+  }
+
+  public KsqlValueJoiner getJoiner() {
+    return joiner;
+  }
+}

--- a/ksql-streams/src/main/java/io/confluent/ksql/execution/streams/JoinParamsFactory.java
+++ b/ksql-streams/src/main/java/io/confluent/ksql/execution/streams/JoinParamsFactory.java
@@ -1,0 +1,50 @@
+/*
+ * Copyright 2019 Confluent Inc.
+ *
+ * Licensed under the Confluent Community License (the "License"); you may not use
+ * this file except in compliance with the License.  You may obtain a copy of the
+ * License at
+ *
+ * http://www.confluent.io/confluent-community-license
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package io.confluent.ksql.execution.streams;
+
+import io.confluent.ksql.schema.ksql.LogicalSchema;
+import io.confluent.ksql.schema.ksql.types.SqlTypes;
+import io.confluent.ksql.util.SchemaUtil;
+
+public final class JoinParamsFactory {
+  private JoinParamsFactory() {
+  }
+
+  public static JoinParams create(
+      final LogicalSchema leftSchema,
+      final LogicalSchema rightSchema) {
+    return new JoinParams(
+        new KsqlValueJoiner(leftSchema, rightSchema),
+        createSchema(leftSchema, rightSchema)
+    );
+  }
+
+  public static LogicalSchema createSchema(
+      final LogicalSchema leftSchema,
+      final LogicalSchema rightSchema
+  ) {
+    final LogicalSchema.Builder joinSchema = LogicalSchema.builder();
+
+    // Hard-wire for now, until we support custom type/name of key fields:
+    joinSchema.keyColumn(SchemaUtil.ROWKEY_NAME, SqlTypes.STRING);
+
+    joinSchema.valueColumns(leftSchema.value());
+
+    joinSchema.valueColumns(rightSchema.value());
+
+    return joinSchema.build();
+  }
+}

--- a/ksql-streams/src/main/java/io/confluent/ksql/execution/streams/StreamFilterBuilder.java
+++ b/ksql-streams/src/main/java/io/confluent/ksql/execution/streams/StreamFilterBuilder.java
@@ -43,7 +43,7 @@ public final class StreamFilterBuilder {
     );
     final SqlPredicate predicate = predicateFactory.create(
         step.getFilterExpression(),
-        step.getSource().getProperties().getSchema(),
+        stream.getSchema(),
         queryBuilder.getKsqlConfig(),
         queryBuilder.getFunctionRegistry(),
         queryBuilder.getProcessingLogContext().getLoggerFactory().getLogger(
@@ -53,7 +53,8 @@ public final class StreamFilterBuilder {
         )
     );
     return stream.withStream(
-        stream.getStream().filter(predicate.getPredicate())
+        stream.getStream().filter(predicate.getPredicate()),
+        stream.getSchema()
     );
   }
 }

--- a/ksql-streams/src/main/java/io/confluent/ksql/execution/streams/StreamMapValuesBuilder.java
+++ b/ksql-streams/src/main/java/io/confluent/ksql/execution/streams/StreamMapValuesBuilder.java
@@ -35,7 +35,7 @@ public final class StreamMapValuesBuilder {
 
     final LogicalSchema sourceSchema = step.getSource().getProperties().getSchema();
 
-    final SelectValueMapper<K> mapper = Selection.<K>of(
+    final Selection<K> selection = Selection.of(
         queryBuilder.getQueryId(),
         queryContext,
         sourceSchema,
@@ -43,12 +43,14 @@ public final class StreamMapValuesBuilder {
         queryBuilder.getKsqlConfig(),
         queryBuilder.getFunctionRegistry(),
         queryBuilder.getProcessingLogContext()
-    ).getMapper();
+    );
+    final SelectValueMapper<K> mapper = selection.getMapper();
 
     final Named selectName = Named.as(queryBuilder.buildUniqueNodeName(step.getSelectNodeName()));
 
     return stream.withStream(
-        stream.getStream().transformValues(() -> mapper, selectName)
+        stream.getStream().transformValues(() -> mapper, selectName),
+        selection.getSchema()
     );
   }
 }

--- a/ksql-streams/src/main/java/io/confluent/ksql/execution/streams/StreamSelectKeyBuilder.java
+++ b/ksql-streams/src/main/java/io/confluent/ksql/execution/streams/StreamSelectKeyBuilder.java
@@ -34,7 +34,7 @@ public final class StreamSelectKeyBuilder {
       final KStreamHolder<?> stream,
       final StreamSelectKey<?> selectKey,
       final KsqlQueryBuilder queryBuilder) {
-    final LogicalSchema sourceSchema = selectKey.getSources().get(0).getProperties().getSchema();
+    final LogicalSchema sourceSchema = stream.getSchema();
     final Column keyColumn = sourceSchema.findValueColumn(selectKey.getFieldName())
         .orElseThrow(IllegalArgumentException::new);
     final int keyIndexInValue = sourceSchema.valueColumnIndex(keyColumn.ref())
@@ -57,6 +57,7 @@ public final class StreamSelectKeyBuilder {
         });
     return new KStreamHolder<>(
         rekeyed,
+        stream.getSchema(),
         (fmt, schema, ctx) -> queryBuilder.buildKeySerde(fmt.getFormatInfo(), schema, ctx)
     );
   }

--- a/ksql-streams/src/main/java/io/confluent/ksql/execution/streams/StreamSinkBuilder.java
+++ b/ksql-streams/src/main/java/io/confluent/ksql/execution/streams/StreamSinkBuilder.java
@@ -40,7 +40,7 @@ public final class StreamSinkBuilder {
       final StreamSink<K> streamSink,
       final KsqlQueryBuilder queryBuilder) {
     final QueryContext queryContext = streamSink.getProperties().getQueryContext();
-    final LogicalSchema schema = SinkSchemaUtil.sinkSchema(streamSink);
+    final LogicalSchema schema = SinkSchemaUtil.sinkSchema(stream.getSchema());
     final Formats formats = streamSink.getFormats();
     final PhysicalSchema physicalSchema = PhysicalSchema.from(schema, formats.getOptions());
     final KeySerde<K> keySerde = stream.getKeySerdeFactory().buildKeySerde(
@@ -54,7 +54,7 @@ public final class StreamSinkBuilder {
         queryContext
     );
     final Set<Integer> rowkeyIndexes =
-        SinkSchemaUtil.implicitAndKeyColumnIndexesInValueSchema(streamSink);
+        SinkSchemaUtil.implicitAndKeyColumnIndexesInValueSchema(stream.getSchema());
     final String kafkaTopicName = streamSink.getTopicName();
     stream.getStream()
         .mapValues(row -> {

--- a/ksql-streams/src/main/java/io/confluent/ksql/execution/streams/StreamSourceBuilder.java
+++ b/ksql-streams/src/main/java/io/confluent/ksql/execution/streams/StreamSourceBuilder.java
@@ -79,6 +79,10 @@ public final class StreamSourceBuilder {
 
     return new KStreamHolder<>(
         kstream,
+        streamSource
+            .getSourceSchema()
+            .withAlias(streamSource.getAlias())
+            .withMetaAndKeyColsInValue(),
         (fmt, schema, ctx) -> queryBuilder.buildKeySerde(fmt.getFormatInfo(), schema, ctx)
     );
   }
@@ -118,6 +122,9 @@ public final class StreamSourceBuilder {
 
     return new KStreamHolder<>(
         kstream,
+        streamSource.getSourceSchema()
+            .withAlias(streamSource.getAlias())
+            .withMetaAndKeyColsInValue(),
         (fmt, schema, ctx) -> queryBuilder.buildKeySerde(
             fmt.getFormatInfo(),
             fmt.getWindowInfo().get(),

--- a/ksql-streams/src/main/java/io/confluent/ksql/execution/streams/StreamToTableBuilder.java
+++ b/ksql-streams/src/main/java/io/confluent/ksql/execution/streams/StreamToTableBuilder.java
@@ -18,7 +18,6 @@ package io.confluent.ksql.execution.streams;
 import io.confluent.ksql.GenericRow;
 import io.confluent.ksql.execution.builder.KsqlQueryBuilder;
 import io.confluent.ksql.execution.context.QueryContext;
-import io.confluent.ksql.execution.plan.ExecutionStep;
 import io.confluent.ksql.execution.plan.KStreamHolder;
 import io.confluent.ksql.execution.plan.KTableHolder;
 import io.confluent.ksql.execution.plan.StreamToTable;
@@ -43,9 +42,8 @@ public final class StreamToTableBuilder {
       final KsqlQueryBuilder queryBuilder,
       final MaterializedFactory materializedFactory) {
     final QueryContext queryContext = streamToTable.getProperties().getQueryContext();
-    final ExecutionStep<?> sourceStep = streamToTable.getSource();
     final PhysicalSchema physicalSchema = PhysicalSchema.from(
-        sourceStep.getProperties().getSchema(),
+        sourceStream.getSchema(),
         streamToTable.getFormats().getOptions()
     );
     final ValueFormat valueFormat = streamToTable.getFormats().getValueFormat();
@@ -83,6 +81,10 @@ public final class StreamToTableBuilder {
             () -> null,
             (k, value, oldValue) -> value.orElse(null),
             materialized);
-    return KTableHolder.unmaterialized(table, sourceStream.getKeySerdeFactory());
+    return KTableHolder.unmaterialized(
+        table,
+        sourceStream.getSchema(),
+        sourceStream.getKeySerdeFactory()
+    );
   }
 }

--- a/ksql-streams/src/main/java/io/confluent/ksql/execution/streams/TableFilterBuilder.java
+++ b/ksql-streams/src/main/java/io/confluent/ksql/execution/streams/TableFilterBuilder.java
@@ -43,7 +43,7 @@ public final class TableFilterBuilder {
     );
     final SqlPredicate predicate = sqlPredicateFactory.create(
         step.getFilterExpression(),
-        step.getSource().getProperties().getSchema(),
+        table.getSchema(),
         queryBuilder.getKsqlConfig(),
         queryBuilder.getFunctionRegistry(),
         queryBuilder.getProcessingLogContext().getLoggerFactory().getLogger(
@@ -53,7 +53,7 @@ public final class TableFilterBuilder {
         )
     );
     return table
-        .withTable(table.getTable().filter(predicate.getPredicate()))
+        .withTable(table.getTable().filter(predicate.getPredicate()), table.getSchema())
         .withMaterialization(
             table.getMaterializationBuilder().map(
                 b -> b.filter(step.getFilterExpression())

--- a/ksql-streams/src/main/java/io/confluent/ksql/execution/streams/TableSinkBuilder.java
+++ b/ksql-streams/src/main/java/io/confluent/ksql/execution/streams/TableSinkBuilder.java
@@ -40,7 +40,7 @@ public final class TableSinkBuilder {
       final TableSink<K> tableSink,
       final KsqlQueryBuilder queryBuilder) {
     final QueryContext queryContext = tableSink.getProperties().getQueryContext();
-    final LogicalSchema schema = SinkSchemaUtil.sinkSchema(tableSink);
+    final LogicalSchema schema = SinkSchemaUtil.sinkSchema(table.getSchema());
     final Formats formats = tableSink.getFormats();
     final PhysicalSchema physicalSchema = PhysicalSchema.from(schema, formats.getOptions());
     final KeySerde<K> keySerde = table.getKeySerdeFactory().buildKeySerde(
@@ -54,7 +54,7 @@ public final class TableSinkBuilder {
         queryContext
     );
     final Set<Integer> rowkeyIndexes =
-        SinkSchemaUtil.implicitAndKeyColumnIndexesInValueSchema(tableSink);
+        SinkSchemaUtil.implicitAndKeyColumnIndexesInValueSchema(table.getSchema());
     final String kafkaTopicName = tableSink.getTopicName();
     table.getTable().toStream()
         .mapValues(row -> {

--- a/ksql-streams/src/main/java/io/confluent/ksql/execution/streams/TableTableJoinBuilder.java
+++ b/ksql-streams/src/main/java/io/confluent/ksql/execution/streams/TableTableJoinBuilder.java
@@ -29,23 +29,23 @@ public final class TableTableJoinBuilder {
       final KTableHolder<K> left,
       final KTableHolder<K> right,
       final TableTableJoin join) {
-    final LogicalSchema leftSchema = join.getLeft().getProperties().getSchema();
-    final LogicalSchema rightSchema = join.getRight().getProperties().getSchema();
-    final KsqlValueJoiner joiner = new KsqlValueJoiner(leftSchema, rightSchema);
+    final LogicalSchema leftSchema = left.getSchema();
+    final LogicalSchema rightSchema = right.getSchema();
+    final JoinParams joinParams = JoinParamsFactory.create(leftSchema, rightSchema);
     final KTable<K, GenericRow> result;
     switch (join.getJoinType()) {
       case LEFT:
-        result = left.getTable().leftJoin(right.getTable(), joiner);
+        result = left.getTable().leftJoin(right.getTable(), joinParams.getJoiner());
         break;
       case INNER:
-        result = left.getTable().join(right.getTable(), joiner);
+        result = left.getTable().join(right.getTable(), joinParams.getJoiner());
         break;
       case OUTER:
-        result = left.getTable().outerJoin(right.getTable(), joiner);
+        result = left.getTable().outerJoin(right.getTable(), joinParams.getJoiner());
         break;
       default:
         throw new IllegalStateException("invalid join type");
     }
-    return left.withTable(result);
+    return left.withTable(result, joinParams.getSchema());
   }
 }

--- a/ksql-streams/src/main/java/io/confluent/ksql/execution/streams/materialization/KsqlMaterializationFactory.java
+++ b/ksql-streams/src/main/java/io/confluent/ksql/execution/streams/materialization/KsqlMaterializationFactory.java
@@ -27,7 +27,7 @@ import io.confluent.ksql.execution.materialization.MaterializationInfo;
 import io.confluent.ksql.execution.materialization.MaterializationInfo.ProjectInfo;
 import io.confluent.ksql.execution.plan.SelectExpression;
 import io.confluent.ksql.execution.sqlpredicate.SqlPredicate;
-import io.confluent.ksql.execution.streams.AggregateParams;
+import io.confluent.ksql.execution.streams.AggregateParamsFactory;
 import io.confluent.ksql.execution.streams.SelectValueMapperFactory;
 import io.confluent.ksql.function.FunctionRegistry;
 import io.confluent.ksql.logging.processing.ProcessingLogContext;
@@ -116,14 +116,12 @@ public final class KsqlMaterializationFactory {
 
   private static AggregateMapperFactory defaultAggregateMapperFactory() {
     return (info, functionRegistry) ->
-        new AggregateParams(
+        new AggregateParamsFactory().create(
             info.schema(),
             info.startingColumnIndex(),
             functionRegistry,
             info.aggregateFunctions()
-        )
-            .getAggregator()
-            .getResultMapper()::apply;
+        ).getAggregator().getResultMapper()::apply;
   }
 
   private static SelectMapperFactory defaultValueMapperFactory() {

--- a/ksql-streams/src/test/java/io/confluent/ksql/execution/streams/JoinParamsFactoryTest.java
+++ b/ksql-streams/src/test/java/io/confluent/ksql/execution/streams/JoinParamsFactoryTest.java
@@ -1,0 +1,52 @@
+package io.confluent.ksql.execution.streams;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.junit.Assert.assertThat;
+
+import io.confluent.ksql.name.ColumnName;
+import io.confluent.ksql.name.SourceName;
+import io.confluent.ksql.schema.ksql.LogicalSchema;
+import io.confluent.ksql.schema.ksql.types.SqlTypes;
+import io.confluent.ksql.util.SchemaUtil;
+import org.junit.Before;
+import org.junit.Test;
+
+public class JoinParamsFactoryTest {
+  private static final SourceName LEFT = SourceName.of("LEFT");
+  private static final SourceName RIGHT = SourceName.of("RIGHT");
+  private static final LogicalSchema LEFT_SCHEMA = LogicalSchema.builder()
+      .valueColumn(ColumnName.of("BLUE"), SqlTypes.STRING)
+      .valueColumn(ColumnName.of("GREEN"), SqlTypes.INTEGER)
+      .build()
+      .withAlias(LEFT)
+      .withMetaAndKeyColsInValue();
+  private static final LogicalSchema RIGHT_SCHEMA = LogicalSchema.builder()
+      .valueColumn(ColumnName.of("RED"), SqlTypes.BIGINT)
+      .valueColumn(ColumnName.of("ORANGE"), SqlTypes.DOUBLE)
+      .build()
+      .withAlias(RIGHT)
+      .withMetaAndKeyColsInValue();
+
+  private JoinParams joinParams;
+
+  @Before
+  public void init() {
+    joinParams = JoinParamsFactory.create(LEFT_SCHEMA, RIGHT_SCHEMA);
+  }
+
+  @Test
+  public void shouldBuildCorrectSchema() {
+    final LogicalSchema expected = LogicalSchema.builder()
+        .keyColumn(SchemaUtil.ROWKEY_NAME, SqlTypes.STRING)
+        .valueColumn(LEFT, SchemaUtil.ROWTIME_NAME, SqlTypes.BIGINT)
+        .valueColumn(LEFT, SchemaUtil.ROWKEY_NAME, SqlTypes.STRING)
+        .valueColumn(LEFT, ColumnName.of("BLUE"), SqlTypes.STRING)
+        .valueColumn(LEFT, ColumnName.of("GREEN"), SqlTypes.INTEGER)
+        .valueColumn(RIGHT, SchemaUtil.ROWTIME_NAME, SqlTypes.BIGINT)
+        .valueColumn(RIGHT, SchemaUtil.ROWKEY_NAME, SqlTypes.STRING)
+        .valueColumn(RIGHT, ColumnName.of("RED"), SqlTypes.BIGINT)
+        .valueColumn(RIGHT, ColumnName.of("ORANGE"), SqlTypes.DOUBLE)
+        .build();
+    assertThat(joinParams.getSchema(), is(expected));
+  }
+}

--- a/ksql-streams/src/test/java/io/confluent/ksql/execution/streams/StreamFilterBuilderTest.java
+++ b/ksql-streams/src/test/java/io/confluent/ksql/execution/streams/StreamFilterBuilderTest.java
@@ -96,7 +96,7 @@ public class StreamFilterBuilderTest {
     when(predicateFactory.create(any(), any(), any(), any(), any())).thenReturn(sqlPredicate);
     when(sqlPredicate.getPredicate()).thenReturn(predicate);
     sourceWithSerdeFactory =
-        new KStreamHolder<>(sourceKStream, keySerdeFactory);
+        new KStreamHolder<>(sourceKStream, schema, keySerdeFactory);
     when(sourceStep.build(any())).thenReturn(sourceWithSerdeFactory);
     final ExecutionStepProperties properties = new DefaultExecutionStepProperties(
         schema,
@@ -105,7 +105,7 @@ public class StreamFilterBuilderTest {
     planBuilder = new KSPlanBuilder(
         queryBuilder,
         predicateFactory,
-        mock(AggregateParams.Factory.class),
+        mock(AggregateParamsFactory.class),
         mock(StreamsFactories.class)
     );
     step = new StreamFilter<>(properties, sourceStep, filterExpression);
@@ -121,6 +121,15 @@ public class StreamFilterBuilderTest {
     assertThat(result.getStream(), is(filteredKStream));
     assertThat(result.getKeySerdeFactory(), is(keySerdeFactory));
     verify(sourceKStream).filter(predicate);
+  }
+
+  @Test
+  public void shouldReturnCorrectSchema() {
+    // When:
+    final KStreamHolder<Struct> result = step.build(planBuilder);
+
+    // Then:
+    assertThat(result.getSchema(), is(schema));
   }
 
   @Test

--- a/ksql-streams/src/test/java/io/confluent/ksql/execution/streams/StreamMapValuesBuilderTest.java
+++ b/ksql-streams/src/test/java/io/confluent/ksql/execution/streams/StreamMapValuesBuilderTest.java
@@ -134,7 +134,7 @@ public class StreamMapValuesBuilderTest {
         sourceKStream.transformValues(any(ValueTransformerWithKeySupplier.class), any(Named.class)))
         .thenReturn(resultKStream);
     final KStreamHolder<Struct> sourceStream
-        = new KStreamHolder<>(sourceKStream, keySerdeFactory);
+        = new KStreamHolder<>(sourceKStream, SCHEMA, keySerdeFactory);
     when(sourceStep.build(any())).thenReturn(sourceStream);
     step = new StreamMapValues<>(
         properties,
@@ -145,7 +145,7 @@ public class StreamMapValuesBuilderTest {
     planBuilder = new KSPlanBuilder(
         queryBuilder,
         mock(SqlPredicateFactory.class),
-        mock(AggregateParams.Factory.class),
+        mock(AggregateParamsFactory.class),
         mock(StreamsFactories.class)
     );
   }
@@ -188,5 +188,19 @@ public class StreamMapValuesBuilderTest {
     );
 
     assertThat(NamedTestAccessor.getName(nameCaptor.getValue()), is(SELECT_STEP_NAME + "-unique"));
+  }
+
+  public void shouldReturnCorrectSchema() {
+    // When:
+    final KStreamHolder<Struct> result = step.build(planBuilder);
+
+    // Then:
+    assertThat(
+        result.getSchema(),
+        is(LogicalSchema.builder()
+            .valueColumn(ColumnName.of("expr1"), SqlTypes.STRING)
+            .valueColumn(ColumnName.of("expr2"), SqlTypes.INTEGER)
+            .build())
+    );
   }
 }

--- a/ksql-streams/src/test/java/io/confluent/ksql/execution/streams/StreamSinkBuilderTest.java
+++ b/ksql-streams/src/test/java/io/confluent/ksql/execution/streams/StreamSinkBuilderTest.java
@@ -105,7 +105,7 @@ public class StreamSinkBuilderTest {
     when(source.getProperties()).thenReturn(
         new DefaultExecutionStepProperties(SCHEMA, mock(QueryContext.class))
     );
-    stream = new KStreamHolder<>(kStream, keySerdeFactory);
+    stream = new KStreamHolder<>(kStream, SCHEMA, keySerdeFactory);
     when(source.build(any())).thenReturn(stream);
     sink = new StreamSink<>(
         new DefaultExecutionStepProperties(SCHEMA, queryContext),
@@ -116,7 +116,7 @@ public class StreamSinkBuilderTest {
     planBuilder = new KSPlanBuilder(
         queryBuilder,
         mock(SqlPredicateFactory.class),
-        mock(AggregateParams.Factory.class),
+        mock(AggregateParamsFactory.class),
         mock(StreamsFactories.class)
     );
   }

--- a/ksql-streams/src/test/java/io/confluent/ksql/execution/streams/StreamToTableBuilderTest.java
+++ b/ksql-streams/src/test/java/io/confluent/ksql/execution/streams/StreamToTableBuilderTest.java
@@ -130,11 +130,11 @@ public class StreamToTableBuilderTest {
     when(ksqlQueryBuilder.getQueryId()).thenReturn(new QueryId("qid"));
     when(ksqlQueryBuilder.buildValueSerde(any(), any(), any())).thenReturn(valueSerde);
     when(source.build(any())).thenReturn(
-        new KStreamHolder<>(kStream, keySerdeFactory));
+        new KStreamHolder<>(kStream, SCHEMA, keySerdeFactory));
     planBuilder = new KSPlanBuilder(
         ksqlQueryBuilder,
         mock(SqlPredicateFactory.class),
-        mock(AggregateParams.Factory.class),
+        mock(AggregateParamsFactory.class),
         new StreamsFactories(
             mock(GroupedFactory.class),
             mock(JoinedFactory.class),
@@ -169,6 +169,18 @@ public class StreamToTableBuilderTest {
     verify(kGroupedStream).aggregate(any(), any(), same(materialized));
     assertThat(result.getTable(), is(kTable));
     assertThat(result.getKeySerdeFactory(), is(keySerdeFactory));
+  }
+
+  @Test
+  public void shouldReturnCorrectSchema() {
+    // Given:
+    givenUnwindowed();
+
+    // When:
+    final KTableHolder<Struct> result = step.build(planBuilder);
+
+    // Then:
+    assertThat(result.getSchema(), is(SCHEMA));
   }
 
   @Test

--- a/ksql-streams/src/test/java/io/confluent/ksql/execution/streams/TableFilterBuilderTest.java
+++ b/ksql-streams/src/test/java/io/confluent/ksql/execution/streams/TableFilterBuilderTest.java
@@ -104,12 +104,12 @@ public class TableFilterBuilderTest {
     );
     step = new TableFilter<>(properties, sourceStep, filterExpression);
     when(sourceStep.build(any())).thenReturn(
-        KTableHolder.materialized(sourceKTable, keySerdeFactory, materializationBuilder))
+        KTableHolder.materialized(sourceKTable, schema, keySerdeFactory, materializationBuilder))
     ;
     planBuilder = new KSPlanBuilder(
         queryBuilder,
         predicateFactory,
-        mock(AggregateParams.Factory.class),
+        mock(AggregateParamsFactory.class),
         mock(StreamsFactories.class)
     );
   }
@@ -124,6 +124,15 @@ public class TableFilterBuilderTest {
     assertThat(result.getTable(), is(filteredKTable));
     assertThat(result.getKeySerdeFactory(), is(keySerdeFactory));
     verify(sourceKTable).filter(predicate);
+  }
+
+  @Test
+  public void shouldReturnCorrectSchema() {
+    // When:
+    final KTableHolder<Struct> result = step.build(planBuilder);
+
+    // Then:
+    assertThat(result.getSchema(), is(schema));
   }
 
   @Test

--- a/ksql-streams/src/test/java/io/confluent/ksql/execution/streams/TableSinkBuilderTest.java
+++ b/ksql-streams/src/test/java/io/confluent/ksql/execution/streams/TableSinkBuilderTest.java
@@ -110,7 +110,7 @@ public class TableSinkBuilderTest {
         new DefaultExecutionStepProperties(SCHEMA, mock(QueryContext.class))
     );
     when(source.build(any())).thenReturn(
-        KTableHolder.unmaterialized(kTable, keySerdeFactory));
+        KTableHolder.unmaterialized(kTable, SCHEMA, keySerdeFactory));
     sink = new TableSink<>(
         new DefaultExecutionStepProperties(SCHEMA, queryContext),
         source,
@@ -120,7 +120,7 @@ public class TableSinkBuilderTest {
     planBuilder = new KSPlanBuilder(
         queryBuilder,
         mock(SqlPredicateFactory.class),
-        mock(AggregateParams.Factory.class),
+        mock(AggregateParamsFactory.class),
         mock(StreamsFactories.class)
     );
   }


### PR DESCRIPTION
This patch refactors the plan builder to build up schemas alongside
the kafka streams app. This way, we don't need to serialize the intermediate
schemas into the execution plan.

- Added holder classes for grouped streams/tables, so that they can
  be passed around alongside their schemas.

- Moved the code that builds schemas into the plan building layer,
  alongside the corresponding data transformation code. In cases where
  we need to do the same transformations from multiple step types, eg
  aggregations and joins, the computed schemas and streams callbacks
  are wrapped in *Param classes (e.g. AggregationParam, JoinParam).
  These classes are constructed by factories.

- Cleaned up some of the schema building code from the logical plan and
  its builder. Where schemas are used, they are generated from the underlying
  step builders, which now own the schema transformations. In a follow up, I'll
  clean up most of the code that uses schemas from the logical plan layer.