### PR TITLE
fix: headless server no longer throws NPE on null configs

### DIFF
--- a/ksql-rest-app/src/main/java/io/confluent/ksql/rest/server/StandaloneExecutor.java
+++ b/ksql-rest-app/src/main/java/io/confluent/ksql/rest/server/StandaloneExecutor.java
@@ -15,6 +15,7 @@
 
 package io.confluent.ksql.rest.server;
 
+import static java.util.Objects.nonNull;
 import static java.util.Objects.requireNonNull;
 
 import com.google.common.collect.ImmutableMap;
@@ -118,7 +119,11 @@ public class StandaloneExecutor implements Executable {
       processesQueryFile(readQueriesFile(queriesFile));
       showWelcomeMessage();
       final Properties properties = new Properties();
-      ksqlConfig.originals().forEach((key, value) -> properties.put(key, value.toString()));
+      ksqlConfig.originals().forEach((key, value) -> {
+        if (nonNull(value)) {
+          properties.put(key, value.toString());
+        }
+      });
       versionChecker.start(KsqlModuleType.SERVER, properties);
     } catch (final Exception e) {
       log.error("Failed to start KSQL Server with query file: " + queriesFile, e);

--- a/ksql-rest-app/src/test/java/io/confluent/ksql/rest/server/StandaloneExecutorTest.java
+++ b/ksql-rest-app/src/test/java/io/confluent/ksql/rest/server/StandaloneExecutorTest.java
@@ -83,6 +83,7 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
 import java.util.OptionalInt;
@@ -338,6 +339,25 @@ public class StandaloneExecutorTest {
 
     // Then:
     verify(ksqlEngine).parse("This statement");
+  }
+
+
+  @Test
+  public void shouldNotThrowIfNullValueInKsqlConfig() {
+    standaloneExecutor = new StandaloneExecutor(
+        serviceContext,
+        processingLogConfig,
+        new KsqlConfig(Collections.singletonMap("test", null)),
+        ksqlEngine,
+        queriesFile.toString(),
+        udfLoader,
+        false,
+        versionChecker,
+        injectorFactory
+    );
+
+    // When:
+    standaloneExecutor.startAsync();
   }
 
   @Test


### PR DESCRIPTION
### Description 
Fixes https://github.com/confluentinc/ksql/issues/4114
Cause: https://github.com/confluentinc/ksql/issues/4114#issuecomment-564769317

This other commit already fixes the problem by removing the config that was being set to null anyways.
https://github.com/confluentinc/ksql/commit/289324117070123a8b4ab686774b6a409b8a5e09#diff-7848c43dbebc7bc8c45c12b2c1e2689cR247

This fix should still go in to prevent something like this from breaking headless mode again. Keys can't be null because the KsqlConfig would throw an exception if they weren't so we only need to check value.

### Testing done 
Spun up headless mode
Added a unit test
### Reviewer checklist
- [ ] Ensure docs are updated if necessary. (eg. if a user visible feature is being added or changed).
- [ ] Ensure relevant issues are linked (description should include text like "Fixes #<issue number>")

