### PR TITLE
Adds support for using primitive types in joins.

### DIFF
--- a/ksql-engine/src/main/java/io/confluent/ksql/planner/plan/DataSourceNode.java
+++ b/ksql-engine/src/main/java/io/confluent/ksql/planner/plan/DataSourceNode.java
@@ -95,7 +95,7 @@ public class DataSourceNode extends PlanNode {
     return dataSource;
   }
 
-  SourceName getAlias() {
+  public SourceName getAlias() {
     return alias;
   }
 

--- a/ksql-engine/src/main/java/io/confluent/ksql/planner/plan/JoinNode.java
+++ b/ksql-engine/src/main/java/io/confluent/ksql/planner/plan/JoinNode.java
@@ -480,7 +480,7 @@ public class JoinNode extends PlanNode {
       if (!keyColumn.isPresent()) {
         throw new KsqlException(
             "Invalid join criteria: Source table (" + sourceName + ") has no key column "
-                + "defined. Only 'ROWKEY' is supported in the join criteria."
+                + "defined. Only 'ROWKEY' is supported in the join criteria for a TABLE."
         );
       }
 
@@ -490,7 +490,8 @@ public class JoinNode extends PlanNode {
               + "(" + keyColumn.get().ref().toString(FormatOptions.noEscape()) + ") "
               + "is not the column used in the join criteria ("
               + joinCol.ref().toString(FormatOptions.noEscape()) + "). "
-              + "Only the table's key column or 'ROWKEY' is supported in the join criteria."
+              + "Only the table's key column or 'ROWKEY' is supported in the join criteria "
+              + "for a TABLE."
       );
     }
 

--- a/ksql-engine/src/main/java/io/confluent/ksql/planner/plan/JoinNode.java
+++ b/ksql-engine/src/main/java/io/confluent/ksql/planner/plan/JoinNode.java
@@ -25,13 +25,12 @@ import io.confluent.ksql.execution.plan.SelectExpression;
 import io.confluent.ksql.execution.streams.JoinParamsFactory;
 import io.confluent.ksql.metastore.model.DataSource.DataSourceType;
 import io.confluent.ksql.metastore.model.KeyField;
-import io.confluent.ksql.name.SourceName;
 import io.confluent.ksql.parser.tree.WithinExpression;
 import io.confluent.ksql.schema.ksql.Column;
+import io.confluent.ksql.schema.ksql.Column.Namespace;
 import io.confluent.ksql.schema.ksql.ColumnRef;
 import io.confluent.ksql.schema.ksql.FormatOptions;
 import io.confluent.ksql.schema.ksql.LogicalSchema;
-import io.confluent.ksql.schema.ksql.SqlBaseType;
 import io.confluent.ksql.serde.ValueFormat;
 import io.confluent.ksql.services.KafkaTopicClient;
 import io.confluent.ksql.structured.SchemaKStream;
@@ -93,11 +92,7 @@ public class JoinNode extends PlanNode {
             ? left.getKeyField()
             : KeyField.of(leftKeyCol.ref());
 
-    this.schema = JoinParamsFactory.createSchema(left.getSchema(), right.getSchema());
-
-    if (schema.key().get(0).type().baseType() != SqlBaseType.STRING) {
-      throw new KsqlException("JOIN is not supported with non-STRING keys");
-    }
+    this.schema = buildJoinSchema(left, leftJoinFieldName, right, rightJoinFieldName);
   }
 
   @Override
@@ -237,11 +232,7 @@ public class JoinNode extends PlanNode {
     }
 
     @SuppressWarnings("unchecked")
-    SchemaKTable<K> buildTable(
-        final PlanNode node,
-        final ColumnRef joinFieldName,
-        final SourceName tableName
-    ) {
+    SchemaKTable<K> buildTable(final PlanNode node) {
       final SchemaKStream<?> schemaKStream = node.buildStream(
           builder.withKsqlConfig(builder.getKsqlConfig()
               .cloneWithPropertyOverwrite(Collections.singletonMap(
@@ -252,37 +243,7 @@ public class JoinNode extends PlanNode {
         throw new RuntimeException("Expected to find a Table, found a stream instead.");
       }
 
-      final Optional<Column> keyColumn = schemaKStream
-          .getKeyField()
-          .resolve(schemaKStream.getSchema());
-
-      final ColumnRef rowKey = ColumnRef.of(
-          tableName,
-          SchemaUtil.ROWKEY_NAME
-      );
-
-      final boolean namesMatch = keyColumn
-          .map(field -> field.ref().equals(joinFieldName))
-          .orElse(false);
-
-      if (namesMatch || joinFieldName.equals(rowKey)) {
-        return (SchemaKTable) schemaKStream;
-      }
-
-      if (!keyColumn.isPresent()) {
-        throw new KsqlException(
-            "Source table (" + tableName.name() + ") has no key column defined. "
-                + "Only 'ROWKEY' is supported in the join criteria."
-        );
-      }
-
-      throw new KsqlException(
-          "Source table (" + tableName.toString(FormatOptions.noEscape()) + ") key column ("
-              + keyColumn.get().ref().toString(FormatOptions.noEscape()) + ") "
-              + "is not the column used in the join criteria ("
-              + joinFieldName.toString(FormatOptions.noEscape()) + "). "
-              + "Only the table's key column or 'ROWKEY' is supported in the join criteria."
-      );
+      return (SchemaKTable<K>) schemaKStream;
     }
 
     @SuppressWarnings("unchecked")
@@ -378,8 +339,7 @@ public class JoinNode extends PlanNode {
             + " the WITHIN clause) and try to execute your join again.");
       }
 
-      final SchemaKTable<K> rightTable = buildTable(
-          joinNode.getRight(), joinNode.rightJoinFieldName, joinNode.right.getAlias());
+      final SchemaKTable<K> rightTable = buildTable(joinNode.getRight());
 
       final SchemaKStream<K> leftStream = buildStream(
           joinNode.getLeft(), joinNode.leftJoinFieldName);
@@ -428,10 +388,8 @@ public class JoinNode extends PlanNode {
             + "join again.");
       }
 
-      final SchemaKTable<K> leftTable = buildTable(
-          joinNode.getLeft(), joinNode.leftJoinFieldName, joinNode.left.getAlias());
-      final SchemaKTable<K> rightTable = buildTable(
-          joinNode.getRight(), joinNode.rightJoinFieldName, joinNode.right.getAlias());
+      final SchemaKTable<K> leftTable = buildTable(joinNode.getLeft());
+      final SchemaKTable<K> rightTable = buildTable(joinNode.getRight());
 
       switch (joinNode.joinType) {
         case LEFT:
@@ -464,5 +422,81 @@ public class JoinNode extends PlanNode {
     return leftType == DataSourceType.KTABLE && rightType == DataSourceType.KTABLE
         ? DataSourceType.KTABLE
         : DataSourceType.KSTREAM;
+  }
+
+  private static LogicalSchema buildJoinSchema(
+      final DataSourceNode left,
+      final ColumnRef leftJoinFieldName,
+      final DataSourceNode right,
+      final ColumnRef rightJoinFieldName
+  ) {
+    final LogicalSchema leftSchema = selectKey(left, leftJoinFieldName);
+    final LogicalSchema rightSchema = selectKey(right, rightJoinFieldName);
+
+    return JoinParamsFactory.createSchema(leftSchema, rightSchema);
+  }
+
+  /**
+   * Adjust the schema to take into account any change in key columns.
+   *
+   * @param source the source node
+   * @param joinColumnRef the join column
+   * @return the true source schema after any change of key columns.
+   */
+  private static LogicalSchema selectKey(
+      final DataSourceNode source,
+      final ColumnRef joinColumnRef
+  ) {
+    final LogicalSchema sourceSchema = source.getSchema();
+
+    final Column joinCol = sourceSchema.findColumn(joinColumnRef)
+        .orElseThrow(() -> new KsqlException("Unknown join column: " + joinColumnRef));
+
+    if (sourceSchema.key().size() != 1) {
+      throw new UnsupportedOperationException("Only single key columns supported");
+    }
+
+    if (joinCol.namespace() == Namespace.KEY) {
+      // Join column is only key column, so no change of key columns required:
+      return sourceSchema;
+    }
+
+    final Optional<Column> keyColumn = source
+        .getKeyField()
+        .resolve(sourceSchema);
+
+    if (keyColumn.isPresent() && keyColumn.get().equals(joinCol)) {
+      // Join column is KEY field, which is an alias for the only key column, so no change of key
+      // columns required:
+      return sourceSchema;
+    }
+
+    // Change of key columns required
+
+    if (source.getDataSourceType() == DataSourceType.KTABLE) {
+      // Tables do not support rekey:
+      final String sourceName = source.getDataSource().getName().toString(FormatOptions.noEscape());
+
+      if (!keyColumn.isPresent()) {
+        throw new KsqlException(
+            "Invalid join criteria: Source table (" + sourceName + ") has no key column "
+                + "defined. Only 'ROWKEY' is supported in the join criteria."
+        );
+      }
+
+      throw new KsqlException(
+          "Invalid join criteria: Source table "
+              + "(" + sourceName + ") key column "
+              + "(" + keyColumn.get().ref().toString(FormatOptions.noEscape()) + ") "
+              + "is not the column used in the join criteria ("
+              + joinCol.ref().toString(FormatOptions.noEscape()) + "). "
+              + "Only the table's key column or 'ROWKEY' is supported in the join criteria."
+      );
+    }
+
+    return LogicalSchema.builder()
+        .keyColumn(source.getAlias(), SchemaUtil.ROWKEY_NAME, joinCol.type())
+        .valueColumns(sourceSchema.value())
+        .build();
   }
 }

--- a/ksql-engine/src/test/java/io/confluent/ksql/physical/PhysicalPlanBuilderTest.java
+++ b/ksql-engine/src/test/java/io/confluent/ksql/physical/PhysicalPlanBuilderTest.java
@@ -68,19 +68,19 @@ public class PhysicalPlanBuilderTest {
       + "WITH (KAFKA_TOPIC = 'test1', VALUE_FORMAT = 'JSON');";
 
   private static final String CREATE_STREAM_TEST2 = "CREATE STREAM TEST2 "
-      + "(ID BIGINT, COL0 VARCHAR, COL1 DOUBLE) "
+      + "(ROWKEY BIGINT KEY, ID BIGINT, COL0 VARCHAR, COL1 BIGINT) "
       + " WITH (KAFKA_TOPIC = 'test2', VALUE_FORMAT = 'JSON', KEY='ID');";
 
   private static final String CREATE_STREAM_TEST3 = "CREATE STREAM TEST3 "
-      + "(ID BIGINT, COL0 VARCHAR, COL1 DOUBLE) "
+      + "(ROWKEY BIGINT KEY, ID BIGINT, COL0 BIGINT, COL1 DOUBLE) "
       + " WITH (KAFKA_TOPIC = 'test3', VALUE_FORMAT = 'JSON', KEY='ID');";
 
   private static final String CREATE_TABLE_TEST4 = "CREATE TABLE TEST4 "
-      + "(ID BIGINT, COL0 VARCHAR, COL1 DOUBLE) "
+      + "(ROWKEY BIGINT KEY, ID BIGINT, COL0 VARCHAR, COL1 DOUBLE) "
       + " WITH (KAFKA_TOPIC = 'test4', VALUE_FORMAT = 'JSON', KEY='ID');";
 
   private static final String CREATE_TABLE_TEST5 = "CREATE TABLE TEST5 "
-      + "(ID BIGINT, COL0 VARCHAR, COL1 DOUBLE) "
+      + "(ROWKEY BIGINT KEY, ID BIGINT, COL0 VARCHAR, COL1 DOUBLE) "
       + " WITH (KAFKA_TOPIC = 'test5', VALUE_FORMAT = 'JSON', KEY='ID');";
 
   private static final String CREATE_STREAM_TEST6 = "CREATE STREAM TEST6 "
@@ -316,7 +316,7 @@ public class PhysicalPlanBuilderTest {
         .get(0);
 
     // Then:
-    assertThat(result.getExecutionPlan(), containsString("[ REKEY ] | Schema: [ROWKEY DOUBLE KEY, TEST2."));
+    assertThat(result.getExecutionPlan(), containsString("[ REKEY ] | Schema: [ROWKEY BIGINT KEY, TEST2."));
   }
 
   @Test
@@ -332,7 +332,7 @@ public class PhysicalPlanBuilderTest {
         .get(0);
 
     // Then:
-    assertThat(result.getExecutionPlan(), containsString("[ REKEY ] | Schema: [ROWKEY STRING KEY, TEST3."));
+    assertThat(result.getExecutionPlan(), containsString("[ REKEY ] | Schema: [ROWKEY BIGINT KEY, TEST3."));
   }
 
   @Test

--- a/ksql-engine/src/test/java/io/confluent/ksql/planner/LogicalPlannerTest.java
+++ b/ksql-engine/src/test/java/io/confluent/ksql/planner/LogicalPlannerTest.java
@@ -87,7 +87,7 @@ public class LogicalPlannerTest {
 
   @Test
   public void testSimpleLeftJoinLogicalPlan() {
-    final String simpleQuery = "SELECT t1.col1, t2.col1, t1.col4, t2.col2 FROM test1 t1 LEFT JOIN test2 t2 ON t1.col1 = t2.col1 EMIT CHANGES;";
+    final String simpleQuery = "SELECT t1.col1, t2.col1, t1.col4, t2.col2 FROM test1 t1 LEFT JOIN test2 t2 ON t1.col0 = t2.col0 EMIT CHANGES;";
     final PlanNode logicalPlan = buildLogicalPlan(simpleQuery);
 
     assertThat(logicalPlan.getSources().get(0), instanceOf(ProjectNode.class));
@@ -106,13 +106,13 @@ public class LogicalPlannerTest {
     final String
         simpleQuery =
         "SELECT t1.col1, t2.col1, col5, t2.col4, t2.col2 FROM test1 t1 LEFT JOIN test2 t2 ON "
-        + "t1.col1 = t2.col1 WHERE t1.col1 > 10 AND t2.col4 = 10.8 EMIT CHANGES;";
+        + "t1.col0 = t2.col0 WHERE t1.col1 > 10 AND t2.col4 = 10.8 EMIT CHANGES;";
     final PlanNode logicalPlan = buildLogicalPlan(simpleQuery);
 
     assertThat(logicalPlan.getSources().get(0), instanceOf(ProjectNode.class));
     final ProjectNode projectNode = (ProjectNode) logicalPlan.getSources().get(0);
 
-    assertThat(projectNode.getKeyField().ref(), is(Optional.of(ColumnRef.withoutSource(ColumnName.of("T1_COL1")))));
+    assertThat(projectNode.getKeyField().ref(), is(Optional.empty()));
     assertThat(projectNode.getSchema().value().size(), equalTo(5));
 
     assertThat(projectNode.getSources().get(0), instanceOf(FilterNode.class));
@@ -183,7 +183,7 @@ public class LogicalPlannerTest {
     final String
         simpleQuery =
         "SELECT t1.col1, t2.col1, col5, t2.col4, t2.col2 FROM test1 t1 LEFT JOIN test2 t2 ON "
-            + "t1.col1 = t2.col1 WHERE t1.col1 > 10 AND t2.col4 = 10.8 EMIT CHANGES;";
+            + "t1.col0 = t2.col0 WHERE t1.col1 > 10 AND t2.col4 = 10.8 EMIT CHANGES;";
     final PlanNode logicalPlan = buildLogicalPlan(simpleQuery);
     assertThat(logicalPlan.getNodeOutputType(), equalTo(DataSourceType.KSTREAM));
   }

--- a/ksql-engine/src/test/java/io/confluent/ksql/planner/PlanSourceExtractorVisitorTest.java
+++ b/ksql-engine/src/test/java/io/confluent/ksql/planner/PlanSourceExtractorVisitorTest.java
@@ -58,7 +58,7 @@ public class PlanSourceExtractorVisitorTest {
   public void shouldExtractCorrectSourceForJoinQuery() {
     final PlanNode planNode = buildLogicalPlan(
         "SELECT t1.col1, t2.col1, t1.col4, t2.col2 FROM test1 t1 LEFT JOIN "
-                          + "test2 t2 ON t1.col1 = t2.col1 EMIT CHANGES;");
+                          + "test2 t2 ON t1.col0 = t2.col0 EMIT CHANGES;");
     final PlanSourceExtractorVisitor planSourceExtractorVisitor = new PlanSourceExtractorVisitor();
     planSourceExtractorVisitor.process(planNode, null);
     final Set<SourceName> sourceNames = planSourceExtractorVisitor.getSourceNames();

--- a/ksql-engine/src/test/java/io/confluent/ksql/planner/plan/JoinNodeTest.java
+++ b/ksql-engine/src/test/java/io/confluent/ksql/planner/plan/JoinNodeTest.java
@@ -446,7 +446,7 @@ public class JoinNodeTest {
     expectedException.expect(KsqlException.class);
     expectedException.expectMessage(
         "Source table (Foobar2) key column (right.R1) is not the column used in the join criteria (right.C0). "
-            + "Only the table's key column or 'ROWKEY' is supported in the join criteria."
+            + "Only the table's key column or 'ROWKEY' is supported in the join criteria for a TABLE."
     );
 
     // When:
@@ -472,7 +472,7 @@ public class JoinNodeTest {
     expectedException.expect(KsqlException.class);
     expectedException.expectMessage(
         "Source table (Foobar2) has no key column defined. "
-            + "Only 'ROWKEY' is supported in the join criteria."
+            + "Only 'ROWKEY' is supported in the join criteria for a TABLE."
     );
 
     // When:
@@ -644,7 +644,7 @@ public class JoinNodeTest {
     expectedException.expect(KsqlException.class);
     expectedException.expectMessage(
         "Source table (Foobar1) key column (left.C0) is not the column used in the join criteria (left.L1). "
-            + "Only the table's key column or 'ROWKEY' is supported in the join criteria."
+            + "Only the table's key column or 'ROWKEY' is supported in the join criteria for a TABLE."
     );
 
     // When:
@@ -673,7 +673,7 @@ public class JoinNodeTest {
     expectedException.expect(KsqlException.class);
     expectedException.expectMessage(
         "Source table (Foobar2) key column (right.R1) is not the column used in the join criteria (right.C0). "
-            + "Only the table's key column or 'ROWKEY' is supported in the join criteria."
+            + "Only the table's key column or 'ROWKEY' is supported in the join criteria for a TABLE."
     );
 
     // When:

--- a/ksql-engine/src/test/java/io/confluent/ksql/planner/plan/KsqlStructuredDataOutputNodeTest.java
+++ b/ksql-engine/src/test/java/io/confluent/ksql/planner/plan/KsqlStructuredDataOutputNodeTest.java
@@ -118,10 +118,6 @@ public class KsqlStructuredDataOutputNodeTest {
 
     when(sourceStream.into(any(), any(), any(), any()))
         .thenReturn((SchemaKStream) sinkStream);
-    when(sourceStream.selectKey(any(), any()))
-        .thenReturn((SchemaKStream) resultWithKeySelected);
-    when(resultWithKeySelected.into(any(), any(), any(), any()))
-        .thenReturn((SchemaKStream) sinkStreamWithKeySelected);
 
     when(ksqlStreamBuilder.buildNodeContext(any())).thenAnswer(inv ->
         new QueryContext.Stacker()

--- a/ksql-engine/src/test/java/io/confluent/ksql/structured/SchemaKStreamTest.java
+++ b/ksql-engine/src/test/java/io/confluent/ksql/structured/SchemaKStreamTest.java
@@ -20,7 +20,6 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.contains;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.is;
-import static org.mockito.Mockito.mock;
 
 import com.google.common.collect.ImmutableList;
 import io.confluent.ksql.execution.builder.KsqlQueryBuilder;
@@ -93,7 +92,6 @@ public class SchemaKStreamTest {
   private final QueryContext.Stacker childContextStacker = queryContext.push("child");
 
   private SchemaKStream initialSchemaKStream;
-  private SchemaKStream secondSchemaKStream;
   private SchemaKTable schemaKTable;
   private KsqlStream<?> ksqlStream;
   private InternalFunctionRegistry functionRegistry;
@@ -112,10 +110,6 @@ public class SchemaKStreamTest {
     schemaResolver = new StepSchemaResolver(ksqlConfig, functionRegistry);
     ksqlStream = (KsqlStream) metaStore.getSource(SourceName.of("TEST1"));
     final KsqlStream secondKsqlStream = (KsqlStream) metaStore.getSource(SourceName.of("ORDERS"));
-    secondSchemaKStream = buildSchemaKStreamForJoin(
-        secondKsqlStream,
-        mock(ExecutionStep.class)
-    );
     final KsqlTable<?> ksqlTable = (KsqlTable) metaStore.getSource(SourceName.of("TEST2"));
     schemaKTable = new SchemaKTable(
         tableSourceStep,

--- a/ksql-engine/src/test/java/io/confluent/ksql/structured/SchemaKStreamTest.java
+++ b/ksql-engine/src/test/java/io/confluent/ksql/structured/SchemaKStreamTest.java
@@ -109,7 +109,6 @@ public class SchemaKStreamTest {
     functionRegistry = new InternalFunctionRegistry();
     schemaResolver = new StepSchemaResolver(ksqlConfig, functionRegistry);
     ksqlStream = (KsqlStream) metaStore.getSource(SourceName.of("TEST1"));
-    final KsqlStream secondKsqlStream = (KsqlStream) metaStore.getSource(SourceName.of("ORDERS"));
     final KsqlTable<?> ksqlTable = (KsqlTable) metaStore.getSource(SourceName.of("TEST2"));
     schemaKTable = new SchemaKTable(
         tableSourceStep,
@@ -797,16 +796,6 @@ public class SchemaKStreamTest {
   }
 
   private SchemaKStream buildSchemaKStreamForJoin(final KsqlStream ksqlStream) {
-    return buildSchemaKStream(
-        ksqlStream.getSchema().withAlias(SourceName.of("left")),
-        ksqlStream.getKeyField().withAlias(SourceName.of("left")),
-        sourceStep
-    );
-  }
-
-  private SchemaKStream buildSchemaKStreamForJoin(
-      final KsqlStream ksqlStream,
-      final ExecutionStep sourceStep) {
     return buildSchemaKStream(
         ksqlStream.getSchema().withAlias(SourceName.of("left")),
         ksqlStream.getKeyField().withAlias(SourceName.of("left")),

--- a/ksql-engine/src/test/java/io/confluent/ksql/structured/SchemaKStreamTest.java
+++ b/ksql-engine/src/test/java/io/confluent/ksql/structured/SchemaKStreamTest.java
@@ -63,7 +63,6 @@ import io.confluent.ksql.util.KsqlConfig;
 import io.confluent.ksql.util.KsqlException;
 import io.confluent.ksql.util.MetaStoreFixture;
 import io.confluent.ksql.util.Pair;
-import java.time.Duration;
 import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
@@ -85,7 +84,7 @@ public class SchemaKStreamTest {
   private final KsqlConfig ksqlConfig = new KsqlConfig(Collections.emptyMap());
   private final MetaStore metaStore = MetaStoreFixture.getNewMetaStore(new InternalFunctionRegistry());
   private final KeyField validJoinKeyField = KeyField
-      .of(Optional.of(ColumnRef.of(SourceName.of("left"), ColumnName.of("COL1"))));
+      .of(Optional.of(ColumnRef.of(SourceName.of("left"), ColumnName.of("COL0"))));
   private final KeyFormat keyFormat = KeyFormat.nonWindowed(FormatInfo.of(Format.KAFKA));
   private final ValueFormat valueFormat = ValueFormat.of(FormatInfo.of(Format.JSON));
   private final ValueFormat rightFormat = ValueFormat.of(FormatInfo.of(Format.DELIMITED));
@@ -422,33 +421,6 @@ public class SchemaKStreamTest {
   }
 
   @Test
-  public void shouldReturnSchemaKStreamWithCorrectSchemaForFilter() {
-    // Given:
-    final PlanNode logicalPlan = givenInitialKStreamOf(
-        "SELECT col0, col2, col3 FROM test1 WHERE col0 > 100 EMIT CHANGES;");
-    final FilterNode filterNode = (FilterNode) logicalPlan.getSources().get(0).getSources().get(0);
-
-    // When:
-    final SchemaKStream filteredSchemaKStream = initialSchemaKStream.filter(
-        filterNode.getPredicate(),
-        childContextStacker
-    );
-
-    // Then:
-    assertThat(filteredSchemaKStream.getSchema().value(), contains(
-        valueColumn(TEST1, ColumnName.of("ROWTIME"), SqlTypes.BIGINT),
-        valueColumn(TEST1, ColumnName.of("ROWKEY"), SqlTypes.STRING),
-        valueColumn(TEST1, ColumnName.of("COL0"), SqlTypes.BIGINT),
-        valueColumn(TEST1, ColumnName.of("COL1"), SqlTypes.STRING),
-        valueColumn(TEST1, ColumnName.of("COL2"), SqlTypes.STRING),
-        valueColumn(TEST1, ColumnName.of("COL3"), SqlTypes.DOUBLE),
-        valueColumn(TEST1, ColumnName.of("COL4"), SqlTypes.array(SqlTypes.DOUBLE)),
-        valueColumn(TEST1, ColumnName.of("COL5"), SqlTypes.map(SqlTypes.DOUBLE))
-    ));
-
-  }
-
-  @Test
   public void shouldRewriteTimeComparisonInFilter() {
     // Given:
     final PlanNode logicalPlan = givenInitialKStreamOf(
@@ -743,77 +715,6 @@ public class SchemaKStreamTest {
         ValueFormat rightFormat,
         QueryContext.Stacker contextStacker
     );
-  }
-
-  @Test
-  public void shouldBuildStepForStreamStreamJoin() {
-    // Given:
-    final SchemaKStream initialSchemaKStream = buildSchemaKStreamForJoin(ksqlStream);
-    final JoinWindows joinWindow = JoinWindows.of(Duration.ofMillis(10L));
-
-    final List<Pair<JoinType, StreamStreamJoin>> cases = ImmutableList.of(
-        Pair.of(JoinType.LEFT, initialSchemaKStream::leftJoin),
-        Pair.of(JoinType.INNER, initialSchemaKStream::join),
-        Pair.of(JoinType.OUTER, initialSchemaKStream::outerJoin)
-    );
-
-    for (final Pair<JoinType, StreamStreamJoin> testcase : cases) {
-      final SchemaKStream joinedKStream = testcase.right.join(
-          secondSchemaKStream,
-          validJoinKeyField,
-          joinWindow,
-          valueFormat,
-          rightFormat,
-          childContextStacker
-      );
-
-      // Then:
-      assertThat(
-          joinedKStream.getSourceStep(),
-          equalTo(
-              ExecutionStepFactory.streamStreamJoin(
-                  childContextStacker,
-                  testcase.left,
-                  Formats.of(keyFormat, valueFormat, SerdeOption.none()),
-                  Formats.of(keyFormat, rightFormat, SerdeOption.none()),
-                  initialSchemaKStream.getSourceStep(),
-                  secondSchemaKStream.getSourceStep(),
-                  joinWindow
-              )
-          )
-      );
-    }
-  }
-
-  @Test
-  public void shouldBuildSchemaForStreamStreamJoin() {
-    // Given:
-    final SchemaKStream initialSchemaKStream = buildSchemaKStreamForJoin(ksqlStream);
-    final JoinWindows joinWindow = JoinWindows.of(Duration.ofMillis(10L));
-
-    final List<Pair<JoinType, StreamStreamJoin>> cases = ImmutableList.of(
-        Pair.of(JoinType.LEFT, initialSchemaKStream::leftJoin),
-        Pair.of(JoinType.INNER, initialSchemaKStream::join),
-        Pair.of(JoinType.OUTER, initialSchemaKStream::outerJoin)
-    );
-
-    for (final Pair<JoinType, StreamStreamJoin> testcase : cases) {
-      final SchemaKStream joinedKStream = testcase.right.join(
-          secondSchemaKStream,
-          validJoinKeyField,
-          joinWindow,
-          valueFormat,
-          rightFormat,
-          childContextStacker
-      );
-
-      // Then:
-      assertThat(joinedKStream.getSchema(), is(schemaResolver.resolve(
-          joinedKStream.getSourceStep(),
-          initialSchemaKStream.getSchema(),
-          secondSchemaKStream.getSchema()))
-      );
-    }
   }
 
   @FunctionalInterface

--- a/ksql-functional-tests/src/test/resources/query-validation-tests/joins.json
+++ b/ksql-functional-tests/src/test/resources/query-validation-tests/joins.json
@@ -74,13 +74,13 @@
         {"topic": "left_topic", "key": "foo", "value": {"ID": 0, "NAME": "bar", "VALUE": 99}, "timestamp": 30000}
       ],
       "outputs": [
-        {"topic": "LEFT_OUTER_JOIN", "key": "0", "value": {"T_ID": 0, "T_ROWKEY": "foo","NAME": "zero", "VALUE": 0, "F1": null, "F2": null}, "timestamp": 0},
-        {"topic": "LEFT_OUTER_JOIN", "key": "0", "value": {"T_ID": 0, "T_ROWKEY": "foo", "NAME": "zero", "VALUE": 0, "F1": "blah", "F2": 50}, "timestamp": 10000},
-        {"topic": "LEFT_OUTER_JOIN", "key": "10", "value": {"T_ID": 10, "T_ROWKEY": "foo", "NAME": "100", "VALUE": 5, "F1": null, "F2": null}, "timestamp": 11000},
-        {"topic": "LEFT_OUTER_JOIN", "key": "0", "value": {"T_ID": 0, "T_ROWKEY": "foo", "NAME": "foo", "VALUE": 100, "F1": "blah", "F2": 50}, "timestamp": 13000},
-        {"topic": "LEFT_OUTER_JOIN", "key": "0", "value": {"T_ID": 0, "T_ROWKEY": "foo", "NAME": "foo", "VALUE": 100, "F1": "a", "F2": 10}, "timestamp": 15000},
-        {"topic": "LEFT_OUTER_JOIN", "key": "90", "value": {"T_ID": 90, "T_ROWKEY": "foo", "NAME": "ninety", "VALUE": 90, "F1": null, "F2": null}, "timestamp": 17000},
-        {"topic": "LEFT_OUTER_JOIN", "key": "0", "value": {"T_ID": 0, "T_ROWKEY": "foo", "NAME": "bar", "VALUE": 99, "F1": null, "F2": null}, "timestamp": 30000}
+        {"topic": "LEFT_OUTER_JOIN", "key": 0, "value": {"T_ID": 0, "T_ROWKEY": "foo","NAME": "zero", "VALUE": 0, "F1": null, "F2": null}, "timestamp": 0},
+        {"topic": "LEFT_OUTER_JOIN", "key": 0, "value": {"T_ID": 0, "T_ROWKEY": "foo", "NAME": "zero", "VALUE": 0, "F1": "blah", "F2": 50}, "timestamp": 10000},
+        {"topic": "LEFT_OUTER_JOIN", "key": 10, "value": {"T_ID": 10, "T_ROWKEY": "foo", "NAME": "100", "VALUE": 5, "F1": null, "F2": null}, "timestamp": 11000},
+        {"topic": "LEFT_OUTER_JOIN", "key": 0, "value": {"T_ID": 0, "T_ROWKEY": "foo", "NAME": "foo", "VALUE": 100, "F1": "blah", "F2": 50}, "timestamp": 13000},
+        {"topic": "LEFT_OUTER_JOIN", "key": 0, "value": {"T_ID": 0, "T_ROWKEY": "foo", "NAME": "foo", "VALUE": 100, "F1": "a", "F2": 10}, "timestamp": 15000},
+        {"topic": "LEFT_OUTER_JOIN", "key": 90, "value": {"T_ID": 90, "T_ROWKEY": "foo", "NAME": "ninety", "VALUE": 90, "F1": null, "F2": null}, "timestamp": 17000},
+        {"topic": "LEFT_OUTER_JOIN", "key": 0, "value": {"T_ID": 0, "T_ROWKEY": "foo", "NAME": "bar", "VALUE": 99, "F1": null, "F2": null}, "timestamp": 30000}
       ],
       "post": {
         "sources": [
@@ -109,14 +109,14 @@
         {"topic": "left_topic", "value": {"ID": 0, "NAME": "bar", "VALUE": 99}, "timestamp": 30000}
       ],
       "outputs": [
-        {"topic": "_confluent-ksql-some.ksql.service.idquery_CSAS_LEFT_OUTER_JOIN_0-Join-left-repartition", "key": "0", "value": {"ROWTIME": 0, "ROWKEY": "", "ID": 0, "NAME": "zero", "VALUE": 0}, "timestamp": 0},
-        {"topic": "_confluent-ksql-some.ksql.service.idquery_CSAS_LEFT_OUTER_JOIN_0-Join-right-repartition", "key": "0", "value": {"ROWTIME": 10000, "ROWKEY": "", "ID": 0, "F1": "blah", "F2": 50}, "timestamp": 10000},
-        {"topic": "_confluent-ksql-some.ksql.service.idquery_CSAS_LEFT_OUTER_JOIN_0-Join-left-repartition", "key": "10", "value": {"ROWTIME": 11000, "ROWKEY": "", "ID": 10, "NAME": "100", "VALUE": 5}, "timestamp": 11000},
-        {"topic": "_confluent-ksql-some.ksql.service.idquery_CSAS_LEFT_OUTER_JOIN_0-Join-left-repartition", "key": "0", "value": {"ROWTIME": 13000, "ROWKEY": "", "ID": 0, "NAME": "foo", "VALUE": 100}, "timestamp": 13000},
-        {"topic": "_confluent-ksql-some.ksql.service.idquery_CSAS_LEFT_OUTER_JOIN_0-Join-right-repartition", "key": "0", "value": {"ROWTIME": 15000, "ROWKEY": "", "ID": 0, "F1": "a", "F2": 10}, "timestamp": 15000},
-        {"topic": "_confluent-ksql-some.ksql.service.idquery_CSAS_LEFT_OUTER_JOIN_0-Join-right-repartition", "key": "100", "value": {"ROWTIME": 16000, "ROWKEY": "", "ID": 100, "F1": "newblah", "F2": 150}, "timestamp": 16000},
-        {"topic": "_confluent-ksql-some.ksql.service.idquery_CSAS_LEFT_OUTER_JOIN_0-Join-left-repartition", "key": "90", "value": {"ROWTIME": 17000, "ROWKEY": "", "ID": 90, "NAME": "ninety", "VALUE": 90}, "timestamp": 17000},
-        {"topic": "_confluent-ksql-some.ksql.service.idquery_CSAS_LEFT_OUTER_JOIN_0-Join-left-repartition", "key": "0", "value": {"ROWTIME": 30000, "ROWKEY": "", "ID": 0, "NAME": "bar", "VALUE": 99}, "timestamp": 30000},
+        {"topic": "_confluent-ksql-some.ksql.service.idquery_CSAS_LEFT_OUTER_JOIN_0-Join-left-repartition", "key": 0, "value": {"ROWTIME": 0, "ROWKEY": "", "ID": 0, "NAME": "zero", "VALUE": 0}, "timestamp": 0},
+        {"topic": "_confluent-ksql-some.ksql.service.idquery_CSAS_LEFT_OUTER_JOIN_0-Join-right-repartition", "key": 0, "value": {"ROWTIME": 10000, "ROWKEY": "", "ID": 0, "F1": "blah", "F2": 50}, "timestamp": 10000},
+        {"topic": "_confluent-ksql-some.ksql.service.idquery_CSAS_LEFT_OUTER_JOIN_0-Join-left-repartition", "key": 10, "value": {"ROWTIME": 11000, "ROWKEY": "", "ID": 10, "NAME": "100", "VALUE": 5}, "timestamp": 11000},
+        {"topic": "_confluent-ksql-some.ksql.service.idquery_CSAS_LEFT_OUTER_JOIN_0-Join-left-repartition", "key": 0, "value": {"ROWTIME": 13000, "ROWKEY": "", "ID": 0, "NAME": "foo", "VALUE": 100}, "timestamp": 13000},
+        {"topic": "_confluent-ksql-some.ksql.service.idquery_CSAS_LEFT_OUTER_JOIN_0-Join-right-repartition", "key": 0, "value": {"ROWTIME": 15000, "ROWKEY": "", "ID": 0, "F1": "a", "F2": 10}, "timestamp": 15000},
+        {"topic": "_confluent-ksql-some.ksql.service.idquery_CSAS_LEFT_OUTER_JOIN_0-Join-right-repartition", "key": 100, "value": {"ROWTIME": 16000, "ROWKEY": "", "ID": 100, "F1": "newblah", "F2": 150}, "timestamp": 16000},
+        {"topic": "_confluent-ksql-some.ksql.service.idquery_CSAS_LEFT_OUTER_JOIN_0-Join-left-repartition", "key": 90, "value": {"ROWTIME": 17000, "ROWKEY": "", "ID": 90, "NAME": "ninety", "VALUE": 90}, "timestamp": 17000},
+        {"topic": "_confluent-ksql-some.ksql.service.idquery_CSAS_LEFT_OUTER_JOIN_0-Join-left-repartition", "key": 0, "value": {"ROWTIME": 30000, "ROWKEY": "", "ID": 0, "NAME": "bar", "VALUE": 99}, "timestamp": 30000},
         {"topic": "_confluent-ksql-some.ksql.service.idquery_CSAS_LEFT_OUTER_JOIN_0-KSTREAM-JOINTHIS-0000000016-store-changelog", "key": "0\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0001", "value": {"ROWTIME": 0, "ROWKEY": "", "ID": 0, "NAME": "zero", "VALUE": 0}, "timestamp": 0},
         {"topic": "_confluent-ksql-some.ksql.service.idquery_CSAS_LEFT_OUTER_JOIN_0-KSTREAM-OUTEROTHER-0000000017-store-changelog", "key": "0\u0000\u0000\u0000\u0000\u0000\u0000'\u0010\u0000\u0000\u0000\u0001", "value": {"ROWTIME": 10000, "ROWKEY": "", "ID": 0, "F1": "blah", "F2": 50}, "timestamp": 10000},
         {"topic": "_confluent-ksql-some.ksql.service.idquery_CSAS_LEFT_OUTER_JOIN_0-KSTREAM-JOINTHIS-0000000016-store-changelog", "key": "10\u0000\u0000\u0000\u0000\u0000\u0000*�\u0000\u0000\u0000\u0002", "value": {"ROWTIME": 11000, "ROWKEY": "", "ID": 10, "NAME": "100", "VALUE": 5}, "timestamp": 11000},
@@ -125,13 +125,13 @@
         {"topic": "_confluent-ksql-some.ksql.service.idquery_CSAS_LEFT_OUTER_JOIN_0-KSTREAM-OUTEROTHER-0000000017-store-changelog", "key": "100\u0000\u0000\u0000\u0000\u0000\u0000>�\u0000\u0000\u0000\u0003", "value": {"ROWTIME": 16000, "ROWKEY": "", "ID": 100, "F1": "newblah", "F2": 150}, "timestamp": 16000},
         {"topic": "_confluent-ksql-some.ksql.service.idquery_CSAS_LEFT_OUTER_JOIN_0-KSTREAM-JOINTHIS-0000000016-store-changelog", "key": "90\u0000\u0000\u0000\u0000\u0000\u0000Bh\u0000\u0000\u0000\u0004", "value": {"ROWTIME": 17000, "ROWKEY": "", "ID": 90, "NAME": "ninety", "VALUE": 90}, "timestamp": 17000},
         {"topic": "_confluent-ksql-some.ksql.service.idquery_CSAS_LEFT_OUTER_JOIN_0-KSTREAM-JOINTHIS-0000000016-store-changelog", "key": "0\u0000\u0000\u0000\u0000\u0000\u0000u0\u0000\u0000\u0000\u0005", "value": {"ROWTIME": 30000, "ROWKEY": "", "ID": 0, "NAME": "bar", "VALUE": 99}, "timestamp": 30000},
-        {"topic": "LEFT_OUTER_JOIN", "key": "0", "value": {"T_ID": 0, "NAME": "zero", "VALUE": 0, "F1": null, "F2": null}, "timestamp": 0},
-        {"topic": "LEFT_OUTER_JOIN", "key": "0", "value": {"T_ID": 0, "NAME": "zero", "VALUE": 0, "F1": "blah", "F2": 50}, "timestamp": 10000},
-        {"topic": "LEFT_OUTER_JOIN", "key": "10", "value": {"T_ID": 10, "NAME": "100", "VALUE": 5, "F1": null, "F2": null}, "timestamp": 11000},
-        {"topic": "LEFT_OUTER_JOIN", "key": "0", "value": {"T_ID": 0, "NAME": "foo", "VALUE": 100, "F1": "blah", "F2": 50}, "timestamp": 13000},
-        {"topic": "LEFT_OUTER_JOIN", "key": "0", "value": {"T_ID": 0, "NAME": "foo", "VALUE": 100, "F1": "a", "F2": 10}, "timestamp": 15000},
-        {"topic": "LEFT_OUTER_JOIN", "key": "90", "value": {"T_ID": 90, "NAME": "ninety", "VALUE": 90, "F1": null, "F2": null}, "timestamp": 17000},
-        {"topic": "LEFT_OUTER_JOIN", "key": "0", "value": {"T_ID": 0, "NAME": "bar", "VALUE": 99, "F1": null, "F2": null}, "timestamp": 30000}
+        {"topic": "LEFT_OUTER_JOIN", "key": 0, "value": {"T_ID": 0, "NAME": "zero", "VALUE": 0, "F1": null, "F2": null}, "timestamp": 0},
+        {"topic": "LEFT_OUTER_JOIN", "key": 0, "value": {"T_ID": 0, "NAME": "zero", "VALUE": 0, "F1": "blah", "F2": 50}, "timestamp": 10000},
+        {"topic": "LEFT_OUTER_JOIN", "key": 10, "value": {"T_ID": 10, "NAME": "100", "VALUE": 5, "F1": null, "F2": null}, "timestamp": 11000},
+        {"topic": "LEFT_OUTER_JOIN", "key": 0, "value": {"T_ID": 0, "NAME": "foo", "VALUE": 100, "F1": "blah", "F2": 50}, "timestamp": 13000},
+        {"topic": "LEFT_OUTER_JOIN", "key": 0, "value": {"T_ID": 0, "NAME": "foo", "VALUE": 100, "F1": "a", "F2": 10}, "timestamp": 15000},
+        {"topic": "LEFT_OUTER_JOIN", "key": 90, "value": {"T_ID": 90, "NAME": "ninety", "VALUE": 90, "F1": null, "F2": null}, "timestamp": 17000},
+        {"topic": "LEFT_OUTER_JOIN", "key": 0, "value": {"T_ID": 0, "NAME": "bar", "VALUE": 99, "F1": null, "F2": null}, "timestamp": 30000}
       ],
       "post": {
         "sources": [
@@ -1286,7 +1286,7 @@
       ],
       "expectedException": {
         "type": "io.confluent.ksql.util.KsqlStatementException",
-        "message": "Source table (T) has no key column defined. Only 'ROWKEY' is supported in the join criteria."
+        "message": "Source table (NO_KEY) has no key column defined. Only 'ROWKEY' is supported in the join criteria."
       }
     },
     {
@@ -1771,6 +1771,72 @@
         "sources": [
           {"name": "LEFT_OUTER_JOIN", "type": "stream", "keyField": "LEFT_ID"}
         ]
+      }
+    },
+    {
+      "name": "on non-STRING key",
+      "statements": [
+        "CREATE STREAM INPUT_STREAM (ROWKEY BIGINT KEY, SF INT) WITH (kafka_topic='stream_topic', value_format='JSON');",
+        "CREATE TABLE INPUT_TABLE (ROWKEY BIGINT KEY, TF INT) WITH (kafka_topic='table_topic', value_format='JSON');",
+        "CREATE STREAM OUTPUT AS SELECT * FROM INPUT_STREAM S JOIN INPUT_TABLE T on S.ROWKEY = T.ROWKEY;"
+      ],
+      "inputs": [
+        {"topic": "table_topic", "key": 26589, "value": {"TF": 1}, "timestamp": 0},
+        {"topic": "stream_topic", "key": 12589, "value": {"SF": 0}, "timestamp": 100},
+        {"topic": "table_topic", "key": 12589, "value": {"TF": 12}, "timestamp": 200},
+        {"topic": "stream_topic", "key": 12589, "value": {"SF": 10}, "timestamp": 300}
+      ],
+      "outputs": [
+        {"topic": "OUTPUT", "key": 12589, "value": {"S_ROWKEY": 12589, "S_ROWTIME": 300, "S_SF": 10, "T_ROWKEY": 12589, "T_ROWTIME": 300, "T_TF": 12}, "timestamp": 300}
+      ],
+      "post": {
+        "sources": [
+          {
+            "name": "OUTPUT",
+            "type": "stream",
+            "keyFormat": {"format": "KAFKA"},
+            "schema": "ROWKEY BIGINT KEY, S_ROWTIME BIGINT, S_ROWKEY BIGINT, S_SF INT, T_ROWTIME BIGINT, T_ROWKEY BIGINT, T_TF INT"
+          }
+        ]
+      }
+    },
+    {
+      "name": "on non-STRING value column",
+      "statements": [
+        "CREATE STREAM INPUT_STREAM (ROWKEY STRING KEY, SF BIGINT) WITH (kafka_topic='stream_topic', value_format='JSON');",
+        "CREATE TABLE INPUT_TABLE (ROWKEY BIGINT KEY, ID BIGINT, TF INT) WITH (kafka_topic='table_topic', value_format='JSON', key='ID');",
+        "CREATE STREAM OUTPUT AS SELECT * FROM INPUT_STREAM S JOIN INPUT_TABLE T on S.SF = T.ID;"
+      ],
+      "inputs": [
+        {"topic": "table_topic", "key": 26589, "value": {"ID": 26589, "TF": 1}, "timestamp": 0},
+        {"topic": "stream_topic", "key": "a", "value": {"SF": 12589}, "timestamp": 100},
+        {"topic": "table_topic", "key": 12589, "value": {"ID": 12589, "TF": 12}, "timestamp": 200},
+        {"topic": "stream_topic", "key": "b", "value": {"SF": 12589}, "timestamp": 300}
+      ],
+      "outputs": [
+        {"topic": "OUTPUT", "key": 12589, "value": {"S_ROWKEY": "b", "S_ROWTIME": 300, "S_SF": 12589, "T_ROWKEY": 12589, "T_ROWTIME": 300, "T_ID": 12589, "T_TF": 12}, "timestamp": 300}
+      ],
+      "post": {
+        "sources": [
+          {
+            "name": "OUTPUT",
+            "type": "stream",
+            "keyFormat": {"format": "KAFKA"},
+            "schema": "ROWKEY BIGINT KEY, S_ROWTIME BIGINT, S_ROWKEY STRING, S_SF BIGINT, T_ROWTIME BIGINT, T_ROWKEY BIGINT, T_ID BIGINT, T_TF INT"
+          }
+        ]
+      }
+    },
+    {
+      "name": "on non-key table column",
+      "statements": [
+        "CREATE STREAM INPUT_STREAM (ROWKEY BIGINT KEY, SF BIGINT) WITH (kafka_topic='stream_topic', value_format='JSON');",
+        "CREATE TABLE INPUT_TABLE (ROWKEY BIGINT KEY, ID BIGINT, TF INT) WITH (kafka_topic='table_topic', value_format='JSON');",
+        "CREATE STREAM OUTPUT AS SELECT * FROM INPUT_STREAM S JOIN INPUT_TABLE T on S.ROWKEY = T.ID;"
+      ],
+      "expectedException": {
+        "type": "io.confluent.ksql.util.KsqlStatementException",
+        "message": "Invalid join criteria: Source table (INPUT_TABLE) has no key column defined. Only 'ROWKEY' is supported in the join criteria."
       }
     }
   ]

--- a/ksql-functional-tests/src/test/resources/query-validation-tests/joins.json
+++ b/ksql-functional-tests/src/test/resources/query-validation-tests/joins.json
@@ -1286,7 +1286,7 @@
       ],
       "expectedException": {
         "type": "io.confluent.ksql.util.KsqlStatementException",
-        "message": "Source table (NO_KEY) has no key column defined. Only 'ROWKEY' is supported in the join criteria."
+        "message": "Source table (NO_KEY) has no key column defined. Only 'ROWKEY' is supported in the join criteria for a TABLE."
       }
     },
     {
@@ -1836,7 +1836,91 @@
       ],
       "expectedException": {
         "type": "io.confluent.ksql.util.KsqlStatementException",
-        "message": "Invalid join criteria: Source table (INPUT_TABLE) has no key column defined. Only 'ROWKEY' is supported in the join criteria."
+        "message": "Invalid join criteria: Source table (INPUT_TABLE) has no key column defined. Only 'ROWKEY' is supported in the join criteria for a TABLE."
+      }
+    },
+    {
+      "name": "on INT column - KAFKA",
+      "format": ["AVRO", "JSON"],
+      "statements": [
+        "CREATE STREAM L (l0 INT, l1 INT) WITH (kafka_topic='left_topic', value_format='{FORMAT}');",
+        "CREATE STREAM R (r0 INT, r1 INT) WITH (kafka_topic='right_topic', value_format='{FORMAT}');",
+        "CREATE STREAM OUTPUT as SELECT L.ROWKEY, L1, R1 FROM L join R WITHIN 11 SECONDS ON L.l0 = R.r0;"
+      ],
+      "inputs": [
+        {"topic": "left_topic", "key": "a", "value": {"L0": 10, "L1": 1}, "timestamp": 0},
+        {"topic": "right_topic", "key": "b" ,"value": {"R0": 10, "R1": 2}, "timestamp": 10000}
+      ],
+      "outputs": [
+        {"topic": "OUTPUT", "key": 10, "value": {"L_ROWKEY": "a", "L1": 1, "R1": 2}, "timestamp": 10000}
+      ],
+      "post": {
+        "sources": [
+          {"name": "OUTPUT", "type": "stream", "schema": "ROWKEY INT KEY, L_ROWKEY STRING, L1 INT, R1 INT"}
+        ]
+      }
+    },
+    {
+      "name": "on BIGINT column - KAFKA",
+      "format": ["AVRO", "JSON"],
+      "statements": [
+        "CREATE STREAM L (l0 BIGINT, l1 INT) WITH (kafka_topic='left_topic', value_format='{FORMAT}');",
+        "CREATE STREAM R (r0 BIGINT, r1 INT) WITH (kafka_topic='right_topic', value_format='{FORMAT}');",
+        "CREATE STREAM OUTPUT as SELECT L.ROWKEY, L1, R1 FROM L join R WITHIN 11 SECONDS ON L.l0 = R.r0;"
+      ],
+      "inputs": [
+        {"topic": "left_topic", "key": "a", "value": {"L0": 1000000000, "L1": 1}, "timestamp": 0},
+        {"topic": "right_topic", "key": "b" ,"value": {"R0": 1000000000, "R1": 2}, "timestamp": 10000}
+      ],
+      "outputs": [
+        {"topic": "OUTPUT", "key": 1000000000, "value": {"L_ROWKEY": "a", "L1": 1, "R1": 2}, "timestamp": 10000}
+      ],
+      "post": {
+        "sources": [
+          {"name": "OUTPUT", "type": "stream", "schema": "ROWKEY BIGINT KEY, L_ROWKEY STRING, L1 INT, R1 INT"}
+        ]
+      }
+    },
+    {
+      "name": "on DOUBLE column - KAFKA",
+      "format": ["AVRO", "JSON"],
+      "statements": [
+        "CREATE STREAM L (l0 DOUBLE, l1 INT) WITH (kafka_topic='left_topic', value_format='{FORMAT}');",
+        "CREATE STREAM R (r0 DOUBLE, r1 INT) WITH (kafka_topic='right_topic', value_format='{FORMAT}');",
+        "CREATE STREAM OUTPUT as SELECT L.ROWKEY, L1, R1 FROM L join R WITHIN 11 SECONDS ON L.l0 = R.r0;"
+      ],
+      "inputs": [
+        {"topic": "left_topic", "key": "a", "value": {"L0": 1.23, "L1": 1}, "timestamp": 0},
+        {"topic": "right_topic", "key": "b" ,"value": {"R0": 1.23, "R1": 2}, "timestamp": 10000}
+      ],
+      "outputs": [
+        {"topic": "OUTPUT", "key": 1.23, "value": {"L_ROWKEY": "a", "L1": 1, "R1": 2}, "timestamp": 10000}
+      ],
+      "post": {
+        "sources": [
+          {"name": "OUTPUT", "type": "stream", "schema": "ROWKEY DOUBLE KEY, L_ROWKEY STRING, L1 INT, R1 INT"}
+        ]
+      }
+    },
+    {
+      "name": "on STRING column - KAFKA",
+      "format": ["AVRO", "JSON"],
+      "statements": [
+        "CREATE STREAM L (l0 STRING, l1 INT) WITH (kafka_topic='left_topic', value_format='{FORMAT}');",
+        "CREATE STREAM R (r0 STRING, r1 INT) WITH (kafka_topic='right_topic', value_format='{FORMAT}');",
+        "CREATE STREAM OUTPUT as SELECT L.ROWKEY, L1, R1 FROM L join R WITHIN 11 SECONDS ON L.l0 = R.r0;"
+      ],
+      "inputs": [
+        {"topic": "left_topic", "key": "a", "value": {"L0": "x", "L1": 1}, "timestamp": 0},
+        {"topic": "right_topic", "key": "b" ,"value": {"R0": "x", "R1": 2}, "timestamp": 10000}
+      ],
+      "outputs": [
+        {"topic": "OUTPUT", "key": "x", "value": {"L_ROWKEY": "a", "L1": 1, "R1": 2}, "timestamp": 10000}
+      ],
+      "post": {
+        "sources": [
+          {"name": "OUTPUT", "type": "stream", "schema": "ROWKEY STRING KEY, L_ROWKEY STRING, L1 INT, R1 INT"}
+        ]
       }
     }
   ]

--- a/ksql-metastore/src/test/java/io/confluent/ksql/util/MetaStoreFixture.java
+++ b/ksql-metastore/src/test/java/io/confluent/ksql/util/MetaStoreFixture.java
@@ -35,7 +35,6 @@ import io.confluent.ksql.serde.SerdeOption;
 import io.confluent.ksql.serde.ValueFormat;
 import java.util.Optional;
 
-@SuppressWarnings("OptionalGetWithoutIsPresent")
 public final class MetaStoreFixture {
 
   private MetaStoreFixture() {
@@ -54,6 +53,7 @@ public final class MetaStoreFixture {
     final KeyFormat keyFormat = KeyFormat.nonWindowed(FormatInfo.of(Format.KAFKA));
 
     final LogicalSchema test1Schema = LogicalSchema.builder()
+        .keyColumn(SchemaUtil.ROWKEY_NAME, SqlTypes.BIGINT)
         .valueColumn(ColumnName.of("COL0"), SqlTypes.BIGINT)
         .valueColumn(ColumnName.of("COL1"), SqlTypes.STRING)
         .valueColumn(ColumnName.of("COL2"), SqlTypes.STRING)
@@ -102,6 +102,7 @@ public final class MetaStoreFixture {
     metaStore.putSource(ksqlStream1);
 
     final LogicalSchema test2Schema = LogicalSchema.builder()
+        .keyColumn(SchemaUtil.ROWKEY_NAME, SqlTypes.BIGINT)
         .valueColumn(ColumnName.of("COL0"), SqlTypes.BIGINT)
         .valueColumn(ColumnName.of("COL1"), SqlTypes.STRING)
         .valueColumn(ColumnName.of("COL2"), SqlTypes.STRING)
@@ -178,6 +179,7 @@ public final class MetaStoreFixture {
     metaStore.putSource(ksqlStreamOrders);
 
     final LogicalSchema testTable3 = LogicalSchema.builder()
+        .keyColumn(SchemaUtil.ROWKEY_NAME, SqlTypes.BIGINT)
         .valueColumn(ColumnName.of("COL0"), SqlTypes.BIGINT)
         .valueColumn(ColumnName.of("COL1"), SqlTypes.STRING)
         .valueColumn(ColumnName.of("COL2"), SqlTypes.STRING)

--- a/ksql-streams/src/test/java/io/confluent/ksql/execution/streams/JoinParamsFactoryTest.java
+++ b/ksql-streams/src/test/java/io/confluent/ksql/execution/streams/JoinParamsFactoryTest.java
@@ -1,25 +1,32 @@
 package io.confluent.ksql.execution.streams;
 
+import static io.confluent.ksql.schema.ksql.ColumnMatchers.keyColumn;
 import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.Matchers.contains;
 import static org.junit.Assert.assertThat;
 
 import io.confluent.ksql.name.ColumnName;
 import io.confluent.ksql.name.SourceName;
 import io.confluent.ksql.schema.ksql.LogicalSchema;
 import io.confluent.ksql.schema.ksql.types.SqlTypes;
+import io.confluent.ksql.util.KsqlException;
 import io.confluent.ksql.util.SchemaUtil;
-import org.junit.Before;
+import org.junit.Rule;
 import org.junit.Test;
+import org.junit.rules.ExpectedException;
 
 public class JoinParamsFactoryTest {
+
   private static final SourceName LEFT = SourceName.of("LEFT");
   private static final SourceName RIGHT = SourceName.of("RIGHT");
+
   private static final LogicalSchema LEFT_SCHEMA = LogicalSchema.builder()
       .valueColumn(ColumnName.of("BLUE"), SqlTypes.STRING)
       .valueColumn(ColumnName.of("GREEN"), SqlTypes.INTEGER)
       .build()
       .withAlias(LEFT)
       .withMetaAndKeyColsInValue();
+
   private static final LogicalSchema RIGHT_SCHEMA = LogicalSchema.builder()
       .valueColumn(ColumnName.of("RED"), SqlTypes.BIGINT)
       .valueColumn(ColumnName.of("ORANGE"), SqlTypes.DOUBLE)
@@ -27,16 +34,18 @@ public class JoinParamsFactoryTest {
       .withAlias(RIGHT)
       .withMetaAndKeyColsInValue();
 
-  private JoinParams joinParams;
+  @Rule
+  public final ExpectedException expectedException = ExpectedException.none();
 
-  @Before
-  public void init() {
-    joinParams = JoinParamsFactory.create(LEFT_SCHEMA, RIGHT_SCHEMA);
-  }
+  private JoinParams joinParams;
 
   @Test
   public void shouldBuildCorrectSchema() {
-    final LogicalSchema expected = LogicalSchema.builder()
+    // when:
+    joinParams = JoinParamsFactory.create(LEFT_SCHEMA, RIGHT_SCHEMA);
+
+    // Then:
+    assertThat(joinParams.getSchema(), is(LogicalSchema.builder()
         .keyColumn(SchemaUtil.ROWKEY_NAME, SqlTypes.STRING)
         .valueColumn(LEFT, SchemaUtil.ROWTIME_NAME, SqlTypes.BIGINT)
         .valueColumn(LEFT, SchemaUtil.ROWKEY_NAME, SqlTypes.STRING)
@@ -46,7 +55,52 @@ public class JoinParamsFactoryTest {
         .valueColumn(RIGHT, SchemaUtil.ROWKEY_NAME, SqlTypes.STRING)
         .valueColumn(RIGHT, ColumnName.of("RED"), SqlTypes.BIGINT)
         .valueColumn(RIGHT, ColumnName.of("ORANGE"), SqlTypes.DOUBLE)
-        .build();
-    assertThat(joinParams.getSchema(), is(expected));
+        .build())
+    );
+  }
+
+  @Test
+  public void shouldThrowOnKeyTypeMismatch() {
+    // Given:
+    final LogicalSchema intKeySchema = LogicalSchema.builder()
+        .keyColumn(ColumnName.of("BOB"), SqlTypes.INTEGER)
+        .valueColumn(ColumnName.of("BLUE"), SqlTypes.STRING)
+        .valueColumn(ColumnName.of("GREEN"), SqlTypes.INTEGER)
+        .build()
+        .withAlias(LEFT)
+        .withMetaAndKeyColsInValue();
+
+    // Expect:
+    expectedException.expect(KsqlException.class);
+    expectedException.expectMessage("Invalid join. Key types differ: INTEGER vs STRING");
+
+    // When:
+    JoinParamsFactory.create(intKeySchema, RIGHT_SCHEMA);
+  }
+
+  @Test
+  public void shouldGetKeyFromLeftSource() {
+    // Given:
+    final LogicalSchema leftSchema = LogicalSchema.builder()
+        .keyColumn(ColumnName.of("BOB"), SqlTypes.BIGINT)
+        .valueColumn(ColumnName.of("BLUE"), SqlTypes.STRING)
+        .build()
+        .withAlias(LEFT)
+        .withMetaAndKeyColsInValue();
+
+    final LogicalSchema rightSchema = LogicalSchema.builder()
+        .keyColumn(ColumnName.of("VIC"), SqlTypes.BIGINT)
+        .valueColumn(ColumnName.of("GREEN"), SqlTypes.DOUBLE)
+        .build()
+        .withAlias(RIGHT)
+        .withMetaAndKeyColsInValue();
+
+    // when:
+    joinParams = JoinParamsFactory.create(leftSchema, rightSchema);
+
+    // Then:
+    assertThat(joinParams.getSchema().key(), contains(
+        keyColumn(ColumnName.of("BOB"), SqlTypes.BIGINT)
+    ));
   }
 }


### PR DESCRIPTION
### Description 

Fixes: https://github.com/confluentinc/ksql/issues/4094

BREAKING CHANGE: Some existing joins may now fail and the type of `ROWKEY` in the result schema of joins may have changed.

When `ROWKEY` was always a `STRING` it was possible to join an `INTEGER` column with a `BIGINT` column.  This is no longer the case. A `JOIN` requires the join columns to be of the same type. (See https://github.com/confluentinc/ksql/issues/4130 which tracks adding support for being able to `CAST` join criteria).

Where joining on two `INT` columns would previously have resulted in a schema containing `ROWKEY STRING KEY`, it would not result in `ROWKEY INT KEY`.

*NOTE*: a fair few tests needed to be fixed as they were now doing invalid joins or expecting a STRING key.  I also removed some tests that were failing as they duplicated existing QTT tests.

### Testing done 

usual

### Reviewer checklist
- [ ] Ensure docs are updated if necessary. (eg. if a user visible feature is being added or changed).
- [ ] Ensure relevant issues are linked (description should include text like "Fixes #<issue number>")

