### PR TITLE
refactor: inject a KsqlSecurityContext to REST requests

### DIFF
--- a/ksql-engine/src/main/java/io/confluent/ksql/security/KsqlSecurityContext.java
+++ b/ksql-engine/src/main/java/io/confluent/ksql/security/KsqlSecurityContext.java
@@ -1,0 +1,58 @@
+/*
+ * Copyright 2019 Confluent Inc.
+ *
+ * Licensed under the Confluent Community License (the "License"); you may not use
+ * this file except in compliance with the License.  You may obtain a copy of the
+ * License at
+ *
+ * http://www.confluent.io/confluent-community-license
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package io.confluent.ksql.security;
+
+import io.confluent.ksql.services.ServiceContext;
+
+import java.security.Principal;
+import java.util.Optional;
+
+/**
+ * A class that provides KSQL security related information for KSQL user requests.
+ */
+public class KsqlSecurityContext {
+  private final Optional<Principal> userPrincipal;
+  private final ServiceContext serviceContext;
+
+  public KsqlSecurityContext(Optional<Principal> userPrincipal, ServiceContext serviceContext) {
+    this.userPrincipal = userPrincipal;
+    this.serviceContext = serviceContext;
+  }
+
+  /**
+   * Returns a {@code java.security.Principal} object containing the name of the current
+   * authenticated user. If the user has not been authenticated, the method returns
+   * {@code Optional.empty}.
+   *
+   * @return a {@code java.security.Principal} containing the name of the user making this request;
+   * {@code Optional.empty} if the user has not been authenticated
+   */
+  public Optional<Principal> getUserPrincipal() {
+    return userPrincipal;
+  }
+
+  /**
+   * Returns a {@link ServiceContext} object with injected credentials of the authenticated
+   * user. If KSQL does not have user authentication configured, the method returns the default
+   * {@code ServiceContext} containing the KSQL server configuration (with KSQL credentials or not).
+   *
+   * @return a {@code ServiceContext} with injected user credentials or default KSQL server
+   *         configuration.
+   */
+  public ServiceContext getServiceContext() {
+    return serviceContext;
+  }
+}

