### PR TITLE
refactor: change processing log stream create to use KsqlResource

### DIFF
--- a/ksql-rest-app/src/main/java/io/confluent/ksql/rest/server/ServerUtil.java
+++ b/ksql-rest-app/src/main/java/io/confluent/ksql/rest/server/ServerUtil.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright 2019 Confluent Inc.
+ *
+ * Licensed under the Confluent Community License (the "License"); you may not use
+ * this file except in compliance with the License.  You may obtain a copy of the
+ * License at
+ *
+ * http://www.confluent.io/confluent-community-license
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package io.confluent.ksql.rest.server;
+
+import io.confluent.rest.RestConfig;
+import java.net.URI;
+import java.net.URL;
+import java.util.List;
+import org.apache.kafka.common.config.ConfigException;
+
+public final class ServerUtil {
+  
+  private ServerUtil() {
+  }
+  
+  public static URI getServerAddress(final KsqlRestConfig restConfig) {
+    final List<String> listeners = restConfig.getList(RestConfig.LISTENERS_CONFIG);
+    final String address = listeners.stream()
+            .map(String::trim)
+            .findFirst()
+            .orElseThrow(() -> invalidAddressException(listeners, "value cannot be empty"));
+
+    try {
+      return new URL(address).toURI();
+    } catch (final Exception e) {
+      throw invalidAddressException(listeners, e.getMessage());
+    }
+  }
+
+  private static RuntimeException invalidAddressException(
+          final List<String> serverAddresses,
+          final String message
+  ) {
+    return new ConfigException(RestConfig.LISTENERS_CONFIG, serverAddresses, message);
+  }
+}

--- a/ksql-rest-app/src/main/java/io/confluent/ksql/rest/server/ServerUtil.java
+++ b/ksql-rest-app/src/main/java/io/confluent/ksql/rest/server/ServerUtil.java
@@ -29,21 +29,15 @@ public final class ServerUtil {
   public static URI getServerAddress(final KsqlRestConfig restConfig) {
     final List<String> listeners = restConfig.getList(RestConfig.LISTENERS_CONFIG);
     final String address = listeners.stream()
-            .map(String::trim)
-            .findFirst()
-            .orElseThrow(() -> invalidAddressException(listeners, "value cannot be empty"));
+        .map(String::trim)
+        .findFirst()
+        .orElseThrow(() ->
+            new ConfigException(RestConfig.LISTENERS_CONFIG, listeners, "value cannot be empty"));
 
     try {
       return new URL(address).toURI();
     } catch (final Exception e) {
-      throw invalidAddressException(listeners, e.getMessage());
+      throw new ConfigException(RestConfig.LISTENERS_CONFIG, listeners, e.getMessage());
     }
-  }
-
-  private static RuntimeException invalidAddressException(
-          final List<String> serverAddresses,
-          final String message
-  ) {
-    return new ConfigException(RestConfig.LISTENERS_CONFIG, serverAddresses, message);
   }
 }

--- a/ksql-rest-app/src/main/java/io/confluent/ksql/rest/util/ProcessingLogServerUtils.java
+++ b/ksql-rest-app/src/main/java/io/confluent/ksql/rest/util/ProcessingLogServerUtils.java
@@ -17,13 +17,8 @@ package io.confluent.ksql.rest.util;
 
 import io.confluent.common.logging.LogRecordStructBuilder;
 import io.confluent.ksql.exception.KafkaTopicExistsException;
-import io.confluent.ksql.function.InternalFunctionRegistry;
 import io.confluent.ksql.logging.processing.ProcessingLogConfig;
 import io.confluent.ksql.logging.processing.ProcessingLogMessageSchema;
-import io.confluent.ksql.metastore.MetaStoreImpl;
-import io.confluent.ksql.parser.DefaultKsqlParser;
-import io.confluent.ksql.parser.KsqlParser.ParsedStatement;
-import io.confluent.ksql.parser.KsqlParser.PreparedStatement;
 import io.confluent.ksql.schema.connect.SqlSchemaFormatter;
 import io.confluent.ksql.schema.connect.SqlSchemaFormatter.Option;
 import io.confluent.ksql.services.KafkaTopicClient;
