### PR TITLE
chore: primitive keys for simple queries

### DIFF
--- a/ksql-engine/src/main/java/io/confluent/ksql/ddl/commands/CreateSourceFactory.java
+++ b/ksql-engine/src/main/java/io/confluent/ksql/ddl/commands/CreateSourceFactory.java
@@ -36,7 +36,6 @@ import io.confluent.ksql.schema.ksql.ColumnRef;
 import io.confluent.ksql.schema.ksql.FormatOptions;
 import io.confluent.ksql.schema.ksql.LogicalSchema;
 import io.confluent.ksql.schema.ksql.PhysicalSchema;
-import io.confluent.ksql.schema.ksql.SqlBaseType;
 import io.confluent.ksql.serde.Format;
 import io.confluent.ksql.serde.GenericRowSerDe;
 import io.confluent.ksql.serde.SerdeOption;
@@ -178,12 +177,6 @@ public final class CreateSourceFactory {
         if (!isRowKey) {
           throw new KsqlException("'" + e.getName().name() + "' is an invalid KEY column name. "
               + "KSQL currently only supports KEY columns named ROWKEY.");
-        }
-
-        if (e.getType().getSqlType().baseType() != SqlBaseType.STRING) {
-          throw new KsqlException("'" + e.getName().name()
-              + "' is a KEY column with an unsupported type. "
-              + "KSQL currently only supports KEY columns of type " + SqlBaseType.STRING + ".");
         }
       } else if (isRowKey) {
         throw new KsqlException("'" + e.getName().name() + "' is a reserved column name. "

--- a/ksql-engine/src/main/java/io/confluent/ksql/planner/plan/AggregateNode.java
+++ b/ksql-engine/src/main/java/io/confluent/ksql/planner/plan/AggregateNode.java
@@ -34,6 +34,7 @@ import io.confluent.ksql.name.ColumnName;
 import io.confluent.ksql.parser.tree.WindowExpression;
 import io.confluent.ksql.schema.ksql.ColumnRef;
 import io.confluent.ksql.schema.ksql.LogicalSchema;
+import io.confluent.ksql.schema.ksql.SqlBaseType;
 import io.confluent.ksql.serde.ValueFormat;
 import io.confluent.ksql.services.KafkaTopicClient;
 import io.confluent.ksql.structured.SchemaKGroupedStream;
@@ -108,6 +109,10 @@ public class AggregateNode extends PlanNode {
     this.havingExpressions = havingExpressions;
     this.keyField = KeyField.of(requireNonNull(keyFieldName, "keyFieldName"))
         .validateKeyExistsIn(schema);
+
+    if (schema.key().get(0).type().baseType() != SqlBaseType.STRING) {
+      throw new KsqlException("GROUP BY is not supported with non-STRING keys");
+    }
   }
 
   @Override

--- a/ksql-engine/src/main/java/io/confluent/ksql/planner/plan/JoinNode.java
+++ b/ksql-engine/src/main/java/io/confluent/ksql/planner/plan/JoinNode.java
@@ -31,6 +31,7 @@ import io.confluent.ksql.schema.ksql.Column;
 import io.confluent.ksql.schema.ksql.ColumnRef;
 import io.confluent.ksql.schema.ksql.FormatOptions;
 import io.confluent.ksql.schema.ksql.LogicalSchema;
+import io.confluent.ksql.schema.ksql.SqlBaseType;
 import io.confluent.ksql.serde.ValueFormat;
 import io.confluent.ksql.services.KafkaTopicClient;
 import io.confluent.ksql.structured.SchemaKStream;
@@ -93,6 +94,10 @@ public class JoinNode extends PlanNode {
             : KeyField.of(leftKeyCol.ref());
 
     this.schema = JoinParamsFactory.createSchema(left.getSchema(), right.getSchema());
+
+    if (schema.key().get(0).type().baseType() != SqlBaseType.STRING) {
+      throw new KsqlException("GROUP BY is not supported with non-STRING keys");
+    }
   }
 
   @Override

--- a/ksql-engine/src/main/java/io/confluent/ksql/planner/plan/RepartitionNode.java
+++ b/ksql-engine/src/main/java/io/confluent/ksql/planner/plan/RepartitionNode.java
@@ -23,8 +23,10 @@ import io.confluent.ksql.execution.expression.tree.Expression;
 import io.confluent.ksql.execution.plan.SelectExpression;
 import io.confluent.ksql.metastore.model.KeyField;
 import io.confluent.ksql.schema.ksql.LogicalSchema;
+import io.confluent.ksql.schema.ksql.SqlBaseType;
 import io.confluent.ksql.services.KafkaTopicClient;
 import io.confluent.ksql.structured.SchemaKStream;
+import io.confluent.ksql.util.KsqlException;
 import java.util.List;
 import java.util.Objects;
 
@@ -45,6 +47,10 @@ public class RepartitionNode extends PlanNode {
     this.source = Objects.requireNonNull(source, "source");
     this.partitionBy = Objects.requireNonNull(partitionBy, "partitionBy");
     this.keyField = Objects.requireNonNull(keyField, "keyField");
+
+    if (source.getSchema().key().get(0).type().baseType() != SqlBaseType.STRING) {
+      throw new KsqlException("GROUP BY is not supported with non-STRING keys");
+    }
   }
 
   @Override

--- a/ksql-functional-tests/src/test/resources/query-validation-tests/key-schemas.json
+++ b/ksql-functional-tests/src/test/resources/query-validation-tests/key-schemas.json
@@ -73,13 +73,57 @@
       ]
     },
     {
-      "name": "explicit non-STRING ROWKEY",
+      "name": "stream explicit non-STRING ROWKEY",
       "statements": [
-        "CREATE STREAM INPUT (ROWKEY INT KEY, ID bigint) WITH (kafka_topic='input',value_format='JSON');"
+        "CREATE STREAM INPUT (ROWKEY INT KEY, ID bigint) WITH (kafka_topic='input',value_format='JSON');",
+        "CREATE STREAM OUTPUT as SELECT ID, ROWKEY as KEY FROM INPUT;"
       ],
-      "expectedException": {
-        "type": "io.confluent.ksql.util.KsqlStatementException",
-        "message": "'ROWKEY' is a KEY column with an unsupported type. KSQL currently only supports KEY columns of type STRING."
+      "inputs": [
+        {"topic": "input", "key": 3, "value": {"id": 1}},
+        {"topic": "input", "key": 2, "value": {"id": 2}},
+        {"topic": "input", "key": null, "value": {"id": 3}}
+      ],
+      "outputs": [
+        {"topic": "OUTPUT", "key": 3, "value": {"ID": 1, "KEY": 3}},
+        {"topic": "OUTPUT", "key": 2, "value": {"ID": 2, "KEY": 2}},
+        {"topic": "OUTPUT", "key": null, "value": {"ID": 3, "KEY": null}}
+      ],
+      "post": {
+        "sources": [
+          {
+            "name": "OUTPUT",
+            "type": "stream",
+            "keyFormat": {"format": "KAFKA"},
+            "schema": "ROWKEY INT KEY, ID BIGINT, KEY INT"
+          }
+        ]
+      }
+    },
+    {
+      "name": "table explicit non-STRING ROWKEY",
+      "statements": [
+        "CREATE TABLE INPUT (ROWKEY BIGINT KEY, ID bigint) WITH (kafka_topic='input',value_format='JSON');",
+        "CREATE TABLE OUTPUT as SELECT ID, ROWKEY as KEY FROM INPUT;"
+      ],
+      "inputs": [
+        {"topic": "input", "key": 3, "value": {"id": 1}},
+        {"topic": "input", "key": 2, "value": {"id": 2}},
+        {"topic": "input", "key": 1, "value": {"id": 3}}
+      ],
+      "outputs": [
+        {"topic": "OUTPUT", "key": 3, "value": {"ID": 1, "KEY": 3}},
+        {"topic": "OUTPUT", "key": 2, "value": {"ID": 2, "KEY": 2}},
+        {"topic": "OUTPUT", "key": 1, "value": {"ID": 3, "KEY": 1}}
+      ],
+      "post": {
+        "sources": [
+          {
+            "name": "OUTPUT",
+            "type": "table",
+            "keyFormat": {"format": "KAFKA"},
+            "schema": "ROWKEY BIGINT KEY, ID BIGINT, KEY BIGINT"
+          }
+        ]
       }
     },
     {

--- a/ksql-streams/src/main/java/io/confluent/ksql/execution/streams/SourceBuilder.java
+++ b/ksql-streams/src/main/java/io/confluent/ksql/execution/streams/SourceBuilder.java
@@ -267,7 +267,7 @@ public final class SourceBuilder {
       final AbstractStreamSource<?> streamSource,
       final KsqlQueryBuilder queryBuilder,
       final Consumed<K, GenericRow> consumed,
-      final Function<K, String> rowKeyGenerator
+      final Function<K, Object> rowKeyGenerator
   ) {
     KStream<K, GenericRow> stream = queryBuilder.getStreamsBuilder()
         .stream(streamSource.getTopicName(), consumed);
@@ -280,7 +280,7 @@ public final class SourceBuilder {
       final AbstractStreamSource<?> streamSource,
       final KsqlQueryBuilder queryBuilder,
       final Consumed<K, GenericRow> consumed,
-      final Function<K, String> rowKeyGenerator,
+      final Function<K, Object> rowKeyGenerator,
       final Materialized<K, GenericRow, KeyValueStore<Bytes, byte[]>> materialized
   ) {
     final KTable<K, GenericRow> table = queryBuilder.getStreamsBuilder()
@@ -344,7 +344,7 @@ public final class SourceBuilder {
     return StreamsUtil.buildOpName(stacker.push("Reduce").getQueryContext());
   }
 
-  private static Function<Windowed<Struct>, String> windowedRowKeyGenerator(
+  private static Function<Windowed<Struct>, Object> windowedRowKeyGenerator(
       final LogicalSchema schema
   ) {
     final org.apache.kafka.connect.data.Field keyField = getKeySchemaSingleField(schema);
@@ -362,7 +362,7 @@ public final class SourceBuilder {
     };
   }
 
-  private static Function<Struct, String> nonWindowedRowKeyGenerator(
+  private static Function<Struct, Object> nonWindowedRowKeyGenerator(
       final LogicalSchema schema
   ) {
     final org.apache.kafka.connect.data.Field keyField = getKeySchemaSingleField(schema);
@@ -371,19 +371,16 @@ public final class SourceBuilder {
         return null;
       }
 
-      final Object k = key.get(keyField);
-      return k == null
-          ? null
-          : k.toString();
+      return key.get(keyField);
     };
   }
 
   private static class AddKeyAndTimestampColumns<K>
       implements ValueTransformerWithKeySupplier<K, GenericRow, GenericRow> {
 
-    private final Function<K, String> rowKeyGenerator;
+    private final Function<K, Object> rowKeyGenerator;
 
-    AddKeyAndTimestampColumns(final Function<K, String> rowKeyGenerator) {
+    AddKeyAndTimestampColumns(final Function<K, Object> rowKeyGenerator) {
       this.rowKeyGenerator = requireNonNull(rowKeyGenerator, "rowKeyGenerator");
     }
 


### PR DESCRIPTION
### Description 

fixes: https://github.com/confluentinc/ksql/issues/3534

First of a few commits to start introducing support for primitive keys in different query types.

This commit opens the door for CT/CS statements with primitive keys, (`STRING`, `INT`, `BIGINT`, `BOOLEAN` and `DOUBLE`), and for using those sources in non-join, non-aggregate and non-partition-by queries.

### Testing done 

Example queries added to `key-schemas.json`, which is a good place to start reviewing.

### Reviewer checklist
- [ ] Ensure docs are updated if necessary. (eg. if a user visible feature is being added or changed).
- [ ] Ensure relevant issues are linked (description should include text like "Fixes #<issue number>")

