### PR TITLE
chore: deprecate maxInterval parameter for ksql-datagen

### DIFF
--- a/ksql-examples/src/main/java/io/confluent/ksql/datagen/DataGen.java
+++ b/ksql-examples/src/main/java/io/confluent/ksql/datagen/DataGen.java
@@ -111,7 +111,6 @@ public final class DataGen {
           arguments.topicName,
           arguments.keyName,
           arguments.iterations,
-          arguments.maxInterval,
           arguments.printRows,
           rateLimiter
       );
@@ -151,7 +150,8 @@ public final class DataGen {
         + "key=<name of key column> " + newLine
         + "[iterations=<number of rows> (if no value is specified, datagen will produce "
             + "indefinitely)] " + newLine
-        + "[maxInterval=<Max time in ms between rows> (defaults to 500)] " + newLine
+        + "[maxInterval=<Max time in ms between rows> (defaults to 500)]"
+            + " parameter is DEPRECATED and will be removed in the future releases" + newLine
         + "[propertiesFile=<file specifying Kafka client properties>] " + newLine
         + "[nThreads=<number of producer threads to start>] " + newLine
         + "[msgRate=<rate to produce in msgs/second>] " + newLine
@@ -170,7 +170,6 @@ public final class DataGen {
     private final String topicName;
     private final String keyName;
     private final int iterations;
-    private final long maxInterval;
     private final String schemaRegistryUrl;
     private final InputStream propertiesFile;
     private final int numThreads;
@@ -188,7 +187,6 @@ public final class DataGen {
         final String topicName,
         final String keyName,
         final int iterations,
-        final long maxInterval,
         final String schemaRegistryUrl,
         final InputStream propertiesFile,
         final int numThreads,
@@ -205,7 +203,6 @@ public final class DataGen {
       this.topicName = topicName;
       this.keyName = keyName;
       this.iterations = iterations;
-      this.maxInterval = maxInterval;
       this.schemaRegistryUrl = schemaRegistryUrl;
       this.propertiesFile = propertiesFile;
       this.numThreads = numThreads;
@@ -237,7 +234,8 @@ public final class DataGen {
               .put("key", (builder, argVal) -> builder.keyName = argVal)
               .put("iterations", (builder, argVal) -> builder.iterations = parseInt(argVal, 1))
               .put("maxInterval",
-                  (builder, argVal) -> builder.maxInterval = parseInt(argVal, 0))
+                  (builder, argVal) -> printMaxIntervalIsDeprecatedMessage()
+              )
               .put("schemaRegistryUrl", (builder, argVal) -> builder.schemaRegistryUrl = argVal)
               .put("propertiesFile",
                   (builder, argVal) -> builder.propertiesFile = toFileInputStream(argVal).get())
@@ -245,6 +243,13 @@ public final class DataGen {
               .put("nThreads", (builder, argVal) -> builder.numThreads = parseNumThreads(argVal))
               .put("printRows", (builder, argVal) -> builder.printRows = parsePrintRows(argVal))
               .build();
+
+      private static void printMaxIntervalIsDeprecatedMessage() {
+        System.err.println("*maxInterval* parameter is *DEPRECATED*");
+        System.err.println("the value will be ignored "
+                               + "and parameter will be removed in future releases");
+        System.err.flush();
+      }
 
       private Quickstart quickstart;
 
@@ -257,7 +262,6 @@ public final class DataGen {
       private String topicName;
       private String keyName;
       private int iterations;
-      private long maxInterval;
       private String schemaRegistryUrl;
       private InputStream propertiesFile;
       private int msgRate;
@@ -275,7 +279,6 @@ public final class DataGen {
         topicName = null;
         keyName = null;
         iterations = -1;
-        maxInterval = -1;
         schemaRegistryUrl = "http://localhost:8081";
         propertiesFile = null;
         msgRate = -1;
@@ -336,7 +339,6 @@ public final class DataGen {
               null,
               null,
               0,
-              -1,
               null,
               null,
               1,
@@ -372,7 +374,6 @@ public final class DataGen {
             topicName,
             keyName,
             iterations,
-            maxInterval,
             schemaRegistryUrl,
             propertiesFile,
             numThreads,

--- a/ksql-examples/src/main/java/io/confluent/ksql/datagen/DataGen.java
+++ b/ksql-examples/src/main/java/io/confluent/ksql/datagen/DataGen.java
@@ -150,8 +150,6 @@ public final class DataGen {
         + "key=<name of key column> " + newLine
         + "[iterations=<number of rows> (if no value is specified, datagen will produce "
             + "indefinitely)] " + newLine
-        + "[maxInterval=<Max time in ms between rows> (defaults to 500)]"
-            + " parameter is DEPRECATED and will be removed in the future releases" + newLine
         + "[propertiesFile=<file specifying Kafka client properties>] " + newLine
         + "[nThreads=<number of producer threads to start>] " + newLine
         + "[msgRate=<rate to produce in msgs/second>] " + newLine

--- a/ksql-examples/src/main/java/io/confluent/ksql/datagen/DataGen.java
+++ b/ksql-examples/src/main/java/io/confluent/ksql/datagen/DataGen.java
@@ -231,9 +231,7 @@ public final class DataGen {
               .put("topic", (builder, argVal) -> builder.topicName = argVal)
               .put("key", (builder, argVal) -> builder.keyName = argVal)
               .put("iterations", (builder, argVal) -> builder.iterations = parseInt(argVal, 1))
-              .put("maxInterval",
-                  (builder, argVal) -> printMaxIntervalIsDeprecatedMessage()
-              )
+              .put("maxInterval", (builder, argVal) -> printMaxIntervalIsDeprecatedMessage())
               .put("schemaRegistryUrl", (builder, argVal) -> builder.schemaRegistryUrl = argVal)
               .put("propertiesFile",
                   (builder, argVal) -> builder.propertiesFile = toFileInputStream(argVal).get())
@@ -246,6 +244,7 @@ public final class DataGen {
         System.err.println("*maxInterval* parameter is *DEPRECATED*");
         System.err.println("the value will be ignored "
                                + "and parameter will be removed in future releases");
+        System.err.println("Please use *msgRate* parameter to adjust sending message frequency");
         System.err.flush();
       }
 

--- a/ksql-examples/src/main/java/io/confluent/ksql/datagen/DataGenProducer.java
+++ b/ksql-examples/src/main/java/io/confluent/ksql/datagen/DataGenProducer.java
@@ -37,9 +37,6 @@ import org.apache.kafka.connect.data.Struct;
 
 public class DataGenProducer {
 
-  // Max 500 ms between messsages.
-  public static final long INTER_MESSAGE_MAX_INTERVAL = 500;
-
   private final SerializerFactory<Struct> keySerializerFactory;
   private final SerializerFactory<GenericRow> valueSerializerFactory;
 
@@ -57,7 +54,6 @@ public class DataGenProducer {
       final String kafkaTopicName,
       final String key,
       final int messageCount,
-      final long maxInterval,
       final boolean printRows,
       final Optional<RateLimiter> rateLimiter
   ) {
@@ -85,7 +81,6 @@ public class DataGenProducer {
             rowGenerator,
             producer,
             kafkaTopicName,
-            maxInterval,
             printRows,
             rateLimiter
         );
@@ -96,7 +91,6 @@ public class DataGenProducer {
             rowGenerator,
             producer,
             kafkaTopicName,
-            maxInterval,
             printRows,
             rateLimiter
         );
@@ -111,7 +105,6 @@ public class DataGenProducer {
       final RowGenerator rowGenerator,
       final KafkaProducer<Struct, GenericRow> producer,
       final String kafkaTopicName,
-      final long maxInterval,
       final boolean printRows,
       final Optional<RateLimiter> rateLimiter
   ) {
@@ -130,14 +123,6 @@ public class DataGenProducer {
             genericRowPair.getLeft(),
             genericRowPair.getRight(),
             printRows));
-
-    try {
-      final long interval = maxInterval < 0 ? INTER_MESSAGE_MAX_INTERVAL : maxInterval;
-
-      Thread.sleep((long) (interval * Math.random()));
-    } catch (final InterruptedException e) {
-      // Ignore the exception.
-    }
   }
 
   private Serializer<Struct> getKeySerializer() {

--- a/ksql-examples/src/test/java/io/confluent/ksql/datagen/DataGenTest.java
+++ b/ksql-examples/src/test/java/io/confluent/ksql/datagen/DataGenTest.java
@@ -79,7 +79,6 @@ public class DataGenTest {
         "topic",
         "key",
         0,
-        0L,
         "srUrl",
         null,
         1,


### PR DESCRIPTION
### Description 
remove `maxInterval` from `DataGen.Arguments` and print deprecation message to a user

Fixes #3565

BREAKING CHANGE: The maxInterval parameter for ksql-datagen is now deprecated. Use msgRate instead.

### Testing done 
None

### Reviewer checklist
- [ ] Ensure docs are updated if necessary. (eg. if a user visible feature is being added or changed).
- [ ] Ensure relevant issues are linked (description should include text like "Fixes #<issue number>")

@vcrfxia, @apurvam could you guys please take a look?
Thank you
