### PR TITLE
feat: ask for password if -p is not provided

### DIFF
--- a/ksql-cli/src/main/java/io/confluent/ksql/Ksql.java
+++ b/ksql-cli/src/main/java/io/confluent/ksql/Ksql.java
@@ -85,7 +85,7 @@ public final class Ksql {
   }
 
   private static String readPassword() {
-    Console console = System.console();
+    final Console console = System.console();
     if (console == null) {
       System.err.println("Could not get console for enter password; use -p option instead.");
       System.exit(-1);

--- a/ksql-cli/src/main/java/io/confluent/ksql/Ksql.java
+++ b/ksql-cli/src/main/java/io/confluent/ksql/Ksql.java
@@ -25,6 +25,8 @@ import io.confluent.ksql.rest.client.KsqlRestClient;
 import io.confluent.ksql.util.ErrorMessageUtil;
 import io.confluent.ksql.version.metrics.KsqlVersionCheckerAgent;
 import io.confluent.ksql.version.metrics.collector.KsqlModuleType;
+
+import java.io.Console;
 import java.io.File;
 import java.io.IOException;
 import java.util.Collections;
@@ -67,6 +69,11 @@ public final class Ksql {
       System.exit(-1);
     }
 
+    // ask for password if not set through command parameters
+    if (!options.getUserName().isEmpty() && !options.isPasswordSet()) {
+      options.setPassword(readPassword());
+    }
+
     try {
       new Ksql(options, System.getProperties(), KsqlRestClient::create, Cli::build).run();
     } catch (final Exception e) {
@@ -75,6 +82,16 @@ public final class Ksql {
       System.err.println(msg);
       System.exit(-1);
     }
+  }
+
+  private static String readPassword() {
+    Console console = System.console();
+    if (console == null) {
+      System.err.println("Could not get console for enter password; use -p option instead.");
+      System.exit(-1);
+    }
+    
+    return new String(console.readPassword("Enter password: "));
   }
 
   void run() {

--- a/ksql-cli/src/main/java/io/confluent/ksql/cli/Options.java
+++ b/ksql-cli/src/main/java/io/confluent/ksql/cli/Options.java
@@ -158,6 +158,18 @@ public class Options {
     return OutputFormat.valueOf(outputFormat);
   }
 
+  public String getUserName() {
+    return userName;
+  }
+
+  public void setPassword(String password) {
+    this.password = password;
+  }
+
+  public boolean isPasswordSet() {
+    return (password != null && !password.trim().isEmpty());
+  }
+
   public Optional<BasicCredentials> getUserNameAndPassword() {
     if ((userName == null && password != null) || (password == null && userName != null)) {
       throw new ConfigException(

--- a/ksql-cli/src/main/java/io/confluent/ksql/cli/Options.java
+++ b/ksql-cli/src/main/java/io/confluent/ksql/cli/Options.java
@@ -162,7 +162,7 @@ public class Options {
     return userName;
   }
 
-  public void setPassword(String password) {
+  public void setPassword(final String password) {
     this.password = password;
   }
 

--- a/ksql-cli/src/test/java/io/confluent/ksql/cli/commands/OptionsTest.java
+++ b/ksql-cli/src/test/java/io/confluent/ksql/cli/commands/OptionsTest.java
@@ -49,4 +49,21 @@ public class OptionsTest {
     assertFalse(options.getUserNameAndPassword().isPresent());
   }
 
+  @Test
+  public void shouldReturnFalseIfPasswordIsNull() throws Exception {
+    final Options options = Options.parse("http://foobar");
+    assertFalse(options.isPasswordSet());
+  }
+
+  @Test
+  public void shouldReturnFalseIfPasswordIsEmpty() throws Exception {
+    final Options options = Options.parse("http://foobar", "-u", "joe", "-p", "");
+    assertFalse(options.isPasswordSet());
+  }
+
+  @Test
+  public void shouldReturnTrueIfPasswordIsNotEmpty() throws Exception {
+    final Options options = Options.parse("http://foobar", "-u", "joe", "-p", "joe");
+    assertTrue(options.isPasswordSet());
+  }
 }

--- a/ksql-cli/src/test/java/io/confluent/ksql/cli/commands/OptionsTest.java
+++ b/ksql-cli/src/test/java/io/confluent/ksql/cli/commands/OptionsTest.java
@@ -50,19 +50,19 @@ public class OptionsTest {
   }
 
   @Test
-  public void shouldReturnFalseIfPasswordIsNull() throws Exception {
+  public void shouldReturnPasswordNotSetIfPasswordIsNull() throws Exception {
     final Options options = Options.parse("http://foobar");
     assertFalse(options.isPasswordSet());
   }
 
   @Test
-  public void shouldReturnFalseIfPasswordIsEmpty() throws Exception {
+  public void shouldReturnPasswordNotSetIfPasswordIsEmpty() throws Exception {
     final Options options = Options.parse("http://foobar", "-u", "joe", "-p", "");
     assertFalse(options.isPasswordSet());
   }
 
   @Test
-  public void shouldReturnTrueIfPasswordIsNotEmpty() throws Exception {
+  public void shouldReturnPasswordSetIfPasswordIsNotEmpty() throws Exception {
     final Options options = Options.parse("http://foobar", "-u", "joe", "-p", "joe");
     assertTrue(options.isPasswordSet());
   }


### PR DESCRIPTION
### Description 
_What behavior do you want to change, why, how does your patch achieve the changes?_

If the `-p` or `--password` parameters are not provided when using authentication, then the CLI will ask the user to enter the password on the prompt:
```
$  ./bin/ksql --user user1 http://localhost:8088
Enter password:
```

BREAKING CHANGE
The old behavior requires a user to type `--user` and `--password` parameters for authentication. This change makes `--password` optional.

This behavior provides an extra security to users who do not want to type the password in plaintext in the console. The `Enter password:` prompt will not echo the password.

### Testing done 
_Describe the testing strategy. Unit and integration tests are expected for any behavior changes._

* Added unit tests for the Options
* Tested manually

### Reviewer checklist
- [ ] Ensure docs are updated if necessary. (eg. if a user visible feature is being added or changed).
- [ ] Ensure relevant issues are linked (description should include text like "Fixes #<issue number>")

