### PR TITLE
docs: add basic docker-compose file and instructions

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -32,6 +32,10 @@ To build and test changes locally, run the following commands:
 $ mvn clean install checkstyle:check integration-test
 ```
 
+### Testing docker image
+
+See comments at the top of the [docker compose file in the root of the project](docker-compose.yml) for instructions
+on how to build and run docker images.
 
 ## How to Contribute
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,10 +1,17 @@
 # Docker compose from bringing up a local KSQL cluster and dependencies.
 #
-# You can scale the number of KSQL nodes in the cluster by using the docker `--scale` command line arg.
-# The default is one primary node and 1 secondary node. The only difference is that the primary node
-# has a well-known port exposed so clients can connect, where as the secondary nodes use auto-port
-# assignment so that ports don't clash.  You can scale out the secondary nodes, e.g. to start a three node cluster run:
-# > docker-compose up --scale ksql-server=2
+# By default, the cluster has two KSQL servers. You can scale the number of KSQL nodes in the
+# cluster by using the docker `--scale` command line arg.
+#
+# e.g. for a 4 node cluster run:
+# > docker-compose up --scale additional-ksqldb-server=3
+#
+# or a 1 node cluster run:
+# > docker-compose up --scale additional-ksqldb-server=0
+#
+# The default is one `primary-ksqldb-server` and one `additional-ksqdb-server`. The only
+# difference is that the primary node has a well-known port exposed so clients can connect, where
+# as the additional nodes use auto-port assignment so that ports don't clash.
 #
 # If you wish to run with locally built KSQL docker images then build then:
 #
@@ -59,10 +66,10 @@ services:
       SCHEMA_REGISTRY_HOST_NAME: schema-registry
       SCHEMA_REGISTRY_KAFKASTORE_CONNECTION_URL: zookeeper:32181
 
-  ksqldb-server-primary:
+  primary-ksqldb-server:
     image: confluentinc/ksqldb-server:latest
-    hostname: ksqldb-server-primary
-    container_name: ksqldb-server-primary
+    hostname: primary-ksqldb-server
+    container_name: primary-ksqldb-server
     depends_on:
       - kafka
       - schema-registry
@@ -75,12 +82,12 @@ services:
       KSQL_KSQL_LOGGING_PROCESSING_STREAM_AUTO_CREATE: "true"
       KSQL_KSQL_LOGGING_PROCESSING_TOPIC_AUTO_CREATE: "true"
 
-  ksqldb-server:
+  additional-ksqldb-server:
     image: confluentinc/ksqldb-server:latest
-    hostname: ksqldb-server
-    container_name: ksqldb-server
+    hostname: additional-ksqldb-server
+    container_name: additional-ksqldb-server
     depends_on:
-      - ksqldb-server-primary
+      - primary-ksqldb-server
     ports:
       - "8090"
     environment:
@@ -89,12 +96,12 @@ services:
       KSQL_KSQL_SCHEMA_REGISTRY_URL: http://schema-registry:8081
 
   # Access the cli by running:
-  # > docker-compose exec ksqldb-cli  ksql http://ksqldb-server-primary:8088
+  # > docker-compose exec ksqldb-cli  ksql http://primary-ksqldb-server:8088
   ksqldb-cli:
     image: confluentinc/ksqldb-cli:latest
     container_name: ksqldb-cli
     depends_on:
-      - ksqldb-server-primary
+      - primary-ksqldb-server
     entrypoint: /bin/sh
     tty: true
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,100 @@
+# Docker compose from bringing up a local KSQL cluster and dependencies.
+#
+# You can scale the number of KSQL nodes in the cluster by using the docker `--scale` command line arg.
+# The default is one primary node and 1 secondary node. The only difference is that the primary node
+# has a well-known port exposed so clients can connect, where as the secondary nodes use auto-port
+# assignment so that ports don't clash.  You can scale out the secondary nodes, e.g. to start a three node cluster run:
+# > docker-compose up --scale ksql-server=2
+#
+# If you wish to run with locally built KSQL docker images then build then:
+#
+# 1. ensure logged in to docker:
+# > docker login
+#
+# 2. ensure you can log in to AWS ECR:
+# > aws ecr get-login --no-include-email | sh
+#
+# 3. build docker images from local changes (Note: access to Confluent docker registry is required):
+# Change `docker.upstream-tag` if you want to depend on anything other than the latest master upstream, e.g. 5.4.x-latest
+# > mvn -Pdocker package -DskipTests -Dspotbugs.skip -Dcheckstyle.skip  -Ddockerfile.skip=false -Dskip.docker.build=false -Ddocker.upstream-tag=master-latest -Ddocker.tag=local.build -Ddocker.upstream-registry='368821881613.dkr.ecr.us-west-2.amazonaws.com/'
+#
+# 4. check images build:
+# > docker image ls | grep ksql.local.build
+# You should see your new images listed
+#
+# 5. update this file below replacing all references to "confluentinc/ksqldb-server:latest" with your image, e.g. "placeholder/confluentinc/ksql-rest-app:local.build"
+
+---
+version: '2'
+services:
+  zookeeper:
+    image: confluentinc/cp-zookeeper:latest
+    environment:
+      ZOOKEEPER_CLIENT_PORT: 32181
+      ZOOKEEPER_TICK_TIME: 2000
+
+  kafka:
+    image: confluentinc/cp-enterprise-kafka:latest
+    ports:
+      - "29092:29092"
+    depends_on:
+      - zookeeper
+    environment:
+      KAFKA_BROKER_ID: 1
+      KAFKA_ZOOKEEPER_CONNECT: zookeeper:32181
+      KAFKA_LISTENER_SECURITY_PROTOCOL_MAP: PLAINTEXT:PLAINTEXT,PLAINTEXT_HOST:PLAINTEXT
+      KAFKA_INTER_BROKER_LISTENER_NAME: PLAINTEXT
+      KAFKA_ADVERTISED_LISTENERS: PLAINTEXT://kafka:9092,PLAINTEXT_HOST://localhost:29092
+      KAFKA_OFFSETS_TOPIC_REPLICATION_FACTOR: 1
+      KAFKA_TRANSACTION_STATE_LOG_REPLICATION_FACTOR: 1
+      KAFKA_TRANSACTION_STATE_LOG_MIN_ISR: 1
+      KAFKA_GROUP_INITIAL_REBALANCE_DELAY_MS: 100
+
+  schema-registry:
+    image: confluentinc/cp-schema-registry:latest
+    depends_on:
+      - zookeeper
+      - kafka
+    environment:
+      SCHEMA_REGISTRY_HOST_NAME: schema-registry
+      SCHEMA_REGISTRY_KAFKASTORE_CONNECTION_URL: zookeeper:32181
+
+  ksqldb-server-primary:
+    image: confluentinc/ksqldb-server:latest
+    hostname: ksqldb-server-primary
+    container_name: ksqldb-server-primary
+    depends_on:
+      - kafka
+      - schema-registry
+    ports:
+      - "8088:8088"
+    environment:
+      KSQL_LISTENERS: http://0.0.0.0:8088
+      KSQL_BOOTSTRAP_SERVERS: kafka:9092
+      KSQL_KSQL_SCHEMA_REGISTRY_URL: http://schema-registry:8081
+      KSQL_KSQL_LOGGING_PROCESSING_STREAM_AUTO_CREATE: "true"
+      KSQL_KSQL_LOGGING_PROCESSING_TOPIC_AUTO_CREATE: "true"
+
+  ksqldb-server:
+    image: confluentinc/ksqldb-server:latest
+    hostname: ksqldb-server
+    container_name: ksqldb-server
+    depends_on:
+      - ksqldb-server-primary
+    ports:
+      - "8090"
+    environment:
+      KSQL_LISTENERS: http://0.0.0.0:8090
+      KSQL_BOOTSTRAP_SERVERS: kafka:9092
+      KSQL_KSQL_SCHEMA_REGISTRY_URL: http://schema-registry:8081
+
+  # Access the cli by running:
+  # > docker-compose exec ksqldb-cli  ksql http://ksqldb-server-primary:8088
+  ksqldb-cli:
+    image: confluentinc/ksqldb-cli:latest
+    container_name: ksqldb-cli
+    depends_on:
+      - ksqldb-server-primary
+    entrypoint: /bin/sh
+    tty: true
+


### PR DESCRIPTION
### Description 

Added a sample docker-compose file with some steps for how to use. Brings up multi-node KSQL with dependants. 

Only outstanding issue is it doesn't look like community members can build docker images locally, as they won't have access to a AWS based docker repo, right?   Does anyone know a way around this, or plans to make this publicly available? cc @apurvam @rodesai @agavra 


### Testing done 

manually checked it all works.

### Reviewer checklist
- [ ] Ensure docs are updated if necessary. (eg. if a user visible feature is being added or changed).
- [ ] Ensure relevant issues are linked (description should include text like "Fixes #<issue number>")

