### PR TITLE
feat: add support for inline struct creation

### DIFF
--- a/docs-md/developer-guide/syntax-reference.md
+++ b/docs-md/developer-guide/syntax-reference.md
@@ -281,12 +281,6 @@ statement by using the syntax `STRUCT<FieldName FieldType, ...>`. For
 example, `STRUCT<ID BIGINT, NAME STRING, AGE INT>` defines a struct with
 three fields, with the supplied name and type.
 
-You can create a struct in a query by specifying the names of the columns
-and expressions that construct the values, separated by `,` and wrapped with
-curly braces. For example: `SELECT {name col0, ageInDogYears col1*7} AS dogs FROM animals`
-would create a schema `col0 STRUCT<VARCHAR, INTEGER>` (assuming `col0` was a string and
-`col1` was an integer).
-
 Access the fields of a struct by using the `->` operator. For example,
 `SOME_STRUCT->ID` retrieves the value of the struct's `ID` field. For
 more information, see [Operators](#operators).

--- a/docs-md/developer-guide/syntax-reference.md
+++ b/docs-md/developer-guide/syntax-reference.md
@@ -281,6 +281,12 @@ statement by using the syntax `STRUCT<FieldName FieldType, ...>`. For
 example, `STRUCT<ID BIGINT, NAME STRING, AGE INT>` defines a struct with
 three fields, with the supplied name and type.
 
+You can create a struct in a query by specifying the names of the columns
+and expressions that construct the values, separated by `,` and wrapped with
+curly braces. For example: `SELECT {name col0, ageInDogYears col1*7} AS dogs FROM animals`
+would create a schema `col0 STRUCT<VARCHAR, INTEGER>` (assuming `col0` was a string and
+`col1` was an integer).
+
 Access the fields of a struct by using the `->` operator. For example,
 `SOME_STRUCT->ID` retrieves the value of the struct's `ID` field. For
 more information, see [Operators](#operators).

--- a/docs/developer-guide/syntax-reference.rst
+++ b/docs/developer-guide/syntax-reference.rst
@@ -71,6 +71,13 @@ encapsulate a street address and a postal code:
      orderId BIGINT,
      address STRUCT<street VARCHAR, zip INTEGER>) WITH (...);
 
+
+You can create a struct in a query by specifying the names of the columns
+and expressions that construct the values, separated by ``,`` and wrapped with
+curly braces. For example: ``SELECT {name col0, ageInDogYears col1*7} AS dogs FROM animals``
+creates a schema ``col0 STRUCT<VARCHAR, INTEGER>``, assuming ``col0`` was a string and
+``col1`` was an integer.
+
 Access the fields in a ``STRUCT`` by using the dereference operator (``->``):
 
 .. code:: sql

--- a/docs/developer-guide/syntax-reference.rst
+++ b/docs/developer-guide/syntax-reference.rst
@@ -74,7 +74,7 @@ encapsulate a street address and a postal code:
 
 You can create a struct in a query by specifying the names of the columns
 and expressions that construct the values, separated by ``,`` and wrapped with
-curly braces. For example: ``SELECT STRUCT(col0 AS name, col1*7 as ageInDogYears) AS dogs FROM animals``
+curly braces. For example: ``SELECT STRUCT(name := col0, ageInDogYears := col1*7) AS dogs FROM animals``
 creates a schema ``col0 STRUCT<name VARCHAR, ageInDogYears INTEGER>``, assuming ``col0`` was a string and
 ``col1`` was an integer.
 

--- a/docs/developer-guide/syntax-reference.rst
+++ b/docs/developer-guide/syntax-reference.rst
@@ -74,8 +74,8 @@ encapsulate a street address and a postal code:
 
 You can create a struct in a query by specifying the names of the columns
 and expressions that construct the values, separated by ``,`` and wrapped with
-curly braces. For example: ``SELECT {name col0, ageInDogYears col1*7} AS dogs FROM animals``
-creates a schema ``col0 STRUCT<VARCHAR, INTEGER>``, assuming ``col0`` was a string and
+curly braces. For example: ``SELECT STRUCT(col0 AS name, col1*7 as ageInDogYears) AS dogs FROM animals``
+creates a schema ``col0 STRUCT<name VARCHAR, ageInDogYears INTEGER>``, assuming ``col0`` was a string and
 ``col1`` was an integer.
 
 Access the fields in a ``STRUCT`` by using the dereference operator (``->``):

--- a/ksql-engine/src/main/java/io/confluent/ksql/engine/rewrite/ExpressionTreeRewriter.java
+++ b/ksql-engine/src/main/java/io/confluent/ksql/engine/rewrite/ExpressionTreeRewriter.java
@@ -23,6 +23,7 @@ import io.confluent.ksql.execution.expression.tree.BooleanLiteral;
 import io.confluent.ksql.execution.expression.tree.Cast;
 import io.confluent.ksql.execution.expression.tree.ColumnReferenceExp;
 import io.confluent.ksql.execution.expression.tree.ComparisonExpression;
+import io.confluent.ksql.execution.expression.tree.CreateStructExpression;
 import io.confluent.ksql.execution.expression.tree.DecimalLiteral;
 import io.confluent.ksql.execution.expression.tree.DereferenceExpression;
 import io.confluent.ksql.execution.expression.tree.DoubleLiteral;
@@ -42,7 +43,6 @@ import io.confluent.ksql.execution.expression.tree.NullLiteral;
 import io.confluent.ksql.execution.expression.tree.SearchedCaseExpression;
 import io.confluent.ksql.execution.expression.tree.SimpleCaseExpression;
 import io.confluent.ksql.execution.expression.tree.StringLiteral;
-import io.confluent.ksql.execution.expression.tree.StructExpression;
 import io.confluent.ksql.execution.expression.tree.SubscriptExpression;
 import io.confluent.ksql.execution.expression.tree.TimeLiteral;
 import io.confluent.ksql.execution.expression.tree.TimestampLiteral;
@@ -190,12 +190,12 @@ public final class ExpressionTreeRewriter<C> {
     }
 
     @Override
-    public Expression visitStructExpression(StructExpression node, C context) {
+    public Expression visitStructExpression(CreateStructExpression node, C context) {
       final Map<String, Expression> struct = new HashMap<>();
       for (Entry<String, Expression> field : node.getStruct().entrySet()) {
         struct.put(field.getKey(), rewriter.apply(field.getValue(), context));
       }
-      return new StructExpression(node.getLocation(), struct);
+      return new CreateStructExpression(node.getLocation(), struct);
     }
 
     @Override

--- a/ksql-engine/src/main/java/io/confluent/ksql/engine/rewrite/ExpressionTreeRewriter.java
+++ b/ksql-engine/src/main/java/io/confluent/ksql/engine/rewrite/ExpressionTreeRewriter.java
@@ -42,12 +42,16 @@ import io.confluent.ksql.execution.expression.tree.NullLiteral;
 import io.confluent.ksql.execution.expression.tree.SearchedCaseExpression;
 import io.confluent.ksql.execution.expression.tree.SimpleCaseExpression;
 import io.confluent.ksql.execution.expression.tree.StringLiteral;
+import io.confluent.ksql.execution.expression.tree.StructExpression;
 import io.confluent.ksql.execution.expression.tree.SubscriptExpression;
 import io.confluent.ksql.execution.expression.tree.TimeLiteral;
 import io.confluent.ksql.execution.expression.tree.TimestampLiteral;
 import io.confluent.ksql.execution.expression.tree.Type;
 import io.confluent.ksql.execution.expression.tree.WhenClause;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
+import java.util.Map.Entry;
 import java.util.Objects;
 import java.util.Optional;
 import java.util.function.BiFunction;
@@ -183,6 +187,15 @@ public final class ExpressionTreeRewriter<C> {
       final Expression index = rewriter.apply(node.getIndex(), context);
 
       return new SubscriptExpression(node.getLocation(), base, index);
+    }
+
+    @Override
+    public Expression visitStructExpression(StructExpression node, C context) {
+      final Map<String, Expression> struct = new HashMap<>();
+      for (Entry<String, Expression> field : node.getStruct().entrySet()) {
+        struct.put(field.getKey(), rewriter.apply(field.getValue(), context));
+      }
+      return new StructExpression(node.getLocation(), struct);
     }
 
     @Override

--- a/ksql-engine/src/main/java/io/confluent/ksql/engine/rewrite/ExpressionTreeRewriter.java
+++ b/ksql-engine/src/main/java/io/confluent/ksql/engine/rewrite/ExpressionTreeRewriter.java
@@ -16,6 +16,7 @@
 package io.confluent.ksql.engine.rewrite;
 
 import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableList.Builder;
 import io.confluent.ksql.execution.expression.tree.ArithmeticBinaryExpression;
 import io.confluent.ksql.execution.expression.tree.ArithmeticUnaryExpression;
 import io.confluent.ksql.execution.expression.tree.BetweenPredicate;
@@ -24,6 +25,7 @@ import io.confluent.ksql.execution.expression.tree.Cast;
 import io.confluent.ksql.execution.expression.tree.ColumnReferenceExp;
 import io.confluent.ksql.execution.expression.tree.ComparisonExpression;
 import io.confluent.ksql.execution.expression.tree.CreateStructExpression;
+import io.confluent.ksql.execution.expression.tree.CreateStructExpression.Field;
 import io.confluent.ksql.execution.expression.tree.DecimalLiteral;
 import io.confluent.ksql.execution.expression.tree.DereferenceExpression;
 import io.confluent.ksql.execution.expression.tree.DoubleLiteral;
@@ -48,10 +50,7 @@ import io.confluent.ksql.execution.expression.tree.TimeLiteral;
 import io.confluent.ksql.execution.expression.tree.TimestampLiteral;
 import io.confluent.ksql.execution.expression.tree.Type;
 import io.confluent.ksql.execution.expression.tree.WhenClause;
-import java.util.HashMap;
 import java.util.List;
-import java.util.Map;
-import java.util.Map.Entry;
 import java.util.Objects;
 import java.util.Optional;
 import java.util.function.BiFunction;
@@ -191,11 +190,11 @@ public final class ExpressionTreeRewriter<C> {
 
     @Override
     public Expression visitStructExpression(CreateStructExpression node, C context) {
-      final Map<String, Expression> struct = new HashMap<>();
-      for (Entry<String, Expression> field : node.getStruct().entrySet()) {
-        struct.put(field.getKey(), rewriter.apply(field.getValue(), context));
+      final Builder<Field> fields = ImmutableList.builder();
+      for (Field field : node.getFields()) {
+        fields.add(new Field(field.getName(), rewriter.apply(field.getValue(), context)));
       }
-      return new CreateStructExpression(node.getLocation(), struct);
+      return new CreateStructExpression(node.getLocation(), fields.build());
     }
 
     @Override

--- a/ksql-engine/src/test/java/io/confluent/ksql/engine/rewrite/ExpressionTreeRewriterTest.java
+++ b/ksql-engine/src/test/java/io/confluent/ksql/engine/rewrite/ExpressionTreeRewriterTest.java
@@ -535,7 +535,7 @@ public class ExpressionTreeRewriterTest {
   @Test
   public void shouldRewriteStructExpression() {
     // Given:
-    final CreateStructExpression parsed = parseExpression("STRUCT('foo' as FOO, col4[1] as BAR)");
+    final CreateStructExpression parsed = parseExpression("STRUCT(FOO := 'foo', BAR := col4[1])");
     final Expression fooVal = parsed.getFields().stream().filter(f -> f.getName().equals("FOO")).findFirst().get().getValue();
     final Expression barVal = parsed.getFields().stream().filter(f -> f.getName().equals("BAR")).findFirst().get().getValue();
     when(processor.apply(fooVal, context)).thenReturn(expr1);

--- a/ksql-engine/src/test/java/io/confluent/ksql/engine/rewrite/ExpressionTreeRewriterTest.java
+++ b/ksql-engine/src/test/java/io/confluent/ksql/engine/rewrite/ExpressionTreeRewriterTest.java
@@ -53,7 +53,7 @@ import io.confluent.ksql.execution.expression.tree.NullLiteral;
 import io.confluent.ksql.execution.expression.tree.SearchedCaseExpression;
 import io.confluent.ksql.execution.expression.tree.SimpleCaseExpression;
 import io.confluent.ksql.execution.expression.tree.StringLiteral;
-import io.confluent.ksql.execution.expression.tree.StructExpression;
+import io.confluent.ksql.execution.expression.tree.CreateStructExpression;
 import io.confluent.ksql.execution.expression.tree.SubscriptExpression;
 import io.confluent.ksql.execution.expression.tree.TimeLiteral;
 import io.confluent.ksql.execution.expression.tree.TimestampLiteral;
@@ -535,7 +535,7 @@ public class ExpressionTreeRewriterTest {
   @Test
   public void shouldRewriteStructExpression() {
     // Given:
-    final StructExpression parsed = parseExpression("{foo 'foo', bar col4[1]}");
+    final CreateStructExpression parsed = parseExpression("STRUCT('foo' as FOO, col4[1] as BAR)");
     final Expression fooVal = parsed.getStruct().get("FOO");
     final Expression barVal = parsed.getStruct().get("BAR");
     when(processor.apply(fooVal, context)).thenReturn(expr1);
@@ -545,7 +545,7 @@ public class ExpressionTreeRewriterTest {
     final Expression rewritten = expressionRewriter.rewrite(parsed, context);
 
     // Then:
-    assertThat(rewritten, equalTo(new StructExpression(ImmutableMap.of("FOO", expr1, "BAR", expr2))));
+    assertThat(rewritten, equalTo(new CreateStructExpression(ImmutableMap.of("FOO", expr1, "BAR", expr2))));
   }
 
   @Test

--- a/ksql-execution/src/main/java/io/confluent/ksql/execution/codegen/CodeGenRunner.java
+++ b/ksql-execution/src/main/java/io/confluent/ksql/execution/codegen/CodeGenRunner.java
@@ -180,12 +180,12 @@ public class CodeGenRunner {
 
     @Override
     public Void visitStructExpression(CreateStructExpression exp, @Nullable Void context) {
-      exp.getStruct().values().forEach(val -> process(val, context));
+      exp.getFields().forEach(val -> process(val.getValue(), context));
       final Schema schema = SchemaConverters
           .sqlToConnectConverter()
           .toConnectSchema(expressionTypeManager.getExpressionSqlType(exp));
 
-      spec.addSchema(exp, schema);
+      spec.addStructSchema(exp, schema);
       return null;
     }
 

--- a/ksql-execution/src/main/java/io/confluent/ksql/execution/codegen/CodeGenRunner.java
+++ b/ksql-execution/src/main/java/io/confluent/ksql/execution/codegen/CodeGenRunner.java
@@ -16,11 +16,11 @@
 package io.confluent.ksql.execution.codegen;
 
 import io.confluent.ksql.execution.expression.tree.ColumnReferenceExp;
+import io.confluent.ksql.execution.expression.tree.CreateStructExpression;
 import io.confluent.ksql.execution.expression.tree.DereferenceExpression;
 import io.confluent.ksql.execution.expression.tree.Expression;
 import io.confluent.ksql.execution.expression.tree.FunctionCall;
 import io.confluent.ksql.execution.expression.tree.LikePredicate;
-import io.confluent.ksql.execution.expression.tree.StructExpression;
 import io.confluent.ksql.execution.expression.tree.SubscriptExpression;
 import io.confluent.ksql.execution.expression.tree.TraversalExpressionVisitor;
 import io.confluent.ksql.execution.util.ExpressionTypeManager;
@@ -179,7 +179,7 @@ public class CodeGenRunner {
     }
 
     @Override
-    public Void visitStructExpression(StructExpression exp, @Nullable Void context) {
+    public Void visitStructExpression(CreateStructExpression exp, @Nullable Void context) {
       exp.getStruct().values().forEach(val -> process(val, context));
       final Schema schema = SchemaConverters
           .sqlToConnectConverter()

--- a/ksql-execution/src/main/java/io/confluent/ksql/execution/codegen/CodeGenRunner.java
+++ b/ksql-execution/src/main/java/io/confluent/ksql/execution/codegen/CodeGenRunner.java
@@ -20,6 +20,7 @@ import io.confluent.ksql.execution.expression.tree.DereferenceExpression;
 import io.confluent.ksql.execution.expression.tree.Expression;
 import io.confluent.ksql.execution.expression.tree.FunctionCall;
 import io.confluent.ksql.execution.expression.tree.LikePredicate;
+import io.confluent.ksql.execution.expression.tree.StructExpression;
 import io.confluent.ksql.execution.expression.tree.SubscriptExpression;
 import io.confluent.ksql.execution.expression.tree.TraversalExpressionVisitor;
 import io.confluent.ksql.execution.util.ExpressionTypeManager;
@@ -40,6 +41,8 @@ import java.util.List;
 import java.util.Objects;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
+import javax.annotation.Nullable;
+import org.apache.kafka.connect.data.Schema;
 import org.codehaus.commons.compiler.CompileException;
 import org.codehaus.commons.compiler.CompilerFactoryFactory;
 import org.codehaus.commons.compiler.IExpressionEvaluator;
@@ -172,6 +175,17 @@ public class CodeGenRunner {
         process(node.getBase(), context);
       }
       process(node.getIndex(), context);
+      return null;
+    }
+
+    @Override
+    public Void visitStructExpression(StructExpression exp, @Nullable Void context) {
+      exp.getStruct().values().forEach(val -> process(val, context));
+      final Schema schema = SchemaConverters
+          .sqlToConnectConverter()
+          .toConnectSchema(expressionTypeManager.getExpressionSqlType(exp));
+
+      spec.addSchema(exp, schema);
       return null;
     }
 

--- a/ksql-execution/src/main/java/io/confluent/ksql/execution/codegen/CodeGenSpec.java
+++ b/ksql-execution/src/main/java/io/confluent/ksql/execution/codegen/CodeGenSpec.java
@@ -84,7 +84,7 @@ public final class CodeGenSpec {
     }
   }
 
-  public String getSchemaName(CreateStructExpression createStructExpression) {
+  public String getStructSchemaName(CreateStructExpression createStructExpression) {
     final String schemaName = structToCodeName.get(createStructExpression);
     if (schemaName == null) {
       throw new KsqlException(
@@ -104,7 +104,7 @@ public final class CodeGenSpec {
         ImmutableMap.builder();
 
     private int argumentCount = 0;
-    private int schemaCount = 0;
+    private int structSchemaCount = 0;
 
     void addParameter(
         final ColumnRef columnRef,
@@ -122,10 +122,10 @@ public final class CodeGenSpec {
       argumentBuilder.add(new FunctionArgumentSpec(codeName, function.getClass(), function));
     }
 
-    void addSchema(CreateStructExpression struct, Schema schema) {
-      final String schemaName = CodeGenUtil.schemaName(schemaCount++);
-      structToSchemaName.put(struct, schemaName);
-      argumentBuilder.add(new SchemaArgumentSpec(schemaName, schema));
+    void addStructSchema(CreateStructExpression struct, Schema schema) {
+      final String structSchemaName = CodeGenUtil.schemaName(structSchemaCount++);
+      structToSchemaName.put(struct, structSchemaName);
+      argumentBuilder.add(new SchemaArgumentSpec(structSchemaName, schema));
     }
 
     CodeGenSpec build() {

--- a/ksql-execution/src/main/java/io/confluent/ksql/execution/codegen/CodeGenUtil.java
+++ b/ksql-execution/src/main/java/io/confluent/ksql/execution/codegen/CodeGenUtil.java
@@ -20,12 +20,17 @@ import io.confluent.ksql.name.FunctionName;
 public final class CodeGenUtil {
 
   private static final String PARAM_NAME_PREFIX = "var";
+  private static final String SCHEMA_NAME_PREFIX = "schema";
 
   private CodeGenUtil() {
   }
 
   public static String paramName(int index) {
     return PARAM_NAME_PREFIX + index;
+  }
+
+  public static String schemaName(int index) {
+    return SCHEMA_NAME_PREFIX + index;
   }
 
   public static String functionName(FunctionName fun, int index) {

--- a/ksql-execution/src/main/java/io/confluent/ksql/execution/codegen/SqlToJavaVisitor.java
+++ b/ksql-execution/src/main/java/io/confluent/ksql/execution/codegen/SqlToJavaVisitor.java
@@ -32,6 +32,7 @@ import io.confluent.ksql.execution.expression.tree.Cast;
 import io.confluent.ksql.execution.expression.tree.ColumnReferenceExp;
 import io.confluent.ksql.execution.expression.tree.ComparisonExpression;
 import io.confluent.ksql.execution.expression.tree.CreateStructExpression;
+import io.confluent.ksql.execution.expression.tree.CreateStructExpression.Field;
 import io.confluent.ksql.execution.expression.tree.DecimalLiteral;
 import io.confluent.ksql.execution.expression.tree.DereferenceExpression;
 import io.confluent.ksql.execution.expression.tree.DoubleLiteral;
@@ -81,7 +82,6 @@ import java.math.MathContext;
 import java.math.RoundingMode;
 import java.util.List;
 import java.util.Map;
-import java.util.Map.Entry;
 import java.util.Objects;
 import java.util.function.Function;
 import java.util.function.Supplier;
@@ -153,7 +153,7 @@ public class SqlToJavaVisitor {
           int index = nameCounts.add(name, 1);
           return spec.getUniqueNameForFunction(name, index);
         },
-        spec::getSchemaName);
+        spec::getStructSchemaName);
   }
 
   @VisibleForTesting
@@ -726,10 +726,10 @@ public class SqlToJavaVisitor {
     public Pair<String, SqlType> visitStructExpression(CreateStructExpression node, Void context) {
       final String schemaName = structToCodeName.apply(node);
       final StringBuilder struct = new StringBuilder("new Struct(").append(schemaName).append(")");
-      for (Entry<String, Expression> field : node.getStruct().entrySet()) {
+      for (Field field : node.getFields()) {
         struct.append(".put(")
             .append('"')
-            .append(field.getKey())
+            .append(field.getName())
             .append('"')
             .append(",")
             .append(process(field.getValue(), context).getLeft())

--- a/ksql-execution/src/main/java/io/confluent/ksql/execution/codegen/SqlToJavaVisitor.java
+++ b/ksql-execution/src/main/java/io/confluent/ksql/execution/codegen/SqlToJavaVisitor.java
@@ -31,6 +31,7 @@ import io.confluent.ksql.execution.expression.tree.BooleanLiteral;
 import io.confluent.ksql.execution.expression.tree.Cast;
 import io.confluent.ksql.execution.expression.tree.ColumnReferenceExp;
 import io.confluent.ksql.execution.expression.tree.ComparisonExpression;
+import io.confluent.ksql.execution.expression.tree.CreateStructExpression;
 import io.confluent.ksql.execution.expression.tree.DecimalLiteral;
 import io.confluent.ksql.execution.expression.tree.DereferenceExpression;
 import io.confluent.ksql.execution.expression.tree.DoubleLiteral;
@@ -50,7 +51,6 @@ import io.confluent.ksql.execution.expression.tree.NullLiteral;
 import io.confluent.ksql.execution.expression.tree.SearchedCaseExpression;
 import io.confluent.ksql.execution.expression.tree.SimpleCaseExpression;
 import io.confluent.ksql.execution.expression.tree.StringLiteral;
-import io.confluent.ksql.execution.expression.tree.StructExpression;
 import io.confluent.ksql.execution.expression.tree.SubscriptExpression;
 import io.confluent.ksql.execution.expression.tree.TimeLiteral;
 import io.confluent.ksql.execution.expression.tree.TimestampLiteral;
@@ -139,7 +139,7 @@ public class SqlToJavaVisitor {
   private final ExpressionTypeManager expressionTypeManager;
   private final Function<FunctionName, String> funNameToCodeName;
   private final Function<ColumnRef, String> colRefToCodeName;
-  private final Function<StructExpression, String> structToCodeName;
+  private final Function<CreateStructExpression, String> structToCodeName;
 
   public static SqlToJavaVisitor of(
       LogicalSchema schema, FunctionRegistry functionRegistry, CodeGenSpec spec
@@ -161,7 +161,7 @@ public class SqlToJavaVisitor {
       LogicalSchema schema, FunctionRegistry functionRegistry,
       Function<ColumnRef, String> colRefToCodeName,
       Function<FunctionName, String> funNameToCodeName,
-      Function<StructExpression, String> structToCodeName
+      Function<CreateStructExpression, String> structToCodeName
   ) {
     this.expressionTypeManager =
         new ExpressionTypeManager(schema, functionRegistry);
@@ -723,7 +723,7 @@ public class SqlToJavaVisitor {
     }
 
     @Override
-    public Pair<String, SqlType> visitStructExpression(StructExpression node, Void context) {
+    public Pair<String, SqlType> visitStructExpression(CreateStructExpression node, Void context) {
       final String schemaName = structToCodeName.apply(node);
       final StringBuilder struct = new StringBuilder("new Struct(").append(schemaName).append(")");
       for (Entry<String, Expression> field : node.getStruct().entrySet()) {

--- a/ksql-execution/src/main/java/io/confluent/ksql/execution/expression/formatter/ExpressionFormatter.java
+++ b/ksql-execution/src/main/java/io/confluent/ksql/execution/expression/formatter/ExpressionFormatter.java
@@ -24,6 +24,7 @@ import io.confluent.ksql.execution.expression.tree.BooleanLiteral;
 import io.confluent.ksql.execution.expression.tree.Cast;
 import io.confluent.ksql.execution.expression.tree.ColumnReferenceExp;
 import io.confluent.ksql.execution.expression.tree.ComparisonExpression;
+import io.confluent.ksql.execution.expression.tree.CreateStructExpression;
 import io.confluent.ksql.execution.expression.tree.DecimalLiteral;
 import io.confluent.ksql.execution.expression.tree.DereferenceExpression;
 import io.confluent.ksql.execution.expression.tree.DoubleLiteral;
@@ -43,7 +44,6 @@ import io.confluent.ksql.execution.expression.tree.NullLiteral;
 import io.confluent.ksql.execution.expression.tree.SearchedCaseExpression;
 import io.confluent.ksql.execution.expression.tree.SimpleCaseExpression;
 import io.confluent.ksql.execution.expression.tree.StringLiteral;
-import io.confluent.ksql.execution.expression.tree.StructExpression;
 import io.confluent.ksql.execution.expression.tree.SubscriptExpression;
 import io.confluent.ksql.execution.expression.tree.TimeLiteral;
 import io.confluent.ksql.execution.expression.tree.TimestampLiteral;
@@ -103,13 +103,13 @@ public final class ExpressionFormatter {
     }
 
     @Override
-    public String visitStructExpression(StructExpression exp, Context context) {
+    public String visitStructExpression(CreateStructExpression exp, Context context) {
       return exp
           .getStruct()
           .entrySet()
           .stream()
-          .map(struct -> struct.getKey() + " " + process(struct.getValue(), context))
-          .collect(Collectors.joining(", ", "{", "}"));
+          .map(struct -> process(struct.getValue(), context) + " AS " + struct.getKey())
+          .collect(Collectors.joining(", ", "STRUCT(", ")"));
     }
 
     @Override

--- a/ksql-execution/src/main/java/io/confluent/ksql/execution/expression/formatter/ExpressionFormatter.java
+++ b/ksql-execution/src/main/java/io/confluent/ksql/execution/expression/formatter/ExpressionFormatter.java
@@ -107,7 +107,7 @@ public final class ExpressionFormatter {
       return exp
           .getFields()
           .stream()
-          .map(struct -> process(struct.getValue(), context) + " AS " + struct.getName())
+          .map(struct -> struct.getName() + ":=" + process(struct.getValue(), context))
           .collect(Collectors.joining(", ", "STRUCT(", ")"));
     }
 

--- a/ksql-execution/src/main/java/io/confluent/ksql/execution/expression/formatter/ExpressionFormatter.java
+++ b/ksql-execution/src/main/java/io/confluent/ksql/execution/expression/formatter/ExpressionFormatter.java
@@ -107,7 +107,10 @@ public final class ExpressionFormatter {
       return exp
           .getFields()
           .stream()
-          .map(struct -> struct.getName() + ":=" + process(struct.getValue(), context))
+          .map(struct ->
+              context.formatOptions.escape(struct.getName())
+                  + ":="
+                  + process(struct.getValue(), context))
           .collect(Collectors.joining(", ", "STRUCT(", ")"));
     }
 

--- a/ksql-execution/src/main/java/io/confluent/ksql/execution/expression/formatter/ExpressionFormatter.java
+++ b/ksql-execution/src/main/java/io/confluent/ksql/execution/expression/formatter/ExpressionFormatter.java
@@ -43,6 +43,7 @@ import io.confluent.ksql.execution.expression.tree.NullLiteral;
 import io.confluent.ksql.execution.expression.tree.SearchedCaseExpression;
 import io.confluent.ksql.execution.expression.tree.SimpleCaseExpression;
 import io.confluent.ksql.execution.expression.tree.StringLiteral;
+import io.confluent.ksql.execution.expression.tree.StructExpression;
 import io.confluent.ksql.execution.expression.tree.SubscriptExpression;
 import io.confluent.ksql.execution.expression.tree.TimeLiteral;
 import io.confluent.ksql.execution.expression.tree.TimestampLiteral;
@@ -52,6 +53,7 @@ import io.confluent.ksql.name.Name;
 import io.confluent.ksql.schema.ksql.FormatOptions;
 import io.confluent.ksql.util.KsqlConstants;
 import java.util.List;
+import java.util.stream.Collectors;
 
 public final class ExpressionFormatter {
 
@@ -98,6 +100,16 @@ public final class ExpressionFormatter {
     public String visitSubscriptExpression(SubscriptExpression node, Context context) {
       return process(node.getBase(), context)
           + "[" + process(node.getIndex(), context) + "]";
+    }
+
+    @Override
+    public String visitStructExpression(StructExpression exp, Context context) {
+      return exp
+          .getStruct()
+          .entrySet()
+          .stream()
+          .map(struct -> struct.getKey() + " " + process(struct.getValue(), context))
+          .collect(Collectors.joining(", ", "{", "}"));
     }
 
     @Override

--- a/ksql-execution/src/main/java/io/confluent/ksql/execution/expression/formatter/ExpressionFormatter.java
+++ b/ksql-execution/src/main/java/io/confluent/ksql/execution/expression/formatter/ExpressionFormatter.java
@@ -105,10 +105,9 @@ public final class ExpressionFormatter {
     @Override
     public String visitStructExpression(CreateStructExpression exp, Context context) {
       return exp
-          .getStruct()
-          .entrySet()
+          .getFields()
           .stream()
-          .map(struct -> process(struct.getValue(), context) + " AS " + struct.getKey())
+          .map(struct -> process(struct.getValue(), context) + " AS " + struct.getName())
           .collect(Collectors.joining(", ", "STRUCT(", ")"));
     }
 

--- a/ksql-execution/src/main/java/io/confluent/ksql/execution/expression/tree/CreateStructExpression.java
+++ b/ksql-execution/src/main/java/io/confluent/ksql/execution/expression/tree/CreateStructExpression.java
@@ -15,30 +15,30 @@
 
 package io.confluent.ksql.execution.expression.tree;
 
-import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.ImmutableList;
 import com.google.errorprone.annotations.Immutable;
 import io.confluent.ksql.parser.NodeLocation;
-import java.util.Map;
+import java.util.List;
 import java.util.Objects;
 import java.util.Optional;
 
 @Immutable
 public class CreateStructExpression extends Expression {
 
-  private final Map<String, Expression> struct;
+  private final ImmutableList<Field> fields;
 
   public CreateStructExpression(
-      final Map<String, Expression> struct
+      final List<Field> fields
   ) {
-    this(Optional.empty(), struct);
+    this(Optional.empty(), fields);
   }
 
   public CreateStructExpression(
       final Optional<NodeLocation> location,
-      final Map<String, Expression> struct
+      final List<Field> fields
   ) {
     super(location);
-    this.struct = ImmutableMap.copyOf(struct);
+    this.fields = ImmutableList.copyOf(fields);
   }
 
   @Override
@@ -46,8 +46,8 @@ public class CreateStructExpression extends Expression {
     return visitor.visitStructExpression(this, context);
   }
 
-  public Map<String, Expression> getStruct() {
-    return struct;
+  public ImmutableList<Field> getFields() {
+    return fields;
   }
 
   @Override
@@ -59,12 +59,56 @@ public class CreateStructExpression extends Expression {
       return false;
     }
     CreateStructExpression that = (CreateStructExpression) o;
-    return Objects.equals(struct, that.struct);
+    return Objects.equals(fields, that.fields);
   }
 
   @Override
   public int hashCode() {
-    return Objects.hash(struct);
+    return Objects.hash(fields);
+  }
+
+  public static class Field {
+    private final String name;
+    private final Expression value;
+
+    public Field(String name, Expression value) {
+      this.name = Objects.requireNonNull(name, "name");
+      this.value = Objects.requireNonNull(value, "value");
+    }
+
+    public String getName() {
+      return name;
+    }
+
+    public Expression getValue() {
+      return value;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+      if (this == o) {
+        return true;
+      }
+      if (o == null || getClass() != o.getClass()) {
+        return false;
+      }
+      Field field = (Field) o;
+      return Objects.equals(name, field.name)
+          && Objects.equals(value, field.value);
+    }
+
+    @Override
+    public int hashCode() {
+      return Objects.hash(name, value);
+    }
+
+    @Override
+    public String toString() {
+      return "Field{"
+          + "name='" + name + '\''
+          + ", value=" + value
+          + '}';
+    }
   }
 
 }

--- a/ksql-execution/src/main/java/io/confluent/ksql/execution/expression/tree/CreateStructExpression.java
+++ b/ksql-execution/src/main/java/io/confluent/ksql/execution/expression/tree/CreateStructExpression.java
@@ -23,17 +23,17 @@ import java.util.Objects;
 import java.util.Optional;
 
 @Immutable
-public class StructExpression extends Expression {
+public class CreateStructExpression extends Expression {
 
   private final Map<String, Expression> struct;
 
-  public StructExpression(
+  public CreateStructExpression(
       final Map<String, Expression> struct
   ) {
     this(Optional.empty(), struct);
   }
 
-  public StructExpression(
+  public CreateStructExpression(
       final Optional<NodeLocation> location,
       final Map<String, Expression> struct
   ) {
@@ -58,7 +58,7 @@ public class StructExpression extends Expression {
     if (o == null || getClass() != o.getClass()) {
       return false;
     }
-    StructExpression that = (StructExpression) o;
+    CreateStructExpression that = (CreateStructExpression) o;
     return Objects.equals(struct, that.struct);
   }
 

--- a/ksql-execution/src/main/java/io/confluent/ksql/execution/expression/tree/ExpressionVisitor.java
+++ b/ksql-execution/src/main/java/io/confluent/ksql/execution/expression/tree/ExpressionVisitor.java
@@ -73,7 +73,7 @@ public interface ExpressionVisitor<R, C> {
 
   R visitSubscriptExpression(SubscriptExpression exp, @Nullable C context);
 
-  R visitStructExpression(StructExpression exp, @Nullable C context);
+  R visitStructExpression(CreateStructExpression exp, @Nullable C context);
 
   R visitTimeLiteral(TimeLiteral exp, @Nullable C context);
 

--- a/ksql-execution/src/main/java/io/confluent/ksql/execution/expression/tree/ExpressionVisitor.java
+++ b/ksql-execution/src/main/java/io/confluent/ksql/execution/expression/tree/ExpressionVisitor.java
@@ -73,6 +73,8 @@ public interface ExpressionVisitor<R, C> {
 
   R visitSubscriptExpression(SubscriptExpression exp, @Nullable C context);
 
+  R visitStructExpression(StructExpression exp, @Nullable C context);
+
   R visitTimeLiteral(TimeLiteral exp, @Nullable C context);
 
   R visitTimestampLiteral(TimestampLiteral exp, @Nullable C context);

--- a/ksql-execution/src/main/java/io/confluent/ksql/execution/expression/tree/StructExpression.java
+++ b/ksql-execution/src/main/java/io/confluent/ksql/execution/expression/tree/StructExpression.java
@@ -1,0 +1,70 @@
+/*
+ * Copyright 2019 Confluent Inc.
+ *
+ * Licensed under the Confluent Community License (the "License"; you may not use
+ * this file except in compliance with the License. You may obtain a copy of the
+ * License at
+ *
+ * http://www.confluent.io/confluent-community-license
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package io.confluent.ksql.execution.expression.tree;
+
+import com.google.common.collect.ImmutableMap;
+import com.google.errorprone.annotations.Immutable;
+import io.confluent.ksql.parser.NodeLocation;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Optional;
+
+@Immutable
+public class StructExpression extends Expression {
+
+  private final Map<String, Expression> struct;
+
+  public StructExpression(
+      final Map<String, Expression> struct
+  ) {
+    this(Optional.empty(), struct);
+  }
+
+  public StructExpression(
+      final Optional<NodeLocation> location,
+      final Map<String, Expression> struct
+  ) {
+    super(location);
+    this.struct = ImmutableMap.copyOf(struct);
+  }
+
+  @Override
+  protected <R, C> R accept(ExpressionVisitor<R, C> visitor, C context) {
+    return visitor.visitStructExpression(this, context);
+  }
+
+  public Map<String, Expression> getStruct() {
+    return struct;
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    StructExpression that = (StructExpression) o;
+    return Objects.equals(struct, that.struct);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(struct);
+  }
+
+}

--- a/ksql-execution/src/main/java/io/confluent/ksql/execution/expression/tree/TraversalExpressionVisitor.java
+++ b/ksql-execution/src/main/java/io/confluent/ksql/execution/expression/tree/TraversalExpressionVisitor.java
@@ -51,6 +51,12 @@ public abstract class TraversalExpressionVisitor<C> implements ExpressionVisitor
   }
 
   @Override
+  public Void visitStructExpression(StructExpression node, C context) {
+    node.getStruct().values().forEach(exp -> process(exp, context));
+    return null;
+  }
+
+  @Override
   public Void visitComparisonExpression(ComparisonExpression node, C context) {
     process(node.getLeft(), context);
     process(node.getRight(), context);

--- a/ksql-execution/src/main/java/io/confluent/ksql/execution/expression/tree/TraversalExpressionVisitor.java
+++ b/ksql-execution/src/main/java/io/confluent/ksql/execution/expression/tree/TraversalExpressionVisitor.java
@@ -52,7 +52,7 @@ public abstract class TraversalExpressionVisitor<C> implements ExpressionVisitor
 
   @Override
   public Void visitStructExpression(CreateStructExpression node, C context) {
-    node.getStruct().values().forEach(exp -> process(exp, context));
+    node.getFields().forEach(field -> process(field.getValue(), context));
     return null;
   }
 

--- a/ksql-execution/src/main/java/io/confluent/ksql/execution/expression/tree/TraversalExpressionVisitor.java
+++ b/ksql-execution/src/main/java/io/confluent/ksql/execution/expression/tree/TraversalExpressionVisitor.java
@@ -51,7 +51,7 @@ public abstract class TraversalExpressionVisitor<C> implements ExpressionVisitor
   }
 
   @Override
-  public Void visitStructExpression(StructExpression node, C context) {
+  public Void visitStructExpression(CreateStructExpression node, C context) {
     node.getStruct().values().forEach(exp -> process(exp, context));
     return null;
   }

--- a/ksql-execution/src/main/java/io/confluent/ksql/execution/expression/tree/VisitParentExpressionVisitor.java
+++ b/ksql-execution/src/main/java/io/confluent/ksql/execution/expression/tree/VisitParentExpressionVisitor.java
@@ -167,6 +167,11 @@ public abstract class VisitParentExpressionVisitor<R, C> implements ExpressionVi
   }
 
   @Override
+  public R visitStructExpression(StructExpression node, C context) {
+    return visitExpression(node, context);
+  }
+
+  @Override
   public R visitLongLiteral(LongLiteral node, C context) {
     return visitLiteral(node, context);
   }

--- a/ksql-execution/src/main/java/io/confluent/ksql/execution/expression/tree/VisitParentExpressionVisitor.java
+++ b/ksql-execution/src/main/java/io/confluent/ksql/execution/expression/tree/VisitParentExpressionVisitor.java
@@ -167,7 +167,7 @@ public abstract class VisitParentExpressionVisitor<R, C> implements ExpressionVi
   }
 
   @Override
-  public R visitStructExpression(StructExpression node, C context) {
+  public R visitStructExpression(CreateStructExpression node, C context) {
     return visitExpression(node, context);
   }
 

--- a/ksql-execution/src/main/java/io/confluent/ksql/execution/util/ExpressionTypeManager.java
+++ b/ksql-execution/src/main/java/io/confluent/ksql/execution/util/ExpressionTypeManager.java
@@ -42,6 +42,7 @@ import io.confluent.ksql.execution.expression.tree.NullLiteral;
 import io.confluent.ksql.execution.expression.tree.SearchedCaseExpression;
 import io.confluent.ksql.execution.expression.tree.SimpleCaseExpression;
 import io.confluent.ksql.execution.expression.tree.StringLiteral;
+import io.confluent.ksql.execution.expression.tree.StructExpression;
 import io.confluent.ksql.execution.expression.tree.SubscriptExpression;
 import io.confluent.ksql.execution.expression.tree.TimeLiteral;
 import io.confluent.ksql.execution.expression.tree.TimestampLiteral;
@@ -61,12 +62,14 @@ import io.confluent.ksql.schema.ksql.types.Field;
 import io.confluent.ksql.schema.ksql.types.SqlArray;
 import io.confluent.ksql.schema.ksql.types.SqlMap;
 import io.confluent.ksql.schema.ksql.types.SqlStruct;
+import io.confluent.ksql.schema.ksql.types.SqlStruct.Builder;
 import io.confluent.ksql.schema.ksql.types.SqlType;
 import io.confluent.ksql.schema.ksql.types.SqlTypes;
 import io.confluent.ksql.util.KsqlException;
 import io.confluent.ksql.util.VisitorUtil;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Map.Entry;
 import java.util.Objects;
 import java.util.Optional;
 import java.util.stream.Collectors;
@@ -317,6 +320,19 @@ public class ExpressionTypeManager {
       }
 
       expressionTypeContext.setSqlType(valueType);
+      return null;
+    }
+
+    @Override
+    public Void visitStructExpression(StructExpression exp, ExpressionTypeContext context) {
+      final Builder builder = SqlStruct.builder();
+
+      for (Entry<String, Expression> field : exp.getStruct().entrySet()) {
+        process(field.getValue(), context);
+        builder.field(field.getKey(), context.getSqlType());
+      }
+
+      context.setSqlType(builder.build());
       return null;
     }
 

--- a/ksql-execution/src/main/java/io/confluent/ksql/execution/util/ExpressionTypeManager.java
+++ b/ksql-execution/src/main/java/io/confluent/ksql/execution/util/ExpressionTypeManager.java
@@ -69,7 +69,6 @@ import io.confluent.ksql.util.KsqlException;
 import io.confluent.ksql.util.VisitorUtil;
 import java.util.ArrayList;
 import java.util.List;
-import java.util.Map.Entry;
 import java.util.Objects;
 import java.util.Optional;
 import java.util.stream.Collectors;
@@ -327,9 +326,9 @@ public class ExpressionTypeManager {
     public Void visitStructExpression(CreateStructExpression exp, ExpressionTypeContext context) {
       final Builder builder = SqlStruct.builder();
 
-      for (Entry<String, Expression> field : exp.getStruct().entrySet()) {
+      for (CreateStructExpression.Field field : exp.getFields()) {
         process(field.getValue(), context);
-        builder.field(field.getKey(), context.getSqlType());
+        builder.field(field.getName(), context.getSqlType());
       }
 
       context.setSqlType(builder.build());

--- a/ksql-execution/src/main/java/io/confluent/ksql/execution/util/ExpressionTypeManager.java
+++ b/ksql-execution/src/main/java/io/confluent/ksql/execution/util/ExpressionTypeManager.java
@@ -23,6 +23,7 @@ import io.confluent.ksql.execution.expression.tree.BooleanLiteral;
 import io.confluent.ksql.execution.expression.tree.Cast;
 import io.confluent.ksql.execution.expression.tree.ColumnReferenceExp;
 import io.confluent.ksql.execution.expression.tree.ComparisonExpression;
+import io.confluent.ksql.execution.expression.tree.CreateStructExpression;
 import io.confluent.ksql.execution.expression.tree.DecimalLiteral;
 import io.confluent.ksql.execution.expression.tree.DereferenceExpression;
 import io.confluent.ksql.execution.expression.tree.DoubleLiteral;
@@ -42,7 +43,6 @@ import io.confluent.ksql.execution.expression.tree.NullLiteral;
 import io.confluent.ksql.execution.expression.tree.SearchedCaseExpression;
 import io.confluent.ksql.execution.expression.tree.SimpleCaseExpression;
 import io.confluent.ksql.execution.expression.tree.StringLiteral;
-import io.confluent.ksql.execution.expression.tree.StructExpression;
 import io.confluent.ksql.execution.expression.tree.SubscriptExpression;
 import io.confluent.ksql.execution.expression.tree.TimeLiteral;
 import io.confluent.ksql.execution.expression.tree.TimestampLiteral;
@@ -324,7 +324,7 @@ public class ExpressionTypeManager {
     }
 
     @Override
-    public Void visitStructExpression(StructExpression exp, ExpressionTypeContext context) {
+    public Void visitStructExpression(CreateStructExpression exp, ExpressionTypeContext context) {
       final Builder builder = SqlStruct.builder();
 
       for (Entry<String, Expression> field : exp.getStruct().entrySet()) {

--- a/ksql-execution/src/test/java/io/confluent/ksql/execution/codegen/SqlToJavaVisitorTest.java
+++ b/ksql-execution/src/test/java/io/confluent/ksql/execution/codegen/SqlToJavaVisitorTest.java
@@ -49,7 +49,7 @@ import io.confluent.ksql.execution.expression.tree.LikePredicate;
 import io.confluent.ksql.execution.expression.tree.SearchedCaseExpression;
 import io.confluent.ksql.execution.expression.tree.SimpleCaseExpression;
 import io.confluent.ksql.execution.expression.tree.StringLiteral;
-import io.confluent.ksql.execution.expression.tree.StructExpression;
+import io.confluent.ksql.execution.expression.tree.CreateStructExpression;
 import io.confluent.ksql.execution.expression.tree.SubscriptExpression;
 import io.confluent.ksql.execution.expression.tree.TimeLiteral;
 import io.confluent.ksql.execution.expression.tree.TimestampLiteral;
@@ -147,7 +147,7 @@ public class SqlToJavaVisitorTest {
   @Test
   public void shouldProcessStructExpressionCorrectly() {
     // Given:
-    Expression expression = new StructExpression(
+    Expression expression = new CreateStructExpression(
         ImmutableMap.of(
             "col1", new StringLiteral("foo"),
             "col2", new SubscriptExpression(MAPCOL, new StringLiteral("key1"))

--- a/ksql-execution/src/test/java/io/confluent/ksql/execution/codegen/SqlToJavaVisitorTest.java
+++ b/ksql-execution/src/test/java/io/confluent/ksql/execution/codegen/SqlToJavaVisitorTest.java
@@ -32,13 +32,14 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
 import com.google.common.collect.ImmutableList;
-import com.google.common.collect.ImmutableMap;
 import io.confluent.ksql.execution.expression.tree.ArithmeticBinaryExpression;
 import io.confluent.ksql.execution.expression.tree.ArithmeticUnaryExpression;
 import io.confluent.ksql.execution.expression.tree.ArithmeticUnaryExpression.Sign;
 import io.confluent.ksql.execution.expression.tree.Cast;
 import io.confluent.ksql.execution.expression.tree.ColumnReferenceExp;
 import io.confluent.ksql.execution.expression.tree.ComparisonExpression;
+import io.confluent.ksql.execution.expression.tree.CreateStructExpression;
+import io.confluent.ksql.execution.expression.tree.CreateStructExpression.Field;
 import io.confluent.ksql.execution.expression.tree.DoubleLiteral;
 import io.confluent.ksql.execution.expression.tree.Expression;
 import io.confluent.ksql.execution.expression.tree.FunctionCall;
@@ -49,7 +50,6 @@ import io.confluent.ksql.execution.expression.tree.LikePredicate;
 import io.confluent.ksql.execution.expression.tree.SearchedCaseExpression;
 import io.confluent.ksql.execution.expression.tree.SimpleCaseExpression;
 import io.confluent.ksql.execution.expression.tree.StringLiteral;
-import io.confluent.ksql.execution.expression.tree.CreateStructExpression;
 import io.confluent.ksql.execution.expression.tree.SubscriptExpression;
 import io.confluent.ksql.execution.expression.tree.TimeLiteral;
 import io.confluent.ksql.execution.expression.tree.TimestampLiteral;
@@ -148,9 +148,9 @@ public class SqlToJavaVisitorTest {
   public void shouldProcessStructExpressionCorrectly() {
     // Given:
     Expression expression = new CreateStructExpression(
-        ImmutableMap.of(
-            "col1", new StringLiteral("foo"),
-            "col2", new SubscriptExpression(MAPCOL, new StringLiteral("key1"))
+        ImmutableList.of(
+            new Field("col1", new StringLiteral("foo")),
+            new Field("col2", new SubscriptExpression(MAPCOL, new StringLiteral("key1")))
         )
     );
 

--- a/ksql-execution/src/test/java/io/confluent/ksql/execution/expression/formatter/ExpressionFormatterTest.java
+++ b/ksql-execution/src/test/java/io/confluent/ksql/execution/expression/formatter/ExpressionFormatterTest.java
@@ -45,7 +45,7 @@ import io.confluent.ksql.execution.expression.tree.NullLiteral;
 import io.confluent.ksql.execution.expression.tree.SearchedCaseExpression;
 import io.confluent.ksql.execution.expression.tree.SimpleCaseExpression;
 import io.confluent.ksql.execution.expression.tree.StringLiteral;
-import io.confluent.ksql.execution.expression.tree.StructExpression;
+import io.confluent.ksql.execution.expression.tree.CreateStructExpression;
 import io.confluent.ksql.execution.expression.tree.SubscriptExpression;
 import io.confluent.ksql.execution.expression.tree.TimeLiteral;
 import io.confluent.ksql.execution.expression.tree.TimestampLiteral;
@@ -89,12 +89,12 @@ public class ExpressionFormatterTest {
 
   @Test
   public void shouldFormatStructExpression() {
-    assertThat(ExpressionFormatter.formatExpression(new StructExpression(
+    assertThat(ExpressionFormatter.formatExpression(new CreateStructExpression(
         ImmutableMap.of(
             "foo", new StringLiteral("abc"),
             "bar", new SubscriptExpression(new ColumnReferenceExp(ColumnRef.withoutSource(ColumnName.of("abc"))), new IntegerLiteral(1)))
         )),
-        equalTo("{foo 'abc', bar abc[1]}"));
+        equalTo("STRUCT('abc' AS foo, abc[1] AS bar)"));
   }
 
   @Test

--- a/ksql-execution/src/test/java/io/confluent/ksql/execution/expression/formatter/ExpressionFormatterTest.java
+++ b/ksql-execution/src/test/java/io/confluent/ksql/execution/expression/formatter/ExpressionFormatterTest.java
@@ -94,7 +94,7 @@ public class ExpressionFormatterTest {
             new Field("foo", new StringLiteral("abc")),
             new Field("bar", new SubscriptExpression(new ColumnReferenceExp(ColumnRef.withoutSource(ColumnName.of("abc"))), new IntegerLiteral(1))))
         )),
-        equalTo("STRUCT('abc' AS foo, abc[1] AS bar)"));
+        equalTo("STRUCT(foo:='abc', bar:=abc[1])"));
   }
 
   @Test

--- a/ksql-execution/src/test/java/io/confluent/ksql/execution/expression/formatter/ExpressionFormatterTest.java
+++ b/ksql-execution/src/test/java/io/confluent/ksql/execution/expression/formatter/ExpressionFormatterTest.java
@@ -20,6 +20,7 @@ import static org.junit.Assert.assertThat;
 import static org.mockito.Mockito.mock;
 
 import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
 import io.confluent.ksql.execution.expression.tree.ArithmeticBinaryExpression;
 import io.confluent.ksql.execution.expression.tree.ArithmeticUnaryExpression;
 import io.confluent.ksql.execution.expression.tree.BetweenPredicate;
@@ -33,6 +34,7 @@ import io.confluent.ksql.execution.expression.tree.DoubleLiteral;
 import io.confluent.ksql.execution.expression.tree.FunctionCall;
 import io.confluent.ksql.execution.expression.tree.InListExpression;
 import io.confluent.ksql.execution.expression.tree.InPredicate;
+import io.confluent.ksql.execution.expression.tree.IntegerLiteral;
 import io.confluent.ksql.execution.expression.tree.IsNotNullPredicate;
 import io.confluent.ksql.execution.expression.tree.IsNullPredicate;
 import io.confluent.ksql.execution.expression.tree.LikePredicate;
@@ -43,6 +45,7 @@ import io.confluent.ksql.execution.expression.tree.NullLiteral;
 import io.confluent.ksql.execution.expression.tree.SearchedCaseExpression;
 import io.confluent.ksql.execution.expression.tree.SimpleCaseExpression;
 import io.confluent.ksql.execution.expression.tree.StringLiteral;
+import io.confluent.ksql.execution.expression.tree.StructExpression;
 import io.confluent.ksql.execution.expression.tree.SubscriptExpression;
 import io.confluent.ksql.execution.expression.tree.TimeLiteral;
 import io.confluent.ksql.execution.expression.tree.TimestampLiteral;
@@ -82,6 +85,16 @@ public class ExpressionFormatterTest {
             new StringLiteral("abc"),
             new DoubleLiteral(3.0))),
         equalTo("'abc'[3.0]"));
+  }
+
+  @Test
+  public void shouldFormatStructExpression() {
+    assertThat(ExpressionFormatter.formatExpression(new StructExpression(
+        ImmutableMap.of(
+            "foo", new StringLiteral("abc"),
+            "bar", new SubscriptExpression(new ColumnReferenceExp(ColumnRef.withoutSource(ColumnName.of("abc"))), new IntegerLiteral(1)))
+        )),
+        equalTo("{foo 'abc', bar abc[1]}"));
   }
 
   @Test

--- a/ksql-execution/src/test/java/io/confluent/ksql/execution/expression/formatter/ExpressionFormatterTest.java
+++ b/ksql-execution/src/test/java/io/confluent/ksql/execution/expression/formatter/ExpressionFormatterTest.java
@@ -20,7 +20,6 @@ import static org.junit.Assert.assertThat;
 import static org.mockito.Mockito.mock;
 
 import com.google.common.collect.ImmutableList;
-import com.google.common.collect.ImmutableMap;
 import io.confluent.ksql.execution.expression.tree.ArithmeticBinaryExpression;
 import io.confluent.ksql.execution.expression.tree.ArithmeticUnaryExpression;
 import io.confluent.ksql.execution.expression.tree.BetweenPredicate;
@@ -28,6 +27,8 @@ import io.confluent.ksql.execution.expression.tree.BooleanLiteral;
 import io.confluent.ksql.execution.expression.tree.Cast;
 import io.confluent.ksql.execution.expression.tree.ColumnReferenceExp;
 import io.confluent.ksql.execution.expression.tree.ComparisonExpression;
+import io.confluent.ksql.execution.expression.tree.CreateStructExpression;
+import io.confluent.ksql.execution.expression.tree.CreateStructExpression.Field;
 import io.confluent.ksql.execution.expression.tree.DecimalLiteral;
 import io.confluent.ksql.execution.expression.tree.DereferenceExpression;
 import io.confluent.ksql.execution.expression.tree.DoubleLiteral;
@@ -45,7 +46,6 @@ import io.confluent.ksql.execution.expression.tree.NullLiteral;
 import io.confluent.ksql.execution.expression.tree.SearchedCaseExpression;
 import io.confluent.ksql.execution.expression.tree.SimpleCaseExpression;
 import io.confluent.ksql.execution.expression.tree.StringLiteral;
-import io.confluent.ksql.execution.expression.tree.CreateStructExpression;
 import io.confluent.ksql.execution.expression.tree.SubscriptExpression;
 import io.confluent.ksql.execution.expression.tree.TimeLiteral;
 import io.confluent.ksql.execution.expression.tree.TimestampLiteral;
@@ -90,9 +90,9 @@ public class ExpressionFormatterTest {
   @Test
   public void shouldFormatStructExpression() {
     assertThat(ExpressionFormatter.formatExpression(new CreateStructExpression(
-        ImmutableMap.of(
-            "foo", new StringLiteral("abc"),
-            "bar", new SubscriptExpression(new ColumnReferenceExp(ColumnRef.withoutSource(ColumnName.of("abc"))), new IntegerLiteral(1)))
+        ImmutableList.of(
+            new Field("foo", new StringLiteral("abc")),
+            new Field("bar", new SubscriptExpression(new ColumnReferenceExp(ColumnRef.withoutSource(ColumnName.of("abc"))), new IntegerLiteral(1))))
         )),
         equalTo("STRUCT('abc' AS foo, abc[1] AS bar)"));
   }

--- a/ksql-execution/src/test/java/io/confluent/ksql/execution/expression/formatter/ExpressionFormatterTest.java
+++ b/ksql-execution/src/test/java/io/confluent/ksql/execution/expression/formatter/ExpressionFormatterTest.java
@@ -93,8 +93,8 @@ public class ExpressionFormatterTest {
         ImmutableList.of(
             new Field("foo", new StringLiteral("abc")),
             new Field("bar", new SubscriptExpression(new ColumnReferenceExp(ColumnRef.withoutSource(ColumnName.of("abc"))), new IntegerLiteral(1))))
-        )),
-        equalTo("STRUCT(foo:='abc', bar:=abc[1])"));
+        ), FormatOptions.of(exp -> exp.equals("foo"))),
+        equalTo("STRUCT(`foo`:='abc', bar:=abc[1])"));
   }
 
   @Test

--- a/ksql-execution/src/test/java/io/confluent/ksql/execution/util/ExpressionTypeManagerTest.java
+++ b/ksql-execution/src/test/java/io/confluent/ksql/execution/util/ExpressionTypeManagerTest.java
@@ -50,7 +50,7 @@ import io.confluent.ksql.execution.expression.tree.NotExpression;
 import io.confluent.ksql.execution.expression.tree.SearchedCaseExpression;
 import io.confluent.ksql.execution.expression.tree.SimpleCaseExpression;
 import io.confluent.ksql.execution.expression.tree.StringLiteral;
-import io.confluent.ksql.execution.expression.tree.StructExpression;
+import io.confluent.ksql.execution.expression.tree.CreateStructExpression;
 import io.confluent.ksql.execution.expression.tree.SubscriptExpression;
 import io.confluent.ksql.execution.expression.tree.TimeLiteral;
 import io.confluent.ksql.execution.expression.tree.TimestampLiteral;
@@ -326,9 +326,10 @@ public class ExpressionTypeManagerTest {
         .build();
     expressionTypeManager = new ExpressionTypeManager(schema, functionRegistry);
 
-    Expression exp = new StructExpression(ImmutableMap.of(
+    Expression exp = new CreateStructExpression(ImmutableMap.of(
         "field1", new StringLiteral("foo"),
-        "field2", new ColumnReferenceExp(ColumnRef.of(TEST1, COL0))
+        "field2", new ColumnReferenceExp(ColumnRef.of(TEST1, COL0)),
+        "field3", new CreateStructExpression(ImmutableMap.of())
     ));
 
     // When:
@@ -339,6 +340,7 @@ public class ExpressionTypeManagerTest {
         is(SqlTypes.struct()
             .field("field1", SqlTypes.STRING)
             .field("field2", SqlTypes.array(SqlTypes.INTEGER))
+            .field("field3", SqlTypes.struct().build())
             .build()));
   }
 

--- a/ksql-execution/src/test/java/io/confluent/ksql/execution/util/ExpressionTypeManagerTest.java
+++ b/ksql-execution/src/test/java/io/confluent/ksql/execution/util/ExpressionTypeManagerTest.java
@@ -33,12 +33,13 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import com.google.common.collect.ImmutableList;
-import com.google.common.collect.ImmutableMap;
 import io.confluent.ksql.execution.expression.tree.ArithmeticBinaryExpression;
 import io.confluent.ksql.execution.expression.tree.BooleanLiteral;
 import io.confluent.ksql.execution.expression.tree.ColumnReferenceExp;
 import io.confluent.ksql.execution.expression.tree.ComparisonExpression;
 import io.confluent.ksql.execution.expression.tree.ComparisonExpression.Type;
+import io.confluent.ksql.execution.expression.tree.CreateStructExpression;
+import io.confluent.ksql.execution.expression.tree.CreateStructExpression.Field;
 import io.confluent.ksql.execution.expression.tree.DereferenceExpression;
 import io.confluent.ksql.execution.expression.tree.Expression;
 import io.confluent.ksql.execution.expression.tree.FunctionCall;
@@ -50,7 +51,6 @@ import io.confluent.ksql.execution.expression.tree.NotExpression;
 import io.confluent.ksql.execution.expression.tree.SearchedCaseExpression;
 import io.confluent.ksql.execution.expression.tree.SimpleCaseExpression;
 import io.confluent.ksql.execution.expression.tree.StringLiteral;
-import io.confluent.ksql.execution.expression.tree.CreateStructExpression;
 import io.confluent.ksql.execution.expression.tree.SubscriptExpression;
 import io.confluent.ksql.execution.expression.tree.TimeLiteral;
 import io.confluent.ksql.execution.expression.tree.TimestampLiteral;
@@ -326,10 +326,10 @@ public class ExpressionTypeManagerTest {
         .build();
     expressionTypeManager = new ExpressionTypeManager(schema, functionRegistry);
 
-    Expression exp = new CreateStructExpression(ImmutableMap.of(
-        "field1", new StringLiteral("foo"),
-        "field2", new ColumnReferenceExp(ColumnRef.of(TEST1, COL0)),
-        "field3", new CreateStructExpression(ImmutableMap.of())
+    Expression exp = new CreateStructExpression(ImmutableList.of(
+        new Field("field1", new StringLiteral("foo")),
+        new Field("field2", new ColumnReferenceExp(ColumnRef.of(TEST1, COL0))),
+        new Field("field3", new CreateStructExpression(ImmutableList.of()))
     ));
 
     // When:

--- a/ksql-functional-tests/src/test/resources/query-validation-tests/create-struct.json
+++ b/ksql-functional-tests/src/test/resources/query-validation-tests/create-struct.json
@@ -4,16 +4,42 @@
   ],
   "tests": [
     {
-      "name": "entries sorted",
+      "name": "basic struct creation",
       "statements": [
         "CREATE STREAM INPUT (col1 VARCHAR, col2 ARRAY<VARCHAR>) WITH (kafka_topic='test', value_format='JSON');",
-        "CREATE STREAM BIG_STRUCT AS SELECT {f1 COL1, f2 COL2, f3 SUBSTRING(col1, 2)} AS s FROM INPUT;"
+        "CREATE STREAM BIG_STRUCT AS SELECT STRUCT(COL1 as F1, COL2 as F2, SUBSTRING(col1, 2) as F3) AS s FROM INPUT;"
       ],
       "inputs": [
         { "topic": "test", "value": {"col1": "foo", "col2": ["bar"]}}
       ],
       "outputs": [
         { "topic": "BIG_STRUCT", "value": {"S": {"F1": "foo", "F2": ["bar"], "F3": "oo"}}}
+      ]
+    },
+    {
+      "name": "nested struct creation",
+      "statements": [
+        "CREATE STREAM INPUT (col1 VARCHAR) WITH (kafka_topic='test', value_format='JSON');",
+        "CREATE STREAM BIG_STRUCT AS SELECT STRUCT(STRUCT(col1 as c1) AS f1) AS s FROM INPUT;"
+      ],
+      "inputs": [
+        { "topic": "test", "value": {"col1": "foo"}}
+      ],
+      "outputs": [
+        { "topic": "BIG_STRUCT", "value": {"S": {"F1": {"C1": "foo"}}}}
+      ]
+    },
+    {
+      "name": "empty struct creation",
+      "statements": [
+        "CREATE STREAM INPUT (col1 VARCHAR) WITH (kafka_topic='test', value_format='JSON');",
+        "CREATE STREAM BIG_STRUCT AS SELECT STRUCT() AS s FROM INPUT;"
+      ],
+      "inputs": [
+        { "topic": "test", "value": {"col1": "foo"}}
+      ],
+      "outputs": [
+        { "topic": "BIG_STRUCT", "value": {"S": {}}}
       ]
     }
   ]

--- a/ksql-functional-tests/src/test/resources/query-validation-tests/create-struct.json
+++ b/ksql-functional-tests/src/test/resources/query-validation-tests/create-struct.json
@@ -1,0 +1,20 @@
+{
+  "comments": [
+    "Tests covering the use of the array returning UDFs."
+  ],
+  "tests": [
+    {
+      "name": "entries sorted",
+      "statements": [
+        "CREATE STREAM INPUT (col1 VARCHAR, col2 ARRAY<VARCHAR>) WITH (kafka_topic='test', value_format='JSON');",
+        "CREATE STREAM BIG_STRUCT AS SELECT {f1 COL1, f2 COL2, f3 SUBSTRING(col1, 2)} AS s FROM INPUT;"
+      ],
+      "inputs": [
+        { "topic": "test", "value": {"col1": "foo", "col2": ["bar"]}}
+      ],
+      "outputs": [
+        { "topic": "BIG_STRUCT", "value": {"S": {"F1": "foo", "F2": ["bar"], "F3": "oo"}}}
+      ]
+    }
+  ]
+}

--- a/ksql-functional-tests/src/test/resources/query-validation-tests/create-struct.json
+++ b/ksql-functional-tests/src/test/resources/query-validation-tests/create-struct.json
@@ -7,7 +7,7 @@
       "name": "basic struct creation",
       "statements": [
         "CREATE STREAM INPUT (col1 VARCHAR, col2 ARRAY<VARCHAR>) WITH (kafka_topic='test', value_format='JSON');",
-        "CREATE STREAM BIG_STRUCT AS SELECT STRUCT(COL1 as F1, COL2 as F2, SUBSTRING(col1, 2) as F3) AS s FROM INPUT;"
+        "CREATE STREAM BIG_STRUCT AS SELECT STRUCT(F1 := COL1, F2 := COL2, F3 := SUBSTRING(col1, 2)) AS s FROM INPUT;"
       ],
       "inputs": [
         { "topic": "test", "value": {"col1": "foo", "col2": ["bar"]}}
@@ -25,7 +25,7 @@
       "name": "nested struct creation",
       "statements": [
         "CREATE STREAM INPUT (col1 VARCHAR) WITH (kafka_topic='test', value_format='JSON');",
-        "CREATE STREAM BIG_STRUCT AS SELECT STRUCT(STRUCT(col1 as c1) AS f1) AS s FROM INPUT;"
+        "CREATE STREAM BIG_STRUCT AS SELECT STRUCT(f1 := STRUCT(c1 := col1)) AS s FROM INPUT;"
       ],
       "inputs": [
         { "topic": "test", "value": {"col1": "foo"}}

--- a/ksql-functional-tests/src/test/resources/query-validation-tests/create-struct.json
+++ b/ksql-functional-tests/src/test/resources/query-validation-tests/create-struct.json
@@ -14,7 +14,12 @@
       ],
       "outputs": [
         { "topic": "BIG_STRUCT", "value": {"S": {"F1": "foo", "F2": ["bar"], "F3": "oo"}}}
-      ]
+      ],
+      "post": {
+        "sources": [
+          {"name": "BIG_STRUCT", "type": "stream", "schema": "ROWKEY STRING KEY, S STRUCT<F1 STRING, F2 ARRAY<STRING>, F3 STRING>"}
+        ]
+      }
     },
     {
       "name": "nested struct creation",
@@ -27,7 +32,12 @@
       ],
       "outputs": [
         { "topic": "BIG_STRUCT", "value": {"S": {"F1": {"C1": "foo"}}}}
-      ]
+      ],
+      "post": {
+        "sources": [
+          {"name": "BIG_STRUCT", "type": "stream","schema": "ROWKEY STRING KEY, S STRUCT<F1 STRUCT<C1 STRING>>"}
+        ]
+      }
     },
     {
       "name": "empty struct creation",
@@ -40,7 +50,12 @@
       ],
       "outputs": [
         { "topic": "BIG_STRUCT", "value": {"S": {}}}
-      ]
+      ],
+      "post": {
+        "sources": [
+          {"name": "BIG_STRUCT", "type": "stream", "schema": "ROWKEY STRING KEY, S STRUCT< >"}
+        ]
+      }
     }
   ]
 }

--- a/ksql-functional-tests/src/test/resources/query-validation-tests/create-struct.json
+++ b/ksql-functional-tests/src/test/resources/query-validation-tests/create-struct.json
@@ -40,6 +40,24 @@
       }
     },
     {
+      "name": "quoted identifiers",
+      "statements": [
+        "CREATE STREAM INPUT (col1 VARCHAR) WITH (kafka_topic='test', value_format='JSON');",
+        "CREATE STREAM BIG_STRUCT AS SELECT STRUCT(FOO := col1, `foo` := col1) AS s FROM INPUT;"
+      ],
+      "inputs": [
+        { "topic": "test", "value": {"col1": "foo"}}
+      ],
+      "outputs": [
+        { "topic": "BIG_STRUCT", "value": {"S": {"FOO": "foo", "foo": "foo"}}}
+      ],
+      "post": {
+        "sources": [
+          {"name": "BIG_STRUCT", "type": "stream","schema": "ROWKEY STRING KEY, S STRUCT<FOO VARCHAR, `foo` VARCHAR>"}
+        ]
+      }
+    },
+    {
       "name": "empty struct creation",
       "statements": [
         "CREATE STREAM INPUT (col1 VARCHAR) WITH (kafka_topic='test', value_format='JSON');",
@@ -55,6 +73,17 @@
         "sources": [
           {"name": "BIG_STRUCT", "type": "stream", "schema": "ROWKEY STRING KEY, S STRUCT< >"}
         ]
+      }
+    },
+    {
+      "name": "duplicate fields",
+      "statements": [
+        "CREATE STREAM INPUT (col1 VARCHAR) WITH (kafka_topic='test', value_format='JSON');",
+        "CREATE STREAM BIG_STRUCT AS SELECT STRUCT(foo := col1, foo := col1) AS s FROM INPUT;"
+      ],
+      "expectedException": {
+        "type": "io.confluent.ksql.util.KsqlException",
+        "message": "Duplicate field names found in STRUCT"
       }
     }
   ]

--- a/ksql-functional-tests/src/test/resources/rest-query-validation-tests/insert-values.json
+++ b/ksql-functional-tests/src/test/resources/rest-query-validation-tests/insert-values.json
@@ -277,13 +277,23 @@
       "name": "should handle struct expressions",
       "statements": [
         "CREATE STREAM TEST (val STRUCT<foo DECIMAL(2, 1), `bar` ARRAY<VARCHAR>>) WITH (kafka_topic='test_topic', value_format='JSON');",
-        "INSERT INTO TEST (val) VALUES ({foo '2.1', `bar` AS_ARRAY('bar')});",
-        "INSERT INTO TEST (val) VALUES ({});"
+        "INSERT INTO TEST (val) VALUES (STRUCT('2.1' as FOO, AS_ARRAY('bar') AS `bar`));"
       ],
       "inputs": [
       ],
       "outputs": [
-        {"topic": "test_topic", "key": null, "value": {"VAL": {"FOO": 2.1, "bar": ["bar"]}}},
+        {"topic": "test_topic", "key": null, "value": {"VAL": {"FOO": 2.1, "bar": ["bar"]}}}
+      ]
+    },
+    {
+      "name": "should handle empty struct expressions",
+      "statements": [
+        "CREATE STREAM TEST (val STRUCT<foo DECIMAL(2, 1), `bar` ARRAY<VARCHAR>>) WITH (kafka_topic='test_topic', value_format='JSON');",
+        "INSERT INTO TEST (val) VALUES (STRUCT());"
+      ],
+      "inputs": [
+      ],
+      "outputs": [
         {"topic": "test_topic", "key": null, "value": {"VAL": {"FOO": null, "bar": null}}}
       ]
     }

--- a/ksql-functional-tests/src/test/resources/rest-query-validation-tests/insert-values.json
+++ b/ksql-functional-tests/src/test/resources/rest-query-validation-tests/insert-values.json
@@ -272,6 +272,20 @@
       "responses": [
         {"admin": {"@type": "currentStatus", "statementText": "{STATEMENT}"}}
       ]
+    },
+    {
+      "name": "should handle struct expressions",
+      "statements": [
+        "CREATE STREAM TEST (val STRUCT<foo DECIMAL(2, 1), `bar` ARRAY<VARCHAR>>) WITH (kafka_topic='test_topic', value_format='JSON');",
+        "INSERT INTO TEST (val) VALUES ({foo '2.1', `bar` AS_ARRAY('bar')});",
+        "INSERT INTO TEST (val) VALUES ({});"
+      ],
+      "inputs": [
+      ],
+      "outputs": [
+        {"topic": "test_topic", "key": null, "value": {"VAL": {"FOO": 2.1, "bar": ["bar"]}}},
+        {"topic": "test_topic", "key": null, "value": {"VAL": {"FOO": null, "bar": null}}}
+      ]
     }
   ]
 }

--- a/ksql-functional-tests/src/test/resources/rest-query-validation-tests/insert-values.json
+++ b/ksql-functional-tests/src/test/resources/rest-query-validation-tests/insert-values.json
@@ -277,7 +277,7 @@
       "name": "should handle struct expressions",
       "statements": [
         "CREATE STREAM TEST (val STRUCT<foo DECIMAL(2, 1), `bar` ARRAY<VARCHAR>>) WITH (kafka_topic='test_topic', value_format='JSON');",
-        "INSERT INTO TEST (val) VALUES (STRUCT('2.1' as FOO, AS_ARRAY('bar') AS `bar`));"
+        "INSERT INTO TEST (val) VALUES (STRUCT(FOO := '2.1', `bar` := AS_ARRAY('bar')));"
       ],
       "inputs": [
       ],
@@ -289,7 +289,7 @@
       "name": "should handle struct coercion",
       "statements": [
         "CREATE STREAM TEST (val STRUCT<foo BIGINT, bar ARRAY<BIGINT>, baz DOUBLE>) WITH (kafka_topic='test_topic', value_format='JSON');",
-        "INSERT INTO TEST (val) VALUES (STRUCT(2 as FOO, AS_ARRAY(2) as BAR, 2 as BAZ));"
+        "INSERT INTO TEST (val) VALUES (STRUCT(FOO := 2, BAR := AS_ARRAY(2), BAZ := 2));"
       ],
       "inputs": [
       ],

--- a/ksql-functional-tests/src/test/resources/rest-query-validation-tests/insert-values.json
+++ b/ksql-functional-tests/src/test/resources/rest-query-validation-tests/insert-values.json
@@ -286,6 +286,18 @@
       ]
     },
     {
+      "name": "should handle struct coercion",
+      "statements": [
+        "CREATE STREAM TEST (val STRUCT<foo BIGINT, bar ARRAY<BIGINT>, baz DOUBLE>) WITH (kafka_topic='test_topic', value_format='JSON');",
+        "INSERT INTO TEST (val) VALUES (STRUCT(2 as FOO, AS_ARRAY(2) as BAR, 2 as BAZ));"
+      ],
+      "inputs": [
+      ],
+      "outputs": [
+        {"topic": "test_topic", "key": null, "value": {"VAL": {"FOO": 2, "BAR": [2], "BAZ": 2.0}}}
+      ]
+    },
+    {
       "name": "should handle empty struct expressions",
       "statements": [
         "CREATE STREAM TEST (val STRUCT<foo DECIMAL(2, 1), `bar` ARRAY<VARCHAR>>) WITH (kafka_topic='test_topic', value_format='JSON');",

--- a/ksql-parser/src/main/antlr4/io/confluent/ksql/parser/SqlBase.g4
+++ b/ksql-parser/src/main/antlr4/io/confluent/ksql/parser/SqlBase.g4
@@ -248,20 +248,20 @@ valueExpression
     ;
 
 primaryExpression
-    : literal                                                                        #literalExpression
-    | identifier STRING                                                              #typeConstructor
-    | CASE valueExpression whenClause+ (ELSE elseExpression=expression)? END         #simpleCase
-    | CASE whenClause+ (ELSE elseExpression=expression)? END                         #searchedCase
-    | CAST '(' expression AS type ')'                                                #cast
-    | ARRAY '[' (expression (',' expression)*)? ']'                                  #arrayConstructor
-    | STRUCT '(' (expression AS identifier (',' expression AS identifier)*)? ')'     #structConstructor
-    | identifier '(' ASTERISK ')'                              		                   #functionCall
-    | identifier'(' (expression (',' expression)*)? ')' 						                 #functionCall
-    | value=primaryExpression '[' index=valueExpression ']'                          #subscript
-    | identifier                                                                     #columnReference
-    | identifier '.' identifier                                                      #columnReference
-    | base=primaryExpression STRUCT_FIELD_REF fieldName=identifier                   #dereference
-    | '(' expression ')'                                                             #parenthesizedExpression
+    : literal                                                                             #literalExpression
+    | identifier STRING                                                                   #typeConstructor
+    | CASE valueExpression whenClause+ (ELSE elseExpression=expression)? END              #simpleCase
+    | CASE whenClause+ (ELSE elseExpression=expression)? END                              #searchedCase
+    | CAST '(' expression AS type ')'                                                     #cast
+    | ARRAY '[' (expression (',' expression)*)? ']'                                       #arrayConstructor
+    | STRUCT '(' (identifier ASSIGN expression (',' identifier ASSIGN expression)*)? ')'  #structConstructor
+    | identifier '(' ASTERISK ')'                              		                        #functionCall
+    | identifier'(' (expression (',' expression)*)? ')' 						                      #functionCall
+    | value=primaryExpression '[' index=valueExpression ']'                               #subscript
+    | identifier                                                                          #columnReference
+    | identifier '.' identifier                                                           #columnReference
+    | base=primaryExpression STRUCT_FIELD_REF fieldName=identifier                        #dereference
+    | '(' expression ')'                                                                  #parenthesizedExpression
     ;
 
 timeZoneSpecifier
@@ -473,6 +473,7 @@ SLASH: '/';
 PERCENT: '%';
 CONCAT: '||';
 
+ASSIGN: ':=';
 STRUCT_FIELD_REF: '->';
 
 STRING

--- a/ksql-parser/src/main/antlr4/io/confluent/ksql/parser/SqlBase.g4
+++ b/ksql-parser/src/main/antlr4/io/confluent/ksql/parser/SqlBase.g4
@@ -250,13 +250,13 @@ valueExpression
 primaryExpression
     : literal                                                                        #literalExpression
     | identifier STRING                                                              #typeConstructor
-    | identifier '(' ASTERISK ')'                              		                   #functionCall
-    | identifier'(' (expression (',' expression)*)? ')' 						                 #functionCall
     | CASE valueExpression whenClause+ (ELSE elseExpression=expression)? END         #simpleCase
     | CASE whenClause+ (ELSE elseExpression=expression)? END                         #searchedCase
     | CAST '(' expression AS type ')'                                                #cast
     | ARRAY '[' (expression (',' expression)*)? ']'                                  #arrayConstructor
-    | '{' (identifier expression (',' identifier expression)*)? '}'                  #structConstructor
+    | STRUCT '(' (expression AS identifier (',' expression AS identifier)*)? ')'     #structConstructor
+    | identifier '(' ASTERISK ')'                              		                   #functionCall
+    | identifier'(' (expression (',' expression)*)? ')' 						                 #functionCall
     | value=primaryExpression '[' index=valueExpression ']'                          #subscript
     | identifier                                                                     #columnReference
     | identifier '.' identifier                                                      #columnReference

--- a/ksql-parser/src/main/antlr4/io/confluent/ksql/parser/SqlBase.g4
+++ b/ksql-parser/src/main/antlr4/io/confluent/ksql/parser/SqlBase.g4
@@ -256,6 +256,7 @@ primaryExpression
     | CASE whenClause+ (ELSE elseExpression=expression)? END                         #searchedCase
     | CAST '(' expression AS type ')'                                                #cast
     | ARRAY '[' (expression (',' expression)*)? ']'                                  #arrayConstructor
+    | '{' (identifier expression (',' identifier expression)*)? '}'                  #structConstructor
     | value=primaryExpression '[' index=valueExpression ']'                          #subscript
     | identifier                                                                     #columnReference
     | identifier '.' identifier                                                      #columnReference

--- a/ksql-parser/src/main/java/io/confluent/ksql/parser/AstBuilder.java
+++ b/ksql-parser/src/main/java/io/confluent/ksql/parser/AstBuilder.java
@@ -47,6 +47,7 @@ import io.confluent.ksql.execution.expression.tree.NullLiteral;
 import io.confluent.ksql.execution.expression.tree.SearchedCaseExpression;
 import io.confluent.ksql.execution.expression.tree.SimpleCaseExpression;
 import io.confluent.ksql.execution.expression.tree.StringLiteral;
+import io.confluent.ksql.execution.expression.tree.StructExpression;
 import io.confluent.ksql.execution.expression.tree.SubscriptExpression;
 import io.confluent.ksql.execution.expression.tree.TimeLiteral;
 import io.confluent.ksql.execution.expression.tree.TimestampLiteral;
@@ -922,6 +923,23 @@ public class AstBuilder {
           getLocation(context),
           (Expression) visit(context.expression()),
           typeParser.getType(context.type())
+      );
+    }
+
+    @Override
+    public Node visitStructConstructor(SqlBaseParser.StructConstructorContext context) {
+      ImmutableMap.Builder<String, Expression> struct = ImmutableMap.builder();
+
+      for (int i = 0; i < context.identifier().size(); i++) {
+        struct.put(
+            ParserUtil.getIdentifierText(context.identifier(i)),
+            (Expression) visit(context.expression(i))
+        );
+      }
+
+      return new StructExpression(
+          getLocation(context),
+          struct.build()
       );
     }
 

--- a/ksql-parser/src/main/java/io/confluent/ksql/parser/AstBuilder.java
+++ b/ksql-parser/src/main/java/io/confluent/ksql/parser/AstBuilder.java
@@ -31,6 +31,7 @@ import io.confluent.ksql.execution.expression.tree.BooleanLiteral;
 import io.confluent.ksql.execution.expression.tree.Cast;
 import io.confluent.ksql.execution.expression.tree.ColumnReferenceExp;
 import io.confluent.ksql.execution.expression.tree.ComparisonExpression;
+import io.confluent.ksql.execution.expression.tree.CreateStructExpression;
 import io.confluent.ksql.execution.expression.tree.DecimalLiteral;
 import io.confluent.ksql.execution.expression.tree.DereferenceExpression;
 import io.confluent.ksql.execution.expression.tree.Expression;
@@ -47,7 +48,6 @@ import io.confluent.ksql.execution.expression.tree.NullLiteral;
 import io.confluent.ksql.execution.expression.tree.SearchedCaseExpression;
 import io.confluent.ksql.execution.expression.tree.SimpleCaseExpression;
 import io.confluent.ksql.execution.expression.tree.StringLiteral;
-import io.confluent.ksql.execution.expression.tree.StructExpression;
 import io.confluent.ksql.execution.expression.tree.SubscriptExpression;
 import io.confluent.ksql.execution.expression.tree.TimeLiteral;
 import io.confluent.ksql.execution.expression.tree.TimestampLiteral;
@@ -937,7 +937,7 @@ public class AstBuilder {
         );
       }
 
-      return new StructExpression(
+      return new CreateStructExpression(
           getLocation(context),
           struct.build()
       );

--- a/ksql-parser/src/main/java/io/confluent/ksql/parser/AstBuilder.java
+++ b/ksql-parser/src/main/java/io/confluent/ksql/parser/AstBuilder.java
@@ -32,6 +32,7 @@ import io.confluent.ksql.execution.expression.tree.Cast;
 import io.confluent.ksql.execution.expression.tree.ColumnReferenceExp;
 import io.confluent.ksql.execution.expression.tree.ComparisonExpression;
 import io.confluent.ksql.execution.expression.tree.CreateStructExpression;
+import io.confluent.ksql.execution.expression.tree.CreateStructExpression.Field;
 import io.confluent.ksql.execution.expression.tree.DecimalLiteral;
 import io.confluent.ksql.execution.expression.tree.DereferenceExpression;
 import io.confluent.ksql.execution.expression.tree.Expression;
@@ -928,18 +929,18 @@ public class AstBuilder {
 
     @Override
     public Node visitStructConstructor(SqlBaseParser.StructConstructorContext context) {
-      ImmutableMap.Builder<String, Expression> struct = ImmutableMap.builder();
+      ImmutableList.Builder<Field> fields = ImmutableList.builder();
 
       for (int i = 0; i < context.identifier().size(); i++) {
-        struct.put(
+        fields.add(new Field(
             ParserUtil.getIdentifierText(context.identifier(i)),
             (Expression) visit(context.expression(i))
-        );
+        ));
       }
 
       return new CreateStructExpression(
           getLocation(context),
-          struct.build()
+          fields.build()
       );
     }
 

--- a/ksql-parser/src/main/java/io/confluent/ksql/schema/ksql/DefaultSqlValueCoercer.java
+++ b/ksql-parser/src/main/java/io/confluent/ksql/schema/ksql/DefaultSqlValueCoercer.java
@@ -94,7 +94,7 @@ public enum DefaultSqlValueCoercer implements SqlValueCoercer {
       Optional<io.confluent.ksql.schema.ksql.types.Field> sqlField = targetType.field(field.name());
       if (!sqlField.isPresent()) {
         // if there was a field in the struct that wasn't in the schema
-        // we should throw an exception
+        // we cannot coerce
         return Optional.empty();
       } else if (struct.schema().field(field.name()) == null) {
         // if we cannot find the field in the struct, we can ignore it


### PR DESCRIPTION
fixes #2147 

### Description 
I was trying to debug an issue (#3874) but to my chagrin I was incapable of finding anyway to produce a struct with a decimal in it to a kafka topic. So I wrote this. What is this? This is the ability to create `STRUCT` types directly from KSQL - a long awaited feature! 

The syntax is up for debate (cc @hjafarpour @blueedgenick @rmoff) though I'd rather not go too far on that tangent as it's a long awaited feature. At the moment I chose ~`{(identifier expression (, identifier expression)*)?}`~ `STRUCT((expression AS identifier (, expression AS identifier)*)?`

Here's how it's used (note that the examples use the old syntax):

**INSERT VALUES:**
```sql
ksql> CREATE STREAM decimals (col0 STRUCT<val DECIMAL(2,1)>) WITH (kafka_topic='decimals', partitions=1, value_format='AVRO');

 Message
----------------
 Stream created
----------------
ksql> INSERT INTO decimals (col0) VALUES ({VAL '2.1'});
ksql> SELECT COL0->val FROM DECIMALS EMIT CHANGES;
+----------------------------------------------------------------------------------------------+
|COL0__VAL                                                                                     |
+----------------------------------------------------------------------------------------------+
|2.1                                                                                           |
```

**CSAS:**
```sql
ksql> CREATE STREAM decimals2 as SELECT {times2 col0->val * 2, times3 col0->val * 3} FROM DECIMALS;

 Message
-----------------------------------------------------------------------------------------
 Stream DECIMALS2 created and running. Created by query with query ID: CSAS_DECIMALS2_12
-----------------------------------------------------------------------------------------
```
```sql
ksql> SELECT KSQL_COL_0->TIMES2, KSQL_COL_0->TIMES3 FROM DECIMALS2 EMIT CHANGES;
+----------------------------------------------+----------------------------------------------+
|KSQL_COL_0__TIMES2                            |KSQL_COL_0__TIMES3                            |
+----------------------------------------------+----------------------------------------------+
|4.2                                           |6.3                                           |
```
```sql
ksql> DESCRIBE DECIMALS2;

Name                 : DECIMALS2
 Field      | Type
-----------------------------------------------------
 ROWTIME    | BIGINT           (system)
 ROWKEY     | VARCHAR(STRING)  (system)
 KSQL_COL_0 | STRUCT<TIMES3 DECIMAL, TIMES2 DECIMAL>
-----------------------------------------------------
For runtime statistics and query details run: DESCRIBE EXTENDED <Stream,Table>;
```


### Implementation

Ah... so you care about how it's implemented, eh? It's actually surprisingly similar to the `FunctionCall` and `SubscriptExpression` implementations combined:

- The `ExpressionTypeManager` can figure out the type of the struct by recursively visiting each field's expression
- The `CodeGenRunner` creates the schema once, and passes it as an argument to the `ExpressionEvaluator`
- The `SqlToJavaVisitor` uses the param that was passed in (see the `SqlToJavaVisitorTest` for an example) to construct the struct in the code that it generates
- The `SqlValueCoercer` helps with some edge cases in `INSERT VALUES` clauses (namely to insert decimals)

That's all folk!

### Testing done 

- Unit tests
- QTT Testing
- E2E Integration testing

### Reviewer checklist
- [ ] Ensure docs are updated if necessary. (eg. if a user visible feature is being added or changed).
- [ ] Ensure relevant issues are linked (description should include text like "Fixes #<issue number>")

