### PR TITLE
feat: add connector status to LIST CONNECTORS

### DIFF
--- a/ksql-cli/src/main/java/io/confluent/ksql/cli/console/table/builder/ConnectorListTableBuilder.java
+++ b/ksql-cli/src/main/java/io/confluent/ksql/cli/console/table/builder/ConnectorListTableBuilder.java
@@ -25,7 +25,7 @@ import org.apache.kafka.connect.runtime.rest.entities.ConnectorType;
 public class ConnectorListTableBuilder implements TableBuilder<ConnectorList>  {
 
   private static final List<String> HEADERS = ImmutableList.of(
-      "Connector Name", "Type", "Class"
+      "Connector Name", "Type", "Class", "Status"
   );
 
 
@@ -38,7 +38,8 @@ public class ConnectorListTableBuilder implements TableBuilder<ConnectorList>  {
             .map(info -> ImmutableList.of(
                 info.getName(),
                 ObjectUtils.defaultIfNull(info.getType(), ConnectorType.UNKNOWN).name(),
-                ObjectUtils.defaultIfNull(info.getClassName(), ""))))
+                ObjectUtils.defaultIfNull(info.getClassName(), ""),
+                ObjectUtils.defaultIfNull(info.getState(), ""))))
         .build();
   }
 }

--- a/ksql-cli/src/test/java/io/confluent/ksql/cli/console/ConsoleTest.java
+++ b/ksql-cli/src/test/java/io/confluent/ksql/cli/console/ConsoleTest.java
@@ -840,8 +840,8 @@ public class ConsoleTest {
             "statement",
             ImmutableList.of(),
             ImmutableList.of(
-                new SimpleConnectorInfo("foo", ConnectorType.SOURCE, "clazz"),
-                new SimpleConnectorInfo("bar", null, null)
+                new SimpleConnectorInfo("foo", ConnectorType.SOURCE, "clazz", "STATUS"),
+                new SimpleConnectorInfo("bar", null, null, null)
         ))
     ));
 
@@ -859,18 +859,19 @@ public class ConsoleTest {
           + "  \"connectors\" : [ {\n"
           + "    \"name\" : \"foo\",\n"
           + "    \"type\" : \"source\",\n"
-          + "    \"className\" : \"clazz\"\n"
+          + "    \"className\" : \"clazz\",\n"
+          + "    \"state\" : \"STATUS\"\n"
           + "  }, {\n"
           + "    \"name\" : \"bar\"\n"
           + "  } ]\n"
           + "} ]\n"));
     } else {
       assertThat(output, is("\n"
-          + " Connector Name | Type    | Class \n"
-          + "----------------------------------\n"
-          + " foo            | SOURCE  | clazz \n"
-          + " bar            | UNKNOWN |       \n"
-          + "----------------------------------\n"));
+          + " Connector Name | Type    | Class | Status \n"
+          + "-------------------------------------------\n"
+          + " foo            | SOURCE  | clazz | STATUS \n"
+          + " bar            | UNKNOWN |       |        \n"
+          + "-------------------------------------------\n"));
     }
   }
 

--- a/ksql-rest-app/src/test/java/io/confluent/ksql/rest/server/ConnectIntegrationTest.java
+++ b/ksql-rest-app/src/test/java/io/confluent/ksql/rest/server/ConnectIntegrationTest.java
@@ -130,6 +130,9 @@ public class ConnectIntegrationTest {
     assertThat(
         ((ConnectorList) response.getResponse().get(0)).getConnectors().get(0).getName(),
         is("mock-connector"));
+    assertThat(
+        ((ConnectorList) response.getResponse().get(0)).getConnectors().get(0).getState(),
+        is("RUNNING (1/1 tasks RUNNING)"));
   }
 
   @Test

--- a/ksql-rest-model/src/main/java/io/confluent/ksql/rest/entity/SimpleConnectorInfo.java
+++ b/ksql-rest-model/src/main/java/io/confluent/ksql/rest/entity/SimpleConnectorInfo.java
@@ -32,16 +32,19 @@ public class SimpleConnectorInfo {
   private final String name;
   private final ConnectorType type;
   private final String className;
+  private final String state;
 
   @JsonCreator
   public SimpleConnectorInfo(
       @JsonProperty("name")       final String name,
       @JsonProperty("type")       final ConnectorType type,
-      @JsonProperty("className")  final String className
+      @JsonProperty("className")  final String className,
+      @JsonProperty("state")      final String state
   ) {
     this.name = Objects.requireNonNull(name, "name");
     this.type = type;
     this.className = className;
+    this.state = state;
   }
 
   public String getName() {
@@ -56,6 +59,10 @@ public class SimpleConnectorInfo {
     return className;
   }
 
+  public String getState() {
+    return state;
+  }
+
   @Override
   public boolean equals(final Object o) {
     if (this == o) {
@@ -67,12 +74,13 @@ public class SimpleConnectorInfo {
     final SimpleConnectorInfo that = (SimpleConnectorInfo) o;
     return Objects.equals(name, that.name)
         && type == that.type
-        && Objects.equals(className, that.className);
+        && Objects.equals(className, that.className)
+        && Objects.equals(state, that.state);
   }
 
   @Override
   public int hashCode() {
-    return Objects.hash(name, type, className);
+    return Objects.hash(name, type, className, state);
   }
 
   @Override
@@ -81,6 +89,7 @@ public class SimpleConnectorInfo {
         + "name='" + name + '\''
         + ", type=" + type
         + ", className='" + className + '\''
+        + ", state=" + state
         + '}';
   }
 }


### PR DESCRIPTION
fixes #3538 

### Description 

Often, it's nice to get a bird's eye view of what is going on with all of your connectors. This PR changes `LIST CONNECTORS` to show the status (whether or not it is running) as well as a quick summary of the task states (e.g. `RUNNING (1/2 tasks RUNNING)`)

### Testing done 

- Unit/Integration Tests
- `mvn clean install`

### Reviewer checklist
- [ ] Ensure docs are updated if necessary. (eg. if a user visible feature is being added or changed).
- [ ] Ensure relevant issues are linked (description should include text like "Fixes #<issue number>")

