### PR TITLE
refactor: expose namespace and index on `Column`

### DIFF
--- a/ksql-common/src/main/java/io/confluent/ksql/schema/ksql/SimpleColumn.java
+++ b/ksql-common/src/main/java/io/confluent/ksql/schema/ksql/SimpleColumn.java
@@ -1,0 +1,31 @@
+/*
+ * Copyright 2019 Confluent Inc.
+ *
+ * Licensed under the Confluent Community License (the "License"); you may not use
+ * this file except in compliance with the License.  You may obtain a copy of the
+ * License at
+ *
+ * http://www.confluent.io/confluent-community-license
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package io.confluent.ksql.schema.ksql;
+
+import io.confluent.ksql.schema.ksql.types.SqlType;
+
+public interface SimpleColumn {
+
+  /**
+   * @return the column source and name
+   */
+  ColumnRef ref();
+
+  /**
+   * @return the type of the field.
+   */
+  SqlType type();
+}

--- a/ksql-common/src/test/java/io/confluent/ksql/schema/ksql/ColumnMatchers.java
+++ b/ksql-common/src/test/java/io/confluent/ksql/schema/ksql/ColumnMatchers.java
@@ -1,0 +1,195 @@
+/*
+ * Copyright 2019 Confluent Inc.
+ *
+ * Licensed under the Confluent Community License (the "License"); you may not use
+ * this file except in compliance with the License.  You may obtain a copy of the
+ * License at
+ *
+ * http://www.confluent.io/confluent-community-license
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package io.confluent.ksql.schema.ksql;
+
+import static org.hamcrest.Matchers.allOf;
+import static org.hamcrest.Matchers.is;
+
+import io.confluent.ksql.name.ColumnName;
+import io.confluent.ksql.name.SourceName;
+import io.confluent.ksql.schema.ksql.Column.Namespace;
+import io.confluent.ksql.schema.ksql.types.SqlType;
+import java.util.Optional;
+import org.hamcrest.FeatureMatcher;
+import org.hamcrest.Matcher;
+
+public final class ColumnMatchers {
+
+  private ColumnMatchers() {
+  }
+
+  public static Matcher<Column> column(
+      final SourceName source,
+      final ColumnName name
+  ) {
+    return allOf(
+        hasSource(Optional.of(source)),
+        hasName(name)
+    );
+  }
+
+  public static Matcher<Column> column(
+      final SourceName source,
+      final ColumnName name,
+      final SqlType type
+  ) {
+    return allOf(
+        hasSource(Optional.of(source)),
+        hasName(name),
+        hasType(type)
+    );
+  }
+
+  public static Matcher<Column> metaColumn(
+      final ColumnName name,
+      final SqlType type
+  ) {
+    return allOf(
+        hasSource(Optional.empty()),
+        hasName(name),
+        hasType(type),
+        hasNamespace(Namespace.META)
+    );
+  }
+
+  public static Matcher<Column> metaColumn(
+      final SourceName source,
+      final ColumnName name,
+      final SqlType type
+  ) {
+    return allOf(
+        hasSource(Optional.of(source)),
+        hasName(name),
+        hasType(type),
+        hasNamespace(Namespace.META)
+    );
+  }
+
+  public static Matcher<Column> keyColumn(
+      final ColumnName name,
+      final SqlType type
+  ) {
+    return allOf(
+        hasSource(Optional.empty()),
+        hasName(name),
+        hasType(type),
+        hasNamespace(Namespace.KEY)
+    );
+  }
+
+  public static Matcher<Column> keyColumn(
+      final SourceName source,
+      final ColumnName name,
+      final SqlType type
+  ) {
+    return allOf(
+        hasSource(Optional.of(source)),
+        hasName(name),
+        hasType(type),
+        hasNamespace(Namespace.KEY)
+    );
+  }
+
+  public static Matcher<Column> valueColumn(
+      final ColumnName name,
+      final SqlType type
+  ) {
+    return allOf(
+        hasSource(Optional.empty()),
+        hasName(name),
+        hasType(type),
+        hasNamespace(Namespace.VALUE)
+    );
+  }
+
+  public static Matcher<Column> valueColumn(
+      final SourceName source,
+      final ColumnName name,
+      final SqlType type
+  ) {
+    return allOf(
+        hasSource(Optional.of(source)),
+        hasName(name),
+        hasType(type),
+        hasNamespace(Namespace.VALUE)
+    );
+  }
+
+  public static Matcher<Column> valueColumn(
+      final Optional<SourceName> source,
+      final ColumnName name,
+      final SqlType type
+  ) {
+    return allOf(
+        hasSource(source),
+        hasName(name),
+        hasType(type),
+        hasNamespace(Namespace.VALUE)
+    );
+  }
+
+  public static Matcher<Column> hasSource(final Optional<SourceName> source) {
+    return new FeatureMatcher<Column, Optional<SourceName>>(
+        is(source),
+        "column with source",
+        "source"
+    ) {
+      @Override
+      protected Optional<SourceName> featureValueOf(final Column actual) {
+        return actual.source();
+      }
+    };
+  }
+
+  public static Matcher<Column> hasName(final ColumnName name) {
+    return new FeatureMatcher<Column, ColumnName>(
+        is(name),
+        "column with name",
+        "name"
+    ) {
+      @Override
+      protected ColumnName featureValueOf(final Column actual) {
+        return actual.name();
+      }
+    };
+  }
+
+  public static Matcher<Column> hasType(final SqlType type) {
+    return new FeatureMatcher<Column, SqlType>(
+        is(type),
+        "column with type",
+        "type"
+    ) {
+      @Override
+      protected SqlType featureValueOf(final Column actual) {
+        return actual.type();
+      }
+    };
+  }
+
+  private static Matcher<Column> hasNamespace(final Namespace ns) {
+    return new FeatureMatcher<Column, Namespace>(
+        is(ns),
+        "column with type",
+        "type"
+    ) {
+      @Override
+      protected Namespace featureValueOf(final Column actual) {
+        return actual.namespace();
+      }
+    };
+  }
+}

--- a/ksql-engine/src/main/java/io/confluent/ksql/structured/SchemaKStream.java
+++ b/ksql-engine/src/main/java/io/confluent/ksql/structured/SchemaKStream.java
@@ -205,26 +205,25 @@ public class SchemaKStream<K> {
     );
   }
 
+  @SuppressWarnings("deprecation")
   KeyField findKeyField(final List<SelectExpression> selectExpressions) {
     if (!getKeyField().ref().isPresent()) {
       return KeyField.none();
     }
 
-    final ColumnRef reference = getKeyField().ref().get();
-    final Column keyColumn = Column.of(reference, SqlTypes.STRING);
+    final ColumnRef keyColumnRef = getKeyField().ref().get();
 
     Optional<Column> found = Optional.empty();
 
-    for (int i = 0; i < selectExpressions.size(); i++) {
-      final ColumnName toName = selectExpressions.get(i).getAlias();
-      final Expression toExpression = selectExpressions.get(i).getExpression();
+    for (SelectExpression selectExpression : selectExpressions) {
+      final ColumnName toName = selectExpression.getAlias();
+      final Expression toExpression = selectExpression.getExpression();
 
       if (toExpression instanceof ColumnReferenceExp) {
-        final ColumnReferenceExp nameRef
-            = (ColumnReferenceExp) toExpression;
+        final ColumnReferenceExp nameRef = (ColumnReferenceExp) toExpression;
 
-        if (keyColumn.ref().equals(nameRef.getReference())) {
-          found = Optional.of(Column.of(toName, keyColumn.type()));
+        if (keyColumnRef.equals(nameRef.getReference())) {
+          found = Optional.of(Column.legacyKeyFieldColumn(toName, SqlTypes.STRING));
           break;
         }
       }

--- a/ksql-engine/src/test/java/io/confluent/ksql/planner/plan/AggregateNodeTest.java
+++ b/ksql-engine/src/test/java/io/confluent/ksql/planner/plan/AggregateNodeTest.java
@@ -18,6 +18,7 @@ package io.confluent.ksql.planner.plan;
 import static io.confluent.ksql.planner.plan.PlanTestUtil.SOURCE_NODE;
 import static io.confluent.ksql.planner.plan.PlanTestUtil.TRANSFORM_NODE;
 import static io.confluent.ksql.planner.plan.PlanTestUtil.getNodeByName;
+import static io.confluent.ksql.schema.ksql.ColumnMatchers.valueColumn;
 import static io.confluent.ksql.util.LimitedProxyBuilder.methodParams;
 import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.CoreMatchers.hasItem;
@@ -47,7 +48,6 @@ import io.confluent.ksql.logging.processing.ProcessingLogContext;
 import io.confluent.ksql.metastore.MetaStore;
 import io.confluent.ksql.name.ColumnName;
 import io.confluent.ksql.query.QueryId;
-import io.confluent.ksql.schema.ksql.Column;
 import io.confluent.ksql.schema.ksql.types.SqlTypes;
 import io.confluent.ksql.serde.KeySerde;
 import io.confluent.ksql.structured.SchemaKStream;
@@ -89,7 +89,7 @@ import org.mockito.Captor;
 import org.mockito.Mock;
 import org.mockito.junit.MockitoJUnitRunner;
 
-@SuppressWarnings("UnstableApiUsage")
+@SuppressWarnings({"UnstableApiUsage", "unchecked"})
 @RunWith(MockitoJUnitRunner.class)
 public class AggregateNodeTest {
 
@@ -245,9 +245,9 @@ public class AggregateNodeTest {
 
     // Then:
     assertThat(stream.getSchema().value(), contains(
-        Column.of(ColumnName.of("COL0"), SqlTypes.BIGINT),
-        Column.of(ColumnName.of("KSQL_COL_1"), SqlTypes.DOUBLE),
-        Column.of(ColumnName.of("KSQL_COL_2"), SqlTypes.BIGINT)));
+        valueColumn(ColumnName.of("COL0"), SqlTypes.BIGINT),
+        valueColumn(ColumnName.of("KSQL_COL_1"), SqlTypes.DOUBLE),
+        valueColumn(ColumnName.of("KSQL_COL_2"), SqlTypes.BIGINT)));
   }
 
   @Test

--- a/ksql-engine/src/test/java/io/confluent/ksql/planner/plan/KsqlBareOutputNodeTest.java
+++ b/ksql-engine/src/test/java/io/confluent/ksql/planner/plan/KsqlBareOutputNodeTest.java
@@ -18,6 +18,7 @@ package io.confluent.ksql.planner.plan;
 import static io.confluent.ksql.planner.plan.PlanTestUtil.SOURCE_NODE;
 import static io.confluent.ksql.planner.plan.PlanTestUtil.TRANSFORM_NODE;
 import static io.confluent.ksql.planner.plan.PlanTestUtil.verifyProcessorNode;
+import static io.confluent.ksql.schema.ksql.ColumnMatchers.valueColumn;
 import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.contains;
@@ -37,7 +38,6 @@ import io.confluent.ksql.metastore.MetaStore;
 import io.confluent.ksql.name.ColumnName;
 import io.confluent.ksql.query.QueryId;
 import io.confluent.ksql.query.id.QueryIdGenerator;
-import io.confluent.ksql.schema.ksql.Column;
 import io.confluent.ksql.schema.ksql.LogicalSchema;
 import io.confluent.ksql.schema.ksql.types.SqlTypes;
 import io.confluent.ksql.serde.KeySerde;
@@ -59,6 +59,7 @@ import org.junit.runner.RunWith;
 import org.mockito.Mock;
 import org.mockito.junit.MockitoJUnitRunner;
 
+@SuppressWarnings("unchecked")
 @RunWith(MockitoJUnitRunner.class)
 public class KsqlBareOutputNodeTest {
 
@@ -126,9 +127,9 @@ public class KsqlBareOutputNodeTest {
   public void shouldCreateCorrectSchema() {
     final LogicalSchema schema = stream.getSchema();
     assertThat(schema.value(), contains(
-        Column.of(ColumnName.of("COL0"), SqlTypes.BIGINT),
-        Column.of(ColumnName.of("COL2"), SqlTypes.STRING),
-        Column.of(ColumnName.of("COL3"), SqlTypes.DOUBLE)));
+        valueColumn(ColumnName.of("COL0"), SqlTypes.BIGINT),
+        valueColumn(ColumnName.of("COL2"), SqlTypes.STRING),
+        valueColumn(ColumnName.of("COL3"), SqlTypes.DOUBLE)));
   }
 
   @Test

--- a/ksql-engine/src/test/java/io/confluent/ksql/structured/SchemaKStreamTest.java
+++ b/ksql-engine/src/test/java/io/confluent/ksql/structured/SchemaKStreamTest.java
@@ -15,6 +15,7 @@
 
 package io.confluent.ksql.structured;
 
+import static io.confluent.ksql.schema.ksql.ColumnMatchers.valueColumn;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.contains;
 import static org.hamcrest.Matchers.equalTo;
@@ -170,9 +171,9 @@ public class SchemaKStreamTest {
 
     // Then:
     assertThat(projectedSchemaKStream.getSchema().value(), contains(
-        Column.of(ColumnName.of("COL0"), SqlTypes.BIGINT),
-        Column.of(ColumnName.of("COL2"), SqlTypes.STRING),
-        Column.of(ColumnName.of("COL3"), SqlTypes.DOUBLE)
+        valueColumn(ColumnName.of("COL0"), SqlTypes.BIGINT),
+        valueColumn(ColumnName.of("COL2"), SqlTypes.STRING),
+        valueColumn(ColumnName.of("COL3"), SqlTypes.DOUBLE)
     ));
     assertThat(projectedSchemaKStream.getSourceSchemaKStreams().get(0), is(initialSchemaKStream));
   }
@@ -335,9 +336,9 @@ public class SchemaKStreamTest {
 
     // Then:
     assertThat(projectedSchemaKStream.getSchema().value(), contains(
-        Column.of(ColumnName.of("COL0"), SqlTypes.BIGINT),
-        Column.of(ColumnName.of("KSQL_COL_1"), SqlTypes.INTEGER),
-        Column.of(ColumnName.of("KSQL_COL_2"), SqlTypes.DOUBLE)
+        valueColumn(ColumnName.of("COL0"), SqlTypes.BIGINT),
+        valueColumn(ColumnName.of("KSQL_COL_1"), SqlTypes.INTEGER),
+        valueColumn(ColumnName.of("KSQL_COL_2"), SqlTypes.DOUBLE)
     ));
 
     assertThat(projectedSchemaKStream.getSourceSchemaKStreams().get(0), is(initialSchemaKStream));
@@ -358,14 +359,14 @@ public class SchemaKStreamTest {
 
     // Then:
     assertThat(filteredSchemaKStream.getSchema().value(), contains(
-        Column.of(TEST1, ColumnName.of("ROWTIME"), SqlTypes.BIGINT),
-        Column.of(TEST1, ColumnName.of("ROWKEY"), SqlTypes.STRING),
-        Column.of(TEST1, ColumnName.of("COL0"), SqlTypes.BIGINT),
-        Column.of(TEST1, ColumnName.of("COL1"), SqlTypes.STRING),
-        Column.of(TEST1, ColumnName.of("COL2"), SqlTypes.STRING),
-        Column.of(TEST1, ColumnName.of("COL3"), SqlTypes.DOUBLE),
-        Column.of(TEST1, ColumnName.of("COL4"), SqlTypes.array(SqlTypes.DOUBLE)),
-        Column.of(TEST1, ColumnName.of("COL5"), SqlTypes.map(SqlTypes.DOUBLE))
+        valueColumn(TEST1, ColumnName.of("ROWTIME"), SqlTypes.BIGINT),
+        valueColumn(TEST1, ColumnName.of("ROWKEY"), SqlTypes.STRING),
+        valueColumn(TEST1, ColumnName.of("COL0"), SqlTypes.BIGINT),
+        valueColumn(TEST1, ColumnName.of("COL1"), SqlTypes.STRING),
+        valueColumn(TEST1, ColumnName.of("COL2"), SqlTypes.STRING),
+        valueColumn(TEST1, ColumnName.of("COL3"), SqlTypes.DOUBLE),
+        valueColumn(TEST1, ColumnName.of("COL4"), SqlTypes.array(SqlTypes.DOUBLE)),
+        valueColumn(TEST1, ColumnName.of("COL5"), SqlTypes.map(SqlTypes.DOUBLE))
     ));
 
     assertThat(filteredSchemaKStream.getSourceSchemaKStreams().get(0), is(initialSchemaKStream));
@@ -843,11 +844,11 @@ public class SchemaKStreamTest {
     final String leftAlias = "left";
     final String rightAlias = "right";
     for (final Column field : leftSchema.value()) {
-      schemaBuilder.valueColumn(Column.of(SourceName.of(leftAlias), field.name(), field.type()));
+      schemaBuilder.valueColumn(SourceName.of(leftAlias), field.name(), field.type());
     }
 
     for (final Column field : rightSchema.value()) {
-      schemaBuilder.valueColumn(Column.of(SourceName.of(rightAlias), field.name(), field.type()));
+      schemaBuilder.valueColumn(SourceName.of(rightAlias), field.name(), field.type());
     }
     return schemaBuilder.build();
   }

--- a/ksql-engine/src/test/java/io/confluent/ksql/structured/SchemaKTableTest.java
+++ b/ksql-engine/src/test/java/io/confluent/ksql/structured/SchemaKTableTest.java
@@ -15,6 +15,7 @@
 
 package io.confluent.ksql.structured;
 
+import static io.confluent.ksql.schema.ksql.ColumnMatchers.valueColumn;
 import static org.easymock.EasyMock.anyObject;
 import static org.easymock.EasyMock.capture;
 import static org.easymock.EasyMock.eq;
@@ -287,9 +288,9 @@ public class SchemaKTableTest {
 
     // Then:
     assertThat(projectedSchemaKStream.getSchema().value(), contains(
-        Column.of(ColumnName.of("COL0"), SqlTypes.BIGINT),
-        Column.of(ColumnName.of("COL2"), SqlTypes.STRING),
-        Column.of(ColumnName.of("COL3"), SqlTypes.DOUBLE)
+        valueColumn(ColumnName.of("COL0"), SqlTypes.BIGINT),
+        valueColumn(ColumnName.of("COL2"), SqlTypes.STRING),
+        valueColumn(ColumnName.of("COL3"), SqlTypes.DOUBLE)
     ));
 
     assertThat(projectedSchemaKStream.getSourceSchemaKStreams().get(0), is(initialSchemaKTable));
@@ -344,9 +345,9 @@ public class SchemaKTableTest {
 
     // Then:
     assertThat(projectedSchemaKStream.getSchema().value(), contains(
-        Column.of(ColumnName.of("COL0"), SqlTypes.BIGINT),
-        Column.of(ColumnName.of("KSQL_COL_1"), SqlTypes.INTEGER),
-        Column.of(ColumnName.of("KSQL_COL_2"), SqlTypes.DOUBLE)
+        valueColumn(ColumnName.of("COL0"), SqlTypes.BIGINT),
+        valueColumn(ColumnName.of("KSQL_COL_1"), SqlTypes.INTEGER),
+        valueColumn(ColumnName.of("KSQL_COL_2"), SqlTypes.DOUBLE)
     ));
 
     assertThat(projectedSchemaKStream.getSourceSchemaKStreams().get(0), is(initialSchemaKTable));
@@ -369,13 +370,13 @@ public class SchemaKTableTest {
     // Then:
     final SourceName test2 = SourceName.of("TEST2");
     assertThat(filteredSchemaKStream.getSchema().value(), contains(
-        Column.of(test2, ColumnName.of("ROWTIME"), SqlTypes.BIGINT),
-        Column.of(test2, ColumnName.of("ROWKEY"), SqlTypes.STRING),
-        Column.of(test2, ColumnName.of("COL0"), SqlTypes.BIGINT),
-        Column.of(test2, ColumnName.of("COL1"), SqlTypes.STRING),
-        Column.of(test2, ColumnName.of("COL2"), SqlTypes.STRING),
-        Column.of(test2, ColumnName.of("COL3"), SqlTypes.DOUBLE),
-        Column.of(test2, ColumnName.of("COL4"), SqlTypes.BOOLEAN)
+        valueColumn(test2, ColumnName.of("ROWTIME"), SqlTypes.BIGINT),
+        valueColumn(test2, ColumnName.of("ROWKEY"), SqlTypes.STRING),
+        valueColumn(test2, ColumnName.of("COL0"), SqlTypes.BIGINT),
+        valueColumn(test2, ColumnName.of("COL1"), SqlTypes.STRING),
+        valueColumn(test2, ColumnName.of("COL2"), SqlTypes.STRING),
+        valueColumn(test2, ColumnName.of("COL3"), SqlTypes.DOUBLE),
+        valueColumn(test2, ColumnName.of("COL4"), SqlTypes.BOOLEAN)
     ));
 
     assertThat(filteredSchemaKStream.getSourceSchemaKStreams().get(0), is(initialSchemaKTable));
@@ -811,11 +812,11 @@ public class SchemaKTableTest {
     final SourceName leftAlias = SourceName.of("left");
     final SourceName rightAlias = SourceName.of("right");
     for (final Column field : leftSchema.value()) {
-      schemaBuilder.valueColumn(Column.of(leftAlias, field.name(), field.type()));
+      schemaBuilder.valueColumn(leftAlias, field.name(), field.type());
     }
 
     for (final Column field : rightSchema.value()) {
-      schemaBuilder.valueColumn(Column.of(rightAlias, field.name(), field.type()));
+      schemaBuilder.valueColumn(rightAlias, field.name(), field.type());
     }
     return schemaBuilder.build();
   }

--- a/ksql-execution/src/main/java/io/confluent/ksql/execution/codegen/CodeGenRunner.java
+++ b/ksql-execution/src/main/java/io/confluent/ksql/execution/codegen/CodeGenRunner.java
@@ -145,9 +145,7 @@ public class CodeGenRunner {
       spec.addParameter(
           schemaColumn.ref(),
           SQL_TO_JAVA_TYPE_CONVERTER.toJavaType(schemaColumn.type()),
-          schema.valueColumnIndex(schemaColumn.ref())
-              .orElseThrow(() -> new KsqlException(
-                  "Expected to find column in schema, but was missing: " + schemaColumn))
+          schemaColumn.index()
       );
     }
 
@@ -156,7 +154,6 @@ public class CodeGenRunner {
       return null;
     }
 
-    @SuppressWarnings("deprecation") // Need to migrate away from Connect Schema use.
     public Void visitFunctionCall(FunctionCall node, Void context) {
       List<SqlType> argumentTypes = new ArrayList<>();
       FunctionName functionName = node.getName();

--- a/ksql-metastore/src/test/java/io/confluent/ksql/metastore/model/KeyFieldTest.java
+++ b/ksql-metastore/src/test/java/io/confluent/ksql/metastore/model/KeyFieldTest.java
@@ -15,8 +15,10 @@
 
 package io.confluent.ksql.metastore.model;
 
+import static io.confluent.ksql.schema.ksql.ColumnMatchers.valueColumn;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.not;
 
 import com.google.common.testing.EqualsTester;
 import io.confluent.ksql.name.ColumnName;
@@ -54,6 +56,7 @@ public class KeyFieldTest {
   @Rule
   public final ExpectedException expectedException = ExpectedException.none();
 
+  @SuppressWarnings("UnstableApiUsage")
   @Test
   public void shouldImplementHashCodeAndEqualsProperly() {
     final ColumnRef keyField = ColumnRef.withoutSource(ColumnName.of("key"));
@@ -134,6 +137,7 @@ public class KeyFieldTest {
     keyField.resolve(SCHEMA);
   }
 
+  @SuppressWarnings("OptionalGetWithoutIsPresent")
   @Test
   public void shouldResolveKeyField() {
     // Given:
@@ -143,7 +147,8 @@ public class KeyFieldTest {
     final Optional<Column> resolved = keyField.resolve(SCHEMA);
 
     // Then:
-    assertThat(resolved, is(Optional.of(Column.of(VALID_COL_REF, VALID_COL_TYPE))));
+    assertThat(resolved, is(not(Optional.empty())));
+    assertThat(resolved.get(), is(valueColumn(VALID_COL_REF.source(), VALID_COL_REF.name(), VALID_COL_TYPE)));
   }
 
   @Test

--- a/ksql-metastore/src/test/java/io/confluent/ksql/metastore/model/MetaStoreModelTest.java
+++ b/ksql-metastore/src/test/java/io/confluent/ksql/metastore/model/MetaStoreModelTest.java
@@ -27,6 +27,7 @@ import io.confluent.ksql.execution.ddl.commands.KsqlTopic;
 import io.confluent.ksql.name.ColumnName;
 import io.confluent.ksql.name.SourceName;
 import io.confluent.ksql.schema.ksql.Column;
+import io.confluent.ksql.schema.ksql.Column.Namespace;
 import io.confluent.ksql.schema.ksql.ColumnRef;
 import io.confluent.ksql.schema.ksql.LogicalSchema;
 import io.confluent.ksql.schema.ksql.types.SqlType;
@@ -48,6 +49,7 @@ import org.junit.runners.Parameterized;
 /**
  * Meta test to ensure all model classes meet certain requirements
  */
