### PR TITLE
chore: switch pull query proxy call to use /query endpoint

### DIFF
--- a/ksql-execution/src/main/java/io/confluent/ksql/services/DisabledKsqlClient.java
+++ b/ksql-execution/src/main/java/io/confluent/ksql/services/DisabledKsqlClient.java
@@ -17,7 +17,9 @@ package io.confluent.ksql.services;
 
 import io.confluent.ksql.rest.client.RestResponse;
 import io.confluent.ksql.rest.entity.KsqlEntityList;
+import io.confluent.ksql.rest.entity.StreamedRow;
 import java.net.URI;
+import java.util.List;
 
 /**
  * A KSQL client implementation for use when communication with other nodes is not supported.
@@ -33,6 +35,11 @@ public final class DisabledKsqlClient implements SimpleKsqlClient {
 
   @Override
   public RestResponse<KsqlEntityList> makeKsqlRequest(URI serverEndPoint, String sql) {
+    throw new UnsupportedOperationException("KSQL client is disabled");
+  }
+
+  @Override
+  public RestResponse<List<StreamedRow>> makeQueryRequest(URI serverEndPoint, String sql) {
     throw new UnsupportedOperationException("KSQL client is disabled");
   }
 }

--- a/ksql-execution/src/main/java/io/confluent/ksql/services/SimpleKsqlClient.java
+++ b/ksql-execution/src/main/java/io/confluent/ksql/services/SimpleKsqlClient.java
@@ -17,13 +17,20 @@ package io.confluent.ksql.services;
 
 import io.confluent.ksql.rest.client.RestResponse;
 import io.confluent.ksql.rest.entity.KsqlEntityList;
+import io.confluent.ksql.rest.entity.StreamedRow;
 import java.net.URI;
+import java.util.List;
 import javax.annotation.concurrent.ThreadSafe;
 
 @ThreadSafe
 public interface SimpleKsqlClient {
 
   RestResponse<KsqlEntityList> makeKsqlRequest(
+      URI serverEndPoint,
+      String sql
+  );
+
+  RestResponse<List<StreamedRow>> makeQueryRequest(
       URI serverEndPoint,
       String sql
   );

--- a/ksql-rest-app/src/main/java/io/confluent/ksql/rest/server/services/ServerInternalKsqlClient.java
+++ b/ksql-rest-app/src/main/java/io/confluent/ksql/rest/server/services/ServerInternalKsqlClient.java
@@ -21,11 +21,13 @@ import io.confluent.ksql.rest.client.KsqlClientUtil;
 import io.confluent.ksql.rest.client.RestResponse;
 import io.confluent.ksql.rest.entity.KsqlEntityList;
 import io.confluent.ksql.rest.entity.KsqlRequest;
+import io.confluent.ksql.rest.entity.StreamedRow;
 import io.confluent.ksql.rest.server.resources.KsqlResource;
 import io.confluent.ksql.services.ServiceContext;
 import io.confluent.ksql.services.SimpleKsqlClient;
 import java.net.URI;
 import java.util.Collections;
+import java.util.List;
 import javax.ws.rs.core.Response;
 
 /**
@@ -60,5 +62,13 @@ public class ServerInternalKsqlClient implements SimpleKsqlClient {
         KSQL_PATH,
         r -> (KsqlEntityList) r.getEntity()
     );
+  }
+
+  @Override
+  public RestResponse<List<StreamedRow>> makeQueryRequest(
+      final URI serverEndpoint,
+      final String sql
+  ) {
+    throw new UnsupportedOperationException();
   }
 }

--- a/ksql-rest-model/src/main/java/io/confluent/ksql/rest/entity/StreamedRow.java
+++ b/ksql-rest-model/src/main/java/io/confluent/ksql/rest/entity/StreamedRow.java
@@ -171,5 +171,23 @@ public final class StreamedRow {
       this.queryId = requireNonNull(queryId, "queryId");
       this.schema = requireNonNull(schema, "schema");
     }
+
+    @Override
+    public boolean equals(final Object o) {
+      if (this == o) {
+        return true;
+      }
+      if (o == null || getClass() != o.getClass()) {
+        return false;
+      }
+      final Header header = (Header) o;
+      return Objects.equals(queryId, header.queryId)
+          && Objects.equals(schema, header.schema);
+    }
+
+    @Override
+    public int hashCode() {
+      return Objects.hash(queryId, schema);
+    }
   }
 }


### PR DESCRIPTION
### Description 

The previous PR missed moving the proxy call made by pull queries when the required data is on another KSQL node.  This PR moves the proxy call over to `/query`.

Due to tight time constraints, this PR may be suboptimal.

Fixes: #3847

### Testing done 

usual

### Reviewer checklist
- [ ] Ensure docs are updated if necessary. (eg. if a user visible feature is being added or changed).
- [ ] Ensure relevant issues are linked (description should include text like "Fixes #<issue number>")

