### PR TITLE
Clean up query plan schema

### DIFF
--- a/ksql-engine/src/main/java/io/confluent/ksql/engine/EngineExecutor.java
+++ b/ksql-engine/src/main/java/io/confluent/ksql/engine/EngineExecutor.java
@@ -168,7 +168,9 @@ final class EngineExecutor {
       final QueryPlan queryPlan = new QueryPlan(
           getSourceNames(outputNode),
           outputNode.getIntoSourceName(),
-          plans.physicalPlan
+          plans.physicalPlan.getPhysicalPlan(),
+          plans.physicalPlan.getQueryId(),
+          plans.physicalPlan.getPlanSummary()
       );
 
       return KsqlPlan.queryPlanCurrent(
@@ -377,7 +379,6 @@ final class EngineExecutor {
       final QueryPlan queryPlan,
       final String statementText
   ) {
-    final PhysicalPlan physicalPlan = queryPlan.getPhysicalPlan();
     final QueryExecutor executor = engineContext.createQueryExecutor(
         ksqlConfig,
         overriddenProperties,
@@ -386,11 +387,11 @@ final class EngineExecutor {
 
     final PersistentQueryMetadata queryMetadata = executor.buildQuery(
         statementText,
-        physicalPlan.getQueryId(),
+        queryPlan.getQueryId(),
         engineContext.getMetaStore().getSource(queryPlan.getSink()),
         queryPlan.getSources(),
-        physicalPlan.getPhysicalPlan(),
-        physicalPlan.getPlanSummary()
+        queryPlan.getPhysicalPlan(),
+        queryPlan.getPlanSummary()
     );
 
     engineContext.registerQuery(queryMetadata);

--- a/ksql-engine/src/main/java/io/confluent/ksql/engine/QueryPlan.java
+++ b/ksql-engine/src/main/java/io/confluent/ksql/engine/QueryPlan.java
@@ -16,24 +16,31 @@
 package io.confluent.ksql.engine;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
+import io.confluent.ksql.execution.plan.ExecutionStep;
 import io.confluent.ksql.name.SourceName;
-import io.confluent.ksql.physical.PhysicalPlan;
+import io.confluent.ksql.query.QueryId;
 import java.util.Objects;
 import java.util.Set;
 
 public final class QueryPlan  {
   private final Set<SourceName> sources;
   private final SourceName sink;
-  private final PhysicalPlan physicalPlan;
+  private final ExecutionStep<?> physicalPlan;
+  private final QueryId queryId;
+  private final String planSummary;
 
   public QueryPlan(
       @JsonProperty(value = "sources", required = true) final Set<SourceName> sources,
       @JsonProperty(value = "sink", required = true) final SourceName sink,
-      @JsonProperty(value = "physicalPlan", required = true) final PhysicalPlan physicalPlan
+      @JsonProperty(value = "physicalPlan", required = true) final ExecutionStep<?> physicalPlan,
+      @JsonProperty(value = "queryId", required = true) final QueryId queryId,
+      @JsonProperty(value = "planSummary", required = true) final String planSummary
   ) {
     this.sources = Objects.requireNonNull(sources, "sources");
     this.sink = Objects.requireNonNull(sink, "sink");
     this.physicalPlan = Objects.requireNonNull(physicalPlan, "physicalPlan");
+    this.queryId = Objects.requireNonNull(queryId, "queryId");
+    this.planSummary = Objects.requireNonNull(planSummary, "planSummary");
   }
 
   public SourceName getSink() {
@@ -44,7 +51,15 @@ public final class QueryPlan  {
     return sources;
   }
 
-  public PhysicalPlan getPhysicalPlan() {
+  public ExecutionStep<?> getPhysicalPlan() {
     return physicalPlan;
+  }
+
+  public QueryId getQueryId() {
+    return queryId;
+  }
+
+  public String getPlanSummary() {
+    return planSummary;
   }
 }

--- a/ksql-engine/src/main/java/io/confluent/ksql/engine/QueryPlan.java
+++ b/ksql-engine/src/main/java/io/confluent/ksql/engine/QueryPlan.java
@@ -27,20 +27,17 @@ public final class QueryPlan  {
   private final SourceName sink;
   private final ExecutionStep<?> physicalPlan;
   private final QueryId queryId;
-  private final String planSummary;
 
   public QueryPlan(
       @JsonProperty(value = "sources", required = true) final Set<SourceName> sources,
       @JsonProperty(value = "sink", required = true) final SourceName sink,
       @JsonProperty(value = "physicalPlan", required = true) final ExecutionStep<?> physicalPlan,
-      @JsonProperty(value = "queryId", required = true) final QueryId queryId,
-      @JsonProperty(value = "planSummary", required = true) final String planSummary
+      @JsonProperty(value = "queryId", required = true) final QueryId queryId
   ) {
     this.sources = Objects.requireNonNull(sources, "sources");
     this.sink = Objects.requireNonNull(sink, "sink");
     this.physicalPlan = Objects.requireNonNull(physicalPlan, "physicalPlan");
     this.queryId = Objects.requireNonNull(queryId, "queryId");
-    this.planSummary = Objects.requireNonNull(planSummary, "planSummary");
   }
 
   public SourceName getSink() {
@@ -57,9 +54,5 @@ public final class QueryPlan  {
 
   public QueryId getQueryId() {
     return queryId;
-  }
-
-  public String getPlanSummary() {
-    return planSummary;
   }
 }

--- a/ksql-engine/src/main/java/io/confluent/ksql/physical/PhysicalPlan.java
+++ b/ksql-engine/src/main/java/io/confluent/ksql/physical/PhysicalPlan.java
@@ -15,9 +15,7 @@
 
 package io.confluent.ksql.physical;
 
-import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonIgnore;
-import com.fasterxml.jackson.annotation.JsonProperty;
 import com.google.errorprone.annotations.Immutable;
 import io.confluent.ksql.execution.plan.ExecutionStep;
 import io.confluent.ksql.metastore.model.KeyField;
@@ -30,7 +28,7 @@ public final class PhysicalPlan {
   private final QueryId queryId;
   private final ExecutionStep<?> physicalPlan;
   private final String planSummary;
-  private final transient Optional<KeyField> keyField;
+  private final Optional<KeyField> keyField;
 
   PhysicalPlan(
       final QueryId queryId,
@@ -42,15 +40,6 @@ public final class PhysicalPlan {
     this.physicalPlan = Objects.requireNonNull(physicalPlan, "physicalPlan");
     this.planSummary = Objects.requireNonNull(planSummary, "planSummary");
     this.keyField = Objects.requireNonNull(keyField, "keyField");
-  }
-
-  @JsonCreator
-  private PhysicalPlan(
-      @JsonProperty(value = "queryId", required = true) final QueryId queryId,
-      @JsonProperty(value = "physicalPlan", required = true) final ExecutionStep<?> physicalPlan,
-      @JsonProperty(value = "planSummary", required = true) final String planSummary
-  ) {
-    this(queryId, physicalPlan, planSummary, Optional.empty());
   }
 
   public ExecutionStep<?> getPhysicalPlan() {

--- a/ksql-engine/src/main/java/io/confluent/ksql/physical/PhysicalPlan.java
+++ b/ksql-engine/src/main/java/io/confluent/ksql/physical/PhysicalPlan.java
@@ -27,27 +27,20 @@ import java.util.Optional;
 public final class PhysicalPlan {
   private final QueryId queryId;
   private final ExecutionStep<?> physicalPlan;
-  private final String planSummary;
   private final Optional<KeyField> keyField;
 
   PhysicalPlan(
       final QueryId queryId,
       final ExecutionStep<?> physicalPlan,
-      final String planSummary,
       final Optional<KeyField> keyField
   ) {
     this.queryId = Objects.requireNonNull(queryId, "queryId");
     this.physicalPlan = Objects.requireNonNull(physicalPlan, "physicalPlan");
-    this.planSummary = Objects.requireNonNull(planSummary, "planSummary");
     this.keyField = Objects.requireNonNull(keyField, "keyField");
   }
 
   public ExecutionStep<?> getPhysicalPlan() {
     return physicalPlan;
-  }
-
-  public String getPlanSummary() {
-    return planSummary;
   }
 
   @JsonIgnore

--- a/ksql-engine/src/main/java/io/confluent/ksql/physical/PhysicalPlanBuilder.java
+++ b/ksql-engine/src/main/java/io/confluent/ksql/physical/PhysicalPlanBuilder.java
@@ -74,7 +74,6 @@ public class PhysicalPlanBuilder {
     return new PhysicalPlan(
         queryId,
         resultStream.getSourceStep(),
-        resultStream.getExecutionPlan(queryId, ""),
         Optional.of(resultStream.getKeyField())
     );
   }

--- a/ksql-engine/src/main/java/io/confluent/ksql/structured/SchemaKGroupedStream.java
+++ b/ksql-engine/src/main/java/io/confluent/ksql/structured/SchemaKGroupedStream.java
@@ -107,7 +107,6 @@ public class SchemaKGroupedStream {
         keyFormat,
         keyField,
         sourceSchemaKStreams,
-        SchemaKStream.Type.AGGREGATE,
         ksqlConfig,
         functionRegistry
     );

--- a/ksql-engine/src/main/java/io/confluent/ksql/structured/SchemaKGroupedTable.java
+++ b/ksql-engine/src/main/java/io/confluent/ksql/structured/SchemaKGroupedTable.java
@@ -108,7 +108,6 @@ public class SchemaKGroupedTable extends SchemaKGroupedStream {
         keyFormat,
         keyField,
         sourceSchemaKStreams,
-        SchemaKStream.Type.AGGREGATE,
         ksqlConfig,
         functionRegistry
     );

--- a/ksql-engine/src/main/java/io/confluent/ksql/structured/SchemaKSourceFactory.java
+++ b/ksql-engine/src/main/java/io/confluent/ksql/structured/SchemaKSourceFactory.java
@@ -236,7 +236,6 @@ public final class SchemaKSourceFactory {
         keyFormat,
         keyField,
         ImmutableList.of(),
-        SchemaKStream.Type.SOURCE,
         builder.getKsqlConfig(),
         builder.getFunctionRegistry()
     );
@@ -253,7 +252,6 @@ public final class SchemaKSourceFactory {
         keyFormat,
         keyField,
         ImmutableList.of(),
-        SchemaKStream.Type.SOURCE,
         builder.getKsqlConfig(),
         builder.getFunctionRegistry()
     );

--- a/ksql-engine/src/main/java/io/confluent/ksql/structured/SchemaKTable.java
+++ b/ksql-engine/src/main/java/io/confluent/ksql/structured/SchemaKTable.java
@@ -56,7 +56,6 @@ public class SchemaKTable<K> extends SchemaKStream<K> {
       final KeyFormat keyFormat,
       final KeyField keyField,
       final List<SchemaKStream> sourceSchemaKStreams,
-      final Type type,
       final KsqlConfig ksqlConfig,
       final FunctionRegistry functionRegistry
   ) {
@@ -66,7 +65,6 @@ public class SchemaKTable<K> extends SchemaKStream<K> {
         keyFormat,
         keyField,
         sourceSchemaKStreams,
-        type,
         ksqlConfig,
         functionRegistry
     );
@@ -93,7 +91,6 @@ public class SchemaKTable<K> extends SchemaKStream<K> {
         keyFormat,
         keyField,
         sourceSchemaKStreams,
-        type,
         ksqlConfig,
         functionRegistry
     );
@@ -117,7 +114,6 @@ public class SchemaKTable<K> extends SchemaKStream<K> {
         keyFormat,
         keyField,
         Collections.singletonList(this),
-        Type.FILTER,
         ksqlConfig,
         functionRegistry
     );
@@ -144,7 +140,6 @@ public class SchemaKTable<K> extends SchemaKStream<K> {
         keyFormat,
         keyField,
         Collections.singletonList(this),
-        Type.PROJECT,
         ksqlConfig,
         functionRegistry
     );
@@ -206,7 +201,6 @@ public class SchemaKTable<K> extends SchemaKStream<K> {
         keyFormat,
         keyField,
         ImmutableList.of(this, schemaKTable),
-        Type.JOIN,
         ksqlConfig,
         functionRegistry
     );
@@ -230,7 +224,6 @@ public class SchemaKTable<K> extends SchemaKStream<K> {
         keyFormat,
         keyField,
         ImmutableList.of(this, schemaKTable),
-        Type.JOIN,
         ksqlConfig,
         functionRegistry
     );
@@ -254,7 +247,6 @@ public class SchemaKTable<K> extends SchemaKStream<K> {
         keyFormat,
         keyField,
         ImmutableList.of(this, schemaKTable),
-        Type.JOIN,
         ksqlConfig,
         functionRegistry
     );

--- a/ksql-engine/src/main/java/io/confluent/ksql/util/PlanSummary.java
+++ b/ksql-engine/src/main/java/io/confluent/ksql/util/PlanSummary.java
@@ -1,0 +1,152 @@
+/*
+ * Copyright 2019 Confluent Inc.
+ *
+ * Licensed under the Confluent Community License (the "License"); you may not use
+ * this file except in compliance with the License.  You may obtain a copy of the
+ * License at
+ *
+ * http://www.confluent.io/confluent-community-license
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package io.confluent.ksql.util;
+
+import com.google.common.annotations.VisibleForTesting;
+import com.google.common.collect.ImmutableMap;
+import io.confluent.ksql.execution.context.QueryLoggerUtil;
+import io.confluent.ksql.execution.plan.AbstractStreamSource;
+import io.confluent.ksql.execution.plan.ExecutionStep;
+import io.confluent.ksql.execution.plan.StreamAggregate;
+import io.confluent.ksql.execution.plan.StreamFilter;
+import io.confluent.ksql.execution.plan.StreamFlatMap;
+import io.confluent.ksql.execution.plan.StreamGroupBy;
+import io.confluent.ksql.execution.plan.StreamMapValues;
+import io.confluent.ksql.execution.plan.StreamSelectKey;
+import io.confluent.ksql.execution.plan.StreamSink;
+import io.confluent.ksql.execution.plan.StreamSource;
+import io.confluent.ksql.execution.plan.StreamStreamJoin;
+import io.confluent.ksql.execution.plan.StreamTableJoin;
+import io.confluent.ksql.execution.plan.StreamWindowedAggregate;
+import io.confluent.ksql.execution.plan.TableAggregate;
+import io.confluent.ksql.execution.plan.TableFilter;
+import io.confluent.ksql.execution.plan.TableGroupBy;
+import io.confluent.ksql.execution.plan.TableMapValues;
+import io.confluent.ksql.execution.plan.TableSink;
+import io.confluent.ksql.execution.plan.TableSource;
+import io.confluent.ksql.execution.plan.TableTableJoin;
+import io.confluent.ksql.execution.plan.WindowedStreamSource;
+import io.confluent.ksql.execution.plan.WindowedTableSource;
+import io.confluent.ksql.execution.streams.StepSchemaResolver;
+import io.confluent.ksql.metastore.MetaStore;
+import io.confluent.ksql.query.QueryId;
+import io.confluent.ksql.schema.ksql.FormatOptions;
+import io.confluent.ksql.schema.ksql.LogicalSchema;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.stream.Collectors;
+
+/**
+ * Builds a string describing a given execution plan. The string describes the plan DAG,
+ * along with a name, schema, and processing logger ID for each step. Currently, this
+ * description is returned in KSQL's HTTP API in response to EXPLAIN statements.
+ */
+public class PlanSummary {
+  private static final FormatOptions FORMAT_OPTIONS = FormatOptions.of(
+      IdentifierUtil::needsQuotes
+  );
+  private static final Map<Class<? extends ExecutionStep>, String> OP_NAME =
+      new ImmutableMap.Builder<Class<? extends ExecutionStep>, String>()
+          .put(StreamAggregate.class, "AGGREGATE")
+          .put(StreamWindowedAggregate.class, "AGGREGATE")
+          .put(StreamFilter.class, "FILTER")
+          .put(StreamFlatMap.class, "FLAT_MAP")
+          .put(StreamGroupBy.class, "GROUP_BY")
+          .put(StreamMapValues.class, "PROJECT")
+          .put(StreamSelectKey.class, "REKEY")
+          .put(StreamSink.class, "SINK")
+          .put(StreamSource.class, "SOURCE")
+          .put(StreamStreamJoin.class, "JOIN")
+          .put(StreamTableJoin.class, "JOIN")
+          .put(WindowedStreamSource.class, "SOURCE")
+          .put(TableAggregate.class, "AGGREGATE")
+          .put(TableFilter.class, "FILTER")
+          .put(TableGroupBy.class, "GROUP_BY")
+          .put(TableMapValues.class, "PROJECT")
+          .put(TableSink.class, "SINK")
+          .put(TableTableJoin.class, "JOIN")
+          .put(TableSource.class, "SOURCE")
+          .put(WindowedTableSource.class, "SOURCE")
+          .build();
+
+  private final QueryId queryId;
+  private final StepSchemaResolver schemaResolver;
+
+  public PlanSummary(final QueryId queryId, final KsqlConfig config, final MetaStore metaStore) {
+    this(queryId, new StepSchemaResolver(config, metaStore));
+  }
+
+  @VisibleForTesting
+  PlanSummary(final QueryId queryId, final StepSchemaResolver schemaResolver) {
+    this.queryId = Objects.requireNonNull(queryId, "queryId");
+    this.schemaResolver = Objects.requireNonNull(schemaResolver);
+  }
+
+  /**
+   * Summarize an execution plan.
+   * @param step the sink step of the plan.
+   * @return A string describing the given plan.
+   */
+  public String summarize(final ExecutionStep<?> step) {
+    return summarize(step, "").summary;
+  }
+
+  private StepSummary summarize(final ExecutionStep<?> step, final String indent) {
+    final StringBuilder stringBuilder = new StringBuilder();
+    final List<StepSummary> sourceSummaries = step.getSources().stream()
+        .map(s -> summarize(s, indent + "\t"))
+        .collect(Collectors.toList());
+    final LogicalSchema schema = getSchema(step, sourceSummaries);
+    stringBuilder.append(indent)
+        .append(" > [ ")
+        .append(OP_NAME.get(step.getClass())).append(" ] | Schema: ")
+        .append(schema.toString(FORMAT_OPTIONS))
+        .append(" | Logger: ")
+        .append(QueryLoggerUtil.queryLoggerName(queryId, step.getProperties().getQueryContext()))
+        .append("\n");
+    for (final StepSummary sourceSummary : sourceSummaries) {
+      stringBuilder
+          .append("\t")
+          .append(indent)
+          .append(sourceSummary.summary);
+    }
+    return new StepSummary(schema, stringBuilder.toString());
+  }
+
+  private LogicalSchema getSchema(
+      final ExecutionStep<?> step,
+      final List<StepSummary> sourceSummaries) {
+    switch (sourceSummaries.size()) {
+      case 1: return schemaResolver.resolve(step, sourceSummaries.get(0).schema);
+      case 2: return schemaResolver.resolve(
+          step, sourceSummaries.get(0).schema, sourceSummaries.get(1).schema);
+      case 0: break;
+      default: throw new IllegalStateException();
+    }
+    return schemaResolver.resolve(step, ((AbstractStreamSource) step).getSourceSchema());
+  }
+
+  private static final class StepSummary {
+    private final LogicalSchema schema;
+    private final String summary;
+
+    private StepSummary(final LogicalSchema schema, final String summary) {
+      this.schema = Objects.requireNonNull(schema, "schema");
+      this.summary = Objects.requireNonNull(summary, "summary");
+    }
+  }
+}

--- a/ksql-engine/src/test/java/io/confluent/ksql/physical/PhysicalPlanBuilderTest.java
+++ b/ksql-engine/src/test/java/io/confluent/ksql/physical/PhysicalPlanBuilderTest.java
@@ -201,6 +201,7 @@ public class PhysicalPlanBuilderTest {
     final QueryMetadata metadata = executeQuery(queryString);
     final String planText = metadata.getExecutionPlan();
     final String[] lines = planText.split("\n");
+
     assertThat(lines[0], startsWith(
         " > [ PROJECT ] | Schema: [ROWKEY STRING KEY, COL0 BIGINT, KSQL_COL_1 DOUBLE, "
             + "KSQL_COL_2 BIGINT] |"));
@@ -209,15 +210,19 @@ public class PhysicalPlanBuilderTest {
             + "KSQL_INTERNAL_COL_1 DOUBLE, KSQL_AGG_VARIABLE_0 DOUBLE, "
             + "KSQL_AGG_VARIABLE_1 BIGINT] |"));
     assertThat(lines[2], startsWith(
-        "\t\t\t\t > [ PROJECT ] | Schema: [ROWKEY STRING KEY, KSQL_INTERNAL_COL_0 BIGINT, "
-            + "KSQL_INTERNAL_COL_1 DOUBLE] |"));
+        "\t\t\t\t > [ GROUP_BY ] | Schema: [ROWKEY STRING KEY, KSQL_INTERNAL_COL_0 BIGINT, "
+            + "KSQL_INTERNAL_COL_1 DOUBLE] |"
+    ));
     assertThat(lines[3], startsWith(
-        "\t\t\t\t\t\t > [ FILTER ] | Schema: [TEST1.ROWKEY STRING KEY, TEST1.ROWTIME BIGINT, TEST1.ROWKEY STRING, "
+        "\t\t\t\t\t\t > [ PROJECT ] | Schema: [ROWKEY STRING KEY, KSQL_INTERNAL_COL_0 BIGINT, "
+            + "KSQL_INTERNAL_COL_1 DOUBLE] |"));
+    assertThat(lines[4], startsWith(
+        "\t\t\t\t\t\t\t\t > [ FILTER ] | Schema: [TEST1.ROWKEY STRING KEY, TEST1.ROWTIME BIGINT, TEST1.ROWKEY STRING, "
             + "TEST1.COL0 BIGINT, TEST1.COL1 STRING, TEST1.COL2 STRING, "
             + "TEST1.COL3 DOUBLE, TEST1.COL4 ARRAY<DOUBLE>, "
             + "TEST1.COL5 MAP<STRING, DOUBLE>] |"));
-    assertThat(lines[4], startsWith(
-        "\t\t\t\t\t\t\t\t > [ SOURCE ] | Schema: [TEST1.ROWKEY STRING KEY, TEST1.ROWTIME BIGINT, TEST1.ROWKEY STRING, "
+    assertThat(lines[5], startsWith(
+        "\t\t\t\t\t\t\t\t\t\t > [ SOURCE ] | Schema: [TEST1.ROWKEY STRING KEY, TEST1.ROWTIME BIGINT, TEST1.ROWKEY STRING, "
             + "TEST1.COL0 BIGINT, TEST1.COL1 STRING, TEST1.COL2 STRING, "
             + "TEST1.COL3 DOUBLE, TEST1.COL4 ARRAY<DOUBLE>, "
             + "TEST1.COL5 MAP<STRING, DOUBLE>] |"));

--- a/ksql-engine/src/test/java/io/confluent/ksql/structured/SchemaKTableTest.java
+++ b/ksql-engine/src/test/java/io/confluent/ksql/structured/SchemaKTableTest.java
@@ -87,7 +87,6 @@ import io.confluent.ksql.serde.GenericRowSerDe;
 import io.confluent.ksql.serde.KeyFormat;
 import io.confluent.ksql.serde.SerdeOption;
 import io.confluent.ksql.serde.ValueFormat;
-import io.confluent.ksql.structured.SchemaKStream.Type;
 import io.confluent.ksql.testutils.AnalysisTestUtil;
 import io.confluent.ksql.util.KsqlConfig;
 import io.confluent.ksql.util.MetaStoreFixture;
@@ -219,7 +218,6 @@ public class SchemaKTableTest {
         keyFormat,
         keyField,
         new ArrayList<>(),
-        Type.SOURCE,
         ksqlConfig,
         functionRegistry
     );
@@ -231,7 +229,6 @@ public class SchemaKTableTest {
         keyFormat,
         logicalPlan.getTheSourceNode().getKeyField(),
         new ArrayList<>(),
-        SchemaKStream.Type.SOURCE,
         ksqlConfig,
         functionRegistry
     );
@@ -542,7 +539,6 @@ public class SchemaKTableTest {
         keyFormat,
         logicalPlan.getTheSourceNode().getKeyField(),
         new ArrayList<>(),
-        SchemaKStream.Type.SOURCE,
         ksqlConfig,
         functionRegistry
     );
@@ -583,7 +579,6 @@ public class SchemaKTableTest {
     ((SchemaKTable) joinedKStream).getSourceTableStep().build(planBuilder);
     verify(mockKTable);
     assertThat(joinedKStream, instanceOf(SchemaKTable.class));
-    assertEquals(SchemaKStream.Type.JOIN, joinedKStream.type);
     assertEquals(joinSchema, joinedKStream.getSchema());
     assertThat(joinedKStream.getKeyField(), is(validKeyField));
     assertEquals(Arrays.asList(firstSchemaKTable, secondSchemaKTable),
@@ -607,7 +602,6 @@ public class SchemaKTableTest {
     ((SchemaKTable) joinedKStream).getSourceTableStep().build(planBuilder);
     verify(mockKTable);
     assertThat(joinedKStream, instanceOf(SchemaKTable.class));
-    assertEquals(SchemaKStream.Type.JOIN, joinedKStream.type);
     assertEquals(joinSchema, joinedKStream.getSchema());
     assertThat(joinedKStream.getKeyField(), is(validKeyField));
     assertEquals(Arrays.asList(firstSchemaKTable, secondSchemaKTable),
@@ -631,7 +625,6 @@ public class SchemaKTableTest {
     ((SchemaKTable) joinedKStream).getSourceTableStep().build(planBuilder);
     verify(mockKTable);
     assertThat(joinedKStream, instanceOf(SchemaKTable.class));
-    assertEquals(SchemaKStream.Type.JOIN, joinedKStream.type);
     assertEquals(joinSchema, joinedKStream.getSchema());
     assertThat(joinedKStream.getKeyField(), is(validKeyField));
     assertEquals(Arrays.asList(firstSchemaKTable, secondSchemaKTable),
@@ -837,7 +830,6 @@ public class SchemaKTableTest {
         keyFormat,
         logicalPlan.getTheSourceNode().getKeyField(),
         new ArrayList<>(),
-        SchemaKStream.Type.SOURCE,
         ksqlConfig,
         functionRegistry
     );

--- a/ksql-engine/src/test/java/io/confluent/ksql/util/PlanSummaryTest.java
+++ b/ksql-engine/src/test/java/io/confluent/ksql/util/PlanSummaryTest.java
@@ -1,0 +1,138 @@
+/*
+ * Copyright 2019 Confluent Inc.
+ *
+ * Licensed under the Confluent Community License (the "License"); you may not use
+ * this file except in compliance with the License.  You may obtain a copy of the
+ * License at
+ *
+ * http://www.confluent.io/confluent-community-license
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package io.confluent.ksql.util;
+
+import static org.hamcrest.Matchers.is;
+import static org.junit.Assert.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.same;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import io.confluent.ksql.execution.context.QueryContext;
+import io.confluent.ksql.execution.plan.ExecutionStep;
+import io.confluent.ksql.execution.plan.ExecutionStepProperties;
+import io.confluent.ksql.execution.plan.StreamMapValues;
+import io.confluent.ksql.execution.plan.StreamSource;
+import io.confluent.ksql.execution.plan.StreamStreamJoin;
+import io.confluent.ksql.execution.streams.StepSchemaResolver;
+import io.confluent.ksql.name.ColumnName;
+import io.confluent.ksql.query.QueryId;
+import io.confluent.ksql.schema.ksql.LogicalSchema;
+import io.confluent.ksql.schema.ksql.types.SqlTypes;
+import java.util.Arrays;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnitRunner;
+
+@RunWith(MockitoJUnitRunner.class)
+public class PlanSummaryTest {
+  private static final QueryId QUERY_ID = new QueryId("QID");
+  private static final LogicalSchema SOURCE_SCHEMA = LogicalSchema.builder()
+      .valueColumn(ColumnName.of("L0"), SqlTypes.INTEGER)
+      .build();
+
+  @Mock
+  private StepSchemaResolver schemaResolver;
+
+  private ExecutionStep sourceStep;
+  private PlanSummary planSummaryBuilder;
+
+  @Before
+  public void setup() {
+    planSummaryBuilder = new PlanSummary(QUERY_ID, schemaResolver);
+    sourceStep = givenStep(StreamSource.class, "src", SOURCE_SCHEMA);
+  }
+
+  @Test
+  public void shouldSummarizeSource() {
+    // When:
+    final String summary = planSummaryBuilder.summarize(sourceStep);
+
+    // Then:
+    assertThat(summary, is(
+        " > [ SOURCE ] | Schema: [ROWKEY STRING KEY, L0 INTEGER] | Logger: QID.src\n"
+    ));
+  }
+
+  @Test
+  public void shouldSummarizeWithSource() {
+    // Given:
+    final LogicalSchema schema = LogicalSchema.builder()
+        .valueColumn(ColumnName.of("L1"), SqlTypes.STRING)
+        .build();
+    final ExecutionStep step = givenStep(StreamMapValues.class, "child", schema, sourceStep);
+
+    // When:
+    final String summary = planSummaryBuilder.summarize(step);
+
+    // Then:
+    assertThat(summary, is(
+        " > [ PROJECT ] | Schema: [ROWKEY STRING KEY, L1 STRING] | Logger: QID.child"
+            + "\n\t\t > [ SOURCE ] | Schema: [ROWKEY STRING KEY, L0 INTEGER] | Logger: QID.src\n"
+    ));
+  }
+
+  @Test
+  public void shouldSummarizePlanWithMultipleSources() {
+    // Given:
+    final LogicalSchema sourceSchema2 = LogicalSchema.builder()
+        .valueColumn(ColumnName.of("L0_2"), SqlTypes.STRING)
+        .build();
+    final LogicalSchema schema = LogicalSchema.builder()
+        .valueColumn(ColumnName.of("L1"), SqlTypes.STRING)
+        .build();
+    final ExecutionStep sourceStep2 = givenStep(StreamSource.class, "src2", sourceSchema2);
+    final ExecutionStep step =
+        givenStep(StreamStreamJoin.class, "child", schema, sourceStep, sourceStep2);
+
+    // When:
+    final String summary = planSummaryBuilder.summarize(step);
+
+    // Then:
+    assertThat(summary, is(
+        " > [ JOIN ] | Schema: [ROWKEY STRING KEY, L1 STRING] | Logger: QID.child"
+            + "\n\t\t > [ SOURCE ] | Schema: [ROWKEY STRING KEY, L0 INTEGER] | Logger: QID.src"
+            + "\n\t\t > [ SOURCE ] | Schema: [ROWKEY STRING KEY, L0_2 STRING] | Logger: QID.src2\n"
+    ));
+  }
+
+  private <T extends ExecutionStep<?>> T givenStep(
+      final Class<T> clazz,
+      final String ctx,
+      final LogicalSchema schema,
+      final ExecutionStep<?> ...sources) {
+    final T step = mock(clazz);
+    givenStep(step, ctx, schema, sources);
+    return step;
+  }
+
+  private void givenStep(
+      final ExecutionStep<?> step,
+      final String ctx,
+      final LogicalSchema schema,
+      final ExecutionStep<?> ...sources) {
+    final ExecutionStepProperties props = mock(ExecutionStepProperties.class);
+    when(step.getProperties()).thenReturn(props);
+    when(props.getQueryContext())
+        .thenReturn(new QueryContext.Stacker().push(ctx).getQueryContext());
+    when(schemaResolver.resolve(same(step), any())).thenReturn(schema);
+    when(schemaResolver.resolve(same(step), any(), any())).thenReturn(schema);
+    when(step.getSources()).thenReturn(Arrays.asList(sources));
+  }
+}

--- a/ksql-engine/src/test/java/io/confluent/ksql/util/PlanSummaryTest.java
+++ b/ksql-engine/src/test/java/io/confluent/ksql/util/PlanSummaryTest.java
@@ -24,7 +24,7 @@ import static org.mockito.Mockito.when;
 
 import io.confluent.ksql.execution.context.QueryContext;
 import io.confluent.ksql.execution.plan.ExecutionStep;
-import io.confluent.ksql.execution.plan.ExecutionStepProperties;
+import io.confluent.ksql.execution.plan.ExecutionStepPropertiesV1;
 import io.confluent.ksql.execution.plan.StreamMapValues;
 import io.confluent.ksql.execution.plan.StreamSource;
 import io.confluent.ksql.execution.plan.StreamStreamJoin;
@@ -127,7 +127,7 @@ public class PlanSummaryTest {
       final String ctx,
       final LogicalSchema schema,
       final ExecutionStep<?> ...sources) {
-    final ExecutionStepProperties props = mock(ExecutionStepProperties.class);
+    final ExecutionStepPropertiesV1 props = mock(ExecutionStepPropertiesV1.class);
     when(step.getProperties()).thenReturn(props);
     when(props.getQueryContext())
         .thenReturn(new QueryContext.Stacker().push(ctx).getQueryContext());

--- a/ksql-execution/src/main/java/io/confluent/ksql/execution/plan/PlanBuilder.java
+++ b/ksql-execution/src/main/java/io/confluent/ksql/execution/plan/PlanBuilder.java
@@ -22,7 +22,7 @@ import org.apache.kafka.streams.kstream.Windowed;
  * A visitor interface for building a query from an execution plan. There is a single
  * visit method for each execution step type (final implementations of ExecutionStep).
  * Implementers typically implement the visit methods by applying the transformation
- * specified in the step to the stream/table(s) returned by visiting hte source steps.
+ * specified in the step to the stream/table(s) returned by visiting the source steps.
  */
 public interface PlanBuilder {
   <K> KStreamHolder<K> visitStreamFilter(StreamFilter<K> streamFilter);

--- a/ksql-rest-app/src/test/resources/ksql-plan-schema/schema.json
+++ b/ksql-rest-app/src/test/resources/ksql-plan-schema/schema.json
@@ -234,26 +234,16 @@
           "type" : "string"
         },
         "physicalPlan" : {
-          "$ref" : "#/definitions/PhysicalPlan"
-        }
-      },
-      "required" : [ "sources", "sink", "physicalPlan" ]
-    },
-    "PhysicalPlan" : {
-      "type" : "object",
-      "additionalProperties" : false,
-      "properties" : {
+          "$ref" : "#/definitions/ExecutionStep"
+        },
         "queryId" : {
           "type" : "string"
-        },
-        "physicalPlan" : {
-          "$ref" : "#/definitions/ExecutionStep"
         },
         "planSummary" : {
           "type" : "string"
         }
       },
-      "required" : [ "queryId", "physicalPlan", "planSummary" ]
+      "required" : [ "sources", "sink", "physicalPlan", "queryId", "planSummary" ]
     },
     "StreamAggregate" : {
       "type" : "object",

--- a/ksql-rest-app/src/test/resources/ksql-plan-schema/schema.json
+++ b/ksql-rest-app/src/test/resources/ksql-plan-schema/schema.json
@@ -238,12 +238,9 @@
         },
         "queryId" : {
           "type" : "string"
-        },
-        "planSummary" : {
-          "type" : "string"
         }
       },
-      "required" : [ "sources", "sink", "physicalPlan", "queryId", "planSummary" ]
+      "required" : [ "sources", "sink", "physicalPlan", "queryId" ]
     },
     "StreamAggregate" : {
       "type" : "object",

--- a/ksql-streams/src/main/java/io/confluent/ksql/execution/streams/StepSchemaResolver.java
+++ b/ksql-streams/src/main/java/io/confluent/ksql/execution/streams/StepSchemaResolver.java
@@ -39,6 +39,7 @@ import io.confluent.ksql.execution.plan.TableTableJoin;
 import io.confluent.ksql.execution.plan.WindowedStreamSource;
 import io.confluent.ksql.execution.plan.WindowedTableSource;
 import io.confluent.ksql.execution.transform.select.Selection;
+import io.confluent.ksql.execution.util.SinkSchemaUtil;
 import io.confluent.ksql.function.FunctionRegistry;
 import io.confluent.ksql.schema.ksql.LogicalSchema;
 import io.confluent.ksql.util.HandlerMaps;
@@ -63,14 +64,14 @@ public final class StepSchemaResolver {
       .put(StreamGroupByKey.class, StepSchemaResolver::sameSchema)
       .put(StreamMapValues.class, StepSchemaResolver::handleStreamMapValues)
       .put(StreamSelectKey.class, StepSchemaResolver::sameSchema)
-      .put(StreamSink.class, StepSchemaResolver::sameSchema)
+      .put(StreamSink.class, StepSchemaResolver::handleSink)
       .put(StreamSource.class, StepSchemaResolver::handleSource)
       .put(WindowedStreamSource.class, StepSchemaResolver::handleSource)
       .put(TableAggregate.class, StepSchemaResolver::handleTableAggregate)
       .put(TableFilter.class, StepSchemaResolver::sameSchema)
       .put(TableGroupBy.class, StepSchemaResolver::sameSchema)
       .put(TableMapValues.class, StepSchemaResolver::handleTableMapValues)
-      .put(TableSink.class, StepSchemaResolver::sameSchema)
+      .put(TableSink.class, StepSchemaResolver::handleSink)
       .put(TableSource.class, StepSchemaResolver::handleSource)
       .put(WindowedTableSource.class, StepSchemaResolver::handleSource)
       .build();
@@ -201,6 +202,10 @@ public final class StepSchemaResolver {
         ksqlConfig,
         functionRegistry
     ).getSchema();
+  }
+
+  private LogicalSchema handleSink(final LogicalSchema schema, final ExecutionStep<?> step) {
+    return SinkSchemaUtil.sinkSchema(schema);
   }
 
   private LogicalSchema sameSchema(final LogicalSchema schema, final ExecutionStep step) {

--- a/ksql-streams/src/main/java/io/confluent/ksql/execution/streams/StepSchemaResolver.java
+++ b/ksql-streams/src/main/java/io/confluent/ksql/execution/streams/StepSchemaResolver.java
@@ -1,0 +1,219 @@
+/*
+ * Copyright 2019 Confluent Inc.
+ *
+ * Licensed under the Confluent Community License (the "License"); you may not use
+ * this file except in compliance with the License.  You may obtain a copy of the
+ * License at
+ *
+ * http://www.confluent.io/confluent-community-license
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package io.confluent.ksql.execution.streams;
+
+import io.confluent.ksql.execution.plan.AbstractStreamSource;
+import io.confluent.ksql.execution.plan.ExecutionStep;
+import io.confluent.ksql.execution.plan.StreamAggregate;
+import io.confluent.ksql.execution.plan.StreamFilter;
+import io.confluent.ksql.execution.plan.StreamFlatMap;
+import io.confluent.ksql.execution.plan.StreamGroupBy;
+import io.confluent.ksql.execution.plan.StreamGroupByKey;
+import io.confluent.ksql.execution.plan.StreamMapValues;
+import io.confluent.ksql.execution.plan.StreamSelectKey;
+import io.confluent.ksql.execution.plan.StreamSink;
+import io.confluent.ksql.execution.plan.StreamSource;
+import io.confluent.ksql.execution.plan.StreamStreamJoin;
+import io.confluent.ksql.execution.plan.StreamTableJoin;
+import io.confluent.ksql.execution.plan.StreamWindowedAggregate;
+import io.confluent.ksql.execution.plan.TableAggregate;
+import io.confluent.ksql.execution.plan.TableFilter;
+import io.confluent.ksql.execution.plan.TableGroupBy;
+import io.confluent.ksql.execution.plan.TableMapValues;
+import io.confluent.ksql.execution.plan.TableSink;
+import io.confluent.ksql.execution.plan.TableSource;
+import io.confluent.ksql.execution.plan.TableTableJoin;
+import io.confluent.ksql.execution.plan.WindowedStreamSource;
+import io.confluent.ksql.execution.plan.WindowedTableSource;
+import io.confluent.ksql.execution.transform.select.Selection;
+import io.confluent.ksql.function.FunctionRegistry;
+import io.confluent.ksql.schema.ksql.LogicalSchema;
+import io.confluent.ksql.util.HandlerMaps;
+import io.confluent.ksql.util.KsqlConfig;
+import java.util.Objects;
+import java.util.Optional;
+
+/**
+ * Computes the schema produced by an execution step, given the schema(s) going into the step.
+ */
+public final class StepSchemaResolver {
+  private static final HandlerMaps.ClassHandlerMapR2
+      <ExecutionStep, StepSchemaResolver, LogicalSchema, LogicalSchema> HANDLERS
+      = HandlerMaps.forClass(ExecutionStep.class)
+      .withArgTypes(StepSchemaResolver.class, LogicalSchema.class)
+      .withReturnType(LogicalSchema.class)
+      .put(StreamAggregate.class, StepSchemaResolver::handleStreamAggregate)
+      .put(StreamWindowedAggregate.class, StepSchemaResolver::handleStreamWindowedAggregate)
+      .put(StreamFilter.class, StepSchemaResolver::sameSchema)
+      .put(StreamFlatMap.class, StepSchemaResolver::handleStreamFlatMap)
+      .put(StreamGroupBy.class, StepSchemaResolver::sameSchema)
+      .put(StreamGroupByKey.class, StepSchemaResolver::sameSchema)
+      .put(StreamMapValues.class, StepSchemaResolver::handleStreamMapValues)
+      .put(StreamSelectKey.class, StepSchemaResolver::sameSchema)
+      .put(StreamSink.class, StepSchemaResolver::sameSchema)
+      .put(StreamSource.class, StepSchemaResolver::handleSource)
+      .put(WindowedStreamSource.class, StepSchemaResolver::handleSource)
+      .put(TableAggregate.class, StepSchemaResolver::handleTableAggregate)
+      .put(TableFilter.class, StepSchemaResolver::sameSchema)
+      .put(TableGroupBy.class, StepSchemaResolver::sameSchema)
+      .put(TableMapValues.class, StepSchemaResolver::handleTableMapValues)
+      .put(TableSink.class, StepSchemaResolver::sameSchema)
+      .put(TableSource.class, StepSchemaResolver::handleSource)
+      .put(WindowedTableSource.class, StepSchemaResolver::handleSource)
+      .build();
+
+  private static final HandlerMaps.ClassHandlerMapR2
+      <ExecutionStep, StepSchemaResolver, JoinSchemas, LogicalSchema> JOIN_HANDLERS
+      = HandlerMaps.forClass(ExecutionStep.class)
+      .withArgTypes(StepSchemaResolver.class, JoinSchemas.class)
+      .withReturnType(LogicalSchema.class)
+      .put(StreamTableJoin.class, StepSchemaResolver::handleJoin)
+      .put(StreamStreamJoin.class, StepSchemaResolver::handleJoin)
+      .put(TableTableJoin.class, StepSchemaResolver::handleJoin)
+      .build();
+
+  private final KsqlConfig ksqlConfig;
+  private final FunctionRegistry functionRegistry;
+
+  public StepSchemaResolver(
+      final KsqlConfig ksqlConfig,
+      final FunctionRegistry functionRegistry) {
+    this.ksqlConfig = Objects.requireNonNull(ksqlConfig);
+    this.functionRegistry = Objects.requireNonNull(functionRegistry, "functionRegistry");
+  }
+
+  /**
+   * Compute the output schema of a given execution step, given the input schema.
+   * @param step The step to compute the output schema for.
+   * @param schema The schema of the data going into the step.
+   * @return The schema of the data outputted by the step.
+   */
+  public LogicalSchema resolve(final ExecutionStep<?> step, final LogicalSchema schema) {
+    return Optional.ofNullable(HANDLERS.get(step.getClass()))
+        .map(h -> h.handle(this, schema, step))
+        .orElseThrow(() -> new IllegalStateException("Unhandled step class: " + step.getClass()));
+  }
+
+  /**
+   * Compute the output schema of an execution step that defines a join.
+   * @param step The step to compute the output schema for.
+   * @param left The schema of the left side of the join.
+   * @param right The schema of the right side of the join.
+   * @return The schema of the data outputted by the step.
+   */
+  public LogicalSchema resolve(
+      final ExecutionStep<?> step,
+      final LogicalSchema left,
+      final LogicalSchema right) {
+    return Optional.ofNullable(JOIN_HANDLERS.get(step.getClass()))
+        .map(h -> h.handle(this, new JoinSchemas(left, right), step))
+        .orElseThrow(() -> new IllegalStateException("Unhandled step class: " + step.getClass()));
+  }
+
+  private LogicalSchema handleStreamAggregate(
+      final LogicalSchema schema,
+      final StreamAggregate step) {
+    return new AggregateParamsFactory().create(
+        schema,
+        step.getNonFuncColumnCount(),
+        functionRegistry,
+        step.getAggregations()
+    ).getSchema();
+  }
+
+  private LogicalSchema handleStreamWindowedAggregate(
+      final LogicalSchema schema,
+      final StreamWindowedAggregate step
+  ) {
+    return new AggregateParamsFactory().create(
+        schema,
+        step.getNonFuncColumnCount(),
+        functionRegistry,
+        step.getAggregations()
+    ).getSchema();
+  }
+
+  private LogicalSchema handleStreamFlatMap(
+      final LogicalSchema schema,
+      final StreamFlatMap<?> streamFlatMap
+  ) {
+    return StreamFlatMapBuilder.buildSchema(
+        schema,
+        streamFlatMap.getTableFunctions(),
+        functionRegistry
+    );
+  }
+
+  private LogicalSchema handleStreamMapValues(
+      final LogicalSchema schema,
+      final StreamMapValues<?> streamMapValues
+  ) {
+    return Selection.of(
+        schema,
+        streamMapValues.getSelectExpressions(),
+        ksqlConfig,
+        functionRegistry
+    ).getSchema();
+  }
+
+  private LogicalSchema handleSource(
+      final LogicalSchema schema,
+      final AbstractStreamSource<?> step) {
+    return schema.withAlias(step.getAlias()).withMetaAndKeyColsInValue();
+  }
+
+  private LogicalSchema handleJoin(final JoinSchemas schemas, final ExecutionStep step) {
+    return JoinParamsFactory.createSchema(schemas.left, schemas.right);
+  }
+
+  private LogicalSchema handleTableAggregate(
+      final LogicalSchema schema,
+      final TableAggregate step
+  ) {
+    return new AggregateParamsFactory().create(
+        schema,
+        step.getNonFuncColumnCount(),
+        functionRegistry,
+        step.getAggregations()
+    ).getSchema();
+  }
+
+  private LogicalSchema handleTableMapValues(
+      final LogicalSchema schema,
+      final TableMapValues<?> step
+  ) {
+    return Selection.of(
+        schema,
+        step.getSelectExpressions(),
+        ksqlConfig,
+        functionRegistry
+    ).getSchema();
+  }
+
+  private LogicalSchema sameSchema(final LogicalSchema schema, final ExecutionStep step) {
+    return schema;
+  }
+
+  private static final class JoinSchemas {
+    private final LogicalSchema left;
+    private final LogicalSchema right;
+
+    private JoinSchemas(final LogicalSchema left, final LogicalSchema right) {
+      this.left = Objects.requireNonNull(left, "left");
+      this.right = Objects.requireNonNull(right, "right");
+    }
+  }
+}

--- a/ksql-streams/src/test/java/io/confluent/ksql/execution/streams/StepSchemaResolverTest.java
+++ b/ksql-streams/src/test/java/io/confluent/ksql/execution/streams/StepSchemaResolverTest.java
@@ -1,0 +1,486 @@
+/*
+ * Copyright 2019 Confluent Inc.
+ *
+ * Licensed under the Confluent Community License (the "License"); you may not use
+ * this file except in compliance with the License.  You may obtain a copy of the
+ * License at
+ *
+ * http://www.confluent.io/confluent-community-license
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package io.confluent.ksql.execution.streams;
+
+import static org.hamcrest.Matchers.is;
+import static org.junit.Assert.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import com.google.common.collect.ImmutableList;
+import io.confluent.ksql.execution.context.QueryContext;
+import io.confluent.ksql.execution.expression.tree.ArithmeticBinaryExpression;
+import io.confluent.ksql.execution.expression.tree.ColumnReferenceExp;
+import io.confluent.ksql.execution.expression.tree.Expression;
+import io.confluent.ksql.execution.expression.tree.FunctionCall;
+import io.confluent.ksql.execution.plan.ExecutionStep;
+import io.confluent.ksql.execution.plan.ExecutionStepPropertiesV1;
+import io.confluent.ksql.execution.plan.Formats;
+import io.confluent.ksql.execution.plan.KGroupedStreamHolder;
+import io.confluent.ksql.execution.plan.KGroupedTableHolder;
+import io.confluent.ksql.execution.plan.KStreamHolder;
+import io.confluent.ksql.execution.plan.KTableHolder;
+import io.confluent.ksql.execution.plan.SelectExpression;
+import io.confluent.ksql.execution.plan.StreamAggregate;
+import io.confluent.ksql.execution.plan.StreamFilter;
+import io.confluent.ksql.execution.plan.StreamFlatMap;
+import io.confluent.ksql.execution.plan.StreamGroupBy;
+import io.confluent.ksql.execution.plan.StreamGroupByKey;
+import io.confluent.ksql.execution.plan.StreamMapValues;
+import io.confluent.ksql.execution.plan.StreamSelectKey;
+import io.confluent.ksql.execution.plan.StreamSource;
+import io.confluent.ksql.execution.plan.StreamWindowedAggregate;
+import io.confluent.ksql.execution.plan.TableAggregate;
+import io.confluent.ksql.execution.plan.TableFilter;
+import io.confluent.ksql.execution.plan.TableGroupBy;
+import io.confluent.ksql.execution.plan.TableMapValues;
+import io.confluent.ksql.execution.plan.TableSource;
+import io.confluent.ksql.execution.plan.WindowedStreamSource;
+import io.confluent.ksql.execution.plan.WindowedTableSource;
+import io.confluent.ksql.execution.windows.TumblingWindowExpression;
+import io.confluent.ksql.function.FunctionRegistry;
+import io.confluent.ksql.function.KsqlAggregateFunction;
+import io.confluent.ksql.function.KsqlTableFunction;
+import io.confluent.ksql.model.WindowType;
+import io.confluent.ksql.name.ColumnName;
+import io.confluent.ksql.name.FunctionName;
+import io.confluent.ksql.name.SourceName;
+import io.confluent.ksql.schema.Operator;
+import io.confluent.ksql.schema.ksql.ColumnRef;
+import io.confluent.ksql.schema.ksql.LogicalSchema;
+import io.confluent.ksql.schema.ksql.types.SqlType;
+import io.confluent.ksql.schema.ksql.types.SqlTypes;
+import io.confluent.ksql.serde.WindowInfo;
+import io.confluent.ksql.util.KsqlConfig;
+import java.time.Duration;
+import java.util.Collections;
+import java.util.Optional;
+import java.util.concurrent.TimeUnit;
+import java.util.function.Supplier;
+import org.apache.kafka.connect.data.Struct;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnitRunner;
+
+@RunWith(MockitoJUnitRunner.class)
+public class StepSchemaResolverTest {
+  private static final KsqlConfig CONFIG = new KsqlConfig(Collections.emptyMap());
+  private static final LogicalSchema SCHEMA = LogicalSchema.builder()
+      .valueColumn(ColumnName.of("ORANGE"), SqlTypes.INTEGER)
+      .valueColumn(ColumnName.of("APPLE"), SqlTypes.BIGINT)
+      .valueColumn(ColumnName.of("BANANA"), SqlTypes.STRING)
+      .build();
+  private static final ExecutionStepPropertiesV1 PROPERTIES = new ExecutionStepPropertiesV1(
+      SCHEMA,
+      new QueryContext.Stacker().getQueryContext()
+  );
+
+  @Mock
+  private FunctionRegistry functionRegistry;
+  @Mock
+  private ExecutionStep<KStreamHolder<Struct>> streamSource;
+  @Mock
+  private ExecutionStep<KGroupedStreamHolder> groupedStreamSource;
+  @Mock
+  private ExecutionStep<KTableHolder<Struct>> tableSource;
+  @Mock
+  private ExecutionStep<KGroupedTableHolder> groupedTableSource;
+  @Mock
+  private Formats formats;
+
+  private StepSchemaResolver resolver;
+
+  @Before
+  public void setup() {
+    resolver = new StepSchemaResolver(CONFIG, functionRegistry);
+  }
+
+  @Test
+  public void shouldResolveSchemaForStreamAggregate() {
+    // Given:
+    givenAggregateFunction("SUM", SqlTypes.BIGINT);
+    final StreamAggregate step = new StreamAggregate(
+        PROPERTIES,
+        groupedStreamSource,
+        formats,
+        1,
+        ImmutableList.of(functionCall("SUM", "APPLE"))
+    );
+
+    // When:
+    final LogicalSchema result = resolver.resolve(step, SCHEMA);
+
+    // Then:
+    assertThat(result, is(
+        LogicalSchema.builder()
+            .valueColumn(ColumnName.of("ORANGE"), SqlTypes.INTEGER)
+            .valueColumn(ColumnName.aggregateColumn(0), SqlTypes.BIGINT)
+            .build())
+    );
+  }
+
+  @Test
+  public void shouldResolveSchemaForStreamWindowedAggregate() {
+    // Given:
+    givenAggregateFunction("SUM", SqlTypes.BIGINT);
+    final StreamWindowedAggregate step = new StreamWindowedAggregate(
+        PROPERTIES,
+        groupedStreamSource,
+        formats,
+        1,
+        ImmutableList.of(functionCall("SUM", "APPLE")),
+        new TumblingWindowExpression(10, TimeUnit.SECONDS)
+    );
+
+    // When:
+    final LogicalSchema result = resolver.resolve(step, SCHEMA);
+
+    // Then:
+    assertThat(result, is(
+        LogicalSchema.builder()
+            .valueColumn(ColumnName.of("ORANGE"), SqlTypes.INTEGER)
+            .valueColumn(ColumnName.aggregateColumn(0), SqlTypes.BIGINT)
+            .build())
+    );
+  }
+
+  @Test
+  public void shouldResolveSchemaForStreamSelect() {
+    // Given:
+    final StreamMapValues<?> step = new StreamMapValues<>(
+        PROPERTIES,
+        streamSource,
+        ImmutableList.of(
+            add("JUICE", "ORANGE", "APPLE"),
+            ref("PLANTAIN", "BANANA"),
+            ref("CITRUS", "ORANGE")),
+        "foo"
+    );
+
+    // When:
+    final LogicalSchema result = resolver.resolve(step, SCHEMA);
+
+    // Then:
+    assertThat(result, is(
+        LogicalSchema.builder()
+            .valueColumn(ColumnName.of("JUICE"), SqlTypes.BIGINT)
+            .valueColumn(ColumnName.of("PLANTAIN"), SqlTypes.STRING)
+            .valueColumn(ColumnName.of("CITRUS"), SqlTypes.INTEGER)
+            .build())
+    );
+  }
+
+  @Test
+  public void shouldResolveSchemaForStreamFlatMap() {
+    // Given:
+    givenTableFunction("EXPLODE", SqlTypes.DOUBLE);
+    final StreamFlatMap<?> step = new StreamFlatMap<>(
+        PROPERTIES,
+        streamSource,
+        ImmutableList.of(functionCall("EXPLODE", "BANANA"))
+    );
+
+    // When:
+    final LogicalSchema result = resolver.resolve(step, SCHEMA);
+
+    // Then:
+    assertThat(result, is(
+        LogicalSchema.builder()
+            .valueColumn(ColumnName.of("ORANGE"), SqlTypes.INTEGER)
+            .valueColumn(ColumnName.of("APPLE"), SqlTypes.BIGINT)
+            .valueColumn(ColumnName.of("BANANA"), SqlTypes.STRING)
+            .valueColumn(ColumnName.synthesisedSchemaColumn(0), SqlTypes.DOUBLE)
+            .build())
+    );
+  }
+
+  @Test
+  public void shouldResolveSchemaForStreamFilter() {
+    // Given:
+    final StreamFilter<?> step = new StreamFilter<>(
+        PROPERTIES,
+        streamSource,
+        mock(Expression.class),
+        "name"
+    );
+
+    // When:
+    final LogicalSchema result = resolver.resolve(step, SCHEMA);
+
+    // Then:
+    assertThat(result, is(SCHEMA));
+  }
+
+  @Test
+  public void shouldResolveSchemaForStreamGroupBy() {
+    // Given:
+    final StreamGroupBy<?> step = new StreamGroupBy<>(
+        PROPERTIES,
+        streamSource,
+        formats,
+        Collections.emptyList()
+    );
+
+    // When:
+    final LogicalSchema result = resolver.resolve(step, SCHEMA);
+
+    // Then:
+    assertThat(result, is(SCHEMA));
+  }
+
+  @Test
+  public void shouldResolveSchemaForStreamGroupByKey() {
+    // Given:
+    final StreamGroupByKey step = new StreamGroupByKey(
+        PROPERTIES,
+        streamSource,
+        formats
+    );
+
+    // When:
+    final LogicalSchema result = resolver.resolve(step, SCHEMA);
+
+    // Then:
+    assertThat(result, is(SCHEMA));
+  }
+
+  @Test
+  public void shouldResolveSchemaForStreamSelectKey() {
+    // Given:
+    final StreamSelectKey step = new StreamSelectKey(
+        PROPERTIES,
+        streamSource,
+        mock(ColumnRef.class)
+    );
+
+    // When:
+    final LogicalSchema result = resolver.resolve(step, SCHEMA);
+
+    // Then:
+    assertThat(result, is(SCHEMA));
+  }
+
+  @Test
+  public void shouldResolveSchemaForStreamSource() {
+    final StreamSource step = new StreamSource(
+        PROPERTIES,
+        "foo",
+        formats,
+        Optional.empty(),
+        Optional.empty(),
+        SCHEMA,
+        SourceName.of("alias")
+    );
+
+    // When:
+    final LogicalSchema result = resolver.resolve(step, SCHEMA);
+
+    // Then:
+    assertThat(result, is(SCHEMA.withAlias(SourceName.of("alias")).withMetaAndKeyColsInValue()));
+  }
+
+  @Test
+  public void shouldResolveSchemaForStreamWindowedSource() {
+    final WindowedStreamSource step = new WindowedStreamSource(
+        PROPERTIES,
+        "foo",
+        formats,
+        WindowInfo.of(WindowType.TUMBLING, Optional.of(Duration.ofMillis(123))),
+        Optional.empty(),
+        Optional.empty(),
+        SCHEMA,
+        SourceName.of("alias")
+    );
+
+    // When:
+    final LogicalSchema result = resolver.resolve(step, SCHEMA);
+
+    // Then:
+    assertThat(result, is(SCHEMA.withAlias(SourceName.of("alias")).withMetaAndKeyColsInValue()));
+  }
+
+  @Test
+  public void shouldResolveSchemaForTableAggregate() {
+    // Given:
+    givenAggregateFunction("SUM", SqlTypes.BIGINT);
+    final TableAggregate step = new TableAggregate(
+        PROPERTIES,
+        groupedTableSource,
+        formats,
+        1,
+        ImmutableList.of(functionCall("SUM", "APPLE"))
+    );
+
+    // When:
+    final LogicalSchema result = resolver.resolve(step, SCHEMA);
+
+    // Then:
+    assertThat(result, is(
+        LogicalSchema.builder()
+            .valueColumn(ColumnName.of("ORANGE"), SqlTypes.INTEGER)
+            .valueColumn(ColumnName.aggregateColumn(0), SqlTypes.BIGINT)
+            .build())
+    );
+  }
+
+  @Test
+  public void shouldResolveSchemaForTableGroupBy() {
+    // Given:
+    final TableGroupBy<?> step = new TableGroupBy<>(
+        PROPERTIES,
+        tableSource,
+        formats,
+        Collections.emptyList()
+    );
+
+    // When:
+    final LogicalSchema result = resolver.resolve(step, SCHEMA);
+
+    // Then:
+    assertThat(result, is(SCHEMA));
+  }
+
+  @Test
+  public void shouldResolveSchemaForTableSelect() {
+    // Given:
+    final TableMapValues<?> step = new TableMapValues<>(
+        PROPERTIES,
+        tableSource,
+        ImmutableList.of(
+            add("JUICE", "ORANGE", "APPLE"),
+            ref("PLANTAIN", "BANANA"),
+            ref("CITRUS", "ORANGE")),
+        "foo"
+    );
+
+    // When:
+    final LogicalSchema result = resolver.resolve(step, SCHEMA);
+
+    // Then:
+    assertThat(result, is(
+        LogicalSchema.builder()
+            .valueColumn(ColumnName.of("JUICE"), SqlTypes.BIGINT)
+            .valueColumn(ColumnName.of("PLANTAIN"), SqlTypes.STRING)
+            .valueColumn(ColumnName.of("CITRUS"), SqlTypes.INTEGER)
+            .build())
+    );
+  }
+
+  @Test
+  public void shouldResolveSchemaForTableFilter() {
+    // Given:
+    final TableFilter<?> step = new TableFilter<>(
+        PROPERTIES,
+        tableSource,
+        mock(Expression.class),
+        "name"
+    );
+
+    // When:
+    final LogicalSchema result = resolver.resolve(step, SCHEMA);
+
+    // Then:
+    assertThat(result, is(SCHEMA));
+  }
+
+  @Test
+  public void shouldResolveSchemaForTableSource() {
+    final TableSource step = new TableSource(
+        PROPERTIES,
+        "foo",
+        formats,
+        Optional.empty(),
+        Optional.empty(),
+        SCHEMA,
+        SourceName.of("alias")
+    );
+
+    // When:
+    final LogicalSchema result = resolver.resolve(step, SCHEMA);
+
+    // Then:
+    assertThat(result, is(SCHEMA.withAlias(SourceName.of("alias")).withMetaAndKeyColsInValue()));
+  }
+
+  @Test
+  public void shouldResolveSchemaForWindowedTableSource() {
+    final WindowedTableSource step = new WindowedTableSource(
+        PROPERTIES,
+        "foo",
+        formats,
+        mock(WindowInfo.class),
+        Optional.empty(),
+        Optional.empty(),
+        SCHEMA,
+        SourceName.of("alias")
+    );
+
+    // When:
+    final LogicalSchema result = resolver.resolve(step, SCHEMA);
+
+    // Then:
+    assertThat(result, is(SCHEMA.withAlias(SourceName.of("alias")).withMetaAndKeyColsInValue()));
+  }
+
+  @SuppressWarnings("unchecked")
+  private void givenTableFunction(final String name, final SqlType returnType) {
+    final KsqlTableFunction tableFunction = mock(KsqlTableFunction.class);
+    when(functionRegistry.isTableFunction(name)).thenReturn(true);
+    when(functionRegistry.getTableFunction(eq(name), any())).thenReturn(tableFunction);
+    when(tableFunction.getReturnType(any())).thenReturn(returnType);
+  }
+
+  @SuppressWarnings("unchecked")
+  private void givenAggregateFunction(final String name, final SqlType returnType) {
+    final KsqlAggregateFunction aggregateFunction = mock(KsqlAggregateFunction.class);
+    when(functionRegistry.getAggregateFunction(eq(name), any(), any()))
+        .thenReturn(aggregateFunction);
+    when(aggregateFunction.name()).thenReturn(FunctionName.of(name));
+    when(aggregateFunction.getAggregateType()).thenReturn(SqlTypes.INTEGER);
+    when(aggregateFunction.returnType()).thenReturn(returnType);
+    when(aggregateFunction.getInitialValueSupplier()).thenReturn(mock(Supplier.class));
+  }
+
+  private static FunctionCall functionCall(final String name, final String column) {
+    return new FunctionCall(
+        FunctionName.of(name),
+        ImmutableList.of(
+            new ColumnReferenceExp(ColumnRef.withoutSource(ColumnName.of(column))))
+    );
+  }
+
+  private static SelectExpression add(final String alias, final String col1, final String col2) {
+    return SelectExpression.of(
+        ColumnName.of(alias),
+        new ArithmeticBinaryExpression(
+            Operator.ADD,
+            new ColumnReferenceExp(ColumnRef.withoutSource(ColumnName.of(col1))),
+            new ColumnReferenceExp(ColumnRef.withoutSource(ColumnName.of(col2)))
+        )
+    );
+  }
+
+  private static SelectExpression ref(final String alias, final String col) {
+    return SelectExpression.of(
+        ColumnName.of(alias),
+        new ColumnReferenceExp(ColumnRef.withoutSource(ColumnName.of(col)))
+    );
+  }
+}


### PR DESCRIPTION
### Description 
The goal here is to clean up the query plan schema as part of the work to
get to the plan schema proposed in https://github.com/confluentinc/ksql/pull/3969

Firstly, we flatten PhysicalPlan into QueryPlan in the plan schema. QueryPlan now
stores the properties it needs from PhysicalPlan, rather than holding a reference to
PhysicalPlan. This gives us a flatter, simpler, plan schema

This patch also cleans up the summary form the serialized plan by building it from
the execution plan, rather than by SchemaKStream. This is better because it gives
us a more accurate summary (previously we would skip some steps), simplifies
SchemaKStream, and simplifies the schema of the serialized plan.

The summary is built by a new class called PlanSummary, which walks the execution
plan and builds up the summary string. It uses a new interface called StepSchemaResolver
to determine the schema computed by a given step given its input schemas.