### PR TITLE
chore: switch CLI over to use `/query` endpoint for pull queries

### DIFF
--- a/ksql-cli/src/test/java/io/confluent/ksql/cli/CliTest.java
+++ b/ksql-cli/src/test/java/io/confluent/ksql/cli/CliTest.java
@@ -643,8 +643,8 @@ public class CliTest {
       return terminal.getOutputString();
     };
 
-    assertThatEventually(runner, containsString("ROWKEY STRING KEY"));
-    assertThatEventually(runner, containsString("COUNT BIGINT"));
+    assertThatEventually(runner, containsString("ROWKEY"));
+    assertThatEventually(runner, containsString("COUNT"));
   }
 
   @Test


### PR DESCRIPTION
### Description 

Fixes: #3847

This means we lose the richer column information for pull queries, e.g.

Where as you would of seen:

```
ksql> SELECT * FROM AGG_TABLE WHERE ROWKEY='ITEM_1';

+------------------------------------------------+-----------------------------------------------+
|ROWKEY STRING KEY                               |COUNT BIGINT                                   |
+------------------------------------------------+-----------------------------------------------+
|ITEM_1                                          |1                                              |
Query terminated
```

You now see:

```
ksql> SELECT * FROM AGG_TABLE WHERE ROWKEY='ITEM_1';

+------------------------------------------------+-----------------------------------------------+
|ROWKEY                                          |COUNT                                          |
+------------------------------------------------+-----------------------------------------------+
|ITEM_1                                          |1                                              |
Query terminated
```

### Testing done 

`mvn test`

### Reviewer checklist
- [ ] Ensure docs are updated if necessary. (eg. if a user visible feature is being added or changed).
- [ ] Ensure relevant issues are linked (description should include text like "Fixes #<issue number>")

