### PR TITLE
docs: update docs site url to match canonical root.

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,5 +1,5 @@
 site_name: ksqlDB
-site_url: https://docs.ksqldb.io
+site_url: https://docs.ksqldb.io/en/latest/
 site_description: ksqlDB documentation
 site_author: Confluent
 copyright: Copyright &copy; 2019 <a href="https://www.confluent.io/">Confluent</a>.


### PR DESCRIPTION
### Description 
Pages on docs.ksqldb.io currently render with an incorrect `<link rel="canonical" ...>` tag. This corrects the respective setting in the docs-building configuration.

### Testing done 
I built the docs site locally and inspected the generated tags:
```
.../ksql/_build/html$ cat index.html | grep canonical
        <link rel="canonical" href="https://docs.ksqldb.io/en/latest/">
```
```
.../ksql/_build/html/concepts$ cat index.html | grep canonical
        <link rel="canonical" href="https://docs.ksqldb.io/en/latest/concepts/">
```

### Reviewer checklist
- [ ] Ensure docs are updated if necessary. (eg. if a user visible feature is being added or changed).
- [ ] Ensure relevant issues are linked (description should include text like "Fixes #<issue number>")

