### PR TITLE
refactor: transient queries should only have value columns in schema

### DIFF
--- a/ksql-engine/src/main/java/io/confluent/ksql/util/TransientQueryMetadata.java
+++ b/ksql-engine/src/main/java/io/confluent/ksql/util/TransientQueryMetadata.java
@@ -67,6 +67,10 @@ public class TransientQueryMetadata extends QueryMetadata {
     );
     this.limitHandlerSetter = Objects.requireNonNull(limitHandlerSetter, "limitHandlerSetter");
     this.rowQueue = Objects.requireNonNull(rowQueue, "rowQueue");
+
+    if (!logicalSchema.metadata().isEmpty() || !logicalSchema.key().isEmpty()) {
+      throw new IllegalArgumentException("Transient queries only support value columns");
+    }
   }
 
   public boolean isRunning() {

--- a/ksql-engine/src/test/java/io/confluent/ksql/physical/PhysicalPlanBuilderTest.java
+++ b/ksql-engine/src/test/java/io/confluent/ksql/physical/PhysicalPlanBuilderTest.java
@@ -146,6 +146,7 @@ public class PhysicalPlanBuilderTest {
 
     // Then:
     assertThat(queryMetadata.getLogicalSchema(), is(LogicalSchema.builder()
+        .noImplicitColumns()
         .valueColumn(ColumnName.of("COL0"), SqlTypes.BIGINT)
         .valueColumn(ColumnName.of("COL2"), SqlTypes.DOUBLE)
         .build()

--- a/ksql-rest-app/src/test/java/io/confluent/ksql/rest/entity/QueryDescriptionFactoryTest.java
+++ b/ksql-rest-app/src/test/java/io/confluent/ksql/rest/entity/QueryDescriptionFactoryTest.java
@@ -57,7 +57,13 @@ import org.mockito.junit.MockitoJUnitRunner;
 @RunWith(MockitoJUnitRunner.class)
 public class QueryDescriptionFactoryTest {
 
-  private static final LogicalSchema SOME_SCHEMA = LogicalSchema.builder()
+  private static final LogicalSchema TRANSIENT_SCHEMA = LogicalSchema.builder()
+      .noImplicitColumns()
+      .valueColumn(ColumnName.of("field1"), SqlTypes.INTEGER)
+      .valueColumn(ColumnName.of("field2"), SqlTypes.STRING)
+      .build();
+
+  private static final LogicalSchema PERSISTENT_SCHEMA = LogicalSchema.builder()
       .valueColumn(ColumnName.of("field1"), SqlTypes.INTEGER)
       .valueColumn(ColumnName.of("field2"), SqlTypes.STRING)
       .build();
@@ -93,7 +99,7 @@ public class QueryDescriptionFactoryTest {
     transientQuery = new TransientQueryMetadata(
         SQL_TEXT,
         queryStreams,
-        SOME_SCHEMA,
+        TRANSIENT_SCHEMA,
         SOURCE_NAMES,
         limitHandler,
         "execution plan",
@@ -109,7 +115,7 @@ public class QueryDescriptionFactoryTest {
     final PersistentQueryMetadata persistentQuery = new PersistentQueryMetadata(
         SQL_TEXT,
         queryStreams,
-        PhysicalSchema.from(SOME_SCHEMA, SerdeOption.none()),
+        PhysicalSchema.from(PERSISTENT_SCHEMA, SerdeOption.none()),
         SOURCE_NAMES,
         SourceName.of("sink Name"),
         "execution plan",
@@ -197,6 +203,7 @@ public class QueryDescriptionFactoryTest {
   public void shouldHandleRowTimeInValueSchemaForTransientQuery() {
     // Given:
     final LogicalSchema schema = LogicalSchema.builder()
+        .noImplicitColumns()
         .valueColumn(ColumnName.of("field1"), SqlTypes.INTEGER)
         .valueColumn(ColumnName.of("ROWTIME"), SqlTypes.BIGINT)
         .valueColumn(ColumnName.of("field2"), SqlTypes.STRING)
@@ -230,6 +237,7 @@ public class QueryDescriptionFactoryTest {
   public void shouldHandleRowKeyInValueSchemaForTransientQuery() {
     // Given:
     final LogicalSchema schema = LogicalSchema.builder()
+        .noImplicitColumns()
         .valueColumn(ColumnName.of("field1"), SqlTypes.INTEGER)
         .valueColumn(ColumnName.of("ROWKEY"), SqlTypes.STRING)
         .valueColumn(ColumnName.of("field2"), SqlTypes.STRING)

--- a/ksql-rest-app/src/test/java/io/confluent/ksql/rest/server/resources/streaming/StreamedQueryResourceTest.java
+++ b/ksql-rest-app/src/test/java/io/confluent/ksql/rest/server/resources/streaming/StreamedQueryResourceTest.java
@@ -101,6 +101,7 @@ public class StreamedQueryResourceTest {
   private static final Duration DISCONNECT_CHECK_INTERVAL = Duration.ofMillis(1000);
   private static final Duration COMMAND_QUEUE_CATCHUP_TIMOEUT = Duration.ofMillis(1000);
   private static final LogicalSchema SOME_SCHEMA = LogicalSchema.builder()
+      .noImplicitColumns()
       .valueColumn(ColumnName.of("f1"), SqlTypes.INTEGER)
       .build();
 
@@ -303,7 +304,6 @@ public class StreamedQueryResourceTest {
     // Then:
     verify(serviceContext, never()).getTopicClient();
   }
-
 
   @Test
   public void shouldStreamRowsCorrectly() throws Throwable {


### PR DESCRIPTION
### Description 

First part of fix for https://github.com/confluentinc/ksql/issues/3859

This commit fixes the schema of `TransientQueryMetadata`, (the query metadata used for push queries), so that it only has value columns.  This makes the _schema_ stored in the metadata match the _data_ returned by push queries.

Previously, the schema contained meta and key columns, which push queries don't return.

Note: When you issue a `SELECT * FROM FOO EMIT CHANGES` style push query, the current impl copies the key and meta columns into the value, so its still only returning value columns.

This allows us to remove a temporary fix in `PushQueryPublisher` that was also removing key and meta columns.


### Testing done 

`mvn test`

### Reviewer checklist
- [ ] Ensure docs are updated if necessary. (eg. if a user visible feature is being added or changed).
- [ ] Ensure relevant issues are linked (description should include text like "Fixes #<issue number>")

