### PR TITLE
chore: build ksql-parser on WSL

### DIFF
--- a/ksql-parser/src/main/java/io/confluent/ksql/parser/AstBuilder.java
+++ b/ksql-parser/src/main/java/io/confluent/ksql/parser/AstBuilder.java
@@ -24,6 +24,7 @@ import static java.util.stream.Collectors.toList;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import io.confluent.ksql.execution.expression.tree.ArithmeticBinaryExpression;
 import io.confluent.ksql.execution.expression.tree.ArithmeticUnaryExpression;
 import io.confluent.ksql.execution.expression.tree.BetweenPredicate;
@@ -151,6 +152,7 @@ import org.antlr.v4.runtime.Token;
 import org.antlr.v4.runtime.tree.ParseTree;
 import org.antlr.v4.runtime.tree.TerminalNode;
 
+@SuppressFBWarnings({"UUF_UNUSED_FIELD", "DLS_DEAD_LOCAL_STORE"})
 public class AstBuilder {
 
   private final TypeRegistry typeRegistry;

--- a/ksql-parser/src/main/java/io/confluent/ksql/parser/KsqlParser.java
+++ b/ksql-parser/src/main/java/io/confluent/ksql/parser/KsqlParser.java
@@ -16,6 +16,7 @@
 package io.confluent.ksql.parser;
 
 import com.google.errorprone.annotations.Immutable;
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import io.confluent.ksql.metastore.TypeRegistry;
 import io.confluent.ksql.parser.SqlBaseParser.SingleStatementContext;
 import io.confluent.ksql.parser.tree.Statement;
@@ -44,6 +45,7 @@ public interface KsqlParser {
    */
   PreparedStatement<?> prepare(ParsedStatement statement, TypeRegistry typeRegistry);
 
+  @SuppressFBWarnings("UUF_UNUSED_FIELD")
   final class ParsedStatement {
     private final String statementText;
     private final SingleStatementContext statement;
@@ -69,6 +71,7 @@ public interface KsqlParser {
     }
   }
 
+  @SuppressFBWarnings("UUF_UNUSED_FIELD")
   @Immutable
   final class PreparedStatement<T extends Statement> {
 

--- a/ksql-parser/src/main/java/io/confluent/ksql/parser/SchemaParser.java
+++ b/ksql-parser/src/main/java/io/confluent/ksql/parser/SchemaParser.java
@@ -18,6 +18,7 @@ package io.confluent.ksql.parser;
 import static io.confluent.ksql.util.ParserUtil.getLocation;
 import static java.util.Objects.requireNonNull;
 
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import io.confluent.ksql.metastore.TypeRegistry;
 import io.confluent.ksql.name.ColumnName;
 import io.confluent.ksql.parser.tree.TableElement;
@@ -34,6 +35,7 @@ import org.antlr.v4.runtime.CommonTokenStream;
 import org.antlr.v4.runtime.RecognitionException;
 import org.antlr.v4.runtime.Recognizer;
 
+@SuppressFBWarnings("UUF_UNUSED_FIELD")
 public final class SchemaParser {
 
   private final TypeRegistry typeRegistry;

--- a/ksql-parser/src/main/java/io/confluent/ksql/schema/ksql/SqlTypeParser.java
+++ b/ksql-parser/src/main/java/io/confluent/ksql/schema/ksql/SqlTypeParser.java
@@ -15,6 +15,7 @@
 
 package io.confluent.ksql.schema.ksql;
 
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import io.confluent.ksql.execution.expression.tree.Type;
 import io.confluent.ksql.metastore.TypeRegistry;
 import io.confluent.ksql.parser.CaseInsensitiveStream;
@@ -36,6 +37,7 @@ import org.antlr.v4.runtime.CharStreams;
 import org.antlr.v4.runtime.CommonTokenStream;
 import org.antlr.v4.runtime.atn.PredictionMode;
 
+@SuppressFBWarnings("UUF_UNUSED_FIELD")
 public final class SqlTypeParser {
 
   private final TypeRegistry typeRegistry;

--- a/ksql-parser/src/main/java/io/confluent/ksql/util/ParserUtil.java
+++ b/ksql-parser/src/main/java/io/confluent/ksql/util/ParserUtil.java
@@ -18,6 +18,7 @@ package io.confluent.ksql.util;
 import static io.confluent.ksql.parser.SqlBaseParser.DecimalLiteralContext;
 import static java.util.Objects.requireNonNull;
 
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import io.confluent.ksql.execution.expression.tree.DoubleLiteral;
 import io.confluent.ksql.execution.expression.tree.IntegerLiteral;
 import io.confluent.ksql.execution.expression.tree.Literal;
@@ -36,6 +37,7 @@ import org.antlr.v4.runtime.ParserRuleContext;
 import org.antlr.v4.runtime.Token;
 import org.antlr.v4.runtime.tree.TerminalNode;
 
+@SuppressFBWarnings("UUF_UNUSED_FIELD")
 public final class ParserUtil {
 
   /**

--- a/ksql-parser/src/test/java/io/confluent/ksql/parser/AstBuilderTest.java
+++ b/ksql-parser/src/test/java/io/confluent/ksql/parser/AstBuilderTest.java
@@ -24,6 +24,7 @@ import static org.hamcrest.Matchers.is;
 import static org.mockito.Mockito.mock;
 
 import com.google.common.collect.ImmutableList;
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import io.confluent.ksql.execution.expression.tree.ColumnReferenceExp;
 import io.confluent.ksql.function.FunctionRegistry;
 import io.confluent.ksql.metastore.MetaStore;
@@ -50,6 +51,7 @@ import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ExpectedException;
 
+@SuppressFBWarnings("UUF_UNUSED_FIELD")
 public class AstBuilderTest {
 
   private static final MetaStore META_STORE = MetaStoreFixture
@@ -62,6 +64,7 @@ public class AstBuilderTest {
 
   private AstBuilder builder;
 
+  @SuppressFBWarnings("URF_UNREAD_FIELD")
   @Before
   public void setup() {
     builder = new AstBuilder(META_STORE);


### PR DESCRIPTION
### Description 
Build on Windows box using WSL.

See #4084.

Run `mvn clean package -DskipTests`
```
[INFO] Total bugs: 7
[ERROR] Unused field: io.confluent.ksql.parser.AstBuilder.typeRegistry [io.confluent.ksql.parser.AstBuilder] In AstBuilder.java UUF_UNUSED_FIELD
[ERROR] Unused field: io.confluent.ksql.parser.AstBuilder$SourceAccumulator.sources [io.confluent.ksql.parser.AstBuilder$SourceAccumulator] In AstBuilder.java UUF_UNUSED_FIELD
[ERROR] Unused field: io.confluent.ksql.parser.AstBuilder$Visitor.buildingPersistentQuery [io.confluent.ksql.parser.AstBuilder$Visitor] In AstBuilder.java UUF_UNUSED_FIELD
[ERROR] Unused field: io.confluent.ksql.parser.AstBuilder$Visitor.sources [io.confluent.ksql.parser.AstBuilder$Visitor] In AstBuilder.java UUF_UNUSED_FIELD
[ERROR] Unused field: io.confluent.ksql.parser.AstBuilder$Visitor.typeParser [io.confluent.ksql.parser.AstBuilder$Visitor] In AstBuilder.java UUF_UNUSED_FIELD
[ERROR] Unused field: io.confluent.ksql.parser.KsqlParser$ParsedStatement.statement [io.confluent.ksql.parser.KsqlParser$ParsedStatement] In KsqlParser.java UUF_UNUSED_FIELD
[ERROR] Unused field: io.confluent.ksql.parser.KsqlParser$ParsedStatement.statementText [io.confluent.ksql.parser.KsqlParser$ParsedStatement] In KsqlParser.java UUF_UNUSED_FIELD
[INFO] 


To see bug detail using the Spotbugs GUI, use the following command "mvn spotbugs:gui"



[INFO] ------------------------------------------------------------------------
[INFO] Reactor Summary for ksql-parent 5.5.0-SNAPSHOT:
[INFO] 
[INFO] ksql-parent ........................................ SUCCESS [  3.727 s]
[INFO] ksql-test-util ..................................... SUCCESS [  9.127 s]
[INFO] ksql-udf ........................................... SUCCESS [  2.966 s]
[INFO] ksql-common ........................................ SUCCESS [ 13.133 s]
[INFO] KSQL UDF / UDAF :: Quickstart ...................... SUCCESS [  3.211 s]
[INFO] ksql-serde ......................................... SUCCESS [  7.021 s]
[INFO] ksql-rest-model .................................... SUCCESS [  6.993 s]
[INFO] ksql-execution ..................................... SUCCESS [ 10.030 s]
[INFO] ksql-metastore ..................................... SUCCESS [  4.867 s]
[INFO] ksql-parser ........................................ FAILURE [ 14.757 s]
[INFO] ksql-streams ....................................... SKIPPED
```

### Testing done 
After applying the patch the build is ok.

### Reviewer checklist
- [ ] Ensure docs are updated if necessary. (eg. if a user visible feature is being added or changed).
- [X] Ensure relevant issues are linked (description should include text like "Fixes #<issue number>")

