### PR TITLE
chore: use UsePartitionTimeOnInvalidTimestamp instead of UsePreviousTimeOnInvalidTimeStamp

### DIFF
--- a/ksql-streams/src/test/java/io/confluent/ksql/execution/streams/timestamp/MetadataTimestampExtractionPolicyTest.java
+++ b/ksql-streams/src/test/java/io/confluent/ksql/execution/streams/timestamp/MetadataTimestampExtractionPolicyTest.java
@@ -16,7 +16,7 @@
 package io.confluent.ksql.execution.streams.timestamp;
 
 import com.google.common.testing.EqualsTester;
-import org.apache.kafka.streams.processor.UsePreviousTimeOnInvalidTimestamp;
+import org.apache.kafka.streams.processor.UsePartitionTimeOnInvalidTimestamp;
 import org.junit.Test;
 
 public class MetadataTimestampExtractionPolicyTest {
@@ -27,8 +27,8 @@ public class MetadataTimestampExtractionPolicyTest {
             new MetadataTimestampExtractionPolicy(),
             new MetadataTimestampExtractionPolicy())
         .addEqualityGroup(
-            new MetadataTimestampExtractionPolicy(new UsePreviousTimeOnInvalidTimestamp()),
-            new MetadataTimestampExtractionPolicy(new UsePreviousTimeOnInvalidTimestamp())
+            new MetadataTimestampExtractionPolicy(new UsePartitionTimeOnInvalidTimestamp()),
+            new MetadataTimestampExtractionPolicy(new UsePartitionTimeOnInvalidTimestamp())
         )
         .testEquals();
   }

--- a/ksql-streams/src/test/java/io/confluent/ksql/execution/streams/timestamp/TimestampExtractionPolicyFactoryTest.java
+++ b/ksql-streams/src/test/java/io/confluent/ksql/execution/streams/timestamp/TimestampExtractionPolicyFactoryTest.java
@@ -31,7 +31,7 @@ import java.util.Collections;
 import java.util.Optional;
 import org.apache.kafka.streams.StreamsConfig;
 import org.apache.kafka.streams.processor.FailOnInvalidTimestamp;
-import org.apache.kafka.streams.processor.UsePreviousTimeOnInvalidTimestamp;
+import org.apache.kafka.streams.processor.UsePartitionTimeOnInvalidTimestamp;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
@@ -105,11 +105,11 @@ public class TimestampExtractionPolicyFactoryTest {
   }
 
   @Test
-  public void shouldCreateMetadataPolicyWithConfiguredUsePreviousTimeOnInvalidTimestamp() {
+  public void shouldCreateMetadataPolicyWithConfiguredUsePartitionTimeOnInvalidTimestamp() {
     // Given:
     final KsqlConfig ksqlConfig = new KsqlConfig(ImmutableMap.of(
         StreamsConfig.DEFAULT_TIMESTAMP_EXTRACTOR_CLASS_CONFIG,
-        UsePreviousTimeOnInvalidTimestamp.class
+        UsePartitionTimeOnInvalidTimestamp.class
     ));
 
     // When:
@@ -122,7 +122,7 @@ public class TimestampExtractionPolicyFactoryTest {
 
     // Then:
     assertThat(result, instanceOf(MetadataTimestampExtractionPolicy.class));
-    assertThat(result.create(0), instanceOf(UsePreviousTimeOnInvalidTimestamp.class));
+    assertThat(result.create(0), instanceOf(UsePartitionTimeOnInvalidTimestamp.class));
   }
 
   @Test


### PR DESCRIPTION
### Description 
UsePreviousTimeOnInvalidTimeStamp is deprecated now. The alternative is UsePartitionTimeOnInvalidTimestamp

### Testing done 
mvn clean install
### Reviewer checklist
- [ ] Ensure docs are updated if necessary. (eg. if a user visible feature is being added or changed).
- [ ] Ensure relevant issues are linked (description should include text like "Fixes #<issue number>")

