### PR TITLE
Do not force push the release tag

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -175,7 +175,7 @@ def job = {
                                 sh "git commit -m \"build: Setting project version ${config.ksql_db_version} and parent version ${config. cp_version}.\""
                                 sh "git tag ${git_tag}"
                                 sshagent (credentials: ['ConfluentJenkins Github SSH Key']) {
-                                    sh "git push -f origin ${git_tag}"
+                                    sh "git push origin ${git_tag}"
                                 }
                             }
 


### PR DESCRIPTION
### Description 
When creating the release tag we do not want to force push it for two reasons. One, we shouldn't be over writing a release tag that we previously created. Two, force pushing a tag causes issues for other people when they try to pull the latest changes from this repo if they already had that tag synced.

### Testing done 
None. Will test this when we do the first official release of ksql-db or we can test it after we push the change to do a test run.

### Reviewer checklist
- [ ] Ensure docs are updated if necessary. (eg. if a user visible feature is being added or changed).
- [ ] Ensure relevant issues are linked (description should include text like "Fixes #<issue number>")

