### PR TITLE
Changing the Default Prompt from "ksql" to "ksqlDB"

### DIFF
--- a/ksql-cli/src/main/java/io/confluent/ksql/cli/console/JLineReader.java
+++ b/ksql-cli/src/main/java/io/confluent/ksql/cli/console/JLineReader.java
@@ -39,7 +39,7 @@ public class JLineReader implements io.confluent.ksql.cli.console.LineReader {
 
   private static final Logger LOGGER = LoggerFactory.getLogger(JLineReader.class);
 
-  private static final String DEFAULT_PROMPT = "ksql> ";
+  private static final String DEFAULT_PROMPT = "ksqlDB> ";
 
   private final DefaultHistory history;
 


### PR DESCRIPTION
### Description 
Inline with the new focus of KSQL of being a streaming database, I think it would be useful to start adopting the ksqlDB as something more concrete since everywhere else there will be references to this name instead of simply KSQL. This PR essentially changes the prompt from "ksql" to "ksqlDB" to make it formal.

### Testing done 
All existing tests have been successfully executed, and there is no actual need (IMO) to implement new tests.

### Reviewer checklist
- [ ] Ensure docs are updated if necessary. (eg. screenshots or the CLI and examples need to be changed).
- [ ] Related issue: https://github.com/confluentinc/ksql/issues/4071

