### PR TITLE
chore: add .vscode/ and .factorypath to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,6 +12,9 @@ logs/
 *.ipr
 .idea/
 
+# VSCode data
+.vscode/
+
 # Other
 .DS_Store
 .dumbjump
@@ -20,6 +23,7 @@ logs/
 *#
 .#*
 .classpath
+.factorypath
 /.metadata
 .project
 .settings


### PR DESCRIPTION
### Description 
Minor change to prevent accidentally including `.vscode` folder in a commit

### Testing done 
When VSCode devs add `.vscode` folder and they use java extensions, .vscode/ and .factorypath don't show up.

### Reviewer checklist
- [ ] Ensure docs are updated if necessary. (eg. if a user visible feature is being added or changed).
- [ ] Ensure relevant issues are linked (description should include text like "Fixes #<issue number>")

