### PR TITLE
feat: Implementation of heartbeat mechanism as part of KLIP-12

### DIFF
--- a/ksql-engine/src/main/java/io/confluent/ksql/util/QueryMetadata.java
+++ b/ksql-engine/src/main/java/io/confluent/ksql/util/QueryMetadata.java
@@ -15,12 +15,14 @@
 
 package io.confluent.ksql.util;
 
+import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import io.confluent.ksql.internal.QueryStateListener;
 import io.confluent.ksql.name.SourceName;
 import io.confluent.ksql.schema.ksql.LogicalSchema;
 import java.lang.Thread.UncaughtExceptionHandler;
 import java.time.Duration;
+import java.util.Collection;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
@@ -28,6 +30,7 @@ import java.util.Set;
 import java.util.function.Consumer;
 import org.apache.kafka.streams.KafkaStreams;
 import org.apache.kafka.streams.Topology;
+import org.apache.kafka.streams.state.StreamsMetadata;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -127,6 +130,15 @@ public class QueryMetadata {
 
   public Topology getTopology() {
     return topology;
+  }
+
+  public Collection<StreamsMetadata> getAllMetadata() {
+    try {
+      return kafkaStreams.allMetadata();
+    } catch (IllegalStateException e) {
+      LOG.error(e.getMessage());
+    }
+    return ImmutableList.of();
   }
 
   public Map<String, Object> getStreamsProperties() {

--- a/ksql-execution/src/main/java/io/confluent/ksql/services/DisabledKsqlClient.java
+++ b/ksql-execution/src/main/java/io/confluent/ksql/services/DisabledKsqlClient.java
@@ -16,10 +16,12 @@
 package io.confluent.ksql.services;
 
 import io.confluent.ksql.rest.client.RestResponse;
+import io.confluent.ksql.rest.entity.ClusterStatusResponse;
 import io.confluent.ksql.rest.entity.KsqlEntityList;
 import io.confluent.ksql.rest.entity.StreamedRow;
 import java.net.URI;
 import java.util.List;
+import org.apache.kafka.streams.state.HostInfo;
 
 /**
  * A KSQL client implementation for use when communication with other nodes is not supported.
@@ -43,6 +45,20 @@ public final class DisabledKsqlClient implements SimpleKsqlClient {
       final URI serverEndPoint,
       final String sql
   ) {
+    throw new UnsupportedOperationException("KSQL client is disabled");
+  }
+
+  @Override
+  public void makeAsyncHeartbeatRequest(
+      final URI serverEndPoint,
+      final HostInfo host,
+      final long timestamp
+  ) {
+    throw new UnsupportedOperationException("KSQL client is disabled");
+  }
+
+  @Override
+  public RestResponse<ClusterStatusResponse> makeClusterStatusRequest(final URI serverEndPoint) {
     throw new UnsupportedOperationException("KSQL client is disabled");
   }
 }

--- a/ksql-execution/src/main/java/io/confluent/ksql/services/SimpleKsqlClient.java
+++ b/ksql-execution/src/main/java/io/confluent/ksql/services/SimpleKsqlClient.java
@@ -16,11 +16,13 @@
 package io.confluent.ksql.services;
 
 import io.confluent.ksql.rest.client.RestResponse;
+import io.confluent.ksql.rest.entity.ClusterStatusResponse;
 import io.confluent.ksql.rest.entity.KsqlEntityList;
 import io.confluent.ksql.rest.entity.StreamedRow;
 import java.net.URI;
 import java.util.List;
 import javax.annotation.concurrent.ThreadSafe;
+import org.apache.kafka.streams.state.HostInfo;
 
 @ThreadSafe
 public interface SimpleKsqlClient {
@@ -34,4 +36,23 @@ public interface SimpleKsqlClient {
       URI serverEndPoint,
       String sql
   );
+
+  /**
+   * Send heartbeat to remote Ksql server.
+   * @param serverEndPoint the remote destination.
+   * @param host the host information of the sender.
+   * @param timestamp the timestamp the heartbeat is sent.
+   */
+  void makeAsyncHeartbeatRequest(
+      URI serverEndPoint,
+      HostInfo host,
+      long timestamp
+  );
+
+  /**
+   * Send a request to remote Ksql server to inquire about its view of the status of the cluster.
+   * @param serverEndPoint the remote destination.
+   * @return response containing the cluster status.
+   */
+  RestResponse<ClusterStatusResponse> makeClusterStatusRequest(URI serverEndPoint);
 }

--- a/ksql-rest-app/src/main/java/io/confluent/ksql/rest/server/HeartbeatAgent.java
+++ b/ksql-rest-app/src/main/java/io/confluent/ksql/rest/server/HeartbeatAgent.java
@@ -1,0 +1,497 @@
+/*
+ * Copyright 2019 Confluent Inc.
+ *
+ * Licensed under the Confluent Community License (the "License"; you may not use
+ * this file except in compliance with the License. You may obtain a copy of the
+ * License at
+ *
+ * http://www.confluent.io/confluent-community-license
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package io.confluent.ksql.rest.server;
+
+import static java.util.Objects.requireNonNull;
+import static org.apache.kafka.common.utils.Utils.getHost;
+import static org.apache.kafka.common.utils.Utils.getPort;
+
+import com.google.common.annotations.VisibleForTesting;
+import com.google.common.util.concurrent.AbstractScheduledService;
+import com.google.common.util.concurrent.ServiceManager;
+import io.confluent.ksql.engine.KsqlEngine;
+import io.confluent.ksql.rest.entity.HostInfoEntity;
+import io.confluent.ksql.rest.entity.HostStatusEntity;
+import io.confluent.ksql.services.ServiceContext;
+import io.confluent.ksql.util.KsqlException;
+import io.confluent.ksql.util.PersistentQueryMetadata;
+import io.confluent.ksql.util.QueryMetadata;
+import java.net.URI;
+import java.net.URL;
+import java.time.Clock;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import java.util.Map.Entry;
+import java.util.Objects;
+import java.util.Set;
+import java.util.TreeMap;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.Executors;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
+import java.util.stream.Collectors;
+import org.apache.kafka.streams.processor.internals.StreamsMetadataState;
+import org.apache.kafka.streams.state.HostInfo;
+import org.apache.kafka.streams.state.StreamsMetadata;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * The heartbeat mechanism consists of three periodic tasks running at configurable time intervals:
+ * 1. Cluster membership: Discover the Ksql hosts that are part of the cluster.
+ * 2. Send heartbeats: Broadcast heartbeats to remote Ksql hosts.
+ * 3. Process received heartbeats: Determine which remote host is alive or dead.
+ *
+ * <p>The services are started in the following order by defining their startup delay:
+ * First, the cluster membership service starts, then the sending of the heartbeats and last the
+ * processing of the received heartbeats. This provides some buffer for the cluster to be discovered
+ * before the processing of heartbeats starts. However, it doesn't not guarantee that a remote
+ * server will not be classified as dead immediately after discovered (although we optimistically
+ * consider all newly discovered servers as alive) if there is lag in the sending/receiving of
+ * heartbeats. That's why the service that sends heartbeats sends to both alive and dead servers:
+ * avoid situations where a remote server is classified as down prematurely.</p>
+ *
+ */
+// CHECKSTYLE_RULES.OFF: ClassDataAbstractionCoupling
+public final class HeartbeatAgent {
+  // CHECKSTYLE_RULES.ON: ClassDataAbstractionCoupling
+
+  private static final int SERVICE_TIMEOUT_SEC = 2;
+  private static final int CHECK_HEARTBEAT_DELAY_MS = 1000;
+  private static final int SEND_HEARTBEAT_DELAY_MS = 100;
+  private static final Logger LOG = LoggerFactory.getLogger(HeartbeatAgent.class);
+
+  private final KsqlEngine engine;
+  private final ServiceContext serviceContext;
+  private final HeartbeatConfig config;
+  private final ConcurrentHashMap<String, TreeMap<Long, HeartbeatInfo>> receivedHeartbeats;
+  private final ConcurrentHashMap<String, HostStatusEntity> hostsStatus;
+  private final ScheduledExecutorService scheduledExecutorService;
+  private final ServiceManager serviceManager;
+  private final Clock clock;
+  private HostInfo localHostInfo;
+  private String localHostString;
+  private URL localURL;
+
+  public static HeartbeatAgent.Builder builder() {
+    return new HeartbeatAgent.Builder();
+  }
+
+  private HeartbeatAgent(final KsqlEngine engine,
+                         final ServiceContext serviceContext,
+                         final HeartbeatConfig config) {
+
+    this.engine = requireNonNull(engine, "engine");
+    this.serviceContext = requireNonNull(serviceContext, "serviceContext");
+    this.config = requireNonNull(config, "configuration parameters");
+    this.scheduledExecutorService = Executors.newScheduledThreadPool(config.threadPoolSize);
+    this.serviceManager = new ServiceManager(Arrays.asList(
+        new DiscoverClusterService(), new SendHeartbeatService(), new CheckHeartbeatService()));
+    this.receivedHeartbeats = new ConcurrentHashMap<>();
+    this.hostsStatus = new ConcurrentHashMap<>();
+    this.clock = Clock.systemUTC();
+  }
+
+  /**
+   * Stores the heartbeats received from a remote Ksql server.
+   * @param hostInfo The host information of the remote Ksql server.
+   * @param timestamp The timestamp the heartbeat was sent.
+   */
+  public void receiveHeartbeat(final HostInfo hostInfo, final long timestamp) {
+    final String hostKey = hostInfo.toString();
+    final TreeMap<Long, HeartbeatInfo> heartbeats = receivedHeartbeats.computeIfAbsent(
+        hostKey, key -> new TreeMap<>());
+    synchronized (heartbeats) {
+      LOG.debug("Receive heartbeat at: {} from host: {} ", timestamp, hostKey);
+      heartbeats.put(timestamp, new HeartbeatInfo(timestamp));
+    }
+  }
+
+  /**
+   * Returns the current view of the cluster containing all hosts discovered (whether alive or dead)
+   * @return status of discovered hosts
+   */
+  public Map<String, HostStatusEntity> getHostsStatus() {
+    return Collections.unmodifiableMap(hostsStatus);
+  }
+
+  @VisibleForTesting
+  void setHostsStatus(final Map<String, HostStatusEntity> status) {
+    hostsStatus.putAll(status);
+  }
+
+  void startAgent() {
+    try {
+      serviceManager.startAsync().awaitHealthy(SERVICE_TIMEOUT_SEC, TimeUnit.SECONDS);
+    } catch (TimeoutException | IllegalStateException e) {
+      LOG.error("Failed to start heartbeat services with exception " + e.getMessage(), e);
+    }
+  }
+
+  void stopAgent() {
+    try {
+      serviceManager.stopAsync().awaitStopped(SERVICE_TIMEOUT_SEC, TimeUnit.SECONDS);
+    } catch (TimeoutException | IllegalStateException e) {
+      LOG.error("Failed to stop heartbeat services with exception " + e.getMessage(), e);
+    } finally {
+      scheduledExecutorService.shutdownNow();
+    }
+  }
+
+  void setLocalAddress(final String applicationServer) {
+
+    this.localHostInfo = parseHostInfo(applicationServer);
+    this.localHostString = localHostInfo.toString();
+    try {
+      this.localURL = new URL(applicationServer);
+    } catch (final Exception e) {
+      throw new IllegalStateException("Failed to convert remote host info to URL."
+                                          + " remoteInfo: " + localHostInfo.host() + ":"
+                                          + localHostInfo.host());
+    }
+    this.hostsStatus.putIfAbsent(localHostString, new HostStatusEntity(
+        new HostInfoEntity(localHostInfo.host(), localHostInfo.port()),
+        true,
+        clock.millis()));
+  }
+
+  private static HostInfo parseHostInfo(final String endPoint) {
+    if (endPoint == null || endPoint.trim().isEmpty()) {
+      return StreamsMetadataState.UNKNOWN_HOST;
+    }
+    final String host = getHost(endPoint);
+    final Integer port = getPort(endPoint);
+
+    if (host == null || port == null) {
+      throw new KsqlException(String.format(
+          "Error parsing host address %s. Expected format host:port.", endPoint));
+    }
+
+    return new HostInfo(host, port);
+  }
+
+
+  /**
+   * Check the heartbeats received from remote hosts and apply policy to determine whether a host
+   * is alive or not.
+   */
+  class CheckHeartbeatService extends AbstractScheduledService {
+
+    @Override
+    protected void runOneIteration() {
+      final long now = clock.millis();
+      final long windowStart = now - config.heartbeatWindowMs;
+      runWithWindow(windowStart, now);
+    }
+
+    @VisibleForTesting
+    void runWithWindow(final long windowStart, final long windowEnd) {
+      try {
+        processHeartbeats(windowStart, windowEnd);
+      } catch (Throwable t) {
+        LOG.error("Failed to process heartbeats for window start = " + windowStart + " end = "
+                      + windowEnd + " with exception " + t.getMessage(), t);
+      }
+    }
+
+    @Override
+    protected Scheduler scheduler() {
+      return Scheduler.newFixedRateSchedule(CHECK_HEARTBEAT_DELAY_MS,
+                                            config.heartbeatCheckIntervalMs,
+                                            TimeUnit.MILLISECONDS);
+    }
+
+    @Override
+    protected ScheduledExecutorService executor() {
+      return scheduledExecutorService;
+    }
+
+    /**
+     * If no heartbeats have been received, all previously discovered hosts are marked as dead.
+     * If a previously discovered host has not received any heartbeat in this window, it is
+     * marked as dead.
+     * For all other hosts that received heartbeats, they are processed to determine whether the
+     * host is alive or dead based on how many consecutive heartbeats it missed.
+     * @param windowStart the start time in ms of the current window
+     * @param windowEnd the end time in ms of the current window
+     */
+    private void processHeartbeats(final long windowStart, final long windowEnd) {
+      // No heartbeats received -> mark all hosts as dead
+      if (receivedHeartbeats.isEmpty()) {
+        hostsStatus.forEach((host, status) -> {
+          if (!host.equals(localHostString)) {
+            status.setHostAlive(false);
+          }
+        });
+      }
+
+      for (String host: hostsStatus.keySet()) {
+        if (host.equals(localHostString)) {
+          continue;
+        }
+        final TreeMap<Long, HeartbeatInfo> heartbeats = receivedHeartbeats.get(host);
+        //For previously discovered hosts, if they have not received any heartbeats, mark them dead
+        if (heartbeats == null || heartbeats.isEmpty()) {
+          hostsStatus.get(host).setHostAlive(false);
+        } else {
+          final TreeMap<Long, HeartbeatInfo> copy;
+          synchronized (heartbeats) {
+            LOG.debug("Process heartbeats: {} of host: {}", heartbeats, host);
+            // 1. remove heartbeats older than window
+            heartbeats.headMap(windowStart).clear();
+            copy = new TreeMap<>(heartbeats.subMap(windowStart, true, windowEnd, true));
+          }
+          // 2. count consecutive missed heartbeats and mark as alive or dead
+          final  boolean isAlive = decideStatus(host, windowStart, windowEnd, copy);
+          final HostStatusEntity status = hostsStatus.get(host);
+          status.setHostAlive(isAlive);
+          status.setLastStatusUpdateMs(windowEnd);
+        }
+      }
+    }
+
+    private boolean decideStatus(final String host, final long windowStart, final long windowEnd,
+                              final TreeMap<Long, HeartbeatInfo> heartbeats) {
+      long missedCount = 0;
+      long prev = windowStart;
+      // No heartbeat received in this window
+      if (heartbeats.isEmpty()) {
+        return false;
+      }
+      // We want to count consecutive missed heartbeats and reset the count when we have received
+      // heartbeats. It's not enough to just count how many heartbeats we missed in the window as a
+      // host may have missed > THRESHOLD but not consecutive ones which doesn't constitute it
+      // as dead.
+      for (long ts : heartbeats.keySet()) {
+        //Don't count heartbeats after window end
+        if (ts >= windowEnd) {
+          break;
+        }
+        if (ts - config.heartbeatSendIntervalMs > prev) {
+          missedCount = (ts - prev - 1) / config.heartbeatSendIntervalMs;
+        } else {
+          //Reset missed count when we receive heartbeat
+          missedCount = 0;
+        }
+        prev = ts;
+      }
+      // Check frame from last received heartbeat to window end
+      if (windowEnd - prev - 1 > 0) {
+        missedCount = (windowEnd - prev - 1) / config.heartbeatSendIntervalMs;
+      }
+
+      LOG.debug("Host: {} has {} missing heartbeats", host, missedCount);
+      return (missedCount < config.heartbeatMissedThreshold);
+    }
+  }
+
+  /**
+   * Broadcast heartbeats to remote hosts whether they are alive or not.
+   * We are sending to hosts that might be dead because at startup, a host maybe marked as dead
+   * only because the sending of heartbeats has not preceded.
+   *
+   * <p>This is an asynchronous RPC and we do not handle the response returned from the remote
+   * server.</p>
+   */
+  class SendHeartbeatService extends AbstractScheduledService {
+
+    @Override
+    protected void runOneIteration() {
+      for (Entry<String, HostStatusEntity> hostStatusEntry: hostsStatus.entrySet()) {
+        final String host = hostStatusEntry.getKey();
+        final HostStatusEntity status = hostStatusEntry.getValue();
+        try {
+          if (!host.equals(localHostString)) {
+            final URI remoteUri = buildLocation(localURL, status.getHostInfoEntity().getHost(),
+                                          status.getHostInfoEntity().getPort());
+            LOG.debug("Send heartbeat to host {} at {}", status.getHostInfoEntity().getHost(),
+                      clock.millis());
+            serviceContext.getKsqlClient().makeAsyncHeartbeatRequest(remoteUri, localHostInfo,
+                                                                     clock.millis());
+          }
+        } catch (Throwable t) {
+          LOG.error("Request to server: " + status.getHostInfoEntity().getHost() + ":"
+                        + status.getHostInfoEntity().getPort()
+                        + " failed with exception: " + t.getMessage(), t);
+        }
+      }
+    }
+
+    @Override
+    protected Scheduler scheduler() {
+      return Scheduler.newFixedRateSchedule(SEND_HEARTBEAT_DELAY_MS,
+                                            config.heartbeatSendIntervalMs,
+                                            TimeUnit.MILLISECONDS);
+    }
+
+    @Override
+    protected ScheduledExecutorService executor() {
+      return scheduledExecutorService;
+    }
+
+    private URI buildLocation(final URL localHost, final String host, final int port) {
+      try {
+        return new URL(localHost.getProtocol(), host, port, "/").toURI();
+      } catch (final Exception e) {
+        throw new IllegalStateException("Failed to convert remote host info to URL."
+                                            + " remoteInfo: " + host + ":" + port);
+      }
+    }
+  }
+
+  /**
+   * Discovers remote hosts in the cluster through the metadata of currently running
+   * persistent queries.
+   */
+  class DiscoverClusterService extends AbstractScheduledService {
+
+    @Override
+    protected void runOneIteration() {
+      try {
+        final List<PersistentQueryMetadata> currentQueries = engine.getPersistentQueries();
+        if (currentQueries.isEmpty()) {
+          return;
+        }
+
+        final Set<HostInfo> uniqueHosts = currentQueries.stream()
+            .map(queryMetadata -> ((QueryMetadata) queryMetadata).getAllMetadata())
+            .filter(Objects::nonNull)
+            .flatMap(Collection::stream)
+            .map(StreamsMetadata::hostInfo)
+            .filter(hostInfo -> !(hostInfo.host().equals(localHostInfo.host())
+                && hostInfo.port() == (localHostInfo.port())))
+            .collect(Collectors.toSet());
+
+        for (HostInfo hostInfo : uniqueHosts) {
+          // Only add to map if it is the first time it is discovered. Design decision to
+          // optimistically consider every newly discovered server as alive to avoid situations of
+          // unavailability until the heartbeating kicks in.
+          hostsStatus.computeIfAbsent(hostInfo.toString(), key -> new HostStatusEntity(
+              new HostInfoEntity(hostInfo.host(), hostInfo.port()),
+              true,
+              clock.millis()));
+        }
+      } catch (Throwable t) {
+        LOG.error("Failed to discover cluster with exception " + t.getMessage(), t);
+      }
+    }
+
+    @Override
+    protected Scheduler scheduler() {
+      return Scheduler.newFixedRateSchedule(0, config.discoverClusterIntervalMs,
+                                            TimeUnit.MILLISECONDS);
+    }
+
+    @Override
+    protected ScheduledExecutorService executor() {
+      return scheduledExecutorService;
+    }
+  }
+
+  public static class Builder {
+
+    private int nestedThreadPoolSize;
+    private long nestedHeartbeatSendIntervalMs;
+    private long nestedHeartbeatCheckIntervalMs;
+    private long nestedDiscoverClusterIntervalMs;
+    private long nestedHeartbeatWindowMs;
+    private long nestedHeartbeatMissedThreshold;
+
+    HeartbeatAgent.Builder threadPoolSize(final int size) {
+      nestedThreadPoolSize = size;
+      return this;
+    }
+
+    HeartbeatAgent.Builder heartbeatSendInterval(final long interval) {
+      nestedHeartbeatSendIntervalMs = interval;
+      return this;
+    }
+
+    HeartbeatAgent.Builder heartbeatCheckInterval(final long interval) {
+      nestedHeartbeatCheckIntervalMs = interval;
+      return this;
+    }
+
+    HeartbeatAgent.Builder heartbeatWindow(final long window) {
+      nestedHeartbeatWindowMs = window;
+      return this;
+    }
+
+    HeartbeatAgent.Builder heartbeatMissedThreshold(final long missed) {
+      nestedHeartbeatMissedThreshold = missed;
+      return this;
+    }
+
+    HeartbeatAgent.Builder discoverClusterInterval(final long interval) {
+      nestedDiscoverClusterIntervalMs = interval;
+      return this;
+    }
+
+    public HeartbeatAgent build(final KsqlEngine engine,
+                                final ServiceContext serviceContext) {
+
+      return new HeartbeatAgent(engine,
+                                serviceContext,
+                                new HeartbeatConfig(nestedThreadPoolSize,
+                                                      nestedHeartbeatSendIntervalMs,
+                                                      nestedHeartbeatCheckIntervalMs,
+                                                      nestedHeartbeatWindowMs,
+                                                      nestedHeartbeatMissedThreshold,
+                                                      nestedDiscoverClusterIntervalMs));
+    }
+  }
+
+  static class HeartbeatConfig {
+    private final int threadPoolSize;
+    private final long heartbeatSendIntervalMs;
+    private final long heartbeatCheckIntervalMs;
+    private final long heartbeatWindowMs;
+    private final long heartbeatMissedThreshold;
+    private final long discoverClusterIntervalMs;
+
+    HeartbeatConfig(final int threadPoolSize, final long heartbeatSendIntervalMs,
+                    final long heartbeatCheckIntervalMs, final long heartbeatWindowMs,
+                    final long heartbeatMissedThreshold, final long discoverClusterIntervalMs) {
+      this.threadPoolSize = threadPoolSize;
+      this.heartbeatSendIntervalMs = heartbeatSendIntervalMs;
+      this.heartbeatCheckIntervalMs = heartbeatCheckIntervalMs;
+      this.heartbeatWindowMs = heartbeatWindowMs;
+      this.heartbeatMissedThreshold = heartbeatMissedThreshold;
+      this.discoverClusterIntervalMs = discoverClusterIntervalMs;
+    }
+  }
+
+  public static class HeartbeatInfo {
+    private final long timestamp;
+
+    public HeartbeatInfo(final long timestamp) {
+      this.timestamp = timestamp;
+    }
+
+    public long getTimestamp() {
+      return timestamp;
+    }
+
+    @Override
+    public String toString() {
+      return String.valueOf(timestamp);
+    }
+  }
+}

--- a/ksql-rest-app/src/main/java/io/confluent/ksql/rest/server/HeartbeatAgent.java
+++ b/ksql-rest-app/src/main/java/io/confluent/ksql/rest/server/HeartbeatAgent.java
@@ -62,11 +62,11 @@ import org.slf4j.LoggerFactory;
  * <p>The services are started in the following order by defining their startup delay:
  * First, the cluster membership service starts, then the sending of the heartbeats and last the
  * processing of the received heartbeats. This provides some buffer for the cluster to be discovered
- * before the processing of heartbeats starts. However, it doesn't not guarantee that a remote
+ * before the processing of heartbeats starts. However, it does not guarantee that a remote
  * server will not be classified as dead immediately after discovered (although we optimistically
  * consider all newly discovered servers as alive) if there is lag in the sending/receiving of
  * heartbeats. That's why the service that sends heartbeats sends to both alive and dead servers:
- * avoid situations where a remote server is classified as down prematurely.</p>
+ * avoid situations where a remote server is classified as dead prematurely.</p>
  *
  */
 // CHECKSTYLE_RULES.OFF: ClassDataAbstractionCoupling

--- a/ksql-rest-app/src/main/java/io/confluent/ksql/rest/server/KsqlRestConfig.java
+++ b/ksql-rest-app/src/main/java/io/confluent/ksql/rest/server/KsqlRestConfig.java
@@ -116,6 +116,40 @@ public class KsqlRestConfig extends RestConfig {
   private static final String KSQL_COMMAND_RUNNER_BLOCKED_THRESHHOLD_ERROR_MS_DOC =
       "How long to wait for the command runner to process a command from the command topic "
           + "before reporting an error metric.";
+  public static final String KSQL_HEARTBEAT_ENABLE_CONFIG =
+      KSQL_CONFIG_PREFIX + "heartbeat.enable";
+  private static final String KSQL_HEARTBEAT_ENABLE_DOC =
+      "Whether the heartheat mechanism is enabled or not. It is disabled by default.";
+
+  public static final String KSQL_HEARTBEAT_SEND_INTERVAL_MS_CONFIG =
+      KSQL_CONFIG_PREFIX + "heartbeat.send.interval.ms";
+  private static final String KSQL_HEARTBEAT_SEND_INTERVAL_MS_DOC =
+      "Interval at which heartbeats are broadcasted to servers.";
+
+  public static final String KSQL_HEARTBEAT_CHECK_INTERVAL_MS_CONFIG =
+      KSQL_CONFIG_PREFIX + "heartbeat.check.interval.ms";
+  private static final String KSQL_HEARTBEAT_CHECK_INTERVAL_MS_DOC =
+      "Interval at which server processes received heartbeats.";
+
+  public static final String KSQL_HEARTBEAT_WINDOW_MS_CONFIG =
+      KSQL_CONFIG_PREFIX + "heartbeat.window.ms";
+  private static final String KSQL_HEARTBEAT_WINDOW_MS_DOC =
+      "Size of time window across which to count missed heartbeats.";
+
+  public static final String KSQL_HEARTBEAT_MISSED_THRESHOLD_CONFIG =
+      KSQL_CONFIG_PREFIX + "heartbeat.missed.threshold.ms";
+  private static final String KSQL_HEARTBEAT_MISSED_THRESHOLD_DOC =
+      "Minimum number of consecutive missed heartbeats that flag a server as down.";
+
+  public static final String KSQL_HEARTBEAT_DISCOVER_CLUSTER_MS_CONFIG =
+      KSQL_CONFIG_PREFIX + "heartbeat.discover.interval.ms";
+  private static final String KSQL_HEARTBEAT_DISCOVER_CLUSTER_MS_DOC =
+      "Interval at which server attempts to discover what other ksql servers exist in the cluster.";
+
+  public static final String KSQL_HEARTBEAT_THREAD_POOL_SIZE_CONFIG =
+      KSQL_CONFIG_PREFIX + "heartbeat.thread.pool.size";
+  private static final String KSQL_HEARTBEAT_THREAD_POOL_SIZE_CONFIG_DOC =
+      "Size of thread pool used for sending / processing heartbeats and cluster discovery.";
 
   private static final ConfigDef CONFIG_DEF;
 
@@ -182,6 +216,48 @@ public class KsqlRestConfig extends RestConfig {
         DefaultErrorMessages.class,
         Importance.LOW,
         KSQL_SERVER_ERRORS_DOC
+    ).define(
+        KSQL_HEARTBEAT_ENABLE_CONFIG,
+        Type.BOOLEAN,
+        false,
+        Importance.MEDIUM,
+        KSQL_HEARTBEAT_ENABLE_DOC
+    ).define(
+        KSQL_HEARTBEAT_SEND_INTERVAL_MS_CONFIG,
+        Type.LONG,
+        100L,
+        Importance.MEDIUM,
+        KSQL_HEARTBEAT_SEND_INTERVAL_MS_DOC
+    ).define(
+        KSQL_HEARTBEAT_CHECK_INTERVAL_MS_CONFIG,
+        Type.LONG,
+        200L,
+        Importance.MEDIUM,
+        KSQL_HEARTBEAT_CHECK_INTERVAL_MS_DOC
+    ).define(
+        KSQL_HEARTBEAT_WINDOW_MS_CONFIG,
+        Type.LONG,
+        2000L,
+        Importance.MEDIUM,
+        KSQL_HEARTBEAT_WINDOW_MS_DOC
+    ).define(
+        KSQL_HEARTBEAT_MISSED_THRESHOLD_CONFIG,
+        Type.LONG,
+        3L,
+        Importance.MEDIUM,
+        KSQL_HEARTBEAT_MISSED_THRESHOLD_DOC
+    ).define(
+        KSQL_HEARTBEAT_DISCOVER_CLUSTER_MS_CONFIG,
+        Type.LONG,
+        2000L,
+        Importance.MEDIUM,
+        KSQL_HEARTBEAT_DISCOVER_CLUSTER_MS_DOC
+    ).define(
+        KSQL_HEARTBEAT_THREAD_POOL_SIZE_CONFIG,
+        Type.INT,
+        3,
+        Importance.MEDIUM,
+        KSQL_HEARTBEAT_THREAD_POOL_SIZE_CONFIG_DOC
     );
   }
 

--- a/ksql-rest-app/src/main/java/io/confluent/ksql/rest/server/resources/ClusterStatusResource.java
+++ b/ksql-rest-app/src/main/java/io/confluent/ksql/rest/server/resources/ClusterStatusResource.java
@@ -1,0 +1,52 @@
+/*
+ * Copyright 2019 Confluent Inc.
+ *
+ * Licensed under the Confluent Community License (the "License"; you may not use
+ * this file except in compliance with the License. You may obtain a copy of the
+ * License at
+ *
+ * http://www.confluent.io/confluent-community-license
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package io.confluent.ksql.rest.server.resources;
+
+import io.confluent.ksql.rest.entity.ClusterStatusResponse;
+import io.confluent.ksql.rest.entity.Versions;
+import io.confluent.ksql.rest.server.HeartbeatAgent;
+import javax.ws.rs.GET;
+import javax.ws.rs.Path;
+import javax.ws.rs.Produces;
+import javax.ws.rs.core.MediaType;
+import javax.ws.rs.core.Response;
+
+/**
+ * Endpoint that reports the view of the cluster that this server has.
+ * Returns every host that has been discovered by this server along side with information about its
+ * status such as whether it is alive or dead and the last time its status got updated.
+ */
+
+@Path("/clusterStatus")
+@Produces({Versions.KSQL_V1_JSON, MediaType.APPLICATION_JSON})
+public class ClusterStatusResource {
+
+  private final HeartbeatAgent heartbeatAgent;
+
+  public ClusterStatusResource(final HeartbeatAgent heartbeatAgent) {
+    this.heartbeatAgent = heartbeatAgent;
+  }
+
+  @GET
+  public Response checkClusterStatus() {
+    final ClusterStatusResponse response = getResponse();
+    return Response.ok(response).build();
+  }
+
+  private ClusterStatusResponse getResponse() {
+    return new ClusterStatusResponse(heartbeatAgent.getHostsStatus());
+  }
+}

--- a/ksql-rest-app/src/main/java/io/confluent/ksql/rest/server/resources/HeartbeatResource.java
+++ b/ksql-rest-app/src/main/java/io/confluent/ksql/rest/server/resources/HeartbeatResource.java
@@ -1,0 +1,57 @@
+/*
+ * Copyright 2019 Confluent Inc.
+ *
+ * Licensed under the Confluent Community License (the "License"; you may not use
+ * this file except in compliance with the License. You may obtain a copy of the
+ * License at
+ *
+ * http://www.confluent.io/confluent-community-license
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package io.confluent.ksql.rest.server.resources;
+
+import io.confluent.ksql.rest.entity.HeartbeatMessage;
+import io.confluent.ksql.rest.entity.HeartbeatResponse;
+import io.confluent.ksql.rest.entity.HostInfoEntity;
+import io.confluent.ksql.rest.entity.Versions;
+import io.confluent.ksql.rest.server.HeartbeatAgent;
+import javax.ws.rs.POST;
+import javax.ws.rs.Path;
+import javax.ws.rs.Produces;
+import javax.ws.rs.core.MediaType;
+import javax.ws.rs.core.Response;
+import org.apache.kafka.streams.state.HostInfo;
+
+/**
+ * Endpoint for registering heartbeats received from remote servers. The heartbeats are used
+ * to determine the status of the remote servers, i.e. whether they are alive or dead.
+ */
+
+@Path("/heartbeat")
+@Produces({Versions.KSQL_V1_JSON, MediaType.APPLICATION_JSON})
+public class HeartbeatResource {
+
+  private final HeartbeatAgent heartbeatAgent;
+
+  public HeartbeatResource(final HeartbeatAgent heartbeatAgent) {
+    this.heartbeatAgent = heartbeatAgent;
+  }
+
+  @POST
+  public Response registerHeartbeat(final HeartbeatMessage request) {
+    handleHeartbeat(request);
+    return Response.ok(new HeartbeatResponse(true)).build();
+  }
+
+  private void handleHeartbeat(final HeartbeatMessage request) {
+    final HostInfoEntity hostInfoEntity = request.getHostInfo();
+    final HostInfo hostInfo = new HostInfo(hostInfoEntity.getHost(), hostInfoEntity.getPort());
+    final long timestamp = request.getTimestamp();
+    heartbeatAgent.receiveHeartbeat(hostInfo, timestamp);
+  }
+}

--- a/ksql-rest-app/src/main/java/io/confluent/ksql/rest/server/services/DefaultKsqlClient.java
+++ b/ksql-rest-app/src/main/java/io/confluent/ksql/rest/server/services/DefaultKsqlClient.java
@@ -26,12 +26,15 @@ import io.confluent.ksql.rest.client.KsqlClient;
 import io.confluent.ksql.rest.client.KsqlTarget;
 import io.confluent.ksql.rest.client.QueryStream;
 import io.confluent.ksql.rest.client.RestResponse;
+import io.confluent.ksql.rest.entity.ClusterStatusResponse;
+import io.confluent.ksql.rest.entity.HostInfoEntity;
 import io.confluent.ksql.rest.entity.KsqlEntityList;
 import io.confluent.ksql.rest.entity.StreamedRow;
 import io.confluent.ksql.services.SimpleKsqlClient;
 import java.net.URI;
 import java.util.List;
 import java.util.Optional;
+import org.apache.kafka.streams.state.HostInfo;
 
 final class DefaultKsqlClient implements SimpleKsqlClient {
 
@@ -97,5 +100,30 @@ final class DefaultKsqlClient implements SimpleKsqlClient {
     }
 
     return RestResponse.successful(resp.getStatusCode(), rows.build());
+  }
+
+  @Override
+  public void makeAsyncHeartbeatRequest(
+      final URI serverEndPoint,
+      final HostInfo host,
+      final long timestamp) {
+    final KsqlTarget target = sharedClient
+        .target(serverEndPoint);
+
+    authHeader
+        .map(target::authorizationHeader)
+        .orElse(target)
+        .postAsyncHeartbeatRequest(new HostInfoEntity(host.host(), host.port()), timestamp);
+  }
+
+  @Override
+  public RestResponse<ClusterStatusResponse> makeClusterStatusRequest(final URI serverEndPoint) {
+    final KsqlTarget target = sharedClient
+        .target(serverEndPoint);
+
+    return authHeader
+        .map(target::authorizationHeader)
+        .orElse(target)
+        .getClusterStatus();
   }
 }