+@SuppressWarnings("UnstableApiUsage")
 @RunWith(Parameterized.class)
 public class MetaStoreModelTest {
 
@@ -64,7 +66,7 @@ public class MetaStoreModelTest {
       .put(org.apache.kafka.connect.data.Field.class,
           new org.apache.kafka.connect.data.Field("bob", 1, Schema.OPTIONAL_STRING_SCHEMA))
       .put(KeyField.class, KeyField.of(Optional.empty()))
-      .put(Column.class, Column.of(ColumnName.of("someField"), SqlTypes.INTEGER))
+      .put(Column.class, Column.of(Optional.empty(), ColumnName.of("someField"), SqlTypes.INTEGER, Namespace.VALUE, 1))
       .put(SqlType.class, SqlTypes.INTEGER)
       .put(LogicalSchema.class, LogicalSchema.builder()
           .valueColumn(ColumnName.of("f0"), SqlTypes.BIGINT)

--- a/ksql-rest-app/src/main/java/io/confluent/ksql/rest/entity/TableRowsEntityFactory.java
+++ b/ksql-rest-app/src/main/java/io/confluent/ksql/rest/entity/TableRowsEntityFactory.java
@@ -35,12 +35,14 @@ import org.apache.kafka.connect.data.Struct;
  */
 public final class TableRowsEntityFactory {
 
+  @SuppressWarnings("deprecation")
   private static final List<Column> TIME_WINDOW_COLUMNS = ImmutableList
-      .of(Column.of(ColumnName.of("WINDOWSTART"), SqlTypes.BIGINT));
+      .of(Column.legacySystemWindowColumn(ColumnName.of("WINDOWSTART"), SqlTypes.BIGINT));
 
+  @SuppressWarnings("deprecation")
   private static final List<Column> SESSION_WINDOW_COLUMNS = ImmutableList.<Column>builder()
       .addAll(TIME_WINDOW_COLUMNS)
-      .add(Column.of(ColumnName.of("WINDOWEND"), SqlTypes.BIGINT))
+      .add(Column.legacySystemWindowColumn(ColumnName.of("WINDOWEND"), SqlTypes.BIGINT))
       .build();
 
   private TableRowsEntityFactory() {

--- a/ksql-streams/src/main/java/io/confluent/ksql/execution/streams/SourceBuilder.java
+++ b/ksql-streams/src/main/java/io/confluent/ksql/execution/streams/SourceBuilder.java
@@ -32,6 +32,7 @@ import io.confluent.ksql.execution.plan.WindowedTableSource;
 import io.confluent.ksql.execution.streams.timestamp.TimestampExtractionPolicy;
 import io.confluent.ksql.execution.streams.timestamp.TimestampExtractionPolicyFactory;
 import io.confluent.ksql.execution.timestamp.TimestampColumn;
+import io.confluent.ksql.schema.ksql.Column;
 import io.confluent.ksql.schema.ksql.LogicalSchema;
 import io.confluent.ksql.schema.ksql.PhysicalSchema;
 import io.confluent.ksql.serde.KeyFormat;
@@ -311,15 +312,19 @@ public final class SourceBuilder {
   private static TimestampExtractor timestampExtractor(
       final KsqlConfig ksqlConfig,
       final LogicalSchema sourceSchema,
-      final Optional<TimestampColumn> timestampColumn) {
+      final Optional<TimestampColumn> timestampColumn
+  ) {
     final TimestampExtractionPolicy timestampPolicy = TimestampExtractionPolicyFactory.create(
         ksqlConfig,
         sourceSchema,
         timestampColumn
     );
+
     final int timestampIndex = timestampColumn.map(TimestampColumn::getColumn)
-        .map(c -> sourceSchema.valueColumnIndex(c).orElseThrow(IllegalStateException::new))
+        .map(c -> sourceSchema.findValueColumn(c).orElseThrow(IllegalStateException::new))
+        .map(Column::index)
         .orElse(-1);
+
     return timestampPolicy.create(timestampIndex);
   }
 

--- a/ksql-streams/src/main/java/io/confluent/ksql/execution/streams/StreamSelectKeyBuilder.java
+++ b/ksql-streams/src/main/java/io/confluent/ksql/execution/streams/StreamSelectKeyBuilder.java
@@ -36,10 +36,12 @@ public final class StreamSelectKeyBuilder {
       final StreamSelectKey selectKey,
       final KsqlQueryBuilder queryBuilder) {
     final LogicalSchema sourceSchema = stream.getSchema();
+
     final Column keyColumn = sourceSchema.findValueColumn(selectKey.getFieldName())
         .orElseThrow(IllegalArgumentException::new);
-    final int keyIndexInValue = sourceSchema.valueColumnIndex(keyColumn.ref())
-        .orElseThrow(IllegalStateException::new);
+
+    final int keyIndexInValue = keyColumn.index();
+
     final boolean updateRowKey = selectKey.isUpdateRowKey();
     final KStream<?, GenericRow> kstream = stream.getStream();
     final KStream<Struct, GenericRow> rekeyed = kstream


### PR DESCRIPTION
### Description 

Prep work for primitive keys

As previously discussed, finally done:

* Removes the private `NamespacedColumn` in favour of adding a `Namespace` field to the existing `Column` type.
* Removes the `LogicalSchema.valueColumnIndex` in favour of adding a `index` fields to the existing `Column` type.
* Removes the overloaded factory methods in `Column`, (used almost exclusively in tests), in favour of using custom hamcrest matchers, and for the few remaining production uses, specific factory methods.
* Adds a `SimpleColumn` interface to, hopefully, make it clear that `valueColumns(scheam.key())` only adds columns with matching type and name, not namespace or index.

### Testing done 

`mvn test`

### Reviewer checklist
- [ ] Ensure docs are updated if necessary. (eg. if a user visible feature is being added or changed).
- [ ] Ensure relevant issues are linked (description should include text like "Fixes #<issue number>")

