### PR TITLE
refactor: remove step schemas from execution plan

### DIFF
--- a/ksql-engine/src/main/java/io/confluent/ksql/planner/plan/DataSourceNode.java
+++ b/ksql-engine/src/main/java/io/confluent/ksql/planner/plan/DataSourceNode.java
@@ -139,7 +139,6 @@ public class DataSourceNode extends PlanNode {
     return schemaKStreamFactory.create(
         builder,
         dataSource,
-        schema,
         contextStacker.push(SOURCE_OP_NAME),
         getAutoOffsetReset(builder.getKsqlConfig().getKsqlStreamConfigProps()),
         keyField,
@@ -152,7 +151,6 @@ public class DataSourceNode extends PlanNode {
     SchemaKStream<?> create(
         KsqlQueryBuilder builder,
         DataSource<?> dataSource,
-        LogicalSchemaWithMetaAndKeyFields schemaWithMetaAndKeyFields,
         QueryContext.Stacker contextStacker,
         Optional<AutoOffsetReset> offsetReset,
         KeyField keyField,

--- a/ksql-engine/src/main/java/io/confluent/ksql/planner/plan/FlatMapNode.java
+++ b/ksql-engine/src/main/java/io/confluent/ksql/planner/plan/FlatMapNode.java
@@ -111,7 +111,6 @@ public class FlatMapNode extends PlanNode {
     final QueryContext.Stacker contextStacker = builder.buildNodeContext(getId().toString());
 
     return getSource().buildStream(builder).flatMap(
-        outputSchema,
         analysis.getTableFunctions(),
         contextStacker
     );

--- a/ksql-engine/src/main/java/io/confluent/ksql/planner/plan/JoinNode.java
+++ b/ksql-engine/src/main/java/io/confluent/ksql/planner/plan/JoinNode.java
@@ -324,7 +324,6 @@ public class JoinNode extends PlanNode {
         case LEFT:
           return leftStream.leftJoin(
               rightStream,
-              joinNode.schema,
               joinNode.keyField,
               joinNode.withinExpression.get().joinWindow(),
               getFormatForSource(joinNode.left),
@@ -334,7 +333,6 @@ public class JoinNode extends PlanNode {
         case OUTER:
           return leftStream.outerJoin(
               rightStream,
-              joinNode.schema,
               joinNode.keyField,
               joinNode.withinExpression.get().joinWindow(),
               getFormatForSource(joinNode.left),
@@ -344,7 +342,6 @@ public class JoinNode extends PlanNode {
         case INNER:
           return leftStream.join(
               rightStream,
-              joinNode.schema,
               joinNode.keyField,
               joinNode.withinExpression.get().joinWindow(),
               getFormatForSource(joinNode.left),
@@ -385,7 +382,6 @@ public class JoinNode extends PlanNode {
         case LEFT:
           return leftStream.leftJoin(
               rightTable,
-              joinNode.schema,
               joinNode.keyField,
               getFormatForSource(joinNode.left),
               contextStacker
@@ -394,7 +390,6 @@ public class JoinNode extends PlanNode {
         case INNER:
           return leftStream.join(
               rightTable,
-              joinNode.schema,
               joinNode.keyField,
               getFormatForSource(joinNode.left),
               contextStacker
@@ -436,19 +431,16 @@ public class JoinNode extends PlanNode {
         case LEFT:
           return leftTable.leftJoin(
               rightTable,
-              joinNode.schema,
               joinNode.keyField,
               contextStacker);
         case INNER:
           return leftTable.join(
               rightTable,
-              joinNode.schema,
               joinNode.keyField,
               contextStacker);
         case OUTER:
           return leftTable.outerJoin(
               rightTable,
-              joinNode.schema,
               joinNode.keyField,
               contextStacker);
         default:

--- a/ksql-engine/src/main/java/io/confluent/ksql/planner/plan/KsqlStructuredDataOutputNode.java
+++ b/ksql-engine/src/main/java/io/confluent/ksql/planner/plan/KsqlStructuredDataOutputNode.java
@@ -117,7 +117,6 @@ public class KsqlStructuredDataOutputNode extends OutputNode {
 
     return schemaKStream.into(
         getKsqlTopic().getKafkaTopicName(),
-        getSchema(),
         getKsqlTopic().getValueFormat(),
         serdeOptions,
         contextStacker

--- a/ksql-engine/src/test/java/io/confluent/ksql/planner/plan/DataSourceNodeTest.java
+++ b/ksql-engine/src/test/java/io/confluent/ksql/planner/plan/DataSourceNodeTest.java
@@ -166,7 +166,7 @@ public class DataSourceNodeTest {
     when(rowSerde.deserializer()).thenReturn(mock(Deserializer.class));
 
     when(dataSource.getDataSourceType()).thenReturn(DataSourceType.KTABLE);
-    when(schemaKStreamFactory.create(any(), any(), any(), any(), any(), any(), any()))
+    when(schemaKStreamFactory.create(any(), any(), any(), any(), any(), any()))
         .thenAnswer(inv -> inv.<DataSource<?>>getArgument(1)
             .getDataSourceType() == DataSourceType.KSTREAM
             ? stream : table
@@ -271,7 +271,7 @@ public class DataSourceNodeTest {
     node.buildStream(ksqlStreamBuilder);
 
     // Then:
-    verify(schemaKStreamFactory).create(any(), any(), any(), any(), any(), any(), any());
+    verify(schemaKStreamFactory).create(any(), any(), any(), any(), any(), any());
   }
 
   // should this even be possible? if you are using a timestamp extractor then shouldn't the name
@@ -285,7 +285,7 @@ public class DataSourceNodeTest {
     node.buildStream(ksqlStreamBuilder);
 
     // Then:
-    verify(schemaKStreamFactory).create(any(), any(), any(), any(), any(), any(), any());
+    verify(schemaKStreamFactory).create(any(), any(), any(), any(), any(), any());
   }
 
   @Test
@@ -302,7 +302,6 @@ public class DataSourceNodeTest {
     verify(schemaKStreamFactory).create(
         same(ksqlStreamBuilder),
         same(dataSource),
-        eq(StreamSource.getSchemaWithMetaAndKeyFields(SourceName.of("name"), REAL_SCHEMA)),
         stackerCaptor.capture(),
         eq(OFFSET_RESET),
         same(node.getKeyField()),
@@ -326,7 +325,6 @@ public class DataSourceNodeTest {
     verify(schemaKStreamFactory).create(
         same(ksqlStreamBuilder),
         same(dataSource),
-        eq(StreamSource.getSchemaWithMetaAndKeyFields(SourceName.of("name"), REAL_SCHEMA)),
         stackerCaptor.capture(),
         eq(OFFSET_RESET),
         same(node.getKeyField()),

--- a/ksql-engine/src/test/java/io/confluent/ksql/planner/plan/JoinNodeTest.java
+++ b/ksql-engine/src/test/java/io/confluent/ksql/planner/plan/JoinNodeTest.java
@@ -322,7 +322,6 @@ public class JoinNodeTest {
     // Then:
     verify(leftSchemaKStream).leftJoin(
         eq(rightSchemaKStream),
-        eq(JOIN_SCHEMA),
         eq(leftJoinField),
         eq(WITHIN_EXPRESSION.get().joinWindow()),
         eq(VALUE_FORMAT),
@@ -354,7 +353,6 @@ public class JoinNodeTest {
     // Then:
     verify(leftSchemaKStream).join(
         eq(rightSchemaKStream),
-        eq(JOIN_SCHEMA),
         eq(leftJoinField),
         eq(WITHIN_EXPRESSION.get().joinWindow()),
         eq(VALUE_FORMAT),
@@ -386,7 +384,6 @@ public class JoinNodeTest {
     // Then:
     verify(leftSchemaKStream).outerJoin(
         eq(rightSchemaKStream),
-        eq(JOIN_SCHEMA),
         eq(KeyField.none()),
         eq(WITHIN_EXPRESSION.get().joinWindow()),
         eq(VALUE_FORMAT),
@@ -533,7 +530,6 @@ public class JoinNodeTest {
     // Then:
     verify(leftSchemaKStream).leftJoin(
         eq(rightSchemaKTable),
-        eq(JOIN_SCHEMA),
         eq(leftJoinField),
         eq(VALUE_FORMAT),
         eq(CONTEXT_STACKER)
@@ -563,7 +559,6 @@ public class JoinNodeTest {
     // Then:
     verify(leftSchemaKStream).leftJoin(
         eq(rightSchemaKTable),
-        eq(JOIN_SCHEMA),
         eq(leftJoinField),
         eq(VALUE_FORMAT),
         eq(CONTEXT_STACKER)
@@ -593,7 +588,6 @@ public class JoinNodeTest {
     // Then:
     verify(leftSchemaKStream).join(
         eq(rightSchemaKTable),
-        eq(JOIN_SCHEMA),
         eq(leftJoinField),
         eq(VALUE_FORMAT),
         eq(CONTEXT_STACKER)
@@ -747,7 +741,6 @@ public class JoinNodeTest {
     // Then:
     verify(leftSchemaKTable).join(
         eq(rightSchemaKTable),
-        eq(JOIN_SCHEMA),
         eq(leftJoinField),
         eq(CONTEXT_STACKER));
   }
@@ -775,7 +768,6 @@ public class JoinNodeTest {
     // Then:
     verify(leftSchemaKTable).leftJoin(
         eq(rightSchemaKTable),
-        eq(JOIN_SCHEMA),
         eq(leftJoinField),
         eq(CONTEXT_STACKER));
   }
@@ -803,7 +795,6 @@ public class JoinNodeTest {
     // Then:
     verify(leftSchemaKTable).outerJoin(
         eq(rightSchemaKTable),
-        eq(JOIN_SCHEMA),
         eq(KeyField.none()),
         eq(CONTEXT_STACKER));
   }
@@ -915,6 +906,24 @@ public class JoinNodeTest {
     // Then:
     verify(leftSource, never()).getSerdeOptions();
     verify(rightSource, never()).getSerdeOptions();
+  }
+
+  @Test
+  public void shouldReturnCorrectSchema() {
+    // When:
+    final JoinNode joinNode = new JoinNode(
+        nodeId,
+        Collections.emptyList(),
+        JoinNode.JoinType.LEFT,
+        left,
+        right,
+        LEFT_JOIN_FIELD_REF,
+        RIGHT_JOIN_FIELD_REF,
+        WITHIN_EXPRESSION
+    );
+
+    // Then:
+    assertThat(joinNode.getSchema(), is(JOIN_SCHEMA));
   }
 
   @SuppressWarnings("unchecked")

--- a/ksql-engine/src/test/java/io/confluent/ksql/planner/plan/KsqlStructuredDataOutputNodeTest.java
+++ b/ksql-engine/src/test/java/io/confluent/ksql/planner/plan/KsqlStructuredDataOutputNodeTest.java
@@ -116,11 +116,11 @@ public class KsqlStructuredDataOutputNodeTest {
     when(sourceNode.getNodeOutputType()).thenReturn(DataSourceType.KSTREAM);
     when(sourceNode.buildStream(ksqlStreamBuilder)).thenReturn((SchemaKStream) sourceStream);
 
-    when(sourceStream.into(any(), any(), any(), any(), any()))
+    when(sourceStream.into(any(), any(), any(), any()))
         .thenReturn((SchemaKStream) sinkStream);
     when(sourceStream.selectKey(any(), any()))
         .thenReturn((SchemaKStream) resultWithKeySelected);
-    when(resultWithKeySelected.into(any(), any(), any(), any(), any()))
+    when(resultWithKeySelected.into(any(), any(), any(), any()))
         .thenReturn((SchemaKStream) sinkStreamWithKeySelected);
 
     when(ksqlStreamBuilder.buildNodeContext(any())).thenAnswer(inv ->
@@ -192,7 +192,7 @@ public class KsqlStructuredDataOutputNodeTest {
     outputNode.buildStream(ksqlStreamBuilder);
 
     // Then:
-    verify(sourceStream).into(any(), any(), eq(valueFormat), any(), any());
+    verify(sourceStream).into(any(), eq(valueFormat), any(), any());
   }
 
   @Test
@@ -203,7 +203,6 @@ public class KsqlStructuredDataOutputNodeTest {
     // Then:
     verify(sourceStream).into(
         eq(SINK_KAFKA_TOPIC_NAME),
-        eq(SCHEMA),
         eq(JSON_FORMAT),
         eq(SerdeOption.none()),
         stackerCaptor.capture()

--- a/ksql-engine/src/test/java/io/confluent/ksql/structured/SchemaKGroupedStreamTest.java
+++ b/ksql-engine/src/test/java/io/confluent/ksql/structured/SchemaKGroupedStreamTest.java
@@ -46,7 +46,6 @@ import io.confluent.ksql.serde.SerdeOption;
 import io.confluent.ksql.serde.ValueFormat;
 import io.confluent.ksql.serde.WindowInfo;
 import io.confluent.ksql.util.KsqlConfig;
-import java.util.List;
 import java.util.Optional;
 import java.util.concurrent.TimeUnit;
 import org.junit.Before;
@@ -77,8 +76,6 @@ public class SchemaKGroupedStreamTest {
   @Mock
   private KeyField keyField;
   @Mock
-  private List<SchemaKStream> sourceStreams;
-  @Mock
   private KsqlConfig config;
   @Mock
   private WindowExpression windowExp;
@@ -101,14 +98,13 @@ public class SchemaKGroupedStreamTest {
 
   @Before
   public void setUp() {
-    when(sourceStep.getSchema()).thenReturn(IN_SCHEMA);
     when(keyFormat.getFormatInfo()).thenReturn(keyFormatInfo);
     when(valueFormat.getFormatInfo()).thenReturn(valueformatInfo);
     schemaGroupedStream = new SchemaKGroupedStream(
         sourceStep,
+        IN_SCHEMA,
         keyFormat,
         keyField,
-        sourceStreams,
         config,
         functionRegistry
     );
@@ -150,8 +146,7 @@ public class SchemaKGroupedStreamTest {
                 schemaGroupedStream.getSourceStep(),
                 Formats.of(keyFormat, valueFormat, SerdeOption.none()),
                 1,
-                ImmutableList.of(AGG),
-                functionRegistry
+                ImmutableList.of(AGG)
             )
         )
     );
@@ -182,8 +177,7 @@ public class SchemaKGroupedStreamTest {
                 Formats.of(expected, valueFormat, SerdeOption.none()),
                 1,
                 ImmutableList.of(AGG),
-                KSQL_WINDOW_EXP,
-                functionRegistry
+                KSQL_WINDOW_EXP
             )
         )
     );

--- a/ksql-engine/src/test/java/io/confluent/ksql/structured/SchemaKGroupedTableTest.java
+++ b/ksql-engine/src/test/java/io/confluent/ksql/structured/SchemaKGroupedTableTest.java
@@ -78,12 +78,6 @@ public class SchemaKGroupedTableTest {
   @Rule
   public final ExpectedException expectedException = ExpectedException.none();
 
-  private static <S> ExecutionStep<S> buildSourceTableStep(final LogicalSchema schema) {
-    final ExecutionStep<S> step = mock(ExecutionStep.class);
-    when(step.getSchema()).thenReturn(schema);
-    return step;
-  }
-
   @Test
   public void shouldFailWindowedTableAggregation() {
     // Given:
@@ -127,10 +121,10 @@ public class SchemaKGroupedTableTest {
 
   private SchemaKGroupedTable buildSchemaKGroupedTable() {
     return new SchemaKGroupedTable(
-        buildSourceTableStep(IN_SCHEMA),
+        mock(ExecutionStep.class),
+        IN_SCHEMA,
         keyFormat,
         KeyField.of(IN_SCHEMA.value().get(0).ref()),
-        Collections.emptyList(),
         ksqlConfig,
         functionRegistry
     );
@@ -158,8 +152,7 @@ public class SchemaKGroupedTableTest {
                 kGroupedTable.getSourceTableStep(),
                 Formats.of(keyFormat, valueFormat, SerdeOption.none()),
                 1,
-                ImmutableList.of(SUM, COUNT),
-                functionRegistry
+                ImmutableList.of(SUM, COUNT)
             )
         )
     );

--- a/ksql-engine/src/test/java/io/confluent/ksql/structured/SchemaKStreamTest.java
+++ b/ksql-engine/src/test/java/io/confluent/ksql/structured/SchemaKStreamTest.java
@@ -20,10 +20,7 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.contains;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.is;
-import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.reset;
-import static org.mockito.Mockito.when;
 
 import com.google.common.collect.ImmutableList;
 import io.confluent.ksql.execution.builder.KsqlQueryBuilder;
@@ -34,14 +31,13 @@ import io.confluent.ksql.execution.expression.tree.Expression;
 import io.confluent.ksql.execution.expression.tree.FunctionCall;
 import io.confluent.ksql.execution.expression.tree.LongLiteral;
 import io.confluent.ksql.execution.plan.ExecutionStep;
-import io.confluent.ksql.execution.plan.ExecutionStepPropertiesV1;
 import io.confluent.ksql.execution.plan.Formats;
 import io.confluent.ksql.execution.plan.JoinType;
 import io.confluent.ksql.execution.plan.SelectExpression;
 import io.confluent.ksql.execution.plan.StreamFilter;
 import io.confluent.ksql.execution.streams.ExecutionStepFactory;
+import io.confluent.ksql.execution.streams.StepSchemaResolver;
 import io.confluent.ksql.function.InternalFunctionRegistry;
-import io.confluent.ksql.logging.processing.ProcessingLogContext;
 import io.confluent.ksql.metastore.MetaStore;
 import io.confluent.ksql.metastore.model.KeyField;
 import io.confluent.ksql.metastore.model.KsqlStream;
@@ -53,7 +49,6 @@ import io.confluent.ksql.name.SourceName;
 import io.confluent.ksql.planner.plan.FilterNode;
 import io.confluent.ksql.planner.plan.PlanNode;
 import io.confluent.ksql.planner.plan.ProjectNode;
-import io.confluent.ksql.schema.ksql.Column;
 import io.confluent.ksql.schema.ksql.ColumnRef;
 import io.confluent.ksql.schema.ksql.LogicalSchema;
 import io.confluent.ksql.schema.ksql.types.SqlTypes;
@@ -67,7 +62,6 @@ import io.confluent.ksql.util.KsqlConfig;
 import io.confluent.ksql.util.MetaStoreFixture;
 import io.confluent.ksql.util.Pair;
 import java.time.Duration;
-import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
@@ -98,21 +92,16 @@ public class SchemaKStreamTest {
   private final QueryContext.Stacker queryContext
       = new QueryContext.Stacker().push("node");
   private final QueryContext.Stacker childContextStacker = queryContext.push("child");
-  private final ProcessingLogContext processingLogContext = ProcessingLogContext.create();
 
   private SchemaKStream initialSchemaKStream;
   private SchemaKStream secondSchemaKStream;
   private SchemaKTable schemaKTable;
   private KsqlStream<?> ksqlStream;
   private InternalFunctionRegistry functionRegistry;
-  private LogicalSchema joinSchema;
+  private StepSchemaResolver schemaResolver;
 
   @Mock
-  private ExecutionStepPropertiesV1 tableSourceProperties;
-  @Mock
   private ExecutionStep tableSourceStep;
-  @Mock
-  private ExecutionStepPropertiesV1 sourceProperties;
   @Mock
   private ExecutionStep sourceStep;
   @Mock
@@ -121,6 +110,7 @@ public class SchemaKStreamTest {
   @Before
   public void init() {
     functionRegistry = new InternalFunctionRegistry();
+    schemaResolver = new StepSchemaResolver(ksqlConfig, functionRegistry);
     ksqlStream = (KsqlStream) metaStore.getSource(SourceName.of("TEST1"));
     final KsqlStream secondKsqlStream = (KsqlStream) metaStore.getSource(SourceName.of("ORDERS"));
     secondSchemaKStream = buildSchemaKStreamForJoin(
@@ -128,19 +118,13 @@ public class SchemaKStreamTest {
         mock(ExecutionStep.class)
     );
     final KsqlTable<?> ksqlTable = (KsqlTable) metaStore.getSource(SourceName.of("TEST2"));
-    when(tableSourceStep.getProperties()).thenReturn(tableSourceProperties);
-    when(tableSourceProperties.getSchema()).thenReturn(ksqlTable.getSchema());
     schemaKTable = new SchemaKTable(
         tableSourceStep,
+        ksqlTable.getSchema(),
         keyFormat,
         ksqlTable.getKeyField(),
-        new ArrayList<>(),
         ksqlConfig,
         functionRegistry);
-    when(sourceStep.getProperties()).thenReturn(sourceProperties);
-    when(queryBuilder.getFunctionRegistry()).thenReturn(functionRegistry);
-    when(queryBuilder.getKsqlConfig()).thenReturn(ksqlConfig);
-    joinSchema = getJoinSchema(ksqlStream.getSchema(), secondKsqlStream.getSchema());
   }
 
   @Test
@@ -166,7 +150,6 @@ public class SchemaKStreamTest {
         valueColumn(ColumnName.of("COL2"), SqlTypes.STRING),
         valueColumn(ColumnName.of("COL3"), SqlTypes.DOUBLE)
     ));
-    assertThat(projectedSchemaKStream.getSourceSchemaKStreams().get(0), is(initialSchemaKStream));
   }
 
   @Test
@@ -192,10 +175,32 @@ public class SchemaKStreamTest {
                 childContextStacker,
                 initialSchemaKStream.getSourceStep(),
                 selectExpressions,
-                SELECT_NODE_NAME,
-                queryBuilder
+                SELECT_NODE_NAME
             )
         )
+    );
+  }
+
+  @Test
+  public void shouldBuildSchemaForSelect() {
+    // Given:
+    final PlanNode logicalPlan = givenInitialKStreamOf(
+        "SELECT col0, col2, col3 FROM test1 WHERE col0 > 100 EMIT CHANGES;");
+    final ProjectNode projectNode = (ProjectNode) logicalPlan.getSources().get(0);
+    final List<SelectExpression> selectExpressions = projectNode.getSelectExpressions();
+
+    // When:
+    final SchemaKStream projectedSchemaKStream = initialSchemaKStream.select(
+        selectExpressions,
+        SELECT_NODE_NAME,
+        childContextStacker,
+        queryBuilder);
+
+    // Then:
+    assertThat(
+        projectedSchemaKStream.getSchema(),
+        is(schemaResolver.resolve(
+            projectedSchemaKStream.getSourceStep(), initialSchemaKStream.schema))
     );
   }
 
@@ -332,7 +337,6 @@ public class SchemaKStreamTest {
         valueColumn(ColumnName.of("KSQL_COL_2"), SqlTypes.DOUBLE)
     ));
 
-    assertThat(projectedSchemaKStream.getSourceSchemaKStreams().get(0), is(initialSchemaKStream));
   }
 
   @Test
@@ -361,7 +365,6 @@ public class SchemaKStreamTest {
         valueColumn(TEST1, ColumnName.of("COL5"), SqlTypes.map(SqlTypes.DOUBLE))
     ));
 
-    assertThat(filteredSchemaKStream.getSourceSchemaKStreams().get(0), is(initialSchemaKStream));
   }
 
   @Test
@@ -461,6 +464,24 @@ public class SchemaKStreamTest {
     );
   }
 
+  @Test
+  public void shouldBuildSchemaForSelectKey() {
+    // Given:
+    givenInitialKStreamOf("SELECT col0, col2, col3 FROM test1 WHERE col0 > 100 EMIT CHANGES;");
+
+    // When:
+    final SchemaKStream<?> rekeyedSchemaKStream = initialSchemaKStream.selectKey(
+        ColumnRef.of(SourceName.of("TEST1"), ColumnName.of("COL1")),
+        childContextStacker);
+
+    // Then:
+    assertThat(
+        rekeyedSchemaKStream.getSchema(),
+        is(schemaResolver.resolve(
+            rekeyedSchemaKStream.getSourceStep(), initialSchemaKStream.getSchema()))
+    );
+  }
+
   @Test(expected = IllegalArgumentException.class)
   public void shouldThrowOnSelectKeyIfKeyNotInSchema() {
     givenInitialKStreamOf("SELECT col0, col2, col3 FROM test1 WHERE col0 > 100 EMIT CHANGES;");
@@ -522,6 +543,29 @@ public class SchemaKStreamTest {
   }
 
   @Test
+  public void shouldBuildSchemaForGroupByKey() {
+    // Given:
+    givenInitialKStreamOf("SELECT col0, col1 FROM test1 WHERE col0 > 100 EMIT CHANGES;");
+    final List<Expression> groupBy = Collections.singletonList(
+        new ColumnReferenceExp(ColumnRef.of(TEST1, ColumnName.of("COL0")))
+    );
+
+    // When:
+    final SchemaKGroupedStream groupedSchemaKStream = initialSchemaKStream.groupBy(
+        valueFormat,
+        groupBy,
+        childContextStacker
+    );
+
+    // Then:
+    assertThat(
+        groupedSchemaKStream.schema,
+        is(schemaResolver.resolve(
+            groupedSchemaKStream.getSourceStep(), initialSchemaKStream.getSchema()))
+    );
+  }
+
+  @Test
   public void shouldBuildStepForGroupBy() {
     // Given:
     givenInitialKStreamOf("SELECT col0, col1 FROM test1 WHERE col0 > 100 EMIT CHANGES;");
@@ -548,6 +592,27 @@ public class SchemaKStreamTest {
                 groupBy
             )
         )
+    );
+  }
+
+  @Test
+  public void shouldBuildSchemaForGroupBy() {
+    // Given:
+    givenInitialKStreamOf("SELECT col0, col1 FROM test1 WHERE col0 > 100 EMIT CHANGES;");
+    final List<Expression> groupBy = Collections.singletonList(
+        new ColumnReferenceExp(ColumnRef.of(TEST1, ColumnName.of("COL1")))
+    );
+
+    // When:
+    final SchemaKGroupedStream groupedSchemaKStream = initialSchemaKStream.groupBy(
+        valueFormat,
+        groupBy,
+        childContextStacker
+    );
+
+    // Then:
+    assertThat(groupedSchemaKStream.schema, is(schemaResolver.resolve(
+        groupedSchemaKStream.getSourceStep(), initialSchemaKStream.getSchema()))
     );
   }
 
@@ -594,7 +659,6 @@ public class SchemaKStreamTest {
   private interface StreamStreamJoin {
     SchemaKStream join(
         SchemaKStream otherSchemaKStream,
-        LogicalSchema joinSchema,
         KeyField keyField,
         JoinWindows joinWindows,
         ValueFormat leftFormat,
@@ -618,7 +682,6 @@ public class SchemaKStreamTest {
     for (final Pair<JoinType, StreamStreamJoin> testcase : cases) {
       final SchemaKStream joinedKStream = testcase.right.join(
           secondSchemaKStream,
-          joinSchema,
           validJoinKeyField,
           joinWindow,
           valueFormat,
@@ -637,10 +700,40 @@ public class SchemaKStreamTest {
                   Formats.of(keyFormat, rightFormat, SerdeOption.none()),
                   initialSchemaKStream.getSourceStep(),
                   secondSchemaKStream.getSourceStep(),
-                  joinSchema,
                   joinWindow
               )
           )
+      );
+    }
+  }
+
+  @Test
+  public void shouldBuildSchemaForStreamStreamJoin() {
+    // Given:
+    final SchemaKStream initialSchemaKStream = buildSchemaKStreamForJoin(ksqlStream);
+    final JoinWindows joinWindow = JoinWindows.of(Duration.ofMillis(10L));
+
+    final List<Pair<JoinType, StreamStreamJoin>> cases = ImmutableList.of(
+        Pair.of(JoinType.LEFT, initialSchemaKStream::leftJoin),
+        Pair.of(JoinType.INNER, initialSchemaKStream::join),
+        Pair.of(JoinType.OUTER, initialSchemaKStream::outerJoin)
+    );
+
+    for (final Pair<JoinType, StreamStreamJoin> testcase : cases) {
+      final SchemaKStream joinedKStream = testcase.right.join(
+          secondSchemaKStream,
+          validJoinKeyField,
+          joinWindow,
+          valueFormat,
+          rightFormat,
+          childContextStacker
+      );
+
+      // Then:
+      assertThat(joinedKStream.getSchema(), is(schemaResolver.resolve(
+          joinedKStream.getSourceStep(),
+          initialSchemaKStream.getSchema(),
+          secondSchemaKStream.getSchema()))
       );
     }
   }
@@ -649,7 +742,6 @@ public class SchemaKStreamTest {
   private interface StreamTableJoin {
     SchemaKStream join(
         SchemaKTable other,
-        LogicalSchema joinSchema,
         KeyField keyField,
         ValueFormat leftFormat,
         QueryContext.Stacker contextStacker
@@ -669,7 +761,6 @@ public class SchemaKStreamTest {
     for (final Pair<JoinType, StreamTableJoin> testcase : cases) {
       final SchemaKStream joinedKStream = testcase.right.join(
           schemaKTable,
-          joinSchema,
           validJoinKeyField,
           valueFormat,
           childContextStacker
@@ -684,53 +775,58 @@ public class SchemaKStreamTest {
                   testcase.left,
                   Formats.of(keyFormat, valueFormat, SerdeOption.none()),
                   initialSchemaKStream.getSourceStep(),
-                  schemaKTable.getSourceTableStep(),
-                  joinSchema
+                  schemaKTable.getSourceTableStep()
               )
           )
       );
     }
   }
 
-  private void givenSourcePropertiesWithSchema(final LogicalSchema schema) {
-    reset(sourceProperties);
-    when(sourceProperties.getSchema()).thenReturn(schema);
+  @Test
+  public void shouldBuildSchemaForStreamTableJoin() {
+    // Given:
+    final SchemaKStream initialSchemaKStream = buildSchemaKStreamForJoin(ksqlStream);
+
+    final List<Pair<JoinType, StreamTableJoin>> cases = ImmutableList.of(
+        Pair.of(JoinType.LEFT, initialSchemaKStream::leftJoin),
+        Pair.of(JoinType.INNER, initialSchemaKStream::join)
+    );
+
+    for (final Pair<JoinType, StreamTableJoin> testcase : cases) {
+      final SchemaKStream joinedKStream = testcase.right.join(
+          schemaKTable,
+          validJoinKeyField,
+          valueFormat,
+          childContextStacker
+      );
+
+      // Then:
+      assertThat(joinedKStream.getSchema(), is(schemaResolver.resolve(
+          joinedKStream.getSourceStep(),
+          initialSchemaKStream.getSchema(),
+          schemaKTable.getSchema()))
+      );
+    }
   }
 
   private SchemaKStream buildSchemaKStream(
       final LogicalSchema schema,
       final KeyField keyField,
       final ExecutionStep sourceStep) {
-    givenSourcePropertiesWithSchema(schema);
     return new SchemaKStream(
         sourceStep,
-        sourceProperties,
+        schema,
         keyFormat,
         keyField,
-        new ArrayList<>(),
         ksqlConfig,
         functionRegistry
     );
   }
 
-  private void givenInitialSchemaKStreamUsesMocks() {
-    final LogicalSchema schema = ksqlStream.getSchema().withAlias(ksqlStream.getName());
-
-    final Optional<ColumnRef> newKeyName = ksqlStream.getKeyField()
-        .ref()
-        .map(ref -> ref.withSource(ksqlStream.getName()));
-
-    initialSchemaKStream = buildSchemaKStream(
-        schema,
-        KeyField.of(newKeyName),
-        sourceStep
-    );
-  }
-
   private SchemaKStream buildSchemaKStreamForJoin(final KsqlStream ksqlStream) {
     return buildSchemaKStream(
-        ksqlStream.getSchema().withAlias(SourceName.of("test")),
-        ksqlStream.getKeyField().withAlias(SourceName.of("test")),
+        ksqlStream.getSchema().withAlias(SourceName.of("left")),
+        ksqlStream.getKeyField().withAlias(SourceName.of("left")),
         sourceStep
     );
   }
@@ -739,27 +835,10 @@ public class SchemaKStreamTest {
       final KsqlStream ksqlStream,
       final ExecutionStep sourceStep) {
     return buildSchemaKStream(
-        ksqlStream.getSchema().withAlias(SourceName.of("test")),
-        ksqlStream.getKeyField().withAlias(SourceName.of("test")),
+        ksqlStream.getSchema().withAlias(SourceName.of("left")),
+        ksqlStream.getKeyField().withAlias(SourceName.of("left")),
         sourceStep
     );
-  }
-
-  private static LogicalSchema getJoinSchema(
-      final LogicalSchema leftSchema,
-      final LogicalSchema rightSchema
-  ) {
-    final LogicalSchema.Builder schemaBuilder = LogicalSchema.builder();
-    final String leftAlias = "left";
-    final String rightAlias = "right";
-    for (final Column field : leftSchema.value()) {
-      schemaBuilder.valueColumn(SourceName.of(leftAlias), field.name(), field.type());
-    }
-
-    for (final Column field : rightSchema.value()) {
-      schemaBuilder.valueColumn(SourceName.of(rightAlias), field.name(), field.type());
-    }
-    return schemaBuilder.build();
   }
 
   private PlanNode givenInitialKStreamOf(final String selectQuery) {
@@ -768,12 +847,11 @@ public class SchemaKStreamTest {
         selectQuery,
         metaStore
     );
-    givenSourcePropertiesWithSchema(logicalPlan.getTheSourceNode().getSchema());
     initialSchemaKStream = new SchemaKStream(
         sourceStep,
+        logicalPlan.getTheSourceNode().getSchema(),
         keyFormat,
         logicalPlan.getTheSourceNode().getKeyField(),
-        new ArrayList<>(),
         ksqlConfig,
         functionRegistry
     );

--- a/ksql-engine/src/test/java/io/confluent/ksql/structured/SchemaKTableTest.java
+++ b/ksql-engine/src/test/java/io/confluent/ksql/structured/SchemaKTableTest.java
@@ -44,7 +44,6 @@ import io.confluent.ksql.execution.expression.tree.ComparisonExpression;
 import io.confluent.ksql.execution.expression.tree.Expression;
 import io.confluent.ksql.execution.expression.tree.LongLiteral;
 import io.confluent.ksql.execution.plan.ExecutionStep;
-import io.confluent.ksql.execution.plan.ExecutionStepPropertiesV1;
 import io.confluent.ksql.execution.plan.Formats;
 import io.confluent.ksql.execution.plan.JoinType;
 import io.confluent.ksql.execution.plan.KTableHolder;
@@ -61,6 +60,7 @@ import io.confluent.ksql.execution.streams.KSPlanBuilder;
 import io.confluent.ksql.execution.streams.KsqlValueJoiner;
 import io.confluent.ksql.execution.streams.MaterializedFactory;
 import io.confluent.ksql.execution.streams.SqlPredicateFactory;
+import io.confluent.ksql.execution.streams.StepSchemaResolver;
 import io.confluent.ksql.execution.streams.StreamJoinedFactory;
 import io.confluent.ksql.execution.streams.StreamsFactories;
 import io.confluent.ksql.execution.streams.StreamsUtil;
@@ -91,7 +91,6 @@ import io.confluent.ksql.testutils.AnalysisTestUtil;
 import io.confluent.ksql.util.KsqlConfig;
 import io.confluent.ksql.util.MetaStoreFixture;
 import io.confluent.ksql.util.Pair;
-import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
@@ -127,8 +126,6 @@ public class SchemaKTableTest {
   private final GroupedFactory groupedFactory = mock(GroupedFactory.class);
   private final Grouped grouped = Grouped.with(
       "group", Serdes.String(), Serdes.String());
-  private final KeyField validKeyField = KeyField
-      .of(Optional.of(ColumnRef.of(SourceName.of("left"), ColumnName.of("COL1"))));
 
   private static final String SELECT_NODE_NAME = "SelectStep";
 
@@ -136,11 +133,14 @@ public class SchemaKTableTest {
   private KTable kTable;
   private KTable secondKTable;
   private KsqlTable<?> ksqlTable;
+  private KsqlTable<?> secondKsqlTable;
   private InternalFunctionRegistry functionRegistry;
   private KTable mockKTable;
+  private KeyField validKeyField;
   private SchemaKTable firstSchemaKTable;
   private SchemaKTable secondSchemaKTable;
   private LogicalSchema joinSchema;
+  private StepSchemaResolver schemaResolver;
   private final QueryContext.Stacker queryContext
       = new QueryContext.Stacker().push("node");
   private final QueryContext.Stacker childContextStacker = queryContext.push("child");
@@ -162,6 +162,7 @@ public class SchemaKTableTest {
   @Before
   public void init() {
     functionRegistry = new InternalFunctionRegistry();
+    schemaResolver = new StepSchemaResolver(ksqlConfig, functionRegistry);
     ksqlTable = (KsqlTable) metaStore.getSource(SourceName.of("TEST2"));
     final StreamsBuilder builder = new StreamsBuilder();
     kTable = builder.table(
@@ -171,7 +172,7 @@ public class SchemaKTableTest {
             getRowSerde(ksqlTable.getKsqlTopic(), ksqlTable.getSchema().valueConnectSchema())
         ));
 
-    final KsqlTable secondKsqlTable = (KsqlTable) metaStore.getSource(SourceName.of("TEST3"));
+    secondKsqlTable = (KsqlTable) metaStore.getSource(SourceName.of("TEST3"));
     secondKTable = builder.table(
         secondKsqlTable.getKsqlTopic().getKafkaTopicName(),
         Consumed.with(
@@ -180,6 +181,8 @@ public class SchemaKTableTest {
         ));
 
     mockKTable = EasyMock.niceMock(KTable.class);
+    validKeyField = KeyField
+        .of(Optional.of(ColumnRef.of(ksqlTable.getName(), ColumnName.of("COL1"))));
     firstSchemaKTable = buildSchemaKTableForJoin(ksqlTable, mockKTable);
     secondSchemaKTable = buildSchemaKTableForJoin(secondKsqlTable, secondKTable);
     joinSchema = getJoinSchema(ksqlTable.getSchema(), secondKsqlTable.getSchema());
@@ -202,8 +205,6 @@ public class SchemaKTableTest {
 
   private ExecutionStep buildSourceStep(final LogicalSchema schema, final KTable kTable) {
     final ExecutionStep sourceStep = Mockito.mock(ExecutionStep.class);
-    when(sourceStep.getProperties()).thenReturn(
-        new ExecutionStepPropertiesV1(schema, queryContext.getQueryContext()));
     when(sourceStep.build(any())).thenReturn(
         KTableHolder.unmaterialized(kTable, schema, keySerdeFactory));
     return sourceStep;
@@ -215,9 +216,9 @@ public class SchemaKTableTest {
       final KTable kTable) {
     return new SchemaKTable(
         buildSourceStep(schema, kTable),
+        schema,
         keyFormat,
         keyField,
-        new ArrayList<>(),
         ksqlConfig,
         functionRegistry
     );
@@ -226,9 +227,9 @@ public class SchemaKTableTest {
   private SchemaKTable buildSchemaKTableFromPlan(final PlanNode logicalPlan) {
     return new SchemaKTable(
         buildSourceStep(logicalPlan.getTheSourceNode().getSchema(), kTable),
+        logicalPlan.getTheSourceNode().getSchema(),
         keyFormat,
         logicalPlan.getTheSourceNode().getKeyField(),
-        new ArrayList<>(),
         ksqlConfig,
         functionRegistry
     );
@@ -289,8 +290,6 @@ public class SchemaKTableTest {
         valueColumn(ColumnName.of("COL2"), SqlTypes.STRING),
         valueColumn(ColumnName.of("COL3"), SqlTypes.DOUBLE)
     ));
-
-    assertThat(projectedSchemaKStream.getSourceSchemaKStreams().get(0), is(initialSchemaKTable));
   }
 
   @Test
@@ -317,10 +316,33 @@ public class SchemaKTableTest {
                 childContextStacker,
                 initialSchemaKTable.getSourceTableStep(),
                 projectNode.getSelectExpressions(),
-                SELECT_NODE_NAME,
-                queryBuilder
+                SELECT_NODE_NAME
             )
         )
+    );
+  }
+
+  @Test
+  public void shouldBuildSchemaForSelect() {
+    // Given:
+    final String selectQuery = "SELECT col0, col2, col3 FROM test2 WHERE col0 > 100 EMIT CHANGES;";
+    final PlanNode logicalPlan = buildLogicalPlan(selectQuery);
+    final ProjectNode projectNode = (ProjectNode) logicalPlan.getSources().get(0);
+    initialSchemaKTable = buildSchemaKTableFromPlan(logicalPlan);
+
+    // When:
+    final SchemaKTable projectedSchemaKStream = initialSchemaKTable.select(
+        projectNode.getSelectExpressions(),
+        SELECT_NODE_NAME,
+        childContextStacker,
+        queryBuilder
+    );
+
+    // Then:
+    assertThat(
+        projectedSchemaKStream.getSchema(),
+        is(schemaResolver.resolve(
+            projectedSchemaKStream.getSourceStep(), initialSchemaKTable.getSchema()))
     );
   }
 
@@ -346,8 +368,6 @@ public class SchemaKTableTest {
         valueColumn(ColumnName.of("KSQL_COL_1"), SqlTypes.INTEGER),
         valueColumn(ColumnName.of("KSQL_COL_2"), SqlTypes.DOUBLE)
     ));
-
-    assertThat(projectedSchemaKStream.getSourceSchemaKStreams().get(0), is(initialSchemaKTable));
   }
 
   @Test
@@ -376,8 +396,6 @@ public class SchemaKTableTest {
         valueColumn(test2, ColumnName.of("COL3"), SqlTypes.DOUBLE),
         valueColumn(test2, ColumnName.of("COL4"), SqlTypes.BOOLEAN)
     ));
-
-    assertThat(filteredSchemaKStream.getSourceSchemaKStreams().get(0), is(initialSchemaKTable));
   }
 
   @Test
@@ -490,6 +508,27 @@ public class SchemaKTableTest {
   }
 
   @Test
+  public void shouldBuildSchemaForGroupBy() {
+    // Given:
+    final String selectQuery = "SELECT col0, col1, col2 FROM test2 EMIT CHANGES;";
+    final PlanNode logicalPlan = buildLogicalPlan(selectQuery);
+    initialSchemaKTable = buildSchemaKTableFromPlan(logicalPlan);
+    final List<Expression> groupByExpressions = Arrays.asList(TEST_2_COL_2, TEST_2_COL_1);
+
+    // When:
+    final SchemaKGroupedTable groupedSchemaKTable = initialSchemaKTable.groupBy(
+        valueFormat,
+        groupByExpressions,
+        childContextStacker
+    );
+
+    // Then:
+    assertThat(groupedSchemaKTable.schema, is(schemaResolver.resolve(
+        groupedSchemaKTable.getSourceTableStep(), initialSchemaKTable.getSchema()))
+    );
+  }
+
+  @Test
   public void shouldUseOpNameForGrouped() {
     // Given:
     final Serde<GenericRow> valSerde =
@@ -536,9 +575,9 @@ public class SchemaKTableTest {
     final PlanNode logicalPlan = buildLogicalPlan(selectQuery);
     initialSchemaKTable = new SchemaKTable(
         buildSourceStep(logicalPlan.getTheSourceNode().getSchema(), mockKTable),
+        logicalPlan.getTheSourceNode().getSchema(),
         keyFormat,
         logicalPlan.getTheSourceNode().getKeyField(),
-        new ArrayList<>(),
         ksqlConfig,
         functionRegistry
     );
@@ -572,7 +611,6 @@ public class SchemaKTableTest {
     final SchemaKStream joinedKStream = firstSchemaKTable
         .leftJoin(
             secondSchemaKTable,
-            joinSchema,
             validKeyField,
             childContextStacker);
 
@@ -581,8 +619,6 @@ public class SchemaKTableTest {
     assertThat(joinedKStream, instanceOf(SchemaKTable.class));
     assertEquals(joinSchema, joinedKStream.getSchema());
     assertThat(joinedKStream.getKeyField(), is(validKeyField));
-    assertEquals(Arrays.asList(firstSchemaKTable, secondSchemaKTable),
-                 joinedKStream.sourceSchemaKStreams);
   }
 
   @SuppressWarnings("unchecked")
@@ -595,7 +631,7 @@ public class SchemaKTableTest {
     replay(mockKTable);
 
     final SchemaKStream joinedKStream = firstSchemaKTable
-        .join(secondSchemaKTable, joinSchema,
+        .join(secondSchemaKTable,
             validKeyField,
             childContextStacker);
 
@@ -604,8 +640,6 @@ public class SchemaKTableTest {
     assertThat(joinedKStream, instanceOf(SchemaKTable.class));
     assertEquals(joinSchema, joinedKStream.getSchema());
     assertThat(joinedKStream.getKeyField(), is(validKeyField));
-    assertEquals(Arrays.asList(firstSchemaKTable, secondSchemaKTable),
-                 joinedKStream.sourceSchemaKStreams);
   }
 
   @SuppressWarnings("unchecked")
@@ -618,7 +652,7 @@ public class SchemaKTableTest {
     replay(mockKTable);
 
     final SchemaKStream joinedKStream = firstSchemaKTable
-        .outerJoin(secondSchemaKTable, joinSchema,
+        .outerJoin(secondSchemaKTable,
             validKeyField,
             childContextStacker);
 
@@ -627,14 +661,11 @@ public class SchemaKTableTest {
     assertThat(joinedKStream, instanceOf(SchemaKTable.class));
     assertEquals(joinSchema, joinedKStream.getSchema());
     assertThat(joinedKStream.getKeyField(), is(validKeyField));
-    assertEquals(Arrays.asList(firstSchemaKTable, secondSchemaKTable),
-                 joinedKStream.sourceSchemaKStreams);
   }
 
   interface Join {
     SchemaKTable join(
         SchemaKTable schemaKTable,
-        LogicalSchema joinSchema,
         KeyField keyField,
         QueryContext.Stacker contextStacker
     );
@@ -642,29 +673,22 @@ public class SchemaKTableTest {
 
   @Test
   public void shouldBuildStepForTableTableJoin() {
-    final KTable resultTable = EasyMock.niceMock(KTable.class);
-    expect(mockKTable.outerJoin(
-        eq(secondKTable),
-        anyObject(KsqlValueJoiner.class))
-    ).andReturn(resultTable);
-    expect(mockKTable.join(
-        eq(secondKTable),
-        anyObject(KsqlValueJoiner.class))
-    ).andReturn(resultTable);
-    expect(mockKTable.leftJoin(
-        eq(secondKTable),
-        anyObject(KsqlValueJoiner.class))
-    ).andReturn(resultTable);
-    replay(mockKTable);
-
+    // Given:
+    givenJoin();
+    givenOuterJoin();
+    givenLeftJoin();
     final List<Pair<JoinType, Join>> cases = ImmutableList.of(
         Pair.of(JoinType.LEFT, firstSchemaKTable::leftJoin),
         Pair.of(JoinType.INNER, firstSchemaKTable::join),
         Pair.of(JoinType.OUTER, firstSchemaKTable::outerJoin)
     );
+
     for (final Pair<JoinType, Join> testCase : cases) {
+      // When:
       final SchemaKTable result =
-          testCase.right.join(secondSchemaKTable, joinSchema, validKeyField, childContextStacker);
+          testCase.right.join(secondSchemaKTable, validKeyField, childContextStacker);
+
+      // Then:
       assertThat(
           result.getSourceTableStep(),
           equalTo(
@@ -672,10 +696,33 @@ public class SchemaKTableTest {
                   childContextStacker,
                   testCase.left,
                   firstSchemaKTable.getSourceTableStep(),
-                  secondSchemaKTable.getSourceTableStep(),
-                  joinSchema
+                  secondSchemaKTable.getSourceTableStep()
               )
           )
+      );
+    }
+  }
+
+  @Test
+  public void shouldBuildSchemaForTableTableJoin() {
+    // Given:
+    givenJoin();
+    givenOuterJoin();
+    givenLeftJoin();
+    final List<Pair<JoinType, Join>> cases = ImmutableList.of(
+        Pair.of(JoinType.LEFT, firstSchemaKTable::leftJoin),
+        Pair.of(JoinType.INNER, firstSchemaKTable::join),
+        Pair.of(JoinType.OUTER, firstSchemaKTable::outerJoin)
+    );
+
+    for (final Pair<JoinType, Join> testCase : cases) {
+      // When:
+      final SchemaKTable result =
+          testCase.right.join(secondSchemaKTable, validKeyField, childContextStacker);
+
+      // Then:
+      assertThat(result.getSchema(), is(schemaResolver.resolve(
+          result.getSourceStep(), firstSchemaKTable.getSchema(), secondSchemaKTable.getSchema()))
       );
     }
   }
@@ -801,13 +848,13 @@ public class SchemaKTableTest {
         is(KeyField.of(ColumnRef.withoutSource(ColumnName.of("COL1")))));
   }
 
-  private static LogicalSchema getJoinSchema(
+  private LogicalSchema getJoinSchema(
       final LogicalSchema leftSchema,
       final LogicalSchema rightSchema
   ) {
     final LogicalSchema.Builder schemaBuilder = LogicalSchema.builder();
-    final SourceName leftAlias = SourceName.of("left");
-    final SourceName rightAlias = SourceName.of("right");
+    final SourceName leftAlias = ksqlTable.getName();
+    final SourceName rightAlias = secondKsqlTable.getName();
     for (final Column field : leftSchema.value()) {
       schemaBuilder.valueColumn(leftAlias, field.name(), field.type());
     }
@@ -827,9 +874,9 @@ public class SchemaKTableTest {
 
     initialSchemaKTable = new SchemaKTable(
         buildSourceStep(logicalPlan.getTheSourceNode().getSchema(), kTable),
+        logicalPlan.getTheSourceNode().getSchema(),
         keyFormat,
         logicalPlan.getTheSourceNode().getKeyField(),
-        new ArrayList<>(),
         ksqlConfig,
         functionRegistry
     );
@@ -840,5 +887,29 @@ public class SchemaKTableTest {
 
   private PlanNode buildLogicalPlan(final String query) {
     return AnalysisTestUtil.buildLogicalPlan(ksqlConfig, query, metaStore);
+  }
+
+  private void givenJoin() {
+    final KTable resultTable = EasyMock.niceMock(KTable.class);
+    expect(mockKTable.join(
+        eq(secondKTable),
+        anyObject(KsqlValueJoiner.class))
+    ).andReturn(resultTable);
+  }
+
+  private void givenOuterJoin() {
+    final KTable resultTable = EasyMock.niceMock(KTable.class);
+    expect(mockKTable.outerJoin(
+        eq(secondKTable),
+        anyObject(KsqlValueJoiner.class))
+    ).andReturn(resultTable);
+  }
+
+  private void givenLeftJoin() {
+    final KTable resultTable = EasyMock.niceMock(KTable.class);
+    expect(mockKTable.leftJoin(
+        eq(secondKTable),
+        anyObject(KsqlValueJoiner.class))
+    ).andReturn(resultTable);
   }
 }

--- a/ksql-execution/src/main/java/io/confluent/ksql/execution/plan/ExecutionStep.java
+++ b/ksql-execution/src/main/java/io/confluent/ksql/execution/plan/ExecutionStep.java
@@ -20,7 +20,6 @@ import com.fasterxml.jackson.annotation.JsonSubTypes.Type;
 import com.fasterxml.jackson.annotation.JsonTypeInfo;
 import com.fasterxml.jackson.annotation.JsonTypeInfo.As;
 import com.google.errorprone.annotations.Immutable;
-import io.confluent.ksql.schema.ksql.LogicalSchema;
 import java.util.List;
 
 @JsonTypeInfo(
@@ -58,9 +57,4 @@ public interface ExecutionStep<S> {
   List<ExecutionStep<?>> getSources();
 
   S build(PlanBuilder planBuilder);
-
-  @JsonIgnore
-  default LogicalSchema getSchema() {
-    return getProperties().getSchema();
-  }
 }

--- a/ksql-execution/src/main/java/io/confluent/ksql/execution/plan/ExecutionStepProperties.java
+++ b/ksql-execution/src/main/java/io/confluent/ksql/execution/plan/ExecutionStepProperties.java
@@ -16,11 +16,8 @@
 package io.confluent.ksql.execution.plan;
 
 import io.confluent.ksql.execution.context.QueryContext;
-import io.confluent.ksql.schema.ksql.LogicalSchema;
 
 public interface ExecutionStepProperties {
-  LogicalSchema getSchema();
-
   String getId();
 
   QueryContext getQueryContext();

--- a/ksql-execution/src/main/java/io/confluent/ksql/execution/plan/ExecutionStepPropertiesV1.java
+++ b/ksql-execution/src/main/java/io/confluent/ksql/execution/plan/ExecutionStepPropertiesV1.java
@@ -18,23 +18,15 @@ import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.google.errorprone.annotations.Immutable;
 import io.confluent.ksql.execution.context.QueryContext;
-import io.confluent.ksql.schema.ksql.LogicalSchema;
 import java.util.Objects;
 
 @Immutable
 public final class ExecutionStepPropertiesV1 implements ExecutionStepProperties {
   private final QueryContext queryContext;
-  private final LogicalSchema schema;
 
   public ExecutionStepPropertiesV1(
-      @JsonProperty(value = "schema", required = true) final LogicalSchema schema,
       @JsonProperty(value = "queryContext", required = true) final QueryContext queryContext) {
     this.queryContext = Objects.requireNonNull(queryContext, "queryContext");
-    this.schema = Objects.requireNonNull(schema, "schema");
-  }
-
-  public LogicalSchema getSchema() {
-    return schema;
   }
 
   @JsonIgnore
@@ -55,20 +47,18 @@ public final class ExecutionStepPropertiesV1 implements ExecutionStepProperties 
       return false;
     }
     final ExecutionStepPropertiesV1 that = (ExecutionStepPropertiesV1) o;
-    return Objects.equals(queryContext, that.queryContext)
-        && Objects.equals(schema, that.schema);
+    return Objects.equals(queryContext, that.queryContext);
   }
 
   @Override
   public int hashCode() {
-    return Objects.hash(queryContext, schema);
+    return Objects.hash(queryContext);
   }
 
   @Override
   public String toString() {
     return "ExecutionStepProperties{"
         + "queryContext='" + queryContext.toString() + '\''
-        + ", schema=" + schema
         + '}';
   }
 }

--- a/ksql-rest-app/src/test/resources/ksql-plan-schema/schema.json
+++ b/ksql-rest-app/src/test/resources/ksql-plan-schema/schema.json
@@ -277,14 +277,11 @@
       "type" : "object",
       "additionalProperties" : false,
       "properties" : {
-        "schema" : {
-          "type" : "string"
-        },
         "queryContext" : {
           "type" : "string"
         }
       },
-      "required" : [ "schema", "queryContext" ]
+      "required" : [ "queryContext" ]
     },
     "StreamFilter" : {
       "type" : "object",

--- a/ksql-streams/src/main/java/io/confluent/ksql/execution/streams/StreamMapValuesBuilder.java
+++ b/ksql-streams/src/main/java/io/confluent/ksql/execution/streams/StreamMapValuesBuilder.java
@@ -40,7 +40,7 @@ public final class StreamMapValuesBuilder {
         step.getProperties().getQueryContext()
     );
 
-    final LogicalSchema sourceSchema = step.getSource().getProperties().getSchema();
+    final LogicalSchema sourceSchema = stream.getSchema();
 
     final Selection<K> selection = Selection.of(
         sourceSchema,

--- a/ksql-streams/src/main/java/io/confluent/ksql/execution/streams/TableMapValuesBuilder.java
+++ b/ksql-streams/src/main/java/io/confluent/ksql/execution/streams/TableMapValuesBuilder.java
@@ -46,7 +46,7 @@ public final class TableMapValuesBuilder {
         step.getProperties().getQueryContext()
     );
 
-    final LogicalSchema sourceSchema = step.getSource().getProperties().getSchema();
+    final LogicalSchema sourceSchema = table.getSchema();
 
     final Selection<K> selection = Selection.of(
         sourceSchema,

--- a/ksql-streams/src/test/java/io/confluent/ksql/execution/streams/SourceBuilderTest.java
+++ b/ksql-streams/src/test/java/io/confluent/ksql/execution/streams/SourceBuilderTest.java
@@ -356,7 +356,7 @@ public class SourceBuilderTest {
     // Given:
     givenUnwindowedSourceStream();
     final StreamSource streamSource = new StreamSource(
-        new ExecutionStepPropertiesV1(SCHEMA, ctx),
+        new ExecutionStepPropertiesV1(ctx),
         TOPIC_NAME,
         Formats.of(keyFormatInfo, valueFormatInfo, SERDE_OPTIONS),
         Optional.empty(),
@@ -599,7 +599,7 @@ public class SourceBuilderTest {
     when(queryBuilder.buildKeySerde(any(), any(), any(), any())).thenReturn(windowedKeySerde);
     givenConsumed(consumedWindowed, windowedKeySerde);
     windowedStreamSource = new WindowedStreamSource(
-        new ExecutionStepPropertiesV1(SCHEMA, ctx),
+        new ExecutionStepPropertiesV1(ctx),
         TOPIC_NAME,
         Formats.of(keyFormatInfo, valueFormatInfo, SERDE_OPTIONS),
         windowInfo,
@@ -614,7 +614,7 @@ public class SourceBuilderTest {
     when(queryBuilder.buildKeySerde(any(), any(), any())).thenReturn(keySerde);
     givenConsumed(consumed, keySerde);
     streamSource = new StreamSource(
-        new ExecutionStepPropertiesV1(SCHEMA, ctx),
+        new ExecutionStepPropertiesV1(ctx),
         TOPIC_NAME,
         Formats.of(keyFormatInfo, valueFormatInfo, SERDE_OPTIONS),
         TIMESTAMP_COLUMN,
@@ -629,7 +629,7 @@ public class SourceBuilderTest {
     givenConsumed(consumedWindowed, windowedKeySerde);
     givenConsumed(consumedWindowed, windowedKeySerde);
     windowedTableSource = new WindowedTableSource(
-        new ExecutionStepPropertiesV1(SCHEMA, ctx),
+        new ExecutionStepPropertiesV1(ctx),
         TOPIC_NAME,
         Formats.of(keyFormatInfo, valueFormatInfo, SERDE_OPTIONS),
         windowInfo,
@@ -644,7 +644,7 @@ public class SourceBuilderTest {
     when(queryBuilder.buildKeySerde(any(), any(), any())).thenReturn(keySerde);
     givenConsumed(consumed, keySerde);
     tableSource = new TableSource(
-        new ExecutionStepPropertiesV1(SCHEMA, ctx),
+        new ExecutionStepPropertiesV1(ctx),
         TOPIC_NAME,
         Formats.of(keyFormatInfo, valueFormatInfo, SERDE_OPTIONS),
         TIMESTAMP_COLUMN,

--- a/ksql-streams/src/test/java/io/confluent/ksql/execution/streams/StepSchemaResolverTest.java
+++ b/ksql-streams/src/test/java/io/confluent/ksql/execution/streams/StepSchemaResolverTest.java
@@ -88,7 +88,6 @@ public class StepSchemaResolverTest {
       .valueColumn(ColumnName.of("BANANA"), SqlTypes.STRING)
       .build();
   private static final ExecutionStepPropertiesV1 PROPERTIES = new ExecutionStepPropertiesV1(
-      SCHEMA,
       new QueryContext.Stacker().getQueryContext()
   );
 

--- a/ksql-streams/src/test/java/io/confluent/ksql/execution/streams/StreamAggregateBuilderTest.java
+++ b/ksql-streams/src/test/java/io/confluent/ksql/execution/streams/StreamAggregateBuilderTest.java
@@ -239,7 +239,7 @@ public class StreamAggregateBuilderTest {
     when(aggregated.transformValues(any(), any(Named.class)))
         .thenReturn((KTable) aggregatedWithResults);
     aggregate = new StreamAggregate(
-        new ExecutionStepPropertiesV1(OUTPUT_SCHEMA, CTX),
+        new ExecutionStepPropertiesV1(CTX),
         sourceStep,
         Formats.of(KEY_FORMAT, VALUE_FORMAT, SerdeOption.none()),
         2,
@@ -261,7 +261,7 @@ public class StreamAggregateBuilderTest {
   private void givenTumblingWindowedAggregate() {
     givenTimeWindowedAggregate();
     windowedAggregate = new StreamWindowedAggregate(
-        new ExecutionStepPropertiesV1(OUTPUT_SCHEMA, CTX),
+        new ExecutionStepPropertiesV1(CTX),
         sourceStep,
         Formats.of(KEY_FORMAT, VALUE_FORMAT, SerdeOption.none()),
         2,
@@ -273,7 +273,7 @@ public class StreamAggregateBuilderTest {
   private void givenHoppingWindowedAggregate() {
     givenTimeWindowedAggregate();
     windowedAggregate = new StreamWindowedAggregate(
-        new ExecutionStepPropertiesV1(OUTPUT_SCHEMA, CTX),
+        new ExecutionStepPropertiesV1(CTX),
         sourceStep,
         Formats.of(KEY_FORMAT, VALUE_FORMAT, SerdeOption.none()),
         2,
@@ -297,7 +297,7 @@ public class StreamAggregateBuilderTest {
     when(windowed.transformValues(any(), any(Named.class)))
         .thenReturn((KTable) windowedWithResults);
     windowedAggregate = new StreamWindowedAggregate(
-        new ExecutionStepPropertiesV1(OUTPUT_SCHEMA, CTX),
+        new ExecutionStepPropertiesV1(CTX),
         sourceStep,
         Formats.of(KEY_FORMAT, VALUE_FORMAT, SerdeOption.none()),
         2,

--- a/ksql-streams/src/test/java/io/confluent/ksql/execution/streams/StreamFilterBuilderTest.java
+++ b/ksql-streams/src/test/java/io/confluent/ksql/execution/streams/StreamFilterBuilderTest.java
@@ -93,7 +93,6 @@ public class StreamFilterBuilderTest {
     when(processingLogContext.getLoggerFactory()).thenReturn(processingLoggerFactory);
     when(processingLoggerFactory.getLogger(any())).thenReturn(processingLogger);
     when(sourceStep.getProperties()).thenReturn(sourceProperties);
-    when(sourceProperties.getSchema()).thenReturn(schema);
     when(sourceKStream
         .flatTransformValues(any(ValueTransformerWithKeySupplier.class), any(Named.class)))
         .thenReturn(filteredKStream);
@@ -104,10 +103,7 @@ public class StreamFilterBuilderTest {
         schema,
         keySerdeFactory
     ));
-    final ExecutionStepPropertiesV1 properties = new ExecutionStepPropertiesV1(
-        schema,
-        queryContext
-    );
+    final ExecutionStepPropertiesV1 properties = new ExecutionStepPropertiesV1(queryContext);
     planBuilder = new KSPlanBuilder(
         queryBuilder,
         predicateFactory,

--- a/ksql-streams/src/test/java/io/confluent/ksql/execution/streams/StreamGroupByBuilderTest.java
+++ b/ksql-streams/src/test/java/io/confluent/ksql/execution/streams/StreamGroupByBuilderTest.java
@@ -74,9 +74,8 @@ public class StreamGroupByBuilderTest {
   private static final QueryContext STEP_CTX =
       new QueryContext.Stacker().push("foo").push("groupby").getQueryContext();
   private static final ExecutionStepPropertiesV1 SOURCE_PROPERTIES
-      = new ExecutionStepPropertiesV1(SCHEMA, SOURCE_CTX);
+      = new ExecutionStepPropertiesV1(SOURCE_CTX);
   private static final ExecutionStepPropertiesV1 PROPERTIES = new ExecutionStepPropertiesV1(
-      SCHEMA,
       STEP_CTX
   );
   private static final Formats FORMATS = Formats.of(
@@ -132,7 +131,6 @@ public class StreamGroupByBuilderTest {
     when(filteredStream.groupBy(any(KeyValueMapper.class), any(Grouped.class)))
         .thenReturn(groupedStream);
     when(sourceStep.getProperties()).thenReturn(SOURCE_PROPERTIES);
-    when(sourceStep.getSchema()).thenReturn(SCHEMA);
     when(sourceStep.build(any())).thenReturn(
         new KStreamHolder<>(sourceStream, SCHEMA, mock(KeySerdeFactory.class)));
     streamGroupBy = new StreamGroupBy<>(

--- a/ksql-streams/src/test/java/io/confluent/ksql/execution/streams/StreamMapValuesBuilderTest.java
+++ b/ksql-streams/src/test/java/io/confluent/ksql/execution/streams/StreamMapValuesBuilderTest.java
@@ -118,7 +118,6 @@ public class StreamMapValuesBuilderTest {
   @Before
   public void setup() {
     when(sourceStep.getProperties()).thenReturn(sourceProperties);
-    when(sourceProperties.getSchema()).thenReturn(SCHEMA);
     when(properties.getQueryContext()).thenReturn(context);
     when(processingLogContext.getLoggerFactory()).thenReturn(processingLoggerFactory);
     when(processingLoggerFactory.getLogger(any())).thenReturn(mock(ProcessingLogger.class));

--- a/ksql-streams/src/test/java/io/confluent/ksql/execution/streams/StreamSelectKeyBuilderTest.java
+++ b/ksql-streams/src/test/java/io/confluent/ksql/execution/streams/StreamSelectKeyBuilderTest.java
@@ -84,10 +84,7 @@ public class StreamSelectKeyBuilderTest {
 
   private final QueryContext queryContext =
       new QueryContext.Stacker().push("ya").getQueryContext();
-  private final ExecutionStepPropertiesV1 properties = new ExecutionStepPropertiesV1(
-      SCHEMA,
-      queryContext
-  );
+  private final ExecutionStepPropertiesV1 properties = new ExecutionStepPropertiesV1(queryContext);
 
   private PlanBuilder planBuilder;
   private StreamSelectKey selectKey;

--- a/ksql-streams/src/test/java/io/confluent/ksql/execution/streams/StreamSinkBuilderTest.java
+++ b/ksql-streams/src/test/java/io/confluent/ksql/execution/streams/StreamSinkBuilderTest.java
@@ -100,7 +100,7 @@ public class StreamSinkBuilderTest {
     when(kStream.mapValues(any(ValueMapper.class))).thenReturn(kStream);
     when(source.build(any())).thenReturn(new KStreamHolder<>(kStream, SCHEMA, keySerdeFactory));
     sink = new StreamSink<>(
-        new ExecutionStepPropertiesV1(SCHEMA, queryContext),
+        new ExecutionStepPropertiesV1(queryContext),
         source,
         Formats.of(KEY_FORMAT, VALUE_FORMAT, SerdeOption.none()),
         TOPIC

--- a/ksql-streams/src/test/java/io/confluent/ksql/execution/streams/StreamStreamJoinBuilderTest.java
+++ b/ksql-streams/src/test/java/io/confluent/ksql/execution/streams/StreamStreamJoinBuilderTest.java
@@ -147,7 +147,7 @@ public class StreamStreamJoinBuilderTest {
   private void givenLeftJoin() {
     when(leftKStream.leftJoin(any(KStream.class), any(), any(), any(StreamJoined.class))).thenReturn(resultKStream);
     join = new StreamStreamJoin<>(
-        new ExecutionStepPropertiesV1(SCHEMA, CTX),
+        new ExecutionStepPropertiesV1(CTX),
         JoinType.LEFT,
         LEFT_FMT,
         RIGHT_FMT,
@@ -162,7 +162,7 @@ public class StreamStreamJoinBuilderTest {
   private void givenOuterJoin() {
     when(leftKStream.outerJoin(any(KStream.class), any(), any(), any(StreamJoined.class))).thenReturn(resultKStream);
     join = new StreamStreamJoin<>(
-        new ExecutionStepPropertiesV1(SCHEMA, CTX),
+        new ExecutionStepPropertiesV1(CTX),
         JoinType.OUTER,
         LEFT_FMT,
         RIGHT_FMT,
@@ -177,7 +177,7 @@ public class StreamStreamJoinBuilderTest {
   private void givenInnerJoin() {
     when(leftKStream.join(any(KStream.class), any(), any(), any(StreamJoined.class))).thenReturn(resultKStream);
     join = new StreamStreamJoin<>(
-        new ExecutionStepPropertiesV1(SCHEMA, CTX),
+        new ExecutionStepPropertiesV1(CTX),
         JoinType.INNER,
         LEFT_FMT,
         RIGHT_FMT,

--- a/ksql-streams/src/test/java/io/confluent/ksql/execution/streams/StreamTableJoinBuilderTest.java
+++ b/ksql-streams/src/test/java/io/confluent/ksql/execution/streams/StreamTableJoinBuilderTest.java
@@ -136,7 +136,7 @@ public class StreamTableJoinBuilderTest {
   private void givenLeftJoin() {
     when(leftKStream.leftJoin(any(KTable.class), any(), any())).thenReturn(resultStream);
     join = new StreamTableJoin(
-        new ExecutionStepPropertiesV1(SCHEMA, CTX),
+        new ExecutionStepPropertiesV1(CTX),
         JoinType.LEFT,
         LEFT_FMT,
         left,
@@ -147,7 +147,7 @@ public class StreamTableJoinBuilderTest {
   @SuppressWarnings("unchecked")
   private void givenOuterJoin() {
     join = new StreamTableJoin(
-        new ExecutionStepPropertiesV1(SCHEMA, CTX),
+        new ExecutionStepPropertiesV1(CTX),
         JoinType.OUTER,
         LEFT_FMT,
         left,
@@ -159,7 +159,7 @@ public class StreamTableJoinBuilderTest {
   private void givenInnerJoin() {
     when(leftKStream.join(any(KTable.class), any(), any())).thenReturn(resultStream);
     join = new StreamTableJoin(
-        new ExecutionStepPropertiesV1(SCHEMA, CTX),
+        new ExecutionStepPropertiesV1(CTX),
         JoinType.INNER,
         LEFT_FMT,
         left,

--- a/ksql-streams/src/test/java/io/confluent/ksql/execution/streams/TableAggregateBuilderTest.java
+++ b/ksql-streams/src/test/java/io/confluent/ksql/execution/streams/TableAggregateBuilderTest.java
@@ -168,7 +168,7 @@ public class TableAggregateBuilderTest {
     when(aggregated.transformValues(any(), any(Named.class)))
         .thenReturn((KTable)aggregatedWithResults);
     aggregate = new TableAggregate(
-        new ExecutionStepPropertiesV1(AGGREGATE_SCHEMA, CTX),
+        new ExecutionStepPropertiesV1(CTX),
         sourceStep,
         Formats.of(KEY_FORMAT, VALUE_FORMAT, SerdeOption.none()),
         2,

--- a/ksql-streams/src/test/java/io/confluent/ksql/execution/streams/TableFilterBuilderTest.java
+++ b/ksql-streams/src/test/java/io/confluent/ksql/execution/streams/TableFilterBuilderTest.java
@@ -115,17 +115,13 @@ public class TableFilterBuilderTest {
     when(processingLogContext.getLoggerFactory()).thenReturn(processingLoggerFactory);
     when(processingLoggerFactory.getLogger(any())).thenReturn(processingLogger);
     when(sourceStep.getProperties()).thenReturn(sourceProperties);
-    when(sourceProperties.getSchema()).thenReturn(schema);
     when(sourceKTable.transformValues(any(), any(Named.class))).thenReturn((KTable)preKTable);
     when(preKTable.filter(any(), any(Named.class))).thenReturn((KTable)filteredKTable);
     when(filteredKTable.mapValues(any(ValueMapper.class), any(Named.class))).thenReturn(postKTable);
     when(predicateFactory.create(any(), any(), any(), any())).thenReturn(sqlPredicate);
     when(sqlPredicate.getTransformer(any())).thenReturn((KsqlTransformer) preTransformer);
     when(materializationBuilder.filter(any(), any())).thenReturn(materializationBuilder);
-    final ExecutionStepPropertiesV1 properties = new ExecutionStepPropertiesV1(
-        schema,
-        queryContext
-    );
+    final ExecutionStepPropertiesV1 properties = new ExecutionStepPropertiesV1(queryContext);
     step = new TableFilter<>(properties, sourceStep, filterExpression, "stepName");
     when(sourceStep.build(any())).thenReturn(
         KTableHolder.materialized(sourceKTable, schema, keySerdeFactory, materializationBuilder))

--- a/ksql-streams/src/test/java/io/confluent/ksql/execution/streams/TableGroupByBuilderTest.java
+++ b/ksql-streams/src/test/java/io/confluent/ksql/execution/streams/TableGroupByBuilderTest.java
@@ -75,9 +75,8 @@ public class TableGroupByBuilderTest {
   private static final QueryContext STEP_CONTEXT =
       new QueryContext.Stacker().push("foo").push("groupby").getQueryContext();
   private static final ExecutionStepPropertiesV1 SOURCE_PROPERTIES =
-      new ExecutionStepPropertiesV1(SCHEMA, SOURCE_CONTEXT);
+      new ExecutionStepPropertiesV1(SOURCE_CONTEXT);
   private static final ExecutionStepPropertiesV1 PROPERTIES = new ExecutionStepPropertiesV1(
-      SCHEMA,
       STEP_CONTEXT
   );
   private static final Formats FORMATS = Formats.of(
@@ -132,7 +131,6 @@ public class TableGroupByBuilderTest {
     when(filteredTable.groupBy(any(KeyValueMapper.class), any(Grouped.class)))
         .thenReturn(groupedTable);
     when(sourceStep.getProperties()).thenReturn(SOURCE_PROPERTIES);
-    when(sourceStep.getSchema()).thenReturn(SCHEMA);
     when(sourceStep.build(any())).thenReturn(
         KTableHolder.unmaterialized(sourceTable, SCHEMA, mock(KeySerdeFactory.class)));
     groupBy = new TableGroupBy<>(

--- a/ksql-streams/src/test/java/io/confluent/ksql/execution/streams/TableSinkBuilderTest.java
+++ b/ksql-streams/src/test/java/io/confluent/ksql/execution/streams/TableSinkBuilderTest.java
@@ -106,7 +106,7 @@ public class TableSinkBuilderTest {
     when(source.build(any())).thenReturn(
         KTableHolder.unmaterialized(kTable, SCHEMA, keySerdeFactory));
     sink = new TableSink<>(
-        new ExecutionStepPropertiesV1(SCHEMA, queryContext),
+        new ExecutionStepPropertiesV1(queryContext),
         source,
         Formats.of(KEY_FORMAT, VALUE_FORMAT, SerdeOption.none()),
         TOPIC

--- a/ksql-streams/src/test/java/io/confluent/ksql/execution/streams/TableTableJoinBuilderTest.java
+++ b/ksql-streams/src/test/java/io/confluent/ksql/execution/streams/TableTableJoinBuilderTest.java
@@ -36,7 +36,6 @@ import org.mockito.junit.MockitoJUnitRunner;
 public class TableTableJoinBuilderTest {
   private static final SourceName LEFT = SourceName.of("LEFT");
   private static final SourceName RIGHT = SourceName.of("RIGHT");
-  private static final SourceName ALIAS = SourceName.of("ALIAS");
   private static final LogicalSchema LEFT_SCHEMA = LogicalSchema.builder()
       .valueColumn(ColumnName.of("BLUE"), SqlTypes.STRING)
       .valueColumn(ColumnName.of("GREEN"), SqlTypes.INTEGER)
@@ -48,14 +47,6 @@ public class TableTableJoinBuilderTest {
       .valueColumn(ColumnName.of("ORANGE"), SqlTypes.DOUBLE)
       .build()
       .withAlias(RIGHT)
-      .withMetaAndKeyColsInValue();
-  private static final LogicalSchema SCHEMA = LogicalSchema.builder()
-      .valueColumn(ColumnName.of("BLUE"), SqlTypes.STRING)
-      .valueColumn(ColumnName.of("GREEN"), SqlTypes.STRING)
-      .valueColumn(ColumnName.of("RED"), SqlTypes.BIGINT)
-      .valueColumn(ColumnName.of("ORANGE"), SqlTypes.DOUBLE)
-      .build()
-      .withAlias(ALIAS)
       .withMetaAndKeyColsInValue();
   private final QueryContext CTX =
       new QueryContext.Stacker().push("jo").push("in").getQueryContext();
@@ -95,7 +86,7 @@ public class TableTableJoinBuilderTest {
   private void givenLeftJoin() {
     when(leftKTable.leftJoin(any(KTable.class), any())).thenReturn(resultKTable);
     join = new TableTableJoin<>(
-        new ExecutionStepPropertiesV1(SCHEMA, CTX),
+        new ExecutionStepPropertiesV1(CTX),
         JoinType.LEFT,
         left,
         right
@@ -106,7 +97,7 @@ public class TableTableJoinBuilderTest {
   private void givenOuterJoin() {
     when(leftKTable.outerJoin(any(KTable.class), any())).thenReturn(resultKTable);
     join = new TableTableJoin<>(
-        new ExecutionStepPropertiesV1(SCHEMA, CTX),
+        new ExecutionStepPropertiesV1(CTX),
         JoinType.OUTER,
         left,
         right
@@ -117,7 +108,7 @@ public class TableTableJoinBuilderTest {
   private void givenInnerJoin() {
     when(leftKTable.join(any(KTable.class), any())).thenReturn(resultKTable);
     join = new TableTableJoin<>(
-        new ExecutionStepPropertiesV1(SCHEMA, CTX),
+        new ExecutionStepPropertiesV1(CTX),
         JoinType.INNER,
         left,
         right


### PR DESCRIPTION
### Description 

This patch removes the individual plan schemas from the execution
plan nodes. Instead, SchemaKX classes use the StepSchemaResolver
API to compute the schema of the next SchemaKX instance. This gives
us a cleaner plan schema.

Part of the work to get us onto the plan schema in #3969 