### PR TITLE
chore: fix command store test missing import

### DIFF
--- a/ksql-rest-app/src/test/java/io/confluent/ksql/rest/integration/PullQueryFunctionalTest.java
+++ b/ksql-rest-app/src/test/java/io/confluent/ksql/rest/integration/PullQueryFunctionalTest.java
@@ -194,7 +194,10 @@ public class PullQueryFunctionalTest {
 
     // Then:
     assertThat(rows_0, hasSize(HEADER + 1));
-    assertThat(rows_1, is(rows_0));
+    assertThat(rows_1, hasSize(rows_0.size()));
+    for (int i = 0; i < rows_1.size(); i++) {
+      compareWithoutQueryId(rows_1.get(i), rows_0.get(i));
+    }
     assertThat(rows_0.get(1).getRow(), is(not(Optional.empty())));
     assertThat(rows_0.get(1).getRow().get().getColumns(), is(ImmutableList.of(key, 1)));
   }
@@ -223,9 +226,24 @@ public class PullQueryFunctionalTest {
 
     // Then:
     assertThat(rows_0, hasSize(HEADER + 1));
-    assertThat(rows_1, is(rows_0));
+    assertThat(rows_1, hasSize(rows_0.size()));
+    for (int i = 0; i < rows_1.size(); i++) {
+      compareWithoutQueryId(rows_1.get(i), rows_0.get(i));
+    }
     assertThat(rows_0.get(1).getRow(), is(not(Optional.empty())));
     assertThat(rows_0.get(1).getRow().get().getColumns(), is(ImmutableList.of(key, BASE_TIME, 1)));
+  }
+
+  private static void compareWithoutQueryId(final StreamedRow a, final StreamedRow b) {
+    if (a.getHeader().isPresent()) {
+      assertThat("expected header", b.getHeader().isPresent());
+      assertThat(
+          a.getHeader().get().getSchema(),
+          is(b.getHeader().get().getSchema()));
+    }
+    assertThat(a.getRow(), is(b.getRow()));
+    assertThat(a.getErrorMessage(), is(b.getErrorMessage()));
+    assertThat(a.getFinalMessage(), is(b.getFinalMessage()));
   }
 
   private static List<StreamedRow> makePullQueryRequest(

--- a/ksql-rest-app/src/test/java/io/confluent/ksql/rest/server/computation/CommandStoreTest.java
+++ b/ksql-rest-app/src/test/java/io/confluent/ksql/rest/server/computation/CommandStoreTest.java
@@ -25,6 +25,7 @@ import static org.hamcrest.core.IsEqual.equalTo;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.ArgumentMatchers.same;
 import static org.mockito.Mockito.inOrder;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
@@ -243,7 +244,7 @@ public class CommandStoreTest {
 
     expectedException.expect(TimeoutException.class);
     expectedException.expectMessage(
-        "Timeout reached while waiting for command sequence number of 2. (Timeout: %d ms)"
+        "Timeout reached while waiting for command sequence number of 2. (Timeout: 1000 ms)"
     );
 
     // When:


### PR DESCRIPTION
### Description 

5.4.x branch is failing due to:
```
17:16:57  [ERROR] Failed to execute goal org.apache.maven.plugins:maven-compiler-plugin:3.8.0:testCompile (default-testCompile) on project ksql-rest-app: Compilation failure
17:16:57  [ERROR] /tmp/confluent/ksql/ksql-rest-app/src/test/java/io/confluent/ksql/rest/server/computation/CommandStoreTest.java:[217,31] cannot find symbol
17:16:57  [ERROR]   symbol:   method same(io.confluent.ksql.rest.entity.CommandId)
17:16:57  [ERROR]   location: class io.confluent.ksql.rest.server.computation.CommandStoreTest
17:16:57  [ERROR] 
17:16:57  [ERROR] -> [Help 1]
```

This should fix that.

### Testing done 
_Describe the testing strategy. Unit and integration tests are expected for any behavior changes._

### Reviewer checklist
- [ ] Ensure docs are updated if necessary. (eg. if a user visible feature is being added or changed).
- [ ] Ensure relevant issues are linked (description should include text like "Fixes #<issue number>")

