### PR TITLE
chore: fix issue with pull queries returning incorrect schema from ws

### DIFF
--- a/ksql-rest-app/src/main/java/io/confluent/ksql/rest/server/resources/streaming/PullQueryPublisher.java
+++ b/ksql-rest-app/src/main/java/io/confluent/ksql/rest/server/resources/streaming/PullQueryPublisher.java
@@ -27,11 +27,15 @@ import io.confluent.ksql.rest.entity.StreamedRow;
 import io.confluent.ksql.rest.entity.TableRowsEntity;
 import io.confluent.ksql.rest.server.execution.StaticQueryExecutor;
 import io.confluent.ksql.rest.server.resources.streaming.Flow.Subscriber;
+import io.confluent.ksql.schema.ksql.Column;
+import io.confluent.ksql.schema.ksql.LogicalSchema;
+import io.confluent.ksql.schema.ksql.LogicalSchema.Builder;
 import io.confluent.ksql.services.ServiceContext;
 import io.confluent.ksql.statement.ConfiguredStatement;
 import java.util.Collection;
 import java.util.List;
 import java.util.concurrent.Callable;
+import java.util.function.Predicate;
 import java.util.stream.Collectors;
 
 class PullQueryPublisher implements Flow.Publisher<Collection<StreamedRow>> {
@@ -72,6 +76,35 @@ class PullQueryPublisher implements Flow.Publisher<Collection<StreamedRow>> {
     subscriber.onSubscribe(subscription);
   }
 
+  /**
+   * Pull queries never return ROWTIME, but the schema returned has meta columns.
+   * Until this is fixed, fix this here.
+   *
+   * @param entity the pull query result entity
+   * @return the corrected schema, with just key and value columns.
+   * @see <a href="https://github.com/confluentinc/ksql/issues/3859">Github issue #3859</a>
+   */
+  private static LogicalSchema correctPullQuerySchema(final TableRowsEntity entity) {
+    final LogicalSchema incorrectSchema = entity.getSchema();
+
+    final Predicate<Column> isMeta = col -> incorrectSchema.isMetaColumn(col.name());
+
+    final Builder builder = LogicalSchema.builder()
+        .noImplicitColumns();
+
+    incorrectSchema.columns().stream()
+        .filter(isMeta.negate())
+        .forEach(col -> {
+          if (incorrectSchema.isKeyColumn(col.name())) {
+            builder.keyColumn(col);
+          } else {
+            builder.valueColumn(col);
+          }
+        });
+
+    return builder.build();
+  }
+
   private static final class PullQuerySubscription implements Flow.Subscription {
 
     private final Subscriber<Collection<StreamedRow>> subscriber;
@@ -99,7 +132,7 @@ class PullQueryPublisher implements Flow.Publisher<Collection<StreamedRow>> {
       try {
         final TableRowsEntity entity = executor.call();
 
-        subscriber.onSchema(entity.getSchema());
+        subscriber.onSchema(correctPullQuerySchema(entity));
 
         final List<StreamedRow> rows = entity.getRows().stream()
             .map(PullQuerySubscription::toGenericRow)

--- a/ksql-rest-app/src/main/java/io/confluent/ksql/rest/server/resources/streaming/PushQueryPublisher.java
+++ b/ksql-rest-app/src/main/java/io/confluent/ksql/rest/server/resources/streaming/PushQueryPublisher.java
@@ -22,6 +22,8 @@ import io.confluent.ksql.engine.KsqlEngine;
 import io.confluent.ksql.parser.tree.Query;
 import io.confluent.ksql.rest.entity.StreamedRow;
 import io.confluent.ksql.rest.server.resources.streaming.Flow.Subscriber;
+import io.confluent.ksql.schema.ksql.LogicalSchema;
+import io.confluent.ksql.schema.ksql.LogicalSchema.Builder;
 import io.confluent.ksql.services.ServiceContext;
 import io.confluent.ksql.statement.ConfiguredStatement;
 import io.confluent.ksql.util.TransientQueryMetadata;
@@ -71,6 +73,26 @@ class PushQueryPublisher implements Flow.Publisher<Collection<StreamedRow>> {
     subscriber.onSubscribe(subscription);
   }
 
+  /**
+   * Push queries only return value columns, but the schema stored in the `TransientQueryMetadata`
+   * has key and meta columns.  Until this is fixed, fix this here.
+   *
+   * @param queryMetadata the query
+   * @return the corrected schema, with just value columns.
+   * @see <a href="https://github.com/confluentinc/ksql/issues/3859">Github issue #3859</a>
+   */
+  private static LogicalSchema correctPushQuerySchema(
+      final TransientQueryMetadata queryMetadata
+  ) {
+    final LogicalSchema incorrectSchema = queryMetadata.getLogicalSchema();
+
+    final Builder builder = LogicalSchema.builder()
+        .noImplicitColumns();
+
+    builder.valueColumns(incorrectSchema.value());
+    return builder.build();
+  }
+
   class PushQuerySubscription extends PollingSubscription<Collection<StreamedRow>> {
 
     private final TransientQueryMetadata queryMetadata;
@@ -80,7 +102,7 @@ class PushQueryPublisher implements Flow.Publisher<Collection<StreamedRow>> {
         final Subscriber<Collection<StreamedRow>> subscriber,
         final TransientQueryMetadata queryMetadata
     ) {
-      super(exec, subscriber, queryMetadata.getLogicalSchema());
+      super(exec, subscriber, correctPushQuerySchema(queryMetadata));
       this.queryMetadata = queryMetadata;
 
       queryMetadata.setLimitHandler(this::setDone);

--- a/ksql-rest-app/src/main/java/io/confluent/ksql/rest/server/resources/streaming/WebSocketSubscriber.java
+++ b/ksql-rest-app/src/main/java/io/confluent/ksql/rest/server/resources/streaming/WebSocketSubscriber.java
@@ -93,7 +93,7 @@ class WebSocketSubscriber<T> implements Flow.Subscriber<Collection<T>>, AutoClos
   public void onSchema(final LogicalSchema schema) {
     try {
       session.getBasicRemote().sendText(
-          mapper.writeValueAsString(EntityUtil.buildSourceSchemaEntity(schema, true))
+          mapper.writeValueAsString(EntityUtil.buildSourceSchemaEntity(schema, false))
       );
     } catch (final IOException e) {
       log.error("Error sending schema", e);

--- a/ksql-rest-app/src/main/java/io/confluent/ksql/rest/util/EntityUtil.java
+++ b/ksql-rest-app/src/main/java/io/confluent/ksql/rest/util/EntityUtil.java
@@ -47,14 +47,14 @@ public final class EntityUtil {
     }
     allFields.addAll(getFields(schema.value(), "value"));
 
+    if (allFields.isEmpty()) {
+      throw new IllegalArgumentException("Root schema should contain columns: " + schema);
+    }
+
     return allFields;
   }
 
   private static List<FieldInfo> getFields(final List<Column> columns, final String type) {
-    if (columns.isEmpty()) {
-      throw new IllegalArgumentException("Root schema should contain columns." + " type: " + type);
-    }
-
     return columns.stream()
         .map(col -> SqlTypeWalker.visit(
             Field.of(col.ref().aliasedFieldName(), col.type()), new Converter()))

--- a/ksql-rest-app/src/test/java/io/confluent/ksql/rest/integration/RestApiTest.java
+++ b/ksql-rest-app/src/test/java/io/confluent/ksql/rest/integration/RestApiTest.java
@@ -226,7 +226,10 @@ public class RestApiTest {
     final List<String> messages = assertThatEventually(call, hasSize(HEADER + 1));
     assertValidJsonMessages(messages);
     assertThat(messages.get(0),
-        is("[{\"name\":\"COUNT\",\"schema\":{\"type\":\"BIGINT\",\"fields\":null,\"memberSchema\":null}}]"));
+        is("["
+            + "{\"name\":\"ROWKEY\",\"schema\":{\"type\":\"STRING\",\"fields\":null,\"memberSchema\":null}},"
+            + "{\"name\":\"COUNT\",\"schema\":{\"type\":\"BIGINT\",\"fields\":null,\"memberSchema\":null}}"
+            + "]"));
     assertThat(messages.get(1),
         is("{\"row\":{\"columns\":[\"USER_1\",1]}}"));
   }
@@ -244,7 +247,10 @@ public class RestApiTest {
     final List<String> messages = assertThatEventually(call, hasSize(HEADER + 1));
     assertValidJsonMessages(messages);
     assertThat(messages.get(0),
-        is("[{\"name\":\"COUNT\",\"schema\":{\"type\":\"BIGINT\",\"fields\":null,\"memberSchema\":null}}]"));
+        is("["
+            + "{\"name\":\"ROWKEY\",\"schema\":{\"type\":\"STRING\",\"fields\":null,\"memberSchema\":null}},"
+            + "{\"name\":\"COUNT\",\"schema\":{\"type\":\"BIGINT\",\"fields\":null,\"memberSchema\":null}}"
+            + "]"));
     assertThat(messages.get(1),
         is("{\"row\":{\"columns\":[1,\"USER_1\"]}}"));
   }
@@ -262,7 +268,10 @@ public class RestApiTest {
     final List<String> messages = assertThatEventually(call, hasSize(HEADER + 1));
     assertValidJsonMessages(messages);
     assertThat(messages.get(0),
-        is("[{\"name\":\"COUNT\",\"schema\":{\"type\":\"BIGINT\",\"fields\":null,\"memberSchema\":null}}]"));
+        is("["
+            + "{\"name\":\"ROWKEY\",\"schema\":{\"type\":\"STRING\",\"fields\":null,\"memberSchema\":null}},"
+            + "{\"name\":\"COUNT\",\"schema\":{\"type\":\"BIGINT\",\"fields\":null,\"memberSchema\":null}}"
+            + "]"));
     assertThat(messages.get(1),
         is("{\"row\":{\"columns\":[\"USER_1\",1]}}"));
   }
@@ -280,7 +289,9 @@ public class RestApiTest {
     final List<String> messages = assertThatEventually(call, hasSize(HEADER + 1));
     assertValidJsonMessages(messages);
     assertThat(messages.get(0),
-        is("[{\"name\":\"COUNT\",\"schema\":{\"type\":\"BIGINT\",\"fields\":null,\"memberSchema\":null}}]"));
+        is("["
+            + "{\"name\":\"COUNT\",\"schema\":{\"type\":\"BIGINT\",\"fields\":null,\"memberSchema\":null}}"
+            + "]"));
     assertThat(messages.get(1),
         is("{\"row\":{\"columns\":[1]}}"));
   }

--- a/ksql-rest-app/src/test/java/io/confluent/ksql/rest/server/resources/streaming/PullQueryPublisherTest.java
+++ b/ksql-rest-app/src/test/java/io/confluent/ksql/rest/server/resources/streaming/PullQueryPublisherTest.java
@@ -50,6 +50,13 @@ import org.mockito.stubbing.Answer;
 public class PullQueryPublisherTest {
 
   private static final LogicalSchema SCHEMA = LogicalSchema.builder()
+      .keyColumn(ColumnName.of("id"), SqlTypes.INTEGER)
+      .valueColumn(ColumnName.of("bob"), SqlTypes.BIGINT)
+      .build();
+
+  private static final LogicalSchema CORRECTED_SCHEMA = LogicalSchema.builder()
+      .noImplicitColumns()
+      .keyColumn(ColumnName.of("id"), SqlTypes.INTEGER)
       .valueColumn(ColumnName.of("bob"), SqlTypes.BIGINT)
       .build();
 
@@ -126,9 +133,21 @@ public class PullQueryPublisherTest {
 
     // Then:
     final InOrder inOrder = inOrder(subscriber);
-    inOrder.verify(subscriber).onSchema(SCHEMA);
-    inOrder.verify(subscriber).onNext(ImmutableList.of());
+    inOrder.verify(subscriber).onSchema(any());
+    inOrder.verify(subscriber).onNext(any());
     inOrder.verify(subscriber).onComplete();
+  }
+
+  @Test
+  public void shouldPassCorrectedSchema() {
+    // Given:
+    givenSubscribed();
+
+    // When:
+    subscription.request(1);
+
+    // Then:
+    verify(subscriber).onSchema(CORRECTED_SCHEMA);
   }
 
   @Test

--- a/ksql-rest-app/src/test/java/io/confluent/ksql/rest/server/resources/streaming/WebSocketSubscriberTest.java
+++ b/ksql-rest-app/src/test/java/io/confluent/ksql/rest/server/resources/streaming/WebSocketSubscriberTest.java
@@ -15,6 +15,8 @@
 
 package io.confluent.ksql.rest.server.resources.streaming;
 
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
 import static org.junit.Assert.assertEquals;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
@@ -103,7 +105,7 @@ public class WebSocketSubscriberTest {
   }
 
   @Test
-  public void testOnSchema() throws Exception {
+  public void shouldOutputSchemaProvided() throws Exception {
     replayOnSubscribe();
 
     session.getBasicRemote();
@@ -125,14 +127,15 @@ public class WebSocketSubscriberTest {
 
     subscriber.close();
 
-    assertEquals(
-        "[" +
-            "{\"name\":\"currency\"," +
-            "\"schema\":{\"type\":\"STRING\",\"fields\":null,\"memberSchema\":null}}," +
-            "{\"name\":\"amount\"," +
-            "\"schema\":{\"type\":\"DOUBLE\",\"fields\":null,\"memberSchema\":null}}"
+    assertThat(
+        schema.getValue(),
+        is("["
+            + "{\"name\":\"ROWTIME\",\"schema\":{\"type\":\"BIGINT\",\"fields\":null,\"memberSchema\":null}},"
+            + "{\"name\":\"ROWKEY\",\"schema\":{\"type\":\"STRING\",\"fields\":null,\"memberSchema\":null}},"
+            + "{\"name\":\"currency\",\"schema\":{\"type\":\"STRING\",\"fields\":null,\"memberSchema\":null}},"
+            + "{\"name\":\"amount\",\"schema\":{\"type\":\"DOUBLE\",\"fields\":null,\"memberSchema\":null}}"
             + "]"
-        , schema.getValue());
+        ));
     assertEquals("Unable to send schema", reason.getValue().getReasonPhrase());
     assertEquals(CloseCodes.PROTOCOL_ERROR, reason.getValue().getCloseCode());
 


### PR DESCRIPTION
### Description 

fixes: #3848

Pull queries never return metadata columns, i.e. `ROWTIME`.
Likewise, push queries never return metadata or key columns, (unless they've been copied into the value schema, which means they're now value columns).

Unfortunately, this is not represented in the schemas built for these queries:
* the schema held in the push query's `TransientQueryMetadata` contains both meta and key columns: this is incorrect and must be removed before returning the schema from the websocket endpoint.
* the schema held in the pull query's `TableRowsEntity`  contains meta columns: this is incorrect and must be removed before returning the schema from the websocket endpoint.

Conversely, the rest endpoint looks to already be returning the correct schema.

This commit is a temporary fix to the schemas in the websocket code. A longer term fix, to fix these schemas at source, is tracked by #3859.

### Testing done 

`mvn test`

### Reviewer checklist
- [ ] Ensure docs are updated if necessary. (eg. if a user visible feature is being added or changed).
- [ ] Ensure relevant issues are linked (description should include text like "Fixes #<issue number>")

