### PR TITLE
refactor: simplify EntityUtil (MINOR)

### DIFF
--- a/ksql-cli/src/test/java/io/confluent/ksql/cli/console/ConsoleTest.java
+++ b/ksql-cli/src/test/java/io/confluent/ksql/cli/console/ConsoleTest.java
@@ -1426,6 +1426,6 @@ public class ConsoleTest {
 
     final LogicalSchema schema = schemaBuilder.build();
 
-    return EntityUtil.buildSourceSchemaEntity(schema, false);
+    return EntityUtil.buildSourceSchemaEntity(schema);
   }
 }

--- a/ksql-rest-app/src/main/java/io/confluent/ksql/rest/entity/QueryDescriptionFactory.java
+++ b/ksql-rest-app/src/main/java/io/confluent/ksql/rest/entity/QueryDescriptionFactory.java
@@ -38,7 +38,6 @@ public final class QueryDescriptionFactory {
           persistentQuery.getQueryId(),
           persistentQuery,
           ImmutableSet.of(persistentQuery.getSinkName()),
-          false,
           Optional.of(persistentQuery.getState())
       );
     }
@@ -47,7 +46,6 @@ public final class QueryDescriptionFactory {
         new QueryId(""),
         queryMetadata,
         Collections.emptySet(),
-        true,
         Optional.empty()
     );
   }
