### PR TITLE
refactor: clean up sql text from ddl commands

### DIFF
--- a/ksql-engine/src/main/java/io/confluent/ksql/ddl/commands/CommandFactories.java
+++ b/ksql-engine/src/main/java/io/confluent/ksql/ddl/commands/CommandFactories.java
@@ -111,7 +111,6 @@ public class CommandFactories implements DdlCommandFactory {
       final CreateStream statement
   ) {
     return createSourceFactory.createStreamCommand(
-        callInfo.sqlExpression,
         statement,
         callInfo.ksqlConfig
     );
@@ -122,7 +121,6 @@ public class CommandFactories implements DdlCommandFactory {
       final CreateTable statement
   ) {
     return createSourceFactory.createTableCommand(
-        callInfo.sqlExpression,
         statement,
         callInfo.ksqlConfig
     );

--- a/ksql-engine/src/main/java/io/confluent/ksql/ddl/commands/CreateSourceFactory.java
+++ b/ksql-engine/src/main/java/io/confluent/ksql/ddl/commands/CreateSourceFactory.java
@@ -72,7 +72,6 @@ public final class CreateSourceFactory {
   }
 
   public CreateStreamCommand createStreamCommand(
-      final String statementText,
       final CreateStream statement,
       final KsqlConfig ksqlConfig
   ) {
@@ -99,7 +98,6 @@ public final class CreateSourceFactory {
         topic
     );
     return new CreateStreamCommand(
-        statementText,
         sourceName,
         schema,
         keyFieldName,
@@ -110,7 +108,6 @@ public final class CreateSourceFactory {
   }
 
   public CreateTableCommand createTableCommand(
-      final String statementText,
       final CreateTable statement,
       final KsqlConfig ksqlConfig
   ) {
@@ -137,7 +134,6 @@ public final class CreateSourceFactory {
         topic
     );
     return new CreateTableCommand(
-        statementText,
         sourceName,
         schema,
         keyFieldName,

--- a/ksql-engine/src/main/java/io/confluent/ksql/ddl/commands/DdlCommandExec.java
+++ b/ksql-engine/src/main/java/io/confluent/ksql/ddl/commands/DdlCommandExec.java
@@ -31,6 +31,7 @@ import io.confluent.ksql.name.ColumnName;
 import io.confluent.ksql.name.SourceName;
 import io.confluent.ksql.schema.ksql.ColumnRef;
 import io.confluent.ksql.schema.ksql.types.SqlType;
+import java.util.Objects;
 import java.util.Optional;
 
 /**
@@ -47,16 +48,21 @@ public class DdlCommandExec {
   /**
    * execute on metaStore
    */
-  public DdlCommandResult execute(final DdlCommand ddlCommand) {
-    return new Executor().execute(ddlCommand);
+  public DdlCommandResult execute(final String sql, final DdlCommand ddlCommand) {
+    return new Executor(sql).execute(ddlCommand);
   }
 
   private final class Executor implements io.confluent.ksql.execution.ddl.commands.Executor {
+    private final String sql;
+
+    private Executor(final String sql) {
+      this.sql = Objects.requireNonNull(sql, "sql");
+    }
 
     @Override
     public DdlCommandResult executeCreateStream(final CreateStreamCommand createStream) {
       final KsqlStream<?> ksqlStream = new KsqlStream<>(
-          createStream.getSqlExpression(),
+          sql,
           createStream.getSourceName(),
           createStream.getSchema(),
           createStream.getSerdeOptions(),
@@ -71,7 +77,7 @@ public class DdlCommandExec {
     @Override
     public DdlCommandResult executeCreateTable(final CreateTableCommand createTable) {
       final KsqlTable<?> ksqlTable = new KsqlTable<>(
-          createTable.getSqlExpression(),
+          sql,
           createTable.getSourceName(),
           createTable.getSchema(),
           createTable.getSerdeOptions(),

--- a/ksql-engine/src/main/java/io/confluent/ksql/engine/EngineContext.java
+++ b/ksql-engine/src/main/java/io/confluent/ksql/engine/EngineContext.java
@@ -190,7 +190,7 @@ final class EngineContext {
       final String sqlExpression,
       final DdlCommand command
   ) {
-    final DdlCommandResult result = ddlCommandExec.execute(command);
+    final DdlCommandResult result = ddlCommandExec.execute(sqlExpression, command);
     if (!result.isSuccess()) {
       throw new KsqlStatementException(result.getMessage(), sqlExpression);
     }

--- a/ksql-engine/src/main/java/io/confluent/ksql/engine/EngineExecutor.java
+++ b/ksql-engine/src/main/java/io/confluent/ksql/engine/EngineExecutor.java
@@ -236,7 +236,6 @@ final class EngineExecutor {
     final CreateSourceCommand ddl;
     if (outputNode.getNodeOutputType() == DataSourceType.KSTREAM) {
       ddl = new CreateStreamCommand(
-          sql,
           outputNode.getIntoSourceName(),
           outputNode.getSchema(),
           keyField.ref().map(ColumnRef::name),
@@ -246,7 +245,6 @@ final class EngineExecutor {
       );
     } else {
       ddl = new CreateTableCommand(
-          sql,
           outputNode.getIntoSourceName(),
           outputNode.getSchema(),
           keyField.ref().map(ColumnRef::name),

--- a/ksql-engine/src/test/java/io/confluent/ksql/ddl/commands/CommandFactoriesTest.java
+++ b/ksql-engine/src/test/java/io/confluent/ksql/ddl/commands/CommandFactoriesTest.java
@@ -127,9 +127,9 @@ public class CommandFactoriesTest {
   public void before() {
     when(serviceContext.getTopicClient()).thenReturn(topicClient);
     when(topicClient.isTopicExists(any())).thenReturn(true);
-    when(createSourceFactory.createStreamCommand(any(), any(), any()))
+    when(createSourceFactory.createStreamCommand(any(), any()))
         .thenReturn(createStreamCommand);
-    when(createSourceFactory.createTableCommand(any(), any(), any()))
+    when(createSourceFactory.createTableCommand(any(), any()))
         .thenReturn(createTableCommand);
     when(dropSourceFactory.create(any(DropStream.class))).thenReturn(dropSourceCommand);
     when(dropSourceFactory.create(any(DropTable.class))).thenReturn(dropSourceCommand);
@@ -165,7 +165,7 @@ public class CommandFactoriesTest {
         .create(sqlExpression, statement, ksqlConfig, emptyMap());
 
     assertThat(result, is(createStreamCommand));
-    verify(createSourceFactory).createStreamCommand(sqlExpression, statement, ksqlConfig);
+    verify(createSourceFactory).createStreamCommand(statement, ksqlConfig);
   }
 
   @Test
@@ -177,7 +177,6 @@ public class CommandFactoriesTest {
     commandFactories.create(sqlExpression, statement, ksqlConfig, OVERRIDES);
 
     verify(createSourceFactory).createStreamCommand(
-        sqlExpression,
         statement,
         ksqlConfig.cloneWithPropertyOverwrite(OVERRIDES));
   }
@@ -197,7 +196,7 @@ public class CommandFactoriesTest {
 
     // Then:
     assertThat(result, is(createTableCommand));
-    verify(createSourceFactory).createTableCommand(sqlExpression, statement, ksqlConfig);
+    verify(createSourceFactory).createTableCommand(statement, ksqlConfig);
   }
 
   @Test
@@ -214,7 +213,6 @@ public class CommandFactoriesTest {
 
     // Then:
     verify(createSourceFactory).createTableCommand(
-        sqlExpression,
         statement,
         ksqlConfig.cloneWithPropertyOverwrite(OVERRIDES)
     );

--- a/ksql-engine/src/test/java/io/confluent/ksql/ddl/commands/CreateSourceFactoryTest.java
+++ b/ksql-engine/src/test/java/io/confluent/ksql/ddl/commands/CreateSourceFactoryTest.java
@@ -87,7 +87,6 @@ import org.mockito.junit.MockitoJUnitRunner;
 @RunWith(MockitoJUnitRunner.class)
 public class CreateSourceFactoryTest {
   private static final SourceName SOME_NAME = SourceName.of("bob");
-  private static final String sqlExpression = "sqlExpression";
   private static final TableElement ELEMENT1 =
       tableElement(Namespace.VALUE, "bob", new Type(SqlTypes.STRING));
   private static final TableElement ELEMENT2 =
@@ -153,7 +152,7 @@ public class CreateSourceFactoryTest {
 
     // When:
     final DdlCommand result = createSourceFactory
-        .createStreamCommand(sqlExpression, ddlStatement, ksqlConfig);
+        .createStreamCommand(ddlStatement, ksqlConfig);
 
     assertThat(result, instanceOf(CreateStreamCommand.class));
   }
@@ -169,7 +168,7 @@ public class CreateSourceFactoryTest {
 
     // When:
     final DdlCommand result = createSourceFactory
-        .createTableCommand(sqlExpression, ddlStatement, ksqlConfig);
+        .createTableCommand(ddlStatement, ksqlConfig);
 
     // Then:
     assertThat(result, instanceOf(CreateTableCommand.class));
@@ -194,7 +193,6 @@ public class CreateSourceFactoryTest {
     // When:
     final DdlCommand cmd = createSourceFactory
         .createStreamCommand(
-            sqlExpression,
             statement,
             ksqlConfig.cloneWithPropertyOverwrite(overrides)
         );
@@ -217,7 +215,7 @@ public class CreateSourceFactoryTest {
 
     // When:
     final DdlCommand cmd = createSourceFactory
-        .createStreamCommand(sqlExpression, statement, ksqlConfig);
+        .createStreamCommand(statement, ksqlConfig);
 
     // Then:
     assertThat(cmd, is(instanceOf(CreateStreamCommand.class)));
@@ -233,7 +231,7 @@ public class CreateSourceFactoryTest {
 
     // When:
     final DdlCommand cmd = createSourceFactory
-        .createStreamCommand(sqlExpression, statement, ksqlConfig);
+        .createStreamCommand(statement, ksqlConfig);
 
     // Then:
     assertThat(cmd, is(instanceOf(CreateStreamCommand.class)));
@@ -260,7 +258,6 @@ public class CreateSourceFactoryTest {
     // When:
     final DdlCommand cmd = createSourceFactory
         .createTableCommand(
-            sqlExpression,
             statement,
             ksqlConfig.cloneWithPropertyOverwrite(overrides));
 
@@ -282,7 +279,7 @@ public class CreateSourceFactoryTest {
 
     // When:
     final DdlCommand cmd = createSourceFactory
-        .createTableCommand(sqlExpression, statement, ksqlConfig);
+        .createTableCommand(statement, ksqlConfig);
 
     // Then:
     assertThat(cmd, is(instanceOf(CreateTableCommand.class)));
@@ -298,7 +295,7 @@ public class CreateSourceFactoryTest {
 
     // When:
     final DdlCommand cmd = createSourceFactory
-        .createTableCommand(sqlExpression, statement, ksqlConfig);
+        .createTableCommand(statement, ksqlConfig);
 
     // Then:
     assertThat(cmd, is(instanceOf(CreateTableCommand.class)));
@@ -318,7 +315,7 @@ public class CreateSourceFactoryTest {
         "The statement does not define any columns.");
 
     // When:
-    createSourceFactory.createStreamCommand("expression", statement, ksqlConfig);
+    createSourceFactory.createStreamCommand(statement, ksqlConfig);
   }
 
   @Test
@@ -333,7 +330,7 @@ public class CreateSourceFactoryTest {
         "The statement does not define any columns.");
 
     // When:
-    createSourceFactory.createTableCommand("expression", statement, ksqlConfig);
+    createSourceFactory.createTableCommand(statement, ksqlConfig);
   }
 
   @Test
@@ -343,7 +340,7 @@ public class CreateSourceFactoryTest {
         new CreateStream(SOME_NAME, SOME_ELEMENTS, true, withProperties);
 
     // When:
-    createSourceFactory.createStreamCommand("expression", statement, ksqlConfig);
+    createSourceFactory.createStreamCommand(statement, ksqlConfig);
 
     // Then: not exception thrown
   }
@@ -355,7 +352,7 @@ public class CreateSourceFactoryTest {
         new CreateTable(SOME_NAME, SOME_ELEMENTS, true, withProperties);
 
     // When:
-    createSourceFactory.createTableCommand("expression", statement, ksqlConfig);
+    createSourceFactory.createTableCommand(statement, ksqlConfig);
 
     // Then: not exception thrown
   }
@@ -372,7 +369,7 @@ public class CreateSourceFactoryTest {
     expectedException.expectMessage("Kafka topic does not exist: " + TOPIC_NAME);
 
     // When:
-    createSourceFactory.createStreamCommand("expression", statement, ksqlConfig);
+    createSourceFactory.createStreamCommand(statement, ksqlConfig);
   }
 
   @SuppressFBWarnings("RV_RETURN_VALUE_IGNORED_NO_SIDE_EFFECT")
@@ -383,7 +380,7 @@ public class CreateSourceFactoryTest {
         new CreateStream(SOME_NAME, SOME_ELEMENTS, true, withProperties);
 
     // When:
-    createSourceFactory.createStreamCommand("expression", statement, ksqlConfig);
+    createSourceFactory.createStreamCommand(statement, ksqlConfig);
 
     // Then:
     verify(topicClient).isTopicExists(TOPIC_NAME);
@@ -402,7 +399,7 @@ public class CreateSourceFactoryTest {
             + "'will-not-find-me'");
 
     // When:
-    createSourceFactory.createStreamCommand("expression", statement, ksqlConfig);
+    createSourceFactory.createStreamCommand(statement, ksqlConfig);
   }
 
   @Test
@@ -422,7 +419,7 @@ public class CreateSourceFactoryTest {
             + "'will-not-find-me'");
 
     // When:
-    createSourceFactory.createStreamCommand("expression", statement, ksqlConfig);
+    createSourceFactory.createStreamCommand(statement, ksqlConfig);
   }
 
   @Test
@@ -437,7 +434,6 @@ public class CreateSourceFactoryTest {
 
     // When:
     final CreateStreamCommand cmd = createSourceFactory.createStreamCommand(
-        "expression",
         statement,
         ksqlConfig
     );
@@ -459,7 +455,6 @@ public class CreateSourceFactoryTest {
 
     // When:
     final CreateStreamCommand result = createSourceFactory.createStreamCommand(
-        "expression",
         statement,
         ksqlConfig
     );
@@ -489,7 +484,6 @@ public class CreateSourceFactoryTest {
 
     // When:
     final CreateStreamCommand result = createSourceFactory.createStreamCommand(
-        "expression",
         statement,
         ksqlConfig
     );
@@ -514,7 +508,7 @@ public class CreateSourceFactoryTest {
         .build();
 
     // When:
-    createSourceFactory.createStreamCommand("expression", statement, ksqlConfig);
+    createSourceFactory.createStreamCommand(statement, ksqlConfig);
 
     // Then:
     verify(serdeFactory).create(
@@ -533,7 +527,6 @@ public class CreateSourceFactoryTest {
 
     // When:
     final CreateStreamCommand cmd = createSourceFactory.createStreamCommand(
-        "expression",
         statement,
         ksqlConfig
     );
@@ -552,7 +545,6 @@ public class CreateSourceFactoryTest {
 
     // When:
     final CreateStreamCommand cmd = createSourceFactory.createStreamCommand(
-        "expression",
         statement,
         ksqlConfig
     );
@@ -570,7 +562,6 @@ public class CreateSourceFactoryTest {
 
     // When:
     final CreateStreamCommand cmd = createSourceFactory.createStreamCommand(
-        "expression",
         statement,
         ksqlConfig
     );
@@ -593,7 +584,6 @@ public class CreateSourceFactoryTest {
 
     // When:
     final CreateStreamCommand cmd = createSourceFactory.createStreamCommand(
-        "expression",
         statement,
         ksqlConfig
     );
@@ -616,7 +606,6 @@ public class CreateSourceFactoryTest {
 
     // When:
     final CreateStreamCommand cmd = createSourceFactory.createStreamCommand(
-        "expression",
         statement,
         ksqlConfig
     );
@@ -643,7 +632,7 @@ public class CreateSourceFactoryTest {
     expectedException.expectMessage("'ROWTIME' is a reserved column name.");
 
     // When:
-    createSourceFactory.createStreamCommand("sqlExpression", statement, ksqlConfig);
+    createSourceFactory.createStreamCommand(statement, ksqlConfig);
   }
 
   @Test
@@ -661,7 +650,7 @@ public class CreateSourceFactoryTest {
     expectedException.expectMessage("'ROWTIME' is a reserved column name.");
 
     // When:
-    createSourceFactory.createStreamCommand("sqlExpression", statement, ksqlConfig);
+    createSourceFactory.createStreamCommand(statement, ksqlConfig);
   }
 
   @Test
@@ -680,7 +669,7 @@ public class CreateSourceFactoryTest {
         "'ROWKEY' is a reserved column name. It can only be used for KEY columns.");
 
     // When:
-    createSourceFactory.createStreamCommand("sqlExpression", statement, ksqlConfig);
+    createSourceFactory.createStreamCommand(statement, ksqlConfig);
   }
 
   @Test
@@ -694,7 +683,7 @@ public class CreateSourceFactoryTest {
     );
 
     // When:
-    createSourceFactory.createStreamCommand("sqlExpression", statement, ksqlConfig);
+    createSourceFactory.createStreamCommand(statement, ksqlConfig);
 
     // Then: did not throw
   }
@@ -715,7 +704,7 @@ public class CreateSourceFactoryTest {
         + "KSQL currently only supports KEY columns of type STRING.");
 
     // When:
-    createSourceFactory.createStreamCommand("sqlExpression", statement, ksqlConfig);
+    createSourceFactory.createStreamCommand(statement, ksqlConfig);
   }
 
   @Test
@@ -734,7 +723,7 @@ public class CreateSourceFactoryTest {
         + "KSQL currently only supports KEY columns named ROWKEY.");
 
     // When:
-    createSourceFactory.createStreamCommand("sqlExpression", statement, ksqlConfig);
+    createSourceFactory.createStreamCommand(statement, ksqlConfig);
   }
 
   private void givenProperty(final String name, final Literal value) {

--- a/ksql-execution/src/main/java/io/confluent/ksql/execution/ddl/commands/CreateSourceCommand.java
+++ b/ksql-execution/src/main/java/io/confluent/ksql/execution/ddl/commands/CreateSourceCommand.java
@@ -28,7 +28,6 @@ import java.util.Set;
  * Base class of create table/stream command
  */
 public abstract class CreateSourceCommand implements DdlCommand {
-  private final String sqlExpression;
   private final SourceName sourceName;
   private final LogicalSchema schema;
   private final Optional<ColumnName> keyField;
@@ -37,7 +36,6 @@ public abstract class CreateSourceCommand implements DdlCommand {
   private final KsqlTopic topic;
 
   CreateSourceCommand(
-      final String sqlExpression,
       final SourceName sourceName,
       final LogicalSchema schema,
       final Optional<ColumnName> keyField,
@@ -45,7 +43,6 @@ public abstract class CreateSourceCommand implements DdlCommand {
       final Set<SerdeOption> serdeOptions,
       final KsqlTopic ksqlTopic
   ) {
-    this.sqlExpression = Objects.requireNonNull(sqlExpression, "sqlExpression");
     this.sourceName = Objects.requireNonNull(sourceName, "sourceName");
     this.schema = Objects.requireNonNull(schema, "schema");
     this.topic = Objects.requireNonNull(ksqlTopic, "topic");
@@ -61,10 +58,6 @@ public abstract class CreateSourceCommand implements DdlCommand {
 
   public KsqlTopic getTopic() {
     return topic;
-  }
-
-  public String getSqlExpression() {
-    return sqlExpression;
   }
 
   public SourceName getSourceName() {

--- a/ksql-execution/src/main/java/io/confluent/ksql/execution/ddl/commands/CreateStreamCommand.java
+++ b/ksql-execution/src/main/java/io/confluent/ksql/execution/ddl/commands/CreateStreamCommand.java
@@ -28,7 +28,6 @@ import java.util.Set;
 @Immutable
 public class CreateStreamCommand extends CreateSourceCommand {
   public CreateStreamCommand(
-      @JsonProperty(value = "sqlExpression", required = true) String sqlExpression,
       @JsonProperty(value = "sourceName", required = true) SourceName sourceName,
       @JsonProperty(value = "schema", required = true) LogicalSchema schema,
       @JsonProperty(value = "keyField", required = true) Optional<ColumnName> keyField,
@@ -38,7 +37,6 @@ public class CreateStreamCommand extends CreateSourceCommand {
       @JsonProperty(value = "topic", required = true) KsqlTopic ksqlTopic
   ) {
     super(
-        sqlExpression,
         sourceName,
         schema,
         keyField,

--- a/ksql-execution/src/main/java/io/confluent/ksql/execution/ddl/commands/CreateTableCommand.java
+++ b/ksql-execution/src/main/java/io/confluent/ksql/execution/ddl/commands/CreateTableCommand.java
@@ -28,7 +28,6 @@ import java.util.Set;
 @Immutable
 public class CreateTableCommand extends CreateSourceCommand {
   public CreateTableCommand(
-      @JsonProperty(value = "sqlExpression", required = true) String sqlExpression,
       @JsonProperty(value = "sourceName", required = true) SourceName sourceName,
       @JsonProperty(value = "schema", required = true) LogicalSchema schema,
       @JsonProperty(value = "keyField", required = true) Optional<ColumnName> keyField,
@@ -38,7 +37,6 @@ public class CreateTableCommand extends CreateSourceCommand {
       @JsonProperty(value = "topic", required = true) KsqlTopic ksqlTopic
   ) {
     super(
-        sqlExpression,
         sourceName,
         schema,
         keyField,

--- a/ksql-rest-app/src/test/resources/ksql-plan-schema/schema.json
+++ b/ksql-rest-app/src/test/resources/ksql-plan-schema/schema.json
@@ -46,9 +46,6 @@
           "enum" : [ "createStreamV1" ],
           "default" : "createStreamV1"
         },
-        "sqlExpression" : {
-          "type" : "string"
-        },
         "sourceName" : {
           "type" : "string"
         },
@@ -79,7 +76,7 @@
         }
       },
       "title" : "createStreamV1",
-      "required" : [ "@type", "sqlExpression", "sourceName", "schema", "keyField", "timestampExtractionPolicy", "serdeOptions", "topic" ]
+      "required" : [ "@type", "sourceName", "schema", "keyField", "timestampExtractionPolicy", "serdeOptions", "topic" ]
     },
     "MetadataTimestampExtractionPolicy" : {
       "type" : "object",
@@ -204,9 +201,6 @@
           "enum" : [ "createTableV1" ],
           "default" : "createTableV1"
         },
-        "sqlExpression" : {
-          "type" : "string"
-        },
         "sourceName" : {
           "type" : "string"
         },
@@ -237,7 +231,7 @@
         }
       },
       "title" : "createTableV1",
-      "required" : [ "@type", "sqlExpression", "sourceName", "schema", "keyField", "timestampExtractionPolicy", "serdeOptions", "topic" ]
+      "required" : [ "@type", "sourceName", "schema", "keyField", "timestampExtractionPolicy", "serdeOptions", "topic" ]
     },
     "RegisterTypeCommand" : {
       "type" : "object",


### PR DESCRIPTION
### Description 
Cleans up the sql text from the ddl command in `KsqlPlan`. Part of a larger
effort to trim down KsqlPlan.