### PR TITLE
refactor: get ROWKEY from key of Kafka record in topology steps

### DIFF
--- a/ksql-common/src/main/java/io/confluent/ksql/schema/ksql/Column.java
+++ b/ksql-common/src/main/java/io/confluent/ksql/schema/ksql/Column.java
@@ -29,9 +29,9 @@ import java.util.Optional;
 public final class Column implements SimpleColumn {
 
   public enum Namespace {
-    META,
     KEY,
-    VALUE
+    VALUE,
+    META
   }
 
   private final ColumnRef ref;

--- a/ksql-common/src/main/java/io/confluent/ksql/schema/ksql/LogicalSchema.java
+++ b/ksql-common/src/main/java/io/confluent/ksql/schema/ksql/LogicalSchema.java
@@ -26,6 +26,7 @@ import io.confluent.ksql.schema.ksql.types.SqlTypes;
 import io.confluent.ksql.util.KsqlException;
 import io.confluent.ksql.util.SchemaUtil;
 import java.util.Arrays;
+import java.util.Comparator;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
@@ -238,9 +239,13 @@ public final class LogicalSchema {
   }
 
   private Optional<Column> findColumnMatching(final Predicate<Column> predicate) {
+    // At the moment, it's possible for some column names to have multiple matches, e.g.
+    // ROWKEY and ROWTIME. Order of preference on namespace is KEY, VALUE then META,
+    // as per Namespace enum ordinal.
+
     return columns.stream()
         .filter(predicate)
-        .findFirst();
+        .min(Comparator.comparingInt(c -> c.namespace().ordinal()));
   }
 
   private Map<Namespace, List<Column>> byNamespace() {

--- a/ksql-common/src/test/java/io/confluent/ksql/schema/ksql/LogicalSchemaTest.java
+++ b/ksql-common/src/test/java/io/confluent/ksql/schema/ksql/LogicalSchemaTest.java
@@ -356,6 +356,37 @@ public class LogicalSchemaTest {
   }
 
   @Test
+  public void shouldPreferKeyOverValueAndMetaColumns() {
+    // Given:
+    final LogicalSchema schema = LogicalSchema.builder()
+        // Implicit meta ROWTIME
+        .valueColumn(ROWTIME_NAME, BIGINT)
+        .keyColumn(ROWTIME_NAME, BIGINT)
+        .build();
+
+    // Then:
+    assertThat(
+        schema.findColumn(ColumnRef.withoutSource(ROWTIME_NAME)).map(Column::namespace),
+        is(Optional.of(Namespace.KEY))
+    );
+  }
+
+  @Test
+  public void shouldPreferValueOverMetaColumns() {
+    // Given:
+    final LogicalSchema schema = LogicalSchema.builder()
+        // Implicit meta ROWTIME
+        .valueColumn(ROWTIME_NAME, BIGINT)
+        .build();
+
+    // Then:
+    assertThat(
+        schema.findColumn(ColumnRef.withoutSource(ROWTIME_NAME)).map(Column::namespace),
+        is(Optional.of(Namespace.VALUE))
+    );
+  }
+
+  @Test
   public void shouldFindExactColumn() {
     // Given:
     final LogicalSchema schema = LogicalSchema.builder()

--- a/ksql-engine/src/main/java/io/confluent/ksql/engine/InsertValuesExecutor.java
+++ b/ksql-engine/src/main/java/io/confluent/ksql/engine/InsertValuesExecutor.java
@@ -441,7 +441,6 @@ public class InsertValuesExecutor {
     }
   }
 
-  @SuppressWarnings("TryFinallyCanBeTryWithResources")
   private static void sendRecord(
       final ProducerRecord<byte[], byte[]> record,
       final ServiceContext serviceContext,
@@ -528,7 +527,7 @@ public class InsertValuesExecutor {
           );
 
       // we expect no column references, so we can pass in an empty generic row
-      final Object value = metadata.evaluate(new GenericRow());
+      final Object value = metadata.evaluate(new Object(), new GenericRow());
 
       return defaultSqlValueCoercer.coerce(value, fieldType)
           .orElseThrow(() -> {

--- a/ksql-engine/src/main/java/io/confluent/ksql/engine/InsertValuesExecutor.java
+++ b/ksql-engine/src/main/java/io/confluent/ksql/engine/InsertValuesExecutor.java
@@ -526,7 +526,7 @@ public class InsertValuesExecutor {
                   functionRegistry)
           );
 
-      // we expect no column references, so we can pass in an empty generic row
+      // we expect no column references, so we can pass in an empty generic key and row
       final Object value = metadata.evaluate(new Object(), new GenericRow());
 
       return defaultSqlValueCoercer.coerce(value, fieldType)

--- a/ksql-engine/src/test/java/io/confluent/ksql/codegen/CodeGenRunnerTest.java
+++ b/ksql-engine/src/test/java/io/confluent/ksql/codegen/CodeGenRunnerTest.java
@@ -923,7 +923,7 @@ public class CodeGenRunnerTest {
 
         return analysis.getSelectExpressions().stream()
             .map(exp -> codeGenRunner.buildCodeGenFromParseTree(exp.getExpression(), "Select"))
-            .map(md -> md.evaluate(StructKeyUtil.asStructKey("rowKey"), input))
+            .map(md -> md.evaluate(key(), input))
             .collect(Collectors.toList());
     }
 

--- a/ksql-engine/src/test/java/io/confluent/ksql/codegen/CodeGenRunnerTest.java
+++ b/ksql-engine/src/test/java/io/confluent/ksql/codegen/CodeGenRunnerTest.java
@@ -19,7 +19,6 @@ import static io.confluent.ksql.testutils.AnalysisTestUtil.analyzeQuery;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.both;
 import static org.hamcrest.Matchers.contains;
-import static org.hamcrest.Matchers.containsInAnyOrder;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.greaterThanOrEqualTo;
 import static org.hamcrest.Matchers.hasSize;
@@ -37,6 +36,7 @@ import io.confluent.ksql.execution.codegen.CodeGenRunner;
 import io.confluent.ksql.execution.codegen.ExpressionMetadata;
 import io.confluent.ksql.execution.ddl.commands.KsqlTopic;
 import io.confluent.ksql.execution.expression.tree.Expression;
+import io.confluent.ksql.execution.util.StructKeyUtil;
 import io.confluent.ksql.function.InternalFunctionRegistry;
 import io.confluent.ksql.function.KsqlScalarFunction;
 import io.confluent.ksql.function.MutableFunctionRegistry;
@@ -71,6 +71,9 @@ import java.util.Optional;
 import java.util.stream.Collectors;
 import org.apache.kafka.connect.data.Schema;
 import org.apache.kafka.connect.data.Struct;
+import org.apache.kafka.streams.kstream.Windowed;
+import org.apache.kafka.streams.kstream.internals.SessionWindow;
+import org.apache.kafka.streams.kstream.internals.TimeWindow;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
@@ -177,7 +180,7 @@ public class CodeGenRunnerTest {
             ValueFormat.of(FormatInfo.of(Format.JSON))
         );
 
-        final KsqlStream ksqlStream = new KsqlStream<>(
+        final KsqlStream<?> ksqlStream = new KsqlStream<>(
             "sqlexpression",
             SourceName.of("CODEGEN_TEST"),
             META_STORE_SCHEMA,
@@ -216,13 +219,13 @@ public class CodeGenRunnerTest {
 
         final ExpressionMetadata expressionEvaluatorMetadata0 = codeGenRunner.buildCodeGenFromParseTree
             (analysis.getSelectExpressions().get(0).getExpression(), "Select");
-        assertThat(expressionEvaluatorMetadata0.getIndexes(), contains(0));
+
         assertThat(expressionEvaluatorMetadata0.arguments(), hasSize(1));
 
-        Object result0 = expressionEvaluatorMetadata0.evaluate(genericRow(null, 1));
+        Object result0 = expressionEvaluatorMetadata0.evaluate(key(), value(null, 1));
         assertThat(result0, is(true));
 
-        result0 = expressionEvaluatorMetadata0.evaluate(genericRow(12345L));
+        result0 = expressionEvaluatorMetadata0.evaluate(key(), value(12345L));
         assertThat(result0, is(false));
     }
 
@@ -235,10 +238,55 @@ public class CodeGenRunnerTest {
         // When:
         final Object result = codeGenRunner.buildCodeGenFromParseTree
             (analysis.getSelectExpressions().get(0).getExpression(), "Select")
-            .evaluate(genericRow(ONE_ROW));
+            .evaluate(key(), value(ONE_ROW));
 
         // Then:
         assertThat(result, is("1"));
+    }
+
+    @Test
+    public void shouldHandleKeyColumnsInSelect() {
+        // Given:
+        final String simpleQuery = "SELECT ROWKEY FROM CODEGEN_TEST EMIT CHANGES;";
+        final Analysis analysis = analyzeQuery(simpleQuery, metaStore);
+
+        // When:
+        final ExpressionMetadata evaluator = codeGenRunner.buildCodeGenFromParseTree
+            (analysis.getSelectExpressions().get(0).getExpression(), "Select");
+
+        // Then:
+        Object result = evaluator.evaluate(key("rowKey"), value());
+        assertThat(result, is("rowKey"));
+    }
+
+    @Test
+    public void shouldHandleKeyColumnsInSelectOfSessionWindowed() {
+        // Given:
+        final String simpleQuery = "SELECT ROWKEY FROM CODEGEN_TEST EMIT CHANGES;";
+        final Analysis analysis = analyzeQuery(simpleQuery, metaStore);
+
+        // When:
+        final ExpressionMetadata evaluator = codeGenRunner.buildCodeGenFromParseTree
+            (analysis.getSelectExpressions().get(0).getExpression(), "Select");
+
+        // Then:
+        Object result = evaluator.evaluate(sessionKey("rowKey", 10, 1000), value());
+        assertThat(result, is("rowKey : Window{start=10 end=1000}"));
+    }
+
+    @Test
+    public void shouldHandleKeyColumnsInSelectOfTimeWindowed() {
+        // Given:
+        final String simpleQuery = "SELECT ROWKEY FROM CODEGEN_TEST EMIT CHANGES;";
+        final Analysis analysis = analyzeQuery(simpleQuery, metaStore);
+
+        // When:
+        final ExpressionMetadata evaluator = codeGenRunner.buildCodeGenFromParseTree
+            (analysis.getSelectExpressions().get(0).getExpression(), "Select");
+
+        // Then:
+        Object result = evaluator.evaluate(windowedKey("rowKey", 10), value());
+        assertThat(result, is("rowKey : Window{start=10 end=-}"));
     }
 
     @Test
@@ -248,13 +296,13 @@ public class CodeGenRunnerTest {
 
         final ExpressionMetadata expressionEvaluatorMetadata0 = codeGenRunner.buildCodeGenFromParseTree
             (analysis.getSelectExpressions().get(0).getExpression(), "Filter");
-        assertThat(expressionEvaluatorMetadata0.getIndexes(), contains(0));
+
         assertThat(expressionEvaluatorMetadata0.arguments(), hasSize(1));
 
-        Object result0 = expressionEvaluatorMetadata0.evaluate(genericRow(null, "1"));
+        Object result0 = expressionEvaluatorMetadata0.evaluate(key(), value(null, "1"));
         assertThat(result0, is(false));
 
-        result0 = expressionEvaluatorMetadata0.evaluate(genericRow(12345L));
+        result0 = expressionEvaluatorMetadata0.evaluate(key(), value(12345L));
         assertThat(result0, is(true));
     }
 
@@ -664,7 +712,7 @@ public class CodeGenRunnerTest {
         // When:
         final Object result = codeGenRunner
             .buildCodeGenFromParseTree(expression, "Group By")
-            .evaluate(genericRow(ONE_ROW));
+            .evaluate(key(), value(ONE_ROW));
 
         // Then:
         assertThat(result, is("value1"));
@@ -683,7 +731,7 @@ public class CodeGenRunnerTest {
         // When:
         final Object result = codeGenRunner
             .buildCodeGenFromParseTree(expression, "math")
-            .evaluate(genericRow(ONE_ROW));
+            .evaluate(key(), value(ONE_ROW));
 
         // Then:
         assertThat(result, is((long) INVALID_JAVA_IDENTIFIER_INDEX));
@@ -706,7 +754,7 @@ public class CodeGenRunnerTest {
         // When:
         final Object result = codeGenRunner
             .buildCodeGenFromParseTree(expression, "Case")
-            .evaluate(genericRow(ONE_ROW));
+            .evaluate(key(), value(ONE_ROW));
 
         // Then:
         assertThat(result, is("small"));
@@ -729,7 +777,7 @@ public class CodeGenRunnerTest {
         // When:
         final Object result = codeGenRunner
             .buildCodeGenFromParseTree(expression, "Case")
-            .evaluate(genericRow(ONE_ROW));
+            .evaluate(key(), value(ONE_ROW));
 
         // Then:
         assertThat(result, is(100));
@@ -752,7 +800,7 @@ public class CodeGenRunnerTest {
         // When:
         final Object result = codeGenRunner
             .buildCodeGenFromParseTree(expression, "Case")
-            .evaluate(genericRow(ONE_ROW));
+            .evaluate(key(), value(ONE_ROW));
 
         // Then:
         assertThat(result, is(300));
@@ -774,7 +822,7 @@ public class CodeGenRunnerTest {
         // When:
         final Object result = codeGenRunner
             .buildCodeGenFromParseTree(expression, "Case")
-            .evaluate(genericRow(ONE_ROW));
+            .evaluate(key(), value(ONE_ROW));
 
         // Then:
         assertThat(result, is("large"));
@@ -795,7 +843,7 @@ public class CodeGenRunnerTest {
         // When:
         final Object result = codeGenRunner
             .buildCodeGenFromParseTree(expression, "Case")
-            .evaluate(genericRow(ONE_ROW));
+            .evaluate(key(), value(ONE_ROW));
 
         // Then:
         assertThat(result, is(nullValue()));
@@ -815,7 +863,7 @@ public class CodeGenRunnerTest {
         // When:
         final Object result = codeGenRunner
             .buildCodeGenFromParseTree(expression, "Select")
-            .evaluate(genericRow(ONE_ROW));
+            .evaluate(key(), value(ONE_ROW));
 
         // Then:
         assertThat(result, is("adelaide"));
@@ -875,7 +923,7 @@ public class CodeGenRunnerTest {
 
         return analysis.getSelectExpressions().stream()
             .map(exp -> codeGenRunner.buildCodeGenFromParseTree(exp.getExpression(), "Select"))
-            .map(md -> md.evaluate(input))
+            .map(md -> md.evaluate(StructKeyUtil.asStructKey("rowKey"), input))
             .collect(Collectors.toList());
     }
 
@@ -918,14 +966,14 @@ public class CodeGenRunnerTest {
 
         final ExpressionMetadata expressionEvaluatorMetadata0 = codeGenRunner.buildCodeGenFromParseTree
             (analysis.getSelectExpressions().get(0).getExpression(), "Filter");
-        assertThat(expressionEvaluatorMetadata0.getIndexes(), containsInAnyOrder(cola, colb));
+
         assertThat(expressionEvaluatorMetadata0.arguments(), hasSize(2));
 
         final List<Object> columns = new ArrayList<>(ONE_ROW);
         columns.set(cola, values[0]);
         columns.set(colb, values[1]);
 
-        final Object result0 = expressionEvaluatorMetadata0.evaluate(genericRow(columns));
+        final Object result0 = expressionEvaluatorMetadata0.evaluate(key(), value(columns));
         assertThat(result0, instanceOf(Boolean.class));
         return (Boolean)result0;
     }
@@ -964,7 +1012,7 @@ public class CodeGenRunnerTest {
         final List<Object> columns = new ArrayList<>(ONE_ROW);
         columns.set(col, val);
 
-        final Object result0 = expressionEvaluatorMetadata0.evaluate(genericRow(columns));
+        final Object result0 = expressionEvaluatorMetadata0.evaluate(key(), value(columns));
         assertThat(result0, instanceOf(Boolean.class));
         return (Boolean)result0;
     }
@@ -972,14 +1020,37 @@ public class CodeGenRunnerTest {
     private static GenericRow buildRow(final Map<Integer, Object> overrides) {
         final List<Object> columns = new ArrayList<>(ONE_ROW);
         overrides.forEach(columns::set);
-        return genericRow(columns);
+        return value(columns);
     }
 
-    private static GenericRow genericRow(final Object... columns) {
-        return genericRow(Arrays.asList(columns));
+    private static Struct key() {
+        return key("rowkey");
     }
 
-    private static GenericRow genericRow(final List<Object> columns) {
+    private static Struct key(final String rowKey) {
+        return StructKeyUtil.asStructKey(rowKey);
+    }
+
+    private static Windowed<Struct> sessionKey(
+        final String rowKey,
+        final int startMs,
+        final int endMs
+    ) {
+        return new Windowed<>(key(rowKey), new SessionWindow(startMs, endMs));
+    }
+
+    private static Windowed<Struct> windowedKey(
+        final String rowKey,
+        final int startMs
+    ) {
+        return new Windowed<>(key(rowKey), new TimeWindow(startMs, startMs + 1));
+    }
+
+    private static GenericRow value(final Object... columns) {
+        return value(Arrays.asList(columns));
+    }
+
+    private static GenericRow value(final List<Object> columns) {
         return new GenericRow(columns);
     }
 

--- a/ksql-execution/src/main/java/io/confluent/ksql/execution/codegen/CodeGenRunner.java
+++ b/ksql-execution/src/main/java/io/confluent/ksql/execution/codegen/CodeGenRunner.java
@@ -206,7 +206,7 @@ public class CodeGenRunner {
     }
 
     private void addRequiredColumn(final ColumnRef columnRef) {
-      final Column column = schema.findValueColumn(columnRef)
+      final Column column = schema.findColumn(columnRef)
           .orElseThrow(() -> new KsqlException(
               "Cannot find the select field in the available fields."
                   + " field: " + columnRef
@@ -215,6 +215,7 @@ public class CodeGenRunner {
       spec.addParameter(
           column.ref(),
           SQL_TO_JAVA_TYPE_CONVERTER.toJavaType(column.type()),
+          column.namespace(),
           column.index()
       );
     }

--- a/ksql-execution/src/main/java/io/confluent/ksql/execution/codegen/CodeGenSpec.java
+++ b/ksql-execution/src/main/java/io/confluent/ksql/execution/codegen/CodeGenSpec.java
@@ -15,6 +15,8 @@
 
 package io.confluent.ksql.execution.codegen;
 
+import static java.util.Objects.requireNonNull;
+
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableListMultimap;
 import com.google.common.collect.ImmutableMap;
@@ -22,14 +24,18 @@ import com.google.errorprone.annotations.Immutable;
 import io.confluent.ksql.GenericRow;
 import io.confluent.ksql.function.udf.Kudf;
 import io.confluent.ksql.name.FunctionName;
+import io.confluent.ksql.schema.ksql.Column.Namespace;
 import io.confluent.ksql.schema.ksql.ColumnRef;
 import io.confluent.ksql.testing.EffectivelyImmutable;
 import io.confluent.ksql.util.KsqlException;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.Optional;
-import java.util.OptionalInt;
+import org.apache.kafka.connect.data.Field;
+import org.apache.kafka.connect.data.Struct;
+import org.apache.kafka.streams.kstream.Window;
+import org.apache.kafka.streams.kstream.Windowed;
+import org.apache.kafka.streams.kstream.internals.SessionWindow;
 
 @Immutable
 public final class CodeGenSpec {
@@ -51,7 +57,7 @@ public final class CodeGenSpec {
     return arguments.stream().map(ArgumentSpec::name).toArray(String[]::new);
   }
 
-  public Class[] argumentTypes() {
+  public Class<?>[] argumentTypes() {
     return arguments.stream().map(ArgumentSpec::type).toArray(Class[]::new);
   }
 
@@ -71,22 +77,9 @@ public final class CodeGenSpec {
     return names.get(index);
   }
 
-  public void resolve(GenericRow row, Object[] parameters) {
+  public void resolve(final Object key, GenericRow row, Object[] parameters) {
     for (int paramIdx = 0; paramIdx < arguments.size(); paramIdx++) {
-      ArgumentSpec spec = arguments.get(paramIdx);
-
-      if (spec.colIndex().isPresent()) {
-        int colIndex = spec.colIndex().getAsInt();
-        parameters[paramIdx] = row.getColumns().get(colIndex);
-      } else {
-        int copyOfParamIdxForLambda = paramIdx;
-        parameters[paramIdx] = spec.kudf()
-            .orElseThrow(() -> new KsqlException(
-                "Expected parameter at index "
-                    + copyOfParamIdxForLambda
-                    + " to be a function, but was "
-                    + spec));
-      }
+      parameters[paramIdx] = arguments.get(paramIdx).resolve(key, row);
     }
   }
 
@@ -99,28 +92,31 @@ public final class CodeGenSpec {
 
     private int argumentCount = 0;
 
-    void addParameter(ColumnRef columnRef, Class<?> type, int colIndex) {
-      String codeName = CodeGenUtil.paramName(argumentCount);
-      argumentBuilder.add(new ArgumentSpec(
-          codeName,
-          type,
-          OptionalInt.of(colIndex),
-          Optional.empty()
-      ));
+    void addParameter(
+        final ColumnRef columnRef,
+        final Class<?> type,
+        final Namespace namespace,
+        final int colIndex
+    ) {
+      final String codeName = CodeGenUtil.paramName(argumentCount++);
       columnRefToName.put(columnRef, codeName);
-      argumentCount++;
+
+      switch (namespace) {
+        case KEY:
+          argumentBuilder.add(new KeyArgumentSpec(codeName, type, colIndex));
+          break;
+        case VALUE:
+          argumentBuilder.add(new ValueArgumentSpec(codeName, type, colIndex));
+          break;
+        default:
+          throw new UnsupportedOperationException();
+      }
     }
 
     void addFunction(FunctionName functionName, Kudf function) {
-      String codeName = CodeGenUtil.functionName(functionName, argumentCount);
+      final String codeName = CodeGenUtil.functionName(functionName, argumentCount++);
       functionNameBuilder.put(functionName, codeName);
-      argumentBuilder.add(new ArgumentSpec(
-          codeName,
-          function.getClass(),
-          OptionalInt.empty(),
-          Optional.of(function)
-      ));
-      argumentCount++;
+      argumentBuilder.add(new FunctionArgumentSpec(codeName, function.getClass(), function));
     }
 
     CodeGenSpec build() {
@@ -137,46 +133,145 @@ public final class CodeGenSpec {
    * {@code Kudf}.
    */
   @Immutable
-  public static class ArgumentSpec {
+  public interface ArgumentSpec {
+
+    String name();
+
+    Class<?> type();
+
+    Object resolve(Object key, GenericRow value);
+  }
+
+  @Immutable
+  private abstract static class BaseArgumentSpec implements ArgumentSpec {
 
     private final String name;
     private final Class<?> type;
-    private final OptionalInt columnIndex;
-    @EffectivelyImmutable
-    private final Optional<Kudf> kudf;
 
-    ArgumentSpec(String name, Class<?> type, OptionalInt columnIndex, Optional<Kudf> kudf) {
-      this.name = name;
-      this.type = type;
-      this.columnIndex = columnIndex;
-      this.kudf = kudf;
+    BaseArgumentSpec(
+        final String name,
+        final Class<?> type
+    ) {
+      this.name = requireNonNull(name, "name");
+      this.type = requireNonNull(type, "type");
     }
 
+    @Override
     public String name() {
       return name;
     }
 
+    @Override
     public Class<?> type() {
       return type;
     }
+  }
 
-    public OptionalInt colIndex() {
-      return columnIndex;
+  @Immutable
+  private static final class FunctionArgumentSpec extends BaseArgumentSpec {
+
+    @EffectivelyImmutable
+    private final Kudf kudf;
+
+    FunctionArgumentSpec(
+        final String name,
+        final Class<?> type,
+        final Kudf kudf
+    ) {
+      super(name, type);
+      this.kudf = requireNonNull(kudf, "kudf");
     }
 
-    public Optional<Kudf> kudf() {
+    @Override
+    public Object resolve(final Object key, final GenericRow value) {
       return kudf;
     }
 
     @Override
     public String toString() {
-      return "ArgumentSpec{"
-          + "name='" + name + '\''
-          + ", type=" + type
-          + ", columnIndex=" + columnIndex
+      return "FunctionArgumentSpec{"
+          + "name='" + name() + '\''
+          + ", type=" + type()
           + ", kudf=" + kudf
           + '}';
     }
   }
 
+  @Immutable
+  public static final class ValueArgumentSpec extends BaseArgumentSpec {
+
+    private final int columnIndex;
+
+    ValueArgumentSpec(
+        final String name,
+        final Class<?> type,
+        final int columnIndex
+    ) {
+      super(name, type);
+      this.columnIndex = columnIndex;
+    }
+
+    @Override
+    public Object resolve(final Object key, final GenericRow value) {
+      return value.getColumns().get(columnIndex);
+    }
+
+    @Override
+    public String toString() {
+      return "ValueArgumentSpec{"
+          + "name='" + name() + '\''
+          + ", type=" + type()
+          + ", columnIndex=" + columnIndex
+          + '}';
+    }
+  }
+
+  @Immutable
+  public static final class KeyArgumentSpec extends BaseArgumentSpec {
+
+    private final int columnIndex;
+
+    KeyArgumentSpec(
+        final String name,
+        final Class<?> type,
+        final int columnIndex
+    ) {
+      super(name, type);
+      this.columnIndex = columnIndex;
+    }
+
+    @SuppressWarnings("unchecked")
+    @Override
+    public Object resolve(final Object key, final GenericRow value) {
+      if (key == null) {
+        return null;
+      }
+
+      return key instanceof Windowed
+          ? resolveWindowed((Windowed<Struct>)key)
+          : resolveNonWindowed((Struct)key);
+    }
+
+    private Object resolveWindowed(final Windowed<Struct> windowedKey) {
+      final Window window = windowedKey.window();
+      final long start = window.start();
+      final String end = window instanceof SessionWindow ? String.valueOf(window.end()) : "-";
+      final Object key = resolveNonWindowed(windowedKey.key());
+      return String.format("%s : Window{start=%d end=%s}", key, start, end);
+    }
+
+    private Object resolveNonWindowed(final Struct key) {
+      final Field field = key.schema().fields().get(columnIndex);
+      return key.get(field);
+    }
+
+    @Override
+    public String toString() {
+      return "KeyArgumentSpec{"
+          + "name='" + name() + '\''
+          + ", type=" + type()
+          + ", columnIndex=" + columnIndex
+          + '}';
+    }
+  }
 }

--- a/ksql-execution/src/main/java/io/confluent/ksql/execution/codegen/SqlToJavaVisitor.java
+++ b/ksql-execution/src/main/java/io/confluent/ksql/execution/codegen/SqlToJavaVisitor.java
@@ -267,7 +267,7 @@ public class SqlToJavaVisitor {
     @Override
     public Pair<String, SqlType> visitColumnReference(ColumnReferenceExp node, Void context) {
       ColumnRef fieldName = node.getReference();
-      Column schemaColumn = schema.findValueColumn(node.getReference())
+      Column schemaColumn = schema.findColumn(node.getReference())
           .orElseThrow(() ->
               new KsqlException("Field not found: " + node.getReference()));
 

--- a/ksql-execution/src/main/java/io/confluent/ksql/execution/function/udtf/KudtfFlatMapper.java
+++ b/ksql-execution/src/main/java/io/confluent/ksql/execution/function/udtf/KudtfFlatMapper.java
@@ -56,7 +56,7 @@ public class KudtfFlatMapper<K> implements KsqlTransformer<K, Iterable<GenericRo
     final List<Iterator<?>> iters = new ArrayList<>(tableFunctionAppliers.size());
     int maxLength = 0;
     for (TableFunctionApplier applier : tableFunctionAppliers) {
-      List<?> exploded = applier.apply(value);
+      List<?> exploded = applier.apply(readOnlyKey, value);
       iters.add(exploded.iterator());
       maxLength = Math.max(maxLength, exploded.size());
     }

--- a/ksql-execution/src/main/java/io/confluent/ksql/execution/function/udtf/TableFunctionApplier.java
+++ b/ksql-execution/src/main/java/io/confluent/ksql/execution/function/udtf/TableFunctionApplier.java
@@ -39,11 +39,11 @@ public class TableFunctionApplier {
     this.expressionMetadataList = ImmutableList.copyOf(requireNonNull(expressionMetadataList));
   }
 
-  List<?> apply(GenericRow row) {
+  List<?> apply(final Object readOnlyKey, final GenericRow value) {
     Object[] args = new Object[expressionMetadataList.size()];
     int i = 0;
     for (ExpressionMetadata expressionMetadata : expressionMetadataList) {
-      args[i++] = expressionMetadata.evaluate(row);
+      args[i++] = expressionMetadata.evaluate(readOnlyKey, value);
     }
     return tableFunction.apply(args);
   }

--- a/ksql-execution/src/main/java/io/confluent/ksql/execution/plan/LogicalSchemaWithMetaAndKeyFields.java
+++ b/ksql-execution/src/main/java/io/confluent/ksql/execution/plan/LogicalSchemaWithMetaAndKeyFields.java
@@ -34,10 +34,6 @@ public final class LogicalSchemaWithMetaAndKeyFields {
         schema.withAlias(alias).withMetaAndKeyColsInValue());
   }
 
-  public static LogicalSchemaWithMetaAndKeyFields fromTransformed(LogicalSchema schema) {
-    return new LogicalSchemaWithMetaAndKeyFields(schema);
-  }
-
   public LogicalSchema getSchema() {
     return schema;
   }

--- a/ksql-execution/src/main/java/io/confluent/ksql/execution/transform/select/SelectValueMapper.java
+++ b/ksql-execution/src/main/java/io/confluent/ksql/execution/transform/select/SelectValueMapper.java
@@ -115,17 +115,17 @@ public class SelectValueMapper<K> {
       final List<Object> newColumns = new ArrayList<>();
 
       for (int i = 0; i < selects.size(); i++) {
-        newColumns.add(processColumn(i, value));
+        newColumns.add(processColumn(i, readOnlyKey, value));
       }
 
       return new GenericRow(newColumns);
     }
 
-    private Object processColumn(final int column, final GenericRow row) {
+    private Object processColumn(final int column, final K readOnlyKey, final GenericRow value) {
       final SelectInfo select = selects.get(column);
 
       try {
-        return select.evaluator.evaluate(row);
+        return select.evaluator.evaluate(readOnlyKey, value);
       } catch (final Exception e) {
         final String errorMsg = String.format(
             "Error computing expression %s for column %s with index %d: %s",
@@ -136,11 +136,7 @@ public class SelectValueMapper<K> {
         );
 
         processingLogger.error(
-            EngineProcessingLogMessageFactory.recordProcessingError(
-                errorMsg,
-                e,
-                row
-            )
+            EngineProcessingLogMessageFactory.recordProcessingError(errorMsg, e, value)
         );
         return null;
       }

--- a/ksql-execution/src/main/java/io/confluent/ksql/execution/transform/sqlpredicate/SqlPredicate.java
+++ b/ksql-execution/src/main/java/io/confluent/ksql/execution/transform/sqlpredicate/SqlPredicate.java
@@ -105,7 +105,7 @@ public final class SqlPredicate {
 
       try {
         Object[] values = new Object[spec.arguments().size()];
-        spec.resolve(value, values);
+        spec.resolve(readOnlyKey, value, values);
         final boolean result = (Boolean) ee.evaluate(values);
         return result
             ? Optional.of(value)

--- a/ksql-execution/src/test/java/io/confluent/ksql/execution/function/udtf/KudtfFlatMapperTest.java
+++ b/ksql-execution/src/test/java/io/confluent/ksql/execution/function/udtf/KudtfFlatMapperTest.java
@@ -78,7 +78,7 @@ public class KudtfFlatMapperTest {
 
   private static <T> TableFunctionApplier createApplier(List<?> list) {
     TableFunctionApplier applier = mock(TableFunctionApplier.class);
-    doReturn(list).when(applier).apply(any());
+    doReturn(list).when(applier).apply(any(), any());
     return applier;
   }
 }

--- a/ksql-execution/src/test/java/io/confluent/ksql/execution/transform/select/SelectValueMapperTest.java
+++ b/ksql-execution/src/test/java/io/confluent/ksql/execution/transform/select/SelectValueMapperTest.java
@@ -53,7 +53,7 @@ public class SelectValueMapperTest {
   private static final ColumnName NAME1 = ColumnName.of("cherry");
   private static final ColumnName NAME2 = ColumnName.of("banana");
   private static final Object KEY = null; // Not used yet.
-  private static final GenericRow VALLUE = new GenericRow(ImmutableList.of(1234, 0, "hotdog"));
+  private static final GenericRow VALUE = new GenericRow(ImmutableList.of(1234, 0, "hotdog"));
 
   @Mock
   private ExpressionMetadata col0;
@@ -82,12 +82,23 @@ public class SelectValueMapperTest {
   }
 
   @Test
+  public void shouldInvokeEvaluatorsWithCorrectParams() {
+    // When:
+    transformer.transform(KEY, VALUE, ctx);
+
+    // Then:
+    verify(col0).evaluate(KEY, VALUE);
+    verify(col1).evaluate(KEY, VALUE);
+    verify(col2).evaluate(KEY, VALUE);
+  }
+
+  @Test
   public void shouldEvaluateExpressions() {
     // Given:
     givenEvaluations(100, 200, 300);
 
     // When:
-    final GenericRow result = transformer.transform(KEY, VALLUE, ctx);
+    final GenericRow result = transformer.transform(KEY, VALUE, ctx);
 
     // Then:
     assertThat(result, equalTo(new GenericRow(ImmutableList.of(100, 200, 300))));
@@ -109,7 +120,7 @@ public class SelectValueMapperTest {
     when(col0.getExpression()).thenReturn(
         new FunctionCall(FunctionName.of("kumquat"), ImmutableList.of())
     );
-    when(col0.evaluate(any())).thenThrow(new RuntimeException("oops"));
+    when(col0.evaluate(any(), any())).thenThrow(new RuntimeException("oops"));
 
     // When:
     transformer.transform(
@@ -140,8 +151,8 @@ public class SelectValueMapperTest {
   }
 
   private void givenEvaluations(final Object result0, final Object result1, final Object result2) {
-    when(col0.evaluate(any())).thenReturn(result0);
-    when(col1.evaluate(any())).thenReturn(result1);
-    when(col2.evaluate(any())).thenReturn(result2);
+    when(col0.evaluate(any(), any())).thenReturn(result0);
+    when(col1.evaluate(any(), any())).thenReturn(result1);
+    when(col2.evaluate(any(), any())).thenReturn(result2);
   }
 }

--- a/ksql-streams/src/main/java/io/confluent/ksql/execution/streams/GroupByMapper.java
+++ b/ksql-streams/src/main/java/io/confluent/ksql/execution/streams/GroupByMapper.java
@@ -44,9 +44,9 @@ class GroupByMapper<K> implements KeyValueMapper<K, GenericRow, Struct> {
   }
 
   @Override
-  public Struct apply(final K key, final GenericRow row) {
+  public Struct apply(final K readOnlyKey, final GenericRow value) {
     final String stringRowKey = IntStream.range(0, expressions.size())
-        .mapToObj(idx -> processColumn(idx, expressions.get(idx), row))
+        .mapToObj(idx -> processColumn(idx, expressions.get(idx), readOnlyKey, value))
         .collect(Collectors.joining(GROUP_BY_VALUE_SEPARATOR));
 
     return StructKeyUtil.asStructKey(stringRowKey);
@@ -55,10 +55,11 @@ class GroupByMapper<K> implements KeyValueMapper<K, GenericRow, Struct> {
   private static String processColumn(
       final int index,
       final ExpressionMetadata exp,
-      final GenericRow row
+      final Object readOnlyKey,
+      final GenericRow value
   ) {
     try {
-      return String.valueOf(exp.evaluate(row));
+      return String.valueOf(exp.evaluate(readOnlyKey, value));
     } catch (final Exception e) {
       LOG.error("Error calculating group-by field with index {}", index, e);
       return "null";

--- a/ksql-streams/src/main/java/io/confluent/ksql/execution/streams/SourceBuilder.java
+++ b/ksql-streams/src/main/java/io/confluent/ksql/execution/streams/SourceBuilder.java
@@ -274,7 +274,7 @@ public final class SourceBuilder {
     );
   }
 
-  private static PhysicalSchema getPhysicalSchema(final AbstractStreamSource streamSource) {
+  private static PhysicalSchema getPhysicalSchema(final AbstractStreamSource<?> streamSource) {
     return PhysicalSchema.from(
         streamSource.getSourceSchema(),
         streamSource.getFormats().getOptions()
@@ -282,7 +282,7 @@ public final class SourceBuilder {
   }
 
   private static <K> KStream<K, GenericRow> buildKStream(
-      final AbstractStreamSource streamSource,
+      final AbstractStreamSource<?> streamSource,
       final KsqlQueryBuilder queryBuilder,
       final Consumed<K, GenericRow> consumed,
       final Function<K, String> rowKeyGenerator
@@ -295,7 +295,7 @@ public final class SourceBuilder {
   }
 
   private static <K> KTable<K, GenericRow> buildKTable(
-      final AbstractStreamSource streamSource,
+      final AbstractStreamSource<?> streamSource,
       final KsqlQueryBuilder queryBuilder,
       final Consumed<K, GenericRow> consumed,
       final Function<K, String> rowKeyGenerator,


### PR DESCRIPTION
### Description 

Part of the primitive key work.

Switch the select mapper to get key columns from the key of the Kafka message

### Testing done 

`mvn test`

### Reviewer checklist
- [ ] Ensure docs are updated if necessary. (eg. if a user visible feature is being added or changed).
- [ ] Ensure relevant issues are linked (description should include text like "Fixes #<issue number>")

