### PR TITLE
chore: fix deprecated warnings in pom

### DIFF
--- a/ksql-udf-quickstart/src/main/resources/archetype-resources/pom.xml
+++ b/ksql-udf-quickstart/src/main/resources/archetype-resources/pom.xml
@@ -19,9 +19,9 @@
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
 
-    <groupId>${groupId}</groupId>
-    <artifactId>${artifactId}</artifactId>
-    <version>${version}</version>
+    <groupId>${project.groupId}</groupId>
+    <artifactId>${project.artifactId}</artifactId>
+    <version>${project.version}</version>
     <packaging>jar</packaging>
 
     <name>KSQL UDF / UDAF Quickstart</name>


### PR DESCRIPTION
### Description 
During my journey on building the project on Windows (see #4084), I noticed a few deprecated warnings in ksql-udf-quickstart pom. I hope I am not too much pedantic.

### Testing done 
The build is ok.

### Reviewer checklist
- [ ] Ensure docs are updated if necessary. (eg. if a user visible feature is being added or changed).
- [ ] Ensure relevant issues are linked (description should include text like "Fixes #<issue number>")
