### PR TITLE
chore: Update KafkaStreams.close to take a duration parameter

### DIFF
--- a/ksql-common/src/main/java/io/confluent/ksql/util/KsqlConfig.java
+++ b/ksql-common/src/main/java/io/confluent/ksql/util/KsqlConfig.java
@@ -187,6 +187,13 @@ public class KsqlConfig extends AbstractConfig {
   public static final Collection<CompatibilityBreakingConfigDef> COMPATIBLY_BREAKING_CONFIG_DEFS
       = ImmutableList.of();
 
+  public static final String KSQL_SHUTDOWN_TIMEOUT_MS_CONFIG =
+      "ksql.streams.shutdown.timeout.ms";
+  public static final Long KSQL_SHUTDOWN_TIMEOUT_MS_DEFAULT = 300_000L;
+  public static final String KSQL_SHUTDOWN_TIMEOUT_MS_DOC = "Timeout in "
+      + "milliseconds to block waiting for the underlying streams instance to exit";
+
+
   private enum ConfigGeneration {
     LEGACY,
     CURRENT
@@ -499,6 +506,12 @@ public class KsqlConfig extends AbstractConfig {
             KSQL_ACTIVE_PERSISTENT_QUERY_LIMIT_DEFAULT,
             Importance.MEDIUM,
             KSQL_ACTIVE_PERSISTENT_QUERY_LIMIT_DOC
+        ).define(
+            KSQL_SHUTDOWN_TIMEOUT_MS_CONFIG,
+            Type.LONG,
+            KSQL_SHUTDOWN_TIMEOUT_MS_DEFAULT,
+            Importance.MEDIUM,
+            KSQL_SHUTDOWN_TIMEOUT_MS_DOC
         )
         .withClientSslSupport();
 

--- a/ksql-engine/src/main/java/io/confluent/ksql/query/QueryExecutor.java
+++ b/ksql-engine/src/main/java/io/confluent/ksql/query/QueryExecutor.java
@@ -15,6 +15,8 @@
 
 package io.confluent.ksql.query;
 
+import static io.confluent.ksql.util.KsqlConfig.KSQL_SHUTDOWN_TIMEOUT_MS_CONFIG;
+
 import io.confluent.ksql.GenericRow;
 import io.confluent.ksql.errors.ProductionExceptionHandlerUtil;
 import io.confluent.ksql.execution.builder.KsqlQueryBuilder;
@@ -179,8 +181,8 @@ public final class QueryExecutor {
         built.topology,
         streamsProperties,
         overrides,
-        queryCloseCallback
-    );
+        queryCloseCallback,
+        ksqlConfig.getLong(KSQL_SHUTDOWN_TIMEOUT_MS_CONFIG));
   }
 
   private static Optional<MaterializationInfo> getMaterializationInfo(final Object result) {
@@ -240,8 +242,8 @@ public final class QueryExecutor {
         ksqlQueryBuilder.getSchemas(),
         streamsProperties,
         overrides,
-        queryCloseCallback
-    );
+        queryCloseCallback,
+        ksqlConfig.getLong(KSQL_SHUTDOWN_TIMEOUT_MS_CONFIG));
   }
 
   private TransientQueryQueue buildTransientQueryQueue(

--- a/ksql-engine/src/main/java/io/confluent/ksql/util/PersistentQueryMetadata.java
+++ b/ksql-engine/src/main/java/io/confluent/ksql/util/PersistentQueryMetadata.java
@@ -63,8 +63,8 @@ public class PersistentQueryMetadata extends QueryMetadata {
       final QuerySchemas schemas,
       final Map<String, Object> streamsProperties,
       final Map<String, Object> overriddenProperties,
-      final Consumer<QueryMetadata> closeCallback
-  ) {
+      final Consumer<QueryMetadata> closeCallback,
+      final Long closeTimeout) {
     // CHECKSTYLE_RULES.ON: ParameterNumberCheck
     super(
         statementString,
@@ -76,7 +76,8 @@ public class PersistentQueryMetadata extends QueryMetadata {
         topology,
         streamsProperties,
         overriddenProperties,
-        closeCallback);
+        closeCallback,
+        closeTimeout);
 
     this.id = requireNonNull(id, "id");
     this.resultTopic = requireNonNull(resultTopic, "resultTopic");

--- a/ksql-engine/src/main/java/io/confluent/ksql/util/QueryMetadata.java
+++ b/ksql-engine/src/main/java/io/confluent/ksql/util/QueryMetadata.java
@@ -45,6 +45,7 @@ public class QueryMetadata {
   private final Consumer<QueryMetadata> closeCallback;
   private final Set<SourceName> sourceNames;
   private final LogicalSchema logicalSchema;
+  private final Long closeTimeout;
 
   private Optional<QueryStateListener> queryStateListener = Optional.empty();
   private boolean everStarted = false;
@@ -60,8 +61,8 @@ public class QueryMetadata {
       final Topology topology,
       final Map<String, Object> streamsProperties,
       final Map<String, Object> overriddenProperties,
-      final Consumer<QueryMetadata> closeCallback
-  ) {
+      final Consumer<QueryMetadata> closeCallback,
+      final Long closeTimeout) {
     // CHECKSTYLE_RULES.ON: ParameterNumberCheck
     this.statementString = Objects.requireNonNull(statementString, "statementString");
     this.kafkaStreams = Objects.requireNonNull(kafkaStreams, "kafkaStreams");
@@ -77,6 +78,7 @@ public class QueryMetadata {
     this.closeCallback = Objects.requireNonNull(closeCallback, "closeCallback");
     this.sourceNames = Objects.requireNonNull(sourceNames, "sourceNames");
     this.logicalSchema = Objects.requireNonNull(logicalSchema, "logicalSchema");
+    this.closeTimeout = Objects.requireNonNull(closeTimeout, "closeTimeout");
   }
 
   protected QueryMetadata(final QueryMetadata other, final Consumer<QueryMetadata> closeCallback) {
@@ -90,6 +92,7 @@ public class QueryMetadata {
     this.sourceNames = other.sourceNames;
     this.logicalSchema = other.logicalSchema;
     this.closeCallback = Objects.requireNonNull(closeCallback, "closeCallback");
+    this.closeTimeout = other.closeTimeout;
   }
 
   public void registerQueryStateListener(final QueryStateListener queryStateListener) {
@@ -142,9 +145,7 @@ public class QueryMetadata {
   }
 
   public void close() {
-    int closeWaitDuration = Integer.parseInt(
-        streamsProperties.getOrDefault("close.wait", "60").toString());
-    kafkaStreams.close(Duration.ofSeconds(closeWaitDuration));
+    kafkaStreams.close(Duration.ofMillis(closeTimeout));
 
     kafkaStreams.cleanUp();
 

--- a/ksql-engine/src/main/java/io/confluent/ksql/util/QueryMetadata.java
+++ b/ksql-engine/src/main/java/io/confluent/ksql/util/QueryMetadata.java
@@ -20,6 +20,7 @@ import io.confluent.ksql.internal.QueryStateListener;
 import io.confluent.ksql.name.SourceName;
 import io.confluent.ksql.schema.ksql.LogicalSchema;
 import java.lang.Thread.UncaughtExceptionHandler;
+import java.time.Duration;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
@@ -141,7 +142,9 @@ public class QueryMetadata {
   }
 
   public void close() {
-    kafkaStreams.close();
+    int closeWaitDuration = Integer.parseInt(
+        streamsProperties.getOrDefault("close.wait", "60").toString());
+    kafkaStreams.close(Duration.ofSeconds(closeWaitDuration));
 
     kafkaStreams.cleanUp();
 

--- a/ksql-engine/src/main/java/io/confluent/ksql/util/TransientQueryMetadata.java
+++ b/ksql-engine/src/main/java/io/confluent/ksql/util/TransientQueryMetadata.java
@@ -51,7 +51,8 @@ public class TransientQueryMetadata extends QueryMetadata {
       final Topology topology,
       final Map<String, Object> streamsProperties,
       final Map<String, Object> overriddenProperties,
-      final Consumer<QueryMetadata> closeCallback) {
+      final Consumer<QueryMetadata> closeCallback,
+      final Long closeTimeout) {
     // CHECKSTYLE_RULES.ON: ParameterNumberCheck
     super(
         statementString,
@@ -63,8 +64,8 @@ public class TransientQueryMetadata extends QueryMetadata {
         topology,
         streamsProperties,
         overriddenProperties,
-        closeCallback
-    );
+        closeCallback,
+        closeTimeout);
     this.limitHandlerSetter = Objects.requireNonNull(limitHandlerSetter, "limitHandlerSetter");
     this.rowQueue = Objects.requireNonNull(rowQueue, "rowQueue");
 

--- a/ksql-engine/src/test/java/io/confluent/ksql/util/QueryMetadataTest.java
+++ b/ksql-engine/src/test/java/io/confluent/ksql/util/QueryMetadataTest.java
@@ -18,6 +18,10 @@ package io.confluent.ksql.util;
 import static io.confluent.ksql.metastore.model.DataSource.DataSourceType;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyByte;
+import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.Mockito.inOrder;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
@@ -28,6 +32,7 @@ import io.confluent.ksql.name.ColumnName;
 import io.confluent.ksql.name.SourceName;
 import io.confluent.ksql.schema.ksql.LogicalSchema;
 import io.confluent.ksql.schema.ksql.types.SqlTypes;
+import java.time.Duration;
 import java.util.Collections;
 import java.util.Set;
 import java.util.function.Consumer;
@@ -131,7 +136,7 @@ public class QueryMetadataTest {
 
     // Then:
     final InOrder inOrder = inOrder(kafkaStreams, closeCallback);
-    inOrder.verify(kafkaStreams).close();
+    inOrder.verify(kafkaStreams).close(any(Duration.class));
     inOrder.verify(closeCallback).accept(query);
   }
 
@@ -142,7 +147,7 @@ public class QueryMetadataTest {
 
     // Then:
     final InOrder inOrder = inOrder(kafkaStreams);
-    inOrder.verify(kafkaStreams).close();
+    inOrder.verify(kafkaStreams).close(any(Duration.class));
     inOrder.verify(kafkaStreams).cleanUp();
   }
 

--- a/ksql-engine/src/test/java/io/confluent/ksql/util/QueryMetadataTest.java
+++ b/ksql-engine/src/test/java/io/confluent/ksql/util/QueryMetadataTest.java
@@ -15,13 +15,8 @@
 
 package io.confluent.ksql.util;
 
-import static io.confluent.ksql.metastore.model.DataSource.DataSourceType;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
-import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.anyByte;
-import static org.mockito.ArgumentMatchers.anyInt;
-import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.Mockito.inOrder;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
@@ -54,6 +49,7 @@ public class QueryMetadataTest {
       .valueColumn(ColumnName.of("f0"), SqlTypes.STRING)
       .build();
   private static final Set<SourceName> SOME_SOURCES = ImmutableSet.of(SourceName.of("s1"), SourceName.of("s2"));
+  private static final Long closeTimeout = KsqlConfig.KSQL_SHUTDOWN_TIMEOUT_MS_DEFAULT;
 
   @Mock
   private Topology topoplogy;
@@ -77,8 +73,8 @@ public class QueryMetadataTest {
         topoplogy,
         Collections.emptyMap(),
         Collections.emptyMap(),
-        closeCallback
-    );
+        closeCallback,
+        closeTimeout);
   }
 
   @Test
@@ -136,7 +132,7 @@ public class QueryMetadataTest {
 
     // Then:
     final InOrder inOrder = inOrder(kafkaStreams, closeCallback);
-    inOrder.verify(kafkaStreams).close(any(Duration.class));
+    inOrder.verify(kafkaStreams).close(Duration.ofMillis(closeTimeout));
     inOrder.verify(closeCallback).accept(query);
   }
 
@@ -147,7 +143,7 @@ public class QueryMetadataTest {
 
     // Then:
     final InOrder inOrder = inOrder(kafkaStreams);
-    inOrder.verify(kafkaStreams).close(any(Duration.class));
+    inOrder.verify(kafkaStreams).close(Duration.ofMillis(closeTimeout));
     inOrder.verify(kafkaStreams).cleanUp();
   }
 

--- a/ksql-rest-app/src/test/java/io/confluent/ksql/rest/entity/QueryDescriptionFactoryTest.java
+++ b/ksql-rest-app/src/test/java/io/confluent/ksql/rest/entity/QueryDescriptionFactoryTest.java
@@ -33,6 +33,7 @@ import io.confluent.ksql.schema.ksql.PhysicalSchema;
 import io.confluent.ksql.schema.ksql.SqlBaseType;
 import io.confluent.ksql.schema.ksql.types.SqlTypes;
 import io.confluent.ksql.serde.SerdeOption;
+import io.confluent.ksql.util.KsqlConfig;
 import io.confluent.ksql.util.PersistentQueryMetadata;
 import io.confluent.ksql.util.QueryMetadata;
 import io.confluent.ksql.util.QuerySchemas;
@@ -74,6 +75,7 @@ public class QueryDescriptionFactoryTest {
   private static final ImmutableSet<SourceName> SOURCE_NAMES = ImmutableSet.of(SourceName.of("s1"), SourceName.of("s2"));
   private static final String SQL_TEXT = "test statement";
   private static final String TOPOLOGY_TEXT = "Topology Text";
+  private static final Long closeTimeout = KsqlConfig.KSQL_SHUTDOWN_TIMEOUT_MS_DEFAULT;
 
   @Mock
   private Consumer<QueryMetadata> queryCloseCallback;
@@ -108,7 +110,8 @@ public class QueryDescriptionFactoryTest {
         topology,
         STREAMS_PROPS,
         PROP_OVERRIDES,
-        queryCloseCallback);
+        queryCloseCallback,
+        closeTimeout);
 
     transientQueryDescription = QueryDescriptionFactory.forQueryMetadata(transientQuery);
 
@@ -128,7 +131,8 @@ public class QueryDescriptionFactoryTest {
         QuerySchemas.of(new LinkedHashMap<>()),
         STREAMS_PROPS,
         PROP_OVERRIDES,
-        queryCloseCallback);
+        queryCloseCallback,
+        closeTimeout);
 
     persistentQueryDescription = QueryDescriptionFactory.forQueryMetadata(persistentQuery);
   }
@@ -221,7 +225,8 @@ public class QueryDescriptionFactoryTest {
         topology,
         STREAMS_PROPS,
         PROP_OVERRIDES,
-        queryCloseCallback);
+        queryCloseCallback,
+        closeTimeout);
 
     // When:
     transientQueryDescription = QueryDescriptionFactory.forQueryMetadata(transientQuery);
@@ -255,7 +260,8 @@ public class QueryDescriptionFactoryTest {
         topology,
         STREAMS_PROPS,
         PROP_OVERRIDES,
-        queryCloseCallback);
+        queryCloseCallback,
+        closeTimeout);
 
     // When:
     transientQueryDescription = QueryDescriptionFactory.forQueryMetadata(transientQuery);

--- a/ksql-rest-app/src/test/java/io/confluent/ksql/rest/server/resources/streaming/StreamedQueryResourceTest.java
+++ b/ksql-rest-app/src/test/java/io/confluent/ksql/rest/server/resources/streaming/StreamedQueryResourceTest.java
@@ -26,6 +26,7 @@ import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.not;
 import static org.junit.Assert.assertEquals;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyInt;
 import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.doThrow;
@@ -451,7 +452,7 @@ public class StreamedQueryResourceTest {
     verify(mockKafkaStreams).start();
     verify(mockKafkaStreams).setUncaughtExceptionHandler(any());
     verify(mockKafkaStreams).cleanUp();
-    verify(mockKafkaStreams).close();
+    verify(mockKafkaStreams).close(any(Duration.class));
 
     // If one of the other threads has somehow managed to throw an exception without breaking things up until this
     // point, we throw that exception now in the main thread and cause the test to fail


### PR DESCRIPTION
### Description 
Updated `QueryMetadata#close` method to use `KafkaStreams#close(Duration.ofXXX)` vs. the no-arg version.  When calling `KafkaStreams#close()` the default timeout is set to `Long.MAX_VALUE` so the `close` call will block forever.

### Testing done 
Updated the existing tests

### Reviewer checklist
- [ ] Ensure docs are updated if necessary. (eg. if a user visible feature is being added or changed).
- [ ] Ensure relevant issues are linked (description should include text like "Fixes #<issue number>")

