### PR TITLE
chore: add default key.converter=StringConverter to all connectors (MINOR)

### DIFF
--- a/ksql-engine/src/main/java/io/confluent/ksql/connect/supported/JdbcSource.java
+++ b/ksql-engine/src/main/java/io/confluent/ksql/connect/supported/JdbcSource.java
@@ -24,7 +24,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import org.apache.kafka.connect.runtime.rest.entities.ConnectorInfo;
-import org.apache.kafka.connect.storage.StringConverter;
 import org.apache.kafka.connect.transforms.ExtractField;
 import org.apache.kafka.connect.transforms.ValueToKey;
 
@@ -69,7 +68,6 @@ public final class JdbcSource implements SupportedConnector {
       resolved.put("transforms.ksqlExtractString.field", key);
     }
 
-    resolved.putIfAbsent("key.converter", StringConverter.class.getName());
     resolved.putIfAbsent("tasks.max", "1");
     return resolved;
   }

--- a/ksql-engine/src/test/java/io/confluent/ksql/connect/supported/ConnectorsTest.java
+++ b/ksql-engine/src/test/java/io/confluent/ksql/connect/supported/ConnectorsTest.java
@@ -1,0 +1,38 @@
+/*
+ * Copyright 2019 Confluent Inc.
+ *
+ * Licensed under the Confluent Community License (the "License"; you may not use
+ * this file except in compliance with the License. You may obtain a copy of the
+ * License at
+ *
+ * http://www.confluent.io/confluent-community-license
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package io.confluent.ksql.connect.supported;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.hasEntry;
+
+import com.google.common.collect.ImmutableMap;
+import java.util.Map;
+import org.apache.kafka.connect.storage.StringConverter;
+import org.junit.Test;
+
+public class ConnectorsTest {
+
+  @Test
+  public void shouldResolveConfigs() {
+    // Given:
+    final Map<String, String> configs = ImmutableMap.of();
+
+    // When/Then:
+    assertThat(
+        Connectors.resolve(configs), hasEntry("key.converter", StringConverter.class.getName()));
+  }
+
+}

--- a/ksql-engine/src/test/java/io/confluent/ksql/connect/supported/JdbcSourceTest.java
+++ b/ksql-engine/src/test/java/io/confluent/ksql/connect/supported/JdbcSourceTest.java
@@ -133,7 +133,6 @@ public class JdbcSourceTest {
             .put("transforms.ksqlCreateKey.fields", "id")
             .put("transforms.ksqlExtractString.type", "org.apache.kafka.connect.transforms.ExtractField$Key")
             .put("transforms.ksqlExtractString.field", "id")
-            .put("key.converter", "org.apache.kafka.connect.storage.StringConverter")
             .put("tasks.max", "1")
             .build()));
   }

--- a/ksql-rest-app/src/test/java/io/confluent/ksql/rest/server/execution/ConnectExecutorTest.java
+++ b/ksql-rest-app/src/test/java/io/confluent/ksql/rest/server/execution/ConnectExecutorTest.java
@@ -16,11 +16,15 @@
 package io.confluent.ksql.rest.server.execution;
 
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.contains;
+import static org.hamcrest.Matchers.hasEntry;
 import static org.hamcrest.Matchers.instanceOf;
 import static org.mockito.ArgumentMatchers.anyMap;
 import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
+import static org.mockito.hamcrest.MockitoHamcrest.argThat;
 
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
@@ -36,6 +40,7 @@ import io.confluent.ksql.services.ConnectClient.ConnectResponse;
 import io.confluent.ksql.services.ServiceContext;
 import io.confluent.ksql.statement.ConfiguredStatement;
 import io.confluent.ksql.util.KsqlConfig;
+import java.util.Map;
 import java.util.Optional;
 import org.apache.http.HttpStatus;
 import org.apache.kafka.connect.runtime.rest.entities.ConnectorInfo;
@@ -43,6 +48,7 @@ import org.apache.kafka.connect.runtime.rest.entities.ConnectorType;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
+import org.mockito.ArgumentMatchers;
 import org.mockito.Mock;
 import org.mockito.junit.MockitoJUnitRunner;
 
@@ -72,6 +78,7 @@ public class ConnectExecutorTest {
     when(serviceContext.getConnectClient()).thenReturn(connectClient);
   }
 
+  @SuppressWarnings("unchecked")
   @Test
   public void shouldPassInCorrectArgsToConnectClient() {
     // Given:
@@ -81,7 +88,7 @@ public class ConnectExecutorTest {
     ConnectExecutor.execute(CREATE_CONNECTOR_CONFIGURED, ImmutableMap.of(), null, serviceContext);
 
     // Then:
-    verify(connectClient).create("foo", ImmutableMap.of("foo", "bar"));
+    verify(connectClient).create(eq("foo"), (Map<String, String>) argThat(hasEntry("foo", "bar")));
   }
 
   @Test


### PR DESCRIPTION
fixes #4036

### Description 
See description on #4036 - just adds a default

### Testing done 
- new unit tests

### Reviewer checklist
- [ ] Ensure docs are updated if necessary. (eg. if a user visible feature is being added or changed).
- [ ] Ensure relevant issues are linked (description should include text like "Fixes #<issue number>")

