### PR TITLE
fix: schema column order returned by websocket pull query (MINOR)

### DIFF
--- a/ksql-rest-app/src/test/java/io/confluent/ksql/rest/integration/RestApiTest.java
+++ b/ksql-rest-app/src/test/java/io/confluent/ksql/rest/integration/RestApiTest.java
@@ -265,8 +265,8 @@ public class RestApiTest {
     assertValidJsonMessages(messages);
     assertThat(messages.get(0),
         is("["
-            + "{\"name\":\"ROWKEY\",\"schema\":{\"type\":\"STRING\",\"fields\":null,\"memberSchema\":null}},"
-            + "{\"name\":\"COUNT\",\"schema\":{\"type\":\"BIGINT\",\"fields\":null,\"memberSchema\":null}}"
+            + "{\"name\":\"COUNT\",\"schema\":{\"type\":\"BIGINT\",\"fields\":null,\"memberSchema\":null}},"
+            + "{\"name\":\"ROWKEY\",\"schema\":{\"type\":\"STRING\",\"fields\":null,\"memberSchema\":null}}"
             + "]"));
     assertThat(messages.get(1),
         is("{\"row\":{\"columns\":[1,\"USER_1\"]}}"));
@@ -276,7 +276,7 @@ public class RestApiTest {
   public void shouldReturnCorrectSchemaForPullQueryWithOnlyKeyInSelect() {
     // When:
     final Supplier<List<String>> call = () -> makeWebSocketRequest(
-        "SELECT * from " + AGG_TABLE + " WHERE ROWKEY='" + AN_AGG_KEY + "';",
+        "SELECT ROWKEY from " + AGG_TABLE + " WHERE ROWKEY='" + AN_AGG_KEY + "';",
         MediaType.APPLICATION_JSON_TYPE,
         MediaType.APPLICATION_JSON_TYPE
     );
@@ -286,11 +286,10 @@ public class RestApiTest {
     assertValidJsonMessages(messages);
     assertThat(messages.get(0),
         is("["
-            + "{\"name\":\"ROWKEY\",\"schema\":{\"type\":\"STRING\",\"fields\":null,\"memberSchema\":null}},"
-            + "{\"name\":\"COUNT\",\"schema\":{\"type\":\"BIGINT\",\"fields\":null,\"memberSchema\":null}}"
+            + "{\"name\":\"ROWKEY\",\"schema\":{\"type\":\"STRING\",\"fields\":null,\"memberSchema\":null}}"
             + "]"));
     assertThat(messages.get(1),
-        is("{\"row\":{\"columns\":[\"USER_1\",1]}}"));
+        is("{\"row\":{\"columns\":[\"USER_1\"]}}"));
   }
 
   @Test

--- a/ksql-rest-app/src/test/java/io/confluent/ksql/rest/util/EntityUtilTest.java
+++ b/ksql-rest-app/src/test/java/io/confluent/ksql/rest/util/EntityUtilTest.java
@@ -190,6 +190,26 @@ public class EntityUtilTest {
     assertThat(fields.get(0).getSchema().getTypeName(), equalTo("INTEGER"));
   }
 
+  @Test
+  public void shouldMaintainColumnOrder() {
+    // Given:
+    final LogicalSchema schema = LogicalSchema.builder()
+        .noImplicitColumns()
+        .valueColumn(ColumnName.of("field0"), SqlTypes.DOUBLE)
+        .keyColumn(ColumnName.of("field1"), SqlTypes.INTEGER)
+        .build();
+
+    // When:
+    final List<FieldInfo> fields = EntityUtil.buildSourceSchemaEntity(schema);
+
+    // Then:
+    assertThat(fields, hasSize(2));
+    assertThat(fields.get(0).getName(), equalTo("field0"));
+    assertThat(fields.get(0).getSchema().getTypeName(), equalTo("DOUBLE"));
+    assertThat(fields.get(1).getName(), equalTo("field1"));
+    assertThat(fields.get(1).getSchema().getTypeName(), equalTo("INTEGER"));
+  }
+
   private static void shouldBuildCorrectPrimitiveField(
       final SqlType primitiveSchema,
       final String schemaName


### PR DESCRIPTION
### Description 

The order of columns was unintentionally getting changed so that key columns can before value columns. This is incorrect.  A user can choose which order the columns are returned, e.g

```sql
SELECT COUNT, ROWKEY from Foo...
```


### Testing done 

usual

### Reviewer checklist
- [ ] Ensure docs are updated if necessary. (eg. if a user visible feature is being added or changed).
- [ ] Ensure relevant issues are linked (description should include text like "Fixes #<issue number>")

