### PR TITLE
feat: add JMX metric for commandRunner status

### DIFF
--- a/ksql-rest-app/src/main/java/io/confluent/ksql/rest/server/KsqlRestApplication.java
+++ b/ksql-rest-app/src/main/java/io/confluent/ksql/rest/server/KsqlRestApplication.java
@@ -519,7 +519,8 @@ public final class KsqlRestApplication extends ExecutableApplication<KsqlRestCon
         commandStore,
         maxStatementRetries,
         new ClusterTerminator(ksqlEngine, serviceContext, managedTopics),
-        serverState
+        serverState,
+        ksqlConfig.getString(KsqlConfig.KSQL_SERVICE_ID_CONFIG)
     );
 
     final KsqlResource ksqlResource = new KsqlResource(

--- a/ksql-rest-app/src/main/java/io/confluent/ksql/rest/server/KsqlRestApplication.java
+++ b/ksql-rest-app/src/main/java/io/confluent/ksql/rest/server/KsqlRestApplication.java
@@ -520,7 +520,9 @@ public final class KsqlRestApplication extends ExecutableApplication<KsqlRestCon
         maxStatementRetries,
         new ClusterTerminator(ksqlEngine, serviceContext, managedTopics),
         serverState,
-        ksqlConfig.getString(KsqlConfig.KSQL_SERVICE_ID_CONFIG)
+        ksqlConfig.getString(KsqlConfig.KSQL_SERVICE_ID_CONFIG),
+        Duration.ofMillis(restConfig.getLong(KsqlRestConfig.KSQL_COMMAND_RUNNER_HEALTH_CHECK_MS)),
+        metricsPrefix
     );
 
     final KsqlResource ksqlResource = new KsqlResource(

--- a/ksql-rest-app/src/main/java/io/confluent/ksql/rest/server/KsqlRestApplication.java
+++ b/ksql-rest-app/src/main/java/io/confluent/ksql/rest/server/KsqlRestApplication.java
@@ -521,7 +521,8 @@ public final class KsqlRestApplication extends ExecutableApplication<KsqlRestCon
         new ClusterTerminator(ksqlEngine, serviceContext, managedTopics),
         serverState,
         ksqlConfig.getString(KsqlConfig.KSQL_SERVICE_ID_CONFIG),
-        Duration.ofMillis(restConfig.getLong(KsqlRestConfig.KSQL_COMMAND_RUNNER_HEALTH_CHECK_MS)),
+        Duration.ofMillis(restConfig.getLong(
+            KsqlRestConfig.KSQL_COMMAND_RUNNER_BLOCKED_THRESHHOLD_ERROR_MS)),
         metricsPrefix
     );
 

--- a/ksql-rest-app/src/main/java/io/confluent/ksql/rest/server/KsqlRestConfig.java
+++ b/ksql-rest-app/src/main/java/io/confluent/ksql/rest/server/KsqlRestConfig.java
@@ -77,10 +77,10 @@ public class KsqlRestConfig extends RestConfig {
       "Minimum time between consecutive health check evaluations. Health check queries before "
           + "the interval has elapsed will receive cached responses.";
 
-  static final String KSQL_COMMAND_RUNNER_HEALTH_CHECK_MS =
-          KSQL_CONFIG_PREFIX + "server.command.runner.healthcheck.ms";
+  static final String KSQL_COMMAND_RUNNER_BLOCKED_THRESHHOLD_ERROR_MS =
+          KSQL_CONFIG_PREFIX + "server.command.blocked.threshold.error.ms";
 
-  private static final String KSQL_COMMAND_RUNNER_HEALTH_CHECK_MS_DOC =
+  private static final String KSQL_COMMAND_RUNNER_BLOCKED_THRESHHOLD_ERROR_MS_DOC =
       "How long to wait for the command runner to process a command from the command topic "
           + "before reporting an error metric.";
 
@@ -131,11 +131,11 @@ public class KsqlRestConfig extends RestConfig {
         KSQL_HEALTHCHECK_INTERVAL_MS_DOC
     )
     .define(
-        KSQL_COMMAND_RUNNER_HEALTH_CHECK_MS,
+        KSQL_COMMAND_RUNNER_BLOCKED_THRESHHOLD_ERROR_MS,
         Type.LONG,
         15000L,
         Importance.LOW,
-        KSQL_COMMAND_RUNNER_HEALTH_CHECK_MS_DOC
+        KSQL_COMMAND_RUNNER_BLOCKED_THRESHHOLD_ERROR_MS_DOC
     );
   }
 

