### PR TITLE
feat: add config to disable pull queries when validation is required

### DIFF
--- a/ksql-cli/src/test/java/io/confluent/ksql/cli/CliTest.java
+++ b/ksql-cli/src/test/java/io/confluent/ksql/cli/CliTest.java
@@ -129,6 +129,7 @@ public class CliTest {
       .builder(CLUSTER::bootstrapServers)
       .withProperty(KsqlConfig.SINK_WINDOW_CHANGE_LOG_ADDITIONAL_RETENTION_MS_PROPERTY,
           KsqlConstants.defaultSinkWindowChangeLogAdditionalRetention + 1)
+      .withProperty(KsqlConfig.KSQL_PULL_QUERIES_SKIP_ACCESS_VALIDATOR_CONFIG, true)
       .build();
 
   @ClassRule

--- a/ksql-common/src/main/java/io/confluent/ksql/config/ImmutableProperties.java
+++ b/ksql-common/src/main/java/io/confluent/ksql/config/ImmutableProperties.java
@@ -30,6 +30,7 @@ public final class ImmutableProperties {
       .add(KsqlConfig.KSQL_EXT_DIR)
       .add(KsqlConfig.KSQL_ACTIVE_PERSISTENT_QUERY_LIMIT_CONFIG)
       .add(KsqlConfig.KSQL_QUERY_PULL_ENABLE_CONFIG)
+      .add(KsqlConfig.KSQL_PULL_QUERIES_SKIP_ACCESS_VALIDATOR_CONFIG)
       .addAll(KsqlConfig.SSL_CONFIG_NAMES)
       .build();
 

--- a/ksql-common/src/main/java/io/confluent/ksql/util/KsqlConfig.java
+++ b/ksql-common/src/main/java/io/confluent/ksql/util/KsqlConfig.java
@@ -201,10 +201,10 @@ public class KsqlConfig extends AbstractConfig {
   public static final String KSQL_PULL_QUERIES_SKIP_ACCESS_VALIDATOR_CONFIG =
       "ksql.query.pull.skip.access.validator";
   public static final boolean KSQL_PULL_QUERIES_SKIP_ACCESS_VALIDATOR_DEFAULT = false;
-  public static final String KSQL_PULL_QUERIES_SKIP_ACCESS_VALIDATOR_DOC = "If true, KSQL will "
+  public static final String KSQL_PULL_QUERIES_SKIP_ACCESS_VALIDATOR_DOC = "If \"true\", KSQL will "
       + " NOT enforce access validation checks for pull queries, which could expose Kafka topics"
-      + " which are secured with RBAC or ACLs. Please enable only after careful consideration."
-      + " Default value: false";
+      + " which are secured with ACLs. Please enable only after careful consideration."
+      + " If \"false\", KSQL pull queries will fail against a secure Kafka cluster";
 
   public static final String KSQL_QUERY_PULL_ENABLE_CONFIG = "ksql.query.pull.enable";
   public static final String KSQL_QUERY_PULL_ENABLE_DOC =

--- a/ksql-common/src/main/java/io/confluent/ksql/util/KsqlConfig.java
+++ b/ksql-common/src/main/java/io/confluent/ksql/util/KsqlConfig.java
@@ -198,6 +198,13 @@ public class KsqlConfig extends AbstractConfig {
           + "\"off\" disables the validator. If set to \"auto\", KSQL will attempt to discover "
           + "whether the Kafka cluster supports the required API, and enables the validator if "
           + "it does.";
+  public static final String KSQL_PULL_QUERIES_SKIP_ACCESS_VALIDATOR_CONFIG =
+      "ksql.query.pull.skip.access.validator";
+  public static final boolean KSQL_PULL_QUERIES_SKIP_ACCESS_VALIDATOR_DEFAULT = false;
+  public static final String KSQL_PULL_QUERIES_SKIP_ACCESS_VALIDATOR_DOC = "If true, KSQL will "
+      + " NOT enforce access validation checks for pull queries, which could expose Kafka topics"
+      + " which are secured with RBAC or ACLs. Please enable only after careful consideration."
+      + " Default value: false";
 
   public static final String KSQL_QUERY_PULL_ENABLE_CONFIG = "ksql.query.pull.enable";
   public static final String KSQL_QUERY_PULL_ENABLE_DOC =
@@ -604,6 +611,12 @@ public class KsqlConfig extends AbstractConfig {
             KSQL_QUERY_PULL_STREAMSTORE_REBALANCING_TIMEOUT_MS_DEFAULT,
             Importance.LOW,
             KSQL_QUERY_PULL_STREAMSTORE_REBALANCING_TIMEOUT_MS_DOC
+        ).define(
+            KSQL_PULL_QUERIES_SKIP_ACCESS_VALIDATOR_CONFIG,
+            Type.BOOLEAN,
+            KSQL_PULL_QUERIES_SKIP_ACCESS_VALIDATOR_DEFAULT,
+            Importance.LOW,
+            KSQL_PULL_QUERIES_SKIP_ACCESS_VALIDATOR_DOC
         )
         .withClientSslSupport();
     for (final CompatibilityBreakingConfigDef compatibilityBreakingConfigDef

--- a/ksql-engine/src/main/java/io/confluent/ksql/services/DefaultServiceContext.java
+++ b/ksql-engine/src/main/java/io/confluent/ksql/services/DefaultServiceContext.java
@@ -78,7 +78,7 @@ public class DefaultServiceContext implements ServiceContext {
   private DefaultServiceContext(
       final KafkaClientSupplier kafkaClientSupplier,
       final Supplier<Admin> adminClientSupplier,
-      final Function<Supplier<Admin>, KafkaTopicClient> topicClientSupplier,
+      final Function<Supplier<Admin>, KafkaTopicClient> topicClientProvider,
       final Supplier<SchemaRegistryClient> srClientSupplier,
       final Supplier<ConnectClient> connectClientSupplier,
       final Supplier<SimpleKsqlClient> ksqlClientSupplier
@@ -100,7 +100,7 @@ public class DefaultServiceContext implements ServiceContext {
     this.kafkaClientSupplier = requireNonNull(kafkaClientSupplier, "kafkaClientSupplier");
 
     this.topicClientSupplier = new MemoizedSupplier<>(
-        () -> topicClientSupplier.apply(this.adminClientSupplier));
+        () -> topicClientProvider.apply(this.adminClientSupplier));
   }
 
   @Override

--- a/ksql-engine/src/test/java/io/confluent/ksql/security/KsqlAuthorizationValidatorFactoryTest.java
+++ b/ksql-engine/src/test/java/io/confluent/ksql/security/KsqlAuthorizationValidatorFactoryTest.java
@@ -18,7 +18,6 @@ package io.confluent.ksql.security;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.instanceOf;
 import static org.hamcrest.Matchers.is;
-import static org.hamcrest.Matchers.not;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verifyZeroInteractions;
@@ -31,6 +30,7 @@ import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import java.util.Set;
 import org.apache.kafka.clients.admin.AdminClient;
 import org.apache.kafka.clients.admin.Config;
@@ -78,44 +78,45 @@ public class KsqlAuthorizationValidatorFactoryTest {
     givenKafkaAuthorizer("an-authorizer-class", Collections.emptySet());
 
     // When:
-    final KsqlAuthorizationValidator validator = KsqlAuthorizationValidatorFactory.create(
+    final Optional<KsqlAuthorizationValidator> validator = KsqlAuthorizationValidatorFactory.create(
         ksqlConfig,
         serviceContext
     );
 
     // Then
-    assertThat(validator, is(instanceOf(KsqlAuthorizationValidatorImpl.class)));
+    assertThat("validator should be present", validator.isPresent());
+    assertThat(validator.get(), is(instanceOf(KsqlAuthorizationValidatorImpl.class)));
   }
 
   @Test
-  public void shouldReturnDummyValidator() {
+  public void shouldReturnEmptyValidator() {
     // Given:
     givenKafkaAuthorizer("", Collections.emptySet());
 
     // When:
-    final KsqlAuthorizationValidator validator = KsqlAuthorizationValidatorFactory.create(
+    final Optional<KsqlAuthorizationValidator> validator = KsqlAuthorizationValidatorFactory.create(
         ksqlConfig,
         serviceContext
     );
 
     // Then
-    assertThat(validator, not(instanceOf(KsqlAuthorizationValidatorImpl.class)));
+    assertThat(validator, is(Optional.empty()));
   }
 
   @Test
-  public void shouldReturnDummyValidatorIfNotEnabled() {
+  public void shouldReturnEmptyValidatorIfNotEnabled() {
     // Given:
     when(ksqlConfig.getString(KsqlConfig.KSQL_ENABLE_TOPIC_ACCESS_VALIDATOR))
         .thenReturn(KsqlConfig.KSQL_ACCESS_VALIDATOR_OFF);
 
     // When:
-    final KsqlAuthorizationValidator validator = KsqlAuthorizationValidatorFactory.create(
+    final Optional<KsqlAuthorizationValidator> validator = KsqlAuthorizationValidatorFactory.create(
         ksqlConfig,
         serviceContext
     );
 
     // Then:
-    assertThat(validator, not(instanceOf(KsqlAuthorizationValidatorImpl.class)));
+    assertThat(validator, is(Optional.empty()));
     verifyZeroInteractions(adminClient);
   }
 
@@ -126,29 +127,30 @@ public class KsqlAuthorizationValidatorFactoryTest {
         .thenReturn(KsqlConfig.KSQL_ACCESS_VALIDATOR_ON);
 
     // When:
-    final KsqlAuthorizationValidator validator = KsqlAuthorizationValidatorFactory.create(
+    final Optional<KsqlAuthorizationValidator> validator = KsqlAuthorizationValidatorFactory.create(
         ksqlConfig,
         serviceContext
     );
 
     // Then:
-    assertThat(validator, instanceOf(KsqlAuthorizationValidatorImpl.class));
+    assertThat("validator should be present", validator.isPresent());
+    assertThat(validator.get(), is(instanceOf(KsqlAuthorizationValidatorImpl.class)));
     verifyZeroInteractions(adminClient);
   }
 
   @Test
-  public void shouldReturnDummyValidatorIfAuthorizedOperationsReturnNull() {
+  public void shouldReturnEmptyValidatorIfAuthorizedOperationsReturnNull() {
     // Given:
     givenKafkaAuthorizer("an-authorizer-class", null);
 
     // When:
-    final KsqlAuthorizationValidator validator = KsqlAuthorizationValidatorFactory.create(
+    final Optional<KsqlAuthorizationValidator> validator = KsqlAuthorizationValidatorFactory.create(
         ksqlConfig,
         serviceContext
     );
 
     // Then
-    assertThat(validator, not(instanceOf(KsqlAuthorizationValidatorImpl.class)));
+    assertThat(validator, is(Optional.empty()));
   }
 
   private void givenKafkaAuthorizer(

--- a/ksql-functional-tests/src/test/java/io/confluent/ksql/test/rest/RestQueryTranslationTest.java
+++ b/ksql-functional-tests/src/test/java/io/confluent/ksql/test/rest/RestQueryTranslationTest.java
@@ -69,6 +69,7 @@ public class RestQueryTranslationTest {
   private static final TestKsqlRestApp REST_APP = TestKsqlRestApp
       .builder(TEST_HARNESS::kafkaBootstrapServers)
       .withProperty(KsqlConfig.KSQL_STREAMS_PREFIX + StreamsConfig.NUM_STREAM_THREADS_CONFIG, 1)
+      .withProperty(KsqlConfig.KSQL_PULL_QUERIES_SKIP_ACCESS_VALIDATOR_CONFIG, true)
       .withStaticServiceContext(TEST_HARNESS::getServiceContext)
       .build();
 
@@ -106,7 +107,7 @@ public class RestQueryTranslationTest {
 
   @Test
   public void shouldBuildAndExecuteQueries() {
-    try (RestTestExecutor testExecutor = textExecutor()) {
+    try (RestTestExecutor testExecutor = testExecutor()) {
       testExecutor.buildAndExecuteQuery(testCase);
     } catch (final AssertionError e) {
       throw new AssertionError(e.getMessage()
@@ -119,7 +120,7 @@ public class RestQueryTranslationTest {
     }
   }
 
-  private static RestTestExecutor textExecutor() {
+  private static RestTestExecutor testExecutor() {
     return new RestTestExecutor(
         REST_APP.getListeners().get(0),
         TEST_HARNESS.getKafkaCluster(),

--- a/ksql-functional-tests/src/test/java/io/confluent/ksql/test/rest/RestTestExecutor.java
+++ b/ksql-functional-tests/src/test/java/io/confluent/ksql/test/rest/RestTestExecutor.java
@@ -402,12 +402,17 @@ public class RestTestExecutor implements Closeable {
 
     final ImmutableList<Response> expectedResponse = ImmutableList.of(queryResponse);
     final ImmutableList<String> statements = ImmutableList.of(querySql);
+    final long waitMs = 10;
 
     final long threshold = System.currentTimeMillis() + MAX_STATIC_WARMUP.toMillis();
     while (System.currentTimeMillis() < threshold) {
       final RestResponse<QueryStream> resp = restClient.makeQueryRequest(querySql, null);
       if (resp.isErroneous()) {
-        Thread.yield();
+        try {
+          Thread.sleep(waitMs);
+        } catch (InterruptedException e) {
+          // ignore
+        }
         LOG.info("Server responded with an error code to a pull query. "
             + "This could be because the materialized store is not yet warm.");
         continue;

--- a/ksql-rest-app/src/main/java/io/confluent/ksql/rest/server/KsqlRestApplication.java
+++ b/ksql-rest-app/src/main/java/io/confluent/ksql/rest/server/KsqlRestApplication.java
@@ -380,7 +380,7 @@ public final class KsqlRestApplication extends ExecutableApplication<KsqlRestCon
       );
 
       final StatementParser statementParser = new StatementParser(ksqlEngine);
-      final KsqlAuthorizationValidator authorizationValidator =
+      final Optional<KsqlAuthorizationValidator> authorizationValidator =
           KsqlAuthorizationValidatorFactory.create(ksqlConfigNoPort, serviceContext);
 
       container.addEndpoint(
@@ -496,7 +496,7 @@ public final class KsqlRestApplication extends ExecutableApplication<KsqlRestCon
 
     final KsqlSecurityExtension securityExtension = loadSecurityExtension(ksqlConfig);
 
-    final KsqlAuthorizationValidator authorizationValidator =
+    final Optional<KsqlAuthorizationValidator> authorizationValidator =
         KsqlAuthorizationValidatorFactory.create(ksqlConfig, serviceContext);
 
     final StreamedQueryResource streamedQueryResource = new StreamedQueryResource(

--- a/ksql-rest-app/src/main/java/io/confluent/ksql/rest/server/resources/KsqlResource.java
+++ b/ksql-rest-app/src/main/java/io/confluent/ksql/rest/server/resources/KsqlResource.java
@@ -56,6 +56,7 @@ import io.confluent.ksql.version.metrics.ActivenessRegistrar;
 import java.time.Duration;
 import java.util.List;
 import java.util.Objects;
+import java.util.Optional;
 import java.util.Set;
 import java.util.function.BiFunction;
 import java.util.regex.PatternSyntaxException;
@@ -97,7 +98,7 @@ public class KsqlResource implements KsqlConfigurable {
   private final Duration distributedCmdResponseTimeout;
   private final ActivenessRegistrar activenessRegistrar;
   private final BiFunction<KsqlExecutionContext, ServiceContext, Injector> injectorFactory;
-  private final KsqlAuthorizationValidator authorizationValidator;
+  private final Optional<KsqlAuthorizationValidator> authorizationValidator;
   private RequestValidator validator;
   private RequestHandler handler;
 
@@ -107,7 +108,7 @@ public class KsqlResource implements KsqlConfigurable {
       final CommandQueue commandQueue,
       final Duration distributedCmdResponseTimeout,
       final ActivenessRegistrar activenessRegistrar,
-      final KsqlAuthorizationValidator authorizationValidator
+      final Optional<KsqlAuthorizationValidator> authorizationValidator
   ) {
     this(
         ksqlEngine,
@@ -125,7 +126,7 @@ public class KsqlResource implements KsqlConfigurable {
       final Duration distributedCmdResponseTimeout,
       final ActivenessRegistrar activenessRegistrar,
       final BiFunction<KsqlExecutionContext, ServiceContext, Injector> injectorFactory,
-      final KsqlAuthorizationValidator authorizationValidator
+      final Optional<KsqlAuthorizationValidator> authorizationValidator
   ) {
     this.ksqlEngine = Objects.requireNonNull(ksqlEngine, "ksqlEngine");
     this.commandQueue = Objects.requireNonNull(commandQueue, "commandQueue");

--- a/ksql-rest-app/src/main/java/io/confluent/ksql/rest/server/resources/streaming/StreamedQueryResource.java
+++ b/ksql-rest-app/src/main/java/io/confluent/ksql/rest/server/resources/streaming/StreamedQueryResource.java
@@ -186,11 +186,12 @@ public class StreamedQueryResource implements KsqlConfigurable {
 
       if (statement.getStatement() instanceof Query) {
         final PreparedStatement<Query> queryStmt = (PreparedStatement<Query>) statement;
-        final boolean skipAccessValidation = ksqlConfig.getBoolean(
-            KsqlConfig.KSQL_PULL_QUERIES_SKIP_ACCESS_VALIDATOR_CONFIG);
+
         if (queryStmt.getStatement().isPullQuery()) {
+          final boolean skipAccessValidation = ksqlConfig.getBoolean(
+              KsqlConfig.KSQL_PULL_QUERIES_SKIP_ACCESS_VALIDATOR_CONFIG);
           if (authorizationValidator.isPresent() && !skipAccessValidation) {
-            return Errors.badRequest("Pull queries are not currently supported, when "
+            return Errors.badRequest("Pull queries are not currently supported when "
                 + "access validation against Kafka is configured. If you really want to "
                 + "bypass this limitation please set "
                 + KsqlConfig.KSQL_PULL_QUERIES_SKIP_ACCESS_VALIDATOR_CONFIG + "=true "

--- a/ksql-rest-app/src/main/java/io/confluent/ksql/rest/server/resources/streaming/WSQueryEndpoint.java
+++ b/ksql-rest-app/src/main/java/io/confluent/ksql/rest/server/resources/streaming/WSQueryEndpoint.java
@@ -88,7 +88,7 @@ public class WSQueryEndpoint {
   private final QueryPublisher pullQueryPublisher;
   private final PrintTopicPublisher topicPublisher;
   private final Duration commandQueueCatchupTimeout;
-  private final KsqlAuthorizationValidator authorizationValidator;
+  private final Optional<KsqlAuthorizationValidator> authorizationValidator;
   private final KsqlSecurityExtension securityExtension;
   private final UserServiceContextFactory serviceContextFactory;
   private final DefaultServiceContextFactory defaultServiceContextFactory;
@@ -108,7 +108,7 @@ public class WSQueryEndpoint {
       final ListeningScheduledExecutorService exec,
       final ActivenessRegistrar activenessRegistrar,
       final Duration commandQueueCatchupTimeout,
-      final KsqlAuthorizationValidator authorizationValidator,
+      final Optional<KsqlAuthorizationValidator> authorizationValidator,
       final KsqlSecurityExtension securityExtension,
       final ServerState serverState
   ) {
@@ -144,7 +144,7 @@ public class WSQueryEndpoint {
       final PrintTopicPublisher topicPublisher,
       final ActivenessRegistrar activenessRegistrar,
       final Duration commandQueueCatchupTimeout,
-      final KsqlAuthorizationValidator authorizationValidator,
+      final Optional<KsqlAuthorizationValidator> authorizationValidator,
       final KsqlSecurityExtension securityExtension,
       final UserServiceContextFactory serviceContextFactory,
       final DefaultServiceContextFactory defaultServiceContextFactory,
@@ -213,10 +213,10 @@ public class WSQueryEndpoint {
 
       serviceContext = createServiceContext(session.getUserPrincipal());
 
-      authorizationValidator.checkAuthorization(
+      authorizationValidator.ifPresent(validator -> validator.checkAuthorization(
           serviceContext,
           ksqlEngine.getMetaStore(),
-          preparedStatement.getStatement()
+          preparedStatement.getStatement())
       );
 
       final Statement statement = preparedStatement.getStatement();

--- a/ksql-rest-app/src/test/java/io/confluent/ksql/rest/integration/PullQueryFunctionalTest.java
+++ b/ksql-rest-app/src/test/java/io/confluent/ksql/rest/integration/PullQueryFunctionalTest.java
@@ -37,6 +37,7 @@ import io.confluent.ksql.serde.Format;
 import io.confluent.ksql.serde.SerdeOption;
 import io.confluent.ksql.test.util.KsqlIdentifierTestUtil;
 import io.confluent.ksql.test.util.TestBasicJaasConfig;
+import io.confluent.ksql.util.KsqlConfig;
 import io.confluent.ksql.util.TestDataProvider;
 import io.confluent.ksql.util.UserDataProvider;
 import io.confluent.rest.RestConfig;
@@ -110,6 +111,7 @@ public class PullQueryFunctionalTest {
       .withBasicCredentials(USER_WITH_ACCESS, USER_WITH_ACCESS_PWD)
       .withProperty(KSQL_STREAMS_PREFIX + StreamsConfig.NUM_STREAM_THREADS_CONFIG, 1)
       .withProperty(KSQL_STREAMS_PREFIX + StreamsConfig.STATE_DIR_CONFIG, getNewStateDir())
+      .withProperty(KsqlConfig.KSQL_PULL_QUERIES_SKIP_ACCESS_VALIDATOR_CONFIG, true)
       .withProperty(RestConfig.AUTHENTICATION_METHOD_CONFIG, RestConfig.AUTHENTICATION_METHOD_BASIC)
       .withProperty(RestConfig.AUTHENTICATION_REALM_CONFIG, PROPS_JAAS_REALM)
       .withProperty(RestConfig.AUTHENTICATION_ROLES_CONFIG, KSQL_CLUSTER_ID)
@@ -121,6 +123,7 @@ public class PullQueryFunctionalTest {
       .withBasicCredentials(USER_WITH_ACCESS, USER_WITH_ACCESS_PWD)
       .withProperty(KSQL_STREAMS_PREFIX + StreamsConfig.NUM_STREAM_THREADS_CONFIG, 1)
       .withProperty(KSQL_STREAMS_PREFIX + StreamsConfig.STATE_DIR_CONFIG, getNewStateDir())
+      .withProperty(KsqlConfig.KSQL_PULL_QUERIES_SKIP_ACCESS_VALIDATOR_CONFIG, true)
       .withProperty(RestConfig.AUTHENTICATION_METHOD_CONFIG, RestConfig.AUTHENTICATION_METHOD_BASIC)
       .withProperty(RestConfig.AUTHENTICATION_REALM_CONFIG, PROPS_JAAS_REALM)
       .withProperty(RestConfig.AUTHENTICATION_ROLES_CONFIG, KSQL_CLUSTER_ID)

--- a/ksql-rest-app/src/test/java/io/confluent/ksql/rest/integration/RestApiTest.java
+++ b/ksql-rest-app/src/test/java/io/confluent/ksql/rest/integration/RestApiTest.java
@@ -50,6 +50,7 @@ import io.confluent.ksql.test.util.EmbeddedSingleNodeKafkaCluster;
 import io.confluent.ksql.test.util.secure.ClientTrustStore;
 import io.confluent.ksql.test.util.secure.Credentials;
 import io.confluent.ksql.test.util.secure.SecureKafkaHelper;
+import io.confluent.ksql.util.KsqlConfig;
 import io.confluent.ksql.util.PageViewDataProvider;
 import java.util.Arrays;
 import java.util.List;
@@ -155,6 +156,7 @@ public class RestApiTest {
       .withProperty("security.protocol", "SASL_SSL")
       .withProperty("sasl.mechanism", "PLAIN")
       .withProperty("sasl.jaas.config", SecureKafkaHelper.buildJaasConfig(NORMAL_USER))
+      .withProperty(KsqlConfig.KSQL_PULL_QUERIES_SKIP_ACCESS_VALIDATOR_CONFIG, true)
       .withProperties(ClientTrustStore.trustStoreProps())
       .build();
 

--- a/ksql-rest-app/src/test/java/io/confluent/ksql/rest/server/computation/DistributingExecutorTest.java
+++ b/ksql-rest-app/src/test/java/io/confluent/ksql/rest/server/computation/DistributingExecutorTest.java
@@ -122,7 +122,7 @@ public class DistributingExecutorTest {
         queue,
         DURATION_10_MS,
         (ec, sc) -> InjectorChain.of(schemaInjector, topicInjector),
-        authorizationValidator,
+        Optional.of(authorizationValidator),
         requestValidator
     );
   }

--- a/ksql-rest-app/src/test/java/io/confluent/ksql/rest/server/computation/RecoveryTest.java
+++ b/ksql-rest-app/src/test/java/io/confluent/ksql/rest/server/computation/RecoveryTest.java
@@ -218,7 +218,7 @@ public class RecoveryTest {
           fakeCommandQueue,
           Duration.ofMillis(0),
           ()->{},
-          (sc, metastore, statement) -> { }
+          Optional.of((sc, metastore, statement) -> { })
       );
 
       this.statementExecutor.configure(ksqlConfig);

--- a/ksql-rest-app/src/test/java/io/confluent/ksql/rest/server/resources/KsqlResourceTest.java
+++ b/ksql-rest-app/src/test/java/io/confluent/ksql/rest/server/resources/KsqlResourceTest.java
@@ -364,7 +364,7 @@ public class KsqlResourceTest {
             schemaInjectorFactory.apply(sc),
             topicInjectorFactory.apply(ec),
             new TopicDeleteInjector(ec, sc)),
-        authorizationValidator
+        Optional.of(authorizationValidator)
     );
 
     // Then:
@@ -392,7 +392,7 @@ public class KsqlResourceTest {
             schemaInjectorFactory.apply(sc),
             topicInjectorFactory.apply(ec),
             new TopicDeleteInjector(ec, sc)),
-        authorizationValidator
+        Optional.of(authorizationValidator)
     );
 
     // Then:
@@ -2077,7 +2077,7 @@ public class KsqlResourceTest {
             schemaInjectorFactory.apply(sc),
             topicInjectorFactory.apply(ec),
             new TopicDeleteInjector(ec, sc)),
-        authorizationValidator
+        Optional.of(authorizationValidator)
     );
 
     ksqlResource.configure(ksqlConfig);

--- a/ksql-rest-app/src/test/java/io/confluent/ksql/rest/server/resources/streaming/WSQueryEndpointTest.java
+++ b/ksql-rest-app/src/test/java/io/confluent/ksql/rest/server/resources/streaming/WSQueryEndpointTest.java
@@ -190,7 +190,7 @@ public class WSQueryEndpointTest {
         topicPublisher,
         activenessRegistrar,
         COMMAND_QUEUE_CATCHUP_TIMEOUT,
-        authorizationValidator,
+        Optional.of(authorizationValidator),
         securityExtension,
         serviceContextFactory,
         defaultServiceContextProvider,

--- a/ksql-rest-app/src/test/java/io/confluent/ksql/rest/server/resources/streaming/WSQueryEndpointTest.java
+++ b/ksql-rest-app/src/test/java/io/confluent/ksql/rest/server/resources/streaming/WSQueryEndpointTest.java
@@ -15,6 +15,7 @@
 
 package io.confluent.ksql.rest.server.resources.streaming;
 
+import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.is;
 import static org.junit.Assert.assertThat;
 import static org.mockito.ArgumentMatchers.any;
@@ -385,6 +386,8 @@ public class WSQueryEndpointTest {
   @Test
   public void shouldHandlePullQuery() {
     // Given:
+    when(ksqlConfig.getBoolean(KsqlConfig.KSQL_PULL_QUERIES_SKIP_ACCESS_VALIDATOR_CONFIG))
+        .thenReturn(true);
     givenQueryIs(QueryType.PULL);
     givenRequestIs(query);
 
@@ -403,6 +406,22 @@ public class WSQueryEndpointTest {
         eq(exec),
         eq(configuredStatement),
         any());
+  }
+
+  @Test
+  public void shouldFailPullQueryIfValidating() throws Exception {
+    // Given:
+    givenQueryIs(QueryType.PULL);
+    givenRequestIs(query);
+
+    // When:
+    wsQueryEndpoint.onOpen(session, null);
+
+    // Then:
+    verifyClosedContainingReason(
+        "Pull queries are not currently supported",
+        CloseCodes.CANNOT_ACCEPT
+    );
   }
 
   @Test
@@ -614,6 +633,13 @@ public class WSQueryEndpointTest {
     } catch (final Exception e) {
       throw new AssertionError("Invalid test", e);
     }
+  }
+
+  private void verifyClosedContainingReason(final String reason, final CloseCodes code) throws Exception {
+    verify(session).close(closeReasonCaptor.capture());
+    final CloseReason closeReason = closeReasonCaptor.getValue();
+    assertThat(closeReason.getReasonPhrase(), containsString(reason));
+    assertThat(closeReason.getCloseCode(), is(code));
   }
 
   private void verifyClosedWithReason(final String reason, final CloseCodes code) throws Exception {


### PR DESCRIPTION
fixes #3863

### Description 
 - Added `ksql.query.pull.skip.access.validator` to control if pull queries work without validation
 - By default, Pull queries error out, if auth validation is needed
 - Replaced DUMMY_VALIDATOR with Optional<> interface for KsqlAuthorizationValidatorFactory
 - Fixed some tests, added test cases

### Testing done 

- [x] Unit tests
- [x] Local testing for performance w and w/o validation enabled 

### Reviewer checklist
- [ ] Ensure docs are updated if necessary. (eg. if a user visible feature is being added or changed).
- [ ] Ensure relevant issues are linked (description should include text like "Fixes #<issue number>")

