### PR TITLE
test: do not mock config store in StandaloneExecutor integration test

### DIFF
--- a/ksql-common/src/main/java/io/confluent/ksql/util/KsqlConfig.java
+++ b/ksql-common/src/main/java/io/confluent/ksql/util/KsqlConfig.java
@@ -256,7 +256,7 @@ public class KsqlConfig extends AbstractConfig {
           new CompatibilityBreakingConfigDef(
               SINK_NUMBER_OF_PARTITIONS_PROPERTY,
               Type.INT,
-              4,
+              null,
               null,
               Importance.LOW,
               Optional.empty(),
@@ -266,7 +266,7 @@ public class KsqlConfig extends AbstractConfig {
           new CompatibilityBreakingConfigDef(
               SINK_NUMBER_OF_REPLICAS_PROPERTY,
               ConfigDef.Type.SHORT,
-              (short) 1,
+              null,
               null,
               ConfigDef.Importance.LOW,
               Optional.empty(),

--- a/ksql-rest-app/src/main/java/io/confluent/ksql/rest/server/StandaloneExecutor.java
+++ b/ksql-rest-app/src/main/java/io/confluent/ksql/rest/server/StandaloneExecutor.java
@@ -15,6 +15,7 @@
 
 package io.confluent.ksql.rest.server;
 
+import static java.util.Objects.nonNull;
 import static java.util.Objects.requireNonNull;
 
 import com.google.common.collect.ImmutableMap;
@@ -118,7 +119,11 @@ public class StandaloneExecutor implements Executable {
       processesQueryFile(readQueriesFile(queriesFile));
       showWelcomeMessage();
       final Properties properties = new Properties();
-      ksqlConfig.originals().forEach((key, value) -> properties.put(key, value.toString()));
+      ksqlConfig.originals().forEach((key, value) -> {
+        if (nonNull(value)) {
+          properties.put(key, value.toString());
+        }
+      });
       versionChecker.start(KsqlModuleType.SERVER, properties);
     } catch (final Exception e) {
       log.error("Failed to start KSQL Server with query file: " + queriesFile, e);

--- a/ksql-rest-app/src/test/java/io/confluent/ksql/rest/server/StandaloneExecutorFunctionalTest.java
+++ b/ksql-rest-app/src/test/java/io/confluent/ksql/rest/server/StandaloneExecutorFunctionalTest.java
@@ -17,14 +17,13 @@ package io.confluent.ksql.rest.server;
 
 import static io.confluent.ksql.serde.Format.AVRO;
 import static io.confluent.ksql.serde.Format.JSON;
-import static org.mockito.Mockito.when;
 
 import com.google.common.collect.ImmutableMap;
 import io.confluent.common.utils.IntegrationTest;
 import io.confluent.ksql.KsqlConfigTestUtil;
 import io.confluent.ksql.integration.IntegrationTestHarness;
 import io.confluent.ksql.name.ColumnName;
-import io.confluent.ksql.rest.server.computation.ConfigStore;
+import io.confluent.ksql.rest.server.computation.KafkaConfigStore;
 import io.confluent.ksql.schema.ksql.LogicalSchema;
 import io.confluent.ksql.schema.ksql.PhysicalSchema;
 import io.confluent.ksql.schema.ksql.types.SqlTypes;
@@ -77,8 +76,6 @@ public class StandaloneExecutorFunctionalTest {
 
   @Mock
   private VersionCheckerAgent versionChecker;
-  @Mock
-  private ConfigStore configStore;
   private Path queryFile;
   private StandaloneExecutor standalone;
   private String s1;
@@ -106,8 +103,6 @@ public class StandaloneExecutorFunctionalTest {
         .build();
     ksqlConfig = new KsqlConfig(properties);
 
-    when(configStore.getKsqlConfig()).thenReturn(ksqlConfig);
-
     final Function<KsqlConfig, ServiceContext> serviceContextFactory = config ->
         TestServiceContext.create(
             ksqlConfig,
@@ -119,7 +114,7 @@ public class StandaloneExecutorFunctionalTest {
         queryFile.toString(),
         ".",
         serviceContextFactory,
-        (topicName, currentConfig) -> configStore,
+        KafkaConfigStore::new,
         activeQuerySupplier -> versionChecker,
         StandaloneExecutor::new
     );

--- a/ksql-rest-app/src/test/java/io/confluent/ksql/rest/server/StandaloneExecutorTest.java
+++ b/ksql-rest-app/src/test/java/io/confluent/ksql/rest/server/StandaloneExecutorTest.java
@@ -83,6 +83,7 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
 import java.util.OptionalInt;
@@ -336,6 +337,24 @@ public class StandaloneExecutorTest {
 
     // Then:
     verify(ksqlEngine).parse("This statement");
+  }
+
+  @Test
+  public void shouldNotThrowIfNullValueInKsqlConfig() {
+    standaloneExecutor = new StandaloneExecutor(
+        serviceContext,
+        processingLogConfig,
+        new KsqlConfig(Collections.singletonMap("test", null)),
+        ksqlEngine,
+        queriesFile.toString(),
+        udfLoader,
+        false,
+        versionChecker,
+        injectorFactory
+    );
+
+    // When:
+    standaloneExecutor.start();
   }
 
   @Test


### PR DESCRIPTION
### Description 

As described in https://github.com/confluentinc/ksql/issues/4114, the ksqlDB server from the latest release fails to start in headless mode. This bug eluded our integration tests for headless mode because the integration test currently mocks the KafkaConfigStore which updates the KSQL config passed to the StandaloneExecutor (the mock does not perform these updates). This PR switches the integration test to use an actual KafkaConfigStore instance, rather than a mock, to avoid similar bugs in the future.

### Testing done 

Test-only change.

### Reviewer checklist
- [ ] Ensure docs are updated if necessary. (eg. if a user visible feature is being added or changed).
- [ ] Ensure relevant issues are linked (description should include text like "Fixes #<issue number>")

