### PR TITLE
chore: update KSQL_PULL_QUERIES_ENABLE_CONFIG name (MINOR)

### DIFF
--- a/ksql-common/src/main/java/io/confluent/ksql/util/KsqlConfig.java
+++ b/ksql-common/src/main/java/io/confluent/ksql/util/KsqlConfig.java
@@ -204,7 +204,7 @@ public class KsqlConfig extends AbstractConfig {
       + " which are secured with ACLs. Please enable only after careful consideration."
       + " If \"false\", KSQL pull queries will fail against a secure Kafka cluster";
 
-  public static final String KSQL_PULL_QUERIES_ENABLE_CONFIG = "ksql.pull.queries.enable";
+  public static final String KSQL_PULL_QUERIES_ENABLE_CONFIG = "ksql.query.pull.enable";
   public static final String KSQL_PULL_QUERIES_ENABLE_DOC =
       "Config to enable or disable transient pull queries on a specific KSQL server.";
   public static final boolean KSQL_PULL_QUERIES_ENABLE_DEFAULT = true;


### PR DESCRIPTION
### Description 

https://github.com/confluentinc/ksql/pull/3778 introduced a config named `ksql.pull.queries.enable` for enabling/disabling pull queries. The config was renamed to `ksql.query.pull.enable` in https://github.com/confluentinc/ksql/pull/3856 after the 5.4.x branch was cut, and has therefore introduced a breaking change between 5.4 and master. This PR updates the config name in 5.4 to match the new name on master.

### Testing done 

Verified there are no docs or examples using the old config name that need to be updated. No additional code changes are needed since only the variable `KSQL_PULL_QUERIES_ENABLE_CONFIG` is used throughout the code.

### Reviewer checklist
- [ ] Ensure docs are updated if necessary. (eg. if a user visible feature is being added or changed).
- [ ] Ensure relevant issues are linked (description should include text like "Fixes #<issue number>")

