### PR TITLE
feat: Add Cube UDTF

### DIFF
--- a/ksql-engine/src/main/java/io/confluent/ksql/function/udtf/Cube.java
+++ b/ksql-engine/src/main/java/io/confluent/ksql/function/udtf/Cube.java
@@ -32,28 +32,40 @@ public class Cube {
     if (columns == null) {
       return Collections.emptyList();
     }
-
-    List<List<T>> result = new ArrayList<>();
-    createAllCombinations(columns, 0, new ArrayList<>(), result);
-
-    return result;
+    return createAllCombinations(columns);
   }
 
 
-  private <T> void createAllCombinations(List<T> columns, int pos, List<T> current,
-                                         List<List<T>> result) {
-    if (pos == columns.size()) {
-      result.add(new ArrayList<>(current));
-      return;
-    }
-    current.add(columns.get(pos));
-    createAllCombinations(columns, pos + 1, current, result);
+  private <T> List<List<T>>  createAllCombinations(List<T> columns) {
 
-    Object col = current.remove(pos);
-    if (col != null) {
-      current.add(null);
-      createAllCombinations(columns, pos + 1, current, result);
-      current.remove(pos);
+    int combinations = 1 << columns.size();
+    // skipBitmask is a binary number representing the input. A set bit means that the input is not
+    // null in that index. This bitmask is used to skip duplicates when the input already contains
+    // a null field as that field should be "flipped" and should not count towards the actual
+    // combinations.
+    int skipBitmask = 0;
+    for (int i = 0; i < columns.size(); i++) {
+      int shift = columns.size() - 1 - i;
+      skipBitmask |=  columns.get(i) == null ? 0 << shift : 1 << shift;
     }
+
+    List<List<T>> result = new ArrayList<>(combinations);
+    // bitmask is a binary number where a set bit represents that the value at that index of input
+    // should be included - start with an empty bitmask (necessary for correctness)
+    for (int bitmask = 0; bitmask <= combinations - 1; bitmask++) {
+      // if the logical end result is greater or equal than the bitmask, we can safely skip because
+      // we know we saw before a value that was smaller than the bitmask. This holds because we
+      // start from an empty bitmask hence, for every index we first encounter a zero (smaller)
+      // and then a one (greater or equal).
+      if ((bitmask & skipBitmask) < bitmask) {
+        continue;
+      }
+      List<T> row = new ArrayList<>(columns.size());
+      for (int i = 0; i < columns.size(); i++) {
+        row.add(0, (bitmask & (1 << i)) == 0 ? null : columns.get(columns.size() -1 -i));
+      }
+      result.add(row);
+    }
+    return result;
   }
 }

--- a/ksql-engine/src/main/java/io/confluent/ksql/function/udtf/Cube.java
+++ b/ksql-engine/src/main/java/io/confluent/ksql/function/udtf/Cube.java
@@ -1,0 +1,59 @@
+/*
+ * Copyright 2019 Confluent Inc.
+ *
+ * Licensed under the Confluent Community License (the "License"; you may not use
+ * this file except in compliance with the License. You may obtain a copy of the
+ * License at
+ *
+ * http://www.confluent.io/confluent-community-license
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package io.confluent.ksql.function.udtf;
+
+import io.confluent.ksql.util.KsqlConstants;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+
+@UdtfDescription(name = "cube_explode", author = KsqlConstants.CONFLUENT_AUTHOR,
+    description =
+        "Takes as argument a list of columns and outputs all possible combinations of them. "
+            + "It produces 2^d new rows where d is the number of columns given as parameter. "
+            + "Duplicate entries for columns with null value are skipped.")
+public class Cube {
+
+  @Udtf
+  public <T> List<List<T>> cube(final List<T> columns) {
+    if (columns == null) {
+      return Collections.emptyList();
+    }
+
+    List<List<T>> result = new ArrayList<>();
+    createAllCombinations(columns, 0, new ArrayList<>(), result);
+
+    return result;
+  }
+
+
+  private <T> void createAllCombinations(List<T> columns, int pos, List<T> current,
+                                         List<List<T>> result) {
+    if (pos == columns.size()) {
+      result.add(new ArrayList<>(current));
+      return;
+    }
+    current.add(columns.get(pos));
+    createAllCombinations(columns, pos + 1, current, result);
+
+    Object col = current.remove(pos);
+    if (col != null) {
+      current.add(null);
+      createAllCombinations(columns, pos + 1, current, result);
+      current.remove(pos);
+    }
+  }
+}

--- a/ksql-engine/src/test/java/io/confluent/ksql/function/udtf/CubeTest.java
+++ b/ksql-engine/src/test/java/io/confluent/ksql/function/udtf/CubeTest.java
@@ -33,10 +33,14 @@ public class CubeTest {
 
     Object[] args = {1};
     List<List<Object>> result = cubeUdtf.cube(Arrays.asList(args));
-
     assertThat(result.size(), is(2));
-    assertThat(result.get(0), is(Lists.newArrayList(1)));
-    assertThat(result.get(1), is(Collections.singletonList(null)));
+    assertThat(result.get(0), is(Collections.singletonList(null)));
+    assertThat(result.get(1), is(Lists.newArrayList(1)));
+
+    Object[] oneNull = {null};
+    result = cubeUdtf.cube(Arrays.asList(oneNull));
+    assertThat(result.size(), is(1));
+    assertThat(result.get(0), is(Arrays.asList(new String[]{null})));
   }
 
   @Test
@@ -46,10 +50,10 @@ public class CubeTest {
     List<List<Object>> result = cubeUdtf.cube(Arrays.asList(args));
 
     assertThat(result.size(), is(4));
-    assertThat(result.get(0), is(Arrays.asList(1, "foo")));
-    assertThat(result.get(1), is(Arrays.asList(1, null)));
-    assertThat(result.get(2), is(Arrays.asList(null, "foo")));
-    assertThat(result.get(3), is(Arrays.asList(null, null)));
+    assertThat(result.get(0), is(Arrays.asList(null, null)));
+    assertThat(result.get(1), is(Arrays.asList(null, "foo")));
+    assertThat(result.get(2), is(Arrays.asList(1, null)));
+    assertThat(result.get(3), is(Arrays.asList(1, "foo")));
   }
 
   @Test
@@ -57,14 +61,12 @@ public class CubeTest {
 
     Object[] oneNull = {1, null};
     List<List<Object>> result = cubeUdtf.cube(Arrays.asList(oneNull));
-
     assertThat(result.size(), is(2));
-    assertThat(result.get(0), is(Arrays.asList(1, null)));
-    assertThat(result.get(1), is(Arrays.asList(null, null)));
+    assertThat(result.get(0), is(Arrays.asList(null, null)));
+    assertThat(result.get(1), is(Arrays.asList(1, null)));
 
     Object[] allNull = {null, null};
     result = cubeUdtf.cube(Arrays.asList(allNull));
-
     assertThat(result.size(), is(1));
     assertThat(result.get(0), is(Arrays.asList(null, null)));
   }

--- a/ksql-engine/src/test/java/io/confluent/ksql/function/udtf/CubeTest.java
+++ b/ksql-engine/src/test/java/io/confluent/ksql/function/udtf/CubeTest.java
@@ -1,0 +1,71 @@
+/*
+ * Copyright 2019 Confluent Inc.
+ *
+ * Licensed under the Confluent Community License (the "License"; you may not use
+ * this file except in compliance with the License. You may obtain a copy of the
+ * License at
+ *
+ * http://www.confluent.io/confluent-community-license
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package io.confluent.ksql.function.udtf;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+
+import com.google.common.collect.Lists;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import org.junit.Test;
+
+public class CubeTest {
+
+  private Cube cubeUdtf = new Cube();
+
+  @Test
+  public void shouldCubeSingleColumn() {
+
+    Object[] args = {1};
+    List<List<Object>> result = cubeUdtf.cube(Arrays.asList(args));
+
+    assertThat(result.size(), is(2));
+    assertThat(result.get(0), is(Lists.newArrayList(1)));
+    assertThat(result.get(1), is(Collections.singletonList(null)));
+  }
+
+  @Test
+  public void shouldCubeColumnsWithDifferentTypes() {
+
+    Object[] args = {1, "foo"};
+    List<List<Object>> result = cubeUdtf.cube(Arrays.asList(args));
+
+    assertThat(result.size(), is(4));
+    assertThat(result.get(0), is(Arrays.asList(1, "foo")));
+    assertThat(result.get(1), is(Arrays.asList(1, null)));
+    assertThat(result.get(2), is(Arrays.asList(null, "foo")));
+    assertThat(result.get(3), is(Arrays.asList(null, null)));
+  }
+
+  @Test
+  public void shouldHandleNulls() {
+
+    Object[] oneNull = {1, null};
+    List<List<Object>> result = cubeUdtf.cube(Arrays.asList(oneNull));
+
+    assertThat(result.size(), is(2));
+    assertThat(result.get(0), is(Arrays.asList(1, null)));
+    assertThat(result.get(1), is(Arrays.asList(null, null)));
+
+    Object[] allNull = {null, null};
+    result = cubeUdtf.cube(Arrays.asList(allNull));
+
+    assertThat(result.size(), is(1));
+    assertThat(result.get(0), is(Arrays.asList(null, null)));
+  }
+}

--- a/ksql-engine/src/test/java/io/confluent/ksql/function/udtf/CubeTest.java
+++ b/ksql-engine/src/test/java/io/confluent/ksql/function/udtf/CubeTest.java
@@ -30,25 +30,40 @@ public class CubeTest {
 
   @Test
   public void shouldCubeSingleColumn() {
-
+    // Given:
     Object[] args = {1};
+
+    // When:
     List<List<Object>> result = cubeUdtf.cube(Arrays.asList(args));
+
+    // Then:
     assertThat(result.size(), is(2));
     assertThat(result.get(0), is(Collections.singletonList(null)));
     assertThat(result.get(1), is(Lists.newArrayList(1)));
+  }
 
+  @Test
+  public void shouldCubeSingleNullColumn() {
+    // Given:
     Object[] oneNull = {null};
-    result = cubeUdtf.cube(Arrays.asList(oneNull));
+
+    // When:
+    List<List<Object>> result = cubeUdtf.cube(Arrays.asList(oneNull));
+
+    // Then:
     assertThat(result.size(), is(1));
     assertThat(result.get(0), is(Arrays.asList(new String[]{null})));
   }
 
   @Test
   public void shouldCubeColumnsWithDifferentTypes() {
-
+    // Given:
     Object[] args = {1, "foo"};
+
+    // When:
     List<List<Object>> result = cubeUdtf.cube(Arrays.asList(args));
 
+    // Then:
     assertThat(result.size(), is(4));
     assertThat(result.get(0), is(Arrays.asList(null, null)));
     assertThat(result.get(1), is(Arrays.asList(null, "foo")));
@@ -57,17 +72,30 @@ public class CubeTest {
   }
 
   @Test
-  public void shouldHandleNulls() {
-
+  public void shouldHandleOneNull() {
+    // Given:
     Object[] oneNull = {1, null};
+
+    // When:
     List<List<Object>> result = cubeUdtf.cube(Arrays.asList(oneNull));
+
+    // Then:
     assertThat(result.size(), is(2));
     assertThat(result.get(0), is(Arrays.asList(null, null)));
     assertThat(result.get(1), is(Arrays.asList(1, null)));
+  }
 
+  @Test
+  public void shouldHandleAllNulls() {
+    // Given:
     Object[] allNull = {null, null};
-    result = cubeUdtf.cube(Arrays.asList(allNull));
+
+    // When:
+    List<List<Object>> result = cubeUdtf.cube(Arrays.asList(allNull));
+
+    // Then:
     assertThat(result.size(), is(1));
     assertThat(result.get(0), is(Arrays.asList(null, null)));
   }
+
 }

--- a/ksql-functional-tests/src/test/resources/query-validation-tests/cube.json
+++ b/ksql-functional-tests/src/test/resources/query-validation-tests/cube.json
@@ -14,12 +14,13 @@
         {"topic": "test_topic", "key": 1, "value": {"col1": 1, "col2": null}}
       ],
       "outputs": [
-        {"topic": "OUTPUT", "key": "0", "value": {"VAL": [1, 2]}},
-        {"topic": "OUTPUT", "key": "0", "value": {"VAL": [1, null]}},
-        {"topic": "OUTPUT", "key": "0", "value": {"VAL": [null, 2]}},
         {"topic": "OUTPUT", "key": "0", "value": {"VAL": [null, null]}},
-        {"topic": "OUTPUT", "key": "1", "value": {"VAL": [1, null]}},
-        {"topic": "OUTPUT", "key": "1", "value": {"VAL": [null, null]}}
+        {"topic": "OUTPUT", "key": "0", "value": {"VAL": [null, 2]}},
+        {"topic": "OUTPUT", "key": "0", "value": {"VAL": [1, null]}},
+        {"topic": "OUTPUT", "key": "0", "value": {"VAL": [1, 2]}},
+        {"topic": "OUTPUT", "key": "1", "value": {"VAL": [null, null]}},
+        {"topic": "OUTPUT", "key": "1", "value": {"VAL": [1, null]}}
+
       ]
     },
     {
@@ -32,14 +33,14 @@
         {"topic": "test_topic", "key": 0, "value": {"col1": "one", "col2": "two", "col3" : "three"}}
       ],
       "outputs": [
-        {"topic": "OUTPUT", "key": "0", "value": {"VAL": ["one", "two", "three"]}},
-        {"topic": "OUTPUT", "key": "0", "value": {"VAL": ["one", "two", null]}},
-        {"topic": "OUTPUT", "key": "0", "value": {"VAL": ["one", null, "three"]}},
-        {"topic": "OUTPUT", "key": "0", "value": {"VAL": ["one", null, null]}},
-        {"topic": "OUTPUT", "key": "0", "value": {"VAL": [null, "two", "three"]}},
-        {"topic": "OUTPUT", "key": "0", "value": {"VAL": [null, "two", null]}},
+        {"topic": "OUTPUT", "key": "0", "value": {"VAL": [null, null, null]}},
         {"topic": "OUTPUT", "key": "0", "value": {"VAL": [null, null, "three"]}},
-        {"topic": "OUTPUT", "key": "0", "value": {"VAL": [null, null, null]}}
+        {"topic": "OUTPUT", "key": "0", "value": {"VAL": [null, "two", null]}},
+        {"topic": "OUTPUT", "key": "0", "value": {"VAL": [null, "two", "three"]}},
+        {"topic": "OUTPUT", "key": "0", "value": {"VAL": ["one", null, null]}},
+        {"topic": "OUTPUT", "key": "0", "value": {"VAL": ["one", null, "three"]}},
+        {"topic": "OUTPUT", "key": "0", "value": {"VAL": ["one", "two", null]}},
+        {"topic": "OUTPUT", "key": "0", "value": {"VAL": ["one", "two", "three"]}}
       ]
     },
     {
@@ -52,10 +53,10 @@
         {"topic": "test_topic", "key": 0, "value": {"col1": "one", "col2": "two", "col3" : 3}}
       ],
       "outputs": [
-        {"topic": "OUTPUT", "key": "0", "value": {"VAL1": ["one", "two"], "VAL2": 3.0}},
-        {"topic": "OUTPUT", "key": "0", "value": {"VAL1": ["one", null], "VAL2": 3.0}},
+        {"topic": "OUTPUT", "key": "0", "value": {"VAL1": [null, null], "VAL2": 3.0}},
         {"topic": "OUTPUT", "key": "0", "value": {"VAL1": [null, "two"], "VAL2": 3.0}},
-        {"topic": "OUTPUT", "key": "0", "value": {"VAL1": [null, null], "VAL2": 3.0}}
+        {"topic": "OUTPUT", "key": "0", "value": {"VAL1": ["one", null], "VAL2": 3.0}},
+        {"topic": "OUTPUT", "key": "0", "value": {"VAL1": ["one", "two"], "VAL2": 3.0}}
       ]
     },
     {
@@ -68,10 +69,10 @@
         {"topic": "test_topic", "key": 0, "value": {"col1": "one", "col2": "two", "col3" : 3, "col4" : 4}}
       ],
       "outputs": [
-        {"topic": "OUTPUT", "key": "0", "value": {"VAL1": ["one", "two"], "VAL2": [3, 4]}},
-        {"topic": "OUTPUT", "key": "0", "value": {"VAL1": ["one", null], "VAL2": [3, null]}},
+        {"topic": "OUTPUT", "key": "0", "value": {"VAL1": [null, null], "VAL2": [null, null]}},
         {"topic": "OUTPUT", "key": "0", "value": {"VAL1": [null, "two"], "VAL2": [null, 4]}},
-        {"topic": "OUTPUT", "key": "0", "value": {"VAL1": [null, null], "VAL2": [null, null]}}
+        {"topic": "OUTPUT", "key": "0", "value": {"VAL1": ["one", null], "VAL2": [3, null]}},
+        {"topic": "OUTPUT", "key": "0", "value": {"VAL1": ["one", "two"], "VAL2": [3, 4]}}
       ]
     }
   ]

--- a/ksql-functional-tests/src/test/resources/query-validation-tests/cube.json
+++ b/ksql-functional-tests/src/test/resources/query-validation-tests/cube.json
@@ -1,0 +1,78 @@
+{
+  "comments": [
+    "Tests for the CUBE table function"
+  ],
+  "tests": [
+    {
+      "name": "cube two int columns",
+      "statements": [
+        "CREATE STREAM TEST (col1 INT, col2 INT) WITH (kafka_topic='test_topic', value_format='JSON');",
+        "CREATE STREAM OUTPUT AS SELECT cube_explode(as_array(col1, col2)) VAL FROM TEST;"
+      ],
+      "inputs": [
+        {"topic": "test_topic", "key": 0, "value": {"col1": 1, "col2": 2}},
+        {"topic": "test_topic", "key": 1, "value": {"col1": 1, "col2": null}}
+      ],
+      "outputs": [
+        {"topic": "OUTPUT", "key": "0", "value": {"VAL": [1, 2]}},
+        {"topic": "OUTPUT", "key": "0", "value": {"VAL": [1, null]}},
+        {"topic": "OUTPUT", "key": "0", "value": {"VAL": [null, 2]}},
+        {"topic": "OUTPUT", "key": "0", "value": {"VAL": [null, null]}},
+        {"topic": "OUTPUT", "key": "1", "value": {"VAL": [1, null]}},
+        {"topic": "OUTPUT", "key": "1", "value": {"VAL": [null, null]}}
+      ]
+    },
+    {
+      "name": "cube three columns",
+      "statements": [
+        "CREATE STREAM TEST (col1 VARCHAR, col2 VARCHAR, col3 VARCHAR) WITH (kafka_topic='test_topic', value_format='JSON');",
+        "CREATE STREAM OUTPUT AS SELECT cube_explode(as_array(col1, col2, col3)) VAL FROM TEST;"
+      ],
+      "inputs": [
+        {"topic": "test_topic", "key": 0, "value": {"col1": "one", "col2": "two", "col3" : "three"}}
+      ],
+      "outputs": [
+        {"topic": "OUTPUT", "key": "0", "value": {"VAL": ["one", "two", "three"]}},
+        {"topic": "OUTPUT", "key": "0", "value": {"VAL": ["one", "two", null]}},
+        {"topic": "OUTPUT", "key": "0", "value": {"VAL": ["one", null, "three"]}},
+        {"topic": "OUTPUT", "key": "0", "value": {"VAL": ["one", null, null]}},
+        {"topic": "OUTPUT", "key": "0", "value": {"VAL": [null, "two", "three"]}},
+        {"topic": "OUTPUT", "key": "0", "value": {"VAL": [null, "two", null]}},
+        {"topic": "OUTPUT", "key": "0", "value": {"VAL": [null, null, "three"]}},
+        {"topic": "OUTPUT", "key": "0", "value": {"VAL": [null, null, null]}}
+      ]
+    },
+    {
+      "name": "cube two columns with udf on third",
+      "statements": [
+        "CREATE STREAM TEST (col1 VARCHAR, col2 VARCHAR, col3 INT) WITH (kafka_topic='test_topic', value_format='JSON');",
+        "CREATE STREAM OUTPUT AS SELECT cube_explode(as_array(col1, col2)) VAL1, ABS(col3) VAL2 FROM TEST;"
+      ],
+      "inputs": [
+        {"topic": "test_topic", "key": 0, "value": {"col1": "one", "col2": "two", "col3" : 3}}
+      ],
+      "outputs": [
+        {"topic": "OUTPUT", "key": "0", "value": {"VAL1": ["one", "two"], "VAL2": 3.0}},
+        {"topic": "OUTPUT", "key": "0", "value": {"VAL1": ["one", null], "VAL2": 3.0}},
+        {"topic": "OUTPUT", "key": "0", "value": {"VAL1": [null, "two"], "VAL2": 3.0}},
+        {"topic": "OUTPUT", "key": "0", "value": {"VAL1": [null, null], "VAL2": 3.0}}
+      ]
+    },
+    {
+      "name": "cube two columns twice",
+      "statements": [
+        "CREATE STREAM TEST (col1 VARCHAR, col2 VARCHAR, col3 INT, col4 INT) WITH (kafka_topic='test_topic', value_format='JSON');",
+        "CREATE STREAM OUTPUT AS SELECT cube_explode(as_array(col1, col2)) VAL1, cube_explode(as_array(col3, col4)) VAL2 FROM TEST;"
+      ],
+      "inputs": [
+        {"topic": "test_topic", "key": 0, "value": {"col1": "one", "col2": "two", "col3" : 3, "col4" : 4}}
+      ],
+      "outputs": [
+        {"topic": "OUTPUT", "key": "0", "value": {"VAL1": ["one", "two"], "VAL2": [3, 4]}},
+        {"topic": "OUTPUT", "key": "0", "value": {"VAL1": ["one", null], "VAL2": [3, null]}},
+        {"topic": "OUTPUT", "key": "0", "value": {"VAL1": [null, "two"], "VAL2": [null, 4]}},
+        {"topic": "OUTPUT", "key": "0", "value": {"VAL1": [null, null], "VAL2": [null, null]}}
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
### Description 
The `cube` UDTF takes as argument a list of d columns and creates up tp 2^d rows (excludes duplicates created by `null` values in the input). Normally, `cube` is as an aggregate operator (extension to `Group By`) used in multi-dimensional data. It is a popular feature supported by all [RDBMSs](https://www.postgresql.org/docs/current/cube.html) and [Spark](https://jaceklaskowski.gitbooks.io/mastering-spark-sql/spark-sql-multi-dimensional-aggregation.html#cube), [Flink](https://ci.apache.org/projects/flink/flink-docs-stable/dev/table/sql.html#aggregations) As we don't have support for `Grouping Sets` yet, this UDTF enables us to achieve the same result in two steps: First, apply the `cube` UDTF to create all combinations, then apply aggregations on the result.

Example:
`SELECT cube_explode(as_array(col1, col2)) VAL FROM TEST;`

Result:

| VAL |
|------|
| [col1 , col2] |
| [col1 , null] |
| [null ,col2] |
| [null , null] |

Once we have support for variadic parameters and Object data type in UDTFs, I will change this to not take an array as parameter.

### Testing done 
Added unit test and QTT test

### Reviewer checklist
Did not update docs yet!