### PR TITLE
fix: Explicitly disallow table functions with table sources, fixes #4033

### DIFF
--- a/ksql-functional-tests/src/test/resources/query-validation-tests/table-functions.json
+++ b/ksql-functional-tests/src/test/resources/query-validation-tests/table-functions.json
@@ -237,6 +237,17 @@
         {"topic": "OUTPUT", "key": "0", "value": {"F0": 2, "VAL": 8}},
         {"topic": "OUTPUT", "key": "0", "value": {"F0": 2, "VAL": 9}}
       ]
+    },
+    {
+      "name": "table functions don't support table sources",
+      "statements": [
+        "CREATE TABLE TEST (ID BIGINT, MY_ARR ARRAY<BIGINT>) WITH (kafka_topic='test_topic', KEY='ID', value_format='JSON');",
+        "CREATE TABLE OUTPUT AS SELECT ID, EXPLODE(MY_ARR) VAL FROM TEST;"
+      ],
+      "expectedException": {
+        "type": "io.confluent.ksql.util.KsqlException",
+        "message": "Table source is not supported with table functions"
+      }
     }
   ]
 }


### PR DESCRIPTION
### Description 

Explicitly disallows use of table sources with table functions.

Fixes https://github.com/confluentinc/ksql/issues/4033

### Testing done 

Added QTT test

### Reviewer checklist
- [ ] Ensure docs are updated if necessary. (eg. if a user visible feature is being added or changed).
- [ ] Ensure relevant issues are linked (description should include text like "Fixes #<issue number>")

