### PR TITLE
chore: issue regular LIST TOPICS from healthcheck, not extended (MINOR)

### DIFF
--- a/ksql-rest-app/src/main/java/io/confluent/ksql/rest/healthcheck/HealthCheckAgent.java
+++ b/ksql-rest-app/src/main/java/io/confluent/ksql/rest/healthcheck/HealthCheckAgent.java
@@ -36,7 +36,7 @@ public class HealthCheckAgent {
 
   private static final List<Check> DEFAULT_CHECKS = ImmutableList.of(
       new ExecuteStatementCheck(METASTORE_CHECK_NAME, "list streams; list tables; list queries;"),
-      new ExecuteStatementCheck(KAFKA_CHECK_NAME, "list topics extended;")
+      new ExecuteStatementCheck(KAFKA_CHECK_NAME, "list topics;")
   );
 
   private final SimpleKsqlClient ksqlClient;

--- a/ksql-rest-app/src/test/java/io/confluent/ksql/rest/healthcheck/HealthCheckAgentTest.java
+++ b/ksql-rest-app/src/test/java/io/confluent/ksql/rest/healthcheck/HealthCheckAgentTest.java
@@ -104,7 +104,7 @@ public class HealthCheckAgentTest {
   @Test
   public void shouldReturnUnhealthyIfKafkaCheckFails() {
     // Given:
-    when(ksqlClient.makeKsqlRequest(SERVER_URI, "list topics extended;"))
+    when(ksqlClient.makeKsqlRequest(SERVER_URI, "list topics;"))
         .thenReturn(unSuccessfulResponse);
 
     // When:


### PR DESCRIPTION
### Description 

The healthcheck endpoint currently checks connectivity to Kafka by issuing `list topics extended;`, but for purposes of checking connectivity it's sufficient to simply issue `list topics;` so we should do that instead to impose less load on Kafka.

### Testing done 

Manual verification that the healthcheck continues to report a failed connection if Kafka is unavailable.

### Reviewer checklist
- [ ] Ensure docs are updated if necessary. (eg. if a user visible feature is being added or changed).
- [ ] Ensure relevant issues are linked (description should include text like "Fixes #<issue number>")

