### PR TITLE
fix: dont create udtf sink w/ qualified rowkey

### DIFF
--- a/ksql-engine/src/main/java/io/confluent/ksql/planner/LogicalPlanner.java
+++ b/ksql-engine/src/main/java/io/confluent/ksql/planner/LogicalPlanner.java
@@ -312,11 +312,9 @@ public class LogicalPlanner {
 
     final Builder builder = LogicalSchema.builder();
 
-    final List<Column> keyColumns = sourcePlanNode.getSchema().isAliased()
-        ? sourcePlanNode.getSchema().withoutAlias().key()
-        : sourcePlanNode.getSchema().key();
-
-    builder.keyColumns(keyColumns);
+    for (final Column column : sourcePlanNode.getSchema().key()) {
+      builder.keyColumn(column.name(), column.type());
+    }
 
     for (int i = 0; i < sourcePlanNode.getSelectExpressions().size(); i++) {
       final SelectExpression select = sourcePlanNode.getSelectExpressions().get(i);

--- a/ksql-engine/src/test/java/io/confluent/ksql/planner/LogicalPlannerTest.java
+++ b/ksql-engine/src/test/java/io/confluent/ksql/planner/LogicalPlannerTest.java
@@ -33,6 +33,7 @@ import io.confluent.ksql.planner.plan.JoinNode;
 import io.confluent.ksql.planner.plan.PlanNode;
 import io.confluent.ksql.planner.plan.ProjectNode;
 import io.confluent.ksql.schema.ksql.ColumnRef;
+import io.confluent.ksql.schema.ksql.LogicalSchema;
 import io.confluent.ksql.schema.ksql.types.SqlTypes;
 import io.confluent.ksql.testutils.AnalysisTestUtil;
 import io.confluent.ksql.util.KsqlConfig;
@@ -69,6 +70,20 @@ public class LogicalPlannerTest {
             .getDataSourceType(),
         equalTo(DataSourceType.KTABLE));
     assertThat(dataSource.getName(), equalTo(SourceName.of("TEST2")));
+  }
+
+  @Test
+  public void shouldCreateCorrectOutputSchemaForExplode() {
+    // When:
+    final PlanNode planNode = buildLogicalPlan(
+        "select EXPLODE(ARR1) as foo from SENSOR_READINGS EMIT CHANGES;");
+
+    // Then:
+    final LogicalSchema schema = planNode.getSchema();
+    assertThat(
+        schema,
+        is(LogicalSchema.builder().valueColumn(ColumnName.of("FOO"), SqlTypes.BIGINT).build())
+    );
   }
 
   @Test

--- a/ksql-streams/src/main/java/io/confluent/ksql/execution/streams/Selection.java
+++ b/ksql-streams/src/main/java/io/confluent/ksql/execution/streams/Selection.java
@@ -69,10 +69,9 @@ public final class Selection<K> {
   ) {
     final LogicalSchema.Builder schemaBuilder = LogicalSchema.builder();
 
-    final List<Column> keyCols = sourceSchema.isAliased()
-        ? sourceSchema.withoutAlias().key() : sourceSchema.key();
-
-    schemaBuilder.keyColumns(keyCols);
+    for (final Column column : sourceSchema.key()) {
+      schemaBuilder.keyColumn(column.name(), column.type());
+    }
 
     for (final SelectInfo select : mapper.getSelects()) {
       schemaBuilder.valueColumn(select.getFieldName(), select.getExpressionType());

--- a/ksql-streams/src/test/java/io/confluent/ksql/execution/streams/SelectionTest.java
+++ b/ksql-streams/src/test/java/io/confluent/ksql/execution/streams/SelectionTest.java
@@ -1,6 +1,7 @@
 package io.confluent.ksql.execution.streams;
 
 import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.is;
 import static org.junit.Assert.assertThat;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.verify;
@@ -21,10 +22,12 @@ import io.confluent.ksql.name.ColumnName;
 import io.confluent.ksql.name.SourceName;
 import io.confluent.ksql.query.QueryId;
 import io.confluent.ksql.schema.Operator;
+import io.confluent.ksql.schema.ksql.Column;
 import io.confluent.ksql.schema.ksql.ColumnRef;
 import io.confluent.ksql.schema.ksql.LogicalSchema;
 import io.confluent.ksql.schema.ksql.types.SqlTypes;
 import io.confluent.ksql.util.KsqlConfig;
+import java.util.Collections;
 import java.util.List;
 import org.junit.Before;
 import org.junit.Rule;
@@ -115,6 +118,28 @@ public class SelectionTest {
         .valueColumn(ColumnName.of("BAR"), SqlTypes.BIGINT)
         .build();
     assertThat(resultSchema, equalTo(expected));
+  }
+
+  @Test
+  public void shouldBuildCorrectResultKeyWhenSchemaHasSomeAliasedColumns() {
+    // Given:
+    final LogicalSchema sourceSchema = LogicalSchema.builder()
+        .keyColumns(SCHEMA.key())
+        .valueColumns(SCHEMA.withoutAlias().value())
+        .build();
+
+    // When:
+    selection = Selection.of(
+        new QueryId("query"),
+        queryContext,
+        sourceSchema,
+        Collections.emptyList(),
+        ksqlConfig,
+        functionRegistry,
+        processingLogContext);
+
+    // Then:
+    assertThat(selection.getSchema().key(), is(SCHEMA.withoutAlias().key()));
   }
 
   @Test


### PR DESCRIPTION
Fixes an issue where the sink stream (in the meta-store) for a query
w/ a UDTF has a rowkey column qualified with the original source
stream. Data sources in the meta-store should never have column
qualifiers. They certainly shouldn't have a mix of qualified and unqualified
columns.

This happens because the result of the FlatMap logical node has a
schema with both aliased and not-aliased columns. When creating
the final key column, the logical planner would decide whether or not
to strip off the alias from the key based on isAlias, which checks just
the first column for an alias. Instead, we just always remove the alias
from the key column when creating the final project schema.