--- a/ksql-rest-app/src/main/java/io/confluent/ksql/rest/server/KsqlRestConfig.java
+++ b/ksql-rest-app/src/main/java/io/confluent/ksql/rest/server/KsqlRestConfig.java
@@ -77,6 +77,13 @@ public class KsqlRestConfig extends RestConfig {
       "Minimum time between consecutive health check evaluations. Health check queries before "
           + "the interval has elapsed will receive cached responses.";
 
+  static final String KSQL_COMMAND_RUNNER_HEALTH_CHECK_MS =
+          KSQL_CONFIG_PREFIX + "server.command.runner.healthcheck.ms";
+
+  private static final String KSQL_COMMAND_RUNNER_HEALTH_CHECK_MS_DOC =
+      "How long to wait for the command runner to process a command from the command topic "
+          + "before reporting an error metric.";
+
   private static final ConfigDef CONFIG_DEF;
 
   static {
@@ -122,6 +129,13 @@ public class KsqlRestConfig extends RestConfig {
         5000L,
         Importance.LOW,
         KSQL_HEALTHCHECK_INTERVAL_MS_DOC
+    )
+    .define(
+        KSQL_COMMAND_RUNNER_HEALTH_CHECK_MS,
+        Type.LONG,
+        15000L,
+        Importance.LOW,
+        KSQL_COMMAND_RUNNER_HEALTH_CHECK_MS_DOC
     );
   }
 

--- a/ksql-rest-app/src/main/java/io/confluent/ksql/rest/server/computation/CommandRunnerStatusMetric.java
+++ b/ksql-rest-app/src/main/java/io/confluent/ksql/rest/server/computation/CommandRunnerStatusMetric.java
@@ -34,19 +34,21 @@ public class CommandRunnerStatusMetric implements Closeable {
 
   private static final String DEFAULT_METRIC_GROUP_PREFIX = "ksql-rest-app";
   private static final String METRIC_GROUP_POST_FIX = "-command-runner";
-  private static final String metricGroupName = DEFAULT_METRIC_GROUP_PREFIX + METRIC_GROUP_POST_FIX;
   
   private final Metrics metrics;
   private final MetricName metricName;
+  private final String metricGroupName;
 
   CommandRunnerStatusMetric(
       final String ksqlServiceId,
-      final CommandRunner commandRunner
+      final CommandRunner commandRunner,
+      final String metricGroupPrefix
   ) {
     this(
         MetricCollectors.getMetrics(),
         commandRunner,
-        ksqlServiceId
+        ksqlServiceId,
+        metricGroupPrefix.isEmpty() ? DEFAULT_METRIC_GROUP_PREFIX : metricGroupPrefix
     );
   }
 
@@ -54,9 +56,11 @@ public class CommandRunnerStatusMetric implements Closeable {
   CommandRunnerStatusMetric(
       final Metrics metrics,
       final CommandRunner commandRunner,
-      final String ksqlServiceId
+      final String ksqlServiceId,
+      final String metricsGroupPrefix
   ) {
     this.metrics =  Objects.requireNonNull(metrics, "metrics");
+    this.metricGroupName = metricsGroupPrefix + METRIC_GROUP_POST_FIX;
     this.metricName = metrics.metricName(
         "status",
         KsqlConstants.KSQL_INTERNAL_TOPIC_PREFIX + ksqlServiceId + metricGroupName,

--- a/ksql-rest-app/src/main/java/io/confluent/ksql/rest/server/computation/CommandRunnerStatusMetric.java
+++ b/ksql-rest-app/src/main/java/io/confluent/ksql/rest/server/computation/CommandRunnerStatusMetric.java
@@ -1,0 +1,78 @@
+/*
+ * Copyright 2019 Confluent Inc.
+ *
+ * Licensed under the Confluent Community License (the "License"); you may not use
+ * this file except in compliance with the License.  You may obtain a copy of the
+ * License at
+ *
+ * http://www.confluent.io/confluent-community-license
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package io.confluent.ksql.rest.server.computation;
+
+import com.google.common.annotations.VisibleForTesting;
+import io.confluent.ksql.metrics.MetricCollectors;
+import io.confluent.ksql.util.KsqlConstants;
+
+import java.io.Closeable;
+import java.util.Collections;
+import java.util.Objects;
+
+import org.apache.kafka.common.MetricName;
+import org.apache.kafka.common.metrics.Gauge;
+import org.apache.kafka.common.metrics.Metrics;
+
+/**
+ * Emits a JMX metric that indicates the health of the CommandRunner thread. 
+ */
+public class CommandRunnerStatusMetric implements Closeable {
+
+  private static final String DEFAULT_METRIC_GROUP_PREFIX = "ksql-rest-app";
+  private static final String METRIC_GROUP_POST_FIX = "-command-runner";
+  private static final String metricGroupName = DEFAULT_METRIC_GROUP_PREFIX + METRIC_GROUP_POST_FIX;
+  
+  private final Metrics metrics;
+  private final MetricName metricName;
+
+  CommandRunnerStatusMetric(
+      final String ksqlServiceId,
+      final CommandRunner commandRunner
+  ) {
+    this(
+        MetricCollectors.getMetrics(),
+        commandRunner,
+        ksqlServiceId
+    );
+  }
+
+  @VisibleForTesting
+  CommandRunnerStatusMetric(
+      final Metrics metrics,
+      final CommandRunner commandRunner,
+      final String ksqlServiceId
+  ) {
+    this.metrics =  Objects.requireNonNull(metrics, "metrics");
+    this.metricName = metrics.metricName(
+        "status",
+        KsqlConstants.KSQL_INTERNAL_TOPIC_PREFIX + ksqlServiceId + metricGroupName,
+       "The status of the commandRunner thread as it processes the command topic.",
+        Collections.emptyMap()
+    );
+
+    this.metrics.addMetric(metricName, (Gauge<String>)
+        (config, now) -> commandRunner.checkCommandRunnerStatus().name());
+  }
+
+  /**
+   * Close the metric
+   */
+  @Override
+  public void close() {
+    metrics.removeMetric(metricName);
+  }
+}

--- a/ksql-rest-app/src/test/java/io/confluent/ksql/rest/server/computation/CommandRunnerStatusMetricTest.java
+++ b/ksql-rest-app/src/test/java/io/confluent/ksql/rest/server/computation/CommandRunnerStatusMetricTest.java
@@ -1,0 +1,108 @@
+/*
+ * Copyright 2019 Confluent Inc.
+ *
+ * Licensed under the Confluent Community License (the "License"); you may not use
+ * this file except in compliance with the License.  You may obtain a copy of the
+ * License at
+ *
+ * http://www.confluent.io/confluent-community-license
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package io.confluent.ksql.rest.server.computation;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyMap;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.ArgumentMatchers.isA;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.google.common.collect.ImmutableMap;
+import org.apache.kafka.common.MetricName;
+import org.apache.kafka.common.metrics.Gauge;
+import org.apache.kafka.common.metrics.Metrics;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Captor;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnitRunner;
+
+import java.util.Collections;
+
+@RunWith(MockitoJUnitRunner.class)
+public class CommandRunnerStatusMetricTest {
+
+  private static final MetricName METRIC_NAME =
+      new MetricName("bob", "g1", "d1", ImmutableMap.of());
+  private static final String KSQL_SERVICE_ID = "kcql-1-";
+
+  @Mock
+  private Metrics metrics;
+  @Mock
+  private CommandRunner commandRunner;
+  @Captor
+  private ArgumentCaptor<Gauge<String>> gaugeCaptor;
+
+  private CommandRunnerStatusMetric commandRunnerStatusMetric;
+
+  @Before
+  public void setUp() {
+    when(metrics.metricName(any(), any(), any(), anyMap())).thenReturn(METRIC_NAME);
+    when(commandRunner.checkCommandRunnerStatus()).thenReturn(CommandRunner.CommandRunnerStatus.RUNNING);
+
+    commandRunnerStatusMetric = new CommandRunnerStatusMetric(metrics, commandRunner, KSQL_SERVICE_ID, "rest");
+  }
+
+  @Test
+  public void shouldAddMetricOnCreation() {
+    // When:
+    // Listener created in setup
+
+    // Then:
+    verify(metrics).metricName("status", "_confluent-ksql-kcql-1-rest-command-runner",
+            "The status of the commandRunner thread as it processes the command topic.",
+            Collections.emptyMap());
+
+    verify(metrics).addMetric(eq(METRIC_NAME), isA(Gauge.class));
+  }
+
+  @Test
+  public void shouldInitiallyBeRunningState() {
+    // When:
+    // CommandRunnerStatusMetric created in setup
+
+    // Then:
+    assertThat(currentGaugeValue(), is(CommandRunner.CommandRunnerStatus.RUNNING.name()));
+  }
+
+  @Test
+  public void shouldUpdateToErrorState() {
+    // When:
+    when(commandRunner.checkCommandRunnerStatus()).thenReturn(CommandRunner.CommandRunnerStatus.ERROR);
+
+    // Then:
+    assertThat(currentGaugeValue(), is(CommandRunner.CommandRunnerStatus.ERROR.name()));
+  }
+
+  @Test
+  public void shouldRemoveMetricOnClose() {
+    // When:
+    commandRunnerStatusMetric.close();
+
+    // Then:
+    verify(metrics).removeMetric(METRIC_NAME);
+  }
+
+  private String currentGaugeValue() {
+    verify(metrics).addMetric(any(), gaugeCaptor.capture());
+    return gaugeCaptor.getValue().value(null, 0L);
+  }
+}

--- a/ksql-rest-app/src/test/java/io/confluent/ksql/rest/server/computation/CommandRunnerTest.java
+++ b/ksql-rest-app/src/test/java/io/confluent/ksql/rest/server/computation/CommandRunnerTest.java
@@ -16,12 +16,15 @@
 package io.confluent.ksql.rest.server.computation;
 
 import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.not;
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.notNullValue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyList;
 import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.ArgumentMatchers.isNotNull;
 import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.inOrder;
@@ -29,19 +32,21 @@ import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 import static org.mockito.hamcrest.MockitoHamcrest.argThat;
+import static io.confluent.ksql.test.util.AssertEventually.assertThatEventually;
 
 import io.confluent.ksql.engine.KsqlEngine;
 import io.confluent.ksql.metrics.MetricCollectors;
 import io.confluent.ksql.rest.server.state.ServerState;
 import io.confluent.ksql.rest.util.ClusterTerminator;
 import io.confluent.ksql.rest.util.TerminateCluster;
+
+import java.time.Clock;
 import java.time.Duration;
+import java.time.Instant;
 import java.util.Arrays;
-import java.util.concurrent.BrokenBarrierException;
-import java.util.concurrent.CompletableFuture;
-import java.util.concurrent.CyclicBarrier;
-import java.util.concurrent.ExecutionException;
+import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.ExecutorService;
+import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicReference;
 
 import org.junit.Before;
@@ -54,7 +59,7 @@ import org.mockito.stubbing.Answer;
 
 @RunWith(MockitoJUnitRunner.class)
 public class CommandRunnerTest {
-  private static long COMMAND_RUNNER_HEALTH_TIMEOUT = 2000;
+  private static long COMMAND_RUNNER_HEALTH_TIMEOUT = 1000;
 
   @Mock
   private InteractiveStatementExecutor statementExecutor;
@@ -66,6 +71,8 @@ public class CommandRunnerTest {
   private ServerState serverState;
   @Mock
   private KsqlEngine ksqlEngine;
+  @Mock
+  private Clock clock;
   @Mock
   private Command command;
   @Mock
@@ -104,7 +111,8 @@ public class CommandRunnerTest {
         serverState,
         "ksql-service-id",
         Duration.ofMillis(COMMAND_RUNNER_HEALTH_TIMEOUT),
-        ""
+        "",
+        clock
     );
   }
 
@@ -183,71 +191,41 @@ public class CommandRunnerTest {
   }
 
   @Test
-  public void shouldReportRunningIfNotStuckProcessingCommand() throws BrokenBarrierException, InterruptedException, ExecutionException {
-    try {
-      checkCommandRunnerStatus(
-          COMMAND_RUNNER_HEALTH_TIMEOUT - 500,
-          COMMAND_RUNNER_HEALTH_TIMEOUT - 1000,
-          CommandRunner.CommandRunnerStatus.RUNNING
-      );
-    } catch (Exception e) {
-      // fail test if an exception happens
-      assertThat(true, equalTo(false));
-    }
-  }
-
-  @Test
-  public void shouldReportErrorIfStuckProcessingCommand() throws BrokenBarrierException, InterruptedException, ExecutionException {
-    try {
-      checkCommandRunnerStatus(
-          COMMAND_RUNNER_HEALTH_TIMEOUT + 1000,
-          COMMAND_RUNNER_HEALTH_TIMEOUT + 500,
-          CommandRunner.CommandRunnerStatus.ERROR
-      );
-    } catch (Exception e) {
-      // fail test if an exception happens
-      assertThat(true, equalTo(false));
-    }
-  }
-
-  private void checkCommandRunnerStatus(
-      long commandProcessingTimeMs,
-      long timeToCheckMetricMs,
-      CommandRunner.CommandRunnerStatus expectedStatus
-  ) throws BrokenBarrierException, InterruptedException, ExecutionException {
+  public void shouldTransitionFromRunningToError() throws InterruptedException {
     // Given:
     givenQueuedCommands(queuedCommand1);
-    doAnswer((Answer) invocation -> {
-      Thread.sleep(commandProcessingTimeMs);
+
+    final Instant current = Instant.now();
+    final CountDownLatch handleStatementLatch = new CountDownLatch(1);
+    final CountDownLatch commandSetLatch = new CountDownLatch(1);
+    when(clock.instant()).thenReturn(current)
+        .thenReturn(current.plusMillis(500))
+        .thenReturn(current.plusMillis(1500))
+        .thenReturn(current.plusMillis(2500));
+    doAnswer(invocation -> {
+      commandSetLatch.countDown();
+      handleStatementLatch.await();
       return null;
     }).when(statementExecutor).handleStatement(queuedCommand1);
 
     // When:
-    final CyclicBarrier gate = new CyclicBarrier(3);
     AtomicReference<Exception> expectedException = new AtomicReference<>(null);
-    (new Thread(() -> {
+    final Thread commandRunnerThread = (new Thread(() -> {
       try {
-        gate.await();
         commandRunner.fetchAndRunCommands();
       } catch (Exception e) {
         expectedException.set(e);
       }
-    })).start();
-
-    CompletableFuture<CommandRunner.CommandRunnerStatus> statusFuture = new CompletableFuture<>();
-    (new Thread(() -> {
-      try {
-        gate.await();
-        Thread.sleep(timeToCheckMetricMs);
-        statusFuture.complete(commandRunner.checkCommandRunnerStatus());
-      } catch (Exception e) {
-        expectedException.set(e);
-      }
-    })).start();
+    }));
 
     // Then:
-    gate.await();
-    assertThat(statusFuture.get(), equalTo(expectedStatus));
+    commandRunnerThread.start();
+    commandSetLatch.await();
+    assertThat(commandRunner.checkCommandRunnerStatus(), is(CommandRunner.CommandRunnerStatus.RUNNING));
+    assertThat(commandRunner.checkCommandRunnerStatus(), is(CommandRunner.CommandRunnerStatus.ERROR));
+    handleStatementLatch.countDown();
+    commandRunnerThread.join();
+    assertThat(commandRunner.checkCommandRunnerStatus(), is(CommandRunner.CommandRunnerStatus.RUNNING));
     assertThat(expectedException.get(), equalTo(null));
   }
 

--- a/ksql-rest-app/src/test/java/io/confluent/ksql/rest/server/computation/CommandRunnerTest.java
+++ b/ksql-rest-app/src/test/java/io/confluent/ksql/rest/server/computation/CommandRunnerTest.java
@@ -29,6 +29,7 @@ import static org.mockito.Mockito.when;
 import static org.mockito.hamcrest.MockitoHamcrest.argThat;
 
 import io.confluent.ksql.engine.KsqlEngine;
+import io.confluent.ksql.metrics.MetricCollectors;
 import io.confluent.ksql.rest.server.state.ServerState;
 import io.confluent.ksql.rest.util.ClusterTerminator;
 import io.confluent.ksql.rest.util.TerminateCluster;
@@ -72,6 +73,7 @@ public class CommandRunnerTest {
 
   @Before
   public void setup() {
+    MetricCollectors.initialize();
     when(statementExecutor.getKsqlEngine()).thenReturn(ksqlEngine);
 
     when(command.getStatement()).thenReturn("something that is not terminate");
@@ -90,7 +92,9 @@ public class CommandRunnerTest {
         1,
         clusterTerminator,
         executor,
-        serverState);
+        serverState,
+        "ksql-service-id"
+    );
   }
 
   @Test

--- a/ksql-rest-app/src/test/java/io/confluent/ksql/rest/server/computation/RecoveryTest.java
+++ b/ksql-rest-app/src/test/java/io/confluent/ksql/rest/server/computation/RecoveryTest.java
@@ -34,6 +34,7 @@ import io.confluent.ksql.internal.KsqlEngineMetrics;
 import io.confluent.ksql.metastore.MetaStore;
 import io.confluent.ksql.metastore.MetaStoreImpl;
 import io.confluent.ksql.metastore.model.DataSource;
+import io.confluent.ksql.metrics.MetricCollectors;
 import io.confluent.ksql.name.SourceName;
 import io.confluent.ksql.query.QueryId;
 import io.confluent.ksql.query.id.SpecificQueryIdGenerator;
@@ -202,13 +203,16 @@ public class RecoveryTest {
           queryIdGenerator
       );
 
+      MetricCollectors.initialize();
       this.commandRunner = new CommandRunner(
           statementExecutor,
           fakeCommandQueue,
           1,
           mock(ClusterTerminator.class),
           serverState,
-          "ksql-service-id"
+          "ksql-service-id",
+          Duration.ofMillis(2000),
+          ""
       );
 
       this.ksqlResource = new KsqlResource(

--- a/ksql-rest-app/src/test/java/io/confluent/ksql/rest/server/computation/RecoveryTest.java
+++ b/ksql-rest-app/src/test/java/io/confluent/ksql/rest/server/computation/RecoveryTest.java
@@ -207,7 +207,8 @@ public class RecoveryTest {
           fakeCommandQueue,
           1,
           mock(ClusterTerminator.class),
-          serverState
+          serverState,
+          "ksql-service-id"
       );
 
       this.ksqlResource = new KsqlResource(


### PR DESCRIPTION
### Description 
https://github.com/confluentinc/ksql/pull/3962 changes the commandRunner to never skip a command if it's gone through the transaction protocol. We need to expose some metric that can be used to alert if the commandRunner thread is stuck on a particular command.

This PR introduces a JMX metric for the commandRunner thread status.

### Testing done 
Cherry-picked https://github.com/confluentinc/ksql/pull/3962 to this branch for testing.
Put `CREATE STREAM qwerqweq(age BIGINT) WITH (KAFKA_TOPIC='foo',  VALUE_FORMAT='DELIMITED');` into the command topic

Deleted topic foo
Started server
Watched the metric value in JConsole, after 15 seconds it went from RUNNING to ERROR since it was stuck processing the above command.
Created topic foo with zookeeper
The server completed start up and the metric value went back to RUNNING

### Reviewer checklist
- [ ] Ensure docs are updated if necessary. (eg. if a user visible feature is being added or changed).
- [ ] Ensure relevant issues are linked (description should include text like "Fixes #<issue number>")

