### PR TITLE
docs: fix docker image names + remove monitoring interceptor docs

### DIFF
--- a/docs-md/developer-guide/query-with-structured-data.md
+++ b/docs-md/developer-guide/query-with-structured-data.md
@@ -114,7 +114,7 @@ Start the ksqlDB CLI:
 
 ```bash
 docker run --network tutorials_default --rm --interactive --tty \
-    confluentinc/cp-ksql-cli:{{ site.release }} \
+    confluentinc/ksqldb-cli:{{ site.release }} \
     http://ksql-server:8088
 ```
 

--- a/docs-md/developer-guide/query-with-structured-data.md
+++ b/docs-md/developer-guide/query-with-structured-data.md
@@ -114,8 +114,8 @@ Start the ksqlDB CLI:
 
 ```bash
 docker run --network tutorials_default --rm --interactive --tty \
-    confluentinc/ksqldb-cli:{{ site.release }} \
-    http://ksql-server:8088
+    confluentinc/ksqldb-cli:{{ site.release }} ksql \
+    http://ksqldb-server:8088
 ```
 
 In the ksqlDB CLI, ensure that `raw-topic` is available:

--- a/docs-md/developer-guide/query-with-structured-data.md
+++ b/docs-md/developer-guide/query-with-structured-data.md
@@ -115,7 +115,7 @@ Start the ksqlDB CLI:
 ```bash
 docker run --network tutorials_default --rm --interactive --tty \
     confluentinc/ksqldb-cli:{{ site.release }} ksql \
-    http://ksqldb-server:8088
+    http://ksql-server:8088
 ```
 
 In the ksqlDB CLI, ensure that `raw-topic` is available:

--- a/docs-md/faq.md
+++ b/docs-md/faq.md
@@ -121,11 +121,11 @@ If you're running with Confluent CLI, use the `confluent stop` command:
 confluent stop KSQL
 ```
 
-If you're running ksqlDB in Docker containers, stop the `cp-ksql-server`
+If you're running ksqlDB in Docker containers, stop the `ksqldb-server`
 container:
 
 ```bash
-docker stop <cp-ksql-server-container-name>
+docker stop <ksqldb-server-container-name>
 ```
 
 If you're running ksqlDB as a system service, use the `systemctl stop`

--- a/docs-md/operate-and-deploy/installation/install-ksqldb-with-docker.md
+++ b/docs-md/operate-and-deploy/installation/install-ksqldb-with-docker.md
@@ -300,7 +300,7 @@ docker run -d -p 10.0.0.11:8088:8088 \
   confluentinc/ksqldb-server:{{ site.release }}
 
 # Connect the ksqlDB CLI to the server.
-docker run -it confluentinc/ksqldb-cli http://10.0.0.11:8088 
+docker run -it confluentinc/ksqldb-cli ksql http://10.0.0.11:8088 
 ```
 
 `KSQL_BOOTSTRAP_SERVERS`
@@ -328,7 +328,7 @@ ls /path/on/host/ksql-cli.properties
 
 docker run -it \
   -v /path/on/host/:/path/in/container  \
-  confluentinc/ksqldb-cli:{{ site.release }} http://10.0.0.11:8088 \
+  confluentinc/ksqldb-cli:{{ site.release }} ksql http://10.0.0.11:8088 \
   --config-file /path/in/container/ksql-cli.properties
 ```
 
@@ -338,7 +338,7 @@ Run a ksqlDB CLI instance in a container and connect to a remote ksqlDB
 Server host:
 
 ```bash
