### PR TITLE
refactor: clean up metastore props from source create steps

### DIFF
--- a/ksql-engine/src/main/java/io/confluent/ksql/structured/SchemaKSourceFactory.java
+++ b/ksql-engine/src/main/java/io/confluent/ksql/structured/SchemaKSourceFactory.java
@@ -33,7 +33,6 @@ import io.confluent.ksql.metastore.model.DataSource;
 import io.confluent.ksql.metastore.model.KeyField;
 import io.confluent.ksql.name.SourceName;
 import io.confluent.ksql.serde.KeyFormat;
-import io.confluent.ksql.serde.WindowInfo;
 import java.util.Optional;
 import org.apache.kafka.streams.Topology.AutoOffsetReset;
 
@@ -110,17 +109,14 @@ public final class SchemaKSourceFactory {
       final KeyField keyField,
       final SourceName alias
   ) {
-    final WindowInfo windowInfo = dataSource.getKsqlTopic().getKeyFormat().getWindowInfo()
+    dataSource.getKsqlTopic().getKeyFormat().getWindowInfo()
         .orElseThrow(IllegalArgumentException::new);
 
     final WindowedStreamSource step = ExecutionStepFactory.streamSourceWindowed(
         contextStacker,
         schemaWithMetaAndKeyFields,
-        dataSource.getKafkaTopicName(),
-        buildFormats(dataSource),
-        windowInfo,
-        dataSource.getTimestampColumn(),
         offsetReset,
+        dataSource.getName(),
         alias
     );
 
@@ -148,10 +144,8 @@ public final class SchemaKSourceFactory {
     final StreamSource step = ExecutionStepFactory.streamSource(
         contextStacker,
         schemaWithMetaAndKeyFields,
-        dataSource.getKafkaTopicName(),
-        buildFormats(dataSource),
-        dataSource.getTimestampColumn(),
         offsetReset,
+        dataSource.getName(),
         alias
     );
 
@@ -172,17 +166,14 @@ public final class SchemaKSourceFactory {
       final KeyField keyField,
       final SourceName alias
   ) {
-    final WindowInfo windowInfo = dataSource.getKsqlTopic().getKeyFormat().getWindowInfo()
+    dataSource.getKsqlTopic().getKeyFormat().getWindowInfo()
         .orElseThrow(IllegalArgumentException::new);
 
     final WindowedTableSource step = ExecutionStepFactory.tableSourceWindowed(
         contextStacker,
         schemaWithMetaAndKeyFields,
-        dataSource.getKafkaTopicName(),
-        buildFormats(dataSource),
-        windowInfo,
-        dataSource.getTimestampColumn(),
         offsetReset,
+        dataSource.getName(),
         alias
     );
 
@@ -210,10 +201,8 @@ public final class SchemaKSourceFactory {
     final TableSource step = ExecutionStepFactory.tableSource(
         contextStacker,
         schemaWithMetaAndKeyFields,
-        dataSource.getKafkaTopicName(),
-        buildFormats(dataSource),
-        dataSource.getTimestampColumn(),
         offsetReset,
+        dataSource.getName(),
         alias
     );
 

--- a/ksql-engine/src/test/java/io/confluent/ksql/planner/plan/AggregateNodeTest.java
+++ b/ksql-engine/src/test/java/io/confluent/ksql/planner/plan/AggregateNodeTest.java
@@ -106,6 +106,7 @@ public class AggregateNodeTest {
   private StreamsBuilder builder = new StreamsBuilder();
   private final ProcessingLogContext processingLogContext = ProcessingLogContext.create();
   private final QueryId queryId = new QueryId("queryid");
+  private final MetaStore metaStore = MetaStoreFixture.getNewMetaStore(FUNCTION_REGISTRY);
 
   @Before
   public void setUp() {
@@ -345,14 +346,14 @@ public class AggregateNodeTest {
     when(ksqlStreamBuilder.buildKeySerde(any(), any(), any())).thenReturn(keySerde);
 
     final SchemaKTable schemaKTable = (SchemaKTable) aggregateNode.buildStream(ksqlStreamBuilder);
-    schemaKTable.getSourceTableStep().build(new KSPlanBuilder(ksqlStreamBuilder));
+    schemaKTable.getSourceTableStep().build(
+        new KSPlanBuilder(metaStore, ksqlStreamBuilder));
     return schemaKTable;
   }
 
-  private static AggregateNode buildAggregateNode(final String queryString) {
-    final MetaStore newMetaStore = MetaStoreFixture.getNewMetaStore(new InternalFunctionRegistry());
+  private AggregateNode buildAggregateNode(final String queryString) {
     final KsqlBareOutputNode planNode = (KsqlBareOutputNode) AnalysisTestUtil
-        .buildLogicalPlan(KSQL_CONFIG, queryString, newMetaStore);
+        .buildLogicalPlan(KSQL_CONFIG, queryString, metaStore);
 
     return (AggregateNode) planNode.getSource();
   }

--- a/ksql-engine/src/test/java/io/confluent/ksql/planner/plan/DataSourceNodeTest.java
+++ b/ksql-engine/src/test/java/io/confluent/ksql/planner/plan/DataSourceNodeTest.java
@@ -38,6 +38,7 @@ import io.confluent.ksql.execution.plan.StreamSource;
 import io.confluent.ksql.execution.streams.KSPlanBuilder;
 import io.confluent.ksql.execution.timestamp.TimestampColumn;
 import io.confluent.ksql.function.FunctionRegistry;
+import io.confluent.ksql.metastore.MetaStore;
 import io.confluent.ksql.metastore.model.DataSource;
 import io.confluent.ksql.metastore.model.KeyField;
 import io.confluent.ksql.metastore.model.KsqlStream;
@@ -132,6 +133,8 @@ public class DataSourceNodeTest {
   @Mock
   private DataSource<?> dataSource;
   @Mock
+  private MetaStore metaStore;
+  @Mock
   private Serde<GenericRow> rowSerde;
   @Mock
   private KeySerde<String> keySerde;
@@ -172,6 +175,7 @@ public class DataSourceNodeTest {
             .getDataSourceType() == DataSourceType.KSTREAM
             ? stream : table
         );
+    when(metaStore.getSource(SourceName.of("datasource"))).thenReturn((DataSource) SOME_SOURCE);
   }
 
   @Test
@@ -367,9 +371,9 @@ public class DataSourceNodeTest {
     final SchemaKStream stream = node.buildStream(ksqlStreamBuilder);
     if (stream instanceof SchemaKTable) {
       final SchemaKTable table = (SchemaKTable) stream;
-      table.getSourceTableStep().build(new KSPlanBuilder(ksqlStreamBuilder));
+      table.getSourceTableStep().build(new KSPlanBuilder(metaStore, ksqlStreamBuilder));
     } else {
-      stream.getSourceStep().build(new KSPlanBuilder(ksqlStreamBuilder));
+      stream.getSourceStep().build(new KSPlanBuilder(metaStore, ksqlStreamBuilder));
     }
     return stream;
   }

--- a/ksql-engine/src/test/java/io/confluent/ksql/planner/plan/JoinNodeTest.java
+++ b/ksql-engine/src/test/java/io/confluent/ksql/planner/plan/JoinNodeTest.java
@@ -967,19 +967,18 @@ public class JoinNodeTest {
   }
 
   private void buildJoin(final String queryString) {
-    buildJoinNode(queryString);
+    final MetaStore metaStore = MetaStoreFixture.getNewMetaStore(new InternalFunctionRegistry());
+    buildJoinNode(metaStore, queryString);
     final SchemaKStream stream = joinNode.buildStream(ksqlStreamBuilder);
     if (stream instanceof SchemaKTable) {
       final SchemaKTable table = (SchemaKTable) stream;
-      table.getSourceTableStep().build(new KSPlanBuilder(ksqlStreamBuilder));
+      table.getSourceTableStep().build(new KSPlanBuilder(metaStore, ksqlStreamBuilder));
     } else {
-      stream.getSourceStep().build(new KSPlanBuilder(ksqlStreamBuilder));
+      stream.getSourceStep().build(new KSPlanBuilder(metaStore, ksqlStreamBuilder));
     }
   }
 
-  private void buildJoinNode(final String queryString) {
-    final MetaStore metaStore = MetaStoreFixture.getNewMetaStore(new InternalFunctionRegistry());
-
+  private void buildJoinNode(final MetaStore metaStore, final String queryString) {
     final KsqlBareOutputNode planNode =
         (KsqlBareOutputNode) AnalysisTestUtil.buildLogicalPlan(ksqlConfig, queryString, metaStore);
 

--- a/ksql-engine/src/test/java/io/confluent/ksql/planner/plan/KsqlBareOutputNodeTest.java
+++ b/ksql-engine/src/test/java/io/confluent/ksql/planner/plan/KsqlBareOutputNodeTest.java
@@ -98,7 +98,7 @@ public class KsqlBareOutputNodeTest {
         .buildLogicalPlan(ksqlConfig, SIMPLE_SELECT_WITH_FILTER, metaStore);
 
     stream = planNode.buildStream(ksqlStreamBuilder);
-    stream.getSourceStep().build(new KSPlanBuilder(ksqlStreamBuilder));
+    stream.getSourceStep().build(new KSPlanBuilder(metaStore, ksqlStreamBuilder));
   }
 
   @Test

--- a/ksql-engine/src/test/java/io/confluent/ksql/query/QueryExecutorTest.java
+++ b/ksql-engine/src/test/java/io/confluent/ksql/query/QueryExecutorTest.java
@@ -30,6 +30,7 @@ import io.confluent.ksql.function.FunctionRegistry;
 import io.confluent.ksql.logging.processing.ProcessingLogContext;
 import io.confluent.ksql.logging.processing.ProcessingLogger;
 import io.confluent.ksql.logging.processing.ProcessingLoggerFactory;
+import io.confluent.ksql.metastore.MetaStore;
 import io.confluent.ksql.metastore.model.DataSource;
 import io.confluent.ksql.metastore.model.DataSource.DataSourceType;
 import io.confluent.ksql.metrics.ConsumerCollector;
@@ -131,7 +132,7 @@ public class QueryExecutorTest {
   @Mock
   private StreamsBuilder streamsBuilder;
   @Mock
-  private FunctionRegistry functionRegistry;
+  private MetaStore metaStore;
   @Mock
   private KafkaStreams kafkaStreams;
   @Mock
@@ -185,7 +186,7 @@ public class QueryExecutorTest {
         OVERRIDES,
         processingLogContext,
         serviceContext,
-        functionRegistry,
+        metaStore,
         closeCallback,
         kafkaStreamsBuilder,
         streamsBuilder,

--- a/ksql-engine/src/test/java/io/confluent/ksql/structured/SchemaKSourceFactoryTest.java
+++ b/ksql-engine/src/test/java/io/confluent/ksql/structured/SchemaKSourceFactoryTest.java
@@ -23,7 +23,6 @@ import static org.hamcrest.Matchers.not;
 import static org.mockito.Mockito.when;
 
 import com.google.common.collect.ImmutableMap;
-import com.google.common.collect.ImmutableSet;
 import io.confluent.ksql.execution.builder.KsqlQueryBuilder;
 import io.confluent.ksql.execution.context.QueryContext;
 import io.confluent.ksql.execution.context.QueryContext.Stacker;
@@ -39,14 +38,10 @@ import io.confluent.ksql.metastore.model.DataSource.DataSourceType;
 import io.confluent.ksql.metastore.model.KeyField;
 import io.confluent.ksql.name.SourceName;
 import io.confluent.ksql.schema.ksql.LogicalSchema;
-import io.confluent.ksql.serde.FormatInfo;
 import io.confluent.ksql.serde.KeyFormat;
-import io.confluent.ksql.serde.SerdeOption;
-import io.confluent.ksql.serde.ValueFormat;
 import io.confluent.ksql.serde.WindowInfo;
 import io.confluent.ksql.util.KsqlConfig;
 import java.util.Optional;
-import java.util.Set;
 import org.apache.kafka.streams.Topology.AutoOffsetReset;
 import org.junit.Before;
 import org.junit.Test;
@@ -60,10 +55,8 @@ public class SchemaKSourceFactoryTest {
   private static final Optional<AutoOffsetReset> OFFSET_RESET = Optional.of(
       AutoOffsetReset.EARLIEST);
   private static final KeyField KEY_FIELD = KeyField.none();
+  private static final SourceName SOURCE = SourceName.of("alice");
   private static final SourceName ALIAS = SourceName.of("bob");
-  private static final Set<SerdeOption> SERDE_OPTIONS = ImmutableSet
-      .of(SerdeOption.UNWRAP_SINGLE_VALUES);
-  private static final String TOPIC_NAME = "fred";
   private static final KsqlConfig CONFIG = new KsqlConfig(ImmutableMap.of());
 
   @Mock
@@ -75,8 +68,6 @@ public class SchemaKSourceFactoryTest {
   @Mock
   private LogicalSchema schema;
   @Mock
-  private LogicalSchema originalSchema;
-  @Mock
   private Stacker contextStacker;
   @Mock
   private QueryContext queryContext;
@@ -85,35 +76,24 @@ public class SchemaKSourceFactoryTest {
   @Mock
   private KeyFormat keyFormat;
   @Mock
-  private FormatInfo keyFormatInfo;
-  @Mock
-  private ValueFormat valueFormat;
-  @Mock
-  private FormatInfo valueFormatInfo;
-  @Mock
   private FunctionRegistry functionRegistry;
   @Mock
   private WindowInfo windowInfo;
 
   @Before
   public void setUp() {
-    when(dataSource.getSerdeOptions()).thenReturn(SERDE_OPTIONS);
     when(dataSource.getKsqlTopic()).thenReturn(topic);
-    when(dataSource.getKafkaTopicName()).thenReturn(TOPIC_NAME);
+    when(dataSource.getName()).thenReturn(SOURCE);
 
     when(topic.getKeyFormat()).thenReturn(keyFormat);
-    when(topic.getValueFormat()).thenReturn(valueFormat);
 
     when(schemaWithStuff.getSchema()).thenReturn(schema);
-    when(schemaWithStuff.getOriginalSchema()).thenReturn(originalSchema);
 
     when(contextStacker.getQueryContext()).thenReturn(queryContext);
 
     when(builder.getKsqlConfig()).thenReturn(CONFIG);
     when(builder.getFunctionRegistry()).thenReturn(functionRegistry);
 
-    when(keyFormat.getFormatInfo()).thenReturn(keyFormatInfo);
-    when(valueFormat.getFormatInfo()).thenReturn(valueFormatInfo);
   }
 
   @Test

--- a/ksql-engine/src/test/java/io/confluent/ksql/structured/SchemaKTableTest.java
+++ b/ksql-engine/src/test/java/io/confluent/ksql/structured/SchemaKTableTest.java
@@ -187,6 +187,7 @@ public class SchemaKTableTest {
     when(queryBuilder.getKsqlConfig()).thenReturn(ksqlConfig);
     when(queryBuilder.getFunctionRegistry()).thenReturn(functionRegistry);
     planBuilder = new KSPlanBuilder(
+        metaStore,
         queryBuilder,
         mock(SqlPredicateFactory.class),
         mock(AggregateParamsFactory.class),

--- a/ksql-execution/src/main/java/io/confluent/ksql/execution/plan/AbstractStreamSource.java
+++ b/ksql-execution/src/main/java/io/confluent/ksql/execution/plan/AbstractStreamSource.java
@@ -17,7 +17,6 @@ package io.confluent.ksql.execution.plan;
 
 import com.google.common.annotations.VisibleForTesting;
 import com.google.errorprone.annotations.Immutable;
-import io.confluent.ksql.execution.timestamp.TimestampColumn;
 import io.confluent.ksql.name.SourceName;
 import io.confluent.ksql.schema.ksql.LogicalSchema;
 import java.util.Collections;
@@ -29,11 +28,8 @@ import org.apache.kafka.streams.Topology.AutoOffsetReset;
 @Immutable
 public abstract class AbstractStreamSource<K> implements ExecutionStep<K> {
   private final ExecutionStepProperties properties;
-  private final String topicName;
-  private final Formats formats;
-  private final Optional<TimestampColumn> timestampColumn;
   private final Optional<AutoOffsetReset> offsetReset;
-  private final LogicalSchema sourceSchema;
+  private final SourceName sourceName;
   private final SourceName alias;
 
   public static LogicalSchemaWithMetaAndKeyFields getSchemaWithMetaAndKeyFields(
@@ -45,18 +41,12 @@ public abstract class AbstractStreamSource<K> implements ExecutionStep<K> {
   @VisibleForTesting
   public AbstractStreamSource(
       ExecutionStepProperties properties,
-      String topicName,
-      Formats formats,
-      Optional<TimestampColumn> timestampColumn,
       Optional<AutoOffsetReset> offsetReset,
-      LogicalSchema sourceSchema,
+      SourceName sourceName,
       SourceName alias) {
     this.properties = Objects.requireNonNull(properties, "properties");
-    this.topicName = Objects.requireNonNull(topicName, "topicName");
-    this.formats = Objects.requireNonNull(formats, "formats");
-    this.timestampColumn = Objects.requireNonNull(timestampColumn, "timestampColumn");
     this.offsetReset = Objects.requireNonNull(offsetReset, "offsetReset");
-    this.sourceSchema = Objects.requireNonNull(sourceSchema, "sourceSchema");
+    this.sourceName = Objects.requireNonNull(sourceName, "sourceName");
     this.alias = Objects.requireNonNull(alias, "alias");
   }
 
@@ -70,28 +60,16 @@ public abstract class AbstractStreamSource<K> implements ExecutionStep<K> {
     return Collections.emptyList();
   }
 
-  public LogicalSchema getSourceSchema() {
-    return sourceSchema;
-  }
-
   public Optional<AutoOffsetReset> getOffsetReset() {
     return offsetReset;
   }
 
-  public Optional<TimestampColumn> getTimestampColumn() {
-    return timestampColumn;
-  }
-
-  public Formats getFormats() {
-    return formats;
-  }
-
-  public String getTopicName() {
-    return topicName;
-  }
-
   public SourceName getAlias() {
     return alias;
+  }
+
+  public SourceName getSourceName() {
+    return sourceName;
   }
 
   @Override
@@ -104,22 +82,18 @@ public abstract class AbstractStreamSource<K> implements ExecutionStep<K> {
     }
     AbstractStreamSource that = (AbstractStreamSource) o;
     return Objects.equals(properties, that.properties)
-        && Objects.equals(topicName, that.topicName)
-        && Objects.equals(formats, that.formats)
-        && Objects.equals(timestampColumn, that.timestampColumn)
         && Objects.equals(offsetReset, that.offsetReset)
-        && Objects.equals(sourceSchema, that.sourceSchema);
+        && Objects.equals(sourceName, that.sourceName)
+        && Objects.equals(alias, that.alias);
   }
 
   @Override
   public int hashCode() {
     return Objects.hash(
         properties,
-        topicName,
-        formats,
-        timestampColumn,
         offsetReset,
-        sourceSchema
+        sourceName,
+        alias
     );
   }
 }

--- a/ksql-execution/src/main/java/io/confluent/ksql/execution/plan/StreamSource.java
+++ b/ksql-execution/src/main/java/io/confluent/ksql/execution/plan/StreamSource.java
@@ -16,9 +16,7 @@ package io.confluent.ksql.execution.plan;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.google.errorprone.annotations.Immutable;
-import io.confluent.ksql.execution.timestamp.TimestampColumn;
 import io.confluent.ksql.name.SourceName;
-import io.confluent.ksql.schema.ksql.LogicalSchema;
 import java.util.Optional;
 import org.apache.kafka.connect.data.Struct;
 import org.apache.kafka.streams.Topology.AutoOffsetReset;
@@ -27,21 +25,10 @@ import org.apache.kafka.streams.Topology.AutoOffsetReset;
 public final class StreamSource extends AbstractStreamSource<KStreamHolder<Struct>> {
   public StreamSource(
       @JsonProperty(value = "properties", required = true) ExecutionStepProperties properties,
-      @JsonProperty(value = "topicName", required = true) String topicName,
-      @JsonProperty(value = "formats", required = true) Formats formats,
-      @JsonProperty("timestampColumn") Optional<TimestampColumn> timestampColumn,
       @JsonProperty("offsetReset") Optional<AutoOffsetReset> offsetReset,
-      @JsonProperty(value = "sourceSchema", required = true) LogicalSchema sourceSchema,
+      @JsonProperty(value = "sourceName", required = true) SourceName sourceName,
       @JsonProperty(value = "alias", required = true) SourceName alias) {
-    super(
-        properties,
-        topicName,
-        formats,
-        timestampColumn,
-        offsetReset,
-        sourceSchema,
-        alias
-    );
+    super(properties, offsetReset, sourceName, alias);
   }
 
   @Override

--- a/ksql-execution/src/main/java/io/confluent/ksql/execution/plan/TableSource.java
+++ b/ksql-execution/src/main/java/io/confluent/ksql/execution/plan/TableSource.java
@@ -17,9 +17,7 @@ package io.confluent.ksql.execution.plan;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.google.errorprone.annotations.Immutable;
-import io.confluent.ksql.execution.timestamp.TimestampColumn;
 import io.confluent.ksql.name.SourceName;
-import io.confluent.ksql.schema.ksql.LogicalSchema;
 import java.util.Optional;
 import org.apache.kafka.connect.data.Struct;
 import org.apache.kafka.streams.Topology.AutoOffsetReset;
@@ -29,22 +27,11 @@ public final class TableSource extends AbstractStreamSource<KTableHolder<Struct>
 
   public TableSource(
       @JsonProperty(value = "properties", required = true) final ExecutionStepProperties properties,
-      @JsonProperty(value = "topicName", required = true) final String topicName,
-      @JsonProperty(value = "formats", required = true) final Formats formats,
-      @JsonProperty("timestampColumn") final Optional<TimestampColumn> timestampColumn,
       @JsonProperty("offsetReset") final Optional<AutoOffsetReset> offsetReset,
-      @JsonProperty(value = "sourceSchema", required = true) final LogicalSchema sourceSchema,
+      @JsonProperty(value = "sourceName", required = true) SourceName sourceName,
       @JsonProperty(value = "alias", required = true) final SourceName alias
   ) {
-    super(
-        properties,
-        topicName,
-        formats,
-        timestampColumn,
-        offsetReset,
-        sourceSchema,
-        alias
-    );
+    super(properties, offsetReset, sourceName, alias);
   }
 
   @Override

--- a/ksql-execution/src/main/java/io/confluent/ksql/execution/plan/WindowedStreamSource.java
+++ b/ksql-execution/src/main/java/io/confluent/ksql/execution/plan/WindowedStreamSource.java
@@ -17,11 +17,7 @@ package io.confluent.ksql.execution.plan;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.google.errorprone.annotations.Immutable;
-import io.confluent.ksql.execution.timestamp.TimestampColumn;
 import io.confluent.ksql.name.SourceName;
-import io.confluent.ksql.schema.ksql.LogicalSchema;
-import io.confluent.ksql.serde.WindowInfo;
-import java.util.Objects;
 import java.util.Optional;
 import org.apache.kafka.connect.data.Struct;
 import org.apache.kafka.streams.Topology.AutoOffsetReset;
@@ -31,31 +27,12 @@ import org.apache.kafka.streams.kstream.Windowed;
 public final class WindowedStreamSource
     extends AbstractStreamSource<KStreamHolder<Windowed<Struct>>> {
 
-  private final WindowInfo windowInfo;
-
   public WindowedStreamSource(
       @JsonProperty(value = "properties", required = true) ExecutionStepProperties properties,
-      @JsonProperty(value = "topicName", required = true) String topicName,
-      @JsonProperty(value = "formats", required = true) Formats formats,
-      @JsonProperty(value = "windowInfo", required = true) WindowInfo windowInfo,
-      @JsonProperty("timestampColumn") Optional<TimestampColumn> timestampColumn,
       @JsonProperty("offsetReset") Optional<AutoOffsetReset> offsetReset,
-      @JsonProperty(value = "sourceSchema", required = true) LogicalSchema sourceSchema,
+      @JsonProperty(value = "sourceName", required = true) SourceName sourceName,
       @JsonProperty(value = "alias", required = true) SourceName alias) {
-    super(
-        properties,
-        topicName,
-        formats,
-        timestampColumn,
-        offsetReset,
-        sourceSchema,
-        alias
-    );
-    this.windowInfo = Objects.requireNonNull(windowInfo, "windowInfo");
-  }
-
-  public WindowInfo getWindowInfo() {
-    return windowInfo;
+    super(properties, offsetReset, sourceName, alias);
   }
 
   @Override

--- a/ksql-execution/src/main/java/io/confluent/ksql/execution/plan/WindowedTableSource.java
+++ b/ksql-execution/src/main/java/io/confluent/ksql/execution/plan/WindowedTableSource.java
@@ -16,11 +16,7 @@
 package io.confluent.ksql.execution.plan;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
-import io.confluent.ksql.execution.timestamp.TimestampColumn;
 import io.confluent.ksql.name.SourceName;
-import io.confluent.ksql.schema.ksql.LogicalSchema;
-import io.confluent.ksql.serde.WindowInfo;
-import java.util.Objects;
 import java.util.Optional;
 import org.apache.kafka.connect.data.Struct;
 import org.apache.kafka.streams.Topology.AutoOffsetReset;
@@ -29,32 +25,13 @@ import org.apache.kafka.streams.kstream.Windowed;
 public final class WindowedTableSource
     extends AbstractStreamSource<KTableHolder<Windowed<Struct>>> {
 
-  private final WindowInfo windowInfo;
-
   public WindowedTableSource(
       @JsonProperty(value = "properties", required = true) ExecutionStepProperties properties,
-      @JsonProperty(value = "topicName", required = true) String topicName,
-      @JsonProperty(value = "formats", required = true) Formats formats,
-      @JsonProperty(value = "windowInfo", required = true) WindowInfo windowInfo,
-      @JsonProperty("timestampColumn") final Optional<TimestampColumn> timestampColumn,
       @JsonProperty("offsetReset") final Optional<AutoOffsetReset> offsetReset,
-      @JsonProperty(value = "sourceSchema", required = true) LogicalSchema sourceSchema,
+      @JsonProperty(value = "sourceName", required = true) SourceName sourceName,
       @JsonProperty(value = "alias", required = true) SourceName alias
   ) {
-    super(
-        properties,
-        topicName,
-        formats,
-        timestampColumn,
-        offsetReset,
-        sourceSchema,
-        alias
-    );
-    this.windowInfo = Objects.requireNonNull(windowInfo, "windowInfo");
-  }
-
-  public WindowInfo getWindowInfo() {
-    return windowInfo;
+    super(properties, offsetReset, sourceName, alias);
   }
 
   @Override

--- a/ksql-streams/pom.xml
+++ b/ksql-streams/pom.xml
@@ -44,6 +44,11 @@
         </dependency>
 
         <dependency>
+            <groupId>io.confluent.ksql</groupId>
+            <artifactId>ksql-metastore</artifactId>
+        </dependency>
+
+        <dependency>
             <groupId>org.apache.kafka</groupId>
             <artifactId>connect-api</artifactId>
         </dependency>

--- a/ksql-streams/src/main/java/io/confluent/ksql/execution/streams/ExecutionStepFactory.java
+++ b/ksql-streams/src/main/java/io/confluent/ksql/execution/streams/ExecutionStepFactory.java
@@ -49,13 +49,11 @@ import io.confluent.ksql.execution.plan.TableSource;
 import io.confluent.ksql.execution.plan.TableTableJoin;
 import io.confluent.ksql.execution.plan.WindowedStreamSource;
 import io.confluent.ksql.execution.plan.WindowedTableSource;
-import io.confluent.ksql.execution.timestamp.TimestampColumn;
 import io.confluent.ksql.execution.windows.KsqlWindowExpression;
 import io.confluent.ksql.function.FunctionRegistry;
 import io.confluent.ksql.name.SourceName;
 import io.confluent.ksql.schema.ksql.ColumnRef;
 import io.confluent.ksql.schema.ksql.LogicalSchema;
-import io.confluent.ksql.serde.WindowInfo;
 import java.time.Duration;
 import java.util.List;
 import java.util.Optional;
@@ -73,11 +71,8 @@ public final class ExecutionStepFactory {
   public static WindowedStreamSource streamSourceWindowed(
       final QueryContext.Stacker stacker,
       final LogicalSchemaWithMetaAndKeyFields schema,
-      final String topicName,
-      final Formats formats,
-      final WindowInfo windowInfo,
-      final Optional<TimestampColumn> timestampColumn,
       final Optional<AutoOffsetReset> offsetReset,
+      final SourceName sourceName,
       final SourceName alias
   ) {
     final QueryContext queryContext = stacker.getQueryContext();
@@ -85,12 +80,8 @@ public final class ExecutionStepFactory {
         new DefaultExecutionStepProperties(
             schema.getSchema(),
             queryContext),
-        topicName,
-        formats,
-        windowInfo,
-        timestampColumn,
         offsetReset,
-        schema.getOriginalSchema(),
+        sourceName,
         alias
     );
   }
@@ -98,10 +89,8 @@ public final class ExecutionStepFactory {
   public static StreamSource streamSource(
       final QueryContext.Stacker stacker,
       final LogicalSchemaWithMetaAndKeyFields schema,
-      final String topicName,
-      final Formats formats,
-      final Optional<TimestampColumn> timestampColumn,
       final Optional<AutoOffsetReset> offsetReset,
+      final SourceName sourceName,
       final SourceName alias
   ) {
     final QueryContext queryContext = stacker.getQueryContext();
@@ -109,11 +98,8 @@ public final class ExecutionStepFactory {
         new DefaultExecutionStepProperties(
             schema.getSchema(),
             queryContext),
-        topicName,
-        formats,
-        timestampColumn,
         offsetReset,
-        schema.getOriginalSchema(),
+        sourceName,
         alias
     );
   }
@@ -121,10 +107,8 @@ public final class ExecutionStepFactory {
   public static TableSource tableSource(
       final QueryContext.Stacker stacker,
       final LogicalSchemaWithMetaAndKeyFields schema,
-      final String topicName,
-      final Formats formats,
-      final Optional<TimestampColumn> timestampColumn,
       final Optional<AutoOffsetReset> offsetReset,
+      final SourceName sourceName,
       final SourceName alias
   ) {
     final QueryContext queryContext = stacker.getQueryContext();
@@ -132,11 +116,8 @@ public final class ExecutionStepFactory {
         new DefaultExecutionStepProperties(
             schema.getSchema(),
             queryContext),
-        topicName,
-        formats,
-        timestampColumn,
         offsetReset,
-        schema.getOriginalSchema(),
+        sourceName,
         alias
     );
   }
@@ -144,11 +125,8 @@ public final class ExecutionStepFactory {
   public static WindowedTableSource tableSourceWindowed(
       final QueryContext.Stacker stacker,
       final LogicalSchemaWithMetaAndKeyFields schema,
-      final String topicName,
-      final Formats formats,
-      final WindowInfo windowInfo,
-      final Optional<TimestampColumn> timestampColumn,
       final Optional<AutoOffsetReset> offsetReset,
+      final SourceName sourceName,
       final SourceName alias
   ) {
     final QueryContext queryContext = stacker.getQueryContext();
@@ -156,12 +134,8 @@ public final class ExecutionStepFactory {
         new DefaultExecutionStepProperties(
             schema.getSchema(),
             queryContext),
-        topicName,
-        formats,
-        windowInfo,
-        timestampColumn,
         offsetReset,
-        schema.getOriginalSchema(),
+        sourceName,
         alias
     );
   }

--- a/ksql-streams/src/test/java/io/confluent/ksql/execution/streams/StreamAggregateBuilderTest.java
+++ b/ksql-streams/src/test/java/io/confluent/ksql/execution/streams/StreamAggregateBuilderTest.java
@@ -52,6 +52,7 @@ import io.confluent.ksql.execution.windows.HoppingWindowExpression;
 import io.confluent.ksql.execution.windows.SessionWindowExpression;
 import io.confluent.ksql.execution.windows.TumblingWindowExpression;
 import io.confluent.ksql.function.FunctionRegistry;
+import io.confluent.ksql.metastore.MetaStore;
 import io.confluent.ksql.name.ColumnName;
 import io.confluent.ksql.name.FunctionName;
 import io.confluent.ksql.schema.ksql.ColumnRef;
@@ -202,6 +203,7 @@ public class StreamAggregateBuilderTest {
     when(aggregateParams.getWindowSelectMapper()).thenReturn(windowSelectMapper);
     when(windowSelectMapper.hasSelects()).thenReturn(false);
     planBuilder = new KSPlanBuilder(
+        mock(MetaStore.class),
         queryBuilder,
         mock(SqlPredicateFactory.class),
         aggregateParamsFactory,

--- a/ksql-streams/src/test/java/io/confluent/ksql/execution/streams/StreamFilterBuilderTest.java
+++ b/ksql-streams/src/test/java/io/confluent/ksql/execution/streams/StreamFilterBuilderTest.java
@@ -23,6 +23,7 @@ import io.confluent.ksql.function.FunctionRegistry;
 import io.confluent.ksql.logging.processing.ProcessingLogContext;
 import io.confluent.ksql.logging.processing.ProcessingLogger;
 import io.confluent.ksql.logging.processing.ProcessingLoggerFactory;
+import io.confluent.ksql.metastore.MetaStore;
 import io.confluent.ksql.query.QueryId;
 import io.confluent.ksql.schema.ksql.LogicalSchema;
 import io.confluent.ksql.util.KsqlConfig;
@@ -103,6 +104,7 @@ public class StreamFilterBuilderTest {
         queryContext
     );
     planBuilder = new KSPlanBuilder(
+        mock(MetaStore.class),
         queryBuilder,
         predicateFactory,
         mock(AggregateParamsFactory.class),

--- a/ksql-streams/src/test/java/io/confluent/ksql/execution/streams/StreamGroupByBuilderTest.java
+++ b/ksql-streams/src/test/java/io/confluent/ksql/execution/streams/StreamGroupByBuilderTest.java
@@ -29,6 +29,7 @@ import io.confluent.ksql.execution.plan.StreamGroupBy;
 import io.confluent.ksql.execution.plan.StreamGroupByKey;
 import io.confluent.ksql.execution.util.StructKeyUtil;
 import io.confluent.ksql.function.FunctionRegistry;
+import io.confluent.ksql.metastore.MetaStore;
 import io.confluent.ksql.name.ColumnName;
 import io.confluent.ksql.name.SourceName;
 import io.confluent.ksql.schema.ksql.ColumnRef;
@@ -144,6 +145,7 @@ public class StreamGroupByBuilderTest {
         GROUP_BY_EXPRESSIONS
     );
     planBuilder = new KSPlanBuilder(
+        mock(MetaStore.class),
         queryBuilder,
         mock(SqlPredicateFactory.class),
         mock(AggregateParamsFactory.class),

--- a/ksql-streams/src/test/java/io/confluent/ksql/execution/streams/StreamMapValuesBuilderTest.java
+++ b/ksql-streams/src/test/java/io/confluent/ksql/execution/streams/StreamMapValuesBuilderTest.java
@@ -40,6 +40,7 @@ import io.confluent.ksql.function.FunctionRegistry;
 import io.confluent.ksql.logging.processing.ProcessingLogContext;
 import io.confluent.ksql.logging.processing.ProcessingLogger;
 import io.confluent.ksql.logging.processing.ProcessingLoggerFactory;
+import io.confluent.ksql.metastore.MetaStore;
 import io.confluent.ksql.name.ColumnName;
 import io.confluent.ksql.name.SourceName;
 import io.confluent.ksql.query.QueryId;
@@ -140,6 +141,7 @@ public class StreamMapValuesBuilderTest {
         SELECT_STEP_NAME
     );
     planBuilder = new KSPlanBuilder(
+        mock(MetaStore.class),
         queryBuilder,
         mock(SqlPredicateFactory.class),
         mock(AggregateParamsFactory.class),

--- a/ksql-streams/src/test/java/io/confluent/ksql/execution/streams/StreamSelectKeyBuilderTest.java
+++ b/ksql-streams/src/test/java/io/confluent/ksql/execution/streams/StreamSelectKeyBuilderTest.java
@@ -34,6 +34,7 @@ import io.confluent.ksql.execution.plan.KStreamHolder;
 import io.confluent.ksql.execution.plan.KeySerdeFactory;
 import io.confluent.ksql.execution.plan.PlanBuilder;
 import io.confluent.ksql.execution.plan.StreamSelectKey;
+import io.confluent.ksql.metastore.MetaStore;
 import io.confluent.ksql.name.ColumnName;
 import io.confluent.ksql.name.SourceName;
 import io.confluent.ksql.query.QueryId;
@@ -113,6 +114,7 @@ public class StreamSelectKeyBuilderTest {
     when(sourceStep.build(any())).thenReturn(
         new KStreamHolder<>(kstream, SCHEMA, mock(KeySerdeFactory.class)));
     planBuilder = new KSPlanBuilder(
+        mock(MetaStore.class),
         queryBuilder,
         mock(SqlPredicateFactory.class),
         mock(AggregateParamsFactory.class),

--- a/ksql-streams/src/test/java/io/confluent/ksql/execution/streams/StreamSinkBuilderTest.java
+++ b/ksql-streams/src/test/java/io/confluent/ksql/execution/streams/StreamSinkBuilderTest.java
@@ -37,6 +37,7 @@ import io.confluent.ksql.execution.plan.KStreamHolder;
 import io.confluent.ksql.execution.plan.KeySerdeFactory;
 import io.confluent.ksql.execution.plan.PlanBuilder;
 import io.confluent.ksql.execution.plan.StreamSink;
+import io.confluent.ksql.metastore.MetaStore;
 import io.confluent.ksql.name.ColumnName;
 import io.confluent.ksql.schema.ksql.LogicalSchema;
 import io.confluent.ksql.schema.ksql.PhysicalSchema;
@@ -107,6 +108,7 @@ public class StreamSinkBuilderTest {
         TOPIC
     );
     planBuilder = new KSPlanBuilder(
+        mock(MetaStore.class),
         queryBuilder,
         mock(SqlPredicateFactory.class),
         mock(AggregateParamsFactory.class),

--- a/ksql-streams/src/test/java/io/confluent/ksql/execution/streams/StreamStreamJoinBuilderTest.java
+++ b/ksql-streams/src/test/java/io/confluent/ksql/execution/streams/StreamStreamJoinBuilderTest.java
@@ -23,6 +23,7 @@ import io.confluent.ksql.execution.plan.KStreamHolder;
 import io.confluent.ksql.execution.plan.KeySerdeFactory;
 import io.confluent.ksql.execution.plan.PlanBuilder;
 import io.confluent.ksql.execution.plan.StreamStreamJoin;
+import io.confluent.ksql.metastore.MetaStore;
 import io.confluent.ksql.name.ColumnName;
 import io.confluent.ksql.name.SourceName;
 import io.confluent.ksql.schema.ksql.LogicalSchema;
@@ -131,6 +132,7 @@ public class StreamStreamJoinBuilderTest {
     when(right.build(any())).thenReturn(
         new KStreamHolder<>(rightKStream, RIGHT_SCHEMA, keySerdeFactory));
     planBuilder = new KSPlanBuilder(
+        mock(MetaStore.class),
         queryBuilder,
         mock(SqlPredicateFactory.class),
         mock(AggregateParamsFactory.class),

--- a/ksql-streams/src/test/java/io/confluent/ksql/execution/streams/StreamTableJoinBuilderTest.java
+++ b/ksql-streams/src/test/java/io/confluent/ksql/execution/streams/StreamTableJoinBuilderTest.java
@@ -22,6 +22,7 @@ import io.confluent.ksql.execution.plan.KTableHolder;
 import io.confluent.ksql.execution.plan.KeySerdeFactory;
 import io.confluent.ksql.execution.plan.PlanBuilder;
 import io.confluent.ksql.execution.plan.StreamTableJoin;
+import io.confluent.ksql.metastore.MetaStore;
 import io.confluent.ksql.name.ColumnName;
 import io.confluent.ksql.name.SourceName;
 import io.confluent.ksql.schema.ksql.LogicalSchema;
@@ -120,6 +121,7 @@ public class StreamTableJoinBuilderTest {
     when(right.build(any())).thenReturn(
         KTableHolder.unmaterialized(rightKTable, RIGHT_SCHEMA, keySerdeFactory));
     planBuilder = new KSPlanBuilder(
+        mock(MetaStore.class),
         queryBuilder,
         mock(SqlPredicateFactory.class),
         mock(AggregateParamsFactory.class),

--- a/ksql-streams/src/test/java/io/confluent/ksql/execution/streams/TableAggregateBuilderTest.java
+++ b/ksql-streams/src/test/java/io/confluent/ksql/execution/streams/TableAggregateBuilderTest.java
@@ -46,6 +46,7 @@ import io.confluent.ksql.execution.plan.KTableHolder;
 import io.confluent.ksql.execution.plan.PlanBuilder;
 import io.confluent.ksql.execution.plan.TableAggregate;
 import io.confluent.ksql.function.FunctionRegistry;
+import io.confluent.ksql.metastore.MetaStore;
 import io.confluent.ksql.name.ColumnName;
 import io.confluent.ksql.name.FunctionName;
 import io.confluent.ksql.schema.ksql.ColumnRef;
@@ -171,6 +172,7 @@ public class TableAggregateBuilderTest {
     );
     when(sourceStep.build(any())).thenReturn(KGroupedTableHolder.of(groupedTable, INPUT_SCHEMA));
     planBuilder = new KSPlanBuilder(
+        mock(MetaStore.class),
         queryBuilder,
         mock(SqlPredicateFactory.class),
         aggregateParamsFactory,

--- a/ksql-streams/src/test/java/io/confluent/ksql/execution/streams/TableFilterBuilderTest.java
+++ b/ksql-streams/src/test/java/io/confluent/ksql/execution/streams/TableFilterBuilderTest.java
@@ -26,6 +26,7 @@
  import io.confluent.ksql.logging.processing.ProcessingLogContext;
  import io.confluent.ksql.logging.processing.ProcessingLogger;
  import io.confluent.ksql.logging.processing.ProcessingLoggerFactory;
+ import io.confluent.ksql.metastore.MetaStore;
  import io.confluent.ksql.query.QueryId;
  import io.confluent.ksql.schema.ksql.LogicalSchema;
  import io.confluent.ksql.util.KsqlConfig;
@@ -118,6 +119,7 @@ public class TableFilterBuilderTest {
         KTableHolder.materialized(sourceKTable, schema, keySerdeFactory, materializationBuilder))
     ;
     planBuilder = new KSPlanBuilder(
+        mock(MetaStore.class),
         queryBuilder,
         predicateFactory,
         mock(AggregateParamsFactory.class),

--- a/ksql-streams/src/test/java/io/confluent/ksql/execution/streams/TableGroupByBuilderTest.java
+++ b/ksql-streams/src/test/java/io/confluent/ksql/execution/streams/TableGroupByBuilderTest.java
@@ -29,6 +29,7 @@ import io.confluent.ksql.execution.plan.TableGroupBy;
 import io.confluent.ksql.execution.streams.TableGroupByBuilder.TableKeyValueMapper;
 import io.confluent.ksql.execution.util.StructKeyUtil;
 import io.confluent.ksql.function.FunctionRegistry;
+import io.confluent.ksql.metastore.MetaStore;
 import io.confluent.ksql.name.ColumnName;
 import io.confluent.ksql.name.SourceName;
 import io.confluent.ksql.query.QueryId;
@@ -144,6 +145,7 @@ public class TableGroupByBuilderTest {
         GROUPBY_EXPRESSIONS
     );
     planBuilder = new KSPlanBuilder(
+        mock(MetaStore.class),
         queryBuilder,
         mock(SqlPredicateFactory.class),
         mock(AggregateParamsFactory.class),

--- a/ksql-streams/src/test/java/io/confluent/ksql/execution/streams/TableSinkBuilderTest.java
+++ b/ksql-streams/src/test/java/io/confluent/ksql/execution/streams/TableSinkBuilderTest.java
@@ -37,6 +37,7 @@ import io.confluent.ksql.execution.plan.KTableHolder;
 import io.confluent.ksql.execution.plan.KeySerdeFactory;
 import io.confluent.ksql.execution.plan.PlanBuilder;
 import io.confluent.ksql.execution.plan.TableSink;
+import io.confluent.ksql.metastore.MetaStore;
 import io.confluent.ksql.name.ColumnName;
 import io.confluent.ksql.schema.ksql.LogicalSchema;
 import io.confluent.ksql.schema.ksql.PhysicalSchema;
@@ -113,6 +114,7 @@ public class TableSinkBuilderTest {
         TOPIC
     );
     planBuilder = new KSPlanBuilder(
+        mock(MetaStore.class),
         queryBuilder,
         mock(SqlPredicateFactory.class),
         mock(AggregateParamsFactory.class),

--- a/ksql-streams/src/test/java/io/confluent/ksql/execution/streams/TableTableJoinBuilderTest.java
+++ b/ksql-streams/src/test/java/io/confluent/ksql/execution/streams/TableTableJoinBuilderTest.java
@@ -20,6 +20,7 @@ import io.confluent.ksql.execution.plan.KTableHolder;
 import io.confluent.ksql.execution.plan.KeySerdeFactory;
 import io.confluent.ksql.execution.plan.PlanBuilder;
 import io.confluent.ksql.execution.plan.TableTableJoin;
+import io.confluent.ksql.metastore.MetaStore;
 import io.confluent.ksql.name.ColumnName;
 import io.confluent.ksql.name.SourceName;
 import io.confluent.ksql.schema.ksql.LogicalSchema;
@@ -84,6 +85,7 @@ public class TableTableJoinBuilderTest {
     when(right.build(any())).thenReturn(
         KTableHolder.unmaterialized(rightKTable, RIGHT_SCHEMA, keySerdeFactory));
     planBuilder = new KSPlanBuilder(
+        mock(MetaStore.class),
         mock(KsqlQueryBuilder.class),
         mock(SqlPredicateFactory.class),
         mock(AggregateParamsFactory.class),


### PR DESCRIPTION
### Description 
This patch cleans up metastore properties from the source creating
steps (StreamSource, WindowedStreamSource, TableSource, WindowedTableSource).
Instead, we store the source name in the step, and pass in the metastore when
building the streams app from the plan.

Part of the work to get our plans into the schema proposed here:
https://github.com/confluentinc/ksql/pull/3969