@@ -87,7 +82,7 @@ public final class ProcessingLogServerUtils {
     return Optional.of(topicName);
   }
 
-  public static PreparedStatement<?> processingLogStreamCreateStatement(
+  public static String processingLogStreamCreateStatement(
       final ProcessingLogConfig config,
       final KsqlConfig ksqlConfig
   ) {
@@ -97,7 +92,7 @@ public final class ProcessingLogServerUtils {
     );
   }
 
-  private static PreparedStatement<?> processingLogStreamCreateStatement(
+  private static String processingLogStreamCreateStatement(
       final String name,
       final String topicName
   ) {
@@ -105,12 +100,8 @@ public final class ProcessingLogServerUtils {
 
     final String elements = FORMATTER.format(schema);
 
-    final String createStreamSql = "CREATE STREAM " + name
+    return "CREATE STREAM " + name
         + " (" + elements + ")"
         + " WITH(KAFKA_TOPIC='" + topicName + "', VALUE_FORMAT='JSON');";
-
-    final DefaultKsqlParser parser = new DefaultKsqlParser();
-    final ParsedStatement parsed = parser.parse(createStreamSql).get(0);
-    return parser.prepare(parsed, new MetaStoreImpl(new InternalFunctionRegistry()));
   }
 }

--- a/ksql-rest-app/src/test/java/io/confluent/ksql/rest/server/KsqlRestApplicationTest.java
+++ b/ksql-rest-app/src/test/java/io/confluent/ksql/rest/server/KsqlRestApplicationTest.java
@@ -15,8 +15,6 @@
 
 package io.confluent.ksql.rest.server;
 
-import static io.confluent.ksql.parser.ParserMatchers.configured;
-import static org.hamcrest.Matchers.equalTo;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyInt;
 import static org.mockito.ArgumentMatchers.anyMap;
@@ -28,7 +26,6 @@ import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyZeroInteractions;
 import static org.mockito.Mockito.when;
-import static org.mockito.hamcrest.MockitoHamcrest.argThat;
 
 import com.google.common.collect.ImmutableList;
 import io.confluent.ksql.KsqlExecutionContext;
@@ -57,9 +54,7 @@ import io.confluent.ksql.security.KsqlAuthorizationProvider;
 import io.confluent.ksql.security.KsqlSecurityExtension;
 import io.confluent.ksql.services.KafkaTopicClient;
 import io.confluent.ksql.services.ServiceContext;
-import io.confluent.ksql.statement.ConfiguredStatement;
 import io.confluent.ksql.util.KsqlConfig;
-import io.confluent.ksql.util.KsqlException;
 import io.confluent.ksql.version.metrics.VersionCheckerAgent;
 import io.confluent.rest.RestConfig;
 import java.util.Collections;

--- a/ksql-rest-app/src/test/java/io/confluent/ksql/rest/server/ServerUtilTest.java
+++ b/ksql-rest-app/src/test/java/io/confluent/ksql/rest/server/ServerUtilTest.java
@@ -1,0 +1,61 @@
+/*
+ * Copyright 2019 Confluent Inc.
+ *
+ * Licensed under the Confluent Community License (the "License"); you may not use
+ * this file except in compliance with the License.  You may obtain a copy of the
+ * License at
+ *
+ * http://www.confluent.io/confluent-community-license
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package io.confluent.ksql.rest.server;
+
+import java.util.Collections;
+import io.confluent.rest.RestConfig;
+import org.apache.kafka.clients.consumer.ConsumerConfig;
+import org.apache.kafka.common.config.ConfigException;
+import org.apache.kafka.test.TestUtils;
+
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+import org.junit.runner.RunWith;
+import org.mockito.junit.MockitoJUnitRunner;
+
+@RunWith(MockitoJUnitRunner.class)
+public class ServerUtilTest {
+
+  @Before
+  public void setUp() { }
+
+  @Test(expected = ConfigException.class)
+  public void shouldThrowConfigExceptionIfInvalidServerAddress() {
+    // Given:
+    KsqlRestConfig restConfig =
+        new KsqlRestConfig(
+            Collections.singletonMap(RestConfig.LISTENERS_CONFIG,
+                "invalid"));
+
+    // Then:
+    ServerUtil.getServerAddress(restConfig);
+  }
+
+  @Test
+  public void shouldReturnServerAddress() {
+    // Given:
+    KsqlRestConfig restConfig =
+        new KsqlRestConfig(
+            Collections.singletonMap(RestConfig.LISTENERS_CONFIG,
+                "http://localhost:8088, http://localhost:9099"));
+
+    // Then:
+    ServerUtil.getServerAddress(restConfig);
+  }
+
+}

--- a/ksql-rest-app/src/test/java/io/confluent/ksql/rest/util/ProcessingLogServerUtilsTest.java
+++ b/ksql-rest-app/src/test/java/io/confluent/ksql/rest/util/ProcessingLogServerUtilsTest.java
@@ -180,18 +180,13 @@ public class ProcessingLogServerUtilsTest {
     serviceContext.getTopicClient().createTopic(TOPIC, 1, (short) 1);
 
     // When:
-    final PreparedStatement<?> statement =
+    final String statement =
         ProcessingLogServerUtils.processingLogStreamCreateStatement(
             config,
             ksqlConfig);
 
-    ksqlEngine.execute(
-        serviceContext,
-        ConfiguredStatement.of(statement, ImmutableMap.of(), ksqlConfig)
-    );
-
     // Then:
-    assertThat(statement.getStatementText(), equalTo(
+    assertThat(statement, equalTo(
         "CREATE STREAM PROCESSING_LOG_STREAM ("
             + "logger VARCHAR, "
             + "level VARCHAR, "
@@ -203,8 +198,6 @@ public class ProcessingLogServerUtilsTest {
             + "productionError STRUCT<errorMessage VARCHAR>"
             + ">"
             + ") WITH(KAFKA_TOPIC='processing_log_topic', VALUE_FORMAT='JSON');"));
-
-    assertLogStream(TOPIC);
   }
 
   @Test
@@ -213,7 +206,7 @@ public class ProcessingLogServerUtilsTest {
     serviceContext.getTopicClient().createTopic(DEFAULT_TOPIC, 1, (short)1);
 
     // When:
-    final PreparedStatement<?> statement =
+    final String statement =
         ProcessingLogServerUtils.processingLogStreamCreateStatement(
             new ProcessingLogConfig(
                 ImmutableMap.of(
@@ -223,16 +216,9 @@ public class ProcessingLogServerUtilsTest {
             ),
             ksqlConfig);
 
-    ksqlEngine.execute(
-        serviceContext,
-        ConfiguredStatement.of(statement, ImmutableMap.of(), ksqlConfig)
-    );
-
     // Then:
-    assertThat(statement.getStatementText(),
+    assertThat(statement,
         containsString("KAFKA_TOPIC='ksql_cluster.ksql_processing_log'"));
-
-    assertLogStream(DEFAULT_TOPIC);
   }
 
   @Test


### PR DESCRIPTION
### Description 
https://github.com/confluentinc/ksql/issues/3768

As part of https://github.com/confluentinc/ksql/pull/3660 , there was a lot of duplicated transaction code put into `KsqlRestApplication.maybeCreateProcessingLogStream()` which isn't ideal. This is the only place in the code where we put a command into the command topic without going through the KsqlResource. This refactor changes `maybeCreateProcessingLogStream()` to use the KsqlResource instead of directly enqueueing the command.

This also fixes a bug where if the create processing log stream command fails to be committed, the aborted command would be left in the command topic and the processing log would never be created since the commandQueue isn't empty.

### Testing done 
Updated unit tests and did some local testing

### Reviewer checklist
- [ ] Ensure docs are updated if necessary. (eg. if a user visible feature is being added or changed).
- [ ] Ensure relevant issues are linked (description should include text like "Fixes #<issue number>")