-docker run -it confluentinc/ksqldb-cli:{{ site.release }} \
+docker run -it confluentinc/ksqldb-cli:{{ site.release }} ksql \
   http://ec2-blah.us-blah.compute.amazonaws.com:8080
 ```
 

--- a/docs-md/operate-and-deploy/installation/install-ksqldb-with-docker.md
+++ b/docs-md/operate-and-deploy/installation/install-ksqldb-with-docker.md
@@ -8,8 +8,8 @@ keywords: ksqldb, docker, install
 
 You can deploy ksqlDB by using Docker containers. Starting with {{ site.cp }}
 4.1.2, Confluent maintains images at [Docker Hub](https://hub.docker.com/u/confluentinc)
-for [ksqlDB Server](https://hub.docker.com/r/confluentinc/cp-ksql-server/) and the
-[ksqlDB command-line interface (CLI)](https://hub.docker.com/r/confluentinc/cp-ksql-cli/).
+for [ksqlDB Server](https://hub.docker.com/r/confluentinc/ksqldb-server/) and the
+[ksqlDB command-line interface (CLI)](https://hub.docker.com/r/confluentinc/ksqldb-cli/).
 
 ksqlDB runs separately from your {{ site.aktm }} cluster, so you specify
 the IP addresses of the cluster's bootstrap servers when you start a
@@ -90,7 +90,7 @@ docker run -d \
   -e KSQL_BOOTSTRAP_SERVERS=localhost:9092 \
   -e KSQL_KSQL_SERVICE_ID=ksql_standalone_1_ \
   -e KSQL_KSQL_QUERIES_FILE=/path/in/container/queries.sql \
-  confluentinc/cp-ksql-server:{{ site.release }}
+  confluentinc/ksqldb-server:{{ site.release }}
 ```
 TODO: Figure out how to style these
 
@@ -127,7 +127,7 @@ docker run -d \
   -e KSQL_PRODUCER_INTERCEPTOR_CLASSES=io.confluent.monitoring.clients.interceptor.MonitoringProducerInterceptor \
   -e KSQL_CONSUMER_INTERCEPTOR_CLASSES=io.confluent.monitoring.clients.interceptor.MonitoringConsumerInterceptor \
   -e KSQL_KSQL_QUERIES_FILE=/path/in/container/queries.sql \
-  confluentinc/cp-ksql-server:{{ site.release }}
+  confluentinc/ksqldb-server:{{ site.release }}
 ```
 
 `KSQL_BOOTSTRAP_SERVERS`
@@ -165,7 +165,7 @@ docker run -d \
   -e KSQL_BOOTSTRAP_SERVERS=localhost:9092 \
   -e KSQL_LISTENERS=http://0.0.0.0:8088/ \
   -e KSQL_KSQL_SERVICE_ID=ksql_service_2_ \
-  confluentinc/cp-ksql-server:{{ site.release }}
+  confluentinc/ksqldb-server:{{ site.release }}
 ```
 
 `KSQL_BOOTSTRAP_SERVERS`
@@ -199,7 +199,7 @@ docker run -d \
   -e KSQL_KSQL_SERVICE_ID=ksql_service_3_ \
   -e KSQL_PRODUCER_INTERCEPTOR_CLASSES=io.confluent.monitoring.clients.interceptor.MonitoringProducerInterceptor \
   -e KSQL_CONSUMER_INTERCEPTOR_CLASSES=io.confluent.monitoring.clients.interceptor.MonitoringConsumerInterceptor \
-  confluentinc/cp-ksql-server:{{ site.release }}
+  confluentinc/ksqldb-server:{{ site.release }}
 ```
 
 `KSQL_BOOTSTRAP_SERVERS`
@@ -250,7 +250,7 @@ docker run -d \
   -e KSQL_SECURITY_PROTOCOL=SASL_SSL \
   -e KSQL_SASL_MECHANISM=PLAIN \
   -e KSQL_SASL_JAAS_CONFIG="org.apache.kafka.common.security.plain.PlainLoginModule required username=\"<username>\" password=\"<strong-password>\";" \
-  confluentinc/cp-ksql-server:{{ site.release }}
+  confluentinc/ksqldb-server:{{ site.release }}
 ```
 
 `KSQL_BOOTSTRAP_SERVERS`
@@ -312,7 +312,7 @@ docker run -d \
   -v /path/on/host:/path/in/container/ \
   -e KSQL_BOOTSTRAP_SERVERS=localhost:9092 \
   -e KSQL_OPTS="-Dksql.service.id=ksql_service_3_  -Dksql.queries.file=/path/in/container/queries.sql" \
