### PR TITLE
test: enhance test framework to support primitive keys

### DIFF
--- a/ksql-functional-tests/src/main/java/io/confluent/ksql/test/model/RecordNode.java
+++ b/ksql-functional-tests/src/main/java/io/confluent/ksql/test/model/RecordNode.java
@@ -23,7 +23,8 @@ import com.fasterxml.jackson.databind.JsonDeserializer;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
-import io.confluent.ksql.test.serde.string.StringSerdeSupplier;
+import com.fasterxml.jackson.databind.node.NullNode;
+import com.fasterxml.jackson.databind.node.TextNode;
 import io.confluent.ksql.test.tools.Record;
 import io.confluent.ksql.test.tools.Topic;
 import io.confluent.ksql.test.tools.exceptions.InvalidFieldException;
@@ -69,7 +70,7 @@ public final class RecordNode {
   public Record build(final Map<String, Topic> topics) {
     final Topic topic = topics.get(topicName);
 
-    final Object recordValue = buildValue(topic);
+    final Object recordValue = buildValue();
 
     return new Record(
         topic,
@@ -85,12 +86,12 @@ public final class RecordNode {
     return window;
   }
 
-  private Object buildValue(final Topic topic) {
-    if (value.asText().equals("null")) {
+  private Object buildValue() {
+    if (value instanceof NullNode) {
       return null;
     }
 
-    if (topic.getValueSerdeSupplier() instanceof StringSerdeSupplier) {
+    if (value instanceof TextNode) {
       return value.asText();
     }
 

--- a/ksql-functional-tests/src/main/java/io/confluent/ksql/test/model/TopicNode.java
+++ b/ksql-functional-tests/src/main/java/io/confluent/ksql/test/model/TopicNode.java
@@ -27,14 +27,9 @@ import io.confluent.ksql.schema.ksql.LogicalSchema;
 import io.confluent.ksql.schema.ksql.LogicalSchema.Builder;
 import io.confluent.ksql.schema.ksql.SchemaConverters;
 import io.confluent.ksql.schema.ksql.types.SqlStruct;
-import io.confluent.ksql.serde.Format;
-import io.confluent.ksql.serde.FormatInfo;
-import io.confluent.ksql.serde.KeyFormat;
 import io.confluent.ksql.test.TestFrameworkException;
-import io.confluent.ksql.test.serde.SerdeSupplier;
 import io.confluent.ksql.test.tools.Topic;
 import io.confluent.ksql.test.tools.exceptions.InvalidFieldException;
-import io.confluent.ksql.test.utils.SerdeUtil;
 import java.util.Optional;
 import org.apache.avro.Schema;
 
@@ -68,28 +63,8 @@ public final class TopicNode {
     }
   }
 
-  public Topic build(final Optional<String> defaultFormat) {
-    final String formatToUse = format
-        .replace("{FORMAT}", defaultFormat.orElse(FORMAT_REPLACE_ERROR));
-
-    final SerdeSupplier<?> keySerdeSupplier = SerdeUtil.getKeySerdeSupplier(
-        KeyFormat.nonWindowed(FormatInfo.of(Format.KAFKA)),
-        LogicalSchema.builder()::build // Assume default STRING key for now.
-    );
-
-    final SerdeSupplier<?> valueSerdeSupplier = SerdeUtil.getSerdeSupplier(
-        Format.of(formatToUse),
-        this::logicalSchema
-    );
-
-    return new Topic(
-        name,
-        avroSchema,
-        keySerdeSupplier,
-        valueSerdeSupplier,
-        numPartitions,
-        replicas
-    );
+  public Topic build() {
+    return new Topic(name, numPartitions, replicas, avroSchema);
   }
 
   private LogicalSchema logicalSchema() {

--- a/ksql-functional-tests/src/main/java/io/confluent/ksql/test/serde/json/ValueSpecJsonSerdeSupplier.java
+++ b/ksql-functional-tests/src/main/java/io/confluent/ksql/test/serde/json/ValueSpecJsonSerdeSupplier.java
@@ -24,6 +24,7 @@ import com.fasterxml.jackson.databind.node.ObjectNode;
 import com.google.common.collect.ImmutableList;
 import io.confluent.kafka.schemaregistry.client.SchemaRegistryClient;
 import io.confluent.ksql.test.serde.SerdeSupplier;
+import java.math.BigDecimal;
 import java.util.Collection;
 import java.util.List;
 import java.util.Map;
@@ -101,6 +102,7 @@ public class ValueSpecJsonSerdeSupplier implements SerdeSupplier<Object> {
         Converter.converter(Long.class, JsonNodeFactory.instance::numberNode),
         Converter.converter(Float.class, JsonNodeFactory.instance::numberNode),
         Converter.converter(Double.class, JsonNodeFactory.instance::numberNode),
+        Converter.converter(BigDecimal.class, JsonNodeFactory.instance::numberNode),
         Converter.converter(String.class, JsonNodeFactory.instance::textNode),
         Converter.converter(Collection.class, Converter::handleCollection),
         Converter.converter(Map.class, Converter::handleMap)

--- a/ksql-functional-tests/src/main/java/io/confluent/ksql/test/tools/Record.java
+++ b/ksql-functional-tests/src/main/java/io/confluent/ksql/test/tools/Record.java
@@ -19,13 +19,6 @@ import com.fasterxml.jackson.databind.JsonNode;
 import io.confluent.ksql.test.model.WindowData;
 import java.util.Objects;
 import java.util.Optional;
-import org.apache.kafka.common.serialization.Deserializer;
-import org.apache.kafka.common.serialization.Serdes;
-import org.apache.kafka.common.serialization.Serializer;
-import org.apache.kafka.streams.kstream.SessionWindowedDeserializer;
-import org.apache.kafka.streams.kstream.SessionWindowedSerializer;
-import org.apache.kafka.streams.kstream.TimeWindowedDeserializer;
-import org.apache.kafka.streams.kstream.TimeWindowedSerializer;
 import org.apache.kafka.streams.kstream.Window;
 import org.apache.kafka.streams.kstream.Windowed;
 import org.apache.kafka.streams.kstream.internals.SessionWindow;
@@ -33,23 +26,12 @@ import org.apache.kafka.streams.kstream.internals.TimeWindow;
 
 public class Record {
 
-  final Topic topic;
+  private final Topic topic;
   private final Object key;
   private final Object value;
   private final Optional<Long> timestamp;
   private final WindowData window;
   private final Optional<JsonNode> jsonValue;
-
-  public Record(
-      final Topic topic,
-      final Object key,
-      final Object value,
-      final JsonNode jsonValue,
-      final long timestamp,
-      final WindowData window
-  ) {
-    this(topic, key, value, jsonValue, Optional.of(timestamp), window);
-  }
 
   public Record(
       final Topic topic,
@@ -67,27 +49,8 @@ public class Record {
     this.window = window;
   }
 
-  Serializer<?> keySerializer() {
-    final Serializer<String> stringDe = Serdes.String().serializer();
-    if (window == null) {
-      return stringDe;
-    }
-
-    return window.type == WindowData.Type.SESSION
-        ? new SessionWindowedSerializer<>(stringDe)
-        : new TimeWindowedSerializer<>(stringDe);
-  }
-
-  @SuppressWarnings("rawtypes")
-  Deserializer keyDeserializer() {
-    if (window == null) {
-      return Serdes.String().deserializer();
-    }
-
-    final Deserializer<String> inner = Serdes.String().deserializer();
-    return window.type == WindowData.Type.SESSION
-        ? new SessionWindowedDeserializer<>(inner)
-        : new TimeWindowedDeserializer<>(inner, window.size());
+  public Topic getTopic() {
+    return topic;
   }
 
   public Object rawKey() {

--- a/ksql-functional-tests/src/main/java/io/confluent/ksql/test/tools/TestCaseBuilder.java
+++ b/ksql-functional-tests/src/main/java/io/confluent/ksql/test/tools/TestCaseBuilder.java
@@ -81,7 +81,6 @@ public final class TestCaseBuilder {
           test.topics(),
           test.outputs(),
           test.inputs(),
-          explicitFormat,
           ee.isPresent(),
           functionRegistry
       );

--- a/ksql-functional-tests/src/main/java/io/confluent/ksql/test/tools/TestCaseBuilderUtil.java
+++ b/ksql-functional-tests/src/main/java/io/confluent/ksql/test/tools/TestCaseBuilderUtil.java
@@ -23,32 +23,22 @@ import io.confluent.connect.avro.AvroData;
 import io.confluent.ksql.execution.ddl.commands.KsqlTopic;
 import io.confluent.ksql.function.FunctionRegistry;
 import io.confluent.ksql.metastore.MetaStoreImpl;
-import io.confluent.ksql.model.WindowType;
 import io.confluent.ksql.parser.DefaultKsqlParser;
 import io.confluent.ksql.parser.KsqlParser;
 import io.confluent.ksql.parser.KsqlParser.ParsedStatement;
 import io.confluent.ksql.parser.KsqlParser.PreparedStatement;
 import io.confluent.ksql.parser.SqlBaseParser;
 import io.confluent.ksql.parser.tree.CreateSource;
-import io.confluent.ksql.schema.ksql.LogicalSchema;
 import io.confluent.ksql.schema.ksql.SchemaConverters;
 import io.confluent.ksql.serde.Format;
-import io.confluent.ksql.serde.FormatInfo;
-import io.confluent.ksql.serde.KeyFormat;
 import io.confluent.ksql.serde.ValueFormat;
-import io.confluent.ksql.serde.WindowInfo;
 import io.confluent.ksql.test.model.RecordNode;
 import io.confluent.ksql.test.model.TopicNode;
-import io.confluent.ksql.test.model.WindowData;
-import io.confluent.ksql.test.model.WindowData.Type;
-import io.confluent.ksql.test.serde.SerdeSupplier;
 import io.confluent.ksql.test.tools.exceptions.InvalidFieldException;
-import io.confluent.ksql.test.utils.SerdeUtil;
 import io.confluent.ksql.topic.TopicFactory;
 import io.confluent.ksql.util.DecimalUtil;
 import io.confluent.ksql.util.KsqlConstants;
 import java.nio.file.Path;
-import java.time.Duration;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -57,7 +47,6 @@ import java.util.Optional;
 import java.util.UUID;
 import java.util.function.Function;
 import java.util.function.Predicate;
-import java.util.function.Supplier;
 import java.util.stream.Collectors;
 import org.apache.kafka.connect.data.Field;
 import org.apache.kafka.connect.data.Schema;
@@ -105,7 +94,6 @@ public final class TestCaseBuilderUtil {
       final List<TopicNode> topics,
       final List<RecordNode> outputs,
       final List<RecordNode> inputs,
-      final Optional<String> defaultFormat,
       final boolean expectsException,
       final FunctionRegistry functionRegistry
   ) {
@@ -113,7 +101,7 @@ public final class TestCaseBuilderUtil {
 
     // Add all topics from topic nodes to the map:
     topics.stream()
-        .map(node -> node.build(defaultFormat))
+        .map(TopicNode::build)
         .forEach(topic -> allTopics.put(topic.getName(), topic));
 
     // Infer topics if not added already:
@@ -129,19 +117,9 @@ public final class TestCaseBuilderUtil {
       throw new InvalidFieldException("statements/topics", "The test does not define any topics");
     }
 
-    final SerdeSupplier<?> defaultValueSerdeSupplier =
-        allTopics.values().iterator().next().getValueSerdeSupplier();
-
     // Get topics from inputs and outputs fields:
     Streams.concat(inputs.stream(), outputs.stream())
-        .map(recordNode -> new Topic(
-            recordNode.topicName(),
-            Optional.empty(),
-            getKeySerdeSupplier(recordNode.getWindow()),
-            defaultValueSerdeSupplier,
-            4,
-            1
-        ))
+        .map(recordNode -> new Topic(recordNode.topicName(), 4, 1, Optional.empty()))
         .forEach(topic -> allTopics.putIfAbsent(topic.getName(), topic));
 
     return allTopics;
@@ -163,14 +141,6 @@ public final class TestCaseBuilderUtil {
 
       final KsqlTopic ksqlTopic = TopicFactory.create(statement.getProperties());
 
-      final KeyFormat keyFormat = ksqlTopic.getKeyFormat();
-
-      final Supplier<LogicalSchema> logicalSchemaSupplier =
-          () -> statement.getElements().toLogicalSchema(true);
-
-      final SerdeSupplier<?> keySerdeSupplier =
-          SerdeUtil.getKeySerdeSupplier(keyFormat, logicalSchemaSupplier);
-
       final ValueFormat valueFormat = ksqlTopic.getValueFormat();
       final Optional<org.apache.avro.Schema> avroSchema;
       if (valueFormat.getFormat() == Format.AVRO) {
@@ -186,18 +156,11 @@ public final class TestCaseBuilderUtil {
         avroSchema = Optional.empty();
       }
 
-      final SerdeSupplier<?> valueSerdeSupplier = SerdeUtil.getSerdeSupplier(
-          valueFormat.getFormat(),
-          logicalSchemaSupplier
-      );
-
       return new Topic(
           ksqlTopic.getKafkaTopicName(),
-          avroSchema,
-          keySerdeSupplier,
-          valueSerdeSupplier,
           KsqlConstants.legacyDefaultSinkPartitionCount,
-          KsqlConstants.legacyDefaultSinkReplicaCount
+          KsqlConstants.legacyDefaultSinkReplicaCount,
+          avroSchema
       );
     };
 
@@ -220,30 +183,6 @@ public final class TestCaseBuilderUtil {
       e.printStackTrace(System.out);
       return null;
     }
-  }
-
-  private static SerdeSupplier<?> getKeySerdeSupplier(final Optional<WindowData> windowDataInfo) {
-    if (windowDataInfo.isPresent()) {
-      final WindowData windowData = windowDataInfo.get();
-      final WindowType windowType = WindowType.of((windowData.type == Type.SESSION)
-          ? WindowType.SESSION.name()
-          : WindowType.TUMBLING.name());
-      final KeyFormat windowKeyFormat = KeyFormat.windowed(
-          FormatInfo.of(
-            Format.KAFKA,
-            Optional.empty(),
-            Optional.empty()
-          ),
-          WindowInfo.of(
-              windowType,
-              windowType == WindowType.SESSION
-                  ? Optional.empty() : Optional.of(Duration.ofMillis(windowData.size())))
-      );
-      return SerdeUtil.getKeySerdeSupplier(windowKeyFormat, () -> LogicalSchema.builder().build());
-    }
-    return SerdeUtil.getKeySerdeSupplier(
-        KeyFormat.nonWindowed(FormatInfo.of(Format.KAFKA)),
-        () -> LogicalSchema.builder().build());
   }
 
   private static Schema addNames(final Schema schema) {

--- a/ksql-functional-tests/src/main/java/io/confluent/ksql/test/tools/Topic.java
+++ b/ksql-functional-tests/src/main/java/io/confluent/ksql/test/tools/Topic.java
@@ -17,37 +17,24 @@ package io.confluent.ksql.test.tools;
 
 import static java.util.Objects.requireNonNull;
 
-import com.google.common.collect.ImmutableMap;
-import io.confluent.kafka.schemaregistry.client.SchemaRegistryClient;
-import io.confluent.kafka.serializers.KafkaAvroSerializerConfig;
-import io.confluent.ksql.test.serde.SerdeSupplier;
 import java.util.Optional;
 import org.apache.avro.Schema;
-import org.apache.kafka.common.serialization.Deserializer;
-import org.apache.kafka.common.serialization.Serializer;
 
-@SuppressWarnings("rawtypes")
 public class Topic {
 
   private final String name;
-  private final Optional<Schema> schema;
-  private final SerdeSupplier keySerdeFactory;
-  private final SerdeSupplier valueSerdeSupplier;
   private final int numPartitions;
   private final short replicas;
+  private final Optional<Schema> avroSchema;
 
   public Topic(
       final String name,
-      final Optional<Schema> schema,
-      final SerdeSupplier keySerdeFactory,
-      final SerdeSupplier valueSerdeSupplier,
       final int numPartitions,
-      final int replicas
+      final int replicas,
+      final Optional<Schema> avroSchema
   ) {
     this.name = requireNonNull(name, "name");
-    this.schema = requireNonNull(schema, "schema");
-    this.keySerdeFactory = requireNonNull(keySerdeFactory, "keySerdeFactory");
-    this.valueSerdeSupplier = requireNonNull(valueSerdeSupplier, "valueSerdeSupplier");
+    this.avroSchema = requireNonNull(avroSchema, "schema");
     this.numPartitions = numPartitions;
     this.replicas = (short) replicas;
   }
@@ -56,8 +43,8 @@ public class Topic {
     return name;
   }
 
-  public Optional<Schema> getSchema() {
-    return schema;
+  public Optional<Schema> getAvroSchema() {
+    return avroSchema;
   }
 
   public int getNumPartitions() {
@@ -66,39 +53,5 @@ public class Topic {
 
   public short getReplicas() {
     return replicas;
-  }
-
-  public SerdeSupplier getValueSerdeSupplier() {
-    return valueSerdeSupplier;
-  }
-
-  public Serializer getValueSerializer(final SchemaRegistryClient schemaRegistryClient) {
-    final Serializer<?> serializer = valueSerdeSupplier.getSerializer(schemaRegistryClient);
-    serializer.configure(ImmutableMap.of(
-        KafkaAvroSerializerConfig.SCHEMA_REGISTRY_URL_CONFIG, "something"
-    ), false);
-    return serializer;
-  }
-
-  public Deserializer getValueDeserializer(final SchemaRegistryClient schemaRegistryClient) {
-    final Deserializer<?> deserializer = valueSerdeSupplier.getDeserializer(schemaRegistryClient);
-    deserializer.configure(ImmutableMap.of(
-        KafkaAvroSerializerConfig.SCHEMA_REGISTRY_URL_CONFIG, "foo"
-    ), false);
-    return deserializer;
-  }
-
-  public Serializer getKeySerializer(final SchemaRegistryClient schemaRegistryClient) {
-    final Serializer<?> serializer = keySerdeFactory.getSerializer(schemaRegistryClient);
-    serializer.configure(ImmutableMap.of(
-        KafkaAvroSerializerConfig.SCHEMA_REGISTRY_URL_CONFIG, "something"
-    ), true);
-    return serializer;
-  }
-
-  public Deserializer<?> getKeyDeserializer(final SchemaRegistryClient schemaRegistryClient) {
-    final Deserializer<?> deserializer = keySerdeFactory.getDeserializer(schemaRegistryClient);
-    deserializer.configure(ImmutableMap.of(), true);
-    return deserializer;
   }
 }

--- a/ksql-functional-tests/src/main/java/io/confluent/ksql/test/tools/TopicInfoCache.java
+++ b/ksql-functional-tests/src/main/java/io/confluent/ksql/test/tools/TopicInfoCache.java
@@ -1,0 +1,272 @@
+/*
+ * Copyright 2019 Confluent Inc.
+ *
+ * Licensed under the Confluent Community License (the "License"); you may not use
+ * this file except in compliance with the License.  You may obtain a copy of the
+ * License at
+ *
+ * http://www.confluent.io/confluent-community-license
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package io.confluent.ksql.test.tools;
+
+import static java.util.Objects.requireNonNull;
+
+import com.google.common.cache.CacheBuilder;
+import com.google.common.cache.CacheLoader;
+import com.google.common.cache.LoadingCache;
+import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.Iterables;
+import io.confluent.kafka.schemaregistry.client.SchemaRegistryClient;
+import io.confluent.kafka.serializers.KafkaAvroSerializerConfig;
+import io.confluent.ksql.KsqlExecutionContext;
+import io.confluent.ksql.parser.DurationParser;
+import io.confluent.ksql.query.QueryId;
+import io.confluent.ksql.schema.ksql.DefaultSqlValueCoercer;
+import io.confluent.ksql.schema.ksql.LogicalSchema;
+import io.confluent.ksql.schema.ksql.SchemaConverters;
+import io.confluent.ksql.schema.ksql.types.SqlType;
+import io.confluent.ksql.serde.KeyFormat;
+import io.confluent.ksql.serde.ValueFormat;
+import io.confluent.ksql.test.TestFrameworkException;
+import io.confluent.ksql.test.serde.SerdeSupplier;
+import io.confluent.ksql.test.utils.SerdeUtil;
+import io.confluent.ksql.util.PersistentQueryMetadata;
+import java.util.OptionalLong;
+import java.util.Set;
+import java.util.function.Function;
+import java.util.regex.Pattern;
+import java.util.stream.Collectors;
+import org.apache.kafka.common.serialization.Deserializer;
+import org.apache.kafka.common.serialization.Serializer;
+import org.apache.kafka.streams.kstream.TimeWindowedDeserializer;
+
+/**
+ * Cache of info known about topics in use in the test.
+ */
+public class TopicInfoCache {
+
+  private static final Pattern INTERNAL_TOPIC_PATTERN = Pattern
+      .compile("_confluent.*query_(.*_\\d+)-.*-(changelog|repartition)");
+
+  private static final Pattern WINDOWED_JOIN_PATTERN = Pattern
+      .compile(
+          "CREATE .* JOIN .* WITHIN (\\d+ \\w+) ON .*",
+          Pattern.CASE_INSENSITIVE | Pattern.DOTALL
+      );
+
+  private final KsqlExecutionContext ksqlEngine;
+  private final SchemaRegistryClient srClient;
+  private final LoadingCache<String, TopicInfo> cache;
+
+  public TopicInfoCache(
+      final KsqlExecutionContext ksqlEngine,
+      final SchemaRegistryClient srClient
+  ) {
+    this.ksqlEngine = requireNonNull(ksqlEngine, "ksqlEngine");
+    this.srClient = requireNonNull(srClient, "srClient");
+    this.cache = CacheBuilder.newBuilder()
+        .build(CacheLoader.from(this::load));
+  }
+
+  public TopicInfo get(final String topicName) {
+    return cache.getUnchecked(topicName);
+  }
+
+  public void clear() {
+    cache.invalidateAll();
+  }
+
+  private TopicInfo load(final String topicName) {
+    try {
+      final java.util.regex.Matcher matcher = INTERNAL_TOPIC_PATTERN.matcher(topicName);
+      if (matcher.matches()) {
+        // Internal topic:
+        final QueryId queryId = new QueryId(matcher.group(1));
+        final PersistentQueryMetadata query = ksqlEngine
+            .getPersistentQuery(queryId)
+            .orElseThrow(() -> new TestFrameworkException("Unknown queryId for internal topic: "
+                + queryId));
+
+        final java.util.regex.Matcher windowedJoinMatcher = WINDOWED_JOIN_PATTERN
+            .matcher(query.getStatementString());
+
+        final OptionalLong changeLogWindowSize = topicName.endsWith("-changelog")
+            && windowedJoinMatcher.matches()
+            ? OptionalLong.of(DurationParser.parse(windowedJoinMatcher.group(1)).toMillis())
+            : OptionalLong.empty();
+
+        return new TopicInfo(
+            topicName,
+            query.getLogicalSchema(),
+            query.getResultTopic().getKeyFormat(),
+            query.getResultTopic().getValueFormat(),
+            changeLogWindowSize
+        );
+      }
+
+      // Source / sink topic:
+      final Set<TopicInfo> keyTypes = ksqlEngine.getMetaStore().getAllDataSources().values()
+          .stream()
+          .filter(source -> source.getKafkaTopicName().equals(topicName))
+          .map(source -> new TopicInfo(
+              topicName,
+              source.getSchema(),
+              source.getKsqlTopic().getKeyFormat(),
+              source.getKsqlTopic().getValueFormat(),
+              OptionalLong.empty()
+          ))
+          .collect(Collectors.toSet());
+
+      if (keyTypes.isEmpty()) {
+        throw new TestFrameworkException("no source found for topic");
+      }
+
+      return Iterables.get(keyTypes, 0);
+    } catch (final Exception e) {
+      throw new TestFrameworkException("Failed to determine key type for"
+          + System.lineSeparator() + "topic: " + topicName
+          + System.lineSeparator() + "reason: " + e.getMessage(), e);
+    }
+  }
+
+  public final class TopicInfo {
+
+    private final String topicName;
+    private final LogicalSchema schema;
+    private final KeyFormat keyFormat;
+    private final ValueFormat valueFormat;
+    private final OptionalLong changeLogWindowSize;
+
+    private TopicInfo(
+        final String topicName,
+        final LogicalSchema schema,
+        final KeyFormat keyFormat,
+        final ValueFormat valueFormat,
+        final OptionalLong changeLogWindowSize
+    ) {
+      this.topicName = requireNonNull(topicName, "topicName");
+      this.schema = requireNonNull(schema, "schema");
+      this.keyFormat = requireNonNull(keyFormat, "keyFormat");
+      this.valueFormat = requireNonNull(valueFormat, "valueFormat");
+      this.changeLogWindowSize = requireNonNull(changeLogWindowSize, "changeLogWindowSize");
+    }
+
+    @SuppressWarnings({"unchecked", "rawtypes"})
+    public Serializer<Object> getKeySerializer() {
+      final SerdeSupplier<?> keySerdeSupplier = SerdeUtil
+          .getKeySerdeSupplier(keyFormat, schema);
+
+      final Serializer<?> serializer = keySerdeSupplier.getSerializer(srClient);
+
+      serializer.configure(ImmutableMap.of(
+          KafkaAvroSerializerConfig.SCHEMA_REGISTRY_URL_CONFIG, "something"
+      ), true);
+
+      return (Serializer) serializer;
+    }
+
+    @SuppressWarnings({"unchecked", "rawtypes"})
+    public Serializer<Object> getValueSerializer() {
+      final SerdeSupplier<?> valueSerdeSupplier = SerdeUtil
+          .getSerdeSupplier(valueFormat.getFormat(), schema);
+
+      final Serializer<?> serializer = valueSerdeSupplier.getSerializer(srClient);
+
+      serializer.configure(ImmutableMap.of(
+          KafkaAvroSerializerConfig.SCHEMA_REGISTRY_URL_CONFIG, "something"
+      ), false);
+
+      return (Serializer) serializer;
+    }
+
+    public Deserializer<?> getKeyDeserializer() {
+      final SerdeSupplier<?> keySerdeSupplier = SerdeUtil
+          .getKeySerdeSupplier(keyFormat, schema);
+
+      Deserializer<?> deserializer = keySerdeSupplier.getDeserializer(srClient);
+
+      deserializer.configure(ImmutableMap.of(), true);
+
+      if (!changeLogWindowSize.isPresent()) {
+        return deserializer;
+      }
+
+      final TimeWindowedDeserializer<?> changeLogDeserializer =
+          new TimeWindowedDeserializer<>(deserializer, changeLogWindowSize.getAsLong());
+
+      changeLogDeserializer.setIsChangelogTopic(true);
+
+      return changeLogDeserializer;
+    }
+
+    public Deserializer<?> getValueDeserializer() {
+      final SerdeSupplier<?> valueSerdeSupplier = SerdeUtil
+          .getSerdeSupplier(valueFormat.getFormat(), schema);
+
+      Deserializer<?> deserializer = valueSerdeSupplier.getDeserializer(srClient);
+
+      deserializer.configure(ImmutableMap.of(), false);
+
+      return deserializer;
+    }
+
+    /**
+     * Coerce the key value to the correct type.
+     *
+     * <p>The type of the key loaded from the JSON test case file may not be the exact match on
+     * type, e.g. JSON will load a small number as an integer, but the key type of the source might
+     * be a long.
+     *
+     * @param record the record to coerce
+     * @param msgIndex the index of the message, displayed in the error message
+     * @return a new Record with the correct key type.
+     */
+    public Record coerceRecordKey(
+        final Record record,
+        final int msgIndex
+    ) {
+      try {
+        final Object coerced = keyCoercer().apply(record.rawKey());
+        return record.withKey(coerced);
+      } catch (final Exception e) {
+        throw new AssertionError(
+            "Topic '" + record.getTopic().getName() + "', message " + msgIndex
+                + ": Invalid test-case: could not coerce key in test case to required type. "
+                + e.getMessage(),
+            e);
+      }
+    }
+
+    private Function<Object, Object> keyCoercer() {
+      final SqlType keyType = schema
+          .key()
+          .get(0)
+          .type();
+
+      return key -> {
+        if (key == null) {
+          return null;
+        }
+
+        return DefaultSqlValueCoercer.INSTANCE
+            .coerce(key, keyType)
+            .orElseThrow(() -> new AssertionError("Invalid key value for topic " + topicName + "."
+                + System.lineSeparator()
+                + "Expected KeyType: " + keyType
+                + System.lineSeparator()
+                + "Actual KeyType: " + SchemaConverters.javaToSqlConverter()
+                .toSqlType(key.getClass())
+                + ", key: " + key + "."
+                + System.lineSeparator()
+                + "This is likely caused by the key type in the test-case not matching the schema."
+            ));
+      };
+    }
+  }
+}

--- a/ksql-functional-tests/src/main/java/io/confluent/ksql/test/tools/TopicInfoCache.java
+++ b/ksql-functional-tests/src/main/java/io/confluent/ksql/test/tools/TopicInfoCache.java
@@ -189,7 +189,7 @@ public class TopicInfoCache {
       final SerdeSupplier<?> keySerdeSupplier = SerdeUtil
           .getKeySerdeSupplier(keyFormat, schema);
 
-      Deserializer<?> deserializer = keySerdeSupplier.getDeserializer(srClient);
+      final Deserializer<?> deserializer = keySerdeSupplier.getDeserializer(srClient);
 
       deserializer.configure(ImmutableMap.of(), true);
 
@@ -209,7 +209,7 @@ public class TopicInfoCache {
       final SerdeSupplier<?> valueSerdeSupplier = SerdeUtil
           .getSerdeSupplier(valueFormat.getFormat(), schema);
 
-      Deserializer<?> deserializer = valueSerdeSupplier.getDeserializer(srClient);
+      final Deserializer<?> deserializer = valueSerdeSupplier.getDeserializer(srClient);
 
       deserializer.configure(ImmutableMap.of(), false);
 

--- a/ksql-functional-tests/src/test/java/io/confluent/ksql/engine/StubInsertValuesExecutorTest.java
+++ b/ksql-functional-tests/src/test/java/io/confluent/ksql/engine/StubInsertValuesExecutorTest.java
@@ -23,9 +23,8 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import com.google.common.collect.ImmutableMap;
+import io.confluent.ksql.KsqlExecutionContext;
 import io.confluent.ksql.engine.StubInsertValuesExecutor.StubProducer;
-import io.confluent.ksql.test.serde.avro.AvroSerdeSupplier;
-import io.confluent.ksql.test.serde.string.StringSerdeSupplier;
 import io.confluent.ksql.test.tools.Record;
 import io.confluent.ksql.test.tools.Topic;
 import io.confluent.ksql.test.tools.stubs.StubKafkaRecord;
@@ -49,6 +48,8 @@ public final class StubInsertValuesExecutorTest {
 
   @Mock
   private StubKafkaService stubKafkaService;
+  @Mock
+  private KsqlExecutionContext executionContext;
   @Captor
   private ArgumentCaptor<StubKafkaRecord> recordCaptor;
   private StubProducer stubProducer;
@@ -57,14 +58,12 @@ public final class StubInsertValuesExecutorTest {
   public void setUp() {
     when(stubKafkaService.getTopic(SOME_TOPIC)).thenReturn(new Topic(
         SOME_TOPIC,
-        Optional.empty(),
-        new StringSerdeSupplier(),
-        new StringSerdeSupplier(),
         1,
-        1
+        1,
+        Optional.empty()
     ));
 
-    stubProducer = new StubProducer(stubKafkaService);
+    stubProducer = new StubProducer(stubKafkaService, executionContext);
   }
 
   @Test
@@ -122,11 +121,9 @@ public final class StubInsertValuesExecutorTest {
 
     when(stubKafkaService.getTopic(SOME_TOPIC)).thenReturn(new Topic(
         SOME_TOPIC,
-        Optional.empty(),
-        new StringSerdeSupplier(),
-        new AvroSerdeSupplier(),
         1,
-        1
+        1,
+        Optional.empty()
     ));
 
     final long timestamp = 22L;

--- a/ksql-functional-tests/src/test/java/io/confluent/ksql/test/SchemaTranslationTest.java
+++ b/ksql-functional-tests/src/test/java/io/confluent/ksql/test/SchemaTranslationTest.java
@@ -13,9 +13,6 @@ import com.google.common.collect.ImmutableList;
 import io.confluent.avro.random.generator.Generator;
 import io.confluent.ksql.test.loader.JsonTestLoader;
 import io.confluent.ksql.test.loader.TestFile;
-import io.confluent.ksql.test.serde.avro.AvroSerdeSupplier;
-import io.confluent.ksql.test.serde.avro.ValueSpecAvroSerdeSupplier;
-import io.confluent.ksql.test.serde.string.StringSerdeSupplier;
 import io.confluent.ksql.test.tools.Record;
 import io.confluent.ksql.test.tools.TestCase;
 import io.confluent.ksql.test.tools.Topic;
@@ -49,11 +46,9 @@ public class SchemaTranslationTest {
 
   private static final Topic OUTPUT_TOPIC = new Topic(
       OUTPUT_TOPIC_NAME,
-      Optional.empty(),
-      new StringSerdeSupplier(),
-      new ValueSpecAvroSerdeSupplier(),
       1,
-      1
+      1,
+      Optional.empty()
   );
 
   private final TestCase testCase;
@@ -160,11 +155,9 @@ public class SchemaTranslationTest {
       try {
         final Topic srcTopic = new Topic(
             TOPIC_NAME,
-            Optional.of(schema),
-            new StringSerdeSupplier(),
-            new AvroSerdeSupplier(),
             1,
-            1
+            1,
+            Optional.of(schema)
         );
 
         final List<Record> inputRecords = generateInputRecords(srcTopic, schema);

--- a/ksql-functional-tests/src/test/java/io/confluent/ksql/test/rest/RestQueryTranslationTest.java
+++ b/ksql-functional-tests/src/test/java/io/confluent/ksql/test/rest/RestQueryTranslationTest.java
@@ -122,6 +122,7 @@ public class RestQueryTranslationTest {
 
   private static RestTestExecutor testExecutor() {
     return new RestTestExecutor(
+        REST_APP.getEngine(),
         REST_APP.getListeners().get(0),
         TEST_HARNESS.getKafkaCluster(),
         TEST_HARNESS.getServiceContext()

--- a/ksql-functional-tests/src/test/java/io/confluent/ksql/test/rest/RestTestCaseBuilder.java
+++ b/ksql-functional-tests/src/test/java/io/confluent/ksql/test/rest/RestTestCaseBuilder.java
@@ -81,7 +81,6 @@ final class RestTestCaseBuilder {
           test.topics(),
           test.outputs(),
           test.inputs(),
-          explicitFormat,
           ee.isPresent(),
           functionRegistry
       );

--- a/ksql-functional-tests/src/test/java/io/confluent/ksql/test/tools/RecordTest.java
+++ b/ksql-functional-tests/src/test/java/io/confluent/ksql/test/tools/RecordTest.java
@@ -21,13 +21,6 @@ import static org.hamcrest.MatcherAssert.assertThat;
 
 import io.confluent.ksql.test.model.WindowData;
 import java.util.Optional;
-import org.apache.kafka.common.serialization.Deserializer;
-import org.apache.kafka.common.serialization.Serdes;
-import org.apache.kafka.common.serialization.Serializer;
-import org.apache.kafka.streams.kstream.SessionWindowedDeserializer;
-import org.apache.kafka.streams.kstream.SessionWindowedSerializer;
-import org.apache.kafka.streams.kstream.TimeWindowedDeserializer;
-import org.apache.kafka.streams.kstream.TimeWindowedSerializer;
 import org.apache.kafka.streams.kstream.Windowed;
 import org.apache.kafka.streams.kstream.internals.SessionWindow;
 import org.apache.kafka.streams.kstream.internals.TimeWindow;
@@ -44,117 +37,10 @@ public class RecordTest {
   private Topic topic;
 
   @Test
-  public void shouldGetCorrectStringKeySerializer() {
-    // Given:
-    final Record record = new Record(
-        topic,
-        "foo",
-        "bar",
-        null,
-        Optional.of(1000L),
-        null
-    );
-
-    // When:
-    final Serializer<?> serializer = record.keySerializer();
-
-    // Then:
-    assertThat(serializer, instanceOf(Serdes.String().serializer().getClass()));
-  }
-
-  @Test
-  public void shouldGetCorrectTimeWondowedKeySerializer() {
+  public void shouldGetKey() {
     // Given:
     final Record record = new Record(topic,
-        "foo",
-        "bar",
-        null,
-        Optional.of(1000L),
-        new WindowData(100L, 1000L, "TIME"));
-
-    // When:
-    final Serializer<?> serializer = record.keySerializer();
-
-    // Then:
-    assertThat(serializer, instanceOf(TimeWindowedSerializer.class));
-  }
-
-  @Test
-  public void shouldGetCorrectSessionWindowedKeySerializer() {
-    // Given:
-    final Record record = new Record(topic,
-        "foo",
-        "bar",
-        null,
-        Optional.of(1000L),
-        new WindowData(100L, 1000L, "SESSION"));
-
-    // When:
-    final Serializer<?> serializer = record.keySerializer();
-
-    // Then:
-    assertThat(serializer, instanceOf(SessionWindowedSerializer.class));
-  }
-
-  @Test
-  public void shouldGetCorrectStringKeyDeserializer() {
-    // Given:
-    final Record record = new Record(topic,
-        "foo",
-        "bar",
-        null,
-        Optional.of(1000L),
-        null);
-
-    // When:
-    final Deserializer deserializer = record.keyDeserializer();
-
-    // Then:
-    assertThat(deserializer, instanceOf(Serdes.String().deserializer().getClass()));
-
-  }
-
-  @Test
-  public void shouldGetCorrectTimedWindowKeyDeserializer() {
-    // Given:
-    final Record record = new Record(topic,
-        "foo",
-        "bar",
-        null,
-        Optional.of(1000L),
-        new WindowData(100L, 1000L, "TIME"));
-
-    // When:
-    final Deserializer deserializer = record.keyDeserializer();
-
-    // Then:
-    assertThat(deserializer, instanceOf(TimeWindowedDeserializer.class));
-
-  }
-
-  @Test
-  public void shouldGetCorrectSessionedWindowKeyDeserializer() {
-    // Given:
-    final Record record = new Record(topic,
-        "foo",
-        "bar",
-        null,
-        Optional.of(1000L),
-        new WindowData(100L, 1000L, "SESSION"));
-
-    // When:
-    final Deserializer deserializer = record.keyDeserializer();
-
-    // Then:
-    assertThat(deserializer, instanceOf(SessionWindowedDeserializer.class));
-
-  }
-
-  @Test
-  public void shouldGetStringKey() {
-    // Given:
-    final Record record = new Record(topic,
-        "foo",
+        10,
         "bar",
         null,
         Optional.of(1000L),
@@ -164,9 +50,8 @@ public class RecordTest {
     final Object key = record.key();
 
     // Then:
-    assertThat(key, equalTo("foo"));
+    assertThat(key, equalTo(10));
   }
-
 
   @Test
   public void shouldGetTimeWindowKey() {
@@ -209,5 +94,4 @@ public class RecordTest {
     assertThat(windowed.window().start(), equalTo(100L));
     assertThat(windowed.window().end(), equalTo(1000L));
   }
-
 }

--- a/ksql-functional-tests/src/test/java/io/confluent/ksql/test/tools/StubKafkaServiceTest.java
+++ b/ksql-functional-tests/src/test/java/io/confluent/ksql/test/tools/StubKafkaServiceTest.java
@@ -18,7 +18,6 @@ package io.confluent.ksql.test.tools;
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
 
-import io.confluent.ksql.test.serde.string.StringSerdeSupplier;
 import io.confluent.ksql.test.tools.stubs.StubKafkaRecord;
 import io.confluent.ksql.test.tools.stubs.StubKafkaService;
 import java.util.List;
@@ -50,14 +49,7 @@ public class StubKafkaServiceTest {
   public void setUp() {
     stubKafkaRecord = StubKafkaRecord.of(record, producerRecord);
     stubKafkaService = StubKafkaService.create();
-    topic = new Topic(
-        "foo",
-        Optional.of(avroSchema),
-        new StringSerdeSupplier(),
-        new StringSerdeSupplier(),
-        1,
-        1
-    );
+    topic = new Topic("foo", 1, 1, Optional.of(avroSchema));
   }
 
 

--- a/ksql-functional-tests/src/test/java/io/confluent/ksql/test/tools/TestExecutorTest.java
+++ b/ksql-functional-tests/src/test/java/io/confluent/ksql/test/tools/TestExecutorTest.java
@@ -27,6 +27,7 @@ import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
+import io.confluent.kafka.schemaregistry.client.SchemaRegistryClient;
 import io.confluent.ksql.engine.KsqlEngine;
 import io.confluent.ksql.execution.ddl.commands.KsqlTopic;
 import io.confluent.ksql.metastore.MetaStore;
@@ -38,6 +39,7 @@ import io.confluent.ksql.schema.ksql.types.SqlTypes;
 import io.confluent.ksql.serde.Format;
 import io.confluent.ksql.serde.FormatInfo;
 import io.confluent.ksql.serde.KeyFormat;
+import io.confluent.ksql.serde.ValueFormat;
 import io.confluent.ksql.services.ServiceContext;
 import io.confluent.ksql.test.tools.TestExecutor.TopologyBuilder;
 import io.confluent.ksql.test.tools.conditions.PostConditions;
@@ -98,6 +100,8 @@ public class TestExecutorTest {
   private MetaStore metaStore;
   @Mock
   private Function<TopologyTestDriver, Set<String>> internalTopicsAccessor;
+  @Mock
+  private SchemaRegistryClient srClient;
 
   private TestExecutor executor;
   private final Map<SourceName, DataSource<?>> allSources = new HashMap<>();
@@ -105,6 +109,8 @@ public class TestExecutorTest {
   @Before
   public void setUp() {
     allSources.clear();
+
+    when(serviceContext.getSchemaRegistryClient()).thenReturn(srClient);
 
     executor = new TestExecutor(
         kafkaService,
@@ -351,6 +357,9 @@ public class TestExecutorTest {
     final KsqlTopic topic = mock(KsqlTopic.class);
     when(topic.getKeyFormat())
         .thenReturn(KeyFormat.of(FormatInfo.of(Format.KAFKA), Optional.empty()));
+    when(topic.getValueFormat())
+        .thenReturn(ValueFormat.of(FormatInfo.of(Format.JSON)));
+
     final DataSource<?> dataSource = mock(DataSource.class);
     when(dataSource.getKsqlTopic()).thenReturn(topic);
     when(dataSource.getSchema()).thenReturn(schema);

--- a/ksql-functional-tests/src/test/java/io/confluent/ksql/test/tools/TestExecutorUtilTest.java
+++ b/ksql-functional-tests/src/test/java/io/confluent/ksql/test/tools/TestExecutorUtilTest.java
@@ -27,7 +27,6 @@ import io.confluent.ksql.planner.plan.ConfiguredKsqlPlan;
 import io.confluent.ksql.services.ServiceContext;
 import io.confluent.ksql.test.model.QttTestFile;
 import io.confluent.ksql.test.model.TestCaseNode;
-import io.confluent.ksql.test.serde.string.StringSerdeSupplier;
 import io.confluent.ksql.test.tools.stubs.StubKafkaService;
 import io.confluent.ksql.util.KsqlConfig;
 import java.io.File;
@@ -74,14 +73,7 @@ public class TestExecutorUtilTest {
   @Test
   public void shouldPlanTestCase() {
     // Given:
-    final Topic sourceTopic = new Topic(
-        "test_topic",
-        Optional.empty(),
-        new StringSerdeSupplier(),
-        new StringSerdeSupplier(),
-        1,
-        1
-    );
+    final Topic sourceTopic = new Topic("test_topic", 1, 1, Optional.empty());
 
     stubKafkaService.createTopic(sourceTopic);
 
@@ -113,15 +105,12 @@ public class TestExecutorUtilTest {
 
   @Test
   public void shouldBuildStreamsTopologyTestDrivers() {
-
     // Given:
     final Topic sourceTopic = new Topic(
         "test_topic",
-        Optional.empty(),
-        new StringSerdeSupplier(),
-        new StringSerdeSupplier(),
         1,
-        1
+        1,
+        Optional.empty()
     );
 
     stubKafkaService.createTopic(sourceTopic);

--- a/ksql-functional-tests/src/test/resources/query-validation-tests/serdes.json
+++ b/ksql-functional-tests/src/test/resources/query-validation-tests/serdes.json
@@ -39,8 +39,7 @@
       "topics": [
         {
           "name": "input_topic",
-          "schema": "int",
-          "format": "{FORMAT}"
+          "schema": "int"
         }
       ],
       "inputs": [
@@ -62,8 +61,7 @@
       "topics": [
         {
           "name": "input_topic",
-          "schema": "int",
-          "format": "{FORMAT}"
+          "schema": "int"
         }
       ],
       "inputs": [
@@ -83,8 +81,7 @@
       "topics": [
         {
           "name": "input_topic",
-          "schema": {"name": "ignored", "type": "record", "fields": [{"name": "FOO", "type": "int"}]},
-          "format": "{FORMAT}"
+          "schema": {"name": "ignored", "type": "record", "fields": [{"name": "FOO", "type": "int"}]}
         }
       ],
       "inputs": [
@@ -109,8 +106,7 @@
       "topics": [
         {
           "name": "input_topic",
-          "schema": {"type": "array", "items": ["null", "string"]},
-          "format": "{FORMAT}"
+          "schema": {"type": "array", "items": ["null", "string"]}
         }
       ],
       "inputs": [
@@ -134,8 +130,7 @@
       "topics": [
         {
           "name": "input_topic",
-          "schema": {"type": "array", "items": ["null", "string"]},
-          "format": "{FORMAT}"
+          "schema": {"type": "array", "items": ["null", "string"]}
         }
       ],
       "inputs": [
@@ -155,8 +150,7 @@
       "topics": [
         {
           "name": "input_topic",
-          "schema": {"name": "ignored", "type": "record", "fields": [{"name": "FOO", "type": ["null", {"type":  "array", "items": ["null", "string"]}]}]},
-          "format": "{FORMAT}"
+          "schema": {"name": "ignored", "type": "record", "fields": [{"name": "FOO", "type": ["null", {"type":  "array", "items": ["null", "string"]}]}]}
         }
       ],
       "inputs": [
@@ -202,13 +196,11 @@
       "topics": [
         {
           "name": "input_topic",
-          "schema": {"type": "map", "values": ["null", "int"]},
-          "format": "{FORMAT}"
+          "schema": {"type": "map", "values": ["null", "int"]}
         },
         {
           "name": "OUTPUT",
-          "schema": {"type": "record", "name": "ignored", "fields": [{"name": "FOO", "type": ["null",{"type":"array","items":{"type":"record","name":"test","fields":[{"name":"key","type":["null","string"],"default":null},{"name":"value","type":["null","int"],"default":null}]}}]}]},
-          "format": "{FORMAT}"
+          "schema": {"type": "record", "name": "ignored", "fields": [{"name": "FOO", "type": ["null",{"type":"array","items":{"type":"record","name":"test","fields":[{"name":"key","type":["null","string"],"default":null},{"name":"value","type":["null","int"],"default":null}]}}]}]}
         }
       ],
       "inputs": [
@@ -275,13 +267,11 @@
       "topics": [
         {
           "name": "input_topic",
-          "schema": {"name": "ignored", "type": "record", "fields": [{"name": "FOO", "type": ["null",{"type": "map", "values": ["null", "int"]}]}]},
-          "format": "{FORMAT}"
+          "schema": {"name": "ignored", "type": "record", "fields": [{"name": "FOO", "type": ["null",{"type": "map", "values": ["null", "int"]}]}]}
         },
         {
           "name": "OUTPUT",
-          "schema": {"type": "record", "name": "ignored", "fields": [{"name": "FOO", "type": ["null",{"type":"array","items":{"type":"record","name":"test","fields":[{"name":"key","type":["null","string"],"default":null},{"name":"value","type":["null","int"],"default":null}]}}]}]},
-          "format": "{FORMAT}"
+          "schema": {"type": "record", "name": "ignored", "fields": [{"name": "FOO", "type": ["null",{"type":"array","items":{"type":"record","name":"test","fields":[{"name":"key","type":["null","string"],"default":null},{"name":"value","type":["null","int"],"default":null}]}}]}]}
         }
       ],
       "inputs": [
@@ -396,8 +386,7 @@
       "topics": [
         {
           "name": "OUTPUT",
-          "schema": "boolean",
-          "format": "{FORMAT}"
+          "schema": "boolean"
         }
       ],
       "inputs": [
@@ -421,8 +410,7 @@
       "topics": [
         {
           "name": "OUTPUT",
-          "schema": {"name": "ignored", "type": "record", "fields": [{"name": "FOO", "type": ["null","boolean"]}]},
-          "format": "{FORMAT}"
+          "schema": {"name": "ignored", "type": "record", "fields": [{"name": "FOO", "type": ["null","boolean"]}]}
         }
       ],
       "inputs": [
@@ -446,8 +434,7 @@
       "topics": [
         {
           "name": "OUTPUT",
-          "schema": {"type": "array", "items": ["null", "long"]},
-          "format": "{FORMAT}"
+          "schema": {"type": "array", "items": ["null", "long"]}
         }
       ],
       "inputs": [
@@ -473,8 +460,7 @@
       "topics": [
         {
           "name": "OUTPUT",
-          "schema": {"name": "ignored", "type": "record", "fields": [{"name": "FOO", "type": ["null",{"type": "array", "items": ["null", "long"]}]}]},
-          "format": "{FORMAT}"
+          "schema": {"name": "ignored", "type": "record", "fields": [{"name": "FOO", "type": ["null",{"type": "array", "items": ["null", "long"]}]}]}
         }
       ],
       "inputs": [
@@ -500,8 +486,7 @@
       "topics": [
         {
           "name": "OUTPUT",
-          "schema": {"type":"array","items":{"type":"record","name":"test","fields":[{"name":"key","type":["null","string"],"default":null},{"name":"value","type":["null","double"],"default":null}]}},
-          "format": "{FORMAT}"
+          "schema": {"type":"array","items":{"type":"record","name":"test","fields":[{"name":"key","type":["null","string"],"default":null},{"name":"value","type":["null","double"],"default":null}]}}
         }
       ],
       "inputs": [
@@ -527,8 +512,7 @@
       "topics": [
         {
           "name": "OUTPUT",
-          "schema": {"name": "ignored", "type": "record", "fields": [{"name": "FOO", "type": ["null",{"type":"array","items":{"type":"record","name":"test","fields":[{"name":"key","type":["null","string"],"default":null},{"name":"value","type":["null","double"],"default":null}]}}]}]},
-          "format": "{FORMAT}"
+          "schema": {"name": "ignored", "type": "record", "fields": [{"name": "FOO", "type": ["null",{"type":"array","items":{"type":"record","name":"test","fields":[{"name":"key","type":["null","string"],"default":null},{"name":"value","type":["null","double"],"default":null}]}}]}]}
         }
       ],
       "inputs": [
@@ -554,8 +538,7 @@
       "topics": [
         {
           "name": "OUTPUT",
-          "schema": {"type": "record", "name": "ignored", "fields": [{"name": "F0", "type": ["null", "int"]}]},
-          "format": "{FORMAT}"
+          "schema": {"type": "record", "name": "ignored", "fields": [{"name": "F0", "type": ["null", "int"]}]}
         }
       ],
       "inputs": [
@@ -583,8 +566,7 @@
           "name": "OUTPUT",
           "schema": {"name": "ignored", "type": "record", "fields": [
             {"name": "FOO", "type": ["null", {"name": "ignored2", "type": "record", "fields": [{"name": "F0", "type": ["null", "int"]}]}]}
-          ]},
-          "format": "{FORMAT}"
+          ]}
         }
       ],
       "inputs": [

--- a/ksql-functional-tests/src/test/resources/rest-query-validation-tests/pull-queries-against-materialized-aggregates.json
+++ b/ksql-functional-tests/src/test/resources/rest-query-validation-tests/pull-queries-against-materialized-aggregates.json
@@ -52,6 +52,59 @@
       ]
     },
     {
+      "name": "non-windowed single key lookup - BIGINT",
+      "statements": [
+        "CREATE STREAM INPUT (ROWKEY BIGINT KEY, IGNORED INT) WITH (kafka_topic='test_topic', value_format='JSON');",
+        "CREATE TABLE AGGREGATE AS SELECT COUNT(1) AS COUNT FROM INPUT GROUP BY ROWKEY;",
+        "SELECT * FROM AGGREGATE WHERE ROWKEY=10;",
+        "SELECT * FROM AGGREGATE WHERE ROWKEY=123369;"
+      ],
+      "inputs": [
+        {"topic": "test_topic", "timestamp": 12345, "key": 11, "value": {}},
+        {"topic": "test_topic", "timestamp": 12365, "key": 10, "value": {}}
+      ],
+      "responses": [
+        {"admin": {"@type": "currentStatus"}},
+        {"admin": {"@type": "currentStatus"}},
+        {"query": [
+          {"header":{"schema":"`ROWKEY` BIGINT KEY, `ROWTIME` BIGINT, `COUNT` BIGINT"}},
+          {"row":{"columns":[10, 12365, 1]}}
+        ]},
+        {"query": [
+          {"header":{"schema":"`ROWKEY` BIGINT KEY, `ROWTIME` BIGINT, `COUNT` BIGINT"}}
+        ]}
+      ]
+    },
+    {
+      "name": "non-windowed single key lookup - DOUBLE",
+      "statements": [
+        "CREATE STREAM INPUT (ROWKEY DOUBLE KEY, IGNORED INT) WITH (kafka_topic='test_topic', value_format='JSON');",
+        "CREATE TABLE AGGREGATE AS SELECT COUNT(1) AS COUNT FROM INPUT GROUP BY ROWKEY;",
+        "SELECT * FROM AGGREGATE WHERE ROWKEY=10;",
+        "SELECT * FROM AGGREGATE WHERE ROWKEY=10.0;",
+        "SELECT * FROM AGGREGATE WHERE ROWKEY=123369;"
+      ],
+      "inputs": [
+        {"topic": "test_topic", "timestamp": 12345, "key": 11.0, "value": {}},
+        {"topic": "test_topic", "timestamp": 12365, "key": 10.0, "value": {}}
+      ],
+      "responses": [
+        {"admin": {"@type": "currentStatus"}},
+        {"admin": {"@type": "currentStatus"}},
+        {"query": [
+          {"header":{"schema":"`ROWKEY` DOUBLE KEY, `ROWTIME` BIGINT, `COUNT` BIGINT"}},
+          {"row":{"columns":[10.0, 12365, 1]}}
+        ]},
+        {"query": [
+          {"header":{"schema":"`ROWKEY` DOUBLE KEY, `ROWTIME` BIGINT, `COUNT` BIGINT"}},
+          {"row":{"columns":[10.0, 12365, 1]}}
+        ]},
+        {"query": [
+          {"header":{"schema":"`ROWKEY` DOUBLE KEY, `ROWTIME` BIGINT, `COUNT` BIGINT"}}
+        ]}
+      ]
+    },
+    {
       "name": "lookup on wrong type type",
       "statements": [
         "CREATE STREAM INPUT (ROWKEY INT KEY, IGNORED INT) WITH (kafka_topic='test_topic', value_format='JSON');",

--- a/ksql-rest-app/src/main/java/io/confluent/ksql/rest/server/KsqlRestApplication.java
+++ b/ksql-rest-app/src/main/java/io/confluent/ksql/rest/server/KsqlRestApplication.java
@@ -236,6 +236,11 @@ public final class KsqlRestApplication extends ExecutableApplication<KsqlRestCon
     initialize();
   }
 
+  @VisibleForTesting
+  KsqlEngine getEngine() {
+    return ksqlEngine;
+  }
+
   private static final class KsqlFailedPrecondition extends RuntimeException {
 
     private KsqlFailedPrecondition(final String message) {

--- a/ksql-rest-app/src/test/java/io/confluent/ksql/rest/server/TestKsqlRestApp.java
+++ b/ksql-rest-app/src/test/java/io/confluent/ksql/rest/server/TestKsqlRestApp.java
@@ -23,6 +23,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.datatype.jdk8.Jdk8Module;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
+import io.confluent.ksql.KsqlExecutionContext;
 import io.confluent.ksql.json.JsonMapper;
 import io.confluent.ksql.query.QueryId;
 import io.confluent.ksql.rest.client.BasicCredentials;
@@ -100,6 +101,7 @@ public class TestKsqlRestApp extends ExternalResource {
   private final List<URL> listeners = new ArrayList<>();
   private final Optional<BasicCredentials> credentials;
   private ExecutableServer<KsqlRestConfig> restServer;
+  private KsqlExecutionContext ksqlEngine;
 
   private TestKsqlRestApp(
       final Supplier<String> bootstrapServers,
@@ -114,6 +116,10 @@ public class TestKsqlRestApp extends ExternalResource {
     this.serviceContextBinderFactory =
         requireNonNull(serviceContextBinderFactory, "serviceContextBinderFactory");
     this.credentials = requireNonNull(credentials, "credentials");
+  }
+
+  public KsqlExecutionContext getEngine() {
+    return ksqlEngine;
   }
 
   public List<URL> getListeners() {
@@ -261,6 +267,8 @@ public class TestKsqlRestApp extends ExternalResource {
     } catch (Exception var2) {
       throw new RuntimeException("Failed to start Ksql rest server", var2);
     }
+
+    ksqlEngine = ksqlRestApplication.getEngine();
   }
 
   @Override


### PR DESCRIPTION
### Description 

Enhanced the test framework to work with test cases with `BIGINT` and `DOUBLE` keys. This was previously failing due to Jackson deserializing the JSON describing the expected values into to `INT` and `DECIMAL`.

To achieve this I've started to tidy up the mess in the test framework. Specifically, we no longer track the serde to use in the `Topic` class, as this is constructed when parsing the test cases. Doing so was problematic as it was hard to know what serde should be used just from the test case text.  The serde to use is now determined by looking at the format of sources in the metastore once the SQL statements have been executed.

Also includes some additional test cases for pull queries working with primitive keys, and pulling out the code that determines the format / serde to use for a topic into a `TopicInfoCache`, as this is not shared by `QTT` and `RQTT` tests.

### Testing done 
 `mvn integration-test`

### Reviewer checklist
- [ ] Ensure docs are updated if necessary. (eg. if a user visible feature is being added or changed).
- [ ] Ensure relevant issues are linked (description should include text like "Fixes #<issue number>")

