### PR TITLE
fix: show topics doesn't display topics with different casing

### DIFF
--- a/ksql-rest-app/src/main/java/io/confluent/ksql/rest/server/execution/ListTopicsExecutor.java
+++ b/ksql-rest-app/src/main/java/io/confluent/ksql/rest/server/execution/ListTopicsExecutor.java
@@ -125,7 +125,7 @@ public final class ListTopicsExecutor {
     for (final Map.Entry<String, TopicDescription> entry : kafkaTopicDescriptions.entrySet()) {
       if (!entry.getKey().startsWith(serviceId + persistentQueryPrefix)
           && !entry.getKey().startsWith(serviceId + transientQueryPrefix)) {
-        filteredKafkaTopics.put(entry.getKey().toLowerCase(), entry.getValue());
+        filteredKafkaTopics.put(entry.getKey(), entry.getValue());
       }
     }
     return filteredKafkaTopics;


### PR DESCRIPTION
### Description 
https://github.com/confluentinc/ksql/issues/1284
Because we lower case all the keys when filtering out internal topics in the return, Kafka topics that differ only by casing will get overwritten in the list returned.
 
I'm not sure exactly why the `.toLowerCase()` is present, it's been there since late 2017 though.

### Testing done 
Unit Test
Did a `show topics` command in the CLI
### Reviewer checklist
- [ ] Ensure docs are updated if necessary. (eg. if a user visible feature is being added or changed).
- [ ] Ensure relevant issues are linked (description should include text like "Fixes #<issue number>")