-  confluentinc/cp-ksql-server:{{ site.release }}
+  confluentinc/ksqldb-server:{{ site.release }}
 ```
 
 `KSQL_BOOTSTRAP_SERVERS`
@@ -386,10 +386,10 @@ that's running in a different container.
 docker run -d -p 10.0.0.11:8088:8088 \
   -e KSQL_BOOTSTRAP_SERVERS=localhost:9092 \
   -e KSQL_OPTS="-Dksql.service.id=ksql_service_3_  -Dlisteners=http://0.0.0.0:8088/" \  
-  confluentinc/cp-ksql-server:{{ site.release }}
+  confluentinc/ksqldb-server:{{ site.release }}
 
 # Connect the ksqlDB CLI to the server.
-docker run -it confluentinc/cp-ksql-cli http://10.0.0.11:8088 
+docker run -it confluentinc/ksqldb-cli http://10.0.0.11:8088 
 ```
 
 `KSQL_BOOTSTRAP_SERVERS`
@@ -417,7 +417,7 @@ ls /path/on/host/ksql-cli.properties
 
 docker run -it \
   -v /path/on/host/:/path/in/container  \
-  confluentinc/cp-ksql-cli:{{ site.release }} http://10.0.0.11:8088 \
+  confluentinc/ksqldb-cli:{{ site.release }} http://10.0.0.11:8088 \
   --config-file /path/in/container/ksql-cli.properties
 ```
 
@@ -427,7 +427,7 @@ Run a ksqlDB CLI instance in a container and connect to a remote ksqlDB
 Server host:
 
 ```bash
-docker run -it confluentinc/cp-ksql-cli:{{ site.release }} \
+docker run -it confluentinc/ksqldb-cli:{{ site.release }} \
   http://ec2-blah.us-blah.compute.amazonaws.com:8080
 ```
 
@@ -515,8 +515,8 @@ which is either `Entrypoint` or `Cmd`:
 
 ```bash
 {% raw %}
-docker inspect --format='{{.Config.Entrypoint}}' confluentinc/cp-ksql-server:{{ site.release }}
-docker inspect --format='{{.Config.Cmd}}' confluentinc/cp-ksql-server:{{ site.release }}
+docker inspect --format='{{.Config.Entrypoint}}' confluentinc/ksqldb-server:{{ site.release }}
+docker inspect --format='{{.Config.Cmd}}' confluentinc/ksqldb-server:{{ site.release }}
 {% endraw %}
 ```
 
@@ -538,7 +538,7 @@ a directory and downloads a tar archive into it.
 
 ```yaml
 ksql-server:
-  image: confluentinc/cp-ksql-server:{{ site.release }}
+  image: confluentinc/ksqldb-server:{{ site.release }}
   depends_on:
     - kafka
   environment:
@@ -555,7 +555,7 @@ ksql-server:
 ```
 
 After the `mkdir`, `cd`, `curl`, and `tar` commands run, the
-`/etc/confluent/docker/run` command starts the `cp-ksql-server` image
+`/etc/confluent/docker/run` command starts the `ksqldb-server` image
 with the specified settings.
 
 !!! note
@@ -573,7 +573,7 @@ the environment to a desired state.
 
 ```yaml
 ksql-cli:
-  image: confluentinc/cp-ksql-cli:{{ site.release }}
+  image: confluentinc/ksqldb-cli:{{ site.release }}
   depends_on:
     - ksql-server
   volumes:

--- a/docs-md/operate-and-deploy/installation/install-ksqldb-with-docker.md
+++ b/docs-md/operate-and-deploy/installation/install-ksqldb-with-docker.md
@@ -108,50 +108,6 @@ TODO: Figure out how to style these
 
 :   A file that specifies predefined SQL queries.
 