@@ -56,13 +54,12 @@ public final class QueryDescriptionFactory {
       final QueryId id,
       final QueryMetadata queryMetadata,
       final Set<SourceName> sinks,
-      final boolean valueSchemaOnly,
       final Optional<String> state
   ) {
     return new QueryDescription(
         id,
         queryMetadata.getStatementString(),
-        EntityUtil.buildSourceSchemaEntity(queryMetadata.getLogicalSchema(), valueSchemaOnly),
+        EntityUtil.buildSourceSchemaEntity(queryMetadata.getLogicalSchema()),
         queryMetadata.getSourceNames().stream().map(SourceName::name).collect(Collectors.toSet()),
         sinks.stream().map(SourceName::name).collect(Collectors.toSet()),
         queryMetadata.getTopologyDescription(),

--- a/ksql-rest-app/src/main/java/io/confluent/ksql/rest/entity/SourceDescriptionFactory.java
+++ b/ksql-rest-app/src/main/java/io/confluent/ksql/rest/entity/SourceDescriptionFactory.java
@@ -41,7 +41,7 @@ public final class SourceDescriptionFactory {
         dataSource.getName().toString(FormatOptions.noEscape()),
         readQueries,
         writeQueries,
-        EntityUtil.buildSourceSchemaEntity(dataSource.getSchema(), false),
+        EntityUtil.buildSourceSchemaEntity(dataSource.getSchema()),
         dataSource.getDataSourceType().getKsqlType(),
         dataSource.getKeyField().ref().map(c -> c.toString(FormatOptions.noEscape())).orElse(""),
         Optional.ofNullable(dataSource.getTimestampExtractionPolicy())

--- a/ksql-rest-app/src/main/java/io/confluent/ksql/rest/server/resources/streaming/WebSocketSubscriber.java
+++ b/ksql-rest-app/src/main/java/io/confluent/ksql/rest/server/resources/streaming/WebSocketSubscriber.java
@@ -94,7 +94,7 @@ class WebSocketSubscriber<T> implements Flow.Subscriber<Collection<T>>, AutoClos
   public void onSchema(final LogicalSchema schema) {
     try {
       session.getBasicRemote().sendText(
-          mapper.writeValueAsString(EntityUtil.buildSourceSchemaEntity(schema, false))
+          mapper.writeValueAsString(EntityUtil.buildSourceSchemaEntity(schema))
       );
     } catch (final IOException e) {
       log.error("Error sending schema", e);

--- a/ksql-rest-app/src/main/java/io/confluent/ksql/rest/util/EntityUtil.java
+++ b/ksql-rest-app/src/main/java/io/confluent/ksql/rest/util/EntityUtil.java
@@ -35,16 +35,10 @@ public final class EntityUtil {
   private EntityUtil() {
   }
 
-  public static List<FieldInfo> buildSourceSchemaEntity(
-      final LogicalSchema schema,
-      final boolean valueSchemaOnly
-  ) {
-
+  public static List<FieldInfo> buildSourceSchemaEntity(final LogicalSchema schema) {
     final List<FieldInfo> allFields = new ArrayList<>();
-    if (!valueSchemaOnly) {
-      allFields.addAll(getFields(schema.metadata(), "meta"));
-      allFields.addAll(getFields(schema.key(), "key"));
-    }
+    allFields.addAll(getFields(schema.metadata(), "meta"));
+    allFields.addAll(getFields(schema.key(), "key"));
     allFields.addAll(getFields(schema.value(), "value"));
 
     if (allFields.isEmpty()) {

--- a/ksql-rest-app/src/test/java/io/confluent/ksql/rest/entity/QueryDescriptionFactoryTest.java
+++ b/ksql-rest-app/src/test/java/io/confluent/ksql/rest/entity/QueryDescriptionFactoryTest.java
@@ -57,7 +57,13 @@ import org.mockito.junit.MockitoJUnitRunner;
 @RunWith(MockitoJUnitRunner.class)
 public class QueryDescriptionFactoryTest {
 
-  private static final LogicalSchema SOME_SCHEMA = LogicalSchema.builder()
+  private static final LogicalSchema TRANSIENT_SCHEMA = LogicalSchema.builder()
+      .noImplicitColumns()
+      .valueColumn(ColumnName.of("field1"), SqlTypes.INTEGER)
+      .valueColumn(ColumnName.of("field2"), SqlTypes.STRING)
+      .build();
+
+  private static final LogicalSchema PERSISTENT_SCHEMA = LogicalSchema.builder()
       .valueColumn(ColumnName.of("field1"), SqlTypes.INTEGER)
       .valueColumn(ColumnName.of("field2"), SqlTypes.STRING)
       .build();
@@ -93,7 +99,7 @@ public class QueryDescriptionFactoryTest {
     transientQuery = new TransientQueryMetadata(
         SQL_TEXT,
         queryStreams,
-        SOME_SCHEMA,
+        TRANSIENT_SCHEMA,
         SOURCE_NAMES,
         limitHandler,
         "execution plan",
@@ -109,7 +115,7 @@ public class QueryDescriptionFactoryTest {
     final PersistentQueryMetadata persistentQuery = new PersistentQueryMetadata(
         SQL_TEXT,
         queryStreams,
-        PhysicalSchema.from(SOME_SCHEMA, SerdeOption.none()),
+        PhysicalSchema.from(PERSISTENT_SCHEMA, SerdeOption.none()),
         SOURCE_NAMES,
         SourceName.of("sink Name"),
         "execution plan",
@@ -197,6 +203,7 @@ public class QueryDescriptionFactoryTest {
   public void shouldHandleRowTimeInValueSchemaForTransientQuery() {
     // Given:
     final LogicalSchema schema = LogicalSchema.builder()
+        .noImplicitColumns()
         .valueColumn(ColumnName.of("field1"), SqlTypes.INTEGER)
         .valueColumn(ColumnName.of("ROWTIME"), SqlTypes.BIGINT)
         .valueColumn(ColumnName.of("field2"), SqlTypes.STRING)
@@ -230,6 +237,7 @@ public class QueryDescriptionFactoryTest {
   public void shouldHandleRowKeyInValueSchemaForTransientQuery() {
     // Given:
     final LogicalSchema schema = LogicalSchema.builder()
+        .noImplicitColumns()
         .valueColumn(ColumnName.of("field1"), SqlTypes.INTEGER)
         .valueColumn(ColumnName.of("ROWKEY"), SqlTypes.STRING)
         .valueColumn(ColumnName.of("field2"), SqlTypes.STRING)

--- a/ksql-rest-app/src/test/java/io/confluent/ksql/rest/server/resources/KsqlResourceTest.java
+++ b/ksql-rest-app/src/test/java/io/confluent/ksql/rest/server/resources/KsqlResourceTest.java
@@ -146,7 +146,6 @@ import io.confluent.ksql.util.KsqlStatementException;
 import io.confluent.ksql.util.PersistentQueryMetadata;
 import io.confluent.ksql.util.QueryMetadata;
 import io.confluent.ksql.util.Sandbox;
-import io.confluent.ksql.util.TransientQueryMetadata;
 import io.confluent.ksql.util.timestamp.MetadataTimestampExtractionPolicy;
 import io.confluent.ksql.version.metrics.ActivenessRegistrar;
 import io.confluent.rest.RestConfig;
@@ -237,8 +236,6 @@ public class KsqlResourceTest {
   private static final LogicalSchema SOME_SCHEMA = LogicalSchema.builder()
       .valueColumn(ColumnName.of("f1"), SqlTypes.STRING)
       .build();
-
-  private static final String COMMAND_TOPIC_NAME = "command-topic";
 
   @Rule
   public final ExpectedException expectedException = ExpectedException.none();
@@ -2061,9 +2058,9 @@ public class KsqlResourceTest {
     assertThat(entity, instanceOf(QueryDescriptionEntity.class));
     final QueryDescriptionEntity queryDescriptionEntity = (QueryDescriptionEntity) entity;
     final QueryDescription queryDescription = queryDescriptionEntity.getQueryDescription();
-    final boolean valueSchemaOnly = queryMetadata instanceof TransientQueryMetadata;
+
     assertThat(queryDescription.getFields(), is(
-        EntityUtil.buildSourceSchemaEntity(queryMetadata.getLogicalSchema(), valueSchemaOnly)));
+        EntityUtil.buildSourceSchemaEntity(queryMetadata.getLogicalSchema())));
     assertThat(queryDescription.getOverriddenProperties(), is(overriddenProperties));
   }
 

--- a/ksql-rest-app/src/test/java/io/confluent/ksql/rest/util/EntityUtilTest.java
+++ b/ksql-rest-app/src/test/java/io/confluent/ksql/rest/util/EntityUtilTest.java
@@ -60,11 +60,12 @@ public class EntityUtilTest {
   public void shouldBuildCorrectMapField() {
     // Given:
     final LogicalSchema schema = LogicalSchema.builder()
+        .noImplicitColumns()
         .valueColumn(ColumnName.of("field"), SqlTypes.map(SqlTypes.INTEGER))
         .build();
 
     // When:
-    final List<FieldInfo> fields = EntityUtil.buildSourceSchemaEntity(schema, true);
+    final List<FieldInfo> fields = EntityUtil.buildSourceSchemaEntity(schema);
 
     // Then:
     assertThat(fields, hasSize(1));
@@ -79,11 +80,12 @@ public class EntityUtilTest {
   public void shouldBuildCorrectArrayField() {
     // Given:
     final LogicalSchema schema = LogicalSchema.builder()
+        .noImplicitColumns()
         .valueColumn(ColumnName.of("field"), SqlTypes.array(SqlTypes.BIGINT))
         .build();
 
     // When:
-    final List<FieldInfo> fields = EntityUtil.buildSourceSchemaEntity(schema, true);
+    final List<FieldInfo> fields = EntityUtil.buildSourceSchemaEntity(schema);
 
     // Then:
     assertThat(fields, hasSize(1));
@@ -98,13 +100,14 @@ public class EntityUtilTest {
   public void shouldBuildCorrectStructField() {
     // Given:
     final LogicalSchema schema = LogicalSchema.builder()
+        .noImplicitColumns()
         .valueColumn(ColumnName.of("field"), SqlTypes.struct()
             .field("innerField", SqlTypes.STRING)
             .build())
         .build();
 
     // When:
-    final List<FieldInfo> fields = EntityUtil.buildSourceSchemaEntity(schema, true);
+    final List<FieldInfo> fields = EntityUtil.buildSourceSchemaEntity(schema);
 
     // Then:
     assertThat(fields, hasSize(1));
@@ -120,12 +123,13 @@ public class EntityUtilTest {
   public void shouldBuildMiltipleFieldsCorrectly() {
     // Given:
     final LogicalSchema schema = LogicalSchema.builder()
+        .noImplicitColumns()
         .valueColumn(ColumnName.of("field1"), SqlTypes.INTEGER)
         .valueColumn(ColumnName.of("field2"), SqlTypes.BIGINT)
         .build();
 
     // When:
-    final List<FieldInfo> fields = EntityUtil.buildSourceSchemaEntity(schema, true);
+    final List<FieldInfo> fields = EntityUtil.buildSourceSchemaEntity(schema);
 
     // Then:
     assertThat(fields, hasSize(2));
@@ -139,13 +143,14 @@ public class EntityUtilTest {
   public void shouldSupportRowTimeAndKeyInValueSchema() {
     // Given:
     final LogicalSchema schema = LogicalSchema.builder()
+        .noImplicitColumns()
         .valueColumn(ColumnName.of("ROWKEY"), SqlTypes.STRING)
         .valueColumn(ColumnName.of("ROWTIME"), SqlTypes.INTEGER)
         .valueColumn(ColumnName.of("field1"), SqlTypes.INTEGER)
         .build();
 
     // When:
-    final List<FieldInfo> fields = EntityUtil.buildSourceSchemaEntity(schema, true);
+    final List<FieldInfo> fields = EntityUtil.buildSourceSchemaEntity(schema);
 
     // Then:
     assertThat(fields, hasSize(3));
@@ -154,22 +159,35 @@ public class EntityUtilTest {
   }
 
   @Test
-  public void shouldSupportGettingFullSchema() {
+  public void shouldSupportSchemasWithMetaColumns() {
     // Given:
     final LogicalSchema schema = LogicalSchema.builder()
-        .valueColumn(ColumnName.of("field1"), SqlTypes.INTEGER)
         .build();
 
     // When:
-    final List<FieldInfo> fields = EntityUtil.buildSourceSchemaEntity(schema, false);
+    final List<FieldInfo> fields = EntityUtil.buildSourceSchemaEntity(schema);
 
     // Then:
-    assertThat(fields, hasSize(3));
+    assertThat(fields, hasSize(2));
     assertThat(fields.get(0).getName(), equalTo("ROWTIME"));
     assertThat(fields.get(0).getSchema().getTypeName(), equalTo("BIGINT"));
-    assertThat(fields.get(1).getName(), equalTo("ROWKEY"));
-    assertThat(fields.get(1).getSchema().getTypeName(), equalTo("STRING"));
-    assertThat(fields.get(2).getName(), equalTo("field1"));
+  }
+
+  @Test
+  public void shouldSupportSchemasWithKeyColumns() {
+    // Given:
+    final LogicalSchema schema = LogicalSchema.builder()
+        .noImplicitColumns()
+        .keyColumn(ColumnName.of("field1"), SqlTypes.INTEGER)
+        .build();
+
+    // When:
+    final List<FieldInfo> fields = EntityUtil.buildSourceSchemaEntity(schema);
+
+    // Then:
+    assertThat(fields, hasSize(1));
+    assertThat(fields.get(0).getName(), equalTo("field1"));
+    assertThat(fields.get(0).getSchema().getTypeName(), equalTo("INTEGER"));
   }
 
   private static void shouldBuildCorrectPrimitiveField(
@@ -178,11 +196,12 @@ public class EntityUtilTest {
   ) {
     // Given:
     final LogicalSchema schema = LogicalSchema.builder()
+        .noImplicitColumns()
         .valueColumn(ColumnName.of("field"), primitiveSchema)
         .build();
 
     // When:
-    final List<FieldInfo> fields = EntityUtil.buildSourceSchemaEntity(schema, true);
+    final List<FieldInfo> fields = EntityUtil.buildSourceSchemaEntity(schema);
 
     // Then:
     assertThat(fields.get(0).getName(), equalTo("field"));


### PR DESCRIPTION
### Description 


The `buildSourceSchemaEntity` used to take a boolean indicating if only the value fields should be taken into account, or the whole schema. With recent changes, the schema passed is now correct and we should always take all fields into account, i.e. where before we were only using the value columns, now the passed schema only has value columns.

This commit removes the `valueSchemaOnly` param from `buildSourceSchemaEntity` and cleans up calling code and tests.

### Testing done 

usual

### Reviewer checklist
- [ ] Ensure docs are updated if necessary. (eg. if a user visible feature is being added or changed).
- [ ] Ensure relevant issues are linked (description should include text like "Fixes #<issue number>")

