### PR TITLE
test: fix flaky test

### DIFF
--- a/ksql-cli/src/test/java/io/confluent/ksql/cli/CliTest.java
+++ b/ksql-cli/src/test/java/io/confluent/ksql/cli/CliTest.java
@@ -612,7 +612,7 @@ public class CliTest {
     };
 
     // Wait for warm store:
-    assertThatEventually(runner, containsString("ROWKEY"));
+    assertThatEventually(runner, containsString("|ITEM_1"));
     assertRunCommand(
         "SELECT * FROM X WHERE ROWKEY='ITEM_1';",
         containsRows(


### PR DESCRIPTION
### Description 

Test was failing because the pull query was return heads, but no row, but this was enough to pass the `assertThatEventually` line.  But this line should actually of been waiting of the store to return the value.

Fixes broken master build: https://jenkins.confluent.io/job/confluentinc/job/ksql/job/master/3680/

### Testing done 

test only change.

### Reviewer checklist
- [ ] Ensure docs are updated if necessary. (eg. if a user visible feature is being added or changed).
- [ ] Ensure relevant issues are linked (description should include text like "Fixes #<issue number>")