--- a/ksql-engine/src/main/java/io/confluent/ksql/security/KsqlSecurityContext.java
+++ b/ksql-engine/src/main/java/io/confluent/ksql/security/KsqlSecurityContext.java
@@ -27,7 +27,10 @@ public class KsqlSecurityContext {
   private final Optional<Principal> userPrincipal;
   private final ServiceContext serviceContext;
 
-  public KsqlSecurityContext(Optional<Principal> userPrincipal, ServiceContext serviceContext) {
+  public KsqlSecurityContext(
+      final Optional<Principal> userPrincipal,
+      final ServiceContext serviceContext
+  ) {
     this.userPrincipal = userPrincipal;
     this.serviceContext = serviceContext;
   }

--- a/ksql-rest-app/src/main/java/io/confluent/ksql/rest/server/KsqlRestApplication.java
+++ b/ksql-rest-app/src/main/java/io/confluent/ksql/rest/server/KsqlRestApplication.java
@@ -72,6 +72,7 @@ import io.confluent.ksql.rest.util.RocksDBConfigSetterHandler;
 import io.confluent.ksql.security.KsqlAuthorizationValidator;
 import io.confluent.ksql.security.KsqlAuthorizationValidatorFactory;
 import io.confluent.ksql.security.KsqlDefaultSecurityExtension;
+import io.confluent.ksql.security.KsqlSecurityContext;
 import io.confluent.ksql.security.KsqlSecurityExtension;
 import io.confluent.ksql.services.LazyServiceContext;
 import io.confluent.ksql.services.ServiceContext;
@@ -688,7 +689,8 @@ public final class KsqlRestApplication extends ExecutableApplication<KsqlRestCon
     
     try {
       final SimpleKsqlClient internalClient =
-          new ServerInternalKsqlClient(ksqlResource, serviceContext);
+          new ServerInternalKsqlClient(ksqlResource, new KsqlSecurityContext(
+              Optional.empty(), serviceContext));
       final URI serverEndpoint = ServerUtil.getServerAddress(restConfig);
 
       final RestResponse<KsqlEntityList> response = internalClient.makeKsqlRequest(

--- a/ksql-rest-app/src/main/java/io/confluent/ksql/rest/server/KsqlRestApplication.java
+++ b/ksql-rest-app/src/main/java/io/confluent/ksql/rest/server/KsqlRestApplication.java
@@ -48,7 +48,7 @@ import io.confluent.ksql.rest.entity.KsqlErrorMessage;
 import io.confluent.ksql.rest.server.computation.CommandRunner;
 import io.confluent.ksql.rest.server.computation.CommandStore;
 import io.confluent.ksql.rest.server.computation.InteractiveStatementExecutor;
-import io.confluent.ksql.rest.server.context.KsqlRestServiceContextBinder;
+import io.confluent.ksql.rest.server.context.KsqlSecurityContextBinder;
 import io.confluent.ksql.rest.server.filters.KsqlAuthorizationFilter;
 import io.confluent.ksql.rest.server.resources.HealthCheckResource;
 import io.confluent.ksql.rest.server.resources.KsqlConfigurable;
@@ -468,7 +468,7 @@ public final class KsqlRestApplication extends ExecutableApplication<KsqlRestCon
         versionCheckerFactory,
         Integer.MAX_VALUE,
         serviceContext,
-        KsqlRestServiceContextBinder::new);
+        KsqlSecurityContextBinder::new);
   }
 
   static KsqlRestApplication buildApplication(

--- a/ksql-rest-app/src/main/java/io/confluent/ksql/rest/server/context/KsqlSecurityContextBinder.java
+++ b/ksql-rest-app/src/main/java/io/confluent/ksql/rest/server/context/KsqlSecurityContextBinder.java
@@ -15,31 +15,31 @@
 
 package io.confluent.ksql.rest.server.context;
 
+import io.confluent.ksql.security.KsqlSecurityContext;
 import io.confluent.ksql.security.KsqlSecurityExtension;
-import io.confluent.ksql.services.ServiceContext;
 import io.confluent.ksql.util.KsqlConfig;
 import org.glassfish.hk2.utilities.binding.AbstractBinder;
 import org.glassfish.jersey.process.internal.RequestScoped;
 
 /**
- * Configures the {@link ServiceContext} class for dependency injection using the
- * {@link javax.ws.rs.core.Context} annotation.
+ * Configures the {@link KsqlSecurityContext} class for dependency injection using
+ * the {@link javax.ws.rs.core.Context} annotation.
  * </p>
- * Inject {@code ServiceContext} on each REST method as follows:
- * i.e. myMethod(@Context ServiceContext serviceContext)
+ * Inject {@code KsqlSecurityContext} on each REST method as follows:
+ * i.e. myMethod(@Context KsqlSecurityContext securityContext)
  */
-public class KsqlRestServiceContextBinder extends AbstractBinder {
-  public KsqlRestServiceContextBinder(
+public class KsqlSecurityContextBinder extends AbstractBinder {
+  public KsqlSecurityContextBinder(
       final KsqlConfig ksqlConfig,
       final KsqlSecurityExtension securityExtension
   ) {
-    KsqlRestServiceContextFactory.configure(ksqlConfig, securityExtension);
+    KsqlSecurityContextBinderFactory.configure(ksqlConfig, securityExtension);
   }
 
   @Override
   protected void configure() {
-    bindFactory(KsqlRestServiceContextFactory.class)
-        .to(ServiceContext.class)
+    bindFactory(KsqlSecurityContextBinderFactory.class)
+        .to(KsqlSecurityContext.class)
         .in(RequestScoped.class);
   }
 }

--- a/ksql-rest-app/src/main/java/io/confluent/ksql/rest/server/resources/HealthCheckResource.java
+++ b/ksql-rest-app/src/main/java/io/confluent/ksql/rest/server/resources/HealthCheckResource.java
@@ -24,9 +24,11 @@ import io.confluent.ksql.rest.entity.Versions;
 import io.confluent.ksql.rest.healthcheck.HealthCheckAgent;
 import io.confluent.ksql.rest.server.KsqlRestConfig;
 import io.confluent.ksql.rest.server.services.ServerInternalKsqlClient;
+import io.confluent.ksql.security.KsqlSecurityContext;
 import io.confluent.ksql.services.ServiceContext;
 import java.time.Duration;
 import java.util.Objects;
+import java.util.Optional;
 import java.util.concurrent.TimeUnit;
 import javax.annotation.Nonnull;
 import javax.ws.rs.GET;
@@ -70,7 +72,8 @@ public class HealthCheckResource {
   ) {
     return new HealthCheckResource(
         new HealthCheckAgent(
-            new ServerInternalKsqlClient(ksqlResource, serviceContext),
+            new ServerInternalKsqlClient(ksqlResource,
+                new KsqlSecurityContext(Optional.empty(), serviceContext)),
             restConfig),
         Duration.ofMillis(restConfig.getLong(KsqlRestConfig.KSQL_HEALTHCHECK_INTERVAL_MS_CONFIG))
     );

--- a/ksql-rest-app/src/main/java/io/confluent/ksql/rest/server/services/ServerInternalKsqlClient.java
+++ b/ksql-rest-app/src/main/java/io/confluent/ksql/rest/server/services/ServerInternalKsqlClient.java
@@ -23,7 +23,7 @@ import io.confluent.ksql.rest.entity.KsqlEntityList;
 import io.confluent.ksql.rest.entity.KsqlRequest;
 import io.confluent.ksql.rest.entity.StreamedRow;
 import io.confluent.ksql.rest.server.resources.KsqlResource;
-import io.confluent.ksql.services.ServiceContext;
+import io.confluent.ksql.security.KsqlSecurityContext;
 import io.confluent.ksql.services.SimpleKsqlClient;
 import java.net.URI;
 import java.util.Collections;
@@ -40,14 +40,14 @@ public class ServerInternalKsqlClient implements SimpleKsqlClient {
   private static final String KSQL_PATH = "/ksql";
 
   private final KsqlResource ksqlResource;
-  private final ServiceContext serviceContext;
+  private final KsqlSecurityContext securityContext;
 
   public ServerInternalKsqlClient(
       final KsqlResource ksqlResource,
-      final ServiceContext serviceContext
+      final KsqlSecurityContext securityContext
   ) {
     this.ksqlResource = requireNonNull(ksqlResource, "ksqlResource");
-    this.serviceContext = requireNonNull(serviceContext, "serviceContext");
+    this.securityContext = requireNonNull(securityContext, "securityContext");
   }
 
   @Override
@@ -56,7 +56,7 @@ public class ServerInternalKsqlClient implements SimpleKsqlClient {
       final String sql
   ) {
     final KsqlRequest request = new KsqlRequest(sql, Collections.emptyMap(), null);
-    final Response response = ksqlResource.handleKsqlStatements(serviceContext, request);
+    final Response response = ksqlResource.handleKsqlStatements(securityContext, request);
     return KsqlClientUtil.toRestResponse(
         response,
         KSQL_PATH,

--- a/ksql-rest-app/src/test/java/io/confluent/ksql/rest/server/KsqlRestApplicationTest.java
+++ b/ksql-rest-app/src/test/java/io/confluent/ksql/rest/server/KsqlRestApplicationTest.java
@@ -40,7 +40,7 @@ import io.confluent.ksql.rest.entity.KsqlErrorMessage;
 import io.confluent.ksql.rest.entity.KsqlRequest;
 import io.confluent.ksql.rest.server.computation.CommandRunner;
 import io.confluent.ksql.rest.server.computation.CommandStore;
-import io.confluent.ksql.rest.server.context.KsqlRestServiceContextBinder;
+import io.confluent.ksql.rest.server.context.KsqlSecurityContextBinder;
 import io.confluent.ksql.rest.server.filters.KsqlAuthorizationFilter;
 import io.confluent.ksql.rest.server.resources.KsqlResource;
 import io.confluent.ksql.rest.server.resources.RootDocument;
@@ -402,7 +402,7 @@ public class KsqlRestApplicationTest {
         streamedQueryResource,
         ksqlResource,
         versionCheckerAgent,
-        KsqlRestServiceContextBinder::new,
+        KsqlSecurityContextBinder::new,
         securityExtension,
         serverState,
         processingLogContext,

--- a/ksql-rest-app/src/test/java/io/confluent/ksql/rest/server/KsqlRestApplicationTest.java
+++ b/ksql-rest-app/src/test/java/io/confluent/ksql/rest/server/KsqlRestApplicationTest.java
@@ -49,6 +49,7 @@ import io.confluent.ksql.rest.server.resources.streaming.StreamedQueryResource;
 import io.confluent.ksql.rest.server.state.ServerState;
 import io.confluent.ksql.rest.util.ProcessingLogServerUtils;
 import io.confluent.ksql.security.KsqlAuthorizationProvider;
+import io.confluent.ksql.security.KsqlSecurityContext;
 import io.confluent.ksql.security.KsqlSecurityExtension;
 import io.confluent.ksql.services.KafkaTopicClient;
 import io.confluent.ksql.services.ServiceContext;
@@ -68,6 +69,7 @@ import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ExpectedException;
 import org.junit.runner.RunWith;
+import org.mockito.ArgumentCaptor;
 import org.mockito.InOrder;
 import org.mockito.Mock;
 import org.mockito.Mockito;
@@ -126,6 +128,10 @@ public class KsqlRestApplicationTest {
   private String logCreateStatement;
   private KsqlRestApplication app;
   private KsqlRestConfig restConfig;
+  private KsqlSecurityContext securityContext;
+
+  private ArgumentCaptor<KsqlSecurityContext> securityContextArgumentCaptor =
+      ArgumentCaptor.forClass(KsqlSecurityContext.class);
 
   @SuppressWarnings("unchecked")
   @Before
@@ -148,6 +154,8 @@ public class KsqlRestApplicationTest {
     when(topicClient.isTopicExists(CMD_TOPIC_NAME)).thenReturn(false);
     when(precondition1.checkPrecondition(any(), any())).thenReturn(Optional.empty());
     when(precondition2.checkPrecondition(any(), any())).thenReturn(Optional.empty());
+
+    securityContext = new KsqlSecurityContext(Optional.empty(), serviceContext);
 
     logCreateStatement = ProcessingLogServerUtils.processingLogStreamCreateStatement(
         processingLogConfig,
@@ -208,10 +216,11 @@ public class KsqlRestApplicationTest {
 
     // Then:
     verify(ksqlResource).handleKsqlStatements(
-        serviceContext,
-        new KsqlRequest(logCreateStatement, Collections.emptyMap(), null)
+        securityContextArgumentCaptor.capture(),
+        eq(new KsqlRequest(logCreateStatement, Collections.emptyMap(), null))
     );
-
+    assertThat(securityContextArgumentCaptor.getValue().getUserPrincipal(), is(Optional.empty()));
+    assertThat(securityContextArgumentCaptor.getValue().getServiceContext(), is(serviceContext));
   }
 
   @Test
@@ -225,7 +234,7 @@ public class KsqlRestApplicationTest {
 
     // Then:
     verify(ksqlResource, never()).handleKsqlStatements(
-        serviceContext,
+        securityContext,
         new KsqlRequest(logCreateStatement, Collections.emptyMap(), null)
     );
   }
@@ -241,9 +250,11 @@ public class KsqlRestApplicationTest {
     inOrder.verify(commandRunner).processPriorCommands();
     inOrder.verify(commandRunner).start();
     inOrder.verify(ksqlResource).handleKsqlStatements(
-        serviceContext,
-        new KsqlRequest(logCreateStatement, Collections.emptyMap(), null)
+        securityContextArgumentCaptor.capture(),
+        eq(new KsqlRequest(logCreateStatement, Collections.emptyMap(), null))
     );
+    assertThat(securityContextArgumentCaptor.getValue().getUserPrincipal(), is(Optional.empty()));
+    assertThat(securityContextArgumentCaptor.getValue().getServiceContext(), is(serviceContext));
   }
 
   @Test
@@ -255,9 +266,11 @@ public class KsqlRestApplicationTest {
     final InOrder inOrder = Mockito.inOrder(topicClient, ksqlResource);
     inOrder.verify(topicClient).createTopic(eq(LOG_TOPIC_NAME), anyInt(), anyShort());
     inOrder.verify(ksqlResource).handleKsqlStatements(
-        serviceContext,
-        new KsqlRequest(logCreateStatement, Collections.emptyMap(), null)
+        securityContextArgumentCaptor.capture(),
+        eq(new KsqlRequest(logCreateStatement, Collections.emptyMap(), null))
     );
+    assertThat(securityContextArgumentCaptor.getValue().getUserPrincipal(), is(Optional.empty()));
+    assertThat(securityContextArgumentCaptor.getValue().getServiceContext(), is(serviceContext));
   }
 
   @Test
@@ -291,9 +304,11 @@ public class KsqlRestApplicationTest {
     // Then:
     final InOrder inOrder = Mockito.inOrder(ksqlResource, serverState);
     verify(ksqlResource).handleKsqlStatements(
-        serviceContext,
-        new KsqlRequest(logCreateStatement, Collections.emptyMap(), null)
+        securityContextArgumentCaptor.capture(),
+        eq(new KsqlRequest(logCreateStatement, Collections.emptyMap(), null))
     );
+    assertThat(securityContextArgumentCaptor.getValue().getUserPrincipal(), is(Optional.empty()));
+    assertThat(securityContextArgumentCaptor.getValue().getServiceContext(), is(serviceContext));
     inOrder.verify(serverState).setReady();
   }
 

--- a/ksql-rest-app/src/test/java/io/confluent/ksql/rest/server/computation/RecoveryTest.java
+++ b/ksql-rest-app/src/test/java/io/confluent/ksql/rest/server/computation/RecoveryTest.java
@@ -48,6 +48,7 @@ import io.confluent.ksql.rest.server.resources.KsqlResource;
 import io.confluent.ksql.rest.server.state.ServerState;
 import io.confluent.ksql.rest.util.ClusterTerminator;
 import io.confluent.ksql.schema.ksql.LogicalSchema;
+import io.confluent.ksql.security.KsqlSecurityContext;
 import io.confluent.ksql.serde.ValueFormat;
 import io.confluent.ksql.services.FakeKafkaTopicClient;
 import io.confluent.ksql.services.ServiceContext;
@@ -88,6 +89,8 @@ public class RecoveryTest {
   private final SpecificQueryIdGenerator queryIdGenerator = new SpecificQueryIdGenerator();
   private final ServiceContext serviceContext = TestServiceContext.create(topicClient);
 
+  private KsqlSecurityContext securityContext;
+
   @Mock
   @SuppressWarnings("unchecked")
   private final Producer<CommandId, Command> transactionalProducer = (Producer<CommandId, Command>) mock(Producer.class);
@@ -97,7 +100,9 @@ public class RecoveryTest {
 
 
   @Before
-  public void setup() { }
+  public void setup() {
+    securityContext = new KsqlSecurityContext(Optional.empty(), serviceContext);
+  }
 
   @After
   public void tearDown() {
@@ -238,7 +243,7 @@ public class RecoveryTest {
 
     void submitCommands(final String ...statements) {
       for (final String statement : statements) {
-        final Response response = ksqlResource.handleKsqlStatements(serviceContext,
+        final Response response = ksqlResource.handleKsqlStatements(securityContext,
             new KsqlRequest(statement, Collections.emptyMap(), null));
         assertThat(response.getStatus(), equalTo(200));
         executeCommands();

--- a/ksql-rest-app/src/test/java/io/confluent/ksql/rest/server/resources/streaming/StreamedQueryResourceTest.java
+++ b/ksql-rest-app/src/test/java/io/confluent/ksql/rest/server/resources/streaming/StreamedQueryResourceTest.java
@@ -58,6 +58,7 @@ import io.confluent.ksql.rest.server.resources.KsqlRestException;
 import io.confluent.ksql.schema.ksql.LogicalSchema;
 import io.confluent.ksql.schema.ksql.types.SqlTypes;
 import io.confluent.ksql.security.KsqlAuthorizationValidator;
+import io.confluent.ksql.security.KsqlSecurityContext;
 import io.confluent.ksql.services.KafkaTopicClient;
 import io.confluent.ksql.services.ServiceContext;
 import io.confluent.ksql.statement.ConfiguredStatement;
@@ -148,6 +149,7 @@ public class StreamedQueryResourceTest {
   private PreparedStatement<Statement> invalid;
   private PreparedStatement<Query> query;
   private PreparedStatement<PrintTopic> print;
+  private KsqlSecurityContext securityContext;
 
   @Before
   public void setup() {
@@ -161,6 +163,8 @@ public class StreamedQueryResourceTest {
     final PreparedStatement<Statement> pullQueryStatement = PreparedStatement.of(PULL_QUERY_STRING, pullQuery);
     when(mockStatementParser.parseSingleStatement(PULL_QUERY_STRING)).thenReturn(pullQueryStatement);
     when(errorsHandler.accessDeniedFromKafkaResponse(any(Exception.class))).thenReturn(AUTHORIZATION_ERROR_RESPONSE);
+
+    securityContext = new KsqlSecurityContext(Optional.empty(), serviceContext);
 
     testResource = new StreamedQueryResource(
         mockKsqlEngine,
@@ -207,7 +211,7 @@ public class StreamedQueryResourceTest {
 
     // When:
     testResource.streamQuery(
-        serviceContext,
+        securityContext,
         new KsqlRequest("query", Collections.emptyMap(), null)
     );
   }
@@ -227,7 +231,7 @@ public class StreamedQueryResourceTest {
 
     // When:
     testResource.streamQuery(
-        serviceContext,
+        securityContext,
         new KsqlRequest("query", Collections.emptyMap(), null)
     );
   }
@@ -236,7 +240,7 @@ public class StreamedQueryResourceTest {
   public void shouldNotWaitIfCommandSequenceNumberSpecified() throws Exception {
     // When:
     testResource.streamQuery(
-        serviceContext,
+        securityContext,
         new KsqlRequest(PUSH_QUERY_STRING, Collections.emptyMap(), null)
     );
 
@@ -248,7 +252,7 @@ public class StreamedQueryResourceTest {
   public void shouldWaitIfCommandSequenceNumberSpecified() throws Exception {
     // When:
     testResource.streamQuery(
-        serviceContext,
+        securityContext,
         new KsqlRequest(PUSH_QUERY_STRING, Collections.emptyMap(), 3L)
     );
 
@@ -273,7 +277,7 @@ public class StreamedQueryResourceTest {
 
     // When:
     testResource.streamQuery(
-        serviceContext,
+        securityContext,
         new KsqlRequest(PUSH_QUERY_STRING, Collections.emptyMap(), 3L)
     );
   }
@@ -288,7 +292,7 @@ public class StreamedQueryResourceTest {
 
     // When:
     testResource.streamQuery(
-        serviceContext,
+        securityContext,
         new KsqlRequest(PULL_QUERY_STRING, Collections.emptyMap(), null)
     );
 
@@ -303,7 +307,7 @@ public class StreamedQueryResourceTest {
   public void shouldThrowExceptionForPullQueryIfValidating() {
     // When:
     final Response response = testResource.streamQuery(
-        serviceContext,
+        securityContext,
         new KsqlRequest(PULL_QUERY_STRING, Collections.emptyMap(), null)
     );
 
@@ -327,7 +331,7 @@ public class StreamedQueryResourceTest {
 
     // When:
     final Response response = testResource.streamQuery(
-        serviceContext,
+        securityContext,
         new KsqlRequest(PULL_QUERY_STRING, Collections.emptyMap(), null)
     );
 
@@ -399,7 +403,7 @@ public class StreamedQueryResourceTest {
 
     final Response response =
         testResource.streamQuery(
-            serviceContext,
+            securityContext,
             new KsqlRequest(queryString, requestStreamsProperties, null)
         );
     final PipedOutputStream responseOutputStream = new EOFPipedOutputStream();
@@ -538,7 +542,7 @@ public class StreamedQueryResourceTest {
   public void shouldUpdateTheLastRequestTime() {
     /// When:
     testResource.streamQuery(
-        serviceContext,
+        securityContext,
         new KsqlRequest(PUSH_QUERY_STRING, Collections.emptyMap(), null)
     );
 
@@ -557,7 +561,7 @@ public class StreamedQueryResourceTest {
 
     // When:
     final Response response = testResource.streamQuery(
-        serviceContext,
+        securityContext,
         new KsqlRequest(PUSH_QUERY_STRING, Collections.emptyMap(), null)
     );
 
@@ -580,7 +584,7 @@ public class StreamedQueryResourceTest {
 
     // When:
     final Response response = testResource.streamQuery(
-        serviceContext,
+        securityContext,
         new KsqlRequest(PRINT_TOPIC, Collections.emptyMap(), null)
     );
 
@@ -626,7 +630,7 @@ public class StreamedQueryResourceTest {
 
     // When:
     testResource.streamQuery(
-        serviceContext,
+        securityContext,
         new KsqlRequest(PRINT_TOPIC, Collections.emptyMap(), null)
     );
   }

--- a/ksql-rest-app/src/test/java/io/confluent/ksql/rest/server/services/ServerInternalKsqlClientTest.java
+++ b/ksql-rest-app/src/test/java/io/confluent/ksql/rest/server/services/ServerInternalKsqlClientTest.java
@@ -23,7 +23,8 @@ import io.confluent.ksql.rest.client.RestResponse;
 import io.confluent.ksql.rest.entity.KsqlEntityList;
 import io.confluent.ksql.rest.entity.KsqlRequest;
 import io.confluent.ksql.rest.server.resources.KsqlResource;
-import io.confluent.ksql.services.ServiceContext;
+import io.confluent.ksql.security.KsqlSecurityContext;
+
 import java.net.URI;
 import java.util.Collections;
 import javax.ws.rs.core.Response;
@@ -44,7 +45,7 @@ public class ServerInternalKsqlClientTest {
   @Mock
   private KsqlResource ksqlResource;
   @Mock
-  private ServiceContext serviceContext;
+  private KsqlSecurityContext securityContext;
   @Mock
   private URI unused;
   @Mock
@@ -58,13 +59,13 @@ public class ServerInternalKsqlClientTest {
     when(response.getStatus()).thenReturn(Status.OK.getStatusCode());
     when(response.getEntity()).thenReturn(entities);
 
-    ksqlClient = new ServerInternalKsqlClient(ksqlResource, serviceContext);
+    ksqlClient = new ServerInternalKsqlClient(ksqlResource, securityContext);
   }
 
   @Test
   public void shouldMakeKsqlRequest() {
     // Given:
-    when(ksqlResource.handleKsqlStatements(serviceContext, EXPECTED_REQUEST)).thenReturn(response);
+    when(ksqlResource.handleKsqlStatements(securityContext, EXPECTED_REQUEST)).thenReturn(response);
 
     // When:
     final RestResponse<KsqlEntityList> restResponse =


### PR DESCRIPTION
### Description 
**Notice:** This refactor is part of implementing a KSQL authorization cache to enable Pull Queries https://github.com/confluentinc/ksql/issues/4158

The KSQL authorization cache being implemented in https://github.com/confluentinc/ksql/issues/4158 requires the authenticated username to use it as part of the cache key. This username must be passed from the REST requests down to the KSQL permission validator. To do so, this PR replaces the current `ServiceContext` binder (which only injects a user impersonated ServiceContext object) with a new `KsqlSecurityContext` binder which wraps the authenticated REST or WS username and the current user impersonated ServiceContext into one context.

This `KsqlSecurityContext` is passed down to the KSQL permission validator where it will be used by the authorization cache to verify if KSQL already requested permissions for the authenticated user.

This PR does not implement any cache and any usage of the authenticated name. It is just a refactor.

Review help:
The PR is divided into commits to help an easy review.
* The 1st commit creates the new `KsqlSecurityContext` and binder/factory classes (replacing old ServiceContext binder/factory).
* The 2nd commit injects the new `ksqlSecurityContext` into the REST methods where the `ServiceContext` is obtained and passed to the validators as it is currently done. 

Websockets do not require any dependency injection, so no changes are done there yet. This will follow up in another PR.

### Testing done 
* Added unit tests to validated the `KsqlSecurityContext` is created with an optional authenticated username

### Reviewer checklist
- [ ] Ensure docs are updated if necessary. (eg. if a user visible feature is being added or changed).
- [ ] Ensure relevant issues are linked (description should include text like "Fixes #<issue number>")

