### PR TITLE
fix: UncaughtExceptionHandler not being set for Persistent Queries

### DIFF
--- a/ksql-engine/src/main/java/io/confluent/ksql/query/KafkaStreamsBuilderImpl.java
+++ b/ksql-engine/src/main/java/io/confluent/ksql/query/KafkaStreamsBuilderImpl.java
@@ -15,6 +15,7 @@
 
 package io.confluent.ksql.query;
 
+import io.confluent.ksql.util.KafkaStreamsUncaughtExceptionHandler;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Properties;
@@ -40,6 +41,7 @@ public class KafkaStreamsBuilderImpl implements KafkaStreamsBuilder {
     props.putAll(conf);
     final Topology topology = builder.build(props);
     final KafkaStreams kafkaStreams = new KafkaStreams(topology, props, clientSupplier);
+    kafkaStreams.setUncaughtExceptionHandler(new KafkaStreamsUncaughtExceptionHandler());
     return new BuildResult(topology, kafkaStreams);
   }
 }

--- a/ksql-engine/src/main/java/io/confluent/ksql/query/QueryExecutor.java
+++ b/ksql-engine/src/main/java/io/confluent/ksql/query/QueryExecutor.java
@@ -43,7 +43,6 @@ import io.confluent.ksql.schema.ksql.PhysicalSchema;
 import io.confluent.ksql.serde.GenericKeySerDe;
 import io.confluent.ksql.serde.KeyFormat;
 import io.confluent.ksql.services.ServiceContext;
-import io.confluent.ksql.util.KafkaStreamsUncaughtExceptionHandler;
 import io.confluent.ksql.util.KsqlConfig;
 import io.confluent.ksql.util.KsqlConstants;
 import io.confluent.ksql.util.KsqlException;
@@ -162,8 +161,6 @@ public final class QueryExecutor {
 
     final BuildResult built =
         kafkaStreamsBuilder.buildKafkaStreams(streamsBuilder, streamsProperties);
-
-    built.kafkaStreams.setUncaughtExceptionHandler(new KafkaStreamsUncaughtExceptionHandler());
 
     final LogicalSchema transientSchema = buildTransientQuerySchema(schema);
 


### PR DESCRIPTION
### Description 
Fixes https://github.com/confluentinc/ksql/issues/4079
It looks like from the original PR https://github.com/confluentinc/ksql/pull/3425/files to master, there was some refactoring done with how the Streams app is created which inadvertently changed the UncaughtExceptionHandler's behavior. The refactor changed https://github.com/confluentinc/ksql/pull/3425/files#diff-ef0765548f1131d562da8a8ef9edad73R285 was doing. The UncaughtExceptionHandler needs to be set for PersistentQueries (It's set in `QueryStreamWriter.java` for transient), which is why previously there's an explicit call in the `buildPlanForStructuredOutputNode` method (this was the pre-refactor method for creating PersistentQueries). The refactor resulted in `setUncaughtExceptionHandler()` being moved to the `buildTransientQuery` when it should've been moved to `buildQuery`
We need to be setting a exception handler for streams threads because they shouldn't pick up the global uncaught exception handler (which terminates the server when hit).

I've moved setting the handler to `KafkaStreamsBuilderImpl` which is called before creating every Streams App.

This may also need to be backported to 5.4.x as the refactor was before that branch was cut.

### Testing done 
Tried the scenario outlined in the Github Issue and the server didn't shut down after this change.
Also, manually verified in debug mode that the handlers were set for the streams threads.
![Screen Shot 2019-12-09 at 11 26 04 AM](https://user-images.githubusercontent.com/35498506/70466011-11c86e80-1a77-11ea-9a46-c62fc059a027.png)

### Reviewer checklist
- [ ] Ensure docs are updated if necessary. (eg. if a user visible feature is being added or changed).
- [ ] Ensure relevant issues are linked (description should include text like "Fixes #<issue number>")

