### PR TITLE
docs: klip-13: Introduce KSQL command to print connect worker properties to the console

### DIFF
--- a/design-proposals/README.md
+++ b/design-proposals/README.md
@@ -53,7 +53,6 @@ Next KLIP number: **14**
 | [KLIP-10: Suppress](klip-10-suppress.md)                                           | Proposal       | N/A     |
 | [KLIP-11: Redesign KSQL query language](klip-11-DQL.md)                            | Proposal       | N/A     |
 | [KLIP-12: Implement High-Availability for Pull queries](klip-12-pull-high-availability.md)| Proposal       | N/A     |
-| KLIP-13: Introduce KSQL command to print connect worker properties to the console | Proposal | N/A |
+| [KLIP-13: Introduce KSQL command to print connect worker properties to the console](klip-13-introduce-KSQL-command-to-print-connect-worker-properties-to-the-console.md) | Proposal | N/A |
 | [KLIP-14: ROWTIME as Pseudocolumn](klip-14-rowtime-as-pseudocolumn.md)             | Proposal       | N/A     |
 | [KLIP-15: KSQLDB new API and Client(klip-15-new-api-and-client.md                  | Proposal       | N/A     |
-

--- a/design-proposals/klip-13-introduce-KSQL-command-to-print-connect-worker-properties-to-the-console.md
+++ b/design-proposals/klip-13-introduce-KSQL-command-to-print-connect-worker-properties-to-the-console.md
@@ -1,0 +1,65 @@
+# KLIP 13 - Introduce KSQL command to print connect worker properties to the console
+
+**Author**: alex-dukhno | 
+**Release Target**: N/A | 
+**Status**: _In Discussion_ | 
+**Discussion**: _link to the design discussion PR_
+
+**tl;dr:** The best tools are ones that greatly support users workflow. As of today users couldn't 
+get connect worker properties in `ksql cli`, thus forcing them to switch to editor to open up that 
+locates under the path `ksql.connect.worker.config`. Having a command to get that information could 
+lead to a better user experience using `ksql cli`.
+
+## Motivation and background
+
+As is mentioned in [issue](https://github.com/confluentinc/ksql/issues/3777) currently user doesn't
+have visibility into connect worker configuration. When something goes wrong one of the first action 
+is to check if configuration is done right. Currently, users, if they need to see connect worker configuration,
+have to use editors to open up the file at `ksql.connect.worker.config` location, which leads to 
+context switch and loosing attention. That could be unpleasant experience during troubleshooting, 
+especially on a production system.
+
+## What is in scope
+
+We would like to extend `(LIST|SHOW) PROPERTIES` `KSQL` command to `(LIST|SHOW) PROPERTIES (CONNECT)?` 
+that could be run from `ksql cli` and prints connect worker configuration.
+
+## What is not in scope
+
+It is not a goal of the KLIP to implement general command (or extension) that could provide configuration
+ information of other `ksql` component. General solution or other extensions require their own KLIP(s).
+
+## Value/Return
+
+The functionality will provide ability for a user to quickly print and check connect worker configuration
+from the `ksql cli` that gives better user experience.
+
+## Public APIS
+
+We need to make small change to KSQL query language by introducing new keyword `CONNECT`.
+
+## Design
+
+One of the way to implement it is to add a `flag` field to `ListProperties` statement class. The `flag` 
+will be set if key word `(LIST|SHOW) PROPERTIES` follows by `CONNECT` keyword. Base on `flag` print 
+connect worker or all configuration properties.
+
+## Test plan
+
+New unit/module level tests will be written as appropriate.
+
+## Documentation Updates
+
+Documentation should reflect that new extension is introduced to `(LIST|SHOW) PROPERTIES` `KSQL` command.
+
+# Compatibility Implications
+
+The only implication is that we are introducing new keyword `CONNECT` that should be supported.
+
+## Performance Implications
+
+The new features will not affect performance of existing KSQL apps
+
+## Security Implications
+
+If connect worker can have security related properties they have to be obfuscated.

--- a/design-proposals/klip-13-introduce-KSQL-command-to-print-connect-worker-properties-to-the-console.md
+++ b/design-proposals/klip-13-introduce-KSQL-command-to-print-connect-worker-properties-to-the-console.md
@@ -21,8 +21,7 @@ especially on a production system.
 
 ## What is in scope
 
-We would like to extend `(LIST|SHOW) PROPERTIES` `KSQL` command to `(LIST|SHOW) PROPERTIES (CONNECT)?` 
-that could be run from `ksql cli` and prints connect worker configuration.
+We would like to extend `(LIST|SHOW) PROPERTIES` `KSQL` command to print embedded connect worker configuration.
 
 ## What is not in scope
 
@@ -36,13 +35,12 @@ from the `ksql cli` that gives better user experience.
 
 ## Public APIS
 
-We need to make small change to KSQL query language by introducing new keyword `CONNECT`.
+No changes to API are required.
 
 ## Design
 
-One of the way to implement it is to add a `flag` field to `ListProperties` statement class. The `flag` 
-will be set if key word `(LIST|SHOW) PROPERTIES` follows by `CONNECT` keyword. Base on `flag` print 
-connect worker or all configuration properties.
+One of the way to implement it is to read file at `ksql.connect.worker.config` location and if it exists
+and not empty merge connect worker properties with global one.
 
 ## Test plan
 
@@ -50,11 +48,11 @@ New unit/module level tests will be written as appropriate.
 
 ## Documentation Updates
 
-Documentation should reflect that new extension is introduced to `(LIST|SHOW) PROPERTIES` `KSQL` command.
+Documentation should reflect that `(LIST|SHOW) PROPERTIES` `KSQL` command prints connect worker properties also.
 
 # Compatibility Implications
 
-The only implication is that we are introducing new keyword `CONNECT` that should be supported.
+No compatibility implications.
 
 ## Performance Implications
 


### PR DESCRIPTION
### Description 
The PR introduce KLIP for adding `KSQL` command for printing connect worker configuration.
This is my first Improvement(Enhancement) Proposal ever written, so I could miss lot of things. Any feedback on content and style is highly appreciated.

Thank you

### Testing done 
_Describe the testing strategy. Unit and integration tests are expected for any behavior changes._

### Reviewer checklist
- [ ] Ensure docs are updated if necessary. (eg. if a user visible feature is being added or changed).
- [ ] Ensure relevant issues are linked (description should include text like "Fixes #<issue number>")

