### PR TITLE
fix: reintroduce FetchFieldFromStruct as a public UDF

### DIFF
--- a/ksql-execution/src/main/java/io/confluent/ksql/execution/codegen/SqlToJavaVisitor.java
+++ b/ksql-execution/src/main/java/io/confluent/ksql/execution/codegen/SqlToJavaVisitor.java
@@ -366,6 +366,10 @@ public class SqlToJavaVisitor {
     private Schema getFunctionReturnSchema(
         final FunctionCall node
     ) {
+      if (node.getName().equals(FetchFieldFromStruct.FUNCTION_NAME)) {
+        return expressionTypeManager.getExpressionSchema(node);
+      }
+
       final UdfFactory udfFactory = functionRegistry.getUdfFactory(node.getName().name());
       final List<Schema> argumentSchemas = node.getArguments().stream()
           .map(expressionTypeManager::getExpressionSchema)

--- a/ksql-execution/src/test/java/io/confluent/ksql/execution/util/ExpressionTypeManagerTest.java
+++ b/ksql-execution/src/test/java/io/confluent/ksql/execution/util/ExpressionTypeManagerTest.java
@@ -297,19 +297,18 @@ public class ExpressionTypeManagerTest {
   }
 
   @Test
-  public void shouldThrowOnFetchFieldFromStructFunctionCall() {
+  public void shouldHandleFetchFieldFromStructFunctionCall() {
     // Given:
     final Expression expression = new FunctionCall(
         FetchFieldFromStruct.FUNCTION_NAME,
         ImmutableList.of(ADDRESS, new StringLiteral("NUMBER"))
     );
 
-    // Then:
-    expectedException.expect(KsqlException.class);
-    expectedException.expectMessage("Can't find any functions with the name 'FETCH_FIELD_FROM_STRUCT'");
-
     // When:
-    expressionTypeManager.getExpressionSqlType(expression);
+    final SqlType sqlType = expressionTypeManager.getExpressionSqlType(expression);
+
+    // Then:
+    assertThat(sqlType, is(SqlTypes.BIGINT));
   }
 
   @Test

--- a/ksql-functional-tests/src/test/resources/query-validation-tests/fetch-field-from-struct.json
+++ b/ksql-functional-tests/src/test/resources/query-validation-tests/fetch-field-from-struct.json
@@ -1,0 +1,20 @@
+{
+  "comments": [
+    "External usage of FETCH_FIELD_FROM_STRUCT"
+  ],
+  "tests": [
+    {
+      "name": "Fetch Field",
+      "statements": [
+        "CREATE STREAM TEST (s STRUCT<val VARCHAR>) WITH (kafka_topic='test_topic', value_format='JSON');",
+        "CREATE STREAM OUTPUT as SELECT FETCH_FIELD_FROM_STRUCT(s, 'VAL') AS value FROM test;"
+      ],
+      "inputs": [
+        {"topic": "test_topic", "key": "foo", "value": {"s": {"val": "foo"}}}
+      ],
+      "outputs": [
+        {"topic": "OUTPUT", "key": "foo", "value": {"VALUE": "foo"}}
+      ]
+    }
+  ]
+}

--- a/ksql-functional-tests/src/test/resources/query-validation-tests/simple-struct.json
+++ b/ksql-functional-tests/src/test/resources/query-validation-tests/simple-struct.json
@@ -1821,17 +1821,6 @@
           "key": 0
         }
       ]
-    },
-    {
-      "name": "direct use of FETCH_FIELD_FROM_STRUCT",
-      "statements": [
-        "CREATE STREAM input (s STRUCT<f0 BIGINT>) WITH (kafka_topic='input_topic', value_format='JSON');",
-        "CREATE STREAM output AS SELECT FETCH_FIELD_FROM_STRUCT(s, 'f0') FROM input;"
-      ],
-      "expectedException": {
-        "type": "io.confluent.ksql.util.KsqlStatementException",
-        "message": "Can't find any functions with the name 'FETCH_FIELD_FROM_STRUCT'"
-      }
     }
   ]
 }


### PR DESCRIPTION
### Description 

When upgrading from 5.3->5.4 commands that were already written into the command topic would fail with "Cannot find function FETCH_FEILD_FROM_STRCUT". The reason is that we made structs stop rewriting with that UDF and instead inlined it's usage and prevent people from using that function externally. This re-introduces the change into 5.4. so that upgrades are possible.

NOTE: This will not be merged to master and master will be considered a breaking upgrade from 5.4

### Testing done 

- verified the problem by running 5.3 and issuing a command with struct access
- upgraded to 5.4 and checked if it can recover; before this fix it cannot and after it can

### Reviewer checklist
- [ ] Ensure docs are updated if necessary. (eg. if a user visible feature is being added or changed).
- [ ] Ensure relevant issues are linked (description should include text like "Fixes #<issue number>")

