### PR TITLE
build: push release tags using Jenkins ssh keys

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -174,7 +174,9 @@ def job = {
                                 sh "git add ."
                                 sh "git commit -m \"build: Setting project version ${config.ksql_db_version} and parent version ${config. cp_version}.\""
                                 sh "git tag ${git_tag}"
-                                sh "git push -f origin ${git_tag}"
+                                sshagent (credentials: ['ConfluentJenkins Github SSH Key']) {
+                                    sh "git push -f origin ${git_tag}"
+                                }
                             }
 
                             cmd = "mvn --batch-mode -Pjenkins clean package dependency:analyze site validate -U "


### PR DESCRIPTION
### Description 
Use SSH credentials to push tag to GitHub.

### Testing done 
Ran a release build, checked on GitHub that the tag was created. I'll be deleting this tag soon as it's not a real release: https://github.com/confluentinc/ksql/releases/tag/v0.6.0-ksqldb

### Reviewer checklist
- [ ] Ensure docs are updated if necessary. (eg. if a user visible feature is being added or changed).
- [ ] Ensure relevant issues are linked (description should include text like "Fixes #<issue number>")