-### ksqlDB Headless Server with Interceptors Settings (Production)
-
-{{ site.cp }} supports pluggable *interceptors* to examine and modify
-incoming and outgoing records. Specify interceptor classes by assigning
-the `KSQL_PRODUCER_INTERCEPTOR_CLASSES` and `KSQL_CONSUMER_INTERCEPTOR_CLASSES`
-settings. For more info on interceptor classes, see
-[Confluent Monitoring Interceptors](https://docs.confluent.io/current/control-center/installation/clients.html).
-
-Use the following command to run a headless, standalone ksqlDB Server with
-the specified interceptor classes in a container:
-
-```bash
-docker run -d \
-  -v /path/on/host:/path/in/container/ \
-  -e KSQL_BOOTSTRAP_SERVERS=localhost:9092 \
-  -e KSQL_KSQL_SERVICE_ID=ksql_standalone_2_ \
-  -e KSQL_PRODUCER_INTERCEPTOR_CLASSES=io.confluent.monitoring.clients.interceptor.MonitoringProducerInterceptor \
-  -e KSQL_CONSUMER_INTERCEPTOR_CLASSES=io.confluent.monitoring.clients.interceptor.MonitoringConsumerInterceptor \
-  -e KSQL_KSQL_QUERIES_FILE=/path/in/container/queries.sql \
-  confluentinc/ksqldb-server:{{ site.release }}
-```
-
-`KSQL_BOOTSTRAP_SERVERS`
-
-:   A list of hosts for establishing the initial connection to the Kafka
-    cluster.
-
-`KSQL_KSQL_SERVICE_ID`
-
-:   The service ID of the ksqlDB server, which is used as the prefix for
-    the internal topics created by ksqlDB.
-
-`KSQL_KSQL_QUERIES_FILE`
-
-:   A file that specifies predefined SQL queries.
-
-`KSQL_PRODUCER_INTERCEPTOR_CLASSES`
-
-:   A list of fully qualified class names for producer interceptors.
-
-`KSQL_CONSUMER_INTERCEPTOR_CLASSES`
-
-:   A list of fully qualified class names for consumer interceptors.
-
 ### ksqlDB Interactive Server Settings (Development)
 
 Develop your ksqlDB applications by using the ksqlDB command-line interface
@@ -185,51 +141,6 @@ docker run -d \
 
 In interactive mode, a ksqlDB CLI instance running outside of Docker can
 connect to the ksqlDB server running in Docker.
-
-### ksqlDB Interactive Server with Interceptors Settings (Development)
-
-Run a ksqlDB Server with interceptors that enables manual interaction by
-using the ksqlDB CLI:
-
-```bash
-docker run -d \
-  -p 127.0.0.1:8088:8088 \
-  -e KSQL_BOOTSTRAP_SERVERS=localhost:9092 \
-  -e KSQL_LISTENERS=http://0.0.0.0:8088/ \
-  -e KSQL_KSQL_SERVICE_ID=ksql_service_3_ \
-  -e KSQL_PRODUCER_INTERCEPTOR_CLASSES=io.confluent.monitoring.clients.interceptor.MonitoringProducerInterceptor \
-  -e KSQL_CONSUMER_INTERCEPTOR_CLASSES=io.confluent.monitoring.clients.interceptor.MonitoringConsumerInterceptor \
-  confluentinc/ksqldb-server:{{ site.release }}
-```
-
-`KSQL_BOOTSTRAP_SERVERS`
-
-:   A list of hosts for establishing the initial connection to the Kafka
-    cluster.
-
-`KSQL_KSQL_SERVICE_ID`
-
-:   The service ID of the ksqlDB server, which is used as the prefix for
-    the internal topics created by ksqlDB.
-
-`KSQL_LISTENERS`
-
-:   A list of URIs, including the protocol, that the broker listens on.
-    If you are using IPv6, set to `http://[::]:8088`.
-
-`KSQL_PRODUCER_INTERCEPTOR_CLASSES`
-
-:   A list of fully qualified class names for producer interceptors.
-
-`KSQL_CONSUMER_INTERCEPTOR_CLASSES`
-
-:   A list of fully qualified class names for consumer interceptors.
-
-For more info on interceptor classes, see
-[Confluent Monitoring Interceptors](https://docs.confluent.io/current/control-center/installation/clients.html).
-
-In interactive mode, a CLI instance running outside of Docker can
-connect to the server running in Docker.
 
 Connect ksqlDB Server to a Secure Kafka Cluster, Like Confluent Cloud
 ===================================================================

--- a/docs-md/operate-and-deploy/installation/installing.md
+++ b/docs-md/operate-and-deploy/installation/installing.md
@@ -156,7 +156,7 @@ After ksqlDB is started, your terminal should resemble this.
 
 Copyright 2017-2019 Confluent Inc.
 
-CLI v{{ site.release }}, Server v{{ site.release }} located at http://ksqldb-server:8088
+CLI v{{ site.release }}, Server v{{ site.release }} located at http://localhost:8088
 
 Having trouble? Type 'help' (case-insensitive) for a rundown of how things work!
 

--- a/docs-md/operate-and-deploy/installation/installing.md
+++ b/docs-md/operate-and-deploy/installation/installing.md
@@ -19,7 +19,7 @@ Docker support
 You can deploy ksqlDB by using
 [Docker containers](install-ksqldb-with-docker.md).
 Starting with {{ site.cp }} 4.1.2, Confluent maintains images at
-[Docker Hub](https://hub.docker.com/r/confluentinc/cp-ksql-server/).
+[Docker Hub](https://hub.docker.com/r/confluentinc/ksqldb-server/).
 To start ksqlDB containers in configurations like "ksqlDB Headless
 Server" and "Interactive Server with Interceptors", see
 [Docker Configuration Parameters](https://docs.confluent.io/current/installation/docker/config-reference.html).

--- a/docs-md/operate-and-deploy/installation/server-config/config-reference.md
+++ b/docs-md/operate-and-deploy/installation/server-config/config-reference.md
@@ -14,7 +14,7 @@ For more information on setting properties, see
 !!! tip
 	Each property has a corresponding environment variable in the Docker
     image for
-    [ksqlDB Server](https://hub.docker.com/r/confluentinc/cp-ksql-server/). The
+    [ksqlDB Server](https://hub.docker.com/r/confluentinc/ksqldb-server/). The
     environment variable name is constructed from the configuration property
     name by converting to uppercase, replacing periods with underscores, and
     prepending with `KSQL_`. For example, the name of the `ksql.service.id`
@@ -49,7 +49,7 @@ For more information, see [Kafka Consumer](https://docs.confluent.io/current/cli
 [AUTO_OFFSET_RESET_CONFIG](https://docs.confluent.io/{{ site.release }}/clients/javadocs/org/apache/kafka/clients/consumer/ConsumerConfig.html#AUTO_OFFSET_RESET_CONFIG).
 
 The corresponding environment variable in the
-[ksqlDB Server image](https://hub.docker.com/r/confluentinc/cp-ksql-server/)
+[ksqlDB Server image](https://hub.docker.com/r/confluentinc/ksqldb-server/)
 is `KSQL_KSQL_STREAMS_AUTO_OFFSET_RESET`.
 
 ### ksql.streams.bootstrap.servers
@@ -69,7 +69,7 @@ and
 [BOOTSTRAP_SERVERS_CONFIG](https://docs.confluent.io/{{ site.release }}/streams/javadocs/org/apache/kafka/streams/StreamsConfig.html#BOOTSTRAP_SERVERS_CONFIG).
 
 The corresponding environment variable in the
-[ksqlDB Server image](https://hub.docker.com/r/confluentinc/cp-ksql-server/)
+[ksqlDB Server image](https://hub.docker.com/r/confluentinc/ksqldb-server/)
 is `KSQL_KSQL_STREAMS_BOOTSTRAP_SERVERS` or `KSQL_BOOTSTRAP_SERVERS`. For
 more information, see
 [Install ksqlDB with Docker](../install-ksqldb-with-docker.md).
@@ -90,7 +90,7 @@ and
 [COMMIT_INTERVAL_MS_CONFIG](https://docs.confluent.io/{{ site.release }}/streams/javadocs/org/apache/kafka/streams/StreamsConfig.html#COMMIT_INTERVAL_MS_CONFIG),
 
 The corresponding environment variable in the
-[ksqlDB Server image](https://hub.docker.com/r/confluentinc/cp-ksql-server/)
+[ksqlDB Server image](https://hub.docker.com/r/confluentinc/ksqldb-server/)
 is `KSQL_KSQL_STREAMS_COMMIT_INTERVAL_MS`.
 
 ### ksql.streams.cache.max.bytes.buffering
@@ -109,7 +109,7 @@ and
 [CACHE_MAX_BYTES_BUFFERING_CONFIG](https://docs.confluent.io/{{ site.release }}/streams/javadocs/org/apache/kafka/streams/StreamsConfig.html#CACHE_MAX_BYTES_BUFFERING_CONFIG).
 
 The corresponding environment variable in the
-[ksqlDB Server image](https://hub.docker.com/r/confluentinc/cp-ksql-server/)
+[ksqlDB Server image](https://hub.docker.com/r/confluentinc/ksqldb-server/)
 is `KSQL_KSQL_STREAMS_CACHE_MAX_BYTES_BUFFERING`.
 
 ### ksql.streams.num.stream.threads
@@ -120,7 +120,7 @@ information about the {{ site.kstreams }} threading model, see
 [Threading Model](https://docs.confluent.io/current/streams/architecture.html#threading-model).
 
 The corresponding environment variable in the
-[ksqlDB Server image](https://hub.docker.com/r/confluentinc/cp-ksql-server/)
+[ksqlDB Server image](https://hub.docker.com/r/confluentinc/ksqldb-server/)
 is `KSQL_KSQL_STREAMS_NUM_STREAM_THREADS`.
 
 ### ksql.output.topic.name.prefix
@@ -134,7 +134,7 @@ interactive mode. For more information, see
 [Interactive ksqlDB clusters](security.md#interactive-ksqldb-clusters).
 
 The corresponding environment variable in the
-[ksqlDB Server image](https://hub.docker.com/r/confluentinc/cp-ksql-server/)
+[ksqlDB Server image](https://hub.docker.com/r/confluentinc/ksqldb-server/)
 is `KSQL_KSQL_OUTPUT_TOPIC_NAME_PREFIX`.
 
 ksqlDB Query Settings
@@ -181,7 +181,7 @@ ksql.fail.on.production.error=false
 ```
 
 The corresponding environment variable in the
-[ksqlDB Server image](https://hub.docker.com/r/confluentinc/cp-ksql-server/)
+[ksqlDB Server image](https://hub.docker.com/r/confluentinc/ksqldb-server/)
 is `KSQL_KSQL_FAIL_ON_DESERIALIZATION_ERROR`.
 
 ### ksql.schema.registry.url
@@ -191,7 +191,7 @@ over a secure connection, see
 [Configure ksqlDB for Secured {{ site.srlong }}](security.md#configure-ksqldb-for-https).
 
 The corresponding environment variable in the
-[ksqlDB Server image](https://hub.docker.com/r/confluentinc/cp-ksql-server/)
+[ksqlDB Server image](https://hub.docker.com/r/confluentinc/ksqldb-server/)
 is `KSQL_KSQL_SCHEMA_REGISTRY_URL`.
 
 ### ksql.service.id
@@ -221,7 +221,7 @@ configured separately. For more information, see
 [Processing Log](../../../developer-guide/test-and-debug/processing-log.md).
 
 The corresponding environment variable in the
-[ksqlDB Server image](https://hub.docker.com/r/confluentinc/cp-ksql-server/)
+[ksqlDB Server image](https://hub.docker.com/r/confluentinc/ksqldb-server/)
 is `KSQL_KSQL_INTERNAL_TOPIC_REPLICAS`.
 
 ### ksql.sink.partitions (Deprecated)
@@ -233,7 +233,7 @@ For more info see the WITH clause properties in
 [CREATE TABLE AS SELECT](../../../developer-guide/ksqldb-reference/create-table-as-select.md).
 
 The corresponding environment variable in the
-[ksqlDB Server image](https://hub.docker.com/r/confluentinc/cp-ksql-server/) is
+[ksqlDB Server image](https://hub.docker.com/r/confluentinc/ksqldb-server/) is
 `KSQL_KSQL_SINK_PARTITIONS`.
 
 ### ksql.sink.replicas (Deprecated)
@@ -251,7 +251,7 @@ documentation in the [function](../../../developer-guide/ksqldb-reference/scalar
 guide for details.
 
 The corresponding environment variable in the
-[ksqlDB Server image](https://hub.docker.com/r/confluentinc/cp-ksql-server/)
+[ksqlDB Server image](https://hub.docker.com/r/confluentinc/ksqldb-server/)
 is `KSQL_KSQL_FUNCTIONS_SUBSTRING_LEGACY_ARGS`.
 
 ### ksql.persistence.wrap.single.values
@@ -349,7 +349,7 @@ For an example, see
 [Non-interactive (Headless) ksqlDB Usage](index.md#non-interactive-headless-ksqldb-usage).
 
 The corresponding environment variable in the
-[ksqlDB Server image](https://hub.docker.com/r/confluentinc/cp-ksql-server/)
+[ksqlDB Server image](https://hub.docker.com/r/confluentinc/ksqldb-server/)
 is `KSQL_KSQL_QUERIES_FILE`.
 
 ### listeners
@@ -378,7 +378,7 @@ You can configure ksqlDB Server to use HTTPS. For more information, see
 [Configure ksqlDB for HTTPS](security.md#configure-ksqldb-for-https).
 
 The corresponding environment variable in the
-[ksqlDB Server image](https://hub.docker.com/r/confluentinc/cp-ksql-server/)
+[ksqlDB Server image](https://hub.docker.com/r/confluentinc/ksqldb-server/)
 is `KSQL_LISTENERS`.
 
 ### ksql.metrics.tags.custom

--- a/docs-md/operate-and-deploy/installation/server-config/index.md
+++ b/docs-md/operate-and-deploy/installation/server-config/index.md
@@ -33,7 +33,7 @@ configuration file and override specific properties as needed, using the
 !!! tip
 	If you deploy {{ site.cp }} by using Docker containers, you can specify
     configuration parameters as environment variables to the
-    [ksqlDB Server image](https://hub.docker.com/r/confluentinc/cp-ksql-server/).
+    [ksqlDB Server image](https://hub.docker.com/r/confluentinc/ksqldb-server/).
     For more information, see
     [Install ksqlDB with Docker](../install-ksqldb-with-docker.md).
 

--- a/docs-md/operate-and-deploy/installation/server-config/security.md
+++ b/docs-md/operate-and-deploy/installation/server-config/security.md
@@ -804,28 +804,6 @@ Consumer groups
 	For more information about interactive and non-interactive queries, see
     [Non-interactive (Headless) ksqlDB Usage](index.md#non-interactive-headless-ksqldb-usage).
 
-#### Configure Control Center Monitoring Interceptors
-
-This configuration enables SASL and SSL for the [monitoring
-interceptors](https://docs.confluent.io/current/control-center/installation/clients.html)
-that integrate ksqlDB with {{ site.c3short }}.
-
-```properties
-# Confluent Monitoring Interceptors for Control Center streams monitoring
-producer.interceptor.classes=io.confluent.monitoring.clients.interceptor.MonitoringProducerInterceptor
-consumer.interceptor.classes=io.confluent.monitoring.clients.interceptor.MonitoringConsumerInterceptor
-
-# Confluent Monitoring interceptors SASL / SSL config
-confluent.monitoring.interceptor.security.protocol=SASL_SSL
-confluent.monitoring.interceptor.ssl.truststore.location=/etc/kafka/secrets/kafka.client.truststore.jks
-confluent.monitoring.interceptor.ssl.truststore.password=confluent
-confluent.monitoring.interceptor.ssl.keystore.location=/etc/kafka/secrets/kafka.client.keystore.jks
-confluent.monitoring.interceptor.ssl.keystore.password=confluent
-confluent.monitoring.interceptor.ssl.key.password=confluent
-confluent.monitoring.interceptor.sasl.jaas.config=org.apache.kafka.common.security.plain.PlainLoginModule required username="ksql-user" password="ksql-user-secret";
-confluent.monitoring.interceptor.sasl.mechanism=PLAIN
-```
-
 Next Steps
 ----------
 

--- a/docs-md/tutorials/basics-docker.md
+++ b/docs-md/tutorials/basics-docker.md
@@ -97,7 +97,7 @@ From the host machine, start ksqlDB CLI:
 ```bash
 docker run --network tutorials_default --rm --interactive --tty \
     confluentinc/ksqldb-cli:{{ site.release }} ksql \
-    http://ksqldb-server:8088
+    http://ksql-server:8088
 ```
 
 Your output should resemble:
@@ -116,7 +116,7 @@ Your output should resemble:
 
 Copyright 2017-2019 Confluent Inc.
 
-CLI v{{ site.release }}, Server v{{ site.release }} located at http://ksqldb-server:8088
+CLI v{{ site.release }}, Server v{{ site.release }} located at http://ksql-server:8088
 
 Having trouble? Type 'help' (case-insensitive) for a rundown of how things work!
 

--- a/docs-md/tutorials/basics-docker.md
+++ b/docs-md/tutorials/basics-docker.md
@@ -96,7 +96,7 @@ From the host machine, start ksqlDB CLI:
 
 ```bash
 docker run --network tutorials_default --rm --interactive --tty \
-    confluentinc/cp-ksql-cli:{{ site.release }} \
+    confluentinc/ksqldb-cli:{{ site.release }} \
     http://ksql-server:8088
 ```
 

--- a/docs-md/tutorials/basics-docker.md
+++ b/docs-md/tutorials/basics-docker.md
@@ -96,8 +96,8 @@ From the host machine, start ksqlDB CLI:
 
 ```bash
 docker run --network tutorials_default --rm --interactive --tty \
-    confluentinc/ksqldb-cli:{{ site.release }} \
-    http://ksql-server:8088
+    confluentinc/ksqldb-cli:{{ site.release }} ksql \
+    http://ksqldb-server:8088
 ```
 
 Your output should resemble:

--- a/docs-md/tutorials/basics-local.md
+++ b/docs-md/tutorials/basics-local.md
@@ -94,7 +94,7 @@ After KSQL is started, your terminal should resemble this.
 
 Copyright 2017-2019 Confluent Inc.
 
-CLI v{{ site.release }}, Server v{{ site.release }} located at http://ksqldb-server:8088
+CLI v{{ site.release }}, Server v{{ site.release }} located at http://localhost:8088
 
 Having trouble? Type 'help' (case-insensitive) for a rundown of how things work!
 

--- a/docs-md/tutorials/clickstream-docker.md
+++ b/docs-md/tutorials/clickstream-docker.md
@@ -166,7 +166,7 @@ Load the Streaming Data to KSQL
 1.  Launch the KSQL CLI:
 
     ```bash
-    docker-compose exec ksql-cli ksql http://ksqldb-server:8088
+    docker-compose exec ksql-cli ksql http://ksql-server:8088
     ```
 
     You should now be in the KSQL CLI.
@@ -185,7 +185,7 @@ Load the Streaming Data to KSQL
 
     Copyright 2017-2019 Confluent Inc.
 
-    CLI v{{ site.release }}, Server v{{ site.release }} located at http://ksqldb-server:8088
+    CLI v{{ site.release }}, Server v{{ site.release }} located at http://ksql-server:8088
 
     Having trouble? Type 'help' (case-insensitive) for a rundown of how things work!
 

--- a/docs-md/tutorials/clickstream-docker.md
+++ b/docs-md/tutorials/clickstream-docker.md
@@ -166,7 +166,7 @@ Load the Streaming Data to KSQL
 1.  Launch the KSQL CLI:
 
     ```bash
-    docker-compose exec ksql-cli ksql http://ksql-server:8088
+    docker-compose exec ksql-cli ksql http://ksqldb-server:8088
     ```
 
     You should now be in the KSQL CLI.


### PR DESCRIPTION
### Description 

Two docs changes:
- update references to `cp-ksql-server` and `cp-ksql-cli` docker images to `ksqldb-server` and `ksqldb-cli` instead, as `cp-ksql-server:0.6.0` and `cp-ksql-cli:0.6.0` don't exist
- remove docs on configuring monitoring interceptors with ksqlDB as ksqlDB docker images are not bundled with Confluent monitoring interceptors so the examples are broken (and confusing users, e.g., https://stackoverflow.com/questions/59214334/ksqldb-select-from-stream-results-in-io-confluent-monitoring-clients-interc)

### Testing done 

Docs-only change.

### Reviewer checklist
- [ ] Ensure docs are updated if necessary. (eg. if a user visible feature is being added or changed).
- [ ] Ensure relevant issues are linked (description should include text like "Fixes #<issue number>")

