### PR TITLE
feat: never skip command in CommandRunner thread

### DIFF
--- a/ksql-rest-app/src/main/java/io/confluent/ksql/rest/server/computation/InteractiveStatementExecutor.java
+++ b/ksql-rest-app/src/main/java/io/confluent/ksql/rest/server/computation/InteractiveStatementExecutor.java
@@ -210,6 +210,7 @@ public class InteractiveStatementExecutor implements KsqlConfigurable {
           statement, command, commandId, commandStatusFuture, mode, offset);
     } catch (final KsqlException exception) {
       log.error("Failed to handle: " + command, exception);
+      
       final CommandStatus errorStatus = new CommandStatus(
           CommandStatus.Status.ERROR,
           ExceptionUtil.stackTraceToString(exception)

--- a/ksql-rest-app/src/main/java/io/confluent/ksql/rest/server/computation/InteractiveStatementExecutor.java
+++ b/ksql-rest-app/src/main/java/io/confluent/ksql/rest/server/computation/InteractiveStatementExecutor.java
@@ -214,7 +214,8 @@ public class InteractiveStatementExecutor implements KsqlConfigurable {
           CommandStatus.Status.ERROR,
           ExceptionUtil.stackTraceToString(exception)
       );
-      putFinalStatus(commandId, commandStatusFuture, errorStatus);
+      putStatus(commandId, commandStatusFuture, errorStatus);
+      throw exception;
     }
   }
 

--- a/ksql-rest-app/src/test/java/io/confluent/ksql/rest/server/computation/CommandTest.java
+++ b/ksql-rest-app/src/test/java/io/confluent/ksql/rest/server/computation/CommandTest.java
@@ -59,24 +59,6 @@ public class CommandTest {
     assertThat(command.getOriginalProperties(), equalTo(Collections.emptyMap()));
   }
 
-  @Test
-  public void shouldDeserializeWithoutUseOffsetAsQueryIDCorrectly() throws IOException {
-    final String commandStr = "{" +
-            "\"statement\": \"test statement;\", " +
-            "\"streamsProperties\": {\"foo\": \"bar\"}, " +
-            "\"originalProperties\": {\"biz\": \"baz\"} " +
-            "}";
-    final ObjectMapper mapper = JsonMapper.INSTANCE.mapper;
-    final Command command = mapper.readValue(commandStr, Command.class);
-    assertThat(command.getStatement(), equalTo("test statement;"));
-    final Map<String, Object> expecteOverwriteProperties
-            = Collections.singletonMap("foo", "bar");
-    assertThat(command.getOverwriteProperties(), equalTo(expecteOverwriteProperties));
-    final Map<String, Object> expectedOriginalProperties
-            = Collections.singletonMap("biz", "baz");
-    assertThat(command.getOriginalProperties(), equalTo(expectedOriginalProperties));
-  }
-
   private void grep(final String string, final String regex) {
     assertThat(string.matches(regex), is(true));
   }

--- a/ksql-rest-app/src/test/java/io/confluent/ksql/rest/server/computation/RecoveryTest.java
+++ b/ksql-rest-app/src/test/java/io/confluent/ksql/rest/server/computation/RecoveryTest.java
@@ -625,50 +625,6 @@ public class RecoveryTest {
   }
 
   @Test
-  public void shouldRecoverLogWithRepeatedTerminates() {
-    server1.submitCommands(
-        "CREATE STREAM A (COLUMN STRING) WITH (KAFKA_TOPIC='A', VALUE_FORMAT='JSON');",
-        "CREATE STREAM B AS SELECT * FROM A;"
-    );
-    server2.executeCommands();
-    server1.submitCommands(
-        "TERMINATE CSAS_B_1;",
-        "INSERT INTO B SELECT * FROM A;",
-        "TERMINATE InsertQuery_3;"
-    );
-    server2.submitCommands("TERMINATE CSAS_B_1;");
-    shouldRecover(commands);
-  }
-
-  @Test
-  public void shouldRecoverLogWithDropWithRacingInsert() {
-    server1.submitCommands(
-        "CREATE STREAM A (COLUMN STRING) WITH (KAFKA_TOPIC='A', VALUE_FORMAT='JSON');",
-        "CREATE STREAM B AS SELECT * FROM A;",
-        "TERMINATE CSAS_B_1;"
-    );
-    server2.executeCommands();
-    server1.submitCommands("INSERT INTO B SELECT * FROM A;");
-    server2.submitCommands("DROP STREAM B;");
-    shouldRecover(commands);
-  }
-
-  @Test
-  public void shouldRecoverLogWithTerminateAfterDrop() {
-    topicClient.preconditionTopicExists("B");
-
-    server1.submitCommands(
-        "CREATE STREAM A (COLUMN STRING) WITH (KAFKA_TOPIC='A', VALUE_FORMAT='JSON');",
-        "CREATE STREAM B (COLUMN STRING) WITH (KAFKA_TOPIC='B', VALUE_FORMAT='JSON');"
-    );
-    server2.executeCommands();
-    server1.submitCommands("INSERT INTO B SELECT * FROM A;");
-    server2.submitCommands("DROP STREAM B;");
-    server1.submitCommands("TERMINATE InsertQuery_2;");
-    shouldRecover(commands);
-  }
-
-  @Test
   public void shouldRecoverQueryIDsByOffset() {
     commands.addAll(
         ImmutableList.of(


### PR DESCRIPTION
### Description 
BREAKING CHANGE: As a follow up to the transactional produce PR, now that every command that's enqueued has been validated against all previous commands, commands shouldn't be skipped when executing from the command topic.

Existing command topics commands may have conflicting commands in them and could cause the server to never start up, so a new flag is introduced for transactionally produced commands to indicate that only they shouldn't be skipped since they've gone through the transactional produce protocol.

A follow up PR will add a JMX metric that will indicate the health of the commandRunner. In addition, after https://github.com/confluentinc/ksql/blob/master/design-proposals/klip-6-execution-plans.md is completed, the chance of the commandRunner getting stuck should decrease.

### Testing done 
mvn clean install

Ran 
```
CREATE STREAM qwerqweq(age BIGINT) WITH (KAFKA_TOPIC='foo',  VALUE_FORMAT='DELIMITED');
```
Closed down server
Deleted topic foo
Tried to bring up server, server gets stuck retrying the command.


### Reviewer checklist
- [ ] Ensure docs are updated if necessary. (eg. if a user visible feature is being added or changed).
- [ ] Ensure relevant issues are linked (description should include text like "Fixes #<issue number>")

