### PR TITLE
feat: implemention of KLIP-13

### DIFF
--- a/design-proposals/README.md
+++ b/design-proposals/README.md
@@ -53,7 +53,7 @@ Next KLIP number: **14**
 | [KLIP-10: Suppress](klip-10-suppress.md)                                           | Proposal       | N/A     |
 | [KLIP-11: Redesign KSQL query language](klip-11-DQL.md)                            | Proposal       | N/A     |
 | [KLIP-12: Implement High-Availability for Pull queries](klip-12-pull-high-availability.md)| Proposal       | N/A     |
-| [KLIP-13: Introduce KSQL command to print connect worker properties to the console](klip-13-introduce-KSQL-command-to-print-connect-worker-properties-to-the-console.md) | Proposal | N/A |
+| [KLIP-13: Introduce KSQL command to print connect worker properties to the console](klip-13-introduce-KSQL-command-to-print-connect-worker-properties-to-the-console.md) | Merged | 5.5 |
 | [KLIP-14: ROWTIME as Pseudocolumn](klip-14-rowtime-as-pseudocolumn.md)             | Approved       | N/A     |
 | [KLIP-15: KSQLDB new API and Client(klip-15-new-api-and-client.md                  | Proposal       | N/A     |
 | [KLIP-16: Introduce 'K$' dynamic views                                             | Proposal       | N/A     |

--- a/ksql-cli/src/main/java/io/confluent/ksql/cli/console/table/builder/PropertiesListTableBuilder.java
+++ b/ksql-cli/src/main/java/io/confluent/ksql/cli/console/table/builder/PropertiesListTableBuilder.java
@@ -19,6 +19,8 @@ import com.google.common.collect.ImmutableList;
 import io.confluent.ksql.cli.console.table.Table;
 import io.confluent.ksql.cli.console.table.Table.Builder;
 import io.confluent.ksql.rest.entity.PropertiesList;
+import io.confluent.ksql.rest.entity.PropertiesList.Property;
+
 import java.util.Comparator;
 import java.util.List;
 import java.util.Map.Entry;
@@ -29,7 +31,7 @@ import java.util.stream.Collectors;
 public class PropertiesListTableBuilder implements TableBuilder<PropertiesList> {
 
   private static final List<String> HEADERS =
-      ImmutableList.of("Property", "Default override", "Effective Value");
+      ImmutableList.of("Property", "Scope", "Default override", "Effective Value");
 
   @Override
   public Table buildTable(final PropertiesList entity) {
@@ -42,24 +44,25 @@ public class PropertiesListTableBuilder implements TableBuilder<PropertiesList> 
   private static List<List<String>> defRowValues(final List<PropertyDef> properties) {
     return properties.stream()
         .sorted(Comparator.comparing(propertyDef -> propertyDef.propertyName))
-        .map(
-            def -> ImmutableList.of(def.propertyName, def.overrideType, def.effectiveValue))
+        .map(def -> ImmutableList.of(
+            def.propertyName, def.scope, def.overrideType, def.effectiveValue))
         .collect(Collectors.toList());
   }
 
   private static List<PropertyDef> propertiesListWithOverrides(final PropertiesList properties) {
 
-    final Function<Entry<String, ?>, PropertyDef> toPropertyDef = e -> {
+    final Function<Entry<Property, ?>, PropertyDef> toPropertyDef = e -> {
       final String value = e.getValue() == null ? "NULL" : e.getValue().toString();
-      if (properties.getOverwrittenProperties().contains(e.getKey())) {
-        return new PropertyDef(e.getKey(), "SESSION", value);
+      Property key = e.getKey();
+      if (properties.getOverwrittenProperties().contains(key.getProperty())) {
+        return new PropertyDef(key.getProperty(), key.getScope(), "SESSION", value);
       }
 
-      if (properties.getDefaultProperties().contains(e.getKey())) {
-        return new PropertyDef(e.getKey(), "", value);
+      if (properties.getDefaultProperties().contains(key.getProperty())) {
+        return new PropertyDef(key.getProperty(), key.getScope(), "", value);
       }
 
-      return new PropertyDef(e.getKey(), "SERVER", value);
+      return new PropertyDef(key.getProperty(), key.getScope(), "SERVER", value);
     };
 
     return properties.getProperties().entrySet().stream()
@@ -70,14 +73,17 @@ public class PropertiesListTableBuilder implements TableBuilder<PropertiesList> 
   private static class PropertyDef {
 
     private final String propertyName;
+    private final String scope;
     private final String overrideType;
     private final String effectiveValue;
 
     PropertyDef(
         final String propertyName,
+        final String scope,
         final String overrideType,
         final String effectiveValue) {
       this.propertyName = Objects.requireNonNull(propertyName, "propertyName");
+      this.scope = Objects.requireNonNull(scope, "scope");
       this.overrideType = Objects.requireNonNull(overrideType, "overrideType");
       this.effectiveValue = Objects.requireNonNull(effectiveValue, "effectiveValue");
     }

--- a/ksql-cli/src/main/java/io/confluent/ksql/cli/console/table/builder/PropertiesListTableBuilder.java
+++ b/ksql-cli/src/main/java/io/confluent/ksql/cli/console/table/builder/PropertiesListTableBuilder.java
@@ -23,7 +23,6 @@ import io.confluent.ksql.rest.entity.PropertiesList.Property;
 
 import java.util.Comparator;
 import java.util.List;
-import java.util.Map.Entry;
 import java.util.Objects;
 import java.util.function.Function;
 import java.util.stream.Collectors;
@@ -51,21 +50,22 @@ public class PropertiesListTableBuilder implements TableBuilder<PropertiesList> 
 
   private static List<PropertyDef> propertiesListWithOverrides(final PropertiesList properties) {
 
-    final Function<Entry<Property, ?>, PropertyDef> toPropertyDef = e -> {
-      final String value = e.getValue() == null ? "NULL" : e.getValue().toString();
-      Property key = e.getKey();
-      if (properties.getOverwrittenProperties().contains(key.getProperty())) {
-        return new PropertyDef(key.getProperty(), key.getScope(), "SESSION", value);
+    final Function<Property, PropertyDef> toPropertyDef = property -> {
+      final String value = property.getValue() == null ? "NULL" : property.getValue();
+      final String name = property.getName();
+      final String scope = property.getScope();
+      if (properties.getOverwrittenProperties().contains(name)) {
+        return new PropertyDef(name, scope, "SESSION", value);
       }
 
-      if (properties.getDefaultProperties().contains(key.getProperty())) {
-        return new PropertyDef(key.getProperty(), key.getScope(), "", value);
+      if (properties.getDefaultProperties().contains(name)) {
+        return new PropertyDef(name, scope, "", value);
       }
 
-      return new PropertyDef(key.getProperty(), key.getScope(), "SERVER", value);
+      return new PropertyDef(name, scope, "SERVER", value);
     };
 
-    return properties.getProperties().entrySet().stream()
+    return properties.getProperties().stream()
         .map(toPropertyDef)
         .collect(Collectors.toList());
   }

--- a/ksql-cli/src/test/java/io/confluent/ksql/cli/CliTest.java
+++ b/ksql-cli/src/test/java/io/confluent/ksql/cli/CliTest.java
@@ -443,17 +443,20 @@ public class CliTest {
         // SERVER OVERRIDES:
         row(
             KsqlConfig.KSQL_STREAMS_PREFIX + StreamsConfig.NUM_STREAM_THREADS_CONFIG,
+            "KSQL",
             SERVER_OVERRIDE,
             "4"
         ),
         row(
             KsqlConfig.SINK_WINDOW_CHANGE_LOG_ADDITIONAL_RETENTION_MS_PROPERTY,
+            "KSQL",
             SERVER_OVERRIDE,
             "" + (KsqlConstants.defaultSinkWindowChangeLogAdditionalRetention + 1)
         ),
         // SESSION OVERRIDES:
         row(
             KsqlConfig.KSQL_STREAMS_PREFIX + ConsumerConfig.AUTO_OFFSET_RESET_CONFIG,
+            "KSQL",
             SESSION_OVERRIDE,
             "latest"
         )

--- a/ksql-cli/src/test/java/io/confluent/ksql/cli/console/ConsoleTest.java
+++ b/ksql-cli/src/test/java/io/confluent/ksql/cli/console/ConsoleTest.java
@@ -56,6 +56,7 @@ import io.confluent.ksql.rest.entity.KsqlEntity;
 import io.confluent.ksql.rest.entity.KsqlEntityList;
 import io.confluent.ksql.rest.entity.KsqlWarning;
 import io.confluent.ksql.rest.entity.PropertiesList;
+import io.confluent.ksql.rest.entity.PropertiesList.Property;
 import io.confluent.ksql.rest.entity.Queries;
 import io.confluent.ksql.rest.entity.RunningQuery;
 import io.confluent.ksql.rest.entity.SchemaInfo;
@@ -233,10 +234,10 @@ public class ConsoleTest {
   @Test
   public void testPrintPropertyList() {
     // Given:
-    final Map<String, Object> properties = new HashMap<>();
-    properties.put("k1", 1);
-    properties.put("k2", "v2");
-    properties.put("k3", true);
+    final Map<Property, Object> properties = new HashMap<>();
+    properties.put(new Property("k1", "KSQL"), 1);
+    properties.put(new Property("k2", "KSQL"), "v2");
+    properties.put(new Property("k3", "KSQL"), true);
 
     final KsqlEntityList entityList = new KsqlEntityList(ImmutableList.of(
         new PropertiesList("e", properties, Collections.emptyList(), Collections.emptyList())
@@ -252,9 +253,9 @@ public class ConsoleTest {
           + "  \"@type\" : \"properties\",\n"
           + "  \"statementText\" : \"e\",\n"
           + "  \"properties\" : {\n"
-          + "    \"k1\" : 1,\n"
-          + "    \"k2\" : \"v2\",\n"
-          + "    \"k3\" : true\n"
+          + "    \"k3-KSQL\" : true,\n"
+          + "    \"k2-KSQL\" : \"v2\",\n"
+          + "    \"k1-KSQL\" : 1\n"
           + "  },\n"
           + "  \"overwrittenProperties\" : [ ],\n"
           + "  \"defaultProperties\" : [ ],\n"
@@ -262,12 +263,12 @@ public class ConsoleTest {
           + "} ]\n"));
     } else {
       assertThat(output, is("\n"
-          + " Property | Default override | Effective Value \n"
-          + "-----------------------------------------------\n"
-          + " k1       | SERVER           | 1               \n"
-          + " k2       | SERVER           | v2              \n"
-          + " k3       | SERVER           | true            \n"
-          + "-----------------------------------------------\n"));
+          + " Property | Scope | Default override | Effective Value \n"
+          + "-------------------------------------------------------\n"
+          + " k1       | KSQL  | SERVER           | 1               \n"
+          + " k2       | KSQL  | SERVER           | v2              \n"
+          + " k3       | KSQL  | SERVER           | true            \n"
+          + "-------------------------------------------------------\n"));
     }
   }
 

--- a/ksql-cli/src/test/java/io/confluent/ksql/cli/console/ConsoleTest.java
+++ b/ksql-cli/src/test/java/io/confluent/ksql/cli/console/ConsoleTest.java
@@ -79,9 +79,7 @@ import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
-import java.util.HashMap;
 import java.util.List;
-import java.util.Map;
 import java.util.function.Supplier;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.kafka.connect.runtime.rest.entities.ConnectorStateInfo;
@@ -234,10 +232,10 @@ public class ConsoleTest {
   @Test
   public void testPrintPropertyList() {
     // Given:
-    final Map<Property, Object> properties = new HashMap<>();
-    properties.put(new Property("k1", "KSQL"), 1);
-    properties.put(new Property("k2", "KSQL"), "v2");
-    properties.put(new Property("k3", "KSQL"), true);
+    final List<Property> properties = new ArrayList<>();
+    properties.add(new Property("k1", "KSQL", "1"));
+    properties.add(new Property("k2", "KSQL", "v2"));
+    properties.add(new Property("k3", "KSQL", "true"));
 
     final KsqlEntityList entityList = new KsqlEntityList(ImmutableList.of(
         new PropertiesList("e", properties, Collections.emptyList(), Collections.emptyList())
@@ -252,11 +250,19 @@ public class ConsoleTest {
       assertThat(output, is("[ {\n"
           + "  \"@type\" : \"properties\",\n"
           + "  \"statementText\" : \"e\",\n"
-          + "  \"properties\" : {\n"
-          + "    \"k3-KSQL\" : true,\n"
-          + "    \"k2-KSQL\" : \"v2\",\n"
-          + "    \"k1-KSQL\" : 1\n"
-          + "  },\n"
+          + "  \"properties\" : [ {\n"
+          + "    \"name\" : \"k1\",\n"
+          + "    \"scope\" : \"KSQL\",\n"
+          + "    \"value\" : \"1\"\n"
+          + "  }, {\n"
+          + "    \"name\" : \"k2\",\n"
+          + "    \"scope\" : \"KSQL\",\n"
+          + "    \"value\" : \"v2\"\n"
+          + "  }, {\n"
+          + "    \"name\" : \"k3\",\n"
+          + "    \"scope\" : \"KSQL\",\n"
+          + "    \"value\" : \"true\"\n"
+          + "  } ],\n"
           + "  \"overwrittenProperties\" : [ ],\n"
           + "  \"defaultProperties\" : [ ],\n"
           + "  \"warnings\" : [ ]\n"

--- a/ksql-cli/src/test/java/io/confluent/ksql/cli/console/table/builder/PropertiesListTableBuilderTest.java
+++ b/ksql-cli/src/test/java/io/confluent/ksql/cli/console/table/builder/PropertiesListTableBuilderTest.java
@@ -22,7 +22,6 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import com.google.common.collect.ImmutableList;
-import com.google.common.collect.ImmutableMap;
 import io.confluent.ksql.cli.console.Console;
 import io.confluent.ksql.cli.console.table.Table;
 import io.confluent.ksql.rest.entity.PropertiesList;
@@ -62,7 +61,7 @@ public class PropertiesListTableBuilderTest {
   public void shouldHandleClientOverwrittenProperties() {
     // Given:
     final PropertiesList propList = new PropertiesList("list properties;",
-        ImmutableMap.of(new Property(SOME_KEY, "KSQL"), "earliest"),
+        ImmutableList.of(new Property(SOME_KEY, "KSQL", "earliest")),
         ImmutableList.of(SOME_KEY),
         Collections.emptyList()
     );
@@ -78,7 +77,7 @@ public class PropertiesListTableBuilderTest {
   public void shouldHandleServerOverwrittenProperties() {
     // Given:
     final PropertiesList propList = new PropertiesList("list properties;",
-        ImmutableMap.of(new Property(SOME_KEY, "KSQL"), "earliest"),
+        ImmutableList.of(new Property(SOME_KEY, "KSQL", "earliest")),
         Collections.emptyList(),
         Collections.emptyList()
     );
@@ -94,7 +93,7 @@ public class PropertiesListTableBuilderTest {
   public void shouldHandleDefaultProperties() {
     // Given:
     final PropertiesList propList = new PropertiesList("list properties;",
-        ImmutableMap.of(new Property(SOME_KEY, "KSQL"), "earliest"),
+        ImmutableList.of(new Property(SOME_KEY, "KSQL", "earliest")),
         Collections.emptyList(),
         ImmutableList.of(SOME_KEY)
     );
@@ -110,7 +109,7 @@ public class PropertiesListTableBuilderTest {
   public void shouldHandlePropertiesWithNullValue() {
     // Given:
     final PropertiesList propList = new PropertiesList("list properties;",
-        Collections.singletonMap(new Property(SOME_KEY, "KSQL"), null),
+        Collections.singletonList(new Property(SOME_KEY, "KSQL", null)),
         Collections.emptyList(),
         ImmutableList.of(SOME_KEY)
     );

--- a/ksql-cli/src/test/java/io/confluent/ksql/cli/console/table/builder/PropertiesListTableBuilderTest.java
+++ b/ksql-cli/src/test/java/io/confluent/ksql/cli/console/table/builder/PropertiesListTableBuilderTest.java
@@ -26,6 +26,7 @@ import com.google.common.collect.ImmutableMap;
 import io.confluent.ksql.cli.console.Console;
 import io.confluent.ksql.cli.console.table.Table;
 import io.confluent.ksql.rest.entity.PropertiesList;
+import io.confluent.ksql.rest.entity.PropertiesList.Property;
 import io.confluent.ksql.util.KsqlConfig;
 import java.io.PrintWriter;
 import java.util.Collections;
@@ -61,7 +62,7 @@ public class PropertiesListTableBuilderTest {
   public void shouldHandleClientOverwrittenProperties() {
     // Given:
     final PropertiesList propList = new PropertiesList("list properties;",
-        ImmutableMap.of(SOME_KEY, "earliest"),
+        ImmutableMap.of(new Property(SOME_KEY, "KSQL"), "earliest"),
         ImmutableList.of(SOME_KEY),
         Collections.emptyList()
     );
@@ -70,14 +71,14 @@ public class PropertiesListTableBuilderTest {
     final Table table = builder.buildTable(propList);
 
     // Then:
-    assertThat(getRows(table), contains(row(SOME_KEY, "SESSION", "earliest")));
+    assertThat(getRows(table), contains(row(SOME_KEY, "KSQL", "SESSION", "earliest")));
   }
 
   @Test
   public void shouldHandleServerOverwrittenProperties() {
     // Given:
     final PropertiesList propList = new PropertiesList("list properties;",
-        ImmutableMap.of(SOME_KEY, "earliest"),
+        ImmutableMap.of(new Property(SOME_KEY, "KSQL"), "earliest"),
         Collections.emptyList(),
         Collections.emptyList()
     );
@@ -86,14 +87,14 @@ public class PropertiesListTableBuilderTest {
     final Table table = builder.buildTable(propList);
 
     // Then:
-    assertThat(getRows(table), contains(row(SOME_KEY, "SERVER", "earliest")));
+    assertThat(getRows(table), contains(row(SOME_KEY, "KSQL", "SERVER", "earliest")));
   }
 
   @Test
   public void shouldHandleDefaultProperties() {
     // Given:
     final PropertiesList propList = new PropertiesList("list properties;",
-        ImmutableMap.of(SOME_KEY, "earliest"),
+        ImmutableMap.of(new Property(SOME_KEY, "KSQL"), "earliest"),
         Collections.emptyList(),
         ImmutableList.of(SOME_KEY)
     );
@@ -102,14 +103,14 @@ public class PropertiesListTableBuilderTest {
     final Table table = builder.buildTable(propList);
 
     // Then:
-    assertThat(getRows(table), contains(row(SOME_KEY, "", "earliest")));
+    assertThat(getRows(table), contains(row(SOME_KEY, "KSQL", "", "earliest")));
   }
 
   @Test
   public void shouldHandlePropertiesWithNullValue() {
     // Given:
     final PropertiesList propList = new PropertiesList("list properties;",
-        Collections.singletonMap(SOME_KEY, null),
+        Collections.singletonMap(new Property(SOME_KEY, "KSQL"), null),
         Collections.emptyList(),
         ImmutableList.of(SOME_KEY)
     );
@@ -118,7 +119,7 @@ public class PropertiesListTableBuilderTest {
     final Table table = builder.buildTable(propList);
 
     // Then:
-    assertThat(getRows(table), contains(row(SOME_KEY, "", "NULL")));
+    assertThat(getRows(table), contains(row(SOME_KEY, "KSQL", "", "NULL")));
   }
 
   private List<List<String>> getRows(final Table table) {
@@ -130,9 +131,10 @@ public class PropertiesListTableBuilderTest {
   @SuppressWarnings("SameParameterValue")
   private static List<String> row(
       final String property,
+      final String scope,
       final String defaultValue,
       final String actualValue
   ) {
-    return ImmutableList.of(property, defaultValue, actualValue);
+    return ImmutableList.of(property, scope, defaultValue, actualValue);
   }
 }

--- a/ksql-rest-app/src/test/java/io/confluent/ksql/rest/server/execution/ListPropertiesExecutorTest.java
+++ b/ksql-rest-app/src/test/java/io/confluent/ksql/rest/server/execution/ListPropertiesExecutorTest.java
@@ -17,9 +17,9 @@ package io.confluent.ksql.rest.server.execution;
 
 import static org.hamcrest.CoreMatchers.hasItem;
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.contains;
 import static org.hamcrest.Matchers.empty;
 import static org.hamcrest.Matchers.equalTo;
-import static org.hamcrest.Matchers.hasEntry;
 import static org.hamcrest.Matchers.hasKey;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.isIn;
@@ -27,6 +27,7 @@ import static org.hamcrest.Matchers.not;
 
 import com.google.common.collect.ImmutableMap;
 import io.confluent.ksql.rest.entity.PropertiesList;
+import io.confluent.ksql.rest.entity.PropertiesList.Property;
 import io.confluent.ksql.rest.server.TemporaryEngine;
 import io.confluent.ksql.util.KsqlConfig;
 import org.junit.Rule;
@@ -34,7 +35,6 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.junit.MockitoJUnitRunner;
 
-import java.util.Map;
 import java.util.stream.Collectors;
 
 @RunWith(MockitoJUnitRunner.class)
@@ -71,7 +71,7 @@ public class ListPropertiesExecutorTest {
 
     // Then:
     assertThat(properties.getProperties(),
-        hasEntry("ksql.streams.auto.offset.reset", "latest"));
+        contains(new Property("ksql.streams.auto.offset.reset", "KSQL", "latest")));
     assertThat(properties.getOverwrittenProperties(), hasItem("ksql.streams.auto.offset.reset"));
   }
 
@@ -86,8 +86,8 @@ public class ListPropertiesExecutorTest {
     ).orElseThrow(IllegalStateException::new);
 
     // Then:
-    assertThat(properties.getProperties().entrySet().stream().collect(
-        Collectors.toMap(e -> e.getKey().getProperty(), Map.Entry::getValue)),
+    assertThat(properties.getProperties().stream().collect(
+        Collectors.toMap(Property::getName, Property::getValue)),
                not(hasKey(isIn(KsqlConfig.SSL_CONFIG_NAMES))));
   }
 

--- a/ksql-rest-app/src/test/java/io/confluent/ksql/rest/server/execution/ListPropertiesExecutorTest.java
+++ b/ksql-rest-app/src/test/java/io/confluent/ksql/rest/server/execution/ListPropertiesExecutorTest.java
@@ -34,6 +34,9 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.junit.MockitoJUnitRunner;
 
+import java.util.Map;
+import java.util.stream.Collectors;
+
 @RunWith(MockitoJUnitRunner.class)
 public class ListPropertiesExecutorTest {
 
@@ -83,7 +86,9 @@ public class ListPropertiesExecutorTest {
     ).orElseThrow(IllegalStateException::new);
 
     // Then:
-    assertThat(properties.getProperties(), not(hasKey(isIn(KsqlConfig.SSL_CONFIG_NAMES))));
+    assertThat(properties.getProperties().entrySet().stream().collect(
+        Collectors.toMap(e -> e.getKey().getProperty(), Map.Entry::getValue)),
+               not(hasKey(isIn(KsqlConfig.SSL_CONFIG_NAMES))));
   }
 
 

--- a/ksql-rest-app/src/test/java/io/confluent/ksql/rest/server/execution/ListPropertiesExecutorTest.java
+++ b/ksql-rest-app/src/test/java/io/confluent/ksql/rest/server/execution/ListPropertiesExecutorTest.java
@@ -17,7 +17,6 @@ package io.confluent.ksql.rest.server.execution;
 
 import static org.hamcrest.CoreMatchers.hasItem;
 import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.Matchers.contains;
 import static org.hamcrest.Matchers.empty;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.hasKey;
@@ -35,7 +34,8 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.junit.MockitoJUnitRunner;
 
-import java.util.stream.Collectors;
+import java.util.HashMap;
+import java.util.Map;
 
 @RunWith(MockitoJUnitRunner.class)
 public class ListPropertiesExecutorTest {
@@ -53,9 +53,18 @@ public class ListPropertiesExecutorTest {
     ).orElseThrow(IllegalStateException::new);
 
     // Then:
-    assertThat(properties.getProperties(),
+    assertThat(
+        toMap(properties),
         equalTo(engine.getKsqlConfig().getAllConfigPropsWithSecretsObfuscated()));
     assertThat(properties.getOverwrittenProperties(), is(empty()));
+  }
+
+  private Map<String, String> toMap(PropertiesList properties) {
+    Map<String, String> map = new HashMap<>();
+    for (Property property : properties.getProperties()) {
+      map.put(property.getName(), property.getValue());
+    }
+    return map;
   }
 
   @Test
@@ -70,8 +79,9 @@ public class ListPropertiesExecutorTest {
     ).orElseThrow(IllegalStateException::new);
 
     // Then:
-    assertThat(properties.getProperties(),
-        contains(new Property("ksql.streams.auto.offset.reset", "KSQL", "latest")));
+    assertThat(
+        properties.getProperties(),
+        hasItem(new Property("ksql.streams.auto.offset.reset", "KSQL", "latest")));
     assertThat(properties.getOverwrittenProperties(), hasItem("ksql.streams.auto.offset.reset"));
   }
 
@@ -86,10 +96,8 @@ public class ListPropertiesExecutorTest {
     ).orElseThrow(IllegalStateException::new);
 
     // Then:
-    assertThat(properties.getProperties().stream().collect(
-        Collectors.toMap(Property::getName, Property::getValue)),
-               not(hasKey(isIn(KsqlConfig.SSL_CONFIG_NAMES))));
+    assertThat(
+        toMap(properties),
+        not(hasKey(isIn(KsqlConfig.SSL_CONFIG_NAMES))));
   }
-
-
 }

--- a/ksql-rest-app/src/test/java/io/confluent/ksql/rest/server/resources/KsqlResourceTest.java
+++ b/ksql-rest-app/src/test/java/io/confluent/ksql/rest/server/resources/KsqlResourceTest.java
@@ -1500,8 +1500,8 @@ public class KsqlResourceTest {
 
     // Then:
     assertThat(
-        props.getProperties().get(new Property("ksql.streams.auto.offset.reset", "KSQL")),
-        is("latest"));
+        props.getProperties(),
+        hasItem(new Property("ksql.streams.auto.offset.reset", "KSQL", "latest")));
     assertThat(props.getOverwrittenProperties(), hasItem("ksql.streams.auto.offset.reset"));
   }
 
@@ -1646,7 +1646,7 @@ public class KsqlResourceTest {
     final PropertiesList props = makeSingleRequest("list properties;", PropertiesList.class);
 
     // Then:
-    assertThat(props.getProperties().keySet().stream().map(Property::getProperty).collect(
+    assertThat(props.getProperties().stream().map(Property::getName).collect(
         Collectors.toList()),
         not(hasItems(KsqlConfig.SSL_CONFIG_NAMES.toArray(new String[0]))));
   }

--- a/ksql-rest-app/src/test/java/io/confluent/ksql/rest/server/resources/KsqlResourceTest.java
+++ b/ksql-rest-app/src/test/java/io/confluent/ksql/rest/server/resources/KsqlResourceTest.java
@@ -100,6 +100,7 @@ import io.confluent.ksql.rest.entity.KsqlErrorMessage;
 import io.confluent.ksql.rest.entity.KsqlRequest;
 import io.confluent.ksql.rest.entity.KsqlStatementErrorMessage;
 import io.confluent.ksql.rest.entity.PropertiesList;
+import io.confluent.ksql.rest.entity.PropertiesList.Property;
 import io.confluent.ksql.rest.entity.Queries;
 import io.confluent.ksql.rest.entity.QueryDescription;
 import io.confluent.ksql.rest.entity.QueryDescriptionEntity;
@@ -1498,7 +1499,9 @@ public class KsqlResourceTest {
         new KsqlRequest("list properties;", overrides, null), PropertiesList.class);
 
     // Then:
-    assertThat(props.getProperties().get("ksql.streams.auto.offset.reset"), is("latest"));
+    assertThat(
+        props.getProperties().get(new Property("ksql.streams.auto.offset.reset", "KSQL")),
+        is("latest"));
     assertThat(props.getOverwrittenProperties(), hasItem("ksql.streams.auto.offset.reset"));
   }
 
@@ -1643,7 +1646,8 @@ public class KsqlResourceTest {
     final PropertiesList props = makeSingleRequest("list properties;", PropertiesList.class);
 
     // Then:
-    assertThat(props.getProperties().keySet(),
+    assertThat(props.getProperties().keySet().stream().map(Property::getProperty).collect(
+        Collectors.toList()),
         not(hasItems(KsqlConfig.SSL_CONFIG_NAMES.toArray(new String[0]))));
   }
 

--- a/ksql-rest-model/src/main/java/io/confluent/ksql/rest/entity/PropertiesList.java
+++ b/ksql-rest-model/src/main/java/io/confluent/ksql/rest/entity/PropertiesList.java
@@ -18,42 +18,40 @@ package io.confluent.ksql.rest.entity;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
-import com.fasterxml.jackson.core.JsonGenerator;
-import com.fasterxml.jackson.databind.DeserializationContext;
-import com.fasterxml.jackson.databind.JsonSerializer;
-import com.fasterxml.jackson.databind.KeyDeserializer;
-import com.fasterxml.jackson.databind.SerializerProvider;
-import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
-import com.fasterxml.jackson.databind.annotation.JsonSerialize;
 
-import java.io.IOException;
 import java.util.Collections;
 import java.util.List;
-import java.util.Map;
 import java.util.Objects;
 
 @JsonIgnoreProperties(ignoreUnknown = true)
 public class PropertiesList extends KsqlEntity {
   @JsonIgnoreProperties(ignoreUnknown = true)
   public static class Property {
-    private final String property;
+    private final String name;
     private final String scope;
+    private final String value;
 
     @JsonCreator
     public Property(
-        @JsonProperty("property") final String property,
-        @JsonProperty("scope") final String scope
+        @JsonProperty("name") final String name,
+        @JsonProperty("scope") final String scope,
+        @JsonProperty("value") final String value
     ) {
-      this.property = property;
+      this.name = name;
       this.scope = scope;
+      this.value = value;
     }
 
-    public String getProperty() {
-      return property;
+    public String getName() {
+      return name;
     }
 
     public String getScope() {
       return scope;
+    }
+
+    public String getValue() {
+      return value;
     }
 
     @Override
@@ -65,57 +63,47 @@ public class PropertiesList extends KsqlEntity {
         return false;
       }
       Property that = (Property) object;
-      return Objects.equals(property, that.property)
-          && Objects.equals(scope, that.scope);
+      return Objects.equals(name, that.name)
+          && Objects.equals(scope, that.scope)
+          && Objects.equals(value, that.value);
     }
 
     @Override
     public int hashCode() {
-      return Objects.hash(property, scope);
+      return Objects.hash(name, scope, value);
     }
-  }
-
-  private static class PropertySerializer extends JsonSerializer<Property> {
 
     @Override
-    public void serialize(
-        Property value, JsonGenerator generator, SerializerProvider serializers)
-        throws IOException {
-      generator.writeFieldName(value.property + '-' + value.scope);
+    public String toString() {
+      return "Property{" +
+          "name='" + name + '\'' +
+          ", scope='" + scope + '\'' +
+          ", value='" + value + '\'' +
+          '}';
     }
   }
 
-  private static class PropertyDeserializer extends KeyDeserializer {
-    @Override
-    public Property deserializeKey(String key, DeserializationContext ctxt) throws IOException {
-      String[] value = key.split("-");
-      return new Property(value[0], value[1]);
-    }
-  }
-
-  private final Map<Property, ?> properties;
+  private final List<Property> properties;
   private final List<String> overwrittenProperties;
   private final List<String> defaultProperties;
 
   @JsonCreator
   public PropertiesList(
       @JsonProperty("statementText") final String statementText,
-      @JsonSerialize(keyUsing = PropertySerializer.class)
-      @JsonDeserialize(keyUsing = PropertyDeserializer.class)
-      @JsonProperty("properties") final Map<Property, ?> properties,
+      @JsonProperty("properties") final List<Property> properties,
       @JsonProperty("overwrittenProperties") final List<String> overwrittenProperties,
       @JsonProperty("defaultProperties") final List<String> defaultProperties
   ) {
     super(statementText);
     this.properties = properties == null
-        ? Collections.emptyMap() : properties;
+        ? Collections.emptyList() : properties;
     this.overwrittenProperties = overwrittenProperties == null
         ? Collections.emptyList() : overwrittenProperties;
     this.defaultProperties = defaultProperties == null
         ? Collections.emptyList() : defaultProperties;
   }
 
-  public Map<Property, ?> getProperties() {
+  public List<Property> getProperties() {
     return properties;
   }
 

--- a/ksql-rest-model/src/main/java/io/confluent/ksql/rest/entity/PropertiesList.java
+++ b/ksql-rest-model/src/main/java/io/confluent/ksql/rest/entity/PropertiesList.java
@@ -75,11 +75,11 @@ public class PropertiesList extends KsqlEntity {
 
     @Override
     public String toString() {
-      return "Property{" +
-          "name='" + name + '\'' +
-          ", scope='" + scope + '\'' +
-          ", value='" + value + '\'' +
-          '}';
+      return "Property{"
+          + "name='" + name + '\''
+          + ", scope='" + scope + '\''
+          + ", value='" + value + '\''
+          + '}';
     }
   }
 


### PR DESCRIPTION
### Description 
Implementation of KLIP-13 Introduce KSQL command to print connect worker properties to the console

`(LIST|SHOW) PROPERTIES` command is extended to print embedded connect worker properties

### Testing done 
N/A
Do we need integration test that touch file system to read connect worker properties file, or it would be better hide the fact that its properties come from file system?
Edited:
This is how it looks in the terminal on my machine
```
ksql> SHOW PROPERTIES;

 Property                                               | Default override | Effective Value
-------------------------------------------------------------------------------------------------------------------------------------------------------------------------
 bootstrap.servers                                      | SESSION          | localhost:9092
 config.storage.replication.factor                      | SESSION          | 1
 config.storage.topic                                   | SESSION          | ksql-connect-configs
 group.id                                               | SESSION          | ksql-connect-cluster
 internal.key.converter                                 | SESSION          | org.apache.kafka.connect.json.JsonConverter
 internal.key.converter.schemas.enable                  | SESSION          | false
 internal.value.converter                               | SESSION          | org.apache.kafka.connect.json.JsonConverter
 key.converter                                          | SESSION          | io.confluent.connect.avro.AvroConverter
 key.converter.schema.registry.url                      | SESSION          | http://localhost:8081
 ksql.access.validator.enable                           |                  | auto
 ksql.connect.url                                       |                  | http://localhost:8083
 ksql.connect.worker.config                             | SERVER           | config/connect.properties
 ksql.extension.dir                                     |                  | ext
 ksql.insert.into.values.enabled                        |                  | true
 ksql.internal.topic.min.insync.replicas                |                  | 1
 ksql.internal.topic.replicas                           |                  | 1
 ksql.metric.reporters                                  |                  |
 ksql.metrics.extension                                 |                  | NULL
 ksql.metrics.tags.custom                               |                  |
 ksql.output.topic.name.prefix                          |                  |
 ksql.persistence.wrap.single.values                    |                  | true
 ksql.persistent.prefix                                 |                  | query_
 ksql.pull.queries.enable                               |                  | true
 ksql.query.persistent.active.limit                     |                  | 2147483647
 ksql.query.pull.routing.timeout.ms                     |                  | 30000
 ksql.query.pull.skip.access.validator                  |                  | false
 ksql.query.pull.streamsstore.rebalancing.timeout.ms    |                  | 10000
 ksql.schema.registry.url                               |                  | http://localhost:8081
 ksql.security.extension.class                          |                  | NULL
 ksql.service.id                                        |                  | default_
 ksql.sink.window.change.log.additional.retention       |                  | 1000000
 ksql.streams.application.server                        | SERVER           | http://localhost:8088
 ksql.streams.bootstrap.servers                         | SERVER           | localhost:9092
 ksql.streams.cache.max.bytes.buffering                 | SERVER           | 10000000
 ksql.streams.commit.interval.ms                        | SERVER           | 2000
 ksql.streams.default.deserialization.exception.handler | SERVER           | io.confluent.ksql.errors.LogMetricAndContinueExceptionHandler
 ksql.streams.default.production.exception.handler      | SERVER           | io.confluent.ksql.errors.ProductionExceptionHandlerUtil$LogAndFailProductionExceptionHandler
 ksql.streams.num.stream.threads                        | SERVER           | 4
 ksql.streams.topology.optimization                     | SERVER           | all
 ksql.transient.prefix                                  |                  | transient_
 ksql.udf.collect.metrics                               |                  | false
 ksql.udf.enable.security.manager                       |                  | true
 ksql.udfs.enabled                                      |                  | true
 offset.storage.replication.factor                      | SESSION          | 1
 offset.storage.topic                                   | SESSION          | ksql-connect-offsets
 status.storage.replication.factor                      | SESSION          | 1
 status.storage.topic                                   | SESSION          | ksql-connect-statuses
 value.converter                                        | SESSION          | io.confluent.connect.avro.AvroConverter
 value.converter.schema.registry.url                    | SESSION          | http://localhost:8081
-------------------------------------------------------------------------------------------------------------------------------------------------------------------------
```

### Documentation
I couldn't find the documentation part that should be changed. Is there another repo for that part?

### Reviewer checklist
- [ ] Ensure docs are updated if necessary. (eg. if a user visible feature is being added or changed).
- [ ] Ensure relevant issues are linked (description should include text like "Fixes #<issue number>")

