### PR TITLE
docs: scrub remaining escaped quote chars in ksqlDB docs (DOCS-3001)

### DIFF
--- a/docs-md/developer-guide/create-a-table.md
+++ b/docs-md/developer-guide/create-a-table.md
@@ -30,7 +30,7 @@ by following the procedure in [Write Streaming Queries Against {{ site.aktm }} U
 
 The following example creates a table that has four columns from the
 `users` topic: `registertime`, `userid`, `gender`, and `regionid`. Also,
-the `userid` field is assigned as the table\'s KEY property.
+the `userid` field is assigned as the table's KEY property.
 
 !!! note
       The KEY field is optional. For more information, see

--- a/docs-md/developer-guide/syntax-reference.md
+++ b/docs-md/developer-guide/syntax-reference.md
@@ -281,7 +281,7 @@ example, `STRUCT<ID BIGINT, NAME STRING, AGE INT>` defines a struct with
 three fields, with the supplied name and type.
 
 Access the fields of a struct by using the `->` operator. For example,
-`SOME_STRUCT->ID` retrieves the value of the struct\'s `ID` field. For
+`SOME_STRUCT->ID` retrieves the value of the struct's `ID` field. For
 more information, see [Operators](#operators).
 
 ### Decimal

--- a/docs-md/operate-and-deploy/installation/install-ksqldb-with-docker.md
+++ b/docs-md/operate-and-deploy/installation/install-ksqldb-with-docker.md
@@ -304,7 +304,7 @@ with `-D`. For example, to set the ksqlDB service identifier in the
 -e KSQL_OPTS="-Dksql.service.id=<your-service-id>"
 ```
 
-Run a ksqlDB Server with a configuration that\'s defined by Java
+Run a ksqlDB Server with a configuration that's defined by Java
 properties:
 
 ```bash

--- a/docs-md/operate-and-deploy/installation/server-config/integrate-ksql-with-confluent-control-center.md
+++ b/docs-md/operate-and-deploy/installation/server-config/integrate-ksql-with-confluent-control-center.md
@@ -84,7 +84,7 @@ are deployed in the following situations:
 -   KSQL Server and {{ site.c3short }} run in separate containers.
 -   They run in separate virtual machines.
 -   They communicate over a virtual private network (VPN).
--   The KSQL Server host publishes a public URL that\'s different from
+-   The KSQL Server host publishes a public URL that's different from
     the private URL for KSQL Server.
 
 !!! note
@@ -169,7 +169,7 @@ Check Network Connectivity Between KSQL and Control Center
 Use a web browser to check the configuration of an advertised URL. Make
 sure that your browser can reach the `info` endpoint at
 `http://<ksql.advertised.url>/info`. If the configuration is wrong, and
-the browser can\'t resolve the URL of the KSQL Server host, you'll
+the browser can't resolve the URL of the KSQL Server host, you'll
 receive an error:
 `Websocket error when communicating with <ksql.advertised.url>`.
 

--- a/docs-md/tutorials/basics-local.md
+++ b/docs-md/tutorials/basics-local.md
@@ -108,7 +108,7 @@ KSQL enables inspecting Kafka topics and messages in real time.
 
 -   Use the SHOW TOPICS statement to list the available topics in the
     Kafka cluster.
--   Use the PRINT statement to see a topic\'s messages as they arrive.
+-   Use the PRINT statement to see a topic's messages as they arrive.
 
 In the KSQL CLI, run the following statement:
 


### PR DESCRIPTION
Scrub the last six instances of `\'` that Pandoc injected during the conversion from reStructuredText.

Also checked the escaped double-quotes, and they’re all legit (compared with the .rst source).