### PR TITLE
fix: change query id generation to work with planned commands

### DIFF
--- a/ksql-engine/src/main/java/io/confluent/ksql/query/id/SpecificQueryIdGenerator.java
+++ b/ksql-engine/src/main/java/io/confluent/ksql/query/id/SpecificQueryIdGenerator.java
@@ -30,7 +30,7 @@ public class SpecificQueryIdGenerator implements QueryIdGenerator {
 
   public SpecificQueryIdGenerator() {
     this.nextId = 0L;
-    this.alreadyUsed = true;
+    this.alreadyUsed = false;
   }
 
   public void setNextId(final long nextId) {
@@ -50,6 +50,6 @@ public class SpecificQueryIdGenerator implements QueryIdGenerator {
 
   @Override
   public QueryIdGenerator createSandbox() {
-    return new SequentialQueryIdGenerator(nextId + 1);
+    return new SequentialQueryIdGenerator(nextId);
   }
 }

--- a/ksql-engine/src/test/java/io/confluent/ksql/query/id/SpecificQueryIdGeneratorTest.java
+++ b/ksql-engine/src/test/java/io/confluent/ksql/query/id/SpecificQueryIdGeneratorTest.java
@@ -40,7 +40,10 @@ public class SpecificQueryIdGeneratorTest {
     assertThat(generator.getNext(), is("5"));
   }
 
-
+  @Test
+  public void shouldReturnZeroIdForFirstQuery() {
+    assertThat(generator.getNext(), is("0"));
+  }
 
   @Test(expected = KsqlServerException.class)
   public void shouldThrowWhenGetNextBeforeSet() {
@@ -54,6 +57,6 @@ public class SpecificQueryIdGeneratorTest {
     generator.setNextId(3L);
     final QueryIdGenerator copy = generator.createSandbox();
     assertThat(copy, instanceOf(SequentialQueryIdGenerator.class));
-    assertThat(copy.getNext(), is("4"));
+    assertThat(copy.getNext(), is("3"));
   }
 }

--- a/ksql-rest-app/src/test/java/io/confluent/ksql/rest/server/computation/InteractiveStatementExecutorTest.java
+++ b/ksql-rest-app/src/test/java/io/confluent/ksql/rest/server/computation/InteractiveStatementExecutorTest.java
@@ -583,7 +583,7 @@ public class InteractiveStatementExecutorTest {
   }
 
   @Test
-  public void shouldSetNextQueryIdToNextOffsetWhenExecutingStatementCommand() {
+  public void shouldSetNextQueryIdToNextOffsetWhenExecutingRestoreCommand() {
     // Given:
     mockReplayCSAS(new QueryId("csas-query-id"));
 

--- a/ksql-rest-app/src/test/java/io/confluent/ksql/rest/server/computation/InteractiveStatementExecutorTest.java
+++ b/ksql-rest-app/src/test/java/io/confluent/ksql/rest/server/computation/InteractiveStatementExecutorTest.java
@@ -346,6 +346,18 @@ public class InteractiveStatementExecutorTest {
   }
 
   @Test
+  public void shouldSetNextQueryIdToNextOffsetWhenExecutingPlannedCommand() {
+    // Given:
+    givenMockPlannedQuery();
+
+    // When:
+    handleStatement(statementExecutorWithMocks, plannedCommand, COMMAND_ID, Optional.empty(), 2L);
+
+    // Then:
+    verify(mockQueryIdGenerator).setNextId(3L);
+  }
+
+  @Test
   public void shouldUpdateStatusOnCompletedPlannedCommand() {
     // Given:
     givenMockPlannedQuery();
@@ -568,6 +580,25 @@ public class InteractiveStatementExecutorTest {
         statementExecutor.getStatus(dropStreamCommandId3);
     assertThat(dropStreamCommandStatus3.get().getStatus(),
         CoreMatchers.equalTo(CommandStatus.Status.SUCCESS));
+  }
+
+  @Test
+  public void shouldSetNextQueryIdToNextOffsetWhenExecutingStatementCommand() {
+    // Given:
+    mockReplayCSAS(new QueryId("csas-query-id"));
+
+    // When:
+    statementExecutorWithMocks.handleRestore(
+        new QueuedCommand(
+            new CommandId(Type.STREAM, "foo", Action.CREATE),
+            new Command("CSAS", emptyMap(), emptyMap(), Optional.empty()),
+            Optional.empty(),
+            2L
+        )
+    );
+
+    // Then:
+    verify(mockQueryIdGenerator).setNextId(3L);
   }
 
   @Test

--- a/ksql-rest-app/src/test/java/io/confluent/ksql/rest/server/computation/RecoveryTest.java
+++ b/ksql-rest-app/src/test/java/io/confluent/ksql/rest/server/computation/RecoveryTest.java
@@ -37,6 +37,7 @@ import io.confluent.ksql.metastore.model.DataSource;
 import io.confluent.ksql.metrics.MetricCollectors;
 import io.confluent.ksql.name.SourceName;
 import io.confluent.ksql.query.QueryId;
+import io.confluent.ksql.query.id.QueryIdGenerator;
 import io.confluent.ksql.query.id.SpecificQueryIdGenerator;
 import io.confluent.ksql.rest.entity.CommandId;
 import io.confluent.ksql.rest.entity.CommandId.Action;
@@ -105,7 +106,7 @@ public class RecoveryTest {
     serviceContext.close();
   }
 
-  private KsqlEngine createKsqlEngine() {
+  private KsqlEngine createKsqlEngine(final QueryIdGenerator queryIdGenerator) {
     final KsqlEngineMetrics engineMetrics = mock(KsqlEngineMetrics.class);
     return KsqlEngineTestUtil.createKsqlEngine(
         serviceContext,
@@ -190,7 +191,8 @@ public class RecoveryTest {
     final ServerState serverState;
 
     KsqlServer(final List<QueuedCommand> commandLog) {
-      this.ksqlEngine = createKsqlEngine();
+      final SpecificQueryIdGenerator queryIdGenerator = new SpecificQueryIdGenerator();
+      this.ksqlEngine = createKsqlEngine(queryIdGenerator);
       this.fakeCommandQueue = new FakeCommandQueue(commandLog, transactionalProducer);
       serverState = new ServerState();
       serverState.setReady();
@@ -560,7 +562,7 @@ public class RecoveryTest {
     server1.submitCommands(
         "CREATE STREAM A (C1 STRING, C2 INT) WITH (KAFKA_TOPIC='A', VALUE_FORMAT='JSON');",
         "CREATE STREAM B AS SELECT C1 FROM A;",
-        "TERMINATE CSAS_B_1;",
+        "TERMINATE CSAS_B_0;",
         "DROP STREAM B;",
         "CREATE STREAM B AS SELECT C2 FROM A;"
     );
@@ -572,7 +574,7 @@ public class RecoveryTest {
     server1.submitCommands(
         "CREATE STREAM A (COLUMN STRING) WITH (KAFKA_TOPIC='A', VALUE_FORMAT='JSON');",
         "CREATE STREAM B AS SELECT * FROM A;",
-        "TERMINATE CSAS_B_1;"
+        "TERMINATE CSAS_B_0;"
     );
     shouldRecover(commands);
   }
@@ -582,7 +584,7 @@ public class RecoveryTest {
     server1.submitCommands(
         "CREATE STREAM A (COLUMN STRING) WITH (KAFKA_TOPIC='A', VALUE_FORMAT='JSON');",
         "CREATE STREAM B AS SELECT * FROM A;",
-        "TERMINATE CSAS_B_1;",
+        "TERMINATE CSAS_B_0;",
         "DROP STREAM B;"
     );
     shouldRecover(commands);
@@ -594,7 +596,7 @@ public class RecoveryTest {
     server1.submitCommands(
         "CREATE STREAM A (COLUMN STRING) WITH (KAFKA_TOPIC='A', VALUE_FORMAT='JSON');",
         "CREATE STREAM B AS SELECT * FROM A;",
-        "TERMINATE CSAS_B_1;",
+        "TERMINATE CSAS_B_0;",
         "DROP STREAM B DELETE TOPIC;"
     );
 
@@ -656,7 +658,7 @@ public class RecoveryTest {
     final Set<QueryId> queryIdNames = queriesById(server.ksqlEngine.getPersistentQueries())
         .keySet();
 
-    assertThat(queryIdNames, contains(new QueryId("CSAS_C_7")));
+    assertThat(queryIdNames, contains(new QueryId("CSAS_C_0")));
   }
 
 }


### PR DESCRIPTION
### Description 

This patch changes up how we generate query IDs to play nice with
planned commands. Before this change, statements would get the current
offset as their query id. However planned commands get their query IDs
before being enqueued, so they should really get the _next_ expected
offset as their ID. This patch changes up the id generation to work
this way. The next ID is set _after_ statements/plans are executed,
and is set to the next expected offset.