### PR TITLE
chore: check retention.ms on internal topic before trying to set value (MINOR)

### DIFF
--- a/ksql-rest-app/src/main/java/io/confluent/ksql/rest/util/KsqlInternalTopicUtils.java
+++ b/ksql-rest-app/src/main/java/io/confluent/ksql/rest/util/KsqlInternalTopicUtils.java
@@ -97,11 +97,14 @@ public final class KsqlInternalTopicUtils {
       final ImmutableMap<String, Object> requiredConfig =
           ImmutableMap.of(TopicConfig.RETENTION_MS_CONFIG, requiredTopicRetention);
 
-      if (topicClient.addTopicConfig(name, requiredConfig)) {
-        log.info(
-            "Corrected retention.ms on ksql internal topic. topic:{}, retention.ms:{}",
-            name,
-            requiredTopicRetention);
+      if (!topicClient.getTopicConfig(name).getOrDefault(TopicConfig.RETENTION_MS_CONFIG, "0")
+          .equals(Long.toString(requiredTopicRetention))) {
+        if (topicClient.addTopicConfig(name, requiredConfig)) {
+          log.info(
+              "Corrected retention.ms on ksql internal topic. topic:{}, retention.ms:{}",
+              name,
+              requiredTopicRetention);
+        }
       }
 
       return;


### PR DESCRIPTION
### Description 
Adds a pre-check before attempting to update the `retention.ms` value on internal topics.

This gets rid of the need to specify a `ALTER_TOPIC` ACL if the user creates the internal topics with `retention.ms` set to `Long.MAX_VALUE` already.
### Testing done 
Unit test

### Reviewer checklist
- [ ] Ensure docs are updated if necessary. (eg. if a user visible feature is being added or changed).
- [ ] Ensure relevant issues are linked (description should include text like "Fixes #<issue number>")

