### PR TITLE
refactor: clean up offset reset from plan steps

### DIFF
--- a/ksql-common/src/main/java/io/confluent/ksql/util/KsqlConfig.java
+++ b/ksql-common/src/main/java/io/confluent/ksql/util/KsqlConfig.java
@@ -34,7 +34,6 @@ import java.util.Set;
 import java.util.stream.Collectors;
 import org.apache.kafka.clients.CommonClientConfigs;
 import org.apache.kafka.clients.admin.AdminClientConfig;
-import org.apache.kafka.clients.consumer.ConsumerConfig;
 import org.apache.kafka.clients.producer.ProducerConfig;
 import org.apache.kafka.common.config.AbstractConfig;
 import org.apache.kafka.common.config.ConfigDef;
@@ -580,8 +579,6 @@ public class KsqlConfig extends AbstractConfig {
     super(configDef(generation), props);
 
     final Map<String, Object> streamsConfigDefaults = new HashMap<>();
-    streamsConfigDefaults.put(ConsumerConfig.AUTO_OFFSET_RESET_CONFIG, KsqlConstants
-        .defaultAutoOffsetRestConfig);
     streamsConfigDefaults.put(StreamsConfig.COMMIT_INTERVAL_MS_CONFIG, KsqlConstants
         .defaultCommitIntervalMsConfig);
     streamsConfigDefaults.put(

--- a/ksql-common/src/main/java/io/confluent/ksql/util/KsqlConstants.java
+++ b/ksql-common/src/main/java/io/confluent/ksql/util/KsqlConstants.java
@@ -34,7 +34,6 @@ public final class KsqlConstants {
   public static final short legacyDefaultSinkReplicaCount = 1;
   public static final long defaultSinkWindowChangeLogAdditionalRetention = 1000000;
 
-  public static final String defaultAutoOffsetRestConfig = "latest";
   public static final long defaultCommitIntervalMsConfig = 2000;
   public static final long defaultCacheMaxBytesBufferingConfig = 10000000;
   public static final int defaultNumberOfStreamsThreads = 4;

--- a/ksql-common/src/test/java/io/confluent/ksql/util/KsqlConfigTest.java
+++ b/ksql-common/src/test/java/io/confluent/ksql/util/KsqlConfigTest.java
@@ -65,6 +65,13 @@ public class KsqlConfigTest {
   }
 
   @Test
+  public void shouldNotSetAutoOffsetResetByDefault() {
+    final KsqlConfig ksqlConfig = new KsqlConfig(Collections.emptyMap());
+    final Object result = ksqlConfig.getKsqlStreamConfigProps().get(ConsumerConfig.AUTO_OFFSET_RESET_CONFIG);
+    assertThat(result, is(nullValue()));
+  }
+
+  @Test
   public void shouldSetLogAndContinueExceptionHandlerWhenFailOnDeserializationErrorFalse() {
     final KsqlConfig ksqlConfig = new KsqlConfig(Collections.singletonMap(KsqlConfig.FAIL_ON_DESERIALIZATION_ERROR_CONFIG, false));
     final Object result = ksqlConfig.getKsqlStreamConfigProps().get(StreamsConfig.DEFAULT_DESERIALIZATION_EXCEPTION_HANDLER_CLASS_CONFIG);

--- a/ksql-engine/src/main/java/io/confluent/ksql/planner/plan/DataSourceNode.java
+++ b/ksql-engine/src/main/java/io/confluent/ksql/planner/plan/DataSourceNode.java
@@ -34,12 +34,6 @@ import io.confluent.ksql.services.KafkaTopicClient;
 import io.confluent.ksql.structured.SchemaKSourceFactory;
 import io.confluent.ksql.structured.SchemaKStream;
 import java.util.List;
-import java.util.Map;
-import java.util.Optional;
-import org.apache.kafka.clients.consumer.ConsumerConfig;
-import org.apache.kafka.common.config.ConfigException;
-import org.apache.kafka.streams.Topology;
-import org.apache.kafka.streams.Topology.AutoOffsetReset;
 
 @Immutable
 public class DataSourceNode extends PlanNode {
@@ -140,7 +134,6 @@ public class DataSourceNode extends PlanNode {
         builder,
         dataSource,
         contextStacker.push(SOURCE_OP_NAME),
-        getAutoOffsetReset(builder.getKsqlConfig().getKsqlStreamConfigProps()),
         keyField,
         alias
     );
@@ -152,27 +145,8 @@ public class DataSourceNode extends PlanNode {
         KsqlQueryBuilder builder,
         DataSource<?> dataSource,
         QueryContext.Stacker contextStacker,
-        Optional<AutoOffsetReset> offsetReset,
         KeyField keyField,
         SourceName alias
     );
-  }
-
-  private static Optional<Topology.AutoOffsetReset> getAutoOffsetReset(
-      final Map<String, Object> props) {
-    final Object offestReset = props.get(ConsumerConfig.AUTO_OFFSET_RESET_CONFIG);
-    if (offestReset == null) {
-      return Optional.empty();
-    }
-
-    try {
-      return Optional.of(AutoOffsetReset.valueOf(offestReset.toString().toUpperCase()));
-    } catch (final Exception e) {
-      throw new ConfigException(
-          ConsumerConfig.AUTO_OFFSET_RESET_CONFIG,
-          offestReset,
-          "Unknown value"
-      );
-    }
   }
 }

--- a/ksql-engine/src/main/java/io/confluent/ksql/structured/SchemaKSourceFactory.java
+++ b/ksql-engine/src/main/java/io/confluent/ksql/structured/SchemaKSourceFactory.java
@@ -35,8 +35,6 @@ import io.confluent.ksql.name.SourceName;
 import io.confluent.ksql.schema.ksql.LogicalSchema;
 import io.confluent.ksql.serde.KeyFormat;
 import io.confluent.ksql.serde.WindowInfo;
-import java.util.Optional;
-import org.apache.kafka.streams.Topology.AutoOffsetReset;
 
 /**
  * Factory class used to create stream and table sources
@@ -50,7 +48,6 @@ public final class SchemaKSourceFactory {
       final KsqlQueryBuilder builder,
       final DataSource<?> dataSource,
       final QueryContext.Stacker contextStacker,
-      final Optional<AutoOffsetReset> offsetReset,
       final KeyField keyField,
       final SourceName alias
   ) {
@@ -62,14 +59,12 @@ public final class SchemaKSourceFactory {
             builder,
             dataSource,
             contextStacker,
-            offsetReset,
             keyField,
             alias
         ) : buildStream(
             builder,
             dataSource,
             contextStacker,
-            offsetReset,
             keyField,
             alias
         );
@@ -80,14 +75,12 @@ public final class SchemaKSourceFactory {
             builder,
             dataSource,
             contextStacker,
-            offsetReset,
             keyField,
             alias
         ) : buildTable(
             builder,
             dataSource,
             contextStacker,
-            offsetReset,
             keyField,
             alias
         );
@@ -101,7 +94,6 @@ public final class SchemaKSourceFactory {
       final KsqlQueryBuilder builder,
       final DataSource<?> dataSource,
       final Stacker contextStacker,
-      final Optional<AutoOffsetReset> offsetReset,
       final KeyField keyField,
       final SourceName alias
   ) {
@@ -115,7 +107,6 @@ public final class SchemaKSourceFactory {
         buildFormats(dataSource),
         windowInfo,
         dataSource.getTimestampColumn(),
-        offsetReset,
         alias
     );
 
@@ -132,7 +123,6 @@ public final class SchemaKSourceFactory {
       final KsqlQueryBuilder builder,
       final DataSource<?> dataSource,
       final Stacker contextStacker,
-      final Optional<AutoOffsetReset> offsetReset,
       final KeyField keyField,
       final SourceName alias
   ) {
@@ -146,7 +136,6 @@ public final class SchemaKSourceFactory {
         dataSource.getKafkaTopicName(),
         buildFormats(dataSource),
         dataSource.getTimestampColumn(),
-        offsetReset,
         alias
     );
 
@@ -163,7 +152,6 @@ public final class SchemaKSourceFactory {
       final KsqlQueryBuilder builder,
       final DataSource<?> dataSource,
       final Stacker contextStacker,
-      final Optional<AutoOffsetReset> offsetReset,
       final KeyField keyField,
       final SourceName alias
   ) {
@@ -177,7 +165,6 @@ public final class SchemaKSourceFactory {
         buildFormats(dataSource),
         windowInfo,
         dataSource.getTimestampColumn(),
-        offsetReset,
         alias
     );
 
@@ -194,7 +181,6 @@ public final class SchemaKSourceFactory {
       final KsqlQueryBuilder builder,
       final DataSource<?> dataSource,
       final Stacker contextStacker,
-      final Optional<AutoOffsetReset> offsetReset,
       final KeyField keyField,
       final SourceName alias
   ) {
@@ -208,7 +194,6 @@ public final class SchemaKSourceFactory {
         dataSource.getKafkaTopicName(),
         buildFormats(dataSource),
         dataSource.getTimestampColumn(),
-        offsetReset,
         alias
     );
 

--- a/ksql-engine/src/test/java/io/confluent/ksql/planner/plan/DataSourceNodeTest.java
+++ b/ksql-engine/src/test/java/io/confluent/ksql/planner/plan/DataSourceNodeTest.java
@@ -34,7 +34,6 @@ import io.confluent.ksql.GenericRow;
 import io.confluent.ksql.execution.builder.KsqlQueryBuilder;
 import io.confluent.ksql.execution.context.QueryContext;
 import io.confluent.ksql.execution.ddl.commands.KsqlTopic;
-import io.confluent.ksql.execution.plan.StreamSource;
 import io.confluent.ksql.execution.streams.KSPlanBuilder;
 import io.confluent.ksql.execution.timestamp.TimestampColumn;
 import io.confluent.ksql.function.FunctionRegistry;
@@ -99,7 +98,6 @@ public class DataSourceNodeTest {
       = KeyField.of(ColumnRef.withoutSource(ColumnName.of("field1")));
   private static final TimestampColumn TIMESTAMP_COLUMN =
       new TimestampColumn(TIMESTAMP_FIELD, Optional.empty());
-  private static final Optional<AutoOffsetReset> OFFSET_RESET = Optional.of(AutoOffsetReset.LATEST);
 
   private final KsqlStream<String> SOME_SOURCE = new KsqlStream<>(
       "sqlExpression",
@@ -166,7 +164,7 @@ public class DataSourceNodeTest {
     when(rowSerde.deserializer()).thenReturn(mock(Deserializer.class));
 
     when(dataSource.getDataSourceType()).thenReturn(DataSourceType.KTABLE);
-    when(schemaKStreamFactory.create(any(), any(), any(), any(), any(), any()))
+    when(schemaKStreamFactory.create(any(), any(), any(), any(), any()))
         .thenAnswer(inv -> inv.<DataSource<?>>getArgument(1)
             .getDataSourceType() == DataSourceType.KSTREAM
             ? stream : table
@@ -271,7 +269,7 @@ public class DataSourceNodeTest {
     node.buildStream(ksqlStreamBuilder);
 
     // Then:
-    verify(schemaKStreamFactory).create(any(), any(), any(), any(), any(), any());
+    verify(schemaKStreamFactory).create(any(), any(), any(), any(), any());
   }
 
   // should this even be possible? if you are using a timestamp extractor then shouldn't the name
@@ -285,7 +283,7 @@ public class DataSourceNodeTest {
     node.buildStream(ksqlStreamBuilder);
 
     // Then:
-    verify(schemaKStreamFactory).create(any(), any(), any(), any(), any(), any());
+    verify(schemaKStreamFactory).create(any(), any(), any(), any(), any());
   }
 
   @Test
@@ -303,7 +301,6 @@ public class DataSourceNodeTest {
         same(ksqlStreamBuilder),
         same(dataSource),
         stackerCaptor.capture(),
-        eq(OFFSET_RESET),
         same(node.getKeyField()),
         eq(SourceName.of("name"))
     );
@@ -326,7 +323,6 @@ public class DataSourceNodeTest {
         same(ksqlStreamBuilder),
         same(dataSource),
         stackerCaptor.capture(),
-        eq(OFFSET_RESET),
         same(node.getKeyField()),
         eq(SourceName.of("name"))
     );

--- a/ksql-engine/src/test/java/io/confluent/ksql/structured/SchemaKSourceFactoryTest.java
+++ b/ksql-engine/src/test/java/io/confluent/ksql/structured/SchemaKSourceFactoryTest.java
@@ -49,7 +49,6 @@ import io.confluent.ksql.serde.WindowInfo;
 import io.confluent.ksql.util.KsqlConfig;
 import java.util.Optional;
 import java.util.Set;
-import org.apache.kafka.streams.Topology.AutoOffsetReset;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -58,8 +57,6 @@ import org.mockito.junit.MockitoJUnitRunner;
 
 @RunWith(MockitoJUnitRunner.class)
 public class SchemaKSourceFactoryTest {
-  private static final Optional<AutoOffsetReset> OFFSET_RESET = Optional.of(
-      AutoOffsetReset.EARLIEST);
   private static final KeyField KEY_FIELD = KeyField.none();
   private static final SourceName ALIAS = SourceName.of("bob");
   private static final LogicalSchema SCHEMA = LogicalSchema.builder()
@@ -125,7 +122,6 @@ public class SchemaKSourceFactoryTest {
         builder,
         dataSource,
         contextStacker,
-        OFFSET_RESET,
         KEY_FIELD,
         ALIAS
     );
@@ -150,7 +146,6 @@ public class SchemaKSourceFactoryTest {
         builder,
         dataSource,
         contextStacker,
-        OFFSET_RESET,
         KEY_FIELD,
         ALIAS
     );
@@ -175,7 +170,6 @@ public class SchemaKSourceFactoryTest {
         builder,
         dataSource,
         contextStacker,
-        OFFSET_RESET,
         KEY_FIELD,
         ALIAS
     );
@@ -200,7 +194,6 @@ public class SchemaKSourceFactoryTest {
         builder,
         dataSource,
         contextStacker,
-        OFFSET_RESET,
         KEY_FIELD,
         ALIAS
     );

--- a/ksql-execution/src/main/java/io/confluent/ksql/execution/plan/AbstractStreamSource.java
+++ b/ksql-execution/src/main/java/io/confluent/ksql/execution/plan/AbstractStreamSource.java
@@ -24,7 +24,6 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Objects;
 import java.util.Optional;
-import org.apache.kafka.streams.Topology.AutoOffsetReset;
 
 @Immutable
 public abstract class AbstractStreamSource<K> implements ExecutionStep<K> {
@@ -32,7 +31,6 @@ public abstract class AbstractStreamSource<K> implements ExecutionStep<K> {
   private final String topicName;
   private final Formats formats;
   private final Optional<TimestampColumn> timestampColumn;
-  private final Optional<AutoOffsetReset> offsetReset;
   private final LogicalSchema sourceSchema;
   private final SourceName alias;
 
@@ -48,14 +46,12 @@ public abstract class AbstractStreamSource<K> implements ExecutionStep<K> {
       String topicName,
       Formats formats,
       Optional<TimestampColumn> timestampColumn,
-      Optional<AutoOffsetReset> offsetReset,
       LogicalSchema sourceSchema,
       SourceName alias) {
     this.properties = Objects.requireNonNull(properties, "properties");
     this.topicName = Objects.requireNonNull(topicName, "topicName");
     this.formats = Objects.requireNonNull(formats, "formats");
     this.timestampColumn = Objects.requireNonNull(timestampColumn, "timestampColumn");
-    this.offsetReset = Objects.requireNonNull(offsetReset, "offsetReset");
     this.sourceSchema = Objects.requireNonNull(sourceSchema, "sourceSchema");
     this.alias = Objects.requireNonNull(alias, "alias");
   }
@@ -72,10 +68,6 @@ public abstract class AbstractStreamSource<K> implements ExecutionStep<K> {
 
   public LogicalSchema getSourceSchema() {
     return sourceSchema;
-  }
-
-  public Optional<AutoOffsetReset> getOffsetReset() {
-    return offsetReset;
   }
 
   public Optional<TimestampColumn> getTimestampColumn() {
@@ -107,7 +99,6 @@ public abstract class AbstractStreamSource<K> implements ExecutionStep<K> {
         && Objects.equals(topicName, that.topicName)
         && Objects.equals(formats, that.formats)
         && Objects.equals(timestampColumn, that.timestampColumn)
-        && Objects.equals(offsetReset, that.offsetReset)
         && Objects.equals(sourceSchema, that.sourceSchema);
   }
 
@@ -118,7 +109,6 @@ public abstract class AbstractStreamSource<K> implements ExecutionStep<K> {
         topicName,
         formats,
         timestampColumn,
-        offsetReset,
         sourceSchema
     );
   }

--- a/ksql-execution/src/main/java/io/confluent/ksql/execution/plan/StreamSource.java
+++ b/ksql-execution/src/main/java/io/confluent/ksql/execution/plan/StreamSource.java
@@ -21,7 +21,6 @@ import io.confluent.ksql.name.SourceName;
 import io.confluent.ksql.schema.ksql.LogicalSchema;
 import java.util.Optional;
 import org.apache.kafka.connect.data.Struct;
-import org.apache.kafka.streams.Topology.AutoOffsetReset;
 
 @Immutable
 public final class StreamSource extends AbstractStreamSource<KStreamHolder<Struct>> {
@@ -30,7 +29,6 @@ public final class StreamSource extends AbstractStreamSource<KStreamHolder<Struc
       @JsonProperty(value = "topicName", required = true) String topicName,
       @JsonProperty(value = "formats", required = true) Formats formats,
       @JsonProperty("timestampColumn") Optional<TimestampColumn> timestampColumn,
-      @JsonProperty("offsetReset") Optional<AutoOffsetReset> offsetReset,
       @JsonProperty(value = "sourceSchema", required = true) LogicalSchema sourceSchema,
       @JsonProperty(value = "alias", required = true) SourceName alias) {
     super(
@@ -38,7 +36,6 @@ public final class StreamSource extends AbstractStreamSource<KStreamHolder<Struc
         topicName,
         formats,
         timestampColumn,
-        offsetReset,
         sourceSchema,
         alias
     );

--- a/ksql-execution/src/main/java/io/confluent/ksql/execution/plan/TableSource.java
+++ b/ksql-execution/src/main/java/io/confluent/ksql/execution/plan/TableSource.java
@@ -22,7 +22,6 @@ import io.confluent.ksql.name.SourceName;
 import io.confluent.ksql.schema.ksql.LogicalSchema;
 import java.util.Optional;
 import org.apache.kafka.connect.data.Struct;
-import org.apache.kafka.streams.Topology.AutoOffsetReset;
 
 @Immutable
 public final class TableSource extends AbstractStreamSource<KTableHolder<Struct>> {
@@ -33,7 +32,6 @@ public final class TableSource extends AbstractStreamSource<KTableHolder<Struct>
       @JsonProperty(value = "topicName", required = true) final String topicName,
       @JsonProperty(value = "formats", required = true) final Formats formats,
       @JsonProperty("timestampColumn") final Optional<TimestampColumn> timestampColumn,
-      @JsonProperty("offsetReset") final Optional<AutoOffsetReset> offsetReset,
       @JsonProperty(value = "sourceSchema", required = true) final LogicalSchema sourceSchema,
       @JsonProperty(value = "alias", required = true) final SourceName alias
   ) {
@@ -42,7 +40,6 @@ public final class TableSource extends AbstractStreamSource<KTableHolder<Struct>
         topicName,
         formats,
         timestampColumn,
-        offsetReset,
         sourceSchema,
         alias
     );

--- a/ksql-execution/src/main/java/io/confluent/ksql/execution/plan/WindowedStreamSource.java
+++ b/ksql-execution/src/main/java/io/confluent/ksql/execution/plan/WindowedStreamSource.java
@@ -24,7 +24,6 @@ import io.confluent.ksql.serde.WindowInfo;
 import java.util.Objects;
 import java.util.Optional;
 import org.apache.kafka.connect.data.Struct;
-import org.apache.kafka.streams.Topology.AutoOffsetReset;
 import org.apache.kafka.streams.kstream.Windowed;
 
 @Immutable
@@ -39,7 +38,6 @@ public final class WindowedStreamSource
       @JsonProperty(value = "formats", required = true) Formats formats,
       @JsonProperty(value = "windowInfo", required = true) WindowInfo windowInfo,
       @JsonProperty("timestampColumn") Optional<TimestampColumn> timestampColumn,
-      @JsonProperty("offsetReset") Optional<AutoOffsetReset> offsetReset,
       @JsonProperty(value = "sourceSchema", required = true) LogicalSchema sourceSchema,
       @JsonProperty(value = "alias", required = true) SourceName alias) {
     super(
@@ -47,7 +45,6 @@ public final class WindowedStreamSource
         topicName,
         formats,
         timestampColumn,
-        offsetReset,
         sourceSchema,
         alias
     );

--- a/ksql-execution/src/main/java/io/confluent/ksql/execution/plan/WindowedTableSource.java
+++ b/ksql-execution/src/main/java/io/confluent/ksql/execution/plan/WindowedTableSource.java
@@ -23,7 +23,6 @@ import io.confluent.ksql.serde.WindowInfo;
 import java.util.Objects;
 import java.util.Optional;
 import org.apache.kafka.connect.data.Struct;
-import org.apache.kafka.streams.Topology.AutoOffsetReset;
 import org.apache.kafka.streams.kstream.Windowed;
 
 public final class WindowedTableSource
@@ -37,7 +36,6 @@ public final class WindowedTableSource
       @JsonProperty(value = "formats", required = true) Formats formats,
       @JsonProperty(value = "windowInfo", required = true) WindowInfo windowInfo,
       @JsonProperty("timestampColumn") final Optional<TimestampColumn> timestampColumn,
-      @JsonProperty("offsetReset") final Optional<AutoOffsetReset> offsetReset,
       @JsonProperty(value = "sourceSchema", required = true) LogicalSchema sourceSchema,
       @JsonProperty(value = "alias", required = true) SourceName alias
   ) {
@@ -46,7 +44,6 @@ public final class WindowedTableSource
         topicName,
         formats,
         timestampColumn,
-        offsetReset,
         sourceSchema,
         alias
     );

--- a/ksql-rest-app/src/test/resources/ksql-plan-schema/schema.json
+++ b/ksql-rest-app/src/test/resources/ksql-plan-schema/schema.json
@@ -473,10 +473,6 @@
         "timestampColumn" : {
           "$ref" : "#/definitions/TimestampColumn"
         },
-        "offsetReset" : {
-          "type" : "string",
-          "enum" : [ "EARLIEST", "LATEST" ]
-        },
         "sourceSchema" : {
           "type" : "string"
         },
@@ -510,10 +506,6 @@
         },
         "timestampColumn" : {
           "$ref" : "#/definitions/TimestampColumn"
-        },
-        "offsetReset" : {
-          "type" : "string",
-          "enum" : [ "EARLIEST", "LATEST" ]
         },
         "sourceSchema" : {
           "type" : "string"
@@ -647,10 +639,6 @@
         "timestampColumn" : {
           "$ref" : "#/definitions/TimestampColumn"
         },
-        "offsetReset" : {
-          "type" : "string",
-          "enum" : [ "EARLIEST", "LATEST" ]
-        },
         "sourceSchema" : {
           "type" : "string"
         },
@@ -684,10 +672,6 @@
         },
         "timestampColumn" : {
           "$ref" : "#/definitions/TimestampColumn"
-        },
-        "offsetReset" : {
-          "type" : "string",
-          "enum" : [ "EARLIEST", "LATEST" ]
         },
         "sourceSchema" : {
           "type" : "string"

--- a/ksql-streams/src/main/java/io/confluent/ksql/execution/streams/ExecutionStepFactory.java
+++ b/ksql-streams/src/main/java/io/confluent/ksql/execution/streams/ExecutionStepFactory.java
@@ -57,7 +57,6 @@ import java.time.Duration;
 import java.util.List;
 import java.util.Optional;
 import org.apache.kafka.connect.data.Struct;
-import org.apache.kafka.streams.Topology.AutoOffsetReset;
 import org.apache.kafka.streams.kstream.JoinWindows;
 
 // CHECKSTYLE_RULES.OFF: ClassDataAbstractionCoupling
@@ -74,7 +73,6 @@ public final class ExecutionStepFactory {
       final Formats formats,
       final WindowInfo windowInfo,
       final Optional<TimestampColumn> timestampColumn,
-      final Optional<AutoOffsetReset> offsetReset,
       final SourceName alias
   ) {
     final QueryContext queryContext = stacker.getQueryContext();
@@ -84,7 +82,6 @@ public final class ExecutionStepFactory {
         formats,
         windowInfo,
         timestampColumn,
-        offsetReset,
         sourceSchema,
         alias
     );
@@ -96,7 +93,6 @@ public final class ExecutionStepFactory {
       final String topicName,
       final Formats formats,
       final Optional<TimestampColumn> timestampColumn,
-      final Optional<AutoOffsetReset> offsetReset,
       final SourceName alias
   ) {
     final QueryContext queryContext = stacker.getQueryContext();
@@ -105,7 +101,6 @@ public final class ExecutionStepFactory {
         topicName,
         formats,
         timestampColumn,
-        offsetReset,
         sourceSchema,
         alias
     );
@@ -117,7 +112,6 @@ public final class ExecutionStepFactory {
       final String topicName,
       final Formats formats,
       final Optional<TimestampColumn> timestampColumn,
-      final Optional<AutoOffsetReset> offsetReset,
       final SourceName alias
   ) {
     final QueryContext queryContext = stacker.getQueryContext();
@@ -126,7 +120,6 @@ public final class ExecutionStepFactory {
         topicName,
         formats,
         timestampColumn,
-        offsetReset,
         sourceSchema,
         alias
     );
@@ -139,7 +132,6 @@ public final class ExecutionStepFactory {
       final Formats formats,
       final WindowInfo windowInfo,
       final Optional<TimestampColumn> timestampColumn,
-      final Optional<AutoOffsetReset> offsetReset,
       final SourceName alias
   ) {
     final QueryContext queryContext = stacker.getQueryContext();
@@ -149,7 +141,6 @@ public final class ExecutionStepFactory {
         formats,
         windowInfo,
         timestampColumn,
-        offsetReset,
         sourceSchema,
         alias
     );

--- a/ksql-streams/src/test/java/io/confluent/ksql/execution/streams/SourceBuilderTest.java
+++ b/ksql-streams/src/test/java/io/confluent/ksql/execution/streams/SourceBuilderTest.java
@@ -27,7 +27,6 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.reset;
 import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.verifyNoMoreInteractions;
 import static org.mockito.Mockito.when;
 
 import com.google.common.collect.ImmutableList;
@@ -61,6 +60,7 @@ import java.util.HashSet;
 import java.util.LinkedList;
 import java.util.Optional;
 import java.util.Set;
+import org.apache.kafka.clients.consumer.ConsumerConfig;
 import org.apache.kafka.clients.consumer.ConsumerRecord;
 import org.apache.kafka.common.serialization.Serde;
 import org.apache.kafka.common.utils.Bytes;
@@ -160,7 +160,6 @@ public class SourceBuilderTest {
   private ArgumentCaptor<ValueTransformerWithKeySupplier> transformSupplierCaptor;
   @Captor
   private ArgumentCaptor<TimestampExtractor> timestampExtractorCaptor;
-  private Optional<AutoOffsetReset> offsetReset = Optional.of(AutoOffsetReset.EARLIEST);
   private final GenericRow row = new GenericRow(new LinkedList<>(ImmutableList.of("baz", 123)));
   private PlanBuilder planBuilder;
 
@@ -219,6 +218,45 @@ public class SourceBuilderTest {
     validator.verify(kStream).transformValues(any(ValueTransformerWithKeySupplier.class));
     verify(consumedFactory).create(keySerde, valueSerde);
     verify(consumed).withTimestampExtractor(any());
+    verify(consumed).withOffsetResetPolicy(any());
+  }
+
+  @Test
+  public void shouldUseOffsetResetLatestForStream() {
+    // Given:
+    givenUnwindowedSourceStream();
+
+    // When
+    streamSource.build(planBuilder);
+
+    // Then:
+    verify(consumed).withOffsetResetPolicy(AutoOffsetReset.LATEST);
+  }
+
+  @Test
+  public void shouldUseOffsetResetLatestForWindowedStream() {
+    // Given:
+    givenWindowedSourceStream();
+
+    // When
+    windowedStreamSource.build(planBuilder);
+
+    // Then:
+    verify(consumedWindowed).withOffsetResetPolicy(AutoOffsetReset.LATEST);
+  }
+
+  @Test
+  public void shouldUseConfiguredResetPolicyForStream() {
+    // Given:
+    when(queryBuilder.getKsqlConfig()).thenReturn(new KsqlConfig(
+        ImmutableMap.of(ConsumerConfig.AUTO_OFFSET_RESET_CONFIG, "earliest")
+    ));
+    givenUnwindowedSourceStream();
+
+    // When
+    streamSource.build(planBuilder);
+
+    // Then:
     verify(consumed).withOffsetResetPolicy(AutoOffsetReset.EARLIEST);
   }
 
@@ -260,6 +298,45 @@ public class SourceBuilderTest {
   }
 
   @Test
+  public void shouldUseOffsetResetEarliestForTable() {
+    // Given:
+    givenUnwindowedSourceTable();
+
+    // When
+    tableSource.build(planBuilder);
+
+    // Then:
+    verify(consumed).withOffsetResetPolicy(AutoOffsetReset.EARLIEST);
+  }
+
+  @Test
+  public void shouldUseOffsetResetEarliestForWindowedTable() {
+    // Given:
+    givenWindowedSourceTable();
+
+    // When
+    windowedTableSource.build(planBuilder);
+
+    // Then:
+    verify(consumedWindowed).withOffsetResetPolicy(AutoOffsetReset.EARLIEST);
+  }
+
+  @Test
+  public void shouldUseConfiguredResetPolicyForTable() {
+    // Given:
+    when(queryBuilder.getKsqlConfig()).thenReturn(new KsqlConfig(
+        ImmutableMap.of(ConsumerConfig.AUTO_OFFSET_RESET_CONFIG, "latest")
+    ));
+    givenUnwindowedSourceTable();
+
+    // When
+    tableSource.build(planBuilder);
+
+    // Then:
+    verify(consumed).withOffsetResetPolicy(AutoOffsetReset.LATEST);
+  }
+
+  @Test
   public void shouldReturnCorrectSchemaForUnwindowedSourceStream() {
     // Given:
     givenUnwindowedSourceStream();
@@ -281,21 +358,6 @@ public class SourceBuilderTest {
 
     // Then:
     assertThat(builtKTable.getSchema(), is(SCHEMA));
-  }
-
-  @Test
-  public void shouldNotBuildWithOffsetResetIfNotProvided() {
-    // Given:
-    offsetReset = Optional.empty();
-    givenUnwindowedSourceStream();
-
-    // When
-    streamSource.build(planBuilder);
-
-    // Then:
-    verify(consumedFactory).create(keySerde, valueSerde);
-    verify(consumed).withTimestampExtractor(any());
-    verifyNoMoreInteractions(consumed, consumedFactory);
   }
 
   @Test
@@ -360,7 +422,6 @@ public class SourceBuilderTest {
         TOPIC_NAME,
         Formats.of(keyFormatInfo, valueFormatInfo, SERDE_OPTIONS),
         Optional.empty(),
-        offsetReset,
         LogicalSchema.builder()
             .keyColumn(ColumnName.of("f1"), SqlTypes.INTEGER)
             .keyColumn(ColumnName.of("f2"), SqlTypes.BIGINT)
@@ -604,7 +665,6 @@ public class SourceBuilderTest {
         Formats.of(keyFormatInfo, valueFormatInfo, SERDE_OPTIONS),
         windowInfo,
         TIMESTAMP_COLUMN,
-        offsetReset,
         SOURCE_SCHEMA,
         ALIAS
     );
@@ -618,7 +678,6 @@ public class SourceBuilderTest {
         TOPIC_NAME,
         Formats.of(keyFormatInfo, valueFormatInfo, SERDE_OPTIONS),
         TIMESTAMP_COLUMN,
-        offsetReset,
         SOURCE_SCHEMA,
         ALIAS
     );
@@ -634,7 +693,6 @@ public class SourceBuilderTest {
         Formats.of(keyFormatInfo, valueFormatInfo, SERDE_OPTIONS),
         windowInfo,
         TIMESTAMP_COLUMN,
-        offsetReset,
         SOURCE_SCHEMA,
         ALIAS
     );
@@ -648,7 +706,6 @@ public class SourceBuilderTest {
         TOPIC_NAME,
         Formats.of(keyFormatInfo, valueFormatInfo, SERDE_OPTIONS),
         TIMESTAMP_COLUMN,
-        offsetReset,
         SOURCE_SCHEMA,
         ALIAS
     );

--- a/ksql-streams/src/test/java/io/confluent/ksql/execution/streams/StepSchemaResolverTest.java
+++ b/ksql-streams/src/test/java/io/confluent/ksql/execution/streams/StepSchemaResolverTest.java
@@ -281,7 +281,6 @@ public class StepSchemaResolverTest {
         "foo",
         formats,
         Optional.empty(),
-        Optional.empty(),
         SCHEMA,
         SourceName.of("alias")
     );
@@ -300,7 +299,6 @@ public class StepSchemaResolverTest {
         "foo",
         formats,
         WindowInfo.of(WindowType.TUMBLING, Optional.of(Duration.ofMillis(123))),
-        Optional.empty(),
         Optional.empty(),
         SCHEMA,
         SourceName.of("alias")
@@ -402,7 +400,6 @@ public class StepSchemaResolverTest {
         "foo",
         formats,
         Optional.empty(),
-        Optional.empty(),
         SCHEMA,
         SourceName.of("alias")
     );
@@ -421,7 +418,6 @@ public class StepSchemaResolverTest {
         "foo",
         formats,
         mock(WindowInfo.class),
-        Optional.empty(),
         Optional.empty(),
         SCHEMA,
         SourceName.of("alias")


### PR DESCRIPTION
### Description 
Cleans up offset reset from plan steps. All streams now default to
starting from the end. All tables now default to starting from the
first record. The reset can be overridden in the config.
