### PR TITLE
refactor: nicer spec for aggregation steps

### DIFF
--- a/ksql-engine/src/main/java/io/confluent/ksql/planner/plan/AggregateNode.java
+++ b/ksql-engine/src/main/java/io/confluent/ksql/planner/plan/AggregateNode.java
@@ -228,8 +228,12 @@ public class AggregateNode extends PlanNode {
 
     final QueryContext.Stacker aggregationContext = contextStacker.push(AGGREGATION_OP_NAME);
 
+    final List<ColumnRef> requiredColumnRefs = requiredColumns.stream()
+        .map(e -> (ColumnReferenceExp) internalSchema.resolveToInternal(e))
+        .map(ColumnReferenceExp::getReference)
+        .collect(Collectors.toList());
     SchemaKTable<?> aggregated = schemaKGroupedStream.aggregate(
-        requiredColumns.size(),
+        requiredColumnRefs,
         functionsWithInternalIdentifiers,
         windowExpression,
         valueFormat,

--- a/ksql-engine/src/main/java/io/confluent/ksql/structured/SchemaKGroupedStream.java
+++ b/ksql-engine/src/main/java/io/confluent/ksql/structured/SchemaKGroupedStream.java
@@ -26,6 +26,7 @@ import io.confluent.ksql.execution.streams.StepSchemaResolver;
 import io.confluent.ksql.function.FunctionRegistry;
 import io.confluent.ksql.metastore.model.KeyField;
 import io.confluent.ksql.parser.tree.WindowExpression;
+import io.confluent.ksql.schema.ksql.ColumnRef;
 import io.confluent.ksql.schema.ksql.LogicalSchema;
 import io.confluent.ksql.serde.Format;
 import io.confluent.ksql.serde.FormatInfo;
@@ -72,7 +73,7 @@ public class SchemaKGroupedStream {
 
   @SuppressWarnings("unchecked")
   public SchemaKTable<?> aggregate(
-      final int nonFuncColumnCount,
+      final List<ColumnRef> nonAggregateColumns,
       final List<FunctionCall> aggregations,
       final Optional<WindowExpression> windowExpression,
       final ValueFormat valueFormat,
@@ -87,7 +88,7 @@ public class SchemaKGroupedStream {
           contextStacker,
           sourceStep,
           Formats.of(keyFormat, valueFormat, SerdeOption.none()),
-          nonFuncColumnCount,
+          nonAggregateColumns,
           aggregations,
           windowExpression.get().getKsqlWindowExpression()
       );
@@ -97,7 +98,7 @@ public class SchemaKGroupedStream {
           contextStacker,
           sourceStep,
           Formats.of(keyFormat, valueFormat, SerdeOption.none()),
-          nonFuncColumnCount,
+          nonAggregateColumns,
           aggregations
       );
     }

--- a/ksql-engine/src/main/java/io/confluent/ksql/structured/SchemaKGroupedTable.java
+++ b/ksql-engine/src/main/java/io/confluent/ksql/structured/SchemaKGroupedTable.java
@@ -29,6 +29,7 @@ import io.confluent.ksql.function.KsqlAggregateFunction;
 import io.confluent.ksql.metastore.model.KeyField;
 import io.confluent.ksql.name.FunctionName;
 import io.confluent.ksql.parser.tree.WindowExpression;
+import io.confluent.ksql.schema.ksql.ColumnRef;
 import io.confluent.ksql.schema.ksql.LogicalSchema;
 import io.confluent.ksql.serde.KeyFormat;
 import io.confluent.ksql.serde.SerdeOption;
@@ -71,7 +72,7 @@ public class SchemaKGroupedTable extends SchemaKGroupedStream {
   @SuppressWarnings("unchecked")
   @Override
   public SchemaKTable<Struct> aggregate(
-      final int nonFuncColumnCount,
+      final List<ColumnRef> nonAggregateColumns,
       final List<FunctionCall> aggregations,
       final Optional<WindowExpression> windowExpression,
       final ValueFormat valueFormat,
@@ -98,7 +99,7 @@ public class SchemaKGroupedTable extends SchemaKGroupedStream {
         contextStacker,
         sourceTableStep,
         Formats.of(keyFormat, valueFormat, SerdeOption.none()),
-        nonFuncColumnCount,
+        nonAggregateColumns,
         aggregations
     );
 

--- a/ksql-engine/src/test/java/io/confluent/ksql/function/KudafUndoAggregatorTest.java
+++ b/ksql-engine/src/test/java/io/confluent/ksql/function/KudafUndoAggregatorTest.java
@@ -42,7 +42,7 @@ public class KudafUndoAggregatorTest {
   public void init() {
     final List<TableAggregationFunction<?, ?, ?>> functions =
         ImmutableList.of((TableAggregationFunction)SUM_INFO);
-    aggregator = new KudafUndoAggregator(2, functions);
+    aggregator = new KudafUndoAggregator(ImmutableList.of(0, 1), functions);
   }
 
   @Test

--- a/ksql-engine/src/test/java/io/confluent/ksql/structured/SchemaKGroupedStreamTest.java
+++ b/ksql-engine/src/test/java/io/confluent/ksql/structured/SchemaKGroupedStreamTest.java
@@ -46,6 +46,7 @@ import io.confluent.ksql.serde.SerdeOption;
 import io.confluent.ksql.serde.ValueFormat;
 import io.confluent.ksql.serde.WindowInfo;
 import io.confluent.ksql.util.KsqlConfig;
+import java.util.List;
 import java.util.Optional;
 import java.util.concurrent.TimeUnit;
 import org.junit.Before;
@@ -71,6 +72,9 @@ public class SchemaKGroupedStreamTest {
   );
   private static final KsqlWindowExpression KSQL_WINDOW_EXP = new SessionWindowExpression(
       100, TimeUnit.SECONDS
+  );
+  private static final List<ColumnRef> NON_AGGREGATE_COLUMNS = ImmutableList.of(
+      ColumnRef.withoutSource(ColumnName.of("IN0"))
   );
 
   @Mock
@@ -115,7 +119,7 @@ public class SchemaKGroupedStreamTest {
   public void shouldReturnKTableWithOutputSchema() {
     // When:
     final SchemaKTable result = schemaGroupedStream.aggregate(
-        1,
+        NON_AGGREGATE_COLUMNS,
         ImmutableList.of(AGG),
         Optional.empty(),
         valueFormat,
@@ -130,7 +134,7 @@ public class SchemaKGroupedStreamTest {
   public void shouldBuildStepForAggregate() {
     // When:
     final SchemaKTable result = schemaGroupedStream.aggregate(
-        1,
+        NON_AGGREGATE_COLUMNS,
         ImmutableList.of(AGG),
         Optional.empty(),
         valueFormat,
@@ -145,7 +149,7 @@ public class SchemaKGroupedStreamTest {
                 queryContext,
                 schemaGroupedStream.getSourceStep(),
                 Formats.of(keyFormat, valueFormat, SerdeOption.none()),
-                1,
+                NON_AGGREGATE_COLUMNS,
                 ImmutableList.of(AGG)
             )
         )
@@ -156,7 +160,7 @@ public class SchemaKGroupedStreamTest {
   public void shouldBuildStepForWindowedAggregate() {
     // When:
     final SchemaKTable result = schemaGroupedStream.aggregate(
-        1,
+        NON_AGGREGATE_COLUMNS,
         ImmutableList.of(AGG),
         Optional.of(windowExp),
         valueFormat,
@@ -175,7 +179,7 @@ public class SchemaKGroupedStreamTest {
                 queryContext,
                 schemaGroupedStream.getSourceStep(),
                 Formats.of(expected, valueFormat, SerdeOption.none()),
-                1,
+                NON_AGGREGATE_COLUMNS,
                 ImmutableList.of(AGG),
                 KSQL_WINDOW_EXP
             )

--- a/ksql-engine/src/test/java/io/confluent/ksql/structured/SchemaKGroupedTableTest.java
+++ b/ksql-engine/src/test/java/io/confluent/ksql/structured/SchemaKGroupedTableTest.java
@@ -44,6 +44,7 @@ import io.confluent.ksql.serde.ValueFormat;
 import io.confluent.ksql.util.KsqlConfig;
 import io.confluent.ksql.util.KsqlException;
 import java.util.Collections;
+import java.util.List;
 import java.util.Optional;
 import org.junit.Rule;
 import org.junit.Test;
@@ -63,6 +64,9 @@ public class SchemaKGroupedTableTest {
       .valueColumn(ColumnName.of("KSQL_AGG_VARIABLE_0"), SqlTypes.INTEGER)
       .valueColumn(ColumnName.of("KSQL_AGG_VARIABLE_1"), SqlTypes.BIGINT)
       .build();
+  private static final List<ColumnRef> NON_AGG_COLUMNS = ImmutableList.of(
+      ColumnRef.withoutSource(ColumnName.of("IN0"))
+  );
   private static final FunctionCall MIN = udaf("MIN");
   private static final FunctionCall MAX = udaf("MAX");
   private static final FunctionCall SUM = udaf("SUM");
@@ -91,7 +95,7 @@ public class SchemaKGroupedTableTest {
 
     // When:
     groupedTable.aggregate(
-        1,
+        NON_AGG_COLUMNS,
         ImmutableList.of(SUM, COUNT),
         Optional.of(windowExp),
         valueFormat,
@@ -111,7 +115,7 @@ public class SchemaKGroupedTableTest {
 
     // When:
     kGroupedTable.aggregate(
-        1,
+        NON_AGG_COLUMNS,
         ImmutableList.of(MIN, MAX),
         Optional.empty(),
         valueFormat,
@@ -136,7 +140,7 @@ public class SchemaKGroupedTableTest {
     final SchemaKGroupedTable kGroupedTable = buildSchemaKGroupedTable();
 
     final SchemaKTable result = kGroupedTable.aggregate(
-        1,
+        NON_AGG_COLUMNS,
         ImmutableList.of(SUM, COUNT),
         Optional.empty(),
         valueFormat,
@@ -151,7 +155,7 @@ public class SchemaKGroupedTableTest {
                 queryContext,
                 kGroupedTable.getSourceTableStep(),
                 Formats.of(keyFormat, valueFormat, SerdeOption.none()),
-                1,
+                NON_AGG_COLUMNS,
                 ImmutableList.of(SUM, COUNT)
             )
         )
@@ -165,7 +169,7 @@ public class SchemaKGroupedTableTest {
 
     // When:
     final SchemaKTable result = groupedTable.aggregate(
-        1,
+        NON_AGG_COLUMNS,
         ImmutableList.of(SUM, COUNT),
         Optional.empty(),
         valueFormat,

--- a/ksql-execution/src/main/java/io/confluent/ksql/execution/plan/StreamWindowedAggregate.java
+++ b/ksql-execution/src/main/java/io/confluent/ksql/execution/plan/StreamWindowedAggregate.java
@@ -23,6 +23,7 @@ import com.google.common.collect.ImmutableList;
 import com.google.errorprone.annotations.Immutable;
 import io.confluent.ksql.execution.expression.tree.FunctionCall;
 import io.confluent.ksql.execution.windows.KsqlWindowExpression;
+import io.confluent.ksql.schema.ksql.ColumnRef;
 import java.util.Collections;
 import java.util.List;
 import java.util.Objects;
@@ -35,7 +36,7 @@ public class StreamWindowedAggregate
   private final ExecutionStepPropertiesV1 properties;
   private final ExecutionStep<KGroupedStreamHolder> source;
   private final Formats internalFormats;
-  private final int nonFuncColumnCount;
+  private final ImmutableList<ColumnRef> nonAggregateColumns;
   private final ImmutableList<FunctionCall> aggregationFunctions;
   private final KsqlWindowExpression windowExpression;
 
@@ -44,7 +45,8 @@ public class StreamWindowedAggregate
       @JsonProperty(value = "source", required = true)
       ExecutionStep<KGroupedStreamHolder> source,
       @JsonProperty(value = "internalFormats", required = true) Formats internalFormats,
-      @JsonProperty(value = "nonFuncColumnCount", required = true) int nonFuncColumnCount,
+      @JsonProperty(value = "nonAggregateColumns", required = true)
+      List<ColumnRef> nonAggregateColumns,
       @JsonProperty(value = "aggregationFunctions", required = true)
       List<FunctionCall> aggregationFunctions,
       @JsonProperty(value = "windowExpression", required = true)
@@ -52,7 +54,8 @@ public class StreamWindowedAggregate
     this.properties = requireNonNull(properties, "properties");
     this.source = requireNonNull(source, "source");
     this.internalFormats = requireNonNull(internalFormats, "internalFormats");
-    this.nonFuncColumnCount = nonFuncColumnCount;
+    this.nonAggregateColumns
+        = ImmutableList.copyOf(requireNonNull(nonAggregateColumns, "nonAggregateColumns"));
     this.aggregationFunctions = ImmutableList.copyOf(
         requireNonNull(aggregationFunctions, "aggregationFunctions"));
     this.windowExpression = requireNonNull(windowExpression, "windowExpression");
@@ -69,16 +72,16 @@ public class StreamWindowedAggregate
     return Collections.singletonList(source);
   }
 
-  public int getNonFuncColumnCount() {
-    return nonFuncColumnCount;
-  }
-
   public List<FunctionCall> getAggregationFunctions() {
     return aggregationFunctions;
   }
 
   public Formats getInternalFormats() {
     return internalFormats;
+  }
+
+  public List<ColumnRef> getNonAggregateColumns() {
+    return nonAggregateColumns;
   }
 
   public KsqlWindowExpression getWindowExpression() {
@@ -107,8 +110,8 @@ public class StreamWindowedAggregate
         && Objects.equals(source, that.source)
         && Objects.equals(internalFormats, that.internalFormats)
         && Objects.equals(aggregationFunctions, that.aggregationFunctions)
-        && nonFuncColumnCount == that.nonFuncColumnCount
-        && Objects.equals(windowExpression, that.windowExpression);
+        && Objects.equals(windowExpression, that.windowExpression)
+        && Objects.equals(nonAggregateColumns, that.nonAggregateColumns);
   }
 
   @Override
@@ -119,7 +122,7 @@ public class StreamWindowedAggregate
         source,
         internalFormats,
         aggregationFunctions,
-        nonFuncColumnCount,
+        nonAggregateColumns,
         windowExpression
     );
   }

--- a/ksql-execution/src/main/java/io/confluent/ksql/execution/plan/TableAggregate.java
+++ b/ksql-execution/src/main/java/io/confluent/ksql/execution/plan/TableAggregate.java
@@ -97,8 +97,8 @@ public class TableAggregate implements ExecutionStep<KTableHolder<Struct>> {
     return Objects.equals(properties, that.properties)
         && Objects.equals(source, that.source)
         && Objects.equals(internalFormats, that.internalFormats)
-        && Objects.equals(aggregationFunctions, that.aggregationFunctions);
-        && Objects.equals(nonAggregateColumns, that.nonAggregateColumns)
+        && Objects.equals(aggregationFunctions, that.aggregationFunctions)
+        && Objects.equals(nonAggregateColumns, that.nonAggregateColumns);
   }
 
   @Override

--- a/ksql-execution/src/main/java/io/confluent/ksql/execution/plan/TableAggregate.java
+++ b/ksql-execution/src/main/java/io/confluent/ksql/execution/plan/TableAggregate.java
@@ -21,6 +21,7 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import com.google.common.collect.ImmutableList;
 import com.google.errorprone.annotations.Immutable;
 import io.confluent.ksql.execution.expression.tree.FunctionCall;
+import io.confluent.ksql.schema.ksql.ColumnRef;
 import java.util.Collections;
 import java.util.List;
 import java.util.Objects;
@@ -31,21 +32,23 @@ public class TableAggregate implements ExecutionStep<KTableHolder<Struct>> {
   private final ExecutionStepPropertiesV1 properties;
   private final ExecutionStep<KGroupedTableHolder> source;
   private final Formats internalFormats;
-  private final int nonFuncColumnCount;
   private final ImmutableList<FunctionCall> aggregationFunctions;
+  private final ImmutableList<ColumnRef> nonAggregateColumns;
 
   public TableAggregate(
       @JsonProperty(value = "properties", required = true) ExecutionStepPropertiesV1 properties,
       @JsonProperty(value = "source", required = true)
       ExecutionStep<KGroupedTableHolder> source,
       @JsonProperty(value = "internalFormats", required = true) Formats internalFormats,
-      @JsonProperty(value = "nonFuncColumnCount", required = true) int nonFuncColumnCount,
+      @JsonProperty(value = "nonAggregateColumns", required = true)
+      List<ColumnRef> nonAggregateColumns,
       @JsonProperty(value = "aggregationFunctions", required = true)
       List<FunctionCall> aggregationFunctions) {
     this.properties = requireNonNull(properties, "properties");
     this.source = requireNonNull(source, "source");
     this.internalFormats = requireNonNull(internalFormats, "internalFormats");
-    this.nonFuncColumnCount = nonFuncColumnCount;
+    this.nonAggregateColumns
+        = ImmutableList.copyOf(requireNonNull(nonAggregateColumns, "nonAggregatecolumns"));
     this.aggregationFunctions = ImmutableList
         .copyOf(requireNonNull(aggregationFunctions, "aggValToFunctionMap"));
   }
@@ -69,8 +72,8 @@ public class TableAggregate implements ExecutionStep<KTableHolder<Struct>> {
     return aggregationFunctions;
   }
 
-  public int getNonFuncColumnCount() {
-    return nonFuncColumnCount;
+  public List<ColumnRef> getNonAggregateColumns() {
+    return nonAggregateColumns;
   }
 
   public ExecutionStep<KGroupedTableHolder> getSource() {
@@ -94,14 +97,14 @@ public class TableAggregate implements ExecutionStep<KTableHolder<Struct>> {
     return Objects.equals(properties, that.properties)
         && Objects.equals(source, that.source)
         && Objects.equals(internalFormats, that.internalFormats)
-        && nonFuncColumnCount == that.nonFuncColumnCount
         && Objects.equals(aggregationFunctions, that.aggregationFunctions);
+        && Objects.equals(nonAggregateColumns, that.nonAggregateColumns)
   }
 
   @Override
   public int hashCode() {
 
-    return Objects.hash(properties, source, internalFormats, nonFuncColumnCount,
+    return Objects.hash(properties, source, internalFormats, nonAggregateColumns,
         aggregationFunctions);
   }
 }

--- a/ksql-rest-app/src/test/resources/ksql-plan-schema/schema.json
+++ b/ksql-rest-app/src/test/resources/ksql-plan-schema/schema.json
@@ -260,8 +260,11 @@
         "internalFormats" : {
           "$ref" : "#/definitions/Formats"
         },
-        "nonFuncColumnCount" : {
-          "type" : "integer"
+        "nonAggregateColumns" : {
+          "type" : "array",
+          "items" : {
+            "type" : "string"
+          }
         },
         "aggregationFunctions" : {
           "type" : "array",
@@ -271,7 +274,7 @@
         }
       },
       "title" : "streamAggregateV1",
-      "required" : [ "@type", "properties", "source", "internalFormats", "nonFuncColumnCount", "aggregationFunctions" ]
+      "required" : [ "@type", "properties", "source", "formats", "nonAggregateColumns", "aggregations" ]
     },
     "ExecutionStepPropertiesV1" : {
       "type" : "object",
@@ -602,8 +605,11 @@
         "internalFormats" : {
           "$ref" : "#/definitions/Formats"
         },
-        "nonFuncColumnCount" : {
-          "type" : "integer"
+        "nonAggregateColumns" : {
+          "type" : "array",
+          "items" : {
+            "type" : "string"
+          }
         },
         "aggregationFunctions" : {
           "type" : "array",
@@ -616,7 +622,7 @@
         }
       },
       "title" : "streamWindowedAggregateV1",
-      "required" : [ "@type", "properties", "source", "internalFormats", "nonFuncColumnCount", "aggregationFunctions", "windowExpression" ]
+      "required" : [ "@type", "properties", "source", "formats", "nonAggregateColumns", "aggregations", "windowExpression" ]
     },
     "TableSource" : {
       "type" : "object",
@@ -701,8 +707,11 @@
         "internalFormats" : {
           "$ref" : "#/definitions/Formats"
         },
-        "nonFuncColumnCount" : {
-          "type" : "integer"
+        "nonAggregateColumns" : {
+          "type" : "array",
+          "items" : {
+            "type" : "string"
+          }
         },
         "aggregationFunctions" : {
           "type" : "array",
@@ -712,7 +721,7 @@
         }
       },
       "title" : "tableAggregateV1",
-      "required" : [ "@type", "properties", "source", "internalFormats", "nonFuncColumnCount", "aggregationFunctions" ]
+      "required" : [ "@type", "properties", "source", "formats", "nonAggregateColumns", "aggregations" ]
     },
     "TableFilter" : {
       "type" : "object",

--- a/ksql-rest-app/src/test/resources/ksql-plan-schema/schema.json
+++ b/ksql-rest-app/src/test/resources/ksql-plan-schema/schema.json
@@ -274,7 +274,7 @@
         }
       },
       "title" : "streamAggregateV1",
-      "required" : [ "@type", "properties", "source", "formats", "nonAggregateColumns", "aggregations" ]
+      "required" : [ "@type", "properties", "source", "internalFormats", "nonAggregateColumns", "aggregationFunctions" ]
     },
     "ExecutionStepPropertiesV1" : {
       "type" : "object",
@@ -622,7 +622,7 @@
         }
       },
       "title" : "streamWindowedAggregateV1",
-      "required" : [ "@type", "properties", "source", "formats", "nonAggregateColumns", "aggregations", "windowExpression" ]
+      "required" : [ "@type", "properties", "source", "internalFormats", "nonAggregateColumns", "aggregationFunctions", "windowExpression" ]
     },
     "TableSource" : {
       "type" : "object",
@@ -721,7 +721,7 @@
         }
       },
       "title" : "tableAggregateV1",
-      "required" : [ "@type", "properties", "source", "formats", "nonAggregateColumns", "aggregations" ]
+      "required" : [ "@type", "properties", "source", "internalFormats", "nonAggregateColumns", "aggregationFunctions" ]
     },
     "TableFilter" : {
       "type" : "object",

--- a/ksql-streams/src/main/java/io/confluent/ksql/execution/streams/ExecutionStepFactory.java
+++ b/ksql-streams/src/main/java/io/confluent/ksql/execution/streams/ExecutionStepFactory.java
@@ -310,7 +310,7 @@ public final class ExecutionStepFactory {
       final QueryContext.Stacker stacker,
       final ExecutionStep<KGroupedStreamHolder> sourceStep,
       final Formats formats,
-      final int nonFuncColumnCount,
+      final List<ColumnRef> nonAggregateColumns,
       final List<FunctionCall> aggregations
   ) {
     final QueryContext queryContext = stacker.getQueryContext();
@@ -318,7 +318,7 @@ public final class ExecutionStepFactory {
         new ExecutionStepPropertiesV1(queryContext),
         sourceStep,
         formats,
-        nonFuncColumnCount,
+        nonAggregateColumns,
         aggregations
     );
   }
@@ -327,7 +327,7 @@ public final class ExecutionStepFactory {
       final QueryContext.Stacker stacker,
       final ExecutionStep<KGroupedStreamHolder> sourceStep,
       final Formats formats,
-      final int nonFuncColumnCount,
+      final List<ColumnRef> nonAggregateColumns,
       final List<FunctionCall> aggregations,
       final KsqlWindowExpression window
   ) {
@@ -336,7 +336,7 @@ public final class ExecutionStepFactory {
         new ExecutionStepPropertiesV1(queryContext),
         sourceStep,
         formats,
-        nonFuncColumnCount,
+        nonAggregateColumns,
         aggregations,
         window
     );
@@ -370,7 +370,7 @@ public final class ExecutionStepFactory {
       final QueryContext.Stacker stacker,
       final ExecutionStep<KGroupedTableHolder> sourceStep,
       final Formats formats,
-      final int nonFuncColumnCount,
+      final List<ColumnRef> nonAggregateColumns,
       final List<FunctionCall> aggregations
   ) {
     final QueryContext queryContext = stacker.getQueryContext();
@@ -378,7 +378,7 @@ public final class ExecutionStepFactory {
         new ExecutionStepPropertiesV1(queryContext),
         sourceStep,
         formats,
-        nonFuncColumnCount,
+        nonAggregateColumns,
         aggregations
     );
   }

--- a/ksql-streams/src/main/java/io/confluent/ksql/execution/streams/ExecutionStepFactory.java
+++ b/ksql-streams/src/main/java/io/confluent/ksql/execution/streams/ExecutionStepFactory.java
@@ -51,6 +51,7 @@ import io.confluent.ksql.execution.plan.WindowedTableSource;
 import io.confluent.ksql.execution.timestamp.TimestampColumn;
 import io.confluent.ksql.execution.windows.KsqlWindowExpression;
 import io.confluent.ksql.name.SourceName;
+import io.confluent.ksql.schema.ksql.ColumnRef;
 import io.confluent.ksql.schema.ksql.LogicalSchema;
 import io.confluent.ksql.serde.WindowInfo;
 import java.time.Duration;

--- a/ksql-streams/src/main/java/io/confluent/ksql/execution/streams/StepSchemaResolver.java
+++ b/ksql-streams/src/main/java/io/confluent/ksql/execution/streams/StepSchemaResolver.java
@@ -131,7 +131,7 @@ public final class StepSchemaResolver {
       final StreamAggregate step) {
     return new AggregateParamsFactory().create(
         schema,
-        step.getNonFuncColumnCount(),
+        step.getNonAggregateColumns(),
         functionRegistry,
         step.getAggregationFunctions()
     ).getSchema();
@@ -143,7 +143,7 @@ public final class StepSchemaResolver {
   ) {
     return new AggregateParamsFactory().create(
         schema,
-        step.getNonFuncColumnCount(),
+        step.getNonAggregateColumns(),
         functionRegistry,
         step.getAggregationFunctions()
     ).getSchema();
@@ -204,7 +204,7 @@ public final class StepSchemaResolver {
   ) {
     return new AggregateParamsFactory().create(
         schema,
-        step.getNonFuncColumnCount(),
+        step.getNonAggregateColumns(),
         functionRegistry,
         step.getAggregationFunctions()
     ).getSchema();

--- a/ksql-streams/src/main/java/io/confluent/ksql/execution/streams/StreamAggregateBuilder.java
+++ b/ksql-streams/src/main/java/io/confluent/ksql/execution/streams/StreamAggregateBuilder.java
@@ -33,9 +33,11 @@ import io.confluent.ksql.execution.windows.KsqlWindowExpression;
 import io.confluent.ksql.execution.windows.SessionWindowExpression;
 import io.confluent.ksql.execution.windows.TumblingWindowExpression;
 import io.confluent.ksql.execution.windows.WindowVisitor;
+import io.confluent.ksql.schema.ksql.ColumnRef;
 import io.confluent.ksql.schema.ksql.LogicalSchema;
 import io.confluent.ksql.schema.ksql.PhysicalSchema;
 import java.time.Duration;
+import java.util.List;
 import java.util.Objects;
 import org.apache.kafka.common.serialization.Serde;
 import org.apache.kafka.common.utils.Bytes;
@@ -74,7 +76,7 @@ public final class StreamAggregateBuilder {
       final MaterializedFactory materializedFactory,
       final AggregateParamsFactory aggregateParamsFactory) {
     final LogicalSchema sourceSchema = groupedStream.getSchema();
-    final int nonFuncColumns = aggregate.getNonFuncColumnCount();
+    final List<ColumnRef> nonFuncColumns = aggregate.getNonAggregateColumns();
     final AggregateParams aggregateParams = aggregateParamsFactory.create(
         sourceSchema,
         nonFuncColumns,
@@ -146,7 +148,7 @@ public final class StreamAggregateBuilder {
       final AggregateParamsFactory aggregateParamsFactory
   ) {
     final LogicalSchema sourceSchema = groupedStream.getSchema();
-    final int nonFuncColumns = aggregate.getNonFuncColumnCount();
+    final List<ColumnRef> nonFuncColumns = aggregate.getNonAggregateColumns();
     final AggregateParams aggregateParams = aggregateParamsFactory.create(
         sourceSchema,
         nonFuncColumns,

--- a/ksql-streams/src/main/java/io/confluent/ksql/execution/streams/TableAggregateBuilder.java
+++ b/ksql-streams/src/main/java/io/confluent/ksql/execution/streams/TableAggregateBuilder.java
@@ -23,7 +23,9 @@ import io.confluent.ksql.execution.plan.KTableHolder;
 import io.confluent.ksql.execution.plan.KeySerdeFactory;
 import io.confluent.ksql.execution.plan.TableAggregate;
 import io.confluent.ksql.execution.streams.transform.KsTransformer;
+import io.confluent.ksql.schema.ksql.ColumnRef;
 import io.confluent.ksql.schema.ksql.LogicalSchema;
+import java.util.List;
 import org.apache.kafka.common.utils.Bytes;
 import org.apache.kafka.connect.data.Struct;
 import org.apache.kafka.streams.kstream.KTable;
@@ -57,7 +59,7 @@ public final class TableAggregateBuilder {
       final AggregateParamsFactory aggregateParamsFactory
   ) {
     final LogicalSchema sourceSchema = groupedTable.getSchema();
-    final int nonFuncColumns = aggregate.getNonFuncColumnCount();
+    final List<ColumnRef> nonFuncColumns = aggregate.getNonAggregateColumns();
     final AggregateParams aggregateParams = aggregateParamsFactory.createUndoable(
         sourceSchema,
         nonFuncColumns,

--- a/ksql-streams/src/test/java/io/confluent/ksql/execution/streams/AggregateParamsFactoryTest.java
+++ b/ksql-streams/src/test/java/io/confluent/ksql/execution/streams/AggregateParamsFactoryTest.java
@@ -42,10 +42,14 @@ import org.mockito.junit.MockitoJUnitRunner;
 public class AggregateParamsFactoryTest {
   private static final LogicalSchema INPUT_SCHEMA = LogicalSchema.builder()
       .valueColumn(ColumnName.of("REQUIRED0"), SqlTypes.BIGINT)
-      .valueColumn(ColumnName.of("REQUIRED1"), SqlTypes.STRING)
       .valueColumn(ColumnName.of("ARGUMENT0"), SqlTypes.INTEGER)
+      .valueColumn(ColumnName.of("REQUIRED1"), SqlTypes.STRING)
       .valueColumn(ColumnName.of("ARGUMENT1"), SqlTypes.DOUBLE)
       .build();
+  private static final List<ColumnRef> NON_AGG_COLUMNS = ImmutableList.of(
+      INPUT_SCHEMA.value().get(0).ref(),
+      INPUT_SCHEMA.value().get(2).ref()
+  );
   private static final FunctionCall AGG0 = new FunctionCall(
       FunctionName.of("AGG0"),
       ImmutableList.of(new ColumnReferenceExp(ColumnRef.withoutSource(ColumnName.of("ARGUMENT0"))))
@@ -111,11 +115,11 @@ public class AggregateParamsFactoryTest {
     when(windowStart.returnType()).thenReturn(SqlTypes.BIGINT);
     when(windowStart.getAggregateType()).thenReturn(SqlTypes.BIGINT);
 
-    when(udafFactory.create(anyInt(), any())).thenReturn(aggregator);
+    when(udafFactory.create(any(), any())).thenReturn(aggregator);
 
     aggregateParams = new AggregateParamsFactory(udafFactory).create(
         INPUT_SCHEMA,
-        2,
+        NON_AGG_COLUMNS,
         functionRegistry,
         FUNCTIONS
     );
@@ -125,7 +129,7 @@ public class AggregateParamsFactoryTest {
   @Test
   public void shouldCreateAggregatorWithCorrectParams() {
     verify(udafFactory).create(
-        2,
+        ImmutableList.of(0, 2),
          ImmutableList.of(agg0, agg1)
     );
   }
@@ -163,14 +167,18 @@ public class AggregateParamsFactoryTest {
   @Test
   public void shouldReturnUndoAggregator() {
     // Given:
-    aggregateParams = new AggregateParamsFactory(udafFactory)
-        .createUndoable(INPUT_SCHEMA, 2, functionRegistry, ImmutableList.of(TABLE_AGG));
+    aggregateParams = new AggregateParamsFactory(udafFactory).createUndoable(
+        INPUT_SCHEMA,
+        NON_AGG_COLUMNS,
+        functionRegistry,
+        ImmutableList.of(TABLE_AGG)
+    );
 
     // When:
     final KudafUndoAggregator undoAggregator = aggregateParams.getUndoAggregator().get();
 
     // Then:
-    assertThat(undoAggregator.getInitialUdafIndex(), equalTo(2));
+    assertThat(undoAggregator.getNonAggColumnIndexes(), equalTo(ImmutableList.of(0, 2)));
     assertThat(
         undoAggregator.getAggregateFunctions(),
         equalTo(ImmutableList.of(tableAgg))
@@ -191,7 +199,7 @@ public class AggregateParamsFactoryTest {
     // Given:
     aggregateParams = new AggregateParamsFactory(udafFactory).create(
         INPUT_SCHEMA,
-        2,
+        NON_AGG_COLUMNS,
         functionRegistry,
         ImmutableList.of(WINDOW_START)
     );

--- a/ksql-streams/src/test/java/io/confluent/ksql/execution/streams/StepSchemaResolverTest.java
+++ b/ksql-streams/src/test/java/io/confluent/ksql/execution/streams/StepSchemaResolverTest.java
@@ -120,7 +120,7 @@ public class StepSchemaResolverTest {
         PROPERTIES,
         groupedStreamSource,
         formats,
-        1,
+        ImmutableList.of(ColumnRef.withoutSource(ColumnName.of("ORANGE"))),
         ImmutableList.of(functionCall("SUM", "APPLE"))
     );
 
@@ -144,7 +144,7 @@ public class StepSchemaResolverTest {
         PROPERTIES,
         groupedStreamSource,
         formats,
-        1,
+        ImmutableList.of(ColumnRef.withoutSource(ColumnName.of("ORANGE"))),
         ImmutableList.of(functionCall("SUM", "APPLE")),
         new TumblingWindowExpression(10, TimeUnit.SECONDS)
     );
@@ -327,7 +327,7 @@ public class StepSchemaResolverTest {
         PROPERTIES,
         groupedTableSource,
         formats,
-        1,
+        ImmutableList.of(ColumnRef.withoutSource(ColumnName.of("ORANGE"))),
         ImmutableList.of(functionCall("SUM", "APPLE"))
     );
 


### PR DESCRIPTION
### Description 

This patch cleans up the aggregation step to specify a list of
non-aggregate column references instead of a count of non-aggregate
columns.

Part of the work to get us on the schema in #3969 