### PR TITLE
docs: migrate syntax reference change from .rst to .md docs (DOCS-3028)

### DIFF
--- a/docs-md/developer-guide/ksqldb-reference/create-stream-as-select.md
+++ b/docs-md/developer-guide/ksqldb-reference/create-stream-as-select.md
@@ -32,7 +32,7 @@ its corresponding topic.
 
 If the PARTITION BY clause is present, then the resulting stream will
 have the specified column as its key. The `column_name` must be present
-in the `select_expr`. For more information, see
+in the `from_stream`. For more information, see
 [Partition Data to Enable Joins](../joins/partition-data.md).
 
 For joins, the key of the resulting stream will be the value from the


### PR DESCRIPTION
Migrate from : https://github.com/confluentinc/ksql/pull/3982.