### PR TITLE
refactor: clean up ksql sink

### DIFF
--- a/ksql-engine/src/main/java/io/confluent/ksql/analyzer/Analyzer.java
+++ b/ksql-engine/src/main/java/io/confluent/ksql/analyzer/Analyzer.java
@@ -199,8 +199,7 @@ class Analyzer {
       final KsqlTopic intoKsqlTopic = new KsqlTopic(
           topicName,
           keyFormat,
-          valueFormat,
-          true
+          valueFormat
       );
 
       analysis.setInto(Into.of(

--- a/ksql-engine/src/main/java/io/confluent/ksql/ddl/commands/DdlCommandExec.java
+++ b/ksql-engine/src/main/java/io/confluent/ksql/ddl/commands/DdlCommandExec.java
@@ -48,15 +48,20 @@ public class DdlCommandExec {
   /**
    * execute on metaStore
    */
-  public DdlCommandResult execute(final String sql, final DdlCommand ddlCommand) {
-    return new Executor(sql).execute(ddlCommand);
+  public DdlCommandResult execute(
+      final String sql,
+      final DdlCommand ddlCommand,
+      final boolean withQuery) {
+    return new Executor(sql, withQuery).execute(ddlCommand);
   }
 
   private final class Executor implements io.confluent.ksql.execution.ddl.commands.Executor {
     private final String sql;
+    private final boolean withQuery;
 
-    private Executor(final String sql) {
+    private Executor(final String sql, final boolean withQuery) {
       this.sql = Objects.requireNonNull(sql, "sql");
+      this.withQuery = withQuery;
     }
 
     @Override
@@ -68,6 +73,7 @@ public class DdlCommandExec {
           createStream.getSerdeOptions(),
           getKeyField(createStream.getKeyField()),
           createStream.getTimestampExtractionPolicy(),
+          withQuery,
           createStream.getTopic()
       );
       metaStore.putSource(ksqlStream);
@@ -83,6 +89,7 @@ public class DdlCommandExec {
           createTable.getSerdeOptions(),
           getKeyField(createTable.getKeyField()),
           createTable.getTimestampExtractionPolicy(),
+          withQuery,
           createTable.getTopic()
       );
       metaStore.putSource(ksqlTable);

--- a/ksql-engine/src/main/java/io/confluent/ksql/engine/EngineContext.java
+++ b/ksql-engine/src/main/java/io/confluent/ksql/engine/EngineContext.java
@@ -188,9 +188,10 @@ final class EngineContext {
 
   String executeDdl(
       final String sqlExpression,
-      final DdlCommand command
+      final DdlCommand command,
+      final boolean withQuery
   ) {
-    final DdlCommandResult result = ddlCommandExec.execute(sqlExpression, command);
+    final DdlCommandResult result = ddlCommandExec.execute(sqlExpression, command, withQuery);
     if (!result.isSuccess()) {
       throw new KsqlStatementException(result.getMessage(), sqlExpression);
     }

--- a/ksql-engine/src/main/java/io/confluent/ksql/engine/EngineExecutor.java
+++ b/ksql-engine/src/main/java/io/confluent/ksql/engine/EngineExecutor.java
@@ -108,7 +108,7 @@ final class EngineExecutor {
   @SuppressWarnings("OptionalGetWithoutIsPresent") // Known to be non-empty
   private ExecuteResult execute(final KsqlPlan plan) {
     final Optional<String> ddlResult = plan.getDdlCommand()
-        .map(ddl -> executeDdl(ddl, plan.getStatementText()));
+        .map(ddl -> executeDdl(ddl, plan.getStatementText(), plan.getQueryPlan().isPresent()));
 
     final Optional<PersistentQueryMetadata> queryMetadata = plan.getQueryPlan()
         .map(qp -> executePersistentQuery(qp, plan.getStatementText()));
@@ -360,10 +360,11 @@ final class EngineExecutor {
 
   private String executeDdl(
       final DdlCommand ddlCommand,
-      final String statementText
+      final String statementText,
+      final boolean withQuery
   ) {
     try {
-      return engineContext.executeDdl(statementText, ddlCommand);
+      return engineContext.executeDdl(statementText, ddlCommand, withQuery);
     } catch (final KsqlStatementException e) {
       throw e;
     } catch (final Exception e) {

--- a/ksql-engine/src/main/java/io/confluent/ksql/topic/TopicFactory.java
+++ b/ksql-engine/src/main/java/io/confluent/ksql/topic/TopicFactory.java
@@ -52,8 +52,7 @@ public final class TopicFactory {
     return new KsqlTopic(
         kafkaTopicName,
         keyFormat,
-        valueFormat,
-        false
+        valueFormat
     );
   }
 }

--- a/ksql-engine/src/test/java/io/confluent/ksql/analyzer/AnalyzerFunctionalTest.java
+++ b/ksql-engine/src/test/java/io/confluent/ksql/analyzer/AnalyzerFunctionalTest.java
@@ -306,8 +306,8 @@ public class AnalyzerFunctionalTest {
     final KsqlTopic ksqlTopic = new KsqlTopic(
         "s0",
         KeyFormat.nonWindowed(FormatInfo.of(Format.KAFKA)),
-        ValueFormat.of(FormatInfo.of(Format.AVRO, Optional.of("org.ac.s1"), Optional.empty())),
-        false);
+        ValueFormat.of(FormatInfo.of(Format.AVRO, Optional.of("org.ac.s1"), Optional.empty()))
+    );
 
     final LogicalSchema schema = LogicalSchema.builder()
             .valueColumn(ColumnName.of("FIELD1"), SqlTypes.BIGINT)
@@ -320,6 +320,7 @@ public class AnalyzerFunctionalTest {
         SerdeOption.none(),
         KeyField.of(ColumnRef.withoutSource(ColumnName.of("FIELD1"))),
         new MetadataTimestampExtractionPolicy(),
+        false,
         ksqlTopic
     );
 
@@ -538,8 +539,8 @@ public class AnalyzerFunctionalTest {
     final KsqlTopic topic = new KsqlTopic(
         "ks",
         KeyFormat.nonWindowed(FormatInfo.of(Format.KAFKA)),
-        ValueFormat.of(FormatInfo.of(Format.KAFKA)),
-        false);
+        ValueFormat.of(FormatInfo.of(Format.KAFKA))
+    );
 
     final KsqlStream<?> stream = new KsqlStream<>(
         "sqlexpression",
@@ -548,6 +549,7 @@ public class AnalyzerFunctionalTest {
         SerdeOption.none(),
         KeyField.none(),
         new MetadataTimestampExtractionPolicy(),
+        false,
         topic
     );
 

--- a/ksql-engine/src/test/java/io/confluent/ksql/codegen/CodeGenRunnerTest.java
+++ b/ksql-engine/src/test/java/io/confluent/ksql/codegen/CodeGenRunnerTest.java
@@ -174,8 +174,7 @@ public class CodeGenRunnerTest {
         final KsqlTopic ksqlTopic = new KsqlTopic(
             "codegen_test",
             KeyFormat.nonWindowed(FormatInfo.of(Format.KAFKA)),
-            ValueFormat.of(FormatInfo.of(Format.JSON)),
-            false
+            ValueFormat.of(FormatInfo.of(Format.JSON))
         );
 
         final KsqlStream ksqlStream = new KsqlStream<>(
@@ -185,6 +184,7 @@ public class CodeGenRunnerTest {
             SerdeOption.none(),
             KeyField.of(ColumnRef.withoutSource(ColumnName.of("COL0"))),
             new MetadataTimestampExtractionPolicy(),
+            false,
             ksqlTopic
         );
 

--- a/ksql-engine/src/test/java/io/confluent/ksql/ddl/commands/DdlCommandExecTest.java
+++ b/ksql-engine/src/test/java/io/confluent/ksql/ddl/commands/DdlCommandExecTest.java
@@ -88,7 +88,7 @@ public class DdlCommandExecTest {
     givenCreateStreamWithKey(Optional.of("F1"));
 
     // When:
-    cmdExec.execute(SQL_TEXT, createStream);
+    cmdExec.execute(SQL_TEXT, createStream, false);
 
     // Then:
     MatcherAssert.assertThat(metaStore.getSource(STREAM_NAME).getKeyField(), hasName("F1"));
@@ -100,10 +100,21 @@ public class DdlCommandExecTest {
     givenCreateStreamWithKey(Optional.of("F1"));
 
     // When:
-    cmdExec.execute(SQL_TEXT, createStream);
+    cmdExec.execute(SQL_TEXT, createStream, false);
 
     // Then:
     assertThat(metaStore.getSource(STREAM_NAME).getSqlExpression(), is(SQL_TEXT));
+  }
+
+  public void shouldAddSinkStream() {
+    // Given:
+    givenCreateStreamWithKey(Optional.empty());
+
+    // When:
+    cmdExec.execute(SQL_TEXT, createStream, true);
+
+    // Then:
+    assertThat(metaStore.getSource(STREAM_NAME).isCasTarget(), is(true));
   }
 
   @Test
@@ -112,7 +123,7 @@ public class DdlCommandExecTest {
     givenCreateStreamWithKey(Optional.empty());
 
     // When:
-    cmdExec.execute(SQL_TEXT, createStream);
+    cmdExec.execute(SQL_TEXT, createStream, false);
 
     // Then:
     MatcherAssert.assertThat(metaStore.getSource(STREAM_NAME).getKeyField(), hasName(Optional.empty()));
@@ -124,7 +135,7 @@ public class DdlCommandExecTest {
     givenCreateTableWithKey(Optional.of("F1"));
 
     // When:
-    cmdExec.execute(SQL_TEXT, createTable);
+    cmdExec.execute(SQL_TEXT, createTable, false);
 
     // Then:
     MatcherAssert.assertThat(metaStore.getSource(TABLE_NAME).getKeyField(), hasName("F1"));
@@ -136,7 +147,7 @@ public class DdlCommandExecTest {
     givenCreateTableWithKey(Optional.empty());
 
     // When:
-    cmdExec.execute(SQL_TEXT, createTable);
+    cmdExec.execute(SQL_TEXT, createTable, false);
 
     // Then:
     MatcherAssert.assertThat(metaStore.getSource(TABLE_NAME).getKeyField(), hasName(Optional.empty()));
@@ -148,10 +159,21 @@ public class DdlCommandExecTest {
     givenCreateTableWithKey(Optional.empty());
 
     // When:
-    cmdExec.execute(SQL_TEXT, createTable);
+    cmdExec.execute(SQL_TEXT, createTable, false);
 
     // Then:
     MatcherAssert.assertThat(metaStore.getSource(TABLE_NAME).getSqlExpression(), is(SQL_TEXT));
+  }
+
+  public void shouldAddSinkTable() {
+    // Given:
+    givenCreateTableWithKey(Optional.empty());
+
+    // When:
+    cmdExec.execute(SQL_TEXT, createTable, true);
+
+    // Then:
+    assertThat(metaStore.getSource(TABLE_NAME).isCasTarget(), is(true));
   }
 
   @Test
@@ -160,7 +182,7 @@ public class DdlCommandExecTest {
     givenDropSourceCommand(STREAM_NAME);
 
     // When:
-    final DdlCommandResult result = cmdExec.execute(SQL_TEXT, dropSource);
+    final DdlCommandResult result = cmdExec.execute(SQL_TEXT, dropSource, false);
 
     // Then:
     assertThat(result.isSuccess(), is(true));
@@ -174,7 +196,7 @@ public class DdlCommandExecTest {
     givenDropSourceCommand(STREAM_NAME);
 
     // When:
-    final DdlCommandResult result = cmdExec.execute(SQL_TEXT, dropSource);
+    final DdlCommandResult result = cmdExec.execute(SQL_TEXT, dropSource, false);
 
     // Then
     assertThat(result.isSuccess(), is(true));
@@ -190,7 +212,7 @@ public class DdlCommandExecTest {
     metaStore.registerType("type", SqlTypes.STRING);
 
     // When:
-    final DdlCommandResult result  = cmdExec.execute(SQL_TEXT, dropType);
+    final DdlCommandResult result  = cmdExec.execute(SQL_TEXT, dropType, false);
 
     // Then:
     assertThat(metaStore.resolveType("type").isPresent(), is(false));
@@ -204,7 +226,7 @@ public class DdlCommandExecTest {
     metaStore.deleteType("type");
 
     // When:
-    final DdlCommandResult result = cmdExec.execute(SQL_TEXT, dropType);
+    final DdlCommandResult result = cmdExec.execute(SQL_TEXT, dropType, false);
 
     // Then:
     MatcherAssert.assertThat("Expected successful execution", result.isSuccess());
@@ -225,8 +247,7 @@ public class DdlCommandExecTest {
         new KsqlTopic(
             "topic",
             KeyFormat.nonWindowed(FormatInfo.of(Format.KAFKA)),
-            ValueFormat.of(FormatInfo.of(Format.JSON)),
-            false
+            ValueFormat.of(FormatInfo.of(Format.JSON))
         )
     );
   }
@@ -241,8 +262,7 @@ public class DdlCommandExecTest {
         new KsqlTopic(
             TOPIC_NAME,
             KeyFormat.nonWindowed(FormatInfo.of(Format.KAFKA)),
-            ValueFormat.of(FormatInfo.of(Format.JSON)),
-            false
+            ValueFormat.of(FormatInfo.of(Format.JSON))
         )
     );
   }

--- a/ksql-engine/src/test/java/io/confluent/ksql/engine/InsertValuesExecutorTest.java
+++ b/ksql-engine/src/test/java/io/confluent/ksql/engine/InsertValuesExecutorTest.java
@@ -868,8 +868,7 @@ public class InsertValuesExecutorTest {
     final KsqlTopic topic = new KsqlTopic(
         TOPIC_NAME,
         KeyFormat.nonWindowed(FormatInfo.of(Format.KAFKA)),
-        ValueFormat.of(FormatInfo.of(Format.JSON)),
-        false
+        ValueFormat.of(FormatInfo.of(Format.JSON))
     );
 
     final KeyField valueKeyField = keyField
@@ -885,6 +884,7 @@ public class InsertValuesExecutorTest {
           serdeOptions,
           valueKeyField,
           new MetadataTimestampExtractionPolicy(),
+          false,
           topic
       );
     } else {
@@ -895,6 +895,7 @@ public class InsertValuesExecutorTest {
           serdeOptions,
           valueKeyField,
           new MetadataTimestampExtractionPolicy(),
+          false,
           topic
       );
     }

--- a/ksql-engine/src/test/java/io/confluent/ksql/engine/KsqlEngineTest.java
+++ b/ksql-engine/src/test/java/io/confluent/ksql/engine/KsqlEngineTest.java
@@ -746,8 +746,8 @@ public class KsqlEngineTest {
     );
 
     // Then:
-    assertThat(metaStore.getSource(SourceName.of("S")).getKsqlTopic().isKsqlSink(), is(true));
-    assertThat(metaStore.getSource(SourceName.of("T")).getKsqlTopic().isKsqlSink(), is(true));
+    assertThat(metaStore.getSource(SourceName.of("S")).isCasTarget(), is(true));
+    assertThat(metaStore.getSource(SourceName.of("T")).isCasTarget(), is(true));
   }
 
   @Test

--- a/ksql-engine/src/test/java/io/confluent/ksql/planner/plan/DataSourceNodeTest.java
+++ b/ksql-engine/src/test/java/io/confluent/ksql/planner/plan/DataSourceNodeTest.java
@@ -112,11 +112,11 @@ public class DataSourceNodeTest {
       SerdeOption.none(),
       KeyField.of(ColumnRef.withoutSource(ColumnName.of("key"))),
       new LongColumnTimestampExtractionPolicy(ColumnRef.withoutSource(ColumnName.of("timestamp"))),
+      false,
       new KsqlTopic(
           "topic",
           KeyFormat.nonWindowed(FormatInfo.of(Format.KAFKA)),
-          ValueFormat.of(FormatInfo.of(Format.JSON)),
-          false
+          ValueFormat.of(FormatInfo.of(Format.JSON))
       )
   );
 
@@ -230,11 +230,11 @@ public class DataSourceNodeTest {
         SerdeOption.none(),
         KeyField.of(ColumnRef.withoutSource(ColumnName.of("field1"))),
         new LongColumnTimestampExtractionPolicy(TIMESTAMP_FIELD),
+        false,
         new KsqlTopic(
             "topic2",
             KeyFormat.nonWindowed(FormatInfo.of(Format.KAFKA)),
-            ValueFormat.of(FormatInfo.of(Format.JSON)),
-            false
+            ValueFormat.of(FormatInfo.of(Format.JSON))
         )
     );
 

--- a/ksql-engine/src/test/java/io/confluent/ksql/security/KsqlAuthorizationValidatorImplTest.java
+++ b/ksql-engine/src/test/java/io/confluent/ksql/security/KsqlAuthorizationValidatorImplTest.java
@@ -442,8 +442,7 @@ public class KsqlAuthorizationValidatorImplTest {
     final KsqlTopic sourceTopic = new KsqlTopic(
         topicDescription.name(),
         KeyFormat.nonWindowed(FormatInfo.of(Format.KAFKA)),
-        ValueFormat.of(FormatInfo.of(Format.JSON)),
-        false
+        ValueFormat.of(FormatInfo.of(Format.JSON))
     );
 
     final KsqlStream<?> streamSource = new KsqlStream<>(
@@ -453,6 +452,7 @@ public class KsqlAuthorizationValidatorImplTest {
         SerdeOption.none(),
         KeyField.none(),
         new MetadataTimestampExtractionPolicy(),
+        false,
         sourceTopic
     );
 

--- a/ksql-engine/src/test/java/io/confluent/ksql/topic/SourceTopicsExtractorTest.java
+++ b/ksql-engine/src/test/java/io/confluent/ksql/topic/SourceTopicsExtractorTest.java
@@ -161,8 +161,7 @@ public class SourceTopicsExtractorTest {
     final KsqlTopic sourceTopic = new KsqlTopic(
         topicDescription.name(),
         KeyFormat.nonWindowed(FormatInfo.of(Format.KAFKA)),
-        ValueFormat.of(FormatInfo.of(Format.JSON)),
-        false
+        ValueFormat.of(FormatInfo.of(Format.JSON))
     );
 
     final KsqlStream<?> streamSource = new KsqlStream<>(
@@ -172,6 +171,7 @@ public class SourceTopicsExtractorTest {
         SerdeOption.none(),
         KeyField.none(),
         new MetadataTimestampExtractionPolicy(),
+        false,
         sourceTopic
     );
 

--- a/ksql-engine/src/test/java/io/confluent/ksql/topic/TopicCreateInjectorTest.java
+++ b/ksql-engine/src/test/java/io/confluent/ksql/topic/TopicCreateInjectorTest.java
@@ -105,8 +105,7 @@ public class TopicCreateInjectorTest {
     final KsqlTopic sourceTopic = new KsqlTopic(
         "source",
         KeyFormat.nonWindowed(FormatInfo.of(Format.KAFKA)),
-        ValueFormat.of(FormatInfo.of(Format.JSON)),
-        false
+        ValueFormat.of(FormatInfo.of(Format.JSON))
     );
 
     final KsqlStream source = new KsqlStream<>(
@@ -116,6 +115,7 @@ public class TopicCreateInjectorTest {
         SerdeOption.none(),
         KeyField.none(),
         new MetadataTimestampExtractionPolicy(),
+        false,
         sourceTopic
     );
     metaStore.putSource(source);
@@ -123,8 +123,7 @@ public class TopicCreateInjectorTest {
     final KsqlTopic joinTopic = new KsqlTopic(
         "jSource",
         KeyFormat.nonWindowed(FormatInfo.of(Format.KAFKA)),
-        ValueFormat.of(FormatInfo.of(Format.JSON)),
-        false
+        ValueFormat.of(FormatInfo.of(Format.JSON))
     );
 
     final KsqlStream joinSource = new KsqlStream<>(
@@ -134,6 +133,7 @@ public class TopicCreateInjectorTest {
         SerdeOption.none(),
         KeyField.none(),
         new MetadataTimestampExtractionPolicy(),
+        false,
         joinTopic
     );
     metaStore.putSource(joinSource);

--- a/ksql-engine/src/test/java/io/confluent/ksql/util/AvroUtilTest.java
+++ b/ksql-engine/src/test/java/io/confluent/ksql/util/AvroUtilTest.java
@@ -103,8 +103,8 @@ public class AvroUtilTest {
   private static final KsqlTopic RESULT_TOPIC = new KsqlTopic(
       "actual-name",
       KeyFormat.nonWindowed(FormatInfo.of(Format.KAFKA)),
-      ValueFormat.of(FormatInfo.of(Format.AVRO, Optional.of(SCHEMA_NAME), Optional.empty())),
-      false);
+      ValueFormat.of(FormatInfo.of(Format.AVRO, Optional.of(SCHEMA_NAME), Optional.empty()))
+  );
 
   @Rule
   public final ExpectedException expectedException = ExpectedException.none();

--- a/ksql-execution/src/main/java/io/confluent/ksql/execution/ddl/commands/KsqlTopic.java
+++ b/ksql-execution/src/main/java/io/confluent/ksql/execution/ddl/commands/KsqlTopic.java
@@ -27,18 +27,15 @@ public class KsqlTopic {
   private final String kafkaTopicName;
   private final KeyFormat keyFormat;
   private final ValueFormat valueFormat;
-  private final boolean isKsqlSink;
 
   public KsqlTopic(
       @JsonProperty(value = "kafkaTopicName", required = true) String kafkaTopicName,
       @JsonProperty(value = "keyFormat", required = true) KeyFormat keyFormat,
-      @JsonProperty(value = "valueFormat", required = true) ValueFormat valueFormat,
-      @JsonProperty(value = "ksqlSink", required = true) boolean isKsqlSink
+      @JsonProperty(value = "valueFormat", required = true) ValueFormat valueFormat
   ) {
     this.kafkaTopicName = requireNonNull(kafkaTopicName, "kafkaTopicName");
     this.keyFormat = requireNonNull(keyFormat, "keyFormat");
     this.valueFormat = requireNonNull(valueFormat, "valueFormat");
-    this.isKsqlSink = isKsqlSink;
   }
 
   public KeyFormat getKeyFormat() {
@@ -51,9 +48,5 @@ public class KsqlTopic {
 
   public String getKafkaTopicName() {
     return kafkaTopicName;
-  }
-
-  public boolean isKsqlSink() {
-    return isKsqlSink;
   }
 }

--- a/ksql-metastore/src/main/java/io/confluent/ksql/metastore/model/DataSource.java
+++ b/ksql-metastore/src/main/java/io/confluent/ksql/metastore/model/DataSource.java
@@ -99,4 +99,9 @@ public interface DataSource<K> {
    * @return the SQL statement used to create this source.
    */
   String getSqlExpression();
+
+  /**
+   * @return returns whether this stream/table was created by a C(T|S)AS
+   */
+  boolean isCasTarget();
 }

--- a/ksql-metastore/src/main/java/io/confluent/ksql/metastore/model/KsqlStream.java
+++ b/ksql-metastore/src/main/java/io/confluent/ksql/metastore/model/KsqlStream.java
@@ -33,6 +33,7 @@ public class KsqlStream<K> extends StructuredDataSource<K> {
       final Set<SerdeOption> serdeOptions,
       final KeyField keyField,
       final TimestampExtractionPolicy timestampExtractionPolicy,
+      final boolean isKsqlSink,
       final KsqlTopic ksqlTopic
   ) {
     super(
@@ -43,6 +44,7 @@ public class KsqlStream<K> extends StructuredDataSource<K> {
         keyField,
         timestampExtractionPolicy,
         DataSourceType.KSTREAM,
+        isKsqlSink,
         ksqlTopic
     );
   }

--- a/ksql-metastore/src/main/java/io/confluent/ksql/metastore/model/KsqlTable.java
+++ b/ksql-metastore/src/main/java/io/confluent/ksql/metastore/model/KsqlTable.java
@@ -33,6 +33,7 @@ public class KsqlTable<K> extends StructuredDataSource<K> {
       final Set<SerdeOption> serdeOptions,
       final KeyField keyField,
       final TimestampExtractionPolicy timestampExtractionPolicy,
+      final boolean isKsqlSink,
       final KsqlTopic ksqlTopic
   ) {
     super(
@@ -43,6 +44,7 @@ public class KsqlTable<K> extends StructuredDataSource<K> {
         keyField,
         timestampExtractionPolicy,
         DataSourceType.KTABLE,
+        isKsqlSink,
         ksqlTopic
     );
   }

--- a/ksql-metastore/src/main/java/io/confluent/ksql/metastore/model/StructuredDataSource.java
+++ b/ksql-metastore/src/main/java/io/confluent/ksql/metastore/model/StructuredDataSource.java
@@ -39,6 +39,7 @@ abstract class StructuredDataSource<K> implements DataSource<K> {
   private final KsqlTopic ksqlTopic;
   private final String sqlExpression;
   private final ImmutableSet<SerdeOption> serdeOptions;
+  private final boolean casTarget;
 
   StructuredDataSource(
       final String sqlExpression,
@@ -48,6 +49,7 @@ abstract class StructuredDataSource<K> implements DataSource<K> {
       final KeyField keyField,
       final TimestampExtractionPolicy tsExtractionPolicy,
       final DataSourceType dataSourceType,
+      final boolean casTarget,
       final KsqlTopic ksqlTopic
   ) {
     this.sqlExpression = requireNonNull(sqlExpression, "sqlExpression");
@@ -59,6 +61,7 @@ abstract class StructuredDataSource<K> implements DataSource<K> {
     this.dataSourceType = requireNonNull(dataSourceType, "dataSourceType");
     this.ksqlTopic = requireNonNull(ksqlTopic, "ksqlTopic");
     this.serdeOptions = ImmutableSet.copyOf(requireNonNull(serdeOptions, "serdeOptions"));
+    this.casTarget = casTarget;
 
     if (schema.findValueColumn(ColumnRef.withoutSource(SchemaUtil.ROWKEY_NAME)).isPresent()
         || schema.findValueColumn(ColumnRef.withoutSource(SchemaUtil.ROWTIME_NAME)).isPresent()) {
@@ -94,6 +97,11 @@ abstract class StructuredDataSource<K> implements DataSource<K> {
   @Override
   public KsqlTopic getKsqlTopic() {
     return ksqlTopic;
+  }
+
+  @Override
+  public boolean isCasTarget() {
+    return casTarget;
   }
 
   @Override

--- a/ksql-metastore/src/test/java/io/confluent/ksql/metastore/model/MetaStoreModelTest.java
+++ b/ksql-metastore/src/test/java/io/confluent/ksql/metastore/model/MetaStoreModelTest.java
@@ -56,8 +56,7 @@ public class MetaStoreModelTest {
       .put(KsqlTopic.class, new KsqlTopic(
           "bob",
           KeyFormat.nonWindowed(FormatInfo.of(Format.KAFKA)),
-          ValueFormat.of(FormatInfo.of(Format.JSON)),
-          false
+          ValueFormat.of(FormatInfo.of(Format.JSON))
       ))
       .put(ColumnName.class, ColumnName.of("f0"))
       .put(SourceName.class, SourceName.of("f0"))

--- a/ksql-metastore/src/test/java/io/confluent/ksql/metastore/model/StructuredDataSourceTest.java
+++ b/ksql-metastore/src/test/java/io/confluent/ksql/metastore/model/StructuredDataSourceTest.java
@@ -99,6 +99,7 @@ public class StructuredDataSourceTest {
           SerdeOption.none(), keyField,
           mock(TimestampExtractionPolicy.class),
           DataSourceType.KSTREAM,
+          false,
           mock(KsqlTopic.class)
       );
     }

--- a/ksql-metastore/src/test/java/io/confluent/ksql/util/MetaStoreFixture.java
+++ b/ksql-metastore/src/test/java/io/confluent/ksql/util/MetaStoreFixture.java
@@ -68,8 +68,7 @@ public final class MetaStoreFixture {
     final KsqlTopic ksqlTopic0 = new KsqlTopic(
         "test0",
         keyFormat,
-        valueFormat,
-        false
+        valueFormat
     );
 
     final KsqlStream<?> ksqlStream0 = new KsqlStream<>(
@@ -79,6 +78,7 @@ public final class MetaStoreFixture {
         SerdeOption.none(),
         KeyField.of(ColumnRef.withoutSource(ColumnName.of("COL0"))),
         timestampExtractionPolicy,
+        false,
         ksqlTopic0
     );
 
@@ -87,8 +87,7 @@ public final class MetaStoreFixture {
     final KsqlTopic ksqlTopic1 = new KsqlTopic(
         "test1",
         keyFormat,
-        valueFormat,
-        false
+        valueFormat
     );
 
     final KsqlStream<?> ksqlStream1 = new KsqlStream<>(
@@ -99,6 +98,7 @@ public final class MetaStoreFixture {
         KeyField.of(
             ColumnRef.withoutSource(ColumnName.of("COL0"))),
         timestampExtractionPolicy,
+        false,
         ksqlTopic1
     );
 
@@ -115,8 +115,7 @@ public final class MetaStoreFixture {
     final KsqlTopic ksqlTopic2 = new KsqlTopic(
         "test2",
         keyFormat,
-        valueFormat,
-        false
+        valueFormat
     );
     final KsqlTable<String> ksqlTable = new KsqlTable<>(
         "sqlexpression",
@@ -126,6 +125,7 @@ public final class MetaStoreFixture {
         KeyField.of(
             ColumnRef.withoutSource(ColumnName.of("COL0"))),
         timestampExtractionPolicy,
+        false,
         ksqlTopic2
     );
 
@@ -164,8 +164,7 @@ public final class MetaStoreFixture {
     final KsqlTopic ksqlTopicOrders = new KsqlTopic(
         "orders_topic",
         keyFormat,
-        valueFormat,
-        false
+        valueFormat
     );
 
     final KsqlStream<?> ksqlStreamOrders = new KsqlStream<>(
@@ -175,6 +174,7 @@ public final class MetaStoreFixture {
         SerdeOption.none(),
         KeyField.of(ColumnRef.withoutSource(ColumnName.of("ORDERTIME"))),
         timestampExtractionPolicy,
+        false,
         ksqlTopicOrders
     );
 
@@ -191,8 +191,7 @@ public final class MetaStoreFixture {
     final KsqlTopic ksqlTopic3 = new KsqlTopic(
         "test3",
         keyFormat,
-        valueFormat,
-        false
+        valueFormat
     );
     final KsqlTable<String> ksqlTable3 = new KsqlTable<>(
         "sqlexpression",
@@ -202,6 +201,7 @@ public final class MetaStoreFixture {
         KeyField.of(
             ColumnRef.withoutSource(ColumnName.of("COL0"))),
         timestampExtractionPolicy,
+        false,
         ksqlTopic3
     );
 
@@ -228,8 +228,7 @@ public final class MetaStoreFixture {
     final KsqlTopic nestedArrayStructMapTopic = new KsqlTopic(
         "NestedArrayStructMap_topic",
         keyFormat,
-        valueFormat,
-        false
+        valueFormat
     );
 
     final KsqlStream<?> nestedArrayStructMapOrders = new KsqlStream<>(
@@ -239,6 +238,7 @@ public final class MetaStoreFixture {
         SerdeOption.none(),
         KeyField.none(),
         timestampExtractionPolicy,
+        false,
         nestedArrayStructMapTopic
     );
 
@@ -247,8 +247,7 @@ public final class MetaStoreFixture {
     final KsqlTopic ksqlTopic4 = new KsqlTopic(
         "test4",
         keyFormat,
-        valueFormat,
-        false
+        valueFormat
     );
 
     final KsqlStream<?> ksqlStream4 = new KsqlStream<>(
@@ -258,6 +257,7 @@ public final class MetaStoreFixture {
         SerdeOption.none(),
         KeyField.none(),
         timestampExtractionPolicy,
+        false,
         ksqlTopic4
     );
 
@@ -275,8 +275,7 @@ public final class MetaStoreFixture {
     final KsqlTopic ksqlTopicSensorReadings = new KsqlTopic(
         "sensor_readings_topic",
         keyFormat,
-        valueFormat,
-        false
+        valueFormat
     );
 
     final KsqlStream<?> ksqlStreamSensorReadings = new KsqlStream<>(
@@ -286,6 +285,7 @@ public final class MetaStoreFixture {
         SerdeOption.none(),
         KeyField.of(ColumnRef.withoutSource(ColumnName.of("ID"))),
         timestampExtractionPolicy,
+        false,
         ksqlTopicSensorReadings
     );
 

--- a/ksql-parser/src/test/java/io/confluent/ksql/parser/KsqlParserTest.java
+++ b/ksql-parser/src/test/java/io/confluent/ksql/parser/KsqlParserTest.java
@@ -158,8 +158,7 @@ public class KsqlParserTest {
     final KsqlTopic ksqlTopicOrders = new KsqlTopic(
         "orders_topic",
         KeyFormat.nonWindowed(FormatInfo.of(Format.KAFKA)),
-        ValueFormat.of(FormatInfo.of(Format.JSON)),
-        false
+        ValueFormat.of(FormatInfo.of(Format.JSON))
     );
 
     final KsqlStream ksqlStreamOrders = new KsqlStream<>(
@@ -169,6 +168,7 @@ public class KsqlParserTest {
         SerdeOption.none(),
         KeyField.of(ColumnRef.withoutSource(ColumnName.of("ORDERTIME"))),
         new MetadataTimestampExtractionPolicy(),
+        false,
         ksqlTopicOrders
     );
 
@@ -177,8 +177,7 @@ public class KsqlParserTest {
     final KsqlTopic ksqlTopicItems = new KsqlTopic(
         "item_topic",
         KeyFormat.nonWindowed(FormatInfo.of(Format.KAFKA)),
-        ValueFormat.of(FormatInfo.of(Format.JSON)),
-        false
+        ValueFormat.of(FormatInfo.of(Format.JSON))
     );
 
     final KsqlTable<String> ksqlTableOrders = new KsqlTable<>(
@@ -188,6 +187,7 @@ public class KsqlParserTest {
         SerdeOption.none(),
         KeyField.of(ColumnRef.withoutSource(ColumnName.of("ITEMID"))),
         new MetadataTimestampExtractionPolicy(),
+        false,
         ksqlTopicItems
     );
 

--- a/ksql-parser/src/test/java/io/confluent/ksql/parser/SqlFormatterTest.java
+++ b/ksql-parser/src/test/java/io/confluent/ksql/parser/SqlFormatterTest.java
@@ -163,8 +163,7 @@ public class SqlFormatterTest {
     final KsqlTopic ksqlTopicOrders = new KsqlTopic(
         "orders_topic",
         KeyFormat.nonWindowed(FormatInfo.of(Format.KAFKA)),
-        ValueFormat.of(FormatInfo.of(Format.JSON)),
-        false
+        ValueFormat.of(FormatInfo.of(Format.JSON))
     );
 
     final KsqlStream ksqlStreamOrders = new KsqlStream<>(
@@ -174,6 +173,7 @@ public class SqlFormatterTest {
         SerdeOption.none(),
         KeyField.of(ColumnRef.withoutSource(ColumnName.of("ORDERTIME"))),
         new MetadataTimestampExtractionPolicy(),
+        false,
         ksqlTopicOrders
     );
 
@@ -182,8 +182,7 @@ public class SqlFormatterTest {
     final KsqlTopic ksqlTopicItems = new KsqlTopic(
         "item_topic",
         KeyFormat.nonWindowed(FormatInfo.of(Format.KAFKA)),
-        ValueFormat.of(FormatInfo.of(Format.JSON)),
-        false
+        ValueFormat.of(FormatInfo.of(Format.JSON))
     );
     final KsqlTable<String> ksqlTableOrders = new KsqlTable<>(
         "sqlexpression",
@@ -192,6 +191,7 @@ public class SqlFormatterTest {
         SerdeOption.none(),
         KeyField.of(ColumnRef.withoutSource(ColumnName.of("ITEMID"))),
         new MetadataTimestampExtractionPolicy(),
+        false,
         ksqlTopicItems
     );
 
@@ -204,6 +204,7 @@ public class SqlFormatterTest {
         SerdeOption.none(),
         KeyField.of(ColumnRef.withoutSource(ColumnName.of("TABLE"))),
         new MetadataTimestampExtractionPolicy(),
+        false,
         ksqlTopicItems
     );
 

--- a/ksql-rest-app/src/main/java/io/confluent/ksql/rest/util/ClusterTerminator.java
+++ b/ksql-rest-app/src/main/java/io/confluent/ksql/rest/util/ClusterTerminator.java
@@ -131,7 +131,7 @@ public class ClusterTerminator {
         .anyMatch(pattern -> pattern.matcher(topicName).matches());
 
     return metaStore.getAllDataSources().values().stream()
-        .filter(s -> s.getKsqlTopic().isKsqlSink())
+        .filter(DataSource::isCasTarget)
         .filter(s -> predicate.test(s.getKsqlTopic().getKafkaTopicName()))
         .collect(Collectors.toList());
   }

--- a/ksql-rest-app/src/test/java/io/confluent/ksql/rest/entity/SourceDescriptionFactoryTest.java
+++ b/ksql-rest-app/src/test/java/io/confluent/ksql/rest/entity/SourceDescriptionFactoryTest.java
@@ -74,8 +74,7 @@ public class SourceDescriptionFactoryTest {
     final KsqlTopic topic = new KsqlTopic(
         kafkaTopicName,
         KeyFormat.nonWindowed(FormatInfo.of(Format.KAFKA)),
-        ValueFormat.of(FormatInfo.of(Format.JSON)),
-        true
+        ValueFormat.of(FormatInfo.of(Format.JSON))
     );
 
     return new KsqlStream<>(
@@ -85,6 +84,7 @@ public class SourceDescriptionFactoryTest {
         SerdeOption.none(),
         KeyField.of(schema.value().get(0).ref()),
         new MetadataTimestampExtractionPolicy(),
+        false,
         topic
     );
   }

--- a/ksql-rest-app/src/test/java/io/confluent/ksql/rest/server/TemporaryEngine.java
+++ b/ksql-rest-app/src/test/java/io/confluent/ksql/rest/server/TemporaryEngine.java
@@ -124,8 +124,7 @@ public class TemporaryEngine extends ExternalResource {
     final KsqlTopic topic = new KsqlTopic(
         name,
         KeyFormat.nonWindowed(FormatInfo.of(Format.KAFKA)),
-        ValueFormat.of(FormatInfo.of(Format.JSON)),
-        false
+        ValueFormat.of(FormatInfo.of(Format.JSON))
     );
 
     final DataSource<?> source;
@@ -139,6 +138,7 @@ public class TemporaryEngine extends ExternalResource {
                 SerdeOption.none(),
                 KeyField.of(ColumnRef.withoutSource(ColumnName.of("val"))),
                 new MetadataTimestampExtractionPolicy(),
+                false,
                 topic
             );
         break;
@@ -151,6 +151,7 @@ public class TemporaryEngine extends ExternalResource {
                 SerdeOption.none(),
                 KeyField.of(ColumnRef.withoutSource(ColumnName.of("val"))),
                 new MetadataTimestampExtractionPolicy(),
+                false,
                 topic
             );
         break;

--- a/ksql-rest-app/src/test/java/io/confluent/ksql/rest/server/execution/DescribeConnectorExecutorTest.java
+++ b/ksql-rest-app/src/test/java/io/confluent/ksql/rest/server/execution/DescribeConnectorExecutorTest.java
@@ -126,8 +126,7 @@ public class DescribeConnectorExecutorTest {
         new KsqlTopic(
             TOPIC,
             KeyFormat.nonWindowed(FormatInfo.of(Format.AVRO)),
-            ValueFormat.of(FormatInfo.of(Format.AVRO)),
-            false
+            ValueFormat.of(FormatInfo.of(Format.AVRO))
         )
     );
     when(source.getSchema()).thenReturn(

--- a/ksql-rest-app/src/test/java/io/confluent/ksql/rest/server/resources/KsqlResourceTest.java
+++ b/ksql-rest-app/src/test/java/io/confluent/ksql/rest/server/resources/KsqlResourceTest.java
@@ -2095,8 +2095,7 @@ public class KsqlResourceTest {
     final KsqlTopic ksqlTopic = new KsqlTopic(
         topicName,
         KeyFormat.nonWindowed(FormatInfo.of(Format.KAFKA)),
-        ValueFormat.of(FormatInfo.of(Format.JSON)),
-        false
+        ValueFormat.of(FormatInfo.of(Format.JSON))
     );
 
     givenKafkaTopicExists(topicName);
@@ -2109,6 +2108,7 @@ public class KsqlResourceTest {
               SerdeOption.none(),
               KeyField.of(schema.value().get(0).ref()),
               new MetadataTimestampExtractionPolicy(),
+              false,
               ksqlTopic
           ));
     }
@@ -2121,6 +2121,7 @@ public class KsqlResourceTest {
               SerdeOption.none(),
               KeyField.of(schema.value().get(0).ref()),
               new MetadataTimestampExtractionPolicy(),
+              false,
               ksqlTopic
           ));
     }

--- a/ksql-rest-app/src/test/java/io/confluent/ksql/rest/util/ClusterTerminatorTest.java
+++ b/ksql-rest-app/src/test/java/io/confluent/ksql/rest/util/ClusterTerminatorTest.java
@@ -443,11 +443,11 @@ public class ClusterTerminatorTest {
 
     final KsqlTopic topic = mock(KsqlTopic.class);
     when(topic.getKafkaTopicName()).thenReturn(kafkaTopicName);
-    when(topic.isKsqlSink()).thenReturn(sink);
     when(topic.getValueFormat()).thenReturn(ValueFormat.of(FormatInfo.of(format)));
 
     final DataSource<?> source = mock(DataSource.class);
     when(source.getKsqlTopic()).thenReturn(topic);
+    when(source.isCasTarget()).thenReturn(sink);
 
     assertThat("topic already registered", dataSources.put(SourceName.of(sourceName), source), is(nullValue()));
   }

--- a/ksql-rest-app/src/test/resources/ksql-plan-schema/schema.json
+++ b/ksql-rest-app/src/test/resources/ksql-plan-schema/schema.json
@@ -141,12 +141,9 @@
         },
         "valueFormat" : {
           "$ref" : "#/definitions/FormatInfo"
-        },
-        "ksqlSink" : {
-          "type" : "boolean"
         }
       },
-      "required" : [ "kafkaTopicName", "keyFormat", "valueFormat", "ksqlSink" ]
+      "required" : [ "kafkaTopicName", "keyFormat", "valueFormat" ]
     },
     "KeyFormat" : {
       "type" : "object",


### PR DESCRIPTION
### Description 
Cleans up the is-sink boolean from the ddl command. We can just infer this information
from the presence of a query in `KsqlPlan`. Part of a larger effort to trim down unnecessary
info in the serialized plan.

