### PR TITLE
chore: turn on checkstyle rule to detect todo comments (MINOR)

### DIFF
--- a/checkstyle/checkstyle.properties
+++ b/checkstyle/checkstyle.properties
@@ -18,3 +18,4 @@ checkstyle.hideutilityclassconstructor.severity=error
 checkstyle.redundantmodifier.severity=error
 checkstyle.customimportorder.severity=error
 checkstyle.finalclass.severity=error
+checkstyle.todocomment.severity=error

--- a/ksql-engine/src/main/java/io/confluent/ksql/function/udf/string/MaskKeepLeftKudf.java
+++ b/ksql-engine/src/main/java/io/confluent/ksql/function/udf/string/MaskKeepLeftKudf.java
@@ -17,6 +17,7 @@ package io.confluent.ksql.function.udf.string;
 
 import io.confluent.ksql.function.udf.Udf;
 import io.confluent.ksql.function.udf.UdfDescription;
+import io.confluent.ksql.function.udf.UdfParameter;
 import io.confluent.ksql.util.KsqlConstants;
 
 @UdfDescription(name = MaskKeepLeftKudf.NAME, author = KsqlConstants.CONFLUENT_AUTHOR,
@@ -29,19 +30,25 @@ public class MaskKeepLeftKudf {
 
   @Udf(description = "Returns a masked version of the input string. All characters except for the"
       + " first n will be replaced according to the default masking rules.")
-  public String mask(final String input, final int numChars) {
+  @SuppressWarnings("MethodMayBeStatic") // Invoked via reflection
+  public String mask(
+      @UdfParameter("input STRING to be masked") final String input,
+      @UdfParameter("number of characters to keep unmasked at the start") final int numChars
+  ) {
     return doMask(new Masker(), input, numChars);
   }
 
   @Udf(description = "Returns a masked version of the input string. All characters except for the"
-      + " first n will be replaced with the specified masking characters: e.g."
-      + " mask_keep_left(input, numberToKeep, upperCaseMask, lowerCaseMask, digitMask, otherMask)"
-      + " . Pass NULL for any of the mask characters to prevent masking of that character type.")
-  public String mask(final String input, final int numChars, final String upper, final String lower,
-      final String digit, final String other) {
-    // TODO once KSQL gains Char sql-datatype support we should change the xxMask params to int
-    // (codepoint) instead of String
-
+      + " first n will be replaced with the specified masking characters")
+  @SuppressWarnings("MethodMayBeStatic") // Invoked via reflection
+  public String mask(
+      @UdfParameter("input STRING to be masked") final String input,
+      @UdfParameter("number of characters to keep unmasked at the start") final int numChars,
+      @UdfParameter("upper-case mask, or NULL to use default") final String upper,
+      @UdfParameter("lower-case mask, or NULL to use default") final String lower,
+      @UdfParameter("digit mask, or NULL to use default") final String digit,
+      @UdfParameter("mask for other characters, or NULL to use default") final String other
+  ) {
     final int upperMask = Masker.getMaskCharacter(upper);
     final int lowerMask = Masker.getMaskCharacter(lower);
     final int digitMask = Masker.getMaskCharacter(digit);
@@ -50,7 +57,7 @@ public class MaskKeepLeftKudf {
     return doMask(masker, input, numChars);
   }
 
-  private String doMask(final Masker masker, final String input, final int numChars) {
+  private static String doMask(final Masker masker, final String input, final int numChars) {
     Masker.validateParams(NAME, numChars);
     if (input == null) {
       return null;
@@ -61,5 +68,4 @@ public class MaskKeepLeftKudf {
     output.append(masker.mask(input.substring(charsToKeep)));
     return output.toString();
   }
-
 }

--- a/ksql-engine/src/main/java/io/confluent/ksql/function/udf/string/MaskKudf.java
+++ b/ksql-engine/src/main/java/io/confluent/ksql/function/udf/string/MaskKudf.java
@@ -17,6 +17,7 @@ package io.confluent.ksql.function.udf.string;
 
 import io.confluent.ksql.function.udf.Udf;
 import io.confluent.ksql.function.udf.UdfDescription;
+import io.confluent.ksql.function.udf.UdfParameter;
 import io.confluent.ksql.util.KsqlConstants;
 
 @UdfDescription(name = "mask", author = KsqlConstants.CONFLUENT_AUTHOR,
@@ -27,24 +28,23 @@ public class MaskKudf {
 
   @Udf(description = "Returns a masked version of the input string. All characters of the input"
       + " will be replaced according to the default masking rules.")
-  public String mask(final String input) {
+  @SuppressWarnings("MethodMayBeStatic") // Invoked via reflection
+  public String mask(
+      @UdfParameter("input STRING to be masked") final String input
+  ) {
     return doMask(new Masker(), input);
   }
 
-  // TODO these descriptions would be much easier and more structured if we had an annotation for
-  // each param (a bit like javadoc) as it's basically the extra params that are getting described
-  // in each variant of the UDF
   @Udf(description = "Returns a masked version of the input string. All characters of the input"
-      + " will be replaced with the specified masking characters: e.g."
-      + " mask(input, upperCaseMask, lowerCaseMask, digitMask, otherMask)."
-      + " Pass NULL for any of the mask characters to prevent masking of that character type.")
-  public String mask(final String input, final String upper, final String lower, final String digit,
-      final String other) {
-    // TODO once KSQL gains Char sql-datatype support we should change the xxMask params to int
-    // (codepoint) instead of String
-
-    // TODO really need a way for UDFs to do one-shot init() stuff instead of repeating all this
-    // literal-param manipulation and validation for every single record
+      + " will be replaced with the specified masking characters")
+  @SuppressWarnings("MethodMayBeStatic") // Invoked via reflection
+  public String mask(
+      @UdfParameter("input STRING to be masked") final String input,
+      @UdfParameter("upper-case mask, or NULL to use default") final String upper,
+      @UdfParameter("lower-case mask, or NULL to use default") final String lower,
+      @UdfParameter("digit mask, or NULL to use default") final String digit,
+      @UdfParameter("mask for other characters, or NULL to use default") final String other
+  ) {
     final int upperMask = Masker.getMaskCharacter(upper);
     final int lowerMask = Masker.getMaskCharacter(lower);
     final int digitMask = Masker.getMaskCharacter(digit);
@@ -53,13 +53,10 @@ public class MaskKudf {
     return doMask(masker, input);
   }
 
-  private String doMask(final Masker masker, final String input) {
+  private static String doMask(final Masker masker, final String input) {
     if (input == null) {
       return null;
     }
-    final StringBuilder output = new StringBuilder(input.length());
-    output.append(masker.mask(input));
-    return output.toString();
+    return masker.mask(input);
   }
-
 }

--- a/ksql-engine/src/main/java/io/confluent/ksql/function/udf/string/MaskLeftKudf.java
+++ b/ksql-engine/src/main/java/io/confluent/ksql/function/udf/string/MaskLeftKudf.java
@@ -17,6 +17,7 @@ package io.confluent.ksql.function.udf.string;
 
 import io.confluent.ksql.function.udf.Udf;
 import io.confluent.ksql.function.udf.UdfDescription;
+import io.confluent.ksql.function.udf.UdfParameter;
 import io.confluent.ksql.util.KsqlConstants;
 
 @UdfDescription(name = MaskLeftKudf.NAME, author = KsqlConstants.CONFLUENT_AUTHOR,
@@ -29,19 +30,25 @@ public class MaskLeftKudf {
 
   @Udf(description = "Returns a masked version of the input string. The first n characters"
       + " will be replaced according to the default masking rules.")
-  public String mask(final String input, final int numChars) {
+  @SuppressWarnings("MethodMayBeStatic") // Invoked via reflection
+  public String mask(
+      @UdfParameter("input STRING to be masked") final String input,
+      @UdfParameter("number of characters to mask from the start") final int numChars
+  ) {
     return doMask(new Masker(), input, numChars);
   }
 
   @Udf(description = "Returns a masked version of the input string. The first n characters"
-      + " will be replaced with the specified masking characters: e.g."
-      + " mask_left(input, numberToMask, upperCaseMask, lowerCaseMask, digitMask, otherMask)"
-      + " . Pass NULL for any of the mask characters to prevent masking of that character type.")
-  public String mask(final String input, final int numChars, final String upper, final String lower,
-      final String digit, final String other) {
-    // TODO once KSQL gains Char sql-datatype support we should change the xxMask params to int
-    // (codepoint) instead of String
-
+      + " will be replaced with the specified masking characters")
+  @SuppressWarnings("MethodMayBeStatic") // Invoked via reflection
+  public String mask(
+      @UdfParameter("input STRING to be masked") final String input,
+      @UdfParameter("number of characters to mask from the start") final int numChars,
+      @UdfParameter("upper-case mask, or NULL to use default") final String upper,
+      @UdfParameter("lower-case mask, or NULL to use default") final String lower,
+      @UdfParameter("digit mask, or NULL to use default") final String digit,
+      @UdfParameter("mask for other characters, or NULL to use default") final String other
+  ) {
     final int upperMask = Masker.getMaskCharacter(upper);
     final int lowerMask = Masker.getMaskCharacter(lower);
     final int digitMask = Masker.getMaskCharacter(digit);
@@ -50,7 +57,7 @@ public class MaskLeftKudf {
     return doMask(masker, input, numChars);
   }
 
-  private String doMask(final Masker masker, final String input, final int numChars) {
+  private static String doMask(final Masker masker, final String input, final int numChars) {
     Masker.validateParams(NAME, numChars);
     if (input == null) {
       return null;

--- a/ksql-engine/src/main/java/io/confluent/ksql/function/udf/string/MaskRightKudf.java
+++ b/ksql-engine/src/main/java/io/confluent/ksql/function/udf/string/MaskRightKudf.java
@@ -17,6 +17,7 @@ package io.confluent.ksql.function.udf.string;
 
 import io.confluent.ksql.function.udf.Udf;
 import io.confluent.ksql.function.udf.UdfDescription;
+import io.confluent.ksql.function.udf.UdfParameter;
 import io.confluent.ksql.util.KsqlConstants;
 
 @UdfDescription(name = MaskRightKudf.NAME, author = KsqlConstants.CONFLUENT_AUTHOR,
@@ -25,23 +26,30 @@ import io.confluent.ksql.util.KsqlConstants;
         + " Default masking rules will replace all upper-case characters with 'X', all lower-case"
         + " characters with 'x', all digits with 'n', and any other character with '-'.")
 public class MaskRightKudf {
+
   protected static final String NAME = "mask_right";
 
   @Udf(description = "Returns a masked version of the input string. The last n characters"
       + " will be replaced according to the default masking rules.")
-  public String mask(final String input, final int numChars) {
+  @SuppressWarnings("MethodMayBeStatic") // Invoked via reflection
+  public String mask(
+      @UdfParameter("input STRING to be masked") final String input,
+      @UdfParameter("number of characters to mask before the end") final int numChars
+  ) {
     return doMask(new Masker(), input, numChars);
   }
 
   @Udf(description = "Returns a masked version of the input string. The last n characters"
-      + " will be replaced with the specified masking characters: e.g."
-      + " mask_right(input, numberToMask, upperCaseMask, lowerCaseMask, digitMask, otherMask)"
-      + " . Pass NULL for any of the mask characters to prevent masking of that character type.")
-  public String mask(final String input, final int numChars, final String upper, final String lower,
-      final String digit, final String other) {
-    // TODO once KSQL gains Char sql-datatype support we should change the xxMask params to int
-    // (codepoint) instead of String
-
+      + " will be replaced with the specified masking characters")
+  @SuppressWarnings("MethodMayBeStatic") // Invoked via reflection
+  public String mask(
+      @UdfParameter("input STRING to be masked") final String input,
+      @UdfParameter("number of characters to mask before the end") final int numChars,
+      @UdfParameter("upper-case mask, or NULL to use default") final String upper,
+      @UdfParameter("lower-case mask, or NULL to use default") final String lower,
+      @UdfParameter("digit mask, or NULL to use default") final String digit,
+      @UdfParameter("mask for other characters, or NULL to use default") final String other
+  ) {
     final int upperMask = Masker.getMaskCharacter(upper);
     final int lowerMask = Masker.getMaskCharacter(lower);
     final int digitMask = Masker.getMaskCharacter(digit);
@@ -50,7 +58,7 @@ public class MaskRightKudf {
     return doMask(masker, input, numChars);
   }
 
-  private String doMask(final Masker masker, final String input, final int numChars) {
+  private static String doMask(final Masker masker, final String input, final int numChars) {
     Masker.validateParams(NAME, numChars);
     if (input == null) {
       return null;

--- a/ksql-engine/src/main/java/io/confluent/ksql/function/udf/string/Masker.java
+++ b/ksql-engine/src/main/java/io/confluent/ksql/function/udf/string/Masker.java
@@ -16,6 +16,7 @@
 package io.confluent.ksql.function.udf.string;
 
 import io.confluent.ksql.function.KsqlFunctionException;
+import io.confluent.ksql.util.KsqlException;
 
 class Masker {
 
@@ -74,8 +75,17 @@ class Masker {
     return c;
   }
 
-  static int getMaskCharacter(final String stringMask) {
-    return stringMask == null ? NO_MASK : stringMask.codePointAt(0);
+  static int getMaskCharacter(final String mask) {
+    if (mask == null) {
+      return NO_MASK;
+    }
+
+    if (mask.length() != 1) {
+      throw new KsqlException("Invalid mask character. "
+          + "Must be only single character, but was '" + mask + "'");
+    }
+
+    return  mask.codePointAt(0);
   }
 
   static void validateParams(final String udfName, final int numChars) {

--- a/ksql-engine/src/test/java/io/confluent/ksql/function/udf/string/MaskerTest.java
+++ b/ksql-engine/src/test/java/io/confluent/ksql/function/udf/string/MaskerTest.java
@@ -1,0 +1,32 @@
+/*
+ * Copyright 2019 Confluent Inc.
+ *
+ * Licensed under the Confluent Community License (the "License"); you may not use
+ * this file except in compliance with the License.  You may obtain a copy of the
+ * License at
+ *
+ * http://www.confluent.io/confluent-community-license
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package io.confluent.ksql.function.udf.string;
+
+import io.confluent.ksql.util.KsqlException;
+import org.junit.Test;
+
+public class MaskerTest {
+
+  @Test(expected = KsqlException.class)
+  public void shoudThrowOnEmptyMask() {
+    Masker.getMaskCharacter("");
+  }
+
+  @Test(expected = KsqlException.class)
+  public void shouldThrowOnMultiCharMask() {
+    Masker.getMaskCharacter("2c");
+  }
+}

--- a/ksql-rest-app/src/main/java/io/confluent/ksql/rest/server/resources/KsqlExceptionMapper.java
+++ b/ksql-rest-app/src/main/java/io/confluent/ksql/rest/server/resources/KsqlExceptionMapper.java
@@ -26,7 +26,6 @@ public class KsqlExceptionMapper implements ExceptionMapper<Throwable> {
 
   @Override
   public Response toResponse(final Throwable exception) {
-    // TODO: Distinguish between exceptions that warrant a stack trace and ones that don't
     if (exception instanceof KsqlRestException) {
       final KsqlRestException restException = (KsqlRestException)exception;
       return restException.getResponse();


### PR DESCRIPTION
### Description 

and fix up / remove any outstanding todos

one new github issue to track outstanding todo:

https://github.com/confluentinc/ksql/issues/3993

I've also completed the other todos in the `MASK` UDFs by adding appropriate parameter descriptions.

While in there I, and looking at #3993, I noticed we didn't currently validate the passed string contained only a single character.  An empty STRING would result an exception, while a multi-character string would be accepted, but only the first character would be used.  In the interest of 'failing hard and failing fast' these edge cases are no explicitly tested.   The main reason for adding this is to make any switch to a `CHAR` type parameters, (again see #3993), easier, as we know existing use only has a single char being passed.

### Dev machine setup changes:
Locally, if you have the checkstyle plugin installed in your IDE you will want to set `checkstyle.todocomment.severity` to `error` to have it run the same checks as the Maven plugin.

### Testing done 

non-functional change.

### Reviewer checklist
- [ ] Ensure docs are updated if necessary. (eg. if a user visible feature is being added or changed).
- [ ] Ensure relevant issues are linked (description should include text like "Fixes #<issue number>")

