### PR TITLE
chore: change pull query disabled exception from KsqlRestException to KsqlException

### DIFF
--- a/ksql-rest-app/src/main/java/io/confluent/ksql/rest/server/execution/PullQueryExecutor.java
+++ b/ksql-rest-app/src/main/java/io/confluent/ksql/rest/server/execution/PullQueryExecutor.java
@@ -141,14 +141,12 @@ public final class PullQueryExecutor {
     }
 
     if (!statement.getConfig().getBoolean(KsqlConfig.KSQL_QUERY_PULL_ENABLE_CONFIG)) {
-      throw new KsqlRestException(
-          Errors.badStatement(
-              "Pull queries are disabled. "
-                  + PullQueryValidator.NEW_QUERY_SYNTAX_SHORT_HELP
-                  + System.lineSeparator()
-                  + "Please set " + KsqlConfig.KSQL_QUERY_PULL_ENABLE_CONFIG + "=true to enable "
-                  + "this feature.",
-              statement.getStatementText()));
+      throw new KsqlException(
+          "Pull queries are disabled. "
+              + PullQueryValidator.NEW_QUERY_SYNTAX_SHORT_HELP
+              + System.lineSeparator()
+              + "Please set " + KsqlConfig.KSQL_QUERY_PULL_ENABLE_CONFIG + "=true to enable "
+              + "this feature.");
     }
 
     try {

--- a/ksql-rest-app/src/main/java/io/confluent/ksql/rest/server/resources/streaming/WebSocketSubscriber.java
+++ b/ksql-rest-app/src/main/java/io/confluent/ksql/rest/server/resources/streaming/WebSocketSubscriber.java
@@ -79,7 +79,7 @@ class WebSocketSubscriber<T> implements Flow.Subscriber<Collection<T>>, AutoClos
     log.error("error in session {}", session.getId(), e);
 
     final String msg = e.getMessage() == null || e.getMessage().trim().isEmpty()
-        ? "KSQL excetion: " + e.getClass().getSimpleName()
+        ? "KSQL exception: " + e.getClass().getSimpleName()
         : e.getMessage();
 
     SessionUtil.closeSilently(session, CloseCodes.UNEXPECTED_CONDITION, msg);

--- a/ksql-rest-app/src/test/java/io/confluent/ksql/rest/server/execution/PullQueryExecutorTest.java
+++ b/ksql-rest-app/src/test/java/io/confluent/ksql/rest/server/execution/PullQueryExecutorTest.java
@@ -32,6 +32,7 @@ import io.confluent.ksql.rest.server.resources.KsqlRestException;
 import io.confluent.ksql.rest.server.validation.CustomValidators;
 import io.confluent.ksql.statement.ConfiguredStatement;
 import io.confluent.ksql.util.KsqlConfig;
+import io.confluent.ksql.util.KsqlException;
 import org.eclipse.jetty.http.HttpStatus.Code;
 import org.junit.Rule;
 import org.junit.Test;
@@ -63,13 +64,8 @@ public class PullQueryExecutorTest {
       );
 
       // Then:
-      expectedException.expect(KsqlRestException.class);
-      expectedException.expect(exceptionStatusCode(is(Code.BAD_REQUEST)));
-      expectedException.expect(exceptionStatementErrorMessage(errorMessage(containsString(
-          "Pull queries are disabled"
-      ))));
-      expectedException.expect(exceptionStatementErrorMessage(statement(containsString(
-          "SELECT * FROM test_table"))));
+      expectedException.expect(KsqlException.class);
+      expectedException.expectMessage(containsString("Pull queries are disabled"));
 
       // When:
       PullQueryExecutor.execute(


### PR DESCRIPTION
### Description 
If the pull query enable config is set to false and a user tries to send a pull query to the websocket, instead of getting back a clear error message, they'll see this.
```
HTTP/1.1 101 Switching Protocols
Date: Thu, 05 Dec 2019 00:02:03 GMT
Connection: Upgrade
Sec-WebSocket-Accept: qGEgH3En71di5rrssAZTmtRTyFk=
Upgrade: WebSocket

?"?KSQL excetion: KsqlRestException
```
That's because in `PullQueryExecutor`, we throw a `KsqlRestException`. `KsqlRestException` doesn't set the message for the exception which is a problem since in `WSQueryEndpoint` on this line, we return the exception.message to the user.
`SessionUtil.closeSilently(session, CloseCodes.CANNOT_ACCEPT, e.getMessage());`

This PR improves the exception message slightly, but it's still getting cut off by the char limit.
The response is now:
```
HTTP/1.1 101 Switching Protocols
Date: Thu, 05 Dec 2019 00:07:15 GMT
Connection: Upgrade
Sec-WebSocket-Accept: qGEgH3En71di5rrssAZTmtRTyFk=
Upgrade: WebSocket

?}?Pull queries are disabled. Refer to https://cnfl.io/queries for info on query types. If you intended to issue a push que...
```

I opened this PR to start a discussion as soon as possible on how to tackle this as this may need to be backported to the 5.4 branch (this behavior exists in that branch also) . The one downside is that since a `KsqlRestException` isn't being thrown from the `StreamedQueryResource`, we lose some detail on what the original statement was from the server response.

There's some other potential solutions that could be done

1. Add a new constructor to KsqlRestException (or also modify the existing constructor) that calls `super(msg)` in order to set the error message
2. Pass down whether or not the PullQueryExecutor is called from the StreamedQueryResource or the Websocket. If it's from the Resource, keep the existing KsqlRestException. If it's from the Websocket, throw a KsqlException (potentially with a shorter error message so it doesn't get cut off)

### Testing done 
Updated the PullQueryExecutor test
Made sure the CLI output is still the same
```
ksql> Select * from steve;
Pull queries are disabled. Refer to https://cnfl.io/queries for info on query types. If you intended to issue a push query, resubmit with the EMIT CHANGES clause
Please set ksql.query.pull.enable=true to enable this feature.
```
Checked the websocket response

### Reviewer checklist
- [ ] Ensure docs are updated if necessary. (eg. if a user visible feature is being added or changed).
- [ ] Ensure relevant issues are linked (description should include text like "Fixes #<issue number>")

