### PR TITLE
chore: switch `TERMINATE ALL` to distribute N `TERMINATE queryId` stmts

### DIFF
--- a/ksql-parser/src/main/java/io/confluent/ksql/parser/AstBuilder.java
+++ b/ksql-parser/src/main/java/io/confluent/ksql/parser/AstBuilder.java
@@ -122,6 +122,7 @@ import io.confluent.ksql.parser.tree.Table;
 import io.confluent.ksql.parser.tree.TableElement;
 import io.confluent.ksql.parser.tree.TableElement.Namespace;
 import io.confluent.ksql.parser.tree.TableElements;
+import io.confluent.ksql.parser.tree.TerminateAllQueries;
 import io.confluent.ksql.parser.tree.TerminateQuery;
 import io.confluent.ksql.parser.tree.UnsetProperty;
 import io.confluent.ksql.parser.tree.WindowExpression;
@@ -634,10 +635,9 @@ public class AstBuilder {
       final Optional<NodeLocation> location = getLocation(context);
 
       return context.ALL() != null
-          ? TerminateQuery.all(location)
-          : TerminateQuery.query(
+          ? new TerminateAllQueries(location)
+          : new TerminateQuery(
               location,
-              // use case sensitive parsing here to maintain backwards compatibility
               new QueryId(ParserUtil.getIdentifierText(true, context.identifier()))
           );
     }

--- a/ksql-parser/src/main/java/io/confluent/ksql/parser/SqlFormatter.java
+++ b/ksql-parser/src/main/java/io/confluent/ksql/parser/SqlFormatter.java
@@ -54,9 +54,9 @@ import io.confluent.ksql.parser.tree.SingleColumn;
 import io.confluent.ksql.parser.tree.Table;
 import io.confluent.ksql.parser.tree.TableElement;
 import io.confluent.ksql.parser.tree.TableElement.Namespace;
+import io.confluent.ksql.parser.tree.TerminateAllQueries;
 import io.confluent.ksql.parser.tree.TerminateQuery;
 import io.confluent.ksql.parser.tree.UnsetProperty;
-import io.confluent.ksql.query.QueryId;
 import io.confluent.ksql.schema.ksql.FormatOptions;
 import io.confluent.ksql.util.IdentifierUtil;
 import java.util.List;
@@ -337,7 +337,13 @@ public final class SqlFormatter {
     @Override
     protected Void visitTerminateQuery(final TerminateQuery node, final Integer context) {
       builder.append("TERMINATE ");
-      builder.append(node.getQueryId().map(QueryId::toString).orElse("ALL"));
+      builder.append(node.getQueryId());
+      return null;
+    }
+
+    @Override
+    protected Void visitTerminateAllQueries(final TerminateAllQueries node, final Integer context) {
+      builder.append("TERMINATE ALL");
       return null;
     }
 

--- a/ksql-parser/src/main/java/io/confluent/ksql/parser/tree/AstVisitor.java
+++ b/ksql-parser/src/main/java/io/confluent/ksql/parser/tree/AstVisitor.java
@@ -153,6 +153,10 @@ public abstract class AstVisitor<R, C> {
     return visitStatement(node, context);
   }
 
+  protected R visitTerminateAllQueries(final TerminateAllQueries node, final C context) {
+    return visitStatement(node, context);
+  }
+
   protected R visitListStreams(final ListStreams node, final C context) {
     return visitStatement(node, context);
   }

--- a/ksql-parser/src/main/java/io/confluent/ksql/parser/tree/TerminateAllQueries.java
+++ b/ksql-parser/src/main/java/io/confluent/ksql/parser/tree/TerminateAllQueries.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018 Confluent Inc.
+ * Copyright 2019 Confluent Inc.
  *
  * Licensed under the Confluent Community License (the "License"); you may not use
  * this file except in compliance with the License.  You may obtain a copy of the
@@ -17,27 +17,19 @@ package io.confluent.ksql.parser.tree;
 
 import com.google.errorprone.annotations.Immutable;
 import io.confluent.ksql.parser.NodeLocation;
-import io.confluent.ksql.query.QueryId;
 import java.util.Objects;
 import java.util.Optional;
 
 @Immutable
-public final class TerminateQuery extends Statement {
+public final class TerminateAllQueries extends Statement {
 
-  private final QueryId queryId;
-
-  public TerminateQuery(final Optional<NodeLocation> location, QueryId queryId) {
+  public TerminateAllQueries(final Optional<NodeLocation> location) {
     super(location);
-    this.queryId = Objects.requireNonNull(queryId, "queryId");
-  }
-
-  public QueryId getQueryId() {
-    return queryId;
   }
 
   @Override
   public <R, C> R accept(final AstVisitor<R, C> visitor, final C context) {
-    return visitor.visitTerminateQuery(this, context);
+    return visitor.visitTerminateAllQueries(this, context);
   }
 
   @Override
@@ -45,23 +37,17 @@ public final class TerminateQuery extends Statement {
     if (this == o) {
       return true;
     }
-    if (o == null || getClass() != o.getClass()) {
-      return false;
-    }
-    final TerminateQuery that = (TerminateQuery) o;
-    return Objects.equals(queryId, that.queryId);
+
+    return o != null && getClass() == o.getClass();
   }
 
   @Override
   public int hashCode() {
-
-    return Objects.hash(queryId);
+    return Objects.hash(getClass());
   }
 
   @Override
   public String toString() {
-    return "TerminateQuery{"
-        + "queryId=" + queryId
-        + '}';
+    return "TerminateAllQueries{}";
   }
 }

--- a/ksql-parser/src/test/java/io/confluent/ksql/parser/KsqlParserTest.java
+++ b/ksql-parser/src/test/java/io/confluent/ksql/parser/KsqlParserTest.java
@@ -78,7 +78,6 @@ import io.confluent.ksql.parser.tree.TableElement;
 import io.confluent.ksql.parser.tree.TableElements;
 import io.confluent.ksql.parser.tree.TerminateQuery;
 import io.confluent.ksql.parser.tree.WithinExpression;
-import io.confluent.ksql.query.QueryId;
 import io.confluent.ksql.schema.ksql.ColumnRef;
 import io.confluent.ksql.schema.ksql.LogicalSchema;
 import io.confluent.ksql.schema.ksql.SqlBaseType;
@@ -475,9 +474,8 @@ public class KsqlParserTest {
         .buildSingleAst("TERMINATE `CSAS-foo_2`;", metaStore);
 
     // Then:
-    assertThat(statement.getStatement().getQueryId().map(QueryId::toString), is(Optional.of("CSAS-foo_2")));
+    assertThat(statement.getStatement().getQueryId().getId(), is("CSAS-foo_2"));
   }
-
 
   @Test
   public void testSelectAllJoin() {

--- a/ksql-parser/src/test/java/io/confluent/ksql/parser/SqlFormatterTest.java
+++ b/ksql-parser/src/test/java/io/confluent/ksql/parser/SqlFormatterTest.java
@@ -51,6 +51,7 @@ import io.confluent.ksql.parser.tree.Table;
 import io.confluent.ksql.parser.tree.TableElement;
 import io.confluent.ksql.parser.tree.TableElement.Namespace;
 import io.confluent.ksql.parser.tree.TableElements;
+import io.confluent.ksql.parser.tree.TerminateAllQueries;
 import io.confluent.ksql.parser.tree.TerminateQuery;
 import io.confluent.ksql.parser.tree.WithinExpression;
 import io.confluent.ksql.properties.with.CommonCreateConfigs;
@@ -585,7 +586,7 @@ public class SqlFormatterTest {
   @Test
   public void shouldFormatTerminateQuery() {
     // Given:
-    final TerminateQuery terminateQuery = TerminateQuery.query(Optional.empty(), new QueryId("FOO"));
+    final TerminateQuery terminateQuery = new TerminateQuery(Optional.empty(), new QueryId("FOO"));
 
     // When:
     final String formatted = SqlFormatter.formatSql(terminateQuery);
@@ -597,10 +598,10 @@ public class SqlFormatterTest {
   @Test
   public void shouldFormatTerminateAllQueries() {
     // Given:
-    final TerminateQuery terminateQuery = TerminateQuery.all(Optional.empty());
+    final TerminateAllQueries terminateAll = new TerminateAllQueries(Optional.empty());
 
     // When:
-    final String formatted = SqlFormatter.formatSql(terminateQuery);
+    final String formatted = SqlFormatter.formatSql(terminateAll);
 
     // Then:
     assertThat(formatted, is("TERMINATE ALL"));

--- a/ksql-parser/src/test/java/io/confluent/ksql/parser/tree/TerminateQueryTest.java
+++ b/ksql-parser/src/test/java/io/confluent/ksql/parser/tree/TerminateQueryTest.java
@@ -33,11 +33,11 @@ public class TerminateQueryTest {
     new EqualsTester()
         .addEqualityGroup(
             // Note: At the moment location does not take part in equality testing
-            TerminateQuery.query(Optional.of(SOME_LOCATION), SOME_QUERY_ID),
-            TerminateQuery.query(Optional.of(OTHER_LOCATION), SOME_QUERY_ID)
+            new TerminateQuery(Optional.of(SOME_LOCATION), SOME_QUERY_ID),
+            new TerminateQuery(Optional.of(OTHER_LOCATION), SOME_QUERY_ID)
         )
         .addEqualityGroup(
-            TerminateQuery.query(Optional.empty(), new QueryId("diff"))
+            new TerminateQuery(Optional.empty(), new QueryId("diff"))
         )
         .testEquals();
   }

--- a/ksql-rest-app/src/main/java/io/confluent/ksql/rest/server/computation/CommandIdAssigner.java
+++ b/ksql-rest-app/src/main/java/io/confluent/ksql/rest/server/computation/CommandIdAssigner.java
@@ -27,7 +27,6 @@ import io.confluent.ksql.parser.tree.InsertInto;
 import io.confluent.ksql.parser.tree.RegisterType;
 import io.confluent.ksql.parser.tree.Statement;
 import io.confluent.ksql.parser.tree.TerminateQuery;
-import io.confluent.ksql.query.QueryId;
 import io.confluent.ksql.rest.entity.CommandId;
 import io.confluent.ksql.rest.entity.CommandId.Action;
 import io.confluent.ksql.rest.entity.CommandId.Type;
@@ -110,7 +109,7 @@ public class CommandIdAssigner {
   private static CommandId getTerminateCommandId(final TerminateQuery terminateQuery) {
     return new CommandId(
         CommandId.Type.TERMINATE,
-        terminateQuery.getQueryId().map(QueryId::toString).orElse("ALL"),
+        terminateQuery.getQueryId().getId(),
         CommandId.Action.EXECUTE
     );
   }

--- a/ksql-rest-app/src/main/java/io/confluent/ksql/rest/server/computation/InteractiveStatementExecutor.java
+++ b/ksql-rest-app/src/main/java/io/confluent/ksql/rest/server/computation/InteractiveStatementExecutor.java
@@ -369,14 +369,9 @@ public class InteractiveStatementExecutor implements KsqlConfigurable {
   }
 
   private void terminateQuery(final PreparedStatement<TerminateQuery> terminateQuery) {
-    final Optional<QueryId> queryId = terminateQuery.getStatement().getQueryId();
+    final QueryId queryId = terminateQuery.getStatement().getQueryId();
 
-    if (!queryId.isPresent()) {
-      ksqlEngine.getPersistentQueries().forEach(PersistentQueryMetadata::close);
-      return;
-    }
-
-    ksqlEngine.getPersistentQuery(queryId.get())
+    ksqlEngine.getPersistentQuery(queryId)
         .orElseThrow(() ->
             new KsqlException(String.format("No running query with id %s was found", queryId)))
         .close();

--- a/ksql-rest-app/src/main/java/io/confluent/ksql/rest/server/execution/ConnectExecutor.java
+++ b/ksql-rest-app/src/main/java/io/confluent/ksql/rest/server/execution/ConnectExecutor.java
@@ -15,6 +15,7 @@
 
 package io.confluent.ksql.rest.server.execution;
 
+import com.google.common.collect.ImmutableList;
 import com.google.common.collect.Maps;
 import io.confluent.ksql.KsqlExecutionContext;
 import io.confluent.ksql.connect.supported.Connectors;
@@ -26,15 +27,15 @@ import io.confluent.ksql.services.ConnectClient;
 import io.confluent.ksql.services.ConnectClient.ConnectResponse;
 import io.confluent.ksql.services.ServiceContext;
 import io.confluent.ksql.statement.ConfiguredStatement;
+import java.util.List;
 import java.util.Map;
-import java.util.Optional;
 import org.apache.kafka.connect.runtime.rest.entities.ConnectorInfo;
 
 public final class ConnectExecutor {
 
   private ConnectExecutor() { }
 
-  public static Optional<KsqlEntity> execute(
+  public static List<? extends KsqlEntity> execute(
       final ConfiguredStatement<CreateConnector> statement,
       final Map<String, ?> sessionProperties,
       final KsqlExecutionContext executionContext,
@@ -51,7 +52,7 @@ public final class ConnectExecutor {
                 l -> l != null ? l.getValue().toString() : null)));
 
     if (response.datum().isPresent()) {
-      return Optional.of(
+      return ImmutableList.of(
           new CreateConnectorEntity(
               statement.getStatementText(),
               response.datum().get()
@@ -60,6 +61,7 @@ public final class ConnectExecutor {
     }
 
     return response.error()
-        .map(err -> new ErrorEntity(statement.getStatementText(), err));
+        .map(err -> ImmutableList.of(new ErrorEntity(statement.getStatementText(), err)))
+        .orElse(ImmutableList.of());
   }
 }

--- a/ksql-rest-app/src/main/java/io/confluent/ksql/rest/server/execution/DefaultCommandQueueSync.java
+++ b/ksql-rest-app/src/main/java/io/confluent/ksql/rest/server/execution/DefaultCommandQueueSync.java
@@ -25,6 +25,7 @@ import io.confluent.ksql.rest.server.resources.KsqlRestException;
 import java.time.Duration;
 import java.util.ArrayList;
 import java.util.Collections;
+import java.util.List;
 import java.util.Objects;
 import java.util.concurrent.TimeoutException;
 import java.util.function.Predicate;
@@ -57,7 +58,7 @@ public class DefaultCommandQueueSync implements CommandQueueSync {
       final KsqlEntityList previousCommands,
       final Class<? extends Statement> statementClass) {
     if (mustSync.test(statementClass)) {
-      final ArrayList<KsqlEntity> reversed = new ArrayList<>(previousCommands);
+      final List<KsqlEntity> reversed = new ArrayList<>(previousCommands);
       Collections.reverse(reversed);
 
       reversed.stream()

--- a/ksql-rest-app/src/main/java/io/confluent/ksql/rest/server/execution/DescribeConnectorExecutor.java
+++ b/ksql-rest-app/src/main/java/io/confluent/ksql/rest/server/execution/DescribeConnectorExecutor.java
@@ -59,7 +59,7 @@ public final class DescribeConnectorExecutor {
   }
 
   @SuppressWarnings("OptionalGetWithoutIsPresent")
-  public Optional<KsqlEntity> execute(
+  public List<? extends KsqlEntity> execute(
       final ConfiguredStatement<DescribeConnector> configuredStatement,
       final Map<String, ?> sessionProperties,
       final KsqlExecutionContext ksqlExecutionContext,
@@ -73,7 +73,7 @@ public final class DescribeConnectorExecutor {
         .getConnectClient()
         .status(connectorName);
     if (statusResponse.error().isPresent()) {
-      return Optional.of(
+      return ImmutableList.of(
           new ErrorEntity(
               configuredStatement.getStatementText(),
               statusResponse.error().get())
@@ -84,7 +84,7 @@ public final class DescribeConnectorExecutor {
         .getConnectClient()
         .describe(connectorName);
     if (infoResponse.error().isPresent()) {
-      return Optional.of(
+      return ImmutableList.of(
           new ErrorEntity(
               configuredStatement.getStatementText(),
               infoResponse.error().get())
@@ -136,10 +136,10 @@ public final class DescribeConnectorExecutor {
         warnings
     );
 
-    return Optional.of(description);
+    return ImmutableList.of(description);
   }
 
-  private List<String> getTopics(final Admin admin, final Optional<Connector> connector)
+  private static List<String> getTopics(final Admin admin, final Optional<Connector> connector)
       throws Exception {
     if (!connector.isPresent()) {
       return ImmutableList.of();

--- a/ksql-rest-app/src/main/java/io/confluent/ksql/rest/server/execution/DescribeFunctionExecutor.java
+++ b/ksql-rest-app/src/main/java/io/confluent/ksql/rest/server/execution/DescribeFunctionExecutor.java
@@ -30,23 +30,17 @@ import io.confluent.ksql.rest.entity.FunctionDescriptionList;
 import io.confluent.ksql.rest.entity.FunctionInfo;
 import io.confluent.ksql.rest.entity.FunctionType;
 import io.confluent.ksql.rest.entity.KsqlEntity;
-import io.confluent.ksql.schema.connect.SqlSchemaFormatter;
 import io.confluent.ksql.services.ServiceContext;
 import io.confluent.ksql.statement.ConfiguredStatement;
-import io.confluent.ksql.util.IdentifierUtil;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
-import java.util.Optional;
 
 public final class DescribeFunctionExecutor {
 
-  private static final SqlSchemaFormatter FORMATTER =
-      new SqlSchemaFormatter(IdentifierUtil::needsQuotes);
-
   private DescribeFunctionExecutor() { }
 
-  public static Optional<KsqlEntity> execute(
+  public static List<? extends KsqlEntity> execute(
       final ConfiguredStatement<DescribeFunction> statement,
       final Map<String, ?> sessionProperties,
       final KsqlExecutionContext executionContext,
@@ -56,16 +50,16 @@ public final class DescribeFunctionExecutor {
     final String functionName = describeFunction.getFunctionName();
 
     if (executionContext.getMetaStore().isAggregate(functionName)) {
-      return Optional.of(
+      return ImmutableList.of(
           describeAggregateFunction(executionContext, functionName, statement.getStatementText()));
     }
 
     if (executionContext.getMetaStore().isTableFunction(functionName)) {
-      return Optional.of(
+      return ImmutableList.of(
           describeTableFunction(executionContext, functionName, statement.getStatementText()));
     }
 
-    return Optional.of(
+    return ImmutableList.of(
         describeNonAggregateFunction(executionContext, functionName, statement.getStatementText()));
   }
 
@@ -173,5 +167,4 @@ public final class DescribeFunctionExecutor {
         functionType
     );
   }
-
 }

--- a/ksql-rest-app/src/main/java/io/confluent/ksql/rest/server/execution/DropConnectorExecutor.java
+++ b/ksql-rest-app/src/main/java/io/confluent/ksql/rest/server/execution/DropConnectorExecutor.java
@@ -15,6 +15,7 @@
 
 package io.confluent.ksql.rest.server.execution;
 
+import com.google.common.collect.ImmutableList;
 import io.confluent.ksql.KsqlExecutionContext;
 import io.confluent.ksql.parser.tree.DropConnector;
 import io.confluent.ksql.rest.entity.DropConnectorEntity;
@@ -23,14 +24,14 @@ import io.confluent.ksql.rest.entity.KsqlEntity;
 import io.confluent.ksql.services.ConnectClient.ConnectResponse;
 import io.confluent.ksql.services.ServiceContext;
 import io.confluent.ksql.statement.ConfiguredStatement;
+import java.util.List;
 import java.util.Map;
-import java.util.Optional;
 
 public final class DropConnectorExecutor {
 
   private DropConnectorExecutor() { }
 
-  public static Optional<KsqlEntity> execute(
+  public static List<? extends KsqlEntity> execute(
       final ConfiguredStatement<DropConnector> statement,
       final Map<String, ?> sessionProperties,
       final KsqlExecutionContext executionContext,
@@ -41,9 +42,10 @@ public final class DropConnectorExecutor {
         serviceContext.getConnectClient().delete(connectorName);
 
     if (response.error().isPresent()) {
-      return Optional.of(new ErrorEntity(statement.getStatementText(), response.error().get()));
+      return ImmutableList
+          .of(new ErrorEntity(statement.getStatementText(), response.error().get()));
     }
 
-    return Optional.of(new DropConnectorEntity(statement.getStatementText(), connectorName));
+    return ImmutableList.of(new DropConnectorEntity(statement.getStatementText(), connectorName));
   }
 }

--- a/ksql-rest-app/src/main/java/io/confluent/ksql/rest/server/execution/ExplainExecutor.java
+++ b/ksql-rest-app/src/main/java/io/confluent/ksql/rest/server/execution/ExplainExecutor.java
@@ -15,6 +15,7 @@
 
 package io.confluent.ksql.rest.server.execution;
 
+import com.google.common.collect.ImmutableList;
 import io.confluent.ksql.KsqlExecutionContext;
 import io.confluent.ksql.parser.KsqlParser.PreparedStatement;
 import io.confluent.ksql.parser.tree.Explain;
@@ -32,6 +33,7 @@ import io.confluent.ksql.util.KsqlException;
 import io.confluent.ksql.util.KsqlStatementException;
 import io.confluent.ksql.util.PersistentQueryMetadata;
 import io.confluent.ksql.util.QueryMetadata;
+import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 
@@ -43,13 +45,13 @@ public final class ExplainExecutor {
 
   private ExplainExecutor() { }
 
-  public static Optional<KsqlEntity> execute(
+  public static List<? extends KsqlEntity> execute(
       final ConfiguredStatement<Explain> statement,
       final Map<String, ?> sessionProperties,
       final KsqlExecutionContext executionContext,
       final ServiceContext serviceContext
   ) {
-    return Optional
+    return ImmutableList
         .of(ExplainExecutor.explain(
             serviceContext,
             statement,

--- a/ksql-rest-app/src/main/java/io/confluent/ksql/rest/server/execution/ListConnectorsExecutor.java
+++ b/ksql-rest-app/src/main/java/io/confluent/ksql/rest/server/execution/ListConnectorsExecutor.java
@@ -15,6 +15,7 @@
 
 package io.confluent.ksql.rest.server.execution;
 
+import com.google.common.collect.ImmutableList;
 import io.confluent.ksql.KsqlExecutionContext;
 import io.confluent.ksql.parser.tree.ListConnectors;
 import io.confluent.ksql.parser.tree.ListConnectors.Scope;
@@ -30,7 +31,6 @@ import io.confluent.ksql.statement.ConfiguredStatement;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
-import java.util.Optional;
 import org.apache.kafka.connect.runtime.ConnectorConfig;
 import org.apache.kafka.connect.runtime.rest.entities.ConnectorInfo;
 import org.apache.kafka.connect.runtime.rest.entities.ConnectorType;
@@ -40,7 +40,7 @@ public final class ListConnectorsExecutor {
   private ListConnectorsExecutor() { }
 
   @SuppressWarnings("OptionalGetWithoutIsPresent")
-  public static Optional<KsqlEntity> execute(
+  public static List<? extends KsqlEntity> execute(
       final ConfiguredStatement<ListConnectors> configuredStatement,
       final Map<String, ?> sessionProperties,
       final KsqlExecutionContext ksqlExecutionContext,
@@ -49,7 +49,7 @@ public final class ListConnectorsExecutor {
     final ConnectClient connectClient = serviceContext.getConnectClient();
     final ConnectResponse<List<String>> connectors = serviceContext.getConnectClient().connectors();
     if (connectors.error().isPresent()) {
-      return Optional.of(new ErrorEntity(
+      return ImmutableList.of(new ErrorEntity(
           configuredStatement.getStatementText(),
           connectors.error().get()
       ));
@@ -76,7 +76,7 @@ public final class ListConnectorsExecutor {
       }
     }
 
-    return Optional.of(
+    return ImmutableList.of(
         new ConnectorList(
             configuredStatement.getStatementText(),
             warnings,

--- a/ksql-rest-app/src/main/java/io/confluent/ksql/rest/server/execution/ListFunctionsExecutor.java
+++ b/ksql-rest-app/src/main/java/io/confluent/ksql/rest/server/execution/ListFunctionsExecutor.java
@@ -15,6 +15,7 @@
 
 package io.confluent.ksql.rest.server.execution;
 
+import com.google.common.collect.ImmutableList;
 import io.confluent.ksql.KsqlExecutionContext;
 import io.confluent.ksql.function.FunctionRegistry;
 import io.confluent.ksql.parser.tree.ListFunctions;
@@ -26,14 +27,13 @@ import io.confluent.ksql.services.ServiceContext;
 import io.confluent.ksql.statement.ConfiguredStatement;
 import java.util.List;
 import java.util.Map;
-import java.util.Optional;
 import java.util.stream.Collectors;
 
 public final class ListFunctionsExecutor {
 
   private ListFunctionsExecutor() { }
 
-  public static Optional<KsqlEntity> execute(
+  public static List<? extends KsqlEntity> execute(
       final ConfiguredStatement<ListFunctions> statement,
       final Map<String, ?> sessionProperties,
       final KsqlExecutionContext executionContext,
@@ -65,7 +65,6 @@ public final class ListFunctionsExecutor {
         ))
         .forEach(all::add);
 
-    return Optional.of(new FunctionNameList(statement.getStatementText(), all));
+    return ImmutableList.of(new FunctionNameList(statement.getStatementText(), all));
   }
-
 }

--- a/ksql-rest-app/src/main/java/io/confluent/ksql/rest/server/execution/ListPropertiesExecutor.java
+++ b/ksql-rest-app/src/main/java/io/confluent/ksql/rest/server/execution/ListPropertiesExecutor.java
@@ -15,6 +15,7 @@
 
 package io.confluent.ksql.rest.server.execution;
 
+import com.google.common.collect.ImmutableList;
 import io.confluent.ksql.KsqlExecutionContext;
 import io.confluent.ksql.config.KsqlConfigResolver;
 import io.confluent.ksql.parser.tree.ListProperties;
@@ -26,14 +27,13 @@ import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
 import java.util.Objects;
-import java.util.Optional;
 import java.util.stream.Collectors;
 
 public final class ListPropertiesExecutor {
 
   private ListPropertiesExecutor() { }
 
-  public static Optional<KsqlEntity> execute(
+  public static List<? extends KsqlEntity> execute(
       final ConfiguredStatement<ListProperties> statement,
       final Map<String, ?> sessionProperties,
       final KsqlExecutionContext executionContext,
@@ -61,8 +61,7 @@ public final class ListPropertiesExecutor {
         .map(Entry::getKey)
         .collect(Collectors.toList());
 
-    return Optional.of(new PropertiesList(
+    return ImmutableList.of(new PropertiesList(
         statement.getStatementText(), mergedProperties, overwritten, defaultProps));
   }
-
 }

--- a/ksql-rest-app/src/main/java/io/confluent/ksql/rest/server/execution/ListQueriesExecutor.java
+++ b/ksql-rest-app/src/main/java/io/confluent/ksql/rest/server/execution/ListQueriesExecutor.java
@@ -15,6 +15,7 @@
 
 package io.confluent.ksql.rest.server.execution;
 
+import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSet;
 import io.confluent.ksql.KsqlExecutionContext;
 import io.confluent.ksql.parser.tree.ListQueries;
@@ -24,15 +25,15 @@ import io.confluent.ksql.rest.entity.QueryDescriptionList;
 import io.confluent.ksql.rest.entity.RunningQuery;
 import io.confluent.ksql.services.ServiceContext;
 import io.confluent.ksql.statement.ConfiguredStatement;
+import java.util.List;
 import java.util.Map;
-import java.util.Optional;
 import java.util.stream.Collectors;
 
 public final class ListQueriesExecutor {
 
   private ListQueriesExecutor() { }
 
-  public static Optional<KsqlEntity> execute(
+  public static List<? extends KsqlEntity> execute(
       final ConfiguredStatement<ListQueries> statement,
       final Map<String, ?> sessionProperties,
       final KsqlExecutionContext executionContext,
@@ -40,14 +41,14 @@ public final class ListQueriesExecutor {
   ) {
     final ListQueries listQueries = statement.getStatement();
     if (listQueries.getShowExtended()) {
-      return Optional.of(new QueryDescriptionList(
+      return ImmutableList.of(new QueryDescriptionList(
           statement.getStatementText(),
           executionContext.getPersistentQueries().stream()
               .map(QueryDescriptionFactory::forQueryMetadata)
               .collect(Collectors.toList())));
     }
 
-    return Optional.of(new io.confluent.ksql.rest.entity.Queries(
+    return ImmutableList.of(new io.confluent.ksql.rest.entity.Queries(
         statement.getStatementText(),
         executionContext.getPersistentQueries()
             .stream()
@@ -58,5 +59,4 @@ public final class ListQueriesExecutor {
                     q.getQueryId()))
             .collect(Collectors.toList())));
   }
-
 }

--- a/ksql-rest-app/src/main/java/io/confluent/ksql/rest/server/execution/ListSourceExecutor.java
+++ b/ksql-rest-app/src/main/java/io/confluent/ksql/rest/server/execution/ListSourceExecutor.java
@@ -15,6 +15,7 @@
 
 package io.confluent.ksql.rest.server.execution;
 
+import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSet;
 import io.confluent.ksql.KsqlExecutionContext;
 import io.confluent.ksql.exception.KafkaResponseGetFailedException;
@@ -55,7 +56,7 @@ public final class ListSourceExecutor {
 
   private ListSourceExecutor() { }
 
-  private static Optional<KsqlEntity> sourceDescriptionList(
+  private static List<? extends KsqlEntity> sourceDescriptionList(
       final ConfiguredStatement<?> statement,
       final KsqlExecutionContext executionContext,
       final ServiceContext serviceContext,
@@ -71,7 +72,7 @@ public final class ListSourceExecutor {
                 statement.getStatementText())
         )
         .collect(Collectors.toList());
-    return Optional.of(
+    return ImmutableList.of(
         new SourceDescriptionList(
             statement.getStatementText(),
             descriptions.stream().map(d -> d.description).collect(Collectors.toList()),
@@ -80,7 +81,7 @@ public final class ListSourceExecutor {
     );
   }
 
-  public static Optional<KsqlEntity> streams(
+  public static List<? extends KsqlEntity> streams(
       final ConfiguredStatement<ListStreams> statement,
       final Map<String, ?> sessionProperties,
       final KsqlExecutionContext executionContext,
@@ -98,14 +99,14 @@ public final class ListSourceExecutor {
       );
     }
 
-    return Optional.of(new StreamsList(
+    return ImmutableList.of(new StreamsList(
         statement.getStatementText(),
         ksqlStreams.stream()
             .map(ListSourceExecutor::sourceSteam)
             .collect(Collectors.toList())));
   }
 
-  public static Optional<KsqlEntity> tables(
+  public static List<? extends KsqlEntity> tables(
       final ConfiguredStatement<ListTables> statement,
       final Map<String, ?> sessionProperties,
       final KsqlExecutionContext executionContext,
@@ -122,14 +123,14 @@ public final class ListSourceExecutor {
           ksqlTables
       );
     }
-    return Optional.of(new TablesList(
+    return ImmutableList.of(new TablesList(
         statement.getStatementText(),
         ksqlTables.stream()
             .map(ListSourceExecutor::sourceTable)
             .collect(Collectors.toList())));
   }
 
-  public static Optional<KsqlEntity> columns(
+  public static List<? extends KsqlEntity> columns(
       final ConfiguredStatement<ShowColumns> statement,
       final Map<String, ?> sessionProperties,
       final KsqlExecutionContext executionContext,
@@ -143,7 +144,7 @@ public final class ListSourceExecutor {
         showColumns.isExtended(),
         statement.getStatementText()
     );
-    return Optional.of(
+    return ImmutableList.of(
         new SourceDescriptionEntity(
             statement.getStatementText(),
             descriptionWithWarnings.description,

--- a/ksql-rest-app/src/main/java/io/confluent/ksql/rest/server/execution/ListTopicsExecutor.java
+++ b/ksql-rest-app/src/main/java/io/confluent/ksql/rest/server/execution/ListTopicsExecutor.java
@@ -15,6 +15,7 @@
 
 package io.confluent.ksql.rest.server.execution;
 
+import com.google.common.collect.ImmutableList;
 import io.confluent.ksql.KsqlExecutionContext;
 import io.confluent.ksql.parser.tree.ListTopics;
 import io.confluent.ksql.rest.entity.KafkaTopicInfo;
@@ -37,7 +38,6 @@ import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
-import java.util.Optional;
 import java.util.Set;
 import java.util.TreeMap;
 import java.util.concurrent.atomic.AtomicInteger;
@@ -48,10 +48,9 @@ import org.apache.kafka.common.TopicPartition;
 public final class ListTopicsExecutor {
 
   private ListTopicsExecutor() {
-
   }
 
-  public static Optional<KsqlEntity> execute(
+  public static List<? extends KsqlEntity> execute(
       final ConfiguredStatement<ListTopics> statement,
       final Map<String, ?> sessionProperties,
       final KsqlExecutionContext executionContext,
@@ -76,14 +75,14 @@ public final class ListTopicsExecutor {
               topicDescriptionToTopicInfoExtended(desc, topicConsumersAndGroupCount))
           .collect(Collectors.toList());
 
-      return Optional.of(
+      return ImmutableList.of(
           new KafkaTopicsListExtended(statement.getStatementText(), topicInfoExtendedList));
     } else {
       final List<KafkaTopicInfo> topicInfoList = filteredDescriptions.values()
           .stream().map(desc -> topicDescriptionToTopicInfo(desc))
           .collect(Collectors.toList());
 
-      return Optional.of(new KafkaTopicsList(statement.getStatementText(), topicInfoList));
+      return ImmutableList.of(new KafkaTopicsList(statement.getStatementText(), topicInfoList));
     }
   }
 

--- a/ksql-rest-app/src/main/java/io/confluent/ksql/rest/server/execution/ListTypesExecutor.java
+++ b/ksql-rest-app/src/main/java/io/confluent/ksql/rest/server/execution/ListTypesExecutor.java
@@ -15,6 +15,7 @@
 
 package io.confluent.ksql.rest.server.execution;
 
+import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import io.confluent.ksql.KsqlExecutionContext;
 import io.confluent.ksql.metastore.TypeRegistry.CustomType;
@@ -26,14 +27,14 @@ import io.confluent.ksql.rest.util.EntityUtil;
 import io.confluent.ksql.services.ServiceContext;
 import io.confluent.ksql.statement.ConfiguredStatement;
 import java.util.Iterator;
+import java.util.List;
 import java.util.Map;
-import java.util.Optional;
 
 public final class ListTypesExecutor {
 
   private ListTypesExecutor() { }
 
-  public static Optional<KsqlEntity> execute(
+  public static List<? extends KsqlEntity> execute(
       final ConfiguredStatement<ListTypes> configuredStatement,
       final Map<String, ?> sessionProperties,
       final KsqlExecutionContext executionContext,
@@ -47,6 +48,6 @@ public final class ListTypesExecutor {
       types.put(customType.getName(), EntityUtil.schemaInfo(customType.getType()));
     }
 
-    return Optional.of(new TypeList(configuredStatement.getStatementText(), types.build()));
+    return ImmutableList.of(new TypeList(configuredStatement.getStatementText(), types.build()));
   }
 }

--- a/ksql-rest-app/src/main/java/io/confluent/ksql/rest/server/execution/PropertyExecutor.java
+++ b/ksql-rest-app/src/main/java/io/confluent/ksql/rest/server/execution/PropertyExecutor.java
@@ -15,6 +15,7 @@
 
 package io.confluent.ksql.rest.server.execution;
 
+import com.google.common.collect.ImmutableList;
 import io.confluent.ksql.KsqlExecutionContext;
 import io.confluent.ksql.parser.tree.SetProperty;
 import io.confluent.ksql.parser.tree.UnsetProperty;
@@ -22,31 +23,30 @@ import io.confluent.ksql.properties.PropertyOverrider;
 import io.confluent.ksql.rest.entity.KsqlEntity;
 import io.confluent.ksql.services.ServiceContext;
 import io.confluent.ksql.statement.ConfiguredStatement;
+import java.util.List;
 import java.util.Map;
-import java.util.Optional;
 
 public final class PropertyExecutor {
 
   private PropertyExecutor() { }
 
-  public static Optional<KsqlEntity> set(
+  public static List<? extends KsqlEntity> set(
       final ConfiguredStatement<SetProperty> statement,
       final Map<String, Object> mutableScopedProperties,
       final KsqlExecutionContext executionContext,
       final ServiceContext serviceContext
   ) {
     PropertyOverrider.set(statement, mutableScopedProperties);
-    return Optional.empty();
+    return ImmutableList.of();
   }
 
-  public static Optional<KsqlEntity> unset(
+  public static List<? extends KsqlEntity> unset(
       final ConfiguredStatement<UnsetProperty> statement,
       final Map<String, Object> mutableScopedProperties,
       final KsqlExecutionContext executionContext,
       final ServiceContext serviceContext
   ) {
     PropertyOverrider.unset(statement, mutableScopedProperties);
-    return Optional.empty();
+    return ImmutableList.of();
   }
-
 }

--- a/ksql-rest-app/src/main/java/io/confluent/ksql/rest/server/execution/PullQueryExecutor.java
+++ b/ksql-rest-app/src/main/java/io/confluent/ksql/rest/server/execution/PullQueryExecutor.java
@@ -122,13 +122,13 @@ public final class PullQueryExecutor {
     throw new KsqlRestException(Errors.queryEndpoint(statement.getStatementText()));
   }
 
-  public static Optional<KsqlEntity> execute(
+  public static List<? extends KsqlEntity> execute(
       final ConfiguredStatement<Query> statement,
       final Map<String, ?> sessionProperties,
       final KsqlExecutionContext executionContext,
       final ServiceContext serviceContext
   ) {
-    return Optional.of(execute(statement, executionContext, serviceContext));
+    return ImmutableList.of(execute(statement, executionContext, serviceContext));
   }
 
   public static TableRowsEntity execute(

--- a/ksql-rest-app/src/main/java/io/confluent/ksql/rest/server/execution/StatementExecutor.java
+++ b/ksql-rest-app/src/main/java/io/confluent/ksql/rest/server/execution/StatementExecutor.java
@@ -20,8 +20,8 @@ import io.confluent.ksql.parser.tree.Statement;
 import io.confluent.ksql.rest.entity.KsqlEntity;
 import io.confluent.ksql.services.ServiceContext;
 import io.confluent.ksql.statement.ConfiguredStatement;
+import java.util.List;
 import java.util.Map;
-import java.util.Optional;
 
 /**
  * An interface that allows for arbitrary execution code of a prepared statement.
@@ -36,9 +36,9 @@ public interface StatementExecutor<T extends Statement> {
    * @param mutableScopedProperties the session properties
    * @param executionContext the context in which to execute it
    * @param serviceContext the services to use to execute it
-   * @return the execution result, if present, else {@link Optional#empty()}
+   * @return the execution results, if any
    */
-  Optional<KsqlEntity> execute(
+  List<? extends KsqlEntity> execute(
       ConfiguredStatement<T> statement,
       Map<String, Object> mutableScopedProperties,
       KsqlExecutionContext executionContext,

--- a/ksql-rest-app/src/main/java/io/confluent/ksql/rest/server/execution/TerminateAllQueriesExecutor.java
+++ b/ksql-rest-app/src/main/java/io/confluent/ksql/rest/server/execution/TerminateAllQueriesExecutor.java
@@ -1,0 +1,78 @@
+/*
+ * Copyright 2019 Confluent Inc.
+ *
+ * Licensed under the Confluent Community License (the "License"); you may not use
+ * this file except in compliance with the License.  You may obtain a copy of the
+ * License at
+ *
+ * http://www.confluent.io/confluent-community-license
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package io.confluent.ksql.rest.server.execution;
+
+import io.confluent.ksql.KsqlExecutionContext;
+import io.confluent.ksql.parser.KsqlParser.PreparedStatement;
+import io.confluent.ksql.parser.tree.Statement;
+import io.confluent.ksql.parser.tree.TerminateAllQueries;
+import io.confluent.ksql.parser.tree.TerminateQuery;
+import io.confluent.ksql.query.QueryId;
+import io.confluent.ksql.rest.entity.KsqlEntity;
+import io.confluent.ksql.rest.server.computation.DistributingExecutor;
+import io.confluent.ksql.services.ServiceContext;
+import io.confluent.ksql.statement.ConfiguredStatement;
+import io.confluent.ksql.util.PersistentQueryMetadata;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Optional;
+import java.util.stream.Collectors;
+
+/**
+ * Executes `TERMINATE ALL` by distributing `TERMINATE queryId` for each existing query id.
+ */
+final class TerminateAllQueriesExecutor implements StatementExecutor<TerminateAllQueries> {
+
+  private final DistributingExecutor distributor;
+
+  TerminateAllQueriesExecutor(
+      final DistributingExecutor distributor
+  ) {
+    this.distributor = Objects.requireNonNull(distributor, "distributor");
+  }
+
+  public List<? extends KsqlEntity> execute(
+      final ConfiguredStatement<TerminateAllQueries> statement,
+      final Map<String, Object> mutableScopedProperties,
+      final KsqlExecutionContext executionContext,
+      final ServiceContext serviceContext
+  ) {
+    return executionContext.getPersistentQueries().stream()
+        .map(PersistentQueryMetadata::getQueryId)
+        .map(id -> buildTerminateStatement(id, statement))
+        .flatMap(terminateStmt -> distributor.execute(
+            terminateStmt,
+            mutableScopedProperties,
+            executionContext,
+            serviceContext
+            ).stream()
+        )
+        .collect(Collectors.toList());
+  }
+
+  private static ConfiguredStatement<Statement> buildTerminateStatement(
+      final QueryId queryId,
+      final ConfiguredStatement<TerminateAllQueries> parent
+  ) {
+    final TerminateQuery terminateQuery = new TerminateQuery(Optional.empty(), queryId);
+
+    final PreparedStatement<Statement> prepared = PreparedStatement
+        .of("TERMINATE " + queryId.getId() + ";", terminateQuery);
+
+    return ConfiguredStatement.of(prepared, parent.getOverrides(), parent.getConfig());
+  }
+}

--- a/ksql-rest-app/src/main/java/io/confluent/ksql/rest/server/validation/CustomValidators.java
+++ b/ksql-rest-app/src/main/java/io/confluent/ksql/rest/server/validation/CustomValidators.java
@@ -37,6 +37,7 @@ import io.confluent.ksql.parser.tree.Query;
 import io.confluent.ksql.parser.tree.SetProperty;
 import io.confluent.ksql.parser.tree.ShowColumns;
 import io.confluent.ksql.parser.tree.Statement;
+import io.confluent.ksql.parser.tree.TerminateAllQueries;
 import io.confluent.ksql.parser.tree.TerminateQuery;
 import io.confluent.ksql.parser.tree.UnsetProperty;
 import io.confluent.ksql.rest.server.execution.DescribeConnectorExecutor;
@@ -84,7 +85,8 @@ public enum CustomValidators {
   SET_PROPERTY(SetProperty.class, PropertyExecutor::set),
   UNSET_PROPERTY(UnsetProperty.class, PropertyExecutor::unset),
 
-  TERMINATE_QUERY(TerminateQuery.class, TerminateQueryValidator::validate);
+  TERMINATE_QUERY(TerminateQuery.class, TerminateQueryValidator::validate),
+  TERMINATE_ALL_QUERIES(TerminateAllQueries.class, TerminateAllQueriesValidator::validate);
 
   public static final Map<Class<? extends Statement>, StatementValidator<?>> VALIDATOR_MAP =
       ImmutableMap.copyOf(

--- a/ksql-rest-app/src/main/java/io/confluent/ksql/rest/server/validation/TerminateAllQueriesValidator.java
+++ b/ksql-rest-app/src/main/java/io/confluent/ksql/rest/server/validation/TerminateAllQueriesValidator.java
@@ -16,29 +16,24 @@
 package io.confluent.ksql.rest.server.validation;
 
 import io.confluent.ksql.KsqlExecutionContext;
-import io.confluent.ksql.parser.tree.TerminateQuery;
-import io.confluent.ksql.query.QueryId;
+import io.confluent.ksql.parser.tree.TerminateAllQueries;
 import io.confluent.ksql.services.ServiceContext;
 import io.confluent.ksql.statement.ConfiguredStatement;
-import io.confluent.ksql.util.KsqlStatementException;
+import io.confluent.ksql.util.QueryMetadata;
 import java.util.Map;
 
-public final class TerminateQueryValidator {
+public final class TerminateAllQueriesValidator {
 
-  private TerminateQueryValidator() { }
+  private TerminateAllQueriesValidator() {
+  }
 
   @SuppressWarnings("unused") // not used, but required to match interface
   public static void validate(
-      final ConfiguredStatement<TerminateQuery> statement,
-      final Map<String, ?> mutableScopedProperties,
+      final ConfiguredStatement<TerminateAllQueries> statement,
+      final Map<String, Object> mutableScopedProperties,
       final KsqlExecutionContext executionContext,
       final ServiceContext serviceContext
   ) {
-    final QueryId queryId = statement.getStatement().getQueryId();
-
-    executionContext.getPersistentQuery(queryId)
-        .orElseThrow(() ->
-            new KsqlStatementException("Unknown queryId: " + queryId, statement.getStatementText()))
-        .close();
+    executionContext.getPersistentQueries().forEach(QueryMetadata::close);
   }
 }

--- a/ksql-rest-app/src/test/java/io/confluent/ksql/rest/server/CommandTopicTest.java
+++ b/ksql-rest-app/src/test/java/io/confluent/ksql/rest/server/CommandTopicTest.java
@@ -34,11 +34,9 @@ import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
-import java.util.concurrent.Future;
 import org.apache.kafka.clients.consumer.Consumer;
 import org.apache.kafka.clients.consumer.ConsumerRecord;
 import org.apache.kafka.clients.consumer.ConsumerRecords;
-import org.apache.kafka.clients.producer.RecordMetadata;
 import org.apache.kafka.common.TopicPartition;
 import org.junit.Before;
 import org.junit.Test;
@@ -56,9 +54,6 @@ public class CommandTopicTest {
   private Consumer<CommandId, Command> commandConsumer;
 
   private CommandTopic commandTopic;
-
-  @Mock
-  private Future<RecordMetadata> future;
 
   @Mock
   private CommandId commandId1;
@@ -81,7 +76,6 @@ public class CommandTopicTest {
   private final static TopicPartition TOPIC_PARTITION = new TopicPartition(COMMAND_TOPIC_NAME, 0);
 
   @Before
-  @SuppressWarnings("unchecked")
   public void setup() {
     commandTopic = new CommandTopic(COMMAND_TOPIC_NAME, commandConsumer);
   }

--- a/ksql-rest-app/src/test/java/io/confluent/ksql/rest/server/computation/DistributingExecutorTest.java
+++ b/ksql-rest-app/src/test/java/io/confluent/ksql/rest/server/computation/DistributingExecutorTest.java
@@ -15,13 +15,12 @@
 package io.confluent.ksql.rest.server.computation;
 
 import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.contains;
 import static org.hamcrest.Matchers.instanceOf;
 import static org.hamcrest.Matchers.is;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.doThrow;
-import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
@@ -30,7 +29,6 @@ import com.google.common.collect.ImmutableMap;
 import io.confluent.ksql.KsqlExecutionContext;
 import io.confluent.ksql.exception.KsqlTopicAuthorizationException;
 import io.confluent.ksql.metastore.MetaStore;
-import io.confluent.ksql.parser.KsqlParser.ParsedStatement;
 import io.confluent.ksql.parser.KsqlParser.PreparedStatement;
 import io.confluent.ksql.parser.tree.ListProperties;
 import io.confluent.ksql.parser.tree.Statement;
@@ -40,20 +38,19 @@ import io.confluent.ksql.rest.entity.CommandId.Type;
 import io.confluent.ksql.rest.entity.CommandStatus;
 import io.confluent.ksql.rest.entity.CommandStatus.Status;
 import io.confluent.ksql.rest.entity.CommandStatusEntity;
+import io.confluent.ksql.rest.entity.KsqlEntity;
 import io.confluent.ksql.rest.server.validation.RequestValidator;
 import io.confluent.ksql.security.KsqlAuthorizationValidator;
 import io.confluent.ksql.services.SandboxedServiceContext;
 import io.confluent.ksql.services.ServiceContext;
-import io.confluent.ksql.services.TestServiceContext;
 import io.confluent.ksql.statement.ConfiguredStatement;
 import io.confluent.ksql.statement.Injector;
-import io.confluent.ksql.statement.InjectorChain;
 import io.confluent.ksql.util.KsqlConfig;
 import io.confluent.ksql.util.KsqlException;
 import io.confluent.ksql.util.KsqlServerException;
 import java.time.Duration;
-import java.util.Collections;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Optional;
 import java.util.concurrent.atomic.AtomicLong;
 import org.apache.kafka.clients.producer.Producer;
@@ -75,28 +72,38 @@ public class DistributingExecutorTest {
   private static final CommandId CS_COMMAND = new CommandId(Type.STREAM, "stream", Action.CREATE);
   private static final CommandStatus SUCCESS_STATUS = new CommandStatus(Status.SUCCESS, "");
   private static final KsqlConfig KSQL_CONFIG = new KsqlConfig(new HashMap<>());
-  private static final ConfiguredStatement<Statement> EMPTY_STATEMENT =
-      ConfiguredStatement.of(
-          PreparedStatement.of("", new ListProperties(Optional.empty())),
-          ImmutableMap.of(),
-          KSQL_CONFIG
-      );
+  private static final String ORIGINAL_SQL = "original-sql";
+  private static final String INJECTED_SQL = "injected-sql";
 
   @Rule
   public ExpectedException expectedException = ExpectedException.none();
 
-  @Mock CommandQueue queue;
-  @Mock QueuedCommandStatus status;
-  @Mock ServiceContext serviceContext;
-  @Mock Injector schemaInjector;
-  @Mock Injector topicInjector;
-  @Mock KsqlAuthorizationValidator authorizationValidator;
-  @Mock KsqlExecutionContext executionContext;
-  @Mock MetaStore metaStore;
-  @Mock RequestValidator requestValidator;
-  @Mock ParsedStatement parsedStatement;
   @Mock
-  Producer<CommandId, Command> transactionalProducer;
+  private CommandQueue queue;
+  @Mock
+  private QueuedCommandStatus status;
+  @Mock
+  private SandboxedServiceContext userServiceContext;
+  @Mock
+  private ServiceContext serverServiceContext;
+  @Mock
+  private Injector injector;
+  @Mock
+  private KsqlAuthorizationValidator authorizationValidator;
+  @Mock
+  private KsqlExecutionContext executionContext;
+  @Mock
+  private MetaStore metaStore;
+  @Mock
+  private RequestValidator requestValidator;
+  @Mock
+  private Producer<CommandId, Command> transactionalProducer;
+  @Mock
+  private ConfiguredStatement<Statement> configuredStatement;
+  @Mock
+  private ConfiguredStatement<Statement> injectedStatement;
+  @Mock
+  private Statement statement;
 
   private DistributingExecutor distributor;
   private AtomicLong scnCounter;
@@ -104,24 +111,22 @@ public class DistributingExecutorTest {
   @Before
   public void setUp() throws InterruptedException {
     scnCounter = new AtomicLong();
-    when(schemaInjector.inject(any())).thenAnswer(inv -> inv.getArgument(0));
-    when(topicInjector.inject(any())).thenAnswer(inv -> inv.getArgument(0));
-    when(queue.enqueueCommand(EMPTY_STATEMENT, transactionalProducer)).thenReturn(status);
+    when(injector.inject(any())).thenReturn(injectedStatement);
+    when(queue.enqueueCommand(injectedStatement, transactionalProducer)).thenReturn(status);
     when(status.tryWaitForFinalStatus(any())).thenReturn(SUCCESS_STATUS);
     when(status.getCommandId()).thenReturn(CS_COMMAND);
     when(status.getCommandSequenceNumber()).thenAnswer(inv -> scnCounter.incrementAndGet());
     when(executionContext.getMetaStore()).thenReturn(metaStore);
-    serviceContext = SandboxedServiceContext.create(TestServiceContext.create());
-    when(executionContext.getServiceContext()).thenReturn(serviceContext);
-    when(requestValidator.validate(
-        serviceContext, Collections.singletonList(parsedStatement), ImmutableMap.of(), SQL_STRING)).thenReturn(1);
-    when(parsedStatement.getStatementText()).thenReturn(SQL_STRING);
+    when(executionContext.getServiceContext()).thenReturn(serverServiceContext);
     when(queue.createTransactionalProducer()).thenReturn(transactionalProducer);
+    when(configuredStatement.getStatementText()).thenReturn(ORIGINAL_SQL);
+    when(injectedStatement.getStatementText()).thenReturn(INJECTED_SQL);
+    when(injectedStatement.getStatement()).thenReturn(statement);
 
     distributor = new DistributingExecutor(
         queue,
         DURATION_10_MS,
-        (ec, sc) -> InjectorChain.of(schemaInjector, topicInjector),
+        (ec, sc) -> injector,
         Optional.of(authorizationValidator),
         requestValidator
     );
@@ -130,127 +135,125 @@ public class DistributingExecutorTest {
   @Test
   public void shouldEnqueueSuccessfulCommandTransactionally() {
     // When:
-    distributor.execute(EMPTY_STATEMENT, parsedStatement, ImmutableMap.of(), executionContext, serviceContext);
+    distributor
+        .execute(configuredStatement, ImmutableMap.of(), executionContext, userServiceContext);
 
     // Then:
-    InOrder inOrder = Mockito.inOrder(transactionalProducer, queue, requestValidator);
+    final InOrder inOrder = Mockito.inOrder(transactionalProducer, queue, requestValidator);
     inOrder.verify(transactionalProducer, times(1)).initTransactions();
     inOrder.verify(transactionalProducer, times(1)).beginTransaction();
     inOrder.verify(queue, times(1)).waitForCommandConsumer();
     inOrder.verify(requestValidator).validate(
-        serviceContext,
-        Collections.singletonList(parsedStatement),
-        ImmutableMap.of(),
-        SQL_STRING);
-    inOrder.verify(queue, times(1)).enqueueCommand(EMPTY_STATEMENT, transactionalProducer);
+        any(),
+        any(ConfiguredStatement.class),
+        any(),
+        any());
+    inOrder.verify(queue, times(1)).enqueueCommand(any(), any());
     inOrder.verify(transactionalProducer, times(1)).commitTransaction();
     inOrder.verify(transactionalProducer, times(1)).close();
   }
 
   @Test
-  public void shouldInferSchemas() {
+  public void shouldValidateStatements() {
     // When:
-    distributor.execute(EMPTY_STATEMENT, parsedStatement, ImmutableMap.of(),  executionContext, serviceContext);
+    distributor
+        .execute(configuredStatement, ImmutableMap.of(), executionContext, userServiceContext);
 
     // Then:
-    verify(schemaInjector, times(1)).inject(eq(EMPTY_STATEMENT));
+    verify(requestValidator).validate(
+        userServiceContext,
+        injectedStatement,
+        ImmutableMap.of(),
+        INJECTED_SQL
+    );
+  }
+
+  @Test
+  public void shouldCallInjector() {
+    // When:
+    distributor
+        .execute(configuredStatement, ImmutableMap.of(), executionContext, userServiceContext);
+
+    // Then:
+    verify(injector, times(1)).inject(eq(configuredStatement));
   }
 
   @Test
   public void shouldReturnCommandStatus() {
     // When:
-    final CommandStatusEntity commandStatusEntity =
-        (CommandStatusEntity) distributor.execute(
-            EMPTY_STATEMENT,
-            parsedStatement,
-            ImmutableMap.of(),
-            executionContext,
-            serviceContext
-        )
-            .orElseThrow(null);
+    final List<? extends KsqlEntity> results = distributor.execute(
+        configuredStatement,
+        ImmutableMap.of(),
+        executionContext,
+        userServiceContext
+    );
 
     // Then:
-    assertThat(commandStatusEntity,
-        equalTo(new CommandStatusEntity("", CS_COMMAND, SUCCESS_STATUS, 1L)));
+    assertThat(results,
+        contains(new CommandStatusEntity("", CS_COMMAND, SUCCESS_STATUS, 1L)));
   }
 
   @Test
   public void shouldThrowExceptionOnFailureToEnqueue() {
     // Given:
     final KsqlException cause = new KsqlException("fail");
+    when(queue.enqueueCommand(any(), any())).thenThrow(cause);
 
-    final PreparedStatement<Statement> preparedStatement =
-        PreparedStatement.of("x", new ListProperties(Optional.empty()));
-
-    final ConfiguredStatement<Statement> configured =
-        ConfiguredStatement.of(
-            preparedStatement,
-            ImmutableMap.of(),
-            KSQL_CONFIG);
-
-    when(queue.enqueueCommand(configured, transactionalProducer)).thenThrow(cause);
     // Expect:
     expectedException.expect(KsqlServerException.class);
     expectedException.expectMessage(
-        "Could not write the statement 'x' into the command topic: fail");
+        "Could not write the statement '" + ORIGINAL_SQL + "' into the command topic: fail");
     expectedException.expectCause(is(cause));
 
     // When:
-    distributor.execute(configured, parsedStatement, ImmutableMap.of(), executionContext, serviceContext);
+    distributor
+        .execute(configuredStatement, ImmutableMap.of(), executionContext, userServiceContext);
     verify(transactionalProducer, times(1)).abortTransaction();
   }
 
   @Test
-  public void shouldThrowFailureIfCannotInferSchema() {
+  public void shouldThrowFailureIfInject() {
     // Given:
     final PreparedStatement<Statement> preparedStatement =
         PreparedStatement.of("", new ListProperties(Optional.empty()));
     final ConfiguredStatement<Statement> configured =
         ConfiguredStatement.of(preparedStatement, ImmutableMap.of(), KSQL_CONFIG);
-    when(schemaInjector.inject(any())).thenThrow(new KsqlException("Could not infer!"));
+    when(injector.inject(any())).thenThrow(new KsqlException("Could not infer!"));
 
     // Expect:
     expectedException.expect(KsqlException.class);
     expectedException.expectMessage("Could not infer!");
 
     // When:
-    distributor.execute(configured, parsedStatement, ImmutableMap.of(), executionContext, serviceContext);
+    distributor.execute(configured, ImmutableMap.of(), executionContext, userServiceContext);
   }
 
   @Test
   public void shouldThrowExceptionIfUserServiceContextIsDeniedAuthorization() {
     // Given:
-    final ServiceContext userServiceContext = mock(ServiceContext.class);
-    final PreparedStatement<Statement> preparedStatement =
-        PreparedStatement.of("", new ListProperties(Optional.empty()));
-    final ConfiguredStatement<Statement> configured =
-        ConfiguredStatement.of(preparedStatement, ImmutableMap.of(), KSQL_CONFIG);
     doThrow(KsqlTopicAuthorizationException.class).when(authorizationValidator)
-        .checkAuthorization(eq(userServiceContext), any(), eq(configured.getStatement()));
+        .checkAuthorization(eq(userServiceContext), any(), eq(statement));
 
     // Expect:
     expectedException.expect(KsqlTopicAuthorizationException.class);
 
     // When:
-    distributor.execute(configured, parsedStatement, ImmutableMap.of(), executionContext, userServiceContext);
+    distributor
+        .execute(configuredStatement, ImmutableMap.of(), executionContext, userServiceContext);
   }
 
   @Test
   public void shouldThrowServerExceptionIfServerServiceContextIsDeniedAuthorization() {
     // Given:
-    final ServiceContext userServiceContext = SandboxedServiceContext.create(TestServiceContext.create());
-    final PreparedStatement<Statement> preparedStatement =
-        PreparedStatement.of("", new ListProperties(Optional.empty()));
-    final ConfiguredStatement<Statement> configured =
-        ConfiguredStatement.of(preparedStatement, ImmutableMap.of(), KSQL_CONFIG);
     doThrow(KsqlTopicAuthorizationException.class).when(authorizationValidator)
-        .checkAuthorization(eq(serviceContext), any(), eq(configured.getStatement()));
+        .checkAuthorization(eq(serverServiceContext), any(), eq(statement));
 
     // Expect:
     expectedException.expect(KsqlServerException.class);
     expectedException.expectCause(is(instanceOf(KsqlTopicAuthorizationException.class)));
 
     // When:
-    distributor.execute(configured, parsedStatement, ImmutableMap.of(), executionContext, userServiceContext);
+    distributor
+        .execute(configuredStatement, ImmutableMap.of(), executionContext, userServiceContext);
   }
 }

--- a/ksql-rest-app/src/test/java/io/confluent/ksql/rest/server/execution/ConnectExecutorTest.java
+++ b/ksql-rest-app/src/test/java/io/confluent/ksql/rest/server/execution/ConnectExecutorTest.java
@@ -16,6 +16,7 @@
 package io.confluent.ksql.rest.server.execution;
 
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.contains;
 import static org.hamcrest.Matchers.instanceOf;
 import static org.mockito.ArgumentMatchers.anyMap;
 import static org.mockito.ArgumentMatchers.anyString;
@@ -36,7 +37,7 @@ import io.confluent.ksql.services.ConnectClient.ConnectResponse;
 import io.confluent.ksql.services.ServiceContext;
 import io.confluent.ksql.statement.ConfiguredStatement;
 import io.confluent.ksql.util.KsqlConfig;
-import java.util.Optional;
+import java.util.List;
 import org.apache.http.HttpStatus;
 import org.apache.kafka.connect.runtime.rest.entities.ConnectorInfo;
 import org.apache.kafka.connect.runtime.rest.entities.ConnectorType;
@@ -90,12 +91,11 @@ public class ConnectExecutorTest {
     givenSuccess();
 
     // When:
-    final Optional<KsqlEntity> entity = ConnectExecutor
+    final List<? extends KsqlEntity> results = ConnectExecutor
         .execute(CREATE_CONNECTOR_CONFIGURED, ImmutableMap.of(), null, serviceContext);
 
     // Then:
-    assertThat("Expected non-empty response", entity.isPresent());
-    assertThat(entity.get(), instanceOf(CreateConnectorEntity.class));
+    assertThat(results, contains(instanceOf(CreateConnectorEntity.class)));
   }
 
   @Test
@@ -104,12 +104,11 @@ public class ConnectExecutorTest {
     givenError();
 
     // When:
-    final Optional<KsqlEntity> entity = ConnectExecutor
+    final List<? extends KsqlEntity> results = ConnectExecutor
         .execute(CREATE_CONNECTOR_CONFIGURED, ImmutableMap.of(), null, serviceContext);
 
     // Then:
-    assertThat("Expected non-empty response", entity.isPresent());
-    assertThat(entity.get(), instanceOf(ErrorEntity.class));
+    assertThat(results, contains(instanceOf(ErrorEntity.class)));
   }
 
   private void givenSuccess() {
@@ -126,5 +125,4 @@ public class ConnectExecutorTest {
     when(connectClient.create(anyString(), anyMap()))
         .thenReturn(ConnectResponse.failure("error!", HttpStatus.SC_BAD_REQUEST));
   }
-
 }

--- a/ksql-rest-app/src/test/java/io/confluent/ksql/rest/server/execution/DescribeConnectorExecutorTest.java
+++ b/ksql-rest-app/src/test/java/io/confluent/ksql/rest/server/execution/DescribeConnectorExecutorTest.java
@@ -16,6 +16,7 @@
 package io.confluent.ksql.rest.server.execution;
 
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.contains;
 import static org.hamcrest.Matchers.empty;
 import static org.hamcrest.Matchers.instanceOf;
 import static org.hamcrest.Matchers.is;
@@ -52,6 +53,7 @@ import io.confluent.ksql.services.ConnectClient.ConnectResponse;
 import io.confluent.ksql.services.ServiceContext;
 import io.confluent.ksql.statement.ConfiguredStatement;
 import io.confluent.ksql.util.KsqlConfig;
+import java.util.List;
 import java.util.Optional;
 import java.util.Set;
 import java.util.function.Function;
@@ -155,18 +157,16 @@ public class DescribeConnectorExecutorTest {
         new KsqlConfig(ImmutableMap.of()));
   }
 
-  @SuppressWarnings("OptionalGetWithoutIsPresent")
   @Test
   public void shouldDescribeKnownConnector() {
     // When:
-    final Optional<KsqlEntity> entity = executor
+    final List<? extends KsqlEntity> result = executor
         .execute(describeStatement, ImmutableMap.of(), engine, serviceContext);
 
     // Then:
-    assertThat("Expected a response", entity.isPresent());
-    assertThat(entity.get(), instanceOf(ConnectorDescription.class));
+    assertThat(result, contains(instanceOf(ConnectorDescription.class)));
 
-    final ConnectorDescription description = (ConnectorDescription) entity.get();
+    final ConnectorDescription description = (ConnectorDescription) result.get(0);
     assertThat(description.getConnectorClass(), is(CONNECTOR_CLASS));
     assertThat(description.getStatus(), is(STATUS));
     assertThat(description.getSources().size(), is(1));
@@ -184,14 +184,13 @@ public class DescribeConnectorExecutorTest {
     when(topics.names()).thenReturn(fut);
 
     // When:
-    final Optional<KsqlEntity> entity = executor
+    final List<? extends KsqlEntity> result = executor
         .execute(describeStatement, ImmutableMap.of(), engine, serviceContext);
 
     // Then:
-    assertThat("Expected a response", entity.isPresent());
-    assertThat(entity.get(), instanceOf(ConnectorDescription.class));
+    assertThat(result, contains(instanceOf(ConnectorDescription.class)));
 
-    final ConnectorDescription description = (ConnectorDescription) entity.get();
+    final ConnectorDescription description = (ConnectorDescription) result.get(0);
     assertThat(description.getConnectorClass(), is(CONNECTOR_CLASS));
     assertThat(description.getTopics().size(), is(0));
     assertThat(description.getWarnings().size(), is(1));
@@ -203,14 +202,13 @@ public class DescribeConnectorExecutorTest {
     when(connectClient.describe(any())).thenReturn(ConnectResponse.failure("error", HttpStatus.SC_INTERNAL_SERVER_ERROR));
 
     // When:
-    final Optional<KsqlEntity> entity = executor
+    final List<? extends KsqlEntity> result = executor
         .execute(describeStatement, ImmutableMap.of(), engine, serviceContext);
 
     // Then:
     verify(connectClient).status("connector");
-    assertThat("Expected a response", entity.isPresent());
-    assertThat(entity.get(), instanceOf(ErrorEntity.class));
-    assertThat(((ErrorEntity) entity.get()).getErrorMessage(), is("error"));
+    assertThat(result, contains(instanceOf(ErrorEntity.class)));
+    assertThat(((ErrorEntity) result.get(0)).getErrorMessage(), is("error"));
   }
 
   @Test
@@ -219,15 +217,14 @@ public class DescribeConnectorExecutorTest {
     when(connectClient.describe(any())).thenReturn(ConnectResponse.failure("error", HttpStatus.SC_INTERNAL_SERVER_ERROR));
 
     // When:
-    final Optional<KsqlEntity> entity = executor
+    final List<? extends KsqlEntity> result = executor
         .execute(describeStatement, ImmutableMap.of(), engine, serviceContext);
 
     // Then:
     verify(connectClient).status("connector");
     verify(connectClient).describe("connector");
-    assertThat("Expected a response", entity.isPresent());
-    assertThat(entity.get(), instanceOf(ErrorEntity.class));
-    assertThat(((ErrorEntity) entity.get()).getErrorMessage(), is("error"));
+    assertThat(result, contains(instanceOf(ErrorEntity.class)));
+    assertThat(((ErrorEntity) result.get(0)).getErrorMessage(), is("error"));
   }
 
   @Test
@@ -237,17 +234,14 @@ public class DescribeConnectorExecutorTest {
     executor = new DescribeConnectorExecutor(connectorFactory);
 
     // When:
-    final Optional<KsqlEntity> entity = executor
+    final List<? extends KsqlEntity> result = executor
         .execute(describeStatement, ImmutableMap.of(), engine, serviceContext);
 
     // Then:
-    assertThat("Expected a response", entity.isPresent());
-    assertThat(entity.get(), instanceOf(ConnectorDescription.class));
-
-    final ConnectorDescription description = (ConnectorDescription) entity.get();
+    assertThat(result, contains(instanceOf(ConnectorDescription.class)));
+    final ConnectorDescription description = (ConnectorDescription) result.get(0);
     assertThat(description.getConnectorClass(), is(CONNECTOR_CLASS));
     assertThat(description.getStatus(), is(STATUS));
     assertThat(description.getSources(), empty());
   }
-
 }

--- a/ksql-rest-app/src/test/java/io/confluent/ksql/rest/server/execution/DropConnectorExecutorTest.java
+++ b/ksql-rest-app/src/test/java/io/confluent/ksql/rest/server/execution/DropConnectorExecutorTest.java
@@ -16,6 +16,7 @@
 package io.confluent.ksql.rest.server.execution;
 
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.contains;
 import static org.hamcrest.Matchers.instanceOf;
 import static org.hamcrest.Matchers.is;
 import static org.mockito.ArgumentMatchers.anyString;
@@ -33,6 +34,7 @@ import io.confluent.ksql.services.ConnectClient.ConnectResponse;
 import io.confluent.ksql.services.ServiceContext;
 import io.confluent.ksql.statement.ConfiguredStatement;
 import io.confluent.ksql.util.KsqlConfig;
+import java.util.List;
 import java.util.Optional;
 import org.apache.http.HttpStatus;
 import org.junit.Before;
@@ -87,12 +89,12 @@ public class DropConnectorExecutorTest {
         .thenReturn(ConnectResponse.success("foo", HttpStatus.SC_OK));
 
     // When:
-    final Optional<KsqlEntity> response = DropConnectorExecutor
-        .execute(DROP_CONNECTOR_CONFIGURED, ImmutableMap.of(),null, serviceContext);
+    final List<? extends KsqlEntity> result = DropConnectorExecutor
+        .execute(DROP_CONNECTOR_CONFIGURED, ImmutableMap.of(), null, serviceContext);
 
     // Then:
-    assertThat("expected response", response.isPresent());
-    assertThat(((DropConnectorEntity) response.get()).getConnectorName(), is("foo"));
+    assertThat(result, contains(instanceOf(DropConnectorEntity.class)));
+    assertThat(((DropConnectorEntity) result.get(0)).getConnectorName(), is("foo"));
   }
 
   @Test
@@ -102,12 +104,10 @@ public class DropConnectorExecutorTest {
         .thenReturn(ConnectResponse.failure("Danger Mouse!", HttpStatus.SC_INTERNAL_SERVER_ERROR));
 
     // When:
-    final Optional<KsqlEntity> entity = DropConnectorExecutor
-        .execute(DROP_CONNECTOR_CONFIGURED, ImmutableMap.of(),null, serviceContext);
+    final List<? extends KsqlEntity> result = DropConnectorExecutor
+        .execute(DROP_CONNECTOR_CONFIGURED, ImmutableMap.of(), null, serviceContext);
 
     // Then:
-    assertThat("Expected non-empty response", entity.isPresent());
-    assertThat(entity.get(), instanceOf(ErrorEntity.class));
+    assertThat(result, contains(instanceOf(ErrorEntity.class)));
   }
-
 }

--- a/ksql-rest-app/src/test/java/io/confluent/ksql/rest/server/execution/ExplainExecutorTest.java
+++ b/ksql-rest-app/src/test/java/io/confluent/ksql/rest/server/execution/ExplainExecutorTest.java
@@ -17,9 +17,11 @@ package io.confluent.ksql.rest.server.execution;
 
 import static io.confluent.ksql.metastore.model.DataSource.DataSourceType;
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.contains;
 import static org.hamcrest.Matchers.containsInAnyOrder;
 import static org.hamcrest.Matchers.empty;
 import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.instanceOf;
 import static org.hamcrest.Matchers.is;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
@@ -28,12 +30,14 @@ import com.google.common.collect.ImmutableMap;
 import io.confluent.ksql.engine.KsqlEngine;
 import io.confluent.ksql.name.SourceName;
 import io.confluent.ksql.query.QueryId;
+import io.confluent.ksql.rest.entity.KsqlEntity;
 import io.confluent.ksql.rest.entity.QueryDescriptionEntity;
 import io.confluent.ksql.rest.entity.QueryDescriptionFactory;
 import io.confluent.ksql.rest.server.TemporaryEngine;
 import io.confluent.ksql.statement.ConfiguredStatement;
 import io.confluent.ksql.util.KsqlException;
 import io.confluent.ksql.util.PersistentQueryMetadata;
+import java.util.List;
 import java.util.Optional;
 import org.junit.Rule;
 import org.junit.Test;
@@ -60,15 +64,17 @@ public class ExplainExecutorTest {
     when(engine.getPersistentQuery(metadata.getQueryId())).thenReturn(Optional.of(metadata));
 
     // When:
-    final QueryDescriptionEntity query = (QueryDescriptionEntity) CustomExecutors.EXPLAIN.execute(
+    final List<? extends KsqlEntity> results = CustomExecutors.EXPLAIN.execute(
         explain,
         ImmutableMap.of(),
         engine,
         this.engine.getServiceContext()
-    ).orElseThrow(IllegalStateException::new);
+    );
 
     // Then:
-    assertThat(query.getQueryDescription(), equalTo(QueryDescriptionFactory.forQueryMetadata(metadata)));
+    assertThat(results, contains(instanceOf(QueryDescriptionEntity.class)));
+    assertThat(((QueryDescriptionEntity)results.get(0)).getQueryDescription(),
+        equalTo(QueryDescriptionFactory.forQueryMetadata(metadata)));
   }
 
   @Test
@@ -79,14 +85,16 @@ public class ExplainExecutorTest {
     final ConfiguredStatement<?> explain = engine.configure("EXPLAIN " + statementText);
 
     // When:
-    final QueryDescriptionEntity query = (QueryDescriptionEntity) CustomExecutors.EXPLAIN.execute(
+    final List<? extends KsqlEntity> results = CustomExecutors.EXPLAIN.execute(
         explain,
         ImmutableMap.of(),
         engine.getEngine(),
         engine.getServiceContext()
-    ).orElseThrow(IllegalStateException::new);
+    );
 
     // Then:
+    assertThat(results, contains(instanceOf(QueryDescriptionEntity.class)));
+    final QueryDescriptionEntity query = (QueryDescriptionEntity) results.get(0);
     assertThat(query.getQueryDescription().getStatementText(), equalTo(statementText));
     assertThat(query.getQueryDescription().getSources(), containsInAnyOrder("Y"));
     assertThat("No side effects should happen", engine.getEngine().getPersistentQueries(), is(empty()));
@@ -100,14 +108,16 @@ public class ExplainExecutorTest {
     final ConfiguredStatement<?> explain = engine.configure("EXPLAIN " + statementText);
 
     // When:
-    final QueryDescriptionEntity query = (QueryDescriptionEntity) CustomExecutors.EXPLAIN.execute(
+    final List<? extends KsqlEntity> results = CustomExecutors.EXPLAIN.execute(
         explain,
         ImmutableMap.of(),
         engine.getEngine(),
         engine.getServiceContext()
-    ).orElseThrow(IllegalStateException::new);
+    );
 
     // Then:
+    assertThat(results, contains(instanceOf(QueryDescriptionEntity.class)));
+    final QueryDescriptionEntity query = (QueryDescriptionEntity) results.get(0);
     assertThat(query.getQueryDescription().getStatementText(), equalTo(statementText));
     assertThat(query.getQueryDescription().getSources(), containsInAnyOrder("Y"));
   }
@@ -120,14 +130,16 @@ public class ExplainExecutorTest {
     final ConfiguredStatement<?> explain = engine.configure("EXPLAIN " + statementText);
 
     // When:
-    final QueryDescriptionEntity query = (QueryDescriptionEntity) CustomExecutors.EXPLAIN.execute(
+    final List<? extends KsqlEntity> results = CustomExecutors.EXPLAIN.execute(
         explain,
         ImmutableMap.of(),
         engine.getEngine(),
         engine.getServiceContext()
-    ).orElseThrow(IllegalStateException::new);
+    );
 
     // Then:
+    assertThat(results, contains(instanceOf(QueryDescriptionEntity.class)));
+    final QueryDescriptionEntity query = (QueryDescriptionEntity) results.get(0);
     assertThat(query.getQueryDescription().getStatementText(), equalTo(statementText));
     assertThat(query.getQueryDescription().getSources(), containsInAnyOrder("Y"));
   }

--- a/ksql-rest-app/src/test/java/io/confluent/ksql/rest/server/execution/ListConnectorsExecutorTest.java
+++ b/ksql-rest-app/src/test/java/io/confluent/ksql/rest/server/execution/ListConnectorsExecutorTest.java
@@ -16,6 +16,8 @@
 package io.confluent.ksql.rest.server.execution;
 
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.contains;
+import static org.hamcrest.Matchers.instanceOf;
 import static org.hamcrest.Matchers.is;
 import static org.mockito.Mockito.when;
 
@@ -34,6 +36,7 @@ import io.confluent.ksql.services.ConnectClient.ConnectResponse;
 import io.confluent.ksql.services.ServiceContext;
 import io.confluent.ksql.statement.ConfiguredStatement;
 import io.confluent.ksql.util.KsqlConfig;
+import java.util.List;
 import java.util.Optional;
 import org.apache.http.HttpStatus;
 import org.apache.kafka.connect.runtime.ConnectorConfig;
@@ -86,12 +89,12 @@ public class ListConnectorsExecutorTest {
     );
 
     // When:
-    final Optional<KsqlEntity> entity = ListConnectorsExecutor
+    final List<? extends KsqlEntity> results = ListConnectorsExecutor
         .execute(statement, ImmutableMap.of(), engine, serviceContext);
 
     // Then:
-    assertThat("expected response!", entity.isPresent());
-    final ConnectorList connectorList = (ConnectorList) entity.get();
+    assertThat(results, contains(instanceOf(ConnectorList.class)));
+    final ConnectorList connectorList = (ConnectorList) results.get(0);
 
     assertThat(connectorList, is(new ConnectorList(
         "",
@@ -115,12 +118,12 @@ public class ListConnectorsExecutorTest {
     );
 
     // When:
-    final Optional<KsqlEntity> entity = ListConnectorsExecutor
+    final List<? extends KsqlEntity> results = ListConnectorsExecutor
         .execute(statement, ImmutableMap.of(), engine, serviceContext);
 
     // Then:
-    assertThat("expected response!", entity.isPresent());
-    final ConnectorList connectorList = (ConnectorList) entity.get();
+    assertThat(results, contains(instanceOf(ConnectorList.class)));
+    final ConnectorList connectorList = (ConnectorList) results.get(0);
 
     assertThat(connectorList, is(new ConnectorList(
         "",
@@ -141,12 +144,12 @@ public class ListConnectorsExecutorTest {
     );
 
     // When:
-    final Optional<KsqlEntity> entity = ListConnectorsExecutor
+    final List<? extends KsqlEntity> results = ListConnectorsExecutor
         .execute(statement, ImmutableMap.of(), engine, serviceContext);
 
     // Then:
-    assertThat("expected response!", entity.isPresent());
-    final ConnectorList connectorList = (ConnectorList) entity.get();
+    assertThat(results, contains(instanceOf(ConnectorList.class)));
+    final ConnectorList connectorList = (ConnectorList) results.get(0);
 
     assertThat(connectorList, is(new ConnectorList(
         "",
@@ -157,5 +160,4 @@ public class ListConnectorsExecutorTest {
         )
     )));
   }
-
 }

--- a/ksql-rest-app/src/test/java/io/confluent/ksql/rest/server/execution/ListFunctionsExecutorTest.java
+++ b/ksql-rest-app/src/test/java/io/confluent/ksql/rest/server/execution/ListFunctionsExecutorTest.java
@@ -18,14 +18,18 @@ package io.confluent.ksql.rest.server.execution;
 import static org.hamcrest.CoreMatchers.hasItem;
 import static org.hamcrest.CoreMatchers.hasItems;
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.contains;
+import static org.hamcrest.Matchers.instanceOf;
 import static org.hamcrest.Matchers.not;
 
 import com.google.common.collect.ImmutableMap;
 import io.confluent.ksql.rest.entity.FunctionNameList;
 import io.confluent.ksql.rest.entity.FunctionType;
+import io.confluent.ksql.rest.entity.KsqlEntity;
 import io.confluent.ksql.rest.entity.SimpleFunctionInfo;
 import io.confluent.ksql.rest.server.TemporaryEngine;
 import java.util.Collection;
+import java.util.List;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -38,16 +42,17 @@ public class ListFunctionsExecutorTest {
 
   @Test
   public void shouldListFunctions() {
-
     // When:
-    final FunctionNameList functionList = (FunctionNameList) CustomExecutors.LIST_FUNCTIONS.execute(
+    final List<? extends KsqlEntity> results = CustomExecutors.LIST_FUNCTIONS.execute(
         engine.configure("LIST FUNCTIONS;"),
         ImmutableMap.of(),
         engine.getEngine(),
         engine.getServiceContext()
-    ).orElseThrow(IllegalStateException::new);
+    );
 
     // Then:
+    assertThat(results, contains(instanceOf(FunctionNameList.class)));
+    final FunctionNameList functionList = (FunctionNameList) results.get(0);
     Collection<SimpleFunctionInfo> functions = functionList.getFunctions();
     assertThat(functions, hasItems(
         new SimpleFunctionInfo("EXTRACTJSONFIELD", FunctionType.SCALAR),
@@ -63,6 +68,4 @@ public class ListFunctionsExecutorTest {
         not(hasItem(new SimpleFunctionInfo("FETCH_FIELD_FROM_STRUCT", FunctionType.SCALAR)))
     );
   }
-
-
 }

--- a/ksql-rest-app/src/test/java/io/confluent/ksql/rest/server/execution/ListQueriesExecutorTest.java
+++ b/ksql-rest-app/src/test/java/io/confluent/ksql/rest/server/execution/ListQueriesExecutorTest.java
@@ -16,8 +16,10 @@
 package io.confluent.ksql.rest.server.execution;
 
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.contains;
 import static org.hamcrest.Matchers.containsInAnyOrder;
 import static org.hamcrest.Matchers.empty;
+import static org.hamcrest.Matchers.instanceOf;
 import static org.hamcrest.Matchers.is;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
@@ -28,6 +30,7 @@ import com.google.common.collect.ImmutableSet;
 import io.confluent.ksql.engine.KsqlEngine;
 import io.confluent.ksql.name.SourceName;
 import io.confluent.ksql.query.QueryId;
+import io.confluent.ksql.rest.entity.KsqlEntity;
 import io.confluent.ksql.rest.entity.Queries;
 import io.confluent.ksql.rest.entity.QueryDescriptionFactory;
 import io.confluent.ksql.rest.entity.QueryDescriptionList;
@@ -35,6 +38,7 @@ import io.confluent.ksql.rest.entity.RunningQuery;
 import io.confluent.ksql.rest.server.TemporaryEngine;
 import io.confluent.ksql.statement.ConfiguredStatement;
 import io.confluent.ksql.util.PersistentQueryMetadata;
+import java.util.List;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -48,14 +52,16 @@ public class ListQueriesExecutorTest {
   @Test
   public void shouldListQueriesEmpty() {
     // When
-    final Queries queries = (Queries) CustomExecutors.LIST_QUERIES.execute(
+    final List<? extends KsqlEntity> results = CustomExecutors.LIST_QUERIES.execute(
         engine.configure("SHOW QUERIES;"),
         ImmutableMap.of(),
         engine.getEngine(),
         engine.getServiceContext()
-    ).orElseThrow(IllegalStateException::new);
+    );
 
-    assertThat(queries.getQueries(), is(empty()));
+    // Then:
+    assertThat(results, contains(instanceOf(Queries.class)));
+    assertThat(((Queries)results.get(0)).getQueries(), is(empty()));
   }
 
   @Test
@@ -68,14 +74,16 @@ public class ListQueriesExecutorTest {
     when(engine.getPersistentQueries()).thenReturn(ImmutableList.of(metadata));
 
     // When
-    final Queries queries = (Queries) CustomExecutors.LIST_QUERIES.execute(
+    final List<? extends KsqlEntity> results = CustomExecutors.LIST_QUERIES.execute(
         showQueries,
         ImmutableMap.of(),
         engine,
         this.engine.getServiceContext()
-    ).orElseThrow(IllegalStateException::new);
+    );
 
-    assertThat(queries.getQueries(), containsInAnyOrder(
+    // Then:
+    assertThat(results, contains(instanceOf(Queries.class)));
+    assertThat(((Queries)results.get(0)).getQueries(), containsInAnyOrder(
         new RunningQuery(
             metadata.getStatementString(),
             ImmutableSet.of(metadata.getSinkName().name()),
@@ -93,14 +101,16 @@ public class ListQueriesExecutorTest {
     when(engine.getPersistentQueries()).thenReturn(ImmutableList.of(metadata));
 
     // When
-    final QueryDescriptionList queries = (QueryDescriptionList) CustomExecutors.LIST_QUERIES.execute(
+    final List<? extends KsqlEntity> results = CustomExecutors.LIST_QUERIES.execute(
         showQueries,
         ImmutableMap.of(),
         engine,
         this.engine.getServiceContext()
-    ).orElseThrow(IllegalStateException::new);
+    );
 
-    assertThat(queries.getQueryDescriptions(), containsInAnyOrder(
+    // Then:
+    assertThat(results, contains(instanceOf(QueryDescriptionList.class)));
+    assertThat(((QueryDescriptionList)results.get(0)).getQueryDescriptions(), containsInAnyOrder(
         QueryDescriptionFactory.forQueryMetadata(metadata)));
   }
 

--- a/ksql-rest-app/src/test/java/io/confluent/ksql/rest/server/execution/ListTopicsExecutorTest.java
+++ b/ksql-rest-app/src/test/java/io/confluent/ksql/rest/server/execution/ListTopicsExecutorTest.java
@@ -16,7 +16,9 @@
 package io.confluent.ksql.rest.server.execution;
 
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.contains;
 import static org.hamcrest.Matchers.containsInAnyOrder;
+import static org.hamcrest.Matchers.instanceOf;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
@@ -26,10 +28,12 @@ import io.confluent.ksql.rest.entity.KafkaTopicInfo;
 import io.confluent.ksql.rest.entity.KafkaTopicInfoExtended;
 import io.confluent.ksql.rest.entity.KafkaTopicsList;
 import io.confluent.ksql.rest.entity.KafkaTopicsListExtended;
+import io.confluent.ksql.rest.entity.KsqlEntity;
 import io.confluent.ksql.rest.server.TemporaryEngine;
 import io.confluent.ksql.services.ServiceContext;
 import io.confluent.ksql.services.TestServiceContext;
 import java.util.Collection;
+import java.util.List;
 import org.apache.kafka.clients.admin.AdminClient;
 import org.apache.kafka.clients.admin.ConsumerGroupListing;
 import org.apache.kafka.clients.admin.ListConsumerGroupsResult;
@@ -42,7 +46,8 @@ import org.mockito.junit.MockitoJUnitRunner;
 @RunWith(MockitoJUnitRunner.class)
 public class ListTopicsExecutorTest {
 
-  @Rule public final TemporaryEngine engine = new TemporaryEngine();
+  @Rule
+  public final TemporaryEngine engine = new TemporaryEngine();
 
   @Test
   public void shouldListKafkaTopics() {
@@ -61,16 +66,16 @@ public class ListTopicsExecutorTest {
     );
 
     // When:
-    final KafkaTopicsList topicsList =
-        (KafkaTopicsList) CustomExecutors.LIST_TOPICS.execute(
-            engine.configure("LIST TOPICS;"),
-            ImmutableMap.of(),
-            engine.getEngine(),
-            serviceContext
-        ).orElseThrow(IllegalStateException::new);
+    final List<? extends KsqlEntity> results = CustomExecutors.LIST_TOPICS.execute(
+        engine.configure("LIST TOPICS;"),
+        ImmutableMap.of(),
+        engine.getEngine(),
+        serviceContext
+    );
 
     // Then:
-    assertThat(topicsList.getTopics(), containsInAnyOrder(
+    assertThat(results, contains(instanceOf(KafkaTopicsList.class)));
+    assertThat(((KafkaTopicsList) results.get(0)).getTopics(), containsInAnyOrder(
         new KafkaTopicInfo("topic1", ImmutableList.of(1)),
         new KafkaTopicInfo("topic2", ImmutableList.of(1))
     ));
@@ -99,19 +104,18 @@ public class ListTopicsExecutorTest {
     );
 
     // When:
-    final KafkaTopicsListExtended topicsList =
-        (KafkaTopicsListExtended) CustomExecutors.LIST_TOPICS.execute(
-            engine.configure("LIST TOPICS EXTENDED;"),
-            ImmutableMap.of(),
-            engine.getEngine(),
-            serviceContext
-        ).orElseThrow(IllegalStateException::new);
+    final List<? extends KsqlEntity> results = CustomExecutors.LIST_TOPICS.execute(
+        engine.configure("LIST TOPICS EXTENDED;"),
+        ImmutableMap.of(),
+        engine.getEngine(),
+        serviceContext
+    );
 
     // Then:
-    assertThat(topicsList.getTopics(), containsInAnyOrder(
+    assertThat(results, contains(instanceOf(KafkaTopicsListExtended.class)));
+    assertThat(((KafkaTopicsListExtended) results.get(0)).getTopics(), containsInAnyOrder(
         new KafkaTopicInfoExtended("topic1", ImmutableList.of(1), 0, 0),
         new KafkaTopicInfoExtended("topic2", ImmutableList.of(1), 0, 0)
     ));
   }
-
 }

--- a/ksql-rest-app/src/test/java/io/confluent/ksql/rest/server/execution/ListTypesExecutorTest.java
+++ b/ksql-rest-app/src/test/java/io/confluent/ksql/rest/server/execution/ListTypesExecutorTest.java
@@ -16,6 +16,8 @@
 package io.confluent.ksql.rest.server.execution;
 
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.contains;
+import static org.hamcrest.Matchers.instanceOf;
 import static org.hamcrest.Matchers.is;
 import static org.mockito.Mockito.when;
 
@@ -33,6 +35,7 @@ import io.confluent.ksql.schema.ksql.SqlBaseType;
 import io.confluent.ksql.schema.ksql.types.SqlPrimitiveType;
 import io.confluent.ksql.statement.ConfiguredStatement;
 import io.confluent.ksql.util.KsqlConfig;
+import java.util.List;
 import java.util.Optional;
 import org.junit.Before;
 import org.junit.Test;
@@ -63,7 +66,7 @@ public class ListTypesExecutorTest {
   @Test
   public void shouldListTypes() {
     // When:
-    final Optional<KsqlEntity> entity = ListTypesExecutor.execute(
+    final List<? extends KsqlEntity> results = ListTypesExecutor.execute(
         ConfiguredStatement.of(
             PreparedStatement.of("statement", new ListTypes(Optional.empty())),
             ImmutableMap.of(),
@@ -74,10 +77,9 @@ public class ListTypesExecutorTest {
         null);
 
     // Then:
-    assertThat("expected a response", entity.isPresent());
-    assertThat(((TypeList) entity.get()).getTypes(), is(ImmutableMap.of(
+    assertThat(results, contains(instanceOf(TypeList.class)));
+    assertThat(((TypeList) results.get(0)).getTypes(), is(ImmutableMap.of(
         "foo", EntityUtil.schemaInfo(SqlPrimitiveType.of(SqlBaseType.STRING))
     )));
   }
-
 }

--- a/ksql-rest-app/src/test/java/io/confluent/ksql/rest/server/execution/TerminateAllQueriesExecutorTest.java
+++ b/ksql-rest-app/src/test/java/io/confluent/ksql/rest/server/execution/TerminateAllQueriesExecutorTest.java
@@ -1,0 +1,146 @@
+/*
+ * Copyright 2019 Confluent Inc.
+ *
+ * Licensed under the Confluent Community License (the "License"); you may not use
+ * this file except in compliance with the License.  You may obtain a copy of the
+ * License at
+ *
+ * http://www.confluent.io/confluent-community-license
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package io.confluent.ksql.rest.server.execution;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.inOrder;
+import static org.mockito.Mockito.when;
+
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+import io.confluent.ksql.engine.KsqlEngine;
+import io.confluent.ksql.parser.KsqlParser.PreparedStatement;
+import io.confluent.ksql.parser.tree.TerminateAllQueries;
+import io.confluent.ksql.parser.tree.TerminateQuery;
+import io.confluent.ksql.query.QueryId;
+import io.confluent.ksql.rest.entity.KsqlEntity;
+import io.confluent.ksql.rest.server.computation.DistributingExecutor;
+import io.confluent.ksql.services.ServiceContext;
+import io.confluent.ksql.statement.ConfiguredStatement;
+import io.confluent.ksql.util.KsqlConfig;
+import io.confluent.ksql.util.PersistentQueryMetadata;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.InOrder;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnitRunner;
+
+@RunWith(MockitoJUnitRunner.class)
+public class TerminateAllQueriesExecutorTest {
+
+  private static final KsqlConfig SOME_CONFIG = new KsqlConfig(ImmutableMap.of());
+  private static final Map<String, Object> SOME_OVERRIDES = ImmutableMap.of("thing", "v");
+  private static final QueryId ID_0 = new QueryId("0");
+  private static final QueryId ID_1 = new QueryId("1");
+
+  @Mock
+  private DistributingExecutor distributor;
+  @Mock
+  private PersistentQueryMetadata query0;
+  @Mock
+  private PersistentQueryMetadata query1;
+  @Mock
+  private KsqlEntity entity0;
+  @Mock
+  private KsqlEntity entity1;
+  @Mock
+  private KsqlEntity entity2;
+  @Mock
+  private KsqlEngine engine;
+  @Mock
+  private ServiceContext serviceContext;
+  @Mock
+  private ConfiguredStatement<TerminateAllQueries> terminateAll;
+  private TerminateAllQueriesExecutor executor;
+
+  @Before
+  public void setUp() {
+    executor = new TerminateAllQueriesExecutor(distributor);
+
+    when(terminateAll.getConfig()).thenReturn(SOME_CONFIG);
+    when(terminateAll.getOverrides()).thenReturn(SOME_OVERRIDES);
+
+    when(query0.getQueryId()).thenReturn(ID_0);
+    when(query1.getQueryId()).thenReturn(ID_1);
+  }
+
+  @Test
+  public void shouldDistributeTerminatesForEachQuery() {
+    // Given:
+    when(engine.getPersistentQueries())
+        .thenReturn(ImmutableList.of(query0, query1));
+
+    // When:
+    executor.execute(terminateAll, ImmutableMap.of(), engine, serviceContext);
+
+    // Then:
+    final InOrder inOrder = inOrder(distributor);
+    inOrder.verify(distributor).execute(
+        ConfiguredStatement.of(
+            PreparedStatement.of(
+                "TERMINATE " + ID_0 + ";",
+                new TerminateQuery(Optional.empty(), ID_0)
+            ),
+            SOME_OVERRIDES,
+            SOME_CONFIG
+        ),
+        ImmutableMap.of(),
+        engine,
+        serviceContext
+    );
+    inOrder.verify(distributor).execute(
+        ConfiguredStatement.of(
+            PreparedStatement.of(
+                "TERMINATE " + ID_1 + ";",
+                new TerminateQuery(Optional.empty(), ID_1)
+            ),
+            SOME_OVERRIDES,
+            SOME_CONFIG
+        ),
+        ImmutableMap.of(),
+        engine,
+        serviceContext
+    );
+  }
+
+  @Test
+  public void shouldReturnEntitiesFromDistributed() {
+    // Given:
+    when(engine.getPersistentQueries())
+        .thenReturn(ImmutableList.of(query0, query1));
+
+    doReturn(
+        ImmutableList.of(entity0),
+        ImmutableList.of(entity1, entity2)
+    )
+        .when(distributor)
+        .execute(any(), any(), any(), any());
+
+    // When:
+    final List<? extends KsqlEntity> result = executor
+        .execute(terminateAll, ImmutableMap.of(), engine, serviceContext);
+
+    // Then:
+    assertThat(result, is(ImmutableList.of(entity0, entity1, entity2)));
+  }
+}


### PR DESCRIPTION
### Description 

As per discussion https://github.com/confluentinc/ksql/pull/3944#discussion_r349709433

This PR switching the `TERMINATE ALL` functionality to write a `TERMINATE <querId>` command to the command topic for each active query, rather than a single `TERMINATE ALL` command.  The reasoning behind this is that it we _want_ the command topic to be key compacted, and such a design works better with this plan.


### Testing done 

usual

### Reviewer checklist
- [ ] Ensure docs are updated if necessary. (eg. if a user visible feature is being added or changed).
- [ ] Ensure relevant issues are linked (description should include text like "Fixes #<issue number>")