--- a/ksql-rest-app/src/main/java/io/confluent/ksql/rest/server/services/ServerInternalKsqlClient.java
+++ b/ksql-rest-app/src/main/java/io/confluent/ksql/rest/server/services/ServerInternalKsqlClient.java
@@ -19,6 +19,7 @@ import static java.util.Objects.requireNonNull;
 
 import io.confluent.ksql.rest.client.KsqlClientUtil;
 import io.confluent.ksql.rest.client.RestResponse;
+import io.confluent.ksql.rest.entity.ClusterStatusResponse;
 import io.confluent.ksql.rest.entity.KsqlEntityList;
 import io.confluent.ksql.rest.entity.KsqlRequest;
 import io.confluent.ksql.rest.entity.StreamedRow;
@@ -29,6 +30,7 @@ import java.net.URI;
 import java.util.Collections;
 import java.util.List;
 import javax.ws.rs.core.Response;
+import org.apache.kafka.streams.state.HostInfo;
 
 /**
  * A KSQL client implementation that sends requests to KsqlResource directly, rather than going
@@ -69,6 +71,20 @@ public class ServerInternalKsqlClient implements SimpleKsqlClient {
       final URI serverEndpoint,
       final String sql
   ) {
+    throw new UnsupportedOperationException();
+  }
+
+  @Override
+  public void makeAsyncHeartbeatRequest(
+      final URI serverEndPoint,
+      final HostInfo host,
+      final long timestamp
+  ) {
+    throw new UnsupportedOperationException();
+  }
+
+  @Override
+  public RestResponse<ClusterStatusResponse> makeClusterStatusRequest(final URI serverEndPoint) {
     throw new UnsupportedOperationException();
   }
 }

--- a/ksql-rest-app/src/test/java/io/confluent/ksql/rest/integration/HeartbeatAgentFunctionalTest.java
+++ b/ksql-rest-app/src/test/java/io/confluent/ksql/rest/integration/HeartbeatAgentFunctionalTest.java
@@ -1,0 +1,262 @@
+/*
+ * Copyright 2019 Confluent Inc.
+ *
+ * Licensed under the Confluent Community License (the "License"; you may not use
+ * this file except in compliance with the License. You may obtain a copy of the
+ * License at
+ *
+ * http://www.confluent.io/confluent-community-license
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package io.confluent.ksql.rest.integration;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+
+import io.confluent.common.utils.IntegrationTest;
+import io.confluent.ksql.integration.IntegrationTestHarness;
+import io.confluent.ksql.integration.Retry;
+import io.confluent.ksql.rest.client.KsqlRestClient;
+import io.confluent.ksql.rest.client.RestResponse;
+import io.confluent.ksql.rest.entity.ClusterStatusResponse;
+import io.confluent.ksql.rest.entity.HostInfoEntity;
+import io.confluent.ksql.rest.entity.HostStatusEntity;
+import io.confluent.ksql.rest.server.KsqlRestConfig;
+import io.confluent.ksql.rest.server.TestKsqlRestApp;
+import io.confluent.ksql.serde.Format;
+import io.confluent.ksql.test.util.secure.ClientTrustStore;
+import io.confluent.ksql.util.PageViewDataProvider;
+import java.util.Map;
+import java.util.Map.Entry;
+import java.util.concurrent.TimeUnit;
+import java.util.function.Function;
+import kafka.zookeeper.ZooKeeperClientException;
+import org.apache.kafka.streams.state.HostInfo;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.BeforeClass;
+import org.junit.ClassRule;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.junit.rules.RuleChain;
+
+@Category({IntegrationTest.class})
+public class HeartbeatAgentFunctionalTest {
+
+  private static final PageViewDataProvider PAGE_VIEWS_PROVIDER = new PageViewDataProvider();
+  private static final String PAGE_VIEW_TOPIC = PAGE_VIEWS_PROVIDER.topicName();
+  private static final String PAGE_VIEW_STREAM = PAGE_VIEWS_PROVIDER.kstreamName();
+
+  private static final HostInfo host0 = new HostInfo("localhost",8088);
+  private static final HostInfo host1 = new HostInfo("localhost",8089);
+  private static final IntegrationTestHarness TEST_HARNESS = IntegrationTestHarness.build();
+  private static final TestKsqlRestApp REST_APP_0 = TestKsqlRestApp
+      .builder(TEST_HARNESS::kafkaBootstrapServers)
+      .withProperty(KsqlRestConfig.LISTENERS_CONFIG, "http://localhost:8088")
+      .withProperty(KsqlRestConfig.KSQL_HEARTBEAT_ENABLE_CONFIG, true)
+      .withProperty(KsqlRestConfig.KSQL_HEARTBEAT_SEND_INTERVAL_MS_CONFIG, 600000)
+      .withProperty(KsqlRestConfig.KSQL_HEARTBEAT_CHECK_INTERVAL_MS_CONFIG, 200)
+      .withProperty(KsqlRestConfig.KSQL_HEARTBEAT_DISCOVER_CLUSTER_MS_CONFIG, 2000)
+      .withProperties(ClientTrustStore.trustStoreProps())
+      .build();
+  private static final TestKsqlRestApp REST_APP_1 = TestKsqlRestApp
+      .builder(TEST_HARNESS::kafkaBootstrapServers)
+      .withProperty(KsqlRestConfig.LISTENERS_CONFIG, "http://localhost:8089")
+      .withProperty(KsqlRestConfig.KSQL_HEARTBEAT_ENABLE_CONFIG, true)
+      .withProperty(KsqlRestConfig.KSQL_HEARTBEAT_SEND_INTERVAL_MS_CONFIG, 600000)
+      .withProperty(KsqlRestConfig.KSQL_HEARTBEAT_CHECK_INTERVAL_MS_CONFIG, 200)
+      .withProperty(KsqlRestConfig.KSQL_HEARTBEAT_DISCOVER_CLUSTER_MS_CONFIG, 2000)
+      .withProperties(ClientTrustStore.trustStoreProps())
+      .build();
+
+  @ClassRule
+  public static final RuleChain CHAIN = RuleChain
+      .outerRule(Retry.of(3, ZooKeeperClientException.class, 3, TimeUnit.SECONDS))
+      .around(TEST_HARNESS)
+      .around(REST_APP_0)
+      .around(REST_APP_1);
+
+  @BeforeClass
+  public static void setUpClass() {
+    TEST_HARNESS.ensureTopics(2, PAGE_VIEW_TOPIC);
+    TEST_HARNESS.produceRows(PAGE_VIEW_TOPIC, PAGE_VIEWS_PROVIDER, Format.JSON);
+    RestIntegrationTestUtil.createStream(REST_APP_0, PAGE_VIEWS_PROVIDER);
+    RestIntegrationTestUtil.makeKsqlRequest(
+        REST_APP_0,
+        "CREATE STREAM S AS SELECT * FROM " + PAGE_VIEW_STREAM + ";"
+    );
+  }
+
+  @Before
+  public void setup() {
+    REST_APP_0.start();
+    REST_APP_1.start();
+  }
+
+  @After
+  public void tearDown() {
+    REST_APP_0.stop();
+    REST_APP_1.stop();
+  }
+
+  @Test(timeout = 60000)
+  public void shouldMarkServersAsUp() {
+    // Given:
+    waitForClusterToBeDiscovered();
+    waitForRemoteServerToChangeStatus(this::remoteServerIsDown);
+
+    // When:
+    sendHeartbeartsEveryIntervalForWindowLength(100, 3000);
+    final ClusterStatusResponse clusterStatusResponseUp = waitForRemoteServerToChangeStatus(
+        this::remoteServerIsUp);
+
+    // Then:
+    assertThat(clusterStatusResponseUp.getClusterStatus().get(host0.toString()).getHostAlive(), is(true));
+    assertThat(clusterStatusResponseUp.getClusterStatus().get(host1.toString()).getHostAlive(), is(true));
+  }
+
+  @Test(timeout = 60000)
+  public void shouldMarkRemoteServerAsDown() {
+    // Given:
+    waitForClusterToBeDiscovered();
+
+    // When:
+    ClusterStatusResponse clusterStatusResponse = waitForRemoteServerToChangeStatus(
+        this::remoteServerIsDown);
+
+    // Then:
+    assertThat(clusterStatusResponse.getClusterStatus().get(host0.toString()).getHostAlive(), is(true));
+    assertThat(clusterStatusResponse.getClusterStatus().get(host1.toString()).getHostAlive(), is(false));
+  }
+
+  @Test(timeout = 60000)
+  public void shouldMarkRemoteServerAsUpThenDownThenUp() {
+    // Given:
+    waitForClusterToBeDiscovered();
+    sendHeartbeartsEveryIntervalForWindowLength(100, 2000);
+
+    // When:
+    final ClusterStatusResponse clusterStatusResponseUp1 = waitForRemoteServerToChangeStatus(
+        this::remoteServerIsUp);
+
+    // Then:
+    assertThat(clusterStatusResponseUp1.getClusterStatus().get(host0.toString()).getHostAlive(), is(true));
+    assertThat(clusterStatusResponseUp1.getClusterStatus().get(host1.toString()).getHostAlive(), is(true));
+
+    // When:
+    ClusterStatusResponse clusterStatusResponseDown = waitForRemoteServerToChangeStatus(
+        this::remoteServerIsDown);
+
+    // Then:
+    assertThat(clusterStatusResponseDown.getClusterStatus().get(host0.toString()).getHostAlive(), is(true));
+    assertThat(clusterStatusResponseDown.getClusterStatus().get(host1.toString()).getHostAlive(), is(false));
+
+    // When :
+    sendHeartbeartsEveryIntervalForWindowLength(100, 2000);
+    ClusterStatusResponse clusterStatusResponseUp2 = waitForRemoteServerToChangeStatus(
+        this::remoteServerIsUp);
+
+    // Then:
+    assertThat(clusterStatusResponseUp2.getClusterStatus().get(host0.toString()).getHostAlive(), is(true));
+    assertThat(clusterStatusResponseUp2.getClusterStatus().get(host1.toString()).getHostAlive(), is(true));
+  }
+
+  private void waitForClusterToBeDiscovered() {
+    while (true) {
+      final ClusterStatusResponse clusterStatusResponse = sendClusterStatusRequest(REST_APP_0);
+      if(allServersDiscovered(clusterStatusResponse.getClusterStatus())) {
+        break;
+      }
+      try {
+        Thread.sleep(200);
+      } catch (final Exception e) {
+        // Meh
+      }
+    }
+  }
+
+  private boolean allServersDiscovered(Map<String, HostStatusEntity> clusterStatus) {
+    if(clusterStatus.size() < 2) {
+      return false;
+    }
+    return true;
+  }
+
+  private void sendHeartbeartsEveryIntervalForWindowLength(long interval, long window) {
+    long start = System.currentTimeMillis();
+    while (System.currentTimeMillis() - start < window) {
+      sendHeartbeatRequest(REST_APP_0, host1, System.currentTimeMillis());
+      try {
+        Thread.sleep(interval);
+      } catch (final Exception e) {
+        // Meh
+      }
+    }
+  }
+
+  private ClusterStatusResponse waitForRemoteServerToChangeStatus(
+      Function<Map<String, HostStatusEntity>, Boolean> function)
+  {
+    while (true) {
+      final ClusterStatusResponse clusterStatusResponse = sendClusterStatusRequest(REST_APP_0);
+      if(function.apply(clusterStatusResponse.getClusterStatus())) {
+        return clusterStatusResponse;
+      }
+      try {
+        Thread.sleep(200);
+      } catch (final Exception e) {
+        // Meh
+      }
+    }
+  }
+
+  private boolean remoteServerIsDown(Map<String, HostStatusEntity> clusterStatus) {
+    if (!clusterStatus.containsKey(host1.toString())) {
+      return true;
+    }
+    for( Entry<String, HostStatusEntity> entry: clusterStatus.entrySet()) {
+      if (entry.getKey().contains("8089") && !entry.getValue().getHostAlive()) {
+        return true;
+      }
+    }
+    return false;
+  }
+
+  private boolean remoteServerIsUp(Map<String, HostStatusEntity> clusterStatus) {
+    for( Entry<String, HostStatusEntity> entry: clusterStatus.entrySet()) {
+      if (entry.getKey().contains("8089") && entry.getValue().getHostAlive()) {
+        return true;
+      }
+    }
+    return false;
+  }
+
+  private static void sendHeartbeatRequest(
+      final TestKsqlRestApp restApp,
+      final HostInfo host,
+      final long timestamp) {
+
+    try (final KsqlRestClient restClient = restApp.buildKsqlClient()) {
+      restClient.makeAsyncHeartbeatRequest(new HostInfoEntity(host.host(), host.port()), timestamp);
+    }
+  }
+
+  private static ClusterStatusResponse sendClusterStatusRequest(final TestKsqlRestApp restApp) {
+
+    try (final KsqlRestClient restClient = restApp.buildKsqlClient()) {
+
+      final RestResponse<ClusterStatusResponse> res = restClient.makeClusterStatusRequest();
+
+      if (res.isErroneous()) {
+        throw new AssertionError("Erroneous result: " + res.getErrorMessage());
+      }
+
+      return res.getResponse();
+    }
+  }
+}

--- a/ksql-rest-app/src/test/java/io/confluent/ksql/rest/server/HeartbeatAgentTest.java
+++ b/ksql-rest-app/src/test/java/io/confluent/ksql/rest/server/HeartbeatAgentTest.java
@@ -1,0 +1,266 @@
+/*
+ * Copyright 2019 Confluent Inc.
+ *
+ * Licensed under the Confluent Community License (the "License"; you may not use
+ * this file except in compliance with the License. You may obtain a copy of the
+ * License at
+ *
+ * http://www.confluent.io/confluent-community-license
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package io.confluent.ksql.rest.server;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.hasSize;
+import static org.hamcrest.Matchers.is;
+import static org.mockito.Mockito.when;
+
+import com.google.common.collect.ImmutableList;
+import io.confluent.ksql.engine.KsqlEngine;
+import io.confluent.ksql.rest.entity.HostInfoEntity;
+import io.confluent.ksql.rest.entity.HostStatusEntity;
+import io.confluent.ksql.rest.server.HeartbeatAgent.Builder;
+import io.confluent.ksql.rest.server.HeartbeatAgent.CheckHeartbeatService;
+import io.confluent.ksql.rest.server.HeartbeatAgent.DiscoverClusterService;
+import io.confluent.ksql.services.ServiceContext;
+import io.confluent.ksql.util.PersistentQueryMetadata;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+import org.apache.kafka.streams.state.HostInfo;
+import org.apache.kafka.streams.state.StreamsMetadata;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnitRunner;
+
+@RunWith(MockitoJUnitRunner.class)
+public class HeartbeatAgentTest {
+  @Mock
+  private PersistentQueryMetadata query0;
+  @Mock
+  private PersistentQueryMetadata query1;
+  @Mock
+  private StreamsMetadata streamsMetadata0;
+  @Mock
+  private StreamsMetadata streamsMetadata1;
+  @Mock
+  private ServiceContext serviceContext;
+  @Mock
+  private KsqlEngine ksqlEngine;
+
+  private HeartbeatAgent heartbeatAgent;
+  private HostInfo localHostInfo;
+  private HostInfo remoteHostInfo;
+  private List<StreamsMetadata> allMetadata0;
+  private List<StreamsMetadata> allMetadata1;
+  private static final String LOCALHOST_URL = "http://localhost:8088";
+
+  @Before
+  public void setUp() {
+    localHostInfo = new HostInfo ("localhost", 8088);
+    remoteHostInfo = new HostInfo("localhost", 8089);
+
+    Builder builder = HeartbeatAgent.builder();
+    heartbeatAgent = builder
+        .heartbeatSendInterval(1)
+        .heartbeatMissedThreshold(2)
+        .build(ksqlEngine, serviceContext);
+    heartbeatAgent.setLocalAddress(LOCALHOST_URL);
+    Map<String, HostStatusEntity> hostsStatus = new ConcurrentHashMap<>();
+    hostsStatus.put(localHostInfo.toString(), new HostStatusEntity(
+        new HostInfoEntity(localHostInfo.host(), localHostInfo.port()), true, 0L));
+    hostsStatus.put(remoteHostInfo.toString(), new HostStatusEntity(
+        new HostInfoEntity(remoteHostInfo.host(), remoteHostInfo.port()), true, 0L));
+    heartbeatAgent.setHostsStatus(hostsStatus);
+    allMetadata0 = ImmutableList.of(streamsMetadata0);
+    allMetadata1 = ImmutableList.of(streamsMetadata1);
+  }
+
+  @Test
+  public void shouldDiscoverServersInCluster() {
+    // Given:
+    when(ksqlEngine.getPersistentQueries()).thenReturn(ImmutableList.of(query0, query1));
+
+    when(query0.getAllMetadata()).thenReturn(allMetadata0);
+    when(streamsMetadata0.hostInfo()).thenReturn(localHostInfo);
+
+    when(query1.getAllMetadata()).thenReturn(allMetadata1);
+    when(streamsMetadata1.hostInfo()).thenReturn(remoteHostInfo);
+
+    DiscoverClusterService discoverService = heartbeatAgent.new DiscoverClusterService();
+
+    // When:
+    discoverService.runOneIteration();
+
+    // Then:
+    assertThat(heartbeatAgent.getHostsStatus().keySet().contains(remoteHostInfo.toString()), is(true));
+  }
+
+  @Test
+  public void shouldMarkServerAsUpNoMissingHeartbeat() {
+    // Given:
+    long windowStart = 0;
+    long windowEnd = 5;
+    heartbeatAgent.receiveHeartbeat(remoteHostInfo, 0L);
+    heartbeatAgent.receiveHeartbeat(remoteHostInfo, 1L);
+    heartbeatAgent.receiveHeartbeat(remoteHostInfo, 2L);
+    heartbeatAgent.receiveHeartbeat(remoteHostInfo, 3L);
+    heartbeatAgent.receiveHeartbeat(remoteHostInfo, 4L);
+    heartbeatAgent.receiveHeartbeat(remoteHostInfo, 5L);
+    CheckHeartbeatService processService = heartbeatAgent.new CheckHeartbeatService();
+
+    // When:
+    processService.runWithWindow(windowStart, windowEnd);
+
+    // Then:
+    assertThat(heartbeatAgent.getHostsStatus().entrySet(), hasSize(2));
+    assertThat(heartbeatAgent.getHostsStatus().get(remoteHostInfo.toString()).getHostAlive(), is(true));
+  }
+
+  @Test
+  public void shouldMarkServerAsUpMissOneHeartbeat() {
+    // Given:
+    long windowStart = 1;
+    long windowEnd = 10;
+    heartbeatAgent.receiveHeartbeat(remoteHostInfo, 0L);
+    heartbeatAgent.receiveHeartbeat(remoteHostInfo, 2L);
+    heartbeatAgent.receiveHeartbeat(remoteHostInfo, 4L);
+    heartbeatAgent.receiveHeartbeat(remoteHostInfo, 6L);
+    heartbeatAgent.receiveHeartbeat(remoteHostInfo, 8L);
+    heartbeatAgent.receiveHeartbeat(remoteHostInfo, 10L);
+    CheckHeartbeatService processService = heartbeatAgent.new CheckHeartbeatService();
+
+    // When:
+    processService.runWithWindow(windowStart, windowEnd);
+
+    // Then:
+    assertThat(heartbeatAgent.getHostsStatus().entrySet(), hasSize(2));
+    assertThat(heartbeatAgent.getHostsStatus().get(remoteHostInfo.toString()).getHostAlive(), is(true));
+  }
+
+  @Test
+  public void shouldMarkServerAsUpMissAtBeginning() {
+    // Given:
+    long windowStart = 0;
+    long windowEnd = 10;
+    heartbeatAgent.receiveHeartbeat(remoteHostInfo, 8L);
+    CheckHeartbeatService processService = heartbeatAgent.new CheckHeartbeatService();
+
+    // When:
+    processService.runWithWindow(windowStart, windowEnd);
+
+    // Then:
+    assertThat(heartbeatAgent.getHostsStatus().entrySet(), hasSize(2));
+    assertThat(heartbeatAgent.getHostsStatus().get(remoteHostInfo.toString()).getHostAlive(), is(true));
+  }
+
+  @Test
+  public void shouldMarkServerAsUpMissInterleaved() {
+    // Given:
+    long windowStart = 0;
+    long windowEnd = 10;
+    heartbeatAgent.receiveHeartbeat(remoteHostInfo, 0L);
+    heartbeatAgent.receiveHeartbeat(remoteHostInfo, 2L);
+    heartbeatAgent.receiveHeartbeat(remoteHostInfo, 5L);
+    heartbeatAgent.receiveHeartbeat(remoteHostInfo, 8L);
+    CheckHeartbeatService processService = heartbeatAgent.new CheckHeartbeatService();
+
+    // When:
+    processService.runWithWindow(windowStart, windowEnd);
+
+    // Then:
+    assertThat(heartbeatAgent.getHostsStatus().entrySet(), hasSize(2));
+    assertThat(heartbeatAgent.getHostsStatus().get(remoteHostInfo.toString()).getHostAlive(), is(true));
+  }
+
+  @Test
+  public void shouldMarkServerAsUpOutOfOrderHeartbeats() {
+    // Given:
+    long windowStart = 0;
+    long windowEnd = 10;
+    heartbeatAgent.receiveHeartbeat(remoteHostInfo, 8L);
+    heartbeatAgent.receiveHeartbeat(remoteHostInfo, 0L);
+    heartbeatAgent.receiveHeartbeat(remoteHostInfo, 5L);
+    heartbeatAgent.receiveHeartbeat(remoteHostInfo, 2L);
+    CheckHeartbeatService processService = heartbeatAgent.new CheckHeartbeatService();
+
+    // When:
+    processService.runWithWindow(windowStart, windowEnd);
+
+    // Then:
+    assertThat(heartbeatAgent.getHostsStatus().entrySet(), hasSize(2));
+    assertThat(heartbeatAgent.getHostsStatus().get(remoteHostInfo.toString()).getHostAlive(), is(true));
+  }
+
+  @Test
+  public void shouldMarkServerAsDownMissAtEnd() {
+    // Given:
+    long windowStart = 0;
+    long windowEnd = 10;
+    heartbeatAgent.receiveHeartbeat(remoteHostInfo, 0L);
+    heartbeatAgent.receiveHeartbeat(remoteHostInfo, 2L);
+    heartbeatAgent.receiveHeartbeat(remoteHostInfo, 4L);
+    heartbeatAgent.receiveHeartbeat(remoteHostInfo, 6L);
+    heartbeatAgent.receiveHeartbeat(remoteHostInfo, 7L);
+    CheckHeartbeatService processService = heartbeatAgent.new CheckHeartbeatService();
+
+    // When:
+    processService.runWithWindow(windowStart, windowEnd);
+
+    // Then:
+    assertThat(heartbeatAgent.getHostsStatus().entrySet(), hasSize(2));
+    assertThat(heartbeatAgent.getHostsStatus().get(remoteHostInfo.toString()).getHostAlive(), is(false));
+  }
+
+  @Test
+  public void shouldMarkServerAsDownIgnoreHeartbeatsOutOfWindow() {
+    // Given:
+    long windowStart = 5;
+    long windowEnd = 8;
+    heartbeatAgent.receiveHeartbeat(remoteHostInfo, 0L);
+    heartbeatAgent.receiveHeartbeat(remoteHostInfo, 1L);
+    heartbeatAgent.receiveHeartbeat(remoteHostInfo, 2L);
+    heartbeatAgent.receiveHeartbeat(remoteHostInfo, 3L);
+    heartbeatAgent.receiveHeartbeat(remoteHostInfo, 4L);
+    heartbeatAgent.receiveHeartbeat(remoteHostInfo, 9L);
+    heartbeatAgent.receiveHeartbeat(remoteHostInfo, 10L);
+    CheckHeartbeatService processService = heartbeatAgent.new CheckHeartbeatService();
+
+    // When:
+    processService.runWithWindow(windowStart, windowEnd);
+
+    // Then:
+    assertThat(heartbeatAgent.getHostsStatus().entrySet(), hasSize(2));
+    assertThat(heartbeatAgent.getHostsStatus().get(remoteHostInfo.toString()).getHostAlive(), is(false));
+  }
+
+  @Test
+  public void shouldMarkServerAsDownOutOfOrderHeartbeats() {
+    // Given:
+    long windowStart = 5;
+    long windowEnd = 8;
+    heartbeatAgent.receiveHeartbeat(remoteHostInfo, 10L);
+    heartbeatAgent.receiveHeartbeat(remoteHostInfo, 9L);
+    heartbeatAgent.receiveHeartbeat(remoteHostInfo, 0L);
+    heartbeatAgent.receiveHeartbeat(remoteHostInfo, 4L);
+    heartbeatAgent.receiveHeartbeat(remoteHostInfo, 2L);
+    heartbeatAgent.receiveHeartbeat(remoteHostInfo, 3L);
+    heartbeatAgent.receiveHeartbeat(remoteHostInfo, 1L);
+    CheckHeartbeatService processService = heartbeatAgent.new CheckHeartbeatService();
+
+    // When:
+    processService.runWithWindow(windowStart, windowEnd);
+
+    // Then:
+    assertThat(heartbeatAgent.getHostsStatus().entrySet(), hasSize(2));
+    assertThat(heartbeatAgent.getHostsStatus().get(remoteHostInfo.toString()).getHostAlive(), is(false));
+  }
+
+}

--- a/ksql-rest-app/src/test/java/io/confluent/ksql/rest/server/KsqlRestApplicationTest.java
+++ b/ksql-rest-app/src/test/java/io/confluent/ksql/rest/server/KsqlRestApplicationTest.java
@@ -126,6 +126,8 @@ public class KsqlRestApplicationTest {
   private PreparedStatement<?> preparedStatement;
   @Mock
   private Consumer<KsqlConfig> rocksDBConfigSetterHandler;
+  @Mock
+  private HeartbeatAgent heartbeatAgent;
 
   @Mock
   private SchemaRegistryClient schemaRegistryClient;
@@ -219,7 +221,7 @@ public class KsqlRestApplicationTest {
   @Test
   public void shouldCreateLogStreamThroughKsqlResource() {
     // When:
-    app.startKsql();
+    app.startKsql(ksqlConfig);
 
     // Then:
     verify(ksqlResource).handleKsqlStatements(
@@ -237,7 +239,7 @@ public class KsqlRestApplicationTest {
         .thenReturn(false);
 
     // When:
-    app.startKsql();
+    app.startKsql(ksqlConfig);
 
     // Then:
     verify(ksqlResource, never()).handleKsqlStatements(
@@ -249,7 +251,7 @@ public class KsqlRestApplicationTest {
   @Test
   public void shouldStartCommandStoreAndCommandRunnerBeforeCreatingLogStream() {
     // When:
-    app.startKsql();
+    app.startKsql(ksqlConfig);
 
     // Then:
     final InOrder inOrder = Mockito.inOrder(commandQueue, commandRunner, ksqlResource);
@@ -267,7 +269,7 @@ public class KsqlRestApplicationTest {
   @Test
   public void shouldCreateLogTopicBeforeSendingCreateStreamRequest() {
     // When:
-    app.startKsql();
+    app.startKsql(ksqlConfig);
 
     // Then:
     final InOrder inOrder = Mockito.inOrder(topicClient, ksqlResource);
@@ -283,7 +285,7 @@ public class KsqlRestApplicationTest {
   @Test
   public void shouldInitializeCommandStoreCorrectly() {
     // When:
-    app.startKsql();
+    app.startKsql(ksqlConfig);
 
     // Then:
     final InOrder inOrder = Mockito.inOrder(topicClient, commandQueue, commandRunner);
@@ -295,7 +297,7 @@ public class KsqlRestApplicationTest {
   @Test
   public void shouldReplayCommandsBeforeSettingReady() {
     // When:
-    app.startKsql();
+    app.startKsql(ksqlConfig);
 
     // Then:
     final InOrder inOrder = Mockito.inOrder(commandRunner, serverState);
@@ -306,7 +308,7 @@ public class KsqlRestApplicationTest {
   @Test
   public void shouldSendCreateStreamRequestBeforeSettingReady() {
     // When:
-    app.startKsql();
+    app.startKsql(ksqlConfig);
 
     // Then:
     final InOrder inOrder = Mockito.inOrder(ksqlResource, serverState);
@@ -328,7 +330,7 @@ public class KsqlRestApplicationTest {
     });
 
     // When:
-    app.startKsql();
+    app.startKsql(ksqlConfig);
 
     // Then:
     final InOrder inOrder = Mockito.inOrder(precondition1, precondition2, serviceContext);
@@ -350,7 +352,7 @@ public class KsqlRestApplicationTest {
     });
 
     // When:
-    app.startKsql();
+    app.startKsql(ksqlConfig);
 
     // Then:
     final InOrder inOrder = Mockito.inOrder(precondition1, precondition2, serverState);
@@ -367,7 +369,7 @@ public class KsqlRestApplicationTest {
   @Test
   public void shouldConfigureRocksDBConfigSetter() {
     // When:
-    app.startKsql();
+    app.startKsql(ksqlConfig);
 
     // Then:
     verify(rocksDBConfigSetterHandler).accept(ksqlConfig);
@@ -431,7 +433,8 @@ public class KsqlRestApplicationTest {
         processingLogContext,
         ImmutableList.of(precondition1, precondition2),
         ImmutableList.of(ksqlResource, streamedQueryResource),
-        rocksDBConfigSetterHandler
+        rocksDBConfigSetterHandler,
+        Optional.of(heartbeatAgent)
     );
   }
 }

--- a/ksql-rest-app/src/test/java/io/confluent/ksql/rest/server/TestKsqlRestApp.java
+++ b/ksql-rest-app/src/test/java/io/confluent/ksql/rest/server/TestKsqlRestApp.java
@@ -413,7 +413,7 @@ public class TestKsqlRestApp extends ExternalResource {
     configMap.put(KsqlConfig.KSQL_STREAMS_PREFIX + "cache.max.bytes.buffering", 0);
     configMap.put(KsqlConfig.KSQL_STREAMS_PREFIX + "auto.offset.reset", "earliest");
     configMap.put(KsqlConfig.KSQL_ENABLE_UDFS, false);
-
+    configMap.put(KsqlRestConfig.KSQL_HEARTBEAT_ENABLE_CONFIG, false);
     configMap.putAll(additionalProps);
     return configMap;
   }

--- a/ksql-rest-app/src/test/java/io/confluent/ksql/rest/server/resources/ClusterStatusResourceTest.java
+++ b/ksql-rest-app/src/test/java/io/confluent/ksql/rest/server/resources/ClusterStatusResourceTest.java
@@ -1,0 +1,53 @@
+/*
+ * Copyright 2019 Confluent Inc.
+ *
+ * Licensed under the Confluent Community License (the "License"; you may not use
+ * this file except in compliance with the License. You may obtain a copy of the
+ * License at
+ *
+ * http://www.confluent.io/confluent-community-license
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package io.confluent.ksql.rest.server.resources;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.instanceOf;
+import static org.hamcrest.Matchers.is;
+
+import io.confluent.ksql.rest.entity.ClusterStatusResponse;
+import io.confluent.ksql.rest.server.HeartbeatAgent;
+import javax.ws.rs.core.Response;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnitRunner;
+
+@RunWith(MockitoJUnitRunner.class)
+public class ClusterStatusResourceTest {
+
+  @Mock
+  private HeartbeatAgent heartbeatAgent;
+
+  private ClusterStatusResource clusterStatusResource;
+
+  @Before
+  public void setUp() {
+    clusterStatusResource = new ClusterStatusResource(heartbeatAgent);
+  }
+
+  @Test
+  public void shouldReturnClusterStatus() {
+    // When:
+    final Response response = clusterStatusResource.checkClusterStatus();
+
+    // Then:
+    assertThat(response.getStatus(), is(200));
+    assertThat(response.getEntity(), instanceOf(ClusterStatusResponse.class));
+  }
+}

--- a/ksql-rest-app/src/test/java/io/confluent/ksql/rest/server/resources/HeartbeatResourceTest.java
+++ b/ksql-rest-app/src/test/java/io/confluent/ksql/rest/server/resources/HeartbeatResourceTest.java
@@ -1,0 +1,55 @@
+/*
+ * Copyright 2019 Confluent Inc.
+ *
+ * Licensed under the Confluent Community License (the "License"; you may not use
+ * this file except in compliance with the License. You may obtain a copy of the
+ * License at
+ *
+ * http://www.confluent.io/confluent-community-license
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package io.confluent.ksql.rest.server.resources;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.instanceOf;
+import static org.hamcrest.Matchers.is;
+
+import io.confluent.ksql.rest.entity.HeartbeatMessage;
+import io.confluent.ksql.rest.entity.HeartbeatResponse;
+import io.confluent.ksql.rest.entity.HostInfoEntity;
+import io.confluent.ksql.rest.server.HeartbeatAgent;
+import javax.ws.rs.core.Response;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnitRunner;
+
+@RunWith(MockitoJUnitRunner.class)
+public class HeartbeatResourceTest {
+
+  @Mock
+  private HeartbeatAgent heartbeatAgent;
+  private HeartbeatResource heartbeatResource;
+
+  @Before
+  public void setUp() {
+    heartbeatResource = new HeartbeatResource(heartbeatAgent);
+  }
+
+  @Test
+  public void shouldSendHeartbeat() {
+    // When:
+    final HeartbeatMessage request = new HeartbeatMessage(new HostInfoEntity("localhost", 8080), 1);
+    final Response response = heartbeatResource.registerHeartbeat(request);
+
+    // Then:
+    assertThat(response.getStatus(), is(200));
+    assertThat(response.getEntity(), instanceOf(HeartbeatResponse.class));
+  }
+}

--- a/ksql-rest-client/src/main/java/io/confluent/ksql/rest/client/KsqlRestClient.java
+++ b/ksql-rest-client/src/main/java/io/confluent/ksql/rest/client/KsqlRestClient.java
@@ -20,9 +20,11 @@ import static java.util.Objects.requireNonNull;
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.collect.ImmutableList;
 import io.confluent.ksql.properties.LocalProperties;
+import io.confluent.ksql.rest.entity.ClusterStatusResponse;
 import io.confluent.ksql.rest.entity.CommandStatus;
 import io.confluent.ksql.rest.entity.CommandStatuses;
 import io.confluent.ksql.rest.entity.HealthCheckResponse;
+import io.confluent.ksql.rest.entity.HostInfoEntity;
 import io.confluent.ksql.rest.entity.KsqlEntityList;
 import io.confluent.ksql.rest.entity.ServerInfo;
 import java.io.Closeable;
@@ -33,7 +35,9 @@ import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+import java.util.concurrent.Future;
 import java.util.stream.Collectors;
+import javax.ws.rs.core.Response;
 
 public class KsqlRestClient implements Closeable {
 
@@ -84,6 +88,17 @@ public class KsqlRestClient implements Closeable {
 
   public RestResponse<HealthCheckResponse> getServerHealth() {
     return target().getServerHealth();
+  }
+
+  public Future<Response> makeAsyncHeartbeatRequest(
+      final HostInfoEntity host,
+      final long timestamp
+  ) {
+    return target().postAsyncHeartbeatRequest(host, timestamp);
+  }
+
+  public RestResponse<ClusterStatusResponse> makeClusterStatusRequest() {
+    return target().getClusterStatus();
   }
 
   public RestResponse<KsqlEntityList> makeKsqlRequest(final String ksql) {

--- a/ksql-rest-model/src/main/java/io/confluent/ksql/rest/entity/ClusterStatusResponse.java
+++ b/ksql-rest-model/src/main/java/io/confluent/ksql/rest/entity/ClusterStatusResponse.java
@@ -1,0 +1,62 @@
+/*
+ * Copyright 2019 Confluent Inc.
+ *
+ * Licensed under the Confluent Community License (the "License"); you may not use
+ * this file except in compliance with the License.  You may obtain a copy of the
+ * License at
+ *
+ * http://www.confluent.io/confluent-community-license
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package io.confluent.ksql.rest.entity;
+
+import static java.util.Objects.requireNonNull;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.google.common.collect.ImmutableMap;
+import com.google.errorprone.annotations.Immutable;
+import java.util.Map;
+import java.util.Objects;
+
+@JsonIgnoreProperties(ignoreUnknown = true)
+@Immutable
+public final class ClusterStatusResponse {
+
+  private final ImmutableMap<String, HostStatusEntity> clusterStatus;
+
+  @JsonCreator
+  public ClusterStatusResponse(
+      @JsonProperty("clusterStatus") final Map<String, HostStatusEntity> clusterStatus) {
+    this.clusterStatus = ImmutableMap.copyOf(requireNonNull(clusterStatus, "status"));
+  }
+
+  public Map<String, HostStatusEntity> getClusterStatus() {
+    return clusterStatus;
+  }
+
+  @Override
+  public boolean equals(final Object o) {
+    if (this == o) {
+      return true;
+    }
+
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+
+    final ClusterStatusResponse that = (ClusterStatusResponse) o;
+    return Objects.equals(clusterStatus, that.clusterStatus);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(clusterStatus);
+  }
+}

--- a/ksql-rest-model/src/main/java/io/confluent/ksql/rest/entity/HeartbeatMessage.java
+++ b/ksql-rest-model/src/main/java/io/confluent/ksql/rest/entity/HeartbeatMessage.java
@@ -1,0 +1,72 @@
+/*
+ * Copyright 2019 Confluent Inc.
+ *
+ * Licensed under the Confluent Community License (the "License"; you may not use
+ * this file except in compliance with the License. You may obtain a copy of the
+ * License at
+ *
+ * http://www.confluent.io/confluent-community-license
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package io.confluent.ksql.rest.entity;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonSubTypes;
+import java.util.Objects;
+
+@JsonIgnoreProperties(ignoreUnknown = true)
+@JsonSubTypes({})
+public class HeartbeatMessage {
+
+  private final HostInfoEntity hostInfo;
+  private final long timestamp;
+
+  @JsonCreator
+  public HeartbeatMessage(@JsonProperty("hostInfo") final HostInfoEntity hostInfo,
+                          @JsonProperty("timestamp") final long timestamp) {
+    this.hostInfo = hostInfo;
+    this.timestamp = timestamp;
+  }
+
+  public HostInfoEntity getHostInfo() {
+    return hostInfo;
+  }
+
+  public long getTimestamp() {
+    return timestamp;
+  }
+
+  @Override
+  public boolean equals(final Object other) {
+    if (this == other) {
+      return true;
+    }
+
+    if (!(other instanceof HeartbeatMessage)) {
+      return false;
+    }
+
+    final HeartbeatMessage that = (HeartbeatMessage) other;
+    return this.timestamp == that.timestamp && Objects.equals(hostInfo, that.hostInfo);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(hostInfo, timestamp);
+  }
+
+  @Override
+  public String toString() {
+    return "HearbeatRequest{"
+        + "hostInfo='" + hostInfo + '\''
+        + "timestamp='" + timestamp + '\''
+        + '}';
+  }
+}

--- a/ksql-rest-model/src/main/java/io/confluent/ksql/rest/entity/HeartbeatResponse.java
+++ b/ksql-rest-model/src/main/java/io/confluent/ksql/rest/entity/HeartbeatResponse.java
@@ -1,0 +1,57 @@
+/*
+ * Copyright 2019 Confluent Inc.
+ *
+ * Licensed under the Confluent Community License (the "License"; you may not use
+ * this file except in compliance with the License. You may obtain a copy of the
+ * License at
+ *
+ * http://www.confluent.io/confluent-community-license
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package io.confluent.ksql.rest.entity;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import java.util.Objects;
+
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class HeartbeatResponse {
+
+  private final boolean isOk;
+
+  @JsonCreator
+  public HeartbeatResponse(
+      @JsonProperty("ok") final boolean ok
+  ) {
+    this.isOk = ok;
+  }
+
+  public boolean getIsOk() {
+    return isOk;
+  }
+
+  @Override
+  public boolean equals(final Object o) {
+    if (this == o) {
+      return true;
+    }
+
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+
+    final HeartbeatResponse that = (HeartbeatResponse) o;
+    return isOk == that.isOk;
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(isOk);
+  }
+}

--- a/ksql-rest-model/src/main/java/io/confluent/ksql/rest/entity/HostInfoEntity.java
+++ b/ksql-rest-model/src/main/java/io/confluent/ksql/rest/entity/HostInfoEntity.java
@@ -1,0 +1,70 @@
+/*
+ * Copyright 2019 Confluent Inc.
+ *
+ * Licensed under the Confluent Community License (the "License"; you may not use
+ * this file except in compliance with the License. You may obtain a copy of the
+ * License at
+ *
+ * http://www.confluent.io/confluent-community-license
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package io.confluent.ksql.rest.entity;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import java.util.Objects;
+
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class HostInfoEntity {
+
+  private final String host;
+  private final int port;
+
+  @JsonCreator
+  public HostInfoEntity(
+      @JsonProperty("host") final String host,
+      @JsonProperty("port") final int port
+  ) {
+    this.host = Objects.requireNonNull(host, "host");
+    this.port = Objects.requireNonNull(port, "port");
+  }
+
+  public String getHost() {
+    return host;
+  }
+
+  public int getPort() {
+    return port;
+  }
+
+  @Override
+  public boolean equals(final Object o) {
+    if (this == o) {
+      return true;
+    }
+
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+
+    final HostInfoEntity that = (HostInfoEntity) o;
+    return Objects.equals(host, that.host)
+        && port == that.port;
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(host, port);
+  }
+
+  @Override
+  public String toString() {
+    return host + "," + port;
+  }
+}

--- a/ksql-rest-model/src/main/java/io/confluent/ksql/rest/entity/HostStatusEntity.java
+++ b/ksql-rest-model/src/main/java/io/confluent/ksql/rest/entity/HostStatusEntity.java
@@ -1,0 +1,89 @@
+/*
+ * Copyright 2019 Confluent Inc.
+ *
+ * Licensed under the Confluent Community License (the "License"; you may not use
+ * this file except in compliance with the License. You may obtain a copy of the
+ * License at
+ *
+ * http://www.confluent.io/confluent-community-license
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package io.confluent.ksql.rest.entity;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import java.util.Objects;
+
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class HostStatusEntity {
+
+  private HostInfoEntity hostInfoEntity;
+  private boolean hostAlive;
+  private long lastStatusUpdateMs;
+
+  @JsonCreator
+  public HostStatusEntity(
+      @JsonProperty("hostInfoEntity") final HostInfoEntity hostInfoEntity,
+      @JsonProperty("hostAlive") final boolean hostAlive,
+      @JsonProperty("lastStatusUpdateMs") final long lastStatusUpdateMs
+  ) {
+    this.hostInfoEntity = Objects.requireNonNull(hostInfoEntity, "hostInfoEntity");
+    this.hostAlive = hostAlive;
+    this.lastStatusUpdateMs = lastStatusUpdateMs;
+  }
+
+  public HostInfoEntity getHostInfoEntity() {
+    return hostInfoEntity;
+  }
+
+  public boolean getHostAlive() {
+    return hostAlive;
+  }
+
+  public long getLastStatusUpdateMs() {
+    return lastStatusUpdateMs;
+  }
+
+  public void setHostInfoEntity(final HostInfoEntity hostInfoEntity) {
+    this.hostInfoEntity = hostInfoEntity;
+  }
+
+  public void setHostAlive(final boolean hostAlive) {
+    this.hostAlive = hostAlive;
+  }
+
+  public void setLastStatusUpdateMs(final long lastStatusUpdateMs) {
+    this.lastStatusUpdateMs = lastStatusUpdateMs;
+  }
+
+  @Override
+  public boolean equals(final Object o) {
+    if (this == o) {
+      return true;
+    }
+
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+
+    final HostStatusEntity that = (HostStatusEntity) o;
+    return Objects.equals(hostInfoEntity, that.hostInfoEntity)
+        && hostAlive == that.hostAlive && lastStatusUpdateMs == that.lastStatusUpdateMs;
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(hostInfoEntity, hostAlive, lastStatusUpdateMs);
+  }
+
+  @Override
+  public String toString() {
+    return hostInfoEntity + "," + hostAlive + "," + lastStatusUpdateMs;
+  }
+}


### PR DESCRIPTION
### Description 
Initial implementation of heartbeat mechanism as part of #3959 

Added two new endpoints, `/heartbeat` used for registering received heartbeats and `/clusterStatus` used for reporting current cluster status. All the logic is in `HeartbeatHandler`. 

**Determining whether server is UP or Down**
Currently, the policy to decide whether a node is UP or DOWN is simplistic and will need to evolve: If a server misses more than `KSQL_HEARTBEAT_MISSED_THRESHOLD_CONFIG` it is marked as DOWN. However, if it receives even one heartbeat before the window closes, it will be marked as UP. So, it may miss all heartbeats except the last and still be marked as UP. We want to update this by counting the received heartbeats as well and having a threshold on them as well. We will update the policy after performing real-world tests. 

**Cluster membership**
Currently, the cluster membership is done via the persistent queries `KStreamsMetadata`.

### Testing done 
Unit tests for the resources and functional test for the `HeartbeatHandler`.
I have a functional test that has two servers that send heartbeats and check the cluster status response.

Manual testing: Three KSQL servers (`A`, `B` and `C`) on EC2. 
Correctness:
1. Kill server `A`, see if the other servers (`B`, `C`) report it as down by checking the result of `curl -sX GET "http://localhost:8088/clusterStatus"`. Bring the server `A`  up, check again the result of curl to see if the rest of the server see it now as up.
2. Use iptables to block outgoing traffic of `A` to `B`. Use curl to check if `B` marks `A` as down. Check if `C` marks `A` as up (since `A` stills ends traffic to `C`). Restore traffic to `B`, check if `A` is marked up.

Time to detect change in status:
300ms to detect `A` is down. 150 ms to detect it is up again.

### Reviewer checklist
- [ ] Ensure docs are updated if necessary. (eg. if a user visible feature is being added or changed).
- [ ] Ensure relevant issues are linked (description should include text like "Fixes #<issue number>")

