### PR TITLE
Makes timeout for owner lookup in StaticQueryExecutor and rebalancin…

### DIFF
--- a/ksql-common/src/main/java/io/confluent/ksql/config/ImmutableProperties.java
+++ b/ksql-common/src/main/java/io/confluent/ksql/config/ImmutableProperties.java
@@ -29,7 +29,7 @@ public final class ImmutableProperties {
       .add(StreamsConfig.BOOTSTRAP_SERVERS_CONFIG)
       .add(KsqlConfig.KSQL_EXT_DIR)
       .add(KsqlConfig.KSQL_ACTIVE_PERSISTENT_QUERY_LIMIT_CONFIG)
-      .add(KsqlConfig.KSQL_PULL_QUERIES_ENABLE_CONFIG)
+      .add(KsqlConfig.KSQL_QUERY_PULL_ENABLE_CONFIG)
       .addAll(KsqlConfig.SSL_CONFIG_NAMES)
       .build();
 

--- a/ksql-common/src/main/java/io/confluent/ksql/util/KsqlConfig.java
+++ b/ksql-common/src/main/java/io/confluent/ksql/util/KsqlConfig.java
@@ -196,10 +196,22 @@ public class KsqlConfig extends AbstractConfig {
           + "whether the Kafka cluster supports the required API, and enables the validator if "
           + "it does.";
 
-  public static final String KSQL_PULL_QUERIES_ENABLE_CONFIG = "ksql.pull.queries.enable";
-  public static final String KSQL_PULL_QUERIES_ENABLE_DOC =
+  public static final String KSQL_QUERY_PULL_ENABLE_CONFIG = "ksql.query.pull.enable";
+  public static final String KSQL_QUERY_PULL_ENABLE_DOC =
       "Config to enable or disable transient pull queries on a specific KSQL server.";
-  public static final boolean KSQL_PULL_QUERIES_ENABLE_DEFAULT = true;
+  public static final boolean KSQL_QUERY_PULL_ENABLE_DEFAULT = true;
+
+  public static final String KSQL_QUERY_PULL_ROUTING_TIMEOUT_MS_CONFIG =
+      "ksql.query.pull.routing.timeout.ms";
+  public static final Long KSQL_QUERY_PULL_ROUTING_TIMEOUT_MS_DEFAULT = 30000L;
+  public static final String KSQL_QUERY_PULL_ROUTING_TIMEOUT_MS_DOC = "Timeout in milliseconds "
+      + "when waiting for the lookup of the owner of a row key";
+
+  public static final String KSQL_QUERY_PULL_STREAMSTORE_REBALANCING_TIMEOUT_MS_CONFIG =
+      "ksql.query.pull.streamsstore.rebalancing.timeout.ms";
+  public static final Long KSQL_QUERY_PULL_STREAMSTORE_REBALANCING_TIMEOUT_MS_DEFAULT = 10000L;
+  public static final String KSQL_QUERY_PULL_STREAMSTORE_REBALANCING_TIMEOUT_MS_DOC = "Timeout in "
+      + "milliseconds when waiting for rebalancing of the stream store during a pull query";
 
   public static final Collection<CompatibilityBreakingConfigDef> COMPATIBLY_BREAKING_CONFIG_DEFS
       = ImmutableList.of(
@@ -566,11 +578,23 @@ public class KsqlConfig extends AbstractConfig {
             Importance.LOW,
             METRIC_REPORTER_CLASSES_DOC
         ).define(
-            KSQL_PULL_QUERIES_ENABLE_CONFIG,
+            KSQL_QUERY_PULL_ENABLE_CONFIG,
             Type.BOOLEAN,
-            KSQL_PULL_QUERIES_ENABLE_DEFAULT,
+            KSQL_QUERY_PULL_ENABLE_DEFAULT,
             Importance.LOW,
-            KSQL_PULL_QUERIES_ENABLE_DOC
+            KSQL_QUERY_PULL_ENABLE_DOC
+        ).define(
+            KSQL_QUERY_PULL_ROUTING_TIMEOUT_MS_CONFIG,
+            ConfigDef.Type.LONG,
+            KSQL_QUERY_PULL_ROUTING_TIMEOUT_MS_DEFAULT,
+            Importance.LOW,
+            KSQL_QUERY_PULL_ROUTING_TIMEOUT_MS_DOC
+        ).define(
+            KSQL_QUERY_PULL_STREAMSTORE_REBALANCING_TIMEOUT_MS_CONFIG,
+            ConfigDef.Type.LONG,
+            KSQL_QUERY_PULL_STREAMSTORE_REBALANCING_TIMEOUT_MS_DEFAULT,
+            Importance.LOW,
+            KSQL_QUERY_PULL_STREAMSTORE_REBALANCING_TIMEOUT_MS_DOC
         )
         .withClientSslSupport();
     for (final CompatibilityBreakingConfigDef compatibilityBreakingConfigDef

--- a/ksql-engine/src/main/java/io/confluent/ksql/query/QueryExecutor.java
+++ b/ksql-engine/src/main/java/io/confluent/ksql/query/QueryExecutor.java
@@ -363,7 +363,8 @@ public final class QueryExecutor {
             info.getStateStoreSchema(),
             keySerializer,
             keyFormat.getWindowType(),
-            streamsProperties
+            streamsProperties,
+            ksqlConfig
         );
 
     return ksMaterialization.map(ksMat -> (queryId, contextStacker) -> ksqlMaterializationFactory

--- a/ksql-engine/src/test/java/io/confluent/ksql/query/QueryExecutorTest.java
+++ b/ksql-engine/src/test/java/io/confluent/ksql/query/QueryExecutorTest.java
@@ -171,7 +171,7 @@ public class QueryExecutorTest {
     when(materializationBuilder.build()).thenReturn(materializationInfo);
     when(materializationInfo.getStateStoreSchema()).thenReturn(aggregationSchema);
     when(materializationInfo.stateStoreName()).thenReturn(STORE_NAME);
-    when(ksMaterializationFactory.create(any(), any(), any(), any(), any(), any()))
+    when(ksMaterializationFactory.create(any(), any(), any(), any(), any(), any(), any()))
         .thenReturn(Optional.of(ksMaterialization));
     when(ksqlMaterializationFactory.create(any(), any(), any(), any())).thenReturn(materialization);
     when(processingLogContext.getLoggerFactory()).thenReturn(processingLoggerFactory);
@@ -301,7 +301,8 @@ public class QueryExecutorTest {
         same(aggregationSchema),
         any(),
         eq(Optional.empty()),
-        eq(properties)
+        eq(properties),
+        eq(ksqlConfig)
     );
   }
 

--- a/ksql-rest-app/src/test/java/io/confluent/ksql/rest/server/execution/StaticQueryExecutorTest.java
+++ b/ksql-rest-app/src/test/java/io/confluent/ksql/rest/server/execution/StaticQueryExecutorTest.java
@@ -46,7 +46,7 @@ public class StaticQueryExecutorTest {
   public static class Disabled {
     @Rule
     public final TemporaryEngine engine = new TemporaryEngine()
-        .withConfigs(ImmutableMap.of(KsqlConfig.KSQL_PULL_QUERIES_ENABLE_CONFIG, false));
+        .withConfigs(ImmutableMap.of(KsqlConfig.KSQL_QUERY_PULL_ENABLE_CONFIG, false));
 
     @Rule
     public final ExpectedException expectedException = ExpectedException.none();

--- a/ksql-streams/src/main/java/io/confluent/ksql/execution/streams/materialization/ks/KsMaterializationFactory.java
+++ b/ksql-streams/src/main/java/io/confluent/ksql/execution/streams/materialization/ks/KsMaterializationFactory.java
@@ -21,6 +21,7 @@ import com.google.common.annotations.VisibleForTesting;
 import io.confluent.ksql.execution.streams.materialization.Locator;
 import io.confluent.ksql.model.WindowType;
 import io.confluent.ksql.schema.ksql.LogicalSchema;
+import io.confluent.ksql.util.KsqlConfig;
 import java.net.MalformedURLException;
 import java.net.URL;
 import java.util.Map;
@@ -74,7 +75,8 @@ public final class KsMaterializationFactory {
       final LogicalSchema schema,
       final Serializer<Struct> keySerializer,
       final Optional<WindowType> windowType,
-      final Map<String, ?> streamsProperties
+      final Map<String, ?> streamsProperties,
+      final KsqlConfig ksqlConfig
   ) {
     final Object appServer = streamsProperties.get(StreamsConfig.APPLICATION_SERVER_CONFIG);
     if (appServer == null) {
@@ -93,7 +95,8 @@ public final class KsMaterializationFactory {
     final KsStateStore stateStore = storeFactory.create(
         stateStoreName,
         kafkaStreams,
-        schema
+        schema,
+        ksqlConfig
     );
 
     final KsMaterialization materialization = materializationFactory.create(
@@ -133,7 +136,8 @@ public final class KsMaterializationFactory {
     KsStateStore create(
         String stateStoreName,
         KafkaStreams kafkaStreams,
-        LogicalSchema schema
+        LogicalSchema schema,
+        KsqlConfig ksqlConfig
     );
   }
 

--- a/ksql-streams/src/test/java/io/confluent/ksql/execution/streams/materialization/ks/KsMaterializationFactoryTest.java
+++ b/ksql-streams/src/test/java/io/confluent/ksql/execution/streams/materialization/ks/KsMaterializationFactoryTest.java
@@ -30,6 +30,7 @@ import io.confluent.ksql.model.WindowType;
 import io.confluent.ksql.name.ColumnName;
 import io.confluent.ksql.schema.ksql.LogicalSchema;
 import io.confluent.ksql.schema.ksql.types.SqlTypes;
+import io.confluent.ksql.util.KsqlConfig;
 import java.net.MalformedURLException;
 import java.net.URL;
 import java.util.HashMap;
@@ -73,6 +74,8 @@ public class KsMaterializationFactoryTest {
   private MaterializationFactory materializationFactory;
   @Mock
   private KsMaterialization materialization;
+  @Mock
+  private KsqlConfig ksqlConfig;
   private KsMaterializationFactory factory;
   private final Map<String, Object> streamsProperties = new HashMap<>();
 
@@ -85,7 +88,7 @@ public class KsMaterializationFactoryTest {
     );
 
     when(locatorFactory.create(any(), any(), any(), any())).thenReturn(locator);
-    when(storeFactory.create(any(), any(), any())).thenReturn(stateStore);
+    when(storeFactory.create(any(), any(), any(), any())).thenReturn(stateStore);
     when(materializationFactory.create(any(), any(), any())).thenReturn(materialization);
 
     streamsProperties.clear();
@@ -108,7 +111,8 @@ public class KsMaterializationFactoryTest {
 
     // When:
     final Optional<KsMaterialization> result = factory
-        .create(STORE_NAME, kafkaStreams, SCHEMA, keySerializer, Optional.empty(), streamsProperties);
+        .create(STORE_NAME, kafkaStreams, SCHEMA, keySerializer, Optional.empty(), streamsProperties,
+            ksqlConfig);
 
     // Then:
     assertThat(result, is(Optional.empty()));
@@ -117,7 +121,8 @@ public class KsMaterializationFactoryTest {
   @Test
   public void shouldBuildLocatorWithCorrectParams() {
     // When:
-    factory.create(STORE_NAME, kafkaStreams, SCHEMA, keySerializer, Optional.empty(), streamsProperties);
+    factory.create(STORE_NAME, kafkaStreams, SCHEMA, keySerializer, Optional.empty(), streamsProperties,
+        ksqlConfig);
 
     // Then:
     verify(locatorFactory).create(
@@ -131,13 +136,15 @@ public class KsMaterializationFactoryTest {
   @Test
   public void shouldBuildStateStoreWithCorrectParams() {
     // When:
-    factory.create(STORE_NAME, kafkaStreams, SCHEMA, keySerializer, Optional.empty(), streamsProperties);
+    factory.create(STORE_NAME, kafkaStreams, SCHEMA, keySerializer, Optional.empty(), streamsProperties,
+        ksqlConfig);
 
     // Then:
     verify(storeFactory).create(
         STORE_NAME,
         kafkaStreams,
-        SCHEMA
+        SCHEMA,
+        ksqlConfig
     );
   }
 
@@ -147,7 +154,8 @@ public class KsMaterializationFactoryTest {
     final Optional<WindowType> windowType = Optional.of(WindowType.SESSION);
 
     // When:
-    factory.create(STORE_NAME, kafkaStreams, SCHEMA, keySerializer, windowType, streamsProperties);
+    factory.create(STORE_NAME, kafkaStreams, SCHEMA, keySerializer, windowType, streamsProperties,
+        ksqlConfig);
 
     // Then:
     verify(materializationFactory).create(
@@ -161,7 +169,8 @@ public class KsMaterializationFactoryTest {
   public void shouldReturnMaterialization() {
     // When:
     final Optional<KsMaterialization> result = factory
-        .create(STORE_NAME, kafkaStreams, SCHEMA, keySerializer, Optional.empty(), streamsProperties);
+        .create(STORE_NAME, kafkaStreams, SCHEMA, keySerializer, Optional.empty(), streamsProperties,
+            ksqlConfig);
 
     // Then:
     assertThat(result,  is(Optional.of(materialization)));


### PR DESCRIPTION
…g in KsStateStore configurable

### Description 
Fixes #3573 

Both timeouts in StaticQueryExecutor and KsStateStore have been factored out to a configuration value that can be updated.  

### Testing done 
Ran all unit tests by `mvn clean install checkstyle:check integration-test`

### Reviewer checklist
- [ ] Ensure docs are updated if necessary. (eg. if a user visible feature is being added or changed).
- [ ] Ensure relevant issues are linked (description should include text like "Fixes #<issue number>")

