### PR TITLE
chore: the KsqlJsonDeserializer no longer guarantees ordering (MINOR)

### DIFF
--- a/ksql-functional-tests/src/test/resources/query-validation-tests/simple-struct.json
+++ b/ksql-functional-tests/src/test/resources/query-validation-tests/simple-struct.json
@@ -590,7 +590,7 @@
           "topic": "S1",
           "timestamp": 0,
           "value": {
-            "ITEMID": "{\"CATEGORY\":{\"ID\":2,\"NAME\":\"Food\"},\"ITEMID\":6,\"NAME\":\"Item_6\"}",
+            "ITEMID": "{\"ITEMID\":6,\"CATEGORY\":{\"ID\":2,\"NAME\":\"Food\"},\"NAME\":\"Item_6\"}",
             "KSQL_COL_1": "6"
           },
           "key": "0"
@@ -599,7 +599,7 @@
           "topic": "S1",
           "timestamp": 0,
           "value": {
-            "ITEMID": "{\"CATEGORY\":{\"ID\":2,\"NAME\":\"Produce\"},\"ITEMID\":6,\"NAME\":\"Item_6\"}",
+            "ITEMID": "{\"ITEMID\":6,\"CATEGORY\":{\"ID\":2,\"NAME\":\"Produce\"},\"NAME\":\"Item_6\"}",
             "KSQL_COL_1": "6"
           },
           "key": "100"
@@ -608,7 +608,7 @@
           "topic": "S1",
           "timestamp": 0,
           "value": {
-            "ITEMID": "{\"CATEGORY\":{\"ID\":2,\"NAME\":\"Produce\"},\"ITEMID\":6,\"NAME\":\"Item_6\"}",
+            "ITEMID": "{\"ITEMID\":6,\"CATEGORY\":{\"ID\":2,\"NAME\":\"Produce\"},\"NAME\":\"Item_6\"}",
             "KSQL_COL_1": "6"
           },
           "key": "101"
@@ -617,7 +617,7 @@
           "topic": "S1",
           "timestamp": 0,
           "value": {
-            "ITEMID": "{\"CATEGORY\":{\"ID\":1,\"NAME\":\"Food\"},\"ITEMID\":2,\"NAME\":\"Item_2\"}",
+            "ITEMID": "{\"ITEMID\":2,\"CATEGORY\":{\"ID\":1,\"NAME\":\"Food\"},\"NAME\":\"Item_2\"}",
             "KSQL_COL_1": "2"
           },
           "key": "101"
@@ -626,7 +626,7 @@
           "topic": "S1",
           "timestamp": 0,
           "value": {
-            "ITEMID":  "{\"CATEGORY\":{\"ID\":1,\"NAME\":\"Produce\"},\"ITEMID\":5,\"NAME\":\"Item_5\"}",
+            "ITEMID":  "{\"ITEMID\":5,\"CATEGORY\":{\"ID\":1,\"NAME\":\"Produce\"},\"NAME\":\"Item_5\"}",
             "KSQL_COL_1": "5"
           },
           "key": "101"

--- a/ksql-serde/src/main/java/io/confluent/ksql/serde/json/KsqlJsonDeserializer.java
+++ b/ksql-serde/src/main/java/io/confluent/ksql/serde/json/KsqlJsonDeserializer.java
@@ -19,7 +19,6 @@ import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.DeserializationFeature;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
-import com.fasterxml.jackson.databind.SerializationFeature;
 import com.fasterxml.jackson.databind.node.ArrayNode;
 import com.fasterxml.jackson.databind.node.NullNode;
 import com.fasterxml.jackson.databind.node.NumericNode;
@@ -60,8 +59,6 @@ public class KsqlJsonDeserializer implements Deserializer<Object> {
   private static final SqlSchemaFormatter FORMATTER = new SqlSchemaFormatter(word -> false);
   private static final ObjectMapper MAPPER = new ObjectMapper()
       .enable(DeserializationFeature.USE_BIG_DECIMAL_FOR_FLOATS);
-  private static final ObjectMapper SORTED_MAPPER = new ObjectMapper()
-      .enable(SerializationFeature.ORDER_MAP_ENTRIES_BY_KEYS);
 
   private static final Map<Schema.Type, Function<JsonValueContext, Object>> HANDLERS = ImmutableMap
       .<Schema.Type, Function<JsonValueContext, Object>>builder()
@@ -139,12 +136,7 @@ public class KsqlJsonDeserializer implements Deserializer<Object> {
   private static String processString(final JsonValueContext context) {
     if (context.val instanceof ObjectNode) {
       try {
-        // this ensure sorted order, there's an issue with Jackson where just enabling
-        // SORT_PROPERTIES_ALPHABETICALLY does not work if it is not a POJO-backed
-        // JSON object
-        return SORTED_MAPPER.writeValueAsString(
-            SORTED_MAPPER.treeToValue(context.val, Object.class)
-        );
+        return MAPPER.writeValueAsString(MAPPER.treeToValue(context.val, Object.class));
       } catch (JsonProcessingException e) {
         throw new KsqlException("Unexpected inability to write value as string: " + context.val);
       }


### PR DESCRIPTION
fixes #3664

### Description 
The JSON standard does not guarantee ordering and it is inefficient to do the sort. This is a small optimization in that regard.

### Testing done 

- `mvn clean install`

### Reviewer checklist
- [ ] Ensure docs are updated if necessary. (eg. if a user visible feature is being added or changed).
- [ ] Ensure relevant issues are linked (description should include text like "Fixes #<issue number>")

