### PR TITLE
chore: fix infering arguments for transformValues

### DIFF
--- a/ksql-streams/src/main/java/io/confluent/ksql/execution/streams/StreamSelectBuilder.java
+++ b/ksql-streams/src/main/java/io/confluent/ksql/execution/streams/StreamSelectBuilder.java
@@ -15,6 +15,7 @@
 
 package io.confluent.ksql.execution.streams;
 
+import io.confluent.ksql.GenericRow;
 import io.confluent.ksql.execution.builder.KsqlQueryBuilder;
 import io.confluent.ksql.execution.context.QueryContext;
 import io.confluent.ksql.execution.context.QueryLoggerUtil;
@@ -61,7 +62,7 @@ public final class StreamSelectBuilder {
 
     return stream.withStream(
         stream.getStream().transformValues(
-            () -> new KsTransformer<>(selectMapper.getTransformer(logger)),
+            () -> new KsTransformer<K, GenericRow>(selectMapper.getTransformer(logger)),
             selectName
         ),
         selection.getSchema()

--- a/ksql-streams/src/main/java/io/confluent/ksql/execution/streams/TableFilterBuilder.java
+++ b/ksql-streams/src/main/java/io/confluent/ksql/execution/streams/TableFilterBuilder.java
@@ -70,7 +70,7 @@ public final class TableFilterBuilder {
     final Stacker stacker = Stacker.of(step.getProperties().getQueryContext());
     final KTable<K, GenericRow> filtered = table.getTable()
         .transformValues(
-            () -> new KsTransformer<>(predicate.getTransformer(processingLogger)),
+            () -> new KsTransformer<K, Optional<GenericRow>>(predicate.getTransformer(processingLogger)),
             Named.as(StreamsUtil.buildOpName(stacker.push(PRE_PROCESS_OP).getQueryContext()))
         )
         .filter(
@@ -93,5 +93,5 @@ public final class TableFilterBuilder {
                 step.getProperties().getQueryContext()
             ))
         );
-  }
+    }
 }


### PR DESCRIPTION
### Description 
I am sorry if I am a bit pedantic, but VSCode highlighted these problems infering type arguments for transformValues.

```
The method transformValues(ValueTransformerSupplier<? super GenericRow,? extends Object>, Named, String[]) is ambiguous for the type KStream<K,GenericRow>
Cannot infer type arguments for KsTransformer<>

Cannot infer type argument(s) for <VR> transformValues(ValueTransformerWithKeySupplier<? super K,? super V,? extends VR>, Named, String[])
```

### Testing done 
The build is ok.

### Reviewer checklist
- [ ] Ensure docs are updated if necessary. (eg. if a user visible feature is being added or changed).
- [ ] Ensure relevant issues are linked (description should include text like "Fixes #<issue number>")

